### PR TITLE
Use upstream ui color constants

### DIFF
--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -1154,7 +1154,7 @@ void CChat::OnPrepareLines()
 			TextRender()->UploadTextContainer(m_aLines[r].m_TextContainerIndex);
 	}
 
-	TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
+	TextRender()->TextColor(CUI::ms_DefaultTextColor);
 }
 
 void CChat::OnRender()

--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -676,7 +676,7 @@ void CGameConsole::OnRender()
 				pEntry = pConsole->m_Backlog.Prev(pEntry);
 
 				// reset color
-				TextRender()->TextColor(1, 1, 1, 1);
+				TextRender()->TextColor(CUI::ms_DefaultTextColor);
 			}
 
 			//	actual backlog page number is too high, render last available page (current checked one, render top down)
@@ -698,7 +698,7 @@ void CGameConsole::OnRender()
 
 		// render page
 		char aBuf[128];
-		TextRender()->TextColor(1, 1, 1, 1);
+		TextRender()->TextColor(CUI::ms_DefaultTextColor);
 		str_format(aBuf, sizeof(aBuf), Localize("-Page %d-"), pConsole->m_BacklogActPage + 1);
 		TextRender()->Text(0, 10.0f, FontSize / 2.f, FontSize, aBuf, -1.0f);
 

--- a/src/game/client/components/debughud.cpp
+++ b/src/game/client/components/debughud.cpp
@@ -144,7 +144,7 @@ void CDebugHud::RenderTuning()
 	}
 	Graphics()->LinesDraw(Array, 100);
 	Graphics()->LinesEnd();
-	TextRender()->TextColor(1, 1, 1, 1);
+	TextRender()->TextColor(CUI::ms_DefaultTextColor);
 }
 
 void CDebugHud::RenderHint()
@@ -154,7 +154,7 @@ void CDebugHud::RenderHint()
 
 	float Width = 300 * Graphics()->ScreenAspect();
 	Graphics()->MapScreen(0, 0, Width, 300);
-	TextRender()->TextColor(1, 1, 1, 1);
+	TextRender()->TextColor(CUI::ms_DefaultTextColor);
 	TextRender()->Text(0x0, 5, 290, 5, Localize("Debug mode enabled. Press Ctrl+Shift+D to disable debug mode."), -1.0f);
 }
 

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -136,7 +136,7 @@ void CHud::RenderGameTimer()
 			TextRender()->TextColor(1.0f, 0.25f, 0.25f, Alpha);
 		}
 		TextRender()->Text(0, Half - w / 2, 2, FontSize, aBuf, -1.0f);
-		TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
+		TextRender()->TextColor(CUI::ms_DefaultTextColor);
 	}
 }
 
@@ -598,7 +598,7 @@ void CHud::RenderTeambalanceWarning()
 			else
 				TextRender()->TextColor(0.7f, 0.7f, 0.2f, 1.0f);
 			TextRender()->Text(0x0, 5, 50, 6, pText, -1.0f);
-			TextRender()->TextColor(1, 1, 1, 1);
+			TextRender()->TextColor(CUI::ms_DefaultTextColor);
 		}
 	}
 }
@@ -615,7 +615,7 @@ void CHud::RenderVoting()
 	RenderTools()->DrawRoundRect(-10, 60 - 2, 100 + 10 + 4 + 5, 46, 5.0f);
 	Graphics()->QuadsEnd();
 
-	TextRender()->TextColor(1, 1, 1, 1);
+	TextRender()->TextColor(CUI::ms_DefaultTextColor);
 
 	CTextCursor Cursor;
 	char aBuf[512];
@@ -956,7 +956,7 @@ void CHud::RenderDDRaceEffects()
 				TextRender()->TextColor(1, 1, 1, a); // white
 			TextRender()->Text(0, 150 * Graphics()->ScreenAspect() - TextRender()->TextWidth(0, 10, aBuf, -1, -1.0f) / 2, 20, 10, aBuf, -1.0f);
 
