### PR TITLE
Set and send solo status on servers with sv_solo_server and sv_team 3

### DIFF
--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -583,6 +583,7 @@ void CPlayer::TryRespawn()
 			NewTeam = 0;
 
 		Controller->m_Teams.SetForceCharacterTeam(GetCID(), NewTeam);
+		m_pCharacter->SetSolo(true);
 	}
 }
 


### PR DESCRIPTION
The solo flag isn't currently being sent on these servers (only tunings for hook and collision), which causes grenades to mistakenly be predicted to collide with others (when client and server both use ddnetcharacter).