### PR TITLE
Enable `-Wextra` and `-Wformat=2`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -461,8 +461,10 @@ foreach(target ${TARGETS_OWN})
     if(CMAKE_VERSION VERSION_GREATER 3.3 OR CMAKE_VERSION VERSION_EQUAL 3.3)
       target_compile_options(${target} PRIVATE $<$<COMPILE_LANGUAGE:C>:-Wdeclaration-after-statement>)
     endif()
-    #target_compile_options(${target} PRIVATE -Wextra)
-    #target_compile_options(${target} PRIVATE -Wformat=2) # Warn about format strings.
+    target_compile_options(${target} PRIVATE -Wextra)
+    target_compile_options(${target} PRIVATE -Wno-unused-parameter)
+    target_compile_options(${target} PRIVATE -Wno-missing-field-initializers)
+    target_compile_options(${target} PRIVATE -Wformat=2) # Warn about format strings.
   endif()
   target_include_directories(${target} PRIVATE src)
   target_compile_definitions(${target} PRIVATE $<$<CONFIG:Debug>:CONF_DEBUG>)

--- a/src/base/system.c
+++ b/src/base/system.c
@@ -193,13 +193,10 @@ void dbg_msg(const char *sys, const char *fmt, ...)
 
 	//str_format(str, sizeof(str), "[%08x][%s]: ", (int)time(0), sys);
 	time_t rawtime;
-	struct tm* timeinfo;
-	char timestr [80];
+	char timestr[80];
 
-	time ( &rawtime );
-	timeinfo = localtime ( &rawtime );
-
-	strftime (timestr,sizeof(timestr),"%y-%m-%d %H:%M:%S",timeinfo);
+	time(&rawtime);
+	str_timestamp_ex(rawtime, timestr, sizeof(timestr), "%Y-%m %H:%M:%S");
 
 #if !defined(CONF_PLATFORM_MACOSX)
 	if(dbg_msg_threaded)
@@ -2228,7 +2225,14 @@ void str_timestamp_ex(time_t time_data, char *buffer, int buffer_size, const cha
 	struct tm *time_info;
 
 	time_info = localtime(&time_data);
+	#ifdef __GNUC__
+	#pragma GCC diagnostic push
+	#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+	#endif
 	strftime(buffer, buffer_size, format, time_info);
+	#ifdef __GNUC__
+	#pragma GCC diagnostic pop
+	#endif
 	buffer[buffer_size-1] = 0;	/* assure null termination */
 }
 

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -45,6 +45,12 @@ void dbg_assert_imp(const char *filename, int line, int test, const char *msg);
 #define dbg_assert(test,msg) assert(test)
 #endif
 
+#ifdef __GNUC__
+#define GNUC_ATTRIBUTE(x) __attribute__(x)
+#else
+#define GNUC_ATTRIBUTE(x)
+#endif
+
 /*
 	Function: dbg_break
 		Breaks into the debugger.
@@ -77,7 +83,8 @@ void dbg_break_imp();
 	See Also:
 		<dbg_assert>
 */
-void dbg_msg(const char *sys, const char *fmt, ...);
+void dbg_msg(const char *sys, const char *fmt, ...)
+GNUC_ATTRIBUTE((format(printf, 2, 3)));
 
 /* Group: Memory */
 
@@ -795,7 +802,8 @@ int str_length(const char *str);
 		- The strings are treated as zero-termineted strings.
 		- Garantees that dst string will contain zero-termination.
 */
-int str_format(char *buffer, int buffer_size, const char *format, ...);
+int str_format(char *buffer, int buffer_size, const char *format, ...)
+GNUC_ATTRIBUTE((format(printf, 3, 4)));
 
 /*
 	Function: str_trim_words
@@ -1056,7 +1064,8 @@ int str_hex_decode(unsigned char *dst, int dst_size, const char *src);
 		- Guarantees that buffer string will contain zero-termination.
 */
 void str_timestamp(char *buffer, int buffer_size);
