### PR TITLE
Fix duplicate teamranks (fixes #2405)

### DIFF
--- a/src/game/server/score.cpp
+++ b/src/game/server/score.cpp
@@ -582,8 +582,8 @@ bool CScore::SaveTeamScoreThread(IDbConnection *pSqlServer, const ISqlData *pGam
 					"FROM %s_teamrace "
 					"WHERE Map = ? AND Name = ? AND DDNet7 = false"
 			") as l INNER JOIN %s_teamrace AS r ON l.ID = r.ID "
-			"ORDER BY l.ID, Name COLLATE utf8mb4_bin;",
-			pSqlServer->GetPrefix(), pSqlServer->GetPrefix());
+			"ORDER BY l.ID, Name COLLATE %s;",
+			pSqlServer->GetPrefix(), pSqlServer->GetPrefix(), pSqlServer->BinaryCollate());
 	pSqlServer->PrepareStatement(aBuf);
 	pSqlServer->BindString(1, pData->m_Map);
 	pSqlServer->BindString(2, pData->m_aNames[0]);


### PR DESCRIPTION
by ordering names in binary collation, consistent with C++ std::sort

Required since the official DDNet DB uses utf8mb4_general_ci default collation