### PR TITLE
Simplify entities destruction

### DIFF
--- a/src/game/client/prediction/entities/laser.cpp
+++ b/src/game/client/prediction/entities/laser.cpp
@@ -67,7 +67,7 @@ void CLaser::DoBounce()
 
 	if(m_Energy < 0)
 	{
-		GameWorld()->DestroyEntity(this);
+		m_MarkedForDestroy = true;
 		return;
 	}
 	m_PrevPos = m_Pos;

--- a/src/game/client/prediction/entities/projectile.cpp
+++ b/src/game/client/prediction/entities/projectile.cpp
@@ -123,10 +123,10 @@ void CProjectile::Tick()
 		}
 		else if(m_Type == WEAPON_GUN)
 		{
-			GameWorld()->DestroyEntity(this);
+			m_MarkedForDestroy = true;
 		}
 		else if(!m_Freeze)
-			GameWorld()->DestroyEntity(this);
+			m_MarkedForDestroy = true;
 	}
 	if(m_LifeSpan == -1)
 	{
@@ -140,7 +140,7 @@ void CProjectile::Tick()
 			GameWorld()->CreateExplosion(ColPos, m_Owner, m_Type, m_Owner == -1, (!pOwnerChar ? -1 : pOwnerChar->Team()),
 				(m_Owner != -1) ? TeamMask : -1LL);
 		}
-		GameWorld()->DestroyEntity(this);
+		m_MarkedForDestroy = true;
 	}
 }
 

--- a/src/game/client/prediction/gameworld.cpp
+++ b/src/game/client/prediction/gameworld.cpp
@@ -121,11 +121,6 @@ void CGameWorld::InsertEntity(CEntity *pEnt, bool Last)
 	}
 }
 
-void CGameWorld::DestroyEntity(CEntity *pEnt)
-{
-	pEnt->m_MarkedForDestroy = true;
-}
-
 void CGameWorld::RemoveEntity(CEntity *pEnt)
 {
 	// not in the list

--- a/src/game/client/prediction/gameworld.h
+++ b/src/game/client/prediction/gameworld.h
@@ -37,7 +37,6 @@ public:
 	class CCharacter *IntersectCharacter(vec2 Pos0, vec2 Pos1, float Radius, vec2 &NewPos, class CCharacter *pNotThis = 0, int CollideWith = -1, class CCharacter *pThisOnly = 0);
 	void InsertEntity(CEntity *pEntity, bool Last = false);
 	void RemoveEntity(CEntity *pEntity);
-	void DestroyEntity(CEntity *pEntity);
 	void Tick();
 
 	// DDRace

--- a/src/game/server/entities/dragger.cpp
+++ b/src/game/server/entities/dragger.cpp
@@ -135,7 +135,7 @@ void CDragger::Drag()
 
 void CDragger::Reset()
 {
-	GameServer()->m_World.DestroyEntity(this);
+	m_MarkedForDestroy = true;
 }
 
 void CDragger::Tick()

--- a/src/game/server/entities/gun.cpp
+++ b/src/game/server/entities/gun.cpp
@@ -89,7 +89,7 @@ void CGun::Fire()
 
 void CGun::Reset()
 {
-	GameServer()->m_World.DestroyEntity(this);
+	m_MarkedForDestroy = true;
 }
 
 void CGun::Tick()

--- a/src/game/server/entities/laser.cpp
+++ b/src/game/server/entities/laser.cpp
@@ -78,7 +78,7 @@ void CLaser::DoBounce()
 
 	if(m_Energy < 0)
 	{
-		GameServer()->m_World.DestroyEntity(this);
+		m_MarkedForDestroy = true;
 		return;
 	}
 	m_PrevPos = m_Pos;
@@ -225,7 +225,7 @@ void CLaser::DoBounce()
 
 void CLaser::Reset()
 {
-	GameServer()->m_World.DestroyEntity(this);
+	m_MarkedForDestroy = true;
 }
 
 void CLaser::Tick()

--- a/src/game/server/entities/light.cpp
+++ b/src/game/server/entities/light.cpp
@@ -76,7 +76,7 @@ void CLight::Step()
 
 void CLight::Reset()
 {
-	GameServer()->m_World.DestroyEntity(this);
+	m_MarkedForDestroy = true;
 }
 
 void CLight::Tick()

--- a/src/game/server/entities/plasma.cpp
+++ b/src/game/server/entities/plasma.cpp
@@ -40,7 +40,7 @@ bool CPlasma::HitCharacter()
 	if(m_Explosive)
 		GameServer()->CreateExplosion(m_Pos, -1, WEAPON_GRENADE, true,
 			m_ResponsibleTeam, Hit->Teams()->TeamMask(m_ResponsibleTeam));
-	GameServer()->m_World.DestroyEntity(this);
+	m_MarkedForDestroy = true;
 	return true;
 }
 
