### PR TITLE
Allow unpredicted TuneZone settings for projectiles and lasers

### DIFF
--- a/src/game/client/components/items.cpp
+++ b/src/game/client/components/items.cpp
@@ -29,20 +29,21 @@ void CItems::RenderProjectile(const CProjectileData *pCurrent, int ItemID)
 	// get positions
 	float Curvature = 0;
 	float Speed = 0;
+	CTuningParams Tuning = pCurrent->m_TuneZone ? GameClient()->GetTunes(pCurrent->m_TuneZone) : m_pClient->m_Tuning[g_Config.m_ClDummy];
 	if(CurWeapon == WEAPON_GRENADE)
 	{
-		Curvature = m_pClient->m_Tuning[g_Config.m_ClDummy].m_GrenadeCurvature;
-		Speed = m_pClient->m_Tuning[g_Config.m_ClDummy].m_GrenadeSpeed;
+		Curvature = Tuning.m_GrenadeCurvature;
+		Speed = Tuning.m_GrenadeSpeed;
 	}
 	else if(CurWeapon == WEAPON_SHOTGUN)
 	{
-		Curvature = m_pClient->m_Tuning[g_Config.m_ClDummy].m_ShotgunCurvature;
-		Speed = m_pClient->m_Tuning[g_Config.m_ClDummy].m_ShotgunSpeed;
+		Curvature = Tuning.m_ShotgunCurvature;
+		Speed = Tuning.m_ShotgunSpeed;
 	}
 	else if(CurWeapon == WEAPON_GUN)
 	{
-		Curvature = m_pClient->m_Tuning[g_Config.m_ClDummy].m_GunCurvature;
-		Speed = m_pClient->m_Tuning[g_Config.m_ClDummy].m_GunSpeed;
+		Curvature = Tuning.m_GunCurvature;
+		Speed = Tuning.m_GunSpeed;
 	}
 
 	bool LocalPlayerInGame = false;
@@ -338,11 +339,11 @@ void CItems::OnRender()
 			CProjectileData Data;
 			if(Item.m_Type == NETOBJTYPE_PROJECTILE)
 			{
-				Data = ExtractProjectileInfo((const CNetObj_Projectile *)pData);
+				Data = ExtractProjectileInfo((const CNetObj_Projectile *)pData, &GameClient()->m_GameWorld);
 			}
 			else
 			{
-				Data = ExtractProjectileInfoDDNet((const CNetObj_DDNetProjectile *)pData);
+				Data = ExtractProjectileInfoDDNet((const CNetObj_DDNetProjectile *)pData, &GameClient()->m_GameWorld);
 			}
 			if(UsePredicted)
 			{
@@ -411,7 +412,7 @@ void CItems::OnRender()
 		}
 		else if(!UsePredicted)
 		{
-			CProjectileData Data = ExtractProjectileInfo(&m_aExtraProjectiles[i]);
+			CProjectileData Data = ExtractProjectileInfo(&m_aExtraProjectiles[i], &GameClient()->m_GameWorld);
 			RenderProjectile(&Data, 0);
 		}
 	}
