### PR TITLE
Global lock for MySQL Connector's get_driver_instance (fixes #1131)

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -292,6 +292,8 @@ CServer::CServer()
 #endif
 
 #if defined (CONF_SQL)
+	m_GlobalSqlLock = lock_create();
+
 	for (int i = 0; i < MAX_SQLSERVERS; i++)
 	{
 		m_apSqlReadServers[i] = 0;
@@ -305,6 +307,13 @@ CServer::CServer()
 	m_aErrorShutdownReason[0] = 0;
 
 	Init();
+}
+
+CServer::~CServer()
+{
+#if defined (CONF_SQL)
+	lock_destroy(m_GlobalSqlLock);
+#endif
 }
 
 int CServer::TrySetClientName(int ClientID, const char *pName)
@@ -2529,7 +2538,7 @@ void CServer::ConAddSqlServer(IConsole::IResult *pResult, void *pUserData)
 	{
 		if (!apSqlServers[i])
 		{
-			apSqlServers[i] = new CSqlServer(pResult->GetString(1), pResult->GetString(2), pResult->GetString(3), pResult->GetString(4), pResult->GetString(5), pResult->GetInteger(6), ReadOnly, SetUpDb);
+			apSqlServers[i] = new CSqlServer(pResult->GetString(1), pResult->GetString(2), pResult->GetString(3), pResult->GetString(4), pResult->GetString(5), pResult->GetInteger(6), pSelf->m_GlobalSqlLock, ReadOnly, SetUpDb);
 
 			if(SetUpDb)
 			{

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -91,6 +91,7 @@ class CServer : public IServer
 	class IStorage *m_pStorage;
 
 #if defined(CONF_SQL)
+	LOCK m_GlobalSqlLock;
 	CSqlServer *m_apSqlReadServers[MAX_SQLSERVERS];
 	CSqlServer *m_apSqlWriteServers[MAX_SQLSERVERS];
 #endif
@@ -227,6 +228,7 @@ public:
 	array<CNameBan> m_aNameBans;
 
 	CServer();
+	~CServer();
 
 	int TrySetClientName(int ClientID, const char *pName);
 

--- a/src/engine/server/sql_server.h
+++ b/src/engine/server/sql_server.h
@@ -7,10 +7,28 @@
 #include <cppconn/exception.h>
 #include <cppconn/statement.h>
 
+class LockScope
+{
+public:
+	LockScope(LOCK &Lock) :
+			m_Lock(Lock)
+	{
+		lock_wait(m_Lock);
+	}
+
+	~LockScope()
+	{
+		lock_unlock(m_Lock);
+	}
+
+private:
+	LOCK &m_Lock;
+};
+
 class CSqlServer
 {
 public:
-	CSqlServer(const char *pDatabase, const char *pPrefix, const char *pUser, const char *pPass, const char *pIp, int Port, bool ReadOnly = true, bool SetUpDb = false);
+	CSqlServer(const char *pDatabase, const char *pPrefix, const char *pUser, const char *pPass, const char *pIp, int Port, LOCK &GlobalLock, bool ReadOnly = true, bool SetUpDb = false);
 	~CSqlServer();
 
 	bool Connect();
@@ -52,6 +70,7 @@ private:
 	bool m_SetUpDB;
 
 	LOCK m_SqlLock;
+	LOCK &m_GlobalLock;
 };
 
 #endif


### PR DESCRIPTION
See note in https://dev.mysql.com/doc/connector-cpp/1.1/en/connector-cpp-examples-connecting.html

> get_mysql_driver_instance() calls get_driver_instance(), which is not
> thread-safe. Either avoid invoking these methods from within multiple
> threads at once, or surround the calls with a mutex to prevent
> simultaneous execution in multiple threads.