### PR TITLE
Alternative fix for malloc of size 0

### DIFF
--- a/src/engine/shared/datafile.cpp
+++ b/src/engine/shared/datafile.cpp
@@ -667,8 +667,15 @@ int CDataFileWriter::AddItem(int Type, int ID, int Size, void *pData)
 	m_pItems[m_NumItems].m_Size = Size;
 
 	// copy data
-	m_pItems[m_NumItems].m_pData = malloc(Size);
-	mem_copy(m_pItems[m_NumItems].m_pData, pData, Size);
+	if(Size > 0)
+	{
+		m_pItems[m_NumItems].m_pData = malloc(Size);
+		mem_copy(m_pItems[m_NumItems].m_pData, pData, Size);
+	}
+	else
+	{
+		m_pItems[m_NumItems].m_pData = 0;
+	}
 
 	if(!m_pItemTypes[Type].m_Num) // count item types
 		m_NumItemTypes++;
@@ -881,7 +888,8 @@ int CDataFileWriter::Finish()
 				swap_endian(m_pItems[k].m_pData, sizeof(int), m_pItems[k].m_Size / sizeof(int));
 #endif
 				io_write(m_File, &Item, sizeof(Item));
-				io_write(m_File, m_pItems[k].m_pData, m_pItems[k].m_Size);
+				if(m_pItems[k].m_Size > 0)
+					io_write(m_File, m_pItems[k].m_pData, m_pItems[k].m_Size);
 
 				// next
 				k = m_pItems[k].m_Next;
@@ -900,8 +908,11 @@ int CDataFileWriter::Finish()
 	// free data
 	for(int i = 0; i < m_NumItems; i++)
 	{
-		free(m_pItems[i].m_pData);
-		m_pItems[i].m_pData = 0;
+		if(m_pItems[i].m_pData)
+		{
+			free(m_pItems[i].m_pData);
+			m_pItems[i].m_pData = 0;
+		}
 	}
 	for(int i = 0; i < m_NumDatas; ++i)
 	{

--- a/src/game/editor/io.cpp
+++ b/src/game/editor/io.cpp
@@ -535,23 +535,23 @@ int CEditorMap::Save(class IStorage *pStorage, const char *pFileName)
 		PointCount += Item.m_NumPoints;
 	}
 
+	// save points
+	int TotalSize = sizeof(CEnvPoint) * PointCount;
+	CEnvPoint *pPoints = 0;
 	if(PointCount > 0)
+		pPoints = (CEnvPoint *)calloc(PointCount, sizeof(*pPoints));
+	PointCount = 0;
+
+	for(int e = 0; e < m_lEnvelopes.size(); e++)
 	{
-		// save points
-		int TotalSize = sizeof(CEnvPoint) * PointCount;
-		CEnvPoint *pPoints = (CEnvPoint *)calloc(PointCount, sizeof(*pPoints));
-		PointCount = 0;
-
-		for(int e = 0; e < m_lEnvelopes.size(); e++)
-		{
-			int Count = m_lEnvelopes[e]->m_lPoints.size();
-			mem_copy(&pPoints[PointCount], m_lEnvelopes[e]->m_lPoints.base_ptr(), sizeof(CEnvPoint) * Count);
-			PointCount += Count;
-		}
-
-		df.AddItem(MAPITEMTYPE_ENVPOINTS, 0, TotalSize, pPoints);
-		free(pPoints);
+		int Count = m_lEnvelopes[e]->m_lPoints.size();
+		mem_copy(&pPoints[PointCount], m_lEnvelopes[e]->m_lPoints.base_ptr(), sizeof(CEnvPoint) * Count);
+		PointCount += Count;
 	}
+
+	df.AddItem(MAPITEMTYPE_ENVPOINTS, 0, TotalSize, pPoints);
+	if(pPoints)
+		free(pPoints);
 
 	// finish the data file
 	df.Finish();


### PR DESCRIPTION
Since a4f13ed4a85a4a2b2e901342a9f4341c779e883c doesn't work with tml

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
