### PR TITLE
Add auto game tiles to all possible layers, increase layer size if needed

### DIFF
--- a/src/game/editor/layer_game.cpp
+++ b/src/game/editor/layer_game.cpp
@@ -30,7 +30,7 @@ void CLayerGame::SetTile(int x, int y, CTile tile)
 		if(!m_pEditor->m_Map.m_pFrontLayer) {
 			CLayer *l = new CLayerFront(m_Width, m_Height);
 			m_pEditor->m_Map.MakeFrontLayer(l);
-			m_pEditor->m_Map.m_lGroups[m_pEditor->m_SelectedGroup]->AddLayer(l);
+			m_pEditor->m_Map.m_pGameGroup->AddLayer(l);
 		}
 		CTile nohook = {TILE_NOHOOK};
 		CLayerTiles::SetTile(x, y, nohook);


### PR DESCRIPTION
- Adds auto game tiles button to every layer that has parallax 100 and is offset by full tiles (fixes #1231)
- Creates tele layer for automapping teleporters if it didn't exist before
- Increases game/tele layer size to match the layer you are automapping from