### PR TITLE
Fix: Switch servers after player confirmed POPUP_DISCONNECT

### DIFF
--- a/data/languages/german.txt
+++ b/data/languages/german.txt
@@ -1333,3 +1333,6 @@ Hookable
 
 Tee
 == Tee
+
+Are you sure that you want to disconnect and switch to a different server?
+== Bist du sicher, dass du die Verbindung trennen und zu einem anderen Server wechseln möchtest?

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -1752,6 +1752,12 @@ int CMenus::Render()
 			pButtonText = m_aMessageButton;
 			ExtraAlign = -1;
 		}
+		else if(m_Popup == POPUP_SWITCH_SERVER)
+		{
+			pTitle = Localize("Disconnect");
+			pExtraText = Localize("Are you sure that you want to disconnect and switch to a different server?");
+			ExtraAlign = -1;
+		}
 
 		CUIRect Box, Part;
 		Box = Screen;
@@ -2392,6 +2398,29 @@ int CMenus::Render()
 				m_Popup = POPUP_NONE;
 				SetActive(false);
 			}
+		}
+		else if(m_Popup == POPUP_SWITCH_SERVER)
+		{
+			CUIRect Yes, No;
+			Box.HSplitBottom(20.f, &Box, &Part);
+			Box.HSplitBottom(24.f, &Box, &Part);
+
+			// buttons
+			Part.VMargin(80.0f, &Part);
+			Part.VSplitMid(&No, &Yes);
+			Yes.VMargin(20.0f, &Yes);
+			No.VMargin(20.0f, &No);
+
+			static int s_ButtonAbort = 0;
+			if(DoButton_Menu(&s_ButtonAbort, Localize("No"), 0, &No) || m_EscapePressed)
+			{
+				m_Popup = POPUP_NONE;
+				m_aNextServer[0] = '\0';
+			}
+
+			static int s_ButtonTryAgain = 0;
+			if(DoButton_Menu(&s_ButtonTryAgain, Localize("Yes"), 0, &Yes) || m_EnterPressed)
+				Client()->Connect(m_aNextServer);
 		}
 		else
 		{

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -290,6 +290,8 @@ protected:
 	vec2 m_MousePos;
 	bool m_MouseSlow;
 
+	char m_aNextServer[256];
+
 	int64 m_LastInput;
 
 	// images
@@ -679,6 +681,7 @@ public:
 		POPUP_DISCONNECT,
 		POPUP_DISCONNECT_DUMMY,
 		POPUP_WARNING,
+		POPUP_SWITCH_SERVER,
 
 		// demo player states
 		DEMOPLAYER_NONE = 0,

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -487,7 +487,10 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 		if(Input()->MouseDoubleClick() && DoubleClicked)
 		{
 			if(Client()->State() == IClient::STATE_ONLINE && Client()->GetCurrentRaceTime() / 60 >= g_Config.m_ClConfirmDisconnectTime && g_Config.m_ClConfirmDisconnectTime >= 0)
-				m_Popup = POPUP_DISCONNECT;
+			{
+				m_Popup = POPUP_SWITCH_SERVER;
+				str_copy(m_aNextServer, g_Config.m_UiServerAddress, sizeof(m_aNextServer));
+			}
 			else
 				Client()->Connect(g_Config.m_UiServerAddress);
 		}
@@ -647,7 +650,10 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 			m_EnterPressed)
 		{
 			if(Client()->State() == IClient::STATE_ONLINE && Client()->GetCurrentRaceTime() / 60 >= g_Config.m_ClConfirmDisconnectTime && g_Config.m_ClConfirmDisconnectTime >= 0)
-				m_Popup = POPUP_DISCONNECT;
+			{
+				m_Popup = POPUP_SWITCH_SERVER;
+				str_copy(m_aNextServer, g_Config.m_UiServerAddress, sizeof(m_aNextServer));
+			}
 			else
 				Client()->Connect(g_Config.m_UiServerAddress);
 			m_EnterPressed = false;


### PR DESCRIPTION
When a player wants to switch servers in-game, but needs to confirm the
action because of cl_confirm_disconnect, the game used to not actually
connect to the new server.

This adds a way to still connect to that server, after the player
confirms.

## Screenshots
![POPUP_SWITCH_SERVER](https://scrumplex.rocks/img/1624708089.png)


## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
