### PR TITLE
Add /showrange (untested)

### DIFF
--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -1158,6 +1158,25 @@ void CGameContext::ConShowAll(IConsole::IResult *pResult, void *pUserData)
 		pSelf->SendChatTarget(pResult->m_ClientID, "You will no longer see all tees on this server");
 }
 
+void CGameContext::ConShowRange(IConsole::IResult *pResult, void *pUserData)
+{
+	CGameContext *pSelf = (CGameContext *) pUserData;
+	if (!CheckClientID(pResult->m_ClientID))
+		return;
+
+	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientID];
+	if (!pPlayer)
+		return;
+
+	const int Range = pResult->GetInteger(0);
+	if (Range < 0)
+	{
+		pSelf->SendChatTarget(pResult->m_ClientID, "Invalid range passed");
+	}
+
+	pPlayer->SetShowRange(Range);
+}
+
 void CGameContext::ConSpecTeam(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *) pUserData;

--- a/src/game/server/ddracechat.h
+++ b/src/game/server/ddracechat.h
@@ -44,6 +44,7 @@ CHAT_COMMAND("invite", "r[player name]", CFGFLAG_CHAT|CFGFLAG_SERVER, ConInviteT
 
 CHAT_COMMAND("showothers", "?i['0'|'1']", CFGFLAG_CHAT|CFGFLAG_SERVER, ConShowOthers, this, "Whether to show players from other teams or not (off by default), optional i = 0 for off else for on")
 CHAT_COMMAND("showall", "?i['0'|'1']", CFGFLAG_CHAT|CFGFLAG_SERVER, ConShowAll, this, "Whether to show players at any distance (off by default), optional i = 0 for off else for on")
+CHAT_COMMAND("showrange", "i[max distance]", CFGFLAG_CHAT|CFGFLAG_SERVER, ConShowRange, this, "Maximum distance to see players at (defaults to 10; see also showall)")
 CHAT_COMMAND("specteam", "?i['0'|'1']", CFGFLAG_CHAT|CFGFLAG_SERVER, ConSpecTeam, this, "Whether to show players from other teams when spectating (on by default), optional i = 0 for off else for on")
 CHAT_COMMAND("ninjajetpack", "?i['0'|'1']", CFGFLAG_CHAT|CFGFLAG_SERVER, ConNinjaJetpack, this, "Whether to use ninja jetpack or not. Makes jetpack look more awesome")
 CHAT_COMMAND("saytime", "?r[player name]", CFGFLAG_CHAT|CFGFLAG_SERVER|CFGFLAG_NONTEEHISTORIC, ConSayTime, this, "Privately messages someone's current time in this current running race (your time by default)")

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -1230,15 +1230,7 @@ int CCharacter::NetworkClipped(int SnappingClient, vec2 CheckPos)
 	if(SnappingClient == -1 || GameServer()->m_apPlayers[SnappingClient]->m_ShowAll)
 		return 0;
 
-	float dx = GameServer()->m_apPlayers[SnappingClient]->m_ViewPos.x-CheckPos.x;
-	float dy = GameServer()->m_apPlayers[SnappingClient]->m_ViewPos.y-CheckPos.y;
-
-	if(absolute(dx) > 1000.0f || absolute(dy) > 800.0f)
-		return 1;
-
-	if(distance(GameServer()->m_apPlayers[SnappingClient]->m_ViewPos, CheckPos) > 4000.0f)
-		return 1;
-	return 0;
+	return CEntity::NetworkClipped(SnappingClient, CheckPos);
 }
 
 // DDRace

--- a/src/game/server/entity.cpp
+++ b/src/game/server/entity.cpp
@@ -38,14 +38,14 @@ int CEntity::NetworkClipped(int SnappingClient, vec2 CheckPos)
 	if(SnappingClient == -1)
 		return 0;
 
-	float dx = GameServer()->m_apPlayers[SnappingClient]->m_ViewPos.x-CheckPos.x;
-	float dy = GameServer()->m_apPlayers[SnappingClient]->m_ViewPos.y-CheckPos.y;
-
-	if(absolute(dx) > 1000.0f || absolute(dy) > 800.0f)
+	const float dx = GameServer()->m_apPlayers[SnappingClient]->m_ViewPos.x-CheckPos.x;
+	if(absolute(dx) > GameServer()->m_apPlayers[SnappingClient]->m_ShowRangeX)
 		return 1;
 
-	if(distance(GameServer()->m_apPlayers[SnappingClient]->m_ViewPos, CheckPos) > 4000.0f)
+	const float dy = GameServer()->m_apPlayers[SnappingClient]->m_ViewPos.y-CheckPos.y;
+	if(absolute(dy) > GameServer()->m_apPlayers[SnappingClient]->m_ShowRangeY)
 		return 1;
+
 	return 0;
 }
 

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -337,6 +337,7 @@ private:
 	static void ConEyeEmote(IConsole::IResult *pResult, void *pUserData);
 	static void ConShowOthers(IConsole::IResult *pResult, void *pUserData);
 	static void ConShowAll(IConsole::IResult *pResult, void *pUserData);
+	static void ConShowRange(IConsole::IResult *pResult, void *pUserData);
 	static void ConSpecTeam(IConsole::IResult *pResult, void *pUserData);
 	static void ConNinjaJetpack(IConsole::IResult *pResult, void *pUserData);
 	static void ConSayTime(IConsole::IResult *pResult, void *pUserData);

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -104,6 +104,7 @@ void CPlayer::Reset()
 	m_ClientVersion = VERSION_VANILLA;
 	m_ShowOthers = g_Config.m_SvShowOthersDefault;
 	m_ShowAll = g_Config.m_SvShowAllDefault;
+	SetShowRange();
 	m_SpecTeam = 0;
 	m_NinjaJetpack = false;
 
@@ -793,4 +794,10 @@ void CPlayer::SpectatePlayerName(const char *pName)
 			return;
 		}
 	}
+}
+
+void CPlayer::SetShowRange(const int Range)
+{
+	m_ShowRangeX = 160.0f * Range;
+	m_ShowRangeY = 90.0f * Range;
 }

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -46,6 +46,7 @@ public:
 
 	void FindDuplicateSkins();
 	void SpectatePlayerName(const char *pName);
+	void SetShowRange(int Range = 10);
 
 	//---------------------------------------------------------
 	// this is used for snapping so we know how we can clip the view for the player
@@ -166,6 +167,8 @@ public:
 	int m_ClientVersion;
 	bool m_ShowOthers;
 	bool m_ShowAll;
+	float m_ShowRangeX;
+	float m_ShowRangeY;
 	bool m_SpecTeam;
 	bool m_NinjaJetpack;
 	bool m_Afk;


### PR DESCRIPTION
- To set the distance you can see tees and other entitys
- Use the common CEntity based function to remove some code duplication
- Set the default range to be the nowadays more common 16:9 instead of 5:4
- Remove the totally unused distance function, let the visible area be
  rectangular instead of circular since most screens are rectangular...

Maybe the client could also just tell the server how far it is zoomed
out so that the server knows how much to send?