### PR TITLE
Enable further clang-tidy checks to modernize the code

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -16,5 +16,6 @@ Checks: >
   -clang-analyzer-optin.cplusplus.VirtualCall,
   -clang-analyzer-optin.performance.Padding,
   -clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling,
+  modernize-loop-convert,
   readability-qualified-auto,
 HeaderFilterRegex: 'src/.*'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -16,4 +16,5 @@ Checks: >
   -clang-analyzer-optin.cplusplus.VirtualCall,
   -clang-analyzer-optin.performance.Padding,
   -clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling,
+  readability-qualified-auto,
 HeaderFilterRegex: 'src/.*'

--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -1826,12 +1826,12 @@ void CCommandProcessorFragment_OpenGL2::Cmd_DeleteBufferContainer(const CCommand
 			int VertBufferID = BufferContainer.m_ContainerInfo.m_Attributes[i].m_VertBufferBindingIndex;
 			if(VertBufferID != -1)
 			{
-				for(size_t j = 0; j < BufferContainer.m_ContainerInfo.m_Attributes.size(); ++j)
+				for(auto &m_Attribute : BufferContainer.m_ContainerInfo.m_Attributes)
 				{
 					// set all equal ids to zero to not double delete
-					if(VertBufferID == BufferContainer.m_ContainerInfo.m_Attributes[j].m_VertBufferBindingIndex)
+					if(VertBufferID == m_Attribute.m_VertBufferBindingIndex)
 					{
-						BufferContainer.m_ContainerInfo.m_Attributes[j].m_VertBufferBindingIndex = -1;
+						m_Attribute.m_VertBufferBindingIndex = -1;
 					}
 				}
 
@@ -3096,12 +3096,12 @@ void CCommandProcessorFragment_OpenGL3_3::DestroyBufferContainer(int Index, bool
 			int VertBufferID = BufferContainer.m_ContainerInfo.m_Attributes[i].m_VertBufferBindingIndex;
 			if(VertBufferID != -1)
 			{
-				for(size_t j = 0; j < BufferContainer.m_ContainerInfo.m_Attributes.size(); ++j)
+				for(auto &m_Attribute : BufferContainer.m_ContainerInfo.m_Attributes)
 				{
 					// set all equal ids to zero to not double delete
-					if(VertBufferID == BufferContainer.m_ContainerInfo.m_Attributes[j].m_VertBufferBindingIndex)
+					if(VertBufferID == m_Attribute.m_VertBufferBindingIndex)
 					{
-						BufferContainer.m_ContainerInfo.m_Attributes[j].m_VertBufferBindingIndex = -1;
+						m_Attribute.m_VertBufferBindingIndex = -1;
 					}
 				}
 
@@ -3146,11 +3146,11 @@ void CCommandProcessorFragment_OpenGL3_3::AppendIndices(unsigned int NewIndicesC
 	glDeleteBuffers(1, &m_QuadDrawIndexBufferID);
 	m_QuadDrawIndexBufferID = NewIndexBufferID;
 
-	for(int i = 0; i < MAX_STREAM_BUFFER_COUNT; ++i)
-		m_LastIndexBufferBound[i] = 0;
-	for(size_t i = 0; i < m_BufferContainers.size(); ++i)
+	for(unsigned int &i : m_LastIndexBufferBound)
+		i = 0;
+	for(auto &m_BufferContainer : m_BufferContainers)
 	{
-		m_BufferContainers[i].m_LastIndexBufferBound = 0;
+		m_BufferContainer.m_LastIndexBufferBound = 0;
 	}
 
 	m_CurrentIndicesInBuffer = NewIndicesCount;

--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -1826,12 +1826,12 @@ void CCommandProcessorFragment_OpenGL2::Cmd_DeleteBufferContainer(const CCommand
 			int VertBufferID = BufferContainer.m_ContainerInfo.m_Attributes[i].m_VertBufferBindingIndex;
 			if(VertBufferID != -1)
 			{
-				for(auto &m_Attribute : BufferContainer.m_ContainerInfo.m_Attributes)
+				for(auto &Attribute : BufferContainer.m_ContainerInfo.m_Attributes)
 				{
 					// set all equal ids to zero to not double delete
-					if(VertBufferID == m_Attribute.m_VertBufferBindingIndex)
+					if(VertBufferID == Attribute.m_VertBufferBindingIndex)
 					{
-						m_Attribute.m_VertBufferBindingIndex = -1;
+						Attribute.m_VertBufferBindingIndex = -1;
 					}
 				}
 
@@ -3096,12 +3096,12 @@ void CCommandProcessorFragment_OpenGL3_3::DestroyBufferContainer(int Index, bool
 			int VertBufferID = BufferContainer.m_ContainerInfo.m_Attributes[i].m_VertBufferBindingIndex;
 			if(VertBufferID != -1)
 			{
-				for(auto &m_Attribute : BufferContainer.m_ContainerInfo.m_Attributes)
+				for(auto &Attribute : BufferContainer.m_ContainerInfo.m_Attributes)
 				{
 					// set all equal ids to zero to not double delete
-					if(VertBufferID == m_Attribute.m_VertBufferBindingIndex)
+					if(VertBufferID == Attribute.m_VertBufferBindingIndex)
 					{
-						m_Attribute.m_VertBufferBindingIndex = -1;
+						Attribute.m_VertBufferBindingIndex = -1;
 					}
 				}
 
@@ -3148,9 +3148,9 @@ void CCommandProcessorFragment_OpenGL3_3::AppendIndices(unsigned int NewIndicesC
 
 	for(unsigned int &i : m_LastIndexBufferBound)
 		i = 0;
-	for(auto &m_BufferContainer : m_BufferContainers)
+	for(auto &BufferContainer : m_BufferContainers)
 	{
-		m_BufferContainer.m_LastIndexBufferBound = 0;
+		BufferContainer.m_LastIndexBufferBound = 0;
 	}
 
 	m_CurrentIndicesInBuffer = NewIndicesCount;

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -263,8 +263,8 @@ void CSmoothTime::Update(CGraph *pGraph, int64 Target, int TimeLeft, int AdjustD
 CClient::CClient() :
 	m_DemoPlayer(&m_SnapshotDelta)
 {
-	for(int i = 0; i < RECORDER_MAX; i++)
-		m_DemoRecorder[i] = CDemoRecorder(&m_SnapshotDelta);
+	for(auto &i : m_DemoRecorder)
+		i = CDemoRecorder(&m_SnapshotDelta);
 
 	m_pEditor = 0;
 	m_pInput = 0;
@@ -403,9 +403,9 @@ int CClient::SendMsg(CMsgPacker *pMsg, int Flags)
 
 	if(Flags & MSGFLAG_RECORD)
 	{
-		for(int i = 0; i < RECORDER_MAX; i++)
-			if(m_DemoRecorder[i].IsRecording())
-				m_DemoRecorder[i].RecordMessage(Packet.m_pData, Packet.m_DataSize);
+		for(auto &i : m_DemoRecorder)
+			if(i.IsRecording())
+				i.RecordMessage(Packet.m_pData, Packet.m_DataSize);
 	}
 
 	if(!(Flags & MSGFLAG_NOSEND))
@@ -2019,12 +2019,12 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket)
 					SnapshotRemoveExtraInfo(aExtraInfoRemoved);
 
 					// add snapshot to demo
-					for(int i = 0; i < RECORDER_MAX; i++)
+					for(auto &i : m_DemoRecorder)
 					{
-						if(m_DemoRecorder[i].IsRecording())
+						if(i.IsRecording())
 						{
 							// write snapshot
-							m_DemoRecorder[i].RecordSnapshot(GameTick, aExtraInfoRemoved, SnapSize);
+							i.RecordSnapshot(GameTick, aExtraInfoRemoved, SnapSize);
 						}
 					}
 
@@ -2091,9 +2091,9 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket)
 		if((pPacket->m_Flags & NET_CHUNKFLAG_VITAL) != 0 || Msg == NETMSGTYPE_SV_EXTRAPROJECTILE)
 		{
 			// game message
-			for(int i = 0; i < RECORDER_MAX; i++)
-				if(m_DemoRecorder[i].IsRecording())
-					m_DemoRecorder[i].RecordMessage(pPacket->m_pData, pPacket->m_DataSize);
+			for(auto &i : m_DemoRecorder)
+				if(i.IsRecording())
+					i.RecordMessage(pPacket->m_pData, pPacket->m_DataSize);
 
 			GameClient()->OnMessage(Msg, &Unpacker);
 		}
@@ -2530,9 +2530,9 @@ void CClient::LoadDDNetInfo()
 
 void CClient::PumpNetwork()
 {
-	for(int i = 0; i < NUM_CLIENTS; i++)
+	for(auto &i : m_NetClient)
 	{
-		m_NetClient[i].Update();
+		i.Update();
 	}
 
 	if(State() != IClient::STATE_DEMOPLAYBACK)
@@ -3056,12 +3056,12 @@ void CClient::Run()
 			mem_zero(&BindAddr, sizeof(BindAddr));
 			BindAddr.type = NETTYPE_ALL;
 		}
-		for(int i = 0; i < NUM_CLIENTS; i++)
+		for(auto &i : m_NetClient)
 		{
 			do
 			{
 				BindAddr.port = (secure_rand() % 64511) + 1024;
-			} while(!m_NetClient[i].Open(BindAddr, 0));
+			} while(!i.Open(BindAddr, 0));
 		}
 	}
 

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -263,8 +263,8 @@ void CSmoothTime::Update(CGraph *pGraph, int64 Target, int TimeLeft, int AdjustD
 CClient::CClient() :
 	m_DemoPlayer(&m_SnapshotDelta)
 {
-	for(auto &i : m_DemoRecorder)
-		i = CDemoRecorder(&m_SnapshotDelta);
+	for(auto &DemoRecorder : m_DemoRecorder)
+		DemoRecorder = CDemoRecorder(&m_SnapshotDelta);
 
 	m_pEditor = 0;
 	m_pInput = 0;
@@ -2019,12 +2019,12 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket)
 					SnapshotRemoveExtraInfo(aExtraInfoRemoved);
 
 					// add snapshot to demo
-					for(auto &i : m_DemoRecorder)
+					for(auto &DemoRecorder : m_DemoRecorder)
 					{
-						if(i.IsRecording())
+						if(DemoRecorder.IsRecording())
 						{
 							// write snapshot
-							i.RecordSnapshot(GameTick, aExtraInfoRemoved, SnapSize);
+							DemoRecorder.RecordSnapshot(GameTick, aExtraInfoRemoved, SnapSize);
 						}
 					}
 
@@ -2091,9 +2091,9 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket)
 		if((pPacket->m_Flags & NET_CHUNKFLAG_VITAL) != 0 || Msg == NETMSGTYPE_SV_EXTRAPROJECTILE)
 		{
 			// game message
-			for(auto &i : m_DemoRecorder)
-				if(i.IsRecording())
-					i.RecordMessage(pPacket->m_pData, pPacket->m_DataSize);
+			for(auto &DemoRecorder : m_DemoRecorder)
+				if(DemoRecorder.IsRecording())
+					DemoRecorder.RecordMessage(pPacket->m_pData, pPacket->m_DataSize);
 
 			GameClient()->OnMessage(Msg, &Unpacker);
 		}
@@ -2530,9 +2530,9 @@ void CClient::LoadDDNetInfo()
 
 void CClient::PumpNetwork()
 {
-	for(auto &i : m_NetClient)
+	for(auto &NetClient : m_NetClient)
 	{
-		i.Update();
+		NetClient.Update();
 	}
 
 	if(State() != IClient::STATE_DEMOPLAYBACK)
@@ -3056,12 +3056,12 @@ void CClient::Run()
 			mem_zero(&BindAddr, sizeof(BindAddr));
 			BindAddr.type = NETTYPE_ALL;
 		}
-		for(auto &i : m_NetClient)
+		for(auto &NetClient : m_NetClient)
 		{
 			do
 			{
 				BindAddr.port = (secure_rand() % 64511) + 1024;
-			} while(!i.Open(BindAddr, 0));
+			} while(!NetClient.Open(BindAddr, 0));
 		}
 	}
 

--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -757,12 +757,12 @@ void CGraphics_Threaded::SetColor(float r, float g, float b, float a)
 	b *= 255.f;
 	a *= 255.f;
 
-	for(int i = 0; i < 4; ++i)
+	for(auto &i : m_aColor)
 	{
-		m_aColor[i].r = (unsigned char)(r);
-		m_aColor[i].g = (unsigned char)(g);
-		m_aColor[i].b = (unsigned char)(b);
-		m_aColor[i].a = (unsigned char)(a);
+		i.r = (unsigned char)(r);
+		i.g = (unsigned char)(g);
+		i.b = (unsigned char)(b);
+		i.a = (unsigned char)(a);
 	}
 }
 
@@ -2022,8 +2022,8 @@ int CGraphics_Threaded::CreateBufferContainer(SBufferContainerInfo *pContainerIn
 
 	mem_copy(Cmd.m_Attributes, &pContainerInfo->m_Attributes[0], Cmd.m_AttrCount * sizeof(SBufferContainerInfo::SAttribute));
 
-	for(size_t i = 0; i < pContainerInfo->m_Attributes.size(); ++i)
-		m_VertexArrayInfo[Index].m_AssociatedBufferObjectIndices.push_back(pContainerInfo->m_Attributes[i].m_VertBufferBindingIndex);
+	for(auto &m_Attribute : pContainerInfo->m_Attributes)
+		m_VertexArrayInfo[Index].m_AssociatedBufferObjectIndices.push_back(m_Attribute.m_VertBufferBindingIndex);
 
 	return Index;
 }
@@ -2058,10 +2058,10 @@ void CGraphics_Threaded::DeleteBufferContainer(int ContainerIndex, bool DestroyA
 			if(BufferObjectIndex != -1)
 			{
 				// don't delete double entries
-				for(size_t n = 0; n < m_VertexArrayInfo[ContainerIndex].m_AssociatedBufferObjectIndices.size(); ++n)
+				for(int &m_AssociatedBufferObjectIndice : m_VertexArrayInfo[ContainerIndex].m_AssociatedBufferObjectIndices)
 				{
-					if(BufferObjectIndex == m_VertexArrayInfo[ContainerIndex].m_AssociatedBufferObjectIndices[n])
-						m_VertexArrayInfo[ContainerIndex].m_AssociatedBufferObjectIndices[n] = -1;
+					if(BufferObjectIndex == m_AssociatedBufferObjectIndice)
+						m_AssociatedBufferObjectIndice = -1;
 				}
 				// clear the buffer object index
 				m_BufferObjectIndices[BufferObjectIndex] = m_FirstFreeBufferObjectIndex;
@@ -2110,8 +2110,8 @@ void CGraphics_Threaded::UpdateBufferContainer(int ContainerIndex, SBufferContai
 	mem_copy(Cmd.m_Attributes, &pContainerInfo->m_Attributes[0], Cmd.m_AttrCount * sizeof(SBufferContainerInfo::SAttribute));
 
 	m_VertexArrayInfo[ContainerIndex].m_AssociatedBufferObjectIndices.clear();
-	for(size_t i = 0; i < pContainerInfo->m_Attributes.size(); ++i)
-		m_VertexArrayInfo[ContainerIndex].m_AssociatedBufferObjectIndices.push_back(pContainerInfo->m_Attributes[i].m_VertBufferBindingIndex);
+	for(auto &m_Attribute : pContainerInfo->m_Attributes)
+		m_VertexArrayInfo[ContainerIndex].m_AssociatedBufferObjectIndices.push_back(m_Attribute.m_VertBufferBindingIndex);
 }
 
 void CGraphics_Threaded::IndicesNumRequiredNotify(unsigned int RequiredIndicesCount)
@@ -2292,8 +2292,8 @@ int CGraphics_Threaded::Init()
 		return -1;
 
 	// create command buffers
-	for(int i = 0; i < NUM_CMDBUFFERS; i++)
-		m_apCommandBuffers[i] = new CCommandBuffer(CMD_BUFFER_CMD_BUFFER_SIZE, CMD_BUFFER_DATA_BUFFER_SIZE);
+	for(auto &m_apCommandBuffer : m_apCommandBuffers)
+		m_apCommandBuffer = new CCommandBuffer(CMD_BUFFER_CMD_BUFFER_SIZE, CMD_BUFFER_DATA_BUFFER_SIZE);
 	m_pCommandBuffer = m_apCommandBuffers[0];
 
 	// create null texture, will get id=0
@@ -2315,8 +2315,8 @@ void CGraphics_Threaded::Shutdown()
 	m_pBackend = 0x0;
 
 	// delete the command buffers
-	for(int i = 0; i < NUM_CMDBUFFERS; i++)
-		delete m_apCommandBuffers[i];
+	for(auto &m_apCommandBuffer : m_apCommandBuffers)
+		delete m_apCommandBuffer;
 }
 
 int CGraphics_Threaded::GetNumScreens() const
@@ -2377,8 +2377,8 @@ void CGraphics_Threaded::Resize(int w, int h)
 	KickCommandBuffer();
 	WaitForIdle();
 
-	for(size_t i = 0; i < m_ResizeListeners.size(); ++i)
-		m_ResizeListeners[i].m_pFunc(m_ResizeListeners[i].m_pUser);
+	for(auto &m_ResizeListener : m_ResizeListeners)
+		m_ResizeListener.m_pFunc(m_ResizeListener.m_pUser);
 }
 
 void CGraphics_Threaded::AddWindowResizeListener(WINDOW_RESIZE_FUNC pFunc, void *pUser)

--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -757,12 +757,12 @@ void CGraphics_Threaded::SetColor(float r, float g, float b, float a)
 	b *= 255.f;
 	a *= 255.f;
 
-	for(auto &i : m_aColor)
+	for(auto &Color : m_aColor)
 	{
-		i.r = (unsigned char)(r);
-		i.g = (unsigned char)(g);
-		i.b = (unsigned char)(b);
-		i.a = (unsigned char)(a);
+		Color.r = (unsigned char)(r);
+		Color.g = (unsigned char)(g);
+		Color.b = (unsigned char)(b);
+		Color.a = (unsigned char)(a);
 	}
 }
 
@@ -2022,8 +2022,8 @@ int CGraphics_Threaded::CreateBufferContainer(SBufferContainerInfo *pContainerIn
 
 	mem_copy(Cmd.m_Attributes, &pContainerInfo->m_Attributes[0], Cmd.m_AttrCount * sizeof(SBufferContainerInfo::SAttribute));
 
-	for(auto &m_Attribute : pContainerInfo->m_Attributes)
-		m_VertexArrayInfo[Index].m_AssociatedBufferObjectIndices.push_back(m_Attribute.m_VertBufferBindingIndex);
+	for(auto &Attribute : pContainerInfo->m_Attributes)
+		m_VertexArrayInfo[Index].m_AssociatedBufferObjectIndices.push_back(Attribute.m_VertBufferBindingIndex);
 
 	return Index;
 }
@@ -2110,8 +2110,8 @@ void CGraphics_Threaded::UpdateBufferContainer(int ContainerIndex, SBufferContai
 	mem_copy(Cmd.m_Attributes, &pContainerInfo->m_Attributes[0], Cmd.m_AttrCount * sizeof(SBufferContainerInfo::SAttribute));
 
 	m_VertexArrayInfo[ContainerIndex].m_AssociatedBufferObjectIndices.clear();
-	for(auto &m_Attribute : pContainerInfo->m_Attributes)
-		m_VertexArrayInfo[ContainerIndex].m_AssociatedBufferObjectIndices.push_back(m_Attribute.m_VertBufferBindingIndex);
+	for(auto &Attribute : pContainerInfo->m_Attributes)
+		m_VertexArrayInfo[ContainerIndex].m_AssociatedBufferObjectIndices.push_back(Attribute.m_VertBufferBindingIndex);
 }
 
 void CGraphics_Threaded::IndicesNumRequiredNotify(unsigned int RequiredIndicesCount)
@@ -2292,8 +2292,8 @@ int CGraphics_Threaded::Init()
 		return -1;
 
 	// create command buffers
-	for(auto &m_apCommandBuffer : m_apCommandBuffers)
-		m_apCommandBuffer = new CCommandBuffer(CMD_BUFFER_CMD_BUFFER_SIZE, CMD_BUFFER_DATA_BUFFER_SIZE);
+	for(auto &pCommandBuffer : m_apCommandBuffers)
+		pCommandBuffer = new CCommandBuffer(CMD_BUFFER_CMD_BUFFER_SIZE, CMD_BUFFER_DATA_BUFFER_SIZE);
 	m_pCommandBuffer = m_apCommandBuffers[0];
 
 	// create null texture, will get id=0
@@ -2315,8 +2315,8 @@ void CGraphics_Threaded::Shutdown()
 	m_pBackend = 0x0;
 
 	// delete the command buffers
-	for(auto &m_apCommandBuffer : m_apCommandBuffers)
-		delete m_apCommandBuffer;
+	for(auto &pCommandBuffer : m_apCommandBuffers)
+		delete pCommandBuffer;
 }
 
 int CGraphics_Threaded::GetNumScreens() const
@@ -2377,8 +2377,8 @@ void CGraphics_Threaded::Resize(int w, int h)
 	KickCommandBuffer();
 	WaitForIdle();
 
-	for(auto &m_ResizeListener : m_ResizeListeners)
-		m_ResizeListener.m_pFunc(m_ResizeListener.m_pUser);
+	for(auto &ResizeListener : m_ResizeListeners)
+		ResizeListener.m_pFunc(ResizeListener.m_pUser);
 }
 
 void CGraphics_Threaded::AddWindowResizeListener(WINDOW_RESIZE_FUNC pFunc, void *pUser)

--- a/src/engine/client/http.cpp
+++ b/src/engine/client/http.cpp
@@ -56,9 +56,9 @@ bool HttpInit(IStorage *pStorage)
 		dbg_msg("http", "libcurl version %s (compiled = " LIBCURL_VERSION ")", pVersion->version);
 	}
 
-	for(auto &gs_aLock : gs_aLocks)
+	for(auto &Lock : gs_aLocks)
 	{
-		gs_aLock = lock_create();
+		Lock = lock_create();
 	}
 	curl_share_setopt(gs_Share, CURLSHOPT_SHARE, CURL_LOCK_DATA_DNS);
 	curl_share_setopt(gs_Share, CURLSHOPT_SHARE, CURL_LOCK_DATA_SSL_SESSION);

--- a/src/engine/client/http.cpp
+++ b/src/engine/client/http.cpp
@@ -56,9 +56,9 @@ bool HttpInit(IStorage *pStorage)
 		dbg_msg("http", "libcurl version %s (compiled = " LIBCURL_VERSION ")", pVersion->version);
 	}
 
-	for(unsigned int i = 0; i < sizeof(gs_aLocks) / sizeof(gs_aLocks[0]); i++)
+	for(auto &gs_aLock : gs_aLocks)
 	{
-		gs_aLocks[i] = lock_create();
+		gs_aLock = lock_create();
 	}
 	curl_share_setopt(gs_Share, CURLSHOPT_SHARE, CURL_LOCK_DATA_DNS);
 	curl_share_setopt(gs_Share, CURLSHOPT_SHARE, CURL_LOCK_DATA_SSL_SESSION);

--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -479,11 +479,11 @@ CServerBrowser::CServerEntry *CServerBrowser::Add(const NETADDR &Addr)
 	}
 
 	// check if it's an official server
