### PR TITLE
Break save/load string into multiple lines

### DIFF
--- a/src/game/server/save.cpp
+++ b/src/game/server/save.cpp
@@ -182,14 +182,127 @@ void CSaveTee::load(CCharacter *pChr, int Team)
 
 char* CSaveTee::GetString()
 {
-	str_format(m_String, sizeof(m_String), "%s\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%f\t%f\t%d\t%d\t%d\t%d\t%d\t%d\t%f\t%f\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%d\t%d\t%d\t%d\t%s", m_name, m_Alive, m_Paused, m_NeededFaketuning, m_TeeFinished, m_IsSolo, m_aWeapons[0].m_AmmoRegenStart, m_aWeapons[0].m_Ammo, m_aWeapons[0].m_Ammocost, m_aWeapons[0].m_Got, m_aWeapons[1].m_AmmoRegenStart, m_aWeapons[1].m_Ammo, m_aWeapons[1].m_Ammocost, m_aWeapons[1].m_Got, m_aWeapons[2].m_AmmoRegenStart, m_aWeapons[2].m_Ammo, m_aWeapons[2].m_Ammocost, m_aWeapons[2].m_Got, m_aWeapons[3].m_AmmoRegenStart, m_aWeapons[3].m_Ammo, m_aWeapons[3].m_Ammocost, m_aWeapons[3].m_Got, m_aWeapons[4].m_AmmoRegenStart, m_aWeapons[4].m_Ammo, m_aWeapons[4].m_Ammocost, m_aWeapons[4].m_Got, m_aWeapons[5].m_AmmoRegenStart, m_aWeapons[5].m_Ammo, m_aWeapons[5].m_Ammocost, m_aWeapons[5].m_Got, m_LastWeapon, m_QueuedWeapon, m_SuperJump, m_Jetpack, m_NinjaJetpack, m_FreezeTime, m_FreezeTick, m_DeepFreeze, m_EndlessHook, m_DDRaceState, m_Hit, m_Collision, m_TuneZone, m_TuneZoneOld, m_Hook, m_Time, (int)m_Pos.x, (int)m_Pos.y, (int)m_PrevPos.x, (int)m_PrevPos.y, m_TeleCheckpoint, m_LastPenalty, (int)m_CorePos.x, (int)m_CorePos.y, m_Vel.x, m_Vel.y, m_ActiveWeapon, m_Jumped, m_JumpedTotal, m_Jumps, (int)m_HookPos.x, (int)m_HookPos.y, m_HookDir.x, m_HookDir.y, (int)m_HookTeleBase.x, (int)m_HookTeleBase.y, m_HookTick, m_HookState, m_CpTime, m_CpActive, m_CpLastBroadcast, m_CpCurrent[0], m_CpCurrent[1], m_CpCurrent[2], m_CpCurrent[3], m_CpCurrent[4], m_CpCurrent[5], m_CpCurrent[6], m_CpCurrent[7], m_CpCurrent[8], m_CpCurrent[9], m_CpCurrent[10], m_CpCurrent[11], m_CpCurrent[12], m_CpCurrent[13], m_CpCurrent[14], m_CpCurrent[15], m_CpCurrent[16], m_CpCurrent[17], m_CpCurrent[18], m_CpCurrent[19], m_CpCurrent[20], m_CpCurrent[21], m_CpCurrent[22], m_CpCurrent[23], m_CpCurrent[24], m_NotEligibleForFinish, m_HasTelegunGun, m_HasTelegunLaser, m_HasTelegunGrenade, m_aGameUuid);
+	str_format(m_String, sizeof(m_String),
+			"%s\t%d\t%d\t%d\t%d\t%d\t"
+			// weapons
+			"%d\t%d\t%d\t%d\t"
+			"%d\t%d\t%d\t%d\t"
+			"%d\t%d\t%d\t%d\t"
+			"%d\t%d\t%d\t%d\t"
+			"%d\t%d\t%d\t%d\t"
+			"%d\t%d\t%d\t%d\t"
+			"%d\t%d\t"
+			// tee stats
+			"%d\t%d\t%d\t%d\t%d\t%d\t%d\t" // m_SuperJump
+			"%d\t%d\t%d\t%d\t%d\t%d\t%d\t" // m_DDRaceState
+			"%d\t%d\t%d\t%d\t" // m_Pos.x
+			"%d\t%d\t"  // m_TeleCheckpoint
+			"%d\t%d\t%f\t%f\t" // m_CorePos.x
+			"%d\t%d\t%d\t%d\t" // m_ActiveWeapon
+			"%d\t%d\t%f\t%f\t" // m_HookPos.x
+			"%d\t%d\t%d\t%d\t" // m_HookTeleBase.x
+			// time checkpoints
+			"%d\t%d\t%d\t"
+			"%f\t%f\t%f\t%f\t%f\t"
+			"%f\t%f\t%f\t%f\t%f\t"
+			"%f\t%f\t%f\t%f\t%f\t"
+			"%f\t%f\t%f\t%f\t%f\t"
+			"%f\t%f\t%f\t%f\t%f\t"
+			"%d\t"
+			"%d\t%d\t%d\t"
+			"%s",
+			m_name, m_Alive, m_Paused, m_NeededFaketuning, m_TeeFinished, m_IsSolo,
+			// weapons
+			m_aWeapons[0].m_AmmoRegenStart, m_aWeapons[0].m_Ammo, m_aWeapons[0].m_Ammocost, m_aWeapons[0].m_Got,
+			m_aWeapons[1].m_AmmoRegenStart, m_aWeapons[1].m_Ammo, m_aWeapons[1].m_Ammocost, m_aWeapons[1].m_Got,
+			m_aWeapons[2].m_AmmoRegenStart, m_aWeapons[2].m_Ammo, m_aWeapons[2].m_Ammocost, m_aWeapons[2].m_Got,
+			m_aWeapons[3].m_AmmoRegenStart, m_aWeapons[3].m_Ammo, m_aWeapons[3].m_Ammocost, m_aWeapons[3].m_Got,
+			m_aWeapons[4].m_AmmoRegenStart, m_aWeapons[4].m_Ammo, m_aWeapons[4].m_Ammocost, m_aWeapons[4].m_Got,
+			m_aWeapons[5].m_AmmoRegenStart, m_aWeapons[5].m_Ammo, m_aWeapons[5].m_Ammocost, m_aWeapons[5].m_Got,
+			m_LastWeapon, m_QueuedWeapon,
+			// tee states
+			m_SuperJump, m_Jetpack, m_NinjaJetpack, m_FreezeTime, m_FreezeTick, m_DeepFreeze, m_EndlessHook,
+			m_DDRaceState, m_Hit, m_Collision, m_TuneZone, m_TuneZoneOld, m_Hook, m_Time,
+			(int)m_Pos.x, (int)m_Pos.y, (int)m_PrevPos.x, (int)m_PrevPos.y,
+			m_TeleCheckpoint, m_LastPenalty,
+			(int)m_CorePos.x, (int)m_CorePos.y, m_Vel.x, m_Vel.y,
+			m_ActiveWeapon, m_Jumped, m_JumpedTotal, m_Jumps,
+			(int)m_HookPos.x, (int)m_HookPos.y, m_HookDir.x, m_HookDir.y,
+			(int)m_HookTeleBase.x, (int)m_HookTeleBase.y, m_HookTick, m_HookState,
+			// time checkpoints
+			m_CpTime, m_CpActive, m_CpLastBroadcast,
+			m_CpCurrent[0], m_CpCurrent[1], m_CpCurrent[2], m_CpCurrent[3], m_CpCurrent[4],
+			m_CpCurrent[5], m_CpCurrent[6], m_CpCurrent[7], m_CpCurrent[8], m_CpCurrent[9],
+			m_CpCurrent[10], m_CpCurrent[11], m_CpCurrent[12], m_CpCurrent[13], m_CpCurrent[14],
+			m_CpCurrent[15], m_CpCurrent[16], m_CpCurrent[17], m_CpCurrent[18], m_CpCurrent[19],
+			m_CpCurrent[20], m_CpCurrent[21], m_CpCurrent[22], m_CpCurrent[23], m_CpCurrent[24],
+			m_NotEligibleForFinish,
+			m_HasTelegunGun, m_HasTelegunLaser, m_HasTelegunGrenade,
+			m_aGameUuid
+	);
 	return m_String;
 }
 
 int CSaveTee::LoadString(char* String)
 {
 	int Num;
-	Num = sscanf(String, "%[^\t]\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%f\t%f\t%f\t%f\t%d\t%d\t%f\t%f\t%f\t%f\t%d\t%d\t%d\t%d\t%f\t%f\t%f\t%f\t%f\t%f\t%d\t%d\t%d\t%d\t%d\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%f\t%d\t%d\t%d\t%d\t%*s", m_name, &m_Alive, &m_Paused, &m_NeededFaketuning, &m_TeeFinished, &m_IsSolo, &m_aWeapons[0].m_AmmoRegenStart, &m_aWeapons[0].m_Ammo, &m_aWeapons[0].m_Ammocost, &m_aWeapons[0].m_Got, &m_aWeapons[1].m_AmmoRegenStart, &m_aWeapons[1].m_Ammo, &m_aWeapons[1].m_Ammocost, &m_aWeapons[1].m_Got, &m_aWeapons[2].m_AmmoRegenStart, &m_aWeapons[2].m_Ammo, &m_aWeapons[2].m_Ammocost, &m_aWeapons[2].m_Got, &m_aWeapons[3].m_AmmoRegenStart, &m_aWeapons[3].m_Ammo, &m_aWeapons[3].m_Ammocost, &m_aWeapons[3].m_Got, &m_aWeapons[4].m_AmmoRegenStart, &m_aWeapons[4].m_Ammo, &m_aWeapons[4].m_Ammocost, &m_aWeapons[4].m_Got, &m_aWeapons[5].m_AmmoRegenStart, &m_aWeapons[5].m_Ammo, &m_aWeapons[5].m_Ammocost, &m_aWeapons[5].m_Got, &m_LastWeapon, &m_QueuedWeapon, &m_SuperJump, &m_Jetpack, &m_NinjaJetpack, &m_FreezeTime, &m_FreezeTick, &m_DeepFreeze, &m_EndlessHook, &m_DDRaceState, &m_Hit, &m_Collision, &m_TuneZone, &m_TuneZoneOld, &m_Hook, &m_Time, &m_Pos.x, &m_Pos.y, &m_PrevPos.x, &m_PrevPos.y, &m_TeleCheckpoint, &m_LastPenalty, &m_CorePos.x, &m_CorePos.y, &m_Vel.x, &m_Vel.y, &m_ActiveWeapon, &m_Jumped, &m_JumpedTotal, &m_Jumps, &m_HookPos.x, &m_HookPos.y, &m_HookDir.x, &m_HookDir.y, &m_HookTeleBase.x, &m_HookTeleBase.y, &m_HookTick, &m_HookState, &m_CpTime, &m_CpActive, &m_CpLastBroadcast, &m_CpCurrent[0], &m_CpCurrent[1], &m_CpCurrent[2], &m_CpCurrent[3], &m_CpCurrent[4], &m_CpCurrent[5], &m_CpCurrent[6], &m_CpCurrent[7], &m_CpCurrent[8], &m_CpCurrent[9], &m_CpCurrent[10], &m_CpCurrent[11], &m_CpCurrent[12], &m_CpCurrent[13], &m_CpCurrent[14], &m_CpCurrent[15], &m_CpCurrent[16], &m_CpCurrent[17], &m_CpCurrent[18], &m_CpCurrent[19], &m_CpCurrent[20], &m_CpCurrent[21], &m_CpCurrent[22], &m_CpCurrent[23], &m_CpCurrent[24], &m_NotEligibleForFinish, &m_HasTelegunGun, &m_HasTelegunLaser, &m_HasTelegunGrenade);
+	Num = sscanf(String,
+			"%[^\t]\t%d\t%d\t%d\t%d\t%d\t"
+			// weapons
+			"%d\t%d\t%d\t%d\t"
+			"%d\t%d\t%d\t%d\t"
+			"%d\t%d\t%d\t%d\t"
+			"%d\t%d\t%d\t%d\t"
+			"%d\t%d\t%d\t%d\t"
+			"%d\t%d\t%d\t%d\t"
+			"%d\t%d\t"
+			// tee states
+			"%d\t%d\t%d\t%d\t%d\t%d\t%d\t" // m_SuperJump
+			"%d\t%d\t%d\t%d\t%d\t%d\t%d\t" // m_DDRaceState
+			"%f\t%f\t%f\t%f\t" // m_Pos.x
+			"%d\t%d\t" // m_TeleCheckpoint,
+			"%f\t%f\t%f\t%f\t" // m_CorePos.x
+			"%d\t%d\t%d\t%d\t" // m_ActiveWeapon
+			"%f\t%f\t%f\t%f\t" // m_HookPos.x
+			"%f\t%f\t%d\t%d\t" // m_HookTeleBase.x
+			// time checkpoints
+			"%d\t%d\t%d\t"
+			"%f\t%f\t%f\t%f\t%f\t"
+			"%f\t%f\t%f\t%f\t%f\t"
+			"%f\t%f\t%f\t%f\t%f\t"
+			"%f\t%f\t%f\t%f\t%f\t"
+			"%f\t%f\t%f\t%f\t%f\t"
+			"%d\t"
+			"%d\t%d\t%d\t"
+			"%*s", // discard the game uuid
+			m_name, &m_Alive, &m_Paused, &m_NeededFaketuning, &m_TeeFinished, &m_IsSolo,
+			// weapons
+			&m_aWeapons[0].m_AmmoRegenStart, &m_aWeapons[0].m_Ammo, &m_aWeapons[0].m_Ammocost, &m_aWeapons[0].m_Got,
+			&m_aWeapons[1].m_AmmoRegenStart, &m_aWeapons[1].m_Ammo, &m_aWeapons[1].m_Ammocost, &m_aWeapons[1].m_Got,
+			&m_aWeapons[2].m_AmmoRegenStart, &m_aWeapons[2].m_Ammo, &m_aWeapons[2].m_Ammocost, &m_aWeapons[2].m_Got,
+			&m_aWeapons[3].m_AmmoRegenStart, &m_aWeapons[3].m_Ammo, &m_aWeapons[3].m_Ammocost, &m_aWeapons[3].m_Got,
+			&m_aWeapons[4].m_AmmoRegenStart, &m_aWeapons[4].m_Ammo, &m_aWeapons[4].m_Ammocost, &m_aWeapons[4].m_Got,
+			&m_aWeapons[5].m_AmmoRegenStart, &m_aWeapons[5].m_Ammo, &m_aWeapons[5].m_Ammocost, &m_aWeapons[5].m_Got,
+			&m_LastWeapon, &m_QueuedWeapon,
+			// tee states
+			&m_SuperJump, &m_Jetpack, &m_NinjaJetpack, &m_FreezeTime, &m_FreezeTick, &m_DeepFreeze, &m_EndlessHook,
+			&m_DDRaceState, &m_Hit, &m_Collision, &m_TuneZone, &m_TuneZoneOld, &m_Hook, &m_Time,
+			&m_Pos.x, &m_Pos.y, &m_PrevPos.x, &m_PrevPos.y,
+			&m_TeleCheckpoint, &m_LastPenalty,
+			&m_CorePos.x, &m_CorePos.y, &m_Vel.x, &m_Vel.y,
+			&m_ActiveWeapon, &m_Jumped, &m_JumpedTotal, &m_Jumps,
+			&m_HookPos.x, &m_HookPos.y, &m_HookDir.x, &m_HookDir.y,
+			&m_HookTeleBase.x, &m_HookTeleBase.y, &m_HookTick, &m_HookState,
+			// time checkpoints
+			&m_CpTime, &m_CpActive, &m_CpLastBroadcast,
+			&m_CpCurrent[0], &m_CpCurrent[1], &m_CpCurrent[2], &m_CpCurrent[3], &m_CpCurrent[4],
+			&m_CpCurrent[5], &m_CpCurrent[6], &m_CpCurrent[7], &m_CpCurrent[8], &m_CpCurrent[9],
+			&m_CpCurrent[10], &m_CpCurrent[11], &m_CpCurrent[12], &m_CpCurrent[13], &m_CpCurrent[14],
+			&m_CpCurrent[15], &m_CpCurrent[16], &m_CpCurrent[17], &m_CpCurrent[18], &m_CpCurrent[19],
+			&m_CpCurrent[20], &m_CpCurrent[21], &m_CpCurrent[22], &m_CpCurrent[23], &m_CpCurrent[24],
+			&m_NotEligibleForFinish,
+			&m_HasTelegunGun, &m_HasTelegunLaser, &m_HasTelegunGrenade
+	);
 	switch(Num) // Don't forget to update this when you save / load more / less.
 	{
 	case 96:


### PR DESCRIPTION
I checked if the format string has changed with this c file: https://gist.github.com/Zwelf/12eb85c47e3ca0691db7710bec497bd6

```bash
$ gcc check.c 
$ ./a.out 
load string compare: 0
get string compare: 0
```

I also checked if the variable names matched with vim (by concatenating the lines with J) and the browser search functionality.