### PR TITLE
Add manual locking to `ASYNCIO` for transacted writes

### DIFF
--- a/src/base/system.h
+++ b/src/base/system.h
@@ -383,6 +383,26 @@ typedef struct ASYNCIO ASYNCIO;
 ASYNCIO *aio_new(IOHANDLE io);
 
 /*
+	Function: aio_lock
+		Locks the ASYNCIO structure so it can't be written into by
+		other threads.
+
+	Parameters:
+		aio - Handle to the file.
+*/
+void aio_lock(ASYNCIO *aio);
+
+/*
+	Function: aio_unlock
+		Unlocks the ASYNCIO structure after finishing the contiguous
+		write.
+
+	Parameters:
+		aio - Handle to the file.
+*/
+void aio_unlock(ASYNCIO *aio);
+
+/*
 	Function: aio_write
 		Queues a chunk of data for writing.
 
@@ -403,6 +423,30 @@ void aio_write(ASYNCIO *aio, const void *buffer, unsigned size);
 
 */
 void aio_write_newline(ASYNCIO *aio);
+
+/*
+	Function: aio_write_unlocked
+		Queues a chunk of data for writing. The ASYNCIO struct must be
+		locked using `aio_lock` first.
+
+	Parameters:
+		aio - Handle to the file.
+		buffer - Pointer to the data that should be written.
+		size - Number of bytes to write.
+
+*/
+void aio_write_unlocked(ASYNCIO *aio, const void *buffer, unsigned size);
+
+/*
+	Function: aio_write_newline_unlocked
+		Queues a newline for writing. The ASYNCIO struct must be locked
+		using `aio_lock` first.
+
+	Parameters:
+		aio - Handle to the file.
+
+*/
+void aio_write_newline_unlocked(ASYNCIO *aio);
 
 /*
 	Function: aio_error

--- a/src/test/aio.cpp
+++ b/src/test/aio.cpp
@@ -122,3 +122,25 @@ TEST_F(Async, NonDivisor)
 	}
 	Expect(aText);
 }
+
+TEST_F(Async, Transaction)
+{
+	static const int NUM_LETTERS = 13;
+	static const int SIZE = BUF_SIZE / NUM_LETTERS * NUM_LETTERS;
+	char aText[SIZE + 1];
+	for(unsigned i = 0; i < sizeof(aText) - 1; i++)
+	{
+		aText[i] = 'a' + i % NUM_LETTERS;
+	}
+	aText[sizeof(aText) - 1] = 0;
+	for(unsigned i = 0; i < (sizeof(aText) - 1) / NUM_LETTERS; i++)
+	{
+		aio_lock(m_pAio);
+		for(char c = 'a'; c < 'a' + NUM_LETTERS; c++)
+		{
+			aio_write_unlocked(m_pAio, &c, 1);
+		}
+		aio_unlock(m_pAio);
+	}
+	Expect(aText);
+}


### PR DESCRIPTION
Previously, e. g. it was possible that newlines are separated from the
printed line in `logger_file`.