### PR TITLE
Don't set cached pings for servers without info

### DIFF
--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -544,7 +544,7 @@ void CServerBrowser::SetLatency(NETADDR Addr, int Latency)
 	{
 		NETADDR Other = pEntry->m_Addr;
 		Other.port = 0;
-		if(net_addr_comp(&Addr, &Other) == 0)
+		if(net_addr_comp(&Addr, &Other) == 0 && pEntry->m_GotInfo)
 		{
 			pEntry->m_Info.m_Latency = Latency;
 			pEntry->m_Info.m_LatencyIsEstimated = false;


### PR DESCRIPTION
Fixes #3899.

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
