### PR TITLE
Port some refactor from teeworlds-0.7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1941,6 +1941,7 @@ set_src(ENGINE_SERVER GLOB_RECURSE src/engine/server
   upnp.h
 )
 set_src(GAME_SERVER GLOB_RECURSE src/game/server
+  alloc.h
   ddracechat.cpp
   ddracechat.h
   ddracecommands.cpp

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -4317,6 +4317,7 @@ int main(int argc, const char **argv) // ignore_convention
 
 	pEngine->Init();
 	pConfig->Init();
+	pConsole->Init();
 	pEngineMasterServer->Init();
 	pEngineMasterServer->Load();
 

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -272,6 +272,8 @@ CClient::CClient() :
 	m_pSound = 0;
 	m_pGameClient = 0;
 	m_pMap = 0;
+	m_pConfigManager = 0;
+	m_pConfig = 0;
 	m_pConsole = 0;
 
 	m_RenderFrameTime = 0.0001f;
@@ -2961,6 +2963,8 @@ void CClient::InitInterfaces()
 	m_pInput = Kernel()->RequestInterface<IEngineInput>();
 	m_pMap = Kernel()->RequestInterface<IEngineMap>();
 	m_pMasterServer = Kernel()->RequestInterface<IEngineMasterServer>();
+	m_pConfigManager = Kernel()->RequestInterface<IConfigManager>();
+	m_pConfig = m_pConfigManager->Values();
 #if defined(CONF_AUTOUPDATE)
 	m_pUpdater = Kernel()->RequestInterface<IUpdater>();
 #endif
@@ -3338,8 +3342,7 @@ void CClient::Run()
 			if(!s_SavedConfig)
 			{
 				// write down the config and quit
-				IConfig *pConfig = Kernel()->RequestInterface<IConfig>();
-				if(!pConfig->Save())
+				if(!m_pConfigManager->Save())
 					m_Warnings.emplace_back(SWarning(Localize("Saving ddnet-settings.cfg failed")));
 				s_SavedConfig = true;
 			}
@@ -4265,7 +4268,7 @@ int main(int argc, const char **argv) // ignore_convention
 	IEngine *pEngine = CreateEngine("DDNet", Silent, 1);
 	IConsole *pConsole = CreateConsole(CFGFLAG_CLIENT);
 	IStorage *pStorage = CreateStorage("Teeworlds", IStorage::STORAGETYPE_CLIENT, argc, argv); // ignore_convention
-	IConfig *pConfig = CreateConfig();
+	IConfigManager *pConfigManager = CreateConfigManager();
 	IEngineSound *pEngineSound = CreateEngineSound();
 	IEngineInput *pEngineInput = CreateEngineInput();
 	IEngineTextRender *pEngineTextRender = CreateEngineTextRender();
@@ -4284,7 +4287,7 @@ int main(int argc, const char **argv) // ignore_convention
 
 		RegisterFail = RegisterFail || !pKernel->RegisterInterface(pEngine);
 		RegisterFail = RegisterFail || !pKernel->RegisterInterface(pConsole);
-		RegisterFail = RegisterFail || !pKernel->RegisterInterface(pConfig);
+		RegisterFail = RegisterFail || !pKernel->RegisterInterface(pConfigManager);
 
 		RegisterFail = RegisterFail || !pKernel->RegisterInterface(pEngineSound); // IEngineSound
 		RegisterFail = RegisterFail || !pKernel->RegisterInterface(static_cast<ISound *>(pEngineSound), false);
@@ -4316,7 +4319,7 @@ int main(int argc, const char **argv) // ignore_convention
 	}
 
 	pEngine->Init();
-	pConfig->Init();
+	pConfigManager->Init();
 	pConsole->Init();
 	pEngineMasterServer->Init();
 	pEngineMasterServer->Load();

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -90,6 +90,8 @@ class CClient : public IClient, public CDemoPlayer::IListener
 	IEngineSound *m_pSound;
 	IGameClient *m_pGameClient;
 	IEngineMap *m_pMap;
+	IConfigManager *m_pConfigManager;
+	CConfig *m_pConfig;
 	IConsole *m_pConsole;
 	IStorage *m_pStorage;
 	IUpdater *m_pUpdater;
@@ -274,6 +276,8 @@ public:
 	IEngineSound *Sound() { return m_pSound; }
 	IGameClient *GameClient() { return m_pGameClient; }
 	IEngineMasterServer *MasterServer() { return m_pMasterServer; }
+	IConfigManager *ConfigManager() { return m_pConfigManager; }
+	CConfig *Config() { return m_pConfig; }
 	IStorage *Storage() { return m_pStorage; }
 	IUpdater *Updater() { return m_pUpdater; }
 	ISteam *Steam() { return m_pSteam; }

--- a/src/engine/client/friends.cpp
+++ b/src/engine/client/friends.cpp
@@ -38,9 +38,9 @@ void CFriends::Init(bool Foes)
 {
 	m_Foes = Foes;
 
-	IConfig *pConfig = Kernel()->RequestInterface<IConfig>();
-	if(pConfig)
-		pConfig->RegisterCallback(ConfigSaveCallback, this);
+	IConfigManager *pConfigManager = Kernel()->RequestInterface<IConfigManager>();
+	if(pConfigManager)
+		pConfigManager->RegisterCallback(ConfigSaveCallback, this);
 
 	IConsole *pConsole = Kernel()->RequestInterface<IConsole>();
 	if(pConsole)
@@ -158,7 +158,7 @@ void CFriends::Friends()
 	}
 }
 
-void CFriends::ConfigSaveCallback(IConfig *pConfig, void *pUserData)
+void CFriends::ConfigSaveCallback(IConfigManager *pConfigManager, void *pUserData)
 {
 	CFriends *pSelf = (CFriends *)pUserData;
 	char aBuf[128];
@@ -175,6 +175,6 @@ void CFriends::ConfigSaveCallback(IConfig *pConfig, void *pUserData)
 		str_escape(&pDst, pSelf->m_aFriends[i].m_aClan, pEnd);
 		str_append(aBuf, "\"", sizeof(aBuf));
 
-		pConfig->WriteLine(aBuf);
+		pConfigManager->WriteLine(aBuf);
 	}
 }

--- a/src/engine/client/friends.h
+++ b/src/engine/client/friends.h
@@ -17,7 +17,7 @@ class CFriends : public IFriends
 	static void ConRemoveFriend(IConsole::IResult *pResult, void *pUserData);
 	static void ConFriends(IConsole::IResult *pResult, void *pUserData);
 
-	static void ConfigSaveCallback(IConfig *pConfig, void *pUserData);
+	static void ConfigSaveCallback(IConfigManager *pConfigManager, void *pUserData);
 
 public:
 	CFriends();

--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -89,9 +89,9 @@ void CServerBrowser::SetBaseInfo(class CNetClient *pClient, const char *pNetVers
 	m_pMasterServer = Kernel()->RequestInterface<IMasterServer>();
 	m_pConsole = Kernel()->RequestInterface<IConsole>();
 	m_pFriends = Kernel()->RequestInterface<IFriends>();
-	IConfig *pConfig = Kernel()->RequestInterface<IConfig>();
-	if(pConfig)
-		pConfig->RegisterCallback(ConfigSaveCallback, this);
+	IConfigManager *pConfigManager = Kernel()->RequestInterface<IConfigManager>();
+	if(pConfigManager)
+		pConfigManager->RegisterCallback(ConfigSaveCallback, this);
 }
 
 const CServerInfo *CServerBrowser::SortedGet(int Index) const
@@ -1264,7 +1264,7 @@ int CServerBrowser::LoadingProgression() const
 	return 100.0f * Loaded / Servers;
 }
 
-void CServerBrowser::ConfigSaveCallback(IConfig *pConfig, void *pUserData)
+void CServerBrowser::ConfigSaveCallback(IConfigManager *pConfigManager, void *pUserData)
 {
 	CServerBrowser *pSelf = (CServerBrowser *)pUserData;
 
@@ -1274,7 +1274,7 @@ void CServerBrowser::ConfigSaveCallback(IConfig *pConfig, void *pUserData)
 	{
 		net_addr_str(&pSelf->m_aFavoriteServers[i], aAddrStr, sizeof(aAddrStr), true);
 		str_format(aBuffer, sizeof(aBuffer), "add_favorite %s", aAddrStr);
-		pConfig->WriteLine(aBuffer);
+		pConfigManager->WriteLine(aBuffer);
 	}
 }
 

--- a/src/engine/client/serverbrowser.h
+++ b/src/engine/client/serverbrowser.h
@@ -206,7 +206,7 @@ private:
 
 	void SetInfo(CServerEntry *pEntry, const CServerInfo &Info);
 
-	static void ConfigSaveCallback(IConfig *pConfig, void *pUserData);
+	static void ConfigSaveCallback(IConfigManager *pConfigManager, void *pUserData);
 };
 
 #endif

--- a/src/engine/config.h
+++ b/src/engine/config.h
@@ -5,21 +5,22 @@
 
 #include "kernel.h"
 
-class IConfig : public IInterface
+class IConfigManager : public IInterface
 {
 	MACRO_INTERFACE("config", 0)
 public:
-	typedef void (*SAVECALLBACKFUNC)(IConfig *pConfig, void *pUserData);
+	typedef void (*SAVECALLBACKFUNC)(IConfigManager *pConfig, void *pUserData);
 
 	virtual void Init() = 0;
 	virtual void Reset() = 0;
 	virtual bool Save() = 0;
+	virtual class CConfig *Values() = 0;
 
 	virtual void RegisterCallback(SAVECALLBACKFUNC pfnFunc, void *pUserData) = 0;
 
 	virtual void WriteLine(const char *pLine) = 0;
 };
 
-extern IConfig *CreateConfig();
+extern IConfigManager *CreateConfigManager();
 
 #endif

--- a/src/engine/console.h
+++ b/src/engine/console.h
@@ -81,6 +81,7 @@ public:
 	typedef void (*FCommandCallback)(IResult *pResult, void *pUserData);
 	typedef void (*FChainCommandCallback)(IResult *pResult, void *pUserData, FCommandCallback pfnCallback, void *pCallbackUserData);
 
