### PR TITLE
Fix client use-after-free reported by mmmds

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -655,6 +655,12 @@ void CClient::EnterGame()
 	if(State() == IClient::STATE_DEMOPLAYBACK)
 		return;
 
+	if(State() == IClient::STATE_ONLINE)
+	{
+		// Don't reset everything while already in game.
+		return;
+	}
+
 	// now we will wait for two snapshots
 	// to finish the connection
 	SendEnterGame();


### PR DESCRIPTION
Fix https://github.com/teeworlds/teeworlds/issues/2645

The `Sv_ReadyToEnter` net message is only valid while we're still
loading stuff, it is used to signal that we can send the `ENTERGAME`
system message. Simply ignoring the server message while we're in the
wrong part of the state machine works.

(cherry picked from commit https://github.com/teeworlds/teeworlds/commit/a97f8a22dee3298c7c0ea7df9bc1733c2dd27a53)


## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
