### PR TITLE
Fix storing finish on solo server with practice mode enabled

### DIFF
--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -147,8 +147,7 @@ void CGameTeams::OnCharacterStart(int ClientID)
 
 void CGameTeams::OnCharacterFinish(int ClientID)
 {
-	if (m_Core.Team(ClientID) == TEAM_FLOCK
-			|| g_Config.m_SvTeam == 3
+	if((m_Core.Team(ClientID) == TEAM_FLOCK && g_Config.m_SvTeam != 3)
 			|| m_Core.Team(ClientID) == TEAM_SUPER)
 	{
 		CPlayer* pPlayer = GetPlayer(ClientID);


### PR DESCRIPTION
Fixes #2445 
vulnerable versions: 
* 506602d472c48821b6e7bb846b86431a113834a1..59a7e1f1873ad58b838cd3470d51b6ba84c02926~
* b99bbccd248437c928b25e32d40deaf98d8ef3ad..4186622d8750f4288be86b9064886a86c665c45d~

Problem was that `OnFinish` is only suited for team0 finishes, where `/practice` can't be enabled. Solo server finishes have to be handled like team finishes in CheckTeamFinished, which checks if `/practice` was enabled.