### PR TITLE
Fix crash with FillSelection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,6 +125,10 @@ if(NOT MSVC)
     endif()
   endif()
 
+  set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
+  set (CMAKE_LINKER_FLAGS_DEBUG "${CMAKE_STATIC_LINKER_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
+
+
   # Protect the stack pointer.
   # -fstack-protector-all doesn't work on MinGW.
   add_c_compiler_flag_if_supported(OUR_FLAGS -fstack-protector-all)

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -2256,7 +2256,15 @@ void CEditor::DoMapEditor(CUIRect View)
 			m_TilesetPicker.m_TexID = t->m_TexID;
 			m_TilesetPicker.m_Color = t->m_Color;
 			m_TilesetPicker.m_Color.a = 255;
-			m_TilesetPicker.Render();
+
+			m_TilesetPicker.m_Tele = t->m_Tele;
+			m_TilesetPicker.m_Speedup = t->m_Speedup;
+			m_TilesetPicker.m_Front = t->m_Front;
+			m_TilesetPicker.m_Switch = t->m_Switch;
+			m_TilesetPicker.m_Tune = t->m_Tune;
+
+			m_TilesetPicker.Render(true);
+
 			if(m_ShowTileInfo)
 				m_TilesetPicker.ShowInfo();
 		}

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -152,7 +152,7 @@ public:
 	virtual void BrushFlipY() {}
 	virtual void BrushRotate(float Amount) {}
 
-	virtual void Render() {}
+	virtual void Render(bool Tileset = false) {}
 	virtual int RenderProperties(CUIRect *pToolbox) { return 0; }
 
 	virtual void ModifyImageIndex(INDEX_MODIFY_FUNC pfnFunc) {}
@@ -519,7 +519,7 @@ public:
 	virtual void Shift(int Direction);
 
 	void MakePalette();
-	virtual void Render();
+	virtual void Render(bool Tileset = false);
 
 	int ConvertX(float x) const;
 	int ConvertY(float y) const;
@@ -571,7 +571,7 @@ public:
 	CLayerQuads();
 	~CLayerQuads();
 
-	virtual void Render();
+	virtual void Render(bool QuadPicker = false);
 	CQuad *NewQuad();
 
 	virtual void BrushSelecting(CUIRect Rect);
@@ -1129,7 +1129,7 @@ public:
 	CLayerSounds();
 	~CLayerSounds();
 
-	virtual void Render();
+	virtual void Render(bool Tileset = false);
 	CSoundSource *NewSource();
 
 	virtual void BrushSelecting(CUIRect Rect);

--- a/src/game/editor/layer_quads.cpp
+++ b/src/game/editor/layer_quads.cpp
@@ -21,7 +21,7 @@ CLayerQuads::~CLayerQuads()
 {
 }
 
-void CLayerQuads::Render()
+void CLayerQuads::Render(bool QuadPicker)
 {
 	Graphics()->TextureSet(-1);
 	if(m_Image >= 0 && m_Image < m_pEditor->m_Map.m_lImages.size())

--- a/src/game/editor/layer_sounds.cpp
+++ b/src/game/editor/layer_sounds.cpp
@@ -16,7 +16,7 @@ CLayerSounds::~CLayerSounds()
 {
 }
 
-void CLayerSounds::Render()
+void CLayerSounds::Render(bool Tileset)
 {
 	// TODO: nice texture
 	Graphics()->TextureSet(-1);

--- a/src/game/editor/layer_tiles.cpp
+++ b/src/game/editor/layer_tiles.cpp
@@ -77,7 +77,7 @@ void CLayerTiles::MakePalette()
 			m_pTiles[y*m_Width+x].m_Index = y*16+x;
 }
 
-void CLayerTiles::Render()
+void CLayerTiles::Render(bool Tileset)
 {
 	if(m_Image >= 0 && m_Image < m_pEditor->m_Map.m_lImages.size())
 		m_TexID = m_pEditor->m_Map.m_lImages[m_Image]->m_TexID;
@@ -91,14 +91,17 @@ void CLayerTiles::Render()
 												m_pEditor->EnvelopeEval, m_pEditor, m_ColorEnv, m_ColorEnvOffset);
 
 	// Render DDRace Layers
-	if(m_Tele)
-		m_pEditor->RenderTools()->RenderTeleOverlay(((CLayerTele*)this)->m_pTeleTile, m_Width, m_Height, 32.0f);
-	if(m_Speedup)
-		m_pEditor->RenderTools()->RenderSpeedupOverlay(((CLayerSpeedup*)this)->m_pSpeedupTile, m_Width, m_Height, 32.0f);
-	if(m_Switch)
-		m_pEditor->RenderTools()->RenderSwitchOverlay(((CLayerSwitch*)this)->m_pSwitchTile, m_Width, m_Height, 32.0f);
-	if(m_Tune)
-		m_pEditor->RenderTools()->RenderTuneOverlay(((CLayerTune*)this)->m_pTuneTile, m_Width, m_Height, 32.0f);
+	if(!Tileset)
+	{
+		if(m_Tele)
+			m_pEditor->RenderTools()->RenderTeleOverlay(((CLayerTele*)this)->m_pTeleTile, m_Width, m_Height, 32.0f);
+		if(m_Speedup)
+			m_pEditor->RenderTools()->RenderSpeedupOverlay(((CLayerSpeedup*)this)->m_pSpeedupTile, m_Width, m_Height, 32.0f);
+		if(m_Switch)
+			m_pEditor->RenderTools()->RenderSwitchOverlay(((CLayerSwitch*)this)->m_pSwitchTile, m_Width, m_Height, 32.0f);
+		if(m_Tune)
+			m_pEditor->RenderTools()->RenderTuneOverlay(((CLayerTune*)this)->m_pTuneTile, m_Width, m_Height, 32.0f);
+	}
 }
 
 int CLayerTiles::ConvertX(float x) const { return (int)(x/32.0f); }
