### PR TITLE
MinGW putenv workaround

### DIFF
--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -38,6 +38,13 @@
 #include "graphics_threaded.h"
 #include "backend_sdl.h"
 
+#ifdef __MINGW32__
+extern "C"
+{
+	int putenv(const char *);
+}
+#endif
+
 // ------------ CGraphicsBackend_Threaded
 
 void CGraphicsBackend_Threaded::ThreadFunc(void *pUser)


### PR DESCRIPTION
Seems like putenv is not defined in mingw. (i couldn't compile the client without this, with mingw)

Heinrich prefers a better version so maybe don't merge yet.