### PR TITLE
dont remove unused tiles

### DIFF
--- a/src/game/collision.cpp
+++ b/src/game/collision.cpp
@@ -106,17 +106,6 @@ void CCollision::Init(class CLayers *pLayers)
 					m_pSwitch[i].m_Type = 0;
 			}
 		}
-		if(m_pFront)
-		{
-			// remove unused tiles from front layer
-			Index = m_pFront[i].m_Index;
-			if(!IsValidFrontTile(Index))
-				m_pFront[i].m_Index = 0;
-		}
-		// remove unused tiles from game layer
-		Index = m_pTiles[i].m_Index;
-		if(!IsValidGameTile(Index))
-			m_pTiles[i].m_Index = 0;
 	}
 
 	if(m_NumSwitchers)


### PR DESCRIPTION
Client and server used to remove unused tiles from the map when loading it. I can't see any reason to do so. It removed some entities used by other gametypes which where then unable to see in the entities clear.