-void str_timestamp_ex(time_t time, char *buffer, int buffer_size, const char *format);
+void str_timestamp_ex(time_t time, char *buffer, int buffer_size, const char *format)
+GNUC_ATTRIBUTE((format(strftime, 4, 0)));
 
 /*
 	Function: str_escape

--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -169,8 +169,8 @@ void CInput::SetIMEState(bool Activate)
 
 const char* CInput::GetIMECandidate()
 {
-	if (str_length(m_pEditingText))
-		return m_pEditingText;
+	if (str_length(m_aEditingText))
+		return m_aEditingText;
 	else
 		return "";
 }
@@ -211,10 +211,10 @@ int CInput::Update()
 				{
 					if(str_length(Event.edit.text))
 					{
-						str_format(m_pEditingText, sizeof(m_pEditingText), Event.edit.text);
+						str_copy(m_aEditingText, Event.edit.text, sizeof(m_aEditingText));
 						m_EditingCursor = 0;
 						for (int i = 0; i < Event.edit.start; i++)
-							m_EditingCursor = str_utf8_forward(m_pEditingText, m_EditingCursor);
+							m_EditingCursor = str_utf8_forward(m_aEditingText, m_EditingCursor);
 					}
 					break;
 				}

--- a/src/engine/client/input.h
+++ b/src/engine/client/input.h
@@ -20,14 +20,14 @@ class CInput : public IEngineInput
 	void Clear();
 	bool IsEventValid(CEvent *pEvent) const { return pEvent->m_InputCount == m_InputCounter; };
 
-	//quick access to input
+	// quick access to input
 	unsigned short m_aInputCount[g_MaxKeys];	// tw-KEY
 	unsigned char m_aInputState[g_MaxKeys];	// SDL_SCANCODE
 	int m_InputCounter;
 
-	//ime support
+	// IME support
 	int m_CountEditingText;
-	char m_pEditingText[32];
+	char m_aEditingText[32];
 	int m_EditingCursor;
 
 	bool KeyState(int Key) const;

--- a/src/engine/shared/datafile.cpp
+++ b/src/engine/shared/datafile.cpp
@@ -299,7 +299,7 @@ void *CDataFileReader::GetDataImpl(int Index, int Swap)
 			unsigned long UncompressedSize = m_pDataFile->m_Info.m_pDataSizes[Index];
 			unsigned long s;
 
-			dbg_msg("datafile", "loading data index=%d size=%d uncompressed=%d", Index, DataSize, UncompressedSize);
+			dbg_msg("datafile", "loading data index=%d size=%d uncompressed=%lu", Index, DataSize, UncompressedSize);
 			m_pDataFile->m_ppDataPtrs[Index] = (char *)mem_alloc(UncompressedSize, 1);
 
 			// read the compressed data
@@ -589,7 +589,7 @@ int CDataFileWriter::Finish()
 	for(int i = 0; i < m_NumItems; i++)
 	{
 		if(DEBUG)
-			dbg_msg("datafile", "item=%d size=%d (%d)", i, m_pItems[i].m_Size, m_pItems[i].m_Size+sizeof(CDatafileItem));
+			dbg_msg("datafile", "item=%d size=%d (%d)", i, m_pItems[i].m_Size, m_pItems[i].m_Size + (int)sizeof(CDatafileItem));
 		ItemSize += m_pItems[i].m_Size + sizeof(CDatafileItem);
 	}
 
@@ -626,7 +626,7 @@ int CDataFileWriter::Finish()
 
 		// write Header
 		if(DEBUG)
-			dbg_msg("datafile", "HeaderSize=%d", sizeof(Header));
+			dbg_msg("datafile", "HeaderSize=%d", (int)sizeof(Header));
 #if defined(CONF_ARCH_ENDIAN_BIG)
 		swap_endian(&Header, sizeof(int), sizeof(Header)/sizeof(int));
 #endif

--- a/src/engine/shared/kernel.cpp
+++ b/src/engine/shared/kernel.cpp
@@ -77,7 +77,7 @@ public:
 	{
 		if(FindInterfaceInfo(pName) == 0)
 		{
-			dbg_msg("kernel", "ERROR: couldn't reregister interface '%s'. interface doesn't exist");
+			dbg_msg("kernel", "ERROR: couldn't reregister interface '%s'. interface doesn't exist", pName);
 			return false;
 		}
 

--- a/src/engine/shared/network_server.cpp
+++ b/src/engine/shared/network_server.cpp
@@ -503,7 +503,7 @@ void CNetServer::OnConnCtrlMsg(NETADDR &Addr, int ClientID, int ControlMsg, cons
 			// correct token
 			// try to accept client
 			if (g_Config.m_Debug)
-				dbg_msg("security", "client %d reconnect");
+				dbg_msg("security", "client %d reconnect", ClientID);
 
 			// reset netconn and process rejoin
 			m_aSlots[ClientID].m_Connection.Reset(true);

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -368,7 +368,7 @@ int CMenus::DoEditBox(void *pID, const CUIRect *pRect, char *pStr, unsigned StrS
 	char aInputing[32] = {0};
 	if(UI()->HotItem() == pID && Input()->GetIMEState())
 	{
-		str_format(aInputing, sizeof(aInputing), pStr);
+		str_copy(aInputing, pStr, sizeof(aInputing));
 		const char *Text = Input()->GetIMECandidate();
 		if (str_length(Text))
 		{
@@ -1098,7 +1098,7 @@ int CMenus::Render()
 			pButtonText = Localize("Ok");
 			if(Client()->m_ReconnectTime > 0)
 			{
-				str_format(aBuf, sizeof(aBuf), Localize("\n\nReconnect in %d sec"), ((Client()->m_ReconnectTime - time_get()) / time_freq() + g_Config.m_ClReconnectFull));
+				str_format(aBuf, sizeof(aBuf), Localize("\n\nReconnect in %d sec"), (int)((Client()->m_ReconnectTime - time_get()) / time_freq() + g_Config.m_ClReconnectFull));
 				pTitle = Client()->ErrorString();
 				pExtraText = aBuf;
 				pButtonText = Localize("Abort");
@@ -1344,18 +1344,18 @@ int CMenus::Render()
 				UI()->DoLabel(&Part, aBuf, 20.f, 0, -1);
 
 				// time left
-				const char *pTimeLeftString;
 				int TimeLeft = max(1, m_DownloadSpeed > 0.0f ? static_cast<int>((Client()->MapDownloadTotalsize()-Client()->MapDownloadAmount())/m_DownloadSpeed) : 1);
 				if(TimeLeft >= 60)
 				{
 					TimeLeft /= 60;
-					pTimeLeftString = TimeLeft == 1 ? Localize("%i minute left") : Localize("%i minutes left");
+					str_format(aBuf, sizeof(aBuf), TimeLeft == 1 ? Localize("%i minute left") : Localize("%i minutes left"), TimeLeft);
 				}
 				else
-					pTimeLeftString = TimeLeft == 1 ? Localize("%i second left") : Localize("%i seconds left");
+				{
+					str_format(aBuf, sizeof(aBuf), TimeLeft == 1 ? Localize("%i second left") : Localize("%i seconds left"), TimeLeft);
+				}
 				Box.HSplitTop(20.f, 0, &Box);
 				Box.HSplitTop(24.f, &Part, &Box);
-				str_format(aBuf, sizeof(aBuf), pTimeLeftString, TimeLeft);
 				UI()->DoLabel(&Part, aBuf, 20.f, 0, -1);
 
 				// progress bar

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -7,6 +7,7 @@
 #include <engine/client.h>
 #include <engine/console.h>
 #include <game/layers.h>
+#include <game/localization.h>
 #include <game/gamecore.h>
 #include "render.h"
 
@@ -441,8 +442,5 @@ inline vec3 RgbToHsl(vec3 RGB)
 }
 
 vec3 CalculateNameColor(vec3 TextColorHSL);
-
-extern const char *Localize(const char *Str);
-
 
 #endif

--- a/src/game/localization.h
+++ b/src/game/localization.h
@@ -56,5 +56,6 @@ public:
 };
 
 
-extern const char *Localize(const char *pStr);
+extern const char *Localize(const char *pStr)
+GNUC_ATTRIBUTE((format_arg(1)));
 #endif

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -1977,34 +1977,35 @@ void CCharacter::HandleTuneLayer()
 void CCharacter::SendZoneMsgs()
 {
 	// send zone leave msg
-	if (m_TuneZoneOld >= 0 && GameServer()->m_ZoneLeaveMsg[m_TuneZoneOld]) // m_TuneZoneOld >= 0: avoid zone leave msgs on spawn
+	// (m_TuneZoneOld >= 0: avoid zone leave msgs on spawn)
+	if (m_TuneZoneOld >= 0 && GameServer()->m_aaZoneLeaveMsg[m_TuneZoneOld])
 	{
-		const char* cur = GameServer()->m_ZoneLeaveMsg[m_TuneZoneOld];
-		const char* pos;
-		while ((pos = str_find(cur, "\\n")))
+		const char *pCur = GameServer()->m_aaZoneLeaveMsg[m_TuneZoneOld];
+		const char *pPos;
+		while ((pPos = str_find(pCur, "\\n")))
 		{
 			char aBuf[256];
-			str_copy(aBuf, cur, pos - cur + 1);
-			aBuf[pos - cur + 1] = '\0';
-			cur = pos + 2;
+			str_copy(aBuf, pCur, pPos - pCur + 1);
+			aBuf[pPos - pCur + 1] = '\0';
+			pCur = pPos + 2;
 			GameServer()->SendChatTarget(m_pPlayer->GetCID(), aBuf);
 		}
-		GameServer()->SendChatTarget(m_pPlayer->GetCID(), cur);
+		GameServer()->SendChatTarget(m_pPlayer->GetCID(), pCur);
 	}
 	// send zone enter msg
-	if (GameServer()->m_ZoneEnterMsg[m_TuneZone])
+	if (GameServer()->m_aaZoneEnterMsg[m_TuneZone])
 	{
-		const char* cur = GameServer()->m_ZoneEnterMsg[m_TuneZone];
-		const char* pos;
-		while ((pos = str_find(cur, "\\n")))
+		const char* pCur = GameServer()->m_aaZoneEnterMsg[m_TuneZone];
+		const char* pPos;
+		while ((pPos = str_find(pCur, "\\n")))
 		{
 			char aBuf[256];
-			str_copy(aBuf, cur, pos - cur + 1);
-			aBuf[pos - cur + 1] = '\0';
-			cur = pos + 2;
+			str_copy(aBuf, pCur, pPos - pCur + 1);
+			aBuf[pPos - pCur + 1] = '\0';
+			pCur = pPos + 2;
 			GameServer()->SendChatTarget(m_pPlayer->GetCID(), aBuf);
 		}
-		GameServer()->SendChatTarget(m_pPlayer->GetCID(), cur);
+		GameServer()->SendChatTarget(m_pPlayer->GetCID(), pCur);
 	}
 }
 
@@ -2240,7 +2241,7 @@ void CCharacter::Rescue()
 		if (m_LastRescue + g_Config.m_SvRescueDelay * Server()->TickSpeed() > Server()->Tick())
 		{
 			char aBuf[256];
-			str_format(aBuf, sizeof(aBuf), "You have to wait %d seconds until you can rescue yourself", (m_LastRescue + g_Config.m_SvRescueDelay * Server()->TickSpeed() - Server()->Tick()) / Server()->TickSpeed());
+			str_format(aBuf, sizeof(aBuf), "You have to wait %d seconds until you can rescue yourself", (int)((m_LastRescue + g_Config.m_SvRescueDelay * Server()->TickSpeed() - Server()->Tick()) / Server()->TickSpeed()));
 			GameServer()->SendChatTarget(GetPlayer()->GetCID(), aBuf);
 			return;
 		}

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -516,7 +516,7 @@ void CGameContext::SendTuningParams(int ClientID, int Zone)
 	if (Zone == 0)
 		pParams = (int *)&m_Tuning;
 	else
-		pParams = (int *)&(m_TuningList[Zone]);
+		pParams = (int *)&(m_aTuningList[Zone]);
 
 	unsigned int last = sizeof(m_Tuning)/sizeof(int);
 	if (m_apPlayers[ClientID] && m_apPlayers[ClientID]->m_ClientVersion < VERSION_DDNET_EXTRATUNES)
@@ -1237,7 +1237,7 @@ void CGameContext::OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID)
 			if(Now < pPlayer->m_FirstVoteTick)
 			{
 				char aBuf[64];
-				str_format(aBuf, sizeof(aBuf), "You must wait %d seconds before making your first vote", ((pPlayer->m_FirstVoteTick - Now) / TickSpeed) + 1);
+				str_format(aBuf, sizeof(aBuf), "You must wait %d seconds before making your first vote", (int)((pPlayer->m_FirstVoteTick - Now) / TickSpeed) + 1);
 				SendChatTarget(ClientID, aBuf);
 				return;
 			}
@@ -1246,7 +1246,7 @@ void CGameContext::OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID)
 			if(pPlayer->m_LastVoteCall && TimeLeft > 0)
 			{
 				char aChatmsg[64];
-				str_format(aChatmsg, sizeof(aChatmsg), "You must wait %d seconds before making another vote", (TimeLeft/TickSpeed)+1);
+				str_format(aChatmsg, sizeof(aChatmsg), "You must wait %d seconds before making another vote", (int)(TimeLeft / TickSpeed) + 1);
 				SendChatTarget(ClientID, aChatmsg);
 				return;
 			}
@@ -1281,9 +1281,8 @@ void CGameContext::OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID)
 						}
 						if(!m_apPlayers[ClientID]->m_Authed && (str_comp_num(pOption->m_aCommand, "sv_map ", 7) == 0 || str_comp_num(pOption->m_aCommand, "change_map ", 11) == 0 || str_comp_num(pOption->m_aCommand, "random_map", 10) == 0 || str_comp_num(pOption->m_aCommand, "random_unfinished_map", 21) == 0) && time_get() < m_LastMapVote + (time_freq() * g_Config.m_SvVoteMapTimeDelay))
 						{
-							char chatmsg[512] = {0};
-							str_format(chatmsg, sizeof(chatmsg), "There's a %d second delay between map-votes, please wait %d seconds.", g_Config.m_SvVoteMapTimeDelay,((m_LastMapVote+(g_Config.m_SvVoteMapTimeDelay * time_freq()))/time_freq())-(time_get()/time_freq()));
-							SendChatTarget(ClientID, chatmsg);
+							str_format(aChatmsg, sizeof(aChatmsg), "There's a %d second delay between map-votes, please wait %d seconds.", g_Config.m_SvVoteMapTimeDelay, (int)(((m_LastMapVote+(g_Config.m_SvVoteMapTimeDelay * time_freq()))/time_freq())-(time_get()/time_freq())));
+							SendChatTarget(ClientID, aChatmsg);
 
 							return;
 						}
@@ -1334,12 +1333,11 @@ void CGameContext::OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID)
 					return;
 				else if(!m_apPlayers[ClientID]->m_Authed && time_get() < m_apPlayers[ClientID]->m_Last_KickVote + (time_freq() * g_Config.m_SvVoteKickDelay))
 				{
-					char chatmsg[512] = {0};
-					str_format(chatmsg, sizeof(chatmsg), "There's a %d second wait time between kick votes for each player please wait %d second(s)",
+					str_format(aChatmsg, sizeof(aChatmsg), "There's a %d second wait time between kick votes for each player please wait %d second(s)",
 					g_Config.m_SvVoteKickDelay,
-					((m_apPlayers[ClientID]->m_Last_KickVote + (m_apPlayers[ClientID]->m_Last_KickVote*time_freq()))/time_freq())-(time_get()/time_freq())
+					(int)(((m_apPlayers[ClientID]->m_Last_KickVote + (m_apPlayers[ClientID]->m_Last_KickVote*time_freq()))/time_freq())-(time_get()/time_freq()))
 					);
-					SendChatTarget(ClientID, chatmsg);
+					SendChatTarget(ClientID, aChatmsg);
 					m_apPlayers[ClientID]->m_Last_KickVote = time_get();
 					return;
 				}
@@ -1846,7 +1844,7 @@ void CGameContext::ConTuneZone(IConsole::IResult *pResult, void *pUserData)
 	const char *pParamName = pResult->GetString(1);
 	float NewValue = pResult->GetFloat(2);
 
-	if (List >= 0 && List < NUM_TUNINGZONES)
+	if (List >= 0 && List < NUM_TUNEZONES)
 	{
 		if(pSelf->TuningList()[List].Set(pParamName, NewValue))
 		{
@@ -1865,7 +1863,7 @@ void CGameContext::ConTuneDumpZone(IConsole::IResult *pResult, void *pUserData)
 	CGameContext *pSelf = (CGameContext *)pUserData;
 	int List = pResult->GetInteger(0);
 	char aBuf[256];
-	if (List >= 0 && List < NUM_TUNINGZONES)
+	if (List >= 0 && List < NUM_TUNEZONES)
 	{
 		for(int i = 0; i < pSelf->TuningList()[List].Num(); i++)
 		{
@@ -1884,7 +1882,7 @@ void CGameContext::ConTuneResetZone(IConsole::IResult *pResult, void *pUserData)
 	if (pResult->NumArguments())
 	{
 		int List = pResult->GetInteger(0);
-		if (List >= 0 && List < NUM_TUNINGZONES)
+		if (List >= 0 && List < NUM_TUNEZONES)
 		{
 			pSelf->TuningList()[List] = TuningParams;
 			char aBuf[256];
@@ -1895,7 +1893,7 @@ void CGameContext::ConTuneResetZone(IConsole::IResult *pResult, void *pUserData)
 	}
 	else
 	{
-		for (int i = 0; i < NUM_TUNINGZONES; i++)
+		for (int i = 0; i < NUM_TUNEZONES; i++)
 		{
 			*(pSelf->TuningList()+i) = TuningParams;
 			pSelf->SendTuningParams(-1, i);
@@ -1910,9 +1908,9 @@ void CGameContext::ConTuneSetZoneMsgEnter(IConsole::IResult *pResult, void *pUse
 	if (pResult->NumArguments())
 	{
 		int List = pResult->GetInteger(0);
-		if (List >= 0 && List < NUM_TUNINGZONES)
+		if (List >= 0 && List < NUM_TUNEZONES)
 		{
-			str_format(pSelf->m_ZoneEnterMsg[List], sizeof(pSelf->m_ZoneEnterMsg[List]), pResult->GetString(1));
+			str_copy(pSelf->m_aaZoneEnterMsg[List], pResult->GetString(1), sizeof(pSelf->m_aaZoneEnterMsg[List]));
 		}
 	}
 }
@@ -1923,9 +1921,9 @@ void CGameContext::ConTuneSetZoneMsgLeave(IConsole::IResult *pResult, void *pUse
 	if (pResult->NumArguments())
 	{
 		int List = pResult->GetInteger(0);
-		if (List >= 0 && List < NUM_TUNINGZONES)
+		if (List >= 0 && List < NUM_TUNEZONES)
 		{
-			str_format(pSelf->m_ZoneLeaveMsg[List], sizeof(pSelf->m_ZoneLeaveMsg[List]), pResult->GetString(1));
+			str_copy(pSelf->m_aaZoneLeaveMsg[List], pResult->GetString(1), sizeof(pSelf->m_aaZoneLeaveMsg[List]));
 		}
 	}
 }
@@ -2443,7 +2441,7 @@ void CGameContext::OnInit(/*class IKernel *pKernel*/)
 
 	// Reset Tunezones
 	CTuningParams TuningParams;
