### PR TITLE
Fix a possible race in load code 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2147,6 +2147,7 @@ if(GTEST_FOUND OR DOWNLOAD_GTEST)
     test.h
     thread.cpp
     unix.cpp
+    uuid.cpp
   )
   set(TESTS_EXTRA
     src/engine/client/blocklist_driver.cpp

--- a/src/engine/shared/uuid_manager.cpp
+++ b/src/engine/shared/uuid_manager.cpp
@@ -53,12 +53,30 @@ void FormatUuid(CUuid Uuid, char *pBuffer, unsigned BufferLength)
 		p[8], p[9], p[10], p[11], p[12], p[13], p[14], p[15]);
 }
 
-void ParseUuid(CUuid *pUuid, char *pBuffer)
+int ParseUuid(CUuid *pUuid, const char *pBuffer)
 {
-	unsigned char *p = pUuid->m_aData;
-	sscanf(pBuffer, "%02hhX%02hhX%02hhX%02hhX-%02hhX%02hhX-%02hhX%02hhX-%02hhX%02hhX-%02hhX%02hhX%02hhX%02hhX%02hhX%02hhX",
-		&p[0], &p[1], &p[2], &p[3], &p[4], &p[5], &p[6], &p[7],
-		&p[8], &p[9], &p[10], &p[11], &p[12], &p[13], &p[14], &p[15]);
+	if(str_length(pBuffer) + 1 != UUID_MAXSTRSIZE)
+	{
+		return 2;
+	}
+	char aCopy[UUID_MAXSTRSIZE];
+	str_copy(aCopy, pBuffer, sizeof(aCopy));
+	// 01234567-9012-4567-9012-456789012345
+	if(aCopy[8] != '-' || aCopy[13] != '-' || aCopy[18] != '-' || aCopy[23] != '-')
+	{
+		return 1;
+	}
+	aCopy[8] = aCopy[13] = aCopy[18] = aCopy[23] = 0;
+	if(0 ||
+		str_hex_decode(pUuid->m_aData + 0, 4, aCopy + 0) ||
+		str_hex_decode(pUuid->m_aData + 4, 2, aCopy + 9) ||
+		str_hex_decode(pUuid->m_aData + 6, 2, aCopy + 14) ||
+		str_hex_decode(pUuid->m_aData + 8, 2, aCopy + 19) ||
+		str_hex_decode(pUuid->m_aData + 10, 6, aCopy + 24))
+	{
+		return 1;
+	}
+	return 0;
 }
 
 bool CUuid::operator==(const CUuid &Other) const

--- a/src/engine/shared/uuid_manager.h
+++ b/src/engine/shared/uuid_manager.h
@@ -27,7 +27,8 @@ CUuid RandomUuid();
 CUuid CalculateUuid(const char *pName);
 // The buffer length should be at least UUID_MAXSTRSIZE.
 void FormatUuid(CUuid Uuid, char *pBuffer, unsigned BufferLength);
