### PR TITLE
Antispoof: vanilla connection default map fallback

### DIFF
--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -152,6 +152,7 @@ MACRO_CONFIG_INT(SvVanillaAntiSpoof, sv_vanilla_antispoof, 1, 0, 1, CFGFLAG_SERV
 MACRO_CONFIG_INT(SvPlayerDemoRecord, sv_player_demo_record, 0, 0, 1, CFGFLAG_SERVER, "Automatically record demos for each player")
 MACRO_CONFIG_INT(SvDemoChat, sv_demo_chat, 0, 0, 1, CFGFLAG_SERVER, "Record chat for demos")
 MACRO_CONFIG_INT(SvServerInfoPerSecond, sv_server_info_per_second, 50, 1, 1000, CFGFLAG_SERVER, "Maximum number of complete server info responses that are sent out per second")
+MACRO_CONFIG_INT(SvVanConnPerSecond, sv_van_conn_per_second, 10, 1, 1000, CFGFLAG_SERVER, "Antispoof specific ratelimit")
 
 MACRO_CONFIG_STR(EcBindaddr, ec_bindaddr, 128, "localhost", CFGFLAG_ECON, "Address to bind the external console to. Anything but 'localhost' is dangerous")
 MACRO_CONFIG_INT(EcPort, ec_port, 0, 0, 0, CFGFLAG_ECON, "Port to use for the external console")

--- a/src/engine/shared/network.h
+++ b/src/engine/shared/network.h
@@ -300,6 +300,11 @@ class CNetServer
 	int64 m_TimeNumConAttempts;
 	unsigned char m_SecurityTokenSeed[16];
 
+	// vanilla connect flood detection
+	bool m_VConnHighLoad;
+	int64 m_VConnFirst;
+	int m_VConnNum;
+
 	CNetRecvUnpacker m_RecvUnpacker;
 
 	void OnTokenCtrlMsg(NETADDR &Addr, int ControlMsg, const CNetPacketConstruct &Packet);

--- a/src/engine/shared/network_server.cpp
+++ b/src/engine/shared/network_server.cpp
@@ -44,6 +44,10 @@ bool CNetServer::Open(NETADDR BindAddr, CNetBan *pNetBan, int MaxClients, int Ma
 	m_NumConAttempts = 0;
 	m_TimeNumConAttempts = time_get();
 
+	m_VConnHighLoad = false;
+	m_VConnNum = 0;
+	m_VConnFirst = 0;
+
 	secure_random_fill(m_SecurityTokenSeed, sizeof(m_SecurityTokenSeed));
 
 	for(int i = 0; i < NET_MAX_CLIENTS; i++)
@@ -275,6 +279,26 @@ void CNetServer::OnPreConnMsg(NETADDR &Addr, CNetPacketConstruct &Packet)
 	{
 		if (g_Config.m_SvVanillaAntiSpoof && g_Config.m_Password[0] == '\0')
 		{
+			// detect flooding
+			int64 Now = time_get();
+			if(Now <= m_VConnFirst + time_freq())
+			{
+				m_VConnNum++;
+			}
+			else
+			{
+				m_VConnHighLoad = m_VConnNum > g_Config.m_SvVanConnPerSecond;
+				m_VConnNum = 1;
+				m_VConnFirst = Now;
+			}
+
+			bool Flooding = m_VConnNum > g_Config.m_SvVanConnPerSecond || m_VConnHighLoad;
+
+			if (g_Config.m_Debug && Flooding)
+			{
+				dbg_msg("security", "vanilla connection flooding detected");
+			}
+
 			// simulate accept
 			SendControl(Addr, NET_CTRLMSG_CONNECTACCEPT, SECURITY_TOKEN_MAGIC,
 						sizeof(SECURITY_TOKEN_MAGIC), NET_SECURITY_TOKEN_UNSUPPORTED);
@@ -295,17 +319,38 @@ void CNetServer::OnPreConnMsg(NETADDR &Addr, CNetPacketConstruct &Packet)
 			// send mapchange + map data + con_ready + 3 x empty snap (with token)
 			CMsgPacker MapChangeMsg(NETMSG_MAP_CHANGE);
 
-			MapChangeMsg.AddString("dummy", 0);
-			MapChangeMsg.AddInt(DummyMapCrc);
-			MapChangeMsg.AddInt(sizeof(g_aDummyMapData));
+			if (Flooding)
+			{
+				MapChangeMsg.AddString("dm1", 0);
+				MapChangeMsg.AddInt(0xf2159e6e);
+				MapChangeMsg.AddInt(5805);
+			}
+			else
+			{
+				MapChangeMsg.AddString("dummy", 0);
+				MapChangeMsg.AddInt(DummyMapCrc);
+				MapChangeMsg.AddInt(sizeof(g_aDummyMapData));
+			}
 
 			CMsgPacker MapDataMsg(NETMSG_MAP_DATA);
 
-			MapDataMsg.AddInt(1); // last chunk
-			MapDataMsg.AddInt(DummyMapCrc); // crc
-			MapDataMsg.AddInt(0); // chunk index
-			MapDataMsg.AddInt(sizeof(g_aDummyMapData)); // map size
-			MapDataMsg.AddRaw(g_aDummyMapData, sizeof(g_aDummyMapData)); // map data
+			if (Flooding)
+			{
+				// send empty map data to keep 0.6.4 support
+				MapDataMsg.AddInt(1); // last chunk
+				MapDataMsg.AddInt(0); // crc
+				MapDataMsg.AddInt(0); // chunk index
+				MapDataMsg.AddInt(0); // map size
+				MapDataMsg.AddRaw(NULL, 0); // map data
+			}
+			else
+			{
+				MapDataMsg.AddInt(1); // last chunk
+				MapDataMsg.AddInt(DummyMapCrc); // crc
+				MapDataMsg.AddInt(0); // chunk index
+				MapDataMsg.AddInt(sizeof(g_aDummyMapData)); // map size
+				MapDataMsg.AddRaw(g_aDummyMapData, sizeof(g_aDummyMapData)); // map data
+			}
 
 			CMsgPacker ConReadyMsg(NETMSG_CON_READY);
 
@@ -505,6 +550,11 @@ int CNetServer::Recv(CNetChunk *pChunk)
 			}
 			else
 			{
+				// drop invalid ctrl packets
+				if (m_RecvUnpacker.m_Data.m_Flags&NET_PACKETFLAG_CONTROL &&
+						m_RecvUnpacker.m_Data.m_DataSize == 0)
+					return 0;
+
 				// normal packet, find matching slot
 				int Slot = GetClientSlot(Addr);
 

--- a/src/engine/shared/network_server.cpp
+++ b/src/engine/shared/network_server.cpp
@@ -314,19 +314,22 @@ void CNetServer::OnPreConnMsg(NETADDR &Addr, CNetPacketConstruct &Packet)
 			// to load a map, otherwise it might crash. The map
 			// should be as small as is possible and directly available
 			// to the client. Therefor a dummy map is sent in the same
-			// packet.
+			// packet. To reduce the traffic we'll fallback to a default
+			// map if there are too many connection attempts at once.
 
 			// send mapchange + map data + con_ready + 3 x empty snap (with token)
 			CMsgPacker MapChangeMsg(NETMSG_MAP_CHANGE);
 
 			if (Flooding)
 			{
+				// Fallback to dm1
 				MapChangeMsg.AddString("dm1", 0);
 				MapChangeMsg.AddInt(0xf2159e6e);
 				MapChangeMsg.AddInt(5805);
 			}
 			else
 			{
+				// dummy map
 				MapChangeMsg.AddString("dummy", 0);
 				MapChangeMsg.AddInt(DummyMapCrc);
 				MapChangeMsg.AddInt(sizeof(g_aDummyMapData));
@@ -345,6 +348,7 @@ void CNetServer::OnPreConnMsg(NETADDR &Addr, CNetPacketConstruct &Packet)
 			}
 			else
 			{
+				// send dummy map data
 				MapDataMsg.AddInt(1); // last chunk
 				MapDataMsg.AddInt(DummyMapCrc); // crc
 				MapDataMsg.AddInt(0); // chunk index


### PR DESCRIPTION
- Added ratelimit (sv_van_conn_per_second) which triggers when there are too many vanilla connection attempts within a second. Once it is triggered, fall back to 'dm1' instead of transferring the complete dummy map in order to reduce traffic (Antispoof related).
- Drop control packets with invalid size.