### PR TITLE
Add bound check in datafile.cpp anywhere m_ppDataPtrs is accessed as …

### DIFF
--- a/src/engine/shared/datafile.cpp
+++ b/src/engine/shared/datafile.cpp
@@ -314,6 +314,9 @@ void *CDataFileReader::GetDataImpl(int Index, int Swap)
 {
 	if(!m_pDataFile) { return 0; }
 
+	if(Index < 0 || Index >= m_pDataFile->m_Header.m_NumRawData)
+		return 0;
+
 	// load it if needed
 	if(!m_pDataFile->m_ppDataPtrs[Index])
 	{
@@ -377,7 +380,7 @@ void *CDataFileReader::GetDataSwapped(int Index)
 
 void CDataFileReader::UnloadData(int Index)
 {
-	if(Index < 0)
+	if(Index < 0 || Index >= m_pDataFile->m_Header.m_NumRawData)
 		return;
 
 	//


### PR DESCRIPTION
…an array. Should fix https://github.com/teeworlds/teeworlds/issues/2073

(cherry picked from commit e086f4b35b1adf7edc35b4ad332dc7ed1edc5988)