### PR TITLE
Search for both x264 and libx264

### DIFF
--- a/cmake/FindFFMPEG.cmake
+++ b/cmake/FindFFMPEG.cmake
@@ -6,7 +6,7 @@ if(NOT CMAKE_CROSSCOMPILING)
   pkg_check_modules(PC_SWSCALE libswscale)
   pkg_check_modules(PC_SWRESAMPLE libswresample)
   if(TARGET_OS STREQUAL "linux")
-    pkg_check_modules(PC_X264 libx264)
+    pkg_search_module(PC_X264 libx264 x264)
   endif()
 endif()
 


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request -->

Set CMake to search for 'x264' pkg-config file as well to fix for Arch Linux (at least).

Fixes #3739

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
