### PR TITLE
Remove superfluous parameter from `CServer::NewClientNoAuthCallback`

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -769,24 +769,21 @@ int CServer::ClientRejoinCallback(int ClientID, void *pUser)
 	return 0;
 }
 
-int CServer::NewClientNoAuthCallback(int ClientID, bool Reset, void *pUser)
+int CServer::NewClientNoAuthCallback(int ClientID, void *pUser)
 {
 	CServer *pThis = (CServer *)pUser;
 
 	pThis->m_aClients[ClientID].m_DnsblState = CClient::DNSBL_STATE_NONE;
 
-	if (Reset)
-	{
-		pThis->m_aClients[ClientID].m_State = CClient::STATE_CONNECTING;
-		pThis->m_aClients[ClientID].m_aName[0] = 0;
-		pThis->m_aClients[ClientID].m_aClan[0] = 0;
-		pThis->m_aClients[ClientID].m_Country = -1;
-		pThis->m_aClients[ClientID].m_Authed = AUTHED_NO;
-		pThis->m_aClients[ClientID].m_AuthKey = -1;
-		pThis->m_aClients[ClientID].m_AuthTries = 0;
-		pThis->m_aClients[ClientID].m_pRconCmdToSend = 0;
-		pThis->m_aClients[ClientID].Reset();
-	}
+	pThis->m_aClients[ClientID].m_State = CClient::STATE_CONNECTING;
+	pThis->m_aClients[ClientID].m_aName[0] = 0;
+	pThis->m_aClients[ClientID].m_aClan[0] = 0;
+	pThis->m_aClients[ClientID].m_Country = -1;
+	pThis->m_aClients[ClientID].m_Authed = AUTHED_NO;
+	pThis->m_aClients[ClientID].m_AuthKey = -1;
+	pThis->m_aClients[ClientID].m_AuthTries = 0;
+	pThis->m_aClients[ClientID].m_pRconCmdToSend = 0;
+	pThis->m_aClients[ClientID].Reset();
 
 	pThis->SendMap(ClientID);
 #if defined(CONF_FAMILY_UNIX)

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -261,7 +261,7 @@ public:
 	void DoSnapshot();
 
 	static int NewClientCallback(int ClientID, void *pUser);
-	static int NewClientNoAuthCallback(int ClientID, bool Reset, void *pUser);
+	static int NewClientNoAuthCallback(int ClientID, void *pUser);
 	static int DelClientCallback(int ClientID, const char *pReason, void *pUser);
 
 	static int ClientRejoinCallback(int ClientID, void *pUser);

--- a/src/engine/shared/network.h
+++ b/src/engine/shared/network.h
@@ -101,7 +101,7 @@ enum
 
 typedef int (*NETFUNC_DELCLIENT)(int ClientID, const char *pReason, void *pUser);
 typedef int (*NETFUNC_NEWCLIENT)(int ClientID, void *pUser);
-typedef int (*NETFUNC_NEWCLIENT_NOAUTH)(int ClientID, bool Reset, void *pUser);
+typedef int (*NETFUNC_NEWCLIENT_NOAUTH)(int ClientID, void *pUser);
 typedef int (*NETFUNC_CLIENTREJOIN)(int ClientID, void *pUser);
 
 struct CNetChunk

--- a/src/engine/shared/network_server.cpp
+++ b/src/engine/shared/network_server.cpp
@@ -280,7 +280,7 @@ int CNetServer::TryAcceptClient(NETADDR &Addr, SECURITY_TOKEN SecurityToken, boo
 
 
 	if (VanillaAuth)
-		m_pfnNewClientNoAuth(Slot, true, m_UserPtr);
+		m_pfnNewClientNoAuth(Slot, m_UserPtr);
 	else
 		m_pfnNewClient(Slot, m_UserPtr);
 


### PR DESCRIPTION
The `Reset` parameter was only ever set to true, at the only call site.