### PR TITLE
Add variable length arrays to protocol

### DIFF
--- a/datasrc/compile.py
+++ b/datasrc/compile.py
@@ -93,6 +93,7 @@ def main():
 		print("#define GAME_GENERATED_PROTOCOL_H")
 		print("#include <engine/shared/protocol.h>")
 		print("#include <engine/message.h>")
+		print("#include <vector>")
 		print(network.RawHeader)
 
 		for e in network.Enums:

--- a/datasrc/datatypes.py
+++ b/datasrc/datatypes.py
@@ -375,7 +375,7 @@ class NetObjects(NetVariable):
 		for v in self.object.variables:
 			sub_lines = v.emit_unpack(var_access="Obj.")
 			lines += ["\t" + l for l in sub_lines]
-			lines += ["\tpMsg->%s.push_back(Obj);" % self.name]
+		lines += ["\tpMsg->%s.push_back(Obj);" % self.name]
 		lines += ["}"]
 
 		return lines

--- a/datasrc/network.py
+++ b/datasrc/network.py
@@ -1,7 +1,7 @@
 # pylint: skip-file
 # See https://github.com/ddnet/ddnet/issues/3507
 
-from datatypes import Enum, Flags, NetBool, NetEvent, NetIntAny, NetIntRange, NetMessage, NetMessageEx, NetObject, NetObjectEx, NetString, NetStringHalfStrict, NetStringStrict, NetTick
+from datatypes import Enum, Flags, NetBool, NetEvent, NetIntAny, NetIntRange, NetMessage, NetMessageEx, NetObject, NetObjectEx, NetString, NetStringHalfStrict, NetStringStrict, NetTick, NetObjects
 
 Emotes = ["NORMAL", "PAIN", "HAPPY", "SURPRISE", "ANGRY", "BLINK"]
 PlayerFlags = ["PLAYING", "IN_MENU", "CHATTING", "SCOREBOARD", "AIM"]
@@ -89,6 +89,7 @@ Flags = [
 	Flags("EXPLAYERFLAG", ExPlayerFlags),
 	Flags("PROJECTILEFLAG", ProjectileFlags),
 ]
+
 
 Objects = [
 
@@ -301,6 +302,11 @@ Objects = [
 	]),
 ]
 
+PlayerTimeMessage = NetMessageEx("Sv_PlayerTime", "player-time@ddnet.tw", [
+		NetStringStrict("m_Name"),
+		NetIntAny("m_Score"),
+	])
+
 Messages = [
 
 	### Server messages
@@ -472,5 +478,11 @@ Messages = [
 	NetMessageEx("Sv_Record", "record@netmsg.ddnet.tw", [
 		NetIntAny("m_ServerTimeBest"),
 		NetIntAny("m_PlayerTimeBest"),
+	]),
+
+	PlayerTimeMessage,
+
+	NetMessageEx("Sv_PlayerRanks", "ranks@netmsg.ddnet.tw", [
+		NetObjects("m_Ranks", PlayerTimeMessage),
 	]),
 ]


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request -->
This PR adds the posibility to send variable length array of the same netmessages (well, the object the message represents)
I added a PlayerTimeMessage and Sv_PlayerRanks as example, they can be removed before this pr is merged.

I made this because this can solve problems like the m_pDescription0 to 12 limitation and also because I think this would be needed if we add a proper netmessage for querying player ranks for showing them in a proper UI.

It uses std::vector, but we are in modern times right?

Here is the code it generates:

![image](https://user-images.githubusercontent.com/15859336/111290855-d851bc00-8646-11eb-946e-bd1233dd19ce.png)

![image](https://user-images.githubusercontent.com/15859336/111289690-b0ae2400-8645-11eb-891b-28c81ebca94e.png)

Let me know what you think.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
