### PR TITLE
Centered entities text

### DIFF
--- a/src/engine/textrender.h
+++ b/src/engine/textrender.h
@@ -100,6 +100,7 @@ public:
 
 	virtual void UploadEntityLayerText(int TextureID, const char *pText, int Length, float x, float y, int FontHeight) = 0;
 	virtual int AdjustFontSize(const char *pText, int TextLength, int MaxSize = -1) = 0;
+	virtual int CalculateTextWidth(const char *pText, int TextLength, int FontWidth, int FontHeight) = 0;
 
 	// old foolish interface
 	virtual void TextColor(float r, float g, float b, float a) = 0;

--- a/src/game/client/components/mapimages.cpp
+++ b/src/game/client/components/mapimages.cpp
@@ -178,7 +178,7 @@ int CMapImages::UploadEntityLayerText(int TextureSize, int YOffset)
 	char aBuf[4];
 	int Len = str_format(aBuf, 4, "%d", 255);
 
-	int FontSize = TextRender()->AdjustFontSize(aBuf, Len, TextureSize);
+	int FontSize = TextRender()->AdjustFontSize(aBuf, Len, TextureSize)-1;
 
 	if (FontSize < 1)
 	{
@@ -191,11 +191,12 @@ int CMapImages::UploadEntityLayerText(int TextureSize, int YOffset)
 	for(int i = 0; i < 256; ++i)
 	{
 		int Len = str_format(aBuf, 4, "%d", i);
+		int XOffSet = (64-((TextureSize/3)*Len))/2;
 
 		float x = (i%16)*64;
 		float y = (i/16)*64;
 		
-		TextRender()->UploadEntityLayerText(TextureID, aBuf, Len, x, y + YOffset, FontSize);
+		TextRender()->UploadEntityLayerText(TextureID, aBuf, Len, x+XOffSet, y+YOffset, FontSize);
 	}
 
 	return TextureID;

--- a/src/game/client/components/mapimages.cpp
+++ b/src/game/client/components/mapimages.cpp
@@ -175,33 +175,47 @@ int CMapImages::UploadEntityLayerText(int TextureSize, int YOffset)
 	int TextureID = Graphics()->LoadTextureRaw(1024, 1024, CImageInfo::FORMAT_ALPHA, pMem, CImageInfo::FORMAT_ALPHA, IGraphics::TEXLOAD_NOMIPMAPS);
 	free(pMem);
 
-	char aBuf[4];
-	int Len = str_format(aBuf, 4, "%d", 255);
-
-	int FontSize = TextRender()->AdjustFontSize(aBuf, Len, TextureSize)-1;
-
-	if (FontSize < 1)
-	{
-		dbg_msg("pFont", "texture with id '%d' will not be loaded. Reason - font is too small", TextureID);
-		return TextureID;
-	}
-
-	YOffset += ((TextureSize - FontSize)/2);
-
-	for(int i = 0; i < 256; ++i)
-	{
-		int Len = str_format(aBuf, 4, "%d", i);
-		int XOffSet = (64-((TextureSize/3)*Len))/2;
-
-		float x = (i%16)*64;
-		float y = (i/16)*64;
-		
-		TextRender()->UploadEntityLayerText(TextureID, aBuf, Len, x+XOffSet, y+YOffset, FontSize);
-	}
+	UpdateEntityLayerText(TextureID, TextureSize, YOffset, 0);
+	UpdateEntityLayerText(TextureID, TextureSize, YOffset, 1);
+	UpdateEntityLayerText(TextureID, TextureSize, YOffset, 2, 255);
 
 	return TextureID;
 }
 
+void CMapImages::UpdateEntityLayerText(int TextureID, int TextureSize, int YOffset, int NumbersPower, int MaxNumber)
+{
+	char aBuf[4];
+	int DigitsCount = NumbersPower+1;
+
+	int CurrentNumber = pow(10, NumbersPower);
+	
+	if (MaxNumber == -1)
+		MaxNumber = CurrentNumber*10-1;
+	
+	str_format(aBuf, 4, "%d", CurrentNumber);
+	
+	int CurrentNumberSuitableFontSize = TextRender()->AdjustFontSize(aBuf, DigitsCount, TextureSize);
+	int UniversalSuitableFontSize = CurrentNumberSuitableFontSize*0.9; // should be smoothed enough to fit any digits combination
+
+	if (UniversalSuitableFontSize < 1)
+	{
+		dbg_msg("pFont", "texture with id '%d' will not be loaded. Reason - font is too small", TextureID);
+	}
+
+	int ApproximateTextWidth = TextRender()->CalculateTextWidth(aBuf, DigitsCount, 0, UniversalSuitableFontSize);
+	int XOffSet = (64-ApproximateTextWidth)/2;
+	YOffset += ((TextureSize - UniversalSuitableFontSize)/2);
+
+	for (; CurrentNumber <= MaxNumber; ++CurrentNumber)
+	{
+		str_format(aBuf, 4, "%d", CurrentNumber);
+
+		float x = (CurrentNumber%16)*64;
+		float y = (CurrentNumber/16)*64;
+
+		TextRender()->UploadEntityLayerText(TextureID, aBuf, DigitsCount, x+XOffSet, y+YOffset, UniversalSuitableFontSize);
+	}
+}
 
 void CMapImages::InitOverlayTextures()
 {

--- a/src/game/client/components/mapimages.h
+++ b/src/game/client/components/mapimages.h
@@ -43,6 +43,7 @@ private:
 	
 	void InitOverlayTextures();
 	int UploadEntityLayerText(int TextureSize, int YOffset);
+	void UpdateEntityLayerText(int TextureID, int TextureSize, int YOffset, int NumbersPower, int MaxNumber = -1);
 };
 
 #endif


### PR DESCRIPTION
Closes https://github.com/ddnet/ddnet/issues/1721

Before:
![not_centered_100](https://user-images.githubusercontent.com/17499770/63204728-89772580-c0a3-11e9-8ad9-060cd03d2f74.png)
Now:
![centered_100](https://user-images.githubusercontent.com/17499770/63204730-8da34300-c0a3-11e9-86e2-5f542e4789a1.png)

It is done for "buffered" mode. Therefore, it works for OpenGL 3.3 only.
