### PR TITLE
add client capabilites and show weapon on freeze

### DIFF
--- a/datasrc/network.py
+++ b/datasrc/network.py
@@ -26,6 +26,10 @@ Emoticons = ["OOP", "EXCLAMATION", "HEARTS", "DROP", "DOTDOT", "MUSIC", "SORRY",
 Powerups = ["HEALTH", "ARMOR", "WEAPON", "NINJA"]
 Authed = ["NO", "HELPER", "MOD", "ADMIN"]
 
+ClientCapabilitiesFlags = [
+	"USE_DDNET_CHAR_FREEZE",
+]
+
 RawHeader = '''
 
 #include <engine/message.h>
@@ -54,6 +58,11 @@ enum
 {
 	GAMEINFO_CURVERSION=4,
 };
+
+enum
+{
+	CLIENT_CAPABILITIES_CURVERSION=1,
+};
 '''
 
 RawSource = '''
@@ -75,6 +84,7 @@ Flags = [
 	Flags("CHARACTERFLAG", CharacterFlags),
 	Flags("GAMEINFOFLAG", GameInfoFlags),
 	Flags("EXPLAYERFLAG", ExPlayerFlags),
+	Flags("CAPABILITIESFLAG", ClientCapabilitiesFlags),
 ]
 
 Objects = [
@@ -419,5 +429,10 @@ Messages = [
 
 	NetMessageEx("Sv_MyOwnMessage", "my-own-message@heinrich5991.de", [
 		NetIntAny("m_Test"),
+	]),
+
+	NetMessageEx("Cl_Capabilities", "client-capabilities@net-message.ddnet.tw", [
+		NetIntAny("m_Version"),
+		NetIntAny("m_Flags"),
 	]),
 ]

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -654,10 +654,10 @@ void CPlayers::OnRender()
 		m_aRenderInfo[i] = m_pClient->m_aClients[i].m_RenderInfo;
 
 		int FreezeEnd = m_pClient->m_Snap.m_aCharacters[i].m_ExtendedData.m_FreezeEnd;
-		bool IsFrozen = FreezeEnd == -1 || FreezeEnd > m_pClient->Client()->PredGameTick(0);
+		bool IsFrozen = FreezeEnd == -1 || FreezeEnd > m_pClient->Client()->PredGameTick(g_Config.m_ClDummy);
 
-		if(!g_Config.m_ClShowWeaponFreeze && IsFrozen)
-			m_pClient->m_Snap.m_aCharacters[i].m_Cur.m_Weapon = WEAPON_NINJA;
+		//if(!g_Config.m_ClShowWeaponFreeze && IsFrozen)
+		//	m_pClient->m_Snap.m_aCharacters[i].m_Cur.m_Weapon = WEAPON_NINJA;
 
 		if(m_pClient->m_Snap.m_aCharacters[i].m_Cur.m_Weapon == WEAPON_NINJA 
 			|| (IsFrozen && g_Config.m_ClShowNinja))

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -656,10 +656,7 @@ void CPlayers::OnRender()
 		int FreezeEnd = m_pClient->m_Snap.m_aCharacters[i].m_ExtendedData.m_FreezeEnd;
 		bool IsFrozen = FreezeEnd == -1 || FreezeEnd > m_pClient->Client()->PredGameTick(g_Config.m_ClDummy);
 
-		//if(!g_Config.m_ClShowWeaponFreeze && IsFrozen)
-		//	m_pClient->m_Snap.m_aCharacters[i].m_Cur.m_Weapon = WEAPON_NINJA;
-
-		if(m_pClient->m_Snap.m_aCharacters[i].m_Cur.m_Weapon == WEAPON_NINJA 
+		if((m_pClient->m_Snap.m_aCharacters[i].m_Cur.m_Weapon == WEAPON_NINJA && g_Config.m_ClShowNinja)
 			|| (IsFrozen && g_Config.m_ClShowNinja))
 		{
 			// change the skin for the player to the ninja

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -459,6 +459,25 @@ void CPlayers::RenderPlayer(
 				p.y -= 8;
 			Graphics()->RenderQuadContainerAsSprite(m_WeaponEmoteQuadContainerIndex, QuadOffset, p.x, p.y);
 		}
+	
+		if(g_Config.m_ClNinjaParticles)
+		{
+			int FreezeEnd = m_pClient->m_Snap.m_aCharacters[ClientID].m_ExtendedData.m_FreezeEnd;
+			vec2 EffectPos = Position;
+			EffectPos.y += g_pData->m_Weapons.m_aId[WEAPON_NINJA].m_Offsety;
+			if(Player.m_Weapon != WEAPON_NINJA && (FreezeEnd == -1 || FreezeEnd > m_pClient->Client()->PredGameTick(0)))
+			{
+				if(Direction.x < 0)
+				{
+					m_pClient->m_pEffects->PowerupShine(EffectPos+vec2(32,0), vec2(32,12));
+				}
+				else
+				{
+					m_pClient->m_pEffects->PowerupShine(EffectPos-vec2(32,0), vec2(32,12));
+				}
+			}
+		}
+		
 
 		if(Player.m_Weapon == WEAPON_GUN || Player.m_Weapon == WEAPON_SHOTGUN)
 		{
@@ -633,7 +652,15 @@ void CPlayers::OnRender()
 	for(int i = 0; i < MAX_CLIENTS; ++i)
 	{
 		m_aRenderInfo[i] = m_pClient->m_aClients[i].m_RenderInfo;
-		if(m_pClient->m_Snap.m_aCharacters[i].m_Cur.m_Weapon == WEAPON_NINJA && g_Config.m_ClShowNinja)
+
+		int FreezeEnd = m_pClient->m_Snap.m_aCharacters[i].m_ExtendedData.m_FreezeEnd;
+		bool IsFrozen = FreezeEnd == -1 || FreezeEnd > m_pClient->Client()->PredGameTick(0);
+
+		if(!g_Config.m_ClShowWeaponFreeze && IsFrozen)
+			m_pClient->m_Snap.m_aCharacters[i].m_Cur.m_Weapon = WEAPON_NINJA;
+
+		if(m_pClient->m_Snap.m_aCharacters[i].m_Cur.m_Weapon == WEAPON_NINJA 
+			|| (IsFrozen && g_Config.m_ClShowNinja))
 		{
 			// change the skin for the player to the ninja
 			int Skin = m_pClient->m_pSkins->Find("x_ninja");

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1509,16 +1509,6 @@ void CGameClient::OnNewSnapshot()
 		m_DDRaceMsgSent[1] = true;
 	}
 
-	if(!m_CapabilitiesSent)
-	{
-		CMsgPacker Msg(NETMSGTYPE_CL_CAPABILITIES, false);
-		Msg.AddInt(CLIENT_CAPABILITIES_CURVERSION);
-		int Flags = 0
-			| CAPABILITIESFLAG_USE_DDNET_CHAR_FREEZE;
-		Msg.AddInt(Flags);
-		Client()->SendMsg(&Msg, MSGFLAG_VITAL);
-	}
-
 	if(m_ShowOthers[g_Config.m_ClDummy] == -1 || (m_ShowOthers[g_Config.m_ClDummy] != -1 && m_ShowOthers[g_Config.m_ClDummy] != g_Config.m_ClShowOthers))
 	{
 		// no need to send, default settings
@@ -1886,6 +1876,7 @@ void CGameClient::SendInfo(bool Start)
 {
 	if(Start)
 	{
+		SendClientCapabilities(false);
 		CNetMsg_Cl_StartInfo Msg;
 		Msg.m_pName = g_Config.m_PlayerName;
 		Msg.m_pClan = g_Config.m_PlayerClan;
@@ -1920,6 +1911,7 @@ void CGameClient::SendDummyInfo(bool Start)
 {
 	if(Start)
 	{
+		SendClientCapabilities(true);
 		CNetMsg_Cl_StartInfo Msg;
 		Msg.m_pName = g_Config.m_ClDummyName;
 		Msg.m_pClan = g_Config.m_ClDummyClan;
@@ -1948,6 +1940,17 @@ void CGameClient::SendDummyInfo(bool Start)
 		Client()->SendMsgY(&Packer, MSGFLAG_VITAL, 1);
 		m_CheckInfo[1] = Client()->GameTickSpeed();
 	}
+}
+
+void CGameClient::SendClientCapabilities(bool Dummy)
+{
+	CNetMsg_Cl_Capabilities Msg;
+	Msg.m_Version = CLIENT_CAPABILITIES_CURVERSION;
+	Msg.m_Flags = 0
+		| CAPABILITIESFLAG_USE_DDNET_CHAR_FREEZE;
+	
+	CMsgPacker Packer(Msg.MsgID(), false);
+	Client()->SendMsgY(&Packer, MSGFLAG_VITAL, Dummy);
 }
 
 void CGameClient::SendKill(int ClientID)

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1503,6 +1503,16 @@ void CGameClient::OnNewSnapshot()
 		m_DDRaceMsgSent[1] = true;
 	}
 
+	if(!m_CapabilitiesSent)
+	{
+		CMsgPacker Msg(NETMSGTYPE_CL_CAPABILITIES, false);
+		Msg.AddInt(CLIENT_CAPABILITIES_CURVERSION);
+		int Flags = 0
+			| CAPABILITIESFLAG_USE_DDNET_CHAR_FREEZE;
+		Msg.AddInt(Flags);
+		Client()->SendMsg(&Msg, MSGFLAG_VITAL);
+	}
+
 	if(m_ShowOthers[g_Config.m_ClDummy] == -1 || (m_ShowOthers[g_Config.m_ClDummy] != -1 && m_ShowOthers[g_Config.m_ClDummy] != g_Config.m_ClShowOthers))
 	{
 		// no need to send, default settings

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1950,6 +1950,7 @@ void CGameClient::SendClientCapabilities(bool Dummy)
 		| CAPABILITIESFLAG_USE_DDNET_CHAR_FREEZE;
 	
 	CMsgPacker Packer(Msg.MsgID(), false);
+	Msg.Pack(&Packer);
 	Client()->SendMsgY(&Packer, MSGFLAG_VITAL, Dummy);
 }
 

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1283,6 +1283,12 @@ void CGameClient::OnNewSnapshot()
 				m_aClients[Item.m_ID].m_HasTelegunLaser = pCharacterData->m_Flags & CHARACTERFLAG_TELEGUN_LASER;
 
 				m_aClients[Item.m_ID].m_Predicted.ReadDDNet(pCharacterData);
+
+				int FreezeEnd = m_Snap.m_aCharacters[Item.m_ID].m_ExtendedData.m_FreezeEnd;
+				bool IsFrozen = FreezeEnd == -1 || FreezeEnd > Client()->PredGameTick(g_Config.m_ClDummy);
+
+				if(!g_Config.m_ClShowWeaponFreeze && IsFrozen)
+					m_Snap.m_aCharacters[Item.m_ID].m_Cur.m_Weapon = WEAPON_NINJA;
 			}
 			else if(Item.m_Type == NETOBJTYPE_SPECTATORINFO)
 			{

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -366,6 +366,7 @@ public:
 	void SendSwitchTeam(int Team);
 	void SendInfo(bool Start);
 	virtual void SendDummyInfo(bool Start);
+	void SendClientCapabilities(bool Dummy);
 	void SendKill(int ClientID);
 
 	// pointers to all systems
@@ -426,7 +427,6 @@ public:
 
 private:
 	bool m_DDRaceMsgSent[2];
-	bool m_CapabilitiesSent;
 	int m_ShowOthers[2];
 
 	void UpdatePrediction();

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -426,6 +426,7 @@ public:
 
 private:
 	bool m_DDRaceMsgSent[2];
+	bool m_CapabilitiesSent;
 	int m_ShowOthers[2];
 
 	void UpdatePrediction();

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -1075,7 +1075,8 @@ void CCharacter::SnapCharacter(int SnappingClient)
 		if(Emote == EMOTE_NORMAL)
 			Emote = m_DeepFreeze ? EMOTE_PAIN : EMOTE_BLINK;
 
-		Weapon = WEAPON_NINJA;
+		if(!GetPlayer()->m_Capabilities.m_UseDDnetCharFreeze)
+			Weapon = WEAPON_NINJA;
 	}
 
 	// This could probably happen when m_Jetpack changes instead

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -1964,18 +1964,6 @@ void CGameContext::OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID)
 			Server()->SetClientDDNetVersion(ClientID, DDNetVersion);
 			OnClientDDNetVersionKnown(ClientID);
 		}
-		else if (MsgID == NETMSGTYPE_CL_CAPABILITIES)
-		{
-			CNetMsg_Cl_Capabilities *pMsg = (CNetMsg_Cl_Capabilities *)pRawMsg;
-
-			int Flags = 0;
-			if(pMsg->m_Version >= 1)
-			{
-				Flags = pMsg->m_Flags;
-			}
-
-			pPlayer->m_Capabilities.m_UseDDnetCharFreeze = Flags&CAPABILITIESFLAG_USE_DDNET_CHAR_FREEZE;
-		}
 		else if (MsgID == NETMSGTYPE_CL_SHOWOTHERS)
 		{
 			if(g_Config.m_SvShowOthers && !g_Config.m_SvShowOthersDefault)
@@ -2176,6 +2164,22 @@ void CGameContext::OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID)
 		}
 
 		Server()->ExpireServerInfo();
+	}
+	else if (MsgID == NETMSGTYPE_CL_CAPABILITIES)
+	{
+		if(pPlayer->m_IsReady || pPlayer->m_ReceivedCapabilities)
+			return;
+
+		CNetMsg_Cl_Capabilities *pMsg = (CNetMsg_Cl_Capabilities *)pRawMsg;
+
+		int Flags = 0;
+		if(pMsg->m_Version >= 1)
+		{
+			Flags = pMsg->m_Flags;
+		}
+
+		pPlayer->m_Capabilities.m_UseDDnetCharFreeze = Flags&CAPABILITIESFLAG_USE_DDNET_CHAR_FREEZE;
+		pPlayer->m_ReceivedCapabilities = true;
 	}
 }
 

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -1964,6 +1964,18 @@ void CGameContext::OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID)
 			Server()->SetClientDDNetVersion(ClientID, DDNetVersion);
 			OnClientDDNetVersionKnown(ClientID);
 		}
+		else if (MsgID == NETMSGTYPE_CL_CAPABILITIES)
+		{
+			CNetMsg_Cl_Capabilities *pMsg = (CNetMsg_Cl_Capabilities *)pRawMsg;
+
+			int Flags = 0;
+			if(pMsg->m_Version >= 1)
+			{
+				Flags = pMsg->m_Flags;
+			}
+
+			pPlayer->m_Capabilities.m_UseDDnetCharFreeze = Flags&CAPABILITIESFLAG_USE_DDNET_CHAR_FREEZE;
+		}
 		else if (MsgID == NETMSGTYPE_CL_SHOWOTHERS)
 		{
 			if(g_Config.m_SvShowOthers && !g_Config.m_SvShowOthersDefault)

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -26,6 +26,7 @@ CPlayer::CPlayer(CGameContext *pGameServer, int ClientID, int Team)
 	m_ClientID = ClientID;
 	m_Team = GameServer()->m_pController->ClampTeam(Team);
 	m_NumInputs = 0;
+	m_Capabilities.m_UseDDnetCharFreeze = false;
 	Reset();
 	GameServer()->Antibot()->OnPlayerInit(m_ClientID);
 }

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -26,6 +26,7 @@ CPlayer::CPlayer(CGameContext *pGameServer, int ClientID, int Team)
 	m_ClientID = ClientID;
 	m_Team = GameServer()->m_pController->ClampTeam(Team);
 	m_NumInputs = 0;
+	m_ReceivedCapabilities = false;
 	m_Capabilities.m_UseDDnetCharFreeze = false;
 	Reset();
 	GameServer()->Antibot()->OnPlayerInit(m_ClientID);

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -202,6 +202,11 @@ public:
 	bool m_NotEligibleForFinish;
 	int64 m_EligibleForFinishCheck;
 	bool m_VotedForPractice;
+
+	struct CCapabilities
+	{
+		bool m_UseDDnetCharFreeze;
+	} m_Capabilities;
 };
 
 #endif

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -192,6 +192,7 @@ public:
 	int m_DefEmoteReset;
 	bool m_Halloween;
 	bool m_FirstPacket;
+	bool m_ReceivedCapabilities;
 #if defined(CONF_SQL)
 	void ProcessSqlResult(CSqlPlayerResult &Result);
 	int64 m_LastSQLQuery;

--- a/src/game/variables.h
+++ b/src/game/variables.h
@@ -82,6 +82,8 @@ MACRO_CONFIG_INT(ClAutoStatboardScreenshot, cl_auto_statboard_screenshot, 0, 0, 
 MACRO_CONFIG_INT(ClAutoStatboardScreenshotMax, cl_auto_statboard_screenshot_max, 10, 0, 1000, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Maximum number of automatically created statboard screenshots (0 = no limit)")
 
 MACRO_CONFIG_INT(ClDefaultZoom, cl_default_zoom, 10, 0, 20, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Default zoom level (10 default, min 0, max 20)")
+MACRO_CONFIG_INT(ClNinjaParticles, cl_ninja_particles, 1, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Whether to show ninja particles on forzen tees.")
+MACRO_CONFIG_INT(ClShowWeaponFreeze, cl_show_weapon_freeze, 1, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Whether to show what weapon a tee has when frozen.")
 
 MACRO_CONFIG_INT(ClPlayerUseCustomColor, player_use_custom_color, 0, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Toggles usage of custom colors")
 MACRO_CONFIG_COL(ClPlayerColorBody, player_color_body, 65408, CFGFLAG_CLIENT|CFGFLAG_SAVE|CFGFLAG_COLLIGHT, "Player body color")

--- a/src/game/variables.h
+++ b/src/game/variables.h
@@ -82,7 +82,7 @@ MACRO_CONFIG_INT(ClAutoStatboardScreenshot, cl_auto_statboard_screenshot, 0, 0, 
 MACRO_CONFIG_INT(ClAutoStatboardScreenshotMax, cl_auto_statboard_screenshot_max, 10, 0, 1000, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Maximum number of automatically created statboard screenshots (0 = no limit)")
 
 MACRO_CONFIG_INT(ClDefaultZoom, cl_default_zoom, 10, 0, 20, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Default zoom level (10 default, min 0, max 20)")
-MACRO_CONFIG_INT(ClNinjaParticles, cl_ninja_particles, 1, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Whether to show ninja particles on forzen tees.")
+MACRO_CONFIG_INT(ClNinjaParticles, cl_ninja_particles, 1, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Whether to show ninja particles on frozen tees.")
 MACRO_CONFIG_INT(ClShowWeaponFreeze, cl_show_weapon_freeze, 1, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Whether to show what weapon a tee has when frozen.")
 
 MACRO_CONFIG_INT(ClPlayerUseCustomColor, player_use_custom_color, 0, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Toggles usage of custom colors")


### PR DESCRIPTION
cl_show_ninja 1
cl_ninja_particles 1
![](https://cdn.discordapp.com/attachments/293493549758939136/724257822103044196/unknown.png)
cl_show_ninja 0
cl_ninja_particles 1
![](https://cdn.discordapp.com/attachments/293493549758939136/724257924834263070/unknown.png)
cl_show_ninja 0
cl_ninja_particles 0
![](https://cdn.discordapp.com/attachments/293493549758939136/724258028840288416/unknown.png)
cl_show_ninja 1
cl_ninja_particles 0
![](https://cdn.discordapp.com/attachments/293493549758939136/724258699945967620/unknown.png)
With the feature disabled (cl_show_weapon_freeze 0) and cl_show_ninja 0 for the people who dislike this.
![image](https://user-images.githubusercontent.com/15859336/85266180-c6eed100-b473-11ea-8258-83928e10f842.png)

This allows to see other tees weapons while frozen, it also adds some options to show freeze particles or even disable completly this feature.

https://github.com/ddnet/ddnet/blob/5835a880c0d51dea46ca996f635647086c90a9bc/src/game/variables.h#L85-L86

It also adds a new packet to know the client capabilities.

Seems to work fine when connecting to a server without the new packet.