### PR TITLE
Add poc for weapon status in scoreboard (#1673)

### DIFF
--- a/src/game/client/components/scoreboard.h
+++ b/src/game/client/components/scoreboard.h
@@ -6,6 +6,7 @@
 
 class CScoreboard : public CComponent
 {
+	int m_SpriteQuadContainerIndex;
 	void RenderGoals(float x, float y, float w);
 	void RenderSpectators(float x, float y, float w);
 	void RenderScoreboard(float x, float y, float w, int Team, const char *pTitle);
@@ -23,6 +24,7 @@ public:
 	virtual void OnConsoleInit();
 	virtual void OnRender();
 	virtual void OnRelease();
+	virtual void OnInit();
 
 	bool Active();
 


### PR DESCRIPTION
Just a sample draft...

I don't think the scoreboard is a good place for this. I would prefer showing a weapon above the tee on change in freeze. Or as suggested by @fokkonaut put it to the ammo and health.

I also didn't find a way yet to get the current weapon in freeze. Seems like only the server knows about it. Because current weapon is ninja and wanted weapon is not being set by scrolling.

![hammer](https://user-images.githubusercontent.com/20344300/56690976-08a0b200-66df-11e9-9348-b29ee99f20f6.png)
![gun](https://user-images.githubusercontent.com/20344300/56690982-0b030c00-66df-11e9-87be-afdf9aa47334.png)
![freeze](https://user-images.githubusercontent.com/20344300/56690988-0dfdfc80-66df-11e9-8c31-5d0e5da9ff42.png)
