### PR TITLE
Add better support for compose binds in demo menu

### DIFF
--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -169,15 +169,18 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 	if(m_pClient->m_pGameConsole->IsClosed() && m_DemoPlayerState == DEMOPLAYER_NONE && g_Config.m_ClDemoKeyboardShortcuts)
 	{
 		// increase/decrease speed
-		if(Input()->KeyPress(KEY_MOUSE_WHEEL_UP) || Input()->KeyPress(KEY_UP))
+		if(!Input()->KeyIsPressed(KEY_LSHIFT) && !Input()->KeyIsPressed(KEY_RSHIFT))
 		{
-			DemoPlayer()->SetSpeedIndex(+1);
-			LastSpeedChange = time_get();
-		}
-		else if(Input()->KeyPress(KEY_MOUSE_WHEEL_DOWN) || Input()->KeyPress(KEY_DOWN))
-		{
-			DemoPlayer()->SetSpeedIndex(-1);
-			LastSpeedChange = time_get();
+			if(Input()->KeyPress(KEY_MOUSE_WHEEL_UP) || Input()->KeyPress(KEY_UP))
+			{
+				DemoPlayer()->SetSpeedIndex(+1);
+				LastSpeedChange = time_get();
+			}
+			else if(Input()->KeyPress(KEY_MOUSE_WHEEL_DOWN) || Input()->KeyPress(KEY_DOWN))
+			{
+				DemoPlayer()->SetSpeedIndex(-1);
+				LastSpeedChange = time_get();
+			}
 		}
 
 		// pause/unpause


### PR DESCRIPTION
I assume shift is a common compose bind. So users might have bound
shift+scroll or shift+arrowkeys to something else and do not want to
change the playback speed while triggering that compose bind.

I have to admit this is something I personally need and I am not sure what the demand for it is.
But for example my zoom bind is shift+mousewheelup and shift+mousewheeldown and I change that a lot while watching demos but it keeps affecting the playback speed. Maybe someone else has a compose bind using the alt key I do not know. But this solves my issue :)

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
