### PR TITLE
Fix text render when a glyph is missing (fixes #1543)

### DIFF
--- a/src/engine/client/text.cpp
+++ b/src/engine/client/text.cpp
@@ -447,7 +447,19 @@ class CTextRender : public IEngineTextRender
 		if(pFont->m_FtFace->charmap)
 			GlyphIndex = FT_Get_Char_Index(pFont->m_FtFace, (FT_ULong)Chr);
 
-		if(GlyphIndex != 0 && FT_Load_Glyph(pFont->m_FtFace, GlyphIndex, FT_LOAD_RENDER|FT_LOAD_NO_BITMAP))
+		if(GlyphIndex == 0)
+		{
+			const int ReplacementChr = 0x25a1; // White square to indicate missing glyph
+			GlyphIndex = FT_Get_Char_Index(pFont->m_FtFace, (FT_ULong)ReplacementChr);
+
+			if(GlyphIndex == 0)
+			{
+				dbg_msg("pFont", "font has no glyph for either %d or replacement char %d", Chr, ReplacementChr);
+				return;
+			}
+		}
+
+		if(FT_Load_Glyph(pFont->m_FtFace, GlyphIndex, FT_LOAD_RENDER|FT_LOAD_NO_BITMAP))
 		{
 			dbg_msg("pFont", "error loading glyph %d", Chr);
 			return;


### PR DESCRIPTION
Instead show □ (white square, 0x25a1) as replacement character

The old behaviour was to continue when a glyph was missing, not load
the glyph and then instead fill the bitmap with random garbage that was
still in the buffer. Introduced by https://github.com/ddnet/ddnet/pull/1081

@Jupeyy 