### PR TITLE
[DON'T SUBMIT] Super hacky image embedder (makes maps compatible to 0.7)

### DIFF
--- a/src/engine/kernel.h
+++ b/src/engine/kernel.h
@@ -13,9 +13,8 @@ class IInterface
 	// friend with the kernel implementation
 	friend class CKernel;
 	IKernel *m_pKernel;
-protected:
-	IKernel *Kernel() { return m_pKernel; }
 public:
+	IKernel *Kernel() { return m_pKernel; }
 	IInterface() : m_pKernel(0) {}
 	virtual ~IInterface() {}
 

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -4126,6 +4126,15 @@ static int EditorListdirCallback(const char *pName, int IsDir, int StorageType, 
 	Item.m_StorageType = StorageType;
 	pEditor->m_FileList.add(Item);
 
+	pEditor->Reset();
+	if(!IsDir)
+	{
+		char aPath[512];
+		str_format(aPath, sizeof(aPath), "maps/%s", pName);
+		pEditor->m_Map.Load(pEditor->Kernel()->RequestInterface<IStorage>(), aPath, StorageType);
+		pEditor->m_Map.Save(pEditor->Kernel()->RequestInterface<IStorage>(), pName);
+	}
+
 	return 0;
 }
 

--- a/src/game/editor/io.cpp
+++ b/src/game/editor/io.cpp
@@ -297,11 +297,8 @@ int CEditorMap::Save(class IStorage *pStorage, const char *pFileName)
 
 		Item.m_Width = pImg->m_Width;
 		Item.m_Height = pImg->m_Height;
-		Item.m_External = pImg->m_External;
+		Item.m_External = false;
 		Item.m_ImageName = df.AddData(str_length(pImg->m_aName)+1, pImg->m_aName);
-		if(pImg->m_External)
-			Item.m_ImageData = -1;
-		else
 		{
 			if(pImg->m_Format == CImageInfo::FORMAT_RGB)
 			{


### PR DESCRIPTION
For #1906 

Instructions:
- Copy all maps to ~/.teeworlds/maps
- Open map editor and click on load
- New maps are now in ~/.teeworlds

Initially I tried to use map_replace_image and build something based on that but that turned out to be harder than this approach.