### PR TITLE
Active moderator mode

### DIFF
--- a/autoexec_server.cfg
+++ b/autoexec_server.cfg
@@ -181,6 +181,7 @@ access_level bans 1
 access_level bans_save 1
 access_level kick 1
 access_level force_vote 1
+access_level moderate 1
 
 
 

--- a/src/game/ddracecommands.h
+++ b/src/game/ddracecommands.h
@@ -47,6 +47,7 @@ CONSOLE_COMMAND("muteid", "v[id] i[seconds]", CFGFLAG_SERVER, ConMuteID, this, "
 CONSOLE_COMMAND("muteip", "s[ip] i[seconds]", CFGFLAG_SERVER, ConMuteIP, this, "");
 CONSOLE_COMMAND("unmute", "v[id]", CFGFLAG_SERVER, ConUnmute, this, "");
 CONSOLE_COMMAND("mutes", "", CFGFLAG_SERVER, ConMutes, this, "");
+CONSOLE_COMMAND("moderate", "", CFGFLAG_SERVER, ConModerate, this, "Enables/disables active moderator mode for the player")
 
 CONSOLE_COMMAND("freezehammer", "v[id]", CFGFLAG_SERVER|CMDFLAG_TEST, ConFreezeHammer, this, "Gives a player Freeze Hammer")
 CONSOLE_COMMAND("unfreezehammer", "v[id]", CFGFLAG_SERVER|CMDFLAG_TEST, ConUnFreezeHammer, this, "Removes Freeze Hammer from a player")

--- a/src/game/server/ddracecommands.cpp
+++ b/src/game/server/ddracecommands.cpp
@@ -461,6 +461,34 @@ void CGameContext::ConMutes(IConsole::IResult *pResult, void *pUserData)
 	}
 }
 
+void CGameContext::ConModerate(IConsole::IResult *pResult, void *pUserData)
+{
+	CGameContext *pSelf = (CGameContext *)pUserData;
+	if (!CheckClientID(pResult->m_ClientID))
+		return;
+
+	bool HadModerator = pSelf->PlayerModerating();
+
+	CPlayer* player = pSelf->m_apPlayers[pResult->m_ClientID];
+	player->m_Moderating = !player->m_Moderating;
+	
+	char aBuf[256];
+
+	if(!HadModerator && player->m_Moderating)
+		str_format(aBuf, sizeof(aBuf), "Server kick/spec votes will now be actively moderated.");
+
+	if (!pSelf->PlayerModerating())
+		str_format(aBuf, sizeof(aBuf), "Server kick/spec votes are no longer actively moderated.");
+
+	pSelf->SendChat(-1, CHAT_ALL, aBuf, 0);
+	
+	if(player->m_Moderating)
+		pSelf->SendChatTarget(pResult->m_ClientID,
+			"Active moderator mode enabled for you.");
+	else
+		pSelf->SendChatTarget(pResult->m_ClientID, "Active moderator mode disabled for you.");
+}
+
 void CGameContext::ConList(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -245,6 +245,8 @@ public:
 	int GetClientVersion(int ClientID);
 	void SetClientVersion(int ClientID, int Version);
 	bool PlayerExists(int ClientID) { return m_apPlayers[ClientID]; };
+	// Returns true if someone is actively moderating.
+	bool PlayerModerating();
 
 private:
 
@@ -335,13 +337,12 @@ private:
 	static void ConRescue(IConsole::IResult *pResult, void *pUserData);
 	static void ConProtectedKill(IConsole::IResult *pResult, void *pUserData);
 
-
-
 	static void ConMute(IConsole::IResult *pResult, void *pUserData);
 	static void ConMuteID(IConsole::IResult *pResult, void *pUserData);
 	static void ConMuteIP(IConsole::IResult *pResult, void *pUserData);
 	static void ConUnmute(IConsole::IResult *pResult, void *pUserData);
 	static void ConMutes(IConsole::IResult *pResult, void *pUserData);
+	static void ConModerate(IConsole::IResult *pResult, void *pUserData);
 
 	static void ConList(IConsole::IResult *pResult, void *pUserData);
 	static void ConSetDDRTeam(IConsole::IResult *pResult, void *pUserData);

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -176,6 +176,8 @@ public:
 
 	int m_ChatScore;
 
+	bool m_Moderating;
+
 	bool AfkTimer(int new_target_x, int new_target_y); //returns true if kicked
 	void AfkVoteTimer(CNetObj_PlayerInput *NewTarget);
 	int64 m_LastPlaytime;


### PR DESCRIPTION
This PR adds a RCON command called "moderate", which enables a active moderator mode for the caller, so this will happen if a vote kick/spec is made:

- Vote will last atleast x seconds defined by CGameContext::m_VoteCloseTime (35 seconds on ddnet, according to @heinrich5991) even if there is majority.
- If a active moderator votes, it will be a force vote.
- If the active moderator doesn't vote, it will pass normally
- This is only for kick and spec votes.

I also added `access_level moderate 1` to autoexec_server.cfg

If there are any spelling errors on the code tell me.

Maybe needs to be tested more.