### PR TITLE
Add libssl-dev as dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Pass the number of threads for compilation to `make -j`. `$(nproc)` in this case
 
 You can install the required libraries on your system, `touch CMakeLists.txt` and CMake will use the system-wide libraries by default. You can install all required dependencies and CMake on Debian or Ubuntu like this:
 
-    sudo apt install cmake git libcurl4-openssl-dev libfreetype6-dev libglew-dev libogg-dev libopus-dev libopusfile-dev libpnglite-dev libsdl2-dev libwavpack-dev python
+    sudo apt install cmake git libcurl4-openssl-dev libssl-dev libfreetype6-dev libglew-dev libogg-dev libopus-dev libopusfile-dev libpnglite-dev libsdl2-dev libwavpack-dev python
 
 Or on Arch Linux like this:
 


### PR DESCRIPTION
I was told that that cmake failed on Crypto not found and installing libssl-dev solved the issue. Could not reproduce it tho.

When compiling ddnet7 with mysql. Might be a issue with ddnet7 only tho so not sure.