### PR TITLE
Rewrite of prediction code, with additional ddrace prediction

### DIFF
--- a/src/engine/client.h
+++ b/src/engine/client.h
@@ -126,7 +126,7 @@ public:
 
 	// input
 	virtual int *GetInput(int Tick) = 0;
-	virtual bool InputExists(int Tick) = 0;
+	virtual int *GetPredictedInput(int Tick) = 0;
 
 	// remote console
 	virtual void RconAuth(const char *pUsername, const char *pPassword) = 0;

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -599,12 +599,12 @@ int *CClient::GetInput(int Tick)
 	return 0;
 }
 
-bool CClient::InputExists(int Tick)
+int *CClient::GetPredictedInput(int Tick)
 {
 	for(int i = 0; i < 200; i++)
 		if(m_aInputs[g_Config.m_ClDummy][i].m_Tick == Tick)
-			return true;
-	return false;
+			return (int *)m_aInputs[g_Config.m_ClDummy][i].m_aData;
+	return 0;
 }
 
 // ------ state handling -----

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -237,7 +237,7 @@ public:
 
 	// TODO: OPT: do this alot smarter!
 	virtual int *GetInput(int Tick);
-	virtual bool InputExists(int Tick);
+	virtual int *GetPredictedInput(int Tick);
 
 	const char *LatestVersion();
 	void VersionUpdate();

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -12,6 +12,9 @@
 
 #include <game/teamscore.h>
 
+#include <game/client/world/gameworld.h>
+#include <game/client/world/entities/character.h>
+
 #define MIN3(x,y,z)  ((y) <= (z) ? \
 	((x) <= (y) ? (x) : (y)) \
 	: \
@@ -21,46 +24,6 @@
 	((x) >= (y) ? (x) : (y)) \
 	: \
 	((x) >= (z) ? (x) : (z)))
