### PR TITLE
 Properly reset context attributes, if OpenGL3 context failed to create

### DIFF
--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -2210,19 +2210,32 @@ int CGraphicsBackend_SDL_OpenGL::Init(const char *pName, int *Screen, int *pWidt
 	SDL_ClearError();
 	const char *pErr = NULL;
 
-	//query default values, since they are platform dependent
+	// Query default values, since they are platform dependent
 	static bool s_InitDefaultParams = false;
 	static int s_SDLGLContextProfileMask, s_SDLGLContextMajorVersion, s_SDLGLContextMinorVersion;
+	static bool s_TriedOpenGL3Context = false;
+
+	if(!s_InitDefaultParams)
+	{
+		SDL_GL_GetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, &s_SDLGLContextProfileMask);
+		SDL_GL_GetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, &s_SDLGLContextMajorVersion);
+		SDL_GL_GetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, &s_SDLGLContextMinorVersion);
+		s_InitDefaultParams = true;
+	}
+
+	// if OpenGL3 context was tried to be created, but failed, we have to restore the old context attributes
+	if(s_TriedOpenGL3Context && !g_Config.m_GfxOpenGL3) {
+		s_TriedOpenGL3Context = false;
+
+		SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, s_SDLGLContextProfileMask);
+		SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, s_SDLGLContextMajorVersion);
+		SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, s_SDLGLContextMinorVersion);
+	}
+
 	m_UseOpenGL3_3 = false;
 	if(g_Config.m_GfxOpenGL3)
 	{
-		if(!s_InitDefaultParams)
-		{
-			SDL_GL_GetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, &s_SDLGLContextProfileMask);
-			SDL_GL_GetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, &s_SDLGLContextMajorVersion);
-			SDL_GL_GetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, &s_SDLGLContextMinorVersion);
-			s_InitDefaultParams = true;
-		}
+		s_TriedOpenGL3Context = true;
 
 		if(SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE) == 0)
 		{

--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -2224,7 +2224,8 @@ int CGraphicsBackend_SDL_OpenGL::Init(const char *pName, int *Screen, int *pWidt
 	}
 
 	// if OpenGL3 context was tried to be created, but failed, we have to restore the old context attributes
-	if(s_TriedOpenGL3Context && !g_Config.m_GfxOpenGL3) {
+	if(s_TriedOpenGL3Context && !g_Config.m_GfxOpenGL3)
+	{
 		s_TriedOpenGL3Context = false;
 
 		SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, s_SDLGLContextProfileMask);

--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -2075,7 +2075,6 @@ int CGraphics_Threaded::InitWindow()
 		g_Config.m_GfxOpenGL3 = 0;
 		if(IssueInit() == 0)
 		{
-			g_Config.m_GfxOpenGL3 = 1;
 			return 0;
 		}
 	}


### PR DESCRIPTION
Automatically creates the older context, if OGL3 isn't supported