### PR TITLE
Fix sizing in graphics menu

### DIFF
--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -1031,7 +1031,8 @@ void CMenus::RenderSettingsGraphics(CUIRect MainView)
 	static int s_GfxHighdpi = g_Config.m_GfxHighdpi;
 
 	CUIRect ModeList;
-	MainView.VSplitLeft(300.0f, &MainView, &ModeList);
+	MainView.VSplitLeft(350.0f, &MainView, &ModeList);
+	MainView.VSplitLeft(340.0f, &MainView, 0);
 
 	// draw allmodes switch
 	ModeList.HSplitTop(20, &Button, &ModeList);
@@ -1195,7 +1196,7 @@ void CMenus::RenderSettingsGraphics(CUIRect MainView)
 	}
 
 	MainView.HSplitTop(20.0f, &Label, &MainView);
-	Label.VSplitLeft(130.0f, &Label, &Button);
+	Label.VSplitLeft(160.0f, &Label, &Button);
 	if(g_Config.m_GfxRefreshRate)
 		str_format(aBuf, sizeof(aBuf), "%s: %i Hz", Localize("Refresh Rate"), g_Config.m_GfxRefreshRate);
 	else


### PR DESCRIPTION
As reported by louis
![screenshot-20210131@202748](https://user-images.githubusercontent.com/2335377/106395490-cc959780-6402-11eb-8217-77c026ce2b4f.png)

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)

