### PR TITLE
Update server list silently

### DIFF
--- a/src/engine/client/serverbrowser.h
+++ b/src/engine/client/serverbrowser.h
@@ -176,7 +176,7 @@ private:
 	CServerEntry *m_pLastReqServer;
 	int m_NumRequests;
 
-	//used instead of g_Config.br_max_requests to get more servers
+	// used instead of g_Config.br_max_requests to get more servers
 	int m_CurrentMaxRequests;
 
 	int m_NeedRefresh;
@@ -192,7 +192,6 @@ private:
 
 	int m_ServerlistType;
 	int64_t m_BroadcastTime;
-	int m_RequestNumber;
 	unsigned char m_aTokenSeed[16];
 
 	bool m_SortOnNextUpdate;
@@ -216,6 +215,8 @@ private:
 	void Filter();
 	void Sort();
 	int SortHash() const;
+
+	void CleanUp();
 
 	void UpdateFromHttp();
 	CServerEntry *Add(const NETADDR &Addr);

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -180,7 +180,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 	{
 		CUIRect MsgBox = View;
 
-		if(ServerBrowser()->IsGettingServerlist())
+		if(!ServerBrowser()->NumServers() && ServerBrowser()->IsGettingServerlist())
 			UI()->DoLabelScaled(&MsgBox, Localize("Getting server list from master server"), 16.0f, 0);
 		else if(!ServerBrowser()->NumServers())
 			UI()->DoLabelScaled(&MsgBox, Localize("No servers found"), 16.0f, 0);
@@ -616,6 +616,8 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 		auto Func = [this]() mutable -> const char * {
 			if(ServerBrowser()->IsRefreshing())
 				str_format(m_aLocalStringHelper, sizeof(m_aLocalStringHelper), "%s (%d%%)", Localize("Refresh"), ServerBrowser()->LoadingProgression());
+			else if(ServerBrowser()->IsGettingServerlist())
+				str_copy(m_aLocalStringHelper, Localize("Refreshing..."), sizeof(m_aLocalStringHelper));
 			else
 				str_copy(m_aLocalStringHelper, Localize("Refresh"), sizeof(m_aLocalStringHelper));
 


### PR DESCRIPTION
So there is always a list rendered(not the "Getting serverlist" string)

This isn't really finished.
The goal should be to also cache the server list to disk and load it, so there is never an empty list.
Also currently I just made the "Refresh" button say "(Fetching) Refresh" to be clear the list might change.
Personally i think greying out the list could be a way to show it "more elegant".

Anyway, didn't really test it, if somebody wants to test out, give feedback or even build upon this, just do it.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
