### PR TITLE
Also compile glew.c with GLEW_STATIC

### DIFF
--- a/cmake/FindGLEW.cmake
+++ b/cmake/FindGLEW.cmake
@@ -16,6 +16,7 @@ if(NOT GLEW_FOUND)
   add_library(glew EXCLUDE_FROM_ALL OBJECT ${GLEW_SRC} ${GLEW_INCLUDES})
   set(GLEW_INCLUDEDIR ${GLEW_SRC_DIR})
   target_include_directories(glew PRIVATE ${GLEW_INCLUDEDIR})
+  target_compile_definitions(glew PRIVATE GLEW_STATIC)
 
   set(GLEW_DEP $<TARGET_OBJECTS:glew>)
   set(GLEW_INCLUDE_DIRS ${GLEW_INCLUDEDIR})


### PR DESCRIPTION
This should fix the warnings when linking to glew on windows