### PR TITLE
Fix statboard rendering

### DIFF
--- a/src/game/client/components/statboard.cpp
+++ b/src/game/client/components/statboard.cpp
@@ -290,6 +290,7 @@ void CStatboard::RenderGlobalStats()
 			str_format(aBuf, sizeof(aBuf), "%d", pStats->m_Frags);
 			tw = TextRender()->TextWidth(0, FontSize, aBuf, -1, -1.0f);
 			TextRender()->Text(0, x - tw + px, y + (LineHeight * 0.95f - FontSize) / 2.f, FontSize, aBuf, -1.0f);
+			px += 85;
 		}
 		// DEATHS
 		{


### PR DESCRIPTION
x coordinate advancing was missing for the "frags"

![screenshot_2020-11-15_09-05-48](https://user-images.githubusercontent.com/6654924/99179887-e091fd00-2721-11eb-93ed-1208e98ac84e.png)

![screenshot_2020-11-15_09-05-22](https://user-images.githubusercontent.com/6654924/99179895-eee01900-2721-11eb-97c9-fee40c109f01.png)

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
