### PR TITLE
Fix filesystem/IO with unicode filenames on windows

### DIFF
--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -2257,25 +2257,22 @@ int fs_is_dir(const char *path)
 {
 #if defined(CONF_FAMILY_WINDOWS)
 	/* TODO: do this smarter */
-	WIN32_FIND_DATA finddata;
+	WIN32_FIND_DATAW finddata;
 	HANDLE handle;
-	char buffer[1024 * 2];
+	char buffer[IO_MAX_PATH_LENGTH];
+	WCHAR wBuffer[IO_MAX_PATH_LENGTH];
 	str_format(buffer, sizeof(buffer), "%s/*", path);
+	MultiByteToWideChar(CP_UTF8, 0, buffer, IO_MAX_PATH_LENGTH, wBuffer, IO_MAX_PATH_LENGTH);
 
-	if((handle = FindFirstFileA(buffer, &finddata)) == INVALID_HANDLE_VALUE)
+	if((handle = FindFirstFileW(wBuffer, &finddata)) == INVALID_HANDLE_VALUE)
 		return 0;
-
 	FindClose(handle);
 	return 1;
 #else
 	struct stat sb;
 	if(stat(path, &sb) == -1)
 		return 0;
-
-	if(S_ISDIR(sb.st_mode))
-		return 1;
-	else
-		return 0;
+	return S_ISDIR(sb.st_mode) ? 1 : 0;
 #endif
 }
 

