### PR TITLE
Implement context for translations (largely taken from Teeworlds)

### DIFF
--- a/data/languages/belarusian.txt
+++ b/data/languages/belarusian.txt
@@ -307,6 +307,7 @@ Ping
 Pistol
 == Пісталет
 
+[Demo browser]
 Play
 == Прагляд
 
@@ -1156,6 +1157,10 @@ Server executable not found, can't run server
 == 
 
 Editor
+== 
+
+[Start menu]
+Play
 == 
 
 DDNet %s is out!

--- a/data/languages/bosnian.txt
+++ b/data/languages/bosnian.txt
@@ -310,6 +310,7 @@ Ping
 Pistol
 == Pištolj
 
+[Demo browser]
 Play
 == Pogledaj
 
@@ -1204,6 +1205,10 @@ Server executable not found, can't run server
 == 
 
 Editor
+== 
+
+[Start menu]
+Play
 == 
 
 Manual %3d:%02d  

--- a/data/languages/brazilian_portuguese.txt
+++ b/data/languages/brazilian_portuguese.txt
@@ -325,6 +325,7 @@ Ping
 Pistol
 == Pistola
 
+[Demo browser]
 Play
 == Assistir
 
@@ -1235,4 +1236,8 @@ Server executable not found, can't run server
 == 
 
 Editor
+== 
+
+[Start menu]
+Play
 == 

--- a/data/languages/bulgarian.txt
+++ b/data/languages/bulgarian.txt
@@ -307,6 +307,7 @@ Ping
 Pistol
 == Пистолет
 
+[Demo browser]
 Play
 == Възпроизведи
 
@@ -1156,6 +1157,10 @@ Server executable not found, can't run server
 == 
 
 Editor
+== 
+
+[Start menu]
+Play
 == 
 
 DDNet %s is out!

--- a/data/languages/catalan.txt
+++ b/data/languages/catalan.txt
@@ -305,6 +305,7 @@ Ping
 Pistol
 == Pistola
 
+[Demo browser]
 Play
 == Reproduir
 
@@ -1215,4 +1216,8 @@ Server executable not found, can't run server
 == 
 
 Editor
+== 
+
+[Start menu]
+Play
 == 

--- a/data/languages/chuvash.txt
+++ b/data/languages/chuvash.txt
@@ -307,6 +307,7 @@ Ping
 Pistol
 == Пистолет
 
+[Demo browser]
 Play
 == Пăхма
 
@@ -1156,6 +1157,10 @@ Server executable not found, can't run server
 == 
 
 Editor
+== 
+
+[Start menu]
+Play
 == 
 
 DDNet %s is out!

--- a/data/languages/czech.txt
+++ b/data/languages/czech.txt
@@ -310,6 +310,7 @@ Ping
 Pistol
 == Pistolka
 
+[Demo browser]
 Play
 == Přehrát
 
@@ -1159,6 +1160,10 @@ Server executable not found, can't run server
 == 
 
 Editor
+== 
+
+[Start menu]
+Play
 == 
 
 DDNet %s is out!

--- a/data/languages/danish.txt
+++ b/data/languages/danish.txt
@@ -307,6 +307,7 @@ Ping
 Pistol
 == Pistol
 
+[Demo browser]
 Play
 == Spil
 
@@ -1156,6 +1157,10 @@ Server executable not found, can't run server
 == 
 
 Editor
+== 
+
+[Start menu]
+Play
 == 
 
 DDNet %s is out!

--- a/data/languages/dutch.txt
+++ b/data/languages/dutch.txt
@@ -319,6 +319,7 @@ Ping
 Pistol
 == Pistool
 
+[Demo browser]
 Play
 == Spelen
 
@@ -1227,6 +1228,10 @@ Server executable not found, can't run server
 == 
 
 Editor
+== 
+
+[Start menu]
+Play
 == 
 
 Net

--- a/data/languages/finnish.txt
+++ b/data/languages/finnish.txt
@@ -308,6 +308,7 @@ Ping
 Pistol
 == Pistooli
 
+[Demo browser]
 Play
 == Toista
 
@@ -1157,6 +1158,10 @@ Server executable not found, can't run server
 == 
 
 Editor
+== 
+
+[Start menu]
+Play
 == 
 
 DDNet %s is out!

--- a/data/languages/french.txt
+++ b/data/languages/french.txt
@@ -319,6 +319,7 @@ Ping
 Pistol
 == Pistolet
 
+[Demo browser]
 Play
 == Jouer
 
@@ -1246,4 +1247,8 @@ Server executable not found, can't run server
 == 
 
 Editor
+== 
+
+[Start menu]
+Play
 == 

