### PR TITLE
Fix "tee hasn't hit the start line yet" error

### DIFF
--- a/src/game/server/gamemodes/DDRace.cpp
+++ b/src/game/server/gamemodes/DDRace.cpp
@@ -63,12 +63,8 @@ void CGameControllerDDRace::HandleCharacterTiles(CCharacter *pChr, int MapIndex)
 
 	const int PlayerDDRaceState = pChr->m_DDRaceState;
 	bool IsOnStartTile = (m_TileIndex == TILE_START) || (m_TileFIndex == TILE_START) || FTile1 == TILE_START || FTile2 == TILE_START || FTile3 == TILE_START || FTile4 == TILE_START || Tile1 == TILE_START || Tile2 == TILE_START || Tile3 == TILE_START || Tile4 == TILE_START;
-	bool CanStart = false;
-	CanStart = CanStart || PlayerDDRaceState == DDRACE_NONE;
-	CanStart = CanStart || PlayerDDRaceState == DDRACE_FINISHED;
-	CanStart = CanStart || (PlayerDDRaceState == DDRACE_STARTED && g_Config.m_SvTeam != 3);
 	// start
-	if(IsOnStartTile && CanStart)
+	if(IsOnStartTile && PlayerDDRaceState != DDRACE_CHEAT)
 	{
 		if(m_Teams.GetSaving(GetPlayerTeam(ClientID)))
 		{

--- a/src/game/server/gamemodes/DDRace.cpp
+++ b/src/game/server/gamemodes/DDRace.cpp
@@ -66,7 +66,7 @@ void CGameControllerDDRace::HandleCharacterTiles(CCharacter *pChr, int MapIndex)
 	bool CanStart = false;
 	CanStart = CanStart || PlayerDDRaceState == DDRACE_NONE;
 	CanStart = CanStart || PlayerDDRaceState == DDRACE_FINISHED;
-	CanStart = CanStart || (PlayerDDRaceState == DDRACE_STARTED && GetPlayerTeam(ClientID) == TEAM_FLOCK && g_Config.m_SvTeam != 3);
+	CanStart = CanStart || (PlayerDDRaceState == DDRACE_STARTED && g_Config.m_SvTeam != 3);
 	// start
 	if(IsOnStartTile && CanStart)
 	{

--- a/src/game/server/gamemodes/DDRace.cpp
+++ b/src/game/server/gamemodes/DDRace.cpp
@@ -62,8 +62,13 @@ void CGameControllerDDRace::HandleCharacterTiles(CCharacter *pChr, int MapIndex)
 	int FTile4 = GameServer()->Collision()->GetFTileIndex(S4);
 
 	const int PlayerDDRaceState = pChr->m_DDRaceState;
+	bool IsOnStartTile = (m_TileIndex == TILE_START) || (m_TileFIndex == TILE_START) || FTile1 == TILE_START || FTile2 == TILE_START || FTile3 == TILE_START || FTile4 == TILE_START || Tile1 == TILE_START || Tile2 == TILE_START || Tile3 == TILE_START || Tile4 == TILE_START;
+	bool CanStart = false;
+	CanStart = CanStart || PlayerDDRaceState == DDRACE_NONE;
+	CanStart = CanStart || PlayerDDRaceState == DDRACE_FINISHED;
+	CanStart = CanStart || (PlayerDDRaceState == DDRACE_STARTED && GetPlayerTeam(ClientID) == TEAM_FLOCK && g_Config.m_SvTeam != 3);
 	// start
-	if(((m_TileIndex == TILE_START) || (m_TileFIndex == TILE_START) || FTile1 == TILE_START || FTile2 == TILE_START || FTile3 == TILE_START || FTile4 == TILE_START || Tile1 == TILE_START || Tile2 == TILE_START || Tile3 == TILE_START || Tile4 == TILE_START) && (PlayerDDRaceState == DDRACE_NONE || PlayerDDRaceState == DDRACE_FINISHED || (PlayerDDRaceState == DDRACE_STARTED && !GetPlayerTeam(ClientID) && g_Config.m_SvTeam != 3)))
+	if(IsOnStartTile && CanStart)
 	{
 		if(m_Teams.GetSaving(GetPlayerTeam(ClientID)))
 		{

--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -68,6 +68,8 @@ void CGameTeams::OnCharacterStart(int ClientID)
 	CCharacter *pStartingChar = Character(ClientID);
 	if(!pStartingChar)
 		return;
+	if(g_Config.m_SvTeam == 3 && pStartingChar->m_DDRaceState == DDRACE_STARTED)
+		return;
 	if((g_Config.m_SvTeam == 3 || m_Core.Team(ClientID) != TEAM_FLOCK) && pStartingChar->m_DDRaceState == DDRACE_FINISHED)
 		return;
 	if(g_Config.m_SvTeam != 3 &&


### PR DESCRIPTION
It has been happening to all teams. Send `CGameTeams::OnCharacterStart`
even if the team has already started.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
