### PR TITLE
removed crypto lib from bam.lua (macOS compile improvement)

### DIFF
--- a/bam.lua
+++ b/bam.lua
@@ -240,7 +240,7 @@ function build(settings)
 		if platform == "macosx" then
 			settings.link.frameworks:Add("Carbon")
 			settings.link.frameworks:Add("AppKit")
-			settings.link.libs:Add("crypto")
+			-- settings.link.libs:Add("crypto")
 		else
 			settings.link.libs:Add("pthread")
 		end


### PR DESCRIPTION
Im having some problems with compiling ddnet on some macOS machines. I figured out that the crypto library causes this problem. And it works fine without on all different macOS machines i tested it. I guess this lib isn't needed anyways so i suggest to remove it to make compiling a bit easier c: