### PR TITLE
Hide Network tabs from settings page, remove editor tab

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -945,14 +945,6 @@ int CMenus::RenderMenubar(CUIRect r)
 	if(DoButton_MenuTab(&s_SettingsButton, "\xEE\xA2\xB8", m_ActivePage==PAGE_SETTINGS, &Button, CUI::CORNER_T))
 		NewPage = PAGE_SETTINGS;
 
-	Box.VSplitRight(10.0f, &Box, &Button);
-	Box.VSplitRight(33.0f, &Box, &Button);
-	static int s_EditorButton=0;
-	if(DoButton_MenuTab(&s_EditorButton, "\xEE\x8F\x89", 0, &Button, CUI::CORNER_T))
-	{
-		g_Config.m_ClEditor = 1;
-	}
-
 	if(Client()->State() == IClient::STATE_OFFLINE)
 	{
 		Box.VSplitRight(10.0f, &Box, &Button);

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -817,6 +817,10 @@ int CMenus::RenderMenubar(CUIRect r)
 				m_DoubleClickIndex = -1;
 			}
 		}
+		else if (m_ActivePage == PAGE_SETTINGS)
+		{
+
+		}
 		else
 		{
 			Box.VSplitLeft(100.0f, &Button, &Box);


### PR DESCRIPTION
1. Settings page should not have Network tabs so tabs were hidden.

2. Editor is not really a tab, as well it exists at home page, as well ctrl+shift+e is a shortcut to enter it from any place of the game so editor tab was removed.

