### PR TITLE
Show mapname in scoreboard

### DIFF
--- a/src/game/client/components/scoreboard.cpp
+++ b/src/game/client/components/scoreboard.cpp
@@ -191,6 +191,8 @@ void CScoreboard::RenderScoreboard(float x, float y, float w, int Team, const ch
 		RenderTools()->DrawRoundRect(x, y, w, h, 17.0f);
 	Graphics()->QuadsEnd();
 
+	char aBuf[128] = {0};
+
 	// render title
 	float TitleFontsize = 40.0f;
 	if(!pTitle)
@@ -198,11 +200,20 @@ void CScoreboard::RenderScoreboard(float x, float y, float w, int Team, const ch
 		if(m_pClient->m_Snap.m_pGameInfoObj->m_GameStateFlags&GAMESTATEFLAG_GAMEOVER)
 			pTitle = Localize("Game over");
 		else
-			pTitle = Localize("Scoreboard");
+		{
+			if(str_length(Client()->GetCurrentMap()) > 16)
+			{
+				str_truncate(aBuf, sizeof(aBuf), Client()->GetCurrentMap(), 16);
+				str_append(aBuf, "...", sizeof(aBuf));
+				pTitle = aBuf;
+			}
+			else
+			{
+				pTitle = Client()->GetCurrentMap();
+			}
+		}
 	}
-	TextRender()->Text(0, x+20.0f, y + (50.f - TitleFontsize) / 2.f, TitleFontsize, pTitle, -1);
-
-	char aBuf[128] = {0};
+	TextRender()->Text(0, x + 20.0f, y + (50.f - TitleFontsize) / 2.f, TitleFontsize, pTitle, -1);
 
 	if(m_pClient->m_Snap.m_pGameInfoObj->m_GameFlags&GAMEFLAG_TEAMS)
 	{


### PR DESCRIPTION
![screenshot_2019-07-11_16-03-47](https://user-images.githubusercontent.com/20344300/61057588-e53ff600-a3f5-11e9-8b20-3b082172bd63.png)
![screenshot_2019-07-11_15-46-04](https://user-images.githubusercontent.com/20344300/61057605-ecff9a80-a3f5-11e9-8f59-68811a1b123a.png)

Not sure if this feature should exclude non ddrace gametypes. Or exclude standard maps. Or if the truncation limit should increase with bigger scoreboards.