### PR TITLE
Rename lock and semaphore classes to match current naming

### DIFF
--- a/src/base/tl/threading.h
+++ b/src/base/tl/threading.h
@@ -3,56 +3,56 @@
 
 #include "../system.h"
 
-class semaphore
+class CSemaphore
 {
-	SEMAPHORE sem;
+	SEMAPHORE m_Sem;
 
 public:
-	semaphore() { sphore_init(&sem); }
-	~semaphore() { sphore_destroy(&sem); }
-	semaphore(const semaphore &) = delete;
-	void wait() { sphore_wait(&sem); }
-	void signal() { sphore_signal(&sem); }
+	CSemaphore() { sphore_init(&m_Sem); }
+	~CSemaphore() { sphore_destroy(&m_Sem); }
+	CSemaphore(const CSemaphore &) = delete;
+	void Wait() { sphore_wait(&m_Sem); }
+	void Signal() { sphore_signal(&m_Sem); }
 };
 
-class lock
+class CLock
 {
-	LOCK var;
+	LOCK m_Lock;
 
 public:
-	lock()
+	CLock()
 	{
-		var = lock_create();
+		m_Lock = lock_create();
 	}
 
-	~lock()
+	~CLock()
 	{
-		lock_destroy(var);
+		lock_destroy(m_Lock);
 	}
 
-	lock(const lock &) = delete;
+	CLock(const CLock &) = delete;
 
-	void take() { lock_wait(var); }
-	void release() { lock_unlock(var); }
+	void Take() { lock_wait(m_Lock); }
+	void Release() { lock_unlock(m_Lock); }
 };
 
-class scope_lock
+class CScopeLock
 {
-	lock *var;
+	CLock *m_pLock;
 
 public:
-	scope_lock(lock *l)
+	CScopeLock(CLock *pLock)
 	{
-		var = l;
-		var->take();
+		m_pLock = pLock;
+		m_pLock->Take();
 	}
 
-	~scope_lock()
+	~CScopeLock()
 	{
-		var->release();
+		m_pLock->Release();
 	}
 
-	scope_lock(const scope_lock &) = delete;
+	CScopeLock(const CScopeLock &) = delete;
 };
 
 #endif // BASE_TL_THREADING_H

--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -71,7 +71,7 @@ void CGraphicsBackend_Threaded::ThreadFunc(void *pUser)
 
 	while(!pThis->m_Shutdown)
 	{
-		pThis->m_Activity.wait();
+		pThis->m_Activity.Wait();
 		if(pThis->m_pBuffer)
 		{
 #ifdef CONF_PLATFORM_MACOSX
@@ -81,7 +81,7 @@ void CGraphicsBackend_Threaded::ThreadFunc(void *pUser)
 
 			sync_barrier();
 			pThis->m_pBuffer = 0x0;
-			pThis->m_BufferDone.signal();
+			pThis->m_BufferDone.Signal();
 		}
 #if defined(CONF_VIDEORECORDER)
 		if(IVideo::Current())
@@ -102,13 +102,13 @@ void CGraphicsBackend_Threaded::StartProcessor(ICommandProcessor *pProcessor)
 	m_Shutdown = false;
 	m_pProcessor = pProcessor;
 	m_pThread = thread_init(ThreadFunc, this, "CGraphicsBackend_Threaded");
-	m_BufferDone.signal();
+	m_BufferDone.Signal();
 }
 
 void CGraphicsBackend_Threaded::StopProcessor()
 {
 	m_Shutdown = true;
-	m_Activity.signal();
+	m_Activity.Signal();
 	if(m_pThread)
 		thread_wait(m_pThread);
 }
@@ -117,7 +117,7 @@ void CGraphicsBackend_Threaded::RunBuffer(CCommandBuffer *pBuffer)
 {
 	WaitForIdle();
 	m_pBuffer = pBuffer;
-	m_Activity.signal();
+	m_Activity.Signal();
 }
 
 bool CGraphicsBackend_Threaded::IsIdle() const
@@ -128,7 +128,7 @@ bool CGraphicsBackend_Threaded::IsIdle() const
 void CGraphicsBackend_Threaded::WaitForIdle()
 {
 	while(m_pBuffer != 0x0)
-		m_BufferDone.wait();
+		m_BufferDone.Wait();
 }
 
 static bool Texture2DTo3D(void *pImageBuffer, int ImageWidth, int ImageHeight, int ImageColorChannelCount, int SplitCountWidth, int SplitCountHeight, void *pTarget3DImageData, int &Target3DImageWidth, int &Target3DImageHeight)
@@ -162,7 +162,7 @@ static bool Texture2DTo3D(void *pImageBuffer, int ImageWidth, int ImageHeight, i
 
 void CCommandProcessorFragment_General::Cmd_Signal(const CCommandBuffer::SCommand_Signal *pCommand)
 {
-	pCommand->m_pSemaphore->signal();
+	pCommand->m_pSemaphore->Signal();
 }
 
 bool CCommandProcessorFragment_General::RunCommand(const CCommandBuffer::SCommand *pBaseCommand)

--- a/src/engine/client/backend_sdl.h
+++ b/src/engine/client/backend_sdl.h
@@ -62,8 +62,8 @@ private:
 	ICommandProcessor *m_pProcessor;
 	CCommandBuffer *volatile m_pBuffer;
 	volatile bool m_Shutdown;
-	semaphore m_Activity;
-	semaphore m_BufferDone;
+	CSemaphore m_Activity;
+	CSemaphore m_BufferDone;
 	void *m_pThread;
 
 	static void ThreadFunc(void *pUser);

--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -2556,7 +2556,7 @@ bool CGraphics_Threaded::SetVSync(bool State)
 }
 
 // synchronization
