### PR TITLE
Remove `mem_alloc` and `mem_free`, use standard C functions instead

### DIFF
--- a/src/base/system.c
+++ b/src/base/system.c
@@ -93,7 +93,6 @@ static DBG_LOGGER_DATA loggers[16];
 static int num_loggers = 0;
 
 static NETSTATS network_stats = {0};
-static MEMSTATS memory_stats = {0};
 
 static NETSOCKET invalid_socket = {NETTYPE_INVALID, -1, -1};
 
@@ -246,138 +245,6 @@ void dbg_logger_file(const char *filename)
 }
 /* */
 
-typedef struct MEMHEADER
-{
-	const char *filename;
-	int line;
-	int size;
-	struct MEMHEADER *prev;
-	struct MEMHEADER *next;
-} MEMHEADER;
-
-typedef struct MEMTAIL
-{
-	int guard;
-} MEMTAIL;
-
-static LOCK mem_lock = (LOCK)0x0;
-static char init_mem_lock = 0;
-static struct MEMHEADER *first = 0;
-static const int MEM_GUARD_VAL = 0xbaadc0de;
-
-void *mem_alloc_impl(unsigned size, unsigned alignment)
-{
-	/* TODO: remove alignment parameter */
-	return malloc(size);
-}
-
-void *mem_alloc_debug(const char *filename, int line, unsigned size, unsigned alignment)
-{
-	/* TODO: add debugging */
-	MEMTAIL *tail;
-	MEMHEADER *header = (struct MEMHEADER *)mem_alloc_impl(size+sizeof(MEMHEADER)+sizeof(MEMTAIL), alignment);
-
-	dbg_assert(header != 0, "mem_alloc failure");
-	if(!header)
-		return NULL;
-
-	tail = (struct MEMTAIL *)(((char*)(header + 1)) + size);
-	header->size = size;
-	header->filename = filename;
-	header->line = line;
-	tail->guard = MEM_GUARD_VAL;
-
-	if(init_mem_lock == 0)
-	{
-		init_mem_lock = 1;
-		mem_lock = lock_create();
-	}
-
-	if(mem_lock)
-		lock_wait(mem_lock);
-
-	memory_stats.allocated += header->size;
-	memory_stats.total_allocations++;
-	memory_stats.active_allocations++;
-
-	header->prev = (MEMHEADER *)0;
-	header->next = first;
-	if(first)
-		first->prev = header;
-	first = header;
-
-	if(mem_lock)
-		lock_unlock(mem_lock);
-
-	/*dbg_msg("mem", "++ %p", header+1); */
-	return header+1;
-}
-
-void mem_free_impl(void *p)
-{
-	free(p);
-}
-
-void mem_free_debug(void *p)
-{
-	if(p)
-	{
-		MEMHEADER *header = (MEMHEADER *)p - 1;
-		MEMTAIL *tail = (MEMTAIL *)(((char*)(header+1))+header->size);
-
-		if(mem_lock)
-			lock_wait(mem_lock);
-
-		if(tail->guard != MEM_GUARD_VAL)
-			dbg_msg("mem", "!! %p", p);
-		/* dbg_msg("mem", "-- %p", p); */
-		memory_stats.allocated -= header->size;
-		memory_stats.active_allocations--;
-
-		if(header->prev)
-			header->prev->next = header->next;
-		else
-			first = header->next;
-		if(header->next)
-			header->next->prev = header->prev;
-
-		if(mem_lock)
-			lock_unlock(mem_lock);
-
-		mem_free_impl(header);
-	}
-}
-
-void mem_debug_dump(IOHANDLE file)
-{
-	char buf[1024];
-	MEMHEADER *header;
-
-	if(mem_lock)
-		lock_wait(mem_lock);
-
-	header = first;
-
-	if(!file)
-		file = io_open("memory.txt", IOFLAG_WRITE);
-
-	if(file)
-	{
-		while(header)
-		{
-			str_format(buf, sizeof(buf), "%s(%d): %d", header->filename, header->line, header->size);
-			io_write(file, buf, strlen(buf));
-			io_write_newline(file);
-			header = header->next;
-		}
-
-		io_close(file);
-	}
-
-	if(mem_lock)
-		lock_unlock(mem_lock);
-}
-
 void mem_copy(void *dest, const void *source, unsigned size)
 {
 	memcpy(dest, source, size);
@@ -391,32 +258,6 @@ void mem_move(void *dest, const void *source, unsigned size)
 void mem_zero(void *block,unsigned size)
 {
 	memset(block, 0, size);
-}
-
-int mem_check_imp()
-{
-	MEMHEADER *header;
-
-	if(mem_lock)
-		lock_wait(mem_lock);
-
-	header = first;
-
-	while(header)
-	{
-		MEMTAIL *tail = (MEMTAIL *)(((char*)(header+1))+header->size);
-		if(tail->guard != MEM_GUARD_VAL)
-		{
-			dbg_msg("mem", "memory check failed at %s(%d): %d", header->filename, header->line, header->size);
-			return 0;
-		}
-		header = header->next;
-	}
-
-	if(mem_lock)
-		lock_unlock(mem_lock);
-
-	return 1;
 }
 
 IOHANDLE io_open(const char *filename, int flags)
@@ -569,10 +410,10 @@ static void aio_handle_free_and_unlock(ASYNCIO *aio)
 	lock_unlock(aio->lock);
 	if(do_free)
 	{
-		mem_free(aio->buffer);
+		free(aio->buffer);
 		sphore_destroy(&aio->sphore);
 		lock_destroy(aio->lock);
-		mem_free(aio);
+		free(aio);
 	}
 }
 
