### PR TITLE
Properly display hdiutil status in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -334,6 +334,11 @@ if(TARGET_OS AND TARGET_OS STREQUAL "mac")
   endif()
 
   find_program(HDIUTIL hdiutil)
+  if(HDIUTIL)
+    set(HDIUTIL_FOUND ON)
+  else()
+    set(HDIUTIL_FOUND OFF)
+  endif()
 endif()
 
 message(STATUS "******** DDNet ********")


### PR DESCRIPTION
(cherry picked from commit cc2be456d4d95bb3196e8201a06ce19403dfc3c9)