+	virtual void Init() = 0;
 	virtual const CCommandInfo *FirstCommandInfo(int AccessLevel, int Flagmask) const = 0;
 	virtual const CCommandInfo *GetCommandInfo(const char *pName, int FlagMask, bool Temp) = 0;
 	virtual void PossibleCommands(const char *pStr, int FlagMask, bool Temp, FPossibleCallback pfnCallback, void *pUser) = 0;

--- a/src/engine/server/register.cpp
+++ b/src/engine/server/register.cpp
@@ -118,10 +118,11 @@ void CRegister::RegisterGotCount(CNetChunk *pChunk)
 	}
 }
 
-void CRegister::Init(CNetServer *pNetServer, IEngineMasterServer *pMasterServer, IConsole *pConsole)
+void CRegister::Init(CNetServer *pNetServer, IEngineMasterServer *pMasterServer, CConfig *pConfig, IConsole *pConsole)
 {
 	m_pNetServer = pNetServer;
 	m_pMasterServer = pMasterServer;
+	m_pConfig = pConfig;
 	m_pConsole = pConsole;
 }
 

--- a/src/engine/server/register.h
+++ b/src/engine/server/register.h
@@ -29,6 +29,7 @@ class CRegister
 
 	class CNetServer *m_pNetServer;
 	class IEngineMasterServer *m_pMasterServer;
+	class CConfig *m_pConfig;
 	class IConsole *m_pConsole;
 
 	bool m_Sixup;
@@ -51,7 +52,7 @@ class CRegister
 
 public:
 	CRegister(bool Sixup);
-	void Init(class CNetServer *pNetServer, class IEngineMasterServer *pMasterServer, class IConsole *pConsole);
+	void Init(class CNetServer *pNetServer, class IEngineMasterServer *pMasterServer, class CConfig *pConfig, class IConsole *pConsole);
 	void RegisterUpdate(int Nettype);
 	int RegisterProcessPacket(struct CNetChunk *pPacket, SECURITY_TOKEN ResponseToken = 0);
 	void FeedToken(NETADDR Addr, SECURITY_TOKEN ResponseToken);

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -3525,6 +3525,7 @@ int main(int argc, const char **argv) // ignore_convention
 
 	pEngine->Init();
 	pConfig->Init();
+	pConsole->Init();
 	pEngineMasterServer->Init();
 	pEngineMasterServer->Load();
 

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -2335,10 +2335,10 @@ int CServer::LoadMap(const char *pMapName)
 	return 1;
 }
 
-void CServer::InitRegister(CNetServer *pNetServer, IEngineMasterServer *pMasterServer, IConsole *pConsole)
+void CServer::InitRegister(CNetServer *pNetServer, IEngineMasterServer *pMasterServer, CConfig *pConfig, IConsole *pConsole)
 {
-	m_Register.Init(pNetServer, pMasterServer, pConsole);
-	m_RegSixup.Init(pNetServer, pMasterServer, pConsole);
+	m_Register.Init(pNetServer, pMasterServer, pConfig, pConsole);
+	m_RegSixup.Init(pNetServer, pMasterServer, pConfig, pConsole);
 }
 
 int CServer::Run()
@@ -2407,7 +2407,7 @@ int CServer::Run()
 
 	m_NetServer.SetCallbacks(NewClientCallback, NewClientNoAuthCallback, ClientRejoinCallback, DelClientCallback, this);
 
-	m_Econ.Init(Console(), &m_ServerBan);
+	m_Econ.Init(Config(), Console(), &m_ServerBan);
 
 #if defined(CONF_FAMILY_UNIX)
 	m_Fifo.Init(Console(), g_Config.m_SvInputFifo, CFGFLAG_SERVER);
@@ -3495,10 +3495,10 @@ int main(int argc, const char **argv) // ignore_convention
 	IConsole *pConsole = CreateConsole(CFGFLAG_SERVER | CFGFLAG_ECON);
 	IEngineMasterServer *pEngineMasterServer = CreateEngineMasterServer();
 	IStorage *pStorage = CreateStorage("Teeworlds", IStorage::STORAGETYPE_SERVER, argc, argv); // ignore_convention
-	IConfig *pConfig = CreateConfig();
+	IConfigManager *pConfigManager = CreateConfigManager();
 	IEngineAntibot *pEngineAntibot = CreateEngineAntibot();
 
-	pServer->InitRegister(&pServer->m_NetServer, pEngineMasterServer, pConsole);
+	pServer->InitRegister(&pServer->m_NetServer, pEngineMasterServer, pConfigManager->Values(), pConsole);
 
 	{
 		bool RegisterFail = false;
@@ -3510,7 +3510,7 @@ int main(int argc, const char **argv) // ignore_convention
 		RegisterFail = RegisterFail || !pKernel->RegisterInterface(pGameServer);
 		RegisterFail = RegisterFail || !pKernel->RegisterInterface(pConsole);
 		RegisterFail = RegisterFail || !pKernel->RegisterInterface(pStorage);
-		RegisterFail = RegisterFail || !pKernel->RegisterInterface(pConfig);
+		RegisterFail = RegisterFail || !pKernel->RegisterInterface(pConfigManager);
 		RegisterFail = RegisterFail || !pKernel->RegisterInterface(pEngineMasterServer); // register as both
 		RegisterFail = RegisterFail || !pKernel->RegisterInterface(static_cast<IMasterServer *>(pEngineMasterServer), false);
 		RegisterFail = RegisterFail || !pKernel->RegisterInterface(pEngineAntibot);
@@ -3524,7 +3524,7 @@ int main(int argc, const char **argv) // ignore_convention
 	}
 
 	pEngine->Init();
