### PR TITLE
Fix unused translations

### DIFF
--- a/data/languages/belarusian.txt
+++ b/data/languages/belarusian.txt
@@ -1193,3 +1193,6 @@ Indicate map finish
 
 Demo
 == 
+
+Connect Dummy
+== 

--- a/data/languages/bosnian.txt
+++ b/data/languages/bosnian.txt
@@ -1195,3 +1195,6 @@ No updates available
 
 Manual %3d:%02d  
 == 
+
+Connect Dummy
+== 

--- a/data/languages/brazilian_portuguese.txt
+++ b/data/languages/brazilian_portuguese.txt
@@ -1195,3 +1195,6 @@ DecSpeed
 
 IncSpeed
 == 
+
+Connect Dummy
+== 

--- a/data/languages/bulgarian.txt
+++ b/data/languages/bulgarian.txt
@@ -1193,3 +1193,6 @@ AntiPing: predict grenade paths
 
 Markers
 == 
+
+Connect Dummy
+== 

--- a/data/languages/catalan.txt
+++ b/data/languages/catalan.txt
@@ -1182,3 +1182,6 @@ Successfully saved the replay!
 
 Update failed! Check log...
 == 
+
+Connect Dummy
+== 

--- a/data/languages/chuvash.txt
+++ b/data/languages/chuvash.txt
@@ -1196,3 +1196,6 @@ IncSpeed
 
 Enable game sounds
 == 
+
+Connect Dummy
+== 

--- a/data/languages/czech.txt
+++ b/data/languages/czech.txt
@@ -1196,3 +1196,6 @@ Enable replays
 
 Hi o/
 == 
+
+Connect Dummy
+== 

--- a/data/languages/danish.txt
+++ b/data/languages/danish.txt
@@ -1196,3 +1196,6 @@ Replay feature is disabled!
 
 Show only chat messages from friends
 == 
+
+Connect Dummy
+== 

--- a/data/languages/dutch.txt
+++ b/data/languages/dutch.txt
@@ -1208,3 +1208,6 @@ Show score
 
 Markers
 == 
+
+Connect Dummy
+== 

--- a/data/languages/finnish.txt
+++ b/data/languages/finnish.txt
@@ -1197,3 +1197,6 @@ Enable highlighted chat sound
 
 Use OpenGL 3.3 (experimental)
 == 
+
+Connect Dummy
+== 

--- a/data/languages/french.txt
+++ b/data/languages/french.txt
@@ -1204,3 +1204,6 @@ DecSpeed
 
 Gameplay
 == 
+
+Connect Dummy
+== 

--- a/data/languages/german.txt
+++ b/data/languages/german.txt
@@ -1209,3 +1209,6 @@ Video name:
 
 Statboard
 == 
+
+Connect Dummy
+== 

--- a/data/languages/greek.txt
+++ b/data/languages/greek.txt
@@ -1193,3 +1193,6 @@ Pause
 
 Automatically take statboard screenshot
 == 
+
+Connect Dummy
+== 

--- a/data/languages/hungarian.txt
+++ b/data/languages/hungarian.txt
@@ -1195,3 +1195,6 @@ Are you sure that you want to disconnect your dummy?
 
 \xEE\x85\x8B
 == 
+
+Connect Dummy
+== 

--- a/data/languages/italian.txt
+++ b/data/languages/italian.txt
@@ -1202,3 +1202,6 @@ Enable replays
 
 DDNet %s is out!
 == 
+
+Connect Dummy
+== 

--- a/data/languages/japanese.txt
+++ b/data/languages/japanese.txt
@@ -1193,3 +1193,6 @@ Connecting dummy
 
 Old mouse mode
 == 
+
+Connect Dummy
+== 

--- a/data/languages/korean.txt
+++ b/data/languages/korean.txt
@@ -1192,3 +1192,6 @@ Search
 
 We will win
 == 
+
+Connect Dummy
+== 

--- a/data/languages/kyrgyz.txt
+++ b/data/languages/kyrgyz.txt
@@ -1190,3 +1190,6 @@ Preinit VBO (iGPUs only)
 
 Threaded sound loading
 == 
+
+Connect Dummy
+== 

--- a/data/languages/norwegian.txt
+++ b/data/languages/norwegian.txt
@@ -1193,3 +1193,6 @@ Markers:
 
 Max CSVs
 == 
+
+Connect Dummy
+== 

