### PR TITLE
Add Speedup tiles correctly at the border creation & remove tile layer extension restriction & fix the LastIndex buffer initlialization & setup non mipmap textures up correctly(texture completness)

### DIFF
--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -760,7 +760,8 @@ void CCommandProcessorFragment_OpenGL3_3::Cmd_Init(const SCommand_Init *pCommand
 	{
 		m_TextureSlotBoundToUnit[i].m_TextureSlot = -1;
 	}
-	
+
+	glBindVertexArray(0);
 	glGenBuffers(1, &m_QuadDrawIndexBufferID);
 	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_QuadDrawIndexBufferID);
 	m_LastIndexBufferBound = 0;
@@ -1158,6 +1159,11 @@ void CCommandProcessorFragment_OpenGL3_3::AppendIndices(unsigned int NewIndicesC
 	
 	glDeleteBuffers(1, &m_QuadDrawIndexBufferID);	
 	m_QuadDrawIndexBufferID = NewIndexBufferID;
+
+	m_LastIndexBufferBound = 0;
+	for (size_t i = 0; i < m_VisualObjects.size(); ++i) {
+		m_VisualObjects[i].m_LastIndexBufferBound = 0;
+	}
 	
 	m_CurrentIndicesInBuffer = NewIndicesCount;
 	delete[] Indices;	

--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -264,9 +264,9 @@ void CCommandProcessorFragment_OpenGL::Cmd_Texture_Create(const CCommandBuffer::
 	if(pCommand->m_Format == CCommandBuffer::TEXFORMAT_RGBA || pCommand->m_Format == CCommandBuffer::TEXFORMAT_RGB)
 	{
 		static int s_MaxTexSize = -1;
-		if(MaxTexSize == -1)
-			glGetIntegerv(GL_MAX_TEXTURE_SIZE, &MaxTexSize);
-		if(Width > MaxTexSize || Height > MaxTexSize)
+		if(s_MaxTexSize == -1)
+			glGetIntegerv(GL_MAX_TEXTURE_SIZE, &s_MaxTexSize);
+		if(Width > s_MaxTexSize || Height > s_MaxTexSize)
 		{
 			do
 			{

--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -263,7 +263,7 @@ void CCommandProcessorFragment_OpenGL::Cmd_Texture_Create(const CCommandBuffer::
 	// resample if needed
 	if(pCommand->m_Format == CCommandBuffer::TEXFORMAT_RGBA || pCommand->m_Format == CCommandBuffer::TEXFORMAT_RGB)
 	{
-		static int MaxTexSize = -1;
+		static int s_MaxTexSize = -1;
 		if(MaxTexSize == -1)
 			glGetIntegerv(GL_MAX_TEXTURE_SIZE, &MaxTexSize);
 		if(Width > MaxTexSize || Height > MaxTexSize)
@@ -1164,7 +1164,8 @@ void CCommandProcessorFragment_OpenGL3_3::AppendIndices(unsigned int NewIndicesC
 	m_QuadDrawIndexBufferID = NewIndexBufferID;
 
 	m_LastIndexBufferBound = 0;
-	for (size_t i = 0; i < m_VisualObjects.size(); ++i) {
+	for (size_t i = 0; i < m_VisualObjects.size(); ++i)
+	{
 		m_VisualObjects[i].m_LastIndexBufferBound = 0;
 	}
 	

--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -273,7 +273,7 @@ void CCommandProcessorFragment_OpenGL::Cmd_Texture_Create(const CCommandBuffer::
 				Width>>=1;
 				Height>>=1;
 			}
-			while(Width > MaxTexSize || Height > MaxTexSize);
+			while(Width > s_MaxTexSize || Height > s_MaxTexSize);
 
 			void *pTmpData = Rescale(pCommand->m_Width, pCommand->m_Height, Width, Height, pCommand->m_Format, static_cast<const unsigned char *>(pCommand->m_pData));
 			mem_free(pTexData);

--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -763,7 +763,7 @@ void CCommandProcessorFragment_OpenGL3_3::Cmd_Init(const SCommand_Init *pCommand
 
 	glBindVertexArray(0);
 	glGenBuffers(1, &m_QuadDrawIndexBufferID);
-	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_QuadDrawIndexBufferID);
+	glBindBuffer(GL_COPY_WRITE_BUFFER, m_QuadDrawIndexBufferID);
 	m_LastIndexBufferBound = 0;
 	
 	unsigned int Indices[CCommandBuffer::MAX_VERTICES/4 * 6];
@@ -778,7 +778,7 @@ void CCommandProcessorFragment_OpenGL3_3::Cmd_Init(const SCommand_Init *pCommand
 		Indices[i+5] = Primq + 3;
 		Primq+=4;
 	}
-	glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(unsigned int) * CCommandBuffer::MAX_VERTICES/4 * 6, Indices, GL_STATIC_DRAW);
+	glBufferData(GL_COPY_WRITE_BUFFER, sizeof(unsigned int) * CCommandBuffer::MAX_VERTICES/4 * 6, Indices, GL_STATIC_DRAW);
 	
 	m_CurrentIndicesInBuffer = CCommandBuffer::MAX_VERTICES/4 * 6;
 	

--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -763,7 +763,7 @@ void CCommandProcessorFragment_OpenGL3_3::Cmd_Init(const SCommand_Init *pCommand
 	
 	glGenBuffers(1, &m_QuadDrawIndexBufferID);
 	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_QuadDrawIndexBufferID);
-	m_LastIndexBufferBound = m_QuadDrawIndexBufferID;
+	m_LastIndexBufferBound = 0;
 	
 	unsigned int Indices[CCommandBuffer::MAX_VERTICES/4 * 6];
 	int Primq = 0;
@@ -927,6 +927,8 @@ void CCommandProcessorFragment_OpenGL3_3::Cmd_Texture_Create(const CCommandBuffe
 	
 	if(pCommand->m_Flags&CCommandBuffer::TEXFLAG_NOMIPMAPS)
 	{
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 		glSamplerParameteri(m_aTextures[pCommand->m_Slot].m_Sampler, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 		glSamplerParameteri(m_aTextures[pCommand->m_Slot].m_Sampler, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 		glTexImage2D(GL_TEXTURE_2D, 0, StoreOglformat, Width, Height, 0, Oglformat, GL_UNSIGNED_BYTE, pTexData);

--- a/src/engine/client/backend_sdl.h
+++ b/src/engine/client/backend_sdl.h
@@ -156,6 +156,7 @@ class CCommandProcessorFragment_OpenGL3_3
 	unsigned int m_CurrentIndicesInBuffer;
 	
 	GLint m_MaxTextureUnits;
+	GLint m_MaxTexSize;
 	
 	int m_LastBlendMode; //avoid all possible opengl state changes
 	bool m_LastClipEnable;

--- a/src/game/client/components/maplayers.cpp
+++ b/src/game/client/components/maplayers.cpp
@@ -636,14 +636,12 @@ void CMapLayers::OnMapLoad()
 								Visuals.m_TilesOfLayer[y][x].m_IndexBufferByteOffset = (char*)(TilesHandledCount*6*sizeof(unsigned int));
 								Visuals.m_TilesOfLayer[y][x].m_TilesHandledCount = tmpTiles.size();
 									
-								if(IsSpeedupLayer && CurOverlay == 0)
-								{
-									if(AddTile(tmpTiles, tmpTileTexCoords, Index, Flags, x, y, pGroup, DoTextureCoords, true, AngleRotate))
-										Visuals.m_TilesOfLayer[y][x].m_Draw = true;
-								}
-								else
-									if(AddTile(tmpTiles, tmpTileTexCoords, Index, Flags, x, y, pGroup, DoTextureCoords))
-										Visuals.m_TilesOfLayer[y][x].m_Draw = true;
+								bool AddAsSpeedup = false;
+								if (IsSpeedupLayer && CurOverlay == 0)
+									AddAsSpeedup = true;
+
+								if(AddTile(tmpTiles, tmpTileTexCoords, Index, Flags, x, y, pGroup, DoTextureCoords, AddAsSpeedup, AngleRotate))
+									Visuals.m_TilesOfLayer[y][x].m_Draw = true;
 								
 								//do the border tiles
 								if(x == 0)
@@ -651,19 +649,19 @@ void CMapLayers::OnMapLoad()
 									if(y == 0)
 									{
 										Visuals.m_BorderTopLeft.m_IndexBufferByteOffset = (char*)(tmpBorderCorners.size()*6*sizeof(unsigned int));
-										if(AddTile(tmpBorderCorners, tmpBorderCornersTexCoords, Index, Flags, x, y, pGroup, DoTextureCoords))
+										if(AddTile(tmpBorderCorners, tmpBorderCornersTexCoords, Index, Flags, x, y, pGroup, DoTextureCoords, AddAsSpeedup, AngleRotate))
 											Visuals.m_BorderTopLeft.m_Draw = true;
 									} else if(y == pTMap->m_Height - 1)
 									{
 										Visuals.m_BorderBottomLeft.m_IndexBufferByteOffset = (char*)(tmpBorderCorners.size()*6*sizeof(unsigned int));
-										if(AddTile(tmpBorderCorners, tmpBorderCornersTexCoords, Index, Flags, x, y, pGroup, DoTextureCoords))
+										if(AddTile(tmpBorderCorners, tmpBorderCornersTexCoords, Index, Flags, x, y, pGroup, DoTextureCoords, AddAsSpeedup, AngleRotate))
 											Visuals.m_BorderBottomLeft.m_Draw = true;
 											
 									} else 
 									{
 										Visuals.m_BorderLeft[y-1].m_IndexBufferByteOffset = (char*)(tmpBorderLeftTiles.size()*6*sizeof(unsigned int));
 										Visuals.m_BorderLeft[y-1].m_TilesHandledCount = tmpBorderLeftTiles.size();
-										if(AddTile(tmpBorderLeftTiles, tmpBorderLeftTilesTexCoords, Index, Flags, x, y, pGroup, DoTextureCoords))
+										if(AddTile(tmpBorderLeftTiles, tmpBorderLeftTilesTexCoords, Index, Flags, x, y, pGroup, DoTextureCoords, AddAsSpeedup, AngleRotate))
 											Visuals.m_BorderLeft[y-1].m_Draw = true;
 									}
 								} else if(x == pTMap->m_Width - 1)
@@ -671,20 +669,20 @@ void CMapLayers::OnMapLoad()
 									if(y == 0)
 									{
 										Visuals.m_BorderTopRight.m_IndexBufferByteOffset = (char*)(tmpBorderCorners.size()*6*sizeof(unsigned int));
-										if(AddTile(tmpBorderCorners, tmpBorderCornersTexCoords, Index, Flags, x, y, pGroup, DoTextureCoords))
+										if(AddTile(tmpBorderCorners, tmpBorderCornersTexCoords, Index, Flags, x, y, pGroup, DoTextureCoords, AddAsSpeedup, AngleRotate))
 											Visuals.m_BorderTopRight.m_Draw = true;
 											
 									} else if(y == pTMap->m_Height - 1)
 									{
 										Visuals.m_BorderBottomRight.m_IndexBufferByteOffset = (char*)(tmpBorderCorners.size()*6*sizeof(unsigned int));
-										if(AddTile(tmpBorderCorners, tmpBorderCornersTexCoords, Index, Flags, x, y, pGroup, DoTextureCoords))
+										if(AddTile(tmpBorderCorners, tmpBorderCornersTexCoords, Index, Flags, x, y, pGroup, DoTextureCoords, AddAsSpeedup, AngleRotate))
 											Visuals.m_BorderBottomRight.m_Draw = true;
 											
 									} else
 									{
 										Visuals.m_BorderRight[y-1].m_IndexBufferByteOffset = (char*)(tmpBorderRightTiles.size()*6*sizeof(unsigned int));
 										Visuals.m_BorderRight[y-1].m_TilesHandledCount = tmpBorderRightTiles.size();
-										if(AddTile(tmpBorderRightTiles, tmpBorderRightTilesTexCoords, Index, Flags, x, y, pGroup, DoTextureCoords))
+										if(AddTile(tmpBorderRightTiles, tmpBorderRightTilesTexCoords, Index, Flags, x, y, pGroup, DoTextureCoords, AddAsSpeedup, AngleRotate))
 											Visuals.m_BorderRight[y-1].m_Draw = true;
 									}
 								} else if(y == 0)
@@ -693,7 +691,7 @@ void CMapLayers::OnMapLoad()
 									{
 										Visuals.m_BorderTop[x-1].m_IndexBufferByteOffset = (char*)(tmpBorderTopTiles.size()*6*sizeof(unsigned int));
 										Visuals.m_BorderTop[x-1].m_TilesHandledCount = tmpBorderTopTiles.size();
-										if(AddTile(tmpBorderTopTiles, tmpBorderTopTilesTexCoords, Index, Flags, x, y, pGroup, DoTextureCoords))
+										if(AddTile(tmpBorderTopTiles, tmpBorderTopTilesTexCoords, Index, Flags, x, y, pGroup, DoTextureCoords, AddAsSpeedup, AngleRotate))
 											Visuals.m_BorderTop[x-1].m_Draw = true;
 									}
 								} else if(y == pTMap->m_Height - 1)
@@ -702,7 +700,7 @@ void CMapLayers::OnMapLoad()
 									{
 										Visuals.m_BorderBottom[x-1].m_IndexBufferByteOffset = (char*)(tmpBorderBottomTiles.size()*6*sizeof(unsigned int));
 										Visuals.m_BorderBottom[x-1].m_TilesHandledCount = tmpBorderBottomTiles.size();
-										if(AddTile(tmpBorderBottomTiles, tmpBorderBottomTilesTexCoords, Index, Flags, x, y, pGroup, DoTextureCoords))
+										if(AddTile(tmpBorderBottomTiles, tmpBorderBottomTilesTexCoords, Index, Flags, x, y, pGroup, DoTextureCoords, AddAsSpeedup, AngleRotate))
 											Visuals.m_BorderBottom[x-1].m_Draw = true;
 									}
 								}

--- a/src/game/client/components/maplayers.cpp
+++ b/src/game/client/components/maplayers.cpp
@@ -884,11 +884,6 @@ void CMapLayers::DrawTileBorder(int LayerIndex, vec4* pColor, CMapItemLayerTilem
 {
 	STileLayerVisuals& Visuals = *m_TileLayerVisuals[LayerIndex];
 	
-	if(BorderX0 < -300 + pGroup->m_OffsetX/32) BorderX0 = -300 + pGroup->m_OffsetX/32;
-	if(BorderY0 < -300 + pGroup->m_OffsetY/32) BorderY0 = -300 + pGroup->m_OffsetY/32;
-	if(BorderX1 >= pTileLayer->m_Width + 300 + pGroup->m_OffsetX/32) BorderX1 = pTileLayer->m_Width + 299 + pGroup->m_OffsetX/32;
-	if(BorderY1 >= pTileLayer->m_Height + 300 + pGroup->m_OffsetY/32) BorderY1 = pTileLayer->m_Height + 299 + pGroup->m_OffsetY/32;	
-	
 	int Y0 = BorderY0;
 	int X0 = BorderX0;
 	int Y1 = BorderY1;


### PR DESCRIPTION
Allows speedups to be drawn on extended range(out of map range) too.