### PR TITLE
Add new freeze automap rule

### DIFF
--- a/data/editor/round_tiles.rules
+++ b/data/editor/round_tiles.rules
@@ -98,3 +98,49 @@ Pos 1 1 FULL
 Pos 0 -1 EMPTY
 Pos -1 0 EMPTY
 Pos -1 -1 EMPTY
+
+[Chiller]
+Index 1
+
+#FLY
+Index 1
+Pos 0 -1 EMPTY
+Pos 1 0 EMPTY
+Pos 0 1 EMPTY
+Pos -1 0 EMPTY
+
+#top
+Index 1
+Pos 0 -1 EMPTY
+
+#right
+Index 1
+Pos 1 0 EMPTY
+
+#bottom
+Index 1
+Pos 0 1 EMPTY
+
+#left
+Index 1
+Pos -1 0 EMPTY
+
+#corner top-right
+Index 18 YFLIP
+Pos 0 -1 EMPTY
+Pos 1 0 EMPTY
+
+#corner top-left
+Index 18 YFLIP XFLIP
+Pos 0 -1 EMPTY
+Pos -1 0 EMPTY
+
+#corner bottom-left
+Index 18 XFLIP
+Pos 0 1 EMPTY
+Pos -1 0 EMPTY
+
+#corner bottom-right
+Index 18 
+Pos 0 1 EMPTY
+Pos 1 0 EMPTY


### PR DESCRIPTION
The other DDNet rule adds these round corners which messes up the gametiles function.
So i decided to publish my own rule im happily using since years especially for my gores maps. But since its also usefull for other gametypes even non ddrace ones i called it the "Chiller" rule^^

I couldn't find a better name for the rule idk if someone has a problem with it.