### PR TITLE
Add dummy_reset and remove +resetdummy

### DIFF
--- a/src/engine/client.h
+++ b/src/engine/client.h
@@ -257,6 +257,7 @@ public:
 	virtual const char *DDNetVersionStr() const = 0;
 
 	virtual void OnDummyDisconnect() = 0;
+	virtual void DummyResetInput() = 0;
 	virtual void Echo(const char *pString) = 0;
 	virtual bool CanDisplayWarning() = 0;
 	virtual bool IsDisplayingWarning() = 0;

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -3486,6 +3486,12 @@ void CClient::Con_DummyDisconnect(IConsole::IResult *pResult, void *pUserData)
 	pSelf->DummyDisconnect(0);
 }
 
+void CClient::Con_DummyResetInput(IConsole::IResult *pResult, void *pUserData)
+{
+	CClient *pSelf = (CClient *)pUserData;
+	pSelf->GameClient()->DummyResetInput();
+}
+
 void CClient::Con_Quit(IConsole::IResult *pResult, void *pUserData)
 {
 	CClient *pSelf = (CClient *)pUserData;
@@ -4175,8 +4181,9 @@ void CClient::RegisterCommands()
 	m_pConsole->Register("stoprecord", "", CFGFLAG_SERVER, 0, 0, "Stop recording");
 	m_pConsole->Register("reload", "", CFGFLAG_SERVER, 0, 0, "Reload the map");
 
-	m_pConsole->Register("dummy_connect", "", CFGFLAG_CLIENT, Con_DummyConnect, this, "connect dummy");
-	m_pConsole->Register("dummy_disconnect", "", CFGFLAG_CLIENT, Con_DummyDisconnect, this, "disconnect dummy");
+	m_pConsole->Register("dummy_connect", "", CFGFLAG_CLIENT, Con_DummyConnect, this, "Connect dummy");
+	m_pConsole->Register("dummy_disconnect", "", CFGFLAG_CLIENT, Con_DummyDisconnect, this, "Disconnect dummy");
+	m_pConsole->Register("dummy_reset", "", CFGFLAG_CLIENT, Con_DummyResetInput, this, "Reset dummy");
 
 	m_pConsole->Register("quit", "", CFGFLAG_CLIENT | CFGFLAG_STORE, Con_Quit, this, "Quit Teeworlds");
 	m_pConsole->Register("exit", "", CFGFLAG_CLIENT | CFGFLAG_STORE, Con_Quit, this, "Quit Teeworlds");

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -400,6 +400,7 @@ public:
 
 	static void Con_DummyConnect(IConsole::IResult *pResult, void *pUserData);
 	static void Con_DummyDisconnect(IConsole::IResult *pResult, void *pUserData);
+	static void Con_DummyResetInput(IConsole::IResult *pResult, void *pUserData);
 
 	static void Con_Quit(IConsole::IResult *pResult, void *pUserData);
 	static void Con_DemoPlay(IConsole::IResult *pResult, void *pUserData);

--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -198,10 +198,6 @@ void CControls::OnConsoleInit()
 		static CInputState s_State = {this, &m_ShowHookColl[0], &m_ShowHookColl[1]};
 		Console()->Register("+showhookcoll", "", CFGFLAG_CLIENT, ConKeyInputState, (void *)&s_State, "Show Hook Collision");
 	}
-	{
-		static CInputState s_State = {this, &m_ResetDummy[0], &m_ResetDummy[1]};
-		Console()->Register("+resetdummy", "", CFGFLAG_CLIENT, ConKeyInputState, (void *)&s_State, "Reset Dummy");
-	}
 
 	{
 		static CInputSet s_Set = {this, &m_InputData[0].m_WantedWeapon, &m_InputData[1].m_WantedWeapon, 1};
@@ -339,19 +335,6 @@ int CControls::SnapInput(int *pData)
 			pDummyInput->m_Jump = g_Config.m_ClDummyJump;
 			pDummyInput->m_Fire = g_Config.m_ClDummyFire;
 			pDummyInput->m_Hook = g_Config.m_ClDummyHook;
-		}
-
-		if(m_ResetDummy[g_Config.m_ClDummy])
-		{
-			ResetInput(!g_Config.m_ClDummy);
-			m_InputData[!g_Config.m_ClDummy].m_Hook = 0;
-
-			CNetObj_PlayerInput *pDummyInput = &m_pClient->m_DummyInput;
-			pDummyInput->m_Hook = m_InputData[!g_Config.m_ClDummy].m_Hook;
-			pDummyInput->m_Jump = m_InputData[!g_Config.m_ClDummy].m_Jump;
-			pDummyInput->m_Direction = m_InputData[!g_Config.m_ClDummy].m_Jump;
-
-			pDummyInput->m_Fire = m_InputData[!g_Config.m_ClDummy].m_Fire;
 		}
 
 		// stress testing

--- a/src/game/client/components/controls.h
+++ b/src/game/client/components/controls.h
@@ -29,7 +29,6 @@ public:
 	int m_InputDirectionLeft[NUM_DUMMIES];
 	int m_InputDirectionRight[NUM_DUMMIES];
 	int m_ShowHookColl[NUM_DUMMIES];
-	int m_ResetDummy[NUM_DUMMIES];
 	int m_LastDummy;
 	int m_OtherFire;
 

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -2992,6 +2992,21 @@ void CGameClient::ConchainMenuMap(IConsole::IResult *pResult, void *pUserData, I
 		pfnCallback(pResult, pCallbackUserData);
 }
 
+void CGameClient::DummyResetInput()
+{
+	if(!Client()->DummyConnected())
+		return;
+
+	if((m_DummyInput.m_Fire & 1) != 0)
+		m_DummyInput.m_Fire++;
+
+	m_pControls->ResetInput(!g_Config.m_ClDummy);
+	m_pControls->m_InputData[!g_Config.m_ClDummy].m_Hook = 0;
+	m_pControls->m_InputData[!g_Config.m_ClDummy].m_Fire = m_DummyInput.m_Fire;
+
+	m_DummyInput = m_pControls->m_InputData[!g_Config.m_ClDummy];
+}
+
 bool CGameClient::CanDisplayWarning()
 {
 	return m_pMenus->CanDisplayWarning();

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -451,6 +451,7 @@ public:
 	CGameWorld m_PredictedWorld;
 	CGameWorld m_PrevPredictedWorld;
 
+	void DummyResetInput();
 	void Echo(const char *pString);
 	bool IsOtherTeam(int ClientID);
 	bool CanDisplayWarning();


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request -->

It's works now for both on console/cfg and as bind. Also tried to fix annoying dummy hammer issue when reset dummy

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [X] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
