### PR TITLE
Fix memleak in CServer on instant shutdown

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -329,6 +329,17 @@ CServer::CServer() :
 	Init();
 }
 
+CServer::~CServer()
+{
+	for(auto &pCurrentMapData : m_apCurrentMapData)
+	{
+		if(pCurrentMapData)
+			free(pCurrentMapData);
+	}
+
+	delete m_pConnectionPool;
+}
+
 bool CServer::IsClientNameAvailable(int ClientID, const char *pNameRequest)
 {
 	// check for empty names
@@ -2649,11 +2660,7 @@ int CServer::Run()
 	GameServer()->OnShutdown();
 	m_pMap->Unload();
 
-	for(auto &pCurrentMapData : m_apCurrentMapData)
-		free(pCurrentMapData);
-
 	DbPool()->OnShutdown();
-	delete m_pConnectionPool;
 
 #if defined(CONF_UPNP)
 	m_UPnP.Shutdown();

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -257,6 +257,7 @@ public:
 	array<CNameBan> m_aNameBans;
 
 	CServer();
+	~CServer();
 
 	bool IsClientNameAvailable(int ClientID, const char *pNameRequest);
 	bool SetClientNameImpl(int ClientID, const char *pNameRequest, bool Set);


### PR DESCRIPTION
```
Direct leak of 566869 byte(s) in 1 object(s) allocated from:
    #0 0x4f28e3 in __interceptor_malloc (/home/teeworlds/servers/DDNet-Server-asan+0x4f28e3)
    #1 0x55b3c9 in CServer::LoadMap(char const*) /home/teeworlds/src/master/src/engine/server/server.cpp:2312:49
    #2 0x55bfdd in CServer::Run() /home/teeworlds/src/master/src/engine/server/server.cpp:2351:6
    #3 0x56add2 in main /home/teeworlds/src/master/src/engine/server/server.cpp:3553:21
    #4 0x7f54401cd09a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2409a)
```

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [x] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
