### PR TITLE
Improved dummy switching

### DIFF
--- a/src/engine/client.h
+++ b/src/engine/client.h
@@ -221,6 +221,7 @@ public:
 	virtual void OnRconType(bool UsernameReq) = 0;
 	virtual void OnRconLine(const char *pLine) = 0;
 	virtual void OnInit() = 0;
+	virtual void InvalidateSnapshot() = 0;
 	virtual void OnNewSnapshot() = 0;
 	virtual void OnEnterGame() = 0;
 	virtual void OnShutdown() = 0;

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -186,7 +186,6 @@ class CClient : public IClient, public CDemoPlayer::IListener
 
 	int m_CurrentInput[2];
 	bool m_LastDummy;
-	bool m_LastDummy2;
 	bool m_DummySendConnInfo;
 
 	// graphs

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -511,10 +511,10 @@ void CGameClient::OnConnected()
 
 void CGameClient::OnReset()
 {
-	// clear out the invalid pointers
 	m_LastNewPredictedTick[0] = -1;
 	m_LastNewPredictedTick[1] = -1;
-	mem_zero(&g_GameClient.m_Snap, sizeof(g_GameClient.m_Snap));
+
+	InvalidateSnapshot();
 
 	for(int i = 0; i < MAX_CLIENTS; i++)
 		m_aClients[i].Reset();
@@ -1084,13 +1084,18 @@ static CGameInfo GetGameInfo(const CNetObj_GameInfoEx *pInfoEx, int InfoExSize, 
 	return Info;
 }
 
-void CGameClient::OnNewSnapshot()
+void CGameClient::InvalidateSnapshot()
 {
-	m_NewTick = true;
-
-	// clear out the invalid pointers
+	// clear all pointers
 	mem_zero(&g_GameClient.m_Snap, sizeof(g_GameClient.m_Snap));
 	m_Snap.m_LocalClientID = -1;
+}
+
+void CGameClient::OnNewSnapshot()
+{
+	InvalidateSnapshot();
+
+	m_NewTick = true;
 
 	// secure snapshot
 	{

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -346,6 +346,7 @@ public:
 	virtual void OnConsoleInit();
 	virtual void OnStateChange(int NewState, int OldState);
 	virtual void OnMessage(int MsgId, CUnpacker *pUnpacker, bool IsDummy = 0);
+	virtual void InvalidateSnapshot();
 	virtual void OnNewSnapshot();
 	virtual void OnPredict();
 	virtual void OnActivateEditor();


### PR DESCRIPTION
- Fix a use-after-free when there are no new snapshots for the cl_dummy tee after the switch: #2499 .
- When one of the tees is hooked, cycling through them will no longer show phantom hook for the other tee: https://youtu.be/mxVT4pdyGnU.
- Dummy switch might happen a bit quicker since it doesn't depend on receiving new snapshots.
- Simplified code: m_LastDummy2 is no more.

