### PR TITLE
Restore old /save behavior

### DIFF
--- a/src/game/server/score/sql_score.cpp
+++ b/src/game/server/score/sql_score.cpp
@@ -1573,9 +1573,18 @@ bool CSqlScore::SaveTeamThread(CSqlServer* pSqlServer, const CSqlData<CScoreSave
 			pData->m_pResult->m_Status = CScoreSaveResult::SAVE_SUCCESS;
 			strcpy(pData->m_pResult->m_aBroadcast,
 					"Database connection failed, teamsave written to a file instead. Admins will add it manually in a few days.");
-			str_format(pData->m_pResult->m_aMessage, sizeof(pData->m_pResult->m_aMessage),
-					"Team successfully saved by %s. Use '/load %s' to continue",
-					pData->m_ClientName, Code.Str());
+			if(str_comp(pData->m_Server, g_Config.m_SvSqlServerName) == 0)
+			{
+				str_format(pData->m_pResult->m_aMessage, sizeof(pData->m_pResult->m_aMessage),
+						"Team successfully saved by %s. The database connection failed, using generated save code instead to avoid collisions. Use '/load %s' to continue",
+						pData->m_ClientName, Code.ClrStr());
+			}
+			else
+			{
+				str_format(pData->m_pResult->m_aMessage, sizeof(pData->m_pResult->m_aMessage),
+						"Team successfully saved by %s. The database connection failed, using generated save code instead to avoid collisions. Use '/load %s' on %s to continue",
+						pData->m_ClientName, Code.ClrStr(), pData->m_Server);
+			}
 			return true;
 		}
 		lock_unlock(ms_FailureFileLock);

--- a/src/game/server/score/sql_score.cpp
+++ b/src/game/server/score/sql_score.cpp
@@ -1606,7 +1606,7 @@ bool CSqlScore::SaveTeamThread(CSqlServer* pSqlServer, const CSqlData<CScoreSave
 				str_copy(Code, pData->m_Code, sizeof(Code));
 			}
 		}
-		if(!UseCode)
+		else
 		{
 			// use random generated passphrase if save code exists or no save code given
 			pPrepStmt->setString(1, pData->m_aGeneratedCode);


### PR DESCRIPTION
Fixes #2362, supersedes #2367 

I didn't change the /save message. There are already two different: "Use '/load %s' on %s to continue" and "Use '/load %s' to continue".
I think it would be better to add a NetMessage, this could also solve the problem of saving which team members were in the team.

>  I guess this can't be used to cheat anything?

Only if an instant rehook is necessary. Might be useful for rehooking an edge hook (but you still have to aim).