### PR TITLE
Fixed hook being lost for specific teleports

### DIFF
--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -742,7 +742,6 @@ void CCharacter::ResetHook()
 	m_Core.m_HookedPlayer = -1;
 	m_Core.m_HookState = HOOK_RETRACTED;
 	m_Core.m_TriggeredEvents |= COREEVENT_HOOK_RETRACT;
-	GameWorld()->ReleaseHooked(GetPlayer()->GetCID());
 	m_Core.m_HookPos = m_Core.m_Pos;
 }
 
@@ -1915,6 +1914,7 @@ void CCharacter::HandleTiles(int Index)
 			if(!g_Config.m_SvTeleportHoldHook)
 			{
 				ResetHook();
+				GameWorld()->ReleaseHooked(GetPlayer()->GetCID());
 			}
 			if(g_Config.m_SvTeleportLoseWeapons)
 			{
@@ -1939,6 +1939,7 @@ void CCharacter::HandleTiles(int Index)
 				if(!g_Config.m_SvTeleportHoldHook)
 				{
 					ResetHook();
+					GameWorld()->ReleaseHooked(GetPlayer()->GetCID());
 				}
 
 				return;
@@ -1954,6 +1955,7 @@ void CCharacter::HandleTiles(int Index)
 			if(!g_Config.m_SvTeleportHoldHook)
 			{
 				ResetHook();
+				GameWorld()->ReleaseHooked(GetPlayer()->GetCID());
 			}
 		}
 		return;
@@ -2264,6 +2266,7 @@ void CCharacter::Pause(bool Pause)
 		if(m_Core.m_HookedPlayer != -1) // Keeping hook would allow cheats
 		{
 			ResetHook();
+			GameWorld()->ReleaseHooked(GetPlayer()->GetCID());
 		}
 	}
 	else

--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -751,6 +751,7 @@ void CGameTeams::SwapTeamCharacters(CPlayer *pPlayer, CPlayer *pTargetPlayer, in
 		if(m_Core.Team(i) == Team && GameServer()->m_apPlayers[i])
 		{
 			GameServer()->m_apPlayers[i]->GetCharacter()->ResetHook();
+			GameServer()->m_World.ReleaseHooked(i);
 		}
 	}
 


### PR DESCRIPTION
Removed the reset of external tees hooks on the specific teleport types. 

For issue #3766 

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
