### PR TITLE
Suggest a shallow clone of the library submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "ddnet-libs"]
 	path = ddnet-libs
 	url = https://github.com/ddnet/ddnet-libs
+	shallow = true


### PR DESCRIPTION
This saves some space on the user's file system. They can still update
to the full history of the binaries if they want, e.g. with
```
git fetch ---unshallow
```
(https://stackoverflow.com/a/17937889/870079)