### PR TITLE
Make Color.HRHConv test runtime more reasonable

### DIFF
--- a/src/test/color.cpp
+++ b/src/test/color.cpp
@@ -7,7 +7,7 @@
 
 TEST(Color, HRHConv)
 {
-    for(int i = 0; i < 0xFFFFFF; i++){
+    for(int i = 0; i < 0xFFFFFF; i+= 0xFF){
         ColorHSLA hsl = i;
         ColorRGBA rgb = color_cast<ColorRGBA>(hsl);
         ColorHSLA hsl2 = color_cast<ColorHSLA>(rgb);


### PR DESCRIPTION
Previous execution time: 650 ms / 661 ms total (98%)
Now:                       3 ms /  15 ms total (20%)