### PR TITLE
Disable chat rendering when Scoreboard is active and fix tee icon pos [Fixes #3215]

### DIFF
--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -58,8 +58,7 @@ void CChat::RebuildChat()
 			Graphics()->DeleteQuadContainer(m_aLines[i].m_QuadContainerIndex);
 		m_aLines[i].m_QuadContainerIndex = -1;
 		// recalculate sizes
-		m_aLines[i].m_YOffset[0] = -1.f;
-		m_aLines[i].m_YOffset[1] = -1.f;
+		m_aLines[i].m_YOffset = -1.f;
 	}
 }
 
@@ -85,7 +84,7 @@ void CChat::Reset()
 		m_aLines[i].m_TimesRepeated = 0;
 		m_aLines[i].m_HasRenderTee = false;
 	}
-	m_PrevScoreBoardShowed = false;
+
 	m_PrevShowChat = false;
 
 	m_ReverseTAB = false;
@@ -702,8 +701,7 @@ void CChat::AddLine(int ClientID, int Team, const char *pLine)
 				Graphics()->DeleteQuadContainer(pCurrentLine->m_QuadContainerIndex);
 			pCurrentLine->m_QuadContainerIndex = -1;
 			pCurrentLine->m_Time = time();
-			pCurrentLine->m_YOffset[0] = -1.f;
-			pCurrentLine->m_YOffset[1] = -1.f;
+			pCurrentLine->m_YOffset = -1.f;
 			return;
 		}
 
@@ -712,8 +710,7 @@ void CChat::AddLine(int ClientID, int Team, const char *pLine)
 		pCurrentLine = &m_aLines[m_CurrentLine];
 		pCurrentLine->m_TimesRepeated = 0;
 		pCurrentLine->m_Time = time();
-		pCurrentLine->m_YOffset[0] = -1.0f;
-		pCurrentLine->m_YOffset[1] = -1.0f;
+		pCurrentLine->m_YOffset = -1.0f;
 		pCurrentLine->m_ClientID = ClientID;
 		pCurrentLine->m_Team = Team;
 		pCurrentLine->m_NameColor = -2;
@@ -893,12 +890,9 @@ void CChat::OnPrepareLines()
 	float y = 300.0f - 28.0f;
 	float FontSize = FONT_SIZE;
 
-	bool ForceRecreate = m_pClient->m_pScoreboard->Active() != m_PrevScoreBoardShowed;
 	bool ShowLargeArea = m_Show || g_Config.m_ClShowChat == 2;
+	bool ForceRecreate = ShowLargeArea != m_PrevShowChat;
 
-	ForceRecreate |= ShowLargeArea != m_PrevShowChat;
-
-	m_PrevScoreBoardShowed = m_pClient->m_pScoreboard->Active();
 	m_PrevShowChat = ShowLargeArea;
 
 	float RealMsgPaddingX = MESSAGE_PADDING_X;
@@ -915,13 +909,12 @@ void CChat::OnPrepareLines()
 		RealMsgPaddingTee = 0;
 
 	int64 Now = time();
-	float LineWidth = (m_pClient->m_pScoreboard->Active() ? 90.0f : 200.0f) - RealMsgPaddingX - RealMsgPaddingTee;
+	float LineWidth = CHAT_WIDTH - RealMsgPaddingX - RealMsgPaddingTee;
 
-	float HeightLimit = m_pClient->m_pScoreboard->Active() ? 180.0f : m_PrevShowChat ? 50.0f : 200.0f;
+	float HeightLimit = m_PrevShowChat ? CHAT_HEIGHT_MIN : CHAT_HEIGHT_FULL;
 	float Begin = x;
 	float TextBegin = Begin + RealMsgPaddingX / 2.0f;
 	CTextCursor Cursor;
-	int OffsetType = m_pClient->m_pScoreboard->Active() ? 1 : 0;
 
 	for(int i = 0; i < MAX_LINES; i++)
 	{
@@ -967,7 +960,7 @@ void CChat::OnPrepareLines()
 		}
 
 		// get the y offset (calculate it if we haven't done that yet)
-		if(m_aLines[r].m_YOffset[OffsetType] < 0.0f)
+		if(m_aLines[r].m_YOffset < 0.0f)
 		{
 			TextRender()->SetCursor(&Cursor, TextBegin, 0.0f, FontSize, 0);
 			Cursor.m_LineWidth = LineWidth;
@@ -997,10 +990,10 @@ void CChat::OnPrepareLines()
 
 			TextRender()->TextEx(&AppendCursor, m_aLines[r].m_aText, -1);
 
-			m_aLines[r].m_YOffset[OffsetType] = AppendCursor.m_Y + AppendCursor.m_FontSize + RealMsgPaddingY;
+			m_aLines[r].m_YOffset = AppendCursor.m_Y + AppendCursor.m_FontSize + RealMsgPaddingY;
 		}
 
-		y -= m_aLines[r].m_YOffset[OffsetType];
+		y -= m_aLines[r].m_YOffset;
 
 		// cut off if msgs waste too much space
 		if(y < HeightLimit)
