### PR TITLE
Remove default bind for home key (kill)

### DIFF
--- a/src/game/client/components/binds.cpp
+++ b/src/game/client/components/binds.cpp
@@ -319,7 +319,6 @@ void CBinds::SetDDRaceBinds(bool FreeOnly)
 	Bind(KEY_KP_PLUS, "zoom+", FreeOnly);
 	Bind(KEY_KP_MINUS, "zoom-", FreeOnly);
 	Bind(KEY_KP_MULTIPLY, "zoom", FreeOnly);
-	Bind(KEY_HOME, "kill", FreeOnly);
 	Bind(KEY_PAUSE, "say /pause", FreeOnly);
 	Bind(KEY_UP, "+jump", FreeOnly);
 	Bind(KEY_LEFT, "+left", FreeOnly);


### PR DESCRIPTION
Kill is already bound to K by default, binding it on home as well doesn't really have any purpose. (?)
Furthermore, the home key is right next to page up which is bound to toggling entities.
It is very easy to accidentally hit home instead of page up, which is highly frustrating.. therefore I suggest removing this duplicate binding.