### PR TITLE
Ghost and Race demo time extraction fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -589,6 +589,7 @@ if(CLIENT)
     components/particles.h
     components/players.cpp
     components/players.h
+    components/race.h
     components/race_demo.cpp
     components/race_demo.h
     components/scoreboard.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -589,6 +589,7 @@ if(CLIENT)
     components/particles.h
     components/players.cpp
     components/players.h
+    components/race.cpp
     components/race.h
     components/race_demo.cpp
     components/race_demo.h

--- a/src/game/client/components/ghost.cpp
+++ b/src/game/client/components/ghost.cpp
@@ -11,6 +11,7 @@
 #include <game/generated/client_data.h>
 #include <game/client/animstate.h>
 
+#include "race.h"
 #include "skins.h"
 #include "menus.h"
 #include "ghost.h"
@@ -555,20 +556,11 @@ void CGhost::OnMessage(int MsgType, void *pRawMsg)
 		if(pMsg->m_ClientID == -1 && m_RaceState == RACE_STARTED)
 		{
 			char aName[MAX_NAME_LENGTH];
-			const char *pFinished = str_find(pMsg->m_pMessage, " finished in: ");
-			int FinishedPos = pFinished - pMsg->m_pMessage;
-			if (!pFinished || FinishedPos == 0 || FinishedPos >= (int)sizeof(aName))
-				return;
-
-			str_copy(aName, pMsg->m_pMessage, FinishedPos + 1);
-
-			// prepare values and state for saving
-			int Minutes;
-			float Seconds;
-			if(!str_comp(aName, m_pClient->m_aClients[m_pClient->m_Snap.m_LocalClientID].m_aName) && sscanf(pFinished, " finished in: %d minute(s) %f", &Minutes, &Seconds) == 2)
+			int Time = CRaceHelper::TimeFromFinishMessage(pMsg->m_pMessage, aName, sizeof(aName));
+			if(Time && str_comp(aName, m_pClient->m_aClients[m_pClient->m_Snap.m_LocalClientID].m_aName) == 0)
 			{
 				m_RaceState = RACE_FINISHED;
-				float CurTime = Minutes*60 + Seconds;
+				float CurTime = Time / 1000.f;
 				if(m_Recording && (CurTime < m_BestTime || m_BestTime == -1))
 				{
 					m_NewRecord = true;

--- a/src/game/client/components/ghost.cpp
+++ b/src/game/client/components/ghost.cpp
@@ -557,7 +557,7 @@ void CGhost::OnMessage(int MsgType, void *pRawMsg)
 		{
 			char aName[MAX_NAME_LENGTH];
 			int Time = CRaceHelper::TimeFromFinishMessage(pMsg->m_pMessage, aName, sizeof(aName));
-			if(Time && str_comp(aName, m_pClient->m_aClients[m_pClient->m_Snap.m_LocalClientID].m_aName) == 0)
+			if(Time > 0 && str_comp(aName, m_pClient->m_aClients[m_pClient->m_Snap.m_LocalClientID].m_aName) == 0)
 			{
 				m_RaceState = RACE_FINISHED;
 				float CurTime = Time / 1000.f;

--- a/src/game/client/components/ghost.h
+++ b/src/game/client/components/ghost.h
@@ -52,7 +52,7 @@ private:
 	bool m_Recording;
 	bool m_Rendering;
 	int m_RaceState;
-	float m_BestTime;
+	int m_BestTime;
 	bool m_NewRecord;
 	bool m_Saving;
 

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -333,7 +333,7 @@ public:
 		char m_aFilename[256];
 		char m_aPlayer[MAX_NAME_LENGTH];
 
-		float m_Time;
+		int m_Time;
 
 		bool m_Active;
 		int m_ID;

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -851,7 +851,7 @@ int CMenus::GhostlistFetchCallback(const char *pName, int IsDir, int StorageType
 	CGhostItem Item;
 	str_copy(Item.m_aFilename, pName, sizeof(Item.m_aFilename));
 	str_copy(Item.m_aPlayer, Header.m_aOwner, sizeof(Item.m_aPlayer));
-	Item.m_Time = Header.m_Time;
+	Item.m_Time = Header.m_Time * 1000;
 	Item.m_Active = false;
 	Item.m_ID = pSelf->m_lGhosts.add(Item);
 
@@ -1079,7 +1079,7 @@ void CMenus::RenderGhost(CUIRect MainView)
 				Cursor.m_LineWidth = Button.w;
 
 				char aBuf[64];
-				str_format(aBuf, sizeof(aBuf), "%02d:%06.3f", (int)pItem->m_Time/60, pItem->m_Time-((int)pItem->m_Time/60*60));
+				str_format(aBuf, sizeof(aBuf), "%02d:%02d.%03d", pItem->m_Time / (60 * 1000), (pItem->m_Time / 1000) % 60, pItem->m_Time % 1000);
 				TextRender()->TextEx(&Cursor, aBuf, -1);
 			}
 		}

--- a/src/game/client/components/race.cpp
+++ b/src/game/client/components/race.cpp
@@ -1,0 +1,48 @@
+#include "race.h"
+
+int CRaceHelper::TimeFromSecondsStr(const char *pStr) // x.xxx
+{
+	int Time = str_toint(pStr) * 1000;
+	while(*pStr >= '0' && *pStr <= '9')
+		pStr++;
+	if(*pStr == '.' || *pStr == ',')
+	{
+		pStr++;
+		static const int s_aMult[3] = { 100, 10, 1 };
+		for(int i = 0; pStr[i] >= '0' && pStr[i] <= '9' && i < 3; i++)
+			Time += (pStr[i] - '0') * s_aMult[i];
+	}
+	return Time;
+}
+
+int CRaceHelper::TimeFromStr(const char *pStr) // x minute(s) x.xxx second(s)
+{
+	static const char * const s_pMinutesStr = " minute(s) ";
+	static const char * const s_pSecondsStr = " second(s)";
+
+	const char *pSeconds = str_find(pStr, s_pSecondsStr);
+	if(!pSeconds)
+		return 0;
+
+	const char *pMinutes = str_find(pStr, s_pMinutesStr);
+	if(pMinutes)
+		return str_toint(pStr) * 60 * 1000 + TimeFromSecondsStr(pMinutes + str_length(s_pMinutesStr));
+	else
+		return TimeFromSecondsStr(pStr);
+}
+
+int CRaceHelper::TimeFromFinishMessage(const char *pStr, char *pNameBuf, int NameBufSize) // xxx finished in: x minute(s) x.xxx second(s)
+{
+	static const char * const s_pFinishedStr = " finished in: ";
+	const char *pFinished = str_find(pStr, s_pFinishedStr);
+	if(!pFinished)
+		return 0;
+
+	int FinishedPos = pFinished - pStr;
+	if(FinishedPos == 0 || FinishedPos >= NameBufSize)
+		return 0;
+
+	str_copy(pNameBuf, pStr, FinishedPos + 1);
+
+	return TimeFromStr(pFinished + str_length(s_pFinishedStr));
+}

--- a/src/game/client/components/race.cpp
+++ b/src/game/client/components/race.cpp
@@ -1,15 +1,21 @@
+#include <ctype.h>
+
 #include "race.h"
 
 int CRaceHelper::TimeFromSecondsStr(const char *pStr) // x.xxx
 {
+	while(*pStr == ' ') // skip leading spaces
+		pStr++;
+	if(!isdigit(*pStr))
+		return -1;
 	int Time = str_toint(pStr) * 1000;
-	while(*pStr >= '0' && *pStr <= '9')
+	while(isdigit(*pStr))
 		pStr++;
 	if(*pStr == '.' || *pStr == ',')
 	{
 		pStr++;
 		static const int s_aMult[3] = { 100, 10, 1 };
-		for(int i = 0; pStr[i] >= '0' && pStr[i] <= '9' && i < 3; i++)
+		for(int i = 0; isdigit(pStr[i]) && i < 3; i++)
 			Time += (pStr[i] - '0') * s_aMult[i];
 	}
 	return Time;
@@ -22,11 +28,18 @@ int CRaceHelper::TimeFromStr(const char *pStr) // x minute(s) x.xxx second(s)
 
 	const char *pSeconds = str_find(pStr, s_pSecondsStr);
 	if(!pSeconds)
-		return 0;
+		return -1;
 
 	const char *pMinutes = str_find(pStr, s_pMinutesStr);
 	if(pMinutes)
-		return str_toint(pStr) * 60 * 1000 + TimeFromSecondsStr(pMinutes + str_length(s_pMinutesStr));
+	{
+		while(*pStr == ' ') // skip leading spaces
+			pStr++;
+		int SecondsTime = TimeFromSecondsStr(pMinutes + str_length(s_pMinutesStr));
+		if(SecondsTime == -1 || !isdigit(*pStr))
+			return -1;
+		return str_toint(pStr) * 60 * 1000 + SecondsTime;
+	}
 	else
 		return TimeFromSecondsStr(pStr);
 }
@@ -36,11 +49,11 @@ int CRaceHelper::TimeFromFinishMessage(const char *pStr, char *pNameBuf, int Nam
 	static const char * const s_pFinishedStr = " finished in: ";
 	const char *pFinished = str_find(pStr, s_pFinishedStr);
 	if(!pFinished)
-		return 0;
+		return -1;
 
 	int FinishedPos = pFinished - pStr;
 	if(FinishedPos == 0 || FinishedPos >= NameBufSize)
-		return 0;
+		return -1;
 
 	str_copy(pNameBuf, pStr, FinishedPos + 1);
 

--- a/src/game/client/components/race.h
+++ b/src/game/client/components/race.h
@@ -1,0 +1,55 @@
+#ifndef GAME_CLIENT_COMPONENTS_RACE_H
+#define GAME_CLIENT_COMPONENTS_RACE_H
+
+#include <base/system.h>
+
+class CRaceHelper
+{
+public:
+	// these functions return the time in milliseconds, time 0 is invalid
+
+	static int TimeFromSecondsStr(const char *pStr) // x.xxx
+	{
+		int Time = str_toint(pStr) * 1000;
+		while(*pStr >= '0' && *pStr <= '9') pStr++;
+		if(*pStr == '.' || *pStr == ',')
+		{
+			pStr++;
+			const int Mult[3] = { 100, 10, 1 };
+			for(int i = 0; pStr[i] >= '0' && pStr[i] <= '9' && i < 3; i++)
+				Time += (pStr[i] - '0') * Mult[i];
+		}
+		return Time;
+	}
+
+	static int TimeFromStr(const char *pStr) // x minute(s) x.xx second(s)
+	{
+		static const char *pMinutesStr = " minute(s) ";
+		static const char *pSecondsStr = " second(s)";
+
+		const char *pSeconds = str_find(pStr, pSecondsStr);
+		if(!pSeconds)
+			return 0;
+
+		const char *pMinutes = str_find(pStr, pMinutesStr);
+		if(pMinutes)
+			return str_toint(pStr) * 60 * 1000 + TimeFromSecondsStr(pMinutes + str_length(pMinutesStr));
+		else
+			return TimeFromSecondsStr(pStr);
+	}
+
+	static int TimeFromFinishMessage(const char *pStr, char *pNameBuf, int NameBufSize) // xxx finished in: x minute(s) x.xx second(s)
+	{
+		static const char *pFinishedStr = " finished in: ";
+		const char *pFinished = str_find(pStr, pFinishedStr);
+		int FinishedPos = pFinished - pStr;
+		if(!pFinished || FinishedPos == 0 || FinishedPos >= NameBufSize)
+			return 0;
+
+		str_copy(pNameBuf, pStr, FinishedPos + 1);
+
+		return TimeFromStr(pFinished + str_length(pFinishedStr));
+	}
+};
+
+#endif

--- a/src/game/client/components/race.h
+++ b/src/game/client/components/race.h
@@ -6,7 +6,7 @@
 class CRaceHelper
 {
 public:
-	// these functions return the time in milliseconds, time 0 is invalid
+	// these functions return the time in milliseconds, time -1 is invalid
 	static int TimeFromSecondsStr(const char *pStr); // x.xxx
 	static int TimeFromStr(const char *pStr); // x minute(s) x.xx second(s)
 	static int TimeFromFinishMessage(const char *pStr, char *pNameBuf, int NameBufSize); // xxx finished in: x minute(s) x.xx second(s)

--- a/src/game/client/components/race.h
+++ b/src/game/client/components/race.h
@@ -7,49 +7,9 @@ class CRaceHelper
 {
 public:
 	// these functions return the time in milliseconds, time 0 is invalid
-
-	static int TimeFromSecondsStr(const char *pStr) // x.xxx
-	{
-		int Time = str_toint(pStr) * 1000;
-		while(*pStr >= '0' && *pStr <= '9') pStr++;
-		if(*pStr == '.' || *pStr == ',')
-		{
-			pStr++;
-			const int Mult[3] = { 100, 10, 1 };
-			for(int i = 0; pStr[i] >= '0' && pStr[i] <= '9' && i < 3; i++)
-				Time += (pStr[i] - '0') * Mult[i];
-		}
-		return Time;
-	}
-
-	static int TimeFromStr(const char *pStr) // x minute(s) x.xx second(s)
-	{
-		static const char *pMinutesStr = " minute(s) ";
-		static const char *pSecondsStr = " second(s)";
-
-		const char *pSeconds = str_find(pStr, pSecondsStr);
-		if(!pSeconds)
-			return 0;
-
-		const char *pMinutes = str_find(pStr, pMinutesStr);
-		if(pMinutes)
-			return str_toint(pStr) * 60 * 1000 + TimeFromSecondsStr(pMinutes + str_length(pMinutesStr));
-		else
-			return TimeFromSecondsStr(pStr);
-	}
-
-	static int TimeFromFinishMessage(const char *pStr, char *pNameBuf, int NameBufSize) // xxx finished in: x minute(s) x.xx second(s)
-	{
-		static const char *pFinishedStr = " finished in: ";
-		const char *pFinished = str_find(pStr, pFinishedStr);
-		int FinishedPos = pFinished - pStr;
-		if(!pFinished || FinishedPos == 0 || FinishedPos >= NameBufSize)
-			return 0;
-
-		str_copy(pNameBuf, pStr, FinishedPos + 1);
-
-		return TimeFromStr(pFinished + str_length(pFinishedStr));
-	}
+	static int TimeFromSecondsStr(const char *pStr); // x.xxx
+	static int TimeFromStr(const char *pStr); // x minute(s) x.xx second(s)
+	static int TimeFromFinishMessage(const char *pStr, char *pNameBuf, int NameBufSize); // xxx finished in: x minute(s) x.xx second(s)
 };
 
 #endif

--- a/src/game/client/components/race_demo.cpp
+++ b/src/game/client/components/race_demo.cpp
@@ -1,7 +1,5 @@
 /* (c) Redix and Sushi */
 
-#include <stdio.h>
-
 #include <base/system.h>
 #include <engine/shared/config.h>
 #include <engine/serverbrowser.h>
@@ -115,7 +113,7 @@ void CRaceDemo::OnMessage(int MsgType, void *pRawMsg)
 		{
 			char aName[MAX_NAME_LENGTH];
 			int Time = CRaceHelper::TimeFromFinishMessage(pMsg->m_pMessage, aName, sizeof(aName));
-			if(Time && str_comp(aName, m_pClient->m_aClients[m_pClient->m_Snap.m_LocalClientID].m_aName) == 0)
+			if(Time > 0 && str_comp(aName, m_pClient->m_aClients[m_pClient->m_Snap.m_LocalClientID].m_aName) == 0)
 			{
 				m_RaceState = RACE_FINISHED;
 				m_RecordStopTime = Client()->GameTick() + Client()->GameTickSpeed();
@@ -148,7 +146,7 @@ void CRaceDemo::CheckDemo()
 			pDemo += MapLen + 1;
 			int Time = CRaceHelper::TimeFromSecondsStr(pDemo);
 			float DemoTime = Time / 1000.f;
-			if(Time && m_Time < DemoTime)
+			if(Time > 0 && m_Time < DemoTime)
 			{
 				// save new record
 				SaveDemo(m_pMap);
@@ -189,11 +187,11 @@ void CRaceDemo::SaveDemo(const char* pDemo)
 			if(aPlayerName[i] == '\\' || aPlayerName[i] == '/' || aPlayerName[i] == '|' || aPlayerName[i] == ':' || aPlayerName[i] == '*' || aPlayerName[i] == '?' || aPlayerName[i] == '<' || aPlayerName[i] == '>' || aPlayerName[i] == '"')
 				aPlayerName[i] = '%';
 
-			str_format(aNewFilename, sizeof(aNewFilename), "demos/%s_%5.2f_%s.demo", pDemo, m_Time, aPlayerName);
+			str_format(aNewFilename, sizeof(aNewFilename), "demos/%s_%.2f_%s.demo", pDemo, m_Time, aPlayerName);
 		}
 	}
 	else
-		str_format(aNewFilename, sizeof(aNewFilename), "demos/%s_%5.2f.demo", pDemo, m_Time);
+		str_format(aNewFilename, sizeof(aNewFilename), "demos/%s_%.2f.demo", pDemo, m_Time);
 
 	str_format(aOldFilename, sizeof(aOldFilename), "demos/%s_tmp_%d.demo", m_pMap, pid());
 

--- a/src/game/client/components/race_demo.cpp
+++ b/src/game/client/components/race_demo.cpp
@@ -137,14 +137,18 @@ void CRaceDemo::CheckDemo()
 	m_pClient->m_pMenus->DemolistPopulate();
 	for(int i = 0; i < m_pClient->m_pMenus->m_lDemos.size(); i++)
 	{
-		if(!str_comp_num(m_pClient->m_pMenus->m_lDemos[i].m_aName, m_pMap, str_length(m_pMap)) && str_comp_num(m_pClient->m_pMenus->m_lDemos[i].m_aName, aTmpDemoName, str_length(aTmpDemoName)) && str_length(m_pClient->m_pMenus->m_lDemos[i].m_aName) > str_length(m_pMap) && m_pClient->m_pMenus->m_lDemos[i].m_aName[str_length(m_pMap)] == '_')
-		{
-			const char *pDemo = m_pClient->m_pMenus->m_lDemos[i].m_aName;
+		const char *pDemo = m_pClient->m_pMenus->m_lDemos[i].m_aName;
+		if(str_comp(pDemo, aTmpDemoName) == 0)
+			continue;
 
+		int MapLen = str_length(m_pMap);
+		if(str_comp_num(pDemo, m_pMap, MapLen) == 0 && pDemo[MapLen] == '_')
+		{
 			// set cursor
-			pDemo += str_length(m_pMap)+1;
-			float DemoTime = str_tofloat(pDemo);
-			if(m_Time < DemoTime)
+			pDemo += MapLen + 1;
+			int Time = CRaceHelper::TimeFromSecondsStr(pDemo);
+			float DemoTime = Time / 1000.f;
+			if(Time && m_Time < DemoTime)
 			{
 				// save new record
 				SaveDemo(m_pMap);

--- a/src/game/client/components/race_demo.cpp
+++ b/src/game/client/components/race_demo.cpp
@@ -8,6 +8,7 @@
 #include <engine/storage.h>
 
 #include "menus.h"
+#include "race.h"
 #include "race_demo.h"
 
 CRaceDemo::CRaceDemo()
@@ -113,22 +114,12 @@ void CRaceDemo::OnMessage(int MsgType, void *pRawMsg)
 		if(pMsg->m_ClientID == -1 && m_RaceState == RACE_STARTED)
 		{
 			char aName[MAX_NAME_LENGTH];
-			const char *pFinished = str_find(pMsg->m_pMessage, " finished in: ");
-			int FinishedPos = pFinished - pMsg->m_pMessage;
-			if (!pFinished || FinishedPos == 0 || FinishedPos >= (int)sizeof(aName))
-				return;
-
-			// store the name
-			str_copy(aName, pMsg->m_pMessage, FinishedPos + 1);
-
-			// prepare values and state for saving
-			int Minutes;
-			float Seconds;
-			if(!str_comp(aName, m_pClient->m_aClients[m_pClient->m_Snap.m_LocalClientID].m_aName) && sscanf(pFinished, " finished in: %d minute(s) %f", &Minutes, &Seconds) == 2)
+			int Time = CRaceHelper::TimeFromFinishMessage(pMsg->m_pMessage, aName, sizeof(aName));
+			if(Time && str_comp(aName, m_pClient->m_aClients[m_pClient->m_Snap.m_LocalClientID].m_aName) == 0)
 			{
 				m_RaceState = RACE_FINISHED;
 				m_RecordStopTime = Client()->GameTick() + Client()->GameTickSpeed();
-				m_Time = Minutes*60 + Seconds;
+				m_Time = Time / 1000.f;
 			}
 		}
 	}

--- a/src/game/client/components/race_demo.cpp
+++ b/src/game/client/components/race_demo.cpp
@@ -117,7 +117,7 @@ void CRaceDemo::OnMessage(int MsgType, void *pRawMsg)
 			{
 				m_RaceState = RACE_FINISHED;
 				m_RecordStopTime = Client()->GameTick() + Client()->GameTickSpeed();
-				m_Time = Time / 1000.f;
+				m_Time = Time;
 			}
 		}
 	}
@@ -145,8 +145,7 @@ void CRaceDemo::CheckDemo()
 			// set cursor
 			pDemo += MapLen + 1;
 			int Time = CRaceHelper::TimeFromSecondsStr(pDemo);
-			float DemoTime = Time / 1000.f;
-			if(Time > 0 && m_Time < DemoTime)
+			if(Time > 0 && m_Time < Time)
 			{
 				// save new record
 				SaveDemo(m_pMap);
@@ -187,11 +186,11 @@ void CRaceDemo::SaveDemo(const char* pDemo)
 			if(aPlayerName[i] == '\\' || aPlayerName[i] == '/' || aPlayerName[i] == '|' || aPlayerName[i] == ':' || aPlayerName[i] == '*' || aPlayerName[i] == '?' || aPlayerName[i] == '<' || aPlayerName[i] == '>' || aPlayerName[i] == '"')
 				aPlayerName[i] = '%';
 
-			str_format(aNewFilename, sizeof(aNewFilename), "demos/%s_%.2f_%s.demo", pDemo, m_Time, aPlayerName);
+			str_format(aNewFilename, sizeof(aNewFilename), "demos/%s_%d.%03d_%s.demo", pDemo, m_Time / 1000, m_Time % 1000, aPlayerName);
 		}
 	}
 	else
-		str_format(aNewFilename, sizeof(aNewFilename), "demos/%s_%.2f.demo", pDemo, m_Time);
+		str_format(aNewFilename, sizeof(aNewFilename), "demos/%s_%d.%03d.demo", pDemo, m_Time / 1000, m_Time % 1000);
 
 	str_format(aOldFilename, sizeof(aOldFilename), "demos/%s_tmp_%d.demo", m_pMap, pid());
 

--- a/src/game/client/components/race_demo.h
+++ b/src/game/client/components/race_demo.h
@@ -11,7 +11,7 @@ class CRaceDemo : public CComponent
 {
 	int m_RecordStopTime;
 	int m_DemoStartTick;
-	float m_Time;
+	int m_Time;
 	const char *m_pMap;
 
 	void Stop();


### PR DESCRIPTION
On systems that use a language with comma as decimal-point character, the decimal places of the ghosts and race demos are dropped. The sscanf call stops when it reaches the dot used by the servers.

The time parsing functions are probably a bit more complicated then needed, but they are able to parse the chat messages of any ddnet, ddrace and race version I encountered.
Seconds are parsed up to the third decimal place.