### PR TITLE
Fix dmg.py

### DIFF
--- a/scripts/dmg.py
+++ b/scripts/dmg.py
@@ -36,10 +36,10 @@ class Dmgtools(Dmg):
 	def _dmg(self, *args):
 		self._check_call((self.config.dmg,) + args)
 
-	def _create_hfs(self, hfs, volume_name, size):
+	def _create_hfs(self, hfs_fd, hfs, volume_name, size):
 		if self.config.verbose >= 1:
 			print("TRUNCATING {} to {} bytes".format(hfs, size))
-		with open(hfs, 'wb') as f:
+		with os.fdopen(hfs_fd, 'wb') as f:
 			f.truncate(size)
 		self._mkfs_hfs('-v', volume_name, hfs)
 
@@ -55,8 +55,8 @@ class Dmgtools(Dmg):
 	def create(self, dmg, volume_name, directory, symlinks):
 		input_size = sum(os.stat(os.path.join(path, f)).st_size for path, dirs, files in os.walk(directory) for f in files)
 		output_size = max(input_size * 2, 1024**2)
-		hfs = tempfile.mkstemp(prefix=dmg + '.', suffix='.hfs')
-		self._create_hfs(hfs, volume_name, output_size)
+		hfs_fd, hfs = tempfile.mkstemp(prefix=dmg + '.', suffix='.hfs')
+		self._create_hfs(hfs_fd, hfs, volume_name, output_size)
 		self._add(hfs, directory)
 		for target, link_name in symlinks:
 			self._symlink(hfs, target, link_name)


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/deen/isos/ddnet/ddnet-source/scripts/dmg.py", line 106, in <module>
    main()
  File "/home/deen/isos/ddnet/ddnet-source/scripts/dmg.py", line 103, in main
    dmg.create(volume_name=args.volume_name, directory=args.directory, dmg=args.output, symlinks=symlinks)
  File "/home/deen/isos/ddnet/ddnet-source/scripts/dmg.py", line 59, in create
    self._create_hfs(hfs, volume_name, output_size)
  File "/home/deen/isos/ddnet/ddnet-source/scripts/dmg.py", line 42, in _create_hfs
    with open(hfs, 'wb') as f:
TypeError: expected str, bytes or os.PathLike object, not tuple
```
Not sure why it worked before, seems to have always been this way: https://docs.python.org/3/library/tempfile.html#tempfile.mkstemp
> mkstemp() returns a tuple containing an OS-level handle to an open file (as would be returned by os.open()) and the absolute pathname of that file, in that order.
<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
