### PR TITLE
Fix updating points on SQLite3 backend

### DIFF
--- a/src/engine/server/databases/sqlite.cpp
+++ b/src/engine/server/databases/sqlite.cpp
@@ -240,7 +240,7 @@ void CSqliteConnection::AddPoints(const char *pPlayer, int Points)
 	str_format(aBuf, sizeof(aBuf),
 		"INSERT INTO %s_points(Name, Points) "
 		"VALUES (?, ?) "
-		"ON CONFLICT(Name) UPDATE SET Points=Points+?;",
+		"ON CONFLICT(Name) DO UPDATE SET Points=Points+?;",
 		GetPrefix());
 	PrepareStatement(aBuf);
 	BindString(1, pPlayer);


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [x] Tested the change ingame (only on sqlite, but shouldn't affect mysql)
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
