### PR TITLE
Added vital flag for mapdata (includes fast download)

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -1024,7 +1024,7 @@ void CServer::ProcessClientPacket(CNetChunk *pPacket)
 			Msg.AddInt(Chunk);
 			Msg.AddInt(ChunkSize);
 			Msg.AddRaw(&m_pCurrentMapData[Offset], ChunkSize);
-			SendMsgEx(&Msg, MSGFLAG_FLUSH, ClientID, true);
+			SendMsgEx(&Msg, MSGFLAG_VITAL|MSGFLAG_FLUSH, ClientID, true);
 
 			if(g_Config.m_Debug)
 			{
@@ -1445,7 +1445,7 @@ void CServer::PumpNetwork()
 			Msg.AddInt(Chunk);
 			Msg.AddInt(ChunkSize);
 			Msg.AddRaw(&m_pCurrentMapData[Offset], ChunkSize);
-			SendMsgEx(&Msg, MSGFLAG_FLUSH, i, true);
+			SendMsgEx(&Msg, MSGFLAG_VITAL|MSGFLAG_FLUSH, i, true);
 
 			if(g_Config.m_Debug)
 			{


### PR DESCRIPTION
Fixes map download for 0.6.4
Note:
- Not sure whether the vital flag has impact on map fast download (could cause many resends on packet loss)
- Also not sure why the vital flag (on normal map download) was removed in the first place @eeeee https://github.com/teeworlds/teeworlds/commit/ee2647de#diff-25bcc1bcfab43c7e0957ca2fa89fe34fL1255