### PR TITLE
Fix inconsistant uppercase server in logs

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -2200,7 +2200,7 @@ void CServer::ConStatus(IConsole::IResult *pResult, void *pUser)
 		{
 			str_format(aBuf, sizeof(aBuf), "id=%d addr=<{%s}> connecting", i, aAddrStr);
 		}
-		pThis->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "Server", aBuf);
+		pThis->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "server", aBuf);
 	}
 }
 


### PR DESCRIPTION
```
$ grep -nr 'IConsole::OUTPUT_LEVEL_STANDARD, "server"' src/ | wc -l
31
$ grep -nr 'IConsole::OUTPUT_LEVEL_STANDARD, "Server"' src/ | wc -l
1
```