### PR TITLE
Fix the same token being generated for each client

### DIFF
--- a/src/engine/shared/network_server.cpp
+++ b/src/engine/shared/network_server.cpp
@@ -147,7 +147,7 @@ SECURITY_TOKEN CNetServer::GetToken(const NETADDR &Addr)
 	SHA256_CTX Sha256;
 	sha256_init(&Sha256);
 	sha256_update(&Sha256, (unsigned char*)m_SecurityTokenSeed, sizeof(m_SecurityTokenSeed));
-	sha256_update(&Sha256, (unsigned char*)&Addr, sizeof(20)); //omit port, bad idea?
+	sha256_update(&Sha256, (unsigned char*)&Addr, 20); // omit port, bad idea!
 
 	SECURITY_TOKEN SecurityToken = ToSecurityToken(sha256_finish(&Sha256).data);
 


### PR DESCRIPTION
Theoretically, a regression test would be nice here, but we don't really
have the infrastructure…

This fixes a spoofing vulnerability.