### PR TITLE
Update README.md instructions for installing dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ DDNet requires additional libraries, that are bundled for the most common platfo
 
 You can install the required libraries on your system, `touch CMakeLists.txt` and CMake will use the system-wide libraries by default. You can install all required dependencies and CMake on Debian or Ubuntu like this:
 
-    sudo apt install cmake libcurl4-openssl-dev libfreetype6-dev libogg-dev libopus-dev libopusfile-dev libsdl2-dev
+    sudo apt install cmake git libcurl4-openssl-dev libfreetype6-dev libglew-dev libogg-dev libopus-dev libopusfile-dev libpnglite-dev libsdl2-dev libwavpack-dev
 
-Or on Arch Linux like this:
+Or on Arch Linux like this (Arch Linux does not package `pnglite`, not even in AUR):
 
-    pacman -S cmake curl freetype2 opusfile sdl2
+    sudo pacman -S --needed cmake curl freetype2 git glew opusfile sdl2 wavpack
 
 If you have the libraries installed, but still want to use the bundled ones instead, you can do so by removing your build directory and re-running CMake with `-DPREFER_BUNDLED_LIBS=ON`, e.g. `cmake -DPREFER_BUNDLED_LIBS=ON ..`.
 


### PR DESCRIPTION
This follows the recent change that glew, pnglite and wavpack can use
the system libraries now.