### PR TITLE
A few more prediction fixes

### DIFF
--- a/src/game/client/components/items.cpp
+++ b/src/game/client/components/items.cpp
@@ -53,7 +53,7 @@ void CItems::RenderProjectile(const CNetObj_Projectile *pCurrent, int ItemID)
 		s_LastGameTickTime = Client()->GameTickTime();
 
 	float Ct;
-	if(m_pClient->AntiPingGrenade() && LocalPlayerInGame && !(Client()->State() == IClient::STATE_DEMOPLAYBACK))
+	if(m_pClient->Predict() && m_pClient->AntiPingGrenade() && LocalPlayerInGame && !(Client()->State() == IClient::STATE_DEMOPLAYBACK))
 		Ct = ((float)(Client()->PredGameTick() - 1 - pCurrent->m_StartTick) + Client()->PredIntraGameTick())/(float)SERVER_TICK_SPEED;
 	else
 		Ct = (Client()->PrevGameTick() - pCurrent->m_StartTick)/(float)SERVER_TICK_SPEED + s_LastGameTickTime;

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -222,10 +222,12 @@ void CPlayers::RenderPlayer(
 		s_LastPredIntraTick = Client()->PredIntraGameTick();
 	}
 
+	bool PredictLocalWeapons = false;
 	float AttackTime = (Client()->PrevGameTick() - Player.m_AttackTick) / (float)SERVER_TICK_SPEED + Client()->GameTickTime();
 	float LastAttackTime = (Client()->PrevGameTick() - Player.m_AttackTick) / (float)SERVER_TICK_SPEED + s_LastGameTickTime;
 	if(Local && m_pClient->m_aClients[ClientID].m_IsPredicted && m_pClient->AntiPingWeapons() && m_pClient->AntiPingGrenade())
 	{
+		PredictLocalWeapons = true;
 		AttackTime = (Client()->PredIntraGameTick() + (Client()->PredGameTick() - 1 - Player.m_AttackTick)) / (float)SERVER_TICK_SPEED;
 		LastAttackTime = (s_LastPredIntraTick + (Client()->PredGameTick() - 1 - Player.m_AttackTick)) / (float)SERVER_TICK_SPEED;
 	}
@@ -446,7 +448,11 @@ void CPlayers::RenderPlayer(
 				}
 				if(g_pData->m_Weapons.m_aId[iw].m_aSpriteMuzzles[IteX])
 				{
-					vec2 Dir = vec2(pPlayerChar->m_X,pPlayerChar->m_Y) - vec2(pPrevChar->m_X, pPrevChar->m_Y);
+					vec2 Dir;
+					if(PredictLocalWeapons)
+						Dir = vec2(pPlayerChar->m_X,pPlayerChar->m_Y) - vec2(pPrevChar->m_X, pPrevChar->m_Y);
+					else
+						Dir = vec2(m_pClient->m_Snap.m_aCharacters[ClientID].m_Cur.m_X, m_pClient->m_Snap.m_aCharacters[ClientID].m_Cur.m_Y) - vec2(m_pClient->m_Snap.m_aCharacters[ClientID].m_Prev.m_X, m_pClient->m_Snap.m_aCharacters[ClientID].m_Prev.m_Y);
 					Dir = normalize(Dir);
 					float HadOkenAngle = GetAngle(Dir);
 					Graphics()->QuadsSetRotation(HadOkenAngle);

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1986,6 +1986,7 @@ void CGameClient::UpdateRenderedCharacters()
 		m_aClients[i].m_RenderCur = m_Snap.m_aCharacters[i].m_Cur;
 		m_aClients[i].m_RenderPrev = m_Snap.m_aCharacters[i].m_Prev;
 		m_aClients[i].m_IsPredicted = false;
+		m_aClients[i].m_IsPredictedLocal = false;
 		vec2 UnpredPos = mix(
 				vec2(m_Snap.m_aCharacters[i].m_Prev.m_X, m_Snap.m_aCharacters[i].m_Prev.m_Y),
 				vec2(m_Snap.m_aCharacters[i].m_Cur.m_X, m_Snap.m_aCharacters[i].m_Cur.m_Y),
@@ -2005,7 +2006,16 @@ void CGameClient::UpdateRenderedCharacters()
 					m_aClients[i].m_IsPredicted ? Client()->PredIntraGameTick() : Client()->IntraGameTick());
 
 			if(i == m_Snap.m_LocalClientID)
+			{
 				m_aClients[i].m_IsPredictedLocal = true;
+				CCharacter *pChar = m_PredictedWorld.GetCharacterByID(i);
+				if(pChar && AntiPingWeapons() && AntiPingGrenade() && ((pChar->m_NinjaJetpack && pChar->m_FreezeTime == 0) || m_Snap.m_aCharacters[i].m_Cur.m_Weapon != WEAPON_NINJA || m_Snap.m_aCharacters[i].m_Cur.m_Weapon == m_aClients[i].m_Predicted.m_ActiveWeapon))
+				{
+					m_aClients[i].m_RenderCur.m_AttackTick = pChar->GetAttackTick();
+					if(m_Snap.m_aCharacters[i].m_Cur.m_Weapon != WEAPON_NINJA && !(pChar->m_NinjaJetpack && pChar->Core()->m_ActiveWeapon == WEAPON_GUN))
+						m_aClients[i].m_RenderCur.m_Weapon = m_aClients[i].m_Predicted.m_ActiveWeapon;
+				}
+			}
 			else
 			{
 				// use unpredicted values for other players
@@ -2014,13 +2024,6 @@ void CGameClient::UpdateRenderedCharacters()
 
 				if(g_Config.m_ClAntiPingSmooth)
 					Pos = GetSmoothPos(i);
-			}
-
-			if(AntiPingWeapons() && AntiPingGrenade() && m_aClients[i].m_IsPredictedLocal && (m_Snap.m_aCharacters[i].m_Cur.m_Weapon != WEAPON_NINJA || m_Snap.m_aCharacters[i].m_Cur.m_Weapon == m_aClients[i].m_Predicted.m_ActiveWeapon))
-			{
-				m_aClients[i].m_RenderCur.m_Weapon = m_aClients[i].m_Predicted.m_ActiveWeapon;
-				if(CCharacter *pChar = m_PredictedWorld.GetCharacterByID(i))
-					m_aClients[i].m_RenderCur.m_AttackTick = pChar->GetAttackTick();
 			}
 
 		}

