### PR TITLE
Fix windows compilation warning

### DIFF
--- a/src/base/system.c
+++ b/src/base/system.c
@@ -673,7 +673,7 @@ struct THREAD_RUN
 #if defined(CONF_FAMILY_UNIX)
 static void *thread_run(void *user)
 #elif defined(CONF_FAMILY_WINDOWS)
-static unsigned int __stdcall thread_run(void *user)
+static unsigned long __stdcall thread_run(void *user)
 #else
 #error not implemented
 #endif


### PR DESCRIPTION
ddnet\src\base\system.c:704:31: warning: passing argument 3 of 'CreateThread' from incompatible pointer type [-Wincompatible-pointer-types]

I got this warning compiling with mingw