### PR TITLE
Fix button presses after esc after color picker usage (fixes# 3575)

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -1470,6 +1470,13 @@ bool CMenus::CanDisplayWarning()
 
 void CMenus::RenderColorPicker()
 {
+	if(m_EscapePressed)
+	{
+		ms_ColorPicker.m_Active = false;
+		ms_ValueSelectorTextMode = false;
+		UI()->SetActiveItem(0);
+	}
+
 	if(!ms_ColorPicker.m_Active)
 		return;
 


### PR DESCRIPTION
fixes #3575 (edit: else issue is probably not closed -- Jupeyy)

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
