### PR TITLE
Rename `GetUncompressedDataSize` to `GetDataSize`

### DIFF
--- a/src/engine/map.h
+++ b/src/engine/map.h
@@ -10,7 +10,7 @@ class IMap : public IInterface
 	MACRO_INTERFACE("map", 0)
 public:
 	virtual void *GetData(int Index) = 0;
-	virtual int GetUncompressedDataSize(int Index) = 0;
+	virtual int GetDataSize(int Index) = 0;
 	virtual void *GetDataSwapped(int Index) = 0;
 	virtual void UnloadData(int Index) = 0;
 	virtual void *GetItem(int Index, int *Type, int *pID) = 0;

--- a/src/engine/shared/datafile.cpp
+++ b/src/engine/shared/datafile.cpp
@@ -258,8 +258,8 @@ int CDataFileReader::NumData()
 	return m_pDataFile->m_Header.m_NumRawData;
 }
 
-// always returns the size in the file
-int CDataFileReader::GetDataSize(int Index)
+// returns the size in the file
+int CDataFileReader::GetFileDataSize(int Index)
 {
 	if(!m_pDataFile) { return 0; }
 
@@ -268,15 +268,15 @@ int CDataFileReader::GetDataSize(int Index)
 	return m_pDataFile->m_Info.m_pDataOffsets[Index+1]-m_pDataFile->m_Info.m_pDataOffsets[Index];
 }
 
-// always returns the size in the file
-int CDataFileReader::GetUncompressedDataSize(int Index)
+// returns the size of the resulting data
+int CDataFileReader::GetDataSize(int Index)
 {
 	if(!m_pDataFile) { return 0; }
 
 	if(m_pDataFile->m_Header.m_Version == 4)
 		return m_pDataFile->m_Info.m_pDataSizes[Index];
 	else
-		return GetDataSize(Index);
+		return GetFileDataSize(Index);
 }
 
 void *CDataFileReader::GetDataImpl(int Index, int Swap)
