### PR TITLE
Revert "Don't use aio logging to stdout on Windows"

### DIFF
--- a/src/base/system.c
+++ b/src/base/system.c
@@ -169,15 +169,6 @@ static void logger_file(const char *line, void *user)
 	aio_unlock(logfile);
 }
 
-#if defined(CONF_FAMILY_WINDOWS)
-static void logger_stdout_sync(const char *line, void *user)
-{
-	(void)user;
-	puts(line);
-	fflush(stdout);
-}
-#endif
-
 static void logger_stdout_finish(void *user)
 {
 	ASYNCIO *logfile = (ASYNCIO *)user;
@@ -220,11 +211,7 @@ void dbg_logger(DBG_LOGGER logger, DBG_LOGGER_FINISH finish, void *user)
 
 void dbg_logger_stdout()
 {
-#if defined(CONF_FAMILY_WINDOWS)
-	dbg_logger(logger_stdout_sync, 0, 0);
-#else
 	dbg_logger(logger_file, logger_stdout_finish, aio_new(io_stdout()));
-#endif
 }
 
 void dbg_logger_debugger()


### PR DESCRIPTION
This reverts commit 8f291ce5284d97353252db6ec852236fed1a355e.