### PR TITLE
Fix config_store for old maps that don't contain MAPITEMTYPE_INFO

### DIFF
--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -2574,6 +2574,7 @@ void CGameContext::OnMapChange(char *pNewMapName, int MapNameSize)
 	Writer.Init();
 
 	int SettingsIndex = Reader.NumData();
+	bool FoundInfo = false;
 	for(int i = 0; i < Reader.NumItems(); i++)
 	{
 		int TypeID;
@@ -2584,6 +2585,7 @@ void CGameContext::OnMapChange(char *pNewMapName, int MapNameSize)
 		CMapItemInfoSettings MapInfo;
 		if(TypeID == MAPITEMTYPE_INFO && ItemID == 0)
 		{
+			FoundInfo = true;
 			CMapItemInfoSettings *pInfo = (CMapItemInfoSettings *)pData;
 			if(Size >= (int)sizeof(CMapItemInfoSettings))
 			{
@@ -2616,6 +2618,18 @@ void CGameContext::OnMapChange(char *pNewMapName, int MapNameSize)
 			}
 		}
 		Writer.AddItem(TypeID, ItemID, Size, pData);
+	}
+
+	if(!FoundInfo)
+	{
+		CMapItemInfoSettings Info;
+		Info.m_Version = 1;
+		Info.m_Author = -1;
+		Info.m_MapVersion = -1;
+		Info.m_Credits = -1;
+		Info.m_License = -1;
+		Info.m_Settings = SettingsIndex;
+		Writer.AddItem(MAPITEMTYPE_INFO, 0, sizeof(Info), &Info);
 	}
 
 	for(int i = 0; i < Reader.NumData() || i == SettingsIndex; i++)

--- a/src/tools/config_store.cpp
+++ b/src/tools/config_store.cpp
@@ -47,6 +47,7 @@ void Process(IStorage *pStorage, const char *pMapName, const char *pConfigName)
 	Writer.Init();
 
 	int SettingsIndex = Reader.NumData();
+	bool FoundInfo = false;
 	for(int i = 0; i < Reader.NumItems(); i++)
 	{
 		int TypeID;
@@ -57,6 +58,7 @@ void Process(IStorage *pStorage, const char *pMapName, const char *pConfigName)
 		CMapItemInfoSettings MapInfo;
 		if(TypeID == MAPITEMTYPE_INFO && ItemID == 0)
 		{
+			FoundInfo = true;
 			CMapItemInfoSettings *pInfo = (CMapItemInfoSettings *)pData;
 			if(Size >= (int)sizeof(CMapItemInfoSettings))
 			{
@@ -92,6 +94,18 @@ void Process(IStorage *pStorage, const char *pMapName, const char *pConfigName)
 			}
 		}
 		Writer.AddItem(TypeID, ItemID, Size, pData);
+	}
+
+	if(!FoundInfo)
+	{
+		CMapItemInfoSettings Info;
+		Info.m_Version = 1;
+		Info.m_Author = -1;
+		Info.m_MapVersion = -1;
+		Info.m_Credits = -1;
+		Info.m_License = -1;
+		Info.m_Settings = SettingsIndex;
+		Writer.AddItem(MAPITEMTYPE_INFO, 0, sizeof(Info), &Info);
 	}
 
 	for(int i = 0; i < Reader.NumData() || i == SettingsIndex; i++)


### PR DESCRIPTION
Just add one in this case.