### PR TITLE
Fix scoreboard on ddnet server

### DIFF
--- a/src/game/client/components/scoreboard.cpp
+++ b/src/game/client/components/scoreboard.cpp
@@ -152,9 +152,6 @@ void CScoreboard::RenderScoreboard(float x, float y, float w, int Team, const ch
 	if(Team == TEAM_SPECTATORS)
 		return;
 
-	if(NumPlayers < 0)
-		NumPlayers = m_pClient->m_Snap.m_aTeamSize[Team];
-
 	bool lower16 = false;
 	bool upper16 = false;
 	bool lower24 = false;
@@ -177,6 +174,9 @@ void CScoreboard::RenderScoreboard(float x, float y, float w, int Team, const ch
 
 	if(Team < -1)
 		Team = 0;
+
+	if(NumPlayers < 0)
+		NumPlayers = m_pClient->m_Snap.m_aTeamSize[Team];
 
 	float h = 760.0f;
 


### PR DESCRIPTION
![screenshot_2020-11-07_18-36-44](https://user-images.githubusercontent.com/2335377/98447851-5990c380-2128-11eb-8577-62a795aa915e.png)

Broken in https://github.com/ddnet/ddnet/pull/3251

Thanks to louis for report

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
