### PR TITLE
Add asynchronous output system and use it for teehistorian and `dbg_msg()`s

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -891,6 +891,7 @@ add_custom_target(everything DEPENDS ${TARGETS_OWN})
 
 if(GTEST_FOUND)
   set_glob(TESTS GLOB src/test
+    async.cpp
     strip_path_and_extension.cpp
     teehistorian.cpp
     thread.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -893,6 +893,7 @@ if(GTEST_FOUND)
   set_glob(TESTS GLOB src/test
     strip_path_and_extension.cpp
     teehistorian.cpp
+    thread.cpp
   )
   set(TESTS_EXTRA
     src/game/server/teehistorian.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -891,7 +891,7 @@ add_custom_target(everything DEPENDS ${TARGETS_OWN})
 
 if(GTEST_FOUND)
   set_glob(TESTS GLOB src/test
-    async.cpp
+    aio.cpp
     strip_path_and_extension.cpp
     teehistorian.cpp
     thread.cpp

--- a/src/base/system.c
+++ b/src/base/system.c
@@ -728,7 +728,10 @@ void async_wait(ASYNCIO *aio)
 	lock_wait(aio->lock);
 	thread = aio->thread;
 	aio->thread = 0;
-	aio->finish = ASYNCIO_EXIT;
+	if(aio->finish == ASYNCIO_RUNNING)
+	{
+		aio->finish = ASYNCIO_EXIT;
+	}
 	lock_unlock(aio->lock);
 	sphore_signal(&aio->sphore);
 	thread_wait(thread);

--- a/src/base/system.c
+++ b/src/base/system.c
@@ -85,7 +85,7 @@ IOHANDLE io_stderr() { return (IOHANDLE)stderr; }
 typedef struct
 {
 	DBG_LOGGER logger;
-	void (*finish)(void *user);
+	DBG_LOGGER_FINISH finish;
 	void *user;
 } DBG_LOGGER_DATA;
 
@@ -194,7 +194,7 @@ static void dbg_logger_finish(void)
 	}
 }
 
-void dbg_logger(DBG_LOGGER logger, void (*finish)(void *user), void *user)
+void dbg_logger(DBG_LOGGER logger, DBG_LOGGER_FINISH finish, void *user)
 {
 	DBG_LOGGER_DATA data;
 	if(num_loggers == 0)
@@ -736,7 +736,6 @@ void async_wait(ASYNCIO *aio)
 	sphore_signal(&aio->sphore);
 	thread_wait(thread);
 }
-
 
 void *thread_init(void (*threadfunc)(void *), void *u)
 {

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -1358,13 +1358,12 @@ void swap_endian(void *data, unsigned elem_size, unsigned num);
 
 
 typedef void (*DBG_LOGGER)(const char *line, void *user);
-void dbg_logger(DBG_LOGGER logger, void (*finish)(void *user), void *user);
+typedef void (*DBG_LOGGER_FINISH)(void *user);
+void dbg_logger(DBG_LOGGER logger, DBG_LOGGER_FINISH finish, void *user);
 
 void dbg_logger_stdout();
 void dbg_logger_debugger();
 void dbg_logger_file(const char *filename);
-
-void dbg_log_finish();
 
 typedef struct
 {

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -336,6 +336,18 @@ int io_close(IOHANDLE io);
 */
 int io_flush(IOHANDLE io);
 
+/*
+	Function: io_error
+		Checks whether an error occured during I/O with the file.
+
+	Parameters:
+		io - Handle to the file.
+
+	Returns:
+		Returns nonzero on error, 0 otherwise.
+*/
+int io_error(IOHANDLE io);
+
 
 /*
 	Function: io_stdin
@@ -355,6 +367,90 @@ IOHANDLE io_stdout();
 */
 IOHANDLE io_stderr();
 
+typedef struct ASYNCIO ASYNCIO;
+
+/*
+	Function: async_new
+		Wraps a <IOHANDLE> for asynchronous writing.
+
+	Parameters:
+		io - Handle to the file.
+
+	Returns:
+		Returns the handle for asynchronous writing.
+
+*/
+ASYNCIO *async_new(IOHANDLE io);
+
+/*
+	Function: async_write
+		Queues a chunk of data for writing.
+
+	Parameters:
+		aio - Handle to the file.
+		buffer - Pointer to the data that should be written.
+		size - Number of bytes to write.
+
+*/
+void async_write(ASYNCIO *aio, const void *buffer, unsigned size);
+
+/*
+	Function: async_write_newline
+		Queues a newline for writing.
+
+	Parameters:
+		aio - Handle to the file.
+
+*/
+void async_write_newline(ASYNCIO *aio);
+
+/*
+	Function: async_error
+		Checks whether errors have occured during the asynchronous
+		writing.
+
+		Call this function regularly to see if there are errors. Call
+		this function after <async_wait> to see if the process of
+		writing to the file succeeded.
+
+	Parameters:
+		aio - Handle to the file.
+
+	Returns:
+		Returns 0 if no error occured, and nonzero on error.
+
+*/
+int async_error(ASYNCIO *aio);
+
+/*
+	Function: async_close
+		Queues file closing.
+
+	Parameters:
+		aio - Handle to the file.
+
+*/
+void async_close(ASYNCIO *aio);
+
+/*
+	Function: async_wait
+		Wait for the asynchronous operations to complete.
+
+	Parameters:
+		aio - Handle to the file.
+
+*/
+void async_wait(ASYNCIO *aio);
+
+/*
+	Function: async_free
+		Frees the resources associated to the asynchronous file handle.
+
+	Parameters:
+		aio - Handle to the file.
+
+*/
+void async_free(ASYNCIO *aio);
 
 /* Group: Threads */
 
@@ -1261,13 +1357,14 @@ void mem_debug_dump(IOHANDLE file);
 void swap_endian(void *data, unsigned elem_size, unsigned num);
 
 
-typedef void (*DBG_LOGGER)(const char *line);
-void dbg_logger(DBG_LOGGER logger);
+typedef void (*DBG_LOGGER)(const char *line, void *user);
+void dbg_logger(DBG_LOGGER logger, void (*finish)(void *user), void *user);
 
-void dbg_enable_threaded();
 void dbg_logger_stdout();
 void dbg_logger_debugger();
 void dbg_logger_file(const char *filename);
+
+void dbg_log_finish();
 
 typedef struct
 {

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -388,7 +388,7 @@ void *thread_init(void (*threadfunc)(void *), void *user);
 void thread_wait(void *thread);
 
 /*
-	Function: thread_yeild
+	Function: thread_yield
 		Yield the current threads execution slice.
 */
 void thread_yield();

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -370,7 +370,7 @@ IOHANDLE io_stderr();
 typedef struct ASYNCIO ASYNCIO;
 
 /*
-	Function: async_new
+	Function: aio_new
 		Wraps a <IOHANDLE> for asynchronous writing.
 
 	Parameters:
@@ -380,10 +380,10 @@ typedef struct ASYNCIO ASYNCIO;
 		Returns the handle for asynchronous writing.
 
 */
-ASYNCIO *async_new(IOHANDLE io);
+ASYNCIO *aio_new(IOHANDLE io);
 
 /*
-	Function: async_write
+	Function: aio_write
 		Queues a chunk of data for writing.
 
 	Parameters:
@@ -392,26 +392,26 @@ ASYNCIO *async_new(IOHANDLE io);
 		size - Number of bytes to write.
 
 */
-void async_write(ASYNCIO *aio, const void *buffer, unsigned size);
+void aio_write(ASYNCIO *aio, const void *buffer, unsigned size);
 
 /*
-	Function: async_write_newline
+	Function: aio_write_newline
 		Queues a newline for writing.
 
 	Parameters:
 		aio - Handle to the file.
 
 */
-void async_write_newline(ASYNCIO *aio);
+void aio_write_newline(ASYNCIO *aio);
 
 /*
-	Function: async_error
+	Function: aio_error
 		Checks whether errors have occured during the asynchronous
 		writing.
 
 		Call this function regularly to see if there are errors. Call
-		this function after <async_wait> to see if the process of
-		writing to the file succeeded.
+		this function after <aio_wait> to see if the process of writing
+		to the file succeeded.
 
 	Parameters:
 		aio - Handle to the file.
@@ -420,37 +420,37 @@ void async_write_newline(ASYNCIO *aio);
 		Returns 0 if no error occured, and nonzero on error.
 
 */
-int async_error(ASYNCIO *aio);
+int aio_error(ASYNCIO *aio);
 
 /*
-	Function: async_close
+	Function: aio_close
 		Queues file closing.
 
 	Parameters:
 		aio - Handle to the file.
 
 */
-void async_close(ASYNCIO *aio);
+void aio_close(ASYNCIO *aio);
 
 /*
-	Function: async_wait
+	Function: aio_wait
 		Wait for the asynchronous operations to complete.
 
 	Parameters:
 		aio - Handle to the file.
 
 */
-void async_wait(ASYNCIO *aio);
+void aio_wait(ASYNCIO *aio);
 
 /*
-	Function: async_free
+	Function: aio_free
 		Frees the resources associated to the asynchronous file handle.
 
 	Parameters:
 		aio - Handle to the file.
 
 */
-void async_free(ASYNCIO *aio);
+void aio_free(ASYNCIO *aio);
 
 /* Group: Threads */
 

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -3444,10 +3444,6 @@ int main(int argc, const char **argv) // ignore_convention
 		}
 	}
 
-#if !defined(CONF_PLATFORM_MACOSX)
-	dbg_enable_threaded();
-#endif
-
 	if(secure_random_init() != 0)
 	{
 		dbg_msg("secure", "could not initialize secure RNG");

--- a/src/engine/server.h
+++ b/src/engine/server.h
@@ -180,6 +180,8 @@ public:
 	virtual void ResetNetErrorString(int ClientID) = 0;
 	virtual bool SetTimedOut(int ClientID, int OrigID) = 0;
 	virtual void SetTimeoutProtected(int ClientID) = 0;
+
+	virtual void SetErrorShutdown(const char *pReason) = 0;
 };
 
 class IGameServer : public IInterface

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -2684,10 +2684,6 @@ int main(int argc, const char **argv) // ignore_convention
 		}
 	}
 
