### PR TITLE
Harden open_link shell injection a bit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2211,6 +2211,7 @@ if(GTEST_FOUND OR DOWNLOAD_GTEST)
     mapbugs.cpp
     name_ban.cpp
     netaddr.cpp
+    open_link.cpp
     packer.cpp
     prng.cpp
     secure_random.cpp

--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -3450,10 +3450,10 @@ int open_link(const char *link)
 	str_format(aBuf, sizeof(aBuf), "start %s", link);
 	return (uintptr_t)ShellExecuteA(NULL, "open", link, NULL, NULL, SW_SHOWDEFAULT) > 32;
 #elif defined(CONF_PLATFORM_LINUX)
-	str_format(aBuf, sizeof(aBuf), "xdg-open %s >/dev/null 2>&1 &", link);
+	str_format(aBuf, sizeof(aBuf), "xdg-open '%s' >/dev/null 2>&1 &", link);
 	return system(aBuf) == 0;
 #elif defined(CONF_FAMILY_UNIX)
-	str_format(aBuf, sizeof(aBuf), "open %s &", link);
+	str_format(aBuf, sizeof(aBuf), "open '%s' &", link);
 	return system(aBuf) == 0;
 #endif
 }

--- a/src/test/open_link.cpp
+++ b/src/test/open_link.cpp
@@ -1,0 +1,23 @@
+#include <gtest/gtest.h>
+
+#include <base/system.h>
+
+TEST(OpenLink, InvalidFile)
+{
+	EXPECT_EQ(open_link("file:///invalid/path/to/file.txt"), 1);
+}
+
+TEST(OpenLink, SimpleShellInjection)
+{
+	EXPECT_EQ(open_link("exit 1"), 1);
+	EXPECT_EQ(open_link(";exit 1"), 1);
+	EXPECT_EQ(open_link(";$(exit 1)"), 1);
+	EXPECT_EQ(open_link("`exit 1`"), 1);
+	EXPECT_EQ(open_link("'\\''$(exit 1)'\\''"), 1);
+	EXPECT_EQ(open_link(";exit 1'\\"), 1);
+}
+
+TEST(OpenLink, TodoSinglequoteEscape)
+{
+	EXPECT_EQ(open_link("--help' >/dev/null 2>&1; exit 1; '"), 0);
+}


### PR DESCRIPTION
It is still not safe!
See the test marked with todo that is bypassing the single quotes.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [X] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
