### PR TITLE
Updates to /top and /rank

### DIFF
--- a/src/game/server/score.cpp
+++ b/src/game/server/score.cpp
@@ -843,18 +843,18 @@ bool CScore::ShowRankThread(IDbConnection *pSqlServer, const ISqlData *pGameData
 			if(str_comp_nocase(pData->m_RequestingPlayer, pData->m_Name) == 0)
 			{
 				str_format(pResult->m_Data.m_aaMessages[0], sizeof(pResult->m_Data.m_aaMessages[0]),
-					"%s Time: %s, better than %d%%",
+					"%s - %s - better than %d%%",
 					pData->m_Name, aBuf, BetterThanPercent);
 			}
 			else
 			{
 				str_format(pResult->m_Data.m_aaMessages[0], sizeof(pResult->m_Data.m_aaMessages[0]),
-					"%s Time: %s, better than %d%%, requested by %s",
+					"%s - %s - better than %d%% - requested by %s",
 					pData->m_Name, aBuf, BetterThanPercent, pData->m_RequestingPlayer);
 			}
 
 			str_format(pResult->m_Data.m_aaMessages[1], sizeof(pResult->m_Data.m_aaMessages[1]),
-				"Global rank %d || %s %s",
+				"Global rank %d - %s %s",
 				Rank, pData->m_Server, aRegionalRank);
 		}
 	}
@@ -996,7 +996,7 @@ bool CScore::ShowTopThread(IDbConnection *pSqlServer, const ISqlData *pGameData,
 	}
 	pSqlServer->BindString(1, pData->m_Map);
 	pSqlServer->BindString(2, pAny);
-	pSqlServer->BindInt(3, 6);
+	pSqlServer->BindInt(3, 5);
 
 	// show top
 	int Line = 0;
@@ -1023,11 +1023,6 @@ bool CScore::ShowTopThread(IDbConnection *pSqlServer, const ISqlData *pGameData,
 		HasLocal = HasLocal || str_comp(aRecordServer, pData->m_Server) == 0;
 
 		Line++;
-
-		if(!HasLocal && Line == 4)
-		{
-			break;
-		}
 	}
 
 	if(!HasLocal)

--- a/src/game/server/score.h
+++ b/src/game/server/score.h
@@ -31,7 +31,7 @@ struct CScorePlayerResult : ISqlResult
 
 	enum
 	{
-		MAX_MESSAGES = 8,
+		MAX_MESSAGES = 10,
 	};
 
 	enum Variant


### PR DESCRIPTION
**/top**
Updated /top to always show the global 5. Also, show the region's top 3 if no local users are represented.

- The same information from the previous /top5 is displayed keeping consistency. Extra information is displayed only when relevant. 
- Regional top will be displayed even less often now that it takes the top 5 entries into consideration - before it was the top 3. 
![image](https://user-images.githubusercontent.com/25198124/111163123-7f7e1700-85a5-11eb-9ed5-815882b18db5.png)
![image](https://user-images.githubusercontent.com/25198124/111163145-87d65200-85a5-11eb-9502-c8aaabcdc22d.png)

**/rank**
Suggestions were made to update the format of /rank. The one with the most consensus was the below.
![rank](https://user-images.githubusercontent.com/25198124/111163322-af2d1f00-85a5-11eb-9f56-5503c3af3649.JPG)

## Checklist
- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
