### PR TITLE
Handle the windows console properly

### DIFF
--- a/src/base/system.c
+++ b/src/base/system.c
@@ -175,22 +175,25 @@ static void logger_stdout_sync(const char *line, void *user)
 	(void)user;
 
 	size_t length = strlen(line);
-	wchar_t *wide = malloc(length * sizeof *wide);
+	wchar_t *wide = malloc(length * sizeof (*wide));
 	mem_zero(wide, length * sizeof *wide);
 
 	const char *p = line;
-	int i = 0;
-	for(int codepoint = 0; (codepoint = str_utf8_decode(&p)); i++)
+	int wlen = 0;
+	for(int codepoint = 0; (codepoint = str_utf8_decode(&p)); wlen++)
 	{
+		if(codepoint < 0)
+			return;
+
 		char u16[4] = {0};
 		if(str_utf16le_encode(u16, codepoint) != 2)
 			return;
 
-		mem_copy(&wide[i], u16, 2);
+		mem_copy(&wide[wlen], u16, 2);
 	}
 
 	HANDLE console = GetStdHandle(STD_OUTPUT_HANDLE);
-	WriteConsoleW(console, wide, i, NULL, NULL);
+	WriteConsoleW(console, wide, wlen, NULL, NULL);
 	WriteConsoleA(console, "\n", 1, NULL, NULL);
 }
 #endif

--- a/src/base/system.c
+++ b/src/base/system.c
@@ -173,8 +173,25 @@ static void logger_file(const char *line, void *user)
 static void logger_stdout_sync(const char *line, void *user)
 {
 	(void)user;
-	puts(line);
-	fflush(stdout);
+
+	size_t length = strlen(line);
+	wchar_t *wide = malloc(length * sizeof *wide);
+	mem_zero(wide, length * sizeof *wide);
+
+	const char *p = line;
+	int i = 0;
+	for(int codepoint = 0; (codepoint = str_utf8_decode(&p)); i++)
+	{
+		char u16[4] = {0};
+		if(str_utf16le_encode(u16, codepoint) != 2)
+			return;
+
+		mem_copy(&wide[i], u16, 2);
+	}
+
+	HANDLE console = GetStdHandle(STD_OUTPUT_HANDLE);
+	WriteConsoleW(console, wide, i, NULL, NULL);
+	WriteConsoleA(console, "\n", 1, NULL, NULL);
 }
 #endif
 
@@ -2783,6 +2800,32 @@ int str_utf8_encode(char *ptr, int chr)
 		ptr[1] = 0x80|((chr>>12)&0x3F);
 		ptr[2] = 0x80|((chr>>6)&0x3F);
 		ptr[3] = 0x80|(chr&0x3F);
+		return 4;
+	}
+
+	return 0;
+}
+
+int str_utf16le_encode(char *ptr, int chr)
+{
+	uf(chr < 0x10000)
+	{
+		ptr[0] = chr;
+		ptr[1] = chr >> 0x8;
+		return 2;
+	}
+	else if(chr <= 0x10FFFF)
+	{
+		int U = chr - 0x10000;
+		int W1 = 0xD800, W2 = 0xDC00;
+
+		W1 |= ((U >> 10) & 0x3FF);
+		W2 |= (U & 0x3FF);
+
+		ptr[0] = W1;
+		ptr[1] = W1 >> 0x8;
+		ptr[2] = W2;
+		ptr[3] = W2 >> 0x8;
 		return 4;
 	}
 

--- a/src/base/system.c
+++ b/src/base/system.c
@@ -2808,7 +2808,7 @@ int str_utf8_encode(char *ptr, int chr)
 
 int str_utf16le_encode(char *ptr, int chr)
 {
-	uf(chr < 0x10000)
+	if(chr < 0x10000)
 	{
 		ptr[0] = chr;
 		ptr[1] = chr >> 0x8;

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -1710,6 +1710,21 @@ int str_utf8_decode(const char **ptr);
 int str_utf8_encode(char *ptr, int chr);
 
 /*
+	Function: str_utf16le_encode
+		Encode an utf8 character
+
+	Parameters:
+		ptr - Pointer to a buffer that should receive the data. Should be able to hold at least 4 bytes.
+
+	Returns:
+		Number of bytes put into the buffer.
+
+	Remarks:
+		- Does not do zero termination of the string.
+*/
+int str_utf16le_encode(char *ptr, int chr);
+
+/*
 	Function: str_utf8_check
 		Checks if a strings contains just valid utf8 characters.
 

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -2787,7 +2787,7 @@ void CClient::Run()
 	bool LastQ = false;
 	bool LastE = false;
 	bool LastG = false;
-	
+
 	int64 LastTime = time_get_microseconds();
 	int64 LastRenderTime = time_get();
 
@@ -3515,9 +3515,9 @@ void CClient::RegisterCommands()
 	m_pConsole->Register("demo_speed", "i[speed]", CFGFLAG_CLIENT, Con_DemoSpeed, this, "Set demo speed");
 
 	m_pConsole->Chain("cl_timeout_seed", ConchainTimeoutSeed, this);
-	
+
 	m_pConsole->Chain("password", ConchainPassword, this);
-	
+
 	// used for server browser update
 	m_pConsole->Chain("br_filter_string", ConchainServerBrowserUpdate, this);
 	m_pConsole->Chain("br_filter_gametype", ConchainServerBrowserUpdate, this);
@@ -3576,10 +3576,6 @@ int main(int argc, const char **argv) // ignore_convention
 			break;
 		}
 	}
-
-#if defined(CONF_FAMILY_WINDOWS)
-	SetConsoleOutputCP(65001);
-#endif
 
 	if(secure_random_init() != 0)
 	{


### PR DESCRIPTION
Consoles in windows are "devices", outputting to them through stdout is handled horribly in msvcrt. Accessing it properly through WinApi seems to fix the issue. This also reverts #1385  as the fix there is broken on Win7, half-baked on Win8 and meh on Win10.