### PR TITLE
Fix /save on solo server

### DIFF
--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -570,7 +570,7 @@ void CGameContext::ConPractice(IConsole::IResult *pResult, void *pUserData)
 
 	int Team = Teams.m_Core.Team(pResult->m_ClientID);
 
-	if(Team <= TEAM_FLOCK || Team >= TEAM_SUPER)
+	if(Team < TEAM_FLOCK || (Team == TEAM_FLOCK && g_Config.m_SvTeam == 3) || Team >= TEAM_SUPER)
 	{
 		pSelf->Console()->Print(
 				IConsole::OUTPUT_LEVEL_STANDARD,
@@ -802,6 +802,13 @@ void CGameContext::ConUnlockTeam(IConsole::IResult *pResult, void *pUserData)
 	CGameContext *pSelf = (CGameContext *) pUserData;
 	if (!CheckClientID(pResult->m_ClientID))
 		return;
+
+	if(g_Config.m_SvTeam == 0 || g_Config.m_SvTeam == 3)
+	{
+		pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "unlock",
+				"Teams are disabled");
+		return;
+	}
 
 	int Team = ((CGameControllerDDRace*) pSelf->m_pController)->m_Teams.m_Core.Team(pResult->m_ClientID);
 

--- a/src/game/server/ddracecommands.cpp
+++ b/src/game/server/ddracecommands.cpp
@@ -658,6 +658,13 @@ void CGameContext::ConSetDDRTeam(IConsole::IResult *pResult, void *pUserData)
 	CGameContext *pSelf = (CGameContext *)pUserData;
 	CGameControllerDDRace *pController = (CGameControllerDDRace *)pSelf->m_pController;
 
+	if(g_Config.m_SvTeam == 0 || g_Config.m_SvTeam == 3)
+	{
+		pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "join",
+				"Teams are disabled");
+		return;
+	}
+
 	int Target = pResult->GetVictim();
 	int Team = pResult->GetInteger(1);
 

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -1910,7 +1910,7 @@ void CCharacter::HandleTiles(int Index)
 
 		m_StartTime -= (min * 60 + sec) * Server()->TickSpeed();
 
