### PR TITLE
Fix: Add generated rcon password as default auth key

### DIFF
--- a/src/engine/server/authmanager.cpp
+++ b/src/engine/server/authmanager.cpp
@@ -27,6 +27,7 @@ void CAuthManager::Init()
 	if(m_aKeys.size() == NumDefaultKeys && !g_Config.m_SvRconPassword[0])
 	{
 		secure_random_password(g_Config.m_SvRconPassword, sizeof(g_Config.m_SvRconPassword), 6);
+		AddDefaultKey(AUTHED_ADMIN, g_Config.m_SvRconPassword);
 		m_Generated = true;
 	}
 }


### PR DESCRIPTION
The generated rcon password never triggers the `ConchainRconPasswordChange` and that's why it's not added to the auth keys.

This PR makes generated passwords work again.