### PR TITLE
Kick-voting someone from team doesn't kill locked team (fixes #3207)

### DIFF
--- a/src/game/server/ddracecommands.cpp
+++ b/src/game/server/ddracecommands.cpp
@@ -665,7 +665,7 @@ void CGameContext::ConSetDDRTeam(IConsole::IResult *pResult, void *pUserData)
 	CCharacter *pChr = pSelf->GetPlayerChar(Target);
 
 	if((pController->m_Teams.m_Core.Team(Target) && pController->m_Teams.GetDDRaceState(pSelf->m_apPlayers[Target]) == DDRACE_STARTED) || (pChr && pController->m_Teams.IsPractice(pChr->Team())))
-		pSelf->m_apPlayers[Target]->KillCharacter(WEAPON_SELF);
+		pSelf->m_apPlayers[Target]->KillCharacter(WEAPON_GAME);
 
 	pController->m_Teams.SetForceCharacterTeam(Target, Team);
 }


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [x] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
