### PR TITLE
Fix composed binds involving F-keys

### DIFF
--- a/src/game/client/components/binds.cpp
+++ b/src/game/client/components/binds.cpp
@@ -13,13 +13,24 @@ bool CBinds::CBindsSpecial::OnInput(IInput::CEvent Event)
 	{
 		int Mask = m_pBinds->GetModifierMask(Input());
 
+		// Look for a composed bind
 		bool ret = false;
-		for(int Mod = 0; Mod < MODIFIER_COMBINATION_COUNT; Mod++)
+		for(int Mod = 1; Mod < MODIFIER_COMBINATION_COUNT; Mod++)
 		{
-			if(Mask & (1 << Mod) && m_pBinds->m_aapKeyBindings[Mod][Event.m_Key])
+			if(Mask == Mod && m_pBinds->m_aapKeyBindings[Mod][Event.m_Key])
+			{
 				m_pBinds->GetConsole()->ExecuteLineStroked(Event.m_Flags & IInput::FLAG_PRESS, m_pBinds->m_aapKeyBindings[Mod][Event.m_Key]);
+				ret = true;
+			}
+		}
+
+		// Look for a non composed bind
+		if(!ret && m_pBinds->m_aapKeyBindings[0][Event.m_Key])
+		{
+			m_pBinds->GetConsole()->ExecuteLineStroked(Event.m_Flags & IInput::FLAG_PRESS, m_pBinds->m_aapKeyBindings[0][Event.m_Key]);
 			ret = true;
 		}
+
 		return ret;
 	}
 


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request -->
This fixes the issues for the meanwhile, but I think I want to rewrite this. We are kind of wasting memory and it behaves really oddly with multiple binds that match the chord progression. The bug was introduced in #2675

Fixed #3771 for now. @fokkonaut please check

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [x] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