-#if !defined(CONF_PLATFORM_MACOSX) && !defined(FUZZING)
-	dbg_enable_threaded();
-#endif
-
 	if(secure_random_init() != 0)
 	{
 		dbg_msg("secure", "could not initialize secure RNG");
@@ -2764,6 +2760,7 @@ int main(int argc, const char **argv) // ignore_convention
 
 	// free
 	delete pKernel;
+
 	return 0;
 }
 

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -334,6 +334,8 @@ CServer::CServer()
 	CSqlConnector::SetWriteServers(m_apSqlWriteServers);
 #endif
 
+	m_aErrorShutdownReason[0] = 0;
+
 	Init();
 }
 
@@ -1746,6 +1748,10 @@ int CServer::Run()
 	Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "server", aBuf);
 
 	GameServer()->OnInit();
+	if(ErrorShutdown())
+	{
+		return 1;
+	}
 	str_format(aBuf, sizeof(aBuf), "version %s", GameServer()->NetVersion());
 	Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "server", aBuf);
 
@@ -1808,6 +1814,10 @@ int CServer::Run()
 					m_ServerInfoFirstRequest = 0;
 					Kernel()->ReregisterInterface(GameServer());
 					GameServer()->OnInit();
+					if(ErrorShutdown())
+					{
+						break;
+					}
 					UpdateServerInfo();
 				}
 				else
