### PR TITLE
Fix storing load/save result in main thread without incrementing usage count

### DIFF
--- a/src/game/server/teams.h
+++ b/src/game/server/teams.h
@@ -123,9 +123,9 @@ public:
 		m_TeeFinished[ClientID] = finished;
 	}
 
-	void SetSaving(int TeamID, std::shared_ptr<CScoreSaveResult> SaveResult)
+	void SetSaving(int TeamID, std::shared_ptr<CScoreSaveResult> &SaveResult)
 	{
-		m_pSaveTeamResult[TeamID] = std::move(SaveResult);
+		m_pSaveTeamResult[TeamID] = SaveResult;
 	}
 
 	bool GetSaving(int TeamID)


### PR DESCRIPTION


Resulting to race condition, since the main thread always thought that the
load/save thread already completed. Passing the shared_ptr by reference to
prevent a similar future bug to happen.

Fixes #3380

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
