### PR TITLE
Sync weapon input with other input

### DIFF
--- a/src/engine/server.h
+++ b/src/engine/server.h
@@ -217,6 +217,7 @@ public:
 	virtual void OnClientDrop(int ClientID, const char *pReason) = 0;
 	virtual void OnClientDirectInput(int ClientID, void *pInput) = 0;
 	virtual void OnClientPredictedInput(int ClientID, void *pInput) = 0;
+	virtual void OnClientPredictedEarlyInput(int ClientID, void *pInput) = 0;
 
 	virtual bool IsClientReady(int ClientID) = 0;
 	virtual bool IsClientPlayer(int ClientID) = 0;

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -1959,6 +1959,12 @@ int CServer::Run()
 
 			while(t > TickStartTime(m_CurrentGameTick+1))
 			{
+				for(int c = 0; c < MAX_CLIENTS; c++)
+					if(m_aClients[c].m_State == CClient::STATE_INGAME)
+						for(int i = 0; i < 200; i++)
+							if(m_aClients[c].m_aInputs[i].m_GameTick == Tick() + 1)
+								GameServer()->OnClientPredictedEarlyInput(c, m_aClients[c].m_aInputs[i].m_aData);
+
 				m_CurrentGameTick++;
 				NewTicks++;
 

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -961,6 +961,12 @@ void CGameContext::OnClientPredictedInput(int ClientID, void *pInput)
 		m_apPlayers[ClientID]->OnPredictedInput((CNetObj_PlayerInput *)pInput);
 }
 
+void CGameContext::OnClientPredictedEarlyInput(int ClientID, void *pInput)
+{
+	if(!m_World.m_Paused)
+		m_apPlayers[ClientID]->OnPredictedEarlyInput((CNetObj_PlayerInput *)pInput);
+}
+
 struct CVoteOptionServer *CGameContext::GetVoteOption(int Index)
 {
 	CVoteOptionServer *pCurrent;

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -234,6 +234,7 @@ public:
 	virtual void OnClientDrop(int ClientID, const char *pReason);
 	virtual void OnClientDirectInput(int ClientID, void *pInput);
 	virtual void OnClientPredictedInput(int ClientID, void *pInput);
+	virtual void OnClientPredictedEarlyInput(int ClientID, void *pInput);
 
 	virtual void OnClientEngineJoin(int ClientID);
 	virtual void OnClientEngineDrop(int ClientID, const char *pReason);

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -446,11 +446,8 @@ void CPlayer::OnDirectInput(CNetObj_PlayerInput *NewInput)
 
 	m_PlayerFlags = NewInput->m_PlayerFlags;
 
-	if(m_pCharacter)
-	{
-		if(m_Paused)
-			m_pCharacter->ResetInput();
-	}
+	if(m_pCharacter && m_Paused)
+		m_pCharacter->ResetInput();
 
 	if(!m_pCharacter && m_Team != TEAM_SPECTATORS && (NewInput->m_Fire&1))
 		m_Spawning = true;

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -448,9 +448,7 @@ void CPlayer::OnDirectInput(CNetObj_PlayerInput *NewInput)
 
 	if(m_pCharacter)
 	{
-		if(!m_Paused)
-			m_pCharacter->OnDirectInput(NewInput);
-		else
+		if(m_Paused)
 			m_pCharacter->ResetInput();
 	}
 
@@ -466,6 +464,16 @@ void CPlayer::OnDirectInput(CNetObj_PlayerInput *NewInput)
 		m_LatestActivity.m_TargetY = NewInput->m_TargetY;
 		m_LastActionTick = Server()->Tick();
 	}
+}
+
+void CPlayer::OnPredictedEarlyInput(CNetObj_PlayerInput *NewInput)
+{
+	// skip the input if chat is active
+	if((m_PlayerFlags&PLAYERFLAG_CHATTING) && (NewInput->m_PlayerFlags&PLAYERFLAG_CHATTING))
+		return;
+
+	if(m_pCharacter && !m_Paused)
+		m_pCharacter->OnDirectInput(NewInput);
 }
 
 CCharacter *CPlayer::GetCharacter()

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -37,6 +37,7 @@ public:
 
 	void OnDirectInput(CNetObj_PlayerInput *NewInput);
 	void OnPredictedInput(CNetObj_PlayerInput *NewInput);
+	void OnPredictedEarlyInput(CNetObj_PlayerInput *NewInput);
 	void OnDisconnect(const char *pReason);
 
 	void ThreadKillCharacter(int Weapon = WEAPON_GAME);


### PR DESCRIPTION
Currently weapon input is applied immediately when it arrives at the server, while hook/movement inputs are buffered and not applied until the tick the client predicted them for. This pr makes the server use buffered inputs for weapons as well, to ensure that inputs are in sync, and delays weapon inputs by the same number of ticks as other inputs if the input arrives early.

The physics and timing of weapons should otherwise be unchanged (the code in server.cpp was a workaround in an attempt to achieve this).

This could perhaps make it easier to play with jitter, which currently makes the timing of things like rocket jumps to be off. Due to the desync it is also currently not possible to counteract this by increasing the input buffering / prediction time.

I've only tested this on a local server with simulated ping/jitter, but so far everything seems to behave as before, with the exception that things behave more like expected when there is jitter.
