### PR TITLE
fix projectiles not rendering on mods based on ddnet

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -1877,10 +1877,7 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket)
 					// for antiping: if the projectile netobjects from the server contains extra data, this is removed and the original content restored before recording demo
 					unsigned char aExtraInfoRemoved[CSnapshot::MAX_SIZE];
 					mem_copy(aExtraInfoRemoved, pTmpBuffer3, SnapSize);
-					CServerInfo Info;
-					GetServerInfo(&Info);
-					if(IsDDNet(&Info))
-						SnapshotRemoveExtraInfo(aExtraInfoRemoved);
+					SnapshotRemoveExtraInfo(aExtraInfoRemoved);
 
 					// add snapshot to demo
 					for(int i = 0; i < RECORDER_MAX; i++)

--- a/src/game/client/components/items.cpp
+++ b/src/game/client/components/items.cpp
@@ -73,9 +73,7 @@ void CItems::RenderProjectile(const CNetObj_Projectile *pCurrent, int ItemID)
 	vec2 StartPos;
 	vec2 StartVel;
 
-	CServerInfo Info;
-	Client()->GetServerInfo(&Info);
-	ExtractInfo(pCurrent, &StartPos, &StartVel, IsDDNet(&Info));
+	ExtractInfo(pCurrent, &StartPos, &StartVel);
 
 	vec2 Pos = CalcPos(StartPos, StartVel, Curvature, Speed, Ct);
 	vec2 PrevPos = CalcPos(StartPos, StartVel, Curvature, Speed, Ct-0.001f);

--- a/src/game/client/components/items.cpp
+++ b/src/game/client/components/items.cpp
@@ -17,7 +17,6 @@
 #include "items.h"
 #include <stdio.h>
 
-#include <engine/serverbrowser.h>
 void CItems::OnReset()
 {
 	m_NumExtraProjectiles = 0;

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -716,7 +716,7 @@ void CGameClient::OnMessage(int MsgId, CUnpacker *pUnpacker, bool IsDummy)
 			{
 				vec2 StartPos;
 				vec2 Direction;
-				ExtractInfo(&Proj, &StartPos, &Direction, 1);
+				ExtractInfo(&Proj, &StartPos, &Direction);
 				if(CWeaponData *pCurrentData = GetWeaponData(Proj.m_StartTick))
 				{
 					if(CWeaponData *pMatchingData = FindWeaponData(Proj.m_StartTick))
@@ -2098,7 +2098,7 @@ void CLocalProjectile::Init(CGameClient *pGameClient, CWorldCore *pWorld, CColli
 	m_Type = pProj->m_Type;
 	m_Weapon = m_Type;
 
-	ExtractInfo(pProj, &m_Pos, &m_Direction, 1);
+	ExtractInfo(pProj, &m_Pos, &m_Direction);
 
 	if(UseExtraInfo(pProj))
 	{

--- a/src/game/extrainfo.cpp
+++ b/src/game/extrainfo.cpp
@@ -61,7 +61,7 @@ void SnapshotRemoveExtraInfo(unsigned char *pData)
 			{
 				vec2 Pos;
 				vec2 Vel;
-				ExtractInfo(pProj, &Pos, &Vel, 1);
+				ExtractInfo(pProj, &Pos, &Vel);
 				pProj->m_X = Pos.x;
 				pProj->m_Y = Pos.y;
 				pProj->m_VelX = (int)(Vel.x*100.0f);

--- a/src/game/extrainfo.cpp
+++ b/src/game/extrainfo.cpp
@@ -12,9 +12,9 @@ bool UseExtraInfo(const CNetObj_Projectile *pProj)
 	return ExtraInfoFlag;
 }
 
-void ExtractInfo(const CNetObj_Projectile *pProj, vec2 *StartPos, vec2 *StartVel, bool IsDDNet)
+void ExtractInfo(const CNetObj_Projectile *pProj, vec2 *StartPos, vec2 *StartVel)
 {
-	if(!UseExtraInfo(pProj) || !IsDDNet)
+	if(!UseExtraInfo(pProj))
 	{
 		StartPos->x = pProj->m_X;
 		StartPos->y = pProj->m_Y;

--- a/src/game/extrainfo.h
+++ b/src/game/extrainfo.h
@@ -6,7 +6,7 @@
 #include <base/vmath.h>
 
 bool UseExtraInfo(const CNetObj_Projectile *pProj);
-void ExtractInfo(const CNetObj_Projectile *pProj, vec2 *StartPos, vec2 *StartVel, bool IsDDNet);
+void ExtractInfo(const CNetObj_Projectile *pProj, vec2 *StartPos, vec2 *StartVel);
 void ExtractExtraInfo(const CNetObj_Projectile *pProj, int *Owner, bool *Explosive, int *Bouncing, bool *Freeze);
 void SnapshotRemoveExtraInfo(unsigned char *pData);
 


### PR DESCRIPTION
for some reason the client doesnt render extrainfo projectiles if the gamemode wasnt ddnet