-			TextRender()->TextColor(1, 1, 1, 1);
+			TextRender()->TextColor(CUI::ms_DefaultTextColor);
 		}
 	}
 }

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -366,7 +366,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 						UI()->DoLabelStreamed(*pItem->m_pUIElement->Get(g_OffsetColName + 0), &Button, pItem->m_aName, FontSize, -1, Button.w, 1, true, (int)(pStr - pItem->m_aName));
 						TextRender()->TextColor(0.4f, 0.4f, 1.0f, 1);
 						UI()->DoLabelStreamed(*pItem->m_pUIElement->Get(g_OffsetColName + 1), &Button, pStr, FontSize, -1, Button.w, 1, true, (int)str_length(g_Config.m_BrFilterString), &pItem->m_pUIElement->Get(g_OffsetColName + 0)->m_Cursor);
-						TextRender()->TextColor(1, 1, 1, 1);
+						TextRender()->TextColor(CUI::ms_DefaultTextColor);
 						UI()->DoLabelStreamed(*pItem->m_pUIElement->Get(g_OffsetColName + 2), &Button, pStr + str_length(g_Config.m_BrFilterString), FontSize, -1, Button.w, 1, true, -1, &pItem->m_pUIElement->Get(g_OffsetColName + 1)->m_Cursor);
 					}
 					else
@@ -399,7 +399,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 						UI()->DoLabelStreamed(*pItem->m_pUIElement->Get(g_OffsetColMap + 0), &Button, pItem->m_aMap, FontSize, -1, Button.w, 1, true, (int)(pStr - pItem->m_aMap));
 						TextRender()->TextColor(0.4f, 0.4f, 1.0f, 1);
 						UI()->DoLabelStreamed(*pItem->m_pUIElement->Get(g_OffsetColMap + 1), &Button, pStr, FontSize, -1, Button.w, 1, true, (int)str_length(g_Config.m_BrFilterString), &pItem->m_pUIElement->Get(g_OffsetColMap + 0)->m_Cursor);
-						TextRender()->TextColor(1, 1, 1, 1);
+						TextRender()->TextColor(CUI::ms_DefaultTextColor);
 						UI()->DoLabelStreamed(*pItem->m_pUIElement->Get(g_OffsetColMap + 2), &Button, pStr + str_length(g_Config.m_BrFilterString), FontSize, -1, Button.w, 1, true, -1, &pItem->m_pUIElement->Get(g_OffsetColMap + 1)->m_Cursor);
 					}
 					else
@@ -424,7 +424,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 					TextRender()->TextColor(0.4f, 0.4f, 1.0f, 1);
 				float FontSize = 12.0f * UI()->Scale();
 				UI()->DoLabelStreamed(*pItem->m_pUIElement->Get(g_OffsetColPlayers), &Button, aTemp, FontSize, 1, -1, 1, false);
-				TextRender()->TextColor(1, 1, 1, 1);
+				TextRender()->TextColor(CUI::ms_DefaultTextColor);
 			}
 			else if(ID == COL_PING)
 			{
@@ -437,7 +437,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 
 				float FontSize = 12.0f * UI()->Scale();
 				UI()->DoLabelStreamed(*pItem->m_pUIElement->Get(g_OffsetColPing), &Button, aTemp, FontSize, 1, -1, 1, false);
-				TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
+				TextRender()->TextColor(CUI::ms_DefaultTextColor);
 			}
 			else if(ID == COL_VERSION)
 			{
@@ -471,7 +471,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 					ColorRGBA rgb = color_cast<ColorRGBA>(hsl);
 					TextRender()->TextColor(rgb);
 					UI()->DoLabelStreamed(*pItem->m_pUIElement->Get(g_OffsetColGameType), &Button, pItem->m_aGameType, FontSize, -1, Button.w, 1, true);
-					TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
+					TextRender()->TextColor(CUI::ms_DefaultTextColor);
 				}
 				else
 					UI()->DoLabelStreamed(*pItem->m_pUIElement->Get(g_OffsetColGameType), &Button, pItem->m_aGameType, FontSize, -1, Button.w, 1, true);
@@ -900,7 +900,7 @@ void CMenus::RenderServerbrowserFilters(CUIRect View)
 
 					TextRender()->TextColor(1.0f, 1.0f, 1.0f, Active ? 1.0f : 0.2f);
 					UI()->DoLabelScaled(&Rect, pName, FontSize, 0);
