### PR TITLE
Add option to pause video rendering when demo playing pause

### DIFF
--- a/src/engine/client/video.cpp
+++ b/src/engine/client/video.cpp
@@ -167,6 +167,12 @@ void CVideo::start()
 	m_vframe = 0;
 }
 
+void CVideo::pause()
+{
+	if(ms_pCurrentVideo)
+		m_Recording ^= true;
+}
+
 void CVideo::stop()
 {
 	m_Recording = false;

--- a/src/engine/client/video.h
+++ b/src/engine/client/video.h
@@ -59,6 +59,7 @@ public:
 
 	virtual void start();
 	virtual void stop();
+	virtual void pause();
 
 	virtual void nextVideoFrame();
 	virtual void nextVideoFrame_thread();

--- a/src/engine/shared/demo.cpp
+++ b/src/engine/shared/demo.cpp
@@ -677,6 +677,8 @@ void CDemoPlayer::DoTick()
 void CDemoPlayer::Pause()
 {
 	m_Info.m_Info.m_Paused = 1;
+	if(IVideo::Current() && g_Config.m_ClVideoPauseWithDemo)
+		IVideo::Current()->pause();
 }
 
 void CDemoPlayer::Unpause()
@@ -687,6 +689,8 @@ void CDemoPlayer::Unpause()
 		m_Info.start_time = time_get();*/
 		m_Info.m_Info.m_Paused = 0;
 	}
+	if(IVideo::Current() && g_Config.m_ClVideoPauseWithDemo)
+		IVideo::Current()->pause();
 }
 
 int CDemoPlayer::Load(class IStorage *pStorage, class IConsole *pConsole, const char *pFilename, int StorageType)

--- a/src/engine/shared/demo.cpp
+++ b/src/engine/shared/demo.cpp
@@ -677,8 +677,10 @@ void CDemoPlayer::DoTick()
 void CDemoPlayer::Pause()
 {
 	m_Info.m_Info.m_Paused = 1;
+#if defined(CONF_VIDEORECORDER)
 	if(IVideo::Current() && g_Config.m_ClVideoPauseWithDemo)
 		IVideo::Current()->pause();
+#endif
 }
 
 void CDemoPlayer::Unpause()
@@ -689,8 +691,10 @@ void CDemoPlayer::Unpause()
 		m_Info.start_time = time_get();*/
 		m_Info.m_Info.m_Paused = 0;
 	}
+#if defined(CONF_VIDEORECORDER)
 	if(IVideo::Current() && g_Config.m_ClVideoPauseWithDemo)
 		IVideo::Current()->pause();
+#endif
 }
 
 int CDemoPlayer::Load(class IStorage *pStorage, class IConsole *pConsole, const char *pFilename, int StorageType)

--- a/src/engine/shared/video.h
+++ b/src/engine/shared/video.h
@@ -10,6 +10,7 @@ public:
 
 	virtual void start() = 0;
 	virtual void stop() = 0;
+	virtual void pause() = 0;
 
 	virtual void nextVideoFrame() = 0;
 	virtual bool frameRendered() = 0;

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -2322,7 +2322,9 @@ bool CGameClient::IsOtherTeam(int ClientID)
 {
 	bool Local = m_Snap.m_LocalClientID == ClientID;
 
-	if((m_aClients[m_Snap.m_LocalClientID].m_Team == TEAM_SPECTATORS && m_Snap.m_SpecInfo.m_SpectatorID == SPEC_FREEVIEW) || ClientID < 0)
+	if(m_Snap.m_LocalClientID < 0)
+		return false;
+	else if((m_aClients[m_Snap.m_LocalClientID].m_Team == TEAM_SPECTATORS && m_Snap.m_SpecInfo.m_SpectatorID == SPEC_FREEVIEW) || ClientID < 0)
 		return false;
 	else if(m_Snap.m_SpecInfo.m_Active && m_Snap.m_SpecInfo.m_SpectatorID != SPEC_FREEVIEW)
 		return m_Teams.Team(ClientID) != m_Teams.Team(m_Snap.m_SpecInfo.m_SpectatorID);

--- a/src/game/variables.h
+++ b/src/game/variables.h
@@ -165,6 +165,7 @@ MACRO_CONFIG_INT(SvRescue, sv_rescue, 0, 0, 1, CFGFLAG_SERVER, "Allow /rescue co
 MACRO_CONFIG_INT(SvRescueDelay, sv_rescue_delay, 5, 0, 1000, CFGFLAG_SERVER, "Number of seconds between two rescues")
 
 #if defined(CONF_VIDEORECORDER)
+MACRO_CONFIG_INT(ClVideoPauseWithDemo, cl_video_pausewithdemo, 1, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Pause video rendering when demo playing pause")
 MACRO_CONFIG_INT(ClVideoShowhud, cl_video_showhud, 0, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Show ingame HUD when rendering video")
 MACRO_CONFIG_INT(ClVideoShowChat, cl_video_showchat, 1, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Show chat when rendering video")
 MACRO_CONFIG_INT(ClVideoSndEnable, cl_video_sound_enable, 1, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Use sound when rendering video")


### PR DESCRIPTION
This option default is open, which means video rendering will pause when demo playing pause, we can use this to:
- change player spec to
- check demo playing speed
- check playing progress

I think this is better.
There is a modification which make tee not transparent when playing demo from server with commit 5dab6e2e1, but if you don't like it, you can undo this modification.