### PR TITLE
Fix #586 (display the killing clipping rectangle)

### DIFF
--- a/src/game/client/components/maplayers.cpp
+++ b/src/game/client/components/maplayers.cpp
@@ -264,7 +264,7 @@ void CMapLayers::OnRender()
 														EnvelopeEval, this, pTMap->m_ColorEnv, pTMap->m_ColorEnvOffset);
 						Graphics()->BlendNormal();
 						
-						//Draw kill tiles outside the entity clipping rectangle
+						// Draw kill tiles outside the entity clipping rectangle
 						if(IsGameLayer)
 						{
 							
@@ -272,10 +272,10 @@ void CMapLayers::OnRender()
 							double Seconds = time_get()/(double)time_freq();
 							vec4 ColorHint = vec4(1.0f, 1.0f, 1.0f, 0.3f + 0.7f*(1.0+sin(2.0f*pi*Seconds/3.f))/2.0f);
 							
-							RenderTools()->RenderTileRetangle(-201, -201, pTMap->m_Width+402, pTMap->m_Height+402,
+							RenderTools()->RenderTileRectangle(-201, -201, pTMap->m_Width+402, pTMap->m_Height+402,
 							                                  0, TILE_DEATH, //Display air inside, death outside
 							                                  32.0f, Color*ColorHint, TILERENDERFLAG_EXTEND|LAYERRENDERFLAG_TRANSPARENT,
-															  EnvelopeEval, this, pTMap->m_ColorEnv, pTMap->m_ColorEnvOffset);
+							                                  EnvelopeEval, this, pTMap->m_ColorEnv, pTMap->m_ColorEnvOffset);
 						}
 						
 						RenderTools()->RenderTilemap(pTiles, pTMap->m_Width, pTMap->m_Height, 32.0f, Color, TILERENDERFLAG_EXTEND|LAYERRENDERFLAG_TRANSPARENT,

--- a/src/game/client/components/maplayers.cpp
+++ b/src/game/client/components/maplayers.cpp
@@ -263,6 +263,21 @@ void CMapLayers::OnRender()
 						RenderTools()->RenderTilemap(pTiles, pTMap->m_Width, pTMap->m_Height, 32.0f, Color, TILERENDERFLAG_EXTEND|LAYERRENDERFLAG_OPAQUE,
 														EnvelopeEval, this, pTMap->m_ColorEnv, pTMap->m_ColorEnvOffset);
 						Graphics()->BlendNormal();
+						
+						//Draw kill tiles outside the entity clipping rectangle
+						if(IsGameLayer)
+						{
+							
+							//Slow blinking to hint that it's not a part of the map
+							double Seconds = time_get()/(double)time_freq();
+							vec4 ColorHint = vec4(1.0f, 1.0f, 1.0f, 0.3f + 0.7f*(1.0+sin(2.0f*pi*Seconds/3.f))/2.0f);
+							
+							RenderTools()->RenderTileRetangle(-201, -201, pTMap->m_Width+402, pTMap->m_Height+402,
+							                                  0, TILE_DEATH, //Display air inside, death outside
+							                                  32.0f, Color*ColorHint, TILERENDERFLAG_EXTEND|LAYERRENDERFLAG_TRANSPARENT,
+															  EnvelopeEval, this, pTMap->m_ColorEnv, pTMap->m_ColorEnvOffset);
+						}
+						
 						RenderTools()->RenderTilemap(pTiles, pTMap->m_Width, pTMap->m_Height, 32.0f, Color, TILERENDERFLAG_EXTEND|LAYERRENDERFLAG_TRANSPARENT,
 														EnvelopeEval, this, pTMap->m_ColorEnv, pTMap->m_ColorEnvOffset);
 					}

--- a/src/game/client/components/maplayers.cpp
+++ b/src/game/client/components/maplayers.cpp
@@ -273,9 +273,9 @@ void CMapLayers::OnRender()
 							vec4 ColorHint = vec4(1.0f, 1.0f, 1.0f, 0.3f + 0.7f*(1.0+sin(2.0f*pi*Seconds/3.f))/2.0f);
 							
 							RenderTools()->RenderTileRectangle(-201, -201, pTMap->m_Width+402, pTMap->m_Height+402,
-							                                  0, TILE_DEATH, // display air inside, death outside
-							                                  32.0f, Color*ColorHint, TILERENDERFLAG_EXTEND|LAYERRENDERFLAG_TRANSPARENT,
-							                                  EnvelopeEval, this, pTMap->m_ColorEnv, pTMap->m_ColorEnvOffset);
+							                                   0, TILE_DEATH, // display air inside, death outside
+							                                   32.0f, Color*ColorHint, TILERENDERFLAG_EXTEND|LAYERRENDERFLAG_TRANSPARENT,
+							                                   EnvelopeEval, this, pTMap->m_ColorEnv, pTMap->m_ColorEnvOffset);
 						}
 						
 						RenderTools()->RenderTilemap(pTiles, pTMap->m_Width, pTMap->m_Height, 32.0f, Color, TILERENDERFLAG_EXTEND|LAYERRENDERFLAG_TRANSPARENT,

--- a/src/game/client/components/maplayers.cpp
+++ b/src/game/client/components/maplayers.cpp
@@ -264,16 +264,16 @@ void CMapLayers::OnRender()
 														EnvelopeEval, this, pTMap->m_ColorEnv, pTMap->m_ColorEnvOffset);
 						Graphics()->BlendNormal();
 						
