### PR TITLE
Flag afk when player timed-out

### DIFF
--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -220,6 +220,8 @@ void CPlayer::Tick()
 
 	if(Server()->GetNetErrorString(m_ClientID)[0])
 	{
+		m_Afk = true;
+
 		char aBuf[512];
 		str_format(aBuf, sizeof(aBuf), "'%s' would have timed out, but can use timeout protection now", Server()->ClientName(m_ClientID));
 		GameServer()->SendChat(-1, CGameContext::CHAT_ALL, aBuf);


### PR DESCRIPTION
Timed out players kills entire team especially on t0 maps. So i just thought we can flag them as afk.