### PR TITLE
Remove unused onChangeTeamState

### DIFF
--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -341,21 +341,7 @@ int CGameTeams::Count(int Team) const
 
 void CGameTeams::ChangeTeamState(int Team, int State)
 {
-	int OldState = m_TeamState[Team];
 	m_TeamState[Team] = State;
-	onChangeTeamState(Team, State, OldState);
-}
-
-void CGameTeams::onChangeTeamState(int Team, int State, int OldState)
-{
-	if(OldState != State && State == TEAMSTATE_STARTED)
-	{
-		// OnTeamStateStarting
-	}
-	if(OldState != State && State == TEAMSTATE_FINISHED)
-	{
-		// OnTeamStateFinishing
-	}
 }
 
 bool CGameTeams::TeamFinished(int Team)

--- a/src/game/server/teams.h
+++ b/src/game/server/teams.h
@@ -65,7 +65,6 @@ public:
 	void CheckTeamFinished(int ClientID);
 
 	void ChangeTeamState(int Team, int State);
-	void onChangeTeamState(int Team, int State, int OldState);
 
 	int64 TeamMask(int Team, int ExceptID = -1, int Asker = -1);
 


### PR DESCRIPTION
This function was never used and just disrupts the reading flow a bit.
<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
