### PR TITLE
Don't send disconnect on timeout

### DIFF
--- a/src/engine/shared/network_conn.cpp
+++ b/src/engine/shared/network_conn.cpp
@@ -201,10 +201,13 @@ void CNetConnection::Disconnect(const char *pReason)
 
 	if(m_RemoteClosed == 0)
 	{
-		if(pReason)
-			SendControl(NET_CTRLMSG_CLOSE, pReason, str_length(pReason)+1);
-		else
-			SendControl(NET_CTRLMSG_CLOSE, 0, 0);
+		if(!m_TimeoutSituation)
+		{
+			if(pReason)
+				SendControl(NET_CTRLMSG_CLOSE, pReason, str_length(pReason)+1);
+			else
+				SendControl(NET_CTRLMSG_CLOSE, 0, 0);
+		}
 
 		if(pReason != m_ErrorString)
 		{


### PR DESCRIPTION
During the recent ddos attacks I realized that the client sends a disconnect message to the server when it doesn't recieve a message for the time set by the setting `conn_timeout`. Often that happened and despite there were no messages reaching the client for 15 seconds that disconnect message reached the server which stopped the timeout protection from working.

I'm still testing if this solves the problem, don't merge yet!