### PR TITLE
Disallow usage of semicolons in chat commands

### DIFF
--- a/src/engine/console.h
+++ b/src/engine/console.h
@@ -87,9 +87,9 @@ public:
 	virtual void StoreCommands(bool Store) = 0;
 
 	virtual bool LineIsValid(const char *pStr) = 0;
-	virtual void ExecuteLine(const char *Sptr, int ClientID = -1) = 0;
-	virtual void ExecuteLineFlag(const char *Sptr, int FlasgMask, int ClientID = -1) = 0;
-	virtual void ExecuteLineStroked(int Stroke, const char *pStr, int ClientID = -1) = 0;
+	virtual void ExecuteLine(const char *Sptr, int ClientID = -1, bool InterpretSemicolons = true) = 0;
+	virtual void ExecuteLineFlag(const char *Sptr, int FlasgMask, int ClientID = -1, bool InterpretSemicolons = true) = 0;
+	virtual void ExecuteLineStroked(int Stroke, const char *pStr, int ClientID = -1, bool InterpretSemicolons = true) = 0;
 	virtual void ExecuteFile(const char *pFilename, int ClientID = -1, bool LogFailure = false) = 0;
 
 	virtual int RegisterPrintCallback(int OutputLevel, FPrintCallback pfnPrintCallback, void *pUserData) = 0;

--- a/src/engine/shared/console.cpp
+++ b/src/engine/shared/console.cpp
@@ -304,8 +304,16 @@ bool CConsole::LineIsValid(const char *pStr)
 	return true;
 }
 
-void CConsole::ExecuteLineStroked(int Stroke, const char *pStr, int ClientID)
+void CConsole::ExecuteLineStroked(int Stroke, const char *pStr, int ClientID, bool InterpretSemicolons)
 {
+	static const char s_aMulticommandPrefix[] = "mc;";
+	static const int s_PrefixLength = str_length(s_aMulticommandPrefix);
+	if(str_length(pStr) >= s_PrefixLength
+		&& str_comp_num(pStr, s_aMulticommandPrefix, s_PrefixLength) == 0)
+	{
+		InterpretSemicolons = true;
+		pStr += s_PrefixLength;
+	}
 	while(pStr && *pStr)
 	{
 		CResult Result;
@@ -323,7 +331,7 @@ void CConsole::ExecuteLineStroked(int Stroke, const char *pStr, int ClientID)
 				if(pEnd[1] == '"')
 					pEnd++;
 			}
-			else if(!InString)
+			else if(!InString && InterpretSemicolons)
 			{
 				if(*pEnd == ';') // command separator
 				{
@@ -467,17 +475,17 @@ CConsole::CCommand *CConsole::FindCommand(const char *pName, int FlagMask)
 	return 0x0;
 }
 
-void CConsole::ExecuteLine(const char *pStr, int ClientID)
+void CConsole::ExecuteLine(const char *pStr, int ClientID, bool InterpretSemicolons)
 {
-	CConsole::ExecuteLineStroked(1, pStr, ClientID); // press it
-	CConsole::ExecuteLineStroked(0, pStr, ClientID); // then release it
+	CConsole::ExecuteLineStroked(1, pStr, ClientID, InterpretSemicolons); // press it
+	CConsole::ExecuteLineStroked(0, pStr, ClientID, InterpretSemicolons); // then release it
 }
 
-void CConsole::ExecuteLineFlag(const char *pStr, int FlagMask, int ClientID)
+void CConsole::ExecuteLineFlag(const char *pStr, int FlagMask, int ClientID, bool InterpretSemicolons)
 {
 	int Temp = m_FlagMask;
 	m_FlagMask = FlagMask;
-	ExecuteLine(pStr, ClientID);
+	ExecuteLine(pStr, ClientID, InterpretSemicolons);
 	m_FlagMask = Temp;
 }
 

--- a/src/engine/shared/console.h
+++ b/src/engine/shared/console.h
@@ -60,7 +60,7 @@ class CConsole : public IConsole
 	static void ConCommandAccess(IResult *pResult, void *pUser);
 	static void ConCommandStatus(IConsole::IResult *pResult, void *pUser);
 
-	void ExecuteLineStroked(int Stroke, const char *pStr, int ClientID = -1);
+	void ExecuteLineStroked(int Stroke, const char *pStr, int ClientID = -1, bool InterpretSemicolons = true);
 
 	struct
 	{
@@ -194,8 +194,8 @@ public:
 	virtual void StoreCommands(bool Store);
 
 	virtual bool LineIsValid(const char *pStr);
-	virtual void ExecuteLine(const char *pStr, int ClientID = -1);
-	virtual void ExecuteLineFlag(const char *pStr, int FlagMask, int ClientID = -1);
+	virtual void ExecuteLine(const char *pStr, int ClientID = -1, bool InterpretSemicolons = true);
+	virtual void ExecuteLineFlag(const char *pStr, int FlagMask, int ClientID = -1, bool InterpretSemicolons = true);
 	virtual void ExecuteFile(const char *pFilename, int ClientID = -1, bool LogFailure = false);
 
 	virtual int RegisterPrintCallback(int OutputLevel, FPrintCallback pfnPrintCallback, void *pUserData);

--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -244,69 +244,25 @@ void CGameContext::ConRules(IConsole::IResult *pResult, void *pUserData)
 				"Be nice.");
 		Printed = true;
 	}
-	if (g_Config.m_SvRulesLine1[0])
+	#define _RL(n) g_Config.m_SvRulesLine ## n
+	char *pRuleLines[] = {
+		_RL(1), _RL(2), _RL(3), _RL(4), _RL(5),
+		_RL(6), _RL(7), _RL(8), _RL(9), _RL(10),
+	};
+	for(unsigned i = 0; i < sizeof(pRuleLines) / sizeof(pRuleLines[0]); i++)
 	{
-		pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "rules",
-				g_Config.m_SvRulesLine1);
-		Printed = true;
-	}
-	if (g_Config.m_SvRulesLine2[0])
-	{
-		pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "rules",
-				g_Config.m_SvRulesLine2);
-		Printed = true;
-	}
-	if (g_Config.m_SvRulesLine3[0])
-	{
-		pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "rules",
-				g_Config.m_SvRulesLine3);
-		Printed = true;
-	}
-	if (g_Config.m_SvRulesLine4[0])
-	{
-		pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "rules",
-				g_Config.m_SvRulesLine4);
-		Printed = true;
-	}
-	if (g_Config.m_SvRulesLine5[0])
-	{
-		pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "rules",
-				g_Config.m_SvRulesLine5);
-		Printed = true;
-	}
-	if (g_Config.m_SvRulesLine6[0])
-	{
-		pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "rules",
-				g_Config.m_SvRulesLine6);
-		Printed = true;
-	}
-	if (g_Config.m_SvRulesLine7[0])
-	{
-		pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "rules",
-				g_Config.m_SvRulesLine7);
-		Printed = true;
-	}
-	if (g_Config.m_SvRulesLine8[0])
-	{
-		pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "rules",
-				g_Config.m_SvRulesLine8);
-		Printed = true;
-	}
-	if (g_Config.m_SvRulesLine9[0])
-	{
-		pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "rules",
-				g_Config.m_SvRulesLine9);
-		Printed = true;
-	}
-	if (g_Config.m_SvRulesLine10[0])
-	{
-		pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "rules",
-				g_Config.m_SvRulesLine10);
-		Printed = true;
+		if(pRuleLines[i][0])
+		{
+			pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD,
+				"rules", pRuleLines[i]);
+			Printed = true;
+		}
 	}
 	if (!Printed)
