### PR TITLE
Add Sleepbubble to ClAfkMark

### DIFF
--- a/src/game/client/components/nameplates.cpp
+++ b/src/game/client/components/nameplates.cpp
@@ -100,7 +100,7 @@ void CNamePlates::RenderNameplate(
 			}
 		}
 
-		if(g_Config.m_ClAfkMark && m_pClient->m_aClients[ClientID].m_Afk)
+		if(g_Config.m_ClAfkMark == 1 && m_pClient->m_aClients[ClientID].m_Afk)
 		{
 			const char *AfkMark = "!";
 			if(str_comp(AfkMark, m_aNamePlates[ClientID].m_aAfkMark) != 0 || (FontSize - FontOffsetAfkMark) != m_aNamePlates[ClientID].m_AfkMarkFontSize)
@@ -166,7 +166,7 @@ void CNamePlates::RenderNameplate(
 				TextRender()->RenderTextContainer(m_aNamePlates[ClientID].m_ClanNameTextContainerIndex, &TColor, &TOutlineColor, Position.x - m_aNamePlates[ClientID].m_ClanNameTextWidth / 2.0f, Position.y - FontSize - FontSizeClan - 38.0f);
 		}
 
-		if(g_Config.m_ClAfkMark && m_pClient->m_aClients[ClientID].m_Afk)
+		if(g_Config.m_ClAfkMark == 1 && m_pClient->m_aClients[ClientID].m_Afk)
 		{
 			if(m_aNamePlates[ClientID].m_AfkMarkContainerIndex != -1)
 				TextRender()->RenderTextContainer(m_aNamePlates[ClientID].m_AfkMarkContainerIndex, &AfkMColor, &TOutlineColor, Position.x - m_aNamePlates[ClientID].m_AfkMarkWidth / 2.0f  - m_aNamePlates[ClientID].m_NameTextWidth / 2.0f - 14.0f, Position.y - FontSize - 38.0f);

--- a/src/game/client/components/nameplates.cpp
+++ b/src/game/client/components/nameplates.cpp
@@ -40,7 +40,6 @@ void CNamePlates::RenderNameplate(
 	float FontSize = 18.0f + 20.0f * g_Config.m_ClNameplatesSize / 100.0f;
 	float FontSizeClan = 18.0f + 20.0f * g_Config.m_ClNameplatesClanSize / 100.0f;
 
-	float FontOffsetAfkMark = 2.0f;
 	// render name plate
 	if(!pPlayerInfo->m_Local || g_Config.m_ClNameplatesOwn)
 	{
@@ -100,37 +99,6 @@ void CNamePlates::RenderNameplate(
 			}
 		}
 
-		if(g_Config.m_ClAfkMark == 1 && m_pClient->m_aClients[ClientID].m_Afk)
-		{
-			const char *AfkMark = "!";
-			if(str_comp(AfkMark, m_aNamePlates[ClientID].m_aAfkMark) != 0 || (FontSize - FontOffsetAfkMark) != m_aNamePlates[ClientID].m_AfkMarkFontSize)
-			{
-				mem_copy(m_aNamePlates[ClientID].m_aAfkMark, AfkMark, sizeof(m_aNamePlates[ClientID].m_aAfkMark));
-				m_aNamePlates[ClientID].m_AfkMarkFontSize = FontSize - FontOffsetAfkMark;
-
-				if(m_aNamePlates[ClientID].m_AfkMarkContainerIndex != -1)
-					TextRender()->DeleteTextContainer(m_aNamePlates[ClientID].m_AfkMarkContainerIndex);
-
-				CTextCursor Cursor;
-				TextRender()->SetCursor(&Cursor, 0, 0, FontSize, TEXTFLAG_RENDER);
-				Cursor.m_LineWidth = -1;
-
-				// create nameplates at standard zoom
-				float ScreenX0, ScreenY0, ScreenX1, ScreenY1;
-				Graphics()->GetScreen(&ScreenX0, &ScreenY0, &ScreenX1, &ScreenY1);
-				MapscreenToGroup(m_pClient->m_pCamera->m_Center.x, m_pClient->m_pCamera->m_Center.y, Layers()->GameGroup());
-
-				m_aNamePlates[ClientID].m_AfkMarkWidth = TextRender()->TextWidth(0, FontSize - FontOffsetAfkMark, AfkMark, -1);
-
-				m_aNamePlates[ClientID].m_AfkMarkContainerIndex = TextRender()->CreateTextContainer(&Cursor, AfkMark);
-				Graphics()->MapScreen(ScreenX0, ScreenY0, ScreenX1, ScreenY1);
-			}
-		}
-
-		ColorRGBA RgbAfkM = color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClAfkMarkColor));
-		STextRenderColor AfkMColor;
-		AfkMColor.Set(RgbAfkM.r, RgbAfkM.g, RgbAfkM.b, g_Config.m_ClShowOthersAlpha / 100.0f);
-
 		float tw = m_aNamePlates[ClientID].m_NameTextWidth;
 		ColorRGBA rgb = ColorRGBA(1.0f, 1.0f, 1.0f);
 		if(g_Config.m_ClNameplatesTeamcolors && m_pClient->m_Teams.Team(ClientID))
@@ -164,12 +132,6 @@ void CNamePlates::RenderNameplate(
 		{
 			if(m_aNamePlates[ClientID].m_ClanNameTextContainerIndex != -1)
 				TextRender()->RenderTextContainer(m_aNamePlates[ClientID].m_ClanNameTextContainerIndex, &TColor, &TOutlineColor, Position.x - m_aNamePlates[ClientID].m_ClanNameTextWidth / 2.0f, Position.y - FontSize - FontSizeClan - 38.0f);
-		}
-
-		if(g_Config.m_ClAfkMark == 1 && m_pClient->m_aClients[ClientID].m_Afk)
-		{
-			if(m_aNamePlates[ClientID].m_AfkMarkContainerIndex != -1)
-				TextRender()->RenderTextContainer(m_aNamePlates[ClientID].m_AfkMarkContainerIndex, &AfkMColor, &TOutlineColor, Position.x - m_aNamePlates[ClientID].m_AfkMarkWidth / 2.0f  - m_aNamePlates[ClientID].m_NameTextWidth / 2.0f - 14.0f, Position.y - FontSize - 38.0f);
 		}
 
 		if(g_Config.m_Debug) // render client id when in debug as well
@@ -224,8 +186,6 @@ void CNamePlates::ResetNamePlates()
 			TextRender()->DeleteTextContainer(m_aNamePlates[i].m_NameTextContainerIndex);
 		if(m_aNamePlates[i].m_ClanNameTextContainerIndex != -1)
 			TextRender()->DeleteTextContainer(m_aNamePlates[i].m_ClanNameTextContainerIndex);
-		if(m_aNamePlates[i].m_AfkMarkContainerIndex != -1)
-			TextRender()->DeleteTextContainer(m_aNamePlates[i].m_AfkMarkContainerIndex);
 
 		m_aNamePlates[i].Reset();
 	}

--- a/src/game/client/components/nameplates.h
+++ b/src/game/client/components/nameplates.h
@@ -12,11 +12,10 @@ struct SPlayerNamePlate
 
 	void Reset()
 	{
-		m_NameTextContainerIndex = m_ClanNameTextContainerIndex = m_AfkMarkContainerIndex = -1;
+		m_NameTextContainerIndex = m_ClanNameTextContainerIndex = -1;
 		m_aName[0] = 0;
 		m_aClanName[0] = 0;
-		m_aAfkMark[0] = 0;
-		m_NameTextWidth = m_ClanNameTextWidth = m_AfkMarkWidth = 0.f;
+		m_NameTextWidth = m_ClanNameTextWidth = 0.f;
 		m_NameTextFontSize = m_ClanNameTextFontSize = 0;
 	}
 
@@ -29,11 +28,6 @@ struct SPlayerNamePlate
 	float m_ClanNameTextWidth;
 	int m_ClanNameTextContainerIndex;
 	float m_ClanNameTextFontSize;
-
-	char m_aAfkMark[MAX_NAME_LENGTH];
-	float m_AfkMarkWidth;
-	int m_AfkMarkContainerIndex;
-	float m_AfkMarkFontSize;
 };
 
 class CNamePlates : public CComponent

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -561,6 +561,17 @@ void CPlayers::RenderPlayer(
 		Graphics()->QuadsSetRotation(0);
 	}
 
