### PR TITLE
Ignore some more common files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,9 +70,11 @@ generated
 .settings
 .vs
 .vscode
+compile_commands.json
 cscope.files
 cscope.out
 out
+tags
 
 # bam ignores
 /.bam


### PR DESCRIPTION
compile_commands.json is used a lot for language servers

https://cmake.org/cmake/help/latest/variable/CMAKE_EXPORT_COMPILE_COMMANDS.html

tags are generated from ctags