### PR TITLE
Fix (harmless) array OOB access when no pings were cached

### DIFF
--- a/src/engine/client/serverbrowser_ping_cache.cpp
+++ b/src/engine/client/serverbrowser_ping_cache.cpp
@@ -197,7 +197,7 @@ void CServerBrowserPingCache::GetPingCache(const CEntry **ppEntries, int *pNumEn
 		}
 		m_aNewEntries.clear();
 	}
-	*ppEntries = &m_aEntries[0];
+	*ppEntries = m_aEntries.data();
 	*pNumEntries = m_aEntries.size();
 }
 


### PR DESCRIPTION
Use `vector.data()` instead of `&vector[0]` to get access to the
underlying array.

Fixes #3850.

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
