### PR TITLE
Add m_PosEnv (of sound sources) as index that must be offset when appending a map

### DIFF
--- a/src/game/editor/layer_sounds.cpp
+++ b/src/game/editor/layer_sounds.cpp
@@ -227,5 +227,8 @@ void CLayerSounds::ModifySoundIndex(INDEX_MODIFY_FUNC Func)
 void CLayerSounds::ModifyEnvelopeIndex(INDEX_MODIFY_FUNC Func)
 {
 	for(int i = 0; i < m_lSources.size(); i++)
+	{
 		Func(&m_lSources[i].m_SoundEnv);
+		Func(&m_lSources[i].m_PosEnv);
+	}
 }


### PR DESCRIPTION
If you append a map to another, all indices of it must be offset. This doesn't happen with the position envelope index of sound sources, meaning it would (if the original maps had at least one envelope) point to the wrong envelope.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
