### PR TITLE
Don't print name change message when trying to change to banned name

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -370,26 +370,23 @@ bool CServer::SetClientNameImpl(int ClientID, const char *pNameRequest, bool Set
 	if(m_aClients[ClientID].m_State < CClient::STATE_READY)
 		return false;
 
-	if(Set)
+	CNameBan *pBanned = IsNameBanned(pNameRequest, m_aNameBans.base_ptr(), m_aNameBans.size());
+	if(pBanned)
 	{
-		CNameBan *pBanned = IsNameBanned(pNameRequest, m_aNameBans.base_ptr(), m_aNameBans.size());
-		if(pBanned)
+		if(m_aClients[ClientID].m_State == CClient::STATE_READY && Set)
 		{
-			if(m_aClients[ClientID].m_State == CClient::STATE_READY)
+			char aBuf[256];
+			if(pBanned->m_aReason[0])
 			{
-				char aBuf[256];
-				if(pBanned->m_aReason[0])
-				{
-					str_format(aBuf, sizeof(aBuf), "Kicked (your name is banned: %s)", pBanned->m_aReason);
-				}
-				else
-				{
-					str_copy(aBuf, "Kicked (your name is banned)", sizeof(aBuf));
-				}
-				Kick(ClientID, aBuf);
+				str_format(aBuf, sizeof(aBuf), "Kicked (your name is banned: %s)", pBanned->m_aReason);
 			}
-			return true;
+			else
+			{
+				str_copy(aBuf, "Kicked (your name is banned)", sizeof(aBuf));
+			}
+			Kick(ClientID, aBuf);
 		}
+		return false;
 	}
 
 	// trim the name


### PR DESCRIPTION
Introduced in https://github.com/ddnet/ddnet/pull/3095/files?w=1

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