@@ -287,7 +287,7 @@ void *CDataFileReader::GetDataImpl(int Index, int Swap)
 	if(!m_pDataFile->m_ppDataPtrs[Index])
 	{
 		// fetch the data size
-		int DataSize = GetDataSize(Index);
+		int DataSize = GetFileDataSize(Index);
 #if defined(CONF_ARCH_ENDIAN_BIG)
 		int SwapSize = DataSize;
 #endif

--- a/src/engine/shared/datafile.h
+++ b/src/engine/shared/datafile.h
@@ -8,6 +8,7 @@ class CDataFileReader
 {
 	struct CDatafile *m_pDataFile;
 	void *GetDataImpl(int Index, int Swap);
+	int GetFileDataSize(int Index);
 public:
 	CDataFileReader() : m_pDataFile(0) {}
 	~CDataFileReader() { Close(); }
@@ -22,7 +23,6 @@ public:
 	void *GetData(int Index);
 	void *GetDataSwapped(int Index); // makes sure that the data is 32bit LE ints when saved
 	int GetDataSize(int Index);
-	int GetUncompressedDataSize(int Index);
 	void UnloadData(int Index);
 	void *GetItem(int Index, int *pType, int *pID);
 	int GetItemSize(int Index);

--- a/src/engine/shared/map.cpp
+++ b/src/engine/shared/map.cpp
@@ -12,7 +12,7 @@ public:
 	CMap() {}
 
 	virtual void *GetData(int Index) { return m_DataFile.GetData(Index); }
-	virtual int GetUncompressedDataSize(int Index) { return m_DataFile.GetUncompressedDataSize(Index); }
+	virtual int GetDataSize(int Index) { return m_DataFile.GetDataSize(Index); }
 	virtual void *GetDataSwapped(int Index) { return m_DataFile.GetDataSwapped(Index); }
 	virtual void UnloadData(int Index) { m_DataFile.UnloadData(Index); }
 	virtual void *GetItem(int Index, int *pType, int *pID) { return m_DataFile.GetItem(Index, pType, pID); }

--- a/src/game/client/components/background.cpp
+++ b/src/game/client/components/background.cpp
@@ -161,7 +161,7 @@ void CBackground::OnRender()
 					Graphics()->TextureSet(m_pImages->Get(pTMap->m_Image));
 
 				CTile *pTiles = (CTile *)m_pMap->GetData(pTMap->m_Data);
-				unsigned int Size = m_pMap->GetUncompressedDataSize(pTMap->m_Data);
+				unsigned int Size = m_pMap->GetDataSize(pTMap->m_Data);
 
 				if (Size >= pTMap->m_Width*pTMap->m_Height*sizeof(CTile))
 				{

--- a/src/game/client/components/maplayers.cpp
+++ b/src/game/client/components/maplayers.cpp
@@ -250,7 +250,7 @@ void CMapLayers::OnRender()
 						Graphics()->TextureSet(m_pClient->m_pMapimages->Get(pTMap->m_Image));
 
 					CTile *pTiles = (CTile *)m_pLayers->Map()->GetData(pTMap->m_Data);
-					unsigned int Size = m_pLayers->Map()->GetUncompressedDataSize(pTMap->m_Data);
+					unsigned int Size = m_pLayers->Map()->GetDataSize(pTMap->m_Data);
 
 					if (Size >= pTMap->m_Width*pTMap->m_Height*sizeof(CTile))
 					{
@@ -304,7 +304,7 @@ void CMapLayers::OnRender()
 				Graphics()->TextureSet(m_pClient->m_pMapimages->GetEntities());
 
 				CTile *pFrontTiles = (CTile *)m_pLayers->Map()->GetData(pTMap->m_Front);
-				unsigned int Size = m_pLayers->Map()->GetUncompressedDataSize(pTMap->m_Front);
+				unsigned int Size = m_pLayers->Map()->GetDataSize(pTMap->m_Front);
 
 				if (Size >= pTMap->m_Width*pTMap->m_Height*sizeof(CTile))
 				{
@@ -323,7 +323,7 @@ void CMapLayers::OnRender()
 				Graphics()->TextureSet(m_pClient->m_pMapimages->GetEntities());
 
 				CSwitchTile *pSwitchTiles = (CSwitchTile *)m_pLayers->Map()->GetData(pTMap->m_Switch);
-				unsigned int Size = m_pLayers->Map()->GetUncompressedDataSize(pTMap->m_Switch);
+				unsigned int Size = m_pLayers->Map()->GetDataSize(pTMap->m_Switch);
 
 				if (Size >= pTMap->m_Width*pTMap->m_Height*sizeof(CSwitchTile))
 				{
@@ -341,7 +341,7 @@ void CMapLayers::OnRender()
 				Graphics()->TextureSet(m_pClient->m_pMapimages->GetEntities());
 
 				CTeleTile *pTeleTiles = (CTeleTile *)m_pLayers->Map()->GetData(pTMap->m_Tele);
-				unsigned int Size = m_pLayers->Map()->GetUncompressedDataSize(pTMap->m_Tele);
+				unsigned int Size = m_pLayers->Map()->GetDataSize(pTMap->m_Tele);
 
 				if (Size >= pTMap->m_Width*pTMap->m_Height*sizeof(CTeleTile))
 				{
@@ -359,7 +359,7 @@ void CMapLayers::OnRender()
 				Graphics()->TextureSet(m_pClient->m_pMapimages->GetEntities());
 
 				CSpeedupTile *pSpeedupTiles = (CSpeedupTile *)m_pLayers->Map()->GetData(pTMap->m_Speedup);
-				unsigned int Size = m_pLayers->Map()->GetUncompressedDataSize(pTMap->m_Speedup);
+				unsigned int Size = m_pLayers->Map()->GetDataSize(pTMap->m_Speedup);
 
 				if (Size >= pTMap->m_Width*pTMap->m_Height*sizeof(CSpeedupTile))
 				{
@@ -377,7 +377,7 @@ void CMapLayers::OnRender()
 				Graphics()->TextureSet(m_pClient->m_pMapimages->GetEntities());
 
 				CTuneTile *pTuneTiles = (CTuneTile *)m_pLayers->Map()->GetData(pTMap->m_Tune);
-				unsigned int Size = m_pLayers->Map()->GetUncompressedDataSize(pTMap->m_Tune);
+				unsigned int Size = m_pLayers->Map()->GetDataSize(pTMap->m_Tune);
 
 				if (Size >= pTMap->m_Width*pTMap->m_Height*sizeof(CTuneTile))
 				{

--- a/src/game/collision.cpp
+++ b/src/game/collision.cpp
@@ -46,21 +46,21 @@ void CCollision::Init(class CLayers *pLayers)
 
 	if(m_pLayers->TeleLayer())
 	{
-		unsigned int Size = m_pLayers->Map()->GetUncompressedDataSize(m_pLayers->TeleLayer()->m_Tele);
+		unsigned int Size = m_pLayers->Map()->GetDataSize(m_pLayers->TeleLayer()->m_Tele);
 		if (Size >= m_Width*m_Height*sizeof(CTeleTile))
 			m_pTele = static_cast<CTeleTile *>(m_pLayers->Map()->GetData(m_pLayers->TeleLayer()->m_Tele));
 	}
 
 	if(m_pLayers->SpeedupLayer())
 	{
-		unsigned int Size = m_pLayers->Map()->GetUncompressedDataSize(m_pLayers->SpeedupLayer()->m_Speedup);
+		unsigned int Size = m_pLayers->Map()->GetDataSize(m_pLayers->SpeedupLayer()->m_Speedup);
 		if (Size >= m_Width*m_Height*sizeof(CSpeedupTile))
 			m_pSpeedup = static_cast<CSpeedupTile *>(m_pLayers->Map()->GetData(m_pLayers->SpeedupLayer()->m_Speedup));
 	}
 
 	if(m_pLayers->SwitchLayer())
 	{
-		unsigned int Size = m_pLayers->Map()->GetUncompressedDataSize(m_pLayers->SwitchLayer()->m_Switch);
+		unsigned int Size = m_pLayers->Map()->GetDataSize(m_pLayers->SwitchLayer()->m_Switch);
 		if (Size >= m_Width*m_Height*sizeof(CSwitchTile))
 			m_pSwitch = static_cast<CSwitchTile *>(m_pLayers->Map()->GetData(m_pLayers->SwitchLayer()->m_Switch));
 
@@ -75,14 +75,14 @@ void CCollision::Init(class CLayers *pLayers)
 
 	if(m_pLayers->TuneLayer())
 	{
-		unsigned int Size = m_pLayers->Map()->GetUncompressedDataSize(m_pLayers->TuneLayer()->m_Tune);
+		unsigned int Size = m_pLayers->Map()->GetDataSize(m_pLayers->TuneLayer()->m_Tune);
 		if (Size >= m_Width*m_Height*sizeof(CTuneTile))
 			m_pTune = static_cast<CTuneTile *>(m_pLayers->Map()->GetData(m_pLayers->TuneLayer()->m_Tune));
 	}
 
 	if(m_pLayers->FrontLayer())
 	{
-		unsigned int Size = m_pLayers->Map()->GetUncompressedDataSize(m_pLayers->FrontLayer()->m_Front);
+		unsigned int Size = m_pLayers->Map()->GetDataSize(m_pLayers->FrontLayer()->m_Front);
 		if (Size >= m_Width*m_Height*sizeof(CTile))
 			m_pFront = static_cast<CTile *>(m_pLayers->Map()->GetData(m_pLayers->FrontLayer()->m_Front));
 	}

--- a/src/game/editor/io.cpp
+++ b/src/game/editor/io.cpp
@@ -633,7 +633,7 @@ int CEditorMap::Load(class IStorage *pStorage, const char *pFileName, int Storag
 				if(!(pItem->m_Settings > -1))
 					break;
 
-				const unsigned Size = DataFile.GetUncompressedDataSize(pItem->m_Settings);
+				const unsigned Size = DataFile.GetDataSize(pItem->m_Settings);
 				char *pSettings = (char *)DataFile.GetData(pItem->m_Settings);
 				char *pNext = pSettings;
 				while(pNext < pSettings + Size)
@@ -867,7 +867,7 @@ int CEditorMap::Load(class IStorage *pStorage, const char *pFileName, int Storag
 
 						pGroup->AddLayer(pTiles);
 						void *pData = DataFile.GetData(pTilemapItem->m_Data);
-						unsigned int Size = DataFile.GetUncompressedDataSize(pTilemapItem->m_Data);
+						unsigned int Size = DataFile.GetDataSize(pTilemapItem->m_Data);
 						pTiles->m_Image = pTilemapItem->m_Image;
 						pTiles->m_Game = pTilemapItem->m_Flags&TILESLAYERFLAG_GAME;
 
@@ -878,7 +878,7 @@ int CEditorMap::Load(class IStorage *pStorage, const char *pFileName, int Storag
 						if(pTiles->m_Tele)
 						{
 							void *pTeleData = DataFile.GetData(pTilemapItem->m_Tele);
-							unsigned int Size = DataFile.GetUncompressedDataSize(pTilemapItem->m_Tele);
+							unsigned int Size = DataFile.GetDataSize(pTilemapItem->m_Tele);
 							if (Size >= pTiles->m_Width*pTiles->m_Height*sizeof(CTeleTile))
 							{
 								static const int s_aTilesRep[] = {
@@ -909,7 +909,7 @@ int CEditorMap::Load(class IStorage *pStorage, const char *pFileName, int Storag
 						else if(pTiles->m_Speedup)
 						{
 							void *pSpeedupData = DataFile.GetData(pTilemapItem->m_Speedup);
-							unsigned int Size = DataFile.GetUncompressedDataSize(pTilemapItem->m_Speedup);
+							unsigned int Size = DataFile.GetDataSize(pTilemapItem->m_Speedup);
 
 							if (Size >= pTiles->m_Width*pTiles->m_Height*sizeof(CSpeedupTile))
 							{
@@ -929,7 +929,7 @@ int CEditorMap::Load(class IStorage *pStorage, const char *pFileName, int Storag
 						else if(pTiles->m_Front)
 						{
 							void *pFrontData = DataFile.GetData(pTilemapItem->m_Front);
-							unsigned int Size = DataFile.GetUncompressedDataSize(pTilemapItem->m_Front);
+							unsigned int Size = DataFile.GetDataSize(pTilemapItem->m_Front);
 							if (Size >= pTiles->m_Width*pTiles->m_Height*sizeof(CTile))
 								mem_copy(((CLayerFront*)pTiles)->m_pTiles, pFrontData, pTiles->m_Width*pTiles->m_Height*sizeof(CTile));
 
@@ -938,7 +938,7 @@ int CEditorMap::Load(class IStorage *pStorage, const char *pFileName, int Storag
 						else if(pTiles->m_Switch)
 						{
 							void *pSwitchData = DataFile.GetData(pTilemapItem->m_Switch);
-							unsigned int Size = DataFile.GetUncompressedDataSize(pTilemapItem->m_Switch);
+							unsigned int Size = DataFile.GetDataSize(pTilemapItem->m_Switch);
 							if (Size >= pTiles->m_Width*pTiles->m_Height*sizeof(CSwitchTile))
 							{
 								const int s_aTilesComp[] = {
@@ -984,7 +984,7 @@ int CEditorMap::Load(class IStorage *pStorage, const char *pFileName, int Storag
 						else if(pTiles->m_Tune)
 						{
 							void *pTuneData = DataFile.GetData(pTilemapItem->m_Tune);
-							unsigned int Size = DataFile.GetUncompressedDataSize(pTilemapItem->m_Tune);
+							unsigned int Size = DataFile.GetDataSize(pTilemapItem->m_Tune);
 							if (Size >= pTiles->m_Width*pTiles->m_Height*sizeof(CTuneTile))
 							{
 								CTuneTile *pLayerTuneTiles = ((CLayerTune *)pTiles)->m_pTuneTile;

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -2720,7 +2720,7 @@ void CGameContext::OnMapChange(char *pNewMapName, int MapNameSize)
 				{
 					SettingsIndex = pInfo->m_Settings;
 					char *pMapSettings = (char *)Reader.GetData(SettingsIndex);
-					int DataSize = Reader.GetUncompressedDataSize(SettingsIndex);
+					int DataSize = Reader.GetDataSize(SettingsIndex);
 					if(DataSize == TotalLength && mem_comp(pSettings, pMapSettings, DataSize) == 0)
 					{
 						// Configs coincide, no need to update map.
@@ -2767,7 +2767,7 @@ void CGameContext::OnMapChange(char *pNewMapName, int MapNameSize)
 			continue;
 		}
 		unsigned char *pData = (unsigned char *)Reader.GetData(i);
-		int Size = Reader.GetUncompressedDataSize(i);
+		int Size = Reader.GetDataSize(i);
 		Writer.AddData(Size, pData);
 		Reader.UnloadData(i);
 	}
@@ -2812,7 +2812,7 @@ void CGameContext::LoadMapSettings()
 		if(!(pItem->m_Settings > -1))
 			break;
 
-		int Size = pMap->GetUncompressedDataSize(pItem->m_Settings);
+		int Size = pMap->GetDataSize(pItem->m_Settings);
 		char *pSettings = (char *)pMap->GetData(pItem->m_Settings);
 		char *pNext = pSettings;
 		while(pNext < pSettings + Size)

--- a/src/tools/config_retrieve.cpp
+++ b/src/tools/config_retrieve.cpp
@@ -35,7 +35,7 @@ void Process(IStorage *pStorage, const char *pMapName, const char *pConfigName)
 			return;
 		}
 
-		int Size = Map.GetUncompressedDataSize(pItem->m_Settings);
+		int Size = Map.GetDataSize(pItem->m_Settings);
 		char *pSettings = (char *)Map.GetData(pItem->m_Settings);
 		char *pNext = pSettings;
 		while(pNext < pSettings + Size)

--- a/src/tools/config_store.cpp
+++ b/src/tools/config_store.cpp
@@ -69,7 +69,7 @@ void Process(IStorage *pStorage, const char *pMapName, const char *pConfigName)
 				{
 					SettingsIndex = pInfo->m_Settings;
 					char *pMapSettings = (char *)Reader.GetData(SettingsIndex);
-					int DataSize = Reader.GetUncompressedDataSize(SettingsIndex);
+					int DataSize = Reader.GetDataSize(SettingsIndex);
 					if(DataSize == TotalLength && mem_comp(pSettings, pMapSettings, DataSize) == 0)
 					{
 						dbg_msg("config_store", "configs coincide, not updating map");
@@ -116,7 +116,7 @@ void Process(IStorage *pStorage, const char *pMapName, const char *pConfigName)
 			continue;
 		}
 		unsigned char *pData = (unsigned char *)Reader.GetData(i);
-		int Size = Reader.GetUncompressedDataSize(i);
+		int Size = Reader.GetDataSize(i);
 		Writer.AddData(Size, pData);
 		Reader.UnloadData(i);
 	}

--- a/src/tools/map_replace_image.cpp
+++ b/src/tools/map_replace_image.cpp
@@ -188,7 +188,7 @@ int main(int argc, const char **argv)
 		else
 		{
 			pData = g_DataReader.GetData(Index);
-			Size = g_DataReader.GetUncompressedDataSize(Index);
+			Size = g_DataReader.GetDataSize(Index);
 		}
 
 		g_DataWriter.AddData(Size, pData);

--- a/src/tools/map_resave.cpp
+++ b/src/tools/map_resave.cpp
@@ -35,7 +35,7 @@ int main(int argc, const char **argv)
 	for(Index = 0; Index < DataFile.NumData(); Index++)
 	{
 		pPtr = DataFile.GetData(Index);
-		Size = DataFile.GetUncompressedDataSize(Index);
+		Size = DataFile.GetDataSize(Index);
 		df.AddData(Size, pPtr);
 	}
 


### PR DESCRIPTION
Also rename the old `GetDataSize` to `GetFileDataSize`. `GetDataSize`
now returns the actual data size, not the data size before
decompression.