### PR TITLE
Fix laser/rifle bounce delay, when server time(server ticks) are high/huge

### DIFF
--- a/src/game/server/entities/laser.cpp
+++ b/src/game/server/entities/laser.cpp
@@ -244,7 +244,7 @@ void CLaser::Tick()
 	else
 		Delay = GameServer()->Tuning()->m_LaserBounceDelay;
 
-	if(Server()->Tick() > m_EvalTick+(Server()->TickSpeed()*Delay/1000.0f))
+	if((Server()->Tick() - m_EvalTick) > (Server()->TickSpeed()*Delay/1000.0f))
 		DoBounce();
 }
 


### PR DESCRIPTION
Caused by unprecise floating point arithmetic (m_EvalTick can be high and is casted to float).

Generelly a cast to double wouldn't hurt, e.g. if the tick speed will be changed in future.