### PR TITLE
Revert "Fix client use-after-free reported by mmmds"

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -655,12 +655,6 @@ void CClient::EnterGame()
 	if(State() == IClient::STATE_DEMOPLAYBACK)
 		return;
 
-	if(State() == IClient::STATE_ONLINE)
-	{
-		// Don't reset everything while already in game.
-		return;
-	}
-
 	// now we will wait for two snapshots
 	// to finish the connection
 	SendEnterGame();


### PR DESCRIPTION
@ChillerDragon  Seems to cause problems:

> Hussain wrote
> :last update+ beta
> my dummy stuck ( this second time)
> disconnect and connect again useless still stuck
> and disconnect server too
> have to restart the game

This reverts commit ce2f29b5f1e1925ac9292f29f7d498bd7da25aed.

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
