### PR TITLE
Remove incorrect check when inserting team ranks

### DIFF
--- a/src/game/server/score.cpp
+++ b/src/game/server/score.cpp
@@ -586,7 +586,7 @@ bool CScore::SaveTeamScoreThread(IDbConnection *pSqlServer, const ISqlData *pGam
 					"FROM %s_teamrace "
 					"WHERE Map = ? AND Name = ? AND DDNet7 = false"
 			") as l INNER JOIN %s_teamrace AS r ON l.ID = r.ID "
-			"ORDER BY l.ID, Name ",
+			"ORDER BY l.ID, Name;",
 			pSqlServer->GetPrefix(), pSqlServer->GetPrefix());
 	pSqlServer->PrepareStatement(aBuf);
 	pSqlServer->BindString(1, pData->m_Map);
@@ -602,13 +602,6 @@ bool CScore::SaveTeamScoreThread(IDbConnection *pSqlServer, const ISqlData *pGam
 		{
 			Time = pSqlServer->GetFloat(3);
 			SearchTeam = Teamrank.NextSqlResult(pSqlServer);
-			if(str_comp(Teamrank.m_aaNames[0], aNames[0].c_str()) != 0)
-			{
-				dbg_msg("sql", "insert team rank logic error: "
-						"first team member from sql (%s) should be first name in array (%s), "
-						"because both are sorted by binary values", Teamrank.m_aaNames[0], aNames[0].c_str());
-				return false;
-			}
 			if(Teamrank.SamePlayers(&aNames))
 			{
 				FoundTeam = true;


### PR DESCRIPTION
Can be reliable reproduced by finishing in this sequence:

1. A, B
2. A, C
3. B, C <- triggers error

Fixes #2568