### PR TITLE
Fix filescore path

### DIFF
--- a/src/engine/server.h
+++ b/src/engine/server.h
@@ -188,6 +188,8 @@ public:
 	virtual void SetTimeoutProtected(int ClientID) = 0;
 
 	virtual void SetErrorShutdown(const char *pReason) = 0;
+
+	virtual char *GetMapName() = 0;
 };
 
 class IGameServer : public IInterface

--- a/src/game/server/score/file_score.cpp
+++ b/src/game/server/score/file_score.cpp
@@ -41,16 +41,16 @@ CFileScore::~CFileScore()
 	lock_unlock(gs_ScoreLock);
 }
 
-std::string SaveFile()
+std::string CFileScore::SaveFile()
 {
 	std::ostringstream oss;
 	char aBuf[256];
-	str_copy(aBuf, g_Config.m_SvMap, sizeof(aBuf));
+	str_copy(aBuf, Server()->GetMapName(), sizeof(aBuf));
 	for(int i = 0; i < 256; i++) if(aBuf[i] == '/') aBuf[i] = '-';
 	if (g_Config.m_SvScoreFolder[0])
 		oss << g_Config.m_SvScoreFolder << "/" << aBuf << "_record.dtb";
 	else
-		oss << g_Config.m_SvMap << "_record.dtb";
+		oss << Server()->GetMapName() << "_record.dtb";
 	return oss.str();
 }
 
@@ -69,10 +69,10 @@ void CFileScore::SaveScoreThread(void *pUser)
 	CFileScore *pSelf = (CFileScore *) pUser;
 	lock_wait(gs_ScoreLock);
 	std::fstream f;
-	f.open(SaveFile().c_str(), std::ios::out);
+	f.open(pSelf->SaveFile().c_str(), std::ios::out);
 	if(f.fail())
 	{
-		dbg_msg("filescore", "opening '%s' for writing failed", SaveFile().c_str());
+		dbg_msg("filescore", "opening '%s' for writing failed", pSelf->SaveFile().c_str());
 	}
 	else
 	{

--- a/src/game/server/score/file_score.h
+++ b/src/game/server/score/file_score.h
@@ -86,6 +86,9 @@ public:
 	virtual void LoadTeam(const char* Code, int ClientID);
 
 	virtual void OnShutdown();
+
+private:
+	std::string SaveFile();
 };
 
 #endif // GAME_SERVER_SCORE_FILE_SCORE_H


### PR DESCRIPTION
The filescore system did not handle map paths well that were an actual path and not just the mapname.

```
# before fix
$ ./DDNet-Server 'sv_map "DDNetPP-maps/BlmapChill"'
[...]
[2019-09-15 13:29:44][filescore]: opening 'records/DDNetPP-maps-BlmapChill_record.dtb' for reading failed

# after fix
$ ./DDNet-Server 'sv_map "DDNetPP-maps/BlmapChill"'
[...]
[2019-09-15 13:31:05][filescore]: opening 'records/BlmapChill_record.dtb' for reading failed
```

I called ```Server()->``` in a thread so please review thread safety before merge.