### PR TITLE
fixed scoreboard update for slow racers

### DIFF
--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -595,7 +595,7 @@ void CGameTeams::OnFinish(CPlayer* Player)
 	}
 
 	int TTime = 0 - (int)Time;
-	if (Player->m_Score < TTime)
+	if (Player->m_Score < TTime || Player->m_Score == -9999)
 		Player->m_Score = TTime;
 
 }


### PR DESCRIPTION
If ppl chill too much in race and get time higher than -9999 they get no score in scoreboard after finishing. I hope my little change fixes this and doesn't add too many new bugsis ... c: