### PR TITLE
Fix votespec on /pause (Fixes #1193)

### DIFF
--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -472,11 +472,8 @@ void CGameContext::StartVote(const char *pDesc, const char *pCommand, const char
 
 void CGameContext::EndVote()
 {
-	if(m_apPlayers[m_VoteVictim])
-		m_apPlayers[m_VoteVictim]->Pause(CPlayer::PAUSE_NONE, false);
 	m_VoteCloseTime = 0;
 	SendVoteSet(-1);
-	m_VoteVictim = -1;
 }
 
 void CGameContext::SendVoteSet(int ClientID)
@@ -2236,6 +2233,7 @@ void CGameContext::ConSetTeam(IConsole::IResult *pResult, void *pUserData)
 	str_format(aBuf, sizeof(aBuf), "moved client %d to team %d", ClientID, Team);
 	pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "server", aBuf);
 
+	pSelf->m_apPlayers[ClientID]->Pause(CPlayer::PAUSE_NONE, false); // reset /spec and /pause to allow rejoin
 	pSelf->m_apPlayers[ClientID]->m_TeamChangeTick = pSelf->Server()->Tick()+pSelf->Server()->TickSpeed()*Delay*60;
 	pSelf->m_apPlayers[ClientID]->SetTeam(Team);
 	if(Team == TEAM_SPECTATORS)

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -472,8 +472,11 @@ void CGameContext::StartVote(const char *pDesc, const char *pCommand, const char
 
 void CGameContext::EndVote()
 {
+	if(m_apPlayers[m_VoteVictim])
+		m_apPlayers[m_VoteVictim]->Pause(CPlayer::PAUSE_NONE, false);
 	m_VoteCloseTime = 0;
 	SendVoteSet(-1);
+	m_VoteVictim = -1;
 }
 
 void CGameContext::SendVoteSet(int ClientID)


### PR DESCRIPTION
I also thought about using a `` if (str_find(m_aVoteCommand, "set_team"))`` in front of the pause reset.
But then i thought its ok to unpause the VoteVictim every time.

I didn't test but i could belive that this can cause some unwanted unpause for a player with the id of the last VoteVictim on a server type vote for example. Thats why i also reset the ``m_VoteVictim`` to -1 to avoid this.