### PR TITLE
Add the VITAL flag to fastdownload packets

### DIFF
--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -154,6 +154,7 @@ public:
 		int m_Score;
 		int m_Authed;
 		int m_AuthTries;
+		int m_NextMapChunk;
 
 		const IConsole::CCommandInfo *m_pRconCmdToSend;
 
@@ -256,6 +257,7 @@ public:
 	static int ClientRejoinCallback(int ClientID, void *pUser);
 
 	void SendMap(int ClientID);
+	void SendMapData(int ClientID, int Chunk);
 	void SendConnectionReady(int ClientID);
 	void SendRconLine(int ClientID, const char *pLine);
 	static void SendRconLineAuthed(const char *pLine, void *pUser, bool Highlighted = false);


### PR DESCRIPTION
This lets 0.6.4 clients connect to DDNet servers again. Instead of doing
our own resend logic, just always send `sv_map_window` packets ahead and
let the Teeworlds network deal with possible resends.