@@ -638,7 +479,7 @@ static void aio_thread(void *user)
 
 ASYNCIO *aio_new(IOHANDLE io)
 {
-	ASYNCIO *aio = mem_alloc(sizeof(*aio), sizeof(void *));
+	ASYNCIO *aio = malloc(sizeof(*aio));
 	if(!aio)
 	{
 		return 0;
@@ -648,12 +489,12 @@ ASYNCIO *aio_new(IOHANDLE io)
 	sphore_init(&aio->sphore);
 	aio->thread = 0;
 
-	aio->buffer = mem_alloc(ASYNC_BUFSIZE, 1);
+	aio->buffer = malloc(ASYNC_BUFSIZE);
 	if(!aio->buffer)
 	{
 		sphore_destroy(&aio->sphore);
 		lock_destroy(aio->lock);
-		mem_free(aio);
+		free(aio);
 		return 0;
 	}
 	aio->buffer_size = ASYNC_BUFSIZE;
@@ -666,10 +507,10 @@ ASYNCIO *aio_new(IOHANDLE io)
 	aio->thread = thread_init(aio_thread, aio);
 	if(!aio->thread)
 	{
-		mem_free(aio->buffer);
+		free(aio->buffer);
 		sphore_destroy(&aio->sphore);
 		lock_destroy(aio->lock);
-		mem_free(aio);
+		free(aio);
 		return 0;
 	}
 	return aio;
@@ -732,7 +573,7 @@ void aio_write_unlocked(ASYNCIO *aio, const void *buffer, unsigned size)
 		unsigned int new_written = buffer_len(aio) + size + 1;
 		unsigned int next_size = next_buffer_size(aio->buffer_size, new_written);
 		unsigned int next_len = 0;
-		unsigned char *next_buffer = mem_alloc(next_size, 1);
+		unsigned char *next_buffer = malloc(next_size);
 
 		struct BUFFERS buffers;
 		buffer_ptrs(aio, &buffers);
@@ -749,7 +590,7 @@ void aio_write_unlocked(ASYNCIO *aio, const void *buffer, unsigned size)
 		mem_copy(next_buffer + next_len, buffer, size);
 		next_len += size;
 
-		mem_free(aio->buffer);
+		free(aio->buffer);
 		aio->buffer = next_buffer;
 		aio->buffer_size = next_size;
 		aio->read_pos = 0;
@@ -899,7 +740,7 @@ typedef CRITICAL_SECTION LOCKINTERNAL;
 
 LOCK lock_create()
 {
-	LOCKINTERNAL *lock = (LOCKINTERNAL*)mem_alloc(sizeof(LOCKINTERNAL), 4);
+	LOCKINTERNAL *lock = (LOCKINTERNAL *)malloc(sizeof(*lock));
 
 #if defined(CONF_FAMILY_UNIX)
 	pthread_mutex_init(lock, 0x0);
@@ -920,7 +761,7 @@ void lock_destroy(LOCK lock)
 #else
 	#error not implemented on this platform
 #endif
-	mem_free(lock);
+	free(lock);
 }
 
 int lock_trylock(LOCK lock)
@@ -2485,9 +2326,9 @@ static int min3(int a, int b, int c)
 int str_utf8_dist(const char *a, const char *b)
 {
 	int buf_len = 2 * (str_length(a) + 1 + str_length(b) + 1);
-	int *buf = (int *)mem_alloc(buf_len * sizeof(*buf), 1);
+	int *buf = (int *)calloc(buf_len, sizeof(*buf));
 	int result = str_utf8_dist_buffer(a, b, buf, buf_len);
-	mem_free(buf);
+	free(buf);
 	return result;
 }
 
@@ -2721,11 +2562,6 @@ void str_escape(char **dst, const char *src, const char *end)
 int mem_comp(const void *a, const void *b, int size)
 {
 	return memcmp(a,b,size);
-}
-
-const MEMSTATS *mem_stats()
-{
-	return &memory_stats;
 }
 
 void net_stats(NETSTATS *stats_inout)

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -9,7 +9,8 @@
 #define BASE_SYSTEM_H
 
 #include "detect.h"
-#include "stddef.h"
+#include <stddef.h>
+#include <stdlib.h>
 #include <time.h>
 
 #ifdef CONF_FAMILY_UNIX
@@ -93,82 +94,6 @@ GNUC_ATTRIBUTE((format(printf, 2, 3)));
 /* Group: Memory */
 
 /*
-	Function: mem_alloc_impl
-		Allocates memory.
-
-	Parameters:
-		size - Size of the needed block.
-		alignment - Alignment for the block.
-
-	Returns:
-		Returns a pointer to the newly allocated block. Returns a
-		null pointer if the memory couldn't be allocated.
-
-	Remarks:
-		- Passing 0 to size will allocated the smallest amount possible
-		and return a unique pointer.
-
-	See Also:
-		<mem_free_impl>
-*/
-void *mem_alloc_impl(unsigned size, unsigned alignment);
-
-/*
-	Function: mem_alloc
-		Allocates memory.
-
-	Parameters:
-		size - Size of the needed block.
-		alignment - Alignment for the block.
-
-	Returns:
-		Returns a pointer to the newly allocated block. Returns a
-		null pointer if the memory couldn't be allocated.
-
-	Remarks:
-		- Passing 0 to size will allocated the smallest amount possible
-		and return a unique pointer.
-
-	See Also:
-		<mem_free>, <mem_alloc_impl>
-*/
-void *mem_alloc_debug(const char *filename, int line, unsigned size, unsigned alignment);
-#ifdef CONF_DEBUG
-#define mem_alloc(s,a) mem_alloc_debug(__FILE__, __LINE__, (s), (a))
-#else
-#define mem_alloc(s,a) mem_alloc_impl(s, a)
-#endif
-
-/*
-	Function: mem_free
-		Frees a block allocated through <mem_alloc>.
-
-	Remarks:
-		- Is safe on null pointers.
-
-	See Also:
-		<mem_alloc_impl>
-*/
-void mem_free_impl(void *block);
-
-/*
-	Function: mem_free
-		Frees a block allocated through <mem_alloc>.
-
-	Remarks:
-		- Is safe on null pointers.
-
-	See Also:
-		<mem_alloc>, <mem_free_impl>
-*/
-void mem_free_debug(void *block);
-#ifdef CONF_DEBUG
-#define mem_free(p) mem_free_debug(p)
-#else
-#define mem_free(p) mem_free_impl(p)
-#endif
-
-/*
 	Function: mem_copy
 		Copies a a memory block.
 
@@ -229,14 +154,6 @@ void mem_zero(void *block, unsigned size);
 		>0 - Block a is greater than block b
 */
 int mem_comp(const void *a, const void *b, int size);
-
-/*
-	Function: mem_check
-		Validates the heap
-		Will trigger a assert if memory has failed.
-*/
-int mem_check_imp();
-#define mem_check() dbg_assert_imp(__FILE__, __LINE__, mem_check_imp(), "Memory check failed")
 
 /* Group: File IO */
 enum {
@@ -1586,8 +1503,6 @@ int net_would_block();
 
 int net_socket_read_wait(NETSOCKET sock, int time);
 
-void mem_debug_dump(IOHANDLE file);
-
 void swap_endian(void *data, unsigned elem_size, unsigned num);
 
 
@@ -1598,15 +1513,6 @@ void dbg_logger(DBG_LOGGER logger, DBG_LOGGER_FINISH finish, void *user);
 void dbg_logger_stdout();
 void dbg_logger_debugger();
 void dbg_logger_file(const char *filename);
-
-typedef struct
-{
-	int allocated;
-	int active_allocations;
-	int total_allocations;
-} MEMSTATS;
-
-const MEMSTATS *mem_stats();
 
 typedef struct
 {

--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -166,7 +166,7 @@ void *CCommandProcessorFragment_OpenGL::Rescale(int Width, int Height, int NewWi
 	else if(Format == CCommandBuffer::TEXFORMAT_ALPHA)
 		Bpp = 1;
 
-	pTmpData = (unsigned char *)mem_alloc(NewWidth*NewHeight*Bpp, 1);
+	pTmpData = (unsigned char *)malloc(NewWidth * NewHeight * Bpp);
 
 	int c = 0;
 	for(int y = 0; y < NewHeight; y++)
@@ -265,13 +265,13 @@ void CCommandProcessorFragment_OpenGL::Cmd_Texture_Update(const CCommandBuffer::
 		}
 
 		void *pTmpData = Rescale(pCommand->m_Width, pCommand->m_Height, Width, Height, pCommand->m_Format, static_cast<const unsigned char *>(pCommand->m_pData));
-		mem_free(pTexData);
+		free(pTexData);
 		pTexData = pTmpData;
 	}
 
 	glTexSubImage2D(GL_TEXTURE_2D, 0, X, Y, Width, Height,
 		TexFormatToOpenGLFormat(pCommand->m_Format), GL_UNSIGNED_BYTE, pTexData);
-	mem_free(pTexData);
+	free(pTexData);
 }
 
 void CCommandProcessorFragment_OpenGL::Cmd_Texture_Destroy(const CCommandBuffer::SCommand_Texture_Destroy *pCommand)
@@ -307,7 +307,7 @@ void CCommandProcessorFragment_OpenGL::Cmd_Texture_Create(const CCommandBuffer::
 			} while(Width > m_MaxTexSize || Height > m_MaxTexSize);
 
 			void *pTmpData = Rescale(pCommand->m_Width, pCommand->m_Height, Width, Height, pCommand->m_Format, static_cast<const unsigned char *>(pCommand->m_pData));
-			mem_free(pTexData);
+			free(pTexData);
 			pTexData = pTmpData;
 		}
 		else if(pCommand->m_Format != CCommandBuffer::TEXFORMAT_ALPHA && (Width > 16 && Height > 16 && (pCommand->m_Flags&CCommandBuffer::TEXFLAG_QUALITY) == 0))
@@ -317,7 +317,7 @@ void CCommandProcessorFragment_OpenGL::Cmd_Texture_Create(const CCommandBuffer::
 			++RescaleCount;
 
 			void *pTmpData = Rescale(pCommand->m_Width, pCommand->m_Height, Width, Height, pCommand->m_Format, static_cast<const unsigned char *>(pCommand->m_pData));
-			mem_free(pTexData);
+			free(pTexData);
 			pTexData = pTmpData;
 		}
 	}
@@ -368,7 +368,7 @@ void CCommandProcessorFragment_OpenGL::Cmd_Texture_Create(const CCommandBuffer::
 	}
 	*m_pTextureMemoryUsage += m_aTextures[pCommand->m_Slot].m_MemSize;
 
-	mem_free(pTexData);
+	free(pTexData);
 }
 
 void CCommandProcessorFragment_OpenGL::Cmd_Clear(const CCommandBuffer::SCommand_Clear *pCommand)
