### PR TITLE
Compress IPv6 string representations according to RFC5952

### DIFF
--- a/src/test/netaddr.cpp
+++ b/src/test/netaddr.cpp
@@ -23,14 +23,55 @@ TEST(NetAddr, FromStr)
 	EXPECT_FALSE(net_addr_from_str(&Addr, "[::1]"));
 	net_addr_str(&Addr, aBuf1, sizeof(aBuf1), true);
 	net_addr_str(&Addr, aBuf2, sizeof(aBuf2), false);
-	EXPECT_STREQ(aBuf1, "[0:0:0:0:0:0:0:1]:0");
-	EXPECT_STREQ(aBuf2, "[0:0:0:0:0:0:0:1]");
+	EXPECT_STREQ(aBuf1, "[::1]:0");
+	EXPECT_STREQ(aBuf2, "[::1]");
 
 	EXPECT_FALSE(net_addr_from_str(&Addr, "[0123:4567:89ab:cdef:1:2:3:4]:5678"));
 	net_addr_str(&Addr, aBuf1, sizeof(aBuf1), true);
 	net_addr_str(&Addr, aBuf2, sizeof(aBuf2), false);
 	EXPECT_STREQ(aBuf1, "[123:4567:89ab:cdef:1:2:3:4]:5678");
 	EXPECT_STREQ(aBuf2, "[123:4567:89ab:cdef:1:2:3:4]");
+}
+
+TEST(NetAddr, StrV6)
+{
+	NETADDR Addr;
+	char aBuf1[NETADDR_MAXSTRSIZE];
+	char aBuf2[NETADDR_MAXSTRSIZE];
+
+	// Test vectors from RFC 5952 section 4:
+	// https://tools.ietf.org/html/rfc5952#section-4
+	// 4.1 Handling Leading Zeros in a 16-Bit Field
+	EXPECT_FALSE(net_addr_from_str(&Addr, "[2001:0db8::0001]:1"));
+	net_addr_str(&Addr, aBuf1, sizeof(aBuf1), true);
+	net_addr_str(&Addr, aBuf2, sizeof(aBuf2), false);
+	EXPECT_STREQ(aBuf1, "[2001:db8::1]:1");
+	EXPECT_STREQ(aBuf2, "[2001:db8::1]");
+
+	// 4.2.1 Shorten as Much as Possible
+	EXPECT_FALSE(net_addr_from_str(&Addr, "[2001:db8:0:0:0:0:2:1]"));
+	net_addr_str(&Addr, aBuf1, sizeof(aBuf1), true);
+	net_addr_str(&Addr, aBuf2, sizeof(aBuf2), false);
+	EXPECT_STREQ(aBuf1, "[2001:db8::2:1]:0");
+	EXPECT_STREQ(aBuf2, "[2001:db8::2:1]");
+
+	EXPECT_FALSE(net_addr_from_str(&Addr, "[2001:db8::0:1]"));
+	net_addr_str(&Addr, aBuf2, sizeof(aBuf2), false);
+	EXPECT_STREQ(aBuf2, "[2001:db8::1]");
+
+	// 4.2.2 Handling One 16-Bit 0 Field
+	EXPECT_FALSE(net_addr_from_str(&Addr, "[2001:db8::1:1:1:1:1]"));
+	net_addr_str(&Addr, aBuf2, sizeof(aBuf2), false);
+	EXPECT_STREQ(aBuf2, "[2001:db8:0:1:1:1:1:1]");
+
+	// 4.2.3 Choice in Placement of "::"
+	EXPECT_FALSE(net_addr_from_str(&Addr, "[2001:0:0:1:0:0:0:1]"));
+	net_addr_str(&Addr, aBuf2, sizeof(aBuf2), false);
+	EXPECT_STREQ(aBuf2, "[2001:0:0:1::1]");
+
+	EXPECT_FALSE(net_addr_from_str(&Addr, "[2001:db8:0:0:1:0:0:1]"));
+	net_addr_str(&Addr, aBuf2, sizeof(aBuf2), false);
+	EXPECT_STREQ(aBuf2, "[2001:db8::1:0:0:1]");
 }
 
 TEST(NetAddr, FromStrInvalid)


### PR DESCRIPTION
https://tools.ietf.org/html/rfc5952#section-4

Also add some tests.

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [x] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