@@ -1111,7 +1104,7 @@ void CChat::OnPrepareLines()
 
 		if(g_Config.m_ClChatBackground && (m_aLines[r].m_aText[0] != '\0' || m_aLines[r].m_aName[0] != '\0'))
 		{
-			float Height = m_aLines[r].m_YOffset[OffsetType];
+			float Height = m_aLines[r].m_YOffset;
 			Graphics()->SetColor(1, 1, 1, 1);
 			m_aLines[r].m_QuadContainerIndex = RenderTools()->CreateRoundRectQuadContainer(Begin, y, (AppendCursor.m_LongestLineWidth - TextBegin) + RealMsgPaddingX * 1.5f, Height, MESSAGE_ROUNDING, CUI::CORNER_ALL);
 		}
@@ -1126,6 +1119,10 @@ void CChat::OnPrepareLines()
 
 void CChat::OnRender()
 {
+	// Do not render chat when scoreboard active
+	if(m_pClient->m_pScoreboard->Active())
+		return;
+
 	// send pending chat messages
 	if(m_PendingChatCounter > 0 && m_LastChatSend + time_freq() < time())
 	{
@@ -1222,8 +1219,7 @@ void CChat::OnRender()
 	OnPrepareLines();
 
 	int64 Now = time();
-	float HeightLimit = m_pClient->m_pScoreboard->Active() ? 180.0f : m_PrevShowChat ? 50.0f : 200.0f;
-	int OffsetType = m_pClient->m_pScoreboard->Active() ? 1 : 0;
+	float HeightLimit = m_PrevShowChat ? CHAT_HEIGHT_MIN : CHAT_HEIGHT_FULL;
 
 	float RealMsgPaddingX = MESSAGE_PADDING_X;
 	float RealMsgPaddingY = MESSAGE_PADDING_Y;
@@ -1240,7 +1236,7 @@ void CChat::OnRender()
 		if(Now > m_aLines[r].m_Time + 16 * time_freq() && !m_PrevShowChat)
 			break;
 
-		y -= m_aLines[r].m_YOffset[OffsetType];
+		y -= m_aLines[r].m_YOffset;
 
 		// cut off if msgs waste too much space
 		if(y < HeightLimit)
@@ -1277,7 +1273,7 @@ void CChat::OnRender()
 				float RowHeight = FONT_SIZE + RealMsgPaddingY;
 				float OffsetTeeY = MESSAGE_TEE_SIZE / 2.0f;
 				float FullHeightMinusTee = RowHeight - MESSAGE_TEE_SIZE;
-				float TWSkinUnreliableOffset = 1.0f; // teeworlds skins were always a bit in the ground
+				float TWSkinUnreliableOffset = 0.25f; // teeworlds skins were always a bit in the ground
 
 				CAnimState *pIdleState = CAnimState::GetIdle();
 				RenderTools()->RenderTee(pIdleState, &RenderInfo, EMOTE_NORMAL, vec2(1, 0.1f), vec2(x + (RealMsgPaddingX + MESSAGE_TEE_SIZE) / 2.0f, y + OffsetTeeY + FullHeightMinusTee / 2.0f + TWSkinUnreliableOffset), Blend);

--- a/src/game/client/components/chat.h
+++ b/src/game/client/components/chat.h
@@ -11,6 +11,9 @@ class CChat : public CComponent
 {
 	CLineInput m_Input;
 
+	static constexpr float CHAT_WIDTH = 200.0f;
+	static constexpr float CHAT_HEIGHT_FULL = 200.0f;
+	static constexpr float CHAT_HEIGHT_MIN = 50.0f;
 	static constexpr float MESSAGE_PADDING_X = 5.0f;
 	static constexpr float MESSAGE_TEE_SIZE = 7.0f;
 	static constexpr float MESSAGE_TEE_PADDING_RIGHT = 0.5f;
@@ -27,7 +30,7 @@ class CChat : public CComponent
 	struct CLine
 	{
 		int64 m_Time;
-		float m_YOffset[2];
+		float m_YOffset;
 		int m_ClientID;
 		int m_Team;
 		int m_NameColor;
@@ -51,7 +54,6 @@ class CChat : public CComponent
 		int m_TimesRepeated;
 	};
 
-	bool m_PrevScoreBoardShowed;
 	bool m_PrevShowChat;
 
 	CLine m_aLines[MAX_LINES];


### PR DESCRIPTION
Fixes: https://github.com/ddnet/ddnet/issues/3215

Disables chat rendering completely if scoreboard is active. Too many issues with chat resizing when scoreboard was active, don't think it is so important to have cropped little box of chat with scoreboard at the same time for such cost.

Also fixed tee icon position in chat, because right now it was like on the below message.

**OLD**
![OLD](https://user-images.githubusercontent.com/39315809/97746111-dd302c00-1afa-11eb-8fb4-6493ffc1e0fd.png)


**NEW**
![NOW](https://user-images.githubusercontent.com/39315809/97746120-df928600-1afa-11eb-9cf2-0030086f740f.png)

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [x] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
