### PR TITLE
Sort servers by a combination of players and ping as default

### DIFF
--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -155,6 +155,19 @@ bool CServerBrowser::SortCompareNumClients(int Index1, int Index2) const
 	return a->m_Info.m_NumClients < b->m_Info.m_NumClients;
 }
 
+bool CServerBrowser::SortCompareNumPlayersAndPing(int Index1, int Index2) const
+{
+	CServerEntry *a = m_ppServerlist[Index1];
+	CServerEntry *b = m_ppServerlist[Index2];
+
+	if(a->m_Info.m_NumFilteredPlayers == b->m_Info.m_NumFilteredPlayers)
+		return a->m_Info.m_Latency > b->m_Info.m_Latency;
+	if(a->m_Info.m_NumFilteredPlayers == 0 || b->m_Info.m_NumFilteredPlayers == 0)
+		return a->m_Info.m_NumFilteredPlayers == 0;
+	else
+		return a->m_Info.m_NumFilteredPlayers - (a->m_Info.m_Latency/100)*MAX_CLIENTS < b->m_Info.m_NumFilteredPlayers - (b->m_Info.m_Latency/100)*MAX_CLIENTS;
+}
+
 void CServerBrowser::Filter()
 {
 	int i = 0, p = 0;
@@ -322,13 +335,13 @@ int CServerBrowser::SortHash() const
 	i |= g_Config.m_BrFilterFriends<<7;
 	i |= g_Config.m_BrFilterPw<<8;
 	i |= g_Config.m_BrSortOrder<<9;
-	i |= g_Config.m_BrFilterCompatversion<<10;
-	i |= g_Config.m_BrFilterPure<<11;
-	i |= g_Config.m_BrFilterPureMap<<12;
-	i |= g_Config.m_BrFilterGametypeStrict<<13;
-	i |= g_Config.m_BrFilterUnfinishedMap<<14;
-	i |= g_Config.m_BrFilterCountry<<15;
-	i |= g_Config.m_BrFilterConnectingPlayers<<16;
+	i |= g_Config.m_BrFilterCompatversion<<11;
+	i |= g_Config.m_BrFilterPure<<12;
+	i |= g_Config.m_BrFilterPureMap<<13;
+	i |= g_Config.m_BrFilterGametypeStrict<<14;
+	i |= g_Config.m_BrFilterUnfinishedMap<<15;
+	i |= g_Config.m_BrFilterCountry<<16;
+	i |= g_Config.m_BrFilterConnectingPlayers<<17;
 	return i;
 }
 
@@ -364,7 +377,9 @@ void CServerBrowser::Sort()
 	Filter();
 
 	// sort
-	if(g_Config.m_BrSort == IServerBrowser::SORT_NAME)
+	if(g_Config.m_BrSortOrder == 2 && (g_Config.m_BrSort == IServerBrowser::SORT_NUMPLAYERS ||g_Config.m_BrSort == IServerBrowser::SORT_PING))
+		std::stable_sort(m_pSortedServerlist, m_pSortedServerlist+m_NumSortedServers, SortWrap(this, &CServerBrowser::SortCompareNumPlayersAndPing));
+	else if(g_Config.m_BrSort == IServerBrowser::SORT_NAME)
 		std::stable_sort(m_pSortedServerlist, m_pSortedServerlist+m_NumSortedServers, SortWrap(this, &CServerBrowser::SortCompareName));
 	else if(g_Config.m_BrSort == IServerBrowser::SORT_PING)
 		std::stable_sort(m_pSortedServerlist, m_pSortedServerlist+m_NumSortedServers, SortWrap(this, &CServerBrowser::SortComparePing));

--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -145,14 +145,14 @@ bool CServerBrowser::SortCompareNumPlayers(int Index1, int Index2) const
 {
 	CServerEntry *a = m_ppServerlist[Index1];
 	CServerEntry *b = m_ppServerlist[Index2];
-	return a->m_Info.m_NumFilteredPlayers < b->m_Info.m_NumFilteredPlayers;
+	return a->m_Info.m_NumFilteredPlayers > b->m_Info.m_NumFilteredPlayers;
 }
 
 bool CServerBrowser::SortCompareNumClients(int Index1, int Index2) const
 {
 	CServerEntry *a = m_ppServerlist[Index1];
 	CServerEntry *b = m_ppServerlist[Index2];
-	return a->m_Info.m_NumClients < b->m_Info.m_NumClients;
+	return a->m_Info.m_NumClients > b->m_Info.m_NumClients;
 }
 
 bool CServerBrowser::SortCompareNumPlayersAndPing(int Index1, int Index2) const

