### PR TITLE
Add cl_show_local_direction (fixes #3978)

### DIFF
--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -374,6 +374,7 @@ MACRO_CONFIG_INT(ClChatReset, cl_chat_reset, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_S
 MACRO_CONFIG_INT(ClChatOld, cl_chat_old, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Old chat style: No tee, no background");
 
 MACRO_CONFIG_INT(ClShowDirection, cl_show_direction, 1, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Show tee direction")
+MACRO_CONFIG_INT(ClShowLocalDirection, cl_show_local_direction, 1, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Show local tee direction")
 MACRO_CONFIG_INT(ClHttpMapDownload, cl_http_map_download, 1, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Try fast HTTP map download first")
 MACRO_CONFIG_INT(ClOldGunPosition, cl_old_gun_position, 0, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Tees hold gun a bit higher like in TW 0.6.1 and older")
 MACRO_CONFIG_INT(ClConfirmDisconnectTime, cl_confirm_disconnect_time, 20, -1, 1440, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Confirmation popup before disconnecting after game time (in minutes, -1 to turn off, 0 to always turn on)")

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -374,7 +374,6 @@ MACRO_CONFIG_INT(ClChatReset, cl_chat_reset, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_S
 MACRO_CONFIG_INT(ClChatOld, cl_chat_old, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Old chat style: No tee, no background");
 
 MACRO_CONFIG_INT(ClShowDirection, cl_show_direction, 1, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Show tee direction")
-MACRO_CONFIG_INT(ClShowLocalDirection, cl_show_local_direction, 1, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Show local tee direction")
 MACRO_CONFIG_INT(ClHttpMapDownload, cl_http_map_download, 1, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Try fast HTTP map download first")
 MACRO_CONFIG_INT(ClOldGunPosition, cl_old_gun_position, 0, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Tees hold gun a bit higher like in TW 0.6.1 and older")
 MACRO_CONFIG_INT(ClConfirmDisconnectTime, cl_confirm_disconnect_time, 20, -1, 1440, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Confirmation popup before disconnecting after game time (in minutes, -1 to turn off, 0 to always turn on)")

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -2530,6 +2530,12 @@ void CMenus::RenderSettingsDDNet(CUIRect MainView)
 	}
 
 	Left.HSplitTop(20.0f, &Button, &Left);
+	if(DoButton_CheckBox(&g_Config.m_ClShowLocalDirection, Localize("Show local player's key presses"), g_Config.m_ClShowLocalDirection, &Button))
+	{
+		g_Config.m_ClShowLocalDirection ^= 1;
+	}
+
+	Left.HSplitTop(20.0f, &Button, &Left);
 	if(DoButton_CheckBox(&g_Config.m_InpMouseOld, Localize("Old mouse mode"), g_Config.m_InpMouseOld, &Button))
 	{
 		g_Config.m_InpMouseOld ^= 1;

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -2524,15 +2524,16 @@ void CMenus::RenderSettingsDDNet(CUIRect MainView)
 	}
 
 	Left.HSplitTop(20.0f, &Button, &Left);
-	if(DoButton_CheckBox(&g_Config.m_ClShowDirection, Localize("Show other players' key presses"), g_Config.m_ClShowDirection, &Button))
+	if(DoButton_CheckBox(&g_Config.m_ClShowDirection, Localize("Show other players' key presses"), g_Config.m_ClShowDirection >= 1, &Button))
 	{
-		g_Config.m_ClShowDirection ^= 1;
+		g_Config.m_ClShowDirection = g_Config.m_ClShowDirection >= 1 ? 0 : 1;
 	}
 
 	Left.HSplitTop(20.0f, &Button, &Left);
-	if(DoButton_CheckBox(&g_Config.m_ClShowLocalDirection, Localize("Show local player's key presses"), g_Config.m_ClShowLocalDirection, &Button))
+	static int s_ShowLocalPlayer = 0;
+	if(DoButton_CheckBox(&s_ShowLocalPlayer, Localize("Show local player's key presses"), g_Config.m_ClShowDirection == 2, &Button))
 	{
-		g_Config.m_ClShowLocalDirection ^= 1;
+		g_Config.m_ClShowDirection = g_Config.m_ClShowDirection != 2 ? 2 : 1;
 	}
 
 	Left.HSplitTop(20.0f, &Button, &Left);

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -543,30 +543,33 @@ void CPlayers::RenderPlayer(
 	Graphics()->SetColor(1.0f, 1.0f, 1.0f, Alpha);
 	Graphics()->QuadsSetRotation(0);
 #if defined(CONF_VIDEORECORDER)
-	if(((!IVideo::Current() && g_Config.m_ClShowDirection) || (IVideo::Current() && g_Config.m_ClVideoShowDirection)) && ClientID >= 0 && (!Local || DemoPlayer()->IsPlaying()))
+	if(((!IVideo::Current() && (g_Config.m_ClShowDirection || g_Config.m_ClShowLocalDirection)) || (IVideo::Current() && g_Config.m_ClVideoShowDirection)) && ClientID >= 0 || DemoPlayer()->IsPlaying())
 #else
-	if(g_Config.m_ClShowDirection && ClientID >= 0 && (!Local || DemoPlayer()->IsPlaying()))
+	if((g_Config.m_ClShowDirection || g_Config.m_ClShowLocalDirection) && ClientID >= 0 || DemoPlayer()->IsPlaying())
 #endif
 	{
-		if(Player.m_Direction == -1)
+		if((Local && g_Config.m_ClShowLocalDirection) || !Local && g_Config.m_ClShowDirection)
 		{
-			Graphics()->TextureSet(g_pData->m_aImages[IMAGE_ARROW].m_Id);
-			Graphics()->QuadsSetRotation(pi);
-			Graphics()->RenderQuadContainerAsSprite(m_DirectionQuadContainerIndex, 0, Position.x - 30.f, Position.y - 70.f);
+			if(Player.m_Direction == -1)
+			{
+				Graphics()->TextureSet(g_pData->m_aImages[IMAGE_ARROW].m_Id);
+				Graphics()->QuadsSetRotation(pi);
+				Graphics()->RenderQuadContainerAsSprite(m_DirectionQuadContainerIndex, 0, Position.x - 30.f, Position.y - 70.f);
+			}
+			else if(Player.m_Direction == 1)
+			{
+				Graphics()->TextureSet(g_pData->m_aImages[IMAGE_ARROW].m_Id);
+				Graphics()->RenderQuadContainerAsSprite(m_DirectionQuadContainerIndex, 0, Position.x + 30.f, Position.y - 70.f);
+			}
+			if(Player.m_Jumped & 1)
+			{
+				Graphics()->TextureSet(g_pData->m_aImages[IMAGE_ARROW].m_Id);
+				Graphics()->QuadsSetRotation(pi * 3 / 2);
+				Graphics()->RenderQuadContainerAsSprite(m_DirectionQuadContainerIndex, 0, Position.x, Position.y - 70.f);
+			}
+			Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
+			Graphics()->QuadsSetRotation(0);
 		}
-		else if(Player.m_Direction == 1)
-		{
-			Graphics()->TextureSet(g_pData->m_aImages[IMAGE_ARROW].m_Id);
-			Graphics()->RenderQuadContainerAsSprite(m_DirectionQuadContainerIndex, 0, Position.x + 30.f, Position.y - 70.f);
-		}
-		if(Player.m_Jumped & 1)
-		{
-			Graphics()->TextureSet(g_pData->m_aImages[IMAGE_ARROW].m_Id);
-			Graphics()->QuadsSetRotation(pi * 3 / 2);
-			Graphics()->RenderQuadContainerAsSprite(m_DirectionQuadContainerIndex, 0, Position.x, Position.y - 70.f);
-		}
-		Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
-		Graphics()->QuadsSetRotation(0);
 	}
 
 	if(OtherTeam || ClientID < 0)

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -545,10 +545,10 @@ void CPlayers::RenderPlayer(
 #if defined(CONF_VIDEORECORDER)
 	if(((!IVideo::Current() && (g_Config.m_ClShowDirection || g_Config.m_ClShowLocalDirection)) || (IVideo::Current() && g_Config.m_ClVideoShowDirection)) && ClientID >= 0 || DemoPlayer()->IsPlaying())
 #else
-	if((g_Config.m_ClShowDirection || g_Config.m_ClShowLocalDirection) && ClientID >= 0 || DemoPlayer()->IsPlaying())
+	if((g_Config.m_ClShowDirection || g_Config.m_ClShowLocalDirection) && (ClientID >= 0) || DemoPlayer()->IsPlaying())
 #endif
 	{
-		if((Local && g_Config.m_ClShowLocalDirection) || !Local && g_Config.m_ClShowDirection)
+		if((Local && g_Config.m_ClShowLocalDirection) || (!Local && g_Config.m_ClShowDirection))
 		{
 			if(Player.m_Direction == -1)
 			{

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -545,10 +545,10 @@ void CPlayers::RenderPlayer(
 #if defined(CONF_VIDEORECORDER)
 	if(((!IVideo::Current() && (g_Config.m_ClShowDirection || g_Config.m_ClShowLocalDirection)) || (IVideo::Current() && g_Config.m_ClVideoShowDirection)) && ClientID >= 0 || DemoPlayer()->IsPlaying())
 #else
-	if((g_Config.m_ClShowDirection || g_Config.m_ClShowLocalDirection) && (ClientID >= 0) || DemoPlayer()->IsPlaying())
+	if((g_Config.m_ClShowDirection || g_Config.m_ClShowLocalDirection) && ClientID >= 0 || DemoPlayer()->IsPlaying())
 #endif
 	{
-		if((Local && g_Config.m_ClShowLocalDirection) || (!Local && g_Config.m_ClShowDirection))
+		if((Local && g_Config.m_ClShowLocalDirection) || !Local && g_Config.m_ClShowDirection)
 		{
 			if(Player.m_Direction == -1)
 			{

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -545,10 +545,10 @@ void CPlayers::RenderPlayer(
 #if defined(CONF_VIDEORECORDER)
 	if(((!IVideo::Current() && (g_Config.m_ClShowDirection || g_Config.m_ClShowLocalDirection)) || (IVideo::Current() && g_Config.m_ClVideoShowDirection)) && ClientID >= 0 || DemoPlayer()->IsPlaying())
 #else
-	if((g_Config.m_ClShowDirection || g_Config.m_ClShowLocalDirection) && ClientID >= 0 || DemoPlayer()->IsPlaying())
+	if(((g_Config.m_ClShowDirection || g_Config.m_ClShowLocalDirection) && ClientID >= 0) || DemoPlayer()->IsPlaying())
 #endif
 	{
-		if((Local && g_Config.m_ClShowLocalDirection) || !Local && g_Config.m_ClShowDirection)
+		if((Local && g_Config.m_ClShowLocalDirection) || (!Local && g_Config.m_ClShowDirection))
 		{
 			if(Player.m_Direction == -1)
 			{

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -543,12 +543,12 @@ void CPlayers::RenderPlayer(
 	Graphics()->SetColor(1.0f, 1.0f, 1.0f, Alpha);
 	Graphics()->QuadsSetRotation(0);
 #if defined(CONF_VIDEORECORDER)
-	if(((!IVideo::Current() && (g_Config.m_ClShowDirection || g_Config.m_ClShowLocalDirection)) || (IVideo::Current() && g_Config.m_ClVideoShowDirection)) && ClientID >= 0 || DemoPlayer()->IsPlaying())
+	if(((!IVideo::Current() && (g_Config.m_ClShowDirection >= 1)) || (IVideo::Current() && g_Config.m_ClVideoShowDirection)) && ClientID >= 0 || DemoPlayer()->IsPlaying())
 #else
-	if(((g_Config.m_ClShowDirection || g_Config.m_ClShowLocalDirection) && ClientID >= 0) || DemoPlayer()->IsPlaying())
+	if((g_Config.m_ClShowDirection >= 1 && ClientID >= 0) || DemoPlayer()->IsPlaying())
 #endif
 	{
-		if((Local && g_Config.m_ClShowLocalDirection) || (!Local && g_Config.m_ClShowDirection))
+		if((Local && g_Config.m_ClShowDirection == 2) || (!Local && g_Config.m_ClShowDirection >= 1))
 		{
 			if(Player.m_Direction == -1)
 			{


### PR DESCRIPTION
cl_show_local_direction allows you to see your own key presses during the game.

I changed the statements so it will allow local player to have key press arrows (inside the game), and I added a statement for configs (settings), so if you have cl_show_local_direction enabled, it will render the directions (arrows) for the local player. (Also affects demos and videos, same as cl_show_direction)

![ScreenShot](https://user-images.githubusercontent.com/57710259/131379491-c32047ef-7941-40eb-9ed5-381ea0cf5497.png)

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
