### PR TITLE
respawn is now instant, but rate limited to 3 sec unless player clicks mouse1

### DIFF
--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -901,7 +901,8 @@ void CCharacter::Die(int Killer, int Weapon)
 	// a nice sound
 	GameServer()->CreateSound(m_Pos, SOUND_PLAYER_DIE, Teams()->TeamMask(Team(), -1, m_pPlayer->GetCID()));
 
-	// this is for auto respawn after 3 secs
+	// this is to rate limit respawning to 3 secs
+	m_pPlayer->m_PreviousDieTick = m_pPlayer->m_DieTick;
 	m_pPlayer->m_DieTick = Server()->Tick();
 
 	m_Alive = false;

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -12,6 +12,7 @@
 #include "gamemodes/DDRace.h"
 #include <time.h>
 
+#include <algorithm>
 
 MACRO_ALLOC_POOL_ID_IMPL(CPlayer, MAX_CLIENTS)
 
@@ -37,6 +38,7 @@ CPlayer::~CPlayer()
 void CPlayer::Reset()
 {
 	m_DieTick = Server()->Tick();
+	m_PreviousDieTick = m_DieTick;
 	m_JoinTick = Server()->Tick();
 	delete m_pCharacter;
 	m_pCharacter = 0;
@@ -196,7 +198,9 @@ void CPlayer::Tick()
 
 	if(!GameServer()->m_World.m_Paused)
 	{
-		if(!m_pCharacter && m_DieTick+Server()->TickSpeed()*3 <= Server()->Tick())
+		int EarliestRespawnTick = m_PreviousDieTick+Server()->TickSpeed()*3;
+		int RespawnTick = std::max(m_DieTick, EarliestRespawnTick);
+		if(!m_pCharacter && RespawnTick <= Server()->Tick())
 			m_Spawning = true;
 
 		if(m_pCharacter)
@@ -219,6 +223,7 @@ void CPlayer::Tick()
 	else
 	{
 		++m_DieTick;
+		++m_PreviousDieTick;
 		++m_JoinTick;
 		++m_LastActionTick;
 		++m_TeamChangeTick;

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -92,6 +92,7 @@ public:
 	} m_TeeInfos;
 
 	int m_DieTick;
+	int m_PreviousDieTick;
 	int m_Score;
 	int m_JoinTick;
 	bool m_ForceBalanced;


### PR DESCRIPTION
3 sec respawn is particularly annoying on dummy maps, when you hit a kill tile you have to wait 3 seconds for your dummy to respawn (or switch to dummy and press mouse1)