### PR TITLE
Work around old glibc version in Discord Linux linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1862,6 +1862,10 @@ if(CLIENT)
 
   if(DISCORD)
     list(APPEND LIBS_CLIENT discord-shared)
+
+    if(TARGET_OS STREQUAL "linux")
+      list(APPEND LIBS_CLIENT -Wl,--unresolved-symbols=ignore-in-shared-libs)
+    endif()
   endif()
 
   if(TARGET_OS STREQUAL "windows")


### PR DESCRIPTION
Strangely on Debian I'm getting an error with this:

  CMake Error at CMakeLists.txt:2613 (target_link_libraries):
    Object library target "engine-shared" may not link to anything.

Not sure how to resolve the rpath issue best. @heinrich5991 any idea?

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
