### PR TITLE
Revert "Don't divide by 0"

### DIFF
--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -681,7 +681,7 @@ void CPlayers::RenderPlayer(
 					vec2 Dir = vec2(pPlayerChar->m_X,pPlayerChar->m_Y) - vec2(pPrevChar->m_X, pPrevChar->m_Y);
 					Dir = normalize(Dir);
 					float HadOkenAngle = GetAngle(Dir);
-					Graphics()->QuadsSetRotation(HadOkenAngle );
+					Graphics()->QuadsSetRotation(HadOkenAngle);
 					//float offsety = -data->weapons[iw].muzzleoffsety;
 					RenderTools()->SelectSprite(g_pData->m_Weapons.m_aId[iw].m_aSpriteMuzzles[IteX], 0);
 					vec2 DirY(-Dir.y,Dir.x);
@@ -798,7 +798,7 @@ void CPlayers::RenderPlayer(
 			if (OtherTeam)
 				Graphics()->SetColor(1.0f, 1.0f, 1.0f, g_Config.m_ClShowOthersAlpha / 100.0f);
 			IGraphics::CQuadItem QuadItem(Position.x-30, Position.y - 70, 22, 22);
-			Graphics()->QuadsSetRotation(GetAngle(vec2(1,0))+pi);
+			Graphics()->QuadsSetRotation(pi);
 			Graphics()->QuadsDraw(&QuadItem, 1);
 			Graphics()->QuadsEnd();
 		}
@@ -819,7 +819,7 @@ void CPlayers::RenderPlayer(
 			if (OtherTeam)
 				Graphics()->SetColor(1.0f, 1.0f, 1.0f, g_Config.m_ClShowOthersAlpha / 100.0f);
 			IGraphics::CQuadItem QuadItem(Position.x, Position.y - 70, 22, 22);
-			Graphics()->QuadsSetRotation(GetAngle(vec2(0,1))+pi);
+			Graphics()->QuadsSetRotation(3 / 2 * pi);
 			Graphics()->QuadsDraw(&QuadItem, 1);
 			Graphics()->QuadsEnd();
 		}

--- a/src/game/gamecore.h
+++ b/src/game/gamecore.h
@@ -67,7 +67,7 @@ inline vec2 GetDir(float Angle)
 
 inline float GetAngle(vec2 Dir)
 {
-	if(Dir.x == 0 || Dir.y == 0)
+	if(Dir.x == 0 && Dir.y == 0)
 		return 0.0f;
 	float a = atanf(Dir.y/Dir.x);
 	if(Dir.x < 0)


### PR DESCRIPTION
This reverts commit 03faa51e2898409d84260395fc59e7704f9a5f8d.

Dividing floats by zero isn't undefined behavior and results in +inf or
-inf depending on the sign of the first operand.

```
#include <math.h>
#include <stdio.h>

#define PRINT(x) printf("%s = %f", #x, x)

int main()
{
	PRINT(1.0 / 0.0);
	PRINT(-1.0 / 0.0);
	PRINT(atanf(1.0 / 0.0));
	PRINT(atanf(-1.0 / 0.0));
	return 0;
}
```
prints
```
1.0 / 0.0 = inf
-1.0 / 0.0 = -inf
atanf(1.0 / 0.0) = 1.570796
atanf(-1.0 / 0.0) = -1.570796
```

The changed function was problematic for values like (0,1), (-1,0),
(0,-1) where it always returned an angle of 0°.