### PR TITLE
Invitation system for loading savegames

### DIFF
--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -10,6 +10,7 @@
 #if defined(CONF_SQL)
 #include <game/server/score/sql_score.h>
 #endif
+#include "save.h"
 
 bool CheckClientID(int ClientID);
 
@@ -618,7 +619,7 @@ void CGameContext::ConSave(IConsole::IResult *pResult, void *pUserData)
 #endif
 }
 
-void CGameContext::ConLoadNew(IConsole::IResult *pResult, void *pUserData)
+void CGameContext::ConAcceptLoad(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *) pUserData;
 	if (!CheckClientID(pResult->m_ClientID))
@@ -630,17 +631,73 @@ void CGameContext::ConLoadNew(IConsole::IResult *pResult, void *pUserData)
 
 	if (pPlayer->m_TeamLoadState.m_State != CTeamLoadState::NONE)
 	{
-		pSelf->SendChatTarget(pResult->m_ClientID, "You cannot use /load now.");
+		pSelf->SendChatTarget(pResult->m_ClientID, "You are already involved in a savegame load.");
 		return;
 	}
 
-	// initiate load
-	pPlayer->m_TeamLoadState.m_State = CTeamLoadState::HOST_THREAD_INIT_LOAD;
-	str_copy(pPlayer->m_TeamLoadState.m_aCode, pResult->GetString(0), sizeof(pPlayer->m_TeamLoadState));
-	pPlayer->m_TeamLoadState.m_TimeInitiated = pSelf->Server()->Tick();
+	// search for host
+	int HostID = -1;
+	for (int i = 0; i < MAX_CLIENTS; i++)
+	{
+		if (str_comp(pResult->GetString(0), pSelf->Server()->ClientName(i)) == 0)
+		{
+			HostID = i;
+			break;
+		}
+	}
 
-	// sql
-	pSelf->Score()->LoadTeamInfo(pResult->GetString(0), pResult->m_ClientID);
+	if (HostID == -1 || !pSelf->m_apPlayers[HostID])
+	{
+		pSelf->SendChatTarget(pResult->m_ClientID, "Unable to find player.");
+		return;
+	}
+
+	CTeamLoadState &MyLoadState = pSelf->m_apPlayers[pResult->m_ClientID]->m_TeamLoadState;
+	CTeamLoadState &HostLoadState = pSelf->m_apPlayers[HostID]->m_TeamLoadState;
+
+	if (HostLoadState.m_State == CTeamLoadState::HOST_WAIT_FOR_CLIENTS)
+	{
+		// try to accept
+		if (HostLoadState.m_NumPlayersLeft > 0)
+		{
+			// find our saved tee id
+			MyLoadState.m_OwnSavedTeeID = -1;
+			for (int i = 0; i < HostLoadState.m_pSaveTeam->GetMembersCount(); i++)
+			{
+				if (str_comp(pSelf->Server()->ClientName(pResult->m_ClientID), HostLoadState.m_pSaveTeam->SavedTees[i].GetName()) == 0)
+				{
+					MyLoadState.m_OwnSavedTeeID = i;
+					break;
+				}
+			}
+
+			if (MyLoadState.m_OwnSavedTeeID == -1)
+			{
+				// Either we weren't invited to the party
+				// or we changed our name before accepting.
+				pSelf->SendChatTarget(pResult->m_ClientID, "You don't belong to this team.");
+			}
+			else
+			{
+				// accept
+				HostLoadState.m_NumPlayersLeft--;
+				MyLoadState.m_JoinID = HostID;
+				MyLoadState.m_State = CTeamLoadState::CLIENT_ACCEPTED;
+				pSelf->SendChatTarget(pResult->m_ClientID, "You accepted the invitation.");
+			}
+		}
+		else
+		{
+			// Some player accepted multiple times.
+			// Currently this is possible via name
+			// changes and/or server rejoin.
+			// Do nothing for now.
+		}
+	}
+	else
+	{
+		pSelf->SendChatTarget(pResult->m_ClientID, "Unable to find load invitation.");
+	}
 }
 
 void CGameContext::ConLoad(IConsole::IResult *pResult, void *pUserData)
@@ -665,11 +722,32 @@ void CGameContext::ConLoad(IConsole::IResult *pResult, void *pUserData)
 			return;
 #endif
 
