### PR TITLE
Fix leaks, initialize everything in UI Element Rect

### DIFF
--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -574,6 +574,12 @@ int CGraphics_Threaded::LoadPNG(CImageInfo *pImg, const char *pFilename, int Sto
 	return 1;
 }
 
+void CGraphics_Threaded::FreePNG(CImageInfo *pImg)
+{
+	free(pImg->m_pData);
+	pImg->m_pData = NULL;
+}
+
 bool CGraphics_Threaded::CheckImageDivisibility(const char *pFileName, CImageInfo &Img, int DivX, int DivY, bool AllowResize)
 {
 	dbg_assert(DivX != 0 && DivY != 0, "Passing 0 to this function is not allowed.");

--- a/src/engine/client/graphics_threaded.h
+++ b/src/engine/client/graphics_threaded.h
@@ -844,6 +844,7 @@ public:
 	// simple uncompressed RGBA loaders
 	IGraphics::CTextureHandle LoadTexture(const char *pFilename, int StorageType, int StoreFormat, int Flags) override;
 	int LoadPNG(CImageInfo *pImg, const char *pFilename, int StorageType) override;
+	void FreePNG(CImageInfo *pImg) override;
 
 	bool CheckImageDivisibility(const char *pFileName, CImageInfo &Img, int DivX, int DivY, bool AllowResize) override;
 

--- a/src/engine/graphics.h
+++ b/src/engine/graphics.h
@@ -221,6 +221,7 @@ public:
 	virtual int MemoryUsage() const = 0;
 
 	virtual int LoadPNG(CImageInfo *pImg, const char *pFilename, int StorageType) = 0;
+	virtual void FreePNG(CImageInfo *pImg) = 0;
 
 	virtual bool CheckImageDivisibility(const char *pFileName, CImageInfo &Img, int DivX, int DivY, bool AllowResize) = 0;
 

--- a/src/game/client/components/countryflags.cpp
+++ b/src/game/client/components/countryflags.cpp
@@ -78,7 +78,7 @@ void CCountryFlags::LoadCountryflagsIndexfile()
 		if(LoadCountryFlags)
 		{
 			CountryFlag.m_Texture = Graphics()->LoadTextureRaw(Info.m_Width, Info.m_Height, Info.m_Format, Info.m_pData, Info.m_Format, 0);
-			free(Info.m_pData);
+			Graphics()->FreePNG(&Info);
 		}
 
 		if(g_Config.m_Debug)

--- a/src/game/client/components/mapimages.cpp
+++ b/src/game/client/components/mapimages.cpp
@@ -330,6 +330,8 @@ IGraphics::CTextureHandle CMapImages::GetEntities(EMapImageEntityLayerType Entit
 			}
 
 			free(pBuildImgData);
+
+			Graphics()->FreePNG(&ImgInfo);
 		}
 	}
 

--- a/src/game/client/components/menu_background.cpp
+++ b/src/game/client/components/menu_background.cpp
@@ -157,6 +157,7 @@ int CMenuBackground::ThemeIconScan(const char *pName, int IsDir, int DirType, vo
 			pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "game", aBuf);
 
 			Theme.m_IconTexture = pSelf->Graphics()->LoadTextureRaw(Info.m_Width, Info.m_Height, Info.m_Format, Info.m_pData, Info.m_Format, 0);
+			pSelf->Graphics()->FreePNG(&Info);
 			return 0;
 		}
 	}

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -2619,7 +2619,7 @@ int CMenus::MenuImageScan(const char *pName, int IsDir, int DirType, void *pUser
 	*/
 
 	MenuImage.m_GreyTexture = pSelf->Graphics()->LoadTextureRaw(Info.m_Width, Info.m_Height, Info.m_Format, Info.m_pData, Info.m_Format, 0);
-	free(Info.m_pData);
+	pSelf->Graphics()->FreePNG(&Info);
 
 	// set menu image data
 	str_truncate(MenuImage.m_aName, sizeof(MenuImage.m_aName), pName, str_length(pName) - 4);

--- a/src/game/client/components/menus_settings_assets.cpp
+++ b/src/game/client/components/menus_settings_assets.cpp
@@ -22,7 +22,7 @@ void CMenus::LoadEntities(SCustomEntities *pEntitiesItem, void *pUser)
 			if(pThis->Graphics()->LoadPNG(&ImgInfo, aBuff, IStorage::TYPE_ALL))
 			{
 				pEntitiesItem->m_aImages[i].m_Texture = pThis->Graphics()->LoadTextureRaw(ImgInfo.m_Width, ImgInfo.m_Height, ImgInfo.m_Format, ImgInfo.m_pData, ImgInfo.m_Format, 0);
-				free(ImgInfo.m_pData);
+				pThis->Graphics()->FreePNG(&ImgInfo);
 
 				if(pEntitiesItem->m_RenderTexture == -1)
 					pEntitiesItem->m_RenderTexture = pEntitiesItem->m_aImages[i].m_Texture;
@@ -38,7 +38,7 @@ void CMenus::LoadEntities(SCustomEntities *pEntitiesItem, void *pUser)
 			if(pThis->Graphics()->LoadPNG(&ImgInfo, aBuff, IStorage::TYPE_ALL))
 			{
 				pEntitiesItem->m_aImages[i].m_Texture = pThis->Graphics()->LoadTextureRaw(ImgInfo.m_Width, ImgInfo.m_Height, ImgInfo.m_Format, ImgInfo.m_pData, ImgInfo.m_Format, 0);
-				free(ImgInfo.m_pData);
+				pThis->Graphics()->FreePNG(&ImgInfo);
 
 				if(pEntitiesItem->m_RenderTexture == -1)
 					pEntitiesItem->m_RenderTexture = pEntitiesItem->m_aImages[i].m_Texture;
@@ -50,7 +50,7 @@ void CMenus::LoadEntities(SCustomEntities *pEntitiesItem, void *pUser)
 				if(pThis->Graphics()->LoadPNG(&ImgInfo, aBuff, IStorage::TYPE_ALL))
 				{
 					pEntitiesItem->m_aImages[i].m_Texture = pThis->Graphics()->LoadTextureRaw(ImgInfo.m_Width, ImgInfo.m_Height, ImgInfo.m_Format, ImgInfo.m_pData, ImgInfo.m_Format, 0);
-					free(ImgInfo.m_pData);
+					pThis->Graphics()->FreePNG(&ImgInfo);
 
 					if(pEntitiesItem->m_RenderTexture == -1)
 						pEntitiesItem->m_RenderTexture = pEntitiesItem->m_aImages[i].m_Texture;
@@ -109,7 +109,7 @@ static void LoadAsset(TName *pAssetItem, const char *pAssetName, IGraphics *pGra
 		if(pGraphics->LoadPNG(&ImgInfo, aBuff, IStorage::TYPE_ALL))
 		{
 			pAssetItem->m_RenderTexture = pGraphics->LoadTextureRaw(ImgInfo.m_Width, ImgInfo.m_Height, ImgInfo.m_Format, ImgInfo.m_pData, ImgInfo.m_Format, 0);
-			free(ImgInfo.m_pData);
+			pGraphics->FreePNG(&ImgInfo);
 		}
 	}
 	else
@@ -119,7 +119,7 @@ static void LoadAsset(TName *pAssetItem, const char *pAssetName, IGraphics *pGra
 		if(pGraphics->LoadPNG(&ImgInfo, aBuff, IStorage::TYPE_ALL))
 		{
 			pAssetItem->m_RenderTexture = pGraphics->LoadTextureRaw(ImgInfo.m_Width, ImgInfo.m_Height, ImgInfo.m_Format, ImgInfo.m_pData, ImgInfo.m_Format, 0);
-			free(ImgInfo.m_pData);
+			pGraphics->FreePNG(&ImgInfo);
 		}
 		else
 		{
@@ -128,7 +128,7 @@ static void LoadAsset(TName *pAssetItem, const char *pAssetName, IGraphics *pGra
 			if(pGraphics->LoadPNG(&ImgInfo, aBuff, IStorage::TYPE_ALL))
 			{
 				pAssetItem->m_RenderTexture = pGraphics->LoadTextureRaw(ImgInfo.m_Width, ImgInfo.m_Height, ImgInfo.m_Format, ImgInfo.m_pData, ImgInfo.m_Format, 0);
-				free(ImgInfo.m_pData);
+				pGraphics->FreePNG(&ImgInfo);
 			}
 		}
 	}

--- a/src/game/client/components/skins.cpp
+++ b/src/game/client/components/skins.cpp
@@ -233,7 +233,7 @@ int CSkins::LoadSkin(const char *pName, const char *pPath, int DirType)
 	for(int i = 0; i < 6; ++i)
 		Skin.m_ColorableSkin.m_Eyes[i] = Graphics()->LoadSpriteTexture(Info, &g_pData->m_aSprites[SPRITE_TEE_EYE_NORMAL + i]);
 
-	free(Info.m_pData);
+	Graphics()->FreePNG(&Info);
 
 	// set skin data
 	str_copy(Skin.m_aName, pName, sizeof(Skin.m_aName));

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -2774,7 +2774,7 @@ void CGameClient::LoadGameSkin(const char *pPath, bool AsDir)
 
 		m_GameSkinLoaded = true;
 
-		free(ImgInfo.m_pData);
+		Graphics()->FreePNG(&ImgInfo);
 	}
 }
 
@@ -2818,7 +2818,7 @@ void CGameClient::LoadEmoticonsSkin(const char *pPath, bool AsDir)
 			m_EmoticonsSkin.m_SpriteEmoticons[i] = Graphics()->LoadSpriteTexture(ImgInfo, &g_pData->m_aSprites[SPRITE_OOP + i]);
 
 		m_EmoticonsSkinLoaded = true;
-		free(ImgInfo.m_pData);
+		Graphics()->FreePNG(&ImgInfo);
 	}
 }
 

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -13,6 +13,14 @@ void CUIElement::Init(CUI *pUI)
 	pUI->AddUIElement(this);
 }
 
