### PR TITLE
Don't use Brew on Travis anymore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ addons:
     - libgtest-dev
     - libsdl2-dev
 script:
-- if [ "$TRAVIS_OS_NAME" = "osx" ]; then CMAKE_EXTRA_ARGS="-DDOWNLOAD_GTEST=ON"; brew update; brew install sdl2; fi
+- if [ "$TRAVIS_OS_NAME" = "osx" ]; then CMAKE_EXTRA_ARGS="-DDOWNLOAD_GTEST=ON"; fi
 - if [ "$TRAVIS_OS_NAME" != "osx" ]; then CMAKE_EXTRA_ARGS="-DGTEST_LIBRARY=../gtest_build/libgtest.a -DGTEST_MAIN_LIBRARY=../gtest_build/libgtest_main.a"; mkdir gtest_build; cmake -E chdir gtest_build cmake /usr/src/gtest; cmake --build gtest_build; fi
 - mkdir build; cd build
 - cmake -Werror=dev $CMAKE_EXTRA_ARGS ..


### PR DESCRIPTION
We now ship SDL2 via ddnet-libs, it's not needed anymore. Fixes #893.