### PR TITLE
Added showtotele and showtotelecp chat commands

### DIFF
--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -1173,6 +1173,82 @@ void CGameContext::ConShowAll(IConsole::IResult *pResult, void *pUserData)
 		pSelf->SendChatTarget(pResult->m_ClientID, "You will no longer see all tees on this server");
 }
 
+void CGameContext::ConShowToTeleporter(IConsole::IResult *pResult, void *pUserData)
+{
+	CGameContext *pSelf = (CGameContext *) pUserData;
+	if (!CheckClientID(pResult->m_ClientID))
+		return;
+
+	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientID];
+	if (!pPlayer)
+		return;
+
+	if (pResult->NumArguments())
+	{
+		unsigned int TeleTo = pResult->GetInteger(0);
+		if (((CGameControllerDDRace*)pSelf->m_pController)->m_TeleOuts[TeleTo-1].size())
+		{
+			int Num = ((CGameControllerDDRace*)pSelf->m_pController)->m_TeleOuts[TeleTo-1].size();
+			vec2 TelePos = ((CGameControllerDDRace*)pSelf->m_pController)->m_TeleOuts[TeleTo-1][(!Num)?Num:rand() % Num];
+			if(!pPlayer->IsPaused())
+				pPlayer->Pause(CPlayer::PAUSE_PAUSED, true);
+			// need to force position for several ticks to prevent the client from
+			// moving around in gameclient.cpp:UpdatePositions at lines 565-584
+			pPlayer->m_ForceViewPos = pSelf->Server()->Tick()+5;
+			pPlayer->m_ViewPos = TelePos;
+		}
+		else
+		{
+			char msg[64];
+			str_format(msg, sizeof(msg), "No output found for tele %d", TeleTo);
+			pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "showtotelechat", msg);
+		}
+	}
+	else
+		pSelf->Console()->Print(
+				IConsole::OUTPUT_LEVEL_STANDARD,
+				"showtotelechat",
+				"Invalid argument... Usage /showtotele i[tele number]");
+}
+
+void CGameContext::ConShowToCheckTeleporter(IConsole::IResult *pResult, void *pUserData)
+{
+	CGameContext *pSelf = (CGameContext *) pUserData;
+	if (!CheckClientID(pResult->m_ClientID))
+		return;
+
+	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientID];
+	if (!pPlayer)
+		return;
+
+	if (pResult->NumArguments())
+	{
+		unsigned int TeleTo = pResult->GetInteger(0);
+		if (((CGameControllerDDRace*)pSelf->m_pController)->m_TeleCheckOuts[TeleTo-1].size())
+		{
+			int Num = ((CGameControllerDDRace*)pSelf->m_pController)->m_TeleCheckOuts[TeleTo-1].size();
+			vec2 TelePos = ((CGameControllerDDRace*)pSelf->m_pController)->m_TeleCheckOuts[TeleTo-1][(!Num)?Num:rand() % Num];
+			if(!pPlayer->IsPaused())
+				pPlayer->Pause(CPlayer::PAUSE_PAUSED, true);
+			// need to force position for several ticks to prevent the client from
+			// moving around in gameclient.cpp:UpdatePositions at lines 565-584
+			pPlayer->m_ForceViewPos = pSelf->Server()->Tick()+5;
+			pPlayer->m_ViewPos = TelePos;
+		}
+		else
+		{
+			char msg[64];
+			str_format(msg, sizeof(msg), "No output found for telecp %d", TeleTo);
+			pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "showtotelecpchat", msg);
+		}
+	}
+	else
+		pSelf->Console()->Print(
+				IConsole::OUTPUT_LEVEL_STANDARD,
+				"showtotelecpchat",
+				"Invalid argument... Usage /showtotelecp i[telecp number]");
+}
+
 void CGameContext::ConSpecTeam(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *) pUserData;

--- a/src/game/server/ddracechat.h
+++ b/src/game/server/ddracechat.h
@@ -45,6 +45,8 @@ CHAT_COMMAND("invite", "r[player name]", CFGFLAG_CHAT|CFGFLAG_SERVER, ConInviteT
 
 CHAT_COMMAND("showothers", "?i['0'|'1']", CFGFLAG_CHAT|CFGFLAG_SERVER, ConShowOthers, this, "Whether to show players from other teams or not (off by default), optional i = 0 for off else for on")
 CHAT_COMMAND("showall", "?i['0'|'1']", CFGFLAG_CHAT|CFGFLAG_SERVER, ConShowAll, this, "Whether to show players at any distance (off by default), optional i = 0 for off else for on")
+CHAT_COMMAND("showtotele", "?i[teleport number]", CFGFLAG_CHAT|CFGFLAG_SERVER, ConShowToTeleporter, this, "Show output of given teleport number")
+CHAT_COMMAND("showtotelecp", "?i[check teleport number]", CFGFLAG_CHAT|CFGFLAG_SERVER, ConShowToCheckTeleporter, this, "Show output of given checkpoint teleport number")
 CHAT_COMMAND("specteam", "?i['0'|'1']", CFGFLAG_CHAT|CFGFLAG_SERVER, ConSpecTeam, this, "Whether to show players from other teams when spectating (on by default), optional i = 0 for off else for on")
 CHAT_COMMAND("ninjajetpack", "?i['0'|'1']", CFGFLAG_CHAT|CFGFLAG_SERVER, ConNinjaJetpack, this, "Whether to use ninja jetpack or not. Makes jetpack look more awesome")
 CHAT_COMMAND("saytime", "?r[player name]", CFGFLAG_CHAT|CFGFLAG_SERVER|CFGFLAG_NONTEEHISTORIC, ConSayTime, this, "Privately messages someone's current time in this current running race (your time by default)")

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -346,6 +346,8 @@ private:
 	static void ConEyeEmote(IConsole::IResult *pResult, void *pUserData);
 	static void ConShowOthers(IConsole::IResult *pResult, void *pUserData);
 	static void ConShowAll(IConsole::IResult *pResult, void *pUserData);
+	static void ConShowToTeleporter(IConsole::IResult *pResult, void *pUserData);
+	static void ConShowToCheckTeleporter(IConsole::IResult *pResult, void *pUserData);
 	static void ConSpecTeam(IConsole::IResult *pResult, void *pUserData);
 	static void ConNinjaJetpack(IConsole::IResult *pResult, void *pUserData);
 	static void ConSayTime(IConsole::IResult *pResult, void *pUserData);

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -49,6 +49,7 @@ public:
 	//---------------------------------------------------------
 	// this is used for snapping so we know how we can clip the view for the player
 	vec2 m_ViewPos;
+	int m_ForceViewPos;
 	int m_TuneZone;
 	int m_TuneZoneOld;
 


### PR DESCRIPTION
This adds 2 new chat commands: /showtotele and /showtotelecp based on their rcon counterpart totele and totelecp.
The commands pause the player and move his view to the output of the given tele number.

Unfortunately, it does not work with standard tw client, unless /spec is allowed and the player is already in /spec. So maybe it should be client side then... (wanted it server side so that everyone could use it, but could not make it work with tw client...)