### PR TITLE
Keep hook after load

### DIFF
--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -41,6 +41,7 @@ bool CCharacter::Spawn(CPlayer *pPlayer, vec2 Pos)
 	m_LastRefillJumps = false;
 	m_LastPenalty = false;
 	m_LastBonus = false;
+	m_KeepHookAfterLoad = false;
 
 	m_TeleGunTeleport = false;
 	m_IsBlueTeleGunTeleport = false;
@@ -2161,6 +2162,13 @@ void CCharacter::SetRescue()
 void CCharacter::DDRaceTick()
 {
 	mem_copy(&m_Input, &m_SavedInput, sizeof(m_Input));
+	if(m_KeepHookAfterLoad)
+	{
+		if(m_Input.m_Hook != 0)
+			m_KeepHookAfterLoad = false;
+		else
+			m_Input.m_Hook = 1;
+	}
 	m_Armor=(m_FreezeTime >= 0)?10-(m_FreezeTime/15):0;
 	if(m_Input.m_Direction != 0 || m_Input.m_Jump != 0)
 		m_LastMove = Server()->Tick();
@@ -2424,7 +2432,7 @@ void CCharacter::Rescue()
 		if((m_SavedInput.m_Fire&1) != 0)
 			m_SavedInput.m_Fire++;
 		m_SavedInput.m_Fire &= INPUT_STATE_MASK;
-		m_SavedInput.m_Hook = 0;
+		m_KeepHookAfterLoad = false;
 		m_pPlayer->Pause(CPlayer::PAUSE_NONE, true);
 	}
 }

--- a/src/game/server/entities/character.h
+++ b/src/game/server/entities/character.h
@@ -140,6 +140,7 @@ private:
 	CNetObj_PlayerInput m_SavedInput;
 	int m_NumInputs;
 	int m_Jumped;
+	bool m_KeepHookAfterLoad;
 
 	int m_DamageTakenTick;
 

--- a/src/game/server/save.cpp
+++ b/src/game/server/save.cpp
@@ -194,7 +194,7 @@ void CSaveTee::load(CCharacter *pChr, int Team)
 	pChr->m_SavedInput.m_Direction = m_InputDirection;
 	pChr->m_SavedInput.m_Jump = m_InputJump;
 	pChr->m_SavedInput.m_Fire = m_InputFire;
-	pChr->m_SavedInput.m_Hook = m_InputHook;
+	pChr->m_KeepHookAfterLoad = m_InputHook;
 
 	pChr->m_ReloadTimer = m_ReloadTimer;
 


### PR DESCRIPTION
Provides a fix for #2507 on the server side. The client shows no hook, as it sends the server to release the hook (`Input.m_Hook = 0`). Made a demo how it currently looks:

![client_demo](https://user-images.githubusercontent.com/9964758/87352493-65de8880-c55b-11ea-88cd-fb71cd262c44.gif)

Looks a bit ugly in the client :/ (sorry for the gif, experimented a bit with video recording and editing)