### PR TITLE
Feature: Hook range indicators

### DIFF
--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -360,6 +360,8 @@ MACRO_CONFIG_INT(ClPredictFreeze, cl_predict_freeze, 1, 0, 2, CFGFLAG_CLIENT | C
 MACRO_CONFIG_INT(ClShowNinja, cl_show_ninja, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show ninja skin")
 MACRO_CONFIG_INT(ClShowHookCollOther, cl_show_hook_coll_other, 1, 0, 2, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show other players' hook collision line (2 to always show)")
 MACRO_CONFIG_INT(ClShowHookCollOwn, cl_show_hook_coll_own, 1, 0, 2, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show own players' hook collision line (2 to always show)")
+MACRO_CONFIG_INT(ClShowOwnHookRangeInd, cl_show_own_hook_range_ind, 0, 0, 2, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show a thin circle around your player that indicates your maximal hook length.")
+MACRO_CONFIG_INT(ClShowOtherHookRangeInd, cl_show_other_hook_range_ind, 0, 0, 2, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show a thin circle around all players that indicates their maximal hook length.")
 
 MACRO_CONFIG_INT(ClChatTeamColors, cl_chat_teamcolors, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show names in chat in team colors")
 MACRO_CONFIG_INT(ClChatReset, cl_chat_reset, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Reset chat when pressing escape")

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -2101,6 +2101,17 @@ void CMenus::RenderSettingsDDNet(CUIRect MainView)
 	}
 
 	Left.HSplitTop(20.0f, &Button, &Left);
+	if(DoButton_CheckBox(&g_Config.m_ClShowOwnHookRangeInd, Localize("Show a circle indicating your hook range"), g_Config.m_ClShowOwnHookRangeInd, &Button))
+	{
+		g_Config.m_ClShowOwnHookRangeInd ^= 1;
+	}
+	Left.HSplitTop(20.0f, &Button, &Left);
+	if(DoButton_CheckBox(&g_Config.m_ClShowOtherHookRangeInd, Localize("Show a circle indicating others hook range"), g_Config.m_ClShowOtherHookRangeInd, &Button))
+	{
+		g_Config.m_ClShowOtherHookRangeInd ^= 1;
+	}
+
+	Left.HSplitTop(20.0f, &Button, &Left);
 	if(DoButton_CheckBox(&g_Config.m_ClShowDirection, Localize("Show other players' key presses"), g_Config.m_ClShowDirection, &Button))
 	{
 		g_Config.m_ClShowDirection ^= 1;

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -273,6 +273,32 @@ void CPlayers::RenderPlayer(
 			vec2(-Player.m_Direction * 100 * length(Vel), -50));
 	}
 
+	// draw optional hook range indicator
+	{
+		bool RenderHookRangeInd = (Local ? g_Config.m_ClShowOwnHookRangeInd : g_Config.m_ClShowOtherHookRangeInd);
+		if(RenderHookRangeInd)
+		{
+			Graphics()->TextureClear();
+			Graphics()->LinesBegin();
+			Graphics()->SetColor(Local ? 255 : 0, Local ? 0 : 255, 255, Alpha);
+
+			IGraphics::CLineItem arr[1];
+			float d = (float)GameClient()->m_Tuning[g_Config.m_ClDummy].m_HookLength;
+			for(int nf = 0; nf < 50; nf++)
+			{
+				float aa = ((float)nf / 50.0 * 2 * pi);
+				float ab = ((float)(nf + 1) / 50.0 * 2 * pi);
+				int offxa = (sin(aa) * d);
+				int offya = (cos(aa) * d);
+				int offxb = (sin(ab) * d);
+				int offyb = (cos(ab) * d);
+				arr[0] = IGraphics::CLineItem((float)Position.x + offxa, (float)Position.y + offya, (float)Position.x + offxb, (float)Position.y + offyb);
+				Graphics()->LinesDraw(arr, 1);
+			}
+			Graphics()->LinesEnd();
+		}
+	}
+
 	// draw gun
 	{
 		bool AlwaysRenderHookColl = GameClient()->m_GameInfo.m_AllowHookColl && (Local ? g_Config.m_ClShowHookCollOwn : g_Config.m_ClShowHookCollOther) == 2;


### PR DESCRIPTION
Since it's hard for new players to estimate the length of their hook on the fly, it would be useful to have a indicator for that.
I've added thin circles around the players and options to enable this for your own hook and the one of other players.

(screenshot upload doesn't work sadly)
## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)

