### PR TITLE
Improve AppStream manifest

### DIFF
--- a/other/ddnet.appdata.xml
+++ b/other/ddnet.appdata.xml
@@ -32,6 +32,10 @@
         <keyword>teeworlds</keyword>
         <keyword>game</keyword>
     </keywords>
+    <content_rating type="oars-1.1">
+        <content_attribute id="violence-cartoon">moderate</content_attribute>
+        <content_attribute id="social-chat">intense</content_attribute>
+    </content_rating>
     <releases>
         <release date="2020-05-01" version="13.1"/>
         <release date="2020-04-10" version="13.0.2"/>

--- a/other/ddnet.appdata.xml
+++ b/other/ddnet.appdata.xml
@@ -32,6 +32,10 @@
         <keyword>teeworlds</keyword>
         <keyword>game</keyword>
     </keywords>
+    <releases>
+        <release date="2020-05-01" version="13.1"/>
+        <release date="2020-04-10" version="13.0.2"/>
+    </releases>
     <url type="homepage">https://ddnet.tw/</url>
     <url type="bugtracker">https://github.com/ddnet/ddnet/issues</url>
     <url type="donation">https://www.paypal.me/ddnet</url>


### PR DESCRIPTION
This tags required for [Flathub AppData Guidelines](https://github.com/flathub/flathub/wiki/AppData-Guidelines).

If watch this tags in [FreeDesktop AppStream Guidelines](https://www.freedesktop.org/software/appstream/docs/chap-CollectionData.html), `content_rating` tag is optional but `releases` tag required.

If you want to know a little bit more about `OARS`, watch [this](https://hughsie.github.io/oars/index.html).