### PR TITLE
Add scaling in Pos Envelopes

### DIFF
--- a/src/game/client/components/maplayers.cpp
+++ b/src/game/client/components/maplayers.cpp
@@ -102,7 +102,7 @@ void CMapLayers::EnvelopeEval(float TimeOffset, int Env, float *pChannels, void 
 	{
 		if(pThis->m_pClient->m_Snap.m_pGameInfoObj) // && !(pThis->m_pClient->m_Snap.m_pGameInfoObj->m_GameStateFlags&GAMESTATEFLAG_PAUSED))
 		{
-			if(pItem->m_Version < 2 || pItem->m_Synchronized)
+			if(pItem->m_Version < CMapItemEnvelope::VERSION_WITH_SYNC || pItem->m_Synchronized)
 			{
 				s_Time = mix((pThis->Client()->PrevGameTick()-pThis->m_pClient->m_Snap.m_pGameInfoObj->m_RoundStartTick) / (float)pThis->Client()->GameTickSpeed(),
 							(pThis->Client()->GameTick()-pThis->m_pClient->m_Snap.m_pGameInfoObj->m_RoundStartTick) / (float)pThis->Client()->GameTickSpeed(),

--- a/src/game/client/render_map.cpp
+++ b/src/game/client/render_map.cpp
@@ -74,11 +74,10 @@ void CRenderTools::RenderEvalEnvelope(CEnvPoint *pPoints, int NumPoints, int Cha
 	return;
 }
 
-
-static void Rotate(CPoint *pCenter, CPoint *pPoint, float Rotation)
+static void RotateAndScale(CPoint *pCenter, CPoint *pPoint, float Rotation, float Scale)
 {
-	int x = pPoint->x - pCenter->x;
-	int y = pPoint->y - pCenter->y;
+	float x = (pPoint->x - pCenter->x)*Scale;
+	float y = (pPoint->y - pCenter->y)*Scale;
 	pPoint->x = (int)(x * cosf(Rotation) - y * sinf(Rotation) + pCenter->x);
 	pPoint->y = (int)(x * sinf(Rotation) + y * cosf(Rotation) + pCenter->y);
 }
@@ -131,6 +130,7 @@ void CRenderTools::ForceRenderQuads(CQuad *pQuads, int NumQuads, int RenderFlags
 		float OffsetX = 0;
 		float OffsetY = 0;
 		float Rot = 0;
+		float Scale = 1;
 
 		// TODO: fix this
 		if(q->m_PosEnv >= 0)
@@ -140,6 +140,7 @@ void CRenderTools::ForceRenderQuads(CQuad *pQuads, int NumQuads, int RenderFlags
 			OffsetX = aChannels[0];
 			OffsetY = aChannels[1];
 			Rot = aChannels[2]/360.0f*pi*2;
+			Scale = aChannels[3];
 		}
 
 		IGraphics::CColorVertex Array[4] = {
@@ -151,7 +152,7 @@ void CRenderTools::ForceRenderQuads(CQuad *pQuads, int NumQuads, int RenderFlags
 
 		CPoint *pPoints = q->m_aPoints;
 
-		if(Rot != 0)
+		if(Rot != 0 || Scale != 1)
 		{
 			static CPoint aRotated[4];
 			aRotated[0] = q->m_aPoints[0];
@@ -160,17 +161,17 @@ void CRenderTools::ForceRenderQuads(CQuad *pQuads, int NumQuads, int RenderFlags
 			aRotated[3] = q->m_aPoints[3];
 			pPoints = aRotated;
 
-			Rotate(&q->m_aPoints[4], &aRotated[0], Rot);
-			Rotate(&q->m_aPoints[4], &aRotated[1], Rot);
-			Rotate(&q->m_aPoints[4], &aRotated[2], Rot);
-			Rotate(&q->m_aPoints[4], &aRotated[3], Rot);
+			RotateAndScale(&q->m_aPoints[4], &aRotated[0], Rot, Scale);
+			RotateAndScale(&q->m_aPoints[4], &aRotated[1], Rot, Scale);
+			RotateAndScale(&q->m_aPoints[4], &aRotated[2], Rot, Scale);
+			RotateAndScale(&q->m_aPoints[4], &aRotated[3], Rot, Scale);
 		}
 
 		IGraphics::CFreeformItem Freeform(
-			fx2f(pPoints[0].x)+OffsetX, fx2f(pPoints[0].y)+OffsetY,
-			fx2f(pPoints[1].x)+OffsetX, fx2f(pPoints[1].y)+OffsetY,
-			fx2f(pPoints[2].x)+OffsetX, fx2f(pPoints[2].y)+OffsetY,
-			fx2f(pPoints[3].x)+OffsetX, fx2f(pPoints[3].y)+OffsetY);
+			fx2f(pPoints[0].x) + OffsetX, fx2f(pPoints[0].y) + OffsetY,
+			fx2f(pPoints[1].x) + OffsetX, fx2f(pPoints[1].y) + OffsetY,
+			fx2f(pPoints[2].x) + OffsetX, fx2f(pPoints[2].y) + OffsetY,
+			fx2f(pPoints[3].x) + OffsetX, fx2f(pPoints[3].y) + OffsetY);
 		Graphics()->QuadsDrawFreeform(&Freeform, 1);
 	}
 	Graphics()->QuadsEnd();

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -49,15 +49,28 @@ struct CEntity
 class CEnvelope
 {
 public:
+	int m_Type;
 	int m_Channels;
 	array<CEnvPoint> m_lPoints;
 	char m_aName[32];
 	float m_Bottom, m_Top;
 	bool m_Synchronized;
 
-	CEnvelope(int Chan)
+	CEnvelope(int Type)
 	{
-		m_Channels = Chan;
+		m_Type = Type;
+		switch(m_Type)
+		{
+			case ENVTYPE_POSITION:
+			case ENVTYPE_COLOR:
+				m_Channels = 4;
+				break;
+			case ENVTYPE_SOUND:
+				m_Channels = 1;
+				break;
+			default:
+				m_Channels = 0;
+		}
 		m_aName[0] = 0;
 		m_Bottom = 0;
 		m_Top = 0;
@@ -385,11 +398,11 @@ public:
 	class CLayerGame *m_pGameLayer;
 	CLayerGroup *m_pGameGroup;
 
-	CEnvelope *NewEnvelope(int Channels)
+	CEnvelope *NewEnvelope(int Type)
 	{
 		m_Modified = true;
 		m_UndoModified++;
-		CEnvelope *e = new CEnvelope(Channels);
+		CEnvelope *e = new CEnvelope(Type);
 		m_lEnvelopes.add(e);
 		return e;
 	}

--- a/src/game/editor/io.cpp
+++ b/src/game/editor/io.cpp
@@ -527,11 +527,31 @@ int CEditorMap::Save(class IStorage *pStorage, const char *pFileName)
 	{
 		CMapItemEnvelope Item;
 		Item.m_Version = CMapItemEnvelope::CURRENT_VERSION;
-		Item.m_Channels = m_lEnvelopes[e]->m_Channels;
 		Item.m_StartPoint = PointCount;
 		Item.m_NumPoints = m_lEnvelopes[e]->m_lPoints.size();
 		Item.m_Synchronized = m_lEnvelopes[e]->m_Synchronized;
 		StrToInts(Item.m_aName, sizeof(Item.m_aName)/sizeof(int), m_lEnvelopes[e]->m_aName);
+		
+		// v1 and v2 use the number of channels to find the type of envelope
+		// v3 use a new field "type" because both color and position envelopes use 4 channels
+		// to maintain the compatibility with previous versions, we
+		// - set a "type" field that only DDNet or client supporting v3 can read
+		// - fake the number of channels for vanilla or older clients
+		switch(m_lEnvelopes[e]->m_Type)
+		{
+			case ENVTYPE_POSITION:
+				Item.m_Channels = 3;
+				break;
+			case ENVTYPE_COLOR:
+				Item.m_Channels = 4;
+				break;
+			case ENVTYPE_SOUND:
+				Item.m_Channels = 1;
+				break;
+			default:
+				Item.m_Channels = 0;
+		}
+		Item.m_Type = m_lEnvelopes[e]->m_Type;
 
 		df.AddItem(MAPITEMTYPE_ENVELOPE, e, sizeof(Item), &Item);
 		PointCount += Item.m_NumPoints;
@@ -1244,13 +1264,43 @@ int CEditorMap::Load(class IStorage *pStorage, const char *pFileName, int Storag
 			for(int e = 0; e < Num; e++)
 			{
 				CMapItemEnvelope *pItem = (CMapItemEnvelope *)DataFile.GetItem(Start+e, 0, 0);
-				CEnvelope *pEnv = new CEnvelope(pItem->m_Channels);
+				
+				int Type;
+				if(pItem->m_Version < CMapItemEnvelope::VERSION_WITH_SCALING)
+				{
+					switch(pItem->m_Channels)
+					{
+						case 1:
+							Type = ENVTYPE_SOUND;
+							break;
+						case 3:
+							Type = ENVTYPE_POSITION;
+							break;
+						case 4:
+							Type = ENVTYPE_COLOR;
+							break;
+						default:
+							Type = ENVTYPE_UNKNOWN;
+					}
+				}
+				else
+					Type = pItem->m_Type;
+				
+				CEnvelope *pEnv = new CEnvelope(Type);
 				pEnv->m_lPoints.set_size(pItem->m_NumPoints);
 				mem_copy(pEnv->m_lPoints.base_ptr(), &pPoints[pItem->m_StartPoint], sizeof(CEnvPoint)*pItem->m_NumPoints);
+				
+				// sanitize unset scaling values coming from the old format
+				if(pItem->m_Version < CMapItemEnvelope::VERSION_WITH_SCALING && Type == ENVTYPE_POSITION)
+				{
+					for(int p=0; p<pItem->m_NumPoints; p++)
+						pEnv->m_lPoints[p].m_aValues[3] = f2fx(1.0f);
+				}
+				
 				if(pItem->m_aName[0] != -1)	// compatibility with old maps
 					IntsToStr(pItem->m_aName, sizeof(pItem->m_aName)/sizeof(int), pEnv->m_aName);
 				m_lEnvelopes.add(pEnv);
-				if(pItem->m_Version >= 2)
+				if(pItem->m_Version >= CMapItemEnvelope::VERSION_WITH_SYNC)
 					pEnv->m_Synchronized = pItem->m_Synchronized;
 			}
 		}

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -592,7 +592,7 @@ int CEditor::PopupQuad(CEditor *pEditor, CUIRect View)
 		if(Step != 0)
 		{
 			for(; Index >= -1 && Index < pEditor->m_Map.m_lEnvelopes.size(); Index += Step)
-				if(Index == -1 || pEditor->m_Map.m_lEnvelopes[Index]->m_Channels == 3)
+				if(Index == -1 || pEditor->m_Map.m_lEnvelopes[Index]->m_Type == ENVTYPE_POSITION)
 				{
 					pQuad->m_PosEnv = Index;
 					break;
@@ -607,7 +607,7 @@ int CEditor::PopupQuad(CEditor *pEditor, CUIRect View)
 		if(Step != 0)
 		{
 			for(; Index >= -1 && Index < pEditor->m_Map.m_lEnvelopes.size(); Index += Step)
-				if(Index == -1 || pEditor->m_Map.m_lEnvelopes[Index]->m_Channels == 4)
+				if(Index == -1 || pEditor->m_Map.m_lEnvelopes[Index]->m_Type == ENVTYPE_COLOR)
 				{
 					pQuad->m_ColorEnv = Index;
 					break;
@@ -741,7 +741,7 @@ int CEditor::PopupSource(CEditor *pEditor, CUIRect View)
 		if(Step != 0)
 		{
 			for(; Index >= -1 && Index < pEditor->m_Map.m_lEnvelopes.size(); Index += Step)
-				if(Index == -1 || pEditor->m_Map.m_lEnvelopes[Index]->m_Channels == 1)
+				if(Index == -1 || pEditor->m_Map.m_lEnvelopes[Index]->m_Type == ENVTYPE_SOUND)
 				{
 					pSource->m_SoundEnv = Index;
 					break;

--- a/src/game/mapitems.h
+++ b/src/game/mapitems.h
@@ -184,6 +184,11 @@ enum
 	TILESLAYERFLAG_TUNE=32,
 
 	ENTITY_OFFSET=255-16*4,
+	
+	ENVTYPE_UNKNOWN=-1,
+	ENVTYPE_POSITION=0,
+	ENVTYPE_COLOR,
+	ENVTYPE_SOUND,
 };
 
 struct CPoint
@@ -337,10 +342,20 @@ struct CMapItemEnvelope_v1
 	int m_aName[8];
 } ;
 
-struct CMapItemEnvelope : public CMapItemEnvelope_v1
+struct CMapItemEnvelope_v2 : public CMapItemEnvelope_v1
 {
-	enum { CURRENT_VERSION=2 };
+	enum { VERSION_WITH_SYNC=2 };
 	int m_Synchronized;
+};
+
+struct CMapItemEnvelope : public CMapItemEnvelope_v2
+{
+	enum
+	{
+		CURRENT_VERSION=3,
+		VERSION_WITH_SCALING=3,
+	};
+	int m_Type;
 };
 
 struct CSoundShape


### PR DESCRIPTION
Scaling is an important transform that is missing in TeeWorlds animations. This commit use the fourth channel of Pos Envelopes to store a scaling information. Since TeeWorlds use the number of channels to deduce the type of envelopes, I've implemented a new version of CMapItemEnvelope that store directly the type of envelopes, while the number of channels is faked to keep backward compatibility. The "type" field is not an obligation but I found it more elegant and it could be used in the future for other kinds of animation (tune animation, layer order animation, ...)
With old versions of DDNet, the scaling is just ignored, meaning that like for sounds, gameplay mechanics should not rely on scaling.

This commit contains the client and the editor part.