### PR TITLE
Selecting multiple quads

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -881,13 +881,13 @@ CLayer *CEditor::GetSelectedLayerType(int Index, int Type)
 array<CQuad *> CEditor::GetSelectedQuads()
 {
 	CLayerQuads *ql = (CLayerQuads *)GetSelectedLayerType(0, LAYERTYPE_QUADS);
-	array<CQuad *> aQuads;
+	array<CQuad *> lQuads;
 	if(!ql)
-		return aQuads;
-	aQuads.set_size(m_lSelectedQuads.size());
+		return lQuads;
+	lQuads.set_size(m_lSelectedQuads.size());
 	for(int i = 0; i < m_lSelectedQuads.size(); ++i)
-		aQuads[i] = &ql->m_lQuads[m_lSelectedQuads[i]];
-	return aQuads;
+		lQuads[i] = &ql->m_lQuads[m_lSelectedQuads[i]];
+	return lQuads;
 }
 
 CSoundSource *CEditor::GetSelectedSource()

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -761,13 +761,18 @@ public:
 	int Append(const char *pFilename, int StorageType);
 	void LoadCurrentMap();
 	void Render();
-
-	CQuad *GetSelectedQuad();
+	
+	array<CQuad *> GetSelectedQuads();
 	CLayer *GetSelectedLayerType(int Index, int Type);
 	CLayer *GetSelectedLayer(int Index);
 	CLayerGroup *GetSelectedGroup();
 	CSoundSource *GetSelectedSource();
 	void SelectLayer(int Index);
+
+	void SelectQuad(int Index);
+	void DeleteSelectedQuads();
+	bool IsQuadSelected(int Index);
+	int FindSelectedQuadIndex(int Index);
 
 	int DoProperties(CUIRect *pToolbox, CProperty *pProps, int *pIDs, int *pNewVal, vec4 Color = vec4(1,1,1,0.5f));
 
@@ -879,8 +884,10 @@ public:
 	bool m_ShowPicker;
 
 	array<int> m_lSelectedLayers;
+	array<int> m_lSelectedQuads;
+	int m_SelectedQuadPoint;
+	int m_SelectedQuadIndex;
 	int m_SelectedGroup;
-	int m_SelectedQuad;
 	int m_SelectedPoints;
 	int m_SelectedEnvelope;
 	int m_SelectedEnvelopePoint;


### PR DESCRIPTION
- shift+drag to select quads. Selection is additive
- left click on any empty space deselects all quads
- moving, resizing, rotating etc. works for every selected quad
- fixed resizing quads on grid and in properties. Vertices don't land on the same spot