@@ -1885,6 +1895,10 @@ int CServer::Run()
 				}
 
 				GameServer()->OnTick();
+				if(ErrorShutdown())
+				{
+					break;
+				}
 			}
 
 			// snap game
@@ -1942,11 +1956,16 @@ int CServer::Run()
 			}
 		}
 	}
+	const char *pDisconnectReason = "Server shutdown";
+	if(ErrorShutdown())
+	{
+		pDisconnectReason = m_aErrorShutdownReason;
+	}
 	// disconnect all clients on shutdown
 	for(int i = 0; i < MAX_CLIENTS; ++i)
 	{
 		if(m_aClients[i].m_State != CClient::STATE_EMPTY)
-			m_NetServer.Drop(i, "Server shutdown");
+			m_NetServer.Drop(i, pDisconnectReason);
 	}
 
 	m_Econ.Shutdown();
@@ -1962,17 +1981,17 @@ int CServer::Run()
 		mem_free(m_pCurrentMapData);
 
 #if defined (CONF_SQL)
-		for (int i = 0; i < MAX_SQLSERVERS; i++)
-		{
-			if (m_apSqlReadServers[i])
-				delete m_apSqlReadServers[i];
+	for (int i = 0; i < MAX_SQLSERVERS; i++)
+	{
+		if (m_apSqlReadServers[i])
+			delete m_apSqlReadServers[i];
 
-			if (m_apSqlWriteServers[i])
-				delete m_apSqlWriteServers[i];
-		}
+		if (m_apSqlWriteServers[i])
+			delete m_apSqlWriteServers[i];
+	}
 #endif
 
