### PR TITLE
Find the common ancestor for the style checking

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -23,5 +23,5 @@ jobs:
     - name: Check style
       run: |
         clang-format -version
-        scripts/fix_style.py --dry-run --base "$(git merge-base origin/master $GITHUB_SHA)"
+        scripts/fix_style.py --dry-run --base origin/master
         scripts/check_header_guards.py

--- a/scripts/fix_style.py
+++ b/scripts/fix_style.py
@@ -43,6 +43,8 @@ def warn(changed_lines):
 		result = subprocess.call(["clang-format", "-Werror", "--dry-run"] + ["--lines={}:{}".format(start, end) for start, end in changed_lines[filename]] + [filename]) or result
 	return result
 
+def get_common_base(base):
+	return subprocess.check_output(["git", "merge-base", "HEAD", base]).decode().strip()
 
 def main():
 	import argparse


### PR DESCRIPTION
This allows the style checker to only look at the changes done in the
current branch, and not the other commits that were done in the base
branch.