### PR TITLE
Fix the double-free of the antibot

### DIFF
--- a/src/game/server/antibot.cpp
+++ b/src/game/server/antibot.cpp
@@ -25,6 +25,9 @@ CAntibot::CAntibot()
 }
 CAntibot::~CAntibot()
 {
+	AntibotDestroy();
+	free(g_Data.m_Map.m_pTiles);
+	g_Data.m_Map.m_pTiles = 0;
 }
 void CAntibot::Init(CGameContext *pGameContext)
 {
@@ -36,12 +39,6 @@ void CAntibot::Init(CGameContext *pGameContext)
 	g_Data.m_pUser = m_pGameContext;
 	AntibotInit(&g_Data);
 	Update();
-}
-void CAntibot::Shutdown()
-{
-	AntibotDestroy();
-	free(g_Data.m_Map.m_pTiles);
-	g_Data.m_Map.m_pTiles = 0;
 }
 void CAntibot::Dump() { AntibotDump(); }
 void CAntibot::Update()
@@ -74,9 +71,6 @@ void CAntibot::Init(CGameContext *pGameContext)
 void CAntibot::Dump()
 {
 	m_pGameContext->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "antibot", "antibot support not compiled in");
-}
-void CAntibot::Shutdown()
-{
 }
 void CAntibot::Update()
 {

--- a/src/game/server/antibot.cpp
+++ b/src/game/server/antibot.cpp
@@ -25,9 +25,15 @@ CAntibot::CAntibot()
 }
 CAntibot::~CAntibot()
 {
-	AntibotDestroy();
-	free(g_Data.m_Map.m_pTiles);
-	g_Data.m_Map.m_pTiles = 0;
+	// Check if `Init` was called. There is no easy way to prevent two
+	// destructors running without an `Init` call in between.
+	if(m_pGameContext)
+	{
+		AntibotDestroy();
+		free(g_Data.m_Map.m_pTiles);
+		g_Data.m_Map.m_pTiles = 0;
+		m_pGameContext = 0;
+	}
 }
 void CAntibot::Init(CGameContext *pGameContext)
 {

--- a/src/game/server/antibot.h
+++ b/src/game/server/antibot.h
@@ -11,7 +11,6 @@ public:
 	CAntibot();
 	~CAntibot();
 	void Init(CGameContext *pGameContext);
-	void Shutdown();
 	void Dump();
 
 	void OnPlayerInit(int ClientID);

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -3044,8 +3044,6 @@ void CGameContext::OnShutdown(bool FullShutdown)
 	if (FullShutdown)
 		Score()->OnShutdown();
 
-	m_Antibot.Shutdown();
-
 	if(m_TeeHistorianActive)
 	{
 		m_TeeHistorian.Finish();


### PR DESCRIPTION
I could not find an easy way to ensure that `AntibotDestroy` is only
being called once for each `AntibotInit` but still happening after all
the `CPlayer` destructors.