### PR TITLE
Fix two mistakes of the MySQL C API rewrite

### DIFF
--- a/src/engine/server/databases/mysql.cpp
+++ b/src/engine/server/databases/mysql.cpp
@@ -647,8 +647,8 @@ bool CMysqlConnection::AddPoints(const char *pPlayer, int Points, char *pError, 
 	BindString(1, pPlayer);
 	BindInt(2, Points);
 	BindInt(3, Points);
-	bool End;
-	if(Step(&End, pError, ErrorSize))
+	int NumUpdated;
+	if(ExecuteUpdate(&NumUpdated, pError, ErrorSize))
 	{
 		return true;
 	}

--- a/src/game/server/score.cpp
+++ b/src/game/server/score.cpp
@@ -686,7 +686,7 @@ bool CScore::SaveTeamScoreThread(IDbConnection *pSqlServer, const ISqlData *pGam
 	}
 	if(!End)
 	{
-		bool SearchTeamEnd = true;
+		bool SearchTeamEnd = false;
 		while(!SearchTeamEnd)
 		{
 			Time = pSqlServer->GetFloat(3);


### PR DESCRIPTION
Thanks to @Zwelf for help with debugging.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
