### PR TITLE
Avoid double free on m_pScore (fixes #3939)

### DIFF
--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -36,7 +36,6 @@ enum
 
 void CGameContext::Construct(int Resetting)
 {
-	m_Resetting = 0;
 	m_pServer = 0;
 
 	for(auto &pPlayer : m_apPlayers)
@@ -49,25 +48,34 @@ void CGameContext::Construct(int Resetting)
 	m_pVoteOptionLast = 0;
 	m_NumVoteOptions = 0;
 	m_LastMapVote = 0;
-	//m_LockTeams = 0;
 
 	m_SqlRandomMapResult = nullptr;
 
+	m_pScore = nullptr;
+	m_NumMutes = 0;
+	m_NumVoteMutes = 0;
+
 	if(Resetting == NO_RESET)
-	{
 		m_pVoteOptionHeap = new CHeap();
-		m_pScore = 0;
-		m_NumMutes = 0;
-		m_NumVoteMutes = 0;
-	}
+
 	m_ChatResponseTargetID = -1;
 	m_aDeleteTempfile[0] = 0;
 	m_TeeHistorianActive = false;
 }
 
-CGameContext::CGameContext(int Resetting)
+void CGameContext::Destruct(int Resetting)
 {
-	Construct(Resetting);
+	for(auto &pPlayer : m_apPlayers)
+		delete pPlayer;
+
+	if(Resetting == NO_RESET)
+		delete m_pVoteOptionHeap;
+
+	if(m_pScore)
+	{
+		delete m_pScore;
+		m_pScore = nullptr;
+	}
 }
 
 CGameContext::CGameContext()
@@ -77,13 +85,7 @@ CGameContext::CGameContext()
 
 CGameContext::~CGameContext()
 {
-	for(auto &pPlayer : m_apPlayers)
-		delete pPlayer;
-	if(!m_Resetting)
-		delete m_pVoteOptionHeap;
-
-	if(m_pScore)
-		delete m_pScore;
+	Destruct(NO_RESET);
 }
 
 void CGameContext::Clear()
@@ -94,10 +96,8 @@ void CGameContext::Clear()
 	int NumVoteOptions = m_NumVoteOptions;
 	CTuningParams Tuning = m_Tuning;
 
-	m_Resetting = true;
-	this->~CGameContext();
-	mem_zero(this, sizeof(*this));
-	new(this) CGameContext(RESET);
+	Destruct(RESET);
+	Construct(RESET);
 
 	m_pVoteOptionHeap = pVoteOptionHeap;
 	m_pVoteOptionFirst = pVoteOptionFirst;

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -116,12 +116,10 @@ class CGameContext : public IGameServer
 	static void ConDumpAntibot(IConsole::IResult *pResult, void *pUserData);
 	static void ConchainSpecialMotdupdate(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 
-	CGameContext(int Resetting);
 	void Construct(int Resetting);
+	void Destruct(int Resetting);
 	void AddVote(const char *pDescription, const char *pCommand);
 	static int MapScan(const char *pName, int IsDir, int DirType, void *pUserData);
-
-	bool m_Resetting;
 
 	struct CPersistentClientData
 	{


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
