### PR TITLE
Fix `AntibotDestroy` being called twice

### DIFF
--- a/src/game/server/antibot.cpp
+++ b/src/game/server/antibot.cpp
@@ -25,9 +25,6 @@ CAntibot::CAntibot()
 }
 CAntibot::~CAntibot()
 {
-	AntibotDestroy();
-	free(g_Data.m_Map.m_pTiles);
-	g_Data.m_Map.m_pTiles = 0;
 }
 void CAntibot::Init(CGameContext *pGameContext)
 {
@@ -39,6 +36,12 @@ void CAntibot::Init(CGameContext *pGameContext)
 	g_Data.m_pUser = m_pGameContext;
 	AntibotInit(&g_Data);
 	Update();
+}
+void CAntibot::Shutdown()
+{
+	AntibotDestroy();
+	free(g_Data.m_Map.m_pTiles);
+	g_Data.m_Map.m_pTiles = 0;
 }
 void CAntibot::Dump() { AntibotDump(); }
 void CAntibot::Update()
@@ -71,6 +74,9 @@ void CAntibot::Init(CGameContext *pGameContext)
 void CAntibot::Dump()
 {
 	m_pGameContext->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "antibot", "antibot support not compiled in");
+}
+void CAntibot::Shutdown()
+{
 }
 void CAntibot::Update()
 {

--- a/src/game/server/antibot.h
+++ b/src/game/server/antibot.h
@@ -11,6 +11,7 @@ public:
 	CAntibot();
 	~CAntibot();
 	void Init(CGameContext *pGameContext);
+	void Shutdown();
 	void Dump();
 
 	void OnPlayerInit(int ClientID);

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -3044,6 +3044,8 @@ void CGameContext::OnShutdown(bool FullShutdown)
 	if (FullShutdown)
 		Score()->OnShutdown();
 
+	m_Antibot.Shutdown();
+
 	if(m_TeeHistorianActive)
 	{
 		m_TeeHistorian.Finish();


### PR DESCRIPTION
The resource deallocation needs to happen in symmetry with the
allocation, otherwise we get unmatched dealloctions leading to crashes.

Allocations happened in `CAntibot::Init`, but it was not guaranteed that
this was called before the destructor.