### PR TITLE
Mark players as afk initially. Fix #1797

### DIFF
--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -141,7 +141,7 @@ public:
 		PAUSE_PAUSED,
 		PAUSE_SPEC
 	};
-	
+
 	enum
 	{
 		TIMERTYPE_GAMETIMER=0,
@@ -183,7 +183,7 @@ public:
 	bool m_LastBroadcastImportance;
 	int m_LastTarget_x;
 	int m_LastTarget_y;
-	CNetObj_PlayerInput m_LastTarget;
+	CNetObj_PlayerInput *m_pLastTarget;
 	int m_Sent1stAfkWarning; // afk timer's 1st warning after 50% of sv_max_afk_time
 	int m_Sent2ndAfkWarning; // afk timer's 2nd warning after 90% of sv_max_afk_time
 	char m_pAfkMsg[160];


### PR DESCRIPTION
The whole afktimer code is quite ugly. I might rework it at a later date.
For now this looks like an acceptable fix.