--- a/data/languages/german.txt
+++ b/data/languages/german.txt
@@ -324,9 +324,6 @@ Ping
 Pistol
 == Pistole
 
-Play
-== Spielen
-
 [Demo browser]
 Play
 == Abspielen
@@ -1229,16 +1226,20 @@ Menu
 == Menü
 
 Warning
-== 
+== Warnung
 
 Speed
-== 
-
-https://wiki.ddnet.tw/
-== 
+== Geschwindigkeit
 
 Website
-== 
+== Website
 
 Server executable not found, can't run server
+== Server-Programm nicht gefunden, kann Server nicht starten
+
+[Start menu]
+Play
+== Spielen
+
+https://wiki.ddnet.tw/
 == 

--- a/data/languages/german.txt
+++ b/data/languages/german.txt
@@ -325,6 +325,10 @@ Pistol
 == Pistole
 
 Play
+== Spielen
+
+[Demo browser]
+Play
 == Abspielen
 
 Play background music

--- a/data/languages/greek.txt
+++ b/data/languages/greek.txt
@@ -310,6 +310,7 @@ Ping
 Pistol
 == Πιστόλι
 
+[Demo browser]
 Play
 == Παίξτε
 
@@ -1156,6 +1157,10 @@ Server executable not found, can't run server
 == 
 
 Editor
+== 
+
+[Start menu]
+Play
 == 
 
 DDNet %s is out!

--- a/data/languages/hungarian.txt
+++ b/data/languages/hungarian.txt
@@ -304,6 +304,7 @@ Ping
 Pistol
 == Pisztoly
 
+[Demo browser]
 Play
 == Játék
 
@@ -1227,4 +1228,8 @@ Server executable not found, can't run server
 == 
 
 Editor
+== 
+
+[Start menu]
+Play
 == 

--- a/data/languages/italian.txt
+++ b/data/languages/italian.txt
@@ -311,6 +311,7 @@ Ping
 Pistol
 == Pistola
 
+[Demo browser]
 Play
 == Riproduci
 
@@ -1162,6 +1163,10 @@ Server executable not found, can't run server
 == 
 
 Editor
+== 
+
+[Start menu]
+Play
 == 
 
 DDNet %s is out!

--- a/data/languages/japanese.txt
+++ b/data/languages/japanese.txt
@@ -307,6 +307,7 @@ Ping
 Pistol
 == ピストル
 
+[Demo browser]
 Play
 == プレイ
 
@@ -1156,6 +1157,10 @@ Server executable not found, can't run server
 == 
 
 Editor
+== 
+
+[Start menu]
+Play
 == 
 
 DDNet %s is out!

--- a/data/languages/korean.txt
+++ b/data/languages/korean.txt
@@ -303,6 +303,7 @@ Ping
 Pistol
 == 권총
 
+[Demo browser]
 Play
 == 플레이
 
@@ -1155,6 +1156,10 @@ Server executable not found, can't run server
 == 
 
 Editor
+== 
+
+[Start menu]
+Play
 == 
 
 DDNet %s is out!

--- a/data/languages/kyrgyz.txt
+++ b/data/languages/kyrgyz.txt
@@ -366,6 +366,7 @@ Ping
 Pistol
 == Тапанча
 
+[Demo browser]
 Play
 == Көрүү
 
@@ -1147,6 +1148,10 @@ Server executable not found, can't run server
 == 
 
 Editor
+== 
+
+[Start menu]
+Play
 == 
 
 DDNet %s is out!

--- a/data/languages/norwegian.txt
+++ b/data/languages/norwegian.txt
@@ -308,6 +308,7 @@ Ping
 Pistol
 == Pistol
 
+[Demo browser]
 Play
 == Spill
 
@@ -1223,4 +1224,8 @@ Server executable not found, can't run server
 == 
 
 Editor
+== 
+
+[Start menu]
+Play
 == 

--- a/data/languages/persian.txt
+++ b/data/languages/persian.txt
@@ -204,157 +204,9 @@ Ping
 == ﮓﻨﯿﭘ
 Pistol
 == ﺮﯿﺗ ﺖﻔﻫ
+[Demo browser]
 Play
 == ﻥﺩﺮﻛ ىﺯﺎﺑ
