### PR TITLE
Generate server-specific timeout codes

### DIFF
--- a/src/base/system.c
+++ b/src/base/system.c
@@ -2559,12 +2559,13 @@ void generate_password(char *buffer, unsigned length, unsigned short *random, un
 {
 	static const char VALUES[] = "ABCDEFGHKLMNPRSTUVWXYZabcdefghjkmnopqt23456789";
 	static const size_t NUM_VALUES = sizeof(VALUES) - 1; // Disregard the '\0'.
+	unsigned i;
 	dbg_assert(length >= random_length * 2 + 1, "too small buffer");
 	dbg_assert(NUM_VALUES * NUM_VALUES >= 2048, "need at least 2048 possibilities for 2-character sequences");
 
 	buffer[random_length * 2] = 0;
 
-	for(size_t i = 0; i < random_length; i++)
+	for(i = 0; i < random_length; i++)
 	{
 		unsigned short random_number = random[i] % 2048;
 		buffer[2 * i + 0] = VALUES[random_number / NUM_VALUES];
@@ -2575,13 +2576,13 @@ void generate_password(char *buffer, unsigned length, unsigned short *random, un
 void secure_random_password(char *buffer, unsigned length, unsigned pw_length)
 {
 	static const size_t MAX_PASSWORD_LENGTH = 128;
+	unsigned short random[MAX_PASSWORD_LENGTH / 2];
 	// With 6 characters, we get a password entropy of log(2048) * 6/2 = 33bit.
 	dbg_assert(length >= pw_length + 1, "too small buffer");
 	dbg_assert(pw_length >= 6, "too small password length");
 	dbg_assert(pw_length % 2 == 0, "need an even password length");
 	dbg_assert(pw_length <= MAX_PASSWORD_LENGTH, "too large password length");
 
-	unsigned short random[MAX_PASSWORD_LENGTH / 2];
 	secure_random_fill(random, pw_length);
 
 	generate_password(buffer, length, random, pw_length / 2);

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -1376,6 +1376,20 @@ void shell_execute(const char *file);
 int os_compare_version(int major, int minor);
 
 /*
+	Function: generate_password
+		Generates a null-terminated password of length `2 *
+		random_length`.
+
+
+	Parameters:
+		buffer - Pointer to the start of the output buffer.
+		length - Length of the buffer.
+		random - Pointer to a randomly-initialized array of shorts.
+		random_length - Length of the short array.
+*/
+void generate_password(char *buffer, unsigned length, unsigned short *random, unsigned random_length);
+
+/*
 	Function: secure_random_init
 		Initializes the secure random module.
 		You *MUST* check the return value of this function.
@@ -1387,6 +1401,21 @@ int os_compare_version(int major, int minor);
 int secure_random_init();
 
 /*
+	Function: secure_random_password
+		Fills the buffer with the specified amount of random password
+		characters.
+
+		The desired password length must be greater or equal to 6, even
+		and smaller or equal to 128.
+
+	Parameters:
+		buffer - Pointer to the start of the buffer.
+		length - Length of the buffer.
+		pw_length - Length of the desired password.
+*/
+void secure_random_password(char *buffer, unsigned length, unsigned pw_length);
+
+/*
 	Function: secure_random_fill
 		Fills the buffer with the specified amount of random bytes.
 
@@ -1394,7 +1423,7 @@ int secure_random_init();
 		buffer - Pointer to the start of the buffer.
 		length - Length of the buffer.
 */
-void secure_random_fill(void *bytes, size_t length);
+void secure_random_fill(void *bytes, unsigned length);
 
 /*
 	Function: secure_rand

--- a/src/engine/client.h
+++ b/src/engine/client.h
@@ -195,6 +195,8 @@ public:
 	virtual void RequestDDNetSrvList() = 0;
 	virtual bool EditorHasUnsavedData() = 0;
 
+	virtual void GenerateTimeoutSeed() = 0;
+
 	virtual IFriends* Foes() = 0;
 };
 

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -728,7 +728,7 @@ void CClient::GenerateTimeoutCodes()
 	else
 	{
 		str_copy(m_aTimeoutCodes[0], g_Config.m_ClTimeoutCode, sizeof(m_aTimeoutCodes[0]));
-		str_copy(m_aTimeoutCodes[0], g_Config.m_ClDummyTimeoutCode, sizeof(m_aTimeoutCodes[0]));
+		str_copy(m_aTimeoutCodes[1], g_Config.m_ClDummyTimeoutCode, sizeof(m_aTimeoutCodes[1]));
 	}
 }
 

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -706,10 +706,7 @@ void GenerateTimeoutCode(char *pBuffer, unsigned Size, char *pSeed, const NETADD
 
 void CClient::GenerateTimeoutSeed()
 {
-	if(m_GenerateTimeoutSeed)
-	{
-		secure_random_password(g_Config.m_ClTimeoutSeed, sizeof(g_Config.m_ClTimeoutSeed), 16);
-	}
+	secure_random_password(g_Config.m_ClTimeoutSeed, sizeof(g_Config.m_ClTimeoutSeed), 16);
 }
 
 void CClient::GenerateTimeoutCodes()
@@ -2629,7 +2626,10 @@ void CClient::Run()
 	m_LocalStartTime = time_get();
 	m_SnapshotParts = 0;
 
-	GenerateTimeoutSeed();
+	if(m_GenerateTimeoutSeed)
+	{
+		GenerateTimeoutSeed();
+	}
 
 	unsigned int Seed;
 	secure_random_fill(&Seed, sizeof(Seed));

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -119,7 +119,9 @@ class CClient : public IClient, public CDemoPlayer::IListener
 	char m_aCurrentMapPath[CEditor::MAX_PATH_LENGTH];
 	unsigned m_CurrentMapCrc;
 
-	bool m_TimeoutCodeSent[2];
+	char m_aTimeoutCodes[2][32];
+	bool m_aTimeoutCodeSent[2];
+	bool m_GenerateTimeoutSeed;
 
 	//
 	char m_aCmdConnect[256];
@@ -342,6 +344,7 @@ public:
 	static void ConchainWindowBordered(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 	static void ConchainWindowScreen(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 	static void ConchainWindowVSync(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
+	static void ConchainTimeoutSeed(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 
 	static void Con_DemoSlice(IConsole::IResult *pResult, void *pUserData);
 	static void Con_DemoSliceBegin(IConsole::IResult *pResult, void *pUserData);
@@ -370,6 +373,9 @@ public:
 	void ToggleWindowVSync();
 
 	// DDRace
+
+	void GenerateTimeoutSeed();
+	void GenerateTimeoutCodes();
 
 	virtual const char* GetCurrentMap();
 	virtual int GetCurrentMapCrc();

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -559,26 +559,7 @@ void CServer::InitRconPasswordIfEmpty()
 		return;
 	}
 
-	static const char VALUES[] = "ABCDEFGHKLMNPRSTUVWXYZabcdefghjkmnopqt23456789";
-	static const size_t NUM_VALUES = sizeof(VALUES) - 1; // Disregard the '\0'.
-	static const size_t PASSWORD_LENGTH = 6;
-	dbg_assert(NUM_VALUES * NUM_VALUES >= 2048, "need at least 2048 possibilities for 2-character sequences");
-	// With 6 characters, we get a password entropy of log(2048) * 6/2 = 33bit.
-
-	dbg_assert(PASSWORD_LENGTH % 2 == 0, "need an even password length");
-	unsigned short aRandom[PASSWORD_LENGTH / 2];
-	char aRandomPassword[PASSWORD_LENGTH+1];
-	aRandomPassword[PASSWORD_LENGTH] = 0;
-
-	secure_random_fill(aRandom, sizeof(aRandom));
-	for(size_t i = 0; i < PASSWORD_LENGTH / 2; i++)
-	{
-		unsigned short RandomNumber = aRandom[i] % 2048;
-		aRandomPassword[2 * i + 0] = VALUES[RandomNumber / NUM_VALUES];
-		aRandomPassword[2 * i + 1] = VALUES[RandomNumber % NUM_VALUES];
-	}
-
-	str_copy(g_Config.m_SvRconPassword, aRandomPassword, sizeof(g_Config.m_SvRconPassword));
+	secure_random_password(g_Config.m_SvRconPassword, sizeof(g_Config.m_SvRconPassword), 6);
 	m_GeneratedRconPassword = 1;
 }
 

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -363,6 +363,7 @@ MACRO_CONFIG_INT(ClOldGunPosition, cl_old_gun_position, 0, 0, 1, CFGFLAG_SAVE|CF
 MACRO_CONFIG_INT(ClConfirmDisconnect, cl_confirm_disconnect, 0, 0, 1, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Confirmation popup before disconnecting")
 MACRO_CONFIG_STR(ClTimeoutCode, cl_timeout_code, 64, "", CFGFLAG_SAVE|CFGFLAG_CLIENT, "Timeout code to use")
 MACRO_CONFIG_STR(ClDummyTimeoutCode, cl_dummy_timeout_code, 64, "", CFGFLAG_SAVE|CFGFLAG_CLIENT, "Dummy Timeout code to use")
+MACRO_CONFIG_STR(ClTimeoutSeed, cl_timeout_seed, 64, "", CFGFLAG_SAVE|CFGFLAG_CLIENT, "Timeout seed")
 MACRO_CONFIG_STR(ClInputFifo, cl_input_fifo, 128, "", CFGFLAG_SAVE|CFGFLAG_CLIENT, "Fifo file to use as input for client console")
 MACRO_CONFIG_INT(ClShowConsole, cl_show_console, 0, 0, 1, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Show console window (Windows only)")
 #if defined(__ANDROID__)

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -2020,24 +2020,11 @@ void CMenus::RenderSettingsDDNet(CUIRect MainView)
 #endif
 
 	{
+		static int s_ButtonTimeout = 0;
 		Right.HSplitTop(20.0f, &Button, &Right);
-		Button.VSplitLeft(190.0f, &Label, &Button);
-		char aBuf[128];
-		str_format(aBuf, sizeof(aBuf), "%s:", Localize("Timeout code"));
-		UI()->DoLabelScaled(&Label, aBuf, 14.0, -1);
-		static float s_OffsetCode = 0.0f;
-		DoEditBox(g_Config.m_ClTimeoutCode, &Button, g_Config.m_ClTimeoutCode, sizeof(g_Config.m_ClTimeoutCode), 14.0f, &s_OffsetCode);
-	}
-
-	Right.HSplitTop(5.0f, &Button, &Right);
-
-	{
-		Right.HSplitTop(20.0f, &Button, &Right);
-		Button.VSplitLeft(190.0f, &Label, &Button);
-		char aBuf[128];
-		str_format(aBuf, sizeof(aBuf), "%s:", Localize("Dummy Timeout code"));
-		UI()->DoLabelScaled(&Label, aBuf, 14.0, -1);
-		static float s_OffsetCode = 0.0f;
-		DoEditBox(g_Config.m_ClDummyTimeoutCode, &Button, g_Config.m_ClDummyTimeoutCode, sizeof(g_Config.m_ClDummyTimeoutCode), 14.0f, &s_OffsetCode);
+		if(DoButton_Menu(&s_ButtonTimeout, Localize("New random timeout code"), 0, &Button))
+		{
+			Client()->GenerateTimeoutSeed();
+		}
 	}
 }


### PR DESCRIPTION
This way, servers can no longer hijack the timeout codes of clients.
Timeout codes are generated from md5(seed + dummy + server address).

If `cl_timeout_seed` is set to the empty string, the old config options
are used instead.