### PR TITLE
Fix IME state softlock under fcitx and macos + Update DoEditBox logic to be the same as chat

### DIFF
--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -49,7 +49,7 @@ CInput::CInput()
 	m_VideoRestartNeeded = 0;
 	m_pClipboardText = NULL;
 
-	m_CountEditingText = 0;
+	m_NumTextInputInstances = 0;
 	m_EditingTextLen = -1;
 	m_aEditingText[0] = 0;
 }
@@ -144,28 +144,28 @@ void CInput::NextFrame()
 
 bool CInput::GetIMEState()
 {
-	return m_CountEditingText > 0;
+	return m_NumTextInputInstances > 0;
 }
 
 void CInput::SetIMEState(bool Activate)
 {
 	if(Activate)
 	{
-		if(m_CountEditingText == 0)
+		if(m_NumTextInputInstances == 0)
 			SDL_StartTextInput();
-		m_CountEditingText++;
+		m_NumTextInputInstances++;
 	}
 	else
 	{
-		if(m_CountEditingText == 0)
+		if(m_NumTextInputInstances == 0)
 			return;
-		m_CountEditingText--;
-		if(m_CountEditingText == 0)
+		m_NumTextInputInstances--;
+		if(m_NumTextInputInstances == 0)
 			SDL_StopTextInput();
 	}
 }
 
-const char *CInput::GetIMECandidate()
+const char *CInput::GetIMEEditingText()
 {
 	if(m_EditingTextLen > 0)
 		return m_aEditingText;
@@ -241,9 +241,14 @@ int CInput::Update()
 					for(int i = 0; i < Event.edit.start; i++)
 						m_EditingCursor = str_utf8_forward(m_aEditingText, m_EditingCursor);
 				}
+				else
+				{
+					m_aEditingText[0] = 0;
+				}
 				break;
 			}
 			case SDL_TEXTINPUT:
+				m_EditingTextLen = 0;
 				AddEvent(Event.text.text, 0, IInput::FLAG_TEXT);
 				break;
 			// handle keys

--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -248,7 +248,7 @@ int CInput::Update()
 				break;
 			}
 			case SDL_TEXTINPUT:
-				m_EditingTextLen = 0;
+				m_EditingTextLen = -1;
 				AddEvent(Event.text.text, 0, IInput::FLAG_TEXT);
 				break;
 			// handle keys

--- a/src/engine/client/input.h
+++ b/src/engine/client/input.h
@@ -31,8 +31,8 @@ class CInput : public IEngineInput
 	int m_InputCounter;
 
 	// IME support
-	int m_CountEditingText;
-	char m_aEditingText[32];
+	int m_NumTextInputInstances;
+	char m_aEditingText[INPUT_TEXT_SIZE];
 	int m_EditingTextLen;
 	int m_EditingCursor;
 
@@ -62,7 +62,7 @@ public:
 
 	virtual bool GetIMEState();
 	virtual void SetIMEState(bool Activate);
-	virtual const char *GetIMECandidate();
+	virtual const char *GetIMEEditingText();
 	virtual int GetEditingCursor();
 	virtual void SetEditingPosition(float X, float Y);
 };

--- a/src/engine/client/input.h
+++ b/src/engine/client/input.h
@@ -62,6 +62,7 @@ public:
 
 	virtual bool GetIMEState();
 	virtual void SetIMEState(bool Activate);
+	int GetIMEEditingTextLength() const { return m_EditingTextLen; }
 	virtual const char *GetIMEEditingText();
 	virtual int GetEditingCursor();
 	virtual void SetEditingPosition(float X, float Y);

--- a/src/engine/input.h
+++ b/src/engine/input.h
@@ -12,12 +12,17 @@ class IInput : public IInterface
 {
 	MACRO_INTERFACE("input", 0)
 public:
+	enum
+	{
+		INPUT_TEXT_SIZE = 128
+	};
+
 	class CEvent
 	{
 	public:
 		int m_Flags;
 		int m_Key;
-		char m_aText[32];
+		char m_aText[INPUT_TEXT_SIZE];
 		int m_InputCount;
 	};
 
@@ -70,7 +75,7 @@ public:
 
 	virtual bool GetIMEState() = 0;
 	virtual void SetIMEState(bool Activate) = 0;
-	virtual const char *GetIMECandidate() = 0;
+	virtual const char *GetIMEEditingText() = 0;
 	virtual int GetEditingCursor() = 0;
 	virtual void SetEditingPosition(float X, float Y) = 0;
 };

