### PR TITLE
Fix handling of default passwords

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -3297,7 +3297,7 @@ void CClient::RegisterCommands()
 	m_pConsole->Register("screenshot", "", CFGFLAG_CLIENT, Con_Screenshot, this, "Take a screenshot");
 	m_pConsole->Register("rcon", "r[rcon-command]", CFGFLAG_CLIENT, Con_Rcon, this, "Send specified command to rcon");
 	m_pConsole->Register("rcon_auth", "s[password]", CFGFLAG_CLIENT, Con_RconAuth, this, "Authenticate to rcon");
-	m_pConsole->Register("rcon_login", "s[username] s[password]", CFGFLAG_CLIENT, Con_RconLogin, this, "Authenticate to rcon with a username");
+	m_pConsole->Register("rcon_login", "s[username] r[password]", CFGFLAG_CLIENT, Con_RconLogin, this, "Authenticate to rcon with a username");
 	m_pConsole->Register("play", "r[file]", CFGFLAG_CLIENT|CFGFLAG_STORE, Con_Play, this, "Play the file specified");
 	m_pConsole->Register("record", "?s[file]", CFGFLAG_CLIENT, Con_Record, this, "Record to the file");
 	m_pConsole->Register("stoprecord", "", CFGFLAG_CLIENT, Con_StopRecord, this, "Stop recording");


### PR DESCRIPTION
It was horribly broken before. :) Only the first password set via
`sv_rcon*_password` worked, and that only due to a bug in `AddHashKey`
-- `AddHashKey` incorrectly assumed that only key slots greater than 0
are valid, but 0 is valid too.

Fix default passwords on password removal, fix no admin password being
generated if you only had `sv_rcon_mod_password` or
`sv_rcon_helper_password` set. Add an assert that would have caught our
mistake.