### PR TITLE
remove ddnet info tmp file always when quitting

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -3347,11 +3347,11 @@ void CClient::Run()
 				s_SavedConfig = true;
 			}
 
-			if(m_Warnings.empty() && !GameClient()->IsDisplayingWarning())
-				break;
-
 			if(m_aDDNetInfoTmp[0])
 				m_pStorage->RemoveFile(m_aDDNetInfoTmp, IStorage::TYPE_SAVE);
+
+			if(m_Warnings.empty() && !GameClient()->IsDisplayingWarning())
+				break;
 		}
 
 #if defined(CONF_FAMILY_UNIX)

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -3347,8 +3347,12 @@ void CClient::Run()
 				s_SavedConfig = true;
 			}
 
-			if(m_aDDNetInfoTmp[0])
+			IOHANDLE File = m_pStorage->OpenFile(m_aDDNetInfoTmp, IOFLAG_READ, IStorage::TYPE_SAVE);
+			if(File)
+			{
+				io_close(File);	
 				m_pStorage->RemoveFile(m_aDDNetInfoTmp, IStorage::TYPE_SAVE);
+			}
 
 			if(m_Warnings.empty() && !GameClient()->IsDisplayingWarning())
 				break;

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -3349,6 +3349,9 @@ void CClient::Run()
 
 			if(m_Warnings.empty() && !GameClient()->IsDisplayingWarning())
 				break;
+
+			if(m_aDDNetInfoTmp[0])
+				m_pStorage->RemoveFile(m_aDDNetInfoTmp, IStorage::TYPE_SAVE);
 		}
 
 #if defined(CONF_FAMILY_UNIX)


### PR DESCRIPTION
Maybe this fixes https://github.com/ddnet/ddnet/issues/3508 ?
Hard to test things involving timeouts tho...

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