-						// Draw kill tiles outside the entity clipping rectangle
+						// draw kill tiles outside the entity clipping rectangle
 						if(IsGameLayer)
 						{
 							
-							//Slow blinking to hint that it's not a part of the map
+							// slow blinking to hint that it's not a part of the map
 							double Seconds = time_get()/(double)time_freq();
 							vec4 ColorHint = vec4(1.0f, 1.0f, 1.0f, 0.3f + 0.7f*(1.0+sin(2.0f*pi*Seconds/3.f))/2.0f);
 							
 							RenderTools()->RenderTileRectangle(-201, -201, pTMap->m_Width+402, pTMap->m_Height+402,
-							                                  0, TILE_DEATH, //Display air inside, death outside
+							                                  0, TILE_DEATH, // display air inside, death outside
 							                                  32.0f, Color*ColorHint, TILERENDERFLAG_EXTEND|LAYERRENDERFLAG_TRANSPARENT,
 							                                  EnvelopeEval, this, pTMap->m_ColorEnv, pTMap->m_ColorEnvOffset);
 						}

--- a/src/game/client/render.h
+++ b/src/game/client/render.h
@@ -76,7 +76,8 @@ public:
 	void RenderQuads(CQuad *pQuads, int NumQuads, int Flags, ENVELOPE_EVAL pfnEval, void *pUser);
 	void ForceRenderQuads(CQuad *pQuads, int NumQuads, int Flags, ENVELOPE_EVAL pfnEval, void *pUser, float Alpha = 1.0f);
 	void RenderTilemap(CTile *pTiles, int w, int h, float Scale, vec4 Color, int RenderFlags, ENVELOPE_EVAL pfnEval, void *pUser, int ColorEnv, int ColorEnvOffset);
-
+	void RenderTileRetangle(int X, int Y, int w, int h, unsigned char indexIn, unsigned char indexOut, float Scale, vec4 Color, int RenderFlags, ENVELOPE_EVAL pfnEval, void *pUser, int ColorEnv, int ColorEnvOffset);
+	
 	// helpers
 	void MapscreenToWorld(float CenterX, float CenterY, float ParallaxX, float ParallaxY,
 		float OffsetX, float OffsetY, float Aspect, float Zoom, float *pPoints);

--- a/src/game/client/render.h
+++ b/src/game/client/render.h
@@ -76,8 +76,11 @@ public:
 	void RenderQuads(CQuad *pQuads, int NumQuads, int Flags, ENVELOPE_EVAL pfnEval, void *pUser);
 	void ForceRenderQuads(CQuad *pQuads, int NumQuads, int Flags, ENVELOPE_EVAL pfnEval, void *pUser, float Alpha = 1.0f);
 	void RenderTilemap(CTile *pTiles, int w, int h, float Scale, vec4 Color, int RenderFlags, ENVELOPE_EVAL pfnEval, void *pUser, int ColorEnv, int ColorEnvOffset);
-	void RenderTileRetangle(int X, int Y, int w, int h, unsigned char indexIn, unsigned char indexOut, float Scale, vec4 Color, int RenderFlags, ENVELOPE_EVAL pfnEval, void *pUser, int ColorEnv, int ColorEnvOffset);
-	
+
+	// render a rectangle made of IndexIn tiles, over a background made of IndexOut tiles
+	// the rectangle include all tiles in [RectX, RectX+RectW-1] x [RectY, RectY+RectH-1]
+	void RenderTileRectangle(int RectX, int RectY, int RectW, int RectH, unsigned char IndexIn, unsigned char IndexOut, float Scale, vec4 Color, int RenderFlags, ENVELOPE_EVAL pfnEval, void *pUser, int ColorEnv, int ColorEnvOffset);
+
 	// helpers
 	void MapscreenToWorld(float CenterX, float CenterY, float ParallaxX, float ParallaxY,
 		float OffsetX, float OffsetY, float Aspect, float Zoom, float *pPoints);

