### PR TITLE
Add /team -1

### DIFF
--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -1034,6 +1034,9 @@ void CGameContext::ConJoinTeam(IConsole::IResult *pResult, void *pUserData)
 		{
 			int Team = pResult->GetInteger(0);
 
+			if(Team < 0 || Team >= MAX_CLIENTS )
+				Team = pController->m_Teams.GetFirstEmptyTeam();
+
 			if(pPlayer->m_Last_Team + (int64_t)pSelf->Server()->TickSpeed() * g_Config.m_SvTeamChangeDelay > pSelf->Server()->Tick())
 			{
 				pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "join",

--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -1034,7 +1034,7 @@ void CGameContext::ConJoinTeam(IConsole::IResult *pResult, void *pUserData)
 		{
 			int Team = pResult->GetInteger(0);
 
-			if(Team < 0 || Team >= MAX_CLIENTS )
+			if(Team < 0 || Team >= MAX_CLIENTS)
 				Team = pController->m_Teams.GetFirstEmptyTeam();
 
 			if(pPlayer->m_Last_Team + (int64_t)pSelf->Server()->TickSpeed() * g_Config.m_SvTeamChangeDelay > pSelf->Server()->Tick())

--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -1073,7 +1073,7 @@ void CGameTeams::ResetSavedTeam(int ClientID, int Team)
 	}
 }
 
-int CGameTeams::GetFirstEmptyTeam()
+int CGameTeams::GetFirstEmptyTeam() const
 {
 	for(int i = 1; i < MAX_CLIENTS; i++)
 		if(m_TeamState[i] == TEAMSTATE_EMPTY)

--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -1072,3 +1072,11 @@ void CGameTeams::ResetSavedTeam(int ClientID, int Team)
 		}
 	}
 }
+
+int CGameTeams::GetFirstEmptyTeam()
+{
+	for(int i = 1; i < MAX_CLIENTS; i++)
+		if(m_TeamState[i] == TEAMSTATE_EMPTY)
+			return i;
+	return -1;
+}

--- a/src/game/server/teams.h
+++ b/src/game/server/teams.h
@@ -111,6 +111,8 @@ public:
 	void SwapTeamCharacters(CPlayer *pPlayer, CPlayer *pTargetPlayer, int Team);
 	void ProcessSaveTeam();
 
+	int GetFirstEmptyTeam() const;
+
 	bool TeeStarted(int ClientID)
 	{
 		return m_TeeStarted[ClientID];


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request -->

## Checklist
In addition for #4005.

Now /team -1 forces player to first empty team.

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
