### PR TITLE
fix websockets client link problem in xp

### DIFF
--- a/src/engine/shared/websockets.cpp
+++ b/src/engine/shared/websockets.cpp
@@ -90,7 +90,8 @@ static int websocket_callback(struct lws *wsi, enum lws_callback_reasons reason,
 		int orig_port = ntohs(pss->addr.sin_port);
 		pss->send_buffer.Init();
 		char addr_str[NETADDR_MAXSTRSIZE];
-		inet_ntop(AF_INET, &pss->addr.sin_addr, addr_str, sizeof(addr_str));
+		int ip_uint32 = pss->addr.sin_addr.s_addr;
+		str_format(addr_str, sizeof(addr_str), "%d.%d.%d.%d", (ip_uint32)&0xff, (ip_uint32 >> 8) & 0xff, (ip_uint32 >> 16) & 0xff, (ip_uint32 >> 24) & 0xff);
 		dbg_msg("websockets",
 			"connection established with %s:%d",
 			addr_str, orig_port);


### PR DESCRIPTION
implement a simple version of inet_ntop by myself. I only check that it can work at MacOS. No way for me to check if it work at windows xp now.