### PR TITLE
Take a blind stab at #718

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -2172,8 +2172,9 @@ void CClient::ResetMapDownload()
 {
 	if(m_pMapdownloadTask)
 	{
+		m_pMapdownloadTask->Abort();
 		delete m_pMapdownloadTask;
-		m_pMapdownloadTask = NULL;
+		m_pMapdownloadTask = 0;
 	}
 	m_MapdownloadFile = 0;
 	m_MapdownloadAmount = 0;
@@ -2195,7 +2196,7 @@ void CClient::FinishMapDownload()
 		m_pConsole->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "client/network", "loading done");
 		SendReady();
 	}
-	else if(m_pMapdownloadTask)
+	else if(m_pMapdownloadTask) // fallback
 	{
 		ResetMapDownload();
 		m_MapdownloadTotalsize = prev;

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -313,7 +313,7 @@ CClient::CClient() : m_DemoPlayer(&m_SnapshotDelta)
 	// map download
 	m_aMapdownloadFilename[0] = 0;
 	m_aMapdownloadName[0] = 0;
-	m_pMapdownloadTask = 0;
+	m_pMapdownloadTask = NULL;
 	m_MapdownloadFile = 0;
 	m_MapdownloadChunk = 0;
 	m_MapdownloadCrc = 0;
@@ -2174,7 +2174,7 @@ void CClient::ResetMapDownload()
 	{
 		m_pMapdownloadTask->Abort();
 		delete m_pMapdownloadTask;
-		m_pMapdownloadTask = 0;
+		m_pMapdownloadTask = NULL;
 	}
 	m_MapdownloadFile = 0;
 	m_MapdownloadAmount = 0;
@@ -2514,7 +2514,7 @@ void CClient::Update()
 		else if(m_pMapdownloadTask->State() == CFetchTask::STATE_ABORTED)
 		{
 			delete m_pMapdownloadTask;
-			m_pMapdownloadTask = 0;
+			m_pMapdownloadTask = NULL;
 		}
 	}
 


### PR DESCRIPTION
Even if this might not the case I encountered it is possible to reach this state. It would cause the fetch thread to read a `delete`'d object.

Tested, does no harm to neither the fallback nor the actual download.