### PR TITLE
Revert "Let's not crash the client and server on dbg_assert"

### DIFF
--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -114,7 +114,7 @@ void dbg_assert_imp(const char *filename, int line, int test, const char *msg)
 	if(!test)
 	{
 		dbg_msg("assert", "%s(%d): %s", filename, line, msg);
-		dbg_break_imp();
+		dbg_break();
 	}
 }
 

--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -118,7 +118,7 @@ void dbg_assert_imp(const char *filename, int line, int test, const char *msg)
 	}
 }
 
-void dbg_break_imp()
+void dbg_break()
 {
 #ifdef __GNUC__
 	__builtin_trap();

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -42,16 +42,12 @@ extern "C" {
 		msg - Message that should be printed if the test fails.
 
 	Remarks:
-		Does nothing in release version
+		Does nothing in release version of the library.
 
 	See Also:
 		<dbg_break>
 */
-#ifdef CONF_DEBUG
 #define dbg_assert(test, msg) dbg_assert_imp(__FILE__, __LINE__, test, msg)
-#else
-#define dbg_assert(test, msg)
-#endif
 void dbg_assert_imp(const char *filename, int line, int test, const char *msg);
 
 #ifdef __clang_analyzer__
@@ -71,17 +67,12 @@ void dbg_assert_imp(const char *filename, int line, int test, const char *msg);
 		Breaks into the debugger.
 
 	Remarks:
-		Does nothing in release version
+		Does nothing in release version of the library.
 
 	See Also:
 		<dbg_assert>
 */
-#ifdef CONF_DEBUG
-#define dbg_break() dbg_break_imp()
-#else
-#define dbg_break()
-#endif
-void dbg_break_imp();
+void dbg_break();
 
 /*
 	Function: dbg_msg
@@ -93,7 +84,7 @@ void dbg_break_imp();
 		fmt - A printf styled format string.
 
 	Remarks:
-		Also works in release version
+		Does nothing in release version of the library.
 
 	See Also:
 		<dbg_assert>

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -42,7 +42,7 @@ extern "C" {
 		msg - Message that should be printed if the test fails.
 
 	Remarks:
-		Does nothing in release version of the library.
+		Also works in release mode.
 
 	See Also:
 		<dbg_break>
@@ -67,7 +67,7 @@ void dbg_assert_imp(const char *filename, int line, int test, const char *msg);
 		Breaks into the debugger.
 
 	Remarks:
-		Does nothing in release version of the library.
+		Also works in release mode.
 
 	See Also:
 		<dbg_assert>
@@ -84,7 +84,7 @@ void dbg_break();
 		fmt - A printf styled format string.
 
 	Remarks:
-		Does nothing in release version of the library.
+		Also works in release mode.
 
 	See Also:
 		<dbg_assert>

--- a/src/engine/shared/uuid_manager.cpp
+++ b/src/engine/shared/uuid_manager.cpp
@@ -101,7 +101,8 @@ static int GetID(int Index)
 
 void CUuidManager::RegisterName(int ID, const char *pName)
 {
-	dbg_assert(GetIndex(ID) == m_aNames.size(), "names must be registered with increasing ID");
+	int Index = GetIndex(ID);
+	dbg_assert(Index == m_aNames.size(), "names must be registered with increasing ID");
 	CName Name;
 	Name.m_pName = pName;
 	Name.m_Uuid = CalculateUuid(pName);


### PR DESCRIPTION
This reverts commit a6e144e.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
