### PR TITLE
Move PNG loading in SkinDL to fetch thread (fixes #3398)

### DIFF
--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -154,6 +154,8 @@ CGraphics_Threaded::CGraphics_Threaded()
 
 	m_RenderEnable = true;
 	m_DoScreenshot = false;
+
+	png_init(0, 0); // ignore_convention
 }
 
 void CGraphics_Threaded::ClipEnable(int x, int y, int w, int h)
@@ -521,8 +523,6 @@ int CGraphics_Threaded::LoadPNG(CImageInfo *pImg, const char *pFilename, int Sto
 	png_t Png; // ignore_convention
 
 	// open file for reading
-	png_init(0, 0); // ignore_convention
-
 	IOHANDLE File = m_pStorage->OpenFile(pFilename, IOFLAG_READ, StorageType, aCompleteFilename, sizeof(aCompleteFilename));
 	if(File)
 		io_close(File);

--- a/src/engine/client/http.cpp
+++ b/src/engine/client/http.cpp
@@ -250,8 +250,8 @@ size_t CGet::OnData(char *pData, size_t DataSize)
 CGetFile::CGetFile(IStorage *pStorage, const char *pUrl, const char *pDest, int StorageType, CTimeout Timeout, bool LogProgress) :
 	CRequest(pUrl, Timeout, LogProgress),
 	m_pStorage(pStorage),
-	m_StorageType(StorageType),
-	m_File(0)
+	m_File(0),
+	m_StorageType(StorageType)
 {
 	str_copy(m_aDest, pDest, sizeof(m_aDest));
 

--- a/src/engine/client/http.h
+++ b/src/engine/client/http.h
@@ -101,12 +101,13 @@ class CGetFile : public CRequest
 
 	IStorage *m_pStorage;
 
-	char m_aDest[MAX_PATH_LENGTH];
 	char m_aDestFull[MAX_PATH_LENGTH];
-	int m_StorageType;
 	IOHANDLE m_File;
 
 protected:
+	char m_aDest[MAX_PATH_LENGTH];
+	int m_StorageType;
+
 	virtual int OnCompletion(int State);
 
 public:

--- a/src/game/client/components/skins.h
+++ b/src/game/client/components/skins.h
@@ -12,9 +12,21 @@
 class CSkins : public CComponent
 {
 public:
+	class CGetPngFile : public CGetFile
+	{
+		CSkins *m_pSkins;
+
+	protected:
+		virtual int OnCompletion(int State);
+
+	public:
+		CGetPngFile(CSkins *pSkins, IStorage *pStorage, const char *pUrl, const char *pDest, int StorageType = -2, CTimeout Timeout = CTimeout{4000, 500, 5}, bool LogProgress = true);
+		CImageInfo m_Info;
+	};
+
 	struct CDownloadSkin
 	{
-		std::shared_ptr<CGetFile> m_pTask;
+		std::shared_ptr<CSkins::CGetPngFile> m_pTask;
 		char m_aPath[MAX_PATH_LENGTH];
 		char m_aName[24];
 
@@ -35,7 +47,9 @@ private:
 	sorted_array<CDownloadSkin> m_aDownloadSkins;
 	char m_EventSkinPrefix[24];
 
+	bool LoadSkinPNG(CImageInfo &Info, const char *pName, const char *pPath, int DirType);
 	int LoadSkin(const char *pName, const char *pPath, int DirType);
+	int LoadSkin(const char *pName, CImageInfo &Info);
 	int FindImpl(const char *pName);
 	static int SkinScan(const char *pName, int IsDir, int DirType, void *pUser);
 };


### PR DESCRIPTION
Sorry for the trouble, seems to work.

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [x] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
