### PR TITLE
Disable text alignment for editboxes

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -492,8 +492,7 @@ int CMenus::DoEditBox(void *pID, const CUIRect *pRect, char *pStr, unsigned StrS
 	UI()->ClipEnable(pRect);
 	Textbox.x -= *Offset;
 
-	int StrLenDispl = str_length(pDisplayStr);
-	UI()->DoLabel(&Textbox, pDisplayStr, FontSize, -1);
+	UI()->DoLabel(&Textbox, pDisplayStr, FontSize, -1, Textbox.w * 2.0f);
 
 	TextRender()->TextColor(1, 1, 1, 1);
 
@@ -506,9 +505,7 @@ int CMenus::DoEditBox(void *pID, const CUIRect *pRect, char *pStr, unsigned StrS
 	{
 		float OffsetGlyph = TextRender()->GetGlyphOffsetX(FontSize, '|');
 
-		if(StrLenDispl >= 1 && StrLenDispl == DispCursorPos && pDisplayStr[StrLenDispl - 1] != ' ')
-			OffsetGlyph = 0;
-		float w = TextRender()->TextWidth(0, FontSize, pDisplayStr, DispCursorPos, -1.0f);
+		float w = TextRender()->TextWidth(0, FontSize, pDisplayStr, DispCursorPos, Textbox.w * 2.0f);
 		Textbox.x += w + OffsetGlyph;
 
 		if((2 * time_get() / time_freq()) % 2)

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -473,18 +473,18 @@ int CEditor::DoEditBox(void *pID, const CUIRect *pRect, char *pStr, unsigned Str
 	UI()->ClipEnable(pRect);
 	Textbox.x -= *Offset;
 
-	UI()->DoLabel(&Textbox, pDisplayStr, FontSize, -1);
+	UI()->DoLabel(&Textbox, pDisplayStr, FontSize, -1, Textbox.w * 2.0f);
 
 	// render the cursor
 	if(UI()->LastActiveItem() == pID && !JustGotActive)
 	{
-		float w = TextRender()->TextWidth(0, FontSize, pDisplayStr, s_AtIndex, -1.0f);
+		float w = TextRender()->TextWidth(0, FontSize, pDisplayStr, s_AtIndex, Textbox.w * 2.0f);
 		Textbox = *pRect;
 		Textbox.VSplitLeft(2.0f, 0, &Textbox);
-		Textbox.x += (w - *Offset - TextRender()->TextWidth(0, FontSize, "|", -1, -1.0f) / 2);
+		Textbox.x += (w - *Offset - TextRender()->TextWidth(0, FontSize, "|", -1, Textbox.w * 2.0f) / 2);
 
 		if((2 * time_get() / time_freq()) % 2) // make it blink
-			UI()->DoLabel(&Textbox, "|", FontSize, -1);
+			UI()->DoLabel(&Textbox, "|", FontSize, -1, Textbox.w * 2.0f);
 	}
 	UI()->ClipDisable();
 


### PR DESCRIPTION
I think they create to much issues with the cursor

![screenshot_2020-10-25_15-16-37](https://user-images.githubusercontent.com/6654924/97109755-52ec6000-16d5-11eb-8f26-48a2bec1d4c9.png)

changed the thing in menus and editor, dunno if there are more editbox impl somewhere