### PR TITLE
Fixed cl_showping (now cl_showpred)

### DIFF
--- a/src/engine/client.h
+++ b/src/engine/client.h
@@ -140,6 +140,8 @@ public:
 
 	virtual void CheckVersionUpdate() = 0;
 
+	virtual int GetPredictionTime() = 0;
+
 	// snapshot interface
 
 	enum

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -933,7 +933,6 @@ void CClient::DebugRender()
 	static NETSTATS Prev, Current;
 	static int64 LastSnap = 0;
 	static float FrameTimeAvg = 0;
-	int64 Now = time_get();
 	char aBuffer[512];
 
 	if(!g_Config.m_Debug)
@@ -999,8 +998,7 @@ void CClient::DebugRender()
 		}
 	}
 
-	str_format(aBuffer, sizeof(aBuffer), "pred: %d ms",
-		(int)((m_PredictedTime.Get(Now)-m_GameTime[g_Config.m_ClDummy].Get(Now))*1000/(float)time_freq()));
+	str_format(aBuffer, sizeof(aBuffer), "pred: %d ms", GetPredictionTime());
 	Graphics()->QuadsText(2, 70, 16, aBuffer);
 	Graphics()->QuadsEnd();
 
@@ -3547,4 +3545,10 @@ void CClient::RequestDDNetSrvList()
 	Packet.m_DataSize = sizeof(VERSIONSRV_GETDDNETLIST)+4;
 	Packet.m_Flags = NETSENDFLAG_CONNLESS;
 	m_NetClient[g_Config.m_ClDummy].Send(&Packet);
+}
+
+int CClient::GetPredictionTime()
+{
+	int64 Now = time_get();
+	return (int)((m_PredictedTime.Get(Now)-m_GameTime[g_Config.m_ClDummy].Get(Now))*1000/(float)time_freq());
 }

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -270,6 +270,7 @@ public:
 
 	// ---
 
+	int GetPredictionTime();
 	void *SnapGetItem(int SnapID, int Index, CSnapItem *pItem);
 	void SnapInvalidateItem(int SnapID, int Index);
 	void *SnapFindItem(int SnapID, int Type, int ID);

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -319,11 +319,10 @@ void CHud::RenderTextInfo()
 		str_format(Buf, sizeof(Buf), "%d", (int)m_AverageFPS);
 		TextRender()->Text(0, m_Width-10-TextRender()->TextWidth(0,12,Buf,-1), 5, 12, Buf, -1);
 	}
-
-	if(g_Config.m_ClShowping)
+	if(g_Config.m_ClShowpred)
 	{
 		char aBuf[64];
-		str_format(aBuf, sizeof(aBuf), "%d", clamp(m_pClient->m_Snap.m_pLocalInfo->m_Latency, 0, 1000));
+		str_format(aBuf, sizeof(aBuf), "%d", Client()->GetPredictionTime());
 		TextRender()->Text(0, m_Width-10-TextRender()->TextWidth(0,12,aBuf,-1), g_Config.m_ClShowfps ? 20 : 5, 12, aBuf, -1);
 	}
 }

--- a/src/game/client/components/killmessages.cpp
+++ b/src/game/client/components/killmessages.cpp
@@ -54,7 +54,7 @@ void CKillMessages::OnRender()
 
 	Graphics()->MapScreen(0, 0, Width*1.5f, Height*1.5f);
 	float StartX = Width*1.5f-10.0f;
-	float y = 30.0f + 100.0f * (g_Config.m_ClShowfps + g_Config.m_ClShowping);
+	float y = 30.0f + 100.0f * (g_Config.m_ClShowfps + g_Config.m_ClShowpred);
 
 	for(int i = 1; i <= MAX_KILLMSGS; i++)
 	{

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -263,8 +263,6 @@ void CPlayer::PostTick()
 				m_aActLatency[i] = GameServer()->m_apPlayers[i]->m_Latency.m_Min;
 		}
 	}
-	else
-		m_aActLatency[m_ClientID] = GameServer()->m_apPlayers[m_ClientID]->m_Latency.m_Min;
 
 	// update view pos for spectators
 	if((m_Team == TEAM_SPECTATORS || m_Paused) && m_SpectatorID != SPEC_FREEVIEW && GameServer()->m_apPlayers[m_SpectatorID] && GameServer()->m_apPlayers[m_SpectatorID]->GetCharacter())

--- a/src/game/variables.h
+++ b/src/game/variables.h
@@ -36,7 +36,7 @@ MACRO_CONFIG_INT(ClShowKillMessages, cl_showkillmessages, 1, 0, 1, CFGFLAG_CLIEN
 MACRO_CONFIG_INT(ClShowVotesAfterVoting, cl_show_votes_after_voting, 0, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Show votes window after voting")
 MACRO_CONFIG_INT(ClShowLocalTimeAlways, cl_show_local_time_always, 0, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Always show local time")
 MACRO_CONFIG_INT(ClShowfps, cl_showfps, 0, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Show ingame FPS counter")
-MACRO_CONFIG_INT(ClShowping, cl_showping, 0, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Show ingame ping counter")
+MACRO_CONFIG_INT(ClShowpred, cl_showpred, 0, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Show ingame prediction time in milliseconds")
 MACRO_CONFIG_INT(ClEyeWheel, cl_eye_wheel, 1, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Show eye wheel along together with emotes")
 MACRO_CONFIG_INT(ClEyeDuration, cl_eye_duration, 999999, 1, 999999, CFGFLAG_CLIENT|CFGFLAG_SAVE, "How long the eyes emotes last")
 


### PR DESCRIPTION
- Renamed cl_showping to cl_showpred
- Now shows prediction time in ms.
- No server compile needed now. (works with all servers)