### PR TITLE
Add a new failure log level to the HTTP module

### DIFF
--- a/src/engine/client/http.h
+++ b/src/engine/client/http.h
@@ -17,6 +17,13 @@ enum
 	HTTP_ABORTED,
 };
 
+enum class HTTPLOG
+{
+	NONE,
+	FAILURE,
+	ALL,
+};
+
 struct CTimeout
 {
 	long ConnectTimeoutMs;
@@ -42,7 +49,7 @@ class CRequest : public IJob
 	double m_Size;
 	double m_Current;
 	int m_Progress;
-	bool m_LogProgress;
+	HTTPLOG m_LogProgress;
 
 	std::atomic<int> m_State;
 	std::atomic<bool> m_Abort;
@@ -57,7 +64,7 @@ protected:
 	virtual int OnCompletion(int State) { return State; }
 
 public:
-	CRequest(const char *pUrl, CTimeout Timeout, bool LogProgress = true);
+	CRequest(const char *pUrl, CTimeout Timeout, HTTPLOG LogProgress = HTTPLOG::ALL);
 
 	double Current() const { return m_Current; }
 	double Size() const { return m_Size; }
@@ -72,7 +79,7 @@ class CHead : public CRequest
 	virtual bool AfterInit(void *pCurl);
 
 public:
-	CHead(const char *pUrl, CTimeout Timeout, bool LogProgress = true);
+	CHead(const char *pUrl, CTimeout Timeout, HTTPLOG LogProgress = HTTPLOG::ALL);
 	~CHead();
 };
 
@@ -85,7 +92,7 @@ class CGet : public CRequest
 	unsigned char *m_pBuffer;
 
 public:
-	CGet(const char *pUrl, CTimeout Timeout, bool LogProgress = true);
+	CGet(const char *pUrl, CTimeout Timeout, HTTPLOG LogProgress = HTTPLOG::ALL);
 	~CGet();
 
 	size_t ResultSize() const
@@ -121,7 +128,7 @@ protected:
 	virtual int OnCompletion(int State);
 
 public:
-	CGetFile(IStorage *pStorage, const char *pUrl, const char *pDest, int StorageType = -2, CTimeout Timeout = CTimeout{4000, 500, 5}, bool LogProgress = true);
+	CGetFile(IStorage *pStorage, const char *pUrl, const char *pDest, int StorageType = -2, CTimeout Timeout = CTimeout{4000, 500, 5}, HTTPLOG LogProgress = HTTPLOG::ALL);
 
 	const char *Dest() const { return m_aDest; }
 };

--- a/src/engine/client/serverbrowser_http.cpp
+++ b/src/engine/client/serverbrowser_http.cpp
@@ -137,14 +137,14 @@ void CChooseMaster::CJob::Run()
 	{
 		aTimeMs[i] = -1;
 		const char *pUrl = m_pData->m_aaUrls[aRandomized[i]];
-		CHead Head(pUrl, Timeout, false);
+		CHead Head(pUrl, Timeout, HTTPLOG::FAILURE);
 		IEngine::RunJobBlocking(&Head);
 		if(Head.State() != HTTP_DONE)
 		{
 			continue;
 		}
 		int64 StartTime = time_get();
-		CGet Get(pUrl, Timeout, false);
+		CGet Get(pUrl, Timeout, HTTPLOG::FAILURE);
 		IEngine::RunJobBlocking(&Get);
 		int Time = (time_get() - StartTime) * 1000 / time_freq();
 		if(Get.State() != HTTP_DONE)

--- a/src/game/client/components/skins.cpp
+++ b/src/game/client/components/skins.cpp
@@ -41,7 +41,7 @@ int CSkins::CGetPngFile::OnCompletion(int State)
 	return State;
 }
 
-CSkins::CGetPngFile::CGetPngFile(CSkins *pSkins, IStorage *pStorage, const char *pUrl, const char *pDest, int StorageType, CTimeout Timeout, bool LogProgress) :
+CSkins::CGetPngFile::CGetPngFile(CSkins *pSkins, IStorage *pStorage, const char *pUrl, const char *pDest, int StorageType, CTimeout Timeout, HTTPLOG LogProgress) :
 	CGetFile(pStorage, pUrl, pDest, StorageType, Timeout, LogProgress), m_pSkins(pSkins)
 {
 }
@@ -420,7 +420,7 @@ int CSkins::FindImpl(const char *pName)
 	char aUrl[256];
 	str_format(aUrl, sizeof(aUrl), "%s%s.png", g_Config.m_ClSkinDownloadUrl, pName);
 	str_format(Skin.m_aPath, sizeof(Skin.m_aPath), "downloadedskins/%s.%d.tmp", pName, pid());
-	Skin.m_pTask = std::make_shared<CGetPngFile>(this, Storage(), aUrl, Skin.m_aPath, IStorage::TYPE_SAVE, CTimeout{0, 0, 0}, false);
+	Skin.m_pTask = std::make_shared<CGetPngFile>(this, Storage(), aUrl, Skin.m_aPath, IStorage::TYPE_SAVE, CTimeout{0, 0, 0}, HTTPLOG::NONE);
 	m_pClient->Engine()->AddJob(Skin.m_pTask);
 	m_aDownloadSkins.add(Skin);
 	return -1;

--- a/src/game/client/components/skins.h
+++ b/src/game/client/components/skins.h
@@ -20,7 +20,7 @@ public:
 		virtual int OnCompletion(int State);
 
 	public:
-		CGetPngFile(CSkins *pSkins, IStorage *pStorage, const char *pUrl, const char *pDest, int StorageType = -2, CTimeout Timeout = CTimeout{4000, 500, 5}, bool LogProgress = true);
+		CGetPngFile(CSkins *pSkins, IStorage *pStorage, const char *pUrl, const char *pDest, int StorageType = -2, CTimeout Timeout = CTimeout{4000, 500, 5}, HTTPLOG LogProgress = HTTPLOG::ALL);
 		CImageInfo m_Info;
 	};
 


### PR DESCRIPTION
Use it for the "determine best masterserver" job, so that we can debug
failures.

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
