### PR TITLE
implemented system to display join-messages according the players Cou…

### DIFF
--- a/src/game/server/countrymessage.cpp
+++ b/src/game/server/countrymessage.cpp
@@ -1,0 +1,169 @@
+#include "gamecontext.h"
+#include "countrymessage.h"
+
+
+CCountryMessages::CCountryMessages()
+{
+	m_NumMessages = 0;
+	m_pCountryMsgFirst = 0;
+	m_pCountryMsgLast = 0;
+}
+
+void CCountryMessages::OnConsoleInit(CGameContext *pGameServer)
+{
+	m_pGameServer = pGameServer;
+	m_pServer = m_pGameServer->Server();
+	m_pConsole = m_pGameServer->Console();
+	m_pHeap = new CHeap();
+
+	Console()->Register("set_country_msg", "is", CFGFLAG_SERVER, ConSetCountryMsg, this, "Sets a message to be displayed for players from specific countrys");
+	Console()->Register("remove_country_msg", "i", CFGFLAG_SERVER, ConRemoveCountryMsg, this, "removes countrymessage");
+	Console()->Register("reset_country_msgs", "", CFGFLAG_SERVER, ConResetCountryMsgs, this, "reset all countrymessages");
+	Console()->Register("dump_country_msgs", "", CFGFLAG_SERVER, ConDumpCountryMsgs, this, "dump all countrymessages");
+}
+
+const char *CCountryMessages::getCountryMessage(int CountryID)
+{
+	CCountryMsg *pCountryMsg = m_pCountryMsgFirst;
+	while(pCountryMsg)
+	{
+		if(pCountryMsg->m_CountryID == CountryID)
+		{
+			return pCountryMsg->m_aMessage;
+		}
+		pCountryMsg = pCountryMsg->m_pNext;
+	}
+	return 0;
+}
+
+void CCountryMessages::ConSetCountryMsg(IConsole::IResult *pResult, void *pUserData)
+{
+	CCountryMessages *pSelf = (CCountryMessages *)pUserData;
+	if(pSelf->m_NumMessages == MAX_COUNTRY_MESSAGES)
+	{
+		pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "server", "maximum number of countrymessages reached");
+		return;
+	}
+
+	int CountryID = pResult->GetInteger(0);
+
+	CCountryMsg *pCountryMsg = pSelf->m_pCountryMsgFirst;
+	while(pCountryMsg)
+	{
+		if(pCountryMsg->m_CountryID == CountryID)
+		{
+			str_copy(pCountryMsg->m_aMessage, pResult->GetString(1), MAX_COUNTRY_MESSAGE_LENGTH);
+
+			char aBuf[512];
+			str_format(aBuf, sizeof(aBuf), "changed countrymessage ID: %d to '%s'", pCountryMsg->m_CountryID, pCountryMsg->m_aMessage);
+			pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "server", aBuf);
+
+			return;
+		}
+		pCountryMsg = pCountryMsg->m_pNext;
+	}
+
+	++pSelf->m_NumMessages;
+	pCountryMsg = (CCountryMsg *)pSelf->m_pHeap->Allocate(sizeof(CCountryMsg));
+
+	pCountryMsg->m_pNext = 0;
+	pCountryMsg->m_pPrev = pSelf->m_pCountryMsgLast;
+	if(pCountryMsg->m_pPrev)
+		pCountryMsg->m_pPrev->m_pNext = pCountryMsg;
+	pSelf->m_pCountryMsgLast = pCountryMsg;
+	if(!pSelf->m_pCountryMsgFirst)
+		pSelf->m_pCountryMsgFirst = pCountryMsg;
+
+	pCountryMsg->m_CountryID = CountryID;
+	str_copy(pCountryMsg->m_aMessage, pResult->GetString(1), MAX_COUNTRY_MESSAGE_LENGTH);
+
+	char aBuf[512];
+	str_format(aBuf, sizeof(aBuf), "added countrymessage ID: %d '%s'", pCountryMsg->m_CountryID, pCountryMsg->m_aMessage);
+	pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "server", aBuf);
+}
+
+void CCountryMessages::ConRemoveCountryMsg(IConsole::IResult *pResult, void *pUserData)
+{
+	CCountryMessages *pSelf = (CCountryMessages *)pUserData;
+
+	CCountryMsg *pCountryMsg = pSelf->m_pCountryMsgFirst;
+	while(pCountryMsg)
+	{
+		if(pCountryMsg->m_CountryID == pResult->GetInteger(0))
+			break;
+		pCountryMsg = pCountryMsg->m_pNext;
+	}
+	if(!pCountryMsg)
+	{
+		char aBuf[256];
+		str_format(aBuf, sizeof(aBuf), "countrymessage %d does not exist", pResult->GetInteger(0));
+		pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "server", aBuf);
+		return;
+	}
+
+	--pSelf->m_NumMessages;
+
+	char aBuf[512];
+	str_format(aBuf, sizeof(aBuf), "removed countrymessage ID: %d '%s'", pCountryMsg->m_CountryID, pCountryMsg->m_aMessage);
+	pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "server", aBuf);
+
+	CHeap *pCountryMsgsHeap = new CHeap();
+	CCountryMsg *pCountryMsgFirst = 0;
+	CCountryMsg *pCountryMsgLast = 0;
+
+	for(CCountryMsg *pSrc = pSelf->m_pCountryMsgFirst; pSrc; pSrc = pSrc->m_pNext)
+	{
+		if(pSrc == pCountryMsg)
+			continue;
+
+		// copy
+		CCountryMsg *pDst = (CCountryMsg *)pCountryMsgsHeap->Allocate(sizeof(CCountryMsg));
+		pDst->m_pNext = 0;
+		pDst->m_pPrev = pCountryMsgLast;
+		if(pDst->m_pPrev)
+			pDst->m_pPrev->m_pNext = pDst;
+		pCountryMsgLast = pDst;
+		if(!pCountryMsgFirst)
+			pCountryMsgFirst = pDst;
+
+		str_copy(pDst->m_aMessage, pSrc->m_aMessage, sizeof(pDst->m_aMessage));
+		pDst->m_CountryID = pSrc->m_CountryID;
+	}
+
+	// clean up
+	delete pSelf->m_pHeap;
+	pSelf->m_pHeap = pCountryMsgsHeap;
+	pSelf->m_pCountryMsgFirst = pCountryMsgFirst;
+	pSelf->m_pCountryMsgLast = pCountryMsgLast;
+}
+
+void CCountryMessages::ConResetCountryMsgs(IConsole::IResult *pResult, void *pUserData)
+{
+	CCountryMessages *pSelf = (CCountryMessages *)pUserData;
+
+	pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "server", "resetted countrymessages");
+	pSelf->m_pHeap->Reset();
+	pSelf->m_pCountryMsgFirst = 0;
+	pSelf->m_pCountryMsgLast = 0;
+	pSelf->m_NumMessages = 0;
+}
+
+void CCountryMessages::ConDumpCountryMsgs(IConsole::IResult *pResult, void *pUserData)
+{
+	CCountryMessages *pSelf = (CCountryMessages *)pUserData;
+
+	CCountryMsg *pCountryMsg = pSelf->m_pCountryMsgFirst;
+
+	while (pCountryMsg)
+	{
+		char aBuf[512];
+		str_format(aBuf, sizeof(aBuf), "ID: %d %s", pCountryMsg->m_CountryID, pCountryMsg->m_aMessage);
+		pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "server", aBuf);
+		pCountryMsg = pCountryMsg->m_pNext;
+	}
+}
+
+CCountryMessages::~CCountryMessages()
+{
+	delete m_pHeap;
+}

