### PR TITLE
Make fallback stronger and safer

### DIFF
--- a/src/engine/client/backend/opengl/backend_opengl.cpp
+++ b/src/engine/client/backend/opengl/backend_opengl.cpp
@@ -1741,12 +1741,14 @@ bool CCommandProcessorFragment_OpenGL2::Cmd_Init(const SCommand_Init *pCommand)
 			glUseProgram(0);
 		}
 
-		if(g_Config.m_Gfx3DTextureAnalysisDone == 0)
+		if(g_Config.m_Gfx3DTextureAnalysisDone == 0 || str_comp(g_Config.m_Gfx3DTextureAnalysisRenderer, pCommand->m_pRendererString) != 0 || str_comp(g_Config.m_Gfx3DTextureAnalysisVersion, pCommand->m_pVersionString) != 0)
 		{
 			AnalysisCorrect = IsTileMapAnalysisSucceeded();
 			if(AnalysisCorrect)
 			{
 				g_Config.m_Gfx3DTextureAnalysisDone = 1;
+				str_copy(g_Config.m_Gfx3DTextureAnalysisRenderer, pCommand->m_pRendererString, sizeof(g_Config.m_Gfx3DTextureAnalysisRenderer) / sizeof(g_Config.m_Gfx3DTextureAnalysisRenderer[0]));
+				str_copy(g_Config.m_Gfx3DTextureAnalysisVersion, pCommand->m_pVersionString, sizeof(g_Config.m_Gfx3DTextureAnalysisVersion) / sizeof(g_Config.m_Gfx3DTextureAnalysisVersion[0]));
 			}
 		}
 	}

--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -347,6 +347,8 @@ static bool BackendInitGlew(EBackendType BackendType, int &GlewMajor, int &GlewM
 			GlewPatch = 0;
 			return true;
 		}
