### PR TITLE
Optimize character evolve

### DIFF
--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1214,10 +1214,26 @@ void CGameClient::OnNewSnapshot()
 					m_Snap.m_aCharacters[Item.m_ID].m_Active = true;
 					m_Snap.m_aCharacters[Item.m_ID].m_Prev = *((const CNetObj_Character *)pOld);
 
+					// reuse the result from the previous evolve if the snapped character didn't change since the previous snapshot
+					if(m_aClients[Item.m_ID].m_Evolved.m_Tick == Client()->PrevGameTick())
+					{
+						if(mem_comp(&m_Snap.m_aCharacters[Item.m_ID].m_Prev, &m_aClients[Item.m_ID].m_Snapped, sizeof(CNetObj_Character)) == 0)
+							m_Snap.m_aCharacters[Item.m_ID].m_Prev = m_aClients[Item.m_ID].m_Evolved;
+						if(mem_comp(&m_Snap.m_aCharacters[Item.m_ID].m_Cur, &m_aClients[Item.m_ID].m_Snapped, sizeof(CNetObj_Character)) == 0)
+							m_Snap.m_aCharacters[Item.m_ID].m_Cur = m_aClients[Item.m_ID].m_Evolved;
+					}
+
 					if(m_Snap.m_aCharacters[Item.m_ID].m_Prev.m_Tick)
 						Evolve(&m_Snap.m_aCharacters[Item.m_ID].m_Prev, Client()->PrevGameTick());
 					if(m_Snap.m_aCharacters[Item.m_ID].m_Cur.m_Tick)
 						Evolve(&m_Snap.m_aCharacters[Item.m_ID].m_Cur, Client()->GameTick());
+
+					m_aClients[Item.m_ID].m_Snapped = *((const CNetObj_Character *)pData);
+					m_aClients[Item.m_ID].m_Evolved = m_Snap.m_aCharacters[Item.m_ID].m_Cur;
+				}
+				else
+				{
+					m_aClients[Item.m_ID].m_Evolved.m_Tick = -1;
 				}
 			}
 			else if(Item.m_Type == NETOBJTYPE_DDNETCHARACTER)
@@ -1797,6 +1813,8 @@ void CGameClient::CClientData::Reset()
 	m_HasTelegunLaser = false;
 	m_FreezeEnd = 0;
 	m_DeepFrozen = false;
+
+	m_Evolved.m_Tick = -1;
 
 	UpdateRenderInfo();
 }

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -310,6 +310,9 @@ public:
 		bool m_Paused;
 		bool m_Spec;
 
+		CNetObj_Character m_Snapped;
+		CNetObj_Character m_Evolved;
+
 		void UpdateRenderInfo();
 		void Reset();
 


### PR DESCRIPTION
I tried profiling DDNet with callgrind/valgrind and gprof, and a large amount of time seemed to be spent in Evolve in gameclient.cpp. By optimizing/memoizing the function, the percentage of total cpu time went from 50% to 2% in callgrind (the game would basically just freeze before the optimization), and a somewhat smaller difference for gprof. (I'm not sure how large the difference will be in practice, and running with a profiler might exaggerate the difference a bit)

This function is called if the client has an out-of-date character from the server, and advances the character to the current tick. However, in many cases the character doesn't  change between snapshots (for example, if a player is standing still the server will save bandwidth by not sending a new character every snapshot), in which case it seems redundant to evolve the character over the same ticks multiple times, instead of reusing the previous results. I also compared the output from the optimized version with the unoptimized one, and they seemed to always be the same.