### PR TITLE
Always render line, if we already are on a new line

### DIFF
--- a/src/engine/client/text.cpp
+++ b/src/engine/client/text.cpp
@@ -850,6 +850,7 @@ public:
 
 		int ActualSize;
 		int GotNewLine = 0;
+		int GotNewLineLast = 0;
 		float DrawX = 0.0f, DrawY = 0.0f;
 		int LineCount = 0;
 		float CursorX, CursorY;
@@ -959,10 +960,10 @@ public:
 					Wlen = Cutter.m_CharCount;
 					NewLine = 1;
 
-					if(WordGlyphs <= 3) // if we can't place 3 chars of the word on this line, take the next
+					if(WordGlyphs <= 3 && GotNewLineLast == 0) // if we can't place 3 chars of the word on this line, take the next
 						Wlen = 0;
 				}
-				else if(Compare.m_X - pCursor->m_StartX > pCursor->m_LineWidth)
+				else if(Compare.m_X - pCursor->m_StartX > pCursor->m_LineWidth && GotNewLineLast == 0)
 				{
 					NewLine = 1;
 					Wlen = 0;
@@ -1068,8 +1069,11 @@ public:
 					DrawY = (int)(DrawY * FakeToScreenY) / FakeToScreenY;
 				}
 				GotNewLine = 1;
+				GotNewLineLast = 1;
 				++LineCount;
 			}
+			else
+				GotNewLineLast = 0;
 		}
 
 		if(pCursor->m_Flags & TEXTFLAG_RENDER)
@@ -1200,6 +1204,7 @@ public:
 
 		int ActualSize;
 		int GotNewLine = 0;
+		int GotNewLineLast = 0;
 		float DrawX = 0.0f, DrawY = 0.0f;
 		int LineCount = 0;
 		float CursorX, CursorY;
@@ -1282,10 +1287,10 @@ public:
 					Wlen = Cutter.m_CharCount;
 					NewLine = 1;
 
-					if(WordGlyphs <= 3) // if we can't place 3 chars of the word on this line, take the next
+					if(WordGlyphs <= 3 && GotNewLineLast == 0) // if we can't place 3 chars of the word on this line, take the next
 						Wlen = 0;
 				}
-				else if(Compare.m_X - pCursor->m_StartX > pCursor->m_LineWidth)
+				else if(Compare.m_X - pCursor->m_StartX > pCursor->m_LineWidth && GotNewLineLast == 0)
 				{
 					NewLine = 1;
 					Wlen = 0;
@@ -1426,8 +1431,11 @@ public:
 					DrawY = (int)(DrawY * FakeToScreenY) / FakeToScreenY;
 				}
 				GotNewLine = 1;
+				GotNewLineLast = 1;
 				++LineCount;
 			}
+			else
+				GotNewLineLast = 0;
 		}
 
 		if(TextContainer.m_StringInfo.m_CharacterQuads.size() != 0)


### PR DESCRIPTION
fixes #3205 in a bad way

![screenshot_2020-10-28_15-55-18](https://user-images.githubusercontent.com/6654924/97453901-78c46f80-1936-11eb-860d-07a0340417e6.png)

looks ugly i know, i don't know a better solution rn. We are just hitting limitations of the impl

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
