### PR TITLE
No infinite loop in TextEx

### DIFF
--- a/src/engine/client/text.cpp
+++ b/src/engine/client/text.cpp
@@ -938,8 +938,12 @@ public:
 		FT_UInt LastCharGlyphIndex = 0;
 		size_t CharacterCounter = 0;
 
-		while(pCurrent < pEnd && (pCursor->m_MaxLines < 1 || LineCount <= pCursor->m_MaxLines))
+		// check if loop is making no progress and exit to prevent infinite loop
+		const char *pLast = 0;
+
+		while(pCurrent != pLast && pCurrent < pEnd && (pCursor->m_MaxLines < 1 || LineCount <= pCursor->m_MaxLines))
 		{
+			pLast = pCurrent;
 			int NewLine = 0;
 			const char *pBatchEnd = pEnd;
 			if(pCursor->m_LineWidth > 0 && !(pCursor->m_Flags & TEXTFLAG_STOP_AT_END))


### PR DESCRIPTION
Happens when writing 4 digits in Maximum ping field in filter. This in
turn causes a clamp to 3 digits. The Length in TextEx is fixed to old
str_length apparently. Maybe there is a better way to fix this.

Found by ChillerDragon

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
