### PR TITLE
Fix /mapinfo displaying a time when not having finished

### DIFF
--- a/src/game/server/score.cpp
+++ b/src/game/server/score.cpp
@@ -454,10 +454,10 @@ bool CScore::MapInfoThread(IDbConnection *pSqlServer, const ISqlData *pGameData,
 		int Stars = pSqlServer->GetInt(5);
 		int Finishes = pSqlServer->GetInt(6);
 		int Finishers = pSqlServer->GetInt(7);
-		float Median = pSqlServer->GetInt(8);
+		float Median = !pSqlServer->IsNull(8) ? pSqlServer->GetInt(8) : -1.0f;
 		int Stamp = pSqlServer->GetInt(9);
 		int Ago = pSqlServer->GetInt(10);
-		float OwnTime = pSqlServer->GetFloat(11);
+		float OwnTime = !pSqlServer->IsNull(11) ? pSqlServer->GetFloat(11) : -1.0f;
 
 		char aAgoString[40] = "\0";
 		char aReleasedString[60] = "\0";


### PR DESCRIPTION
The C API doesn't return 0.0f for NULL values, check for them
explicitly.

Fixes #3653.

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
