### PR TITLE
Make mouse pos calculation more robust against NaNs

### DIFF
--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -17,6 +17,8 @@
 #include <game/client/gameclient.h>
 #include <game/collision.h>
 
+#include <base/vmath.h>
+
 #include "controls.h"
 
 enum
@@ -572,9 +574,17 @@ void CControls::ClampMousePos()
 		float MinDistance = g_Config.m_ClDyncam ? g_Config.m_ClDyncamMinDistance : g_Config.m_ClMouseMinDistance;
 		float MouseMin = MinDistance;
 
-		if(length(m_MousePos[g_Config.m_ClDummy]) < MouseMin)
-			m_MousePos[g_Config.m_ClDummy] = normalize(m_MousePos[g_Config.m_ClDummy]) * MouseMin;
-		if(length(m_MousePos[g_Config.m_ClDummy]) > MouseMax)
-			m_MousePos[g_Config.m_ClDummy] = normalize(m_MousePos[g_Config.m_ClDummy]) * MouseMax;
+		float MDistance = length(m_MousePos[g_Config.m_ClDummy]);
+		if(MDistance < 0.001f)
+		{
+			m_MousePos[g_Config.m_ClDummy].x = 0.001f;
+			m_MousePos[g_Config.m_ClDummy].y = 0;
+			MDistance = 0.001f;
+		}
+		if(MDistance < MouseMin)
+			m_MousePos[g_Config.m_ClDummy] = normalize_pre_length(m_MousePos[g_Config.m_ClDummy], MDistance) * MouseMin;
+		MDistance = length(m_MousePos[g_Config.m_ClDummy]);
+		if(MDistance > MouseMax)
+			m_MousePos[g_Config.m_ClDummy] = normalize_pre_length(m_MousePos[g_Config.m_ClDummy], MDistance) * MouseMax;
 	}
 }

--- a/src/game/variables.h
+++ b/src/game/variables.h
@@ -60,17 +60,17 @@ MACRO_CONFIG_INT(ClThreadsoundloading, cl_threadsoundloading, 0, 0, 1, CFGFLAG_C
 
 MACRO_CONFIG_INT(ClWarningTeambalance, cl_warning_teambalance, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Warn about team balance")
 
-MACRO_CONFIG_INT(ClMouseDeadzone, cl_mouse_deadzone, 0, 0, 0, CFGFLAG_CLIENT | CFGFLAG_SAVE, "")
-MACRO_CONFIG_INT(ClMouseFollowfactor, cl_mouse_followfactor, 0, 0, 200, CFGFLAG_CLIENT | CFGFLAG_SAVE, "")
-MACRO_CONFIG_INT(ClMouseMaxDistance, cl_mouse_max_distance, 400, 0, 0, CFGFLAG_CLIENT | CFGFLAG_SAVE, "")
-MACRO_CONFIG_INT(ClMouseMinDistance, cl_mouse_min_distance, 0, 0, 0, CFGFLAG_CLIENT | CFGFLAG_SAVE, "")
+MACRO_CONFIG_INT(ClMouseDeadzone, cl_mouse_deadzone, 0, 0, 3000, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Deadzone for the camera to follow the cursor")
+MACRO_CONFIG_INT(ClMouseFollowfactor, cl_mouse_followfactor, 0, 0, 200, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Factor for the camera to follow the cursor")
+MACRO_CONFIG_INT(ClMouseMaxDistance, cl_mouse_max_distance, 400, 0, 5000, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Maximum cursor distance")
+MACRO_CONFIG_INT(ClMouseMinDistance, cl_mouse_min_distance, 0, 0, 5000, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Minimum cursor distance")
 
 MACRO_CONFIG_INT(ClDyncam, cl_dyncam, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Enable dyncam")
-MACRO_CONFIG_INT(ClDyncamMaxDistance, cl_dyncam_max_distance, 1000, 0, 2000, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Maximum dynamic camera distance")
-MACRO_CONFIG_INT(ClDyncamMinDistance, cl_dyncam_min_distance, 0, 0, 2000, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Minimum dynamic camera distance")
+MACRO_CONFIG_INT(ClDyncamMaxDistance, cl_dyncam_max_distance, 1000, 0, 2000, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Maximum dynamic camera cursor distance")
+MACRO_CONFIG_INT(ClDyncamMinDistance, cl_dyncam_min_distance, 0, 0, 2000, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Minimum dynamic camera cursor distance")
 MACRO_CONFIG_INT(ClDyncamMousesens, cl_dyncam_mousesens, 0, 0, 100000, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Mouse sens used when dyncam is toggled on")
-MACRO_CONFIG_INT(ClDyncamDeadzone, cl_dyncam_deadzone, 300, 1, 1300, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Dynamic camera dead zone")
-MACRO_CONFIG_INT(ClDyncamFollowFactor, cl_dyncam_follow_factor, 60, 0, 200, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Dynamic camera follow factor")
+MACRO_CONFIG_INT(ClDyncamDeadzone, cl_dyncam_deadzone, 300, 1, 1300, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Deadzone for the dynamic camera to follow the cursor")
+MACRO_CONFIG_INT(ClDyncamFollowFactor, cl_dyncam_follow_factor, 60, 0, 200, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Factor for the dynamic camera to follow the cursor")
 
 MACRO_CONFIG_INT(ClDyncamSmoothness, cl_dyncam_smoothness, 0, 0, 100, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Transition amount of the camera movement, 0=instant, 100=slow and smooth")
 MACRO_CONFIG_INT(ClDyncamStabilizing, cl_dyncam_stabilizing, 0, 0, 100, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Amount of camera slowdown during fast cursor movement. High value can cause delay in camera movement")


### PR DESCRIPTION
1. Since the config didn't have a limit set, they could be negative, which directly caused bugs
2. If you set a min mouse distance, lets say 5, It can mathematically happen that you drag your mouse exactly so much that you hit the (0, 0) point and the if(.. < MinDistance) branch normalizes that point, which causes non restorable NaNs.
It's now safe, the min distance is later in code checked to be atleast 1, i "even" just made it safe enough, so there shouldn't be any change in behaviour:
https://github.com/ddnet/ddnet/blob/07ab4d53562cd81db27fa6e7f7cc2fa23a583e38/src/game/client/components/controls.cpp#L298-L304
Which casts the float to an int and checks the int, and this does not restore the mouse pos for NaNs, because nan to int is not 0
its some insanly high value int_max or smth

To reproduce both bugs "easily" on current master you can abuse a SDL limitation,
relative mouse mode seems to only move upto +-1 unit,
- so for 1. set the ingame mouse sens to 100000 and the max mouse distance to -1000 and move your mouse fast for a few seconds, happens relativly easy (Thanks to Souly how to reproduce it)
- for 2. set mouse sens to 100 and max distance to 1 and min distance to 5, this case is a bit harder to reprod in debug mode, probably bcs of the way mouse pos is later handled and also maybe bcs of floating point differences with signs that go close to 0... had to move the mouse few seconds but still got it relativly fast (with -0fast it happens almost instant)

it will exactly happen what i explained in 2. that the reported mouse movement negates the current mouse pos, resulting in mouse pos (0,0)

![screenshot_2021-06-06_21-55-18](https://user-images.githubusercontent.com/6654924/120938281-35bf4b80-c712-11eb-9b6b-7523e8b436bd.png)

This this was also a bug reported in #bugs channel, i think we could also add it to the release

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
