### PR TITLE
Basic DNSBL implementation

### DIFF
--- a/src/engine/server.h
+++ b/src/engine/server.h
@@ -166,6 +166,7 @@ public:
 
 	virtual int* GetIdMap(int ClientID) = 0;
 
+	virtual bool DnsblWhite(int ClientID) = 0;
 };
 
 class IGameServer : public IInterface

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -3,6 +3,7 @@
 #ifndef ENGINE_SERVER_SERVER_H
 #define ENGINE_SERVER_SERVER_H
 
+#include <engine/engine.h>
 #include <engine/server.h>
 
 #include <engine/map.h>
@@ -116,7 +117,12 @@ public:
 
 			SNAPRATE_INIT=0,
 			SNAPRATE_FULL,
-			SNAPRATE_RECOVER
+			SNAPRATE_RECOVER,
+
+			DNSBL_STATE_NONE=0,
+			DNSBL_STATE_PENDING,
+			DNSBL_STATE_BLACKLISTED,
+			DNSBL_STATE_WHITELISTED,
 		};
 
 		class CInput
@@ -156,6 +162,10 @@ public:
 		// DDRace
 
 		NETADDR m_Addr;
+
+		// DNSBL
+		int m_DnsblState;
+		CHostLookup m_DnsblLookup;
 	};
 
 	CClient m_aClients[MAX_CLIENTS];
@@ -320,6 +330,12 @@ public:
 
 	virtual int* GetIdMap(int ClientID);
 
+	void InitDnsbl(int ClientID);
+	bool DnsblWhite(int ClientID)
+	{
+		return m_aClients[ClientID].m_DnsblState == CClient::DNSBL_STATE_NONE ||
+		m_aClients[ClientID].m_DnsblState == CClient::DNSBL_STATE_WHITELISTED;
+	}
 };
 
 #endif

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -292,6 +292,7 @@ public:
 	static void ConStopRecord(IConsole::IResult *pResult, void *pUser);
 	static void ConMapReload(IConsole::IResult *pResult, void *pUser);
 	static void ConLogout(IConsole::IResult *pResult, void *pUser);
