### PR TITLE
Implement upstream download code style

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -801,7 +801,10 @@ void CClient::DisconnectWithReason(const char *pReason)
 	if(m_pMapdownloadTask)
 		m_pMapdownloadTask->Abort();
 	if(m_MapdownloadFile)
+	{
 		io_close(m_MapdownloadFile);
+		Storage()->RemoveFile(m_aMapdownloadFilename, IStorage::TYPE_SAVE);
+	}
 	m_MapdownloadFile = 0;
 	m_MapdownloadSha256Present = false;
 	m_MapdownloadSha256 = SHA256_ZEROED;

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -457,7 +457,10 @@ void CClient::SendReady()
 void CClient::SendMapRequest()
 {
 	if(m_MapdownloadFile)
+	{
 		io_close(m_MapdownloadFile);
+		Storage()->RemoveFile(m_aMapdownloadFilename, IStorage::TYPE_SAVE);
+	}
 	m_MapdownloadFile = Storage()->OpenFile(m_aMapdownloadFilename, IOFLAG_WRITE, IStorage::TYPE_SAVE);
 	CMsgPacker Msg(NETMSG_REQUEST_MAP_DATA, true);
 	Msg.AddInt(m_MapdownloadChunk);

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -180,8 +180,9 @@ class CClient : public IClient, public CDemoPlayer::IListener
 	// map download
 	std::shared_ptr<CGetFile> m_pMapdownloadTask;
 	char m_aMapdownloadFilename[256];
+	char m_aMapdownloadFilenameTemp[256];
 	char m_aMapdownloadName[256];
-	IOHANDLE m_MapdownloadFile;
+	IOHANDLE m_MapdownloadFileTemp;
 	int m_MapdownloadChunk;
 	int m_MapdownloadCrc;
 	int m_MapdownloadAmount;


### PR DESCRIPTION
In https://github.com/teeworlds/teeworlds/pull/2556 teeworlds introduced temporary download files for maps. DDNet already has that but a bit different. Those temporary files are now also deleted on error like it is done in the upstream. The main goal of this pr is to reduce code diff to upstream.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