+	if(g_Config.m_ClAfkMark == 2 && m_pClient->m_aClients[ClientID].m_Afk && !(Player.m_PlayerFlags&PLAYERFLAG_CHATTING))
+	{
+		Graphics()->TextureSet(g_pData->m_aImages[IMAGE_EMOTICONS].m_Id);
+		int QuadOffset = QuadOffsetToEmoticon + (SPRITE_ZZZ - SPRITE_OOP);
+		Graphics()->SetColor(1.0f, 1.0f, 1.0f, Alpha);
+		Graphics()->RenderQuadContainerAsSprite(m_WeaponEmoteQuadContainerIndex, QuadOffset, Position.x + 24.f, Position.y - 40.f);
+
+		Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
+		Graphics()->QuadsSetRotation(0);
+	}
+
 	if(ClientID < 0)
 		return;
 

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -561,7 +561,7 @@ void CPlayers::RenderPlayer(
 		Graphics()->QuadsSetRotation(0);
 	}
 
-	if(g_Config.m_ClAfkMark == 2 && m_pClient->m_aClients[ClientID].m_Afk && !(Player.m_PlayerFlags&PLAYERFLAG_CHATTING))
+	if(g_Config.m_ClAfkEmote && m_pClient->m_aClients[ClientID].m_Afk && !(Player.m_PlayerFlags&PLAYERFLAG_CHATTING))
 	{
 		Graphics()->TextureSet(g_pData->m_aImages[IMAGE_EMOTICONS].m_Id);
 		int QuadOffset = QuadOffsetToEmoticon + (SPRITE_ZZZ - SPRITE_OOP);

--- a/src/game/variables.h
+++ b/src/game/variables.h
@@ -15,7 +15,7 @@ MACRO_CONFIG_INT(ClAntiPingSmooth, cl_antiping_smooth, 0, 0, 1, CFGFLAG_CLIENT|C
 MACRO_CONFIG_INT(ClAntiPingGunfire, cl_antiping_gunfire, 1, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Predict gunfire and show predicted weapon physics (with cl_antiping_grenade 1 and cl_antiping_weapons 1)")
 
 MACRO_CONFIG_INT(ClNameplates, cl_nameplates, 1, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Show name plates")
-MACRO_CONFIG_INT(ClAfkMark, cl_afk_mark, 1, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Show afk marks")
+MACRO_CONFIG_INT(ClAfkMark, cl_afk_mark, 1, 0, 2, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Show afk marks (0=off, 1=show mark, 2=show sleepbubble)")
 MACRO_CONFIG_INT(ClNameplatesAlways, cl_nameplates_always, 1, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Always show name plates disregarding of distance")
 MACRO_CONFIG_INT(ClNameplatesTeamcolors, cl_nameplates_teamcolors, 1, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Use team colors for name plates")
 MACRO_CONFIG_INT(ClNameplatesSize, cl_nameplates_size, 50, 0, 100, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Size of the name plates from 0 to 100%")

--- a/src/game/variables.h
+++ b/src/game/variables.h
@@ -15,7 +15,7 @@ MACRO_CONFIG_INT(ClAntiPingSmooth, cl_antiping_smooth, 0, 0, 1, CFGFLAG_CLIENT|C
 MACRO_CONFIG_INT(ClAntiPingGunfire, cl_antiping_gunfire, 1, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Predict gunfire and show predicted weapon physics (with cl_antiping_grenade 1 and cl_antiping_weapons 1)")
 
 MACRO_CONFIG_INT(ClNameplates, cl_nameplates, 1, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Show name plates")
-MACRO_CONFIG_INT(ClAfkMark, cl_afk_mark, 1, 0, 2, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Show afk marks (0=off, 1=show mark, 2=show sleepbubble)")
+MACRO_CONFIG_INT(ClAfkEmote, cl_afk_emote, 1, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Show zzz emote next to afk players")
 MACRO_CONFIG_INT(ClNameplatesAlways, cl_nameplates_always, 1, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Always show name plates disregarding of distance")
 MACRO_CONFIG_INT(ClNameplatesTeamcolors, cl_nameplates_teamcolors, 1, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Use team colors for name plates")
 MACRO_CONFIG_INT(ClNameplatesSize, cl_nameplates_size, 50, 0, 100, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Size of the name plates from 0 to 100%")
@@ -24,8 +24,6 @@ MACRO_CONFIG_INT(ClNameplatesClanSize, cl_nameplates_clan_size, 30, 0, 100, CFGF
 MACRO_CONFIG_INT(ClNameplatesOwn, cl_nameplates_own, 0, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Show own name plate (useful for demo recording)")
 MACRO_CONFIG_INT(ClTextEntities, cl_text_entities, 1, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Render textual entity data")
 MACRO_CONFIG_INT(ClTextEntitiesSize, cl_text_entities_size, 100, 0, 100, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Size of textual entity data from 0 to 100%")
-
-MACRO_CONFIG_COL(ClAfkMarkColor, cl_afk_mark_color, 16449510, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Color of afk mark of marks next to nameplates.")
 
 MACRO_CONFIG_COL(ClAuthedPlayerColor, cl_authed_player_color, 5898211, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Color of name of authenticated player in scoreboard")
 MACRO_CONFIG_COL(ClSameClanColor, cl_same_clan_color, 5898211, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Clan color of players with the same clan as you in scoreboard.")


### PR DESCRIPTION
With setting cl_afk_mark to 2 you will now get a sleepbubble on afk instead of the mark.

Which option should be default?
Also it displays chatbubble instead of sleepbubble when the playerflag is active. (I don't know which behavior is preferred)
Kept sleepy eyes on afk aswell.

 ![screenshot_2019-07-29_14-47-34](https://user-images.githubusercontent.com/13277346/62049848-624dd680-b210-11e9-82f7-2d20281eb899.png)