### PR TITLE
Some improves for layers editing in editor

### DIFF
--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -540,6 +540,7 @@ public:
 
 	void GetSize(float *w, float *h) { *w = m_Width*32.0f; *h = m_Height*32.0f; }
 
+
 	int m_TexID;
 	int m_Game;
 	int m_Image;
@@ -1061,7 +1062,6 @@ public:
 	virtual void BrushFlipY();
 	virtual void BrushRotate(float Amount);
 	virtual void FillSelection(bool Empty, CLayer *pBrush, CUIRect Rect);
-	virtual void ChangeValuesNumbersTo(int number);
 };
 
 class CLayerSpeedup : public CLayerTiles
@@ -1102,8 +1102,6 @@ public:
 	~CLayerSwitch();
 
 	CSwitchTile *m_pSwitchTile;
-	unsigned char m_SwitchNumber;
-	unsigned char m_SwitchDelay;
 
 	virtual void Resize(int NewW, int NewH);
 	virtual void Shift(int Direction);

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -1110,7 +1110,8 @@ public:
 	virtual void BrushDraw(CLayer *pBrush, float wx, float wy);
 	virtual void FillSelection(bool Empty, CLayer *pBrush, CUIRect Rect);
 	virtual void BrushRotate(float Amount);
-
+	virtual void BrushFlipX();
+	virtual void BrushFlipY();
 };
 
 class CLayerTune : public CLayerTiles

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -1053,7 +1053,6 @@ public:
 	~CLayerTele();
 
 	CTeleTile *m_pTeleTile;
-	unsigned char m_TeleNum;
 
 	virtual void Resize(int NewW, int NewH);
 	virtual void Shift(int Direction);
@@ -1062,6 +1061,7 @@ public:
 	virtual void BrushFlipY();
 	virtual void BrushRotate(float Amount);
 	virtual void FillSelection(bool Empty, CLayer *pBrush, CUIRect Rect);
+	virtual void ChangeValuesNumbersTo(int number);
 };
 
 class CLayerSpeedup : public CLayerTiles

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -1109,6 +1109,8 @@ public:
 	virtual void Shift(int Direction);
 	virtual void BrushDraw(CLayer *pBrush, float wx, float wy);
 	virtual void FillSelection(bool Empty, CLayer *pBrush, CUIRect Rect);
+	virtual void BrushRotate(float Amount);
+
 };
 
 class CLayerTune : public CLayerTiles

--- a/src/game/editor/layer_tiles.cpp
+++ b/src/game/editor/layer_tiles.cpp
@@ -102,6 +102,7 @@ void CLayerTiles::Render()
 }
 
 int CLayerTiles::ConvertX(float x) const { return (int)(x/32.0f); }
+
 int CLayerTiles::ConvertY(float y) const { return (int)(y/32.0f); }
 
 void CLayerTiles::Convert(CUIRect Rect, RECTi *pOut)
@@ -770,6 +771,8 @@ void CLayerTiles::ModifyEnvelopeIndex(INDEX_MODIFY_FUNC Func)
 {
 }
 
+//------------------------------------------------------
+
 CLayerTele::CLayerTele(int w, int h)
 : CLayerTiles(w, h)
 {
@@ -1026,6 +1029,8 @@ void CLayerTele::ChangeValuesNumbersTo(int number)
 				m_pTeleTile[m_Width*y + x].m_Number = number;
 		}
 }
+
+//------------------------------------------------------
 
 CLayerSpeedup::CLayerSpeedup(int w, int h)
 : CLayerTiles(w, h)
@@ -1300,6 +1305,8 @@ void CLayerSpeedup::FillSelection(bool Empty, CLayer *pBrush, CUIRect Rect)
 	}
 }
 
+//------------------------------------------------------
+
 CLayerFront::CLayerFront(int w, int h)
 : CLayerTiles(w, h)
 {
@@ -1368,6 +1375,8 @@ void CLayerFront::BrushDraw(CLayer *pBrush, float wx, float wy)
 	m_pEditor->m_Map.m_Modified = true;
 }
 
+//------------------------------------------------------
+
 CLayerSwitch::CLayerSwitch(int w, int h)
 : CLayerTiles(w, h)
 {
@@ -1418,31 +1427,39 @@ void CLayerSwitch::BrushRotate(float Amount)
 		delete[] pTempData;
 	}
 