@@ -502,20 +503,22 @@ void CItems::ReconstructSmokeTrail(const CProjectileData *pCurrent, int DestroyT
 	// get positions
 	float Curvature = 0;
 	float Speed = 0;
+	CTuningParams Tuning = pCurrent->m_TuneZone ? GameClient()->GetTunes(pCurrent->m_TuneZone) : m_pClient->m_Tuning[g_Config.m_ClDummy];
+
 	if(pCurrent->m_Type == WEAPON_GRENADE)
 	{
-		Curvature = m_pClient->m_Tuning[g_Config.m_ClDummy].m_GrenadeCurvature;
-		Speed = m_pClient->m_Tuning[g_Config.m_ClDummy].m_GrenadeSpeed;
+		Curvature = Tuning.m_GrenadeCurvature;
+		Speed = Tuning.m_GrenadeSpeed;
 	}
 	else if(pCurrent->m_Type == WEAPON_SHOTGUN)
 	{
-		Curvature = m_pClient->m_Tuning[g_Config.m_ClDummy].m_ShotgunCurvature;
-		Speed = m_pClient->m_Tuning[g_Config.m_ClDummy].m_ShotgunSpeed;
+		Curvature = Tuning.m_ShotgunCurvature;
+		Speed = Tuning.m_ShotgunSpeed;
 	}
 	else if(pCurrent->m_Type == WEAPON_GUN)
 	{
-		Curvature = m_pClient->m_Tuning[g_Config.m_ClDummy].m_GunCurvature;
-		Speed = m_pClient->m_Tuning[g_Config.m_ClDummy].m_GunSpeed;
+		Curvature = Tuning.m_GunCurvature;
+		Speed = Tuning.m_GunSpeed;
 	}
 
 	float Pt = ((float)(Client()->PredGameTick(g_Config.m_ClDummy) - pCurrent->m_StartTick) + Client()->PredIntraGameTick(g_Config.m_ClDummy)) / (float)SERVER_TICK_SPEED;

--- a/src/game/client/components/items.cpp
+++ b/src/game/client/components/items.cpp
@@ -29,7 +29,7 @@ void CItems::RenderProjectile(const CProjectileData *pCurrent, int ItemID)
 	// get positions
 	float Curvature = 0;
 	float Speed = 0;
-	CTuningParams Tuning = pCurrent->m_TuneZone ? GameClient()->GetTunes(pCurrent->m_TuneZone) : m_pClient->m_Tuning[g_Config.m_ClDummy];
+	CTuningParams Tuning = GameClient()->GetTunes(pCurrent->m_TuneZone);
 	if(CurWeapon == WEAPON_GRENADE)
 	{
 		Curvature = Tuning.m_GrenadeCurvature;
@@ -236,6 +236,8 @@ void CItems::RenderLaser(const struct CNetObj_Laser *pCurrent, bool IsPredicted)
 	RGB = color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClLaserInnerColor));
 	ColorRGBA InnerColor(RGB.r, RGB.g, RGB.b, 1.0f);
 
