### PR TITLE
Fix warning about incompatible function pointers

### DIFF
--- a/src/base/system.c
+++ b/src/base/system.c
@@ -664,17 +664,44 @@ void aio_wait(ASYNCIO *aio)
 	thread_wait(thread);
 }
 
+struct THREAD_RUN
+{
+	void (*threadfunc)(void *);
+	void *u;
+};
+
+#if defined(CONF_FAMILY_UNIX)
+static void *thread_run(void *user)
+#elif defined(CONF_FAMILY_WINDOWS)
+static unsigned int __stdcall thread_run(void *user)
+#else
+#error not implemented
+#endif
+{
+	struct THREAD_RUN *data = user;
+	void (*threadfunc)(void *) = data->threadfunc;
+	void *u = data->u;
+	free(data);
+	threadfunc(u);
+	return 0;
+}
+
 void *thread_init(void (*threadfunc)(void *), void *u)
 {
+	struct THREAD_RUN *data = malloc(sizeof(*data));
+	data->threadfunc = threadfunc;
+	data->u = u;
 #if defined(CONF_FAMILY_UNIX)
-	pthread_t id;
-	if(pthread_create(&id, NULL, (void *(*)(void*))threadfunc, u) != 0)
 	{
-		return 0;
+		pthread_t id;
+		if(pthread_create(&id, NULL, thread_run, data) != 0)
+		{
+			return 0;
+		}
+		return (void*)id;
 	}
-	return (void*)id;
 #elif defined(CONF_FAMILY_WINDOWS)
-	return CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE)threadfunc, u, 0, NULL);
+	return CreateThread(NULL, 0, thread_run, data, 0, NULL);
 #else
 	#error not implemented
 #endif


### PR DESCRIPTION
This comes at the cost of one allocation per started thread. This should
be okay because we're about to invoke a syscall anyway.