### PR TITLE
Fix prediction of pickups in disabled switch

### DIFF
--- a/src/game/client/components/items.cpp
+++ b/src/game/client/components/items.cpp
@@ -320,7 +320,7 @@ void CItems::OnRender()
 		}
 		for(auto *pPickup = (CPickup *)GameClient()->m_PredictedWorld.FindFirst(CGameWorld::ENTTYPE_PICKUP); pPickup; pPickup = (CPickup *)pPickup->NextEntity())
 		{
-			if(pPickup->InDDNetTile())
+			if(pPickup->PredictMoving())
 			{
 				if(auto *pPrev = (CPickup *)GameClient()->m_PrevPredictedWorld.GetEntity(pPickup->ID(), CGameWorld::ENTTYPE_PICKUP))
 				{
@@ -374,7 +374,7 @@ void CItems::OnRender()
 			if(UsePredicted)
 			{
 				auto *pPickup = (CPickup *)GameClient()->m_GameWorld.FindMatch(Item.m_ID, Item.m_Type, pData);
-				if(pPickup && pPickup->InDDNetTile())
+				if(pPickup && pPickup->PredictMoving())
 					continue;
 			}
 			const void *pPrev = Client()->SnapFindItem(IClient::SNAP_PREV, Item.m_Type, Item.m_ID);

--- a/src/game/client/prediction/entities/pickup.cpp
+++ b/src/game/client/prediction/entities/pickup.cpp
@@ -7,6 +7,10 @@
 void CPickup::Tick()
 {
 	Move();
+
+	if(!PredictActive())
+		return;
+
 	// Check if a player intersected us
 	CCharacter *apEnts[MAX_CLIENTS];
 	int Num = GameWorld()->FindEntities(m_Pos, 20.0f, (CEntity **)apEnts, MAX_CLIENTS, CGameWorld::ENTTYPE_CHARACTER);
@@ -78,10 +82,6 @@ void CPickup::Move()
 			m_IsCoreActive = true;
 			m_Core = Collision()->CpSpeed(index, Flags);
 		}
-		else
-		{
-			m_IsCoreActive = false;
-		}
 		m_Pos += m_Core;
 	}
 }
@@ -98,6 +98,7 @@ CPickup::CPickup(CGameWorld *pGameWorld, int ID, CNetObj_Pickup *pPickup) :
 	m_ID = ID;
 	m_Layer = LAYER_GAME;
 	m_Number = 0;
+	m_FirstSnapTick = pGameWorld->GameTick();
 }
 
 void CPickup::FillInfo(CNetObj_Pickup *pPickup)

--- a/src/game/client/prediction/entities/pickup.h
+++ b/src/game/client/prediction/entities/pickup.h
@@ -15,7 +15,10 @@ public:
 	CPickup(CGameWorld *pGameWorld, int ID, CNetObj_Pickup *pPickup);
 	void FillInfo(CNetObj_Pickup *pPickup);
 	bool Match(CPickup *pPickup);
-	bool InDDNetTile() { return m_IsCoreActive; }
+	bool PredictMoving() { return m_IsCoreActive && PredictActive(); }
+
+	// only predict pickups that have been seen for at least one second, to avoid predicting disabled switch layer
+	bool PredictActive() { return GameWorld()->GameTick() - m_FirstSnapTick > 50; }
 
 private:
 	int m_Type;
@@ -26,6 +29,7 @@ private:
 	void Move();
 	vec2 m_Core;
 	bool m_IsCoreActive;
+	int m_FirstSnapTick;
 };
 
 #endif


### PR DESCRIPTION
This only enables prediction if the pickup has existed for some time (e.g. is not blinking, like disabled switch ones), for #3990. It also makes moving pickups slightly smoother in some cases.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
