### PR TITLE
[Concept] Add new mouse state (ingame mouse)

### DIFF
--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -895,9 +895,6 @@ int CGraphicsBackend_SDL_OpenGL::Init(const char *pName, int *pScreen, int *pWid
 		SDL_GL_SetAttribute(SDL_GL_MULTISAMPLESAMPLES, 0);
 	}
 
-	if(g_Config.m_InpMouseOld)
-		SDL_SetHint(SDL_HINT_MOUSE_RELATIVE_MODE_WARP, "1");
-
 	m_pWindow = SDL_CreateWindow(
 		pName,
 		SDL_WINDOWPOS_CENTERED_DISPLAY(*pScreen),
@@ -1215,6 +1212,11 @@ void CGraphicsBackend_SDL_OpenGL::NotifyWindow()
 		return;
 	}
 #endif
+}
+
+void CGraphicsBackend_SDL_OpenGL::WarpMouse(int MouseX, int MouseY)
+{
+	SDL_WarpMouseInWindow(m_pWindow, MouseX, MouseY);
 }
 
 IGraphicsBackend *CreateGraphicsBackend() { return new CGraphicsBackend_SDL_OpenGL; }

--- a/src/engine/client/backend_sdl.h
+++ b/src/engine/client/backend_sdl.h
@@ -257,6 +257,7 @@ public:
 	virtual void ResizeWindow(int w, int h, int RefreshRate);
 	virtual void GetViewportSize(int &w, int &h);
 	virtual void NotifyWindow();
+	virtual void WarpMouse(int MouseX, int MouseY);
 
 	virtual void GetDriverVersion(EGraphicsDriverAgeType DriverAgeType, int &Major, int &Minor, int &Patch);
 	virtual bool IsConfigModernAPI() { return IsModernAPI(m_BackendType); }

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -3254,7 +3254,6 @@ void CClient::Run()
 		if(CtrlShiftKey(KEY_E, LastE))
 		{
 			g_Config.m_ClEditor = g_Config.m_ClEditor ^ 1;
-			Input()->MouseModeRelative();
 			Input()->SetIMEState(true);
 		}
 
@@ -3264,7 +3263,6 @@ void CClient::Run()
 			{
 				if(!m_EditorActive)
 				{
-					Input()->MouseModeRelative();
 					GameClient()->OnActivateEditor();
 					m_pEditor->ResetMentions();
 					m_EditorActive = true;

--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -2430,6 +2430,11 @@ void CGraphics_Threaded::NotifyWindow()
 	return m_pBackend->NotifyWindow();
 }
 
+void CGraphics_Threaded::WarpMouse(int MouseX, int MouseY)
+{
+	return m_pBackend->WarpMouse(MouseX, MouseY);
+}
+
 void CGraphics_Threaded::TakeScreenshot(const char *pFilename)
 {
 	// TODO: screenshot support

--- a/src/engine/client/graphics_threaded.h
+++ b/src/engine/client/graphics_threaded.h
@@ -678,6 +678,7 @@ public:
 	virtual void ResizeWindow(int w, int h, int RefreshRate) = 0;
 	virtual void GetViewportSize(int &w, int &h) = 0;
 	virtual void NotifyWindow() = 0;
+	virtual void WarpMouse(int MouseX, int MouseY) = 0;
 
 	virtual void RunBuffer(CCommandBuffer *pBuffer) = 0;
 	virtual bool IsIdle() const = 0;
@@ -1178,6 +1179,7 @@ public:
 
 	void SetWindowGrab(bool Grab) override;
 	void NotifyWindow() override;
+	void WarpMouse(int MouseX, int MouseY) override;
 
 	int Init() override;
 	void Shutdown() override;

--- a/src/engine/client/graphics_threaded_null.h
+++ b/src/engine/client/graphics_threaded_null.h
@@ -162,6 +162,8 @@ public:
 	void SetWindowGrab(bool Grab) override{};
 	void NotifyWindow() override{};
 
+	void WarpMouse(int MouseX, int MouseY) override {}
+
 	int Init() override { return 0; };
 	void Shutdown() override{};
 

--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -8,6 +8,9 @@
 #include <engine/keys.h>
 #include <engine/shared/config.h>
 
+#include "SDL_mouse.h"
+#include "SDL_video.h"
+
 #include "input.h"
 
 //print >>f, "int inp_key_code(const char *key_name) { int i; if (!strcmp(key_name, \"-?-\")) return -1; else for (i = 0; i < 512; i++) if (!strcmp(key_strings[i], key_name)) return i; return -1; }"
@@ -38,7 +41,6 @@ CInput::CInput()
 	mem_zero(m_aInputState, sizeof(m_aInputState));
 
 	m_InputCounter = 1;
-	m_InputGrabbed = 0;
 
 	m_LastRelease = 0;
 	m_ReleaseDelta = -1;
@@ -52,9 +54,6 @@ CInput::CInput()
 	m_NumTextInputInstances = 0;
 	m_EditingTextLen = -1;
 	m_aEditingText[0] = 0;
-
-	m_LastX = 0;
-	m_LastY = 0;
 }
 
 void CInput::Init()
@@ -66,10 +65,10 @@ void CInput::Init()
 	MouseModeRelative();
 }
 
-void CInput::MouseRelative(float *x, float *y)
+bool CInput::MouseRelative(float *x, float *y)
 {
-	if(!m_MouseFocus || !m_InputGrabbed)
-		return;
+	if(!m_MouseFocus || GetMouseMode() != INPUT_MOUSE_MODE_RELATIVE)
+		return false;
 
 	int nx = 0, ny = 0;
 	float Sens = g_Config.m_InpMousesens / 100.0f;
@@ -89,24 +88,142 @@ void CInput::MouseRelative(float *x, float *y)
 
 	*x = nx * Sens;
 	*y = ny * Sens;
+
+	return true;
 }
 
-void CInput::MouseModeAbsolute()
+bool CInput::MouseDesktopRelative(int *x, int *y)
 {
-	m_InputGrabbed = 0;
-	SDL_SetRelativeMouseMode(SDL_FALSE);
-	Graphics()->SetWindowGrab(false);
+	if(!m_MouseFocus || GetMouseMode() != INPUT_MOUSE_MODE_INGAME_RELATIVE)
+		return false;
+
+	SDL_GetRelativeMouseState(x, y);
+
+	return true;
 }
 