-	pConfig->Init();
+	pConfigManager->Init();
 	pConsole->Init();
 	pEngineMasterServer->Init();
 	pEngineMasterServer->Load();

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -89,6 +89,7 @@ public:
 class CServer : public IServer
 {
 	class IGameServer *m_pGameServer;
+	class CConfig *m_pConfig;
 	class IConsole *m_pConsole;
 	class IStorage *m_pStorage;
 	class IEngineAntibot *m_pAntibot;
@@ -107,6 +108,7 @@ class CServer : public IServer
 
 public:
 	class IGameServer *GameServer() { return m_pGameServer; }
+	class CConfig *Config() { return m_pConfig; }
 	class IConsole *Console() { return m_pConsole; }
 	class IStorage *Storage() { return m_pStorage; }
 	class IEngineAntibot *Antibot() { return m_pAntibot; }
@@ -366,7 +368,7 @@ public:
 	void StopRecord(int ClientID);
 	bool IsRecording(int ClientID);
 
-	void InitRegister(CNetServer *pNetServer, IEngineMasterServer *pMasterServer, IConsole *pConsole);
+	void InitRegister(CNetServer *pNetServer, IEngineMasterServer *pMasterServer, CConfig *pConfig, IConsole *pConsole);
 	int Run();
 
 	static void ConTestingCommands(IConsole::IResult *pResult, void *pUser);

--- a/src/engine/shared/config.cpp
+++ b/src/engine/shared/config.cpp
@@ -5,49 +5,35 @@
 #include <engine/shared/protocol.h>
 #include <engine/storage.h>
 
-CConfiguration g_Config;
+CConfig g_Config;
 
-class CConfig : public IConfig
+void EscapeParam(char *pDst, const char *pSrc, int size)
 {
-	IStorage *m_pStorage;
-	IOHANDLE m_ConfigFile;
-	bool m_Failed;
-
-	struct CCallback
+	for(int i = 0; *pSrc && i < size - 1; ++i)
 	{
-		SAVECALLBACKFUNC m_pfnFunc;
-		void *m_pUserData;
-	};
-
-	enum
-	{
-		MAX_CALLBACKS = 16
-	};
-
-	CCallback m_aCallbacks[MAX_CALLBACKS];
-	int m_NumCallbacks;
-
-	void EscapeParam(char *pDst, const char *pSrc, int Size)
-	{
-		str_escape(&pDst, pSrc, pDst + Size);
+		if(*pSrc == '"' || *pSrc == '\\') // escape \ and "
+			*pDst++ = '\\';
+		*pDst++ = *pSrc++;
 	}
+	*pDst = 0;
+}
 
-public:
-	CConfig()
-	{
-		m_ConfigFile = 0;
-		m_NumCallbacks = 0;
-		m_Failed = false;
-	}
+CConfigManager::CConfigManager()
+{
+	m_pStorage = 0;
+	m_ConfigFile = 0;
+	m_NumCallbacks = 0;
+	m_Failed = false;
+}
 
-	virtual void Init()
-	{
-		m_pStorage = Kernel()->RequestInterface<IStorage>();
-		Reset();
-	}
+void CConfigManager::Init()
+{
+	m_pStorage = Kernel()->RequestInterface<IStorage>();
+	Reset();
+}
 
-	virtual void Reset()
-	{
+void CConfigManager::Reset()
+{
 #define MACRO_CONFIG_INT(Name, ScriptName, def, min, max, flags, desc) g_Config.m_##Name = def;
 #define MACRO_CONFIG_COL(Name, ScriptName, def, flags, desc) MACRO_CONFIG_INT(Name, ScriptName, def, 0, 0, flags, desc)
 #define MACRO_CONFIG_STR(Name, ScriptName, len, def, flags, desc) str_copy(g_Config.m_##Name, def, len);
@@ -57,28 +43,28 @@ public:
 #undef MACRO_CONFIG_INT
 #undef MACRO_CONFIG_COL
 #undef MACRO_CONFIG_STR
+}
+
+bool CConfigManager::Save()
+{
+	if(!m_pStorage || !g_Config.m_ClSaveSettings)
+		return true;
+
+	char aConfigFileTmp[64];
+	str_format(aConfigFileTmp, sizeof(aConfigFileTmp), CONFIG_FILE ".%d.tmp", pid());
+
+	m_ConfigFile = m_pStorage->OpenFile(aConfigFileTmp, IOFLAG_WRITE, IStorage::TYPE_SAVE);
+
+	if(!m_ConfigFile)
+	{
+		dbg_msg("config", "ERROR: opening %s failed", aConfigFileTmp);
+		return false;
 	}
 
-	virtual bool Save()
-	{
-		if(!m_pStorage || !g_Config.m_ClSaveSettings)
-			return true;
+	m_Failed = false;
 
-		char aConfigFileTmp[64];
-		str_format(aConfigFileTmp, sizeof(aConfigFileTmp), CONFIG_FILE ".%d.tmp", pid());
-
-		m_ConfigFile = m_pStorage->OpenFile(aConfigFileTmp, IOFLAG_WRITE, IStorage::TYPE_SAVE);
-
-		if(!m_ConfigFile)
-		{
-			dbg_msg("config", "ERROR: opening %s failed", aConfigFileTmp);
-			return false;
-		}
-
-		m_Failed = false;
-
-		char aLineBuf[1024 * 2];
-		char aEscapeBuf[1024 * 2];
+	char aLineBuf[1024 * 2];
+	char aEscapeBuf[1024 * 2];
 
 #define MACRO_CONFIG_INT(Name, ScriptName, def, min, max, flags, desc) \
 	if((flags)&CFGFLAG_SAVE && g_Config.m_##Name != def) \
@@ -106,48 +92,47 @@ public:
 #undef MACRO_CONFIG_COL
 #undef MACRO_CONFIG_STR
 
-		for(int i = 0; i < m_NumCallbacks; i++)
-			m_aCallbacks[i].m_pfnFunc(this, m_aCallbacks[i].m_pUserData);
+	for(int i = 0; i < m_NumCallbacks; i++)
+		m_aCallbacks[i].m_pfnFunc(this, m_aCallbacks[i].m_pUserData);
 
-		if(io_close(m_ConfigFile) != 0)
-			m_Failed = true;
+	if(io_close(m_ConfigFile) != 0)
+		m_Failed = true;
 
-		m_ConfigFile = 0;
+	m_ConfigFile = 0;
 
-		if(m_Failed)
-		{
-			dbg_msg("config", "ERROR: writing to %s failed", aConfigFileTmp);
-			return false;
-		}
-
-		if(!m_pStorage->RenameFile(aConfigFileTmp, CONFIG_FILE, IStorage::TYPE_SAVE))
-		{
-			dbg_msg("config", "ERROR: renaming %s to " CONFIG_FILE " failed", aConfigFileTmp);
-			return false;
-		}
-
-		return true;
+	if(m_Failed)
+	{
+		dbg_msg("config", "ERROR: writing to %s failed", aConfigFileTmp);
+		return false;
 	}
 
-	virtual void RegisterCallback(SAVECALLBACKFUNC pfnFunc, void *pUserData)
+	if(!m_pStorage->RenameFile(aConfigFileTmp, CONFIG_FILE, IStorage::TYPE_SAVE))
 	{
-		dbg_assert(m_NumCallbacks < MAX_CALLBACKS, "too many config callbacks");
-		m_aCallbacks[m_NumCallbacks].m_pfnFunc = pfnFunc;
-		m_aCallbacks[m_NumCallbacks].m_pUserData = pUserData;
-		m_NumCallbacks++;
+		dbg_msg("config", "ERROR: renaming %s to " CONFIG_FILE " failed", aConfigFileTmp);
+		return false;
 	}
 
-	virtual void WriteLine(const char *pLine)
-	{
-		if(!m_ConfigFile ||
-			io_write(m_ConfigFile, pLine, str_length(pLine)) != static_cast<unsigned>(str_length(pLine)) ||
+	return true;
+}
+
+void CConfigManager::RegisterCallback(SAVECALLBACKFUNC pfnFunc, void *pUserData)
+{
+	dbg_assert(m_NumCallbacks < MAX_CALLBACKS, "too many config callbacks");
+	m_aCallbacks[m_NumCallbacks].m_pfnFunc = pfnFunc;
+	m_aCallbacks[m_NumCallbacks].m_pUserData = pUserData;
+	m_NumCallbacks++;
+}
+
+void CConfigManager::WriteLine(const char *pLine)
+{
+	if(!m_ConfigFile ||
+		io_write(m_ConfigFile, pLine, str_length(pLine)) != static_cast<unsigned>(str_length(pLine)) ||
 #if defined(CONF_FAMILY_WINDOWS)
-			io_write_newline(m_ConfigFile) != 2)
+		io_write_newline(m_ConfigFile) != 2)
 #else
-			io_write_newline(m_ConfigFile) != 1)
+		io_write_newline(m_ConfigFile) != 1)
 #endif
-			m_Failed = true;
-	}
-};
+		m_Failed = true;
+}
 
-IConfig *CreateConfig() { return new CConfig; }
+IConfigManager *CreateConfigManager() { return new CConfigManager; }

--- a/src/engine/shared/config.h
+++ b/src/engine/shared/config.h
@@ -4,14 +4,16 @@
 #define ENGINE_SHARED_CONFIG_H
 
 #include <base/detect.h>
+#include <engine/config.h>
 
 #define CONFIG_FILE "settings_ddnet.cfg"
 #define AUTOEXEC_FILE "autoexec.cfg"
 #define AUTOEXEC_CLIENT_FILE "autoexec_client.cfg"
 #define AUTOEXEC_SERVER_FILE "autoexec_server.cfg"
 
-struct CConfiguration
+class CConfig
 {
+public:
 #define MACRO_CONFIG_INT(Name, ScriptName, Def, Min, Max, Save, Desc) int m_##Name;
 #define MACRO_CONFIG_COL(Name, ScriptName, Def, Save, Desc) unsigned m_##Name;
 #define MACRO_CONFIG_STR(Name, ScriptName, Len, Def, Save, Desc) char m_##Name[Len]; // Flawfinder: ignore
@@ -21,7 +23,7 @@ struct CConfiguration
 #undef MACRO_CONFIG_STR
 };
 
-extern CConfiguration g_Config;
+extern CConfig g_Config;
 
 enum
 {
@@ -39,6 +41,38 @@ enum
 	CFGFLAG_NONTEEHISTORIC = 1 << 9,
 	CFGFLAG_COLLIGHT = 1 << 10,
 	CFGFLAG_COLALPHA = 1 << 11,
+};
+
+class CConfigManager : public IConfigManager
+{
+	enum
+	{
+		MAX_CALLBACKS = 16
+	};
+
+	struct CCallback
+	{
+		SAVECALLBACKFUNC m_pfnFunc;
+		void *m_pUserData;
+	};
+
+	class IStorage *m_pStorage;
+	IOHANDLE m_ConfigFile;
+	bool m_Failed;
+	CCallback m_aCallbacks[MAX_CALLBACKS];
+	int m_NumCallbacks;
+
+public:
+	CConfigManager();
+
+	virtual void Init();
+	virtual void Reset();
+	virtual bool Save();
+	virtual CConfig *Values() { return &g_Config; }
+
+	virtual void RegisterCallback(SAVECALLBACKFUNC pfnFunc, void *pUserData);
+
+	virtual void WriteLine(const char *pLine);
 };
 
 #endif

--- a/src/engine/shared/console.cpp
+++ b/src/engine/shared/console.cpp
@@ -971,6 +971,7 @@ CConsole::~CConsole()
 
 void CConsole::Init()
 {
+	m_pConfig = Kernel()->RequestInterface<IConfigManager>()->Values();
 	m_pStorage = Kernel()->RequestInterface<IStorage>();
 
 // TODO: this should disappear

--- a/src/engine/shared/console.h
+++ b/src/engine/shared/console.h
@@ -46,6 +46,7 @@ class CConsole : public IConsole
 	};
 
 	CExecFile *m_pFirstExec;
+	class CConfig *m_pConfig;
 	class IStorage *m_pStorage;
 	int m_AccessLevel;
 

--- a/src/engine/shared/console.h
+++ b/src/engine/shared/console.h
@@ -196,6 +196,7 @@ public:
 	CConsole(int FlagMask);
 	~CConsole();
 
+	virtual void Init();
 	virtual const CCommandInfo *FirstCommandInfo(int AccessLevel, int FlagMask) const;
 	virtual const CCommandInfo *GetCommandInfo(const char *pName, int FlagMask, bool Temp);
 	virtual void PossibleCommands(const char *pStr, int FlagMask, bool Temp, FPossibleCallback pfnCallback, void *pUser);

--- a/src/engine/shared/econ.cpp
+++ b/src/engine/shared/econ.cpp
@@ -59,8 +59,9 @@ void CEcon::ConLogout(IConsole::IResult *pResult, void *pUserData)
 		pThis->m_NetConsole.Drop(pThis->m_UserClientID, "Logout");
 }
 
