### PR TITLE
Disabling 3.3 in settings tab should reset to version 3.0

### DIFF
--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -1025,8 +1025,8 @@ void CMenus::RenderSettingsGraphics(CUIRect MainView)
 		CheckSettings = true;
 		if(IsNewOpenGL)
 		{
-			g_Config.m_GfxOpenGLMajor = 2;
-			g_Config.m_GfxOpenGLMinor = 1;
+			g_Config.m_GfxOpenGLMajor = 3;
+			g_Config.m_GfxOpenGLMinor = 0;
 			g_Config.m_GfxOpenGLPatch = 0;
 			IsNewOpenGL = false;
 		}


### PR DESCRIPTION
We don't have a way to query the default config value, except including the config_variables.h, do we?