### PR TITLE
Require DNSBL check on /modhelp

### DIFF
--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -1404,9 +1404,15 @@ void CGameContext::ConModhelp(IConsole::IResult *pResult, void *pUserData)
 	if(!pPlayer)
 		return;
 
+	if(!pSelf->Server()->DnsblWhite(pResult->m_ClientID))
+	{
+		pSelf->SendChatTarget(pResult->m_ClientID, "You are not allowed to make requests from a blacklisted ip.");
+		return;
+	}
+
 	if(pPlayer->m_pPostJson)
 	{
-		pSelf->SendChatTarget(pResult->m_ClientID, "Your last request hasn't finished processing yet, please slow down");
+		pSelf->SendChatTarget(pResult->m_ClientID, "Your last request hasn't finished processing yet, please slow down.");
 		return;
 	}
 

--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -1404,12 +1404,6 @@ void CGameContext::ConModhelp(IConsole::IResult *pResult, void *pUserData)
 	if(!pPlayer)
 		return;
 
-	if(!pSelf->Server()->DnsblWhite(pResult->m_ClientID))
-	{
-		pSelf->SendChatTarget(pResult->m_ClientID, "You are not allowed to make requests from a blacklisted ip.");
-		return;
-	}
-
 	if(pPlayer->m_pPostJson)
 	{
 		pSelf->SendChatTarget(pResult->m_ClientID, "Your last request hasn't finished processing yet, please slow down.");
@@ -1462,10 +1456,11 @@ void CGameContext::ConModhelp(IConsole::IResult *pResult, void *pUserData)
 		char aJson[512];
 		char aPlayerName[64];
 		char aMessage[128];
-		str_format(aJson, sizeof(aJson), "{\"port\":%d,\"moderator_present\":%s,\"player_id\":%d,\"player_name\":\"%s\",\"message\":\"%s\"}",
+		str_format(aJson, sizeof(aJson), "{\"port\":%d,\"moderator_present\":%s,\"player_id\":%d,\"blacklisted\":%s,\"player_name\":\"%s\",\"message\":\"%s\"}",
 			g_Config.m_SvPort,
 			ModeratorPresent ? "true" : "false",
 			pResult->m_ClientID,
+			!pSelf->Server()->DnsblWhite(pResult->m_ClientID) ? "true" : "false",
 			EscapeJson(aPlayerName, sizeof(aPlayerName), pSelf->Server()->ClientName(pResult->m_ClientID)),
 			EscapeJson(aMessage, sizeof(aMessage), pResult->GetString(0)));
 		pSelf->Engine()->AddJob(pPlayer->m_pPostJson = std::make_shared<CPostJson>(g_Config.m_SvModhelpUrl, aJson));


### PR DESCRIPTION
Might also just remove `/modhelp`. So far it has proven to be pretty useless without accounts.