### PR TITLE
Fix UUID formatting - the last field only has 12 hex digits

### DIFF
--- a/src/engine/shared/uuid_manager.cpp
+++ b/src/engine/shared/uuid_manager.cpp
@@ -39,7 +39,7 @@ void FormatUuid(CUuid Uuid, char *pBuffer, unsigned BufferLength)
 {
 	unsigned char *p = Uuid.m_aData;
 	str_format(pBuffer, BufferLength,
-		"%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x%02x%02x",
+		"%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
 		p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7],
 		p[8], p[9], p[10], p[11], p[12], p[13], p[14], p[15]);
 }


### PR DESCRIPTION
It didn't cause misprinted UUIDs because the string buffers had the
correct size.