### PR TITLE
Recorded the time of the player's game after the client was opened and show it on the top.

### DIFF
--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -766,6 +766,24 @@ void CHud::RenderLocalTime(float x)
 	char aTimeStr[6];
 	str_timestamp_format(aTimeStr, sizeof(aTimeStr), "%H:%M");
 	TextRender()->Text(0, x-25.0f, (12.5f - 5.f) / 2.f, 5.0f, aTimeStr, -1);
+
+	//draw the text
+	char aPlayTimeStr[6];
+	time_t CurrTime;
+	time(&CurrTime);
+	// str_timestamp_ex(m_pClient->GetPlayingTime(CurrTime), aPlayTimeStr, sizeof(aPlayTimeStr), "%H:%M");
+	int Time = m_pClient->GetPlayingTime(CurrTime) / 60;
+	str_format(aPlayTimeStr, sizeof(aPlayTimeStr), "%02d:%02d", Time/60, Time%60);
+
+	Graphics()->BlendNormal();
+	Graphics()->TextureSet(-1);
+	Graphics()->QuadsBegin();
+	Graphics()->SetColor(0.0f, 0.0f, 0.0f, 0.4f);
+	RenderTools()->DrawRoundRectExt(x-95.0f, 0.0f, 30.0f+TextRender()->TextWidth(0, 12, aPlayTimeStr, -1)/2, 12.5f, 3.75f, CUI::CORNER_B);
+	Graphics()->QuadsEnd();
+
+	TextRender()->Text(0, x-70.0f, (12.5f - 5.f) / 2.f, 5.0f, aPlayTimeStr, -1);
+	TextRender()->Text(0, x-90.0f, (12.5f - 5.f) / 2.f, 5.0f, "PLAYED", -1);
 }
 
 void CHud::OnRender()

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -766,15 +766,21 @@ void CHud::RenderLocalTime(float x)
 	char aTimeStr[6];
 	str_timestamp_format(aTimeStr, sizeof(aTimeStr), "%H:%M");
 	TextRender()->Text(0, x-25.0f, (12.5f - 5.f) / 2.f, 5.0f, aTimeStr, -1);
+}
 
-	//draw the text
+void CHud::RenderPlayTime(float x)
+{
+	if(!g_Config.m_ClShowPlayTimeAlways && !m_pClient->m_pScoreboard->Active())
+		return;
+
+	// get the time
 	char aPlayTimeStr[6];
 	time_t CurrTime;
 	time(&CurrTime);
-	// str_timestamp_ex(m_pClient->GetPlayingTime(CurrTime), aPlayTimeStr, sizeof(aPlayTimeStr), "%H:%M");
-	int Time = m_pClient->GetPlayingTime(CurrTime) / 60;
+	int Time = m_pClient->GetPlayTime(CurrTime) / 60;
 	str_format(aPlayTimeStr, sizeof(aPlayTimeStr), "%02d:%02d", Time/60, Time%60);
 
+	//draw the box
 	Graphics()->BlendNormal();
 	Graphics()->TextureSet(-1);
 	Graphics()->QuadsBegin();
@@ -782,6 +788,7 @@ void CHud::RenderLocalTime(float x)
 	RenderTools()->DrawRoundRectExt(x-95.0f, 0.0f, 30.0f+TextRender()->TextWidth(0, 12, aPlayTimeStr, -1)/2, 12.5f, 3.75f, CUI::CORNER_B);
 	Graphics()->QuadsEnd();
 
+	//draw the text
 	TextRender()->Text(0, x-70.0f, (12.5f - 5.f) / 2.f, 5.0f, aPlayTimeStr, -1);
 	TextRender()->Text(0, x-90.0f, (12.5f - 5.f) / 2.f, 5.0f, "PLAYED", -1);
 }
@@ -818,6 +825,7 @@ void CHud::OnRender()
 		RenderWarmupTimer();
 		RenderTextInfo();
 		RenderLocalTime((m_Width/7)*3);
+		RenderPlayTime((m_Width/7)*3);
 		if(Client()->State() != IClient::STATE_DEMOPLAYBACK)
 			RenderConnectionWarning();
 		RenderTeambalanceWarning();

--- a/src/game/client/components/hud.h
+++ b/src/game/client/components/hud.h
@@ -59,6 +59,7 @@ class CHud : public CComponent
 	void RenderSpectatorHud();
 	void RenderWarmupTimer();
 	void RenderLocalTime(float x);
+	void RenderPlayTime(float x);
 
 	void MapscreenToGroup(float CenterX, float CenterY, struct CMapItemGroup *PGroup);
 public:

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -274,6 +274,7 @@ void CGameClient::OnConsoleInit()
 
 void CGameClient::OnInit()
 {
+	time(&m_InitTime);
 	m_pGraphics = Kernel()->RequestInterface<IGraphics>();
 
 	m_pGraphics->AddWindowResizeListener(OnWindowResizeCB, this);

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -147,7 +147,7 @@ public:
 	int NetobjNumCorrections() { return m_NetObjHandler.NumObjCorrections(); }
 	const char *NetobjCorrectedOn() { return m_NetObjHandler.CorrectedObjOn(); }
 
-	double GetPlayingTime(time_t Curr){ return difftime(Curr, m_InitTime); };
+	double GetPlayTime(time_t Curr){ return difftime(Curr, m_InitTime); };
 
 	bool m_SuppressEvents;
 	bool m_NewTick;

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -112,6 +112,8 @@ class CGameClient : public IGameClient
 
 	int m_CheckInfo[2];
 
+	time_t m_InitTime;
+
 	static void ConTeam(IConsole::IResult *pResult, void *pUserData);
 	static void ConKill(IConsole::IResult *pResult, void *pUserData);
 
@@ -144,6 +146,8 @@ public:
 
 	int NetobjNumCorrections() { return m_NetObjHandler.NumObjCorrections(); }
 	const char *NetobjCorrectedOn() { return m_NetObjHandler.CorrectedObjOn(); }
+
+	double GetPlayingTime(time_t Curr){ return difftime(Curr, m_InitTime); };
 
 	bool m_SuppressEvents;
 	bool m_NewTick;

--- a/src/game/variables.h
+++ b/src/game/variables.h
@@ -42,6 +42,7 @@ MACRO_CONFIG_INT(ClShowChatSystem, cl_show_chat_system, 1, 0, 1, CFGFLAG_CLIENT|
 MACRO_CONFIG_INT(ClShowKillMessages, cl_showkillmessages, 1, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Show kill messages")
 MACRO_CONFIG_INT(ClShowVotesAfterVoting, cl_show_votes_after_voting, 0, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Show votes window after voting")
 MACRO_CONFIG_INT(ClShowLocalTimeAlways, cl_show_local_time_always, 0, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Always show local time")
+MACRO_CONFIG_INT(ClShowPlayTimeAlways, cl_show_play_time_always, 0, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Always show the time you have played after client opened.")
 MACRO_CONFIG_INT(ClShowfps, cl_showfps, 0, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Show ingame FPS counter")
 MACRO_CONFIG_INT(ClShowpred, cl_showpred, 0, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Show ingame prediction time in milliseconds")
 MACRO_CONFIG_INT(ClEyeWheel, cl_eye_wheel, 1, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Show eye wheel along together with emotes")


### PR DESCRIPTION
I think it's better to record the total time player had played, but the data before can't be recorded.