### PR TITLE
Suppress open_link output

### DIFF
--- a/src/base/system.c
+++ b/src/base/system.c
@@ -3254,7 +3254,7 @@ int open_link(const char *link)
 	str_format(aBuf, sizeof(aBuf), "start %s", link);
 	return (uintptr_t)ShellExecuteA(NULL, "open", link, NULL, NULL, SW_SHOWDEFAULT) > 32;
 #elif defined(CONF_PLATFORM_LINUX)
-	str_format(aBuf, sizeof(aBuf), "xdg-open %s &", link);
+    str_format(aBuf, sizeof(aBuf), "xdg-open %s >/dev/null 2>&1 &", link);
 	return system(aBuf) == 0;
 #elif defined(CONF_FAMILY_UNIX)
 	str_format(aBuf, sizeof(aBuf), "open %s &", link);

--- a/src/base/system.c
+++ b/src/base/system.c
@@ -3254,7 +3254,7 @@ int open_link(const char *link)
 	str_format(aBuf, sizeof(aBuf), "start %s", link);
 	return (uintptr_t)ShellExecuteA(NULL, "open", link, NULL, NULL, SW_SHOWDEFAULT) > 32;
 #elif defined(CONF_PLATFORM_LINUX)
-    str_format(aBuf, sizeof(aBuf), "xdg-open %s >/dev/null 2>&1 &", link);
+	str_format(aBuf, sizeof(aBuf), "xdg-open %s >/dev/null 2>&1 &", link);
 	return system(aBuf) == 0;
 #elif defined(CONF_FAMILY_UNIX)
 	str_format(aBuf, sizeof(aBuf), "open %s &", link);


### PR DESCRIPTION
Fixes so that Firefox and other browsers wont output warnings