### PR TITLE
Don't lock SQL writes

### DIFF
--- a/src/game/server/score.cpp
+++ b/src/game/server/score.cpp
@@ -574,11 +574,6 @@ bool CScore::SaveTeamScoreThread(IDbConnection *pSqlServer, const ISqlData *pGam
 	for(unsigned int i = 0; i < pData->m_Size; i++)
 		aNames.push_back(pData->m_aNames[i]);
 
-	char aTable[512];
-	str_format(aTable, sizeof(aTable),
-			"%s_teamrace WRITE, %s_teamrace AS r WRITE",
-			pSqlServer->GetPrefix(), pSqlServer->GetPrefix());
-	pSqlServer->Lock(aTable);
 	std::sort(aNames.begin(), aNames.end());
 	str_format(aBuf, sizeof(aBuf),
 			"SELECT l.ID, Name, Time "
@@ -645,8 +640,6 @@ bool CScore::SaveTeamScoreThread(IDbConnection *pSqlServer, const ISqlData *pGam
 			pSqlServer->Step();
 		}
 	}
-	pSqlServer->Unlock();
-
 	return true;
 }
 


### PR DESCRIPTION
The slow query logs are full of this:

    # Time: 200906 21:03:43
    # User@Host: teeworlds[teeworlds] @ ger6.ddnet.tw [89.163.212.120]
    # Thread_id: 101540  Schema: teeworlds  QC_hit: No
    # Query_time: 11.012166  Lock_time: 0.000000  Rows_sent: 0  Rows_examined: 0
    # Rows_affected: 0  Bytes_sent: 67
    SET timestamp=1599419023;
    LOCK TABLES record_teamrace WRITE, record_teamrace AS r WRITE;

Do we really need these lock? See also
https://dev.mysql.com/doc/refman/5.7/en/table-locking.html

> InnoDB tables use row-level locking so that multiple sessions and
> applications can read from and write to the same table simultaneously,
> without making each other wait or producing inconsistent results. For
> this storage engine, avoid using the LOCK TABLES statement, because it
> does not offer any extra protection, but instead reduces concurrency.