@@ -52,7 +52,7 @@ void CPlasma::Move()
 
 void CPlasma::Reset()
 {
-	GameServer()->m_World.DestroyEntity(this);
+	m_MarkedForDestroy = true;
 }
 
 void CPlasma::Tick()

--- a/src/game/server/entities/projectile.cpp
+++ b/src/game/server/entities/projectile.cpp
@@ -50,7 +50,7 @@ CProjectile::CProjectile(
 void CProjectile::Reset()
 {
 	if(m_LifeSpan > -2)
-		GameServer()->m_World.DestroyEntity(this);
+		m_MarkedForDestroy = true;
 }
 
 vec2 CProjectile::GetPos(float Time)
@@ -144,7 +144,7 @@ void CProjectile::Tick()
 	}
 	else if(m_Owner >= 0 && (m_Type != WEAPON_GRENADE || g_Config.m_SvDestroyBulletsOnDeath))
 	{
-		GameServer()->m_World.DestroyEntity(this);
+		m_MarkedForDestroy = true;
 		return;
 	}
 
@@ -232,14 +232,14 @@ void CProjectile::Tick()
 		else if(m_Type == WEAPON_GUN)
 		{
 			GameServer()->CreateDamageInd(CurPos, -atan2(m_Direction.x, m_Direction.y), 10, (m_Owner != -1) ? TeamMask : -1LL);
-			GameServer()->m_World.DestroyEntity(this);
+			m_MarkedForDestroy = true;
 			return;
 		}
 		else
 		{
 			if(!m_Freeze)
 			{
-				GameServer()->m_World.DestroyEntity(this);
+				m_MarkedForDestroy = true;
 				return;
 			}
 		}
@@ -262,7 +262,7 @@ void CProjectile::Tick()
 			GameServer()->CreateSound(ColPos, m_SoundImpact,
 				(m_Owner != -1) ? TeamMask : -1LL);
 		}
-		GameServer()->m_World.DestroyEntity(this);
+		m_MarkedForDestroy = true;
 		return;
 	}
 

--- a/src/game/server/entity.h
+++ b/src/game/server/entity.h
@@ -34,12 +34,11 @@ private:
 	*/
 	float m_ProximityRadius;
 
+protected:
 	/* State */
 	bool m_MarkedForDestroy;
 
 public: // TODO: Maybe make protected
-	/* State */
-
 	/*
 		Variable: m_Pos
 			Contains the current posititon of the entity.
@@ -67,10 +66,6 @@ public:
 	CEntity *TypePrev() { return m_pPrevTypeEntity; }
 	const vec2 &GetPos() const { return m_Pos; }
 	float GetProximityRadius() const { return m_ProximityRadius; }
-	bool IsMarkedForDestroy() const { return m_MarkedForDestroy; }
-
-	/* Setters */
-	void MarkForDestroy() { m_MarkedForDestroy = true; }
 
 	/* Other functions */
 

--- a/src/game/server/gameworld.cpp
+++ b/src/game/server/gameworld.cpp
@@ -81,11 +81,6 @@ void CGameWorld::InsertEntity(CEntity *pEnt)
 	m_apFirstEntityTypes[pEnt->m_ObjType] = pEnt;
 }
 
-void CGameWorld::DestroyEntity(CEntity *pEnt)
-{
-	pEnt->m_MarkedForDestroy = true;
-}
-
 void CGameWorld::RemoveEntity(CEntity *pEnt)
 {
 	// not in the list

--- a/src/game/server/gameworld.h
+++ b/src/game/server/gameworld.h
@@ -123,15 +123,6 @@ public:
 	void RemoveEntity(CEntity *pEntity);
 
 	/*
-		Function: destroy_entity
-			Destroys an entity in the world.
-
-		Arguments:
-			entity - Entity to destroy
-	*/
-	void DestroyEntity(CEntity *pEntity);
-
-	/*
 		Function: snap
 			Calls snap on all the entities in the world to create
 			the snapshot.


### PR DESCRIPTION
Removed one indirection from entities destruction code and removed two related unused functions. I could change the access to `m_MarkedForDestroy` via `IsMarkedForDestroy()` and `MarkForDestroy()` if it is preferred (the previous code didn't use the functions).

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