-
-class CGameClient;
-
-class CWeaponData
-{
-public:
-	int m_Tick;
-	vec2 m_Pos;
-	vec2 m_Direction;
-	vec2 StartPos() { return m_Pos + m_Direction * 28.0f * 0.75f; }
-};
-
-class CLocalProjectile
-{
-public:
-	int m_Active;
-	CGameClient *m_pGameClient;
-	CWorldCore *m_pWorld;
-	CCollision *m_pCollision;
-
-	vec2 m_Direction;
-	vec2 m_Pos;
-	int m_StartTick;
-	int m_Type;
-
-	int m_Owner;
-	int m_Weapon;
-	bool m_Explosive;
-	int m_Bouncing;
-	bool m_Freeze;
-	bool m_ExtraInfo;
-
-	vec2 GetPos(float Time);
-	void CreateExplosion(vec2 Pos, int LocalClientID);
-	void Tick(int CurrentTick, int GameTickSpeed, int LocalClientID);
-	void Init(CGameClient *pGameClient, CWorldCore *pWorld, CCollision *pCollision, const CNetObj_Projectile *pProj);
-	void Init(CGameClient *pGameClient, CWorldCore *pWorld, CCollision *pCollision, vec2 Vel, vec2 Pos, int StartTick, int Type, int Owner, int Weapon, bool Explosive, int Bouncing, bool Freeze, bool ExtraInfo);
-	bool GameLayerClipped(vec2 CheckPos);
-	void Deactivate() { m_Active = 0; }
-};
 
 class CGameClient : public IGameClient
 {
@@ -357,17 +320,14 @@ public:
 	class CTeamsCore m_Teams;
 
 	int IntersectCharacter(vec2 Pos0, vec2 Pos1, vec2& NewPos, int ownID);
-	int IntersectCharacter(vec2 OldPos, vec2 NewPos, float Radius, vec2* NewPos2, int ownID, CWorldCore *World);
-
-	CWeaponData m_aWeaponData[150];
-	CWeaponData *GetWeaponData(int Tick) { return &m_aWeaponData[((Tick%150)+150)%150]; }
-	CWeaponData *FindWeaponData(int TargetTick);
 
 	void FindWeaker(bool IsWeaker[2][MAX_CLIENTS]);
 
 	bool AntiPingPlayers() { return g_Config.m_ClAntiPing && g_Config.m_ClAntiPingPlayers && !m_Snap.m_SpecInfo.m_Active && Client()->State() != IClient::STATE_DEMOPLAYBACK; }
 	bool AntiPingGrenade() { return g_Config.m_ClAntiPing && g_Config.m_ClAntiPingGrenade && !m_Snap.m_SpecInfo.m_Active && Client()->State() != IClient::STATE_DEMOPLAYBACK; }
 	bool AntiPingWeapons() { return g_Config.m_ClAntiPing && g_Config.m_ClAntiPingWeapons && !m_Snap.m_SpecInfo.m_Active && Client()->State() != IClient::STATE_DEMOPLAYBACK; }
+
+	CGameWorld m_GameWorld[2];
 
 private:
 	bool m_DDRaceMsgSent[2];

--- a/src/game/client/world/entities/character.cpp
+++ b/src/game/client/world/entities/character.cpp
@@ -1,0 +1,1322 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#include <new>
+#include <engine/shared/config.h>
+#include <game/mapitems.h>
+
+#include "character.h"
+#include "projectile.h"
+#include "laser.h"
+
+#include <stdio.h>
+#include <string.h>
+
+// Character, "physical" player's part
+CCharacter::CCharacter(CGameWorld *pWorld)
+: CEntity(pWorld, CGameWorld::ENTTYPE_CHARACTER)
+{
+	m_ProximityRadius = ms_PhysSize;
+	m_Health = 0;
+	m_Armor = 0;
+}
+
+void CCharacter::Reset()
+{
+	Destroy();
+}
+
+bool CCharacter::Spawn(int ID, vec2 Pos)
+{
+	m_EmoteStop = -1;
+	m_LastAction = -1;
+	m_LastNoAmmoSound = -1;
+	m_LastWeapon = WEAPON_HAMMER;
+	m_QueuedWeapon = -1;
+	m_LastRefillJumps = false;
+	m_LastPenalty = false;
+	m_LastBonus = false;
+
+	m_Pos = Pos;
+
+	m_Core.Reset();
+	m_Core.Init(&GameWorld()->m_Core, GameWorld()->Collision(), GameWorld()->Teams());
+	m_Core.m_ActiveWeapon = WEAPON_GUN;
+	m_Core.m_Pos = m_Pos;
+
+	m_ReckoningTick = 0;
+	mem_zero(&m_SendCore, sizeof(m_SendCore));
+	mem_zero(&m_ReckoningCore, sizeof(m_ReckoningCore));
+
+	m_Core.m_Id = ID;
+	GameWorld()->InsertEntity(this);
+	m_Alive = true;
+
+	IncreaseHealth(10);
+
+	GiveWeapon(WEAPON_HAMMER, -1);
+	GiveWeapon(WEAPON_GUN, -1);
+
+	SetSolo(false);
+
+	DDRaceInit();
+
+	m_TuneZone = Collision()->IsTune(Collision()->GetMapIndex(Pos));
+	m_TuneZoneOld = -1; // no zone leave msg on spawn
+	m_NeededFaketuning = 0; // reset fake tunings on respawn and send the client
+
+	return true;
+}
+
+void CCharacter::Destroy()
+{
+	m_Alive = false;
+}
+
+void CCharacter::SetWeapon(int W)
+{
+	if(W == m_Core.m_ActiveWeapon)
+		return;
+
+	m_LastWeapon = m_Core.m_ActiveWeapon;
+	m_QueuedWeapon = -1;
+	m_Core.m_ActiveWeapon = W;
+
+	if(m_Core.m_ActiveWeapon < 0 || m_Core.m_ActiveWeapon >= NUM_WEAPONS)
+		m_Core.m_ActiveWeapon = 0;
+}
+
+void CCharacter::SetSolo(bool Solo)
+{
+	TeamsCore()->SetSolo(GetCID(), Solo);
+	if(Solo)
+		m_NeededFaketuning |= FAKETUNE_SOLO;
+	else
+		m_NeededFaketuning &= ~FAKETUNE_SOLO;
+}
+
+bool CCharacter::IsGrounded()
+{
+	if(Collision()->CheckPoint(m_Pos.x+m_ProximityRadius/2, m_Pos.y+m_ProximityRadius/2+5))
+		return true;
+	if(Collision()->CheckPoint(m_Pos.x-m_ProximityRadius/2, m_Pos.y+m_ProximityRadius/2+5))
+		return true;
+
+	int index = Collision()->GetPureMapIndex(vec2(m_Pos.x, m_Pos.y+m_ProximityRadius/2+4));
+	int tile = Collision()->GetTileIndex(index);
+	int flags = Collision()->GetTileFlags(index);
+	if(tile == TILE_STOPA || (tile == TILE_STOP && flags == ROTATION_0) || (tile ==TILE_STOPS && (flags == ROTATION_0 || flags == ROTATION_180)))
+		return true;
+	tile = Collision()->GetFTileIndex(index);
+	flags = Collision()->GetFTileFlags(index);
+	if(tile == TILE_STOPA || (tile == TILE_STOP && flags == ROTATION_0) || (tile ==TILE_STOPS && (flags == ROTATION_0 || flags == ROTATION_180)))
+		return true;
+
+	return false;
+}
+
+void CCharacter::HandleJetpack()
+{
+	vec2 Direction = normalize(vec2(m_LatestInput.m_TargetX, m_LatestInput.m_TargetY));
+
+	bool FullAuto = false;
+	if(m_Core.m_ActiveWeapon == WEAPON_GRENADE || m_Core.m_ActiveWeapon == WEAPON_SHOTGUN || m_Core.m_ActiveWeapon == WEAPON_RIFLE)
+		FullAuto = true;
+	if (m_Jetpack && m_Core.m_ActiveWeapon == WEAPON_GUN)
+		FullAuto = true;
+
+	// check if we gonna fire
+	bool WillFire = false;
+	if(CountInput(m_LatestPrevInput.m_Fire, m_LatestInput.m_Fire).m_Presses)
+		WillFire = true;
+
+	if(FullAuto && (m_LatestInput.m_Fire&1) && m_aWeapons[m_Core.m_ActiveWeapon].m_Ammo)
+		WillFire = true;
+
+	if(!WillFire)
+		return;
+
+	// check for ammo
+	if(!m_aWeapons[m_Core.m_ActiveWeapon].m_Ammo)
+	{
+		return;
+	}
+
+	switch(m_Core.m_ActiveWeapon)
+	{
+		case WEAPON_GUN:
+		{
+			if (m_Jetpack)
+			{
+				float Strength = m_JetpackStrength;
+				TakeDamage(Direction * -1.0f * (Strength / 100.0f / 6.11f), g_pData->m_Weapons.m_Hammer.m_pBase->m_Damage, GetCID(), m_Core.m_ActiveWeapon);
+			}
+		}
+	}
+}
+
+void CCharacter::HandleNinja()
+{
+	if(m_Core.m_ActiveWeapon != WEAPON_NINJA)
+		return;
+
+	if ((GameWorld()->GameTick() - m_Ninja.m_ActivationTick) > (g_pData->m_Weapons.m_Ninja.m_Duration * GameWorld()->GameTickSpeed() / 1000))
+	{
+		// time's up, return
+		m_Ninja.m_CurrentMoveTime = 0;
+		m_aWeapons[WEAPON_NINJA].m_Got = false;
+		m_Core.m_ActiveWeapon = m_LastWeapon;
+
+		SetWeapon(m_Core.m_ActiveWeapon);
+		return;
+	}
+
+	int NinjaTime = m_Ninja.m_ActivationTick + (g_pData->m_Weapons.m_Ninja.m_Duration * GameWorld()->GameTickSpeed() / 1000) - GameWorld()->GameTick();
+
+	m_Armor = 10 - (NinjaTime / 15);
+
+	// force ninja Weapon
+	SetWeapon(WEAPON_NINJA);
+
+	m_Ninja.m_CurrentMoveTime--;
+
+	if (m_Ninja.m_CurrentMoveTime == 0)
+	{
+		// reset velocity
+		m_Core.m_Vel = m_Ninja.m_ActivationDir*m_Ninja.m_OldVelAmount;
+	}
+
+	if (m_Ninja.m_CurrentMoveTime > 0)
+	{
+		// Set velocity
+		m_Core.m_Vel = m_Ninja.m_ActivationDir * g_pData->m_Weapons.m_Ninja.m_Velocity;
+		vec2 OldPos = m_Pos;
+		Collision()->MoveBox(&m_Core.m_Pos, &m_Core.m_Vel, vec2(m_ProximityRadius, m_ProximityRadius), 0.f);
+
+		// reset velocity so the client doesn't predict stuff
+		m_Core.m_Vel = vec2(0.f, 0.f);
+
+		// check if we Hit anything along the way
+		{
+			CCharacter *aEnts[MAX_CLIENTS];
+			vec2 Dir = m_Pos - OldPos;
+			float Radius = m_ProximityRadius * 2.0f;
+			vec2 Center = OldPos + Dir * 0.5f;
+			int Num = GameWorld()->FindEntities(Center, Radius, (CEntity**)aEnts, MAX_CLIENTS, CGameWorld::ENTTYPE_CHARACTER);
+
+			// check that we're not in solo part
+			if (TeamsCore()->GetSolo(GetCID()))
+				return;
+
+			for (int i = 0; i < Num; ++i)
+			{
+				if (aEnts[i] == this)
+					continue;
+
+				// Don't hit players in other teams
+				if (Team() != aEnts[i]->Team())
+					continue;
+
+				// Don't hit players in solo parts
+				if (TeamsCore()->GetSolo(aEnts[i]->GetCID()))
+					return;
+
+				// make sure we haven't Hit this object before
+				bool bAlreadyHit = false;
+				for (int j = 0; j < m_NumObjectsHit; j++)
+				{
+					if (m_aHitObjects[j] == aEnts[i]->GetCID())
+						bAlreadyHit = true;
+				}
+				if (bAlreadyHit)
+					continue;
+
+				// check so we are sufficiently close
+				if (distance(aEnts[i]->m_Pos, m_Pos) > (m_ProximityRadius * 2.0f))
+					continue;
+
+				// Hit a player, give him damage and stuffs...
+				// set his velocity to fast upward (for now)
+				if(m_NumObjectsHit < 10)
+					m_aHitObjects[m_NumObjectsHit++] = aEnts[i]->GetCID();
+
+				CCharacter *pChar = GameWorld()->GetCharacterByID(aEnts[i]->GetCID());
+				if(pChar)
+					pChar->TakeDamage(vec2(0, -10.0f), g_pData->m_Weapons.m_Ninja.m_pBase->m_Damage, GetCID(), WEAPON_NINJA);
+			}
+		}
+
+		return;
+	}
+
+	return;
+}
+
+void CCharacter::DoWeaponSwitch()
+{
+	// make sure we can switch
+	if(m_ReloadTimer != 0 || m_QueuedWeapon == -1 || m_aWeapons[WEAPON_NINJA].m_Got)
+		return;
+
+	// switch Weapon
+	SetWeapon(m_QueuedWeapon);
+}
+
+void CCharacter::HandleWeaponSwitch()
+{
+	int WantedWeapon = m_Core.m_ActiveWeapon;
+	if(m_QueuedWeapon != -1)
+		WantedWeapon = m_QueuedWeapon;
+
+	bool Anything = false;
+	 for(int i = 0; i < NUM_WEAPONS - 1; ++i)
+		 if(m_aWeapons[i].m_Got)
+			 Anything = true;
+	 if(!Anything)
+		 return;
+	// select Weapon
+	int Next = CountInput(m_LatestPrevInput.m_NextWeapon, m_LatestInput.m_NextWeapon).m_Presses;
+	int Prev = CountInput(m_LatestPrevInput.m_PrevWeapon, m_LatestInput.m_PrevWeapon).m_Presses;
+
+	if(Next < 128) // make sure we only try sane stuff
+	{
+		while(Next) // Next Weapon selection
+		{
+			WantedWeapon = (WantedWeapon+1)%NUM_WEAPONS;
+			if(m_aWeapons[WantedWeapon].m_Got)
+				Next--;
+		}
+	}
+
+	if(Prev < 128) // make sure we only try sane stuff
+	{
+		while(Prev) // Prev Weapon selection
+		{
+			WantedWeapon = (WantedWeapon-1)<0?NUM_WEAPONS-1:WantedWeapon-1;
+			if(m_aWeapons[WantedWeapon].m_Got)
+				Prev--;
+		}
+	}
+
+	// Direct Weapon selection
+	if(m_LatestInput.m_WantedWeapon)
+		WantedWeapon = m_Input.m_WantedWeapon-1;
+
+	// check for insane values
+	if(WantedWeapon >= 0 && WantedWeapon < NUM_WEAPONS && WantedWeapon != m_Core.m_ActiveWeapon && m_aWeapons[WantedWeapon].m_Got)
+		m_QueuedWeapon = WantedWeapon;
+
+	DoWeaponSwitch();
+}
+
+void CCharacter::FireWeapon()
+{
+	if(!GameWorld()->m_PredictWeapons)
+		return;
+
+	if(m_ReloadTimer != 0)
+		return;
+
+	DoWeaponSwitch();
+	vec2 Direction = normalize(vec2(m_LatestInput.m_TargetX, m_LatestInput.m_TargetY));
+
+	bool FullAuto = false;
+	if(m_Core.m_ActiveWeapon == WEAPON_GRENADE || m_Core.m_ActiveWeapon == WEAPON_SHOTGUN || m_Core.m_ActiveWeapon == WEAPON_RIFLE)
+		FullAuto = true;
+	if (m_Jetpack && m_Core.m_ActiveWeapon == WEAPON_GUN)
+		FullAuto = true;
+
+	// check if we gonna fire
+	bool WillFire = false;
+	if(CountInput(m_LatestPrevInput.m_Fire, m_LatestInput.m_Fire).m_Presses)
+		WillFire = true;
+
+	if(FullAuto && (m_LatestInput.m_Fire&1) && m_aWeapons[m_Core.m_ActiveWeapon].m_Ammo)
+		WillFire = true;
+
+	if(!WillFire)
+		return;
+
+	// check for ammo
+	if(!m_aWeapons[m_Core.m_ActiveWeapon].m_Ammo)
+	{
+		/*// 125ms is a magical limit of how fast a human can click
+		m_ReloadTimer = 125 * Server()->TickSpeed() / 1000;
+		GameServer()->CreateSound(m_Pos, SOUND_WEAPON_NOAMMO);*/
+		return;
+	}
+
+	vec2 ProjStartPos = m_Pos+Direction*m_ProximityRadius*0.75f;
+
+	switch(m_Core.m_ActiveWeapon)
+	{
+		case WEAPON_HAMMER:
+		{
+			// reset objects Hit
+			m_NumObjectsHit = 0;
+
+			if (m_Hit&DISABLE_HIT_HAMMER) break;
+
+			CCharacter *apEnts[MAX_CLIENTS];
+			int Hits = 0;
+			int Num = GameWorld()->FindEntities(ProjStartPos, m_ProximityRadius*0.5f, (CEntity**)apEnts,
+														MAX_CLIENTS, CGameWorld::ENTTYPE_CHARACTER);
+
+			for (int i = 0; i < Num; ++i)
+			{
+				CCharacter *pTarget = apEnts[i];
+
+				if((pTarget == this || (pTarget->IsAlive() && !CanCollide(pTarget->GetCID()))))
+					continue;
+
+				// set his velocity to fast upward (for now)
+
+				vec2 Dir;
+				if (length(pTarget->m_Pos - m_Pos) > 0.0f)
+					Dir = normalize(pTarget->m_Pos - m_Pos);
+				else
+					Dir = vec2(0.f, -1.f);
+
+				float Strength = Tuning()->m_HammerStrength;
+
+				vec2 Temp = pTarget->m_Core.m_Vel + normalize(Dir + vec2(0.f, -1.1f)) * 10.0f;
+				pTarget->Core()->LimitForce(&Temp);
+				Temp -= pTarget->m_Core.m_Vel;
+				pTarget->TakeDamage((vec2(0.f, -1.0f) + Temp) * Strength, g_pData->m_Weapons.m_Hammer.m_pBase->m_Damage,
+					GetCID(), m_Core.m_ActiveWeapon);
+				pTarget->UnFreeze();
+
+				if(m_FreezeHammer)
+					pTarget->Freeze();
+
+				Hits++;
+			}
+
+			// if we Hit anything, we have to wait for the reload
+			if(Hits)
+				m_ReloadTimer = GameWorld()->GameTickSpeed()/3;
+
+		} break;
+
+		case WEAPON_GUN:
+		{
+			if (!m_Jetpack)
+			{
+				int Lifetime;
+				Lifetime = (int)(GameWorld()->GameTickSpeed()*Tuning()->m_GunLifetime);
+				new CProjectile
+						(
+						GameWorld(),
+						WEAPON_GUN,//Type
+						GetCID(),//Owner
+						ProjStartPos,//Pos
+						Direction,//Dir
+						Lifetime,//Span
+						0,//Freeze
+						0,//Explosive
+						0,//Force
+						-1,//SoundImpact
+						WEAPON_GUN//Weapon
+						);
+			}
+		} break;
+
+		case WEAPON_SHOTGUN:
+		{
+			if(GameWorld()->m_IsDDRace)
+			{
+				float LaserReach = Tuning()->m_LaserReach;
+				new CLaser(GameWorld(), m_Pos, Direction, LaserReach, GetCID(), WEAPON_SHOTGUN);
+			}
+		} break;
+
+		case WEAPON_GRENADE:
+		{
+			int Lifetime = (int)(GameWorld()->GameTickSpeed()*Tuning()->m_GrenadeLifetime);
+			new CProjectile
+					(
+					GameWorld(),
+					WEAPON_GRENADE,//Type
+					GetCID(),//Owner
+					ProjStartPos,//Pos
+					Direction,//Dir
+					Lifetime,//Span
+					0,//Freeze
+					true,//Explosive
+					0,//Force
+					SOUND_GRENADE_EXPLODE,//SoundImpact
+					WEAPON_GRENADE//Weapon
+					);//SoundImpact
+		} break;
+
+		case WEAPON_RIFLE:
+		{
+			if(GameWorld()->m_IsDDRace)
+			{
+				float LaserReach = Tuning()->m_LaserReach;
+				new CLaser(GameWorld(), m_Pos, Direction, LaserReach, GetCID(), WEAPON_RIFLE);
+			}
+		} break;
+
+		case WEAPON_NINJA:
+		{
+			// reset Hit objects
+			m_NumObjectsHit = 0;
+
+			m_Ninja.m_ActivationDir = Direction;
+			m_Ninja.m_CurrentMoveTime = g_pData->m_Weapons.m_Ninja.m_Movetime * GameWorld()->GameTickSpeed() / 1000;
+			m_Ninja.m_OldVelAmount = length(m_Core.m_Vel);
+		} break;
+
+	}
+
+	m_AttackTick = GameWorld()->GameTick();
+
+	if(!m_ReloadTimer)
+	{
+		float FireDelay;
+		if (!m_TuneZone)
+		Tuning()->Get(38 + m_Core.m_ActiveWeapon, &FireDelay);
+		m_ReloadTimer = FireDelay * GameWorld()->GameTickSpeed() / 1000;
+	}
+}
+
+void CCharacter::HandleWeapons()
+{
+	//ninja
+	HandleNinja();
+	HandleJetpack();
+
+	if(m_PainSoundTimer > 0)
+		m_PainSoundTimer--;
+
+	// check reload timer
+	if(m_ReloadTimer)
+	{
+		m_ReloadTimer--;
+		return;
+	}
+
+	// fire Weapon, if wanted
+	FireWeapon();
+/*
+	// ammo regen
+	int AmmoRegenTime = g_pData->m_Weapons.m_aId[m_Core.m_ActiveWeapon].m_Ammoregentime;
+	if(AmmoRegenTime)
+	{
+		// If equipped and not active, regen ammo?
+		if (m_ReloadTimer <= 0)
+		{
+			if (m_aWeapons[m_Core.m_ActiveWeapon].m_AmmoRegenStart < 0)
+				m_aWeapons[m_Core.m_ActiveWeapon].m_AmmoRegenStart = Server()->Tick();
+
+			if ((Server()->Tick() - m_aWeapons[m_Core.m_ActiveWeapon].m_AmmoRegenStart) >= AmmoRegenTime * Server()->TickSpeed() / 1000)
+			{
+				// Add some ammo
+				m_aWeapons[m_Core.m_ActiveWeapon].m_Ammo = min(m_aWeapons[m_Core.m_ActiveWeapon].m_Ammo + 1, 10);
+				m_aWeapons[m_Core.m_ActiveWeapon].m_AmmoRegenStart = -1;
+			}
+		}
+		else
+		{
+			m_aWeapons[m_Core.m_ActiveWeapon].m_AmmoRegenStart = -1;
+		}
+	}*/
+
+	return;
+}
+
+bool CCharacter::GiveWeapon(int Weapon, int Ammo)
+{
+	if(m_aWeapons[Weapon].m_Ammo < g_pData->m_Weapons.m_aId[Weapon].m_Maxammo || !m_aWeapons[Weapon].m_Got)
+	{
+		m_aWeapons[Weapon].m_Got = true;
+		if(!m_FreezeTime)
+			m_aWeapons[Weapon].m_Ammo = min(g_pData->m_Weapons.m_aId[Weapon].m_Maxammo, Ammo);
+		return true;
+	}
+	return false;
+}
+
+void CCharacter::GiveNinja()
+{
+	m_Ninja.m_ActivationTick = GameWorld()->GameTick();
+	m_aWeapons[WEAPON_NINJA].m_Got = true;
+	if (!m_FreezeTime)
+		m_aWeapons[WEAPON_NINJA].m_Ammo = -1;
+	if (m_Core.m_ActiveWeapon != WEAPON_NINJA)
+		m_LastWeapon = m_Core.m_ActiveWeapon;
+	m_Core.m_ActiveWeapon = WEAPON_NINJA;
+}
+
+void CCharacter::SetEmote(int Emote, int Tick)
+{
+	m_EmoteType = Emote;
+	m_EmoteStop = Tick;
+}
+
+void CCharacter::OnPredictedInput(CNetObj_PlayerInput *pNewInput)
+{
+	// check for changes
+	if(mem_comp(&m_Input, pNewInput, sizeof(CNetObj_PlayerInput)) != 0)
+		m_LastAction = GameWorld()->GameTick();
+
+	// copy new input
+	mem_copy(&m_Input, pNewInput, sizeof(m_Input));
+	m_NumInputs++;
+
+	// it is not allowed to aim in the center
+	if(m_Input.m_TargetX == 0 && m_Input.m_TargetY == 0)
+		m_Input.m_TargetY = -1;
+}
+
+void CCharacter::OnDirectInput(CNetObj_PlayerInput *pNewInput)
+{
+	mem_copy(&m_LatestPrevInput, &m_LatestInput, sizeof(m_LatestInput));
+	mem_copy(&m_LatestInput, pNewInput, sizeof(m_LatestInput));
+
+	// it is not allowed to aim in the center
+	if(m_LatestInput.m_TargetX == 0 && m_LatestInput.m_TargetY == 0)
+		m_LatestInput.m_TargetY = -1;
+
+	if(m_NumInputs > 2 && Team() != TEAM_SPECTATORS)
+	{
+		HandleWeaponSwitch();
+		FireWeapon();
+	}
+
+	mem_copy(&m_LatestPrevInput, &m_LatestInput, sizeof(m_LatestInput));
+}
+
+void CCharacter::ResetInput()
+{
+	m_Input.m_Direction = 0;
+	//m_Input.m_Hook = 0;
+	// simulate releasing the fire button
+	if((m_Input.m_Fire&1) != 0)
+		m_Input.m_Fire++;
+	m_Input.m_Fire &= INPUT_STATE_MASK;
+	m_Input.m_Jump = 0;
+	m_LatestPrevInput = m_LatestInput = m_Input;
+}
+
+void CCharacter::Tick()
+{
+	if (m_Paused)
+		return;
+
+	DDRaceTick();
+
+	m_Core.m_Input = m_Input;
+	m_Core.Tick(true);
+
+	// handle Weapons
+	HandleWeapons();
+
+	DDRacePostCoreTick();
+
+	// Previnput
+	m_PrevInput = m_Input;
+
+	m_PrevPos = m_Core.m_Pos;
+	return;
+}
+
+void CCharacter::TickDefered()
+{
+	m_Core.Move();
+	m_Core.Quantize();
+	m_Pos = m_Core.m_Pos;
+}
+
+void CCharacter::TickPaused()
+{
+	++m_AttackTick;
+	++m_DamageTakenTick;
+	++m_Ninja.m_ActivationTick;
+	++m_ReckoningTick;
+	if(m_LastAction != -1)
+		++m_LastAction;
+	if(m_aWeapons[m_Core.m_ActiveWeapon].m_AmmoRegenStart > -1)
+		++m_aWeapons[m_Core.m_ActiveWeapon].m_AmmoRegenStart;
+	if(m_EmoteStop > -1)
+		++m_EmoteStop;
+}
+
+bool CCharacter::IncreaseHealth(int Amount)
+{
+	if(m_Health >= 10)
+		return false;
+	m_Health = clamp(m_Health+Amount, 0, 10);
+	return true;
+}
+
+bool CCharacter::IncreaseArmor(int Amount)
+{
+	if(m_Armor >= 10)
+		return false;
+	m_Armor = clamp(m_Armor+Amount, 0, 10);
+	return true;
+}
+
+bool CCharacter::TakeDamage(vec2 Force, int Dmg, int From, int Weapon)
+{
+	m_Core.ApplyForce(Force);
+	return true;
+}
+
+// DDRace
+
+bool CCharacter::CanCollide(int ClientID)
+{
+	return TeamsCore()->CanCollide(GetCID(), ClientID);
+}
+
+bool CCharacter::SameTeam(int ClientID)
+{
+	return TeamsCore()->SameTeam(GetCID(), ClientID);
+}
+
+int CCharacter::Team()
+{
+	return TeamsCore()->Team(GetCID());
+}
+
+void CCharacter::HandleSkippableTiles(int Index)
+{
+	if(Index < 0)
+		return;
+
+	// handle speedup tiles
+	if(Collision()->IsSpeedup(Index))
+	{
+		vec2 Direction, MaxVel, TempVel = m_Core.m_Vel;
+		int Force, MaxSpeed = 0;
+		float TeeAngle, SpeederAngle, DiffAngle, SpeedLeft, TeeSpeed;
+		Collision()->GetSpeedup(Index, &Direction, &Force, &MaxSpeed);
+		if(Force == 255 && MaxSpeed)
+		{
+			m_Core.m_Vel = Direction * (MaxSpeed/5);
+		}
+		else
+		{
+			if(MaxSpeed > 0 && MaxSpeed < 5) MaxSpeed = 5;
+			//dbg_msg("speedup tile start","Direction %f %f, Force %d, Max Speed %d", (Direction).x,(Direction).y, Force, MaxSpeed);
+			if(MaxSpeed > 0)
+			{
+				if(Direction.x > 0.0000001f)
+					SpeederAngle = -atan(Direction.y / Direction.x);
+				else if(Direction.x < 0.0000001f)
+					SpeederAngle = atan(Direction.y / Direction.x) + 2.0f * asin(1.0f);
+				else if(Direction.y > 0.0000001f)
+					SpeederAngle = asin(1.0f);
+				else
+					SpeederAngle = asin(-1.0f);
+
+				if(SpeederAngle < 0)
+					SpeederAngle = 4.0f * asin(1.0f) + SpeederAngle;
+
+				if(TempVel.x > 0.0000001f)
+					TeeAngle = -atan(TempVel.y / TempVel.x);
+				else if(TempVel.x < 0.0000001f)
+					TeeAngle = atan(TempVel.y / TempVel.x) + 2.0f * asin(1.0f);
+				else if(TempVel.y > 0.0000001f)
+					TeeAngle = asin(1.0f);
+				else
+					TeeAngle = asin(-1.0f);
+
+				if(TeeAngle < 0)
+					TeeAngle = 4.0f * asin(1.0f) + TeeAngle;
+
+				TeeSpeed = sqrt(pow(TempVel.x, 2) + pow(TempVel.y, 2));
+
+				DiffAngle = SpeederAngle - TeeAngle;
+				SpeedLeft = MaxSpeed / 5.0f - cos(DiffAngle) * TeeSpeed;
+				//dbg_msg("speedup tile debug","MaxSpeed %i, TeeSpeed %f, SpeedLeft %f, SpeederAngle %f, TeeAngle %f", MaxSpeed, TeeSpeed, SpeedLeft, SpeederAngle, TeeAngle);
+				if(abs((int)SpeedLeft) > Force && SpeedLeft > 0.0000001f)
+					TempVel += Direction * Force;
+				else if(abs((int)SpeedLeft) > Force)
+					TempVel += Direction * -Force;
+				else
+					TempVel += Direction * SpeedLeft;
+			}
+			else
+				TempVel += Direction * Force;
+			m_Core.LimitForce(&TempVel);
+			m_Core.m_Vel = TempVel;
+		}
+	}
+}
+
+void CCharacter::HandleTiles(int Index)
+{
+	//CGameControllerDDRace* Controller = (CGameControllerDDRace*)GameServer()->m_pController;
+	int MapIndex = Index;
+	float Offset = 4.0f;
+	int MapIndexL = Collision()->GetPureMapIndex(vec2(m_Pos.x + (m_ProximityRadius / 2) + Offset, m_Pos.y));
+	int MapIndexR = Collision()->GetPureMapIndex(vec2(m_Pos.x - (m_ProximityRadius / 2) - Offset, m_Pos.y));
+	int MapIndexT = Collision()->GetPureMapIndex(vec2(m_Pos.x, m_Pos.y + (m_ProximityRadius / 2) + Offset));
+	int MapIndexB = Collision()->GetPureMapIndex(vec2(m_Pos.x, m_Pos.y - (m_ProximityRadius / 2) - Offset));
+	//dbg_msg("","N%d L%d R%d B%d T%d",MapIndex,MapIndexL,MapIndexR,MapIndexB,MapIndexT);
+	m_TileIndex = Collision()->GetTileIndex(MapIndex);
+	m_TileFlags = Collision()->GetTileFlags(MapIndex);
+	m_TileIndexL = Collision()->GetTileIndex(MapIndexL);
+	m_TileFlagsL = Collision()->GetTileFlags(MapIndexL);
+	m_TileIndexR = Collision()->GetTileIndex(MapIndexR);
+	m_TileFlagsR = Collision()->GetTileFlags(MapIndexR);
+	m_TileIndexB = Collision()->GetTileIndex(MapIndexB);
+	m_TileFlagsB = Collision()->GetTileFlags(MapIndexB);
+	m_TileIndexT = Collision()->GetTileIndex(MapIndexT);
+	m_TileFlagsT = Collision()->GetTileFlags(MapIndexT);
+	m_TileFIndex = Collision()->GetFTileIndex(MapIndex);
+	m_TileFFlags = Collision()->GetFTileFlags(MapIndex);
+	m_TileFIndexL = Collision()->GetFTileIndex(MapIndexL);
+	m_TileFFlagsL = Collision()->GetFTileFlags(MapIndexL);
+	m_TileFIndexR = Collision()->GetFTileIndex(MapIndexR);
+	m_TileFFlagsR = Collision()->GetFTileFlags(MapIndexR);
+	m_TileFIndexB = Collision()->GetFTileIndex(MapIndexB);
+	m_TileFFlagsB = Collision()->GetFTileFlags(MapIndexB);
+	m_TileFIndexT = Collision()->GetFTileIndex(MapIndexT);
+	m_TileFFlagsT = Collision()->GetFTileFlags(MapIndexT);//
+	m_TileSIndex = (Collision()->m_pSwitchers && Collision()->m_pSwitchers[Collision()->GetDTileNumber(MapIndex)].m_Status[Team()])?(Team() != TEAM_SUPER)? Collision()->GetDTileIndex(MapIndex) : 0 : 0;
+	m_TileSFlags = (Collision()->m_pSwitchers && Collision()->m_pSwitchers[Collision()->GetDTileNumber(MapIndex)].m_Status[Team()])?(Team() != TEAM_SUPER)? Collision()->GetDTileFlags(MapIndex) : 0 : 0;
+	m_TileSIndexL = (Collision()->m_pSwitchers && Collision()->m_pSwitchers[Collision()->GetDTileNumber(MapIndexL)].m_Status[Team()])?(Team() != TEAM_SUPER)? Collision()->GetDTileIndex(MapIndexL) : 0 : 0;
+	m_TileSFlagsL = (Collision()->m_pSwitchers && Collision()->m_pSwitchers[Collision()->GetDTileNumber(MapIndexL)].m_Status[Team()])?(Team() != TEAM_SUPER)? Collision()->GetDTileFlags(MapIndexL) : 0 : 0;
+	m_TileSIndexR = (Collision()->m_pSwitchers && Collision()->m_pSwitchers[Collision()->GetDTileNumber(MapIndexR)].m_Status[Team()])?(Team() != TEAM_SUPER)? Collision()->GetDTileIndex(MapIndexR) : 0 : 0;
+	m_TileSFlagsR = (Collision()->m_pSwitchers && Collision()->m_pSwitchers[Collision()->GetDTileNumber(MapIndexR)].m_Status[Team()])?(Team() != TEAM_SUPER)? Collision()->GetDTileFlags(MapIndexR) : 0 : 0;
+	m_TileSIndexB = (Collision()->m_pSwitchers && Collision()->m_pSwitchers[Collision()->GetDTileNumber(MapIndexB)].m_Status[Team()])?(Team() != TEAM_SUPER)? Collision()->GetDTileIndex(MapIndexB) : 0 : 0;
+	m_TileSFlagsB = (Collision()->m_pSwitchers && Collision()->m_pSwitchers[Collision()->GetDTileNumber(MapIndexB)].m_Status[Team()])?(Team() != TEAM_SUPER)? Collision()->GetDTileFlags(MapIndexB) : 0 : 0;
+	m_TileSIndexT = (Collision()->m_pSwitchers && Collision()->m_pSwitchers[Collision()->GetDTileNumber(MapIndexT)].m_Status[Team()])?(Team() != TEAM_SUPER)? Collision()->GetDTileIndex(MapIndexT) : 0 : 0;
+	m_TileSFlagsT = (Collision()->m_pSwitchers && Collision()->m_pSwitchers[Collision()->GetDTileNumber(MapIndexT)].m_Status[Team()])?(Team() != TEAM_SUPER)? Collision()->GetDTileFlags(MapIndexT) : 0 : 0;
+	//dbg_msg("Tiles","%d, %d, %d, %d, %d", m_TileSIndex, m_TileSIndexL, m_TileSIndexR, m_TileSIndexB, m_TileSIndexT);
+	//dbg_msg("","N%d L%d R%d B%d T%d",m_TileIndex,m_TileIndexL,m_TileIndexR,m_TileIndexB,m_TileIndexT);
+	//dbg_msg("","N%d L%d R%d B%d T%d",m_TileFIndex,m_TileFIndexL,m_TileFIndexR,m_TileFIndexB,m_TileFIndexT);
+	if(Index < 0)
+	{
+		m_LastRefillJumps = false;
+		m_LastPenalty = false;
+		m_LastBonus = false;
+		return;
+	}
+
+	// freeze
+	if(((m_TileIndex == TILE_FREEZE) || (m_TileFIndex == TILE_FREEZE)) && !m_Super && !m_DeepFreeze)
+		Freeze();
+	else if(((m_TileIndex == TILE_UNFREEZE) || (m_TileFIndex == TILE_UNFREEZE)) && !m_DeepFreeze)
+		UnFreeze();
+
+	// deep freeze
+	if(((m_TileIndex == TILE_DFREEZE) || (m_TileFIndex == TILE_DFREEZE)) && !m_Super && !m_DeepFreeze)
+		m_DeepFreeze = true;
+	else if(((m_TileIndex == TILE_DUNFREEZE) || (m_TileFIndex == TILE_DUNFREEZE)) && !m_Super && m_DeepFreeze)
+		m_DeepFreeze = false;
+
+	// endless hook
+	if(((m_TileIndex == TILE_EHOOK_START) || (m_TileFIndex == TILE_EHOOK_START)) && !m_EndlessHook)
+	{
+		//GameServer()->SendChatTarget(GetPlayer()->GetCID(), "Endless hook has been activated");
+		m_EndlessHook = true;
+	}
+	else if(((m_TileIndex == TILE_EHOOK_END) || (m_TileFIndex == TILE_EHOOK_END)) && m_EndlessHook)
+	{
+		//GameServer()->SendChatTarget(GetPlayer()->GetCID(), "Endless hook has been deactivated");
+		m_EndlessHook = false;
+	}
+
+	// hit others
+	if(((m_TileIndex == TILE_HIT_END) || (m_TileFIndex == TILE_HIT_END)) && m_Hit != (DISABLE_HIT_GRENADE|DISABLE_HIT_HAMMER|DISABLE_HIT_RIFLE|DISABLE_HIT_SHOTGUN))
+	{
+		//GameServer()->SendChatTarget(GetPlayer()->GetCID(), "You can't hit others");
+		m_Hit = DISABLE_HIT_GRENADE|DISABLE_HIT_HAMMER|DISABLE_HIT_RIFLE|DISABLE_HIT_SHOTGUN;
+	}
+	else if(((m_TileIndex == TILE_HIT_START) || (m_TileFIndex == TILE_HIT_START)) && m_Hit != HIT_ALL)
+	{
+		//GameServer()->SendChatTarget(GetPlayer()->GetCID(), "You can hit others");
+		m_Hit = HIT_ALL;
+	}
+
+	// collide with others
+	if(((m_TileIndex == TILE_NPC_END) || (m_TileFIndex == TILE_NPC_END)) && m_Core.m_Collision)
+	{
+		//GameServer()->SendChatTarget(GetPlayer()->GetCID(), "You can't collide with others");
+		m_Core.m_Collision = false;
+		//m_NeededFaketuning |= FAKETUNE_NOCOLL;
+		//GameServer()->SendTuningParams(m_pPlayer->GetCID(), m_TuneZone); // update tunings
+	}
+	else if(((m_TileIndex == TILE_NPC_START) || (m_TileFIndex == TILE_NPC_START)) && !m_Core.m_Collision)
+	{
+		//GameServer()->SendChatTarget(GetPlayer()->GetCID(),"You can collide with others");
+		m_Core.m_Collision = true;
+		//m_NeededFaketuning &= ~FAKETUNE_NOCOLL;
+		//GameServer()->SendTuningParams(m_pPlayer->GetCID(), m_TuneZone); // update tunings
+	}
+
+	// hook others
+	if(((m_TileIndex == TILE_NPH_END) || (m_TileFIndex == TILE_NPH_END)) && m_Core.m_Hook)
+	{
+		//GameServer()->SendChatTarget(GetPlayer()->GetCID(), "You can't hook others");
+		m_Core.m_Hook = false;
+		//m_NeededFaketuning |= FAKETUNE_NOHOOK;
+		//GameServer()->SendTuningParams(m_pPlayer->GetCID(), m_TuneZone); // update tunings
+	}
+	else if(((m_TileIndex == TILE_NPH_START) || (m_TileFIndex == TILE_NPH_START)) && !m_Core.m_Hook)
+	{
+		//GameServer()->SendChatTarget(GetPlayer()->GetCID(),"You can hook others");
+		m_Core.m_Hook = true;
+		//m_NeededFaketuning &= ~FAKETUNE_NOHOOK;
+		//GameServer()->SendTuningParams(m_pPlayer->GetCID(), m_TuneZone); // update tunings
+	}
+
+	// unlimited air jumps
+	if(((m_TileIndex == TILE_SUPER_START) || (m_TileFIndex == TILE_SUPER_START)) && !m_SuperJump)
+	{
+		//GameServer()->SendChatTarget(GetPlayer()->GetCID(),"You have unlimited air jumps");
+		m_SuperJump = true;
+		if (m_Core.m_Jumps == 0)
+		{
+			m_NeededFaketuning &= ~FAKETUNE_NOJUMP;
+			//GameServer()->SendTuningParams(m_pPlayer->GetCID(), m_TuneZone); // update tunings
+		}
+	}
+	else if(((m_TileIndex == TILE_SUPER_END) || (m_TileFIndex == TILE_SUPER_END)) && m_SuperJump)
+	{
+		//GameServer()->SendChatTarget(GetPlayer()->GetCID(), "You don't have unlimited air jumps");
+		m_SuperJump = false;
+		if (m_Core.m_Jumps == 0)
+		{
+			m_NeededFaketuning |= FAKETUNE_NOJUMP;
+			//GameServer()->SendTuningParams(m_pPlayer->GetCID(), m_TuneZone); // update tunings
+		}
+	}
+
+	// walljump
+	if((m_TileIndex == TILE_WALLJUMP) || (m_TileFIndex == TILE_WALLJUMP))
+	{
+		if(m_Core.m_Vel.y > 0 && m_Core.m_Colliding && m_Core.m_LeftWall)
+		{
+			m_Core.m_LeftWall = false;
+			m_Core.m_JumpedTotal = m_Core.m_Jumps - 1;
+			m_Core.m_Jumped = 1;
+		}
+	}
+
+	// jetpack gun
+	if(((m_TileIndex == TILE_JETPACK_START) || (m_TileFIndex == TILE_JETPACK_START)) && !m_Jetpack)
+	{
+		//GameServer()->SendChatTarget(GetPlayer()->GetCID(),"You have a jetpack gun");
+		m_Jetpack = true;
+	}
+	else if(((m_TileIndex == TILE_JETPACK_END) || (m_TileFIndex == TILE_JETPACK_END)) && m_Jetpack)
+	{
+		//GameServer()->SendChatTarget(GetPlayer()->GetCID(), "You lost your jetpack gun");
+		m_Jetpack = false;
+	}
+
+	// solo part
+	if(((m_TileIndex == TILE_SOLO_START) || (m_TileFIndex == TILE_SOLO_START)) && !TeamsCore()->GetSolo(GetCID()))
+	{
+		//GameServer()->SendChatTarget(GetPlayer()->GetCID(), "You are now in a solo part.");
+		SetSolo(true);
+	}
+	else if(((m_TileIndex == TILE_SOLO_END) || (m_TileFIndex == TILE_SOLO_END)) && TeamsCore()->GetSolo(GetCID()))
+	{
+		//GameServer()->SendChatTarget(GetPlayer()->GetCID(), "You are now out of the solo part.");
+		SetSolo(false);
+	}
+
+	// refill jumps
+	if(((m_TileIndex == TILE_REFILL_JUMPS) || (m_TileFIndex == TILE_REFILL_JUMPS)) && !m_LastRefillJumps)
+	{
+		m_Core.m_JumpedTotal = 0;
+		m_Core.m_Jumped = 0;
+		m_LastRefillJumps = true;
+	}
+	if((m_TileIndex != TILE_REFILL_JUMPS) && (m_TileFIndex != TILE_REFILL_JUMPS))
+	{
+		m_LastRefillJumps = false;
+	}
+
+	// stopper
+	if(((m_TileIndex == TILE_STOP && m_TileFlags == ROTATION_270) || (m_TileIndexL == TILE_STOP && m_TileFlagsL == ROTATION_270) || (m_TileIndexL == TILE_STOPS && (m_TileFlagsL == ROTATION_90 || m_TileFlagsL ==ROTATION_270)) || (m_TileIndexL == TILE_STOPA) || (m_TileFIndex == TILE_STOP && m_TileFFlags == ROTATION_270) || (m_TileFIndexL == TILE_STOP && m_TileFFlagsL == ROTATION_270) || (m_TileFIndexL == TILE_STOPS && (m_TileFFlagsL == ROTATION_90 || m_TileFFlagsL == ROTATION_270)) || (m_TileFIndexL == TILE_STOPA) || (m_TileSIndex == TILE_STOP && m_TileSFlags == ROTATION_270) || (m_TileSIndexL == TILE_STOP && m_TileSFlagsL == ROTATION_270) || (m_TileSIndexL == TILE_STOPS && (m_TileSFlagsL == ROTATION_90 || m_TileSFlagsL == ROTATION_270)) || (m_TileSIndexL == TILE_STOPA)) && m_Core.m_Vel.x > 0)
+	{
+		if((int)Collision()->GetPos(MapIndexL).x)
+			if((int)Collision()->GetPos(MapIndexL).x < (int)m_Core.m_Pos.x)
+				m_Core.m_Pos = m_PrevPos;
+		m_Core.m_Vel.x = 0;
+	}
+	if(((m_TileIndex == TILE_STOP && m_TileFlags == ROTATION_90) || (m_TileIndexR == TILE_STOP && m_TileFlagsR == ROTATION_90) || (m_TileIndexR == TILE_STOPS && (m_TileFlagsR == ROTATION_90 || m_TileFlagsR == ROTATION_270)) || (m_TileIndexR == TILE_STOPA) || (m_TileFIndex == TILE_STOP && m_TileFFlags == ROTATION_90) || (m_TileFIndexR == TILE_STOP && m_TileFFlagsR == ROTATION_90) || (m_TileFIndexR == TILE_STOPS && (m_TileFFlagsR == ROTATION_90 || m_TileFFlagsR == ROTATION_270)) || (m_TileFIndexR == TILE_STOPA) || (m_TileSIndex == TILE_STOP && m_TileSFlags == ROTATION_90) || (m_TileSIndexR == TILE_STOP && m_TileSFlagsR == ROTATION_90) || (m_TileSIndexR == TILE_STOPS && (m_TileSFlagsR == ROTATION_90 || m_TileSFlagsR == ROTATION_270)) || (m_TileSIndexR == TILE_STOPA)) && m_Core.m_Vel.x < 0)
+	{
+		if((int)Collision()->GetPos(MapIndexR).x)
+			if((int)Collision()->GetPos(MapIndexR).x > (int)m_Core.m_Pos.x)
+				m_Core.m_Pos = m_PrevPos;
+		m_Core.m_Vel.x = 0;
+	}
+	if(((m_TileIndex == TILE_STOP && m_TileFlags == ROTATION_180) || (m_TileIndexB == TILE_STOP && m_TileFlagsB == ROTATION_180) || (m_TileIndexB == TILE_STOPS && (m_TileFlagsB == ROTATION_0 || m_TileFlagsB == ROTATION_180)) || (m_TileIndexB == TILE_STOPA) || (m_TileFIndex == TILE_STOP && m_TileFFlags == ROTATION_180) || (m_TileFIndexB == TILE_STOP && m_TileFFlagsB == ROTATION_180) || (m_TileFIndexB == TILE_STOPS && (m_TileFFlagsB == ROTATION_0 || m_TileFFlagsB == ROTATION_180)) || (m_TileFIndexB == TILE_STOPA) || (m_TileSIndex == TILE_STOP && m_TileSFlags == ROTATION_180) || (m_TileSIndexB == TILE_STOP && m_TileSFlagsB == ROTATION_180) || (m_TileSIndexB == TILE_STOPS && (m_TileSFlagsB == ROTATION_0 || m_TileSFlagsB == ROTATION_180)) || (m_TileSIndexB == TILE_STOPA)) && m_Core.m_Vel.y < 0)
+	{
+		if((int)Collision()->GetPos(MapIndexB).y)
+			if((int)Collision()->GetPos(MapIndexB).y > (int)m_Core.m_Pos.y)
+				m_Core.m_Pos = m_PrevPos;
+		m_Core.m_Vel.y = 0;
+	}
+	if(((m_TileIndex == TILE_STOP && m_TileFlags == ROTATION_0) || (m_TileIndexT == TILE_STOP && m_TileFlagsT == ROTATION_0) || (m_TileIndexT == TILE_STOPS && (m_TileFlagsT == ROTATION_0 || m_TileFlagsT == ROTATION_180)) || (m_TileIndexT == TILE_STOPA) || (m_TileFIndex == TILE_STOP && m_TileFFlags == ROTATION_0) || (m_TileFIndexT == TILE_STOP && m_TileFFlagsT == ROTATION_0) || (m_TileFIndexT == TILE_STOPS && (m_TileFFlagsT == ROTATION_0 || m_TileFFlagsT == ROTATION_180)) || (m_TileFIndexT == TILE_STOPA) || (m_TileSIndex == TILE_STOP && m_TileSFlags == ROTATION_0) || (m_TileSIndexT == TILE_STOP && m_TileSFlagsT == ROTATION_0) || (m_TileSIndexT == TILE_STOPS && (m_TileSFlagsT == ROTATION_0 || m_TileSFlagsT == ROTATION_180)) || (m_TileSIndexT == TILE_STOPA)) && m_Core.m_Vel.y > 0)
+	{
+		//dbg_msg("","%f %f",Collision()->GetPos(MapIndex).y,m_Core.m_Pos.y);
+		if((int)Collision()->GetPos(MapIndexT).y)
+			if((int)Collision()->GetPos(MapIndexT).y < (int)m_Core.m_Pos.y)
+				m_Core.m_Pos = m_PrevPos;
+		m_Core.m_Vel.y = 0;
+		m_Core.m_Jumped = 0;
+		m_Core.m_JumpedTotal = 0;
+	}
+
+	// handle switch tiles
+	if(Collision()->IsSwitch(MapIndex) == TILE_SWITCHOPEN && Team() != TEAM_SUPER)
+	{
+		Collision()->m_pSwitchers[Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()] = true;
+		Collision()->m_pSwitchers[Collision()->GetSwitchNumber(MapIndex)].m_EndTick[Team()] = 0;
+		Collision()->m_pSwitchers[Collision()->GetSwitchNumber(MapIndex)].m_Type[Team()] = TILE_SWITCHOPEN;
+	}
+	else if(Collision()->IsSwitch(MapIndex) == TILE_SWITCHTIMEDOPEN && Team() != TEAM_SUPER)
+	{
+		Collision()->m_pSwitchers[Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()] = true;
+		Collision()->m_pSwitchers[Collision()->GetSwitchNumber(MapIndex)].m_EndTick[Team()] = GameWorld()->GameTick() + 1 + Collision()->GetSwitchDelay(MapIndex)*GameWorld()->GameTickSpeed() ;
+		Collision()->m_pSwitchers[Collision()->GetSwitchNumber(MapIndex)].m_Type[Team()] = TILE_SWITCHTIMEDOPEN;
+	}
+	else if(Collision()->IsSwitch(MapIndex) == TILE_SWITCHTIMEDCLOSE && Team() != TEAM_SUPER)
+	{
+		Collision()->m_pSwitchers[Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()] = false;
+		Collision()->m_pSwitchers[Collision()->GetSwitchNumber(MapIndex)].m_EndTick[Team()] = GameWorld()->GameTick() + 1 + Collision()->GetSwitchDelay(MapIndex)*GameWorld()->GameTickSpeed();
+		Collision()->m_pSwitchers[Collision()->GetSwitchNumber(MapIndex)].m_Type[Team()] = TILE_SWITCHTIMEDCLOSE;
+	}
+	else if(Collision()->IsSwitch(MapIndex) == TILE_SWITCHCLOSE && Team() != TEAM_SUPER)
+	{
+		Collision()->m_pSwitchers[Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()] = false;
+		Collision()->m_pSwitchers[Collision()->GetSwitchNumber(MapIndex)].m_EndTick[Team()] = 0;
+		Collision()->m_pSwitchers[Collision()->GetSwitchNumber(MapIndex)].m_Type[Team()] = TILE_SWITCHCLOSE;
+	}
+	else if(Collision()->IsSwitch(MapIndex) == TILE_FREEZE && Team() != TEAM_SUPER)
+	{
+		if(Collision()->GetSwitchNumber(MapIndex) == 0 || Collision()->m_pSwitchers[Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()])
+			Freeze(Collision()->GetSwitchDelay(MapIndex));
+	}
+	else if(Collision()->IsSwitch(MapIndex) == TILE_DFREEZE && Team() != TEAM_SUPER && Collision()->m_pSwitchers[Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()])
+	{
+		m_DeepFreeze = true;
+	}
+	else if(Collision()->IsSwitch(MapIndex) == TILE_DUNFREEZE && Team() != TEAM_SUPER && Collision()->m_pSwitchers[Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()])
+	{
+		m_DeepFreeze = false;
+	}
+	else if(Collision()->IsSwitch(MapIndex) == TILE_HIT_START && m_Hit&DISABLE_HIT_HAMMER && Collision()->GetSwitchDelay(MapIndex) == WEAPON_HAMMER)
+	{
+		//GameServer()->SendChatTarget(GetPlayer()->GetCID(),"You can hammer hit others");
+		m_Hit &= ~DISABLE_HIT_HAMMER;
+	}
+	else if(Collision()->IsSwitch(MapIndex) == TILE_HIT_END && !(m_Hit&DISABLE_HIT_HAMMER) && Collision()->GetSwitchDelay(MapIndex) == WEAPON_HAMMER)
+	{
+		//GameServer()->SendChatTarget(GetPlayer()->GetCID(),"You can't hammer hit others");
+		m_Hit |= DISABLE_HIT_HAMMER;
+	}
+	else if(Collision()->IsSwitch(MapIndex) == TILE_HIT_START && m_Hit&DISABLE_HIT_SHOTGUN && Collision()->GetSwitchDelay(MapIndex) == WEAPON_SHOTGUN)
+	{
+		//GameServer()->SendChatTarget(GetPlayer()->GetCID(),"You can shoot others with shotgun");
+		m_Hit &= ~DISABLE_HIT_SHOTGUN;
+	}
+	else if(Collision()->IsSwitch(MapIndex) == TILE_HIT_END && !(m_Hit&DISABLE_HIT_SHOTGUN) && Collision()->GetSwitchDelay(MapIndex) == WEAPON_SHOTGUN)
+	{
+		//GameServer()->SendChatTarget(GetPlayer()->GetCID(),"You can't shoot others with shotgun");
+		m_Hit |= DISABLE_HIT_SHOTGUN;
+	}
+	else if(Collision()->IsSwitch(MapIndex) == TILE_HIT_START && m_Hit&DISABLE_HIT_GRENADE && Collision()->GetSwitchDelay(MapIndex) == WEAPON_GRENADE)
+	{
+		//GameServer()->SendChatTarget(GetPlayer()->GetCID(),"You can shoot others with grenade");
+		m_Hit &= ~DISABLE_HIT_GRENADE;
+	}
+	else if(Collision()->IsSwitch(MapIndex) == TILE_HIT_END && !(m_Hit&DISABLE_HIT_GRENADE) && Collision()->GetSwitchDelay(MapIndex) == WEAPON_GRENADE)
+	{
+		//GameServer()->SendChatTarget(GetPlayer()->GetCID(),"You can't shoot others with grenade");
+		m_Hit |= DISABLE_HIT_GRENADE;
+	}
+	else if(Collision()->IsSwitch(MapIndex) == TILE_HIT_START && m_Hit&DISABLE_HIT_RIFLE && Collision()->GetSwitchDelay(MapIndex) == WEAPON_RIFLE)
+	{
+		//GameServer()->SendChatTarget(GetPlayer()->GetCID(),"You can shoot others with rifle");
+		m_Hit &= ~DISABLE_HIT_RIFLE;
+	}
+	else if(Collision()->IsSwitch(MapIndex) == TILE_HIT_END && !(m_Hit&DISABLE_HIT_RIFLE) && Collision()->GetSwitchDelay(MapIndex) == WEAPON_RIFLE)
+	{
+		//GameServer()->SendChatTarget(GetPlayer()->GetCID(),"You can't shoot others with rifle");
+		m_Hit |= DISABLE_HIT_RIFLE;
+	}
+	else if(Collision()->IsSwitch(MapIndex) == TILE_JUMP)
+	{
+		int newJumps = Collision()->GetSwitchDelay(MapIndex);
+
+		if (newJumps != m_Core.m_Jumps)
+		{
+			char aBuf[256];
+			if(newJumps == 1)
+				str_format(aBuf, sizeof(aBuf), "You can jump %d time", newJumps);
+			else
+				str_format(aBuf, sizeof(aBuf), "You can jump %d times", newJumps);
+			//GameServer()->SendChatTarget(GetPlayer()->GetCID(),aBuf);
+
+			if (newJumps == 0 && !m_SuperJump)
+			{
+				m_NeededFaketuning |= FAKETUNE_NOJUMP;
+				//GameServer()->SendTuningParams(m_pPlayer->GetCID(), m_TuneZone); // update tunings
+			}
+			else if (m_Core.m_Jumps == 0)
+			{
+				m_NeededFaketuning &= ~FAKETUNE_NOJUMP;
+				//GameServer()->SendTuningParams(m_pPlayer->GetCID(), m_TuneZone); // update tunings
+			}
+
+			m_Core.m_Jumps = newJumps;
+		}
+	}
+
+	if(Collision()->IsSwitch(MapIndex) != TILE_PENALTY)
+	{
+		m_LastPenalty = false;
+	}
+
+	if(Collision()->IsSwitch(MapIndex) != TILE_BONUS)
+	{
+		m_LastBonus = false;
+	}
+}
+
+void CCharacter::DDRaceTick()
+{
+	if(!GameWorld()->m_PredictDDRace)
+		return;
+
+	m_Armor=(m_FreezeTime >= 0)?10-(m_FreezeTime/15):0;
+	if(m_Input.m_Direction != 0 || m_Input.m_Jump != 0)
+		m_LastMove = GameWorld()->GameTick();
+
+	if(m_FreezeTime > 0 || m_FreezeTime == -1)
+	{
+		if(m_FreezeTime > 0)
+			m_FreezeTime--;
+		else
+			m_Ninja.m_ActivationTick = GameWorld()->GameTick();
+		m_Input.m_Direction = 0;
+		m_Input.m_Jump = 0;
+		m_Input.m_Hook = 0;
+		if (m_FreezeTime == 1)
+			UnFreeze();
+	}
+
+	//HandleTuneLayer(); // need this before coretick
+}
+
+void CCharacter::DDRacePostCoreTick()
+{
+	if(!GameWorld()->m_PredictDDRace)
+		return;
+
+	m_Time = (float)(GameWorld()->GameTick() - m_StartTime) / ((float)GameWorld()->GameTickSpeed());
+
+	if (m_EndlessHook || (m_Super && g_Config.m_SvEndlessSuperHook))
+		m_Core.m_HookTick = 0;
+
+	if (m_DeepFreeze && !m_Super)
+		Freeze();
+
+	if (m_Core.m_Jumps == 0 && !m_Super)
+		m_Core.m_Jumped = 3;
+	else if (m_Core.m_Jumps == 1 && m_Core.m_Jumped > 0)
+		m_Core.m_Jumped = 3;
+	else if (m_Core.m_JumpedTotal < m_Core.m_Jumps - 1 && m_Core.m_Jumped > 1)
+		m_Core.m_Jumped = 1;
+
+	if ((m_Super || m_SuperJump) && m_Core.m_Jumped > 1)
+		m_Core.m_Jumped = 1;
+
+	int CurrentIndex = Collision()->GetMapIndex(m_Pos);
+	HandleSkippableTiles(CurrentIndex);
+
+	// handle Anti-Skip tiles
+	std::list < int > Indices = Collision()->GetMapIndices(m_PrevPos, m_Pos);
+	if(!Indices.empty())
+		for(std::list < int >::iterator i = Indices.begin(); i != Indices.end(); i++)
+		{
+			HandleTiles(*i);
+			//dbg_msg("Running","%d", *i);
+		}
+	else
+	{
+		HandleTiles(CurrentIndex);
+		//dbg_msg("Running","%d", CurrentIndex);
+	}
+}
+
+bool CCharacter::Freeze(int Seconds)
+{
+	if ((Seconds <= 0 || m_Super || m_FreezeTime == -1 || m_FreezeTime > Seconds * GameWorld()->GameTickSpeed()) && Seconds != -1)
+		 return false;
+	if (m_FreezeTick < GameWorld()->GameTick() - GameWorld()->GameTickSpeed() || Seconds == -1)
+	{
+		for(int i = 0; i < NUM_WEAPONS; i++)
+			if(m_aWeapons[i].m_Got)
+			 {
+				 m_aWeapons[i].m_Ammo = 0;
+			 }
+		m_Armor = 0;
+		m_FreezeTime = Seconds == -1 ? Seconds : Seconds * GameWorld()->GameTickSpeed();
+		m_FreezeTick = GameWorld()->GameTick();
+		return true;
+	}
+	return false;
+}
+
+bool CCharacter::Freeze()
+{
+	return Freeze(g_Config.m_SvFreezeDelay);
+}
+
+bool CCharacter::UnFreeze()
+{
+	if (m_FreezeTime > 0)
+	{
+		m_Armor=10;
+		for(int i=0;i<NUM_WEAPONS;i++)
+			if(m_aWeapons[i].m_Got)
+			 {
+				 m_aWeapons[i].m_Ammo = -1;
+			 }
+		if(!m_aWeapons[m_Core.m_ActiveWeapon].m_Got)
+			m_Core.m_ActiveWeapon = WEAPON_GUN;
+		m_FreezeTime = 0;
+		m_FreezeTick = 0;
+		if (m_Core.m_ActiveWeapon==WEAPON_HAMMER) m_ReloadTimer = 0;
+		return true;
+	}
+	return false;
+}
+
+void CCharacter::GiveAllWeapons()
+{
+	for(int i=WEAPON_GUN;i<NUM_WEAPONS-1;i++)
+	{
+		m_aWeapons[i].m_Got = true;
+		if(!m_FreezeTime) m_aWeapons[i].m_Ammo = -1;
+	}
+	return;
+}
+
+void CCharacter::DDRaceInit()
+{
+	m_Paused = false;
+	m_DDRaceState = DDRACE_NONE;
+	m_PrevPos = m_Pos;
+	m_SetSavePos = false;
+	m_LastBroadcast = 0;
+	m_TeamBeforeSuper = 0;
+
+	m_TeleCheckpoint = 0;
+	m_EndlessHook = g_Config.m_SvEndlessDrag;
+	m_Hit = g_Config.m_SvHit ? HIT_ALL : DISABLE_HIT_GRENADE|DISABLE_HIT_HAMMER|DISABLE_HIT_RIFLE|DISABLE_HIT_SHOTGUN;
+	m_SuperJump = false;
+	m_Jetpack = false;
+	m_Core.m_Jumps = 2;
+	m_FreezeHammer = false;
+}
+
+CTeamsCore* CCharacter::TeamsCore()
+{
+	return m_Core.m_pTeams;
+}
+
+CCharacter::CCharacter(CGameWorld *pGameWorld, int ID, CNetObj_Character *pChar)
+: CEntity(pGameWorld, CGameWorld::ENTTYPE_CHARACTER)
+{
+	m_ID = ID;
+	Spawn(ID, vec2(pChar->m_X, pChar->m_Y));
+	mem_zero(&m_Ninja, sizeof(m_Ninja));
+	mem_zero(&m_Input, sizeof(m_Input));
+	m_LatestInput = m_LatestPrevInput = m_PrevInput = m_Input;
+	m_ProximityRadius = ms_PhysSize;
+	m_Core.m_LeftWall = 1;
+	m_TeamMask = -1LL;
+	m_NumInputs = 3;
+	m_Super = 0;
+	m_FreezeTime = 0;
+	m_FreezeTick = 0;
+	m_DeepFreeze = 0;
+	m_PainSoundTimer = 0;
+	m_LastMove = 0;
+	m_StartTime = 0;
+	m_StrongWeakID = 0;
+	m_PrevPos = m_Pos;
+	m_Jetpack = 0;
+	GiveAllWeapons();
+	Read(pChar, false);
+}
+
+void CCharacter::Read(CNetObj_Character *pChar, bool IsLocal)
+{
+	vec2 PosBefore = m_Pos;
+
+	m_Core.Read((CNetObj_CharacterCore*) pChar);
+	m_EmoteType = pChar->m_Emote;
+	m_Health = pChar->m_Health;
+	m_Armor = pChar->m_Armor;
+	m_AttackTick = pChar->m_AttackTick;
+	m_Pos = m_Core.m_Pos;
+
+	if(distance(PosBefore, m_Pos) > 2.f)
+		m_PrevPos = m_Pos;
+
+	if(pChar->m_Weapon != WEAPON_NINJA)
+	{
+		if(m_Core.m_ActiveWeapon != pChar->m_Weapon)
+		{
+			SetNinjaActivationDir(vec2(0,0));
+			SetNinjaActivationTick(-500);
+			SetNinjaCurrentMoveTime(0);
+			m_aWeapons[m_Core.m_ActiveWeapon].m_Got = false;
+			SetActiveWeapon(pChar->m_Weapon);
+		}
+		m_aWeapons[pChar->m_Weapon].m_Got = true;
+		m_aWeapons[pChar->m_Weapon].m_Ammo = (GameWorld()->m_InfiniteAmmo || pChar->m_Weapon == WEAPON_HAMMER) ? -1 : pChar->m_AmmoCount;
+	}
+
+	if(m_FreezeTime && (pChar->m_Weapon != WEAPON_NINJA || pChar->m_AttackTick > m_FreezeTick || absolute(pChar->m_VelX) == 256*10))
+	{
+		m_DeepFreeze = false;
+		UnFreeze();
+	}
+
+	if(!m_FreezeTime)
+	{
+		m_Jetpack = Tuning()->m_JetpackStrength > 0;
+		m_JetpackStrength = Tuning()->m_JetpackStrength;
+	}
+
+	if(pChar->m_Jumped&2)
+	{
+		m_SuperJump = false;
+		if(m_Core.m_Jumps > m_Core.m_JumpedTotal && m_Core.m_JumpedTotal > 0)
+			m_Core.m_Jumps = m_Core.m_JumpedTotal + 1;
+	}
+
+	if(m_Core.m_HookTick != 0)
+		m_EndlessHook = false;
+
+	SetSolo(!Tuning()->m_PlayerCollision && !Tuning()->m_PlayerHooking);
+
+	if(!IsLocal)
+	{
+		mem_zero(&m_Input, sizeof(m_Input));
+		m_Input.m_Direction = m_Core.m_Direction;
+		m_Input.m_Hook = (m_Core.m_HookState == HOOK_GRABBED);
+	}
+}
+
+void CCharacter::SetGameWorld(CGameWorld *pGameWorld)
+{
+	m_Core.m_pWorld = &pGameWorld->m_Core;
+	m_Core.m_pCollision = pGameWorld->Collision();
+	m_Core.m_pTeams = pGameWorld->Teams();
+}

--- a/src/game/client/world/entities/character.h
+++ b/src/game/client/world/entities/character.h
@@ -1,0 +1,287 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#ifndef GAME_CLIENT_WORLD_ENTITIES_CHARACTER_H
+#define GAME_CLIENT_WORLD_ENTITIES_CHARACTER_H
+
+#include <game/client/world/entity.h>
+#include "projectile.h"
+
+#include <game/gamecore.h>
+#include <game/generated/client_data.h>
+
+enum
+{
+	WEAPON_GAME = -3, // team switching etc
+	WEAPON_SELF = -2, // console kill command
+	WEAPON_WORLD = -1, // death tiles etc
+};
+
+enum
+{
+	FAKETUNE_FREEZE = 1,
+	FAKETUNE_SOLO = 2,
+	FAKETUNE_NOJUMP = 4,
+	FAKETUNE_NOCOLL = 8,
+	FAKETUNE_NOHOOK = 16,
+	FAKETUNE_JETPACK = 32,
+};
+
+class CCharacter : public CEntity
+{
+	friend class CGameWorld;
+public:
+	//character's size
+	static const int ms_PhysSize = 28;
+
+	CCharacter(CGameWorld *pWorld);
+
+	virtual void Reset();
+	virtual void Destroy();
+	virtual void Tick();
+	virtual void TickDefered();
+	virtual void TickPaused();
+	//virtual void Snap(int SnappingClient);
+	//virtual int NetworkClipped(int SnappingClient);
+	//virtual int NetworkClipped(int SnappingClient, vec2 CheckPos);
+
+	bool IsGrounded();
+
+	void SetWeapon(int W);
+	void SetSolo(bool Solo);
+	void HandleWeaponSwitch();
+	void DoWeaponSwitch();
+
+	void HandleWeapons();
+	void HandleNinja();
+	void HandleJetpack();
+
+	void OnPredictedInput(CNetObj_PlayerInput *pNewInput);
+	void OnDirectInput(CNetObj_PlayerInput *pNewInput);
+	void ResetInput();
+	void FireWeapon();
+
+	void Die(int Killer, int Weapon);
+	bool TakeDamage(vec2 Force, int Dmg, int From, int Weapon);
+
+	bool Spawn(/*class CPlayer *pPlayer, */ int ID, vec2 Pos);
+	bool Remove();
+
+	bool IncreaseHealth(int Amount);
+	bool IncreaseArmor(int Amount);
+
+	bool GiveWeapon(int Weapon, int Ammo);
+	void GiveNinja();
+
+	void SetEmote(int Emote, int Tick);
+
+	void Rescue();
+
+	int NeededFaketuning() {return m_NeededFaketuning;}
+	bool IsAlive() const { return m_Alive; }
+	bool IsPaused() const { return m_Paused; }
+
+private:
+	bool m_Alive;
+	bool m_Paused;
+	int m_NeededFaketuning;
+
+	// weapon info
+	int m_aHitObjects[10];
+	int m_NumObjectsHit;
+
+	struct WeaponStat
+	{
+		int m_AmmoRegenStart;
+		int m_Ammo;
+		int m_Ammocost;
+		bool m_Got;
+	} m_aWeapons[NUM_WEAPONS];
+
+	int m_LastWeapon;
+	int m_QueuedWeapon;
+
+	int m_ReloadTimer;
+	int m_AttackTick;
+
+	int m_DamageTaken;
+
+	int m_EmoteType;
+	int m_EmoteStop;
+
+	// last tick that the player took any action ie some input
+	int m_LastAction;
+	int m_LastNoAmmoSound;
+
+	// these are non-heldback inputs
+	CNetObj_PlayerInput m_LatestPrevInput;
+	CNetObj_PlayerInput m_LatestInput;
+
+	// input
+	CNetObj_PlayerInput m_PrevInput;
+	CNetObj_PlayerInput m_Input;
+
+	int m_NumInputs;
+	int m_Jumped;
+
+	int m_DamageTakenTick;
+
+	int m_Health;
+	int m_Armor;
+
+	// ninja
+	struct NinjaStat
+	{
+		vec2 m_ActivationDir;
+		int m_ActivationTick;
+		int m_CurrentMoveTime;
+		int m_OldVelAmount;
+	} m_Ninja;
+
+	// the player core for the physics
+	CCharacterCore m_Core;
+
+	// info for dead reckoning
+	int m_ReckoningTick; // tick that we are performing dead reckoning From
+	CCharacterCore m_SendCore; // core that we should send
+	CCharacterCore m_ReckoningCore; // the dead reckoning core
+
+	// DDRace
+
+
+	void HandleTiles(int Index);
+	float m_Time;
+	int m_LastBroadcast;
+	void DDRaceInit();
+	void HandleSkippableTiles(int Index);
+	void DDRaceTick();
+	void DDRacePostCoreTick();
+	void HandleBroadcast();
+	void HandleTuneLayer();
+	//void SendZoneMsgs();
+
+	bool m_SetSavePos;
+	vec2 m_PrevSavePos;
+
+public:
+	CTeamsCore* TeamsCore();
+	void Pause(bool Pause);
+	bool Freeze(int Time);
+	bool Freeze();
+	bool UnFreeze();
+	void GiveAllWeapons();
+	int m_DDRaceState;
+	int Team();
+	bool CanCollide(int ClientID);
+	bool SameTeam(int ClientID);
+	bool m_Super;
+	bool m_SuperJump;
+	bool m_Jetpack;
+	int m_TeamBeforeSuper;
+	int m_FreezeTime;
+	int m_FreezeTick;
+	bool m_DeepFreeze;
+	bool m_EndlessHook;
+	bool m_FreezeHammer;
+	enum
+	{
+		HIT_ALL=0,
+		DISABLE_HIT_HAMMER=1,
+		DISABLE_HIT_SHOTGUN=2,
+		DISABLE_HIT_GRENADE=4,
+		DISABLE_HIT_RIFLE=8
+	};
+	int m_Hit;
+	int m_TuneZone;
+	int m_TuneZoneOld;
+	int m_PainSoundTimer;
+	int m_LastMove;
+	int m_StartTime;
+	vec2 m_PrevPos;
+	int m_TeleCheckpoint;
+	int m_CpTick;
+	int m_CpActive;
+	int m_CpLastBroadcast;
+	float m_CpCurrent[25];
+	int m_TileIndex;
+	int m_TileFlags;
+	int m_TileFIndex;
+	int m_TileFFlags;
+	int m_TileSIndex;
+	int m_TileSFlags;
+	int m_TileIndexL;
+	int m_TileFlagsL;
+	int m_TileFIndexL;
+	int m_TileFFlagsL;
+	int m_TileSIndexL;
+	int m_TileSFlagsL;
+	int m_TileIndexR;
+	int m_TileFlagsR;
+	int m_TileFIndexR;
+	int m_TileFFlagsR;
+	int m_TileSIndexR;
+	int m_TileSFlagsR;
+	int m_TileIndexT;
+	int m_TileFlagsT;
+	int m_TileFIndexT;
+	int m_TileFFlagsT;
+	int m_TileSIndexT;
+	int m_TileSFlagsT;
+	int m_TileIndexB;
+	int m_TileFlagsB;
+	int m_TileFIndexB;
+	int m_TileFFlagsB;
+	int m_TileSIndexB;
+	int m_TileSFlagsB;
+	vec2 m_Intersection;
+	int64 m_LastStartWarning;
+	int64 m_LastRescue;
+	bool m_LastRefillJumps;
+	bool m_LastPenalty;
+	bool m_LastBonus;
+
+	// Setters/Getters because i don't want to modify vanilla vars access modifiers
+	int GetLastWeapon() { return m_LastWeapon; };
+	void SetLastWeapon(int LastWeap) {m_LastWeapon = LastWeap; };
+	int GetActiveWeapon() { return m_Core.m_ActiveWeapon; };
+	void SetActiveWeapon(int ActiveWeap) {m_Core.m_ActiveWeapon = ActiveWeap; };
+	void SetLastAction(int LastAction) {m_LastAction = LastAction; };
+	int GetArmor() { return m_Armor; };
+	void SetArmor(int Armor) {m_Armor = Armor; };
+	CCharacterCore GetCore() { return m_Core; };
+	void SetCore(CCharacterCore Core) {m_Core = Core; };
+	CCharacterCore* Core() { return &m_Core; };
+	bool GetWeaponGot(int Type) { return m_aWeapons[Type].m_Got; };
+	void SetWeaponGot(int Type, bool Value) { m_aWeapons[Type].m_Got = Value; };
+	int GetWeaponAmmo(int Type) { return m_aWeapons[Type].m_Ammo; };
+	void SetWeaponAmmo(int Type, int Value) { m_aWeapons[Type].m_Ammo = Value; };
+	bool IsAlive() { return m_Alive; };
+	void SetEmoteType(int EmoteType) { m_EmoteType = EmoteType; };
+	void SetEmoteStop(int EmoteStop) { m_EmoteStop = EmoteStop; };
+	void SetNinjaActivationDir(vec2 ActivationDir) { m_Ninja.m_ActivationDir = ActivationDir; };
+	void SetNinjaActivationTick(int ActivationTick) { m_Ninja.m_ActivationTick = ActivationTick; };
+	void SetNinjaCurrentMoveTime(int CurrentMoveTime) { m_Ninja.m_CurrentMoveTime = CurrentMoveTime; };
+	int GetCID() { return m_ID; }
+	void SetInput(CNetObj_PlayerInput *pNewInput) { m_LatestInput = m_Input = *pNewInput; };
+	int GetJumped() { return m_Core.m_Jumped; }
+
+	int m_IsSolo;
+	int m_StrongWeakID;
+	int64_t m_TeamMask;
+	float m_JetpackStrength;
+
+	int64_t TeamMask() { return m_TeamMask; }
+
+	CCharacter(CGameWorld *pGameWorld, int ID, CNetObj_Character *pChar);
+	void Read(CNetObj_Character *pChar, bool IsLocal);
+	void SetGameWorld(CGameWorld *pGameWorld);
+};
+
+enum
+{
+	DDRACE_NONE = 0,
+	DDRACE_STARTED,
+	DDRACE_CHEAT, // no time and won't start again unless ordered by a mod or death
+	DDRACE_FINISHED
+};
+
+#endif

--- a/src/game/client/world/entities/laser.cpp
+++ b/src/game/client/world/entities/laser.cpp
@@ -1,0 +1,191 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#include <game/generated/protocol.h>
+#include "character.h"
+#include "laser.h"
+
+#include <engine/shared/config.h>
+
+CLaser::CLaser(CGameWorld *pGameWorld, vec2 Pos, vec2 Direction, float StartEnergy, int Owner, int Type)
+: CEntity(pGameWorld, CGameWorld::ENTTYPE_LASER)
+{
+	m_Pos = Pos;
+	m_Owner = Owner;
+	m_Energy = StartEnergy;
+	m_Dir = Direction;
+	m_Bounces = 0;
+	m_EvalTick = 0;
+	m_TelePos = vec2(0,0);
+	m_WasTele = false;
+	m_Type = Type;
+	m_TeamMask = -1;
+	GameWorld()->InsertEntity(this);
+	DoBounce();
+}
+
+
+bool CLaser::HitCharacter(vec2 From, vec2 To)
+{
+	vec2 At;
+	CCharacter *pOwnerChar = GameWorld()->GetCharacterByID(m_Owner);
+	CCharacter *pHit;
+	bool pDontHitSelf = g_Config.m_SvOldLaser || (m_Bounces == 0 && !m_WasTele);
+
+	if(pOwnerChar ? (!(pOwnerChar->m_Hit&CCharacter::DISABLE_HIT_RIFLE) && m_Type == WEAPON_RIFLE) || (!(pOwnerChar->m_Hit&CCharacter::DISABLE_HIT_SHOTGUN) && m_Type == WEAPON_SHOTGUN) : g_Config.m_SvHit)
+		pHit = GameWorld()->IntersectCharacter(m_Pos, To, 0.f, At, pDontHitSelf ? pOwnerChar : 0, m_Owner);
+	else
+		pHit = GameWorld()->IntersectCharacter(m_Pos, To, 0.f, At, pDontHitSelf ? pOwnerChar : 0, m_Owner, pOwnerChar);
+
+	if(!pHit || (pHit == pOwnerChar && g_Config.m_SvOldLaser) || (pHit != pOwnerChar && pOwnerChar ? (pOwnerChar->m_Hit&CCharacter::DISABLE_HIT_RIFLE  && m_Type == WEAPON_RIFLE) || (pOwnerChar->m_Hit&CCharacter::DISABLE_HIT_SHOTGUN && m_Type == WEAPON_SHOTGUN) : !g_Config.m_SvHit))
+		return false;
+	m_From = From;
+	m_Pos = At;
+	m_Energy = -1;
+	if (m_Type == WEAPON_SHOTGUN)
+	{
+		vec2 Temp;
+
+		float Strength = GameWorld()->Tuning()->m_ShotgunStrength;;
+
+		if(!g_Config.m_SvOldLaser)
+			Temp = pHit->Core()->m_Vel + normalize(m_PrevPos - pHit->Core()->m_Pos) * Strength;
+		else
+			Temp = pHit->Core()->m_Vel + normalize(pOwnerChar->Core()->m_Pos - pHit->Core()->m_Pos) * Strength;
+		if(Temp.x > 0 && ((pHit->m_TileIndex == TILE_STOP && pHit->m_TileFlags == ROTATION_270) || (pHit->m_TileIndexL == TILE_STOP && pHit->m_TileFlagsL == ROTATION_270) || (pHit->m_TileIndexL == TILE_STOPS && (pHit->m_TileFlagsL == ROTATION_90 || pHit->m_TileFlagsL ==ROTATION_270)) || (pHit->m_TileIndexL == TILE_STOPA) || (pHit->m_TileFIndex == TILE_STOP && pHit->m_TileFFlags == ROTATION_270) || (pHit->m_TileFIndexL == TILE_STOP && pHit->m_TileFFlagsL == ROTATION_270) || (pHit->m_TileFIndexL == TILE_STOPS && (pHit->m_TileFFlagsL == ROTATION_90 || pHit->m_TileFFlagsL == ROTATION_270)) || (pHit->m_TileFIndexL == TILE_STOPA) || (pHit->m_TileSIndex == TILE_STOP && pHit->m_TileSFlags == ROTATION_270) || (pHit->m_TileSIndexL == TILE_STOP && pHit->m_TileSFlagsL == ROTATION_270) || (pHit->m_TileSIndexL == TILE_STOPS && (pHit->m_TileSFlagsL == ROTATION_90 || pHit->m_TileSFlagsL == ROTATION_270)) || (pHit->m_TileSIndexL == TILE_STOPA)))
+			Temp.x = 0;
+		if(Temp.x < 0 && ((pHit->m_TileIndex == TILE_STOP && pHit->m_TileFlags == ROTATION_90) || (pHit->m_TileIndexR == TILE_STOP && pHit->m_TileFlagsR == ROTATION_90) || (pHit->m_TileIndexR == TILE_STOPS && (pHit->m_TileFlagsR == ROTATION_90 || pHit->m_TileFlagsR == ROTATION_270)) || (pHit->m_TileIndexR == TILE_STOPA) || (pHit->m_TileFIndex == TILE_STOP && pHit->m_TileFFlags == ROTATION_90) || (pHit->m_TileFIndexR == TILE_STOP && pHit->m_TileFFlagsR == ROTATION_90) || (pHit->m_TileFIndexR == TILE_STOPS && (pHit->m_TileFFlagsR == ROTATION_90 || pHit->m_TileFFlagsR == ROTATION_270)) || (pHit->m_TileFIndexR == TILE_STOPA) || (pHit->m_TileSIndex == TILE_STOP && pHit->m_TileSFlags == ROTATION_90) || (pHit->m_TileSIndexR == TILE_STOP && pHit->m_TileSFlagsR == ROTATION_90) || (pHit->m_TileSIndexR == TILE_STOPS && (pHit->m_TileSFlagsR == ROTATION_90 || pHit->m_TileSFlagsR == ROTATION_270)) || (pHit->m_TileSIndexR == TILE_STOPA)))
+			Temp.x = 0;
+		if(Temp.y < 0 && ((pHit->m_TileIndex == TILE_STOP && pHit->m_TileFlags == ROTATION_180) || (pHit->m_TileIndexB == TILE_STOP && pHit->m_TileFlagsB == ROTATION_180) || (pHit->m_TileIndexB == TILE_STOPS && (pHit->m_TileFlagsB == ROTATION_0 || pHit->m_TileFlagsB == ROTATION_180)) || (pHit->m_TileIndexB == TILE_STOPA) || (pHit->m_TileFIndex == TILE_STOP && pHit->m_TileFFlags == ROTATION_180) || (pHit->m_TileFIndexB == TILE_STOP && pHit->m_TileFFlagsB == ROTATION_180) || (pHit->m_TileFIndexB == TILE_STOPS && (pHit->m_TileFFlagsB == ROTATION_0 || pHit->m_TileFFlagsB == ROTATION_180)) || (pHit->m_TileFIndexB == TILE_STOPA) || (pHit->m_TileSIndex == TILE_STOP && pHit->m_TileSFlags == ROTATION_180) || (pHit->m_TileSIndexB == TILE_STOP && pHit->m_TileSFlagsB == ROTATION_180) || (pHit->m_TileSIndexB == TILE_STOPS && (pHit->m_TileSFlagsB == ROTATION_0 || pHit->m_TileSFlagsB == ROTATION_180)) || (pHit->m_TileSIndexB == TILE_STOPA)))
+			Temp.y = 0;
+		if(Temp.y > 0 && ((pHit->m_TileIndex == TILE_STOP && pHit->m_TileFlags == ROTATION_0) || (pHit->m_TileIndexT == TILE_STOP && pHit->m_TileFlagsT == ROTATION_0) || (pHit->m_TileIndexT == TILE_STOPS && (pHit->m_TileFlagsT == ROTATION_0 || pHit->m_TileFlagsT == ROTATION_180)) || (pHit->m_TileIndexT == TILE_STOPA) || (pHit->m_TileFIndex == TILE_STOP && pHit->m_TileFFlags == ROTATION_0) || (pHit->m_TileFIndexT == TILE_STOP && pHit->m_TileFFlagsT == ROTATION_0) || (pHit->m_TileFIndexT == TILE_STOPS && (pHit->m_TileFFlagsT == ROTATION_0 || pHit->m_TileFFlagsT == ROTATION_180)) || (pHit->m_TileFIndexT == TILE_STOPA) || (pHit->m_TileSIndex == TILE_STOP && pHit->m_TileSFlags == ROTATION_0) || (pHit->m_TileSIndexT == TILE_STOP && pHit->m_TileSFlagsT == ROTATION_0) || (pHit->m_TileSIndexT == TILE_STOPS && (pHit->m_TileSFlagsT == ROTATION_0 || pHit->m_TileSFlagsT == ROTATION_180)) || (pHit->m_TileSIndexT == TILE_STOPA)))
+			Temp.y = 0;
+		pHit->Core()->m_Vel = Temp;
+	}
+	else if (m_Type == WEAPON_RIFLE)
+	{
+		pHit->UnFreeze();
+	}
+	return true;
+}
+
+void CLaser::DoBounce()
+{
+	m_EvalTick = GameWorld()->GameTick();
+
+	if(m_Energy < 0)
+	{
+		GameWorld()->DestroyEntity(this);
+		return;
+	}
+	m_PrevPos = m_Pos;
+	vec2 Coltile;
+
+	int Res;
+	int z;
+
+	if (m_WasTele)
+	{
+		m_PrevPos = m_TelePos;
+		m_Pos = m_TelePos;
+		m_TelePos = vec2(0,0);
+	}
+
+	vec2 To = m_Pos + m_Dir * m_Energy;
+
+	Res = Collision()->IntersectLineTeleWeapon(m_Pos, To, &Coltile, &To, &z);
+
+	if(Res)
+	{
+		if(!HitCharacter(m_Pos, To))
+		{
+			// intersected
+			m_From = m_Pos;
+			m_Pos = To;
+
+			vec2 TempPos = m_Pos;
+			vec2 TempDir = m_Dir * 4.0f;
+
+			int f = 0;
+			if(Res == -1)
+			{
+				f = Collision()->GetTile(round_to_int(Coltile.x), round_to_int(Coltile.y));
+				Collision()->SetCollisionAt(round_to_int(Coltile.x), round_to_int(Coltile.y), TILE_SOLID);
+			}
+			Collision()->MovePoint(&TempPos, &TempDir, 1.0f, 0);
+			if(Res == -1)
+			{
+				Collision()->SetCollisionAt(round_to_int(Coltile.x), round_to_int(Coltile.y), f);
+			}
+			m_Pos = TempPos;
+			m_Dir = normalize(TempDir);
+
+			m_Energy -= distance(m_From, m_Pos) + GameWorld()->Tuning()->m_LaserBounceCost;
+
+			//if (Res&CCollision::COLFLAG_TELE && ((CGameControllerDDRace*)GameServer()->m_pController)->m_TeleOuts[z-1].size())
+			//{
+				//int Num = ((CGameControllerDDRace*)GameServer()->m_pController)->m_TeleOuts[z-1].size();
+				//m_TelePos = ((CGameControllerDDRace*)GameServer()->m_pController)->m_TeleOuts[z-1][(!Num)?Num:rand() % Num];
+				//m_WasTele = true;
+			//}
+			//else
+			{
+				m_Bounces++;
+				m_WasTele = false;
+			}
+
+			int BounceNum = GameWorld()->Tuning()->m_LaserBounceNum;
+
+			if(m_Bounces > BounceNum)
+				m_Energy = -1;
+		}
+	}
+	else
+	{
+		if(!HitCharacter(m_Pos, To))
+		{
+			m_From = m_Pos;
+			m_Pos = To;
+			m_Energy = -1;
+		}
+	}
+	//m_Owner = -1;
+}
+
+void CLaser::Reset()
+{
+	GameWorld()->DestroyEntity(this);
+}
+
+void CLaser::Tick()
+{
+	float Delay = GameWorld()->Tuning()->m_LaserBounceDelay;
+
+	if(GameWorld()->GameTick() > m_EvalTick+(GameWorld()->GameTickSpeed()*Delay/1000.0f))
+		DoBounce();
+}
+
+void CLaser::TickPaused()
+{
+	++m_EvalTick;
+}
+
+CLaser::CLaser(CGameWorld *pGameWorld, int ID, CNetObj_Laser *pLaser)
+: CEntity(pGameWorld, CGameWorld::ENTTYPE_LASER)
+{
+	m_Pos.x = pLaser->m_X;
+	m_Pos.y = pLaser->m_Y;
+	m_From.x = pLaser->m_FromX;
+	m_From.y = pLaser->m_FromY;
+	m_EvalTick = pLaser->m_StartTick;
+	m_Owner = -2;
+	m_Energy = pGameWorld->Tuning()->m_LaserReach;
+
+	m_Dir = m_Pos - m_From;
+	if(length(m_Pos - m_From) > 0.001)
+		m_Dir = normalize(m_Dir);
+	else
+		m_Energy = 0;
+	m_Type = WEAPON_RIFLE;
+	m_PrevPos = m_From;
+	m_ID = ID;
+}

--- a/src/game/client/world/entities/laser.h
+++ b/src/game/client/world/entities/laser.h
@@ -1,0 +1,47 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#ifndef GAME_CLIENT_WORLD_ENTITIES_LASER_H
+#define GAME_CLIENT_WORLD_ENTITIES_LASER_H
+
+#include <game/client/world/entity.h>
+
+class CLaser : public CEntity
+{
+	friend class CGameWorld;
+public:
+	CLaser(CGameWorld *pGameWorld, vec2 Pos, vec2 Direction, float StartEnergy, int Owner, int Type);
+
+	virtual void Reset();
+	virtual void Tick();
+	virtual void TickPaused();
+	//virtual void Snap(int SnappingClient);
+
+protected:
+	bool HitCharacter(vec2 From, vec2 To);
+	void DoBounce();
+
+private:
+	vec2 m_From;
+	vec2 m_Dir;
+	vec2 m_TelePos;
+	bool m_WasTele;
+	float m_Energy;
+	int m_Bounces;
+	int m_EvalTick;
+	int m_Owner;
+	int m_TeamMask;
+
+	// DDRace
+
+	vec2 m_PrevPos;
+	int m_Type;
+	int m_TuneZone;
+
+public:
+	const vec2 &GetFrom() { return m_From; }
+	const int &GetOwner() { return m_Owner; }
+	const int &GetEvalTick() { return m_EvalTick; }
+	CLaser(CGameWorld *pGameWorld, int ID, CNetObj_Laser *pLaser);
+};
+
+#endif

--- a/src/game/client/world/entities/pickup.cpp
+++ b/src/game/client/world/entities/pickup.cpp
@@ -1,0 +1,132 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#include <game/generated/protocol.h>
+#include "character.h"
+#include "pickup.h"
+
+CPickup::CPickup(CGameWorld *pGameWorld, int Type, int SubType, int Layer, int Number)
+: CEntity(pGameWorld, CGameWorld::ENTTYPE_PICKUP)
+{
+	m_Type = Type;
+	m_Subtype = SubType;
+	m_ProximityRadius = PickupPhysSize;
+
+	m_Layer = Layer;
+	m_Number = Number;
+
+	Reset();
+
+	GameWorld()->InsertEntity(this);
+}
+
+void CPickup::Reset()
+{
+}
+
+void CPickup::Tick()
+{
+	Move();
+	// Check if a player intersected us
+	CCharacter *apEnts[MAX_CLIENTS];
+	int Num = GameWorld()->FindEntities(m_Pos, 20.0f, (CEntity**)apEnts, MAX_CLIENTS, CGameWorld::ENTTYPE_CHARACTER);
+	for(int i = 0; i < Num; ++i) {
+		CCharacter * pChr = apEnts[i];
+		if(pChr && pChr->IsAlive())
+		{
+			if(m_Layer == LAYER_SWITCH && !Collision()->m_pSwitchers[m_Number].m_Status[pChr->Team()]) continue;
+			bool sound = false;
+			// player picked us up, is someone was hooking us, let them go
+			switch (m_Type)
+			{
+				case POWERUP_HEALTH:
+					//if(pChr->Freeze()) GameServer()->CreateSound(m_Pos, SOUND_PICKUP_HEALTH, pChr->Teams()->TeamMask(pChr->Team()));
+					break;
+
+				case POWERUP_ARMOR:
+					if(pChr->Team() == TEAM_SUPER) continue;
+					for(int i = WEAPON_SHOTGUN; i < NUM_WEAPONS; i++)
+					{
+						if(pChr->GetWeaponGot(i))
+						{
+							if(!(pChr->m_FreezeTime && i == WEAPON_NINJA))
+							{
+								pChr->SetWeaponGot(i, false);
+								pChr->SetWeaponAmmo(i, 0);
+								sound = true;
+							}
+						}
+					}
+					pChr->SetNinjaActivationDir(vec2(0,0));
+					pChr->SetNinjaActivationTick(-500);
+					pChr->SetNinjaCurrentMoveTime(0);
+					if (sound)
+					{
+						pChr->SetLastWeapon(WEAPON_GUN);
+						//GameServer()->CreateSound(m_Pos, SOUND_PICKUP_ARMOR, pChr->Teams()->TeamMask(pChr->Team()));
+					}
+					if(!pChr->m_FreezeTime && pChr->GetActiveWeapon() >= WEAPON_SHOTGUN)
+						pChr->SetActiveWeapon(WEAPON_HAMMER);
+					break;
+
+				case POWERUP_WEAPON:
+
+					if(m_Subtype >= 0 && m_Subtype < NUM_WEAPONS && (!pChr->GetWeaponGot(m_Subtype) || (pChr->GetWeaponAmmo(m_Subtype) != -1 && !pChr->m_FreezeTime)))
+					{
+						if(pChr->GiveWeapon(m_Subtype, -1))
+						{
+							//RespawnTime = g_pData->m_aPickups[m_Type].m_Respawntime;
+
+							//if(m_Subtype == WEAPON_GRENADE)
+								//GameServer()->CreateSound(m_Pos, SOUND_PICKUP_GRENADE, pChr->Teams()->TeamMask(pChr->Team()));
+							//else if(m_Subtype == WEAPON_SHOTGUN)
+								//GameServer()->CreateSound(m_Pos, SOUND_PICKUP_SHOTGUN, pChr->Teams()->TeamMask(pChr->Team()));
+							//else if(m_Subtype == WEAPON_RIFLE)
+								//GameServer()->CreateSound(m_Pos, SOUND_PICKUP_SHOTGUN, pChr->Teams()->TeamMask(pChr->Team()));
+
+							//if(pChr->GetPlayer())
+								//GameServer()->SendWeaponPickup(pChr->GetPlayer()->GetCID(), m_Subtype);
+						}
+					}
+					break;
+
+			case POWERUP_NINJA:
+				{
+					// activate ninja on target player
+					pChr->GiveNinja();
+					//RespawnTime = g_pData->m_aPickups[m_Type].m_Respawntime;
+					break;
+				}
+				default:
+					break;
+			};
+		}
+	}
+}
+
+void CPickup::TickPaused()
+{
+}
+
+void CPickup::Move()
+{
+	if (GameWorld()->GameTick()%int(GameWorld()->GameTickSpeed() * 0.15f) == 0)
+	{
+		int Flags;
+		int index = Collision()->IsMover(m_Pos.x,m_Pos.y, &Flags);
+		if (index)
+		{
+			m_Core=Collision()->CpSpeed(index, Flags);
+		}
+		m_Pos += m_Core;
+	}
+}
+
+CPickup::CPickup(CGameWorld *pGameWorld, int ID, CNetObj_Pickup *pPickup)
+: CEntity(pGameWorld, CGameWorld::ENTTYPE_PICKUP)
+{
+	m_Pos.x = pPickup->m_X;
+	m_Pos.y = pPickup->m_Y;
+	m_Type = pPickup->m_Type;
+	m_Subtype = pPickup->m_Subtype;
+	m_Core = vec2(0.f, 0.f);
+}

--- a/src/game/client/world/entities/pickup.h
+++ b/src/game/client/world/entities/pickup.h
@@ -1,0 +1,36 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#ifndef GAME_CLIENT_WORLD_ENTITIES_PICKUP_H
+#define GAME_CLIENT_WORLD_ENTITIES_PICKUP_H
+
+#include <game/client/world/entity.h>
+
+const int PickupPhysSize = 14;
+
+class CPickup : public CEntity
+{
+public:
+	CPickup(CGameWorld *pGameWorld, int Type, int SubType = 0, int Layer = 0, int Number = 0);
+
+	virtual void Reset();
+	virtual void Tick();
+	virtual void TickPaused();
+	//virtual void Snap(int SnappingClient);
+
+private:
+
+	int m_Type;
+	int m_Subtype;
+	//int m_SpawnTick;
+
+	// DDRace
+
+	void Move();
+	vec2 m_Core;
+
+public:
+
+	CPickup(CGameWorld *pGameWorld, int ID, CNetObj_Pickup *pPickup);
+};
+
+#endif

--- a/src/game/client/world/entities/projectile.cpp
+++ b/src/game/client/world/entities/projectile.cpp
@@ -1,0 +1,210 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#include <game/generated/protocol.h>
+#include "projectile.h"
+
+#include <engine/shared/config.h>
+
+CProjectile::CProjectile
+	(
+		CGameWorld *pGameWorld,
+		int Type,
+		int Owner,
+		vec2 Pos,
+		vec2 Dir,
+		int Span,
+		bool Freeze,
+		bool Explosive,
+		float Force,
+		int SoundImpact,
+		int Weapon,
+		int Layer,
+		int Number
+	)
+: CEntity(pGameWorld, CGameWorld::ENTTYPE_PROJECTILE)
+{
+	m_Type = Type;
+	m_Pos = Pos;
+	m_Direction = Dir;
+	m_LifeSpan = Span;
+	m_Owner = Owner;
+	m_Force = Force;
+	//m_Damage = Damage;
+	m_SoundImpact = SoundImpact;
+	m_Weapon = Weapon;
+	m_StartTick = GameWorld()->GameTick();
+	m_Explosive = Explosive;
+
+	m_Layer = Layer;
+	m_Number = Number;
+	m_Freeze = Freeze;
+
+	//m_TuneZone = Collision()->IsTune(Collision()->GetMapIndex(m_Pos));
+
+	GameWorld()->InsertEntity(this);
+}
+
+void CProjectile::Reset()
+{
+	if(m_LifeSpan > -2)
+		GameWorld()->DestroyEntity(this);
+}
+
+vec2 CProjectile::GetPos(float Time)
+{
+	float Curvature = 0;
+	float Speed = 0;
+
+	switch(m_Type)
+	{
+		case WEAPON_GRENADE:
+			Curvature = Tuning()->m_GrenadeCurvature;
+			Speed = Tuning()->m_GrenadeSpeed;
+			break;
+
+		case WEAPON_SHOTGUN:
+			Curvature = Tuning()->m_ShotgunCurvature;
+			Speed = Tuning()->m_ShotgunSpeed;
+			break;
+
+		case WEAPON_GUN:
+			Curvature = Tuning()->m_GunCurvature;
+			Speed = Tuning()->m_GunSpeed;
+			break;
+	}
+
+	return CalcPos(m_Pos, m_Direction, Curvature, Speed, Time);
+}
+
+
+void CProjectile::Tick()
+{
+	float Pt = (GameWorld()->GameTick()-m_StartTick-1)/(float)GameWorld()->GameTickSpeed();
+	float Ct = (GameWorld()->GameTick()-m_StartTick)/(float)GameWorld()->GameTickSpeed();
+	vec2 PrevPos = GetPos(Pt);
+	vec2 CurPos = GetPos(Ct);
+	vec2 ColPos;
+	vec2 NewPos;
+	int Collide = Collision()->IntersectLine(PrevPos, CurPos, &ColPos, &NewPos);
+	CCharacter *pOwnerChar = GameWorld()->GetCharacterByID(m_Owner);
+
+	CCharacter *pTargetChr = GameWorld()->IntersectCharacter(PrevPos, ColPos, m_Freeze ? 1.0f : 6.0f, ColPos, pOwnerChar, m_Owner);
+
+	if(m_LifeSpan > -1)
+		m_LifeSpan--;
+
+	int64_t TeamMask = -1LL;
+	bool isWeaponCollide = false;
+	if
+	(
+			pOwnerChar &&
+			pTargetChr &&
+			pOwnerChar->IsAlive() &&
+			pTargetChr->IsAlive() &&
+			!pTargetChr->CanCollide(m_Owner)
+			)
+	{
+			isWeaponCollide = true;
+			//TeamMask = OwnerChar->Teams()->TeamMask( OwnerChar->Team());
+	}
+	if (pOwnerChar && pOwnerChar->IsAlive())
+	{
+		//TeamMask = pOwnerChar->Teams()->TeamMask(pOwnerChar->Team(), -1, m_Owner);
+	}
+	else if (m_Owner >= 0)
+	{
+		GameWorld()->DestroyEntity(this);
+	}
+
+	if( ((pTargetChr && (pOwnerChar ? !(pOwnerChar->m_Hit&CCharacter::DISABLE_HIT_GRENADE) : g_Config.m_SvHit || m_Owner == -1 || pTargetChr == pOwnerChar)) || Collide || GameLayerClipped(CurPos)) && !isWeaponCollide)
+	{
+		if(m_Explosive/*??*/ && (!pTargetChr || (pTargetChr && (!m_Freeze || (m_Weapon == WEAPON_SHOTGUN && Collide)))))
+		{
+			GameWorld()->CreateExplosion(ColPos, m_Owner, m_Weapon, m_Owner == -1, (!pTargetChr ? -1 : pTargetChr->Team()),
+			(m_Owner != -1)? TeamMask : -1LL);
+		}
+		else if(pTargetChr && m_Freeze && ((m_Layer == LAYER_SWITCH && Collision()->m_pSwitchers[m_Number].m_Status[pTargetChr->Team()]) || m_Layer != LAYER_SWITCH))
+			pTargetChr->Freeze();
+		if(Collide && m_Bouncing != 0)
+		{
+			m_StartTick = GameWorld()->GameTick();
+			m_Pos = NewPos+(-(m_Direction*4));
+			if (m_Bouncing == 1)
+				m_Direction.x = -m_Direction.x;
+			else if(m_Bouncing == 2)
+				m_Direction.y = -m_Direction.y;
+			if (fabs(m_Direction.x) < 1e-6)
+				m_Direction.x = 0;
+			if (fabs(m_Direction.y) < 1e-6)
+				m_Direction.y = 0;
+			m_Pos += m_Direction;
+		}
+		else if (m_Weapon == WEAPON_GUN)
+		{
+			GameWorld()->DestroyEntity(this);
+		}
+		else
+			if (!m_Freeze)
+				GameWorld()->DestroyEntity(this);
+	}
+	if(m_LifeSpan == -1)
+	{
+		if(m_Explosive)
+		{
+			if(m_Owner >= 0)
+				pOwnerChar = GameWorld()->GetCharacterByID(m_Owner);
+
+			int64_t TeamMask = -1LL;
+			if (pOwnerChar && pOwnerChar->IsAlive())
+			{
+					TeamMask = pOwnerChar->TeamMask();
+			}
+
+			GameWorld()->CreateExplosion(ColPos, m_Owner, m_Weapon, m_Owner == -1, (!pOwnerChar ? -1 : pOwnerChar->Team()),
+			(m_Owner != -1)? TeamMask : -1LL);
+		}
+		GameWorld()->DestroyEntity(this);
+	}
+}
+
+void CProjectile::TickPaused()
+{
+	++m_StartTick;
+}
+
+// DDRace
+
+void CProjectile::SetBouncing(int Value)
+{
+	m_Bouncing = Value;
+}
+
+CProjectile::CProjectile(CGameWorld *pGameWorld, int ID, CNetObj_Projectile *pProj)
+: CEntity(pGameWorld, CGameWorld::ENTTYPE_PROJECTILE)
+{
+	ExtractInfo(pProj, &m_Pos, &m_Direction, pGameWorld->m_IsDDRace);
+	if(UseExtraInfo(pProj) && pGameWorld->m_IsDDRace)
+		ExtractExtraInfo(pProj, &m_Owner, &m_Explosive, &m_Bouncing, &m_Freeze);
+	else
+	{
+		m_Owner = -1;
+		m_Bouncing = m_Freeze = 0;
+		m_Explosive = (pProj->m_Type == WEAPON_GRENADE) && (abs(1.0f - length(m_Direction)) < 0.015f);
+	}
+	m_Type = m_Weapon = pProj->m_Type;
+	m_StartTick = pProj->m_StartTick;
+
+	int Lifetime = 20 * GameWorld()->GameTickSpeed();
+	m_SoundImpact = -1;
+	if(m_Weapon == WEAPON_GRENADE)
+	{
+		Lifetime = pGameWorld->Tuning()->m_GrenadeLifetime * GameWorld()->GameTickSpeed();
+		m_SoundImpact = SOUND_GRENADE_EXPLODE;
+	}
+	else if(m_Weapon == WEAPON_GUN)
+		Lifetime = pGameWorld->Tuning()->m_GunLifetime * GameWorld()->GameTickSpeed();
+	else if(m_Weapon == WEAPON_SHOTGUN && !GameWorld()->m_IsDDRace)
+		Lifetime = pGameWorld->Tuning()->m_ShotgunLifetime * GameWorld()->GameTickSpeed();
+	m_LifeSpan = Lifetime - (pGameWorld->GameTick() - m_StartTick);
+	m_ID = ID;
+}

--- a/src/game/client/world/entities/projectile.h
+++ b/src/game/client/world/entities/projectile.h
@@ -1,0 +1,67 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#ifndef GAME_CLIENT_WORLD_ENTITIES_PROJECTILE_H
+#define GAME_CLIENT_WORLD_ENTITIES_PROJECTILE_H
+
+#include <game/client/world/entity.h>
+#include "character.h"
+
+class CProjectile : public CEntity
+{
+	friend class CGameWorld;
+public:
+	CProjectile
+	(
+		CGameWorld *pGameWorld,
+		int Type,
+		int Owner,
+		vec2 Pos,
+		vec2 Dir,
+		int Span,
+		bool Freeeze,
+		bool Explosive,
+		float Force,
+		int SoundImpact,
+		int Weapon,
+		int Layer = 0,
+		int Number = 0
+	);
+
+	vec2 GetPos(float Time);
+	void FillInfo(CNetObj_Projectile *pProj);
+
+	virtual void Reset();
+	virtual void Tick();
+	virtual void TickPaused();
+	//virtual void Snap(int SnappingClient);
+
+private:
+	vec2 m_Direction;
+	int m_LifeSpan;
+	int m_Owner;
+	int m_Type;
+	//int m_Damage;
+	int m_SoundImpact;
+	int m_Weapon;
+	float m_Force;
+	int m_StartTick;
+	bool m_Explosive;
+
+	// DDRace
+
+	int m_Bouncing;
+	bool m_Freeze;
+	int m_TuneZone;
+
+public:
+
+	void SetBouncing(int Value);
+	void FillExtraInfo(CNetObj_Projectile *pProj);
+
+	const vec2 &GetDirection() { return m_Direction; }
+	const int &GetOwner() { return m_Owner; }
+	const int &GetStartTick() { return m_StartTick; }
+	CProjectile(CGameWorld *pGameWorld, int ID, CNetObj_Projectile *pProj);
+};
+
+#endif

--- a/src/game/client/world/entity.cpp
+++ b/src/game/client/world/entity.cpp
@@ -1,0 +1,33 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
+
+#include "entity.h"
+
+//////////////////////////////////////////////////
+// Entity
+//////////////////////////////////////////////////
+CEntity::CEntity(CGameWorld *pGameWorld, int ObjType)
+{
+	m_pGameWorld = pGameWorld;
+
+	m_ObjType = ObjType;
+	m_Pos = vec2(0,0);
+	m_ProximityRadius = 0;
+
+	m_MarkedForDestroy = false;
+	m_ID = -1;
+
+	m_pPrevTypeEntity = 0;
+	m_pNextTypeEntity = 0;
+}
+
+CEntity::~CEntity()
+{
+	GameWorld()->RemoveEntity(this);
+}
+
+bool CEntity::GameLayerClipped(vec2 CheckPos)
+{
+	return round_to_int(CheckPos.x)/32 < -200 || round_to_int(CheckPos.x)/32 > Collision()->GetWidth()+200 ||
+			round_to_int(CheckPos.y)/32 < -200 || round_to_int(CheckPos.y)/32 > Collision()->GetHeight()+200 ? true : false;
+}

--- a/src/game/client/world/entity.h
+++ b/src/game/client/world/entity.h
@@ -1,0 +1,58 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#ifndef GAME_CLIENT_WORLD_ENTITY_H
+#define GAME_CLIENT_WORLD_ENTITY_H
+
+#include <new>
+#include <base/vmath.h>
+#include "gameworld.h"
+
+#define MACRO_ALLOC_HEAP() \
+	public: \
+	void *operator new(size_t Size) \
+	{ \
+		void *p = mem_alloc(Size, 1); \
+		/*dbg_msg("", "++ %p %d", p, size);*/ \
+		mem_zero(p, Size); \
+		return p; \
+	} \
+	void operator delete(void *pPtr) \
+	{ \
+		/*dbg_msg("", "-- %p", p);*/ \
+		mem_free(pPtr); \
+	} \
+	private:
+
+class CEntity
+{
+	MACRO_ALLOC_HEAP()
+	friend class CGameWorld;	// entity list handling
+	CEntity *m_pPrevTypeEntity;
+	CEntity *m_pNextTypeEntity;
+protected:
+	class CGameWorld *m_pGameWorld;
+	bool m_MarkedForDestroy;
+	int m_ID;
+	int m_ObjType;
+public:
+	CEntity(CGameWorld *pGameWorld, int Objtype);
+	virtual ~CEntity();
+
+	class CGameWorld *GameWorld() { return m_pGameWorld; }
+	CTuningParams *Tuning() { return GameWorld()->Tuning(); }
+	class CCollision *Collision() { return GameWorld()->Collision(); }
+	CEntity *TypeNext() { return m_pNextTypeEntity; }
+	CEntity *TypePrev() { return m_pPrevTypeEntity; }
+	virtual void Destroy() { delete this; }
+	virtual void Reset() {}
+	virtual void Tick() {}
+	virtual void TickDefered() {}
+	virtual void TickPaused() {}
+	bool GameLayerClipped(vec2 CheckPos);
+	float m_ProximityRadius;
+	vec2 m_Pos;
+	int m_Number;
+	int m_Layer;
+};
+
+#endif

--- a/src/game/client/world/gameworld.cpp
+++ b/src/game/client/world/gameworld.cpp
@@ -1,0 +1,507 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
+
+#include "gameworld.h"
+#include "entity.h"
+#include "entities/character.h"
+#include "entities/projectile.h"
+#include "entities/laser.h"
+#include "entities/pickup.h"
+#include <algorithm>
+#include <utility>
+#include <engine/shared/config.h>
+
+//////////////////////////////////////////////////
+// game world
+//////////////////////////////////////////////////
+CGameWorld::CGameWorld()
+{
+	m_Paused = false;
+	m_ResetRequested = false;
+	for(int i = 0; i < NUM_ENTTYPES; i++)
+		m_apFirstEntityTypes[i] = 0;
+	for(int i = 0; i < MAX_CLIENTS; i++)
+		m_apCharacters[i] = 0;
+	m_pCollision = 0;
+	m_pTeams = 0;
+	m_GameTick = 0;
+}
+
+CGameWorld::~CGameWorld()
+{
+	// delete all entities
+	for(int i = 0; i < NUM_ENTTYPES; i++)
+		while(m_apFirstEntityTypes[i])
+			delete m_apFirstEntityTypes[i];
+}
+
+CEntity *CGameWorld::FindFirst(int Type)
+{
+	return Type < 0 || Type >= NUM_ENTTYPES ? 0 : m_apFirstEntityTypes[Type];
+}
+
+int CGameWorld::FindEntities(vec2 Pos, float Radius, CEntity **ppEnts, int Max, int Type)
+{
+	if(Type < 0 || Type >= NUM_ENTTYPES)
+		return 0;
+
+	int Num = 0;
+	for(CEntity *pEnt = m_apFirstEntityTypes[Type]; pEnt; pEnt = pEnt->m_pNextTypeEntity)
+	{
+		if(distance(pEnt->m_Pos, Pos) < Radius+pEnt->m_ProximityRadius)
+		{
+			if(ppEnts)
+				ppEnts[Num] = pEnt;
+			Num++;
+			if(Num == Max)
+				break;
+		}
+	}
+
+	return Num;
+}
+
+void CGameWorld::InsertEntity(CEntity *pEnt)
+{
+#ifdef CONF_DEBUG
+	for(CEntity *pCur = m_apFirstEntityTypes[pEnt->m_ObjType]; pCur; pCur = pCur->m_pNextTypeEntity)
+		dbg_assert(pCur != pEnt, "err");
+#endif
+	pEnt->m_pGameWorld = this;
+	if(pEnt->m_ObjType == ENTTYPE_CHARACTER)
+	{
+		CCharacter *pChar = (CCharacter*) pEnt;
+		int ID = pChar->GetCID();
+		if(ID >= 0 && ID < MAX_CLIENTS)
+		{
+			m_apCharacters[ID] = pChar;
+			m_Core.m_apCharacters[ID] = pChar->Core();
+		}
+		pChar->SetGameWorld(this);
+	}
+
+	// insert it
+	if(m_apFirstEntityTypes[pEnt->m_ObjType])
+		m_apFirstEntityTypes[pEnt->m_ObjType]->m_pPrevTypeEntity = pEnt;
+	pEnt->m_pNextTypeEntity = m_apFirstEntityTypes[pEnt->m_ObjType];
+	pEnt->m_pPrevTypeEntity = 0x0;
+	m_apFirstEntityTypes[pEnt->m_ObjType] = pEnt;
+}
+
+void CGameWorld::DestroyEntity(CEntity *pEnt)
+{
+	pEnt->m_MarkedForDestroy = true;
+}
+
+void CGameWorld::RemoveEntity(CEntity *pEnt)
+{
+	// not in the list
+	if(!pEnt->m_pNextTypeEntity && !pEnt->m_pPrevTypeEntity && m_apFirstEntityTypes[pEnt->m_ObjType] != pEnt)
+		return;
+
+	// remove
+	if(pEnt->m_pPrevTypeEntity)
+		pEnt->m_pPrevTypeEntity->m_pNextTypeEntity = pEnt->m_pNextTypeEntity;
+	else
+		m_apFirstEntityTypes[pEnt->m_ObjType] = pEnt->m_pNextTypeEntity;
+	if(pEnt->m_pNextTypeEntity)
+		pEnt->m_pNextTypeEntity->m_pPrevTypeEntity = pEnt->m_pPrevTypeEntity;
+
+	// keep list traversing valid
+	if(m_pNextTraverseEntity == pEnt)
+		m_pNextTraverseEntity = pEnt->m_pNextTypeEntity;
+
+	pEnt->m_pNextTypeEntity = 0;
+	pEnt->m_pPrevTypeEntity = 0;
+
+	if(pEnt->m_ObjType == ENTTYPE_CHARACTER)
+	{
+		CCharacter *pChar = (CCharacter*) pEnt;
+		int ID = pChar->GetCID();
+		if(ID >= 0 && ID < MAX_CLIENTS)
+		{
+			m_apCharacters[ID] = 0;
+			m_Core.m_apCharacters[ID] = 0;
+		}
+	}
+}
+
+void CGameWorld::Reset()
+{
+	// reset all entities
+	for(int i = 0; i < NUM_ENTTYPES; i++)
+		for(CEntity *pEnt = m_apFirstEntityTypes[i]; pEnt; )
+		{
+			m_pNextTraverseEntity = pEnt->m_pNextTypeEntity;
+			pEnt->Reset();
+			pEnt = m_pNextTraverseEntity;
+		}
+	RemoveEntities();
+
+	//GameServer()->m_pController->PostReset();
+	//RemoveEntities();
+
+	m_ResetRequested = false;
+}
+
+void CGameWorld::RemoveEntities()
+{
+	// destroy objects marked for destruction
+	for(int i = 0; i < NUM_ENTTYPES; i++)
+		for(CEntity *pEnt = m_apFirstEntityTypes[i]; pEnt; )
+		{
+			m_pNextTraverseEntity = pEnt->m_pNextTypeEntity;
+			if(pEnt->m_MarkedForDestroy)
+			{
+				RemoveEntity(pEnt);
+				pEnt->Destroy();
+			}
+			pEnt = m_pNextTraverseEntity;
+		}
+}
+
+bool distCompare(std::pair<float,int> a, std::pair<float,int> b)
+{
+	return (a.first < b.first);
+}
+
+void CGameWorld::Tick()
+{
+	if(m_ResetRequested)
+		Reset();
+
+	if(!m_Paused)
+	{
+		// update all objects
+		for(int i = 0; i < NUM_ENTTYPES; i++)
+			for(CEntity *pEnt = m_apFirstEntityTypes[i]; pEnt; )
+			{
+				m_pNextTraverseEntity = pEnt->m_pNextTypeEntity;
+				pEnt->Tick();
+				pEnt = m_pNextTraverseEntity;
+			}
+
+		for(int i = 0; i < NUM_ENTTYPES; i++)
+			for(CEntity *pEnt = m_apFirstEntityTypes[i]; pEnt; )
+			{
+				m_pNextTraverseEntity = pEnt->m_pNextTypeEntity;
+				pEnt->TickDefered();
+				pEnt = m_pNextTraverseEntity;
+			}
+	}
+	else
+	{
+		// update all objects
+		for(int i = 0; i < NUM_ENTTYPES; i++)
+			for(CEntity *pEnt = m_apFirstEntityTypes[i]; pEnt; )
+			{
+				m_pNextTraverseEntity = pEnt->m_pNextTypeEntity;
+				pEnt->TickPaused();
+				pEnt = m_pNextTraverseEntity;
+			}
+	}
+
+	RemoveEntities();
+}
+
+
+// TODO: should be more general
+//CCharacter *CGameWorld::IntersectCharacter(vec2 Pos0, vec2 Pos1, float Radius, vec2& NewPos, CEntity *pNotThis)
+CCharacter *CGameWorld::IntersectCharacter(vec2 Pos0, vec2 Pos1, float Radius, vec2& NewPos, CCharacter *pNotThis, int CollideWith, class CCharacter *pThisOnly)
+{
+	// Find other players
+	float ClosestLen = distance(Pos0, Pos1) * 100.0f;
+	CCharacter *pClosest = 0;
+
+	CCharacter *p = (CCharacter *)FindFirst(ENTTYPE_CHARACTER);
+	for(; p; p = (CCharacter *)p->TypeNext())
+	{
+		if(p == pNotThis)
+			continue;
+
+		if(CollideWith != -1 && !p->CanCollide(CollideWith))
+			continue;
+
+		vec2 IntersectPos = closest_point_on_line(Pos0, Pos1, p->m_Pos);
+		float Len = distance(p->m_Pos, IntersectPos);
+		if(Len < p->m_ProximityRadius+Radius)
+		{
+			Len = distance(Pos0, IntersectPos);
+			if(Len < ClosestLen)
+			{
+				NewPos = IntersectPos;
+				ClosestLen = Len;
+				pClosest = p;
+			}
+		}
+	}
+
+	return pClosest;
+}
+
+CCharacter *CGameWorld::ClosestCharacter(vec2 Pos, float Radius, CEntity *pNotThis)
+{
+	// Find other players
+	float ClosestRange = Radius*2;
+	CCharacter *pClosest = 0;
+
+	CCharacter *p = (CCharacter *)FindFirst(ENTTYPE_CHARACTER);
+	for(; p; p = (CCharacter *)p->TypeNext())
+	{
+		if(p == pNotThis)
+			continue;
+
+		float Len = distance(Pos, p->m_Pos);
+		if(Len < p->m_ProximityRadius+Radius)
+		{
+			if(Len < ClosestRange)
+			{
+				ClosestRange = Len;
+				pClosest = p;
+			}
+		}
+	}
+
+	return pClosest;
+}
+std::list<class CCharacter *> CGameWorld::IntersectedCharacters(vec2 Pos0, vec2 Pos1, float Radius, class CEntity *pNotThis)
+{
+	std::list< CCharacter * > listOfChars;
+
+	CCharacter *pChr = (CCharacter *)FindFirst(CGameWorld::ENTTYPE_CHARACTER);
+	for(; pChr; pChr = (CCharacter *)pChr->TypeNext())
+	{
+		if(pChr == pNotThis)
+			continue;
+
+		vec2 IntersectPos = closest_point_on_line(Pos0, Pos1, pChr->m_Pos);
+		float Len = distance(pChr->m_Pos, IntersectPos);
+		if(Len < pChr->m_ProximityRadius+Radius)
+		{
+			pChr->m_Intersection = IntersectPos;
+			listOfChars.push_back(pChr);
+		}
+	}
+	return listOfChars;
+}
+
+void CGameWorld::ReleaseHooked(int ClientID)
+{
+	CCharacter *pChr = (CCharacter *)CGameWorld::FindFirst(CGameWorld::ENTTYPE_CHARACTER);
+		for(; pChr; pChr = (CCharacter *)pChr->TypeNext())
+		{
+			CCharacterCore* Core = pChr->Core();
+			if(Core->m_HookedPlayer == ClientID && !pChr->m_Super)
+			{
+				Core->m_HookedPlayer = -1;
+				Core->m_HookState = HOOK_RETRACTED;
+				Core->m_TriggeredEvents |= COREEVENT_HOOK_RETRACT;
+				Core->m_HookState = HOOK_RETRACTED;
+			}
+		}
+}
+
+CTuningParams *CGameWorld::Tuning()
+{
+	return &m_Core.m_Tuning[g_Config.m_ClDummy];
+}
+
+CEntity *CGameWorld::GetEntity(int ID, int EntType)
+{
+	for(CEntity *pEnt = m_apFirstEntityTypes[EntType]; pEnt; pEnt = pEnt->m_pNextTypeEntity)
+		if(pEnt->m_ID == ID)
+			return pEnt;
+	return 0;
+}
+
+void CGameWorld::CreateExplosion(vec2 Pos, int Owner, int Weapon, bool NoDamage, int ActivatedTeam, int64_t Mask)
+{
+	// deal damage
+	CCharacter *apEnts[MAX_CLIENTS];
+	float Radius = 135.0f;
+	float InnerRadius = 48.0f;
+	int Num = FindEntities(Pos, Radius, (CEntity**)apEnts, MAX_CLIENTS, CGameWorld::ENTTYPE_CHARACTER);
+	for(int i = 0; i < Num; i++)
+	{
+		vec2 Diff = apEnts[i]->m_Pos - Pos;
+		vec2 ForceDir(0,1);
+		float l = length(Diff);
+		if(l)
+			ForceDir = normalize(Diff);
+		l = 1-clamp((l-InnerRadius)/(Radius-InnerRadius), 0.0f, 1.0f);
+		float Strength;
+		if(Owner == -1 || !GetCharacterByID(Owner))
+			Strength = Tuning()->m_ExplosionStrength;
+		else
+			Strength = GetCharacterByID(Owner)->Tuning()->m_ExplosionStrength;
+
+		float Dmg = Strength * l;
+		if((int)Dmg)
+			if((GetCharacterByID(Owner) ? !(GetCharacterByID(Owner)->m_Hit&CCharacter::DISABLE_HIT_GRENADE) : g_Config.m_SvHit || NoDamage) || Owner == apEnts[i]->GetCID())
+			{
+				if(Owner != -1 && apEnts[i]->IsAlive() && !apEnts[i]->CanCollide(Owner)) continue;
+				if(Owner == -1 && ActivatedTeam != -1 && apEnts[i]->IsAlive() && apEnts[i]->Team() != ActivatedTeam) continue;
+				apEnts[i]->TakeDamage(ForceDir*Dmg*2, (int)Dmg, Owner, Weapon);
+				if(GetCharacterByID(Owner) ? GetCharacterByID(Owner)->m_Hit&CCharacter::DISABLE_HIT_GRENADE : !g_Config.m_SvHit || NoDamage) break;
+			}
+	}
+}
+
+void CGameWorld::NetObjBegin()
+{
+	for(int i = 0; i < NUM_ENTTYPES; i++)
+		for(CEntity *pEnt = FindFirst(i); pEnt; pEnt = pEnt->TypeNext())
+			pEnt->m_MarkedForDestroy = true;
+}
+
+void CGameWorld::NetObjAdd(int ObjID, int ObjType, const void *pObjData, bool IsLocal)
+{
+	if(ObjType == NETOBJTYPE_CHARACTER)
+	{
+		if(CCharacter *pChar = GetCharacterByID(ObjID))
+		{
+			pChar->Read((CNetObj_Character*) pObjData, IsLocal);
+			pChar->m_MarkedForDestroy = false;
+		}
+		else
+			new CCharacter(this, ObjID, (CNetObj_Character*) pObjData);
+	}
+	else if(ObjType == NETOBJTYPE_PROJECTILE && m_PredictWeapons)
+	{
+		CProjectile NetProj = CProjectile(this, ObjID, (CNetObj_Projectile*) pObjData);
+		if(CEntity *pEnt = GetEntity(ObjID, ENTTYPE_PROJECTILE))
+		{
+			CProjectile *pProj = (CProjectile*) pEnt;
+			if(distance(pProj->m_Pos, NetProj.m_Pos) < 2.f && distance(pProj->GetDirection(), NetProj.GetDirection()) < 2.f && pProj->GetStartTick() == NetProj.GetStartTick())
+			{
+				pEnt->m_MarkedForDestroy = false;
+				if(pProj->m_Type == WEAPON_SHOTGUN && m_IsDDRace)
+					pProj->m_LifeSpan = 20 * GameTickSpeed() - (GameTick() - pProj->m_StartTick);
+				return;
+			}
+		}
+		for(CProjectile *pProj = (CProjectile*) FindFirst(CGameWorld::ENTTYPE_PROJECTILE); pProj; pProj = (CProjectile*) pProj->TypeNext())
+		{
+			if(pProj->m_ID == -1 && NetProj.GetOwner() < 0 && distance(pProj->m_Pos, NetProj.m_Pos) < 2.f && distance(pProj->GetDirection(), NetProj.GetDirection()) < 2.f && pProj->GetStartTick() == NetProj.GetStartTick())
+			{
+				pProj->m_ID = ObjID;
+				pProj->m_MarkedForDestroy = false;
+				return;
+			}
+		}
+		if(NetProj.m_Explosive)
+		{
+			CEntity *pEnt = new CProjectile(NetProj);
+			InsertEntity(pEnt);
+		}
+	}
+	else if(ObjType == NETOBJTYPE_PICKUP && m_PredictWeapons)
+	{
+		CPickup NetPickup = CPickup(this, ObjID, (CNetObj_Pickup*) pObjData);
+		if(CEntity *pEnt = GetEntity(ObjID, ENTTYPE_PICKUP))
+		{
+			pEnt->m_Pos = NetPickup.m_Pos;
+			pEnt->m_MarkedForDestroy = false;
+			return;
+		}
+		CEntity *pEnt = new CPickup(NetPickup);
+		InsertEntity(pEnt);
+	}
+	else if(ObjType == NETOBJTYPE_LASER && m_PredictWeapons)
+	{
+		CLaser NetLaser = CLaser(this, ObjID, (CNetObj_Laser*) pObjData);
+		if(CEntity *pEnt = GetEntity(ObjID, ENTTYPE_LASER))
+		{
+			CLaser *pLaser = (CLaser*) pEnt;
+			const vec2 NetDiff = NetLaser.m_Pos - NetLaser.GetFrom();
+			const vec2 EntDiff = pLaser->m_Pos - pLaser->GetFrom();
+			const float DirError = distance(normalize(EntDiff)*length(NetDiff), NetDiff);
+			if(distance(pLaser->GetFrom(), NetLaser.GetFrom()) < 2.f && pLaser->GetEvalTick() == NetLaser.GetEvalTick() && DirError < 2.f)
+			{
+				pEnt->m_MarkedForDestroy = false;
+				if(distance(pLaser->m_Pos, NetLaser.m_Pos) > 2.f)
+				{
+					pLaser->m_Energy = 0.f;
+					pLaser->m_Pos = NetLaser.m_Pos;
+				}
+			}
+		}
+		else
+		{
+			for(CLaser *pLaser = (CLaser*) FindFirst(CGameWorld::ENTTYPE_LASER); pLaser; pLaser = (CLaser*) pLaser->TypeNext())
+			{
+				if(distance(pLaser->m_Pos, NetLaser.m_Pos) < 2.f && distance(pLaser->GetFrom(), NetLaser.GetFrom()) < 2.f && pLaser->GetEvalTick() == NetLaser.GetEvalTick())
+				{
+					pLaser->m_ID = ObjID;
+					pLaser->m_MarkedForDestroy = false;
+					return;
+				}
+			}
+		}
+	}
+}
+
+void CGameWorld::NetObjEnd()
+{
+	for(int i = 0; i < MAX_CLIENTS; i++)
+	{
+		if(CCharacter *pChar = GetCharacterByID(i))
+		{
+			if(CCharacter *pHookedChar = GetCharacterByID(pChar->m_Core.m_HookedPlayer))
+			{
+				if(pHookedChar->m_MarkedForDestroy)
+				{
+					pHookedChar->m_Pos = pChar->m_Core.m_HookPos;
+					mem_zero(&pHookedChar->m_Input, sizeof(pHookedChar->m_Input));
+					pHookedChar->m_MarkedForDestroy = false;
+				}
+			}
+		}
+	}
+	RemoveEntities();
+}
+
+void CGameWorld::CopyWorld(CGameWorld *pFrom)
+{
+	if(pFrom == this)
+		return;
+	m_ResetRequested = pFrom->m_ResetRequested;
+	m_Paused = pFrom->m_Paused;
+	m_GameTick = pFrom->m_GameTick;
+	m_GameTickSpeed = pFrom->m_GameTickSpeed;
+	m_IsDDRace = pFrom->m_IsDDRace;
+	m_PredictDDRace = pFrom->m_PredictDDRace;
+	m_PredictWeapons = pFrom->m_PredictWeapons;
+	m_InfiniteAmmo = pFrom->m_InfiniteAmmo;
+	m_pCollision = pFrom->m_pCollision;
+	for(int i = 0; i < 2; i++)
+		m_Core.m_Tuning[i] = pFrom->m_Core.m_Tuning[i];
+	m_pTeams = pFrom->m_pTeams;
+	// delete the previous entities
+	for(int i = 0; i < NUM_ENTTYPES; i++)
+		while(m_apFirstEntityTypes[i])
+			delete m_apFirstEntityTypes[i];
+	// copy and insert the new entities
+	for(int Type = 0; Type < NUM_ENTTYPES; Type++)
+	{
+		CEntity *pLast = pFrom->FindFirst(Type);
+		if(!pLast)
+			continue;
+		while(pLast->TypeNext())
+			pLast = pLast->TypeNext();
+		for(CEntity *pEnt = pLast; pEnt; pEnt = pEnt->TypePrev())
+		{
+			CEntity *pCopy = 0;
+			if(Type == ENTTYPE_PROJECTILE)
+				pCopy = new CProjectile(*((CProjectile*)pEnt));
+			else if(Type == ENTTYPE_LASER)
+				pCopy = new CLaser(*((CLaser*)pEnt));
+			else if(Type == ENTTYPE_CHARACTER)
+				pCopy = new CCharacter(*((CCharacter*)pEnt));
+			else if(Type == ENTTYPE_PICKUP)
+				pCopy = new CPickup(*((CPickup*)pEnt));
+			if(pCopy)
+				this->InsertEntity(pCopy);
+		}
+	}
+}

--- a/src/game/client/world/gameworld.h
+++ b/src/game/client/world/gameworld.h
@@ -1,0 +1,88 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#ifndef GAME_CLIENT_WORLD_GAMEWORLD_H
+#define GAME_CLIENT_WORLD_GAMEWORLD_H
+
+#include <game/gamecore.h>
+
+#include <list>
+
+class CEntity;
+class CCharacter;
+
+class CGameWorld
+{
+	friend class CCharacter;
+public:
+	enum
+	{
+		ENTTYPE_PROJECTILE = 0,
+		ENTTYPE_LASER,
+		ENTTYPE_PICKUP,
+		ENTTYPE_FLAG,
+		ENTTYPE_CHARACTER,
+		NUM_ENTTYPES
+	};
+
+private:
+	void Reset();
+	void RemoveEntities();
+
+	CEntity *m_pNextTraverseEntity;
+	CEntity *m_apFirstEntityTypes[NUM_ENTTYPES];
+
+	class CCharacter *m_apCharacters[MAX_CLIENTS];
+
+public:
+	bool m_ResetRequested;
+	bool m_Paused;
+	CWorldCore m_Core;
+
+	CGameWorld();
+	~CGameWorld();
+
+	CEntity *FindFirst(int Type);
+	int FindEntities(vec2 Pos, float Radius, CEntity **ppEnts, int Max, int Type);
+	class CCharacter *IntersectCharacter(vec2 Pos0, vec2 Pos1, float Radius, vec2 &NewPos, class CCharacter *pNotThis = 0, int CollideWith = -1, class CCharacter *pThisOnly = 0);
+	class CCharacter *ClosestCharacter(vec2 Pos, float Radius, CEntity *ppNotThis);
+	void InsertEntity(CEntity *pEntity);
+	void RemoveEntity(CEntity *pEntity);
+	void DestroyEntity(CEntity *pEntity);
+	void Snap(int SnappingClient);
+	void Tick();
+
+	// DDRace
+
+	std::list<class CCharacter *> IntersectedCharacters(vec2 Pos0, vec2 Pos1, float Radius, vec2 &NewPos, class CEntity *pNotThis);
+	void ReleaseHooked(int ClientID);
+	std::list<class CCharacter *> IntersectedCharacters(vec2 Pos0, vec2 Pos1, float Radius, class CEntity *pNotThis = 0);
+
+	int m_GameTick;
+	int m_GameTickSpeed;
+	CCollision *m_pCollision;
+	CTeamsCore *m_pTeams;
+
+	bool m_IsDDRace;
+	bool m_InfiniteAmmo;
+	bool m_PredictDDRace;
+	bool m_PredictWeapons;
+
+	int GameTick() { return m_GameTick; }
+	int GameTickSpeed() { return m_GameTickSpeed; }
+	class CCollision *Collision() { return m_pCollision; }
+	CTeamsCore *Teams() { return m_pTeams; }
+	class CCharacter *GetCharacterByID(int ID) { return (ID >= 0 && ID < MAX_CLIENTS) ? m_apCharacters[ID] : 0; }
+	CTuningParams *Tuning();
+	CEntity *GetEntity(int ID, int EntityType);
+
+	// gamecontext functions
+	void CreateExplosion(vec2 Pos, int Owner, int Weapon, bool NoDamage, int ActivatedTeam, int64_t Mask);
+
+	// helper functions for client side prediction
+	void NetObjBegin();
+	void NetObjAdd(int ObjID, int ObjType, const void *pObjData, bool IsLocal = false);
+	void NetObjEnd();
+	void CopyWorld(CGameWorld *pFrom);
+};
+
+#endif

--- a/src/game/gamecore.h
+++ b/src/game/gamecore.h
@@ -214,7 +214,7 @@ public:
 	void Init(CWorldCore *pWorld, CCollision *pCollision, CTeamsCore* pTeams);
 	void Init(CWorldCore *pWorld, CCollision *pCollision, CTeamsCore* pTeams, std::map<int, std::vector<vec2> > *pTeleOuts);
 	void Reset();
-	void Tick(bool UseInput, bool IsClient);
+	void Tick(bool UseInput);
 	void Move();
 
 	void Read(const CNetObj_CharacterCore *pObjCore);

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -744,7 +744,7 @@ void CCharacter::Tick()
 	DDRaceTick();
 
 	m_Core.m_Input = m_Input;
-	m_Core.Tick(true, false);
+	m_Core.Tick(true);
 
 	// handle Weapons
 	HandleWeapons();
@@ -765,7 +765,7 @@ void CCharacter::TickDefered()
 		CWorldCore TempWorld;
 		m_ReckoningCore.Init(&TempWorld, GameServer()->Collision(), &((CGameControllerDDRace*)GameServer()->m_pController)->m_Teams.m_Core, &((CGameControllerDDRace*)GameServer()->m_pController)->m_TeleOuts);
 		m_ReckoningCore.m_Id = m_pPlayer->GetCID();
-		m_ReckoningCore.Tick(false, false);
+		m_ReckoningCore.Tick(false);
 		m_ReckoningCore.Move();
 		m_ReckoningCore.Quantize();
 	}


### PR DESCRIPTION
This is an attempt at cleaning up the prediction/antiping code, and to separate it from the rest of the client code.

It also changes the approach that the client uses for prediction. This was done to make it easier to predict things like shotgun/laser/freeze, which would be difficult with the previous approach, and also to make it easier to extend the prediction in general.

There is now prediction for shotgun, ninja, freeze (only from ddrace freeze tiles), laser/unfreeze, some new tiles and pickups.

This currently only affects the predicted physics, and certain things like the trail of the predicted laser are not rendered yet, but that would be possible to add later. Also, this only changes the client code, and certain things that the client does not have accurate information about are still not predicted, such as laser/shotgun from other players.