### PR TITLE
Add ddnet-libs as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ddnet-libs"]
+	path = ddnet-libs
+	url = https://github.com/ddnet/ddnet-libs


### PR DESCRIPTION
So you can clone ddnet using:

`git clone --recursive https://github.com/ddnet/ddnet` and will download all the libs

if you clone it with `git clone  https://github.com/ddnet/ddnet` it wont download the libs

If you have cloned the repo without the libs and want them run:
`git submodule update --init --recursive`