### PR TITLE
Fix uninitialized variable

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -472,6 +472,7 @@ int CServer::Init()
 		m_aClients[i].m_TrafficSince = 0;
 		m_aClients[i].m_ShowIps = false;
 		m_aClients[i].m_AuthKey = -1;
+		m_aClients[i].m_Latency = 0;
 	}
 
 	m_CurrentGameTick = 0;

--- a/src/engine/shared/demo.cpp
+++ b/src/engine/shared/demo.cpp
@@ -25,6 +25,7 @@ static const int gs_NumMarkersOffset = 176;
 CDemoRecorder::CDemoRecorder(class CSnapshotDelta *pSnapshotDelta, bool NoMapData)
 {
 	m_File = 0;
+	m_aCurrentFilename[0] = '\0';
 	m_pfnFilter = 0;
 	m_pUser = 0;
 	m_LastTickMarker = -1;


### PR DESCRIPTION
As reported by valgrind --tool=memcheck:

==344082== Conditional jump or move depends on uninitialised value(s)
==344082==    at 0x483BC85: strlen (vg_replace_strmem.c:461)
==344082==    by 0x5B9E61D: __vfprintf_internal (in /usr/lib/libc-2.30.so)
==344082==    by 0x5BB0409: __vsnprintf_internal (in /usr/lib/libc-2.30.so)
==344082==    by 0x222AE7: str_format (system.c:2350)
==344082==    by 0x2196AB: CStorage::GetPath(int, char const*, char*, unsigned int) (storage.cpp:274)
==344082==    by 0x219DDD: CStorage::RemoveFile(char const*, int) (storage.cpp:409)
==344082==    by 0x255D3C: CClient::DemoRecorder_Stop(int, bool) (client.cpp:3546)
==344082==    by 0x2569E7: CClient::ConchainReplays(IConsole::IResult*, void*, void (*)(IConsole::IResult*, void*), void*) (client.cpp:3727)
==344082==    by 0x1F4659: CConsole::Con_Chain(IConsole::IResult*, void*) (console.cpp:1169)
==344082==    by 0x1E4C2C: CConsole::ExecuteLineStroked(int, char const*, int, bool) (console.cpp:504)
==344082==    by 0x1E4F37: CConsole::ExecuteLine(char const*, int, bool) (console.cpp:558)
==344082==    by 0x1E5240: CConsole::ExecuteFile(char const*, int, bool, int) (console.cpp:604)