### PR TITLE
Fix mysql windows

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -2511,8 +2511,12 @@ void CServer::ConAddSqlServer(IConsole::IResult *pResult, void *pUserData)
 	}
 
 	bool ReadOnly;
+	bool SetUpDb;
 	if (str_comp_nocase(pResult->GetString(0), "w") == 0)
+	{
 		ReadOnly = false;
+		SetUpDb = pResult->NumArguments() == 8 ? pResult->GetInteger(7) : true;
+	}
 	else if (str_comp_nocase(pResult->GetString(0), "r") == 0)
 		ReadOnly = true;
 	else
@@ -2520,8 +2524,6 @@ void CServer::ConAddSqlServer(IConsole::IResult *pResult, void *pUserData)
 		pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "server", "choose either 'r' for SqlReadServer or 'w' for SqlWriteServer");
 		return;
 	}
-
-	bool SetUpDb = pResult->NumArguments() == 8 ? pResult->GetInteger(7) : true;
 
 	CSqlServer** apSqlServers = ReadOnly ? pSelf->m_apSqlReadServers : pSelf->m_apSqlWriteServers;
 

--- a/src/engine/server/sql_server.cpp
+++ b/src/engine/server/sql_server.cpp
@@ -98,6 +98,19 @@ bool CSqlServer::Connect()
 		m_pDriver = 0;
 		m_pConnection = 0;
 		m_pStatement = 0;
+		
+#if defined(CONF_FAMILY_WINDOWS)
+		char aBuf[128];
+		str_format(aBuf, sizeof(aBuf), "tcp://%s:%d", m_aIp, m_Port);
+		
+		// Create connection
+		{
+			scope_lock GlobalLockScope(m_pGlobalLock);
+			m_pDriver = get_driver_instance();
+		}
+		
+		m_pConnection = m_pDriver->connect(aBuf, m_aUser, m_aPass);
+#else
 
 		sql::ConnectOptionsMap connection_properties;
 		connection_properties["hostName"]      = sql::SQLString(m_aIp);
@@ -116,7 +129,7 @@ bool CSqlServer::Connect()
 			m_pDriver = get_driver_instance();
 		}
 		m_pConnection = m_pDriver->connect(connection_properties);
-
+#endif
 		// Create Statement
 		m_pStatement = m_pConnection->createStatement();
 

--- a/src/engine/shared/http.cpp
+++ b/src/engine/shared/http.cpp
@@ -152,6 +152,7 @@ void CRequest::Run()
 	dbg_msg("http", "http %s", m_aUrl);
 	m_State = HTTP_RUNNING;
 	int Ret = curl_easy_perform(pHandle);
+	BeforeCompletion();
 	if(Ret != CURLE_OK)
 	{
 		dbg_msg("http", "task failed. libcurl error: %s", aErr);
@@ -165,7 +166,6 @@ void CRequest::Run()
 
 	curl_easy_cleanup(pHandle);
 
-	BeforeCompletion();
 	OnCompletion();
 }
 


### PR DESCRIPTION
sv_use_sql 1
add_sqlserver "w" "teeworlds" "record" "root" "" "localhost" "3306" "1"
add_sqlserver "r" "teeworlds" "record" "root" "" "localhost" "3306"
for config file something like this wll work without crash mysql on windows.