@@ -419,7 +419,7 @@ void CCommandProcessorFragment_OpenGL::Cmd_Screenshot(const CCommandBuffer::SCom
 	int h = aViewport[3];
 
 	// we allocate one more row to use when we are flipping the texture
-	unsigned char *pPixelData = (unsigned char *)mem_alloc(w*(h+1)*3, 1);
+	unsigned char *pPixelData = (unsigned char *)malloc(w*(h+1)*3);
 	unsigned char *pTempRow = pPixelData+w*h*3;
 
 	// fetch the pixels
@@ -498,7 +498,7 @@ void *CCommandProcessorFragment_OpenGL3_3::Rescale(int Width, int Height, int Ne
 	else if(Format == CCommandBuffer::TEXFORMAT_ALPHA)
 		Bpp = 1;
 
-	pTmpData = (unsigned char *)mem_alloc(NewWidth*NewHeight*Bpp, 1);
+	pTmpData = (unsigned char *)malloc(NewWidth*NewHeight*Bpp);
 
 	int c = 0;
 	for(int y = 0; y < NewHeight; y++)
@@ -1054,13 +1054,13 @@ void CCommandProcessorFragment_OpenGL3_3::Cmd_Texture_Update(const CCommandBuffe
 		}
 
 		void *pTmpData = Rescale(pCommand->m_Width, pCommand->m_Height, Width, Height, pCommand->m_Format, static_cast<const unsigned char *>(pCommand->m_pData));
-		mem_free(pTexData);
+		free(pTexData);
 		pTexData = pTmpData;
 	}
 
 	glTexSubImage2D(GL_TEXTURE_2D, 0, X, Y, Width, Height,
 		TexFormatToOpenGLFormat(pCommand->m_Format), GL_UNSIGNED_BYTE, pTexData);
-	mem_free(pTexData);
+	free(pTexData);
 }
 
 void CCommandProcessorFragment_OpenGL3_3::Cmd_Texture_Destroy(const CCommandBuffer::SCommand_Texture_Destroy *pCommand)
@@ -1099,7 +1099,7 @@ void CCommandProcessorFragment_OpenGL3_3::Cmd_Texture_Create(const CCommandBuffe
 			while(Width > m_MaxTexSize || Height > m_MaxTexSize);
 
 			void *pTmpData = Rescale(pCommand->m_Width, pCommand->m_Height, Width, Height, pCommand->m_Format, static_cast<const unsigned char *>(pCommand->m_pData));
-			mem_free(pTexData);
+			free(pTexData);
 			pTexData = pTmpData;
 		}
 		else if(pCommand->m_Format != CCommandBuffer::TEXFORMAT_ALPHA && (Width > 16 && Height > 16 && (pCommand->m_Flags&CCommandBuffer::TEXFLAG_QUALITY) == 0))
@@ -1109,7 +1109,7 @@ void CCommandProcessorFragment_OpenGL3_3::Cmd_Texture_Create(const CCommandBuffe
 			++RescaleCount;
 
 			void *pTmpData = Rescale(pCommand->m_Width, pCommand->m_Height, Width, Height, pCommand->m_Format, static_cast<const unsigned char *>(pCommand->m_pData));
-			mem_free(pTexData);
+			free(pTexData);
 			pTexData = pTmpData;
 		}
 	}
@@ -1192,7 +1192,7 @@ void CCommandProcessorFragment_OpenGL3_3::Cmd_Texture_Create(const CCommandBuffe
 	}
 	*m_pTextureMemoryUsage += m_aTextures[pCommand->m_Slot].m_MemSize;
 	
-	mem_free(pTexData);
+	free(pTexData);
 }
 
 void CCommandProcessorFragment_OpenGL3_3::Cmd_Clear(const CCommandBuffer::SCommand_Clear *pCommand)
@@ -1275,7 +1275,7 @@ void CCommandProcessorFragment_OpenGL3_3::Cmd_Screenshot(const CCommandBuffer::S
 	int h = aViewport[3];
 
 	// we allocate one more row to use when we are flipping the texture
-	unsigned char *pPixelData = (unsigned char *)mem_alloc(w*(h+1)*3, 1);
+	unsigned char *pPixelData = (unsigned char *)malloc(w*(h+1)*3);
 	unsigned char *pTempRow = pPixelData+w*h*3;
 
 	// fetch the pixels

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -942,10 +942,8 @@ void CClient::DebugRender()
 		total = 42
 	*/
 	FrameTimeAvg = FrameTimeAvg*0.9f + m_RenderFrameTime*0.1f;
-	str_format(aBuffer, sizeof(aBuffer), "ticks: %8d %8d mem %dk %d gfxmem: %dk fps: %3d",
+	str_format(aBuffer, sizeof(aBuffer), "ticks: %8d %8d gfxmem: %dk fps: %3d",
 		m_CurGameTick[g_Config.m_ClDummy], m_PredTick[g_Config.m_ClDummy],
-		mem_stats()->allocated/1024,
-		mem_stats()->total_allocations,
 		Graphics()->MemoryUsage()/1024,
 		(int)(1.0f/FrameTimeAvg + 0.5f));
 	Graphics()->QuadsText(2, 2, 16, aBuffer);
@@ -3439,7 +3437,7 @@ void CClient::RegisterCommands()
 
 static CClient *CreateClient()
 {
-	CClient *pClient = static_cast<CClient *>(mem_alloc(sizeof(CClient), 1));
+	CClient *pClient = static_cast<CClient *>(malloc(sizeof(*pClient)));
 	mem_zero(pClient, sizeof(CClient));
 	return new(pClient) CClient;
 }
@@ -3536,7 +3534,7 @@ int main(int argc, const char **argv) // ignore_convention
 		{
 			delete pKernel;
 			pClient->~CClient();
-			mem_free(pClient);
+			free(pClient);
 			return -1;
 		}
 	}
@@ -3612,7 +3610,7 @@ int main(int argc, const char **argv) // ignore_convention
 
 	delete pKernel;
 	pClient->~CClient();
-	mem_free(pClient);
+	free(pClient);
 
 	return 0;
 }

--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -391,7 +391,7 @@ int CGraphics_Threaded::LoadTextureRawSub(int TextureID, int x, int y, int Width
 	int MemSize = Width*Height*ImageFormatToPixelSize(Format);
 
 	// copy texture data
-	void *pTmpData = mem_alloc(MemSize, sizeof(void*));
+	void *pTmpData = malloc(MemSize);
 	mem_copy(pTmpData, pData, MemSize);
 	Cmd.m_pData = pTmpData;
 	
@@ -437,7 +437,7 @@ int CGraphics_Threaded::LoadTextureRaw(int Width, int Height, int Format, const 
 
 	// copy texture data
 	int MemSize = Width*Height*Cmd.m_PixelSize;
-	void *pTmpData = mem_alloc(MemSize, sizeof(void*));
+	void *pTmpData = malloc(MemSize);
 	mem_copy(pTmpData, pData, MemSize);
 	Cmd.m_pData = pTmpData;
 
@@ -467,7 +467,7 @@ int CGraphics_Threaded::LoadTexture(const char *pFilename, int StorageType, int 
 			StoreFormat = Img.m_Format;
 
 		ID = LoadTextureRaw(Img.m_Width, Img.m_Height, Img.m_Format, Img.m_pData, StoreFormat, Flags);
-		mem_free(Img.m_pData);
+		free(Img.m_pData);
 		if(ID != m_InvalidTexture && g_Config.m_Debug)
 			dbg_msg("graphics/texture", "loaded %s", pFilename);
 		return ID;
@@ -510,7 +510,7 @@ int CGraphics_Threaded::LoadPNG(CImageInfo *pImg, const char *pFilename, int Sto
 		return 0;
 	}
 
-	pBuffer = (unsigned char *)mem_alloc(Png.width * Png.height * Png.bpp, 1); // ignore_convention
+	pBuffer = (unsigned char *)malloc(Png.width * Png.height * Png.bpp); // ignore_convention
 	png_get_data(&Png, pBuffer); // ignore_convention
 	png_close_file(&Png); // ignore_convention
 
@@ -566,7 +566,7 @@ void CGraphics_Threaded::ScreenshotDirect()
 		png_set_data(&Png, Image.m_Width, Image.m_Height, 8, PNG_TRUECOLOR, (unsigned char *)Image.m_pData); // ignore_convention
 		png_close_file(&Png); // ignore_convention
 
-		mem_free(Image.m_pData);
+		free(Image.m_pData);
 	}
 }
 

--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -166,9 +166,9 @@ void CServerBrowser::Filter()
 	if(m_NumSortedServersCapacity < m_NumServers)
 	{
 		if(m_pSortedServerlist)
-			mem_free(m_pSortedServerlist);
+			free(m_pSortedServerlist);
 		m_NumSortedServersCapacity = m_NumServers;
-		m_pSortedServerlist = (int *)mem_alloc(m_NumSortedServersCapacity*sizeof(int), 1);
+		m_pSortedServerlist = (int *)calloc(m_NumSortedServersCapacity, sizeof(int));
 	}
 
 	// filter the servers
@@ -467,9 +467,9 @@ CServerBrowser::CServerEntry *CServerBrowser::Add(const NETADDR &Addr)
 	{
 		CServerEntry **ppNewlist;
 		m_NumServerCapacity += 100;
-		ppNewlist = (CServerEntry **)mem_alloc(m_NumServerCapacity*sizeof(CServerEntry*), 1);
+		ppNewlist = (CServerEntry **)calloc(m_NumServerCapacity, sizeof(CServerEntry *));
 		mem_copy(ppNewlist, m_ppServerlist, m_NumServers*sizeof(CServerEntry*));
-		mem_free(m_ppServerlist);
+		free(m_ppServerlist);
 		m_ppServerlist = ppNewlist;
 	}
 
@@ -1093,7 +1093,7 @@ void CServerBrowser::LoadDDNetInfoJson()
 		return;
 	}
 
