### PR TITLE
Refcount the IME usage

### DIFF
--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -49,7 +49,7 @@ CInput::CInput()
 	m_VideoRestartNeeded = 0;
 	m_pClipboardText = NULL;
 
-	m_IsEditingText = false;
+	m_IsEditingText = 0;
 }
 
 void CInput::Init()
@@ -143,18 +143,34 @@ void CInput::NextFrame()
 
 bool CInput::GetIMEState()
 {
-	return m_IsEditingText;
+	return m_IsEditingText != 0;
 }
 
-void CInput::SetIMEState(bool activate)
+void CInput::SetIMEState(bool Activate)
 {
-	if (activate)
-		SDL_StartTextInput();
+	if(Activate)
+	{
+		if(m_IsEditingText == 0)
+		{
+			SDL_StartTextInput();
+		}
+		else
+		{
+			m_IsEditingText++;
+		}
+	}
 	else
 	{
-		// force stop editing
-		SDL_StopTextInput();
-		m_IsEditingText = false;
+		if(m_IsEditingText == 0)
+		{
+			return;
+		}
+		m_IsEditingText--;
+		if(m_IsEditingText == 0)
+		{
+			// force stop editing
+			SDL_StopTextInput();
+		}
 	}
 }
 
@@ -200,7 +216,7 @@ int CInput::Update()
 			{
 				case SDL_TEXTEDITING:
 				{
-					if (str_length(Event.edit.text))
+					if(str_length(Event.edit.text))
 					{
 						str_format(m_pEditingText, sizeof(m_pEditingText), Event.edit.text);
 						m_EditingCursor = 0;
@@ -318,7 +334,7 @@ int CInput::Update()
 					return 1;
 			}
 
-			if(Key >= 0 && Key < g_MaxKeys && !IgnoreKeys && !m_IsEditingText)
+			if(Key >= 0 && Key < g_MaxKeys && !IgnoreKeys && m_IsEditingText == 0)
 			{
 				if(Action&IInput::FLAG_PRESS)
 				{

--- a/src/engine/client/input.h
+++ b/src/engine/client/input.h
@@ -26,7 +26,7 @@ class CInput : public IEngineInput
 	int m_InputCounter;
 
 	//ime support
-	bool m_IsEditingText;
+	unsigned int m_IsEditingText;
 	char m_pEditingText[32];
 	int m_EditingCursor;
 
@@ -55,7 +55,7 @@ public:
 	virtual int VideoRestartNeeded();
 
 	virtual bool GetIMEState();
-	virtual void SetIMEState(bool activate);
+	virtual void SetIMEState(bool Activate);
 	virtual const char* GetIMECandidate();
 	virtual int GetEditingCursor();
 };


### PR DESCRIPTION
This fixes #577, the bug that the text editing in chat cannot continue
after opening and closing the console.

Thanks to Henningstone and necropotame for finding out what caused this
bug.