### PR TITLE
Much more readable Call Vote menu and code

### DIFF
--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -616,14 +616,7 @@ void CMenus::RenderServerControl(CUIRect MainView)
 	MainView.Margin(10.0f, &MainView);
 
 	if(Client()->RconAuthed())
-	{
 		MainView.HSplitBottom(90.0f, &MainView, &RconExtension);
-		
-		// background
-		RconExtension.Margin(10.0f, &RconExtension);
-		RconExtension.HSplitTop(20.0f, &Bottom, &RconExtension);
-		RconExtension.HSplitTop(5.0f, 0, &RconExtension);
-	}
 
 	// tab bar
 	{
@@ -731,6 +724,11 @@ void CMenus::RenderServerControl(CUIRect MainView)
 		// extended features (only available when authed in rcon)
 		if(Client()->RconAuthed())
 		{
+			// background
+			RconExtension.Margin(10.0f, &RconExtension);
+			RconExtension.HSplitTop(20.0f, &Bottom, &RconExtension);
+			RconExtension.HSplitTop(5.0f, 0, &RconExtension);
+
 			// force vote
 			Bottom.VSplitLeft(5.0f, 0, &Bottom);
 			Bottom.VSplitLeft(120.0f, &Button, &Bottom);

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -530,7 +530,7 @@ bool CMenus::RenderServerControlServer(CUIRect MainView)
 		TotalShown++;
 	}
 
-	UiDoListboxStart(&s_VoteList, &List, 24.0f, "", "", TotalShown, 1, s_CurVoteOption, s_ScrollValue);
+	UiDoListboxStart(&s_VoteList, &List, 20.0f, "", "", TotalShown, 1, s_CurVoteOption, s_ScrollValue);
 
 	int i = -1;
 	for(CVoteOptionClient *pOption = m_pClient->m_pVoting->m_pFirst; pOption; pOption = pOption->m_pNext)
@@ -542,7 +542,7 @@ bool CMenus::RenderServerControlServer(CUIRect MainView)
 		CListboxItem Item = UiDoListboxNextItem(pOption);
 
 		if(Item.m_Visible)
-			UI()->DoLabelScaled(&Item.m_Rect, pOption->m_aDescription, 16.0f, -1);
+			UI()->DoLabelScaled(&Item.m_Rect, pOption->m_aDescription, 14.0f, -1);
 
 		if(NumVoteOptions < Total)
 			aIndices[NumVoteOptions] = i;
@@ -608,13 +608,22 @@ void CMenus::RenderServerControl(CUIRect MainView)
 	static int s_ControlPage = 0;
 
 	// render background
-	CUIRect Bottom, Extended, TabBar, Button;
+	CUIRect Bottom, RconExtension, TabBar, Button;
 	MainView.HSplitTop(20.0f, &Bottom, &MainView);
 	RenderTools()->DrawUIRect(&Bottom, ms_ColorTabbarActive, 0, 10.0f);
 	MainView.HSplitTop(20.0f, &TabBar, &MainView);
 	RenderTools()->DrawUIRect(&MainView, ms_ColorTabbarActive, CUI::CORNER_B, 10.0f);
 	MainView.Margin(10.0f, &MainView);
-	MainView.HSplitBottom(90.0f, &MainView, &Extended);
+
+	if(Client()->RconAuthed())
+	{
+		MainView.HSplitBottom(90.0f, &MainView, &RconExtension);
+		
+		// background
+		RconExtension.Margin(10.0f, &RconExtension);
+		RconExtension.HSplitTop(20.0f, &Bottom, &RconExtension);
+		RconExtension.HSplitTop(5.0f, 0, &RconExtension);
+	}
 
 	// tab bar
 	{
@@ -722,14 +731,10 @@ void CMenus::RenderServerControl(CUIRect MainView)
 		// extended features (only available when authed in rcon)
 		if(Client()->RconAuthed())
 		{
-			// background
-			Extended.Margin(10.0f, &Extended);
-			Extended.HSplitTop(20.0f, &Bottom, &Extended);
-			Extended.HSplitTop(5.0f, 0, &Extended);
-
 			// force vote
 			Bottom.VSplitLeft(5.0f, 0, &Bottom);
 			Bottom.VSplitLeft(120.0f, &Button, &Bottom);
+
 			static int s_ForceVoteButton = 0;
 			if(DoButton_Menu(&s_ForceVoteButton, Localize("Force vote"), 0, &Button))
 			{
@@ -766,7 +771,7 @@ void CMenus::RenderServerControl(CUIRect MainView)
 					m_pClient->m_pVoting->RemovevoteOption(m_CallvoteSelectedOption);
 
 				// add vote
-				Extended.HSplitTop(20.0f, &Bottom, &Extended);
+				RconExtension.HSplitTop(20.0f, &Bottom, &RconExtension);
 				Bottom.VSplitLeft(5.0f, 0, &Bottom);
 				Bottom.VSplitLeft(250.0f, &Button, &Bottom);
 				UI()->DoLabelScaled(&Button, Localize("Vote description:"), 14.0f, -1);
@@ -776,7 +781,7 @@ void CMenus::RenderServerControl(CUIRect MainView)
 
 				static char s_aVoteDescription[64] = {0};
 				static char s_aVoteCommand[512] = {0};
-				Extended.HSplitTop(20.0f, &Bottom, &Extended);
+				RconExtension.HSplitTop(20.0f, &Bottom, &RconExtension);
 				Bottom.VSplitRight(10.0f, &Bottom, 0);
 				Bottom.VSplitRight(120.0f, &Bottom, &Button);
 				static int s_AddVoteButton = 0;

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -530,7 +530,7 @@ bool CMenus::RenderServerControlServer(CUIRect MainView)
 		TotalShown++;
 	}
 
-	UiDoListboxStart(&s_VoteList, &List, 20.0f, "", "", TotalShown, 1, s_CurVoteOption, s_ScrollValue);
+	UiDoListboxStart(&s_VoteList, &List, 19.0f, "", "", TotalShown, 1, s_CurVoteOption, s_ScrollValue);
 
 	int i = -1;
 	for(CVoteOptionClient *pOption = m_pClient->m_pVoting->m_pFirst; pOption; pOption = pOption->m_pNext)
@@ -542,7 +542,7 @@ bool CMenus::RenderServerControlServer(CUIRect MainView)
 		CListboxItem Item = UiDoListboxNextItem(pOption);
 
 		if(Item.m_Visible)
-			UI()->DoLabelScaled(&Item.m_Rect, pOption->m_aDescription, 14.0f, -1);
+			UI()->DoLabelScaled(&Item.m_Rect, pOption->m_aDescription, 13.0f, -1);
 
 		if(NumVoteOptions < Total)
 			aIndices[NumVoteOptions] = i;


### PR DESCRIPTION
I find "Call Vote" menu useless af right now, because it's simply impossible to read it. So when you want to call vote for a map you open website and find the one you want, after that making /map skipping the "Call Vote" menu completely. It's useful for calling for random map btw, but anyway too ugly to look at.

**OLD LOOK**
![callvoteold](https://user-images.githubusercontent.com/39315809/97338602-a48e1980-1892-11eb-8c93-5d8656d3abeb.png)

**NEW LOOK**
![callvotenew](https://user-images.githubusercontent.com/39315809/97339380-9096e780-1893-11eb-8c3c-1f8630096d9f.png)

**NEW LOOK (RconAuted)**
![callvotenewrcon](https://user-images.githubusercontent.com/39315809/97340605-0e0f2780-1895-11eb-898b-3c3b8258cced.png)



Changed nothing, but row and text size + View rect size, because for some reason it was small for preserving space for RCON Auted users. Why?
Also changed the name of rect "Extended" to "RconExtension" to make it more clear what is it for.

Would be cool also to remove all that junk that is not actual votes from DDNet server vote list (finishers, average time) and merge it into one line with map's name. 

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