--- a/src/game/server/countrymessage.h
+++ b/src/game/server/countrymessage.h
@@ -1,0 +1,51 @@
+#ifndef GAME_SERVER_COUNTRY_MESSAGE_H
+#define GAME_SERVER_COUNTRY_MESSAGE_H
+
+#include <engine/shared/config.h>
+#include <engine/shared/memheap.h>
+#include <engine/console.h>
+
+enum
+{
+	MAX_COUNTRY_MESSAGE_LENGTH=256,
+	MAX_COUNTRY_MESSAGES=512
+};
+
+struct CCountryMsg
+{
+	CCountryMsg *m_pNext;
+	CCountryMsg *m_pPrev;
+	char m_aMessage[MAX_COUNTRY_MESSAGE_LENGTH];
+	int m_CountryID;
+};
+
+class CCountryMessages
+{
+public:
+	CCountryMessages();
+	~CCountryMessages();
+	void OnConsoleInit(class CGameContext *pGameServer);
+
+	const char *getCountryMessage(int CountryID);
+
+	CGameContext *GameServer() const { return m_pGameServer; }
+	IServer *Server() const { return m_pServer; }
+	class IConsole *Console() { return m_pConsole; }
+
+private:
+	class CGameContext *m_pGameServer;
+	class IServer *m_pServer;
+	class IConsole *m_pConsole;
+
+	static void ConSetCountryMsg(IConsole::IResult *pResult, void *pUserData);
+	static void ConRemoveCountryMsg(IConsole::IResult *pResult, void *pUserData);
+	static void ConResetCountryMsgs(IConsole::IResult *pResult, void *pUserData);
+	static void ConDumpCountryMsgs(IConsole::IResult *pResult, void *pUserData);
+
+	CHeap *m_pHeap;
+	int m_NumMessages;
+	CCountryMsg *m_pCountryMsgFirst;
+	CCountryMsg *m_pCountryMsgLast;
+};
+
+#endif

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -912,10 +912,15 @@ void CGameContext::OnClientEnter(int ClientID)
 		SendChatTarget(ClientID, "please visit http://ddnet.tw or say /info for more info");
 
 		if(g_Config.m_SvWelcome[0]!=0)
