### PR TITLE
Support entities bind in editor (closed #1990)

### DIFF
--- a/src/engine/client.h
+++ b/src/engine/client.h
@@ -222,6 +222,7 @@ public:
 	virtual void OnShutdown() = 0;
 	virtual void OnRender() = 0;
 	virtual void OnUpdate() = 0;
+	virtual void OnEditor() = 0;
 	virtual void OnStateChange(int NewState, int OldState) = 0;
 	virtual void OnConnected() = 0;
 	virtual void OnMessage(int MsgID, CUnpacker *pUnpacker, bool IsDummy = 0) = 0;

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -2728,6 +2728,8 @@ void CClient::Update()
 	// update gameclient
 	if(!m_EditorActive)
 		GameClient()->OnUpdate();
+	else
+		GameClient()->OnEditor();
 
 	if(m_ReconnectTime > 0 && time_get() > m_ReconnectTime)
 	{

--- a/src/engine/editor.h
+++ b/src/engine/editor.h
@@ -17,6 +17,7 @@ public:
 	virtual int Save(const char *pFilename) = 0;
 	virtual void UpdateMentions() = 0;
 	virtual void ResetMentions() = 0;
+	virtual void ToggleEntities() = 0;
 };
 
 extern IEditor *CreateEditor();

--- a/src/game/client/component.h
+++ b/src/game/client/component.h
@@ -45,6 +45,7 @@ public:
 	virtual void OnMessage(int Msg, void *pRawMsg) {}
 	virtual bool OnMouseMove(float x, float y) { return false; }
 	virtual bool OnInput(IInput::CEvent e) { return false; }
+	virtual bool IsEntitites(IInput::CEvent e) { return false; }
 };
 
 #endif

--- a/src/game/client/components/binds.cpp
+++ b/src/game/client/components/binds.cpp
@@ -165,6 +165,37 @@ bool CBinds::OnInput(IInput::CEvent e)
 	return ret;
 }
 
+bool CBinds::IsEntities(IInput::CEvent e)
+{
+	// don't handle invalid events
+	if(e.m_Key <= 0 || e.m_Key >= KEY_LAST)
+		return false;
+
+	int Mask = GetModifierMask(Input());
+	int KeyModifierMask = GetModifierMaskOfKey(e.m_Key);
+	Mask &= ~KeyModifierMask;
+	if(!Mask)
+		Mask = 1 << MODIFIER_NONE;
+
+	bool ret = false;
+	for(int Mod = 1; Mod < MODIFIER_COUNT; Mod++)
+	{
+		if(m_aapKeyBindings[Mod][e.m_Key] && Mask & (1 << Mod))	// always trigger +xxx binds despite any modifier
+		{
+			if(e.m_Flags&IInput::FLAG_PRESS)
+				if(str_find_nocase(m_aapKeyBindings[Mod][e.m_Key], "cl_overlay_entitie"))
+					return true;
+			ret = true;
+		}
+	}
+
+	if(m_aapKeyBindings[0][e.m_Key] && (!ret || m_aapKeyBindings[0][e.m_Key][0] == '+'))
+		if(e.m_Flags&IInput::FLAG_PRESS)
+			if(str_find_nocase(m_aapKeyBindings[0][e.m_Key], "cl_overlay_entitie"))
+				return true;
+	return false;
+}
+
 void CBinds::UnbindAll()
 {
 	for(int i = 0; i < MODIFIER_COUNT; i++)

--- a/src/game/client/components/binds.h
+++ b/src/game/client/components/binds.h
@@ -55,6 +55,7 @@ public:
 	// DDRace
 
 	void SetDDRaceBinds(bool FreeOnly);
+	virtual bool IsEntities(IInput::CEvent Event);
 
 private:
 	char *m_aapKeyBindings[MODIFIER_COUNT][KEY_LAST];

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -386,6 +386,20 @@ void CGameClient::OnUpdate()
 	}
 }
 
