### PR TITLE
Fix wrong calculation of weapon Angle in demo player

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,5 +50,6 @@ bam.exe
 .settings
 *.opensdf
 *.pyc
+*.dll
 
 DDNet*

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -417,7 +417,8 @@ void CPlayers::RenderPlayer(
 	}
 	else
 	{
-		// fix wrong calculation of weapon Angle in demo player				
+		// If player move his weapon through top then change the end angle on 2*Pi.
+		// So mix function will calculate offset angle by a short path, and not by long one.
 		if (Player.m_Angle > (256.0f * pi) && Prev.m_Angle < 0)
 		{
 			Player.m_Angle -= 256.0f * 2 * pi;

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -418,14 +418,14 @@ void CPlayers::RenderPlayer(
 	else
 	{
 		// fix wrong calculation of weapon Angle in demo player				
-		if (Player.m_Angle > 800 && Prev.m_Angle < 0)
+		if (Player.m_Angle > (256.0f * pi) && Prev.m_Angle < 0)
 		{
-			Player.m_Angle -= 1600;
+			Player.m_Angle -= 256.0f * 2 * pi;
 			Angle = mix((float)Prev.m_Angle, (float)Player.m_Angle, IntraTick) / 256.0f;
 		}
-		else if (Player.m_Angle < 0 && Prev.m_Angle > 800)
+		else if (Player.m_Angle < 0 && Prev.m_Angle > (256.0f * pi))
 		{
-			Player.m_Angle += 1600;
+			Player.m_Angle += 256.0f * 2 * pi;
 			Angle = mix((float)Prev.m_Angle, (float)Player.m_Angle, IntraTick) / 256.0f;
 		}
 		/*

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -417,6 +417,17 @@ void CPlayers::RenderPlayer(
 	}
 	else
 	{
+		// fix wrong calculation of weapon Angle in demo player				
+		if (Player.m_Angle > 800 && Prev.m_Angle < 0)
+		{
+			Player.m_Angle -= 1600;
+			Angle = mix((float)Prev.m_Angle, (float)Player.m_Angle, IntraTick) / 256.0f;
+		}
+		else if (Player.m_Angle < 0 && Prev.m_Angle > 800)
+		{
+			Player.m_Angle += 1600;
+			Angle = mix((float)Prev.m_Angle, (float)Player.m_Angle, IntraTick) / 256.0f;
+		}
 		/*
 		float mixspeed = Client()->FrameTime()*2.5f;
 		if(player.attacktick != prev.attacktick) // shooting boosts the mixing speed


### PR DESCRIPTION
Fix wrong calculation of weapon Angle in demo player, more here: http://forum.ddnet.tw/viewtopic.php?f=45&t=2717
and
Add *.dll to .gitignore (for Windows)