### PR TITLE
Copied Teeworld patches for the Haiku operating system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,7 +155,7 @@ if(CMAKE_GENERATOR STREQUAL "Ninja")
   add_c_compiler_flag_if_supported(OUR_FLAGS -fcolor-diagnostics)
 endif()
 
-if(NOT MSVC)
+if(NOT MSVC AND NOT HAIKU)
   if(CMAKE_VERSION VERSION_LESS 3.1 OR TARGET_OS STREQUAL "mac")
     check_cxx_compiler_flag(-std=gnu++11 FLAG_SUPPORTED_std_gnu__11)
     if(FLAG_SUPPORTED_std_gnu__11)
@@ -210,9 +210,15 @@ if(NOT MSVC)
   add_c_compiler_flag_if_supported(OUR_FLAGS_OWN -Wthread-safety)
   # TODO: Enable for C++ code except gtest
   #add_cxx_compiler_flag_if_supported(OUR_FLAGS_OWN "-Wuseless-cast")
+else()
+  if(TARGET_OS STREQUAL "haiku")
+    set(PLATFORM_CLIENT)
+    find_package(OpenGL)
+    set(PLATFORM_LIBS GL network)
+  endif()
 endif()
 
-if(NOT MSVC)
+if(NOT MSVC AND NOT HAIKU)
   check_c_compiler_flag("-O2;-Wp,-Werror;-D_FORTIFY_SOURCE=2" DEFINE_FORTIFY_SOURCE) # Some distributions define _FORTIFY_SOURCE by themselves.
 endif()
 

--- a/src/base/detect.h
+++ b/src/base/detect.h
@@ -82,6 +82,13 @@
 #define PLATFORM_STRING "beos"
 #endif
 
+#if defined(__HAIKU__)
+#define CONF_FAMILY_UNIX 1
+#define CONF_FAMILY_STRING "unix"
+#define CONF_PLATFORM_HAIKU 1
+#define CONF_PLATFORM_STRING "haiku"
+#endif
+
 /* use gcc endianness definitions when available */
 #if defined(__GNUC__) && !defined(__APPLE__) && !defined(__MINGW32__) && !defined(__sun)
 #if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)

--- a/src/base/system.c
+++ b/src/base/system.c
@@ -2074,6 +2074,11 @@ int fs_storage_path(const char *appname, char *path, int max)
 	if(!home)
 		return -1;
 
+#if defined(CONF_PLATFORM_HAIKU)
+	str_format(path, max, "%s/config/settings/%s", home, appname);
+	return 0;
+#endif
+
 #if defined(CONF_PLATFORM_MACOS)
 	snprintf(path, max, "%s/Library/Application Support/%s", home, appname);
 #else
@@ -2113,6 +2118,11 @@ int fs_makedir(const char *path)
 		return 0;
 	return -1;
 #else
+#ifdef CONF_PLATFORM_HAIKU
+	struct stat st;
+	if(stat(path, &st) == 0)
+		return 0;
+#endif
 	if(mkdir(path, 0755) == 0)
 		return 0;
 	if(errno == EEXIST)

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -631,7 +631,11 @@ void sphore_destroy(SEMAPHORE *sem);
 /* if compiled with -pedantic-errors it will complain about long
 	not being a C90 thing.
 */
+#ifdef CONF_PLATFORM_HAIKU
+#include <SupportDefs.h>
+#else
 __extension__ typedef long long int64;
+#endif
 __extension__ typedef unsigned long long uint64;
 #else
 typedef long long int64;

--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -4777,7 +4777,7 @@ void CGraphicsBackend_SDL_OpenGL::SetWindowParams(int FullscreenMode, bool IsBor
 	{
 		if(FullscreenMode == 1)
 		{
-#if defined(CONF_PLATFORM_MACOS) // Todo SDL: remove this when fixed (game freezes when losing focus in fullscreen)
+#if defined(CONF_PLATFORM_MACOS) || defined(CONF_PLATFORM_HAIKU) // Todo SDL: remove this when fixed (game freezes when losing focus in fullscreen)
 			SDL_SetWindowFullscreen(m_pWindow, SDL_WINDOW_FULLSCREEN_DESKTOP);
 #else
 			SDL_SetWindowFullscreen(m_pWindow, SDL_WINDOW_FULLSCREEN);

--- a/src/engine/shared/storage.cpp
+++ b/src/engine/shared/storage.cpp
@@ -6,6 +6,10 @@
 #include <engine/client/updater.h>
 #include <engine/storage.h>
 
+#ifdef CONF_PLATFORM_HAIKU
+#include <stdlib.h>
+#endif
+
 class CStorage : public IStorage
 {
 public:
@@ -193,6 +197,9 @@ public:
 
 		// 3) check for usable path in argv[0]
 		{
+#ifdef CONF_PLATFORM_HAIKU
+			pArgv0 = realpath(pArgv0, NULL);
+#endif
 			unsigned int Pos = ~0U;
 			for(unsigned i = 0; pArgv0[i]; i++)
 				if(pArgv0[i] == '/' || pArgv0[i] == '\\')
@@ -211,6 +218,9 @@ public:
 				}
 			}
 		}
+#ifdef CONF_PLATFORM_HAIKU
+		free((void *)pArgv0);
+#endif
 
 #if defined(CONF_FAMILY_UNIX)
 		// 4) check for all default locations


### PR DESCRIPTION
I initiated a port of ddnet and received a lot of help from the IRC in order to do so as seen in #2986. Unfortunately, my efforts went stale after one point. Fortunately, however, @threedeyes released a [set of patches for Teeworlds](https://github.com/haikuports/haikuports/blob/2ea72967cd2ab635a328ea82d686956769dd9ffc/games-action/teeworlds/patches/teeworlds-0.7.5.patchset). I decided to take down my repository with my own work and attempt to port Gerasim's work, which includes code for setting the directories that ddnet should use the same way one would do so in a Mac OS X-system in `src/base/system.c`, which was precisely the part where I got stuck in on my first attempt.

The changes have not been tested thoroughly yet and were the result of methodic copying and pasting.

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [ ] Tested the change ingame
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
