### PR TITLE
[map_optimize] Fix duplication of ITEMTYPE_EX (uuid index) items

### DIFF
--- a/src/tools/map_optimize.cpp
+++ b/src/tools/map_optimize.cpp
@@ -146,6 +146,12 @@ int main(int argc, const char **argv)
 	{
 		pPtr = DataFile.GetItem(Index, &Type, &ID);
 		Size = DataFile.GetItemSize(Index);
+
+		// filter ITEMTYPE_EX items, they will be automatically added again
+		if(Type == 0xffff)
+		{
+			continue;
+		}
 		// for all layers, check if it uses a image and set the corresponding flag
 		if(Type == MAPITEMTYPE_LAYER)
 		{


### PR DESCRIPTION
This resulted in duplicate items, with the exact same id and type_id (and content, but id + type_id are supposed to be unique)

Credits to heinrich5991 for his feeling that the UUID index duplication could originate in this file.

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [x] Tested the change ~~ingame~~
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
