### PR TITLE
Try to fix "start line skipping"

### DIFF
--- a/src/game/server/gamemodes/DDRace.cpp
+++ b/src/game/server/gamemodes/DDRace.cpp
@@ -163,6 +163,7 @@ void CGameControllerDDRace::Tick()
 {
 	IGameController::Tick();
 	m_Teams.ProcessSaveTeam();
+	m_Teams.Tick();
 
 	if(m_pInitResult != nullptr && m_pInitResult->m_Completed)
 	{

--- a/src/game/server/save.cpp
+++ b/src/game/server/save.cpp
@@ -26,6 +26,7 @@ void CSaveTee::Save(CCharacter *pChr)
 	m_Paused = abs(pChr->m_pPlayer->IsPaused());
 	m_NeededFaketuning = pChr->m_NeededFaketuning;
 
+	m_TeeStarted = pChr->Teams()->TeeStarted(m_ClientID);
 	m_TeeFinished = pChr->Teams()->TeeFinished(m_ClientID);
 	m_IsSolo = pChr->m_Solo;
 
@@ -116,6 +117,7 @@ void CSaveTee::Load(CCharacter *pChr, int Team)
 	pChr->m_NeededFaketuning = m_NeededFaketuning;
 
 	pChr->Teams()->SetForceCharacterTeam(pChr->m_pPlayer->GetCID(), Team);
+	pChr->Teams()->SetStarted(pChr->m_pPlayer->GetCID(), m_TeeStarted);
 	pChr->Teams()->SetFinished(pChr->m_pPlayer->GetCID(), m_TeeFinished);
 
 	for(int i = 0; i < NUM_WEAPONS; i++)
@@ -248,12 +250,13 @@ char *CSaveTee::GetString(const CSaveTeam *pTeam)
 		"%f\t%f\t%f\t%f\t%f\t"
 		"%f\t%f\t%f\t%f\t%f\t"
 		"%f\t%f\t%f\t%f\t%f\t"
-		"%d\t"
-		"%d\t%d\t%d\t"
-		"%s\t"
-		"%d\t%d\t"
-		"%d\t%d\t%d\t%d\t"
-		"%d",
+		"%d\t" // m_NotEligibleForFinish
+		"%d\t%d\t%d\t" // tele weapons
+		"%s\t" // m_aGameUuid
+		"%d\t%d" // m_HookedPlayer, m_NewHook
+		"%d\t%d\t%d\t%d\t" // input stuff
+		"%d\t" // m_ReloadTimer
+		"%d", // m_TeeStarted
 		m_aName, m_Alive, m_Paused, m_NeededFaketuning, m_TeeFinished, m_IsSolo,
 		// weapons
 		m_aWeapons[0].m_AmmoRegenStart, m_aWeapons[0].m_Ammo, m_aWeapons[0].m_Ammocost, m_aWeapons[0].m_Got,
@@ -284,7 +287,8 @@ char *CSaveTee::GetString(const CSaveTeam *pTeam)
 		m_aGameUuid,
 		HookedPlayer, m_NewHook,
 		m_InputDirection, m_InputJump, m_InputFire, m_InputHook,
-		m_ReloadTimer);
+		m_ReloadTimer,
+		m_TeeStarted);
 	return m_aString;
 }
 
@@ -317,12 +321,13 @@ int CSaveTee::FromString(const char *String)
 		"%f\t%f\t%f\t%f\t%f\t"
 		"%f\t%f\t%f\t%f\t%f\t"
 		"%f\t%f\t%f\t%f\t%f\t"
-		"%d\t"
-		"%d\t%d\t%d\t"
-		"%36s\t"
-		"%d\t%d"
-		"%d\t%d\t%d\t%d\t"
-		"%d",
+		"%d\t" // m_NotEligibleForFinish
+		"%d\t%d\t%d\t" // tele weapons
+		"%36s\t" // m_aGameUuid
+		"%d\t%d" // m_HookedPlayer, m_NewHook
+		"%d\t%d\t%d\t%d\t" // input stuff
+		"%d\t" // m_ReloadTimer
+		"%d", // m_TeeStarted
 		m_aName, &m_Alive, &m_Paused, &m_NeededFaketuning, &m_TeeFinished, &m_IsSolo,
 		// weapons
 		&m_aWeapons[0].m_AmmoRegenStart, &m_aWeapons[0].m_Ammo, &m_aWeapons[0].m_Ammocost, &m_aWeapons[0].m_Got,
@@ -353,7 +358,8 @@ int CSaveTee::FromString(const char *String)
 		m_aGameUuid,
 		&m_HookedPlayer, &m_NewHook,
 		&m_InputDirection, &m_InputJump, &m_InputFire, &m_InputHook,
