### PR TITLE
Fix unpacking of net events

### DIFF
--- a/datasrc/compile.py
+++ b/datasrc/compile.py
@@ -194,19 +194,20 @@ if gen_network_source:
 
 	lines += ["const char *CNetObjHandler::ms_apObjNames[] = {"]
 	lines += ['\t"invalid",']
-	lines += ['\t"%s",' % o.name for o in network.Objects]
+	lines += ['\t"%s",' % o.name for o in network.Objects if o.ex is None]
 	lines += ['\t""', "};", ""]
 
 	lines += ["int CNetObjHandler::ms_aObjSizes[] = {"]
 	lines += ['\t0,']
-	lines += ['\tsizeof(%s),' % o.struct_name for o in network.Objects]
+	lines += ['\tsizeof(%s),' % o.struct_name for o in network.Objects if o.ex is None]
 	lines += ['\t0', "};", ""]
 
 
 	lines += ['const char *CNetObjHandler::ms_apMsgNames[] = {']
 	lines += ['\t"invalid",']
 	for msg in network.Messages:
-		lines += ['\t"%s",' % msg.name]
+		if msg.ex is None:
+			lines += ['\t"%s",' % msg.name]
 	lines += ['\t""']
 	lines += ['};']
 	lines += ['']

--- a/src/engine/shared/snapshot.cpp
+++ b/src/engine/shared/snapshot.cpp
@@ -359,7 +359,7 @@ int CSnapshotDelta::UnpackDelta(CSnapshot *pFrom, CSnapshot *pTo, void *pSrcData
 
 		Type = *pData++;
 		ID = *pData++;
-		if ((unsigned int)Type < sizeof(m_aItemSizes) && m_aItemSizes[Type])
+		if ((unsigned int)Type < sizeof(m_aItemSizes) / sizeof(m_aItemSizes[0]) && m_aItemSizes[Type])
 			ItemSize = m_aItemSizes[Type];
 		else
 		{


### PR DESCRIPTION
The UUID objects accidently made it into the lists of object sizes.

Also fix a possible out-of-bounds read inherited from vanilla.