### PR TITLE
Fix use of uninitialized variable during /load of old saves

### DIFF
--- a/src/game/server/save.cpp
+++ b/src/game/server/save.cpp
@@ -364,6 +364,7 @@ int CSaveTee::FromString(const char *String)
 		m_HasTelegunGrenade = 0;
 		m_HasTelegunLaser = 0;
 		m_HasTelegunGun = 0;
+		FormatUuid(CalculateUuid("game-uuid-nonexistent@ddnet.tw"), m_aGameUuid, sizeof(m_aGameUuid));
 		// fall through
 	case 101:
 		m_HookedPlayer = -1;


### PR DESCRIPTION
Should fix #3144 again. Better name for the nonexistent game uuid appreciated, but would be fine the current one.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
