### PR TITLE
cl_overlay_entities_show_unused

### DIFF
--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -300,6 +300,7 @@ MACRO_CONFIG_INT(SvResetPickups, sv_reset_pickups, 0, 0, 1, CFGFLAG_SERVER|CFGFL
 MACRO_CONFIG_INT(ClShowOthers, cl_show_others, 0, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Show players in other teams")
 MACRO_CONFIG_INT(ClShowOthersAlpha, cl_show_others_alpha, 40, 0, 100, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Show players in other teams (alpha value, 0 invisible, 100 fully visible)")
 MACRO_CONFIG_INT(ClOverlayEntities, cl_overlay_entities, 0, 0, 100, CFGFLAG_CLIENT, "Overlay game tiles with a percentage of opacity")
+MACRO_CONFIG_INT(ClOverlayEntitiesShowUnused, cl_overlay_entities_show_unused, 1, 0, 1, CFGFLAG_CLIENT, "Show overlay game tiles not used in DDNet")
 MACRO_CONFIG_INT(ClShowQuads, cl_show_quads, 1, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Show quads")
 MACRO_CONFIG_INT(ClZoomBackgroundLayers, cl_zoom_background_layers, 0, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Zoom background layers")
 MACRO_CONFIG_INT(ClBackgroundHue, cl_background_hue, 0, 0, 255, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Background color hue")

--- a/src/game/client/components/maplayers.cpp
+++ b/src/game/client/components/maplayers.cpp
@@ -258,10 +258,10 @@ void CMapLayers::OnRender()
 						if(!IsGameLayer && g_Config.m_ClOverlayEntities)
 							Color = vec4(pTMap->m_Color.r/255.0f, pTMap->m_Color.g/255.0f, pTMap->m_Color.b/255.0f, pTMap->m_Color.a/255.0f*(100-g_Config.m_ClOverlayEntities)/100.0f);
 						RenderTools()->RenderTilemap(pTiles, pTMap->m_Width, pTMap->m_Height, 32.0f, Color, TILERENDERFLAG_EXTEND|LAYERRENDERFLAG_OPAQUE,
-														EnvelopeEval, this, pTMap->m_ColorEnv, pTMap->m_ColorEnvOffset);
+														EnvelopeEval, this, pTMap->m_ColorEnv, pTMap->m_ColorEnvOffset, IsValidGameTile);
 						Graphics()->BlendNormal();
 						RenderTools()->RenderTilemap(pTiles, pTMap->m_Width, pTMap->m_Height, 32.0f, Color, TILERENDERFLAG_EXTEND|LAYERRENDERFLAG_TRANSPARENT,
-														EnvelopeEval, this, pTMap->m_ColorEnv, pTMap->m_ColorEnvOffset);
+														EnvelopeEval, this, pTMap->m_ColorEnv, pTMap->m_ColorEnvOffset, IsValidGameTile);
 					}
 				}
 				else if(pLayer->m_Type == LAYERTYPE_QUADS)
@@ -293,10 +293,10 @@ void CMapLayers::OnRender()
 					Graphics()->BlendNone();
 					vec4 Color = vec4(pTMap->m_Color.r/255.0f, pTMap->m_Color.g/255.0f, pTMap->m_Color.b/255.0f, pTMap->m_Color.a/255.0f*g_Config.m_ClOverlayEntities/100.0f);
 					RenderTools()->RenderTilemap(pFrontTiles, pTMap->m_Width, pTMap->m_Height, 32.0f, Color, TILERENDERFLAG_EXTEND|LAYERRENDERFLAG_OPAQUE,
-							EnvelopeEval, this, pTMap->m_ColorEnv, pTMap->m_ColorEnvOffset);
+							EnvelopeEval, this, pTMap->m_ColorEnv, pTMap->m_ColorEnvOffset, IsValidFrontTile);
 					Graphics()->BlendNormal();
 					RenderTools()->RenderTilemap(pFrontTiles, pTMap->m_Width, pTMap->m_Height, 32.0f, Color, TILERENDERFLAG_EXTEND|LAYERRENDERFLAG_TRANSPARENT,
-							EnvelopeEval, this, pTMap->m_ColorEnv, pTMap->m_ColorEnvOffset);
+							EnvelopeEval, this, pTMap->m_ColorEnv, pTMap->m_ColorEnvOffset, IsValidFrontTile);
 				}
 			}
 			else if(Render && g_Config.m_ClOverlayEntities && IsSwitchLayer)

