### PR TITLE
Fix uninitialised values in sixup differently (fixes #2421)

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -273,7 +273,7 @@ CServer::CServer(): m_Register(false), m_RegSixup(true)
 	m_pGameServer = 0;
 
 	m_CurrentGameTick = 0;
-	m_RunServer = 1;
+	m_RunServer = UNINITIALIZED;
 
 	for(int i = 0; i < 2; i++)
 	{
@@ -2075,6 +2075,9 @@ void CServer::ExpireServerInfo()
 
 void CServer::UpdateServerInfo(bool Resend)
 {
+	if(m_RunServer == UNINITIALIZED)
+		return;
+
 	for(int i = 0; i < 3; i++)
 		for(int j = 0; j < 2; j++)
 			CacheServerInfo(&m_ServerInfoCache[i * 2 + j], i, j);
@@ -2292,6 +2295,9 @@ void CServer::InitRegister(CNetServer *pNetServer, IEngineMasterServer *pMasterS
 
 int CServer::Run()
 {
+	if(m_RunServer == UNINITIALIZED)
+		m_RunServer = RUNNING;
+
 	m_AuthManager.Init();
 
 	if(g_Config.m_Debug)
@@ -2351,7 +2357,7 @@ int CServer::Run()
 	GameServer()->OnInit();
 	if(ErrorShutdown())
 	{
-		m_RunServer = false;
+		m_RunServer = STOPPING;
 	}
 	str_format(aBuf, sizeof(aBuf), "version %s", GameServer()->NetVersion());
 	Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "server", aBuf);
@@ -2374,7 +2380,7 @@ int CServer::Run()
 		m_GameStartTime = time_get();
 
 		UpdateServerInfo();
-		while(m_RunServer)
+		while(m_RunServer < STOPPING)
 		{
 			if(NonActive)
 				PumpNetwork();
@@ -2549,7 +2555,7 @@ int CServer::Run()
 				}
 
 				if(g_Config.m_SvShutdownWhenEmpty)
-					m_RunServer = false;
+					m_RunServer = STOPPING;
 				else
 					net_socket_read_wait(m_NetServer.Socket(), 1000000);
 			}
@@ -2960,7 +2966,7 @@ void CServer::ConNameBans(IConsole::IResult *pResult, void *pUser)
 
 void CServer::ConShutdown(IConsole::IResult *pResult, void *pUser)
 {
-	((CServer *)pUser)->m_RunServer = 0;
+	((CServer *)pUser)->m_RunServer = STOPPING;
 }
 
 void CServer::DemoRecorder_HandleAutoStart()

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -221,7 +221,16 @@ public:
 
 	int64 m_GameStartTime;
 	//int m_CurrentGameTick;
+
+	enum
+	{
+		UNINITIALIZED=0,
+		RUNNING=1,
+		STOPPING=2
+	};
+
 	int m_RunServer;
+
 	int m_MapReload;
 	bool m_ReloadedWhenEmpty;
 	int m_RconClientID;


### PR DESCRIPTION
"./DDNet-Server shutdown" still works