### PR TITLE
Fix show_ips on non-SQL servers

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -3107,8 +3107,6 @@ void CServer::ConLogout(IConsole::IResult *pResult, void *pUser)
 
 void CServer::ConShowIps(IConsole::IResult *pResult, void *pUser)
 {
-	if(!g_Config.m_SvUseSQL)
-		return;
 	CServer *pServer = (CServer *)pUser;
 
 	if(pServer->m_RconClientID >= 0 && pServer->m_RconClientID < MAX_CLIENTS &&


### PR DESCRIPTION
Mistake was introduced in 7c31a15c93b34bd0557039ded65ea9456a72e33b

We didn't notice since official servers are SQL, except Block servers, and we just started moderating them a bit.