### PR TITLE
Fix segmentation fault when creating sql tables failed

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -2063,7 +2063,7 @@ int CServer::Run()
 	GameServer()->OnInit();
 	if(ErrorShutdown())
 	{
-		return 1;
+		m_RunServer = false;
 	}
 	str_format(aBuf, sizeof(aBuf), "version %s", GameServer()->NetVersion());
 	Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "server", aBuf);
@@ -2281,6 +2281,7 @@ int CServer::Run()
 	const char *pDisconnectReason = "Server shutdown";
 	if(ErrorShutdown())
 	{
+		dbg_msg("server", "shutdown from game server (%s)", m_aErrorShutdownReason);
 		pDisconnectReason = m_aErrorShutdownReason;
 	}
 	// disconnect all clients on shutdown


### PR DESCRIPTION
`GameServer()->OnShutdown(true);` (which would wait on running threads to exit)
wasn't called if an error occured in the server init. Therefore `CServer` was
freed before the init-thread finished executing, causing a use after free from
`CSqlConnector::ms_ppSqlReadServers` pointing to `CServer->m_apSqlReadServers`.

Fixes #2271 

Note that the server exits when creating tables failed. Since the tables are created by default, it has to be disabled explicitly (e.g. `add_sqlserver r teeworlds record teeworlds PASSWORD "localhost" 3306 0`) if the servers should start even when the database connection fails.