### PR TITLE
Rework the pause system

### DIFF
--- a/src/game/ddracecommands.h
+++ b/src/game/ddracecommands.h
@@ -34,8 +34,8 @@ CONSOLE_COMMAND("down", "", CFGFLAG_SERVER|CMDFLAG_TEST, ConGoDown, this, "Makes
 
 CONSOLE_COMMAND("move", "i[x] i[y]", CFGFLAG_SERVER|CMDFLAG_TEST, ConMove, this, "Moves to the tile with x/y-number ii")
 CONSOLE_COMMAND("move_raw", "i[x] i[y]", CFGFLAG_SERVER|CMDFLAG_TEST, ConMoveRaw, this, "Moves to the point with x/y-coordinates ii")
-CONSOLE_COMMAND("force_pause", "i[id] i[seconds]", CFGFLAG_SERVER, ConForcePause, this, "Force i to pause for i seconds")
-CONSOLE_COMMAND("force_unpause", "i[id]", CFGFLAG_SERVER, ConForcePause, this, "Set force-pause timer of i to 0.")
+CONSOLE_COMMAND("force_pause", "v[id] i[seconds]", CFGFLAG_SERVER, ConForcePause, this, "Force i to pause for i seconds")
+CONSOLE_COMMAND("force_unpause", "v[id]", CFGFLAG_SERVER, ConForcePause, this, "Set force-pause timer of i to 0.")
 CONSOLE_COMMAND("showothers", "?i['0'|'1']", CFGFLAG_CHAT, ConShowOthers, this, "Whether to show players from other teams or not (off by default), optional i = 0 for off else for on")
 CONSOLE_COMMAND("showall", "?i['0'|'1']", CFGFLAG_CHAT, ConShowAll, this, "Whether to show players at any distance (off by default), optional i = 0 for off else for on")
 

--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -288,9 +288,9 @@ void CGameContext::ConToggleSpec(IConsole::IResult *pResult, void *pUserData)
 	if(PauseState <= 0)
 	{
 		if(-PauseState != CPlayer::PAUSE_SPEC)
-			pPlayer->Pause(CPlayer::PAUSE_SPEC);
+			pPlayer->Pause(CPlayer::PAUSE_SPEC, false);
 		else if(-PauseState == CPlayer::PAUSE_SPEC)
-			pPlayer->Pause(CPlayer::PAUSE_NONE);
+			pPlayer->Pause(CPlayer::PAUSE_NONE, false);
 	}
 	else
 	{
@@ -316,9 +316,9 @@ void CGameContext::ConTogglePause(IConsole::IResult *pResult, void *pUserData)
 	if(PauseState <= 0)
 	{
 		if(-PauseState != CPlayer::PAUSE_PAUSED)
-			pPlayer->Pause(CPlayer::PAUSE_PAUSED);
+			pPlayer->Pause(CPlayer::PAUSE_PAUSED, false);
 		else if(-PauseState == CPlayer::PAUSE_PAUSED)
-			pPlayer->Pause(CPlayer::PAUSE_NONE);
+			pPlayer->Pause(CPlayer::PAUSE_NONE, false);
 	}
 	else
 	{

--- a/src/game/server/ddracechat.h
+++ b/src/game/server/ddracechat.h
@@ -17,8 +17,8 @@ CHAT_COMMAND("w", "s[player name] r[message]", CFGFLAG_CHAT|CFGFLAG_SERVER, ConW
 CHAT_COMMAND("whisper", "s[player name] r[message]", CFGFLAG_CHAT|CFGFLAG_SERVER, ConWhisper, this, "Whisper something to someone (private message)")
 CHAT_COMMAND("c", "r[message]", CFGFLAG_CHAT|CFGFLAG_SERVER, ConConverse, this, "Converse with the last person you whispered to (private message)");
 CHAT_COMMAND("converse", "r[message]", CFGFLAG_CHAT|CFGFLAG_SERVER, ConConverse, this, "Converse with the last person you whispered to (private message)");
-CHAT_COMMAND("pause", "", CFGFLAG_CHAT|CFGFLAG_SERVER, ConToggleSpec, this, "Toggles spec(if not available behaves as /spec)")
-CHAT_COMMAND("spec", "", CFGFLAG_CHAT|CFGFLAG_SERVER, ConTogglePause, this, "Toggles pause")
+CHAT_COMMAND("pause", "", CFGFLAG_CHAT|CFGFLAG_SERVER, ConTogglePause, this, "Toggles spec(if not available behaves as /spec)")
+CHAT_COMMAND("spec", "", CFGFLAG_CHAT|CFGFLAG_SERVER, ConToggleSpec, this, "Toggles pause")
 CHAT_COMMAND("dnd", "", CFGFLAG_CHAT|CFGFLAG_SERVER, ConDND, this, "Toggle Do Not Disturb (no chat and server messages)")
 CHAT_COMMAND("mapinfo", "?r[map]", CFGFLAG_CHAT|CFGFLAG_SERVER, ConMapInfo, this, "Show info about the map with name r gives (current map by default)")
 CHAT_COMMAND("timeout", "s[code]", CFGFLAG_CHAT|CFGFLAG_SERVER, ConTimeout, this, "Set timeout protection code s")

--- a/src/game/server/ddracechat.h
+++ b/src/game/server/ddracechat.h
@@ -17,8 +17,8 @@ CHAT_COMMAND("w", "s[player name] r[message]", CFGFLAG_CHAT|CFGFLAG_SERVER, ConW
 CHAT_COMMAND("whisper", "s[player name] r[message]", CFGFLAG_CHAT|CFGFLAG_SERVER, ConWhisper, this, "Whisper something to someone (private message)")
 CHAT_COMMAND("c", "r[message]", CFGFLAG_CHAT|CFGFLAG_SERVER, ConConverse, this, "Converse with the last person you whispered to (private message)");
 CHAT_COMMAND("converse", "r[message]", CFGFLAG_CHAT|CFGFLAG_SERVER, ConConverse, this, "Converse with the last person you whispered to (private message)");
-CHAT_COMMAND("pause", "", CFGFLAG_CHAT|CFGFLAG_SERVER, ConTogglePause, this, "Toggles pause")
-CHAT_COMMAND("spec", "", CFGFLAG_CHAT|CFGFLAG_SERVER, ConToggleSpec, this, "Toggles spec (if not activated on the server, it toggles pause)")
+CHAT_COMMAND("pause", "", CFGFLAG_CHAT|CFGFLAG_SERVER, ConToggleSpec, this, "Toggles spec(if not available behaves as /spec)")
+CHAT_COMMAND("spec", "", CFGFLAG_CHAT|CFGFLAG_SERVER, ConTogglePause, this, "Toggles pause")
 CHAT_COMMAND("dnd", "", CFGFLAG_CHAT|CFGFLAG_SERVER, ConDND, this, "Toggle Do Not Disturb (no chat and server messages)")
 CHAT_COMMAND("mapinfo", "?r[map]", CFGFLAG_CHAT|CFGFLAG_SERVER, ConMapInfo, this, "Show info about the map with name r gives (current map by default)")
 CHAT_COMMAND("timeout", "s[code]", CFGFLAG_CHAT|CFGFLAG_SERVER, ConTimeout, this, "Set timeout protection code s")

--- a/src/game/server/ddracecommands.cpp
+++ b/src/game/server/ddracecommands.cpp
@@ -335,7 +335,6 @@ void CGameContext::ConKill(IConsole::IResult *pResult, void *pUserData)
 void CGameContext::ConForcePause(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	CServer* pServ = (CServer*)pSelf->Server();
 	int Victim = pResult->GetVictim();
 	int Seconds = 0;
 	if (pResult->NumArguments() > 0)
@@ -345,8 +344,7 @@ void CGameContext::ConForcePause(IConsole::IResult *pResult, void *pUserData)
 	if (!pPlayer)
 		return;
 
-	pPlayer->m_ForcePauseTime = Seconds*pServ->TickSpeed();
-	pPlayer->m_Paused = CPlayer::PAUSED_FORCE;
+	pPlayer->ForcePause(Seconds);
 }
 
 void CGameContext::Mute(IConsole::IResult *pResult, NETADDR *Addr, int Secs,

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -1025,15 +1025,15 @@ void CCharacter::Snap(int SnappingClient)
 		CCharacter* SnapChar = GameServer()->GetPlayerChar(SnappingClient);
 		CPlayer* SnapPlayer = GameServer()->m_apPlayers[SnappingClient];
 
-		if((SnapPlayer->GetTeam() == TEAM_SPECTATORS || SnapPlayer->m_Paused) && SnapPlayer->m_SpectatorID != -1
+		if((SnapPlayer->GetTeam() == TEAM_SPECTATORS || SnapPlayer->IsPaused()) && SnapPlayer->m_SpectatorID != -1
 			&& !CanCollide(SnapPlayer->m_SpectatorID) && !SnapPlayer->m_ShowOthers)
 			return;
 
-		if( SnapPlayer->GetTeam() != TEAM_SPECTATORS && !SnapPlayer->m_Paused && SnapChar && !SnapChar->m_Super
+		if( SnapPlayer->GetTeam() != TEAM_SPECTATORS && !SnapPlayer->IsPaused() && SnapChar && !SnapChar->m_Super
 			&& !CanCollide(SnappingClient) && !SnapPlayer->m_ShowOthers)
 			return;
 
-		if((SnapPlayer->GetTeam() == TEAM_SPECTATORS || SnapPlayer->m_Paused) && SnapPlayer->m_SpectatorID == -1
+		if((SnapPlayer->GetTeam() == TEAM_SPECTATORS || SnapPlayer->IsPaused()) && SnapPlayer->m_SpectatorID == -1
 			&& !CanCollide(SnappingClient) && SnapPlayer->m_SpecTeam)
 			return;
 	}
@@ -1134,7 +1134,7 @@ void CCharacter::Snap(int SnappingClient)
 			pCharacter->m_AmmoCount = (!m_FreezeTime)?m_aWeapons[m_Core.m_ActiveWeapon].m_Ammo:0;
 	}
 
-	if(GetPlayer()->m_Afk || GetPlayer()->m_Paused)
+	if(GetPlayer()->m_Afk || GetPlayer()->IsPaused())
 		pCharacter->m_Emote = EMOTE_BLINK;
 
 	if(pCharacter->m_Emote == EMOTE_NORMAL)

--- a/src/game/server/entities/door.cpp
+++ b/src/game/server/entities/door.cpp
@@ -83,7 +83,7 @@ void CDoor::Snap(int SnappingClient)
 	int Tick = (Server()->Tick() % Server()->TickSpeed()) % 11;
 
 	if(SnappingClient > -1 && (GameServer()->m_apPlayers[SnappingClient]->GetTeam() == -1
-				|| GameServer()->m_apPlayers[SnappingClient]->m_Paused)
+				|| GameServer()->m_apPlayers[SnappingClient]->IsPaused())
 			&& GameServer()->m_apPlayers[SnappingClient]->m_SpectatorID != SPEC_FREEVIEW)
 		Char = GameServer()->GetPlayerChar(GameServer()->m_apPlayers[SnappingClient]->m_SpectatorID);
 

--- a/src/game/server/entities/dragger.cpp
+++ b/src/game/server/entities/dragger.cpp
@@ -320,7 +320,7 @@ void CDragger::Snap(int SnappingClient)
 		CCharacter * Char = GameServer()->GetPlayerChar(SnappingClient);
 
 		if(SnappingClient > -1 && (GameServer()->m_apPlayers[SnappingClient]->GetTeam() == -1
-					|| GameServer()->m_apPlayers[SnappingClient]->m_Paused)
+					|| GameServer()->m_apPlayers[SnappingClient]->IsPaused())
 				&& GameServer()->m_apPlayers[SnappingClient]->m_SpectatorID != SPEC_FREEVIEW)
 			Char = GameServer()->GetPlayerChar(GameServer()->m_apPlayers[SnappingClient]->m_SpectatorID);
 

--- a/src/game/server/entities/gun.cpp
+++ b/src/game/server/entities/gun.cpp
@@ -118,7 +118,7 @@ void CGun::Snap(int SnappingClient)
 	CCharacter *Char = GameServer()->GetPlayerChar(SnappingClient);
 
 	if(SnappingClient > -1 && (GameServer()->m_apPlayers[SnappingClient]->GetTeam() == -1
-				|| GameServer()->m_apPlayers[SnappingClient]->m_Paused)
+				|| GameServer()->m_apPlayers[SnappingClient]->IsPaused())
 			&& GameServer()->m_apPlayers[SnappingClient]->m_SpectatorID != SPEC_FREEVIEW)
 		Char = GameServer()->GetPlayerChar(GameServer()->m_apPlayers[SnappingClient]->m_SpectatorID);
 

--- a/src/game/server/entities/light.cpp
+++ b/src/game/server/entities/light.cpp
@@ -111,7 +111,7 @@ void CLight::Snap(int SnappingClient)
 	CCharacter *Char = GameServer()->GetPlayerChar(SnappingClient);
 
 	if(SnappingClient > -1 && (GameServer()->m_apPlayers[SnappingClient]->GetTeam() == -1
-				|| GameServer()->m_apPlayers[SnappingClient]->m_Paused)
+				|| GameServer()->m_apPlayers[SnappingClient]->IsPaused())
 			&& GameServer()->m_apPlayers[SnappingClient]->m_SpectatorID != SPEC_FREEVIEW)
 		Char = GameServer()->GetPlayerChar(GameServer()->m_apPlayers[SnappingClient]->m_SpectatorID);
 

--- a/src/game/server/entities/pickup.cpp
+++ b/src/game/server/entities/pickup.cpp
@@ -154,7 +154,7 @@ void CPickup::Snap(int SnappingClient)
 	CCharacter *Char = GameServer()->GetPlayerChar(SnappingClient);
 
 	if(SnappingClient > -1 && (GameServer()->m_apPlayers[SnappingClient]->GetTeam() == -1
-				|| GameServer()->m_apPlayers[SnappingClient]->m_Paused)
+				|| GameServer()->m_apPlayers[SnappingClient]->IsPaused())
 			&& GameServer()->m_apPlayers[SnappingClient]->m_SpectatorID != SPEC_FREEVIEW)
 		Char = GameServer()->GetPlayerChar(GameServer()->m_apPlayers[SnappingClient]->m_SpectatorID);
 

--- a/src/game/server/entities/plasma.cpp
+++ b/src/game/server/entities/plasma.cpp
@@ -96,18 +96,18 @@ void CPlasma::Snap(int SnappingClient)
 			&& (!Tick))
 		return;
 
-	if(SnapPlayer && (SnapPlayer->GetTeam() == TEAM_SPECTATORS || SnapPlayer->m_Paused) && SnapPlayer->m_SpectatorID != -1
+	if(SnapPlayer && (SnapPlayer->GetTeam() == TEAM_SPECTATORS || SnapPlayer->IsPaused()) && SnapPlayer->m_SpectatorID != -1
 		&& GameServer()->GetPlayerChar(SnapPlayer->m_SpectatorID)
 		&& GameServer()->GetPlayerChar(SnapPlayer->m_SpectatorID)->Team() != m_ResponsibleTeam
 		&& !SnapPlayer->m_ShowOthers)
 		return;
 
-	if(SnapPlayer && SnapPlayer->GetTeam() != TEAM_SPECTATORS && !SnapPlayer->m_Paused && SnapChar
+	if(SnapPlayer && SnapPlayer->GetTeam() != TEAM_SPECTATORS && !SnapPlayer->IsPaused() && SnapChar
 		&& SnapChar && SnapChar->Team() != m_ResponsibleTeam
 		&& !SnapPlayer->m_ShowOthers)
 		return;
 
-	if(SnapPlayer && (SnapPlayer->GetTeam() == TEAM_SPECTATORS || SnapPlayer->m_Paused) && SnapPlayer->m_SpectatorID == -1
+	if(SnapPlayer && (SnapPlayer->GetTeam() == TEAM_SPECTATORS || SnapPlayer->IsPaused()) && SnapPlayer->m_SpectatorID == -1
 		&& SnapChar
 		&& SnapChar->Team() != m_ResponsibleTeam
 		&& SnapPlayer->m_SpecTeam)

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -1529,7 +1529,7 @@ void CGameContext::OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID)
 			{
 				//if(m_pController->CanChangeTeam(pPlayer, pMsg->m_Team))
 
-				if(pPlayer->m_Paused)
+				if(pPlayer->IsPaused())
 					SendChatTarget(ClientID,"Use /pause first then you can kill");
 				else
 				{
@@ -1729,7 +1729,7 @@ void CGameContext::OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID)
 			}
 			if(pPlayer->m_LastKill && pPlayer->m_LastKill+Server()->TickSpeed()*g_Config.m_SvKillDelay > Server()->Tick())
 				return;
-			if(pPlayer->m_Paused)
+			if(pPlayer->IsPaused())
 				return;
 
 			CCharacter *pChr = pPlayer->GetCharacter();
@@ -2033,7 +2033,7 @@ void CGameContext::ConSetTeam(IConsole::IResult *pResult, void *pUserData)
 	pSelf->m_apPlayers[ClientID]->m_TeamChangeTick = pSelf->Server()->Tick()+pSelf->Server()->TickSpeed()*Delay*60;
 	pSelf->m_apPlayers[ClientID]->SetTeam(Team);
 	if(Team == TEAM_SPECTATORS)
-		pSelf->m_apPlayers[ClientID]->m_Paused = CPlayer::PAUSED_NONE;
+		pSelf->m_apPlayers[ClientID]->Pause(CPlayer::PAUSE_NONE);
 	// (void)pSelf->m_pController->CheckTeamBalance();
 }
 

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -2033,7 +2033,7 @@ void CGameContext::ConSetTeam(IConsole::IResult *pResult, void *pUserData)
 	pSelf->m_apPlayers[ClientID]->m_TeamChangeTick = pSelf->Server()->Tick()+pSelf->Server()->TickSpeed()*Delay*60;
 	pSelf->m_apPlayers[ClientID]->SetTeam(Team);
 	if(Team == TEAM_SPECTATORS)
-		pSelf->m_apPlayers[ClientID]->Pause(CPlayer::PAUSE_NONE);
+		pSelf->m_apPlayers[ClientID]->Pause(CPlayer::PAUSE_NONE, true);
 	// (void)pSelf->m_pController->CheckTeamBalance();
 }
 

--- a/src/game/server/gamecontroller.cpp
+++ b/src/game/server/gamecontroller.cpp
@@ -772,7 +772,7 @@ void IGameController::Snap(int SnappingClient)
 
 	if(pPlayer && (pPlayer->m_TimerType == CPlayer::TIMERTYPE_GAMETIMER || pPlayer->m_TimerType == CPlayer::TIMERTYPE_GAMETIMER_AND_BROADCAST) && pPlayer->m_ClientVersion >= VERSION_DDNET_GAMETICK)
 	{
-		if((pPlayer->GetTeam() == -1 || pPlayer->m_Paused)
+		if((pPlayer->GetTeam() == -1 || pPlayer->IsPaused())
 			&& pPlayer->m_SpectatorID != SPEC_FREEVIEW
 			&& (pPlayer2 = GameServer()->m_apPlayers[pPlayer->m_SpectatorID]))
 		{

--- a/src/game/server/gameworld.cpp
+++ b/src/game/server/gameworld.cpp
@@ -183,7 +183,7 @@ void CGameWorld::UpdatePlayerMaps()
 			// copypasted chunk from character.cpp Snap() follows
 			CCharacter* SnapChar = GameServer()->GetPlayerChar(i);
 			if(SnapChar && !SnapChar->m_Super &&
-				!GameServer()->m_apPlayers[i]->m_Paused && GameServer()->m_apPlayers[i]->GetTeam() != -1 &&
+				!GameServer()->m_apPlayers[i]->IsPaused() && GameServer()->m_apPlayers[i]->GetTeam() != -1 &&
 				!ch->CanCollide(i) &&
 				(!GameServer()->m_apPlayers[i] ||
 					GameServer()->m_apPlayers[i]->m_ClientVersion == VERSION_VANILLA ||

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -115,7 +115,7 @@ void CPlayer::Reset()
 	m_SpecTeam = 0;
 	m_NinjaJetpack = false;
 
-	m_Paused = PAUSED_NONE;
+	m_Paused = PAUSE_NONE;
 	m_DND = false;
 
 	m_NextPauseTick = 0;
@@ -157,9 +157,6 @@ void CPlayer::Tick()
 	if (m_ChatScore > 0)
 		m_ChatScore--;
 
-	if (m_ForcePauseTime > 0)
-		m_ForcePauseTime--;
-
 	Server()->SetClientScore(m_ClientID, m_Score);
 
 	// do latency stuff
@@ -200,21 +197,7 @@ void CPlayer::Tick()
 		{
 			if(m_pCharacter->IsAlive())
 			{
-				if(m_Paused >= PAUSED_FORCE)
-				{
-					if(m_ForcePauseTime == 0)
-					m_Paused = PAUSED_NONE;
-					ProcessPause();
-				}
-				else if(m_Paused == PAUSED_PAUSED && m_NextPauseTick < Server()->Tick())
-				{
-					if((!m_pCharacter->GetWeaponGot(WEAPON_NINJA) || m_pCharacter->m_FreezeTime) && m_pCharacter->IsGrounded() && m_pCharacter->m_Pos == m_pCharacter->m_PrevPos)
-						ProcessPause();
-				}
-				else if(m_NextPauseTick < Server()->Tick())
-				{
-					ProcessPause();
-				}
+				ProcessPause();
 				if(!m_Paused)
 					m_ViewPos = m_pCharacter->m_Pos;
 			}
@@ -315,9 +298,9 @@ void CPlayer::Snap(int SnappingClient)
 	pPlayerInfo->m_Local = 0;
 	pPlayerInfo->m_ClientID = id;
 	pPlayerInfo->m_Score = abs(m_Score) * -1;
-	pPlayerInfo->m_Team = (m_ClientVersion < VERSION_DDNET_OLD || m_Paused != PAUSED_SPEC || m_ClientID != SnappingClient) && m_Paused < PAUSED_PAUSED ? m_Team : TEAM_SPECTATORS;
+	pPlayerInfo->m_Team = (m_ClientVersion < VERSION_DDNET_OLD || m_Paused != PAUSE_SPEC || m_ClientID != SnappingClient) && m_Paused < PAUSE_PAUSED ? m_Team : TEAM_SPECTATORS;
 
-	if(m_ClientID == SnappingClient && (m_Paused != PAUSED_SPEC || m_ClientVersion >= VERSION_DDNET_OLD))
+	if(m_ClientID == SnappingClient && (m_Paused != PAUSE_SPEC || m_ClientVersion >= VERSION_DDNET_OLD))
 		pPlayerInfo->m_Local = 1;
 
 	if(m_ClientID == SnappingClient && (m_Team == TEAM_SPECTATORS || m_Paused))
@@ -357,7 +340,7 @@ void CPlayer::FakeSnap()
 	StrToInts(&pClientInfo->m_Clan0, 3, "");
 	StrToInts(&pClientInfo->m_Skin0, 6, "default");
 
-	if(m_Paused != PAUSED_SPEC)
+	if(m_Paused != PAUSE_SPEC)
 		return;
 
 	CNetObj_PlayerInfo *pPlayerInfo = static_cast<CNetObj_PlayerInfo *>(Server()->SnapNewItem(NETOBJTYPE_PLAYERINFO, FakeID, sizeof(CNetObj_PlayerInfo)));
@@ -562,6 +545,7 @@ void CPlayer::TryRespawn()
 
 	m_WeakHookSpawn = false;
 	m_Spawning = false;
+	m_Paused = false;
 	m_pCharacter = new(m_ClientID) CCharacter(&GameServer()->m_World);
 	m_pCharacter->Spawn(this, SpawnPos);
 	GameServer()->CreatePlayerSpawn(SpawnPos, m_pCharacter->Teams()->TeamMask(m_pCharacter->Team(), -1, m_ClientID));
@@ -664,39 +648,69 @@ void CPlayer::AfkVoteTimer(CNetObj_PlayerInput *NewTarget)
 
 void CPlayer::ProcessPause()
 {
+	if(m_ForcePauseTime && m_ForcePauseTime < Server()->Tick())
+	{
+		m_ForcePauseTime = 0;
+		Pause(PAUSE_NONE);
+	}
+
+	if(m_Paused == PAUSE_SPEC && !m_pCharacter->IsPaused() && m_pCharacter->IsGrounded() && m_pCharacter->m_Pos == m_pCharacter->m_PrevPos)
+	{
+		m_pCharacter->Pause(true);
+		GameServer()->CreateDeath(m_pCharacter->m_Pos, m_ClientID, m_pCharacter->Teams()->TeamMask(m_pCharacter->Team(), -1, m_ClientID));
+		GameServer()->CreateSound(m_pCharacter->m_Pos, SOUND_PLAYER_DIE, m_pCharacter->Teams()->TeamMask(m_pCharacter->Team(), -1, m_ClientID));
+	}
+}
+
+int CPlayer::Pause(int State)
+{
+	dbg_assert(State >= PAUSE_NONE && State <= PAUSE_SPEC, "invalid pause state passed");
 	if(!m_pCharacter)
-		return;
+		return 0;
 
 	char aBuf[128];
-	if(m_Paused >= PAUSED_PAUSED)
+	if(State != m_Paused)
 	{
-		if(!m_pCharacter->IsPaused())
-		{
-			m_pCharacter->Pause(true);
+		// Get to wanted state
+		switch(State){
+		case PAUSE_SPEC:
 			if(g_Config.m_SvPauseMessages)
 			{
-				str_format(aBuf, sizeof(aBuf), (m_Paused == PAUSED_PAUSED) ? "'%s' paused" : "'%s' was force-paused for %ds", Server()->ClientName(m_ClientID), m_ForcePauseTime/Server()->TickSpeed());
+				str_format(aBuf, sizeof(aBuf), (m_Paused == PAUSE_PAUSED) ? "'%s' paused" : "'%s' was force-paused for %ds", Server()->ClientName(m_ClientID), m_ForcePauseTime/Server()->TickSpeed());
 				GameServer()->SendChat(-1, CGameContext::CHAT_ALL, aBuf);
 			}
-			GameServer()->CreateDeath(m_pCharacter->m_Pos, m_ClientID, m_pCharacter->Teams()->TeamMask(m_pCharacter->Team(), -1, m_ClientID));
-			GameServer()->CreateSound(m_pCharacter->m_Pos, SOUND_PLAYER_DIE, m_pCharacter->Teams()->TeamMask(m_pCharacter->Team(), -1, m_ClientID));
-			m_NextPauseTick = Server()->Tick() + g_Config.m_SvPauseFrequency * Server()->TickSpeed();
-		}
-	}
-	else
-	{
-		if(m_pCharacter->IsPaused())
-		{
-			m_pCharacter->Pause(false);
-			if(g_Config.m_SvPauseMessages)
+			break;
+		case PAUSE_PAUSED:
+		case PAUSE_NONE:
+			if(m_Paused == PAUSE_SPEC && m_pCharacter->IsPaused())
 			{
-				str_format(aBuf, sizeof(aBuf), "'%s' resumed", Server()->ClientName(m_ClientID));
-				GameServer()->SendChat(-1, CGameContext::CHAT_ALL, aBuf);
+				m_pCharacter->Pause(false);
+				if(g_Config.m_SvPauseMessages && State == PAUSE_NONE)
+				{
+					str_format(aBuf, sizeof(aBuf), "'%s' resumed", Server()->ClientName(m_ClientID));
+					GameServer()->SendChat(-1, CGameContext::CHAT_ALL, aBuf);
+				}
+				GameServer()->CreatePlayerSpawn(m_pCharacter->m_Pos, m_pCharacter->Teams()->TeamMask(m_pCharacter->Team(), -1, m_ClientID));
 			}
-			GameServer()->CreatePlayerSpawn(m_pCharacter->m_Pos, m_pCharacter->Teams()->TeamMask(m_pCharacter->Team(), -1, m_ClientID));
-			m_NextPauseTick = Server()->Tick() + g_Config.m_SvPauseFrequency * Server()->TickSpeed();
+			break;
 		}
+		// Update state
+		m_Paused = State;
 	}
+
+	return m_Paused;
+}
+
+int CPlayer::ForcePause(int Time)
+{
+	m_ForcePauseTime = Server()->Tick() + Server()->TickSpeed() * Time;
+
+	return Pause(PAUSE_SPEC);
+}
+
+int CPlayer::IsPaused()
+{
+	return m_ForcePauseTime ? m_ForcePauseTime : -1 * m_Paused;
 }
 
 bool CPlayer::IsPlaying()

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -118,7 +118,7 @@ void CPlayer::Reset()
 	m_Paused = PAUSE_NONE;
 	m_DND = false;
 
-	m_NextPauseTick = 0;
+	m_LastPause = 0;
 
 	// Variable initialized:
 	m_Last_Team = 0;
@@ -651,7 +651,7 @@ void CPlayer::ProcessPause()
 	if(m_ForcePauseTime && m_ForcePauseTime < Server()->Tick())
 	{
 		m_ForcePauseTime = 0;
-		Pause(PAUSE_NONE);
+		Pause(PAUSE_NONE, true);
 	}
 
 	if(m_Paused == PAUSE_SPEC && !m_pCharacter->IsPaused() && m_pCharacter->IsGrounded() && m_pCharacter->m_Pos == m_pCharacter->m_PrevPos)
@@ -662,7 +662,7 @@ void CPlayer::ProcessPause()
 	}
 }
 
-int CPlayer::Pause(int State)
+int CPlayer::Pause(int State, bool Force)
 {
 	dbg_assert(State >= PAUSE_NONE && State <= PAUSE_SPEC, "invalid pause state passed");
 	if(!m_pCharacter)
@@ -673,29 +673,30 @@ int CPlayer::Pause(int State)
 	{
 		// Get to wanted state
 		switch(State){
+		case PAUSE_PAUSED:
+		case PAUSE_NONE:
+			if(m_pCharacter->IsPaused()) // First condition might be unnecessary
+			{
+				if(!Force && m_LastPause && m_LastPause + g_Config.m_SvPauseFrequency * Server()->TickSpeed() > Server()->Tick())
+				{
+					GameServer()->SendChatTarget(m_ClientID, "Can't pause that quickly.");
+					return m_Paused; // Do not update state. Do not collect $200
+				}
+				m_pCharacter->Pause(false);
+				GameServer()->CreatePlayerSpawn(m_pCharacter->m_Pos, m_pCharacter->Teams()->TeamMask(m_pCharacter->Team(), -1, m_ClientID));
+			}
 		case PAUSE_SPEC:
 			if(g_Config.m_SvPauseMessages)
 			{
-				str_format(aBuf, sizeof(aBuf), (m_Paused == PAUSE_PAUSED) ? "'%s' paused" : "'%s' was force-paused for %ds", Server()->ClientName(m_ClientID), m_ForcePauseTime/Server()->TickSpeed());
+				str_format(aBuf, sizeof(aBuf), (m_Paused > PAUSE_NONE) ? "'%s' paused" : "'%s' resumed", Server()->ClientName(m_ClientID));
 				GameServer()->SendChat(-1, CGameContext::CHAT_ALL, aBuf);
 			}
 			break;
-		case PAUSE_PAUSED:
-		case PAUSE_NONE:
-			if(m_Paused == PAUSE_SPEC && m_pCharacter->IsPaused())
-			{
-				m_pCharacter->Pause(false);
-				if(g_Config.m_SvPauseMessages && State == PAUSE_NONE)
-				{
-					str_format(aBuf, sizeof(aBuf), "'%s' resumed", Server()->ClientName(m_ClientID));
-					GameServer()->SendChat(-1, CGameContext::CHAT_ALL, aBuf);
-				}
-				GameServer()->CreatePlayerSpawn(m_pCharacter->m_Pos, m_pCharacter->Teams()->TeamMask(m_pCharacter->Team(), -1, m_ClientID));
-			}
-			break;
 		}
+
 		// Update state
 		m_Paused = State;
+		m_LastPause = Server()->Tick();
 	}
 
 	return m_Paused;
@@ -705,7 +706,14 @@ int CPlayer::ForcePause(int Time)
 {
 	m_ForcePauseTime = Server()->Tick() + Server()->TickSpeed() * Time;
 
-	return Pause(PAUSE_SPEC);
+	if(g_Config.m_SvPauseMessages)
+	{
+		char aBuf[128];
+		str_format(aBuf, sizeof(aBuf), "'%s' was force-paused for %ds", Server()->ClientName(m_ClientID), Time);
+		GameServer()->SendChat(-1, CGameContext::CHAT_ALL, aBuf);
+	}
+
+	return Pause(PAUSE_SPEC, true);
 }
 
 int CPlayer::IsPaused()

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -128,16 +128,17 @@ private:
 	int m_ClientID;
 	int m_Team;
 
+	int m_Paused;
+	int m_ForcePauseTime;
 
 	// DDRace
 
 public:
 	enum
 	{
-		PAUSED_NONE=0,
-		PAUSED_SPEC,
-		PAUSED_PAUSED,
-		PAUSED_FORCE
+		PAUSE_NONE=0,
+		PAUSE_PAUSED,
+		PAUSE_SPEC
 	};
 	
 	enum
@@ -148,14 +149,16 @@ public:
 		TIMERTYPE_NONE,
 	};
 
-	int m_Paused;
 	bool m_DND;
 	int64 m_FirstVoteTick;
 	int64 m_NextPauseTick;
 	char m_TimeoutCode[64];
 
 	void ProcessPause();
-	int m_ForcePauseTime;
+	int Pause(int State);
+	int ForcePause(int Time);
+	int IsPaused();
+
 	bool IsPlaying();
 	int64 m_Last_KickVote;
 	int64 m_Last_Team;

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -129,7 +129,8 @@ private:
 	int m_Team;
 
 	int m_Paused;
-	int m_ForcePauseTime;
+	int64 m_ForcePauseTime;
+	int64 m_LastPause;
 
 	// DDRace
 
@@ -151,11 +152,10 @@ public:
 
 	bool m_DND;
 	int64 m_FirstVoteTick;
-	int64 m_NextPauseTick;
 	char m_TimeoutCode[64];
 
 	void ProcessPause();
-	int Pause(int State);
+	int Pause(int State, bool Force);
 	int ForcePause(int Time);
 	int IsPaused();
 

--- a/src/game/server/save.cpp
+++ b/src/game/server/save.cpp
@@ -90,7 +90,7 @@ void CSaveTee::save(CCharacter *pChr)
 
 void CSaveTee::load(CCharacter *pChr, int Team)
 {
-	pChr->m_pPlayer->Pause(m_Paused);
+	pChr->m_pPlayer->Pause(m_Paused, true);
 
 	pChr->m_Alive = m_Alive;
 	pChr->m_NeededFaketuning = m_NeededFaketuning;

--- a/src/game/server/save.cpp
+++ b/src/game/server/save.cpp
@@ -22,7 +22,7 @@ void CSaveTee::save(CCharacter *pChr)
 	str_copy(m_name, pChr->m_pPlayer->Server()->ClientName(pChr->m_pPlayer->GetCID()), sizeof(m_name));
 
 	m_Alive = pChr->m_Alive;
-	m_Paused = pChr->m_pPlayer->m_Paused;
+	m_Paused = pChr->m_pPlayer->IsPaused();
 	m_NeededFaketuning = pChr->m_NeededFaketuning;
 
 	m_TeeFinished = pChr->Teams()->TeeFinished(pChr->m_pPlayer->GetCID());
@@ -90,8 +90,7 @@ void CSaveTee::save(CCharacter *pChr)
 
 void CSaveTee::load(CCharacter *pChr, int Team)
 {
-	pChr->m_pPlayer->m_Paused = m_Paused;
-	pChr->m_pPlayer->ProcessPause();
+	pChr->m_pPlayer->Pause(m_Paused);
 
 	pChr->m_Alive = m_Alive;
 	pChr->m_NeededFaketuning = m_NeededFaketuning;

--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -286,7 +286,7 @@ int64_t CGameTeams::TeamMask(int Team, int ExceptID, int Asker)
 		if (!GetPlayer(i))
 			continue; // Player doesn't exist
 
-		if (!(GetPlayer(i)->GetTeam() == -1 || GetPlayer(i)->m_Paused))
+		if (!(GetPlayer(i)->GetTeam() == -1 || GetPlayer(i)->IsPaused()))
 		{ // Not spectator
 			if (i != Asker)
 			{ // Actions of other players


### PR DESCRIPTION
Fixes some odd bugs about the pause system. Including `/pause` while `/spec`, vice-versa and `force_pause`.

Consequently fixes the vote "Move player to spectators".

First reported in #628.