### PR TITLE
Don't waste bytes when we are already aligned

### DIFF
--- a/src/engine/client/graphics_threaded.h
+++ b/src/engine/client/graphics_threaded.h
@@ -41,7 +41,10 @@ class CCommandBuffer
 
 		void *Alloc(unsigned Requested, unsigned Alignment = alignof(std::max_align_t))
 		{
-			size_t Offset = Alignment - (reinterpret_cast<uintptr_t>(m_pData + m_Used) % Alignment);
+			size_t Offset = reinterpret_cast<uintptr_t>(m_pData + m_Used) % Alignment;
+			if(Offset)
+				Offset = Alignment - Offset;
+
 			if(Requested + Offset + m_Used > m_Size)
 				return 0;
 


### PR DESCRIPTION
This fixes #3084, seems to be enough to make all the data fit in the buffer again.