### PR TITLE
After initialization: Agressively try to grab window again

### DIFF
--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -374,6 +374,10 @@ void CGameClient::OnInit()
 	m_GameWorld.m_pTuningList = m_aTuningList;
 
 	m_pMapimages->SetTextureScale(g_Config.m_ClTextEntitiesSize);
+
+	// Agressively try to grab window again since some Windows users report
+	// window not being focussed after starting client.
+	Graphics()->SetWindowGrab(true);
 }
 
 void CGameClient::OnUpdate()


### PR DESCRIPTION
Since some users on Windows report window not being initially focussed. Reincarnation of https://github.com/ddnet/ddnet/pull/2897 but not for OSX

I think this doesn't hurt.