### PR TITLE
Don't str_copy into string itself

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -704,7 +704,8 @@ void CClient::Connect(const char *pAddress, const char *pPassword)
 	Disconnect();
 
 	m_ConnectionID = RandomUuid();
-	str_copy(m_aServerAddressStr, pAddress, sizeof(m_aServerAddressStr));
+	if(pAddress != m_aServerAddressStr)
+		str_copy(m_aServerAddressStr, pAddress, sizeof(m_aServerAddressStr));
 
 	str_format(aBuf, sizeof(aBuf), "connecting to '%s'", m_aServerAddressStr);
 	m_pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "client", aBuf);


### PR DESCRIPTION
when reconnecting after server was full:

[2020-09-25 15:39:34][client]: offline error='This server is full'
Source and destination overlap in strncpy(0xd3328e2, 0xd3328e2, 255)
   at 0x483DFDC: strncpy (vg_replace_strmem.c:550)
   by 0x249180: str_copy (system.c:2328)
   by 0x27E1F5: CClient::Connect(char const*, char const*) (client.cpp:707)
   by 0x287864: CClient::Update() (client.cpp:2914)
   by 0x28891B: CClient::Run() (client.cpp:3216)
   by 0x28EDEC: main (client.cpp:4309)