-void CGraphics_Threaded::InsertSignal(semaphore *pSemaphore)
+void CGraphics_Threaded::InsertSignal(CSemaphore *pSemaphore)
 {
 	CCommandBuffer::SCommand_Signal Cmd;
 	Cmd.m_pSemaphore = pSemaphore;

--- a/src/engine/client/graphics_threaded.h
+++ b/src/engine/client/graphics_threaded.h
@@ -213,7 +213,7 @@ public:
 	{
 		SCommand_Signal() :
 			SCommand(CMD_SIGNAL) {}
-		semaphore *m_pSemaphore;
+		CSemaphore *m_pSemaphore;
 	};
 
 	struct SCommand_RunBuffer : public SCommand
@@ -1136,7 +1136,7 @@ public:
 	virtual int GetDesktopScreenHeight() { return m_DesktopScreenHeight; }
 
 	// synchronization
-	void InsertSignal(semaphore *pSemaphore) override;
+	void InsertSignal(CSemaphore *pSemaphore) override;
 	bool IsIdle() override;
 	void WaitForIdle() override;
 

--- a/src/engine/graphics.h
+++ b/src/engine/graphics.h
@@ -374,7 +374,7 @@ public:
 	virtual int GetNumScreens() const = 0;
 
 	// synchronization
-	virtual void InsertSignal(class semaphore *pSemaphore) = 0;
+	virtual void InsertSignal(class CSemaphore *pSemaphore) = 0;
 	virtual bool IsIdle() = 0;
 	virtual void WaitForIdle() = 0;
 

--- a/src/engine/server/databases/connection_pool.cpp
+++ b/src/engine/server/databases/connection_pool.cpp
@@ -92,7 +92,7 @@ void CDbConnectionPool::Execute(
 {
 	m_aTasks[FirstElem++].reset(new CSqlExecData(pFunc, std::move(pThreadData), pName));
 	FirstElem %= sizeof(m_aTasks) / sizeof(m_aTasks[0]);
-	m_NumElem.signal();
+	m_NumElem.Signal();
 }
 
 void CDbConnectionPool::ExecuteWrite(
@@ -102,13 +102,13 @@ void CDbConnectionPool::ExecuteWrite(
 {
 	m_aTasks[FirstElem++].reset(new CSqlExecData(pFunc, std::move(pThreadData), pName));
 	FirstElem %= sizeof(m_aTasks) / sizeof(m_aTasks[0]);
-	m_NumElem.signal();
+	m_NumElem.Signal();
 }
 
 void CDbConnectionPool::OnShutdown()
 {
 	m_Shutdown.store(true);
-	m_NumElem.signal();
+	m_NumElem.Signal();
 	int i = 0;
 	while(m_Shutdown.load())
 	{
@@ -139,7 +139,7 @@ void CDbConnectionPool::Worker()
 	int WriteServer = 0;
 	while(1)
 	{
-		m_NumElem.wait();
+		m_NumElem.Wait();
 		auto pThreadData = std::move(m_aTasks[LastElem++]);
 		// work through all database jobs after OnShutdown is called before exiting the thread
 		if(pThreadData == nullptr)

--- a/src/engine/server/databases/connection_pool.h
+++ b/src/engine/server/databases/connection_pool.h
@@ -57,7 +57,7 @@ private:
 	bool ExecSqlFunc(IDbConnection *pConnection, struct CSqlExecData *pData, bool Failure);
 
 	std::atomic_bool m_Shutdown;
-	semaphore m_NumElem;
+	CSemaphore m_NumElem;
 	int FirstElem;
 	int LastElem;
 	std::unique_ptr<struct CSqlExecData> m_aTasks[512];

--- a/src/engine/server/databases/mysql.cpp
+++ b/src/engine/server/databases/mysql.cpp
@@ -11,7 +11,7 @@
 
 #include <string>
 
-lock CMysqlConnection::m_SqlDriverLock;
+CLock CMysqlConnection::m_SqlDriverLock;
 
 CMysqlConnection::CMysqlConnection(
 	const char *pDatabase,
@@ -117,7 +117,7 @@ IDbConnection::Status CMysqlConnection::Connect()
 
 		// Create connection
 		{
-			scope_lock GlobalLockScope(&m_SqlDriverLock);
+			CScopeLock GlobalLockScope(&m_SqlDriverLock);
 			sql::Driver *pDriver = get_driver_instance();
 			m_pConnection.reset(pDriver->connect(connection_properties));
 		}

--- a/src/engine/server/databases/mysql.h
+++ b/src/engine/server/databases/mysql.h
@@ -5,7 +5,7 @@
 #include <engine/server/databases/connection.h>
 #include <memory>
 
-class lock;
+class CLock;
 namespace sql {
 class Connection;
 class PreparedStatement;
@@ -79,7 +79,7 @@ private:
 	bool m_Setup;
 
 	std::atomic_bool m_InUse;
-	static lock m_SqlDriverLock;
+	static CLock m_SqlDriverLock;
 };
 
 #endif // ENGINE_SERVER_DATABASES_MYSQL_H


### PR DESCRIPTION
Changed these old classes names to match our current standards.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
