### PR TITLE
Use renderinfo for player death effect

### DIFF
--- a/src/game/client/components/effects.cpp
+++ b/src/game/client/components/effects.cpp
@@ -167,7 +167,7 @@ void CEffects::PlayerDeath(vec2 Pos, int ClientID)
 	if(ClientID >= 0)
 	{
 		if(m_pClient->m_aClients[ClientID].m_UseCustomColor)
-			BloodColor = color_cast<ColorRGBA>(ColorHSLA(m_pClient->m_aClients[ClientID].m_ColorBody).UnclampLighting(0.5f));
+			BloodColor = m_pClient->m_aClients[ClientID].m_RenderInfo.m_ColorBody;
 		else
 		{
 			const CSkins::CSkin *s = m_pClient->m_pSkins->Get(m_pClient->m_aClients[ClientID].m_SkinID);


### PR DESCRIPTION
the render info color is created the same way, just that it is allowed to be overritten for team colors
see OnNewSnapshot
and UpdateRenderInfo