### PR TITLE
Fix 2 leaks in CServerBrowser

### DIFF
--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -70,6 +70,12 @@ CServerBrowser::CServerBrowser()
 
 CServerBrowser::~CServerBrowser()
 {
+	if(m_ppServerlist)
+		free(m_ppServerlist);
+
+	if(m_pSortedServerlist)
+		free(m_pSortedServerlist);
+
 	if(m_pDDNetInfo)
 		json_value_free(m_pDDNetInfo);
 }


### PR DESCRIPTION
The only leaks reported by ASan that are allocated by us. There is one other by SDL and one by X11.