### PR TITLE
Only sort friends, if you got any

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2203,6 +2203,7 @@ if(GTEST_FOUND OR DOWNLOAD_GTEST)
     netaddr.cpp
     packer.cpp
     prng.cpp
+    sorted_array.cpp
     str.cpp
     strip_path_and_extension.cpp
     teehistorian.cpp

--- a/src/base/tl/sorted_array.h
+++ b/src/base/tl/sorted_array.h
@@ -38,7 +38,8 @@ public:
 
 	void sort_range()
 	{
-		sort(all());
+		if(parent::size() > 0)
+			sort(all());
 	}
 
 	/*

--- a/src/test/sorted_array.cpp
+++ b/src/test/sorted_array.cpp
@@ -1,0 +1,9 @@
+#include <gtest/gtest.h>
+
+#include <base/tl/sorted_array.h>
+
+TEST(SortedArray, SortEmptyRange)
+{
+	sorted_array<int> x;
+	x.sort_range();
+}


### PR DESCRIPTION
as TsFreddie pointed out, it asserts inside the array function back(), bcs the list is empty.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
