### PR TITLE
Add nameplates friend marks

### DIFF
--- a/src/game/client/components/nameplates.cpp
+++ b/src/game/client/components/nameplates.cpp
@@ -135,23 +135,39 @@ void CNamePlates::RenderNameplatePos(vec2 Position, const CNetObj_PlayerInfo *pP
 		TOutlineColor.m_A *= Alpha;
 		TColor.m_A *= Alpha;
 
+		float YOffSet = Position.y - 38;
+
 		if(m_aNamePlates[ClientID].m_NameTextContainerIndex != -1)
-			TextRender()->RenderTextContainer(m_aNamePlates[ClientID].m_NameTextContainerIndex, &TColor, &TOutlineColor, Position.x - tw / 2.0f, Position.y - FontSize - 38.0f);
+		{
+			YOffSet -= FontSize;
+			TextRender()->RenderTextContainer(m_aNamePlates[ClientID].m_NameTextContainerIndex, &TColor, &TOutlineColor, Position.x - tw / 2.0f, YOffSet);
+		}
 
 		if(g_Config.m_ClNameplatesClan)
 		{
+			YOffSet -= FontSizeClan;
 			if(m_aNamePlates[ClientID].m_ClanNameTextContainerIndex != -1)
-				TextRender()->RenderTextContainer(m_aNamePlates[ClientID].m_ClanNameTextContainerIndex, &TColor, &TOutlineColor, Position.x - m_aNamePlates[ClientID].m_ClanNameTextWidth / 2.0f, Position.y - FontSize - FontSizeClan - 38.0f);
+				TextRender()->RenderTextContainer(m_aNamePlates[ClientID].m_ClanNameTextContainerIndex, &TColor, &TOutlineColor, Position.x - m_aNamePlates[ClientID].m_ClanNameTextWidth / 2.0f, YOffSet);
+		}
+
+		if (g_Config.m_ClNameplatesFriendMark && m_pClient->m_aClients[ClientID].m_Friend)
+		{
+			YOffSet -= FontSize;
+			char aBuf[128];
+			str_format(aBuf, sizeof(aBuf),"[F]");
+			float XOffSet = TextRender()->TextWidth(0, FontSize, aBuf, -1, -1.0f)/2.0f;
+			TextRender()->TextColor(rgb);
+			TextRender()->Text(0, Position.x-XOffSet, YOffSet, FontSize, aBuf, -1.0f);
 		}
 
 		if(g_Config.m_Debug || g_Config.m_ClNameplatesIDs) // render client id when in debug as well
 		{
+			YOffSet -= FontSize;
 			char aBuf[128];
 			str_format(aBuf, sizeof(aBuf),"%d", pPlayerInfo->m_ClientID);
-			float Offset = g_Config.m_ClNameplatesClan ? (FontSize * 2 + FontSizeClan) : (FontSize * 2);
-			float tw_id = TextRender()->TextWidth(0, FontSize, aBuf, -1, -1.0f);
+			float XOffSet = TextRender()->TextWidth(0, FontSize, aBuf, -1, -1.0f)/2.0f;
 			TextRender()->TextColor(rgb);
-			TextRender()->Text(0, Position.x-tw_id/2.0f, Position.y-Offset-38.0f, 28.0f, aBuf, -1.0f);
+			TextRender()->Text(0, Position.x-XOffSet, YOffSet, FontSize, aBuf, -1.0f);
 		}
 
 		if(g_Config.m_ClNameplatesHA) // render health and armor in nameplate

--- a/src/game/client/components/nameplates.cpp
+++ b/src/game/client/components/nameplates.cpp
@@ -135,47 +135,58 @@ void CNamePlates::RenderNameplatePos(vec2 Position, const CNetObj_PlayerInfo *pP
 		TOutlineColor.m_A *= Alpha;
 		TColor.m_A *= Alpha;
 
-		float YOffSet = Position.y - 38;
+		float YOffset = Position.y-38;
 
 		if(m_aNamePlates[ClientID].m_NameTextContainerIndex != -1)
 		{
-			YOffSet -= FontSize;
-			TextRender()->RenderTextContainer(m_aNamePlates[ClientID].m_NameTextContainerIndex, &TColor, &TOutlineColor, Position.x - tw / 2.0f, YOffSet);
+			YOffset -= FontSize;
+			TextRender()->RenderTextContainer(m_aNamePlates[ClientID].m_NameTextContainerIndex, &TColor, &TOutlineColor, Position.x - tw / 2.0f, YOffset);
 		}
 
 		if(g_Config.m_ClNameplatesClan)
 		{
-			YOffSet -= FontSizeClan;
+			YOffset -= FontSizeClan;
 			if(m_aNamePlates[ClientID].m_ClanNameTextContainerIndex != -1)
-				TextRender()->RenderTextContainer(m_aNamePlates[ClientID].m_ClanNameTextContainerIndex, &TColor, &TOutlineColor, Position.x - m_aNamePlates[ClientID].m_ClanNameTextWidth / 2.0f, YOffSet);
+				TextRender()->RenderTextContainer(m_aNamePlates[ClientID].m_ClanNameTextContainerIndex, &TColor, &TOutlineColor, Position.x - m_aNamePlates[ClientID].m_ClanNameTextWidth / 2.0f, YOffset);
 		}
 
 		if (g_Config.m_ClNameplatesFriendMark && m_pClient->m_aClients[ClientID].m_Friend)
 		{
-			YOffSet -= FontSize;
+			YOffset -= FontSize;
 			char aBuf[128];
-			str_format(aBuf, sizeof(aBuf),"[F]");
+			
+			if (g_Config.m_ClNameplatesFriendMark == 1)
+			{
+				str_format(aBuf, sizeof(aBuf),"♥");
+				TextRender()->TextColor(ColorRGBA(1.0f, 0.0f, 0.0f));
+			}
+			else if (g_Config.m_ClNameplatesFriendMark == 2)
+			{
+				str_format(aBuf, sizeof(aBuf),"[F]");
+				TextRender()->TextColor(rgb);
+			}			
+			
 			float XOffSet = TextRender()->TextWidth(0, FontSize, aBuf, -1, -1.0f)/2.0f;
-			TextRender()->TextColor(rgb);
-			TextRender()->Text(0, Position.x-XOffSet, YOffSet, FontSize, aBuf, -1.0f);
+			TextRender()->Text(0, Position.x-XOffSet, YOffset, FontSize, aBuf, -1.0f);
 		}
 
 		if(g_Config.m_Debug || g_Config.m_ClNameplatesIDs) // render client id when in debug as well
 		{
-			YOffSet -= FontSize;
+			YOffset -= FontSize;
 			char aBuf[128];
 			str_format(aBuf, sizeof(aBuf),"%d", pPlayerInfo->m_ClientID);
-			float XOffSet = TextRender()->TextWidth(0, FontSize, aBuf, -1, -1.0f)/2.0f;
+			float XOffset = TextRender()->TextWidth(0, FontSize, aBuf, -1, -1.0f)/2.0f;
 			TextRender()->TextColor(rgb);
-			TextRender()->Text(0, Position.x-XOffSet, YOffSet, FontSize, aBuf, -1.0f);
+			TextRender()->Text(0, Position.x-XOffset, YOffset, FontSize, aBuf, -1.0f);
 		}
 
 		if(g_Config.m_ClNameplatesHA) // render health and armor in nameplate
 		{
 			int Health = m_pClient->m_Snap.m_aCharacters[ClientID].m_Cur.m_Health;
-			if(Health > 0)
+			int Armor = m_pClient->m_Snap.m_aCharacters[ClientID].m_Cur.m_Armor;
+			
+			if(Health > 0 || Armor > 0)
 			{
-				int Armor = m_pClient->m_Snap.m_aCharacters[ClientID].m_Cur.m_Armor;
 				float HFontSize = 5.0f + 20.0f * g_Config.m_ClNameplatesHASize / 100.0f;
 				float AFontSize = 6.0f + 24.0f * g_Config.m_ClNameplatesHASize / 100.0f;
 				char aHealth[40] = "\0";
@@ -191,24 +202,16 @@ void CNamePlates::RenderNameplatePos(vec2 Position, const CNetObj_PlayerInfo *pP
 					str_append(aArmor, "⚪", sizeof(aArmor));
 				str_append(aArmor, "\0", sizeof(aArmor));
 
-				float Offset;
 
-				if(g_Config.m_ClNameplatesClan && (g_Config.m_Debug || g_Config.m_ClNameplatesIDs))
-					Offset = (FontSize * 3 + FontSizeClan);
-				else if (g_Config.m_ClNameplatesClan)
-					Offset = (FontSize * 2 + FontSizeClan);
-				else if (g_Config.m_Debug || g_Config.m_ClNameplatesIDs)
-					Offset = (FontSize * 3);
-				else
-					Offset = (FontSize * 2);
-
+				YOffset -= HFontSize+AFontSize;
 				float PosHealth = TextRender()->TextWidth(0, HFontSize, aHealth, -1, -1.0f);
 				TextRender()->TextColor(ColorRGBA(1.0f, 0.0f, 0.0f));
-				TextRender()->Text(0, Position.x-PosHealth/2.0f, Position.y-Offset-HFontSize-AFontSize, HFontSize, aHealth, -1);
+				TextRender()->Text(0, Position.x-PosHealth/2.0f, YOffset, HFontSize, aHealth, -1);
 
+				YOffset -= -AFontSize+3.0f;
 				float PosArmor = TextRender()->TextWidth(0, AFontSize, aArmor, -1, -1.0f);
 				TextRender()->TextColor(ColorRGBA(1.0f, 1.0f, 0.0f));
-				TextRender()->Text(0, Position.x-PosArmor/2.0f, Position.y-Offset-AFontSize-3.0f, AFontSize, aArmor, -1);
+				TextRender()->Text(0, Position.x-PosArmor/2.0f, YOffset, AFontSize, aArmor, -1);
 			}
 		}
 

--- a/src/game/client/components/nameplates.cpp
+++ b/src/game/client/components/nameplates.cpp
@@ -153,21 +153,10 @@ void CNamePlates::RenderNameplatePos(vec2 Position, const CNetObj_PlayerInfo *pP
 		if (g_Config.m_ClNameplatesFriendMark && m_pClient->m_aClients[ClientID].m_Friend)
 		{
 			YOffset -= FontSize;
-			char aBuf[128];
-			
-			if (g_Config.m_ClNameplatesFriendMark == 1)
-			{
-				str_format(aBuf, sizeof(aBuf),"♥");
-				TextRender()->TextColor(ColorRGBA(1.0f, 0.0f, 0.0f));
-			}
-			else if (g_Config.m_ClNameplatesFriendMark == 2)
-			{
-				str_format(aBuf, sizeof(aBuf),"[F]");
-				TextRender()->TextColor(rgb);
-			}			
-			
-			float XOffSet = TextRender()->TextWidth(0, FontSize, aBuf, -1, -1.0f)/2.0f;
-			TextRender()->Text(0, Position.x-XOffSet, YOffset, FontSize, aBuf, -1.0f);
+			char aFriendMark[]  = "♥";
+			TextRender()->TextColor(ColorRGBA(1.0f, 0.0f, 0.0f));
+			float XOffSet = TextRender()->TextWidth(0, FontSize, aFriendMark, -1, -1.0f)/2.0f;
+			TextRender()->Text(0, Position.x-XOffSet, YOffset, FontSize, aFriendMark, -1.0f);
 		}
 
 		if(g_Config.m_Debug || g_Config.m_ClNameplatesIDs) // render client id when in debug as well

--- a/src/game/variables.h
+++ b/src/game/variables.h
@@ -26,7 +26,7 @@ MACRO_CONFIG_INT(ClNameplatesIDs, cl_nameplates_ids, 0, 0, 1, CFGFLAG_CLIENT|CFG
 MACRO_CONFIG_INT(ClNameplatesHA, cl_nameplates_ha, 0, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Show Health and Armor in name plates")
 MACRO_CONFIG_INT(ClNameplatesHASize, cl_nameplates_ha_size, 50, 0, 100, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Size of the health and armor nameplates from 0 to 100%")
 MACRO_CONFIG_INT(ClNameplatesOwn, cl_nameplates_own, 0, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Show own name plate (useful for demo recording)")
-MACRO_CONFIG_INT(ClNameplatesFriendMark, cl_nameplates_friendmark, 0, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Show friend mark under nameplate")
+MACRO_CONFIG_INT(ClNameplatesFriendMark, cl_nameplates_friendmark, 0, 0, 2, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Show friend mark in name plates (1 - show heart, 2 - show '[F]')")
 MACRO_CONFIG_INT(ClTextEntities, cl_text_entities, 1, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Render textual entity data")
 MACRO_CONFIG_INT(ClTextEntitiesSize, cl_text_entities_size, 100, 0, 100, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Size of textual entity data from 0 to 100%")
 

--- a/src/game/variables.h
+++ b/src/game/variables.h
@@ -26,6 +26,7 @@ MACRO_CONFIG_INT(ClNameplatesIDs, cl_nameplates_ids, 0, 0, 1, CFGFLAG_CLIENT|CFG
 MACRO_CONFIG_INT(ClNameplatesHA, cl_nameplates_ha, 0, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Show Health and Armor in name plates")
 MACRO_CONFIG_INT(ClNameplatesHASize, cl_nameplates_ha_size, 50, 0, 100, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Size of the health and armor nameplates from 0 to 100%")
 MACRO_CONFIG_INT(ClNameplatesOwn, cl_nameplates_own, 0, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Show own name plate (useful for demo recording)")
+MACRO_CONFIG_INT(ClNameplatesFriendMark, cl_nameplates_friendmark, 0, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Show friend mark under nameplate")
 MACRO_CONFIG_INT(ClTextEntities, cl_text_entities, 1, 0, 1, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Render textual entity data")
 MACRO_CONFIG_INT(ClTextEntitiesSize, cl_text_entities_size, 100, 0, 100, CFGFLAG_CLIENT|CFGFLAG_SAVE, "Size of textual entity data from 0 to 100%")
 


### PR DESCRIPTION
Problem: when I play with a friend in team 0, and there are many players nearby, I cannot distinguish him due to nameplates overlapping. It's getting worse when they are in freeze.

Solution: Mark your teammate as "Friend" and setup "cl_nameplates_friendmark"

Result:
![v2](https://user-images.githubusercontent.com/17499770/91647684-08988b00-ea66-11ea-9407-336437391b4f.png)
