### PR TITLE
Don't try to update .so files on Windows

### DIFF
--- a/src/engine/client/updater.cpp
+++ b/src/engine/client/updater.cpp
@@ -156,6 +156,11 @@ bool CUpdater::MoveFile(const char *pFile)
 		return Success;
 #endif
 
+#if !defined(CONF_PLATFORM_LINUX)
+	if(!str_comp_nocase(pFile + len - 4, ".so"))
+		return Success;
+#endif
+
 	if(!str_comp_nocase(pFile + len - 4, ".dll") || !str_comp_nocase(pFile + len - 4, ".ttf") || !str_comp_nocase(pFile + len - 3, ".so"))
 	{
 		str_format(aBuf, sizeof(aBuf), "%s.old", pFile);


### PR DESCRIPTION
```
[2021-02-12 10:33:01][storage]: failed to rename: Z:\DDNet-15.2.5-win64/discord_game_sdk.dll -> Z:\DDNet-15.2.5-win64/discord_game_sdk.dll.old
[2021-02-12 10:33:01][storage]: failed to rename: Z:\DDNet-15.2.5-win64/discord_game_sdk.so -> Z:\DDNet-15.2.5-win64/discord_game_sdk.so.old
[2021-02-12 10:33:01][storage]: failed to rename: Z:\DDNet-15.2.5-win64/update/discord_game_sdk.so -> Z:\DDNet-15.2.5-win64/discord_game_sdk.so
[2021-02-12 10:33:01][updater]: replacing DDNet.exe
[2021-02-12 10:33:01][storage]: failed to remove: Z:\DDNet-15.2.5-win64/DDNet.old
[2021-02-12 10:33:01][updater]: replacing DDNet-Server.exe
[2021-02-12 10:33:01][storage]: failed to remove: Z:\DDNet-15.2.5-win64/DDNet-Server.old
```

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
