### PR TITLE
Change the wrong translation of Simplified Chinese

### DIFF
--- a/data/languages/simplified_chinese.txt
+++ b/data/languages/simplified_chinese.txt
@@ -1006,7 +1006,7 @@ Follow
 == 跟(Follow)
 
 Manual %3d:%02d  
-== 手册 %3d:%02d
+== 手动 %3d:%02d
 
 Automatically create statboard csv
 == 自动创建状态版的纯文本文件(CSV)


### PR DESCRIPTION
“Manual” here should be translated to “手动” or "手动录制" but not "手册"。