-	char *pBuf = (char *)mem_alloc(Length, 1);
+	char *pBuf = (char *)malloc(Length);
 	pBuf[0] = '\0';
 
 	io_read(File, pBuf, Length);
@@ -1104,7 +1104,7 @@ void CServerBrowser::LoadDDNetInfoJson()
 
 	m_pDDNetInfo = json_parse(pBuf, Length);
 
-	mem_free(pBuf);
+	free(pBuf);
 
 	if(m_pDDNetInfo && m_pDDNetInfo->type != json_object)
 	{

--- a/src/engine/client/sound.cpp
+++ b/src/engine/client/sound.cpp
@@ -322,7 +322,7 @@ int CSound::Init()
 		dbg_msg("client/sound", "sound init successful");
 
 	m_MaxFrames = FormatOut.samples*2;
-	m_pMixBuffer = (int *)mem_alloc(m_MaxFrames*2*sizeof(int), 1);
+	m_pMixBuffer = (int *)calloc(m_MaxFrames * 2, sizeof(int));
 
 	SDL_PauseAudioDevice(m_Device, 0);
 
@@ -359,7 +359,7 @@ int CSound::Shutdown()
 	SDL_CloseAudioDevice(m_Device);
 	SDL_QuitSubSystem(SDL_INIT_AUDIO);
 	lock_destroy(m_SoundLock);
-	mem_free(m_pMixBuffer);
+	free(m_pMixBuffer);
 	m_pMixBuffer = 0;
 	return 0;
 }
@@ -388,7 +388,7 @@ void CSound::RateConvert(int SampleID)
 
 	// allocate new data
 	NumFrames = (int)((pSample->m_NumFrames/(float)pSample->m_Rate)*m_MixingRate);
-	pNewData = (short *)mem_alloc(NumFrames*pSample->m_Channels*sizeof(short), 1);
+	pNewData = (short *)calloc(NumFrames * pSample->m_Channels, sizeof(short));
 
 	for(int i = 0; i < NumFrames; i++)
 	{
@@ -409,7 +409,7 @@ void CSound::RateConvert(int SampleID)
 	}
 
 	// free old data and apply new
-	mem_free(pSample->m_pData);
+	free(pSample->m_pData);
 	pSample->m_pData = pNewData;
 	pSample->m_NumFrames = NumFrames;
 	pSample->m_Rate = m_MixingRate;
@@ -436,7 +436,7 @@ int CSound::DecodeOpus(int SampleID, const void *pData, unsigned DataSize)
 			return -1;
 		}
 
-		pSample->m_pData = (short *)mem_alloc(NumSamples * sizeof(short) * NumChannels, 1);
+		pSample->m_pData = (short *)calloc(NumSamples * NumChannels, sizeof(short));
 
 		int Read;
 		int Pos = 0;
@@ -550,17 +550,17 @@ int CSound::DecodeWV(int SampleID, const void *pData, unsigned DataSize)
 			return -1;
 		}
 
-		int *pBuffer = (int *)mem_alloc(4*NumSamples*NumChannels, 1);
+		int *pBuffer = (int *)calloc(NumSamples * NumChannels, sizeof(int));
 		WavpackUnpackSamples(pContext, pBuffer, NumSamples); // TODO: check return value
 		pSrc = pBuffer;
 
-		pSample->m_pData = (short *)mem_alloc(2*NumSamples*NumChannels, 1);
+		pSample->m_pData = (short *)calloc(NumSamples * NumChannels, sizeof(short));
 		pDst = pSample->m_pData;
 
 		for (i = 0; i < NumSamples*NumChannels; i++)
 			*pDst++ = (short)*pSrc++;
 
-		mem_free(pBuffer);
+		free(pBuffer);
 
 		pSample->m_NumFrames = NumSamples;
 		pSample->m_LoopStart = -1;
@@ -731,7 +731,7 @@ void CSound::UnloadSample(int SampleID)
 		return;
 
 	Stop(SampleID);
-	mem_free(m_aSamples[SampleID].m_pData);
+	free(m_aSamples[SampleID].m_pData);
 
 	m_aSamples[SampleID].m_pData = 0x0;
 }

--- a/src/engine/client/text.cpp
+++ b/src/engine/client/text.cpp
@@ -103,7 +103,7 @@ public:
 	
 	int m_aTextures[2];
 	// keep the full texture, because opengl doesn't provide texture copying
-	unsigned char* m_TextureData[2];
+	unsigned char *m_TextureData[2];
 
 	// width and height are the same
 	int m_CurTextureDimensions[2];
@@ -282,21 +282,22 @@ class CTextRender : public IEngineTextRender
 			}
 	}
 
-	int InitTexture(int Width, int Height, void* pUploadData = NULL)
+	int InitTexture(int Width, int Height, void *pUploadData = NULL)
 	{	
 		void *pMem = NULL;
 		if(pUploadData)
+		{
 			pMem = pUploadData;
+		}
 		else
 		{
-			pMem = mem_alloc(Width*Height, 1);
-			mem_zero(pMem, Width*Height);
+			pMem = calloc(Width * Height, 1);
 		}
 
 		int TextureID = Graphics()->LoadTextureRaw(Width, Height, CImageInfo::FORMAT_ALPHA, pMem, CImageInfo::FORMAT_ALPHA, IGraphics::TEXLOAD_NOMIPMAPS);
 
 		if(!pUploadData)
-			mem_free(pMem);
+			free(pMem);
 
 		return TextureID;
 	}
