### PR TITLE
Fix parsing an IPv6 address without port

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2178,6 +2178,7 @@ if(GTEST_FOUND OR DOWNLOAD_GTEST)
     json.cpp
     mapbugs.cpp
     name_ban.cpp
+    netaddr.cpp
     packer.cpp
     prng.cpp
     str.cpp

--- a/src/base/system.c
+++ b/src/base/system.c
@@ -1287,6 +1287,10 @@ int net_addr_from_str(NETADDR *addr, const char *string)
 				if(parse_uint16(&addr->port, &str))
 					return -1;
 			}
+			else
+			{
+				addr->port = 0;
+			}
 		}
 		else
 			return -1;

--- a/src/test/netaddr.cpp
+++ b/src/test/netaddr.cpp
@@ -1,0 +1,48 @@
+#include <gtest/gtest.h>
+
+#include <base/system.h>
+
+TEST(NetAddr, FromStr)
+{
+	NETADDR Addr;
+	char aBuf1[NETADDR_MAXSTRSIZE];
+	char aBuf2[NETADDR_MAXSTRSIZE];
+
+	EXPECT_FALSE(net_addr_from_str(&Addr, "127.0.0.1"));
+	net_addr_str(&Addr, aBuf1, sizeof(aBuf1), true);
+	net_addr_str(&Addr, aBuf2, sizeof(aBuf2), false);
+	EXPECT_STREQ(aBuf1, "127.0.0.1:0");
+	EXPECT_STREQ(aBuf2, "127.0.0.1");
+
+	EXPECT_FALSE(net_addr_from_str(&Addr, "1.2.3.4:5678"));
+	net_addr_str(&Addr, aBuf1, sizeof(aBuf1), true);
+	net_addr_str(&Addr, aBuf2, sizeof(aBuf2), false);
+	EXPECT_STREQ(aBuf1, "1.2.3.4:5678");
+	EXPECT_STREQ(aBuf2, "1.2.3.4");
+
+	EXPECT_FALSE(net_addr_from_str(&Addr, "[::1]"));
+	net_addr_str(&Addr, aBuf1, sizeof(aBuf1), true);
+	net_addr_str(&Addr, aBuf2, sizeof(aBuf2), false);
+	EXPECT_STREQ(aBuf1, "[0:0:0:0:0:0:0:1]:0");
+	EXPECT_STREQ(aBuf2, "[0:0:0:0:0:0:0:1]");
+
+	EXPECT_FALSE(net_addr_from_str(&Addr, "[0123:4567:89ab:cdef:1:2:3:4]:5678"));
+	net_addr_str(&Addr, aBuf1, sizeof(aBuf1), true);
+	net_addr_str(&Addr, aBuf2, sizeof(aBuf2), false);
+	EXPECT_STREQ(aBuf1, "[123:4567:89ab:cdef:1:2:3:4]:5678");
+	EXPECT_STREQ(aBuf2, "[123:4567:89ab:cdef:1:2:3:4]");
+}
+
+TEST(NetAddr, FromStrInvalid)
+{
+	NETADDR Addr;
+	EXPECT_TRUE(net_addr_from_str(&Addr, "127.0.0."));
+	//EXPECT_TRUE(net_addr_from_str(&Addr, "127.0.0.1a"));
+	EXPECT_TRUE(net_addr_from_str(&Addr, "1.1"));
+	EXPECT_TRUE(net_addr_from_str(&Addr, "[::1"));
+	EXPECT_TRUE(net_addr_from_str(&Addr, "[::"));
+	EXPECT_TRUE(net_addr_from_str(&Addr, "127.0.0.1:"));
+	EXPECT_TRUE(net_addr_from_str(&Addr, "[::]:"));
+	//EXPECT_TRUE(net_addr_from_str(&Addr, "127.0.0.1:1a"));
+	EXPECT_TRUE(net_addr_from_str(&Addr, "[::]:c"));
+}


### PR DESCRIPTION
The port in the NETADDR struct was left uninitialized.

Add some tests to ensure behavior.

CC #3774 #3775

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [x] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
