### PR TITLE
Don't bundle libcurl for Linux

### DIFF
--- a/cmake/FindCurl.cmake
+++ b/cmake/FindCurl.cmake
@@ -26,25 +26,6 @@ if(CURL_FOUND)
   is_bundled(CURL_BUNDLED "${CURL_LIBRARY}")
   set(CURL_LIBRARIES ${CURL_LIBRARY})
   set(CURL_INCLUDE_DIRS ${CURL_INCLUDEDIR})
-  if(CURL_BUNDLED AND TARGET_OS STREQUAL "linux")
-    find_library(CURL_LIBRARY_SSL
-      NAMES ssl
-      HINTS ${EXTRA_CURL_LIBDIR}
-    )
-    find_library(CURL_LIBRARY_CRYPTO
-      NAMES crypto
-      HINTS ${EXTRA_CURL_LIBDIR}
-    )
-    # If we don't add `dl`, we get a missing reference to `dlclose`:
-    # ```
-    # /usr/bin/ld: ../ddnet-libs/curl/linux/lib64/libcrypto.a(dso_dlfcn.o): undefined reference to symbol 'dlclose@@GLIBC_2.2.5'
-    # ```
-    #
-    # Order matters, SSL needs to be linked before CRYPTO, otherwise we also get
-    # undefined symbols.
-    list(APPEND CURL_LIBRARIES ${CURL_LIBRARY_SSL} ${CURL_LIBRARY_CRYPTO} dl)
-  endif()
-
   if(CURL_BUNDLED AND TARGET_OS STREQUAL "windows")
     set(CURL_COPY_FILES
       "${EXTRA_CURL_LIBDIR}/libcurl.dll"


### PR DESCRIPTION
It's installed basically everywhere and just increases release size.
They're serious about backward compatibility and haven't had a breaking
change in ages.