### PR TITLE
Add set_view camera position command

### DIFF
--- a/src/game/client/components/camera.h
+++ b/src/game/client/components/camera.h
@@ -51,6 +51,9 @@ private:
 	static void ConZoomPlus(IConsole::IResult *pResult, void *pUserData);
 	static void ConZoomMinus(IConsole::IResult *pResult, void *pUserData);
 	static void ConZoomReset(IConsole::IResult *pResult, void *pUserData);
+	static void ConSetView(IConsole::IResult *pResult, void *pUserData);
+
+	vec2 m_ForceFreeviewPos;
 };
 
 #endif


### PR DESCRIPTION
Allows to bind spectator camera positions. Can be used to write teleport binds for test server or quickly spectate specific spots of the map.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