-			SendChatTarget(ClientID,g_Config.m_SvWelcome);
+			SendChatTarget(ClientID, g_Config.m_SvWelcome);
 		str_format(aBuf, sizeof(aBuf), "team_join player='%d:%s' team=%d", ClientID, Server()->ClientName(ClientID), m_apPlayers[ClientID]->GetTeam());
 
 		Console()->Print(IConsole::OUTPUT_LEVEL_DEBUG, "game", aBuf);
+
+
+		const char* pCountryMessage = m_CountryMessages.getCountryMessage(Server()->ClientCountry(ClientID));
+		if(pCountryMessage)
+			SendChatTarget(ClientID, pCountryMessage);
 
 		if (g_Config.m_SvShowOthersDefault)
 		{
@@ -2280,6 +2285,8 @@ void CGameContext::OnConsoleInit()
 #include "game/ddracecommands.h"
 #define CHAT_COMMAND(name, params, flags, callback, userdata, help) m_pConsole->Register(name, params, flags, callback, userdata, help);
 #include "ddracechat.h"
+
+	m_CountryMessages.OnConsoleInit(this);
 }
 
 void CGameContext::OnInit(/*class IKernel *pKernel*/)

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -14,6 +14,7 @@
 #include "gamecontroller.h"
 #include "gameworld.h"
 #include "player.h"
+#include "countrymessage.h"
 
 #include "score.h"
 #ifdef _MSC_VER
@@ -60,6 +61,7 @@ class CGameContext : public IGameServer
 	CNetObjHandler m_NetObjHandler;
 	CTuningParams m_Tuning;
 	CTuningParams m_TuningList[NUM_TUNINGZONES];
+	CCountryMessages m_CountryMessages;
 
 	static void ConTuneParam(IConsole::IResult *pResult, void *pUserData);
 	static void ConTuneReset(IConsole::IResult *pResult, void *pUserData);


### PR DESCRIPTION
…ntryFlag

this adds the following commands:
- set_country_msg <CountryID (can be found in data/countryflags/index.txt)> <message>
adds specified message or updates it in case it already exists
- remove_country_msg <CountryID> removes specified message
- reset_country_msgs resets everything
- dump_country_msgs dumps all message entries

would be helpful to inform chileans about the situation + we could ask them if anyone could setup servers for us / knows a good hostingcompany