### PR TITLE
Add timeout for serverbrowser http request

### DIFF
--- a/src/engine/client/serverbrowser_http.cpp
+++ b/src/engine/client/serverbrowser_http.cpp
@@ -272,7 +272,9 @@ void CServerBrowserHttp::Update()
 			}
 			return;
 		}
-		m_pEngine->AddJob(m_pGetServers = std::make_shared<CGet>(pBestUrl, CTimeout{0, 0, 0}));
+		// 10 seconds connection timeout, lower than 8KB/s for 10 seconds to fail.
+		CTimeout Timeout{10000, 8000, 10};
+		m_pEngine->AddJob(m_pGetServers = std::make_shared<CGet>(pBestUrl, Timeout));
 		m_State = STATE_REFRESHING;
 	}
 	else if(m_State == STATE_REFRESHING)


### PR DESCRIPTION
to prevent getting stuck entirely. Following #3889

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
