### PR TITLE
Remove "Show only supported" switch from graphics tab

### DIFF
--- a/data/languages/arabic.txt
+++ b/data/languages/arabic.txt
@@ -411,9 +411,6 @@ Show name plates
 Show only chat messages from friends
 == ﺀﺎﻗﺪﺻﻻﺍ ﻦﻣ ﻂﻘﻓ ﻞﺋﺎﺳﺮﻟﺍ ﺭﺎﻬﻇﺍ
 
-Show only supported
-== ﻂﻘﻓ ﻡﻮﻋﺪﻣ ﺽﺮﻋ
-
 Skins
 == ﺕﺎﻨﻜﺴﻟﺍ
 

--- a/data/languages/belarusian.txt
+++ b/data/languages/belarusian.txt
@@ -413,9 +413,6 @@ Show ingame HUD
 Show name plates
 == Паказваць нікі гульцоў
 
-Show only supported
-== Паказваць толькі падтрымоўваныя дазволы экрана
-
 Skins
 == Скіны
 

--- a/data/languages/bosnian.txt
+++ b/data/languages/bosnian.txt
@@ -416,9 +416,6 @@ Show ingame HUD
 Show name plates
 == Prikaži imena igrača
 
-Show only supported
-== Prikaži samo podržane
-
 Skins
 == Skinovi
 

--- a/data/languages/brazilian_portuguese.txt
+++ b/data/languages/brazilian_portuguese.txt
@@ -436,9 +436,6 @@ Show name plates
 Show only chat messages from friends
 == Mostrar apenas mensagens de amigos
 
-Show only supported
-== Mostrar apenas modos suportados
-
 Skins
 == Skins
 

--- a/data/languages/bulgarian.txt
+++ b/data/languages/bulgarian.txt
@@ -413,9 +413,6 @@ Show ingame HUD
 Show name plates
 == Показвай лентите с имената
 
-Show only supported
-== Показвай само съвместимите
-
 Skins
 == Модели
 

--- a/data/languages/catalan.txt
+++ b/data/languages/catalan.txt
@@ -414,9 +414,6 @@ Show name plates
 Show only chat messages from friends
 == Rebre només missatges d'amics
 
-Show only supported
-== Veure únicament modes compatibles
-
 Skins
 == Skins
 

--- a/data/languages/chuvash.txt
+++ b/data/languages/chuvash.txt
@@ -413,9 +413,6 @@ Show ingame HUD
 Show name plates
 == Вылякансен ят кăтартма
 
-Show only supported
-== Ĕçлекен экран режимĕсем анчах
-
 Skins
 == Сăнсем
 

--- a/data/languages/czech.txt
+++ b/data/languages/czech.txt
@@ -412,9 +412,6 @@ Show ingame HUD
 Show name plates
 == Zobrazovat jména hráčů
 
-Show only supported
-== Zobrazit pouze podporované
-
 Skins
 == Vzhledy
 

--- a/data/languages/danish.txt
+++ b/data/languages/danish.txt
@@ -414,9 +414,6 @@ Show ingame HUD
 Show name plates
 == Vis navneskilte
 
-Show only supported
-== Vis kun understøttede
-
 Skins
 == Udseende
 

--- a/data/languages/dutch.txt
+++ b/data/languages/dutch.txt
@@ -425,9 +425,6 @@ Show ingame HUD
 Show name plates
 == Laat naamplaat zien
 
-Show only supported
-== Laat alleen compatibele servers zien
-
 Skins
 == Skins
 

--- a/data/languages/finnish.txt
+++ b/data/languages/finnish.txt
@@ -414,9 +414,6 @@ Show ingame HUD
 Show name plates
 == Näytä nimikyltit
 
-Show only supported
-== Näytä vain tuetut
-
 Skins
 == Ulkonäkö
 

--- a/data/languages/french.txt
+++ b/data/languages/french.txt
@@ -427,9 +427,6 @@ Show ingame HUD
 Show name plates
 == Afficher les pseudonymes
 
-Show only supported
-== N'afficher que les résolutions supportées
-
 Skins
 == Skins
 

--- a/data/languages/german.txt
+++ b/data/languages/german.txt
@@ -433,9 +433,6 @@ Show name plates
 Show only chat messages from friends
 == Nur Nachrichten von Freunden zeigen
 
-Show only supported
-== Nur Unterstützte anzeigen
-
 Skins
 == Skins
 

--- a/data/languages/greek.txt
+++ b/data/languages/greek.txt
@@ -419,9 +419,6 @@ Show name plates
 Show only chat messages from friends
 == Προβολή μηνυμάτων μόνο από φίλους
 
