### PR TITLE
Properly force spawn order of teams. Fix #1828

### DIFF
--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -195,7 +195,7 @@ void CPlayer::Tick()
 	if(!GameServer()->m_World.m_Paused)
 	{
 		int EarliestRespawnTick = m_PreviousDieTick+Server()->TickSpeed()*3;
-		int RespawnTick = maximum(m_DieTick, EarliestRespawnTick);
+		int RespawnTick = maximum(m_DieTick, EarliestRespawnTick)+2;
 		if(!m_pCharacter && RespawnTick <= Server()->Tick())
 			m_Spawning = true;
 

--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -646,8 +646,6 @@ void CGameTeams::OnCharacterSpawn(int ClientID)
 
 void CGameTeams::OnCharacterDeath(int ClientID, int Weapon)
 {
-	GameServer()->m_apPlayers[ClientID]->Respawn(); // queue the spawn as kill tiles don't
-
 	m_Core.SetSolo(ClientID, false);
 
 	int Team = m_Core.Team(ClientID);


### PR DESCRIPTION
Mimic old behavior of having a respawn tick > 0 ticks after current tick. 2 ticks later is still "instant enough".

The code below the change mentions strong spawning, so without deciphering it we simply give 2 extra ticks to make sure that it executes before spawning (2 instead of 1 so that it definitely executes for both primary and dummy).