### PR TITLE
Don't rotate static game tiles and fix switch rotation

### DIFF
--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -1135,6 +1135,9 @@ public:
 	virtual void Resize(int NewW, int NewH);
 	virtual void Shift(int Direction);
 	virtual void BrushDraw(CLayer *pBrush, float wx, float wy);
+	virtual void BrushFlipX();
+	virtual void BrushFlipY();
+	virtual void BrushRotate(float Amount);
 	virtual void FillSelection(bool Empty, CLayer *pBrush, CUIRect Rect);
 };
 

--- a/src/game/mapitems.cpp
+++ b/src/game/mapitems.cpp
@@ -91,3 +91,18 @@ bool IsValidEntity(int Index)
 		||  Index == ENTITY_DOOR
 	);
 }
+
+bool IsRotatableTile(int Index)
+{
+	return (
+		    Index == TILE_STOP
+		||  Index == TILE_STOPS
+		||  Index == TILE_CP
+		||  Index == TILE_CP_F
+		||  Index == TILE_THROUGH_DIR
+		||  Index == TILE_ENTITIES_OFF_1
+		||  Index == TILE_ENTITIES_OFF_2
+		||  Index - ENTITY_OFFSET == ENTITY_CRAZY_SHOTGUN_EX
+		||  Index - ENTITY_OFFSET == ENTITY_CRAZY_SHOTGUN
+	);
+}

--- a/src/game/mapitems.h
+++ b/src/game/mapitems.h
@@ -472,5 +472,6 @@ bool IsValidTeleTile(int Index);
 bool IsValidSpeedupTile(int Index);
 bool IsValidSwitchTile(int Index);
 bool IsValidEntity(int Index);
+bool IsRotatableTile(int Index);
 
 #endif


### PR DESCRIPTION
Should be handy for mapping.
Can be disabled by activating unused tiles (don't think it's worth a separate toggle and if you want to do it, you're doing something unusal)