### PR TITLE
Added possibility to discard settings

### DIFF
--- a/src/engine/shared/config.cpp
+++ b/src/engine/shared/config.cpp
@@ -75,7 +75,7 @@ public:
 
 	virtual void Save()
 	{
-		if(!m_pStorage)
+		if(!m_pStorage || !g_Config.m_ClSaveSettings)
 			return;
 		m_ConfigFile = m_pStorage->OpenFile(CONFIG_FILE ".tmp", IOFLAG_WRITE, IStorage::TYPE_SAVE);
 

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -15,6 +15,7 @@ MACRO_CONFIG_STR(Password, password, 32, "", CFGFLAG_CLIENT|CFGFLAG_SERVER, "Pas
 MACRO_CONFIG_STR(Logfile, logfile, 128, "", CFGFLAG_SAVE|CFGFLAG_CLIENT|CFGFLAG_SERVER, "Filename to log all output to")
 MACRO_CONFIG_INT(ConsoleOutputLevel, console_output_level, 0, 0, 2, CFGFLAG_CLIENT|CFGFLAG_SERVER, "Adjusts the amount of information in the console")
 
+MACRO_CONFIG_INT(ClSaveSettings, cl_save_settings, 1, 0, 1, CFGFLAG_CLIENT, "Write the settings file on exit")
 MACRO_CONFIG_INT(ClCpuThrottle, cl_cpu_throttle, 0, 0, 100, CFGFLAG_SAVE|CFGFLAG_CLIENT, "")
 MACRO_CONFIG_INT(ClCpuThrottleInactive, cl_cpu_throttle_inactive, 1, 0, 1, CFGFLAG_SAVE|CFGFLAG_CLIENT, "")
 MACRO_CONFIG_INT(ClEditor, cl_editor, 0, 0, 1, CFGFLAG_CLIENT, "")


### PR DESCRIPTION
This is useful for having multiple configs to start your client with but keeping the original settings if you want to start your client without a config. For example my maprelease config looks like this:

cl_save_settings 0
gfx_screen_width 1440
gfx_screen_height 900
gfx_high_detail 1
gfx_texture_quality 1
cl_showhud 0
cl_showchat 0
cl_showkillmessages 0
ui_page 9
br_filter_exclude_types ",RUS,USA,CAN,CHN,CHL,BRA,ZAF,DDNet,Infection,iCTF,gCTF,Vanilla,zCatch,openFNG,Monster,Block,Bomb,Foot"