### PR TITLE
Add script to strip out graphic code

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -100,6 +100,22 @@ jobs:
         ${{ matrix.cmake-path }}cmake --build . --config Release --target run_tests ${{ matrix.build-args }}
         ./DDNet-Server shutdown
 
+    - name: Build client release mode (no graphics)
+      env: ${{ matrix.env }}
+      run: |
+        python3 ./scripts/strip_gfx.py -i
+        mkdir release_no_gfx
+        cd release_no_gfx
+        ${{ matrix.cmake-path }}cmake -E env CXXFLAGS='' ${{ matrix.cmake-path }}cmake ${{ matrix.cmake-args }} -DCMAKE_BUILD_TYPE=Release -Werror=dev -DDOWNLOAD_GTEST=ON -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE=. ..
+        ${{ matrix.cmake-path }}cmake -E env CXXFLAGS='' ${{ matrix.cmake-path }}cmake --build . --config Release --target everything ${{ matrix.build-args }}
+    - name: Test client release (no graphics)
+      run: |
+        cd release_no_gfx
+        ${{ matrix.cmake-path }}cmake -E env CXXFLAGS='' ${{ matrix.cmake-path }}cmake --build . --config Release --target run_tests ${{ matrix.build-args }}
+        ./DDNet quit
+        cd ..
+        git checkout -- src
+
     - name: Build in release mode with debug info and all features on
       if: matrix.fancy
       env: ${{ matrix.env }}