-	for(auto &m_aNetwork : m_aNetworks)
+	for(auto &Network : m_aNetworks)
 	{
-		for(int i = 0; i < m_aNetwork.m_NumCountries; i++)
+		for(int i = 0; i < Network.m_NumCountries; i++)
 		{
-			CNetworkCountry *pCntr = &m_aNetwork.m_aCountries[i];
+			CNetworkCountry *pCntr = &Network.m_aCountries[i];
 			for(int j = 0; j < pCntr->m_NumServers; j++)
 			{
 				if(net_addr_comp(&Addr, &pCntr->m_aServers[j]) == 0)
@@ -1139,11 +1139,11 @@ void CServerBrowser::LoadDDNetServers()
 
 void CServerBrowser::RecheckOfficial()
 {
-	for(auto &m_aNetwork : m_aNetworks)
+	for(auto &Network : m_aNetworks)
 	{
-		for(int i = 0; i < m_aNetwork.m_NumCountries; i++)
+		for(int i = 0; i < Network.m_NumCountries; i++)
 		{
-			CNetworkCountry *pCntr = &m_aNetwork.m_aCountries[i];
+			CNetworkCountry *pCntr = &Network.m_aCountries[i];
 			for(int j = 0; j < pCntr->m_NumServers; j++)
 			{
 				CServerEntry *pEntry = Find(pCntr->m_aServers[j]);
@@ -1321,11 +1321,11 @@ void CServerBrowser::CountryFilterClean(int Network)
 	char aNewList[128];
 	aNewList[0] = '\0';
 
-	for(auto &m_aNetwork : m_aNetworks)
+	for(auto &Network : m_aNetworks)
 	{
-		for(int i = 0; i < m_aNetwork.m_NumCountries; i++)
+		for(int i = 0; i < Network.m_NumCountries; i++)
 		{
-			const char *pName = m_aNetwork.m_aCountries[i].m_aName;
+			const char *pName = Network.m_aCountries[i].m_aName;
 			if(DDNetFiltered(pExcludeCountries, pName))
 			{
 				char aBuf[128];

--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -334,10 +334,8 @@ void SetFilteredPlayers(const CServerInfo &Item)
 		Item.m_NumFilteredPlayers = Item.m_NumClients;
 	if(g_Config.m_BrFilterConnectingPlayers)
 	{
-		for(int i = 0; i < MAX_CLIENTS; i++)
+		for(const auto &Client : Item.m_aClients)
 		{
-			const CServerInfo::CClient &Client = Item.m_aClients[i];
-
 			if(str_comp(Client.m_aName, "(connecting)") == 0 && Client.m_aClan[0] == '\0' && Client.m_Country == -1 && Client.m_Score == 0)
 				Item.m_NumFilteredPlayers--;
 		}
@@ -481,11 +479,11 @@ CServerBrowser::CServerEntry *CServerBrowser::Add(const NETADDR &Addr)
 	}
 
 	// check if it's an official server
-	for(int Network = 0; Network < NUM_NETWORKS; Network++)
+	for(auto &m_aNetwork : m_aNetworks)
 	{
-		for(int i = 0; i < m_aNetworks[Network].m_NumCountries; i++)
+		for(int i = 0; i < m_aNetwork.m_NumCountries; i++)
 		{
-			CNetworkCountry *pCntr = &m_aNetworks[Network].m_aCountries[i];
+			CNetworkCountry *pCntr = &m_aNetwork.m_aCountries[i];
 			for(int j = 0; j < pCntr->m_NumServers; j++)
 			{
 				if(net_addr_comp(&Addr, &pCntr->m_aServers[j]) == 0)
@@ -1141,11 +1139,11 @@ void CServerBrowser::LoadDDNetServers()
 
 void CServerBrowser::RecheckOfficial()
 {
-	for(int Network = 0; Network < NUM_NETWORKS; Network++)
+	for(auto &m_aNetwork : m_aNetworks)
 	{
-		for(int i = 0; i < m_aNetworks[Network].m_NumCountries; i++)
+		for(int i = 0; i < m_aNetwork.m_NumCountries; i++)
 		{
-			CNetworkCountry *pCntr = &m_aNetworks[Network].m_aCountries[i];
+			CNetworkCountry *pCntr = &m_aNetwork.m_aCountries[i];
 			for(int j = 0; j < pCntr->m_NumServers; j++)
 			{
 				CServerEntry *pEntry = Find(pCntr->m_aServers[j]);
@@ -1323,11 +1321,11 @@ void CServerBrowser::CountryFilterClean(int Network)
 	char aNewList[128];
 	aNewList[0] = '\0';
 
-	for(int Network = 0; Network < NUM_NETWORKS; Network++)
+	for(auto &m_aNetwork : m_aNetworks)
 	{
-		for(int i = 0; i < m_aNetworks[Network].m_NumCountries; i++)
+		for(int i = 0; i < m_aNetwork.m_NumCountries; i++)
 		{
-			const char *pName = m_aNetworks[Network].m_aCountries[i].m_aName;
+			const char *pName = m_aNetwork.m_aCountries[i].m_aName;
 			if(DDNetFiltered(pExcludeCountries, pName))
 			{
 				char aBuf[128];

--- a/src/engine/client/sound.cpp
+++ b/src/engine/client/sound.cpp
@@ -115,12 +115,12 @@ static void Mix(short *pFinalOut, unsigned Frames)
 
 	MasterVol = m_SoundVolume;
 
-	for(unsigned i = 0; i < NUM_VOICES; i++)
+	for(auto &m_aVoice : m_aVoices)
 	{
-		if(m_aVoices[i].m_pSample)
+		if(m_aVoice.m_pSample)
 		{
 			// mix voice
-			CVoice *v = &m_aVoices[i];
+			CVoice *v = &m_aVoice;
 			int *pOut = m_pMixBuffer;
 
 			int Step = v->m_pSample->m_Channels; // setup input sources
@@ -937,15 +937,15 @@ void CSound::Stop(int SampleID)
 	// TODO: a nice fade out
 	lock_wait(m_SoundLock);
 	CSample *pSample = &m_aSamples[SampleID];
-	for(int i = 0; i < NUM_VOICES; i++)
+	for(auto &m_aVoice : m_aVoices)
 	{
-		if(m_aVoices[i].m_pSample == pSample)
+		if(m_aVoice.m_pSample == pSample)
 		{
-			if(m_aVoices[i].m_Flags & FLAG_LOOP)
-				m_aVoices[i].m_pSample->m_PausedAt = m_aVoices[i].m_Tick;
+			if(m_aVoice.m_Flags & FLAG_LOOP)
+				m_aVoice.m_pSample->m_PausedAt = m_aVoice.m_Tick;
 			else
-				m_aVoices[i].m_pSample->m_PausedAt = 0;
-			m_aVoices[i].m_pSample = 0;
+				m_aVoice.m_pSample->m_PausedAt = 0;
+			m_aVoice.m_pSample = 0;
 		}
 	}
 	lock_unlock(m_SoundLock);
@@ -955,16 +955,16 @@ void CSound::StopAll()
 {
 	// TODO: a nice fade out
 	lock_wait(m_SoundLock);
-	for(int i = 0; i < NUM_VOICES; i++)
+	for(auto &m_aVoice : m_aVoices)
 	{
-		if(m_aVoices[i].m_pSample)
+		if(m_aVoice.m_pSample)
 		{
-			if(m_aVoices[i].m_Flags & FLAG_LOOP)
-				m_aVoices[i].m_pSample->m_PausedAt = m_aVoices[i].m_Tick;
+			if(m_aVoice.m_Flags & FLAG_LOOP)
+				m_aVoice.m_pSample->m_PausedAt = m_aVoice.m_Tick;
 			else
-				m_aVoices[i].m_pSample->m_PausedAt = 0;
+				m_aVoice.m_pSample->m_PausedAt = 0;
 		}
-		m_aVoices[i].m_pSample = 0;
+		m_aVoice.m_pSample = 0;
 	}
 	lock_unlock(m_SoundLock);
 }

--- a/src/engine/client/sound.cpp
+++ b/src/engine/client/sound.cpp
@@ -115,37 +115,36 @@ static void Mix(short *pFinalOut, unsigned Frames)
 
 	MasterVol = m_SoundVolume;
 
-	for(auto &m_aVoice : m_aVoices)
+	for(auto &Voice : m_aVoices)
 	{
-		if(m_aVoice.m_pSample)
+		if(Voice.m_pSample)
 		{
 			// mix voice
-			CVoice *v = &m_aVoice;
 			int *pOut = m_pMixBuffer;
 
-			int Step = v->m_pSample->m_Channels; // setup input sources
-			short *pInL = &v->m_pSample->m_pData[v->m_Tick * Step];
-			short *pInR = &v->m_pSample->m_pData[v->m_Tick * Step + 1];
+			int Step = Voice.m_pSample->m_Channels; // setup input sources
+			short *pInL = &Voice.m_pSample->m_pData[Voice.m_Tick * Step];
+			short *pInR = &Voice.m_pSample->m_pData[Voice.m_Tick * Step + 1];
 
-			unsigned End = v->m_pSample->m_NumFrames - v->m_Tick;
+			unsigned End = Voice.m_pSample->m_NumFrames - Voice.m_Tick;
 
-			int Rvol = (int)(v->m_pChannel->m_Vol * (v->m_Vol / 255.0f));
-			int Lvol = (int)(v->m_pChannel->m_Vol * (v->m_Vol / 255.0f));
+			int Rvol = (int)(Voice.m_pChannel->m_Vol * (Voice.m_Vol / 255.0f));
+			int Lvol = (int)(Voice.m_pChannel->m_Vol * (Voice.m_Vol / 255.0f));
 
 			// make sure that we don't go outside the sound data
 			if(Frames < End)
 				End = Frames;
 
 			// check if we have a mono sound
-			if(v->m_pSample->m_Channels == 1)
+			if(Voice.m_pSample->m_Channels == 1)
 				pInR = pInL;
 
 			// volume calculation
-			if(v->m_Flags & ISound::FLAG_POS && v->m_pChannel->m_Pan)
+			if(Voice.m_Flags & ISound::FLAG_POS && Voice.m_pChannel->m_Pan)
 			{
 				// TODO: we should respect the channel panning value
-				int dx = v->m_X - m_CenterX;
-				int dy = v->m_Y - m_CenterY;
+				int dx = Voice.m_X - m_CenterX;
+				int dy = Voice.m_Y - m_CenterY;
 				//
 				int p = IntAbs(dx);
 				float FalloffX = 0.0f;
@@ -154,11 +153,11 @@ static void Mix(short *pFinalOut, unsigned Frames)
 				int RangeX = 0; // for panning
 				bool InVoiceField = false;
 
-				switch(v->m_Shape)
+				switch(Voice.m_Shape)
 				{
 				case ISound::SHAPE_CIRCLE:
 				{
-					float r = v->m_Circle.m_Radius;
+					float r = Voice.m_Circle.m_Radius;
 					RangeX = r;
 
 					int Dist = (int)sqrtf((float)dx * dx + dy * dy); // nasty float
@@ -167,7 +166,7 @@ static void Mix(short *pFinalOut, unsigned Frames)
 						InVoiceField = true;
 
 						// falloff
-						int FalloffDistance = r * v->m_Falloff;
+						int FalloffDistance = r * Voice.m_Falloff;
 						if(Dist > FalloffDistance)
 							FalloffX = FalloffY = (r - Dist) / (r - FalloffDistance);
 						else
@@ -181,21 +180,21 @@ static void Mix(short *pFinalOut, unsigned Frames)
 
 				case ISound::SHAPE_RECTANGLE:
 				{
-					RangeX = v->m_Rectangle.m_Width / 2.0f;
+					RangeX = Voice.m_Rectangle.m_Width / 2.0f;
 
 					int abs_dx = abs(dx);
 					int abs_dy = abs(dy);
 
-					int w = v->m_Rectangle.m_Width / 2.0f;
-					int h = v->m_Rectangle.m_Height / 2.0f;
+					int w = Voice.m_Rectangle.m_Width / 2.0f;
+					int h = Voice.m_Rectangle.m_Height / 2.0f;
 
 					if(abs_dx < w && abs_dy < h)
 					{
 						InVoiceField = true;
 
 						// falloff
-						int fx = v->m_Falloff * w;
-						int fy = v->m_Falloff * h;
+						int fx = Voice.m_Falloff * w;
+						int fy = Voice.m_Falloff * h;
 
 						FalloffX = abs_dx > fx ? (float)(w - abs_dx) / (w - fx) : 1.0f;
 						FalloffY = abs_dy > fy ? (float)(h - abs_dy) / (h - fy) : 1.0f;
@@ -210,7 +209,7 @@ static void Mix(short *pFinalOut, unsigned Frames)
 				if(InVoiceField)
 				{
 					// panning
-					if(!(v->m_Flags & ISound::FLAG_NO_PANNING))
+					if(!(Voice.m_Flags & ISound::FLAG_NO_PANNING))
 					{
 						if(dx > 0)
 							Lvol = ((RangeX - p) * Lvol) / RangeX;
@@ -237,18 +236,18 @@ static void Mix(short *pFinalOut, unsigned Frames)
 				*pOut++ += (*pInR) * Rvol;
 				pInL += Step;
 				pInR += Step;
-				v->m_Tick++;
+				Voice.m_Tick++;
 			}
 
 			// free voice if not used any more
-			if(v->m_Tick == v->m_pSample->m_NumFrames)
+			if(Voice.m_Tick == Voice.m_pSample->m_NumFrames)
 			{
-				if(v->m_Flags & ISound::FLAG_LOOP)
-					v->m_Tick = 0;
+				if(Voice.m_Flags & ISound::FLAG_LOOP)
+					Voice.m_Tick = 0;
 				else
 				{
-					v->m_pSample = 0;
-					v->m_Age++;
+					Voice.m_pSample = 0;
+					Voice.m_Age++;
 				}
 			}
 		}
@@ -937,15 +936,15 @@ void CSound::Stop(int SampleID)
 	// TODO: a nice fade out
 	lock_wait(m_SoundLock);
 	CSample *pSample = &m_aSamples[SampleID];
-	for(auto &m_aVoice : m_aVoices)
+	for(auto &Voice : m_aVoices)
 	{
-		if(m_aVoice.m_pSample == pSample)
+		if(Voice.m_pSample == pSample)
 		{
-			if(m_aVoice.m_Flags & FLAG_LOOP)
-				m_aVoice.m_pSample->m_PausedAt = m_aVoice.m_Tick;
+			if(Voice.m_Flags & FLAG_LOOP)
+				Voice.m_pSample->m_PausedAt = Voice.m_Tick;
 			else
-				m_aVoice.m_pSample->m_PausedAt = 0;
-			m_aVoice.m_pSample = 0;
+				Voice.m_pSample->m_PausedAt = 0;
+			Voice.m_pSample = 0;
 		}
 	}
 	lock_unlock(m_SoundLock);
@@ -955,16 +954,16 @@ void CSound::StopAll()
 {
 	// TODO: a nice fade out
 	lock_wait(m_SoundLock);
-	for(auto &m_aVoice : m_aVoices)
+	for(auto &Voice : m_aVoices)
 	{
-		if(m_aVoice.m_pSample)
+		if(Voice.m_pSample)
 		{
-			if(m_aVoice.m_Flags & FLAG_LOOP)
-				m_aVoice.m_pSample->m_PausedAt = m_aVoice.m_Tick;
+			if(Voice.m_Flags & FLAG_LOOP)
+				Voice.m_pSample->m_PausedAt = Voice.m_Tick;
 			else
-				m_aVoice.m_pSample->m_PausedAt = 0;
+				Voice.m_pSample->m_PausedAt = 0;
 		}
-		m_aVoice.m_pSample = 0;
+		Voice.m_pSample = 0;
 	}
 	lock_unlock(m_SoundLock);
 }

--- a/src/engine/client/text.cpp
+++ b/src/engine/client/text.cpp
@@ -85,9 +85,9 @@ public:
 		free(m_pBuf);
 		delete[] m_TextureData[0];
 		delete[] m_TextureData[1];
-		for(auto &m_FtFallbackFont : m_FtFallbackFonts)
+		for(auto &FtFallbackFont : m_FtFallbackFonts)
 		{
-			free(m_FtFallbackFont.m_pBuf);
+			free(FtFallbackFont.m_pBuf);
 		}
 	}
 
@@ -600,16 +600,16 @@ public:
 
 	virtual ~CTextRender()
 	{
-		for(auto &m_Font : m_Fonts)
+		for(auto &pFont : m_Fonts)
 		{
-			FT_Done_Face(m_Font->m_FtFace);
+			FT_Done_Face(pFont->m_FtFace);
 
-			for(CFont::SFontFallBack &FallbackFont : m_Font->m_FtFallbackFonts)
+			for(CFont::SFontFallBack &FallbackFont : pFont->m_FtFallbackFonts)
 			{
 				FT_Done_Face(FallbackFont.m_FtFace);
 			}
 
-			delete m_Font;
+			delete pFont;
 		}
 
 		if(m_FTLibrary != 0)
@@ -733,10 +733,10 @@ public:
 
 	CFont *GetFont(const char *pFilename)
 	{
-		for(auto &m_Font : m_Fonts)
+		for(auto &pFont : m_Fonts)
 		{
-			if(str_comp(pFilename, m_Font->m_aFilename) == 0)
-				return m_Font;
+			if(str_comp(pFilename, pFont->m_aFilename) == 0)
+				return pFont;
 		}
 
 		return NULL;
@@ -1975,8 +1975,8 @@ public:
 	virtual void OnWindowResize()
 	{
 		bool FoundTextContainer = false;
-		for(auto &m_TextContainer : m_TextContainers)
-			if(m_TextContainer.m_StringInfo.m_QuadBufferContainerIndex != -1)
+		for(auto &TextContainer : m_TextContainers)
+			if(TextContainer.m_StringInfo.m_QuadBufferContainerIndex != -1)
 				FoundTextContainer = true;
 		if(FoundTextContainer)
 		{
@@ -1984,19 +1984,19 @@ public:
 			dbg_assert(false, "text container was not empty");
 		}
 
-		for(auto &m_Font : m_Fonts)
+		for(auto &pFont : m_Fonts)
 		{
 			// reset the skylines
 			for(int j = 0; j < 2; ++j)
 			{
-				for(int & k : m_Font->m_TextureSkyline[j].m_CurHeightOfPixelColumn)
+				for(int &k : pFont->m_TextureSkyline[j].m_CurHeightOfPixelColumn)
 					k = 0;
 
-				mem_zero(m_Font->m_TextureData[j], (size_t)m_Font->m_CurTextureDimensions[j] * m_Font->m_CurTextureDimensions[j] * sizeof(unsigned char));
-				Graphics()->LoadTextureRawSub(m_Font->m_aTextures[j], 0, 0, m_Font->m_CurTextureDimensions[j], m_Font->m_CurTextureDimensions[j], CImageInfo::FORMAT_ALPHA, m_Font->m_TextureData[j]);
+				mem_zero(pFont->m_TextureData[j], (size_t)pFont->m_CurTextureDimensions[j] * pFont->m_CurTextureDimensions[j] * sizeof(unsigned char));
+				Graphics()->LoadTextureRawSub(pFont->m_aTextures[j], 0, 0, pFont->m_CurTextureDimensions[j], pFont->m_CurTextureDimensions[j], CImageInfo::FORMAT_ALPHA, pFont->m_TextureData[j]);
 			}
 
-			m_Font->InitFontSizes();
+			pFont->InitFontSizes();
 		}
 	}
 };

--- a/src/engine/client/text.cpp
+++ b/src/engine/client/text.cpp
@@ -85,9 +85,9 @@ public:
 		free(m_pBuf);
 		delete[] m_TextureData[0];
 		delete[] m_TextureData[1];
-		for(size_t i = 0; i < m_FtFallbackFonts.size(); i++)
+		for(auto &m_FtFallbackFont : m_FtFallbackFonts)
 		{
-			free(m_FtFallbackFonts[i].m_pBuf);
+			free(m_FtFallbackFont.m_pBuf);
 		}
 	}
 
@@ -600,16 +600,16 @@ public:
 
 	virtual ~CTextRender()
 	{
-		for(size_t i = 0; i < m_Fonts.size(); ++i)
+		for(auto &m_Font : m_Fonts)
 		{
-			FT_Done_Face(m_Fonts[i]->m_FtFace);
+			FT_Done_Face(m_Font->m_FtFace);
 
-			for(CFont::SFontFallBack &FallbackFont : m_Fonts[i]->m_FtFallbackFonts)
+			for(CFont::SFontFallBack &FallbackFont : m_Font->m_FtFallbackFonts)
 			{
 				FT_Done_Face(FallbackFont.m_FtFace);
 			}
 
-			delete m_Fonts[i];
+			delete m_Font;
 		}
 
 		if(m_FTLibrary != 0)
@@ -733,10 +733,10 @@ public:
 
 	CFont *GetFont(const char *pFilename)
 	{
-		for(size_t i = 0; i < m_Fonts.size(); ++i)
+		for(auto &m_Font : m_Fonts)
 		{
-			if(str_comp(pFilename, m_Fonts[i]->m_aFilename) == 0)
-				return m_Fonts[i];
+			if(str_comp(pFilename, m_Font->m_aFilename) == 0)
+				return m_Font;
 		}
 
 		return NULL;
@@ -1975,8 +1975,8 @@ public:
 	virtual void OnWindowResize()
 	{
 		bool FoundTextContainer = false;
-		for(size_t i = 0; i < m_TextContainers.size(); ++i)
-			if(m_TextContainers[i].m_StringInfo.m_QuadBufferContainerIndex != -1)
+		for(auto &m_TextContainer : m_TextContainers)
+			if(m_TextContainer.m_StringInfo.m_QuadBufferContainerIndex != -1)
 				FoundTextContainer = true;
 		if(FoundTextContainer)
 		{
@@ -1984,19 +1984,19 @@ public:
 			dbg_assert(false, "text container was not empty");
 		}
 
-		for(size_t i = 0; i < m_Fonts.size(); ++i)
+		for(auto &m_Font : m_Fonts)
 		{
 			// reset the skylines
 			for(int j = 0; j < 2; ++j)
 			{
-				for(size_t k = 0; k < m_Fonts[i]->m_TextureSkyline[j].m_CurHeightOfPixelColumn.size(); ++k)
-					m_Fonts[i]->m_TextureSkyline[j].m_CurHeightOfPixelColumn[k] = 0;
+				for(int & k : m_Font->m_TextureSkyline[j].m_CurHeightOfPixelColumn)
+					k = 0;
 
-				mem_zero(m_Fonts[i]->m_TextureData[j], (size_t)m_Fonts[i]->m_CurTextureDimensions[j] * m_Fonts[i]->m_CurTextureDimensions[j] * sizeof(unsigned char));
-				Graphics()->LoadTextureRawSub(m_Fonts[i]->m_aTextures[j], 0, 0, m_Fonts[i]->m_CurTextureDimensions[j], m_Fonts[i]->m_CurTextureDimensions[j], CImageInfo::FORMAT_ALPHA, m_Fonts[i]->m_TextureData[j]);
+				mem_zero(m_Font->m_TextureData[j], (size_t)m_Font->m_CurTextureDimensions[j] * m_Font->m_CurTextureDimensions[j] * sizeof(unsigned char));
+				Graphics()->LoadTextureRawSub(m_Font->m_aTextures[j], 0, 0, m_Font->m_CurTextureDimensions[j], m_Font->m_CurTextureDimensions[j], CImageInfo::FORMAT_ALPHA, m_Font->m_TextureData[j]);
 			}
 
-			m_Fonts[i]->InitFontSizes();
+			m_Font->InitFontSizes();
 		}
 	}
 };

--- a/src/engine/client/updater.cpp
+++ b/src/engine/client/updater.cpp
@@ -312,11 +312,11 @@ void CUpdater::PerformUpdate()
 		}
 	}
 
-	for(map<string, bool>::iterator it = m_FileJobs.begin(); it != m_FileJobs.end(); ++it)
+	for(auto &m_FileJob : m_FileJobs)
 	{
-		if(it->second)
+		if(m_FileJob.second)
 		{
-			const char *pFile = it->first.c_str();
+			const char *pFile = m_FileJob.first.c_str();
 			size_t len = str_length(pFile);
 			if(!str_comp_nocase(pFile + len - 4, ".dll"))
 			{
@@ -347,7 +347,7 @@ void CUpdater::PerformUpdate()
 			pLastFile = pFile;
 		}
 		else
-			m_pStorage->RemoveBinaryFile(it->first.c_str());
+			m_pStorage->RemoveBinaryFile(m_FileJob.first.c_str());
 	}
 
 	if(m_ServerUpdate)
@@ -368,9 +368,9 @@ void CUpdater::CommitUpdate()
 {
 	bool Success = true;
 
-	for(map<std::string, bool>::iterator it = m_FileJobs.begin(); it != m_FileJobs.end(); ++it)
-		if(it->second)
-			Success &= MoveFile(it->first.c_str());
+	for(auto &m_FileJob : m_FileJobs)
+		if(m_FileJob.second)
+			Success &= MoveFile(m_FileJob.first.c_str());
 
 	if(m_ClientUpdate)
 		Success &= ReplaceClient();

--- a/src/engine/client/updater.cpp
+++ b/src/engine/client/updater.cpp
@@ -312,11 +312,11 @@ void CUpdater::PerformUpdate()
 		}
 	}
 
-	for(auto &m_FileJob : m_FileJobs)
+	for(auto &FileJob : m_FileJobs)
 	{
-		if(m_FileJob.second)
+		if(FileJob.second)
 		{
-			const char *pFile = m_FileJob.first.c_str();
+			const char *pFile = FileJob.first.c_str();
 			size_t len = str_length(pFile);
 			if(!str_comp_nocase(pFile + len - 4, ".dll"))
 			{
@@ -347,7 +347,7 @@ void CUpdater::PerformUpdate()
 			pLastFile = pFile;
 		}
 		else
-			m_pStorage->RemoveBinaryFile(m_FileJob.first.c_str());
+			m_pStorage->RemoveBinaryFile(FileJob.first.c_str());
 	}
 
 	if(m_ServerUpdate)
@@ -368,9 +368,9 @@ void CUpdater::CommitUpdate()
 {
 	bool Success = true;
 
-	for(auto &m_FileJob : m_FileJobs)
-		if(m_FileJob.second)
-			Success &= MoveFile(m_FileJob.first.c_str());
+	for(auto &FileJob : m_FileJobs)
+		if(FileJob.second)
+			Success &= MoveFile(FileJob.first.c_str());
 
 	if(m_ClientUpdate)
 		Success &= ReplaceClient();

--- a/src/engine/server/authmanager.cpp
+++ b/src/engine/server/authmanager.cpp
@@ -66,15 +66,15 @@ int CAuthManager::AddKey(const char *pIdent, const char *pPw, int AuthLevel)
 int CAuthManager::RemoveKey(int Slot)
 {
 	m_aKeys.remove_index_fast(Slot);
-	for(int i = 0; i < (int)(sizeof(m_aDefault) / sizeof(m_aDefault[0])); i++)
+	for(int &i : m_aDefault)
 	{
-		if(m_aDefault[i] == Slot)
+		if(i == Slot)
 		{
-			m_aDefault[i] = -1;
+			i = -1;
 		}
-		else if(m_aDefault[i] == m_aKeys.size())
+		else if(i == m_aKeys.size())
 		{
-			m_aDefault[i] = Slot;
+			i = Slot;
 		}
 	}
 	return m_aKeys.size();

--- a/src/engine/server/authmanager.cpp
+++ b/src/engine/server/authmanager.cpp
@@ -66,15 +66,15 @@ int CAuthManager::AddKey(const char *pIdent, const char *pPw, int AuthLevel)
 int CAuthManager::RemoveKey(int Slot)
 {
 	m_aKeys.remove_index_fast(Slot);
-	for(int &i : m_aDefault)
+	for(int &Default : m_aDefault)
 	{
-		if(i == Slot)
+		if(Default == Slot)
 		{
-			i = -1;
+			Default = -1;
 		}
-		else if(i == m_aKeys.size())
+		else if(Default == m_aKeys.size())
 		{
-			i = Slot;
+			Default = Slot;
 		}
 	}
 	return m_aKeys.size();

--- a/src/engine/server/register.cpp
+++ b/src/engine/server/register.cpp
@@ -32,13 +32,13 @@ CRegister::CRegister(bool Sixup)
 void CRegister::FeedToken(NETADDR Addr, SECURITY_TOKEN ResponseToken)
 {
 	Addr.port = 0;
-	for(int i = 0; i < IMasterServer::MAX_MASTERSERVERS; i++)
+	for(auto &i : m_aMasterserverInfo)
 	{
-		NETADDR Addr2 = m_aMasterserverInfo[i].m_Addr;
+		NETADDR Addr2 = i.m_Addr;
 		Addr2.port = 0;
 		if(net_addr_comp(&Addr, &Addr2) == 0)
 		{
-			m_aMasterserverInfo[i].m_Token = ResponseToken;
+			i.m_Token = ResponseToken;
 			break;
 		}
 	}
@@ -108,11 +108,11 @@ void CRegister::RegisterGotCount(CNetChunk *pChunk)
 	unsigned char *pData = (unsigned char *)pChunk->m_pData;
 	int Count = (pData[sizeof(SERVERBROWSE_COUNT)] << 8) | pData[sizeof(SERVERBROWSE_COUNT) + 1];
 
-	for(int i = 0; i < IMasterServer::MAX_MASTERSERVERS; i++)
+	for(auto &i : m_aMasterserverInfo)
 	{
-		if(net_addr_comp(&m_aMasterserverInfo[i].m_Addr, &pChunk->m_Address) == 0)
+		if(net_addr_comp(&i.m_Addr, &pChunk->m_Address) == 0)
 		{
-			m_aMasterserverInfo[i].m_Count = Count;
+			i.m_Count = Count;
 			break;
 		}
 	}
@@ -183,21 +183,21 @@ void CRegister::RegisterUpdate(int Nettype)
 	else if(m_RegisterState == REGISTERSTATE_QUERY_COUNT)
 	{
 		int Left = 0;
-		for(int i = 0; i < IMasterServer::MAX_MASTERSERVERS; i++)
+		for(auto &i : m_aMasterserverInfo)
 		{
-			if(!m_aMasterserverInfo[i].m_Valid)
+			if(!i.m_Valid)
 				continue;
 
-			if(m_aMasterserverInfo[i].m_Count == -1)
+			if(i.m_Count == -1)
 			{
 				Left++;
-				if(m_aMasterserverInfo[i].m_LastSend + Freq < Now)
+				if(i.m_LastSend + Freq < Now)
 				{
-					m_aMasterserverInfo[i].m_LastSend = Now;
-					if(m_Sixup && m_aMasterserverInfo[i].m_Token == NET_SECURITY_TOKEN_UNKNOWN)
-						m_pNetServer->SendTokenSixup(m_aMasterserverInfo[i].m_Addr, NET_SECURITY_TOKEN_UNKNOWN);
+					i.m_LastSend = Now;
+					if(m_Sixup && i.m_Token == NET_SECURITY_TOKEN_UNKNOWN)
+						m_pNetServer->SendTokenSixup(i.m_Addr, NET_SECURITY_TOKEN_UNKNOWN);
 					else
-						RegisterSendCountRequest(m_aMasterserverInfo[i].m_Addr, m_aMasterserverInfo[i].m_Token);
+						RegisterSendCountRequest(i.m_Addr, i.m_Token);
 				}
 			}
 		}
@@ -280,9 +280,9 @@ int CRegister::RegisterProcessPacket(CNetChunk *pPacket, SECURITY_TOKEN Response
 {
 	// check for masterserver address
 	bool Valid = false;
-	for(int i = 0; i < IMasterServer::MAX_MASTERSERVERS; i++)
+	for(auto &i : m_aMasterserverInfo)
 	{
-		if(net_addr_comp_noport(&pPacket->m_Address, &m_aMasterserverInfo[i].m_Addr) == 0)
+		if(net_addr_comp_noport(&pPacket->m_Address, &i.m_Addr) == 0)
 		{
 			Valid = true;
 			break;

--- a/src/engine/server/register.cpp
+++ b/src/engine/server/register.cpp
@@ -32,13 +32,13 @@ CRegister::CRegister(bool Sixup)
 void CRegister::FeedToken(NETADDR Addr, SECURITY_TOKEN ResponseToken)
 {
 	Addr.port = 0;
-	for(auto &i : m_aMasterserverInfo)
+	for(auto &MasterserverInfo : m_aMasterserverInfo)
 	{
-		NETADDR Addr2 = i.m_Addr;
+		NETADDR Addr2 = MasterserverInfo.m_Addr;
 		Addr2.port = 0;
 		if(net_addr_comp(&Addr, &Addr2) == 0)
 		{
-			i.m_Token = ResponseToken;
+			MasterserverInfo.m_Token = ResponseToken;
 			break;
 		}
 	}
@@ -108,11 +108,11 @@ void CRegister::RegisterGotCount(CNetChunk *pChunk)
 	unsigned char *pData = (unsigned char *)pChunk->m_pData;
 	int Count = (pData[sizeof(SERVERBROWSE_COUNT)] << 8) | pData[sizeof(SERVERBROWSE_COUNT) + 1];
 
-	for(auto &i : m_aMasterserverInfo)
+	for(auto &MasterserverInfo : m_aMasterserverInfo)
 	{
-		if(net_addr_comp(&i.m_Addr, &pChunk->m_Address) == 0)
+		if(net_addr_comp(&MasterserverInfo.m_Addr, &pChunk->m_Address) == 0)
 		{
-			i.m_Count = Count;
+			MasterserverInfo.m_Count = Count;
 			break;
 		}
 	}
@@ -183,21 +183,21 @@ void CRegister::RegisterUpdate(int Nettype)
 	else if(m_RegisterState == REGISTERSTATE_QUERY_COUNT)
 	{
 		int Left = 0;
-		for(auto &i : m_aMasterserverInfo)
+		for(auto &MasterserverInfo : m_aMasterserverInfo)
 		{
-			if(!i.m_Valid)
+			if(!MasterserverInfo.m_Valid)
 				continue;
 
-			if(i.m_Count == -1)
+			if(MasterserverInfo.m_Count == -1)
 			{
 				Left++;
-				if(i.m_LastSend + Freq < Now)
+				if(MasterserverInfo.m_LastSend + Freq < Now)
 				{
-					i.m_LastSend = Now;
-					if(m_Sixup && i.m_Token == NET_SECURITY_TOKEN_UNKNOWN)
-						m_pNetServer->SendTokenSixup(i.m_Addr, NET_SECURITY_TOKEN_UNKNOWN);
+					MasterserverInfo.m_LastSend = Now;
+					if(m_Sixup && MasterserverInfo.m_Token == NET_SECURITY_TOKEN_UNKNOWN)
+						m_pNetServer->SendTokenSixup(MasterserverInfo.m_Addr, NET_SECURITY_TOKEN_UNKNOWN);
 					else
-						RegisterSendCountRequest(i.m_Addr, i.m_Token);
+						RegisterSendCountRequest(MasterserverInfo.m_Addr, MasterserverInfo.m_Token);
 				}
 			}
 		}
@@ -280,9 +280,9 @@ int CRegister::RegisterProcessPacket(CNetChunk *pPacket, SECURITY_TOKEN Response
 {
 	// check for masterserver address
 	bool Valid = false;
-	for(auto &i : m_aMasterserverInfo)
+	for(auto &MasterserverInfo : m_aMasterserverInfo)
 	{
-		if(net_addr_comp_noport(&pPacket->m_Address, &i.m_Addr) == 0)
+		if(net_addr_comp_noport(&pPacket->m_Address, &MasterserverInfo.m_Addr) == 0)
 		{
 			Valid = true;
 			break;

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -269,8 +269,8 @@ void CServerBan::ConBanRegionRange(IConsole::IResult *pResult, void *pUser)
 void CServer::CClient::Reset()
 {
 	// reset input
-	for(int i = 0; i < 200; i++)
-		m_aInputs[i].m_GameTick = -1;
+	for(auto &m_aInput : m_aInputs)
+		m_aInput.m_GameTick = -1;
 	m_CurrentInput = 0;
 	mem_zero(&m_LatestInput, sizeof(m_LatestInput));
 
@@ -502,19 +502,19 @@ int64 CServer::TickStartTime(int Tick)
 
 int CServer::Init()
 {
-	for(int i = 0; i < MAX_CLIENTS; i++)
+	for(auto &m_aClient : m_aClients)
 	{
-		m_aClients[i].m_State = CClient::STATE_EMPTY;
-		m_aClients[i].m_aName[0] = 0;
-		m_aClients[i].m_aClan[0] = 0;
-		m_aClients[i].m_Country = -1;
-		m_aClients[i].m_Snapshots.Init();
-		m_aClients[i].m_Traffic = 0;
-		m_aClients[i].m_TrafficSince = 0;
-		m_aClients[i].m_ShowIps = false;
-		m_aClients[i].m_AuthKey = -1;
-		m_aClients[i].m_Latency = 0;
-		m_aClients[i].m_Sixup = false;
+		m_aClient.m_State = CClient::STATE_EMPTY;
+		m_aClient.m_aName[0] = 0;
+		m_aClient.m_aClan[0] = 0;
+		m_aClient.m_Country = -1;
+		m_aClient.m_Snapshots.Init();
+		m_aClient.m_Traffic = 0;
+		m_aClient.m_TrafficSince = 0;
+		m_aClient.m_ShowIps = false;
+		m_aClient.m_AuthKey = -1;
+		m_aClient.m_Latency = 0;
+		m_aClient.m_Sixup = false;
 	}
 
 	m_CurrentGameTick = 0;
@@ -641,9 +641,9 @@ int CServer::MaxClients() const
 int CServer::ClientCount()
 {
 	int ClientCount = 0;
-	for(int i = 0; i < MAX_CLIENTS; i++)
+	for(auto &m_aClient : m_aClients)
 	{
-		if(m_aClients[i].m_State != CClient::STATE_EMPTY)
+		if(m_aClient.m_State != CClient::STATE_EMPTY)
 		{
 			ClientCount++;
 		}
@@ -2533,9 +2533,9 @@ int CServer::Run()
 			{
 				for(int c = 0; c < MAX_CLIENTS; c++)
 					if(m_aClients[c].m_State == CClient::STATE_INGAME)
-						for(int i = 0; i < 200; i++)
-							if(m_aClients[c].m_aInputs[i].m_GameTick == Tick() + 1)
-								GameServer()->OnClientPredictedEarlyInput(c, m_aClients[c].m_aInputs[i].m_aData);
+						for(auto &m_aInput : m_aClients[c].m_aInputs)
+							if(m_aInput.m_GameTick == Tick() + 1)
+								GameServer()->OnClientPredictedEarlyInput(c, m_aInput.m_aData);
 
 				m_CurrentGameTick++;
 				NewTicks++;
@@ -2545,11 +2545,11 @@ int CServer::Run()
 				{
 					if(m_aClients[c].m_State != CClient::STATE_INGAME)
 						continue;
-					for(int i = 0; i < 200; i++)
+					for(auto &m_aInput : m_aClients[c].m_aInputs)
 					{
-						if(m_aClients[c].m_aInputs[i].m_GameTick == Tick())
+						if(m_aInput.m_GameTick == Tick())
 						{
-							GameServer()->OnClientPredictedInput(c, m_aClients[c].m_aInputs[i].m_aData);
+							GameServer()->OnClientPredictedInput(c, m_aInput.m_aData);
 							break;
 						}
 					}
@@ -2590,8 +2590,8 @@ int CServer::Run()
 
 			NonActive = true;
 
-			for(int c = 0; c < MAX_CLIENTS; c++)
-				if(m_aClients[c].m_State != CClient::STATE_EMPTY)
+			for(auto &m_aClient : m_aClients)
+				if(m_aClient.m_State != CClient::STATE_EMPTY)
 					NonActive = false;
 
 			// wait for incoming data
@@ -2647,8 +2647,8 @@ int CServer::Run()
 	GameServer()->OnShutdown();
 	m_pMap->Unload();
 
-	for(int i = 0; i < 2; i++)
-		free(m_apCurrentMapData[i]);
+	for(auto &i : m_apCurrentMapData)
+		free(i);
 
 	DbPool()->OnShutdown();
 	delete m_pConnectionPool;
@@ -2760,9 +2760,9 @@ void CServer::AuthRemoveKey(int KeySlot)
 	// Update indices.
 	if(OldKeySlot != NewKeySlot)
 	{
-		for(int i = 0; i < MAX_CLIENTS; i++)
-			if(m_aClients[i].m_AuthKey == OldKeySlot)
-				m_aClients[i].m_AuthKey = NewKeySlot;
+		for(auto &m_aClient : m_aClients)
+			if(m_aClient.m_AuthKey == OldKeySlot)
+				m_aClient.m_AuthKey = NewKeySlot;
 	}
 }
 

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -269,8 +269,8 @@ void CServerBan::ConBanRegionRange(IConsole::IResult *pResult, void *pUser)
 void CServer::CClient::Reset()
 {
 	// reset input
-	for(auto &m_aInput : m_aInputs)
-		m_aInput.m_GameTick = -1;
+	for(auto &Input : m_aInputs)
+		Input.m_GameTick = -1;
 	m_CurrentInput = 0;
 	mem_zero(&m_LatestInput, sizeof(m_LatestInput));
 
@@ -502,19 +502,19 @@ int64 CServer::TickStartTime(int Tick)
 
 int CServer::Init()
 {
-	for(auto &m_aClient : m_aClients)
+	for(auto &Client : m_aClients)
 	{
-		m_aClient.m_State = CClient::STATE_EMPTY;
-		m_aClient.m_aName[0] = 0;
-		m_aClient.m_aClan[0] = 0;
-		m_aClient.m_Country = -1;
-		m_aClient.m_Snapshots.Init();
-		m_aClient.m_Traffic = 0;
-		m_aClient.m_TrafficSince = 0;
-		m_aClient.m_ShowIps = false;
-		m_aClient.m_AuthKey = -1;
-		m_aClient.m_Latency = 0;
-		m_aClient.m_Sixup = false;
+		Client.m_State = CClient::STATE_EMPTY;
+		Client.m_aName[0] = 0;
+		Client.m_aClan[0] = 0;
+		Client.m_Country = -1;
+		Client.m_Snapshots.Init();
+		Client.m_Traffic = 0;
+		Client.m_TrafficSince = 0;
+		Client.m_ShowIps = false;
+		Client.m_AuthKey = -1;
+		Client.m_Latency = 0;
+		Client.m_Sixup = false;
 	}
 
 	m_CurrentGameTick = 0;
@@ -641,9 +641,9 @@ int CServer::MaxClients() const
 int CServer::ClientCount()
 {
 	int ClientCount = 0;
-	for(auto &m_aClient : m_aClients)
+	for(auto &Client : m_aClients)
 	{
-		if(m_aClient.m_State != CClient::STATE_EMPTY)
+		if(Client.m_State != CClient::STATE_EMPTY)
 		{
 			ClientCount++;
 		}
@@ -2533,9 +2533,9 @@ int CServer::Run()
 			{
 				for(int c = 0; c < MAX_CLIENTS; c++)
 					if(m_aClients[c].m_State == CClient::STATE_INGAME)
-						for(auto &m_aInput : m_aClients[c].m_aInputs)
-							if(m_aInput.m_GameTick == Tick() + 1)
-								GameServer()->OnClientPredictedEarlyInput(c, m_aInput.m_aData);
+						for(auto &Input : m_aClients[c].m_aInputs)
+							if(Input.m_GameTick == Tick() + 1)
+								GameServer()->OnClientPredictedEarlyInput(c, Input.m_aData);
 
 				m_CurrentGameTick++;
 				NewTicks++;
@@ -2545,11 +2545,11 @@ int CServer::Run()
 				{
 					if(m_aClients[c].m_State != CClient::STATE_INGAME)
 						continue;
-					for(auto &m_aInput : m_aClients[c].m_aInputs)
+					for(auto &Input : m_aClients[c].m_aInputs)
 					{
-						if(m_aInput.m_GameTick == Tick())
+						if(Input.m_GameTick == Tick())
 						{
-							GameServer()->OnClientPredictedInput(c, m_aInput.m_aData);
+							GameServer()->OnClientPredictedInput(c, Input.m_aData);
 							break;
 						}
 					}
@@ -2590,8 +2590,8 @@ int CServer::Run()
 
 			NonActive = true;
 
-			for(auto &m_aClient : m_aClients)
-				if(m_aClient.m_State != CClient::STATE_EMPTY)
+			for(auto &Client : m_aClients)
+				if(Client.m_State != CClient::STATE_EMPTY)
 					NonActive = false;
 
 			// wait for incoming data
@@ -2647,8 +2647,8 @@ int CServer::Run()
 	GameServer()->OnShutdown();
 	m_pMap->Unload();
 
-	for(auto &i : m_apCurrentMapData)
-		free(i);
+	for(auto &pCurrentMapData : m_apCurrentMapData)
+		free(pCurrentMapData);
 
 	DbPool()->OnShutdown();
 	delete m_pConnectionPool;
@@ -2760,9 +2760,9 @@ void CServer::AuthRemoveKey(int KeySlot)
 	// Update indices.
 	if(OldKeySlot != NewKeySlot)
 	{
-		for(auto &m_aClient : m_aClients)
-			if(m_aClient.m_AuthKey == OldKeySlot)
-				m_aClient.m_AuthKey = NewKeySlot;
+		for(auto &Client : m_aClients)
+			if(Client.m_AuthKey == OldKeySlot)
+				Client.m_AuthKey = NewKeySlot;
 	}
 }
 

--- a/src/engine/shared/datafile.cpp
+++ b/src/engine/shared/datafile.cpp
@@ -549,9 +549,9 @@ SHA256_DIGEST CDataFileReader::Sha256()
 	if(!m_pDataFile)
 	{
 		SHA256_DIGEST Result;
-		for(unsigned char &i : Result.data)
+		for(unsigned char &d : Result.data)
 		{
-			i = 0xff;
+			d = 0xff;
 		}
 		return Result;
 	}

--- a/src/engine/shared/datafile.cpp
+++ b/src/engine/shared/datafile.cpp
@@ -549,9 +549,9 @@ SHA256_DIGEST CDataFileReader::Sha256()
 	if(!m_pDataFile)
 	{
 		SHA256_DIGEST Result;
-		for(unsigned i = 0; i < sizeof(Result.data); i++)
+		for(unsigned char &i : Result.data)
 		{
-			Result.data[i] = 0xff;
+			i = 0xff;
 		}
 		return Result;
 	}

--- a/src/engine/shared/econ.cpp
+++ b/src/engine/shared/econ.cpp
@@ -63,8 +63,8 @@ void CEcon::Init(IConsole *pConsole, CNetBan *pNetBan)
 {
 	m_pConsole = pConsole;
 
-	for(auto &m_aClient : m_aClients)
-		m_aClient.m_State = CClient::STATE_EMPTY;
+	for(auto &Client : m_aClients)
+		Client.m_State = CClient::STATE_EMPTY;
 
 	m_Ready = false;
 	m_UserClientID = -1;

--- a/src/engine/shared/econ.cpp
+++ b/src/engine/shared/econ.cpp
@@ -63,8 +63,8 @@ void CEcon::Init(IConsole *pConsole, CNetBan *pNetBan)
 {
 	m_pConsole = pConsole;
 
-	for(int i = 0; i < NET_MAX_CONSOLE_CLIENTS; i++)
-		m_aClients[i].m_State = CClient::STATE_EMPTY;
+	for(auto &m_aClient : m_aClients)
+		m_aClient.m_State = CClient::STATE_EMPTY;
 
 	m_Ready = false;
 	m_UserClientID = -1;

--- a/src/engine/shared/masterserver.cpp
+++ b/src/engine/shared/masterserver.cpp
@@ -168,11 +168,11 @@ public:
 			{
 				Info.m_Addr.port = 8300;
 				bool Added = false;
-				for(auto &m_aMasterServer : m_aMasterServers)
+				for(auto &MasterServer : m_aMasterServers)
 				{
-					if(str_comp(m_aMasterServer.m_aHostname, Info.m_aHostname) == 0)
+					if(str_comp(MasterServer.m_aHostname, Info.m_aHostname) == 0)
 					{
-						m_aMasterServer = Info;
+						MasterServer = Info;
 						Added = true;
 						break;
 					}
@@ -180,11 +180,11 @@ public:
 
 				if(!Added)
 				{
-					for(auto &m_aMasterServer : m_aMasterServers)
+					for(auto &MasterServer : m_aMasterServers)
 					{
-						if(m_aMasterServer.m_Addr.type == NETTYPE_INVALID)
+						if(MasterServer.m_Addr.type == NETTYPE_INVALID)
 						{
-							m_aMasterServer = Info;
+							MasterServer = Info;
 							Added = true;
 							break;
 						}
@@ -210,15 +210,15 @@ public:
 		if(!File)
 			return -1;
 
-		for(auto &m_aMasterServer : m_aMasterServers)
+		for(auto &MasterServer : m_aMasterServers)
 		{
 			char aAddrStr[NETADDR_MAXSTRSIZE];
-			if(m_aMasterServer.m_Addr.type != NETTYPE_INVALID)
-				net_addr_str(&m_aMasterServer.m_Addr, aAddrStr, sizeof(aAddrStr), true);
+			if(MasterServer.m_Addr.type != NETTYPE_INVALID)
+				net_addr_str(&MasterServer.m_Addr, aAddrStr, sizeof(aAddrStr), true);
 			else
 				aAddrStr[0] = 0;
 			char aBuf[256];
-			str_format(aBuf, sizeof(aBuf), "%s %s", m_aMasterServer.m_aHostname, aAddrStr);
+			str_format(aBuf, sizeof(aBuf), "%s %s", MasterServer.m_aHostname, aAddrStr);
 			io_write(File, aBuf, str_length(aBuf));
 			io_write_newline(File);
 		}

--- a/src/engine/shared/masterserver.cpp
+++ b/src/engine/shared/masterserver.cpp
@@ -168,11 +168,11 @@ public:
 			{
 				Info.m_Addr.port = 8300;
 				bool Added = false;
-				for(int i = 0; i < MAX_MASTERSERVERS; ++i)
+				for(auto &m_aMasterServer : m_aMasterServers)
 				{
-					if(str_comp(m_aMasterServers[i].m_aHostname, Info.m_aHostname) == 0)
+					if(str_comp(m_aMasterServer.m_aHostname, Info.m_aHostname) == 0)
 					{
-						m_aMasterServers[i] = Info;
+						m_aMasterServer = Info;
 						Added = true;
 						break;
 					}
@@ -180,11 +180,11 @@ public:
 
 				if(!Added)
 				{
-					for(int i = 0; i < MAX_MASTERSERVERS; ++i)
+					for(auto &m_aMasterServer : m_aMasterServers)
 					{
-						if(m_aMasterServers[i].m_Addr.type == NETTYPE_INVALID)
+						if(m_aMasterServer.m_Addr.type == NETTYPE_INVALID)
 						{
-							m_aMasterServers[i] = Info;
+							m_aMasterServer = Info;
 							Added = true;
 							break;
 						}
@@ -210,15 +210,15 @@ public:
 		if(!File)
 			return -1;
 
-		for(int i = 0; i < MAX_MASTERSERVERS; i++)
+		for(auto &m_aMasterServer : m_aMasterServers)
 		{
 			char aAddrStr[NETADDR_MAXSTRSIZE];
-			if(m_aMasterServers[i].m_Addr.type != NETTYPE_INVALID)
-				net_addr_str(&m_aMasterServers[i].m_Addr, aAddrStr, sizeof(aAddrStr), true);
+			if(m_aMasterServer.m_Addr.type != NETTYPE_INVALID)
+				net_addr_str(&m_aMasterServer.m_Addr, aAddrStr, sizeof(aAddrStr), true);
 			else
 				aAddrStr[0] = 0;
 			char aBuf[256];
-			str_format(aBuf, sizeof(aBuf), "%s %s", m_aMasterServers[i].m_aHostname, aAddrStr);
+			str_format(aBuf, sizeof(aBuf), "%s %s", m_aMasterServer.m_aHostname, aAddrStr);
 			io_write(File, aBuf, str_length(aBuf));
 			io_write_newline(File);
 		}

--- a/src/engine/shared/network_console.cpp
+++ b/src/engine/shared/network_console.cpp
@@ -24,8 +24,8 @@ bool CNetConsole::Open(NETADDR BindAddr, CNetBan *pNetBan, int Flags)
 		return false;
 	net_set_non_blocking(m_Socket);
 
-	for(auto &m_aSlot : m_aSlots)
-		m_aSlot.m_Connection.Reset();
+	for(auto &Slot : m_aSlots)
+		Slot.m_Connection.Reset();
 
 	return true;
 }
@@ -39,8 +39,8 @@ void CNetConsole::SetCallbacks(NETFUNC_NEWCLIENT_CON pfnNewClient, NETFUNC_DELCL
 
 int CNetConsole::Close()
 {
-	for(auto &m_aSlot : m_aSlots)
-		m_aSlot.m_Connection.Disconnect("closing console");
+	for(auto &Slot : m_aSlots)
+		Slot.m_Connection.Disconnect("closing console");
 
 	net_tcp_close(m_Socket);
 

--- a/src/engine/shared/network_console.cpp
+++ b/src/engine/shared/network_console.cpp
@@ -24,8 +24,8 @@ bool CNetConsole::Open(NETADDR BindAddr, CNetBan *pNetBan, int Flags)
 		return false;
 	net_set_non_blocking(m_Socket);
 
-	for(int i = 0; i < NET_MAX_CONSOLE_CLIENTS; i++)
-		m_aSlots[i].m_Connection.Reset();
+	for(auto &m_aSlot : m_aSlots)
+		m_aSlot.m_Connection.Reset();
 
 	return true;
 }
@@ -39,8 +39,8 @@ void CNetConsole::SetCallbacks(NETFUNC_NEWCLIENT_CON pfnNewClient, NETFUNC_DELCL
 
 int CNetConsole::Close()
 {
-	for(int i = 0; i < NET_MAX_CONSOLE_CLIENTS; i++)
-		m_aSlots[i].m_Connection.Disconnect("closing console");
+	for(auto &m_aSlot : m_aSlots)
+		m_aSlot.m_Connection.Disconnect("closing console");
 
 	net_tcp_close(m_Socket);
 

--- a/src/engine/shared/network_server.cpp
+++ b/src/engine/shared/network_server.cpp
@@ -76,8 +76,8 @@ bool CNetServer::Open(NETADDR BindAddr, CNetBan *pNetBan, int MaxClients, int Ma
 
 	secure_random_fill(m_SecurityTokenSeed, sizeof(m_SecurityTokenSeed));
 
-	for(auto &m_aSlot : m_aSlots)
-		m_aSlot.m_Connection.Init(m_Socket, true);
+	for(auto &Slot : m_aSlots)
+		Slot.m_Connection.Init(m_Socket, true);
 
 	net_init_mmsgs(&m_MMSGS);
 

--- a/src/engine/shared/network_server.cpp
+++ b/src/engine/shared/network_server.cpp
@@ -76,8 +76,8 @@ bool CNetServer::Open(NETADDR BindAddr, CNetBan *pNetBan, int MaxClients, int Ma
 
 	secure_random_fill(m_SecurityTokenSeed, sizeof(m_SecurityTokenSeed));
 
-	for(int i = 0; i < NET_MAX_CLIENTS; i++)
-		m_aSlots[i].m_Connection.Init(m_Socket, true);
+	for(auto &m_aSlot : m_aSlots)
+		m_aSlot.m_Connection.Init(m_Socket, true);
 
 	net_init_mmsgs(&m_MMSGS);
 

--- a/src/game/client/components/binds.cpp
+++ b/src/game/client/components/binds.cpp
@@ -33,9 +33,9 @@ CBinds::CBinds()
 CBinds::~CBinds()
 {
 	for(int i = 0; i < KEY_LAST; i++)
-		for(auto &m_aapKeyBinding : m_aapKeyBindings)
-			if(m_aapKeyBinding[i])
-				free(m_aapKeyBinding[i]);
+		for(auto &apKeyBinding : m_aapKeyBindings)
+			if(apKeyBinding[i])
+				free(apKeyBinding[i]);
 }
 
 void CBinds::Bind(int KeyID, const char *pStr, bool FreeOnly, int Modifier)
@@ -158,13 +158,13 @@ bool CBinds::OnInput(IInput::CEvent e)
 
 void CBinds::UnbindAll()
 {
-	for(auto &m_aapKeyBinding : m_aapKeyBindings)
+	for(auto &apKeyBinding : m_aapKeyBindings)
 	{
-		for(auto & j : m_aapKeyBinding)
+		for(auto &pKeyBinding : apKeyBinding)
 		{
-			if(j)
-				free(j);
-			j = 0;
+			if(pKeyBinding)
+				free(pKeyBinding);
+			pKeyBinding = 0;
 		}
 	}
 }

--- a/src/game/client/components/binds.cpp
+++ b/src/game/client/components/binds.cpp
@@ -33,9 +33,9 @@ CBinds::CBinds()
 CBinds::~CBinds()
 {
 	for(int i = 0; i < KEY_LAST; i++)
-		for(int j = 0; j < MODIFIER_COMBINATION_COUNT; j++)
-			if(m_aapKeyBindings[j][i])
-				free(m_aapKeyBindings[j][i]);
+		for(auto &m_aapKeyBinding : m_aapKeyBindings)
+			if(m_aapKeyBinding[i])
+				free(m_aapKeyBinding[i]);
 }
 
 void CBinds::Bind(int KeyID, const char *pStr, bool FreeOnly, int Modifier)
@@ -158,13 +158,13 @@ bool CBinds::OnInput(IInput::CEvent e)
 
 void CBinds::UnbindAll()
 {
-	for(int i = 0; i < MODIFIER_COMBINATION_COUNT; i++)
+	for(auto &m_aapKeyBinding : m_aapKeyBindings)
 	{
-		for(int j = 0; j < KEY_LAST; j++)
+		for(auto & j : m_aapKeyBinding)
 		{
-			if(m_aapKeyBindings[i][j])
-				free(m_aapKeyBindings[i][j]);
-			m_aapKeyBindings[i][j] = 0;
+			if(j)
+				free(j);
+			j = 0;
 		}
 	}
 }

--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -27,11 +27,11 @@
 
 CChat::CChat()
 {
-	for(auto &m_aLine : m_aLines)
+	for(auto &Line : m_aLines)
 	{
 		// reset the container indices, so the text containers can be deleted on reset
-		m_aLine.m_TextContainerIndex = -1;
-		m_aLine.m_QuadContainerIndex = -1;
+		Line.m_TextContainerIndex = -1;
+		Line.m_QuadContainerIndex = -1;
 	}
 
 #define CHAT_COMMAND(name, params, flags, callback, userdata, help) RegisterCommand(name, params, flags, help);
@@ -49,17 +49,17 @@ void CChat::RegisterCommand(const char *pName, const char *pParams, int flags, c
 
 void CChat::RebuildChat()
 {
-	for(auto &m_aLine : m_aLines)
+	for(auto &Line : m_aLines)
 	{
-		if(m_aLine.m_TextContainerIndex != -1)
-			TextRender()->DeleteTextContainer(m_aLine.m_TextContainerIndex);
-		m_aLine.m_TextContainerIndex = -1;
-		if(m_aLine.m_QuadContainerIndex != -1)
-			Graphics()->DeleteQuadContainer(m_aLine.m_QuadContainerIndex);
-		m_aLine.m_QuadContainerIndex = -1;
+		if(Line.m_TextContainerIndex != -1)
+			TextRender()->DeleteTextContainer(Line.m_TextContainerIndex);
+		Line.m_TextContainerIndex = -1;
+		if(Line.m_QuadContainerIndex != -1)
+			Graphics()->DeleteQuadContainer(Line.m_QuadContainerIndex);
+		Line.m_QuadContainerIndex = -1;
 		// recalculate sizes
-		m_aLine.m_YOffset[0] = -1.f;
-		m_aLine.m_YOffset[1] = -1.f;
+		Line.m_YOffset[0] = -1.f;
+		Line.m_YOffset[1] = -1.f;
 	}
 }
 
@@ -70,20 +70,20 @@ void CChat::OnWindowResize()
 
 void CChat::Reset()
 {
-	for(auto &m_aLine : m_aLines)
+	for(auto &Line : m_aLines)
 	{
-		if(m_aLine.m_TextContainerIndex != -1)
-			TextRender()->DeleteTextContainer(m_aLine.m_TextContainerIndex);
-		if(m_aLine.m_QuadContainerIndex != -1)
-			Graphics()->DeleteQuadContainer(m_aLine.m_QuadContainerIndex);
-		m_aLine.m_Time = 0;
-		m_aLine.m_aText[0] = 0;
-		m_aLine.m_aName[0] = 0;
-		m_aLine.m_Friend = false;
-		m_aLine.m_TextContainerIndex = -1;
-		m_aLine.m_QuadContainerIndex = -1;
-		m_aLine.m_TimesRepeated = 0;
-		m_aLine.m_HasRenderTee = false;
+		if(Line.m_TextContainerIndex != -1)
+			TextRender()->DeleteTextContainer(Line.m_TextContainerIndex);
+		if(Line.m_QuadContainerIndex != -1)
+			Graphics()->DeleteQuadContainer(Line.m_QuadContainerIndex);
+		Line.m_Time = 0;
+		Line.m_aText[0] = 0;
+		Line.m_aName[0] = 0;
+		Line.m_Friend = false;
+		Line.m_TextContainerIndex = -1;
+		Line.m_QuadContainerIndex = -1;
+		Line.m_TimesRepeated = 0;
+		Line.m_HasRenderTee = false;
 	}
 	m_PrevScoreBoardShowed = false;
 	m_PrevShowChat = false;
@@ -102,8 +102,8 @@ void CChat::Reset()
 	m_CurrentLine = 0;
 	DisableMode();
 
-	for(long long &i : m_aLastSoundPlayed)
-		i = 0;
+	for(long long &LastSoundPlayed : m_aLastSoundPlayed)
+		LastSoundPlayed = 0;
 }
 
 void CChat::OnRelease()

--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -27,11 +27,11 @@
 
 CChat::CChat()
 {
-	for(int i = 0; i < MAX_LINES; i++)
+	for(auto &m_aLine : m_aLines)
 	{
 		// reset the container indices, so the text containers can be deleted on reset
-		m_aLines[i].m_TextContainerIndex = -1;
-		m_aLines[i].m_QuadContainerIndex = -1;
+		m_aLine.m_TextContainerIndex = -1;
+		m_aLine.m_QuadContainerIndex = -1;
 	}
 
 #define CHAT_COMMAND(name, params, flags, callback, userdata, help) RegisterCommand(name, params, flags, help);
@@ -49,17 +49,17 @@ void CChat::RegisterCommand(const char *pName, const char *pParams, int flags, c
 
 void CChat::RebuildChat()
 {
-	for(int i = 0; i < MAX_LINES; i++)
+	for(auto &m_aLine : m_aLines)
 	{
-		if(m_aLines[i].m_TextContainerIndex != -1)
-			TextRender()->DeleteTextContainer(m_aLines[i].m_TextContainerIndex);
-		m_aLines[i].m_TextContainerIndex = -1;
-		if(m_aLines[i].m_QuadContainerIndex != -1)
-			Graphics()->DeleteQuadContainer(m_aLines[i].m_QuadContainerIndex);
-		m_aLines[i].m_QuadContainerIndex = -1;
+		if(m_aLine.m_TextContainerIndex != -1)
+			TextRender()->DeleteTextContainer(m_aLine.m_TextContainerIndex);
+		m_aLine.m_TextContainerIndex = -1;
+		if(m_aLine.m_QuadContainerIndex != -1)
+			Graphics()->DeleteQuadContainer(m_aLine.m_QuadContainerIndex);
+		m_aLine.m_QuadContainerIndex = -1;
 		// recalculate sizes
-		m_aLines[i].m_YOffset[0] = -1.f;
-		m_aLines[i].m_YOffset[1] = -1.f;
+		m_aLine.m_YOffset[0] = -1.f;
+		m_aLine.m_YOffset[1] = -1.f;
 	}
 }
 
@@ -70,20 +70,20 @@ void CChat::OnWindowResize()
 
 void CChat::Reset()
 {
-	for(int i = 0; i < MAX_LINES; i++)
+	for(auto &m_aLine : m_aLines)
 	{
-		if(m_aLines[i].m_TextContainerIndex != -1)
-			TextRender()->DeleteTextContainer(m_aLines[i].m_TextContainerIndex);
-		if(m_aLines[i].m_QuadContainerIndex != -1)
-			Graphics()->DeleteQuadContainer(m_aLines[i].m_QuadContainerIndex);
-		m_aLines[i].m_Time = 0;
-		m_aLines[i].m_aText[0] = 0;
-		m_aLines[i].m_aName[0] = 0;
-		m_aLines[i].m_Friend = false;
-		m_aLines[i].m_TextContainerIndex = -1;
-		m_aLines[i].m_QuadContainerIndex = -1;
-		m_aLines[i].m_TimesRepeated = 0;
-		m_aLines[i].m_HasRenderTee = false;
+		if(m_aLine.m_TextContainerIndex != -1)
+			TextRender()->DeleteTextContainer(m_aLine.m_TextContainerIndex);
+		if(m_aLine.m_QuadContainerIndex != -1)
+			Graphics()->DeleteQuadContainer(m_aLine.m_QuadContainerIndex);
+		m_aLine.m_Time = 0;
+		m_aLine.m_aText[0] = 0;
+		m_aLine.m_aName[0] = 0;
+		m_aLine.m_Friend = false;
+		m_aLine.m_TextContainerIndex = -1;
+		m_aLine.m_QuadContainerIndex = -1;
+		m_aLine.m_TimesRepeated = 0;
+		m_aLine.m_HasRenderTee = false;
 	}
 	m_PrevScoreBoardShowed = false;
 	m_PrevShowChat = false;
@@ -102,8 +102,8 @@ void CChat::Reset()
 	m_CurrentLine = 0;
 	DisableMode();
 
-	for(int i = 0; i < CHAT_NUM; ++i)
-		m_aLastSoundPlayed[i] = 0;
+	for(long long &i : m_aLastSoundPlayed)
+		i = 0;
 }
 
 void CChat::OnRelease()

--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -71,8 +71,8 @@ void CControls::OnReset()
 	m_JoystickFirePressed = false;
 	m_JoystickRunPressed = false;
 	m_JoystickTapTime = 0;
-	for(int i = 0; i < NUM_WEAPONS; i++)
-		m_AmmoCount[i] = 0;
+	for(int &i : m_AmmoCount)
+		i = 0;
 	m_OldMouseX = m_OldMouseY = 0.0f;
 }
 
@@ -100,8 +100,8 @@ void CControls::OnPlayerDeath()
 {
 	if(g_Config.m_ClResetWantedWeaponOnDeath)
 		m_LastData[g_Config.m_ClDummy].m_WantedWeapon = m_InputData[g_Config.m_ClDummy].m_WantedWeapon = 0;
-	for(int i = 0; i < NUM_WEAPONS; i++)
-		m_AmmoCount[i] = 0;
+	for(int &i : m_AmmoCount)
+		i = 0;
 	m_JoystickTapTime = 0; // Do not launch hook on first tap
 }
 

--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -71,8 +71,8 @@ void CControls::OnReset()
 	m_JoystickFirePressed = false;
 	m_JoystickRunPressed = false;
 	m_JoystickTapTime = 0;
-	for(int &i : m_AmmoCount)
-		i = 0;
+	for(int &AmmoCount : m_AmmoCount)
+		AmmoCount = 0;
 	m_OldMouseX = m_OldMouseY = 0.0f;
 }
 
@@ -100,8 +100,8 @@ void CControls::OnPlayerDeath()
 {
 	if(g_Config.m_ClResetWantedWeaponOnDeath)
 		m_LastData[g_Config.m_ClDummy].m_WantedWeapon = m_InputData[g_Config.m_ClDummy].m_WantedWeapon = 0;
-	for(int &i : m_AmmoCount)
-		i = 0;
+	for(int &AmmoCount : m_AmmoCount)
+		AmmoCount = 0;
 	m_JoystickTapTime = 0; // Do not launch hook on first tap
 }
 

--- a/src/game/client/components/countryflags.cpp
+++ b/src/game/client/components/countryflags.cpp
@@ -102,8 +102,8 @@ void CCountryFlags::LoadCountryflagsIndexfile()
 
 	// init LUT
 	if(DefaultIndex != 0)
-		for(int &i : m_CodeIndexLUT)
-			i = DefaultIndex;
+		for(int &CodeIndexLUT : m_CodeIndexLUT)
+			CodeIndexLUT = DefaultIndex;
 	else
 		mem_zero(m_CodeIndexLUT, sizeof(m_CodeIndexLUT));
 	for(int i = 0; i < m_aCountryFlags.size(); ++i)

--- a/src/game/client/components/countryflags.cpp
+++ b/src/game/client/components/countryflags.cpp
@@ -102,8 +102,8 @@ void CCountryFlags::LoadCountryflagsIndexfile()
 
 	// init LUT
 	if(DefaultIndex != 0)
-		for(int i = 0; i < CODE_RANGE; ++i)
-			m_CodeIndexLUT[i] = DefaultIndex;
+		for(int &i : m_CodeIndexLUT)
+			i = DefaultIndex;
 	else
 		mem_zero(m_CodeIndexLUT, sizeof(m_CodeIndexLUT));
 	for(int i = 0; i < m_aCountryFlags.size(); ++i)

--- a/src/game/client/components/ghost.cpp
+++ b/src/game/client/components/ghost.cpp
@@ -78,8 +78,8 @@ CGhost::CGhostPath &CGhost::CGhostPath::operator=(CGhostPath &&Other)
 
 void CGhost::CGhostPath::Reset(int ChunkSize)
 {
-	for(unsigned i = 0; i < m_lChunks.size(); i++)
-		free(m_lChunks[i]);
+	for(auto &m_lChunk : m_lChunks)
+		free(m_lChunk);
 	m_lChunks.clear();
 	m_ChunkSize = ChunkSize;
 	m_NumItems = 0;
@@ -167,8 +167,8 @@ int CGhost::GetSlot() const
 int CGhost::FreeSlots() const
 {
 	int Num = 0;
-	for(int i = 0; i < MAX_ACTIVE_GHOSTS; i++)
-		if(m_aActiveGhosts[i].Empty())
+	for(const auto &m_aActiveGhost : m_aActiveGhosts)
+		if(m_aActiveGhost.Empty())
 			Num++;
 	return Num;
 }
@@ -308,9 +308,9 @@ void CGhost::OnRender()
 
 	int PlaybackTick = Client()->PredGameTick(g_Config.m_ClDummy) - m_StartRenderTick;
 
-	for(int i = 0; i < MAX_ACTIVE_GHOSTS; i++)
+	for(auto &m_aActiveGhost : m_aActiveGhosts)
 	{
-		CGhostItem *pGhost = &m_aActiveGhosts[i];
+		CGhostItem *pGhost = &m_aActiveGhost;
 		if(pGhost->Empty())
 			continue;
 
@@ -431,8 +431,8 @@ void CGhost::StartRender(int Tick)
 {
 	m_Rendering = true;
 	m_StartRenderTick = Tick;
-	for(int i = 0; i < MAX_ACTIVE_GHOSTS; i++)
-		m_aActiveGhosts[i].m_PlaybackPos = 0;
+	for(auto &m_aActiveGhost : m_aActiveGhosts)
+		m_aActiveGhost.m_PlaybackPos = 0;
 }
 
 void CGhost::StopRender()
@@ -632,12 +632,12 @@ int CGhost::GetLastRaceTick()
 void CGhost::RefindSkin()
 {
 	char aSkinName[64];
-	for(int i = 0; i < (int)(sizeof(m_aActiveGhosts) / sizeof(m_aActiveGhosts[0])); ++i)
+	for(auto &m_aActiveGhost : m_aActiveGhosts)
 	{
-		IntsToStr(&m_aActiveGhosts[i].m_Skin.m_Skin0, 6, aSkinName);
+		IntsToStr(&m_aActiveGhost.m_Skin.m_Skin0, 6, aSkinName);
 		if(aSkinName[0] != '\0')
 		{
-			CTeeRenderInfo *pRenderInfo = &m_aActiveGhosts[i].m_RenderInfo;
+			CTeeRenderInfo *pRenderInfo = &m_aActiveGhost.m_RenderInfo;
 
 			int SkinId = m_pClient->m_pSkins->Find(aSkinName);
 			const CSkin *pSkin = m_pClient->m_pSkins->Get(SkinId);

--- a/src/game/client/components/killmessages.cpp
+++ b/src/game/client/components/killmessages.cpp
@@ -12,30 +12,30 @@
 
 void CKillMessages::OnWindowResize()
 {
-	for(int i = 0; i < MAX_KILLMSGS; i++)
+	for(auto &m_aKillmsg : m_aKillmsgs)
 	{
-		if(m_aKillmsgs[i].m_VictimTextContainerIndex != -1)
-			TextRender()->DeleteTextContainer(m_aKillmsgs[i].m_VictimTextContainerIndex);
-		if(m_aKillmsgs[i].m_KillerTextContainerIndex != -1)
-			TextRender()->DeleteTextContainer(m_aKillmsgs[i].m_KillerTextContainerIndex);
-		m_aKillmsgs[i].m_VictimTextContainerIndex = m_aKillmsgs[i].m_KillerTextContainerIndex = -1;
+		if(m_aKillmsg.m_VictimTextContainerIndex != -1)
+			TextRender()->DeleteTextContainer(m_aKillmsg.m_VictimTextContainerIndex);
+		if(m_aKillmsg.m_KillerTextContainerIndex != -1)
+			TextRender()->DeleteTextContainer(m_aKillmsg.m_KillerTextContainerIndex);
+		m_aKillmsg.m_VictimTextContainerIndex = m_aKillmsg.m_KillerTextContainerIndex = -1;
 	}
 }
 
 void CKillMessages::OnReset()
 {
 	m_KillmsgCurrent = 0;
-	for(int i = 0; i < MAX_KILLMSGS; i++)
+	for(auto &m_aKillmsg : m_aKillmsgs)
 	{
-		m_aKillmsgs[i].m_Tick = -100000;
+		m_aKillmsg.m_Tick = -100000;
 
-		if(m_aKillmsgs[i].m_VictimTextContainerIndex != -1)
-			TextRender()->DeleteTextContainer(m_aKillmsgs[i].m_VictimTextContainerIndex);
+		if(m_aKillmsg.m_VictimTextContainerIndex != -1)
+			TextRender()->DeleteTextContainer(m_aKillmsg.m_VictimTextContainerIndex);
 
-		if(m_aKillmsgs[i].m_KillerTextContainerIndex != -1)
-			TextRender()->DeleteTextContainer(m_aKillmsgs[i].m_KillerTextContainerIndex);
+		if(m_aKillmsg.m_KillerTextContainerIndex != -1)
+			TextRender()->DeleteTextContainer(m_aKillmsg.m_KillerTextContainerIndex);
 
-		m_aKillmsgs[i].m_VictimTextContainerIndex = m_aKillmsgs[i].m_KillerTextContainerIndex = -1;
+		m_aKillmsg.m_VictimTextContainerIndex = m_aKillmsg.m_KillerTextContainerIndex = -1;
 	}
 }
 

--- a/src/game/client/components/killmessages.cpp
+++ b/src/game/client/components/killmessages.cpp
@@ -12,30 +12,30 @@
 
 void CKillMessages::OnWindowResize()
 {
-	for(auto &m_aKillmsg : m_aKillmsgs)
+	for(auto &Killmsg : m_aKillmsgs)
 	{
-		if(m_aKillmsg.m_VictimTextContainerIndex != -1)
-			TextRender()->DeleteTextContainer(m_aKillmsg.m_VictimTextContainerIndex);
-		if(m_aKillmsg.m_KillerTextContainerIndex != -1)
-			TextRender()->DeleteTextContainer(m_aKillmsg.m_KillerTextContainerIndex);
-		m_aKillmsg.m_VictimTextContainerIndex = m_aKillmsg.m_KillerTextContainerIndex = -1;
+		if(Killmsg.m_VictimTextContainerIndex != -1)
+			TextRender()->DeleteTextContainer(Killmsg.m_VictimTextContainerIndex);
+		if(Killmsg.m_KillerTextContainerIndex != -1)
+			TextRender()->DeleteTextContainer(Killmsg.m_KillerTextContainerIndex);
+		Killmsg.m_VictimTextContainerIndex = Killmsg.m_KillerTextContainerIndex = -1;
 	}
 }
 
 void CKillMessages::OnReset()
 {
 	m_KillmsgCurrent = 0;
-	for(auto &m_aKillmsg : m_aKillmsgs)
+	for(auto &Killmsg : m_aKillmsgs)
 	{
-		m_aKillmsg.m_Tick = -100000;
+		Killmsg.m_Tick = -100000;
 
-		if(m_aKillmsg.m_VictimTextContainerIndex != -1)
-			TextRender()->DeleteTextContainer(m_aKillmsg.m_VictimTextContainerIndex);
+		if(Killmsg.m_VictimTextContainerIndex != -1)
+			TextRender()->DeleteTextContainer(Killmsg.m_VictimTextContainerIndex);
 
-		if(m_aKillmsg.m_KillerTextContainerIndex != -1)
-			TextRender()->DeleteTextContainer(m_aKillmsg.m_KillerTextContainerIndex);
+		if(Killmsg.m_KillerTextContainerIndex != -1)
+			TextRender()->DeleteTextContainer(Killmsg.m_KillerTextContainerIndex);
 
-		m_aKillmsg.m_VictimTextContainerIndex = m_aKillmsg.m_KillerTextContainerIndex = -1;
+		Killmsg.m_VictimTextContainerIndex = Killmsg.m_KillerTextContainerIndex = -1;
 	}
 }
 

--- a/src/game/client/components/menu_background.cpp
+++ b/src/game/client/components/menu_background.cpp
@@ -108,14 +108,14 @@ int CMenuBackground::ThemeScan(const char *pName, int IsDir, int DirType, void *
 		return 0;
 
 	// try to edit an existing theme
-	for(int i = 0; i < (int)pSelf->m_lThemes.size(); i++)
+	for(auto &m_lTheme : pSelf->m_lThemes)
 	{
-		if(str_comp(pSelf->m_lThemes[i].m_Name, aThemeName) == 0)
+		if(str_comp(m_lTheme.m_Name, aThemeName) == 0)
 		{
 			if(IsDay)
-				pSelf->m_lThemes[i].m_HasDay = true;
+				m_lTheme.m_HasDay = true;
 			if(IsNight)
-				pSelf->m_lThemes[i].m_HasNight = true;
+				m_lTheme.m_HasNight = true;
 			return 0;
 		}
 	}

--- a/src/game/client/components/menu_background.cpp
+++ b/src/game/client/components/menu_background.cpp
@@ -108,14 +108,14 @@ int CMenuBackground::ThemeScan(const char *pName, int IsDir, int DirType, void *
 		return 0;
 
 	// try to edit an existing theme
-	for(auto &m_lTheme : pSelf->m_lThemes)
+	for(auto &Theme : pSelf->m_lThemes)
 	{
-		if(str_comp(m_lTheme.m_Name, aThemeName) == 0)
+		if(str_comp(Theme.m_Name, aThemeName) == 0)
 		{
 			if(IsDay)
-				m_lTheme.m_HasDay = true;
+				Theme.m_HasDay = true;
 			if(IsNight)
-				m_lTheme.m_HasNight = true;
+				Theme.m_HasNight = true;
 			return 0;
 		}
 	}

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1081,10 +1081,10 @@ void CMenus::RenderServerbrowserServerDetail(CUIRect View)
 		ServerDetails.VSplitLeft(5.0f, 0x0, &ServerDetails);
 		ServerDetails.VSplitLeft(80.0f, &LeftColumn, &RightColumn);
 
-		for(unsigned int i = 0; i < sizeof(s_aLabels) / sizeof(s_aLabels[0]); i++)
+		for(auto &s_aLabel : s_aLabels)
 		{
 			LeftColumn.HSplitTop(15.0f, &Row, &LeftColumn);
-			UI()->DoLabelScaled(&Row, s_aLabels[i], FontSize, -1);
+			UI()->DoLabelScaled(&Row, s_aLabel, FontSize, -1);
 		}
 
 		RightColumn.HSplitTop(15.0f, &Row, &RightColumn);

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1081,10 +1081,10 @@ void CMenus::RenderServerbrowserServerDetail(CUIRect View)
 		ServerDetails.VSplitLeft(5.0f, 0x0, &ServerDetails);
 		ServerDetails.VSplitLeft(80.0f, &LeftColumn, &RightColumn);
 
-		for(auto &s_aLabel : s_aLabels)
+		for(auto &Label : s_aLabels)
 		{
 			LeftColumn.HSplitTop(15.0f, &Row, &LeftColumn);
-			UI()->DoLabelScaled(&Row, s_aLabel, FontSize, -1);
+			UI()->DoLabelScaled(&Row, Label, FontSize, -1);
 		}
 
 		RightColumn.HSplitTop(15.0f, &Row, &RightColumn);

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -248,12 +248,12 @@ void CMenus::RenderPlayers(CUIRect MainView)
 
 	int TotalPlayers = 0;
 
-	for(auto &i : m_pClient->m_Snap.m_paInfoByName)
+	for(auto &pInfoByName : m_pClient->m_Snap.m_paInfoByName)
 	{
-		if(!i)
+		if(!pInfoByName)
 			continue;
 
-		int Index = i->m_ClientID;
+		int Index = pInfoByName->m_ClientID;
 
 		if(Index == m_pClient->m_Snap.m_LocalClientID)
 			continue;
@@ -561,13 +561,13 @@ bool CMenus::RenderServerControlKick(CUIRect MainView, bool FilterSpectators)
 	int NumOptions = 0;
 	int Selected = -1;
 	static int aPlayerIDs[MAX_CLIENTS];
-	for(auto &i : m_pClient->m_Snap.m_paInfoByName)
+	for(auto &pInfoByName : m_pClient->m_Snap.m_paInfoByName)
 	{
-		if(!i)
+		if(!pInfoByName)
 			continue;
 
-		int Index = i->m_ClientID;
-		if(Index == m_pClient->m_Snap.m_LocalClientID || (FilterSpectators && i->m_Team == TEAM_SPECTATORS))
+		int Index = pInfoByName->m_ClientID;
+		if(Index == m_pClient->m_Snap.m_LocalClientID || (FilterSpectators && pInfoByName->m_Team == TEAM_SPECTATORS))
 			continue;
 
 		if(!str_find_nocase(m_pClient->m_aClients[Index].m_aName, m_aFilterString))

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -248,12 +248,12 @@ void CMenus::RenderPlayers(CUIRect MainView)
 
 	int TotalPlayers = 0;
 
-	for(int i = 0; i < MAX_CLIENTS; ++i)
+	for(auto &i : m_pClient->m_Snap.m_paInfoByName)
 	{
-		if(!m_pClient->m_Snap.m_paInfoByName[i])
+		if(!i)
 			continue;
 
-		int Index = m_pClient->m_Snap.m_paInfoByName[i]->m_ClientID;
+		int Index = i->m_ClientID;
 
 		if(Index == m_pClient->m_Snap.m_LocalClientID)
 			continue;
@@ -561,13 +561,13 @@ bool CMenus::RenderServerControlKick(CUIRect MainView, bool FilterSpectators)
 	int NumOptions = 0;
 	int Selected = -1;
 	static int aPlayerIDs[MAX_CLIENTS];
-	for(int i = 0; i < MAX_CLIENTS; i++)
+	for(auto &i : m_pClient->m_Snap.m_paInfoByName)
 	{
-		if(!m_pClient->m_Snap.m_paInfoByName[i])
+		if(!i)
 			continue;
 
-		int Index = m_pClient->m_Snap.m_paInfoByName[i]->m_ClientID;
-		if(Index == m_pClient->m_Snap.m_LocalClientID || (FilterSpectators && m_pClient->m_Snap.m_paInfoByName[i]->m_Team == TEAM_SPECTATORS))
+		int Index = i->m_ClientID;
+		if(Index == m_pClient->m_Snap.m_LocalClientID || (FilterSpectators && i->m_Team == TEAM_SPECTATORS))
 			continue;
 
 		if(!str_find_nocase(m_pClient->m_aClients[Index].m_aName, m_aFilterString))

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -529,13 +529,12 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 	SkinPrefix.HSplitTop(2.0f, 0, &SkinPrefix);
 	{
 		static const char *s_aSkinPrefixes[] = {"kitty", "santa"};
-		for(auto &s_aSkinPrefixe : s_aSkinPrefixes)
+		for(auto &pPrefix : s_aSkinPrefixes)
 		{
-			const char *pPrefix = s_aSkinPrefixe;
 			CUIRect Button;
 			SkinPrefix.HSplitTop(20.0f, &Button, &SkinPrefix);
 			Button.HMargin(2.0f, &Button);
-			if(DoButton_Menu(&s_aSkinPrefixe, pPrefix, 0, &Button))
+			if(DoButton_Menu(&pPrefix, pPrefix, 0, &Button))
 			{
 				str_copy(g_Config.m_ClSkinPrefix, pPrefix, sizeof(g_Config.m_ClSkinPrefix));
 			}
@@ -848,8 +847,8 @@ void CMenus::RenderSettingsControls(CUIRect MainView)
 	char aBuf[128];
 
 	// this is kinda slow, but whatever
-	for(auto &gs_aKey : gs_aKeys)
-		gs_aKey.m_KeyId = gs_aKey.m_Modifier = 0;
+	for(auto &Key : gs_aKeys)
+		Key.m_KeyId = Key.m_Modifier = 0;
 
 	for(int Mod = 0; Mod < CBinds::MODIFIER_COUNT; Mod++)
 	{
@@ -859,11 +858,11 @@ void CMenus::RenderSettingsControls(CUIRect MainView)
 			if(!pBind[0])
 				continue;
 
-			for(auto &gs_aKey : gs_aKeys)
-				if(str_comp(pBind, gs_aKey.m_pCommand) == 0)
+			for(auto &Key : gs_aKeys)
+				if(str_comp(pBind, Key.m_pCommand) == 0)
 				{
-					gs_aKey.m_KeyId = KeyId;
-					gs_aKey.m_Modifier = Mod;
+					Key.m_KeyId = KeyId;
+					Key.m_Modifier = Mod;
 					break;
 				}
 		}

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -529,13 +529,13 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 	SkinPrefix.HSplitTop(2.0f, 0, &SkinPrefix);
 	{
 		static const char *s_aSkinPrefixes[] = {"kitty", "santa"};
-		for(unsigned i = 0; i < sizeof(s_aSkinPrefixes) / sizeof(s_aSkinPrefixes[0]); i++)
+		for(auto &s_aSkinPrefixe : s_aSkinPrefixes)
 		{
-			const char *pPrefix = s_aSkinPrefixes[i];
+			const char *pPrefix = s_aSkinPrefixe;
 			CUIRect Button;
 			SkinPrefix.HSplitTop(20.0f, &Button, &SkinPrefix);
 			Button.HMargin(2.0f, &Button);
-			if(DoButton_Menu(&s_aSkinPrefixes[i], pPrefix, 0, &Button))
+			if(DoButton_Menu(&s_aSkinPrefixe, pPrefix, 0, &Button))
 			{
 				str_copy(g_Config.m_ClSkinPrefix, pPrefix, sizeof(g_Config.m_ClSkinPrefix));
 			}
@@ -813,8 +813,6 @@ static CKeyInfo gs_aKeys[] =
 	Localize("Lock team");Localize("Show entities");Localize("Show HUD");
 */
 
-const int g_KeyCount = sizeof(gs_aKeys) / sizeof(CKeyInfo);
-
 void CMenus::UiDoGetButtons(int Start, int Stop, CUIRect View, CUIRect ScopeView)
 {
 	for(int i = Start; i < Stop; i++)
@@ -850,8 +848,8 @@ void CMenus::RenderSettingsControls(CUIRect MainView)
 	char aBuf[128];
 
 	// this is kinda slow, but whatever
-	for(int i = 0; i < g_KeyCount; i++)
-		gs_aKeys[i].m_KeyId = gs_aKeys[i].m_Modifier = 0;
+	for(auto &gs_aKey : gs_aKeys)
+		gs_aKey.m_KeyId = gs_aKey.m_Modifier = 0;
 
 	for(int Mod = 0; Mod < CBinds::MODIFIER_COUNT; Mod++)
 	{
@@ -861,11 +859,11 @@ void CMenus::RenderSettingsControls(CUIRect MainView)
 			if(!pBind[0])
 				continue;
 
-			for(int i = 0; i < g_KeyCount; i++)
-				if(str_comp(pBind, gs_aKeys[i].m_pCommand) == 0)
+			for(auto &gs_aKey : gs_aKeys)
+				if(str_comp(pBind, gs_aKey.m_pCommand) == 0)
 				{
-					gs_aKeys[i].m_KeyId = KeyId;
-					gs_aKeys[i].m_Modifier = Mod;
+					gs_aKey.m_KeyId = KeyId;
+					gs_aKey.m_Modifier = Mod;
 					break;
 				}
 		}

--- a/src/game/client/components/menus_settings_assets.cpp
+++ b/src/game/client/components/menus_settings_assets.cpp
@@ -241,11 +241,11 @@ void CMenus::ClearCustomItems(int CurTab)
 	{
 		for(int i = 0; i < m_EntitiesList.size(); ++i)
 		{
-			for(int n = 0; n < MAP_IMAGE_MOD_TYPE_COUNT; ++n)
+			for(auto &m_aImage : m_EntitiesList[i].m_aImages)
 			{
-				if(m_EntitiesList[i].m_aImages[n].m_Texture != -1)
-					Graphics()->UnloadTexture(m_EntitiesList[i].m_aImages[n].m_Texture);
-				m_EntitiesList[i].m_aImages[n].m_Texture = IGraphics::CTextureHandle();
+				if(m_aImage.m_Texture != -1)
+					Graphics()->UnloadTexture(m_aImage.m_Texture);
+				m_aImage.m_Texture = IGraphics::CTextureHandle();
 			}
 		}
 		m_EntitiesList.clear();

--- a/src/game/client/components/menus_settings_assets.cpp
+++ b/src/game/client/components/menus_settings_assets.cpp
@@ -241,11 +241,11 @@ void CMenus::ClearCustomItems(int CurTab)
 	{
 		for(int i = 0; i < m_EntitiesList.size(); ++i)
 		{
-			for(auto &m_aImage : m_EntitiesList[i].m_aImages)
+			for(auto &Image : m_EntitiesList[i].m_aImages)
 			{
-				if(m_aImage.m_Texture != -1)
-					Graphics()->UnloadTexture(m_aImage.m_Texture);
-				m_aImage.m_Texture = IGraphics::CTextureHandle();
+				if(Image.m_Texture != -1)
+					Graphics()->UnloadTexture(Image.m_Texture);
+				Image.m_Texture = IGraphics::CTextureHandle();
 			}
 		}
 		m_EntitiesList.clear();

--- a/src/game/client/components/nameplates.cpp
+++ b/src/game/client/components/nameplates.cpp
@@ -247,14 +247,14 @@ void CNamePlates::SetPlayers(CPlayers *pPlayers)
 
 void CNamePlates::ResetNamePlates()
 {
-	for(auto &m_aNamePlate : m_aNamePlates)
+	for(auto &NamePlate : m_aNamePlates)
 	{
-		if(m_aNamePlate.m_NameTextContainerIndex != -1)
-			TextRender()->DeleteTextContainer(m_aNamePlate.m_NameTextContainerIndex);
-		if(m_aNamePlate.m_ClanNameTextContainerIndex != -1)
-			TextRender()->DeleteTextContainer(m_aNamePlate.m_ClanNameTextContainerIndex);
+		if(NamePlate.m_NameTextContainerIndex != -1)
+			TextRender()->DeleteTextContainer(NamePlate.m_NameTextContainerIndex);
+		if(NamePlate.m_ClanNameTextContainerIndex != -1)
+			TextRender()->DeleteTextContainer(NamePlate.m_ClanNameTextContainerIndex);
 
-		m_aNamePlate.Reset();
+		NamePlate.Reset();
 	}
 }
 

--- a/src/game/client/components/nameplates.cpp
+++ b/src/game/client/components/nameplates.cpp
@@ -247,14 +247,14 @@ void CNamePlates::SetPlayers(CPlayers *pPlayers)
 
 void CNamePlates::ResetNamePlates()
 {
-	for(int i = 0; i < MAX_CLIENTS; ++i)
+	for(auto &m_aNamePlate : m_aNamePlates)
 	{
-		if(m_aNamePlates[i].m_NameTextContainerIndex != -1)
-			TextRender()->DeleteTextContainer(m_aNamePlates[i].m_NameTextContainerIndex);
-		if(m_aNamePlates[i].m_ClanNameTextContainerIndex != -1)
-			TextRender()->DeleteTextContainer(m_aNamePlates[i].m_ClanNameTextContainerIndex);
+		if(m_aNamePlate.m_NameTextContainerIndex != -1)
+			TextRender()->DeleteTextContainer(m_aNamePlate.m_NameTextContainerIndex);
+		if(m_aNamePlate.m_ClanNameTextContainerIndex != -1)
+			TextRender()->DeleteTextContainer(m_aNamePlate.m_ClanNameTextContainerIndex);
 
-		m_aNamePlates[i].Reset();
+		m_aNamePlate.Reset();
 	}
 }
 

--- a/src/game/client/components/particles.cpp
+++ b/src/game/client/components/particles.cpp
@@ -30,8 +30,8 @@ void CParticles::OnReset()
 	m_aParticles[MAX_PARTICLES - 1].m_NextPart = -1;
 	m_FirstFree = 0;
 
-	for(int &i : m_aFirstPart)
-		i = -1;
+	for(int &FirstPart : m_aFirstPart)
+		FirstPart = -1;
 }
 
 void CParticles::Add(int Group, CParticle *pPart, float TimePassed)
@@ -89,9 +89,9 @@ void CParticles::Update(float TimePassed)
 		FrictionFraction -= 0.05f;
 	}
 
-	for(int &g : m_aFirstPart)
+	for(int &FirstPart : m_aFirstPart)
 	{
-		int i = g;
+		int i = FirstPart;
 		while(i != -1)
 		{
 			int Next = m_aParticles[i].m_NextPart;
@@ -116,7 +116,7 @@ void CParticles::Update(float TimePassed)
 				if(m_aParticles[i].m_PrevPart != -1)
 					m_aParticles[m_aParticles[i].m_PrevPart].m_NextPart = m_aParticles[i].m_NextPart;
 				else
-					g = m_aParticles[i].m_NextPart;
+					FirstPart = m_aParticles[i].m_NextPart;
 
 				if(m_aParticles[i].m_NextPart != -1)
 					m_aParticles[m_aParticles[i].m_NextPart].m_PrevPart = m_aParticles[i].m_PrevPart;

--- a/src/game/client/components/particles.cpp
+++ b/src/game/client/components/particles.cpp
@@ -30,8 +30,8 @@ void CParticles::OnReset()
 	m_aParticles[MAX_PARTICLES - 1].m_NextPart = -1;
 	m_FirstFree = 0;
 
-	for(int i = 0; i < NUM_GROUPS; i++)
-		m_aFirstPart[i] = -1;
+	for(int &i : m_aFirstPart)
+		i = -1;
 }
 
 void CParticles::Add(int Group, CParticle *pPart, float TimePassed)
@@ -89,9 +89,9 @@ void CParticles::Update(float TimePassed)
 		FrictionFraction -= 0.05f;
 	}
 
-	for(int g = 0; g < NUM_GROUPS; g++)
+	for(int &g : m_aFirstPart)
 	{
-		int i = m_aFirstPart[g];
+		int i = g;
 		while(i != -1)
 		{
 			int Next = m_aParticles[i].m_NextPart;
@@ -116,7 +116,7 @@ void CParticles::Update(float TimePassed)
 				if(m_aParticles[i].m_PrevPart != -1)
 					m_aParticles[m_aParticles[i].m_PrevPart].m_NextPart = m_aParticles[i].m_NextPart;
 				else
-					m_aFirstPart[g] = m_aParticles[i].m_NextPart;
+					g = m_aParticles[i].m_NextPart;
 
 				if(m_aParticles[i].m_NextPart != -1)
 					m_aParticles[m_aParticles[i].m_NextPart].m_PrevPart = m_aParticles[i].m_PrevPart;

--- a/src/game/client/components/race_demo.cpp
+++ b/src/game/client/components/race_demo.cpp
@@ -214,14 +214,14 @@ bool CRaceDemo::CheckDemo(int Time) const
 	Storage()->ListDirectoryInfo(IStorage::TYPE_SAVE, ms_pRaceDemoDir, RaceDemolistFetchCallback, &Param);
 
 	// loop through demo files
-	for(unsigned i = 0; i < lDemos.size(); i++)
+	for(auto &lDemo : lDemos)
 	{
-		if(Time >= lDemos[i].m_Time) // found a better demo
+		if(Time >= lDemo.m_Time) // found a better demo
 			return false;
 
 		// delete old demo
 		char aFilename[512];
-		str_format(aFilename, sizeof(aFilename), "%s/%s.demo", ms_pRaceDemoDir, lDemos[i].m_aName);
+		str_format(aFilename, sizeof(aFilename), "%s/%s.demo", ms_pRaceDemoDir, lDemo.m_aName);
 		Storage()->RemoveFile(aFilename, IStorage::TYPE_SAVE);
 	}
 

--- a/src/game/client/components/race_demo.cpp
+++ b/src/game/client/components/race_demo.cpp
@@ -214,14 +214,14 @@ bool CRaceDemo::CheckDemo(int Time) const
 	Storage()->ListDirectoryInfo(IStorage::TYPE_SAVE, ms_pRaceDemoDir, RaceDemolistFetchCallback, &Param);
 
 	// loop through demo files
-	for(auto &lDemo : lDemos)
+	for(auto &Demo : lDemos)
 	{
-		if(Time >= lDemo.m_Time) // found a better demo
+		if(Time >= Demo.m_Time) // found a better demo
 			return false;
 
 		// delete old demo
 		char aFilename[512];
-		str_format(aFilename, sizeof(aFilename), "%s/%s.demo", ms_pRaceDemoDir, lDemo.m_aName);
+		str_format(aFilename, sizeof(aFilename), "%s/%s.demo", ms_pRaceDemoDir, Demo.m_aName);
 		Storage()->RemoveFile(aFilename, IStorage::TYPE_SAVE);
 	}
 

--- a/src/game/client/components/scoreboard.cpp
+++ b/src/game/client/components/scoreboard.cpp
@@ -120,9 +120,8 @@ void CScoreboard::RenderSpectators(float x, float y, float w)
 	Cursor.m_LineWidth = w - 20.0f;
 	Cursor.m_MaxLines = 4;
 
-	for(int i = 0; i < MAX_CLIENTS; ++i)
+	for(const auto *pInfo : m_pClient->m_Snap.m_paInfoByName)
 	{
-		const CNetObj_PlayerInfo *pInfo = m_pClient->m_Snap.m_paInfoByName[i];
 		if(!pInfo || pInfo->m_Team != TEAM_SPECTATORS)
 			continue;
 
@@ -692,9 +691,8 @@ const char *CScoreboard::GetClanName(int Team)
 {
 	int ClanPlayers = 0;
 	const char *pClanName = 0;
-	for(int i = 0; i < MAX_CLIENTS; i++)
+	for(const auto *pInfo : m_pClient->m_Snap.m_paInfoByScore)
 	{
-		const CNetObj_PlayerInfo *pInfo = m_pClient->m_Snap.m_paInfoByScore[i];
 		if(!pInfo || pInfo->m_Team != Team)
 			continue;
 

--- a/src/game/client/components/skins.cpp
+++ b/src/game/client/components/skins.cpp
@@ -20,9 +20,9 @@ static const char *VANILLA_SKINS[] = {"bluekitty", "bluestripe", "brownbear",
 
 static bool IsVanillaSkin(const char *pName)
 {
-	for(auto &i : VANILLA_SKINS)
+	for(auto &pVanillaSkin : VANILLA_SKINS)
 	{
-		if(str_comp(pName, i) == 0)
+		if(str_comp(pName, pVanillaSkin) == 0)
 		{
 			return true;
 		}
@@ -210,8 +210,8 @@ void CSkins::Refresh()
 		Graphics()->UnloadTextureNew(m_aSkins[i].m_OriginalSkin.m_FeetOutline);
 		Graphics()->UnloadTextureNew(m_aSkins[i].m_OriginalSkin.m_Hands);
 		Graphics()->UnloadTextureNew(m_aSkins[i].m_OriginalSkin.m_HandsOutline);
-		for(auto &m_Eye : m_aSkins[i].m_OriginalSkin.m_Eyes)
-			Graphics()->UnloadTextureNew(m_Eye);
+		for(auto &Eye : m_aSkins[i].m_OriginalSkin.m_Eyes)
+			Graphics()->UnloadTextureNew(Eye);
 
 		Graphics()->UnloadTextureNew(m_aSkins[i].m_ColorableSkin.m_Body);
 		Graphics()->UnloadTextureNew(m_aSkins[i].m_ColorableSkin.m_BodyOutline);
@@ -219,8 +219,8 @@ void CSkins::Refresh()
 		Graphics()->UnloadTextureNew(m_aSkins[i].m_ColorableSkin.m_FeetOutline);
 		Graphics()->UnloadTextureNew(m_aSkins[i].m_ColorableSkin.m_Hands);
 		Graphics()->UnloadTextureNew(m_aSkins[i].m_ColorableSkin.m_HandsOutline);
-		for(auto &m_Eye : m_aSkins[i].m_ColorableSkin.m_Eyes)
-			Graphics()->UnloadTextureNew(m_Eye);
+		for(auto &Eye : m_aSkins[i].m_ColorableSkin.m_Eyes)
+			Graphics()->UnloadTextureNew(Eye);
 	}
 
 	m_aSkins.clear();

--- a/src/game/client/components/skins.cpp
+++ b/src/game/client/components/skins.cpp
@@ -20,9 +20,9 @@ static const char *VANILLA_SKINS[] = {"bluekitty", "bluestripe", "brownbear",
 
 static bool IsVanillaSkin(const char *pName)
 {
-	for(unsigned int i = 0; i < sizeof(VANILLA_SKINS) / sizeof(VANILLA_SKINS[0]); i++)
+	for(auto &i : VANILLA_SKINS)
 	{
-		if(str_comp(pName, VANILLA_SKINS[i]) == 0)
+		if(str_comp(pName, i) == 0)
 		{
 			return true;
 		}
@@ -210,8 +210,8 @@ void CSkins::Refresh()
 		Graphics()->UnloadTextureNew(m_aSkins[i].m_OriginalSkin.m_FeetOutline);
 		Graphics()->UnloadTextureNew(m_aSkins[i].m_OriginalSkin.m_Hands);
 		Graphics()->UnloadTextureNew(m_aSkins[i].m_OriginalSkin.m_HandsOutline);
-		for(int n = 0; n < 6; ++n)
-			Graphics()->UnloadTextureNew(m_aSkins[i].m_OriginalSkin.m_Eyes[n]);
+		for(auto &m_Eye : m_aSkins[i].m_OriginalSkin.m_Eyes)
+			Graphics()->UnloadTextureNew(m_Eye);
 
 		Graphics()->UnloadTextureNew(m_aSkins[i].m_ColorableSkin.m_Body);
 		Graphics()->UnloadTextureNew(m_aSkins[i].m_ColorableSkin.m_BodyOutline);
@@ -219,8 +219,8 @@ void CSkins::Refresh()
 		Graphics()->UnloadTextureNew(m_aSkins[i].m_ColorableSkin.m_FeetOutline);
 		Graphics()->UnloadTextureNew(m_aSkins[i].m_ColorableSkin.m_Hands);
 		Graphics()->UnloadTextureNew(m_aSkins[i].m_ColorableSkin.m_HandsOutline);
-		for(int n = 0; n < 6; ++n)
-			Graphics()->UnloadTextureNew(m_aSkins[i].m_ColorableSkin.m_Eyes[n]);
+		for(auto &m_Eye : m_aSkins[i].m_ColorableSkin.m_Eyes)
+			Graphics()->UnloadTextureNew(m_Eye);
 	}
 
 	m_aSkins.clear();

--- a/src/game/client/components/spectator.cpp
+++ b/src/game/client/components/spectator.cpp
@@ -217,9 +217,9 @@ void CSpectator::OnRender()
 	float BoxMove = -10.0f;
 	float BoxOffset = 0.0f;
 
-	for(auto &i : m_pClient->m_Snap.m_paInfoByDDTeamName)
+	for(auto &pInfo : m_pClient->m_Snap.m_paInfoByDDTeamName)
 	{
-		if(!i || i->m_Team == TEAM_SPECTATORS)
+		if(!pInfo || pInfo->m_Team == TEAM_SPECTATORS)
 			continue;
 
 		++TotalPlayers;

--- a/src/game/client/components/spectator.cpp
+++ b/src/game/client/components/spectator.cpp
@@ -217,9 +217,9 @@ void CSpectator::OnRender()
 	float BoxMove = -10.0f;
 	float BoxOffset = 0.0f;
 
-	for(int i = 0; i < MAX_CLIENTS; ++i)
+	for(auto &i : m_pClient->m_Snap.m_paInfoByDDTeamName)
 	{
-		if(!m_pClient->m_Snap.m_paInfoByDDTeamName[i] || m_pClient->m_Snap.m_paInfoByDDTeamName[i]->m_Team == TEAM_SPECTATORS)
+		if(!i || i->m_Team == TEAM_SPECTATORS)
 			continue;
 
 		++TotalPlayers;

--- a/src/game/client/components/statboard.cpp
+++ b/src/game/client/components/statboard.cpp
@@ -19,8 +19,8 @@ CStatboard::CStatboard()
 
 void CStatboard::OnReset()
 {
-	for(int i = 0; i < MAX_CLIENTS; i++)
-		m_pClient->m_aStats[i].Reset();
+	for(auto &m_aStat : m_pClient->m_aStats)
+		m_aStat.Reset();
 	m_Active = false;
 	m_ScreenshotTaken = false;
 	m_ScreenshotTime = -1;
@@ -136,9 +136,8 @@ void CStatboard::RenderGlobalStats()
 	int NumPlayers = 0;
 
 	// sort red or dm players by score
-	for(int i = 0; i < MAX_CLIENTS; i++)
+	for(const auto *pInfo : m_pClient->m_Snap.m_paInfoByScore)
 	{
-		const CNetObj_PlayerInfo *pInfo = m_pClient->m_Snap.m_paInfoByScore[i];
 		if(!pInfo || !m_pClient->m_aStats[pInfo->m_ClientID].IsActive() || m_pClient->m_aClients[pInfo->m_ClientID].m_Team != TEAM_RED)
 			continue;
 		apPlayers[NumPlayers] = pInfo;
@@ -148,9 +147,8 @@ void CStatboard::RenderGlobalStats()
 	// sort blue players by score after
 	if(m_pClient->m_Snap.m_pGameInfoObj && m_pClient->m_Snap.m_pGameInfoObj->m_GameFlags & GAMEFLAG_TEAMS)
 	{
-		for(int i = 0; i < MAX_CLIENTS; i++)
+		for(const auto *pInfo : m_pClient->m_Snap.m_paInfoByScore)
 		{
-			const CNetObj_PlayerInfo *pInfo = m_pClient->m_Snap.m_paInfoByScore[i];
 			if(!pInfo || !m_pClient->m_aStats[pInfo->m_ClientID].IsActive() || m_pClient->m_aClients[pInfo->m_ClientID].m_Team != TEAM_BLUE)
 				continue;
 			apPlayers[NumPlayers] = pInfo;
@@ -182,8 +180,8 @@ void CStatboard::RenderGlobalStats()
 		for(int j = 0; j < NUM_WEAPONS; j++)
 			aDisplayWeapon[j] = aDisplayWeapon[j] || pStats->m_aFragsWith[j] || pStats->m_aDeathsFrom[j];
 	}
-	for(int i = 0; i < NUM_WEAPONS; i++)
-		if(aDisplayWeapon[i])
+	for(bool i : aDisplayWeapon)
+		if(i)
 			StatboardContentWidth += 80;
 
 	float x = StatboardWidth / 2 - StatboardContentWidth / 2;
@@ -449,9 +447,8 @@ void CStatboard::FormatStats()
 	int NumPlayers = 0;
 
 	// sort red or dm players by score
-	for(int i = 0; i < MAX_CLIENTS; i++)
+	for(const auto *pInfo : m_pClient->m_Snap.m_paInfoByScore)
 	{
-		const CNetObj_PlayerInfo *pInfo = m_pClient->m_Snap.m_paInfoByScore[i];
 		if(!pInfo || !m_pClient->m_aStats[pInfo->m_ClientID].IsActive() || m_pClient->m_aClients[pInfo->m_ClientID].m_Team != TEAM_RED)
 			continue;
 		apPlayers[NumPlayers] = pInfo;
@@ -461,9 +458,8 @@ void CStatboard::FormatStats()
 	// sort blue players by score after
 	if(m_pClient->m_Snap.m_pGameInfoObj && m_pClient->m_Snap.m_pGameInfoObj->m_GameFlags & GAMEFLAG_TEAMS)
 	{
-		for(int i = 0; i < MAX_CLIENTS; i++)
+		for(const auto *pInfo : m_pClient->m_Snap.m_paInfoByScore)
 		{
-			const CNetObj_PlayerInfo *pInfo = m_pClient->m_Snap.m_paInfoByScore[i];
 			if(!pInfo || !m_pClient->m_aStats[pInfo->m_ClientID].IsActive() || m_pClient->m_aClients[pInfo->m_ClientID].m_Team != TEAM_BLUE)
 				continue;
 			apPlayers[NumPlayers] = pInfo;

--- a/src/game/client/components/statboard.cpp
+++ b/src/game/client/components/statboard.cpp
@@ -19,8 +19,8 @@ CStatboard::CStatboard()
 
 void CStatboard::OnReset()
 {
-	for(auto &m_aStat : m_pClient->m_aStats)
-		m_aStat.Reset();
+	for(auto &Stat : m_pClient->m_aStats)
+		Stat.Reset();
 	m_Active = false;
 	m_ScreenshotTaken = false;
 	m_ScreenshotTime = -1;
@@ -180,8 +180,8 @@ void CStatboard::RenderGlobalStats()
 		for(int j = 0; j < NUM_WEAPONS; j++)
 			aDisplayWeapon[j] = aDisplayWeapon[j] || pStats->m_aFragsWith[j] || pStats->m_aDeathsFrom[j];
 	}
-	for(bool i : aDisplayWeapon)
-		if(i)
+	for(bool DisplayWeapon : aDisplayWeapon)
+		if(DisplayWeapon)
 			StatboardContentWidth += 80;
 
 	float x = StatboardWidth / 2 - StatboardContentWidth / 2;

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -524,8 +524,8 @@ void CGameClient::OnConnected()
 	m_GameWorld.Clear();
 	m_GameWorld.m_WorldConfig.m_InfiniteAmmo = true;
 	m_PredictedDummyID = -1;
-	for(int i = 0; i < MAX_CLIENTS; i++)
-		m_aLastWorldCharacters[i].m_Alive = false;
+	for(auto &m_aLastWorldCharacter : m_aLastWorldCharacters)
+		m_aLastWorldCharacter.m_Alive = false;
 	LoadMapSettings();
 
 	if(Client()->State() != IClient::STATE_DEMOPLAYBACK && g_Config.m_ClAutoDemoOnConnect)
@@ -539,8 +539,8 @@ void CGameClient::OnReset()
 
 	InvalidateSnapshot();
 
-	for(int i = 0; i < MAX_CLIENTS; i++)
-		m_aClients[i].Reset();
+	for(auto &m_aClient : m_aClients)
+		m_aClient.Reset();
 
 	for(int i = 0; i < m_All.m_Num; i++)
 		m_All.m_paComponents[i]->OnReset();
@@ -1208,9 +1208,9 @@ void CGameClient::OnNewSnapshot()
 
 	bool FoundGameInfoEx = false;
 
-	for(int i = 0; i < MAX_CLIENTS; i++)
+	for(auto &m_aClient : m_aClients)
 	{
-		m_aClients[i].m_SpecCharPresent = false;
+		m_aClient.m_SpecCharPresent = false;
 	}
 
 	// go trough all the items in the snapshot and gather the info we want
@@ -2243,14 +2243,14 @@ void CGameClient::UpdatePrediction()
 		if(m_Snap.m_aCharacters[m_Snap.m_LocalClientID].m_HasExtendedData)
 		{
 			int aIDs[MAX_CLIENTS];
-			for(int i = 0; i < MAX_CLIENTS; i++)
-				aIDs[i] = -1;
+			for(int &aID : aIDs)
+				aID = -1;
 			for(int i = 0; i < MAX_CLIENTS; i++)
 				if(CCharacter *pChar = m_GameWorld.GetCharacterByID(i))
 					aIDs[pChar->GetStrongWeakID()] = i;
-			for(int i = 0; i < MAX_CLIENTS; i++)
-				if(aIDs[i] >= 0)
-					m_CharOrder.GiveStrong(aIDs[i]);
+			for(int aID : aIDs)
+				if(aID >= 0)
+					m_CharOrder.GiveStrong(aID);
 		}
 		else
 		{
@@ -2545,9 +2545,9 @@ void CGameClient::LoadGameSkin(const char *pPath, bool AsDir)
 		Graphics()->UnloadTextureNew(m_GameSkin.m_SpriteWeaponNinjaCursor);
 		Graphics()->UnloadTextureNew(m_GameSkin.m_SpriteWeaponLaserCursor);
 
-		for(int i = 0; i < 6; ++i)
+		for(auto &m_SpriteWeaponCursor : m_GameSkin.m_SpriteWeaponCursors)
 		{
-			m_GameSkin.m_SpriteWeaponCursors[i] = IGraphics::CTextureHandle();
+			m_SpriteWeaponCursor = IGraphics::CTextureHandle();
 		}
 
 		Graphics()->UnloadTextureNew(m_GameSkin.m_SpriteHookChain);
@@ -2559,19 +2559,19 @@ void CGameClient::LoadGameSkin(const char *pPath, bool AsDir)
 		Graphics()->UnloadTextureNew(m_GameSkin.m_SpriteWeaponNinja);
 		Graphics()->UnloadTextureNew(m_GameSkin.m_SpriteWeaponLaser);
 
-		for(int i = 0; i < 6; ++i)
+		for(auto &m_SpriteWeapon : m_GameSkin.m_SpriteWeapons)
 		{
-			m_GameSkin.m_SpriteWeapons[i] = IGraphics::CTextureHandle();
+			m_SpriteWeapon = IGraphics::CTextureHandle();
 		}
 
-		for(int i = 0; i < 9; ++i)
+		for(auto &m_SpriteParticle : m_GameSkin.m_SpriteParticles)
 		{
-			Graphics()->UnloadTextureNew(m_GameSkin.m_SpriteParticles[i]);
+			Graphics()->UnloadTextureNew(m_SpriteParticle);
 		}
 
-		for(int i = 0; i < 3; ++i)
+		for(auto &m_SpriteStar : m_GameSkin.m_SpriteStars)
 		{
-			Graphics()->UnloadTextureNew(m_GameSkin.m_SpriteStars[i]);
+			Graphics()->UnloadTextureNew(m_SpriteStar);
 		}
 
 		Graphics()->UnloadTextureNew(m_GameSkin.m_SpriteWeaponGunProjectile);
@@ -2581,9 +2581,9 @@ void CGameClient::LoadGameSkin(const char *pPath, bool AsDir)
 		Graphics()->UnloadTextureNew(m_GameSkin.m_SpriteWeaponNinjaProjectile);
 		Graphics()->UnloadTextureNew(m_GameSkin.m_SpriteWeaponLaserProjectile);
 
-		for(int i = 0; i < 6; ++i)
+		for(auto &m_SpriteWeaponProjectile : m_GameSkin.m_SpriteWeaponProjectiles)
 		{
-			m_GameSkin.m_SpriteWeaponProjectiles[i] = IGraphics::CTextureHandle();
+			m_SpriteWeaponProjectile = IGraphics::CTextureHandle();
 		}
 
 		for(int i = 0; i < 3; ++i)
@@ -2592,9 +2592,9 @@ void CGameClient::LoadGameSkin(const char *pPath, bool AsDir)
 			Graphics()->UnloadTextureNew(m_GameSkin.m_SpriteWeaponShotgunMuzzles[i]);
 			Graphics()->UnloadTextureNew(m_GameSkin.m_SpriteWeaponNinjaMuzzles[i]);
 
-			for(int n = 0; n < 6; ++n)
+			for(auto &m_SpriteWeaponsMuzzle : m_GameSkin.m_SpriteWeaponsMuzzles)
 			{
-				m_GameSkin.m_SpriteWeaponsMuzzles[n][i] = IGraphics::CTextureHandle();
+				m_SpriteWeaponsMuzzle[i] = IGraphics::CTextureHandle();
 			}
 		}
 
@@ -2607,9 +2607,9 @@ void CGameClient::LoadGameSkin(const char *pPath, bool AsDir)
 		Graphics()->UnloadTextureNew(m_GameSkin.m_SpritePickupGun);
 		Graphics()->UnloadTextureNew(m_GameSkin.m_SpritePickupHammer);
 
-		for(int i = 0; i < 6; ++i)
+		for(auto &m_SpritePickupWeapon : m_GameSkin.m_SpritePickupWeapons)
 		{
-			m_GameSkin.m_SpritePickupWeapons[i] = IGraphics::CTextureHandle();
+			m_SpritePickupWeapon = IGraphics::CTextureHandle();
 		}
 
 		Graphics()->UnloadTextureNew(m_GameSkin.m_SpriteFlagBlue);
@@ -2773,8 +2773,8 @@ void CGameClient::LoadEmoticonsSkin(const char *pPath, bool AsDir)
 {
 	if(m_EmoticonsSkinLoaded)
 	{
-		for(int i = 0; i < 16; ++i)
-			Graphics()->UnloadTextureNew(m_EmoticonsSkin.m_SpriteEmoticons[i]);
+		for(auto &m_SpriteEmoticon : m_EmoticonsSkin.m_SpriteEmoticons)
+			Graphics()->UnloadTextureNew(m_SpriteEmoticon);
 
 		m_EmoticonsSkinLoaded = false;
 	}
@@ -2819,16 +2819,16 @@ void CGameClient::LoadParticlesSkin(const char *pPath, bool AsDir)
 	{
 		Graphics()->UnloadTextureNew(m_ParticlesSkin.m_SpriteParticleSlice);
 		Graphics()->UnloadTextureNew(m_ParticlesSkin.m_SpriteParticleBall);
-		for(int i = 0; i < 3; ++i)
-			Graphics()->UnloadTextureNew(m_ParticlesSkin.m_SpriteParticleSplat[i]);
+		for(auto &i : m_ParticlesSkin.m_SpriteParticleSplat)
+			Graphics()->UnloadTextureNew(i);
 		Graphics()->UnloadTextureNew(m_ParticlesSkin.m_SpriteParticleSmoke);
 		Graphics()->UnloadTextureNew(m_ParticlesSkin.m_SpriteParticleShell);
 		Graphics()->UnloadTextureNew(m_ParticlesSkin.m_SpriteParticleExpl);
 		Graphics()->UnloadTextureNew(m_ParticlesSkin.m_SpriteParticleAirJump);
 		Graphics()->UnloadTextureNew(m_ParticlesSkin.m_SpriteParticleHit);
 
-		for(int i = 0; i < (int)(sizeof(m_ParticlesSkin.m_SpriteParticles) / sizeof(m_ParticlesSkin.m_SpriteParticles[0])); ++i)
-			m_ParticlesSkin.m_SpriteParticles[i] = IGraphics::CTextureHandle();
+		for(auto &m_SpriteParticle : m_ParticlesSkin.m_SpriteParticles)
+			m_SpriteParticle = IGraphics::CTextureHandle();
 
 		m_ParticlesSkinLoaded = false;
 	}
@@ -2886,14 +2886,14 @@ void CGameClient::LoadParticlesSkin(const char *pPath, bool AsDir)
 
 void CGameClient::RefindSkins()
 {
-	for(int i = 0; i < MAX_CLIENTS; ++i)
+	for(auto &m_aClient : m_aClients)
 	{
-		if(m_aClients[i].m_aSkinName[0] != '\0')
+		if(m_aClient.m_aSkinName[0] != '\0')
 		{
-			const CSkin *pSkin = m_pSkins->Get(m_pSkins->Find(m_aClients[i].m_aSkinName));
-			m_aClients[i].m_SkinInfo.m_OriginalRenderSkin = pSkin->m_OriginalSkin;
-			m_aClients[i].m_SkinInfo.m_ColorableRenderSkin = pSkin->m_ColorableSkin;
-			m_aClients[i].UpdateRenderInfo();
+			const CSkin *pSkin = m_pSkins->Get(m_pSkins->Find(m_aClient.m_aSkinName));
+			m_aClient.m_SkinInfo.m_OriginalRenderSkin = pSkin->m_OriginalSkin;
+			m_aClient.m_SkinInfo.m_ColorableRenderSkin = pSkin->m_ColorableSkin;
+			m_aClient.UpdateRenderInfo();
 		}
 	}
 	m_pGhost->RefindSkin();

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -524,8 +524,8 @@ void CGameClient::OnConnected()
 	m_GameWorld.Clear();
 	m_GameWorld.m_WorldConfig.m_InfiniteAmmo = true;
 	m_PredictedDummyID = -1;
-	for(auto &m_aLastWorldCharacter : m_aLastWorldCharacters)
-		m_aLastWorldCharacter.m_Alive = false;
+	for(auto &LastWorldCharacter : m_aLastWorldCharacters)
+		LastWorldCharacter.m_Alive = false;
 	LoadMapSettings();
 
 	if(Client()->State() != IClient::STATE_DEMOPLAYBACK && g_Config.m_ClAutoDemoOnConnect)
@@ -539,8 +539,8 @@ void CGameClient::OnReset()
 
 	InvalidateSnapshot();
 
-	for(auto &m_aClient : m_aClients)
-		m_aClient.Reset();
+	for(auto &Client : m_aClients)
+		Client.Reset();
 
 	for(int i = 0; i < m_All.m_Num; i++)
 		m_All.m_paComponents[i]->OnReset();
@@ -1208,9 +1208,9 @@ void CGameClient::OnNewSnapshot()
 
 	bool FoundGameInfoEx = false;
 
-	for(auto &m_aClient : m_aClients)
+	for(auto &Client : m_aClients)
 	{
-		m_aClient.m_SpecCharPresent = false;
+		Client.m_SpecCharPresent = false;
 	}
 
 	// go trough all the items in the snapshot and gather the info we want
@@ -2243,14 +2243,14 @@ void CGameClient::UpdatePrediction()
 		if(m_Snap.m_aCharacters[m_Snap.m_LocalClientID].m_HasExtendedData)
 		{
 			int aIDs[MAX_CLIENTS];
-			for(int &aID : aIDs)
-				aID = -1;
+			for(int &ID : aIDs)
+				ID = -1;
 			for(int i = 0; i < MAX_CLIENTS; i++)
 				if(CCharacter *pChar = m_GameWorld.GetCharacterByID(i))
 					aIDs[pChar->GetStrongWeakID()] = i;
-			for(int aID : aIDs)
-				if(aID >= 0)
-					m_CharOrder.GiveStrong(aID);
+			for(int ID : aIDs)
+				if(ID >= 0)
+					m_CharOrder.GiveStrong(ID);
 		}
 		else
 		{
@@ -2545,9 +2545,9 @@ void CGameClient::LoadGameSkin(const char *pPath, bool AsDir)
 		Graphics()->UnloadTextureNew(m_GameSkin.m_SpriteWeaponNinjaCursor);
 		Graphics()->UnloadTextureNew(m_GameSkin.m_SpriteWeaponLaserCursor);
 
-		for(auto &m_SpriteWeaponCursor : m_GameSkin.m_SpriteWeaponCursors)
+		for(auto &SpriteWeaponCursor : m_GameSkin.m_SpriteWeaponCursors)
 		{
-			m_SpriteWeaponCursor = IGraphics::CTextureHandle();
+			SpriteWeaponCursor = IGraphics::CTextureHandle();
 		}
 
 		Graphics()->UnloadTextureNew(m_GameSkin.m_SpriteHookChain);
@@ -2559,19 +2559,19 @@ void CGameClient::LoadGameSkin(const char *pPath, bool AsDir)
 		Graphics()->UnloadTextureNew(m_GameSkin.m_SpriteWeaponNinja);
 		Graphics()->UnloadTextureNew(m_GameSkin.m_SpriteWeaponLaser);
 
-		for(auto &m_SpriteWeapon : m_GameSkin.m_SpriteWeapons)
+		for(auto &SpriteWeapon : m_GameSkin.m_SpriteWeapons)
 		{
-			m_SpriteWeapon = IGraphics::CTextureHandle();
+			SpriteWeapon = IGraphics::CTextureHandle();
 		}
 
-		for(auto &m_SpriteParticle : m_GameSkin.m_SpriteParticles)
+		for(auto &SpriteParticle : m_GameSkin.m_SpriteParticles)
 		{
-			Graphics()->UnloadTextureNew(m_SpriteParticle);
+			Graphics()->UnloadTextureNew(SpriteParticle);
 		}
 
-		for(auto &m_SpriteStar : m_GameSkin.m_SpriteStars)
+		for(auto &SpriteStar : m_GameSkin.m_SpriteStars)
 		{
-			Graphics()->UnloadTextureNew(m_SpriteStar);
+			Graphics()->UnloadTextureNew(SpriteStar);
 		}
 
 		Graphics()->UnloadTextureNew(m_GameSkin.m_SpriteWeaponGunProjectile);
@@ -2581,9 +2581,9 @@ void CGameClient::LoadGameSkin(const char *pPath, bool AsDir)
 		Graphics()->UnloadTextureNew(m_GameSkin.m_SpriteWeaponNinjaProjectile);
 		Graphics()->UnloadTextureNew(m_GameSkin.m_SpriteWeaponLaserProjectile);
 
-		for(auto &m_SpriteWeaponProjectile : m_GameSkin.m_SpriteWeaponProjectiles)
+		for(auto &SpriteWeaponProjectile : m_GameSkin.m_SpriteWeaponProjectiles)
 		{
-			m_SpriteWeaponProjectile = IGraphics::CTextureHandle();
+			SpriteWeaponProjectile = IGraphics::CTextureHandle();
 		}
 
 		for(int i = 0; i < 3; ++i)
@@ -2592,9 +2592,9 @@ void CGameClient::LoadGameSkin(const char *pPath, bool AsDir)
 			Graphics()->UnloadTextureNew(m_GameSkin.m_SpriteWeaponShotgunMuzzles[i]);
 			Graphics()->UnloadTextureNew(m_GameSkin.m_SpriteWeaponNinjaMuzzles[i]);
 
-			for(auto &m_SpriteWeaponsMuzzle : m_GameSkin.m_SpriteWeaponsMuzzles)
+			for(auto &SpriteWeaponsMuzzle : m_GameSkin.m_SpriteWeaponsMuzzles)
 			{
-				m_SpriteWeaponsMuzzle[i] = IGraphics::CTextureHandle();
+				SpriteWeaponsMuzzle[i] = IGraphics::CTextureHandle();
 			}
 		}
 
@@ -2607,9 +2607,9 @@ void CGameClient::LoadGameSkin(const char *pPath, bool AsDir)
 		Graphics()->UnloadTextureNew(m_GameSkin.m_SpritePickupGun);
 		Graphics()->UnloadTextureNew(m_GameSkin.m_SpritePickupHammer);
 
-		for(auto &m_SpritePickupWeapon : m_GameSkin.m_SpritePickupWeapons)
+		for(auto &SpritePickupWeapon : m_GameSkin.m_SpritePickupWeapons)
 		{
-			m_SpritePickupWeapon = IGraphics::CTextureHandle();
+			SpritePickupWeapon = IGraphics::CTextureHandle();
 		}
 
 		Graphics()->UnloadTextureNew(m_GameSkin.m_SpriteFlagBlue);
@@ -2773,8 +2773,8 @@ void CGameClient::LoadEmoticonsSkin(const char *pPath, bool AsDir)
 {
 	if(m_EmoticonsSkinLoaded)
 	{
-		for(auto &m_SpriteEmoticon : m_EmoticonsSkin.m_SpriteEmoticons)
-			Graphics()->UnloadTextureNew(m_SpriteEmoticon);
+		for(auto &SpriteEmoticon : m_EmoticonsSkin.m_SpriteEmoticons)
+			Graphics()->UnloadTextureNew(SpriteEmoticon);
 
 		m_EmoticonsSkinLoaded = false;
 	}
@@ -2819,16 +2819,16 @@ void CGameClient::LoadParticlesSkin(const char *pPath, bool AsDir)
 	{
 		Graphics()->UnloadTextureNew(m_ParticlesSkin.m_SpriteParticleSlice);
 		Graphics()->UnloadTextureNew(m_ParticlesSkin.m_SpriteParticleBall);
-		for(auto &i : m_ParticlesSkin.m_SpriteParticleSplat)
-			Graphics()->UnloadTextureNew(i);
+		for(auto &SpriteParticleSplat : m_ParticlesSkin.m_SpriteParticleSplat)
+			Graphics()->UnloadTextureNew(SpriteParticleSplat);
 		Graphics()->UnloadTextureNew(m_ParticlesSkin.m_SpriteParticleSmoke);
 		Graphics()->UnloadTextureNew(m_ParticlesSkin.m_SpriteParticleShell);
 		Graphics()->UnloadTextureNew(m_ParticlesSkin.m_SpriteParticleExpl);
 		Graphics()->UnloadTextureNew(m_ParticlesSkin.m_SpriteParticleAirJump);
 		Graphics()->UnloadTextureNew(m_ParticlesSkin.m_SpriteParticleHit);
 
-		for(auto &m_SpriteParticle : m_ParticlesSkin.m_SpriteParticles)
-			m_SpriteParticle = IGraphics::CTextureHandle();
+		for(auto &SpriteParticle : m_ParticlesSkin.m_SpriteParticles)
+			SpriteParticle = IGraphics::CTextureHandle();
 
 		m_ParticlesSkinLoaded = false;
 	}
@@ -2886,14 +2886,14 @@ void CGameClient::LoadParticlesSkin(const char *pPath, bool AsDir)
 
 void CGameClient::RefindSkins()
 {
-	for(auto &m_aClient : m_aClients)
+	for(auto &Client : m_aClients)
 	{
-		if(m_aClient.m_aSkinName[0] != '\0')
+		if(Client.m_aSkinName[0] != '\0')
 		{
-			const CSkin *pSkin = m_pSkins->Get(m_pSkins->Find(m_aClient.m_aSkinName));
-			m_aClient.m_SkinInfo.m_OriginalRenderSkin = pSkin->m_OriginalSkin;
-			m_aClient.m_SkinInfo.m_ColorableRenderSkin = pSkin->m_ColorableSkin;
-			m_aClient.UpdateRenderInfo();
+			const CSkin *pSkin = m_pSkins->Get(m_pSkins->Find(Client.m_aSkinName));
+			Client.m_SkinInfo.m_OriginalRenderSkin = pSkin->m_OriginalSkin;
+			Client.m_SkinInfo.m_ColorableRenderSkin = pSkin->m_ColorableSkin;
+			Client.UpdateRenderInfo();
 		}
 	}
 	m_pGhost->RefindSkin();

--- a/src/game/client/prediction/entities/character.cpp
+++ b/src/game/client/prediction/entities/character.cpp
@@ -917,8 +917,8 @@ void CCharacter::DDRacePostCoreTick()
 	// handle Anti-Skip tiles
 	std::list<int> Indices = Collision()->GetMapIndices(m_PrevPos, m_Pos);
 	if(!Indices.empty())
-		for(std::list<int>::iterator i = Indices.begin(); i != Indices.end(); i++)
-			HandleTiles(*i);
+		for(int &Indice : Indices)
+			HandleTiles(Indice);
 	else
 	{
 		HandleTiles(CurrentIndex);

--- a/src/game/client/prediction/entities/character.cpp
+++ b/src/game/client/prediction/entities/character.cpp
@@ -917,8 +917,8 @@ void CCharacter::DDRacePostCoreTick()
 	// handle Anti-Skip tiles
 	std::list<int> Indices = Collision()->GetMapIndices(m_PrevPos, m_Pos);
 	if(!Indices.empty())
-		for(int &Indice : Indices)
-			HandleTiles(Indice);
+		for(int Index : Indices)
+			HandleTiles(Index);
 	else
 	{
 		HandleTiles(CurrentIndex);

--- a/src/game/client/prediction/gameworld.cpp
+++ b/src/game/client/prediction/gameworld.cpp
@@ -16,10 +16,10 @@
 //////////////////////////////////////////////////
 CGameWorld::CGameWorld()
 {
-	for(auto &m_apFirstEntityType : m_apFirstEntityTypes)
-		m_apFirstEntityType = 0;
-	for(auto &m_apCharacter : m_apCharacters)
-		m_apCharacter = 0;
+	for(auto &pFirstEntityType : m_apFirstEntityTypes)
+		pFirstEntityType = 0;
+	for(auto &pCharacter : m_apCharacters)
+		pCharacter = 0;
 	m_pCollision = 0;
 	m_GameTick = 0;
 	m_pParent = 0;
@@ -29,9 +29,9 @@ CGameWorld::CGameWorld()
 CGameWorld::~CGameWorld()
 {
 	// delete all entities
-	for(auto &m_apFirstEntityType : m_apFirstEntityTypes)
-		while(m_apFirstEntityType)
-			delete m_apFirstEntityType;
+	for(auto &pFirstEntityType : m_apFirstEntityTypes)
+		while(pFirstEntityType)
+			delete pFirstEntityType;
 	if(m_pChild && m_pChild->m_pParent == this)
 	{
 		OnModified();
@@ -534,9 +534,9 @@ void CGameWorld::CopyWorld(CGameWorld *pFrom)
 	m_pTuningList = pFrom->m_pTuningList;
 	m_Teams = pFrom->m_Teams;
 	// delete the previous entities
-	for(auto &m_apFirstEntityType : m_apFirstEntityTypes)
-		while(m_apFirstEntityType)
-			delete m_apFirstEntityType;
+	for(auto &pFirstEntityType : m_apFirstEntityTypes)
+		while(pFirstEntityType)
+			delete pFirstEntityType;
 	for(int i = 0; i < MAX_CLIENTS; i++)
 	{
 		m_apCharacters[i] = 0;
@@ -594,7 +594,7 @@ void CGameWorld::OnModified()
 void CGameWorld::Clear()
 {
 	// delete all entities
-	for(auto &m_apFirstEntityType : m_apFirstEntityTypes)
-		while(m_apFirstEntityType)
-			delete m_apFirstEntityType;
+	for(auto &pFirstEntityType : m_apFirstEntityTypes)
+		while(pFirstEntityType)
+			delete pFirstEntityType;
 }

--- a/src/game/client/prediction/gameworld.cpp
+++ b/src/game/client/prediction/gameworld.cpp
@@ -16,10 +16,10 @@
 //////////////////////////////////////////////////
 CGameWorld::CGameWorld()
 {
-	for(int i = 0; i < NUM_ENTTYPES; i++)
-		m_apFirstEntityTypes[i] = 0;
-	for(int i = 0; i < MAX_CLIENTS; i++)
-		m_apCharacters[i] = 0;
+	for(auto &m_apFirstEntityType : m_apFirstEntityTypes)
+		m_apFirstEntityType = 0;
+	for(auto &m_apCharacter : m_apCharacters)
+		m_apCharacter = 0;
 	m_pCollision = 0;
 	m_GameTick = 0;
 	m_pParent = 0;
@@ -29,9 +29,9 @@ CGameWorld::CGameWorld()
 CGameWorld::~CGameWorld()
 {
 	// delete all entities
-	for(int i = 0; i < NUM_ENTTYPES; i++)
-		while(m_apFirstEntityTypes[i])
-			delete m_apFirstEntityTypes[i];
+	for(auto &m_apFirstEntityType : m_apFirstEntityTypes)
+		while(m_apFirstEntityType)
+			delete m_apFirstEntityType;
 	if(m_pChild && m_pChild->m_pParent == this)
 	{
 		OnModified();
@@ -165,8 +165,8 @@ void CGameWorld::RemoveEntity(CEntity *pEnt)
 void CGameWorld::RemoveEntities()
 {
 	// destroy objects marked for destruction
-	for(int i = 0; i < NUM_ENTTYPES; i++)
-		for(CEntity *pEnt = m_apFirstEntityTypes[i]; pEnt;)
+	for(auto *pEnt : m_apFirstEntityTypes)
+		for(; pEnt;)
 		{
 			m_pNextTraverseEntity = pEnt->m_pNextTypeEntity;
 			if(pEnt->m_MarkedForDestroy)
@@ -186,16 +186,16 @@ bool distCompare(std::pair<float, int> a, std::pair<float, int> b)
 void CGameWorld::Tick()
 {
 	// update all objects
-	for(int i = 0; i < NUM_ENTTYPES; i++)
-		for(CEntity *pEnt = m_apFirstEntityTypes[i]; pEnt;)
+	for(auto *pEnt : m_apFirstEntityTypes)
+		for(; pEnt;)
 		{
 			m_pNextTraverseEntity = pEnt->m_pNextTypeEntity;
 			pEnt->Tick();
 			pEnt = m_pNextTraverseEntity;
 		}
 
-	for(int i = 0; i < NUM_ENTTYPES; i++)
-		for(CEntity *pEnt = m_apFirstEntityTypes[i]; pEnt;)
+	for(auto *pEnt : m_apFirstEntityTypes)
+		for(; pEnt;)
 		{
 			m_pNextTraverseEntity = pEnt->m_pNextTypeEntity;
 			pEnt->TickDefered();
@@ -534,9 +534,9 @@ void CGameWorld::CopyWorld(CGameWorld *pFrom)
 	m_pTuningList = pFrom->m_pTuningList;
 	m_Teams = pFrom->m_Teams;
 	// delete the previous entities
-	for(int i = 0; i < NUM_ENTTYPES; i++)
-		while(m_apFirstEntityTypes[i])
-			delete m_apFirstEntityTypes[i];
+	for(auto &m_apFirstEntityType : m_apFirstEntityTypes)
+		while(m_apFirstEntityType)
+			delete m_apFirstEntityType;
 	for(int i = 0; i < MAX_CLIENTS; i++)
 	{
 		m_apCharacters[i] = 0;
@@ -594,7 +594,7 @@ void CGameWorld::OnModified()
 void CGameWorld::Clear()
 {
 	// delete all entities
-	for(int i = 0; i < NUM_ENTTYPES; i++)
-		while(m_apFirstEntityTypes[i])
-			delete m_apFirstEntityTypes[i];
+	for(auto &m_apFirstEntityType : m_apFirstEntityTypes)
+		while(m_apFirstEntityType)
+			delete m_apFirstEntityType;
 }

--- a/src/game/client/race.cpp
+++ b/src/game/client/race.cpp
@@ -80,11 +80,11 @@ bool CRaceHelper::IsStart(CGameClient *pClient, vec2 Prev, vec2 Pos)
 	{
 		std::list<int> Indices = pCollision->GetMapIndices(Prev, Pos);
 		if(!Indices.empty())
-			for(std::list<int>::iterator i = Indices.begin(); i != Indices.end(); i++)
+			for(int &Indice : Indices)
 			{
-				if(pCollision->GetTileIndex(*i) == TILE_START)
+				if(pCollision->GetTileIndex(Indice) == TILE_START)
 					return true;
-				if(pCollision->GetFTileIndex(*i) == TILE_START)
+				if(pCollision->GetFTileIndex(Indice) == TILE_START)
 					return true;
 			}
 		else

--- a/src/game/client/skin.h
+++ b/src/game/client/skin.h
@@ -32,8 +32,8 @@ struct CSkin
 			m_FeetOutline = IGraphics::CTextureHandle();
 			m_Hands = IGraphics::CTextureHandle();
 			m_HandsOutline = IGraphics::CTextureHandle();
-			for(auto &m_Eye : m_Eyes)
-				m_Eye = IGraphics::CTextureHandle();
+			for(auto &Eye : m_Eyes)
+				Eye = IGraphics::CTextureHandle();
 		}
 	};
 

--- a/src/game/client/skin.h
+++ b/src/game/client/skin.h
@@ -32,8 +32,8 @@ struct CSkin
 			m_FeetOutline = IGraphics::CTextureHandle();
 			m_Hands = IGraphics::CTextureHandle();
 			m_HandsOutline = IGraphics::CTextureHandle();
-			for(int i = 0; i < 6; ++i)
-				m_Eyes[i] = IGraphics::CTextureHandle();
+			for(auto &m_Eye : m_Eyes)
+				m_Eye = IGraphics::CTextureHandle();
 		}
 	};
 

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -67,9 +67,9 @@ static const char *VANILLA_IMAGES[] = {
 
 static bool IsVanillaImage(const char *pImage)
 {
-	for(unsigned i = 0; i < sizeof(VANILLA_IMAGES) / sizeof(VANILLA_IMAGES[0]); i++)
+	for(auto &i : VANILLA_IMAGES)
 	{
-		if(str_comp(pImage, VANILLA_IMAGES[i]) == 0)
+		if(str_comp(pImage, i) == 0)
 		{
 			return true;
 		}
@@ -1687,10 +1687,10 @@ void CEditor::DoQuad(CQuad *q, int Index)
 					for(int i = 0; i < m_lSelectedQuads.size(); ++i)
 					{
 						CQuad *pCurrentQuad = &pLayer->m_lQuads[m_lSelectedQuads[i]];
-						for(int v = 0; v < 5; v++)
+						for(auto &m_aPoint : pCurrentQuad->m_aPoints)
 						{
-							pCurrentQuad->m_aPoints[v].x += OffsetX;
-							pCurrentQuad->m_aPoints[v].y += OffsetY;
+							m_aPoint.x += OffsetX;
+							m_aPoint.y += OffsetY;
 						}
 					}
 				}
@@ -1702,10 +1702,10 @@ void CEditor::DoQuad(CQuad *q, int Index)
 					for(int i = 0; i < m_lSelectedQuads.size(); ++i)
 					{
 						CQuad *pCurrentQuad = &pLayer->m_lQuads[m_lSelectedQuads[i]];
-						for(int v = 0; v < 5; v++)
+						for(auto &m_aPoint : pCurrentQuad->m_aPoints)
 						{
-							pCurrentQuad->m_aPoints[v].x += OffsetX;
-							pCurrentQuad->m_aPoints[v].y += OffsetY;
+							m_aPoint.x += OffsetX;
+							m_aPoint.y += OffsetY;
 						}
 					}
 				}

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -67,9 +67,9 @@ static const char *VANILLA_IMAGES[] = {
 
 static bool IsVanillaImage(const char *pImage)
 {
-	for(auto &i : VANILLA_IMAGES)
+	for(const auto *pVanillaImage : VANILLA_IMAGES)
 	{
-		if(str_comp(pImage, i) == 0)
+		if(str_comp(pImage, pVanillaImage) == 0)
 		{
 			return true;
 		}
@@ -1687,10 +1687,10 @@ void CEditor::DoQuad(CQuad *q, int Index)
 					for(int i = 0; i < m_lSelectedQuads.size(); ++i)
 					{
 						CQuad *pCurrentQuad = &pLayer->m_lQuads[m_lSelectedQuads[i]];
-						for(auto &m_aPoint : pCurrentQuad->m_aPoints)
+						for(auto &Point : pCurrentQuad->m_aPoints)
 						{
-							m_aPoint.x += OffsetX;
-							m_aPoint.y += OffsetY;
+							Point.x += OffsetX;
+							Point.y += OffsetY;
 						}
 					}
 				}
@@ -1702,10 +1702,10 @@ void CEditor::DoQuad(CQuad *q, int Index)
 					for(int i = 0; i < m_lSelectedQuads.size(); ++i)
 					{
 						CQuad *pCurrentQuad = &pLayer->m_lQuads[m_lSelectedQuads[i]];
-						for(auto &m_aPoint : pCurrentQuad->m_aPoints)
+						for(auto &Point : pCurrentQuad->m_aPoints)
 						{
-							m_aPoint.x += OffsetX;
-							m_aPoint.y += OffsetY;
+							Point.x += OffsetX;
+							Point.y += OffsetY;
 						}
 					}
 				}

--- a/src/game/editor/io.cpp
+++ b/src/game/editor/io.cpp
@@ -915,10 +915,10 @@ int CEditorMap::Load(class IStorage *pStorage, const char *pFileName, int Storag
 								for(int i = 0; i < pTiles->m_Width * pTiles->m_Height; i++)
 								{
 									pTiles->m_pTiles[i].m_Index = 0;
-									for(unsigned e = 0; e < sizeof(s_aTilesRep) / sizeof(s_aTilesRep[0]); e++)
+									for(int e : s_aTilesRep)
 									{
-										if(((CLayerTele *)pTiles)->m_pTeleTile[i].m_Type == s_aTilesRep[e])
-											pTiles->m_pTiles[i].m_Index = s_aTilesRep[e];
+										if(((CLayerTele *)pTiles)->m_pTeleTile[i].m_Type == e)
+											pTiles->m_pTiles[i].m_Index = e;
 									}
 								}
 							}
@@ -988,11 +988,11 @@ int CEditorMap::Load(class IStorage *pStorage, const char *pFileName, int Storag
 										continue;
 									}
 
-									for(unsigned e = 0; e < sizeof(s_aTilesComp) / sizeof(s_aTilesComp[0]); e++)
+									for(int e : s_aTilesComp)
 									{
-										if(pLayerSwitchTiles[i].m_Type == s_aTilesComp[e])
+										if(pLayerSwitchTiles[i].m_Type == e)
 										{
-											pTiles->m_pTiles[i].m_Index = s_aTilesComp[e];
+											pTiles->m_pTiles[i].m_Index = e;
 											pTiles->m_pTiles[i].m_Flags = pLayerSwitchTiles[i].m_Flags;
 										}
 									}

--- a/src/game/editor/io.cpp
+++ b/src/game/editor/io.cpp
@@ -915,10 +915,10 @@ int CEditorMap::Load(class IStorage *pStorage, const char *pFileName, int Storag
 								for(int i = 0; i < pTiles->m_Width * pTiles->m_Height; i++)
 								{
 									pTiles->m_pTiles[i].m_Index = 0;
-									for(int e : s_aTilesRep)
+									for(int TilesRep : s_aTilesRep)
 									{
-										if(((CLayerTele *)pTiles)->m_pTeleTile[i].m_Type == e)
-											pTiles->m_pTiles[i].m_Index = e;
+										if(((CLayerTele *)pTiles)->m_pTeleTile[i].m_Type == TilesRep)
+											pTiles->m_pTiles[i].m_Index = TilesRep;
 									}
 								}
 							}
@@ -988,11 +988,11 @@ int CEditorMap::Load(class IStorage *pStorage, const char *pFileName, int Storag
 										continue;
 									}
 
-									for(int e : s_aTilesComp)
+									for(int TilesComp : s_aTilesComp)
 									{
-										if(pLayerSwitchTiles[i].m_Type == e)
+										if(pLayerSwitchTiles[i].m_Type == TilesComp)
 										{
-											pTiles->m_pTiles[i].m_Index = e;
+											pTiles->m_pTiles[i].m_Index = TilesComp;
 											pTiles->m_pTiles[i].m_Flags = pLayerSwitchTiles[i].m_Flags;
 										}
 									}

--- a/src/game/editor/layer_quads.cpp
+++ b/src/game/editor/layer_quads.cpp
@@ -124,10 +124,10 @@ int CLayerQuads::BrushGrab(CLayerGroup *pBrush, CUIRect Rect)
 			CQuad n;
 			n = *q;
 
-			for(auto &m_aPoint : n.m_aPoints)
+			for(auto &Point : n.m_aPoints)
 			{
-				m_aPoint.x -= f2fx(Rect.x);
-				m_aPoint.y -= f2fx(Rect.y);
+				Point.x -= f2fx(Rect.x);
+				Point.y -= f2fx(Rect.y);
 			}
 
 			pGrabbed->m_lQuads.add(n);
@@ -144,10 +144,10 @@ void CLayerQuads::BrushPlace(CLayer *pBrush, float wx, float wy)
 	{
 		CQuad n = l->m_lQuads[i];
 
-		for(auto &m_aPoint : n.m_aPoints)
+		for(auto &Point : n.m_aPoints)
 		{
-			m_aPoint.x += f2fx(wx);
-			m_aPoint.y += f2fx(wy);
+			Point.x += f2fx(wx);
+			Point.y += f2fx(wy);
 		}
 
 		m_lQuads.add(n);
@@ -211,12 +211,12 @@ void CLayerQuads::BrushRotate(float Amount)
 	{
 		CQuad *q = &m_lQuads[i];
 
-		for(auto &m_aPoint : q->m_aPoints)
+		for(auto &Point : q->m_aPoints)
 		{
-			vec2 Pos(fx2f(m_aPoint.x), fx2f(m_aPoint.y));
+			vec2 Pos(fx2f(Point.x), fx2f(Point.y));
 			Rotate(&Center, &Pos, Amount);
-			m_aPoint.x = f2fx(Pos.x);
-			m_aPoint.y = f2fx(Pos.y);
+			Point.x = f2fx(Pos.x);
+			Point.y = f2fx(Pos.y);
 		}
 	}
 }
@@ -228,10 +228,10 @@ void CLayerQuads::GetSize(float *w, float *h)
 
 	for(int i = 0; i < m_lQuads.size(); i++)
 	{
-		for(auto &m_aPoint : m_lQuads[i].m_aPoints)
+		for(auto &Point : m_lQuads[i].m_aPoints)
 		{
-			*w = maximum(*w, fx2f(m_aPoint.x));
-			*h = maximum(*h, fx2f(m_aPoint.y));
+			*w = maximum(*w, fx2f(Point.x));
+			*h = maximum(*h, fx2f(Point.y));
 		}
 	}
 }

--- a/src/game/editor/layer_quads.cpp
+++ b/src/game/editor/layer_quads.cpp
@@ -124,10 +124,10 @@ int CLayerQuads::BrushGrab(CLayerGroup *pBrush, CUIRect Rect)
 			CQuad n;
 			n = *q;
 
-			for(int p = 0; p < 5; p++)
+			for(auto &m_aPoint : n.m_aPoints)
 			{
-				n.m_aPoints[p].x -= f2fx(Rect.x);
-				n.m_aPoints[p].y -= f2fx(Rect.y);
+				m_aPoint.x -= f2fx(Rect.x);
+				m_aPoint.y -= f2fx(Rect.y);
 			}
 
 			pGrabbed->m_lQuads.add(n);
@@ -144,10 +144,10 @@ void CLayerQuads::BrushPlace(CLayer *pBrush, float wx, float wy)
 	{
 		CQuad n = l->m_lQuads[i];
 
-		for(int p = 0; p < 5; p++)
+		for(auto &m_aPoint : n.m_aPoints)
 		{
-			n.m_aPoints[p].x += f2fx(wx);
-			n.m_aPoints[p].y += f2fx(wy);
+			m_aPoint.x += f2fx(wx);
+			m_aPoint.y += f2fx(wy);
 		}
 
 		m_lQuads.add(n);
@@ -211,12 +211,12 @@ void CLayerQuads::BrushRotate(float Amount)
 	{
 		CQuad *q = &m_lQuads[i];
 
-		for(int p = 0; p < 5; p++)
+		for(auto &m_aPoint : q->m_aPoints)
 		{
-			vec2 Pos(fx2f(q->m_aPoints[p].x), fx2f(q->m_aPoints[p].y));
+			vec2 Pos(fx2f(m_aPoint.x), fx2f(m_aPoint.y));
 			Rotate(&Center, &Pos, Amount);
-			q->m_aPoints[p].x = f2fx(Pos.x);
-			q->m_aPoints[p].y = f2fx(Pos.y);
+			m_aPoint.x = f2fx(Pos.x);
+			m_aPoint.y = f2fx(Pos.y);
 		}
 	}
 }
@@ -228,10 +228,10 @@ void CLayerQuads::GetSize(float *w, float *h)
 
 	for(int i = 0; i < m_lQuads.size(); i++)
 	{
-		for(int p = 0; p < 5; p++)
+		for(auto &m_aPoint : m_lQuads[i].m_aPoints)
 		{
-			*w = maximum(*w, fx2f(m_lQuads[i].m_aPoints[p].x));
-			*h = maximum(*h, fx2f(m_lQuads[i].m_aPoints[p].y));
+			*w = maximum(*w, fx2f(m_aPoint.x));
+			*h = maximum(*h, fx2f(m_aPoint.y));
 		}
 	}
 }

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -638,13 +638,13 @@ int CEditor::PopupQuad(CEditor *pEditor, CUIRect View, void *pContext)
 	{
 		if(Prop == PROP_POS_X)
 		{
-			for(auto &m_aPoint : lQuads[i]->m_aPoints)
-				m_aPoint.x += OffsetX;
+			for(auto &Point : lQuads[i]->m_aPoints)
+				Point.x += OffsetX;
 		}
 		if(Prop == PROP_POS_Y)
 		{
-			for(auto &m_aPoint : lQuads[i]->m_aPoints)
-				m_aPoint.y += OffsetY;
+			for(auto &Point : lQuads[i]->m_aPoints)
+				Point.y += OffsetY;
 		}
 		if(Prop == PROP_POS_ENV)
 		{

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -638,13 +638,13 @@ int CEditor::PopupQuad(CEditor *pEditor, CUIRect View, void *pContext)
 	{
 		if(Prop == PROP_POS_X)
 		{
-			for(int k = 0; k < 5; ++k)
-				lQuads[i]->m_aPoints[k].x += OffsetX;
+			for(auto &m_aPoint : lQuads[i]->m_aPoints)
+				m_aPoint.x += OffsetX;
 		}
 		if(Prop == PROP_POS_Y)
 		{
-			for(int k = 0; k < 5; ++k)
-				lQuads[i]->m_aPoints[k].y += OffsetY;
+			for(auto &m_aPoint : lQuads[i]->m_aPoints)
+				m_aPoint.y += OffsetY;
 		}
 		if(Prop == PROP_POS_ENV)
 		{

--- a/src/game/mapbugs.cpp
+++ b/src/game/mapbugs.cpp
@@ -50,11 +50,11 @@ CMapBugs GetMapBugs(const char *pName, int Size, SHA256_DIGEST Sha256)
 	CMapDescription Map = {pName, Size, Sha256};
 	CMapBugs Result;
 	Result.m_Extra = 0;
-	for(unsigned int i = 0; i < sizeof(MAP_BUGS) / sizeof(MAP_BUGS[0]); i++)
+	for(auto &i : MAP_BUGS)
 	{
-		if(Map == MAP_BUGS[i].m_Map)
+		if(Map == i.m_Map)
 		{
-			Result.m_pData = &MAP_BUGS[i];
+			Result.m_pData = &i;
 			return Result;
 		}
 	}

--- a/src/game/mapbugs.cpp
+++ b/src/game/mapbugs.cpp
@@ -50,11 +50,11 @@ CMapBugs GetMapBugs(const char *pName, int Size, SHA256_DIGEST Sha256)
 	CMapDescription Map = {pName, Size, Sha256};
 	CMapBugs Result;
 	Result.m_Extra = 0;
-	for(auto &i : MAP_BUGS)
+	for(auto &MapBug : MAP_BUGS)
 	{
-		if(Map == i.m_Map)
+		if(Map == MapBug.m_Map)
 		{
-			Result.m_pData = &i;
+			Result.m_pData = &MapBug;
 			return Result;
 		}
 	}

--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -262,12 +262,12 @@ void CGameContext::ConRules(IConsole::IResult *pResult, void *pUserData)
 		_RL(9),
 		_RL(10),
 	};
-	for(unsigned i = 0; i < sizeof(pRuleLines) / sizeof(pRuleLines[0]); i++)
+	for(auto &pRuleLine : pRuleLines)
 	{
-		if(pRuleLines[i][0])
+		if(pRuleLine[0])
 		{
 			pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD,
-				"rules", pRuleLines[i]);
+				"rules", pRuleLine);
 			Printed = true;
 		}
 	}

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -2259,9 +2259,9 @@ void CCharacter::DDRacePostCoreTick()
 	std::list<int> Indices = GameServer()->Collision()->GetMapIndices(m_PrevPos, m_Pos);
 	if(!Indices.empty())
 	{
-		for(int &Indice : Indices)
+		for(int &Index : Indices)
 		{
-			HandleTiles(Indice);
+			HandleTiles(Index);
 			if(!m_Alive)
 				return;
 		}

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -2259,9 +2259,9 @@ void CCharacter::DDRacePostCoreTick()
 	std::list<int> Indices = GameServer()->Collision()->GetMapIndices(m_PrevPos, m_Pos);
 	if(!Indices.empty())
 	{
-		for(std::list<int>::iterator i = Indices.begin(); i != Indices.end(); i++)
+		for(int &Indice : Indices)
 		{
-			HandleTiles(*i);
+			HandleTiles(Indice);
 			if(!m_Alive)
 				return;
 		}

--- a/src/game/server/entities/dragger.cpp
+++ b/src/game/server/entities/dragger.cpp
@@ -21,9 +21,9 @@ CDragger::CDragger(CGameWorld *pGameWorld, vec2 Pos, float Strength, bool NW,
 	m_CaughtTeam = CaughtTeam;
 	GameWorld()->InsertEntity(this);
 
-	for(int &m_SoloID : m_SoloIDs)
+	for(int &SoloID : m_SoloIDs)
 	{
-		m_SoloID = -1;
+		SoloID = -1;
 	}
 }
 
@@ -84,10 +84,10 @@ void CDragger::Move()
 
 	if(m_Target)
 	{
-		for(auto &m_SoloEnt : m_SoloEnts)
+		for(auto &SoloEnt : m_SoloEnts)
 		{
-			if(m_SoloEnt == m_Target)
-				m_SoloEnt = 0;
+			if(SoloEnt == m_Target)
+				SoloEnt = 0;
 		}
 	}
 }
@@ -163,13 +163,13 @@ void CDragger::Snap(int SnappingClient)
 
 	CCharacter *Target = m_Target;
 
-	for(int &m_SoloID : m_SoloIDs)
+	for(int &SoloID : m_SoloIDs)
 	{
-		if(m_SoloID == -1)
+		if(SoloID == -1)
 			break;
 
-		Server()->SnapFreeID(m_SoloID);
-		m_SoloID = -1;
+		Server()->SnapFreeID(SoloID);
+		SoloID = -1;
 	}
 
 	int pos = 0;

--- a/src/game/server/entities/dragger.cpp
+++ b/src/game/server/entities/dragger.cpp
@@ -21,9 +21,9 @@ CDragger::CDragger(CGameWorld *pGameWorld, vec2 Pos, float Strength, bool NW,
 	m_CaughtTeam = CaughtTeam;
 	GameWorld()->InsertEntity(this);
 
-	for(int i = 0; i < MAX_CLIENTS; i++)
+	for(int &m_SoloID : m_SoloIDs)
 	{
-		m_SoloIDs[i] = -1;
+		m_SoloID = -1;
 	}
 }
 
@@ -84,10 +84,10 @@ void CDragger::Move()
 
 	if(m_Target)
 	{
-		for(int i = 0; i < MAX_CLIENTS; i++)
+		for(auto &m_SoloEnt : m_SoloEnts)
 		{
-			if(m_SoloEnts[i] == m_Target)
-				m_SoloEnts[i] = 0;
+			if(m_SoloEnt == m_Target)
+				m_SoloEnt = 0;
 		}
 	}
 }
@@ -163,13 +163,13 @@ void CDragger::Snap(int SnappingClient)
 
 	CCharacter *Target = m_Target;
 
-	for(int i = 0; i < MAX_CLIENTS; i++)
+	for(int &m_SoloID : m_SoloIDs)
 	{
-		if(m_SoloIDs[i] == -1)
+		if(m_SoloID == -1)
 			break;
 
-		Server()->SnapFreeID(m_SoloIDs[i]);
-		m_SoloIDs[i] = -1;
+		Server()->SnapFreeID(m_SoloID);
+		m_SoloID = -1;
 	}
 
 	int pos = 0;

--- a/src/game/server/entities/light.cpp
+++ b/src/game/server/entities/light.cpp
@@ -27,10 +27,8 @@ bool CLight::HitCharacter()
 		GameServer()->m_World.IntersectedCharacters(m_Pos, m_To, 0.0f, 0);
 	if(HitCharacters.empty())
 		return false;
-	for(std::list<CCharacter *>::iterator i = HitCharacters.begin();
-		i != HitCharacters.end(); i++)
+	for(auto *Char : HitCharacters)
 	{
-		CCharacter *Char = *i;
 		if(m_Layer == LAYER_SWITCH && !GameServer()->Collision()->m_pSwitchers[m_Number].m_Status[Char->Team()])
 			continue;
 		Char->Freeze();

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -37,8 +37,8 @@ void CGameContext::Construct(int Resetting)
 	m_Resetting = 0;
 	m_pServer = 0;
 
-	for(auto &m_apPlayer : m_apPlayers)
-		m_apPlayer = 0;
+	for(auto &pPlayer : m_apPlayers)
+		pPlayer = 0;
 
 	m_pController = 0;
 	m_VoteType = VOTE_TYPE_UNKNOWN;
@@ -75,8 +75,8 @@ CGameContext::CGameContext()
 
 CGameContext::~CGameContext()
 {
-	for(auto &m_apPlayer : m_apPlayers)
-		delete m_apPlayer;
+	for(auto &pPlayer : m_apPlayers)
+		delete pPlayer;
 	if(!m_Resetting)
 		delete m_pVoteOptionHeap;
 
@@ -142,10 +142,10 @@ void CGameContext::FillAntibot(CAntibotRoundData *pData)
 	for(int i = 0; i < MAX_CLIENTS; i++)
 	{
 		CAntibotCharacterData *pChar = &pData->m_aCharacters[i];
-		for(auto &m_aLatestInput : pChar->m_aLatestInputs)
+		for(auto &LatestInput : pChar->m_aLatestInputs)
 		{
-			m_aLatestInput.m_TargetX = -1;
-			m_aLatestInput.m_TargetY = -1;
+			LatestInput.m_TargetX = -1;
+			LatestInput.m_TargetY = -1;
 		}
 		pChar->m_Alive = false;
 		pChar->m_Pause = false;
@@ -479,12 +479,12 @@ void CGameContext::SendBroadcast(const char *pText, int ClientID, bool IsImporta
 		dbg_assert(IsImportant, "broadcast messages to all players must be important");
 		Server()->SendPackMsg(&Msg, MSGFLAG_VITAL, ClientID);
 
-		for(auto &m_apPlayer : m_apPlayers)
+		for(auto &pPlayer : m_apPlayers)
 		{
-			if(m_apPlayer)
+			if(pPlayer)
 			{
-				m_apPlayer->m_LastBroadcastImportance = true;
-				m_apPlayer->m_LastBroadcast = Server()->Tick();
+				pPlayer->m_LastBroadcastImportance = true;
+				pPlayer->m_LastBroadcast = Server()->Tick();
 			}
 		}
 		return;
@@ -506,12 +506,12 @@ void CGameContext::StartVote(const char *pDesc, const char *pCommand, const char
 	// reset votes
 	m_VoteEnforce = VOTE_ENFORCE_UNKNOWN;
 	m_VoteEnforcer = -1;
-	for(auto &m_apPlayer : m_apPlayers)
+	for(auto &pPlayer : m_apPlayers)
 	{
-		if(m_apPlayer)
+		if(pPlayer)
 		{
-			m_apPlayer->m_Vote = 0;
-			m_apPlayer->m_VotePos = 0;
+			pPlayer->m_Vote = 0;
+			pPlayer->m_VotePos = 0;
 		}
 	}
 
@@ -784,10 +784,10 @@ void CGameContext::OnTick()
 		}
 	}
 
-	for(auto &m_apPlayer : m_apPlayers)
+	for(auto &pPlayer : m_apPlayers)
 	{
-		if(m_apPlayer)
-			m_apPlayer->PostPostTick();
+		if(pPlayer)
+			pPlayer->PostPostTick();
 	}
 
 	// update voting
@@ -1309,9 +1309,9 @@ void CGameContext::OnClientConnected(int ClientID)
 {
 	{
 		bool Empty = true;
-		for(auto &m_apPlayer : m_apPlayers)
+		for(auto &pPlayer : m_apPlayers)
 		{
-			if(m_apPlayer)
+			if(pPlayer)
 			{
 				Empty = false;
 				break;
@@ -1379,17 +1379,17 @@ void CGameContext::OnClientDrop(int ClientID, const char *pReason)
 	m_VoteUpdate = true;
 
 	// update spectator modes
-	for(auto &m_apPlayer : m_apPlayers)
+	for(auto &pPlayer : m_apPlayers)
 	{
-		if(m_apPlayer && m_apPlayer->m_SpectatorID == ClientID)
-			m_apPlayer->m_SpectatorID = SPEC_FREEVIEW;
+		if(pPlayer && pPlayer->m_SpectatorID == ClientID)
+			pPlayer->m_SpectatorID = SPEC_FREEVIEW;
 	}
 
 	// update conversation targets
-	for(auto &m_apPlayer : m_apPlayers)
+	for(auto &pPlayer : m_apPlayers)
 	{
-		if(m_apPlayer && m_apPlayer->m_LastWhisperTo == ClientID)
-			m_apPlayer->m_LastWhisperTo = -1;
+		if(pPlayer && pPlayer->m_LastWhisperTo == ClientID)
+			pPlayer->m_LastWhisperTo = -1;
 	}
 
 	protocol7::CNetMsg_Sv_ClientDrop Msg;
@@ -2688,9 +2688,9 @@ void CGameContext::ConSetTeamAll(IConsole::IResult *pResult, void *pUserData)
 	str_format(aBuf, sizeof(aBuf), "All players were moved to the %s", pSelf->m_pController->GetTeamName(Team));
 	pSelf->SendChat(-1, CGameContext::CHAT_ALL, aBuf);
 
-	for(auto &m_apPlayer : pSelf->m_apPlayers)
-		if(m_apPlayer)
-			m_apPlayer->SetTeam(Team, false);
+	for(auto &pPlayer : pSelf->m_apPlayers)
+		if(pPlayer)
+			pPlayer->SetTeam(Team, false);
 }
 
 void CGameContext::ConAddVote(IConsole::IResult *pResult, void *pUserData)
@@ -2789,10 +2789,10 @@ void CGameContext::ConRemoveVote(IConsole::IResult *pResult, void *pUserData)
 	pSelf->Server()->SendPackMsg(&VoteClearOptionsMsg, MSGFLAG_VITAL, -1);
 
 	// reset sending of vote options
-	for(auto &m_apPlayer : pSelf->m_apPlayers)
+	for(auto &pPlayer : pSelf->m_apPlayers)
 	{
-		if(m_apPlayer)
-			m_apPlayer->m_SendVoteIndex = 0;
+		if(pPlayer)
+			pPlayer->m_SendVoteIndex = 0;
 	}
 
 	// TODO: improve this
@@ -2916,10 +2916,10 @@ void CGameContext::ConClearVotes(IConsole::IResult *pResult, void *pUserData)
 	pSelf->m_NumVoteOptions = 0;
 
 	// reset sending of vote options
-	for(auto &m_apPlayer : pSelf->m_apPlayers)
+	for(auto &pPlayer : pSelf->m_apPlayers)
 	{
-		if(m_apPlayer)
-			m_apPlayer->m_SendVoteIndex = 0;
+		if(pPlayer)
+			pPlayer->m_SendVoteIndex = 0;
 	}
 }
 
@@ -3567,10 +3567,10 @@ void CGameContext::OnSnap(int ClientID)
 	m_pController->Snap(ClientID);
 	m_Events.Snap(ClientID);
 
-	for(auto &m_apPlayer : m_apPlayers)
+	for(auto &pPlayer : m_apPlayers)
 	{
-		if(m_apPlayer)
-			m_apPlayer->Snap(ClientID);
+		if(pPlayer)
+			pPlayer->Snap(ClientID);
 	}
 
 	if(ClientID > -1)
@@ -4016,9 +4016,9 @@ int CGameContext::GetClientVersion(int ClientID)
 
 bool CGameContext::PlayerModerating()
 {
-	for(auto &m_apPlayer : m_apPlayers)
+	for(auto &pPlayer : m_apPlayers)
 	{
-		if(m_apPlayer && m_apPlayer->m_Moderating)
+		if(pPlayer && pPlayer->m_Moderating)
 			return true;
 	}
 	return false;

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -37,8 +37,8 @@ void CGameContext::Construct(int Resetting)
 	m_Resetting = 0;
 	m_pServer = 0;
 
-	for(int i = 0; i < MAX_CLIENTS; i++)
-		m_apPlayers[i] = 0;
+	for(auto &m_apPlayer : m_apPlayers)
+		m_apPlayer = 0;
 
 	m_pController = 0;
 	m_VoteType = VOTE_TYPE_UNKNOWN;
@@ -75,8 +75,8 @@ CGameContext::CGameContext()
 
 CGameContext::~CGameContext()
 {
-	for(int i = 0; i < MAX_CLIENTS; i++)
-		delete m_apPlayers[i];
+	for(auto &m_apPlayer : m_apPlayers)
+		delete m_apPlayer;
 	if(!m_Resetting)
 		delete m_pVoteOptionHeap;
 
@@ -142,10 +142,10 @@ void CGameContext::FillAntibot(CAntibotRoundData *pData)
 	for(int i = 0; i < MAX_CLIENTS; i++)
 	{
 		CAntibotCharacterData *pChar = &pData->m_aCharacters[i];
-		for(int i = 0; i < 3; i++)
+		for(auto &m_aLatestInput : pChar->m_aLatestInputs)
 		{
-			pChar->m_aLatestInputs[i].m_TargetX = -1;
-			pChar->m_aLatestInputs[i].m_TargetY = -1;
+			m_aLatestInput.m_TargetX = -1;
+			m_aLatestInput.m_TargetY = -1;
 		}
 		pChar->m_Alive = false;
 		pChar->m_Pause = false;
@@ -479,12 +479,12 @@ void CGameContext::SendBroadcast(const char *pText, int ClientID, bool IsImporta
 		dbg_assert(IsImportant, "broadcast messages to all players must be important");
 		Server()->SendPackMsg(&Msg, MSGFLAG_VITAL, ClientID);
 
-		for(int i = 0; i < MAX_CLIENTS; i++)
+		for(auto &m_apPlayer : m_apPlayers)
 		{
-			if(m_apPlayers[i])
+			if(m_apPlayer)
 			{
-				m_apPlayers[i]->m_LastBroadcastImportance = true;
-				m_apPlayers[i]->m_LastBroadcast = Server()->Tick();
+				m_apPlayer->m_LastBroadcastImportance = true;
+				m_apPlayer->m_LastBroadcast = Server()->Tick();
 			}
 		}
 		return;
@@ -506,12 +506,12 @@ void CGameContext::StartVote(const char *pDesc, const char *pCommand, const char
 	// reset votes
 	m_VoteEnforce = VOTE_ENFORCE_UNKNOWN;
 	m_VoteEnforcer = -1;
-	for(int i = 0; i < MAX_CLIENTS; i++)
+	for(auto &m_apPlayer : m_apPlayers)
 	{
-		if(m_apPlayers[i])
+		if(m_apPlayer)
 		{
-			m_apPlayers[i]->m_Vote = 0;
-			m_apPlayers[i]->m_VotePos = 0;
+			m_apPlayer->m_Vote = 0;
+			m_apPlayer->m_VotePos = 0;
 		}
 	}
 
@@ -784,10 +784,10 @@ void CGameContext::OnTick()
 		}
 	}
 
-	for(int i = 0; i < MAX_CLIENTS; i++)
+	for(auto &m_apPlayer : m_apPlayers)
 	{
-		if(m_apPlayers[i])
-			m_apPlayers[i]->PostPostTick();
+		if(m_apPlayer)
+			m_apPlayer->PostPostTick();
 	}
 
 	// update voting
@@ -1309,9 +1309,9 @@ void CGameContext::OnClientConnected(int ClientID)
 {
 	{
 		bool Empty = true;
-		for(int i = 0; i < MAX_CLIENTS; i++)
+		for(auto &m_apPlayer : m_apPlayers)
 		{
-			if(m_apPlayers[i])
+			if(m_apPlayer)
 			{
 				Empty = false;
 				break;
@@ -1379,17 +1379,17 @@ void CGameContext::OnClientDrop(int ClientID, const char *pReason)
 	m_VoteUpdate = true;
 
 	// update spectator modes
-	for(int i = 0; i < MAX_CLIENTS; ++i)
+	for(auto &m_apPlayer : m_apPlayers)
 	{
-		if(m_apPlayers[i] && m_apPlayers[i]->m_SpectatorID == ClientID)
-			m_apPlayers[i]->m_SpectatorID = SPEC_FREEVIEW;
+		if(m_apPlayer && m_apPlayer->m_SpectatorID == ClientID)
+			m_apPlayer->m_SpectatorID = SPEC_FREEVIEW;
 	}
 
 	// update conversation targets
-	for(int i = 0; i < MAX_CLIENTS; ++i)
+	for(auto &m_apPlayer : m_apPlayers)
 	{
-		if(m_apPlayers[i] && m_apPlayers[i]->m_LastWhisperTo == ClientID)
-			m_apPlayers[i]->m_LastWhisperTo = -1;
+		if(m_apPlayer && m_apPlayer->m_LastWhisperTo == ClientID)
+			m_apPlayer->m_LastWhisperTo = -1;
 	}
 
 	protocol7::CNetMsg_Sv_ClientDrop Msg;
@@ -2688,9 +2688,9 @@ void CGameContext::ConSetTeamAll(IConsole::IResult *pResult, void *pUserData)
 	str_format(aBuf, sizeof(aBuf), "All players were moved to the %s", pSelf->m_pController->GetTeamName(Team));
 	pSelf->SendChat(-1, CGameContext::CHAT_ALL, aBuf);
 
-	for(int i = 0; i < MAX_CLIENTS; ++i)
-		if(pSelf->m_apPlayers[i])
-			pSelf->m_apPlayers[i]->SetTeam(Team, false);
+	for(auto &m_apPlayer : pSelf->m_apPlayers)
+		if(m_apPlayer)
+			m_apPlayer->SetTeam(Team, false);
 }
 
 void CGameContext::ConAddVote(IConsole::IResult *pResult, void *pUserData)
@@ -2789,10 +2789,10 @@ void CGameContext::ConRemoveVote(IConsole::IResult *pResult, void *pUserData)
 	pSelf->Server()->SendPackMsg(&VoteClearOptionsMsg, MSGFLAG_VITAL, -1);
 
 	// reset sending of vote options
-	for(int i = 0; i < MAX_CLIENTS; i++)
+	for(auto &m_apPlayer : pSelf->m_apPlayers)
 	{
-		if(pSelf->m_apPlayers[i])
-			pSelf->m_apPlayers[i]->m_SendVoteIndex = 0;
+		if(m_apPlayer)
+			m_apPlayer->m_SendVoteIndex = 0;
 	}
 
 	// TODO: improve this
@@ -2916,10 +2916,10 @@ void CGameContext::ConClearVotes(IConsole::IResult *pResult, void *pUserData)
 	pSelf->m_NumVoteOptions = 0;
 
 	// reset sending of vote options
-	for(int i = 0; i < MAX_CLIENTS; i++)
+	for(auto &m_apPlayer : pSelf->m_apPlayers)
 	{
-		if(pSelf->m_apPlayers[i])
-			pSelf->m_apPlayers[i]->m_SendVoteIndex = 0;
+		if(m_apPlayer)
+			m_apPlayer->m_SendVoteIndex = 0;
 	}
 }
 
@@ -3567,10 +3567,10 @@ void CGameContext::OnSnap(int ClientID)
 	m_pController->Snap(ClientID);
 	m_Events.Snap(ClientID);
 
-	for(int i = 0; i < MAX_CLIENTS; i++)
+	for(auto &m_apPlayer : m_apPlayers)
 	{
-		if(m_apPlayers[i])
-			m_apPlayers[i]->Snap(ClientID);
+		if(m_apPlayer)
+			m_apPlayer->Snap(ClientID);
 	}
 
 	if(ClientID > -1)
@@ -4016,9 +4016,9 @@ int CGameContext::GetClientVersion(int ClientID)
 
 bool CGameContext::PlayerModerating()
 {
-	for(int i = 0; i < MAX_CLIENTS; i++)
+	for(auto &m_apPlayer : m_apPlayers)
 	{
-		if(m_apPlayers[i] && m_apPlayers[i]->m_Moderating)
+		if(m_apPlayer && m_apPlayer->m_Moderating)
 			return true;
 	}
 	return false;

--- a/src/game/server/gamecontroller.cpp
+++ b/src/game/server/gamecontroller.cpp
@@ -377,9 +377,9 @@ void IGameController::ChangeMap(const char *pToMap)
 
 void IGameController::PostReset()
 {
-	for(auto &m_apPlayer : GameServer()->m_apPlayers)
-		if(m_apPlayer)
-			m_apPlayer->Respawn();
+	for(auto &pPlayer : GameServer()->m_apPlayers)
+		if(pPlayer)
+			pPlayer->Respawn();
 }
 
 int IGameController::OnCharacterDeath(class CCharacter *pVictim, class CPlayer *pKiller, int Weapon)
@@ -462,8 +462,8 @@ void IGameController::Tick()
 					{
 						// move player to spectator if the reserved slots aren't filled yet, kick him otherwise
 						int Spectators = 0;
-						for(auto &m_apPlayer : GameServer()->m_apPlayers)
-							if(m_apPlayer && m_apPlayer->GetTeam() == TEAM_SPECTATORS)
+						for(auto &pPlayer : GameServer()->m_apPlayers)
+							if(pPlayer && pPlayer->GetTeam() == TEAM_SPECTATORS)
 								++Spectators;
 						if(Spectators >= g_Config.m_SvSpectatorSlots)
 							Server()->Kick(i, "Kicked for inactivity");

--- a/src/game/server/gamecontroller.cpp
+++ b/src/game/server/gamecontroller.cpp
@@ -377,9 +377,9 @@ void IGameController::ChangeMap(const char *pToMap)
 
 void IGameController::PostReset()
 {
-	for(int i = 0; i < MAX_CLIENTS; i++)
-		if(GameServer()->m_apPlayers[i])
-			GameServer()->m_apPlayers[i]->Respawn();
+	for(auto &m_apPlayer : GameServer()->m_apPlayers)
+		if(m_apPlayer)
+			m_apPlayer->Respawn();
 }
 
 int IGameController::OnCharacterDeath(class CCharacter *pVictim, class CPlayer *pKiller, int Weapon)
@@ -462,8 +462,8 @@ void IGameController::Tick()
 					{
 						// move player to spectator if the reserved slots aren't filled yet, kick him otherwise
 						int Spectators = 0;
-						for(int j = 0; j < MAX_CLIENTS; ++j)
-							if(GameServer()->m_apPlayers[j] && GameServer()->m_apPlayers[j]->GetTeam() == TEAM_SPECTATORS)
+						for(auto &m_apPlayer : GameServer()->m_apPlayers)
+							if(m_apPlayer && m_apPlayer->GetTeam() == TEAM_SPECTATORS)
 								++Spectators;
 						if(Spectators >= g_Config.m_SvSpectatorSlots)
 							Server()->Kick(i, "Kicked for inactivity");

--- a/src/game/server/gameworld.cpp
+++ b/src/game/server/gameworld.cpp
@@ -18,16 +18,16 @@ CGameWorld::CGameWorld()
 
 	m_Paused = false;
 	m_ResetRequested = false;
-	for(int i = 0; i < NUM_ENTTYPES; i++)
-		m_apFirstEntityTypes[i] = 0;
+	for(auto &m_apFirstEntityType : m_apFirstEntityTypes)
+		m_apFirstEntityType = 0;
 }
 
 CGameWorld::~CGameWorld()
 {
 	// delete all entities
-	for(int i = 0; i < NUM_ENTTYPES; i++)
-		while(m_apFirstEntityTypes[i])
-			delete m_apFirstEntityTypes[i];
+	for(auto &m_apFirstEntityType : m_apFirstEntityTypes)
+		while(m_apFirstEntityType)
+			delete m_apFirstEntityType;
 }
 
 void CGameWorld::SetGameServer(CGameContext *pGameServer)
@@ -107,8 +107,8 @@ void CGameWorld::RemoveEntity(CEntity *pEnt)
 //
 void CGameWorld::Snap(int SnappingClient)
 {
-	for(int i = 0; i < NUM_ENTTYPES; i++)
-		for(CEntity *pEnt = m_apFirstEntityTypes[i]; pEnt;)
+	for(auto *pEnt : m_apFirstEntityTypes)
+		for(; pEnt;)
 		{
 			m_pNextTraverseEntity = pEnt->m_pNextTypeEntity;
 			pEnt->Snap(SnappingClient);
@@ -119,8 +119,8 @@ void CGameWorld::Snap(int SnappingClient)
 void CGameWorld::Reset()
 {
 	// reset all entities
-	for(int i = 0; i < NUM_ENTTYPES; i++)
-		for(CEntity *pEnt = m_apFirstEntityTypes[i]; pEnt;)
+	for(auto *pEnt : m_apFirstEntityTypes)
+		for(; pEnt;)
 		{
 			m_pNextTraverseEntity = pEnt->m_pNextTypeEntity;
 			pEnt->Reset();
@@ -137,8 +137,8 @@ void CGameWorld::Reset()
 void CGameWorld::RemoveEntities()
 {
 	// destroy objects marked for destruction
-	for(int i = 0; i < NUM_ENTTYPES; i++)
-		for(CEntity *pEnt = m_apFirstEntityTypes[i]; pEnt;)
+	for(auto *pEnt : m_apFirstEntityTypes)
+		for(; pEnt;)
 		{
 			m_pNextTraverseEntity = pEnt->m_pNextTypeEntity;
 			if(pEnt->m_MarkedForDestroy)
@@ -204,9 +204,9 @@ void CGameWorld::UpdatePlayerMaps()
 
 		// compute reverse map
 		int rMap[MAX_CLIENTS];
-		for(int j = 0; j < MAX_CLIENTS; j++)
+		for(int &j : rMap)
 		{
-			rMap[j] = -1;
+			j = -1;
 		}
 		for(int j = 0; j < VANILLA_MAX_CLIENTS; j++)
 		{
@@ -254,16 +254,16 @@ void CGameWorld::Tick()
 		if(GameServer()->m_pController->IsForceBalanced())
 			GameServer()->SendChat(-1, CGameContext::CHAT_ALL, "Teams have been balanced");
 		// update all objects
-		for(int i = 0; i < NUM_ENTTYPES; i++)
-			for(CEntity *pEnt = m_apFirstEntityTypes[i]; pEnt;)
+		for(auto *pEnt : m_apFirstEntityTypes)
+			for(; pEnt;)
 			{
 				m_pNextTraverseEntity = pEnt->m_pNextTypeEntity;
 				pEnt->Tick();
 				pEnt = m_pNextTraverseEntity;
 			}
 
-		for(int i = 0; i < NUM_ENTTYPES; i++)
-			for(CEntity *pEnt = m_apFirstEntityTypes[i]; pEnt;)
+		for(auto *pEnt : m_apFirstEntityTypes)
+			for(; pEnt;)
 			{
 				m_pNextTraverseEntity = pEnt->m_pNextTypeEntity;
 				pEnt->TickDefered();
@@ -273,8 +273,8 @@ void CGameWorld::Tick()
 	else
 	{
 		// update all objects
-		for(int i = 0; i < NUM_ENTTYPES; i++)
-			for(CEntity *pEnt = m_apFirstEntityTypes[i]; pEnt;)
+		for(auto *pEnt : m_apFirstEntityTypes)
+			for(; pEnt;)
 			{
 				m_pNextTraverseEntity = pEnt->m_pNextTypeEntity;
 				pEnt->TickPaused();

--- a/src/game/server/gameworld.cpp
+++ b/src/game/server/gameworld.cpp
@@ -18,16 +18,16 @@ CGameWorld::CGameWorld()
 
 	m_Paused = false;
 	m_ResetRequested = false;
-	for(auto &m_apFirstEntityType : m_apFirstEntityTypes)
-		m_apFirstEntityType = 0;
+	for(auto &pFirstEntityType : m_apFirstEntityTypes)
+		pFirstEntityType = 0;
 }
 
 CGameWorld::~CGameWorld()
 {
 	// delete all entities
-	for(auto &m_apFirstEntityType : m_apFirstEntityTypes)
-		while(m_apFirstEntityType)
-			delete m_apFirstEntityType;
+	for(auto &pFirstEntityType : m_apFirstEntityTypes)
+		while(pFirstEntityType)
+			delete pFirstEntityType;
 }
 
 void CGameWorld::SetGameServer(CGameContext *pGameServer)

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -655,10 +655,10 @@ void CPlayer::SetTeam(int Team, bool DoChatMsg)
 	if(Team == TEAM_SPECTATORS)
 	{
 		// update spectator modes
-		for(auto &m_apPlayer : GameServer()->m_apPlayers)
+		for(auto &pPlayer : GameServer()->m_apPlayers)
 		{
-			if(m_apPlayer && m_apPlayer->m_SpectatorID == m_ClientID)
-				m_apPlayer->m_SpectatorID = SPEC_FREEVIEW;
+			if(pPlayer && pPlayer->m_SpectatorID == m_ClientID)
+				pPlayer->m_SpectatorID = SPEC_FREEVIEW;
 		}
 	}
 }
@@ -931,19 +931,19 @@ void CPlayer::ProcessScoreResult(CScorePlayerResult &Result)
 		switch(Result.m_MessageKind)
 		{
 		case CScorePlayerResult::DIRECT:
-			for(auto &m_aaMessage : Result.m_Data.m_aaMessages)
+			for(auto &aMessage : Result.m_Data.m_aaMessages)
 			{
-				if(m_aaMessage[0] == 0)
+				if(aMessage[0] == 0)
 					break;
-				GameServer()->SendChatTarget(m_ClientID, m_aaMessage);
+				GameServer()->SendChatTarget(m_ClientID, aMessage);
 			}
 			break;
 		case CScorePlayerResult::ALL:
-			for(auto &m_aaMessage : Result.m_Data.m_aaMessages)
+			for(auto &aMessage : Result.m_Data.m_aaMessages)
 			{
-				if(m_aaMessage[0] == 0)
+				if(aMessage[0] == 0)
 					break;
-				GameServer()->SendChat(-1, CGameContext::CHAT_ALL, m_aaMessage, m_ClientID);
+				GameServer()->SendChat(-1, CGameContext::CHAT_ALL, aMessage, m_ClientID);
 			}
 			break;
 		case CScorePlayerResult::BROADCAST:

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -655,10 +655,10 @@ void CPlayer::SetTeam(int Team, bool DoChatMsg)
 	if(Team == TEAM_SPECTATORS)
 	{
 		// update spectator modes
-		for(int i = 0; i < MAX_CLIENTS; ++i)
+		for(auto &m_apPlayer : GameServer()->m_apPlayers)
 		{
-			if(GameServer()->m_apPlayers[i] && GameServer()->m_apPlayers[i]->m_SpectatorID == m_ClientID)
-				GameServer()->m_apPlayers[i]->m_SpectatorID = SPEC_FREEVIEW;
+			if(m_apPlayer && m_apPlayer->m_SpectatorID == m_ClientID)
+				m_apPlayer->m_SpectatorID = SPEC_FREEVIEW;
 		}
 	}
 }
@@ -931,19 +931,19 @@ void CPlayer::ProcessScoreResult(CScorePlayerResult &Result)
 		switch(Result.m_MessageKind)
 		{
 		case CScorePlayerResult::DIRECT:
-			for(int i = 0; i < CScorePlayerResult::MAX_MESSAGES; i++)
+			for(auto &m_aaMessage : Result.m_Data.m_aaMessages)
 			{
-				if(Result.m_Data.m_aaMessages[i][0] == 0)
+				if(m_aaMessage[0] == 0)
 					break;
-				GameServer()->SendChatTarget(m_ClientID, Result.m_Data.m_aaMessages[i]);
+				GameServer()->SendChatTarget(m_ClientID, m_aaMessage);
 			}
 			break;
 		case CScorePlayerResult::ALL:
-			for(int i = 0; i < CScorePlayerResult::MAX_MESSAGES; i++)
+			for(auto &m_aaMessage : Result.m_Data.m_aaMessages)
 			{
-				if(Result.m_Data.m_aaMessages[i][0] == 0)
+				if(m_aaMessage[0] == 0)
 					break;
-				GameServer()->SendChat(-1, CGameContext::CHAT_ALL, Result.m_Data.m_aaMessages[i], m_ClientID);
+				GameServer()->SendChat(-1, CGameContext::CHAT_ALL, m_aaMessage, m_ClientID);
 			}
 			break;
 		case CScorePlayerResult::BROADCAST:

--- a/src/game/server/score.cpp
+++ b/src/game/server/score.cpp
@@ -30,8 +30,8 @@ void CScorePlayerResult::SetVariant(Variant v)
 	{
 	case DIRECT:
 	case ALL:
-		for(auto &m_aaMessage : m_Data.m_aaMessages)
-			m_aaMessage[0] = 0;
+		for(auto &aMessage : m_Data.m_aaMessages)
+			aMessage[0] = 0;
 		break;
 	case BROADCAST:
 		m_Data.m_Broadcast[0] = 0;
@@ -46,16 +46,16 @@ void CScorePlayerResult::SetVariant(Variant v)
 		m_Data.m_Info.m_Birthday = 0;
 		m_Data.m_Info.m_HasFinishScore = false;
 		m_Data.m_Info.m_Time = 0;
-		for(float &i : m_Data.m_Info.m_CpTime)
-			i = 0;
+		for(float &CpTime : m_Data.m_Info.m_CpTime)
+			CpTime = 0;
 	}
 }
 
 CTeamrank::CTeamrank() :
 	m_NumNames(0)
 {
-	for(auto &m_aaName : m_aaNames)
-		m_aaName[0] = '\0';
+	for(auto &aName : m_aaNames)
+		aName[0] = '\0';
 	mem_zero(&m_TeamID.m_aData, sizeof(m_TeamID));
 }
 

--- a/src/game/server/score.cpp
+++ b/src/game/server/score.cpp
@@ -275,7 +275,7 @@ void CScore::MapVote(int ClientID, const char *MapName)
 bool CScore::MapVoteThread(IDbConnection *pSqlServer, const ISqlData *pGameData)
 {
 	const CSqlPlayerRequest *pData = dynamic_cast<const CSqlPlayerRequest *>(pGameData);
-	auto paMessages = pData->m_pResult->m_Data.m_aaMessages;
+	auto *paMessages = pData->m_pResult->m_Data.m_aaMessages;
 
 	char aFuzzyMap[128];
 	str_copy(aFuzzyMap, pData->m_Name, sizeof(aFuzzyMap));
@@ -304,7 +304,7 @@ bool CScore::MapVoteThread(IDbConnection *pSqlServer, const ISqlData *pGameData)
 	if(pSqlServer->Step())
 	{
 		pData->m_pResult->SetVariant(CScorePlayerResult::MAP_VOTE);
-		auto MapVote = &pData->m_pResult->m_Data.m_MapVote;
+		auto *MapVote = &pData->m_pResult->m_Data.m_MapVote;
 		pSqlServer->GetString(1, MapVote->m_Map, sizeof(MapVote->m_Map));
 		pSqlServer->GetString(2, MapVote->m_Server, sizeof(MapVote->m_Server));
 		strcpy(MapVote->m_Reason, "/map");
@@ -474,7 +474,7 @@ void CScore::SaveScore(int ClientID, float Time, const char *pTimestamp, float C
 bool CScore::SaveScoreThread(IDbConnection *pSqlServer, const ISqlData *pGameData, bool Failure)
 {
 	const CSqlScoreData *pData = dynamic_cast<const CSqlScoreData *>(pGameData);
-	auto paMessages = pData->m_pResult->m_Data.m_aaMessages;
+	auto *paMessages = pData->m_pResult->m_Data.m_aaMessages;
 
 	char aBuf[1024];
 
@@ -843,7 +843,7 @@ void CScore::ShowTeamTop5(int ClientID, int Offset)
 bool CScore::ShowTeamTop5Thread(IDbConnection *pSqlServer, const ISqlData *pGameData)
 {
 	const CSqlPlayerRequest *pData = dynamic_cast<const CSqlPlayerRequest *>(pGameData);
-	auto paMessages = pData->m_pResult->m_Data.m_aaMessages;
+	auto *paMessages = pData->m_pResult->m_Data.m_aaMessages;
 
 	int LimitStart = maximum(abs(pData->m_Offset) - 1, 0);
 	const char *pOrder = pData->m_Offset >= 0 ? "ASC" : "DESC";
@@ -933,7 +933,7 @@ void CScore::ShowTimes(int ClientID, const char *pName, int Offset)
 bool CScore::ShowTimesThread(IDbConnection *pSqlServer, const ISqlData *pGameData)
 {
 	const CSqlPlayerRequest *pData = dynamic_cast<const CSqlPlayerRequest *>(pGameData);
-	auto paMessages = pData->m_pResult->m_Data.m_aaMessages;
+	auto *paMessages = pData->m_pResult->m_Data.m_aaMessages;
 
 	int LimitStart = maximum(abs(pData->m_Offset) - 1, 0);
 	const char *pOrder = pData->m_Offset >= 0 ? "DESC" : "ASC";
@@ -1036,7 +1036,7 @@ void CScore::ShowPoints(int ClientID, const char *pName)
 bool CScore::ShowPointsThread(IDbConnection *pSqlServer, const ISqlData *pGameData)
 {
 	const CSqlPlayerRequest *pData = dynamic_cast<const CSqlPlayerRequest *>(pGameData);
-	auto paMessages = pData->m_pResult->m_Data.m_aaMessages;
+	auto *paMessages = pData->m_pResult->m_Data.m_aaMessages;
 
 	char aBuf[512];
 	str_format(aBuf, sizeof(aBuf),
@@ -1081,7 +1081,7 @@ void CScore::ShowTopPoints(int ClientID, int Offset)
 bool CScore::ShowTopPointsThread(IDbConnection *pSqlServer, const ISqlData *pGameData)
 {
 	const CSqlPlayerRequest *pData = dynamic_cast<const CSqlPlayerRequest *>(pGameData);
-	auto paMessages = pData->m_pResult->m_Data.m_aaMessages;
+	auto *paMessages = pData->m_pResult->m_Data.m_aaMessages;
 
 	int LimitStart = maximum(abs(pData->m_Offset) - 1, 0);
 	const char *pOrder = pData->m_Offset >= 0 ? "ASC" : "DESC";
@@ -1246,7 +1246,7 @@ void CScore::SaveTeam(int ClientID, const char *Code, const char *Server)
 {
 	if(RateLimitPlayer(ClientID))
 		return;
-	auto pController = ((CGameControllerDDRace *)(GameServer()->m_pController));
+	auto *pController = ((CGameControllerDDRace *)(GameServer()->m_pController));
 	int Team = pController->m_Teams.m_Core.Team(ClientID);
 	if(pController->m_Teams.GetSaving(Team))
 		return;
@@ -1376,7 +1376,7 @@ void CScore::LoadTeam(const char *Code, int ClientID)
 {
 	if(RateLimitPlayer(ClientID))
 		return;
-	auto pController = ((CGameControllerDDRace *)(GameServer()->m_pController));
+	auto *pController = ((CGameControllerDDRace *)(GameServer()->m_pController));
 	int Team = pController->m_Teams.m_Core.Team(ClientID);
 	if(pController->m_Teams.GetSaving(Team))
 		return;
@@ -1519,7 +1519,7 @@ void CScore::GetSaves(int ClientID)
 bool CScore::GetSavesThread(IDbConnection *pSqlServer, const ISqlData *pGameData)
 {
 	const CSqlPlayerRequest *pData = dynamic_cast<const CSqlPlayerRequest *>(pGameData);
-	auto paMessages = pData->m_pResult->m_Data.m_aaMessages;
+	auto *paMessages = pData->m_pResult->m_Data.m_aaMessages;
 
 	char aSaveLike[128] = "";
 	str_append(aSaveLike, "%\n", sizeof(aSaveLike));

--- a/src/game/server/score.cpp
+++ b/src/game/server/score.cpp
@@ -30,8 +30,8 @@ void CScorePlayerResult::SetVariant(Variant v)
 	{
 	case DIRECT:
 	case ALL:
-		for(int i = 0; i < MAX_MESSAGES; i++)
-			m_Data.m_aaMessages[i][0] = 0;
+		for(auto &m_aaMessage : m_Data.m_aaMessages)
+			m_aaMessage[0] = 0;
 		break;
 	case BROADCAST:
 		m_Data.m_Broadcast[0] = 0;
@@ -46,16 +46,16 @@ void CScorePlayerResult::SetVariant(Variant v)
 		m_Data.m_Info.m_Birthday = 0;
 		m_Data.m_Info.m_HasFinishScore = false;
 		m_Data.m_Info.m_Time = 0;
-		for(int i = 0; i < NUM_CHECKPOINTS; i++)
-			m_Data.m_Info.m_CpTime[i] = 0;
+		for(float &i : m_Data.m_Info.m_CpTime)
+			i = 0;
 	}
 }
 
 CTeamrank::CTeamrank() :
 	m_NumNames(0)
 {
-	for(int i = 0; i < MAX_CLIENTS; i++)
-		m_aaNames[i][0] = '\0';
+	for(auto &m_aaName : m_aaNames)
+		m_aaName[0] = '\0';
 	mem_zero(&m_TeamID.m_aData, sizeof(m_TeamID));
 }
 

--- a/src/game/server/score.cpp
+++ b/src/game/server/score.cpp
@@ -307,7 +307,7 @@ bool CScore::MapVoteThread(IDbConnection *pSqlServer, const ISqlData *pGameData)
 		auto *MapVote = &pData->m_pResult->m_Data.m_MapVote;
 		pSqlServer->GetString(1, MapVote->m_Map, sizeof(MapVote->m_Map));
 		pSqlServer->GetString(2, MapVote->m_Server, sizeof(MapVote->m_Server));
-		strcpy(MapVote->m_Reason, "/map");
+		str_copy(MapVote->m_Reason, "/map", sizeof(MapVote->m_Reason));
 
 		for(char *p = MapVote->m_Server; *p; p++) // lower case server
 			*p = tolower(*p);
@@ -413,12 +413,12 @@ bool CScore::MapInfoThread(IDbConnection *pSqlServer, const ISqlData *pGameData)
 		char aStars[20];
 		switch(Stars)
 		{
-		case 0: strcpy(aStars, "✰✰✰✰✰"); break;
-		case 1: strcpy(aStars, "★✰✰✰✰"); break;
-		case 2: strcpy(aStars, "★★✰✰✰"); break;
-		case 3: strcpy(aStars, "★★★✰✰"); break;
-		case 4: strcpy(aStars, "★★★★✰"); break;
-		case 5: strcpy(aStars, "★★★★★"); break;
+		case 0: str_copy(aStars, "✰✰✰✰✰", sizeof(aStars)); break;
+		case 1: str_copy(aStars, "★✰✰✰✰", sizeof(aStars)); break;
+		case 2: str_copy(aStars, "★★✰✰✰", sizeof(aStars)); break;
+		case 3: str_copy(aStars, "★★★✰✰", sizeof(aStars)); break;
+		case 4: str_copy(aStars, "★★★★✰", sizeof(aStars)); break;
+		case 5: str_copy(aStars, "★★★★★", sizeof(aStars)); break;
 		default: aStars[0] = '\0';
 		}
 
@@ -813,7 +813,7 @@ bool CScore::ShowTop5Thread(IDbConnection *pSqlServer, const ISqlData *pGameData
 	pSqlServer->BindString(1, pData->m_Map);
 
 	// show top5
-	strcpy(pData->m_pResult->m_Data.m_aaMessages[0], "----------- Top 5 -----------");
+	str_copy(pData->m_pResult->m_Data.m_aaMessages[0], "----------- Top 5 -----------", sizeof(pData->m_pResult->m_Data.m_aaMessages[0]));
 
 	int Line = 1;
 	while(pSqlServer->Step())
@@ -827,7 +827,7 @@ bool CScore::ShowTop5Thread(IDbConnection *pSqlServer, const ISqlData *pGameData
 			"%d. %s Time: %s", Rank, aName, aBuf);
 		Line++;
 	}
-	strcpy(pData->m_pResult->m_Data.m_aaMessages[Line], "-------------------------------");
+	str_copy(pData->m_pResult->m_Data.m_aaMessages[Line], "-------------------------------", sizeof(pData->m_pResult->m_Data.m_aaMessages[Line]));
 
 	pData->m_pResult->m_Done = true;
 	return true;
@@ -873,7 +873,7 @@ bool CScore::ShowTeamTop5Thread(IDbConnection *pSqlServer, const ISqlData *pGame
 
 	// show teamtop5
 	int Line = 0;
-	strcpy(paMessages[Line++], "------- Team Top 5 -------");
+	str_copy(paMessages[Line++], "------- Team Top 5 -------", sizeof(paMessages[Line]));
 
 	if(pSqlServer->Step())
 	{
@@ -911,7 +911,7 @@ bool CScore::ShowTeamTop5Thread(IDbConnection *pSqlServer, const ISqlData *pGame
 		}
 	}
 
-	strcpy(paMessages[Line], "-------------------------------");
+	str_copy(paMessages[Line], "-------------------------------", sizeof(paMessages[Line]));
 	pData->m_pResult->m_Done = true;
 	return true;
 }
@@ -976,12 +976,12 @@ bool CScore::ShowTimesThread(IDbConnection *pSqlServer, const ISqlData *pGameDat
 	// show top5
 	if(!pSqlServer->Step())
 	{
-		strcpy(paMessages[0], "There are no times in the specified range");
+		str_copy(paMessages[0], "There are no times in the specified range", sizeof(paMessages[0]));
 		pData->m_pResult->m_Done = true;
 		return true;
 	}
 
-	strcpy(paMessages[0], "------------- Last Times -------------");
+	str_copy(paMessages[0], "------------- Last Times -------------", sizeof(paMessages[0]));
 	int Line = 1;
 
 	do
@@ -1020,7 +1020,7 @@ bool CScore::ShowTimesThread(IDbConnection *pSqlServer, const ISqlData *pGameDat
 		}
 		Line++;
 	} while(pSqlServer->Step());
-	strcpy(paMessages[Line], "----------------------------------------------------");
+	str_copy(paMessages[Line], "----------------------------------------------------", sizeof(paMessages[Line]));
 
 	pData->m_pResult->m_Done = true;
 	return true;
@@ -1101,7 +1101,7 @@ bool CScore::ShowTopPointsThread(IDbConnection *pSqlServer, const ISqlData *pGam
 	pSqlServer->BindInt(1, LimitStart);
 
 	// show top points
-	strcpy(paMessages[0], "-------- Top Points --------");
+	str_copy(paMessages[0], "-------- Top Points --------", sizeof(paMessages[0]));
 
 	int Line = 1;
 	while(pSqlServer->Step())
@@ -1114,7 +1114,7 @@ bool CScore::ShowTopPointsThread(IDbConnection *pSqlServer, const ISqlData *pGam
 			"%d. %s Points: %d", Rank, aName, Points);
 		Line++;
 	}
-	strcpy(paMessages[Line], "-------------------------------");
+	str_copy(paMessages[Line], "-------------------------------", sizeof(paMessages[Line]));
 
 	pData->m_pResult->m_Done = true;
 	return true;
@@ -1343,8 +1343,9 @@ bool CScore::SaveTeamThread(IDbConnection *pSqlServer, const ISqlData *pGameData
 		}
 		else
 		{
-			strcpy(pData->m_pResult->m_aBroadcast,
-				"Database connection failed, teamsave written to a file instead. Admins will add it manually in a few days.");
+			str_copy(pData->m_pResult->m_aBroadcast,
+				"Database connection failed, teamsave written to a file instead. Admins will add it manually in a few days.",
+				sizeof(pData->m_pResult->m_aBroadcast));
 			if(str_comp(pData->m_Server, g_Config.m_SvSqlServerName) == 0)
 			{
 				str_format(pData->m_pResult->m_aMessage, sizeof(pData->m_pResult->m_aMessage),
@@ -1365,7 +1366,7 @@ bool CScore::SaveTeamThread(IDbConnection *pSqlServer, const ISqlData *pGameData
 	{
 		dbg_msg("sql", "ERROR: This save-code already exists");
 		pData->m_pResult->m_Status = CScoreSaveResult::SAVE_FAILED;
-		strcpy(pData->m_pResult->m_aMessage, "This save-code already exists");
+		str_copy(pData->m_pResult->m_aMessage, "This save-code already exists", sizeof(pData->m_pResult->m_aMessage));
 	}
 
 	pSqlServer->Unlock();
@@ -1448,7 +1449,7 @@ bool CScore::LoadTeamThread(IDbConnection *pSqlServer, const ISqlData *pGameData
 
 		if(!pSqlServer->Step())
 		{
-			strcpy(pData->m_pResult->m_aMessage, "No such savegame for this map");
+			str_copy(pData->m_pResult->m_aMessage, "No such savegame for this map", sizeof(pData->m_pResult->m_aMessage));
 			goto end;
 		}
 
@@ -1468,7 +1469,7 @@ bool CScore::LoadTeamThread(IDbConnection *pSqlServer, const ISqlData *pGameData
 			pSqlServer->GetString(3, aSaveID, sizeof(aSaveID));
 			if(str_length(aSaveID) + 1 != UUID_MAXSTRSIZE)
 			{
-				strcpy(pData->m_pResult->m_aMessage, "Unable to load savegame: SaveID corrupted");
+				str_copy(pData->m_pResult->m_aMessage, "Unable to load savegame: SaveID corrupted", sizeof(pData->m_pResult->m_aMessage));
 				goto end;
 			}
 			ParseUuid(&pData->m_pResult->m_SaveID, aSaveID);
@@ -1480,7 +1481,7 @@ bool CScore::LoadTeamThread(IDbConnection *pSqlServer, const ISqlData *pGameData
 
 		if(Num != 0)
 		{
-			strcpy(pData->m_pResult->m_aMessage, "Unable to load savegame: data corrupted");
+			str_copy(pData->m_pResult->m_aMessage, "Unable to load savegame: data corrupted", sizeof(pData->m_pResult->m_aMessage));
 			goto end;
 		}
 
@@ -1502,7 +1503,7 @@ bool CScore::LoadTeamThread(IDbConnection *pSqlServer, const ISqlData *pGameData
 		pSqlServer->Step();
 
 		pData->m_pResult->m_Status = CScoreSaveResult::LOAD_SUCCESS;
-		strcpy(pData->m_pResult->m_aMessage, "Loading successfully done");
+		str_copy(pData->m_pResult->m_aMessage, "Loading successfully done", sizeof(pData->m_pResult->m_aMessage));
 	}
 end:
 	pSqlServer->Unlock();

--- a/src/game/server/score.h
+++ b/src/game/server/score.h
@@ -129,8 +129,8 @@ public:
 	{
 		m_BestTime = 0;
 		m_CurrentTime = 0;
-		for(float &i : m_aBestCpTime)
-			i = 0;
+		for(float &BestCpTime : m_aBestCpTime)
+			BestCpTime = 0;
 	}
 
 	void Set(float Time, float CpTime[NUM_CHECKPOINTS])

--- a/src/game/server/score.h
+++ b/src/game/server/score.h
@@ -129,8 +129,8 @@ public:
 	{
 		m_BestTime = 0;
 		m_CurrentTime = 0;
-		for(int i = 0; i < NUM_CHECKPOINTS; i++)
-			m_aBestCpTime[i] = 0;
+		for(float &i : m_aBestCpTime)
+			i = 0;
 	}
 
 	void Set(float Time, float CpTime[NUM_CHECKPOINTS])

--- a/src/game/server/teehistorian.cpp
+++ b/src/game/server/teehistorian.cpp
@@ -48,10 +48,10 @@ void CTeeHistorian::Reset(const CGameInfo *pGameInfo, WRITE_CALLBACK pfnWriteCal
 	m_TickWritten = true;
 	m_MaxClientID = MAX_CLIENTS;
 	// `m_PrevMaxClientID` is initialized in `BeginTick`
-	for(int i = 0; i < MAX_CLIENTS; i++)
+	for(auto &m_aPrevPlayer : m_aPrevPlayers)
 	{
-		m_aPrevPlayers[i].m_Alive = false;
-		m_aPrevPlayers[i].m_InputExists = false;
+		m_aPrevPlayer.m_Alive = false;
+		m_aPrevPlayer.m_InputExists = false;
 	}
 	m_pfnWriteCallback = pfnWriteCallback;
 	m_pWriteCallbackUserdata = pUser;

--- a/src/game/server/teehistorian.cpp
+++ b/src/game/server/teehistorian.cpp
@@ -48,10 +48,10 @@ void CTeeHistorian::Reset(const CGameInfo *pGameInfo, WRITE_CALLBACK pfnWriteCal
 	m_TickWritten = true;
 	m_MaxClientID = MAX_CLIENTS;
 	// `m_PrevMaxClientID` is initialized in `BeginTick`
-	for(auto &m_aPrevPlayer : m_aPrevPlayers)
+	for(auto &PrevPlayer : m_aPrevPlayers)
 	{
-		m_aPrevPlayer.m_Alive = false;
-		m_aPrevPlayer.m_InputExists = false;
+		PrevPlayer.m_Alive = false;
+		PrevPlayer.m_InputExists = false;
 	}
 	m_pfnWriteCallback = pfnWriteCallback;
 	m_pWriteCallbackUserdata = pUser;

--- a/src/game/server/teeinfo.cpp
+++ b/src/game/server/teeinfo.cpp
@@ -58,15 +58,15 @@ void CTeeInfo::ToSixup()
 	}
 
 	// check for std skin
-	for(auto &g_StdSkin : g_StdSkins)
+	for(auto &StdSkin : g_StdSkins)
 	{
-		if(!str_comp(m_SkinName, g_StdSkin.m_SkinName))
+		if(!str_comp(m_SkinName, StdSkin.m_SkinName))
 		{
 			for(int p = 0; p < 6; p++)
 			{
-				str_copy(m_apSkinPartNames[p], g_StdSkin.m_apSkinPartNames[p], 24);
-				m_aUseCustomColors[p] = g_StdSkin.m_aUseCustomColors[p];
-				m_aSkinPartColors[p] = g_StdSkin.m_aSkinPartColors[p];
+				str_copy(m_apSkinPartNames[p], StdSkin.m_apSkinPartNames[p], 24);
+				m_aUseCustomColors[p] = StdSkin.m_aUseCustomColors[p];
+				m_aSkinPartColors[p] = StdSkin.m_aSkinPartColors[p];
 			}
 			break;
 		}
@@ -98,12 +98,12 @@ void CTeeInfo::FromSixup()
 	m_ColorFeet = 0;
 
 	// check for std skin
-	for(auto &g_StdSkin : g_StdSkins)
+	for(auto &StdSkin : g_StdSkins)
 	{
 		bool match = true;
 		for(int p = 0; p < 6; p++)
 		{
-			if(str_comp(m_apSkinPartNames[p], g_StdSkin.m_apSkinPartNames[p]) || m_aUseCustomColors[p] != g_StdSkin.m_aUseCustomColors[p] || (m_aUseCustomColors[p] && m_aSkinPartColors[p] != g_StdSkin.m_aSkinPartColors[p]))
+			if(str_comp(m_apSkinPartNames[p], StdSkin.m_apSkinPartNames[p]) || m_aUseCustomColors[p] != StdSkin.m_aUseCustomColors[p] || (m_aUseCustomColors[p] && m_aSkinPartColors[p] != StdSkin.m_aSkinPartColors[p]))
 			{
 				match = false;
 				break;
@@ -111,7 +111,7 @@ void CTeeInfo::FromSixup()
 		}
 		if(match)
 		{
-			str_copy(m_SkinName, g_StdSkin.m_SkinName, sizeof(m_SkinName));
+			str_copy(m_SkinName, StdSkin.m_SkinName, sizeof(m_SkinName));
 			return;
 		}
 	}

--- a/src/game/server/teeinfo.cpp
+++ b/src/game/server/teeinfo.cpp
@@ -58,15 +58,15 @@ void CTeeInfo::ToSixup()
 	}
 
 	// check for std skin
-	for(int s = 0; s < 16; s++)
+	for(auto &g_StdSkin : g_StdSkins)
 	{
-		if(!str_comp(m_SkinName, g_StdSkins[s].m_SkinName))
+		if(!str_comp(m_SkinName, g_StdSkin.m_SkinName))
 		{
 			for(int p = 0; p < 6; p++)
 			{
-				str_copy(m_apSkinPartNames[p], g_StdSkins[s].m_apSkinPartNames[p], 24);
-				m_aUseCustomColors[p] = g_StdSkins[s].m_aUseCustomColors[p];
-				m_aSkinPartColors[p] = g_StdSkins[s].m_aSkinPartColors[p];
+				str_copy(m_apSkinPartNames[p], g_StdSkin.m_apSkinPartNames[p], 24);
+				m_aUseCustomColors[p] = g_StdSkin.m_aUseCustomColors[p];
+				m_aSkinPartColors[p] = g_StdSkin.m_aSkinPartColors[p];
 			}
 			break;
 		}
@@ -98,12 +98,12 @@ void CTeeInfo::FromSixup()
 	m_ColorFeet = 0;
 
 	// check for std skin
-	for(int s = 0; s < 16; s++)
+	for(auto &g_StdSkin : g_StdSkins)
 	{
 		bool match = true;
 		for(int p = 0; p < 6; p++)
 		{
-			if(str_comp(m_apSkinPartNames[p], g_StdSkins[s].m_apSkinPartNames[p]) || m_aUseCustomColors[p] != g_StdSkins[s].m_aUseCustomColors[p] || (m_aUseCustomColors[p] && m_aSkinPartColors[p] != g_StdSkins[s].m_aSkinPartColors[p]))
+			if(str_comp(m_apSkinPartNames[p], g_StdSkin.m_apSkinPartNames[p]) || m_aUseCustomColors[p] != g_StdSkin.m_aUseCustomColors[p] || (m_aUseCustomColors[p] && m_aSkinPartColors[p] != g_StdSkin.m_aSkinPartColors[p]))
 			{
 				match = false;
 				break;
@@ -111,7 +111,7 @@ void CTeeInfo::FromSixup()
 		}
 		if(match)
 		{
-			str_copy(m_SkinName, g_StdSkins[s].m_SkinName, sizeof(m_SkinName));
+			str_copy(m_SkinName, g_StdSkin.m_SkinName, sizeof(m_SkinName));
 			return;
 		}
 	}

--- a/src/tools/dummy_map.cpp
+++ b/src/tools/dummy_map.cpp
@@ -59,12 +59,12 @@ void CreateEmptyMap(IStorage *pStorage)
 	Writer.AddItem(MAPITEMTYPE_LAYER, 1, sizeof(Layer) - sizeof(Layer.m_aName), &Layer);
 
 	CTile Tiles[4];
-	for(int i = 0; i < 4; i++)
+	for(auto &Tile : Tiles)
 	{
-		Tiles[i].m_Index = 1;
-		Tiles[i].m_Flags = 0;
-		Tiles[i].m_Skip = 0;
-		Tiles[i].m_Reserved = 0;
+		Tile.m_Index = 1;
+		Tile.m_Flags = 0;
+		Tile.m_Skip = 0;
+		Tile.m_Reserved = 0;
 	}
 	Writer.AddData(sizeof(Tiles), &Tiles);
 

--- a/src/tools/packetgen.cpp
+++ b/src/tools/packetgen.cpp
@@ -11,10 +11,10 @@ void Run(NETADDR Dest)
 {
 	NETSOCKET aSockets[NUM_SOCKETS];
 
-	for(int i = 0; i < NUM_SOCKETS; i++)
+	for(auto &aSocket : aSockets)
 	{
 		NETADDR BindAddr = {NETTYPE_IPV4, {0}, 0};
-		aSockets[i] = net_udp_create(BindAddr);
+		aSocket = net_udp_create(BindAddr);
 	}
 
 	while(1)

--- a/src/tools/packetgen.cpp
+++ b/src/tools/packetgen.cpp
@@ -11,10 +11,10 @@ void Run(NETADDR Dest)
 {
 	NETSOCKET aSockets[NUM_SOCKETS];
 
-	for(auto &aSocket : aSockets)
+	for(auto &Socket : aSockets)
 	{
 		NETADDR BindAddr = {NETTYPE_IPV4, {0}, 0};
-		aSocket = net_udp_create(BindAddr);
+		Socket = net_udp_create(BindAddr);
 	}
 
 	while(1)


### PR DESCRIPTION
https://clang.llvm.org/extra/clang-tidy/checks/modernize-use-auto.html

And fix the code:

    cmake -GNinja -DWEBSOCKETS=OFF -DMYSQL=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo -DVIDEORECORDER=ON -DAUTOUPDATE=OFF -DANTIBOT=OFF -DUPNP=OFF -DPREFER_BUNDLED_LIBS=OFF -DINFORM_UPDATE=OFF -DCMAKE_CXX_CLANG_TIDY="clang-tidy;--fix-errors" -DCMAKE_C_CLANG_TIDY="clang-tidy;--fix-errors" .
    ninja -j 1

Manually fixed sizeof(auto) in a few occurences (i.e. server.cpp:1359)

First steps for #3088