### PR TITLE
Use a longer bors timeout

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -3,3 +3,4 @@ status = [
   "continuous-integration/appveyor/branch",
   "continuous-integration/travis-ci/push",
 ]
+timeout_sec = 10800 # macOS on Travis CI has long waiting times


### PR DESCRIPTION
This will hopefully allow the macOS system on Travis CI to finish.