### PR TITLE
Fix inconsistent handling of death tile between front and game layer

### DIFF
--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -1369,10 +1369,11 @@ void CCharacter::HandleSkippableTiles(int Index)
 	if((GameServer()->Collision()->GetCollisionAt(m_Pos.x + GetProximityRadius() / 3.f, m_Pos.y - GetProximityRadius() / 3.f) == TILE_DEATH ||
 		   GameServer()->Collision()->GetCollisionAt(m_Pos.x + GetProximityRadius() / 3.f, m_Pos.y + GetProximityRadius() / 3.f) == TILE_DEATH ||
 		   GameServer()->Collision()->GetCollisionAt(m_Pos.x - GetProximityRadius() / 3.f, m_Pos.y - GetProximityRadius() / 3.f) == TILE_DEATH ||
+		   GameServer()->Collision()->GetCollisionAt(m_Pos.x - GetProximityRadius() / 3.f, m_Pos.y + GetProximityRadius() / 3.f) == TILE_DEATH ||
 		   GameServer()->Collision()->GetFCollisionAt(m_Pos.x + GetProximityRadius() / 3.f, m_Pos.y - GetProximityRadius() / 3.f) == TILE_DEATH ||
 		   GameServer()->Collision()->GetFCollisionAt(m_Pos.x + GetProximityRadius() / 3.f, m_Pos.y + GetProximityRadius() / 3.f) == TILE_DEATH ||
 		   GameServer()->Collision()->GetFCollisionAt(m_Pos.x - GetProximityRadius() / 3.f, m_Pos.y - GetProximityRadius() / 3.f) == TILE_DEATH ||
-		   GameServer()->Collision()->GetCollisionAt(m_Pos.x - GetProximityRadius() / 3.f, m_Pos.y + GetProximityRadius() / 3.f) == TILE_DEATH) &&
+		   GameServer()->Collision()->GetFCollisionAt(m_Pos.x - GetProximityRadius() / 3.f, m_Pos.y + GetProximityRadius() / 3.f) == TILE_DEATH) &&
 		!m_Super && !(Team() && Teams()->TeeFinished(m_pPlayer->GetCID())))
 	{
 		Die(m_pPlayer->GetCID(), WEAPON_WORLD);


### PR DESCRIPTION
Fixes #3880

I believe that it can be safely merged. I tried to see the difference, but I couldn't get a measureable difference with only Kill-Tiles and Stoppers.

All affected maps with number of death tiles in front layer (generated with Patigas twmap library):

```
"types/brutal/maps/Rogue World.map": 189
"types/brutal/maps/New World.map": 214
"types/brutal/maps/Flow Fever.map": 7
"types/brutal/maps/A Strange Dream.map": 372
"types/brutal/maps/Jungledread.map": 1253
"types/brutal/maps/Lobster Party.map": 19
"types/novice/maps/Tangerine.map": 354
"types/solo/maps/Vesper.map": 238
"types/ddmax/maps/Creative.map": 6
"types/dummy/maps/Juma.map": 1
"types/dummy/maps/Ulver.map": 15
"types/dummy/maps/NoTeleBro.map": 1
"types/dummy/maps/Gummy.map": 1
"types/dummy/maps/Cultist.map": 5
"types/dummy/maps/Nincorn.map": 42
"types/dummy/maps/Squadron.map": 85
"types/dummy/maps/DarkSpy 2.map": 49
"types/dummy/maps/Capricorn.map": 1
"types/moderate/maps/Kero-Gores8.map": 109
"types/moderate/maps/The Swamp.map": 62
"types/insane/maps/Redefined 2.map": 1
"types/insane/maps/1AndOnLyLife.map": 2
```

I looked into some of these maps and it doesn't make a difference there.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
