### PR TITLE
Fix top time not being displayed on old servers

### DIFF
--- a/datasrc/network.py
+++ b/datasrc/network.py
@@ -469,7 +469,7 @@ Messages = [
 		NetIntRange("m_Finish", 0, 1),
 	]),
 
-	NetMessageEx("Sv_Record", "weird-record@netmsg.ddnet.tw", [
+	NetMessageEx("Sv_Record", "record@netmsg.ddnet.tw", [
 		NetIntAny("m_ServerTimeBest"),
 		NetIntAny("m_PlayerTimeBest"),
 	]),

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -882,7 +882,7 @@ void CHud::OnMessage(int MsgType, void *pRawMsg)
 		CNetMsg_Sv_Record *pMsg = (CNetMsg_Sv_Record *)pRawMsg;
 
 		// NETMSGTYPE_SV_RACETIME on old race servers
-		if(GameClient()->m_GameInfo.m_DDRaceRecordMessage)
+		if(MsgType == NETMSGTYPE_SV_RECORDLEGACY && GameClient()->m_GameInfo.m_DDRaceRecordMessage)
 		{
 			m_DDRaceTimeReceived = true;
 
@@ -896,7 +896,7 @@ void CHud::OnMessage(int MsgType, void *pRawMsg)
 				m_CheckpointTick = Client()->GameTick(g_Config.m_ClDummy);
 			}
 		}
-		else if(GameClient()->m_GameInfo.m_RaceRecordMessage)
+		else if(MsgType == NETMSGTYPE_SV_RECORD || GameClient()->m_GameInfo.m_RaceRecordMessage)
 		{
 			m_ServerRecord = (float)pMsg->m_ServerTimeBest / 100;
 			m_PlayerRecord[g_Config.m_ClDummy] = (float)pMsg->m_PlayerTimeBest / 100;

--- a/src/game/client/components/scoreboard.cpp
+++ b/src/game/client/components/scoreboard.cpp
@@ -46,7 +46,7 @@ void CScoreboard::OnRelease()
 
 void CScoreboard::OnMessage(int MsgType, void *pRawMsg)
 {
-	if(MsgType == NETMSGTYPE_SV_RECORD)
+	if(MsgType == NETMSGTYPE_SV_RECORD || MsgType == NETMSGTYPE_SV_RECORDLEGACY)
 	{
 		CNetMsg_Sv_Record *pMsg = (CNetMsg_Sv_Record *)pRawMsg;
 		m_ServerRecord = (float)pMsg->m_ServerTimeBest / 100;


### PR DESCRIPTION
Fix #3599.

(Forgot to check for both NETMSG_RECORD and NETMSG_RECORDLEGACY in one
place.)

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