--- a/src/engine/input.h
+++ b/src/engine/input.h
@@ -75,6 +75,7 @@ public:
 
 	virtual bool GetIMEState() = 0;
 	virtual void SetIMEState(bool Activate) = 0;
+	virtual int GetIMEEditingTextLength() const = 0;
 	virtual const char *GetIMEEditingText() = 0;
 	virtual int GetEditingCursor() = 0;
 	virtual void SetEditingPosition(float X, float Y) = 0;

--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -1152,9 +1152,9 @@ void CChat::OnRender()
 		int EditingCursor = Input()->GetEditingCursor();
 		if(Input()->GetIMEState())
 		{
-			if(str_length(Input()->GetIMECandidate()))
+			if(str_length(Input()->GetIMEEditingText()))
 			{
-				m_Input.Editing(Input()->GetIMECandidate(), EditingCursor);
+				m_Input.Editing(Input()->GetIMEEditingText(), EditingCursor);
 				Editing = true;
 			}
 		}

--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -580,9 +580,9 @@ void CGameConsole::OnRender()
 		int EditingCursor = Input()->GetEditingCursor();
 		if(Input()->GetIMEState())
 		{
-			if(str_length(Input()->GetIMECandidate()))
+			if(str_length(Input()->GetIMEEditingText()))
 			{
-				pConsole->m_Input.Editing(Input()->GetIMECandidate(), EditingCursor);
+				pConsole->m_Input.Editing(Input()->GetIMEEditingText(), EditingCursor);
 				Editing = true;
 			}
 		}

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -439,11 +439,11 @@ int CMenus::DoEditBox(void *pID, const CUIRect *pRect, char *pStr, unsigned StrS
 		pDisplayStr = aStars;
 	}
 
