### PR TITLE
Display AllTheHaxx and chillerbot in status

### DIFF
--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -191,6 +191,7 @@ public:
 		int m_DDNetVersion;
 		char m_aDDNetVersionStr[64];
 		CUuid m_ConnectionID;
+		char m_CustomClientStr[64];
 
 		// DNSBL
 		int m_DnsblState;

--- a/src/engine/shared/protocol_ex_msgs.h
+++ b/src/engine/shared/protocol_ex_msgs.h
@@ -29,3 +29,6 @@ UUID(NETMSG_CAPABILITIES, "capabilities@ddnet.tw")
 UUID(NETMSG_CLIENTVER, "clientver@ddnet.tw")
 UUID(NETMSG_PINGEX, "ping@ddnet.tw")
 UUID(NETMSG_PONGEX, "pong@ddnet.tw")
+
+UUID(NETMSG_IAMALLTHEHAXX, "i-am-allthehaxx@allthehaxx.github.io")
+UUID(NETMSG_IAMCHILLERBOT, "i-am-chillerbot@chillerbot.github.io")


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/20344300/124353635-fa784580-dc07-11eb-8cf8-3d54fc447b50.png)

Display custom clients that implemented the ddnet ex protocol in ``status``

AllTheHaxx:
 https://github.com/AllTheHaxx/AllTheHaxx/blob/fc41bd151a26c5e1e0d9163a4dc583c6397644ba/src/engine/client/client.cpp#L518-L534

chillerbot-ux:
https://github.com/chillerbot/chillerbot-ux/blob/ebc337a6c754ecd9a5c1f2486dd503cf55d00498/src/engine/client/client.cpp#L456-L470

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)


