### PR TITLE
Hide empty broadcast messages.

### DIFF
--- a/src/game/client/components/broadcast.cpp
+++ b/src/game/client/components/broadcast.cpp
@@ -56,7 +56,8 @@ void CBroadcast::OnMessage(int MsgType, void *pRawMsg)
 				{
 					aBuf[ii] = '\0';
 					ii = 0;
-					m_pClient->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "broadcast", aBuf, true);
+					if (aBuf[0])
+						m_pClient->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "broadcast", aBuf, true);
 				}
 				else
 				{
@@ -65,7 +66,8 @@ void CBroadcast::OnMessage(int MsgType, void *pRawMsg)
 				}
 			}
 			aBuf[ii] = '\0';
-			m_pClient->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "broadcast", aBuf, true);
+			if (aBuf[0])
+				m_pClient->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "broadcast", aBuf, true);
 		}
 	}
 }


### PR DESCRIPTION
InfectionClass sends a lot of these messages, and they flood both the console and stdout with this client (but not with stock Teeworlds client)