### PR TITLE
Force spawn order of teams. Fix #1828

### DIFF
--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -646,6 +646,8 @@ void CGameTeams::OnCharacterSpawn(int ClientID)
 
 void CGameTeams::OnCharacterDeath(int ClientID, int Weapon)
 {
+	GameServer()->m_apPlayers[ClientID]->Respawn(); // queue the spawn as kill tiles don't
+
 	m_Core.SetSolo(ClientID, false);
 
 	int Team = m_Core.Team(ClientID);


### PR DESCRIPTION
This has an unfortunate(?) consequence of causing tees that hit kill tiles and fall out of map respawn instantly. If this is undesirable the fix would be a little more complex, maybe implementing a delay to the spawn in `CPlayer` or reordering the entity list to force strong on the tee (by swapping with one of their teammates (this might have some undesirable effects aswell, not sure though)).