### PR TITLE
Add broadcast importance (fixes #669)

### DIFF
--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -187,7 +187,6 @@ MACRO_CONFIG_INT(SvHit, sv_hit, 1, 0, 1, CFGFLAG_SERVER|CFGFLAG_GAME, "Whether p
 MACRO_CONFIG_INT(SvEndlessDrag, sv_endless_drag, 0, 0, 1, CFGFLAG_SERVER|CFGFLAG_GAME, "Turns endless hooking on/off")
 MACRO_CONFIG_INT(SvTestingCommands, sv_test_cmds, 0, 0, 1, CFGFLAG_SERVER, "Turns testing commands aka cheats on/off")
 MACRO_CONFIG_INT(SvFreezeDelay, sv_freeze_delay, 3, 1, 30, CFGFLAG_SERVER|CFGFLAG_GAME, "How many seconds the players will remain frozen (applies to all except delayed freeze in switch layer & deepfreeze)")
-MACRO_CONFIG_INT(SvBroadcastDelay, sv_broadcast_delay, 6, 1, 180, CFGFLAG_SERVER, "How many seconds unimportant broadcasts won't overwrite important ones")
 MACRO_CONFIG_INT(ClDDRaceBinds, cl_race_binds, 1, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Enable Default DDRace builds when pressing the reset binds button")
 MACRO_CONFIG_INT(ClDDRaceBindsSet, cl_race_binds_set, 0, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Whether the DDRace binds set or not (this is automated you don't need to use this)")
 MACRO_CONFIG_INT(SvEndlessSuperHook, sv_endless_super_hook, 0, 0, 1, CFGFLAG_SERVER, "Endless hook for super players on/off")

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -187,6 +187,7 @@ MACRO_CONFIG_INT(SvHit, sv_hit, 1, 0, 1, CFGFLAG_SERVER|CFGFLAG_GAME, "Whether p
 MACRO_CONFIG_INT(SvEndlessDrag, sv_endless_drag, 0, 0, 1, CFGFLAG_SERVER|CFGFLAG_GAME, "Turns endless hooking on/off")
 MACRO_CONFIG_INT(SvTestingCommands, sv_test_cmds, 0, 0, 1, CFGFLAG_SERVER, "Turns testing commands aka cheats on/off")
 MACRO_CONFIG_INT(SvFreezeDelay, sv_freeze_delay, 3, 1, 30, CFGFLAG_SERVER|CFGFLAG_GAME, "How many seconds the players will remain frozen (applies to all except delayed freeze in switch layer & deepfreeze)")
+MACRO_CONFIG_INT(SvBroadcastDelay, sv_broadcast_delay, 6, 1, 180, CFGFLAG_SERVER, "How many seconds unimportant broadcasts won't overwrite important ones")
 MACRO_CONFIG_INT(ClDDRaceBinds, cl_race_binds, 1, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Enable Default DDRace builds when pressing the reset binds button")
 MACRO_CONFIG_INT(ClDDRaceBindsSet, cl_race_binds_set, 0, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Whether the DDRace binds set or not (this is automated you don't need to use this)")
 MACRO_CONFIG_INT(SvEndlessSuperHook, sv_endless_super_hook, 0, 0, 1, CFGFLAG_SERVER, "Endless hook for super players on/off")

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -1221,7 +1221,7 @@ void CCharacter::HandleBroadcast()
 		char aBuftime[64];
 		int IntTime = (int)((float)(Server()->Tick() - m_StartTime) / ((float)Server()->TickSpeed()));
 		str_format(aBuftime, sizeof(aBuftime), "%s%d:%s%d", ((IntTime/60) > 9)?"":"0", IntTime/60, ((IntTime%60) > 9)?"":"0", IntTime%60);
-		GameServer()->SendBroadcast(aBuftime, m_pPlayer->GetCID());
+		GameServer()->SendBroadcast(aBuftime, m_pPlayer->GetCID(), false);
 		m_CpLastBroadcast = m_CpActive;
 		m_LastBroadcast = Server()->Tick();
 	}

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -421,7 +421,7 @@ void CGameContext::SendBroadcast(const char *pText, int ClientID, bool IsImporta
 	if (!m_apPlayers[ClientID])
 		return;
 
-	if (!IsImportant && m_apPlayers[ClientID]->m_LastBroadcastImportance && m_apPlayers[ClientID]->m_LastBroadcast > Server()->Tick() - Server()->TickSpeed() * 6)
+	if (!IsImportant && m_apPlayers[ClientID]->m_LastBroadcastImportance && m_apPlayers[ClientID]->m_LastBroadcast > Server()->Tick() - Server()->TickSpeed() * g_Config.m_SvBroadcastDelay)
 		return;
 
 	Server()->SendPackMsg(&Msg, MSGFLAG_VITAL, ClientID);

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -421,7 +421,7 @@ void CGameContext::SendBroadcast(const char *pText, int ClientID, bool IsImporta
 	if(!m_apPlayers[ClientID])
 		return;
 
-	if(!IsImportant && m_apPlayers[ClientID]->m_LastBroadcastImportance && m_apPlayers[ClientID]->m_LastBroadcast > Server()->Tick() - Server()->TickSpeed() * g_Config.m_SvBroadcastDelay)
+	if(!IsImportant && m_apPlayers[ClientID]->m_LastBroadcastImportance && m_apPlayers[ClientID]->m_LastBroadcast > Server()->Tick() - Server()->TickSpeed() * 10)
 		return;
 
 	Server()->SendPackMsg(&Msg, MSGFLAG_VITAL, ClientID);

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -405,6 +405,7 @@ void CGameContext::SendBroadcast(const char *pText, int ClientID, bool IsImporta
 
 	if(ClientID == -1)
 	{
+        dbg_assert(IsImportant, "broadcast messages to all players must be important");
 		Server()->SendPackMsg(&Msg, MSGFLAG_VITAL, ClientID);
 
 		for(int i = 0; i < MAX_CLIENTS; i++)

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -403,13 +403,13 @@ void CGameContext::SendBroadcast(const char *pText, int ClientID, bool IsImporta
 	CNetMsg_Sv_Broadcast Msg;
 	Msg.m_pMessage = pText;
 
-	if (ClientID == -1)
+	if(ClientID == -1)
 	{
 		Server()->SendPackMsg(&Msg, MSGFLAG_VITAL, ClientID);
 
-		for (int i = 0; i < MAX_CLIENTS; i++)
+		for(int i = 0; i < MAX_CLIENTS; i++)
 		{
-			if (m_apPlayers[i])
+			if(m_apPlayers[i])
 			{
 				m_apPlayers[i]->m_LastBroadcastImportance = true;
 				m_apPlayers[i]->m_LastBroadcast = Server()->Tick();
@@ -418,10 +418,10 @@ void CGameContext::SendBroadcast(const char *pText, int ClientID, bool IsImporta
 		return;
 	}
 
-	if (!m_apPlayers[ClientID])
+	if(!m_apPlayers[ClientID])
 		return;
 
-	if (!IsImportant && m_apPlayers[ClientID]->m_LastBroadcastImportance && m_apPlayers[ClientID]->m_LastBroadcast > Server()->Tick() - Server()->TickSpeed() * g_Config.m_SvBroadcastDelay)
+	if(!IsImportant && m_apPlayers[ClientID]->m_LastBroadcastImportance && m_apPlayers[ClientID]->m_LastBroadcast > Server()->Tick() - Server()->TickSpeed() * g_Config.m_SvBroadcastDelay)
 		return;
 
 	Server()->SendPackMsg(&Msg, MSGFLAG_VITAL, ClientID);

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -191,7 +191,7 @@ public:
 	void SendChat(int ClientID, int Team, const char *pText, int SpamProtectionClientID = -1);
 	void SendEmoticon(int ClientID, int Emoticon);
 	void SendWeaponPickup(int ClientID, int Weapon);
-	void SendBroadcast(const char *pText, int ClientID);
+	void SendBroadcast(const char *pText, int ClientID, bool IsImportant = true);
 
 	void List(int ClientID, const char* filter);
 

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -181,6 +181,8 @@ public:
 	void AfkVoteTimer(CNetObj_PlayerInput *NewTarget);
 	int64 m_LastPlaytime;
 	int64 m_LastEyeEmote;
+	int64 m_LastBroadcast;
+	bool m_LastBroadcastImportance;
 	int m_LastTarget_x;
 	int m_LastTarget_y;
 	CNetObj_PlayerInput m_LastTarget;


### PR DESCRIPTION
The broadcast timer is marked as unimportant and it won't overwrite if there was another broadcast sent less than 6 seconds ago. So vanilla clients won't miss any important news c: