### PR TITLE
Fix all Multiplication type alerts by CodeQL

### DIFF
--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -326,7 +326,7 @@ void *CCommandProcessorFragment_OpenGL::Resize(int Width, int Height, int NewWid
 
 	int Bpp = TexFormatToImageColorChannelCount(Format);
 
-	pTmpData = (unsigned char *)malloc(NewWidth * NewHeight * Bpp);
+	pTmpData = (unsigned char *)malloc((size_t)NewWidth * NewHeight * Bpp);
 
 	ResizeImage((uint8_t *)pData, Width, Height, (uint8_t *)pTmpData, NewWidth, NewHeight, Bpp);
 
@@ -726,7 +726,7 @@ void CCommandProcessorFragment_OpenGL::Cmd_Texture_Create(const CCommandBuffer::
 			bool IsSingleLayer = (pCommand->m_Flags & (CCommandBuffer::TEXFLAG_TO_2D_ARRAY_TEXTURE_SINGLE_LAYER | CCommandBuffer::TEXFLAG_TO_3D_TEXTURE_SINGLE_LAYER)) != 0;
 
 			if(!IsSingleLayer)
-				p3DImageData = (uint8_t *)malloc(ImageColorChannels * Width * Height);
+				p3DImageData = (uint8_t *)malloc((size_t)ImageColorChannels * Width * Height);
 			int Image3DWidth, Image3DHeight;
 
 			int ConvertWidth = Width;
@@ -832,7 +832,7 @@ void CCommandProcessorFragment_OpenGL::Cmd_Screenshot(const CCommandBuffer::SCom
 	int h = aViewport[3];
 
 	// we allocate one more row to use when we are flipping the texture
-	unsigned char *pPixelData = (unsigned char *)malloc(w * (h + 1) * 3);
+	unsigned char *pPixelData = (unsigned char *)malloc((size_t)w * (h + 1) * 3);
 	unsigned char *pTempRow = pPixelData + w * h * 3;
 
 	// fetch the pixels
@@ -1211,7 +1211,7 @@ bool CCommandProcessorFragment_OpenGL2::DoAnalyzeStep(size_t StepN, size_t Check
 	int w = aViewport[2];
 	int h = aViewport[3];
 
-	size_t PixelDataSize = w * h * 3;
+	size_t PixelDataSize = (size_t)w * h * 3;
 	if(PixelDataSize == 0)
 		return false;
 	uint8_t *pPixelData = (uint8_t *)malloc(PixelDataSize);
@@ -2821,7 +2821,7 @@ void CCommandProcessorFragment_OpenGL3_3::Cmd_Texture_Create(const CCommandBuffe
 			bool IsSingleLayer = (pCommand->m_Flags & CCommandBuffer::TEXFLAG_TO_2D_ARRAY_TEXTURE_SINGLE_LAYER) != 0;
 
 			if(!IsSingleLayer)
-				p3DImageData = (uint8_t *)malloc(ImageColorChannels * Width * Height);
+				p3DImageData = (uint8_t *)malloc((size_t)ImageColorChannels * Width * Height);
 			int Image3DWidth, Image3DHeight;
 
 			int ConvertWidth = Width;
@@ -2995,7 +2995,7 @@ void CCommandProcessorFragment_OpenGL3_3::Cmd_Screenshot(const CCommandBuffer::S
 	int h = aViewport[3];
 
 	// we allocate one more row to use when we are flipping the texture
-	unsigned char *pPixelData = (unsigned char *)malloc(w * (h + 1) * 3);
+	unsigned char *pPixelData = (unsigned char *)malloc((size_t)w * (h + 1) * 3);
 	unsigned char *pTempRow = pPixelData + w * h * 3;
 
 	// fetch the pixels

--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -457,7 +457,7 @@ int CGraphics_Threaded::LoadPNG(CImageInfo *pImg, const char *pFilename, int Sto
 		return 0;
 	}
 
-	pBuffer = (unsigned char *)malloc(Png.width * Png.height * Png.bpp); // ignore_convention
+	pBuffer = (unsigned char *)malloc((size_t)Png.width * Png.height * Png.bpp); // ignore_convention
 	Error = png_get_data(&Png, pBuffer); // ignore_convention
 	if(Error != PNG_NO_ERROR)
 	{

--- a/src/engine/client/sound.cpp
+++ b/src/engine/client/sound.cpp
@@ -401,7 +401,7 @@ void CSound::RateConvert(int SampleID)
 
 	// allocate new data
 	NumFrames = (int)((pSample->m_NumFrames / (float)pSample->m_Rate) * m_MixingRate);
-	pNewData = (short *)calloc(NumFrames * pSample->m_Channels, sizeof(short));
+	pNewData = (short *)calloc((size_t)NumFrames * pSample->m_Channels, sizeof(short));
 
 	for(int i = 0; i < NumFrames; i++)
 	{
@@ -449,7 +449,7 @@ int CSound::DecodeOpus(int SampleID, const void *pData, unsigned DataSize)
 			return -1;
 		}
 
-		pSample->m_pData = (short *)calloc(NumSamples * NumChannels, sizeof(short));
+		pSample->m_pData = (short *)calloc((size_t)NumSamples * NumChannels, sizeof(short));
 
 		int Read;
 		int Pos = 0;
@@ -563,11 +563,11 @@ int CSound::DecodeWV(int SampleID, const void *pData, unsigned DataSize)
 			return -1;
 		}
 
-		int *pBuffer = (int *)calloc(NumSamples * NumChannels, sizeof(int));
+		int *pBuffer = (int *)calloc((size_t)NumSamples * NumChannels, sizeof(int));
 		WavpackUnpackSamples(pContext, pBuffer, NumSamples); // TODO: check return value
 		pSrc = pBuffer;
 
-		pSample->m_pData = (short *)calloc(NumSamples * NumChannels, sizeof(short));
+		pSample->m_pData = (short *)calloc((size_t)NumSamples * NumChannels, sizeof(short));
 		pDst = pSample->m_pData;
 
 		for(i = 0; i < NumSamples * NumChannels; i++)

--- a/src/engine/client/text.cpp
+++ b/src/engine/client/text.cpp
@@ -305,7 +305,7 @@ class CTextRender : public IEngineTextRender
 		}
 		else
 		{
-			pMem = calloc(Width * Height, 1);
+			pMem = calloc((size_t)Width * Height, 1);
 		}
 
 		IGraphics::CTextureHandle Texture = Graphics()->LoadTextureRaw(Width, Height, CImageInfo::FORMAT_ALPHA, pMem, CImageInfo::FORMAT_ALPHA, IGraphics::TEXLOAD_NOMIPMAPS | IGraphics::TEXLOAD_NO_COMPRESSION);
@@ -326,7 +326,7 @@ class CTextRender : public IEngineTextRender
 		int NewDimensions = pFont->m_CurTextureDimensions[TextureIndex] * 2;
 
 		unsigned char *pTmpTexBuffer = new unsigned char[NewDimensions * NewDimensions];
-		mem_zero(pTmpTexBuffer, NewDimensions * NewDimensions * sizeof(unsigned char));
+		mem_zero(pTmpTexBuffer, (size_t)NewDimensions * NewDimensions * sizeof(unsigned char));
 
 		for(int y = 0; y < pFont->m_CurTextureDimensions[TextureIndex]; ++y)
 		{
@@ -683,10 +683,10 @@ public:
 		pFont->m_pBuf = (void *)pBuf;
 		pFont->m_CurTextureDimensions[0] = 1024;
 		pFont->m_TextureData[0] = new unsigned char[pFont->m_CurTextureDimensions[0] * pFont->m_CurTextureDimensions[0]];
-		mem_zero(pFont->m_TextureData[0], pFont->m_CurTextureDimensions[0] * pFont->m_CurTextureDimensions[0] * sizeof(unsigned char));
+		mem_zero(pFont->m_TextureData[0], (size_t)pFont->m_CurTextureDimensions[0] * pFont->m_CurTextureDimensions[0] * sizeof(unsigned char));
 		pFont->m_CurTextureDimensions[1] = 1024;
 		pFont->m_TextureData[1] = new unsigned char[pFont->m_CurTextureDimensions[1] * pFont->m_CurTextureDimensions[1]];
-		mem_zero(pFont->m_TextureData[1], pFont->m_CurTextureDimensions[1] * pFont->m_CurTextureDimensions[1] * sizeof(unsigned char));
+		mem_zero(pFont->m_TextureData[1], (size_t)pFont->m_CurTextureDimensions[1] * pFont->m_CurTextureDimensions[1] * sizeof(unsigned char));
 
 		pFont->m_aTextures[0] = InitTexture(pFont->m_CurTextureDimensions[0], pFont->m_CurTextureDimensions[0]);
 		pFont->m_aTextures[1] = InitTexture(pFont->m_CurTextureDimensions[1], pFont->m_CurTextureDimensions[1]);
@@ -1896,7 +1896,7 @@ public:
 				for(size_t k = 0; k < m_Fonts[i]->m_TextureSkyline[j].m_CurHeightOfPixelColumn.size(); ++k)
 					m_Fonts[i]->m_TextureSkyline[j].m_CurHeightOfPixelColumn[k] = 0;
 
-				mem_zero(m_Fonts[i]->m_TextureData[j], m_Fonts[i]->m_CurTextureDimensions[j] * m_Fonts[i]->m_CurTextureDimensions[j] * sizeof(unsigned char));
+				mem_zero(m_Fonts[i]->m_TextureData[j], (size_t)m_Fonts[i]->m_CurTextureDimensions[j] * m_Fonts[i]->m_CurTextureDimensions[j] * sizeof(unsigned char));
 				Graphics()->LoadTextureRawSub(m_Fonts[i]->m_aTextures[j], 0, 0, m_Fonts[i]->m_CurTextureDimensions[j], m_Fonts[i]->m_CurTextureDimensions[j], CImageInfo::FORMAT_ALPHA, m_Fonts[i]->m_TextureData[j]);
 			}
 

--- a/src/engine/shared/dilate.cpp
+++ b/src/engine/shared/dilate.cpp
@@ -66,8 +66,8 @@ void DilateImage(unsigned char *pImageBuff, int w, int h, int BPP)
 {
 	unsigned char *pBuffer[2] = {NULL, NULL};
 
-	pBuffer[0] = (unsigned char *)malloc(w * h * sizeof(unsigned char) * BPP);
-	pBuffer[1] = (unsigned char *)malloc(w * h * sizeof(unsigned char) * BPP);
+	pBuffer[0] = (unsigned char *)malloc((size_t)w * h * sizeof(unsigned char) * BPP);
+	pBuffer[1] = (unsigned char *)malloc((size_t)w * h * sizeof(unsigned char) * BPP);
 
 	unsigned char *pPixelBuff = (unsigned char *)pImageBuff;
 

--- a/src/game/client/components/flow.cpp
+++ b/src/game/client/components/flow.cpp
@@ -50,7 +50,7 @@ void CFlow::Init()
 	m_Height = pTilemap->m_Height * 32 / m_Spacing;
 
 	// allocate and clear
-	m_pCells = (CCell *)calloc(m_Width * m_Height, sizeof(CCell));
+	m_pCells = (CCell *)calloc((size_t)m_Width * m_Height, sizeof(CCell));
 	for(int y = 0; y < m_Height; y++)
 		for(int x = 0; x < m_Width; x++)
 			m_pCells[y * m_Width + x].m_Vel = vec2(0.0f, 0.0f);

--- a/src/game/client/components/maplayers.cpp
+++ b/src/game/client/components/maplayers.cpp
@@ -1721,7 +1721,7 @@ void CMapLayers::OnRender()
 					CTile *pTiles = (CTile *)m_pLayers->Map()->GetData(pTMap->m_Data);
 					unsigned int Size = m_pLayers->Map()->GetDataSize(pTMap->m_Data);
 
-					if(Size >= pTMap->m_Width * pTMap->m_Height * sizeof(CTile))
+					if(Size >= (size_t)pTMap->m_Width * pTMap->m_Height * sizeof(CTile))
 					{
 						ColorRGBA Color = ColorRGBA(pTMap->m_Color.r / 255.0f, pTMap->m_Color.g / 255.0f, pTMap->m_Color.b / 255.0f, pTMap->m_Color.a / 255.0f);
 						if(IsGameLayer && EntityOverlayVal)
@@ -1819,7 +1819,7 @@ void CMapLayers::OnRender()
 				CTile *pFrontTiles = (CTile *)m_pLayers->Map()->GetData(pTMap->m_Front);
 				unsigned int Size = m_pLayers->Map()->GetDataSize(pTMap->m_Front);
 
-				if(Size >= pTMap->m_Width * pTMap->m_Height * sizeof(CTile))
+				if(Size >= (size_t)pTMap->m_Width * pTMap->m_Height * sizeof(CTile))
 				{
 					ColorRGBA Color = ColorRGBA(pTMap->m_Color.r / 255.0f, pTMap->m_Color.g / 255.0f, pTMap->m_Color.b / 255.0f, pTMap->m_Color.a / 255.0f * EntityOverlayVal / 100.0f);
 					if(!Graphics()->IsTileBufferingEnabled())
@@ -1846,7 +1846,7 @@ void CMapLayers::OnRender()
 				CSwitchTile *pSwitchTiles = (CSwitchTile *)m_pLayers->Map()->GetData(pTMap->m_Switch);
 				unsigned int Size = m_pLayers->Map()->GetDataSize(pTMap->m_Switch);
 
-				if(Size >= pTMap->m_Width * pTMap->m_Height * sizeof(CSwitchTile))
+				if(Size >= (size_t)pTMap->m_Width * pTMap->m_Height * sizeof(CSwitchTile))
 				{
 					ColorRGBA Color = ColorRGBA(pTMap->m_Color.r / 255.0f, pTMap->m_Color.g / 255.0f, pTMap->m_Color.b / 255.0f, pTMap->m_Color.a / 255.0f * EntityOverlayVal / 100.0f);
 					if(!Graphics()->IsTileBufferingEnabled())
@@ -1879,7 +1879,7 @@ void CMapLayers::OnRender()
 				CTeleTile *pTeleTiles = (CTeleTile *)m_pLayers->Map()->GetData(pTMap->m_Tele);
 				unsigned int Size = m_pLayers->Map()->GetDataSize(pTMap->m_Tele);
 
-				if(Size >= pTMap->m_Width * pTMap->m_Height * sizeof(CTeleTile))
+				if(Size >= (size_t)pTMap->m_Width * pTMap->m_Height * sizeof(CTeleTile))
 				{
 					ColorRGBA Color = ColorRGBA(pTMap->m_Color.r / 255.0f, pTMap->m_Color.g / 255.0f, pTMap->m_Color.b / 255.0f, pTMap->m_Color.a / 255.0f * EntityOverlayVal / 100.0f);
 					if(!Graphics()->IsTileBufferingEnabled())
@@ -1910,7 +1910,7 @@ void CMapLayers::OnRender()
 				CSpeedupTile *pSpeedupTiles = (CSpeedupTile *)m_pLayers->Map()->GetData(pTMap->m_Speedup);
 				unsigned int Size = m_pLayers->Map()->GetDataSize(pTMap->m_Speedup);
 
-				if(Size >= pTMap->m_Width * pTMap->m_Height * sizeof(CSpeedupTile))
+				if(Size >= (size_t)pTMap->m_Width * pTMap->m_Height * sizeof(CSpeedupTile))
 				{
 					ColorRGBA Color = ColorRGBA(pTMap->m_Color.r / 255.0f, pTMap->m_Color.g / 255.0f, pTMap->m_Color.b / 255.0f, pTMap->m_Color.a / 255.0f * EntityOverlayVal / 100.0f);
 					if(!Graphics()->IsTileBufferingEnabled())
@@ -1948,7 +1948,7 @@ void CMapLayers::OnRender()
 				CTuneTile *pTuneTiles = (CTuneTile *)m_pLayers->Map()->GetData(pTMap->m_Tune);
 				unsigned int Size = m_pLayers->Map()->GetDataSize(pTMap->m_Tune);
 
-				if(Size >= pTMap->m_Width * pTMap->m_Height * sizeof(CTuneTile))
+				if(Size >= (size_t)pTMap->m_Width * pTMap->m_Height * sizeof(CTuneTile))
 				{
 					ColorRGBA Color = ColorRGBA(pTMap->m_Color.r / 255.0f, pTMap->m_Color.g / 255.0f, pTMap->m_Color.b / 255.0f, pTMap->m_Color.a / 255.0f * EntityOverlayVal / 100.0f);
 					if(!Graphics()->IsTileBufferingEnabled())

--- a/src/game/collision.cpp
+++ b/src/game/collision.cpp
@@ -70,25 +70,25 @@ void CCollision::Init(class CLayers *pLayers)
 	if(m_pLayers->TeleLayer())
 	{
 		unsigned int Size = m_pLayers->Map()->GetDataSize(m_pLayers->TeleLayer()->m_Tele);
-		if(Size >= m_Width * m_Height * sizeof(CTeleTile))
+		if(Size >= (size_t)m_Width * m_Height * sizeof(CTeleTile))
 			m_pTele = static_cast<CTeleTile *>(m_pLayers->Map()->GetData(m_pLayers->TeleLayer()->m_Tele));
 	}
 
 	if(m_pLayers->SpeedupLayer())
 	{
 		unsigned int Size = m_pLayers->Map()->GetDataSize(m_pLayers->SpeedupLayer()->m_Speedup);
-		if(Size >= m_Width * m_Height * sizeof(CSpeedupTile))
+		if(Size >= (size_t)m_Width * m_Height * sizeof(CSpeedupTile))
 			m_pSpeedup = static_cast<CSpeedupTile *>(m_pLayers->Map()->GetData(m_pLayers->SpeedupLayer()->m_Speedup));
 	}
 
 	if(m_pLayers->SwitchLayer())
 	{
 		unsigned int Size = m_pLayers->Map()->GetDataSize(m_pLayers->SwitchLayer()->m_Switch);
-		if(Size >= m_Width * m_Height * sizeof(CSwitchTile))
+		if(Size >= (size_t)m_Width * m_Height * sizeof(CSwitchTile))
 			m_pSwitch = static_cast<CSwitchTile *>(m_pLayers->Map()->GetData(m_pLayers->SwitchLayer()->m_Switch));
 
 		m_pDoor = new CDoorTile[m_Width * m_Height];
-		mem_zero(m_pDoor, m_Width * m_Height * sizeof(CDoorTile));
+		mem_zero(m_pDoor, (size_t)m_Width * m_Height * sizeof(CDoorTile));
 	}
 	else
 	{
@@ -99,14 +99,14 @@ void CCollision::Init(class CLayers *pLayers)
 	if(m_pLayers->TuneLayer())
 	{
 		unsigned int Size = m_pLayers->Map()->GetDataSize(m_pLayers->TuneLayer()->m_Tune);
-		if(Size >= m_Width * m_Height * sizeof(CTuneTile))
+		if(Size >= (size_t)m_Width * m_Height * sizeof(CTuneTile))
 			m_pTune = static_cast<CTuneTile *>(m_pLayers->Map()->GetData(m_pLayers->TuneLayer()->m_Tune));
 	}
 
 	if(m_pLayers->FrontLayer())
 	{
 		unsigned int Size = m_pLayers->Map()->GetDataSize(m_pLayers->FrontLayer()->m_Front);
-		if(Size >= m_Width * m_Height * sizeof(CTile))
+		if(Size >= (size_t)m_Width * m_Height * sizeof(CTile))
 			m_pFront = static_cast<CTile *>(m_pLayers->Map()->GetData(m_pLayers->FrontLayer()->m_Front));
 	}
 
@@ -156,7 +156,7 @@ void CCollision::FillAntibot(CAntibotMapData *pMapData)
 {
 	pMapData->m_Width = m_Width;
 	pMapData->m_Height = m_Height;
-	pMapData->m_pTiles = (unsigned char *)malloc(m_Width * m_Height);
+	pMapData->m_pTiles = (unsigned char *)malloc((size_t)m_Width * m_Height);
 	for(int i = 0; i < m_Width * m_Height; i++)
 	{
 		pMapData->m_pTiles[i] = 0;

--- a/src/game/editor/io.cpp
+++ b/src/game/editor/io.cpp
@@ -308,7 +308,7 @@ int CEditorMap::Save(class IStorage *pStorage, const char *pFileName)
 			if(pImg->m_Format == CImageInfo::FORMAT_RGB)
 			{
 				// Convert to RGBA
-				unsigned char *pDataRGBA = (unsigned char *)malloc(Item.m_Width * Item.m_Height * 4);
+				unsigned char *pDataRGBA = (unsigned char *)malloc((size_t)Item.m_Width * Item.m_Height * 4);
 				unsigned char *pDataRGB = (unsigned char *)pImg->m_pData;
 				for(int i = 0; i < Item.m_Width * Item.m_Height; i++)
 				{
@@ -423,24 +423,24 @@ int CEditorMap::Save(class IStorage *pStorage, const char *pFileName)
 
 				if(Item.m_Flags && !(pLayer->m_Game))
 				{
-					CTile *pEmptyTiles = (CTile *)calloc(pLayer->m_Width * pLayer->m_Height, sizeof(CTile));
-					mem_zero(pEmptyTiles, pLayer->m_Width * pLayer->m_Height * sizeof(CTile));
-					Item.m_Data = df.AddData(pLayer->m_Width * pLayer->m_Height * sizeof(CTile), pEmptyTiles);
+					CTile *pEmptyTiles = (CTile *)calloc((size_t)pLayer->m_Width * pLayer->m_Height, sizeof(CTile));
+					mem_zero(pEmptyTiles, (size_t)pLayer->m_Width * pLayer->m_Height * sizeof(CTile));
+					Item.m_Data = df.AddData((size_t)pLayer->m_Width * pLayer->m_Height * sizeof(CTile), pEmptyTiles);
 					free(pEmptyTiles);
 
 					if(pLayer->m_Tele)
-						Item.m_Tele = df.AddData(pLayer->m_Width * pLayer->m_Height * sizeof(CTeleTile), ((CLayerTele *)pLayer)->m_pTeleTile);
+						Item.m_Tele = df.AddData((size_t)pLayer->m_Width * pLayer->m_Height * sizeof(CTeleTile), ((CLayerTele *)pLayer)->m_pTeleTile);
 					else if(pLayer->m_Speedup)
-						Item.m_Speedup = df.AddData(pLayer->m_Width * pLayer->m_Height * sizeof(CSpeedupTile), ((CLayerSpeedup *)pLayer)->m_pSpeedupTile);
+						Item.m_Speedup = df.AddData((size_t)pLayer->m_Width * pLayer->m_Height * sizeof(CSpeedupTile), ((CLayerSpeedup *)pLayer)->m_pSpeedupTile);
 					else if(pLayer->m_Front)
-						Item.m_Front = df.AddData(pLayer->m_Width * pLayer->m_Height * sizeof(CTile), pLayer->m_pTiles);
+						Item.m_Front = df.AddData((size_t)pLayer->m_Width * pLayer->m_Height * sizeof(CTile), pLayer->m_pTiles);
 					else if(pLayer->m_Switch)
-						Item.m_Switch = df.AddData(pLayer->m_Width * pLayer->m_Height * sizeof(CSwitchTile), ((CLayerSwitch *)pLayer)->m_pSwitchTile);
+						Item.m_Switch = df.AddData((size_t)pLayer->m_Width * pLayer->m_Height * sizeof(CSwitchTile), ((CLayerSwitch *)pLayer)->m_pSwitchTile);
 					else if(pLayer->m_Tune)
-						Item.m_Tune = df.AddData(pLayer->m_Width * pLayer->m_Height * sizeof(CTuneTile), ((CLayerTune *)pLayer)->m_pTuneTile);
+						Item.m_Tune = df.AddData((size_t)pLayer->m_Width * pLayer->m_Height * sizeof(CTuneTile), ((CLayerTune *)pLayer)->m_pTuneTile);
 				}
 				else
-					Item.m_Data = df.AddData(pLayer->m_Width * pLayer->m_Height * sizeof(CTile), pLayer->m_pTiles);
+					Item.m_Data = df.AddData((size_t)pLayer->m_Width * pLayer->m_Height * sizeof(CTile), pLayer->m_pTiles);
 
 				// save layer name
 				StrToInts(Item.m_aName, sizeof(Item.m_aName) / sizeof(int), pLayer->m_aName);
@@ -700,7 +700,7 @@ int CEditorMap::Load(class IStorage *pStorage, const char *pFileName, int Storag
 
 					// copy image data
 					void *pData = DataFile.GetData(pItem->m_ImageData);
-					pImg->m_pData = malloc(pImg->m_Width * pImg->m_Height * 4);
+					pImg->m_pData = malloc((size_t)pImg->m_Width * pImg->m_Height * 4);
 					mem_copy(pImg->m_pData, pData, pImg->m_Width * pImg->m_Height * 4);
 					int TextureLoadFlag = m_pEditor->Graphics()->HasTextureArrays() ? IGraphics::TEXLOAD_TO_2D_ARRAY_TEXTURE : IGraphics::TEXLOAD_TO_3D_TEXTURE;
 					if(pImg->m_Width % 16 != 0 || pImg->m_Height % 16 != 0)
@@ -899,7 +899,7 @@ int CEditorMap::Load(class IStorage *pStorage, const char *pFileName, int Storag
 						{
 							void *pTeleData = DataFile.GetData(pTilemapItem->m_Tele);
 							unsigned int Size = DataFile.GetDataSize(pTilemapItem->m_Tele);
-							if(Size >= pTiles->m_Width * pTiles->m_Height * sizeof(CTeleTile))
+							if(Size >= (size_t)pTiles->m_Width * pTiles->m_Height * sizeof(CTeleTile))
 							{
 								static const int s_aTilesRep[] = {
 									TILE_TELEIN,
@@ -911,7 +911,7 @@ int CEditorMap::Load(class IStorage *pStorage, const char *pFileName, int Storag
 									TILE_TELECHECKOUT,
 									TILE_TELEINWEAPON,
 									TILE_TELEINHOOK};
-								mem_copy(((CLayerTele *)pTiles)->m_pTeleTile, pTeleData, pTiles->m_Width * pTiles->m_Height * sizeof(CTeleTile));
+								mem_copy(((CLayerTele *)pTiles)->m_pTeleTile, pTeleData, (size_t)pTiles->m_Width * pTiles->m_Height * sizeof(CTeleTile));
 
 								for(int i = 0; i < pTiles->m_Width * pTiles->m_Height; i++)
 								{
@@ -930,9 +930,9 @@ int CEditorMap::Load(class IStorage *pStorage, const char *pFileName, int Storag
 							void *pSpeedupData = DataFile.GetData(pTilemapItem->m_Speedup);
 							unsigned int Size = DataFile.GetDataSize(pTilemapItem->m_Speedup);
 
-							if(Size >= pTiles->m_Width * pTiles->m_Height * sizeof(CSpeedupTile))
+							if(Size >= (size_t)pTiles->m_Width * pTiles->m_Height * sizeof(CSpeedupTile))
 							{
-								mem_copy(((CLayerSpeedup *)pTiles)->m_pSpeedupTile, pSpeedupData, pTiles->m_Width * pTiles->m_Height * sizeof(CSpeedupTile));
+								mem_copy(((CLayerSpeedup *)pTiles)->m_pSpeedupTile, pSpeedupData, (size_t)pTiles->m_Width * pTiles->m_Height * sizeof(CSpeedupTile));
 
 								for(int i = 0; i < pTiles->m_Width * pTiles->m_Height; i++)
 								{
@@ -949,8 +949,8 @@ int CEditorMap::Load(class IStorage *pStorage, const char *pFileName, int Storag
 						{
 							void *pFrontData = DataFile.GetData(pTilemapItem->m_Front);
 							unsigned int Size = DataFile.GetDataSize(pTilemapItem->m_Front);
-							if(Size >= pTiles->m_Width * pTiles->m_Height * sizeof(CTile))
-								mem_copy(((CLayerFront *)pTiles)->m_pTiles, pFrontData, pTiles->m_Width * pTiles->m_Height * sizeof(CTile));
+							if(Size >= (size_t)pTiles->m_Width * pTiles->m_Height * sizeof(CTile))
+								mem_copy(((CLayerFront *)pTiles)->m_pTiles, pFrontData, (size_t)pTiles->m_Width * pTiles->m_Height * sizeof(CTile));
 
 							DataFile.UnloadData(pTilemapItem->m_Front);
 						}
@@ -958,7 +958,7 @@ int CEditorMap::Load(class IStorage *pStorage, const char *pFileName, int Storag
 						{
 							void *pSwitchData = DataFile.GetData(pTilemapItem->m_Switch);
 							unsigned int Size = DataFile.GetDataSize(pTilemapItem->m_Switch);
-							if(Size >= pTiles->m_Width * pTiles->m_Height * sizeof(CSwitchTile))
+							if(Size >= (size_t)pTiles->m_Width * pTiles->m_Height * sizeof(CSwitchTile))
 							{
 								const int s_aTilesComp[] = {
 									TILE_SWITCHTIMEDOPEN,
@@ -976,7 +976,7 @@ int CEditorMap::Load(class IStorage *pStorage, const char *pFileName, int Storag
 									TILE_ALLOW_TELE_GUN,
 									TILE_ALLOW_BLUE_TELE_GUN};
 								CSwitchTile *pLayerSwitchTiles = ((CLayerSwitch *)pTiles)->m_pSwitchTile;
-								mem_copy(((CLayerSwitch *)pTiles)->m_pSwitchTile, pSwitchData, pTiles->m_Width * pTiles->m_Height * sizeof(CSwitchTile));
+								mem_copy(((CLayerSwitch *)pTiles)->m_pSwitchTile, pSwitchData, (size_t)pTiles->m_Width * pTiles->m_Height * sizeof(CSwitchTile));
 
 								for(int i = 0; i < pTiles->m_Width * pTiles->m_Height; i++)
 								{
@@ -1005,10 +1005,10 @@ int CEditorMap::Load(class IStorage *pStorage, const char *pFileName, int Storag
 						{
 							void *pTuneData = DataFile.GetData(pTilemapItem->m_Tune);
 							unsigned int Size = DataFile.GetDataSize(pTilemapItem->m_Tune);
-							if(Size >= pTiles->m_Width * pTiles->m_Height * sizeof(CTuneTile))
+							if(Size >= (size_t)pTiles->m_Width * pTiles->m_Height * sizeof(CTuneTile))
 							{
 								CTuneTile *pLayerTuneTiles = ((CLayerTune *)pTiles)->m_pTuneTile;
-								mem_copy(((CLayerTune *)pTiles)->m_pTuneTile, pTuneData, pTiles->m_Width * pTiles->m_Height * sizeof(CTuneTile));
+								mem_copy(((CLayerTune *)pTiles)->m_pTuneTile, pTuneData, (size_t)pTiles->m_Width * pTiles->m_Height * sizeof(CTuneTile));
 
 								for(int i = 0; i < pTiles->m_Width * pTiles->m_Height; i++)
 								{
@@ -1022,9 +1022,9 @@ int CEditorMap::Load(class IStorage *pStorage, const char *pFileName, int Storag
 						}
 						else // regular tile layer or game layer
 						{
-							if(Size >= pTiles->m_Width * pTiles->m_Height * sizeof(CTile))
+							if(Size >= (size_t)pTiles->m_Width * pTiles->m_Height * sizeof(CTile))
 							{
-								mem_copy(pTiles->m_pTiles, pData, pTiles->m_Width * pTiles->m_Height * sizeof(CTile));
+								mem_copy(pTiles->m_pTiles, pData, (size_t)pTiles->m_Width * pTiles->m_Height * sizeof(CTile));
 
 								if(pTiles->m_Game && pTilemapItem->m_Version == MakeVersion(1, *pTilemapItem))
 								{

--- a/src/game/editor/layer_tiles.cpp
+++ b/src/game/editor/layer_tiles.cpp
@@ -41,7 +41,7 @@ CLayerTiles::CLayerTiles(int w, int h)
 	m_AutoAutoMap = false;
 
 	m_pTiles = new CTile[m_Width * m_Height];
-	mem_zero(m_pTiles, m_Width * m_Height * sizeof(CTile));
+	mem_zero(m_pTiles, (size_t)m_Width * m_Height * sizeof(CTile));
 }
 
 CLayerTiles::~CLayerTiles()
@@ -559,7 +559,7 @@ void CLayerTiles::BrushRotate(float Amount)
 	{
 		// 90° rotation
 		CTile *pTempData = new CTile[m_Width * m_Height];
-		mem_copy(pTempData, m_pTiles, m_Width * m_Height * sizeof(CTile));
+		mem_copy(pTempData, m_pTiles, (size_t)m_Width * m_Height * sizeof(CTile));
 		CTile *pDst = m_pTiles;
 		bool Rotate = !(m_Game || m_Front) || m_pEditor->m_AllowPlaceUnusedTiles;
 		for(int x = 0; x < m_Width; ++x)
@@ -592,7 +592,7 @@ void CLayerTiles::BrushRotate(float Amount)
 void CLayerTiles::Resize(int NewW, int NewH)
 {
 	CTile *pNewData = new CTile[NewW * NewH];
-	mem_zero(pNewData, NewW * NewH * sizeof(CTile));
+	mem_zero(pNewData, (size_t)NewW * NewH * sizeof(CTile));
 
 	// copy old data
 	for(int y = 0; y < minimum(NewH, m_Height); y++)
@@ -1107,7 +1107,7 @@ CLayerTele::CLayerTele(int w, int h) :
 	m_Tele = 1;
 
 	m_pTeleTile = new CTeleTile[w * h];
-	mem_zero(m_pTeleTile, w * h * sizeof(CTeleTile));
+	mem_zero(m_pTeleTile, (size_t)w * h * sizeof(CTeleTile));
 }
 
 CLayerTele::~CLayerTele()
@@ -1119,7 +1119,7 @@ void CLayerTele::Resize(int NewW, int NewH)
 {
 	// resize tele data
 	CTeleTile *pNewTeleData = new CTeleTile[NewW * NewH];
-	mem_zero(pNewTeleData, NewW * NewH * sizeof(CTeleTile));
+	mem_zero(pNewTeleData, (size_t)NewW * NewH * sizeof(CTeleTile));
 
 	// copy old data
 	for(int y = 0; y < minimum(NewH, m_Height); y++)
@@ -1292,8 +1292,8 @@ void CLayerTele::BrushRotate(float Amount)
 		// 90° rotation
 		CTeleTile *pTempData1 = new CTeleTile[m_Width * m_Height];
 		CTile *pTempData2 = new CTile[m_Width * m_Height];
-		mem_copy(pTempData1, m_pTeleTile, m_Width * m_Height * sizeof(CTeleTile));
-		mem_copy(pTempData2, m_pTiles, m_Width * m_Height * sizeof(CTile));
+		mem_copy(pTempData1, m_pTeleTile, (size_t)m_Width * m_Height * sizeof(CTeleTile));
+		mem_copy(pTempData2, m_pTiles, (size_t)m_Width * m_Height * sizeof(CTile));
 		CTeleTile *pDst1 = m_pTeleTile;
 		CTile *pDst2 = m_pTiles;
 		for(int x = 0; x < m_Width; ++x)
@@ -1395,7 +1395,7 @@ CLayerSpeedup::CLayerSpeedup(int w, int h) :
 	m_Speedup = 1;
 
 	m_pSpeedupTile = new CSpeedupTile[w * h];
-	mem_zero(m_pSpeedupTile, w * h * sizeof(CSpeedupTile));
+	mem_zero(m_pSpeedupTile, (size_t)w * h * sizeof(CSpeedupTile));
 }
 
 CLayerSpeedup::~CLayerSpeedup()
@@ -1407,7 +1407,7 @@ void CLayerSpeedup::Resize(int NewW, int NewH)
 {
 	// resize speedup data
 	CSpeedupTile *pNewSpeedupData = new CSpeedupTile[NewW * NewH];
-	mem_zero(pNewSpeedupData, NewW * NewH * sizeof(CSpeedupTile));
+	mem_zero(pNewSpeedupData, (size_t)NewW * NewH * sizeof(CSpeedupTile));
 
 	// copy old data
 	for(int y = 0; y < minimum(NewH, m_Height); y++)
@@ -1597,8 +1597,8 @@ void CLayerSpeedup::BrushRotate(float Amount)
 		// 90° rotation
 		CSpeedupTile *pTempData1 = new CSpeedupTile[m_Width * m_Height];
 		CTile *pTempData2 = new CTile[m_Width * m_Height];
-		mem_copy(pTempData1, m_pSpeedupTile, m_Width * m_Height * sizeof(CSpeedupTile));
-		mem_copy(pTempData2, m_pTiles, m_Width * m_Height * sizeof(CTile));
+		mem_copy(pTempData1, m_pSpeedupTile, (size_t)m_Width * m_Height * sizeof(CSpeedupTile));
+		mem_copy(pTempData2, m_pTiles, (size_t)m_Width * m_Height * sizeof(CTile));
 		CSpeedupTile *pDst1 = m_pSpeedupTile;
 		CTile *pDst2 = m_pTiles;
 		for(int x = 0; x < m_Width; ++x)
@@ -1739,7 +1739,7 @@ CLayerSwitch::CLayerSwitch(int w, int h) :
 	m_Switch = 1;
 
 	m_pSwitchTile = new CSwitchTile[w * h];
-	mem_zero(m_pSwitchTile, w * h * sizeof(CSwitchTile));
+	mem_zero(m_pSwitchTile, (size_t)w * h * sizeof(CSwitchTile));
 }
 
 CLayerSwitch::~CLayerSwitch()
@@ -1751,7 +1751,7 @@ void CLayerSwitch::Resize(int NewW, int NewH)
 {
 	// resize switch data
 	CSwitchTile *pNewSwitchData = new CSwitchTile[NewW * NewH];
-	mem_zero(pNewSwitchData, NewW * NewH * sizeof(CSwitchTile));
+	mem_zero(pNewSwitchData, (size_t)NewW * NewH * sizeof(CSwitchTile));
 
 	// copy old data
 	for(int y = 0; y < minimum(NewH, m_Height); y++)
@@ -1938,8 +1938,8 @@ void CLayerSwitch::BrushRotate(float Amount)
 		// 90° rotation
 		CSwitchTile *pTempData1 = new CSwitchTile[m_Width * m_Height];
 		CTile *pTempData2 = new CTile[m_Width * m_Height];
-		mem_copy(pTempData1, m_pSwitchTile, m_Width * m_Height * sizeof(CSwitchTile));
-		mem_copy(pTempData2, m_pTiles, m_Width * m_Height * sizeof(CTile));
+		mem_copy(pTempData1, m_pSwitchTile, (size_t)m_Width * m_Height * sizeof(CSwitchTile));
+		mem_copy(pTempData2, m_pTiles, (size_t)m_Width * m_Height * sizeof(CTile));
 		CSwitchTile *pDst1 = m_pSwitchTile;
 		CTile *pDst2 = m_pTiles;
 		for(int x = 0; x < m_Width; ++x)
@@ -2055,7 +2055,7 @@ CLayerTune::CLayerTune(int w, int h) :
 	m_Tune = 1;
 
 	m_pTuneTile = new CTuneTile[w * h];
-	mem_zero(m_pTuneTile, w * h * sizeof(CTuneTile));
+	mem_zero(m_pTuneTile, (size_t)w * h * sizeof(CTuneTile));
 }
 
 CLayerTune::~CLayerTune()
@@ -2067,7 +2067,7 @@ void CLayerTune::Resize(int NewW, int NewH)
 {
 	// resize Tune data
 	CTuneTile *pNewTuneData = new CTuneTile[NewW * NewH];
-	mem_zero(pNewTuneData, NewW * NewH * sizeof(CTuneTile));
+	mem_zero(pNewTuneData, (size_t)NewW * NewH * sizeof(CTuneTile));
 
 	// copy old data
 	for(int y = 0; y < minimum(NewH, m_Height); y++)
@@ -2242,8 +2242,8 @@ void CLayerTune::BrushRotate(float Amount)
 		// 90° rotation
 		CTuneTile *pTempData1 = new CTuneTile[m_Width * m_Height];
 		CTile *pTempData2 = new CTile[m_Width * m_Height];
-		mem_copy(pTempData1, m_pTuneTile, m_Width * m_Height * sizeof(CTuneTile));
-		mem_copy(pTempData2, m_pTiles, m_Width * m_Height * sizeof(CTile));
+		mem_copy(pTempData1, m_pTuneTile, (size_t)m_Width * m_Height * sizeof(CTuneTile));
+		mem_copy(pTempData2, m_pTiles, (size_t)m_Width * m_Height * sizeof(CTile));
 		CTuneTile *pDst1 = m_pTuneTile;
 		CTile *pDst2 = m_pTiles;
 		for(int x = 0; x < m_Width; ++x)

--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -926,7 +926,7 @@ void CGameContext::ConJoinTeam(IConsole::IResult *pResult, void *pUserData)
 				str_format(aBuf, sizeof(aBuf), "You are in team %d already", Team);
 				pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "join", aBuf);
 			}
-			else if(pPlayer->m_Last_Team + pSelf->Server()->TickSpeed() * g_Config.m_SvTeamChangeDelay > pSelf->Server()->Tick())
+			else if(pPlayer->m_Last_Team + (int64_t)pSelf->Server()->TickSpeed() * g_Config.m_SvTeamChangeDelay > pSelf->Server()->Tick())
 			{
 				pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "join",
 					"You can\'t change teams that fast!");
@@ -1080,7 +1080,7 @@ void CGameContext::ConEyeEmote(IConsole::IResult *pResult, void *pUserData)
 	}
 	else
 	{
-		if(pPlayer->m_LastEyeEmote + g_Config.m_SvEyeEmoteChangeDelay * pSelf->Server()->TickSpeed() >= pSelf->Server()->Tick())
+		if(pPlayer->m_LastEyeEmote + (int64_t)g_Config.m_SvEyeEmoteChangeDelay * pSelf->Server()->TickSpeed() >= pSelf->Server()->Tick())
 			return;
 
 		if(!str_comp(pResult->GetString(0), "angry"))

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -2418,10 +2418,10 @@ void CCharacter::Rescue()
 {
 	if(m_SetSavePos && !m_Super)
 	{
-		if(m_LastRescue + g_Config.m_SvRescueDelay * Server()->TickSpeed() > Server()->Tick())
+		if(m_LastRescue + (int64_t)g_Config.m_SvRescueDelay * Server()->TickSpeed() > Server()->Tick())
 		{
 			char aBuf[256];
-			str_format(aBuf, sizeof(aBuf), "You have to wait %d seconds until you can rescue yourself", (int)((m_LastRescue + g_Config.m_SvRescueDelay * Server()->TickSpeed() - Server()->Tick()) / Server()->TickSpeed()));
+			str_format(aBuf, sizeof(aBuf), "You have to wait %d seconds until you can rescue yourself", (int)((m_LastRescue + (int64_t)g_Config.m_SvRescueDelay * Server()->TickSpeed() - Server()->Tick()) / Server()->TickSpeed()));
 			GameServer()->SendChatTarget(GetPlayer()->GetCID(), aBuf);
 			return;
 		}

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -843,7 +843,7 @@ int CPlayer::Pause(int State, bool Force)
 		case PAUSE_NONE:
 			if(m_pCharacter->IsPaused()) // First condition might be unnecessary
 			{
-				if(!Force && m_LastPause && m_LastPause + g_Config.m_SvSpecFrequency * Server()->TickSpeed() > Server()->Tick())
+				if(!Force && m_LastPause && m_LastPause + (int64_t)g_Config.m_SvSpecFrequency * Server()->TickSpeed() > Server()->Tick())
 				{
 					GameServer()->SendChatTarget(m_ClientID, "Can't /spec that quickly.");
 					return m_Paused; // Do not update state. Do not collect $200

--- a/src/game/server/score.cpp
+++ b/src/game/server/score.cpp
@@ -121,7 +121,7 @@ bool CScore::RateLimitPlayer(int ClientID)
 	CPlayer *pPlayer = GameServer()->m_apPlayers[ClientID];
 	if(pPlayer == 0)
 		return true;
-	if(pPlayer->m_LastSQLQuery + g_Config.m_SvSqlQueriesDelay * Server()->TickSpeed() >= Server()->Tick())
+	if(pPlayer->m_LastSQLQuery + (int64_t)g_Config.m_SvSqlQueriesDelay * Server()->TickSpeed() >= Server()->Tick())
 		return true;
 	pPlayer->m_LastSQLQuery = Server()->Tick();
 	return false;

--- a/src/tools/dilate.cpp
+++ b/src/tools/dilate.cpp
@@ -25,7 +25,7 @@ int DilateFile(const char *pFileName)
 		return 1;
 	}
 
-	unsigned char *pBuffer = (unsigned char *)malloc(Png.width * Png.height * sizeof(unsigned char) * 4);
+	unsigned char *pBuffer = (unsigned char *)malloc((size_t)Png.width * Png.height * sizeof(unsigned char) * 4);
 
 	Error = png_get_data(&Png, pBuffer);
 	if(Error != PNG_NO_ERROR)

--- a/src/tools/map_convert_07.cpp
+++ b/src/tools/map_convert_07.cpp
@@ -46,7 +46,7 @@ int LoadPNG(CImageInfo *pImg, const char *pFilename)
 		return 0;
 	}
 
-	pBuffer = (unsigned char *)malloc(Png.width * Png.height * Png.bpp);
+	pBuffer = (unsigned char *)malloc((size_t)Png.width * Png.height * Png.bpp);
 	Error = png_get_data(&Png, pBuffer);
 	if(Error != PNG_NO_ERROR)
 	{

--- a/src/tools/map_replace_image.cpp
+++ b/src/tools/map_replace_image.cpp
@@ -46,7 +46,7 @@ int LoadPNG(CImageInfo *pImg, const char *pFilename)
 		return 0;
 	}
 
-	pBuffer = (unsigned char *)malloc(Png.width * Png.height * Png.bpp);
+	pBuffer = (unsigned char *)malloc((size_t)Png.width * Png.height * Png.bpp);
 	Error = png_get_data(&Png, pBuffer);
 	if(Error != PNG_NO_ERROR)
 	{


### PR DESCRIPTION
> Multiplication result converted to larger type

> A multiplication result that is converted to a larger type can be a
> sign that the result can overflow the type converted from.

Example: https://github.com/ddnet/ddnet/security/code-scanning/17?query=ref%3Arefs%2Fheads%2Fmaster