### PR TITLE
Fix spacing in kick-vote menu (center tees and text)

### DIFF
--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -590,9 +590,8 @@ bool CMenus::RenderServerControlKick(CUIRect MainView, bool FilterSpectators)
 		{
 			CTeeRenderInfo Info = m_pClient->m_aClients[aPlayerIDs[i]].m_RenderInfo;
 			Info.m_Size = Item.m_Rect.h;
-			Item.m_Rect.HSplitTop(5.0f, 0, &Item.m_Rect); // some margin from the top
-			RenderTools()->RenderTee(CAnimState::GetIdle(), &Info, EMOTE_NORMAL, vec2(1,0), vec2(Item.m_Rect.x+Item.m_Rect.h/2, Item.m_Rect.y+Item.m_Rect.h/2));
-			Item.m_Rect.x +=Info.m_Size;
+			RenderTools()->RenderTee(CAnimState::GetIdle(), &Info, EMOTE_NORMAL, vec2(1, 0), vec2(Item.m_Rect.x + Item.m_Rect.h / 2, Item.m_Rect.y + Item.m_Rect.h / 2));
+			Item.m_Rect.x += Info.m_Size;
 			UI()->DoLabelScaled(&Item.m_Rect, m_pClient->m_aClients[aPlayerIDs[i]].m_aName, 16.0f, -1);
 		}
 	}


### PR DESCRIPTION
Old: ![screenshot-20200917@090205](https://user-images.githubusercontent.com/2335377/93431529-882ab480-f8c4-11ea-8e56-dfe903a5ae06.png)
New: ![screenshot-20200917@090226](https://user-images.githubusercontent.com/2335377/93431538-8cef6880-f8c4-11ea-8946-449e7aa6dea7.png)
