### PR TITLE
Just show chat behind scoreboard (fixes #3223)

### DIFF
--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -85,7 +85,6 @@ void CChat::Reset()
 		Line.m_TimesRepeated = 0;
 		Line.m_HasRenderTee = false;
 	}
-	m_PrevScoreBoardShowed = false;
 	m_PrevShowChat = false;
 
 	m_ReverseTAB = false;
@@ -893,14 +892,10 @@ void CChat::OnPrepareLines()
 	float y = 300.0f - 28.0f;
 	float FontSize = FONT_SIZE;
 
-	bool IsScoreBoardOpen = m_pClient->m_pScoreboard->Active();
-
-	bool ForceRecreate = IsScoreBoardOpen != m_PrevScoreBoardShowed;
 	bool ShowLargeArea = m_Show || g_Config.m_ClShowChat == 2;
 
-	ForceRecreate |= ShowLargeArea != m_PrevShowChat;
+	bool ForceRecreate = ShowLargeArea != m_PrevShowChat;
 
-	m_PrevScoreBoardShowed = IsScoreBoardOpen;
 	m_PrevShowChat = ShowLargeArea;
 
 	float RealMsgPaddingX = MESSAGE_PADDING_X;
@@ -917,13 +912,13 @@ void CChat::OnPrepareLines()
 		RealMsgPaddingTee = 0;
 
 	int64 Now = time();
-	float LineWidth = (IsScoreBoardOpen ? 90.0f : 200.0f) - RealMsgPaddingX - RealMsgPaddingTee;
+	float LineWidth = 200.0f - RealMsgPaddingX - RealMsgPaddingTee;
 
-	float HeightLimit = IsScoreBoardOpen ? 180.0f : m_PrevShowChat ? 50.0f : 200.0f;
+	float HeightLimit = m_PrevShowChat ? 50.0f : 200.0f;
 	float Begin = x;
 	float TextBegin = Begin + RealMsgPaddingX / 2.0f;
 	CTextCursor Cursor;
-	int OffsetType = IsScoreBoardOpen ? 1 : 0;
+	int OffsetType = 0;
 
 	for(int i = 0; i < MAX_LINES; i++)
 	{
@@ -994,12 +989,8 @@ void CChat::OnPrepareLines()
 			}
 
 			CTextCursor AppendCursor = Cursor;
-
-			if(!IsScoreBoardOpen)
-			{
-				AppendCursor.m_StartX = Cursor.m_X;
-				AppendCursor.m_LineWidth -= (Cursor.m_LongestLineWidth - Cursor.m_StartX);
-			}
+			AppendCursor.m_StartX = Cursor.m_X;
+			AppendCursor.m_LineWidth -= (Cursor.m_LongestLineWidth - Cursor.m_StartX);
 
 			TextRender()->TextEx(&AppendCursor, m_aLines[r].m_aText, -1);
 
@@ -1107,11 +1098,8 @@ void CChat::OnPrepareLines()
 		TextRender()->TextColor(Color);
 
 		CTextCursor AppendCursor = Cursor;
-		if(!IsScoreBoardOpen)
-		{
-			AppendCursor.m_LineWidth -= (Cursor.m_LongestLineWidth - Cursor.m_StartX);
-			AppendCursor.m_StartX = Cursor.m_X;
-		}
+		AppendCursor.m_LineWidth -= (Cursor.m_LongestLineWidth - Cursor.m_StartX);
+		AppendCursor.m_StartX = Cursor.m_X;
 
 		if(m_aLines[r].m_TextContainerIndex == -1)
 			m_aLines[r].m_TextContainerIndex = TextRender()->CreateTextContainer(&AppendCursor, m_aLines[r].m_aText);
@@ -1231,8 +1219,8 @@ void CChat::OnRender()
 	OnPrepareLines();
 
 	int64 Now = time();
-	float HeightLimit = m_pClient->m_pScoreboard->Active() ? 180.0f : m_PrevShowChat ? 50.0f : 200.0f;
-	int OffsetType = m_pClient->m_pScoreboard->Active() ? 1 : 0;
+	float HeightLimit = m_PrevShowChat ? 50.0f : 200.0f;
+	int OffsetType = 0;
 
 	float RealMsgPaddingX = MESSAGE_PADDING_X;
 	float RealMsgPaddingY = MESSAGE_PADDING_Y;

--- a/src/game/client/components/chat.h
+++ b/src/game/client/components/chat.h
@@ -51,7 +51,6 @@ class CChat : public CComponent
 		int m_TimesRepeated;
 	};
 
-	bool m_PrevScoreBoardShowed;
 	bool m_PrevShowChat;
 
 	CLine m_aLines[MAX_LINES];


### PR DESCRIPTION
![screenshot_2020-11-05_10-27-55](https://user-images.githubusercontent.com/2335377/98222850-abcbbc00-1f51-11eb-8ec3-7f38e607936a.png)
![screenshot_2020-11-05_10-29-20](https://user-images.githubusercontent.com/2335377/98222993-c9992100-1f51-11eb-832c-3e4c68155bcc.png)

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [x] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)