-Play background music
-== ﻪﻨﯿﻣﺯ ﺲﭘ ﻚﯾﺯﻮﻣ ﻥﺩﺮﻛ ﺶﺨﭘ
-Player
-== ﻦﻜﯾﺯﺎﺑ
-Player country:
-== ﻦﻜﯾﺯﺎﺑ ﺭﻮﺸﻛ:
-Player options
-== ﻦﻜﯾﺯﺎﺑ ﺕﺎﻤﯿﻈﻨﺗ:
-Players
-== ﻥﺎﻨﻜﯾﺯﺎﺑ
-Please balance teams!
-== !ﺪﯿﻨﻛ ﻝﺩﺎﻌﺘﻣ ﺍﺭ ﺎﻫ ﻢﯿﺗ ﺎﻔﻄﻟ
-Prev. weapon
-== ﯽﻠﺒﻗ ﻪﺤﻠﺳﺍ
-Quit
-== ﻥﺪﺷ ﺝﺭﺎﺧ
-Reason:
-== ﻞﯿﻟﺩ:
-Red team
-== ﺰﻣﺮﻗ ﻢﯿﺗ
-Red team wins!
-== !ﺪﺷ ﻩﺪﻧﺮﺑ ﺰﻣﺮﻗ ﻢﯿﺗ
-Refresh
-== ﻩﺭﺎﺑﻭﺩ ىﺭﺍﺬﮔﺭﺎﺑ
-Refreshing master servers
-== ﯽﻠﺻﺍ ىﺎﻫ ﺭﻭﺮﺳ ﻩﺭﺎﺑﻭﺩ ىﺭﺍﺬﮔﺭﺎﺑ
-Remote console
-== ﻝﻮﺴﻨﮐ ﻝﺮﺘﻨﮐ
-Remove
-== ﻥﺩﺮﮐ ﻑﺬﺣ
-Remove friend
-== ﺖﺳﻭﺩ ﻥﺩﺮﮐ ﻑﺪﺣ
-Rename
-== ﻡﺎﻧ ﺮﯿﯿﻐﺗ
-Rename demo
-== ﻮﻣﺩ ﻡﺎﻧ ﺮﯿﯿﻐﺗ
-Reset filter
-== ﺮﺘﻠﯿﻓ ﻩﺭﺎﺑﻭﺩ ﻢﯿﻈﻨﺗ
-Sample rate
-== ﻪﻧﻮﻤﻧ ﺶﺠﻨﺳ
-Score
-== ﺯﺎﯿﺘﻣﺍ
-Score limit
-== ﺯﺎﯿﺘﻣﺍ ﺪﺣ
-Scoreboard
-== ﯼﺪﻨﺑ ﻪﺒﺗﺭ
-Screenshot
-== ﻪﺤﻔﺻ ﺯﺍ ﯼﺭﺍﺩﺮﺑ ﺲﮑﻋ
-Server address:
-== :ﺭﻭﺮﺳ ﺱﺭﺩﺁ
-Server details
-== ﺭﻭﺮﺳ ﺕﺎﯿﺋﺰﺟ
-Server filter
-== ﺭﻭﺮﺳ ﯽﮔﮋﯾﻭ
-Server info
-== ﺭﻭﺮﺳ ﺕﺎﻋﻼﻃﺍ
-Server not full
-== ﻩﺪﺸﻧ ﺮﭘ ﺭﻭﺮﺳ
-Shotgun
-== ىﺍ ﻪﻤﭼﺎﺳ ﮓﻨﻔﺗ
-Show chat
-== ﺖﭼ ﻥﺩﺍﺩ ﻥﺎﺸﻧ
-Show friends only
-== ﻥﺎﺘﺳﻭﺩ ﺶﯾﺎﻤﻧ ﻂﻘﻓ
-Show ingame HUD
-== ﯼﺯﺎﺑ ﺭﺩ HUD ﻥﺩﺍﺩ ﻥﺎﺸﻧ
-Show name plates
-== ﻢﺳﺍ ﻥﺩﺍﺩ ﻥﺎﺸﻧ
-Show only chat messages from friends
-== ﻥﺎﺘﺳﻭﺩ ﯼﺎﻫ ﻡﺎﯿﭘ ﻥﺩﺍﺩ ﻥﺎﺸﻧ ﻂﻘﻓ
-Show only supported
-== ﺪﻧﻮﺷ ﯽﻣ ﯽﻧﺎﺒﯿﺘﺸﭘ ﻪﻛ ﯽﯾﺎﻫ ﺖﻟﺎﺣ ﺶﯾﺎﻤﻧ ﻂﻘﻓ
-Skins
-== ﻦﯿﮑﺳﺍ
-Sound
-== ﺍﺪﺻ
-Sound error
-== ﺍﺪﺻ ﯼﺎﻄﺧ
-Spectate
-== ﺎﺷﺎﻤﺗ
-Spectate next
-== ﯼﺪﻌﺑ ﯼ ﺎﺷﺎﻤﺗ
-Spectate previous
-== ﯽﻠﺒﻗ ﯼ ﺎﺷﺎﻤﺗ
-Spectator mode
-== ﺮﮔﺎﺷﺎﻤﺗ ﺖﻟﺎﺣ
-Spectators
-== ﺎﻫ ﺮﮔﺎﺷﺎﻤﺗ
-Standard gametype
-== ﯼﺯﺎﺑ ﺩﺭﺍﺪﻧﺎﺘﺳﺍ ﯼﺎﻫ ﻝﺪﻣ
-Standard map
-== ﺩﺭﺍﺪﻧﺎﺘﺳﺍ ﯼﺎﻫ ﭗﻣ
-Stop record
-== ﻥﺩﺮﮐ ﻂﺒﺿ ﻒﻗﻮﺗ
-Strict gametype filter
-== ﯼﺯﺎﺑ ﺩﻮﻣ ﺮﺘﻠﯿﻓ
-Sudden Death
-== ﯽﻧﺎﻬﮔﺎﻧ ﮒﺮﻣ
-Switch weapon on pickup
-== ﻥﺪﺷ ﻪﺘﺷﺍﺩﺭﻭ ﺕﺭﻮﺻ ﺭﺩ ﻪﺤﻠﺳﺍ ﺮﯿﯿﻐﺗ
-Team
-== ﻢﯿﺗ
-Team chat
-== ﻢﯿﺗ ﺖﭼ
-The audio device couldn't be initialised.
-== .ﺪﺸﻧ ﻥﺪﺷ ﺐﺼﻧ ﻪﺑ ﻖﻓﻮﻣ ﺍﺪﺻ ﻩﺎﮕﺘﺳﺩ
-The server is running a non-standard tuning on a pure game type.
-== .ﺖﺳﺍ ﺮﮕﯾﺩ ﯼﺯﺎﺑ ﻝﺪﻣ ﮏﯾ ﯼﻭﺭ ﻭ ﺩﺭﺍﺪﻧﺎﺘﺳﺍ ﺮﯿﻏ ﺕﺎﻤﯿﻈﻨﺗ ﯼﺍﺭﺍﺩ ﺍﺮﺟﺍ ﻝﺎﺣ ﺭﺩ ﺭﻭﺮﺳ
-There's an unsaved map in the editor, you might want to save it before you quit the game.
-== .ﯼﺯﺎﺑ ﺯﺍ ﺝﻭﺮﺧ ﺯﺍ ﻼﺒﻗ ﺪﯿﻨﮐ ﻩﺮﯿﺧﺫ ﺍﺭ ﻥﺁ ﺪﯿﻫﺍﻮﺨﺑ ﺎﻤﺷ ﺖﺳﺍ ﻦﮑﻤﻣ , ﺮﮕﻨﯾﻭﺪﺗ ﺭﺩ ﻩﺪﺸﻧ ﻩﺮﯿﺧﺫ ﭗﻣ ﻦﯾﺍ
-Time limit
-== ﻥﺎﻣﺯ ﺖﯾﺎﻬﻧ
-Time limit: %d min
-== ﻪﻘﯿﻗﺩ d% :ﻥﺎﻣﺯ ﺖﯾﺎﻬﻧ
-Try again
-== ﻩﺭﺎﺑﻭﺩ ﺵﻼﺗ
-Type
-== ﻝﺪﻣ
-Unable to delete the demo
-== ﺩﺮﮐ ﮎﺎﭘ ﺍﺭ ﻮﻣﺩ ﻦﯾﺍ ﻥﺍﻮﺘﯿﻤﻧ
-Unable to rename the demo
-== ﺩﺮﮐ ﺽﻮﻋ ﺍﺭ ﻮﻣﺩ ﻦﯾﺍ ﻢﺳﺍ ﻥﺍﻮﺘﯿﻤﻧ
-Use sounds
-== ﺍﺪﺻ ﺯﺍ ﻩﺩﺎﻔﺘﺳﺍ
-Use team colors for name plates
-== ﺎﻫ ﻢﺳﺍ ﯼﺍﺮﺑ ﻢﯿﺗ ﮓﻧﺭ ﺯﺍ ﻩﺩﺎﻔﺘﺳﺍ
-V-Sync
-== V-Sync
-Version
-== ﻪﺨﺴﻧ
-Vote command:
-== ﯽﺠﻨﺳ ﺮﻈﻧ ﺕﺍﺭﻮﺘﺳﺩ:
-Vote description:
-== :ﯽﺠﻨﺳ ﺮﻈﻧ ﺕﺎﺤﯿﺿﻮﺗ
-Vote no
-== ﻪﻧ ﯼﺍﺭ
-Vote yes
-== ﻪﻠﺑ ﯼﺍﺭ
-Voting
-== ﯼﺮﯿﮔ ﯼﺍﺭ
-Warmup
-== ﺪﯿﻨﮐ ﻪﻠﺠﻋ
-Weapon
-== ﻪﺤﻠﺳﺍ
-Yes
-== ﻪﻠﺑ
-You must restart the game for all settings to take effect.
-== ﺪﻧﻮﺷ ﻡﺎﺠﻧﺍ ﺕﺎﻤﯿﻈﻨﺗ ﻪﮑﻨﯾﺍ ﯼﺍﺮﺑ ﺪﯿﻨﮐ ﯼﺭﺍﺰﮔﺭﺎﺑ ﻩﺭﺎﺑﻭﺩ ﺍﺭ ﯼﺯﺎﺑ ﺪﯾﺎﺑ ﺎﻤﺷ
-##### ﻪﻤﺟﺮﺗ ﻪﺑ ﺝﺎﯿﺘﺣﺍ #####
 Borderless window
 == ﺯﺮﻣ ﻩﺮﺠﻨﭘ
 Demo
