### PR TITLE
Free Client.m_PersistentData

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -2685,6 +2685,11 @@ int CServer::Run()
 	m_UPnP.Shutdown();
 #endif
 
+	for(auto &Client : m_aClients)
+	{
+		free(Client.m_pPersistentData);
+	}
+
 	return ErrorShutdown();
 }
 


### PR DESCRIPTION
Caused by https://github.com/ddnet/ddnet/pull/3605

Found by ASAN:
```
==11628==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 64 byte(s) in 64 object(s) allocated from:
    #0 0x4f36b3 in __interceptor_malloc (/home/teeworlds/servers/DDNet-Server-asan+0x4f36b3)
    #1 0x5536a7 in CServer::Run() /home/teeworlds/src/master/src/engine/server/server.cpp:2362:31
    #2 0x562408 in main /home/teeworlds/src/master/src/engine/server/server.cpp:3594:21
    #3 0x7f6ee56d209a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2409a)
```
<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
