### PR TITLE
Only predict pickup if affected by movers

### DIFF
--- a/src/game/client/components/items.cpp
+++ b/src/game/client/components/items.cpp
@@ -320,12 +320,15 @@ void CItems::OnRender()
 		}
 		for(auto *pPickup = (CPickup *)GameClient()->m_PredictedWorld.FindFirst(CGameWorld::ENTTYPE_PICKUP); pPickup; pPickup = (CPickup *)pPickup->NextEntity())
 		{
-			if(auto *pPrev = (CPickup *)GameClient()->m_PrevPredictedWorld.GetEntity(pPickup->ID(), CGameWorld::ENTTYPE_PICKUP))
+			if(pPickup->InDDNetTile())
 			{
-				CNetObj_Pickup Data, Prev;
-				pPickup->FillInfo(&Data);
-				pPrev->FillInfo(&Prev);
-				RenderPickup(&Prev, &Data, true);
+				if(auto *pPrev = (CPickup *)GameClient()->m_PrevPredictedWorld.GetEntity(pPickup->ID(), CGameWorld::ENTTYPE_PICKUP))
+				{
+					CNetObj_Pickup Data, Prev;
+					pPickup->FillInfo(&Data);
+					pPrev->FillInfo(&Prev);
+					RenderPickup(&Prev, &Data, true);
+				}
 			}
 		}
 	}
@@ -369,7 +372,11 @@ void CItems::OnRender()
 		else if(Item.m_Type == NETOBJTYPE_PICKUP)
 		{
 			if(UsePredicted)
-				continue;
+			{
+				auto *pPickup = (CPickup *)GameClient()->m_GameWorld.FindMatch(Item.m_ID, Item.m_Type, pData);
+				if(pPickup && pPickup->InDDNetTile())
+					continue;
+			}
 			const void *pPrev = Client()->SnapFindItem(IClient::SNAP_PREV, Item.m_Type, Item.m_ID);
 			if(pPrev)
 				RenderPickup((const CNetObj_Pickup *)pPrev, (const CNetObj_Pickup *)pData);

--- a/src/game/client/prediction/entities/pickup.cpp
+++ b/src/game/client/prediction/entities/pickup.cpp
@@ -77,7 +77,12 @@ void CPickup::Move()
 		int index = Collision()->IsMover(m_Pos.x, m_Pos.y, &Flags);
 		if(index)
 		{
+			m_IsCoreActive = true;
 			m_Core = Collision()->CpSpeed(index, Flags);
+		}
+		else
+		{
+			m_IsCoreActive = false;
 		}
 		m_Pos += m_Core;
 	}
@@ -91,6 +96,7 @@ CPickup::CPickup(CGameWorld *pGameWorld, int ID, CNetObj_Pickup *pPickup) :
 	m_Type = pPickup->m_Type;
 	m_Subtype = pPickup->m_Subtype;
 	m_Core = vec2(0.f, 0.f);
+	m_IsCoreActive = false;
 	m_ID = ID;
 	m_Layer = LAYER_GAME;
 	m_Number = 0;

--- a/src/game/client/prediction/entities/pickup.h
+++ b/src/game/client/prediction/entities/pickup.h
@@ -15,6 +15,7 @@ public:
 	CPickup(CGameWorld *pGameWorld, int ID, CNetObj_Pickup *pPickup);
 	void FillInfo(CNetObj_Pickup *pPickup);
 	bool Match(CPickup *pPickup);
+	bool InDDNetTile() { return m_IsCoreActive; }
 
 private:
 	int m_Type;
@@ -24,6 +25,7 @@ private:
 
 	void Move();
 	vec2 m_Core;
+	bool m_IsCoreActive;
 };
 
 #endif


### PR DESCRIPTION
PrevPredictedWorld is copied more frequently than snapshots so the position of pickups isn't interpolated unless it is moved by movers which happens in predictedworld. So, fallback to the normal path if mover is not present would fix jittery motions of pickups in mods like monster.

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