@@ -310,7 +311,7 @@ class CTextRender : public IEngineTextRender
 	{
 		int NewDimensions = pFont->m_CurTextureDimensions[TextureIndex] * 2;
 
-		unsigned char* pTmpTexBuffer = new unsigned char[NewDimensions*NewDimensions];
+		unsigned char *pTmpTexBuffer = new unsigned char[NewDimensions*NewDimensions];
 		mem_zero(pTmpTexBuffer, NewDimensions * NewDimensions * sizeof(unsigned char));
 
 		for(int y = 0; y < pFont->m_CurTextureDimensions[TextureIndex]; ++y)

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -1705,9 +1705,8 @@ int CServer::LoadMap(const char *pMapName)
 	{
 		IOHANDLE File = Storage()->OpenFile(aBuf, IOFLAG_READ, IStorage::TYPE_ALL);
 		m_CurrentMapSize = (unsigned int)io_length(File);
-		if(m_pCurrentMapData)
-			mem_free(m_pCurrentMapData);
-		m_pCurrentMapData = (unsigned char *)mem_alloc(m_CurrentMapSize, 1);
+		free(m_pCurrentMapData);
+		m_pCurrentMapData = (unsigned char *)malloc(m_CurrentMapSize);
 		io_read(File, m_pCurrentMapData, m_CurrentMapSize);
 		io_close(File);
 	}
@@ -1798,12 +1797,6 @@ int CServer::Run()
 
 		m_Lastheartbeat = 0;
 		m_GameStartTime = time_get();
-
-		if(g_Config.m_Debug)
-		{
-			str_format(aBuf, sizeof(aBuf), "baseline memory usage %dk", mem_stats()->allocated/1024);
-			Console()->Print(IConsole::OUTPUT_LEVEL_DEBUG, "server", aBuf);
-		}
 
 		while(m_RunServer)
 		{
@@ -2004,8 +1997,7 @@ int CServer::Run()
 	GameServer()->OnShutdown(true);
 	m_pMap->Unload();
 
-	if(m_pCurrentMapData)
-		mem_free(m_pCurrentMapData);
+	free(m_pCurrentMapData);
 
 #if defined (CONF_SQL)
 	for (int i = 0; i < MAX_SQLSERVERS; i++)

--- a/src/engine/shared/console.cpp
+++ b/src/engine/shared/console.cpp
@@ -863,7 +863,7 @@ CConsole::~CConsole()
 	{
 		CCommand *pNext = pCommand->m_pNext;
 		if(pCommand->m_pfnCallback == Con_Chain)
-			mem_free(static_cast<CChain *>(pCommand->m_pUserData));
+			delete static_cast<CChain *>(pCommand->m_pUserData);
 		delete pCommand;
 		pCommand = pNext;
 	}
@@ -1048,7 +1048,7 @@ void CConsole::Chain(const char *pName, FChainCommandCallback pfnChainFunc, void
 		return;
 	}
 
-	CChain *pChainInfo = (CChain *)mem_alloc(sizeof(CChain), sizeof(void*));
+	CChain *pChainInfo = new CChain();
 
 	// store info
 	pChainInfo->m_pfnChainCallback = pfnChainFunc;

--- a/src/engine/shared/demo.cpp
+++ b/src/engine/shared/demo.cpp
@@ -497,7 +497,7 @@ void CDemoPlayer::ScanFile()
 	}
 
 	// copy all the frames to an array instead for fast access
-	m_pKeyFrames = (CKeyFrame*)mem_alloc(m_Info.m_SeekablePoints*sizeof(CKeyFrame), 1);
+	m_pKeyFrames = (CKeyFrame *)calloc(m_Info.m_SeekablePoints, sizeof(CKeyFrame));
 	for(pCurrentKey = pFirstKey, i = 0; pCurrentKey; pCurrentKey = pCurrentKey->m_pNext, i++)
 		m_pKeyFrames[i] = pCurrentKey->m_Frame;
 
@@ -715,7 +715,7 @@ int CDemoPlayer::Load(class IStorage *pStorage, class IConsole *pConsole, const 
 	else if(MapSize > 0)
 	{
 		// get map data
-		unsigned char *pMapData = (unsigned char *)mem_alloc(MapSize, 1);
+		unsigned char *pMapData = (unsigned char *)malloc(MapSize);
 		io_read(m_File, pMapData, MapSize);
 
 		// save map
@@ -724,7 +724,7 @@ int CDemoPlayer::Load(class IStorage *pStorage, class IConsole *pConsole, const 
 		io_close(MapFile);
 
 		// free data
-		mem_free(pMapData);
+		free(pMapData);
 	}
 
 	// store map inforation
@@ -891,7 +891,7 @@ int CDemoPlayer::Stop()
 	m_pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "demo_player", "Stopped playback");
 	io_close(m_File);
 	m_File = 0;
-	mem_free(m_pKeyFrames);
+	free(m_pKeyFrames);
 	m_pKeyFrames = 0;
 	str_copy(m_aFilename, "", sizeof(m_aFilename));
 	return 0;

--- a/src/engine/shared/engine.cpp
+++ b/src/engine/shared/engine.cpp
@@ -32,16 +32,6 @@ public:
 	IStorage *m_pStorage;
 	bool m_Logging;
 
-	static void Con_DbgDumpmem(IConsole::IResult *pResult, void *pUserData)
-	{
-		CEngine *pEngine = static_cast<CEngine *>(pUserData);
-		char aBuf[32];
-		str_timestamp(aBuf, sizeof(aBuf));
-		char aFilename[128];
-		str_format(aFilename, sizeof(aFilename), "dumps/memory_%s.txt", aBuf);
-		mem_debug_dump(pEngine->m_pStorage->OpenFile(aFilename, IOFLAG_WRITE, IStorage::TYPE_SAVE));
-	}
-
 	static void Con_DbgLognetwork(IConsole::IResult *pResult, void *pUserData)
 	{
 		CEngine *pEngine = static_cast<CEngine *>(pUserData);
@@ -97,9 +87,6 @@ public:
 		if(!m_pConsole || !m_pStorage)
 			return;
 
-#ifdef CONF_DEBUG
-		m_pConsole->Register("dbg_dumpmem", "", CFGFLAG_SERVER|CFGFLAG_CLIENT, Con_DbgDumpmem, this, "Dump the memory");
-#endif
 		m_pConsole->Register("dbg_lognetwork", "", CFGFLAG_SERVER|CFGFLAG_CLIENT, Con_DbgLognetwork, this, "Log the network");
 	}
 

--- a/src/engine/shared/memheap.cpp
+++ b/src/engine/shared/memheap.cpp
@@ -10,7 +10,7 @@ void CHeap::NewChunk()
 	char *pMem;
 
 	// allocate memory
-	pMem = (char*)mem_alloc(sizeof(CChunk)+CHUNK_SIZE, 1);
+	pMem = (char *)malloc(sizeof(CChunk) + CHUNK_SIZE);
 	if(!pMem)
 		return;
 
@@ -68,7 +68,7 @@ void CHeap::Clear()
 	while(pChunk)
 	{
 		pNext = pChunk->m_pNext;
-		mem_free(pChunk);
+		free(pChunk);
 		pChunk = pNext;
 	}
 

--- a/src/engine/shared/snapshot.cpp
+++ b/src/engine/shared/snapshot.cpp
@@ -419,7 +419,7 @@ void CSnapshotStorage::PurgeAll()
 	while(pHolder)
 	{
 		pNext = pHolder->m_pNext;
-		mem_free(pHolder);
+		free(pHolder);
 		pHolder = pNext;
 	}
 
@@ -438,7 +438,7 @@ void CSnapshotStorage::PurgeUntil(int Tick)
 		pNext = pHolder->m_pNext;
 		if(pHolder->m_Tick >= Tick)
 			return; // no more to remove
-		mem_free(pHolder);
+		free(pHolder);
 
 		// did we come to the end of the list?
 		if (!pNext)
@@ -463,7 +463,7 @@ void CSnapshotStorage::Add(int Tick, int64 Tagtime, int DataSize, void *pData, i
 	if(CreateAlt)
 		TotalSize += DataSize;
 
-	CHolder *pHolder = (CHolder *)mem_alloc(TotalSize, 1);
+	CHolder *pHolder = (CHolder *)malloc(TotalSize);
 
 	// set data
 	pHolder->m_Tick = Tick;

--- a/src/game/client/components/binds.cpp
+++ b/src/game/client/components/binds.cpp
@@ -30,7 +30,7 @@ CBinds::~CBinds()
 {
 	for(int i = 0; i < KEY_LAST; i++)
 		if(m_apKeyBindings[i])
-			mem_free(m_apKeyBindings[i]);
+			free(m_apKeyBindings[i]);
 }
 
 void CBinds::Bind(int KeyID, const char *pStr, bool FreeOnly)
@@ -43,7 +43,7 @@ void CBinds::Bind(int KeyID, const char *pStr, bool FreeOnly)
 
 	if(m_apKeyBindings[KeyID])
 	{
-		mem_free(m_apKeyBindings[KeyID]);
+		free(m_apKeyBindings[KeyID]);
 		m_apKeyBindings[KeyID] = 0;
 	}
 
@@ -54,17 +54,10 @@ void CBinds::Bind(int KeyID, const char *pStr, bool FreeOnly)
 	}
 	else
 	{
-		int size = str_length(pStr) + 1;
-		m_apKeyBindings[KeyID] = (char *)mem_alloc(size, 1);
-		if(!m_apKeyBindings[KeyID])
-		{
-			str_format(aBuf, sizeof(aBuf), "couldn't bind %s (%d) (bind might be too long)", Input()->KeyName(KeyID), KeyID);
-		}
-		else
-		{
-			str_copy(m_apKeyBindings[KeyID], pStr, size);
-			str_format(aBuf, sizeof(aBuf), "bound %s (%d) = %s", Input()->KeyName(KeyID), KeyID, m_apKeyBindings[KeyID]);
-		}
+		int Size = str_length(pStr) + 1;
+		m_apKeyBindings[KeyID] = (char *)malloc(Size);
+		str_copy(m_apKeyBindings[KeyID], pStr, Size);
+		str_format(aBuf, sizeof(aBuf), "bound %s (%d) = %s", Input()->KeyName(KeyID), KeyID, m_apKeyBindings[KeyID]);
 	}
 	Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "binds", aBuf);
 }
