### PR TITLE
Add server to discord bridge

### DIFF
--- a/scripts/ddnet-discord.py
+++ b/scripts/ddnet-discord.py
@@ -8,8 +8,8 @@ import sys
 def send_discord(message):
     requests.post("https://discordapp.com/api/webhooks/" + keys.webhook, data={"content": message})
 
-if not len(sys.argv) == 2:
-    print('usage: ' + str(sys.argv[0]) + ' "message"')
+if len(sys.argv) != 2:
+    print('usage: ' + str(sys.argv[0]) + ' message')
     exit()
 
 send_discord(sys.argv[1])

--- a/scripts/ddnet-discord.py
+++ b/scripts/ddnet-discord.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+# Python webhook to discord
+
+import requests
+import keys
+import sys
+
+def send_discord(message):
+    requests.post("https://discordapp.com/api/webhooks/" + keys.webhook, data={"content": message})
+
+if not len(sys.argv) == 2:
+    print('usage: ' + str(sys.argv[0]) + ' "message"')
+    exit()
+
+send_discord(sys.argv[1])

--- a/scripts/keys.py
+++ b/scripts/keys.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python3
+
+webhook = "443098194583486464/-VMsqTICEmDWxFmN_Iz5gp5J_AmTQGwF_4NJCRro3Gf6ZBx4wMbCe_bnQX8XA8K7x_jI"

--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -1438,6 +1438,39 @@ void CGameContext::ConModHelp(IConsole::IResult *pResult, void *pUserData)
 			pSelf->Server()->ClientName(pResult->m_ClientID),
 			pResult->m_ClientID);
 
+    // Prepare user data for discord
+    char aHelpMsg[128];
+    char aName[32];
+    str_copy(aName, pSelf->Server()->ClientName(pResult->m_ClientID), sizeof(aName));
+    str_copy(aHelpMsg, pResult->GetString(0), sizeof(aHelpMsg));
+    for(unsigned int i = 0; i < sizeof(aHelpMsg); i++) // don't escape the discord format
+    {
+        if(aHelpMsg[i] == '\0') { break; }
+        if(aHelpMsg[i] == '`') { aHelpMsg[i] = ' '; }
+    }
+    for(unsigned int i = 0; i < sizeof(aName); i++)
+    {
+        if(aName[i] == '\0') { break; }
+        if(aName[i] == '`') { aName[i] = ' '; }
+    }
+    for(unsigned int i = 0; i < sizeof(aHelpMsg); i++) // don't escape the argument string
+    {
+        if(aHelpMsg[i] == '\0') { break; }
+        if(aHelpMsg[i] == '\'') { aHelpMsg[i] = ' '; }
+    }
+    for(unsigned int i = 0; i < sizeof(aName); i++)
+    {
+        if(aName[i] == '\0') { break; }
+        if(aName[i] == '\'') { aName[i] = ' '; }
+    }
+
+    // Execute discord script
+    char aDiscord[128 + 512];
+    str_format(aDiscord, sizeof(aDiscord), "./ddnet-discord.py '@Moderator\n``Player: %s\nPort: %d\nProblem: %s``'", aName, g_Config.m_SvPort, aHelpMsg);
+    dbg_msg("discord", "sycall: %s", aDiscord);
+    int sys = system(aDiscord);
+    if (!sys) { dbg_msg("discord", "syscall failed with code: %d", sys); }
+
 	// Send the request to all authed clients.
 	for ( int i = 0; i < MAX_CLIENTS; i++ )
 	{


### PR DESCRIPTION
ddnet-discord.py does all the magic. It takes an string as argument and sends it too an discord webhook.
The keys.py could be hidden by gitignore for example, but for now it holds my webhook super secret key so you can test it on my server if you want.

To test it the server needs ``ddnet-discord.py`` and ``keys.py`` in the same directory as the server.
Then an ingame command like ``/modhelp help me please c:`` should arrive at the https://discord.gg/HsTAyzp discord.

For security i did replace some chars like ` and ' with spaces to avoid some escapes, but im not sure if it is really secure. I guess its dangerous since we have userinput in a system call o.O