### PR TITLE
Don't deactivate menu when a popup is active

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -1348,6 +1348,7 @@ int CMenus::Render()
 			{
 				Client()->DummyDisconnect(0);
 				m_Popup = POPUP_NONE;
+				SetActive(false);
 			}
 		}
 		else if(m_Popup == POPUP_PASSWORD)
@@ -2103,7 +2104,7 @@ void CMenus::OnRender()
 void CMenus::RenderBackground()
 {
 	Graphics()->BlendNormal();
-	
+
 	float sw = 300*Graphics()->ScreenAspect();
 	float sh = 300;
 	Graphics()->MapScreen(0, 0, sw, sh);

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -83,9 +83,9 @@ void CMenus::RenderGame(CUIRect MainView)
 			else
 			{
 				Client()->DummyDisconnect(0);
+				SetActive(false);
 			}
 		}
-		SetActive(false);
 	}
 
 	ButtonBar.VSplitRight(5.0f, &ButtonBar, 0);


### PR DESCRIPTION
Deactivating menu while a popup is active causes the menu to never open again.

Reported by Anxton on discord.