### PR TITLE
Fix demo recording with broken maps

### DIFF
--- a/src/engine/shared/demo.cpp
+++ b/src/engine/shared/demo.cpp
@@ -46,7 +46,6 @@ int CDemoRecorder::Start(class IStorage *pStorage, class IConsole *pConsole, con
 	m_pfnFilter = pfnFilter;
 	m_pUser = pUser;
 
-	m_MapSize = MapSize;
 	m_pMapData = pMapData;
 	m_pConsole = pConsole;
 
@@ -121,6 +120,9 @@ int CDemoRecorder::Start(class IStorage *pStorage, class IConsole *pConsole, con
 
 		CloseMapFile = true;
 	}
+
+	if(MapFile)
+		MapSize = io_length(MapFile);
 
 	// write header
 	mem_zero(&Header, sizeof(Header));

--- a/src/engine/shared/demo.h
+++ b/src/engine/shared/demo.h
@@ -23,7 +23,6 @@ class CDemoRecorder : public IDemoRecorder
 	int m_NumTimelineMarkers;
 	int m_aTimelineMarkers[MAX_TIMELINE_MARKERS];
 	bool m_NoMapData;
-	unsigned int m_MapSize;
 	unsigned char *m_pMapData;
 
 	DEMOFUNC_FILTER m_pfnFilter;


### PR DESCRIPTION
Apparently there are maps out there with broken headers advertising the wrong map size. This allows demos to be recorded on those.

Example of such a map is `ctf4_old_d668e9fa_2f472051b26b6bffaa4af8990cf882cafd6364e00e1333b77762cb9911e49464.map`
Hosted on `Allround Network`

Reported by teini94 on discord