### PR TITLE
Add a limit to GetNearestAirPos. Fix #1931

### DIFF
--- a/src/game/server/entity.cpp
+++ b/src/game/server/entity.cpp
@@ -57,7 +57,7 @@ bool CEntity::GameLayerClipped(vec2 CheckPos)
 
 bool CEntity::GetNearestAirPos(vec2 Pos, vec2 PrevPos, vec2* pOutPos)
 {
-	while (GameServer()->Collision()->CheckPoint(Pos))
+	for(int k = 0; k < 16 && GameServer()->Collision()->CheckPoint(Pos); k++)
 	{
 		Pos -= normalize(PrevPos - Pos);
 	}


### PR DESCRIPTION
There isn't really any sane behaviour here, so I just avoided the infinite loop.

You shouldn't be in the wall to begin with :P