### PR TITLE
Always initialize m_InfosLoaded

### DIFF
--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -690,6 +690,7 @@ int CMenus::DemolistFetchCallback(const char *pName, time_t Date, int IsDir, int
 	if(IsDir)
 	{
 		str_format(Item.m_aName, sizeof(Item.m_aName), "%s/", pName);
+		Item.m_InfosLoaded = false;
 		Item.m_Valid = false;
 	}
 	else


### PR DESCRIPTION
otherwise it's uninitialized and then read, found by valgrind --tool=memcheck