### PR TITLE
Treat checkpoint teleporters the same independent of the number

### DIFF
--- a/src/game/collision.cpp
+++ b/src/game/collision.cpp
@@ -502,7 +502,7 @@ int CCollision::IsCheckTeleport(int Index)
 		return 0;
 
 	if(m_pTele[Index].m_Type == TILE_TELECHECKIN)
-		return m_pTele[Index].m_Number;
+		return 1;
 
 	return 0;
 }
@@ -515,7 +515,7 @@ int CCollision::IsCheckEvilTeleport(int Index)
 		return 0;
 
 	if(m_pTele[Index].m_Type == TILE_TELECHECKINEVIL)
-		return m_pTele[Index].m_Number;
+		return 1;
 
 	return 0;
 }


### PR DESCRIPTION
Previously, checkpoint teleporters with a number of 0 were displayed but
not effective.