### PR TITLE
Improve the handling of invalid skins.

### DIFF
--- a/src/engine/shared/datafile.cpp
+++ b/src/engine/shared/datafile.cpp
@@ -102,7 +102,8 @@ bool CDataFileReader::Open(class IStorage *pStorage, const char *pFilename, int 
 
 	// TODO: change this header
 	CDatafileHeader Header;
-	if (sizeof Header != io_read(File, &Header, sizeof(Header))) {
+	if (sizeof(Header) != io_read(File, &Header, sizeof(Header)))
+	{
 		dbg_msg("datafile", "couldn't load header");
 		return 0;
 	}

--- a/src/engine/shared/datafile.cpp
+++ b/src/engine/shared/datafile.cpp
@@ -102,7 +102,10 @@ bool CDataFileReader::Open(class IStorage *pStorage, const char *pFilename, int 
 
 	// TODO: change this header
 	CDatafileHeader Header;
-	io_read(File, &Header, sizeof(Header));
+	if (sizeof Header != io_read(File, &Header, sizeof(Header))) {
+		dbg_msg("datafile", "couldn't load header");
+		return 0;
+	}
 	if(Header.m_aID[0] != 'A' || Header.m_aID[1] != 'T' || Header.m_aID[2] != 'A' || Header.m_aID[3] != 'D')
 	{
 		if(Header.m_aID[0] != 'D' || Header.m_aID[1] != 'A' || Header.m_aID[2] != 'T' || Header.m_aID[3] != 'A')

--- a/src/game/client/components/skins.cpp
+++ b/src/game/client/components/skins.cpp
@@ -62,6 +62,8 @@ int CSkins::SkinScan(const char *pName, int IsDir, int DirType, void *pUser)
 	Skin.m_OrgTexture = pSelf->Graphics()->LoadTextureRaw(Info.m_Width, Info.m_Height, Info.m_Format, Info.m_pData, Info.m_Format, 0);
 
 	int BodySize = 96; // body size
+	if (BodySize > Info.m_Height)
+		return 0;
 	unsigned char *d = (unsigned char *)Info.m_pData;
 	int Pitch = Info.m_Width*4;
 


### PR DESCRIPTION
CDataFileReader::Open(): Check the return status of io_read()
before reading the buffer, to avoid reading uninitialized data
in case the file was shorter than a full header.

CSkins::SkinScan(): Check that the image is high enough.