### PR TITLE
Retry SQL write statements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1403,6 +1403,7 @@ set_src(BASE GLOB_RECURSE src/base
   tl/allocator.h
   tl/array.h
   tl/base.h
+  tl/mpsc.h
   tl/range.h
   tl/sorted_array.h
   tl/string.h

--- a/src/base/system.c
+++ b/src/base/system.c
@@ -866,11 +866,26 @@ void lock_unlock(LOCK lock)
 }
 
 #if defined(CONF_FAMILY_WINDOWS)
-void sphore_init(SEMAPHORE *sem) { *sem = CreateSemaphore(0, 0, 10000, 0); }
-void sphore_wait(SEMAPHORE *sem) { WaitForSingleObject((HANDLE)*sem, INFINITE); }
-int sphore_trywait(SEMAPHORE *sem) { return WaitForSingleObject((HANDLE)*sem, 0) == WAIT_OBJECT_0; }
-void sphore_signal(SEMAPHORE *sem) { ReleaseSemaphore((HANDLE)*sem, 1, NULL); }
-void sphore_destroy(SEMAPHORE *sem) { CloseHandle((HANDLE)*sem); }
+void sphore_init(SEMAPHORE *sem)
+{
+	*sem = CreateSemaphore(0, 0, 10000, 0);
+}
+void sphore_wait(SEMAPHORE *sem)
+{
+	WaitForSingleObject((HANDLE)*sem, INFINITE);
+}
+int sphore_trywait(SEMAPHORE *sem)
+{
+	return WaitForSingleObject((HANDLE)*sem, 0) == WAIT_OBJECT_0;
+}
+void sphore_signal(SEMAPHORE *sem)
+{
+	ReleaseSemaphore((HANDLE)*sem, 1, NULL);
+}
+void sphore_destroy(SEMAPHORE *sem)
+{
+	CloseHandle((HANDLE)*sem);
+}
 #elif defined(CONF_PLATFORM_MACOSX)
 void sphore_init(SEMAPHORE *sem)
 {
@@ -878,9 +893,18 @@ void sphore_init(SEMAPHORE *sem)
 	str_format(aBuf, sizeof(aBuf), "/%d-ddnet.tw-%p", pid(), (void *)sem);
 	*sem = sem_open(aBuf, O_CREAT | O_EXCL, S_IRWXU | S_IRWXG, 0);
 }
-void sphore_wait(SEMAPHORE *sem) { sem_wait(*sem); }
-int sphore_trywait(SEMAPHORE *sem) { return sem_trywait(*sem) == 0; }
-void sphore_signal(SEMAPHORE *sem) { sem_post(*sem); }
+void sphore_wait(SEMAPHORE *sem)
+{
+	sem_wait(*sem);
+}
+int sphore_trywait(SEMAPHORE *sem)
+{
+	return sem_trywait(*sem) == 0;
+}
+void sphore_signal(SEMAPHORE *sem)
+{
+	sem_post(*sem);
+}
 void sphore_destroy(SEMAPHORE *sem)
 {
 	char aBuf[64];

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -557,6 +557,8 @@ void lock_unlock(LOCK lock);
 
 void sphore_init(SEMAPHORE *sem);
 void sphore_wait(SEMAPHORE *sem);
+// returns non-zero value if successfully decreasing the semaphore
+int sphore_trywait(SEMAPHORE *sem);
 void sphore_signal(SEMAPHORE *sem);
 void sphore_destroy(SEMAPHORE *sem);
 

--- a/src/base/tl/mpsc.h
+++ b/src/base/tl/mpsc.h
@@ -1,0 +1,60 @@
+#ifndef BASE_TL_MPSC_H
+#define BASE_TL_MPSC_H
+
+#include "threading.h"
+
+#include <atomic>
+#include <mutex>
+#include <queue>
+
+// simple thread safe multiple producer, single consumer queue
+template<class T, int size>
+class CMpsc
+{
+public:
+	CMpsc()
+		: m_Head(0),
+		  m_Tail(0),
+		  m_SignalElems(new semaphore()),
+		  m_SendMutex(new std::mutex())
+	{
+	}
+
+	void Send(T Task)
+	{
+		std::lock_guard<std::mutex> lock(*m_SendMutex);
+		m_Queue[m_Head++] = std::move(Task);
+		m_Head %= sizeof(m_Queue) / sizeof(m_Queue[0]);
+		m_SignalElems->signal();
+	}
+
+	T Recv()
+	{
+		m_SignalElems->wait();
+		T pThreadData = std::move(m_Queue[m_Tail++]);
+		m_Tail %= sizeof(m_Queue) / sizeof(m_Queue[0]);
+		return pThreadData; // guaranteed to be move semantic
+	}
+
+	// non-blocking; given pointer has to be allocated
+	// only written to if true is returned
+	bool TryRecv(T *pTask)
+	{
+		if(m_SignalElems->trywait())
+		{
+			*pTask = std::move(m_Queue[m_Tail++]);
+			m_Tail %= sizeof(m_Queue) / sizeof(m_Queue[0]);
+			return true;
+		}
+		return false;
+	}
+
+private:
+	int m_Head;
+	int m_Tail;
+	std::unique_ptr<semaphore> m_SignalElems;
+	std::unique_ptr<std::mutex> m_SendMutex;
+	T m_Queue[size];
+};
+
+#endif // BASE_TL_MPSC_H

--- a/src/base/tl/threading.h
+++ b/src/base/tl/threading.h
@@ -11,6 +11,7 @@ public:
 	~semaphore() { sphore_destroy(&sem); }
 	semaphore(const semaphore&) = delete;
 	void wait() { sphore_wait(&sem); }
+	bool trywait() { return sphore_trywait(&sem) != 0; }
 	void signal() { sphore_signal(&sem); }
 };
 