--- a/src/game/client/render_map.cpp
+++ b/src/game/client/render_map.cpp
@@ -176,13 +176,13 @@ void CRenderTools::ForceRenderQuads(CQuad *pQuads, int NumQuads, int RenderFlags
 	Graphics()->QuadsEnd();
 }
 
-void CRenderTools::RenderTileRetangle(int X, int Y, int w, int h, unsigned char indexIn, unsigned char indexOut, float Scale, vec4 Color, int RenderFlags,
-									ENVELOPE_EVAL pfnEval, void *pUser, int ColorEnv, int ColorEnvOffset)
+void CRenderTools::RenderTileRectangle(int RectX, int RectY, int RectW, int RectH,
+                                       unsigned char IndexIn, unsigned char IndexOut,
+                                       float Scale, vec4 Color, int RenderFlags,
+                                       ENVELOPE_EVAL pfnEval, void *pUser, int ColorEnv, int ColorEnvOffset)
 {
-	//Graphics()->TextureSet(img_get(tmap->image));
 	float ScreenX0, ScreenY0, ScreenX1, ScreenY1;
 	Graphics()->GetScreen(&ScreenX0, &ScreenY0, &ScreenX1, &ScreenY1);
-	//Graphics()->MapScreen(screen_x0-50, screen_y0-50, screen_x1+50, screen_y1+50);
 
 	// calculate the final pixelsize for the tiles
 	float TilePixelSize = 1024/32.0f;
@@ -214,9 +214,10 @@ void CRenderTools::RenderTileRetangle(int X, int Y, int w, int h, unsigned char 
 	float Nudge = (0.5f/TexSize) * (1/FinalTilesetScale);
 
 	for(int y = StartY; y < EndY; y++)
+	{
 		for(int x = StartX; x < EndX; x++)
 		{
-			unsigned char Index = (x<X || x>=X+w || y<Y || y>Y+h) ? indexOut : indexIn;
+			unsigned char Index = (x>=RectX && x<RectX+RectW && y>=RectY && y<RectY+RectH) ? IndexIn : IndexOut;
 			if(Index)
 			{
 				bool Render = false;
@@ -225,7 +226,6 @@ void CRenderTools::RenderTileRetangle(int X, int Y, int w, int h, unsigned char 
 
 				if(Render)
 				{
-
 					int tx = Index%16;
 					int ty = Index/16;
 					int Px0 = tx*(1024/16);
@@ -248,18 +248,17 @@ void CRenderTools::RenderTileRetangle(int X, int Y, int w, int h, unsigned char 
 				}
 			}
 		}
+	}
 
 	Graphics()->QuadsEnd();
 	Graphics()->MapScreen(ScreenX0, ScreenY0, ScreenX1, ScreenY1);
 }
 
 void CRenderTools::RenderTilemap(CTile *pTiles, int w, int h, float Scale, vec4 Color, int RenderFlags,
-									ENVELOPE_EVAL pfnEval, void *pUser, int ColorEnv, int ColorEnvOffset)
+                                 ENVELOPE_EVAL pfnEval, void *pUser, int ColorEnv, int ColorEnvOffset)
 {
-	//Graphics()->TextureSet(img_get(tmap->image));
 	float ScreenX0, ScreenY0, ScreenX1, ScreenY1;
 	Graphics()->GetScreen(&ScreenX0, &ScreenY0, &ScreenX1, &ScreenY1);
-	//Graphics()->MapScreen(screen_x0-50, screen_y0-50, screen_x1+50, screen_y1+50);
 
 	// calculate the final pixelsize for the tiles
 	float TilePixelSize = 1024/32.0f;
@@ -291,6 +290,7 @@ void CRenderTools::RenderTilemap(CTile *pTiles, int w, int h, float Scale, vec4 
 	float Nudge = (0.5f/TexSize) * (1/FinalTilesetScale);
 
 	for(int y = StartY; y < EndY; y++)
+	{
 		for(int x = StartX; x < EndX; x++)
 		{
 			int mx = x;
@@ -340,7 +340,6 @@ void CRenderTools::RenderTilemap(CTile *pTiles, int w, int h, float Scale, vec4 
 
 				if(Render)
 				{
-
 					int tx = Index%16;
 					int ty = Index/16;
 					int Px0 = tx*(1024/16);
@@ -394,6 +393,7 @@ void CRenderTools::RenderTilemap(CTile *pTiles, int w, int h, float Scale, vec4 
 			}
 			x += pTiles[c].m_Skip;
 		}
+	}
 
 	Graphics()->QuadsEnd();
 	Graphics()->MapScreen(ScreenX0, ScreenY0, ScreenX1, ScreenY1);

--- a/src/game/client/render_map.cpp
+++ b/src/game/client/render_map.cpp
@@ -176,6 +176,83 @@ void CRenderTools::ForceRenderQuads(CQuad *pQuads, int NumQuads, int RenderFlags
 	Graphics()->QuadsEnd();
 }
 
+void CRenderTools::RenderTileRetangle(int X, int Y, int w, int h, unsigned char indexIn, unsigned char indexOut, float Scale, vec4 Color, int RenderFlags,
+									ENVELOPE_EVAL pfnEval, void *pUser, int ColorEnv, int ColorEnvOffset)
+{
+	//Graphics()->TextureSet(img_get(tmap->image));
+	float ScreenX0, ScreenY0, ScreenX1, ScreenY1;
+	Graphics()->GetScreen(&ScreenX0, &ScreenY0, &ScreenX1, &ScreenY1);
+	//Graphics()->MapScreen(screen_x0-50, screen_y0-50, screen_x1+50, screen_y1+50);
+
+	// calculate the final pixelsize for the tiles
+	float TilePixelSize = 1024/32.0f;
+	float FinalTileSize = Scale/(ScreenX1-ScreenX0) * Graphics()->ScreenWidth();
+	float FinalTilesetScale = FinalTileSize/TilePixelSize;
+
+	float r=1, g=1, b=1, a=1;
+	if(ColorEnv >= 0)
+	{
+		float aChannels[4];
+		pfnEval(ColorEnvOffset/1000.0f, ColorEnv, aChannels, pUser);
+		r = aChannels[0];
+		g = aChannels[1];
+		b = aChannels[2];
+		a = aChannels[3];
+	}
+
+	Graphics()->QuadsBegin();
+	Graphics()->SetColor(Color.r*r, Color.g*g, Color.b*b, Color.a*a);
+
+	int StartY = (int)(ScreenY0/Scale)-1;
+	int StartX = (int)(ScreenX0/Scale)-1;
+	int EndY = (int)(ScreenY1/Scale)+1;
+	int EndX = (int)(ScreenX1/Scale)+1;
+
+	// adjust the texture shift according to mipmap level
+	float TexSize = 1024.0f;
+	float Frac = (1.25f/TexSize) * (1/FinalTilesetScale);
+	float Nudge = (0.5f/TexSize) * (1/FinalTilesetScale);
+
+	for(int y = StartY; y < EndY; y++)
+		for(int x = StartX; x < EndX; x++)
+		{
+			unsigned char Index = (x<X || x>=X+w || y<Y || y>Y+h) ? indexOut : indexIn;
+			if(Index)
+			{
+				bool Render = false;
+				if(RenderFlags&LAYERRENDERFLAG_TRANSPARENT)
+					Render = true;
+
+				if(Render)
+				{
+
+					int tx = Index%16;
+					int ty = Index/16;
+					int Px0 = tx*(1024/16);
+					int Py0 = ty*(1024/16);
+					int Px1 = Px0+(1024/16)-1;
+					int Py1 = Py0+(1024/16)-1;
+
+					float x0 = Nudge + Px0/TexSize+Frac;
+					float y0 = Nudge + Py0/TexSize+Frac;
+					float x1 = Nudge + Px1/TexSize-Frac;
+					float y1 = Nudge + Py0/TexSize+Frac;
+					float x2 = Nudge + Px1/TexSize-Frac;
+					float y2 = Nudge + Py1/TexSize-Frac;
+					float x3 = Nudge + Px0/TexSize+Frac;
+					float y3 = Nudge + Py1/TexSize-Frac;
+
+					Graphics()->QuadsSetSubsetFree(x0, y0, x1, y1, x2, y2, x3, y3);
+					IGraphics::CQuadItem QuadItem(x*Scale, y*Scale, Scale, Scale);
+					Graphics()->QuadsDrawTL(&QuadItem, 1);
+				}
+			}
+		}
+
+	Graphics()->QuadsEnd();
+	Graphics()->MapScreen(ScreenX0, ScreenY0, ScreenX1, ScreenY1);
+}
+
 void CRenderTools::RenderTilemap(CTile *pTiles, int w, int h, float Scale, vec4 Color, int RenderFlags,
 									ENVELOPE_EVAL pfnEval, void *pUser, int ColorEnv, int ColorEnvOffset)
 {


### PR DESCRIPTION
Could be faster if we just render 8 rectangles with a "death tile" texture, but we need 3D texture for that (see #675).

I can of course remove the blinking effect, but I think it's better to give a hint that those tiles are not really in the map