### PR TITLE
add windows websockets client support

### DIFF
--- a/src/engine/shared/websockets.cpp
+++ b/src/engine/shared/websockets.cpp
@@ -7,7 +7,11 @@
 #include "base/system.h"
 #include "protocol.h"
 #include "ringbuffer.h"
+#if defined(CONF_FAMILY_UNIX)
 #include <arpa/inet.h>
+#elif defined(CONF_FAMILY_WINDOWS)
+#include <Ws2tcpip.h>
+#endif
 #include <libwebsockets.h>
 
 extern "C" {

--- a/src/engine/shared/websockets.h
+++ b/src/engine/shared/websockets.h
@@ -1,11 +1,10 @@
 #ifndef ENGINE_SHARED_WEBSOCKETS_H
 #define ENGINE_SHARED_WEBSOCKETS_H
 
-#if !defined(CONF_FAMILY_UNIX)
-#error websockets only work on unix, sorry
+#if defined(CONF_FAMILY_UNIX)
+#elif defined(CONF_FAMILY_WINDOWS)
+#include <winsock2.h>
 #endif
-
-#include <netinet/in.h>
 
 int websocket_create(const char *addr, int port);
 int websocket_destroy(int socket);


### PR DESCRIPTION
In the last PR of websockets https://github.com/ddnet/ddnet/pull/2805 , It only support the websocket client in macOS and LinuxOS. And I add the Windows OS windows websockets client support in this PR.

It seem that netinet/in.h isn't used by websocket code so I remove it. After removed it I can successfully compile and run DDNet client and server in Linux too. If netinet/in.h have something usage I don't know, please tell me.