-
-
 	if (Rotation == 2 || Rotation == 3)
 	{
-		for (int y = 0; y < m_Height; y++)
-			for (int x = 0; x < m_Width / 2; x++)
-			{
-				CSwitchTile Tmp = m_pSwitchTile[y*m_Width + x];
-				m_pSwitchTile[y*m_Width + x] = m_pSwitchTile[y*m_Width + m_Width - 1 - x];
-				m_pSwitchTile[y*m_Width + m_Width - 1 - x] = Tmp;
-				m_pSwitchTile[y*m_Width + x].m_Flags ^= m_pSwitchTile[y*m_Width + x].m_Flags&TILEFLAG_ROTATE ? TILEFLAG_HFLIP : TILEFLAG_VFLIP;
-			}
-
-		for (int y = 0; y < m_Height / 2; y++)
-			for (int x = 0; x < m_Width; x++)
-			{
-				CSwitchTile Tmp = m_pSwitchTile[y*m_Width + x];
-				m_pSwitchTile[y*m_Width + x] = m_pSwitchTile[(m_Height - 1 - y)*m_Width + x];
-				m_pSwitchTile[(m_Height - 1 - y)*m_Width + x] = Tmp;
-				m_pSwitchTile[y*m_Width + x].m_Flags ^= m_pSwitchTile[y*m_Width + x].m_Flags&TILEFLAG_ROTATE ? TILEFLAG_VFLIP : TILEFLAG_HFLIP;
-			}
+		BrushFlipX();
+		BrushFlipY();
 	}
+}
 
+void CLayerSwitch::BrushFlipX() 
+{
+	CLayerTiles::BrushFlipX();
 
+	for (int y = 0; y < m_Height; y++)
+		for (int x = 0; x < m_Width / 2; x++)
+		{
+			CSwitchTile Tmp = m_pSwitchTile[y*m_Width + x];
+			m_pSwitchTile[y*m_Width + x] = m_pSwitchTile[y*m_Width + m_Width - 1 - x];
+			m_pSwitchTile[y*m_Width + m_Width - 1 - x] = Tmp;
+			m_pSwitchTile[y*m_Width + x].m_Flags ^= m_pSwitchTile[y*m_Width + x].m_Flags&TILEFLAG_ROTATE ? TILEFLAG_HFLIP : TILEFLAG_VFLIP;
+		}
+}
 
+void CLayerSwitch::BrushFlipY()
+{
+	CLayerTiles::BrushFlipY();
+
+	for (int y = 0; y < m_Height / 2; y++)
+		for (int x = 0; x < m_Width; x++)
+		{
+			CSwitchTile Tmp = m_pSwitchTile[y*m_Width + x];
+			m_pSwitchTile[y*m_Width + x] = m_pSwitchTile[(m_Height - 1 - y)*m_Width + x];
+			m_pSwitchTile[(m_Height - 1 - y)*m_Width + x] = Tmp;
+			m_pSwitchTile[y*m_Width + x].m_Flags ^= m_pSwitchTile[y*m_Width + x].m_Flags&TILEFLAG_ROTATE ? TILEFLAG_VFLIP : TILEFLAG_HFLIP;
+		}
 }
 
 void CLayerSwitch::Resize(int NewW, int NewH)

--- a/src/game/editor/layer_tiles.cpp
+++ b/src/game/editor/layer_tiles.cpp
@@ -1534,7 +1534,7 @@ void CLayerSwitch::BrushDraw(CLayer *pBrush, float wx, float wy)
 			if(fx<0 || fx >= m_Width || fy < 0 || fy >= m_Height)
 				continue;
 
