### PR TITLE
Make cl_authed_player_color modifiable

### DIFF
--- a/src/game/client/components/scoreboard.cpp
+++ b/src/game/client/components/scoreboard.cpp
@@ -15,6 +15,7 @@
 #include <game/client/components/countryflags.h>
 #include <game/client/components/motd.h>
 #include <game/client/components/statboard.h>
+#include <game/client/components/skins.h>
 
 #include "scoreboard.h"
 
@@ -133,7 +134,10 @@ void CScoreboard::RenderSpectators(float x, float y, float w)
 			TextRender()->TextEx(&Cursor, ", ", 2);
 
 		if(m_pClient->m_aClients[pInfo->m_ClientID].m_AuthLevel)
-			TextRender()->TextColor(0.78f, 1.0f, 0.8f, 1.0f);
+		{
+			vec4 Color = m_pClient->m_pSkins->GetColorV4(g_Config.m_ClAuthedPlayerColor);
+			TextRender()->TextColor(Color.r, Color.g, Color.b, Color.a);
+		}
 
 		if(g_Config.m_ClShowIDs)
 		{
@@ -451,7 +455,10 @@ void CScoreboard::RenderScoreboard(float x, float y, float w, int Team, const ch
 		// name
 		TextRender()->SetCursor(&Cursor, NameOffset, y + (LineHeight - FontSize) / 2.f, FontSize, TEXTFLAG_RENDER|TEXTFLAG_STOP_AT_END);
 		if(m_pClient->m_aClients[pInfo->m_ClientID].m_AuthLevel)
-			TextRender()->TextColor(0.78f, 1.0f, 0.8f, 1.0f);
+		{
+			vec4 Color = m_pClient->m_pSkins->GetColorV4(g_Config.m_ClAuthedPlayerColor);
+			TextRender()->TextColor(Color.r, Color.g, Color.b, Color.a);
+		}
 
 		if(g_Config.m_ClShowIDs)
 		{

--- a/src/game/variables.h
+++ b/src/game/variables.h
@@ -19,6 +19,7 @@ MACRO_CONFIG_INT(ClNameplatesClan, cl_nameplates_clan, 0, 0, 1, CFGFLAG_CLIENT|C
 MACRO_CONFIG_INT(ClNameplatesClanSize, cl_nameplates_clan_size, 30, 0, 100, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Size of the clan plates from 0 to 100%")
 MACRO_CONFIG_INT(ClNameplatesOwn, cl_nameplates_own, 0, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Show own name plate (useful for demo recording)")
 MACRO_CONFIG_INT(ClTextEntities, cl_text_entities, 1, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Render textual entity data")
+MACRO_CONFIG_INT(ClAuthedPlayerColor, cl_authed_player_color, 5898183, 0, 0xFFFFFF, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Color of name of authenticated player in scoreboard")
 #if defined(__ANDROID__)
 MACRO_CONFIG_INT(ClAutoswitchWeapons, cl_autoswitch_weapons, 1, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Auto switch weapon on pickup")
 MACRO_CONFIG_INT(ClAutoswitchWeaponsOutOfAmmo, cl_autoswitch_weapons_out_of_ammo, 1, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Auto switch weapon when out of ammo")


### PR DESCRIPTION
Old color was rgb = (0.78, 1.0, 0.8)
In hsl = (125°, 100%, 89%)
Converted to hex hsl:
H = 125° / 360° * 255 = 89 = 0x59
S = 100% = 0xFF
since the TW HSL color system fobids too dark colors it uses l = 0.5 + 0.5 * L/255
so L = (0.89 - 0.5) * 2 * 255 = 199 = 0xC7
So in total we get 0x59FFC7 = 5898183
(Someone should just make a web interface where you can punch in all TW color formats and get them interchanged....)