### PR TITLE
Fix overlapping of combined binds with modifiers [Fixes #3182]

### DIFF
--- a/src/game/client/components/binds.cpp
+++ b/src/game/client/components/binds.cpp
@@ -143,8 +143,7 @@ bool CBinds::OnInput(IInput::CEvent e)
 		}
 	}
 
-	// Shift for emoticons works while moving through map
-	if(m_aapKeyBindings[0][e.m_Key] && (!ret || m_aapKeyBindings[0][e.m_Key][0] == '+'))
+	if(m_aapKeyBindings[0][e.m_Key] && !ret)
 	{
 		// When ctrl+shift are pressed (ctrl+shift binds and also the hard-coded ctrl+shift+d, ctrl+shift+g, ctrl+shift+e), ignore other +xxx binds
 		if(e.m_Flags & IInput::FLAG_PRESS && Mask != ((1 << MODIFIER_CTRL) | (1 << MODIFIER_SHIFT)))


### PR DESCRIPTION
Just fixes https://github.com/ddnet/ddnet/issues/3182

Works as it used to work, but does not call for binds with no modifier when the same key was used already for modified bind