-			if(IsValidSwitchTile(l->m_pTiles[y*l->m_Width+x].m_Index))
+			if(m_pEditor->m_AllowPlaceUnusedTiles ||IsValidSwitchTile(l->m_pTiles[y*l->m_Width+x].m_Index))
 			{
 				if(m_pEditor->m_SwitchNum != l->m_SwitchNumber || m_pEditor->m_SwitchDelay != l->m_SwitchDelay)
 				{

--- a/src/game/editor/layer_tiles.cpp
+++ b/src/game/editor/layer_tiles.cpp
@@ -1380,6 +1380,7 @@ CLayerSwitch::~CLayerSwitch()
 	delete[] m_pSwitchTile;
 }
 
+
 void CLayerSwitch::Resize(int NewW, int NewH)
 {
 	// resize switch data
@@ -1473,7 +1474,7 @@ void CLayerSwitch::BrushDraw(CLayer *pBrush, float wx, float wy)
 			if(fx<0 || fx >= m_Width || fy < 0 || fy >= m_Height)
 				continue;
 
-			if((l->m_pTiles[y*l->m_Width+x].m_Index >= (ENTITY_ARMOR_1 + ENTITY_OFFSET) && l->m_pTiles[y*l->m_Width+x].m_Index <= (ENTITY_DOOR + ENTITY_OFFSET)) || l->m_pTiles[y*l->m_Width+x].m_Index == TILE_HIT_START || l->m_pTiles[y*l->m_Width+x].m_Index == TILE_HIT_END || l->m_pTiles[y*l->m_Width+x].m_Index == TILE_SWITCHOPEN || l->m_pTiles[y*l->m_Width+x].m_Index == TILE_SWITCHCLOSE || l->m_pTiles[y*l->m_Width+x].m_Index == TILE_SWITCHTIMEDOPEN || l->m_pTiles[y*l->m_Width+x].m_Index == TILE_SWITCHTIMEDCLOSE || l->m_pTiles[y*l->m_Width+x].m_Index == TILE_FREEZE || l->m_pTiles[y*l->m_Width+x].m_Index == TILE_DFREEZE || l->m_pTiles[y*l->m_Width+x].m_Index == TILE_DUNFREEZE || l->m_pTiles[y*l->m_Width+x].m_Index == TILE_JUMP || l->m_pTiles[y*l->m_Width+x].m_Index == TILE_PENALTY || l->m_pTiles[y*l->m_Width+x].m_Index == TILE_BONUS)
+			if(IsValidSwitchTile(l->m_pTiles[y*l->m_Width+x].m_Index))
 			{
 				if(m_pEditor->m_SwitchNum != l->m_SwitchNumber || m_pEditor->m_SwitchDelay != l->m_SwitchDelay)
 				{

--- a/src/game/editor/layer_tiles.cpp
+++ b/src/game/editor/layer_tiles.cpp
@@ -1380,6 +1380,61 @@ CLayerSwitch::~CLayerSwitch()
 	delete[] m_pSwitchTile;
 }
 
+void CLayerSwitch::BrushRotate(float Amount)
+{
+	CLayerTiles::BrushRotate(Amount);
+	//back width and height to it previous state
+	int Temp = m_Width;
+	m_Width = m_Height;
+	m_Height = Temp;
+
+	int Rotation = (round_to_int(360.0f*Amount / (pi * 2)) / 90) % 4;	// 0=0°, 1=90°, 2=180°, 3=270°
+	if (Rotation < 0)
+		Rotation += 4;
+
+	if (Rotation == 1 || Rotation == 3)
+	{
+		// 90° rotation
+		CSwitchTile *pTempData = new CSwitchTile[m_Width*m_Height];
+		mem_copy(pTempData, m_pSwitchTile, m_Width*m_Height * sizeof(CSwitchTile));
+
+		CSwitchTile *pDst = m_pSwitchTile;
+		for (int x = 0; x < m_Width; ++x)
+			for (int y = m_Height - 1; y >= 0; --y, ++pDst)
+			{
+				*pDst = pTempData[y*m_Width + x];
+			}
+
+		int Temp = m_Width;
+		m_Width = m_Height;
+		m_Height = Temp;
+		delete[] pTempData;
+	}
+
+
+
+	if (Rotation == 2 || Rotation == 3)
+	{
+		for (int y = 0; y < m_Height; y++)
+			for (int x = 0; x < m_Width / 2; x++)
+			{
+				CSwitchTile Tmp = m_pSwitchTile[y*m_Width + x];
+				m_pSwitchTile[y*m_Width + x] = m_pSwitchTile[y*m_Width + m_Width - 1 - x];
+				m_pSwitchTile[y*m_Width + m_Width - 1 - x] = Tmp;
+			}
+
+		for (int y = 0; y < m_Height / 2; y++)
+			for (int x = 0; x < m_Width; x++)
+			{
+				CSwitchTile Tmp = m_pSwitchTile[y*m_Width + x];
+				m_pSwitchTile[y*m_Width + x] = m_pSwitchTile[(m_Height - 1 - y)*m_Width + x];
+				m_pSwitchTile[(m_Height - 1 - y)*m_Width + x] = Tmp;
+			}
+	}
+
+
+
+}
 
 void CLayerSwitch::Resize(int NewW, int NewH)
 {

--- a/src/game/editor/layer_tiles.cpp
+++ b/src/game/editor/layer_tiles.cpp
@@ -1403,6 +1403,9 @@ void CLayerSwitch::BrushRotate(float Amount)
 			for (int y = m_Height - 1; y >= 0; --y, ++pDst)
 			{
 				*pDst = pTempData[y*m_Width + x];
+				if (pDst->m_Flags&TILEFLAG_ROTATE)
+					pDst->m_Flags ^= (TILEFLAG_HFLIP | TILEFLAG_VFLIP);
+				pDst->m_Flags ^= TILEFLAG_ROTATE;
 			}
 
 		int Temp = m_Width;
@@ -1421,6 +1424,7 @@ void CLayerSwitch::BrushRotate(float Amount)
 				CSwitchTile Tmp = m_pSwitchTile[y*m_Width + x];
 				m_pSwitchTile[y*m_Width + x] = m_pSwitchTile[y*m_Width + m_Width - 1 - x];
 				m_pSwitchTile[y*m_Width + m_Width - 1 - x] = Tmp;
+				m_pSwitchTile[y*m_Width + x].m_Flags ^= m_pSwitchTile[y*m_Width + x].m_Flags&TILEFLAG_ROTATE ? TILEFLAG_HFLIP : TILEFLAG_VFLIP;
 			}
 
 		for (int y = 0; y < m_Height / 2; y++)
@@ -1429,6 +1433,7 @@ void CLayerSwitch::BrushRotate(float Amount)
 				CSwitchTile Tmp = m_pSwitchTile[y*m_Width + x];
 				m_pSwitchTile[y*m_Width + x] = m_pSwitchTile[(m_Height - 1 - y)*m_Width + x];
 				m_pSwitchTile[(m_Height - 1 - y)*m_Width + x] = Tmp;
+				m_pSwitchTile[y*m_Width + x].m_Flags ^= m_pSwitchTile[y*m_Width + x].m_Flags&TILEFLAG_ROTATE ? TILEFLAG_VFLIP : TILEFLAG_HFLIP;
 			}
 	}
 
@@ -1549,7 +1554,6 @@ void CLayerSwitch::BrushDraw(CLayer *pBrush, float wx, float wy)
 
 				m_pSwitchTile[fy*m_Width+fx].m_Type = l->m_pTiles[y*l->m_Width+x].m_Index;
 				m_pSwitchTile[fy*m_Width+fx].m_Flags = l->m_pTiles[y*l->m_Width+x].m_Flags;
-				m_pTiles[fy*m_Width+fx].m_Index = l->m_pTiles[y*l->m_Width+x].m_Index;
 			}
 			else
 			{
@@ -1557,8 +1561,9 @@ void CLayerSwitch::BrushDraw(CLayer *pBrush, float wx, float wy)
 				m_pSwitchTile[fy*m_Width+fx].m_Type = 0;
 				m_pSwitchTile[fy*m_Width+fx].m_Flags = 0;
 				m_pSwitchTile[fy*m_Width+fx].m_Delay = 0;
-				m_pTiles[fy*m_Width+fx].m_Index = 0;
 			}