--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -283,6 +283,7 @@ void mem_zero(void *block, unsigned size)
 
 IOHANDLE io_open(const char *filename, int flags)
 {
+	dbg_assert(flags == IOFLAG_READ || flags == IOFLAG_WRITE || flags == IOFLAG_APPEND, "flags must be read, write or append");
 	if(flags == IOFLAG_READ)
 		return (IOHANDLE)fopen(filename, "rb");
 	if(flags == IOFLAG_WRITE)

--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -64,6 +64,7 @@
 #include <process.h>
 #include <shellapi.h>
 #include <wincrypt.h>
+#include <share.h>
 #else
 #error NOT IMPLEMENTED
 #endif
@@ -284,6 +285,43 @@ void mem_zero(void *block, unsigned size)
 IOHANDLE io_open(const char *filename, int flags)
 {
 	dbg_assert(flags == IOFLAG_READ || flags == IOFLAG_WRITE || flags == IOFLAG_APPEND, "flags must be read, write or append");
+#if defined(CONF_FAMILY_WINDOWS)
+	WCHAR wBuffer[IO_MAX_PATH_LENGTH];
+	if(flags == IOFLAG_READ)
+	{
+		// check for filename case sensitive
+		WIN32_FIND_DATAW finddata;
+		HANDLE handle;
+		char buffer[IO_MAX_PATH_LENGTH];
+
+		int length = str_length(filename);
+		if(!filename || !length || filename[length-1] == '\\')
+			return 0x0;
+		MultiByteToWideChar(CP_UTF8, 0, filename, IO_MAX_PATH_LENGTH, wBuffer, IO_MAX_PATH_LENGTH);
+		handle = FindFirstFileW(wBuffer, &finddata);
+		if(handle == INVALID_HANDLE_VALUE)
+			return 0x0;
+		WideCharToMultiByte(CP_UTF8, 0, finddata.cFileName, -1, buffer, IO_MAX_PATH_LENGTH, NULL, NULL);
+		if(str_comp(filename+length-str_length(buffer), buffer) != 0)
+		{
+			FindClose(handle);
+			return 0x0;
+		}
+		FindClose(handle);
+		return (IOHANDLE)_wfsopen(wBuffer, L"rb", _SH_DENYNO);
+	}
+	if(flags == IOFLAG_WRITE)
+	{
+		MultiByteToWideChar(CP_UTF8, 0, filename, IO_MAX_PATH_LENGTH, wBuffer, IO_MAX_PATH_LENGTH);
+		return (IOHANDLE)_wfsopen(wBuffer, L"wb", _SH_DENYNO);
+	}
+	if(flags == IOFLAG_APPEND)
+	{
+		MultiByteToWideChar(CP_UTF8, 0, filename, IO_MAX_PATH_LENGTH, wBuffer, IO_MAX_PATH_LENGTH);
+		return (IOHANDLE)_wfsopen(wBuffer, L"ab", _SH_DENYNO);
+	}
+	return 0x0;
+#else
 	if(flags == IOFLAG_READ)
 		return (IOHANDLE)fopen(filename, "rb");
 	if(flags == IOFLAG_WRITE)
@@ -291,6 +329,7 @@ IOHANDLE io_open(const char *filename, int flags)
 	if(flags == IOFLAG_APPEND)
 		return (IOHANDLE)fopen(filename, "ab");
 	return 0x0;
+#endif
 }
 
 unsigned io_read(IOHANDLE io, void *buffer, unsigned size)

--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -62,9 +62,9 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <process.h>
+#include <share.h>
 #include <shellapi.h>
 #include <wincrypt.h>
-#include <share.h>
 #else
 #error NOT IMPLEMENTED
 #endif
@@ -295,14 +295,14 @@ IOHANDLE io_open(const char *filename, int flags)
 		char buffer[IO_MAX_PATH_LENGTH];
 
 		int length = str_length(filename);
-		if(!filename || !length || filename[length-1] == '\\')
+		if(!filename || !length || filename[length - 1] == '\\')
 			return 0x0;
 		MultiByteToWideChar(CP_UTF8, 0, filename, IO_MAX_PATH_LENGTH, wBuffer, IO_MAX_PATH_LENGTH);
 		handle = FindFirstFileW(wBuffer, &finddata);
 		if(handle == INVALID_HANDLE_VALUE)
 			return 0x0;
 		WideCharToMultiByte(CP_UTF8, 0, finddata.cFileName, -1, buffer, IO_MAX_PATH_LENGTH, NULL, NULL);
-		if(str_comp(filename+length-str_length(buffer), buffer) != 0)
+		if(str_comp(filename + length - str_length(buffer), buffer) != 0)
 		{
 			FindClose(handle);
 			return 0x0;
@@ -2026,7 +2026,7 @@ void net_unix_close(UNIXSOCKET sock)
 }
 #endif
 
-#if defined (CONF_FAMILY_WINDOWS)
+#if defined(CONF_FAMILY_WINDOWS)
 static inline time_t filetime_to_unixtime(LPFILETIME filetime)
 {
 	time_t t;
@@ -2066,11 +2066,10 @@ void fs_listdir(const char *dir, FS_LISTDIR_CALLBACK cb, int type, void *user)
 	do
 	{
 		WideCharToMultiByte(CP_UTF8, 0, finddata.cFileName, -1, buffer2, IO_MAX_PATH_LENGTH, NULL, NULL);
-		str_copy(buffer+length, buffer2, (int)sizeof(buffer)-length);
+		str_copy(buffer + length, buffer2, (int)sizeof(buffer) - length);
 		if(cb(buffer2, fs_is_dir(buffer), type, user))
 			break;
-	}
-	while(FindNextFileW(handle, &finddata));
+	} while(FindNextFileW(handle, &finddata));
 
 	FindClose(handle);
 #else
@@ -2087,7 +2086,7 @@ void fs_listdir(const char *dir, FS_LISTDIR_CALLBACK cb, int type, void *user)
 
 	while((entry = readdir(d)) != NULL)
 	{
-		str_copy(buffer+length, entry->d_name, (int)sizeof(buffer)-length);
+		str_copy(buffer + length, entry->d_name, (int)sizeof(buffer) - length);
 		if(cb(entry->d_name, fs_is_dir(buffer), type, user))
 			break;
 	}
@@ -2121,7 +2120,7 @@ void fs_listdir_fileinfo(const char *dir, FS_LISTDIR_CALLBACK_FILEINFO cb, int t
 	do
 	{
 		WideCharToMultiByte(CP_UTF8, 0, finddata.cFileName, -1, buffer2, IO_MAX_PATH_LENGTH, NULL, NULL);
-		str_copy(buffer+length, buffer2, (int)sizeof(buffer)-length);
+		str_copy(buffer + length, buffer2, (int)sizeof(buffer) - length);
 
 		CFsFileInfo info;
 		info.m_pName = buffer2;
@@ -2130,8 +2129,7 @@ void fs_listdir_fileinfo(const char *dir, FS_LISTDIR_CALLBACK_FILEINFO cb, int t
 
 		if(cb(&info, fs_is_dir(buffer), type, user))
 			break;
-	}
-	while(FindNextFileW(handle, &finddata));
+	} while(FindNextFileW(handle, &finddata));
 
 	FindClose(handle);
 #else
@@ -2151,7 +2149,7 @@ void fs_listdir_fileinfo(const char *dir, FS_LISTDIR_CALLBACK_FILEINFO cb, int t
 	{
 		CFsFileInfo info;
 
-		str_copy(buffer+length, entry->d_name, (int)sizeof(buffer)-length);
+		str_copy(buffer + length, entry->d_name, (int)sizeof(buffer) - length);
 		fs_file_time(buffer, &created, &modified);
 
 		info.m_pName = entry->d_name;
@@ -2369,7 +2367,7 @@ int fs_file_time(const char *name, time_t *created, time_t *modified)
 	*created = sb.st_ctime;
 	*modified = sb.st_mtime;
 #else
-	#error not implemented
+#error not implemented
 #endif
 
 	return 0;

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -1761,6 +1761,23 @@ int fs_remove(const char *filename);
 int fs_rename(const char *oldname, const char *newname);
 
 /*
+	Function: fs_file_time
+		Gets the creation and the last modification date of a file.
+
+	Parameters:
+		name - The filename.
+		created - Pointer to time_t
+		modified - Pointer to time_t
+
+	Returns:
+		0 on success non-zero on failure
+
+	Remarks:
+		- Returned time is in seconds since UNIX Epoch
+*/
+int fs_file_time(const char *name, time_t *created, time_t *modified);
+
+/*
 	Group: Undocumented
 */
 

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -174,7 +174,9 @@ enum
 
 	IOSEEK_START = 0,
 	IOSEEK_CUR = 1,
-	IOSEEK_END = 2
+	IOSEEK_END = 2,
+
+	IO_MAX_PATH_LENGTH = 512,
 };
 
 typedef struct IOINTERNAL *IOHANDLE;
@@ -1597,14 +1599,29 @@ void str_escape(char **dst, const char *src, const char *end);
 		cb - Callback function to call for each entry
 		type - Type of the directory
 		user - Pointer to give to the callback
-
-	Returns:
-		Always returns 0.
 */
 typedef int (*FS_LISTDIR_CALLBACK)(const char *name, int is_dir, int dir_type, void *user);
-typedef int (*FS_LISTDIR_INFO_CALLBACK)(const char *name, time_t date, int is_dir, int dir_type, void *user);
-int fs_listdir(const char *dir, FS_LISTDIR_CALLBACK cb, int type, void *user);
-int fs_listdir_info(const char *dir, FS_LISTDIR_INFO_CALLBACK cb, int type, void *user);
+void fs_listdir(const char *dir, FS_LISTDIR_CALLBACK cb, int type, void *user);
+
+typedef struct
+{
+	const char *m_pName;
+	time_t m_TimeCreated; // seconds since UNIX Epoch
+	time_t m_TimeModified; // seconds since UNIX Epoch
+} CFsFileInfo;
+
+/*
+	Function: fs_listdir_fileinfo
+		Lists the files in a directory and gets additional file information
+
+	Parameters:
+		dir - Directory to list
+		cb - Callback function to call for each entry
+		type - Type of the directory
+		user - Pointer to give to the callback
+*/
+typedef int (*FS_LISTDIR_CALLBACK_FILEINFO)(const CFsFileInfo *info, int is_dir, int dir_type, void *user);
+void fs_listdir_fileinfo(const char *dir, FS_LISTDIR_CALLBACK_FILEINFO cb, int type, void *user);
 
 /*
 	Function: fs_makedir

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -170,8 +170,7 @@ enum
 {
 	IOFLAG_READ = 1,
 	IOFLAG_WRITE = 2,
-	IOFLAG_RANDOM = 4,
-	IOFLAG_APPEND = 8,
+	IOFLAG_APPEND = 4,
 
 	IOSEEK_START = 0,
 	IOSEEK_CUR = 1,
@@ -186,7 +185,7 @@ typedef struct IOINTERNAL *IOHANDLE;
 
 	Parameters:
 		filename - File to open.
-		flags - A set of flags. IOFLAG_READ, IOFLAG_WRITE, IOFLAG_RANDOM, IOFLAG_APPEND.
+		flags - A set of flags. IOFLAG_READ, IOFLAG_WRITE, IOFLAG_APPEND.
 
 	Returns:
 		Returns a handle to the file on success and 0 on failure.

--- a/src/engine/shared/storage.cpp
+++ b/src/engine/shared/storage.cpp
@@ -300,19 +300,19 @@ public:
 		// no binary directory found, use $PATH on Posix, $PWD on Windows
 	}
 
-	virtual void ListDirectoryInfo(int Type, const char *pPath, FS_LISTDIR_INFO_CALLBACK pfnCallback, void *pUser)
+	virtual void ListDirectoryInfo(int Type, const char *pPath, FS_LISTDIR_CALLBACK_FILEINFO pfnCallback, void *pUser)
 	{
 		char aBuffer[MAX_PATH_LENGTH];
 		if(Type == TYPE_ALL)
 		{
 			// list all available directories
 			for(int i = 0; i < m_NumPaths; ++i)
-				fs_listdir_info(GetPath(i, pPath, aBuffer, sizeof(aBuffer)), pfnCallback, i, pUser);
+				fs_listdir_fileinfo(GetPath(i, pPath, aBuffer, sizeof(aBuffer)), pfnCallback, i, pUser);
 		}
 		else if(Type >= 0 && Type < m_NumPaths)
 		{
 			// list wanted directory
-			fs_listdir_info(GetPath(Type, pPath, aBuffer, sizeof(aBuffer)), pfnCallback, Type, pUser);
+			fs_listdir_fileinfo(GetPath(Type, pPath, aBuffer, sizeof(aBuffer)), pfnCallback, Type, pUser);
 		}
 	}
 

--- a/src/engine/storage.h
+++ b/src/engine/storage.h
@@ -27,7 +27,7 @@ public:
 	};
 
 	virtual void ListDirectory(int Type, const char *pPath, FS_LISTDIR_CALLBACK pfnCallback, void *pUser) = 0;
-	virtual void ListDirectoryInfo(int Type, const char *pPath, FS_LISTDIR_INFO_CALLBACK pfnCallback, void *pUser) = 0;
+	virtual void ListDirectoryInfo(int Type, const char *pPath, FS_LISTDIR_CALLBACK_FILEINFO pfnCallback, void *pUser) = 0;
 	virtual IOHANDLE OpenFile(const char *pFilename, int Flags, int Type, char *pBuffer = 0, int BufferSize = 0) = 0;
 	virtual bool FindFile(const char *pFilename, const char *pPath, int Type, char *pBuffer, int BufferSize) = 0;
 	virtual bool RemoveFile(const char *pFilename, int Type) = 0;

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -442,7 +442,7 @@ protected:
 
 	void DemolistOnUpdate(bool Reset);
 	//void DemolistPopulate();
-	static int DemolistFetchCallback(const char *pName, time_t Date, int IsDir, int StorageType, void *pUser);
+	static int DemolistFetchCallback(const CFsFileInfo *pInfo, int IsDir, int StorageType, void *pUser);
 
 	// friends
 	struct CFriendItem

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -740,28 +740,28 @@ int CMenus::UiLogicGetCurrentClickedItem()
 		return -1;
 }
 
-int CMenus::DemolistFetchCallback(const char *pName, time_t Date, int IsDir, int StorageType, void *pUser)
+int CMenus::DemolistFetchCallback(const CFsFileInfo *pInfo, int IsDir, int StorageType, void *pUser)
 {
 	CMenus *pSelf = (CMenus *)pUser;
-	if(str_comp(pName, ".") == 0 || (str_comp(pName, "..") == 0 && str_comp(pSelf->m_aCurrentDemoFolder, "demos") == 0) || (!IsDir && !str_endswith(pName, ".demo")))
+	if(str_comp(pInfo->m_pName, ".") == 0 || (str_comp(pInfo->m_pName, "..") == 0 && str_comp(pSelf->m_aCurrentDemoFolder, "demos") == 0) || (!IsDir && !str_endswith(pInfo->m_pName, ".demo")))
 	{
 		return 0;
 	}
 
 	CDemoItem Item;
-	str_copy(Item.m_aFilename, pName, sizeof(Item.m_aFilename));
+	str_copy(Item.m_aFilename, pInfo->m_pName, sizeof(Item.m_aFilename));
 	if(IsDir)
 	{
-		str_format(Item.m_aName, sizeof(Item.m_aName), "%s/", pName);
+		str_format(Item.m_aName, sizeof(Item.m_aName), "%s/", pInfo->m_pName);
 		Item.m_InfosLoaded = false;
 		Item.m_Valid = false;
 		Item.m_Date = 0;
 	}
 	else
 	{
-		str_truncate(Item.m_aName, sizeof(Item.m_aName), pName, str_length(pName) - 5);
+		str_truncate(Item.m_aName, sizeof(Item.m_aName), pInfo->m_pName, str_length(pInfo->m_pName) - 5);
 		Item.m_InfosLoaded = false;
-		Item.m_Date = Date;
+		Item.m_Date = pInfo->m_TimeModified;
 	}
 	Item.m_IsDir = IsDir != 0;
 	Item.m_StorageType = StorageType;

--- a/src/game/client/components/race_demo.cpp
+++ b/src/game/client/components/race_demo.cpp
@@ -175,15 +175,15 @@ void CRaceDemo::StopRecord(int Time)
 	m_RecordStopTick = -1;
 }
 
-int CRaceDemo::RaceDemolistFetchCallback(const char *pName, time_t Date, int IsDir, int StorageType, void *pUser)
+int CRaceDemo::RaceDemolistFetchCallback(const CFsFileInfo *pInfo, int IsDir, int StorageType, void *pUser)
 {
 	CDemoListParam *pParam = (CDemoListParam *)pUser;
 	int MapLen = str_length(pParam->pMap);
-	if(IsDir || !str_endswith(pName, ".demo") || !str_startswith(pName, pParam->pMap) || pName[MapLen] != '_')
+	if(IsDir || !str_endswith(pInfo->m_pName, ".demo") || !str_startswith(pInfo->m_pName, pParam->pMap) || pInfo->m_pName[MapLen] != '_')
 		return 0;
 
 	CDemoItem Item;
-	str_truncate(Item.m_aName, sizeof(Item.m_aName), pName, str_length(pName) - 5);
+	str_truncate(Item.m_aName, sizeof(Item.m_aName), pInfo->m_pName, str_length(pInfo->m_pName) - 5);
 
 	const char *pTime = Item.m_aName + MapLen + 1;
 	const char *pTEnd = pTime;

--- a/src/game/client/components/race_demo.h
+++ b/src/game/client/components/race_demo.h
@@ -25,7 +25,7 @@ class CRaceDemo : public CComponent
 	int m_RecordStopTick;
 	int m_Time;
 
-	static int RaceDemolistFetchCallback(const char *pName, time_t Date, int IsDir, int StorageType, void *pUser);
+	static int RaceDemolistFetchCallback(const CFsFileInfo *pInfo, int IsDir, int StorageType, void *pUser);
 
 	void GetPath(char *pBuf, int Size, int Time = -1) const;
 


### PR DESCRIPTION
It was previously not possible to load a map or really any file with a filename containing unicode, e.g. german umlauts.

Now all filenames are converted from multibyte to widechar on windows, and the correct functions and structs (with the `W` suffix) are used consistently.

Some changes are made to synchronize ddnet's implementation with upstream (once https://github.com/teeworlds/teeworlds/pull/2936 has been merged there):
- The unused and not working `IOFLAG_RANDOM` is removed (on upstream ddnet's `IOFLAG_APPEND` is added instead).
- The `fs_listdir_info` function is renamed to `fs_listdir_fileinfo` and now using the parameter object `CFsFileInfo` that contains the filename, modified date and creation date, making it easier to add more properties in the future. `FS_LISTDIR_INFO_CALLBACK` is renamed to `FS_LISTDIR_CALLBACK_FILEINFO`.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
