### PR TITLE
Add possibility to ban players by name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1101,6 +1101,7 @@ if(GTEST_FOUND OR DOWNLOAD_GTEST)
     fs.cpp
     git_revision.cpp
     jobs.cpp
+    str.cpp
     strip_path_and_extension.cpp
     teehistorian.cpp
     test.cpp

--- a/src/base/confusables.c
+++ b/src/base/confusables.c
@@ -63,6 +63,23 @@ int str_utf8_skeleton_next(struct SKELETON *skel)
 	return ch;
 }
 
+int str_utf8_to_skeleton(const char *str, int *buf, int buf_len)
+{
+	int i;
+	struct SKELETON skel;
+	str_utf8_skeleton_begin(&skel, str);
+	for(i = 0; i < buf_len; i++)
+	{
+		int ch = str_utf8_skeleton_next(&skel);
+		if(ch == 0)
+		{
+			break;
+		}
+		buf[i] = ch;
+	}
+	return i;
+}
+
 int str_utf8_comp_confusable(const char *str1, const char *str2)
 {
 	struct SKELETON skel1;

--- a/src/base/system.c
+++ b/src/base/system.c
@@ -2408,6 +2408,98 @@ int str_comp_filenames(const char *a, const char *b)
 	return *a - *b;
 }
 
