### PR TITLE
Fix crashbug in bind system

### DIFF
--- a/src/game/client/components/binds.cpp
+++ b/src/game/client/components/binds.cpp
@@ -39,7 +39,10 @@ void CBinds::Bind(int KeyID, const char *pStr)
 		return;
 
 	if(m_apKeyBindings[KeyID])
+	{
 		mem_free(m_apKeyBindings[KeyID]);
+		m_apKeyBindings[KeyID] = 0;
+	}
 
 	char aBuf[256];
 	if(!pStr[0])

--- a/src/game/client/components/binds.cpp
+++ b/src/game/client/components/binds.cpp
@@ -88,7 +88,7 @@ void CBinds::UnbindAll()
 
 const char *CBinds::Get(int KeyID)
 {
-	if(KeyID > 0 && KeyID < KEY_LAST)
+	if(KeyID > 0 && KeyID < KEY_LAST && m_apKeyBindings[KeyID])
 		return m_apKeyBindings[KeyID];
 	return "";
 }


### PR DESCRIPTION
Restore old behavior around the bind's Get() function, return "" if
there is no bind. Fixes #730.