### PR TITLE
Don't count freshly loaded map as modified (fixes #2178)

### DIFF
--- a/src/game/editor/io.cpp
+++ b/src/game/editor/io.cpp
@@ -1294,6 +1294,7 @@ int CEditorMap::Load(class IStorage *pStorage, const char *pFileName, int Storag
 	else
 		return 0;
 
+	m_Modified = false;
 	return 1;
 }
 


### PR DESCRIPTION
The reason is that we increased the sensitivity of the modified flag to
include adding layers and groups, and simply loading the map already
adds those, so every loaded map was considered modified.