### PR TITLE
Fix out of bounds read

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -912,7 +912,7 @@ void CMenus::RenderNews(CUIRect MainView)
 		else
 		{
 			MainView.HSplitTop(20.0f, &Label, &MainView);
-			UI()->DoLabelScaled(&Label, aLine, 15.f, -1, MainView.w-30.0f);
+			UI()->DoLabelScaled(&Label, aLine, 15.f, -1, -1);
 		}
 	}
 }


### PR DESCRIPTION
@Jupeyy I'm not completely familiar with the text rendering code but I think it needs a large rework. The code isn't concise or easy to read, the interface is horrendous.

e.g. That `MaxWidth` parameter on `DoLabel` is an integer and it's used completely wrongly leading to a out of bounds read.