### PR TITLE
Fix license

### DIFF
--- a/license.txt
+++ b/license.txt
@@ -21,7 +21,8 @@ freely, subject to the following restrictions:
 ------------------------------------------------------------------------
 
 All content under 'data' except the assets, font, language & skin files,
-(which have their own licenses):
+(which have their own licenses) are released under
+CC-BY-SA 3.0 (http://creativecommons.org/licenses/by-sa/3.0/).
 Apache 2.0 for the 'Icon.tff' file:
 Copyright Google
 


### PR DESCRIPTION
Currently it sounds like its missing a license for "All content", because "The other fonts" should have been "The other files".

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
