### PR TITLE
Fix centering texts by making TextWidth accurate

### DIFF
--- a/src/engine/client/text.cpp
+++ b/src/engine/client/text.cpp
@@ -780,7 +780,10 @@ public:
 		CTextCursor Cursor;
 		SetCursor(&Cursor, 0, 0, Size, 0);
 		Cursor.m_LineWidth = LineWidth;
+		int OldRenderFlags = m_RenderFlags;
+		SetRenderFlags(OldRenderFlags | ETextRenderFlags::TEXT_RENDER_FLAG_NO_LAST_CHARACTER_ADVANCE);
 		TextEx(&Cursor, pText, StrLength);
+		SetRenderFlags(OldRenderFlags);
 		if(pAlignedHeight != NULL)
 			*pAlignedHeight = Cursor.m_AlignedFontSize;
 		return Cursor.m_X;


### PR DESCRIPTION
Previously the spacing after the last character was added to the width,
leading to all centerd texts being slightly too far right.

This was especially noticable for the x in clearable buttons, but
affected everything.

Thanks to @edg-l for bringing this up on Discord.

Look at the buttons at the top:
Old: ![screenshot-20201005@180730](https://user-images.githubusercontent.com/2335377/95104098-bbc76480-0735-11eb-92e9-a0e08b9156a6.png)
New: ![screenshot-20201005@180738](https://user-images.githubusercontent.com/2335377/95104122-c550cc80-0735-11eb-9482-d29d97f5ab31.png)

Browser, look at the clearable text boxes at bottom:
Old: ![screenshot-20201005@180718](https://user-images.githubusercontent.com/2335377/95104161-d3065200-0735-11eb-8b16-f52154893b19.png)
New: ![screenshot-20201005@180722](https://user-images.githubusercontent.com/2335377/95104191-d994c980-0735-11eb-8722-72c9974691fe.png)