+// Don't allow GL 3.3, if the driver doesn't support atleast OpenGL 4.5
+#ifndef CONF_PLATFORM_WINDOWS
 		if(GLEW_VERSION_4_4)
 		{
 			GlewMajor = 4;
@@ -389,6 +391,7 @@ static bool BackendInitGlew(EBackendType BackendType, int &GlewMajor, int &GlewM
 			GlewPatch = 0;
 			return true;
 		}
+#endif
 		if(GLEW_VERSION_3_0)
 		{
 			GlewMajor = 3;

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -403,6 +403,9 @@ MACRO_CONFIG_INT(GfxOpenGLPatch, gfx_opengl_patch, 0, 0, 10, CFGFLAG_SAVE | CFGF
 MACRO_CONFIG_INT(GfxOpenGLTextureLODBIAS, gfx_opengl_texture_lod_bias, -500, -15000, 15000, CFGFLAG_SAVE | CFGFLAG_CLIENT, "The lod bias for OpenGL texture sampling multiplied by 1000")
 
 MACRO_CONFIG_INT(Gfx3DTextureAnalysisDone, gfx_3d_texture_analysis_done, 0, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Analyzed, if sampling 3D/2D array textures was correct")
+MACRO_CONFIG_STR(Gfx3DTextureAnalysisRenderer, gfx_3d_texture_analysis_renderer, 128, "", CFGFLAG_SAVE | CFGFLAG_CLIENT, "The renderer on which the analysis was performed")
+MACRO_CONFIG_STR(Gfx3DTextureAnalysisVersion, gfx_3d_texture_analysis_version, 128, "", CFGFLAG_SAVE | CFGFLAG_CLIENT, "The version on which the analysis was performed")
+
 MACRO_CONFIG_INT(GfxDriverIsBlocked, gfx_driver_is_blocked, 0, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "If 1, the current driver is in a blocked error state.")
 #if !defined(CONF_PLATFORM_MACOS)
 MACRO_CONFIG_INT(GfxEnableTextureUnitOptimization, gfx_enable_texture_unit_optimization, 1, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Use multiple texture units, instead of only one.")

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -1197,38 +1197,43 @@ void CMenus::RenderSettingsGraphics(CUIRect MainView)
 	if(DoButton_CheckBox(&g_Config.m_GfxHighDetail, Localize("High Detail"), g_Config.m_GfxHighDetail, &Button))
 		g_Config.m_GfxHighDetail ^= 1;
 
-	MainView.HSplitTop(20.0f, &Button, &MainView);
 	bool IsNewOpenGL = Graphics()->IsConfigModernAPI();
 
-	if(DoButton_CheckBox(&g_Config.m_GfxOpenGLMajor, Localize("Use modern OpenGL"), IsNewOpenGL, &Button))
+	// only promote modern GL in menu settings if the driver isn't on the blocklist already
+	if(g_Config.m_GfxDriverIsBlocked == 0)
 	{
-		CheckSettings = true;
+		MainView.HSplitTop(20.0f, &Button, &MainView);
+
+		if(DoButton_CheckBox(&g_Config.m_GfxOpenGLMajor, Localize("Use modern OpenGL"), IsNewOpenGL, &Button))
+		{
+			CheckSettings = true;
+			if(IsNewOpenGL)
+			{
+				Graphics()->GetDriverVersion(GRAPHICS_DRIVER_AGE_TYPE_DEFAULT, g_Config.m_GfxOpenGLMajor, g_Config.m_GfxOpenGLMinor, g_Config.m_GfxOpenGLPatch);
+				IsNewOpenGL = false;
+			}
+			else
+			{
+				Graphics()->GetDriverVersion(GRAPHICS_DRIVER_AGE_TYPE_MODERN, g_Config.m_GfxOpenGLMajor, g_Config.m_GfxOpenGLMinor, g_Config.m_GfxOpenGLPatch);
+				IsNewOpenGL = true;
+			}
+		}
+
 		if(IsNewOpenGL)
 		{
-			Graphics()->GetDriverVersion(GRAPHICS_DRIVER_AGE_TYPE_DEFAULT, g_Config.m_GfxOpenGLMajor, g_Config.m_GfxOpenGLMinor, g_Config.m_GfxOpenGLPatch);
-			IsNewOpenGL = false;
-		}
-		else
-		{
-			Graphics()->GetDriverVersion(GRAPHICS_DRIVER_AGE_TYPE_MODERN, g_Config.m_GfxOpenGLMajor, g_Config.m_GfxOpenGLMinor, g_Config.m_GfxOpenGLPatch);
-			IsNewOpenGL = true;
-		}
-	}
+			MainView.HSplitTop(20.0f, &Button, &MainView);
+			if(DoButton_CheckBox(&g_Config.m_GfxUsePreinitBuffer, Localize("Preinit VBO (iGPUs only)"), g_Config.m_GfxUsePreinitBuffer, &Button))
+			{
+				CheckSettings = true;
+				g_Config.m_GfxUsePreinitBuffer ^= 1;
+			}
 
-	if(IsNewOpenGL)
-	{
-		MainView.HSplitTop(20.0f, &Button, &MainView);
-		if(DoButton_CheckBox(&g_Config.m_GfxUsePreinitBuffer, Localize("Preinit VBO (iGPUs only)"), g_Config.m_GfxUsePreinitBuffer, &Button))
-		{
-			CheckSettings = true;
-			g_Config.m_GfxUsePreinitBuffer ^= 1;
-		}
-
-		MainView.HSplitTop(20.0f, &Button, &MainView);
-		if(DoButton_CheckBox(&g_Config.m_GfxEnableTextureUnitOptimization, Localize("Multiple texture units (disable for macOS)"), g_Config.m_GfxEnableTextureUnitOptimization, &Button))
-		{
-			CheckSettings = true;
-			g_Config.m_GfxEnableTextureUnitOptimization ^= 1;
+			MainView.HSplitTop(20.0f, &Button, &MainView);
+			if(DoButton_CheckBox(&g_Config.m_GfxEnableTextureUnitOptimization, Localize("Multiple texture units (disable for macOS)"), g_Config.m_GfxEnableTextureUnitOptimization, &Button))
+			{
+				CheckSettings = true;
+				g_Config.m_GfxEnableTextureUnitOptimization ^= 1;
+			}
 		}
 	}
 


### PR DESCRIPTION
- Save renderer & version string, so the fallback isn't portable between driver updates or system changes
- Only allow modern GL on modern systems(windows)
- Don't show modern GL in settings, if the driver is on the blocklist(this prevents Intel users from doing it, they can still force it over F1 console)

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