-void CEcon::Init(IConsole *pConsole, CNetBan *pNetBan)
+void CEcon::Init(CConfig *pConfig, IConsole *pConsole, CNetBan *pNetBan)
 {
+	m_pConfig = pConfig;
 	m_pConsole = pConsole;
 
 	for(auto &Client : m_aClients)

--- a/src/engine/shared/econ.h
+++ b/src/engine/shared/econ.h
@@ -5,6 +5,8 @@
 
 #include <engine/console.h>
 
+class CConfig;
+
 class CEcon
 {
 	enum
@@ -28,6 +30,7 @@ class CEcon
 	};
 	CClient m_aClients[NET_MAX_CONSOLE_CLIENTS];
 
+	CConfig *m_pConfig;
 	IConsole *m_pConsole;
 	CNetConsole m_NetConsole;
 
@@ -45,7 +48,7 @@ class CEcon
 public:
 	IConsole *Console() { return m_pConsole; }
 
-	void Init(IConsole *pConsole, class CNetBan *pNetBan);
+	void Init(CConfig *pConfig, IConsole *pConsole, class CNetBan *pNetBan);
 	void Update();
 	void Send(int ClientID, const char *pLine);
 	void Shutdown();

--- a/src/game/client/component.h
+++ b/src/game/client/component.h
@@ -26,6 +26,7 @@ protected:
 	class CUI *UI() const { return m_pClient->UI(); }
 	class ISound *Sound() const { return m_pClient->Sound(); }
 	class CRenderTools *RenderTools() const { return m_pClient->RenderTools(); }
+	class CConfig *Config() const { return m_pClient->Config(); }
 	class IConsole *Console() const { return m_pClient->Console(); }
 	class IDemoPlayer *DemoPlayer() const { return m_pClient->DemoPlayer(); }
 	class IDemoRecorder *DemoRecorder(int Recorder) const { return m_pClient->DemoRecorder(Recorder); }

--- a/src/game/client/components/binds.cpp
+++ b/src/game/client/components/binds.cpp
@@ -250,9 +250,9 @@ void CBinds::SetDefaults()
 void CBinds::OnConsoleInit()
 {
 	// bindings
-	IConfig *pConfig = Kernel()->RequestInterface<IConfig>();
-	if(pConfig)
-		pConfig->RegisterCallback(ConfigSaveCallback, this);
+	IConfigManager *pConfigManager = Kernel()->RequestInterface<IConfigManager>();
+	if(pConfigManager)
+		pConfigManager->RegisterCallback(ConfigSaveCallback, this);
 
 	Console()->Register("bind", "s[key] r[command]", CFGFLAG_CLIENT, ConBind, this, "Bind key to execute the command");
 	Console()->Register("dump_binds", "?s[key]", CFGFLAG_CLIENT, ConDumpBinds, this, "Print command executed by this keybindind or all binds");
@@ -423,13 +423,13 @@ const char *CBinds::GetKeyBindModifiersName(int Modifier)
 	return aModifier;
 }
 
-void CBinds::ConfigSaveCallback(IConfig *pConfig, void *pUserData)
+void CBinds::ConfigSaveCallback(IConfigManager *pConfigManager, void *pUserData)
 {
 	CBinds *pSelf = (CBinds *)pUserData;
 
 	char aBuffer[256];
 	char *pEnd = aBuffer + sizeof(aBuffer);
-	pConfig->WriteLine("unbindall");
+	pConfigManager->WriteLine("unbindall");
 	for(int i = 0; i < MODIFIER_COMBINATION_COUNT; i++)
 	{
 		for(int j = 0; j < KEY_LAST; j++)
@@ -443,7 +443,7 @@ void CBinds::ConfigSaveCallback(IConfig *pConfig, void *pUserData)
 			str_escape(&pDst, pSelf->m_aapKeyBindings[i][j], pEnd);
 			str_append(aBuffer, "\"", sizeof(aBuffer));
 
-			pConfig->WriteLine(aBuffer);
+			pConfigManager->WriteLine(aBuffer);
 		}
 	}
 }

--- a/src/game/client/components/binds.h
+++ b/src/game/client/components/binds.h
@@ -15,7 +15,7 @@ class CBinds : public CComponent
 	static void ConUnbindAll(IConsole::IResult *pResult, void *pUserData);
 	class IConsole *GetConsole() const { return Console(); }
 
-	static void ConfigSaveCallback(class IConfig *pConfig, void *pUserData);
+	static void ConfigSaveCallback(IConfigManager *pConfigManager, void *pUserData);
 
 public:
 	CBinds();

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -744,8 +744,6 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 	TextRender()->SetCurFont(NULL);
 }
 
