### PR TITLE
Revert "Show halloween skins only on Halloween"

### DIFF
--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -12,11 +12,6 @@
 #include <game/version.h>
 #include <time.h>
 
-static const char g_aHalloweenSkins[][64] = {
-	"Bat", "Cyclops", "darky", "dynamite", "Electro Tee", "evil", "ghost", "glitch",
-	"Lord_of_Zombie", "pumpkin", "reaper", "red_flame", "undead", "Voodoo_tee_1",
-	"zombie", "zombie1", "zombie2", "zombie3", "zombie4"};
-
 MACRO_ALLOC_POOL_ID_IMPL(CPlayer, MAX_CLIENTS)
 
 IServer *CPlayer::Server() const { return m_pGameServer->Server(); }
@@ -321,31 +316,10 @@ void CPlayer::Snap(int SnappingClient)
 	if(!pClientInfo)
 		return;
 
-	const char *pSkinName = m_TeeInfos.m_SkinName;
-
-	if(m_Halloween)
-	{
-		bool Found = false;
-
-		for(const auto &HalloweenSkin : g_aHalloweenSkins)
-		{
-			if(str_comp(pSkinName, HalloweenSkin) == 0)
-			{
-				Found = true;
-				break;
-			}
-		}
-
-		if(!Found)
-		{
-			pSkinName = g_aHalloweenSkins[str_quickhash(Server()->ClientName(m_ClientID)) % (sizeof(g_aHalloweenSkins) / sizeof(g_aHalloweenSkins[0]))];
-		}
-	}
-
 	StrToInts(&pClientInfo->m_Name0, 4, Server()->ClientName(m_ClientID));
 	StrToInts(&pClientInfo->m_Clan0, 3, Server()->ClientClan(m_ClientID));
 	pClientInfo->m_Country = Server()->ClientCountry(m_ClientID);
-	StrToInts(&pClientInfo->m_Skin0, 6, pSkinName);
+	StrToInts(&pClientInfo->m_Skin0, 6, m_TeeInfos.m_SkinName);
 	pClientInfo->m_UseCustomColor = m_TeeInfos.m_UseCustomColor;
 	pClientInfo->m_ColorBody = m_TeeInfos.m_ColorBody;
 	pClientInfo->m_ColorFeet = m_TeeInfos.m_ColorFeet;


### PR DESCRIPTION
People are clearly unhappy with this event, so let's revert it. On
servers I've set events 0 already.

This reverts commit ae90bdf3f9cf522b0fca5f3b690a624d319f04cf.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
