### PR TITLE
Escape during popup: Only make popup disappear

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -1733,7 +1733,8 @@ bool CMenus::OnInput(IInput::CEvent e)
 		if(e.m_Key == KEY_ESCAPE)
 		{
 			m_EscapePressed = true;
-			SetActive(!IsActive());
+			if(m_Popup == POPUP_NONE)
+				SetActive(!IsActive());
 			return true;
 		}
 	}


### PR DESCRIPTION
Not the menu. Otherwise when opening the menu again the popup will reappear for one frame before disappearing.