### PR TITLE
Show correct hook position in pause

### DIFF
--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -309,7 +309,7 @@ void CPlayers::RenderHook(
 		{
 			if(pPlayerChar->m_HookedPlayer != -1)
 			{
-				if(m_pClient->m_Snap.m_pLocalInfo && pPlayerChar->m_HookedPlayer == m_pClient->m_Snap.m_pLocalInfo->m_ClientID)
+				if(m_pClient->m_Snap.m_pLocalInfo && pPlayerChar->m_HookedPlayer == m_pClient->m_Snap.m_pLocalInfo->m_ClientID && !m_pClient->m_Snap.m_SpecInfo.m_Active)
 				{
 					if(Client()->State() == IClient::STATE_DEMOPLAYBACK) // only use prediction if needed
 						HookPos = vec2(m_pClient->m_LocalCharacterPos.x, m_pClient->m_LocalCharacterPos.y);


### PR DESCRIPTION
Fixes #556 by not using the predicted position for drawing the hook when the player is paused.