-					TextRender()->TextColor(1.0, 1.0, 1.0, 1.0f);
+					TextRender()->TextColor(CUI::ms_DefaultTextColor);
 				}
 			}
 		}
@@ -1178,7 +1178,7 @@ void CMenus::RenderServerbrowserServerDetail(CUIRect View)
 					TextRender()->TextEx(&Cursor, pName, (int)(s - pName));
 					TextRender()->TextColor(0.4f, 0.4f, 1.0f, 1.0f);
 					TextRender()->TextEx(&Cursor, s, str_length(g_Config.m_BrFilterString));
-					TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
+					TextRender()->TextColor(CUI::ms_DefaultTextColor);
 					TextRender()->TextEx(&Cursor, s + str_length(g_Config.m_BrFilterString), -1);
 				}
 				else
@@ -1200,7 +1200,7 @@ void CMenus::RenderServerbrowserServerDetail(CUIRect View)
 					TextRender()->TextEx(&Cursor, pClan, (int)(s - pClan));
 					TextRender()->TextColor(0.4f, 0.4f, 1.0f, 1.0f);
 					TextRender()->TextEx(&Cursor, s, str_length(g_Config.m_BrFilterString));
-					TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
+					TextRender()->TextColor(CUI::ms_DefaultTextColor);
 					TextRender()->TextEx(&Cursor, s + str_length(g_Config.m_BrFilterString), -1);
 				}
 				else

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -1134,7 +1134,7 @@ void CMenus::RenderGhost(CUIRect MainView)
 			}
 		}
 
-		TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
+		TextRender()->TextColor(CUI::ms_DefaultTextColor);
 	}
 
 	UI()->ClipDisable();

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -1640,7 +1640,7 @@ void CMenus::RenderSettings(CUIRect MainView)
 	{
 		TextRender()->TextColor(1.0f, 0.4f, 0.4f, 1.0f);
 		UI()->DoLabelScaled(&RestartWarning, Localize("DDNet Client needs to be restarted to complete update!"), 14.0f, -1);
-		TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
+		TextRender()->TextColor(CUI::ms_DefaultTextColor);
 	}
 	else if(m_NeedRestartGeneral || m_NeedRestartSkins || m_NeedRestartGraphics || m_NeedRestartSound || m_NeedRestartDDNet)
 		UI()->DoLabelScaled(&RestartWarning, Localize("You must restart the game for all settings to take effect."), 14.0f, -1);
@@ -2309,7 +2309,7 @@ void CMenus::RenderSettingsHUD(CUIRect MainView)
 	TextRender()->TextEx(&Cursor, "*** Echo command executed", -1);
 	TextRender()->SetCursorPosition(&Cursor, X, Y);
 
-	TextRender()->TextColor(1, 1, 1, 1);
+	TextRender()->TextColor(CUI::ms_DefaultTextColor);
 }
 
 void CMenus::RenderSettingsDDNet(CUIRect MainView)
@@ -2614,7 +2614,7 @@ void CMenus::RenderSettingsDDNet(CUIRect MainView)
 			}
 		}
 		UI()->DoLabelScaled(&Label, aBuf, 14.0f, -1);
-		TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
+		TextRender()->TextColor(CUI::ms_DefaultTextColor);
 	}
 #endif
 }

--- a/src/game/client/components/menus_start.cpp
+++ b/src/game/client/components/menus_start.cpp
@@ -202,7 +202,7 @@ void CMenus::RenderStartMenu(CUIRect MainView)
 		TextRender()->TextColor(1.0f, 0.4f, 0.4f, 1.0f);
 	}
 	UI()->DoLabel(&VersionUpdate, aBuf, 14.0f, -1);
-	TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
+	TextRender()->TextColor(CUI::ms_DefaultTextColor);
 
 	VersionUpdate.VSplitLeft(TextRender()->TextWidth(0, 14.0f, aBuf, -1, -1.0f) + 10.0f, 0, &Part);
 
