### PR TITLE
Reset statboard after a game restart

### DIFF
--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1072,7 +1072,7 @@ void CGameClient::OnNewSnapshot()
 					OnStartGame();
 				// Reset statboard when new round is started (RoundStartTick changed)
 				// New round is usually started after `restart` on server
-				if ((m_Snap.m_pGameInfoObj->m_RoundStartTick - m_LastRoundStartTick > 2)
+				if(m_Snap.m_pGameInfoObj->m_RoundStartTick != m_LastRoundStartTick
 						// In GamePaused or GameOver state RoundStartTick is updated on each tick
 						// hence no need to reset stats until player leaves GameOver
 						// and it would be a mistake to reset stats after or during the pause


### PR DESCRIPTION
Fixes #335 

The details of this PR are written in #335. The way I chose to solve the issue decouples statboard reset from the demo recording as it was suggested in the issue.