### PR TITLE
Use minimum instead of std::min

### DIFF
--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -914,7 +914,7 @@ void CServerBrowser::RequestCurrentServerWithRandomToken(const NETADDR &Addr, in
 
 void CServerBrowser::SetCurrentServerPing(const NETADDR &Addr, int Ping)
 {
-	SetLatency(Addr, std::min(Ping, 999));
+	SetLatency(Addr, minimum(Ping, 999));
 }
 
 void ServerBrowserFillEstimatedLatency(int OwnLocation, const IServerBrowserPingCache::CEntry *pEntries, int NumEntries, int *pIndex, NETADDR Addr, CServerInfo *pInfo)

--- a/src/engine/shared/serverinfo.cpp
+++ b/src/engine/shared/serverinfo.cpp
@@ -173,7 +173,7 @@ CServerInfo2::operator CServerInfo() const
 	str_copy(Result.m_aMap, m_aMapName, sizeof(Result.m_aMap));
 	str_copy(Result.m_aVersion, m_aVersion, sizeof(Result.m_aVersion));
 
-	for(int i = 0; i < std::min(m_NumClients, (int)MAX_CLIENTS); i++)
+	for(int i = 0; i < minimum(m_NumClients, (int)MAX_CLIENTS); i++)
 	{
 		str_copy(Result.m_aClients[i].m_aName, m_aClients[i].m_aName, sizeof(Result.m_aClients[i].m_aName));
 		str_copy(Result.m_aClients[i].m_aClan, m_aClients[i].m_aClan, sizeof(Result.m_aClients[i].m_aClan));
@@ -182,7 +182,7 @@ CServerInfo2::operator CServerInfo() const
 		Result.m_aClients[i].m_Player = m_aClients[i].m_IsPlayer;
 	}
 
-	Result.m_NumReceivedClients = std::min(m_NumClients, (int)MAX_CLIENTS);
+	Result.m_NumReceivedClients = minimum(m_NumClients, (int)MAX_CLIENTS);
 	Result.m_Latency = -1;
 
 	return Result;


### PR DESCRIPTION
This replaces remaining usages of `std::min` with `minimum`. Fixes build for me on Windows with Visual Studio 2015.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
