### PR TITLE
Implement ISDDNET server message to decouple version expectation from gametype

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -758,7 +758,6 @@ void CClient::DisconnectWithReason(const char *pReason)
 	// clear the current server info
 	mem_zero(&m_CurrentServerInfo, sizeof(m_CurrentServerInfo));
 	mem_zero(&m_ServerAddress, sizeof(m_ServerAddress));
-	m_ServerVersion = VERSION_VANILLA;
 
 	// clear snapshots
 	m_aSnapshots[g_Config.m_ClDummy][SNAP_CURRENT] = 0;
@@ -1531,6 +1530,8 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket)
 			bool MapDetailsWerePresent = m_MapDetailsPresent;
 			m_MapDetailsPresent = false;
 
+			m_ServerVersion = VERSION_VANILLA;
+
 			const char *pMap = Unpacker.GetString(CUnpacker::SANITIZE_CC|CUnpacker::SKIP_START_WHITESPACES);
 			int MapCrc = Unpacker.GetInt();
 			int MapSize = Unpacker.GetInt();
@@ -1941,7 +1942,10 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket)
 		}
 		else if(Msg == NETMSG_ISDDNET)
 		{
-			m_ServerVersion = Unpacker.GetInt();
+			int NewServerVersion = Unpacker.GetInt();
+			if(Unpacker.Error())
+				return;
+			m_ServerVersion = NewServerVersion;
 		}
 	}
 	else

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -188,20 +188,7 @@ class CClient : public IClient, public CDemoPlayer::IListener
 	//
 	class CServerInfo m_CurrentServerInfo;
 	int64 m_CurrentServerInfoRequestTime; // >= 0 should request, == -1 got info
-
-	// version info
-	struct CVersionInfo
-	{
-		enum
-		{
-			STATE_INIT=0,
-			STATE_START,
-			STATE_READY,
-		};
-
-		int m_State;
-		class CHostLookup m_VersionServeraddr;
-	} m_VersionInfo;
+	int m_ServerVersion;
 
 	volatile int m_GfxState;
 	static void GraphicsThreadProxy(void *pThis) { ((CClient*)pThis)->GraphicsThread(); }

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -36,6 +36,7 @@
 #include <vector>
 #include <engine/shared/linereader.h>
 #include <game/extrainfo.h>
+#include <game/version.h>
 
 #include "register.h"
 #include "server.h"
@@ -934,6 +935,13 @@ void CServer::SendMap(int ClientID)
 	m_aClients[ClientID].m_NextMapChunk = 0;
 }
 
+void CServer::SendIsDDNet(int ClientID)
+{
+	CMsgPacker Msg(NETMSG_ISDDNET);
+	Msg.AddInt(GAME_VERSIONNR);
+	SendMsgEx(&Msg, MSGFLAG_VITAL|MSGFLAG_NORECORD, ClientID, true);
+}
+
 void CServer::SendMapData(int ClientID, int Chunk)
 {
 	unsigned int ChunkSize = 1024-128;
@@ -1113,6 +1121,7 @@ void CServer::ProcessClientPacket(CNetChunk *pPacket)
 				m_aClients[ClientID].m_State = CClient::STATE_CONNECTING;
 				SendRconType(ClientID, m_AuthManager.NumNonDefaultKeys() > 0);
 				SendMap(ClientID);
+				SendIsDDNet(ClientID);
 			}
 		}
 		else if(Msg == NETMSG_REQUEST_MAP_DATA)

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -935,13 +935,6 @@ void CServer::SendMap(int ClientID)
 	m_aClients[ClientID].m_NextMapChunk = 0;
 }
 
-void CServer::SendIsDDNet(int ClientID)
-{
-	CMsgPacker Msg(NETMSG_ISDDNET);
-	Msg.AddInt(GAME_VERSIONNR);
-	SendMsgEx(&Msg, MSGFLAG_VITAL|MSGFLAG_NORECORD, ClientID, false);
-}
-
 void CServer::SendMapData(int ClientID, int Chunk)
 {
 	unsigned int ChunkSize = 1024-128;
@@ -976,6 +969,10 @@ void CServer::SendMapData(int ClientID, int Chunk)
 
 void CServer::SendConnectionReady(int ClientID)
 {
+	CMsgPacker Msg(NETMSG_ISDDNET);
+	Msg.AddInt(GAME_VERSIONNR);
+	SendMsgEx(&Msg, MSGFLAG_VITAL|MSGFLAG_NORECORD, ClientID, false);
+
 	CMsgPacker Msg(NETMSG_CON_READY);
 	SendMsgEx(&Msg, MSGFLAG_VITAL|MSGFLAG_FLUSH, ClientID, true);
 }
@@ -1121,7 +1118,6 @@ void CServer::ProcessClientPacket(CNetChunk *pPacket)
 				m_aClients[ClientID].m_State = CClient::STATE_CONNECTING;
 				SendRconType(ClientID, m_AuthManager.NumNonDefaultKeys() > 0);
 				SendMap(ClientID);
-				SendIsDDNet(ClientID);
 			}
 		}
 		else if(Msg == NETMSG_REQUEST_MAP_DATA)
@@ -1852,7 +1848,6 @@ int CServer::Run()
 							continue;
 
 						SendMap(ClientID);
-						SendIsDDNet(ClientID);
 						m_aClients[ClientID].Reset();
 						m_aClients[ClientID].m_State = CClient::STATE_CONNECTING;
 					}

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -939,7 +939,7 @@ void CServer::SendIsDDNet(int ClientID)
 {
 	CMsgPacker Msg(NETMSG_ISDDNET);
 	Msg.AddInt(GAME_VERSIONNR);
-	SendMsgEx(&Msg, MSGFLAG_VITAL|MSGFLAG_NORECORD, ClientID, true);
+	SendMsgEx(&Msg, MSGFLAG_VITAL|MSGFLAG_NORECORD, ClientID, false);
 }
 
 void CServer::SendMapData(int ClientID, int Chunk)
