### PR TITLE
Only render visible entities

### DIFF
--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -226,6 +226,11 @@ void CGraphics_Threaded::GetScreen(float *pTopLeftX, float *pTopLeftY, float *pB
 	*pBottomRightY = m_State.m_ScreenBR.y;
 }
 
+bool CGraphics_Threaded::IsPosVisible(vec2 Pos, float Width, float Height)
+{
+	return in_range(Pos.x, m_State.m_ScreenTL.x - Width / 2.f, m_State.m_ScreenBR.x + Width / 2.f) && in_range(Pos.y, m_State.m_ScreenTL.y - Height / 2.f, m_State.m_ScreenBR.y + Height / 2.f);
+}
+
 void CGraphics_Threaded::LinesBegin()
 {
 	dbg_assert(m_Drawing == 0, "called Graphics()->LinesBegin twice");

--- a/src/engine/client/graphics_threaded.h
+++ b/src/engine/client/graphics_threaded.h
@@ -825,6 +825,8 @@ public:
 	void MapScreen(float TopLeftX, float TopLeftY, float BottomRightX, float BottomRightY) override;
 	void GetScreen(float *pTopLeftX, float *pTopLeftY, float *pBottomRightX, float *pBottomRightY) override;
 
+	bool IsPosVisible(vec2 Pos, float Width, float Height) override;
+
 	void LinesBegin() override;
 	void LinesEnd() override;
 	void LinesDraw(const CLineItem *pArray, int Num) override;

--- a/src/engine/graphics.h
+++ b/src/engine/graphics.h
@@ -212,6 +212,8 @@ public:
 	virtual void MapScreen(float TopLeftX, float TopLeftY, float BottomRightX, float BottomRightY) = 0;
 	virtual void GetScreen(float *pTopLeftX, float *pTopLeftY, float *pBottomRightX, float *pBottomRightY) = 0;
 
+	virtual bool IsPosVisible(vec2 Pos, float Width, float Height) = 0;
+
 	// TODO: These should perhaps not be virtuals
 	virtual void BlendNone() = 0;
 	virtual void BlendNormal() = 0;

--- a/src/game/client/components/items.cpp
+++ b/src/game/client/components/items.cpp
@@ -70,6 +70,10 @@ void CItems::RenderProjectile(const CNetObj_Projectile *pCurrent, int ItemID)
 	vec2 Pos = CalcPos(StartPos, StartVel, Curvature, Speed, Ct);
 	vec2 PrevPos = CalcPos(StartPos, StartVel, Curvature, Speed, Ct - 0.001f);
 
+	// only render visible (with some extra margin make sure smoketrails outside screen are kept)
+	if(!m_pClient->Graphics()->IsPosVisible(Pos, 30 * 32.f, 30 * 32.f))
+		return;
+
 	float Alpha = 1.f;
 	if(UseExtraInfo(pCurrent))
 	{
@@ -127,6 +131,10 @@ void CItems::RenderProjectile(const CNetObj_Projectile *pCurrent, int ItemID)
 
 void CItems::RenderPickup(const CNetObj_Pickup *pPrev, const CNetObj_Pickup *pCurrent, bool IsPredicted)
 {
+	// only render visible
+	if(!m_pClient->Graphics()->IsPosVisible(vec2(pCurrent->m_X, pCurrent->m_Y), 7 * 32.f, 7 * 32.f))
+		return;
+
 	const int c[] = {
 		SPRITE_PICKUP_HEALTH,
 		SPRITE_PICKUP_ARMOR,
@@ -236,6 +244,11 @@ void CItems::RenderLaser(const struct CNetObj_Laser *pCurrent, bool IsPredicted)
 	vec2 Pos = vec2(pCurrent->m_X, pCurrent->m_Y);
 	vec2 From = vec2(pCurrent->m_FromX, pCurrent->m_FromY);
 	float Len = distance(Pos, From);
+
+	// only render visible
+	if(!m_pClient->Graphics()->IsPosVisible(mix(From, Pos, 0.5f), fabs(From.x - Pos.x) / 2 + 7 * 32.f, fabs(From.y - Pos.y) / 2 + 7 * 32.f))
+		return;
+
 	RGB = color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClLaserOutlineColor));
 	ColorRGBA OuterColor(RGB.r, RGB.g, RGB.b, 1.0f);
 	RGB = color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClLaserInnerColor));

--- a/src/game/client/components/nameplates.cpp
+++ b/src/game/client/components/nameplates.cpp
@@ -39,6 +39,9 @@ void CNamePlates::RenderNameplate(
 
 void CNamePlates::RenderNameplatePos(vec2 Position, const CNetObj_PlayerInfo *pPlayerInfo, float Alpha)
 {
+	if(!m_pClient->Graphics()->IsPosVisible(Position, 15 * 32.f, 15 * 32.f))
+		return;
+
 	int ClientID = pPlayerInfo->m_ClientID;
 
 	bool OtherTeam = m_pClient->IsOtherTeam(ClientID);

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -182,6 +182,15 @@ void CPlayers::RenderPlayer(
 	if(ClientID >= 0)
 		IntraTick = m_pClient->m_aClients[ClientID].m_IsPredicted ? Client()->PredIntraGameTick(g_Config.m_ClDummy) : Client()->IntraGameTick(g_Config.m_ClDummy);
 
+	vec2 Position;
+	if(in_range(ClientID, MAX_CLIENTS - 1))
+		Position = m_pClient->m_aClients[ClientID].m_RenderPos;
+	else
+		Position = mix(vec2(Prev.m_X, Prev.m_Y), vec2(Player.m_X, Player.m_Y), IntraTick);
+
+	if(!m_pClient->Graphics()->IsPosVisible(Position, 7 * 32.f, 7 * 32.f))
+		return;
+
 	static float s_LastGameTickTime = Client()->GameTickTime(g_Config.m_ClDummy);
 	static float s_LastPredIntraTick = Client()->PredIntraGameTick(g_Config.m_ClDummy);
 	if(m_pClient->m_Snap.m_pGameInfoObj && !(m_pClient->m_Snap.m_pGameInfoObj->m_GameStateFlags & GAMESTATEFLAG_PAUSED))
@@ -225,12 +234,6 @@ void CPlayers::RenderPlayer(
 	}
 
 	vec2 Direction = GetDirection((int)(Angle * 256.0f));
-	vec2 Position;
-	if(in_range(ClientID, MAX_CLIENTS - 1))
-		Position = m_pClient->m_aClients[ClientID].m_RenderPos;
-	else
-		Position = mix(vec2(Prev.m_X, Prev.m_Y), vec2(Player.m_X, Player.m_Y), IntraTick);
-
 	vec2 Vel = mix(vec2(Prev.m_VelX / 256.0f, Prev.m_VelY / 256.0f), vec2(Player.m_VelX / 256.0f, Player.m_VelY / 256.0f), IntraTick);
 
 	m_pClient->m_pFlow->Add(Position, Vel * 100.0f, 10.0f);


### PR DESCRIPTION
Some entities like pickups are always sent to the client, and the client will currently try to render them even if they are off screen.

I'm not sure if using hardcoded values for the maximum item size is the correct way. For some entities it can vary depending on the game.png, or on font size and namelength for nameplates, so I tried to find the maximum values and added an extra margin of 2-3 tiles.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
