### PR TITLE
Add man pages with asciidoc

### DIFF
--- a/man/DDNet-Server.6
+++ b/man/DDNet-Server.6
@@ -1,0 +1,135 @@
+'\" t
+.\"     Title: DDNet-Server
+.\"    Author: DDNet Contributors
+.\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
+.\"      Date: v1.0.0
+.\"    Manual: DDNet Server Manual
+.\"    Source: DDNet Server 11.7.2
+.\"  Language: English
+.\"
+.TH "DDNET\-SERVER" "6" "v1\&.0\&.0" "DDNet Server 11\&.7\&.2" "DDNet Server Manual"
+.\" -----------------------------------------------------------------
+.\" * Define some portability stuff
+.\" -----------------------------------------------------------------
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.\" http://bugs.debian.org/507673
+.\" http://lists.gnu.org/archive/html/groff/2009-02/msg00013.html
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.ie \n(.g .ds Aq \(aq
+.el       .ds Aq '
+.\" -----------------------------------------------------------------
+.\" * set default formatting
+.\" -----------------------------------------------------------------
+.\" disable hyphenation
+.nh
+.\" disable justification (adjust text to left margin only)
+.ad l
+.\" -----------------------------------------------------------------
+.\" * MAIN CONTENT STARTS HERE *
+.\" -----------------------------------------------------------------
+.SH "NAME"
+DDNet-Server \- Starts the DDNet server\&.
+.SH "SYNOPSIS"
+.sp
+\fBDDNet\-Server\fR [\fIOPTION\fR]\&... [\-f \fICONFIG_FILE\fR]\&...
+.SH "DESCRIPTION"
+.sp
+DDraceNetwork (DDNet) is an actively maintained version of \fBDDRace\fR, a \fBTeeworlds\fR modification with a unique cooperative gameplay\&.
+.SH "EXAMPLES"
+.sp
+\fBDDNet\-Server\fR \-f myfile\&.cfg
+.sp
+\fBDDNet\-Server\fR \-f myfile\&.cfg \-f myfile2\&.cfg
+.sp
+\fBDDNet\-Server\fR \*(Aqsv_register 0\*(Aq \*(Aqsv_name "Nameless Server"\*(Aq
+.SH "OPTIONS"
+.SS "Configuration file"
+.PP
+\fB\-f\fR \fICONFIGURATION_FILE\fR
+.RS 4
+Load
+\fICONFIGURATION_FILE\fR
+instead of default
+\fIautoexec_server\&.cfg\fR
+.RE
+.SS "Other options"
+.sp
+All options can be found here: https://ddnet\&.tw/settingscommands/
+.SH "RESOURCES"
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+\fBWebsite\fR:
+https://ddnet\&.tw/
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+\fBRSS\fR:
+https://ddnet\&.tw/feed/
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+\fBForum\fR:
+https://forum\&.ddnet\&.tw/
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+\fBDiscord\fR:
+https://ddnet\&.tw/discord
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+\fBSource\fR:
+https://github\&.com/ddnet/ddnet
+.RE
+.SH "REPORTING BUGS"
+.sp
+Report any issues here: https://github\&.com/ddnet/ddnet/issues
+.SH "CONTRIBUTING"
+.sp
+You can contribute by opening a pull request here: https://github\&.com/ddnet/ddnet/pulls
+.SH "COPYRIGHT"
+.sp
+Free use of this software is granted under the terms of the MIT License\&.
+.sp
+You can read the license here: https://github\&.com/ddnet/ddnet/blob/master/license\&.txt
+.SH "AUTHOR"
+.PP
+\fBDDNet Contributors\fR
+.RS 4
+Author.
+.RE

--- a/man/DDNet.6
+++ b/man/DDNet.6
@@ -1,0 +1,135 @@
+'\" t
+.\"     Title: DDNet
+.\"    Author: DDNet Contributors
+.\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
+.\"      Date: v1.0.0
+.\"    Manual: DDNet Manual
+.\"    Source: DDNet 11.7.2
+.\"  Language: English
+.\"
+.TH "DDNET" "6" "v1\&.0\&.0" "DDNet 11\&.7\&.2" "DDNet Manual"
+.\" -----------------------------------------------------------------
+.\" * Define some portability stuff
+.\" -----------------------------------------------------------------
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.\" http://bugs.debian.org/507673
+.\" http://lists.gnu.org/archive/html/groff/2009-02/msg00013.html
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.ie \n(.g .ds Aq \(aq
+.el       .ds Aq '
+.\" -----------------------------------------------------------------
+.\" * set default formatting
+.\" -----------------------------------------------------------------
+.\" disable hyphenation
+.nh
+.\" disable justification (adjust text to left margin only)
+.ad l
+.\" -----------------------------------------------------------------
+.\" * MAIN CONTENT STARTS HERE *
+.\" -----------------------------------------------------------------
+.SH "NAME"
+DDNet \- Starts the DDNet client\&.
+.SH "SYNOPSIS"
+.sp
+\fBDDNet\fR [\fIOPTION\fR]\&... [\-f \fICONFIG_FILE\fR]\&...
+.SH "DESCRIPTION"
+.sp
+DDraceNetwork (DDNet) is an actively maintained version of \fBDDRace\fR, a \fBTeeworlds\fR modification with a unique cooperative gameplay\&.
+.SH "EXAMPLES"
+.sp
+\fBDDNet\fR \-f myfile\&.cfg
+.sp
+\fBDDNet\fR \-f myfile\&.cfg \-f myfile2\&.cfg
+.sp
+\fBDDNet\fR \*(Aqcl_showhud 0\*(Aq \*(Aqplayer_name "nameless tee"\*(Aq
+.SH "OPTIONS"
+.SS "Configuration file"
+.PP
+\fB\-f\fR \fICONFIGURATION_FILE\fR
+.RS 4
+Load
+\fICONFIGURATION_FILE\fR
+instead of default
+\fIsettings_ddnet\&.cfg\fR
+.RE
+.SS "Other options"
+.sp
+All options can be found here: https://ddnet\&.tw/settingscommands/
+.SH "RESOURCES"
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+\fBWebsite\fR:
+https://ddnet\&.tw/
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+\fBRSS\fR:
+https://ddnet\&.tw/feed/
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+\fBForum\fR:
+https://forum\&.ddnet\&.tw/
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+\fBDiscord\fR:
+https://ddnet\&.tw/discord
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+\fBSource\fR:
+https://github\&.com/ddnet/ddnet
+.RE
+.SH "REPORTING BUGS"
+.sp
+Report any issues here: https://github\&.com/ddnet/ddnet/issues
+.SH "CONTRIBUTING"
+.sp
+You can contribute by opening a pull request here: https://github\&.com/ddnet/ddnet/pulls
+.SH "COPYRIGHT"
+.sp
+Free use of this software is granted under the terms of the MIT License\&.
+.sp
+You can read the license here: https://github\&.com/ddnet/ddnet/blob/master/license\&.txt
+.SH "AUTHOR"
+.PP
+\fBDDNet Contributors\fR
+.RS 4
+Author.
+.RE

--- a/man/DDNet.adoc
+++ b/man/DDNet.adoc
@@ -1,0 +1,56 @@
+= DDNet(6)
+DDNet Contributors
+v1.0.0
+// User defined variables
+:ddnet-version: 11.7.2
+// man page variables
+:doctype: manpage
+:man manual: DDNet Manual
+:man source: DDNet
+:man version: {ddnet-version}
+:page-layout: base
+:man-linkstyle: pass:[blue R < >]
+
+== NAME
+DDNet - Starts the DDNet client.
+
+== SYNOPSIS
+*DDNet* [_OPTION_]... [-f _CONFIG_FILE_]...
+
+== DESCRIPTION
+DDraceNetwork (DDNet) is an actively maintained version of *DDRace*,
+a *Teeworlds* modification with a unique cooperative gameplay.
+
+== EXAMPLES
+*DDNet* -f myfile.cfg
+
+*DDNet* -f myfile.cfg -f myfile2.cfg
+
+*DDNet* \'cl_showhud 0' \'player_name "nameless tee"'
+
+== Options
+
+=== Configuration file
+*-f* _CONFIGURATION_FILE_::
+Load _CONFIGURATION_FILE_ instead of default _settings_ddnet.cfg_
+
+=== Other options
+All options can be found here: https://ddnet.tw/settingscommands/
+
+== RESOURCES
+- *Website*: https://ddnet.tw/
+- *RSS*: https://ddnet.tw/feed/
+- *Forum*: https://forum.ddnet.tw/
+- *Discord*: https://ddnet.tw/discord
+- *Source*: https://github.com/ddnet/ddnet
+
+== REPORTING BUGS
+Report any issues here: https://github.com/ddnet/ddnet/issues
+
+== CONTRIBUTING
+You can contribute by opening a pull request here: https://github.com/ddnet/ddnet/pulls
+
+== COPYRIGHT
+Free use of this software is granted under the terms of the MIT License.
+
+You can read the license here: https://github.com/ddnet/ddnet/blob/master/license.txt

--- a/man/DDNetServer.adoc
+++ b/man/DDNetServer.adoc
@@ -1,0 +1,56 @@
+= DDNet-Server(6)
+DDNet Contributors
+v1.0.0
+// User defined variables
+:ddnet-version: 11.7.2
+// man page variables
+:doctype: manpage
+:man manual: DDNet Server Manual
+:man source: DDNet Server
+:man version: {ddnet-version}
+:page-layout: base
+:man-linkstyle: pass:[blue R < >]
+
+== NAME
+DDNet-Server - Starts the DDNet server.
+
+== SYNOPSIS
+*DDNet-Server* [_OPTION_]... [-f _CONFIG_FILE_]...
+
+== DESCRIPTION
+DDraceNetwork (DDNet) is an actively maintained version of *DDRace*,
+a *Teeworlds* modification with a unique cooperative gameplay.
+
+== EXAMPLES
+*DDNet-Server* -f myfile.cfg
+
+*DDNet-Server* -f myfile.cfg -f myfile2.cfg
+
+*DDNet-Server* \'sv_register 0' \'sv_name "Nameless Server"'
+
+== Options
+
+=== Configuration file
+*-f* _CONFIGURATION_FILE_::
+Load _CONFIGURATION_FILE_ instead of default _autoexec_server.cfg_
+
+=== Other options
+All options can be found here: https://ddnet.tw/settingscommands/
+
+== RESOURCES
+- *Website*: https://ddnet.tw/
+- *RSS*: https://ddnet.tw/feed/
+- *Forum*: https://forum.ddnet.tw/
+- *Discord*: https://ddnet.tw/discord
+- *Source*: https://github.com/ddnet/ddnet
+
+== REPORTING BUGS
+Report any issues here: https://github.com/ddnet/ddnet/issues
+
+== CONTRIBUTING
+You can contribute by opening a pull request here: https://github.com/ddnet/ddnet/pulls
+
+== COPYRIGHT
+Free use of this software is granted under the terms of the MIT License.
+
+You can read the license here: https://github.com/ddnet/ddnet/blob/master/license.txt

--- a/man/generate.sh
+++ b/man/generate.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# You need asciidoc installed
+# Debian/Ubuntu: sudo apt install asciidoc
+# http://asciidoc.org/
+
+set -ex
+
+# To generate all possible formats uncomment this and be sure to have all the needed tools:
+: << 'EOF'
+for FORMAT in 'epub' 'htmlhelp' 'manpage' 'pdf' 'text' 'xhtml' 'dvi' 'ps' 'tex' 'docbook'
+do
+    a2x --doctype manpage --format $FORMAT DDNet.adoc
+    a2x --doctype manpage --format $FORMAT DDNetServer.adoc
+done
+EOF
+
+a2x --doctype manpage --format manpage DDNet.adoc
+a2x --doctype manpage --format manpage DDNetServer.adoc


### PR DESCRIPTION
Fixes #1240 

I added a simple script to generate the man pages.

To edit the man pages in the future, you must edit the `.adoc` files and then run generate.sh

You need asciidoc package to generate the manpages.

`sudo apt install asciidoc`

http://asciidoc.org/

Writing plain troff is a pain in the ass.