### PR TITLE
Get rid of unnecessary queue in CFetcher

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -1517,8 +1517,8 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket)
 
 						str_append(aUrl, aEscaped, sizeof(aUrl));
 
-						m_pMapdownloadTask = new CFetchTask(true, UseDDNetCA);
-						Fetcher()->QueueAdd(m_pMapdownloadTask, aUrl, m_aMapdownloadFilename, IStorage::TYPE_SAVE);
+						m_pMapdownloadTask = new CFetchTask;
+						Fetcher()->FetchFile(m_pMapdownloadTask, aUrl, m_aMapdownloadFilename, IStorage::TYPE_SAVE, UseDDNetCA, true);
 					}
 					else
 						SendMapRequest();
@@ -3643,8 +3643,8 @@ void CClient::RequestDDNetInfo()
 		str_append(aUrl, aEscaped, sizeof(aUrl));
 	}
 
-	m_pDDNetInfoTask = new CFetchTask(true, /*UseDDNetCA*/ true);
-	Fetcher()->QueueAdd(m_pDDNetInfoTask, aUrl, "ddnet-info.json.tmp", IStorage::TYPE_SAVE);
+	m_pDDNetInfoTask = new CFetchTask;
+	Fetcher()->FetchFile(m_pDDNetInfoTask, aUrl, "ddnet-info.json.tmp", IStorage::TYPE_SAVE, true, true);
 }
 
 int CClient::GetPredictionTime()

--- a/src/engine/client/fetcher.h
+++ b/src/engine/client/fetcher.h
@@ -1,33 +1,21 @@
 #ifndef ENGINE_CLIENT_FETCHER_H
 #define ENGINE_CLIENT_FETCHER_H
 
-#define WIN32_LEAN_AND_MEAN
-#include "curl/curl.h"
-#include "curl/easy.h"
 #include <engine/fetcher.h>
 
 class CFetcher : public IFetcher
 {
 private:
-	CURL *m_pHandle;
-
-	void *m_pThHandle;
-
-	bool m_Running;
-	LOCK m_Lock;
-	SEMAPHORE m_Queued;
-	CFetchTask *m_pFirst;
-	CFetchTask *m_pLast;
+	class IEngine *m_pEngine;
 	class IStorage *m_pStorage;
-public:
-	CFetcher();
-	virtual bool Init();
-	~CFetcher();
 
-	virtual void QueueAdd(CFetchTask *pTask, const char *pUrl, const char *pDest, int StorageType = -2, void *pUser = 0, COMPFUNC pfnCompCb = 0, PROGFUNC pfnProgCb = 0);
+public:
+	virtual bool Init();
+
+	virtual void FetchFile(CFetchTask *pTask, const char *pUrl, const char *pDest, int StorageType = -2, bool UseDDNetCA = false, bool CanTimeout = true, void *pUser = 0, COMPFUNC pfnCompCb = 0, PROGFUNC pfnProgCb = 0);
 	virtual void Escape(char *pBud, size_t size, const char *pStr);
-	static void FetcherThread(void *pUser);
-	void FetchFile(CFetchTask *pTask);
+
+	static int FetcherThread(void *pUser);
 	static size_t WriteToFile(char *pData, size_t size, size_t nmemb, void *pFile);
 	static int ProgressCallback(void *pUser, double DlTotal, double DlCurr, double UlTotal, double UlCurr);
 };

--- a/src/engine/client/updater.cpp
+++ b/src/engine/client/updater.cpp
@@ -71,8 +71,8 @@ void CUpdater::FetchFile(const char *pFile, const char *pDestPath)
 	if(!pDestPath)
 		pDestPath = pFile;
 	str_format(aPath, sizeof(aPath), "update/%s", pDestPath);
-	CFetchTask *Task = new CFetchTask(false, true);
-	m_pFetcher->QueueAdd(Task, aBuf, aPath, -2, this, &CUpdater::CompletionCallback, &CUpdater::ProgressCallback);
+	CFetchTask *Task = new CFetchTask;
+	m_pFetcher->FetchFile(Task, aBuf, aPath, -2, true, false, this, &CUpdater::CompletionCallback, &CUpdater::ProgressCallback);
 }
 
 void CUpdater::MoveFile(const char *pFile)

--- a/src/engine/fetcher.h
+++ b/src/engine/fetcher.h
@@ -1,8 +1,12 @@
 #ifndef ENGINE_FETCHER_H
 #define ENGINE_FETCHER_H
 
+#include <engine/shared/jobs.h>
 #include "kernel.h"
 #include "stddef.h"
+
+#define WIN32_LEAN_AND_MEAN
+#include "curl/curl.h"
 
 class CFetchTask;
 
@@ -12,26 +16,28 @@ typedef void (*COMPFUNC)(CFetchTask *pDest, void *pUser);
 class CFetchTask
 {
 	friend class CFetcher;
+	class CFetcher *m_pFetcher;
 
-	CFetchTask *m_pNext;
+	CJob m_Job;
+	CURL *m_pHandle;
+	void *m_pUser;
 
 	char m_aUrl[256];
 	char m_aDest[128];
-	PROGFUNC m_pfnProgressCallback;
-	COMPFUNC m_pfnCompCallback;
-	void *m_pUser;
-
-	double m_Current;
-	double m_Size;
-	int m_Progress;
-	int m_State;
-	bool m_Abort;
-	bool m_CanTimeout;
 	int m_StorageType;
 	bool m_UseDDNetCA;
-public:
-	CFetchTask(bool canTimeout, bool useDDNetCA);
+	bool m_CanTimeout;
 
+	PROGFUNC m_pfnProgressCallback;
+	COMPFUNC m_pfnCompCallback;
+
+	double m_Size;
+	double m_Current;
+	int m_Progress;
+	int m_State;
+
+	bool m_Abort;
+public:
 	enum
 	{
 		STATE_ERROR = -1,
@@ -55,7 +61,7 @@ class IFetcher : public IInterface
 	MACRO_INTERFACE("fetcher", 0)
 public:
 	virtual bool Init() = 0;
-	virtual void QueueAdd(CFetchTask *pTask, const char *pUrl, const char *pDest, int StorageType = -2, void *pUser = 0, COMPFUNC pfnCompCb = 0, PROGFUNC pfnProgCb = 0) = 0;
+	virtual void FetchFile(CFetchTask *pTask, const char *pUrl, const char *pDest, int StorageType = -2, bool UseDDNetCA = false, bool CanTimeout = true, void *pUser = 0, COMPFUNC pfnCompCb = 0, PROGFUNC pfnProgCb = 0) = 0;
 	virtual void Escape(char *pBud, size_t size, const char *pStr) = 0;
 };
 


### PR DESCRIPTION
Use a `CJob` instead. Also kept fetcher as a separate interface but it might also fit in `IEngine` along with `HostLookup`

Appears to be working on Linux x86_64. Please test it on another platform before merging.