### PR TITLE
Don't copy alpha when coloring the brush

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -2255,6 +2255,7 @@ void CEditor::DoMapEditor(CUIRect View)
 			m_TilesetPicker.m_Image = t->m_Image;
 			m_TilesetPicker.m_TexID = t->m_TexID;
 			m_TilesetPicker.m_Color = t->m_Color;
+			m_TilesetPicker.m_Color.a = 255;
 			m_TilesetPicker.Render();
 			if(m_ShowTileInfo)
 				m_TilesetPicker.ShowInfo();

--- a/src/game/editor/layer_tiles.cpp
+++ b/src/game/editor/layer_tiles.cpp
@@ -180,6 +180,7 @@ int CLayerTiles::BrushGrab(CLayerGroup *pBrush, CUIRect Rect)
 		pGrabbed->m_Image = m_Image;
 		pGrabbed->m_Game = m_Game;
 		pGrabbed->m_Color = m_Color;
+		pGrabbed->m_Color.a = 255;
 
 		pBrush->AddLayer(pGrabbed);
 
@@ -208,6 +209,7 @@ int CLayerTiles::BrushGrab(CLayerGroup *pBrush, CUIRect Rect)
 		pGrabbed->m_Image = m_Image;
 		pGrabbed->m_Game = m_Game;
 		pGrabbed->m_Color = m_Color;
+		pGrabbed->m_Color.a = 255;
 
 		pBrush->AddLayer(pGrabbed);
 
@@ -242,6 +244,7 @@ int CLayerTiles::BrushGrab(CLayerGroup *pBrush, CUIRect Rect)
 		pGrabbed->m_Image = m_Image;
 		pGrabbed->m_Game = m_Game;
 		pGrabbed->m_Color = m_Color;
+		pGrabbed->m_Color.a = 255;
 
 		pBrush->AddLayer(pGrabbed);
 
@@ -275,6 +278,8 @@ int CLayerTiles::BrushGrab(CLayerGroup *pBrush, CUIRect Rect)
 		pGrabbed->m_Image = m_Image;
 		pGrabbed->m_Game = m_Game;
 		pGrabbed->m_Color = m_Color;
+		pGrabbed->m_Color.a = 255;
+
 		pBrush->AddLayer(pGrabbed);
 
 		// copy the tiles
@@ -304,6 +309,8 @@ int CLayerTiles::BrushGrab(CLayerGroup *pBrush, CUIRect Rect)
 		pGrabbed->m_Image = m_Image;
 		pGrabbed->m_Game = m_Game;
 		pGrabbed->m_Color = m_Color;
+		pGrabbed->m_Color.a = 255;
+
 		pBrush->AddLayer(pGrabbed);
 
 		// copy the tiles
@@ -320,6 +327,8 @@ int CLayerTiles::BrushGrab(CLayerGroup *pBrush, CUIRect Rect)
 		pGrabbed->m_Image = m_Image;
 		pGrabbed->m_Game = m_Game;
 		pGrabbed->m_Color = m_Color;
+		pGrabbed->m_Color.a = 255;
+
 		pBrush->AddLayer(pGrabbed);
 
 		// copy the tiles


### PR DESCRIPTION
This is to improve visibility when working with nearly-transparent layers. It shouldn't cause problems when working with partly-transparent layers.