### PR TITLE
Revert "rescue on freeze/dfreeze"

### DIFF
--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -2104,8 +2104,13 @@ void CCharacter::DDRaceTick()
 	// look for save position for rescue feature
 	if(g_Config.m_SvRescue || ((g_Config.m_SvTeam == 3 || Team() > TEAM_FLOCK) && Team() >= TEAM_FLOCK && Team() < TEAM_SUPER))
 	{
-		if(IsGrounded() && !m_FreezeTime && !m_DeepFreeze)
+		int index = GameServer()->Collision()->GetPureMapIndex(m_Pos);
+		int tile = GameServer()->Collision()->GetTileIndex(index);
+		int ftile = GameServer()->Collision()->GetFTileIndex(index);
+		if(IsGrounded() && tile != TILE_FREEZE && tile != TILE_DFREEZE && ftile != TILE_FREEZE && ftile != TILE_DFREEZE && !m_DeepFreeze)
+		{
 			SetRescue();
+		}
 	}
 
 	m_Core.m_Id = GetPlayer()->GetCID();


### PR DESCRIPTION
This reverts commit 28cf3b31bab7df4c94e9e7d8e53973dd62de7e5a.

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
