### PR TITLE
Don't push notification when active

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -3786,7 +3786,7 @@ void CClient::LoadFont()
 
 void CClient::Notify(const char *pTitle, const char *pMessage)
 {
-	if(!g_Config.m_ClShowNotifications)
+	if(m_pGraphics->WindowActive() || !g_Config.m_ClShowNotifications)
 		return;
 
 	NotificationsNotify(pTitle, pMessage);


### PR DESCRIPTION
In the game we already have highlighted text and sounds, we don't need to bother with notifications.