### PR TITLE
Fix: automapper skips tiles when it shouldn't

### DIFF
--- a/src/game/editor/auto_map.cpp
+++ b/src/game/editor/auto_map.cpp
@@ -330,6 +330,7 @@ void CAutoMapper::Load(const char* pTileName)
 				}
 				if(pIndexRule->m_SkipEmpty && pIndexRule->m_SkipFull)
 				{
+					pIndexRule->m_SkipEmpty = false;
 					pIndexRule->m_SkipFull = false;
 				}
 			}


### PR DESCRIPTION
In case of something like: INDEX 0 OR 1 all tiles need to be automapped.