### PR TITLE
Continue work on Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,4 +59,3 @@ RUN printf '#!/bin/bash\n \
 RUN chmod +x build-all.sh
 RUN mkdir /build
 
-ADD . /ddnet


### PR DESCRIPTION
Use a bind mount for the source instead.
This changes the docker run command to:
```
docker run -it \
  --mount type=bind,source="$(pwd)"/build,target=/build \
  --mount type=bind,source="$(pwd)", target=/ddnet \
  ddnet ./build-all.sh