### PR TITLE
Fix auto reconnect while in game

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -2953,7 +2953,8 @@ void CClient::Update()
 
 	if(m_ReconnectTime > 0 && time_get() > m_ReconnectTime)
 	{
-		Connect(m_aServerAddressStr);
+		if(State() != STATE_ONLINE)
+			Connect(m_aServerAddressStr);
 		m_ReconnectTime = 0;
 	}
 }


### PR DESCRIPTION
When for example using local console ``connect localhost`` while being in reconnect state. The timer will not be reset to 0. And maybe there are even other cases so make sure to never reconnect while being in game.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
