### PR TITLE
Increase Intel driver blocklist range

### DIFF
--- a/src/engine/client/blocklist_driver.cpp
+++ b/src/engine/client/blocklist_driver.cpp
@@ -36,7 +36,7 @@ struct SBackEndDriverBlockList
 };
 
 static SBackEndDriverBlockList gs_aBlockList[] = {
-	{{26, 20, 100, 7800}, {26, 20, 100, 7999}, 2, 0, 0, "This Intel driver version can cause crashes, please update it to a newer version."}};
+	{{26, 20, 100, 7800}, {27, 20, 100, 8853}, 2, 0, 0, "This Intel driver version can cause crashes, please update it to a newer version."}};
 
 const char *ParseBlocklistDriverVersions(const char *pVendorStr, const char *pVersionStr, int &BlocklistMajor, int &BlocklistMinor, int &BlocklistPatch)
 {


### PR DESCRIPTION
As reported by louis, who tested different drivers, since he still has the other bug: ALT + TAB makes the screen go black for 5seconds

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
