### PR TITLE
Execute `git_revision.py` in the source directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -527,10 +527,11 @@ if(NOT PROJECT_GIT_DIR_ERROR)
     ${PROJECT_GIT_DIR}/logs/HEAD
   )
 endif()
-add_custom_command(OUTPUT src/game/generated/git_revision.cpp
+add_custom_command(OUTPUT ${PROJECT_BINARY_DIR}/src/game/generated/git_revision.cpp
   COMMAND ${PYTHON_EXECUTABLE}
-    ${PROJECT_SOURCE_DIR}/scripts/git_revision.py
-    > src/game/generated/git_revision.cpp
+    scripts/git_revision.py
+    > ${PROJECT_BINARY_DIR}/src/game/generated/git_revision.cpp
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
   DEPENDS
     ${GIT_REVISION_EXTRA_DEPS}
     scripts/git_revision.py


### PR DESCRIPTION
Previously, if using an out-of-source build directory, git would report
an error and no revision string would be added to the final executable.