### PR TITLE
Fix laser rendering on high gameticks

### DIFF
--- a/src/game/client/components/items.cpp
+++ b/src/game/client/components/items.cpp
@@ -229,7 +229,7 @@ void CItems::RenderLaser(const struct CNetObj_Laser *pCurrent)
 	vec2 From = vec2(pCurrent->m_FromX, pCurrent->m_FromY);
 	vec2 Dir = normalize(Pos-From);
 
-	float Ticks = Client()->GameTick() + Client()->IntraGameTick() - pCurrent->m_StartTick;
+	float Ticks = Client()->GameTick() - pCurrent->m_StartTick + Client()->IntraGameTick();
 	float Ms = (Ticks/50.0f) * 1000.0f;
 	float a = Ms / m_pClient->m_Tuning[g_Config.m_ClDummy].m_LaserBounceDelay;
 	a = clamp(a, 0.0f, 1.0f);


### PR DESCRIPTION
Float inaccuracy causing the laser to look weird on servers with high gameticks. Why wasn't this fixed before?

This PR changes the expression from `int + float - int` to `int - int + float`