+			m_pTiles[fy*m_Width + fx].m_Index = l->m_pTiles[y*l->m_Width + x].m_Index;
+			m_pTiles[fy*m_Width + fx].m_Flags = l->m_pTiles[y*l->m_Width + x].m_Flags;
 
 			if(l->m_pTiles[y*l->m_Width+x].m_Index == TILE_FREEZE)
 			{

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -1429,7 +1429,13 @@ int CEditor::PopupTele(CEditor *pEditor, CUIRect View)
 				if (tl->m_Type == LAYERTYPE_TILES)
 					if (((CLayerTiles*)tl)->m_Tele == 1)
 				{
-					((CLayerTele*)tl)->ChangeValuesNumbersTo(NewVal);
+					CLayerTele *tel = (CLayerTele*)tl;
+					for (int y = 0; y < tel->m_Height; y++)
+						for (int x = 0; x < tel->m_Width; x++)
+						{
+							if (tel->m_pTiles[tel->m_Width*y + x].m_Index != 0)
+								tel->m_pTeleTile[tel->m_Width*y + x].m_Number = pEditor->m_TeleNumber;
+						}
 					break;
 				}
 			}
@@ -1501,6 +1507,8 @@ int CEditor::PopupSwitch(CEditor *pEditor, CUIRect View)
 		NewVal = (NewVal + 256) % 256;
 
 		CLayerSwitch *gl = pEditor->m_Map.m_pSwitchLayer;
