### PR TITLE
Optimize automapper a bit

### DIFF
--- a/src/game/editor/auto_map.h
+++ b/src/game/editor/auto_map.h
@@ -34,6 +34,8 @@ class CAutoMapper
 		int m_Flag;
 		float m_RandomProbability;
 		bool m_DefaultRule;
+		bool m_SkipEmpty;
+		bool m_SkipFull;
 	};
 
 	struct CRun


### PR DESCRIPTION
Pretty simple yet super effective: 
If index rule has any `Pos 0 0` for non-empty tile, then it is flagged to skip all the empty tiles. And vice versa.

In many cases it will significantly speed up the process, especially when using big automappers on huge maps.