### PR TITLE
Fix empty sound (fixes #2163)

### DIFF
--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -581,6 +581,11 @@ void CChat::AddLine(int ClientID, int Team, const char *pLine)
 
 	bool Highlighted = false;
 	char *p = const_cast<char*>(pLine);
+
+	// Only empty string left
+	if(*p == 0)
+		return;
+
 	while(*p)
 	{
 		Highlighted = false;


### PR DESCRIPTION
The problem was that the string is empty after going through the trim, thus the main displaying loop doesn't run, but the sound still does. Verified that it works.