### PR TITLE
Add feature to disable votes when a mod joins

### DIFF
--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -221,6 +221,7 @@ MACRO_CONFIG_INT(SvVoteYesPercentage, sv_vote_yes_percentage, 50, 1, 100, CFGFLA
 MACRO_CONFIG_INT(SvVoteMajority, sv_vote_majority, 0, 0, 1, CFGFLAG_SERVER, "Whether No. of Yes is compared to No. of No votes or to number of total Players ( Default is 0 Y compare N)")
 MACRO_CONFIG_INT(SvVoteMaxTotal, sv_vote_max_total, 0, 0, MAX_CLIENTS, CFGFLAG_SERVER, "How many people can participate in a vote at max (0 = no limit by default)")
 MACRO_CONFIG_INT(SvVoteVetoTime, sv_vote_veto_time, 20, 0, 1000, CFGFLAG_SERVER, "Minutes of time on a server until a player can veto map change votes (0 = disabled)")
+MACRO_CONFIG_INT(SvVoteKickModerated, sv_vote_kick_moderated, 0, 0, 1, CFGFLAG_SERVER, "Disable voting when a moderator is on the server")
 MACRO_CONFIG_INT(SvSpectatorVotes, sv_spectator_votes, 1, 0, 1, CFGFLAG_SERVER, "Choose if spectators are allowed to start votes")
 MACRO_CONFIG_INT(SvKillDelay, sv_kill_delay, 1, 0, 9999, CFGFLAG_SERVER, "The minimum time in seconds between kills")
 MACRO_CONFIG_INT(SvSuicidePenalty, sv_suicide_penalty, 0, 0, 9999, CFGFLAG_SERVER, "The minimum time in seconds between kill or /kills and respawn")

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -1378,6 +1378,18 @@ void CGameContext::OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID)
 					return;
 				}
 
+				if(g_Config.m_SvVoteKickModerated)
+				{
+					for(int i = 0; i < MAX_CLIENTS; i++)
+					{
+						if(m_apPlayers[i]->m_Authed > IServer::AUTHED_HELPER && !m_apPlayers[i]->m_Afk)
+						{
+							SendChatTarget(ClientID, "Can't vote kick while there is a moderator on the server");
+							return;
+						}
+					}
+				}
+
 				if(g_Config.m_SvVoteKickMin)
 				{
 					int PlayerNum = 0;


### PR DESCRIPTION
Disables kick votes when a non afk moderator is on.

Requested by @snailx3 on discord.
  