### PR TITLE
Don't sort on entry adding

### DIFF
--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -66,6 +66,8 @@ CServerBrowser::CServerBrowser()
 	m_RequestNumber = 0;
 
 	m_pDDNetInfo = 0;
+
+	m_SortOnNextUpdate = false;
 }
 
 CServerBrowser::~CServerBrowser()
@@ -369,10 +371,6 @@ void CServerBrowser::Sort()
 	else if(g_Config.m_BrSort == IServerBrowser::SORT_GAMETYPE)
 		std::stable_sort(m_pSortedServerlist, m_pSortedServerlist + m_NumSortedServers, SortWrap(this, &CServerBrowser::SortCompareGametype));
 
-	// set indexes
-	for(i = 0; i < m_NumSortedServers; i++)
-		m_ppServerlist[m_pSortedServerlist[i]]->m_Info.m_SortedIndex = i;
-
 	str_copy(m_aFilterGametypeString, g_Config.m_BrFilterGametype, sizeof(m_aFilterGametypeString));
 	str_copy(m_aFilterString, g_Config.m_BrFilterString, sizeof(m_aFilterString));
 	m_Sorthash = SortHash();
@@ -621,7 +619,7 @@ void CServerBrowser::Set(const NETADDR &Addr, int Type, int Token, const CServer
 		RemoveRequest(pEntry);
 	}
 
-	Sort();
+	m_SortOnNextUpdate = true;
 }
 
 void CServerBrowser::Refresh(int Type)
@@ -981,8 +979,11 @@ void CServerBrowser::Update(bool ForceResort)
 	}
 
 	// check if we need to resort
-	if(m_Sorthash != SortHash() || ForceResort)
+	if(m_Sorthash != SortHash() || ForceResort || m_SortOnNextUpdate)
+	{
 		Sort();
+		m_SortOnNextUpdate = false;
+	}
 }
 
 bool CServerBrowser::IsFavorite(const NETADDR &Addr) const

--- a/src/engine/client/serverbrowser.h
+++ b/src/engine/client/serverbrowser.h
@@ -178,6 +178,8 @@ private:
 	int m_RequestNumber;
 	unsigned char m_aTokenSeed[16];
 
+	bool m_SortOnNextUpdate;
+
 	int GenerateToken(const NETADDR &Addr) const;
 	static int GetBasicToken(int Token);
 	static int GetExtraToken(int Token);

--- a/src/engine/serverbrowser.h
+++ b/src/engine/serverbrowser.h
@@ -32,7 +32,6 @@ public:
 		int m_FriendState;
 	};
 
-	int m_SortedIndex;
 	int m_ServerIndex;
 
 	int m_Type;


### PR DESCRIPTION
Don't sort the whole server browser everytime an entry is added, instead only sort it once per Update call.

I hope this will help a bit with wrong Ping display, bcs of the br_max_request thing.
However, it won't fix it completly, since new request will still alter its correctness

for testing: br_max_request 500 makes the effect more visible, then its highly noticable

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