--- a/src/engine/server/databases/connection.h
+++ b/src/engine/server/databases/connection.h
@@ -14,8 +14,8 @@ public:
 		str_copy(m_aPrefix, pPrefix, sizeof(m_aPrefix));
 	}
 	virtual ~IDbConnection() {}
-	IDbConnection& operator=(const IDbConnection&) = delete;
-	virtual void Print(IConsole *pConsole, const char *Mode) = 0;
+	IDbConnection &operator=(const IDbConnection &) = delete;
+	virtual void Format(char *pBuffer, int BufferSize) = 0;
 
 	// copies the credentials, not the active connection
 	virtual IDbConnection *Copy() = 0;

--- a/src/engine/server/databases/connection_pool.cpp
+++ b/src/engine/server/databases/connection_pool.cpp
@@ -1,116 +1,243 @@
 #include "connection_pool.h"
 #include "connection.h"
 
+#include <base/math.h>
+#include <base/tl/mpsc.h>
+#include <base/tl/threading.h>
 #include <engine/console.h>
+#include <engine/shared/uuid_manager.h>
+
 #if defined(CONF_SQL)
 #include <cppconn/exception.h>
 #endif
-#include <stdexcept>
 
-// helper struct to hold thread data
+#include <atomic>
+#include <chrono>
+#include <stdexcept>
+#include <vector>
+
+static int64 millis()
+{
+	auto duration = std::chrono::system_clock::now().time_since_epoch();
+	return std::chrono::duration_cast<std::chrono::microseconds>(duration).count();
+}
+
+// struct holding data for one sql execution thread
 struct CSqlExecData
 {
 	CSqlExecData(
-			CDbConnectionPool::FRead pFunc,
-			std::unique_ptr<const ISqlData> pThreadData,
-			const char *pName);
-	CSqlExecData(
-			CDbConnectionPool::FWrite pFunc,
-			std::unique_ptr<const ISqlData> pThreadData,
-			const char *pName);
-	~CSqlExecData() {}
-
-	enum
+		FSqlThread pFunc,
+		std::unique_ptr<const ISqlData> pThreadData,
+		const char *pName,
+		bool FaultTolerant)
+		: m_pSqlFunc(pFunc),
+		  m_pName(pName),
+		  m_FaultTolerant(FaultTolerant),
+		  m_NumTries(0),
+		  m_LastTryTime(0),
+		  m_CreateTime(time_timestamp())
 	{
-		READ_ACCESS,
-		WRITE_ACCESS,
-	} m_Mode;
-	union
-	{
-		CDbConnectionPool::FRead m_pReadFunc;
-		CDbConnectionPool::FWrite m_pWriteFunc;
-	} m_Ptr;
+		CUuid Id = RandomUuid();
+		FormatUuid(Id, m_Id, sizeof(m_Id));
+		m_pThreadData = std::move(pThreadData);
+	}
 
+	void PrintPerf(const char *pThreadName, const char *pAction)
+	{
+		dbg_msg("sql_perf", "%s,%s,%s,%s,%lld", m_Id, m_pName, pThreadName, pAction, millis());
+	}
+
+	FSqlThread m_pSqlFunc;
 	std::unique_ptr<const ISqlData> m_pThreadData;
 	const char *m_pName;
+
+	char m_Id[UUID_MAXSTRSIZE];
+	bool m_FaultTolerant;
+	int m_NumTries;
+	int m_LastTryTime;
+	int m_CreateTime;
 };
 
