### PR TITLE
Add clang-tidy to CI and enable clang-analyzer checks (supersedes #3075, fixes #3071)

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,19 @@
+# Why we disabled individual checks:
+#
+# clang-analyzer-optin.cplusplus.UninitializedObject
+#   TODO: Occurs commonly in graphics_threaded.h
+# clang-analyzer-optin.cplusplus.VirtualCall
+#   Occurs very commonly all over
+# clang-analyzer-optin.performance.Padding
+#   Too annoying to always align for perfect padding
+# clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling,
+#   TODO: Requires C11 to fix
+
+Checks: >
+  -*,
+  clang-analyzer-*,
+  -clang-analyzer-optin.cplusplus.UninitializedObject,
+  -clang-analyzer-optin.cplusplus.VirtualCall,
+  -clang-analyzer-optin.performance.Padding,
+  -clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling,
+HeaderFilterRegex: 'src/.*'

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -1,0 +1,30 @@
+name: Check clang-tidy
+
+on:
+  push:
+    branches-ignore:
+      - master
+      - staging.tmp
+      - trying.tmp
+      - staging-squash-merge.tmp
+  pull_request:
+
+jobs:
+  check-clang-tidy:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+
+    - name: Install clang-tidy
+      run: |
+        sudo apt-get update -y
+        sudo apt-get install pkg-config cmake libfreetype6-dev libnotify-dev libsdl2-dev libsqlite3-dev clang-tidy -y
+    - name: Build with clang-tidy
+      run: |
+        mkdir clang-tidy
+        cd clang-tidy
+        cmake -G "Unix Makefiles" -DCMAKE_CXX_CLANG_TIDY="clang-tidy;-warnings-as-errors=*" -DCMAKE_C_CLANG_TIDY="clang-tidy;-warnings-as-errors=*" -DCMAKE_BUILD_TYPE=Debug -Werror=dev -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE=. ..
+        cmake --build . --config Debug --parallel --target everything -- --keep-going
+

--- a/src/base/system.c
+++ b/src/base/system.c
@@ -803,6 +803,7 @@ LOCK lock_create(void)
 	if(result != 0)
 	{
 		dbg_msg("lock", "init failed: %d", result);
+		free(lock);
 		return 0;
 	}
 #elif defined(CONF_FAMILY_WINDOWS)

--- a/src/base/system.c
+++ b/src/base/system.c
@@ -2691,13 +2691,8 @@ int str_utf8_dist_buffer(const char *a_utf8, const char *b_utf8, int *buf, int b
 	dbg_assert(buf_len >= 2 * (a_utf8_len + 1 + b_utf8_len + 1), "buffer too small");
 	if(a_utf8_len > b_utf8_len)
 	{
-		int tmp1 = a_utf8_len;
 		const char *tmp2 = a_utf8;
-
-		a_utf8_len = b_utf8_len;
 		a_utf8 = b_utf8;
-
-		b_utf8_len = tmp1;
 		b_utf8 = tmp2;
 	}
 	a = buf;

--- a/src/base/system.c
+++ b/src/base/system.c
@@ -1030,7 +1030,9 @@ static void netaddr_to_sockaddr_in6(const NETADDR *src, struct sockaddr_in6 *des
 
 static void sockaddr_to_netaddr(const struct sockaddr *src, NETADDR *dst)
 {
-	if(src->sa_family == AF_INET)
+	// Filled by accept, clang-analyzer probably can't tell because of the
+	// (struct sockaddr *) cast.
+	if(src->sa_family == AF_INET) // NOLINT(clang-analyzer-core.UndefinedBinaryOperatorResult)
 	{
 		mem_zero(dst, sizeof(NETADDR));
 		dst->type = NETTYPE_IPV4;

--- a/src/base/tl/array.h
+++ b/src/base/tl/array.h
@@ -3,6 +3,7 @@
 #ifndef BASE_TL_ARRAY_H
 #define BASE_TL_ARRAY_H
 
+#include "base/math.h"
 #include "base/tl/allocator.h"
 #include "base/tl/range.h"
 
@@ -318,7 +319,7 @@ protected:
 
 	void alloc(int new_len)
 	{
-		list_size = new_len;
+		list_size = maximum(1, new_len);
 		T *new_list = ALLOCATOR::alloc_array(list_size);
 
 		int end = num_elements < list_size ? num_elements : list_size;

--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -3770,7 +3770,6 @@ void CCommandProcessorFragment_SDL::Cmd_Init(const SCommand_Init *pCommand)
 
 	int MajorV = pCommand->m_pCapabilities->m_ContextMajor;
 	int MinorV = pCommand->m_pCapabilities->m_ContextMinor;
-	int PatchV = pCommand->m_pCapabilities->m_ContextPatch;
 
 	*pCommand->m_pInitError = 0;
 
@@ -3786,6 +3785,7 @@ void CCommandProcessorFragment_SDL::Cmd_Init(const SCommand_Init *pCommand)
 		}
 		else if(MinorV == pCommand->m_RequestedMinor)
 		{
+			int PatchV = pCommand->m_pCapabilities->m_ContextPatch;
 			if(PatchV < pCommand->m_RequestedPatch)
 			{
 				*pCommand->m_pInitError = -2;
@@ -3797,7 +3797,6 @@ void CCommandProcessorFragment_SDL::Cmd_Init(const SCommand_Init *pCommand)
 	{
 		MajorV = pCommand->m_RequestedMajor;
 		MinorV = pCommand->m_RequestedMinor;
-		PatchV = pCommand->m_RequestedPatch;
 
 		pCommand->m_pCapabilities->m_2DArrayTexturesAsExtension = false;
 		pCommand->m_pCapabilities->m_NPOTTextures = true;

--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -326,7 +326,9 @@ void *CCommandProcessorFragment_OpenGL::Resize(int Width, int Height, int NewWid
 
 	int Bpp = TexFormatToImageColorChannelCount(Format);
 
-	pTmpData = (unsigned char *)malloc((size_t)NewWidth * NewHeight * Bpp);
+	// All calls to Resize() ensure width & height are > 0, Bpp is always > 0,
+	// thus no allocation size 0 possible.
+	pTmpData = (unsigned char *)malloc((size_t)NewWidth * NewHeight * Bpp); // NOLINT(clang-analyzer-optin.portability.UnixAPI)
 
 	ResizeImage((uint8_t *)pData, Width, Height, (uint8_t *)pTmpData, NewWidth, NewHeight, Bpp);
 

--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -551,6 +551,11 @@ int CGraphics_Threaded::LoadPNG(CImageInfo *pImg, const char *pFilename, int Sto
 		pImg->m_Format = CImageInfo::FORMAT_RGB;
 	else if(Png.color_type == PNG_TRUECOLOR_ALPHA) // ignore_convention
 		pImg->m_Format = CImageInfo::FORMAT_RGBA;
+	else
+	{
+		free(pBuffer);
+		return 0;
+	}
 	pImg->m_pData = pBuffer;
 	return 1;
 }

--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -227,7 +227,6 @@ int CInput::Update()
 		bool IgnoreKeys = false;
 		while(SDL_PollEvent(&Event))
 		{
-			int Key = -1;
 			int Scancode = 0;
 			int Action = IInput::FLAG_PRESS;
 			switch(Event.type)
@@ -265,13 +264,11 @@ int CInput::Update()
 				// Sum if you want to ignore multiple modifiers.
 				if(!(Event.key.keysym.mod & g_Config.m_InpIgnoredModifiers))
 				{
-					Key = Event.key.keysym.sym;
 					Scancode = Event.key.keysym.scancode;
 				}
 				break;
 			case SDL_KEYUP:
 				Action = IInput::FLAG_RELEASE;
-				Key = Event.key.keysym.sym;
 				Scancode = Event.key.keysym.scancode;
 				break;
 
@@ -288,37 +285,35 @@ int CInput::Update()
 				// fall through
 			case SDL_MOUSEBUTTONDOWN:
 				if(Event.button.button == SDL_BUTTON_LEFT)
-					Key = KEY_MOUSE_1; // ignore_convention
+					Scancode = KEY_MOUSE_1; // ignore_convention
 				if(Event.button.button == SDL_BUTTON_RIGHT)
-					Key = KEY_MOUSE_2; // ignore_convention
+					Scancode = KEY_MOUSE_2; // ignore_convention
 				if(Event.button.button == SDL_BUTTON_MIDDLE)
-					Key = KEY_MOUSE_3; // ignore_convention
+					Scancode = KEY_MOUSE_3; // ignore_convention
 				if(Event.button.button == SDL_BUTTON_X1)
-					Key = KEY_MOUSE_4; // ignore_convention
+					Scancode = KEY_MOUSE_4; // ignore_convention
 				if(Event.button.button == SDL_BUTTON_X2)
-					Key = KEY_MOUSE_5; // ignore_convention
+					Scancode = KEY_MOUSE_5; // ignore_convention
 				if(Event.button.button == 6)
-					Key = KEY_MOUSE_6; // ignore_convention
+					Scancode = KEY_MOUSE_6; // ignore_convention
 				if(Event.button.button == 7)
-					Key = KEY_MOUSE_7; // ignore_convention
+					Scancode = KEY_MOUSE_7; // ignore_convention
 				if(Event.button.button == 8)
-					Key = KEY_MOUSE_8; // ignore_convention
+					Scancode = KEY_MOUSE_8; // ignore_convention
 				if(Event.button.button == 9)
-					Key = KEY_MOUSE_9; // ignore_convention
-				Scancode = Key;
+					Scancode = KEY_MOUSE_9; // ignore_convention
 				break;
 
 			case SDL_MOUSEWHEEL:
 				if(Event.wheel.y > 0)
-					Key = KEY_MOUSE_WHEEL_UP; // ignore_convention
+					Scancode = KEY_MOUSE_WHEEL_UP; // ignore_convention
 				if(Event.wheel.y < 0)
-					Key = KEY_MOUSE_WHEEL_DOWN; // ignore_convention
+					Scancode = KEY_MOUSE_WHEEL_DOWN; // ignore_convention
 				if(Event.wheel.x > 0)
-					Key = KEY_MOUSE_WHEEL_LEFT; // ignore_convention
+					Scancode = KEY_MOUSE_WHEEL_LEFT; // ignore_convention
 				if(Event.wheel.x < 0)
-					Key = KEY_MOUSE_WHEEL_RIGHT; // ignore_convention
+					Scancode = KEY_MOUSE_WHEEL_RIGHT; // ignore_convention
 				Action |= IInput::FLAG_RELEASE;
-				Scancode = Key;
 				break;
 
 			case SDL_WINDOWEVENT:

--- a/src/engine/client/text.cpp
+++ b/src/engine/client/text.cpp
@@ -1510,8 +1510,6 @@ public:
 			DrawY = TextContainer.m_AlignedStartY;
 		}
 
-		DrawX = TextContainer.m_X;
-		DrawY = TextContainer.m_Y;
 		LineCount = TextContainer.m_LineCount;
 
 		if(TextContainer.m_StringInfo.m_SelectionQuadContainerIndex == -1)

--- a/src/engine/client/video.cpp
+++ b/src/engine/client/video.cpp
@@ -545,7 +545,7 @@ bool CVideo::OpenAudio()
 	av_opt_set_sample_fmt(m_AudioStream.pSwrCtx, "out_sample_fmt", c->sample_fmt, 0);
 
 	/* initialize the resampling context */
-	if((Ret = swr_init(m_AudioStream.pSwrCtx)) < 0)
+	if(swr_init(m_AudioStream.pSwrCtx) < 0)
 	{
 		dbg_msg("video_recorder", "Failed to initialize the resampling context");
 		return false;

--- a/src/engine/external/.clang-tidy
+++ b/src/engine/external/.clang-tidy
@@ -1,3 +1,3 @@
 # Need at least one check, otherwise clang-tidy fails, use one that can't
 # happen in our code since we don't use OpenMP API.
-Checks: openmp-exception-escape
+Checks: '-*,openmp-exception-escape'

--- a/src/engine/external/.clang-tidy
+++ b/src/engine/external/.clang-tidy
@@ -1,0 +1,3 @@
+# Need at least one check, otherwise clang-tidy fails, use one that can't
+# happen in our code since we don't use OpenMP API.
+Checks: openmp-exception-escape

--- a/src/engine/server/sql_string_helpers.cpp
+++ b/src/engine/server/sql_string_helpers.cpp
@@ -40,7 +40,7 @@ int sqlstr::EscapeLike(char *pDst, const char *pSrc, int DstSize)
 	return DstPos;
 }
 
-void sqlstr::AgoTimeToString(int AgoTime, char *pAgoString)
+void sqlstr::AgoTimeToString(int AgoTime, char *pAgoString, int Size)
 {
 	char aBuf[20];
 	int aTimes[7] =
@@ -71,7 +71,7 @@ void sqlstr::AgoTimeToString(int AgoTime, char *pAgoString)
 	for(i = 0; i < 7; i++)
 	{
 		Seconds = aTimes[i];
-		strcpy(aName, aaNames[i]);
+		str_copy(aName, aaNames[i], sizeof(aName));
 
 		Count = floor((float)AgoTime / (float)Seconds);
 		if(Count != 0)
@@ -88,14 +88,14 @@ void sqlstr::AgoTimeToString(int AgoTime, char *pAgoString)
 	{
 		str_format(aBuf, sizeof(aBuf), "%d %ss", Count, aName);
 	}
-	strcat(pAgoString, aBuf);
+	str_append(pAgoString, aBuf, Size);
 
 	if(i + 1 < 7)
 	{
 		// getting second piece now
 		int Seconds2 = aTimes[i + 1];
 		char aName2[6];
-		strcpy(aName2, aaNames[i + 1]);
+		str_copy(aName2, aaNames[i + 1], sizeof(aName2));
 
 		// add second piece if it's greater than 0
 		int Count2 = floor((float)(AgoTime - (Seconds * Count)) / (float)Seconds2);
@@ -110,7 +110,7 @@ void sqlstr::AgoTimeToString(int AgoTime, char *pAgoString)
 			{
 				str_format(aBuf, sizeof(aBuf), " and %d %ss", Count2, aName2);
 			}
-			strcat(pAgoString, aBuf);
+			str_append(pAgoString, aBuf, Size);
 		}
 	}
 }

--- a/src/engine/server/sql_string_helpers.h
+++ b/src/engine/server/sql_string_helpers.h
@@ -8,7 +8,7 @@ void FuzzyString(char *pString, int size);
 // written number of added bytes
 int EscapeLike(char *pDst, const char *pSrc, int DstSize);
 
-void AgoTimeToString(int agoTime, char *pAgoString);
+void AgoTimeToString(int agoTime, char *pAgoString, int Size);
 
 } // namespace sqlstr
 

--- a/src/engine/shared/demo.cpp
+++ b/src/engine/shared/demo.cpp
@@ -531,9 +531,12 @@ void CDemoPlayer::ScanFile()
 	}
 
 	// copy all the frames to an array instead for fast access
-	m_pKeyFrames = (CKeyFrame *)calloc(m_Info.m_SeekablePoints, sizeof(CKeyFrame));
-	for(pCurrentKey = pFirstKey, i = 0; pCurrentKey; pCurrentKey = pCurrentKey->m_pNext, i++)
-		m_pKeyFrames[i] = pCurrentKey->m_Frame;
+	if(m_Info.m_SeekablePoints > 0)
+	{
+		m_pKeyFrames = (CKeyFrame *)calloc(m_Info.m_SeekablePoints, sizeof(CKeyFrame));
+		for(pCurrentKey = pFirstKey, i = 0; pCurrentKey; pCurrentKey = pCurrentKey->m_pNext, i++)
+			m_pKeyFrames[i] = pCurrentKey->m_Frame;
+	}
 
 	// destroy the temporary heap and seek back to the start
 	io_seek(m_File, StartPos, IOSEEK_START);
@@ -1040,8 +1043,11 @@ int CDemoPlayer::Stop()
 		m_pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "demo_player", "Stopped playback");
 	io_close(m_File);
 	m_File = 0;
-	free(m_pKeyFrames);
-	m_pKeyFrames = 0;
+	if(m_pKeyFrames)
+	{
+		free(m_pKeyFrames);
+		m_pKeyFrames = 0;
+	}
 	str_copy(m_aFilename, "", sizeof(m_aFilename));
 	return 0;
 }

--- a/src/engine/shared/dilate.cpp
+++ b/src/engine/shared/dilate.cpp
@@ -29,7 +29,10 @@ static void Dilate(int w, int h, int BPP, unsigned char *pSrc, unsigned char *pD
 				if(pSrc[k + AlphaCompIndex] > AlphaThreshold)
 				{
 					for(int p = 0; p < BPP - 1; ++p)
-						SumOfOpaque[p] += pSrc[k + p];
+						// Seems safe for BPP = 3, 4 which we use. clang-analyzer seems to
+						// asssume being called with larger value. TODO: Can make this
+						// safer anyway.
+						SumOfOpaque[p] += pSrc[k + p]; // NOLINT(clang-analyzer-core.uninitialized.Assign)
 					++Counter;
 					break;
 				}

--- a/src/game/client/animstate.cpp
+++ b/src/game/client/animstate.cpp
@@ -51,7 +51,9 @@ static void AnimSeqEval(CAnimSequence *pSeq, float Time, CAnimKeyframe *pFrame)
 
 static void AnimAddKeyframe(CAnimKeyframe *pSeq, CAnimKeyframe *pAdded, float Amount)
 {
-	pSeq->m_X += pAdded->m_X * Amount;
+	// AnimSeqEval fills m_X for any case, clang-analyzer assumes going into the
+	// final else branch with pSeq->m_NumFrames < 2, which is impossible.
+	pSeq->m_X += pAdded->m_X * Amount; // NOLINT(clang-analyzer-core.UndefinedBinaryOperatorResult)
 	pSeq->m_Y += pAdded->m_Y * Amount;
 	pSeq->m_Angle += pAdded->m_Angle * Amount;
 }

--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -178,7 +178,6 @@ bool CChat::OnInput(IInput::CEvent Event)
 			}
 			int max = minimum(i - Begin + 1, (int)sizeof(Line));
 			str_utf8_copy(Line, Text + Begin, max);
-			Begin = i + 1;
 			m_Input.Add(Line);
 		}
 	}

--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -180,7 +180,6 @@ void CGameConsole::CInstance::OnInput(IInput::CEvent Event)
 			}
 			int max = minimum(i - Begin + 1, (int)sizeof(Line));
 			str_copy(Line, Text + Begin, max);
-			Begin = i + 1;
 			m_Input.Add(Line);
 		}
 	}

