### PR TITLE
Fix fullscreen resolution setting on SDL 2.0.16

### DIFF
--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -1114,7 +1114,17 @@ void CGraphicsBackend_SDL_OpenGL::SetWindowGrab(bool Grab)
 
 void CGraphicsBackend_SDL_OpenGL::ResizeWindow(int w, int h)
 {
-	SDL_SetWindowSize(m_pWindow, w, h);
+	if(SDL_GetWindowFlags(m_pWindow) & SDL_WINDOW_FULLSCREEN)
+	{
+		SDL_DisplayMode displaymode = {};
+		displaymode.w = w;
+		displaymode.h = h;
+		SDL_SetWindowDisplayMode(m_pWindow, &displaymode);
+	}
+	else
+	{
+		SDL_SetWindowSize(m_pWindow, w, h);
+	}
 }
 
 void CGraphicsBackend_SDL_OpenGL::GetViewportSize(int &w, int &h)


### PR DESCRIPTION
`SDL_SetWindowSize`'s documentation tells that `SDL_SetWindowDisplayMode` should be used to set the sizes of fullscreen windows. [SDL commit 72d812852023450b7c3850b8e87b63575df041ee](https://github.com/libsdl-org/SDL/commit/72d812852023450b7c3850b8e87b63575df041ee) changed `SDL_SetWindowSize`'s behavior so that it can no longer be used to set the screen resolution with windows that are created in fullscreen mode. `SDL_SetWindowDisplaymode` can be used instead when the window is fullscreen.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