-	return 0;
+	return ErrorShutdown();
 }
 
 void CServer::ConTestingCommands(CConsole::IResult *pResult, void *pUser)
@@ -2812,12 +2831,13 @@ const char *CServer::GetAnnouncementLine(char const *pFileName)
 	return v[m_AnnouncementLastLine];
 }
 
-int* CServer::GetIdMap(int ClientID)
+int *CServer::GetIdMap(int ClientID)
 {
-	return (int*)(IdMap + VANILLA_MAX_CLIENTS * ClientID);
+	return (int *)(IdMap + VANILLA_MAX_CLIENTS * ClientID);
 }
 
-bool CServer::SetTimedOut(int ClientID, int OrigID) {
+bool CServer::SetTimedOut(int ClientID, int OrigID)
+{
 	if (!m_NetServer.SetTimedOut(ClientID, OrigID))
 	{
 		return false;
@@ -2825,4 +2845,9 @@ bool CServer::SetTimedOut(int ClientID, int OrigID) {
 	DelClientCallback(OrigID, "Timeout Protection used", this);
 	m_aClients[ClientID].m_Authed = IServer::AUTHED_NO;
 	return true;
+}
+
+void CServer::SetErrorShutdown(const char *pReason)
+{
+	str_copy(m_aErrorShutdownReason, pReason, sizeof(m_aErrorShutdownReason));
 }

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -209,6 +209,8 @@ public:
 	int64 m_ServerInfoFirstRequest;
 	int m_ServerInfoNumRequests;
 
+	char m_aErrorShutdownReason[128];
+
 	CServer();
 
 	int TrySetClientName(int ClientID, const char *pName);
@@ -353,6 +355,9 @@ public:
 	void ResetNetErrorString(int ClientID) { m_NetServer.ResetErrorString(ClientID); };
 	bool SetTimedOut(int ClientID, int OrigID);
 	void SetTimeoutProtected(int ClientID) { m_NetServer.SetTimeoutProtected(ClientID); };
+
+	bool ErrorShutdown() const { return m_aErrorShutdownReason[0] != 0; }
+	void SetErrorShutdown(const char *pReason);
 };
 
 #endif

--- a/src/engine/shared/engine.cpp
+++ b/src/engine/shared/engine.cpp
@@ -59,9 +59,7 @@ public:
 	{
 		if(!Silent)
 			dbg_logger_stdout();
-#if defined(CONF_FAMILY_WINDOWS)
 		dbg_logger_debugger();
-#endif
 
 		//
 		dbg_msg("engine", "running on %s-%s-%s", CONF_FAMILY_STRING, CONF_PLATFORM_STRING, CONF_ARCH_STRING);

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -104,7 +104,7 @@ void CGameContext::Clear()
 void CGameContext::TeeHistorianWrite(const void *pData, int DataSize, void *pUser)
 {
 	CGameContext *pSelf = (CGameContext *)pUser;
-	async_write(pSelf->m_pTeeHistorianFile, pData, DataSize);
+	aio_write(pSelf->m_pTeeHistorianFile, pData, DataSize);
 }
 
 void CGameContext::CommandCallback(int ClientID, int FlagMask, const char *pCmd, IConsole::IResult *pResult, void *pUser)
@@ -604,7 +604,7 @@ void CGameContext::OnTick()
 
 	if(m_TeeHistorianActive)
 	{
-		int Error = async_error(m_pTeeHistorianFile);
+		int Error = aio_error(m_pTeeHistorianFile);
 		if(Error)
 		{
 			dbg_msg("teehistorian", "error writing to file, err=%d", Error);
@@ -2589,7 +2589,7 @@ void CGameContext::OnInit(/*class IKernel *pKernel*/)
 		{
 			dbg_msg("teehistorian", "recording to '%s'", aFilename);
 		}
-		m_pTeeHistorianFile = async_new(File);
+		m_pTeeHistorianFile = aio_new(File);
 
 		char aVersion[128];
 #ifdef GIT_SHORTREV_HASH
@@ -2911,15 +2911,15 @@ void CGameContext::OnShutdown(bool FullShutdown)
 	if(m_TeeHistorianActive)
 	{
 		m_TeeHistorian.Finish();
-		async_close(m_pTeeHistorianFile);
-		async_wait(m_pTeeHistorianFile);
-		int Error = async_error(m_pTeeHistorianFile);
+		aio_close(m_pTeeHistorianFile);
+		aio_wait(m_pTeeHistorianFile);
+		int Error = aio_error(m_pTeeHistorianFile);
 		if(Error)
 		{
 			dbg_msg("teehistorian", "error closing file, err=%d", Error);
 			Server()->SetErrorShutdown("teehistorian close error");
 		}
-		async_free(m_pTeeHistorianFile);
+		aio_free(m_pTeeHistorianFile);
 	}
 
 	DeleteTempfile();

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -52,10 +52,13 @@ enum
 	NUM_TUNEZONES = 256
 };
 
+class IStorage;
+
 class CGameContext : public IGameServer
 {
 	IServer *m_pServer;
 	class IConsole *m_pConsole;
+	IStorage *m_pStorage;
 	CLayers m_Layers;
 	CCollision m_Collision;
 	CNetObjHandler m_NetObjHandler;
@@ -107,6 +110,7 @@ class CGameContext : public IGameServer
 public:
 	IServer *Server() const { return m_pServer; }
 	class IConsole *Console() { return m_pConsole; }
+	IStorage *Storage() { return m_pStorage; }
 	CCollision *Collision() { return &m_Collision; }
 	CTuningParams *Tuning() { return &m_Tuning; }
 	CTuningParams *TuningList() { return &m_aTuningList[0]; }

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -64,7 +64,7 @@ class CGameContext : public IGameServer
 
 	bool m_TeeHistorianActive;
 	CTeeHistorian m_TeeHistorian;
-	IOHANDLE m_TeeHistorianFile;
+	ASYNCIO *m_pTeeHistorianFile;
 	CUuid m_GameUuid;
 
 	static void CommandCallback(int ClientID, int FlagMask, const char *pCmd, IConsole::IResult *pResult, void *pUser);

--- a/src/test/async.cpp
+++ b/src/test/async.cpp
@@ -1,0 +1,89 @@
+#include <gtest/gtest.h>
+
+#include <base/system.h>
+
+class Async : public ::testing::Test
+{
+protected:
+	ASYNCIO *m_pAio;
+	char m_aFilename[64];
+	bool Delete;
+
+	Async()
+	{
+		const ::testing::TestInfo *pTestInfo =
+			::testing::UnitTest::GetInstance()->current_test_info();
+		const char *pTestName = pTestInfo->name();
+
+		str_format(m_aFilename, sizeof(m_aFilename), "Async.%s-%d.tmp", pTestName, pid());
+		m_pAio = async_new(io_open(m_aFilename, IOFLAG_WRITE));
+		Delete = false;
+	}
+
+	~Async()
+	{
+		if(Delete)
+		{
+			fs_remove(m_aFilename);
+		}
+	}
+
+	void Write(const char *pText)
+	{
+		async_write(m_pAio, pText, str_length(pText));
+	}
+
+	void Expect(const char *pOutput)
+	{
+		async_close(m_pAio);
+		async_wait(m_pAio);
+		async_free(m_pAio);
+
+		char aBuf[64 * 1024];
+		IOHANDLE File = io_open(m_aFilename, IOFLAG_READ);
+		int Read = io_read(File, aBuf, sizeof(aBuf));
+
+		ASSERT_EQ(str_length(pOutput), Read);
+		ASSERT_TRUE(mem_comp(aBuf, pOutput, Read) == 0);
+		Delete = true;
+	}
+};
+
+TEST_F(Async, Empty)
+{
+	Expect("");
+}
+
+TEST_F(Async, Simple)
+{
+	static const char TEXT[] = "a\n";
+	Write(TEXT);
+	Expect(TEXT);
+}
+
+TEST_F(Async, Long)
+{
+	char aText[32 * 1024 + 1];
+	for(unsigned i = 0; i < sizeof(aText) - 1; i++)
+	{
+		aText[i] = 'a';
+	}
+	aText[sizeof(aText) - 1] = 0;
+	Write(aText);
+	Expect(aText);
+}
+
+TEST_F(Async, Pieces)
+{
+	char aText[64 * 1024 + 1];
+	for(unsigned i = 0; i < sizeof(aText) - 1; i++)
+	{
+		aText[i] = 'a';
+	}
+	aText[sizeof(aText) - 1] = 0;
+	for(unsigned i = 0; i < sizeof(aText) - 1; i++)
+	{
+		Write("a");
+	}
+	Expect(aText);
+}

--- a/src/test/async.cpp
+++ b/src/test/async.cpp
@@ -87,3 +87,19 @@ TEST_F(Async, Pieces)
 	}
 	Expect(aText);
 }
+
+TEST_F(Async, Mixed)
+{
+	char aText[64 * 1024 + 1];
+	for(unsigned i = 0; i < sizeof(aText) - 1; i++)
+	{
+		aText[i] = 'a' + i % 26;
+	}
+	aText[sizeof(aText) - 1] = 0;
+	for(unsigned i = 0; i < sizeof(aText) - 1; i++)
+	{
+		char w = 'a' + i % 26;
+		async_write(m_pAio, &w, 1);
+	}
+	Expect(aText);
+}

--- a/src/test/thread.cpp
+++ b/src/test/thread.cpp
@@ -1,0 +1,81 @@
+#include <gtest/gtest.h>
+
+#include <base/system.h>
+
+static void Nothing(void *pUser)
+{
+	(void)pUser;
+}
+
+TEST(Thread, Detach)
+{
+	void *pThread = thread_init(Nothing, 0);
+	thread_detach(pThread);
+}
+
+static void SetToOne(void *pUser)
+{
+	*(int *)pUser = 1;
+}
+
+TEST(Thread, Wait)
+{
+	int Integer = 0;
+	void *pThread = thread_init(SetToOne, &Integer);
+	thread_wait(pThread);
+	EXPECT_EQ(Integer, 1);
+}
+
+TEST(Thread, Yield)
+{
+	thread_yield();
+}
+
+TEST(Thread, Semaphore)
+{
+	SEMAPHORE Semaphore;
+	sphore_init(&Semaphore);
+	sphore_destroy(&Semaphore);
+}
+
+TEST(Thread, SemaphoreSingleThreaded)
+{
+	SEMAPHORE Semaphore;
+	sphore_init(&Semaphore);
+	sphore_signal(&Semaphore);
+	sphore_signal(&Semaphore);
+	sphore_wait(&Semaphore);
+	sphore_wait(&Semaphore);
+	sphore_destroy(&Semaphore);
+}
+
+static void SemaphoreThread(void *pUser)
+{
+	SEMAPHORE *pSemaphore = (SEMAPHORE *)pUser;
+	sphore_wait(pSemaphore);
+}
+
+TEST(Thread, SemaphoreMultiThreaded)
+{
+	SEMAPHORE Semaphore;
+	sphore_init(&Semaphore);
+	sphore_signal(&Semaphore);
+	void *pThread = thread_init(SemaphoreThread, &Semaphore);
+	thread_wait(pThread);
+	sphore_destroy(&Semaphore);
+}
+
+static void LockThread(void *pUser)
+{
+	LOCK *pLock = (LOCK *)pUser;
+	lock_wait(*pLock);
+	lock_unlock(*pLock);
+}
+
+TEST(Thread, Lock)
+{
+	LOCK Lock = lock_create();
+	void *pThread = thread_init(LockThread, &Lock);
+	lock_unlock(Lock);
+	thread_wait(pThread);
+}


### PR DESCRIPTION
The asynchronous output uses a writer thread for every file; the buffer is kept in a dynamically growing queue that is thread-safe due to the use of locks.