### PR TITLE
Don't use HEAD^2 in codeql anymore

### DIFF
--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -37,11 +37,6 @@ jobs:
         fetch-depth: 2
         submodules: true
 
-    # If this run was triggered by a pull request event, then checkout
-    # the head of the pull request instead of the merge commit.
-    - run: git checkout HEAD^2
-      if: ${{ github.event_name == 'pull_request' }}
-
     - name: Prepare Linux
       if: matrix.language == 'cpp'
       run: |


### PR DESCRIPTION
> 1 issue was detected with this workflow: git checkout HEAD^2 is no
> longer necessary. Please remove this step as Code Scanning recommends
> analyzing the merge commit for best results.

https://github.com/ddnet/ddnet/actions/runs/931568951

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
