### PR TITLE
Send chat message when team is unlocked by a tile

### DIFF
--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -1590,9 +1590,13 @@ void CCharacter::HandleTiles(int Index)
 	}
 
 	// unlock team
-	else if((m_TileIndex == TILE_UNLOCK_TEAM) || (m_TileFIndex == TILE_UNLOCK_TEAM))
+	else if(((m_TileIndex == TILE_UNLOCK_TEAM) || (m_TileFIndex == TILE_UNLOCK_TEAM)) && Teams()->TeamLocked(Team()))
 	{
 		Teams()->SetTeamLock(Team(), false);
+
+		for(int i = 0; i < MAX_CLIENTS; i++)
+			if(Teams()->m_Core.Team(i) == Team())
+				GameServer()->SendChatTarget(i, "Your team was unlocked by a unlock team tile.");
 	}
 
 	// solo part


### PR DESCRIPTION
The new dummy map "Greed" kills the dummy without warning you before and just places unlock team tiles before, I feel like this is going to get more common now because of the unlock team tiles. Because I didn't notice that my team was unlocked with clear entities turned off I panicked when I saw my dummy out of the map and used `/lock` which locked my team again which was unlocked by the unlock team tiles. I think the same happened to Fňokurka oo7: https://forum.ddnet.tw/viewtopic.php?f=6&t=4&p=40318#p40318