### PR TITLE
Use `EXPECT_*` rather than `ASSERT_*` in tests

### DIFF
--- a/src/test/git_revision.cpp
+++ b/src/test/git_revision.cpp
@@ -7,6 +7,6 @@ TEST(GitRevision, ExistsOrNull)
 {
 	if(GIT_SHORTREV_HASH)
 	{
-		ASSERT_STRNE(GIT_SHORTREV_HASH, "");
+		EXPECT_STRNE(GIT_SHORTREV_HASH, "");
 	}
 }

--- a/src/test/name_ban.cpp
+++ b/src/test/name_ban.cpp
@@ -4,26 +4,26 @@
 
 TEST(NameBan, Empty)
 {
-	ASSERT_FALSE(IsNameBanned("", 0, 0));
-	ASSERT_FALSE(IsNameBanned("abc", 0, 0));
+	EXPECT_FALSE(IsNameBanned("", 0, 0));
+	EXPECT_FALSE(IsNameBanned("abc", 0, 0));
 }
 
 TEST(NameBan, Equality)
 {
 	CNameBan Abc0("abc", 0, 0);
-	ASSERT_TRUE(IsNameBanned("abc", &Abc0, 1));
-	ASSERT_TRUE(IsNameBanned("   abc", &Abc0, 1));
-	ASSERT_TRUE(IsNameBanned("abc   ", &Abc0, 1));
-	ASSERT_TRUE(IsNameBanned("abc                   foo", &Abc0, 1)); // Maximum name length.
-	ASSERT_TRUE(IsNameBanned("äbc", &Abc0, 1)); // Confusables
-	ASSERT_FALSE(IsNameBanned("def", &Abc0, 1));
-	ASSERT_FALSE(IsNameBanned("abcdef", &Abc0, 1));
+	EXPECT_TRUE(IsNameBanned("abc", &Abc0, 1));
+	EXPECT_TRUE(IsNameBanned("   abc", &Abc0, 1));
+	EXPECT_TRUE(IsNameBanned("abc   ", &Abc0, 1));
+	EXPECT_TRUE(IsNameBanned("abc                   foo", &Abc0, 1)); // Maximum name length.
+	EXPECT_TRUE(IsNameBanned("äbc", &Abc0, 1)); // Confusables
+	EXPECT_FALSE(IsNameBanned("def", &Abc0, 1));
+	EXPECT_FALSE(IsNameBanned("abcdef", &Abc0, 1));
 }
 
 TEST(NameBan, Substring)
 {
 	CNameBan Xyz("xyz", 0, 1);
-	ASSERT_TRUE(IsNameBanned("abcxyz", &Xyz, 1));
-	ASSERT_TRUE(IsNameBanned("abcxyzdef", &Xyz, 1));
-	ASSERT_FALSE(IsNameBanned("abcdef", &Xyz, 1));
+	EXPECT_TRUE(IsNameBanned("abcxyz", &Xyz, 1));
+	EXPECT_TRUE(IsNameBanned("abcxyzdef", &Xyz, 1));
+	EXPECT_FALSE(IsNameBanned("abcdef", &Xyz, 1));
 }


### PR DESCRIPTION
`EXPECT_*` allows the test to continue even in the case of failure. Use
this where it makes sense to continue.