@@ -243,9 +243,9 @@ void CMenus::RenderStartMenu(CUIRect MainView)
 	{
 		char aBuf[64];
 		str_format(aBuf, sizeof(aBuf), Localize("DDNet %s is out!"), Client()->LatestVersion());
-		TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
+		TextRender()->TextColor(CUI::ms_DefaultTextColor);
 		UI()->DoLabel(&VersionUpdate, aBuf, 14.0f, 0);
-		TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
+		TextRender()->TextColor(CUI::ms_DefaultTextColor);
 	}
 #endif
 

--- a/src/game/client/components/scoreboard.cpp
+++ b/src/game/client/components/scoreboard.cpp
@@ -141,7 +141,7 @@ void CScoreboard::RenderSpectators(float x, float y, float w)
 			TextRender()->TextEx(&Cursor, aBuffer, size);
 		}
 		TextRender()->TextEx(&Cursor, m_pClient->m_aClients[pInfo->m_ClientID].m_aName, -1);
-		TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
+		TextRender()->TextColor(CUI::ms_DefaultTextColor);
 
 		Multiple = true;
 	}
@@ -501,14 +501,14 @@ void CScoreboard::RenderScoreboard(float x, float y, float w, int Team, const ch
 			TextRender()->TextColor(Color);
 		}
 		else
-			TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
+			TextRender()->TextColor(CUI::ms_DefaultTextColor);
 
 		tw = minimum(TextRender()->TextWidth(nullptr, FontSize, m_pClient->m_aClients[pInfo->m_ClientID].m_aClan, -1, -1.0f), ClanLength);
 		TextRender()->SetCursor(&Cursor, ClanOffset + (ClanLength - tw) / 2, y + (LineHeight - FontSize) / 2.f, FontSize, TEXTFLAG_RENDER | TEXTFLAG_STOP_AT_END);
 		Cursor.m_LineWidth = ClanLength;
 		TextRender()->TextEx(&Cursor, m_pClient->m_aClients[pInfo->m_ClientID].m_aClan, -1);
 
-		TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
+		TextRender()->TextColor(CUI::ms_DefaultTextColor);
 
 		// country flag
 		ColorRGBA Color(1.0f, 1.0f, 1.0f, 0.5f);
@@ -527,7 +527,7 @@ void CScoreboard::RenderScoreboard(float x, float y, float w, int Team, const ch
 		Cursor.m_LineWidth = PingLength;
 		TextRender()->TextEx(&Cursor, aBuf, -1);
 
-		TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
+		TextRender()->TextColor(CUI::ms_DefaultTextColor);
 
 		y += LineHeight + Spacing;
 		if(lower32 || upper32)

--- a/src/game/client/components/spectator.cpp
+++ b/src/game/client/components/spectator.cpp
@@ -281,7 +281,7 @@ void CSpectator::OnRender()
 		m_SelectedSpectatorID = SPEC_FREEVIEW;
 		Selected = true;
 	}
-	TextRender()->TextColor(1.0f, 1.0f, 1.0f, Selected ? 1.0f : 0.5f);
+	TextRender()->TextColor(Selected ? CUI::ms_DefaultTextColor : CUI::ms_TransparentTextColor);
 	TextRender()->Text(0, Width / 2.0f - (ObjWidth - 60.0f), Height / 2.0f - 280.f + (60.f - BigFontSize) / 2.f, BigFontSize, Localize("Free-View"), -1.0f);
 
 	if(Client()->State() == IClient::STATE_DEMOPLAYBACK)
@@ -293,7 +293,7 @@ void CSpectator::OnRender()
 			m_SelectedSpectatorID = SPEC_FOLLOW;
 			Selected = true;
 		}
-		TextRender()->TextColor(1.0f, 1.0f, 1.0f, Selected ? 1.0f : 0.5f);
+		TextRender()->TextColor(Selected ? CUI::ms_DefaultTextColor : CUI::ms_TransparentTextColor);
 		TextRender()->Text(0, Width / 2.0f - (ObjWidth - 350.0f), Height / 2.0f - 280.0f + (60.f - BigFontSize) / 2.f, BigFontSize, Localize("Follow"), -1.0f);
 	}
 