+void CGameClient::OnEditor()
+{
+	// handle key presses
+	for(int i = 0; i < Input()->NumEvents(); i++)
+	{
+		IInput::CEvent e = Input()->GetEvent(i);
+		if(!Input()->IsEventValid(&e))
+			continue;
+
+		if(m_pBinds->IsEntities(e))
+			Editor()->ToggleEntities();
+	}
+}
+
 void CGameClient::OnDummySwap()
 {
 	if(g_Config.m_ClDummyResetOnSwitch)

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -373,6 +373,7 @@ public:
 	virtual void OnConnected();
 	virtual void OnRender();
 	virtual void OnUpdate();
+	virtual void OnEditor();
 	virtual void OnDummyDisconnect();
 	virtual void OnRelease();
 	virtual void OnInit();

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -6126,6 +6126,49 @@ void CEditor::CreateUndoStepThread(void *pUser)
 
 void CEditor::UpdateAndRender()
 {
+	if(m_ToggleEntitites)
+	{
+		int Found = 0;
+		int Visible = 0;
+		if(m_Map.m_pGameLayer)
+		{
+			Found++;
+			if(m_Map.m_pGameLayer->m_Visible)
+				Visible++;
+		}
+		if(m_Map.m_pFrontLayer)
+		{
+			Found++;
+			if(m_Map.m_pFrontLayer->m_Visible)
+				Visible++;
+		}
+		if(m_Map.m_pSwitchLayer)
+		{
+			Found++;
+			if(m_Map.m_pSwitchLayer->m_Visible)
+				Visible++;
+		}
+		if(m_Map.m_pTuneLayer)
+		{
+			Found++;
+			if(m_Map.m_pTuneLayer->m_Visible)
+				Visible++;
+		}
+		if(m_Map.m_pSpeedupLayer)
+		{
+			Found++;
+			if(m_Map.m_pSpeedupLayer->m_Visible)
+				Visible++;
+		}
+		if(m_Map.m_pTeleLayer)
+		{
+			Found++;
+			if(m_Map.m_pTeleLayer->m_Visible)
+				Visible++;
+		}
+		SetEntitiesVisible(Visible < ((Found+1)/2));
+		m_ToggleEntitites = false;
+	}
 	static float s_MouseX = 0.0f;
 	static float s_MouseY = 0.0f;
 
@@ -6219,9 +6262,25 @@ void CEditor::UpdateAndRender()
 	Input()->Clear();
 }
 
-IEditor *CreateEditor() { return new CEditor; }
-
 // DDRace
+
+void CEditor::SetEntitiesVisible(bool Visible)
+{
+	if(m_Map.m_pGameLayer)
+		m_Map.m_pGameLayer->m_Visible = Visible;
+	if(m_Map.m_pFrontLayer)
+		m_Map.m_pFrontLayer->m_Visible = Visible;
+	if(m_Map.m_pSwitchLayer)
+		m_Map.m_pSwitchLayer->m_Visible = Visible;
+	if(m_Map.m_pTuneLayer)
+		m_Map.m_pTuneLayer->m_Visible = Visible;
+	if(m_Map.m_pSpeedupLayer)
+		m_Map.m_pSpeedupLayer->m_Visible = Visible;
+	if(m_Map.m_pTeleLayer)
+		m_Map.m_pTeleLayer->m_Visible = Visible;
+}
+
+IEditor *CreateEditor() { return new CEditor; }
 
 void CEditorMap::MakeTeleLayer(CLayer *pLayer)
 {

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -732,6 +732,7 @@ public:
 	virtual bool HasUnsavedData() { return m_Map.m_Modified; }
 	virtual void UpdateMentions() { m_Mentions++; }
 	virtual void ResetMentions() { m_Mentions = 0; }
+	virtual void ToggleEntities() { m_ToggleEntitites = true; };
 
 	int64 m_LastUndoUpdateTime;
 	bool m_UndoRunning;
@@ -813,6 +814,7 @@ public:
 	bool m_BrushDrawDestructive;
 
 	int m_Mentions;
+	bool m_ToggleEntitites;
 
 	enum
 	{
@@ -1032,6 +1034,7 @@ public:
 
 	// DDRace
 
+	void SetEntitiesVisible(bool Visible);
 	IGraphics::CTextureHandle m_FrontTexture;
 	IGraphics::CTextureHandle m_TeleTexture;
 	IGraphics::CTextureHandle m_SpeedupTexture;


### PR DESCRIPTION
Any bind containing cl_overlay_entities pressed in editor
causes all "entities" layers (game/front/switch/speedup/tune) to toggle
visibility. It checks if more are visible or hidden and sets all of them
to the opposite.