### PR TITLE
Changing vanila skins option no longer requires restart

### DIFF
--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -367,8 +367,6 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 {
 	CUIRect Button, Label, Button2, Dummy, DummyLabel, SkinList, QuickSearch, QuickSearchClearButton, SkinPrefix, SkinPrefixLabel;
 
-	bool CheckSettings = false;
-	static int s_ClVanillaSkinsOnly = g_Config.m_ClVanillaSkinsOnly;
 	static float s_ClSkinPrefix = 0.0f;
 
 	static bool s_InitSkinlist = true;
@@ -424,7 +422,6 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 	if(DoButton_CheckBox(&g_Config.m_ClVanillaSkinsOnly, Localize("Vanilla skins only"), g_Config.m_ClVanillaSkinsOnly, &DummyLabel))
 	{
 		g_Config.m_ClVanillaSkinsOnly ^= 1;
-		CheckSettings = true;
 	}
 
 	Dummy.HSplitTop(20.0f, &DummyLabel, &Dummy);
@@ -439,14 +436,6 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 
 	SkinPrefix.HSplitTop(20.0f, &SkinPrefixLabel, &SkinPrefix);
 	DoEditBox(g_Config.m_ClSkinPrefix, &SkinPrefixLabel, g_Config.m_ClSkinPrefix, sizeof(g_Config.m_ClSkinPrefix), 14.0f, &s_ClSkinPrefix);
-
-	if(CheckSettings)
-	{
-		if(s_ClVanillaSkinsOnly == g_Config.m_ClVanillaSkinsOnly)
-			m_NeedRestartSkins = false;
-		else
-			m_NeedRestartSkins = true;
-	}
 
 	Dummy.HSplitTop(20.0f, &DummyLabel, &Dummy);
 

--- a/src/game/client/components/skins.cpp
+++ b/src/game/client/components/skins.cpp
@@ -40,11 +40,6 @@ int CSkins::SkinScan(const char *pName, int IsDir, int DirType, void *pUser)
 	str_copy(aFilenameWithoutPng, pName, sizeof(aFilenameWithoutPng));
 	aFilenameWithoutPng[str_length(aFilenameWithoutPng) - 4] = 0;
 
-	if(g_Config.m_ClVanillaSkinsOnly && !IsVanillaSkin(aFilenameWithoutPng))
-	{
-		return 0;
-	}
-
 	// Don't add duplicate skins (one from user's config directory, other from
 	// client itself)
 	for(int i = 0; i < pSelf->Num(); i++)
@@ -204,7 +199,14 @@ int CSkins::FindImpl(const char *pName) const
 	{
 		if(str_comp(m_aSkins[i].m_aName, pName) == 0)
 		{
-			return i;
+			if(g_Config.m_ClVanillaSkinsOnly && !IsVanillaSkin(m_aSkins[i].m_aName))
+			{
+				return -1;
+			}
+			else
+			{
+				return i;
+			}
 		}
 	}
 	return -1;


### PR DESCRIPTION
Fixes #1216

Didn't work on making the panel underneath show only vanilla skins, but it might be doable as well.