### PR TITLE
give cl_mouse_max_distance a min of 25 to block the perfect aim glitch

### DIFF
--- a/src/game/variables.h
+++ b/src/game/variables.h
@@ -52,9 +52,9 @@ MACRO_CONFIG_INT(ClMouseDeadzone, cl_mouse_deadzone, 300, 0, 0, CFGFLAG_CLIENT|C
 #endif
 MACRO_CONFIG_INT(ClMouseFollowfactor, cl_mouse_followfactor, 60, 0, 200, CFGFLAG_CLIENT|CFGFLAG_SAVE, "")
 #if defined(__ANDROID__)
-MACRO_CONFIG_INT(ClMouseMaxDistance, cl_mouse_max_distance, 400, 0, 0, CFGFLAG_CLIENT|CFGFLAG_SAVE, "") // Prevent crosshair from moving out of screen on Android
+MACRO_CONFIG_INT(ClMouseMaxDistance, cl_mouse_max_distance, 400, 25, 0, CFGFLAG_CLIENT|CFGFLAG_SAVE, "") // Prevent crosshair from moving out of screen on Android
 #else
-MACRO_CONFIG_INT(ClMouseMaxDistance, cl_mouse_max_distance, 800, 0, 0, CFGFLAG_CLIENT|CFGFLAG_SAVE, "")
+MACRO_CONFIG_INT(ClMouseMaxDistance, cl_mouse_max_distance, 800, 25, 0, CFGFLAG_CLIENT|CFGFLAG_SAVE, "")
 #endif
 
 MACRO_CONFIG_INT(ClDyncam, cl_dyncam, 0, 0, 1, CFGFLAG_CLIENT, "Enable dyncam")


### PR DESCRIPTION
low values of cl_mouse_max_distance (2, for example) make it extremely
easy to aim straight up/down (or to be more specific, any angle
divisible by 45 degrees), which allows cheating maps that require
that skill


25 might be too high or not high enough, I'm not sure. the number of angles that your aim "snaps" to correlates with cl_mouse_max_distance, it's not a black and white issue. I tested that a value of 25 made it at least a tiny bit difficult to aim straight up/down