### PR TITLE
Fix input message position in teehistorian files

### DIFF
--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -1066,11 +1066,6 @@ void CGameContext::OnClientDirectInput(int ClientID, void *pInput)
 	if(!m_World.m_Paused)
 		m_apPlayers[ClientID]->OnDirectInput((CNetObj_PlayerInput *)pInput);
 
-	if(m_TeeHistorianActive)
-	{
-		m_TeeHistorian.RecordPlayerInput(ClientID, (CNetObj_PlayerInput *)pInput);
-	}
-
 	int Flags = ((CNetObj_PlayerInput *)pInput)->m_PlayerFlags;
 	if((Flags & 256) || (Flags & 512))
 	{
@@ -1088,6 +1083,11 @@ void CGameContext::OnClientPredictedEarlyInput(int ClientID, void *pInput)
 {
 	if(!m_World.m_Paused)
 		m_apPlayers[ClientID]->OnPredictedEarlyInput((CNetObj_PlayerInput *)pInput);
+
+	if(m_TeeHistorianActive)
+	{
+		m_TeeHistorian.RecordPlayerInput(ClientID, (CNetObj_PlayerInput *)pInput);
+	}
 }
 
 struct CVoteOptionServer *CGameContext::GetVoteOption(int Index)

--- a/src/game/server/teehistorian.cpp
+++ b/src/game/server/teehistorian.cpp
@@ -491,6 +491,8 @@ void CTeeHistorian::RecordTestExtra()
 
 void CTeeHistorian::RecordTeamSaveSuccess(int Team, CUuid SaveID, const char *pTeamSave)
 {
+	EnsureTickWritten();
+
 	CPacker Buffer;
 	Buffer.Reset();
 	Buffer.AddInt(Team);
@@ -509,6 +511,8 @@ void CTeeHistorian::RecordTeamSaveSuccess(int Team, CUuid SaveID, const char *pT
 
 void CTeeHistorian::RecordTeamSaveFailure(int Team)
 {
+	EnsureTickWritten();
+
 	CPacker Buffer;
 	Buffer.Reset();
 	Buffer.AddInt(Team);
@@ -523,6 +527,8 @@ void CTeeHistorian::RecordTeamSaveFailure(int Team)
 
 void CTeeHistorian::RecordTeamLoadSuccess(int Team, CUuid SaveID, const char *pTeamSave)
 {
+	EnsureTickWritten();
+
 	CPacker Buffer;
 	Buffer.Reset();
 	Buffer.AddInt(Team);
@@ -541,6 +547,8 @@ void CTeeHistorian::RecordTeamLoadSuccess(int Team, CUuid SaveID, const char *pT
 
 void CTeeHistorian::RecordTeamLoadFailure(int Team)
 {
+	EnsureTickWritten();
+
 	CPacker Buffer;
 	Buffer.Reset();
 	Buffer.AddInt(Team);

--- a/src/game/server/teehistorian.cpp
+++ b/src/game/server/teehistorian.cpp
@@ -47,7 +47,7 @@ void CTeeHistorian::Reset(const CGameInfo *pGameInfo, WRITE_CALLBACK pfnWriteCal
 	// Tick 0 is implicit at the start, game starts as tick 1.
 	m_TickWritten = true;
 	m_MaxClientID = MAX_CLIENTS;
-	// `m_PrevMaxClientID` is initialized in `BeginTick`
+	// `m_PrevMaxClientID` is initialized in `BeginPlayers`
 	for(auto &PrevPlayer : m_aPrevPlayers)
 	{
 		PrevPlayer.m_Alive = false;
@@ -204,6 +204,8 @@ void CTeeHistorian::BeginPlayers()
 	dbg_assert(m_State == STATE_BEFORE_PLAYERS, "invalid teehistorian state");
 
 	m_PrevMaxClientID = m_MaxClientID;
+	// ensure that PLAYER_{DIFF, NEW, OLD} don't cause an implicit tick after a TICK_SKIP
+	// by not overwriting m_MaxClientID during RecordPlayer
 	m_MaxClientID = -1;
 
 	m_State = STATE_PLAYERS;


### PR DESCRIPTION
Previously the message was recorded when incoming. But the time when the input should apply wasn't recorded. Now inputs are recorded right before they get applied in the game world.

And record exact tick where load/save result is returned.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
