### PR TITLE
Fix utf8 handling in str_truncate (fixes #2533)

### DIFF
--- a/src/base/system.c
+++ b/src/base/system.c
@@ -2319,10 +2319,12 @@ void str_copy(char *dst, const char *src, int dst_size)
 	dst[dst_size-1] = 0; /* assure null termination */
 }
 
-void str_truncate(char *dst, int dst_size, const char *src, int truncation_len)
+void str_utf8_truncate(char *dst, int dst_size, const char *src, int truncation_len)
 {
-	int size = truncation_len >= dst_size ? dst_size : truncation_len + 1;
-	str_copy(dst, src, size);
+	int size = -1;
+	for(int cursor = 0, pos = 0; pos <= truncation_len && cursor < dst_size && size != cursor; cursor = str_utf8_forward(src, cursor), pos++)
+		size = cursor;
+	str_copy(dst, src, size+1);
 }
 
 int str_length(const char *str)

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -997,21 +997,20 @@ void str_append(char *dst, const char *src, int dst_size);
 void str_copy(char *dst, const char *src, int dst_size);
 
 /*
-	Function: str_truncate
-		Truncates a string to a given length.
+	Function: str_utf8_truncate
+		Truncates a utf8 encoded string to a given length.
 
 	Parameters:
 		dst - Pointer to a buffer that shall receive the string.
 		dst_size - Size of the buffer dst.
 		str - String to be truncated.
-		truncation_len - Maximum length of the returned string (not
-		counting the zero termination).
+		truncation_len - Maximum codepoints in the returned string.
 
 	Remarks:
-		- The strings are treated as zero-terminated strings.
+		- The strings are treated as utf8-encoded zero-terminated strings.
 		- Guarantees that dst string will contain zero-termination.
 */
-void str_truncate(char *dst, int dst_size, const char *src, int truncation_len);
+void str_utf8_truncate(char *dst, int dst_size, const char *src, int truncation_len);
 
 /*
 	Function: str_length

--- a/src/game/client/components/scoreboard.cpp
+++ b/src/game/client/components/scoreboard.cpp
@@ -201,16 +201,10 @@ void CScoreboard::RenderScoreboard(float x, float y, float w, int Team, const ch
 			pTitle = Localize("Game over");
 		else
 		{
-			if(str_length(Client()->GetCurrentMap()) > 16)
-			{
-				str_truncate(aBuf, sizeof(aBuf), Client()->GetCurrentMap(), 16);
-				str_append(aBuf, "...", sizeof(aBuf));
-				pTitle = aBuf;
-			}
-			else
-			{
-				pTitle = Client()->GetCurrentMap();
-			}
+			str_utf8_truncate(aBuf, sizeof(aBuf), Client()->GetCurrentMap(), 16);
+			if(str_comp(aBuf, Client()->GetCurrentMap()))
+				str_append(aBuf, "…", sizeof(aBuf));
+			pTitle = aBuf;
 		}
 	}
 	TextRender()->Text(0, x + 20.0f, y + (50.f - TitleFontsize) / 2.f, TitleFontsize, pTitle, -1.0f);

--- a/src/game/client/components/statboard.cpp
+++ b/src/game/client/components/statboard.cpp
@@ -85,7 +85,7 @@ void CStatboard::OnMessage(int MsgType, void *pRawMsg)
 
 				if(t <= p)
 					return;
-				str_truncate(aName, sizeof(aName), p, t - p);
+				str_utf8_truncate(aName, sizeof(aName), p, t - p);
 
 				for(int i = 0; i < MAX_CLIENTS; i++)
 				{

--- a/src/test/str.cpp
+++ b/src/test/str.cpp
@@ -188,14 +188,23 @@ TEST(Str, StrFormat)
 
 TEST(Str, StrCopyNum)
 {
-	const char *foo = "Foobar";
+	const char *foo = "Foobaré";
 	char aBuf[64];
-	str_truncate(aBuf, 3, foo, 1);
+	str_utf8_truncate(aBuf, 3, foo, 1);
 	EXPECT_STREQ(aBuf, "F");
-	str_truncate(aBuf, 3, foo, 2);
+	str_utf8_truncate(aBuf, 3, foo, 2);
 	EXPECT_STREQ(aBuf, "Fo");
-	str_truncate(aBuf, 3, foo, 3);
+	str_utf8_truncate(aBuf, 3, foo, 3);
 	EXPECT_STREQ(aBuf, "Fo");
-	str_truncate(aBuf, sizeof(aBuf), foo, 6);
+	str_utf8_truncate(aBuf, sizeof(aBuf), foo, 6);
 	EXPECT_STREQ(aBuf, "Foobar");
+	str_utf8_truncate(aBuf, sizeof(aBuf), foo, 7);
+	EXPECT_STREQ(aBuf, "Foobaré");
+
+	char aBuf2[8];
+	str_utf8_truncate(aBuf2, sizeof(aBuf2), foo, 7);
+	EXPECT_STREQ(aBuf2, "Foobar");
+	char aBuf3[9];
+	str_utf8_truncate(aBuf3, sizeof(aBuf3), foo, 7);
+	EXPECT_STREQ(aBuf3, "Foobaré");
 }


### PR DESCRIPTION
and rename to str_utf8_truncate since it's only used for utf8 strings