+	{
 		pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "rules",
 				"No Rules Defined, Kill em all!!");
+	}
 }
 
 void CGameContext::ConToggleSpec(IConsole::IResult *pResult, void *pUserData)

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -1136,7 +1136,62 @@ void CGameContext::OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID)
 						Console()->SetAccessLevel(IConsole::ACCESS_LEVEL_USER);
 					Console()->SetPrintOutputLevel(m_ChatPrintCBIndex, 0);
 
-					Console()->ExecuteLine(pMsg->m_pMessage + 1, ClientID);
+					bool InterpretSemicolons = !(m_apPlayers[ClientID]->m_PlayerFlags & PLAYERFLAG_CHATTING);
+					Console()->ExecuteLine(pMsg->m_pMessage + 1, ClientID, InterpretSemicolons);
+					if(InterpretSemicolons && !m_apPlayers[ClientID]->m_SentSemicolonTip)
+					{
+						bool FoundSemicolons = false;
+
+						const char *pStr = pMsg->m_pMessage + 1;
+						int Length = str_length(pStr);
+						bool InString = false;
+						bool Escape = false;
+						for(int i = 0; i < Length; i++)
+						{
+							char c = pStr[i];
+							if(InString)
+							{
+								if(Escape)
+								{
+									Escape = false;
+									if(c == '\\' || c == '"')
+									{
+										continue;
+									}
+								}
+								else if(c == '\\')
+								{
+									Escape = true;
+								}
+								else if(c == '"')
+								{
+									InString = false;
+								}
+							}
+							else
+							{
+								if(c == '"')
+								{
+									InString = true;
+								}
+								else if(c == ';')
+								{
+									FoundSemicolons = true;
+									break;
+								}
+							}
+						}
+						static const char s_aPrefix[] = "mc;";
+						static const int s_PrefixLength = str_length(s_aPrefix);
+						if(FoundSemicolons && !(Length >= s_PrefixLength && str_comp_num(pStr, s_aPrefix, s_PrefixLength) == 0))
+						{
+							SendChatTarget(ClientID, "Usage of semicolons without /mc is deprecated");
+							char aBuf[256];
+							str_format(aBuf, sizeof(aBuf), "Try changing your bind to '/mc;%s'", pStr);
+							SendChatTarget(ClientID, aBuf);
+							m_apPlayers[ClientID]->m_SentSemicolonTip = true;
+						}
+					}
 					char aBuf[256];
 					str_format(aBuf, sizeof(aBuf), "%d used %s", ClientID, pMsg->m_pMessage);
 					Console()->Print(IConsole::OUTPUT_LEVEL_DEBUG, "chat-command", aBuf);

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -96,6 +96,7 @@ public:
 	int m_LastActionTick;
 	bool m_StolenSkin;
 	int m_TeamChangeTick;
+	bool m_SentSemicolonTip;
 	struct
 	{
 		int m_TargetX;


### PR DESCRIPTION
This prevents player name exploits due to tab completion of nicknames
that could result in unwanted commands being executed.

Print a deprecation message that is supposed to be removed in the
future.