### PR TITLE
Handle PNG read errors (fixes #2959)

### DIFF
--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -440,7 +440,7 @@ int CGraphics_Threaded::LoadPNG(CImageInfo *pImg, const char *pFilename, int Sto
 	int Error = png_open_file(&Png, aCompleteFilename); // ignore_convention
 	if(Error != PNG_NO_ERROR)
 	{
-		dbg_msg("game/png", "failed to open file. filename='%s'", aCompleteFilename);
+		dbg_msg("game/png", "failed to open file. filename='%s', pnglite: %s", aCompleteFilename, png_error_string(Error));
 		if(Error != PNG_FILE_ERROR)
 			png_close_file(&Png); // ignore_convention
 		return 0;
@@ -454,7 +454,14 @@ int CGraphics_Threaded::LoadPNG(CImageInfo *pImg, const char *pFilename, int Sto
 	}
 
 	pBuffer = (unsigned char *)malloc(Png.width * Png.height * Png.bpp); // ignore_convention
-	png_get_data(&Png, pBuffer); // ignore_convention
+	Error = png_get_data(&Png, pBuffer); // ignore_convention
+	if(Error != PNG_NO_ERROR)
+	{
+		dbg_msg("game/png", "failed to read image. filename='%s', pnglite: %s", aCompleteFilename, png_error_string(Error));
+		free(pBuffer);
+		png_close_file(&Png); // ignore_convention
+		return 0;
+	}
 	png_close_file(&Png); // ignore_convention
 
 	pImg->m_Width = Png.width; // ignore_convention

--- a/src/tools/dilate.cpp
+++ b/src/tools/dilate.cpp
@@ -13,7 +13,7 @@ int DilateFile(const char *pFileName)
 	int Error = png_open_file(&Png, pFileName);
 	if(Error != PNG_NO_ERROR)
 	{
-		dbg_msg("dilate", "failed to open image file. filename='%s'", pFileName);
+		dbg_msg("dilate", "failed to open image file. filename='%s', pnglite: %s", pFileName, png_error_string(Error));
 		if(Error != PNG_FILE_ERROR)
 			png_close_file(&Png);
 		return 0;
@@ -27,7 +27,14 @@ int DilateFile(const char *pFileName)
 
 	unsigned char *pBuffer = (unsigned char *)malloc(Png.width * Png.height * sizeof(unsigned char) * 4);
 
-	png_get_data(&Png, pBuffer);
+	Error = png_get_data(&Png, pBuffer);
+	if(Error != PNG_NO_ERROR)
+	{
+		dbg_msg("map_convert_07", "failed to read image. filename='%s', pnglite: %s", pFileName, png_error_string(Error));
+		free(pBuffer);
+		png_close_file(&Png);
+		return 0;
+	}
 	png_close_file(&Png);
 
 	int w = Png.width;

--- a/src/tools/map_convert_07.cpp
+++ b/src/tools/map_convert_07.cpp
@@ -33,7 +33,7 @@ int LoadPNG(CImageInfo *pImg, const char *pFilename)
 	int Error = png_open_file(&Png, pFilename);
 	if(Error != PNG_NO_ERROR)
 	{
-		dbg_msg("map_convert_07", "failed to open image file. filename='%s'", pFilename);
+		dbg_msg("map_convert_07", "failed to open image file. filename='%s', pnglite: %s", pFilename, png_error_string(Error));
 		if(Error != PNG_FILE_ERROR)
 			png_close_file(&Png);
 		return 0;
@@ -47,7 +47,14 @@ int LoadPNG(CImageInfo *pImg, const char *pFilename)
 	}
 
 	pBuffer = (unsigned char *)malloc(Png.width * Png.height * Png.bpp);
-	png_get_data(&Png, pBuffer);
+	Error = png_get_data(&Png, pBuffer);
+	if(Error != PNG_NO_ERROR)
+	{
+		dbg_msg("map_convert_07", "failed to read image. filename='%s', pnglite: %s", pFilename, png_error_string(Error));
+		free(pBuffer);
+		png_close_file(&Png);
+		return 0;
+	}
 	png_close_file(&Png);
 
 	pImg->m_Width = Png.width;

--- a/src/tools/map_replace_image.cpp
+++ b/src/tools/map_replace_image.cpp
@@ -33,7 +33,7 @@ int LoadPNG(CImageInfo *pImg, const char *pFilename)
 	int Error = png_open_file(&Png, pFilename);
 	if(Error != PNG_NO_ERROR)
 	{
-		dbg_msg("map_replace_image", "failed to open image file. filename='%s'", pFilename);
+		dbg_msg("map_replace_image", "failed to open image file. filename='%s', pnglite: %s", pFilename, png_error_string(Error));
 		if(Error != PNG_FILE_ERROR)
 			png_close_file(&Png);
 		return 0;
@@ -47,7 +47,14 @@ int LoadPNG(CImageInfo *pImg, const char *pFilename)
 	}
 
 	pBuffer = (unsigned char *)malloc(Png.width * Png.height * Png.bpp);
-	png_get_data(&Png, pBuffer);
+	Error = png_get_data(&Png, pBuffer);
+	if(Error != PNG_NO_ERROR)
+	{
+		dbg_msg("map_convert_07", "failed to read image. filename='%s', pnglite: %s", pFilename, png_error_string(Error));
+		free(pBuffer);
+		png_close_file(&Png);
+		return 0;
+	}
 	png_close_file(&Png);
 
 	pImg->m_Width = Png.width;


### PR DESCRIPTION
and print a more telling error message

I'll check all our existing maps for failures now:
```
$ find . -iname '*.map' | while read i; do echo $i; map_extract $i > /dev/null; find . -iname '*.png' | while read j; do dilate $j; rm -- $j; done; done
```
For skins Soreu and the skin DB team is already taking care. (but I checked and the ones in Skin DB now can all be loaded without error)