### PR TITLE
Clean up color handling a bit

### DIFF
--- a/src/base/color.h
+++ b/src/base/color.h
@@ -32,6 +32,8 @@ inline float RgbToHue(float r, float g, float b)
 	return hue / 6.0f;
 }
 
+// Curiously Recurring Template Pattern for type safety
+template <typename DerivedT>
 class color4_base
 {
 public:
@@ -89,23 +91,21 @@ public:
 		return (Alpha ? ((unsigned)(a * 255.0f) << 24) : 0) + ((unsigned)(x * 255.0f) << 16) + ((unsigned)(y * 255.0f) << 8) + (unsigned)(z * 255.0f);
 	}
 
-	color4_base SetAlpha(float alpha)
+	DerivedT WithAlpha(float alpha)
 	{
-		color4_base col;
-		col = *this;
+		DerivedT col(static_cast<DerivedT&>(*this));
 		col.a = alpha;
 		return col;
 	}
 };
 
-class ColorHSLA : public color4_base
+class ColorHSLA : public color4_base<ColorHSLA>
 {
 public:
 	bool m_Lit = false;
 
 	using color4_base::color4_base;
 	ColorHSLA() {};
-	ColorHSLA(color4_base b): color4_base(b) {};
 
 	ColorHSLA Lighten()
 	{
@@ -138,20 +138,18 @@ public:
 	}
 };
 
-class ColorHSVA : public color4_base
+class ColorHSVA : public color4_base<ColorHSVA>
 {
 public:
 	using color4_base::color4_base;
 	ColorHSVA() {};
-	ColorHSVA(color4_base b): color4_base(b) {};
 };
 
-class ColorRGBA : public color4_base
+class ColorRGBA : public color4_base<ColorRGBA>
 {
 public:
 	using color4_base::color4_base;
 	ColorRGBA() {};
-	ColorRGBA(color4_base b): color4_base(b) {};
 };
 
 template <typename T, typename F> T color_cast(const F &f) = delete;
@@ -232,9 +230,15 @@ inline ColorHSVA color_cast(const ColorRGBA &rgb)
 }
 
 template <typename T>
-T color_scale(const color4_base &col, float s)
+T color_scale(const T &col, float s)
 {
 	return T(col.x * s, col.y * s, col.z * s, col.a * s);
+}
+
+template <typename T>
+T color_invert(const T &col)
+{
+	return T(1.0f - col.x, 1.0f - col.y, 1.0f - col.z, 1.0f - col.a);
 }
 
 #endif

--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -810,7 +810,7 @@ void CChat::OnPrepareLines()
 		if(g_Config.m_ClMessageFriend)
 		{
 			ColorRGBA rgb = color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClMessageFriendColor));
-			TextRender()->TextColor(rgb.SetAlpha(m_aLines[r].m_Friend ? 1.f : 0.f)); //Less ugly hack to align messages
+			TextRender()->TextColor(rgb.WithAlpha(m_aLines[r].m_Friend ? 1.f : 0.f)); //Less ugly hack to align messages
 			m_aLines[r].m_TextContainerIndex = TextRender()->CreateTextContainer(&Cursor, "♥ ");
 		}
 

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -1053,7 +1053,7 @@ void CMenus::RenderGhost(CUIRect MainView)
 		if(pItem->m_Own)
 			rgb = color_cast<ColorRGBA>(ColorHSLA(0.33f, 1.0f, 0.75f));
 
-		TextRender()->TextColor(rgb.SetAlpha(pItem->HasFile() ? 1.0f : 0.5f));
+		TextRender()->TextColor(rgb.WithAlpha(pItem->HasFile() ? 1.0f : 0.5f));
 
 		for(int c = 0; c < NumCols; c++)
 		{

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -292,7 +292,7 @@ void CPlayers::RenderPlayer(
 			vec2 FinishPos = InitPos + ExDirection * (m_pClient->m_Tuning[g_Config.m_ClDummy].m_HookLength-42.0f);
 
 			Graphics()->LinesBegin();
-			vec3 HookCollColor(1.0f, 0.0f, 0.0f);
+			ColorRGBA HookCollColor(1.0f, 0.0f, 0.0f);
 
 			float PhysSize = 28.0f;
 
@@ -319,17 +319,13 @@ void CPlayers::RenderPlayer(
 				{
 					if(Hit != TILE_NOHOOK)
 					{
-						HookCollColor.r = 130.0f/255.0f;
-						HookCollColor.g = 232.0f/255.0f;
-						HookCollColor.b = 160.0f/255.0f;
+						HookCollColor = ColorRGBA(130.0f/255.0f, 232.0f/255.0f, 160.0f/255.0f);
 					}
 				}
 
 				if(m_pClient->IntersectCharacter(OldPos, FinishPos, FinishPos, ClientID) != -1)
 				{
-					HookCollColor.r = 1.0f;
-					HookCollColor.g = 1.0f;
-					HookCollColor.b = 0.0f;
+					HookCollColor = ColorRGBA(1.0f, 1.0f, 0.0f);
 					break;
 				}
 
@@ -349,11 +345,9 @@ void CPlayers::RenderPlayer(
 			if(g_Config.m_ClShowHookCollAlways && (Player.m_PlayerFlags&PLAYERFLAG_AIM))
 			{
 				// invert the hook coll colors when using cl_show_hook_coll_always and +showhookcoll is pressed
-				HookCollColor.r = 1.0f-HookCollColor.r;
-				HookCollColor.g = 1.0f-HookCollColor.g;
-				HookCollColor.b = 1.0f-HookCollColor.b;
+				HookCollColor = color_invert(HookCollColor);
 			}
-			Graphics()->SetColor(HookCollColor.r, HookCollColor.g, HookCollColor.b, Alpha);
+			Graphics()->SetColor(HookCollColor.WithAlpha(Alpha));
 			IGraphics::CLineItem LineItem(InitPos.x, InitPos.y, FinishPos.x, FinishPos.y);
 			Graphics()->LinesDraw(&LineItem, 1);
 			Graphics()->LinesEnd();


### PR DESCRIPTION
- SetAlpha should be called WithAlpha and only works for RGBA
- Fix type correctness of color_scale and introduce color_invert
- Nicer hook coll color handling in RenderPlayer
- Use CRTP to have type safe WithAlpha, otherwise this would compile:
  `ColorHSLA = WithAlpha(ColorRGBA(1.0f, 1.0f, 1.0f));`


Follow-up to https://github.com/ddnet/ddnet/pull/1968