### PR TITLE
Reset input when server/map changes. Fixes #633

### DIFF
--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -309,6 +309,7 @@ CGameConsole::CInstance *CGameConsole::CurrentConsole()
 
 void CGameConsole::OnReset()
 {
+	m_RemoteConsole.m_Input.Clear();
 }
 
 // only defined for 0<=t<=1

--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -309,7 +309,6 @@ CGameConsole::CInstance *CGameConsole::CurrentConsole()
 
 void CGameConsole::OnReset()
 {
-	m_RemoteConsole.m_Input.Clear();
 }
 
 // only defined for 0<=t<=1
@@ -489,7 +488,7 @@ void CGameConsole::OnRender()
 		const char *pPrompt = "> ";
 		if(m_ConsoleType == CONSOLETYPE_REMOTE)
 		{
-			if(Client()->State() == IClient::STATE_ONLINE)
+			if(Client()->State() == IClient::STATE_LOADING || Client()->State() == IClient::STATE_ONLINE)
 			{
 				if(Client()->RconAuthed())
 					pPrompt = "rcon> ";
@@ -812,5 +811,8 @@ void CGameConsole::OnConsoleInit()
 void CGameConsole::OnStateChange(int NewState, int OldState)
 {
 	if(OldState == IClient::STATE_ONLINE && NewState < IClient::STATE_LOADING)
+	{
 		m_RemoteConsole.m_UserGot = false;
+		m_RemoteConsole.m_Input.Clear();
+	}
 }


### PR DESCRIPTION
Didn't push this with the other one b/c wasn't sure if this is desired. Could also only reset in case of a password input. Or could overengineer it with saving the buffer to another place.