### PR TITLE
Respect outline in skin metrics

### DIFF
--- a/src/game/client/render.cpp
+++ b/src/game/client/render.cpp
@@ -566,10 +566,10 @@ void CRenderTools::GetRenderTeeBodySize(CAnimState *pAnim, CTeeRenderInfo *pInfo
 	float BodyScale;
 	GetRenderTeeBodyScale(BaseSize, BodyScale);
 
-	Width = pInfo->m_SkinMetrics.BodyWidthNormalized() * 64.0f * BodyScale;
-	Height = pInfo->m_SkinMetrics.BodyHeightNormalized() * 64.0f * BodyScale;
-	BodyOffset.x = pInfo->m_SkinMetrics.BodyOffsetXNormalized() * 64.0f * BodyScale;
-	BodyOffset.y = pInfo->m_SkinMetrics.BodyOffsetYNormalized() * 64.0f * BodyScale;
+	Width = pInfo->m_SkinMetrics.m_Body.WidthNormalized() * 64.0f * BodyScale;
+	Height = pInfo->m_SkinMetrics.m_Body.HeightNormalized() * 64.0f * BodyScale;
+	BodyOffset.x = pInfo->m_SkinMetrics.m_Body.OffsetXNormalized() * 64.0f * BodyScale;
+	BodyOffset.y = pInfo->m_SkinMetrics.m_Body.OffsetYNormalized() * 64.0f * BodyScale;
 }
 
 void CRenderTools::GetRenderTeeFeetSize(CAnimState *pAnim, CTeeRenderInfo *pInfo, vec2 &FeetOffset, float &Width, float &Height)
@@ -580,10 +580,10 @@ void CRenderTools::GetRenderTeeFeetSize(CAnimState *pAnim, CTeeRenderInfo *pInfo
 	float FeetScaleWidth, FeetScaleHeight;
 	GetRenderTeeFeetScale(BaseSize, FeetScaleWidth, FeetScaleHeight);
 
-	Width = pInfo->m_SkinMetrics.FeetWidthNormalized() * 64.0f * FeetScaleWidth;
-	Height = pInfo->m_SkinMetrics.FeetHeightNormalized() * 32.0f * FeetScaleHeight;
-	FeetOffset.x = pInfo->m_SkinMetrics.FeetOffsetXNormalized() * 64.0f * FeetScaleWidth;
-	FeetOffset.y = pInfo->m_SkinMetrics.FeetOffsetYNormalized() * 32.0f * FeetScaleHeight;
+	Width = pInfo->m_SkinMetrics.m_Feet.WidthNormalized() * 64.0f * FeetScaleWidth;
+	Height = pInfo->m_SkinMetrics.m_Feet.HeightNormalized() * 32.0f * FeetScaleHeight;
+	FeetOffset.x = pInfo->m_SkinMetrics.m_Feet.OffsetXNormalized() * 64.0f * FeetScaleWidth;
+	FeetOffset.y = pInfo->m_SkinMetrics.m_Feet.OffsetYNormalized() * 32.0f * FeetScaleHeight;
 }
 
 void CRenderTools::GetRenderTeeOffsetToRenderedTee(CAnimState *pAnim, CTeeRenderInfo *pInfo, vec2 &TeeOffsetToMid)

--- a/src/game/client/skin.h
+++ b/src/game/client/skin.h
@@ -5,6 +5,7 @@
 #include <base/tl/sorted_array.h>
 #include <base/vmath.h>
 #include <engine/graphics.h>
+#include <limits>
 
 // do this better and nicer
 struct CSkin
@@ -42,16 +43,80 @@ struct CSkin
 	char m_aName[24];
 	ColorRGBA m_BloodColor;
 
