### PR TITLE
Fix str comp parameter in updater

### DIFF
--- a/src/engine/client/updater.cpp
+++ b/src/engine/client/updater.cpp
@@ -157,7 +157,7 @@ bool CUpdater::MoveFile(const char *pFile)
 #endif
 
 #if !defined(CONF_PLATFORM_LINUX)
-	if(!str_comp_nocase(pFile + len - 4, ".so"))
+	if(!str_comp_nocase(pFile + len - 3, ".so"))
 		return Success;
 #endif
 


### PR DESCRIPTION
looks wrong to me

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