-	if (pResult->NumArguments() > 0) {
-		pSelf->Score()->LoadTeam(pResult->GetString(0), pResult->m_ClientID);
+	if (g_Config.m_SvLoadInvite)
+	{
+		// load via invitation
+		if (pPlayer->m_TeamLoadState.m_State != CTeamLoadState::NONE)
+		{
+			pSelf->SendChatTarget(pResult->m_ClientID, "You are already involved in a savegame load.");
+			return;
+		}
+
+		// initiate load
+		pPlayer->m_TeamLoadState.m_State = CTeamLoadState::HOST_THREAD_INIT_LOAD;
+		str_copy(pPlayer->m_TeamLoadState.m_aCode, pResult->GetString(0), sizeof(pPlayer->m_TeamLoadState));
+		pPlayer->m_TeamLoadState.m_TimeInitiated = pSelf->Server()->Tick();
+
+		// sql
+		pSelf->Score()->LoadTeamInfo(pResult->GetString(0), pResult->m_ClientID);
 	}
 	else
-		return;
+	{
+		// old enforced load
+		if (pResult->NumArguments() > 0) {
+			pSelf->Score()->LoadTeam(pResult->GetString(0), pResult->m_ClientID);
+		}
+		else
+			return;
+	}
 
 #if defined(CONF_SQL)
 	if(g_Config.m_SvUseSQL)

--- a/src/game/server/ddracechat.h
+++ b/src/game/server/ddracechat.h
@@ -24,7 +24,7 @@ CHAT_COMMAND("mapinfo", "?r[map]", CFGFLAG_CHAT|CFGFLAG_SERVER, ConMapInfo, this
 CHAT_COMMAND("timeout", "s[code]", CFGFLAG_CHAT|CFGFLAG_SERVER, ConTimeout, this, "Set timeout protection code s")
 CHAT_COMMAND("save", "r[code]", CFGFLAG_CHAT|CFGFLAG_SERVER, ConSave, this, "Save team with code r")
 CHAT_COMMAND("load", "r[code]", CFGFLAG_CHAT|CFGFLAG_SERVER, ConLoad, this, "Load with code r")
-CHAT_COMMAND("loadnew", "s[code]", CFGFLAG_CHAT|CFGFLAG_SERVER, ConLoadNew, this, "Load with code s")
+CHAT_COMMAND("acceptload", "s[code]", CFGFLAG_CHAT|CFGFLAG_SERVER, ConAcceptLoad, this, "Accept a load invitation")
 CHAT_COMMAND("map", "?r[map]", CFGFLAG_CHAT|CFGFLAG_SERVER, ConMap, this, "Vote a map by name")
 CHAT_COMMAND("rankteam", "?r[playername]", CFGFLAG_CHAT|CFGFLAG_SERVER, ConTeamRank, this, "Shows the team rank of player with name r (your team rank by default)")
 CHAT_COMMAND("teamrank", "?r[playername]", CFGFLAG_CHAT|CFGFLAG_SERVER, ConTeamRank, this, "Shows the team rank of player with name r (your team rank by default)")

--- a/src/game/server/ddracechat.h
+++ b/src/game/server/ddracechat.h
@@ -24,6 +24,7 @@ CHAT_COMMAND("mapinfo", "?r[map]", CFGFLAG_CHAT|CFGFLAG_SERVER, ConMapInfo, this
 CHAT_COMMAND("timeout", "s[code]", CFGFLAG_CHAT|CFGFLAG_SERVER, ConTimeout, this, "Set timeout protection code s")
 CHAT_COMMAND("save", "r[code]", CFGFLAG_CHAT|CFGFLAG_SERVER, ConSave, this, "Save team with code r")
 CHAT_COMMAND("load", "r[code]", CFGFLAG_CHAT|CFGFLAG_SERVER, ConLoad, this, "Load with code r")
+CHAT_COMMAND("loadnew", "s[code]", CFGFLAG_CHAT|CFGFLAG_SERVER, ConLoadNew, this, "Load with code s")
 CHAT_COMMAND("map", "?r[map]", CFGFLAG_CHAT|CFGFLAG_SERVER, ConMap, this, "Vote a map by name")
 CHAT_COMMAND("rankteam", "?r[playername]", CFGFLAG_CHAT|CFGFLAG_SERVER, ConTeamRank, this, "Shows the team rank of player with name r (your team rank by default)")
 CHAT_COMMAND("teamrank", "?r[playername]", CFGFLAG_CHAT|CFGFLAG_SERVER, ConTeamRank, this, "Shows the team rank of player with name r (your team rank by default)")

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -835,7 +835,7 @@ void CGameContext::OnTick()
 
 			if (LoadState.m_OwnSavedTeeID == -1)
 			{
-				// this player is not part of the savepoint
+				// this player is not part of the savegame
 				SendChatTarget(i, "You don't belong to this team");
 
 				// reset
@@ -961,7 +961,7 @@ void CGameContext::OnTick()
 		{
 			if (LoadState.m_NumPlayersLeft == 0)
 			{
-				// All players accepted, do actual team/savepoint load
+				// All players accepted, do actual team/savegame load
 
 				// load team
 				Score()->LoadTeam(LoadState.m_aCode, i);

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -814,7 +814,7 @@ void CGameContext::OnTick()
 		CTeamLoadState &LoadState = m_apPlayers[i]->m_TeamLoadState;
 
 		if (LoadState.m_State == CTeamLoadState::HOST_THREAD_INIT_DONE)
-    {
+		{
 			// sql thread gave us information about the savegame
 			CSaveTeam *pSaveTeam = LoadState.m_pSaveTeam;
 			LoadState.m_NumPlayersLeft = pSaveTeam->GetMembersCount()-1;

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -836,9 +836,6 @@ void CGameContext::OnTick()
 			if (LoadState.m_OwnSavedTeeID == -1)
 			{
 				// this player is not part of the savegame
-				SendChatTarget(i, "You don't belong to this team");
-
-				// reset
 				ResetTeamLoadState(i, "You don't belong to this team");
 			}
 			else if (pSaveTeam->GetMembersCount() > 1)

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -292,7 +292,7 @@ private:
 	static void ConTimeout(IConsole::IResult *pResult, void *pUserData);
 	static void ConSave(IConsole::IResult *pResult, void *pUserData);
 	static void ConLoad(IConsole::IResult *pResult, void *pUserData);
-	static void ConLoadNew(IConsole::IResult *pResult, void *pUserData);
+	static void ConAcceptLoad(IConsole::IResult *pResult, void *pUserData);
 	static void ConMap(IConsole::IResult *pResult, void *pUserData);
 	static void ConTeamRank(IConsole::IResult *pResult, void *pUserData);
 	static void ConRank(IConsole::IResult *pResult, void *pUserData);
@@ -365,6 +365,8 @@ public:
 	virtual bool PlayerCollision();
 	virtual bool PlayerHooking();
 	virtual float PlayerJetpack();
+
+  void ResetTeamLoadState(int ClientID, const char *pInfo);
 
 	void ResetTuning();
 

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -292,6 +292,7 @@ private:
 	static void ConTimeout(IConsole::IResult *pResult, void *pUserData);
 	static void ConSave(IConsole::IResult *pResult, void *pUserData);
 	static void ConLoad(IConsole::IResult *pResult, void *pUserData);
+	static void ConLoadNew(IConsole::IResult *pResult, void *pUserData);
 	static void ConMap(IConsole::IResult *pResult, void *pUserData);
 	static void ConTeamRank(IConsole::IResult *pResult, void *pUserData);
 	static void ConRank(IConsole::IResult *pResult, void *pUserData);

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -366,7 +366,7 @@ public:
 	virtual bool PlayerHooking();
 	virtual float PlayerJetpack();
 
-  void ResetTeamLoadState(int ClientID, const char *pInfo);
+	void ResetTeamLoadState(int ClientID, const char *pInfo);
 
 	void ResetTuning();
 

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -28,6 +28,7 @@ CPlayer::CPlayer(CGameContext *pGameServer, int ClientID, int Team)
 	m_pCharacter = 0;
 	m_NumInputs = 0;
 	m_KillMe = 0;
+	m_TeamLoadState.m_State = CTeamLoadState::NONE;
 	Reset();
 }
 
@@ -243,20 +244,6 @@ void CPlayer::Tick()
 	if (m_TuneZone != m_TuneZoneOld) // dont send tunigs all the time
 	{
 		GameServer()->SendTuningParams(m_ClientID, m_TuneZone);
-	}
-
-	// team load state
-	if (m_TeamLoadState.m_State == CTeamLoadState::HOST_THREAD_INIT_DONE) {
-		// sql thread gave us information of the savegame 
-		CSaveTeam *pSaveTeam = m_TeamLoadState.m_pSaveTeam;
-		dbg_msg("asd", "success number of players: %d", pSaveTeam->GetMembersCount());
-		// next state
-		m_TeamLoadState.m_State = CTeamLoadState::HOST_WAIT_FOR_CLIENTS;
-	} else if (m_TeamLoadState.m_State == CTeamLoadState::HOST_THREAD_INIT_FAILED) {
-		// sql thread had problem retrieving savegame information 
-		dbg_msg("asd", "problems");
-		// reset
-		m_TeamLoadState.m_State = CTeamLoadState::NONE;
 	}
 }
 

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -14,6 +14,7 @@
 #include <stdio.h>
 #include <time.h>
 
+#include <game/server/save.h>
 
 MACRO_ALLOC_POOL_ID_IMPL(CPlayer, MAX_CLIENTS)
 
@@ -242,6 +243,20 @@ void CPlayer::Tick()
 	if (m_TuneZone != m_TuneZoneOld) // dont send tunigs all the time
 	{
 		GameServer()->SendTuningParams(m_ClientID, m_TuneZone);
+	}
+
+	// team load state
+	if (m_TeamLoadState.m_State == CTeamLoadState::HOST_THREAD_INIT_DONE) {
+		// sql thread gave us information of the savegame 
+		CSaveTeam *pSaveTeam = m_TeamLoadState.m_pSaveTeam;
+		dbg_msg("asd", "success number of players: %d", pSaveTeam->GetMembersCount());
+		// next state
+		m_TeamLoadState.m_State = CTeamLoadState::HOST_WAIT_FOR_CLIENTS;
+	} else if (m_TeamLoadState.m_State == CTeamLoadState::HOST_THREAD_INIT_FAILED) {
+		// sql thread had problem retrieving savegame information 
+		dbg_msg("asd", "problems");
+		// reset
+		m_TeamLoadState.m_State = CTeamLoadState::NONE;
 	}
 }
 

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -31,8 +31,8 @@ struct CTeamLoadState
 	// client
 	int m_JoinID;
 
-  // both
-  int m_OwnSavedTeeID; // CSaveTeam.SavedTees index
+	// both
+	int m_OwnSavedTeeID; // CSaveTeam.SavedTees index
 };
 
 // player object

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -7,6 +7,31 @@
 #include "entities/character.h"
 #include "gamecontext.h"
 
+struct CTeamLoadState
+{
+	enum
+	{
+		NONE=0,
+		// host states
+		HOST_THREAD_INIT_LOAD,
+		HOST_THREAD_INIT_DONE,
+		HOST_THREAD_INIT_FAILED,
+		HOST_WAIT_FOR_CLIENTS,
+		// client states
+		CLIENT_ACCEPTED,
+	};
+
+	int m_State;
+	// host
+	char m_aCode[128+1];
+	int m_TimeInitiated;
+	int m_NumPlayersLeft;
+	struct CSaveTeam *m_pSaveTeam;
+
+	// client
+	int m_JoinID;
+};
+
 // player object
 class CPlayer
 {
@@ -189,6 +214,8 @@ public:
 #if defined(CONF_SQL)
 	int64 m_LastSQLQuery;
 #endif
+
+	CTeamLoadState m_TeamLoadState;
 };
 
 #endif

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -30,6 +30,9 @@ struct CTeamLoadState
 
 	// client
 	int m_JoinID;
+
+  // both
+  int m_OwnSavedTeeID; // CSaveTeam.SavedTees index
 };
 
 // player object

--- a/src/game/server/score.h
+++ b/src/game/server/score.h
@@ -65,6 +65,7 @@ public:
 
 	virtual void SaveTeam(int Team, const char *pCode, int ClientID, const char *pServer) = 0;
 	virtual void LoadTeam(const char *pCode, int ClientID) = 0;
+	virtual void LoadTeamInfo(const char *pCode, int ClientID) = 0;
 
 	// called when the server is shut down but not on mapchange/reload
 	virtual void OnShutdown() = 0;

--- a/src/game/server/score/file_score.cpp
+++ b/src/game/server/score/file_score.cpp
@@ -352,6 +352,13 @@ void CFileScore::LoadTeam(const char* Code, int ClientID)
 	GameServer()->SendChatTarget(ClientID, aBuf);
 }
 
+void CFileScore::LoadTeamInfo(const char* Code, int ClientID)
+{
+	char aBuf[512];
+	str_format(aBuf, sizeof(aBuf), "Save-function not supported in file based servers");
+	GameServer()->SendChatTarget(ClientID, aBuf);
+}
+
 void CFileScore::OnShutdown()
 {
 	;

--- a/src/game/server/score/file_score.h
+++ b/src/game/server/score/file_score.h
@@ -84,6 +84,7 @@ public:
 	virtual void RandomUnfinishedMap(int ClientID, int stars);
 	virtual void SaveTeam(int Team, const char* Code, int ClientID, const char* Server);
 	virtual void LoadTeam(const char* Code, int ClientID);
+	virtual void LoadTeamInfo(const char* Code, int ClientID);
 
 	virtual void OnShutdown();
 };

--- a/src/game/server/score/sql_score.cpp
+++ b/src/game/server/score/sql_score.cpp
@@ -1414,13 +1414,13 @@ bool CSqlScore::SaveTeamThread(CSqlServer* pSqlServer, const CSqlData *pGameData
 		try
 		{
 			char aBuf[512];
-			str_format(aBuf, sizeof(aBuf), "select Savegame from %s_saves where Code = '%s' and Map = '%s';",  pSqlServer->GetPrefix(), pData->m_Code.ClrStr(), pData->m_Map.ClrStr());
+			str_format(aBuf, sizeof(aBuf), "select Savegame from %s_saves where Code = '%s' and Map = '%s';", pSqlServer->GetPrefix(), pData->m_Code.ClrStr(), pData->m_Map.ClrStr());
 			pSqlServer->executeSqlQuery(aBuf);
 
 			if (pSqlServer->GetResults()->rowsCount() == 0)
 			{
 				char aBuf[65536];
-				str_format(aBuf, sizeof(aBuf), "INSERT IGNORE INTO %s_saves(Savegame, Map, Code, Timestamp, Server) VALUES ('%s', '%s', '%s', CURRENT_TIMESTAMP(), '%s')",  pSqlServer->GetPrefix(), TeamString, pData->m_Map.ClrStr(), pData->m_Code.ClrStr(), pData->m_Server);
+				str_format(aBuf, sizeof(aBuf), "INSERT IGNORE INTO %s_saves(Savegame, Map, Code, Timestamp, Server) VALUES ('%s', '%s', '%s', CURRENT_TIMESTAMP(), '%s')", pSqlServer->GetPrefix(), TeamString, pData->m_Map.ClrStr(), pData->m_Code.ClrStr(), pData->m_Server);
 				dbg_msg("sql", "%s", aBuf);
 				pSqlServer->executeSql(aBuf);
 
@@ -1468,6 +1468,114 @@ void CSqlScore::LoadTeam(const char* Code, int ClientID)
 	thread_detach(LoadThread);
 }
 
+void CSqlScore::LoadTeamInfo(const char* Code, int ClientID)
+{
+	CSqlTeamLoad *Tmp = new CSqlTeamLoad();
+	Tmp->m_Code = Code;
+	Tmp->m_ClientID = ClientID;
+
+	void *LoadThread = thread_init(ExecSqlFunc, new CSqlExecData(LoadTeamInfoThread, Tmp));
+	thread_detach(LoadThread);
+}
+
+bool CSqlScore::LoadTeamInfoThread(CSqlServer* pSqlServer, const CSqlData *pGameData, bool HandleFailure)
+{
+	const CSqlTeamLoad *pData = dynamic_cast<const CSqlTeamLoad *>(pGameData);
+
+	if (HandleFailure)
+		return true;
+
+	try
+	{
+		char aBuf[768];
+		str_format(aBuf, sizeof(aBuf), "select Savegame, Server, UNIX_TIMESTAMP(CURRENT_TIMESTAMP)-UNIX_TIMESTAMP(Timestamp) as Ago from %s_saves where Code = '%s' and Map = '%s';", pSqlServer->GetPrefix(), pData->m_Code.ClrStr(), pData->m_Map.ClrStr());
+		pSqlServer->executeSqlQuery(aBuf);
+
+		//TODO: what about thread safety?
+		CPlayer *pPlayer = pData->GameServer()->m_apPlayers[pData->m_ClientID];
+		CTeamLoadState *pTeamLoadState = &pPlayer->m_TeamLoadState;
+
+		if (pPlayer && pTeamLoadState->m_State == CTeamLoadState::HOST_THREAD_INIT_LOAD)
+		{
+			if (pSqlServer->GetResults()->rowsCount() > 0)
+			{
+				pSqlServer->GetResults()->first();
+				char ServerName[5];
+				str_copy(ServerName, pSqlServer->GetResults()->getString("Server").c_str(), sizeof(ServerName));
+				if(str_comp(ServerName, g_Config.m_SvSqlServerName))
+				{
+					str_format(aBuf, sizeof(aBuf), "You have to be on the '%s' server to load this savegame", ServerName);
+					pData->GameServer()->SendChatTarget(pData->m_ClientID, aBuf);
+					pTeamLoadState->m_State = CTeamLoadState::HOST_THREAD_INIT_FAILED;
+					goto end;
+				}
+
+				pSqlServer->GetResults()->getInt("Ago");
+				int since = (int)pSqlServer->GetResults()->getInt("Ago");
+
+				if(since < g_Config.m_SvSaveGamesDelay)
+				{
+					str_format(aBuf, sizeof(aBuf), "You have to wait %d seconds until you can load this savegame", g_Config.m_SvSaveGamesDelay - since);
+					pData->GameServer()->SendChatTarget(pData->m_ClientID, aBuf);
+					pTeamLoadState->m_State = CTeamLoadState::HOST_THREAD_INIT_FAILED;
+					goto end;
+				}
+
+				CSaveTeam *pSavedTeam = new CSaveTeam(pData->GameServer()->m_pController);
+
+				int Num = pSavedTeam->LoadString(pSqlServer->GetResults()->getString("Savegame").c_str());
+
+				if(Num)
+				{
+					pData->GameServer()->SendChatTarget(pData->m_ClientID, "Unable to load savegame: data corrupted");
+					pTeamLoadState->m_State = CTeamLoadState::HOST_THREAD_INIT_FAILED;
+				}
+				else
+				{
+
+					bool Found = false;
+					for (int i = 0; i < pSavedTeam->GetMembersCount(); i++)
+					{
+						if(str_comp(pSavedTeam->SavedTees[i].GetName(), pData->Server()->ClientName(pData->m_ClientID)) == 0)
+						{ Found = true; break; }
+					}
+					if (!Found)
+					{
+						pData->GameServer()->SendChatTarget(pData->m_ClientID, "You don't belong to this team");
+						pTeamLoadState->m_State = CTeamLoadState::HOST_THREAD_INIT_FAILED;
+					}
+					else
+					{
+						// complete initiation by returning team savegame information to main thread
+						pPlayer->m_TeamLoadState.m_pSaveTeam = pSavedTeam;
+						pPlayer->m_TeamLoadState.m_State = CTeamLoadState::HOST_THREAD_INIT_DONE;
+					}
+				}
+			}
+			else
+			{
+				pData->GameServer()->SendChatTarget(pData->m_ClientID, "No such savegame for this map");
+				pTeamLoadState->m_State = CTeamLoadState::HOST_THREAD_INIT_FAILED;
+			}
+		}
+
+		end:
+		return true;
+	}
+	catch (sql::SQLException &e)
+	{
+		dbg_msg("sql", "MySQL Error: %s", e.what());
+		dbg_msg("sql", "ERROR: Could not load the team");
+		pData->GameServer()->SendChatTarget(pData->m_ClientID, "MySQL Error: Could not load the team");
+	}
+	catch (CGameContextError &e)
+	{
+		dbg_msg("sql", "WARNING: Aborted loading team due to reload/change of map.");
+		return true;
+	}
+	return false;
+}
+
 bool CSqlScore::LoadTeamThread(CSqlServer* pSqlServer, const CSqlData *pGameData, bool HandleFailure)
 {
 	const CSqlTeamLoad *pData = dynamic_cast<const CSqlTeamLoad *>(pGameData);
@@ -1478,7 +1586,7 @@ bool CSqlScore::LoadTeamThread(CSqlServer* pSqlServer, const CSqlData *pGameData
 	try
 	{
 		char aBuf[768];
-		str_format(aBuf, sizeof(aBuf), "select Savegame, Server, UNIX_TIMESTAMP(CURRENT_TIMESTAMP)-UNIX_TIMESTAMP(Timestamp) as Ago from %s_saves where Code = '%s' and Map = '%s';",  pSqlServer->GetPrefix(), pData->m_Code.ClrStr(), pData->m_Map.ClrStr());
+		str_format(aBuf, sizeof(aBuf), "select Savegame, Server, UNIX_TIMESTAMP(CURRENT_TIMESTAMP)-UNIX_TIMESTAMP(Timestamp) as Ago from %s_saves where Code = '%s' and Map = '%s';", pSqlServer->GetPrefix(), pData->m_Code.ClrStr(), pData->m_Map.ClrStr());
 		pSqlServer->executeSqlQuery(aBuf);
 
 		if (pSqlServer->GetResults()->rowsCount() > 0)

--- a/src/game/server/score/sql_score.h
+++ b/src/game/server/score/sql_score.h
@@ -163,6 +163,7 @@ class CSqlScore: public IScore
 	static bool RandomUnfinishedMapThread(CSqlServer* pSqlServer, const CSqlData *pGameData, bool HandleFailure = false);
 	static bool SaveTeamThread(CSqlServer* pSqlServer, const CSqlData *pGameData, bool HandleFailure = false);
 	static bool LoadTeamThread(CSqlServer* pSqlServer, const CSqlData *pGameData, bool HandleFailure = false);
+	static bool LoadTeamInfoThread(CSqlServer* pSqlServer, const CSqlData *pGameData, bool HandleFailure = false);
 
 public:
 
@@ -191,6 +192,7 @@ public:
 	virtual void RandomUnfinishedMap(int ClientID, int stars);
 	virtual void SaveTeam(int Team, const char* Code, int ClientID, const char* Server);
 	virtual void LoadTeam(const char* Code, int ClientID);
+	virtual void LoadTeamInfo(const char* Code, int ClientID);
 
 	virtual void OnShutdown();
 };

--- a/src/game/variables.h
+++ b/src/game/variables.h
@@ -167,6 +167,10 @@ MACRO_CONFIG_INT(SvSendVotesPerTick, sv_send_votes_per_tick, 5, 1, 15, CFGFLAG_S
 MACRO_CONFIG_INT(SvRescue, sv_rescue, 0, 0, 1, CFGFLAG_SERVER, "Allow /rescue command so players can teleport themselves out of freeze")
 MACRO_CONFIG_INT(SvRescueDelay, sv_rescue_delay, 5, 0, 1000, CFGFLAG_SERVER, "Number of seconds inbetween two rescues")
 
+
+MACRO_CONFIG_INT(SvLoadInviteTimeout, sv_load_invite_timeout, 60, 0, 1000, CFGFLAG_SERVER, "Load invite timeout in seconds")
+MACRO_CONFIG_INT(SvLoadInvite, sv_load_invite, 1, 0, 1, CFGFLAG_SERVER, "Enable/Disable savegame load via invitation")
+
 // debug
 #ifdef CONF_DEBUG // this one can crash the server if not used correctly
 	MACRO_CONFIG_INT(DbgDummies, dbg_dummies, 0, 0, 15, CFGFLAG_SERVER, "")


### PR DESCRIPTION
This is my first approach of making the /load command more passive (via invitation).

Here the loading of a savegame now forces all participants to accept an invitation before they can continue.

Scenario (savegame participants A and B):

Player A: `/load savegamecode`
(Player B is informed about the invitation)
Player B: `/acceptload A`
(savegame is loaded)

The invitation is skipped if all participants have the same ip address (in order to make /load with dummy more comfortable).
If atleast one participant does not accept the invitation within `sv_load_invite_timeout` seconds, the loading process is cancelled.

`sv_load_invite 0` can be used to fall back to the old system in case there is some sort of bug.

Notes:
- Do not merge yet, needs testing
- The case where an invited player changes his name currently is ignored (it will prevent the load from succeeding in worst-case)
- We should consider something about the thread synchronization