-	char aInputing[32] = {0};
+	char aInputing[IInput::INPUT_TEXT_SIZE] = {0};
 	if(UI()->HotItem() == pID && Input()->GetIMEState())
 	{
 		str_copy(aInputing, pStr, sizeof(aInputing));
-		const char *Text = Input()->GetIMECandidate();
+		const char *Text = Input()->GetIMEEditingText();
 		if(str_length(Text))
 		{
 			int NewTextLen = str_length(Text);

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -422,12 +422,6 @@ int CMenus::DoEditBox(void *pID, const CUIRect *pRect, char *pStr, unsigned StrS
 	const char *pDisplayStr = pStr;
 	char aStars[128];
 
-	if(pDisplayStr[0] == '\0')
-	{
-		pDisplayStr = pEmptyText;
-		TextRender()->TextColor(1, 1, 1, 0.75f);
-	}
-
 	if(Hidden)
 	{
 		unsigned s = str_length(pDisplayStr);
@@ -439,39 +433,48 @@ int CMenus::DoEditBox(void *pID, const CUIRect *pRect, char *pStr, unsigned StrS
 		pDisplayStr = aStars;
 	}
 
-	char aInputing[IInput::INPUT_TEXT_SIZE] = {0};
-	if(UI()->HotItem() == pID && Input()->GetIMEState())
+	char aDispEditingText[128 + IInput::INPUT_TEXT_SIZE + 2] = {0};
+	int DispCursorPos = s_AtIndex;
+	if(UI()->LastActiveItem() == pID && Input()->GetIMEEditingTextLength() > -1)
 	{
-		str_copy(aInputing, pStr, sizeof(aInputing));
-		const char *Text = Input()->GetIMEEditingText();
-		if(str_length(Text))
+		int EditingTextCursor = Input()->GetEditingCursor();
+		str_copy(aDispEditingText, pDisplayStr, sizeof(aDispEditingText));
+		char aEditingText[IInput::INPUT_TEXT_SIZE + 2];
+		if(Hidden)
 		{
-			int NewTextLen = str_length(Text);
-			int CharsLeft = StrSize - str_length(aInputing) - 1;
-			int FillCharLen = minimum(NewTextLen, CharsLeft);
-			//Push Char Backward
-			for(int i = str_length(aInputing); i >= s_AtIndex; i--)
-				aInputing[i + FillCharLen] = aInputing[i];
-			for(int i = 0; i < FillCharLen; i++)
-			{
-				if(Text[i] == '\n')
-					aInputing[s_AtIndex + i] = ' ';
-				else
-					aInputing[s_AtIndex + i] = Text[i];
-			}
-			//s_AtIndex = s_AtIndex+FillCharLen;
-			pDisplayStr = aInputing;
+			// Do not show editing text in password field
+			str_copy(aEditingText, "[*]", sizeof(aEditingText));
+			EditingTextCursor = 1;
 		}
+		else
+		{
+			str_format(aEditingText, sizeof(aEditingText), "[%s]", Input()->GetIMEEditingText());
+		}
+		int NewTextLen = str_length(aEditingText);
+		int CharsLeft = (int)sizeof(aDispEditingText) - str_length(aDispEditingText) - 1;
+		int FillCharLen = minimum(NewTextLen, CharsLeft);
+		for(int i = str_length(aDispEditingText) - 1; i >= s_AtIndex; i--)
+			aDispEditingText[i + FillCharLen] = aDispEditingText[i];
+		for(int i = 0; i < FillCharLen; i++)
+			aDispEditingText[s_AtIndex + i] = aEditingText[i];
+		DispCursorPos = s_AtIndex + EditingTextCursor + 1;
+		pDisplayStr = aDispEditingText;
+	}
+
+	if(pDisplayStr[0] == '\0')
+	{
+		pDisplayStr = pEmptyText;
+		TextRender()->TextColor(1, 1, 1, 0.75f);
 	}
 
 	// check if the text has to be moved
 	if(UI()->LastActiveItem() == pID && !JustGotActive && (UpdateOffset || m_NumInputEvents))
 	{
-		float w = TextRender()->TextWidth(0, FontSize, pDisplayStr, s_AtIndex, -1.0f);
+		float w = TextRender()->TextWidth(0, FontSize, pStr, s_AtIndex, -1.0f);
 		if(w - *Offset > Textbox.w)
 		{
 			// move to the left
-			float wt = TextRender()->TextWidth(0, FontSize, pDisplayStr, -1, -1.0f);
+			float wt = TextRender()->TextWidth(0, FontSize, pStr, -1, -1.0f);
 			do
 			{
 				*Offset += minimum(wt - *Offset - Textbox.w, Textbox.w / 3);
@@ -502,29 +505,10 @@ int CMenus::DoEditBox(void *pID, const CUIRect *pRect, char *pStr, unsigned StrS
 	if(UI()->LastActiveItem() == pID && !JustGotActive)
 	{
 		float OffsetGlyph = TextRender()->GetGlyphOffsetX(FontSize, '|');
-		CUIRect TmpTextBox = Textbox;
-		if(str_length(aInputing))
-		{
-			float OffsetGlyphThis = OffsetGlyph;
-			if(StrLenDispl >= 1 && StrLenDispl == s_AtIndex + Input()->GetEditingCursor() && pDisplayStr[StrLenDispl - 1] != ' ')
-				OffsetGlyphThis = 0;
-			float w = TextRender()->TextWidth(0, FontSize, pDisplayStr, s_AtIndex + Input()->GetEditingCursor(), -1.0f);
-			Textbox.x += w + OffsetGlyphThis;
 
-			Graphics()->TextureClear();
-			Graphics()->QuadsBegin();
-			Graphics()->SetColor(0, 0, 0, 0.3f);
-			IGraphics::CQuadItem CursorTBack(Textbox.x - (OnePixelWidth * 2.0f) / 2.0f, Textbox.y, OnePixelWidth * 2 * 2.0f, Textbox.h);
-			Graphics()->QuadsDrawTL(&CursorTBack, 1);
-			Graphics()->SetColor(1, 1, 1, 1);
-			IGraphics::CQuadItem CursorT(Textbox.x, Textbox.y + OnePixelWidth * 1.5f, OnePixelWidth * 2.0f, Textbox.h - OnePixelWidth * 1.5f * 2);
-			Graphics()->QuadsDrawTL(&CursorT, 1);
-			Graphics()->QuadsEnd();
-		}
-		if(StrLenDispl >= 1 && StrLenDispl == s_AtIndex && pDisplayStr[StrLenDispl - 1] != ' ')
+		if(StrLenDispl >= 1 && StrLenDispl == DispCursorPos && pDisplayStr[StrLenDispl - 1] != ' ')
 			OffsetGlyph = 0;
-		float w = TextRender()->TextWidth(0, FontSize, pDisplayStr, s_AtIndex, -1.0f);
-		Textbox = TmpTextBox;
+		float w = TextRender()->TextWidth(0, FontSize, pDisplayStr, DispCursorPos, -1.0f);
 		Textbox.x += w + OffsetGlyph;
 
 		if((2 * time_get() / time_freq()) % 2)

--- a/src/game/client/lineinput.cpp
+++ b/src/game/client/lineinput.cpp
@@ -33,20 +33,15 @@ void CLineInput::Set(const char *pString)
 void CLineInput::Editing(const char *pString, int Cursor)
 {
 	str_copy(m_DisplayStr, m_Str, sizeof(m_DisplayStr));
-	char EditingText[IInput::INPUT_TEXT_SIZE + 2];
-	str_format(EditingText, sizeof(EditingText), "[%s]", pString);
-	int NewTextLen = str_length(EditingText);
+	char aEditingText[IInput::INPUT_TEXT_SIZE + 2];
+	str_format(aEditingText, sizeof(aEditingText), "[%s]", pString);
+	int NewTextLen = str_length(aEditingText);
 	int CharsLeft = (int)sizeof(m_DisplayStr) - str_length(m_DisplayStr) - 1;
 	int FillCharLen = NewTextLen < CharsLeft ? NewTextLen : CharsLeft;
 	for(int i = str_length(m_DisplayStr) - 1; i >= m_CursorPos; i--)
 		m_DisplayStr[i + FillCharLen] = m_DisplayStr[i];
 	for(int i = 0; i < FillCharLen; i++)
-	{
-		if(EditingText[i] == 28)
-			m_DisplayStr[m_CursorPos + i] = ' ';
-		else
-			m_DisplayStr[m_CursorPos + i] = EditingText[i];
-	}
+		m_DisplayStr[m_CursorPos + i] = aEditingText[i];
 	m_FakeLen = str_length(m_DisplayStr);
 	m_FakeCursorPos = m_CursorPos + Cursor + 1;
 }

--- a/src/game/client/lineinput.cpp
+++ b/src/game/client/lineinput.cpp
@@ -33,19 +33,19 @@ void CLineInput::Set(const char *pString)
 void CLineInput::Editing(const char *pString, int Cursor)
 {
 	str_copy(m_DisplayStr, m_Str, sizeof(m_DisplayStr));
-	char Texting[34];
-	str_format(Texting, sizeof(Texting), "[%s]", pString);
-	int NewTextLen = str_length(Texting);
+	char EditingText[IInput::INPUT_TEXT_SIZE + 2];
+	str_format(EditingText, sizeof(EditingText), "[%s]", pString);
+	int NewTextLen = str_length(EditingText);
 	int CharsLeft = (int)sizeof(m_DisplayStr) - str_length(m_DisplayStr) - 1;
 	int FillCharLen = NewTextLen < CharsLeft ? NewTextLen : CharsLeft;
 	for(int i = str_length(m_DisplayStr) - 1; i >= m_CursorPos; i--)
 		m_DisplayStr[i + FillCharLen] = m_DisplayStr[i];
 	for(int i = 0; i < FillCharLen; i++)
 	{
-		if(Texting[i] == 28)
+		if(EditingText[i] == 28)
 			m_DisplayStr[m_CursorPos + i] = ' ';
 		else
-			m_DisplayStr[m_CursorPos + i] = Texting[i];
+			m_DisplayStr[m_CursorPos + i] = EditingText[i];
 	}
 	m_FakeLen = str_length(m_DisplayStr);
 	m_FakeCursorPos = m_CursorPos + Cursor + 1;

--- a/src/game/client/lineinput.h
+++ b/src/game/client/lineinput.h
@@ -18,7 +18,7 @@ class CLineInput
 	int m_CursorPos;
 	int m_NumChars;
 
-	char m_DisplayStr[MAX_SIZE + 34];
+	char m_DisplayStr[MAX_SIZE + IInput::INPUT_TEXT_SIZE + 2];
 	int m_FakeLen;
 	int m_FakeCursorPos;
 


### PR DESCRIPTION
IME state fix closes #3185 and closes #3150 
DoEditBox update closes #3186, now cursor behave the same as chat where only one cursor (either the real one or the editing one) will be shown.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [x] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
