### PR TITLE
teehistorian: Hide chat from teehistorian

### DIFF
--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -1101,7 +1101,10 @@ void CGameContext::OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID)
 
 	if(m_TeeHistorianActive)
 	{
-		m_TeeHistorian.RecordPlayerMessage(ClientID, pUnpacker->CompleteData(), pUnpacker->CompleteSize());
+		if(m_NetObjHandler.TeeHistorianRecordMsg(MsgID)
+		{
+			m_TeeHistorian.RecordPlayerMessage(ClientID, pUnpacker->CompleteData(), pUnpacker->CompleteSize());
+		}
 	}
 
 	if(!pRawMsg)


### PR DESCRIPTION
There was a missing check that allowed chat messages to be written to
disk.