### PR TITLE
Jekyll clip

### DIFF
--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -19,6 +19,9 @@ MACRO_CONFIG_INT(ClRefreshRate, cl_refresh_rate, 480, 0, 10000, CFGFLAG_SAVE|CFG
 MACRO_CONFIG_INT(ClRefreshRateInactive, cl_refresh_rate_inactive, 120, 0, 10000, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Refresh rate for updating the game when the window is inactive (in Hz)")
 MACRO_CONFIG_INT(ClEditor, cl_editor, 0, 0, 1, CFGFLAG_CLIENT, "")
 MACRO_CONFIG_INT(ClEditorUndo, cl_editorundo, 0, 0, 1, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Undo function in editor")
+MACRO_CONFIG_INT(ClEditorClipDraw, cl_editorclipdraw, 3, 0, 3, CFGFLAG_SAVE | CFGFLAG_CLIENT, "How man clip areas to draw (0=None, 1=Selected only, 2=Visible in list, 3=All")
+MACRO_CONFIG_INT(ClEditorClipTrigger, cl_editorcliptrigger, 0, 0, 1, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Clip/trigger function in editor")
+
 MACRO_CONFIG_INT(ClLoadCountryFlags, cl_load_country_flags, 1, 0, 1, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Load and show country flags")
 MACRO_CONFIG_STR(ClSkinFilterString, cl_skin_filter_string, 25, "", CFGFLAG_SAVE|CFGFLAG_CLIENT, "Skin filtering string")
 

--- a/src/game/client/components/maplayers.cpp
+++ b/src/game/client/components/maplayers.cpp
@@ -428,56 +428,55 @@ void CMapLayers::ChangeClipping(int trigger, int x, int y, int w, int h, int dis
 				pGroup->m_ClipW = w;
 				pGroup->m_ClipH = h;
 				pGroup->m_UseClipping = true;
+			}
 
-				if (!rewind) continue;
-				for (int l = 0; l < pGroup->m_NumLayers; l++)
+			if (!rewind) continue;
+			for (int l = 0; l < pGroup->m_NumLayers; l++)
+			{
+				CMapItemLayer *pLayer = m_pLayers->GetLayer(pGroup->m_StartLayer + l);
+
+				//// skip adjustment if detail layers if not wanted
+
+				//if (pLayer->m_Flags&LAYERFLAG_DETAIL && !g_Config.m_GfxHighDetail)
+				//	continue;
+				if (pLayer->m_Type == LAYERTYPE_TILES)
 				{
-					CMapItemLayer *pLayer = m_pLayers->GetLayer(pGroup->m_StartLayer + l);
+					CMapItemLayerTilemap *pTMap = (CMapItemLayerTilemap *)pLayer;
+					pTMap->m_ColorEnvOffset = Client()->LocalTime() * -1000;
+				}
+				else if (pLayer->m_Type == LAYERTYPE_QUADS)
+				{
+					CMapItemLayerQuads *pQLayer = (CMapItemLayerQuads *)pLayer;
+					CQuad *pQuads = (CQuad *)m_pLayers->Map()->GetDataSwapped(pQLayer->m_Data);
 
-					//// skip adjustment if detail layers if not wanted
-
-					//if (pLayer->m_Flags&LAYERFLAG_DETAIL && !g_Config.m_GfxHighDetail)
-					//	continue;
-					if (pLayer->m_Type == LAYERTYPE_TILES)
+					for (int q = 0; q < pQLayer->m_NumQuads; q++)
 					{
-						CMapItemLayerTilemap *pTMap = (CMapItemLayerTilemap *)pLayer;
-						pTMap->m_ColorEnvOffset = Client()->LocalTime() * -1000;
+						CQuad *quad = &pQuads[q];
+						quad->m_ColorEnvOffset = Client()->LocalTime()*-1000;
+						quad->m_PosEnvOffset = Client()->LocalTime() * -1000;
 					}
-					else if (pLayer->m_Type == LAYERTYPE_QUADS)
+				}
+				else if (pLayer->m_Type == LAYERTYPE_SOUNDS)
+				{
+					//I have never used sounds so i have no idea if this is right
+					CMapItemLayerSounds *pSoundLayer = (CMapItemLayerSounds *)pLayer;
+					if (pSoundLayer->m_Version < 1 || pSoundLayer->m_Version > CMapItemLayerSounds::CURRENT_VERSION)
+						continue;
+					if (pSoundLayer->m_Sound == -1)
+						continue;
+
+					CSoundSource *pSources = (CSoundSource *)Layers()->Map()->GetDataSwapped(pSoundLayer->m_Data);
+					if (!pSources)
+						continue;
+
+					for (int s = 0; s < pSoundLayer->m_NumSources; s++)
 					{
-						CMapItemLayerQuads *pQLayer = (CMapItemLayerQuads *)pLayer;
-						CQuad *pQuads = (CQuad *)m_pLayers->Map()->GetDataSwapped(pQLayer->m_Data);
-
-						for (int q = 0; q < pQLayer->m_NumQuads; q++)
-						{
-							CQuad *quad = &pQuads[q];
-							quad->m_ColorEnvOffset = Client()->LocalTime()*-1000;
-							quad->m_PosEnvOffset = Client()->LocalTime() * -1000;
-						}
-					}
-					else if (pLayer->m_Type == LAYERTYPE_SOUNDS)
-					{
-						//I have never used sounds so i have no idea if this is right
-						CMapItemLayerSounds *pSoundLayer = (CMapItemLayerSounds *)pLayer;
-						if (pSoundLayer->m_Version < 1 || pSoundLayer->m_Version > CMapItemLayerSounds::CURRENT_VERSION)
-							continue;
-						if (pSoundLayer->m_Sound == -1)
-							continue;
-
-						CSoundSource *pSources = (CSoundSource *)Layers()->Map()->GetDataSwapped(pSoundLayer->m_Data);
-						if (!pSources)
-							continue;
-
-						for (int s = 0; s < pSoundLayer->m_NumSources; s++)
-						{
-							CSoundSource *snd = &pSources[s];
-							snd->m_PosEnvOffset = Client()->LocalTime() * -1000;
-							snd->m_SoundEnvOffset = Client()->LocalTime() * -1000;
-						}
+						CSoundSource *snd = &pSources[s];
+						snd->m_PosEnvOffset = Client()->LocalTime() * -1000;
+						snd->m_SoundEnvOffset = Client()->LocalTime() * -1000;
 					}
 				}
 			}
 		}
-
 	}
 }

--- a/src/game/client/components/maplayers.cpp
+++ b/src/game/client/components/maplayers.cpp
@@ -433,7 +433,6 @@ void CMapLayers::ChangeClipping(int trigger, int x, int y, int w, int h, int dis
 			}
 			else 
 			{
-
 				pGroup->m_ClipX = x;
 				pGroup->m_ClipY = y;
 				pGroup->m_ClipW = w;
@@ -447,7 +446,6 @@ void CMapLayers::ChangeClipping(int trigger, int x, int y, int w, int h, int dis
 				CMapItemLayer *pLayer = m_pLayers->GetLayer(pGroup->m_StartLayer + l);
 
 				//// skip adjustment if detail layers if not wanted
-
 				//if (pLayer->m_Flags&LAYERFLAG_DETAIL && !g_Config.m_GfxHighDetail)
 				//	continue;
 				if (pLayer->m_Type == LAYERTYPE_TILES)

--- a/src/game/client/components/maplayers.cpp
+++ b/src/game/client/components/maplayers.cpp
@@ -77,8 +77,8 @@ void CMapLayers::EnvelopeEval(float TimeOffset, int Env, float *pChannels, void 
 
 	CMapItemEnvelope *pItem = (CMapItemEnvelope *)pThis->m_pLayers->Map()->GetItem(Start+Env, 0, 0);
 
-	static float s_Time = 0.0f;
-	static float s_LastLocalTime = pThis->Client()->LocalTime();
+	float envTime = pThis->Client()->LocalTime();
+
 	if(pThis->Client()->State() == IClient::STATE_DEMOPLAYBACK)
 	{
 		const IDemoPlayer::CInfo *pInfo = pThis->DemoPlayer()->BaseInfo();
@@ -91,12 +91,12 @@ void CMapLayers::EnvelopeEval(float TimeOffset, int Env, float *pChannels, void 
 				pThis->m_CurrentLocalTick = pInfo->m_CurrentTick;
 			}
 
-			s_Time = mix(pThis->m_LastLocalTick / (float)pThis->Client()->GameTickSpeed(),
+			envTime = mix(pThis->m_LastLocalTick / (float)pThis->Client()->GameTickSpeed(),
 						pThis->m_CurrentLocalTick / (float)pThis->Client()->GameTickSpeed(),
 						pThis->Client()->IntraGameTick());
 		}
 
-		pThis->RenderTools()->RenderEvalEnvelope(pPoints+pItem->m_StartPoint, pItem->m_NumPoints, 4, s_Time+TimeOffset, pChannels);
+		pThis->RenderTools()->RenderEvalEnvelope(pPoints+pItem->m_StartPoint, pItem->m_NumPoints, 4, envTime+TimeOffset, pChannels);
 	}
 	else
 	{
@@ -104,15 +104,13 @@ void CMapLayers::EnvelopeEval(float TimeOffset, int Env, float *pChannels, void 
 		{
 			if(pItem->m_Version < 2 || pItem->m_Synchronized)
 			{
-				s_Time = mix((pThis->Client()->PrevGameTick()-pThis->m_pClient->m_Snap.m_pGameInfoObj->m_RoundStartTick) / (float)pThis->Client()->GameTickSpeed(),
+				envTime = mix((pThis->Client()->PrevGameTick()-pThis->m_pClient->m_Snap.m_pGameInfoObj->m_RoundStartTick) / (float)pThis->Client()->GameTickSpeed(),
 							(pThis->Client()->GameTick()-pThis->m_pClient->m_Snap.m_pGameInfoObj->m_RoundStartTick) / (float)pThis->Client()->GameTickSpeed(),
 							pThis->Client()->IntraGameTick());
 			}
-			else
-				s_Time += pThis->Client()->LocalTime()-s_LastLocalTime;
+
 		}
-		pThis->RenderTools()->RenderEvalEnvelope(pPoints+pItem->m_StartPoint, pItem->m_NumPoints, 4, s_Time+TimeOffset, pChannels);
-		s_LastLocalTime = pThis->Client()->LocalTime();
+		pThis->RenderTools()->RenderEvalEnvelope(pPoints+pItem->m_StartPoint, pItem->m_NumPoints, 4, envTime+TimeOffset, pChannels);
 	}
 }
 

--- a/src/game/client/components/maplayers.cpp
+++ b/src/game/client/components/maplayers.cpp
@@ -400,3 +400,86 @@ void CMapLayers::OnRender()
 	// reset the screen like it was before
 	Graphics()->MapScreen(Screen.x, Screen.y, Screen.w, Screen.h);
 }
+
+//Modify group clipping on zone change
+void CMapLayers::ChangeClipping(int trigger, int x, int y, int w, int h, int disable, int rewind) {
+	for (int g = 0; g < m_pLayers->NumGroups(); g++)
+	{
+		CMapItemGroup *pGroup = m_pLayers->GetGroup(g);
+
+		if (!pGroup)
+		{
+			dbg_msg("maplayers", "error group was null, group number = %d, total groups = %d", g, m_pLayers->NumGroups());
+			dbg_msg("maplayers", "this is here to prevent a crash but the source of this is unknown, please report this for it to get fixed");
+			dbg_msg("maplayers", "we need mapname and crc and the map that caused this if possible, and anymore info you think is relevant");
+			continue;
+		}
+		//If map loaded from old format it probably has bad value here
+		if (pGroup->m_ClipTrigger > 255) continue;
+
+		if (!g_Config.m_GfxNoclip && pGroup->m_Version >= 2 && (pGroup->m_ClipTrigger == trigger || (pGroup->m_ClipTrigger > 0 && trigger == -1)))
+		{
+
+			if (disable) {
+				pGroup->m_UseClipping = false;
+			}
+			else {
+
+				pGroup->m_ClipX = x;
+				pGroup->m_ClipY = y;
+				pGroup->m_ClipW = w;
+				pGroup->m_ClipH = h;
+				pGroup->m_UseClipping = true;
+
+				if (!rewind) continue;
+				for (int l = 0; l < pGroup->m_NumLayers; l++)
+				{
+					CMapItemLayer *pLayer = m_pLayers->GetLayer(pGroup->m_StartLayer + l);
+
+					//// skip adjustment if detail layers if not wanted
+
+					//if (pLayer->m_Flags&LAYERFLAG_DETAIL && !g_Config.m_GfxHighDetail)
+					//	continue;
+					if (pLayer->m_Type == LAYERTYPE_TILES)
+					{
+						CMapItemLayerTilemap *pTMap = (CMapItemLayerTilemap *)pLayer;
+						pTMap->m_ColorEnvOffset = Client()->LocalTime() * -1000;
+					}
+					else if (pLayer->m_Type == LAYERTYPE_QUADS)
+					{
+						CMapItemLayerQuads *pQLayer = (CMapItemLayerQuads *)pLayer;
+						CQuad *pQuads = (CQuad *)m_pLayers->Map()->GetDataSwapped(pQLayer->m_Data);
+
+						for (int q = 0; q < pQLayer->m_NumQuads; q++)
+						{
+							CQuad *quad = &pQuads[q];
+							quad->m_ColorEnvOffset = Client()->LocalTime()*-1000;
+							quad->m_PosEnvOffset = Client()->LocalTime() * -1000;
+						}
+					}
+					else if (pLayer->m_Type == LAYERTYPE_SOUNDS)
+					{
+						//I have never used sounds so i have no idea if this is right
+						CMapItemLayerSounds *pSoundLayer = (CMapItemLayerSounds *)pLayer;
+						if (pSoundLayer->m_Version < 1 || pSoundLayer->m_Version > CMapItemLayerSounds::CURRENT_VERSION)
+							continue;
+						if (pSoundLayer->m_Sound == -1)
+							continue;
+
+						CSoundSource *pSources = (CSoundSource *)Layers()->Map()->GetDataSwapped(pSoundLayer->m_Data);
+						if (!pSources)
+							continue;
+
+						for (int s = 0; s < pSoundLayer->m_NumSources; s++)
+						{
+							CSoundSource *snd = &pSources[s];
+							snd->m_PosEnvOffset = Client()->LocalTime() * -1000;
+							snd->m_SoundEnvOffset = Client()->LocalTime() * -1000;
+						}
+					}
+				}
+			}
+		}
+
+	}
+}

--- a/src/game/client/components/maplayers.cpp
+++ b/src/game/client/components/maplayers.cpp
@@ -399,8 +399,14 @@ void CMapLayers::OnRender()
 	Graphics()->MapScreen(Screen.x, Screen.y, Screen.w, Screen.h);
 }
 
-//Modify group clipping on zone change
-void CMapLayers::ChangeClipping(int trigger, int x, int y, int w, int h, int disable, int rewind) {
+//Modify group clipping on tune zone change
+void CMapLayers::ChangeClipping(int trigger, int x, int y, int w, int h, int disable, int rewind) 
+{
+	//Skip if theres no trigger data
+	int Start, Num;
+	m_pLayers->Map()->GetType(MAPITEMTYPE_TRIGGERS, &Start, &Num);
+	if (Num == 0) return;
+
 	for (int g = 0; g < m_pLayers->NumGroups(); g++)
 	{
 		CMapItemGroup *pGroup = m_pLayers->GetGroup(g);
@@ -414,21 +420,19 @@ void CMapLayers::ChangeClipping(int trigger, int x, int y, int w, int h, int dis
 		}
 
 		//get group trigger number
-		int tStart, tNum, groupTrigger = -2;
+		int groupTrigger = -3;
+		CMapItemTriggers *pTrigger = (CMapItemTriggers *)m_pLayers->Map()->GetItem(Start + g, 0, 0);
+		groupTrigger = pTrigger->m_Trigger;
 
-		m_pLayers->Map()->GetType(MAPITEMTYPE_TRIGGERS, &tStart, &tNum);
-		if (tNum > 0) {
-			CMapItemTriggers *pTrigger = (CMapItemTriggers *)m_pLayers->Map()->GetItem(tStart + g, 0, 0);
-			groupTrigger = pTrigger->m_Trigger;
-		}
-
-		if (!g_Config.m_GfxNoclip && pGroup->m_Version >= 2 && (groupTrigger == trigger || (groupTrigger > 0 && trigger == -1)))
+		if (!g_Config.m_GfxNoclip && pGroup->m_Version >= 2 && (groupTrigger == trigger || (groupTrigger >= 0 && trigger == -2)))
 		{
 
-			if (disable) {
+			if (disable)
+			{
 				pGroup->m_UseClipping = false;
 			}
-			else {
+			else 
+			{
 
 				pGroup->m_ClipX = x;
 				pGroup->m_ClipY = y;

--- a/src/game/client/components/maplayers.cpp
+++ b/src/game/client/components/maplayers.cpp
@@ -412,10 +412,17 @@ void CMapLayers::ChangeClipping(int trigger, int x, int y, int w, int h, int dis
 			dbg_msg("maplayers", "we need mapname and crc and the map that caused this if possible, and anymore info you think is relevant");
 			continue;
 		}
-		//If map loaded from old format it probably has bad value here
-		if (pGroup->m_ClipTrigger > 255) continue;
 
-		if (!g_Config.m_GfxNoclip && pGroup->m_Version >= 2 && (pGroup->m_ClipTrigger == trigger || (pGroup->m_ClipTrigger > 0 && trigger == -1)))
+		//get group trigger number
+		int tStart, tNum, groupTrigger = -2;
+
+		m_pLayers->Map()->GetType(MAPITEMTYPE_TRIGGERS, &tStart, &tNum);
+		if (tNum > 0) {
+			CMapItemTriggers *pTrigger = (CMapItemTriggers *)m_pLayers->Map()->GetItem(tStart + g, 0, 0);
+			groupTrigger = pTrigger->m_Trigger;
+		}
+
+		if (!g_Config.m_GfxNoclip && pGroup->m_Version >= 2 && (groupTrigger == trigger || (groupTrigger > 0 && trigger == -1)))
 		{
 
 			if (disable) {

--- a/src/game/client/components/maplayers.h
+++ b/src/game/client/components/maplayers.h
@@ -29,6 +29,8 @@ public:
 	void EnvelopeUpdate();
 
 	static void EnvelopeEval(float TimeOffset, int Env, float *pChannels, void *pUser);
+	void ChangeClipping(int trigger, int x, int y , int w, int h, int disable, int rewind);
+
 };
 
 #endif

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -571,6 +571,26 @@ void CGameClient::UpdatePositions()
 			m_Snap.m_SpecInfo.m_UsePosition = true;
 		}
 	}
+	
+	//With updated positions, check if we're in a new tune zone, to alter clip areas
+	int zone = Collision()->GetTune(m_LocalCharacterPos);
+	if (m_lastTuneZone != zone) {
+		m_lastTuneZone = zone;
+
+		int Start, Num;
+		IMap *pMap = Kernel()->RequestInterface<IMap>();
+		pMap->GetType(MAPITEMTYPE_CLIPS, &Start, &Num);
+
+		for (int i = 0; i < Num; i++) {
+			CMapItemClips *pItem = (CMapItemClips *)pMap->GetItem(Start + i, 0, 0);
+
+			if (pItem->zone == zone) {
+				//m_pMapLayersBackGround->ChangeClipping(pItem->trigger, pItem->x, pItem->y, pItem->w, pItem->h);
+				m_pMapLayersForeGround->ChangeClipping(pItem->trigger, pItem->x, pItem->y, pItem->w, pItem->h, pItem->disable, pItem->rewind);
+			}
+		}
+	}
+
 }
 
 

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -584,9 +584,9 @@ void CGameClient::UpdatePositions()
 		for (int i = 0; i < Num; i++) {
 			CMapItemClips *pItem = (CMapItemClips *)pMap->GetItem(Start + i, 0, 0);
 
-			if (pItem->zone == zone) {
+			if (pItem->m_Zone == zone) {
 				//m_pMapLayersBackGround->ChangeClipping(pItem->trigger, pItem->x, pItem->y, pItem->w, pItem->h);
-				m_pMapLayersForeGround->ChangeClipping(pItem->trigger, pItem->x, pItem->y, pItem->w, pItem->h, pItem->disable, pItem->rewind);
+				m_pMapLayersForeGround->ChangeClipping(pItem->m_Trigger, pItem->m_X, pItem->m_Y, pItem->m_W, pItem->m_H, pItem->m_Disable, pItem->m_Rewind);
 			}
 		}
 	}

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -115,6 +115,8 @@ class CGameClient : public IGameClient
 	int m_LastFlagCarrierBlue;
 
 	int m_CheckInfo[2];
+	
+	int m_lastTuneZone=0;
 
 	static void ConTeam(IConsole::IResult *pResult, void *pUserData);
 	static void ConKill(IConsole::IResult *pResult, void *pUserData);

--- a/src/game/collision.cpp
+++ b/src/game/collision.cpp
@@ -579,6 +579,20 @@ int CCollision::IsTune(int Index)
 	return 0;
 }
 
+int CCollision::GetTune(vec2 Pos)
+{
+	if (!m_pTune) return 0;
+
+	int Nx = clamp((int)Pos.x / 32, 0, m_Width - 1);
+	int Ny = clamp((int)Pos.y / 32, 0, m_Height - 1);
+	int Index = Ny*m_Width + Nx;
+
+	if (m_pTune[Index].m_Type)
+		return m_pTune[Index].m_Number;
+
+	return 0;
+}
+
 void CCollision::GetSpeedup(int Index, vec2 *Dir, int *Force, int *MaxSpeed)
 {
 	if(Index < 0 || !m_pSpeedup)

--- a/src/game/collision.h
+++ b/src/game/collision.h
@@ -71,6 +71,7 @@ public:
 	int IsTCheckpoint(int Index);
 	int IsSpeedup(int Index);
 	int IsTune(int Index);
+	int GetTune(vec2 Pos);
 	void GetSpeedup(int Index, vec2 *Dir, int *Force, int *MaxSpeed);
 	int IsSwitch(int Index);
 	int GetSwitchNumber(int Index);

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -27,7 +27,6 @@
 
 #include "auto_map.h"
 #include "editor.h"
-#include <string.h>
 
 const char* vanillaImages[] = {"bg_cloud1", "bg_cloud2", "bg_cloud3",
 	"desert_doodads", "desert_main", "desert_mountains", "desert_mountains2",
@@ -5229,7 +5228,7 @@ void CEditor::RenderClipTriggerEditor(CUIRect View, CUIRect EditorRect)
 			Button.VSplitLeft(5.0f, 0, &Button);
 
 			char aBuf[128];
-			bool unnamed = strcmp(m_Map.m_lClipTriggers[i].m_aName, "") == 0;
+			bool unnamed = str_comp(m_Map.m_lClipTriggers[i].m_aName, "") == 0;
 
 			if (m_Map.m_lClipTriggers[i].m_Disable)
 				str_format(aBuf, sizeof(aBuf), "{ Zone: %d   Trigger: %d   Disables Clipping Area   Rewind? %s }   \"%s\"", m_Map.m_lClipTriggers[i].m_Zone, m_Map.m_lClipTriggers[i].m_Trigger, m_Map.m_lClipTriggers[i].m_Rewind ? "Yes" : "No", unnamed ? "Unnamed Clip" : m_Map.m_lClipTriggers[i].m_aName);

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -1580,7 +1580,7 @@ void CEditor::DoQuad(CQuad *q, int Index)
 				m_Map.m_UndoModified++;
 
 				static int s_QuadPopupID = 0;
-				UiInvokePopupMenu(&s_QuadPopupID, 0, UI()->MouseX(), UI()->MouseY(), 120, 180, PopupQuad);
+				UiInvokePopupMenu(&s_QuadPopupID, 0, UI()->MouseX(), UI()->MouseY(), 120, 198, PopupQuad);
 				m_LockMouse = false;
 				s_Operation = OP_NONE;
 				UI()->SetActiveItem(0);
@@ -5236,10 +5236,33 @@ void CEditor::RenderClipTriggerEditor(CUIRect View, CUIRect EditorRect)
 	if (UI()->MouseInside(&FullPanel) && Input()->KeyIsPressed(KEY_MOUSE_1)) {
 		s_ClipTriggerSelectedIndex = -1;
 		if (!m_aClipTrigger.disable) {
-			m_EditorOffsetX = m_aClipTrigger.x + m_aClipTrigger.w / 2;
-			m_EditorOffsetY = m_aClipTrigger.y + m_aClipTrigger.h / 2;
+			m_WorldOffsetX = m_aClipTrigger.x + m_aClipTrigger.w / 2;
+			m_WorldOffsetY = m_aClipTrigger.y + m_aClipTrigger.h / 2;
 		}
 	}
+	
+	//Copy selected groups clip into editor panel
+	if (UI()->MouseInside(&FullPanel) && Input()->KeyPress(KEY_C)) {
+		m_aClipTrigger.x = GetSelectedGroup()->m_ClipX;
+		m_aClipTrigger.y = GetSelectedGroup()->m_ClipY;
+		m_aClipTrigger.w = GetSelectedGroup()->m_ClipW;
+		m_aClipTrigger.h = GetSelectedGroup()->m_ClipH;
+		m_aClipTrigger.trigger = GetSelectedGroup()->m_ClipTrigger;
+		m_WorldOffsetX = m_aClipTrigger.x + m_aClipTrigger.w / 2;
+		m_WorldOffsetY = m_aClipTrigger.y + m_aClipTrigger.h / 2;
+		exists = false;
+		for (int i = 0; i < m_Map.m_lClipTriggers.size(); i++) {
+			if (m_aClipTrigger == m_Map.m_lClipTriggers[i]) {
+				exists = true;
+				s_ClipTriggerSelectedIndex = i;
+				s_ScrollValue = (float)i / m_Map.m_lClipTriggers.size();
+				break;
+			}
+		}
+	}
+
+	
+
 	if (changeView) {
 		if (!m_Map.m_lClipTriggers[s_ClipTriggerSelectedIndex].disable) {
 			m_EditorOffsetX = m_Map.m_lClipTriggers[s_ClipTriggerSelectedIndex].x + m_Map.m_lClipTriggers[s_ClipTriggerSelectedIndex].w / 2;

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -2988,7 +2988,7 @@ void CEditor::RenderLayers(CUIRect ToolBox, CUIRect ToolBar, CUIRect View)
 
 					static int s_GroupPopupId = 0;
 					if(Result == 2)
-						UiInvokePopupMenu(&s_GroupPopupId, 0, UI()->MouseX(), UI()->MouseY(), 145, 230, PopupGroup);
+						UiInvokePopupMenu(&s_GroupPopupId, 0, UI()->MouseX(), UI()->MouseY(), 145, 245, PopupGroup);
 
 					if(m_Map.m_lGroups[g]->m_lLayers.size() && Input()->MouseDoubleClick())
 						m_Map.m_lGroups[g]->m_Collapse ^= 1;
@@ -4196,7 +4196,6 @@ void CEditor::RenderStatusbar(CUIRect View)
 		View.VSplitRight(60.0f, &View, &Button);
 		static int s_ClipTriggerButton = 0;
 		if (DoButton_Editor(&s_ClipTriggerButton, "Clip List", m_ShowClipTrigger, &Button, 0, "Toggles the clip/trigger list.")) {
-			if (abs(m_aClipTrigger.zone) > 255) m_aClipTrigger.Reset();
 			m_ShowEnvelopeEditor = 0;
 			m_ShowServerSettingsEditor = false;
 			m_ShowClipTrigger ^= 1;
@@ -4972,7 +4971,7 @@ void CEditor::RenderClipTriggerEditor(CUIRect View, CUIRect EditorRect)
 	Slider.VSplitRight(20, &Slider, &Inc);
 	Slider.VSplitLeft(20, &Dec, &Slider);
 	UI()->DoLabel(&Label, "Tune Zone", 13, -1, -1);
-	int newZone = UiDoValueSelector(&s_aIds[buttonID++], &Slider, "", m_aClipTrigger.zone, 0, 255, 1, 1.0f, "Tune zone that triggers this clip. Hold shift to be more precise. Rightclick to edit as text.", false, false, 0);
+	int newZone = UiDoValueSelector(&s_aIds[buttonID++], &Slider, "", m_aClipTrigger.m_Zone, 0, 255, 1, 1.0f, "Tune zone that triggers this clip. Hold shift to be more precise. Rightclick to edit as text.", false, false, 0);
 	if (DoButton_ButtonDec(&s_aIds[buttonID++], 0, 0, &Dec, 0, "Decrease"))
 		newZone = clamp(newZone - 1, 0, 255);
 	if (DoButton_ButtonInc(&s_aIds[buttonID++], 0, 0, &Inc, 0, "Increase"))
@@ -4985,16 +4984,16 @@ void CEditor::RenderClipTriggerEditor(CUIRect View, CUIRect EditorRect)
 	Slider.VSplitRight(20, &Slider, &Inc);
 	Slider.VSplitLeft(20, &Dec, &Slider);
 	UI()->DoLabel(&Label, "Trigger", 13, -1, -1);
-	int newTrigger = UiDoValueSelector(&s_aIds[buttonID++], &Slider, "", m_aClipTrigger.trigger, -1, 255, 1, 1.0f, "Trigger group for this clip. -1 for all triggers greater than 0. Hold shift to be more precise. Rightclick to edit as text.", false, false, 0);
+	int newTrigger = UiDoValueSelector(&s_aIds[buttonID++], &Slider, "", m_aClipTrigger.m_Trigger, -1, 255, 1, 1.0f, "Trigger group for this clip. -1 for all triggers greater than 0. Hold shift to be more precise. Rightclick to edit as text.", false, false, 0);
 	if (DoButton_ButtonDec(&s_aIds[buttonID++], 0, 0, &Dec, 0, "Decrease"))
 		newTrigger = clamp(newTrigger - 1, -1, 255);
 	if (DoButton_ButtonInc(&s_aIds[buttonID++], 0, 0, &Inc, 0, "Increase"))
 		newTrigger = clamp(newTrigger + 1, -1, 255);
 
 	static bool exists = false;
-	if (newZone != m_aClipTrigger.zone || newTrigger != m_aClipTrigger.trigger) {
-		m_aClipTrigger.zone = newZone;
-		m_aClipTrigger.trigger = newTrigger;
+	if (newZone != m_aClipTrigger.m_Zone || newTrigger != m_aClipTrigger.m_Trigger) {
+		m_aClipTrigger.m_Zone = newZone;
+		m_aClipTrigger.m_Trigger = newTrigger;
 		exists = false;
 		for (int i = 0; i < m_Map.m_lClipTriggers.size(); i++) {
 			if (m_aClipTrigger == m_Map.m_lClipTriggers[i]) {
@@ -5013,10 +5012,10 @@ void CEditor::RenderClipTriggerEditor(CUIRect View, CUIRect EditorRect)
 	UI()->DoLabel(&Label, "Rewind Envelopes", 10, -1, -1);
 
 	Slider.VSplitMid(&Label, &Slider);
-	if (DoButton_ButtonDec(&s_aIds[buttonID++], "No", !m_aClipTrigger.rewind, &Label, 0, "Entering tune zone will rewind all envelopes to the beginning"))
-		m_aClipTrigger.rewind = 0;
-	if (DoButton_ButtonInc(&s_aIds[buttonID++], "Yes", m_aClipTrigger.rewind, &Slider, 0, "Envelopes will not be modified"))
-		m_aClipTrigger.rewind = 1;
+	if (DoButton_ButtonDec(&s_aIds[buttonID++], "No", !m_aClipTrigger.m_Rewind, &Label, 0, "Entering tune zone will rewind all envelopes to the beginning"))
+		m_aClipTrigger.m_Rewind = 0;
+	if (DoButton_ButtonInc(&s_aIds[buttonID++], "Yes", m_aClipTrigger.m_Rewind, &Slider, 0, "Envelopes will not be modified"))
+		m_aClipTrigger.m_Rewind = 1;
 
 	//Disable clipping
 	Remains.HSplitTop(15, &Slider, &Remains);
@@ -5024,12 +5023,12 @@ void CEditor::RenderClipTriggerEditor(CUIRect View, CUIRect EditorRect)
 	UI()->DoLabel(&Label, "Disable (show all)", 10, -1, -1);
 
 	Slider.VSplitMid(&Label, &Slider);
-	if (DoButton_ButtonDec(&s_aIds[buttonID++], "No", !m_aClipTrigger.disable, &Label, 0, "This tune zone does not disable clipping, clip values will be updated on entering zone"))
-		m_aClipTrigger.disable = 0;
-	if (DoButton_ButtonInc(&s_aIds[buttonID++], "Yes", m_aClipTrigger.disable, &Slider, 0, "This tune zone will disable clipping, showing the whole layer"))
-		m_aClipTrigger.disable = 1;
+	if (DoButton_ButtonDec(&s_aIds[buttonID++], "No", !m_aClipTrigger.m_Disable, &Label, 0, "This tune zone does not disable clipping, clip values will be updated on entering zone"))
+		m_aClipTrigger.m_Disable = 0;
+	if (DoButton_ButtonInc(&s_aIds[buttonID++], "Yes", m_aClipTrigger.m_Disable, &Slider, 0, "This tune zone will disable clipping, showing the whole layer"))
+		m_aClipTrigger.m_Disable = 1;
 
-	if (!m_aClipTrigger.disable) {
+	if (!m_aClipTrigger.m_Disable) {
 		//Clip X
 		Remains.VSplitMid(&Slider, &Remains);
 		Slider.Margin(2, &Slider);
@@ -5037,40 +5036,40 @@ void CEditor::RenderClipTriggerEditor(CUIRect View, CUIRect EditorRect)
 		Slider.HSplitMid(&Slider, &More);
 		Slider.VSplitMid(&Label, &Slider);
 		UI()->DoLabel(&Label, "Clip X", 10.0f, -1, -1);
-		m_aClipTrigger.x = UiDoValueSelector(&s_aIds[buttonID++], &Slider, "", m_aClipTrigger.x, -1000000, 1000000, 1, 1.0f, "Clip area X position. Hold shift to be more precise. Rightclick to edit as text.");
+		m_aClipTrigger.m_X = UiDoValueSelector(&s_aIds[buttonID++], &Slider, "", m_aClipTrigger.m_X, -1000000, 1000000, 1, 1.0f, "Clip area X position. Hold shift to be more precise. Rightclick to edit as text.");
 
 		//Clip Y
 		More.VSplitMid(&Label, &Slider);
 		UI()->DoLabel(&Label, "Clip Y", 10.0f, -1, -1);
-		m_aClipTrigger.y = UiDoValueSelector(&s_aIds[buttonID++], &Slider, "", m_aClipTrigger.y, -1000000, 1000000, 1, 1.0f, "Clip area Y position. Hold shift to be more precise. Rightclick to edit as text.");
+		m_aClipTrigger.m_Y = UiDoValueSelector(&s_aIds[buttonID++], &Slider, "", m_aClipTrigger.m_Y, -1000000, 1000000, 1, 1.0f, "Clip area Y position. Hold shift to be more precise. Rightclick to edit as text.");
 
 		//Clip W
 		Remains.HSplitMid(&Slider, &More);
 		Slider.VSplitMid(&Label, &Slider);
 		UI()->DoLabel(&Label, "Clip W", 10.0f, -1, -1);
-		m_aClipTrigger.w = UiDoValueSelector(&s_aIds[buttonID++], &Slider, "", m_aClipTrigger.w, -1000000, 1000000, 1, 1.0f, "Clip area width. Hold shift to be more precise. Rightclick to edit as text.");
+		m_aClipTrigger.m_W = UiDoValueSelector(&s_aIds[buttonID++], &Slider, "", m_aClipTrigger.m_W, -1000000, 1000000, 1, 1.0f, "Clip area width. Hold shift to be more precise. Rightclick to edit as text.");
 
 		//Clip H
 		More.VSplitMid(&Label, &Slider);
 		UI()->DoLabel(&Label, "Clip H", 10.0f, -1, -1);
-		m_aClipTrigger.h = UiDoValueSelector(&s_aIds[buttonID++], &Slider, "", m_aClipTrigger.h, -1000000, 1000000, 1, 1.0f, "Clip area height. Hold shift to be more precise. Rightclick to edit as text.");
+		m_aClipTrigger.m_H = UiDoValueSelector(&s_aIds[buttonID++], &Slider, "", m_aClipTrigger.m_H, -1000000, 1000000, 1, 1.0f, "Clip area height. Hold shift to be more precise. Rightclick to edit as text.");
 	}
 
 
 	if (exists) {
 		char aBuf[128];
-		str_format(aBuf, sizeof(aBuf), "Update Zone %d Trigger %d clip", m_aClipTrigger.zone, m_aClipTrigger.trigger);
+		str_format(aBuf, sizeof(aBuf), "Update Zone %d Trigger %d clip", m_aClipTrigger.m_Zone, m_aClipTrigger.m_Trigger);
 		if (DoButton_Editor(&s_aIds[buttonID], aBuf, 0, &Buttons, 0, "Modify existing clip area with new clip values."))
 		{
 
 			for (int i = 0; i < m_Map.m_lClipTriggers.size(); i++) {
 				if (m_aClipTrigger == m_Map.m_lClipTriggers[i]) {
-					m_Map.m_lClipTriggers[i].x = m_aClipTrigger.x;
-					m_Map.m_lClipTriggers[i].y = m_aClipTrigger.y;
-					m_Map.m_lClipTriggers[i].w = m_aClipTrigger.w;
-					m_Map.m_lClipTriggers[i].h = m_aClipTrigger.h;
-					m_Map.m_lClipTriggers[i].disable = m_aClipTrigger.disable;
-					m_Map.m_lClipTriggers[i].rewind = m_aClipTrigger.rewind;
+					m_Map.m_lClipTriggers[i].m_X = m_aClipTrigger.m_X;
+					m_Map.m_lClipTriggers[i].m_Y = m_aClipTrigger.m_Y;
+					m_Map.m_lClipTriggers[i].m_W = m_aClipTrigger.m_W;
+					m_Map.m_lClipTriggers[i].m_H = m_aClipTrigger.m_H;
+					m_Map.m_lClipTriggers[i].m_Disable = m_aClipTrigger.m_Disable;
+					m_Map.m_lClipTriggers[i].m_Rewind = m_aClipTrigger.m_Rewind;
 					s_ScrollValue = (float)i / m_Map.m_lClipTriggers.size();
 					s_ClipTriggerSelectedIndex = i;
 					break;
@@ -5082,7 +5081,7 @@ void CEditor::RenderClipTriggerEditor(CUIRect View, CUIRect EditorRect)
 	}
 	else {
 		char aBuf[128];
-		str_format(aBuf, sizeof(aBuf), "Add Zone %d Trigger %d clip", m_aClipTrigger.zone, m_aClipTrigger.trigger);
+		str_format(aBuf, sizeof(aBuf), "Add Zone %d Trigger %d clip", m_aClipTrigger.m_Zone, m_aClipTrigger.m_Trigger);
 		if (DoButton_Editor(&s_aIds[buttonID], aBuf, 0, &Buttons, 0, "Add a new clip/trigger."))
 		{
 
@@ -5165,24 +5164,24 @@ void CEditor::RenderClipTriggerEditor(CUIRect View, CUIRect EditorRect)
 			Button.VSplitLeft(5.0f, 0, &Button);
 
 			char aBuf[128];
-			if (m_Map.m_lClipTriggers[i].disable)
+			if (m_Map.m_lClipTriggers[i].m_Disable)
 
-				str_format(aBuf, sizeof(aBuf), "Zone: %d   Trigger: %d   Disables Clipping Area   Rewind? %s", m_Map.m_lClipTriggers[i].zone, m_Map.m_lClipTriggers[i].trigger, m_Map.m_lClipTriggers[i].rewind ? "Yes" : "No");
+				str_format(aBuf, sizeof(aBuf), "Zone: %d   Trigger: %d   Disables Clipping Area   Rewind? %s", m_Map.m_lClipTriggers[i].m_Zone, m_Map.m_lClipTriggers[i].m_Trigger, m_Map.m_lClipTriggers[i].m_Rewind ? "Yes" : "No");
 
 			else
-				str_format(aBuf, sizeof(aBuf), "Zone: %d   Trigger: %d   X: %d   Y: %d   W: %d   H: %d   Rewind? %s", m_Map.m_lClipTriggers[i].zone, m_Map.m_lClipTriggers[i].trigger, m_Map.m_lClipTriggers[i].x, m_Map.m_lClipTriggers[i].y, m_Map.m_lClipTriggers[i].w, m_Map.m_lClipTriggers[i].h, m_Map.m_lClipTriggers[i].rewind ? "Yes" : "No");
+				str_format(aBuf, sizeof(aBuf), "Zone: %d   Trigger: %d   X: %d   Y: %d   W: %d   H: %d   Rewind? %s", m_Map.m_lClipTriggers[i].m_Zone, m_Map.m_lClipTriggers[i].m_Trigger, m_Map.m_lClipTriggers[i].m_X, m_Map.m_lClipTriggers[i].m_Y, m_Map.m_lClipTriggers[i].m_W, m_Map.m_lClipTriggers[i].m_H, m_Map.m_lClipTriggers[i].m_Rewind ? "Yes" : "No");
 
 			if (DoButton_MenuItem(&m_Map.m_lClipTriggers[i], aBuf, s_ClipTriggerSelectedIndex == i, &Button, 0, "Click to highlight clip area. Click twice to copy values into interface. While selected, press NumPad-/+ to reorder")) {
 				changeView = true;
 				if (s_ClipTriggerSelectedIndex == i) {
-					m_aClipTrigger.zone = m_Map.m_lClipTriggers[i].zone;
-					m_aClipTrigger.trigger = m_Map.m_lClipTriggers[i].trigger;
-					m_aClipTrigger.x = m_Map.m_lClipTriggers[i].x;
-					m_aClipTrigger.y = m_Map.m_lClipTriggers[i].y;
-					m_aClipTrigger.w = m_Map.m_lClipTriggers[i].w;
-					m_aClipTrigger.h = m_Map.m_lClipTriggers[i].h;
-					m_aClipTrigger.disable = m_Map.m_lClipTriggers[i].disable;
-					m_aClipTrigger.rewind = m_Map.m_lClipTriggers[i].rewind;
+					m_aClipTrigger.m_Zone = m_Map.m_lClipTriggers[i].m_Zone;
+					m_aClipTrigger.m_Trigger = m_Map.m_lClipTriggers[i].m_Trigger;
+					m_aClipTrigger.m_X = m_Map.m_lClipTriggers[i].m_X;
+					m_aClipTrigger.m_Y = m_Map.m_lClipTriggers[i].m_Y;
+					m_aClipTrigger.m_W = m_Map.m_lClipTriggers[i].m_W;
+					m_aClipTrigger.m_H = m_Map.m_lClipTriggers[i].m_H;
+					m_aClipTrigger.m_Disable = m_Map.m_lClipTriggers[i].m_Disable;
+					m_aClipTrigger.m_Rewind = m_Map.m_lClipTriggers[i].m_Rewind;
 				}
 				else {
 					s_ClipTriggerSelectedIndex = i;
@@ -5202,7 +5201,6 @@ void CEditor::RenderClipTriggerEditor(CUIRect View, CUIRect EditorRect)
 
 	if (g_Config.m_ClEditorClipDraw >= 1) {
 		CEditorMap::CClipTrigger previewClip = m_aClipTrigger;
-		if (previewClip.disable)continue;
 		if (s_ClipTriggerSelectedIndex == -1)
 			DrawClipBox(previewClip, vec4(0, 1, 0, 1), vec4(0, 0.5f, 0, 0.2f));
 		else
@@ -5212,6 +5210,7 @@ void CEditor::RenderClipTriggerEditor(CUIRect View, CUIRect EditorRect)
 		ListCur = 0;
 		for (int i = 0; i < m_Map.m_lClipTriggers.size(); i++) {
 			CEditorMap::CClipTrigger previewClip = m_Map.m_lClipTriggers[i];
+			if (previewClip.m_Disable)continue;
 			//Show hotitem 
 			if (UI()->HotItem() == &m_Map.m_lClipTriggers[i])
 				DrawClipBox(previewClip, vec4(1, 0, 0, 0.5f), vec4(0.3f, 0, 1, 0.1f));
@@ -5238,22 +5237,22 @@ void CEditor::RenderClipTriggerEditor(CUIRect View, CUIRect EditorRect)
 
 	if (UI()->MouseInside(&FullPanel) && Input()->KeyIsPressed(KEY_MOUSE_1)) {
 		s_ClipTriggerSelectedIndex = -1;
-		if (!m_aClipTrigger.disable) {
-			m_WorldOffsetX = m_aClipTrigger.x + m_aClipTrigger.w / 2;
-			m_WorldOffsetY = m_aClipTrigger.y + m_aClipTrigger.h / 2;
+		if (!m_aClipTrigger.m_Disable) {
+			m_WorldOffsetX = m_aClipTrigger.m_X + m_aClipTrigger.m_W / 2;
+			m_WorldOffsetY = m_aClipTrigger.m_Y + m_aClipTrigger.m_H / 2;
 		}
 	}
 	
 	//Copy selected groups clip into editor panel
 	if (UI()->MouseInside(&FullPanel) && Input()->KeyPress(KEY_C)) {
-		m_aClipTrigger.x = GetSelectedGroup()->m_ClipX;
-		m_aClipTrigger.y = GetSelectedGroup()->m_ClipY;
-		m_aClipTrigger.w = GetSelectedGroup()->m_ClipW;
-		m_aClipTrigger.h = GetSelectedGroup()->m_ClipH;
-		m_aClipTrigger.trigger = GetSelectedGroup()->m_ClipTrigger;
-		if (m_aClipTrigger.w > 1 && m_aClipTrigger.h > 1) {
-			m_WorldOffsetX = m_aClipTrigger.x + m_aClipTrigger.w / 2;
-			m_WorldOffsetY = m_aClipTrigger.y + m_aClipTrigger.h / 2;
+		m_aClipTrigger.m_X = GetSelectedGroup()->m_ClipX;
+		m_aClipTrigger.m_Y = GetSelectedGroup()->m_ClipY;
+		m_aClipTrigger.m_W = GetSelectedGroup()->m_ClipW;
+		m_aClipTrigger.m_H = GetSelectedGroup()->m_ClipH;
+		m_aClipTrigger.m_Trigger = GetSelectedGroup()->m_ClipTrigger;
+		if (m_aClipTrigger.m_W > 1 && m_aClipTrigger.m_H > 1) {
+			m_WorldOffsetX = m_aClipTrigger.m_X + m_aClipTrigger.m_W / 2;
+			m_WorldOffsetY = m_aClipTrigger.m_Y + m_aClipTrigger.m_H / 2;
 		}
 		exists = false;
 		for (int i = 0; i < m_Map.m_lClipTriggers.size(); i++) {
@@ -5269,10 +5268,10 @@ void CEditor::RenderClipTriggerEditor(CUIRect View, CUIRect EditorRect)
 	
 
 	if (changeView) {
-		if (!m_Map.m_lClipTriggers[s_ClipTriggerSelectedIndex].disable) {
-			if (m_Map.m_lClipTriggers[s_ClipTriggerSelectedIndex].w > 0 && m_Map.m_lClipTriggers[s_ClipTriggerSelectedIndex].h > 0) {
-				m_EditorOffsetX = m_Map.m_lClipTriggers[s_ClipTriggerSelectedIndex].x + m_Map.m_lClipTriggers[s_ClipTriggerSelectedIndex].w / 2;
-				m_EditorOffsetY = m_Map.m_lClipTriggers[s_ClipTriggerSelectedIndex].y + m_Map.m_lClipTriggers[s_ClipTriggerSelectedIndex].h / 2;
+		if (!m_Map.m_lClipTriggers[s_ClipTriggerSelectedIndex].m_Disable) {
+			if (m_Map.m_lClipTriggers[s_ClipTriggerSelectedIndex].m_W > 0 && m_Map.m_lClipTriggers[s_ClipTriggerSelectedIndex].m_H > 0) {
+				m_EditorOffsetX = m_Map.m_lClipTriggers[s_ClipTriggerSelectedIndex].m_X + m_Map.m_lClipTriggers[s_ClipTriggerSelectedIndex].m_W / 2;
+				m_EditorOffsetY = m_Map.m_lClipTriggers[s_ClipTriggerSelectedIndex].m_Y + m_Map.m_lClipTriggers[s_ClipTriggerSelectedIndex].m_H / 2;
 			}
 		}
 	}
@@ -5305,16 +5304,16 @@ void CEditor::DrawClipBox(CEditorMap::CClipTrigger clip, vec4 boxColor, vec4 fil
 	Graphics()->LinesBegin();
 
 	IGraphics::CLineItem Array[4] = {
-		IGraphics::CLineItem(clip.x, clip.y, clip.x + clip.w, clip.y),
-		IGraphics::CLineItem(clip.x + clip.w, clip.y, clip.x + clip.w, clip.y + clip.h),
-		IGraphics::CLineItem(clip.x + clip.w, clip.y + clip.h, clip.x, clip.y + clip.h),
-		IGraphics::CLineItem(clip.x, clip.y + clip.h, clip.x, clip.y) };
+		IGraphics::CLineItem(clip.m_X, clip.m_Y, clip.m_X + clip.m_W, clip.m_Y),
+		IGraphics::CLineItem(clip.m_X + clip.m_W, clip.m_Y, clip.m_X + clip.m_W, clip.m_Y + clip.m_H),
+		IGraphics::CLineItem(clip.m_X + clip.m_W, clip.m_Y + clip.m_H, clip.m_X, clip.m_Y + clip.m_H),
+		IGraphics::CLineItem(clip.m_X, clip.m_Y + clip.m_H, clip.m_X, clip.m_Y) };
 	Graphics()->SetColor(boxColor.r, boxColor.g, boxColor.b, boxColor.a);
 	Graphics()->LinesDraw(Array, 4);
 	Graphics()->LinesEnd();
 
 	Graphics()->QuadsBegin();
-	IGraphics::CQuadItem QuadItem(clip.x, clip.y, clip.w, clip.h);
+	IGraphics::CQuadItem QuadItem(clip.m_X, clip.m_Y, clip.m_W, clip.m_H);
 	Graphics()->SetColor(fillColor.r, fillColor.g, fillColor.b, fillColor.a);
 	Graphics()->QuadsDrawTL(&QuadItem, 1);
 	Graphics()->QuadsEnd();
@@ -5753,6 +5752,8 @@ void CEditor::Reset(bool CreateDefault)
 	m_Map.m_Modified = false;
 	m_Map.m_UndoModified = 0;
 	m_LastUndoUpdateTime = time_get();
+
+	m_aClipTrigger.Reset();
 }
 
 int CEditor::GetLineDistance()

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -5125,7 +5125,7 @@ void CEditor::RenderClipTriggerEditor(CUIRect View, CUIRect EditorRect)
 		{
 			for (int i = 0; i < m_Map.m_lClipTriggers.size(); i++) {
 				if (m_aClipTrigger == m_Map.m_lClipTriggers[i]) {
-					strcpy(m_Map.m_lClipTriggers[i].m_aName, m_aClipTrigger.m_aName);
+					mem_copy(m_Map.m_lClipTriggers[i].m_aName, m_aClipTrigger.m_aName, sizeof(m_aClipTrigger.m_aName));
 					m_Map.m_lClipTriggers[i].m_X = m_aClipTrigger.m_X;
 					m_Map.m_lClipTriggers[i].m_Y = m_aClipTrigger.m_Y;
 					m_Map.m_lClipTriggers[i].m_W = m_aClipTrigger.m_W;

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -5239,6 +5239,7 @@ void CEditor::RenderClipTriggerEditor(CUIRect View, CUIRect EditorRect)
 				changeView = true;
 				if (s_ClipTriggerSelectedIndex == i)
 				{
+					mem_copy(m_aClipTrigger.m_aName, m_Map.m_lClipTriggers[i].m_aName, sizeof(m_Map.m_lClipTriggers[i].m_aName));
 					strcpy(m_aClipTrigger.m_aName, m_Map.m_lClipTriggers[i].m_aName);
 					m_aClipTrigger.m_Zone = m_Map.m_lClipTriggers[i].m_Zone;
 					m_aClipTrigger.m_Trigger = m_Map.m_lClipTriggers[i].m_Trigger;

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -6111,15 +6111,6 @@ void CEditor::UpdateAndRender()
 #else
 		UI()->ConvertMouseMove(&rx, &ry);
 
-		//QWER
-		if (isnan(rx) || isnan(ry))
-		{
-			char aBuf[256];
-			str_format(aBuf, sizeof(aBuf), "This never happens, but isnan seems to prevent a bug");
-			Console()->Print(IConsole::OUTPUT_LEVEL_DEBUG, "editor", aBuf);
-
-		}
-
 		m_MouseDeltaX = rx;
 		m_MouseDeltaY = ry;
 

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -4994,10 +4994,7 @@ void CEditor::RenderClipTriggerEditor(CUIRect View, CUIRect EditorRect)
 		//m_Map.m_UndoModified++;
 	}
 
-
-
 	//Tune zone
-
 	More.HSplitMid(&Slider, &More);
 	Slider.HMargin(2, &Slider);
 	Slider.VSplitMid(&Label, &Slider);
@@ -5038,7 +5035,6 @@ void CEditor::RenderClipTriggerEditor(CUIRect View, CUIRect EditorRect)
 			}
 		}
 	}
-
 
 	//Rewind Animation
 	Remains.HSplitTop(15, &Slider, &Remains);
@@ -5112,8 +5108,6 @@ void CEditor::RenderClipTriggerEditor(CUIRect View, CUIRect EditorRect)
 			changeView = true;
 			s_ClipTriggerSelectedIndex = -1;
 		}
-
-
 	}
 
 
@@ -5255,13 +5249,10 @@ void CEditor::RenderClipTriggerEditor(CUIRect View, CUIRect EditorRect)
 					s_ClipTriggerSelectedIndex = i;
 				}
 			}
-
 		}
 		ListCur += itemHeight;
 	}
 	UI()->ClipDisable();
-
-
 
 	//Preview the clip areas
 	UI()->ClipEnable(&EditorRect);
@@ -5336,8 +5327,6 @@ void CEditor::RenderClipTriggerEditor(CUIRect View, CUIRect EditorRect)
 		}
 	}
 
-	
-
 	if (changeView) 
 	{
 		CEditorMap::CClipTrigger previewClip = m_aClipTrigger;
@@ -5353,7 +5342,6 @@ void CEditor::RenderClipTriggerEditor(CUIRect View, CUIRect EditorRect)
 		}
 	}
 	
-	
 	if (s_ClipTriggerSelectedIndex > 0 && Input()->KeyPress(KEY_KP_MINUS)) 
 	{
 		CEditorMap::CClipTrigger temp = m_Map.m_lClipTriggers[s_ClipTriggerSelectedIndex];
@@ -5361,7 +5349,6 @@ void CEditor::RenderClipTriggerEditor(CUIRect View, CUIRect EditorRect)
 		m_Map.m_lClipTriggers[s_ClipTriggerSelectedIndex - 1] = temp;
 		s_ClipTriggerSelectedIndex--;
 		s_ScrollValue = (float)s_ClipTriggerSelectedIndex / m_Map.m_lClipTriggers.size();
-
 	}
 	if (s_ClipTriggerSelectedIndex < m_Map.m_lClipTriggers.size() - 1 && Input()->KeyPress(KEY_KP_PLUS))
 	{
@@ -5371,16 +5358,10 @@ void CEditor::RenderClipTriggerEditor(CUIRect View, CUIRect EditorRect)
 		s_ClipTriggerSelectedIndex++;
 		s_ScrollValue = (float)s_ClipTriggerSelectedIndex / m_Map.m_lClipTriggers.size();
 	}
-
-
-
-
-
 }
 
 void CEditor::DrawClipBox(CEditorMap::CClipTrigger clip, vec4 boxColor, vec4 fillColor) 
 {
-
 	Graphics()->LinesBegin();
 
 	IGraphics::CLineItem Array[4] = {
@@ -5397,7 +5378,6 @@ void CEditor::DrawClipBox(CEditorMap::CClipTrigger clip, vec4 boxColor, vec4 fil
 	Graphics()->SetColor(fillColor.r, fillColor.g, fillColor.b, fillColor.a);
 	Graphics()->QuadsDrawTL(&QuadItem, 1);
 	Graphics()->QuadsEnd();
-
 }
 
 int CEditor::PopupMenuFile(CEditor *pEditor, CUIRect View)

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -5240,7 +5240,6 @@ void CEditor::RenderClipTriggerEditor(CUIRect View, CUIRect EditorRect)
 				if (s_ClipTriggerSelectedIndex == i)
 				{
 					mem_copy(m_aClipTrigger.m_aName, m_Map.m_lClipTriggers[i].m_aName, sizeof(m_Map.m_lClipTriggers[i].m_aName));
-					strcpy(m_aClipTrigger.m_aName, m_Map.m_lClipTriggers[i].m_aName);
 					m_aClipTrigger.m_Zone = m_Map.m_lClipTriggers[i].m_Zone;
 					m_aClipTrigger.m_Trigger = m_Map.m_lClipTriggers[i].m_Trigger;
 					m_aClipTrigger.m_X = m_Map.m_lClipTriggers[i].m_X;

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -27,6 +27,7 @@
 
 #include "auto_map.h"
 #include "editor.h"
+#include <string.h>
 
 const char* vanillaImages[] = {"bg_cloud1", "bg_cloud2", "bg_cloud3",
 	"desert_doodads", "desert_main", "desert_mountains", "desert_mountains2",

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -390,20 +390,27 @@ public:
 	array<CSetting> m_lSettings;
 
 	struct CClipTrigger {
-		int zone, trigger, x, y, w, h, disable, rewind;
+		int m_Zone; 
+		int m_Trigger; 
+		int m_X;
+		int m_Y; 
+		int m_W; 
+		int m_H;
+		int m_Disable;
+		int m_Rewind;
 		void Reset() {
-			zone = 1;
-			trigger = 1;
-			x = 0;
-			y = 0;
-			w = 128;
-			h = 128;
-			disable = 0;
-			rewind = 1;
+			m_Zone = 1;
+			m_Trigger = 1;
+			m_X = 0;
+			m_Y = 0;
+			m_W = 128;
+			m_H = 128;
+			m_Disable = 0;
+			m_Rewind = 1;
 
 		}
 		bool operator == (CClipTrigger other) {
-			return zone == other.zone && trigger == other.trigger;
+			return m_Zone == other.m_Zone && m_Trigger == other.m_Trigger;
 		}
 	};
 	array<CClipTrigger> m_lClipTriggers;

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -189,6 +189,8 @@ public:
 	int m_ClipW;
 	int m_ClipH;
 
+	int m_ClipTrigger;
+
 	char m_aName[12];
 	bool m_GameGroup;
 	bool m_Visible;
@@ -386,6 +388,25 @@ public:
 		char m_aCommand[64];
 	};
 	array<CSetting> m_lSettings;
+
+	struct CClipTrigger {
+		int zone, trigger, x, y, w, h, disable, rewind;
+		void Reset() {
+			zone = 1;
+			trigger = 1;
+			x = 0;
+			y = 0;
+			w = 128;
+			h = 128;
+			disable = 0;
+			rewind = 1;
+
+		}
+		bool operator == (CClipTrigger other) {
+			return zone == other.zone && trigger == other.trigger;
+		}
+	};
+	array<CClipTrigger> m_lClipTriggers;
 
 	class CLayerGame *m_pGameLayer;
 	CLayerGroup *m_pGameGroup;
@@ -696,6 +717,7 @@ public:
 		m_ShowUndo = 0;
 		m_UndoScrollValue = 0.0f;
 		m_ShowServerSettingsEditor = false;
+		m_ShowClipTrigger = false;
 
 		m_ShowEnvelopePreview = 0;
 		m_SelectedQuadEnvelope = -1;
@@ -875,6 +897,7 @@ public:
 	int m_ShowEnvelopeEditor;
 	int m_ShowEnvelopePreview; //Values: 0-Off|1-Selected Envelope|2-All
 	bool m_ShowServerSettingsEditor;
+	bool m_ShowClipTrigger;
 	bool m_ShowPicker;
 
 	int m_SelectedLayer;
@@ -996,6 +1019,10 @@ public:
 	void RenderEnvelopeEditor(CUIRect View);
 	void RenderUndoList(CUIRect View);
 	void RenderServerSettingsEditor(CUIRect View);
+	void RenderClipTriggerEditor(CUIRect View, CUIRect EditorRect);
+	void DrawClipBox(CEditorMap::CClipTrigger clip, vec4 boxColor, vec4 fillColor);
+
+	CEditorMap::CClipTrigger m_aClipTrigger;
 
 	void RenderMenubar(CUIRect Menubar);
 	void RenderFileDialog();

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -188,7 +188,6 @@ public:
 	int m_ClipY;
 	int m_ClipW;
 	int m_ClipH;
-
 	int m_ClipTrigger;
 
 	char m_aName[12];
@@ -389,8 +388,10 @@ public:
 	};
 	array<CSetting> m_lSettings;
 
-	struct CClipTrigger {
-		int m_Zone; 
+	struct CClipTrigger 
+	{
+		char m_aName[32];
+		int m_Zone;
 		int m_Trigger; 
 		int m_X;
 		int m_Y; 
@@ -398,7 +399,9 @@ public:
 		int m_H;
 		int m_Disable;
 		int m_Rewind;
-		void Reset() {
+		void Reset() 
+		{
+			memset(&m_aName[0], 0, sizeof(m_aName));
 			m_Zone = 1;
 			m_Trigger = 1;
 			m_X = 0;
@@ -409,7 +412,8 @@ public:
 			m_Rewind = 1;
 
 		}
-		bool operator == (CClipTrigger other) {
+		bool operator == (CClipTrigger other) 
+		{
 			return m_Zone == other.m_Zone && m_Trigger == other.m_Trigger;
 		}
 	};
@@ -1030,6 +1034,7 @@ public:
 	void DrawClipBox(CEditorMap::CClipTrigger clip, vec4 boxColor, vec4 fillColor);
 
 	CEditorMap::CClipTrigger m_aClipTrigger;
+	bool m_ClipExists = false;
 
 	void RenderMenubar(CUIRect Menubar);
 	void RenderFileDialog();

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -401,7 +401,7 @@ public:
 		int m_Rewind;
 		void Reset() 
 		{
-			memset(&m_aName[0], 0, sizeof(m_aName));
+			mem_zero(&m_aName[0], sizeof(m_aName));
 			m_Zone = 1;
 			m_Trigger = 1;
 			m_X = 0;

--- a/src/game/editor/io.cpp
+++ b/src/game/editor/io.cpp
@@ -370,6 +370,11 @@ int CEditorMap::Save(class IStorage *pStorage, const char *pFileName)
 		GItem.m_ClipY = pGroup->m_ClipY;
 		GItem.m_ClipW = pGroup->m_ClipW;
 		GItem.m_ClipH = pGroup->m_ClipH;
+		if (pGroup->m_GameGroup)
+			GItem.m_ClipTrigger = 0;
+		else
+			GItem.m_ClipTrigger = pGroup->m_ClipTrigger;
+
 		GItem.m_StartLayer = LayerCount;
 		GItem.m_NumLayers = 0;
 
@@ -533,6 +538,27 @@ int CEditorMap::Save(class IStorage *pStorage, const char *pFileName)
 	df.AddItem(MAPITEMTYPE_ENVPOINTS, 0, TotalSize, pPoints);
 	mem_free(pPoints);
 
+	//Save clips
+	if (m_lClipTriggers.size())
+	{
+		for (int i = 0; i < m_lClipTriggers.size(); i++)
+		{
+			CMapItemClips Item;
+			Item.zone = m_lClipTriggers[i].zone;
+			Item.trigger = m_lClipTriggers[i].trigger;
+			Item.x = m_lClipTriggers[i].x;
+			Item.y = m_lClipTriggers[i].y;
+			Item.w = m_lClipTriggers[i].w;
+			Item.h = m_lClipTriggers[i].h;
+			Item.disable = m_lClipTriggers[i].disable;
+			Item.rewind = m_lClipTriggers[i].rewind;
+			df.AddItem(MAPITEMTYPE_CLIPS, i, sizeof(Item), &Item);
+
+		}
+	}
+
+
+	
 	// finish the data file
 	df.Finish();
 	m_pEditor->Console()->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "editor", "saving done");
@@ -790,6 +816,9 @@ int CEditorMap::Load(class IStorage *pStorage, const char *pFileName, int Storag
 					pGroup->m_ClipY = pGItem->m_ClipY;
 					pGroup->m_ClipW = pGItem->m_ClipW;
 					pGroup->m_ClipH = pGItem->m_ClipH;
+					pGroup->m_ClipTrigger = pGItem->m_ClipTrigger;
+					//Hack reading file save in previous format, where this value was read from a different item - set to zero
+					if (pGroup->m_ClipTrigger > 255)pGroup->m_ClipTrigger = 0;
 				}
 
 				// load group name
@@ -1261,6 +1290,19 @@ int CEditorMap::Load(class IStorage *pStorage, const char *pFileName, int Storag
 					pEnv->m_Synchronized = pItem->m_Synchronized;
 			}
 		}
+		
+		//Load clips
+		{
+			int Start, Num;
+			DataFile.GetType(MAPITEMTYPE_CLIPS, &Start, &Num);
+			for (int i = 0; i < Num; i++)
+			{
+				CMapItemClips *pItem = (CMapItemClips *)DataFile.GetItem(Start + i, 0, 0);
+				CClipTrigger newClip = { pItem->zone, pItem->trigger, pItem->x, pItem->y, pItem->w, pItem->h, pItem->disable, pItem->rewind };
+				m_lClipTriggers.add(newClip);
+			}
+		}
+		
 	}
 	else
 		return 0;

--- a/src/game/editor/io.cpp
+++ b/src/game/editor/io.cpp
@@ -549,7 +549,6 @@ int CEditorMap::Save(class IStorage *pStorage, const char *pFileName)
 			Item.m_Disable = m_lClipTriggers[i].m_Disable;
 			Item.m_Rewind = m_lClipTriggers[i].m_Rewind;
 			df.AddItem(MAPITEMTYPE_CLIPS, i, sizeof(Item), &Item);
-
 		}
 	}
 

--- a/src/game/editor/io.cpp
+++ b/src/game/editor/io.cpp
@@ -370,7 +370,6 @@ int CEditorMap::Save(class IStorage *pStorage, const char *pFileName)
 		GItem.m_ClipY = pGroup->m_ClipY;
 		GItem.m_ClipW = pGroup->m_ClipW;
 		GItem.m_ClipH = pGroup->m_ClipH;
-
 		GItem.m_StartLayer = LayerCount;
 		GItem.m_NumLayers = 0;
 
@@ -540,6 +539,7 @@ int CEditorMap::Save(class IStorage *pStorage, const char *pFileName)
 		for (int i = 0; i < m_lClipTriggers.size(); i++)
 		{
 			CMapItemClips Item;
+			StrToInts(Item.m_aName, sizeof(Item.m_aName) / sizeof(int), m_lClipTriggers[i].m_aName);
 			Item.m_Zone = m_lClipTriggers[i].m_Zone;
 			Item.m_Trigger = m_lClipTriggers[i].m_Trigger;
 			Item.m_X = m_lClipTriggers[i].m_X;
@@ -559,7 +559,14 @@ int CEditorMap::Save(class IStorage *pStorage, const char *pFileName)
 		CLayerGroup *pGroup = m_lGroups[g];
 		CMapItemTriggers Item;
 		Item.m_Group = g;
-		Item.m_Trigger = pGroup->m_ClipTrigger;
+		if (pGroup->m_GameGroup)
+		{
+			Item.m_Trigger = -1;
+		}
+		else
+		{
+			Item.m_Trigger = pGroup->m_ClipTrigger;
+		}
 		df.AddItem(MAPITEMTYPE_TRIGGERS, g, sizeof(Item), &Item);
 
 		
@@ -826,9 +833,14 @@ int CEditorMap::Load(class IStorage *pStorage, const char *pFileName, int Storag
 
 					int tStart, tNum;
 					DataFile.GetType(MAPITEMTYPE_TRIGGERS, &tStart, &tNum);
-					if (tNum > 0) {
+					if (tNum > 0)
+					{
 						CMapItemTriggers *pTrigger = (CMapItemTriggers *)DataFile.GetItem(tStart + g, 0, 0);
 						pGroup->m_ClipTrigger = pTrigger->m_Trigger;
+					}
+					else
+					{
+						pGroup->m_ClipTrigger = 0;
 					}
 				}
 
@@ -1309,7 +1321,9 @@ int CEditorMap::Load(class IStorage *pStorage, const char *pFileName, int Storag
 			for (int i = 0; i < Num; i++)
 			{
 				CMapItemClips *pItem = (CMapItemClips *)DataFile.GetItem(Start + i, 0, 0);
-				CClipTrigger newClip = { pItem->m_Zone, pItem->m_Trigger, pItem->m_X, pItem->m_Y, pItem->m_W, pItem->m_H, pItem->m_Disable, pItem->m_Rewind };
+				CClipTrigger newClip = {"", pItem->m_Zone, pItem->m_Trigger, pItem->m_X, pItem->m_Y, pItem->m_W, pItem->m_H, pItem->m_Disable, pItem->m_Rewind };
+				IntsToStr(pItem->m_aName, sizeof(pItem->m_aName) / sizeof(int), newClip.m_aName);
+
 				m_lClipTriggers.add(newClip);
 			}
 		}

--- a/src/game/editor/io.cpp
+++ b/src/game/editor/io.cpp
@@ -1352,7 +1352,7 @@ int CEditor::Append(const char *pFileName, int StorageType)
 	if(!Err)
 		return Err;
 
-	// modify indecies
+	// modify indicies
 	gs_ModifyAddAmount = m_Map.m_lImages.size();
 	NewMap.ModifyImageIndex(ModifyAdd);
 
@@ -1365,12 +1365,16 @@ int CEditor::Append(const char *pFileName, int StorageType)
 	NewMap.m_lImages.clear();
 
 	// transfer envelopes
-	for(int i = 0; i < NewMap.m_lEnvelopes.size(); i++)
+	for (int i = 0; i < NewMap.m_lEnvelopes.size(); i++)
 		m_Map.m_lEnvelopes.add(NewMap.m_lEnvelopes[i]);
 	NewMap.m_lEnvelopes.clear();
 
-	// transfer groups
+	// transfer clip list
+	for (int i = 0; i < NewMap.m_lClipTriggers.size(); i++)
+		m_Map.m_lClipTriggers.add(NewMap.m_lClipTriggers[i]);
+	NewMap.m_lClipTriggers.clear();
 
+	// transfer groups
 	for(int i = 0; i < NewMap.m_lGroups.size(); i++)
 	{
 		if(NewMap.m_lGroups[i] == NewMap.m_pGameGroup)

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -308,6 +308,7 @@ int CEditor::PopupGroup(CEditor *pEditor, CUIRect View)
 		PROP_CLIP_Y,
 		PROP_CLIP_W,
 		PROP_CLIP_H,
+		PROP_CLIP_TRIGGER,
 		NUM_PROPS,
 	};
 
@@ -323,6 +324,7 @@ int CEditor::PopupGroup(CEditor *pEditor, CUIRect View)
 		{"Clip Y", pEditor->m_Map.m_lGroups[pEditor->m_SelectedGroup]->m_ClipY, PROPTYPE_INT_SCROLL, -1000000, 1000000},
 		{"Clip W", pEditor->m_Map.m_lGroups[pEditor->m_SelectedGroup]->m_ClipW, PROPTYPE_INT_SCROLL, 0, 1000000},
 		{"Clip H", pEditor->m_Map.m_lGroups[pEditor->m_SelectedGroup]->m_ClipH, PROPTYPE_INT_SCROLL, 0, 1000000},
+		{"Clip Trigger", pEditor->m_Map.m_lGroups[pEditor->m_SelectedGroup]->m_ClipTrigger, PROPTYPE_INT_STEP, 0, 255},
 		{0},
 	};
 
@@ -352,6 +354,7 @@ int CEditor::PopupGroup(CEditor *pEditor, CUIRect View)
 		else if(Prop == PROP_CLIP_Y) pEditor->m_Map.m_lGroups[pEditor->m_SelectedGroup]->m_ClipY = NewVal;
 		else if(Prop == PROP_CLIP_W) pEditor->m_Map.m_lGroups[pEditor->m_SelectedGroup]->m_ClipW = NewVal;
 		else if(Prop == PROP_CLIP_H) pEditor->m_Map.m_lGroups[pEditor->m_SelectedGroup]->m_ClipH = NewVal;
+		else if (Prop == PROP_CLIP_TRIGGER) pEditor->m_Map.m_lGroups[pEditor->m_SelectedGroup]->m_ClipTrigger = NewVal;
 	}
 
 	return 0;

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -546,6 +546,63 @@ int CEditor::PopupQuad(CEditor *pEditor, CUIRect View)
 		pEditor->m_Map.m_Modified = true;
 		return 1;
 	}
+	
+	// Order Buttons
+	View.HSplitBottom(6.0f, &View, &Button);
+	View.HSplitBottom(12.0f, &View, &Button);
+	static int s_Button1 = 0;
+	static int s_Button2 = 0;
+	static int s_Button3 = 0;
+	static int s_Button4 = 0;
+	CUIRect miniButton;
+
+	Button.VSplitLeft(Button.w / 4, &miniButton, &Button);
+	if (pEditor->DoButton_ButtonDec(&s_Button1, "Back", 0, &miniButton, 0, "Push Quad to the back"))
+	{
+		plain_range<CQuad> pl = plain_range<CQuad>(&pLayer->m_lQuads[0], &pLayer->m_lQuads[pLayer->m_lQuads.size() - 1]);
+		pl.index(0);
+		CQuad *q = &(pLayer->m_lQuads[pEditor->m_SelectedQuad]);
+		CQuad n;
+		n = *q;
+		pLayer->m_lQuads.remove_index(pEditor->m_SelectedQuad);
+		pLayer->m_lQuads.insert(n, pl);
+		pEditor->m_SelectedQuad = 0;
+		pQuad = pEditor->GetSelectedQuad();
+		pEditor->m_Map.m_Modified = true;
+	}
+
+	Button.VSplitLeft(Button.w / 3, &miniButton, &Button);
+	if (pEditor->DoButton_Ex(&s_Button2, "-", 0, &miniButton, 0, "Push Quad backwards by 1",0) && pEditor->m_SelectedQuad > 0)
+	{
+		CQuad temp = pLayer->m_lQuads[pEditor->m_SelectedQuad];
+		pLayer->m_lQuads[pEditor->m_SelectedQuad] = pLayer->m_lQuads[pEditor->m_SelectedQuad - 1];
+		pLayer->m_lQuads[pEditor->m_SelectedQuad - 1] = temp;
+		pEditor->m_SelectedQuad--;
+		pQuad = pEditor->GetSelectedQuad();
+		pEditor->m_Map.m_Modified = true;
+	}
+
+	Button.VSplitLeft(Button.w / 2, &miniButton, &Button);
+	if (pEditor->DoButton_Ex(&s_Button3, "+", 0, &miniButton, 0, "Bring Quad forwards by 1",0) && pEditor->m_SelectedQuad < pLayer->m_lQuads.size() - 1)
+	{
+		CQuad temp = pLayer->m_lQuads[pEditor->m_SelectedQuad];
+		pLayer->m_lQuads[pEditor->m_SelectedQuad] = pLayer->m_lQuads[pEditor->m_SelectedQuad + 1];
+		pLayer->m_lQuads[pEditor->m_SelectedQuad + 1] = temp;
+		pEditor->m_SelectedQuad++;
+		pQuad = pEditor->GetSelectedQuad();
+		pEditor->m_Map.m_Modified = true;
+	}
+
+
+	if (pEditor->DoButton_ButtonInc(&s_Button4, "Front", 0, &Button, 0, "Bring Quad to the front"))
+	{
+		CQuad temp = pLayer->m_lQuads[pEditor->m_SelectedQuad];
+		pLayer->m_lQuads.remove_index(pEditor->m_SelectedQuad);
+		pLayer->m_lQuads.add(temp);
+		pEditor->m_SelectedQuad = pLayer->m_lQuads.size() - 1;
+		pQuad = pEditor->GetSelectedQuad();
+		pEditor->m_Map.m_Modified = true;
+	}
 
 
 	enum

--- a/src/game/mapitems.h
+++ b/src/game/mapitems.h
@@ -29,6 +29,7 @@ enum
 	MAPITEMTYPE_LAYER,
 	MAPITEMTYPE_ENVPOINTS,
 	MAPITEMTYPE_SOUND,
+	MAPITEMTYPE_CLIPS,
 
 
 	CURVETYPE_STEP=0,
@@ -266,6 +267,7 @@ struct CMapItemGroup : public CMapItemGroup_v1
 	int m_ClipH;
 
 	int m_aName[3];
+	int m_ClipTrigger;
 } ;
 
 struct CMapItemLayer
@@ -411,6 +413,18 @@ struct CMapItemSound
 	int m_SoundData;
 	int m_SoundDataSize;
 } ;
+
+struct CMapItemClips
+{
+	int zone;
+	int trigger;
+	int x;
+	int y;
+	int w;
+	int h;
+	int disable;
+	int rewind;
+};
 
 
 // DDRace

--- a/src/game/mapitems.h
+++ b/src/game/mapitems.h
@@ -416,6 +416,7 @@ struct CMapItemSound
 
 struct CMapItemClips
 {
+	int m_aName[8];
 	int m_Zone;
 	int m_Trigger;
 	int m_X;

--- a/src/game/mapitems.h
+++ b/src/game/mapitems.h
@@ -30,6 +30,7 @@ enum
 	MAPITEMTYPE_ENVPOINTS,
 	MAPITEMTYPE_SOUND,
 	MAPITEMTYPE_CLIPS,
+	MAPITEMTYPE_TRIGGERS,
 
 
 	CURVETYPE_STEP=0,
@@ -267,7 +268,6 @@ struct CMapItemGroup : public CMapItemGroup_v1
 	int m_ClipH;
 
 	int m_aName[3];
-	int m_ClipTrigger;
 } ;
 
 struct CMapItemLayer
@@ -416,14 +416,19 @@ struct CMapItemSound
 
 struct CMapItemClips
 {
-	int zone;
-	int trigger;
-	int x;
-	int y;
-	int w;
-	int h;
-	int disable;
-	int rewind;
+	int m_Zone;
+	int m_Trigger;
+	int m_X;
+	int m_Y;
+	int m_W;
+	int m_H;
+	int m_Disable;
+	int m_Rewind;
+};
+struct CMapItemTriggers
+{
+	int m_Group;
+	int m_Trigger;
 };
 
 


### PR DESCRIPTION
Create modifiable group clipping

Add a list of clipping areas to map file using new editor window (enable cl_editorcliptrigger 1)
 -These consist of tune zone, trigger id, clip x,y,w&h, disableclipping and rewind (envelopes)
Assign a trigger to groups that you want to change (in group context popup)
Add tune zones as normal

Current ver DDNet server & client load these map fine (but with clipping fixed as default)
Vanilla TW connects to server running these maps also

