### PR TITLE
Add str_utf8_copy that trim broken utf8 sequence at the end.

### DIFF
--- a/src/base/system.c
+++ b/src/base/system.c
@@ -3182,51 +3182,6 @@ int str_utf8_check(const char *str)
 	return 1;
 }
 
-void str_utf8_copy(char *dst, const char *src, int dst_size)
-{
-	char *end = dst + (dst_size-2);
-	char *ptr = end;
-
-	strncpy(dst, src, dst_size);
-	dst[dst_size-1] = 0;
-
-	// check whether we need to remove a broken utf8 character
-	while(ptr > dst)
-	{
-		if((*ptr&0xC0) == 0x80)
-		{
-			ptr--;
-		}
-		else if((*ptr&0x80) == 0)
-		{
-			return;
-		}
-		else if((*ptr&0xE0) == 0xC0)
-		{
-			if(end-ptr != 1)
-				*ptr = 0;
-			return;
-		}
-		else if((*ptr&0xF0) == 0xE0)
-		{
-			if(end-ptr != 2)
-				*ptr = 0;
-			return;
-		}
-		else if((*ptr&0xF8) == 0xF0)
-		{
-			if(end-ptr != 3)
-				*ptr = 0;
-			return;
-		}
-		else
-		{
-			return;
-		}
-	}
-
-	*ptr = 0;
-}
 
 unsigned str_quickhash(const char *str)
 {

--- a/src/base/system.c
+++ b/src/base/system.c
@@ -3182,6 +3182,50 @@ int str_utf8_check(const char *str)
 	return 1;
 }
 
+void str_utf8_copy(char *dst, const char *src, int dst_size)
+{
+	strncpy(dst, src, dst_size);
+	dst[dst_size-1] = 0; /* assure null termination */
+
+	// check whether we need to remove a broken utf8 character
+	char *end = dst + (dst_size-2);
+	char *ptr = end;
+	while(ptr > dst)
+	{
+		if((*ptr&0xC0) == 0x80)
+		{
+			ptr--;
+		}
+		else if((*ptr&0x80) == 0)
+		{
+			return;
+		}
+		else if((*ptr&0xE0) == 0xC0)
+		{
+			if(end-ptr != 1)
+				*ptr = 0;
+			return;
+		}
+		else if((*ptr&0xF0) == 0xE0)
+		{
+			if(end-ptr != 2)
+				*ptr = 0;
+			return;
+		}
+		else if((*ptr&0xF8) == 0xF0)
+		{
+			if(end-ptr != 3)
+				*ptr = 0;
+			return;
+		}
+		else
+		{
+			return;
+		}
+	}
+
+	*ptr = 0;
+}
 
 unsigned str_quickhash(const char *str)
 {

--- a/src/base/system.c
+++ b/src/base/system.c
@@ -3182,6 +3182,51 @@ int str_utf8_check(const char *str)
 	return 1;
 }
 