@@ -786,22 +638,229 @@ The width or height of texture %s is not divisible by 16, which might cause visu
 Warning
 == 
 
+Team
+== 
+
+Sudden Death
+== 
+
+Warmup
+== 
+
+Please balance teams!
+== 
+
+Reason:
+== 
+
+Vote yes
+== 
+
+Vote no
+== 
+
+Spectate
+== 
+
 Menu
+== 
+
+Players
+== 
+
+Server info
+== 
+
+The server is running a non-standard tuning on a pure game type.
+== 
+
+Rename demo
+== 
+
+Remove friend
+== 
+
+Sound error
+== 
+
+The audio device couldn't be initialised.
+== 
+
+Try again
+== 
+
+Quit
 == 
 
 Use k key to kill (restart), q to pause and watch other players. See settings for other key binds.
 == 
 
+There's an unsaved map in the editor, you might want to save it before you quit the game.
+== 
+
+Yes
+== 
+
 Country / Region
+== 
+
+Unable to delete the demo
+== 
+
+Unable to rename the demo
+== 
+
+Show chat
+== 
+
+Use sounds
 == 
 
 Speed
 == 
 
+Show ingame HUD
+== 
+
+Type
+== 
+
+Refreshing master servers
+== 
+
+Server filter
+== 
+
+Server not full
+== 
+
+Show friends only
+== 
+
+Standard gametype
+== 
+
+Standard map
+== 
+
+Strict gametype filter
+== 
+
+Server address:
+== 
+
+Player country:
+== 
+
+Reset filter
+== 
+
+Server details
+== 
+
+Scoreboard
+== 
+
+Remove
+== 
+
+Refresh
+== 
+
+Rename
+== 
+
+Stop record
+== 
+
+Player options
+== 
+
+Player
+== 
+
+Version
+== 
+
+Score limit
+== 
+
+Time limit
+== 
+
+Vote description:
+== 
+
+Vote command:
+== 
+
+Switch weapon on pickup
+== 
+
+Show only chat messages from friends
+== 
+
+Show name plates
+== 
+
+Use team colors for name plates
+== 
+
 Skip the main menu
 == 
 
