### PR TITLE
Use NUM_DUMMYS for dummy array length

### DIFF
--- a/src/engine/client.h
+++ b/src/engine/client.h
@@ -18,6 +18,8 @@ enum
 	RECORDER_RACE = 2,
 	RECORDER_REPLAYS = 3,
 	RECORDER_MAX = 4,
+
+	NUM_DUMMIES = 2,
 };
 
 typedef bool (*CLIENTFUNC_FILTER)(const void *pData, int DataSize, void *pUser);
@@ -30,13 +32,13 @@ protected:
 	int m_State;
 
 	// quick access to time variables
-	int m_PrevGameTick[2];
-	int m_CurGameTick[2];
-	float m_GameIntraTick[2];
-	float m_GameTickTime[2];
+	int m_PrevGameTick[NUM_DUMMIES];
+	int m_CurGameTick[NUM_DUMMIES];
+	float m_GameIntraTick[NUM_DUMMIES];
+	float m_GameTickTime[NUM_DUMMIES];
 
-	int m_PredTick[2];
-	float m_PredIntraTick[2];
+	int m_PredTick[NUM_DUMMIES];
+	float m_PredIntraTick[NUM_DUMMIES];
 
 	float m_LocalTime;
 	float m_RenderFrameTime;

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -500,7 +500,7 @@ void CClient::SendInput()
 
 	bool Force = false;
 	// fetch input
-	for(int Dummy = 0; Dummy < 2; Dummy++)
+	for(int Dummy = 0; Dummy < NUM_DUMMIES; Dummy++)
 	{
 		if(!m_DummyConnected && Dummy != 0)
 		{

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -104,7 +104,7 @@ class CClient : public IClient, public CDemoPlayer::IListener
 
 	enum
 	{
-		CLIENT_MAIN,
+		CLIENT_MAIN = 0,
 		CLIENT_DUMMY,
 		CLIENT_CONTACT,
 		NUM_CLIENTS,
@@ -125,7 +125,7 @@ class CClient : public IClient, public CDemoPlayer::IListener
 
 	CUuid m_ConnectionID;
 
-	unsigned m_SnapshotParts[2];
+	unsigned m_SnapshotParts[NUM_DUMMIES];
 	int64 m_LocalStartTime;
 
 	IGraphics::CTextureHandle m_DebugFont;
@@ -145,9 +145,9 @@ class CClient : public IClient, public CDemoPlayer::IListener
 	bool m_SoundInitFailed;
 	bool m_ResortServerBrowser;
 
-	int m_AckGameTick[2];
-	int m_CurrentRecvTick[2];
-	int m_RconAuthed[2];
+	int m_AckGameTick[NUM_DUMMIES];
+	int m_CurrentRecvTick[NUM_DUMMIES];
+	int m_RconAuthed[NUM_DUMMIES];
 	char m_RconPassword[32];
 	int m_UseTempRconCommands;
 	char m_Password[32];
@@ -163,8 +163,8 @@ class CClient : public IClient, public CDemoPlayer::IListener
 	char m_aCurrentMap[MAX_PATH_LENGTH];
 	char m_aCurrentMapPath[MAX_PATH_LENGTH];
 
-	char m_aTimeoutCodes[2][32];
-	bool m_aTimeoutCodeSent[2];
+	char m_aTimeoutCodes[NUM_DUMMIES][32];
+	bool m_aTimeoutCodeSent[NUM_DUMMIES];
 	bool m_GenerateTimeoutSeed;
 
 	//
@@ -195,7 +195,7 @@ class CClient : public IClient, public CDemoPlayer::IListener
 	char m_aDummyNameBuf[16];
 
 	// time
-	CSmoothTime m_GameTime[2];
+	CSmoothTime m_GameTime[NUM_DUMMIES];
 	CSmoothTime m_PredictedTime;
 
 	// input
@@ -205,9 +205,9 @@ class CClient : public IClient, public CDemoPlayer::IListener
 		int m_Tick; // the tick that the input is for
 		int64 m_PredictedTime; // prediction latency when we sent this input
 		int64 m_Time;
-	} m_aInputs[2][200];
+	} m_aInputs[NUM_DUMMIES][200];
 
-	int m_CurrentInput[2];
+	int m_CurrentInput[NUM_DUMMIES];
 	bool m_LastDummy;
 	bool m_DummySendConnInfo;
 
@@ -217,10 +217,10 @@ class CClient : public IClient, public CDemoPlayer::IListener
 	CGraph m_FpsGraph;
 
 	// the game snapshots are modifiable by the game
-	class CSnapshotStorage m_SnapshotStorage[2];
-	CSnapshotStorage::CHolder *m_aSnapshots[2][NUM_SNAPSHOT_TYPES];
+	class CSnapshotStorage m_SnapshotStorage[NUM_DUMMIES];
+	CSnapshotStorage::CHolder *m_aSnapshots[NUM_DUMMIES][NUM_SNAPSHOT_TYPES];
 
-	int m_ReceivedSnapshots[2];
+	int m_ReceivedSnapshots[NUM_DUMMIES];
 	char m_aSnapshotIncomingData[CSnapshot::MAX_SIZE];
 
 	class CSnapshotStorage::CHolder m_aDemorecSnapshotHolders[NUM_SNAPSHOT_TYPES];

--- a/src/game/client/components/camera.h
+++ b/src/game/client/components/camera.h
@@ -18,7 +18,7 @@ class CCamera : public CComponent
 	};
 
 	int m_CamType;