+void str_utf8_copy(char *dst, const char *src, int dst_size)
+{
+	char *end = dst + (dst_size-2);
+	char *ptr = end;
+
+	strncpy(dst, src, dst_size);
+	dst[dst_size-1] = 0;
+
+	// check whether we need to remove a broken utf8 character
+	while(ptr > dst)
+	{
+		if((*ptr&0xC0) == 0x80)
+		{
+			ptr--;
+		}
+		else if((*ptr&0x80) == 0)
+		{
+			return;
+		}
+		else if((*ptr&0xE0) == 0xC0)
+		{
+			if(end-ptr != 1)
+				*ptr = 0;
+			return;
+		}
+		else if((*ptr&0xF0) == 0xE0)
+		{
+			if(end-ptr != 2)
+				*ptr = 0;
+			return;
+		}
+		else if((*ptr&0xF8) == 0xF0)
+		{
+			if(end-ptr != 3)
+				*ptr = 0;
+			return;
+		}
+		else
+		{
+			return;
+		}
+	}
+
+	*ptr = 0;
+}
 
 unsigned str_quickhash(const char *str)
 {

--- a/src/base/system.c
+++ b/src/base/system.c
@@ -3184,48 +3184,7 @@ int str_utf8_check(const char *str)
 
 void str_utf8_copy(char *dst, const char *src, int dst_size)
 {
-	char *end = dst + (dst_size-2);
-	char *ptr = end;
-
-	strncpy(dst, src, dst_size);
-	dst[dst_size-1] = 0;
-
-	// check whether we need to remove a broken utf8 character
-	while(ptr > dst)
-	{
-		if((*ptr&0xC0) == 0x80)
-		{
-			ptr--;
-		}
-		else if((*ptr&0x80) == 0)
-		{
-			return;
-		}
-		else if((*ptr&0xE0) == 0xC0)
-		{
-			if(end-ptr != 1)
-				*ptr = 0;
-			return;
-		}
-		else if((*ptr&0xF0) == 0xE0)
-		{
-			if(end-ptr != 2)
-				*ptr = 0;
-			return;
-		}
-		else if((*ptr&0xF8) == 0xF0)
-		{
-			if(end-ptr != 3)
-				*ptr = 0;
-			return;
-		}
-		else
-		{
-			return;
-		}
-	}
-
-	*ptr = 0;
+	str_utf8_truncate(dst, dst_size, src, dst_size);
 }
 
 unsigned str_quickhash(const char *str)

--- a/src/base/system.c
+++ b/src/base/system.c
@@ -3184,12 +3184,13 @@ int str_utf8_check(const char *str)
 
 void str_utf8_copy(char *dst, const char *src, int dst_size)
 {
-	strncpy(dst, src, dst_size);
-	dst[dst_size-1] = 0; /* assure null termination */
-
-	// check whether we need to remove a broken utf8 character
 	char *end = dst + (dst_size-2);
 	char *ptr = end;
+
+	strncpy(dst, src, dst_size);
+	dst[dst_size-1] = 0;
+
+	// check whether we need to remove a broken utf8 character
 	while(ptr > dst)
 	{
 		if((*ptr&0xC0) == 0x80)

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -1919,23 +1919,6 @@ int str_utf16le_encode(char *ptr, int chr);
 int str_utf8_check(const char *str);
 
 /*
-	Function: str_utf8_copy
-		Copies a utf8 string to a buffer.
-
-	Parameters:
-		dst - Pointer to a buffer that shall receive the string.
-		src - utf8 string to be copied.
-		dst_size - Size of the buffer dst.
-
-	Remarks:
-		- The strings are treated as zero-terminated strings.
-		- Guarantees that dst string will contain zero-termination.
-		- Guarantees that dst always ends with a valid utf8 sequence.
-		- Does not guarantee the entire string is a valid utf8 string.
-*/
-void str_utf8_copy(char *dst, const char *src, int dst_size);
-
-/*
 	Function: str_next_token
 		Writes the next token after str into buf, returns the rest of the string.
 	Parameters:

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -1930,8 +1930,7 @@ int str_utf8_check(const char *str);
 	Remarks:
 		- The strings are treated as zero-terminated strings.
 		- Guarantees that dst string will contain zero-termination.
-		- Guarantees that dst always ends with a valid utf8 sequence.
-		- Does not guarantee the entire string is a valid utf8 string.
+		- Guarantees that dst always contains a valid utf8 string.
 */
 void str_utf8_copy(char *dst, const char *src, int dst_size);
 

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -1919,6 +1919,23 @@ int str_utf16le_encode(char *ptr, int chr);
 int str_utf8_check(const char *str);
 
 /*
+	Function: str_utf8_copy
+		Copies a utf8 string to a buffer.
+
+	Parameters:
+		dst - Pointer to a buffer that shall receive the string.
+		src - utf8 string to be copied.
+		dst_size - Size of the buffer dst.
+
+	Remarks:
+		- The strings are treated as zero-terminated strings.
+		- Guarantees that dst string will contain zero-termination.
+		- Guarantees that dst always ends with a valid utf8 sequence.
+		- Does not guarantee the entire string is a valid utf8 string.
+*/
+void str_utf8_copy(char *dst, const char *src, int dst_size);
+
+/*
 	Function: str_next_token
 		Writes the next token after str into buf, returns the rest of the string.
 	Parameters:

--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -26,7 +26,7 @@ void CInput::AddEvent(char *pText, int Key, int Flags)
 		if(!pText)
 			m_aInputEvents[m_NumEvents].m_aText[0] = 0;
 		else
-			str_copy(m_aInputEvents[m_NumEvents].m_aText, pText, sizeof(m_aInputEvents[m_NumEvents].m_aText));
+			str_utf8_copy(m_aInputEvents[m_NumEvents].m_aText, pText, sizeof(m_aInputEvents[m_NumEvents].m_aText));
 		m_aInputEvents[m_NumEvents].m_InputCount = m_InputCounter;
 		m_NumEvents++;
 	}

--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -24,14 +24,9 @@ void CInput::AddEvent(char *pText, int Key, int Flags)
 		m_aInputEvents[m_NumEvents].m_Key = Key;
 		m_aInputEvents[m_NumEvents].m_Flags = Flags;
 		if(!pText)
-		{
 			m_aInputEvents[m_NumEvents].m_aText[0] = 0;
-		}
 		else
-		{
-			int TextSize = sizeof(m_aInputEvents[m_NumEvents].m_aText);
-			str_utf8_truncate(m_aInputEvents[m_NumEvents].m_aText, TextSize, pText, TextSize);
-		}
+			str_utf8_copy(m_aInputEvents[m_NumEvents].m_aText, pText, sizeof(m_aInputEvents[m_NumEvents].m_aText));
 		m_aInputEvents[m_NumEvents].m_InputCount = m_InputCounter;
 		m_NumEvents++;
 	}

--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -24,9 +24,14 @@ void CInput::AddEvent(char *pText, int Key, int Flags)
 		m_aInputEvents[m_NumEvents].m_Key = Key;
 		m_aInputEvents[m_NumEvents].m_Flags = Flags;
 		if(!pText)
+		{
 			m_aInputEvents[m_NumEvents].m_aText[0] = 0;
+		}
 		else
-			str_utf8_copy(m_aInputEvents[m_NumEvents].m_aText, pText, sizeof(m_aInputEvents[m_NumEvents].m_aText));
+		{
+			int TextSize = sizeof(m_aInputEvents[m_NumEvents].m_aText);
+			str_utf8_truncate(m_aInputEvents[m_NumEvents].m_aText, TextSize, pText, TextSize);
+		}
 		m_aInputEvents[m_NumEvents].m_InputCount = m_InputCounter;
 		m_NumEvents++;
 	}

--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -168,14 +168,14 @@ bool CChat::OnInput(IInput::CEvent Event)
 				if(Text[i] == '\n')
 				{
 					int max = minimum(i - Begin + 1, (int)sizeof(Line));
-					str_copy(Line, Text + Begin, max);
+					str_utf8_copy(Line, Text + Begin, max);
 					Begin = i+1;
 					SayChat(Line);
 					while(Text[i] == '\n') i++;
 				}
 			}
 			int max = minimum(i - Begin + 1, (int)sizeof(Line));
-			str_copy(Line, Text + Begin, max);
+			str_utf8_copy(Line, Text + Begin, max);
 			Begin = i+1;
 			m_Input.Add(Line);
 		}

--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -168,14 +168,14 @@ bool CChat::OnInput(IInput::CEvent Event)
 				if(Text[i] == '\n')
 				{
 					int max = minimum(i - Begin + 1, (int)sizeof(Line));
-					str_utf8_truncate(Line, max, Text + Begin, max);
+					str_utf8_copy(Line, Text + Begin, max);
 					Begin = i+1;
 					SayChat(Line);
 					while(Text[i] == '\n') i++;
 				}
 			}
 			int max = minimum(i - Begin + 1, (int)sizeof(Line));
-			str_utf8_truncate(Line, max, Text + Begin, max);
+			str_utf8_copy(Line, Text + Begin, max);
 			Begin = i+1;
 			m_Input.Add(Line);
 		}

--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -168,14 +168,14 @@ bool CChat::OnInput(IInput::CEvent Event)
 				if(Text[i] == '\n')
 				{
 					int max = minimum(i - Begin + 1, (int)sizeof(Line));
-					str_utf8_copy(Line, Text + Begin, max);
+					str_utf8_truncate(Line, max, Text + Begin, max);
 					Begin = i+1;
 					SayChat(Line);
 					while(Text[i] == '\n') i++;
 				}
 			}
 			int max = minimum(i - Begin + 1, (int)sizeof(Line));
-			str_utf8_copy(Line, Text + Begin, max);
+			str_utf8_truncate(Line, max, Text + Begin, max);
 			Begin = i+1;
 			m_Input.Add(Line);
 		}

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -249,12 +249,16 @@ int CMenus::DoEditBox(void *pID, const CUIRect *pRect, char *pStr, unsigned StrS
 			{
 				int Offset = str_length(pStr);
 				int CharsLeft = StrSize - Offset - 1;
-				for(int i = 0; i < str_length(Text) && i < CharsLeft; i++)
+				char *pCur = pStr + Offset;
+				str_utf8_copy(pCur, Text, CharsLeft);
+				for(int i = 0; i < CharsLeft; i++)
 				{
-					if(Text[i] == '\n')
-						pStr[i + Offset] = ' ';
-					else
-						pStr[i + Offset] = Text[i];
+					if(pCur[i] == 0)
+						break;
+					else if(pCur[i] == '\r')
+						pCur[i] = ' ';
+					else if(pCur[i] == '\n')
+						pCur[i] = ' ';
 				}
 				s_AtIndex = str_length(pStr);
 				ReturnValue = true;

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -250,7 +250,7 @@ int CMenus::DoEditBox(void *pID, const CUIRect *pRect, char *pStr, unsigned StrS
 				int Offset = str_length(pStr);
 				int CharsLeft = StrSize - Offset - 1;
 				char *pCur = pStr + Offset;
-				str_utf8_copy(pCur, Text, CharsLeft);
+				str_utf8_truncate(pCur, CharsLeft, Text, CharsLeft);
 				for(int i = 0; i < CharsLeft; i++)
 				{
 					if(pCur[i] == 0)

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -250,7 +250,7 @@ int CMenus::DoEditBox(void *pID, const CUIRect *pRect, char *pStr, unsigned StrS
 				int Offset = str_length(pStr);
 				int CharsLeft = StrSize - Offset - 1;
 				char *pCur = pStr + Offset;
-				str_utf8_truncate(pCur, CharsLeft, Text, CharsLeft);
+				str_utf8_copy(pCur, Text, CharsLeft);
 				for(int i = 0; i < CharsLeft; i++)
 				{
 					if(pCur[i] == 0)

--- a/src/test/str.cpp
+++ b/src/test/str.cpp
@@ -218,19 +218,19 @@ TEST(Str, StrCopyUtf8)
 	str_utf8_copy(aBuf, foo, 8);
 	EXPECT_STREQ(aBuf, "DDNet");
 	str_utf8_copy(aBuf, foo, 9);
-	EXPECT_STREQ(aBuf, "DDNet");
+	EXPECT_STREQ(aBuf, "DDNet最");
 	str_utf8_copy(aBuf, foo, 10);
 	EXPECT_STREQ(aBuf, "DDNet最");
 	str_utf8_copy(aBuf, foo, 11);
 	EXPECT_STREQ(aBuf, "DDNet最");
 	str_utf8_copy(aBuf, foo, 12);
-	EXPECT_STREQ(aBuf, "DDNet最");
+	EXPECT_STREQ(aBuf, "DDNet最好");
 	str_utf8_copy(aBuf, foo, 13);
 	EXPECT_STREQ(aBuf, "DDNet最好");
 	str_utf8_copy(aBuf, foo, 14);
 	EXPECT_STREQ(aBuf, "DDNet最好");
 	str_utf8_copy(aBuf, foo, 15);
-	EXPECT_STREQ(aBuf, "DDNet最好");
+	EXPECT_STREQ(aBuf, "DDNet最好了");
 	str_utf8_copy(aBuf, foo, 16);
 	EXPECT_STREQ(aBuf, "DDNet最好了");
 }

--- a/src/test/str.cpp
+++ b/src/test/str.cpp
@@ -208,3 +208,29 @@ TEST(Str, StrCopyNum)
 	str_utf8_truncate(aBuf3, sizeof(aBuf3), foo, 7);
 	EXPECT_STREQ(aBuf3, "Foobaré");
 }
+
+TEST(Str, StrCopyUtf8)
+{
+	const char *foo = "DDNet最好了";
+	char aBuf[64];
+	str_utf8_copy(aBuf, foo, 7);
+	EXPECT_STREQ(aBuf, "DDNet");
+	str_utf8_copy(aBuf, foo, 8);
+	EXPECT_STREQ(aBuf, "DDNet");
+	str_utf8_copy(aBuf, foo, 9);
+	EXPECT_STREQ(aBuf, "DDNet");
+	str_utf8_copy(aBuf, foo, 10);
+	EXPECT_STREQ(aBuf, "DDNet最");
+	str_utf8_copy(aBuf, foo, 11);
+	EXPECT_STREQ(aBuf, "DDNet最");
+	str_utf8_copy(aBuf, foo, 12);
+	EXPECT_STREQ(aBuf, "DDNet最");
+	str_utf8_copy(aBuf, foo, 13);
+	EXPECT_STREQ(aBuf, "DDNet最好");
+	str_utf8_copy(aBuf, foo, 14);
+	EXPECT_STREQ(aBuf, "DDNet最好");
+	str_utf8_copy(aBuf, foo, 15);
+	EXPECT_STREQ(aBuf, "DDNet最好");
+	str_utf8_copy(aBuf, foo, 16);
+	EXPECT_STREQ(aBuf, "DDNet最好了");
+}


### PR DESCRIPTION
Currently this replaces `str_copy` text input and clipboard paste in chat. Many places may need the same treatments, like steam names.

![image](https://user-images.githubusercontent.com/3797859/92263741-08b8e080-eed5-11ea-84a5-b7f070ded260.png)

Test string:
abcd今天是个好日子心想的事儿都能成今天是个好日子打开了家门咱迎春风今天是个好日子心想的事儿都能成今天是个好日子打开了家门咱迎春风今天是个好日子心想的事儿都能成今天是个好日子打