### PR TITLE
Fix skin index

### DIFF
--- a/src/game/client/components/skins.cpp
+++ b/src/game/client/components/skins.cpp
@@ -55,7 +55,7 @@ int CSkins::SkinScan(const char *pName, int IsDir, int DirType, void *pUser)
 	return pSelf->LoadSkin(aNameWithoutPng, aBuf, DirType);
 }
 
-int CSkins::LoadSkin(const char *pName, const char *pPath, int DirType, int *pGetSkinID)
+int CSkins::LoadSkin(const char *pName, const char *pPath, int DirType)
 {
 	char aBuf[512];
 	CImageInfo Info;
@@ -172,10 +172,8 @@ int CSkins::LoadSkin(const char *pName, const char *pPath, int DirType, int *pGe
 		str_format(aBuf, sizeof(aBuf), "load skin %s", Skin.m_aName);
 		Console()->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "game", aBuf);
 	}
-	m_aSkins.add(Skin);
 
-	if(pGetSkinID)
-		*pGetSkinID = m_aSkins.size() - 1;
+	m_aSkins.add(Skin);
 
 	return 0;
 }
@@ -293,20 +291,19 @@ int CSkins::FindImpl(const char *pName)
 	auto d = ::find_binary(m_aDownloadSkins.all(), pName);
 	if(!d.empty())
 	{
-		int SkinID = -1;
 		if(d.front().m_pTask && d.front().m_pTask->State() == HTTP_DONE)
 		{
 			char aPath[MAX_PATH_LENGTH];
 			str_format(aPath, sizeof(aPath), "downloadedskins/%s.png", d.front().m_aName);
 			Storage()->RenameFile(d.front().m_aPath, aPath, IStorage::TYPE_SAVE);
-			LoadSkin(d.front().m_aName, aPath, IStorage::TYPE_SAVE, &SkinID);
+			LoadSkin(d.front().m_aName, aPath, IStorage::TYPE_SAVE);
 			d.front().m_pTask = nullptr;
 		}
 		if(d.front().m_pTask && (d.front().m_pTask->State() == HTTP_ERROR || d.front().m_pTask->State() == HTTP_ABORTED))
 		{
 			d.front().m_pTask = nullptr;
 		}
-		return SkinID;
+		return -1;
 	}
 
 	CDownloadSkin Skin;

--- a/src/game/client/components/skins.h
+++ b/src/game/client/components/skins.h
@@ -35,7 +35,7 @@ private:
 	sorted_array<CDownloadSkin> m_aDownloadSkins;
 	char m_EventSkinPrefix[24];
 
-	int LoadSkin(const char *pName, const char *pPath, int DirType, int *pGetSkinID = NULL);
+	int LoadSkin(const char *pName, const char *pPath, int DirType);
 	int FindImpl(const char *pName);
 	static int SkinScan(const char *pName, int IsDir, int DirType, void *pUser);
 };


### PR DESCRIPTION
Beside that this was wrong anyway, i hoped i could atleast get the index from the sorted list insert, but that returns the last index in the list, instead of the new inserted index(just like rn), so just revert what I added in 8d6148b20b2cde94d8e1fbe0a0dcd0bd81e86acc

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
