### PR TITLE
Don't use compression for text rendering

### DIFF
--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -430,7 +430,7 @@ int CGraphics_Threaded::LoadTextureRaw(int Width, int Height, int Format, const 
 	Cmd.m_Flags = 0;
 	if(Flags&IGraphics::TEXLOAD_NOMIPMAPS)
 		Cmd.m_Flags |= CCommandBuffer::TEXFLAG_NOMIPMAPS;
-	if(g_Config.m_GfxTextureCompression)
+	if(g_Config.m_GfxTextureCompression && ((Flags&IGraphics::TEXLOAD_NO_COMPRESSION) == 0))
 		Cmd.m_Flags |= CCommandBuffer::TEXFLAG_COMPRESSED;
 	if(g_Config.m_GfxTextureQuality || Flags&TEXLOAD_NORESAMPLE)
 		Cmd.m_Flags |= CCommandBuffer::TEXFLAG_QUALITY;

--- a/src/engine/client/text.cpp
+++ b/src/engine/client/text.cpp
@@ -295,7 +295,7 @@ class CTextRender : public IEngineTextRender
 			pMem = calloc(Width * Height, 1);
 		}
 
-		int TextureID = Graphics()->LoadTextureRaw(Width, Height, CImageInfo::FORMAT_ALPHA, pMem, CImageInfo::FORMAT_ALPHA, IGraphics::TEXLOAD_NOMIPMAPS);
+		int TextureID = Graphics()->LoadTextureRaw(Width, Height, CImageInfo::FORMAT_ALPHA, pMem, CImageInfo::FORMAT_ALPHA, IGraphics::TEXLOAD_NOMIPMAPS | IGraphics::TEXLOAD_NO_COMPRESSION);
 
 		if(!pUploadData)
 			free(pMem);

--- a/src/engine/graphics.h
+++ b/src/engine/graphics.h
@@ -106,8 +106,9 @@ public:
 	*/
 	enum
 	{
-		TEXLOAD_NORESAMPLE = 1,
-		TEXLOAD_NOMIPMAPS = 2,
+		TEXLOAD_NORESAMPLE = 1<<0,
+		TEXLOAD_NOMIPMAPS = 1<<1,
+		TEXLOAD_NO_COMPRESSION = 1<<2,
 	};
 
 	int ScreenWidth() const { return m_ScreenWidth; }


### PR DESCRIPTION
This probably fixes the text rendering issue for some people(where random characters where missing).

I still think it's a driver bug, relating to `GL_COMPRESSED_ALPHA_ARB`, which is deprecated in newer OpenGL versions(that's probably why it worked with OpenGL3.3 and not with the older one, because our OGL 3.3 implementation uses `GL_COMPRESSED_RED`, which replaced the above)

To be extra sure, i also looked up the causing function:
https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glPixelStore.xhtml

but it clearly says it supports texture compression.

Anyway, i did not fix this by using `GL_COMPRESSED_RED`, because this is only core in newer OpenGL versions.
see:
https://www.khronos.org/registry/OpenGL/specs/gl/glspec20.pdf
(Table 3.18, which only lists *_ALPHA not *_RED)

I just disabled texture compression for text rendering now, if somebody gets asked about texture compression it's probably better to say it's really only useful, if very very low on VRAM, or the bandwidth between GPU and its memory is limited for some reasons.