### PR TITLE
Left align editor menu texts like server settings, closes #1215

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -641,7 +641,7 @@ int CEditor::DoButton_MenuItem(const void *pID, const char *pText, int Checked, 
 
 	CUIRect t = *pRect;
 	t.VMargin(5.0f, &t);
-	UI()->DoLabel(&t, pText, 10, 0, -1);
+	UI()->DoLabel(&t, pText, 10, -1, -1);
 	return DoButton_Editor_Common(pID, pText, Checked, pRect, Flags, pToolTip);
 }
 
@@ -3543,7 +3543,7 @@ int CEditor::PopupImage(CEditor *pEditor, CUIRect View)
 		}
 	}
 
-	View.HSplitTop(10.0f, &Slot, &View);
+	View.HSplitTop(5.0f, &Slot, &View);
 	View.HSplitTop(12.0f, &Slot, &View);
 	if(pEditor->DoButton_MenuItem(&s_ReplaceButton, "Replace", 0, &Slot, 0, "Replaces the image with a new one"))
 	{
@@ -3551,7 +3551,7 @@ int CEditor::PopupImage(CEditor *pEditor, CUIRect View)
 		return 1;
 	}
 
-	View.HSplitTop(10.0f, &Slot, &View);
+	View.HSplitTop(5.0f, &Slot, &View);
 	View.HSplitTop(12.0f, &Slot, &View);
 	if(pEditor->DoButton_MenuItem(&s_RemoveButton, "Remove", 0, &Slot, 0, "Removes the image from the map"))
 	{
@@ -3594,7 +3594,7 @@ int CEditor::PopupSound(CEditor *pEditor, CUIRect View)
 	}
 
 
-	View.HSplitTop(10.0f, &Slot, &View);
+	View.HSplitTop(5.0f, &Slot, &View);
 	View.HSplitTop(12.0f, &Slot, &View);
 	if(pEditor->DoButton_MenuItem(&s_ReplaceButton, "Replace", 0, &Slot, 0, "Replaces the sound with a new one"))
 	{
@@ -3602,7 +3602,7 @@ int CEditor::PopupSound(CEditor *pEditor, CUIRect View)
 		return 1;
 	}
 
-	View.HSplitTop(10.0f, &Slot, &View);
+	View.HSplitTop(5.0f, &Slot, &View);
 	View.HSplitTop(12.0f, &Slot, &View);
 	if(pEditor->DoButton_MenuItem(&s_RemoveButton, "Remove", 0, &Slot, 0, "Removes the sound from the map"))
 	{
@@ -3775,7 +3775,7 @@ void CEditor::RenderImages(CUIRect ToolBox, CUIRect View)
 
 				static int s_PopupImageID = 0;
 				if(Result == 2)
-					UiInvokePopupMenu(&s_PopupImageID, 0, UI()->MouseX(), UI()->MouseY(), 120, 80, PopupImage);
+					UiInvokePopupMenu(&s_PopupImageID, 0, UI()->MouseX(), UI()->MouseY(), 120, 60, PopupImage);
 			}
 
 			ToolBox.HSplitTop(2.0f, 0, &ToolBox);
@@ -3929,7 +3929,7 @@ void CEditor::RenderSounds(CUIRect ToolBox, CUIRect View)
 
 				static int s_PopupSoundID = 0;
 				if(Result == 2)
-					UiInvokePopupMenu(&s_PopupSoundID, 0, UI()->MouseX(), UI()->MouseY(), 120, 80, PopupSound);
+					UiInvokePopupMenu(&s_PopupSoundID, 0, UI()->MouseX(), UI()->MouseY(), 120, 60, PopupSound);
 			}
 
 			ToolBox.HSplitTop(2.0f, 0, &ToolBox);


### PR DESCRIPTION
Affects those menus:

![image](https://user-images.githubusercontent.com/8438790/46312012-1e744b80-c5c4-11e8-99ad-64b83cba00d5.png)

![image](https://user-images.githubusercontent.com/8438790/46311975-04d30400-c5c4-11e8-8673-4576db9e9bdc.png)

![image](https://user-images.githubusercontent.com/8438790/46311914-e7059f00-c5c3-11e8-9bea-f23ab2532059.png)

Closes #1215
