### PR TITLE
No negative count in server browser

### DIFF
--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -330,15 +330,12 @@ int CServerBrowser::SortHash() const
 
 void SetFilteredPlayers(const CServerInfo &Item)
 {
-	if(g_Config.m_BrFilterSpectators)
-		Item.m_NumFilteredPlayers = Item.m_NumPlayers;
-	else
-		Item.m_NumFilteredPlayers = Item.m_NumClients;
+	Item.m_NumFilteredPlayers = g_Config.m_BrFilterSpectators ? Item.m_NumPlayers : Item.m_NumClients;
 	if(g_Config.m_BrFilterConnectingPlayers)
 	{
 		for(const auto &Client : Item.m_aClients)
 		{
-			if(str_comp(Client.m_aName, "(connecting)") == 0 && Client.m_aClan[0] == '\0' && Client.m_Country == -1 && Client.m_Score == 0)
+			if((!g_Config.m_BrFilterSpectators || Client.m_Player) && str_comp(Client.m_aName, "(connecting)") == 0 && Client.m_aClan[0] == '\0')
 				Item.m_NumFilteredPlayers--;
 		}
 	}


### PR DESCRIPTION
With "Count playery only" and "Filter connecting players" both activated

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
