### PR TITLE
Refresh server browser immediately when updated ddnet info arrived

### DIFF
--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -343,6 +343,7 @@ public:
 
 	void RequestDDNetInfo();
 	void ResetDDNetInfo();
+	bool IsDDNetInfoChanged();
 	void FinishDDNetInfo();
 	void LoadDDNetInfo();
 


### PR DESCRIPTION
At the moment it only happens the next time you press refresh.

Before we had it so that it always reloaded once the ddnet info arrived,
causing a quick flickering and lots of packets having to be resent every
time someone pressed refresh, even if nothing changed.

The new approach combines the advantages of both without the
disadvantages. An even nicer way would be to compare the json objects,
so that news and version updates don't matter, but our json library
doesn't seem to support that.