### PR TITLE
[map tools] Fix duplicate uuid index in maps edited by tools

### DIFF
--- a/src/engine/shared/datafile.cpp
+++ b/src/engine/shared/datafile.cpp
@@ -15,7 +15,6 @@ static const int DEBUG = 0;
 enum
 {
 	OFFSET_UUID_TYPE = 0x8000,
-	ITEMTYPE_EX = 0xffff,
 };
 
 struct CItemEx

--- a/src/engine/shared/datafile.h
+++ b/src/engine/shared/datafile.h
@@ -10,6 +10,11 @@
 
 #include <zlib.h>
 
+enum
+{
+	ITEMTYPE_EX = 0xffff,
+};
+
 // raw datafile access
 class CDataFileReader
 {

--- a/src/tools/map_convert_07.cpp
+++ b/src/tools/map_convert_07.cpp
@@ -218,6 +218,12 @@ int main(int argc, const char **argv)
 		pItem = g_DataReader.GetItem(Index, &Type, &ID);
 		Size = g_DataReader.GetItemSize(Index);
 
+		// filter ITEMTYPE_EX items, they will be automatically added again
+		if(Type == ITEMTYPE_EX)
+		{
+			continue;
+		}
+
 		Success &= CheckImageDimensions(pItem, Type, pSourceFileName);
 
 		pItem = ReplaceImageItem(pItem, Type, &NewImageItem);

--- a/src/tools/map_optimize.cpp
+++ b/src/tools/map_optimize.cpp
@@ -148,7 +148,7 @@ int main(int argc, const char **argv)
 		Size = DataFile.GetItemSize(Index);
 
 		// filter ITEMTYPE_EX items, they will be automatically added again
-		if(Type == 0xffff)
+		if(Type == ITEMTYPE_EX)
 		{
 			continue;
 		}

--- a/src/tools/map_replace_image.cpp
+++ b/src/tools/map_replace_image.cpp
@@ -156,6 +156,13 @@ int main(int argc, const char **argv)
 		CMapItemImage NewImageItem;
 		pItem = g_DataReader.GetItem(Index, &Type, &ID);
 		Size = g_DataReader.GetItemSize(Index);
+
+		// filter ITEMTYPE_EX items, they will be automatically added again
+		if(Type == ITEMTYPE_EX)
+		{
+			continue;
+		}
+
 		pItem = ReplaceImageItem(pItem, Type, pImageName, pImageFile, &NewImageItem);
 		if(!pItem)
 			return -1;

--- a/src/tools/map_resave.cpp
+++ b/src/tools/map_resave.cpp
@@ -28,6 +28,13 @@ int main(int argc, const char **argv)
 	{
 		pPtr = DataFile.GetItem(Index, &Type, &ID);
 		Size = DataFile.GetItemSize(Index);
+
+		// filter ITEMTYPE_EX items, they will be automatically added again
+		if(Type == ITEMTYPE_EX)
+		{
+			continue;
+		}
+
 		df.AddItem(Type, ID, Size, pPtr);
 	}
 


### PR DESCRIPTION
As @Jupeyy correctly pointed out in #3803, the issue is in every single tool that resaves a map.
The only tool I haven't tested the fix with is map_replace_image, since I experienced other unrelated issues there.

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [x] Tested the change ~~ingame~~
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
