### PR TITLE
Always request 64pl server info

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -1403,17 +1403,6 @@ void CClient::ProcessConnlessPacket(CNetChunk *pPacket)
 					m_CurrentServerInfoRequestTime = -1;
 				}
 			}
-
-			if (Is64Player(&Info))
-			{
-				pEntry = m_ServerBrowser.Find(pPacket->m_Address);
-				if (pEntry)
-				{
-					pEntry->m_Is64 = true;
-					m_ServerBrowser.RequestImpl64(pEntry->m_Addr, pEntry); // Force a quick update
-					//m_ServerBrowser.QueueRequest(pEntry);
-				}
-			}
 		}
 	}
 
@@ -1472,6 +1461,11 @@ void CClient::ProcessConnlessPacket(CNetChunk *pPacket)
 				mem_copy(&m_CurrentServerInfo, &Info, sizeof(m_CurrentServerInfo));
 				m_CurrentServerInfo.m_NetAddr = m_ServerAddress;
 				m_CurrentServerInfoRequestTime = -1;
+			}
+
+			if (pEntry)
+			{
+				pEntry->m_Is64 = true;
 			}
 		}
 	}

--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -774,10 +774,11 @@ void CServerBrowser::Update(bool ForceResort)
 
 		if(pEntry->m_RequestTime == 0)
 		{
-			if (pEntry->m_Is64)
-				RequestImpl64(pEntry->m_Addr, pEntry);
-			else
+			if (!pEntry->m_Is64)
 				RequestImpl(pEntry->m_Addr, pEntry);
+
+			// always request 64 info
+			RequestImpl64(pEntry->m_Addr, pEntry);
 		}
 
 		Count++;


### PR DESCRIPTION
Currently 64 player info only is requested if the server name contains "64" or a specific game-type is being used. I think we should always send it next to the vanilla request, see the following reasons:

- The additional traffic caused by the request is trivial (+ 15 bytes).
- The current approach doesn't support non-ddnet game-types with max 16 < x < 64 players.
- No need to wait for vanilla response.
- Some advantages in case of current flooding attacks
