### PR TITLE
Fixed mouse jumping after losing focus

### DIFF
--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -89,6 +89,8 @@ void CInput::MouseModeRelative()
 	m_InputGrabbed = 1;
 	SDL_SetRelativeMouseMode(SDL_TRUE);
 	Graphics()->SetWindowGrab(true);
+	// We should do this call to reset relative mouse position after alt+tab
+	SDL_GetRelativeMouseState(0x0, 0x0);
 }
 
 int CInput::MouseDoubleClick()


### PR DESCRIPTION
Extremely annoying bug fixed when you alt+tab from the game in SPEC mode, then open game window again and your screen was teleporting to somewhere nearby your position.
(https://cdn.discordapp.com/attachments/293493549758939136/789480934592217108/freecam-bug.gif)

Eventually fixes some other issues with relative mouse mode.