### PR TITLE
Fix settings compare

### DIFF
--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -2594,7 +2594,7 @@ void CGameContext::OnMapChange(char *pNewMapName, int MapNameSize)
 					SettingsIndex = pInfo->m_Settings;
 					char *pMapSettings = (char *)Reader.GetData(SettingsIndex);
 					int DataSize = Reader.GetUncompressedDataSize(SettingsIndex);
-					if(DataSize == TotalLength && mem_comp(pSettings, pMapSettings, Size) == 0)
+					if(DataSize == TotalLength && mem_comp(pSettings, pMapSettings, DataSize) == 0)
 					{
 						// Configs coincide, no need to update map.
 						return;

--- a/src/tools/config_store.cpp
+++ b/src/tools/config_store.cpp
@@ -70,7 +70,7 @@ void Process(IStorage *pStorage, const char *pMapName, const char *pConfigName)
 					SettingsIndex = pInfo->m_Settings;
 					char *pMapSettings = (char *)Reader.GetData(SettingsIndex);
 					int DataSize = Reader.GetUncompressedDataSize(SettingsIndex);
-					if(DataSize == TotalLength && mem_comp(pSettings, pMapSettings, Size) == 0)
+					if(DataSize == TotalLength && mem_comp(pSettings, pMapSettings, DataSize) == 0)
 					{
 						dbg_msg("config_store", "configs coincide, not updating map");
 						return;


### PR DESCRIPTION
It was just using a heuristic, comparing the first 24 bytes. Memory unsafety
for configs that were shorter than 24 bytes.