### PR TITLE
Some shader refactoring

### DIFF
--- a/data/shader/prim.frag
+++ b/data/shader/prim.frag
@@ -1,5 +1,4 @@
-uniform int isTextured;
-uniform sampler2D textureSampler;
+uniform sampler2D gTextureSampler;
 
 noperspective in vec2 texCoord;
 noperspective in vec4 vertColor;
@@ -7,10 +6,10 @@ noperspective in vec4 vertColor;
 out vec4 FragClr;
 void main()
 {
-	if(isTextured == 1)
-	{
-		vec4 tex = texture(textureSampler, texCoord);
-		FragClr = tex * vertColor;
-	}
-	else FragClr = vertColor;
+#ifdef TW_TEXTURED
+	vec4 tex = texture(gTextureSampler, texCoord);
+	FragClr = tex * vertColor;
+#else
+	FragClr = vertColor;
+#endif
 }

--- a/data/shader/prim.vert
+++ b/data/shader/prim.vert
@@ -2,14 +2,14 @@ layout (location = 0) in vec2 inVertex;
 layout (location = 1) in vec2 inVertexTexCoord;
 layout (location = 2) in vec4 inVertexColor;
 
-uniform mat4x2 Pos;
+uniform mat4x2 gPos;
 
 noperspective out vec2 texCoord;
 noperspective out vec4 vertColor;
 
 void main()
 {
-	gl_Position = vec4(Pos * vec4(inVertex, 0.0, 1.0), 0.0, 1.0);
+	gl_Position = vec4(gPos * vec4(inVertex, 0.0, 1.0), 0.0, 1.0);
 	texCoord = inVertexTexCoord;
 	vertColor = inVertexColor;
 }

--- a/data/shader/primex.vert
+++ b/data/shader/primex.vert
@@ -4,7 +4,9 @@ layout (location = 2) in vec4 inVertexColor;
 
 uniform mat4x2 gPos;
 
+#ifndef TW_ROTATIONLESS
 uniform float gRotation;
+#endif
 uniform vec2 gCenter;
 
 noperspective out vec2 texCoord;