+Skins
+== 
+
+Shotgun
+== 
+
+Prev. weapon
+== 
+
+Team chat
+== 
+
+Spectator mode
+== 
+
+Spectate next
+== 
+
+Spectate previous
+== 
+
+Remote console
+== 
+
+Screenshot
+== 
+
+Weapon
+== 
+
+Voting
+== 
+
+Show only supported
+== 
+
+V-Sync
+== 
+
 may cause delay
+== 
+
+Play background music
+== 
+
+Sample rate
+== 
+
+Sound
+== 
+
+You must restart the game for all settings to take effect.
 == 
 
 Client message
@@ -829,4 +888,23 @@ Server executable not found, can't run server
 == 
 
 Editor
+== 
+
+[Start menu]
+Play
+== 
+
+Time limit: %d min
+== 
+
+Spectators
+== 
+
+Score
+== 
+
+Red team wins!
+== 
+
+Red team
 == 

--- a/data/languages/polish.txt
+++ b/data/languages/polish.txt
@@ -312,6 +312,7 @@ Ping
 Pistol
 == Pistolet
 
+[Demo browser]
 Play
 == Graj
 
@@ -1227,4 +1228,8 @@ Server executable not found, can't run server
 == 
 
 Editor
+== 
+
+[Start menu]
+Play
 == 

--- a/data/languages/portuguese.txt
+++ b/data/languages/portuguese.txt
@@ -322,6 +322,7 @@ Ping
 Pistol
 == Pistola
 
