### PR TITLE
Initialize pointer in dragger

### DIFF
--- a/src/game/server/entities/dragger.cpp
+++ b/src/game/server/entities/dragger.cpp
@@ -12,6 +12,7 @@ CDragger::CDragger(CGameWorld *pGameWorld, vec2 Pos, float Strength, bool NW,
 	int CaughtTeam, int Layer, int Number) :
 	CEntity(pGameWorld, CGameWorld::ENTTYPE_LASER)
 {
+	m_Target = 0;
 	m_Layer = Layer;
 	m_Number = Number;
 	m_Pos = Pos;

--- a/src/game/server/entities/dragger.cpp
+++ b/src/game/server/entities/dragger.cpp
@@ -57,10 +57,9 @@ void CDragger::Move()
 			continue;
 		}
 		int Res =
-			m_NW ? GameServer()->Collision()->IntersectNoLaserNW(m_Pos,
-				       Temp->m_Pos, 0, 0) :
-			       GameServer()->Collision()->IntersectNoLaser(m_Pos,
-				       Temp->m_Pos, 0, 0);
+			m_NW ?
+				GameServer()->Collision()->IntersectNoLaserNW(m_Pos, Temp->m_Pos, 0, 0) :
+				GameServer()->Collision()->IntersectNoLaser(m_Pos, Temp->m_Pos, 0, 0);
 
 		if(Res == 0)
 		{
@@ -81,9 +80,10 @@ void CDragger::Move()
 	}
 
 	if(!m_Target)
+	{
 		m_Target = Id != -1 ? TempEnts[Id] : 0;
-
-	if(m_Target)
+	}
+	else
 	{
 		for(auto &SoloEnt : m_SoloEnts)
 		{
@@ -95,38 +95,38 @@ void CDragger::Move()
 
 void CDragger::Drag()
 {
-	if(m_Target)
+	if(!m_Target)
+		return;
+
+	CCharacter *Target = m_Target;
+
+	for(int i = -1; i < MAX_CLIENTS; i++)
 	{
-		CCharacter *Target = m_Target;
+		if(i >= 0)
+			Target = m_SoloEnts[i];
 
-		for(int i = -1; i < MAX_CLIENTS; i++)
+		if(!Target)
+			continue;
+
+		int Res = 0;
+		if(!m_NW)
+			Res = GameServer()->Collision()->IntersectNoLaser(m_Pos,
+				Target->m_Pos, 0, 0);
+		else
+			Res = GameServer()->Collision()->IntersectNoLaserNW(m_Pos,
+				Target->m_Pos, 0, 0);
+		if(Res || length(m_Pos - Target->m_Pos) > g_Config.m_SvDraggerRange)
 		{
-			if(i >= 0)
-				Target = m_SoloEnts[i];
-
-			if(!Target)
-				continue;
-
-			int Res = 0;
-			if(!m_NW)
-				Res = GameServer()->Collision()->IntersectNoLaser(m_Pos,
-					Target->m_Pos, 0, 0);
+			Target = 0;
+			if(i == -1)
+				m_Target = 0;
 			else
-				Res = GameServer()->Collision()->IntersectNoLaserNW(m_Pos,
-					Target->m_Pos, 0, 0);
-			if(Res || length(m_Pos - Target->m_Pos) > g_Config.m_SvDraggerRange)
-			{
-				Target = 0;
-				if(i == -1)
-					m_Target = 0;
-				else
-					m_SoloEnts[i] = 0;
-			}
-			else if(length(m_Pos - Target->m_Pos) > 28)
-			{
-				vec2 Temp = Target->Core()->m_Vel + (normalize(m_Pos - Target->m_Pos) * m_Strength);
-				Target->Core()->m_Vel = ClampVel(Target->m_MoveRestrictions, Temp);
-			}
+				m_SoloEnts[i] = 0;
+		}
+		else if(length(m_Pos - Target->m_Pos) > 28)
+		{
+			vec2 Temp = Target->Core()->m_Vel + (normalize(m_Pos - Target->m_Pos) * m_Strength);
+			Target->Core()->m_Vel = ClampVel(Target->m_MoveRestrictions, Temp);
 		}
 	}
 }


### PR DESCRIPTION
How did this not blow up all day long for years?!
    
Found by UBSAN:

    /home/teeworlds/src/master/src/game/server/entities/dragger.cpp:32:29: runtime error: member call on address 0x0000013319b8 which does not point to an object of type 'CCharacter'
    0x0000013319b8: note: object has invalid vptr
     00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00
                  ^~~~~~~~~~~~~~~~~~~~~~~
                  invalid vptr
        #0 0x5501de in CDragger::Move() /home/teeworlds/src/master/src/game/server/entities/dragger.cpp:32:29
        #1 0x5522c2 in CDragger::Tick() /home/teeworlds/src/master/src/game/server/entities/dragger.cpp:153:3
        #2 0x5eb11e in CGameWorld::Tick() /home/teeworlds/src/master/src/game/server/gameworld.cpp:261:11
        #3 0x58d660 in CGameContext::OnTick() /home/teeworlds/src/master/src/game/server/gamecontext.cpp:751:10
        #4 0x4afefe in CServer::Run() /home/teeworlds/src/master/src/engine/server/server.cpp:2558:19
        #5 0x4c26fd in main /home/teeworlds/src/master/src/engine/server/server.cpp:3551:21
        #6 0x7f2c8cc9309a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2409a)
        #7 0x451509 in _start (/home/teeworlds/servers/DDNet-Server-ubsan+0x451509)


## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
