### PR TITLE
Analyse 3D/2D array texture sampling data when creating context

### DIFF
--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -1456,7 +1456,17 @@ void CCommandProcessorFragment_OpenGL2::Cmd_Init(const SCommand_Init *pCommand)
 		glUseProgram(0);
 	}
 
-	if(!IsTileMapAnalysisSucceeded())
+	bool AnalysisCorrect = true;
+	if(g_Config.m_GfxDid3DTextureAnalysis == 0)
+	{
+		AnalysisCorrect = IsTileMapAnalysisSucceeded();
+		if(AnalysisCorrect)
+		{
+			g_Config.m_GfxDid3DTextureAnalysis = 1;
+		}
+	}
+
+	if(!AnalysisCorrect)
 	{
 		// downgrade to opengl 1.5
 		*pCommand->m_pInitError = -2;

--- a/src/engine/client/backend_sdl.h
+++ b/src/engine/client/backend_sdl.h
@@ -152,7 +152,8 @@ public:
 		SCommand_Init() : SCommand(CMD_INIT) {}
 		class IStorage *m_pStorage;
 		std::atomic<int> *m_pTextureMemoryUsage;
-		const SBackendCapabilites* m_pCapabilities;
+		SBackendCapabilites *m_pCapabilities;
+		int *m_pInitError;
 	};
 
 	struct SCommand_Shutdown : public CCommandBuffer::SCommand
@@ -228,6 +229,8 @@ class CCommandProcessorFragment_OpenGL2 : public CCommandProcessorFragment_OpenG
 	};
 
 	std::vector<SBufferObject> m_BufferObjectIndices;
+
+	bool IsTileMapAnalysisSucceeded();
 
 	void RenderBorderTileEmulation(SBufferContainer& BufferContainer, const CCommandBuffer::SState& State, const float* pColor, const char *pBuffOffset, unsigned int DrawNum, const float* pOffset, const float* pDir, int JumpIndex);
 	void RenderBorderTileLineEmulation(SBufferContainer& BufferContainer, const CCommandBuffer::SState& State, const float* pColor, const char *pBuffOffset, unsigned int IndexDrawNum, unsigned int DrawNum, const float* pOffset, const float* pDir);
@@ -387,9 +390,9 @@ public:
 		SCommand_Init() : SCommand(CMD_INIT) {}
 		SDL_Window *m_pWindow;
 		SDL_GLContext m_GLContext;
-		SBackendCapabilites* m_pCapabilities;
+		SBackendCapabilites *m_pCapabilities;
 
-		int* m_pInitError;
+		int *m_pInitError;
 
 		int m_RequestedMajor;
 		int m_RequestedMinor;

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -378,6 +378,7 @@ MACRO_CONFIG_INT(ClDemoKeyboardShortcuts, cl_demo_keyboard_shortcuts, 1, 0, 1, C
 MACRO_CONFIG_INT(GfxOpenGLMajor, gfx_opengl_major, 3, 1, 10, CFGFLAG_SAVE|CFGFLAG_CLIENT, "OpenGL major version")
 MACRO_CONFIG_INT(GfxOpenGLMinor, gfx_opengl_minor, 0, 0, 10, CFGFLAG_SAVE|CFGFLAG_CLIENT, "OpenGL minor version")
 MACRO_CONFIG_INT(GfxOpenGLPatch, gfx_opengl_patch, 0, 0, 10, CFGFLAG_SAVE|CFGFLAG_CLIENT, "OpenGL patch version")
+MACRO_CONFIG_INT(GfxDid3DTextureAnalysis, gfx_did_3d_texture_analysis, 0, 0, 1, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Analyzed, if sampling 3D/2D array textures was correct")
 #if !defined(CONF_PLATFORM_MACOSX)
 MACRO_CONFIG_INT(GfxEnableTextureUnitOptimization, gfx_enable_texture_unit_optimization, 1, 0, 1, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Use multiple texture units, instead of only one.")
 #else


### PR DESCRIPTION

Will create a texture, samples over it

![test](https://user-images.githubusercontent.com/6654924/91640751-2e02a600-ea20-11ea-8e66-e7884b4d8142.png)

and checks the pixel data.

I'm not the hugest fan of this hack, but if it works its fine