-	for (int i = 0; i < NUM_TUNINGZONES; i++)
+	for (int i = 0; i < NUM_TUNEZONES; i++)
 	{
 		TuningList()[i] = TuningParams;
 		TuningList()[i].Set("gun_curvature", 0);
@@ -2453,10 +2451,11 @@ void CGameContext::OnInit(/*class IKernel *pKernel*/)
 		TuningList()[i].Set("shotgun_speeddiff", 0);
 	}
 
-	for (int i = 0; i < NUM_TUNINGZONES; i++) // decided to send no text on changing Tunezones for now
+	for (int i = 0; i < NUM_TUNEZONES; i++)
 	{
-		str_format(m_ZoneEnterMsg[i], sizeof(m_ZoneEnterMsg[i]), "", i);
-		str_format(m_ZoneLeaveMsg[i], sizeof(m_ZoneLeaveMsg[i]), "", i);
+		// Send no text by default when changing tune zones.
+		m_aaZoneEnterMsg[i][0] = 0;
+		m_aaZoneLeaveMsg[i][0] = 0;
 	}
 	// Reset Tuning
 	if(g_Config.m_SvTuneReset)
@@ -2503,7 +2502,7 @@ void CGameContext::OnInit(/*class IKernel *pKernel*/)
 		Tuning()->Set("player_collision", 0);
 		Tuning()->Set("player_hooking", 0);
 
