### PR TITLE
Add tune zone prediction

### DIFF
--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -331,7 +331,7 @@ MACRO_CONFIG_STR(SvConnLoggingServer, sv_conn_logging_server, 128, "", CFGFLAG_S
 #endif
 
 MACRO_CONFIG_INT(ClUnpredictedShadow, cl_unpredicted_shadow, 0, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Show unpredicted shadow tee to estimate your delay")
-MACRO_CONFIG_INT(ClPredictDDRace, cl_predict_ddrace, 1, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Predict some DDRace tiles")
+MACRO_CONFIG_INT(ClPredictDDRace, cl_predict_ddrace, 1, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Predict DDRace tiles and tunezones")
 MACRO_CONFIG_INT(ClPredictFreeze, cl_predict_freeze, 1, 0, 2, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Predict freeze tiles (0 = off, 1 = on, 2 = partial (allow a small amount of movement in freeze)")
 MACRO_CONFIG_INT(ClShowNinja, cl_show_ninja, 1, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Show ninja skin")
 MACRO_CONFIG_INT(ClShowHookCollOther, cl_show_hook_coll_other, 1, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Show other players' hook collision line")

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -2003,9 +2003,10 @@ void CGameClient::UpdatePrediction()
 		m_GameWorld.m_WorldConfig.m_InfiniteAmmo = false;
 	m_GameWorld.m_WorldConfig.m_IsSolo = !m_Snap.m_aCharacters[m_Snap.m_LocalClientID].m_HasExtendedData && !m_Tuning[g_Config.m_ClDummy].m_PlayerCollision && !m_Tuning[g_Config.m_ClDummy].m_PlayerHooking;
 
-	int TuneZone = Collision()->IsTune(Collision()->GetMapIndex(m_LocalCharacterPos));
+	// update the tuning/tunezone at the local character position with the latest tunings received before the new snapshot
+	int TuneZone = Collision()->IsTune(Collision()->GetMapIndex(vec2(m_Snap.m_pLocalCharacter->m_X, m_Snap.m_pLocalCharacter->m_Y)));
 	if(!TuneZone || !m_GameWorld.m_WorldConfig.m_PredictTiles)
-		m_GameWorld.m_Tuning[g_Config.m_ClDummy] = m_GameWorld.m_Core.m_Tuning[g_Config.m_ClDummy] = m_Tuning[g_Config.m_ClDummy];
+		m_GameWorld.m_Tuning[g_Config.m_ClDummy] = m_Tuning[g_Config.m_ClDummy];
 	else
 		m_GameWorld.TuningList()[TuneZone] = m_GameWorld.m_Core.m_Tuning[g_Config.m_ClDummy] = m_Tuning[g_Config.m_ClDummy];
 

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -154,6 +154,8 @@ class CGameClient : public IGameClient
 	static void ConchainSpecialDummy(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 	static void ConchainClTextEntitiesSize(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 
+	static void ConTuneZone(IConsole::IResult *pResult, void *pUserData);
+
 public:
 	IKernel *Kernel() { return IInterface::Kernel(); }
 	IEngine *Engine() const { return m_pEngine; }
@@ -465,6 +467,14 @@ private:
 
 	CCharOrder m_CharOrder;
 	class CCharacter m_aLastWorldCharacters[MAX_CLIENTS];
+
+	enum
+	{
+		NUM_TUNEZONES = 256
+	};
+	void LoadMapSettings();
+	CTuningParams m_aTuningList[NUM_TUNEZONES];
+	CTuningParams *TuningList() { return &m_aTuningList[0]; }
 };
 
 ColorRGBA CalculateNameColor(ColorHSLA TextColorHSL);

--- a/src/game/client/prediction/entities/character.h
+++ b/src/game/client/prediction/entities/character.h
@@ -88,6 +88,7 @@ public:
 		DISABLE_HIT_RIFLE=8
 	};
 	int m_Hit;
+	int m_TuneZone;
 	vec2 m_PrevPos;
 	vec2 m_PrevPrevPos;
 	int m_TeleCheckpoint;
@@ -207,6 +208,7 @@ private:
 	void HandleSkippableTiles(int Index);
 	void DDRaceTick();
 	void DDRacePostCoreTick();
+	void HandleTuneLayer();
 
 	int m_StrongWeakID;
 };

--- a/src/game/client/prediction/entities/laser.cpp
+++ b/src/game/client/prediction/entities/laser.cpp
@@ -20,6 +20,7 @@ CLaser::CLaser(CGameWorld *pGameWorld, vec2 Pos, vec2 Direction, float StartEner
 	m_TelePos = vec2(0,0);
 	m_WasTele = false;
 	m_Type = Type;
+	m_TuneZone = Collision()->IsTune(Collision()->GetMapIndex(m_Pos));
 	GameWorld()->InsertEntity(this);
 	DoBounce();
 }
@@ -45,7 +46,12 @@ bool CLaser::HitCharacter(vec2 From, vec2 To)
 	{
 		vec2 Temp;
 
-		float Strength = GameWorld()->Tuning()->m_ShotgunStrength;;
+		float Strength;
+		if (!m_TuneZone)
+			Strength = GameWorld()->Tuning()->m_ShotgunStrength;
+		else
+			Strength = GameWorld()->TuningList()[m_TuneZone].m_ShotgunStrength;
+
 
 		if(!g_Config.m_SvOldLaser)
 			Temp = pHit->Core()->m_Vel + normalize(m_PrevPos - pHit->Core()->m_Pos) * Strength;
@@ -119,12 +125,18 @@ void CLaser::DoBounce()
 			m_Pos = TempPos;
 			m_Dir = normalize(TempDir);
 
-			m_Energy -= distance(m_From, m_Pos) + GameWorld()->Tuning()->m_LaserBounceCost;
+			if(!m_TuneZone)
+				m_Energy -= distance(m_From, m_Pos) + GameWorld()->Tuning()->m_LaserBounceCost;
+			else
+				m_Energy -= distance(m_From, m_Pos) + GameWorld()->TuningList()[m_TuneZone].m_LaserBounceCost;
+
 
 			m_Bounces++;
 			m_WasTele = false;
 
 			int BounceNum = GameWorld()->Tuning()->m_LaserBounceNum;
+			if(m_TuneZone)
+                BounceNum = GameWorld()->TuningList()[m_TuneZone].m_LaserBounceNum;
 
 			if(m_Bounces > BounceNum)
 				m_Energy = -1;
@@ -143,7 +155,11 @@ void CLaser::DoBounce()
 
 void CLaser::Tick()
 {
-	float Delay = GameWorld()->Tuning()->m_LaserBounceDelay;
+	float Delay;
+	if(m_TuneZone)
+		Delay = GameWorld()->TuningList()[m_TuneZone].m_LaserBounceDelay;
+	else
+		Delay = GameWorld()->Tuning()->m_LaserBounceDelay;
 
 	if(GameWorld()->m_WorldConfig.m_IsVanilla) // predict old physics on vanilla 0.6 servers
 	{
@@ -177,6 +193,7 @@ CLaser::CLaser(CGameWorld *pGameWorld, int ID, CNetObj_Laser *pLaser)
 		m_Energy = 0;
 	m_Type = WEAPON_RIFLE;
 	m_PrevPos = m_From;
+	m_TuneZone = Collision()->IsTune(Collision()->GetMapIndex(m_Pos));
 	m_ID = ID;
 }
 

--- a/src/game/client/prediction/entities/laser.h
+++ b/src/game/client/prediction/entities/laser.h
@@ -38,6 +38,7 @@ private:
 
 	vec2 m_PrevPos;
 	int m_Type;
+	int m_TuneZone;
 };
 
 #endif

--- a/src/game/client/prediction/entities/projectile.cpp
+++ b/src/game/client/prediction/entities/projectile.cpp
@@ -38,7 +38,7 @@ CProjectile::CProjectile
 	m_Number = Number;
 	m_Freeze = Freeze;
 
-	m_TuneZone = Collision()->IsTune(Collision()->GetMapIndex(m_Pos));
+	m_TuneZone = GameWorld()->m_WorldConfig.m_PredictTiles ? Collision()->IsTune(Collision()->GetMapIndex(m_Pos)) : 0;
 
 	GameWorld()->InsertEntity(this);
 }
@@ -47,48 +47,23 @@ vec2 CProjectile::GetPos(float Time)
 {
 	float Curvature = 0;
 	float Speed = 0;
+	CTuningParams *pTuning = GetTuning(m_TuneZone);
 
 	switch(m_Type)
 	{
 		case WEAPON_GRENADE:
-			if(!m_TuneZone)
-			{
-				Curvature = Tuning()->m_GrenadeCurvature;
-				Speed = Tuning()->m_GrenadeSpeed;
-			}
-			else
-			{
-				Curvature = TuningList()[m_TuneZone].m_GrenadeCurvature;
-				Speed = TuningList()[m_TuneZone].m_GrenadeSpeed;
-			}
-
+			Curvature = pTuning->m_GrenadeCurvature;
+			Speed = pTuning->m_GrenadeSpeed;
 			break;
 
 		case WEAPON_SHOTGUN:
-			if(!m_TuneZone)
-			{
-				Curvature = Tuning()->m_ShotgunCurvature;
-				Speed = Tuning()->m_ShotgunSpeed;
-			}
-			else
-			{
-				Curvature = TuningList()[m_TuneZone].m_ShotgunCurvature;
-				Speed = TuningList()[m_TuneZone].m_ShotgunSpeed;
-			}
-
+			Curvature = pTuning->m_ShotgunCurvature;
+			Speed = pTuning->m_ShotgunSpeed;
 			break;
 
 		case WEAPON_GUN:
-			if(!m_TuneZone)
-			{
-				Curvature = Tuning()->m_GunCurvature;
-				Speed = Tuning()->m_GunSpeed;
-			}
-			else
-			{
-				Curvature = TuningList()[m_TuneZone].m_GunCurvature;
-				Speed = TuningList()[m_TuneZone].m_GunSpeed;
-			}
+			Curvature = pTuning->m_GunCurvature;
+			Speed = pTuning->m_GunSpeed;
 			break;
 	}
 
@@ -197,21 +172,21 @@ CProjectile::CProjectile(CGameWorld *pGameWorld, int ID, CNetObj_Projectile *pPr
 	}
 	m_Type = m_Weapon = pProj->m_Type;
 	m_StartTick = pProj->m_StartTick;
+	m_TuneZone = GameWorld()->m_WorldConfig.m_PredictTiles ? Collision()->IsTune(Collision()->GetMapIndex(m_Pos)) : 0;
 
 	int Lifetime = 20 * GameWorld()->GameTickSpeed();
 	m_SoundImpact = -1;
 	if(m_Weapon == WEAPON_GRENADE)
 	{
-		Lifetime = pGameWorld->Tuning()->m_GrenadeLifetime * GameWorld()->GameTickSpeed();
+		Lifetime = GetTuning(m_TuneZone)->m_GrenadeLifetime * GameWorld()->GameTickSpeed();
 		m_SoundImpact = SOUND_GRENADE_EXPLODE;
 	}
 	else if(m_Weapon == WEAPON_GUN)
-		Lifetime = pGameWorld->Tuning()->m_GunLifetime * GameWorld()->GameTickSpeed();
+		Lifetime = GetTuning(m_TuneZone)->m_GunLifetime * GameWorld()->GameTickSpeed();
 	else if(m_Weapon == WEAPON_SHOTGUN && !GameWorld()->m_WorldConfig.m_IsDDRace)
-		Lifetime = pGameWorld->Tuning()->m_ShotgunLifetime * GameWorld()->GameTickSpeed();
+		Lifetime = GetTuning(m_TuneZone)->m_ShotgunLifetime * GameWorld()->GameTickSpeed();
 	m_LifeSpan = Lifetime - (pGameWorld->GameTick() - m_StartTick);
 	m_ID = ID;
-	m_TuneZone = Collision()->IsTune(Collision()->GetMapIndex(m_Pos));
 }
 
 void CProjectile::FillInfo(CNetObj_Projectile *pProj)

--- a/src/game/client/prediction/entities/projectile.cpp
+++ b/src/game/client/prediction/entities/projectile.cpp
@@ -38,6 +38,8 @@ CProjectile::CProjectile
 	m_Number = Number;
 	m_Freeze = Freeze;
 
+	m_TuneZone = Collision()->IsTune(Collision()->GetMapIndex(m_Pos));
+
 	GameWorld()->InsertEntity(this);
 }
 
@@ -49,18 +51,44 @@ vec2 CProjectile::GetPos(float Time)
 	switch(m_Type)
 	{
 		case WEAPON_GRENADE:
-			Curvature = Tuning()->m_GrenadeCurvature;
-			Speed = Tuning()->m_GrenadeSpeed;
+			if(!m_TuneZone)
+			{
+				Curvature = Tuning()->m_GrenadeCurvature;
+				Speed = Tuning()->m_GrenadeSpeed;
+			}
+			else
+			{
+				Curvature = TuningList()[m_TuneZone].m_GrenadeCurvature;
+				Speed = TuningList()[m_TuneZone].m_GrenadeSpeed;
+			}
+
 			break;
 
 		case WEAPON_SHOTGUN:
-			Curvature = Tuning()->m_ShotgunCurvature;
-			Speed = Tuning()->m_ShotgunSpeed;
+			if(!m_TuneZone)
+			{
+				Curvature = Tuning()->m_ShotgunCurvature;
+				Speed = Tuning()->m_ShotgunSpeed;
+			}
+			else
+			{
+				Curvature = TuningList()[m_TuneZone].m_ShotgunCurvature;
+				Speed = TuningList()[m_TuneZone].m_ShotgunSpeed;
+			}
+
 			break;
 
 		case WEAPON_GUN:
-			Curvature = Tuning()->m_GunCurvature;
-			Speed = Tuning()->m_GunSpeed;
+			if(!m_TuneZone)
+			{
+				Curvature = Tuning()->m_GunCurvature;
+				Speed = Tuning()->m_GunSpeed;
+			}
+			else
+			{
+				Curvature = TuningList()[m_TuneZone].m_GunCurvature;
+				Speed = TuningList()[m_TuneZone].m_GunSpeed;
+			}
 			break;
 	}
 
@@ -183,6 +211,7 @@ CProjectile::CProjectile(CGameWorld *pGameWorld, int ID, CNetObj_Projectile *pPr
 		Lifetime = pGameWorld->Tuning()->m_ShotgunLifetime * GameWorld()->GameTickSpeed();
 	m_LifeSpan = Lifetime - (pGameWorld->GameTick() - m_StartTick);
 	m_ID = ID;
+	m_TuneZone = Collision()->IsTune(Collision()->GetMapIndex(m_Pos));
 }
 
 void CProjectile::FillInfo(CNetObj_Projectile *pProj)

--- a/src/game/client/prediction/entities/projectile.h
+++ b/src/game/client/prediction/entities/projectile.h
@@ -59,6 +59,7 @@ private:
 
 	int m_Bouncing;
 	bool m_Freeze;
+	int m_TuneZone;
 };
 
 #endif

--- a/src/game/client/prediction/entity.h
+++ b/src/game/client/prediction/entity.h
@@ -41,6 +41,7 @@ public:
 	class CGameWorld *GameWorld() { return m_pGameWorld; }
 	CTuningParams *Tuning() { return GameWorld()->Tuning(); }
 	CTuningParams *TuningList() { return GameWorld()->TuningList(); }
+	CTuningParams *GetTuning(int i) { return GameWorld()->GetTuning(i); }
 	class CCollision *Collision() { return GameWorld()->Collision(); }
 	CEntity *TypeNext() { return m_pNextTypeEntity; }
 	CEntity *TypePrev() { return m_pPrevTypeEntity; }

--- a/src/game/client/prediction/entity.h
+++ b/src/game/client/prediction/entity.h
@@ -40,6 +40,7 @@ public:
 
 	class CGameWorld *GameWorld() { return m_pGameWorld; }
 	CTuningParams *Tuning() { return GameWorld()->Tuning(); }
+	CTuningParams *TuningList() { return GameWorld()->TuningList(); }
 	class CCollision *Collision() { return GameWorld()->Collision(); }
 	CEntity *TypeNext() { return m_pNextTypeEntity; }
 	CEntity *TypePrev() { return m_pPrevTypeEntity; }

--- a/src/game/client/prediction/gameworld.cpp
+++ b/src/game/client/prediction/gameworld.cpp
@@ -518,7 +518,11 @@ void CGameWorld::CopyWorld(CGameWorld *pFrom)
 	m_pCollision = pFrom->m_pCollision;
 	m_WorldConfig = pFrom->m_WorldConfig;
 	for(int i = 0; i < 2; i++)
+	{
 		m_Core.m_Tuning[i] = pFrom->m_Core.m_Tuning[i];
+		m_Tuning[i] = pFrom->m_Tuning[i];
+	}
+	m_pTuningList = pFrom->m_pTuningList;
 	m_Teams = pFrom->m_Teams;
 	// delete the previous entities
 	for(int i = 0; i < NUM_ENTTYPES; i++)

--- a/src/game/client/prediction/gameworld.cpp
+++ b/src/game/client/prediction/gameworld.cpp
@@ -281,7 +281,7 @@ void CGameWorld::ReleaseHooked(int ClientID)
 
 CTuningParams *CGameWorld::Tuning()
 {
-	return &m_Core.m_Tuning[g_Config.m_ClDummy];
+	return &m_Tuning[g_Config.m_ClDummy];
 }
 
 CEntity *CGameWorld::GetEntity(int ID, int EntType)

--- a/src/game/client/prediction/gameworld.h
+++ b/src/game/client/prediction/gameworld.h
@@ -88,6 +88,10 @@ public:
 	CEntity *FindMatch(int ObjID, int ObjType, const void *pObjData);
 	void Clear();
 
+	CTuningParams m_Tuning[2];
+	CTuningParams *m_pTuningList;
+	CTuningParams *TuningList() { return m_pTuningList; }
+
 private:
 	void RemoveEntities();
 

--- a/src/game/client/prediction/gameworld.h
+++ b/src/game/client/prediction/gameworld.h
@@ -91,6 +91,7 @@ public:
 	CTuningParams m_Tuning[2];
 	CTuningParams *m_pTuningList;
 	CTuningParams *TuningList() { return m_pTuningList; }
+	CTuningParams *GetTuning(int i) { return i == 0 ? Tuning() : &TuningList()[i]; }
 
 private:
 	void RemoveEntities();


### PR DESCRIPTION
Is enabled with cl_predict_ddrace 1.

This will predict tunings loaded from the map the first time tunezones are entered, but will also update the tunes after you receive new tunes while in a tunezone, since it's possible to change them in rcon.