### PR TITLE
Use GL_ARRAY_BUFFER

### DIFF
--- a/src/engine/client/backend/opengl/backend_opengl.cpp
+++ b/src/engine/client/backend/opengl/backend_opengl.cpp
@@ -1834,9 +1834,9 @@ void CCommandProcessorFragment_OpenGL2::Cmd_CreateBufferObject(const CCommandBuf
 	if(m_HasShaders)
 	{
 		glGenBuffers(1, &VertBufferID);
-		glBindBuffer(GL_COPY_WRITE_BUFFER, VertBufferID);
-		glBufferData(GL_COPY_WRITE_BUFFER, (GLsizeiptr)(pCommand->m_DataSize), pUploadData, GL_STATIC_DRAW);
-		glBindBuffer(GL_COPY_WRITE_BUFFER, 0);
+		glBindBuffer(GL_ARRAY_BUFFER, VertBufferID);
+		glBufferData(GL_ARRAY_BUFFER, (GLsizeiptr)(pCommand->m_DataSize), pUploadData, GL_STATIC_DRAW);
+		glBindBuffer(GL_ARRAY_BUFFER, 0);
 	}
 
 	SBufferObject &BufferObject = m_BufferObjectIndices[Index];
@@ -1858,9 +1858,9 @@ void CCommandProcessorFragment_OpenGL2::Cmd_RecreateBufferObject(const CCommandB
 
 	if(m_HasShaders)
 	{
-		glBindBuffer(GL_COPY_WRITE_BUFFER, BufferObject.m_BufferObjectID);
-		glBufferData(GL_COPY_WRITE_BUFFER, (GLsizeiptr)(pCommand->m_DataSize), pUploadData, GL_STATIC_DRAW);
-		glBindBuffer(GL_COPY_WRITE_BUFFER, 0);
+		glBindBuffer(GL_ARRAY_BUFFER, BufferObject.m_BufferObjectID);
+		glBufferData(GL_ARRAY_BUFFER, (GLsizeiptr)(pCommand->m_DataSize), pUploadData, GL_STATIC_DRAW);
+		glBindBuffer(GL_ARRAY_BUFFER, 0);
 	}
 
 	BufferObject.m_DataSize = pCommand->m_DataSize;
@@ -1882,9 +1882,9 @@ void CCommandProcessorFragment_OpenGL2::Cmd_UpdateBufferObject(const CCommandBuf
 
 	if(m_HasShaders)
 	{
-		glBindBuffer(GL_COPY_WRITE_BUFFER, BufferObject.m_BufferObjectID);
-		glBufferSubData(GL_COPY_WRITE_BUFFER, (GLintptr)(pCommand->m_pOffset), (GLsizeiptr)(pCommand->m_DataSize), pUploadData);
-		glBindBuffer(GL_COPY_WRITE_BUFFER, 0);
+		glBindBuffer(GL_ARRAY_BUFFER, BufferObject.m_BufferObjectID);
+		glBufferSubData(GL_ARRAY_BUFFER, (GLintptr)(pCommand->m_pOffset), (GLsizeiptr)(pCommand->m_DataSize), pUploadData);
+		glBindBuffer(GL_ARRAY_BUFFER, 0);
 	}
 
 	if(pUploadData)
@@ -1906,9 +1906,9 @@ void CCommandProcessorFragment_OpenGL2::Cmd_CopyBufferObject(const CCommandBuffe
 
 	if(m_HasShaders)
 	{
-		glBindBuffer(GL_COPY_WRITE_BUFFER, WriteBufferObject.m_BufferObjectID);
-		glBufferSubData(GL_COPY_WRITE_BUFFER, (GLintptr)(pCommand->m_pWriteOffset), (GLsizeiptr)(pCommand->m_CopySize), ((uint8_t *)WriteBufferObject.m_pData) + (ptrdiff_t)pCommand->m_pWriteOffset);
-		glBindBuffer(GL_COPY_WRITE_BUFFER, 0);
+		glBindBuffer(GL_ARRAY_BUFFER, WriteBufferObject.m_BufferObjectID);
+		glBufferSubData(GL_ARRAY_BUFFER, (GLintptr)(pCommand->m_pWriteOffset), (GLsizeiptr)(pCommand->m_CopySize), ((uint8_t *)WriteBufferObject.m_pData) + (ptrdiff_t)pCommand->m_pWriteOffset);
+		glBindBuffer(GL_ARRAY_BUFFER, 0);
 	}
 }
 


### PR DESCRIPTION
For older OpenGL contexts

@Learath2 can you check this?

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
