### PR TITLE
Fix keeping tmp files on map change

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -1117,7 +1117,7 @@ const char *CClient::LoadMap(const char *pName, const char *pFilename, SHA256_DI
 
 	// stop demo recording if we loaded a new map
 	for(int i = 0; i < RECORDER_MAX; i++)
-		DemoRecorder_Stop(i);
+		DemoRecorder_Stop(i, i == RECORDER_REPLAYS);
 
 	char aBuf[256];
 	str_format(aBuf, sizeof(aBuf), "loaded map '%s'", pFilename);
@@ -3534,7 +3534,7 @@ void CClient::DemoRecorder_Stop(int Recorder, bool RemoveFile)
 	m_DemoRecorder[Recorder].Stop();
 	if(RemoveFile)
 	{
-		const char *pFilename = (&m_DemoRecorder[RECORDER_REPLAYS])->GetCurrentFilename();
+		const char *pFilename = (&m_DemoRecorder[Recorder])->GetCurrentFilename();
 		Storage()->RemoveFile(pFilename, IStorage::TYPE_SAVE);
 	}
 }


### PR DESCRIPTION
This fixes an issue I noticed with replays. When you change the map but you stay on the same server, the temporary demo file used to save replays isn't deleted since the map name has changed.
This adds a way that will delete every single demo file in tmp/ directory under demos/replays, so that no more temporary files are kept.