### PR TITLE
Update GLEW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2025,6 +2025,10 @@ if(CLIENT)
 	  target_compile_definitions(${TARGET_CLIENT} PRIVATE CONF_WAVPACK_CLOSE_FILE)
   endif()
 
+  if(GLEW_BUNDLED)
+	  target_compile_definitions(${TARGET_CLIENT} PRIVATE CONF_GLEW_HAS_CONTEXT_INIT)
+  endif()
+
   list(APPEND TARGETS_OWN ${TARGET_CLIENT})
   list(APPEND TARGETS_LINK ${TARGET_CLIENT})
 endif()

--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -301,7 +301,11 @@ static bool BackendInitGlew(EBackendType BackendType, int &GlewMajor, int &GlewM
 #ifndef CONF_BACKEND_OPENGL_ES
 		//support graphic cards that are pretty old(and linux)
 		glewExperimental = GL_TRUE;
+#ifdef CONF_GLEW_HAS_CONTEXT_INIT
+		if(GLEW_OK != glewContextInit())
+#else
 		if(GLEW_OK != glewInit())
+#endif
 			return false;
 
 #ifdef GLEW_VERSION_4_6

--- a/src/engine/external/glew/GL/glew.h
+++ b/src/engine/external/glew/GL/glew.h
@@ -23645,6 +23645,7 @@ VERSION_MICRO 0
 
 /* API */
 GLEWAPI GLenum GLEWAPIENTRY glewInit (void);
+GLEWAPI GLenum GLEWAPIENTRY glewContextInit (void);
 GLEWAPI GLboolean GLEWAPIENTRY glewIsSupported (const char *name);
 #define glewIsExtensionSupported(x) glewIsSupported(x)
 

--- a/src/engine/external/glew/glew.c
+++ b/src/engine/external/glew/glew.c
@@ -16156,7 +16156,7 @@ GLboolean GLEWAPIENTRY glewGetExtension (const char* name)
 typedef const GLubyte* (GLAPIENTRY * PFNGLGETSTRINGPROC) (GLenum name);
 typedef void (GLAPIENTRY * PFNGLGETINTEGERVPROC) (GLenum pname, GLint *params);
 
-static GLenum GLEWAPIENTRY glewContextInit ()
+GLenum GLEWAPIENTRY glewContextInit ()
 {
   PFNGLGETSTRINGPROC getString;
   const GLubyte* s;


### PR DESCRIPTION
If the glew mantainer merges his pr we can remove the ifdefs
But we can also use it like this for now, then atleast our official build has no x11 calls

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
