### PR TITLE
Added a Hint for Disabling Debug Mode

### DIFF
--- a/src/game/client/components/debughud.cpp
+++ b/src/game/client/components/debughud.cpp
@@ -143,8 +143,20 @@ void CDebugHud::RenderTuning()
 	TextRender()->TextColor(1, 1, 1, 1);
 }
 
+void CDebugHud::RenderHint()
+{
+	if(!g_Config.m_Debug)
+		return;
+
+	float Width = 300 * Graphics()->ScreenAspect();
+	Graphics()->MapScreen(0, 0, Width, 300);
+	TextRender()->TextColor(1, 1, 1, 1);
+	TextRender()->Text(0x0, 5, 290, 5, Localize("Debug mode enabled. Press Ctrl+Shift+D to disable debug mode."), -1.0f);
+}
+
 void CDebugHud::OnRender()
 {
 	RenderTuning();
 	RenderNetCorrections();
+	RenderHint();
 }

--- a/src/game/client/components/debughud.h
+++ b/src/game/client/components/debughud.h
@@ -8,6 +8,7 @@ class CDebugHud : public CComponent
 {
 	void RenderNetCorrections();
 	void RenderTuning();
+	void RenderHint();
 
 public:
 	virtual void OnRender();


### PR DESCRIPTION
Added a line at the bottom of the screen when cl_debug is 1

![screenshot_2020-11-03_15-09-52](https://user-images.githubusercontent.com/3797859/97957689-ab62e200-1de6-11eb-822c-4ffaa684b06e.png)

## Checklist

- [ ] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
