### PR TITLE
Clamp kill border count

### DIFF
--- a/src/game/client/components/camera.cpp
+++ b/src/game/client/components/camera.cpp
@@ -36,9 +36,19 @@ void CCamera::ScaleZoom(float Factor)
 	ChangeZoom(CurrentTarget * Factor);
 }
 
+float CCamera::MaxZoomLevel()
+{
+	return (Graphics()->IsTileBufferingEnabled()? 60 : 30);
+}
+
+float CCamera::MinZoomLevel()
+{
+	return 0.01f;
+}
+
 void CCamera::ChangeZoom(float Target)
 {
-	if(Target >= (Graphics()->IsTileBufferingEnabled()? 60 : 30))
+	if(Target > MaxZoomLevel() || Target < MinZoomLevel())
 	{
 		return;
 	}
@@ -75,6 +85,7 @@ void CCamera::OnRender()
 		{
 			m_Zoom = m_ZoomSmoothing.Evaluate(ZoomProgress(Time));
 		}
+		m_Zoom = clamp(m_Zoom, MinZoomLevel(), MaxZoomLevel());
 	}
 
 	if(!(m_pClient->m_Snap.m_SpecInfo.m_Active || GameClient()->m_GameInfo.m_AllowZoom || Client()->State() == IClient::STATE_DEMOPLAYBACK))

--- a/src/game/client/components/camera.h
+++ b/src/game/client/components/camera.h
@@ -28,6 +28,8 @@ class CCamera : public CComponent
 	void ChangeZoom(float Target);
 	float ZoomProgress(float CurrentTime) const;
 
+	float MinZoomLevel();
+	float MaxZoomLevel();
 public:
 	vec2 m_Center;
 	bool m_ZoomSet;

--- a/src/game/client/components/maplayers.cpp
+++ b/src/game/client/components/maplayers.cpp
@@ -1293,6 +1293,8 @@ void CMapLayers::RenderKillTileBorder(int LayerIndex, ColorRGBA* pColor, CMapIte
 		vec2 Offset;
 		int OffX0 = (BorderX0 < -201 ? -201 : BorderX0);
 		int OffX1 = (BorderX1 >= pTileLayer->m_Width + 201 ? pTileLayer->m_Width + 201 : BorderX1);
+		OffX0 = clamp(OffX0, -201, (int)pTileLayer->m_Width + 201);
+		OffX1 = clamp(OffX1, -201, (int)pTileLayer->m_Width + 201);
 		Offset.x = OffX0 * 32.f;
 		Offset.y = BorderY0 * 32.f;
 		vec2 Dir;
@@ -1321,6 +1323,8 @@ void CMapLayers::RenderKillTileBorder(int LayerIndex, ColorRGBA* pColor, CMapIte
 		vec2 Offset;
 		int OffX0 = (BorderX0 < -201 ? -201 : BorderX0);
 		int OffX1 = (BorderX1 >= pTileLayer->m_Width + 201 ? pTileLayer->m_Width + 201 : BorderX1);
+		OffX0 = clamp(OffX0, -201, (int)pTileLayer->m_Width + 201);
+		OffX1 = clamp(OffX1, -201, (int)pTileLayer->m_Width + 201);
 		Offset.x = OffX0 * 32.f;
 		Offset.y = (pTileLayer->m_Height + 201) * 32.f;
 		vec2 Dir;


### PR DESCRIPTION
fixes #2766

Appearently the center of the camera can even go outside of the kill border(like even left from it)

I also notice that sometimes when zooming out, and then in again the zoom level gets negative(since the new smooth zoom)(atleast i see everything upside down for few frames)

These numerical unstableness makes me sweat a bit xd