### PR TITLE
Fix str_format on mingw

### DIFF
--- a/src/base/system.c
+++ b/src/base/system.c
@@ -2333,11 +2333,13 @@ int str_length(const char *str)
 int str_format(char *buffer, int buffer_size, const char *format, ...)
 {
 	int ret;
-#if defined(CONF_FAMILY_WINDOWS)
+
 	va_list ap;
 	va_start(ap, format);
+#if defined(__MINGW32__)
+	ret = __mingw_vsnprintf(buffer, buffer_size, format, ap);
+#elif defined(CONF_FAMILY_WINDOWS)
 	ret = _vsnprintf(buffer, buffer_size, format, ap);
-	va_end(ap);
 
 	buffer[buffer_size-1] = 0; /* assure null termination */
 
@@ -2346,13 +2348,11 @@ int str_format(char *buffer, int buffer_size, const char *format, ...)
 	if(ret < 0)
 		ret = buffer_size - 1;
 #else
-	va_list ap;
-	va_start(ap, format);
 	ret = vsnprintf(buffer, buffer_size, format, ap);
+#endif
 	va_end(ap);
 
 	/* null termination is assured by definition of vsnprintf */
-#endif
 
 	/* a return value of buffer_size or more indicates truncated output */
 	if(ret >= buffer_size)


### PR DESCRIPTION
```
src/game/server/ddracecommands.cpp:743:39: warning: unknown conversion type character ‘l’ in format [-Wformat=]
  743 |  str_format(aBuf, sizeof(aBuf), "%s-%lld-%s.save", pSelf->Server()->GetMapName(), time_get(), pSelf->Server()->GetAuthName(pResult->m_ClientID));
```
See https://sourceforge.net/p/mingw-w64/wiki2/gnu%20printf/