### PR TITLE
always read fifo from start

### DIFF
--- a/src/engine/shared/fifo.cpp
+++ b/src/engine/shared/fifo.cpp
@@ -58,7 +58,9 @@ void CFifo::Update()
 	if(m_File == NULL)
 		return;
 
+#ifdef CONF_PLATFORM_MACOSX
 	rewind(m_File);
+#endif
 
 	char aBuf[8192];
 

--- a/src/engine/shared/fifo.cpp
+++ b/src/engine/shared/fifo.cpp
@@ -58,6 +58,8 @@ void CFifo::Update()
 	if(m_File == NULL)
 		return;
 
+	rewind(m_File);
+
 	char aBuf[8192];
 
 	while(true)


### PR DESCRIPTION
Without this the fifo is not read on OS X.