### PR TITLE
Fix compilation on MinGW Windows

### DIFF
--- a/src/engine/graphics.h
+++ b/src/engine/graphics.h
@@ -7,6 +7,7 @@
 
 #include <base/color.h>
 #include <stddef.h>
+#include <stdint.h>
 
 #include <vector>
 #define GRAPHICS_TYPE_UNSIGNED_BYTE 0x1401


### PR DESCRIPTION
graphics.h:197:36: error: ‘uint8_t’ has not been declared