+	static void ConDnsblStatus(IConsole::IResult *pResult, void *pUser);
 
 #if defined (CONF_SQL)
 	// console commands for sqlmasters

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -153,6 +153,7 @@ MACRO_CONFIG_INT(SvVanillaAntiSpoof, sv_vanilla_antispoof, 1, 0, 1, CFGFLAG_SERV
 MACRO_CONFIG_INT(SvDnsbl, sv_dnsbl, 0, 0, 1, CFGFLAG_SERVER, "Enable DNSBL (DNS-based Blackhole List)")
 MACRO_CONFIG_STR(SvDnsblHost, sv_dnsbl_host, 128, "", CFGFLAG_SERVER, "Hostname of DNSBL provider to use for IP Verification")
 MACRO_CONFIG_STR(SvDnsblKey, sv_dnsbl_key, 128, "", CFGFLAG_SERVER, "Optional Authentification Key for the specified DNSBL provider")
+MACRO_CONFIG_INT(SvDnsblVote, sv_dnsbl_vote, 0, 0, 1, CFGFLAG_SERVER, "Block votes by blacklisted addresses")
 MACRO_CONFIG_INT(SvDnsblBan, sv_dnsbl_ban, 0, 0, 1, CFGFLAG_SERVER, "Automatically ban blacklisted addresses")
 
 

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -150,6 +150,11 @@ MACRO_CONFIG_INT(SvRconBantime, sv_rcon_bantime, 5, 0, 1440, CFGFLAG_SERVER, "Th
 MACRO_CONFIG_INT(SvAutoDemoRecord, sv_auto_demo_record, 0, 0, 1, CFGFLAG_SERVER, "Automatically record demos")
 MACRO_CONFIG_INT(SvAutoDemoMax, sv_auto_demo_max, 10, 0, 1000, CFGFLAG_SERVER, "Maximum number of automatically recorded demos (0 = no limit)")
 MACRO_CONFIG_INT(SvVanillaAntiSpoof, sv_vanilla_antispoof, 1, 0, 1, CFGFLAG_SERVER, "Enable vanilla Antispoof")
+MACRO_CONFIG_INT(SvDnsbl, sv_dnsbl, 0, 0, 1, CFGFLAG_SERVER, "Enable DNSBL (DNS-based Blackhole List)")
+MACRO_CONFIG_STR(SvDnsblHost, sv_dnsbl_host, 128, "", CFGFLAG_SERVER, "Hostname of DNSBL provider to use for IP Verification")
+MACRO_CONFIG_STR(SvDnsblKey, sv_dnsbl_key, 128, "", CFGFLAG_SERVER, "Optional Authentification Key for the specified DNSBL provider")
+MACRO_CONFIG_INT(SvDnsblBan, sv_dnsbl_ban, 0, 0, 1, CFGFLAG_SERVER, "Automatically ban blacklisted addresses")
+
 
 MACRO_CONFIG_INT(SvPlayerDemoRecord, sv_player_demo_record, 0, 0, 1, CFGFLAG_SERVER, "Automatically record demos for each player")
 MACRO_CONFIG_INT(SvDemoChat, sv_demo_chat, 0, 0, 1, CFGFLAG_SERVER, "Record chat for demos")

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -653,6 +653,10 @@ void CGameContext::OnTick()
 					if(m_apPlayers[i]->m_Afk && i != m_VoteCreator)
 						continue;
 
+					// don't count votes by blacklisted clients
+					if (!m_pServer->DnsblWhite(i))
+						continue;
+
 					int ActVote = m_apPlayers[i]->m_Vote;
 					int ActVotePos = m_apPlayers[i]->m_VotePos;
 
@@ -1150,6 +1154,13 @@ void CGameContext::OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID)
 		{
 			int64 Now = Server()->Tick();
 			int64 TickSpeed = Server()->TickSpeed();
+
+			if (!m_pServer->DnsblWhite(ClientID))
+			{
+				// blacklisted by dnsbl
+				SendChatTarget(ClientID, "You are not allowed to vote due to DNSBL");
+				return;
+			}
 
 			if(g_Config.m_SvSpamprotection && pPlayer->m_LastVoteTry && pPlayer->m_LastVoteTry + TickSpeed * 3 > Now)
 				return;

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -654,7 +654,7 @@ void CGameContext::OnTick()
 						continue;
 
 					// don't count votes by blacklisted clients
-					if (!m_pServer->DnsblWhite(i))
+					if (g_Config.m_SvDnsblVote && !m_pServer->DnsblWhite(i))
 						continue;
 
 					int ActVote = m_apPlayers[i]->m_Vote;
@@ -1155,7 +1155,7 @@ void CGameContext::OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID)
 			int64 Now = Server()->Tick();
 			int64 TickSpeed = Server()->TickSpeed();
 
-			if (!m_pServer->DnsblWhite(ClientID))
+			if (g_Config.m_SvDnsblVote && !m_pServer->DnsblWhite(ClientID))
 			{
 				// blacklisted by dnsbl
 				SendChatTarget(ClientID, "You are not allowed to vote due to DNSBL");


### PR DESCRIPTION
Basic implementation of a "DNS-based Blackhole List" resolver

Can be used to block ip-addresses that are flagged as malicious / spam by anti-spam companies (eg. NiX Spam, Spamhaus, SpamCop, ...).

Options:
- sv_dnsbl - enable/disable
- sv_dnsbl_host - host of DNSBL provider
- sv_dnsbl_key - optional auth key
- sv_dnsbl_vote - prevent voting by blacklisted addresses
- sv_dnsbl_ban - ban blacklisted addresses (Warning: client might be able to join before the ban is triggered)

The implementation is rather passive and can also be used as drop-in solution (can be enabled/disabled at runtime).

//edit:
- dnsbl_status added (dumps a list of all blacklisted clients currently connected to the server)