### PR TITLE
Allow resizing on Windows too

### DIFF
--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -3990,7 +3990,6 @@ void CCommandProcessorFragment_SDL::Cmd_VSync(const CCommandBuffer::SCommand_VSy
 
 void CCommandProcessorFragment_SDL::Cmd_Resize(const CCommandBuffer::SCommand_Resize *pCommand)
 {
-	SDL_SetWindowSize(m_pWindow, pCommand->m_Width, pCommand->m_Height);
 	glViewport(0, 0, pCommand->m_Width, pCommand->m_Height);
 }
 
@@ -4333,11 +4332,6 @@ int CGraphicsBackend_SDL_OpenGL::Init(const char *pName, int *Screen, int *pWidt
 			dbg_msg("gfx", "unable to init SDL video: %s", SDL_GetError());
 			return EGraphicsBackendErrorCodes::GRAPHICS_BACKEND_ERROR_CODE_SDL_INIT_FAILED;
 		}
-
-#ifdef CONF_FAMILY_WINDOWS
-		if(!getenv("SDL_VIDEO_WINDOW_POS") && !getenv("SDL_VIDEO_CENTERED")) // ignore_convention
-			putenv("SDL_VIDEO_WINDOW_POS=center"); // ignore_convention
-#endif
 	}
 
 	SDL_ClearError();
