### PR TITLE
Re-ordered the Gametiles-menu

### DIFF
--- a/src/game/editor/layer_tiles.cpp
+++ b/src/game/editor/layer_tiles.cpp
@@ -600,27 +600,27 @@ int CLayerTiles::RenderProperties(CUIRect *pToolBox)
 
 		int Result = m_pEditor->PopupSelectGameTileOpResult();
 		switch(Result)
-		{
+		{	
 			case 4:
-				Result = TILE_FREEZE;
+				Result = TILE_THROUGH_CUT;
 				break;
 			case 5:
-				Result = TILE_UNFREEZE;
+				Result = TILE_FREEZE;
 				break;
 			case 6:
-				Result = TILE_DFREEZE;
+				Result = TILE_UNFREEZE;
 				break;
 			case 7:
-				Result = TILE_DUNFREEZE;
+				Result = TILE_DFREEZE;
 				break;
 			case 8:
-				Result = TILE_TELECHECKIN;
+				Result = TILE_DUNFREEZE;
 				break;
 			case 9:
-				Result = TILE_TELECHECKINEVIL;
+				Result = TILE_TELECHECKIN;
 				break;
 			case 10:
-				Result = TILE_THROUGH_CUT;
+				Result = TILE_TELECHECKINEVIL;
 			default:
 				break;
 		}

--- a/src/game/editor/layer_tiles.cpp
+++ b/src/game/editor/layer_tiles.cpp
@@ -600,7 +600,7 @@ int CLayerTiles::RenderProperties(CUIRect *pToolBox)
 
 		int Result = m_pEditor->PopupSelectGameTileOpResult();
 		switch(Result)
-		{	
+		{
 			case 4:
 				Result = TILE_THROUGH_CUT;
 				break;

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -1307,7 +1307,7 @@ static int s_GametileOpSelected = -1;
 
 int CEditor::PopupSelectGametileOp(CEditor *pEditor, CUIRect View)
 {
-	static const char *s_pButtonNames[] = { "Clear", "Collision", "Death", "Unhookable", "Freeze", "Unfreeze", "Deep Freeze", "Deep Unfreeze", "Check-Tele From", "Evil Check-Tele From", "Hookthrough" };
+	static const char *s_pButtonNames[] = { "Clear", "Collision", "Death", "Unhookable", "Hookthrough", "Freeze", "Unfreeze", "Deep Freeze", "Deep Unfreeze", "Blue Check-Tele", "Red Check-Tele" };
 	static unsigned s_NumButtons = sizeof(s_pButtonNames) / sizeof(char*);
 	CUIRect Button;
 


### PR DESCRIPTION
Moves _Hookthrough_ up and replaces the outdated term _Evil_ for teleport.

![Game tiles](https://cloud.githubusercontent.com/assets/17771744/15028338/aca09f94-1248-11e6-9f1f-def1f78d339e.png)
