### PR TITLE
Fix objc_msgSend() xcode11 error

### DIFF
--- a/src/engine/client/backend_sdl.h
+++ b/src/engine/client/backend_sdl.h
@@ -21,13 +21,13 @@
 			Class NSAutoreleasePoolClass = (Class) objc_getClass("NSAutoreleasePool");
 			m_Pool = class_createInstance(NSAutoreleasePoolClass, 0);
 			SEL selector = sel_registerName("init");
-			objc_msgSend(m_Pool, selector);
+			((id (*)(id, SEL))objc_msgSend)(m_Pool, selector);
 		}
 
 		~CAutoreleasePool()
 		{
 			SEL selector = sel_registerName("drain");
-			objc_msgSend(m_Pool, selector);
+			((id (*)(id, SEL))objc_msgSend)(m_Pool, selector);
 		}
 	};
 #endif


### PR DESCRIPTION
Fix by @heinrich5991
from the documentation of objc_msgSend in <objc/message.h>
```
/* Basic Messaging Primitives
 *
 * On some architectures, use objc_msgSend_stret for some struct return types.
 * On some architectures, use objc_msgSend_fpret for some float return types.
 * On some architectures, use objc_msgSend_fp2ret for some float return types.
 *
 * These functions must be cast to an appropriate function pointer type
 * before being called.
 */
OBJC_EXPORT void
objc_msgSend(void /* id self, SEL op, ... */ )
    OBJC_AVAILABLE(10.0, 2.0, 9.0, 1.0, 2.0);

OBJC_EXPORT void
objc_msgSendSuper(void /* struct objc_super *super, SEL op, ... */ )
    OBJC_AVAILABLE(10.0, 2.0, 9.0, 1.0, 2.0);
```