### PR TITLE
DrawRoundRectEx easier for understanding, out of bounds safer

### DIFF
--- a/src/game/client/render.cpp
+++ b/src/game/client/render.cpp
@@ -174,9 +174,11 @@ void CRenderTools::QuadContainerAddSprite(int QuadContainerIndex, float X, float
 
 void CRenderTools::DrawRoundRectExt(float x, float y, float w, float h, float r, int Corners)
 {
-	IGraphics::CFreeformItem ArrayF[32];
 	int NumItems = 0;
-	int Num = 8;
+	const int Num = 8;
+
+	IGraphics::CFreeformItem ArrayF[Num * 4];
+	
 	for(int i = 0; i < Num; i += 2)
 	{
 		float a1 = i / (float)Num * pi / 2;


### PR DESCRIPTION
I don't know if it's ok to make 2 line changes PRs, but this one would make new method's values (added some days ago with Chat Visuals update) `CRenderTools::DrawRoundRectExt` easier to understand and safer for out of bounds exception.