### PR TITLE
Restore old behaviour, dont snap while specced

### DIFF
--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -1238,6 +1238,9 @@ bool CCharacter::CanSnapCharacter(int SnappingClient)
 
 void CCharacter::Snap(int SnappingClient)
 {
+	if (m_Paused)
+		return;
+
 	int ID = m_pPlayer->GetCID();
 
 	if(SnappingClient > -1 && !Server()->Translate(ID, SnappingClient))


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