@@ -389,7 +389,7 @@ void CSpectator::OnRender()
 		}
 		else
 		{
-			TextRender()->TextColor(1.0f, 1.0f, 1.0f, Selected ? 1.0f : 0.5f);
+			TextRender()->TextColor(Selected ? CUI::ms_DefaultTextColor : CUI::ms_TransparentTextColor);
 			TeeAlpha = 1.0f;
 		}
 		TextRender()->Text(0, Width / 2.0f + x + 50.0f, Height / 2.0f + y + BoxMove + (LineHeight - FontSize) / 2.f, FontSize, m_pClient->m_aClients[m_pClient->m_Snap.m_paInfoByDDTeamName[i]->m_ClientID].m_aName, 220.0f);
@@ -428,12 +428,12 @@ void CSpectator::OnRender()
 			ColorRGBA rgb = color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClMessageFriendColor));
 			TextRender()->TextColor(rgb.WithAlpha(1.f));
 			TextRender()->Text(0, Width / 2.0f + x - TeeInfo.m_Size / 2.0f, Height / 2.0f + y + BoxMove + (LineHeight - FontSize) / 2.f, FontSize, "♥", 220.0f);
-			TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
+			TextRender()->TextColor(CUI::ms_DefaultTextColor);
 		}
 
 		y += LineHeight;
 	}
-	TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
+	TextRender()->TextColor(CUI::ms_DefaultTextColor);
 
 	// draw cursor
 	Graphics()->WrapClamp();

--- a/src/game/client/render_map.cpp
+++ b/src/game/client/render_map.cpp
@@ -475,7 +475,7 @@ void CRenderTools::RenderTeleOverlay(CTeleTile *pTele, int w, int h, float Scale
 				str_format(aBuf, sizeof(aBuf), "%d", Index);
 				UI()->TextRender()->TextColor(1.0f, 1.0f, 1.0f, Alpha);
 				UI()->TextRender()->Text(0, mx * Scale - 3.f, (my + ToCenterOffset) * Scale, Size * Scale, aBuf, -1.0f);
-				UI()->TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
+				UI()->TextRender()->TextColor(CUI::ms_DefaultTextColor);
 			}
 		}
 
@@ -537,13 +537,13 @@ void CRenderTools::RenderSpeedupOverlay(CSpeedupTile *pSpeedup, int w, int h, fl
 					str_format(aBuf, sizeof(aBuf), "%d", Force);
 					UI()->TextRender()->TextColor(1.0f, 1.0f, 1.0f, Alpha);
 					UI()->TextRender()->Text(0, mx * Scale, (my + 0.5f + ToCenterOffset / 2) * Scale, Size * Scale / 2.f, aBuf, -1.0f);
-					UI()->TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
+					UI()->TextRender()->TextColor(CUI::ms_DefaultTextColor);
 					if(MaxSpeed)
 					{
 						str_format(aBuf, sizeof(aBuf), "%d", MaxSpeed);
 						UI()->TextRender()->TextColor(1.0f, 1.0f, 1.0f, Alpha);
 						UI()->TextRender()->Text(0, mx * Scale, (my + ToCenterOffset / 2) * Scale, Size * Scale / 2.f, aBuf, -1.0f);
-						UI()->TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
+						UI()->TextRender()->TextColor(CUI::ms_DefaultTextColor);
 					}
 				}
 			}
@@ -594,7 +594,7 @@ void CRenderTools::RenderSwitchOverlay(CSwitchTile *pSwitch, int w, int h, float
 				str_format(aBuf, sizeof(aBuf), "%d", Index);
 				UI()->TextRender()->TextColor(1.0f, 1.0f, 1.0f, Alpha);
 				UI()->TextRender()->Text(0, mx * Scale, (my + ToCenterOffset / 2) * Scale, Size * Scale / 2.f, aBuf, -1.0f);
-				UI()->TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
+				UI()->TextRender()->TextColor(CUI::ms_DefaultTextColor);
 			}
 
 			unsigned char Delay = pSwitch[c].m_Delay;
