### PR TITLE
Fix serverbrowser crash

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -3176,6 +3176,13 @@ void CMenus::SetMenuPage(int NewPage)
 
 bool CMenus::HandleListInputs(const CUIRect &View, float &ScrollValue, const float ScrollAmount, int *pScrollOffset, const float ElemHeight, int &SelectedIndex, const int NumElems)
 {
+	if(NumElems == 0)
+	{
+		ScrollValue = 0;
+		SelectedIndex = 0;
+		return false;
+	}
+
 	int NewIndex = -1;
 	int Num = (int)(View.h / ElemHeight);
 	int ScrollNum = maximum(NumElems - Num, 0);
@@ -3193,7 +3200,7 @@ bool CMenus::HandleListInputs(const CUIRect &View, float &ScrollValue, const flo
 	}
 
 	ScrollValue = clamp(ScrollValue, 0.0f, 1.0f);
-	SelectedIndex = clamp(SelectedIndex, 0, NumElems);
+	SelectedIndex = clamp(SelectedIndex, 0, NumElems - 1);
 
 	for(int i = 0; i < m_NumInputEvents; i++)
 	{

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -1155,7 +1155,7 @@ void CMenus::RenderGhost(CUIRect MainView)
 		GhostlistPopulate();
 	}
 
-	if(s_SelectedIndex >= m_lGhosts.size())
+	if(s_SelectedIndex == -1 || s_SelectedIndex >= m_lGhosts.size())
 		return;
 
 	CGhostItem *pGhost = &m_lGhosts[s_SelectedIndex];


### PR DESCRIPTION
Putting a search string that doesnt find any server, or hold Up key while loading the client, or switching tabs can cause a crash, bcs the server list is empty, but input signals, it was changed

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
