### PR TITLE
only load + save auto mappers for tile layers, not physics layers

### DIFF
--- a/src/game/editor/io.cpp
+++ b/src/game/editor/io.cpp
@@ -440,7 +440,8 @@ int CEditorMap::Save(class IStorage *pStorage, const char *pFileName)
 				df.AddItem(MAPITEMTYPE_LAYER, LayerCount, sizeof(Item), &Item);
 
 				// save auto mapper of each tile layer (not physics layer)
-				if(!Item.m_Flags) {
+				if(!Item.m_Flags)
+				{
 					CMapItemAutoMapperConfig ItemAutomapper;
 					ItemAutomapper.m_Version = CMapItemAutoMapperConfig::CURRENT_VERSION;
 					ItemAutomapper.m_GroupId = GroupCount;
@@ -1285,11 +1286,13 @@ int CEditorMap::Load(class IStorage *pStorage, const char *pFileName, int Storag
 					if(pItem->m_GroupId >= 0 && pItem->m_GroupId < m_lGroups.size() &&
 						pItem->m_LayerId >= 0 && pItem->m_LayerId < m_lGroups[pItem->m_GroupId]->m_lLayers.size()) {
 						CLayer *pLayer = m_lGroups[pItem->m_GroupId]->m_lLayers[pItem->m_LayerId];
-						if (pLayer->m_Type == LAYERTYPE_TILES) {
+						if (pLayer->m_Type == LAYERTYPE_TILES)
+						{
 							CLayerTiles *pLayer = (CLayerTiles *)m_lGroups[pItem->m_GroupId]->m_lLayers[pItem->m_LayerId];
 							// only load auto mappers for tile layers (not physics layers)
 							if (!(pLayer->m_Game || pLayer->m_Tele || pLayer->m_Speedup ||
-									pLayer->m_Front || pLayer->m_Switch || pLayer->m_Tune)) {
+									pLayer->m_Front || pLayer->m_Switch || pLayer->m_Tune))
+							{
 								pLayer->m_AutoMapperConfig = pItem->m_AutomapperConfig;
 								pLayer->m_Seed = pItem->m_AutomapperSeed;
 								pLayer->m_AutoAutoMap = !!(pItem->m_Flags & CMapItemAutoMapperConfig::FLAG_AUTOMATIC);

--- a/src/game/editor/io.cpp
+++ b/src/game/editor/io.cpp
@@ -439,18 +439,21 @@ int CEditorMap::Save(class IStorage *pStorage, const char *pFileName)
 
 				df.AddItem(MAPITEMTYPE_LAYER, LayerCount, sizeof(Item), &Item);
 
-				CMapItemAutoMapperConfig ItemAutomapper;
-				ItemAutomapper.m_Version = CMapItemAutoMapperConfig::CURRENT_VERSION;
-				ItemAutomapper.m_GroupId = GroupCount;
-				ItemAutomapper.m_LayerId = GItem.m_NumLayers;
-				ItemAutomapper.m_AutomapperConfig = pLayer->m_AutoMapperConfig;
-				ItemAutomapper.m_AutomapperSeed = pLayer->m_Seed;
-				ItemAutomapper.m_Flags = 0;
-				if(pLayer->m_AutoAutoMap)
-					ItemAutomapper.m_Flags |= CMapItemAutoMapperConfig::FLAG_AUTOMATIC;
+				// save auto mapper of each tile layer (not physics layer)
+				if(!Item.m_Flags) {
+					CMapItemAutoMapperConfig ItemAutomapper;
+					ItemAutomapper.m_Version = CMapItemAutoMapperConfig::CURRENT_VERSION;
+					ItemAutomapper.m_GroupId = GroupCount;
+					ItemAutomapper.m_LayerId = GItem.m_NumLayers;
+					ItemAutomapper.m_AutomapperConfig = pLayer->m_AutoMapperConfig;
+					ItemAutomapper.m_AutomapperSeed = pLayer->m_Seed;
+					ItemAutomapper.m_Flags = 0;
+					if(pLayer->m_AutoAutoMap)
+						ItemAutomapper.m_Flags |= CMapItemAutoMapperConfig::FLAG_AUTOMATIC;
 
-				df.AddItem(MAPITEMTYPE_AUTOMAPPER_CONFIG, AutomapperCount, sizeof(ItemAutomapper), &ItemAutomapper);
-				AutomapperCount++;
+					df.AddItem(MAPITEMTYPE_AUTOMAPPER_CONFIG, AutomapperCount, sizeof(ItemAutomapper), &ItemAutomapper);
+					AutomapperCount++;
+				}
 
 				GItem.m_NumLayers++;
 				LayerCount++;
@@ -1280,13 +1283,18 @@ int CEditorMap::Load(class IStorage *pStorage, const char *pFileName, int Storag
 				if(pItem->m_Version == CMapItemAutoMapperConfig::CURRENT_VERSION)
 				{
 					if(pItem->m_GroupId >= 0 && pItem->m_GroupId < m_lGroups.size() &&
-						pItem->m_LayerId >= 0 && pItem->m_LayerId < m_lGroups[pItem->m_GroupId]->m_lLayers.size() &&
-						m_lGroups[pItem->m_GroupId]->m_lLayers[pItem->m_LayerId]->m_Type == LAYERTYPE_TILES)
-					{
-						CLayerTiles *pLayer = (CLayerTiles *)m_lGroups[pItem->m_GroupId]->m_lLayers[pItem->m_LayerId];
-						pLayer->m_AutoMapperConfig = pItem->m_AutomapperConfig;
-						pLayer->m_Seed = pItem->m_AutomapperSeed;
-						pLayer->m_AutoAutoMap = !!(pItem->m_Flags & CMapItemAutoMapperConfig::FLAG_AUTOMATIC);
+						pItem->m_LayerId >= 0 && pItem->m_LayerId < m_lGroups[pItem->m_GroupId]->m_lLayers.size()) {
+						CLayer *pLayer = m_lGroups[pItem->m_GroupId]->m_lLayers[pItem->m_LayerId];
+						if (pLayer->m_Type == LAYERTYPE_TILES) {
+							CLayerTiles *pLayer = (CLayerTiles *)m_lGroups[pItem->m_GroupId]->m_lLayers[pItem->m_LayerId];
+							// only load auto mappers for tile layers (not physics layers)
+							if (!(pLayer->m_Game || pLayer->m_Tele || pLayer->m_Speedup ||
+									pLayer->m_Front || pLayer->m_Switch || pLayer->m_Tune)) {
+								pLayer->m_AutoMapperConfig = pItem->m_AutomapperConfig;
+								pLayer->m_Seed = pItem->m_AutomapperSeed;
+								pLayer->m_AutoAutoMap = !!(pItem->m_Flags & CMapItemAutoMapperConfig::FLAG_AUTOMATIC);
+							}
+						}
 					}
 				}
 			}

--- a/src/game/editor/io.cpp
+++ b/src/game/editor/io.cpp
@@ -1284,14 +1284,15 @@ int CEditorMap::Load(class IStorage *pStorage, const char *pFileName, int Storag
 				if(pItem->m_Version == CMapItemAutoMapperConfig::CURRENT_VERSION)
 				{
 					if(pItem->m_GroupId >= 0 && pItem->m_GroupId < m_lGroups.size() &&
-						pItem->m_LayerId >= 0 && pItem->m_LayerId < m_lGroups[pItem->m_GroupId]->m_lLayers.size()) {
+						pItem->m_LayerId >= 0 && pItem->m_LayerId < m_lGroups[pItem->m_GroupId]->m_lLayers.size())
+					{
 						CLayer *pLayer = m_lGroups[pItem->m_GroupId]->m_lLayers[pItem->m_LayerId];
-						if (pLayer->m_Type == LAYERTYPE_TILES)
+						if(pLayer->m_Type == LAYERTYPE_TILES)
 						{
 							CLayerTiles *pLayer = (CLayerTiles *)m_lGroups[pItem->m_GroupId]->m_lLayers[pItem->m_LayerId];
 							// only load auto mappers for tile layers (not physics layers)
-							if (!(pLayer->m_Game || pLayer->m_Tele || pLayer->m_Speedup ||
-									pLayer->m_Front || pLayer->m_Switch || pLayer->m_Tune))
+							if(!(pLayer->m_Game || pLayer->m_Tele || pLayer->m_Speedup ||
+								   pLayer->m_Front || pLayer->m_Switch || pLayer->m_Tune))
 							{
 								pLayer->m_AutoMapperConfig = pItem->m_AutomapperConfig;
 								pLayer->m_Seed = pItem->m_AutomapperSeed;


### PR DESCRIPTION
If I'm not mistaken, loading a map without auto mappers, then saving would've caused uninitialized values to be written to the auto mappers of physics layers.