### PR TITLE
Fix cutting of one character when showing ips in rcon

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -1227,7 +1227,7 @@ void CServer::SendRconLineAuthed(const char *pLine, void *pUser, bool Highlighte
 	else
 	{
 		str_append(aLine, pLine, pStart - pLine + 1);
-		str_append(aLine, pStart + 2, pStart - pLine + pEnd - pStart - 2);
+		str_append(aLine, pStart + 2, pStart - pLine + pEnd - pStart - 1);
 		str_append(aLine, pEnd + 2, sizeof(aLine));
 
 		str_append(aLineWithoutIps, pLine, pStart - pLine + 1);


### PR DESCRIPTION
The buffer size passed to `str_append` includes the null terminator.