### PR TITLE
Some chat fixes

### DIFF
--- a/src/engine/textrender.h
+++ b/src/engine/textrender.h
@@ -25,6 +25,7 @@ enum ETextRenderFlags
 	TEXT_RENDER_FLAG_NO_OVERSIZE = 1 << 5,
 	TEXT_RENDER_FLAG_NO_FIRST_CHARACTER_X_BEARING = 1 << 6,
 	TEXT_RENDER_FLAG_NO_LAST_CHARACTER_ADVANCE = 1 << 7,
+	TEXT_RENDER_FLAG_NO_AUTOMATIC_QUAD_UPLOAD = 1 << 8,
 };
 
 enum
@@ -91,6 +92,7 @@ public:
 	virtual void SetCurFont(CFont *pFont) = 0;
 
 	virtual void SetRenderFlags(unsigned int Flags) = 0;
+	virtual unsigned int GetRenderFlags() = 0;
 
 	//
 	virtual void TextEx(CTextCursor *pCursor, const char *pText, int Length) = 0;
@@ -101,6 +103,8 @@ public:
 	virtual void RecreateTextContainerSoft(CTextCursor *pCursor, int TextContainerIndex, const char *pText) = 0;
 	virtual void SetTextContainerSelection(int TextContainerIndex, const char *pText, int CursorPos, int SelectionStart, int SelectionEnd) = 0;
 	virtual void DeleteTextContainer(int TextContainerIndex) = 0;
+
+	virtual void UploadTextContainer(int TextContainerIndex) = 0;
 
 	virtual void RenderTextContainer(int TextContainerIndex, STextRenderColor *pTextColor, STextRenderColor *pTextOutlineColor) = 0;
 	virtual void RenderTextContainer(int TextContainerIndex, STextRenderColor *pTextColor, STextRenderColor *pTextOutlineColor, float X, float Y) = 0;

--- a/src/game/client/components/chat.h
+++ b/src/game/client/components/chat.h
@@ -12,11 +12,12 @@ class CChat : public CComponent
 	CLineInput m_Input;
 
 	static constexpr float MESSAGE_PADDING_X = 5.0f;
-	static constexpr float MESSAGE_TEE_SIZE = 8.0f;
+	static constexpr float MESSAGE_TEE_SIZE = 7.0f;
 	static constexpr float MESSAGE_TEE_PADDING_RIGHT = 0.5f;
 	static constexpr float FONT_SIZE = 6.0f;
-	static constexpr float MESSAGE_PADDING_Y = 3.f;
-	static_assert(FONT_SIZE + MESSAGE_PADDING_Y >= 8.0f, "Corners for background chat are too huge for this combination of font size and message padding.");
+	static constexpr float MESSAGE_PADDING_Y = 1.0f;
+	static constexpr float MESSAGE_ROUNDING = 3.0f;
+	static_assert(FONT_SIZE + MESSAGE_PADDING_Y >= MESSAGE_ROUNDING * 2.0f, "Corners for background chat are too huge for this combination of font size and message padding.");
 
 	enum
 	{


### PR DESCRIPTION
Very round:
![screenshot_2020-10-22_22-16-56](https://user-images.githubusercontent.com/6654924/96926091-6a4d0280-14b5-11eb-81bf-387019f29562.png)

bit round:
![screenshot_2020-10-22_22-17-33](https://user-images.githubusercontent.com/6654924/96926098-6de08980-14b5-11eb-8086-6b1ffc48bc86.png)

No rounding left:
![screenshot_2020-10-22_22-18-16](https://user-images.githubusercontent.com/6654924/96926111-72a53d80-14b5-11eb-93d3-cb3e4ff8b475.png)

No rounding at all:
![screenshot_2020-10-22_22-18-54](https://user-images.githubusercontent.com/6654924/96926120-76d15b00-14b5-11eb-8ab8-1cb1dfc8c1a8.png)

old chat:
![screenshot_2020-10-22_22-28-43](https://user-images.githubusercontent.com/6654924/96926568-04ad4600-14b6-11eb-92eb-ff3400edc499.png)


Just gave some examples so its easier to see what is nice