--- a/data/languages/persian.txt
+++ b/data/languages/persian.txt
@@ -1379,3 +1379,6 @@ Show other players' hook collision lines
 
 Disconnect Dummy
 == 
+
+Connect Dummy
+== 

--- a/data/languages/polish.txt
+++ b/data/languages/polish.txt
@@ -1198,3 +1198,6 @@ Replay %3d:%02d
 
 Friend
 == 
+
+Connect Dummy
+== 

--- a/data/languages/portuguese.txt
+++ b/data/languages/portuguese.txt
@@ -1193,3 +1193,6 @@ DDraceNetwork is a cooperative online game where the goal is for you and your gr
 
 Render demo
 == 
+
+Connect Dummy
+== 

--- a/data/languages/romanian.txt
+++ b/data/languages/romanian.txt
@@ -1202,3 +1202,6 @@ Check now
 
 Show votes window after voting
 == 
+
+Connect Dummy
+== 

--- a/data/languages/russian.txt
+++ b/data/languages/russian.txt
@@ -1200,3 +1200,6 @@ Best
 
 Gameplay
 == 
+
+Connect Dummy
+== 

--- a/data/languages/serbian.txt
+++ b/data/languages/serbian.txt
@@ -1195,3 +1195,6 @@ Unfinished map
 
 Wait before try for
 == 
+
+Connect Dummy
+== 

--- a/data/languages/simplified_chinese.txt
+++ b/data/languages/simplified_chinese.txt
@@ -1196,3 +1196,8 @@ Replace video
 
 Video name:
 == 视频名称
+
+### needs translation ###
+
+Connect Dummy
+== 

--- a/data/languages/slovak.txt
+++ b/data/languages/slovak.txt
@@ -1196,3 +1196,6 @@ DecSpeed
 
 FPM
 == 
+
+Connect Dummy
+== 

--- a/data/languages/spanish.txt
+++ b/data/languages/spanish.txt
@@ -1200,3 +1200,6 @@ Show tiles layers from BG map
 
 9+ new mentions
 == 
+
+Connect Dummy
+== 

--- a/data/languages/swedish.txt
+++ b/data/languages/swedish.txt
@@ -1194,7 +1194,10 @@ Team message
 == Lag meddelande
 
 File already exists, do you want to overwrite it?
-== Fil finns redan, vill du skriv över den?
+== Filen finns redan, vill du skriv över den?
 
 Hook collisions
 == Hook kollisioner
+
+Connect Dummy
+== Anslut Dummy

--- a/data/languages/traditional_chinese.txt
+++ b/data/languages/traditional_chinese.txt
@@ -1191,3 +1191,6 @@ Show entities
 
 Dummy copy
 == 
+
+Connect Dummy
+== 

--- a/data/languages/turkish.txt
+++ b/data/languages/turkish.txt
@@ -1198,3 +1198,6 @@ Outline color
 
 %.2f KiB
 == 
+
+Connect Dummy
+== 

--- a/data/languages/ukrainian.txt
+++ b/data/languages/ukrainian.txt
@@ -1193,3 +1193,6 @@ Vote description:
 
 Skin prefix
 == 
+
+Connect Dummy
+== 

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -136,7 +136,7 @@ void CMenus::RenderGame(CUIRect MainView)
 	{
 		DoButton_Menu(&s_DummyButton, Localize("Connecting dummy"), 1, &Button);
 	}
-	else if(DoButton_Menu(&s_DummyButton, Localize(Client()->DummyConnected() ? "Disconnect dummy" : "Connect dummy"), 0, &Button))
+	else if(DoButton_Menu(&s_DummyButton, Localize(Client()->DummyConnected() ? "Disconnect Dummy" : "Connect Dummy"), 0, &Button))
 	{
 		if(!Client()->DummyConnected())
 		{

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -136,7 +136,7 @@ void CMenus::RenderGame(CUIRect MainView)
 	{
 		DoButton_Menu(&s_DummyButton, Localize("Connecting dummy"), 1, &Button);
 	}
-	else if(DoButton_Menu(&s_DummyButton, Localize(Client()->DummyConnected() ? "Disconnect Dummy" : "Connect Dummy"), 0, &Button))
+	else if(DoButton_Menu(&s_DummyButton, Client()->DummyConnected() ? Localize("Disconnect Dummy") : Localize("Connect Dummy"), 0, &Button))
 	{
 		if(!Client()->DummyConnected())
 		{


### PR DESCRIPTION
Fix so that "Connect Dummy" and "Disconnect Dummy" follows language file