--- a/src/game/client/render.h
+++ b/src/game/client/render.h
@@ -75,7 +75,7 @@ public:
 	static void RenderEvalEnvelope(CEnvPoint *pPoints, int NumPoints, int Channels, float Time, float *pResult);
 	void RenderQuads(CQuad *pQuads, int NumQuads, int Flags, ENVELOPE_EVAL pfnEval, void *pUser);
 	void ForceRenderQuads(CQuad *pQuads, int NumQuads, int Flags, ENVELOPE_EVAL pfnEval, void *pUser, float Alpha = 1.0f);
-	void RenderTilemap(CTile *pTiles, int w, int h, float Scale, vec4 Color, int RenderFlags, ENVELOPE_EVAL pfnEval, void *pUser, int ColorEnv, int ColorEnvOffset);
+	void RenderTilemap(CTile *pTiles, int w, int h, float Scale, vec4 Color, int RenderFlags, ENVELOPE_EVAL pfnEval, void *pUser, int ColorEnv, int ColorEnvOffset, bool tileCheck(int Index) = NULL);
 
 	// helpers
 	void MapscreenToWorld(float CenterX, float CenterY, float ParallaxX, float ParallaxY,

--- a/src/game/client/render_map.cpp
+++ b/src/game/client/render_map.cpp
@@ -177,7 +177,7 @@ void CRenderTools::ForceRenderQuads(CQuad *pQuads, int NumQuads, int RenderFlags
 }
 
 void CRenderTools::RenderTilemap(CTile *pTiles, int w, int h, float Scale, vec4 Color, int RenderFlags,
-									ENVELOPE_EVAL pfnEval, void *pUser, int ColorEnv, int ColorEnvOffset)
+									ENVELOPE_EVAL pfnEval, void *pUser, int ColorEnv, int ColorEnvOffset, bool tileCheck(int Index))
 {
 	//Graphics()->TextureSet(img_get(tmap->image));
 	float ScreenX0, ScreenY0, ScreenX1, ScreenY1;
@@ -245,6 +245,10 @@ void CRenderTools::RenderTilemap(CTile *pTiles, int w, int h, float Scale, vec4 
 			int c = mx + my*w;
 
 			unsigned char Index = pTiles[c].m_Index;
+
+			if (!g_Config.m_ClOverlayEntitiesShowUnused && tileCheck != NULL && !(tileCheck(Index)))
+				continue;
+			
 			if(Index)
 			{
 				unsigned char Flags = pTiles[c].m_Flags;
@@ -357,6 +361,10 @@ void CRenderTools::RenderTeleOverlay(CTeleTile *pTele, int w, int h, float Scale
 			int c = mx + my*w;
 
 			unsigned char Index = pTele[c].m_Number;
+
+			if (!g_Config.m_ClOverlayEntitiesShowUnused && !IsValidTeleTile(Index))
+				continue;
+
 			if(Index && pTele[c].m_Type != TILE_TELECHECKIN && pTele[c].m_Type != TILE_TELECHECKINEVIL)
 			{
 				char aBuf[16];
@@ -399,6 +407,11 @@ void CRenderTools::RenderSpeedupOverlay(CSpeedupTile *pSpeedup, int w, int h, fl
 				continue; // my = h-1;
 
 			int c = mx + my*w;
+
+			unsigned char Index = pSpeedup[c].m_Type;
+
+			if (!g_Config.m_ClOverlayEntitiesShowUnused && !IsValidSpeedupTile(Index))
+				continue;
 
 			int Force = (int)pSpeedup[c].m_Force;
 			int MaxSpeed = (int)pSpeedup[c].m_MaxSpeed;
@@ -471,6 +484,10 @@ void CRenderTools::RenderSwitchOverlay(CSwitchTile *pSwitch, int w, int h, float
 			int c = mx + my*w;
 
 			unsigned char Index = pSwitch[c].m_Number;
+
+			if (!g_Config.m_ClOverlayEntitiesShowUnused && !IsValidSwitchTile(Index))
+				continue;
+
 			if(Index)
 			{
 				char aBuf[16];
@@ -529,6 +546,10 @@ void CRenderTools::RenderTuneOverlay(CTuneTile *pTune, int w, int h, float Scale
 			int c = mx + my*w;
 
 			unsigned char Index = pTune[c].m_Number;
+
+			if (!g_Config.m_ClOverlayEntitiesShowUnused && !IsValidTuneTile(Index))
+				continue;
+
 			if(Index)
 			{
 				char aBuf[16];
@@ -597,6 +618,10 @@ void CRenderTools::RenderTelemap(CTeleTile *pTele, int w, int h, float Scale, ve
 			int c = mx + my*w;
 
 			unsigned char Index = pTele[c].m_Type;
+
+			if (!g_Config.m_ClOverlayEntitiesShowUnused && !IsValidTeleTile(Index))
+				continue;
+
 			if(Index)
 			{
 				bool Render = false;
@@ -690,6 +715,10 @@ void CRenderTools::RenderSpeedupmap(CSpeedupTile *pSpeedupTile, int w, int h, fl
 			int c = mx + my*w;
 
 			unsigned char Index = pSpeedupTile[c].m_Type;
+
+			if (!g_Config.m_ClOverlayEntitiesShowUnused && !IsValidSpeedupTile(Index))
+				continue;
+
 			if(Index)
 			{
 				bool Render = false;
@@ -783,6 +812,10 @@ void CRenderTools::RenderSwitchmap(CSwitchTile *pSwitchTile, int w, int h, float
 			int c = mx + my*w;
 
 			unsigned char Index = pSwitchTile[c].m_Type;
+
+			if (!g_Config.m_ClOverlayEntitiesShowUnused && !IsValidSwitchTile(Index))
+				continue;
+
 			if(Index)
 			{
 				if(Index == TILE_SWITCHTIMEDOPEN)
@@ -917,6 +950,10 @@ void CRenderTools::RenderTunemap(CTuneTile *pTune, int w, int h, float Scale, ve
 			int c = mx + my*w;
 
 			unsigned char Index = pTune[c].m_Type;
+
+			if (!g_Config.m_ClOverlayEntitiesShowUnused && !IsValidTuneTile(Index))
+				continue;
+
 			if(Index)
 			{
 				bool Render = false;

--- a/src/game/mapitems.cpp
+++ b/src/game/mapitems.cpp
@@ -2,48 +2,75 @@
 
 bool IsValidGameTile(int Index)
 {
-	return (
-		    Index == TILE_AIR
-		|| (Index >= TILE_SOLID && Index <= TILE_NOLASER)
-		||  Index == TILE_THROUGH
-		||  Index == TILE_FREEZE
-		|| (Index >= TILE_UNFREEZE && Index <= TILE_DUNFREEZE)
+	return ((Index >= TILE_AIR && Index <= TILE_THROUGH)
+		|| Index == TILE_FREEZE
+		|| Index == TILE_UNFREEZE
+		|| Index == TILE_DFREEZE
+		|| Index == TILE_DUNFREEZE
 		|| (Index >= TILE_WALLJUMP && Index <= TILE_SOLO_END)
 		|| (Index >= TILE_REFILL_JUMPS && Index <= TILE_STOPA)
 		|| (Index >= TILE_CP && Index <= TILE_THROUGH_DIR)
 		|| (Index >= TILE_OLDLASER && Index <= TILE_UNLOCK_TEAM)
 		|| (Index >= TILE_NPC_END && Index <= TILE_NPH_END)
 		|| (Index >= TILE_NPC_START && Index <= TILE_NPH_START)
-		|| (Index >= TILE_ENTITIES_OFF_1 && Index <= TILE_ENTITIES_OFF_2)
-		||  IsValidEntity(Index)
-	);
+		|| Index == TILE_ENTITIES_OFF_1
+		|| Index == TILE_ENTITIES_OFF_2
+		|| IsValidEntity(Index)
+		);
 }
 
 bool IsValidFrontTile(int Index)
 {
-	return (
-		    Index == TILE_AIR
-		||  Index == TILE_DEATH
-		|| (Index >= TILE_NOLASER && Index <= TILE_THROUGH)
-		||  Index == TILE_FREEZE
-		|| (Index >= TILE_UNFREEZE && Index <= TILE_DUNFREEZE)
-		|| (Index >= TILE_WALLJUMP && Index <= TILE_SOLO_END)
-		|| (Index >= TILE_REFILL_JUMPS && Index <= TILE_STOPA)
-		|| (Index >= TILE_CP && Index <= TILE_THROUGH_DIR)
-		|| (Index >= TILE_OLDLASER && Index <= TILE_UNLOCK_TEAM)
-		|| (Index >= TILE_NPC_END && Index <= TILE_NPH_END)
-		|| (Index >= TILE_NPC_START && Index <= TILE_NPH_START)
-		||  IsValidEntity(Index)
-	);
+	return (IsValidGameTile(Index) && (Index != TILE_SOLID) && (Index != TILE_NOHOOK) && (Index != TILE_ENTITIES_OFF_1) && (Index != TILE_ENTITIES_OFF_1));
 }
 
+bool IsValidTeleTile(int Index)
+{
+	return (
+		Index == TILE_TELEINEVIL
+		|| Index == TILE_TELEINWEAPON
+		|| Index == TILE_TELEINHOOK
+		|| Index == TILE_TELEIN
+		|| Index == TILE_TELEOUT
+		|| Index == TILE_TELECHECK
+		|| Index == TILE_TELECHECKOUT
+		|| Index == TILE_TELECHECKIN
+		|| Index == TILE_TELECHECKINEVIL
+		);
+}
+
+bool IsValidSwitchTile(int Index)
+{
+	return (
+		Index == TILE_JUMP
+		|| Index == TILE_FREEZE
+		|| Index == TILE_DFREEZE
+		|| Index == TILE_DUNFREEZE
+		|| Index == TILE_HIT_START
+		|| Index == TILE_HIT_END
+		|| (Index >= TILE_SWITCHTIMEDOPEN && Index <= TILE_SWITCHCLOSE)
+		|| Index == TILE_PENALTY
+		|| Index == TILE_BONUS
+		|| (Index <= ENTITY_ARMOR_1 - ENTITY_OFFSET && IsValidEntity(Index))
+		);
+}
+
+bool IsValidSpeedupTile(int Index)
+{
+	return (Index == 28);
+}
+
+bool IsValidTuneTile(int Index)
+{
+	return (Index == 68);
+}
 bool IsValidEntity(int Index)
 {
 	Index -= ENTITY_OFFSET;
 	return (
-		   (Index >= ENTITY_SPAWN && Index <= ENTITY_LASER_O_FAST)
+		(Index >= ENTITY_SPAWN && Index <= ENTITY_LASER_O_FAST)
 		|| (Index >= ENTITY_PLASMAE && Index <= ENTITY_CRAZY_SHOTGUN)
 		|| (Index >= ENTITY_DRAGGER_WEAK && Index <= ENTITY_DRAGGER_STRONG_NW)
-		||  Index == ENTITY_DOOR
-	);
+		|| Index == ENTITY_DOOR
+		);
 }

--- a/src/game/mapitems.h
+++ b/src/game/mapitems.h
@@ -458,6 +458,10 @@ public:
 
 bool IsValidGameTile(int Index);
 bool IsValidFrontTile(int Index);
+bool IsValidTeleTile(int Index);
+bool IsValidSwitchTile(int Index);
+bool IsValidSpeedupTile(int Index);
+bool IsValidTuneTile(int Index);
 bool IsValidEntity(int Index);
 
 #endif


### PR DESCRIPTION
Since 4a22e762ffa12ca02bec21d1470212ace0d03fd8 some maps may contain visible unused tiles in DDNet, which not affect on gameplay.
Added possibiliy to hide such tiles for players, who use overlay entities for playing on DDNet mode.

Fix for #580

Maybe I should drop it there : I`m done with this pr.