--- a/src/engine/client/serverbrowser.h
+++ b/src/engine/client/serverbrowser.h
@@ -182,6 +182,7 @@ private:
 	bool SortCompareGametype(int Index1, int Index2) const;
 	bool SortCompareNumPlayers(int Index1, int Index2) const;
 	bool SortCompareNumClients(int Index1, int Index2) const;
+	bool SortCompareNumPlayersAndPing(int Index1, int Index2) const;
 
 	//
 	void Filter();

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -62,7 +62,7 @@ MACRO_CONFIG_STR(BrFilterExcludeCountriesKoG, br_filter_exclude_countries_kog, 1
 MACRO_CONFIG_STR(BrFilterExcludeTypesKoG, br_filter_exclude_types_kog, 128, "", CFGFLAG_SAVE|CFGFLAG_CLIENT, "Filter out kog servers by type (mod)")
 
 MACRO_CONFIG_INT(BrSort, br_sort, 4, 0, 256, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Sorting column in server browser")
-MACRO_CONFIG_INT(BrSortOrder, br_sort_order, 1, 0, 1, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Sorting order in server browser")
+MACRO_CONFIG_INT(BrSortOrder, br_sort_order, 2, 0, 2, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Sorting order in server browser")
 MACRO_CONFIG_INT(BrMaxRequests, br_max_requests, 25, 0, 1000, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Number of requests to use when refreshing server browser")
 
 MACRO_CONFIG_INT(BrDemoSort, br_demo_sort, 0, 0, 3, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Sorting column in demo browser")

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -174,7 +174,9 @@ int CMenus::DoButton_MenuTab(const void *pID, const char *pText, int Checked, co
 
 int CMenus::DoButton_GridHeader(const void *pID, const char *pText, int Checked, const CUIRect *pRect)
 {
-	if(Checked)
+	if(Checked == 2)
+		RenderTools()->DrawUIRect(pRect, ColorRGBA(1,0.98f,0.5f,0.55f), CUI::CORNER_T, 5.0f);
+	else if(Checked)
 		RenderTools()->DrawUIRect(pRect, ColorRGBA(1,1,1,0.5f), CUI::CORNER_T, 5.0f);
 	CUIRect t;
 	pRect->VSplitLeft(5.0f, 0, &t);

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -109,15 +109,26 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 			s_aCols[i].m_Rect = Headers;
 	}
 
+	const bool PlayersOrPing = (g_Config.m_BrSort == IServerBrowser::SORT_NUMPLAYERS || g_Config.m_BrSort == IServerBrowser::SORT_PING);
+
 	// do headers
 	for(int i = 0; i < NumCols; i++)
 	{
-		if(DoButton_GridHeader(s_aCols[i].m_Caption, s_aCols[i].m_Caption, g_Config.m_BrSort == s_aCols[i].m_Sort, &s_aCols[i].m_Rect))
+		int Checked = g_Config.m_BrSort == s_aCols[i].m_Sort;
+		if(PlayersOrPing && g_Config.m_BrSortOrder == 2 && (s_aCols[i].m_Sort == IServerBrowser::SORT_NUMPLAYERS || s_aCols[i].m_Sort == IServerBrowser::SORT_PING))
+			Checked = 2;
+
+		if(DoButton_GridHeader(s_aCols[i].m_Caption, s_aCols[i].m_Caption, Checked, &s_aCols[i].m_Rect))
 		{
 			if(s_aCols[i].m_Sort != -1)
 			{
 				if(g_Config.m_BrSort == s_aCols[i].m_Sort)
-					g_Config.m_BrSortOrder ^= 1;
+				{
+					if(PlayersOrPing)
+						g_Config.m_BrSortOrder = (g_Config.m_BrSortOrder+1)%3;
+					else
+						g_Config.m_BrSortOrder = (g_Config.m_BrSortOrder+1)%2;
+				}
 				else
 					g_Config.m_BrSortOrder = 0;
 				g_Config.m_BrSort = s_aCols[i].m_Sort;


### PR DESCRIPTION
Fixes #2633.

Did the sorting in groups of 100 ping, since that seemed more readable and less confusing.
Example:
![image](https://user-images.githubusercontent.com/9425859/91101586-b4f20000-e667-11ea-8ba2-fb9b394f2fc8.png)
