### PR TITLE
Don't update particles, if no time passed

### DIFF
--- a/src/game/client/components/particles.cpp
+++ b/src/game/client/components/particles.cpp
@@ -74,6 +74,9 @@ void CParticles::Add(int Group, CParticle *pPart)
 
 void CParticles::Update(float TimePassed)
 {
+	if(TimePassed <= 0.0f)
+		return;
+
 	static float FrictionFraction = 0;
 	FrictionFraction += TimePassed;
 


### PR DESCRIPTION
Else NaNs are created, when deviding through zero(TimePassed), resulting in paricles not rendered.