### PR TITLE
Remove heart from on reset messages

### DIFF
--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -37,6 +37,7 @@ void CChat::OnReset()
 		m_aLines[i].m_Time = 0;
 		m_aLines[i].m_aText[0] = 0;
 		m_aLines[i].m_aName[0] = 0;
+		m_aLines[i].m_Friend = false;
 	}
 
 	m_ReverseTAB = false;


### PR DESCRIPTION
Wrongly assumed the old messages were cleared by `m_Time` being 0 but missed that `m_Show` overrides it.