### PR TITLE
fixed mysql compiling on mac

### DIFF
--- a/bam.lua
+++ b/bam.lua
@@ -26,7 +26,7 @@ Import("other/mysql/mysql.lua")
 config = NewConfig()
 config:Add(OptCCompiler("compiler"))
 config:Add(OptTestCompileC("stackprotector", "int main(){return 0;}", "-fstack-protector -fstack-protector-all"))
-config:Add(OptTestCompileC("minmacosxsdk", "int main(){return 0;}", "-mmacosx-version-min=10.5 -isysroot /Developer/SDKs/MacOSX10.5.sdk"))
+config:Add(OptTestCompileC("minmacosxsdk", "int main(){return 0;}", "-mmacosx-version-min=10.7 -isysroot /Developer/SDKs/MacOSX10.7.sdk"))
 config:Add(OptTestCompileC("macosxppc", "int main(){return 0;}", "-arch ppc"))
 config:Add(OptLibrary("zlib", "zlib.h", false))
 config:Add(SDL.OptFind("sdl", true))
@@ -235,11 +235,13 @@ function build(settings)
 			-- disable visibility attribute support for gcc on windows
 			settings.cc.defines:Add("NO_VIZ")
 		elseif platform == "macosx" then
-			settings.cc.flags:Add("-mmacosx-version-min=10.5")
-			settings.link.flags:Add("-mmacosx-version-min=10.5")
+			settings.cc.flags:Add("-mmacosx-version-min=10.7")
+			settings.link.flags:Add("-mmacosx-version-min=10.7")
+			settings.cc.flags:Add("-stdlib=libc++")
+			settings.link.flags:Add("-stdlib=libc++")
 			if config.minmacosxsdk.value == 1 then
-				settings.cc.flags:Add("-isysroot /Developer/SDKs/MacOSX10.5.sdk")
-				settings.link.flags:Add("-isysroot /Developer/SDKs/MacOSX10.5.sdk")
+				settings.cc.flags:Add("-isysroot /Developer/SDKs/MacOSX10.7.sdk")
+				settings.link.flags:Add("-isysroot /Developer/SDKs/MacOSX10.7.sdk")
 			end
 		elseif config.stackprotector.value == 1 then
 			settings.cc.flags:Add("-fstack-protector", "-fstack-protector-all")

--- a/other/mysql/mysql.lua
+++ b/other/mysql/mysql.lua
@@ -50,7 +50,9 @@ Mysql = {
 					settings.link.libs:Add("mysqlcppconn-static")
 					settings.link.libs:Add("mysqlclient")
 					settings.link.libs:Add("dl")
-					settings.link.libs:Add("rt")
+					if platform ~= "macosx" then
+						settings.link.libs:Add("rt")
+					end
 				end
 
 				if platform == "macosx" and string.find(settings.config_name, "32") then


### PR DESCRIPTION
This is required in order to compile DDNet-sql versions on mac.
Previously mysql-libs were compiled with libc++ but rest of DDNet with libstdc++ resulting in a crash every time the ddnet-server tried to establish a sql-connection.
This, however, required to bump the macosx-version-min to 10.7.