### PR TITLE
clarified /practice voting instructions

### DIFF
--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -657,7 +657,7 @@ void CGameContext::ConPractice(IConsole::IResult *pResult, void *pUserData)
 	int NumRequiredVotes = TeamSize / 2 + 1;
 
 	char aBuf[512];
-	str_format(aBuf, sizeof(aBuf), "'%s' voted to %s /practice mode for your team, which means you can use /r, but you can't earn a rank. (%d/%d required votes)", pSelf->Server()->ClientName(pResult->m_ClientID), VotedForPractice ? "enable" : "disable", NumCurrentVotes, NumRequiredVotes);
+	str_format(aBuf, sizeof(aBuf), "'%s' voted to %s /practice mode for your team, which means you can use /r, but you can't earn a rank. Type /practice to vote (%d/%d required votes)", pSelf->Server()->ClientName(pResult->m_ClientID), VotedForPractice ? "enable" : "disable", NumCurrentVotes, NumRequiredVotes);
 
 	for(int i = 0; i < MAX_CLIENTS; i++)
 		if(Teams.m_Core.Team(i) == Team)


### PR DESCRIPTION
If a person is attempting to enable practice mode for the *first time ever* (unfamiliar with it) and they're doing it with a dummy rather than a real player, the current message doesn't really explain the voting procedure very well. I for one expected to see an f3/f4 vote dialog and even filed a bug report on the matter (#2222). The current message does mention "/practice" but it didn't make me think "ok now I need to switch to my dummy and type /practice". For example when a person types "/map Epix" it doesn't then require everybody on the server to *also* type "/map Epix"..... in that case it uses the normal f3/f4 vote dialog.