### PR TITLE
Fix antibot crash

### DIFF
--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -772,7 +772,8 @@ void CCharacter::Tick()
 
 	if(m_Core.m_TriggeredEvents&COREEVENT_HOOK_ATTACH_PLAYER)
 	{
-		if(GameServer()->m_apPlayers[m_Core.m_HookedPlayer]->GetTeam() != -1)
+		if(m_Core.m_HookedPlayer != -1
+			&& GameServer()->m_apPlayers[m_Core.m_HookedPlayer]->GetTeam() != -1)
 		{
 			Antibot()->OnHookAttach(m_pPlayer->GetCID(), true);
 		}


### PR DESCRIPTION
`m_Core.m_HookedPlayer` can be -1 if you get teleported the moment you'd
normally attach the hook.