@@ -172,7 +175,7 @@ int CLayerTiles::BrushGrab(CLayerGroup *pBrush, CUIRect Rect)
 		return 0;
 
 	// create new layers
-	if(this == m_pEditor->m_Map.m_pTeleLayer)
+	if(this->m_Tele)
 	{
 		CLayerTele *pGrabbed = new CLayerTele(r.w, r.h);
 		pGrabbed->m_pEditor = m_pEditor;
@@ -201,7 +204,7 @@ int CLayerTiles::BrushGrab(CLayerGroup *pBrush, CUIRect Rect)
 		pGrabbed->m_TeleNum = m_pEditor->m_TeleNumber;
 		str_copy(pGrabbed->m_aFileName, m_pEditor->m_aFileName, sizeof(pGrabbed->m_aFileName));
 	}
-	else if(this == m_pEditor->m_Map.m_pSpeedupLayer)
+	else if(this->m_Speedup)
 	{
 		CLayerSpeedup *pGrabbed = new CLayerSpeedup(r.w, r.h);
 		pGrabbed->m_pEditor = m_pEditor;
@@ -236,7 +239,7 @@ int CLayerTiles::BrushGrab(CLayerGroup *pBrush, CUIRect Rect)
 		pGrabbed->m_SpeedupAngle = m_pEditor->m_SpeedupAngle;
 		str_copy(pGrabbed->m_aFileName, m_pEditor->m_aFileName, sizeof(pGrabbed->m_aFileName));
 	}
-	else if(this == m_pEditor->m_Map.m_pSwitchLayer)
+	else if(this->m_Switch)
 	{
 		CLayerSwitch *pGrabbed = new CLayerSwitch(r.w, r.h);
 		pGrabbed->m_pEditor = m_pEditor;
@@ -270,7 +273,7 @@ int CLayerTiles::BrushGrab(CLayerGroup *pBrush, CUIRect Rect)
 		str_copy(pGrabbed->m_aFileName, m_pEditor->m_aFileName, sizeof(pGrabbed->m_aFileName));
 	}
 
-	else if(this == m_pEditor->m_Map.m_pTuneLayer)
+	else if(this->m_Tune)
 	{
 		CLayerTune *pGrabbed = new CLayerTune(r.w, r.h);
 		pGrabbed->m_pEditor = m_pEditor;
@@ -301,7 +304,7 @@ int CLayerTiles::BrushGrab(CLayerGroup *pBrush, CUIRect Rect)
 		pGrabbed->m_TuningNumber = m_pEditor->m_TuningNum;
 		str_copy(pGrabbed->m_aFileName, m_pEditor->m_aFileName, sizeof(pGrabbed->m_aFileName));
 	}
-	else if(this == m_pEditor->m_Map.m_pFrontLayer)
+	else if(this->m_Front)
 	{
 		CLayerFront *pGrabbed = new CLayerFront(r.w, r.h);
 		pGrabbed->m_pEditor = m_pEditor;


### PR DESCRIPTION
`CLayerTiles::BrushGrab` needs to know which kind of layer a tile/brush was picked from, in case of the Tilesets this information was missing because it used to be provided by the selected layer.

Reported by Silex and Im' Corneum on Discord.