### PR TITLE
Revert 75987a26cf2eec415f3fba0607e755a42ef85eab and don't align for scoreboard

### DIFF
--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -893,12 +893,14 @@ void CChat::OnPrepareLines()
 	float y = 300.0f - 28.0f;
 	float FontSize = FONT_SIZE;
 
-	bool ForceRecreate = m_pClient->m_pScoreboard->Active() != m_PrevScoreBoardShowed;
+	bool IsScoreBoardOpen = m_pClient->m_pScoreboard->Active();
+
+	bool ForceRecreate = IsScoreBoardOpen != m_PrevScoreBoardShowed;
 	bool ShowLargeArea = m_Show || g_Config.m_ClShowChat == 2;
 
 	ForceRecreate |= ShowLargeArea != m_PrevShowChat;
 
-	m_PrevScoreBoardShowed = m_pClient->m_pScoreboard->Active();
+	m_PrevScoreBoardShowed = IsScoreBoardOpen;
 	m_PrevShowChat = ShowLargeArea;
 
 	float RealMsgPaddingX = MESSAGE_PADDING_X;
@@ -915,13 +917,13 @@ void CChat::OnPrepareLines()
 		RealMsgPaddingTee = 0;
 
 	int64 Now = time();
-	float LineWidth = (m_pClient->m_pScoreboard->Active() ? 90.0f : 200.0f) - RealMsgPaddingX - RealMsgPaddingTee;
+	float LineWidth = (IsScoreBoardOpen ? 90.0f : 200.0f) - RealMsgPaddingX - RealMsgPaddingTee;
 
-	float HeightLimit = m_pClient->m_pScoreboard->Active() ? 180.0f : m_PrevShowChat ? 50.0f : 200.0f;
+	float HeightLimit = IsScoreBoardOpen ? 180.0f : m_PrevShowChat ? 50.0f : 200.0f;
 	float Begin = x;
 	float TextBegin = Begin + RealMsgPaddingX / 2.0f;
 	CTextCursor Cursor;
-	int OffsetType = m_pClient->m_pScoreboard->Active() ? 1 : 0;
+	int OffsetType = IsScoreBoardOpen ? 1 : 0;
 
 	for(int i = 0; i < MAX_LINES; i++)
 	{
@@ -992,8 +994,12 @@ void CChat::OnPrepareLines()
 			}
 
 			CTextCursor AppendCursor = Cursor;
-			AppendCursor.m_StartX = Cursor.m_X;
-			AppendCursor.m_LineWidth -= (Cursor.m_LongestLineWidth - Cursor.m_StartX);
+
+			if(!IsScoreBoardOpen)
+			{
+				AppendCursor.m_StartX = Cursor.m_X;
+				AppendCursor.m_LineWidth -= (Cursor.m_LongestLineWidth - Cursor.m_StartX);
+			}
 
 			TextRender()->TextEx(&AppendCursor, m_aLines[r].m_aText, -1);
 
@@ -1101,8 +1107,11 @@ void CChat::OnPrepareLines()
 		TextRender()->TextColor(Color);
 
 		CTextCursor AppendCursor = Cursor;
-		AppendCursor.m_LineWidth -= (Cursor.m_LongestLineWidth - Cursor.m_StartX);
-		AppendCursor.m_StartX = Cursor.m_X;
+		if(!IsScoreBoardOpen)
+		{
+			AppendCursor.m_LineWidth -= (Cursor.m_LongestLineWidth - Cursor.m_StartX);
+			AppendCursor.m_StartX = Cursor.m_X;
+		}
 
 		if(m_aLines[r].m_TextContainerIndex == -1)
 			m_aLines[r].m_TextContainerIndex = TextRender()->CreateTextContainer(&AppendCursor, m_aLines[r].m_aText);

--- a/src/game/client/components/chat.h
+++ b/src/game/client/components/chat.h
@@ -11,9 +11,6 @@ class CChat : public CComponent
 {
 	CLineInput m_Input;
 
-	static constexpr float CHAT_WIDTH = 200.0f;
-	static constexpr float CHAT_HEIGHT_FULL = 200.0f;
-	static constexpr float CHAT_HEIGHT_MIN = 50.0f;
 	static constexpr float MESSAGE_PADDING_X = 5.0f;
 	static constexpr float MESSAGE_TEE_SIZE = 7.0f;
 	static constexpr float MESSAGE_TEE_PADDING_RIGHT = 0.5f;
@@ -30,7 +27,7 @@ class CChat : public CComponent
 	struct CLine
 	{
 		int64 m_Time;
-		float m_YOffset;
+		float m_YOffset[2];
 		int m_ClientID;
 		int m_Team;
 		int m_NameColor;
@@ -54,6 +51,7 @@ class CChat : public CComponent
 		int m_TimesRepeated;
 	};
 
+	bool m_PrevScoreBoardShowed;
 	bool m_PrevShowChat;
 
 	CLine m_aLines[MAX_LINES];


### PR DESCRIPTION
with scoreboard:
![screenshot_2020-11-01_04-52-35](https://user-images.githubusercontent.com/6654924/97794770-42207a80-1bfe-11eb-9cb3-4dae2af8d399.png)

without scoreboard still same:
![screenshot_2020-11-01_04-54-44](https://user-images.githubusercontent.com/6654924/97794778-611f0c80-1bfe-11eb-83c0-6992dbaee024.png)
