### PR TITLE
initialize CClient::m_HasPersistentData

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -2361,6 +2361,7 @@ int CServer::Run()
 		int Size = GameServer()->PersistentClientDataSize();
 		for(auto &Client : m_aClients)
 		{
+			Client.m_HasPersistentData = false;
 			Client.m_pPersistentData = malloc(Size);
 		}
 	}


### PR DESCRIPTION
My server puts newly joined players in spectators despite sv_tornament_mode 0.

Seems like CClient::m_HasPersistentData is never initialized, and it was read as true (non 0) by chance (server.cpp:1477) and the server get to read more garbage in CClient::m_pPersistentData, then decided to put the player in spec.

## Checklist

- [*] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
