### PR TITLE
Respect possible particle size increase, of worst case rotation

### DIFF
--- a/src/game/client/components/particles.cpp
+++ b/src/game/client/components/particles.cpp
@@ -177,6 +177,10 @@ bool CParticles::ParticleIsVisibleOnScreen(const vec2 &CurPos, float CurSize)
 	float ScreenX0, ScreenY0, ScreenX1, ScreenY1;
 	Graphics()->GetScreen(&ScreenX0, &ScreenY0, &ScreenX1, &ScreenY1);
 
+	// for simplicity assume the worst case rotation, that increases the bounding box around the particle by its diagonal
+	const float SqrtOf2 = sqrtf(2);
+	CurSize = SqrtOf2 * CurSize;
+
 	// always uses the mid of the particle
 	float SizeHalf = CurSize / 2;
 


### PR DESCRIPTION
Particle's achsis aligned bounding box can increase in size if the particle is rotating.
Even if the particle images are all "pretty" round and so it wouldn't matter for default particles,
its not correct and with a custom image it could break.
following #3441

Basically this:
![image](https://user-images.githubusercontent.com/6654924/103292756-be60ef80-49ee-11eb-8518-dd120d19ca17.png)


## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
