### PR TITLE
Don't clamp values that have no reasonable values

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -3330,9 +3330,6 @@ int CEditor::DoProperties(CUIRect *pToolBox, CProperty *pProps, int *pIDs, int *
 		}
 	}
 
-	if(Change != -1)
-		*pNewVal = clamp(*pNewVal, pProps[Change].m_Min, pProps[Change].m_Max);
-
 	return Change;
 }
 

--- a/src/game/editor/layer_quads.cpp
+++ b/src/game/editor/layer_quads.cpp
@@ -240,7 +240,7 @@ int CLayerQuads::RenderProperties(CUIRect *pToolBox)
 	};
 
 	CProperty aProps[] = {
-		{"Image", m_Image, PROPTYPE_IMAGE, -1, m_pEditor->m_Map.m_lImages.size()},
+		{"Image", m_Image, PROPTYPE_IMAGE, -1, 0},
 		{0},
 	};
 
@@ -252,7 +252,10 @@ int CLayerQuads::RenderProperties(CUIRect *pToolBox)
 
 	if(Prop == PROP_IMAGE)
 	{
-		m_Image = NewVal;
+		if(NewVal >= 0)
+			m_Image = NewVal%m_pEditor->m_Map.m_lImages.size();
+		else
+			m_Image = -1;
 	}
 
 	return 0;

--- a/src/game/editor/layer_sounds.cpp
+++ b/src/game/editor/layer_sounds.cpp
@@ -199,7 +199,7 @@ int CLayerSounds::RenderProperties(CUIRect *pToolBox)
 	};
 
 	CProperty aProps[] = {
-		{"Sound", m_Sound, PROPTYPE_SOUND, -1, m_pEditor->m_Map.m_lSounds.size()},
+		{"Sound", m_Sound, PROPTYPE_SOUND, -1, 0},
 		{0},
 	};
 
@@ -211,7 +211,10 @@ int CLayerSounds::RenderProperties(CUIRect *pToolBox)
 
 	if(Prop == PROP_SOUND)
 	{
-		m_Sound = NewVal;
+		if(NewVal >= 0)
+			m_Sound = NewVal%m_pEditor->m_Map.m_lSounds.size();
+		else
+			m_Sound = -1;
 	}
 
 	return 0;

--- a/src/game/editor/layer_tiles.cpp
+++ b/src/game/editor/layer_tiles.cpp
@@ -870,7 +870,7 @@ int CLayerTiles::RenderProperties(CUIRect *pToolBox)
 		{"Height", m_Height, PROPTYPE_INT_SCROLL, 1, 100000},
 		{"Shift", 0, PROPTYPE_SHIFT, 0, 0},
 		{"Shift by", m_pEditor->m_ShiftBy, PROPTYPE_INT_SCROLL, 1, 100000},
-		{"Image", m_Image, PROPTYPE_IMAGE, 0, m_pEditor->m_Map.m_lImages.size()},
+		{"Image", m_Image, PROPTYPE_IMAGE, 0, 0},
 		{"Color", Color, PROPTYPE_COLOR, 0, 0},
 		{"Color Env", m_ColorEnv+1, PROPTYPE_ENVELOPE, 0, 0},
 		{"Color TO", m_ColorEnvOffset, PROPTYPE_INT_SCROLL, -1000000, 1000000},
@@ -925,9 +925,11 @@ int CLayerTiles::RenderProperties(CUIRect *pToolBox)
 		if (NewVal == -1)
 		{
 			m_Texture = IGraphics::CTextureHandle();
+			m_Image = -1;
 		}
 		else
 		{
+			m_Image = NewVal%m_pEditor->m_Map.m_lImages.size();
 			m_AutoMapperConfig = -1;
 		}
 	}


### PR DESCRIPTION
Still affects many values in editor, for example colors in tiles and quads.

Thanks to Pipou for report.