### PR TITLE
Fix the possibility of tees stacking by joining teams

### DIFF
--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -281,6 +281,23 @@ const char *CGameTeams::SetCharacterTeam(int ClientID, int Team)
 	if(m_Core.Team(ClientID) != TEAM_SUPER && GetSaving(m_Core.Team(ClientID)))
 		return "This team is currently saving";
 
+	if(!m_Core.GetSolo(ClientID))
+	{
+		CCharacter *pChar = Character(ClientID);
+		for(int i = 0; i < MAX_CLIENTS; i++)
+		{
+			CCharacter *pOther = Character(i);
+			if(ClientID == i || !pOther || m_Core.GetSolo(i) || Team != m_Core.Team(i))
+			{
+				continue;
+			}
+			if(distance(pChar->Core()->m_Pos, pOther->Core()->m_Pos) < CCharacter::ms_PhysSize * 1.25f)
+			{
+				return "Your position is blocked by another tee";
+			}
+		}
+	}
+
 	SetForceCharacterTeam(ClientID, Team);
 	return nullptr;
 }


### PR DESCRIPTION
This would make some startline skips harder to exploit.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [x] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
