### PR TITLE
Other idea about #3219 (Scoreboard line height and font size matches for each team)

### DIFF
--- a/src/game/client/components/scoreboard.cpp
+++ b/src/game/client/components/scoreboard.cpp
@@ -654,11 +654,12 @@ void CScoreboard::OnRender()
 				float w = TextRender()->TextWidth(0, 86.0f, aText, -1, -1.0f);
 				TextRender()->Text(0, Width / 2 - w / 2, 39, 86.0f, aText, -1.0f);
 			}
-            
-            if(m_pClient->m_Snap.m_aTeamSize[TEAM_RED] >= m_pClient->m_Snap.m_aTeamSize[TEAM_BLUE])
-                m_pClient->m_Snap.m_aTeamSize[TEAM_BLUE] = m_pClient->m_Snap.m_aTeamSize[TEAM_RED];
-            else
-                m_pClient->m_Snap.m_aTeamSize[TEAM_RED] = m_pClient->m_Snap.m_aTeamSize[TEAM_BLUE];
+            		
+			// Fix #3216
+            		if(m_pClient->m_Snap.m_aTeamSize[TEAM_RED] >= m_pClient->m_Snap.m_aTeamSize[TEAM_BLUE])
+                		m_pClient->m_Snap.m_aTeamSize[TEAM_BLUE] = m_pClient->m_Snap.m_aTeamSize[TEAM_RED];
+           		else
+                		m_pClient->m_Snap.m_aTeamSize[TEAM_RED] = m_pClient->m_Snap.m_aTeamSize[TEAM_BLUE];
 
 			RenderScoreboard(Width / 2 - w - 5.0f, 150.0f, w, TEAM_RED, pRedClanName ? pRedClanName : Localize("Red team"));
 			RenderScoreboard(Width / 2 + 5.0f, 150.0f, w, TEAM_BLUE, pBlueClanName ? pBlueClanName : Localize("Blue team"));

--- a/src/game/client/components/scoreboard.cpp
+++ b/src/game/client/components/scoreboard.cpp
@@ -654,6 +654,11 @@ void CScoreboard::OnRender()
 				float w = TextRender()->TextWidth(0, 86.0f, aText, -1, -1.0f);
 				TextRender()->Text(0, Width / 2 - w / 2, 39, 86.0f, aText, -1.0f);
 			}
+            
+            if(m_pClient->m_Snap.m_aTeamSize[TEAM_RED] >= m_pClient->m_Snap.m_aTeamSize[TEAM_BLUE])
+                m_pClient->m_Snap.m_aTeamSize[TEAM_BLUE] = m_pClient->m_Snap.m_aTeamSize[TEAM_RED];
+            else
+                m_pClient->m_Snap.m_aTeamSize[TEAM_RED] = m_pClient->m_Snap.m_aTeamSize[TEAM_BLUE];
 
 			RenderScoreboard(Width / 2 - w - 5.0f, 150.0f, w, TEAM_RED, pRedClanName ? pRedClanName : Localize("Red team"));
 			RenderScoreboard(Width / 2 + 5.0f, 150.0f, w, TEAM_BLUE, pBlueClanName ? pBlueClanName : Localize("Blue team"));


### PR DESCRIPTION
Maybe this would be a solution? Or does is break anything else important? I have no overview.
I tested it ingame and it seemed to work.

I am not sure if this is a good idea but are the team sizes used for anything else?

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
