### PR TITLE
boundary check on curve type label in editor, avoids client crash

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -5103,8 +5103,11 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 				const char *paTypeName[] = {
 					"N", "L", "S", "F", "M"
 					};
-
-				if(DoButton_Editor(pID, paTypeName[pEnvelope->m_lPoints[i].m_Curvetype], 0, &v, 0, "Switch curve type"))
+				const char *pTypeName = "Invalid";
+				if(0 <= pEnvelope->m_lPoints[i].m_Curvetype
+						&& pEnvelope->m_lPoints[i].m_Curvetype < (int)(sizeof(paTypeName)/sizeof(const char *)))
+					pTypeName = paTypeName[pEnvelope->m_lPoints[i].m_Curvetype];
+				if(DoButton_Editor(pID, pTypeName, 0, &v, 0, "Switch curve type"))
 					pEnvelope->m_lPoints[i].m_Curvetype = (pEnvelope->m_lPoints[i].m_Curvetype+1)%NUM_CURVETYPES;
 			}
 		}


### PR DESCRIPTION
Encountered crash when checking out some old maps (e.g. [Demon_72eab2fd](https://heinrich5991.de/teeworlds/maps/maps/Demon_72eab2fd.map) from heinrich5991's map collection). Will now show "Invalid" in the label instead of crashing. "Invalid" is a bit long in comparison to the size of the label, but it shouldn't ever be encountered on a usual map.