+[Demo browser]
 Play
 == Ver
 
@@ -1172,6 +1173,10 @@ Server executable not found, can't run server
 == 
 
 Editor
+== 
+
+[Start menu]
+Play
 == 
 
 DDNet %s is out!

--- a/data/languages/romanian.txt
+++ b/data/languages/romanian.txt
@@ -316,6 +316,7 @@ Ping
 Pistol
 == Pistol
 
+[Demo browser]
 Play
 == Redă
 
@@ -1162,6 +1163,10 @@ Server executable not found, can't run server
 == 
 
 Editor
+== 
+
+[Start menu]
+Play
 == 
 
 DDNet %s is out!

--- a/data/languages/russian.txt
+++ b/data/languages/russian.txt
@@ -314,6 +314,7 @@ Ping
 Pistol
 == Пистолет
 
+[Demo browser]
 Play
 == Просмотр
 

--- a/data/languages/serbian.txt
+++ b/data/languages/serbian.txt
@@ -310,6 +310,7 @@ Ping
 Pistol
 == Pištolj
 
+[Demo browser]
 Play
 == Pokreni
 
@@ -1157,6 +1158,10 @@ Server executable not found, can't run server
 == 
 
 Editor
+== 
+
+[Start menu]
+Play
 == 
 
 DDNet %s is out!

--- a/data/languages/simplified_chinese.txt
+++ b/data/languages/simplified_chinese.txt
@@ -341,6 +341,7 @@ Ping
 Pistol
 == 手枪
 
+[Demo browser]
 Play
 == 播放
 
@@ -1233,4 +1234,8 @@ Server executable not found, can't run server
 == 
 
 Editor
+== 
+
+[Start menu]
+Play
 == 

--- a/data/languages/slovak.txt
+++ b/data/languages/slovak.txt
@@ -307,6 +307,7 @@ Ping
 Pistol
 == Pištoľ
 
+[Demo browser]
 Play
 == Prehrať
 
@@ -1156,6 +1157,10 @@ Server executable not found, can't run server
 == 
 
 Editor
+== 
+
+[Start menu]
+Play
 == 
 
 DDNet %s is out!

--- a/data/languages/spanish.txt
+++ b/data/languages/spanish.txt
@@ -316,6 +316,7 @@ Ping
 Pistol
 == Pistola
 
+[Demo browser]
 Play
 == Reproducir
 
@@ -1228,4 +1229,8 @@ Server executable not found, can't run server
 == 
 
 Editor
+== 
+
+[Start menu]
+Play
 == 

--- a/data/languages/swedish.txt
+++ b/data/languages/swedish.txt
@@ -309,6 +309,7 @@ Ping
 Pistol
 == Pistol
 
+[Demo browser]
 Play
 == Spela
 
@@ -1224,4 +1225,8 @@ Server executable not found, can't run server
 == 
 
 Editor
+== 
+
+[Start menu]
+Play
 == 

--- a/data/languages/traditional_chinese.txt
+++ b/data/languages/traditional_chinese.txt
@@ -335,6 +335,7 @@ Ping
 Pistol
 == 手槍
 
+[Demo browser]
 Play
 == 播放
 
@@ -1227,4 +1228,8 @@ Server executable not found, can't run server
 == 
 
 Editor
+== 
+
+[Start menu]
+Play
 == 

--- a/data/languages/turkish.txt
+++ b/data/languages/turkish.txt
@@ -312,6 +312,7 @@ Ping
 Pistol
 == Tabanca
 
+[Demo browser]
 Play
 == Oynat
 
@@ -1227,4 +1228,8 @@ Server executable not found, can't run server
 == 
 
 Editor
+== 
+
+[Start menu]
+Play
 == 

--- a/data/languages/ukrainian.txt
+++ b/data/languages/ukrainian.txt
@@ -238,6 +238,7 @@ Ping
 Pistol
 == Пістолет
 
+[Demo browser]
 Play
 == Перегляд
 
@@ -1222,4 +1223,8 @@ Server executable not found, can't run server
 == 
 
 Editor
+== 
+
+[Start menu]
+Play
 == 

--- a/scripts/languages/copy_fix.py
+++ b/scripts/languages/copy_fix.py
@@ -48,7 +48,9 @@ if append_missing:
         if content[-1] != "\n":
             content.append("\n")
         for i, miss in enumerate(missing):
-            content.append(local[miss]+"\n== \n\n")
+            if local[miss][1] != "":
+                content.append("["+local[miss][1]+"]\n")
+            content.append(local[miss][0]+"\n== \n\n")
         content[-1] = content[-1][:-1]
 
 open(outfile, "w").write("".join(content))

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -1245,7 +1245,7 @@ void CMenus::RenderDemoList(CUIRect MainView)
 	}
 
 	static int s_PlayButton = 0;
