### PR TITLE
Disabling quick editing in the console

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -4380,7 +4380,14 @@ int main(int argc, const char **argv) // ignore_convention
 
 #if defined(CONF_FAMILY_WINDOWS)
 	if(g_Config.m_ClShowConsole)
+	{
 		AllocConsole();
+		HANDLE hInput;
+		DWORD prev_mode;
+		hInput = GetStdHandle(STD_INPUT_HANDLE);
+		GetConsoleMode(hInput, &prev_mode);
+		SetConsoleMode(hInput, prev_mode & ENABLE_EXTENDED_FLAGS);
+	}
 #endif
 
 	// execute autoexec file


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request -->
I think it should fix #3925.

Previously, the game stopped due to the fact that it was possible to turn on the selection by a random click, but if you disable the quick edit flags, then the selection can be made only by right-clicking the mouse and selecting an necessery option. 

The game will also stop, but after copying it will immediately continue, and this eliminates accidental pressing, that is, the person is fully responsible for his actions.
![console](https://user-images.githubusercontent.com/33897884/126964490-89bb6138-3bdf-4325-8241-30fff3bfb7f0.jpg)
## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
