### PR TITLE
Fix save codes (symptom: always jumping after load)

### DIFF
--- a/src/game/server/save.cpp
+++ b/src/game/server/save.cpp
@@ -253,7 +253,7 @@ char *CSaveTee::GetString(const CSaveTeam *pTeam)
 		"%d\t" // m_NotEligibleForFinish
 		"%d\t%d\t%d\t" // tele weapons
 		"%s\t" // m_aGameUuid
-		"%d\t%d" // m_HookedPlayer, m_NewHook
+		"%d\t%d\t" // m_HookedPlayer, m_NewHook
 		"%d\t%d\t%d\t%d\t" // input stuff
 		"%d\t" // m_ReloadTimer
 		"%d", // m_TeeStarted
@@ -324,7 +324,7 @@ int CSaveTee::FromString(const char *String)
 		"%d\t" // m_NotEligibleForFinish
 		"%d\t%d\t%d\t" // tele weapons
 		"%36s\t" // m_aGameUuid
-		"%d\t%d" // m_HookedPlayer, m_NewHook
+		"%d\t%d\t" // m_HookedPlayer, m_NewHook
 		"%d\t%d\t%d\t%d\t" // input stuff
 		"%d\t" // m_ReloadTimer
 		"%d", // m_TeeStarted


### PR DESCRIPTION
"\t" was missing for one variable.

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