-	vec2 m_LastPos[2];
+	vec2 m_LastPos[NUM_DUMMIES];
 	vec2 m_PrevCenter;
 
 	bool m_Zooming;

--- a/src/game/client/components/controls.h
+++ b/src/game/client/components/controls.h
@@ -10,8 +10,8 @@
 class CControls : public CComponent
 {
 public:
-	vec2 m_MousePos[2];
-	vec2 m_TargetPos[2];
+	vec2 m_MousePos[NUM_DUMMIES];
+	vec2 m_TargetPos[NUM_DUMMIES];
 	float m_OldMouseX;
 	float m_OldMouseY;
 	SDL_Joystick *m_Joystick;
@@ -24,12 +24,12 @@ public:
 
 	int m_AmmoCount[NUM_WEAPONS];
 
-	CNetObj_PlayerInput m_InputData[2];
-	CNetObj_PlayerInput m_LastData[2];
-	int m_InputDirectionLeft[2];
-	int m_InputDirectionRight[2];
-	int m_ShowHookColl[2];
-	int m_ResetDummy[2];
+	CNetObj_PlayerInput m_InputData[NUM_DUMMIES];
+	CNetObj_PlayerInput m_LastData[NUM_DUMMIES];
+	int m_InputDirectionLeft[NUM_DUMMIES];
+	int m_InputDirectionRight[NUM_DUMMIES];
+	int m_ShowHookColl[NUM_DUMMIES];
+	int m_ResetDummy[NUM_DUMMIES];
 	int m_LastDummy;
 	int m_OtherFire;
 

--- a/src/game/client/components/hud.h
+++ b/src/game/client/components/hud.h
@@ -80,7 +80,7 @@ private:
 	void RenderDDRaceEffects();
 	float m_CheckpointDiff;
 	float m_ServerRecord;
-	float m_PlayerRecord[2];
+	float m_PlayerRecord[NUM_DUMMIES];
 	int m_DDRaceTime;
 	int m_LastReceivedTimeTick;
 	int m_CheckpointTick;

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -102,14 +102,14 @@ class CGameClient : public IGameClient
 	void UpdatePositions();
 
 	int m_PredictedTick;
-	int m_LastNewPredictedTick[2];
+	int m_LastNewPredictedTick[NUM_DUMMIES];
 
 	int m_LastRoundStartTick;
 
 	int m_LastFlagCarrierRed;
 	int m_LastFlagCarrierBlue;
 
-	int m_CheckInfo[2];
+	int m_CheckInfo[NUM_DUMMIES];
 
 	char m_aDDNetVersionStr[64];
 
@@ -164,7 +164,7 @@ public:
 	int m_FlagDropTick[2];
 
 	// TODO: move this
-	CTuningParams m_Tuning[2];
+	CTuningParams m_Tuning[NUM_DUMMIES];
 
 	enum
 	{
@@ -421,7 +421,7 @@ public:
 
 	// DDRace
 
-	int m_LocalIDs[2];
+	int m_LocalIDs[NUM_DUMMIES];
 	CNetObj_PlayerInput m_DummyInput;
 	CNetObj_PlayerInput m_HammerInput;
 	int m_DummyFire;
@@ -566,8 +566,8 @@ public:
 	bool m_EmoticonsSkinLoaded;
 
 private:
-	bool m_DDRaceMsgSent[2];
-	int m_ShowOthers[2];
+	bool m_DDRaceMsgSent[NUM_DUMMIES];
+	int m_ShowOthers[NUM_DUMMIES];
 
 	void UpdatePrediction();
 	void UpdateRenderedCharacters();


### PR DESCRIPTION
Should make code more readable by explaining that the array is used for dummy. Also makes modders life easier if there is a need to scale up dummy count.

I left out two places that do not include client.h

https://github.com/ddnet/ddnet/blob/3be8a592e52a03e555b6aa29a8dea529797bb645/src/game/client/prediction/gameworld.h#L92

https://github.com/ddnet/ddnet/blob/3be8a592e52a03e555b6aa29a8dea529797bb645/src/game/gamecore.h#L212

Moving the enum to protocol.h for example is probably not nice.