### PR TITLE
Switch back to using a stable sort

### DIFF
--- a/src/base/tl/algorithm.h
+++ b/src/base/tl/algorithm.h
@@ -109,7 +109,7 @@ void sort_quick(R range)
 template<class R>
 void sort(R range)
 {
-	std::sort(&range.front(), &range.back() + 1);
+	std::stable_sort(&range.front(), &range.back() + 1);
 }
 
 template<class R>


### PR DESCRIPTION
so that for example demos stay sorted the same way when sorting by demo
markers and removing a demo, otherwise they get totally reordered every
time.

as reported by Shyzo

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
