### PR TITLE
Add a missing call to `lock_wait` in test function

### DIFF
--- a/src/test/thread.cpp
+++ b/src/test/thread.cpp
@@ -75,6 +75,7 @@ static void LockThread(void *pUser)
 TEST(Thread, Lock)
 {
 	LOCK Lock = lock_create();
+	lock_wait(Lock);
 	void *pThread = thread_init(LockThread, &Lock);
 	lock_unlock(Lock);
 	thread_wait(pThread);


### PR DESCRIPTION
This was uncovered when I tried to run other code with ThreadSan, but it
only found this. :(