--- a/src/game/client/components/countryflags.cpp
+++ b/src/game/client/components/countryflags.cpp
@@ -58,7 +58,8 @@ void CCountryFlags::LoadCountryflagsIndexfile()
 		// load the graphic file
 		char aBuf[128];
 		CImageInfo Info;
-		if(g_Config.m_ClLoadCountryFlags)
+		bool LoadCountryFlags = g_Config.m_ClLoadCountryFlags;
+		if(LoadCountryFlags)
 		{
 			str_format(aBuf, sizeof(aBuf), "countryflags/%s.png", aOrigin);
 			if(!Graphics()->LoadPNG(&Info, aBuf, IStorage::TYPE_ALL))
@@ -74,7 +75,7 @@ void CCountryFlags::LoadCountryflagsIndexfile()
 		CCountryFlag CountryFlag;
 		CountryFlag.m_CountryCode = CountryCode;
 		str_copy(CountryFlag.m_aCountryCodeString, aOrigin, sizeof(CountryFlag.m_aCountryCodeString));
-		if(g_Config.m_ClLoadCountryFlags)
+		if(LoadCountryFlags)
 		{
 			CountryFlag.m_Texture = Graphics()->LoadTextureRaw(Info.m_Width, Info.m_Height, Info.m_Format, Info.m_pData, Info.m_Format, 0);
 			free(Info.m_pData);

--- a/src/game/client/components/mapimages.cpp
+++ b/src/game/client/components/mapimages.cpp
@@ -217,7 +217,7 @@ IGraphics::CTextureHandle CMapImages::GetEntities(EMapImageEntityLayerType Entit
 
 		if(ImagePNGLoaded && ImgInfo.m_Width > 0 && ImgInfo.m_Height > 0)
 		{
-			int ColorChannelCount = 0;
+			int ColorChannelCount = 4;
 			if(ImgInfo.m_Format == CImageInfo::FORMAT_ALPHA)
 				ColorChannelCount = 1;
 			else if(ImgInfo.m_Format == CImageInfo::FORMAT_RGB)

--- a/src/game/client/components/statboard.cpp
+++ b/src/game/client/components/statboard.cpp
@@ -244,10 +244,6 @@ void CStatboard::RenderGlobalStats()
 		RenderTools()->DrawSprite(x + px, y + 15, 48 * ScaleX, 48 * ScaleY);
 		Graphics()->QuadsEnd();
 	}
-	else
-	{
-		px += 40;
-	}
 
 	y += 29.0f;
 
@@ -285,7 +281,6 @@ void CStatboard::RenderGlobalStats()
 
 		char aBuf[128];
 		CTextCursor Cursor;
-		tw = TextRender()->TextWidth(0, FontSize, m_pClient->m_aClients[pInfo->m_ClientID].m_aName, -1, -1.0f);
 		TextRender()->SetCursor(&Cursor, x + 64, y + (LineHeight * 0.95f - FontSize) / 2.f, FontSize, TEXTFLAG_RENDER | TEXTFLAG_STOP_AT_END);
 		Cursor.m_LineWidth = 220;
 		TextRender()->TextEx(&Cursor, m_pClient->m_aClients[pInfo->m_ClientID].m_aName, -1);
@@ -297,7 +292,6 @@ void CStatboard::RenderGlobalStats()
 			str_format(aBuf, sizeof(aBuf), "%d", pStats->m_Frags);
 			tw = TextRender()->TextWidth(0, FontSize, aBuf, -1, -1.0f);
 			TextRender()->Text(0, x - tw + px, y + (LineHeight * 0.95f - FontSize) / 2.f, FontSize, aBuf, -1.0f);
-			px += 85;
 		}
 		// DEATHS
 		{
@@ -379,7 +373,6 @@ void CStatboard::RenderGlobalStats()
 			str_format(aBuf, sizeof(aBuf), "%d", pStats->m_FlagCaptures);
 			tw = TextRender()->TextWidth(0, FontSize, aBuf, -1, -1.0f);
 			TextRender()->Text(0, x - tw + px, y + (LineHeight * 0.95f - FontSize) / 2.f, FontSize, aBuf, -1.0f);
-			px += 85;
 		}
 		y += LineHeight;
 	}

--- a/src/game/client/prediction/entities/laser.cpp
+++ b/src/game/client/prediction/entities/laser.cpp
@@ -48,10 +48,10 @@ bool CLaser::HitCharacter(vec2 From, vec2 To)
 
 		float Strength = GetTuning(m_TuneZone)->m_ShotgunStrength;
 
-		if(!g_Config.m_SvOldLaser)
-			Temp = pHit->Core()->m_Vel + normalize(m_PrevPos - pHit->Core()->m_Pos) * Strength;
-		else
+		if(g_Config.m_SvOldLaser && pOwnerChar)
 			Temp = pHit->Core()->m_Vel + normalize(pOwnerChar->Core()->m_Pos - pHit->Core()->m_Pos) * Strength;
+		else
+			Temp = pHit->Core()->m_Vel + normalize(m_PrevPos - pHit->Core()->m_Pos) * Strength;
 		pHit->Core()->m_Vel = ClampVel(pHit->m_MoveRestrictions, Temp);
 	}
 	else if(m_Type == WEAPON_LASER)