@@ -1852,6 +1852,7 @@ int CServer::Run()
 							continue;
 
 						SendMap(ClientID);
+						SendIsDDNet(ClientID);
 						m_aClients[ClientID].Reset();
 						m_aClients[ClientID].m_State = CClient::STATE_CONNECTING;
 					}

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -969,9 +969,9 @@ void CServer::SendMapData(int ClientID, int Chunk)
 
 void CServer::SendConnectionReady(int ClientID)
 {
-	CMsgPacker Msg(NETMSG_ISDDNET);
-	Msg.AddInt(GAME_VERSIONNR);
-	SendMsgEx(&Msg, MSGFLAG_VITAL|MSGFLAG_NORECORD, ClientID, false);
+	CMsgPacker aMsg(NETMSG_ISDDNET);
+	aMsg.AddInt(GAME_VERSIONNR);
+	SendMsgEx(&aMsg, MSGFLAG_VITAL|MSGFLAG_NORECORD, ClientID, false);
 
 	CMsgPacker Msg(NETMSG_CON_READY);
 	SendMsgEx(&Msg, MSGFLAG_VITAL|MSGFLAG_FLUSH, ClientID, true);

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -274,7 +274,6 @@ public:
 
 	void SendRconType(int ClientID, bool UsernameReq);
 	void SendMap(int ClientID);
-	void SendIsDDNet(int ClientID);
 	void SendMapData(int ClientID, int Chunk);
 	void SendConnectionReady(int ClientID);
 	void SendRconLine(int ClientID, const char *pLine);

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -274,6 +274,7 @@ public:
 
 	void SendRconType(int ClientID, bool UsernameReq);
 	void SendMap(int ClientID);
+	void SendIsDDNet(int ClientID);
 	void SendMapData(int ClientID, int Chunk);
 	void SendConnectionReady(int ClientID);
 	void SendRconLine(int ClientID, const char *pLine);

--- a/src/engine/serverbrowser.h
+++ b/src/engine/serverbrowser.h
@@ -43,6 +43,8 @@ public:
 	int m_QuickSearchHit;
 	int m_FriendState;
 
+	int m_ServerVersion;
+
 	int m_MaxClients;
 	int m_NumClients;
 	int m_MaxPlayers;

--- a/src/engine/shared/protocol_ex_msgs.h
+++ b/src/engine/shared/protocol_ex_msgs.h
@@ -25,3 +25,4 @@ UUID(NETMSG_IDONTKNOW,    "i-dont-know@ddnet.tw")
 
 UUID(NETMSG_RCONTYPE,     "rcon-type@ddnet.tw")
 UUID(NETMSG_MAP_DETAILS,  "map-details@ddnet.tw")
+UUID(NETMSG_ISDDNET,      "is-ddnet@ddnet.tw")

--- a/src/engine/shared/serverbrowser.cpp
+++ b/src/engine/shared/serverbrowser.cpp
@@ -48,7 +48,8 @@ bool IsDDRace(const CServerInfo *pInfo)
 
 bool IsDDNet(const CServerInfo *pInfo)
 {
-	return str_find_nocase(pInfo->m_aGameType, "ddracenet")
+	return pInfo->m_ServerVersion >= VERSION_DDNET_OLD
+	    || str_find_nocase(pInfo->m_aGameType, "ddracenet")
 	    || str_find_nocase(pInfo->m_aGameType, "ddnet");
 }
 

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1329,7 +1329,7 @@ void CGameClient::OnNewSnapshot()
 	if(!m_DDRaceMsgSent[0] && m_Snap.m_pLocalInfo)
 	{
 		CMsgPacker Msg(NETMSGTYPE_CL_ISDDNET);
-		Msg.AddInt(CLIENT_VERSIONNR);
+		Msg.AddInt(GAME_VERSIONNR);
 		Client()->SendMsgExY(&Msg, MSGFLAG_VITAL,false, 0);
 		m_DDRaceMsgSent[0] = true;
 	}
@@ -1337,7 +1337,7 @@ void CGameClient::OnNewSnapshot()
 	if(!m_DDRaceMsgSent[1] && m_Snap.m_pLocalInfo && Client()->DummyConnected())
 	{
 		CMsgPacker Msg(NETMSGTYPE_CL_ISDDNET);
-		Msg.AddInt(CLIENT_VERSIONNR);
+		Msg.AddInt(GAME_VERSIONNR);
 		Client()->SendMsgExY(&Msg, MSGFLAG_VITAL,false, 1);
 		m_DDRaceMsgSent[1] = true;
 	}

--- a/src/game/version.h
+++ b/src/game/version.h
@@ -5,6 +5,6 @@
 #define GAME_VERSION "0.6.4, 11.4.4"
 #define GAME_NETVERSION "0.6 626fce9a778df4d4"
 #define GAME_RELEASE_VERSION "11.4.4"
-#define CLIENT_VERSIONNR 11044
+#define GAME_VERSIONNR 11044
 extern const char *GIT_SHORTREV_HASH;
 #endif


### PR DESCRIPTION
This adds a new network message sent from the server to the client when a client connects. It tells the client that the server is a DDNet server and it is used in addition to the gametype to determine whether the server supports DDNet features. This can be used by server modifications e.g. Unique Race which support DDNet features but want to use a different gametype string.