### PR TITLE
Don't change SpectatorID when not spectating

### DIFF
--- a/src/game/client/components/spectator.h
+++ b/src/game/client/components/spectator.h
@@ -22,6 +22,9 @@ class CSpectator : public CComponent
 	float m_OldMouseX;
 	float m_OldMouseY;
 
+	bool CanChangeSpectator();
+	void SpectateNext(bool Reverse);
+
 	static void ConKeySpectator(IConsole::IResult *pResult, void *pUserData);
 	static void ConSpectate(IConsole::IResult *pResult, void *pUserData);
 	static void ConSpectateNext(IConsole::IResult *pResult, void *pUserData);


### PR DESCRIPTION
This prevents a confusing situation where /pause and /spec lead to spectating yourself: https://youtu.be/9MzvDoXtMLc (looks as if /pause is broken unless you notice that you are spectating yourself).

This could've happened when you pressed spectate_next button while playing and SpectatorID got changed to yourself. I think it doesn't make sense to allow changing SpectatorID when playing at all.

I've also tried to simplify the code: the number of `for` loops in the updated code goes down from 10 to 3.

Things tested with this change:
1. Cycling through players when spectating (works)
2. Changing SpectatorID when not spectating (no longer possible)
3. Spectating yourself (still possible with "spectate N" command but no longer happens accidentally because of 2)
4. "spectate_closest" command (works)
5. Replaying demos where player goes into spectators (works)
