### PR TITLE
Add benchmark for text rendering

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -310,7 +310,7 @@ if(CLIENT)
   endif()
   
   # Benchmark for text rendering
-  set(TARGET_BM_TEXTRENDERING benchmarks_textrendering)
+  set(TARGET_BM_TEXTRENDERING benchmark_textrendering)
   add_executable(${TARGET_BM_TEXTRENDERING}
     "src/benchmarks/textrendering.cpp"
     "src/engine/client/graphics_threaded.cpp"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -272,6 +272,15 @@ if(CLIENT)
   set(DEPS_CLIENT ${DEPS} ${DEP_JSON} ${DEP_PNG} ${DEP_WAV})
 
   # Libraries
+  set(INCLUDE_DIRS_CLIENT
+    ${CURL_INCLUDE_DIRS}
+    ${FREETYPE_INCLUDE_DIRS}
+    ${OGG_INCLUDE_DIRS}
+    ${OPUSFILE_INCLUDE_DIRS}
+    ${OPUS_INCLUDE_DIRS}
+    ${SDL2_INCLUDE_DIRS}
+  )
+  
   set(LIBS_CLIENT
     ${LIBS}
     ${CURL_LIBRARIES}
@@ -293,19 +302,27 @@ if(CLIENT)
   )
   target_link_libraries(${TARGET_CLIENT} ${LIBS_CLIENT})
 
-  target_include_directories(${TARGET_CLIENT} PRIVATE
-    ${CURL_INCLUDE_DIRS}
-    ${FREETYPE_INCLUDE_DIRS}
-    ${OGG_INCLUDE_DIRS}
-    ${OPUSFILE_INCLUDE_DIRS}
-    ${OPUS_INCLUDE_DIRS}
-    ${SDL2_INCLUDE_DIRS}
-  )
+  target_include_directories(${TARGET_CLIENT} PRIVATE ${INCLUDE_DIRS_CLIENT})
   list(APPEND TARGETS_OWN ${TARGET_CLIENT})
 
   if(TARGET_OS STREQUAL "windows")
     target_sources(${TARGET_CLIENT} PRIVATE "other/icons/DDNet.rc")
   endif()
+  
+  # Benchmark for text rendering
+  set(TARGET_BM_TEXTRENDERING benchmarks_textrendering)
+  add_executable(${TARGET_BM_TEXTRENDERING}
+    "src/benchmarks/textrendering.cpp"
+    "src/engine/client/graphics_threaded.cpp"
+    "src/engine/client/backend_sdl.cpp"
+    "src/engine/client/text.cpp"
+    ${DEPS_CLIENT}
+    $<TARGET_OBJECTS:engine-shared>
+    $<TARGET_OBJECTS:game-shared>
+  )
+  target_link_libraries(${TARGET_BM_TEXTRENDERING} ${LIBS_CLIENT})
+  target_include_directories(${TARGET_BM_TEXTRENDERING} PRIVATE ${INCLUDE_DIRS_CLIENT})
+  list(APPEND TARGETS_OWN ${TARGET_BM_TEXTRENDERING})
 endif()
 
 

--- a/src/benchmarks/textrendering.cpp
+++ b/src/benchmarks/textrendering.cpp
@@ -1,0 +1,131 @@
+#include "SDL.h"
+#ifdef main
+#undef main
+#endif
+
+#include <engine/kernel.h>
+#include <engine/graphics.h>
+#include <engine/textrender.h>
+#include <base/math.h>
+
+#if defined(CONF_PLATFORM_MACOSX) || defined(__ANDROID__)
+extern "C" int SDL_main(int argc, char **argv_) // ignore_convention
+{
+	const char **argv = const_cast<const char **>(argv_);
+#else
+int main(int argc, const char **argv) // ignore_convention
+{
+#endif
+	dbg_logger_stdout();
+	
+	IKernel* pKernel = IKernel::Create();
+
+	// init SDL
+	{
+		if(SDL_Init(0) < 0)
+		{
+			dbg_msg("client", "unable to init SDL base: %s", SDL_GetError());
+			return 1;
+		}
+
+		atexit(SDL_Quit); // ignore_convention
+	}
+
+	// init graphics
+	IEngineGraphics* pGraphics = CreateEngineGraphicsThreaded();
+	pKernel->RegisterInterface(static_cast<IEngineGraphics*>(pGraphics));
+	pKernel->RegisterInterface(static_cast<IGraphics*>(pGraphics));
+	if(pGraphics->Init() != 0)
+	{
+		dbg_msg("client", "couldn't init graphics");
+		return 1;
+	}
+	
+	// init textrender
+	IEngineTextRender* pTextRender = CreateEngineTextRender();
+	pKernel->RegisterInterface(static_cast<IEngineTextRender*>(pTextRender));
+	pKernel->RegisterInterface(static_cast<ITextRender*>(pTextRender));
+	pTextRender->Init();
+	
+	static CFont *pDefaultFont = pTextRender->LoadFont("data/fonts/DejaVuSansCJKName.ttf");
+	pTextRender->SetDefaultFont(pDefaultFont);
+	
+	pGraphics->BlendNormal();
+	
+	dbg_msg("benchmark", "ready!");
+	
+	// text from https://fr.wikibooks.org/wiki/Translinguisme/Par_expression/Bonjour
+	static const char aaText[][1024] = 
+	{
+		"Hello DDNet",
+		"Bonjour",
+		"صَباح الخير",
+		"早晨",
+		"안녕하세요",
+		"नमस्कार",
+		"Günaydın",
+		"Καλιμέρα",
+		"おはようございます",
+		"สวัสดี ครับ",
+		"Здравствуй",
+		"בוקר טוב",
+		"Paakuinôgwzian",
+	};
+	static const int NbText = 13;
+	
+	int64 StartTime = time_get();
+	int FrameCounter = 0;
+	while(1)
+	{		
+		int64 CurrentTime = time_get();
+		double RenderTime = (CurrentTime - StartTime)/(double)time_freq();
+		
+		pGraphics->Clear(0.5f, 0.5f, 0.5f);
+		
+		float Height = 300.0f;
+		float Width = Height*pGraphics->ScreenAspect();
+		pGraphics->MapScreen(0.0f, 0.0f, Width, Height);
+		
+		//~ for(int i=0; i<NbText; i++)
+		//~ {
+			//~ float Angle = RenderTime*pi/2.0f + i*2.0f*pi/NbText;
+			//~ CTextCursor Cursor;
+			//~ pTextRender->SetCursor(&Cursor, Width/4, Height/2 + (i - NbText/2)*15.0f , 40.0f, TEXTFLAG_RENDER|TEXTFLAG_STOP_AT_END);
+			//~ Cursor.m_LineWidth = Width/2;
+			//~ pTextRender->TextEx(&Cursor, aaText[i], -1);
+		//~ }
+		//~ for(int i=0; i<NbText; i++)
+		//~ {
+			//~ float Angle = RenderTime*pi/2.0f + i*2.0f*pi/NbText;
+			//~ CTextCursor Cursor;
+			//~ pTextRender->SetCursor(&Cursor, Width/2, Height/2 + (i - NbText/2)*15.0f , 8.0f, TEXTFLAG_RENDER|TEXTFLAG_STOP_AT_END);
+			//~ Cursor.m_LineWidth = Width/2;
+			//~ pTextRender->TextEx(&Cursor, aaText[i], -1);
+		//~ }
+		for(int i=0; i<2*NbText; i++)
+		{
+			float Angle = RenderTime*pi/2.0f + i*pi/NbText;
+			CTextCursor Cursor;
+			pTextRender->SetCursor(&Cursor, Width/4 + sin(Angle)*100.f, Height/2 + cos(Angle)*100.f, 8.0f + (sin(Angle)+1)*20.0, TEXTFLAG_RENDER|TEXTFLAG_STOP_AT_END);
+			Cursor.m_LineWidth = Width;
+			pTextRender->TextEx(&Cursor, aaText[i%NbText], -1);
+		}
+		
+		pGraphics->Swap();
+		
+		FrameCounter++;
+		CurrentTime = time_get();
+		if(CurrentTime - StartTime > time_freq()*10)
+		{
+			double Time = (CurrentTime - StartTime)/(double)time_freq();
+			dbg_msg("benchmark", "result: %lf fps", (double)FrameCounter / Time);
+			break;
+		}
+	}
+	
+	delete pTextRender;
+	delete pGraphics;
+	delete pKernel;
+
+	return 0;
+}

--- a/src/benchmarks/textrendering.cpp
+++ b/src/benchmarks/textrendering.cpp
@@ -18,7 +18,7 @@ int main(int argc, const char **argv) // ignore_convention
 #endif
 	dbg_logger_stdout();
 	
-	IKernel* pKernel = IKernel::Create();
+	IKernel *pKernel = IKernel::Create();
 
 	// init SDL
 	{
@@ -32,7 +32,7 @@ int main(int argc, const char **argv) // ignore_convention
 	}
 
 	// init graphics
-	IEngineGraphics* pGraphics = CreateEngineGraphicsThreaded();
+	IEngineGraphics *pGraphics = CreateEngineGraphicsThreaded();
 	pKernel->RegisterInterface(static_cast<IEngineGraphics*>(pGraphics));
 	pKernel->RegisterInterface(static_cast<IGraphics*>(pGraphics));
 	if(pGraphics->Init() != 0)
@@ -42,12 +42,12 @@ int main(int argc, const char **argv) // ignore_convention
 	}
 	
 	// init textrender
-	IEngineTextRender* pTextRender = CreateEngineTextRender();
+	IEngineTextRender *pTextRender = CreateEngineTextRender();
 	pKernel->RegisterInterface(static_cast<IEngineTextRender*>(pTextRender));
 	pKernel->RegisterInterface(static_cast<ITextRender*>(pTextRender));
 	pTextRender->Init();
 	
-	static CFont *pDefaultFont = pTextRender->LoadFont("data/fonts/DejaVuSansCJKName.ttf");
+	CFont *pDefaultFont = pTextRender->LoadFont("data/fonts/DejaVuSansCJKName.ttf");
 	pTextRender->SetDefaultFont(pDefaultFont);
 	
 	pGraphics->BlendNormal();
@@ -55,7 +55,7 @@ int main(int argc, const char **argv) // ignore_convention
 	dbg_msg("benchmark", "ready!");
 	
 	// text from https://fr.wikibooks.org/wiki/Translinguisme/Par_expression/Bonjour
-	static const char aaText[][1024] =
+	static const char aaText[][32] =
 	{
 		"azertyuiop",
 		"ըթժիլխծկհձ",
@@ -81,7 +81,7 @@ int main(int argc, const char **argv) // ignore_convention
 		"כלםמןנסעףפ",
 		"AZERTYUIOP",
 	};
-	static const int NbText = sizeof(aaText)/sizeof(aaText[0]);
+	static const int NbText = sizeof(aaText) / sizeof(aaText[0]);
 	static const int Duration = 20; // in seconds
 	
 	float Fps = 0.0f;
@@ -92,28 +92,28 @@ int main(int argc, const char **argv) // ignore_convention
 		while(1)
 		{
 			int64 CurrentTime = time_get();
-			double RenderTime = 0.1*(CurrentTime - StartTime)/(double)time_freq();
+			double RenderTime = 0.1 * (CurrentTime - StartTime) / (double) time_freq();
 
 			pGraphics->Clear(0.5f, 0.5f, 0.5f);
 			
 			float Height = 300.0f;
-			float Width = Height*pGraphics->ScreenAspect();
+			float Width = Height * pGraphics->ScreenAspect();
 			pGraphics->MapScreen(0.0f, 0.0f, Width, Height);
 			
-			for(int j=0; j<3; j++)
+			for(int j = 0; j < 3; j++)
 			{
-				for(int i=0; i<NbText; i++)
+				for(int i=0; i < NbText; i++)
 				{
-					float TimeWrap = fmod(RenderTime + i/(double)(NbText), 1.0f);
+					float TimeWrap = fmod(RenderTime + i / (double) (NbText), 1.0f);
 					
-					float PositionX = j*Width/3.0f;
-					float PositionY = TimeWrap*Height*0.8f;
-					float Size = 8+TimeWrap*40.0;
+					float PositionX = j * Width / 3.0f;
+					float PositionY = TimeWrap * Height * 0.8f;
+					float Size = 8 + TimeWrap * 40.0;
 					
 					CTextCursor Cursor;
 					pTextRender->SetCursor(&Cursor, PositionX, PositionY, Size, TEXTFLAG_RENDER|TEXTFLAG_STOP_AT_END);
 					Cursor.m_LineWidth = Width;
-					pTextRender->TextEx(&Cursor, aaText[i%NbText], -1);
+					pTextRender->TextEx(&Cursor, aaText[i % NbText], -1);
 				}
 			}
 			
@@ -121,16 +121,16 @@ int main(int argc, const char **argv) // ignore_convention
 			
 			FrameCounter++;
 			int64 TimeDiff = CurrentTime - StartTime;
-			if(TimeDiff > time_freq()*Duration)
+			if(TimeDiff > time_freq() * Duration)
 			{
-				double Time = TimeDiff/(double)time_freq();
+				double Time = TimeDiff / (double) time_freq();
 				Fps = (double)FrameCounter / Time;
 				break;
 			}
 		}
 	}
 