@@ -87,7 +80,7 @@ void CBinds::UnbindAll()
 	for(int i = 0; i < KEY_LAST; i++)
 	{
 		if(m_apKeyBindings[i])
-			mem_free(m_apKeyBindings[i]);
+			free(m_apKeyBindings[i]);
 		m_apKeyBindings[i] = 0;
 	}
 }

--- a/src/game/client/components/countryflags.cpp
+++ b/src/game/client/components/countryflags.cpp
@@ -78,7 +78,7 @@ void CCountryFlags::LoadCountryflagsIndexfile()
 		if(g_Config.m_ClLoadCountryFlags)
 		{
 			CountryFlag.m_Texture = Graphics()->LoadTextureRaw(Info.m_Width, Info.m_Height, Info.m_Format, Info.m_pData, Info.m_Format, 0);
-			mem_free(Info.m_pData);
+			free(Info.m_pData);
 		}
 		else
 			CountryFlag.m_Texture = -1;

--- a/src/game/client/components/flow.cpp
+++ b/src/game/client/components/flow.cpp
@@ -42,18 +42,15 @@ void CFlow::DbgRender()
 
 void CFlow::Init()
 {
-	if(m_pCells)
-	{
-		mem_free(m_pCells);
-		m_pCells = 0;
-	}
+	free(m_pCells);
+	m_pCells = 0;
 
 	CMapItemLayerTilemap *pTilemap = Layers()->GameLayer();
 	m_Width = pTilemap->m_Width*32/m_Spacing;
 	m_Height = pTilemap->m_Height*32/m_Spacing;
 
 	// allocate and clear
-	m_pCells = (CCell *)mem_alloc(sizeof(CCell)*m_Width*m_Height, 1);
+	m_pCells = (CCell *)calloc(m_Width * m_Height, sizeof(CCell));
 	for(int y = 0; y < m_Height; y++)
 		for(int x = 0; x < m_Width; x++)
 			m_pCells[y*m_Width+x].m_Vel = vec2(0.0f, 0.0f);

--- a/src/game/client/components/ghost.cpp
+++ b/src/game/client/components/ghost.cpp
@@ -79,7 +79,7 @@ CGhost::CGhostPath &CGhost::CGhostPath::operator = (CGhostPath &&Other)
 void CGhost::CGhostPath::Reset(int ChunkSize)
 {
 	for(unsigned i = 0; i < m_lChunks.size(); i++)
-		mem_free(m_lChunks[i]);
+		free(m_lChunks[i]);
 	m_lChunks.clear();
 	m_ChunkSize = ChunkSize;
 	m_NumItems = 0;
@@ -94,7 +94,7 @@ void CGhost::CGhostPath::SetSize(int Items)
 	{
 		m_lChunks.resize(NeededChunks);
 		for(int i = Chunks; i < NeededChunks; i++)
-			m_lChunks[i] = (CGhostCharacter*)mem_alloc(sizeof(CGhostCharacter) * m_ChunkSize, 1);
+			m_lChunks[i] = (CGhostCharacter *)calloc(m_ChunkSize, sizeof(CGhostCharacter));
 	}
 
 	m_NumItems = Items;

--- a/src/game/client/components/mapimages.cpp
+++ b/src/game/client/components/mapimages.cpp
@@ -24,10 +24,9 @@ void CMapImages::OnInit()
 	//TODO: improve this a bit -- with better fron sizes etc.
 	if(m_OverlayBottomTexture == -1)
 	{
-		void *pMem = mem_alloc(1024*1024, 1);
-		mem_zero(pMem, 1024*1024);
+		void *pMem = calloc(1024 * 1024, 1);
 		m_OverlayBottomTexture = Graphics()->LoadTextureRaw(1024, 1024, CImageInfo::FORMAT_ALPHA, pMem, CImageInfo::FORMAT_ALPHA, IGraphics::TEXLOAD_NOMIPMAPS);
-		mem_free(pMem);
+		free(pMem);
 		
 		for(int i = 0; i < 256; ++i)
 		{
@@ -41,10 +40,9 @@ void CMapImages::OnInit()
 	}
 	if(m_OverlayTopTexture == -1)
 	{
-		void *pMem = mem_alloc(1024*1024, 1);
-		mem_zero(pMem, 1024*1024);
+		void *pMem = calloc(1024 * 1024, 1);
 		m_OverlayTopTexture = Graphics()->LoadTextureRaw(1024, 1024, CImageInfo::FORMAT_ALPHA, pMem, CImageInfo::FORMAT_ALPHA, IGraphics::TEXLOAD_NOMIPMAPS);
-		mem_free(pMem);
+		free(pMem);
 		
 		for(int i = 0; i < 256; ++i)
 		{
@@ -58,10 +56,9 @@ void CMapImages::OnInit()
 	}
 	if(m_OverlayCenterTexture == -1)
 	{
-		void *pMem = mem_alloc(1024*1024, 1);
-		mem_zero(pMem, 1024*1024);
+		void *pMem = calloc(1024 * 1024, 1);
 		m_OverlayCenterTexture = Graphics()->LoadTextureRaw(1024, 1024, CImageInfo::FORMAT_ALPHA, pMem, CImageInfo::FORMAT_ALPHA, IGraphics::TEXLOAD_NOMIPMAPS);
-		mem_free(pMem);
+		free(pMem);
 
 		for(int i = 0; i < 256; ++i)
 		{

--- a/src/game/client/components/skins.cpp
+++ b/src/game/client/components/skins.cpp
@@ -132,7 +132,7 @@ int CSkins::SkinScan(const char *pName, int IsDir, int DirType, void *pUser)
 		}
 
 	Skin.m_ColorTexture = pSelf->Graphics()->LoadTextureRaw(Info.m_Width, Info.m_Height, Info.m_Format, Info.m_pData, Info.m_Format, 0);
-	mem_free(Info.m_pData);
+	free(Info.m_pData);
 
 	// set skin data
 	str_copy(Skin.m_aName, pName, min((int)sizeof(Skin.m_aName),l-3));

--- a/src/game/client/components/statboard.cpp
+++ b/src/game/client/components/statboard.cpp
@@ -419,19 +419,11 @@ void CStatboard::AutoStatCSV()
 
 		FormatStats();
 
-		unsigned int len = str_length(m_pCSVstr);
-		char* buf = (char*)mem_alloc(len, 0);
-		mem_copy(buf, m_pCSVstr, len);
-
-		mem_free(m_pCSVstr);
-
 		if(File)
 		{
-			io_write(File, buf, sizeof(char)*len);
+			io_write(File, m_pCSVstr, str_length(m_pCSVstr));
 			io_close(File);
 		}
-
-		mem_free(buf);
 
 		Client()->AutoCSV_Start();
 	}
@@ -560,8 +552,7 @@ void CStatboard::FormatStats()
 	char aStats[1024*(VANILLA_MAX_CLIENTS+1)];
 	str_format(aStats, sizeof(aStats), "%s\n\n%s", aServerStats, aPlayerStats);
 
-	unsigned int len = str_length(aStats);
-	m_pCSVstr = (char*)mem_alloc(len, 0);
-	mem_zero(m_pCSVstr, len);
-	str_copy(m_pCSVstr, aStats, len);
+	unsigned int Len = str_length(aStats);
+	m_pCSVstr = (char *)malloc(Len);
+	str_copy(m_pCSVstr, aStats, Len);
 }

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -63,7 +63,7 @@ CEditorImage::~CEditorImage()
 	m_pEditor->Graphics()->UnloadTexture(m_TexID);
 	if(m_pData)
 	{
-		mem_free(m_pData);
+		free(m_pData);
 		m_pData = 0;
 	}
 }
@@ -73,7 +73,7 @@ CEditorSound::~CEditorSound()
 	m_pEditor->Sound()->UnloadSample(m_SoundID);
 	if(m_pData)
 	{
-		mem_free(m_pData);
+		free(m_pData);
 		m_pData = 0x0;
 	}
 }
@@ -3069,7 +3069,7 @@ void CEditor::ReplaceImage(const char *pFileName, int StorageType, void *pUser)
 	pEditor->Graphics()->UnloadTexture(pImg->m_TexID);
 	if(pImg->m_pData)
 	{
-		mem_free(pImg->m_pData);
+		free(pImg->m_pData);
 		pImg->m_pData = 0;
 	}
 	*pImg = ImgInfo;
@@ -3155,7 +3155,7 @@ void CEditor::AddSound(const char *pFileName, int StorageType, void *pUser)
 		return;
 	}
 