+	int TuneZone = GameClient()->m_GameWorld.m_WorldConfig.m_UseTuneZones ? Collision()->IsTune(Collision()->GetMapIndex(From)) : 0;
+
 	vec2 Dir;
 	if(Len > 0)
 	{
@@ -247,7 +249,7 @@ void CItems::RenderLaser(const struct CNetObj_Laser *pCurrent, bool IsPredicted)
 		else
 			Ticks = (float)(Client()->GameTick(g_Config.m_ClDummy) - pCurrent->m_StartTick) + Client()->IntraGameTick(g_Config.m_ClDummy);
 		float Ms = (Ticks / 50.0f) * 1000.0f;
-		float a = Ms / m_pClient->m_Tuning[g_Config.m_ClDummy].m_LaserBounceDelay;
+		float a = Ms / m_pClient->GetTunes(TuneZone).m_LaserBounceDelay;
 		a = clamp(a, 0.0f, 1.0f);
 		float Ia = 1 - a;
 
@@ -503,7 +505,7 @@ void CItems::ReconstructSmokeTrail(const CProjectileData *pCurrent, int DestroyT
 	// get positions
 	float Curvature = 0;
 	float Speed = 0;
-	CTuningParams Tuning = pCurrent->m_TuneZone ? GameClient()->GetTunes(pCurrent->m_TuneZone) : m_pClient->m_Tuning[g_Config.m_ClDummy];
+	CTuningParams Tuning = GameClient()->GetTunes(pCurrent->m_TuneZone);
 
 	if(pCurrent->m_Type == WEAPON_GRENADE)
 	{

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -2213,6 +2213,7 @@ void CGameClient::UpdatePrediction()
 	m_GameWorld.m_WorldConfig.m_IsFNG = m_GameInfo.m_PredictFNG;
 	m_GameWorld.m_WorldConfig.m_PredictDDRace = g_Config.m_ClPredictDDRace;
 	m_GameWorld.m_WorldConfig.m_PredictTiles = g_Config.m_ClPredictDDRace && m_GameInfo.m_PredictDDRaceTiles;
+	m_GameWorld.m_WorldConfig.m_UseTuneZones = m_GameInfo.m_PredictDDRaceTiles;
 	m_GameWorld.m_WorldConfig.m_PredictFreeze = g_Config.m_ClPredictFreeze;
 	m_GameWorld.m_WorldConfig.m_PredictWeapons = AntiPingWeapons();
 	if(m_Snap.m_pLocalCharacter->m_AmmoCount > 0 && m_Snap.m_pLocalCharacter->m_Weapon != WEAPON_NINJA)
@@ -2221,7 +2222,7 @@ void CGameClient::UpdatePrediction()
 
 	// update the tuning/tunezone at the local character position with the latest tunings received before the new snapshot
 	int TuneZone = Collision()->IsTune(Collision()->GetMapIndex(vec2(m_Snap.m_pLocalCharacter->m_X, m_Snap.m_pLocalCharacter->m_Y)));
-	if(!TuneZone || !m_GameWorld.m_WorldConfig.m_PredictTiles)
+	if(!TuneZone || !m_GameWorld.m_WorldConfig.m_UseTuneZones)
 		m_GameWorld.m_Tuning[g_Config.m_ClDummy] = m_Tuning[g_Config.m_ClDummy];
 	else
 		m_GameWorld.TuningList()[TuneZone] = m_GameWorld.m_Core.m_Tuning[g_Config.m_ClDummy] = m_Tuning[g_Config.m_ClDummy];

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -2201,6 +2201,8 @@ ColorRGBA CalculateNameColor(ColorHSLA TextColorHSL)
 
 void CGameClient::UpdatePrediction()
 {
+	m_GameWorld.m_WorldConfig.m_UseTuneZones = m_GameInfo.m_PredictDDRaceTiles;
+
 	if(!m_Snap.m_pLocalCharacter)
 	{
 		if(CCharacter *pLocalChar = m_GameWorld.GetCharacterByID(m_Snap.m_LocalClientID))
@@ -2213,7 +2215,6 @@ void CGameClient::UpdatePrediction()
 	m_GameWorld.m_WorldConfig.m_IsFNG = m_GameInfo.m_PredictFNG;
 	m_GameWorld.m_WorldConfig.m_PredictDDRace = g_Config.m_ClPredictDDRace;
 	m_GameWorld.m_WorldConfig.m_PredictTiles = g_Config.m_ClPredictDDRace && m_GameInfo.m_PredictDDRaceTiles;
-	m_GameWorld.m_WorldConfig.m_UseTuneZones = m_GameInfo.m_PredictDDRaceTiles;
 	m_GameWorld.m_WorldConfig.m_PredictFreeze = g_Config.m_ClPredictFreeze;
 	m_GameWorld.m_WorldConfig.m_PredictWeapons = AntiPingWeapons();
 	if(m_Snap.m_pLocalCharacter->m_AmmoCount > 0 && m_Snap.m_pLocalCharacter->m_Weapon != WEAPON_NINJA)

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -2222,11 +2222,10 @@ void CGameClient::UpdatePrediction()
 	m_GameWorld.m_WorldConfig.m_IsSolo = !m_Snap.m_aCharacters[m_Snap.m_LocalClientID].m_HasExtendedData && !m_Tuning[g_Config.m_ClDummy].m_PlayerCollision && !m_Tuning[g_Config.m_ClDummy].m_PlayerHooking;
 
 	// update the tuning/tunezone at the local character position with the latest tunings received before the new snapshot
-	int TuneZone = Collision()->IsTune(Collision()->GetMapIndex(vec2(m_Snap.m_pLocalCharacter->m_X, m_Snap.m_pLocalCharacter->m_Y)));
-	if(!TuneZone || !m_GameWorld.m_WorldConfig.m_UseTuneZones)
-		m_GameWorld.m_Tuning[g_Config.m_ClDummy] = m_Tuning[g_Config.m_ClDummy];
-	else
-		m_GameWorld.TuningList()[TuneZone] = m_GameWorld.m_Core.m_Tuning[g_Config.m_ClDummy] = m_Tuning[g_Config.m_ClDummy];
+	int TuneZone = 0;
+	if(m_GameWorld.m_WorldConfig.m_UseTuneZones)
+		TuneZone = Collision()->IsTune(Collision()->GetMapIndex(vec2(m_Snap.m_pLocalCharacter->m_X, m_Snap.m_pLocalCharacter->m_Y)));
+	m_GameWorld.TuningList()[TuneZone] = m_GameWorld.m_Core.m_Tuning[g_Config.m_ClDummy] = m_Tuning[g_Config.m_ClDummy];
 
 	// if ddnetcharacter is available, ignore server-wide tunings for hook and collision
 	if(m_Snap.m_aCharacters[m_Snap.m_LocalClientID].m_HasExtendedData)

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -446,6 +446,7 @@ public:
 	bool AntiPingGunfire() { return AntiPingGrenade() && AntiPingWeapons() && g_Config.m_ClAntiPingGunfire; }
 	bool Predict() { return g_Config.m_ClPredict && !(m_Snap.m_pGameInfoObj && m_Snap.m_pGameInfoObj->m_GameStateFlags & GAMESTATEFLAG_GAMEOVER) && !m_Snap.m_SpecInfo.m_Active && Client()->State() != IClient::STATE_DEMOPLAYBACK && m_Snap.m_pLocalCharacter; }
 	bool PredictDummy() { return g_Config.m_ClPredictDummy && Client()->DummyConnected() && m_Snap.m_LocalClientID >= 0 && m_PredictedDummyID >= 0 && !m_aClients[m_PredictedDummyID].m_Paused; }
+	CTuningParams GetTunes(int i) { return m_aTuningList[i]; }
 
 	CGameWorld m_GameWorld;
 	CGameWorld m_PredictedWorld;

--- a/src/game/client/prediction/entities/laser.cpp
+++ b/src/game/client/prediction/entities/laser.cpp
@@ -20,7 +20,7 @@ CLaser::CLaser(CGameWorld *pGameWorld, vec2 Pos, vec2 Direction, float StartEner
 	m_TelePos = vec2(0, 0);
 	m_WasTele = false;
 	m_Type = Type;
-	m_TuneZone = GameWorld()->m_WorldConfig.m_PredictTiles ? Collision()->IsTune(Collision()->GetMapIndex(m_Pos)) : 0;
+	m_TuneZone = GameWorld()->m_WorldConfig.m_UseTuneZones ? Collision()->IsTune(Collision()->GetMapIndex(m_Pos)) : 0;
 	GameWorld()->InsertEntity(this);
 	DoBounce();
 }
@@ -158,7 +158,7 @@ CLaser::CLaser(CGameWorld *pGameWorld, int ID, CNetObj_Laser *pLaser) :
 	m_From.x = pLaser->m_FromX;
 	m_From.y = pLaser->m_FromY;
 	m_EvalTick = pLaser->m_StartTick;
-	m_TuneZone = GameWorld()->m_WorldConfig.m_PredictTiles ? Collision()->IsTune(Collision()->GetMapIndex(m_Pos)) : 0;
+	m_TuneZone = GameWorld()->m_WorldConfig.m_UseTuneZones ? Collision()->IsTune(Collision()->GetMapIndex(m_Pos)) : 0;
 	m_Owner = -2;
 	m_Energy = GetTuning(m_TuneZone)->m_LaserReach;
 	if(pGameWorld->m_WorldConfig.m_IsFNG && m_Energy < 10.f)

--- a/src/game/client/prediction/entities/projectile.cpp
+++ b/src/game/client/prediction/entities/projectile.cpp
@@ -35,7 +35,7 @@ CProjectile::CProjectile(
 	m_Number = Number;
 	m_Freeze = Freeze;
 
-	m_TuneZone = GameWorld()->m_WorldConfig.m_PredictTiles ? Collision()->IsTune(Collision()->GetMapIndex(m_Pos)) : 0;
+	m_TuneZone = GameWorld()->m_WorldConfig.m_UseTuneZones ? Collision()->IsTune(Collision()->GetMapIndex(m_Pos)) : 0;
 
 	GameWorld()->InsertEntity(this);
 }
@@ -172,7 +172,7 @@ CProjectile::CProjectile(CGameWorld *pGameWorld, int ID, CProjectileData *pProj)
 	}
 	m_Type = pProj->m_Type;
 	m_StartTick = pProj->m_StartTick;
-	m_TuneZone = GameWorld()->m_WorldConfig.m_PredictTiles ? Collision()->IsTune(Collision()->GetMapIndex(m_Pos)) : 0;
+	m_TuneZone = pProj->m_TuneZone;
 
 	int Lifetime = 20 * GameWorld()->GameTickSpeed();
 	m_SoundImpact = -1;
@@ -201,6 +201,7 @@ CProjectileData CProjectile::GetData() const
 	Result.m_Explosive = m_Explosive;
 	Result.m_Bouncing = m_Bouncing;
 	Result.m_Freeze = m_Freeze;
+	Result.m_TuneZone = m_TuneZone;
 	return Result;
 }
 

--- a/src/game/client/prediction/gameworld.cpp
+++ b/src/game/client/prediction/gameworld.cpp
@@ -374,11 +374,11 @@ void CGameWorld::NetObjAdd(int ObjID, int ObjType, const void *pObjData)
 		CProjectileData Data;
 		if(ObjType == NETOBJTYPE_PROJECTILE)
 		{
-			Data = ExtractProjectileInfo((const CNetObj_Projectile *)pObjData);
+			Data = ExtractProjectileInfo((const CNetObj_Projectile *)pObjData, this);
 		}
 		else
 		{
-			Data = ExtractProjectileInfoDDNet((const CNetObj_DDNetProjectile *)pObjData);
+			Data = ExtractProjectileInfoDDNet((const CNetObj_DDNetProjectile *)pObjData, this);
 		}
 		CProjectile NetProj = CProjectile(this, ObjID, &Data);
 
@@ -586,11 +586,11 @@ CEntity *CGameWorld::FindMatch(int ObjID, int ObjType, const void *pObjData)
 		CProjectileData Data;
 		if(ObjType == NETOBJTYPE_PROJECTILE)
 		{
-			Data = ExtractProjectileInfo((const CNetObj_Projectile *)pObjData);
+			Data = ExtractProjectileInfo((const CNetObj_Projectile *)pObjData, this);
 		}
 		else
 		{
-			Data = ExtractProjectileInfoDDNet((const CNetObj_DDNetProjectile *)pObjData);
+			Data = ExtractProjectileInfoDDNet((const CNetObj_DDNetProjectile *)pObjData, this);
 		}
 		CProjectile *pEnt = (CProjectile *)GetEntity(ObjID, ENTTYPE_PROJECTILE);
 		if(pEnt && CProjectile(this, ObjID, &Data).Match(pEnt))

--- a/src/game/client/prediction/gameworld.h
+++ b/src/game/client/prediction/gameworld.h
@@ -74,6 +74,7 @@ public:
 		bool m_PredictWeapons;
 		bool m_PredictDDRace;
 		bool m_IsSolo;
+		bool m_UseTuneZones;
 	} m_WorldConfig;
 
 	bool m_IsValidCopy;

--- a/src/game/client/projectile_data.cpp
+++ b/src/game/client/projectile_data.cpp
@@ -5,6 +5,7 @@
 
 #include <base/math.h>
 #include <engine/shared/snapshot.h>
+#include <game/client/prediction/gameworld.h>
 #include <game/generated/protocol.h>
 
 bool UseProjectileExtraInfo(const CNetObj_Projectile *pProj)
@@ -12,13 +13,13 @@ bool UseProjectileExtraInfo(const CNetObj_Projectile *pProj)
 	return pProj->m_VelY >= 0 && (pProj->m_VelY & PROJECTILEFLAG_IS_DDNET) != 0;
 }
 
-CProjectileData ExtractProjectileInfo(const CNetObj_Projectile *pProj)
+CProjectileData ExtractProjectileInfo(const CNetObj_Projectile *pProj, CGameWorld *pGameWorld)
 {
 	if(UseProjectileExtraInfo(pProj))
 	{
 		CNetObj_DDNetProjectile Proj;
 		mem_copy(&Proj, pProj, sizeof(Proj));
-		return ExtractProjectileInfoDDNet(&Proj);
+		return ExtractProjectileInfoDDNet(&Proj, pGameWorld);
 	}
 
 	CProjectileData Result = {vec2(0, 0)};
@@ -30,10 +31,11 @@ CProjectileData ExtractProjectileInfo(const CNetObj_Projectile *pProj)
 	Result.m_StartTick = pProj->m_StartTick;
 	Result.m_ExtraInfo = false;
 	Result.m_Owner = -1;
+	Result.m_TuneZone = pGameWorld && pGameWorld->m_WorldConfig.m_UseTuneZones ? pGameWorld->Collision()->IsTune(pGameWorld->Collision()->GetMapIndex(Result.m_StartPos)) : 0;
 	return Result;
 }
 
-CProjectileData ExtractProjectileInfoDDNet(const CNetObj_DDNetProjectile *pProj)
+CProjectileData ExtractProjectileInfoDDNet(const CNetObj_DDNetProjectile *pProj, CGameWorld *pGameWorld)
 {
 	CProjectileData Result = {vec2(0, 0)};
 
@@ -55,6 +57,7 @@ CProjectileData ExtractProjectileInfoDDNet(const CNetObj_DDNetProjectile *pProj)
 	Result.m_Bouncing = (pProj->m_Data >> 10) & 3;
 	Result.m_Explosive = pProj->m_Data & PROJECTILEFLAG_EXPLOSIVE;
 	Result.m_Freeze = pProj->m_Data & PROJECTILEFLAG_FREEZE;
+	Result.m_TuneZone = pGameWorld && pGameWorld->m_WorldConfig.m_UseTuneZones ? pGameWorld->Collision()->IsTune(pGameWorld->Collision()->GetMapIndex(Result.m_StartPos)) : 0;
 	return Result;
 }
 
@@ -69,7 +72,7 @@ void SnapshotRemoveExtraProjectileInfo(unsigned char *pData)
 			CNetObj_Projectile *pProj = (CNetObj_Projectile *)((void *)pItem->Data());
 			if(UseProjectileExtraInfo(pProj))
 			{
-				CProjectileData Data = ExtractProjectileInfo(pProj);
+				CProjectileData Data = ExtractProjectileInfo(pProj, nullptr);
 				pProj->m_X = Data.m_StartPos.x;
 				pProj->m_Y = Data.m_StartPos.y;
 				pProj->m_VelX = (int)(Data.m_StartVel.x * 100.0f);

--- a/src/game/client/projectile_data.h
+++ b/src/game/client/projectile_data.h
@@ -21,9 +21,11 @@ public:
 	bool m_Explosive;
 	int m_Bouncing;
 	bool m_Freeze;
+	// TuneZone is introduced locally
+	int m_TuneZone;
 };
 
-CProjectileData ExtractProjectileInfo(const CNetObj_Projectile *pProj);
-CProjectileData ExtractProjectileInfoDDNet(const CNetObj_DDNetProjectile *pProj);
+CProjectileData ExtractProjectileInfo(const CNetObj_Projectile *pProj, class CGameWorld *pGameWorld);
+CProjectileData ExtractProjectileInfoDDNet(const CNetObj_DDNetProjectile *pProj, class CGameWorld *pGameWorld);
 
 #endif // GAME_CLIENT_PROJECTILE_DATA_H


### PR DESCRIPTION
Video demo: https://cdn.discordapp.com/attachments/293493549758939136/834971531464671252/2021-04-23_09-57-35.mp4
(notice the speed difference between player's shotgun bullets and the bouncing ones)

Video demo2: https://cdn.discordapp.com/attachments/293493549758939136/834990657147764736/demotopleftisnew.mp4
(Right: before, Left: after)

Since TuneZones are known (baked into the map), and entities' position received are known. We have a pretty good reason, if the server is believed to make use of it (GAMEINFOFLAG_PREDICT_DDRACE_TILES), to make entities always reference TuneZone settings, even if they are not predicted. 

Introduced a new worldconfig, `m_UseTuneZones`, that ignores antiping settings and apply TuneZone where applicable if the server is believed to support TuneZone.

When antiping is off, predictedworld is still inactive and only the rendering are affected, making them still **unpredicted** but now with correct intra-tick interpolations.


## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options (with different antiping settings and ping)
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps (client-side only)
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
