### PR TITLE
allow empty max ping filter

### DIFF
--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -218,7 +218,7 @@ void CServerBrowser::Filter()
 		{
 			Filtered = 1;
 		}
-		else if(g_Config.m_BrFilterPing < m_ppServerlist[i]->m_Info.m_Latency)
+		else if(g_Config.m_BrFilterPing && g_Config.m_BrFilterPing < m_ppServerlist[i]->m_Info.m_Latency)
 			Filtered = 1;
 		else if(g_Config.m_BrFilterCompatversion && str_comp_num(m_ppServerlist[i]->m_Info.m_aVersion, m_aNetVersion, 3) != 0)
 			Filtered = 1;

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -614,8 +614,9 @@ void CMenus::RenderServerbrowserFilters(CUIRect View)
 
 		UI()->DoLabelScaled(&Button, Localize("Maximum ping:"), FontSize, -1);
 
-		char aBuf[5];
-		str_format(aBuf, sizeof(aBuf), "%d", g_Config.m_BrFilterPing);
+		char aBuf[5] = "";
+		if (g_Config.m_BrFilterPing != 0)
+			str_format(aBuf, sizeof(aBuf), "%d", g_Config.m_BrFilterPing);
 		static float Offset = 0.0f;
 		DoEditBox(&g_Config.m_BrFilterPing, &EditBox, aBuf, sizeof(aBuf), FontSize, &Offset);
 		g_Config.m_BrFilterPing = clamp(str_toint(aBuf), 0, 999);

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -615,7 +615,7 @@ void CMenus::RenderServerbrowserFilters(CUIRect View)
 		UI()->DoLabelScaled(&Button, Localize("Maximum ping:"), FontSize, -1);
 
 		char aBuf[5] = "";
-		if (g_Config.m_BrFilterPing != 0)
+		if(g_Config.m_BrFilterPing != 0)
 			str_format(aBuf, sizeof(aBuf), "%d", g_Config.m_BrFilterPing);
 		static float Offset = 0.0f;
 		DoEditBox(&g_Config.m_BrFilterPing, &EditBox, aBuf, sizeof(aBuf), FontSize, &Offset);


### PR DESCRIPTION
The inconvenieces I discovered so far:
1. You got to write 999 to "disable" this filter
2. If you try to clear this field and then type 75 then the field will contain 750 because the last zero is bugged at this point
Those are fixed

What I would like to be fixed as well (not sure if I gona do this soon):
1. Update browser servers live without refreshing. You press refresh - you receives all the servers and then you should be able (but currently not) to filter them out without pressing on "Refresh" button again but just by changing the max ping value