### PR TITLE
Allow to use pausevoted as normal pause

### DIFF
--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -311,9 +311,13 @@ void ToggleSpecPauseVoted(IConsole::IResult *pResult, void *pUserData, int Pause
 		str_format(aBuf, sizeof(aBuf), "You are force-paused for %d seconds.", (PauseState - pServ->Tick()) / pServ->TickSpeed());
 		pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "spec", aBuf);
 	}
-	else if(!pSelf->m_VoteCloseTime || (!pSelf->m_VoteKick && !pSelf->m_VoteSpec) || (pPlayer->IsPaused() && pPlayer->m_SpectatorID == pSelf->m_VoteVictim) || pResult->m_ClientID == pSelf->m_VoteVictim)
+	else if(-PauseState == PauseType)
 	{
 		pPlayer->Pause(CPlayer::PAUSE_NONE, false);
+	}
+	else if(!pSelf->m_VoteCloseTime || (!pSelf->m_VoteKick && !pSelf->m_VoteSpec) || (pPlayer->IsPaused() && pPlayer->m_SpectatorID == pSelf->m_VoteVictim) || pResult->m_ClientID == pSelf->m_VoteVictim)
+	{
+		pPlayer->Pause(PauseType, false);
 	}
 	else
 	{


### PR DESCRIPTION
Currently pause or spec voted is totally useless if no vote is running. This pr allows to use the commands as normal pause if no vote is running. So only one bind is required and not two.