### PR TITLE
Remove a `#include <base/system.h>`

### DIFF
--- a/src/test/test.h
+++ b/src/test/test.h
@@ -1,8 +1,6 @@
 #ifndef TEST_TEST_H
 #define TEST_TEST_H
 
-#include <base/system.h>
-
 class IStorage;
 
 class CTestInfo
@@ -11,6 +9,6 @@ public:
 	CTestInfo();
 	IStorage *CreateTestStorage();
 	void DeleteTestStorageFilesOnSuccess();
-	char m_aFilename[IO_MAX_PATH_LENGTH];
+	char m_aFilename[64];
 };
 #endif // TEST_TEST_H


### PR DESCRIPTION
The variable isn't actually a path, just the test name formatted as file
name, so the 64 isn't actually too strict.

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