-typedef void (*pfnAssignFuncCallback)(CConfiguration *pConfig, int Value);
-
 typedef struct
 {
 	CLocConstString m_Name;

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -84,6 +84,7 @@ class CGameClient : public IGameClient
 	class ITextRender *m_pTextRender;
 	class IClient *m_pClient;
 	class ISound *m_pSound;
+	class CConfig *m_pConfig;
 	class IConsole *m_pConsole;
 	class IStorage *m_pStorage;
 	class IDemoPlayer *m_pDemoPlayer;
@@ -135,6 +136,7 @@ public:
 	class ISound *Sound() const { return m_pSound; }
 	class IInput *Input() const { return m_pInput; }
 	class IStorage *Storage() const { return m_pStorage; }
+	class CConfig *Config() const { return m_pConfig; }
 	class IConsole *Console() { return m_pConsole; }
 	class ITextRender *TextRender() const { return m_pTextRender; }
 	class IDemoPlayer *DemoPlayer() const { return m_pDemoPlayer; }

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -6346,6 +6346,7 @@ void CEditor::Init()
 {
 	m_pInput = Kernel()->RequestInterface<IInput>();
 	m_pClient = Kernel()->RequestInterface<IClient>();
+	m_pConfig = Kernel()->RequestInterface<IConfigManager>()->Values();
 	m_pConsole = Kernel()->RequestInterface<IConsole>();
 	m_pGraphics = Kernel()->RequestInterface<IGraphics>();
 	m_pTextRender = Kernel()->RequestInterface<ITextRender>();

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -631,6 +631,7 @@ class CEditor : public IEditor
 {
 	class IInput *m_pInput;
 	class IClient *m_pClient;
+	class CConfig *m_pConfig;
 	class IConsole *m_pConsole;
 	class IGraphics *m_pGraphics;
 	class ITextRender *m_pTextRender;
@@ -642,6 +643,7 @@ class CEditor : public IEditor
 public:
 	class IInput *Input() { return m_pInput; };
 	class IClient *Client() { return m_pClient; };
+	class CConfig *Config() { return m_pConfig; }
 	class IConsole *Console() { return m_pConsole; };
 	class IGraphics *Graphics() { return m_pGraphics; };
 	class ISound *Sound() { return m_pSound; }

--- a/src/game/server/alloc.h
+++ b/src/game/server/alloc.h
@@ -1,0 +1,62 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#ifndef GAME_SERVER_ALLOC_H
+#define GAME_SERVER_ALLOC_H
+
+#include <new>
+
+#include <base/system.h>
+
+#define MACRO_ALLOC_HEAP() \
+public: \
+	void *operator new(size_t Size) \
+	{ \
+		void *p = malloc(Size); \
+		mem_zero(p, Size); \
+		return p; \
+	} \
+	void operator delete(void *pPtr) \
+	{ \
+		free(pPtr); \
+	} \
+\
+private:
+
+#define MACRO_ALLOC_POOL_ID() \
+public: \
+	void *operator new(size_t Size, int id); \
+	void operator delete(void *p, int id); \
+	void operator delete(void *p); /* NOLINT(misc-new-delete-overloads) */ \
+\
+private:
+
+#define MACRO_ALLOC_POOL_ID_IMPL(POOLTYPE, PoolSize) \
+	static char ms_PoolData##POOLTYPE[PoolSize][sizeof(POOLTYPE)] = {{0}}; \
+	static int ms_PoolUsed##POOLTYPE[PoolSize] = {0}; \
+	void *POOLTYPE::operator new(size_t Size, int id) \
+	{ \
+		dbg_assert(sizeof(POOLTYPE) == Size, "size error"); \
+		dbg_assert(!ms_PoolUsed##POOLTYPE[id], "already used"); \
+		/*dbg_msg("pool", "++ %s %d", #POOLTYPE, id);*/ \
+		ms_PoolUsed##POOLTYPE[id] = 1; \
+		mem_zero(ms_PoolData##POOLTYPE[id], Size); \
+		return ms_PoolData##POOLTYPE[id]; \
+	} \
+	void POOLTYPE::operator delete(void *p, int id) \
+	{ \
+		dbg_assert(ms_PoolUsed##POOLTYPE[id], "not used"); \
+		dbg_assert(id == (POOLTYPE *)p - (POOLTYPE *)ms_PoolData##POOLTYPE, "invalid id"); \
+		/*dbg_msg("pool", "-- %s %d", #POOLTYPE, id);*/ \
+		ms_PoolUsed##POOLTYPE[id] = 0; \
+		mem_zero(ms_PoolData##POOLTYPE[id], sizeof(POOLTYPE)); \
+	} \
+	void POOLTYPE::operator delete(void *p) /* NOLINT(misc-new-delete-overloads) */ \
+	{ \
+		int id = (POOLTYPE *)p - (POOLTYPE *)ms_PoolData##POOLTYPE; \
+		dbg_assert(ms_PoolUsed##POOLTYPE[id], "not used"); \
+		/*dbg_msg("pool", "-- %s %d", #POOLTYPE, id);*/ \
+		ms_PoolUsed##POOLTYPE[id] = 0; \
+		mem_zero(ms_PoolData##POOLTYPE[id], sizeof(POOLTYPE)); \
+	}
+
+#endif

--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -8,6 +8,7 @@
 #include <game/version.h>
 
 #include "entities/character.h"
+#include "player.h"
 
 bool CheckClientID(int ClientID);
 

--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -7,6 +7,8 @@
 #include <game/server/teams.h>
 #include <game/version.h>
 
+#include "entities/character.h"
+
 bool CheckClientID(int ClientID);
 
 void CGameContext::ConCredits(IConsole::IResult *pResult, void *pUserData)

--- a/src/game/server/ddracecommands.cpp
+++ b/src/game/server/ddracecommands.cpp
@@ -3,6 +3,7 @@
 #include <engine/shared/config.h>
 #include <game/server/entities/character.h>
 #include <game/server/gamemodes/DDRace.h>
+#include <game/server/player.h>
 #include <game/server/save.h>
 #include <game/server/teams.h>
 #include <game/version.h>

--- a/src/game/server/ddracecommands.cpp
+++ b/src/game/server/ddracecommands.cpp
@@ -1,6 +1,7 @@
 /* (c) Shereef Marzouk. See "licence DDRace.txt" and the readme.txt in the root of the distribution for more information. */
 #include "gamecontext.h"
 #include <engine/shared/config.h>
+#include <game/server/entities/character.h>
 #include <game/server/gamemodes/DDRace.h>
 #include <game/server/save.h>
 #include <game/server/teams.h>

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -2,6 +2,7 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include <antibot/antibot_data.h>
 #include <engine/shared/config.h>
+#include <game/generated/server_data.h>
 #include <game/mapitems.h>
 #include <game/server/gamecontext.h>
 #include <game/server/player.h>

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -4,6 +4,7 @@
 #include <engine/shared/config.h>
 #include <game/mapitems.h>
 #include <game/server/gamecontext.h>
+#include <game/server/player.h>
 #include <new>
 
 #include "character.h"

--- a/src/game/server/entities/character.h
+++ b/src/game/server/entities/character.h
@@ -17,13 +17,6 @@ struct CAntibotCharacterData;
 
 enum
 {
-	WEAPON_GAME = -3, // team switching etc
-	WEAPON_SELF = -2, // console kill command
-	WEAPON_WORLD = -1, // death tiles etc
-};
-
-enum
-{
 	FAKETUNE_FREEZE = 1,
 	FAKETUNE_SOLO = 2,
 	FAKETUNE_NOJUMP = 4,

--- a/src/game/server/entities/character.h
+++ b/src/game/server/entities/character.h
@@ -4,12 +4,8 @@
 #define GAME_SERVER_ENTITIES_CHARACTER_H
 
 #include <engine/antibot.h>
-#include <game/generated/protocol.h>
-#include <game/generated/server_data.h>
 #include <game/server/entity.h>
 #include <game/server/save.h>
-
-#include <game/gamecore.h>
 
 class CAntibot;
 class CGameTeams;

--- a/src/game/server/entities/door.cpp
+++ b/src/game/server/entities/door.cpp
@@ -3,6 +3,7 @@
 #include <game/generated/protocol.h>
 #include <game/server/gamecontext.h>
 #include <game/server/gamemodes/DDRace.h>
+#include <game/server/player.h>
 
 #include "character.h"
 #include "door.h"

--- a/src/game/server/entities/door.cpp
+++ b/src/game/server/entities/door.cpp
@@ -66,7 +66,7 @@ void CDoor::Snap(int SnappingClient)
 		return;
 
 	CNetObj_Laser *pObj = static_cast<CNetObj_Laser *>(Server()->SnapNewItem(
-		NETOBJTYPE_LASER, m_ID, sizeof(CNetObj_Laser)));
+		NETOBJTYPE_LASER, GetID(), sizeof(CNetObj_Laser)));
 
 	if(!pObj)
 		return;

--- a/src/game/server/entities/door.cpp
+++ b/src/game/server/entities/door.cpp
@@ -4,6 +4,7 @@
 #include <game/server/gamecontext.h>
 #include <game/server/gamemodes/DDRace.h>
 
+#include "character.h"
 #include "door.h"
 
 CDoor::CDoor(CGameWorld *pGameWorld, vec2 Pos, float Rotation, int Length,

--- a/src/game/server/entities/dragger.cpp
+++ b/src/game/server/entities/dragger.cpp
@@ -6,6 +6,7 @@
 #include <game/generated/protocol.h>
 #include <game/server/gamecontext.h>
 #include <game/server/gamemodes/DDRace.h>
+#include <game/server/player.h>
 #include <game/server/teams.h>
 
 #include "character.h"

--- a/src/game/server/entities/dragger.cpp
+++ b/src/game/server/entities/dragger.cpp
@@ -225,7 +225,7 @@ void CDragger::Snap(int SnappingClient)
 		if(i == -1)
 		{
 			obj = static_cast<CNetObj_Laser *>(Server()->SnapNewItem(
-				NETOBJTYPE_LASER, m_ID, sizeof(CNetObj_Laser)));
+				NETOBJTYPE_LASER, GetID(), sizeof(CNetObj_Laser)));
 		}
 		else
 		{

--- a/src/game/server/entities/dragger.cpp
+++ b/src/game/server/entities/dragger.cpp
@@ -8,6 +8,8 @@
 #include <game/server/gamemodes/DDRace.h>
 #include <game/server/teams.h>
 
+#include "character.h"
+
 CDragger::CDragger(CGameWorld *pGameWorld, vec2 Pos, float Strength, bool NW,
 	int CaughtTeam, int Layer, int Number) :
 	CEntity(pGameWorld, CGameWorld::ENTTYPE_LASER)

--- a/src/game/server/entities/gun.cpp
+++ b/src/game/server/entities/gun.cpp
@@ -5,6 +5,7 @@
 #include <game/server/gamecontext.h>
 #include <game/server/teams.h>
 
+#include "character.h"
 #include "gun.h"
 #include "plasma.h"
 

--- a/src/game/server/entities/gun.cpp
+++ b/src/game/server/entities/gun.cpp
@@ -3,6 +3,7 @@
 #include <engine/shared/config.h>
 #include <game/generated/protocol.h>
 #include <game/server/gamecontext.h>
+#include <game/server/player.h>
 #include <game/server/teams.h>
 
 #include "character.h"

--- a/src/game/server/entities/gun.cpp
+++ b/src/game/server/entities/gun.cpp
@@ -123,7 +123,7 @@ void CGun::Snap(int SnappingClient)
 	int Tick = (Server()->Tick() % Server()->TickSpeed()) % 11;
 	if(Char && Char->IsAlive() && (m_Layer == LAYER_SWITCH && !GameServer()->Collision()->m_pSwitchers[m_Number].m_Status[Char->Team()]) && (!Tick))
 		return;
-	CNetObj_Laser *pObj = static_cast<CNetObj_Laser *>(Server()->SnapNewItem(NETOBJTYPE_LASER, m_ID, sizeof(CNetObj_Laser)));
+	CNetObj_Laser *pObj = static_cast<CNetObj_Laser *>(Server()->SnapNewItem(NETOBJTYPE_LASER, GetID(), sizeof(CNetObj_Laser)));
 
 	if(!pObj)
 		return;

--- a/src/game/server/entities/laser.cpp
+++ b/src/game/server/entities/laser.cpp
@@ -8,6 +8,8 @@
 #include <engine/shared/config.h>
 #include <game/server/teams.h>
 
+#include "character.h"
+
 CLaser::CLaser(CGameWorld *pGameWorld, vec2 Pos, vec2 Direction, float StartEnergy, int Owner, int Type) :
 	CEntity(pGameWorld, CGameWorld::ENTTYPE_LASER)
 {

--- a/src/game/server/entities/laser.cpp
+++ b/src/game/server/entities/laser.cpp
@@ -275,7 +275,7 @@ void CLaser::Snap(int SnappingClient)
 
 	if(!CmaskIsSet(TeamMask, SnappingClient))
 		return;
-	CNetObj_Laser *pObj = static_cast<CNetObj_Laser *>(Server()->SnapNewItem(NETOBJTYPE_LASER, m_ID, sizeof(CNetObj_Laser)));
+	CNetObj_Laser *pObj = static_cast<CNetObj_Laser *>(Server()->SnapNewItem(NETOBJTYPE_LASER, GetID(), sizeof(CNetObj_Laser)));
 	if(!pObj)
 		return;
 

--- a/src/game/server/entities/light.cpp
+++ b/src/game/server/entities/light.cpp
@@ -115,7 +115,7 @@ void CLight::Snap(int SnappingClient)
 		return;
 
 	CNetObj_Laser *pObj = static_cast<CNetObj_Laser *>(Server()->SnapNewItem(
-		NETOBJTYPE_LASER, m_ID, sizeof(CNetObj_Laser)));
+		NETOBJTYPE_LASER, GetID(), sizeof(CNetObj_Laser)));
 
 	if(!pObj)
 		return;

--- a/src/game/server/entities/light.cpp
+++ b/src/game/server/entities/light.cpp
@@ -6,6 +6,8 @@
 #include <game/mapitems.h>
 #include <game/server/gamecontext.h>
 
+#include "character.h"
+
 CLight::CLight(CGameWorld *pGameWorld, vec2 Pos, float Rotation, int Length,
 	int Layer, int Number) :
 	CEntity(pGameWorld, CGameWorld::ENTTYPE_LASER)

--- a/src/game/server/entities/light.cpp
+++ b/src/game/server/entities/light.cpp
@@ -5,6 +5,7 @@
 #include <game/generated/protocol.h>
 #include <game/mapitems.h>
 #include <game/server/gamecontext.h>
+#include <game/server/player.h>
 
 #include "character.h"
 

--- a/src/game/server/entities/pickup.cpp
+++ b/src/game/server/entities/pickup.cpp
@@ -6,6 +6,8 @@
 
 #include <game/server/teams.h>
 
+#include "character.h"
+
 CPickup::CPickup(CGameWorld *pGameWorld, int Type, int SubType, int Layer, int Number) :
 	CEntity(pGameWorld, CGameWorld::ENTTYPE_PICKUP)
 {

--- a/src/game/server/entities/pickup.cpp
+++ b/src/game/server/entities/pickup.cpp
@@ -3,6 +3,7 @@
 #include "pickup.h"
 #include <game/generated/protocol.h>
 #include <game/server/gamecontext.h>
+#include <game/server/player.h>
 
 #include <game/server/teams.h>
 

--- a/src/game/server/entities/pickup.cpp
+++ b/src/game/server/entities/pickup.cpp
@@ -166,7 +166,7 @@ void CPickup::Snap(int SnappingClient)
 		return;
 
 	int Size = Server()->IsSixup(SnappingClient) ? 3 * 4 : sizeof(CNetObj_Pickup);
-	CNetObj_Pickup *pP = static_cast<CNetObj_Pickup *>(Server()->SnapNewItem(NETOBJTYPE_PICKUP, m_ID, Size));
+	CNetObj_Pickup *pP = static_cast<CNetObj_Pickup *>(Server()->SnapNewItem(NETOBJTYPE_PICKUP, GetID(), Size));
 	if(!pP)
 		return;
 

--- a/src/game/server/entities/pickup.cpp
+++ b/src/game/server/entities/pickup.cpp
@@ -10,11 +10,10 @@
 #include "character.h"
 
 CPickup::CPickup(CGameWorld *pGameWorld, int Type, int SubType, int Layer, int Number) :
-	CEntity(pGameWorld, CGameWorld::ENTTYPE_PICKUP)
+	CEntity(pGameWorld, CGameWorld::ENTTYPE_PICKUP, vec2(0, 0), PickupPhysSize)
 {
 	m_Type = Type;
 	m_Subtype = SubType;
-	m_ProximityRadius = PickupPhysSize;
 
 	m_Layer = Layer;
 	m_Number = Number;

--- a/src/game/server/entities/plasma.cpp
+++ b/src/game/server/entities/plasma.cpp
@@ -104,7 +104,7 @@ void CPlasma::Snap(int SnappingClient)
 		return;
 
 	CNetObj_Laser *pObj = static_cast<CNetObj_Laser *>(Server()->SnapNewItem(
-		NETOBJTYPE_LASER, m_ID, sizeof(CNetObj_Laser)));
+		NETOBJTYPE_LASER, GetID(), sizeof(CNetObj_Laser)));
 
 	if(!pObj)
 		return;

--- a/src/game/server/entities/plasma.cpp
+++ b/src/game/server/entities/plasma.cpp
@@ -5,6 +5,7 @@
 #include <game/generated/protocol.h>
 #include <game/server/gamecontext.h>
 #include <game/server/gamemodes/DDRace.h>
+#include <game/server/player.h>
 #include <game/server/teams.h>
 
 #include "character.h"

--- a/src/game/server/entities/plasma.cpp
+++ b/src/game/server/entities/plasma.cpp
@@ -7,6 +7,8 @@
 #include <game/server/gamemodes/DDRace.h>
 #include <game/server/teams.h>
 
+#include "character.h"
+
 const float PLASMA_ACCEL = 1.1f;
 
 CPlasma::CPlasma(CGameWorld *pGameWorld, vec2 Pos, vec2 Dir, bool Freeze,

--- a/src/game/server/entities/projectile.cpp
+++ b/src/game/server/entities/projectile.cpp
@@ -8,6 +8,8 @@
 #include <engine/shared/config.h>
 #include <game/server/teams.h>
 
+#include "character.h"
+
 CProjectile::CProjectile(
 	CGameWorld *pGameWorld,
 	int Type,

--- a/src/game/server/entities/projectile.cpp
+++ b/src/game/server/entities/projectile.cpp
@@ -4,6 +4,7 @@
 #include <game/generated/protocol.h>
 #include <game/server/gamecontext.h>
 #include <game/server/gamemodes/DDRace.h>
+#include <game/server/player.h>
 
 #include <engine/shared/config.h>
 #include <game/server/teams.h>

--- a/src/game/server/entities/projectile.cpp
+++ b/src/game/server/entities/projectile.cpp
@@ -319,7 +319,7 @@ void CProjectile::Snap(int SnappingClient)
 	if(m_Owner != -1 && !CmaskIsSet(TeamMask, SnappingClient))
 		return;
 
-	CNetObj_Projectile *pProj = static_cast<CNetObj_Projectile *>(Server()->SnapNewItem(NETOBJTYPE_PROJECTILE, m_ID, sizeof(CNetObj_Projectile)));
+	CNetObj_Projectile *pProj = static_cast<CNetObj_Projectile *>(Server()->SnapNewItem(NETOBJTYPE_PROJECTILE, GetID(), sizeof(CNetObj_Projectile)));
 	if(pProj)
 	{
 		if(SnappingClient > -1 && GameServer()->m_apPlayers[SnappingClient] && GameServer()->m_apPlayers[SnappingClient]->GetClientVersion() >= VERSION_DDNET_ANTIPING_PROJECTILE)

--- a/src/game/server/entity.cpp
+++ b/src/game/server/entity.cpp
@@ -3,6 +3,7 @@
 
 #include "entity.h"
 #include "gamecontext.h"
+#include "player.h"
 
 //////////////////////////////////////////////////
 // Entity

--- a/src/game/server/entity.cpp
+++ b/src/game/server/entity.cpp
@@ -8,13 +8,13 @@
 //////////////////////////////////////////////////
 // Entity
 //////////////////////////////////////////////////
-CEntity::CEntity(CGameWorld *pGameWorld, int ObjType)
+CEntity::CEntity(CGameWorld *pGameWorld, int ObjType, vec2 Pos, int ProximityRadius)
 {
 	m_pGameWorld = pGameWorld;
 
 	m_ObjType = ObjType;
-	m_Pos = vec2(0, 0);
-	m_ProximityRadius = 0;
+	m_Pos = Pos;
+	m_ProximityRadius = ProximityRadius;
 
 	m_MarkedForDestroy = false;
 	m_ID = Server()->SnapNewID();

--- a/src/game/server/entity.h
+++ b/src/game/server/entity.h
@@ -4,9 +4,9 @@
 #define GAME_SERVER_ENTITY_H
 
 #include <base/vmath.h>
-#include <game/server/gameworld.h>
 
 #include "alloc.h"
+#include "gameworld.h"
 
 /*
 	Class: Entity
@@ -16,50 +16,86 @@ class CEntity
 {
 	MACRO_ALLOC_HEAP()
 
+private:
 	friend class CGameWorld; // entity list handling
 	CEntity *m_pPrevTypeEntity;
 	CEntity *m_pNextTypeEntity;
 
 protected:
+	/* Identity */
 	class CGameWorld *m_pGameWorld;
-	bool m_MarkedForDestroy;
+
 	int m_ID;
 	int m_ObjType;
 
-public:
-	CEntity(CGameWorld *pGameWorld, int Objtype);
-	virtual ~CEntity();
+	/*
+		Variable: m_ProximityRadius
+			Contains the physical size of the entity.
+	*/
+	float m_ProximityRadius;
 
-	class CGameWorld *GameWorld() { return m_pGameWorld; }
-	class CGameContext *GameServer() { return GameWorld()->GameServer(); }
-	class IServer *Server() { return GameWorld()->Server(); }
+	/* State */
+	bool m_MarkedForDestroy;
 
-	CEntity *TypeNext() { return m_pNextTypeEntity; }
-	CEntity *TypePrev() { return m_pPrevTypeEntity; }
+public: // TODO: Maybe make protected
+	/* State */
 
 	/*
-		Function: destroy
+		Variable: m_Pos
+			Contains the current posititon of the entity.
+	*/
+	vec2 m_Pos;
+
+	/* Getters */
+	int GetID() const { return m_ID; }
+
+public:
+	/* Constructor */
+	CEntity(CGameWorld *pGameWorld, int Objtype, vec2 Pos = vec2(0, 0), int ProximityRadius = 0);
+
+	/* Destructor */
+	virtual ~CEntity();
+
+	/* Objects */
+	class CGameWorld *GameWorld() { return m_pGameWorld; }
+	class CGameContext *GameServer() { return m_pGameWorld->GameServer(); }
+	class IServer *Server() { return m_pGameWorld->Server(); }
+
+	/* Getters */
+	CEntity *TypeNext() { return m_pNextTypeEntity; }
+	CEntity *TypePrev() { return m_pPrevTypeEntity; }
+	const vec2 &GetPos() const { return m_Pos; }
+	float GetProximityRadius() const { return m_ProximityRadius; }
+	bool IsMarkedForDestroy() const { return m_MarkedForDestroy; }
+
+	/* Setters */
+	void MarkForDestroy() { m_MarkedForDestroy = true; }
+
+	/* Other functions */
+
+	/*
+		Function: Destroy
 			Destroys the entity.
 	*/
 	virtual void Destroy() { delete this; }
 
 	/*
-		Function: reset
+		Function: Reset
 			Called when the game resets the map. Puts the entity
-			back to it's starting state or perhaps destroys it.
+			back to its starting state or perhaps destroys it.
 	*/
 	virtual void Reset() {}
 
 	/*
-		Function: tick
-			Called progress the entity to the next tick. Updates
-			and moves the entity to it's new state and position.
+		Function: Tick
+			Called to progress the entity to the next tick. Updates
+			and moves the entity to its new state and position.
 	*/
 	virtual void Tick() {}
 
 	/*
-		Function: tick_defered
-			Called after all entities tick() function has been called.
+		Function: TickDefered
+			Called after all entities Tick() function has been called.
 	*/
 	virtual void TickDefered() {}
 
@@ -70,12 +106,12 @@ public:
 	virtual void TickPaused() {}
 
 	/*
-		Function: snap
+		Function: Snap
 			Called when a new snapshot is being generated for a specific
 			client.
 
 		Arguments:
-			snapping_client - ID of the client which snapshot is
+			SnappingClient - ID of the client which snapshot is
 				being generated. Could be -1 to create a complete
 				snapshot of everything in the game for demo
 				recording.
@@ -88,7 +124,7 @@ public:
 			entity.
 
 		Arguments:
-			snapping_client - ID of the client which snapshot is
+			SnappingClient - ID of the client which snapshot is
 				being generated. Could be -1 to create a complete
 				snapshot of everything in the game for demo
 				recording.
@@ -100,18 +136,6 @@ public:
 	virtual int NetworkClipped(int SnappingClient, vec2 CheckPos);
 
 	bool GameLayerClipped(vec2 CheckPos);
-
-	/*
-		Variable: proximity_radius
-			Contains the physical size of the entity.
-	*/
-	float m_ProximityRadius;
-
-	/*
-		Variable: pos
-			Contains the current posititon of the entity.
-	*/
-	vec2 m_Pos;
 
 	// DDRace
 

--- a/src/game/server/entity.h
+++ b/src/game/server/entity.h
@@ -57,6 +57,7 @@ public:
 
 	/* Objects */
 	class CGameWorld *GameWorld() { return m_pGameWorld; }
+	class CConfig *Config() { return m_pGameWorld->Config(); }
 	class CGameContext *GameServer() { return m_pGameWorld->GameServer(); }
 	class IServer *Server() { return m_pGameWorld->Server(); }
 

--- a/src/game/server/entity.h
+++ b/src/game/server/entity.h
@@ -5,59 +5,8 @@
 
 #include <base/vmath.h>
 #include <game/server/gameworld.h>
-#include <new>
 
-#define MACRO_ALLOC_HEAP() \
-public: \
-	void *operator new(size_t Size) \
-	{ \
-		void *p = malloc(Size); \
-		mem_zero(p, Size); \
-		return p; \
-	} \
-	void operator delete(void *pPtr) \
-	{ \
-		free(pPtr); \
-	} \
-\
-private:
-
-#define MACRO_ALLOC_POOL_ID() \
-public: \
-	void *operator new(size_t Size, int id); \
-	void operator delete(void *p, int id); \
-	void operator delete(void *p); /* NOLINT(misc-new-delete-overloads) */ \
-\
-private:
-
-#define MACRO_ALLOC_POOL_ID_IMPL(POOLTYPE, PoolSize) \
-	static char ms_PoolData##POOLTYPE[PoolSize][sizeof(POOLTYPE)] = {{0}}; \
-	static int ms_PoolUsed##POOLTYPE[PoolSize] = {0}; \
-	void *POOLTYPE::operator new(size_t Size, int id) \
-	{ \
-		dbg_assert(sizeof(POOLTYPE) == Size, "size error"); \
-		dbg_assert(!ms_PoolUsed##POOLTYPE[id], "already used"); \
-		/*dbg_msg("pool", "++ %s %d", #POOLTYPE, id);*/ \
-		ms_PoolUsed##POOLTYPE[id] = 1; \
-		mem_zero(ms_PoolData##POOLTYPE[id], Size); \
-		return ms_PoolData##POOLTYPE[id]; \
-	} \
-	void POOLTYPE::operator delete(void *p, int id) \
-	{ \
-		dbg_assert(ms_PoolUsed##POOLTYPE[id], "not used"); \
-		dbg_assert(id == (POOLTYPE *)p - (POOLTYPE *)ms_PoolData##POOLTYPE, "invalid id"); \
-		/*dbg_msg("pool", "-- %s %d", #POOLTYPE, id);*/ \
-		ms_PoolUsed##POOLTYPE[id] = 0; \
-		mem_zero(ms_PoolData##POOLTYPE[id], sizeof(POOLTYPE)); \
-	} \
-	void POOLTYPE::operator delete(void *p) /* NOLINT(misc-new-delete-overloads) */ \
-	{ \
-		int id = (POOLTYPE *)p - (POOLTYPE *)ms_PoolData##POOLTYPE; \
-		dbg_assert(ms_PoolUsed##POOLTYPE[id], "not used"); \
-		/*dbg_msg("pool", "-- %s %d", #POOLTYPE, id);*/ \
-		ms_PoolUsed##POOLTYPE[id] = 0; \
-		mem_zero(ms_PoolData##POOLTYPE[id], sizeof(POOLTYPE)); \
-	}
+#include "alloc.h"
 
 /*
 	Class: Entity

--- a/src/game/server/entity.h
+++ b/src/game/server/entity.h
@@ -21,7 +21,6 @@ private:
 	CEntity *m_pPrevTypeEntity;
 	CEntity *m_pNextTypeEntity;
 
-protected:
 	/* Identity */
 	class CGameWorld *m_pGameWorld;
 

--- a/src/game/server/eventhandler.cpp
+++ b/src/game/server/eventhandler.cpp
@@ -2,6 +2,7 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include "eventhandler.h"
 #include "gamecontext.h"
+#include "player.h"
 
 //////////////////////////////////////////////////
 // Event handler

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -3006,6 +3006,7 @@ void CGameContext::ConchainSpecialMotdupdate(IConsole::IResult *pResult, void *p
 void CGameContext::OnConsoleInit()
 {
 	m_pServer = Kernel()->RequestInterface<IServer>();
+	m_pConfig = Kernel()->RequestInterface<IConfigManager>()->Values();
 	m_pConsole = Kernel()->RequestInterface<IConsole>();
 	m_pEngine = Kernel()->RequestInterface<IEngine>();
 	m_pStorage = Kernel()->RequestInterface<IStorage>();
@@ -3052,6 +3053,7 @@ void CGameContext::OnConsoleInit()
 void CGameContext::OnInit(/*class IKernel *pKernel*/)
 {
 	m_pServer = Kernel()->RequestInterface<IServer>();
+	m_pConfig = Kernel()->RequestInterface<IConfigManager>()->Values();
 	m_pConsole = Kernel()->RequestInterface<IConsole>();
 	m_pEngine = Kernel()->RequestInterface<IEngine>();
 	m_pStorage = Kernel()->RequestInterface<IStorage>();

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -25,6 +25,7 @@
 
 #include "entities/character.h"
 #include "gamemodes/DDRace.h"
+#include "player.h"
 #include "score.h"
 
 enum

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -13,11 +13,11 @@
 #include <engine/shared/config.h>
 #include <engine/shared/datafile.h>
 #include <engine/shared/linereader.h>
+#include <engine/shared/memheap.h>
 #include <engine/storage.h>
 #include <game/collision.h>
 #include <game/gamecore.h>
 #include <game/version.h>
-#include <new>
 #include <string.h>
 
 #include <game/generated/protocol7.h>

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -23,6 +23,7 @@
 #include <game/generated/protocol7.h>
 #include <game/generated/protocolglue.h>
 
+#include "entities/character.h"
 #include "gamemodes/DDRace.h"
 #include "score.h"
 

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -469,6 +469,28 @@ void CGameContext::SendWeaponPickup(int ClientID, int Weapon)
 	Server()->SendPackMsg(&Msg, MSGFLAG_VITAL, ClientID);
 }
 
+void CGameContext::SendMotd(int ClientID)
+{
+	CNetMsg_Sv_Motd Msg;
+	Msg.m_pMessage = g_Config.m_SvMotd;
+	Server()->SendPackMsg(&Msg, MSGFLAG_VITAL, ClientID);
+}
+
+void CGameContext::SendSettings(int ClientID)
+{
+	if(Server()->IsSixup(ClientID))
+	{
+		protocol7::CNetMsg_Sv_ServerSettings Msg;
+		Msg.m_KickVote = g_Config.m_SvVoteKick;
+		Msg.m_KickMin = g_Config.m_SvVoteKickMin;
+		Msg.m_SpecVote = g_Config.m_SvVoteSpectate;
+		Msg.m_TeamLock = 0;
+		Msg.m_TeamBalance = 0;
+		Msg.m_PlayerSlots = g_Config.m_SvMaxClients - g_Config.m_SvSpectatorSlots;
+		Server()->SendPackMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_NORECORD, ClientID);
+	}
+}
+
 void CGameContext::SendBroadcast(const char *pText, int ClientID, bool IsImportant)
 {
 	CNetMsg_Sv_Broadcast Msg;
@@ -1361,23 +1383,8 @@ void CGameContext::OnClientConnected(int ClientID)
 	}
 #endif
 
-	// send motd
-	CNetMsg_Sv_Motd Msg;
-	Msg.m_pMessage = g_Config.m_SvMotd;
-	Server()->SendPackMsg(&Msg, MSGFLAG_VITAL, ClientID);
-
-	//send sixup settings
-	if(Server()->IsSixup(ClientID))
-	{
-		protocol7::CNetMsg_Sv_ServerSettings Msg;
-		Msg.m_KickVote = g_Config.m_SvVoteKick;
-		Msg.m_KickMin = g_Config.m_SvVoteKickMin;
-		Msg.m_SpecVote = g_Config.m_SvVoteSpectate;
-		Msg.m_TeamLock = 0;
-		Msg.m_TeamBalance = 0;
-		Msg.m_PlayerSlots = g_Config.m_SvMaxClients - g_Config.m_SvSpectatorSlots;
-		Server()->SendPackMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_NORECORD, ClientID);
-	}
+	SendMotd(ClientID);
+	SendSettings(ClientID);
 
 	Server()->ExpireServerInfo();
 }
@@ -2989,12 +2996,8 @@ void CGameContext::ConchainSpecialMotdupdate(IConsole::IResult *pResult, void *p
 	pfnCallback(pResult, pCallbackUserData);
 	if(pResult->NumArguments())
 	{
-		CNetMsg_Sv_Motd Msg;
-		Msg.m_pMessage = g_Config.m_SvMotd;
 		CGameContext *pSelf = (CGameContext *)pUserData;
-		for(int i = 0; i < MAX_CLIENTS; ++i)
-			if(pSelf->m_apPlayers[i])
-				pSelf->Server()->SendPackMsg(&Msg, MSGFLAG_VITAL, i);
+		pSelf->SendMotd(-1);
 	}
 }
 

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -56,6 +56,7 @@ enum
 	NUM_TUNEZONES = 256
 };
 
+class CConfig;
 class CHeap;
 class CPlayer;
 class CScore;
@@ -69,6 +70,7 @@ struct CScoreRandomMapResult;
 class CGameContext : public IGameServer
 {
 	IServer *m_pServer;
+	CConfig *m_pConfig;
 	IConsole *m_pConsole;
 	IEngine *m_pEngine;
 	IStorage *m_pStorage;
@@ -131,6 +133,7 @@ class CGameContext : public IGameServer
 
 public:
 	IServer *Server() const { return m_pServer; }
+	CConfig *Config() { return m_pConfig; }
 	IConsole *Console() { return m_pConsole; }
 	IEngine *Engine() { return m_pEngine; }
 	IStorage *Storage() { return m_pStorage; }

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -219,6 +219,8 @@ public:
 	void SendChat(int ClientID, int Team, const char *pText, int SpamProtectionClientID = -1, int Flags = CHAT_SIX | CHAT_SIXUP);
 	void SendEmoticon(int ClientID, int Emoticon);
 	void SendWeaponPickup(int ClientID, int Weapon);
+	void SendMotd(int ClientID);
+	void SendSettings(int ClientID);
 	void SendBroadcast(const char *pText, int ClientID, bool IsImportant = true);
 
 	void List(int ClientID, const char *filter);

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -6,7 +6,6 @@
 #include <engine/antibot.h>
 #include <engine/console.h>
 #include <engine/server.h>
-#include <engine/shared/memheap.h>
 
 #include <game/layers.h>
 #include <game/mapbugs.h>
@@ -16,7 +15,7 @@
 #include <base/tl/string.h>
 
 #include "eventhandler.h"
-#include "gamecontroller.h"
+//#include "gamecontroller.h"
 #include "gameworld.h"
 #include "teehistorian.h"
 
@@ -57,8 +56,11 @@ enum
 	NUM_TUNEZONES = 256
 };
 
+class CHeap;
+class CPlayer;
 class CScore;
 class IConsole;
+class IGameController;
 class IEngine;
 class IStorage;
 struct CAntibotData;

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -18,7 +18,6 @@
 #include "eventhandler.h"
 #include "gamecontroller.h"
 #include "gameworld.h"
-#include "player.h"
 #include "teehistorian.h"
 
 #include <memory>

--- a/src/game/server/gamecontroller.cpp
+++ b/src/game/server/gamecontroller.cpp
@@ -22,6 +22,7 @@
 IGameController::IGameController(class CGameContext *pGameServer)
 {
 	m_pGameServer = pGameServer;
+	m_pConfig = m_pGameServer->Config();
 	m_pServer = m_pGameServer->Server();
 	m_pGameType = "unknown";
 

--- a/src/game/server/gamecontroller.cpp
+++ b/src/game/server/gamecontroller.cpp
@@ -83,7 +83,7 @@ void IGameController::EvaluateSpawnType(CSpawnEval *pEval, int Type)
 				break;
 			for(int c = 0; c < Num; ++c)
 				if(GameServer()->Collision()->CheckPoint(m_aaSpawnPoints[Type][i] + Positions[Index]) ||
-					distance(aEnts[c]->m_Pos, m_aaSpawnPoints[Type][i] + Positions[Index]) <= aEnts[c]->m_ProximityRadius)
+					distance(aEnts[c]->m_Pos, m_aaSpawnPoints[Type][i] + Positions[Index]) <= aEnts[c]->GetProximityRadius())
 				{
 					Result = -1;
 					break;

--- a/src/game/server/gamecontroller.cpp
+++ b/src/game/server/gamecontroller.cpp
@@ -9,6 +9,7 @@
 #include "entities/pickup.h"
 #include "gamecontext.h"
 #include "gamecontroller.h"
+#include "player.h"
 
 #include "entities/door.h"
 #include "entities/dragger.h"

--- a/src/game/server/gamecontroller.cpp
+++ b/src/game/server/gamecontroller.cpp
@@ -5,6 +5,7 @@
 
 #include <game/generated/protocol.h>
 
+#include "entities/character.h"
 #include "entities/pickup.h"
 #include "gamecontext.h"
 #include "gamecontroller.h"

--- a/src/game/server/gamecontroller.h
+++ b/src/game/server/gamecontroller.h
@@ -29,10 +29,12 @@ class IGameController
 	int m_aNumSpawnPoints[3];
 
 	class CGameContext *m_pGameServer;
+	class CConfig *m_pConfig;
 	class IServer *m_pServer;
 
 protected:
 	CGameContext *GameServer() const { return m_pGameServer; }
+	CConfig *Config() { return m_pConfig; }
 	IServer *Server() const { return m_pServer; }
 
 	struct CSpawnEval

--- a/src/game/server/gameworld.cpp
+++ b/src/game/server/gameworld.cpp
@@ -5,6 +5,7 @@
 #include "entities/character.h"
 #include "entity.h"
 #include "gamecontext.h"
+#include "player.h"
 #include <algorithm>
 #include <engine/shared/config.h>
 #include <utility>

--- a/src/game/server/gameworld.cpp
+++ b/src/game/server/gameworld.cpp
@@ -16,6 +16,7 @@
 CGameWorld::CGameWorld()
 {
 	m_pGameServer = 0x0;
+	m_pConfig = 0x0;
 	m_pServer = 0x0;
 
 	m_Paused = false;
@@ -35,6 +36,7 @@ CGameWorld::~CGameWorld()
 void CGameWorld::SetGameServer(CGameContext *pGameServer)
 {
 	m_pGameServer = pGameServer;
+	m_pConfig = m_pGameServer->Config();
 	m_pServer = m_pGameServer->Server();
 }
 

--- a/src/game/server/gameworld.cpp
+++ b/src/game/server/gameworld.cpp
@@ -2,6 +2,7 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 
 #include "gameworld.h"
+#include "entities/character.h"
 #include "entity.h"
 #include "gamecontext.h"
 #include <algorithm>

--- a/src/game/server/gameworld.h
+++ b/src/game/server/gameworld.h
@@ -36,12 +36,14 @@ private:
 	CEntity *m_apFirstEntityTypes[NUM_ENTTYPES];
 
 	class CGameContext *m_pGameServer;
+	class CConfig *m_pConfig;
 	class IServer *m_pServer;
 
 	void UpdatePlayerMaps();
 
 public:
 	class CGameContext *GameServer() { return m_pGameServer; }
+	class CConfig *Config() { return m_pConfig; }
 	class IServer *Server() { return m_pServer; }
 
 	bool m_ResetRequested;

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -2,7 +2,6 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include "player.h"
 #include <engine/shared/config.h>
-#include <new>
 
 #include "entities/character.h"
 #include "gamecontext.h"
@@ -11,7 +10,6 @@
 #include <game/gamecore.h>
 #include <game/server/teams.h>
 #include <game/version.h>
-#include <time.h>
 
 MACRO_ALLOC_POOL_ID_IMPL(CPlayer, MAX_CLIENTS)
 

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -4,6 +4,7 @@
 #include <engine/shared/config.h>
 #include <new>
 
+#include "entities/character.h"
 #include "gamecontext.h"
 #include "gamemodes/DDRace.h"
 #include <engine/server.h>

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -3,11 +3,11 @@
 #ifndef GAME_SERVER_PLAYER_H
 #define GAME_SERVER_PLAYER_H
 
+#include "alloc.h"
+
 // this include should perhaps be removed
-#include "gamecontext.h"
 #include "score.h"
 #include "teeinfo.h"
-#include <memory>
 
 enum
 {

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -4,7 +4,6 @@
 #define GAME_SERVER_PLAYER_H
 
 // this include should perhaps be removed
-#include "entities/character.h"
 #include "gamecontext.h"
 #include "score.h"
 #include "teeinfo.h"

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -10,6 +10,13 @@
 #include "teeinfo.h"
 #include <memory>
 
+enum
+{
+	WEAPON_GAME = -3, // team switching etc
+	WEAPON_SELF = -2, // console kill command
+	WEAPON_WORLD = -1, // death tiles etc
+};
+
 // player object
 class CPlayer
 {

--- a/src/game/server/save.cpp
+++ b/src/game/server/save.cpp
@@ -5,6 +5,7 @@
 
 #include "entities/character.h"
 #include "gamemodes/DDRace.h"
+#include "player.h"
 #include "teams.h"
 #include <engine/shared/config.h>
 

--- a/src/game/server/save.cpp
+++ b/src/game/server/save.cpp
@@ -3,6 +3,7 @@
 #include <cstdio>
 #include <new>
 
+#include "entities/character.h"
 #include "gamemodes/DDRace.h"
 #include "teams.h"
 #include <engine/shared/config.h>

--- a/src/game/server/score.cpp
+++ b/src/game/server/score.cpp
@@ -1,6 +1,7 @@
 #include "score.h"
 #include "entities/character.h"
 #include "gamemodes/DDRace.h"
+#include "player.h"
 #include "save.h"
 
 #include <base/system.h>

--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -4,6 +4,8 @@
 #include "teehistorian.h"
 #include <engine/shared/config.h>
 
+#include "entities/character.h"
+
 CGameTeams::CGameTeams(CGameContext *pGameContext) :
 	m_pGameContext(pGameContext)
 {

--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -5,6 +5,7 @@
 #include <engine/shared/config.h>
 
 #include "entities/character.h"
+#include "player.h"
 
 CGameTeams::CGameTeams(CGameContext *pGameContext) :
 	m_pGameContext(pGameContext)

--- a/src/game/server/teams.h
+++ b/src/game/server/teams.h
@@ -4,6 +4,7 @@
 
 #include <engine/shared/config.h>
 #include <game/server/gamecontext.h>
+#include <game/server/score.h>
 #include <game/teamscore.h>
 
 #include <utility>

--- a/src/game/server/teehistorian.h
+++ b/src/game/server/teehistorian.h
@@ -9,7 +9,7 @@
 
 #include <time.h>
 
-struct CConfiguration;
+class CConfig;
 class CTuningParams;
 class CUuidManager;
 
@@ -34,7 +34,7 @@ public:
 		SHA256_DIGEST m_MapSha256;
 		int m_MapCrc;
 
-		CConfiguration *m_pConfig;
+		CConfig *m_pConfig;
 		CTuningParams *m_pTuning;
 		CUuidManager *m_pUuids;
 	};

--- a/src/mastersrv/mastersrv.cpp
+++ b/src/mastersrv/mastersrv.cpp
@@ -332,17 +332,17 @@ int main(int argc, const char **argv) // ignore_convention
 
 	IKernel *pKernel = IKernel::Create();
 	IStorage *pStorage = CreateStorage("Teeworlds", IStorage::STORAGETYPE_BASIC, argc, argv);
-	IConfig *pConfig = CreateConfig();
+	IConfigManager *pConfigManager = CreateConfigManager();
 	m_pConsole = CreateConsole(CFGFLAG_MASTER);
 
 	bool RegisterFail = !pKernel->RegisterInterface(pStorage);
 	RegisterFail |= !pKernel->RegisterInterface(m_pConsole);
-	RegisterFail |= !pKernel->RegisterInterface(pConfig);
+	RegisterFail |= !pKernel->RegisterInterface(pConfigManager);
 
 	if(RegisterFail)
 		return -1;
 
-	pConfig->Init();
+	pConfigManager->Init();
 	m_pConsole->Init();
 	m_NetBan.Init(m_pConsole, pStorage);
 	if(argc > 1) // ignore_convention

--- a/src/mastersrv/mastersrv.cpp
+++ b/src/mastersrv/mastersrv.cpp
@@ -343,6 +343,7 @@ int main(int argc, const char **argv) // ignore_convention
 		return -1;
 
 	pConfig->Init();
+	m_pConsole->Init();
 	m_NetBan.Init(m_pConsole, pStorage);
 	if(argc > 1) // ignore_convention
 		m_pConsole->ParseArguments(argc - 1, &argv[1]); // ignore_convention

--- a/src/test/teehistorian.cpp
+++ b/src/test/teehistorian.cpp
@@ -12,7 +12,7 @@ class TeeHistorian : public ::testing::Test
 {
 protected:
 	CTeeHistorian m_TH;
-	CConfiguration m_Config;
+	CConfig m_Config;
 	CTuningParams m_Tuning;
 	CUuidManager m_UuidManager;
 	CTeeHistorian::CGameInfo m_GameInfo;


### PR DESCRIPTION
Hi, devs.

I'm considering options to rebase another mod on the DDNet code and I found a lot of missing API.
I also think that it would be simpler for you to cherry-pick patches if DDNet will provide and use a similar API.

I ran the client and checked that the configuration save/load works correctly.

Backported changes overview:
- Extract some `CGameContext` code to methods (`SendMotd()`, `SendSettings()`)
- Provide getters for CEntity members and make some of them `private`
- Extract allocation macros from `entity.h` to `alloc.h` (to reduce includes)
- Extract / introduce `CConsole::Init()`
- Introduce CConfig API from commit https://github.com/teeworlds/teeworlds/commit/de5859b3717406f9f0e728506ad0ef15d4e87337 (the old API is kept and still used in the codebase)

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
