### PR TITLE
Dynamically size scoreboard title

### DIFF
--- a/src/game/client/components/scoreboard.cpp
+++ b/src/game/client/components/scoreboard.cpp
@@ -197,13 +197,16 @@ void CScoreboard::RenderScoreboard(float x, float y, float w, int Team, const ch
 
 	// render title
 	float TitleFontsize = 40.0f;
+	int TitleWidth = (lower32 || lower24 || lower16) ? 1140 : 440;
 	if(!pTitle)
 	{
 		if(m_pClient->m_Snap.m_pGameInfoObj->m_GameStateFlags & GAMESTATEFLAG_GAMEOVER)
 			pTitle = Localize("Game over");
 		else
 		{
-			str_utf8_truncate(aBuf, sizeof(aBuf), Client()->GetCurrentMap(), 16);
+			str_utf8_copy(aBuf, Client()->GetCurrentMap(), sizeof(aBuf));
+			while(TextRender()->TextWidth(0, TitleFontsize, aBuf, -1, -1.0f) > TitleWidth)
+				aBuf[str_length(aBuf) - 1] = '\0';
 			if(str_comp(aBuf, Client()->GetCurrentMap()))
 				str_append(aBuf, "…", sizeof(aBuf));
 			pTitle = aBuf;
@@ -614,18 +617,18 @@ void CScoreboard::OnRender()
 		{
 			if(m_pClient->m_Snap.m_aTeamSize[0] > 48)
 			{
-				RenderScoreboard(Width / 2 - w, 150.0f, w, -4, 0);
 				RenderScoreboard(Width / 2, 150.0f, w, -5, "");
+				RenderScoreboard(Width / 2 - w, 150.0f, w, -4, 0);
 			}
 			else if(m_pClient->m_Snap.m_aTeamSize[0] > 32)
 			{
-				RenderScoreboard(Width / 2 - w, 150.0f, w, -7, 0);
 				RenderScoreboard(Width / 2, 150.0f, w, -8, "");
+				RenderScoreboard(Width / 2 - w, 150.0f, w, -7, 0);
 			}
 			else if(m_pClient->m_Snap.m_aTeamSize[0] > 16)
 			{
-				RenderScoreboard(Width / 2 - w, 150.0f, w, -6, 0);
 				RenderScoreboard(Width / 2, 150.0f, w, -3, "");
+				RenderScoreboard(Width / 2 - w, 150.0f, w, -6, 0);
 			}
 			else
 			{

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -2975,7 +2975,7 @@ float CEditor::ScaleFontSize(char *pText, int TextSize, float FontSize, int Widt
 		else
 		{
 			pText[str_length(pText) - 4] = '\0';
-			str_append(pText, "...", TextSize);
+			str_append(pText, "…", TextSize);
 		}
 	}
 	return FontSize;


### PR DESCRIPTION
![screenshot_2020-12-31_10-01-53](https://user-images.githubusercontent.com/2335377/103403147-80c7a800-4b4f-11eb-90d3-90d032439cf3.png)
![screenshot_2020-12-31_10-13-23](https://user-images.githubusercontent.com/2335377/103403580-ed8f7200-4b50-11eb-9798-01fd4e283405.png)

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