+
+		s_color = vec4(0.5f, 1, 0.5f, 0.5f);
 		for(int y = 0; y < gl->m_Height; ++y)
 		{
 			for(int x = 0; x < gl->m_Width; ++x)
@@ -1508,19 +1516,62 @@ int CEditor::PopupSwitch(CEditor *pEditor, CUIRect View)
 				if(gl->m_pSwitchTile[y*gl->m_Width+x].m_Number == NewVal)
 				{
 					s_color = vec4(1,0.5f,0.5f,0.5f);
-					goto done;
+					break;
 				}
 			}
 		}
 
-		s_color = vec4(0.5f,1,0.5f,0.5f);
-
-		done:
 		pEditor->m_SwitchNum = NewVal;
+		if (!pEditor->m_Brush.IsEmpty())
+		{
+			CLayer *tl = pEditor->m_Brush.m_lLayers[0];
+			for (int i = 0; i < pEditor->m_Brush.m_lLayers.size(); i++, tl++)
+			{
+				if (tl->m_Type == LAYERTYPE_TILES)
+					if (((CLayerTiles*)tl)->m_Switch == 1)
+					{
+
+						CLayerSwitch *sl = (CLayerSwitch*)tl;
+						for (int y = 0; y < sl->m_Height; y++)
+							for (int x = 0; x < sl->m_Width; x++)
+							{
+								if (sl->m_pTiles[sl->m_Width*y + x].m_Index != 0)
+								{
+									sl->m_pSwitchTile[sl->m_Width*y + x].m_Number = pEditor->m_SwitchNum;
+								}
+							}
+						break;
+					}
+			}
+		}
 	}
-	if(Prop == PROP_SwitchDelay)
+	if (Prop == PROP_SwitchDelay) 
+	{
 		pEditor->m_SwitchDelay = (NewVal + 256) % 256;
 
+		if (!pEditor->m_Brush.IsEmpty())
+		{
+			CLayer *tl = pEditor->m_Brush.m_lLayers[0];
+			for (int i = 0; i < pEditor->m_Brush.m_lLayers.size(); i++, tl++)
+			{
+				if (tl->m_Type == LAYERTYPE_TILES)
+					if (((CLayerTiles*)tl)->m_Switch == 1)
+					{
+
+						CLayerSwitch *sl = (CLayerSwitch*)tl;
+						for (int y = 0; y < sl->m_Height; y++)
+							for (int x = 0; x < sl->m_Width; x++)
+							{
+								if (sl->m_pTiles[sl->m_Width*y + x].m_Index != 0)
+								{
+									sl->m_pSwitchTile[sl->m_Width*y + x].m_Delay = pEditor->m_SwitchDelay;
+								}
+							}
+						break;
+					}
+			}
+		}
+	}
 	return 0;
 }
 

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -169,7 +169,6 @@ int CEditor::PopupGroup(CEditor *pEditor, CUIRect View)
 			pEditor->m_Map.MakeTeleLayer(l);
 			pEditor->m_Map.m_lGroups[pEditor->m_SelectedGroup]->AddLayer(l);
 			pEditor->m_SelectedLayer = pEditor->m_Map.m_lGroups[pEditor->m_SelectedGroup]->m_lLayers.size()-1;
-			pEditor->m_Brush.Clear();
 			return 1;
 		}
 	}
@@ -1407,6 +1406,7 @@ int CEditor::PopupTele(CEditor *pEditor, CUIRect View)
 	{
 		NewVal = (NewVal + 256) % 256;
 
+		s_color = vec4(0.5f, 1, 0.5f, 0.5f);
 		CLayerTele *gl = pEditor->m_Map.m_pTeleLayer;
 		for(int y = 0; y < gl->m_Height; ++y)
 		{
@@ -1415,15 +1415,25 @@ int CEditor::PopupTele(CEditor *pEditor, CUIRect View)
 				if(gl->m_pTeleTile[y*gl->m_Width+x].m_Number == NewVal)
 				{
 					s_color = vec4(1,0.5f,0.5f,0.5f);
-					goto done;
+					break;
 				}
 			}
 		}
