### PR TITLE
Add sv_tele_unfreeze setting

### DIFF
--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -200,6 +200,7 @@ MACRO_CONFIG_INT(SvSpecFrequency, sv_pause_frequency, 1, 0, 9999, CFGFLAG_SERVER
 MACRO_CONFIG_INT(SvInvite, sv_invite, 1, 0, 1, CFGFLAG_SERVER, "Whether players can invite other players to teams")
 MACRO_CONFIG_INT(SvInviteFrequency, sv_invite_frequency, 1, 0, 9999, CFGFLAG_SERVER, "The minimum allowed delay between invites")
 MACRO_CONFIG_INT(SvTeleOthersAuthLevel, sv_tele_others_auth_level, 1, 1, 3, CFGFLAG_SERVER, "The auth level you need to tele others")
+MACRO_CONFIG_INT(SvTeleUnfreeze, sv_tele_unfreeze, 0, 0, 1, CFGFLAG_SERVER | CFGFLAG_GAME, "Unfreeze on teleport")
 
 MACRO_CONFIG_INT(SvEmotionalTees, sv_emotional_tees, 1, -1, 1, CFGFLAG_SERVER, "Whether eye change of tees is enabled with emoticons = 1, not = 0, -1 not at all")
 MACRO_CONFIG_INT(SvEmoticonDelay, sv_emoticon_delay, 3, 0, 9999, CFGFLAG_SERVER, "The time in seconds between over-head emoticons")

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -1884,6 +1884,8 @@ void CCharacter::HandleTiles(int Index)
 			return;
 		int TeleOut = m_Core.m_pWorld->RandomOr0((*m_pTeleOuts)[z - 1].size());
 		m_Core.m_Pos = (*m_pTeleOuts)[z - 1][TeleOut];
+		if(!m_DeepFreeze && Config()->m_SvTeleUnfreeze)
+			UnFreeze();
 		if(!g_Config.m_SvTeleportHoldHook)
 		{
 			m_Core.m_HookedPlayer = -1;
@@ -1902,6 +1904,8 @@ void CCharacter::HandleTiles(int Index)
 			return;
 		int TeleOut = m_Core.m_pWorld->RandomOr0((*m_pTeleOuts)[evilz - 1].size());
 		m_Core.m_Pos = (*m_pTeleOuts)[evilz - 1][TeleOut];
+		if(!m_DeepFreeze && Config()->m_SvTeleUnfreeze)
+			UnFreeze();
 		if(!g_Config.m_SvOldTeleportHook && !g_Config.m_SvOldTeleportWeapons)
 		{
 			m_Core.m_Vel = vec2(0, 0);
@@ -1933,6 +1937,8 @@ void CCharacter::HandleTiles(int Index)
 				int TeleOut = m_Core.m_pWorld->RandomOr0((*m_pTeleCheckOuts)[k].size());
 				m_Core.m_Pos = (*m_pTeleCheckOuts)[k][TeleOut];
 				m_Core.m_Vel = vec2(0, 0);
+				if(!m_DeepFreeze && Config()->m_SvTeleUnfreeze)
+					UnFreeze();
 
 				if(!g_Config.m_SvTeleportHoldHook)
 				{
@@ -1952,6 +1958,8 @@ void CCharacter::HandleTiles(int Index)
 		{
 			m_Core.m_Pos = SpawnPos;
 			m_Core.m_Vel = vec2(0, 0);
+			if(!m_DeepFreeze && Config()->m_SvTeleUnfreeze)
+				UnFreeze();
 
 			if(!g_Config.m_SvTeleportHoldHook)
 			{
@@ -1975,6 +1983,8 @@ void CCharacter::HandleTiles(int Index)
 			{
 				int TeleOut = m_Core.m_pWorld->RandomOr0((*m_pTeleCheckOuts)[k].size());
 				m_Core.m_Pos = (*m_pTeleCheckOuts)[k][TeleOut];
+				if(!m_DeepFreeze && Config()->m_SvTeleUnfreeze)
+					UnFreeze();
 
 				if(!g_Config.m_SvTeleportHoldHook)
 				{
@@ -1992,6 +2002,8 @@ void CCharacter::HandleTiles(int Index)
 		if(GameServer()->m_pController->CanSpawn(m_pPlayer->GetTeam(), &SpawnPos))
 		{
 			m_Core.m_Pos = SpawnPos;
+			if(!m_DeepFreeze && Config()->m_SvTeleUnfreeze)
+				UnFreeze();
 
 			if(!g_Config.m_SvTeleportHoldHook)
 			{


### PR DESCRIPTION
Allows mappers to use `sv_tele_unfreeze 1` instead of placing unfreezing tiles on top of teleouters.

closes #2385

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
