### PR TITLE
Clamp font size to atleast 2 (fixes #3145)

### DIFF
--- a/src/game/client/components/mapimages.cpp
+++ b/src/game/client/components/mapimages.cpp
@@ -465,6 +465,7 @@ void CMapImages::UpdateEntityLayerText(void *pTexBuffer, int ImageColorChannelCo
 void CMapImages::InitOverlayTextures()
 {
 	int TextureSize = 64 * m_TextureScale / 100;
+	TextureSize = clamp(TextureSize, 2, 64);
 	int TextureToVerticalCenterOffset = (64 - TextureSize) / 2; // should be used to move texture to the center of 64 pixels area
 
 	if(m_OverlayBottomTexture == -1)


### PR DESCRIPTION
We dont need to `close` #3146
i think setting it to 0 makes no sense anyway the config to disable entities text is `cl_text_entities` not this one