### PR TITLE
Fix build error for Fedora Rawhide

### DIFF
--- a/src/game/client/components/maplayers.h
+++ b/src/game/client/components/maplayers.h
@@ -5,6 +5,7 @@
 #include <game/client/component.h>
 
 #include <vector>
+#include <cstdint>
 
 
 #define INDEX_BUFFER_GROUP_WIDTH 12


### PR DESCRIPTION
This PR fixes build error while building DDNet for Fedora Rawhide.
Build error seems like this:
```
FAILED: CMakeFiles/DDNet.dir/src/game/client/components/background.cpp.o
/usr/bin/c++  -DCONF_OPENSSL -DCONF_WAVPACK_OPEN_FILE_INPUT_EX -DGLEW_STATIC -D_FORTIFY_SOURCE=2 -I/usr/include/freetype2 -I/usr/include/ogg -I/usr/include/opus -I/usr/include/SDL2 -I/usr/include/wavpack -Isrc -I../src -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -flto -O2 -g -DNDEBUG   -fdiagnostics-color=always -fstack-protector-all -Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers -Wformat=2 -Wduplicated-cond -Wduplicated-branches -Wlogical-op -Wrestrict -std=gnu++11 -MD -MT CMakeFiles/DDNet.dir/src/game/client/components/background.cpp.o -MF CMakeFiles/DDNet.dir/src/game/client/components/background.cpp.o.d -o CMakeFiles/DDNet.dir/src/game/client/components/background.cpp.o -c ../src/game/client/components/background.cpp
In file included from ../src/game/client/components/background.cpp:8:
../src/game/client/components/maplayers.h:15:9: error: 'uintptr_t' does not name a type; did you mean 'uint64_t'?
   15 | typedef uintptr_t offset_ptr;
      |         ^~~~~~~~~
      |         uint64_t
../src/game/client/components/maplayers.h:61:4: error: 'offset_ptr' does not name a type; did you mean 'offset_ptr32'?
   61 |    offset_ptr IndexBufferByteOffset()
      |    ^~~~~~~~~~
      |    offset_ptr32
In file included from ../src/game/client/components/background.cpp:8:
../src/game/client/components/maplayers.h:105:4: error: 'offset_ptr' does not name a type; did you mean 'offset_ptr32'?
  105 |    offset_ptr m_IndexBufferByteOffset;
      |    ^~~~~~~~~~
      |    offset_ptr32
../src/game/client/components/maplayers.h: In constructor 'CMapLayers::SQuadLayerVisuals::SQuadVisual::SQuadVisual()':
../src/game/client/components/maplayers.h:103:20: error: class 'CMapLayers::SQuadLayerVisuals::SQuadVisual' does not have any field named 'm_IndexBufferByteOffset'
  103 |    SQuadVisual() : m_IndexBufferByteOffset(0) {}
      |                    ^~~~~~~~~~~~~~~~~~~~~~~
```

Full build log you can find here (available for 14 days after build): https://download.copr.fedorainfracloud.org/results/elxreno/ddnet/fedora-rawhide-x86_64/01238446-ddnet/build.log.gz