### PR TITLE
invalidate texture when unloading a texture.

### DIFF
--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -264,27 +264,29 @@ void CGraphics_Threaded::LinesDraw(const CLineItem *pArray, int Num)
 	AddVertices(2 * Num);
 }
 
-int CGraphics_Threaded::UnloadTexture(CTextureHandle Index)
+int CGraphics_Threaded::UnloadTexture(CTextureHandle *Index)
 {
-	if(Index.Id() == m_InvalidTexture.Id())
+	if(Index->Id() == m_InvalidTexture.Id())
 		return 0;
 
-	if(!Index.IsValid())
+	if(!Index->IsValid())
 		return 0;
 
 	CCommandBuffer::SCommand_Texture_Destroy Cmd;
-	Cmd.m_Slot = Index.Id();
+	Cmd.m_Slot = Index->Id();
 	AddCmd(
 		Cmd, [] { return true; }, "failed to unload texture.");
 
-	m_TextureIndices[Index.Id()] = m_FirstFreeTexture;
-	m_FirstFreeTexture = Index.Id();
+	m_TextureIndices[Index->Id()] = m_FirstFreeTexture;
+	m_FirstFreeTexture = Index->Id();
+
+	Index->Invalidate();
 	return 0;
 }
 
 int CGraphics_Threaded::UnloadTextureNew(CTextureHandle &TextureHandle)
 {
-	int Ret = UnloadTexture(TextureHandle);
+	int Ret = UnloadTexture(&TextureHandle);
 	TextureHandle = IGraphics::CTextureHandle();
 	return Ret;
 }

--- a/src/engine/client/graphics_threaded.h
+++ b/src/engine/client/graphics_threaded.h
@@ -874,7 +874,7 @@ public:
 	void LinesEnd() override;
 	void LinesDraw(const CLineItem *pArray, int Num) override;
 
-	int UnloadTexture(IGraphics::CTextureHandle Index) override;
+	int UnloadTexture(IGraphics::CTextureHandle *Index) override;
 	int UnloadTextureNew(CTextureHandle &TextureHandle) override;
 	IGraphics::CTextureHandle LoadTextureRaw(int Width, int Height, int Format, const void *pData, int StoreFormat, int Flags, const char *pTexName = NULL) override;
 	int LoadTextureRawSub(IGraphics::CTextureHandle TextureID, int x, int y, int Width, int Height, int Format, const void *pData) override;

--- a/src/engine/client/graphics_threaded_null.h
+++ b/src/engine/client/graphics_threaded_null.h
@@ -43,7 +43,7 @@ public:
 	void LinesEnd() override{};
 	void LinesDraw(const CLineItem *pArray, int Num) override{};
 
-	int UnloadTexture(IGraphics::CTextureHandle Index) override { return 0; };
+	int UnloadTexture(IGraphics::CTextureHandle *Index) override { return 0; };
 	int UnloadTextureNew(CTextureHandle &TextureHandle) override { return 0; };
 	IGraphics::CTextureHandle LoadTextureRaw(int Width, int Height, int Format, const void *pData, int StoreFormat, int Flags, const char *pTexName = NULL) override { return CreateTextureHandle(0); };
 	int LoadTextureRawSub(IGraphics::CTextureHandle TextureID, int x, int y, int Width, int Height, int Format, const void *pData) override { return 0; };

--- a/src/engine/client/text.cpp
+++ b/src/engine/client/text.cpp
@@ -323,7 +323,7 @@ class CTextRender : public IEngineTextRender
 
 	void UnloadTexture(IGraphics::CTextureHandle Index)
 	{
-		Graphics()->UnloadTexture(Index);
+		Graphics()->UnloadTexture(&Index);
 	}
 
 	void IncreaseFontTexture(CFont *pFont, int TextureIndex)

--- a/src/engine/graphics.h
+++ b/src/engine/graphics.h
@@ -199,6 +199,7 @@ public:
 
 		bool IsValid() const { return Id() >= 0; }
 		int Id() const { return m_Id; }
+		void Invalidate() { m_Id = -1; }
 	};
 
 	int ScreenWidth() const { return m_ScreenWidth; }
@@ -245,7 +246,7 @@ public:
 	// destination width must be equal to the subwidth of the source
 	virtual void CopyTextureFromTextureBufferSub(uint8_t *pDestBuffer, int DestWidth, int DestHeight, uint8_t *pSourceBuffer, int SrcWidth, int SrcHeight, int ColorChannelCount, int SrcSubOffsetX, int SrcSubOffsetY, int SrcSubCopyWidth, int SrcSubCopyHeight) = 0;
 
-	virtual int UnloadTexture(CTextureHandle Index) = 0;
+	virtual int UnloadTexture(CTextureHandle *Index) = 0;
 	virtual int UnloadTextureNew(CTextureHandle &TextureHandle) = 0;
 	virtual CTextureHandle LoadTextureRaw(int Width, int Height, int Format, const void *pData, int StoreFormat, int Flags, const char *pTexName = NULL) = 0;
 	virtual int LoadTextureRawSub(CTextureHandle TextureID, int x, int y, int Width, int Height, int Format, const void *pData) = 0;

