### PR TITLE
Fix offset of strong symbol in nameplate

### DIFF
--- a/src/game/client/components/nameplates.cpp
+++ b/src/game/client/components/nameplates.cpp
@@ -211,36 +211,39 @@ void CNamePlates::RenderNameplatePos(vec2 Position, const CNetObj_PlayerInfo *pP
 			CCharacter *pCharacter = m_pClient->m_GameWorld.GetCharacterByID(pPlayerInfo->m_ClientID);
 			if(pCharacter && pLocalChar)
 			{
-				YOffset -= FontSize;
 				if(pPlayerInfo->m_Local)
 					TextRender()->TextColor(rgb);
 				else
 				{
+					float ScaleX, ScaleY;
+					const float StrongWeakImgSize = 40.0f;
 					Graphics()->TextureClear();
+					Graphics()->TextureSet(g_pData->m_aImages[IMAGE_STRONGWEAK].m_Id);
+					Graphics()->QuadsBegin();
+					ColorRGBA StrongWeakStatusColor;
+					int StrongWeakSpriteID;
 					if(pLocalChar->GetStrongWeakID() > pCharacter->GetStrongWeakID())
 					{
-						Graphics()->TextureSet(g_pData->m_aImages[IMAGE_STRONGWEAK].m_Id);
-						Graphics()->QuadsBegin();
-						Graphics()->SetColor(color_cast<ColorRGBA>(ColorHSLA(6401973)));
-						RenderTools()->SelectSprite(SPRITE_HOOK_STRONG);
-						ColorRGBA WeakStatusColor = color_cast<ColorRGBA>(ColorHSLA(6401973));
-						TextRender()->TextColor(WeakStatusColor);
+						StrongWeakStatusColor = color_cast<ColorRGBA>(ColorHSLA(6401973));
+						StrongWeakSpriteID = SPRITE_HOOK_STRONG;
 					}
 					else
 					{
-						Graphics()->TextureSet(g_pData->m_aImages[IMAGE_STRONGWEAK].m_Id);
-						Graphics()->QuadsBegin();
-						Graphics()->SetColor(color_cast<ColorRGBA>(ColorHSLA(41131)));
-						RenderTools()->SelectSprite(SPRITE_HOOK_WEAK);
-						ColorRGBA StrongStatusColor = color_cast<ColorRGBA>(ColorHSLA(41131));
-						TextRender()->TextColor(StrongStatusColor);
+						StrongWeakStatusColor = color_cast<ColorRGBA>(ColorHSLA(41131));
+						StrongWeakSpriteID = SPRITE_HOOK_WEAK;
 					}
-					RenderTools()->DrawSprite(Position.x, YOffset + 15, 40.0f);
+					Graphics()->SetColor(StrongWeakStatusColor);
+					RenderTools()->SelectSprite(StrongWeakSpriteID);
+					RenderTools()->GetSpriteScale(StrongWeakSpriteID, ScaleX, ScaleY);
+					TextRender()->TextColor(StrongWeakStatusColor);
+
+					YOffset -= StrongWeakImgSize * ScaleY;
+					RenderTools()->DrawSprite(Position.x, YOffset + (StrongWeakImgSize / 2.0f) * ScaleY, StrongWeakImgSize);
 					Graphics()->QuadsEnd();
-					YOffset -= FontSize;
 				}
 				if(g_Config.m_Debug || g_Config.m_ClNameplatesStrong == 2)
 				{
+					YOffset -= FontSize;
 					char aBuf[12];
 					str_format(aBuf, sizeof(aBuf), "%d", pCharacter->GetStrongWeakID());
 					float XOffset = TextRender()->TextWidth(0, FontSize, aBuf, -1, -1.0f) / 2.0f;


### PR DESCRIPTION
As reported by Skeith

when scaling nameplate size to 10 it was overlapping since the image size is not affected by nameplate font size.

Before:
![screenshot-20210827@145748](https://user-images.githubusercontent.com/2335377/131130842-edd76bde-c732-441b-aa2d-3a2e17379fa1.png)
Now:
![screenshot-20210827@145326](https://user-images.githubusercontent.com/2335377/131130706-0f7c6225-8c9e-4167-b225-5ce087c28092.png)


<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
