### PR TITLE
Don't disconnect on missing demo

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -3706,14 +3706,15 @@ const char *CClient::DemoPlayer_Play(const char *pFilename, int StorageType)
 {
 	int Crc;
 	const char *pError;
-	Disconnect();
-	m_NetClient[CLIENT_MAIN].ResetErrorString();
 
 	// try to start playback
 	m_DemoPlayer.SetListener(this);
 
 	if(m_DemoPlayer.Load(Storage(), m_pConsole, pFilename, StorageType))
 		return "error loading demo";
+
+	Disconnect();
+	m_NetClient[CLIENT_MAIN].ResetErrorString();
 
 	// load map
 	Crc = m_DemoPlayer.GetMapInfo()->m_Crc;


### PR DESCRIPTION
This fixes the issue of people telling others to enter `play tetris`
into the console. Fixes #3283.

Supersedes #3284, same thing, but without the TOCTOU stuff.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
