### PR TITLE
Adopt some more refactoring from upstream

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2012,7 +2012,6 @@ set_src(GAME_SERVER GLOB_RECURSE src/game/server
   gamecontroller.h
   gamemodes/DDRace.cpp
   gamemodes/DDRace.h
-  gamemodes/gamemode.h
   gameworld.cpp
   gameworld.h
   player.cpp

--- a/datasrc/compile.py
+++ b/datasrc/compile.py
@@ -148,15 +148,15 @@ def main():
 		CNetObjHandler();
 
 		int ValidateObj(int Type, void *pData, int Size);
-		const char *GetObjName(int Type);
-		int GetObjSize(int Type);
-		int NumObjCorrections();
-		const char *CorrectedObjOn();
+		const char *GetObjName(int Type) const;
+		int GetObjSize(int Type) const;
+		int NumObjCorrections() const;
+		const char *CorrectedObjOn() const;
 
-		const char *GetMsgName(int Type);
+		const char *GetMsgName(int Type) const;
 		void *SecureUnpackMsg(int Type, CUnpacker *pUnpacker);
 		bool TeeHistorianRecordMsg(int Type);
-		const char *FailedMsgOn();
+		const char *FailedMsgOn() const;
 	};
 
 	""")
@@ -180,9 +180,9 @@ def main():
 		lines += ['\tm_NumObjCorrections = 0;']
 		lines += ['}']
 		lines += ['']
-		lines += ['int CNetObjHandler::NumObjCorrections() { return m_NumObjCorrections; }']
-		lines += ['const char *CNetObjHandler::CorrectedObjOn() { return m_pObjCorrectedOn; }']
-		lines += ['const char *CNetObjHandler::FailedMsgOn() { return m_pMsgFailedOn; }']
+		lines += ['int CNetObjHandler::NumObjCorrections() const { return m_NumObjCorrections; }']
+		lines += ['const char *CNetObjHandler::CorrectedObjOn() const { return m_pObjCorrectedOn; }']
+		lines += ['const char *CNetObjHandler::FailedMsgOn() const { return m_pMsgFailedOn; }']
 		lines += ['']
 		lines += ['']
 		lines += ['']
@@ -219,14 +219,14 @@ def main():
 		lines += ['};']
 		lines += ['']
 
-		lines += ['const char *CNetObjHandler::GetObjName(int Type)']
+		lines += ['const char *CNetObjHandler::GetObjName(int Type) const']
 		lines += ['{']
 		lines += ['\tif(Type < 0 || Type >= NUM_NETOBJTYPES) return "(out of range)";']
 		lines += ['\treturn ms_apObjNames[Type];']
 		lines += ['}']
 		lines += ['']
 
-		lines += ['int CNetObjHandler::GetObjSize(int Type)']
+		lines += ['int CNetObjHandler::GetObjSize(int Type) const']
 		lines += ['{']
 		lines += ['\tif(Type < 0 || Type >= NUM_NETOBJTYPES) return 0;']
 		lines += ['\treturn ms_aObjSizes[Type];']
@@ -234,7 +234,7 @@ def main():
 		lines += ['']
 
 
-		lines += ['const char *CNetObjHandler::GetMsgName(int Type)']
+		lines += ['const char *CNetObjHandler::GetMsgName(int Type) const']
 		lines += ['{']
 		lines += ['\tif(Type < 0 || Type >= NUM_NETMSGTYPES) return "(out of range)";']
 		lines += ['\treturn ms_apMsgNames[Type];']

--- a/src/base/tl/array.h
+++ b/src/base/tl/array.h
@@ -280,7 +280,7 @@ public:
 		Function: memusage
 			Returns how much memory this dynamic array is using
 	*/
-	int memusage()
+	int memusage() const
 	{
 		return sizeof(array) + sizeof(T) * list_size;
 	}
@@ -303,7 +303,7 @@ public:
 		Function: all
 			Returns a range that contains the whole array.
 	*/
-	range all() { return range(list, list + num_elements); }
+	range all() const { return range(list, list + num_elements); }
 
 protected:
 	void incsize()

--- a/src/engine/client.h
+++ b/src/engine/client.h
@@ -135,22 +135,22 @@ public:
 	virtual void EnterGame() = 0;
 
 	//
-	virtual const char *MapDownloadName() = 0;
-	virtual int MapDownloadAmount() = 0;
-	virtual int MapDownloadTotalsize() = 0;
+	virtual const char *MapDownloadName() const = 0;
+	virtual int MapDownloadAmount() const = 0;
+	virtual int MapDownloadTotalsize() const = 0;
 
 	// input
-	virtual int *GetInput(int Tick, int IsDummy = 0) = 0;
-	virtual int *GetDirectInput(int Tick, int IsDummy = 0) = 0;
+	virtual int *GetInput(int Tick, int IsDummy = 0) const = 0;
+	virtual int *GetDirectInput(int Tick, int IsDummy = 0) const = 0;
 
 	// remote console
 	virtual void RconAuth(const char *pUsername, const char *pPassword) = 0;
-	virtual bool RconAuthed() = 0;
-	virtual bool UseTempRconCommands() = 0;
+	virtual bool RconAuthed() const = 0;
+	virtual bool UseTempRconCommands() const = 0;
 	virtual void Rcon(const char *pLine) = 0;
 
 	// server info
-	virtual void GetServerInfo(class CServerInfo *pServerInfo) = 0;
+	virtual void GetServerInfo(class CServerInfo *pServerInfo) const = 0;
 
 	virtual int GetPredictionTime() = 0;
 
@@ -163,10 +163,10 @@ public:
 	};
 
 	// TODO: Refactor: should redo this a bit i think, too many virtual calls
-	virtual int SnapNumItems(int SnapID) = 0;
-	virtual void *SnapFindItem(int SnapID, int Type, int ID) = 0;
-	virtual void *SnapGetItem(int SnapID, int Index, CSnapItem *pItem) = 0;
-	virtual int SnapItemSize(int SnapID, int Index) = 0;
+	virtual int SnapNumItems(int SnapID) const = 0;
+	virtual void *SnapFindItem(int SnapID, int Type, int ID) const = 0;
+	virtual void *SnapGetItem(int SnapID, int Index, CSnapItem *pItem) const = 0;
+	virtual int SnapItemSize(int SnapID, int Index) const = 0;
 	virtual void SnapInvalidateItem(int SnapID, int Index) = 0;
 
 	virtual void SnapSetStaticsize(int ItemType, int Size) = 0;
@@ -184,22 +184,22 @@ public:
 	}
 
 	//
-	virtual const char *PlayerName() = 0;
-	virtual const char *DummyName() = 0;
-	virtual const char *ErrorString() = 0;
-	virtual const char *LatestVersion() = 0;
-	virtual bool ConnectionProblems() = 0;
+	virtual const char *PlayerName() const = 0;
+	virtual const char *DummyName() const = 0;
+	virtual const char *ErrorString() const = 0;
+	virtual const char *LatestVersion() const = 0;
+	virtual bool ConnectionProblems() const = 0;
 
-	virtual bool SoundInitFailed() = 0;
+	virtual bool SoundInitFailed() const = 0;
 
-	virtual IGraphics::CTextureHandle GetDebugFont() = 0; // TODO: remove this function
+	virtual IGraphics::CTextureHandle GetDebugFont() const = 0; // TODO: remove this function
 
 	//DDRace
 
-	virtual const char *GetCurrentMap() = 0;
-	virtual const char *GetCurrentMapPath() = 0;
-	virtual SHA256_DIGEST GetCurrentMapSha256() = 0;
-	virtual unsigned GetCurrentMapCrc() = 0;
+	virtual const char *GetCurrentMap() const = 0;
+	virtual const char *GetCurrentMapPath() const = 0;
+	virtual SHA256_DIGEST GetCurrentMapSha256() const = 0;
+	virtual unsigned GetCurrentMapCrc() const = 0;
 
 	virtual int GetCurrentRaceTime() = 0;
 
@@ -212,7 +212,7 @@ public:
 	virtual void DemoSlice(const char *pDstPath, CLIENTFUNC_FILTER pfnFilter, void *pUser) = 0;
 
 	virtual void RequestDDNetInfo() = 0;
-	virtual bool EditorHasUnsavedData() = 0;
+	virtual bool EditorHasUnsavedData() const = 0;
 
 	virtual void GenerateTimeoutSeed() = 0;
 
@@ -250,11 +250,11 @@ public:
 	virtual void SendDummyInfo(bool Start) = 0;
 	virtual int GetLastRaceTick() = 0;
 
-	virtual const char *GetItemName(int Type) = 0;
-	virtual const char *Version() = 0;
-	virtual const char *NetVersion() = 0;
-	virtual int DDNetVersion() = 0;
-	virtual const char *DDNetVersionStr() = 0;
+	virtual const char *GetItemName(int Type) const = 0;
+	virtual const char *Version() const = 0;
+	virtual const char *NetVersion() const = 0;
+	virtual int DDNetVersion() const = 0;
+	virtual const char *DDNetVersionStr() const = 0;
 
 	virtual void OnDummyDisconnect() = 0;
 	virtual void Echo(const char *pString) = 0;

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -478,7 +478,7 @@ void CClient::Rcon(const char *pCmd)
 	SendMsg(&Msg, MSGFLAG_VITAL);
 }
 
-bool CClient::ConnectionProblems()
+bool CClient::ConnectionProblems() const
 {
 	return m_NetClient[g_Config.m_ClDummy].GotProblems() != 0;
 }
@@ -543,13 +543,13 @@ void CClient::SendInput()
 	}
 }
 
-const char *CClient::LatestVersion()
+const char *CClient::LatestVersion() const
 {
 	return m_aVersionStr;
 }
 
 // TODO: OPT: do this a lot smarter!
-int *CClient::GetInput(int Tick, int IsDummy)
+int *CClient::GetInput(int Tick, int IsDummy) const
 {
 	int Best = -1;
 	const int d = IsDummy ^ g_Config.m_ClDummy;
@@ -564,7 +564,7 @@ int *CClient::GetInput(int Tick, int IsDummy)
 	return 0;
 }
 
-int *CClient::GetDirectInput(int Tick, int IsDummy)
+int *CClient::GetDirectInput(int Tick, int IsDummy) const
 {
 	const int d = IsDummy ^ g_Config.m_ClDummy;
 	for(int i = 0; i < 200; i++)
@@ -899,7 +899,7 @@ int CClient::SendMsgY(CMsgPacker *pMsg, int Flags, int NetClient)
 	return 0;
 }
 
-void CClient::GetServerInfo(CServerInfo *pServerInfo)
+void CClient::GetServerInfo(CServerInfo *pServerInfo) const
 {
 	mem_copy(pServerInfo, &m_CurrentServerInfo, sizeof(m_CurrentServerInfo));
 
@@ -921,7 +921,7 @@ int CClient::LoadData()
 
 // ---
 
-void *CClient::SnapGetItem(int SnapID, int Index, CSnapItem *pItem)
+void *CClient::SnapGetItem(int SnapID, int Index, CSnapItem *pItem) const
 {
 	CSnapshotItem *i;
 	dbg_assert(SnapID >= 0 && SnapID < NUM_SNAPSHOT_TYPES, "invalid SnapID");
@@ -932,7 +932,7 @@ void *CClient::SnapGetItem(int SnapID, int Index, CSnapItem *pItem)
 	return (void *)i->Data();
 }
 
-int CClient::SnapItemSize(int SnapID, int Index)
+int CClient::SnapItemSize(int SnapID, int Index) const
 {
 	dbg_assert(SnapID >= 0 && SnapID < NUM_SNAPSHOT_TYPES, "invalid SnapID");
 	return m_aSnapshots[g_Config.m_ClDummy][SnapID]->m_pAltSnap->GetItemSize(Index);
@@ -953,7 +953,7 @@ void CClient::SnapInvalidateItem(int SnapID, int Index)
 	}
 }
 
-void *CClient::SnapFindItem(int SnapID, int Type, int ID)
+void *CClient::SnapFindItem(int SnapID, int Type, int ID) const
 {
 	// TODO: linear search. should be fixed.
 	int i;
@@ -970,7 +970,7 @@ void *CClient::SnapFindItem(int SnapID, int Type, int ID)
 	return 0x0;
 }
 
-int CClient::SnapNumItems(int SnapID)
+int CClient::SnapNumItems(int SnapID) const
 {
 	dbg_assert(SnapID >= 0 && SnapID < NUM_SNAPSHOT_TYPES, "invalid SnapID");
 	if(!m_aSnapshots[g_Config.m_ClDummy][SnapID])
@@ -1083,7 +1083,7 @@ void CClient::Quit()
 	SetState(IClient::STATE_QUITTING);
 }
 
-const char *CClient::PlayerName()
+const char *CClient::PlayerName() const
 {
 	if(g_Config.m_PlayerName[0])
 	{
@@ -1096,7 +1096,7 @@ const char *CClient::PlayerName()
 	return "nameless tee";
 }
 
-const char *CClient::DummyName()
+const char *CClient::DummyName() const
 {
 	if(g_Config.m_ClDummyName[0])
 	{
@@ -1113,13 +1113,14 @@ const char *CClient::DummyName()
 	}
 	if(pBase)
 	{
-		str_format(m_aDummyNameBuf, sizeof(m_aDummyNameBuf), "[D] %s", pBase);
-		return m_aDummyNameBuf;
+		static char aDummyNameBuf[16];
+		str_format(aDummyNameBuf, sizeof(aDummyNameBuf), "[D] %s", pBase);
+		return aDummyNameBuf;
 	}
 	return "brainless tee";
 }
 
-const char *CClient::ErrorString()
+const char *CClient::ErrorString() const
 {
 	return m_NetClient[CLIENT_MAIN].ErrorString();
 }
@@ -4435,22 +4436,22 @@ int main(int argc, const char **argv) // ignore_convention
 
 // DDRace
 
-const char *CClient::GetCurrentMap()
+const char *CClient::GetCurrentMap() const
 {
 	return m_aCurrentMap;
 }
 
-const char *CClient::GetCurrentMapPath()
+const char *CClient::GetCurrentMapPath() const
 {
 	return m_aCurrentMapPath;
 }
 
-SHA256_DIGEST CClient::GetCurrentMapSha256()
+SHA256_DIGEST CClient::GetCurrentMapSha256() const
 {
 	return m_pMap->Sha256();
 }
 
-unsigned CClient::GetCurrentMapCrc()
+unsigned CClient::GetCurrentMapCrc() const
 {
 	return m_pMap->Crc();
 }

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -197,8 +197,6 @@ class CClient : public IClient, public CDemoPlayer::IListener
 	char m_aDDNetInfoTmp[64];
 	std::shared_ptr<CGetFile> m_pDDNetInfoTask;
 
-	char m_aDummyNameBuf[16];
-
 	// time
 	CSmoothTime m_GameTime[NUM_DUMMIES];
 	CSmoothTime m_PredictedTime;
@@ -297,25 +295,25 @@ public:
 	void SendReady();
 	void SendMapRequest();
 
-	virtual bool RconAuthed() { return m_RconAuthed[g_Config.m_ClDummy] != 0; }
-	virtual bool UseTempRconCommands() { return m_UseTempRconCommands != 0; }
+	virtual bool RconAuthed() const { return m_RconAuthed[g_Config.m_ClDummy] != 0; }
+	virtual bool UseTempRconCommands() const { return m_UseTempRconCommands != 0; }
 	void RconAuth(const char *pName, const char *pPassword);
 	virtual void Rcon(const char *pCmd);
 
-	virtual bool ConnectionProblems();
+	virtual bool ConnectionProblems() const;
 
-	virtual bool SoundInitFailed() { return m_SoundInitFailed; }
+	virtual bool SoundInitFailed() const { return m_SoundInitFailed; }
 
-	virtual IGraphics::CTextureHandle GetDebugFont() { return m_DebugFont; }
+	virtual IGraphics::CTextureHandle GetDebugFont() const { return m_DebugFont; }
 
 	void DirectInput(int *pInput, int Size);
 	void SendInput();
 
 	// TODO: OPT: do this a lot smarter!
-	virtual int *GetInput(int Tick, int IsDummy);
-	virtual int *GetDirectInput(int Tick, int IsDummy);
+	virtual int *GetInput(int Tick, int IsDummy) const;
+	virtual int *GetDirectInput(int Tick, int IsDummy) const;
 
-	const char *LatestVersion();
+	const char *LatestVersion() const;
 
 	// ------ state handling -----
 	void SetState(int s);
@@ -335,7 +333,7 @@ public:
 	int m_DummyConnected;
 	int m_LastDummyConnectTime;
 
-	virtual void GetServerInfo(CServerInfo *pServerInfo);
+	virtual void GetServerInfo(CServerInfo *pServerInfo) const;
 	void ServerInfoRequest();
 
 	int LoadData();
@@ -343,11 +341,11 @@ public:
 	// ---
 
 	int GetPredictionTime();
-	void *SnapGetItem(int SnapID, int Index, CSnapItem *pItem);
-	int SnapItemSize(int SnapID, int Index);
+	void *SnapGetItem(int SnapID, int Index, CSnapItem *pItem) const;
+	int SnapItemSize(int SnapID, int Index) const;
 	void SnapInvalidateItem(int SnapID, int Index);
-	void *SnapFindItem(int SnapID, int Type, int ID);
-	int SnapNumItems(int SnapID);
+	void *SnapFindItem(int SnapID, int Type, int ID) const;
+	int SnapNumItems(int SnapID) const;
 	void SnapSetStaticsize(int ItemType, int Size);
 
 	void Render();
@@ -356,9 +354,9 @@ public:
 	virtual void Restart();
 	virtual void Quit();
 
-	virtual const char *PlayerName();
-	virtual const char *DummyName();
-	virtual const char *ErrorString();
+	virtual const char *PlayerName() const;
+	virtual const char *DummyName() const;
+	virtual const char *ErrorString() const;
 
 	const char *LoadMap(const char *pName, const char *pFilename, SHA256_DIGEST *pWantedSha256, unsigned WantedCrc);
 	const char *LoadMapSearch(const char *pMapName, SHA256_DIGEST *pWantedSha256, int WantedCrc);
@@ -379,9 +377,9 @@ public:
 	void FinishDDNetInfo();
 	void LoadDDNetInfo();
 
-	virtual const char *MapDownloadName() { return m_aMapdownloadName; }
-	virtual int MapDownloadAmount() { return !m_pMapdownloadTask ? m_MapdownloadAmount : (int)m_pMapdownloadTask->Current(); }
-	virtual int MapDownloadTotalsize() { return !m_pMapdownloadTask ? m_MapdownloadTotalsize : (int)m_pMapdownloadTask->Size(); }
+	virtual const char *MapDownloadName() const { return m_aMapdownloadName; }
+	virtual int MapDownloadAmount() const { return !m_pMapdownloadTask ? m_MapdownloadAmount : (int)m_pMapdownloadTask->Current(); }
+	virtual int MapDownloadTotalsize() const { return !m_pMapdownloadTask ? m_MapdownloadTotalsize : (int)m_pMapdownloadTask->Size(); }
 
 	void PumpNetwork();
 
@@ -482,10 +480,10 @@ public:
 
 	virtual int GetCurrentRaceTime();
 
-	virtual const char *GetCurrentMap();
-	virtual const char *GetCurrentMapPath();
-	virtual SHA256_DIGEST GetCurrentMapSha256();
-	virtual unsigned GetCurrentMapCrc();
+	virtual const char *GetCurrentMap() const;
+	virtual const char *GetCurrentMapPath() const;
+	virtual SHA256_DIGEST GetCurrentMapSha256() const;
+	virtual unsigned GetCurrentMapCrc() const;
 
 	virtual void RaceRecord_Start(const char *pFilename);
 	virtual void RaceRecord_Stop();
@@ -496,7 +494,7 @@ public:
 	virtual void DemoSlice(const char *pDstPath, CLIENTFUNC_FILTER pfnFilter, void *pUser);
 	virtual void SaveReplay(const int Length);
 
-	virtual bool EditorHasUnsavedData() { return m_pEditor->HasUnsavedData(); }
+	virtual bool EditorHasUnsavedData() const { return m_pEditor->HasUnsavedData(); }
 
 	virtual IFriends *Foes() { return &m_Foes; }
 

--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -2570,7 +2570,7 @@ void CGraphics_Threaded::InsertSignal(CSemaphore *pSemaphore)
 	m_pCommandBuffer->AddCommand(Cmd);
 }
 
-bool CGraphics_Threaded::IsIdle()
+bool CGraphics_Threaded::IsIdle() const
 {
 	return m_pBackend->IsIdle();
 }

--- a/src/engine/client/graphics_threaded.h
+++ b/src/engine/client/graphics_threaded.h
@@ -54,8 +54,8 @@ class CCommandBuffer
 		}
 
 		unsigned char *DataPtr() { return m_pData; }
-		unsigned DataSize() { return m_Size; }
-		unsigned DataUsed() { return m_Used; }
+		unsigned DataSize() const { return m_Size; }
+		unsigned DataUsed() const { return m_Used; }
 	};
 
 public:
@@ -1135,12 +1135,12 @@ public:
 
 	int GetVideoModes(CVideoMode *pModes, int MaxModes, int Screen) override;
 
-	virtual int GetDesktopScreenWidth() { return m_DesktopScreenWidth; }
-	virtual int GetDesktopScreenHeight() { return m_DesktopScreenHeight; }
+	virtual int GetDesktopScreenWidth() const { return m_DesktopScreenWidth; }
+	virtual int GetDesktopScreenHeight() const { return m_DesktopScreenHeight; }
 
 	// synchronization
 	void InsertSignal(CSemaphore *pSemaphore) override;
-	bool IsIdle() override;
+	bool IsIdle() const override;
 	void WaitForIdle() override;
 
 	SWarning *GetCurWarning() override;

--- a/src/engine/editor.h
+++ b/src/engine/editor.h
@@ -11,7 +11,7 @@ public:
 	virtual ~IEditor() {}
 	virtual void Init() = 0;
 	virtual void UpdateAndRender() = 0;
-	virtual bool HasUnsavedData() = 0;
+	virtual bool HasUnsavedData() const = 0;
 	virtual int Load(const char *pFilename, int StorageType) = 0;
 	virtual int Save(const char *pFilename) = 0;
 	virtual void UpdateMentions() = 0;

--- a/src/engine/graphics.h
+++ b/src/engine/graphics.h
@@ -375,7 +375,7 @@ public:
 
 	// synchronization
 	virtual void InsertSignal(class CSemaphore *pSemaphore) = 0;
-	virtual bool IsIdle() = 0;
+	virtual bool IsIdle() const = 0;
 	virtual void WaitForIdle() = 0;
 
 	virtual void SetWindowGrab(bool Grab) = 0;

--- a/src/engine/masterserver.h
+++ b/src/engine/masterserver.h
@@ -21,12 +21,12 @@ public:
 
 	virtual int RefreshAddresses(int Nettype) = 0;
 	virtual void Update() = 0;
-	virtual int IsRefreshing() = 0;
-	virtual NETADDR GetAddr(int Index) = 0;
+	virtual bool IsRefreshing() const = 0;
+	virtual NETADDR GetAddr(int Index) const = 0;
 	virtual void SetCount(int Index, int Count) = 0;
-	virtual int GetCount(int Index) = 0;
-	virtual const char *GetName(int Index) = 0;
-	virtual bool IsValid(int Index) = 0;
+	virtual int GetCount(int Index) const = 0;
+	virtual const char *GetName(int Index) const = 0;
+	virtual bool IsValid(int Index) const = 0;
 };
 
 class IEngineMasterServer : public IMasterServer

--- a/src/engine/server.h
+++ b/src/engine/server.h
@@ -267,7 +267,22 @@ public:
 
 	virtual void OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID) = 0;
 
-	virtual void OnClientConnected(int ClientID) = 0;
+	// Called before map reload, for any data that the game wants to
+	// persist to the next map.
+	//
+	// Has the size of the return value of `PersistentClientDataSize()`.
+	//
+	// Returns whether the game should be supplied with the data when the
+	// client connects for the next map.
+	virtual bool OnClientDataPersist(int ClientID, void *pData) = 0;
+
+	// Called when a client connects.
+	//
+	// If it is reconnecting to the game after a map change, the
+	// `pPersistentData` point is nonnull and contains the data the game
+	// previously stored.
+	virtual void OnClientConnected(int ClientID, void *pPersistentData) = 0;
+
 	virtual void OnClientEnter(int ClientID) = 0;
 	virtual void OnClientDrop(int ClientID, const char *pReason) = 0;
 	virtual void OnClientDirectInput(int ClientID, void *pInput) = 0;
@@ -276,6 +291,8 @@ public:
 
 	virtual bool IsClientReady(int ClientID) const = 0;
 	virtual bool IsClientPlayer(int ClientID) const = 0;
+
+	virtual int PersistentClientDataSize() const = 0;
 
 	virtual CUuid GameUuid() const = 0;
 	virtual const char *GameType() const = 0;

--- a/src/engine/server.h
+++ b/src/engine/server.h
@@ -43,16 +43,16 @@ public:
 
 	virtual int Port() const = 0;
 	virtual int MaxClients() const = 0;
-	virtual int ClientCount() = 0;
-	virtual int DistinctClientCount() = 0;
-	virtual const char *ClientName(int ClientID) = 0;
-	virtual const char *ClientClan(int ClientID) = 0;
-	virtual int ClientCountry(int ClientID) = 0;
-	virtual bool ClientIngame(int ClientID) = 0;
-	virtual bool ClientAuthed(int ClientID) = 0;
-	virtual int GetClientInfo(int ClientID, CClientInfo *pInfo) = 0;
+	virtual int ClientCount() const = 0;
+	virtual int DistinctClientCount() const = 0;
+	virtual const char *ClientName(int ClientID) const = 0;
+	virtual const char *ClientClan(int ClientID) const = 0;
+	virtual int ClientCountry(int ClientID) const = 0;
+	virtual bool ClientIngame(int ClientID) const = 0;
+	virtual bool ClientAuthed(int ClientID) const = 0;
+	virtual int GetClientInfo(int ClientID, CClientInfo *pInfo) const = 0;
 	virtual void SetClientDDNetVersion(int ClientID, int DDNetVersion) = 0;
-	virtual void GetClientAddr(int ClientID, char *pAddrStr, int Size) = 0;
+	virtual void GetClientAddr(int ClientID, char *pAddrStr, int Size) const = 0;
 	virtual void RestrictRconOutput(int ClientID) = 0;
 
 	virtual int SendMsg(CMsgPacker *pMsg, int Flags, int ClientID) = 0;
@@ -209,8 +209,8 @@ public:
 		RCON_CID_VOTE = -2,
 	};
 	virtual void SetRconCID(int ClientID) = 0;
-	virtual int GetAuthedState(int ClientID) = 0;
-	virtual const char *GetAuthName(int ClientID) = 0;
+	virtual int GetAuthedState(int ClientID) const = 0;
+	virtual const char *GetAuthName(int ClientID) const = 0;
 	virtual void Kick(int ClientID, const char *pReason) = 0;
 	virtual void Ban(int ClientID, int Seconds, const char *pReason) = 0;
 
@@ -224,7 +224,7 @@ public:
 	virtual void StopRecord(int ClientID) = 0;
 	virtual bool IsRecording(int ClientID) = 0;
 
-	virtual void GetClientAddr(int ClientID, NETADDR *pAddr) = 0;
+	virtual void GetClientAddr(int ClientID, NETADDR *pAddr) const = 0;
 
 	virtual int *GetIdMap(int ClientID) = 0;
 
@@ -243,7 +243,7 @@ public:
 
 	virtual void SendMsgRaw(int ClientID, const void *pData, int Size, int Flags) = 0;
 
-	virtual char *GetMapName() = 0;
+	virtual char *GetMapName() const = 0;
 
 	virtual bool IsSixup(int ClientID) const = 0;
 };
@@ -274,18 +274,18 @@ public:
 	virtual void OnClientPredictedInput(int ClientID, void *pInput) = 0;
 	virtual void OnClientPredictedEarlyInput(int ClientID, void *pInput) = 0;
 
-	virtual bool IsClientReady(int ClientID) = 0;
-	virtual bool IsClientPlayer(int ClientID) = 0;
+	virtual bool IsClientReady(int ClientID) const = 0;
+	virtual bool IsClientPlayer(int ClientID) const = 0;
 
-	virtual CUuid GameUuid() = 0;
-	virtual const char *GameType() = 0;
-	virtual const char *Version() = 0;
-	virtual const char *NetVersion() = 0;
+	virtual CUuid GameUuid() const = 0;
+	virtual const char *GameType() const = 0;
+	virtual const char *Version() const = 0;
+	virtual const char *NetVersion() const = 0;
 
 	// DDRace
 
 	virtual void OnSetAuthed(int ClientID, int Level) = 0;
-	virtual bool PlayerExists(int ClientID) = 0;
+	virtual bool PlayerExists(int ClientID) const = 0;
 
 	virtual void OnClientEngineJoin(int ClientID, bool Sixup) = 0;
 	virtual void OnClientEngineDrop(int ClientID, const char *pReason) = 0;

--- a/src/engine/server/authmanager.cpp
+++ b/src/engine/server/authmanager.cpp
@@ -80,7 +80,7 @@ int CAuthManager::RemoveKey(int Slot)
 	return m_aKeys.size();
 }
 
-int CAuthManager::FindKey(const char *pIdent)
+int CAuthManager::FindKey(const char *pIdent) const
 {
 	for(int i = 0; i < m_aKeys.size(); i++)
 		if(!str_comp(m_aKeys[i].m_aIdent, pIdent))
@@ -89,28 +89,28 @@ int CAuthManager::FindKey(const char *pIdent)
 	return -1;
 }
 
-bool CAuthManager::CheckKey(int Slot, const char *pPw)
+bool CAuthManager::CheckKey(int Slot, const char *pPw) const
 {
 	if(Slot < 0 || Slot >= m_aKeys.size())
 		return false;
 	return m_aKeys[Slot].m_Pw == HashPassword(pPw, m_aKeys[Slot].m_aSalt);
 }
 
-int CAuthManager::DefaultKey(int AuthLevel)
+int CAuthManager::DefaultKey(int AuthLevel) const
 {
 	if(AuthLevel < 0 || AuthLevel > AUTHED_ADMIN)
 		return 0;
 	return m_aDefault[AUTHED_ADMIN - AuthLevel];
 }
 
-int CAuthManager::KeyLevel(int Slot)
+int CAuthManager::KeyLevel(int Slot) const
 {
 	if(Slot < 0 || Slot >= m_aKeys.size())
 		return false;
 	return m_aKeys[Slot].m_Level;
 }
 
-const char *CAuthManager::KeyIdent(int Slot)
+const char *CAuthManager::KeyIdent(int Slot) const
 {
 	if(Slot < 0 || Slot >= m_aKeys.size())
 		return NULL;
@@ -157,12 +157,12 @@ void CAuthManager::AddDefaultKey(int Level, const char *pPw)
 	m_aDefault[Index] = AddKey(IDENTS[Index], pPw, Level);
 }
 
-bool CAuthManager::IsGenerated()
+bool CAuthManager::IsGenerated() const
 {
 	return m_Generated;
 }
 
-int CAuthManager::NumNonDefaultKeys()
+int CAuthManager::NumNonDefaultKeys() const
 {
 	int DefaultCount = (m_aDefault[0] >= 0) + (m_aDefault[1] >= 0) + (m_aDefault[2] >= 0);
 	return m_aKeys.size() - DefaultCount;

--- a/src/engine/server/authmanager.h
+++ b/src/engine/server/authmanager.h
@@ -37,17 +37,17 @@ public:
 	int AddKeyHash(const char *pIdent, MD5_DIGEST Hash, const unsigned char *pSalt, int AuthLevel);
 	int AddKey(const char *pIdent, const char *pPw, int AuthLevel);
 	int RemoveKey(int Slot); // Returns the old key slot that is now in the named one.
-	int FindKey(const char *pIdent);
-	bool CheckKey(int Slot, const char *pPw);
-	int DefaultKey(int AuthLevel);
-	int KeyLevel(int Slot);
-	const char *KeyIdent(int Slot);
+	int FindKey(const char *pIdent) const;
+	bool CheckKey(int Slot, const char *pPw) const;
+	int DefaultKey(int AuthLevel) const;
+	int KeyLevel(int Slot) const;
+	const char *KeyIdent(int Slot) const;
 	void UpdateKeyHash(int Slot, MD5_DIGEST Hash, const unsigned char *pSalt, int AuthLevel);
 	void UpdateKey(int Slot, const char *pPw, int AuthLevel);
 	void ListKeys(FListCallback pfnListCallbac, void *pUser);
 	void AddDefaultKey(int Level, const char *pPw);
-	bool IsGenerated();
-	int NumNonDefaultKeys();
+	bool IsGenerated() const;
+	int NumNonDefaultKeys() const;
 };
 
 #endif //ENGINE_SERVER_AUTHMANAGER_H

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -539,12 +539,12 @@ void CServer::SetRconCID(int ClientID)
 	m_RconClientID = ClientID;
 }
 
-int CServer::GetAuthedState(int ClientID)
+int CServer::GetAuthedState(int ClientID) const
 {
 	return m_aClients[ClientID].m_Authed;
 }
 
-const char *CServer::GetAuthName(int ClientID)
+const char *CServer::GetAuthName(int ClientID) const
 {
 	int Key = m_aClients[ClientID].m_AuthKey;
 	if(Key == -1)
@@ -554,7 +554,7 @@ const char *CServer::GetAuthName(int ClientID)
 	return m_AuthManager.KeyIdent(Key);
 }
 
-int CServer::GetClientInfo(int ClientID, CClientInfo *pInfo)
+int CServer::GetClientInfo(int ClientID, CClientInfo *pInfo) const
 {
 	dbg_assert(ClientID >= 0 && ClientID < MAX_CLIENTS, "client_id is not valid");
 	dbg_assert(pInfo != 0, "info can not be null");
@@ -591,13 +591,13 @@ void CServer::SetClientDDNetVersion(int ClientID, int DDNetVersion)
 	}
 }
 
-void CServer::GetClientAddr(int ClientID, char *pAddrStr, int Size)
+void CServer::GetClientAddr(int ClientID, char *pAddrStr, int Size) const
 {
 	if(ClientID >= 0 && ClientID < MAX_CLIENTS && m_aClients[ClientID].m_State == CClient::STATE_INGAME)
 		net_addr_str(m_NetServer.ClientAddr(ClientID), pAddrStr, Size, false);
 }
 
-const char *CServer::ClientName(int ClientID)
+const char *CServer::ClientName(int ClientID) const
 {
 	if(ClientID < 0 || ClientID >= MAX_CLIENTS || m_aClients[ClientID].m_State == CServer::CClient::STATE_EMPTY)
 		return "(invalid)";
@@ -607,7 +607,7 @@ const char *CServer::ClientName(int ClientID)
 		return "(connecting)";
 }
 
-const char *CServer::ClientClan(int ClientID)
+const char *CServer::ClientClan(int ClientID) const
 {
 	if(ClientID < 0 || ClientID >= MAX_CLIENTS || m_aClients[ClientID].m_State == CServer::CClient::STATE_EMPTY)
 		return "";
@@ -617,7 +617,7 @@ const char *CServer::ClientClan(int ClientID)
 		return "";
 }
 
-int CServer::ClientCountry(int ClientID)
+int CServer::ClientCountry(int ClientID) const
 {
 	if(ClientID < 0 || ClientID >= MAX_CLIENTS || m_aClients[ClientID].m_State == CServer::CClient::STATE_EMPTY)
 		return -1;
@@ -627,12 +627,12 @@ int CServer::ClientCountry(int ClientID)
 		return -1;
 }
 
-bool CServer::ClientIngame(int ClientID)
+bool CServer::ClientIngame(int ClientID) const
 {
 	return ClientID >= 0 && ClientID < MAX_CLIENTS && m_aClients[ClientID].m_State == CServer::CClient::STATE_INGAME;
 }
 
-bool CServer::ClientAuthed(int ClientID)
+bool CServer::ClientAuthed(int ClientID) const
 {
 	return ClientID >= 0 && ClientID < MAX_CLIENTS && m_aClients[ClientID].m_Authed;
 }
@@ -647,10 +647,10 @@ int CServer::MaxClients() const
 	return m_NetServer.MaxClients();
 }
 
-int CServer::ClientCount()
+int CServer::ClientCount() const
 {
 	int ClientCount = 0;
-	for(auto &Client : m_aClients)
+	for(const auto &Client : m_aClients)
 	{
 		if(Client.m_State != CClient::STATE_EMPTY)
 		{
@@ -661,7 +661,7 @@ int CServer::ClientCount()
 	return ClientCount;
 }
 
-int CServer::DistinctClientCount()
+int CServer::DistinctClientCount() const
 {
 	NETADDR aAddresses[MAX_CLIENTS];
 	for(int i = 0; i < MAX_CLIENTS; i++)
@@ -2234,7 +2234,7 @@ void CServer::PumpNetwork(bool PacketWaiting)
 	m_Econ.Update();
 }
 
-char *CServer::GetMapName()
+char *CServer::GetMapName() const
 {
 	// get the name of the map without his path
 	char *pMapShortName = &g_Config.m_SvMap[0];
@@ -3564,7 +3564,7 @@ int main(int argc, const char **argv) // ignore_convention
 
 // DDRace
 
-void CServer::GetClientAddr(int ClientID, NETADDR *pAddr)
+void CServer::GetClientAddr(int ClientID, NETADDR *pAddr) const
 {
 	if(ClientID >= 0 && ClientID < MAX_CLIENTS && m_aClients[ClientID].m_State == CClient::STATE_INGAME)
 	{

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -178,6 +178,9 @@ public:
 
 		const IConsole::CCommandInfo *m_pRconCmdToSend;
 
+		bool m_HasPersistentData;
+		void *m_pPersistentData;
+
 		void Reset();
 
 		// DDRace

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -284,21 +284,21 @@ public:
 	int Init();
 
 	void SetRconCID(int ClientID);
-	int GetAuthedState(int ClientID);
-	const char *GetAuthName(int ClientID);
+	int GetAuthedState(int ClientID) const;
+	const char *GetAuthName(int ClientID) const;
 	void GetMapInfo(char *pMapName, int MapNameSize, int *pMapSize, SHA256_DIGEST *pMapSha256, int *pMapCrc);
-	int GetClientInfo(int ClientID, CClientInfo *pInfo);
+	int GetClientInfo(int ClientID, CClientInfo *pInfo) const;
 	void SetClientDDNetVersion(int ClientID, int DDNetVersion);
-	void GetClientAddr(int ClientID, char *pAddrStr, int Size);
-	const char *ClientName(int ClientID);
-	const char *ClientClan(int ClientID);
-	int ClientCountry(int ClientID);
-	bool ClientIngame(int ClientID);
-	bool ClientAuthed(int ClientID);
+	void GetClientAddr(int ClientID, char *pAddrStr, int Size) const;
+	const char *ClientName(int ClientID) const;
+	const char *ClientClan(int ClientID) const;
+	int ClientCountry(int ClientID) const;
+	bool ClientIngame(int ClientID) const;
+	bool ClientAuthed(int ClientID) const;
 	int Port() const;
 	int MaxClients() const;
-	int ClientCount();
-	int DistinctClientCount();
+	int ClientCount() const;
+	int DistinctClientCount() const;
 
 	virtual int SendMsg(CMsgPacker *pMsg, int Flags, int ClientID);
 
@@ -360,7 +360,7 @@ public:
 
 	void PumpNetwork(bool PacketWaiting);
 
-	char *GetMapName();
+	char *GetMapName() const;
 	int LoadMap(const char *pMapName);
 
 	void SaveDemo(int ClientID, float Time);
@@ -423,7 +423,7 @@ public:
 
 	// DDRace
 
-	void GetClientAddr(int ClientID, NETADDR *pAddr);
+	void GetClientAddr(int ClientID, NETADDR *pAddr) const;
 	int m_aPrevStates[MAX_CLIENTS];
 	const char *GetAnnouncementLine(char const *pFileName);
 	unsigned m_AnnouncementLastLine;

--- a/src/engine/shared/datafile.cpp
+++ b/src/engine/shared/datafile.cpp
@@ -278,7 +278,7 @@ bool CDataFileReader::Open(class IStorage *pStorage, const char *pFilename, int 
 	return true;
 }
 
-int CDataFileReader::NumData()
+int CDataFileReader::NumData() const
 {
 	if(!m_pDataFile)
 	{
@@ -395,7 +395,7 @@ void CDataFileReader::UnloadData(int Index)
 	m_pDataFile->m_ppDataPtrs[Index] = 0x0;
 }
 
-int CDataFileReader::GetItemSize(int Index)
+int CDataFileReader::GetItemSize(int Index) const
 {
 	if(!m_pDataFile)
 		return 0;
@@ -519,7 +519,7 @@ void *CDataFileReader::FindItem(int Type, int ID)
 	return GetItem(Index, 0, 0);
 }
 
-int CDataFileReader::NumItems()
+int CDataFileReader::NumItems() const
 {
 	if(!m_pDataFile)
 		return 0;
@@ -542,7 +542,7 @@ bool CDataFileReader::Close()
 	return true;
 }
 
-SHA256_DIGEST CDataFileReader::Sha256()
+SHA256_DIGEST CDataFileReader::Sha256() const
 {
 	if(!m_pDataFile)
 	{
@@ -556,14 +556,14 @@ SHA256_DIGEST CDataFileReader::Sha256()
 	return m_pDataFile->m_Sha256;
 }
 
-unsigned CDataFileReader::Crc()
+unsigned CDataFileReader::Crc() const
 {
 	if(!m_pDataFile)
 		return 0xFFFFFFFF;
 	return m_pDataFile->m_Crc;
 }
 
-int CDataFileReader::MapSize()
+int CDataFileReader::MapSize() const
 {
 	if(!m_pDataFile)
 		return 0;

--- a/src/engine/shared/datafile.h
+++ b/src/engine/shared/datafile.h
@@ -35,17 +35,17 @@ public:
 	int GetDataSize(int Index);
 	void UnloadData(int Index);
 	void *GetItem(int Index, int *pType, int *pID);
-	int GetItemSize(int Index);
+	int GetItemSize(int Index) const;
 	void GetType(int Type, int *pStart, int *pNum);
 	int FindItemIndex(int Type, int ID);
 	void *FindItem(int Type, int ID);
-	int NumItems();
-	int NumData();
+	int NumItems() const;
+	int NumData() const;
 	void Unload();
 
-	SHA256_DIGEST Sha256();
-	unsigned Crc();
-	int MapSize();
+	SHA256_DIGEST Sha256() const;
+	unsigned Crc() const;
+	int MapSize() const;
 	IOHANDLE File();
 };
 

--- a/src/engine/shared/masterserver.cpp
+++ b/src/engine/shared/masterserver.cpp
@@ -97,12 +97,12 @@ public:
 		}
 	}
 
-	virtual int IsRefreshing()
+	virtual bool IsRefreshing() const
 	{
 		return m_State != STATE_READY;
 	}
 
-	virtual NETADDR GetAddr(int Index)
+	virtual NETADDR GetAddr(int Index) const
 	{
 		return m_aMasterServers[Index].m_Addr;
 	}
@@ -112,17 +112,17 @@ public:
 		m_aMasterServers[Index].m_Count = Count;
 	}
 
-	virtual int GetCount(int Index)
+	virtual int GetCount(int Index) const
 	{
 		return m_aMasterServers[Index].m_Count;
 	}
 
-	virtual const char *GetName(int Index)
+	virtual const char *GetName(int Index) const
 	{
 		return m_aMasterServers[Index].m_aHostname;
 	}
 
-	virtual bool IsValid(int Index)
+	virtual bool IsValid(int Index) const
 	{
 		return m_aMasterServers[Index].m_Valid;
 	}

--- a/src/engine/shared/network.h
+++ b/src/engine/shared/network.h
@@ -455,8 +455,8 @@ public:
 	// error and state
 	int NetType() const { return m_Socket.type; }
 	int State();
-	int GotProblems();
-	const char *ErrorString();
+	int GotProblems() const;
+	const char *ErrorString() const;
 
 	bool SecurityTokenUnknown() { return m_Connection.SecurityToken() == NET_SECURITY_TOKEN_UNKNOWN; }
 };

--- a/src/engine/shared/network_client.cpp
+++ b/src/engine/shared/network_client.cpp
@@ -143,14 +143,14 @@ int CNetClient::Flush()
 	return m_Connection.Flush();
 }
 
-int CNetClient::GotProblems()
+int CNetClient::GotProblems() const
 {
 	if(time_get() - m_Connection.LastRecvTime() > time_freq())
 		return 1;
 	return 0;
 }
 
-const char *CNetClient::ErrorString()
+const char *CNetClient::ErrorString() const
 {
 	return m_Connection.ErrorString();
 }

--- a/src/engine/shared/snapshot.cpp
+++ b/src/engine/shared/snapshot.cpp
@@ -9,19 +9,19 @@
 
 // CSnapshot
 
-CSnapshotItem *CSnapshot::GetItem(int Index)
+CSnapshotItem *CSnapshot::GetItem(int Index) const
 {
 	return (CSnapshotItem *)(DataStart() + Offsets()[Index]);
 }
 
-int CSnapshot::GetItemSize(int Index)
+int CSnapshot::GetItemSize(int Index) const
 {
 	if(Index == m_NumItems - 1)
 		return (m_DataSize - Offsets()[Index]) - sizeof(CSnapshotItem);
 	return (Offsets()[Index + 1] - Offsets()[Index]) - sizeof(CSnapshotItem);
 }
 
-int CSnapshot::GetItemType(int Index)
+int CSnapshot::GetItemType(int Index) const
 {
 	int InternalType = GetItem(Index)->Type();
 	if(InternalType < OFFSET_UUID_TYPE)
@@ -48,7 +48,7 @@ int CSnapshot::GetItemType(int Index)
 	return g_UuidManager.LookupUuid(Uuid);
 }
 
-int CSnapshot::GetItemIndex(int Key)
+int CSnapshot::GetItemIndex(int Key) const
 {
 	// TODO: OPT: this should not be a linear search. very bad
 	for(int i = 0; i < m_NumItems; i++)

--- a/src/engine/shared/snapshot.h
+++ b/src/engine/shared/snapshot.h
@@ -13,9 +13,9 @@ public:
 	int m_TypeAndID;
 
 	int *Data() { return (int *)(this + 1); }
-	int Type() { return m_TypeAndID >> 16; }
-	int ID() { return m_TypeAndID & 0xffff; }
-	int Key() { return m_TypeAndID; }
+	int Type() const { return m_TypeAndID >> 16; }
+	int ID() const { return m_TypeAndID & 0xffff; }
+	int Key() const { return m_TypeAndID; }
 };
 
 class CSnapshot
@@ -42,10 +42,10 @@ public:
 		m_NumItems = 0;
 	}
 	int NumItems() const { return m_NumItems; }
-	CSnapshotItem *GetItem(int Index);
-	int GetItemSize(int Index);
-	int GetItemIndex(int Key);
-	int GetItemType(int Index);
+	CSnapshotItem *GetItem(int Index) const;
+	int GetItemSize(int Index) const;
+	int GetItemIndex(int Key) const;
+	int GetItemType(int Index) const;
 
 	unsigned Crc();
 	void DebugDump();

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -112,11 +112,11 @@ static CGhost gs_Ghost;
 CGameClient::CStack::CStack() { m_Num = 0; }
 void CGameClient::CStack::Add(class CComponent *pComponent) { m_paComponents[m_Num++] = pComponent; }
 
-const char *CGameClient::Version() { return GAME_VERSION; }
-const char *CGameClient::NetVersion() { return GAME_NETVERSION; }
-int CGameClient::DDNetVersion() { return CLIENT_VERSIONNR; }
-const char *CGameClient::DDNetVersionStr() { return m_aDDNetVersionStr; }
-const char *CGameClient::GetItemName(int Type) { return m_NetObjHandler.GetObjName(Type); }
+const char *CGameClient::Version() const { return GAME_VERSION; }
+const char *CGameClient::NetVersion() const { return GAME_NETVERSION; }
+int CGameClient::DDNetVersion() const { return CLIENT_VERSIONNR; }
+const char *CGameClient::DDNetVersionStr() const { return m_aDDNetVersionStr; }
+const char *CGameClient::GetItemName(int Type) const { return m_NetObjHandler.GetObjName(Type); }
 
 void CGameClient::OnConsoleInit()
 {

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -383,11 +383,11 @@ public:
 
 	void OnLanguageChange();
 
-	virtual const char *GetItemName(int Type);
-	virtual const char *Version();
-	virtual const char *NetVersion();
-	virtual int DDNetVersion();
-	virtual const char *DDNetVersionStr();
+	virtual const char *GetItemName(int Type) const;
+	virtual const char *Version() const;
+	virtual const char *NetVersion() const;
+	virtual int DDNetVersion() const;
+	virtual const char *DDNetVersionStr() const;
 
 	// actions
 	// TODO: move these

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -118,14 +118,14 @@ int CUI::Update(float Mx, float My, float Mwx, float Mwy, int Buttons)
 	return 0;
 }
 
-int CUI::MouseInside(const CUIRect *r)
+int CUI::MouseInside(const CUIRect *r) const
 {
 	if(m_MouseX >= r->x && m_MouseX < r->x + r->w && m_MouseY >= r->y && m_MouseY < r->y + r->h)
 		return 1;
 	return 0;
 }
 
-void CUI::ConvertMouseMove(float *x, float *y)
+void CUI::ConvertMouseMove(float *x, float *y) const
 {
 	float Fac = (float)(g_Config.m_UiMousesens) / g_Config.m_InpMousesens;
 	*x = *x * Fac;
@@ -156,7 +156,7 @@ void CUI::SetScale(float s)
 	g_Config.m_UiScale = (int)(s * 100.0f);
 }
 
-float CUI::Scale()
+float CUI::Scale() const
 {
 	return g_Config.m_UiScale / 100.0f;
 }

--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -202,8 +202,8 @@ public:
 		m_pGraphics = pGraphics;
 		m_pTextRender = pTextRender;
 	}
-	class IGraphics *Graphics() { return m_pGraphics; }
-	class ITextRender *TextRender() { return m_pTextRender; }
+	class IGraphics *Graphics() const { return m_pGraphics; }
+	class ITextRender *TextRender() const { return m_pTextRender; }
 
 	CUI();
 	~CUI();
@@ -241,8 +241,8 @@ public:
 	float MouseWorldX() const { return m_MouseWorldX; }
 	float MouseWorldY() const { return m_MouseWorldY; }
 	int MouseButton(int Index) const { return (m_MouseButtons >> Index) & 1; }
-	int MouseButtonClicked(int Index) { return MouseButton(Index) && !((m_LastMouseButtons >> Index) & 1); }
-	int MouseButtonReleased(int Index) { return ((m_LastMouseButtons >> Index) & 1) && !MouseButton(Index); }
+	int MouseButtonClicked(int Index) const { return MouseButton(Index) && !((m_LastMouseButtons >> Index) & 1); }
+	int MouseButtonReleased(int Index) const { return ((m_LastMouseButtons >> Index) & 1) && !MouseButton(Index); }
 
 	void SetHotItem(const void *pID) { m_pBecommingHotItem = pID; }
 	void SetActiveItem(const void *pID)
@@ -257,8 +257,8 @@ public:
 	const void *ActiveItem() const { return m_pActiveItem; }
 	const void *LastActiveItem() const { return m_pLastActiveItem; }
 
-	int MouseInside(const CUIRect *pRect);
-	void ConvertMouseMove(float *x, float *y);
+	int MouseInside(const CUIRect *pRect) const;
+	void ConvertMouseMove(float *x, float *y) const;
 
 	CUIRect *Screen();
 	float PixelSize();
@@ -267,7 +267,7 @@ public:
 
 	// TODO: Refactor: Redo UI scaling
 	void SetScale(float s);
-	float Scale();
+	float Scale() const;
 
 	int DoButtonLogic(const void *pID, int Checked, const CUIRect *pRect);
 	int DoButtonLogic(const void *pID, const char *pText /* TODO: Refactor: Remove */, int Checked, const CUIRect *pRect);

--- a/src/game/collision.cpp
+++ b/src/game/collision.cpp
@@ -293,7 +293,7 @@ int CCollision::GetMoveRestrictions(CALLBACK_SWITCHACTIVE pfnSwitchActive, void 
 	return Restrictions;
 }
 
-int CCollision::GetTile(int x, int y)
+int CCollision::GetTile(int x, int y) const
 {
 	if(!m_pTiles)
 		return 0;
@@ -308,7 +308,7 @@ int CCollision::GetTile(int x, int y)
 }
 
 // TODO: rewrite this smarter!
-int CCollision::IntersectLine(vec2 Pos0, vec2 Pos1, vec2 *pOutCollision, vec2 *pOutBeforeCollision)
+int CCollision::IntersectLine(vec2 Pos0, vec2 Pos1, vec2 *pOutCollision, vec2 *pOutBeforeCollision) const
 {
 	float Distance = distance(Pos0, Pos1);
 	int End(Distance + 1);
@@ -339,7 +339,7 @@ int CCollision::IntersectLine(vec2 Pos0, vec2 Pos1, vec2 *pOutCollision, vec2 *p
 	return 0;
 }
 
-int CCollision::IntersectLineTeleHook(vec2 Pos0, vec2 Pos1, vec2 *pOutCollision, vec2 *pOutBeforeCollision, int *pTeleNr)
+int CCollision::IntersectLineTeleHook(vec2 Pos0, vec2 Pos1, vec2 *pOutCollision, vec2 *pOutBeforeCollision, int *pTeleNr) const
 {
 	float Distance = distance(Pos0, Pos1);
 	int End(Distance + 1);
@@ -396,7 +396,7 @@ int CCollision::IntersectLineTeleHook(vec2 Pos0, vec2 Pos1, vec2 *pOutCollision,
 	return 0;
 }
 
-int CCollision::IntersectLineTeleWeapon(vec2 Pos0, vec2 Pos1, vec2 *pOutCollision, vec2 *pOutBeforeCollision, int *pTeleNr)
+int CCollision::IntersectLineTeleWeapon(vec2 Pos0, vec2 Pos1, vec2 *pOutCollision, vec2 *pOutBeforeCollision, int *pTeleNr) const
 {
 	float Distance = distance(Pos0, Pos1);
 	int End(Distance + 1);
@@ -442,7 +442,7 @@ int CCollision::IntersectLineTeleWeapon(vec2 Pos0, vec2 Pos1, vec2 *pOutCollisio
 }
 
 // TODO: OPT: rewrite this smarter!
-void CCollision::MovePoint(vec2 *pInoutPos, vec2 *pInoutVel, float Elasticity, int *pBounces)
+void CCollision::MovePoint(vec2 *pInoutPos, vec2 *pInoutVel, float Elasticity, int *pBounces) const
 {
 	if(pBounces)
 		*pBounces = 0;
@@ -480,7 +480,7 @@ void CCollision::MovePoint(vec2 *pInoutPos, vec2 *pInoutVel, float Elasticity, i
 	}
 }
 
-bool CCollision::TestBox(vec2 Pos, vec2 Size)
+bool CCollision::TestBox(vec2 Pos, vec2 Size) const
 {
 	Size *= 0.5f;
 	if(CheckPoint(Pos.x - Size.x, Pos.y - Size.y))
@@ -494,7 +494,7 @@ bool CCollision::TestBox(vec2 Pos, vec2 Size)
 	return false;
 }
 
-void CCollision::MoveBox(vec2 *pInoutPos, vec2 *pInoutVel, vec2 Size, float Elasticity)
+void CCollision::MoveBox(vec2 *pInoutPos, vec2 *pInoutVel, vec2 Size, float Elasticity) const
 {
 	// do the move
 	vec2 Pos = *pInoutPos;
@@ -583,13 +583,13 @@ void CCollision::Dest()
 	m_pSwitchers = 0;
 }
 
-int CCollision::IsSolid(int x, int y)
+int CCollision::IsSolid(int x, int y) const
 {
 	int index = GetTile(x, y);
 	return index == TILE_SOLID || index == TILE_NOHOOK;
 }
 
-bool CCollision::IsThrough(int x, int y, int xoff, int yoff, vec2 pos0, vec2 pos1)
+bool CCollision::IsThrough(int x, int y, int xoff, int yoff, vec2 pos0, vec2 pos1) const
 {
 	int pos = GetPureMapIndex(x, y);
 	if(m_pFront && (m_pFront[pos].m_Index == TILE_THROUGH_ALL || m_pFront[pos].m_Index == TILE_THROUGH_CUT))
@@ -602,7 +602,7 @@ bool CCollision::IsThrough(int x, int y, int xoff, int yoff, vec2 pos0, vec2 pos
 	return false;
 }
 
-bool CCollision::IsHookBlocker(int x, int y, vec2 pos0, vec2 pos1)
+bool CCollision::IsHookBlocker(int x, int y, vec2 pos0, vec2 pos1) const
 {
 	int pos = GetPureMapIndex(x, y);
 	if(m_pTiles[pos].m_Index == TILE_THROUGH_ALL || (m_pFront && m_pFront[pos].m_Index == TILE_THROUGH_ALL))
@@ -617,7 +617,7 @@ bool CCollision::IsHookBlocker(int x, int y, vec2 pos0, vec2 pos1)
 	return false;
 }
 
-int CCollision::IsWallJump(int Index)
+int CCollision::IsWallJump(int Index) const
 {
 	if(Index < 0)
 		return 0;
@@ -625,17 +625,17 @@ int CCollision::IsWallJump(int Index)
 	return m_pTiles[Index].m_Index == TILE_WALLJUMP;
 }
 
-int CCollision::IsNoLaser(int x, int y)
+int CCollision::IsNoLaser(int x, int y) const
 {
 	return (CCollision::GetTile(x, y) == TILE_NOLASER);
 }
 
-int CCollision::IsFNoLaser(int x, int y)
+int CCollision::IsFNoLaser(int x, int y) const
 {
 	return (CCollision::GetFTile(x, y) == TILE_NOLASER);
 }
 
-int CCollision::IsTeleport(int Index)
+int CCollision::IsTeleport(int Index) const
 {
 	if(Index < 0 || !m_pTele)
 		return 0;
@@ -646,7 +646,7 @@ int CCollision::IsTeleport(int Index)
 	return 0;
 }
 
-int CCollision::IsEvilTeleport(int Index)
+int CCollision::IsEvilTeleport(int Index) const
 {
 	if(Index < 0)
 		return 0;
@@ -659,7 +659,7 @@ int CCollision::IsEvilTeleport(int Index)
 	return 0;
 }
 
-int CCollision::IsCheckTeleport(int Index)
+int CCollision::IsCheckTeleport(int Index) const
 {
 	if(Index < 0)
 		return 0;
@@ -672,7 +672,7 @@ int CCollision::IsCheckTeleport(int Index)
 	return 0;
 }
 
-int CCollision::IsCheckEvilTeleport(int Index)
+int CCollision::IsCheckEvilTeleport(int Index) const
 {
 	if(Index < 0)
 		return 0;
@@ -685,7 +685,7 @@ int CCollision::IsCheckEvilTeleport(int Index)
 	return 0;
 }
 
-int CCollision::IsTCheckpoint(int Index)
+int CCollision::IsTCheckpoint(int Index) const
 {
 	if(Index < 0)
 		return 0;
@@ -699,7 +699,7 @@ int CCollision::IsTCheckpoint(int Index)
 	return 0;
 }
 
-int CCollision::IsTeleportWeapon(int Index)
+int CCollision::IsTeleportWeapon(int Index) const
 {
 	if(Index < 0 || !m_pTele)
 		return 0;
@@ -710,7 +710,7 @@ int CCollision::IsTeleportWeapon(int Index)
 	return 0;
 }
 
-int CCollision::IsTeleportHook(int Index)
+int CCollision::IsTeleportHook(int Index) const
 {
 	if(Index < 0 || !m_pTele)
 		return 0;
@@ -721,7 +721,7 @@ int CCollision::IsTeleportHook(int Index)
 	return 0;
 }
 
-int CCollision::IsSpeedup(int Index)
+int CCollision::IsSpeedup(int Index) const
 {
 	if(Index < 0 || !m_pSpeedup)
 		return 0;
@@ -732,7 +732,7 @@ int CCollision::IsSpeedup(int Index)
 	return 0;
 }
 
-int CCollision::IsTune(int Index)
+int CCollision::IsTune(int Index) const
 {
 	if(Index < 0 || !m_pTune)
 		return 0;
@@ -743,7 +743,7 @@ int CCollision::IsTune(int Index)
 	return 0;
 }
 
-void CCollision::GetSpeedup(int Index, vec2 *Dir, int *Force, int *MaxSpeed)
+void CCollision::GetSpeedup(int Index, vec2 *Dir, int *Force, int *MaxSpeed) const
 {
 	if(Index < 0 || !m_pSpeedup)
 		return;
@@ -754,7 +754,7 @@ void CCollision::GetSpeedup(int Index, vec2 *Dir, int *Force, int *MaxSpeed)
 		*MaxSpeed = m_pSpeedup[Index].m_MaxSpeed;
 }
 
-int CCollision::IsSwitch(int Index)
+int CCollision::IsSwitch(int Index) const
 {
 	if(Index < 0 || !m_pSwitch)
 		return 0;
@@ -765,7 +765,7 @@ int CCollision::IsSwitch(int Index)
 	return 0;
 }
 
-int CCollision::GetSwitchNumber(int Index)
+int CCollision::GetSwitchNumber(int Index) const
 {
 	if(Index < 0 || !m_pSwitch)
 		return 0;
@@ -776,7 +776,7 @@ int CCollision::GetSwitchNumber(int Index)
 	return 0;
 }
 
-int CCollision::GetSwitchDelay(int Index)
+int CCollision::GetSwitchDelay(int Index) const
 {
 	if(Index < 0 || !m_pSwitch)
 		return 0;
@@ -787,7 +787,7 @@ int CCollision::GetSwitchDelay(int Index)
 	return 0;
 }
 
-int CCollision::IsMover(int x, int y, int *pFlags)
+int CCollision::IsMover(int x, int y, int *pFlags) const
 {
 	int Nx = clamp(x / 32, 0, m_Width - 1);
 	int Ny = clamp(y / 32, 0, m_Height - 1);
@@ -801,7 +801,7 @@ int CCollision::IsMover(int x, int y, int *pFlags)
 		return 0;
 }
 
-vec2 CCollision::CpSpeed(int Index, int Flags)
+vec2 CCollision::CpSpeed(int Index, int Flags) const
 {
 	if(Index < 0)
 		return vec2(0, 0);
@@ -834,14 +834,14 @@ vec2 CCollision::CpSpeed(int Index, int Flags)
 	return target;
 }
 
-int CCollision::GetPureMapIndex(float x, float y)
+int CCollision::GetPureMapIndex(float x, float y) const
 {
 	int Nx = clamp(round_to_int(x) / 32, 0, m_Width - 1);
 	int Ny = clamp(round_to_int(y) / 32, 0, m_Height - 1);
 	return Ny * m_Width + Nx;
 }
 
-bool CCollision::TileExists(int Index)
+bool CCollision::TileExists(int Index) const
 {
 	if(Index < 0)
 		return false;
@@ -863,7 +863,7 @@ bool CCollision::TileExists(int Index)
 	return TileExistsNext(Index);
 }
 
-bool CCollision::TileExistsNext(int Index)
+bool CCollision::TileExistsNext(int Index) const
 {
 	if(Index < 0)
 		return false;
@@ -905,7 +905,7 @@ bool CCollision::TileExistsNext(int Index)
 	return false;
 }
 
-int CCollision::GetMapIndex(vec2 Pos)
+int CCollision::GetMapIndex(vec2 Pos) const
 {
 	int Nx = clamp((int)Pos.x / 32, 0, m_Width - 1);
 	int Ny = clamp((int)Pos.y / 32, 0, m_Height - 1);
@@ -917,7 +917,7 @@ int CCollision::GetMapIndex(vec2 Pos)
 		return -1;
 }
 
-std::list<int> CCollision::GetMapIndices(vec2 PrevPos, vec2 Pos, unsigned MaxIndices)
+std::list<int> CCollision::GetMapIndices(vec2 PrevPos, vec2 Pos, unsigned MaxIndices) const
 {
 	std::list<int> Indices;
 	float d = distance(PrevPos, Pos);
@@ -963,7 +963,7 @@ std::list<int> CCollision::GetMapIndices(vec2 PrevPos, vec2 Pos, unsigned MaxInd
 	}
 }
 
-vec2 CCollision::GetPos(int Index)
+vec2 CCollision::GetPos(int Index) const
 {
 	if(Index < 0)
 		return vec2(0, 0);
@@ -973,40 +973,40 @@ vec2 CCollision::GetPos(int Index)
 	return vec2(x * 32 + 16, y * 32 + 16);
 }
 
-int CCollision::GetTileIndex(int Index)
+int CCollision::GetTileIndex(int Index) const
 {
 	if(Index < 0)
 		return 0;
 	return m_pTiles[Index].m_Index;
 }
 
-int CCollision::GetFTileIndex(int Index)
+int CCollision::GetFTileIndex(int Index) const
 {
 	if(Index < 0 || !m_pFront)
 		return 0;
 	return m_pFront[Index].m_Index;
 }
 
-int CCollision::GetTileFlags(int Index)
+int CCollision::GetTileFlags(int Index) const
 {
 	if(Index < 0)
 		return 0;
 	return m_pTiles[Index].m_Flags;
 }
 
-int CCollision::GetFTileFlags(int Index)
+int CCollision::GetFTileFlags(int Index) const
 {
 	if(Index < 0 || !m_pFront)
 		return 0;
 	return m_pFront[Index].m_Flags;
 }
 
-int CCollision::GetIndex(int Nx, int Ny)
+int CCollision::GetIndex(int Nx, int Ny) const
 {
 	return m_pTiles[Ny * m_Width + Nx].m_Index;
 }
 
-int CCollision::GetIndex(vec2 PrevPos, vec2 Pos)
+int CCollision::GetIndex(vec2 PrevPos, vec2 Pos) const
 {
 	float Distance = distance(PrevPos, Pos);
 
@@ -1043,14 +1043,14 @@ int CCollision::GetIndex(vec2 PrevPos, vec2 Pos)
 	return -1;
 }
 
-int CCollision::GetFIndex(int Nx, int Ny)
+int CCollision::GetFIndex(int Nx, int Ny) const
 {
 	if(!m_pFront)
 		return 0;
 	return m_pFront[Ny * m_Width + Nx].m_Index;
 }
 
-int CCollision::GetFTile(int x, int y)
+int CCollision::GetFTile(int x, int y) const
 {
 	if(!m_pFront)
 		return 0;
@@ -1062,7 +1062,7 @@ int CCollision::GetFTile(int x, int y)
 		return 0;
 }
 
-int CCollision::Entity(int x, int y, int Layer)
+int CCollision::Entity(int x, int y, int Layer) const
 {
 	if((0 > x || x >= m_Width) || (0 > y || y >= m_Height))
 	{
@@ -1133,14 +1133,14 @@ void CCollision::SetDCollisionAt(float x, float y, int Type, int Flags, int Numb
 	m_pDoor[Ny * m_Width + Nx].m_Number = Number;
 }
 
-int CCollision::GetDTileIndex(int Index)
+int CCollision::GetDTileIndex(int Index) const
 {
 	if(!m_pDoor || Index < 0 || !m_pDoor[Index].m_Index)
 		return 0;
 	return m_pDoor[Index].m_Index;
 }
 
-int CCollision::GetDTileNumber(int Index)
+int CCollision::GetDTileNumber(int Index) const
 {
 	if(!m_pDoor || Index < 0 || !m_pDoor[Index].m_Index)
 		return 0;
@@ -1149,7 +1149,7 @@ int CCollision::GetDTileNumber(int Index)
 	return 0;
 }
 
-int CCollision::GetDTileFlags(int Index)
+int CCollision::GetDTileFlags(int Index) const
 {
 	if(!m_pDoor || Index < 0 || !m_pDoor[Index].m_Index)
 		return 0;
@@ -1188,7 +1188,7 @@ void ThroughOffset(vec2 Pos0, vec2 Pos1, int *Ox, int *Oy)
 	}
 }
 
-int CCollision::IntersectNoLaser(vec2 Pos0, vec2 Pos1, vec2 *pOutCollision, vec2 *pOutBeforeCollision)
+int CCollision::IntersectNoLaser(vec2 Pos0, vec2 Pos1, vec2 *pOutCollision, vec2 *pOutBeforeCollision) const
 {
 	float d = distance(Pos0, Pos1);
 	vec2 Last = Pos0;
@@ -1219,7 +1219,7 @@ int CCollision::IntersectNoLaser(vec2 Pos0, vec2 Pos1, vec2 *pOutCollision, vec2
 	return 0;
 }
 
-int CCollision::IntersectNoLaserNW(vec2 Pos0, vec2 Pos1, vec2 *pOutCollision, vec2 *pOutBeforeCollision)
+int CCollision::IntersectNoLaserNW(vec2 Pos0, vec2 Pos1, vec2 *pOutCollision, vec2 *pOutBeforeCollision) const
 {
 	float d = distance(Pos0, Pos1);
 	vec2 Last = Pos0;
@@ -1248,7 +1248,7 @@ int CCollision::IntersectNoLaserNW(vec2 Pos0, vec2 Pos1, vec2 *pOutCollision, ve
 	return 0;
 }
 
-int CCollision::IntersectAir(vec2 Pos0, vec2 Pos1, vec2 *pOutCollision, vec2 *pOutBeforeCollision)
+int CCollision::IntersectAir(vec2 Pos0, vec2 Pos1, vec2 *pOutCollision, vec2 *pOutBeforeCollision) const
 {
 	float d = distance(Pos0, Pos1);
 	vec2 Last = Pos0;
@@ -1279,7 +1279,7 @@ int CCollision::IntersectAir(vec2 Pos0, vec2 Pos1, vec2 *pOutCollision, vec2 *pO
 	return 0;
 }
 
-int CCollision::IsCheckpoint(int Index)
+int CCollision::IsCheckpoint(int Index) const
 {
 	if(Index < 0)
 		return -1;
@@ -1290,7 +1290,7 @@ int CCollision::IsCheckpoint(int Index)
 	return -1;
 }
 
-int CCollision::IsFCheckpoint(int Index)
+int CCollision::IsFCheckpoint(int Index) const
 {
 	if(Index < 0 || !m_pFront)
 		return -1;

--- a/src/game/collision.h
+++ b/src/game/collision.h
@@ -33,17 +33,17 @@ public:
 	~CCollision();
 	void Init(class CLayers *pLayers);
 	void FillAntibot(CAntibotMapData *pMapData);
-	bool CheckPoint(float x, float y) { return IsSolid(round_to_int(x), round_to_int(y)); }
-	bool CheckPoint(vec2 Pos) { return CheckPoint(Pos.x, Pos.y); }
-	int GetCollisionAt(float x, float y) { return GetTile(round_to_int(x), round_to_int(y)); }
-	int GetWidth() { return m_Width; };
-	int GetHeight() { return m_Height; };
-	int IntersectLine(vec2 Pos0, vec2 Pos1, vec2 *pOutCollision, vec2 *pOutBeforeCollision);
-	int IntersectLineTeleWeapon(vec2 Pos0, vec2 Pos1, vec2 *pOutCollision, vec2 *pOutBeforeCollision, int *pTeleNr);
-	int IntersectLineTeleHook(vec2 Pos0, vec2 Pos1, vec2 *pOutCollision, vec2 *pOutBeforeCollision, int *pTeleNr);
-	void MovePoint(vec2 *pInoutPos, vec2 *pInoutVel, float Elasticity, int *pBounces);
-	void MoveBox(vec2 *pInoutPos, vec2 *pInoutVel, vec2 Size, float Elasticity);
-	bool TestBox(vec2 Pos, vec2 Size);
+	bool CheckPoint(float x, float y) const { return IsSolid(round_to_int(x), round_to_int(y)); }
+	bool CheckPoint(vec2 Pos) const { return CheckPoint(Pos.x, Pos.y); }
+	int GetCollisionAt(float x, float y) const { return GetTile(round_to_int(x), round_to_int(y)); }
+	int GetWidth() const { return m_Width; }
+	int GetHeight() const { return m_Height; }
+	int IntersectLine(vec2 Pos0, vec2 Pos1, vec2 *pOutCollision, vec2 *pOutBeforeCollision) const;
+	int IntersectLineTeleWeapon(vec2 Pos0, vec2 Pos1, vec2 *pOutCollision, vec2 *pOutBeforeCollision, int *pTeleNr) const;
+	int IntersectLineTeleHook(vec2 Pos0, vec2 Pos1, vec2 *pOutCollision, vec2 *pOutBeforeCollision, int *pTeleNr) const;
+	void MovePoint(vec2 *pInoutPos, vec2 *pInoutVel, float Elasticity, int *pBounces) const;
+	void MoveBox(vec2 *pInoutPos, vec2 *pInoutVel, vec2 Size, float Elasticity) const;
+	bool TestBox(vec2 Pos, vec2 Size) const;
 
 	// DDRace
 
@@ -51,16 +51,16 @@ public:
 	void SetCollisionAt(float x, float y, int id);
 	void SetDTile(float x, float y, bool State);
 	void SetDCollisionAt(float x, float y, int Type, int Flags, int Number);
-	int GetDTileIndex(int Index);
-	int GetDTileFlags(int Index);
-	int GetDTileNumber(int Index);
-	int GetFCollisionAt(float x, float y) { return GetFTile(round_to_int(x), round_to_int(y)); }
-	int IntersectNoLaser(vec2 Pos0, vec2 Pos1, vec2 *pOutCollision, vec2 *pOutBeforeCollision);
-	int IntersectNoLaserNW(vec2 Pos0, vec2 Pos1, vec2 *pOutCollision, vec2 *pOutBeforeCollision);
-	int IntersectAir(vec2 Pos0, vec2 Pos1, vec2 *pOutCollision, vec2 *pOutBeforeCollision);
-	int GetIndex(int x, int y);
-	int GetIndex(vec2 PrevPos, vec2 Pos);
-	int GetFIndex(int x, int y);
+	int GetDTileIndex(int Index) const;
+	int GetDTileFlags(int Index) const;
+	int GetDTileNumber(int Index) const;
+	int GetFCollisionAt(float x, float y) const { return GetFTile(round_to_int(x), round_to_int(y)); }
+	int IntersectNoLaser(vec2 Pos0, vec2 Pos1, vec2 *pOutCollision, vec2 *pOutBeforeCollision) const;
+	int IntersectNoLaserNW(vec2 Pos0, vec2 Pos1, vec2 *pOutCollision, vec2 *pOutBeforeCollision) const;
+	int IntersectAir(vec2 Pos0, vec2 Pos1, vec2 *pOutCollision, vec2 *pOutBeforeCollision) const;
+	int GetIndex(int x, int y) const;
+	int GetIndex(vec2 PrevPos, vec2 Pos) const;
+	int GetFIndex(int x, int y) const;
 
 	int GetMoveRestrictions(CALLBACK_SWITCHACTIVE pfnSwitchActive, void *pUser, vec2 Pos, float Distance = 18.0f, int OverrideCenterTileIndex = -1);
 	int GetMoveRestrictions(vec2 Pos, float Distance = 18.0f)
@@ -68,47 +68,47 @@ public:
 		return GetMoveRestrictions(0, 0, Pos, Distance);
 	}
 
-	int GetTile(int x, int y);
-	int GetFTile(int x, int y);
-	int Entity(int x, int y, int Layer);
-	int GetPureMapIndex(float x, float y);
-	int GetPureMapIndex(vec2 Pos) { return GetPureMapIndex(Pos.x, Pos.y); }
-	std::list<int> GetMapIndices(vec2 PrevPos, vec2 Pos, unsigned MaxIndices = 0);
-	int GetMapIndex(vec2 Pos);
-	bool TileExists(int Index);
-	bool TileExistsNext(int Index);
-	vec2 GetPos(int Index);
-	int GetTileIndex(int Index);
-	int GetFTileIndex(int Index);
-	int GetTileFlags(int Index);
-	int GetFTileFlags(int Index);
-	int IsTeleport(int Index);
-	int IsEvilTeleport(int Index);
-	int IsCheckTeleport(int Index);
-	int IsCheckEvilTeleport(int Index);
-	int IsTeleportWeapon(int Index);
-	int IsTeleportHook(int Index);
-	int IsTCheckpoint(int Index);
-	int IsSpeedup(int Index);
-	int IsTune(int Index);
-	void GetSpeedup(int Index, vec2 *Dir, int *Force, int *MaxSpeed);
-	int IsSwitch(int Index);
-	int GetSwitchNumber(int Index);
-	int GetSwitchDelay(int Index);
+	int GetTile(int x, int y) const;
+	int GetFTile(int x, int y) const;
+	int Entity(int x, int y, int Layer) const;
+	int GetPureMapIndex(float x, float y) const;
+	int GetPureMapIndex(vec2 Pos) const { return GetPureMapIndex(Pos.x, Pos.y); }
+	std::list<int> GetMapIndices(vec2 PrevPos, vec2 Pos, unsigned MaxIndices = 0) const;
+	int GetMapIndex(vec2 Pos) const;
+	bool TileExists(int Index) const;
+	bool TileExistsNext(int Index) const;
+	vec2 GetPos(int Index) const;
+	int GetTileIndex(int Index) const;
+	int GetFTileIndex(int Index) const;
+	int GetTileFlags(int Index) const;
+	int GetFTileFlags(int Index) const;
+	int IsTeleport(int Index) const;
+	int IsEvilTeleport(int Index) const;
+	int IsCheckTeleport(int Index) const;
+	int IsCheckEvilTeleport(int Index) const;
+	int IsTeleportWeapon(int Index) const;
+	int IsTeleportHook(int Index) const;
+	int IsTCheckpoint(int Index) const;
+	int IsSpeedup(int Index) const;
+	int IsTune(int Index) const;
+	void GetSpeedup(int Index, vec2 *Dir, int *Force, int *MaxSpeed) const;
+	int IsSwitch(int Index) const;
+	int GetSwitchNumber(int Index) const;
+	int GetSwitchDelay(int Index) const;
 
-	int IsSolid(int x, int y);
-	bool IsThrough(int x, int y, int xoff, int yoff, vec2 pos0, vec2 pos1);
-	bool IsHookBlocker(int x, int y, vec2 pos0, vec2 pos1);
-	int IsWallJump(int Index);
-	int IsNoLaser(int x, int y);
-	int IsFNoLaser(int x, int y);
+	int IsSolid(int x, int y) const;
+	bool IsThrough(int x, int y, int xoff, int yoff, vec2 pos0, vec2 pos1) const;
+	bool IsHookBlocker(int x, int y, vec2 pos0, vec2 pos1) const;
+	int IsWallJump(int Index) const;
+	int IsNoLaser(int x, int y) const;
+	int IsFNoLaser(int x, int y) const;
 
-	int IsCheckpoint(int Index);
-	int IsFCheckpoint(int Index);
+	int IsCheckpoint(int Index) const;
+	int IsFCheckpoint(int Index) const;
 
-	int IsMover(int x, int y, int *pFlags);
+	int IsMover(int x, int y, int *pFlags) const;
 
-	vec2 CpSpeed(int index, int Flags = 0);
+	vec2 CpSpeed(int index, int Flags = 0) const;
 
 	class CTeleTile *TeleLayer() { return m_pTele; }
 	class CSwitchTile *SwitchLayer() { return m_pSwitch; }

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -223,7 +223,7 @@ void CLayerGroup::DeleteLayer(int Index)
 	m_pMap->m_UndoModified++;
 }
 
-void CLayerGroup::GetSize(float *w, float *h)
+void CLayerGroup::GetSize(float *w, float *h) const
 {
 	*w = 0;
 	*h = 0;
@@ -888,14 +888,14 @@ int CEditor::UiDoValueSelector(void *pID, CUIRect *pRect, const char *pLabel, in
 	return Current;
 }
 
-CLayerGroup *CEditor::GetSelectedGroup()
+CLayerGroup *CEditor::GetSelectedGroup() const
 {
 	if(m_SelectedGroup >= 0 && m_SelectedGroup < m_Map.m_lGroups.size())
 		return m_Map.m_lGroups[m_SelectedGroup];
 	return 0x0;
 }
 
-CLayer *CEditor::GetSelectedLayer(int Index)
+CLayer *CEditor::GetSelectedLayer(int Index) const
 {
 	CLayerGroup *pGroup = GetSelectedGroup();
 	if(!pGroup)
@@ -911,7 +911,7 @@ CLayer *CEditor::GetSelectedLayer(int Index)
 	return 0x0;
 }
 
-CLayer *CEditor::GetSelectedLayerType(int Index, int Type)
+CLayer *CEditor::GetSelectedLayerType(int Index, int Type) const
 {
 	CLayer *p = GetSelectedLayer(Index);
 	if(p && p->m_Type == Type)
@@ -973,7 +973,7 @@ void CEditor::DeleteSelectedQuads()
 	}
 }
 
-bool CEditor::IsQuadSelected(int Index)
+bool CEditor::IsQuadSelected(int Index) const
 {
 	for(int i = 0; i < m_lSelectedQuads.size(); ++i)
 		if(m_lSelectedQuads[i] == Index)
@@ -981,7 +981,7 @@ bool CEditor::IsQuadSelected(int Index)
 	return false;
 }
 
-int CEditor::FindSelectedQuadIndex(int Index)
+int CEditor::FindSelectedQuadIndex(int Index) const
 {
 	for(int i = 0; i < m_lSelectedQuads.size(); ++i)
 		if(m_lSelectedQuads[i] == Index)
@@ -4856,7 +4856,7 @@ void CEditor::RenderUndoList(CUIRect View)
 	}
 }
 
-bool CEditor::IsEnvelopeUsed(int EnvelopeIndex)
+bool CEditor::IsEnvelopeUsed(int EnvelopeIndex) const
 {
 	for(int i = 0; i < m_Map.m_lGroups.size(); i++)
 	{
@@ -6197,7 +6197,7 @@ void CEditor::Reset(bool CreateDefault)
 	m_LastUndoUpdateTime = time_get();
 }
 
-int CEditor::GetLineDistance()
+int CEditor::GetLineDistance() const
 {
 	int LineDistance = 512;
 

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -106,7 +106,7 @@ public:
 		Resort();
 	}
 
-	float EndTime()
+	float EndTime() const
 	{
 		if(m_lPoints.size())
 			return m_lPoints[m_lPoints.size() - 1].m_Time * (1.0f / 1000.0f);
@@ -204,7 +204,7 @@ public:
 	void MapScreen();
 	void Mapping(float *pPoints);
 
-	void GetSize(float *w, float *h);
+	void GetSize(float *w, float *h) const;
 
 	void DeleteLayer(int Index);
 	int SwapLayers(int Index0, int Index1);
@@ -754,7 +754,7 @@ public:
 
 	virtual void Init();
 	virtual void UpdateAndRender();
-	virtual bool HasUnsavedData() { return m_Map.m_Modified; }
+	virtual bool HasUnsavedData() const { return m_Map.m_Modified; }
 	virtual void UpdateMentions() { m_Mentions++; }
 	virtual void ResetMentions() { m_Mentions = 0; }
 
@@ -791,15 +791,15 @@ public:
 	void Render();
 
 	array<CQuad *> GetSelectedQuads();
-	CLayer *GetSelectedLayerType(int Index, int Type);
-	CLayer *GetSelectedLayer(int Index);
-	CLayerGroup *GetSelectedGroup();
+	CLayer *GetSelectedLayerType(int Index, int Type) const;
+	CLayer *GetSelectedLayer(int Index) const;
+	CLayerGroup *GetSelectedGroup() const;
 	CSoundSource *GetSelectedSource();
 	void SelectLayer(int LayerIndex, int GroupIndex = -1);
 	void SelectQuad(int Index);
 	void DeleteSelectedQuads();
-	bool IsQuadSelected(int Index);
-	int FindSelectedQuadIndex(int Index);
+	bool IsQuadSelected(int Index) const;
+	int FindSelectedQuadIndex(int Index) const;
 
 	float ScaleFontSize(char *pText, int TextSize, float FontSize, int Width);
 	int DoProperties(CUIRect *pToolbox, CProperty *pProps, int *pIDs, int *pNewVal, ColorRGBA Color = ColorRGBA(1, 1, 1, 0.5f));
@@ -1041,7 +1041,7 @@ public:
 	static void AddImage(const char *pFilename, int StorageType, void *pUser);
 	static void AddSound(const char *pFileName, int StorageType, void *pUser);
 
-	bool IsEnvelopeUsed(int EnvelopeIndex);
+	bool IsEnvelopeUsed(int EnvelopeIndex) const;
 
 	void RenderImages(CUIRect Toolbox, CUIRect View);
 	void RenderLayers(CUIRect Toolbox, CUIRect View);
@@ -1058,9 +1058,9 @@ public:
 	void AddFileDialogEntry(int Index, CUIRect *pView);
 	void SelectGameLayer();
 	void SortImages();
-	const char *Explain(int Tile, int Layer);
+	static const char *Explain(int Tile, int Layer);
 
-	int GetLineDistance();
+	int GetLineDistance() const;
 	void ZoomMouseTarget(float ZoomFactor);
 
 	static ColorHSVA ms_PickerColor;

--- a/src/game/gamecore.cpp
+++ b/src/game/gamecore.cpp
@@ -19,7 +19,7 @@ bool CTuningParams::Set(int Index, float Value)
 	return true;
 }
 
-bool CTuningParams::Get(int Index, float *pValue)
+bool CTuningParams::Get(int Index, float *pValue) const
 {
 	if(Index < 0 || Index >= Num())
 		return false;
@@ -35,7 +35,7 @@ bool CTuningParams::Set(const char *pName, float Value)
 	return false;
 }
 
-bool CTuningParams::Get(const char *pName, float *pValue)
+bool CTuningParams::Get(const char *pName, float *pValue) const
 {
 	for(int i = 0; i < Num(); i++)
 		if(str_comp_nocase(pName, ms_apNames[i]) == 0)

--- a/src/game/gamecore.h
+++ b/src/game/gamecore.h
@@ -61,8 +61,8 @@ public:
 	}
 	bool Set(int Index, float Value);
 	bool Set(const char *pName, float Value);
-	bool Get(int Index, float *pValue);
-	bool Get(const char *pName, float *pValue);
+	bool Get(int Index, float *pValue) const;
+	bool Get(const char *pName, float *pValue) const;
 };
 
 inline void StrToInts(int *pInts, int Num, const char *pStr)

--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -950,7 +950,7 @@ void CGameContext::ConJoinTeam(IConsole::IResult *pResult, void *pUserData)
 		{
 			int Team = pResult->GetInteger(0);
 
-			if(pPlayer->m_Last_Team + (int64_t)pSelf->Server()->TickSpeed() * g_Config.m_SvTeamChangeDelay > pSelf->Server()->Tick())
+			if(pPlayer->m_Last_Team + (int64)pSelf->Server()->TickSpeed() * g_Config.m_SvTeamChangeDelay > pSelf->Server()->Tick())
 			{
 				pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "join",
 					"You can\'t change teams that fast!");

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -2335,10 +2335,10 @@ void CCharacter::Rescue()
 {
 	if(m_SetSavePos && !m_Super)
 	{
-		if(m_LastRescue + (int64_t)g_Config.m_SvRescueDelay * Server()->TickSpeed() > Server()->Tick())
+		if(m_LastRescue + (int64)g_Config.m_SvRescueDelay * Server()->TickSpeed() > Server()->Tick())
 		{
 			char aBuf[256];
-			str_format(aBuf, sizeof(aBuf), "You have to wait %d seconds until you can rescue yourself", (int)((m_LastRescue + (int64_t)g_Config.m_SvRescueDelay * Server()->TickSpeed() - Server()->Tick()) / Server()->TickSpeed()));
+			str_format(aBuf, sizeof(aBuf), "You have to wait %d seconds until you can rescue yourself", (int)((m_LastRescue + (int64)g_Config.m_SvRescueDelay * Server()->TickSpeed() - Server()->Tick()) / Server()->TickSpeed()));
 			GameServer()->SendChatTarget(GetPlayer()->GetCID(), aBuf);
 			return;
 		}

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -617,6 +617,14 @@ void CGameContext::SendVoteSet(int ClientID)
 
 void CGameContext::SendVoteStatus(int ClientID, int Total, int Yes, int No)
 {
+	if(ClientID == -1)
+	{
+		for(int i = 0; i < MAX_CLIENTS; ++i)
+			if(Server()->ClientIngame(i))
+				SendVoteStatus(i, Total, Yes, No);
+		return;
+	}
+
 	if(Total > VANILLA_MAX_CLIENTS && m_apPlayers[ClientID] && m_apPlayers[ClientID]->GetClientVersion() <= VERSION_DDRACE)
 	{
 		Yes = float(Yes) * VANILLA_MAX_CLIENTS / float(Total);
@@ -981,9 +989,7 @@ void CGameContext::OnTick()
 			else if(m_VoteUpdate)
 			{
 				m_VoteUpdate = false;
-				for(int i = 0; i < MAX_CLIENTS; ++i)
-					if(Server()->ClientIngame(i))
-						SendVoteStatus(i, Total, Yes, No);
+				SendVoteStatus(-1, Total, Yes, No);
 			}
 		}
 	}

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -3586,20 +3586,20 @@ void CGameContext::OnPostSnap()
 	m_Events.Clear();
 }
 
-bool CGameContext::IsClientReady(int ClientID)
+bool CGameContext::IsClientReady(int ClientID) const
 {
 	return m_apPlayers[ClientID] && m_apPlayers[ClientID]->m_IsReady ? true : false;
 }
 
-bool CGameContext::IsClientPlayer(int ClientID)
+bool CGameContext::IsClientPlayer(int ClientID) const
 {
 	return m_apPlayers[ClientID] && m_apPlayers[ClientID]->GetTeam() == TEAM_SPECTATORS ? false : true;
 }
 
-CUuid CGameContext::GameUuid() { return m_GameUuid; }
-const char *CGameContext::GameType() { return m_pController && m_pController->m_pGameType ? m_pController->m_pGameType : ""; }
-const char *CGameContext::Version() { return GAME_VERSION; }
-const char *CGameContext::NetVersion() { return GAME_NETVERSION; }
+CUuid CGameContext::GameUuid() const { return m_GameUuid; }
+const char *CGameContext::GameType() const { return m_pController && m_pController->m_pGameType ? m_pController->m_pGameType : ""; }
+const char *CGameContext::Version() const { return GAME_VERSION; }
+const char *CGameContext::NetVersion() const { return GAME_NETVERSION; }
 
 IGameServer *CreateGameServer() { return new CGameContext; }
 
@@ -4011,16 +4011,16 @@ void CGameContext::List(int ClientID, const char *pFilter)
 	SendChatTarget(ClientID, aBuf);
 }
 
-int CGameContext::GetClientVersion(int ClientID)
+int CGameContext::GetClientVersion(int ClientID) const
 {
 	IServer::CClientInfo Info = {0};
 	Server()->GetClientInfo(ClientID, &Info);
 	return Info.m_DDNetVersion;
 }
 
-bool CGameContext::PlayerModerating()
+bool CGameContext::PlayerModerating() const
 {
-	for(auto &pPlayer : m_apPlayers)
+	for(const auto &pPlayer : m_apPlayers)
 	{
 		if(pPlayer && pPlayer->m_Moderating)
 			return true;

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -1179,8 +1179,9 @@ void CGameContext::ProgressVoteOptions(int ClientID)
 
 void CGameContext::OnClientEnter(int ClientID)
 {
+	m_pController->OnPlayerConnect(m_apPlayers[ClientID]);
+
 	//world.insert_entity(&players[client_id]);
-	m_apPlayers[ClientID]->Respawn();
 	// init the player
 	Score()->PlayerData(ClientID)->Reset();
 	m_apPlayers[ClientID]->m_Score = Score()->PlayerData(ClientID)->m_BestTime ? Score()->PlayerData(ClientID)->m_BestTime : -9999;
@@ -1255,9 +1256,6 @@ void CGameContext::OnClientEnter(int ClientID)
 
 		if(g_Config.m_SvWelcome[0] != 0)
 			SendChatTarget(ClientID, g_Config.m_SvWelcome);
-		str_format(aBuf, sizeof(aBuf), "team_join player='%d:%s' team=%d", ClientID, Server()->ClientName(ClientID), m_apPlayers[ClientID]->GetTeam());
-
-		Console()->Print(IConsole::OUTPUT_LEVEL_DEBUG, "game", aBuf);
 
 		IServer::CClientInfo Info;
 		Server()->GetClientInfo(ClientID, &Info);

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -1181,15 +1181,6 @@ void CGameContext::OnClientEnter(int ClientID)
 {
 	m_pController->OnPlayerConnect(m_apPlayers[ClientID]);
 
-	//world.insert_entity(&players[client_id]);
-	// init the player
-	Score()->PlayerData(ClientID)->Reset();
-	m_apPlayers[ClientID]->m_Score = Score()->PlayerData(ClientID)->m_BestTime ? Score()->PlayerData(ClientID)->m_BestTime : -9999;
-
-	// Can't set score here as LoadScore() is threaded, run it in
-	// LoadScoreThreaded() instead
-	Score()->LoadPlayerData(ClientID);
-
 	if(Server()->IsSixup(ClientID))
 	{
 		{
@@ -1247,13 +1238,6 @@ void CGameContext::OnClientEnter(int ClientID)
 
 	if(!Server()->ClientPrevIngame(ClientID))
 	{
-		char aBuf[512];
-		str_format(aBuf, sizeof(aBuf), "'%s' entered and joined the %s", Server()->ClientName(ClientID), m_pController->GetTeamName(m_apPlayers[ClientID]->GetTeam()));
-		SendChat(-1, CGameContext::CHAT_ALL, aBuf, -1, CHAT_SIX);
-
-		SendChatTarget(ClientID, "DDraceNetwork Mod. Version: " GAME_VERSION);
-		SendChatTarget(ClientID, "please visit DDNet.tw or say /info and make sure to read our /rules");
-
 		if(g_Config.m_SvWelcome[0] != 0)
 			SendChatTarget(ClientID, g_Config.m_SvWelcome);
 

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -256,13 +256,13 @@ public:
 	virtual void OnClientEngineJoin(int ClientID, bool Sixup);
 	virtual void OnClientEngineDrop(int ClientID, const char *pReason);
 
-	virtual bool IsClientReady(int ClientID);
-	virtual bool IsClientPlayer(int ClientID);
+	virtual bool IsClientReady(int ClientID) const;
+	virtual bool IsClientPlayer(int ClientID) const;
 
-	virtual CUuid GameUuid();
-	virtual const char *GameType();
-	virtual const char *Version();
-	virtual const char *NetVersion();
+	virtual CUuid GameUuid() const;
+	virtual const char *GameType() const;
+	virtual const char *Version() const;
+	virtual const char *NetVersion() const;
 
 	// DDRace
 	bool OnClientDDNetVersionKnown(int ClientID);
@@ -272,10 +272,10 @@ public:
 	// Describes the time when the first player joined the server.
 	int64 m_NonEmptySince;
 	int64 m_LastMapVote;
-	int GetClientVersion(int ClientID);
-	bool PlayerExists(int ClientID) { return m_apPlayers[ClientID]; };
+	int GetClientVersion(int ClientID) const;
+	bool PlayerExists(int ClientID) const { return m_apPlayers[ClientID]; }
 	// Returns true if someone is actively moderating.
-	bool PlayerModerating();
+	bool PlayerModerating() const;
 	void ForceVote(int EnforcerID, bool Success);
 
 	// Checks if player can vote and notify them about the reason

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -21,14 +21,6 @@
 
 #include <memory>
 
-#ifdef _MSC_VER
-typedef __int32 int32_t;
-typedef unsigned __int32 uint32_t;
-typedef __int64 int64;
-typedef unsigned __int64 uint64;
-#else
-#include <stdint.h>
-#endif
 /*
 	Tick
 		Game Context (CGameContext::tick)

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -123,6 +123,11 @@ class CGameContext : public IGameServer
 
 	bool m_Resetting;
 
+	struct CPersistentClientData
+	{
+		bool m_IsSpectator;
+	};
+
 public:
 	IServer *Server() const { return m_pServer; }
 	CConfig *Config() { return m_pConfig; }
@@ -246,7 +251,8 @@ public:
 	void CensorMessage(char *pCensoredMessage, const char *pMessage, int Size);
 	virtual void OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID);
 
-	virtual void OnClientConnected(int ClientID);
+	virtual bool OnClientDataPersist(int ClientID, void *pData);
+	virtual void OnClientConnected(int ClientID, void *pData);
 	virtual void OnClientEnter(int ClientID);
 	virtual void OnClientDrop(int ClientID, const char *pReason);
 	virtual void OnClientDirectInput(int ClientID, void *pInput);
@@ -258,6 +264,7 @@ public:
 
 	virtual bool IsClientReady(int ClientID) const;
 	virtual bool IsClientPlayer(int ClientID) const;
+	virtual int PersistentClientDataSize() const { return sizeof(CPersistentClientData); }
 
 	virtual CUuid GameUuid() const;
 	virtual const char *GameType() const;

--- a/src/game/server/gamecontroller.cpp
+++ b/src/game/server/gamecontroller.cpp
@@ -384,6 +384,19 @@ bool IGameController::OnEntity(int Index, vec2 Pos, int Layer, int Flags, int Nu
 	return false;
 }
 
+void IGameController::OnPlayerConnect(CPlayer *pPlayer)
+{
+	int ClientID = pPlayer->GetCID();
+	pPlayer->Respawn();
+
+	if(!Server()->ClientPrevIngame(ClientID))
+	{
+		char aBuf[128];
+		str_format(aBuf, sizeof(aBuf), "team_join player='%d:%s' team=%d", ClientID, Server()->ClientName(ClientID), pPlayer->GetTeam());
+		GameServer()->Console()->Print(IConsole::OUTPUT_LEVEL_DEBUG, "game", aBuf);
+	}
+}
+
 void IGameController::OnPlayerDisconnect(class CPlayer *pPlayer, const char *pReason)
 {
 	pPlayer->OnDisconnect();

--- a/src/game/server/gamecontroller.h
+++ b/src/game/server/gamecontroller.h
@@ -6,16 +6,6 @@
 #include <base/vmath.h>
 #include <engine/map.h>
 
-class CDoor;
-#if !defined(_MSC_VER) || _MSC_VER >= 1600
-#include <stdint.h>
-#else
-typedef __int32 int32_t;
-typedef unsigned __int32 uint32_t;
-typedef __int64 int64;
-typedef unsigned __int64 uint64;
-#endif
-
 /*
 	Class: Game Controller
 		Controls the main game logic. Keeping track of team and player score,

--- a/src/game/server/gamecontroller.h
+++ b/src/game/server/gamecontroller.h
@@ -105,6 +105,7 @@ public:
 	*/
 	virtual bool OnEntity(int Index, vec2 Pos, int Layer, int Flags, int Number = 0);
 
+	virtual void OnPlayerConnect(class CPlayer *pPlayer);
 	virtual void OnPlayerDisconnect(class CPlayer *pPlayer, const char *pReason);
 
 	void OnReset();

--- a/src/game/server/gamemodes/DDRace.cpp
+++ b/src/game/server/gamemodes/DDRace.cpp
@@ -22,6 +22,11 @@ CGameControllerDDRace::~CGameControllerDDRace()
 	// Nothing to clean
 }
 
+CScore *CGameControllerDDRace::Score()
+{
+	return GameServer()->Score();
+}
+
 void CGameControllerDDRace::OnCharacterSpawn(CCharacter *pChr)
 {
 	IGameController::OnCharacterSpawn(pChr);

--- a/src/game/server/gamemodes/DDRace.cpp
+++ b/src/game/server/gamemodes/DDRace.cpp
@@ -1,7 +1,7 @@
 /* (c) Shereef Marzouk. See "licence DDRace.txt" and the readme.txt in the root of the distribution for more information. */
 /* Based on Race mod stuff and tweaked by GreYFoX@GTi and others to fit our DDRace needs. */
 #include "DDRace.h"
-#include "gamemode.h"
+
 #include <engine/server.h>
 #include <engine/shared/config.h>
 #include <game/mapitems.h>
@@ -9,10 +9,13 @@
 #include <game/server/gamecontext.h>
 #include <game/server/player.h>
 
+#define GAME_TYPE_NAME "DDraceNetwork"
+#define TEST_TYPE_NAME "TestDDraceNetwork"
+
 CGameControllerDDRace::CGameControllerDDRace(class CGameContext *pGameServer) :
 	IGameController(pGameServer), m_Teams(pGameServer), m_pInitResult(nullptr)
 {
-	m_pGameType = g_Config.m_SvTestingCommands ? TEST_NAME : GAME_NAME;
+	m_pGameType = g_Config.m_SvTestingCommands ? TEST_TYPE_NAME : GAME_TYPE_NAME;
 
 	InitTeleporter();
 }

--- a/src/game/server/gamemodes/DDRace.h
+++ b/src/game/server/gamemodes/DDRace.h
@@ -15,6 +15,8 @@ public:
 	CGameControllerDDRace(class CGameContext *pGameServer);
 	~CGameControllerDDRace();
 
+	CScore *Score();
+
 	void OnCharacterSpawn(class CCharacter *pChr) override;
 	void HandleCharacterTiles(class CCharacter *pChr, int MapIndex) override;
 

--- a/src/game/server/gamemodes/DDRace.h
+++ b/src/game/server/gamemodes/DDRace.h
@@ -20,6 +20,7 @@ public:
 	void OnCharacterSpawn(class CCharacter *pChr) override;
 	void HandleCharacterTiles(class CCharacter *pChr, int MapIndex) override;
 
+	void OnPlayerConnect(class CPlayer *pPlayer) override;
 	void OnPlayerDisconnect(class CPlayer *pPlayer, const char *pReason) override;
 
 	void Tick() override;

--- a/src/game/server/gamemodes/gamemode.h
+++ b/src/game/server/gamemodes/gamemode.h
@@ -1,8 +1,0 @@
-/* (c) Shereef Marzouk. See "licence DDRace.txt" and the readme.txt in the root of the distribution for more information. */
-/* This is used for all NONE Official Builds of DDRace, if you changed the source in anyway change this to something other than DDRace */
-#ifndef GAME_SERVER_GAMEMODES_GAMEMODE_H
-#define GAME_SERVER_GAMEMODES_GAMEMODE_H
-
-#define GAME_NAME "DDraceNetwork"
-#define TEST_NAME "TestDDraceNetwork"
-#endif // GAME_SERVER_GAMEMODES_GAMEMODE_H

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -805,7 +805,7 @@ void CPlayer::OverrideDefaultEmote(int Emote, int Tick)
 
 bool CPlayer::CanOverrideDefaultEmote() const
 {
-	return m_LastEyeEmote == 0 || m_LastEyeEmote + (int64_t)g_Config.m_SvEyeEmoteChangeDelay * Server()->TickSpeed() < Server()->Tick();
+	return m_LastEyeEmote == 0 || m_LastEyeEmote + (int64)g_Config.m_SvEyeEmoteChangeDelay * Server()->TickSpeed() < Server()->Tick();
 }
 
 void CPlayer::ProcessPause()
@@ -842,7 +842,7 @@ int CPlayer::Pause(int State, bool Force)
 		case PAUSE_NONE:
 			if(m_pCharacter->IsPaused()) // First condition might be unnecessary
 			{
-				if(!Force && m_LastPause && m_LastPause + (int64_t)g_Config.m_SvSpecFrequency * Server()->TickSpeed() > Server()->Tick())
+				if(!Force && m_LastPause && m_LastPause + (int64)g_Config.m_SvSpecFrequency * Server()->TickSpeed() > Server()->Tick())
 				{
 					GameServer()->SendChatTarget(m_ClientID, "Can't /spec that quickly.");
 					return m_Paused; // Do not update state. Do not collect $200

--- a/src/game/server/score.cpp
+++ b/src/game/server/score.cpp
@@ -128,7 +128,7 @@ bool CScore::RateLimitPlayer(int ClientID)
 	CPlayer *pPlayer = GameServer()->m_apPlayers[ClientID];
 	if(pPlayer == 0)
 		return true;
-	if(pPlayer->m_LastSQLQuery + (int64_t)g_Config.m_SvSqlQueriesDelay * Server()->TickSpeed() >= Server()->Tick())
+	if(pPlayer->m_LastSQLQuery + (int64)g_Config.m_SvSqlQueriesDelay * Server()->TickSpeed() >= Server()->Tick())
 		return true;
 	pPlayer->m_LastSQLQuery = Server()->Tick();
 	return false;


### PR DESCRIPTION
- Backport 'Make spectators stay specs on map changed'
- Adopt upstream refactoring: Mark several functions as 'const'
- CGameContext::SendVoteStatus: Hide the trick for 64 clients
- GameController: Add OnPlayerConnect() like in the upstream
- Move DDRace-specific player initialization code to the Controller. Dependencies:
  - CGameControllerDDRace: Add Score() getter
  - Get rid of gamemode.h with confusing/conflicting definitions (re-defined `GAME_NAME`)
- Replace remaining int64_t by int64 for the sake of consistency

I checked the changes in-game (I ran a server and tested with two players)

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