--- a/scripts/strip_gfx.py
+++ b/scripts/strip_gfx.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""
+comments out graphic code to turn any src base into a headless client
+"""
+
+import os
+import argparse
+import re
+
+os.chdir(os.path.dirname(__file__) + "/..")
+
+GFX_FILES = [
+	['src/engine/client/graphics_threaded.cpp', ['CGraphics_Threaded']],
+	['src/engine/client/backend_sdl.cpp', [
+		'CGraphicsBackend_Threaded',
+		'CCommandProcessorFragment_General',
+		'CCommandProcessorFragment_SDL',
+		'CCommandProcessor_SDL_OpenGL',
+		'CGraphicsBackend_SDL_OpenGL']]
+]
+
+GFX_IN_CLASS = [
+	['src/engine/client/text.cpp', 'CTextRender']
+]
+
+# pylint: disable=too-many-branches
+# pylint: disable=too-many-statements
+def comment_gfx_file(filename, class_names, inplace):
+	"""Comment out all function bodys of given cpp file expecting function in class"""
+	new_file_buffer = ''
+	current_function = None
+	reached_body = False
+	is_pointer = False
+	with open(filename) as file:
+		for line in file:
+			# pre parser
+			if line.startswith('}') and current_function:
+				if current_function == 'bool':
+					new_file_buffer += "\treturn false;\n"
+				elif current_function == 'const char':
+					new_file_buffer += "\treturn \"\";\n"
+				elif current_function == 'int':
+					if is_pointer:
+						new_file_buffer += "\tstatic int ret = 0;return &ret;\n"
+					else:
+						new_file_buffer += "\treturn 0;\n"
+				elif current_function == 'void':
+					if is_pointer:
+						new_file_buffer += '\treturn NULL;\n'
+					else:
+						new_file_buffer += '\treturn;\n'
+				elif current_function == 'IGraphics::CTextureHandle':
+					new_file_buffer += '\treturn CreateTextureHandle(0);\n'
+				else:
+					if is_pointer:
+						new_file_buffer += "\treturn NULL;\n"
+					else:
+						new_file_buffer += f"\treturn {current_function} ret;\n"
+				current_function = None
+
+			if current_function and reached_body:
+				new_file_buffer += "//"
+				if line != "\n":
+					new_file_buffer += " "
+			new_file_buffer += line
+
+			# post parser
+			if current_function and not reached_body:
+				if line.startswith('{'):
+					reached_body = True
+			for class_name in class_names:
+				for func_type in ('void', 'bool', 'const char', 'int', 'IGraphics::CTextureHandle'):
+					if line.startswith(f"{func_type} {class_name}::"):
+						is_pointer = False
+						current_function = func_type
+						reached_body = False
+					elif line.startswith(f"{func_type} *{class_name}::"):
+						is_pointer = True
+						current_function = func_type
+						reached_body = False
+	if inplace:
+		with open(filename, 'w') as out_file:
+			out_file.write(new_file_buffer)
+			out_file.close()
+	else:
+		print(new_file_buffer)
+	return current_function is None
+
+# pylint: disable=too-many-branches
+# pylint: disable=too-many-statements
+def comment_gfx_in_class(filename, class_names, inplace):
+	"""Comment out all function bodys of given cpp file"""
+	new_file_buffer = ''
+	current_function = None
+	reached_body = False
+	is_pointer = False
+	in_class = False
+	with open(filename) as file:
+		for line in file:
+			# pre parser
+			if line.startswith('\t}') and current_function:
+				if current_function == 'bool':
+					new_file_buffer += "\t\treturn false;\n"
+				elif current_function == 'const char':
+					new_file_buffer += "\t\treturn \"\";\n"
+				elif current_function == 'int':
+					if is_pointer:
+						new_file_buffer += "\t\tstatic int ret = 0;return &ret;\n"
+					else:
+						new_file_buffer += "\t\treturn 0;\n"
+				elif current_function == 'void':
+					if is_pointer:
+						new_file_buffer += '\t\treturn NULL;\n'
+					else:
+						new_file_buffer += '\t\treturn;\n'
+				else:
+					if is_pointer:
+						new_file_buffer += "\t\treturn NULL;\n"
+					else:
+						new_file_buffer += f"\t\treturn {current_function} ret();\n"
+
+				current_function = None
+			elif line.startswith('}'):
+				in_class = False
+			for class_name in class_names:
+				if line.startswith(f"class {class_name}"):
+					in_class = True
+
+			if current_function and reached_body and in_class:
+				new_file_buffer += "//"
+				if line != "\n":
+					new_file_buffer += " "
+			new_file_buffer += line
+
+			# post parser
+			if current_function and not reached_body:
+				if line.startswith('\t{'):
+					reached_body = True
+			if not in_class:
+				continue
+			for func_type in ('void', 'bool', 'const char', 'int', 'CFont'):
+				if re.match(f'^\t?(virtual ){func_type} [a-zA-Z_][a-zA-Z0-9_]*\\(', line):
+					is_pointer = False
+					current_function = func_type
+					reached_body = False
+				elif re.match(f'^\t?(virtual ){func_type} \\*[a-zA-Z_][a-zA-Z0-9_]*\\(', line):
+					is_pointer = True
+					current_function = func_type
+					reached_body = False
+	if inplace:
+		with open(filename, 'w') as out_file:
+			out_file.write(new_file_buffer)
+			out_file.close()
+	else:
+		print(new_file_buffer)
+	return current_function is None
+
+def main():
+	"""main method"""
+	parser = argparse.ArgumentParser(
+		description='Comment out the graphic code to get a headless client')
+	parser.add_argument(
+		'-i',
+		'--inplace',
+		action='store_true',
+		help='Edit files in place instead of printing to stdout')
+	args = parser.parse_args()
+	for file in GFX_FILES:
+		comment_gfx_file(file[0], file[1], inplace = args.inplace)
+	for file in GFX_IN_CLASS:
+		comment_gfx_in_class(file[0], file[1], inplace = args.inplace)
+
+
+if __name__ == '__main__':
+	main()


### PR DESCRIPTION
Add a script to strip out the client graphic code. Which creates a client that can be run in a non graphical environment.
Can be used by modders who want a headless client for things like console chat or similar. Also useful to have a client that is almost the same as the normal ddnet client but can run in the CI. Should pick up obvious crashes of the client on launch that are unrelated to graphic code. Also can be used for further CI testing where a headless client connects to the server and checks if everything works out properly.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