--- a/src/game/client/components/mapimages.cpp
+++ b/src/game/client/components/mapimages.cpp
@@ -50,8 +50,7 @@ void CMapImages::OnMapLoadImpl(class CLayers *pLayers, IMap *pMap)
 	// unload all textures
 	for(int i = 0; i < m_Count; i++)
 	{
-		Graphics()->UnloadTexture(m_aTextures[i]);
-		m_aTextures[i] = IGraphics::CTextureHandle();
+		Graphics()->UnloadTexture(&(m_aTextures[i]));
 		m_aTextureUsedByTileOrQuadLayerFlag[i] = 0;
 	}
 	m_Count = 0;
@@ -388,7 +387,7 @@ void CMapImages::ChangeEntitiesPath(const char *pPath)
 			for(int n = 0; n < MAP_IMAGE_ENTITY_LAYER_TYPE_COUNT; ++n)
 			{
 				if(m_EntitiesTextures[i][n].IsValid())
-					Graphics()->UnloadTexture(m_EntitiesTextures[i][n]);
+					Graphics()->UnloadTexture(&(m_EntitiesTextures[i][n]));
 				m_EntitiesTextures[i][n] = IGraphics::CTextureHandle();
 			}
 
@@ -407,9 +406,9 @@ void CMapImages::SetTextureScale(int Scale)
 	if(Graphics() && m_OverlayCenterTexture.IsValid()) // check if component was initialized
 	{
 		// reinitialize component
-		Graphics()->UnloadTexture(m_OverlayBottomTexture);
-		Graphics()->UnloadTexture(m_OverlayTopTexture);
-		Graphics()->UnloadTexture(m_OverlayCenterTexture);
+		Graphics()->UnloadTexture(&m_OverlayBottomTexture);
+		Graphics()->UnloadTexture(&m_OverlayTopTexture);
+		Graphics()->UnloadTexture(&m_OverlayCenterTexture);
 
 		m_OverlayBottomTexture = IGraphics::CTextureHandle();
 		m_OverlayTopTexture = IGraphics::CTextureHandle();

--- a/src/game/client/components/menus_settings_assets.cpp
+++ b/src/game/client/components/menus_settings_assets.cpp
@@ -229,7 +229,7 @@ void ClearAssetList(sorted_array<TName> &List, IGraphics *pGraphics)
 	for(int i = 0; i < List.size(); ++i)
 	{
 		if(List[i].m_RenderTexture.IsValid())
-			pGraphics->UnloadTexture(List[i].m_RenderTexture);
+			pGraphics->UnloadTexture(&(List[i].m_RenderTexture));
 		List[i].m_RenderTexture = IGraphics::CTextureHandle();
 	}
 	List.clear();
@@ -244,7 +244,7 @@ void CMenus::ClearCustomItems(int CurTab)
 			for(auto &Image : m_EntitiesList[i].m_aImages)
 			{
 				if(Image.m_Texture.IsValid())
-					Graphics()->UnloadTexture(Image.m_Texture);
+					Graphics()->UnloadTexture(&Image.m_Texture);
 				Image.m_Texture = IGraphics::CTextureHandle();
 			}
 		}

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -92,7 +92,7 @@ enum
 
 CEditorImage::~CEditorImage()
 {
-	m_pEditor->Graphics()->UnloadTexture(m_Texture);
+	m_pEditor->Graphics()->UnloadTexture(&m_Texture);
 	if(m_pData)
 	{
 		free(m_pData);
@@ -3435,7 +3435,7 @@ void CEditor::ReplaceImage(const char *pFileName, int StorageType, void *pUser)
 		return;
 
 	CEditorImage *pImg = pEditor->m_Map.m_lImages[pEditor->m_SelectedImage];
-	pEditor->Graphics()->UnloadTexture(pImg->m_Texture);
+	pEditor->Graphics()->UnloadTexture(&(pImg->m_Texture));
 	if(pImg->m_pData)
 	{
 		free(pImg->m_pData);

--- a/src/game/editor/layer_tiles.cpp
+++ b/src/game/editor/layer_tiles.cpp
@@ -914,7 +914,7 @@ int CLayerTiles::RenderProperties(CUIRect *pToolBox)
 		m_Image = NewVal;
 		if(NewVal == -1)
 		{
-			m_Texture = IGraphics::CTextureHandle();
+			m_Texture.Invalidate();
 			m_Image = -1;
 		}
 		else

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -1860,7 +1860,7 @@ int CEditor::PopupEntities(CEditor *pEditor, CUIRect View, void *pContext)
 				char aBuf[512];
 				str_format(aBuf, sizeof(aBuf), "editor/entities/%s.png", Name);
 
-				pEditor->Graphics()->UnloadTexture(pEditor->m_EntitiesTexture);
+				pEditor->Graphics()->UnloadTexture(&pEditor->m_EntitiesTexture);
 				int TextureLoadFlag = pEditor->Graphics()->HasTextureArrays() ? IGraphics::TEXLOAD_TO_2D_ARRAY_TEXTURE : IGraphics::TEXLOAD_TO_3D_TEXTURE;
 				pEditor->m_EntitiesTexture = pEditor->Graphics()->LoadTexture(aBuf, IStorage::TYPE_ALL, CImageInfo::FORMAT_AUTO, TextureLoadFlag);
 				g_UiNumPopups--;


### PR DESCRIPTION
Closes https://github.com/teeworlds/teeworlds/issues/1450

(cherry picked from commit https://github.com/teeworlds/teeworlds/commit/23a1b80f60801e4d0022ac895d3a6af4d929a302)

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
