### PR TITLE
Allow any update.json size

### DIFF
--- a/src/engine/client/http.cpp
+++ b/src/engine/client/http.cpp
@@ -146,7 +146,7 @@ int CRequest::RunImpl(CURL *pHandle)
 		|| str_comp_nocase_num("https://maps.ddnet.tw/", m_aUrl, 22) == 0
 		|| str_comp_nocase_num("http://info.ddnet.tw/", m_aUrl, 21) == 0
 		|| str_comp_nocase_num("https://info.ddnet.tw/", m_aUrl, 22) == 0
-		|| str_comp_nocase_num("https://update4.ddnet.tw/", m_aUrl, 25) == 0)
+		|| str_comp_nocase_num("https://update5.ddnet.tw/", m_aUrl, 25) == 0)
 	{
 		curl_easy_setopt(pHandle, CURLOPT_CAINFO, CA_FILE_PATH);
 	}

--- a/src/engine/client/updater.cpp
+++ b/src/engine/client/updater.cpp
@@ -27,7 +27,7 @@ public:
 
 static const char *GetUpdaterUrl(char *pBuf, int BufSize, const char *pFile)
 {
-	str_format(pBuf, BufSize, "https://update4.ddnet.tw/%s", pFile);
+	str_format(pBuf, BufSize, "https://update5.ddnet.tw/%s", pFile);
 	return pBuf;
 }
 
@@ -244,12 +244,14 @@ void CUpdater::ParseUpdate()
 	if(!File)
 		return;
 
-	char aBuf[4096*4];
-	mem_zero(aBuf, sizeof (aBuf));
-	io_read(File, aBuf, sizeof(aBuf));
+	long int Length = io_length(File);
+	char *pBuf = (char *)malloc(Length);
+	mem_zero(pBuf, Length);
+	io_read(File, pBuf, Length);
 	io_close(File);
 
-	json_value *pVersions = json_parse(aBuf, sizeof(aBuf));
+	json_value *pVersions = json_parse(pBuf, Length);
+	free(pBuf);
 
 	if(pVersions && pVersions->type == json_array)
 	{


### PR DESCRIPTION
just grew over 16 KB and thus updates failed. I still need to setup update5 server and will need to release a last release on update4 to have a seemless upgrade-path.

Update: https://update5.ddnet.tw/update.json is ready, 14.0.1 will still land on update4, then we switch to update5.