### PR TITLE
Fix memory leak in SQLite3 print statement

### DIFF
--- a/src/engine/server/databases/sqlite.cpp
+++ b/src/engine/server/databases/sqlite.cpp
@@ -162,7 +162,11 @@ extern char *sqlite3_expanded_sql(sqlite3_stmt *pStmt) __attribute__((weak));
 void CSqliteConnection::Print()
 {
 	if(m_pStmt != nullptr && sqlite3_expanded_sql != nullptr)
-		dbg_msg("sql", "SQLite statement: %s", sqlite3_expanded_sql(m_pStmt));
+	{
+		char *pExpandedStmt = sqlite3_expanded_sql(m_pStmt);
+		dbg_msg("sql", "SQLite statement: %s", pExpandedStmt);
+		sqlite3_free(pExpandedStmt);
+	}
 }
 
 bool CSqliteConnection::Step()


### PR DESCRIPTION
https://www.sqlite.org/c3ref/expanded_sql.html

Fixes #3381

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [x] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
