### PR TITLE
Fix crash on startup due to sound initialization 

### DIFF
--- a/cmake/FindGLEW.cmake
+++ b/cmake/FindGLEW.cmake
@@ -9,7 +9,6 @@ if(NOT PREFER_BUNDLED_LIBS)
 endif()
 
 if(NOT GLEW_FOUND)
-  set(GLEW_FOUND ON)
   set(GLEW_BUNDLED ON)
   set(GLEW_SRC_DIR src/engine/external/glew)
   set_glob(GLEW_SRC GLOB ${GLEW_SRC_DIR} glew.c)

--- a/cmake/FindZLIB.cmake
+++ b/cmake/FindZLIB.cmake
@@ -9,7 +9,6 @@ if(NOT PREFER_BUNDLED_LIBS)
 endif()
 
 if(NOT ZLIB_FOUND)
-  set(ZLIB_FOUND ON)
   set(ZLIB_BUNDLED ON)
   set(ZLIB_SRC_DIR src/engine/external/zlib)
   set_glob(ZLIB_SRC GLOB ${ZLIB_SRC_DIR}

--- a/src/engine/client/sound.cpp
+++ b/src/engine/client/sound.cpp
@@ -521,7 +521,7 @@ int CSound::DecodeWV(int SampleID, const void *pData, unsigned DataSize)
 	Callback.get_pos = GetPos;
 	Callback.push_back_byte = PushBackByte;
 	Callback.read_bytes = ReadData;
-	pContext = WavpackOpenFileInputEx(&Callback,0, 0, aError, 0, 0);
+	pContext = WavpackOpenFileInputEx(&Callback, (void *)1, 0, aError, 0, 0);
 #else
 	pContext = WavpackOpenFileInput(ReadDataOld, aError);
 #endif


### PR DESCRIPTION
Of course `WavpackOpenFileInputEx` is subtly incompatible to
`WavpackOpenFileInputEx64` in that it requires the userdata for the main
steam to be nonnull.

Fixes #1041.