### PR TITLE
Remove flags in language list

### DIFF
--- a/data/languages/index.txt
+++ b/data/languages/index.txt
@@ -2,120 +2,90 @@
 
 belarusian
 == Беларуская
-== 112
 
 bosnian
 == Bosanski
-== 70
 
 brazilian_portuguese
 == Português brasileiro
-== 76
 
 bulgarian
 == Български
-== 100
 
 catalan
 == Català
-== 906
 
 czech
 == Česky
-== 203
 
 danish
 == Dansk
-== 208
 
 dutch
 == Nederlands
-== 528
 
 finnish
 == Suomi
-== 246
 
 french
 == Français
-== 250
 
 german
 == Deutsch
-== 276
 
 hungarian
 == Magyar
-== 348
 
 italian
 == Italiano
-== 380
 
 japanese
 == 日本語
-== 392
 
 korean
 == 한국어
-== 410
 
 kyrgyz
 == Кыргызча
-== 417
 
 norwegian
 == Norsk
-== 578
 
 persian
 == Persian
-== 364
 
 polish
 == Polski
-== 616
 
 portuguese
 == Português
-== 620
 
 romanian
 == Română
-== 642
 
 russian
 == Русский
-== 643
 
 serbian
 == Srpski
-== 688
 
 simplified_chinese
 == 简体中文
-== 156
 
 slovak
 == Slovensky
-== 703
 
 spanish
 == Español
-== 724
 
 swedish
 == Svenska
-== 752
 
 traditional_chinese
 == 繁體中文
-== 158
 
 turkish
 == Türkçe
-== 792
 
 ukrainian
 == Українська
-== 804

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -1105,11 +1105,10 @@ class CLanguage
 {
 public:
 	CLanguage() {}
-	CLanguage(const char *n, const char *f, int Code) : m_Name(n), m_FileName(f), m_CountryCode(Code) {}
+	CLanguage(const char *n, const char *f) : m_Name(n), m_FileName(f) {}
 
 	string m_Name;
 	string m_FileName;
-	int m_CountryCode;
 
 	bool operator<(const CLanguage &Other) { return m_Name < Other.m_Name; }
 };
@@ -1152,24 +1151,9 @@ void LoadLanguageIndexfile(IStorage *pStorage, IConsole *pConsole, sorted_array<
 		}
 		str_copy(aReplacement, pLine+3, sizeof(aReplacement));
 
-		pLine = LineReader.Get();
-		if(!pLine)
-		{
-			pConsole->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "localization", "unexpected end of index file");
-			break;
-		}
-
-		if(pLine[0] != '=' || pLine[1] != '=' || pLine[2] != ' ')
-		{
-			char aBuf[128];
-			str_format(aBuf, sizeof(aBuf), "malform replacement for index '%s'", aOrigin);
-			pConsole->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "localization", aBuf);
-			continue;
-		}
-
 		char aFileName[128];
 		str_format(aFileName, sizeof(aFileName), "languages/%s.txt", aOrigin);
-		pLanguages->add(CLanguage(aReplacement, aFileName, str_toint(pLine+3)));
+		pLanguages->add(CLanguage(aReplacement, aFileName));
 	}
 	io_close(File);
 }
@@ -1183,7 +1167,7 @@ void CMenus::RenderLanguageSelection(CUIRect MainView)
 
 	if(s_Languages.size() == 0)
 	{
-		s_Languages.add(CLanguage("English", "", 826));
+		s_Languages.add(CLanguage("English", ""));
 		LoadLanguageIndexfile(Storage(), Console(), &s_Languages);
 		for(int i = 0; i < s_Languages.size(); i++)
 			if(str_comp(s_Languages[i].m_FileName, g_Config.m_ClLanguagefile) == 0)
@@ -1207,13 +1191,6 @@ void CMenus::RenderLanguageSelection(CUIRect MainView)
 
 		if(Item.m_Visible)
 		{
-			CUIRect Rect;
-			Item.m_Rect.VSplitLeft(Item.m_Rect.h*2.0f, &Rect, &Item.m_Rect);
-			Rect.VMargin(6.0f, &Rect);
-			Rect.HMargin(3.0f, &Rect);
-			vec4 Color(1.0f, 1.0f, 1.0f, 1.0f);
-			m_pClient->m_pCountryFlags->Render(r.front().m_CountryCode, &Color, Rect.x, Rect.y, Rect.w, Rect.h);
-			Item.m_Rect.HSplitTop(2.0f, 0, &Item.m_Rect);
 			UI()->DoLabelScaled(&Item.m_Rect, r.front().m_Name, 16.0f, -1);
 		}
 	}


### PR DESCRIPTION
Flags have nothing to do with languages. It breaks the readability of the list and only gives false informations if you didn't come from the associated country.

[I think this page resume quite well the problem](http://www.cs.tut.fi/~jkorpela/flags.html).

I know that this can be view as a downgrade, but it's not!