### PR TITLE
Make mem_alloc, mem_free thread safe (fixes #1087)

### DIFF
--- a/src/base/system.h
+++ b/src/base/system.h
@@ -93,6 +93,27 @@ GNUC_ATTRIBUTE((format(printf, 2, 3)));
 /* Group: Memory */
 
 /*
+	Function: mem_alloc_impl
+		Allocates memory.
+
+	Parameters:
+		size - Size of the needed block.
+		alignment - Alignment for the block.
+
+	Returns:
+		Returns a pointer to the newly allocated block. Returns a
+		null pointer if the memory couldn't be allocated.
+
+	Remarks:
+		- Passing 0 to size will allocated the smallest amount possible
+		and return a unique pointer.
+
+	See Also:
+		<mem_free_impl>
+*/
+void *mem_alloc_impl(unsigned size, unsigned alignment);
+
+/*
 	Function: mem_alloc
 		Allocates memory.
 
@@ -109,10 +130,14 @@ GNUC_ATTRIBUTE((format(printf, 2, 3)));
 		and return a unique pointer.
 
 	See Also:
-		<mem_free>
+		<mem_free>, <mem_alloc_impl>
 */
 void *mem_alloc_debug(const char *filename, int line, unsigned size, unsigned alignment);
+#ifdef CONF_DEBUG
 #define mem_alloc(s,a) mem_alloc_debug(__FILE__, __LINE__, (s), (a))
+#else
+#define mem_alloc(s,a) mem_alloc_impl(s, a)
+#endif
 
 /*
 	Function: mem_free
@@ -122,9 +147,26 @@ void *mem_alloc_debug(const char *filename, int line, unsigned size, unsigned al
 		- Is safe on null pointers.
 
 	See Also:
-		<mem_alloc>
+		<mem_alloc_impl>
 */
-void mem_free(void *block);
+void mem_free_impl(void *block);
+
+/*
+	Function: mem_free
+		Frees a block allocated through <mem_alloc>.
+
+	Remarks:
+		- Is safe on null pointers.
+
+	See Also:
+		<mem_alloc>, <mem_free_impl>
+*/
+void mem_free_debug(void *block);
+#ifdef CONF_DEBUG
+#define mem_free(p) mem_free_debug(p)
+#else
+#define mem_free(p) mem_free_impl(p)
+#endif
 
 /*
 	Function: mem_copy

--- a/src/engine/shared/engine.cpp
+++ b/src/engine/shared/engine.cpp
@@ -97,7 +97,9 @@ public:
 		if(!m_pConsole || !m_pStorage)
 			return;
 
+#ifdef CONF_DEBUG
 		m_pConsole->Register("dbg_dumpmem", "", CFGFLAG_SERVER|CFGFLAG_CLIENT, Con_DbgDumpmem, this, "Dump the memory");
+#endif
 		m_pConsole->Register("dbg_lognetwork", "", CFGFLAG_SERVER|CFGFLAG_CLIENT, Con_DbgLognetwork, this, "Log the network");
 	}
 


### PR DESCRIPTION
Imo very important fix. E.g. basically everytime a glyph is uploaded there is a potential risk. (the easiest way to reproduce it is enable threaded sound loading and start the client a few times)

It doesn't create the "allocation list" for realease mode and adds a mutex for the debug mode.