### PR TITLE
Disallow to ignore src/mastersrv and src/twping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,10 @@ unicode_confusables
 uuid
 versionsrv
 
+# But we still should allow to download mastersrv/twping sources
+!src/mastersrv
+!src/twping
+
 generated
 
 # IDE project files


### PR DESCRIPTION
Before it was annoying to download sources and get stupid CMake errors about it.
