### PR TITLE
Fix .gitignore excluding some src directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,21 +9,21 @@ SDL.dll
 SDL2.dll
 freetype.dll
 
-crapnet*
-config_store*
-config_retrieve*
-dilate*
-fake_server*
-map_resave*
-map_version*
-mastersrv*
-packetgen*
-teeworlds*
-teeworlds_srv*
-serverlaunch_*
-tileset_border*
-twping*
-versionsrv*
+/crapnet*
+/config_store*
+/config_retrieve*
+/dilate*
+/fake_server*
+/map_resave*
+/map_version*
+/mastersrv*
+/packetgen*
+/teeworlds*
+/teeworlds_srv*
+/serverlaunch_*
+/tileset_border*
+/twping*
+/versionsrv*
 
 Debug
 bam


### PR DESCRIPTION
`.gitignore` used to exclude `/src/versionsrv` as well as `/src/mastersrv` from git.