### PR TITLE
Remove dump_binds. Let bind_print dump all. Fixes #634

### DIFF
--- a/src/game/client/components/binds.cpp
+++ b/src/game/client/components/binds.cpp
@@ -154,7 +154,7 @@ void CBinds::OnConsoleInit()
 		pConfig->RegisterCallback(ConfigSaveCallback, this);
 
 	Console()->Register("bind", "s[key] r[command]", CFGFLAG_CLIENT, ConBind, this, "Bind key to execute the command");
-	Console()->Register("bind_print", "?s[key]", CFGFLAG_CLIENT, ConBindPrint, this, "Print command executed by this keybinding");
+	Console()->Register("dump_binds", "?s[key]", CFGFLAG_CLIENT, ConDumpBinds, this, "Print command executed by this keybindind or all binds");
 	Console()->Register("unbind", "s[key]", CFGFLAG_CLIENT, ConUnbind, this, "Unbind key");
 	Console()->Register("unbindall", "", CFGFLAG_CLIENT, ConUnbindAll, this, "Unbind all keys");
 
@@ -179,7 +179,7 @@ void CBinds::ConBind(IConsole::IResult *pResult, void *pUserData)
 	pBinds->Bind(id, pResult->GetString(1));
 }
 
-void CBinds::ConBindPrint(IConsole::IResult *pResult, void *pUserData)
+void CBinds::ConDumpBinds(IConsole::IResult *pResult, void *pUserData)
 {
 	CBinds *pBinds = (CBinds *)pUserData;
 	if(pResult->NumArguments() == 1)
@@ -190,7 +190,7 @@ void CBinds::ConBindPrint(IConsole::IResult *pResult, void *pUserData)
 		int id = pBinds->GetKeyID(pKeyName);
 		if (!id)
 		{
-			str_format(aBuf, sizeof(aBuf), "key %s not found", pKeyName);
+			str_format(aBuf, sizeof(aBuf), "key '%s' not found", pKeyName);
 			pBinds->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "binds", aBuf);
 		}
 		else

--- a/src/game/client/components/binds.cpp
+++ b/src/game/client/components/binds.cpp
@@ -154,10 +154,9 @@ void CBinds::OnConsoleInit()
 		pConfig->RegisterCallback(ConfigSaveCallback, this);
 
 	Console()->Register("bind", "s[key] r[command]", CFGFLAG_CLIENT, ConBind, this, "Bind key to execute the command");
-	Console()->Register("bind_print", "s[key]", CFGFLAG_CLIENT, ConBindPrint, this, "Print command executed by this keybinding");
+	Console()->Register("bind_print", "?s[key]", CFGFLAG_CLIENT, ConBindPrint, this, "Print command executed by this keybinding");
 	Console()->Register("unbind", "s[key]", CFGFLAG_CLIENT, ConUnbind, this, "Unbind key");
 	Console()->Register("unbindall", "", CFGFLAG_CLIENT, ConUnbindAll, this, "Unbind all keys");
-	Console()->Register("dump_binds", "", CFGFLAG_CLIENT, ConDumpBinds, this, "Dump binds");
 
 	// default bindings
 	SetDefaults();
@@ -183,32 +182,39 @@ void CBinds::ConBind(IConsole::IResult *pResult, void *pUserData)
 void CBinds::ConBindPrint(IConsole::IResult *pResult, void *pUserData)
 {
 	CBinds *pBinds = (CBinds *)pUserData;
-	const char *pKeyName = pResult->GetString(0);
-	int id = pBinds->GetKeyID(pKeyName);
-
-	if (!id)
+	if(pResult->NumArguments() == 1)
 	{
 		char aBuf[256];
-		str_format(aBuf, sizeof(aBuf), "key %s not found", pKeyName);
-		pBinds->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "binds", aBuf);
+		const char *pKeyName = pResult->GetString(0);
+
+		int id = pBinds->GetKeyID(pKeyName);
+		if (!id)
+		{
+			str_format(aBuf, sizeof(aBuf), "key %s not found", pKeyName);
+			pBinds->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "binds", aBuf);
+		}
+		else
+		{
+			if (pBinds->m_aaKeyBindings[id][0] == '\0')
+				str_format(aBuf, sizeof(aBuf), "%s (%d) is not bound", pKeyName, id);
+			else
+				str_format(aBuf, sizeof(aBuf), "%s (%d) = %s", pKeyName, id, pBinds->m_aaKeyBindings[id]);
+
+			pBinds->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "binds", aBuf);
+		}
 	}
