### PR TITLE
Silence GCC warning

### DIFF
--- a/src/game/editor/auto_map.cpp
+++ b/src/game/editor/auto_map.cpp
@@ -72,6 +72,7 @@ void CAutoMapper::Load(const char* pTileName)
 				// new configuration, get the name
 				pLine++;
 				CConfiguration NewConf;
+				NewConf.m_aName[0] = '\0';
 				NewConf.m_StartX = 0;
 				NewConf.m_StartY = 0;
 				NewConf.m_EndX = 0;


### PR DESCRIPTION
```
src/game/editor/auto_map.h:47:9: warning: ‘*((void*)& NewConf +16)’ may be used uninitialized in this function [-Wmaybe-uninitialized]
```
I don't think it's an actual problem