### PR TITLE
 Provide more controlable command for dummy 

### DIFF
--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -291,6 +291,13 @@ int CControls::SnapInput(int *pData)
 
 			m_InputData[!g_Config.m_ClDummy] = *pDummyInput;
 		}
+		
+		if(g_Config.m_ClControlDummy){
+			CNetObj_PlayerInput *pDummyInput = &m_pClient->m_DummyInput;
+			pDummyInput->m_Jump = g_Config.m_ClDummyJump;
+			pDummyInput->m_Fire = g_Config.m_ClDummyFire;
+			pDummyInput->m_Hook = g_Config.m_ClDummyHook;
+		}
 
 		// stress testing
 #ifdef CONF_DEBUG

--- a/src/game/variables.h
+++ b/src/game/variables.h
@@ -124,6 +124,12 @@ MACRO_CONFIG_INT(ClDummyHammer, cl_dummy_hammer, 0, 0, 1, CFGFLAG_CLIENT, "Wheth
 MACRO_CONFIG_INT(ClDummyResetOnSwitch, cl_dummy_resetonswitch, 0, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Whether dummy should stop pressing keys when you switch")
 MACRO_CONFIG_INT(ClDummyCopyMoves, cl_dummy_copy_moves, 0, 0, 1, CFGFLAG_CLIENT, "Wether dummy should copy your moves")
 
+// more controlable dummy command
+MACRO_CONFIG_INT(ClControlDummy, cl_control_dummy, 0, 0, 1, CFGFLAG_CLIENT, "Whether can you control dummy at the same time")
+MACRO_CONFIG_INT(ClDummyJump, cl_dummy_jump, 0, 0, 1, CFGFLAG_CLIENT, "Whether dummy is jumping")
+MACRO_CONFIG_INT(ClDummyFire, cl_dummy_fire, 0, 0, 1, CFGFLAG_CLIENT, "Whether dummy is fire")
+MACRO_CONFIG_INT(ClDummyHook, cl_dummy_fire, 0, 0, 1, CFGFLAG_CLIENT, "Whether dummy is hook")
+	
 // curl http download
 MACRO_CONFIG_INT(ClHTTPConnectTimeoutMs, cl_http_connect_timeout_ms, 2000, 0, 100000, CFGFLAG_CLIENT, "HTTP downloads: timeout for the connect phase in milliseconds (0 to disable)")
 MACRO_CONFIG_INT(ClHTTPLowSpeedLimit, cl_http_low_speed_limit, 500, 0, 100000, CFGFLAG_CLIENT, "HTTP downloads: Set low speed limit in bytes per second (0 to disable)")


### PR DESCRIPTION
I  register some new command, which are cl_control_dummy, cl_dummy_jump, cl_dummy_fire and cl_dummy_hook, to make dummy more controlable.
if i want to contol my dummy to jump, 
first, press f1 in game, and use "cl_control_dummy 1",
second, use "bind mouse1 +toggle cl_dummy_jump 1 0".
finally, i can contol my dummy to jump by pressing left mouse button.