--- a/src/game/client/prediction/entities/character.cpp
+++ b/src/game/client/prediction/entities/character.cpp
@@ -1035,6 +1035,7 @@ void CCharacter::ResetPrediction()
 	m_Hit = HIT_ALL;
 	m_SuperJump = false;
 	m_Jetpack = false;
+	m_NinjaJetpack = false;
 	m_Core.m_Jumps = 2;
 	m_NumInputs = 0;
 	m_FreezeTime = 0;
@@ -1108,6 +1109,9 @@ void CCharacter::Read(CNetObj_Character *pChar, CNetObj_DDNetCharacter *pExtende
 	{
 		m_LastJetpackStrength = Tuning()->m_JetpackStrength;
 		m_Jetpack = true;
+		m_aWeapons[WEAPON_GUN].m_Got = true;
+		m_aWeapons[WEAPON_GUN].m_Ammo = -1;
+		m_NinjaJetpack = pChar->m_Weapon == WEAPON_NINJA;
 	}
 	else if(pChar->m_Weapon != WEAPON_NINJA)
 		m_Jetpack = false;

--- a/src/game/client/prediction/entities/character.cpp
+++ b/src/game/client/prediction/entities/character.cpp
@@ -555,6 +555,7 @@ void CCharacter::Tick()
 	// Previnput
 	m_PrevInput = m_Input;
 
+	m_PrevPrevPos = m_PrevPos;
 	m_PrevPos = m_Core.m_Pos;
 	return;
 }
@@ -1004,8 +1005,7 @@ CCharacter::CCharacter(CGameWorld *pGameWorld, int ID, CNetObj_Character *pChar,
 	m_LastWeapon = WEAPON_HAMMER;
 	m_QueuedWeapon = -1;
 	m_LastRefillJumps = false;
-	m_Pos = vec2(pChar->m_X, pChar->m_Y);
-	m_PrevPos = m_Pos;
+	m_PrevPrevPos = m_PrevPos = m_Pos = vec2(pChar->m_X, pChar->m_Y);
 	m_Core.Reset();
 	m_Core.Init(&GameWorld()->m_Core, GameWorld()->Collision(), GameWorld()->Teams());
 	m_Core.m_Id = ID;

--- a/src/game/client/prediction/entities/character.h
+++ b/src/game/client/prediction/entities/character.h
@@ -74,6 +74,7 @@ public:
 	bool m_Super;
 	bool m_SuperJump;
 	bool m_Jetpack;
+	bool m_NinjaJetpack;
 	int m_FreezeTime;
 	int m_FreezeTick;
 	bool m_DeepFreeze;

--- a/src/game/client/prediction/entities/character.h
+++ b/src/game/client/prediction/entities/character.h
@@ -88,6 +88,7 @@ public:
 	};
 	int m_Hit;
 	vec2 m_PrevPos;
+	vec2 m_PrevPrevPos;
 
 	int m_TileIndex;
 	int m_TileFlags;

--- a/src/game/client/prediction/entities/projectile.cpp
+++ b/src/game/client/prediction/entities/projectile.cpp
@@ -81,6 +81,9 @@ void CProjectile::Tick()
 
 	CCharacter *pTargetChr = GameWorld()->IntersectCharacter(PrevPos, ColPos, m_Freeze ? 1.0f : 6.0f, ColPos, pOwnerChar, m_Owner);
 
+	if(GameWorld()->m_WorldConfig.m_IsSolo && !(m_Weapon == WEAPON_SHOTGUN && GameWorld()->m_WorldConfig.m_IsDDRace))
+		pTargetChr = 0;
+
 	if(m_LifeSpan > -1)
 		m_LifeSpan--;
 

--- a/src/game/client/prediction/gameworld.h
+++ b/src/game/client/prediction/gameworld.h
@@ -72,6 +72,7 @@ public:
 		int m_PredictFreeze;
 		bool m_PredictWeapons;
 		bool m_PredictDDRace;
+		bool m_IsSolo;
 	} m_WorldConfig;
 
 	bool m_IsValidCopy;


### PR DESCRIPTION
Fixes direction of ninja animation (#1707) and jerky hammer animation (#1709)

Also:
-Make ninjajetpack prediction work again
-Disable antiping for grenades with cl_predict 0
-Fix grenade prediction on fastcap (no collision with others)
-Improve grenade prediction on non-ddnet servers slightly by detecting who fired a projectile when possible