### PR TITLE
Force alpha values from glReadPixel to 255

### DIFF
--- a/src/engine/client/backend/opengl/backend_opengl.cpp
+++ b/src/engine/client/backend/opengl/backend_opengl.cpp
@@ -1009,6 +1009,11 @@ void CCommandProcessorFragment_OpenGL::Cmd_Screenshot(const CCommandBuffer::SCom
 		mem_copy(pTempRow, pPixelData + y * w * 4, w * 4);
 		mem_copy(pPixelData + y * w * 4, pPixelData + (h - y - 1) * w * 4, w * 4);
 		mem_copy(pPixelData + (h - y - 1) * w * 4, pTempRow, w * 4);
+		for(int x = 0; x < w; x++)
+		{
+			pPixelData[y * w * 4 + x * 4 + 3] = 255;
+			pPixelData[(h - y - 1) * w * 4 + x * 4 + 3] = 255;
+		}
 	}
 
 	// fill in the information


### PR DESCRIPTION
Makes sure to ignore framebuffer values.

This should be part of the next patch.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
