### PR TITLE
Add some UI for the skin prefix stuff

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -456,6 +456,28 @@ int CMenus::DoEditBox(void *pID, const CUIRect *pRect, char *pStr, unsigned StrS
 	return ReturnValue;
 }
 
+int CMenus::DoClearableEditBox(void *pID, void *pClearID, const CUIRect *pRect, char *pStr, unsigned StrSize, float FontSize, float *Offset, bool Hidden, int Corners, const char *pEmptyText)
+{
+	bool ReturnValue = false;
+	CUIRect EditBox;
+	CUIRect ClearButton;
+	pRect->VSplitRight(15.0f, &EditBox, &ClearButton);
+	if(DoEditBox(pID, &EditBox, pStr, StrSize, FontSize, Offset, Hidden, Corners&~CUI::CORNER_R, pEmptyText))
+	{
+		ReturnValue = true;
+	}
+
+	RenderTools()->DrawUIRect(&ClearButton, vec4(1, 1, 1, 0.33f) * ButtonColorMul(pClearID), Corners&~CUI::CORNER_L, 3.0f);
+	UI()->DoLabel(&ClearButton, "×", ClearButton.h * ms_FontmodHeight, 0);
+	if(UI()->DoButtonLogic(pClearID, "×", 0, &ClearButton))
+	{
+		pStr[0] = 0;
+		UI()->SetActiveItem(pID);
+		ReturnValue = true;
+	}
+	return ReturnValue;
+}
+
 float CMenus::DoScrollbarV(const void *pID, const CUIRect *pRect, float Current)
 {
 	CUIRect Handle;

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -65,6 +65,7 @@ class CMenus : public CComponent
 	static void ui_draw_checkbox_number(const void *id, const char *text, int checked, const CUIRect *r, const void *extra);
 	*/
 	int DoEditBox(void *pID, const CUIRect *pRect, char *pStr, unsigned StrSize, float FontSize, float *Offset, bool Hidden=false, int Corners=CUI::CORNER_ALL, const char *pEmptyText = "");
+	int DoClearableEditBox(void *pID, void *pClearID, const CUIRect *pRect, char *pStr, unsigned StrSize, float FontSize, float *Offset, bool Hidden=false, int Corners=CUI::CORNER_ALL, const char *pEmptyText = "");
 	//static int ui_do_edit_box(void *id, const CUIRect *rect, char *str, unsigned str_size, float font_size, bool hidden=false);
 
 	float DoScrollbarV(const void *pID, const CUIRect *pRect, float Current);

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -495,7 +495,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 	QuickExclude.VSplitLeft(5.0f, 0, &QuickExclude);
 	// render quick search
 	{
-		const char *pLabel = "\xEE\xA2\xB6";
+		const char *pLabel = "\xEE\xA2\xB6"; // U+0e8b6
 		TextRender()->SetCurFont(TextRender()->GetFont(TEXT_FONT_ICON_FONT));
 		TextRender()->SetRenderFlags(ETextRenderFlags::TEXT_RENDER_FLAG_ONLY_ADVANCE_WIDTH | ETextRenderFlags::TEXT_RENDER_FLAG_NO_X_BEARING | ETextRenderFlags::TEXT_RENDER_FLAG_NO_Y_BEARING);
 		UI()->DoLabelScaled(&QuickSearch, pLabel, 16.0f, -1);
@@ -504,30 +504,17 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 		TextRender()->SetCurFont(NULL);
 		QuickSearch.VSplitLeft(w, 0, &QuickSearch);
 		QuickSearch.VSplitLeft(5.0f, 0, &QuickSearch);
-		QuickSearch.VSplitLeft(QuickSearch.w-15.0f, &QuickSearch, &Button);
 		static float Offset = 0.0f;
 		if(Input()->KeyPress(KEY_F) && (Input()->KeyIsPressed(KEY_LCTRL) || Input()->KeyIsPressed(KEY_RCTRL)))
 			UI()->SetActiveItem(&g_Config.m_BrFilterString);
-		if(DoEditBox(&g_Config.m_BrFilterString, &QuickSearch, g_Config.m_BrFilterString, sizeof(g_Config.m_BrFilterString), 12.0f, &Offset, false, CUI::CORNER_L, Localize("Search")))
-			Client()->ServerBrowserUpdate();
-	}
-
-	// clear button
-	{
 		static int s_ClearButton = 0;
-		RenderTools()->DrawUIRect(&Button, vec4(1,1,1,0.33f)*ButtonColorMul(&s_ClearButton), CUI::CORNER_R, 3.0f);
-		UI()->DoLabel(&Button, "×", Button.h*ms_FontmodHeight, 0);
-		if(UI()->DoButtonLogic(&s_ClearButton, "×", 0, &Button))
-		{
-			g_Config.m_BrFilterString[0] = 0;
-			UI()->SetActiveItem(&g_Config.m_BrFilterString);
+		if(DoClearableEditBox(&g_Config.m_BrFilterString, &s_ClearButton, &QuickSearch, g_Config.m_BrFilterString, sizeof(g_Config.m_BrFilterString), 12.0f, &Offset, false, CUI::CORNER_ALL, Localize("Search")))
 			Client()->ServerBrowserUpdate();
-		}
 	}
 
 	// render quick exclude
 	{
-		const char *pLabel = Localize("\xEE\x85\x8B");
+		const char *pLabel = Localize("\xEE\x85\x8B"); // U+0e14b
 		TextRender()->SetCurFont(TextRender()->GetFont(TEXT_FONT_ICON_FONT));
 		TextRender()->SetRenderFlags(ETextRenderFlags::TEXT_RENDER_FLAG_ONLY_ADVANCE_WIDTH | ETextRenderFlags::TEXT_RENDER_FLAG_NO_X_BEARING | ETextRenderFlags::TEXT_RENDER_FLAG_NO_Y_BEARING);
 		UI()->DoLabelScaled(&QuickExclude, pLabel, 16.0f, -1);
@@ -537,24 +524,12 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 		QuickExclude.VSplitLeft(w, 0, &QuickExclude);
 		QuickExclude.VSplitLeft(5.0f, 0, &QuickExclude);
 		QuickExclude.VSplitLeft(QuickExclude.w-15.0f, &QuickExclude, &Button);
+		static int s_ClearButton = 0;
 		static float Offset = 0.0f;
 		if(Input()->KeyPress(KEY_X) && (Input()->KeyIsPressed(KEY_LCTRL) || Input()->KeyIsPressed(KEY_RCTRL)))
 			UI()->SetActiveItem(&g_Config.m_BrExcludeString);
-		if(DoEditBox(&g_Config.m_BrExcludeString, &QuickExclude, g_Config.m_BrExcludeString, sizeof(g_Config.m_BrExcludeString), 12.0f, &Offset, false, CUI::CORNER_L, Localize("Exclude")))
+		if(DoClearableEditBox(&g_Config.m_BrExcludeString, &s_ClearButton, &QuickExclude, g_Config.m_BrExcludeString, sizeof(g_Config.m_BrExcludeString), 12.0f, &Offset, false, CUI::CORNER_ALL, Localize("Exclude")))
 			Client()->ServerBrowserUpdate();
-	}
-
-	// clear button
-	{
-		static int s_ClearButton = 0;
-		RenderTools()->DrawUIRect(&Button, vec4(1,1,1,0.33f)*ButtonColorMul(&s_ClearButton), CUI::CORNER_R, 3.0f);
-		UI()->DoLabel(&Button, "×", Button.h*ms_FontmodHeight, 0);
-		if(UI()->DoButtonLogic(&s_ClearButton, "×", 0, &Button))
-		{
-			g_Config.m_BrExcludeString[0] = 0;
-			UI()->SetActiveItem(&g_Config.m_BrExcludeString);
-			Client()->ServerBrowserUpdate();
-		}
 	}
 
 	// render status

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -609,7 +609,7 @@ void CMenus::RenderServerControl(CUIRect MainView)
 
 	// vote menu
 	{
-		CUIRect Button, Button2, QuickSearch;
+		CUIRect Button, QuickSearch;
 
 		// render quick search
 		{
@@ -624,26 +624,14 @@ void CMenus::RenderServerControl(CUIRect MainView)
 			TextRender()->SetCurFont(NULL);
 			QuickSearch.VSplitLeft(wSearch, 0, &QuickSearch);
 			QuickSearch.VSplitLeft(5.0f, 0, &QuickSearch);
-			QuickSearch.VSplitLeft(QuickSearch.w-15.0f, &QuickSearch, &Button2);
+			static int s_ClearButton = 0;
 			static float Offset = 0.0f;
 			//static char aFilterString[25];
 			if(Input()->KeyPress(KEY_F) && (Input()->KeyIsPressed(KEY_LCTRL) || Input()->KeyIsPressed(KEY_RCTRL)))
 				UI()->SetActiveItem(&m_aFilterString);
-			if(DoEditBox(&m_aFilterString, &QuickSearch, m_aFilterString, sizeof(m_aFilterString), 14.0f, &Offset, false, CUI::CORNER_L, Localize("Search"))) {
-				// TODO: Implement here
-			}
-
-			// clear button
+			if(DoClearableEditBox(&m_aFilterString, &s_ClearButton, &QuickSearch, m_aFilterString, sizeof(m_aFilterString), 14.0f, &Offset, false, CUI::CORNER_ALL, Localize("Search")))
 			{
-				static int s_ClearButton = 0;
-				RenderTools()->DrawUIRect(&Button2, vec4(1,1,1,0.33f)*ButtonColorMul(&s_ClearButton), CUI::CORNER_R, 3.0f);
-				UI()->DoLabel(&Button2, "×", Button2.h*ms_FontmodHeight, 0);
-				if(UI()->DoButtonLogic(&s_ClearButton, "×", 0, &Button2))
-				{
-					m_aFilterString[0] = 0;
-					UI()->SetActiveItem(&m_aFilterString);
-					Client()->ServerBrowserUpdate();
-				}
+				// TODO: Implement here
 			}
 		}
 

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -436,18 +436,19 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 	UI()->DoLabelScaled(&SkinPrefixLabel, Localize("Skin prefix"), 14.0f, -1);
 
 	SkinPrefix.HSplitTop(20.0f, &SkinPrefixLabel, &SkinPrefix);
-	DoEditBox(g_Config.m_ClSkinPrefix, &SkinPrefixLabel, g_Config.m_ClSkinPrefix, sizeof(g_Config.m_ClSkinPrefix), 14.0f, &s_ClSkinPrefix);
+	{
+		static int s_ClearButton = 0;
+		DoClearableEditBox(g_Config.m_ClSkinPrefix, &s_ClearButton, &SkinPrefixLabel, g_Config.m_ClSkinPrefix, sizeof(g_Config.m_ClSkinPrefix), 14.0f, &s_ClSkinPrefix);
+	}
 
 	SkinPrefix.HSplitTop(2.0f, 0, &SkinPrefix);
 	{
 		bool Left = true;
 		CUIRect Right;
-		static const char *s_aSkinPrefixes[] = {0, "kitty", "coala", "santa"};
+		static const char *s_aSkinPrefixes[] = {"kitty", "coala", "santa"};
 		for(unsigned i = 0; i < sizeof(s_aSkinPrefixes) / sizeof(s_aSkinPrefixes[0]); i++)
 		{
 			const char *pPrefix = s_aSkinPrefixes[i];
-			const char *pLabel = pPrefix ? pPrefix : Localize("none");
-			const char *pText = pPrefix ? pPrefix : "";
 			CUIRect Button;
 			if(Left)
 			{
@@ -468,9 +469,9 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 				Button.VSplitLeft(2.0f, 0, &Button);
 			}
 			Left = !Left;
-			if(DoButton_Menu(&s_aSkinPrefixes[i], pLabel, 0, &Button))
+			if(DoButton_Menu(&s_aSkinPrefixes[i], pPrefix, 0, &Button))
 			{
-				str_copy(g_Config.m_ClSkinPrefix, pText, sizeof(g_Config.m_ClSkinPrefix));
+				str_copy(g_Config.m_ClSkinPrefix, pPrefix, sizeof(g_Config.m_ClSkinPrefix));
 			}
 		}
 	}

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -653,24 +653,12 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 		QuickSearch.VSplitLeft(wSearch, 0, &QuickSearch);
 		QuickSearch.VSplitLeft(5.0f, 0, &QuickSearch);
 		QuickSearch.VSplitLeft(QuickSearch.w-15.0f, &QuickSearch, &QuickSearchClearButton);
+		static int s_ClearButton = 0;
 		static float Offset = 0.0f;
 		if(Input()->KeyPress(KEY_F) && (Input()->KeyIsPressed(KEY_LCTRL) || Input()->KeyIsPressed(KEY_RCTRL)))
 			UI()->SetActiveItem(&g_Config.m_ClSkinFilterString);
-		if(DoEditBox(&g_Config.m_ClSkinFilterString, &QuickSearch, g_Config.m_ClSkinFilterString, sizeof(g_Config.m_ClSkinFilterString), 14.0f, &Offset, false, CUI::CORNER_L, Localize("Search")))
+		if(DoClearableEditBox(&g_Config.m_ClSkinFilterString, &s_ClearButton, &QuickSearch, g_Config.m_ClSkinFilterString, sizeof(g_Config.m_ClSkinFilterString), 14.0f, &Offset, false, CUI::CORNER_ALL, Localize("Search")))
 			s_InitSkinlist = true;
-
-		// clear button
-		{
-			static int s_ClearButton = 0;
-			RenderTools()->DrawUIRect(&QuickSearchClearButton, vec4(1,1,1,0.33f)*ButtonColorMul(&s_ClearButton), CUI::CORNER_R, 3.0f);
-			UI()->DoLabel(&QuickSearchClearButton, "×", QuickSearchClearButton.h*ms_FontmodHeight, 0);
-			if(UI()->DoButtonLogic(&s_ClearButton, "×", 0, &QuickSearchClearButton))
-			{
-				g_Config.m_ClSkinFilterString[0] = 0;
-				UI()->SetActiveItem(&g_Config.m_ClSkinFilterString);
-				s_InitSkinlist = true;
-			}
-		}
 	}
 }
 

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -443,32 +443,13 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 
 	SkinPrefix.HSplitTop(2.0f, 0, &SkinPrefix);
 	{
-		bool Left = true;
-		CUIRect Right;
 		static const char *s_aSkinPrefixes[] = {"kitty", "coala", "santa"};
 		for(unsigned i = 0; i < sizeof(s_aSkinPrefixes) / sizeof(s_aSkinPrefixes[0]); i++)
 		{
 			const char *pPrefix = s_aSkinPrefixes[i];
 			CUIRect Button;
-			if(Left)
-			{
-				SkinPrefix.HSplitTop(20.0f, &Button, &SkinPrefix);
-				Button.VSplitMid(&Button, &Right);
-			}
-			else
-			{
-				Button = Right;
-			}
+			SkinPrefix.HSplitTop(20.0f, &Button, &SkinPrefix);
 			Button.HMargin(2.0f, &Button);
-			if(Left)
-			{
-				Button.VSplitRight(2.0f, &Button, 0);
-			}
-			else
-			{
-				Button.VSplitLeft(2.0f, 0, &Button);
-			}
-			Left = !Left;
 			if(DoButton_Menu(&s_aSkinPrefixes[i], pPrefix, 0, &Button))
 			{
 				str_copy(g_Config.m_ClSkinPrefix, pPrefix, sizeof(g_Config.m_ClSkinPrefix));

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -406,6 +406,7 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 	Label.VSplitLeft(280.0f, &Label, &Dummy);
 	Label.VSplitLeft(230.0f, &Label, 0);
 	Dummy.VSplitLeft(250.0f, &Dummy, &SkinPrefix);
+	SkinPrefix.VSplitLeft(150.0f, &SkinPrefix, 0);
 	char aBuf[128];
 	str_format(aBuf, sizeof(aBuf), "%s:", Localize("Your skin"));
 	UI()->DoLabelScaled(&Label, aBuf, 14.0f, -1);
@@ -430,12 +431,49 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 	{
 		g_Config.m_ClFatSkins ^= 1;
 	}
-	
+
 	SkinPrefix.HSplitTop(20.0f, &SkinPrefixLabel, &SkinPrefix);
-	UI()->DoLabelScaled(&SkinPrefixLabel, Localize("Skin prefix (e.g. kitty, coala, santa)"), 14.0f, -1);
+	UI()->DoLabelScaled(&SkinPrefixLabel, Localize("Skin prefix"), 14.0f, -1);
 
 	SkinPrefix.HSplitTop(20.0f, &SkinPrefixLabel, &SkinPrefix);
 	DoEditBox(g_Config.m_ClSkinPrefix, &SkinPrefixLabel, g_Config.m_ClSkinPrefix, sizeof(g_Config.m_ClSkinPrefix), 14.0f, &s_ClSkinPrefix);
+
+	SkinPrefix.HSplitTop(2.0f, 0, &SkinPrefix);
+	{
+		bool Left = true;
+		CUIRect Right;
+		static const char *s_aSkinPrefixes[] = {0, "kitty", "coala", "santa"};
+		for(unsigned i = 0; i < sizeof(s_aSkinPrefixes) / sizeof(s_aSkinPrefixes[0]); i++)
+		{
+			const char *pPrefix = s_aSkinPrefixes[i];
+			const char *pLabel = pPrefix ? pPrefix : Localize("none");
+			const char *pText = pPrefix ? pPrefix : "";
+			CUIRect Button;
+			if(Left)
+			{
+				SkinPrefix.HSplitTop(20.0f, &Button, &SkinPrefix);
+				Button.VSplitMid(&Button, &Right);
+			}
+			else
+			{
+				Button = Right;
+			}
+			Button.HMargin(2.0f, &Button);
+			if(Left)
+			{
+				Button.VSplitRight(2.0f, &Button, 0);
+			}
+			else
+			{
+				Button.VSplitLeft(2.0f, 0, &Button);
+			}
+			Left = !Left;
+			if(DoButton_Menu(&s_aSkinPrefixes[i], pLabel, 0, &Button))
+			{
+				str_copy(g_Config.m_ClSkinPrefix, pText, sizeof(g_Config.m_ClSkinPrefix));
+			}
+		}
+	}
 
 	Dummy.HSplitTop(20.0f, &DummyLabel, &Dummy);
 


### PR DESCRIPTION
This displays four buttons below the edit box, one for resetting the
skin prefix, and the other three for activating the shipped variants
"kitty", "coala", "santa".

The "none" string is translatable, the variants names are not because
they correspond to file names.