### PR TITLE
Use pointer directly for tile layer building

### DIFF
--- a/src/engine/client/graphics_threaded.h
+++ b/src/engine/client/graphics_threaded.h
@@ -250,6 +250,7 @@ public:
 
 		int m_BufferIndex;
 
+		bool m_DeletePointer;
 		void *m_pUploadData;
 		size_t m_DataSize;
 	};
@@ -261,6 +262,7 @@ public:
 
 		int m_BufferIndex;
 
+		bool m_DeletePointer;
 		void *m_pUploadData;
 		size_t m_DataSize;
 	};
@@ -272,6 +274,7 @@ public:
 
 		int m_BufferIndex;
 
+		bool m_DeletePointer;
 		void *m_pOffset;
 		void *m_pUploadData;
 		size_t m_DataSize;
@@ -1076,9 +1079,9 @@ public:
 	void RenderText(int BufferContainerIndex, int TextQuadNum, int TextureSize, int TextureTextIndex, int TextureTextOutlineIndex, float *pTextColor, float *pTextoutlineColor) override;
 
 	// opengl 3.3 functions
-	int CreateBufferObject(size_t UploadDataSize, void *pUploadData) override;
-	void RecreateBufferObject(int BufferIndex, size_t UploadDataSize, void *pUploadData) override;
-	void UpdateBufferObject(int BufferIndex, size_t UploadDataSize, void *pUploadData, void *pOffset) override;
+	int CreateBufferObject(size_t UploadDataSize, void *pUploadData, bool IsMovedPointer = false) override;
+	void RecreateBufferObject(int BufferIndex, size_t UploadDataSize, void *pUploadData, bool IsMovedPointer = false) override;
+	void UpdateBufferObject(int BufferIndex, size_t UploadDataSize, void *pUploadData, void *pOffset, bool IsMovedPointer = false) override;
 	void CopyBufferObject(int WriteBufferIndex, int ReadBufferIndex, size_t WriteOffset, size_t ReadOffset, size_t CopyDataSize) override;
 	void DeleteBufferObject(int BufferIndex) override;
 

--- a/src/engine/graphics.h
+++ b/src/engine/graphics.h
@@ -254,9 +254,10 @@ public:
 	virtual void RenderText(int BufferContainerIndex, int TextQuadNum, int TextureSize, int TextureTextIndex, int TextureTextOutlineIndex, float *pTextColor, float *pTextoutlineColor) = 0;
 
 	// opengl 3.3 functions
-	virtual int CreateBufferObject(size_t UploadDataSize, void *pUploadData) = 0;
-	virtual void RecreateBufferObject(int BufferIndex, size_t UploadDataSize, void *pUploadData) = 0;
-	virtual void UpdateBufferObject(int BufferIndex, size_t UploadDataSize, void *pUploadData, void *pOffset) = 0;
+	// if a pointer is passed as moved pointer, it requires to be allocated with malloc()
+	virtual int CreateBufferObject(size_t UploadDataSize, void *pUploadData, bool IsMovedPointer = false) = 0;
+	virtual void RecreateBufferObject(int BufferIndex, size_t UploadDataSize, void *pUploadData, bool IsMovedPointer = false) = 0;
+	virtual void UpdateBufferObject(int BufferIndex, size_t UploadDataSize, void *pUploadData, void *pOffset, bool IsMovedPointer = false) = 0;
 	virtual void CopyBufferObject(int WriteBufferIndex, int ReadBufferIndex, size_t WriteOffset, size_t ReadOffset, size_t CopyDataSize) = 0;
 	virtual void DeleteBufferObject(int BufferIndex) = 0;
 

--- a/src/game/client/components/maplayers.cpp
+++ b/src/game/client/components/maplayers.cpp
@@ -836,7 +836,7 @@ void CMapLayers::OnMapLoad()
 						size_t UploadDataSize = tmpTileTexCoords.size() * sizeof(SGraphicTileTexureCoords) + tmpTiles.size() * sizeof(SGraphicTile);
 						if(UploadDataSize > 0)
 						{
-							char *pUploadData = new char[UploadDataSize];
+							char *pUploadData = (char *)malloc(sizeof(char) * UploadDataSize);
 
 							mem_copy_special(pUploadData, pTmpTiles, sizeof(vec2), tmpTiles.size() * 4, (DoTextureCoords ? sizeof(vec3) : 0));
 							if(DoTextureCoords)
@@ -845,8 +845,7 @@ void CMapLayers::OnMapLoad()
 							}
 
 							// first create the buffer object
-							int BufferObjectIndex = Graphics()->CreateBufferObject(UploadDataSize, pUploadData);
-							delete[] pUploadData;
+							int BufferObjectIndex = Graphics()->CreateBufferObject(UploadDataSize, pUploadData, true);
 
 							// then create the buffer container
 							SBufferContainerInfo ContainerInfo;


### PR DESCRIPTION
Huge maps like back in time 2, will always "only" upload 2MB of data at once, and then wait for the graphics thread to finish building/copying the VRAM, this might increase performance a bit