### PR TITLE
Fix negative numbers in char

### DIFF
--- a/src/test/str.cpp
+++ b/src/test/str.cpp
@@ -67,10 +67,12 @@ TEST(Str, Utf8ToLower)
 	EXPECT_TRUE(str_utf8_comp_nocase("ÖlÜ", "ölüa") < 0); // NULL < a
 	EXPECT_TRUE(str_utf8_comp_nocase("ölüa", "ÖlÜ") > 0); // a < NULL
 
-	const char a[2] = {-128, 0};
+#if (CHAR_MIN < 0)
+	const char a[2] = {CHAR_MIN, 0};
 	const char b[2] = {0, 0};
 	EXPECT_TRUE(str_utf8_comp_nocase(a, b) > 0);
 	EXPECT_TRUE(str_utf8_comp_nocase(b, a) < 0);
+#endif
 
 	EXPECT_TRUE(str_utf8_comp_nocase_num("ÖlÜ", "ölüa", 5) == 0);
 	EXPECT_TRUE(str_utf8_comp_nocase_num("ÖlÜ", "ölüa", 6) != 0);


### PR DESCRIPTION
On some architectures char can be unsigned, which makes g++
very unhappy.

  error: narrowing conversion of '-128' from 'int' to 'char' inside { }