### PR TITLE
Revert "Set libnotify icon"

### DIFF
--- a/src/engine/client/notifications.cpp
+++ b/src/engine/client/notifications.cpp
@@ -16,7 +16,7 @@ void NotificationsUninit()
 }
 void NotificationsNotify(const char *pTitle, const char *pMessage)
 {
-	NotifyNotification *pNotif = notify_notification_new(pTitle, pMessage, "ddnet");
+	NotifyNotification *pNotif = notify_notification_new(pTitle, pMessage, NULL);
 	notify_notification_show(pNotif, NULL);
 	g_object_unref(G_OBJECT(pNotif));
 }


### PR DESCRIPTION
Seems to cause crashes in Gnome, for ChillerDragon at least

This reverts commit 8ce6de6d8e520f96724d9e2c4c8da8f24e3e72a8.

@yangfl 