### PR TITLE
Add eval_if console command

### DIFF
--- a/src/engine/console.h
+++ b/src/engine/console.h
@@ -40,6 +40,8 @@ public:
 		unsigned m_NumArgs;
 
 	public:
+		int m_Value;
+		char m_aValue[128];
 		IResult() { m_NumArgs = 0; }
 		virtual ~IResult() {}
 

--- a/src/engine/shared/console.cpp
+++ b/src/engine/shared/console.cpp
@@ -748,6 +748,7 @@ static void IntVariableCommand(IConsole::IResult *pResult, void *pUserData)
 		char aBuf[32];
 		str_format(aBuf, sizeof(aBuf), "Value: %d", *(pData->m_pVariable));
 		pData->m_pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "console", aBuf);
+		pResult->m_Value = *(pData->m_pVariable);
 	}
 }
 
@@ -769,6 +770,7 @@ static void ColVariableCommand(IConsole::IResult *pResult, void *pUserData)
 		char aBuf[256];
 		str_format(aBuf, sizeof(aBuf), "Value: %u", *(pData->m_pVariable));
 		pData->m_pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "console", aBuf);
+		pResult->m_Value = *(pData->m_pVariable);
 
 		ColorHSLA Hsla(*(pData->m_pVariable), true);
 		if(pData->m_Light)
@@ -823,7 +825,50 @@ static void StrVariableCommand(IConsole::IResult *pResult, void *pUserData)
 		char aBuf[1024];
 		str_format(aBuf, sizeof(aBuf), "Value: %s", pData->m_pStr);
 		pData->m_pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "console", aBuf);
+		str_copy(pResult->m_aValue, pData->m_pStr, sizeof(pResult->m_aValue));
 	}
+}
+
+void CConsole::Con_EvalIf(IResult *pResult, void *pUserData)
+{
+	CConsole *pConsole = static_cast<CConsole *>(pUserData);
+	CCommand *pCommand = pConsole->FindCommand(pResult->GetString(0), pConsole->m_FlagMask);
+	char aBuf[128];
+	if(!pCommand)
+	{
+		str_format(aBuf, sizeof(aBuf), "No such command: '%s'.", pResult->GetString(0));
+		pConsole->Print(OUTPUT_LEVEL_STANDARD, "Console", aBuf);
+		return;
+	}
+	CResult Result;
+	pCommand->m_pfnCallback(&Result, pCommand->m_pUserData);
+	bool Condition = false;
+	if(pCommand->m_pfnCallback == IntVariableCommand)
+		Condition = Result.m_Value == atoi(pResult->GetString(2));
+	else
+		Condition = !str_comp_nocase(Result.m_aValue, pResult->GetString(2));
+	if(!str_comp(pResult->GetString(1), "!="))
+		Condition = !Condition;
+	else if(str_comp(pResult->GetString(1), "==") && pCommand->m_pfnCallback == StrVariableCommand)
+		pConsole->Print(OUTPUT_LEVEL_STANDARD, "Console", "Error: invalid comparator for type string");
+	else if(!str_comp(pResult->GetString(1), ">"))
+		Condition = Result.m_Value > atoi(pResult->GetString(2));
+	else if(!str_comp(pResult->GetString(1), "<"))
+		Condition = Result.m_Value < atoi(pResult->GetString(2));
+	else if(!str_comp(pResult->GetString(1), "<="))
+		Condition = Result.m_Value <= atoi(pResult->GetString(2));
+	else if(!str_comp(pResult->GetString(1), ">="))
+		Condition = Result.m_Value >= atoi(pResult->GetString(2));
+	else if(str_comp(pResult->GetString(1), "=="))
+		pConsole->Print(OUTPUT_LEVEL_STANDARD, "Console", "Error: invalid comparator for type integer");
+
+	if(pResult->NumArguments() > 4 && str_comp_nocase(pResult->GetString(4), "else"))
+		pConsole->Print(OUTPUT_LEVEL_STANDARD, "Console", "Error: expected else");
+
+	if(Condition)
+		pConsole->ExecuteLine(pResult->GetString(3));
+	else if(pResult->NumArguments() == 6)
+		pConsole->ExecuteLine(pResult->GetString(5));
 }
 
 void CConsole::ConToggle(IConsole::IResult *pResult, void *pUser)
@@ -941,6 +986,7 @@ CConsole::CConsole(int FlagMask)
 	// register some basic commands
 	Register("echo", "r[text]", CFGFLAG_SERVER, Con_Echo, this, "Echo the text");
 	Register("exec", "r[file]", CFGFLAG_SERVER | CFGFLAG_CLIENT, Con_Exec, this, "Execute the specified file");
+	Register("eval_if", "s[config] s[comparison] s[value] s[command] ?s[else] ?s[command]", CFGFLAG_SERVER | CFGFLAG_CLIENT | CFGFLAG_STORE, Con_EvalIf, this, "Execute command if condition is true");
 
 	Register("toggle", "s[config-option] i[value 1] i[value 2]", CFGFLAG_SERVER | CFGFLAG_CLIENT, ConToggle, this, "Toggle config value");
 	Register("+toggle", "s[config-option] i[value 1] i[value 2]", CFGFLAG_CLIENT, ConToggleStroke, this, "Toggle config value via keypress");

--- a/src/engine/shared/console.h
+++ b/src/engine/shared/console.h
@@ -56,6 +56,7 @@ class CConsole : public IConsole
 	static void Con_Chain(IResult *pResult, void *pUserData);
 	static void Con_Echo(IResult *pResult, void *pUserData);
 	static void Con_Exec(IResult *pResult, void *pUserData);
+	static void Con_EvalIf(IResult *pResult, void *pUserData);
 	static void ConToggle(IResult *pResult, void *pUser);
 	static void ConToggleStroke(IResult *pResult, void *pUser);
 	static void ConCommandAccess(IResult *pResult, void *pUser);


### PR DESCRIPTION
# SYNOPSIS

eval_if

s[config] s[comparison] s[value] s[command] ?s[else] ?s[command]

# EXAMPLE

eval_if ui_server_address == "localhost" "rcon_auth rcon" else "rcon_auth strong_password"

Ported from upstream https://github.com/teeworlds/teeworlds/pull/2723

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
