### PR TITLE
Add protocol extension with UUIDs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ freetype.dll
 /serverlaunch_*
 /tileset_border*
 /twping*
+/uuid*
 /versionsrv*
 
 Debug

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,8 +233,9 @@ generate_source("src/game/generated/server_data.h" "server_content_header")
 # Sources
 file(GLOB_RECURSE BASE "src/base/*.c" "src/base/*.cpp" "src/base/*.h")
 file(GLOB_RECURSE ENGINE_SHARED "src/engine/shared/*.cpp" "src/engine/shared/*.h")
+set(ENGINE_GENERATED_SHARED "src/game/generated/protocol.cpp" "src/game/generated/protocol.h")
 file(GLOB GAME_SHARED "src/game/*.cpp" "src/game/*.h")
-set(GAME_GENERATED_SHARED "src/game/generated/protocol.cpp" "src/game/generated/protocol.h" "src/game/generated/nethash.cpp")
+set(GAME_GENERATED_SHARED "src/game/generated/nethash.cpp")
 
 # Static dependencies
 file(GLOB DEP_MD5_SRC "src/engine/external/md5/*.c" "src/engine/external/md5/*.h")
@@ -257,7 +258,7 @@ set(DEPS ${DEP_MD5} ${DEP_WEBSOCKETS} ${DEP_ZLIB})
 set(LIBS ${CMAKE_THREAD_LIBS_INIT} ${ZLIB_LIBRARIES} ${PLATFORM_LIBS})
 
 # Targets
-add_library(engine-shared EXCLUDE_FROM_ALL OBJECT ${ENGINE_SHARED} ${BASE})
+add_library(engine-shared EXCLUDE_FROM_ALL OBJECT ${ENGINE_SHARED} ${ENGINE_GENERATED_SHARED} ${BASE})
 add_library(game-shared EXCLUDE_FROM_ALL OBJECT ${GAME_SHARED} ${GAME_GENERATED_SHARED})
 list(APPEND TARGETS_OWN engine-shared game-shared)
 

--- a/bam.lua
+++ b/bam.lua
@@ -379,7 +379,7 @@ function build(settings)
 	tools = {}
 	for i,v in ipairs(tools_src) do
 		toolname = PathFilename(PathBase(v))
-		tools[i] = Link(settings, toolname, Compile(settings, v), engine, zlib, pnglite, md5)
+		tools[i] = Link(settings, toolname, Compile(settings, v), engine, zlib, pnglite, md5, game_shared)
 	end
 
 	-- build client, server, version server and master server
@@ -396,13 +396,13 @@ function build(settings)
 	end
 
 	versionserver_exe = Link(server_settings, "versionsrv", versionserver,
-		engine, zlib, libwebsockets, md5)
+		engine, zlib, libwebsockets, md5, game_shared)
 
 	masterserver_exe = Link(server_settings, "mastersrv", masterserver,
-		engine, zlib, libwebsockets, md5)
+		engine, zlib, libwebsockets, md5, game_shared)
 
 	twping_exe = Link(server_settings, "twping", twping,
-		engine, zlib, libwebsockets, md5)
+		engine, zlib, libwebsockets, md5, game_shared)
 
 	-- make targets
 	c = PseudoTarget("client".."_"..settings.config_name, client_exe, client_depends)

