### PR TITLE
Reload skin menu when skin count changed

### DIFF
--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -555,8 +555,9 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 	MainView.HSplitTop(20.0f, 0, &MainView);
 	MainView.HSplitTop(230.0f, &SkinList, &MainView);
 	static sorted_array<const CSkins::CSkin *> s_paSkinList;
+	static int s_SkinCount = 0;
 	static float s_ScrollValue = 0.0f;
-	if(s_InitSkinlist)
+	if(s_InitSkinlist || m_pClient->m_pSkins->Num() != s_SkinCount)
 	{
 		s_paSkinList.clear();
 		for(int i = 0; i < m_pClient->m_pSkins->Num(); ++i)
@@ -575,9 +576,10 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 			if (g_Config.m_ClVanillaSkinsOnly && !s->m_IsVanilla)
 				continue;
 
-			s_paSkinList.add(s);
+			s_paSkinList.add_unsorted(s);
 		}
 		s_InitSkinlist = false;
+		s_SkinCount = m_pClient->m_pSkins->Num();
 	}
 
 	int OldSelected = -1;


### PR DESCRIPTION
fixes graphics bug when new skins are added, skins array is reallocated and we accessed freed memory

Thanks to Jupeyy & Learath2 for also looking into this

Screenshot of the bug for reference, reproduced by removing all skins in data/skins, opening skin menu, joining a full server and waiting a bit:
![screenshot-20200921@005129](https://user-images.githubusercontent.com/2335377/93745612-1cae5300-fbf4-11ea-8b9f-887f0f46f7a6.png)