@@ -604,7 +604,7 @@ void CRenderTools::RenderSwitchOverlay(CSwitchTile *pSwitch, int w, int h, float
 				str_format(aBuf, sizeof(aBuf), "%d", Delay);
 				UI()->TextRender()->TextColor(1.0f, 1.0f, 1.0f, Alpha);
 				UI()->TextRender()->Text(0, mx * Scale, (my + 0.5f + ToCenterOffset / 2) * Scale, Size * Scale / 2.f, aBuf, -1.0f);
-				UI()->TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
+				UI()->TextRender()->TextColor(CUI::ms_DefaultTextColor);
 			}
 		}
 
@@ -653,7 +653,7 @@ void CRenderTools::RenderTuneOverlay(CTuneTile *pTune, int w, int h, float Scale
 				str_format(aBuf, sizeof(aBuf), "%d", Index);
 				UI()->TextRender()->TextColor(1.0f, 1.0f, 1.0f, Alpha);
 				UI()->TextRender()->Text(0, mx * Scale + 11.f, my * Scale + 6.f, Size * Scale / 1.5f - 5.f, aBuf, -1.0f); // numbers shouldn't be too big and in the center of the tile
-				UI()->TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
+				UI()->TextRender()->TextColor(CUI::ms_DefaultTextColor);
 			}
 		}
 

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -25,6 +25,9 @@ CUIElement::SUIElementRect::SUIElementRect() :
  UI
 *********************************************************/
 
+const vec4 CUI::ms_DefaultTextColor(1.0f, 1.0f, 1.0f, 1.0f);
+const vec4 CUI::ms_TransparentTextColor(1.0f, 1.0f, 1.0f, 0.5f);
+
 CUI::CUI()
 {
 	m_pHotItem = 0;

--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -196,6 +196,9 @@ class CUI
 	std::vector<CUIElement *> m_UIElements;
 
 public:
+	static const vec4 ms_DefaultTextColor;
+	static const vec4 ms_TransparentTextColor;
+
 	// TODO: Refactor: Fill this in
 	void SetGraphics(class IGraphics *pGraphics, class ITextRender *pTextRender)
 	{

--- a/src/game/client/ui_ex.cpp
+++ b/src/game/client/ui_ex.cpp
@@ -242,7 +242,7 @@ int CUIEx::DoEditBox(void *pID, const CUIRect *pRect, char *pStr, unsigned StrSi
 
 	UI()->DoLabel(&Textbox, pDisplayStr, FontSize, -1);
 
-	TextRender()->TextColor(1, 1, 1, 1);
+	TextRender()->TextColor(CUI::ms_DefaultTextColor);
 
 	float ScreenX0, ScreenY0, ScreenX1, ScreenY1;
 	Graphics()->GetScreen(&ScreenX0, &ScreenY0, &ScreenX1, &ScreenY1);

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -5766,7 +5766,7 @@ void CEditor::Render()
 
 		TextRender()->TextColor(1.0f, 0.0f, 0.0f, 1.0f);
 		TextRender()->Text(0, 5.0f, 27.0f, 10.0f, aBuf, -1.0f);
-		TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
+		TextRender()->TextColor(CUI::ms_DefaultTextColor);
 	}
 
 	// do the toolbar

--- a/src/game/editor/layer_tiles.cpp
+++ b/src/game/editor/layer_tiles.cpp
@@ -1012,7 +1012,7 @@ int CLayerTiles::RenderCommonProperties(SCommonPropState &State, CEditor *pEdito
 
 		pEditor->TextRender()->TextColor(ColorRGBA(1.0f, 0.0f, 0.0f, 1.0f));
 		pEditor->UI()->DoLabel(&Warning, "Editing multiple layers", 9.0f, -1, Warning.w);
-		pEditor->TextRender()->TextColor(ColorRGBA(1.0f, 1.0f, 1.0f, 1.0f));
+		pEditor->TextRender()->TextColor(ColorRGBA(CUI::ms_DefaultTextColor));
 		pToolbox->HSplitTop(2.0f, 0, pToolbox);
 	}
 


### PR DESCRIPTION
add text and outline color constants, fix reset after loading
https://github.com/teeworlds/teeworlds/commit/f81eaa9d09c9c4066c05ccb8b55fbe09861c4e64

Use consistent text transparency
https://github.com/teeworlds/teeworlds/commit/d28782d169f0d7831754ec8d7b5f616d658e8c3b

One less undefined constant when stealing upstream code :)

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
