### PR TITLE
Editor: only externalize images with vanilla names

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -3811,18 +3811,20 @@ int CEditor::PopupImage(CEditor *pEditor, CUIRect View, void *pContext)
 			pImg->m_External = 0;
 			return 1;
 		}
+		View.HSplitTop(5.0f, &Slot, &View);
+		View.HSplitTop(12.0f, &Slot, &View);
 	}
-	else
+	else if(IsVanillaImage(pImg->m_aName))
 	{
 		if(pEditor->DoButton_MenuItem(&s_ExternalButton, "Make external", 0, &Slot, 0, "Removes the image from the map file."))
 		{
 			pImg->m_External = 1;
 			return 1;
 		}
+		View.HSplitTop(5.0f, &Slot, &View);
+		View.HSplitTop(12.0f, &Slot, &View);
 	}
 
-	View.HSplitTop(5.0f, &Slot, &View);
-	View.HSplitTop(12.0f, &Slot, &View);
 	if(pEditor->DoButton_MenuItem(&s_ReplaceButton, "Replace", 0, &Slot, 0, "Replaces the image with a new one"))
 	{
 		pEditor->InvokeFileDialog(IStorage::TYPE_ALL, FILETYPE_IMG, "Replace Image", "Replace", "mapres", "", ReplaceImage, pEditor);
@@ -4038,7 +4040,15 @@ void CEditor::RenderImages(CUIRect ToolBox, CUIRect View)
 
 				static int s_PopupImageID = 0;
 				if(Result == 2)
-					UiInvokePopupMenu(&s_PopupImageID, 0, UI()->MouseX(), UI()->MouseY(), 120, 60, PopupImage);
+				{
+					CEditorImage *pImg = m_Map.m_lImages[m_SelectedImage];
+					int Height;
+					if(pImg->m_External || IsVanillaImage(pImg->m_aName))
+						Height = 60;
+					else
+						Height = 43;
+					UiInvokePopupMenu(&s_PopupImageID, 0, UI()->MouseX(), UI()->MouseY(), 120, Height, PopupImage);
+				}
 			}
 
 			ToolBox.HSplitTop(2.0f, 0, &ToolBox);


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request -->
All external images should be vanilla images, since other images can't be loaded by other clients.
Also:
- all external images should be allowed to be embedded (for example for 0.7 compatibility)
- only embedded vanilla images should be allowed to become embedded again

This change focuses on enforcing those basic rules. Vanilla images are identified using only their name, this method was used to sort images into embedded/external upon adding them.

The only real change is that the editor will now only allow making an image external if it has a vanilla name.

The motivation of this change are:
- a few times I was sent maps I couldn't load properly because the mapper accidentally made some images external
- there are some DDNet maps with external images that are not vanilla images

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
