### PR TITLE
Fix weak hooks

### DIFF
--- a/src/game/gamecore.h
+++ b/src/game/gamecore.h
@@ -219,11 +219,12 @@ public:
 class CCharacterCore
 {
 	friend class CCharacter;
-	CWorldCore *m_pWorld;
 	CCollision *m_pCollision;
 	std::map<int, std::vector<vec2>> *m_pTeleOuts;
 
 public:
+	CWorldCore *m_pWorld;
+
 	vec2 m_Pos;
 	vec2 m_Vel;
 	bool m_Hook;

--- a/src/game/gamecore.h
+++ b/src/game/gamecore.h
@@ -288,9 +288,9 @@ public:
 	bool m_HasTelegunLaser;
 	int m_FreezeEnd;
 	bool m_DeepFrozen;
+	CTeamsCore *m_pTeams;
 
 private:
-	CTeamsCore *m_pTeams;
 	int m_MoveRestrictions;
 	static bool IsSwitchActiveCb(int Number, void *pUser);
 };

--- a/src/game/server/entities/character.h
+++ b/src/game/server/entities/character.h
@@ -80,6 +80,9 @@ public:
 	bool IsPaused() const { return m_Paused; }
 	class CPlayer *GetPlayer() { return m_pPlayer; }
 
+	// the player core for the physics
+	CCharacterCore m_Core;
+
 private:
 	// player controlling this character
 	class CPlayer *m_pPlayer;
@@ -141,9 +144,6 @@ private:
 		int m_CurrentMoveTime;
 		int m_OldVelAmount;
 	} m_Ninja;
-
-	// the player core for the physics
-	CCharacterCore m_Core;
 
 	// info for dead reckoning
 	int m_ReckoningTick; // tick that we are performing dead reckoning From

--- a/src/game/server/gameworld.cpp
+++ b/src/game/server/gameworld.cpp
@@ -319,7 +319,7 @@ void CGameWorld::Tick()
 			CEntity *pEnt = m_apFirstEntityTypes[ENTTYPE_CHARACTER];
 			for(; pEnt;)
 			{
-				if (((CCharacter*)pEnt)->m_Core.m_Id == i)
+				if(((CCharacter *)pEnt)->m_Core.m_Id == i)
 				{
 					ToChange.push_back(pEnt);
 					break;
@@ -328,7 +328,7 @@ void CGameWorld::Tick()
 			}
 		}
 