-Show only supported
-== Προβολή υποστηριζόμενων μόνο
-
 Skins
 == Στολές
 

--- a/data/languages/hungarian.txt
+++ b/data/languages/hungarian.txt
@@ -404,9 +404,6 @@ Show ingame HUD
 Show name plates
 == Név táblák mutatása
 
-Show only supported
-== Csak támogatott mutatása
-
 Skins
 == Skinek
 

--- a/data/languages/italian.txt
+++ b/data/languages/italian.txt
@@ -418,9 +418,6 @@ Show ingame HUD
 Show name plates
 == Mostra nomi
 
-Show only supported
-== Mostra solo supportati
-
 Skins
 == Skin
 

--- a/data/languages/japanese.txt
+++ b/data/languages/japanese.txt
@@ -413,9 +413,6 @@ Show ingame HUD
 Show name plates
 == 名前を表示
 
-Show only supported
-== 対応している項目のみを表示
-
 Skins
 == スキン
 

--- a/data/languages/korean.txt
+++ b/data/languages/korean.txt
@@ -403,9 +403,6 @@ Show ingame HUD
 Show name plates
 == 이름 표시
 
-Show only supported
-== 지원하는 해상도 표시
-
 Skins
 == 스킨
 

--- a/data/languages/kyrgyz.txt
+++ b/data/languages/kyrgyz.txt
@@ -484,9 +484,6 @@ Show ingame HUD
 Show name plates
 == Оюнчулардын аттарын көрсөтүү
 
-Show only supported
-== Колдолгонду гана көрсөтүү
-
 Size:
 == Өлчөмү:
 

--- a/data/languages/norwegian.txt
+++ b/data/languages/norwegian.txt
@@ -415,9 +415,6 @@ Show ingame HUD
 Show name plates
 == Vis navneskilt
 
-Show only supported
-== Vis kompatible
-
 Skins
 == Utseender
 

--- a/data/languages/persian.txt
+++ b/data/languages/persian.txt
@@ -784,9 +784,6 @@ Dummy
 Miscellaneous
 == 
 
-Show only supported
-== 
-
 Display Modes
 == 
 

--- a/data/languages/polish.txt
+++ b/data/languages/polish.txt
@@ -416,9 +416,6 @@ Show ingame HUD
 Show name plates
 == Pokazuj nicki
 
-Show only supported
-== Pokazuj tylko wspierane
-
 Skins
 == Motywy
 

--- a/data/languages/portuguese.txt
+++ b/data/languages/portuguese.txt
@@ -437,9 +437,6 @@ Show name plates
 Show only chat messages from friends
 == Mostrar apenas mensagens dos amigos no chat
 
-Show only supported
-== Mostrar apenas suportado
-
 Skins
 == Skins
 

--- a/data/languages/romanian.txt
+++ b/data/languages/romanian.txt
@@ -425,9 +425,6 @@ Show name plates
 Show only chat messages from friends
 == Arată doar chatul prietenilor
 
-Show only supported
-== Arată doar modurile suportate
-
 Skins
 == Costume
 

--- a/data/languages/russian.txt
+++ b/data/languages/russian.txt
@@ -421,9 +421,6 @@ Show ingame HUD
 Show name plates
 == Показывать имена игроков
 
-Show only supported
-== Показывать только поддерживаемые разрешения экрана
-
 Skins
 == Скины
 

--- a/data/languages/serbian.txt
+++ b/data/languages/serbian.txt
@@ -416,9 +416,6 @@ Show ingame HUD
 Show name plates
 == Prikaži imena igrača
 
-Show only supported
-== Prikaži samo podržane
-
 Skins
 == Skinovi
 

--- a/data/languages/serbian_cyrillic.txt
+++ b/data/languages/serbian_cyrillic.txt
@@ -412,9 +412,6 @@ Show ingame HUD
 Show name plates
 == Прикажи плочице са именима
 
-Show only supported
-== Прикажи само подржане
-
 Skins
 == Теме
 

--- a/data/languages/simplified_chinese.txt
+++ b/data/languages/simplified_chinese.txt
@@ -454,9 +454,6 @@ Show name plates
 Show only chat messages from friends
 == 只显示好友消息
 
-Show only supported
-== 只显示支持的分辨率
-
 Skins
 == 皮肤
 

--- a/data/languages/slovak.txt
+++ b/data/languages/slovak.txt
@@ -413,9 +413,6 @@ Show ingame HUD
 Show name plates
 == Zobrazovať menovky
 