-	if(DoButton_Menu(&s_PlayButton, m_DemolistSelectedIsDir?Localize("Open"):Localize("Play"), 0, &PlayRect) || Activated || Input()->KeyPress(KEY_P))
+	if(DoButton_Menu(&s_PlayButton, m_DemolistSelectedIsDir ? Localize("Open") : Localize("Play", "Demo browser"), 0, &PlayRect) || Activated || Input()->KeyPress(KEY_P))
 	{
 		if(m_DemolistSelectedIndex >= 0)
 		{

--- a/src/game/client/components/menus_start.cpp
+++ b/src/game/client/components/menus_start.cpp
@@ -155,7 +155,7 @@ void CMenus::RenderStartMenu(CUIRect MainView)
 	Menu.HSplitBottom(5.0f, &Menu, 0); // little space
 	Menu.HSplitBottom(40.0f, &Menu, &Button);
 	static int s_PlayButton;
-	if(DoButton_Menu(&s_PlayButton, Localize("Play"), 0, &Button, g_Config.m_ClShowStartMenuImages ? "play_game" : 0, CUI::CORNER_ALL, Rounding, 0.5f, vec4(0.0f, 0.0f, 0.0f, 0.5f), vec4(0.0f, 0.0f, 0.0f, 0.25f)) || m_EnterPressed || CheckHotKey(KEY_P))
+	if(DoButton_Menu(&s_PlayButton, Localize("Play", "Start menu"), 0, &Button, g_Config.m_ClShowStartMenuImages ? "play_game" : 0, CUI::CORNER_ALL, Rounding, 0.5f, vec4(0.0f, 0.0f, 0.0f, 0.5f), vec4(0.0f, 0.0f, 0.0f, 0.25f)) || m_EnterPressed || CheckHotKey(KEY_P))
 	{
 		NewPage = g_Config.m_UiPage >= PAGE_INTERNET && g_Config.m_UiPage <= PAGE_KOG ? g_Config.m_UiPage : PAGE_DDNET;
 	}

--- a/src/game/localization.cpp
+++ b/src/game/localization.cpp
@@ -8,13 +8,13 @@
 #include <engine/console.h>
 #include <engine/storage.h>
 
-const char *Localize(const char *pStr)
+const char *Localize(const char *pStr, const char *pContext)
 {
-	const char *pNewStr = g_Localization.FindString(str_quickhash(pStr));
+	const char *pNewStr = g_Localization.FindString(str_quickhash(pStr), str_quickhash(pContext));
 	return pNewStr ? pNewStr : pStr;
 }
 
-CLocConstString::CLocConstString(const char *pStr)
+CLocConstString::CLocConstString(const char *pStr, const char *pContext)
 {
 	m_pDefaultStr = pStr;
 	m_Hash = str_quickhash(m_pDefaultStr);
@@ -24,7 +24,7 @@ CLocConstString::CLocConstString(const char *pStr)
 void CLocConstString::Reload()
 {
 	m_Version = g_Localization.Version();
-	const char *pNewStr = g_Localization.FindString(m_Hash);
+	const char *pNewStr = g_Localization.FindString(m_Hash, m_ContextHash);
 	m_pCurrentStr = pNewStr;
 	if(!m_pCurrentStr)
 		m_pCurrentStr = m_pDefaultStr;
@@ -36,10 +36,11 @@ CLocalizationDatabase::CLocalizationDatabase()
 	m_CurrentVersion = 0;
 }
 
-void CLocalizationDatabase::AddString(const char *pOrgStr, const char *pNewStr)
+void CLocalizationDatabase::AddString(const char *pOrgStr, const char *pNewStr, const char *pContext)
 {
 	CString s;
 	s.m_Hash = str_quickhash(pOrgStr);
+	s.m_ContextHash = str_quickhash(pContext);
 	s.m_Replacement = *pNewStr ? pNewStr : pOrgStr;
 	m_Strings.add(s);
 }
@@ -63,6 +64,7 @@ bool CLocalizationDatabase::Load(const char *pFilename, IStorage *pStorage, ICon
 	pConsole->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "localization", aBuf);
 	m_Strings.clear();
 
+	char aContext[512];
 	char aOrigin[512];
 	CLineReader LineReader;
 	LineReader.Init(IoHandle);
@@ -76,6 +78,23 @@ bool CLocalizationDatabase::Load(const char *pFilename, IStorage *pStorage, ICon
 
 		if(pLine[0] == '#') // skip comments
 			continue;
+
+		if(pLine[0] == '[') // context
+		{
+			size_t Len = str_length(pLine);
+			if(Len < 1 || pLine[Len - 1] != ']')
+			{
+				str_format(aBuf, sizeof(aBuf), "malform context line (%d): %s", Line, pLine);
+				pConsole->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "localization", aBuf);
+				continue;
+			}
+			str_copy(aContext, pLine + 1, Len - 1);
+			pLine = LineReader.Get();
+		}
+		else
+		{
+			aContext[0] = '\0';
+		}
 
 		str_copy(aOrigin, pLine, sizeof(aOrigin));
 		char *pReplacement = LineReader.Get();
@@ -94,7 +113,7 @@ bool CLocalizationDatabase::Load(const char *pFilename, IStorage *pStorage, ICon
 		}
 
 		pReplacement += 3;
-		AddString(aOrigin, pReplacement);
+		AddString(aOrigin, pReplacement, aContext);
 	}
 	io_close(IoHandle);
 
@@ -102,14 +121,27 @@ bool CLocalizationDatabase::Load(const char *pFilename, IStorage *pStorage, ICon
 	return true;
 }
 
-const char *CLocalizationDatabase::FindString(unsigned Hash)
+const char *CLocalizationDatabase::FindString(unsigned Hash, unsigned ContextHash)
 {
 	CString String;
 	String.m_Hash = Hash;
+	String.m_ContextHash = ContextHash;
 	sorted_array<CString>::range r = ::find_binary(m_Strings.all(), String);
 	if(r.empty())
 		return 0;
-	return r.front().m_Replacement;
+
+	unsigned DefaultHash = str_quickhash("");
+	unsigned DefaultIndex = 0;
+	for(unsigned i = 0; i < r.size() && r.index(i).m_Hash == Hash; ++i)
+	{
+		const CString &rStr = r.index(i);
+		if(rStr.m_ContextHash == ContextHash)
+			return rStr.m_Replacement;
+		else if(rStr.m_ContextHash == DefaultHash)
+			DefaultIndex = i;
+	}
+
+	return r.index(DefaultIndex).m_Replacement;
 }
 
 CLocalizationDatabase g_Localization;

--- a/src/game/localization.h
+++ b/src/game/localization.h
@@ -11,13 +11,14 @@ class CLocalizationDatabase
 	{
 	public:
 		unsigned m_Hash;
+		unsigned m_ContextHash;
 
 		// TODO: do this as an const char * and put everything on a incremental heap
 		string m_Replacement;
 
-		bool operator <(const CString &Other) const { return m_Hash < Other.m_Hash; }
-		bool operator <=(const CString &Other) const { return m_Hash <= Other.m_Hash; }
-		bool operator ==(const CString &Other) const { return m_Hash == Other.m_Hash; }
+		bool operator<(const CString &Other) const { return m_Hash < Other.m_Hash || (m_Hash == Other.m_Hash && m_ContextHash < Other.m_ContextHash); }
+		bool operator<=(const CString &Other) const { return m_Hash < Other.m_Hash || (m_Hash == Other.m_Hash && m_ContextHash <= Other.m_ContextHash); }
+		bool operator==(const CString &Other) const { return m_Hash == Other.m_Hash && m_ContextHash == Other.m_ContextHash; }
 	};
 
 	sorted_array<CString> m_Strings;
@@ -31,8 +32,8 @@ public:
 
 	int Version() { return m_CurrentVersion; }
 
-	void AddString(const char *pOrgStr, const char *pNewStr);
-	const char *FindString(unsigned Hash);
+	void AddString(const char *pOrgStr, const char *pNewStr, const char *pContext);
+	const char *FindString(unsigned Hash, unsigned ContextHash);
 };
 
 extern CLocalizationDatabase g_Localization;
@@ -42,9 +43,11 @@ class CLocConstString
 	const char *m_pDefaultStr;
 	const char *m_pCurrentStr;
 	unsigned m_Hash;
+	unsigned m_ContextHash;
 	int m_Version;
+
 public:
-	CLocConstString(const char *pStr);
+	CLocConstString(const char *pStr, const char *pContext = "");
 	void Reload();
 
 	inline operator const char *()
@@ -55,7 +58,6 @@ public:
 	}
 };
 
-
-extern const char *Localize(const char *pStr)
-GNUC_ATTRIBUTE((format_arg(1)));
+extern const char *Localize(const char *pStr, const char *pContext = "")
+	GNUC_ATTRIBUTE((format_arg(1)));
 #endif


### PR DESCRIPTION
Missing: scripts/languages doesn't work yet, but the context can be
added manually, see german.txt for an example.