### PR TITLE
Further fixes for Haiku

### DIFF
--- a/src/base/detect.h
+++ b/src/base/detect.h
@@ -179,7 +179,13 @@
 #define PLATFORM_SUFFIX ""
 #endif
 
-#define CONF_PLATFORM_STRING PLATFORM_STRING PLATFORM_SUFFIX
+#ifndef CONF_PLATFORM_STRING
+#define CONF_PLATFORM_STRING "unknown"
+#endif
+
+#ifndef PLATFORM_STRING
+#define PLATFORM_STRING "unknown"
+#endif
 
 #ifndef CONF_ARCH_STRING
 #define CONF_ARCH_STRING "unknown"

--- a/src/base/detect.h
+++ b/src/base/detect.h
@@ -96,7 +96,7 @@
 #define CONF_FAMILY_UNIX 1
 #define CONF_FAMILY_STRING "unix"
 #define CONF_PLATFORM_HAIKU 1
-#define CONF_PLATFORM_STRING "haiku"
+#define PLATFORM_STRING "haiku"
 #endif
 
 /* use gcc endianness definitions when available */

--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -1115,7 +1115,8 @@ void CGraphicsBackend_SDL_OpenGL::SetWindowParams(int FullscreenMode, bool IsBor
 	{
 		if(FullscreenMode == 1)
 		{
-#if defined(CONF_PLATFORM_MACOS) || defined(CONF_PLATFORM_HAIKU) // Todo SDL: remove this when fixed (game freezes when losing focus in fullscreen)
+#if defined(CONF_PLATFORM_MACOS) || defined(CONF_PLATFORM_HAIKU)
+// Todo SDL: remove this when fixed (game freezes when losing focus in fullscreen)
 			SDL_SetWindowFullscreen(m_pWindow, SDL_WINDOW_FULLSCREEN_DESKTOP);
 #else
 			SDL_SetWindowFullscreen(m_pWindow, SDL_WINDOW_FULLSCREEN);

--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -1116,7 +1116,7 @@ void CGraphicsBackend_SDL_OpenGL::SetWindowParams(int FullscreenMode, bool IsBor
 		if(FullscreenMode == 1)
 		{
 #if defined(CONF_PLATFORM_MACOS) || defined(CONF_PLATFORM_HAIKU)
-// Todo SDL: remove this when fixed (game freezes when losing focus in fullscreen)
+			// Todo SDL: remove this when fixed (game freezes when losing focus in fullscreen)
 			SDL_SetWindowFullscreen(m_pWindow, SDL_WINDOW_FULLSCREEN_DESKTOP);
 #else
 			SDL_SetWindowFullscreen(m_pWindow, SDL_WINDOW_FULLSCREEN);

--- a/src/engine/client/notifications.cpp
+++ b/src/engine/client/notifications.cpp
@@ -4,7 +4,7 @@
 
 #if defined(CONF_PLATFORM_MACOS)
 // Code is in src/macos/notification.mm.
-#elif defined(CONF_FAMILY_UNIX) && !defined(CONF_PLATFORM_ANDROID)
+#elif defined(CONF_FAMILY_UNIX) && !defined(CONF_PLATFORM_ANDROID) && !defined(CONF_PLATFORM_HAIKU)
 #include <libnotify/notify.h>
 void NotificationsInit()
 {


### PR DESCRIPTION
- Haiku is Unix-like, but it still doesn't use libnotify.
- Haiku comes with its own sets of definitions for certain long variables. There's still a problem revolving around the variables, but I removed a duplicate, conflicting definition on the Haiku platform.
- Changed some definition-related logic in detect.h, because the gcc compiler in Haiku (version 8.3.0) complained about duplicate definitions. I chose to use 'unknown' rather than an empty string.

I think that I'm very close.