### PR TITLE
Fix pressing Home or End in server address field changes the selected server

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -3007,7 +3007,9 @@ bool CMenus::HandleListInputs(const CUIRect &View, float &ScrollValue, const flo
 	{
 		if(m_aInputEvents[i].m_Flags & IInput::FLAG_PRESS)
 		{
-			if(m_aInputEvents[i].m_Key == KEY_DOWN)
+			if(UI()->LastActiveItem() == &g_Config.m_UiServerAddress)
+				return false;
+			else if(m_aInputEvents[i].m_Key == KEY_DOWN)
 				NewIndex = minimum(SelectedIndex + 1, NumElems - 1);
 			else if(m_aInputEvents[i].m_Key == KEY_UP)
 				NewIndex = maximum(SelectedIndex - 1, 0);


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request -->
I think it should fix #3964.
# Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
