### PR TITLE
Fix chat refind skins

### DIFF
--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -877,21 +877,17 @@ void CChat::AddLine(int ClientID, int Team, const char *pLine)
 
 void CChat::RefindSkins()
 {
-	for(int i = 0; i < MAX_LINES; i++)
+	for(auto &Line : m_aLines)
 	{
-		int r = ((m_CurrentLine - i) + MAX_LINES) % MAX_LINES;
-		if(m_aLines[r].m_TextContainerIndex == -1)
-			continue;
-
-		if(m_aLines[r].m_HasRenderTee)
+		if(Line.m_HasRenderTee)
 		{
-			const CSkin *pSkin = m_pClient->m_pSkins->Get(m_pClient->m_pSkins->Find(m_aLines[r].m_aSkinName));
-			if(m_aLines[r].m_CustomColoredSkin)
-				m_aLines[r].m_RenderSkin = pSkin->m_ColorableSkin;
+			const CSkin *pSkin = m_pClient->m_pSkins->Get(m_pClient->m_pSkins->Find(Line.m_aSkinName));
+			if(Line.m_CustomColoredSkin)
+				Line.m_RenderSkin = pSkin->m_ColorableSkin;
 			else
-				m_aLines[r].m_RenderSkin = pSkin->m_OriginalSkin;
+				Line.m_RenderSkin = pSkin->m_OriginalSkin;
 
-			m_aLines[r].m_RenderSkinMetrics = pSkin->m_Metrics;
+			Line.m_RenderSkinMetrics = pSkin->m_Metrics;
 		}
 	}
 }

--- a/src/game/client/skin.h
+++ b/src/game/client/skin.h
@@ -118,15 +118,6 @@ struct CSkin
 		SSkinMetricVariable m_Body;
 		SSkinMetricVariable m_Feet;
 
-		int m_FeetWidth;
-		int m_FeetHeight;
-		int m_FeetOffsetX;
-		int m_FeetOffsetY;
-
-		// these can be used to normalize the metrics
-		int m_FeetMaxWidth;
-		int m_FeetMaxHeight;
-
 		void Reset()
 		{
 			m_Body.Reset();


### PR DESCRIPTION
It should always search all lines(reprod. by changing windows size, which causes text containers to reset, which then causes skins to be not refound, when skins actually changed)

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
