### PR TITLE
Don't leak memory on Windows in logger

### DIFF
--- a/src/base/system.c
+++ b/src/base/system.c
@@ -177,10 +177,16 @@ static void logger_stdout_sync(const char *line, void *user)
 		char u16[4] = {0};
 
 		if(codepoint < 0)
+		{
+			free(wide);
 			return;
+		}
 
 		if(str_utf16le_encode(u16, codepoint) != 2)
+		{
+			free(wide);
 			return;
+		}
 
 		mem_copy(&wide[wlen], u16, 2);
 	}

--- a/src/base/system.c
+++ b/src/base/system.c
@@ -188,6 +188,7 @@ static void logger_stdout_sync(const char *line, void *user)
 	console = GetStdHandle(STD_OUTPUT_HANDLE);
 	WriteConsoleW(console, wide, wlen, NULL, NULL);
 	WriteConsoleA(console, "\n", 1, NULL, NULL);
+	free(wide);
 }
 #endif
 


### PR DESCRIPTION
Thanks to 拓真 on Discord for report

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
