### PR TITLE
Make gfx_quad_as_triangle 0 default

### DIFF
--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -825,7 +825,7 @@ void CCommandProcessorFragment_OpenGL::Cmd_Render(const CCommandBuffer::SCommand
 		glDrawArrays(GL_TRIANGLES, 0, pCommand->m_PrimCount * 3);
 		break;
 	default:
-		dbg_msg("render", "unknown primtype %d\n", pCommand->m_Cmd);
+		dbg_msg("render", "unknown primtype %d\n", pCommand->m_PrimType);
 	};
 }
 
@@ -1649,7 +1649,7 @@ void CCommandProcessorFragment_OpenGL2::Cmd_RenderTex3D(const CCommandBuffer::SC
 		glDrawArrays(GL_TRIANGLES, 0, pCommand->m_PrimCount * 3);
 		break;
 	default:
-		dbg_msg("render", "unknown primtype %d\n", pCommand->m_Cmd);
+		dbg_msg("render", "unknown primtype %d\n", pCommand->m_PrimType);
 	};
 
 	glDisableClientState(GL_VERTEX_ARRAY);
@@ -2928,6 +2928,9 @@ void CCommandProcessorFragment_OpenGL3_3::UploadStreamBufferData(unsigned int Pr
 	case CCommandBuffer::PRIMTYPE_LINES:
 		Count = PrimitiveCount * 2;
 		break;
+	case CCommandBuffer::PRIMTYPE_TRIANGLES:
+		Count = PrimitiveCount * 3;
+		break;
 	case CCommandBuffer::PRIMTYPE_QUADS:
 		Count = PrimitiveCount * 4;
 		break;
@@ -2968,6 +2971,9 @@ void CCommandProcessorFragment_OpenGL3_3::Cmd_Render(const CCommandBuffer::SComm
 	case CCommandBuffer::PRIMTYPE_LINES:
 		glDrawArrays(GL_LINES, 0, pCommand->m_PrimCount * 2);
 		break;
+	case CCommandBuffer::PRIMTYPE_TRIANGLES:
+		glDrawArrays(GL_TRIANGLES, 0, pCommand->m_PrimCount * 3);
+		break;
 	case CCommandBuffer::PRIMTYPE_QUADS:
 		if(m_LastIndexBufferBound[m_LastStreamBuffer] != m_QuadDrawIndexBufferID)
 		{
@@ -2977,7 +2983,7 @@ void CCommandProcessorFragment_OpenGL3_3::Cmd_Render(const CCommandBuffer::SComm
 		glDrawElements(GL_TRIANGLES, pCommand->m_PrimCount * 6, GL_UNSIGNED_INT, 0);
 		break;
 	default:
-		dbg_msg("render", "unknown primtype %d\n", pCommand->m_Cmd);
+		dbg_msg("render", "unknown primtype %d\n", pCommand->m_PrimType);
 	};
 
 	m_LastStreamBuffer = (m_LastStreamBuffer + 1 >= MAX_STREAM_BUFFER_COUNT ? 0 : m_LastStreamBuffer + 1);
@@ -3006,7 +3012,7 @@ void CCommandProcessorFragment_OpenGL3_3::Cmd_RenderTex3D(const CCommandBuffer::
 		glDrawElements(GL_TRIANGLES, pCommand->m_PrimCount * 6, GL_UNSIGNED_INT, 0);
 		break;
 	default:
-		dbg_msg("render", "unknown primtype %d\n", pCommand->m_Cmd);
+		dbg_msg("render", "unknown primtype %d\n", pCommand->m_PrimType);
 	};
 }
 

--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -684,6 +684,23 @@ void CGraphics_Threaded::QuadsTex3DEnd()
 	m_Drawing = 0;
 }
 
+void CGraphics_Threaded::TrianglesBegin()
+{
+	dbg_assert(m_Drawing == 0, "called Graphics()->TrianglesBegin twice");
+	m_Drawing = DRAWING_TRIANGLES;
+
+	QuadsSetSubset(0, 0, 1, 1);
+	QuadsSetRotation(0);
+	SetColor(1, 1, 1, 1);
+}
+
+void CGraphics_Threaded::TrianglesEnd()
+{
+	dbg_assert(m_Drawing == DRAWING_TRIANGLES, "called Graphics()->TrianglesEnd without begin");
+	FlushVertices();
+	m_Drawing = 0;
+}
+
 void CGraphics_Threaded::QuadsEndKeepVertices()
 {
 	dbg_assert(m_Drawing == DRAWING_QUADS, "called Graphics()->QuadsEndKeepVertices without begin");
@@ -914,9 +931,9 @@ void CGraphics_Threaded::QuadsTex3DDrawTL(const CQuadItem *pArray, int Num)
 
 void CGraphics_Threaded::QuadsDrawFreeform(const CFreeformItem *pArray, int Num)
 {
-	dbg_assert(m_Drawing == DRAWING_QUADS, "called Graphics()->QuadsDrawFreeform without begin");
+	dbg_assert(m_Drawing == DRAWING_QUADS || m_Drawing == DRAWING_TRIANGLES, "called Graphics()->QuadsDrawFreeform without begin");
 
-	if(g_Config.m_GfxQuadAsTriangle && !m_IsNewOpenGL)
+	if((g_Config.m_GfxQuadAsTriangle && !m_IsNewOpenGL) || m_Drawing == DRAWING_TRIANGLES)
 	{
 		for(int i = 0; i < Num; ++i)
 		{
@@ -1539,10 +1556,9 @@ void CGraphics_Threaded::RenderQuadContainerEx(int ContainerIndex, int QuadOffse
 		}
 		else
 		{
+			mem_copy(m_aVertices, &Container.m_Quads[QuadOffset], sizeof(CCommandBuffer::SVertex) * 4 * QuadDrawNum);
 			for(int i = 0; i < QuadDrawNum; ++i)
 			{
-				mem_copy(m_aVertices, &Container.m_Quads[QuadOffset], sizeof(CCommandBuffer::SVertex) * 4 * 1);
-
 				for(int n = 0; n < 4; ++n)
 				{
 					m_aVertices[i * 4 + n].m_Pos.x *= ScaleX;

--- a/src/engine/client/graphics_threaded.h
+++ b/src/engine/client/graphics_threaded.h
@@ -680,7 +680,8 @@ class CGraphics_Threaded : public IEngineGraphics
 		NUM_CMDBUFFERS = 2,
 
 		DRAWING_QUADS = 1,
-		DRAWING_LINES = 2
+		DRAWING_LINES = 2,
+		DRAWING_TRIANGLES = 3
 	};
 
 	CCommandBuffer::SState m_State;
@@ -856,6 +857,8 @@ public:
 	void TextQuadsEnd(int TextureSize, int TextTextureIndex, int TextOutlineTextureIndex, float *pOutlineTextColor) override;
 	void QuadsTex3DBegin() override;
 	void QuadsTex3DEnd() override;
+	void TrianglesBegin() override;
+	void TrianglesEnd() override;
 	void QuadsEndKeepVertices() override;
 	void QuadsDrawCurrentVertices(bool KeepVertices = true) override;
 	void QuadsSetRotation(float Angle) override;
@@ -1025,6 +1028,11 @@ public:
 		{
 			PrimType = CCommandBuffer::PRIMTYPE_LINES;
 			PrimCount = NumVerts / 2;
+		}
+		else if(m_Drawing == DRAWING_TRIANGLES)
+		{
+			PrimType = CCommandBuffer::PRIMTYPE_TRIANGLES;
+			PrimCount = NumVerts / 3;
 		}
 		else
 			return;

--- a/src/engine/graphics.h
+++ b/src/engine/graphics.h
@@ -290,6 +290,8 @@ public:
 	virtual void TextQuadsEnd(int TextureSize, int TextTextureIndex, int TextOutlineTextureIndex, float *pOutlineTextColor) = 0;
 	virtual void QuadsTex3DBegin() = 0;
 	virtual void QuadsTex3DEnd() = 0;
+	virtual void TrianglesBegin() = 0;
+	virtual void TrianglesEnd() = 0;
 	virtual void QuadsEndKeepVertices() = 0;
 	virtual void QuadsDrawCurrentVertices(bool KeepVertices = true) = 0;
 	virtual void QuadsSetRotation(float Angle) = 0;

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -122,7 +122,7 @@ MACRO_CONFIG_INT(GfxBackgroundRender, gfx_backgroundrender, 1, 0, 1, CFGFLAG_SAV
 MACRO_CONFIG_INT(GfxTextOverlay, gfx_text_overlay, 10, 1, 100, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Stop rendering textoverlay in editor or with entities: high value = less details = more speed")
 MACRO_CONFIG_INT(GfxAsyncRenderOld, gfx_asyncrender_old, 1, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Do rendering async from the the update")
 MACRO_CONFIG_INT(GfxTuneOverlay, gfx_tune_overlay, 20, 1, 100, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Stop rendering text overlay in tuning zone in editor: high value = less details = more speed")
-MACRO_CONFIG_INT(GfxQuadAsTriangle, gfx_quad_as_triangle, 1, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Render quads as triangles (fixes quad coloring on some GPUs)")
+MACRO_CONFIG_INT(GfxQuadAsTriangle, gfx_quad_as_triangle, 0, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Render quads as triangles (fixes quad coloring on some GPUs)")
 MACRO_CONFIG_INT(GfxShowWarnings, gfx_show_warnings, 1, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Render gfx warnings to screen")
 
 MACRO_CONFIG_INT(InpMousesens, inp_mousesens, 200, 1, 100000, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Mouse sensitivity")

--- a/src/game/client/render_map.cpp
+++ b/src/game/client/render_map.cpp
@@ -94,7 +94,7 @@ void CRenderTools::RenderQuads(CQuad *pQuads, int NumQuads, int RenderFlags, ENV
 
 void CRenderTools::ForceRenderQuads(CQuad *pQuads, int NumQuads, int RenderFlags, ENVELOPE_EVAL pfnEval, void *pUser, float Alpha)
 {
-	Graphics()->QuadsBegin();
+	Graphics()->TrianglesBegin();
 	float Conv = 1 / 255.0f;
 	for(int i = 0; i < NumQuads; i++)
 	{
@@ -173,7 +173,7 @@ void CRenderTools::ForceRenderQuads(CQuad *pQuads, int NumQuads, int RenderFlags
 			fx2f(pPoints[3].x) + OffsetX, fx2f(pPoints[3].y) + OffsetY);
 		Graphics()->QuadsDrawFreeform(&Freeform, 1);
 	}
-	Graphics()->QuadsEnd();
+	Graphics()->TrianglesEnd();
 }
 
 void CRenderTools::RenderTileRectangle(int RectX, int RectY, int RectW, int RectH,


### PR DESCRIPTION
fixes #3097
I added a TrianglesBeing/End() instead for ingame quads
Let me quickly explain why #177 failed.

In the screenshots of #177 you already see the problem

the driver can built a quad like:
![image](https://user-images.githubusercontent.com/6654924/96621122-86f80780-1308-11eb-881a-eb51bdbe558c.png)

or like:

![image](https://user-images.githubusercontent.com/6654924/96621195-a131e580-1308-11eb-91c4-cc4cab96bdfd.png)

or somehow it wants, but it will always do them as triangles

And thats why the ingame quads were basically flipped in the screenshots of #177

But this almost never matters.
Tiles are single colored, text is single colored, ui elements are single colored.
So it only matters for ingame quads probably, which specify the color of each edge

Also even if it would matter, we can simply change the quads to triangles now.

Pro:
- Generally less vertices upload
- Less vertices building on CPU side

Cons:
- nothing

