### PR TITLE
Don't request IUpdater interface when built without updater

### DIFF
--- a/src/game/client/component.h
+++ b/src/game/client/component.h
@@ -32,7 +32,9 @@ protected:
 	class IServerBrowser *ServerBrowser() const { return m_pClient->ServerBrowser(); }
 	class CLayers *Layers() const { return m_pClient->Layers(); }
 	class CCollision *Collision() const { return m_pClient->Collision(); }
+#if defined(CONF_AUTOUPDATE)
 	class IUpdater *Updater() const { return m_pClient->Updater(); }
+#endif
 
 #if defined(CONF_VIDEORECORDER)
 	int64 time() const { return IVideo::Current() ? IVideo::Time() : time_get(); }

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -130,7 +130,7 @@ void CGameClient::OnConsoleInit()
 	m_pEditor = Kernel()->RequestInterface<IEditor>();
 	m_pFriends = Kernel()->RequestInterface<IFriends>();
 	m_pFoes = Client()->Foes();
-#if defined(CONF_FAMILY_WINDOWS) || defined(CONF_PLATFORM_LINUX)
+#if defined(CONF_AUTOUPDATE)
 	m_pUpdater = Kernel()->RequestInterface<IUpdater>();
 #endif
 

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -89,7 +89,9 @@ class CGameClient : public IGameClient
 	class IEditor *m_pEditor;
 	class IFriends *m_pFriends;
 	class IFriends *m_pFoes;
+#if defined(CONF_AUTOUPDATE)
 	class IUpdater *m_pUpdater;
+#endif
 
 	CLayers m_Layers;
 	class CCollision m_Collision;
@@ -140,7 +142,9 @@ public:
 	class IEditor *Editor() { return m_pEditor; }
 	class IFriends *Friends() { return m_pFriends; }
 	class IFriends *Foes() { return m_pFoes; }
+#if defined(CONF_AUTOUPDATE)
 	class IUpdater *Updater() { return m_pUpdater; }
+#endif
 
 	int NetobjNumCorrections() { return m_NetObjHandler.NumObjCorrections(); }
 	const char *NetobjCorrectedOn() { return m_NetObjHandler.CorrectedObjOn(); }


### PR DESCRIPTION
Fixes warning:

[kernel]: failed to find interface with the name 'updater'