@@ -13,14 +15,13 @@ noperspective out vec4 vertColor;
 void main()
 {
 	vec2 FinalPos = vec2(inVertex.xy);
-	if(gRotation != 0.0)
-	{
-		float X = FinalPos.x - gCenter.x;
-		float Y = FinalPos.y - gCenter.y;
-		
-		FinalPos.x = X * cos(gRotation) - Y * sin(gRotation) + gCenter.x;
-		FinalPos.y = X * sin(gRotation) + Y * cos(gRotation) + gCenter.y;
-	}
+#ifndef TW_ROTATIONLESS
+	float X = FinalPos.x - gCenter.x;
+	float Y = FinalPos.y - gCenter.y;
+	
+	FinalPos.x = X * cos(gRotation) - Y * sin(gRotation) + gCenter.x;
+	FinalPos.y = X * sin(gRotation) + Y * cos(gRotation) + gCenter.y;
+#endif
 
 	gl_Position = vec4(gPos * vec4(FinalPos, 0.0, 1.0), 0.0, 1.0);
 	texCoord = inVertexTexCoord;

--- a/data/shader/spritemulti.frag
+++ b/data/shader/spritemulti.frag
@@ -1,6 +1,6 @@
-uniform sampler2D textureSampler;
+uniform sampler2D gTextureSampler;
 
-uniform vec4 VerticesColor;
+uniform vec4 gVerticesColor;
 
 noperspective in vec2 texCoord;
 noperspective in vec4 vertColor;
@@ -8,6 +8,6 @@ noperspective in vec4 vertColor;
 out vec4 FragClr;
 void main()
 {
-	vec4 tex = texture(textureSampler, texCoord);
-	FragClr = tex * vertColor * VerticesColor;
+	vec4 tex = texture(gTextureSampler, texCoord);
+	FragClr = tex * vertColor * gVerticesColor;
 }

--- a/data/shader/spritemulti.vert
+++ b/data/shader/spritemulti.vert
@@ -2,10 +2,10 @@ layout (location = 0) in vec2 inVertex;
 layout (location = 1) in vec2 inVertexTexCoord;
 layout (location = 2) in vec4 inVertexColor;
 
-uniform mat4x2 Pos;
+uniform mat4x2 gPos;
 
-uniform vec4 RSP[228];
-uniform vec2 Center;
+uniform vec4 gRSP[228];
+uniform vec2 gCenter;
 
 noperspective out vec2 texCoord;
 noperspective out vec4 vertColor;
@@ -13,22 +13,22 @@ noperspective out vec4 vertColor;
 void main()
 {
 	vec2 FinalPos = vec2(inVertex.xy);
-	if(RSP[gl_InstanceID].w != 0.0)
+	if(gRSP[gl_InstanceID].w != 0.0)
 	{
-		float X = FinalPos.x - Center.x;
-		float Y = FinalPos.y - Center.y;
+		float X = FinalPos.x - gCenter.x;
+		float Y = FinalPos.y - gCenter.y;
 		
-		FinalPos.x = X * cos(RSP[gl_InstanceID].w) - Y * sin(RSP[gl_InstanceID].w) + Center.x;
-		FinalPos.y = X * sin(RSP[gl_InstanceID].w) + Y * cos(RSP[gl_InstanceID].w) + Center.y;
+		FinalPos.x = X * cos(gRSP[gl_InstanceID].w) - Y * sin(gRSP[gl_InstanceID].w) + gCenter.x;
+		FinalPos.y = X * sin(gRSP[gl_InstanceID].w) + Y * cos(gRSP[gl_InstanceID].w) + gCenter.y;
 	}
 	
-	FinalPos.x *= RSP[gl_InstanceID].z;
-	FinalPos.y *= RSP[gl_InstanceID].z;
+	FinalPos.x *= gRSP[gl_InstanceID].z;
+	FinalPos.y *= gRSP[gl_InstanceID].z;
 		
-	FinalPos.x += RSP[gl_InstanceID].x;
-	FinalPos.y += RSP[gl_InstanceID].y;
+	FinalPos.x += gRSP[gl_InstanceID].x;
+	FinalPos.y += gRSP[gl_InstanceID].y;
 
-	gl_Position = vec4(Pos * vec4(FinalPos, 0.0, 1.0), 0.0, 1.0);
+	gl_Position = vec4(gPos * vec4(FinalPos, 0.0, 1.0), 0.0, 1.0);
 	texCoord = inVertexTexCoord;
 	vertColor = inVertexColor;
 }

--- a/data/shader/text.frag
+++ b/data/shader/text.frag
@@ -1,8 +1,8 @@
-uniform sampler2D textSampler;
-uniform sampler2D textOutlineSampler;
+uniform sampler2D gTextSampler;
+uniform sampler2D gTextOutlineSampler;
 
-uniform vec4 vertColor;
-uniform vec4 vertOutlineColor;
+uniform vec4 gVertColor;
+uniform vec4 gVertOutlineColor;
 
 noperspective in vec2 texCoord;
 noperspective in vec4 outVertColor;
@@ -10,8 +10,8 @@ noperspective in vec4 outVertColor;
 out vec4 FragClr;
 void main()
 {
-	vec4 textColor = vertColor * outVertColor * texture(textSampler, texCoord);
-	vec4 textOutlineTex = vertOutlineColor * texture(textOutlineSampler, texCoord);
+	vec4 textColor = gVertColor * outVertColor * texture(gTextSampler, texCoord);
+	vec4 textOutlineTex = gVertOutlineColor * texture(gTextOutlineSampler, texCoord);
 	
 	// ratio between the two textures
 	float OutlineBlend = (1.0 - textColor.a);	
@@ -28,10 +28,6 @@ void main()
 	vec3 finalFragColor = textOutlineFrag.rgb + textFrag;
 	
 	float RealAlpha = (textOutlineFrag.a + textColor.a);
-	
-	// discard transparent fragments
-	if(RealAlpha == 0.0)
-		discard;
 	
 	// simply add the color we will loose through blending
 	FragClr = vec4(finalFragColor / RealAlpha, RealAlpha);

--- a/data/shader/text.vert
+++ b/data/shader/text.vert
@@ -2,16 +2,16 @@ layout (location = 0) in vec2 inVertex;
 layout (location = 1) in vec2 inVertexTexCoord;
 layout (location = 2) in vec4 inVertexColor;
 
-uniform mat4x2 Pos;
-uniform float textureSize;
+uniform mat4x2 gPos;
+uniform float gTextureSize;
 
 noperspective out vec2 texCoord;
 noperspective out vec4 outVertColor;
 
 void main()
 {
-	gl_Position = vec4(Pos * vec4(inVertex, 0.0, 1.0), 0.0, 1.0);
+	gl_Position = vec4(gPos * vec4(inVertex, 0.0, 1.0), 0.0, 1.0);
 
-	texCoord = vec2(inVertexTexCoord.x / textureSize, inVertexTexCoord.y / textureSize);
+	texCoord = vec2(inVertexTexCoord.x / gTextureSize, inVertexTexCoord.y / gTextureSize);
 	outVertColor = inVertexColor;
 }

--- a/src/engine/client/backend_sdl.h
+++ b/src/engine/client/backend_sdl.h
@@ -170,6 +170,7 @@ public:
 	};
 
 protected:
+	bool IsTexturedState(const CCommandBuffer::SState &State);
 	void SetState(const CCommandBuffer::SState &State, bool Use2DArrayTexture = false);
 	virtual bool IsNewApi() { return false; }
 	void DestroyTexture(int Slot);
@@ -310,6 +311,7 @@ class CCommandProcessorFragment_OpenGL3_3 : public CCommandProcessorFragment_Ope
 	static const int m_MaxQuadsPossible = 256;
 
 	CGLSLPrimitiveProgram *m_pPrimitiveProgram;
+	CGLSLPrimitiveProgram *m_pPrimitiveProgramTextured;
 	CGLSLTileProgram *m_pBorderTileProgram;
 	CGLSLTileProgram *m_pBorderTileProgramTextured;
 	CGLSLTileProgram *m_pBorderTileLineProgram;
@@ -319,6 +321,8 @@ class CCommandProcessorFragment_OpenGL3_3 : public CCommandProcessorFragment_Ope
 	CGLSLTextProgram *m_pTextProgram;
 	CGLSLPrimitiveExProgram *m_pPrimitiveExProgram;
 	CGLSLPrimitiveExProgram *m_pPrimitiveExProgramTextured;
+	CGLSLPrimitiveExProgram *m_pPrimitiveExProgramRotationless;
+	CGLSLPrimitiveExProgram *m_pPrimitiveExProgramTexturedRotationless;
 	CGLSLSpriteMultipleProgram *m_pSpriteProgramMultiple;
 
 	GLuint m_LastProgramID;
@@ -352,6 +356,8 @@ class CCommandProcessorFragment_OpenGL3_3 : public CCommandProcessorFragment_Ope
 	std::vector<GLuint> m_BufferObjectIndices;
 
 	CCommandBuffer::SColorf m_ClearColor;
+
+	void InitPrimExProgram(CGLSLPrimitiveExProgram *pProgram, class CGLSLCompiler *pCompiler, class IStorage *pStorage, bool Textured, bool Rotationless);
 
 protected:
 	static int TexFormatToNewOpenGLFormat(int TexFormat);

--- a/src/engine/client/opengl_sl_program.h
+++ b/src/engine/client/opengl_sl_program.h
@@ -45,13 +45,12 @@ class CGLSLTWProgram : public CGLSLProgram
 {
 public:
 	CGLSLTWProgram() :
-		m_LocPos(-1), m_LocIsTextured(-1), m_LocTextureSampler(-1), m_LastTextureSampler(-1), m_LastIsTextured(-1)
+		m_LocPos(-1), m_LocTextureSampler(-1), m_LastTextureSampler(-1), m_LastIsTextured(-1)
 	{
 		m_LastScreen[0] = m_LastScreen[1] = m_LastScreen[2] = m_LastScreen[3] = -1.f;
 	}
 
 	int m_LocPos;
-	int m_LocIsTextured;
 	int m_LocTextureSampler;
 
 	int m_LastTextureSampler;


### PR DESCRIPTION
Small refactoring for GL 3.3+ shaders.
Removes "if" checks where unneeded or CPU can calculate the result faster.

Also renames some uniforms to be consistent within all shaders.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
