### PR TITLE
Fix Mac linking for cross-compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -409,8 +409,8 @@ elseif(TARGET_OS STREQUAL "mac")
     src/osxlaunch/client.h
     src/osxlaunch/client.m
   )
-  set(PLATFORM_CLIENT_LIBS ${COCOA} ${OPENGL} ${SECURITY})
-  set(PLATFORM_LIBS ${CARBON})
+  set(PLATFORM_CLIENT_LIBS ${COCOA} ${OPENGL})
+  set(PLATFORM_LIBS ${CARBON} ${SECURITY})
 else()
   set(PLATFORM_CLIENT)
   set(PLATFORM_CLIENT_LIBS GL GLU X11)


### PR DESCRIPTION
The `Security` framework is now needed on all targets because we link
libcurl everywhere.