### PR TITLE
Fix prediction of non-grabbed hook

### DIFF
--- a/src/game/client/prediction/entities/character.cpp
+++ b/src/game/client/prediction/entities/character.cpp
@@ -1153,7 +1153,7 @@ void CCharacter::Read(CNetObj_Character *pChar, CNetObj_DDNetCharacter *pExtende
 		mem_zero(&m_Input, sizeof(m_Input));
 		mem_zero(&m_SavedInput, sizeof(m_SavedInput));
 		m_Input.m_Direction = m_SavedInput.m_Direction = m_Core.m_Direction;
-		m_Input.m_Hook = m_SavedInput.m_Hook = (m_Core.m_HookState == HOOK_GRABBED);
+		m_Input.m_Hook = m_SavedInput.m_Hook = (m_Core.m_HookState != HOOK_IDLE);
 		m_Input.m_TargetX = cosf(pChar->m_Angle/256.0f);
 		m_Input.m_TargetY = sinf(pChar->m_Angle/256.0f);
 	}


### PR DESCRIPTION
Fix #1766.

Turns out the bug was not just in the rendering, but in the prediction itself (hooks were not predicted unless/until they grabbed on to something). I compared with an older client (and the old implementation) and this seems like it will restore the old behavior.