### PR TITLE
Fix server port in teehistorian

### DIFF
--- a/src/engine/server.h
+++ b/src/engine/server.h
@@ -41,6 +41,7 @@ public:
 	int Tick() const { return m_CurrentGameTick; }
 	int TickSpeed() const { return m_TickSpeed; }
 
+	virtual int Port() const = 0;
 	virtual int MaxClients() const = 0;
 	virtual int ClientCount() = 0;
 	virtual int DistinctClientCount() = 0;

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -618,6 +618,11 @@ bool CServer::ClientAuthed(int ClientID)
 	return ClientID >= 0 && ClientID < MAX_CLIENTS && m_aClients[ClientID].m_Authed;
 }
 
+int CServer::Port() const
+{
+	return m_NetServer.Address().port;
+}
+
 int CServer::MaxClients() const
 {
 	return m_NetServer.MaxClients();

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -293,6 +293,7 @@ public:
 	int ClientCountry(int ClientID);
 	bool ClientIngame(int ClientID);
 	bool ClientAuthed(int ClientID);
+	int Port() const;
 	int MaxClients() const;
 	int ClientCount();
 	int DistinctClientCount();

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -3096,7 +3096,7 @@ void CGameContext::OnInit(/*class IKernel *pKernel*/)
 		GameInfo.m_pPrngDescription = m_Prng.Description();
 
 		GameInfo.m_pServerName = g_Config.m_SvName;
-		GameInfo.m_ServerPort = g_Config.m_SvPort;
+		GameInfo.m_ServerPort = Server()->Port();
 		GameInfo.m_pGameType = m_pController->m_pGameType;
 
 		GameInfo.m_pConfig = &g_Config;


### PR DESCRIPTION
Official servers weren't affected because they didn't use the default of
`sv_port 0`.