### PR TITLE
Fix alignment for CVoteOptionServer

### DIFF
--- a/src/engine/shared/memheap.h
+++ b/src/engine/shared/memheap.h
@@ -2,6 +2,8 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #ifndef ENGINE_SHARED_MEMHEAP_H
 #define ENGINE_SHARED_MEMHEAP_H
+
+#include <cstddef>
 class CHeap
 {
 	struct CChunk
@@ -22,12 +24,12 @@ class CHeap
 
 	void Clear();
 	void NewChunk();
-	void *AllocateFromChunk(unsigned int Size);
+	void *AllocateFromChunk(unsigned int Size, unsigned Alignment);
 
 public:
 	CHeap();
 	~CHeap();
 	void Reset();
-	void *Allocate(unsigned Size);
+	void *Allocate(unsigned Size, unsigned Alignment = alignof(std::max_align_t));
 };
 #endif

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -2778,7 +2778,7 @@ void CGameContext::AddVote(const char *pDescription, const char *pCommand)
 	++m_NumVoteOptions;
 	int Len = str_length(pCommand);
 
-	pOption = (CVoteOptionServer *)m_pVoteOptionHeap->Allocate(sizeof(CVoteOptionServer) + Len);
+	pOption = (CVoteOptionServer *)m_pVoteOptionHeap->Allocate(sizeof(CVoteOptionServer) + Len, alignof(CVoteOptionServer));
 	pOption->m_pNext = 0;
 	pOption->m_pPrev = m_pVoteOptionLast;
 	if(pOption->m_pPrev)


### PR DESCRIPTION
Fixes alignment issues for `CVoteOptionServer`. I used a default parameter so everything should be (wastefully) aligned at the very least.

Maybe in the long term we can look to get rid of usages of memheap. Should be careful to not replace it with just malloc though since in many uses of the memheap we have it would cause a lot of fragmentation leading to (ithink) cache misses and wouldn't play along well with prefetch.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [x] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
