### PR TITLE
Prevent placing unused tiles in the editor

### DIFF
--- a/src/game/collision.cpp
+++ b/src/game/collision.cpp
@@ -110,13 +110,13 @@ void CCollision::Init(class CLayers *pLayers)
 		{
 			// remove unused tiles from front layer
 			Index = m_pFront[i].m_Index;
-			if(Index <= TILE_NPH_START && !(Index == TILE_DEATH || (Index >= TILE_NOLASER && Index <= TILE_THROUGH) || Index == TILE_FREEZE || (Index >= TILE_UNFREEZE && Index <= TILE_DUNFREEZE) || (Index >= TILE_WALLJUMP && Index <= TILE_SOLO_END) || (Index >= TILE_REFILL_JUMPS && Index <= TILE_STOPA) || (Index >= TILE_CP && Index <= TILE_THROUGH_DIR) || (Index >= TILE_OLDLASER && Index <= TILE_UNLOCK_TEAM) || (Index >= TILE_NPC_END && Index <= TILE_NPH_END) || (Index >= TILE_NPC_START && Index <= TILE_NPH_START)))
+			if(!IsValidFrontTile(Index))
 				m_pFront[i].m_Index = 0;
 		}
 		// remove unused tiles from game layer
 		Index = m_pTiles[i].m_Index;
-		if(Index <= TILE_NPH_START && !((Index >= TILE_SOLID && Index <= TILE_NOLASER) || Index == TILE_THROUGH || Index == TILE_FREEZE || (Index >= TILE_UNFREEZE && Index <= TILE_DUNFREEZE) || (Index >= TILE_WALLJUMP && Index <= TILE_SOLO_END) || (Index >= TILE_REFILL_JUMPS && Index <= TILE_STOPA) || (Index >= TILE_CP && Index <= TILE_THROUGH_DIR) || (Index >= TILE_OLDLASER && Index <= TILE_UNLOCK_TEAM) || (Index >= TILE_NPC_END && Index <= TILE_NPH_END) || (Index >= TILE_NPC_START && Index <= TILE_NPH_START)))
-				m_pTiles[i].m_Index = 0;
+		if(!IsValidGameTile(Index))
+			m_pTiles[i].m_Index = 0;
 	}
 
 	if(m_NumSwitchers)

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -1027,6 +1027,17 @@ void CEditor::DoToolbar(CUIRect ToolBar)
 		m_ShowEnvelopePreview = 0;
 	}
 
+	TB_Top.VSplitLeft(5.0f, 0, &TB_Top);
+
+	// allow place unused tiles button
+	TB_Top.VSplitLeft(40.0f, &Button, &TB_Top);
+	static int s_AllowPlaceUnusedTilesButton = 0;
+	if(DoButton_Editor(&s_AllowPlaceUnusedTilesButton, "Unused", m_AllowPlaceUnusedTiles, &Button, 0, "[ctrl+u] Allow placing unused tiles") ||
+		(Input()->KeyDown('u') && (Input()->KeyPressed(KEY_LCTRL) || Input()->KeyPressed(KEY_RCTRL))))
+	{
+		m_AllowPlaceUnusedTiles = !m_AllowPlaceUnusedTiles;
+	}
+
 	TB_Top.VSplitLeft(15.0f, 0, &TB_Top);
 
 	// zoom group

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -721,6 +721,7 @@ public:
 		m_SpeedupMaxSpeed = 0;
 		m_SpeedupAngle = 0;
 		m_LargeLayerWasWarned = false;
+		m_AllowPlaceUnusedTiles = false;
 	}
 
 	virtual void Init();
@@ -787,6 +788,7 @@ public:
 	int m_PopupEventActivated;
 	int m_PopupEventWasActivated;
 	bool m_LargeLayerWasWarned;
+	bool m_AllowPlaceUnusedTiles;
 
 	enum
 	{

--- a/src/game/editor/layer_game.cpp
+++ b/src/game/editor/layer_game.cpp
@@ -42,7 +42,13 @@ void CLayerGame::SetTile(int x, int y, CTile tile, bool force)
 			CTile air = {TILE_AIR, 0, 0, 0};
 			m_pEditor->m_Map.m_pFrontLayer->SetTile(x, y, air, true);
 		}
-		m_pTiles[y*m_Width+x] = tile;
+		// set normal game tile
+		if(m_pEditor->m_AllowPlaceUnusedTiles || IsValidGameTile(tile.m_Index)) {
+			m_pTiles[y*m_Width+x] = tile;
+		} else {
+			CTile air = {TILE_AIR, 0, 0, 0};
+			SetTile(x, y, air);
+		}
 	}
 }
 

