### PR TITLE
Reset authed level in client

### DIFF
--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1857,6 +1857,9 @@ void CGameClient::CClientData::Reset()
 	m_EmoticonStart = -1;
 	m_Active = false;
 	m_ChatIgnore = false;
+	m_Friend = false;
+	m_Foe = false;
+	m_AuthLevel = AUTHED_NO;
 	m_SkinInfo.m_Texture = g_GameClient.m_pSkins->Get(0)->m_ColorTexture;
 	m_SkinInfo.m_ColorBody = vec4(1,1,1,1);
 	m_SkinInfo.m_ColorFeet = vec4(1,1,1,1);


### PR DESCRIPTION
As reported by jao on Discord:

22:26 jao @Learath2 client auth level needs to reset on server join or something
22:28 jao because other servers don't send it