### PR TITLE
Better Sliders(V) / Lists

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -984,13 +984,10 @@ float CMenus::DoScrollbarH(const void *pID, const CUIRect *pRect, float Current)
 	// render
 	CUIRect Rail;
 	pRect->HMargin(5.0f, &Rail);
-	RenderTools()->DrawUIRect(&Rail, ColorRGBA(1, 1, 1, 0.25f), 0, 0.0f);
+	RenderTools()->DrawUIRect(&Rail, ColorRGBA(1, 1, 1, 0.25f), CUI::CORNER_ALL, 3.0f);
 
 	CUIRect Slider = Handle;
-	Slider.h = Rail.y - Slider.y;
-	RenderTools()->DrawUIRect(&Slider, ColorRGBA(1, 1, 1, 0.25f), CUI::CORNER_T, 2.5f);
-	Slider.y = Rail.y + Rail.h;
-	RenderTools()->DrawUIRect(&Slider, ColorRGBA(1, 1, 1, 0.25f), CUI::CORNER_B, 2.5f);
+	RenderTools()->DrawUIRect(&Slider, ColorRGBA(0.5f, 0.5f, 0.5f, 1), CUI::CORNER_ALL, 3.0f);
 
 	Slider = Handle;
 	Slider.Margin(5.0f, &Slider);

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -923,11 +923,7 @@ float CMenus::DoScrollbarV(const void *pID, const CUIRect *pRect, float Current)
 		UI()->SetHotItem(pID);
 
 	// render
-	RenderTools()->DrawUIRect(pRect, ColorRGBA(0, 0, 0, 0.25f), CUI::CORNER_ALL, 2.5f);
-
-	CUIRect Slider = Handle;
-	RenderTools()->DrawUIRect(&Slider, ColorRGBA(1, 1, 1, 0.25f), CUI::CORNER_ALL, 2.5f);
-	Slider.Margin(2, &Slider);
+	RenderTools()->DrawUIRect(pRect, ColorRGBA(0, 0, 0, 0.25f), CUI::CORNER_ALL, 5.0f);
 
 	float ColorSlider = 0;
 
@@ -938,7 +934,7 @@ float CMenus::DoScrollbarV(const void *pID, const CUIRect *pRect, float Current)
 	else
 		ColorSlider = 0.75f;
 
-	RenderTools()->DrawUIRect(&Slider, ColorRGBA(ColorSlider, ColorSlider, ColorSlider, 0.75f), CUI::CORNER_ALL, 2.5f);
+	RenderTools()->DrawUIRect(&Handle, ColorRGBA(ColorSlider, ColorSlider, ColorSlider, 0.75f), CUI::CORNER_ALL, 5.0f);
 
 	return ReturnValue;
 }

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -887,7 +887,8 @@ float CMenus::DoScrollbarV(const void *pID, const CUIRect *pRect, float Current)
 	static float OffsetY;
 	pRect->HSplitTop(33, &Handle, 0);
 
