### PR TITLE
Don't access m_aaSpawnPoints out of bounds

### DIFF
--- a/src/game/server/gamecontroller.cpp
+++ b/src/game/server/gamecontroller.cpp
@@ -138,12 +138,12 @@ bool IGameController::OnEntity(int Index, vec2 Pos, int Layer, int Flags, int Nu
 	sides[6] = GameServer()->Collision()->Entity(x - 1, y, Layer);
 	sides[7] = GameServer()->Collision()->Entity(x - 1, y + 1, Layer);
 
-	if(Index == ENTITY_SPAWN)
-		m_aaSpawnPoints[0][m_aNumSpawnPoints[0]++] = Pos;
-	else if(Index == ENTITY_SPAWN_RED)
-		m_aaSpawnPoints[1][m_aNumSpawnPoints[1]++] = Pos;
-	else if(Index == ENTITY_SPAWN_BLUE)
-		m_aaSpawnPoints[2][m_aNumSpawnPoints[2]++] = Pos;
+	if(Index >= ENTITY_SPAWN && Index <= ENTITY_SPAWN_BLUE)
+	{
+		int Type = Index - ENTITY_SPAWN;
+		m_aaSpawnPoints[Type][m_aNumSpawnPoints[Type]] = Pos;
+		m_aNumSpawnPoints[Type] = minimum(m_aNumSpawnPoints[Type], (int)(sizeof(m_aaSpawnPoints[0]) / sizeof(m_aaSpawnPoints[0][0]) - 1));
+	}
 
 	else if(Index == ENTITY_DOOR)
 	{


### PR DESCRIPTION
As discovered by ASAN:

```
/home/teeworlds/src/master/src/game/server/gamecontroller.cpp:142:3: runtime error: index 65 out of bounds for type 'vec2 [64]'
    #0 0x5de082 in IGameController::OnEntity(int, vector2_base<float>, int, int, int) /home/teeworlds/src/master/src/game/server/gamecontroller.cpp:142:3
    #1 0x5c9f43 in CGameContext::OnInit() /home/teeworlds/src/master/src/game/server/gamecontext.cpp:3291:20
    #2 0x4ae3aa in CServer::Run() /home/teeworlds/src/master/src/engine/server/server.cpp:2473:20
    #3 0x4c265d in main /home/teeworlds/src/master/src/engine/server/server.cpp:3551:21
    #4 0x7f400fedc09a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2409a)
    #5 0x451509 in _start (/home/teeworlds/servers/DDNet-Server-ubsan+0x451509)
```

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
