### PR TITLE
Add `.vs` directory that is created by MSVS 2017

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ DDNet-Server_d
 DDNet-Server_sql
 DDNet-Server_sql_d
 
+/.vs
 /build
 CMakeCache.txt
 CMakeFiles


### PR DESCRIPTION
It is created in case you open the project "as a folder", using the
native CMake capabilities of MSVS 2017.