+CUIElement::SUIElementRect::SUIElementRect() :
+	m_UIRectQuadContainer(-1), m_UITextContainer(-1), m_X(-1), m_Y(-1), m_Width(-1), m_Height(-1)
+{
+	mem_zero(&m_Cursor, sizeof(m_Cursor));
+	mem_zero(&m_TextColor, sizeof(m_TextColor));
+	mem_zero(&m_TextOutlineColor, sizeof(m_TextOutlineColor));
+}
+
 /********************************************************
  UI
 *********************************************************/

--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -129,10 +129,7 @@ public:
 		STextRenderColor m_TextColor;
 		STextRenderColor m_TextOutlineColor;
 
-		SUIElementRect() :
-			m_UIRectQuadContainer(-1), m_UITextContainer(-1), m_X(-1), m_Y(-1), m_Width(-1), m_Height(-1)
-		{
-		}
+		SUIElementRect();
 	};
 
 protected:

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -4497,7 +4497,9 @@ void CEditor::RenderFileDialog()
 				if(Graphics()->LoadPNG(&m_FilePreviewImageInfo, aBuffer, IStorage::TYPE_ALL))
 				{
 					m_FilePreviewImage = Graphics()->LoadTextureRaw(m_FilePreviewImageInfo.m_Width, m_FilePreviewImageInfo.m_Height, m_FilePreviewImageInfo.m_Format, m_FilePreviewImageInfo.m_pData, m_FilePreviewImageInfo.m_Format, IGraphics::TEXLOAD_NORESAMPLE);
-					free(m_FilePreviewImageInfo.m_pData);
+					CImageInfo DummyInfo = m_FilePreviewImageInfo;
+					m_FilePreviewImageInfo.m_pData = NULL;
+					Graphics()->FreePNG(&DummyInfo);
 					m_PreviewImageIsLoaded = true;
 				}
 			}


### PR DESCRIPTION
This time tested with valgrind to find uninitialized memory(the one i found isnt critical)

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
