### PR TITLE
Run server in background on Windows (fixes #3525)

### DIFF
--- a/src/base/system.c
+++ b/src/base/system.c
@@ -3345,7 +3345,7 @@ PROCESS shell_execute(const char *file)
 	info.cbSize = sizeof(SHELLEXECUTEINFOA);
 	info.lpVerb = "open";
 	info.lpFile = file;
-	info.nShow = SW_SHOWDEFAULT;
+	info.nShow = SW_SHOWMINNOACTIVE;
 	info.fMask = SEE_MASK_NOCLOSEPROCESS;
 	ShellExecuteEx(&info);
 	return info.hProcess;


### PR DESCRIPTION
https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-showwindow

> Displays a window in its most recent size and position. This value is
> similar to SW_SHOWNORMAL, except that the window is not activated.

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [x] Written a unit test if it works standalone, system.c especially
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
