### PR TITLE
Fix null pointer to mem_copy

### DIFF
--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -499,13 +499,12 @@ CServerBrowser::CServerEntry *CServerBrowser::Add(const NETADDR &Addr)
 	pEntry->m_pNextIp = m_aServerlistIp[Hash];
 	m_aServerlistIp[Hash] = pEntry;
 
-	if(m_NumServers == m_NumServerCapacity)
+	if(m_NumServers == m_NumServerCapacity && m_NumServers > 0 && m_ppServerlist != 0)
 	{
 		CServerEntry **ppNewlist;
 		m_NumServerCapacity += 100;
 		ppNewlist = (CServerEntry **)calloc(m_NumServerCapacity, sizeof(CServerEntry *)); // NOLINT(bugprone-sizeof-expression)
-		if(m_NumServers > 0)
-			mem_copy(ppNewlist, m_ppServerlist, m_NumServers * sizeof(CServerEntry *)); // NOLINT(bugprone-sizeof-expression)
+		mem_copy(ppNewlist, m_ppServerlist, m_NumServers * sizeof(CServerEntry *)); // NOLINT(bugprone-sizeof-expression)
 		free(m_ppServerlist);
 		m_ppServerlist = ppNewlist;
 	}


### PR DESCRIPTION
As found by ubsan. I'm not sure why m_ppServerlist is 0 here.
```
src/base/system.c:261:15: runtime error: null pointer passed as argument 2, which is declared to never be null
/usr/include/string.h:44:28: note: nonnull attribute specified here
    #0 0x55ea065eb20c in mem_copy /media/ddnet/src/base/system.c:261:2
    #1 0x55ea0696278d in CServerBrowser::Add(NETADDR const&) /media/ddnet/src/engine/client/serverbrowser.cpp:503:3
    #2 0x55ea06963c85 in CServerBrowser::Set(NETADDR const&, int, int, CServerInfo const*) /media/ddnet/src/engine/client/serverbrowser.cpp:548:13
    #3 0x55ea06968b23 in CServerBrowser::Refresh(int) /media/ddnet/src/engine/client/serverbrowser.cpp:705:6
    #4 0x55ea06d2ae6c in CMenus::Render() /media/ddnet/src/game/client/components/menus.cpp:1162:21
    #5 0x55ea06d5cf1b in CMenus::OnRender() /media/ddnet/src/game/client/components/menus.cpp:2334:2
    #6 0x55ea0701d239 in CGameClient::OnRender() /media/ddnet/src/game/client/gameclient.cpp:671:28
    #7 0x55ea067b9709 in CClient::Render() /media/ddnet/src/engine/client/client.cpp:1135:16
    #8 0x55ea0680b5be in CClient::Run() /media/ddnet/src/engine/client/client.cpp:3288:7
    #9 0x55ea0683cbec in main /media/ddnet/src/engine/client/client.cpp:4344:11
    #10 0x7f31e7f18151 in __libc_start_main (/usr/lib/libc.so.6+0x28151)
    #11 0x55ea0631f96d in _start (/media/ddnet/DDNet+0x8c496d)
```

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