-	void *pData = mem_alloc((unsigned) DataSize, 1);
+	void *pData = malloc((unsigned) DataSize);
 	io_read(SoundFile, pData, (unsigned) DataSize);
 	io_close(SoundFile);
 
@@ -3208,7 +3208,7 @@ void CEditor::ReplaceSound(const char *pFileName, int StorageType, void *pUser)
 		return;
 	}
 
-	void *pData = mem_alloc((unsigned) DataSize, 1);
+	void *pData = malloc((unsigned) DataSize);
 	io_read(SoundFile, pData, (unsigned) DataSize);
 	io_close(SoundFile);
 
@@ -3219,7 +3219,7 @@ void CEditor::ReplaceSound(const char *pFileName, int StorageType, void *pUser)
 	pEditor->Sound()->UnloadSample(pSound->m_SoundID);
 	if(pSound->m_pData)
 	{
-		mem_free(pSound->m_pData);
+		free(pSound->m_pData);
 		pSound->m_pData = 0x0;
 	}
 
@@ -3893,7 +3893,7 @@ void CEditor::RenderFileDialog()
 				if(Graphics()->LoadPNG(&m_FilePreviewImageInfo, aBuffer, IStorage::TYPE_ALL))
 				{
 					m_FilePreviewImage = Graphics()->LoadTextureRaw(m_FilePreviewImageInfo.m_Width, m_FilePreviewImageInfo.m_Height, m_FilePreviewImageInfo.m_Format, m_FilePreviewImageInfo.m_pData, m_FilePreviewImageInfo.m_Format, IGraphics::TEXLOAD_NORESAMPLE);
-					mem_free(m_FilePreviewImageInfo.m_pData);
+					free(m_FilePreviewImageInfo.m_pData);
 				}
 			}
 		}

--- a/src/game/editor/io.cpp
+++ b/src/game/editor/io.cpp
@@ -267,7 +267,7 @@ int CEditorMap::Save(class IStorage *pStorage, const char *pFileName)
 				Size += str_length(m_lSettings[i].m_aCommand) + 1;
 			}
 
-			char *pSettings = (char *)mem_alloc(Size, 1);
+			char *pSettings = (char *)malloc(Size);
 			char *pNext = pSettings;
 			for(int i = 0; i < m_lSettings.size(); i++)
 			{
@@ -276,7 +276,7 @@ int CEditorMap::Save(class IStorage *pStorage, const char *pFileName)
 				pNext += Length;
 			}
 			Item.m_Settings = df.AddData(Size, pSettings);
-			mem_free(pSettings);
+			free(pSettings);
 		}
 
 		df.AddItem(MAPITEMTYPE_INFO, 0, sizeof(Item), &Item);
@@ -305,7 +305,7 @@ int CEditorMap::Save(class IStorage *pStorage, const char *pFileName)
 			if(pImg->m_Format == CImageInfo::FORMAT_RGB)
 			{
 				// Convert to RGBA
-				unsigned char *pDataRGBA = (unsigned char *)mem_alloc(Item.m_Width*Item.m_Height*4, 1);
+				unsigned char *pDataRGBA = (unsigned char *)malloc(Item.m_Width * Item.m_Height * 4);
 				unsigned char *pDataRGB = (unsigned char *)pImg->m_pData;
 				for(int i = 0; i < Item.m_Width*Item.m_Height; i++)
 				{
@@ -316,7 +316,7 @@ int CEditorMap::Save(class IStorage *pStorage, const char *pFileName)
 					pDataRGBA[i*4+3] = 255;
 				}
 				Item.m_ImageData = df.AddData(Item.m_Width*Item.m_Height*4, pDataRGBA);
-				mem_free(pDataRGBA);
+				free(pDataRGBA);
 			}
 			else
 			{
@@ -418,10 +418,10 @@ int CEditorMap::Save(class IStorage *pStorage, const char *pFileName)
 
 				if (Item.m_Flags && !(pLayer->m_Game))
 				{
-					CTile *pEmptyTiles = (CTile*)mem_alloc(sizeof(CTile)*pLayer->m_Width*pLayer->m_Height, 1);
+					CTile *pEmptyTiles = (CTile *)calloc(pLayer->m_Width*pLayer->m_Height, sizeof(CTile));
 					mem_zero(pEmptyTiles, pLayer->m_Width*pLayer->m_Height*sizeof(CTile));
 					Item.m_Data = df.AddData(pLayer->m_Width*pLayer->m_Height*sizeof(CTile), pEmptyTiles);
-					mem_free(pEmptyTiles);
+					free(pEmptyTiles);
 
 					if(pLayer->m_Tele)
 						Item.m_Tele = df.AddData(pLayer->m_Width*pLayer->m_Height*sizeof(CTeleTile), ((CLayerTele *)pLayer)->m_pTeleTile);
@@ -520,7 +520,7 @@ int CEditorMap::Save(class IStorage *pStorage, const char *pFileName)
 
 	// save points
 	int TotalSize = sizeof(CEnvPoint) * PointCount;
-	CEnvPoint *pPoints = (CEnvPoint *)mem_alloc(TotalSize, 1);
+	CEnvPoint *pPoints = (CEnvPoint *)calloc(PointCount, sizeof(*pPoints));
 	PointCount = 0;
 
 	for(int e = 0; e < m_lEnvelopes.size(); e++)
@@ -531,7 +531,7 @@ int CEditorMap::Save(class IStorage *pStorage, const char *pFileName)
 	}
 
 	df.AddItem(MAPITEMTYPE_ENVPOINTS, 0, TotalSize, pPoints);
-	mem_free(pPoints);
+	free(pPoints);
 
 	// finish the data file
 	df.Finish();
@@ -683,7 +683,7 @@ int CEditorMap::Load(class IStorage *pStorage, const char *pFileName, int Storag
 
 					// copy image data
 					void *pData = DataFile.GetData(pItem->m_ImageData);
-					pImg->m_pData = mem_alloc(pImg->m_Width*pImg->m_Height*4, 1);
+					pImg->m_pData = malloc(pImg->m_Width*pImg->m_Height*4);
 					mem_copy(pImg->m_pData, pData, pImg->m_Width*pImg->m_Height*4);
 					pImg->m_TexID = m_pEditor->Graphics()->LoadTextureRaw(pImg->m_Width, pImg->m_Height, pImg->m_Format, pImg->m_pData, CImageInfo::FORMAT_AUTO, 0);
 				}
@@ -730,7 +730,7 @@ int CEditorMap::Load(class IStorage *pStorage, const char *pFileName, int Storag
 
 						if(pSound->m_DataSize > 0)
 						{
-							pSound->m_pData = mem_alloc(pSound->m_DataSize, 1);
+							pSound->m_pData = malloc(pSound->m_DataSize);
 							io_read(SoundFile, pSound->m_pData, pSound->m_DataSize);
 						}
 						io_close(SoundFile);
@@ -746,7 +746,7 @@ int CEditorMap::Load(class IStorage *pStorage, const char *pFileName, int Storag
 
 					// copy sample data
 					void *pData = DataFile.GetData(pItem->m_SoundData);
-					pSound->m_pData = mem_alloc(pSound->m_DataSize, 1);
+					pSound->m_pData = malloc(pSound->m_DataSize);
 					mem_copy(pSound->m_pData, pData, pSound->m_DataSize);
 					pSound->m_SoundID = m_pEditor->Sound()->LoadOpusFromMem(pSound->m_pData, pSound->m_DataSize, true);
 				}

--- a/src/game/server/entity.h
+++ b/src/game/server/entity.h
@@ -11,15 +11,13 @@
 	public: \
 	void *operator new(size_t Size) \
 	{ \
-		void *p = mem_alloc(Size, 1); \
-		/*dbg_msg("", "++ %p %d", p, size);*/ \
+		void *p = malloc(Size); \
 		mem_zero(p, Size); \
 		return p; \
 	} \
 	void operator delete(void *pPtr) \
 	{ \
-		/*dbg_msg("", "-- %p", p);*/ \
-		mem_free(pPtr); \
+		free(pPtr); \
 	} \
 	private:
 

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -2855,21 +2855,21 @@ void CGameContext::OnMapChange(char *pNewMapName, int MapNameSize)
 	while((pLine = LineReader.Get()))
 	{
 		int Length = str_length(pLine) + 1;
-		char *pCopy = (char *)mem_alloc(Length, 1);
+		char *pCopy = (char *)malloc(Length);
 		mem_copy(pCopy, pLine, Length);
 		aLines.add(pCopy);
 		TotalLength += Length;
 	}
 	io_close(File);
 
-	char *pSettings = (char *)mem_alloc(TotalLength, 1);
+	char *pSettings = (char *)malloc(TotalLength);
 	int Offset = 0;
 	for(int i = 0; i < aLines.size(); i++)
 	{
 		int Length = str_length(aLines[i]) + 1;
 		mem_copy(pSettings + Offset, aLines[i], Length);
 		Offset += Length;
-		mem_free(aLines[i]);
+		free(aLines[i]);
 	}
 
 	CDataFileReader Reader;

--- a/src/tools/config_store.cpp
+++ b/src/tools/config_store.cpp
@@ -24,21 +24,21 @@ void Process(IStorage *pStorage, const char *pMapName, const char *pConfigName)
 	while((pLine = LineReader.Get()))
 	{
 		int Length = str_length(pLine) + 1;
-		char *pCopy = (char *)mem_alloc(Length, 1);
+		char *pCopy = (char *)malloc(Length);
 		mem_copy(pCopy, pLine, Length);
 		aLines.add(pCopy);
 		TotalLength += Length;
 	}
 	io_close(File);
 
-	pSettings = (char *)mem_alloc(TotalLength, 1);
+	pSettings = (char *)malloc(TotalLength);
 	int Offset = 0;
 	for(int i = 0; i < aLines.size(); i++)
 	{
 		int Length = str_length(aLines[i]) + 1;
 		mem_copy(pSettings + Offset, aLines[i], Length);
 		Offset += Length;
-		mem_free(aLines[i]);
+		free(aLines[i]);
 	}
 
 	CDataFileReader Reader;

--- a/src/tools/crapnet.cpp
+++ b/src/tools/crapnet.cpp
@@ -79,7 +79,7 @@ void Run(unsigned short Port, NETADDR Dest)
 			}
 
 			// create new packet
-			CPacket *p = (CPacket *)mem_alloc(sizeof(CPacket)+Bytes, 1);
+			CPacket *p = (CPacket *)malloc(sizeof(CPacket) + Bytes);
 
 			if(net_addr_comp(&From, &Dest) == 0)
 				p->m_SendTo = Src; // from the server
@@ -198,7 +198,7 @@ void Run(unsigned short Port, NETADDR Dest)
 				}
 
 
