### PR TITLE
Fix skin prefix search crash

### DIFF
--- a/src/game/client/components/skins.cpp
+++ b/src/game/client/components/skins.cpp
@@ -257,7 +257,11 @@ int CSkins::FindImpl(const char *pName)
 		return -1;
 	}
 
-	int DefaultIndex = CSkins::Find("default");
+	int DefaultIndex = CSkins::FindImpl("default");
+
+	// if default fails don't start any download
+	if(DefaultIndex == -1)
+		return -1;
 
 	CDownloadSkin Skin;
 	str_copy(Skin.m_aName, pName, sizeof(Skin.m_aName));


### PR DESCRIPTION
Thanks alot to Spooky, with whom I painfully installed VS to find this crash.

Just use FindImpl on default, also added check if default exists, else return and abort the download.

To explain the crash:
e.g. Spooky used pinky as prefix:
it then tried pinky_x_spec, didnt found
it then tried pinky_default(bcs Find was used instead of FindImpl)
and then it always tried pinky_default, bcs the prefix was always added