### PR TITLE
Add build-essential dependency to debian build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Pass the number of threads for compilation to `make -j`. `$(nproc)` in this case
 
 You can install the required libraries on your system, `touch CMakeLists.txt` and CMake will use the system-wide libraries by default. You can install all required dependencies and CMake on Debian or Ubuntu like this:
 
-    sudo apt install cmake git libcurl4-openssl-dev libssl-dev libfreetype6-dev libglew-dev libnotify-dev libogg-dev libopus-dev libopusfile-dev libpnglite-dev libsdl2-dev libwavpack-dev python
+    sudo apt install build-essential cmake git libcurl4-openssl-dev libssl-dev libfreetype6-dev libglew-dev libnotify-dev libogg-dev libopus-dev libopusfile-dev libpnglite-dev libsdl2-dev libwavpack-dev python
 
 Or on Arch Linux like this:
 


### PR DESCRIPTION
Required for g++ and make