### PR TITLE
Prefer downloadedmaps over maps ( #1702 )

### DIFF
--- a/src/engine/shared/demo.cpp
+++ b/src/engine/shared/demo.cpp
@@ -68,13 +68,13 @@ int CDemoRecorder::Start(class IStorage *pStorage, class IConsole *pConsole, con
 	{
 		// open mapfile
 		char aMapFilename[128];
-		// try the normal maps folder
-		str_format(aMapFilename, sizeof(aMapFilename), "maps/%s.map", pMap);
+		// try the downloaded maps
+		str_format(aMapFilename, sizeof(aMapFilename), "downloadedmaps/%s_%08x.map", pMap, Crc);
 		MapFile = pStorage->OpenFile(aMapFilename, IOFLAG_READ, IStorage::TYPE_ALL);
 		if(!MapFile)
 		{
-			// try the downloaded maps
-			str_format(aMapFilename, sizeof(aMapFilename), "downloadedmaps/%s_%08x.map", pMap, Crc);
+			// try the normal maps folder
+			str_format(aMapFilename, sizeof(aMapFilename), "maps/%s.map", pMap);
 			MapFile = pStorage->OpenFile(aMapFilename, IOFLAG_READ, IStorage::TYPE_ALL);
 		}
 		if(!MapFile)


### PR DESCRIPTION
Fixes corrupted demos if there is a different version of the current map in the maps/ folder.
Thanks to @archimede67 for initial research.

Who ever implemented that probably thought maps/ is a good source of truth because the user put a map intentionally there. It has no crc check tho.

Tested this fix with already downloaded maps and maps only present in maps/ folder. Worked fine.
Fixes a bug from the issue #1702 .