### PR TITLE
Fix team rank updating not working

### DIFF
--- a/src/game/server/score.cpp
+++ b/src/game/server/score.cpp
@@ -718,7 +718,8 @@ bool CScore::SaveTeamScoreThread(IDbConnection *pSqlServer, const ISqlData *pGam
 			pSqlServer->BindString(2, pData->m_GameUuid);
 			pSqlServer->BindBlob(3, Teamrank.m_TeamID.m_aData, sizeof(Teamrank.m_TeamID.m_aData));
 			pSqlServer->Print();
-			if(pSqlServer->Step(&End, pError, ErrorSize))
+			int NumUpdated;
+			if(pSqlServer->ExecuteUpdate(&NumUpdated, pError, ErrorSize))
 			{
 				return true;
 			}


### PR DESCRIPTION
With the MySQL C API, we need to distinguish between SQL statements that
return result sets and those that do not, UPDATE is one of those that
don't produce a result set.

Fixes #3725.

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