-		if (Team != TEAM_FLOCK && Team != TEAM_SUPER)
+		if ((g_Config.m_SvTeam == 3 || Team != TEAM_FLOCK) && Team != TEAM_SUPER)
 		{
 			for (int i = 0; i < MAX_CLIENTS; i++)
 			{
@@ -1936,7 +1936,7 @@ void CCharacter::HandleTiles(int Index)
 		if (m_StartTime > Server()->Tick())
 			m_StartTime = Server()->Tick();
 
-		if (Team != TEAM_FLOCK && Team != TEAM_SUPER)
+		if ((g_Config.m_SvTeam == 3 || Team != TEAM_FLOCK) && Team != TEAM_SUPER)
 		{
 			for (int i = 0; i < MAX_CLIENTS; i++)
 			{
@@ -2187,7 +2187,10 @@ void CCharacter::DDRaceTick()
 	HandleTuneLayer(); // need this before coretick
 
 	// look for save position for rescue feature
-	if(g_Config.m_SvRescue || (Team() > TEAM_FLOCK && Team() < TEAM_SUPER)) {
+	if(g_Config.m_SvRescue
+			|| ((g_Config.m_SvTeam == 3 || Team() > TEAM_FLOCK)
+					&& Team() >= TEAM_FLOCK
+					&& Team() < TEAM_SUPER)) {
 		int index = GameServer()->Collision()->GetPureMapIndex(m_Pos);
 		int tile = GameServer()->Collision()->GetTileIndex(index);
 		int ftile = GameServer()->Collision()->GetFTileIndex(index);

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -2971,6 +2971,21 @@ void CGameContext::OnInit(/*class IKernel *pKernel*/)
 
 	m_MapBugs.Dump();
 
+	if(g_Config.m_SvSoloServer)
+	{
+		g_Config.m_SvTeam = 3;
+		g_Config.m_SvShowOthersDefault = 1;
+
+		Tuning()->Set("player_collision", 0);
+		Tuning()->Set("player_hooking", 0);
+
+		for (int i = 0; i < NUM_TUNEZONES; i++)
+		{
+			TuningList()[i].Set("player_collision", 0);
+			TuningList()[i].Set("player_hooking", 0);
+		}
+	}
+
 	m_pController = new CGameControllerDDRace(this);
 	((CGameControllerDDRace*)m_pController)->m_Teams.Reset();
 
@@ -3033,21 +3048,6 @@ void CGameContext::OnInit(/*class IKernel *pKernel*/)
 			{
 				m_TeeHistorian.RecordAuthInitial(i, Level, Server()->GetAuthName(i));
 			}
-		}
-	}
-
-	if(g_Config.m_SvSoloServer)
-	{
-		g_Config.m_SvTeam = 3;
-		g_Config.m_SvShowOthersDefault = 1;
-
-		Tuning()->Set("player_collision", 0);
-		Tuning()->Set("player_hooking", 0);
-
-		for (int i = 0; i < NUM_TUNEZONES; i++)
-		{
-			TuningList()[i].Set("player_collision", 0);
-			TuningList()[i].Set("player_hooking", 0);
 		}
 	}
 

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -479,7 +479,8 @@ void CPlayer::OnDisconnect(const char *pReason)
 	}
 
 	CGameControllerDDRace* Controller = (CGameControllerDDRace*)GameServer()->m_pController;
-	Controller->m_Teams.SetForceCharacterTeam(m_ClientID, 0);
+	if(g_Config.m_SvTeam != 3)
+		Controller->m_Teams.SetForceCharacterTeam(m_ClientID, TEAM_FLOCK);
 }
 
 void CPlayer::OnPredictedInput(CNetObj_PlayerInput *NewInput)
@@ -618,7 +619,8 @@ void CPlayer::SetTeam(int Team, bool DoChatMsg)
 	if(Team == TEAM_SPECTATORS)
 	{
 		CGameControllerDDRace* Controller = (CGameControllerDDRace*)GameServer()->m_pController;
-		Controller->m_Teams.SetForceCharacterTeam(m_ClientID, 0);
+		if(g_Config.m_SvTeam != 3)
+			Controller->m_Teams.SetForceCharacterTeam(m_ClientID, TEAM_FLOCK);
 	}
 
 	KillCharacter();
@@ -703,8 +705,6 @@ void CPlayer::TryRespawn()
 	if(!GameServer()->m_pController->CanSpawn(m_Team, &SpawnPos))
 		return;
 
-	CGameControllerDDRace* Controller = (CGameControllerDDRace*)GameServer()->m_pController;
-
 	m_WeakHookSpawn = false;
 	m_Spawning = false;
 	m_pCharacter = new(m_ClientID) CCharacter(&GameServer()->m_World);
@@ -712,18 +712,7 @@ void CPlayer::TryRespawn()
 	GameServer()->CreatePlayerSpawn(SpawnPos, m_pCharacter->Teams()->TeamMask(m_pCharacter->Team(), -1, m_ClientID));
 
 	if(g_Config.m_SvTeam == 3)
-	{
-		int NewTeam = 1;
-		for(; NewTeam < TEAM_SUPER; NewTeam++)
-			if(Controller->m_Teams.Count(NewTeam) == 0)
-				break;
-
-		if(NewTeam == TEAM_SUPER)
-			NewTeam = 0;
-
-		Controller->m_Teams.SetForceCharacterTeam(GetCID(), NewTeam);
 		m_pCharacter->SetSolo(true);
-	}
 }
 
 bool CPlayer::AfkTimer(int NewTargetX, int NewTargetY)

--- a/src/game/server/score/sql_score.cpp
+++ b/src/game/server/score/sql_score.cpp
@@ -1687,7 +1687,7 @@ void CSqlScore::LoadTeam(const char* Code, int ClientID)
 	int Team = pController->m_Teams.m_Core.Team(ClientID);
 	if(pController->m_Teams.GetSaving(Team))
 		return;
-	if(Team <= 0 || Team >= MAX_CLIENTS)
+	if(Team < TEAM_FLOCK || Team >= MAX_CLIENTS || (g_Config.m_SvTeam != 3 && Team == TEAM_FLOCK))
 	{
 		GameServer()->SendChatTarget(ClientID, "You have to be in a team (from 1-63)");
 		return;

--- a/src/game/server/teams.h
+++ b/src/game/server/teams.h
@@ -2,6 +2,7 @@
 #ifndef GAME_SERVER_TEAMS_H
 #define GAME_SERVER_TEAMS_H
 
+#include <engine/shared/config.h>
 #include <game/teamscore.h>
 #include <game/server/gamecontext.h>
 
@@ -123,7 +124,9 @@ public:
 
 	bool GetSaving(int TeamID)
 	{
-		if(TeamID <= TEAM_FLOCK || TeamID >= TEAM_SUPER)
+		if(TeamID < TEAM_FLOCK || TeamID >= TEAM_SUPER)
+			return false;
+		if(g_Config.m_SvTeam != 3 && TeamID == TEAM_FLOCK)
 			return false;
 
 		return m_pSaveTeamResult[TeamID] != nullptr;
@@ -131,7 +134,9 @@ public:
 
 	void EnablePractice(int Team)
 	{
-		if(Team <= TEAM_FLOCK || Team >= TEAM_SUPER)
+		if(Team < TEAM_FLOCK || Team >= TEAM_SUPER)
+			return;
+		if(g_Config.m_SvTeam != 3 && Team == TEAM_FLOCK)
 			return;
 
 		m_Practice[Team] = true;
@@ -139,7 +144,9 @@ public:
 
 	bool IsPractice(int Team)
 	{
-		if(Team <= TEAM_FLOCK || Team >= TEAM_SUPER)
+		if(Team < TEAM_FLOCK || Team >= TEAM_SUPER)
+			return false;
+		if(g_Config.m_SvTeam != 3 && Team == TEAM_FLOCK)
 			return false;
 
 		return m_Practice[Team];

--- a/src/game/teamscore.cpp
+++ b/src/game/teamscore.cpp
@@ -45,7 +45,10 @@ void CTeamsCore::Reset()
 
 	for (int i = 0; i < MAX_CLIENTS; ++i)
 	{
-		m_Team[i] = TEAM_FLOCK;
+		if(g_Config.m_SvTeam == 3)
+			m_Team[i] = i;
+		else
+			m_Team[i] = TEAM_FLOCK;
 		m_IsSolo[i] = false;
 	}
 }

--- a/src/game/teamscore.h
+++ b/src/game/teamscore.h
@@ -2,6 +2,7 @@
 #ifndef GAME_TEAMSCORE_H
 #define GAME_TEAMSCORE_H
 
+#include <engine/shared/config.h>
 #include <engine/shared/protocol.h>
 
 enum


### PR DESCRIPTION
Fixes #2404

The save code expected the tee to stay in the same team when the character is killed (and not explicitly moved out of the team). With this change ClientID always matches the TeamID on solo servers. Therefore on solo servers no special treatment of team 0 == TEAM_FLOCK is needed