### PR TITLE
Add Intel as vendor to the block list on windows

### DIFF
--- a/src/engine/client/backend/opengl/backend_opengl.cpp
+++ b/src/engine/client/backend/opengl/backend_opengl.cpp
@@ -372,7 +372,8 @@ void CCommandProcessorFragment_OpenGL::InitOpenGL(const SCommand_Init *pCommand)
 	*pCommand->m_pInitError = 0;
 
 	int BlocklistMajor = -1, BlocklistMinor = -1, BlocklistPatch = -1;
-	const char *pErrString = ParseBlocklistDriverVersions(pVendorString, pVersionString, BlocklistMajor, BlocklistMinor, BlocklistPatch);
+	bool RequiresWarning = false;
+	const char *pErrString = ParseBlocklistDriverVersions(pVendorString, pVersionString, BlocklistMajor, BlocklistMinor, BlocklistPatch, RequiresWarning);
 	//if the driver is buggy, and the requested GL version is the default, fallback
 	if(pErrString != NULL && pCommand->m_RequestedMajor == 3 && pCommand->m_RequestedMinor == 0 && pCommand->m_RequestedPatch == 0)
 	{
@@ -385,7 +386,8 @@ void CCommandProcessorFragment_OpenGL::InitOpenGL(const SCommand_Init *pCommand)
 			pCommand->m_pCapabilities->m_ContextPatch = BlocklistPatch;
 
 			// set backend error string
-			*pCommand->m_pErrStringPtr = pErrString;
+			if(RequiresWarning)
+				*pCommand->m_pErrStringPtr = pErrString;
 			*pCommand->m_pInitError = -2;
 
 			g_Config.m_GfxDriverIsBlocked = 1;

--- a/src/engine/client/blocklist_driver.h
+++ b/src/engine/client/blocklist_driver.h
@@ -1,6 +1,6 @@
 #ifndef ENGINE_CLIENT_BLOCKLIST_DRIVER_H
 #define ENGINE_CLIENT_BLOCKLIST_DRIVER_H
 
-const char *ParseBlocklistDriverVersions(const char *pVendorStr, const char *pVersionStr, int &BlocklistMajor, int &BlocklistMinor, int &BlocklistPatch);
+const char *ParseBlocklistDriverVersions(const char *pVendorStr, const char *pVersionStr, int &BlocklistMajor, int &BlocklistMinor, int &BlocklistPatch, bool &RequiresWarning);
 
 #endif // ENGINE_CLIENT_BLOCKLIST_DRIVER_H

--- a/src/test/blocklist_driver.cpp
+++ b/src/test/blocklist_driver.cpp
@@ -1,37 +1,54 @@
 #include <gtest/gtest.h>
 
+#include <base/detect.h>
+
 #include <engine/client/blocklist_driver.h>
 
 TEST(BlocklistDriver, Valid1)
 {
+#ifdef CONF_FAMILY_WINDOWS
 	int Major = -1, Minor = -1, Patch = -1;
-	EXPECT_STREQ(ParseBlocklistDriverVersions("Intel", "Build 26.20.100.7810", Major, Minor, Patch), "This Intel driver version can cause crashes, please update it to a newer version.");
+	bool WarningReq = false;
+	EXPECT_STREQ(ParseBlocklistDriverVersions("Intel", "Build 26.20.100.7810", Major, Minor, Patch, WarningReq), "This Intel driver version can cause crashes, please update it to a newer version.");
 	EXPECT_EQ(Major, 2);
 	EXPECT_EQ(Minor, 0);
 	EXPECT_EQ(Patch, 0);
+#endif
 }
 
 TEST(BlocklistDriver, Valid2)
 {
+#ifdef CONF_FAMILY_WINDOWS
 	int Major = -1, Minor = -1, Patch = -1;
-	EXPECT_STREQ(ParseBlocklistDriverVersions("Intel", "Build 26.20.100.7926", Major, Minor, Patch), "This Intel driver version can cause crashes, please update it to a newer version.");
+	bool WarningReq = false;
+	EXPECT_STREQ(ParseBlocklistDriverVersions("Intel", "Build 26.20.100.7926", Major, Minor, Patch, WarningReq), "This Intel driver version can cause crashes, please update it to a newer version.");
 	EXPECT_EQ(Major, 2);
 	EXPECT_EQ(Minor, 0);
 	EXPECT_EQ(Patch, 0);
+#endif
 }
 
 TEST(BlocklistDriver, Valid3)
 {
+#ifdef CONF_FAMILY_WINDOWS
 	int Major = -1, Minor = -1, Patch = -1;
-	EXPECT_STREQ(ParseBlocklistDriverVersions("Intel", "Build 26.20.100.7985", Major, Minor, Patch), "This Intel driver version can cause crashes, please update it to a newer version.");
+	bool WarningReq = false;
+	EXPECT_STREQ(ParseBlocklistDriverVersions("Intel", "Build 26.20.100.7985", Major, Minor, Patch, WarningReq), "This Intel driver version can cause crashes, please update it to a newer version.");
 	EXPECT_EQ(Major, 2);
 	EXPECT_EQ(Minor, 0);
 	EXPECT_EQ(Patch, 0);
+#endif
 }
 
 TEST(BlocklistDriver, Invalid)
 {
 	int Major, Minor, Patch;
-	EXPECT_STREQ(ParseBlocklistDriverVersions("Intel", "Build 25.20.100.7810", Major, Minor, Patch), NULL);
-	EXPECT_STREQ(ParseBlocklistDriverVersions("Intel", "Build 26.20.100.7799", Major, Minor, Patch), NULL);
+	bool WarningReq = false;
+#ifdef CONF_FAMILY_WINDOWS
+	EXPECT_STREQ(ParseBlocklistDriverVersions("AMD", "Build 25.20.100.7810", Major, Minor, Patch, WarningReq), NULL);
+	EXPECT_STREQ(ParseBlocklistDriverVersions("NVIDIA", "Build 26.20.100.7799", Major, Minor, Patch, WarningReq), NULL);
+#else
+	EXPECT_STREQ(ParseBlocklistDriverVersions("Intel", "Build 26.20.100.7985", Major, Minor, Patch, WarningReq), NULL);
+	EXPECT_STREQ(ParseBlocklistDriverVersions("Intel", "Build 26.20.100.7799", Major, Minor, Patch, WarningReq), NULL);
+#endif
 }


### PR DESCRIPTION
I also added, that the warning doesnt require to be displayed, as it currently won't help anyway to update the driver.

Should set all Intel users to OGL 2.0 default, they can ofc still manually change the setting as they want

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