-CSqlExecData::CSqlExecData(
-	CDbConnectionPool::FRead pFunc,
-	std::unique_ptr<const ISqlData> pThreadData,
-	const char *pName) :
-			m_Mode(READ_ACCESS),
-			m_pThreadData(std::move(pThreadData)),
-			m_pName(pName)
+// struct holding one task to process
+struct CSqlTask
 {
-	m_Ptr.m_pReadFunc = pFunc;
+	enum Task
+	{
+		NONE,
+		ADD_SQL_SERVER,
+		SET_SQL_BACKUP_SERVER,
+		EXECUTE_THREAD,
+		PRINT_SQL_SERVER,
+		SHUTDOWN,
+	} m_Task;
+
+	// no using a union, since unions don't support non-POD (plain old data)
+	// set if m_Task is either ADD_SQL_SERVER or ADD_SQL_BACKUP_SERVER
+	std::unique_ptr<IDbConnection> m_Db;
+	// set if m_Task is EXECUTE_THREAD
+	std::unique_ptr<struct CSqlExecData> m_ExecData;
+
+	static CSqlTask ExecuteThread(std::unique_ptr<struct CSqlExecData> pThreadData)
+	{
+		return CSqlTask(EXECUTE_THREAD, nullptr, std::move(pThreadData));
+	}
+	static CSqlTask RegisterDb(std::unique_ptr<IDbConnection> pDb)
+	{
+		return CSqlTask(ADD_SQL_SERVER, std::move(pDb), nullptr);
+	}
+	static CSqlTask SetBackupDb(std::unique_ptr<IDbConnection> pDb)
+	{
+		return CSqlTask(SET_SQL_BACKUP_SERVER, std::move(pDb), nullptr);
+	}
+	static CSqlTask Print()
+	{
+		return CSqlTask(PRINT_SQL_SERVER, nullptr, nullptr);
+	}
+	static CSqlTask Shutdown()
+	{
+		return CSqlTask(SHUTDOWN, nullptr, nullptr);
+	}
+
+	CSqlTask()
+		: m_Task(NONE)
+	{
+	}
+
+private:
+	CSqlTask(Task t, std::unique_ptr<IDbConnection> pDb, std::unique_ptr<struct CSqlExecData> pThreadData)
+		: m_Task(t)
+	{
+		m_Db = std::move(pDb);
+		m_ExecData = std::move(pThreadData);
+	}
+};
+
+struct CWorker
+{
+	// Mode in which the thread using this queue operates
+	CDbConnectionPool::Mode m_Mode;
+	CMpsc<CSqlTask, 512> m_Queue;
+
+	CWorker(CDbConnectionPool::Mode Mode)
+		: m_Mode(Mode)
+	{
+	}
+};
+
+// private implementation of the connection pool
+struct CDbConnectionPool::Impl
+{
+	Impl();
+	std::vector<std::unique_ptr<IDbConnection>> m_aapDbConnections[CDbConnectionPool::NUM_MODES];
+
+	static void ReadWorker(void *pUser);
+	static void WriteWorker(void *pUser);
+	static void WriteBackupWorker(void *pUser);
+
+	void Worker(CWorker *pWorker);
+	bool ExecSqlFunc(IDbConnection *pConnection, struct CSqlExecData *pData, bool Failure);
+
+	// three queues for inter-thread communication:
+	// 1. main thread -> read thread
+	// 2. main thread -> write thread
+	// 3. main thread, write thread, write_backup thread -> write_backup thread
+	CWorker m_aWorker[CDbConnectionPool::NUM_MODES];
+
+	// Threads can relay information back to the main thread by putting information into
+	// this queue
+	CMpsc<CSqlResponse, 64> m_Responses;
+
+	// stores the number of threads, that didn't shutdown yet, after OnShutdown was issued
+	std::atomic_int m_Shutdown;
+};
+
+CDbConnectionPool::Impl::Impl()
+	: m_aWorker{CWorker(READ), CWorker(WRITE), CWorker(WRITE_BACKUP)}
+{
+	thread_init_and_detach(Impl::ReadWorker, this, "database read worker thread");
+	thread_init_and_detach(Impl::WriteWorker, this, "database write worker thread");
+	thread_init_and_detach(Impl::WriteBackupWorker, this, "database write backup worker thread");
 }
 
-CSqlExecData::CSqlExecData(
-	CDbConnectionPool::FWrite pFunc,
-	std::unique_ptr<const ISqlData> pThreadData,
-	const char *pName) :
-			m_Mode(WRITE_ACCESS),
-			m_pThreadData(std::move(pThreadData)),
-			m_pName(pName)
+CDbConnectionPool::CDbConnectionPool()
 {
-	m_Ptr.m_pWriteFunc = pFunc;
-}
-
-CDbConnectionPool::CDbConnectionPool() :
-	m_NumElem(),
-	FirstElem(0),
-	LastElem(0)
-{
-	thread_init_and_detach(CDbConnectionPool::Worker, this, "database worker thread");
+	pImpl = std::unique_ptr<Impl>(new Impl());
 }
 
 CDbConnectionPool::~CDbConnectionPool()
 {
 }
 
+// public interface of the connection pool
 void CDbConnectionPool::Print(IConsole *pConsole, Mode DatabaseMode)
 {
-	const char *ModeDesc[] = {"Read", "Write", "WriteBackup"};
-	for(unsigned int i = 0; i < m_aapDbConnections[DatabaseMode].size(); i++)
-	{
-		m_aapDbConnections[DatabaseMode][i]->Print(pConsole, ModeDesc[DatabaseMode]);
-	}
+	if(0 <= DatabaseMode && DatabaseMode < Mode::NUM_MODES)
+		pImpl->m_aWorker[DatabaseMode].m_Queue.Send(std::move(CSqlTask::Print()));
 }
 
 void CDbConnectionPool::RegisterDatabase(std::unique_ptr<IDbConnection> pDatabase, Mode DatabaseMode)
 {
-	if(DatabaseMode < 0 || NUM_MODES <= DatabaseMode)
-		return;
-	m_aapDbConnections[DatabaseMode].push_back(std::move(pDatabase));
+	switch(DatabaseMode)
+	{
+	case READ:
+		pImpl->m_aWorker[READ].m_Queue.Send(std::move(CSqlTask::RegisterDb(std::move(pDatabase))));
+		break;
+	case WRITE:
+		pImpl->m_aWorker[WRITE].m_Queue.Send(std::move(CSqlTask::RegisterDb(
+			std::move(std::unique_ptr<IDbConnection>(pDatabase->Copy())))));
+		pImpl->m_aWorker[WRITE_BACKUP].m_Queue.Send(std::move(CSqlTask::RegisterDb(std::move(pDatabase))));
+		break;
+	case WRITE_BACKUP:
+		pImpl->m_aWorker[WRITE_BACKUP].m_Queue.Send(std::move(CSqlTask::SetBackupDb(std::move(pDatabase))));
+		break;
+	case NUM_MODES:
+		break;
+	}
 }
 