--- a/src/game/collision.cpp
+++ b/src/game/collision.cpp
@@ -1027,9 +1027,9 @@ int CCollision::GetIndex(vec2 PrevPos, vec2 Pos)
 	int Nx = 0;
 	int Ny = 0;
 
-	for(float f = 0; f < Distance; f++)
+	for(int i = 0, id = (int)Distance; i <= id; i++)
 	{
-		a = f / Distance;
+		a = (float)i / Distance;
 		Tmp = mix(PrevPos, Pos, a);
 		Nx = clamp((int)Tmp.x / 32, 0, m_Width - 1);
 		Ny = clamp((int)Tmp.y / 32, 0, m_Height - 1);
@@ -1193,9 +1193,9 @@ int CCollision::IntersectNoLaser(vec2 Pos0, vec2 Pos1, vec2 *pOutCollision, vec2
 	float d = distance(Pos0, Pos1);
 	vec2 Last = Pos0;
 
-	for(float f = 0; f < d; f++)
+	for(int i = 0, id = (int)d; i <= id; i++)
 	{
-		float a = f / d;
+		float a = (int)i / d;
 		vec2 Pos = mix(Pos0, Pos1, a);
 		int Nx = clamp(round_to_int(Pos.x) / 32, 0, m_Width - 1);
 		int Ny = clamp(round_to_int(Pos.y) / 32, 0, m_Height - 1);
@@ -1224,9 +1224,9 @@ int CCollision::IntersectNoLaserNW(vec2 Pos0, vec2 Pos1, vec2 *pOutCollision, ve
 	float d = distance(Pos0, Pos1);
 	vec2 Last = Pos0;
 
-	for(float f = 0; f < d; f++)
+	for(int i = 0, id = (int)d; i <= id; i++)
 	{
-		float a = f / d;
+		float a = (float)i / d;
 		vec2 Pos = mix(Pos0, Pos1, a);
 		if(IsNoLaser(round_to_int(Pos.x), round_to_int(Pos.y)) || IsFNoLaser(round_to_int(Pos.x), round_to_int(Pos.y)))
 		{
@@ -1253,9 +1253,9 @@ int CCollision::IntersectAir(vec2 Pos0, vec2 Pos1, vec2 *pOutCollision, vec2 *pO
 	float d = distance(Pos0, Pos1);
 	vec2 Last = Pos0;
 
-	for(float f = 0; f < d; f++)
+	for(int i = 0, id = (int)d; i <= id; i++)
 	{
-		float a = f / d;
+		float a = (float)i / d;
 		vec2 Pos = mix(Pos0, Pos1, a);
 		if(IsSolid(round_to_int(Pos.x), round_to_int(Pos.y)) || (!GetTile(round_to_int(Pos.x), round_to_int(Pos.y)) && !GetFTile(round_to_int(Pos.x), round_to_int(Pos.y))))
 		{

--- a/src/game/editor/auto_map.cpp
+++ b/src/game/editor/auto_map.cpp
@@ -86,7 +86,7 @@ void CAutoMapper::Load(const char *pTileName)
 				int RunID = pCurrentConf->m_aRuns.add(NewRun);
 				pCurrentRun = &pCurrentConf->m_aRuns[RunID];
 			}
-			else if(str_startswith(pLine, "NewRun"))
+			else if(str_startswith(pLine, "NewRun") && pCurrentConf)
 			{
 				// add new run
 				CRun NewRun;

--- a/src/game/editor/auto_map.cpp
+++ b/src/game/editor/auto_map.cpp
@@ -430,6 +430,9 @@ void CAutoMapper::ProceedLocalized(CLayerTiles *pLayer, int ConfigID, int Seed, 
 			out->m_Flags = in->m_Flags;
 		}
 	}
+
+	if(pUpdateLayer)
+		delete pUpdateLayer;
 }
 
 void CAutoMapper::Proceed(CLayerTiles *pLayer, int ConfigID, int Seed, int SeedOffsetX, int SeedOffsetY)

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -5633,8 +5633,6 @@ void CEditor::RenderServerSettingsEditor(CUIRect View, bool ShowServerSettingsEd
 				if(Input()->KeyPress(KEY_MOUSE_WHEEL_DOWN))
 					s_ScrollValue = clamp(s_ScrollValue + 1.0f / ScrollNum, 0.0f, 1.0f);
 			}
-			else
-				ScrollNum = 0;
 		}
 	}
 

--- a/src/game/editor/io.cpp
+++ b/src/game/editor/io.cpp
@@ -270,7 +270,8 @@ int CEditorMap::Save(class IStorage *pStorage, const char *pFileName)
 				Size += str_length(m_lSettings[i].m_aCommand) + 1;
 			}
 
-			char *pSettings = (char *)malloc(Size);
+			// Checked that m_lSettings.size() is not 0, thus Size is > 0 as ell
+			char *pSettings = (char *)malloc(Size); // NOLINT(clang-analyzer-optin.portability.UnixAPI)
 			char *pNext = pSettings;
 			for(int i = 0; i < m_lSettings.size(); i++)
 			{
@@ -542,20 +543,23 @@ int CEditorMap::Save(class IStorage *pStorage, const char *pFileName)
 		PointCount += Item.m_NumPoints;
 	}
 
-	// save points
-	int TotalSize = sizeof(CEnvPoint) * PointCount;
-	CEnvPoint *pPoints = (CEnvPoint *)calloc(PointCount, sizeof(*pPoints));
-	PointCount = 0;
-
-	for(int e = 0; e < m_lEnvelopes.size(); e++)
+	if(PointCount > 0)
 	{
-		int Count = m_lEnvelopes[e]->m_lPoints.size();
-		mem_copy(&pPoints[PointCount], m_lEnvelopes[e]->m_lPoints.base_ptr(), sizeof(CEnvPoint) * Count);
-		PointCount += Count;
-	}
+		// save points
+		int TotalSize = sizeof(CEnvPoint) * PointCount;
+		CEnvPoint *pPoints = (CEnvPoint *)calloc(PointCount, sizeof(*pPoints));
+		PointCount = 0;
 
-	df.AddItem(MAPITEMTYPE_ENVPOINTS, 0, TotalSize, pPoints);
-	free(pPoints);
+		for(int e = 0; e < m_lEnvelopes.size(); e++)
+		{
+			int Count = m_lEnvelopes[e]->m_lPoints.size();
+			mem_copy(&pPoints[PointCount], m_lEnvelopes[e]->m_lPoints.base_ptr(), sizeof(CEnvPoint) * Count);
+			PointCount += Count;
+		}
+
+		df.AddItem(MAPITEMTYPE_ENVPOINTS, 0, TotalSize, pPoints);
+		free(pPoints);
+	}
 
 	// finish the data file
 	df.Finish();

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -1474,8 +1474,6 @@ int CEditor::PopupSelectConfigAutoMap(CEditor *pEditor, CUIRect View, void *pCon
 				if(pEditor->Input()->KeyPress(KEY_MOUSE_WHEEL_DOWN))
 					s_ScrollValue = clamp(s_ScrollValue + 1.0f / ScrollNum, 0.0f, 1.0f);
 			}
-			else
-				ScrollNum = 0;
 		}
 
 		// Margin for scrollbar

--- a/src/game/mapbugs.cpp
+++ b/src/game/mapbugs.cpp
@@ -27,7 +27,8 @@ static unsigned int BugToFlag(int Bug)
 {
 	unsigned int Result;
 	dbg_assert((unsigned)Bug < 8 * sizeof(Result), "invalid shift");
-	return Result = (1 << Bug);
+	Result = (1 << Bug);
+	return Result;
 }
 
 static unsigned int IsBugFlagSet(int Bug, unsigned int BugFlags)

--- a/src/game/server/entities/projectile.cpp
+++ b/src/game/server/entities/projectile.cpp
@@ -198,7 +198,7 @@ void CProjectile::Tick()
 				vec2 PossiblePos;
 
 				if(!Collide)
-					Found = GetNearestAirPosPlayer(pTargetChr->m_Pos, &PossiblePos);
+					Found = GetNearestAirPosPlayer(pTargetChr ? pTargetChr->m_Pos : ColPos, &PossiblePos);
 				else
 					Found = GetNearestAirPos(NewPos, CurPos, &PossiblePos);
 

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -3335,7 +3335,7 @@ void CGameContext::OnMapChange(char *pNewMapName, int MapNameSize)
 	}
 	io_close(File);
 
-	char *pSettings = (char *)malloc(TotalLength);
+	char *pSettings = (char *)malloc(maximum(1, TotalLength));
 	int Offset = 0;
 	for(int i = 0; i < aLines.size(); i++)
 	{
@@ -3374,6 +3374,7 @@ void CGameContext::OnMapChange(char *pNewMapName, int MapNameSize)
 					if(DataSize == TotalLength && mem_comp(pSettings, pMapSettings, DataSize) == 0)
 					{
 						// Configs coincide, no need to update map.
+						free(pSettings);
 						return;
 					}
 					Reader.UnloadData(pInfo->m_Settings);
@@ -3423,6 +3424,7 @@ void CGameContext::OnMapChange(char *pNewMapName, int MapNameSize)
 	}
 
 	dbg_msg("mapchange", "imported settings");
+	free(pSettings);
 	Reader.Close();
 	Writer.OpenFile(Storage(), aTemp);
 	Writer.Finish();

--- a/src/game/server/score.cpp
+++ b/src/game/server/score.cpp
@@ -399,7 +399,7 @@ bool CScore::MapInfoThread(IDbConnection *pSqlServer, const ISqlData *pGameData)
 		char aReleasedString[60] = "\0";
 		if(Stamp != 0)
 		{
-			sqlstr::AgoTimeToString(Ago, aAgoString);
+			sqlstr::AgoTimeToString(Ago, aAgoString, sizeof(aAgoString));
 			str_format(aReleasedString, sizeof(aReleasedString), ", released %s ago", aAgoString);
 		}
 
@@ -986,7 +986,7 @@ bool CScore::ShowTimesThread(IDbConnection *pSqlServer, const ISqlData *pGameDat
 		int Stamp = pSqlServer->GetInt(3);
 
 		char aAgoString[40] = "\0";
-		sqlstr::AgoTimeToString(Ago, aAgoString);
+		sqlstr::AgoTimeToString(Ago, aAgoString, sizeof(aAgoString));
 
 		if(pData->m_Name[0] != '\0') // last 5 times of a player
 		{
@@ -1550,7 +1550,7 @@ bool CScore::GetSavesThread(IDbConnection *pSqlServer, const ISqlData *pGameData
 		char aLastSavedString[60] = "\0";
 		if(Ago)
 		{
-			sqlstr::AgoTimeToString(Ago, aAgoString);
+			sqlstr::AgoTimeToString(Ago, aAgoString, sizeof(aAgoString));
 			str_format(aLastSavedString, sizeof(aLastSavedString), ", last saved %s ago", aAgoString);
 		}
 

--- a/src/tools/config_store.cpp
+++ b/src/tools/config_store.cpp
@@ -31,7 +31,7 @@ void Process(IStorage *pStorage, const char *pMapName, const char *pConfigName)
 	}
 	io_close(File);
 
-	pSettings = (char *)malloc(TotalLength);
+	pSettings = (char *)malloc(maximum(1, TotalLength));
 	int Offset = 0;
 	for(int i = 0; i < aLines.size(); i++)
 	{
@@ -73,6 +73,7 @@ void Process(IStorage *pStorage, const char *pMapName, const char *pConfigName)
 					if(DataSize == TotalLength && mem_comp(pSettings, pMapSettings, DataSize) == 0)
 					{
 						dbg_msg("config_store", "configs coincide, not updating map");
+						free(pSettings);
 						return;
 					}
 					Reader.UnloadData(pInfo->m_Settings);
@@ -121,6 +122,7 @@ void Process(IStorage *pStorage, const char *pMapName, const char *pConfigName)
 		Reader.UnloadData(i);
 	}
 
+	free(pSettings);
 	Reader.Close();
 	if(!Writer.OpenFile(pStorage, pMapName))
 	{

--- a/src/tools/map_convert_07.cpp
+++ b/src/tools/map_convert_07.cpp
@@ -222,7 +222,6 @@ int main(int argc, const char **argv)
 	int i = 0;
 	for(int Index = 0; Index < g_DataReader.NumItems(); Index++)
 	{
-		pItem = g_DataReader.GetItem(Index, &Type, &ID);
 		if(Type == MAPITEMTYPE_IMAGE)
 			g_aImageIDs[i++] = Index;
 	}

--- a/src/tools/map_replace_image.cpp
+++ b/src/tools/map_replace_image.cpp
@@ -63,6 +63,11 @@ int LoadPNG(CImageInfo *pImg, const char *pFilename)
 		pImg->m_Format = CImageInfo::FORMAT_RGB;
 	else if(Png.color_type == PNG_TRUECOLOR_ALPHA)
 		pImg->m_Format = CImageInfo::FORMAT_RGBA;
+	else
+	{
+		free(pBuffer);
+		return 0;
+	}
 	pImg->m_pData = pBuffer;
 	return 1;
 }


### PR DESCRIPTION
> 470 warnings treated as errors

The actual work will be fixing those or at least NOLINT(clang-analyzer-optin.cplusplus.VirtualCall) them so we can enable this.

```
$ cmake -GNinja -DWEBSOCKETS=OFF -DMYSQL=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo -DVIDEORECORDER=ON -DAUTOUPDATE=OFF -DANTIBOT=OFF -DUPNP=OFF -DPREFER_BUNDLED_LIBS=OFF -DINFORM_UPDATE=OFF -DCMAKE_CXX_CLANG_TIDY=clang-tidy -DCMAKE_C_CLANG_TIDY=clang-tidy .
$ ninja > out
$ grep clang-analyzer out | sed -e "s/.* \[/\[/" | sort | uniq -c | sort -n -r
    477 [clang-analyzer-optin.cplusplus.VirtualCall]
     37 [clang-analyzer-optin.cplusplus.UninitializedObject]
     25 [clang-analyzer-optin.performance.Padding]
     20 [clang-analyzer-deadcode.DeadStores]
      9 [clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling]
      7 [clang-analyzer-optin.portability.UnixAPI]
      6 [clang-analyzer-security.insecureAPI.strcpy]
      4 [clang-analyzer-core.CallAndMessage]
      4 [clang-analyzer-security.FloatLoopCounter]
      3 [clang-analyzer-core.UndefinedBinaryOperatorResult]
      2 [clang-analyzer-core.uninitialized.Assign]
      1 [clang-analyzer-unix.Malloc]
      1 [clang-analyzer-cplusplus.NewDeleteLeaks]
      1 [clang-analyzer-cplusplus.NewDelete]
      1 [clang-analyzer-core.NonNullParamChecker]
```