### PR TITLE
WIP: Try to test ringbuffer (for #1307)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1124,6 +1124,7 @@ if(GTEST_FOUND OR DOWNLOAD_GTEST)
     json.cpp
     mapbugs.cpp
     name_ban.cpp
+    ringbuffer.cpp
     str.cpp
     strip_path_and_extension.cpp
     teehistorian.cpp

--- a/src/test/ringbuffer.cpp
+++ b/src/test/ringbuffer.cpp
@@ -1,0 +1,31 @@
+#include <gtest/gtest.h>
+
+#include <engine/shared/ringbuffer.h>
+
+TEST(DISABLED_Ringbuffer, Small)
+{
+    // TODO: stack smashing detected
+    TStaticRingBuffer<int, 4> buffer;
+}
+
+TEST(DISABLED_Ringbuffer, Bigger)
+{
+    TStaticRingBuffer<int, 32> buffer;
+
+    buffer.Init();
+
+    int *pMem1 = buffer.Allocate(1024);
+
+    // TODO: segfault
+    pMem1 = buffer.Next(pMem1);
+}
+
+TEST(Ringbuffer, Big)
+{
+    TStaticRingBuffer<int, 4096> buffer;
+
+    buffer.Init();
+
+    int *pMem1 = buffer.Allocate(sizeof(int)*4096);
+    buffer.Prev(pMem1);
+}


### PR DESCRIPTION
I tried to test it and create a similar scenario like in the crash:

```
(gdb) print m_Buffer
$18 = {<CRingBufferBase> = {m_pProduce = 0x7f26f6135050, m_pConsume = 0x7f26f6135050, m_pFirst = 0x7f26f6134fd8, m_pLast = 0x7f26f6135050, m_Size = 32760, m_Flags = 0},
  m_aBuffer = "\000\000\000\000\000\000\000\000 3 years\001\000\000\000\001\200\000\000\001\000\000\000)\000\000\000\030P\023\366&\177\000\000L\001\000\000\000\000\000\000\355\066\f\223\066\001\000\000\355\066\f\223\066\001\000\000\006\000
@'M4xk1ng' entered and joined the game\000nishing their f\330O\023\366&\177\000\000 3 years ago!\000\000\000\330O\023\366&\177\000\000PP\023\366&\177\000\000\001\000\000\000h\177\000\000\001\000\000\000\030\000\000\000\250P\023\366&\177\00
0\000G\001\000\000iSwe\334\301ߒ6\001\000\000\334"...}
```

But I find the ring buffer too unintuitive to use and didn't manage.