### PR TITLE
Ignore unknown commands from map config in client

### DIFF
--- a/src/engine/console.h
+++ b/src/engine/console.h
@@ -94,9 +94,9 @@ public:
 	virtual void StoreCommands(bool Store) = 0;
 
 	virtual bool LineIsValid(const char *pStr) = 0;
-	virtual void ExecuteLine(const char *Sptr, int ClientID = -1, bool InterpretSemicolons = true) = 0;
-	virtual void ExecuteLineFlag(const char *Sptr, int FlasgMask, int ClientID = -1, bool InterpretSemicolons = true) = 0;
-	virtual void ExecuteLineStroked(int Stroke, const char *pStr, int ClientID = -1, bool InterpretSemicolons = true) = 0;
+	virtual void ExecuteLine(const char *Sptr, int ClientID = -1, bool InterpretSemicolons = true, bool IgnoreUnknown = false) = 0;
+	virtual void ExecuteLineFlag(const char *Sptr, int FlasgMask, int ClientID = -1, bool InterpretSemicolons = true, bool IgnoreUnknown = false) = 0;
+	virtual void ExecuteLineStroked(int Stroke, const char *pStr, int ClientID = -1, bool InterpretSemicolons = true, bool IgnoreUnknown = false) = 0;
 	virtual void ExecuteFile(const char *pFilename, int ClientID = -1, bool LogFailure = false, int StorageType = IStorage::TYPE_ALL) = 0;
 
 	virtual int RegisterPrintCallback(int OutputLevel, FPrintCallback pfnPrintCallback, void *pUserData) = 0;

--- a/src/engine/shared/console.cpp
+++ b/src/engine/shared/console.cpp
@@ -381,7 +381,7 @@ bool CConsole::LineIsValid(const char *pStr)
 	return true;
 }
 
-void CConsole::ExecuteLineStroked(int Stroke, const char *pStr, int ClientID, bool InterpretSemicolons)
+void CConsole::ExecuteLineStroked(int Stroke, const char *pStr, int ClientID, bool InterpretSemicolons, bool IgnoreUnknown)
 {
 	const char *pWithoutPrefix = str_startswith(pStr, "mc;");
 	if(pWithoutPrefix)
@@ -513,7 +513,7 @@ void CConsole::ExecuteLineStroked(int Stroke, const char *pStr, int ClientID, bo
 				Print(OUTPUT_LEVEL_STANDARD, "console", aBuf);
 			}
 		}
-		else if(Stroke)
+		else if(Stroke && !IgnoreUnknown)
 		{
 			char aBuf[256];
 			str_format(aBuf, sizeof(aBuf), "No such command: %s.", Result.m_pCommand);
@@ -550,17 +550,17 @@ CConsole::CCommand *CConsole::FindCommand(const char *pName, int FlagMask)
 	return 0x0;
 }
 
-void CConsole::ExecuteLine(const char *pStr, int ClientID, bool InterpretSemicolons)
+void CConsole::ExecuteLine(const char *pStr, int ClientID, bool InterpretSemicolons, bool IgnoreUnknown)
 {
-	CConsole::ExecuteLineStroked(1, pStr, ClientID, InterpretSemicolons); // press it
-	CConsole::ExecuteLineStroked(0, pStr, ClientID, InterpretSemicolons); // then release it
+	CConsole::ExecuteLineStroked(1, pStr, ClientID, InterpretSemicolons, IgnoreUnknown); // press it
+	CConsole::ExecuteLineStroked(0, pStr, ClientID, InterpretSemicolons, IgnoreUnknown); // then release it
 }
 
-void CConsole::ExecuteLineFlag(const char *pStr, int FlagMask, int ClientID, bool InterpretSemicolons)
+void CConsole::ExecuteLineFlag(const char *pStr, int FlagMask, int ClientID, bool InterpretSemicolons, bool IgnoreUnknown)
 {
 	int Temp = m_FlagMask;
 	m_FlagMask = FlagMask;
-	ExecuteLine(pStr, ClientID, InterpretSemicolons);
+	ExecuteLine(pStr, ClientID, InterpretSemicolons, IgnoreUnknown);
 	m_FlagMask = Temp;
 }
 

--- a/src/engine/shared/console.h
+++ b/src/engine/shared/console.h
@@ -60,7 +60,7 @@ class CConsole : public IConsole
 	static void ConCommandAccess(IResult *pResult, void *pUser);
 	static void ConCommandStatus(IConsole::IResult *pResult, void *pUser);
 
-	void ExecuteLineStroked(int Stroke, const char *pStr, int ClientID = -1, bool InterpretSemicolons = true);
+	void ExecuteLineStroked(int Stroke, const char *pStr, int ClientID = -1, bool InterpretSemicolons = true, bool IgnoreUnknown = false);
 
 	struct
 	{
@@ -209,8 +209,8 @@ public:
 	virtual void StoreCommands(bool Store);
 
 	virtual bool LineIsValid(const char *pStr);
-	virtual void ExecuteLine(const char *pStr, int ClientID = -1, bool InterpretSemicolons = true);
-	virtual void ExecuteLineFlag(const char *pStr, int FlagMask, int ClientID = -1, bool InterpretSemicolons = true);
+	virtual void ExecuteLine(const char *pStr, int ClientID = -1, bool InterpretSemicolons = true, bool IgnoreUnknown = false);
+	virtual void ExecuteLineFlag(const char *pStr, int FlagMask, int ClientID = -1, bool InterpretSemicolons = true, bool IgnoreUnknown = false);
 	virtual void ExecuteFile(const char *pFilename, int ClientID = -1, bool LogFailure = false, int StorageType = IStorage::TYPE_ALL);
 
 	virtual int RegisterPrintCallback(int OutputLevel, FPrintCallback pfnPrintCallback, void *pUserData);

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -2950,7 +2950,7 @@ void CGameClient::LoadMapSettings()
 		while(pNext < pSettings + Size)
 		{
 			int StrSize = str_length(pNext) + 1;
-			Console()->ExecuteLine(pNext, IConsole::CLIENT_ID_GAME);
+			Console()->ExecuteLine(pNext, IConsole::CLIENT_ID_GAME, true, true);
 			pNext += StrSize;
 		}
 		pMap->UnloadData(pItem->m_Settings);


### PR DESCRIPTION
Reported by Pipou
```
[2020-12-10 20:53:10][tune]: tune_zone_enter 1 "Let's warm up a little"
Thread 1 "DDNet" hit Breakpoint 1, CConsole::ExecuteLineStroked (this=0x555555adb430, Stroke=1,
    pStr=0x55555826cd30 "tune_zone_enter 1 \"Let's warm up a little\"", ClientID=-2, InterpretSemicolons=true)
    at src/engine/shared/console.cpp:519
warning: Source file is more recent than executable.
519				str_format(aBuf, sizeof(aBuf), "No such command: %s.", Result.m_pCommand);
(gdb) bt
    (this=0x555555adb430, Stroke=1, pStr=0x55555826cd30 "tune_zone_enter 1 \"Let's warm up a little\"", ClientID=-2, InterpretSemicolons=true) at src/engine/shared/console.cpp:519
    (this=0x555555adb430, pStr=0x55555826cd30 "tune_zone_enter 1 \"Let's warm up a little\"", ClientID=-2, InterpretSemicolons=true) at src/engine/shared/console.cpp:555
    at src/game/client/gameclient.cpp:2953
    at src/game/client/gameclient.cpp:529
    at src/engine/client/client.cpp:1796
```
<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
