### PR TITLE
Fix unwanted dummy fire

### DIFF
--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -401,7 +401,9 @@ void CGameClient::OnDummySwap()
 		m_pControls->ResetInput(!g_Config.m_ClDummy);
 		m_pControls->m_InputData[!g_Config.m_ClDummy].m_Hook = 0;
 	}
+	int tmp = m_DummyInput.m_Fire;
 	m_DummyInput = m_pControls->m_InputData[!g_Config.m_ClDummy];
+	m_pControls->m_InputData[g_Config.m_ClDummy].m_Fire = tmp;
 }
 
 int CGameClient::OnSnapInput(int *pData, bool Dummy, bool Force)


### PR DESCRIPTION
If the latest fire input and the current differ in any way it causes firing.
So if you switch dummy after hammerfly was used it causes a weaponfire.
This unwanted fireing caused many unlucky fails for me already.
So i swap the fire status on dummyswapping so the server doesn't see any difference even if hammerfly was used.