### PR TITLE
Remove cl_load_country_flags

### DIFF
--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -22,7 +22,6 @@ MACRO_CONFIG_INT(ClRefreshRateInactive, cl_refresh_rate_inactive, 120, 0, 10000,
 MACRO_CONFIG_INT(ClEditor, cl_editor, 0, 0, 1, CFGFLAG_CLIENT, "")
 MACRO_CONFIG_INT(ClEditorUndo, cl_editorundo, 0, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Undo function in editor")
 MACRO_CONFIG_INT(ClEditorDilate, cl_editor_dilate, 1, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Automatically dilates embedded images")
-MACRO_CONFIG_INT(ClLoadCountryFlags, cl_load_country_flags, 1, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Load and show country flags")
 MACRO_CONFIG_STR(ClSkinFilterString, cl_skin_filter_string, 25, "", CFGFLAG_SAVE | CFGFLAG_CLIENT, "Skin filtering string")
 
 MACRO_CONFIG_INT(ClAutoDemoRecord, cl_auto_demo_record, 0, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Automatically record demos")

--- a/src/game/client/components/countryflags.cpp
+++ b/src/game/client/components/countryflags.cpp
@@ -58,28 +58,21 @@ void CCountryFlags::LoadCountryflagsIndexfile()
 		// load the graphic file
 		char aBuf[128];
 		CImageInfo Info;
-		bool LoadCountryFlags = g_Config.m_ClLoadCountryFlags;
-		if(LoadCountryFlags)
+		str_format(aBuf, sizeof(aBuf), "countryflags/%s.png", aOrigin);
+		if(!Graphics()->LoadPNG(&Info, aBuf, IStorage::TYPE_ALL))
 		{
-			str_format(aBuf, sizeof(aBuf), "countryflags/%s.png", aOrigin);
-			if(!Graphics()->LoadPNG(&Info, aBuf, IStorage::TYPE_ALL))
-			{
-				char aMsg[128];
-				str_format(aMsg, sizeof(aMsg), "failed to load '%s'", aBuf);
-				Console()->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "countryflags", aMsg);
-				continue;
-			}
+			char aMsg[128];
+			str_format(aMsg, sizeof(aMsg), "failed to load '%s'", aBuf);
+			Console()->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "countryflags", aMsg);
+			continue;
 		}
 
 		// add entry
 		CCountryFlag CountryFlag;
 		CountryFlag.m_CountryCode = CountryCode;
 		str_copy(CountryFlag.m_aCountryCodeString, aOrigin, sizeof(CountryFlag.m_aCountryCodeString));
-		if(LoadCountryFlags)
-		{
-			CountryFlag.m_Texture = Graphics()->LoadTextureRaw(Info.m_Width, Info.m_Height, Info.m_Format, Info.m_pData, Info.m_Format, 0);
-			Graphics()->FreePNG(&Info);
-		}
+		CountryFlag.m_Texture = Graphics()->LoadTextureRaw(Info.m_Width, Info.m_Height, Info.m_Format, Info.m_pData, Info.m_Format, 0);
+		Graphics()->FreePNG(&Info);
 
 		if(g_Config.m_Debug)
 		{
@@ -151,12 +144,5 @@ void CCountryFlags::Render(int CountryCode, const ColorRGBA *pColor, float x, fl
 		IGraphics::CQuadItem QuadItem(x, y, w, h);
 		Graphics()->QuadsDrawTL(&QuadItem, 1);
 		Graphics()->QuadsEnd();
-	}
-	else
-	{
-		CTextCursor Cursor;
-		TextRender()->SetCursor(&Cursor, x, y, 10.0f, TEXTFLAG_RENDER | TEXTFLAG_STOP_AT_END);
-		Cursor.m_LineWidth = w;
-		TextRender()->TextEx(&Cursor, pFlag->m_aCountryCodeString, -1);
 	}
 }


### PR DESCRIPTION
`https://github.com/teeworlds/teeworlds/issues/897`
this was the reason why it was ever implemented into teeworlds, but i guess this won't help alot with performance to run potatoworlds
just another random setting imo



## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
