### PR TITLE
Detect hangul choseong filler character as whitespace (fixes #3752)

### DIFF
--- a/src/base/system.c
+++ b/src/base/system.c
@@ -3017,8 +3017,8 @@ const char *str_utf8_find_nocase(const char *haystack, const char *needle)
 
 int str_utf8_isspace(int code)
 {
-	return code <= 0x0020 || code == 0x0085 || code == 0x00A0 ||
-	       code == 0x034F || code == 0x1160 || code == 0x1680 || code == 0x180E ||
+	return code <= 0x0020 || code == 0x0085 || code == 0x00A0 || code == 0x034F ||
+	       code == 0x115F || code == 0x1160 || code == 0x1680 || code == 0x180E ||
 	       (code >= 0x2000 && code <= 0x200F) || (code >= 0x2028 && code <= 0x202F) ||
 	       (code >= 0x205F && code <= 0x2064) || (code >= 0x206A && code <= 0x206F) ||
 	       code == 0x2800 || code == 0x3000 || code == 0x3164 ||


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