-void CDbConnectionPool::Execute(
-		FRead pFunc,
-		std::unique_ptr<const ISqlData> pThreadData,
-		const char *pName)
+void CDbConnectionPool::ExecuteRead(
+	FSqlThread pFunc,
+	std::unique_ptr<const ISqlData> pThreadData,
+	const char *pName)
 {
-	m_aTasks[FirstElem++].reset(new CSqlExecData(pFunc, std::move(pThreadData), pName));
-	FirstElem %= sizeof(m_aTasks) / sizeof(m_aTasks[0]);
-	m_NumElem.signal();
+	auto pTask = std::unique_ptr<CSqlExecData>(new CSqlExecData(pFunc, std::move(pThreadData), pName, false));
+	pTask->PrintPerf("Main", "Create");
+	pImpl->m_aWorker[READ].m_Queue.Send(std::move(CSqlTask::ExecuteThread(std::move(pTask))));
 }
 
 void CDbConnectionPool::ExecuteWrite(
-		FWrite pFunc,
-		std::unique_ptr<const ISqlData> pThreadData,
-		const char *pName)
+	FSqlThread pFunc,
+	std::unique_ptr<const ISqlData> pThreadData,
+	const char *pName)
 {
-	m_aTasks[FirstElem++].reset(new CSqlExecData(pFunc, std::move(pThreadData), pName));
-	FirstElem %= sizeof(m_aTasks) / sizeof(m_aTasks[0]);
-	m_NumElem.signal();
+	auto pTask = std::unique_ptr<CSqlExecData>(new CSqlExecData(pFunc, std::move(pThreadData), pName, false));
+	pTask->PrintPerf("Main", "Create");
+	pImpl->m_aWorker[WRITE].m_Queue.Send(std::move(CSqlTask::ExecuteThread(std::move(pTask))));
+}
+
+void CDbConnectionPool::ExecuteWriteFaultTolerant(
+	FSqlThread pFunc,
+	std::unique_ptr<const ISqlData> pThreadData,
+	const char *pName)
+{
+	auto pTask = std::unique_ptr<CSqlExecData>(new CSqlExecData(pFunc, std::move(pThreadData), pName, true));
+	pTask->PrintPerf("Main", "Create");
+	pImpl->m_aWorker[WRITE].m_Queue.Send(std::move(CSqlTask::ExecuteThread(std::move(pTask))));
+}
+
+bool CDbConnectionPool::GetResponse(CSqlResponse *pResponse)
+{
+	return pImpl->m_Responses.TryRecv(pResponse);
 }
 
 void CDbConnectionPool::OnShutdown()
 {
-	m_Shutdown.store(true);
-	m_NumElem.signal();
+	pImpl->m_Shutdown.store(NUM_MODES);
+	// "close" the sender from the main thread
+	for(int i = 0; i < NUM_MODES; i++)
+		pImpl->m_aWorker[i].m_Queue.Send(std::move(CSqlTask::Shutdown()));
 	int i = 0;
-	while(m_Shutdown.load())
+	while(pImpl->m_Shutdown.load() != 0)
 	{
 		if (i > 600)  {
 			dbg_msg("sql", "Waited 60 seconds for score-threads to complete, quitting anyway");
@@ -125,21 +252,176 @@ void CDbConnectionPool::OnShutdown()
 	}
 }
 
-void CDbConnectionPool::Worker(void *pUser)
+void CDbConnectionPool::Impl::ReadWorker(void *pUser)
 {
-	CDbConnectionPool *pThis = (CDbConnectionPool *)pUser;
-	pThis->Worker();
+	CDbConnectionPool::Impl *pThis = (CDbConnectionPool::Impl *)pUser;
+	pThis->Worker(&pThis->m_aWorker[READ]);
 }
 
-void CDbConnectionPool::Worker()
+void CDbConnectionPool::Impl::WriteWorker(void *pUser)
+{
+	CDbConnectionPool::Impl *pThis = (CDbConnectionPool::Impl *)pUser;
+	pThis->Worker(&pThis->m_aWorker[WRITE]);
+}
+
+void CDbConnectionPool::Impl::WriteBackupWorker(void *pUser)
+{
+	CDbConnectionPool::Impl *pThis = (CDbConnectionPool::Impl *)pUser;
+	pThis->Worker(&pThis->m_aWorker[WRITE_BACKUP]);
+}
+
+void CDbConnectionPool::Impl::Worker(CWorker *pWorker)
 {
 	// remember last working server and try to connect to it first
-	int ReadServer = 0;
-	int WriteServer = 0;
+	int LastServer = 0;
+	std::vector<std::unique_ptr<IDbConnection>> apDb;
+	std::unique_ptr<IDbConnection> pDbBackup = nullptr;
+	const char *ModeDesc[] = {"Read", "Write", "WriteBackup"};
+	int NumClosed = 0;
 	while(1)
 	{
-		m_NumElem.wait();
-		auto pThreadData = std::move(m_aTasks[LastElem++]);
+		CSqlTask Task = pWorker->m_Queue.Recv();
+		switch(Task.m_Task)
+		{
+		case CSqlTask::NONE:
+			dbg_msg("sql_pool", "received empty job, which shouldn't happen");
+			break;
+		case CSqlTask::ADD_SQL_SERVER:
+		{
+			if(Task.m_Db == nullptr)
+				dbg_msg("sql_pool", "received invalid add_sql_server request (nullptr)");
+			else
+				apDb.push_back(std::move(Task.m_Db));
+			break;
+		}
+		case CSqlTask::SET_SQL_BACKUP_SERVER:
+		{
+			if(Task.m_Db == nullptr)
+				dbg_msg("sql_pool", "received invalid set_sql_backup_server request (nullptr)");
+			else
+				pDbBackup = std::move(Task.m_Db);
+			break;
+		}
+		case CSqlTask::EXECUTE_THREAD:
+		{
+			Task.m_ExecData->m_NumTries += 1;
+			Task.m_ExecData->PrintPerf(ModeDesc[pWorker->m_Mode], "Dequeue");
+			if(pWorker->m_Mode == WRITE_BACKUP && !m_Shutdown)
+			{
+				// delay retries around 10 sec (convert seconds to microseconds) to prevent flooding the sql server
+				// but also process queries in time
+				thread_sleep(clamp(10 + time_timestamp() - Task.m_ExecData->m_LastTryTime, 0, 10) * 1000000);
+				Task.m_ExecData->PrintPerf(ModeDesc[pWorker->m_Mode], "Wait");
+			}
+			bool Success = false;
+			for(int i = 0; i < (int)apDb.size(); i++)
+			{
+				if(m_Shutdown)
+				{
+					// When shutting down, always use backup SQLite DB to speed things up, discarding reads
+					break;
+				}
+				int CurServer = (LastServer + i) % (int)apDb.size();
+				if(ExecSqlFunc(apDb[CurServer].get(), Task.m_ExecData.get(), false))
+				{
+					char aBuf[16];
+					str_format(aBuf, sizeof(aBuf), "Success %d", CurServer);
+					Task.m_ExecData->PrintPerf(ModeDesc[pWorker->m_Mode], aBuf);
+					LastServer = CurServer;
+					dbg_msg("sql", "%s done on %s database %d", Task.m_ExecData->m_pName, ModeDesc[pWorker->m_Mode], CurServer);
+					Success = true;
+					break;
+				}
+				else
+				{
+					char aBuf[16];
+					str_format(aBuf, sizeof(aBuf), "Failure %d", CurServer);
+					Task.m_ExecData->PrintPerf(ModeDesc[pWorker->m_Mode], aBuf);
+				}
+			}
+			Task.m_ExecData->m_LastTryTime = time_timestamp();
+			if(!Success && pWorker->m_Mode == WRITE)
+			{
+				Task.m_ExecData->PrintPerf(ModeDesc[pWorker->m_Mode], "EnqueueBackup");
+				m_aWorker[WRITE_BACKUP].m_Queue.Send(std::move(Task));
+			}
+			else if(!Success && pWorker->m_Mode == WRITE_BACKUP)
+			{
+				if(Task.m_ExecData->m_FaultTolerant && !m_Shutdown && (Task.m_ExecData->m_NumTries < 3 || time_timestamp() < Task.m_ExecData->m_CreateTime + 60))
+				{
+					// retry FaultTolerant write requests
+					Task.m_ExecData->PrintPerf(ModeDesc[pWorker->m_Mode], "EnqueueBackup");
+					m_aWorker[WRITE_BACKUP].m_Queue.Send(std::move(Task));
+				}
+				else
+				{
+					// retried some times already or shutting down, last chance is the backup SQLite server
+					if(ExecSqlFunc(pDbBackup.get(), Task.m_ExecData.get(), true))
+					{
+						Task.m_ExecData->PrintPerf(ModeDesc[pWorker->m_Mode], "Success Backup");
+						dbg_msg("sql", "%s done on write backup database", Task.m_ExecData->m_pName);
+						Success = true;
+						break;
+					}
+					else
+					{
+						Task.m_ExecData->PrintPerf(ModeDesc[pWorker->m_Mode], "Failure Backup");
+						dbg_msg("sql", "%s failed on all databases", Task.m_ExecData->m_pName);
+					}
+				}
+			}
+			else if(!Success && pWorker->m_Mode == READ)
+			{
+				// failed reads are ok, just log it
+				dbg_msg("sql", "%s failed on all databases", Task.m_ExecData->m_pName);
+			}
+			break;
+		}
+		case CSqlTask::PRINT_SQL_SERVER:
+		{
+			char aBuf[512];
+			for(unsigned int i = 0; i < apDb.size(); i++)
+			{
+				apDb[i]->Format(aBuf, sizeof(aBuf));
+				CSqlResponse Response = CSqlResponse(CSqlResponse::CONSOLE);
+				str_format(Response.aMsg, sizeof(Response.aMsg), "%s: %s",
+					ModeDesc[pWorker->m_Mode], aBuf);
+				m_Responses.Send(Response);
+			}
+			if(pDbBackup != nullptr)
+			{
+				pDbBackup->Format(aBuf, sizeof(aBuf));
+				CSqlResponse Response = CSqlResponse(CSqlResponse::CONSOLE);
+				str_format(Response.aMsg, sizeof(Response.aMsg), "%s (Fallback): %s",
+					ModeDesc[pWorker->m_Mode], aBuf);
+				m_Responses.Send(Response);
+			}
+			break;
+		}
+		case CSqlTask::SHUTDOWN:
+			NumClosed += 1;
+			// the WRITE thread is responsible to notify WRITE_BACKUP that no further
+			// queries get send from the WRITE thread
+			if(pWorker->m_Mode == CDbConnectionPool::WRITE)
+			{
+				m_aWorker[WRITE_BACKUP].m_Queue.Send(std::move(Task));
+			}
+			if(pWorker->m_Mode == CDbConnectionPool::WRITE_BACKUP)
+			{
+				// main thread and write thread closed their Sender to this queue,
+				// now we are the last thread sending messages to this queue;
+				// close our end at last
+				if(NumClosed == 2)
+					m_aWorker[WRITE_BACKUP].m_Queue.Send(std::move(Task));
+				// do not exit backup thread yet until we received all three closing notifications (including ours)
+				if(NumClosed < 3)
+					break;
+			}
+			// signal, that all jobs got processed and thread exits
+			m_Shutdown.fetch_sub(1);
+			return;
+		}
+		/*
 		// work through all database jobs after OnShutdown is called before exiting the thread
 		if(pThreadData == nullptr)
 		{
@@ -193,27 +475,19 @@ void CDbConnectionPool::Worker()
 		}
 		if(!Success)
 			dbg_msg("sql", "%s failed on all databases", pThreadData->m_pName);
+	*/
 	}
 }
 
-bool CDbConnectionPool::ExecSqlFunc(IDbConnection *pConnection, CSqlExecData *pData, bool Failure)
+bool CDbConnectionPool::Impl::ExecSqlFunc(IDbConnection *pConnection, CSqlExecData *pData, bool Failure)
 {
 	if(pConnection->Connect() != IDbConnection::SUCCESS)
 		return false;
 	bool Success = false;
 	try
 	{
-		switch(pData->m_Mode)
-		{
-		case CSqlExecData::READ_ACCESS:
-			if(pData->m_Ptr.m_pReadFunc(pConnection, pData->m_pThreadData.get()))
-				Success = true;
-			break;
-		case CSqlExecData::WRITE_ACCESS:
-			if(pData->m_Ptr.m_pWriteFunc(pConnection, pData->m_pThreadData.get(), Failure))
-				Success = true;
-			break;
-		}
+		if(pData->m_pSqlFunc(pConnection, pData->m_pThreadData.get(), Failure))
+			Success = true;
 	}
 #if defined(CONF_SQL)
 	catch (sql::SQLException &e)
@@ -252,4 +526,3 @@ bool CDbConnectionPool::ExecSqlFunc(IDbConnection *pConnection, CSqlExecData *pD
 		dbg_msg("sql", "%s failed", pData->m_pName);
 	return Success;
 }
-

--- a/src/engine/server/databases/connection_pool.cpp
+++ b/src/engine/server/databases/connection_pool.cpp
@@ -411,7 +411,7 @@ void CDbConnectionPool::Impl::Worker(CWorker *pWorker)
 			{
 				apDb[i]->Format(aBuf, sizeof(aBuf));
 				CSqlResponse Response = CSqlResponse(CSqlResponse::CONSOLE);
-				str_format(Response.aMsg, sizeof(Response.aMsg), "%s: %s",
+				str_format(Response.aMsg, sizeof(Response.aMsg), "%s (Retry): %s",
 					ModeDesc[pWorker->m_Mode], aBuf);
 				m_Responses.Send(Response);
 			}

--- a/src/engine/server/databases/mysql.cpp
+++ b/src/engine/server/databases/mysql.cpp
@@ -48,13 +48,11 @@ CMysqlConnection::~CMysqlConnection()
 #endif
 }
 
-void CMysqlConnection::Print(IConsole *pConsole, const char *Mode)
+void CMysqlConnection::Format(char *pBuffer, int BufferSize)
 {
-	char aBuf[512];
-	str_format(aBuf, sizeof(aBuf),
-			"MySQL-%s: DB: '%s' Prefix: '%s' User: '%s' IP: <{'%s'}> Port: %d",
-			Mode, m_aDatabase, GetPrefix(), m_aUser, m_aIp, m_Port);
-	pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "server", aBuf);
+	str_format(pBuffer, BufferSize,
+		"MySQL: DB: '%s' Prefix: '%s' User: '%s' IP: <{'%s'}> Port: %d",
+		m_aDatabase, GetPrefix(), m_aUser, m_aIp, m_Port);
 }
 
 CMysqlConnection *CMysqlConnection::Copy()

--- a/src/engine/server/databases/mysql.h
+++ b/src/engine/server/databases/mysql.h
@@ -25,7 +25,7 @@ public:
 			int Port,
 			bool Setup);
 	virtual ~CMysqlConnection();
