### PR TITLE
Steam: Support connecting to hostname

### DIFF
--- a/src/engine/client/steam.cpp
+++ b/src/engine/client/steam.cpp
@@ -34,7 +34,7 @@ public:
 		if(pConnect[0])
 		{
 			NETADDR Connect;
-			if(net_addr_from_str(&Connect, pConnect) == 0)
+			if(net_host_lookup(pConnect, &Connect, NETTYPE_IPV4) == 0)
 			{
 				m_ConnectAddr = Connect;
 				m_GotConnectAddr = true;

--- a/src/engine/client/steam.cpp
+++ b/src/engine/client/steam.cpp
@@ -34,7 +34,7 @@ public:
 		if(pConnect[0])
 		{
 			NETADDR Connect;
-			if(net_host_lookup(pConnect, &Connect, NETTYPE_IPV4) == 0)
+			if(net_host_lookup(pConnect, &Connect, NETTYPE_ALL) == 0)
 			{
 				m_ConnectAddr = Connect;
 				m_GotConnectAddr = true;


### PR DESCRIPTION
instead of just ip address

Currently works: steam://run/412220//185.107.94.201:8337/
Should work with this PR: steam://run/412220//nld.ddnet.tw:8337/

I'm building a test build with Steam support to verify this works. Update: Verified that this works.

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