-Show only supported
-== Zobraziť len podporované
-
 Skins
 == Skiny
 

--- a/data/languages/spanish.txt
+++ b/data/languages/spanish.txt
@@ -426,9 +426,6 @@ Show name plates
 Show only chat messages from friends
 == Recibir mensages solo de amigos
 
-Show only supported
-== Mostrar únicamente modos soportados
-
 Skins
 == Skins
 

--- a/data/languages/swedish.txt
+++ b/data/languages/swedish.txt
@@ -416,9 +416,6 @@ Show ingame HUD
 Show name plates
 == Visa namnskyltar
 
-Show only supported
-== Visa endast upplösningar som stöds
-
 Skins
 == Utseende
 

--- a/data/languages/traditional_chinese.txt
+++ b/data/languages/traditional_chinese.txt
@@ -448,9 +448,6 @@ Show name plates
 Show only chat messages from friends
 == 只顯示好友訊息
 
-Show only supported
-== 只顯示支援的解析度
-
 Skins
 == 外觀
 

--- a/data/languages/turkish.txt
+++ b/data/languages/turkish.txt
@@ -415,9 +415,6 @@ Show ingame HUD
 Show name plates
 == Oyuncu isimlerini göster
 
-Show only supported
-== Desteklenmeyen çözünürlükleri gizle
-
 Skins
 == Skinler
 

--- a/data/languages/ukrainian.txt
+++ b/data/languages/ukrainian.txt
@@ -311,9 +311,6 @@ Show chat
 Show name plates
 == Показувати ніки гравців
 
-Show only supported
-== Тільки підтримувані режими
-
 Skins
 == Скіни
 

--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -2514,7 +2514,7 @@ const char *CGraphics_Threaded::GetRendererString()
 
 int CGraphics_Threaded::GetVideoModes(CVideoMode *pModes, int MaxModes, int Screen)
 {
-	if(g_Config.m_GfxDisplayAllModes)
+	if(g_Config.m_GfxDisplayAllVideoModes)
 	{
 		int Count = sizeof(g_aFakeModes) / sizeof(CVideoMode);
 		mem_copy(pModes, g_aFakeModes, sizeof(g_aFakeModes));

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -111,7 +111,7 @@ MACRO_CONFIG_INT(GfxColorDepth, gfx_color_depth, 24, 16, 24, CFGFLAG_SAVE | CFGF
 //MACRO_CONFIG_INT(GfxClear, gfx_clear, 1, 0, 1, CFGFLAG_SAVE|CFGFLAG_CLIENT, "Clear screen before rendering")
 MACRO_CONFIG_INT(GfxVsync, gfx_vsync, 0, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Vertical sync (may cause delay)")
 MACRO_CONFIG_INT(GfxResizable, gfx_resizable, 0, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Enables window resizing")
-MACRO_CONFIG_INT(GfxDisplayAllModes, gfx_display_all_modes, 0, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "")
+MACRO_CONFIG_INT(GfxDisplayAllVideoModes, gfx_display_all_video_modes, 0, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Show all video modes")
 MACRO_CONFIG_INT(GfxTextureQualityOld, gfx_texture_quality_old, 1, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "")
 MACRO_CONFIG_INT(GfxHighDetail, gfx_high_detail, 1, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "High detail")
 MACRO_CONFIG_INT(GfxFsaaSamples, gfx_fsaa_samples, 0, 0, 16, CFGFLAG_SAVE | CFGFLAG_CLIENT, "FSAA Samples")

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -1089,14 +1089,6 @@ void CMenus::RenderSettingsGraphics(CUIRect MainView)
 	MainView.VSplitLeft(350.0f, &MainView, &ModeList);
 	MainView.VSplitLeft(340.0f, &MainView, 0);
 
-	// draw allmodes switch
-	ModeList.HSplitTop(20, &Button, &ModeList);
-	if(DoButton_CheckBox(&g_Config.m_GfxDisplayAllModes, Localize("Show only supported"), g_Config.m_GfxDisplayAllModes ^ 1, &Button))
-	{
-		g_Config.m_GfxDisplayAllModes ^= 1;
-		s_NumNodes = Graphics()->GetVideoModes(s_aModes, MAX_RESOLUTIONS, g_Config.m_GfxScreen);
-	}
-
 	// display mode list
 	static float s_ScrollValue = 0;
 	int OldSelected = -1;


### PR DESCRIPTION
gfx_display_all_modes can be used instead

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