-
-		s_color = vec4(0.5f,1,0.5f,0.5f);
-
-		done:
 		pEditor->m_TeleNumber = NewVal;
+		if (!pEditor->m_Brush.IsEmpty())
+		{
+			CLayer *tl = pEditor->m_Brush.m_lLayers[0];
+			//checking for brush type==tele
+			for (int i = 0; i < pEditor->m_Brush.m_lLayers.size(); i++, tl++)
+			{
+				if (tl->m_Type == LAYERTYPE_TILES)
+					if (((CLayerTiles*)tl)->m_Tele == 1)
+				{
+					((CLayerTele*)tl)->ChangeValuesNumbersTo(NewVal);
+					break;
+				}
+			}
+		}
 	}
 
 	return 0;

--- a/src/game/mapitems.cpp
+++ b/src/game/mapitems.cpp
@@ -37,6 +37,27 @@ bool IsValidFrontTile(int Index)
 	);
 }
 
+bool IsValidSwitchTile(int Index)
+{
+	return (
+		Index == TILE_JUMP
+		|| Index == TILE_FREEZE
+		|| Index == TILE_DFREEZE
+		|| Index == TILE_DUNFREEZE
+		|| Index == TILE_HIT_START
+		|| Index == TILE_HIT_END
+		|| Index == TILE_SWITCHTIMEDOPEN
+		|| Index == TILE_SWITCHTIMEDCLOSE
+		|| Index == TILE_SWITCHOPEN
+		|| Index == TILE_SWITCHCLOSE
+		|| Index == TILE_PENALTY
+		|| Index == TILE_BONUS
+		//Switch layer do not contain spawns and flags (which acceptedeable in IsValidEntity() )
+		|| (Index >= ENTITY_ARMOR_1 + ENTITY_OFFSET && IsValidEntity(Index))
+		);
+}
+
+
 bool IsValidEntity(int Index)
 {
 	Index -= ENTITY_OFFSET;

--- a/src/game/mapitems.cpp
+++ b/src/game/mapitems.cpp
@@ -52,7 +52,7 @@ bool IsValidSwitchTile(int Index)
 		|| Index == TILE_SWITCHCLOSE
 		|| Index == TILE_PENALTY
 		|| Index == TILE_BONUS
-		//Switch layer do not contain spawns and flags (which acceptedeable in IsValidEntity() )
+		//Switch layer do not contain spawn-entities and flag-enties (which acceptedeable in IsValidEntity() )
 		|| (Index >= ENTITY_ARMOR_1 + ENTITY_OFFSET && IsValidEntity(Index))
 		);
 }

--- a/src/game/mapitems.cpp
+++ b/src/game/mapitems.cpp
@@ -57,6 +57,20 @@ bool IsValidSwitchTile(int Index)
 		);
 }
 
+bool IsValidTeleTile(int Index)
+{
+	return (
+		Index == TILE_TELEIN
+		|| Index == TILE_TELEINEVIL
+		|| Index == TILE_TELECHECKINEVIL
+		|| Index == TILE_TELEOUT
+		|| Index == TILE_TELECHECK
+		|| Index == TILE_TELECHECKOUT
+		|| Index == TILE_TELECHECKIN
+		|| Index == TILE_TELEINWEAPON
+		|| Index == TILE_TELEINHOOK
+		);
+}
 
 bool IsValidEntity(int Index)
 {

--- a/src/game/mapitems.h
+++ b/src/game/mapitems.h
@@ -455,7 +455,7 @@ public:
 	unsigned char m_Type;
 };
 
-
+bool IsValidSwitchTile(int Index);
 bool IsValidGameTile(int Index);
 bool IsValidFrontTile(int Index);
 bool IsValidEntity(int Index);

--- a/src/game/mapitems.h
+++ b/src/game/mapitems.h
@@ -458,6 +458,7 @@ public:
 bool IsValidSwitchTile(int Index);
 bool IsValidGameTile(int Index);
 bool IsValidFrontTile(int Index);
+bool IsValidTeleTile(int Index);
 bool IsValidEntity(int Index);
 
 #endif


### PR DESCRIPTION
Some fixes for editor while editing  switch layer
-removed unused entities
-fixed (added) rotation for switch indicators (number/delay) ( tiles has only rotation possibility before)
- added tiles rotation possibility for switch layer (Its useless but not less useless as for almost all game/front tiles)