### PR TITLE
Handle 0 star random map votes

### DIFF
--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -1422,7 +1422,7 @@ void CGameContext::OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID)
 									pOption->m_aDescription, aReason);
 						str_format(aDesc, sizeof(aDesc), "%s", pOption->m_aDescription);
 
-						if((str_startswith(pOption->m_aCommand, "random_map") || str_startswith(pOption->m_aCommand, "random_unfinished_map")) && str_length(aReason) == 1 && aReason[0] >= '1' && aReason[0] <= '5')
+						if((str_startswith(pOption->m_aCommand, "random_map") || str_startswith(pOption->m_aCommand, "random_unfinished_map")) && str_length(aReason) == 1 && aReason[0] >= '0' && aReason[0] <= '5')
 						{
 							int Stars = aReason[0] - '0';
 							str_format(aCmd, sizeof(aCmd), "%s %d", pOption->m_aCommand, Stars);
@@ -2176,9 +2176,7 @@ void CGameContext::ConRandomMap(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
 
-	int Stars = 0;
-	if(pResult->NumArguments())
-		Stars = pResult->GetInteger(0);
+	int Stars = pResult->NumArguments() ? pResult->GetInteger(0) : -1;
 
 	pSelf->m_pScore->RandomMap(&pSelf->m_pRandomMapResult, pSelf->m_VoteCreator, Stars);
 }
@@ -2187,11 +2185,9 @@ void CGameContext::ConRandomUnfinishedMap(IConsole::IResult *pResult, void *pUse
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
 
-	int stars = 0;
-	if (pResult->NumArguments())
-		stars = pResult->GetInteger(0);
+	int Stars = pResult->NumArguments() ? pResult->GetInteger(0) : -1;
 
-	pSelf->m_pScore->RandomUnfinishedMap(&pSelf->m_pRandomMapResult, pSelf->m_VoteCreator, stars);
+	pSelf->m_pScore->RandomUnfinishedMap(&pSelf->m_pRandomMapResult, pSelf->m_VoteCreator, Stars);
 }
 
 void CGameContext::ConRestart(IConsole::IResult *pResult, void *pUserData)

--- a/src/game/server/score/sql_score.cpp
+++ b/src/game/server/score/sql_score.cpp
@@ -1277,7 +1277,7 @@ bool CSqlScore::RandomMapThread(CSqlServer* pSqlServer, const CSqlData *pGameDat
 	try
 	{
 		char aBuf[512];
-		if(pData->m_Num)
+		if(pData->m_Num >= 0)
 			str_format(aBuf, sizeof(aBuf), "select * from %s_maps where Server = \"%s\" and Map != \"%s\" and Stars = \"%d\" order by RAND() limit 1;", pSqlServer->GetPrefix(), g_Config.m_SvServerType, g_Config.m_SvMap, pData->m_Num);
 		else
 			str_format(aBuf, sizeof(aBuf), "select * from %s_maps where Server = \"%s\" and Map != \"%s\" order by RAND() limit 1;", pSqlServer->GetPrefix(), g_Config.m_SvServerType, g_Config.m_SvMap);
@@ -1335,7 +1335,7 @@ bool CSqlScore::RandomUnfinishedMapThread(CSqlServer* pSqlServer, const CSqlData
 	try
 	{
 		char aBuf[512];
-		if(pData->m_Num)
+		if(pData->m_Num >= 0)
 			str_format(aBuf, sizeof(aBuf), "select * from %s_maps where Server = \"%s\" and Map != \"%s\" and Stars = \"%d\" and not exists (select * from %s_race where Name = \"%s\" and %s_race.Map = %s_maps.Map) order by RAND() limit 1;", pSqlServer->GetPrefix(), g_Config.m_SvServerType, g_Config.m_SvMap, pData->m_Num, pSqlServer->GetPrefix(), pData->m_Name.ClrStr(), pSqlServer->GetPrefix(), pSqlServer->GetPrefix());
 		else
 			str_format(aBuf, sizeof(aBuf), "select * from %s_maps where Server = \"%s\" and Map != \"%s\" and not exists (select * from %s_race where Name = \"%s\" and %s_race.Map = %s_maps.Map) order by RAND() limit 1;", pSqlServer->GetPrefix(), g_Config.m_SvServerType, g_Config.m_SvMap, pSqlServer->GetPrefix(), pData->m_Name.ClrStr(), pSqlServer->GetPrefix(), pSqlServer->GetPrefix());


### PR DESCRIPTION
0 star maps are a thing:
```
MariaDB [teeworlds]> select * from record_maps where stars = 0;
+-----------------+----------+--------+-------+----------------+---------------------+
| Map             | Server   | Points | Stars | Mapper         | Timestamp           |
+-----------------+----------+--------+-------+----------------+---------------------+
| CYO             | Moderate |      5 |     0 | =CuBe=         | 2015-07-31 13:35:00 |
| Flappy Bird     | Solo     |      0 |     0 | Saavik         | 2014-02-15 16:56:00 |
| NUT_short_race3 | DDmaX    |      0 |     0 | Zeta-Hoernchen | 2016-02-19 18:51:00 |
| NUT_short_race6 | DDmaX    |      0 |     0 | Zeta-Hoernchen | 2016-03-11 18:24:00 |
| NUT_short_race7 | DDmaX    |      0 |     0 | Zeta-Hoernchen | 2016-03-16 18:56:00 |
| SimplePlay      | Moderate |      5 |     0 | SBL            | 2014-05-13 00:04:00 |
| SimplePlay 2    | Moderate |      5 |     0 | SBL            | 2014-05-15 11:19:00 |
| SimplePlay 3    | Moderate |      5 |     0 | SBL            | 2014-05-18 00:20:00 |
| run_ankii       | Race     |      0 |     0 | Anki           | 2015-09-14 12:00:00 |
| run_blue        | Race     |      0 |     0 | Rainbow        | 2015-09-24 12:00:00 |
| run_g6          | Race     |      0 |     0 | Anki           | 2015-07-23 12:22:00 |
| run_orange      | Race     |      0 |     0 | Melone         | 2015-10-03 12:00:00 |
+-----------------+----------+--------+-------+----------------+---------------------+
12 rows in set (0.004 sec)
```