### PR TITLE
Fix pain emote immunity with jetpack

### DIFF
--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -165,7 +165,7 @@ void CCharacter::HandleJetpack()
 					Strength = GameServer()->Tuning()->m_JetpackStrength;
 				else
 					Strength = GameServer()->TuningList()[m_TuneZone].m_JetpackStrength;
-				TakeDamage(Direction * -1.0f * (Strength / 100.0f / 6.11f), g_pData->m_Weapons.m_Hammer.m_pBase->m_Damage, m_pPlayer->GetCID(), m_Core.m_ActiveWeapon);
+				TakeDamage(Direction * -1.0f * (Strength / 100.0f / 6.11f), 0, m_pPlayer->GetCID(), m_Core.m_ActiveWeapon);
 			}
 		}
 	}
@@ -990,7 +990,7 @@ bool CCharacter::TakeDamage(vec2 Force, int Dmg, int From, int Weapon)
 	else
 		GameServer()->CreateSound(m_Pos, SOUND_PLAYER_PAIN_SHORT);*/
 
-	if (!m_Jetpack || m_Core.m_ActiveWeapon != WEAPON_GUN)
+	if (Dmg)
 	{
 		m_EmoteType = EMOTE_PAIN;
 		m_EmoteStop = Server()->Tick() + 500 * Server()->TickSpeed() / 1000;


### PR DESCRIPTION
When using jetpack, tees don't do pain emotes when they're supposed to (e.g. when they get hit by exploding bullets).

Notice how in the image below the tee doesn't have the pain emote.
![jetpack-pain-emote-immunity](https://user-images.githubusercontent.com/20409621/41883435-9b13aa1e-78bc-11e8-8fef-fd75165b4d79.png)
