### PR TITLE
Handle rcon cmd completion properly with dummy

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -1805,17 +1805,23 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket)
 		}
 		else if((pPacket->m_Flags & NET_CHUNKFLAG_VITAL) != 0 && Msg == NETMSG_RCON_CMD_ADD)
 		{
-			const char *pName = Unpacker.GetString(CUnpacker::SANITIZE_CC);
-			const char *pHelp = Unpacker.GetString(CUnpacker::SANITIZE_CC);
-			const char *pParams = Unpacker.GetString(CUnpacker::SANITIZE_CC);
-			if(Unpacker.Error() == 0)
-				m_pConsole->RegisterTemp(pName, pParams, CFGFLAG_SERVER, pHelp);
+			if(!g_Config.m_ClDummy)
+			{
+				const char *pName = Unpacker.GetString(CUnpacker::SANITIZE_CC);
+				const char *pHelp = Unpacker.GetString(CUnpacker::SANITIZE_CC);
+				const char *pParams = Unpacker.GetString(CUnpacker::SANITIZE_CC);
+				if(Unpacker.Error() == 0)
+					m_pConsole->RegisterTemp(pName, pParams, CFGFLAG_SERVER, pHelp);
+			}
 		}
 		else if((pPacket->m_Flags & NET_CHUNKFLAG_VITAL) != 0 && Msg == NETMSG_RCON_CMD_REM)
 		{
-			const char *pName = Unpacker.GetString(CUnpacker::SANITIZE_CC);
-			if(Unpacker.Error() == 0)
-				m_pConsole->DeregisterTemp(pName);
+			if(!g_Config.m_ClDummy)
+			{
+				const char *pName = Unpacker.GetString(CUnpacker::SANITIZE_CC);
+				if(Unpacker.Error() == 0)
+					m_pConsole->DeregisterTemp(pName);
+			}
 		}
 		else if((pPacket->m_Flags & NET_CHUNKFLAG_VITAL) != 0 && Msg == NETMSG_RCON_AUTH_STATUS)
 		{
@@ -2129,6 +2135,26 @@ void CClient::ProcessServerPacketDummy(CNetChunk *pPacket)
 			Rcon("crashmeplx");
 			if(m_RconAuthed[0])
 				RconAuth("", m_RconPassword);
+		}
+		else if(Msg == NETMSG_RCON_CMD_ADD)
+		{
+			if(g_Config.m_ClDummy)
+			{
+				const char *pName = Unpacker.GetString(CUnpacker::SANITIZE_CC);
+				const char *pHelp = Unpacker.GetString(CUnpacker::SANITIZE_CC);
+				const char *pParams = Unpacker.GetString(CUnpacker::SANITIZE_CC);
+				if(Unpacker.Error() == 0)
+					m_pConsole->RegisterTemp(pName, pParams, CFGFLAG_SERVER, pHelp);
+			}
+		}
+		else if(Msg == NETMSG_RCON_CMD_REM)
+		{
+			if(g_Config.m_ClDummy)
+			{
+				const char *pName = Unpacker.GetString(CUnpacker::SANITIZE_CC);
+				if(Unpacker.Error() == 0)
+					m_pConsole->DeregisterTemp(pName);
+			}
 		}
 		else if(Msg == NETMSG_SNAP || Msg == NETMSG_SNAPSINGLE || Msg == NETMSG_SNAPEMPTY)
 		{


### PR DESCRIPTION
Only active player received them, reconnecting dummy a few times lead to
duplicate entries in tab completion. Now only main player is considered
for the completion.

as reported by Betz@lel-$h@l0m on Discord