### PR TITLE
Save active weapon with /rescue

### DIFF
--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -2153,6 +2153,7 @@ void CCharacter::DDRaceTick()
 				m_aPrevSaveWeapons[i].m_Ammocost = m_aWeapons[i].m_Ammocost;
 				m_aPrevSaveWeapons[i].m_Got = m_aWeapons[i].m_Got;
 			}
+			m_PrevSaveActiveWeapon = m_Core.m_ActiveWeapon;
 			m_SetSavePos = true;
 		}
 	}
@@ -2392,5 +2393,6 @@ void CCharacter::Rescue()
 			m_aWeapons[i].m_Ammocost = m_aPrevSaveWeapons[i].m_Ammocost;
 			m_aWeapons[i].m_Got = m_aPrevSaveWeapons[i].m_Got;
 		}
+		m_Core.m_ActiveWeapon = m_PrevSaveActiveWeapon;
 	}
 }

--- a/src/game/server/entities/character.h
+++ b/src/game/server/entities/character.h
@@ -113,6 +113,7 @@ private:
 	} m_aWeapons[NUM_WEAPONS];
 
 	struct WeaponStat m_aPrevSaveWeapons[NUM_WEAPONS];
+	int m_PrevSaveActiveWeapon;
 
 	int m_LastWeapon;
 	int m_QueuedWeapon;


### PR DESCRIPTION
If you don't have a certain weapon in your last m_SavePos and you get a weapon and then use /r before touching the ground, currently it's bugged and you'll *appear* to have that weapon still out after you use /r.... except it doesn't fire. This is because weapons are saved/restored as of cacf17bd966e200523c8287991255c528f30c6ee

A map to test this buggy behavior is Aim 5.0; swing and get the sg and then use /r before you hit the ground. It will *appear* as though you still have the sg, but it won't fire.