-void CInput::MouseModeRelative()
+bool CInput::MouseAbsolute(int *x, int *y)
 {
-	m_InputGrabbed = 1;
-#if !defined(CONF_PLATFORM_ANDROID) // No relative mouse on Android
-	SDL_SetRelativeMouseMode(SDL_TRUE);
+	if(!m_MouseFocus || (GetMouseMode() != INPUT_MOUSE_MODE_INGAME && GetMouseMode() != INPUT_MOUSE_MODE_ABSOLUTE))
+		return false;
+
+	SDL_GetMouseState(x, y);
+
+	m_DesktopX = *x;
+	m_DesktopY = *y;
+
+	return true;
+}
+
+void CInput::MouseModeChange(EInputMouseMode OldState, EInputMouseMode NewState)
+{
+	if(g_Config.m_InpMouseOld && (NewState == EInputMouseMode::INPUT_MOUSE_MODE_RELATIVE))
+		SDL_SetHintWithPriority(SDL_HINT_MOUSE_RELATIVE_MODE_WARP, "1", SDL_HINT_OVERRIDE);
+	else
+		SDL_SetHintWithPriority(SDL_HINT_MOUSE_RELATIVE_MODE_WARP, "0", SDL_HINT_OVERRIDE);
+}
+
+bool CInput::MouseModeAbsolute()
+{
+	if(GetMouseMode() != INPUT_MOUSE_MODE_ABSOLUTE)
+	{
+		MouseModeChange(GetMouseMode(), INPUT_MOUSE_MODE_ABSOLUTE);
+		SetMouseMode(INPUT_MOUSE_MODE_ABSOLUTE);
+		SDL_SetRelativeMouseMode(SDL_FALSE);
+		Graphics()->SetWindowGrab(false);
+
+		SDL_ShowCursor(true);
+
+		return true;
+	}
+
+	return false;
+}
+
+bool CInput::MouseModeRelative()
+{
+	if(GetMouseMode() != INPUT_MOUSE_MODE_RELATIVE)
+	{
+		EInputMouseMode OldMode = GetMouseMode();
+		MouseModeChange(OldMode, INPUT_MOUSE_MODE_RELATIVE);
+		// turn off relative mouse to trigger the SDL hints
+// TODO: remove this once SDL fixes mouse grabbing in macos @see MouseModeInGame
+#ifdef CONF_PLATFORM_MACOS
+		if(OldMode != INPUT_MOUSE_MODE_ABSOLUTE)
+#else
+		if(OldMode == INPUT_MOUSE_MODE_INGAME_RELATIVE)
 #endif
+			SDL_SetRelativeMouseMode(SDL_FALSE);
+		SetMouseMode(INPUT_MOUSE_MODE_RELATIVE);
+		SDL_SetRelativeMouseMode(SDL_TRUE);
+		Graphics()->SetWindowGrab(true);
+		// Clear pending relative mouse motion
+		SDL_GetRelativeMouseState(0x0, 0x0);
+
+		return true;
+	}
+
+	return false;
+}
+
+void CInput::MouseModeInGameRelativeImpl()
+{
+	SDL_SetHintWithPriority(SDL_HINT_MOUSE_RELATIVE_MODE_WARP, "1", SDL_HINT_OVERRIDE);
+	SDL_SetRelativeMouseMode(SDL_TRUE);
 	Graphics()->SetWindowGrab(true);
-	// Clear pending relative mouse motion
 	SDL_GetRelativeMouseState(0x0, 0x0);
+}
+
+bool CInput::MouseModeInGame(int *pDesiredX, int *pDesiredY)
+{
+	if(GetMouseMode() != INPUT_MOUSE_MODE_INGAME)
+	{
+		EInputMouseMode OldMode = GetMouseMode();
+		MouseModeChange(OldMode, INPUT_MOUSE_MODE_INGAME);
+		SetMouseMode(INPUT_MOUSE_MODE_INGAME);
+
+// TODO: remove this once SDL fixes mouse grabbing in macos (https://github.com/libsdl-org/SDL/commit/2fdbae22cb2f75643447c34d2dab7f15305e3567)
+#ifdef CONF_PLATFORM_MACOS
+		// turn off relative mouse to trigger the SDL hints
+		if(OldMode == INPUT_MOUSE_MODE_RELATIVE)
+			SDL_SetRelativeMouseMode(SDL_FALSE);
+		MouseModeInGameRelativeImpl();
+#else
+		SDL_SetRelativeMouseMode(SDL_FALSE);
+		Graphics()->SetWindowGrab(true);
+		SDL_ShowCursor(false);
+#endif
+
+		if(OldMode == INPUT_MOUSE_MODE_RELATIVE || OldMode == INPUT_MOUSE_MODE_INGAME_RELATIVE)
+		{
+			int WarpX = pDesiredX ? *pDesiredX : m_DesktopX;
+			int WarpY = pDesiredY ? *pDesiredY : m_DesktopY;
+			Graphics()->WarpMouse(WarpX, WarpY);
+		}
+
+		return true;
+	}
+
+	return false;
+}
+
+bool CInput::MouseModeInGameRelative()
+{
+	if(GetMouseMode() != INPUT_MOUSE_MODE_INGAME_RELATIVE)
+	{
+		EInputMouseMode OldMode = GetMouseMode();
+		MouseModeChange(OldMode, INPUT_MOUSE_MODE_INGAME_RELATIVE);
+		// turn off relative mouse to trigger the SDL hints
+		if(OldMode == INPUT_MOUSE_MODE_RELATIVE)
+			SDL_SetRelativeMouseMode(SDL_FALSE);
+		SetMouseMode(INPUT_MOUSE_MODE_INGAME_RELATIVE);
+
+		MouseModeInGameRelativeImpl();
+
+		return true;
+	}
+
+	return false;
 }
 
 void CInput::NativeMousePos(int *x, int *y) const
@@ -364,29 +481,25 @@ int CInput::Update()
 					Graphics()->Resize(Event.window.data1, Event.window.data2, -1);
 					break;
 				case SDL_WINDOWEVENT_FOCUS_GAINED:
-					if(m_InputGrabbed)
-						MouseModeRelative();
+					if(GetMouseMode() != INPUT_MOUSE_MODE_ABSOLUTE)
+					{
+						SDL_ShowCursor(SDL_FALSE);
+					}
 					m_MouseFocus = true;
 					IgnoreKeys = true;
 					break;
 				case SDL_WINDOWEVENT_FOCUS_LOST:
 					m_MouseFocus = false;
 					IgnoreKeys = true;
-					if(m_InputGrabbed)
+					if(GetMouseMode() != INPUT_MOUSE_MODE_ABSOLUTE)
 					{
-						MouseModeAbsolute();
-						// Remember that we had relative mouse
-						m_InputGrabbed = true;
+						SDL_ShowCursor(SDL_TRUE);
 					}
 					break;
 				case SDL_WINDOWEVENT_MINIMIZED:
 					Graphics()->WindowDestroyNtf(Event.window.windowID);
 					break;
 				case SDL_WINDOWEVENT_MAXIMIZED:
-#if defined(CONF_PLATFORM_MACOS) // Todo: remove this when fixed in SDL
-					MouseModeAbsolute();
-					MouseModeRelative();
-#endif
 					// fallthrough
 				case SDL_WINDOWEVENT_RESTORED:
 					Graphics()->WindowCreateNtf(Event.window.windowID);