-	virtual void Print(IConsole *pConsole, const char *Mode);
+	virtual void Format(char *pBuffer, int BufferSize);
 
 	virtual CMysqlConnection *Copy();
 

--- a/src/engine/server/databases/sqlite.cpp
+++ b/src/engine/server/databases/sqlite.cpp
@@ -26,13 +26,9 @@ CSqliteConnection::~CSqliteConnection()
 	m_pDb = nullptr;
 }
 
-void CSqliteConnection::Print(IConsole *pConsole, const char *Mode)
+void CSqliteConnection::Format(char *pBuffer, int BufferSize)
 {
-	char aBuf[512];
-	str_format(aBuf, sizeof(aBuf),
-			"SQLite-%s: DB: '%s'",
-			Mode, m_aFilename);
-	pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "server", aBuf);
+	str_format(pBuffer, BufferSize, "SQLite: File: '%s'", m_aFilename);
 }
 
 void CSqliteConnection::ToUnixTimestamp(const char *pTimestamp, char *aBuf, unsigned int BufferSize)

--- a/src/engine/server/databases/sqlite.h
+++ b/src/engine/server/databases/sqlite.h
@@ -12,7 +12,7 @@ class CSqliteConnection : public IDbConnection
 public:
 	CSqliteConnection(const char *pFilename, bool Setup);
 	virtual ~CSqliteConnection();