-	struct SSkinMetrics
+	template<bool IsSizeType>
+	struct SSkinMetricVariableInt
 	{
-		int m_BodyWidth;
-		int m_BodyHeight;
-		int m_BodyOffsetX;
-		int m_BodyOffsetY;
+		int m_Value;
+		operator int() { return m_Value; }
+		SSkinMetricVariableInt &operator=(int NewVal)
+		{
+			if(IsSizeType)
+				m_Value = maximum(m_Value, NewVal);
+			else
+				m_Value = minimum(m_Value, NewVal);
+			return *this;
+		}
+
+		SSkinMetricVariableInt()
+		{
+			Reset();
+		}
+
+		void Reset()
+		{
+			if(IsSizeType)
+				m_Value = std::numeric_limits<int>::lowest();
+			else
+				m_Value = std::numeric_limits<int>::max();
+		}
+	};
+
+	struct SSkinMetricVariable
+	{
+		SSkinMetricVariableInt<true> m_Width;
+		SSkinMetricVariableInt<true> m_Height;
+		SSkinMetricVariableInt<false> m_OffsetX;
+		SSkinMetricVariableInt<false> m_OffsetY;
 
 		// these can be used to normalize the metrics
-		int m_BodyMaxWidth;
-		int m_BodyMaxHeight;
+		SSkinMetricVariableInt<true> m_MaxWidth;
+		SSkinMetricVariableInt<true> m_MaxHeight;
+
+		float WidthNormalized()
+		{
+			return (float)m_Width / (float)m_MaxWidth;
+		}
+
+		float HeightNormalized()
+		{
+			return (float)m_Height / (float)m_MaxHeight;
+		}
+
+		float OffsetXNormalized()
+		{
+			return (float)m_OffsetX / (float)m_MaxWidth;
+		}
+
+		float OffsetYNormalized()
+		{
+			return (float)m_OffsetY / (float)m_MaxHeight;
+		}
+
+		void Reset()
+		{
+			m_Width.Reset();
+			m_Height.Reset();
+			m_OffsetX.Reset();
+			m_OffsetY.Reset();
+			m_MaxWidth.Reset();
+			m_MaxHeight.Reset();
+		}
+	};
+
+	struct SSkinMetrics
+	{
+		SSkinMetricVariable m_Body;
+		SSkinMetricVariable m_Feet;
 
 		int m_FeetWidth;
 		int m_FeetHeight;
@@ -64,47 +129,13 @@ struct CSkin
 
 		void Reset()
 		{
-			m_BodyWidth = m_BodyHeight = m_BodyOffsetX = m_BodyOffsetY = m_FeetWidth = m_FeetHeight = m_FeetOffsetX = m_FeetOffsetY = -1;
+			m_Body.Reset();
+			m_Feet.Reset();
 		}
 
-		float BodyWidthNormalized()
+		SSkinMetrics()
 		{
-			return (float)m_BodyWidth / (float)m_BodyMaxWidth;
-		}
-
-		float BodyHeightNormalized()
-		{
-			return (float)m_BodyHeight / (float)m_BodyMaxHeight;
-		}
-
-		float BodyOffsetXNormalized()
-		{
-			return (float)m_BodyOffsetX / (float)m_BodyMaxWidth;
-		}
-
-		float BodyOffsetYNormalized()
-		{
-			return (float)m_BodyOffsetY / (float)m_BodyMaxHeight;
-		}
-
-		float FeetWidthNormalized()
-		{
-			return (float)m_FeetWidth / (float)m_FeetMaxWidth;
-		}
-
-		float FeetHeightNormalized()
-		{
-			return (float)m_FeetHeight / (float)m_FeetMaxHeight;
-		}
-
-		float FeetOffsetXNormalized()
-		{
-			return (float)m_FeetOffsetX / (float)m_FeetMaxWidth;
-		}
-
-		float FeetOffsetYNormalized()
-		{
-			return (float)m_FeetOffsetY / (float)m_FeetMaxHeight;
+			Reset();
 		}
 	};
 	SSkinMetrics m_Metrics;


### PR DESCRIPTION
beast.png has no body at all,
so for this skin we need to calculate the metrics with the outline.

Sadly comes with more overheat ofc

old:
![screenshot_2020-11-12_08-42-52](https://user-images.githubusercontent.com/6654924/98910148-15544900-24c3-11eb-8cde-3c5bfb847527.png)
new:
![screenshot_2020-11-12_08-41-30](https://user-images.githubusercontent.com/6654924/98910094-0077b580-24c3-11eb-804b-7849a7d18d14.png)

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