--- a/src/engine/client/input.h
+++ b/src/engine/client/input.h
@@ -12,10 +12,6 @@ class CInput : public IEngineInput
 {
 	IEngineGraphics *m_pGraphics;
 
-	int m_LastX;
-	int m_LastY;
-
-	int m_InputGrabbed;
 	char *m_pClipboardText;
 
 	int64_t m_LastRelease;
@@ -39,9 +35,14 @@ class CInput : public IEngineInput
 	int m_EditingTextLen;
 	int m_EditingCursor;
 
+	int m_DesktopX = 0;
+	int m_DesktopY = 0;
+
 	bool KeyState(int Key) const;
 
 	IEngineGraphics *Graphics() { return m_pGraphics; }
+
+	void MouseModeInGameRelativeImpl();
 
 public:
 	CInput();
@@ -51,11 +52,19 @@ public:
 	bool KeyIsPressed(int Key) const { return KeyState(Key); }
 	bool KeyPress(int Key, bool CheckCounter) const { return CheckCounter ? (m_aInputCount[Key] == m_InputCounter) : m_aInputCount[Key]; }
 
-	virtual void MouseRelative(float *x, float *y);
-	virtual void MouseModeAbsolute();
-	virtual void MouseModeRelative();
 	virtual void NativeMousePos(int *x, int *y) const;
 	virtual bool NativeMousePressed(int index);
+	virtual bool MouseRelative(float *x, float *y);
+	virtual bool MouseDesktopRelative(int *x, int *y);
+	virtual bool MouseAbsolute(int *x, int *y);
+
+	// return true if the mode was changed
+	virtual void MouseModeChange(EInputMouseMode OldState, EInputMouseMode NewState);
+	virtual bool MouseModeAbsolute();
+	virtual bool MouseModeRelative();
+	virtual bool MouseModeInGame(int *pDesiredX = NULL, int *pDesiredY = NULL);
+	virtual bool MouseModeInGameRelative();
+
 	virtual int MouseDoubleClick();
 	virtual const char *GetClipboardText();
 	virtual void SetClipboardText(const char *Text);

--- a/src/engine/graphics.h
+++ b/src/engine/graphics.h
@@ -410,6 +410,8 @@ public:
 	virtual void SetWindowGrab(bool Grab) = 0;
 	virtual void NotifyWindow() = 0;
 
+	virtual void WarpMouse(int MouseX, int MouseY) = 0;
+
 	virtual SWarning *GetCurWarning() = 0;
 
 protected:

--- a/src/engine/input.h
+++ b/src/engine/input.h
@@ -8,6 +8,18 @@
 const int g_MaxKeys = 512;
 extern const char g_aaKeyStrings[g_MaxKeys][20];
 
+enum EInputMouseMode
+{
+	// Use absolute mouse mode, doesn't grab the mouse inside the window and uses desktop cursor coordinates
+	INPUT_MOUSE_MODE_ABSOLUTE = 0,
+	// Use relative mouse mode, does grab the mouse inside the window and uses mouse driver coordinates(except if mouse old)
+	INPUT_MOUSE_MODE_RELATIVE,
+	// Use ingame mouse mode, does grab the mouse inside the window, but uses uses desktop cursor coordinates
+	INPUT_MOUSE_MODE_INGAME,
+	// Use ingame mouse mode, does grab the mouse inside the window, but uses uses desktop cursor coordinates, but is relative
+	INPUT_MOUSE_MODE_INGAME_RELATIVE,
+};
+
 class IInput : public IInterface
 {
 	MACRO_INTERFACE("input", 0)
@@ -36,6 +48,8 @@ protected:
 	int m_NumEvents;
 	IInput::CEvent m_aInputEvents[INPUT_BUFFER_SIZE];
 
+	EInputMouseMode m_MouseMode = INPUT_MOUSE_MODE_ABSOLUTE;
+
 public:
 	enum
 	{
@@ -44,6 +58,9 @@ public:
 		FLAG_REPEAT = 4,
 		FLAG_TEXT = 8,
 	};
+
+	EInputMouseMode GetMouseMode() { return m_MouseMode; };
+	void SetMouseMode(EInputMouseMode NewMode) { m_MouseMode = NewMode; };
 
 	// events
 	int NumEvents() const { return m_NumEvents; }
@@ -68,15 +85,22 @@ public:
 	virtual void Clear() = 0;
 
 	//
-	virtual void NativeMousePos(int *mx, int *my) const = 0;
+	virtual void NativeMousePos(int *x, int *y) const = 0;
 	virtual bool NativeMousePressed(int index) = 0;
-	virtual void MouseModeRelative() = 0;
-	virtual void MouseModeAbsolute() = 0;
+	// return true if the mode was changed
+	virtual bool MouseModeRelative() = 0;
+	virtual bool MouseModeAbsolute() = 0;
+	virtual bool MouseModeInGame(int *pDesiredX = NULL, int *pDesiredY = NULL) = 0;
+	virtual bool MouseModeInGameRelative() = 0;
+
 	virtual int MouseDoubleClick() = 0;
 	virtual const char *GetClipboardText() = 0;
 	virtual void SetClipboardText(const char *Text) = 0;
 
-	virtual void MouseRelative(float *x, float *y) = 0;
+	// return true if there was a mouse input
+	virtual bool MouseAbsolute(int *x, int *y) = 0;
+	virtual bool MouseDesktopRelative(int *x, int *y) = 0;
+	virtual bool MouseRelative(float *x, float *y) = 0;
 
 	virtual bool GetIMEState() = 0;
 	virtual void SetIMEState(bool Activate) = 0;

--- a/src/game/client/component.h
+++ b/src/game/client/component.h
@@ -18,6 +18,16 @@
 
 class CGameClient;
 
+enum EComponentMouseMovementBlockMode
+{
+	COMPONENT_MOUSE_MOVEMENT_BLOCK_MODE_DONT_BLOCK = 0,
+	COMPONENT_MOUSE_MOVEMENT_BLOCK_MODE_BLOCK,
+	COMPONENT_MOUSE_MOVEMENT_BLOCK_MODE_BLOCK_AND_CHANGE_TO_INGAME,
+	COMPONENT_MOUSE_MOVEMENT_BLOCK_MODE_BLOCK_AND_CHANGE_TO_INGAME_RELATIVE,
+	COMPONENT_MOUSE_MOVEMENT_BLOCK_MODE_BLOCK_AND_CHANGE_TO_RELATIVE,
+	COMPONENT_MOUSE_MOVEMENT_BLOCK_MODE_BLOCK_AND_CHANGE_TO_ABSOLUTE,
+};
+
 /**
 * This class is inherited by all the client components.
 *
@@ -192,12 +202,38 @@ public:
 	 */
 	virtual void OnMessage(int Msg, void *pRawMsg) {}
 	/**
-	 * Called on mouse movement, where the x and y values are deltas.
+	 * Called on mouse movement, where the x and y values are the desktop cursor coordinates relative to the window rect.
+	 *
+	 * @param x The x relative coordinate of the desktop cursor inside the window rect.
+	 * @param y The y relative coordinate of the desktop cursor inside the window rect.
+	 * @return Returns how to block the mouse for components that are called after the current component. Can also be used to change the mouse mode to a desired mode.
+	 */
+	virtual EComponentMouseMovementBlockMode OnMouseInWindowPos(int X, int Y) { return COMPONENT_MOUSE_MOVEMENT_BLOCK_MODE_DONT_BLOCK; }
+	/**
+	 * Called on absolute mouse movement, where the x and y values are the desktop cursor coordinates relative to the window rect.
+	 * It's similar to @see OnMouseInWindowPos, but does not grab the mouse inside the window and also shows the desktop cursor
+	 *
+	 * @param x The x relative coordinate of the desktop cursor inside the window rect.
+	 * @param y The y relative coordinate of the desktop cursor inside the window rect.
+	 * @return Returns how to block the mouse for components that are called after the current component. Can also be used to change the mouse mode to a desired mode.
+	 */
+	virtual EComponentMouseMovementBlockMode OnMouseAbsoluteInWindowPos(int X, int Y) { return COMPONENT_MOUSE_MOVEMENT_BLOCK_MODE_DONT_BLOCK; }
+	/**
+	 * Called on relative mouse movement, where the x and y values are deltas of the desktop cursor.
 	 *
 	 * @param x The amount of change in the x coordinate since the last call.
 	 * @param y The amount of change in the y coordinate since the last call.
+	 * @return Returns how to block the mouse for components that are called after the current component. Can also be used to change the mouse mode to a desired mode.
 	 */
-	virtual bool OnMouseMove(float x, float y) { return false; }
+	virtual EComponentMouseMovementBlockMode OnMouseInWindowRelativeMove(int X, int Y) { return COMPONENT_MOUSE_MOVEMENT_BLOCK_MODE_DONT_BLOCK; }
+	/**
+	 * Called on relative mouse movement, where the x and y values are deltas.
+	 *
+	 * @param x The amount of change in the x coordinate since the last call.
+	 * @param y The amount of change in the y coordinate since the last call.
+	 * @return Returns how to block the mouse for components that are called after the current component. Can also be used to change the mouse mode to a desired mode.
+	 */
+	virtual EComponentMouseMovementBlockMode OnMouseRelativeMove(float x, float y) { return COMPONENT_MOUSE_MOVEMENT_BLOCK_MODE_DONT_BLOCK; }
 	/**
 	 * Called on a input event.
 	 * @param e The input event.

--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -701,14 +701,14 @@ void CGameConsole::OnRender()
 				{
 					m_MouseIsPress = true;
 					Input()->NativeMousePos(&m_MousePressX, &m_MousePressY);
-					m_MousePressX = (m_MousePressX / (float)Graphics()->ScreenWidth()) * Screen.w;
-					m_MousePressY = (m_MousePressY / (float)Graphics()->ScreenHeight()) * Screen.h;
+					m_MousePressX = (m_MousePressX / (float)Graphics()->WindowWidth()) * Screen.w;
+					m_MousePressY = (m_MousePressY / (float)Graphics()->WindowHeight()) * Screen.h;
 				}
 				if(m_MouseIsPress)
 				{
 					Input()->NativeMousePos(&m_MouseCurX, &m_MouseCurY);
-					m_MouseCurX = (m_MouseCurX / (float)Graphics()->ScreenWidth()) * Screen.w;
-					m_MouseCurY = (m_MouseCurY / (float)Graphics()->ScreenHeight()) * Screen.h;
+					m_MouseCurX = (m_MouseCurX / (float)Graphics()->WindowWidth()) * Screen.w;
+					m_MouseCurY = (m_MouseCurY / (float)Graphics()->WindowHeight()) * Screen.h;
 				}
 				if(m_MouseIsPress && !Input()->NativeMousePressed(1))
 				{
@@ -839,7 +839,6 @@ void CGameConsole::Toggle(int Type)
 
 		if(m_ConsoleState == CONSOLE_CLOSED || m_ConsoleState == CONSOLE_CLOSING)
 		{
-			/*Input()->MouseModeAbsolute();*/
 			m_pClient->m_Menus.UseMouseButtons(false);
 			m_ConsoleState = CONSOLE_OPENING;
 			/*// reset controls
@@ -849,7 +848,6 @@ void CGameConsole::Toggle(int Type)
 		}
 		else
 		{
-			Input()->MouseModeRelative();
 			m_pClient->m_Menus.UseMouseButtons(true);
 			m_pClient->OnRelease();
 			m_ConsoleState = CONSOLE_CLOSING;

--- a/src/game/client/components/console.h
+++ b/src/game/client/components/console.h
@@ -109,6 +109,8 @@ class CGameConsole : public CComponent
 	static void ConConsolePageDown(IConsole::IResult *pResult, void *pUserData);
 	static void ConchainConsoleOutputLevelUpdate(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 
+	EComponentMouseMovementBlockMode OnConsoleMouseFeedback() { return m_ConsoleState == CONSOLE_OPEN ? COMPONENT_MOUSE_MOVEMENT_BLOCK_MODE_BLOCK : COMPONENT_MOUSE_MOVEMENT_BLOCK_MODE_DONT_BLOCK; }
+
 public:
 	enum
 	{
@@ -129,5 +131,10 @@ public:
 	virtual bool OnInput(IInput::CEvent Events);
 
 	bool IsClosed() { return m_ConsoleState == CONSOLE_CLOSED; }
+
+	virtual EComponentMouseMovementBlockMode OnMouseInWindowPos(int X, int Y) { return OnConsoleMouseFeedback(); }
+	virtual EComponentMouseMovementBlockMode OnMouseAbsoluteInWindowPos(int X, int Y) { return OnConsoleMouseFeedback(); }
+	virtual EComponentMouseMovementBlockMode OnMouseInWindowRelativeMove(int X, int Y) { return OnConsoleMouseFeedback(); }
+	virtual EComponentMouseMovementBlockMode OnMouseRelativeMove(float RelX, float RelY) { return OnConsoleMouseFeedback(); }
 };
 #endif

--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -534,27 +534,50 @@ void CControls::OnRender()
 		m_TargetPos[g_Config.m_ClDummy] = m_MousePos[g_Config.m_ClDummy];
 }
 
-bool CControls::OnMouseMove(float x, float y)
+EComponentMouseMovementBlockMode CControls::OnMouseWrongStateImpl()
 {
 	if((m_pClient->m_Snap.m_pGameInfoObj && m_pClient->m_Snap.m_pGameInfoObj->m_GameStateFlags & GAMESTATEFLAG_PAUSED))
-		return false;
+		return COMPONENT_MOUSE_MOVEMENT_BLOCK_MODE_DONT_BLOCK;
+
+	return COMPONENT_MOUSE_MOVEMENT_BLOCK_MODE_BLOCK_AND_CHANGE_TO_RELATIVE;
+}
+
+EComponentMouseMovementBlockMode CControls::OnMouseInWindowPos(int X, int Y)
+{
+	return OnMouseWrongStateImpl();
+}
+
+EComponentMouseMovementBlockMode CControls::OnMouseAbsoluteInWindowPos(int X, int Y)
+{
+	return OnMouseWrongStateImpl();
+}
+
+EComponentMouseMovementBlockMode CControls::OnMouseInWindowRelativeMove(int X, int Y)
+{
+	return OnMouseWrongStateImpl();
+}
+
+EComponentMouseMovementBlockMode CControls::OnMouseRelativeMove(float RelX, float RelY)
+{
+	if((m_pClient->m_Snap.m_pGameInfoObj && m_pClient->m_Snap.m_pGameInfoObj->m_GameStateFlags & GAMESTATEFLAG_PAUSED))
+		return COMPONENT_MOUSE_MOVEMENT_BLOCK_MODE_DONT_BLOCK;
 
 	if(g_Config.m_ClDyncam && g_Config.m_ClDyncamMousesens)
 	{
-		x = x * g_Config.m_ClDyncamMousesens / g_Config.m_InpMousesens;
-		y = y * g_Config.m_ClDyncamMousesens / g_Config.m_InpMousesens;
+		RelX = RelX * g_Config.m_ClDyncamMousesens / g_Config.m_InpMousesens;
+		RelY = RelY * g_Config.m_ClDyncamMousesens / g_Config.m_InpMousesens;
 	}
 
 	if(m_pClient->m_Snap.m_SpecInfo.m_Active && m_pClient->m_Snap.m_SpecInfo.m_SpectatorID < 0)
 	{
-		x = x * m_pClient->m_Camera.m_Zoom;
-		y = y * m_pClient->m_Camera.m_Zoom;
+		RelX = RelX * m_pClient->m_Camera.m_Zoom;
+		RelY = RelY * m_pClient->m_Camera.m_Zoom;
 	}
 
-	m_MousePos[g_Config.m_ClDummy] += vec2(x, y); // TODO: ugly
+	m_MousePos[g_Config.m_ClDummy] += vec2(RelX, RelY); // TODO: ugly
 	ClampMousePos();
 
-	return true;
+	return COMPONENT_MOUSE_MOVEMENT_BLOCK_MODE_BLOCK;
 }
 
 void CControls::ClampMousePos()

--- a/src/game/client/components/controls.h
+++ b/src/game/client/components/controls.h
@@ -11,6 +11,8 @@
 
 class CControls : public CComponent
 {
+	EComponentMouseMovementBlockMode OnMouseWrongStateImpl();
+
 public:
 	vec2 m_MousePos[NUM_DUMMIES];
 	vec2 m_TargetPos[NUM_DUMMIES];
@@ -40,7 +42,12 @@ public:
 	virtual void OnRelease();
 	virtual void OnRender();
 	virtual void OnMessage(int MsgType, void *pRawMsg);
-	virtual bool OnMouseMove(float x, float y);
+
+	virtual EComponentMouseMovementBlockMode OnMouseInWindowPos(int X, int Y);
+	virtual EComponentMouseMovementBlockMode OnMouseAbsoluteInWindowPos(int X, int Y);
+	virtual EComponentMouseMovementBlockMode OnMouseInWindowRelativeMove(int X, int Y);
+	virtual EComponentMouseMovementBlockMode OnMouseRelativeMove(float RelX, float RelY);
+
 	virtual void OnConsoleInit();
 	virtual void OnPlayerDeath();
 

--- a/src/game/client/components/emoticon.cpp
+++ b/src/game/client/components/emoticon.cpp
@@ -8,6 +8,9 @@
 
 #include "chat.h"
 #include "emoticon.h"
+
+#include <game/client/component.h>
+
 #include <game/client/animstate.h>
 #include <game/client/render.h>
 #include <game/client/ui.h>
@@ -51,14 +54,39 @@ void CEmoticon::OnRelease()
 	m_Active = false;
 }
 
-bool CEmoticon::OnMouseMove(float x, float y)
+EComponentMouseMovementBlockMode CEmoticon::OnMouseWrongStateImpl()
 {
 	if(!m_Active)
-		return false;
+		return COMPONENT_MOUSE_MOVEMENT_BLOCK_MODE_DONT_BLOCK;
+	return COMPONENT_MOUSE_MOVEMENT_BLOCK_MODE_BLOCK_AND_CHANGE_TO_INGAME_RELATIVE;
+}
 
-	UI()->ConvertMouseMove(&x, &y);
-	m_SelectorMouse += vec2(x, y);
-	return true;
+EComponentMouseMovementBlockMode CEmoticon::OnMouseInWindowPos(int X, int Y)
+{
+	return OnMouseWrongStateImpl();
+}
+
+EComponentMouseMovementBlockMode CEmoticon::OnMouseAbsoluteInWindowPos(int X, int Y)
+{
+	return OnMouseWrongStateImpl();
+}
+
+EComponentMouseMovementBlockMode CEmoticon::OnMouseInWindowRelativeMove(int X, int Y)
+{
+	if(!m_Active)
+		return COMPONENT_MOUSE_MOVEMENT_BLOCK_MODE_DONT_BLOCK;
+
+	CUIRect *pScreen = UI()->Screen();
+	float TmpX = (X / (float)Graphics()->WindowWidth()) * pScreen->w;
+	float TmpY = (Y / (float)Graphics()->WindowHeight()) * pScreen->h;
+	m_SelectorMouse += vec2(TmpX, TmpY);
+
+	return COMPONENT_MOUSE_MOVEMENT_BLOCK_MODE_BLOCK;
+}
+
+EComponentMouseMovementBlockMode CEmoticon::OnMouseRelativeMove(float x, float y)
+{
+	return OnMouseWrongStateImpl();
 }
 
 void CEmoticon::DrawCircle(float x, float y, float r, int Segments)

--- a/src/game/client/components/emoticon.h
+++ b/src/game/client/components/emoticon.h
@@ -19,6 +19,8 @@ class CEmoticon : public CComponent
 	static void ConKeyEmoticon(IConsole::IResult *pResult, void *pUserData);
 	static void ConEmote(IConsole::IResult *pResult, void *pUserData);
 
+	EComponentMouseMovementBlockMode OnMouseWrongStateImpl();
+
 public:
 	CEmoticon();
 
@@ -26,7 +28,11 @@ public:
 	virtual void OnConsoleInit();
 	virtual void OnRender();
 	virtual void OnRelease();
-	virtual bool OnMouseMove(float x, float y);
+
+	virtual EComponentMouseMovementBlockMode OnMouseInWindowPos(int X, int Y);
+	virtual EComponentMouseMovementBlockMode OnMouseAbsoluteInWindowPos(int X, int Y);
+	virtual EComponentMouseMovementBlockMode OnMouseInWindowRelativeMove(int X, int Y);
+	virtual EComponentMouseMovementBlockMode OnMouseRelativeMove(float x, float y);
 
 	void Emote(int Emote);
 	void EyeEmote(int EyeEmote);

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -37,6 +37,8 @@
 #include <game/localization.h>
 #include <mastersrv/mastersrv.h>
 
+#include <game/client/component.h>
+
 #include "controls.h"
 #include "countryflags.h"
 #include "menus.h"
@@ -654,7 +656,7 @@ float CMenus::DoScrollbarV(const void *pID, const CUIRect *pRect, float Current)
 			UI()->SetActiveItem(0);
 
 		if(Input()->KeyIsPressed(KEY_LSHIFT) || Input()->KeyIsPressed(KEY_RSHIFT))
-			m_MouseSlow = true;
+			SetMouseSlow(true);
 
 		float Min = pRect->y;
 		float Max = pRect->h - Handle.h;
@@ -712,7 +714,7 @@ float CMenus::DoScrollbarH(const void *pID, const CUIRect *pRect, float Current,
 			UI()->SetActiveItem(0);
 
 		if(Input()->KeyIsPressed(KEY_LSHIFT) || Input()->KeyIsPressed(KEY_RSHIFT))
-			m_MouseSlow = true;
+			SetMouseSlow(true);
 
 		float Min = pRect->x;
 		float Max = pRect->w - Handle.w;
@@ -1453,7 +1455,8 @@ int CMenus::Render()
 	CUIRect Screen = *UI()->Screen();
 	UI()->MapScreen();
 
-	m_MouseSlow = false;
+	if((!Input()->KeyIsPressed(KEY_LSHIFT) && !Input()->KeyIsPressed(KEY_RSHIFT)) || UI()->ActiveItem() == nullptr)
+		SetMouseSlow(false);
 
 	static int s_Frame = 0;
 	if(s_Frame == 0)
@@ -2550,26 +2553,59 @@ void CMenus::OnReset()
 {
 }
 
-bool CMenus::OnMouseMove(float x, float y)
+EComponentMouseMovementBlockMode CMenus::OnMouseInWindowPos(int X, int Y)
 {
 	if(!m_MenuActive)
-		return false;
+		return COMPONENT_MOUSE_MOVEMENT_BLOCK_MODE_DONT_BLOCK;
 
-	UI()->ConvertMouseMove(&x, &y);
 	if(m_MouseSlow)
+		return COMPONENT_MOUSE_MOVEMENT_BLOCK_MODE_BLOCK_AND_CHANGE_TO_INGAME_RELATIVE;
+	else
 	{
-		m_MousePos.x += x * 0.05f;
-		m_MousePos.y += y * 0.05f;
+		m_MousePos.x = clamp<float>(X, 0.f, (float)Graphics()->WindowWidth());
+		m_MousePos.y = clamp<float>(Y, 0.f, (float)Graphics()->WindowHeight());
+	}
+	return COMPONENT_MOUSE_MOVEMENT_BLOCK_MODE_BLOCK;
+}
+
+EComponentMouseMovementBlockMode CMenus::OnMouseAbsoluteInWindowPos(int X, int Y)
+{
+	if(!m_MenuActive)
+		return COMPONENT_MOUSE_MOVEMENT_BLOCK_MODE_DONT_BLOCK;
+
+	if(!m_MouseSlow)
+		return COMPONENT_MOUSE_MOVEMENT_BLOCK_MODE_BLOCK_AND_CHANGE_TO_INGAME;
+	else
+		return COMPONENT_MOUSE_MOVEMENT_BLOCK_MODE_BLOCK_AND_CHANGE_TO_INGAME_RELATIVE;
+}
+
+EComponentMouseMovementBlockMode CMenus::OnMouseInWindowRelativeMove(int X, int Y)
+{
+	if(!m_MenuActive)
+		return COMPONENT_MOUSE_MOVEMENT_BLOCK_MODE_DONT_BLOCK;
+
+	if(!m_MouseSlow)
+	{
+		return COMPONENT_MOUSE_MOVEMENT_BLOCK_MODE_BLOCK_AND_CHANGE_TO_INGAME;
 	}
 	else
 	{
-		m_MousePos.x += x;
-		m_MousePos.y += y;
+		m_MousePos.x = clamp<float>(m_MousePos.x + X * 0.05f, 0.f, (float)Graphics()->WindowWidth());
+		m_MousePos.y = clamp<float>(m_MousePos.y + Y * 0.05f, 0.f, (float)Graphics()->WindowHeight());
 	}
-	m_MousePos.x = clamp(m_MousePos.x, 0.f, (float)Graphics()->ScreenWidth());
-	m_MousePos.y = clamp(m_MousePos.y, 0.f, (float)Graphics()->ScreenHeight());
 
-	return true;
+	return COMPONENT_MOUSE_MOVEMENT_BLOCK_MODE_BLOCK;
+}
+
+EComponentMouseMovementBlockMode CMenus::OnMouseRelativeMove(float x, float y)
+{
+	if(!m_MenuActive)
+		return COMPONENT_MOUSE_MOVEMENT_BLOCK_MODE_DONT_BLOCK;
+
+	if(!m_MouseSlow)
+		return COMPONENT_MOUSE_MOVEMENT_BLOCK_MODE_BLOCK_AND_CHANGE_TO_INGAME;
+	else
+		return COMPONENT_MOUSE_MOVEMENT_BLOCK_MODE_BLOCK_AND_CHANGE_TO_INGAME_RELATIVE;
 }
 
 bool CMenus::OnInput(IInput::CEvent e)
@@ -2645,6 +2681,24 @@ void CMenus::OnStateChange(int NewState, int OldState)
 	}
 }
 
+void CMenus::SetMouseSlow(bool SetVal)
+{
+	if(m_MouseSlow != SetVal)
+	{
+		m_MouseSlow = SetVal;
+		if(SetVal)
+		{
+			Input()->MouseModeInGameRelative();
+		}
+		else
+		{
+			int CursorX = (int)m_MousePos.x;
+			int CursorY = (int)m_MousePos.y;
+			Input()->MouseModeInGame(&CursorX, &CursorY);
+		}
+	}
+}
+
 void CMenus::OnRender()
 {
 	if(Client()->State() != IClient::STATE_ONLINE && Client()->State() != IClient::STATE_DEMOPLAYBACK)
@@ -2698,8 +2752,8 @@ void CMenus::OnRender()
 
 	// update the ui
 	CUIRect *pScreen = UI()->Screen();
-	float mx = (m_MousePos.x / (float)Graphics()->ScreenWidth()) * pScreen->w;
-	float my = (m_MousePos.y / (float)Graphics()->ScreenHeight()) * pScreen->h;
+	float mx = (m_MousePos.x / (float)Graphics()->WindowWidth()) * pScreen->w;
+	float my = (m_MousePos.y / (float)Graphics()->WindowHeight()) * pScreen->h;
 
 	int Buttons = 0;
 	if(m_UseMouseButtons)

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -289,6 +289,8 @@ protected:
 	vec2 m_MousePos;
 	bool m_MouseSlow;
 
+	void SetMouseSlow(bool SetVal);
+
 	char m_aNextServer[256];
 
 	// images
@@ -551,7 +553,10 @@ public:
 	virtual void OnReset();
 	virtual void OnRender();
 	virtual bool OnInput(IInput::CEvent Event);
-	virtual bool OnMouseMove(float x, float y);
+	virtual EComponentMouseMovementBlockMode OnMouseInWindowPos(int X, int Y);
+	virtual EComponentMouseMovementBlockMode OnMouseAbsoluteInWindowPos(int X, int Y);
+	virtual EComponentMouseMovementBlockMode OnMouseInWindowRelativeMove(int X, int Y);
+	virtual EComponentMouseMovementBlockMode OnMouseRelativeMove(float x, float y);
 
 	enum
 	{

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -935,19 +935,6 @@ void CMenus::RenderSettingsControls(CUIRect MainView)
 			MovementSettings.HSplitTop(20.0f, 0, &MovementSettings);
 		}
 
-		{
-			CUIRect Button, Label;
-			MovementSettings.HSplitTop(20.0f, &Button, &MovementSettings);
-			Button.VSplitLeft(160.0f, &Label, &Button);
-			str_format(aBuf, sizeof(aBuf), "%s: %i", Localize("UI mouse s."), g_Config.m_UiMousesens);
-			UI()->DoLabel(&Label, aBuf, 14.0f * UI()->Scale(), -1);
-			Button.HMargin(2.0f, &Button);
-			int NewValue = (int)(DoScrollbarH(&g_Config.m_UiMousesens, &Button, (minimum(g_Config.m_UiMousesens, 500) - 1) / 500.0f) * 500.0f) + 1;
-			if(g_Config.m_UiMousesens < 500 || NewValue < 500)
-				g_Config.m_UiMousesens = minimum(NewValue, 500);
-			MovementSettings.HSplitTop(20.0f, 0, &MovementSettings);
-		}
-
 		UiDoGetButtons(0, 15, MovementSettings, MainView);
 	}
 
@@ -2378,9 +2365,6 @@ void CMenus::RenderSettingsDDNet(CUIRect MainView)
 {
 	CUIRect Button, Left, Right, LeftLeft, Demo, Gameplay, Miscellaneous, Label, Background;
 
-	bool CheckSettings = false;
-	static int s_InpMouseOld = g_Config.m_InpMouseOld;
-
 	MainView.HSplitTop(100.0f, &Demo, &MainView);
 
 	Demo.HSplitTop(30.0f, &Label, &Demo);
@@ -2577,11 +2561,7 @@ void CMenus::RenderSettingsDDNet(CUIRect MainView)
 	if(DoButton_CheckBox(&g_Config.m_InpMouseOld, Localize("Old mouse mode"), g_Config.m_InpMouseOld, &Button))
 	{
 		g_Config.m_InpMouseOld ^= 1;
-		CheckSettings = true;
 	}
-
-	if(CheckSettings)
-		m_NeedRestartDDNet = s_InpMouseOld != g_Config.m_InpMouseOld;
 
 	Left.HSplitTop(5.0f, &Button, &Left);
 	Right.HSplitTop(25.0f, &Button, &Right);

--- a/src/game/client/components/menus_start.cpp
+++ b/src/game/client/components/menus_start.cpp
@@ -138,7 +138,6 @@ void CMenus::RenderStartMenu(CUIRect MainView)
 	if(DoButton_Menu(&s_MapEditorButton, Localize("Editor"), 0, &Button, g_Config.m_ClShowStartMenuImages ? "editor" : 0, CUI::CORNER_ALL, Rounding, 0.5f, vec4(0.0f, 0.0f, 0.0f, 0.5f), m_pClient->Editor()->HasUnsavedData() ? vec4(0.0f, 1.0f, 0.0f, 0.25f) : vec4(0.0f, 0.0f, 0.0f, 0.25f)) || (!EditorHotkeyWasPressed && Client()->LocalTime() - EditorHotKeyChecktime < 0.1f && CheckHotKey(KEY_E)))
 	{
 		g_Config.m_ClEditor = 1;
-		Input()->MouseModeRelative();
 		EditorHotkeyWasPressed = true;
 	}
 	if(!Input()->KeyIsPressed(KEY_E))

--- a/src/game/client/components/spectator.h
+++ b/src/game/client/components/spectator.h
@@ -19,9 +19,6 @@ class CSpectator : public CComponent
 	int m_SelectedSpectatorID;
 	vec2 m_SelectorMouse;
 
-	float m_OldMouseX;
-	float m_OldMouseY;
-
 	bool CanChangeSpectator();
 	void SpectateNext(bool Reverse);
 
@@ -31,11 +28,16 @@ class CSpectator : public CComponent
 	static void ConSpectatePrevious(IConsole::IResult *pResult, void *pUserData);
 	static void ConSpectateClosest(IConsole::IResult *pResult, void *pUserData);
 
+	EComponentMouseMovementBlockMode OnMouseWrongStateImpl();
+
 public:
 	CSpectator();
 
 	virtual void OnConsoleInit();
-	virtual bool OnMouseMove(float x, float y);
+	virtual EComponentMouseMovementBlockMode OnMouseInWindowPos(int X, int Y);
+	virtual EComponentMouseMovementBlockMode OnMouseAbsoluteInWindowPos(int X, int Y);
+	virtual EComponentMouseMovementBlockMode OnMouseInWindowRelativeMove(int X, int Y);
+	virtual EComponentMouseMovementBlockMode OnMouseRelativeMove(float x, float y);
 	virtual void OnRender();
 	virtual void OnRelease();
 	virtual void OnReset();

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -24,6 +24,10 @@
 #include <base/math.h>
 #include <base/vmath.h>
 
+#include <engine/input.h>
+
+#include <game/client/component.h>
+
 #include "race.h"
 #include "render.h"
 #include <game/localization.h>
@@ -326,13 +330,54 @@ void CGameClient::OnUpdate()
 {
 	// handle mouse movement
 	float x = 0.0f, y = 0.0f;
-	Input()->MouseRelative(&x, &y);
-	if(x != 0.0f || y != 0.0f)
+	int PosX = 0, PosY = 0;
+	bool GotInput = false;
+	if(Input()->GetMouseMode() == INPUT_MOUSE_MODE_RELATIVE)
+	{
+		GotInput = Input()->MouseRelative(&x, &y);
+	}
+	else if(Input()->GetMouseMode() == INPUT_MOUSE_MODE_INGAME_RELATIVE)
+	{
+		GotInput = Input()->MouseDesktopRelative(&PosX, &PosY);
+	}
+	else
+	{
+		GotInput = Input()->MouseAbsolute(&PosX, &PosY);
+	}
+	if(GotInput)
 	{
 		for(int h = 0; h < m_Input.m_Num; h++)
 		{
-			if(m_Input.m_paComponents[h]->OnMouseMove(x, y))
+			EComponentMouseMovementBlockMode CompBreak = COMPONENT_MOUSE_MOVEMENT_BLOCK_MODE_DONT_BLOCK;
+			if(Input()->GetMouseMode() == INPUT_MOUSE_MODE_RELATIVE)
+				CompBreak = m_Input.m_paComponents[h]->OnMouseRelativeMove(x, y);
+			else if(Input()->GetMouseMode() == INPUT_MOUSE_MODE_INGAME_RELATIVE)
+				CompBreak = m_Input.m_paComponents[h]->OnMouseInWindowRelativeMove(PosX, PosY);
+			else if(Input()->GetMouseMode() == INPUT_MOUSE_MODE_INGAME)
+				CompBreak = m_Input.m_paComponents[h]->OnMouseInWindowPos(PosX, PosY);
+			else if(Input()->GetMouseMode() == INPUT_MOUSE_MODE_ABSOLUTE)
+				CompBreak = m_Input.m_paComponents[h]->OnMouseAbsoluteInWindowPos(PosX, PosY);
+			if(CompBreak != COMPONENT_MOUSE_MOVEMENT_BLOCK_MODE_DONT_BLOCK)
+			{
+				switch(CompBreak)
+				{
+				case COMPONENT_MOUSE_MOVEMENT_BLOCK_MODE_BLOCK_AND_CHANGE_TO_INGAME:
+					Input()->MouseModeInGame();
+					break;
+				case COMPONENT_MOUSE_MOVEMENT_BLOCK_MODE_BLOCK_AND_CHANGE_TO_INGAME_RELATIVE:
+					Input()->MouseModeInGameRelative();
+					break;
+				case COMPONENT_MOUSE_MOVEMENT_BLOCK_MODE_BLOCK_AND_CHANGE_TO_RELATIVE:
+					Input()->MouseModeRelative();
+					break;
+				case COMPONENT_MOUSE_MOVEMENT_BLOCK_MODE_BLOCK_AND_CHANGE_TO_ABSOLUTE:
+					Input()->MouseModeAbsolute();
+					break;
+				default:
+					break;
+				}
 				break;
+			}
 		}
 	}
 

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -142,13 +142,6 @@ int CUI::MouseInside(const CUIRect *r) const
 	return 0;
 }
 
-void CUI::ConvertMouseMove(float *x, float *y) const
-{
-	float Fac = (float)(g_Config.m_UiMousesens) / g_Config.m_InpMousesens;
-	*x = *x * Fac;
-	*y = *y * Fac;
-}
-
 CUIRect *CUI::Screen()
 {
 	float Aspect = Graphics()->ScreenAspect();

--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -257,7 +257,6 @@ public:
 	const void *LastActiveItem() const { return m_pLastActiveItem; }
 
 	int MouseInside(const CUIRect *pRect) const;
-	void ConvertMouseMove(float *x, float *y) const;
 
 	CUIRect *Screen();
 	void MapScreen();

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -634,7 +634,7 @@ int CEditor::UiDoValueSelector(void *pID, CUIRect *pRect, const char *pLabel, in
 	{
 		if(!UI()->MouseButton(0))
 		{
-			m_LockMouse = false;
+			SetLockMouse(false);
 			UI()->SetActiveItem(0);
 			s_TextMode = false;
 		}
@@ -656,14 +656,14 @@ int CEditor::UiDoValueSelector(void *pID, CUIRect *pRect, const char *pLabel, in
 				Current = clamp(str_toint_base(s_aNumStr, 16), Min, Max);
 			else
 				Current = clamp(str_toint(s_aNumStr), Min, Max);
-			m_LockMouse = false;
+			SetLockMouse(false);
 			UI()->SetActiveItem(0);
 			s_TextMode = false;
 		}
 
 		if(Input()->KeyIsPressed(KEY_ESCAPE))
 		{
-			m_LockMouse = false;
+			SetLockMouse(false);
 			UI()->SetActiveItem(0);
 			s_TextMode = false;
 		}
@@ -700,7 +700,7 @@ int CEditor::UiDoValueSelector(void *pID, CUIRect *pRect, const char *pLabel, in
 		{
 			if(UI()->MouseButton(0))
 			{
-				m_LockMouse = true;
+				SetLockMouse(true);
 				s_Value = 0;
 				UI()->SetActiveItem(pID);
 			}
@@ -1378,7 +1378,7 @@ void CEditor::DoSoundSource(CSoundSource *pSource, int Index)
 
 					static int s_SourcePopupID = 0;
 					UiInvokePopupMenu(&s_SourcePopupID, 0, UI()->MouseX(), UI()->MouseY(), 120, 200, PopupSource);
-					m_LockMouse = false;
+					SetLockMouse(false);
 				}
 				s_Operation = OP_NONE;
 				UI()->SetActiveItem(0);
@@ -1393,7 +1393,7 @@ void CEditor::DoSoundSource(CSoundSource *pSource, int Index)
 					m_Map.m_UndoModified++;
 				}
 
-				m_LockMouse = false;
+				SetLockMouse(false);
 				s_Operation = OP_NONE;
 				UI()->SetActiveItem(0);
 			}
@@ -1583,7 +1583,7 @@ void CEditor::DoQuad(CQuad *q, int Index)
 
 					static int s_QuadPopupID = 0;
 					UiInvokePopupMenu(&s_QuadPopupID, 0, UI()->MouseX(), UI()->MouseY(), 120, 180, PopupQuad);
-					m_LockMouse = false;
+					SetLockMouse(false);
 				}
 				s_Operation = OP_NONE;
 				UI()->SetActiveItem(0);
@@ -1596,7 +1596,7 @@ void CEditor::DoQuad(CQuad *q, int Index)
 				if(m_lSelectedLayers.size() == 1)
 				{
 					m_Map.m_UndoModified++;
-					m_LockMouse = false;
+					SetLockMouse(false);
 					m_Map.m_Modified = true;
 					DeleteSelectedQuads();
 				}
@@ -1613,7 +1613,7 @@ void CEditor::DoQuad(CQuad *q, int Index)
 					m_Map.m_UndoModified++;
 				}
 
-				m_LockMouse = false;
+				SetLockMouse(false);
 				s_Operation = OP_NONE;
 				UI()->SetActiveItem(0);
 			}
@@ -1638,7 +1638,7 @@ void CEditor::DoQuad(CQuad *q, int Index)
 			}
 			else if(Input()->KeyIsPressed(KEY_LCTRL) || Input()->KeyIsPressed(KEY_RCTRL))
 			{
-				m_LockMouse = true;
+				SetLockMouse(true);
 				s_Operation = OP_ROTATE;
 				s_RotateAngle = 0;
 
@@ -1852,7 +1852,7 @@ void CEditor::DoQuadPoint(CQuad *pQuad, int QuadIndex, int V)
 				if(s_Operation == OP_MOVEPOINT || s_Operation == OP_MOVEUV)
 					m_Map.m_UndoModified++;
 
-				m_LockMouse = false;
+				SetLockMouse(false);
 				UI()->SetActiveItem(0);
 			}
 		}
@@ -1873,7 +1873,7 @@ void CEditor::DoQuadPoint(CQuad *pQuad, int QuadIndex, int V)
 			if(Input()->KeyIsPressed(KEY_LSHIFT) || Input()->KeyIsPressed(KEY_RSHIFT))
 			{
 				s_Operation = OP_MOVEUV;
-				m_LockMouse = true;
+				SetLockMouse(true);
 			}
 			else
 				s_Operation = OP_MOVEPOINT;
@@ -2101,7 +2101,7 @@ void CEditor::DoQuadEnvPoint(const CQuad *pQuad, int QIndex, int PIndex)
 
 		if(!UI()->MouseButton(0))
 		{
-			m_LockMouse = false;
+			SetLockMouse(false);
 			s_Operation = OP_NONE;
 			UI()->SetActiveItem(0);
 		}
@@ -2119,7 +2119,7 @@ void CEditor::DoQuadEnvPoint(const CQuad *pQuad, int QIndex, int PIndex)
 		{
 			if(Input()->KeyIsPressed(KEY_LCTRL) || Input()->KeyIsPressed(KEY_RCTRL))
 			{
-				m_LockMouse = true;
+				SetLockMouse(true);
 				s_Operation = OP_ROTATE;
 
 				SelectQuad(QIndex);
@@ -6199,6 +6199,18 @@ void CEditorMap::CreateDefault(IGraphics::CTextureHandle EntitiesTexture)
 	m_pTuneLayer = 0x0;
 }
 
+void CEditor::SetLockMouse(bool SetVal)
+{
+	if(m_LockMouse != SetVal)
+	{
+		m_LockMouse = SetVal;
+		if(SetVal)
+			Input()->MouseModeInGameRelative();
+		else
+			Input()->MouseModeInGame();
+	}
+}
+
 void CEditor::Init()
 {
 	m_pInput = Kernel()->RequestInterface<IInput>();
@@ -6293,40 +6305,49 @@ void CEditor::CreateUndoStepThread(void *pUser)
 
 void CEditor::UpdateAndRender()
 {
-	static float s_MouseX = 0.0f;
-	static float s_MouseY = 0.0f;
-
 	if(m_Animate)
 		m_AnimateTime = (time_get() - m_AnimateStart) / (float)time_freq();
 	else
 		m_AnimateTime = 0;
 	ms_pUiGotContext = 0;
 
-	// handle mouse movement
-	float mx, my, Mwx, Mwy;
-	float rx = 0, ry = 0;
+	float mx = 0, my = 0, Mwx = 0, Mwy = 0;
+	int rx = 0, ry = 0;
+	if(m_LockMouse)
 	{
-		Input()->MouseRelative(&rx, &ry);
-		UI()->ConvertMouseMove(&rx, &ry);
-
-		// TODO: Why do we have to halve this?
-		rx /= 2;
-		ry /= 2;
-
-		m_MouseDeltaX = rx;
-		m_MouseDeltaY = ry;
-
-		if(!m_LockMouse)
+		// use relative mouse movement when locked
+		Input()->MouseModeInGameRelative();
+		int TmpDeltaX = 0;
+		int TmpDeltaY = 0;
+		Input()->MouseDesktopRelative(&TmpDeltaX, &TmpDeltaY);
+		m_MouseDeltaX = TmpDeltaX;
+		m_MouseDeltaY = TmpDeltaY;
+		rx = m_LastX;
+		ry = m_LastY;
+	}
+	else
+	{
+		// use desktop mouse movement when not locked
+		Input()->MouseModeInGame();
+		bool GotInput = Input()->MouseAbsolute(&rx, &ry);
+		if(!GotInput)
 		{
-			s_MouseX = clamp(s_MouseX + rx, 0.0f, UI()->Screen()->w);
-			s_MouseY = clamp(s_MouseY + ry, 0.0f, UI()->Screen()->h);
+			rx = m_LastX;
+			ry = m_LastY;
 		}
 
+		m_MouseDeltaX = rx - m_LastX;
+		m_MouseDeltaY = ry - m_LastY;
+
+		m_LastX = rx;
+		m_LastY = ry;
+	}
+
+	// handle mouse movement
+	{
 		// update the ui
-		mx = s_MouseX;
-		my = s_MouseY;
-		Mwx = 0;
-		Mwy = 0;
+		mx = UI()->Screen()->w * ((float)rx / Graphics()->WindowWidth());
+		my = UI()->Screen()->h * ((float)ry / Graphics()->WindowHeight());
 
 		// fix correct world x and y
 		CLayerGroup *g = GetSelectedGroup();
@@ -6338,10 +6359,11 @@ void CEditor::UpdateAndRender()
 			float WorldWidth = aPoints[2] - aPoints[0];
 			float WorldHeight = aPoints[3] - aPoints[1];
 
-			Mwx = aPoints[0] + WorldWidth * (s_MouseX / UI()->Screen()->w);
-			Mwy = aPoints[1] + WorldHeight * (s_MouseY / UI()->Screen()->h);
-			m_MouseDeltaWx = m_MouseDeltaX * (WorldWidth / UI()->Screen()->w);
-			m_MouseDeltaWy = m_MouseDeltaY * (WorldHeight / UI()->Screen()->h);
+			Mwx = aPoints[0] + WorldWidth * ((float)rx / Graphics()->WindowWidth());
+			Mwy = aPoints[1] + WorldHeight * ((float)ry / Graphics()->WindowHeight());
+
+			m_MouseDeltaWx = m_MouseDeltaX * (WorldWidth / Graphics()->ScreenWidth());
+			m_MouseDeltaWy = m_MouseDeltaY * (WorldHeight / Graphics()->ScreenHeight());
 		}
 
 		int Buttons = 0;

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -642,6 +642,8 @@ class CEditor : public IEditor
 	CUI m_UI;
 	CUIEx m_UIEx;
 
+	void SetLockMouse(bool SetVal);
+
 public:
 	class IInput *Input() { return m_pInput; };
 	class IClient *Client() { return m_pClient; };
@@ -907,6 +909,9 @@ public:
 	float m_MouseDeltaY;
 	float m_MouseDeltaWx;
 	float m_MouseDeltaWy;
+
+	int m_LastX = 0;
+	int m_LastY = 0;
 
 	bool m_ShowTileInfo;
 	bool m_ShowDetail;

--- a/src/game/variables.h
+++ b/src/game/variables.h
@@ -111,7 +111,6 @@ MACRO_CONFIG_INT(UiSettingsPage, ui_settings_page, 0, 0, 9, CFGFLAG_CLIENT | CFG
 MACRO_CONFIG_INT(UiToolboxPage, ui_toolbox_page, 0, 0, 2, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Toolbox page")
 MACRO_CONFIG_STR(UiServerAddress, ui_server_address, 64, "localhost:8303", CFGFLAG_CLIENT | CFGFLAG_SAVE, "Interface server address")
 MACRO_CONFIG_INT(UiScale, ui_scale, 100, 50, 150, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Interface scale")
-MACRO_CONFIG_INT(UiMousesens, ui_mousesens, 200, 1, 100000, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Mouse sensitivity for menus/editor")
 
 MACRO_CONFIG_COL(UiColor, ui_color, 0xE4A046AF, CFGFLAG_CLIENT | CFGFLAG_SAVE | CFGFLAG_COLALPHA, "Interface color") // 160 70 175 228 hasalpha
 


### PR DESCRIPTION
This would remove ui_mousesense and use the desktop cursor position instead for menus and editor
This would also fix the editor cursor to not move faster than in menus.
That's probably how most games would handle menus, instead of using relative mouse mode
And this would work for touch inputs.

The normal gameplay relative mouse is ofc NOT affected by any kind

Opinions?

Missing:
- [x] m_MouseSlow in menus
- [x] Make desktop cursor invisible
- [x] Some components that use ui mouse
- [x] Remove focus in/out relative mouse state changes, fixed with next SDL version


## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