-	Handle.y += (pRect->h - Handle.h) * Current;
+	Current = clamp(Current, 0.0f, 1.0f);
+	Handle.y = pRect->y + (pRect->h - Handle.h) * Current;
 
 	// logic
 	float ReturnValue = Current;

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -3162,8 +3162,8 @@ void CMenus::SetMenuPage(int NewPage)
 bool CMenus::HandleListInputs(const CUIRect &View, float &ScrollValue, const float ScrollAmount, int *pScrollOffset, const float ElemHeight, int &SelectedIndex, const int NumElems)
 {
 	int NewIndex = -1;
-	int Num = (int)(View.h / ElemHeight) + 1;
-	int ScrollNum = maximum(NumElems - Num + 1, 0);
+	int Num = (int)(View.h / ElemHeight);
+	int ScrollNum = maximum(NumElems - Num, 0);
 	if(ScrollNum > 0)
 	{
 		if(pScrollOffset && *pScrollOffset >= 0)

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -984,10 +984,13 @@ float CMenus::DoScrollbarH(const void *pID, const CUIRect *pRect, float Current)
 	// render
 	CUIRect Rail;
 	pRect->HMargin(5.0f, &Rail);
-	RenderTools()->DrawUIRect(&Rail, ColorRGBA(1, 1, 1, 0.25f), CUI::CORNER_ALL, 3.0f);
+	RenderTools()->DrawUIRect(&Rail, ColorRGBA(1, 1, 1, 0.25f), 0, 0.0f);
 
 	CUIRect Slider = Handle;
-	RenderTools()->DrawUIRect(&Slider, ColorRGBA(0.5f, 0.5f, 0.5f, 1), CUI::CORNER_ALL, 3.0f);
+	Slider.h = Rail.y - Slider.y;
+	RenderTools()->DrawUIRect(&Slider, ColorRGBA(1, 1, 1, 0.25f), CUI::CORNER_T, 2.5f);
+	Slider.y = Rail.y + Rail.h;
+	RenderTools()->DrawUIRect(&Slider, ColorRGBA(1, 1, 1, 0.25f), CUI::CORNER_B, 2.5f);
 
 	Slider = Handle;
 	Slider.Margin(5.0f, &Slider);

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -148,7 +148,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 	RenderTools()->DrawUIRect(&View, ColorRGBA(0, 0, 0, 0.15f), 0, 0);
 
 	CUIRect Scroll;
-	View.VSplitRight(15, &View, &Scroll);
+	View.VSplitRight(10, &View, &Scroll);
 
 	int NumServers = ServerBrowser()->NumSortedServers();
 
@@ -168,7 +168,6 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 	static int s_ScrollBar = 0;
 	static float s_ScrollValue = 0;
 
-	Scroll.HMargin(5.0f, &Scroll);
 	s_ScrollValue = DoScrollbarV(&s_ScrollBar, &Scroll, s_ScrollValue);
 
 	if(Input()->KeyPress(KEY_TAB) && m_pClient->m_pGameConsole->IsClosed())

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -543,8 +543,9 @@ void CMenus::UiDoListboxStart(const void *pID, const CUIRect *pRect, float RowHe
 	// do the scrollbar
 	View.HSplitTop(gs_ListBoxRowHeight, &Row, 0);
 
-	int NumViewable = (int)(gs_ListBoxOriginalView.h / Row.h) + 1;
-	int Num = (NumItems + gs_ListBoxItemsPerRow - 1) / gs_ListBoxItemsPerRow - NumViewable + 1;
+	int NumViewable = (int)(gs_ListBoxOriginalView.h / Row.h) * gs_ListBoxItemsPerRow;
+	//int Num = (NumItems + gs_ListBoxItemsPerRow - 1) / gs_ListBoxItemsPerRow - NumViewable + 1;
+	int Num = NumItems - NumViewable;
 	if(Num <= 0)
 	{
 		Num = 0;

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -517,7 +517,6 @@ void CMenus::UiDoListboxStart(const void *pID, const CUIRect *pRect, float RowHe
 {
 	CUIRect Scroll, Row;
 	CUIRect View = *pRect;
-	CUIRect Header, Footer;
 
 	if(!LogicOnly)
 	{

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -522,22 +522,18 @@ void CMenus::UiDoListboxStart(const void *pID, const CUIRect *pRect, float RowHe
 	if(!LogicOnly)
 	{
 		// draw header
+		/*
 		View.HSplitTop(ms_ListheaderHeight, &Header, &View);
 		RenderTools()->DrawUIRect(&Header, ColorRGBA(1, 1, 1, 0.25f), CUI::CORNER_T, 5.0f);
 		UI()->DoLabel(&Header, pTitle, Header.h * ms_FontmodHeight, 0);
-
-		// draw footers
-		View.HSplitBottom(ms_ListheaderHeight, &View, &Footer);
-		RenderTools()->DrawUIRect(&Footer, ColorRGBA(1, 1, 1, 0.25f), CUI::CORNER_B, 5.0f);
-		Footer.VSplitLeft(10.0f, 0, &Footer);
-		UI()->DoLabel(&Footer, pBottomText, Header.h * ms_FontmodHeight, 0);
+		*/
 
 		// background
-		RenderTools()->DrawUIRect(&View, ColorRGBA(0, 0, 0, 0.15f), 0, 0);
+		RenderTools()->DrawUIRect(&View, ColorRGBA(0, 0, 0, 0.15f), CUI::CORNER_ALL, 5.0f);
 	}
 
 	// prepare the scroll
-	View.VSplitRight(15, &View, &Scroll);
+	View.VSplitRight(10, &View, &Scroll);
 
 	// setup the variables
 	gs_ListBoxOriginalView = View;
@@ -569,8 +565,8 @@ void CMenus::UiDoListboxStart(const void *pID, const CUIRect *pRect, float RowHe
 			gs_ListBoxScrollValue += Num == 1 ? 0.1f : 3.0f / Num;
 	}
 
-	Scroll.HMargin(5.0f, &Scroll);
-	gs_ListBoxScrollValue = clamp(DoScrollbarV(pID, &Scroll, clamp(gs_ListBoxScrollValue, 0.0f, 1.0f)), 0.0f, 1.0f);
+	//Scroll.HMargin(5.0f, &Scroll);
+	gs_ListBoxScrollValue = clamp(DoScrollbarV(pID, &Scroll, gs_ListBoxScrollValue), 0.0f, 1.0f);
 
 	// the list
 	gs_ListBoxView = gs_ListBoxOriginalView;

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -545,7 +545,7 @@ void CMenus::UiDoListboxStart(const void *pID, const CUIRect *pRect, float RowHe
 
 	int NumViewable = (int)(gs_ListBoxOriginalView.h / Row.h) * gs_ListBoxItemsPerRow;
 	//int Num = (NumItems + gs_ListBoxItemsPerRow - 1) / gs_ListBoxItemsPerRow - NumViewable + 1;
-	int Num = NumItems - NumViewable;
+	int Num = ceil((NumItems - NumViewable) / (float)gs_ListBoxItemsPerRow);
 	if(Num <= 0)
 	{
 		Num = 0;
@@ -558,7 +558,10 @@ void CMenus::UiDoListboxStart(const void *pID, const CUIRect *pRect, float RowHe
 			gs_ListBoxScrollValue += Num == 1 ? 0.1f : 3.0f / Num;
 	}
 
-	gs_ListBoxScrollValue = clamp(DoScrollbarV(pID, &Scroll, gs_ListBoxScrollValue), 0.0f, 1.0f);
+	if(Num == 0)
+		gs_ListBoxScrollValue = 0;
+	else
+		gs_ListBoxScrollValue = clamp(DoScrollbarV(pID, &Scroll, gs_ListBoxScrollValue), 0.0f, 1.0f);
 
 	// the list
 	gs_ListBoxView = gs_ListBoxOriginalView;

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -521,18 +521,10 @@ void CMenus::UiDoListboxStart(const void *pID, const CUIRect *pRect, float RowHe
 
 	if(!LogicOnly)
 	{
-		// draw header
-		/*
-		View.HSplitTop(ms_ListheaderHeight, &Header, &View);
-		RenderTools()->DrawUIRect(&Header, ColorRGBA(1, 1, 1, 0.25f), CUI::CORNER_T, 5.0f);
-		UI()->DoLabel(&Header, pTitle, Header.h * ms_FontmodHeight, 0);
-		*/
-
 		// background
 		RenderTools()->DrawUIRect(&View, ColorRGBA(0, 0, 0, 0.15f), CUI::CORNER_ALL, 5.0f);
 	}
 
-	// prepare the scroll
 	View.VSplitRight(10, &View, &Scroll);
 
 	// setup the variables
@@ -565,7 +557,6 @@ void CMenus::UiDoListboxStart(const void *pID, const CUIRect *pRect, float RowHe
 			gs_ListBoxScrollValue += Num == 1 ? 0.1f : 3.0f / Num;
 	}
 
-	//Scroll.HMargin(5.0f, &Scroll);
 	gs_ListBoxScrollValue = clamp(DoScrollbarV(pID, &Scroll, gs_ListBoxScrollValue), 0.0f, 1.0f);
 
 	// the list

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -1012,14 +1012,13 @@ void CMenus::RenderGhost(CUIRect MainView)
 	RenderTools()->DrawUIRect(&View, ColorRGBA(0, 0, 0, 0.15f), 0, 0);
 
 	CUIRect Scroll;
-	View.VSplitRight(15, &View, &Scroll);
+	View.VSplitRight(10, &View, &Scroll);
 
 	int NumGhosts = m_lGhosts.size();
 	static int s_ScrollBar = 0;
 	static float s_ScrollValue = 0;
 	static int s_SelectedIndex = 0;
 
-	Scroll.HMargin(5.0f, &Scroll);
 	s_ScrollValue = DoScrollbarV(&s_ScrollBar, &Scroll, s_ScrollValue);
 
 	HandleListInputs(View, s_ScrollValue, 1.0f, nullptr, s_aCols[0].m_Rect.h, s_SelectedIndex, NumGhosts);

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -884,7 +884,7 @@ void CMenus::RenderSettingsControls(CUIRect MainView)
 	static int s_SelectedControl = -1;
 	static float s_ScrollValue = 0;
 	int OldSelected = s_SelectedControl;
-	UiDoListboxStart(&s_ControlsList, &MainView, 475.0f, Localize("Controls"), "", 1, 1, s_SelectedControl, s_ScrollValue);
+	UiDoListboxStart(&s_ControlsList, &MainView, 500.0f, Localize("Controls"), "", 1, 1, s_SelectedControl, s_ScrollValue);
 
 	CUIRect MovementSettings, WeaponSettings, VotingSettings, ChatSettings, DummySettings, MiscSettings, ResetButton;
 	CListboxItem Item = UiDoListboxNextItem(&OldSelected, false, false, true);

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -624,6 +624,9 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 			if(g_Config.m_ClVanillaSkinsOnly && !s->m_IsVanilla)
 				continue;
 
+			if(s == 0)
+				continue;
+
 			s_paSkinList.add_unsorted(s);
 		}
 		s_InitSkinlist = false;
@@ -635,8 +638,6 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 	for(int i = 0; i < s_paSkinList.size(); ++i)
 	{
 		const CSkin *s = s_paSkinList[i];
-		if(s == 0)
-			continue;
 
 		if(str_comp(s->m_aName, Skin) == 0)
 			OldSelected = i;


### PR DESCRIPTION
Horizontal sliders stays the same

**THESE FIXES ARE TEMPORARY**
PR contains some shitty hotfixes which I'm planning to rework later. The reason of them being shitty is that the source code for it was shitty already, simple as it is. The whole list idea should be reworked in order to make the code more clearer and nicer. Will do later. Also I'm planning to make much better mouse scrolling for lists, not the crappy "teleporting" thing we have right now, so anyway I will back to the lists later.

Basically, I'm reworking all the UI tabs one by one.
Now I am making the new "Tee" tab, which will combine "Player" and "Tee" setting tabs in one. As well as include improved skin selector with much more clear view on skins and so on... And I need this list update for it.

"Tee" tab update turns out to be a big one, so I decided trying to split it into several PRs. So lists and sliders goes first.

**FIXES/UPDATES:**
1. Slider is not flickering anymore when scrolling mouse wheel at the min/max slider position
2. Cool visual change of course, how can I go without that?
3. Slider is not shown for List if all list elements are visible in rect
4. Disabled List footers (useless and ugly)
5. Disabled List headers (useless and ugly)

![Screenshot_1](https://user-images.githubusercontent.com/39315809/102316987-ec264d00-3f87-11eb-9620-284912b346c6.png)

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [x] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