@@ -4491,10 +4485,8 @@ int CGraphicsBackend_SDL_OpenGL::Init(const char *pName, int *Screen, int *pWidt
 	int SdlFlags = SDL_WINDOW_OPENGL | SDL_WINDOW_INPUT_GRABBED | SDL_WINDOW_INPUT_FOCUS | SDL_WINDOW_MOUSE_FOCUS;
 	if(Flags & IGraphicsBackend::INITFLAG_HIGHDPI)
 		SdlFlags |= SDL_WINDOW_ALLOW_HIGHDPI;
-#if defined(SDL_VIDEO_DRIVER_X11)
 	if(Flags & IGraphicsBackend::INITFLAG_RESIZABLE)
 		SdlFlags |= SDL_WINDOW_RESIZABLE;
-#endif
 	if(Flags & IGraphicsBackend::INITFLAG_BORDERLESS)
 		SdlFlags |= SDL_WINDOW_BORDERLESS;
 	if(Flags & IGraphicsBackend::INITFLAG_FULLSCREEN)
@@ -4542,8 +4534,8 @@ int CGraphicsBackend_SDL_OpenGL::Init(const char *pName, int *Screen, int *pWidt
 
 	m_pWindow = SDL_CreateWindow(
 		pName,
-		SDL_WINDOWPOS_UNDEFINED,
-		SDL_WINDOWPOS_UNDEFINED,
+		SDL_WINDOWPOS_CENTERED,
+		SDL_WINDOWPOS_CENTERED,
 		*pWidth,
 		*pHeight,
 		SdlFlags);
@@ -4807,6 +4799,16 @@ int CGraphicsBackend_SDL_OpenGL::WindowOpen()
 void CGraphicsBackend_SDL_OpenGL::SetWindowGrab(bool Grab)
 {
 	SDL_SetWindowGrab(m_pWindow, Grab ? SDL_TRUE : SDL_FALSE);
+}
+
+void CGraphicsBackend_SDL_OpenGL::ResizeWindow(int w, int h)
+{
+	SDL_SetWindowSize(m_pWindow, w, h);
+}
+
+void CGraphicsBackend_SDL_OpenGL::GetViewportSize(int &w, int &h)
+{
+	SDL_GL_GetDrawableSize(m_pWindow, &w, &h);
 }
 
 void CGraphicsBackend_SDL_OpenGL::NotifyWindow()

--- a/src/engine/client/backend_sdl.h
+++ b/src/engine/client/backend_sdl.h
@@ -518,6 +518,8 @@ public:
 	virtual int WindowActive();
 	virtual int WindowOpen();
 	virtual void SetWindowGrab(bool Grab);
+	virtual void ResizeWindow(int w, int h);
+	virtual void GetViewportSize(int &w, int &h);
 	virtual void NotifyWindow();
 
 	virtual bool IsNewOpenGL() { return m_UseNewOpenGL; }

--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -2433,27 +2433,33 @@ bool CGraphics_Threaded::SetWindowScreen(int Index)
 	return m_pBackend->SetWindowScreen(Index);
 }
 
-void CGraphics_Threaded::Resize(int w, int h)
+void CGraphics_Threaded::Resize(int w, int h, bool SetWindowSize)
 {
 #if defined(CONF_VIDEORECORDER)
 	if(IVideo::Current() && IVideo::Current()->IsRecording())
 		return;
 #endif
 
-	if(m_ScreenWidth == w && m_ScreenHeight == h)
+	if(m_DesktopScreenWidth == w && m_DesktopScreenHeight == h)
 		return;
 
-	if(h > 4 * w / 5)
-		h = 4 * w / 5;
-	if(w > 21 * h / 9)
-		w = 21 * h / 9;
+	if(SetWindowSize)
+		m_pBackend->ResizeWindow(w, h);
 
-	m_ScreenWidth = w;
-	m_ScreenHeight = h;
+	m_DesktopScreenWidth = w;
+	m_DesktopScreenHeight = h;
+
+	m_pBackend->GetViewportSize(m_ScreenWidth, m_ScreenHeight);
+
+	// adjust the viewport to only allow certain aspect ratios
+	if(m_ScreenHeight > 4 * m_ScreenWidth / 5)
+		m_ScreenHeight = 4 * m_ScreenWidth / 5;
+	if(m_ScreenWidth > 21 * m_ScreenHeight / 9)
+		m_ScreenWidth = 21 * m_ScreenHeight / 9;
 
 	CCommandBuffer::SCommand_Resize Cmd;
-	Cmd.m_Width = w;
-	Cmd.m_Height = h;
+	Cmd.m_Width = m_ScreenWidth;
+	Cmd.m_Height = m_ScreenHeight;
 	m_pCommandBuffer->AddCommand(Cmd);
 
 	// kick the command buffer

--- a/src/engine/client/graphics_threaded.h
+++ b/src/engine/client/graphics_threaded.h
@@ -659,6 +659,8 @@ public:
 	virtual int WindowActive() = 0;
 	virtual int WindowOpen() = 0;
 	virtual void SetWindowGrab(bool Grab) = 0;
+	virtual void ResizeWindow(int w, int h) = 0;
+	virtual void GetViewportSize(int &w, int &h) = 0;
 	virtual void NotifyWindow() = 0;
 
 	virtual void RunBuffer(CCommandBuffer *pBuffer) = 0;
@@ -1112,7 +1114,7 @@ public:
 	bool Fullscreen(bool State) override;
 	void SetWindowBordered(bool State) override;
 	bool SetWindowScreen(int Index) override;
-	void Resize(int w, int h) override;
+	void Resize(int w, int h, bool SetWindowSize = false) override;
 	void AddWindowResizeListener(WINDOW_RESIZE_FUNC pFunc, void *pUser) override;
 	int GetWindowScreen() override;
 

--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -327,9 +327,7 @@ int CInput::Update()
 				switch(Event.window.event)
 				{
 				case SDL_WINDOWEVENT_RESIZED:
-#if defined(SDL_VIDEO_DRIVER_X11)
 					Graphics()->Resize(Event.window.data1, Event.window.data2);
-#endif
 					break;
 				case SDL_WINDOWEVENT_FOCUS_GAINED:
 					if(m_InputGrabbed)

--- a/src/engine/graphics.h
+++ b/src/engine/graphics.h
@@ -201,7 +201,7 @@ public:
 	virtual bool SetWindowScreen(int Index) = 0;
 	virtual bool SetVSync(bool State) = 0;
 	virtual int GetWindowScreen() = 0;
-	virtual void Resize(int w, int h) = 0;
+	virtual void Resize(int w, int h, bool SetWindowSize = false) = 0;
 	virtual void AddWindowResizeListener(WINDOW_RESIZE_FUNC pFunc, void *pUser) = 0;
 
 	virtual void Clear(float r, float g, float b) = 0;

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -1056,11 +1056,7 @@ void CMenus::RenderSettingsGraphics(CUIRect MainView)
 		g_Config.m_GfxColorDepth = Depth;
 		g_Config.m_GfxScreenWidth = s_aModes[NewSelected].m_Width;
 		g_Config.m_GfxScreenHeight = s_aModes[NewSelected].m_Height;
-#if defined(SDL_VIDEO_DRIVER_X11)
-		Graphics()->Resize(g_Config.m_GfxScreenWidth, g_Config.m_GfxScreenHeight);
-#else
-		CheckSettings = true;
-#endif
+		Graphics()->Resize(g_Config.m_GfxScreenWidth, g_Config.m_GfxScreenHeight, true);
 	}
 
 	// switches


### PR DESCRIPTION
I actually wanted to fix the grabbing issue on Windows, but sadly couldn't fix it, while trying to fix it, i fixed the resizing stuff tho(tested with a vm on win10 and win7), also gfx_resizable 1 should be fine now with KDE too(couldn't reproduce that blackscreen bug anymore)

Tho I also want to share some things about the grabbing thing, maybe someone is interested in improving it:
I found out that disabling the console on windows and creating the window as fast as possible reduces the grabbing issues.
Even better was making the windows always on top so SDL doesn't call the grab when our window looses focus, while the IO stuff is blocking.
The code is really random but here are the things i tried(https://github.com/Jupeyy/ddnet/commit/c881720137ecdba7d766c8affef755c54a9b08ff)



## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