--- a/datasrc/network.py
+++ b/datasrc/network.py
@@ -12,6 +12,7 @@ Powerups = ["HEALTH", "ARMOR", "WEAPON", "NINJA"]
 RawHeader = '''
 
 #include <engine/message.h>
+#include <engine/shared/protocol_ex.h>
 
 enum
 {
@@ -189,6 +190,10 @@ Objects = [
 		NetIntAny("m_Y"),
 	]),
 
+	NetObjectEx("MyOwnObject", "my-own-object@heinrich5991.de", [
+		NetIntAny("m_Test"),
+	]),
+
 	## Events
 
 	NetEvent("Common", [
@@ -215,6 +220,10 @@ Objects = [
 
 	NetEvent("DamageInd:Common", [
 		NetIntAny("m_Angle"),
+	]),
+
+	NetObjectEx("MyOwnEvent", "my-own-event@heinrich5991.de", [
+		NetIntAny("m_Test"),
 	]),
 ]
 
@@ -364,6 +373,10 @@ Messages = [
 
 	NetMessage("Cl_ShowOthers", [
 		NetBool("m_Show"),
-	])
+	]),
 # Can't add any NetMessages here!
+
+	NetMessageEx("Sv_MyOwnMessage", "my-own-message@heinrich5991.de", [
+		NetIntAny("m_Test"),
+	]),
 ]

--- a/src/base/tl/base.h
+++ b/src/base/tl/base.h
@@ -4,18 +4,14 @@
 #define BASE_TL_BASE_H
 
 #include <base/system.h>
+#include <algorithm>
+#include <utility>
+
+using std::swap;
 
 inline void tl_assert(bool statement)
 {
 	dbg_assert(statement, "assert!");
-}
-
-template<class T>
-inline void swap(T &a, T &b)
-{
-	T c = b;
-	b = a;
-	a = c;
 }
 
 #endif

--- a/src/engine/message.h
+++ b/src/engine/message.h
@@ -4,6 +4,7 @@
 #define ENGINE_MESSAGE_H
 
 #include <engine/shared/packer.h>
+#include <engine/shared/uuid_manager.h>
 
 class CMsgPacker : public CPacker
 {
@@ -11,7 +12,15 @@ public:
 	CMsgPacker(int Type)
 	{
 		Reset();
-		AddInt(Type);
+		if(Type < OFFSET_UUID)
+		{
+			AddInt(Type);
+		}
+		else
+		{
+			AddInt(0); // NETMSG_EX, NETMSGTYPE_EX
+			g_UuidManager.PackUuid(Type, this);
+		}
 	}
 };
 

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -18,6 +18,7 @@
 #include <engine/shared/econ.h>
 #include <engine/shared/fifo.h>
 #include <engine/shared/netban.h>
+#include <engine/shared/uuid_manager.h>
 
 #include "authmanager.h"
 

--- a/src/engine/shared/global_uuid_manager.cpp
+++ b/src/engine/shared/global_uuid_manager.cpp
@@ -1,0 +1,14 @@
+#include "protocol_ex.h"
+#include "uuid_manager.h"
+
+#include <engine/uuid.h>
+
+static CUuidManager CreateGlobalUuidManager()
+{
+	CUuidManager Manager;
+	RegisterUuids(&Manager);
+	RegisterGameUuids(&Manager);
+	return Manager;
+}
+
+CUuidManager g_UuidManager = CreateGlobalUuidManager();

--- a/src/engine/shared/protocol.h
+++ b/src/engine/shared/protocol.h
@@ -30,7 +30,7 @@
 
 enum
 {
-	NETMSG_NULL=0,
+	NETMSG_EX=0,
 
 	// the first thing sent by the client
 	// contains the version info for the client
@@ -70,6 +70,8 @@ enum
 	// sent by server (todo: move it up)
 	NETMSG_RCON_CMD_ADD,
 	NETMSG_RCON_CMD_REM,
+
+	NUM_NETMSGS,
 };
 
 // this should be revised

--- a/src/engine/shared/protocol_ex.cpp
+++ b/src/engine/shared/protocol_ex.cpp
@@ -1,0 +1,102 @@
+#include "protocol_ex.h"
+
+#include "config.h"
+#include "protocol.h"
+#include "uuid_manager.h"
+
+#include <new>
+
+void RegisterUuids(class CUuidManager *pManager)
+{
+	#define UUID(id, name) pManager->RegisterName(id, name);
+	#include "protocol_ex_msgs.h"
+	#undef UUID
+}
+
+int UnpackMessageID(int *pID, bool *pSys, struct CUuid *pUuid, CUnpacker *pUnpacker, CMsgPacker *pPacker)
+{
+	*pID = 0;
+	*pSys = false;
+	mem_zero(pUuid, sizeof(*pUuid));
+
+	int MsgID = pUnpacker->GetInt();
+
+	if(pUnpacker->Error())
+	{
+		return UNPACKMESSAGE_ERROR;
+	}
+
+	*pID = MsgID >> 1;
+	*pSys = MsgID & 1;
+
+	if(*pID < 0 || *pID >= OFFSET_UUID)
+	{
+		return UNPACKMESSAGE_ERROR;
+	}
+
+	if(*pID != 0) // NETMSG_EX, NETMSGTYPE_EX
+	{
+		return UNPACKMESSAGE_OK;
+	}
+
+	*pID = g_UuidManager.UnpackUuid(pUnpacker, pUuid);
+
+	if(*pID == UUID_INVALID || *pID == UUID_UNKNOWN)
+	{
+		return UNPACKMESSAGE_ERROR;
+	}
+
+	if(*pSys)
+	{
+		switch(*pID)
+		{
+		case NETMSG_WHATIS:
+			{
+				CUuid Uuid2;
+				int ID2 = g_UuidManager.UnpackUuid(pUnpacker, &Uuid2);
+				if(ID2 == UUID_INVALID)
+				{
+					break;
+				}
+				if(ID2 == UUID_UNKNOWN)
+				{
+					new (pPacker) CMsgPacker(NETMSG_IDONTKNOW);
+					pPacker->AddRaw(&Uuid2, sizeof(Uuid2));
+				}
+				else
+				{
+					new (pPacker) CMsgPacker(NETMSG_ITIS);
+					pPacker->AddRaw(&Uuid2, sizeof(Uuid2));
+					pPacker->AddString(g_UuidManager.GetName(ID2), 0);
+				}
+				return UNPACKMESSAGE_ANSWER;
+			}
+		case NETMSG_IDONTKNOW:
+			if(g_Config.m_Debug)
+			{
+				CUuid Uuid2;
+				g_UuidManager.UnpackUuid(pUnpacker, &Uuid2);
+				if(pUnpacker->Error())
+					break;
+				char aBuf[UUID_MAXSTRSIZE];
+				FormatUuid(Uuid2, aBuf, sizeof(aBuf));
+				dbg_msg("uuid", "peer: unknown %s", aBuf);
+			}
+			break;
+		case NETMSG_ITIS:
+			if(g_Config.m_Debug)
+			{
+				CUuid Uuid2;
+				g_UuidManager.UnpackUuid(pUnpacker, &Uuid2);
+				const char *pName = pUnpacker->GetString(CUnpacker::SANITIZE_CC);
+				if(pUnpacker->Error())
+					break;
+				char aBuf[UUID_MAXSTRSIZE];
+				FormatUuid(Uuid2, aBuf, sizeof(aBuf));
+				dbg_msg("uuid", "peer: %s %s", aBuf, pName);
+			}
+			break;
+		}
+	}
+	return UNPACKMESSAGE_OK;
+}

--- a/src/engine/shared/protocol_ex.h
+++ b/src/engine/shared/protocol_ex.h
@@ -1,0 +1,29 @@
+#ifndef ENGINE_SHARED_PROTOCOL_EX_H
+#define ENGINE_SHARED_PROTOCOL_EX_H
+
+#include <engine/message.h>
+
+enum
+{
+	NETMSG_EX_INVALID=UUID_INVALID,
+	NETMSG_EX_UNKNOWN=UUID_UNKNOWN,
+
+	OFFSET_NETMSG_UUID=OFFSET_UUID,
+
+	__NETMSG_UUID_HELPER=OFFSET_NETMSG_UUID-1,
+	#define UUID(id, name) id,
+	#include "protocol_ex_msgs.h"
+	#undef UUID
+	OFFSET_GAME_UUID,
+
+	UNPACKMESSAGE_ERROR=0,
+	UNPACKMESSAGE_OK,
+	UNPACKMESSAGE_ANSWER,
+};
+
+void RegisterUuids(class CUuidManager *pManager);
+bool NetworkExDefaultHandler(int *pID, struct CUuid *pUuid, CUnpacker *pUnpacker, CMsgPacker *pPacker, int Type);
+
+int UnpackMessageID(int *pID, bool *pSys, struct CUuid *pUuid, CUnpacker *pUnpacker, CMsgPacker *pPacker);
+
+#endif // ENGINE_SHARED_PROTOCOL_EX_H

--- a/src/engine/shared/protocol_ex_msgs.h
+++ b/src/engine/shared/protocol_ex_msgs.h
@@ -1,0 +1,22 @@
+// UUID(name_in_code, name)
+//
+// When adding your own extended net messages, choose the name (third
+// parameter) as `<name>@<domain>` where `<name>` is a name you can choose
+// freely and `<domain>` is a domain you own. If you don't own a domain, try
+// choosing a string that is not a domain and uniquely identifies you, e.g. use
+// the name of the client/server you develop.
+//
+// Example:
+//
+// 1) `i-unfreeze-you@ddnet.tw`
+// 2) `creeper@minetee`
+//
+// The first example applies if you own the `ddnet.tw` domain, that is, if you
+// are adding this message on behalf of the DDNet team.
+//
+// The second example shows how you could add a message if you don't own a
+// domain, but need a message for your minetee client/server.
+
+UUID(NETMSG_WHATIS,       "what-is@ddnet.tw")
+UUID(NETMSG_ITIS,         "it-is@ddnet.tw")
+UUID(NETMSG_IDONTKNOW,    "i-dont-know@ddnet.tw")

--- a/src/engine/shared/snapshot.h
+++ b/src/engine/shared/snapshot.h
@@ -31,6 +31,8 @@ class CSnapshot
 public:
 	enum
 	{
+		OFFSET_UUID_TYPE=0x4000,
+		MAX_TYPE=0x7fff,
 		MAX_SIZE=64*1024
 	};
 
@@ -39,6 +41,7 @@ public:
 	CSnapshotItem *GetItem(int Index);
 	int GetItemSize(int Index);
 	int GetItemIndex(int Key);
+	int GetItemType(int Index);
 
 	int Crc();
 	void DebugDump();
@@ -114,7 +117,8 @@ class CSnapshotBuilder
 {
 	enum
 	{
-		MAX_ITEMS = 1024
+		MAX_ITEMS = 1024,
+		MAX_EXTENDED_ITEM_TYPES = 64,
 	};
 
 	char m_aData[CSnapshot::MAX_SIZE];
@@ -123,7 +127,16 @@ class CSnapshotBuilder
 	int m_aOffsets[MAX_ITEMS];
 	int m_NumItems;
 
+	int m_aExtendedItemTypes[MAX_EXTENDED_ITEM_TYPES];
+	bool m_aExtendedItemTypesAdded[MAX_EXTENDED_ITEM_TYPES];
+	int m_NumExtendedItemTypes;
+
+	void AddExtendedItemType(int Index);
+	int GetExtendedItemTypeIndex(int TypeID);
+
 public:
+	CSnapshotBuilder();
+
 	void Init();
 
 	void *NewItem(int Type, int ID, int Size);

--- a/src/engine/shared/uuid_manager.cpp
+++ b/src/engine/shared/uuid_manager.cpp
@@ -1,0 +1,132 @@
+#include "uuid_manager.h"
+
+#include <engine/external/md5/md5.h>
+#include <engine/shared/packer.h>
+
+#include <stdio.h>
+
+static const CUuid TEEWORLDS_NAMESPACE = {
+	// "e05ddaaa-c4e6-4cfb-b642-5d48e80c0029"
+	0xe0, 0x5d, 0xda, 0xaa, 0xc4, 0xe6, 0x4c, 0xfb,
+	0xb6, 0x42, 0x5d, 0x48, 0xe8, 0x0c, 0x00, 0x29
+};
+
+CUuid CalculateUuid(const char *pName)
+{
+	md5_state_t Md5;
+	md5_byte_t aDigest[16];
+	md5_init(&Md5);
+
+	md5_append(&Md5, TEEWORLDS_NAMESPACE.m_aData, sizeof(TEEWORLDS_NAMESPACE.m_aData));
+	// Without terminating NUL.
+	md5_append(&Md5, (const unsigned char *)pName, str_length(pName));
+	md5_finish(&Md5, aDigest);
+
+	CUuid Result;
+	for(unsigned i = 0; i < sizeof(Result.m_aData); i++)
+	{
+		Result.m_aData[i] = aDigest[i];
+	}
+
+	Result.m_aData[6] &= 0x0f;
+	Result.m_aData[6] |= 0x30;
+	Result.m_aData[8] &= 0x3f;
+	Result.m_aData[8] |= 0x80;
+	return Result;
+}
+
+void FormatUuid(CUuid Uuid, char *pBuffer, unsigned BufferLength)
+{
+	unsigned char *p = Uuid.m_aData;
+	str_format(pBuffer, BufferLength,
+		"%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x%02x%02x",
+		p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7],
+		p[8], p[9], p[10], p[11], p[12], p[13], p[14], p[15]);
+}
+
+bool CUuid::operator==(const CUuid& Other)
+{
+	return mem_comp(this, &Other, sizeof(*this)) == 0;
+}
+
+bool CUuid::operator!=(const CUuid& Other)
+{
+	return !(*this == Other);
+}
+
+static int GetIndex(int ID)
+{
+	return ID - OFFSET_UUID;
+}
+
+static int GetID(int Index)
+{
+	return Index + OFFSET_UUID;
+}
+
+void CUuidManager::RegisterName(int ID, const char *pName)
+{
+	int Index = GetIndex(ID);
+	dbg_assert(Index == m_aNames.size(), "names must be registered with increasing ID");
+	CName Name;
+	Name.m_pName = pName;
+	Name.m_Uuid = CalculateUuid(pName);
+	dbg_assert(LookupUuid(Name.m_Uuid) == -1, "duplicate uuid");
+
+	m_aNames.add(Name);
+}
+
+CUuid CUuidManager::GetUuid(int ID) const
+{
+	return m_aNames[GetIndex(ID)].m_Uuid;
+}
+
+const char *CUuidManager::GetName(int ID) const
+{
+	return m_aNames[GetIndex(ID)].m_pName;
+}
+
+int CUuidManager::LookupUuid(CUuid Uuid) const
+{
+	for(int i = 0; i < m_aNames.size(); i++)
+	{
+		if(Uuid == m_aNames[i].m_Uuid)
+		{
+			return GetID(i);
+		}
+	}
+	return UUID_UNKNOWN;
+}
+
+int CUuidManager::UnpackUuid(CUnpacker *pUnpacker) const
+{
+	CUuid Temp;
+	return UnpackUuid(pUnpacker, &Temp);
+}
+
+int CUuidManager::UnpackUuid(CUnpacker *pUnpacker, CUuid *pOut) const
+{
+	const CUuid *pUuid = (const CUuid *)pUnpacker->GetRaw(sizeof(*pUuid));
+	if(pUuid == NULL)
+	{
+		return UUID_INVALID;
+	}
+	*pOut = *pUuid;
+	return LookupUuid(*pUuid);
+}
+
+void CUuidManager::PackUuid(int ID, CPacker *pPacker) const
+{
+	CUuid Uuid = GetUuid(ID);
+	pPacker->AddRaw(&Uuid, sizeof(Uuid));
+}
+
+void CUuidManager::DebugDump() const
+{
+	for(int i = 0; i < m_aNames.size(); i++)
+	{
+		char aBuf[UUID_MAXSTRSIZE];
+		FormatUuid(m_aNames[i].m_Uuid, aBuf, sizeof(aBuf));
+		dbg_msg("uuid", "%s %s", aBuf, m_aNames[i].m_pName);
+	}
+}

--- a/src/engine/shared/uuid_manager.h
+++ b/src/engine/shared/uuid_manager.h
@@ -1,0 +1,54 @@
+#ifndef ENGINE_SHARED_UUID_MANAGER_H
+#define ENGINE_SHARED_UUID_MANAGER_H
+
+#include <base/tl/array.h>
+
+enum
+{
+	UUID_MAXSTRSIZE = 37, // 12345678-0123-5678-0123-567890123456
+
+	UUID_INVALID=-2,
+	UUID_UNKNOWN=-1,
+
+	OFFSET_UUID=1<<16,
+};
+
+struct CUuid
+{
+	unsigned char m_aData[16];
+
+	bool operator==(const CUuid &Other);
+	bool operator!=(const CUuid &Other);
+};
+
+CUuid CalculateUuid(const char *pName);
+void FormatUuid(CUuid Uuid, char *pBuffer, unsigned BufferLength);
+
+struct CName
+{
+	CUuid m_Uuid;
+	const char *m_pName;
+};
+
+class CPacker;
+class CUnpacker;
+
+class CUuidManager
+{
+	array<CName> m_aNames;
+public:
+	void RegisterName(int ID, const char *pName);
+	CUuid GetUuid(int ID) const;
+	const char *GetName(int ID) const;
+	int LookupUuid(CUuid Uuid) const;
+
+	int UnpackUuid(CUnpacker *pUnpacker) const;
+	int UnpackUuid(CUnpacker *pUnpacker, CUuid *pOut) const;
+	void PackUuid(int ID, CPacker *pPacker) const;
+
+	void DebugDump() const;
+};
+
+extern CUuidManager g_UuidManager;
+
+#endif // ENGINE_SHARED_UUID_MANAGER_H

--- a/src/engine/uuid.h
+++ b/src/engine/uuid.h
@@ -1,0 +1,4 @@
+#ifndef ENGINE_UUID_H
+#define ENGINE_UUID_H
+void RegisterGameUuids(CUuidManager *pManager);
+#endif // ENGINE_UUID_H

--- a/src/tools/uuid.cpp
+++ b/src/tools/uuid.cpp
@@ -1,0 +1,14 @@
+#include <engine/shared/uuid_manager.h>
+int main(int argc, char **argv)
+{
+	dbg_logger_stdout();
+	if(argc != 2)
+	{
+		dbg_msg("usage", "uuid <NAME>");
+		return -1;
+	}
+	CUuid Uuid = CalculateUuid(argv[1]);
+	char aBuf[UUID_MAXSTRSIZE];
+	FormatUuid(Uuid, aBuf, sizeof(aBuf));
+	dbg_msg("uuid", "%s", aBuf);
+}


### PR DESCRIPTION
This system can easily be extended by independent authors without
collisions, something the old system with plain increasing integers did
not allow.

Do this by utilizing the previously unused message code `NETMSG_NULL`
which has a value of 0.