### PR TITLE
remove unused MenuTick, reuse existing m_LocalStartTime

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -3429,9 +3429,7 @@ void CClient::Run()
 	m_pGraphics->Shutdown();
 
 	// shutdown SDL
-	{
-		SDL_Quit();
-	}
+	SDL_Quit();
 }
 
 bool CClient::CtrlShiftKey(int Key, bool &Last)


### PR DESCRIPTION
(cherry picked from commit https://github.com/teeworlds/teeworlds/commit/009b072c340b778e0be4ee8eabd8522763233493)

Ok that was a weird cherry pick... 90% was already in :D
