### PR TITLE
Fix CMake LibNotify warning (fixes #2141)

### DIFF
--- a/cmake/FindNotify.cmake
+++ b/cmake/FindNotify.cmake
@@ -1,4 +1,4 @@
 find_package(PkgConfig REQUIRED QUIET)
 pkg_check_modules(NOTIFY REQUIRED QUIET libnotify)
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(LibNotify DEFAULT_MSG NOTIFY_LIBRARIES NOTIFY_INCLUDE_DIRS)
+find_package_handle_standard_args(Notify DEFAULT_MSG NOTIFY_LIBRARIES NOTIFY_INCLUDE_DIRS)


### PR DESCRIPTION
The LibNotify name is not used anywhere?