-	else 
+	else if(pResult->NumArguments() == 0)
 	{
-		char aBuf[256];
-
-		if (pBinds->m_aaKeyBindings[id][0] == '\0')
+		char aBuf[1024];
+		for(int i = 0; i < KEY_LAST; i++)
 		{
-			str_format(aBuf, sizeof(aBuf), "%s (%d) is not bound", pKeyName, id);
+			if(pBinds->m_aaKeyBindings[i][0] == 0)
+				continue;
+			str_format(aBuf, sizeof(aBuf), "%s (%d) = %s", pBinds->Input()->KeyName(i), i, pBinds->m_aaKeyBindings[i]);
+			pBinds->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "binds", aBuf);
 		}
-		else 
-		{
-			str_format(aBuf, sizeof(aBuf), "%s (%d) = %s", pKeyName, id, pBinds->m_aaKeyBindings[id]);
-		}
-		
-		pBinds->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "binds", aBuf);
 	}
 }
-
 
 void CBinds::ConUnbind(IConsole::IResult *pResult, void *pUserData)
 {
@@ -227,25 +233,10 @@ void CBinds::ConUnbind(IConsole::IResult *pResult, void *pUserData)
 	pBinds->Bind(id, "");
 }
 
-
 void CBinds::ConUnbindAll(IConsole::IResult *pResult, void *pUserData)
 {
 	CBinds *pBinds = (CBinds *)pUserData;
 	pBinds->UnbindAll();
-}
-
-
-void CBinds::ConDumpBinds(IConsole::IResult *pResult, void *pUserData)
-{
-	CBinds *pBinds = (CBinds *)pUserData;
-	char aBuf[1024];
-	for(int i = 0; i < KEY_LAST; i++)
-	{
-		if(pBinds->m_aaKeyBindings[i][0] == 0)
-			continue;
-		str_format(aBuf, sizeof(aBuf), "%s (%d) = %s", pBinds->Input()->KeyName(i), i, pBinds->m_aaKeyBindings[i]);
-		pBinds->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "binds", aBuf);
-	}
 }
 
 int CBinds::GetKeyID(const char *pKeyName)

--- a/src/game/client/components/binds.h
+++ b/src/game/client/components/binds.h
@@ -15,7 +15,6 @@ class CBinds : public CComponent
 	static void ConBindPrint(IConsole::IResult *pResult, void *pUserData);
 	static void ConUnbind(IConsole::IResult *pResult, void *pUserData);
 	static void ConUnbindAll(IConsole::IResult *pResult, void *pUserData);
-	static void ConDumpBinds(IConsole::IResult *pResult, void *pUserData);
 	class IConsole *GetConsole() const { return Console(); }
 
 	static void ConfigSaveCallback(class IConfig *pConfig, void *pUserData);

--- a/src/game/client/components/binds.h
+++ b/src/game/client/components/binds.h
@@ -12,7 +12,7 @@ class CBinds : public CComponent
 	int GetKeyID(const char *pKeyName);
 
 	static void ConBind(IConsole::IResult *pResult, void *pUserData);
-	static void ConBindPrint(IConsole::IResult *pResult, void *pUserData);
+	static void ConDumpBinds(IConsole::IResult *pResult, void *pUserData);
 	static void ConUnbind(IConsole::IResult *pResult, void *pUserData);
 	static void ConUnbindAll(IConsole::IResult *pResult, void *pUserData);
 	class IConsole *GetConsole() const { return Console(); }


### PR DESCRIPTION
`bind_print` without any arguments now dumps all binds this effectively deprecates `dump_binds`.