### PR TITLE
cl_chat_tee + cl_chat_background => cl_chat_old (fixes #3106)

### DIFF
--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -362,8 +362,7 @@ MACRO_CONFIG_INT(ClShowHookCollOwn, cl_show_hook_coll_own, 1, 0, 2, CFGFLAG_CLIE
 
 MACRO_CONFIG_INT(ClChatTeamColors, cl_chat_teamcolors, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show names in chat in team colors")
 MACRO_CONFIG_INT(ClChatReset, cl_chat_reset, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Reset chat when pressing escape")
-MACRO_CONFIG_INT(ClChatTee, cl_chat_tee, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show a tee before the player name in chat");
-MACRO_CONFIG_INT(ClChatBackground, cl_chat_background, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show a background for each chat message");
+MACRO_CONFIG_INT(ClChatOld, cl_chat_old, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Old chat style: No tee, no background");
 
 MACRO_CONFIG_INT(ClShowDirection, cl_show_direction, 1, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Show tee direction")
 MACRO_CONFIG_INT(ClHttpMapDownload, cl_http_map_download, 1, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Try fast HTTP map download first")

--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -799,7 +799,7 @@ void CChat::AddLine(int ClientID, int Team, const char *pLine)
 
 		if(pCurrentLine->m_ClientID >= 0 && pCurrentLine->m_aName[0] != '\0')
 		{
-			if(g_Config.m_ClChatTee)
+			if(!g_Config.m_ClChatOld)
 			{
 				pCurrentLine->m_CustomColoredSkin = m_pClient->m_aClients[pCurrentLine->m_ClientID].m_RenderInfo.m_CustomColoredSkin;
 				if(pCurrentLine->m_CustomColoredSkin)
@@ -907,14 +907,12 @@ void CChat::OnPrepareLines()
 	float RealMsgPaddingY = MESSAGE_PADDING_Y;
 	float RealMsgPaddingTee = MESSAGE_TEE_SIZE + MESSAGE_TEE_PADDING_RIGHT;
 
-	if(!g_Config.m_ClChatBackground)
+	if(g_Config.m_ClChatOld)
 	{
 		RealMsgPaddingX = 0;
-		RealMsgPaddingY = (g_Config.m_ClChatTee ? (MESSAGE_TEE_SIZE - FONT_SIZE) : 0);
-	}
-
-	if(!g_Config.m_ClChatTee)
+		RealMsgPaddingY = 0;
 		RealMsgPaddingTee = 0;
+	}
 
 	int64 Now = time();
 	float LineWidth = (IsScoreBoardOpen ? 90.0f : 200.0f) - RealMsgPaddingX - RealMsgPaddingTee;
@@ -963,7 +961,7 @@ void CChat::OnPrepareLines()
 		else
 			str_format(aCount, sizeof(aCount), " [%d]", m_aLines[r].m_TimesRepeated + 1);
 
-		if(!g_Config.m_ClChatTee)
+		if(g_Config.m_ClChatOld)
 		{
 			m_aLines[r].m_HasRenderTee = false;
 		}
@@ -1118,7 +1116,7 @@ void CChat::OnPrepareLines()
 		else
 			TextRender()->AppendTextContainer(&AppendCursor, m_aLines[r].m_TextContainerIndex, m_aLines[r].m_aText);
 
-		if(g_Config.m_ClChatBackground && (m_aLines[r].m_aText[0] != '\0' || m_aLines[r].m_aName[0] != '\0'))
+		if(!g_Config.m_ClChatOld && (m_aLines[r].m_aText[0] != '\0' || m_aLines[r].m_aName[0] != '\0'))
 		{
 			float Height = m_aLines[r].m_YOffset[OffsetType];
 			Graphics()->SetColor(1, 1, 1, 1);
@@ -1237,10 +1235,10 @@ void CChat::OnRender()
 	float RealMsgPaddingX = MESSAGE_PADDING_X;
 	float RealMsgPaddingY = MESSAGE_PADDING_Y;
 
-	if(!g_Config.m_ClChatBackground)
+	if(g_Config.m_ClChatOld)
 	{
 		RealMsgPaddingX = 0;
-		RealMsgPaddingY = (g_Config.m_ClChatTee ? (MESSAGE_TEE_SIZE - FONT_SIZE) : 0);
+		RealMsgPaddingY = 0;
 	}
 
 	for(int i = 0; i < MAX_LINES; i++)
@@ -1258,7 +1256,7 @@ void CChat::OnRender()
 		float Blend = Now > m_aLines[r].m_Time + 14 * time_freq() && !m_PrevShowChat ? 1.0f - (Now - m_aLines[r].m_Time - 14 * time_freq()) / (2.0f * time_freq()) : 1.0f;
 
 		// Draw backgrounds for messages in one batch
-		if(g_Config.m_ClChatBackground)
+		if(!g_Config.m_ClChatOld)
 		{
 			Graphics()->TextureClear();
 			if(m_aLines[r].m_QuadContainerIndex != -1)
@@ -1270,7 +1268,7 @@ void CChat::OnRender()
 
 		if(m_aLines[r].m_TextContainerIndex != -1)
 		{
-			if(g_Config.m_ClChatTee && m_aLines[r].m_HasRenderTee)
+			if(!g_Config.m_ClChatOld && m_aLines[r].m_HasRenderTee)
 			{
 				CTeeRenderInfo RenderInfo;
 				RenderInfo.m_CustomColoredSkin = m_aLines[r].m_CustomColoredSkin;

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -1646,21 +1646,10 @@ void CMenus::RenderSettingsHUD(CUIRect MainView)
 			g_Config.m_ClShowChat ^= 1;
 		}
 
-		bool IsOldChat = !(g_Config.m_ClChatTee || g_Config.m_ClChatBackground);
-
 		Left.HSplitTop(20.0f, &Button, &Left);
-		if(DoButton_CheckBox(&g_Config.m_ClChatTee, Localize("Use old chat style"), IsOldChat, &Button))
+		if(DoButton_CheckBox(&g_Config.m_ClChatOld, Localize("Use old chat style"), g_Config.m_ClChatOld, &Button))
 		{
-			if(IsOldChat)
-			{
-				g_Config.m_ClChatTee = 1;
-				g_Config.m_ClChatBackground = 1;
-			}
-			else
-			{
-				g_Config.m_ClChatTee = 0;
-				g_Config.m_ClChatBackground = 0;
-			}
+			g_Config.m_ClChatOld ^= 1;
 			GameClient()->m_pChat->RebuildChat();
 		}
 


### PR DESCRIPTION
![screenshot-20201105@131601](https://user-images.githubusercontent.com/2335377/98240075-30760480-1f69-11eb-91ab-4be84ab84aab.png)
![screenshot-20201105@131537](https://user-images.githubusercontent.com/2335377/98240077-310e9b00-1f69-11eb-8454-71d2c6612a2a.png)

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [x] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