-	dbg_msg("Benchmark", "Result: %f", Fps);
+	dbg_msg("Benchmark", "Result: %f fps", Fps);
 
 	delete pTextRender;
 	delete pGraphics;

--- a/src/benchmarks/textrendering.cpp
+++ b/src/benchmarks/textrendering.cpp
@@ -55,7 +55,7 @@ int main(int argc, const char **argv) // ignore_convention
 	dbg_msg("benchmark", "ready!");
 	
 	// text from https://fr.wikibooks.org/wiki/Translinguisme/Par_expression/Bonjour
-	static const char aaText[][32] =
+	static const char s_aaText[][32] =
 	{
 		"azertyuiop",
 		"ըթժիլխծկհձ",
@@ -81,8 +81,8 @@ int main(int argc, const char **argv) // ignore_convention
 		"כלםמןנסעףפ",
 		"AZERTYUIOP",
 	};
-	static const int NbText = sizeof(aaText) / sizeof(aaText[0]);
-	static const int Duration = 20; // in seconds
+	static const int s_NbText = sizeof(s_aaText) / sizeof(s_aaText[0]);
+	static const int s_Duration = 20; // in seconds
 	
 	float Fps = 0.0f;
 	unsigned int FrameCounter = 0;
@@ -92,7 +92,7 @@ int main(int argc, const char **argv) // ignore_convention
 		while(1)
 		{
 			int64 CurrentTime = time_get();
-			double RenderTime = 0.1 * (CurrentTime - StartTime) / (double) time_freq();
+			double RenderTime = 0.1 * (CurrentTime - StartTime) / (double)time_freq();
 
 			pGraphics->Clear(0.5f, 0.5f, 0.5f);
 			
@@ -102,9 +102,9 @@ int main(int argc, const char **argv) // ignore_convention
 			
 			for(int j = 0; j < 3; j++)
 			{
-				for(int i=0; i < NbText; i++)
+				for(int i = 0; i < s_NbText; i++)
 				{
-					float TimeWrap = fmod(RenderTime + i / (double) (NbText), 1.0f);
+					float TimeWrap = fmod(RenderTime + i / (double)(s_NbText), 1.0f);
 					
 					float PositionX = j * Width / 3.0f;
 					float PositionY = TimeWrap * Height * 0.8f;
@@ -113,7 +113,7 @@ int main(int argc, const char **argv) // ignore_convention
 					CTextCursor Cursor;
 					pTextRender->SetCursor(&Cursor, PositionX, PositionY, Size, TEXTFLAG_RENDER|TEXTFLAG_STOP_AT_END);
 					Cursor.m_LineWidth = Width;
-					pTextRender->TextEx(&Cursor, aaText[i % NbText], -1);
+					pTextRender->TextEx(&Cursor, s_aaText[i % s_NbText], -1);
 				}
 			}
 			
@@ -121,9 +121,9 @@ int main(int argc, const char **argv) // ignore_convention
 			
 			FrameCounter++;
 			int64 TimeDiff = CurrentTime - StartTime;
-			if(TimeDiff > time_freq() * Duration)
+			if(TimeDiff > time_freq() * s_Duration)
 			{
-				double Time = TimeDiff / (double) time_freq();
+				double Time = TimeDiff / (double)time_freq();
 				Fps = (double)FrameCounter / Time;
 				break;
 			}

--- a/src/benchmarks/textrendering.cpp
+++ b/src/benchmarks/textrendering.cpp
@@ -55,74 +55,83 @@ int main(int argc, const char **argv) // ignore_convention
 	dbg_msg("benchmark", "ready!");
 	
 	// text from https://fr.wikibooks.org/wiki/Translinguisme/Par_expression/Bonjour
-	static const char aaText[][1024] = 
+	static const char aaText[][1024] =
 	{
-		"Hello DDNet",
-		"Bonjour",
-		"صَباح الخير",
-		"早晨",
-		"안녕하세요",
-		"नमस्कार",
-		"Günaydın",
-		"Καλιμέρα",
-		"おはようございます",
-		"สวัสดี ครับ",
-		"Здравствуй",
-		"בוקר טוב",
-		"Paakuinôgwzian",
+		"azertyuiop",
+		"ըթժիլխծկհձ",
+		"ءحآخغأدؤذإ",
+		"ႠႡႢႣႤႥႦႧႨႩ",
+		"ΑΒΓΔΕΖΗΘΙΚ",
+		"٠١٢٣٤٥٦٧٨٩",
+		"ЀЎМЪЁЏНЫЂА",
+		"QSDFGHJKLM",
+		"رئزاسبشفةص",
+		"ﬡﬢﬣﬤﬥﬦﬧﬨ﬩שׁ",
+		"αβγδεζηθικ",
+		"ႭႮႯႰႱႲႳႴႵႶ",
+		"ՋՍՌՎՏՐՑՒՓՔ",
+		"ОЬЃБПЭЄВРЮ",
+		"0123456789",
+		"wxcvbnqsdf",
+		"قتضكثطلجظم",
+		"ΛΜΝΞΟΠΡΣΤΥ",
+		"ნოპჟრსტუფქ",
+		"еужфзхицйч",
+		"ԱԲԳԴԵԶԷԸԹԺ",
+		"כלםמןנסעףפ",
+		"AZERTYUIOP",
 	};
-	static const int NbText = 13;
+	static const int NbText = sizeof(aaText)/sizeof(aaText[0]);
+	static const int Duration = 20; // in seconds
 	
-	int64 StartTime = time_get();
-	int FrameCounter = 0;
-	while(1)
-	{		
-		int64 CurrentTime = time_get();
-		double RenderTime = (CurrentTime - StartTime)/(double)time_freq();
-		
-		pGraphics->Clear(0.5f, 0.5f, 0.5f);
-		
-		float Height = 300.0f;
-		float Width = Height*pGraphics->ScreenAspect();
-		pGraphics->MapScreen(0.0f, 0.0f, Width, Height);
-		
-		//~ for(int i=0; i<NbText; i++)
-		//~ {
-			//~ float Angle = RenderTime*pi/2.0f + i*2.0f*pi/NbText;
-			//~ CTextCursor Cursor;
-			//~ pTextRender->SetCursor(&Cursor, Width/4, Height/2 + (i - NbText/2)*15.0f , 40.0f, TEXTFLAG_RENDER|TEXTFLAG_STOP_AT_END);
-			//~ Cursor.m_LineWidth = Width/2;
-			//~ pTextRender->TextEx(&Cursor, aaText[i], -1);
-		//~ }
-		//~ for(int i=0; i<NbText; i++)
-		//~ {
-			//~ float Angle = RenderTime*pi/2.0f + i*2.0f*pi/NbText;
-			//~ CTextCursor Cursor;
-			//~ pTextRender->SetCursor(&Cursor, Width/2, Height/2 + (i - NbText/2)*15.0f , 8.0f, TEXTFLAG_RENDER|TEXTFLAG_STOP_AT_END);
-			//~ Cursor.m_LineWidth = Width/2;
-			//~ pTextRender->TextEx(&Cursor, aaText[i], -1);
-		//~ }
-		for(int i=0; i<2*NbText; i++)
+	float Fps = 0.0f;
+	unsigned int FrameCounter = 0;
+	
+	{
+		int64 StartTime = time_get();
+		while(1)
 		{
-			float Angle = RenderTime*pi/2.0f + i*pi/NbText;
-			CTextCursor Cursor;
-			pTextRender->SetCursor(&Cursor, Width/4 + sin(Angle)*100.f, Height/2 + cos(Angle)*100.f, 8.0f + (sin(Angle)+1)*20.0, TEXTFLAG_RENDER|TEXTFLAG_STOP_AT_END);
-			Cursor.m_LineWidth = Width;
-			pTextRender->TextEx(&Cursor, aaText[i%NbText], -1);
-		}
-		
-		pGraphics->Swap();
-		
-		FrameCounter++;
-		CurrentTime = time_get();
-		if(CurrentTime - StartTime > time_freq()*10)
-		{
-			double Time = (CurrentTime - StartTime)/(double)time_freq();
-			dbg_msg("benchmark", "result: %lf fps", (double)FrameCounter / Time);
-			break;
+			int64 CurrentTime = time_get();
+			double RenderTime = 0.1*(CurrentTime - StartTime)/(double)time_freq();
+
+			pGraphics->Clear(0.5f, 0.5f, 0.5f);
+			
+			float Height = 300.0f;
+			float Width = Height*pGraphics->ScreenAspect();
+			pGraphics->MapScreen(0.0f, 0.0f, Width, Height);
+			
+			for(int j=0; j<3; j++)
+			{
+				for(int i=0; i<NbText; i++)
+				{
+					float TimeWrap = fmod(RenderTime + i/(double)(NbText), 1.0f);
+					
+					float PositionX = j*Width/3.0f;
+					float PositionY = TimeWrap*Height*0.8f;
+					float Size = 8+TimeWrap*40.0;
+					
+					CTextCursor Cursor;
+					pTextRender->SetCursor(&Cursor, PositionX, PositionY, Size, TEXTFLAG_RENDER|TEXTFLAG_STOP_AT_END);
+					Cursor.m_LineWidth = Width;
+					pTextRender->TextEx(&Cursor, aaText[i%NbText], -1);
+				}
+			}
+			
+			pGraphics->Swap();
+			
+			FrameCounter++;
+			int64 TimeDiff = CurrentTime - StartTime;
+			if(TimeDiff > time_freq()*Duration)
+			{
+				double Time = TimeDiff/(double)time_freq();
+				Fps = (double)FrameCounter / Time;
+				break;
+			}
 		}
 	}
-	
+
+	dbg_msg("Benchmark", "Result: %f", Fps);
+
 	delete pTextRender;
 	delete pGraphics;
 	delete pKernel;


### PR DESCRIPTION
This is a small and dirty benchmark. Please tell me if I should make it differently. I will revert it once we are done with this branch.
The benchmark print during 10 seconds a wheel of text (hello in different languages), with various sizes. After this time, the program quit (or crash...) and display the number of frame per sec:
```
[17-03-16 18:59:20][benchmark]: result: 158.791187 fps
``` 

Once we have an acceptable benchmark, we can try to improve the text render :)