### PR TITLE
Initialize m_LastLoad in constructor and reset it when a new map is loaded

### DIFF
--- a/src/game/client/components/background.cpp
+++ b/src/game/client/components/background.cpp
@@ -63,7 +63,7 @@ void CBackground::LoadBackground()
 	else if(str_comp(g_Config.m_ClBackgroundEntities, CURRENT) == 0)
 	{
 		m_pMap = Kernel()->RequestInterface<IEngineMap>();
-		if (m_pMap->IsLoaded())
+		if(m_pMap->IsLoaded())
 		{
 			m_pLayers = GameClient()->Layers();
 			m_pImages = GameClient()->m_pMapimages;
@@ -79,7 +79,7 @@ void CBackground::LoadBackground()
 
 void CBackground::OnMapLoad()
 {
-	if (str_comp(g_Config.m_ClBackgroundEntities, CURRENT) == 0 || str_comp(g_Config.m_ClBackgroundEntities, m_aMapName))
+	if(str_comp(g_Config.m_ClBackgroundEntities, CURRENT) == 0 || str_comp(g_Config.m_ClBackgroundEntities, m_aMapName))
 	{
 		m_LastLoad = 0;
 		LoadBackground();

--- a/src/game/client/components/background.cpp
+++ b/src/game/client/components/background.cpp
@@ -20,6 +20,7 @@ CBackground::CBackground() : CMapLayers(CMapLayers::TYPE_BACKGROUND_FORCE)
 	m_pBackgroundMap = m_pMap;
 	m_Loaded = false;
 	m_aMapName[0] = '\0';
+	m_LastLoad = 0;
 }
 
 CBackground::~CBackground()
@@ -62,9 +63,12 @@ void CBackground::LoadBackground()
 	else if(str_comp(g_Config.m_ClBackgroundEntities, CURRENT) == 0)
 	{
 		m_pMap = Kernel()->RequestInterface<IEngineMap>();
-		m_pLayers = GameClient()->Layers();
-		m_pImages = GameClient()->m_pMapimages;
-		m_Loaded = true;
+		if (m_pMap->IsLoaded())
+		{
+			m_pLayers = GameClient()->Layers();
+			m_pImages = GameClient()->m_pMapimages;
+			m_Loaded = true;
+		}
 	}
 	
 	if(m_Loaded) 
@@ -75,8 +79,11 @@ void CBackground::LoadBackground()
 
 void CBackground::OnMapLoad()
 {
-	if(str_comp(g_Config.m_ClBackgroundEntities, CURRENT) == 0 || str_comp(g_Config.m_ClBackgroundEntities, m_aMapName))
+	if (str_comp(g_Config.m_ClBackgroundEntities, CURRENT) == 0 || str_comp(g_Config.m_ClBackgroundEntities, m_aMapName))
+	{
+		m_LastLoad = 0;
 		LoadBackground();
+	}
 }
 
 void CBackground::OnRender()


### PR DESCRIPTION
Currently the LastLoad variable might block the map(especially when the %current% is used) to be loaded, when you join a server.
That led to try rendering a non initialized map.
Also now it's checked if a map for %current% even is loaded.