### PR TITLE
Prevent OpenSSL SIGPIPE (fixes #3513)

### DIFF
--- a/src/engine/client/http.cpp
+++ b/src/engine/client/http.cpp
@@ -7,6 +7,10 @@
 #include <engine/storage.h>
 #include <game/version.h>
 
+#if !defined(CONF_FAMILY_WINDOWS)
+#include <signal.h>
+#endif
+
 #define WIN32_LEAN_AND_MEAN
 #include "curl/curl.h"
 #include "curl/easy.h"
@@ -65,6 +69,13 @@ bool HttpInit(IStorage *pStorage)
 	curl_share_setopt(gs_Share, CURLSHOPT_SHARE, CURL_LOCK_DATA_CONNECT);
 	curl_share_setopt(gs_Share, CURLSHOPT_LOCKFUNC, CurlLock);
 	curl_share_setopt(gs_Share, CURLSHOPT_UNLOCKFUNC, CurlUnlock);
+
+#if !defined(CONF_FAMILY_WINDOWS)
+	// As a multithreaded application we have to tell curl to not install signal
+	// handlers and instead ignore SIGPIPE from OpenSSL ourselves.
+	signal(SIGPIPE, SIG_IGN);
+#endif
+
 	return false;
 }
 


### PR DESCRIPTION
by making libcurl handle the signal itself

See https://curl.se/libcurl/c/CURLOPT_NOSIGNAL.html

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
