### PR TITLE
Restore old message behavior when using /load and /save

### DIFF
--- a/src/game/server/score/sql_score.cpp
+++ b/src/game/server/score/sql_score.cpp
@@ -1525,10 +1525,6 @@ void CSqlScore::SaveTeam(int ClientID, const char* Code, const char* Server)
 	GeneratePassphrase(Tmp->m_aGeneratedCode, sizeof(Tmp->m_aGeneratedCode));
 
 	pController->m_Teams.KillSavedTeam(ClientID, Team);
-	char aBuf[512];
-	// TODO: better message, maybe hint that one should wait until the next message to leave
-	str_format(aBuf, sizeof(aBuf), "Saving team initiated by '%s'", this->Server()->ClientName(ClientID));
-	GameServer()->SendChatTeam(Team, aBuf);
 	thread_init_and_detach(
 			CSqlExecData<CSqlSaveResult>::ExecSqlFunc,
 			new CSqlExecData<CSqlSaveResult>(SaveTeamThread, Tmp, false),
@@ -1703,9 +1699,6 @@ void CSqlScore::LoadTeam(const char* Code, int ClientID)
 			Tmp->m_NumPlayer++;
 		}
 	}
-	char aBuf[512];
-	str_format(aBuf, sizeof(aBuf), "Loading team initiated by '%s'", this->Server()->ClientName(ClientID));
-	GameServer()->SendChatTeam(Team, aBuf);
 	thread_init_and_detach(
 			CSqlExecData<CSqlSaveResult>::ExecSqlFunc,
 			new CSqlExecData<CSqlSaveResult>(LoadTeamThread, Tmp, false),

--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -690,7 +690,7 @@ void CGameTeams::ProcessSaveTeam()
 			continue;
 		if(m_pSaveTeamResult[Team]->m_aBroadcast[0] != '\0')
 			GameServer()->SendBroadcast(m_pSaveTeamResult[Team]->m_aBroadcast, -1);
-		if(m_pSaveTeamResult[Team]->m_aMessage[0] != '\0')
+		if(m_pSaveTeamResult[Team]->m_aMessage[0] != '\0' && m_pSaveTeamResult[Team]->m_Status != CSqlSaveResult::LOAD_FAILED)
 			GameServer()->SendChatTeam(Team, m_pSaveTeamResult[Team]->m_aMessage);
 		// TODO: log load/save success/fail in teehistorian
 		switch(m_pSaveTeamResult[Team]->m_Status)
@@ -717,6 +717,8 @@ void CGameTeams::ProcessSaveTeam()
 			break;
 		}
 		case CSqlSaveResult::LOAD_FAILED:
+			if(m_pSaveTeamResult[Team]->m_aMessage[0] != '\0')
+				GameServer()->SendChatTarget(m_pSaveTeamResult[Team]->m_RequestingPlayer, m_pSaveTeamResult[Team]->m_aMessage);
 			break;
 		}
 		m_pSaveTeamResult[Team] = nullptr;


### PR DESCRIPTION
Only notify the player initiating /load about the error and don't send
'Loading initiated by ...' and 'Saving initiated by ...' messages resulting
in two messages per /load and /save.

Not sure if the old behavior is better or if we want to keep the new with sending two messages per /save and /load.