### PR TITLE
Make use of IO_MAX_PATH_LENGTH

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -1263,7 +1263,7 @@ const char *CClient::LoadMapSearch(const char *pMapName, SHA256_DIGEST *pWantedS
 		return pError;
 
 	// search for the map within subfolders
-	char aFilename[128];
+	char aFilename[IO_MAX_PATH_LENGTH];
 	str_format(aFilename, sizeof(aFilename), "%s.map", pMapName);
 	if(Storage()->FindFile(aFilename, "maps", IStorage::TYPE_ALL, aBuf, sizeof(aBuf)))
 		pError = LoadMap(pMapName, aBuf, pWantedSha256, WantedCrc);
@@ -1666,10 +1666,10 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket)
 				}
 				else
 				{
-					char aFilename[256];
+					char aFilename[IO_MAX_PATH_LENGTH];
 					FormatMapDownloadFilename(pMap, pMapSha256, MapCrc, false, aFilename, sizeof(aFilename));
 
-					char aTempFilename[256];
+					char aTempFilename[IO_MAX_PATH_LENGTH];
 					FormatMapDownloadFilename(pMap, pMapSha256, MapCrc, true, aTempFilename, sizeof(aTempFilename));
 
 					str_format(m_aMapdownloadFilename, sizeof(m_aMapdownloadFilename), "downloadedmaps/%s", aTempFilename);
@@ -2350,9 +2350,9 @@ void CClient::FinishMapDownload()
 	m_MapdownloadTotalsize = -1;
 	SHA256_DIGEST *pSha256 = m_MapdownloadSha256Present ? &m_MapdownloadSha256 : 0;
 
-	char aTmp[MAX_PATH_LENGTH];
-	char aMapFileTemp[MAX_PATH_LENGTH];
-	char aMapFile[MAX_PATH_LENGTH];
+	char aTmp[IO_MAX_PATH_LENGTH];
+	char aMapFileTemp[IO_MAX_PATH_LENGTH];
+	char aMapFile[IO_MAX_PATH_LENGTH];
 	FormatMapDownloadFilename(m_aMapdownloadName, pSha256, m_MapdownloadCrc, true, aTmp, sizeof(aTmp));
 	str_format(aMapFileTemp, sizeof(aMapFileTemp), "downloadedmaps/%s", aTmp);
 	FormatMapDownloadFilename(m_aMapdownloadName, pSha256, m_MapdownloadCrc, false, aTmp, sizeof(aTmp));
@@ -3724,7 +3724,7 @@ void CClient::SaveReplay(const int Length)
 	{
 		// First we stop the recorder to slice correctly the demo after
 		DemoRecorder_Stop(RECORDER_REPLAYS);
-		char aFilename[MAX_PATH_LENGTH];
+		char aFilename[IO_MAX_PATH_LENGTH];
 
 		char aDate[64];
 		str_timestamp(aDate, sizeof(aDate));
@@ -3875,7 +3875,7 @@ void CClient::DemoRecorder_Start(const char *pFilename, bool WithTimestamp, int 
 		m_pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "demorec/record", "client is not online");
 	else
 	{
-		char aFilename[128];
+		char aFilename[IO_MAX_PATH_LENGTH];
 		if(WithTimestamp)
 		{
 			char aDate[20];
@@ -3977,7 +3977,7 @@ void CClient::Con_BenchmarkQuit(IConsole::IResult *pResult, void *pUserData)
 
 void CClient::BenchmarkQuit(int Seconds, const char *pFilename)
 {
-	char aBuf[MAX_PATH_LENGTH];
+	char aBuf[IO_MAX_PATH_LENGTH];
 	m_BenchmarkFile = Storage()->OpenFile(pFilename, IOFLAG_WRITE, IStorage::TYPE_ABSOLUTE, aBuf, sizeof(aBuf));
 	m_BenchmarkStopTime = time_get() + time_freq() * Seconds;
 }
@@ -4063,7 +4063,7 @@ void CClient::ToggleWindowVSync()
 void CClient::LoadFont()
 {
 	static CFont *pDefaultFont = 0;
-	char aFilename[512];
+	char aFilename[IO_MAX_PATH_LENGTH];
 	char aBuff[1024];
 	const char *pFontFile = "fonts/DejaVuSans.ttf";
 	const char *apFallbackFontFiles[] =

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -166,8 +166,8 @@ class CClient : public IClient, public CDemoPlayer::IListener
 	// pinging
 	int64_t m_PingStartTime;
 
-	char m_aCurrentMap[MAX_PATH_LENGTH];
-	char m_aCurrentMapPath[MAX_PATH_LENGTH];
+	char m_aCurrentMap[IO_MAX_PATH_LENGTH];
+	char m_aCurrentMapPath[IO_MAX_PATH_LENGTH];
 
 	char m_aTimeoutCodes[NUM_DUMMIES][32];
 	bool m_aTimeoutCodeSent[NUM_DUMMIES];
@@ -175,8 +175,8 @@ class CClient : public IClient, public CDemoPlayer::IListener
 
 	//
 	char m_aCmdConnect[256];
-	char m_aCmdPlayDemo[MAX_PATH_LENGTH];
-	char m_aCmdEditMap[MAX_PATH_LENGTH];
+	char m_aCmdPlayDemo[IO_MAX_PATH_LENGTH];
+	char m_aCmdEditMap[IO_MAX_PATH_LENGTH];
 
 	// map download
 	std::shared_ptr<CGetFile> m_pMapdownloadTask;

--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -506,7 +506,7 @@ IGraphics::CTextureHandle CGraphics_Threaded::LoadTexture(const char *pFilename,
 
 int CGraphics_Threaded::LoadPNG(CImageInfo *pImg, const char *pFilename, int StorageType)
 {
-	char aCompleteFilename[512];
+	char aCompleteFilename[IO_MAX_PATH_LENGTH];
 	unsigned char *pBuffer;
 	png_t Png; // ignore_convention
 

--- a/src/engine/client/http.h
+++ b/src/engine/client/http.h
@@ -118,11 +118,11 @@ class CGetFile : public CRequest
 
 	IStorage *m_pStorage;
 
-	char m_aDestFull[MAX_PATH_LENGTH];
+	char m_aDestFull[IO_MAX_PATH_LENGTH];
 	IOHANDLE m_File;
 
 protected:
-	char m_aDest[MAX_PATH_LENGTH];
+	char m_aDest[IO_MAX_PATH_LENGTH];
 	int m_StorageType;
 
 	virtual int OnCompletion(int State);

--- a/src/engine/client/sqlite.cpp
+++ b/src/engine/client/sqlite.cpp
@@ -27,7 +27,7 @@ int SqliteHandleError(IConsole *pConsole, int Error, sqlite3 *pSqlite, const cha
 
 CSqlite SqliteOpen(IConsole *pConsole, IStorage *pStorage, const char *pPath)
 {
-	char aFullPath[MAX_PATH_LENGTH];
+	char aFullPath[IO_MAX_PATH_LENGTH];
 	pStorage->GetCompletePath(IStorage::TYPE_SAVE, pPath, aFullPath, sizeof(aFullPath));
 	sqlite3 *pSqlite = nullptr;
 	const bool ErrorOpening = SQLITE_HANDLE_ERROR(sqlite3_open(aFullPath, &pSqlite)) != SQLITE_OK;

--- a/src/engine/client/text.cpp
+++ b/src/engine/client/text.cpp
@@ -109,13 +109,13 @@ public:
 	}
 
 	void *m_pBuf;
-	char m_aFilename[512];
+	char m_aFilename[IO_MAX_PATH_LENGTH];
 	FT_Face m_FtFace;
 
 	struct SFontFallBack
 	{
 		void *m_pBuf;
-		char m_aFilename[512];
+		char m_aFilename[IO_MAX_PATH_LENGTH];
 		FT_Face m_FtFace;
 	};
 
@@ -658,7 +658,7 @@ public:
 		pAttr->m_VertBufferBindingIndex = -1;
 
 		IStorage *pStorage = Kernel()->RequestInterface<IStorage>();
-		char aFilename[512];
+		char aFilename[IO_MAX_PATH_LENGTH];
 		const char *pFontFile = "fonts/Icons.ttf";
 		IOHANDLE File = pStorage->OpenFile(pFontFile, IOFLAG_READ, IStorage::TYPE_ALL, aFilename, sizeof(aFilename));
 		if(File)

--- a/src/engine/client/updater.cpp
+++ b/src/engine/client/updater.cpp
@@ -200,7 +200,7 @@ bool CUpdater::ReplaceClient()
 {
 	dbg_msg("updater", "replacing " PLAT_CLIENT_EXEC);
 	bool Success = true;
-	char aPath[512];
+	char aPath[IO_MAX_PATH_LENGTH];
 
 	// Replace running executable by renaming twice...
 	m_pStorage->RemoveBinaryFile(CLIENT_EXEC ".old");
@@ -224,7 +224,7 @@ bool CUpdater::ReplaceServer()
 {
 	dbg_msg("updater", "replacing " PLAT_SERVER_EXEC);
 	bool Success = true;
-	char aPath[512];
+	char aPath[IO_MAX_PATH_LENGTH];
 
 	//Replace running executable by renaming twice...
 	m_pStorage->RemoveBinaryFile(SERVER_EXEC ".old");
@@ -246,7 +246,7 @@ bool CUpdater::ReplaceServer()
 
 void CUpdater::ParseUpdate()
 {
-	char aPath[512];
+	char aPath[IO_MAX_PATH_LENGTH];
 	IOHANDLE File = m_pStorage->OpenFile(m_pStorage->GetBinaryPath("update/update.json", aPath, sizeof aPath), IOFLAG_READ, IStorage::TYPE_ABSOLUTE);
 	if(!File)
 		return;

--- a/src/engine/server/databases/sqlite.cpp
+++ b/src/engine/server/databases/sqlite.cpp
@@ -49,7 +49,7 @@ public:
 
 private:
 	// copy of config vars
-	char m_aFilename[512];
+	char m_aFilename[IO_MAX_PATH_LENGTH];
 	bool m_Setup;
 
 	sqlite3 *m_pDb;

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -3095,7 +3095,7 @@ void CServer::DemoRecorder_HandleAutoStart()
 	if(g_Config.m_SvAutoDemoRecord)
 	{
 		m_aDemoRecorder[MAX_CLIENTS].Stop();
-		char aFilename[128];
+		char aFilename[IO_MAX_PATH_LENGTH];
 		char aDate[20];
 		str_timestamp(aDate, sizeof(aDate));
 		str_format(aFilename, sizeof(aFilename), "demos/%s_%s.demo", "auto/autorecord", aDate);
@@ -3121,8 +3121,8 @@ void CServer::SaveDemo(int ClientID, float Time)
 		m_aDemoRecorder[ClientID].Stop();
 
 		// rename the demo
-		char aOldFilename[256];
-		char aNewFilename[256];
+		char aOldFilename[IO_MAX_PATH_LENGTH];
+		char aNewFilename[IO_MAX_PATH_LENGTH];
 		str_format(aOldFilename, sizeof(aOldFilename), "demos/%s_%d_%d_tmp.demo", m_aCurrentMap, m_NetServer.Address().port, ClientID);
 		str_format(aNewFilename, sizeof(aNewFilename), "demos/%s_%s_%5.2f.demo", m_aCurrentMap, m_aClients[ClientID].m_aName, Time);
 		Storage()->RenameFile(aOldFilename, aNewFilename, IStorage::TYPE_SAVE);
@@ -3133,7 +3133,7 @@ void CServer::StartRecord(int ClientID)
 {
 	if(g_Config.m_SvPlayerDemoRecord)
 	{
-		char aFilename[128];
+		char aFilename[IO_MAX_PATH_LENGTH];
 		str_format(aFilename, sizeof(aFilename), "demos/%s_%d_%d_tmp.demo", m_aCurrentMap, m_NetServer.Address().port, ClientID);
 		m_aDemoRecorder[ClientID].Start(Storage(), Console(), aFilename, GameServer()->NetVersion(), m_aCurrentMap, &m_aCurrentMapSha256[SIX], m_aCurrentMapCrc[SIX], "server", m_aCurrentMapSize[SIX], m_apCurrentMapData[SIX]);
 	}
@@ -3145,7 +3145,7 @@ void CServer::StopRecord(int ClientID)
 	{
 		m_aDemoRecorder[ClientID].Stop();
 
-		char aFilename[128];
+		char aFilename[IO_MAX_PATH_LENGTH];
 		str_format(aFilename, sizeof(aFilename), "demos/%s_%d_%d_tmp.demo", m_aCurrentMap, m_NetServer.Address().port, ClientID);
 		Storage()->RemoveFile(aFilename, IStorage::TYPE_SAVE);
 	}
@@ -3159,7 +3159,7 @@ bool CServer::IsRecording(int ClientID)
 void CServer::ConRecord(IConsole::IResult *pResult, void *pUser)
 {
 	CServer *pServer = (CServer *)pUser;
-	char aFilename[128];
+	char aFilename[IO_MAX_PATH_LENGTH];
 
 	if(pResult->NumArguments())
 		str_format(aFilename, sizeof(aFilename), "demos/%s.demo", pResult->GetString(0));

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -241,7 +241,7 @@ public:
 		SIXUP,
 	};
 
-	char m_aCurrentMap[MAX_PATH_LENGTH];
+	char m_aCurrentMap[IO_MAX_PATH_LENGTH];
 	SHA256_DIGEST m_aCurrentMapSha256[2];
 	unsigned m_aCurrentMapCrc[2];
 	unsigned char *m_apCurrentMapData[2];

--- a/src/engine/shared/demo.h
+++ b/src/engine/shared/demo.h
@@ -97,7 +97,7 @@ private:
 	class IConsole *m_pConsole;
 	IOHANDLE m_File;
 	long m_MapOffset;
-	char m_aFilename[256];
+	char m_aFilename[IO_MAX_PATH_LENGTH];
 	CKeyFrame *m_pKeyFrames;
 	CMapInfo m_MapInfo;
 	int m_SpeedIndex;

--- a/src/engine/shared/engine.cpp
+++ b/src/engine/shared/engine.cpp
@@ -44,7 +44,7 @@ public:
 		{
 			char aBuf[32];
 			str_timestamp(aBuf, sizeof(aBuf));
-			char aFilenameSent[128], aFilenameRecv[128];
+			char aFilenameSent[IO_MAX_PATH_LENGTH], aFilenameRecv[IO_MAX_PATH_LENGTH];
 			str_format(aFilenameSent, sizeof(aFilenameSent), "dumps/network_sent_%s.txt", aBuf);
 			str_format(aFilenameRecv, sizeof(aFilenameRecv), "dumps/network_recv_%s.txt", aBuf);
 			CNetBase::OpenLog(pEngine->m_pStorage->OpenFile(aFilenameSent, IOFLAG_WRITE, IStorage::TYPE_SAVE),

--- a/src/engine/shared/fifo.h
+++ b/src/engine/shared/fifo.h
@@ -8,7 +8,7 @@
 class CFifo
 {
 	IConsole *m_pConsole;
-	char m_aFilename[MAX_PATH_LENGTH];
+	char m_aFilename[IO_MAX_PATH_LENGTH];
 	int m_Flag;
 	int m_File;
 

--- a/src/engine/shared/filecollection.h
+++ b/src/engine/shared/filecollection.h
@@ -22,7 +22,7 @@ class CFileCollection
 	int m_FileDescLength;
 	char m_aFileExt[32];
 	int m_FileExtLength;
-	char m_aPath[512];
+	char m_aPath[IO_MAX_PATH_LENGTH];
 	IStorage *m_pStorage;
 	int64_t m_Remove; // Timestamp we want to remove
 

--- a/src/engine/shared/storage.cpp
+++ b/src/engine/shared/storage.cpp
@@ -13,12 +13,12 @@
 class CStorage : public IStorage
 {
 public:
-	char m_aaStoragePaths[MAX_PATHS][MAX_PATH_LENGTH];
+	char m_aaStoragePaths[MAX_PATHS][IO_MAX_PATH_LENGTH];
 	int m_NumPaths;
-	char m_aDatadir[MAX_PATH_LENGTH];
-	char m_aUserdir[MAX_PATH_LENGTH];
-	char m_aCurrentdir[MAX_PATH_LENGTH];
-	char m_aBinarydir[MAX_PATH_LENGTH];
+	char m_aDatadir[IO_MAX_PATH_LENGTH];
+	char m_aUserdir[IO_MAX_PATH_LENGTH];
+	char m_aCurrentdir[IO_MAX_PATH_LENGTH];
+	char m_aBinarydir[IO_MAX_PATH_LENGTH];
 
 	CStorage()
 	{
@@ -55,7 +55,7 @@ public:
 		// add save directories
 		if(StorageType != STORAGETYPE_BASIC && m_NumPaths && (!m_aaStoragePaths[TYPE_SAVE][0] || !fs_makedir(m_aaStoragePaths[TYPE_SAVE])))
 		{
-			char aPath[MAX_PATH_LENGTH];
+			char aPath[IO_MAX_PATH_LENGTH];
 			if(StorageType == STORAGETYPE_CLIENT)
 			{
 				fs_makedir(GetPath(TYPE_SAVE, "screenshots", aPath, sizeof(aPath)));
@@ -100,15 +100,15 @@ public:
 			for(unsigned i = 0; pArgv0[i]; i++)
 				if(pArgv0[i] == '/' || pArgv0[i] == '\\')
 					Pos = i;
-			if(Pos < MAX_PATH_LENGTH)
+			if(Pos < IO_MAX_PATH_LENGTH)
 			{
-				char aBuffer[MAX_PATH_LENGTH];
+				char aBuffer[IO_MAX_PATH_LENGTH];
 				str_copy(aBuffer, pArgv0, Pos + 1);
 				str_append(aBuffer, "/storage.cfg", sizeof(aBuffer));
 				File = io_open(aBuffer, IOFLAG_READ);
 			}
 
-			if(Pos >= MAX_PATH_LENGTH || !File)
+			if(Pos >= IO_MAX_PATH_LENGTH || !File)
 			{
 				dbg_msg("storage", "couldn't open storage.cfg");
 				return;
@@ -150,7 +150,7 @@ public:
 		{
 			if(m_aUserdir[0])
 			{
-				str_copy(m_aaStoragePaths[m_NumPaths++], m_aUserdir, MAX_PATH_LENGTH);
+				str_copy(m_aaStoragePaths[m_NumPaths++], m_aUserdir, IO_MAX_PATH_LENGTH);
 				dbg_msg("storage", "added path '$USERDIR' ('%s')", m_aUserdir);
 			}
 		}
@@ -158,7 +158,7 @@ public:
 		{
 			if(m_aDatadir[0])
 			{
-				str_copy(m_aaStoragePaths[m_NumPaths++], m_aDatadir, MAX_PATH_LENGTH);
+				str_copy(m_aaStoragePaths[m_NumPaths++], m_aDatadir, IO_MAX_PATH_LENGTH);
 				dbg_msg("storage", "added path '$DATADIR' ('%s')", m_aDatadir);
 			}
 		}
@@ -171,7 +171,7 @@ public:
 		{
 			if(fs_is_dir(pPath))
 			{
-				str_copy(m_aaStoragePaths[m_NumPaths++], pPath, MAX_PATH_LENGTH);
+				str_copy(m_aaStoragePaths[m_NumPaths++], pPath, IO_MAX_PATH_LENGTH);
 				dbg_msg("storage", "added path '%s'", pPath);
 			}
 		}
@@ -205,10 +205,10 @@ public:
 				if(pArgv0[i] == '/' || pArgv0[i] == '\\')
 					Pos = i;
 
-			if(Pos < MAX_PATH_LENGTH)
+			if(Pos < IO_MAX_PATH_LENGTH)
 			{
-				char aBuf[MAX_PATH_LENGTH];
-				char aDir[MAX_PATH_LENGTH];
+				char aBuf[IO_MAX_PATH_LENGTH];
+				char aDir[IO_MAX_PATH_LENGTH];
 				str_copy(aDir, pArgv0, Pos + 1);
 				str_format(aBuf, sizeof(aBuf), "%s/data/mapres", aDir);
 				if(fs_is_dir(aBuf))
@@ -266,9 +266,9 @@ public:
 				if(pArgv0[i] == '/' || pArgv0[i] == '\\')
 					Pos = i;
 
-			if(Pos < MAX_PATH_LENGTH)
+			if(Pos < IO_MAX_PATH_LENGTH)
 			{
-				char aBuf[MAX_PATH_LENGTH];
+				char aBuf[IO_MAX_PATH_LENGTH];
 				str_copy(m_aBinarydir, pArgv0, Pos + 1);
 				str_format(aBuf, sizeof(aBuf), "%s/" PLAT_SERVER_EXEC, m_aBinarydir);
 				IOHANDLE File = io_open(aBuf, IOFLAG_READ);
@@ -302,7 +302,7 @@ public:
 
 	virtual void ListDirectoryInfo(int Type, const char *pPath, FS_LISTDIR_CALLBACK_FILEINFO pfnCallback, void *pUser)
 	{
-		char aBuffer[MAX_PATH_LENGTH];
+		char aBuffer[IO_MAX_PATH_LENGTH];
 		if(Type == TYPE_ALL)
 		{
 			// list all available directories
@@ -318,7 +318,7 @@ public:
 
 	virtual void ListDirectory(int Type, const char *pPath, FS_LISTDIR_CALLBACK pfnCallback, void *pUser)
 	{
-		char aBuffer[MAX_PATH_LENGTH];
+		char aBuffer[IO_MAX_PATH_LENGTH];
 		if(Type == TYPE_ALL)
 		{
 			// list all available directories
@@ -347,7 +347,7 @@ public:
 
 	virtual IOHANDLE OpenFile(const char *pFilename, int Flags, int Type, char *pBuffer = 0, int BufferSize = 0)
 	{
-		char aBuffer[MAX_PATH_LENGTH];
+		char aBuffer[IO_MAX_PATH_LENGTH];
 		if(!pBuffer)
 		{
 			pBuffer = aBuffer;
@@ -419,8 +419,8 @@ public:
 				return 0;
 
 			// search within the folder
-			char aBuf[MAX_PATH_LENGTH];
-			char aPath[MAX_PATH_LENGTH];
+			char aBuf[IO_MAX_PATH_LENGTH];
+			char aPath[IO_MAX_PATH_LENGTH];
 			str_format(aPath, sizeof(aPath), "%s/%s", Data.m_pPath, pName);
 			Data.m_pPath = aPath;
 			fs_listdir(Data.m_pStorage->GetPath(Type, aPath, aBuf, sizeof(aBuf)), FindFileCallback, Type, &Data);
@@ -443,7 +443,7 @@ public:
 			return false;
 
 		pBuffer[0] = 0;
-		char aBuf[MAX_PATH_LENGTH];
+		char aBuf[IO_MAX_PATH_LENGTH];
 		CFindCBData Data;
 		Data.m_pStorage = this;
 		Data.m_pFilename = pFilename;
@@ -475,7 +475,7 @@ public:
 		if(Type < TYPE_ABSOLUTE || Type == TYPE_ALL || Type >= m_NumPaths)
 			return false;
 
-		char aBuffer[MAX_PATH_LENGTH];
+		char aBuffer[IO_MAX_PATH_LENGTH];
 		GetPath(Type, pFilename, aBuffer, sizeof(aBuffer));
 
 		bool Success = !fs_remove(aBuffer);
@@ -486,7 +486,7 @@ public:
 
 	virtual bool RemoveBinaryFile(const char *pFilename)
 	{
-		char aBuffer[MAX_PATH_LENGTH];
+		char aBuffer[IO_MAX_PATH_LENGTH];
 		GetBinaryPath(pFilename, aBuffer, sizeof(aBuffer));
 
 		bool Success = !fs_remove(aBuffer);
@@ -500,8 +500,8 @@ public:
 		if(Type < 0 || Type >= m_NumPaths)
 			return false;
 
-		char aOldBuffer[MAX_PATH_LENGTH];
-		char aNewBuffer[MAX_PATH_LENGTH];
+		char aOldBuffer[IO_MAX_PATH_LENGTH];
+		char aNewBuffer[IO_MAX_PATH_LENGTH];
 		GetPath(Type, pOldFilename, aOldBuffer, sizeof(aOldBuffer));
 		GetPath(Type, pNewFilename, aNewBuffer, sizeof(aNewBuffer));
 
@@ -513,8 +513,8 @@ public:
 
 	virtual bool RenameBinaryFile(const char *pOldFilename, const char *pNewFilename)
 	{
-		char aOldBuffer[MAX_PATH_LENGTH];
-		char aNewBuffer[MAX_PATH_LENGTH];
+		char aOldBuffer[IO_MAX_PATH_LENGTH];
+		char aNewBuffer[IO_MAX_PATH_LENGTH];
 		GetBinaryPath(pOldFilename, aOldBuffer, sizeof(aOldBuffer));
 		GetBinaryPath(pNewFilename, aNewBuffer, sizeof(aNewBuffer));
 
@@ -532,7 +532,7 @@ public:
 		if(Type < 0 || Type >= m_NumPaths)
 			return false;
 
-		char aBuffer[MAX_PATH_LENGTH];
+		char aBuffer[IO_MAX_PATH_LENGTH];
 		GetPath(Type, pFoldername, aBuffer, sizeof(aBuffer));
 
 		bool Success = !fs_makedir(aBuffer);

--- a/src/engine/storage.h
+++ b/src/engine/storage.h
@@ -7,8 +7,7 @@
 
 enum
 {
-	MAX_PATHS = 16,
-	MAX_PATH_LENGTH = 512
+	MAX_PATHS = 16
 };
 
 class IStorage : public IInterface

--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -776,7 +776,7 @@ void CGameConsole::Toggle(int Type)
 void CGameConsole::Dump(int Type)
 {
 	CInstance *pConsole = Type == CONSOLETYPE_REMOTE ? &m_RemoteConsole : &m_LocalConsole;
-	char aFilename[128];
+	char aFilename[IO_MAX_PATH_LENGTH];
 	char aDate[20];
 
 	str_timestamp(aDate, sizeof(aDate));

--- a/src/game/client/components/mapimages.cpp
+++ b/src/game/client/components/mapimages.cpp
@@ -100,10 +100,10 @@ void CMapImages::OnMapLoadImpl(class CLayers *pLayers, IMap *pMap)
 		CMapItemImage *pImg = (CMapItemImage *)pMap->GetItem(Start + i, 0, 0);
 		if(pImg->m_External)
 		{
-			char Buf[256];
+			char aPath[IO_MAX_PATH_LENGTH];
 			char *pName = (char *)pMap->GetData(pImg->m_ImageName);
-			str_format(Buf, sizeof(Buf), "mapres/%s.png", pName);
-			m_aTextures[i] = Graphics()->LoadTexture(Buf, IStorage::TYPE_ALL, CImageInfo::FORMAT_AUTO, LoadFlag);
+			str_format(aPath, sizeof(aPath), "mapres/%s.png", pName);
+			m_aTextures[i] = Graphics()->LoadTexture(aPath, IStorage::TYPE_ALL, CImageInfo::FORMAT_AUTO, LoadFlag);
 		}
 		else
 		{

--- a/src/game/client/components/mapimages.h
+++ b/src/game/client/components/mapimages.h
@@ -47,7 +47,7 @@ class CMapImages : public CComponent
 	int m_aTextureUsedByTileOrQuadLayerFlag[64]; // 0: nothing, 1(as flag): tile layer, 2(as flag): quad layer
 	int m_Count;
 
-	char m_aEntitiesPath[MAX_PATH_LENGTH];
+	char m_aEntitiesPath[IO_MAX_PATH_LENGTH];
 
 	bool HasFrontLayer(EMapImageModType ModType);
 	bool HasSpeedupLayer(EMapImageModType ModType);

--- a/src/game/client/components/maplayers.cpp
+++ b/src/game/client/components/maplayers.cpp
@@ -1656,7 +1656,7 @@ void CMapLayers::OnRender()
 				CTile *pTiles = (CTile *)m_pLayers->Map()->GetData(pTMap->m_Data);
 				CServerInfo CurrentServerInfo;
 				Client()->GetServerInfo(&CurrentServerInfo);
-				char aFilename[256];
+				char aFilename[IO_MAX_PATH_LENGTH];
 				str_format(aFilename, sizeof(aFilename), "dumps/tilelayer_dump_%s-%d-%d-%dx%d.txt", CurrentServerInfo.m_aMap, g, l, pTMap->m_Width, pTMap->m_Height);
 				IOHANDLE File = Storage()->OpenFile(aFilename, IOFLAG_WRITE, IStorage::TYPE_SAVE);
 				if(File)

--- a/src/game/client/components/menu_background.cpp
+++ b/src/game/client/components/menu_background.cpp
@@ -148,7 +148,7 @@ int CMenuBackground::ThemeIconScan(const char *pName, int IsDir, int DirType, vo
 	{
 		if(str_comp(Theme.m_Name, aThemeName) == 0 || (!Theme.m_Name[0] && str_comp(aThemeName, "none") == 0))
 		{
-			char aBuf[MAX_PATH_LENGTH];
+			char aBuf[IO_MAX_PATH_LENGTH];
 			str_format(aBuf, sizeof(aBuf), "themes/%s", pName);
 			CImageInfo Info;
 			if(!pSelf->Graphics()->LoadPNG(&Info, aBuf, DirType))

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -2877,7 +2877,7 @@ int CMenus::MenuImageScan(const char *pName, int IsDir, int DirType, void *pUser
 	if(IsDir || !str_endswith(pName, ".png"))
 		return 0;
 
-	char aBuf[MAX_PATH_LENGTH];
+	char aBuf[IO_MAX_PATH_LENGTH];
 	str_format(aBuf, sizeof(aBuf), "menuimages/%s", pName);
 	CImageInfo Info;
 	if(!pSelf->Graphics()->LoadPNG(&Info, aBuf, DirType))

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -374,7 +374,7 @@ protected:
 
 	struct CDemoItem
 	{
-		char m_aFilename[128];
+		char m_aFilename[IO_MAX_PATH_LENGTH];
 		char m_aName[128];
 		bool m_IsDir;
 		int m_StorageType;
@@ -624,7 +624,7 @@ public:
 	// Ghost
 	struct CGhostItem
 	{
-		char m_aFilename[256];
+		char m_aFilename[IO_MAX_PATH_LENGTH];
 		char m_aPlayer[MAX_NAME_LENGTH];
 
 		int m_Time;

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -122,7 +122,7 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 				if(!str_endswith(m_aCurrentDemoFile, ".demo"))
 					str_append(m_aCurrentDemoFile, ".demo", sizeof(m_aCurrentDemoFile));
 
-				char aPath[512];
+				char aPath[IO_MAX_PATH_LENGTH];
 				str_format(aPath, sizeof(aPath), "%s/%s", m_aCurrentDemoFolder, m_aCurrentDemoFile);
 
 				IOHANDLE DemoFile = Storage()->OpenFile(aPath, IOFLAG_READ, IStorage::TYPE_SAVE);
@@ -1257,8 +1257,8 @@ void CMenus::RenderDemoList(CUIRect MainView)
 	static int s_DirectoryButtonID = 0;
 	if(DoButton_Menu(&s_DirectoryButtonID, Localize("Demos directory"), 0, &DirectoryButton))
 	{
-		char aBuf[MAX_PATH_LENGTH];
-		char aBufFull[MAX_PATH_LENGTH + 7];
+		char aBuf[IO_MAX_PATH_LENGTH];
+		char aBufFull[IO_MAX_PATH_LENGTH + 7];
 		Storage()->GetCompletePath(IStorage::TYPE_SAVE, "demos", aBuf, sizeof(aBuf));
 		Storage()->CreateFolder("demos", IStorage::TYPE_SAVE);
 		str_format(aBufFull, sizeof(aBufFull), "file://%s", aBuf);

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -899,7 +899,7 @@ int CMenus::GhostlistFetchCallback(const char *pName, int IsDir, int StorageType
 	if(IsDir || !str_endswith(pName, ".gho") || !str_startswith(pName, pMap))
 		return 0;
 
-	char aFilename[256];
+	char aFilename[IO_MAX_PATH_LENGTH];
 	str_format(aFilename, sizeof(aFilename), "%s/%s", pSelf->m_pClient->m_Ghost.GetGhostDir(), pName);
 
 	CGhostInfo Info;

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -274,8 +274,8 @@ void CMenus::RenderSettingsGeneral(CUIRect MainView)
 		static int s_ThemesButtonID = 0;
 		if(DoButton_Menu(&s_ThemesButtonID, Localize("Themes directory"), 0, &DirectoryButton))
 		{
-			char aBuf[MAX_PATH_LENGTH];
-			char aBufFull[MAX_PATH_LENGTH + 7];
+			char aBuf[IO_MAX_PATH_LENGTH];
+			char aBufFull[IO_MAX_PATH_LENGTH + 7];
 			Storage()->GetCompletePath(IStorage::TYPE_SAVE, "themes", aBuf, sizeof(aBuf));
 			Storage()->CreateFolder("themes", IStorage::TYPE_SAVE);
 			str_format(aBufFull, sizeof(aBufFull), "file://%s", aBuf);
@@ -742,8 +742,8 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 	static int s_DirectoryButtonID = 0;
 	if(DoButton_Menu(&s_DirectoryButtonID, Localize("Skins directory"), 0, &DirectoryButton))
 	{
-		char aBuf[MAX_PATH_LENGTH];
-		char aBufFull[MAX_PATH_LENGTH + 7];
+		char aBuf[IO_MAX_PATH_LENGTH];
+		char aBufFull[IO_MAX_PATH_LENGTH + 7];
 		Storage()->GetCompletePath(IStorage::TYPE_SAVE, "skins", aBuf, sizeof(aBuf));
 		Storage()->CreateFolder("skins", IStorage::TYPE_SAVE);
 		str_format(aBufFull, sizeof(aBufFull), "file://%s", aBuf);
@@ -1510,7 +1510,7 @@ void LoadLanguageIndexfile(IStorage *pStorage, IConsole *pConsole, sorted_array<
 			continue;
 		}
 
-		char aFileName[128];
+		char aFileName[IO_MAX_PATH_LENGTH];
 		str_format(aFileName, sizeof(aFileName), "languages/%s.txt", aOrigin);
 		pLanguages->add(CLanguage(aReplacement, aFileName, str_toint(pLine + 3)));
 	}

--- a/src/game/client/components/menus_settings_assets.cpp
+++ b/src/game/client/components/menus_settings_assets.cpp
@@ -11,7 +11,7 @@ void CMenus::LoadEntities(SCustomEntities *pEntitiesItem, void *pUser)
 {
 	CMenus *pThis = (CMenus *)pUser;
 
-	char aBuff[MAX_PATH_LENGTH];
+	char aBuff[IO_MAX_PATH_LENGTH];
 
 	if(str_comp(pEntitiesItem->m_aName, "default") == 0)
 	{
@@ -81,7 +81,7 @@ int CMenus::EntitiesScan(const char *pName, int IsDir, int DirType, void *pUser)
 	{
 		if(str_endswith(pName, ".png"))
 		{
-			char aName[MAX_PATH_LENGTH];
+			char aName[IO_MAX_PATH_LENGTH];
 			str_truncate(aName, sizeof(aName), pName, str_length(pName) - 4);
 			// default is reserved
 			if(str_comp(aName, "default") == 0)
@@ -100,7 +100,7 @@ int CMenus::EntitiesScan(const char *pName, int IsDir, int DirType, void *pUser)
 template<typename TName>
 static void LoadAsset(TName *pAssetItem, const char *pAssetName, IGraphics *pGraphics, void *pUser)
 {
-	char aBuff[MAX_PATH_LENGTH];
+	char aBuff[IO_MAX_PATH_LENGTH];
 
 	if(str_comp(pAssetItem->m_aName, "default") == 0)
 	{
@@ -155,7 +155,7 @@ static int AssetScan(const char *pName, int IsDir, int DirType, sorted_array<TNa
 	{
 		if(str_endswith(pName, ".png"))
 		{
-			char aName[MAX_PATH_LENGTH];
+			char aName[IO_MAX_PATH_LENGTH];
 			str_truncate(aName, sizeof(aName), pName, str_length(pName) - 4);
 			// default is reserved
 			if(str_comp(aName, "default") == 0)
@@ -534,8 +534,8 @@ void CMenus::RenderSettingsCustom(CUIRect MainView)
 	static int s_AssetsDirID = 0;
 	if(DoButton_Menu(&s_AssetsDirID, Localize("Assets directory"), 0, &DirectoryButton))
 	{
-		char aBuf[MAX_PATH_LENGTH];
-		char aBufFull[MAX_PATH_LENGTH + 7];
+		char aBuf[IO_MAX_PATH_LENGTH];
+		char aBufFull[IO_MAX_PATH_LENGTH + 7];
 		if(s_CurCustomTab == 0)
 			str_copy(aBufFull, "assets/entities", sizeof(aBufFull));
 		else if(s_CurCustomTab == 1)

--- a/src/game/client/components/menus_start.cpp
+++ b/src/game/client/components/menus_start.cpp
@@ -115,7 +115,7 @@ void CMenus::RenderStartMenu(CUIRect MainView)
 		}
 		else
 		{
-			char aBuf[MAX_PATH_LENGTH];
+			char aBuf[IO_MAX_PATH_LENGTH];
 			Storage()->GetBinaryPath(PLAT_SERVER_EXEC, aBuf, sizeof(aBuf));
 			IOHANDLE File = io_open(aBuf, IOFLAG_READ);
 			if(File)

--- a/src/game/client/components/race_demo.cpp
+++ b/src/game/client/components/race_demo.cpp
@@ -222,7 +222,7 @@ bool CRaceDemo::CheckDemo(int Time) const
 			return false;
 
 		// delete old demo
-		char aFilename[512];
+		char aFilename[IO_MAX_PATH_LENGTH];
 		str_format(aFilename, sizeof(aFilename), "%s/%s.demo", ms_pRaceDemoDir, Demo.m_aName);
 		Storage()->RemoveFile(aFilename, IStorage::TYPE_SAVE);
 	}

--- a/src/game/client/components/skins.cpp
+++ b/src/game/client/components/skins.cpp
@@ -70,7 +70,7 @@ int CSkins::SkinScan(const char *pName, int IsDir, int DirType, void *pUser)
 			return 0;
 	}
 
-	char aBuf[MAX_PATH_LENGTH];
+	char aBuf[IO_MAX_PATH_LENGTH];
 	str_format(aBuf, sizeof(aBuf), "skins/%s", pName);
 	return pSelf->LoadSkin(aNameWithoutPng, aBuf, DirType);
 }
@@ -405,7 +405,7 @@ int CSkins::FindImpl(const char *pName)
 	{
 		if(d.front().m_pTask && d.front().m_pTask->State() == HTTP_DONE)
 		{
-			char aPath[MAX_PATH_LENGTH];
+			char aPath[IO_MAX_PATH_LENGTH];
 			str_format(aPath, sizeof(aPath), "downloadedskins/%s.png", d.front().m_aName);
 			Storage()->RenameFile(d.front().m_aPath, aPath, IStorage::TYPE_SAVE);
 			LoadSkin(d.front().m_aName, d.front().m_pTask->m_Info);

--- a/src/game/client/components/skins.h
+++ b/src/game/client/components/skins.h
@@ -27,7 +27,7 @@ public:
 	struct CDownloadSkin
 	{
 		std::shared_ptr<CSkins::CGetPngFile> m_pTask;
-		char m_aPath[MAX_PATH_LENGTH];
+		char m_aPath[IO_MAX_PATH_LENGTH];
 		char m_aName[24];
 
 		bool operator<(const CDownloadSkin &Other) const { return str_comp(m_aName, Other.m_aName) < 0; }

--- a/src/game/client/components/statboard.cpp
+++ b/src/game/client/components/statboard.cpp
@@ -399,7 +399,7 @@ void CStatboard::AutoStatCSV()
 {
 	if(Client()->State() != IClient::STATE_DEMOPLAYBACK)
 	{
-		char aDate[20], aFilename[128];
+		char aDate[20], aFilename[IO_MAX_PATH_LENGTH];
 		str_timestamp(aDate, sizeof(aDate));
 		str_format(aFilename, sizeof(aFilename), "screenshots/auto/stats_%s.csv", aDate);
 		IOHANDLE File = Storage()->OpenFile(aFilename, IOFLAG_WRITE, IStorage::TYPE_ALL);

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -2701,7 +2701,7 @@ void CGameClient::LoadGameSkin(const char *pPath, bool AsDir)
 		m_GameSkinLoaded = false;
 	}
 
-	char aPath[MAX_PATH_LENGTH];
+	char aPath[IO_MAX_PATH_LENGTH];
 	bool IsDefault = false;
 	if(str_comp(pPath, "default") == 0)
 	{
@@ -2854,7 +2854,7 @@ void CGameClient::LoadEmoticonsSkin(const char *pPath, bool AsDir)
 		m_EmoticonsSkinLoaded = false;
 	}
 
-	char aPath[MAX_PATH_LENGTH];
+	char aPath[IO_MAX_PATH_LENGTH];
 	bool IsDefault = false;
 	if(str_comp(pPath, "default") == 0)
 	{
@@ -2908,7 +2908,7 @@ void CGameClient::LoadParticlesSkin(const char *pPath, bool AsDir)
 		m_ParticlesSkinLoaded = false;
 	}
 
-	char aPath[MAX_PATH_LENGTH];
+	char aPath[IO_MAX_PATH_LENGTH];
 	bool IsDefault = false;
 	if(str_comp(pPath, "default") == 0)
 	{

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -4443,9 +4443,9 @@ void CEditor::RenderFileDialog()
 				}
 				else
 				{
-					char aTemp[MAX_PATH_LENGTH];
+					char aTemp[IO_MAX_PATH_LENGTH];
 					str_copy(aTemp, m_pFileDialogPath, sizeof(aTemp));
-					str_format(m_pFileDialogPath, MAX_PATH_LENGTH, "%s/%s", aTemp, m_FileList[m_FilesSelectedIndex].m_aFilename);
+					str_format(m_pFileDialogPath, IO_MAX_PATH_LENGTH, "%s/%s", aTemp, m_FileList[m_FilesSelectedIndex].m_aFilename);
 				}
 			}
 			FilelistPopulate(!str_comp(m_pFileDialogPath, "maps") || !str_comp(m_pFileDialogPath, "mapres") ? m_FileDialogStorageType :

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -586,7 +586,7 @@ public:
 	int m_Front;
 	int m_Switch;
 	int m_Tune;
-	char m_aFileName[512];
+	char m_aFileName[IO_MAX_PATH_LENGTH];
 };
 
 class CLayerQuads : public CLayer
@@ -816,8 +816,8 @@ public:
 
 	bool m_BrushColorEnabled;
 
-	char m_aFileName[512];
-	char m_aFileSaveName[512];
+	char m_aFileName[IO_MAX_PATH_LENGTH];
+	char m_aFileSaveName[IO_MAX_PATH_LENGTH];
 	bool m_ValidSaveFilename;
 
 	enum
@@ -857,9 +857,9 @@ public:
 	const char *m_pFileDialogButtonText;
 	void (*m_pfnFileDialogFunc)(const char *pFileName, int StorageType, void *pUser);
 	void *m_pFileDialogUser;
-	char m_aFileDialogFileName[MAX_PATH_LENGTH];
-	char m_aFileDialogCurrentFolder[MAX_PATH_LENGTH];
-	char m_aFileDialogCurrentLink[MAX_PATH_LENGTH];
+	char m_aFileDialogFileName[IO_MAX_PATH_LENGTH];
+	char m_aFileDialogCurrentFolder[IO_MAX_PATH_LENGTH];
+	char m_aFileDialogCurrentLink[IO_MAX_PATH_LENGTH];
 	char m_aFileDialogSearchText[64];
 	char m_aFileDialogPrevSearchText[64];
 	char *m_pFileDialogPath;
@@ -876,7 +876,7 @@ public:
 
 	struct CFilelistItem
 	{
-		char m_aFilename[128];
+		char m_aFilename[IO_MAX_PATH_LENGTH];
 		char m_aName[128];
 		bool m_IsDir;
 		bool m_IsLink;

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -2958,7 +2958,7 @@ void CGameContext::ConClearVotes(IConsole::IResult *pResult, void *pUserData)
 
 struct CMapNameItem
 {
-	char m_aName[MAX_PATH_LENGTH - 4];
+	char m_aName[IO_MAX_PATH_LENGTH - 4];
 
 	bool operator<(const CMapNameItem &Other) const { return str_comp_nocase(m_aName, Other.m_aName) < 0; }
 };
@@ -2975,8 +2975,8 @@ void CGameContext::ConAddMapVotes(IConsole::IResult *pResult, void *pUserData)
 		char aDescription[64];
 		str_format(aDescription, sizeof(aDescription), "Map: %s", MapList[i].m_aName);
 
-		char aCommand[MAX_PATH_LENGTH * 2 + 10];
-		char aMapEscaped[MAX_PATH_LENGTH * 2];
+		char aCommand[IO_MAX_PATH_LENGTH * 2 + 10];
+		char aMapEscaped[IO_MAX_PATH_LENGTH * 2];
 		char *pDst = aMapEscaped;
 		str_escape(&pDst, MapList[i].m_aName, aMapEscaped + sizeof(aMapEscaped));
 		str_format(aCommand, sizeof(aCommand), "change_map \"%s\"", aMapEscaped);
@@ -3206,7 +3206,7 @@ void CGameContext::OnInit(/*class IKernel *pKernel*/)
 		char aGameUuid[UUID_MAXSTRSIZE];
 		FormatUuid(m_GameUuid, aGameUuid, sizeof(aGameUuid));
 
-		char aFilename[64];
+		char aFilename[IO_MAX_PATH_LENGTH];
 		str_format(aFilename, sizeof(aFilename), "teehistorian/%s.teehistorian", aGameUuid);
 
 		IOHANDLE File = Storage()->OpenFile(aFilename, IOFLAG_WRITE, IStorage::TYPE_SAVE);

--- a/src/test/fs.cpp
+++ b/src/test/fs.cpp
@@ -16,7 +16,7 @@ TEST(Filesystem, CreateCloseDelete)
 TEST(Filesystem, CreateDeleteDirectory)
 {
 	CTestInfo Info;
-	char aFilename[128];
+	char aFilename[IO_MAX_PATH_LENGTH];
 	str_format(aFilename, sizeof(aFilename), "%s/test.txt", Info.m_aFilename);
 
 	EXPECT_FALSE(fs_makedir(Info.m_aFilename));

--- a/src/test/teehistorian.cpp
+++ b/src/test/teehistorian.cpp
@@ -127,7 +127,7 @@ protected:
 
 		if(m_Buffer.Error() || m_Buffer.Size() != OutputSize || mem_comp(m_Buffer.Data(), pOutput, OutputSize) != 0)
 		{
-			char aFilename[64];
+			char aFilename[IO_MAX_PATH_LENGTH];
 			IOHANDLE File;
 
 			str_format(aFilename, sizeof(aFilename), "%sGot.teehistorian", pTestName);

--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -29,7 +29,7 @@ class CTestInfoPath
 {
 public:
 	bool m_IsDirectory;
-	char m_aData[MAX_PATH_LENGTH];
+	char m_aData[IO_MAX_PATH_LENGTH];
 
 	bool operator<(const CTestInfoPath &Other) const
 	{
@@ -44,7 +44,7 @@ public:
 class CTestCollectData
 {
 public:
-	char m_aCurrentDir[MAX_PATH_LENGTH];
+	char m_aCurrentDir[IO_MAX_PATH_LENGTH];
 	std::vector<CTestInfoPath> *m_paEntries;
 };
 

--- a/src/test/test.h
+++ b/src/test/test.h
@@ -1,5 +1,8 @@
 #ifndef TEST_TEST_H
 #define TEST_TEST_H
+
+#include <base/system.h>
+
 class IStorage;
 
 class CTestInfo
@@ -8,6 +11,6 @@ public:
 	CTestInfo();
 	IStorage *CreateTestStorage();
 	void DeleteTestStorageFilesOnSuccess();
-	char m_aFilename[64];
+	char m_aFilename[IO_MAX_PATH_LENGTH];
 };
 #endif // TEST_TEST_H

--- a/src/tools/map_convert_07.cpp
+++ b/src/tools/map_convert_07.cpp
@@ -151,7 +151,7 @@ int main(int argc, const char **argv)
 	const char *pSourceFileName = argv[1];
 
 	const char *pDestFileName;
-	char aDestFileName[MAX_PATH_LENGTH];
+	char aDestFileName[IO_MAX_PATH_LENGTH];
 
 	if(argc == 3)
 	{
@@ -159,7 +159,7 @@ int main(int argc, const char **argv)
 	}
 	else
 	{
-		char aBuf[MAX_PATH_LENGTH];
+		char aBuf[IO_MAX_PATH_LENGTH];
 		IStorage::StripPathAndExtension(pSourceFileName, aBuf, sizeof(aBuf));
 		str_format(aDestFileName, sizeof(aDestFileName), "data/maps7/%s.map", aBuf);
 		pDestFileName = aDestFileName;

--- a/src/tools/map_optimize.cpp
+++ b/src/tools/map_optimize.cpp
@@ -83,7 +83,7 @@ int main(int argc, const char **argv)
 	IStorage *pStorage = CreateStorage("Teeworlds", IStorage::STORAGETYPE_BASIC, argc, argv);
 	int Index, ID = 0, Type = 0, Size;
 	void *pPtr;
-	char aFileName[1024];
+	char aFileName[IO_MAX_PATH_LENGTH];
 	CDataFileReader DataFile;
 	CDataFileWriter df;
 
@@ -103,7 +103,7 @@ int main(int argc, const char **argv)
 	else
 	{
 		fs_makedir("out");
-		char aBuff[MAX_PATH_LENGTH];
+		char aBuff[IO_MAX_PATH_LENGTH];
 		pStorage->StripPathAndExtension(argv[1], aBuff, sizeof(aBuff));
 		str_format(aFileName, sizeof(aFileName), "out/%s.map", aBuff);
 	}
@@ -303,7 +303,7 @@ int main(int argc, const char **argv)
 				// Please read the comments inside the functions to understand it
 				GetImageSHA256(pImgBuff, ImgSize, Width, Height, aSHA256Str);
 
-				char aNewName[MAX_PATH_LENGTH];
+				char aNewName[IO_MAX_PATH_LENGTH];
 				int StrLen = str_format(aNewName, sizeof(aNewName) / sizeof(aNewName[0]), "%s_cut_%s", pImgName, aSHA256Str);
 
 				DeletePtr = true;

--- a/src/tools/map_resave.cpp
+++ b/src/tools/map_resave.cpp
@@ -9,7 +9,7 @@ int main(int argc, const char **argv)
 	IStorage *pStorage = CreateStorage("Teeworlds", IStorage::STORAGETYPE_BASIC, argc, argv);
 	int Index, ID = 0, Type = 0, Size;
 	void *pPtr;
-	char aFileName[1024];
+	char aFileName[IO_MAX_PATH_LENGTH];
 	CDataFileReader DataFile;
 	CDataFileWriter df;
 


### PR DESCRIPTION
Inspired by
https://github.com/teeworlds/teeworlds/commit/0a7d0fee7ca11ea3cfa1effd28a6aa06b5f50821

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
