### PR TITLE
Remove clientside zoom restrictions

### DIFF
--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1019,7 +1019,7 @@ static CGameInfo GetGameInfo(const CNetObj_GameInfoEx *pInfoEx, int InfoExSize, 
 	Info.m_RaceRecordMessage = DDNet || (Race && !DDRace);
 	Info.m_AllowEyeWheel = DDRace || BlockWorlds || Plus;
 	Info.m_AllowHookColl = DDRace;
-	Info.m_AllowZoom = Race || BlockWorlds;
+	Info.m_AllowZoom = true;
 	Info.m_BugDDRaceGhost = DDRace;
 	Info.m_BugDDRaceInput = DDRace;
 	Info.m_BugFNGLaserRange = FNG;


### PR DESCRIPTION
My own problem:
I play with cl_default_zoom setting, what means my zoom is always different from "default" one.
But there is fng servers where I am forced to use "default" one which renders game at least uncomfortable for playing

General problem:
Ridiculous client side limitations leads to new clients without such

I consider zoom as graphics setting, which should NOT be limited by any gameplay mode (as dynamic camera is)

P.s.: some of you might consider it as "cheat" or something but the serverside solution is already there - you cannot see distant players. But yea, this change might lead to advantage until serverside anticheat is not good enough