-	virtual void Print(IConsole *pConsole, const char *Mode);
+	virtual void Format(char *pBuffer, int BufferSize);
 
 	virtual CSqliteConnection *Copy();
 

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -2531,7 +2531,7 @@ int CServer::Run()
 
 			RecvConnectionPoolMsgs();
 
-			while(t > TickStartTime(m_CurrentGameTick+1))
+			while(t > TickStartTime(m_CurrentGameTick + 1))
 			{
 				for(int c = 0; c < MAX_CLIENTS; c++)
 					if(m_aClients[c].m_State == CClient::STATE_INGAME)

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -3187,11 +3187,14 @@ void CServer::ConDumpSqlServers(IConsole::IResult *pResult, void *pUserData)
 	if(str_comp_nocase(pResult->GetString(0), "w") == 0)
 	{
 		pSelf->DbPool()->Print(pSelf->Console(), CDbConnectionPool::WRITE);
-		pSelf->DbPool()->Print(pSelf->Console(), CDbConnectionPool::WRITE_BACKUP);
 	}
 	else if(str_comp_nocase(pResult->GetString(0), "r") == 0)
 	{
 		pSelf->DbPool()->Print(pSelf->Console(), CDbConnectionPool::READ);
+	}
+	else if(str_comp_nocase(pResult->GetString(0), "b") == 0)
+	{
+		pSelf->DbPool()->Print(pSelf->Console(), CDbConnectionPool::WRITE_BACKUP);
 	}
 	else
 	{
@@ -3402,7 +3405,7 @@ void CServer::RegisterCommands()
 	Console()->Register("reload", "", CFGFLAG_SERVER, ConMapReload, this, "Reload the map");
 
 	Console()->Register("add_sqlserver", "s['r'|'w'] s[Database] s[Prefix] s[User] s[Password] s[IP] i[Port] ?i[SetUpDatabase ?]", CFGFLAG_SERVER|CFGFLAG_NONTEEHISTORIC, ConAddSqlServer, this, "add a sqlserver");
-	Console()->Register("dump_sqlservers", "s['r'|'w']", CFGFLAG_SERVER, ConDumpSqlServers, this, "dumps all sqlservers readservers = r, writeservers = w");
+	Console()->Register("dump_sqlservers", "s['r'|'w'|'b']", CFGFLAG_SERVER, ConDumpSqlServers, this, "dumps all sqlservers readservers = r, writeservers = w, backupwriteserver = b");
 
 	Console()->Register("auth_add", "s[ident] s[level] s[pw]", CFGFLAG_SERVER|CFGFLAG_NONTEEHISTORIC, ConAuthAdd, this, "Add a rcon key");
 	Console()->Register("auth_add_p", "s[ident] s[level] s[hash] s[salt]", CFGFLAG_SERVER|CFGFLAG_NONTEEHISTORIC, ConAuthAddHashed, this, "Add a prehashed rcon key");

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -106,6 +106,7 @@ class CServer : public IServer
 #endif
 
 	class CDbConnectionPool *m_pConnectionPool;
+	void RecvConnectionPoolMsgs();
 
 public:
 	class IGameServer *GameServer() { return m_pGameServer; }

--- a/src/game/server/score.h
+++ b/src/game/server/score.h
@@ -273,22 +273,22 @@ class CScore
 	CPlayerData m_aPlayerData[MAX_CLIENTS];
 	CDbConnectionPool *m_pPool;
 
-	static bool Init(IDbConnection *pSqlServer, const ISqlData *pGameData);
+	static bool Init(IDbConnection *pSqlServer, const ISqlData *pGameData, bool Failure);
 
-	static bool RandomMapThread(IDbConnection *pSqlServer, const ISqlData *pGameData);
-	static bool RandomUnfinishedMapThread(IDbConnection *pSqlServer, const ISqlData *pGameData);
-	static bool MapVoteThread(IDbConnection *pSqlServer, const ISqlData *pGameData);
+	static bool RandomMapThread(IDbConnection *pSqlServer, const ISqlData *pGameData, bool Failure);
+	static bool RandomUnfinishedMapThread(IDbConnection *pSqlServer, const ISqlData *pGameData, bool Failure);
+	static bool MapVoteThread(IDbConnection *pSqlServer, const ISqlData *pGameData, bool Failure);
 
-	static bool LoadPlayerDataThread(IDbConnection *pSqlServer, const ISqlData *pGameData);
-	static bool MapInfoThread(IDbConnection *pSqlServer, const ISqlData *pGameData);
-	static bool ShowRankThread(IDbConnection *pSqlServer, const ISqlData *pGameData);
-	static bool ShowTeamRankThread(IDbConnection *pSqlServer, const ISqlData *pGameData);
-	static bool ShowTop5Thread(IDbConnection *pSqlServer, const ISqlData *pGameData);
-	static bool ShowTeamTop5Thread(IDbConnection *pSqlServer, const ISqlData *pGameData);
-	static bool ShowTimesThread(IDbConnection *pSqlServer, const ISqlData *pGameData);
-	static bool ShowPointsThread(IDbConnection *pSqlServer, const ISqlData *pGameData);
-	static bool ShowTopPointsThread(IDbConnection *pSqlServer, const ISqlData *pGameData);
-	static bool GetSavesThread(IDbConnection *pSqlServer, const ISqlData *pGameData);
+	static bool LoadPlayerDataThread(IDbConnection *pSqlServer, const ISqlData *pGameData, bool Failure);
+	static bool MapInfoThread(IDbConnection *pSqlServer, const ISqlData *pGameData, bool Failure);
+	static bool ShowRankThread(IDbConnection *pSqlServer, const ISqlData *pGameData, bool Failure);
+	static bool ShowTeamRankThread(IDbConnection *pSqlServer, const ISqlData *pGameData, bool Failure);
+	static bool ShowTop5Thread(IDbConnection *pSqlServer, const ISqlData *pGameData, bool Failure);
+	static bool ShowTeamTop5Thread(IDbConnection *pSqlServer, const ISqlData *pGameData, bool Failure);
+	static bool ShowTimesThread(IDbConnection *pSqlServer, const ISqlData *pGameData, bool Failure);
+	static bool ShowPointsThread(IDbConnection *pSqlServer, const ISqlData *pGameData, bool Failure);
+	static bool ShowTopPointsThread(IDbConnection *pSqlServer, const ISqlData *pGameData, bool Failure);
+	static bool GetSavesThread(IDbConnection *pSqlServer, const ISqlData *pGameData, bool Failure);
 
 	static bool SaveTeamThread(IDbConnection *pSqlServer, const ISqlData *pGameData, bool Failure);
 	static bool LoadTeamThread(IDbConnection *pSqlServer, const ISqlData *pGameData, bool Failure);
@@ -309,11 +309,11 @@ class CScore
 	std::shared_ptr<CScorePlayerResult> NewSqlPlayerResult(int ClientID);
 	// Creates for player database requests
 	void ExecPlayerThread(
-			bool (*pFuncPtr) (IDbConnection *, const ISqlData *),
-			const char *pThreadName,
-			int ClientID,
-			const char *pName,
-			int Offset);
+		FSqlThread pFuncPtr,
+		const char *pThreadName,
+		int ClientID,
+		const char *pName,
+		int Offset);
 
 	// returns true if the player should be rate limited
 	bool RateLimitPlayer(int ClientID);


### PR DESCRIPTION
Still a draft, since I want to do more testing by myself. But ready for review anyway.
This implements a thread safe queue, which would be good if reviewed carefully.

Fixes #2746. Helps with #2622, #2671 and #2672 because it enables a way to add/remove sql servers in a thread-safe fashion. If required, I can add a config option to disable retrying write statements.

This PR splits the worker threads into three: one for read requests, one for write requests and one to process the retries. If there are questions concerning the design, I would gladly answer them.

Additionally outputs some stats about time required for each step. I am interested in the output (can be filtered e.g. by `grep -E '^\[....-..-.. ..:..:..\]\[sql_perf\]:` before rotating the log file), as it would show how reasonable some defaults were set.

Behavior changes:
* `dump_sqlservers` output changed and the output for write servers might interleave with the output for write_backup server

Edit: I have to read a bit more about move semantics in c++ with structs containing unique_ptr's. Therefore how the queue is called and how it contains the elements may change, but I don't intent to change the concept of the queues and how the threads are connected to each other.