### PR TITLE
Fix a heap-use-after-free

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -3639,6 +3639,12 @@ void CClient::RequestDDNetInfo()
 		str_append(aUrl, aEscaped, sizeof(aUrl));
 	}
 
+	if(m_pDDNetInfoTask)
+	{
+		m_pDDNetInfoTask->Abort();
+		m_pDDNetInfoTask->Destroy();
+	}
+
 	m_pDDNetInfoTask = Fetcher()->FetchFile(aUrl, "ddnet-info.json.tmp", IStorage::TYPE_SAVE, true, true);
 }
 

--- a/src/engine/client/fetcher.cpp
+++ b/src/engine/client/fetcher.cpp
@@ -49,7 +49,7 @@ public:
 
 void CFetchTask::Destroy()
 {
-	if(m_State >= IFetchTask::STATE_DONE || m_State == IFetchTask::STATE_ERROR)
+	if(m_Job.Status() == CJob::STATE_DONE)
 	{
 		delete this;
 	}
@@ -87,6 +87,8 @@ IFetchTask *CFetcher::FetchFile(const char *pUrl, const char *pDest, int Storage
 	pTask->m_pUser = pUser;
 	pTask->m_pfnCompCallback = pfnCompCb;
 	pTask->m_pfnProgressCallback = pfnProgCb;
+	pTask->m_UseDDNetCA = UseDDNetCA;
+	pTask->m_CanTimeout = CanTimeout;
 
 	pTask->m_Abort = false;
 	pTask->m_Destroy = false;


### PR DESCRIPTION
This still has a heap-use-after-free but I couldn't really figure out how to get rid of that one without making lots of changes.

The `CJob` being a part of `CFetchTask` turned out to be a problem as if I free the `CFetchTask` the job result can no longer be written. If `Destroy()` is called after the job is done the free works as expected, otherwise we are either leaking memory, or using after free.