### PR TITLE
Made int packing functions safe

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -1731,7 +1731,7 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket)
 
 					if(CompleteSize)
 					{
-						int IntSize = CVariableInt::Decompress(m_aSnapshotIncomingData, CompleteSize, aTmpBuffer2);
+						int IntSize = CVariableInt::Decompress(m_aSnapshotIncomingData, CompleteSize, aTmpBuffer2, sizeof(aTmpBuffer2));
 
 						if(IntSize < 0) // failure during decompression, bail
 							return;
@@ -1991,7 +1991,7 @@ void CClient::ProcessServerPacketDummy(CNetChunk *pPacket)
 
 					if(CompleteSize)
 					{
-						int IntSize = CVariableInt::Decompress(m_aSnapshotIncomingData, CompleteSize, aTmpBuffer2);
+						int IntSize = CVariableInt::Decompress(m_aSnapshotIncomingData, CompleteSize, aTmpBuffer2, sizeof(aTmpBuffer2));
 
 						if(IntSize < 0) // failure during decompression, bail
 							return;

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -709,10 +709,10 @@ void CServer::DoSnapshot()
 				const int MaxSize = MAX_SNAPSHOT_PACKSIZE;
 				int NumPackets;
 
-				SnapshotSize = CVariableInt::Compress(aDeltaData, DeltaSize, aCompData);
+				SnapshotSize = CVariableInt::Compress(aDeltaData, DeltaSize, aCompData, sizeof(aCompData));
 				NumPackets = (SnapshotSize+MaxSize-1)/MaxSize;
 
-				for(int n = 0, Left = SnapshotSize; Left; n++)
+				for(int n = 0, Left = SnapshotSize; Left > 0; n++)
 				{
 					int Chunk = Left < MaxSize ? Left : MaxSize;
 					Left -= Chunk;

--- a/src/engine/shared/compression.cpp
+++ b/src/engine/shared/compression.cpp
@@ -60,26 +60,32 @@ const unsigned char *CVariableInt::Unpack(const unsigned char *pSrc, int *pInOut
 }
 
 
-long CVariableInt::Decompress(const void *pSrc_, int Size, void *pDst_)
+long CVariableInt::Decompress(const void *pSrc_, int Size, void *pDst_, int DstSize)
 {
 	const unsigned char *pSrc = (unsigned char *)pSrc_;
 	const unsigned char *pEnd = pSrc + Size;
 	int *pDst = (int *)pDst_;
+	int *pDstEnd = pDst + DstSize / 4;
 	while(pSrc < pEnd)
 	{
+		if(pDst >= pDstEnd)
+			return -1;
 		pSrc = CVariableInt::Unpack(pSrc, pDst);
 		pDst++;
 	}
 	return (long)((unsigned char *)pDst-(unsigned char *)pDst_);
 }
 
-long CVariableInt::Compress(const void *pSrc_, int Size, void *pDst_)
+long CVariableInt::Compress(const void *pSrc_, int Size, void *pDst_, int DstSize)
 {
 	int *pSrc = (int *)pSrc_;
 	unsigned char *pDst = (unsigned char *)pDst_;
+	unsigned char *pDstEnd = pDst + DstSize;
 	Size /= 4;
 	while(Size)
 	{
+		if(pDstEnd - pDst < 6)
+			return -1;
 		pDst = CVariableInt::Pack(pDst, *pSrc);
 		Size--;
 		pSrc++;

--- a/src/engine/shared/compression.h
+++ b/src/engine/shared/compression.h
@@ -8,7 +8,7 @@ class CVariableInt
 public:
 	static unsigned char *Pack(unsigned char *pDst, int i);
 	static const unsigned char *Unpack(const unsigned char *pSrc, int *pInOut);
-	static long Compress(const void *pSrc, int Size, void *pDst);
-	static long Decompress(const void *pSrc, int Size, void *pDst);
+	static long Compress(const void *pSrc, int Size, void *pDst, int DstSize);
+	static long Decompress(const void *pSrc, int Size, void *pDst, int DstSize);
 };
 #endif

--- a/src/engine/shared/demo.cpp
+++ b/src/engine/shared/demo.cpp
@@ -228,8 +228,13 @@ void CDemoRecorder::Write(int Type, const void *pData, int Size)
 	mem_copy(aBuffer2, pData, Size);
 	while(Size&3)
 		aBuffer2[Size++] = 0;
-	Size = CVariableInt::Compress(aBuffer2, Size, aBuffer); // buffer2 -> buffer
+	Size = CVariableInt::Compress(aBuffer2, Size, aBuffer, sizeof(aBuffer)); // buffer2 -> buffer
+	if(Size < 0)
+		return;
+
 	Size = CNetBase::Compress(aBuffer, Size, aBuffer2, sizeof(aBuffer2)); // buffer -> buffer2
+	if(Size < 0)
+		return;
 
 
 	aChunk[0] = ((Type&0x3)<<5);
@@ -550,7 +555,7 @@ void CDemoPlayer::DoTick()
 				break;
 			}
 
-			DataSize = CVariableInt::Decompress(aDecompressed, DataSize, aData);
+			DataSize = CVariableInt::Decompress(aDecompressed, DataSize, aData, sizeof(aData));
 
 			if(DataSize < 0)
 			{

--- a/src/game/client/components/ghost.cpp
+++ b/src/game/client/components/ghost.cpp
@@ -359,8 +359,13 @@ void CGhost::Save()
 		mem_copy(aBuffer2, Data, Size);
 		Data += Items;
 
-		Size = CVariableInt::Compress(aBuffer2, Size, aBuffer);
+		Size = CVariableInt::Compress(aBuffer2, Size, aBuffer, sizeof(aBuffer));
+		if(Size < 0)
+			return;
+
 		Size = CNetBase::Compress(aBuffer, Size, aBuffer2, sizeof(aBuffer2));
+		if(Size < 0)
+			return;
 
 		aSize[0] = (Size>>24)&0xff;
 		aSize[1] = (Size>>16)&0xff;
@@ -490,7 +495,7 @@ void CGhost::Load(const char* pFilename, int ID)
 			break;
 		}
 
-		Size = CVariableInt::Decompress(aDecompressed, Size, aData);
+		Size = CVariableInt::Decompress(aDecompressed, Size, aData, sizeof(aData));
 		if(Size < 0)
 		{
 			Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "ghost", "error during intpack decompression");


### PR DESCRIPTION
The missing bounds check in the int packing functions makes it possible, to at least crash the client with prepared snapshots. Malicious demo files could also be a problem.