-				mem_free(p);
+				free(p);
 			}
 		}
 

--- a/src/tools/dilate.cpp
+++ b/src/tools/dilate.cpp
@@ -62,9 +62,9 @@ int DilateFile(const char *pFileName)
 		return 1;
 	}
 
-	pBuffer[0] = (CPixel*)mem_alloc(Png.width*Png.height*sizeof(CPixel), 1);
-	pBuffer[1] = (CPixel*)mem_alloc(Png.width*Png.height*sizeof(CPixel), 1);
-	pBuffer[2] = (CPixel*)mem_alloc(Png.width*Png.height*sizeof(CPixel), 1);
+	pBuffer[0] = (CPixel *)malloc(Png.width * Png.height * sizeof(CPixel));
+	pBuffer[1] = (CPixel *)malloc(Png.width * Png.height * sizeof(CPixel));
+	pBuffer[2] = (CPixel *)malloc(Png.width * Png.height * sizeof(CPixel));
 	png_get_data(&Png, (unsigned char *)pBuffer[0]);
 	png_close_file(&Png);
 

--- a/src/tools/map_replace_image.cpp
+++ b/src/tools/map_replace_image.cpp
@@ -46,7 +46,7 @@ int LoadPNG(CImageInfo *pImg, const char *pFilename)
 		return 0;
 	}
 
-	pBuffer = (unsigned char *)mem_alloc(Png.width * Png.height * Png.bpp, 1);
+	pBuffer = (unsigned char *)malloc(Png.width * Png.height * Png.bpp);
 	png_get_data(&Png, pBuffer);
 	png_close_file(&Png);
 

--- a/src/tools/tileset_borderadd.cpp
+++ b/src/tools/tileset_borderadd.cpp
@@ -57,8 +57,8 @@ int FixFile(const char *pFileName)
 	int w = Png.width;
 	int h = Png.height;
 
-	pBuffer[0] = (CPixel*)mem_alloc(w*h*sizeof(CPixel), 1);
-	pBuffer[1] = (CPixel*)mem_alloc((w+16*4)*(h+16*4)*sizeof(CPixel), 1);
+	pBuffer[0] = (CPixel *)malloc(w * h * sizeof(CPixel));
+	pBuffer[1] = (CPixel *)malloc((w + 16 * 4) * (h + 16 * 4) * sizeof(CPixel));
 	png_get_data(&Png, (unsigned char *)pBuffer[0]);
 	png_close_file(&Png);
 

--- a/src/tools/tileset_borderfix.cpp
+++ b/src/tools/tileset_borderfix.cpp
@@ -69,8 +69,8 @@ int FixFile(const char *pFileName)
 	int w = Png.width;
 	int h = Png.height;
 
-	pBuffer[0] = (CPixel*)mem_alloc(w*h*sizeof(CPixel), 1);
-	pBuffer[1] = (CPixel*)mem_alloc(w*h*sizeof(CPixel), 1);
+	pBuffer[0] = (CPixel *)malloc(w * h * sizeof(CPixel));
+	pBuffer[1] = (CPixel *)malloc(w * h * sizeof(CPixel));
 	png_get_data(&Png, (unsigned char *)pBuffer[0]);
 	png_close_file(&Png);
 

--- a/src/tools/tileset_borderrem.cpp
+++ b/src/tools/tileset_borderrem.cpp
@@ -57,8 +57,8 @@ int FixFile(const char *pFileName)
 	int w = Png.width;
 	int h = Png.height;
 
-	pBuffer[0] = (CPixel*)mem_alloc(w*h*sizeof(CPixel), 1);
-	pBuffer[1] = (CPixel*)mem_alloc((w-16*4)*(h-16*4)*sizeof(CPixel), 1);
+	pBuffer[0] = (CPixel *)malloc(w * h * sizeof(CPixel));
+	pBuffer[1] = (CPixel *)malloc((w - 16 * 4) * (h - 16 * 4) * sizeof(CPixel));
 	png_get_data(&Png, (unsigned char *)pBuffer[0]);
 	png_close_file(&Png);
 

--- a/src/tools/tileset_borderset.cpp
+++ b/src/tools/tileset_borderset.cpp
@@ -49,8 +49,8 @@ int FixFile(const char *pFileName)
 	int w = Png.width;
 	int h = Png.height;
 
-	pBuffer[0] = (CPixel*)mem_alloc(w*h*sizeof(CPixel), 1);
-	pBuffer[1] = (CPixel*)mem_alloc(w*h*sizeof(CPixel), 1);
+	pBuffer[0] = (CPixel *)malloc(w * h * sizeof(CPixel));
+	pBuffer[1] = (CPixel *)malloc(w * h * sizeof(CPixel));
 	png_get_data(&Png, (unsigned char *)pBuffer[0]);
 	png_close_file(&Png);
 


### PR DESCRIPTION
Replace `mem_free` by `free`, and `mem_alloc` by `malloc` or `calloc`
(the latter one being used to allocate a zeroed array of elements,
sometimes, this makes a call to `mem_zero` superfluous).

This results in having to remove `mem_stats` which previously recorded
the number of allocations and their size that the Teeworlds code did
directly.

Remove OOM handling in `src/game/client/components/binds.cpp`.

Remove needless copying in the CSV code in
`src/game/client/components/statboard.cpp`.