### PR TITLE
bugfix: laser_damage was removed from tunes of 0.7 protocol

### DIFF
--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -676,7 +676,12 @@ void CGameContext::SendTuningParams(int ClientID, int Zone)
 	{
 		if (m_apPlayers[ClientID] && m_apPlayers[ClientID]->GetCharacter())
 		{
-			if((i==31) // collision
+			if((i==30) // laser_damage is removed from 0.7
+			&& (Server()->IsSixup(ClientID)))
+			{
+				continue;
+			}
+			else if((i==31) // collision
 			&& (m_apPlayers[ClientID]->GetCharacter()->NeededFaketuning() & FAKETUNE_SOLO
 			 || m_apPlayers[ClientID]->GetCharacter()->NeededFaketuning() & FAKETUNE_NOCOLL))
 			{

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -676,14 +676,13 @@ void CGameContext::SendTuningParams(int ClientID, int Zone)
 	{
 		if (m_apPlayers[ClientID] && m_apPlayers[ClientID]->GetCharacter())
 		{
-			if((i==30) // laser_damage is removed from 0.7
-			&& (Server()->IsSixup(ClientID)))
+			if((i == 30) // laser_damage is removed from 0.7
+				&& (Server()->IsSixup(ClientID)))
 			{
 				continue;
 			}
-			else if((i==31) // collision
-			&& (m_apPlayers[ClientID]->GetCharacter()->NeededFaketuning() & FAKETUNE_SOLO
-			 || m_apPlayers[ClientID]->GetCharacter()->NeededFaketuning() & FAKETUNE_NOCOLL))
+			else if((i == 31) // collision
+				&& (m_apPlayers[ClientID]->GetCharacter()->NeededFaketuning() & FAKETUNE_SOLO || m_apPlayers[ClientID]->GetCharacter()->NeededFaketuning() & FAKETUNE_NOCOLL))
 			{
 				Msg.AddInt(0);
 			}


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/68428243/94279573-f7ec0f80-ff54-11ea-852f-f6a2a195f935.png)

After:

![image](https://user-images.githubusercontent.com/68428243/94279452-c96e3480-ff54-11ea-8af6-d12ef6b86312.png)
