### PR TITLE
Export all symbols from the main executable for the antibot

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2552,6 +2552,8 @@ endmacro()
 source_group_tree(src)
 
 if(ANTIBOT)
+  # Allow the antibot library to use functions from the server binary.
+  add_c_compiler_flag_if_supported(OUR_FLAGS_LINK -rdynamic)
   set_own_rpath(${TARGET_SERVER})
 endif()
 


### PR DESCRIPTION
Add `-rdynamic` if supported by the linker.

Not all symbols being exported broke our builds recently, the antibot
library used `mem_comp` from the main binary but it wasn't exported,
leading to the following runtime error:

```
./DDRace64-Server_sql: symbol lookup error: /home/teeworlds/servers/libantibot.so: undefined symbol: mem_comp
```

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