-		for(CEntity* pE : ToChange)
+		for(CEntity *pE : ToChange)
 		{
 			if(pE == m_apFirstEntityTypes[ENTTYPE_CHARACTER])
 				continue;

--- a/src/game/server/gameworld.cpp
+++ b/src/game/server/gameworld.cpp
@@ -257,6 +257,99 @@ void CGameWorld::Tick()
 	{
 		if(GameServer()->m_pController->IsForceBalanced())
 			GameServer()->SendChat(-1, CGameContext::CHAT_ALL, "Teams have been balanced");
+		
+		constexpr float PhysSize = 28.0f;
+		CEntity *pEnt = m_apFirstEntityTypes[ENTTYPE_CHARACTER];
+		static std::vector<CEntity *> ToChange;
+		static std::vector<int> ToChangeID;
+		for(; pEnt;)
+		{
+			m_pNextTraverseEntity = pEnt->m_pNextTypeEntity;
+			
+			CCharacter *pChar = (CCharacter *)pEnt;
+			CCharacterCore *pCore = &pChar->m_Core;
+
+			if(pCore->m_HookState == HOOK_FLYING)
+			{
+				vec2 NewPos = pCore->m_HookPos + pCore->m_HookDir * pCore->m_pWorld->m_Tuning[g_Config.m_ClDummy].m_HookFireSpeed;
+				if((!pCore->m_NewHook && distance(pCore->m_Pos, NewPos) > pCore->m_pWorld->m_Tuning[g_Config.m_ClDummy].m_HookLength) || (pCore->m_NewHook && distance(pCore->m_HookTeleBase, NewPos) > pCore->m_pWorld->m_Tuning[g_Config.m_ClDummy].m_HookLength))
+				{
+					NewPos = pCore->m_Pos + normalize(NewPos - pCore->m_Pos) * pCore->m_pWorld->m_Tuning[g_Config.m_ClDummy].m_HookLength;
+				}
+
+				int CurrentIndex = GameServer()->Collision()->GetMapIndex(pChar->m_Pos);
+				int TuneZone = GameServer()->Collision()->IsTune(CurrentIndex);
+
+				if(TuneZone)
+					pCore->m_pWorld->m_Tuning[g_Config.m_ClDummy] = GameServer()->TuningList()[TuneZone]; // throw tunings from specific zone into gamecore
+				else
+					pCore->m_pWorld->m_Tuning[g_Config.m_ClDummy] = *GameServer()->Tuning();
+
+				if(pCore->m_Hook && pCore->m_pWorld && pCore->m_pWorld->m_Tuning[g_Config.m_ClDummy].m_PlayerHooking)
+				{
+					float Distance = 0.0f;
+					for(int i = 0; i < MAX_CLIENTS; i++)
+					{
+						CCharacterCore *pCharCore = pCore->m_pWorld->m_apCharacters[i];
+						if(!pCharCore || pCharCore == pCore || (!(pCore->m_Super || pCharCore->m_Super) && ((pCore->m_Id != -1 && !pCore->m_pTeams->CanCollide(i, pCore->m_Id)) || pCharCore->m_Solo || pCore->m_Solo)))
+							continue;
+
+						vec2 ClosestPoint;
+						if(closest_point_on_line(pCore->m_HookPos, NewPos, pCharCore->m_Pos, ClosestPoint))
+						{
+							if(distance(pCharCore->m_Pos, ClosestPoint) < PhysSize + 2.0f)
+							{
+								if(pCore->m_HookedPlayer == -1 || distance(pCore->m_HookPos, pCharCore->m_Pos) < Distance)
+								{
+									if(pCharCore->m_HookedPlayer != pCore->m_Id)
+									{
+										ToChangeID.push_back(i);
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+			pEnt = m_pNextTraverseEntity;
+		}
+
+		for(int i : ToChangeID)
+		{
+			CEntity *pEnt = m_apFirstEntityTypes[ENTTYPE_CHARACTER];
+			for(; pEnt;)
+			{
+				if (((CCharacter*)pEnt)->m_Core.m_Id == i)
+				{
+					ToChange.push_back(pEnt);
+					break;
+				}
+				pEnt = pEnt->m_pNextTypeEntity;
+			}
+		}
+
+		for(CEntity* pE : ToChange)
+		{
+			if(pE == m_apFirstEntityTypes[ENTTYPE_CHARACTER])
+				continue;
+
+			CEntity *prev = pE->m_pPrevTypeEntity;
+			CEntity *next = pE->m_pNextTypeEntity;
+			if(prev)
+				prev->m_pNextTypeEntity = next;
+			if(next)
+				next->m_pPrevTypeEntity = prev;
+
+			CEntity *first = m_apFirstEntityTypes[ENTTYPE_CHARACTER];
+			first->m_pPrevTypeEntity = pE;
+			pE->m_pNextTypeEntity = first;
+			m_apFirstEntityTypes[ENTTYPE_CHARACTER] = pE;
+			pE->m_pPrevTypeEntity = nullptr;
+		}
+
+		ToChange.clear();
+		ToChangeID.clear();
+
 		// update all objects
 		for(auto *pEnt : m_apFirstEntityTypes)
 			for(; pEnt;)


### PR DESCRIPTION
Again disappointed in the community, so doesn't care. But here is the working version.
The way it works:
-If you hook someone you gain strong
-If you hook someone while he's already hooking you - you gain weak. And stay weak for this entire hook until you rehook while not being hooked by that person.

Complicated, but the idea is that you're always strong except for the times when two tees hooking each other at the same time. Then someone is weak to simulate current physics behavior so it don't change anything for game world


## Checklist

- Tested the change ingame
- Changed YES physics that affect existing maps <<<<<<<<<<<