--- a/src/game/editor/layer_tiles.cpp
+++ b/src/game/editor/layer_tiles.cpp
@@ -1312,8 +1312,15 @@ CTile CLayerFront::GetTile(int x, int y, bool force)
 
 void CLayerFront::SetTile(int x, int y, CTile tile, bool force)
 {
-	if(force || (GetTile(x, y, true).m_Index != TILE_THROUGH_CUT && tile.m_Index != TILE_THROUGH_CUT))
-		m_pTiles[y*m_Width+x] = tile;
+	if(force || (GetTile(x, y, true).m_Index != TILE_THROUGH_CUT && tile.m_Index != TILE_THROUGH_CUT)) {
+		// set normal front tile
+		if(m_pEditor->m_AllowPlaceUnusedTiles || IsValidFrontTile(tile.m_Index)) {
+			m_pTiles[y*m_Width+x] = tile;
+		} else {
+			CTile air = {TILE_AIR, 0, 0, 0};
+			SetTile(x, y, air);
+		}
+	}
 }
 
 void CLayerFront::Resize(int NewW, int NewH)

--- a/src/game/mapitems.cpp
+++ b/src/game/mapitems.cpp
@@ -1,0 +1,41 @@
+#include <game/mapitems.h>
+
+bool IsValidGameTile(int Index)
+{
+	return (IsValidEntity(Index)
+		||  Index == TILE_AIR
+		|| (Index >= TILE_SOLID && Index <= TILE_NOLASER)
+		||  Index == TILE_THROUGH
+		||  Index == TILE_FREEZE
+		|| (Index >= TILE_UNFREEZE && Index <= TILE_DUNFREEZE)
+		|| (Index >= TILE_WALLJUMP && Index <= TILE_SOLO_END)
+		|| (Index >= TILE_REFILL_JUMPS && Index <= TILE_STOPA)
+		|| (Index >= TILE_CP && Index <= TILE_THROUGH_DIR)
+		|| (Index >= TILE_OLDLASER && Index <= TILE_UNLOCK_TEAM)
+		|| (Index >= TILE_NPC_END && Index <= TILE_NPH_END)
+		|| (Index >= TILE_NPC_START && Index <= TILE_NPH_START)
+		|| (Index >= TILE_ENTITIES_OFF_1 && Index <= TILE_ENTITIES_OFF_2)
+	);
+}
+
+bool IsValidFrontTile(int Index)
+{
+	return (IsValidEntity(Index)
+		||  Index == TILE_AIR
+		||  Index == TILE_DEATH
+		|| (Index >= TILE_NOLASER && Index <= TILE_THROUGH)
+		||  Index == TILE_FREEZE
+		|| (Index >= TILE_UNFREEZE && Index <= TILE_DUNFREEZE)
+		|| (Index >= TILE_WALLJUMP && Index <= TILE_SOLO_END)
+		|| (Index >= TILE_REFILL_JUMPS && Index <= TILE_STOPA)
+		|| (Index >= TILE_CP && Index <= TILE_THROUGH_DIR)
+		|| (Index >= TILE_OLDLASER && Index <= TILE_UNLOCK_TEAM)
+		|| (Index >= TILE_NPC_END && Index <= TILE_NPH_END)
+		|| (Index >= TILE_NPC_START && Index <= TILE_NPH_START)
+	);
+}
+
+bool IsValidEntity(int Index)
+{
+	return Index > ENTITY_OFFSET;
+}

--- a/src/game/mapitems.h
+++ b/src/game/mapitems.h
@@ -152,7 +152,9 @@ enum
 	TILE_NPC_START = 104,
 	TILE_SUPER_START,
 	TILE_JETPACK_START,
-	TILE_NPH_START,//Remember to change this in collision.cpp if you add anymore tiles
+	TILE_NPH_START,
+	TILE_ENTITIES_OFF_1 = 190,
+	TILE_ENTITIES_OFF_2,
 	//End of higher tiles
 	//Layers
 	LAYER_GAME=0,
@@ -452,5 +454,10 @@ public:
 	unsigned char m_Number;
 	unsigned char m_Type;
 };
+
+
+bool IsValidGameTile(int Index);
+bool IsValidFrontTile(int Index);
+bool IsValidEntity(int Index);
 
 #endif


### PR DESCRIPTION
Prevent placing unused tiles in the editor, can be turned off with a new switch in the editor