-		for (int i = 0; i < NUM_TUNINGZONES; i++)
+		for (int i = 0; i < NUM_TUNEZONES; i++)
 		{
 			TuningList()[i].Set("player_collision", 0);
 			TuningList()[i].Set("player_hooking", 0);
@@ -3209,7 +3208,7 @@ void CGameContext::List(int ClientID, const char *pFilter)
 	if (pFilter[0])
 		str_format(aBuf, sizeof(aBuf), "Listing players with \"%s\" in name:", pFilter);
 	else
-		str_format(aBuf, sizeof(aBuf), "Listing all players:", pFilter);
+		str_format(aBuf, sizeof(aBuf), "Listing all players:");
 	SendChatTarget(ClientID, aBuf);
 	for(int i = 0; i < MAX_CLIENTS; i++)
 	{

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -48,7 +48,7 @@ typedef unsigned __int64 uint64_t;
 
 enum
 {
-	NUM_TUNINGZONES = 256
+	NUM_TUNEZONES = 256
 };
 
 class CGameContext : public IGameServer
@@ -59,7 +59,7 @@ class CGameContext : public IGameServer
 	CCollision m_Collision;
 	CNetObjHandler m_NetObjHandler;
 	CTuningParams m_Tuning;
-	CTuningParams m_TuningList[NUM_TUNINGZONES];
+	CTuningParams m_aTuningList[NUM_TUNEZONES];
 
 	static void ConTuneParam(IConsole::IResult *pResult, void *pUserData);
 	static void ConTuneReset(IConsole::IResult *pResult, void *pUserData);
@@ -100,7 +100,7 @@ public:
 	class IConsole *Console() { return m_pConsole; }
 	CCollision *Collision() { return &m_Collision; }
 	CTuningParams *Tuning() { return &m_Tuning; }
-	CTuningParams *TuningList() { return &m_TuningList[0]; }
+	CTuningParams *TuningList() { return &m_aTuningList[0]; }
 
 	CGameContext();
 	~CGameContext();
@@ -134,8 +134,8 @@ public:
 	char m_aVoteReason[VOTE_REASON_LENGTH];
 	int m_NumVoteOptions;
 	int m_VoteEnforce;
-	char m_ZoneEnterMsg[NUM_TUNINGZONES][256]; // 0 is used for switching from or to area without tunings
-	char m_ZoneLeaveMsg[NUM_TUNINGZONES][256];
+	char m_aaZoneEnterMsg[NUM_TUNEZONES][256]; // 0 is used for switching from or to area without tunings
+	char m_aaZoneLeaveMsg[NUM_TUNEZONES][256];
 
 	char m_aDeleteTempfile[128];
 	void DeleteTempfile();

--- a/src/tools/map_extract.cpp
+++ b/src/tools/map_extract.cpp
@@ -25,10 +25,10 @@ bool Process(IStorage *pStorage, const char *pMapName, const char *pPathSave)
 
 	CMapItemInfo *pInfo = (CMapItemInfo *)Map.FindItem(MAPITEMTYPE_INFO, 0);
 
-	dbg_msg("map_extract", "author:  %s", Map.GetData(pInfo->m_Author));
-	dbg_msg("map_extract", "version: %s", Map.GetData(pInfo->m_MapVersion));
-	dbg_msg("map_extract", "credits: %s", Map.GetData(pInfo->m_Credits));
-	dbg_msg("map_extract", "license: %s", Map.GetData(pInfo->m_License));
+	dbg_msg("map_extract", "author:  %s", (char *)Map.GetData(pInfo->m_Author));
+	dbg_msg("map_extract", "version: %s", (char *)Map.GetData(pInfo->m_MapVersion));
+	dbg_msg("map_extract", "credits: %s", (char *)Map.GetData(pInfo->m_Credits));
+	dbg_msg("map_extract", "license: %s", (char *)Map.GetData(pInfo->m_License));
 
 	int Start, Num;
 
@@ -77,7 +77,7 @@ bool Process(IStorage *pStorage, const char *pMapName, const char *pPathSave)
 	return Map.Close();
 }
 
-int main(int argc, char* argv[])
+int main(int argc, char *argv[])
 {
 	dbg_logger_stdout();
 
@@ -104,7 +104,7 @@ int main(int argc, char* argv[])
 
 	if (!fs_is_dir(aDir))
 	{
-		dbg_msg("usage" "directory '%s' does not exist", aDir);
+		dbg_msg("usage", "directory '%s' does not exist", aDir);
 		return -1;
 	}
 


### PR DESCRIPTION
Also annotate `dbg_msg`, `str_format` and `str_timestamp_ex` so that the
compiler can determine whether the format strings are correct.

Fix the compiler warnings generated by these extra warnings -- some of
them were security issues.