-		&m_ReloadTimer);
+		&m_ReloadTimer,
+		&m_TeeStarted);
 	switch(Num) // Don't forget to update this when you save / load more / less.
 	{
 	case 96:
@@ -377,6 +383,9 @@ int CSaveTee::FromString(const char *String)
 		m_ReloadTimer = 0;
 		// fall through
 	case 108:
+		m_TeeStarted = true;
+		// fall through
+	case 109:
 		return 0;
 	default:
 		dbg_msg("load", "failed to load tee-string");

--- a/src/game/server/save.h
+++ b/src/game/server/save.h
@@ -37,6 +37,7 @@ private:
 	int m_NeededFaketuning;
 
 	// Teamstuff
+	int m_TeeStarted;
 	int m_TeeFinished;
 	int m_IsSolo;
 

--- a/src/game/server/teams.h
+++ b/src/game/server/teams.h
@@ -12,6 +12,14 @@
 class CGameTeams
 {
 	int m_TeamState[MAX_CLIENTS];
+	// `m_TeeStarted` is used to keep track whether a given tee has hit the
+	// start of the map yet. If a tee that leaves hasn't hit the start line
+	// yet, the team will be marked as "not allowed to finish"
+	// (`TEAMSTATE_STARTED_UNFINISHABLE`). If this were not the case, tees
+	// could go around the startline on a map, leave one tee behind at
+	// start, go to the finish line, let the tee start and kill, allowing
+	// the team to finish instantly.
+	bool m_TeeStarted[MAX_CLIENTS];
 	bool m_TeeFinished[MAX_CLIENTS];
 	bool m_TeamLocked[MAX_CLIENTS];
 	uint64_t m_Invited[MAX_CLIENTS];
@@ -31,6 +39,9 @@ public:
 		TEAMSTATE_EMPTY,
 		TEAMSTATE_OPEN,
 		TEAMSTATE_STARTED,
+		// Happens when a tee that hasn't hit the start tiles leaves
+		// the team.
+		TEAMSTATE_STARTED_UNFINISHABLE,
 		TEAMSTATE_FINISHED
 	};
 
@@ -126,9 +137,9 @@ public:
 		return m_TeamState[Team] == CGameTeams::TEAMSTATE_STARTED;
 	}
 
-	void SetFinished(int ClientID, bool finished)
+	void SetFinished(int ClientID, bool Finished)
 	{
-		m_TeeFinished[ClientID] = finished;
+		m_TeeFinished[ClientID] = Finished;
 	}
 
 	void SetSaving(int TeamID, std::shared_ptr<CScoreSaveResult> &SaveResult)

--- a/src/game/server/teams.h
+++ b/src/game/server/teams.h
@@ -109,6 +109,11 @@ public:
 	void SwapTeamCharacters(CPlayer *pPlayer, CPlayer *pTargetPlayer, int Team);
 	void ProcessSaveTeam();
 
+	bool TeeStarted(int ClientID)
+	{
+		return m_TeeStarted[ClientID];
+	}
+
 	bool TeeFinished(int ClientID)
 	{
 		return m_TeeFinished[ClientID];
@@ -135,6 +140,11 @@ public:
 	bool IsStarted(int Team)
 	{
 		return m_TeamState[Team] == CGameTeams::TEAMSTATE_STARTED;
+	}
+
+	void SetStarted(int ClientID, bool Started)
+	{
+		m_TeeStarted[ClientID] = Started;
 	}
 
 	void SetFinished(int ClientID, bool Finished)

--- a/src/game/server/teams.h
+++ b/src/game/server/teams.h
@@ -26,6 +26,7 @@ class CGameTeams
 	bool m_Practice[MAX_CLIENTS];
 	std::shared_ptr<CScoreSaveResult> m_pSaveTeamResult[MAX_CLIENTS];
 	uint64_t m_LastSwap[MAX_CLIENTS];
+	bool m_TeamSentStartWarning[MAX_CLIENTS];
 
 	class CGameContext *m_pGameContext;
 
@@ -72,6 +73,7 @@ public:
 	void OnCharacterFinish(int ClientID);
 	void OnCharacterSpawn(int ClientID);
 	void OnCharacterDeath(int ClientID, int Weapon);
+	void Tick();
 
 	// returns nullptr if successful, error string if failed
 	const char *SetCharacterTeam(int ClientID, int Team);


### PR DESCRIPTION
Previously, tees could go around the start line on some maps, going
directly to the finish line while leaving one tee behind at the start.
By letting that sole tee start and kill itself, the team could be
directly at the finish at time 0:00.

Fix this by requiring every tee of a team to hit the start line before
being able to finish. Tees can still get some advantage by skipping the
start line, but it will no longer be a 0:00 finish.

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