-void ParseUuid(CUuid *pUuid, char *pBuffer);
+// Returns nonzero on failure.
+int ParseUuid(CUuid *pUuid, const char *pBuffer);
 
 struct CName
 {

--- a/src/game/server/score.cpp
+++ b/src/game/server/score.cpp
@@ -1533,17 +1533,16 @@ bool CScore::LoadTeamThread(IDbConnection *pSqlServer, const ISqlData *pGameData
 		return true;
 	}
 
-	char aSaveID[UUID_MAXSTRSIZE];
 	memset(pResult->m_SaveID.m_aData, 0, sizeof(pResult->m_SaveID.m_aData));
 	if(!pSqlServer->IsNull(3))
 	{
+		char aSaveID[UUID_MAXSTRSIZE];
 		pSqlServer->GetString(3, aSaveID, sizeof(aSaveID));
-		if(str_length(aSaveID) + 1 != UUID_MAXSTRSIZE)
+		if(ParseUuid(&pResult->m_SaveID, aSaveID))
 		{
 			str_copy(pResult->m_aMessage, "Unable to load savegame: SaveID corrupted", sizeof(pResult->m_aMessage));
 			return true;
 		}
-		ParseUuid(&pResult->m_SaveID, aSaveID);
 	}
 
 	char aSaveString[65536];

--- a/src/game/server/score.cpp
+++ b/src/game/server/score.cpp
@@ -19,6 +19,12 @@
 #include <fstream>
 #include <random>
 
+// "6b407e81-8b77-3e04-a207-8da17f37d000"
+// "save-no-save-id@ddnet.tw"
+static const CUuid UUID_NO_SAVE_ID =
+	{{0x6b, 0x40, 0x7e, 0x81, 0x8b, 0x77, 0x3e, 0x04,
+		0xa2, 0x07, 0x8d, 0xa1, 0x7f, 0x37, 0xd0, 0x00}};
+
 CScorePlayerResult::CScorePlayerResult()
 {
 	SetVariant(Variant::DIRECT);
@@ -1533,12 +1539,12 @@ bool CScore::LoadTeamThread(IDbConnection *pSqlServer, const ISqlData *pGameData
 		return true;
 	}
 
-	memset(pResult->m_SaveID.m_aData, 0, sizeof(pResult->m_SaveID.m_aData));
+	pResult->m_SaveID = UUID_NO_SAVE_ID;
 	if(!pSqlServer->IsNull(3))
 	{
 		char aSaveID[UUID_MAXSTRSIZE];
 		pSqlServer->GetString(3, aSaveID, sizeof(aSaveID));
-		if(ParseUuid(&pResult->m_SaveID, aSaveID))
+		if(ParseUuid(&pResult->m_SaveID, aSaveID) || pResult->m_SaveID == UUID_NO_SAVE_ID)
 		{
 			str_copy(pResult->m_aMessage, "Unable to load savegame: SaveID corrupted", sizeof(pResult->m_aMessage));
 			return true;
@@ -1563,12 +1569,19 @@ bool CScore::LoadTeamThread(IDbConnection *pSqlServer, const ISqlData *pGameData
 		return true;
 
 	str_format(aBuf, sizeof(aBuf),
-		"DELETE FROM  %s_saves "
-		"WHERE Code = ? AND Map = ?;",
-		pSqlServer->GetPrefix());
+		"DELETE FROM %s_saves "
+		"WHERE Code = ? AND Map = ? AND SaveID %s;",
+		pSqlServer->GetPrefix(),
+		pResult->m_SaveID != UUID_NO_SAVE_ID ? "= ?" : "IS NULL");
 	pSqlServer->PrepareStatement(aBuf);
 	pSqlServer->BindString(1, pData->m_Code);
 	pSqlServer->BindString(2, pData->m_Map);
+	char aUuid[UUID_MAXSTRSIZE];
+	if(pResult->m_SaveID != UUID_NO_SAVE_ID)
+	{
+		FormatUuid(pResult->m_SaveID, aUuid, sizeof(aUuid));
+		pSqlServer->BindString(3, aUuid);
+	}
 	pSqlServer->Print();
 	int NumDeleted = pSqlServer->ExecuteUpdate();
 

--- a/src/test/uuid.cpp
+++ b/src/test/uuid.cpp
@@ -1,0 +1,37 @@
+#include <gtest/gtest.h>
+
+#include <engine/shared/uuid_manager.h>
+
+TEST(Uuid, FromToString)
+{
+	char aUuid[UUID_MAXSTRSIZE];
+	CUuid Uuid;
+	EXPECT_FALSE(ParseUuid(&Uuid, "8d300ecf-5873-4297-bee5-95668fdff320"));
+	FormatUuid(Uuid, aUuid, sizeof(aUuid));
+	EXPECT_STREQ(aUuid, "8d300ecf-5873-4297-bee5-95668fdff320");
+	EXPECT_FALSE(ParseUuid(&Uuid, "00000000-0000-0000-0000-000000000000"));
+	FormatUuid(Uuid, aUuid, sizeof(aUuid));
+	EXPECT_STREQ(aUuid, "00000000-0000-0000-0000-000000000000");
+	EXPECT_FALSE(ParseUuid(&Uuid, "ffffffff-ffff-ffff-ffff-ffffffffffff"));
+	FormatUuid(Uuid, aUuid, sizeof(aUuid));
+	EXPECT_STREQ(aUuid, "ffffffff-ffff-ffff-ffff-ffffffffffff");
+	EXPECT_FALSE(ParseUuid(&Uuid, "01234567-89aB-cDeF-0123-456789AbCdEf"));
+	FormatUuid(Uuid, aUuid, sizeof(aUuid));
+	EXPECT_STREQ(aUuid, "01234567-89ab-cdef-0123-456789abcdef");
+}
+
+TEST(Uuid, ParseFailures)
+{
+	CUuid Uuid;
+	EXPECT_TRUE(ParseUuid(&Uuid, ""));
+	EXPECT_TRUE(ParseUuid(&Uuid, "01234567-89ab-cdef-0123-456789abcdeg"));
+	EXPECT_TRUE(ParseUuid(&Uuid, "0-0-0-0-0"));
+	EXPECT_TRUE(ParseUuid(&Uuid, "01234567-89ab-cdef-0123-456789abcde"));
+	EXPECT_TRUE(ParseUuid(&Uuid, "01234567-89ab-cdef-0123-456789abcdef0"));
+	EXPECT_TRUE(ParseUuid(&Uuid, "01234567+89ab-cdef-0123-456789abcdef"));
+	EXPECT_TRUE(ParseUuid(&Uuid, "01234567-89ab+cdef-0123-456789abcdef"));
+	EXPECT_TRUE(ParseUuid(&Uuid, "01234567-89ab-cdef+0123-456789abcdef"));
+	EXPECT_TRUE(ParseUuid(&Uuid, "01234567-89ab-cdef-0123+456789abcdef"));
+	EXPECT_TRUE(ParseUuid(&Uuid, "01234567-89ab-cdef-0123-456789abcdef "));
+	EXPECT_TRUE(ParseUuid(&Uuid, "0x01234567-89ab-cdef-0123-456789abcdef"));
+}


### PR DESCRIPTION
Previously, a save could possibly be loaded twice given enough latency
discrepancy between servers. The server only verified that it deleted
*some* save with the given password, not *the* save it is trying to
load. This is fixed by also checking the SaveID column that is random
and globally unique (except for the old NULLs). Since users can't create
new saves with NULL SaveID, these pose no problem.

Also change the default UUID for saves without save ID to something
nonzero, so we can't accidentally hit it due to a bug.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [x] Written a unit test if it works standalone, system.c especially
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
