### PR TITLE
Fix bug about console video start

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -3314,6 +3314,9 @@ void CClient::Con_StartVideo(IConsole::IResult *pResult, void *pUserData)
 	{
 		new CVideo((CGraphics_Threaded*)pSelf->m_pGraphics, pSelf->Storage(), pSelf->m_pConsole, pSelf->Graphics()->ScreenWidth(), pSelf->Graphics()->ScreenHeight(), "");
 		IVideo::Current()->start();
+		bool paused = pSelf->m_DemoPlayer.Info()->m_Info.m_Paused;
+		if(paused)
+			IVideo::Current()->pause(true);
 	}
 	else
 		pSelf->m_pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "videorecorder", "Videorecorder already running.");

--- a/src/engine/client/video.cpp
+++ b/src/engine/client/video.cpp
@@ -167,10 +167,10 @@ void CVideo::start()
 	m_vframe = 0;
 }
 
-void CVideo::pause()
+void CVideo::pause(bool p)
 {
 	if(ms_pCurrentVideo)
-		m_Recording ^= true;
+		m_Recording = !p;
 }
 
 void CVideo::stop()

--- a/src/engine/client/video.h
+++ b/src/engine/client/video.h
@@ -59,7 +59,7 @@ public:
 
 	virtual void start();
 	virtual void stop();
-	virtual void pause();
+	virtual void pause(bool p);
 
 	virtual void nextVideoFrame();
 	virtual void nextVideoFrame_thread();

--- a/src/engine/shared/demo.cpp
+++ b/src/engine/shared/demo.cpp
@@ -681,7 +681,7 @@ void CDemoPlayer::Pause()
 	m_Info.m_Info.m_Paused = 1;
 #if defined(CONF_VIDEORECORDER)
 	if(IVideo::Current() && g_Config.m_ClVideoPauseWithDemo)
-		IVideo::Current()->pause();
+		IVideo::Current()->pause(true);
 #endif
 }
 
@@ -695,7 +695,7 @@ void CDemoPlayer::Unpause()
 	}
 #if defined(CONF_VIDEORECORDER)
 	if(IVideo::Current() && g_Config.m_ClVideoPauseWithDemo)
-		IVideo::Current()->pause();
+		IVideo::Current()->pause(false);
 #endif
 }
 

--- a/src/engine/shared/video.h
+++ b/src/engine/shared/video.h
@@ -10,7 +10,7 @@ public:
 
 	virtual void start() = 0;
 	virtual void stop() = 0;
-	virtual void pause() = 0;
+	virtual void pause(bool p) = 0;
 
 	virtual void nextVideoFrame() = 0;
 	virtual bool frameRendered() = 0;


### PR DESCRIPTION
Did some small modifications to console video start (using video_start command):
- Fix bug that demo can't play when demo pause and then use console video start.
- If demo playing paused when console video start, video rendering will not begin until video playing continue.

I think this will make experience of console video start more comfortable, you can pause demo playing and type video_start in console, quit console and continue demo playing, then console will not be rendered into video.