### PR TITLE
dummy copyMoves/hammer disabling when dummy connecting

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -841,6 +841,9 @@ void CClient::DummyConnect()
 
 	m_DummySendConnInfo = true;
 
+	g_Config.m_ClDummyCopyMoves = 0;
+	g_Config.m_ClDummyHammer = 0;
+
 	//connecting to the server
 	m_NetClient[1].Connect(&m_ServerAddress);
 }

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -619,7 +619,6 @@ void CGameClient::OnDummyDisconnect()
 	m_DDRaceMsgSent[1] = false;
 	m_ShowOthers[1] = -1;
 	m_LastNewPredictedTick[1] = -1;
-	g_Config.m_ClDummyCopyMoves = 0;
 }
 
 void CGameClient::OnRelease()


### PR DESCRIPTION
#529

disabling copy moves during connecting is better than during disconnecting, in case for example the copy moves key was accidentally pressed while the primary tee was beating the noobfilter