+static int min3(int a, int b, int c)
+{
+	int min = a;
+	if(b < min)
+		min = b;
+	if(c < min)
+		min = c;
+	return min;
+}
+
+int str_utf8_dist(const char *a, const char *b)
+{
+	int buf_len = 2 * (str_length(a) + 1 + str_length(b) + 1);
+	int *buf = (int *)mem_alloc(buf_len * sizeof(*buf), 1);
+	int result = str_utf8_dist_buffer(a, b, buf, buf_len);
+	mem_free(buf);
+	return result;
+}
+
+static int str_to_utf32_unchecked(const char *str, int **out)
+{
+	int out_len = 0;
+	while((**out = str_utf8_decode(&str)))
+	{
+		(*out)++;
+		out_len++;
+	}
+	return out_len;
+}
+
+int str_utf32_dist_buffer(const int *a, int a_len, const int *b, int b_len, int *buf, int buf_len)
+{
+	int i, j;
+	dbg_assert(buf_len >= (a_len + 1) + (b_len + 1), "buffer too small");
+	if(a_len > b_len)
+	{
+		int tmp1 = a_len;
+		const int *tmp2 = a;
+
+		a_len = b_len;
+		a = b;
+
+		b_len = tmp1;
+		b = tmp2;
+	}
+#define B(i, j) buf[((j)&1) * (a_len + 1) + (i)]
+	for(i = 0; i <= a_len; i++)
+	{
+		B(i, 0) = i;
+	}
+	for(j = 1; j <= b_len; j++)
+	{
+		B(0, j) = j;
+		for(i = 1; i <= a_len; i++)
+		{
+			int subst = (a[i - 1] != b[j - 1]);
+			B(i, j) = min3(
+				B(i - 1, j) + 1,
+				B(i, j - 1) + 1,
+				B(i - 1, j - 1) + subst
+			);
+		}
+	}
+	return B(a_len, b_len);
+#undef B
+}
+
+int str_utf8_dist_buffer(const char *a_utf8, const char *b_utf8, int *buf, int buf_len)
+{
+	int a_utf8_len = str_length(a_utf8);
+	int b_utf8_len = str_length(b_utf8);
+	int *a, *b; // UTF-32
+	int a_len, b_len; // UTF-32 length
+	dbg_assert(buf_len >= 2 * (a_utf8_len + 1 + b_utf8_len + 1), "buffer too small");
+	if(a_utf8_len > b_utf8_len)
+	{
+		int tmp1 = a_utf8_len;
+		const char *tmp2 = a_utf8;
+
+		a_utf8_len = b_utf8_len;
+		a_utf8 = b_utf8;
+
+		b_utf8_len = tmp1;
+		b_utf8 = tmp2;
+	}
+	a = buf;
+	a_len = str_to_utf32_unchecked(a_utf8, &buf);
+	b = buf;
+	b_len = str_to_utf32_unchecked(b_utf8, &buf);
+	return str_utf32_dist_buffer(a, a_len, b, b_len, buf, buf_len - b_len - a_len);
+}
+
 const char *str_find_nocase(const char *haystack, const char *needle)
 {
 	while(*haystack) /* native implementation */

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -1182,6 +1182,64 @@ int str_comp_num(const char *a, const char *b, const int num);
 int str_comp_filenames(const char *a, const char *b);
 
 /*
+	Function: str_utf8_dist
+		Computes the edit distance between two strings.
+
+	Parameters:
+		a - First string for the edit distance.
+		b - Second string for the edit distance.
+
+	Returns:
+		The edit distance between the both strings.
+
+	Remarks:
+		- The strings are treated as zero-terminated strings.
+*/
+int str_utf8_dist(const char *a, const char *b);
+
+/*
+	Function: str_utf8_dist_buffer
+		Computes the edit distance between two strings, allows buffers
+		to be passed in.
+
+	Parameters:
+		a - First string for the edit distance.
+		b - Second string for the edit distance.
+		buf - Buffer for the function.
+		buf_len - Length of the buffer, must be at least as long as
+		          twice the length of both strings combined plus two.
+
+	Returns:
+		The edit distance between the both strings.
+
+	Remarks:
+		- The strings are treated as zero-terminated strings.
+*/
+int str_utf8_dist_buffer(const char *a, const char *b, int *buf, int buf_len);
+
+/*
+	Function: str_utf32_dist_buffer
+		Computes the edit distance between two strings, allows buffers
+		to be passed in.
+
+	Parameters:
+		a - First string for the edit distance.
+		a_len - Length of the first string.
+		b - Second string for the edit distance.
+		b_len - Length of the second string.
+		buf - Buffer for the function.
+		buf_len - Length of the buffer, must be at least as long as
+		          the length of both strings combined plus two.
+
+	Returns:
+		The edit distance between the both strings.
+
+	Remarks:
+		- The strings are treated as zero-terminated strings.
+*/
+int str_utf32_dist_buffer(const int *a, int a_len, const int *b, int b_len, int *buf, int buf_len);
+
+/*
 	Function: str_find_nocase
 		Finds a string inside another string case insensitive.
 
@@ -1235,18 +1293,18 @@ void str_hex(char *dst, int dst_size, const void *data, int data_size);
 	Function: str_hex_decode
 		Takes a hex string and returns a byte array.
 
-		Parameters:
-			dst - Buffer for the byte array
-			dst_size - size of the buffer
-			data - String to decode
+	Parameters:
+		dst - Buffer for the byte array
+		dst_size - size of the buffer
+		data - String to decode
 
-		Returns:
-			2 - String doesn't exactly fit the buffer
-			1 - Invalid character in string
-			0 - Success
+	Returns:
+		2 - String doesn't exactly fit the buffer
+		1 - Invalid character in string
+		0 - Success
 
-		Remarks:
-			- The contents of the buffer is only valid on success
+	Remarks:
+		- The contents of the buffer is only valid on success
 */
 int str_hex_decode(unsigned char *dst, int dst_size, const char *src);
 /*
@@ -1503,6 +1561,11 @@ float str_tofloat(const char *str);
 int str_isspace(char c);
 char str_uppercase(char c);
 unsigned str_quickhash(const char *str);
+
+struct SKELETON;
+void str_utf8_skeleton_begin(struct SKELETON *skel, const char *str);
+int str_utf8_skeleton_next(struct SKELETON *skel);
+int str_utf8_to_skeleton(const char *str, int *buf, int buf_len);
 
 /*
 	Function: str_utf8_comp_confusable

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -19,6 +19,8 @@
 #include <engine/shared/netban.h>
 #include <engine/shared/uuid_manager.h>
 
+#include <base/tl/array.h>
+
 #include "authmanager.h"
 
 #if defined (CONF_SQL)
@@ -95,6 +97,27 @@ class CServer : public IServer
 	bool m_ConnLoggingSocketCreated;
 	UNIXSOCKET m_ConnLoggingSocket;
 #endif
+
+	enum
+	{
+		MAX_NAME_SKELETON_LENGTH=MAX_NAME_LENGTH*4,
+	};
+
+	class CNameBan
+	{
+	public:
+		CNameBan() {}
+		CNameBan(const char *pName, int Distance) :
+			m_Distance(Distance)
+		{
+			str_copy(m_aName, pName, sizeof(m_aName));
+			m_SkeletonLength = str_utf8_to_skeleton(m_aName, m_aSkeleton, sizeof(m_aSkeleton) / sizeof(m_aSkeleton[0]));
+		}
+		char m_aName[MAX_NAME_LENGTH];
+		int m_aSkeleton[MAX_NAME_SKELETON_LENGTH];
+		int m_SkeletonLength;
+		int m_Distance;
+	};
 
 public:
 	class IGameServer *GameServer() { return m_pGameServer; }
@@ -217,6 +240,8 @@ public:
 
 	char m_aErrorShutdownReason[128];
 
+	array<CNameBan> m_aNameBans;
+
 	CServer();
 
 	int TrySetClientName(int ClientID, const char *pName);
@@ -307,6 +332,10 @@ public:
 	static void ConAuthUpdateHashed(IConsole::IResult *pResult, void *pUser);
 	static void ConAuthRemove(IConsole::IResult *pResult, void *pUser);
 	static void ConAuthList(IConsole::IResult *pResult, void *pUser);
+
+	static void ConNameBan(IConsole::IResult *pResult, void *pUser);
+	static void ConNameUnban(IConsole::IResult *pResult, void *pUser);
+	static void ConNameBans(IConsole::IResult *pResult, void *pUser);
 
 	static void StatusImpl(IConsole::IResult *pResult, void *pUser, bool DnsblBlacklistedOnly);
 

--- a/src/test/str.cpp
+++ b/src/test/str.cpp
@@ -1,0 +1,19 @@
+#include <gtest/gtest.h>
+
+#include <base/system.h>
+
+TEST(Str, Dist)
+{
+	EXPECT_EQ(str_utf8_dist("aaa", "aaa"), 0);
+	EXPECT_EQ(str_utf8_dist("123", "123"), 0);
+	EXPECT_EQ(str_utf8_dist("", ""), 0);
+	EXPECT_EQ(str_utf8_dist("a", "b"), 1);
+	EXPECT_EQ(str_utf8_dist("", "aaa"), 3);
+	EXPECT_EQ(str_utf8_dist("123", ""), 3);
+	EXPECT_EQ(str_utf8_dist("ä", ""), 1);
+	EXPECT_EQ(str_utf8_dist("Hëllö", "Hello"), 2);
+	// https://en.wikipedia.org/w/index.php?title=Levenshtein_distance&oldid=828480025#Example
+	EXPECT_EQ(str_utf8_dist("kitten", "sitting"), 3);
+	EXPECT_EQ(str_utf8_dist("flaw", "lawn"), 2);
+	EXPECT_EQ(str_utf8_dist("saturday", "sunday"), 3);
+}


### PR DESCRIPTION
This uses the Unicode confusable data together with judging how close
two strings are by using the Levenshtein distance.

Adds the commands `name_ban`, `name_unban` and `name_bans`. Kicks
players who join using a banned name and doesn't allow ingame players to
change their names to the banned ones.