### PR TITLE
Configurable snapshot skipping

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -2436,6 +2436,9 @@ int CServer::Run()
 		dbg_msg("server", "+-------------------------+");
 	}
 
+	m_SnapshotCycle = 2;
+	m_SnapshotSkip = 0;
+
 	// start game
 	{
 		bool NonActive = false;
@@ -2575,8 +2578,20 @@ int CServer::Run()
 			// snap game
 			if(NewTicks)
 			{
-				if(g_Config.m_SvHighBandwidth || (m_CurrentGameTick % 2) == 0)
+				bool Skipping = true;
+				if(m_SnapshotSkip % m_SnapshotCycle == 0)
+				{
+					m_SnapshotCycle += 1;
+					if(m_SnapshotCycle > g_Config.m_SvSnapshotSkip + 1)
+						m_SnapshotCycle = 2;
+					m_SnapshotSkip = 0;
+					Skipping = false;
+				}
+
+				if(g_Config.m_SvHighBandwidth || !Skipping)
 					DoSnapshot();
+
+				m_SnapshotSkip++;
 
 				UpdateClientRconCommands();
 

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -199,6 +199,9 @@ public:
 	CClient m_aClients[MAX_CLIENTS];
 	int m_aIdMap[MAX_CLIENTS * VANILLA_MAX_CLIENTS];
 
+	int m_SnapshotSkip;
+	int m_SnapshotCycle;
+
 	CSnapshotDelta m_SnapshotDelta;
 	CSnapshotBuilder m_SnapshotBuilder;
 	CSnapIDPool m_IDPool;

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -139,6 +139,7 @@ MACRO_CONFIG_STR(SvMap, sv_map, 128, "Sunny Side Up", CFGFLAG_SERVER, "Map to us
 MACRO_CONFIG_INT(SvMaxClients, sv_max_clients, MAX_CLIENTS, 1, MAX_CLIENTS, CFGFLAG_SERVER, "Maximum number of clients that are allowed on a server")
 MACRO_CONFIG_INT(SvMaxClientsPerIP, sv_max_clients_per_ip, 4, 1, MAX_CLIENTS, CFGFLAG_SERVER, "Maximum number of clients with the same IP that can connect to the server")
 MACRO_CONFIG_INT(SvHighBandwidth, sv_high_bandwidth, 0, 0, 1, CFGFLAG_SERVER, "Use high bandwidth mode. Doubles the bandwidth required for the server. LAN use only")
+MACRO_CONFIG_INT(SvSnapshotSkip, sv_snapshot_skip, 1, 1, 4, CFGFLAG_SERVER, "When high bandwidth mode is off, determine how many snapshots are skiped before actually sending a snapshot")
 MACRO_CONFIG_INT(SvRegister, sv_register, 1, 0, 1, CFGFLAG_SERVER, "Register server with master server for public listing")
 MACRO_CONFIG_STR(SvRconPassword, sv_rcon_password, 32, "", CFGFLAG_SERVER | CFGFLAG_NONTEEHISTORIC, "Remote console password (full access)")
 MACRO_CONFIG_STR(SvRconModPassword, sv_rcon_mod_password, 32, "", CFGFLAG_SERVER | CFGFLAG_NONTEEHISTORIC, "Remote console password for moderators (limited access)")


### PR DESCRIPTION
Attempting to skip more snapshots to save bandwidth
Anti-ping works really well when multiple snapshots are skipped, the most affected elements are entities based on laser since laser movement aren't predicted.

This is quite a brute force method for now. Although I made it skip in a pattern that may reduce the stutter a little bit for non-antiping user.

Introduced a server setting `sv_snapshot_skip`, which only works when `sv_high_bandwidth` is 0
* When `sv_snapshot_skip` is set to 1, the behavior is the same with high bandwidth mode off before
* When set to 2, I think it is still playable, and skips about 16% more snapshots per second
* Anything about 2 is barely playable with antiping off, but antiping seems to be able to save it.

Maybe we can do a test run on CHN3 with `sv_snapshot_skip` set to 2 on a few servers?

_I think if we can keep the NetEvents across multiple snapshots attempts and track which event has been snapped for a specific player, we can make snapshot rate of players independent from each other._

_With that, we can do some fancy stuff like snapping for a player immediately when the player is firing or a hook is attached by or to the player to improve the control for non-antiping players while keeping the snapshot rate lower_ 

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
