### PR TITLE
Make emoticons smoother

### DIFF
--- a/src/engine/client.h
+++ b/src/engine/client.h
@@ -36,6 +36,7 @@ protected:
 	int m_CurGameTick[NUM_DUMMIES];
 	float m_GameIntraTick[NUM_DUMMIES];
 	float m_GameTickTime[NUM_DUMMIES];
+	float m_GameIntraTickSincePrev[NUM_DUMMIES];
 
 	int m_PredTick[NUM_DUMMIES];
 	float m_PredIntraTick[NUM_DUMMIES];
@@ -90,6 +91,7 @@ public:
 	inline int PredGameTick(int Dummy) const { return m_PredTick[Dummy]; }
 	inline float IntraGameTick(int Dummy) const { return m_GameIntraTick[Dummy]; }
 	inline float PredIntraGameTick(int Dummy) const { return m_PredIntraTick[Dummy]; }
+	inline float IntraGameTickSincePrev(int Dummy) const { return m_GameIntraTickSincePrev[Dummy]; }
 	inline float GameTickTime(int Dummy) const { return m_GameTickTime[Dummy]; }
 	inline int GameTickSpeed() const { return m_GameTickSpeed; }
 

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -266,7 +266,7 @@ void CSmoothTime::Update(CGraph *pGraph, int64_t Target, int TimeLeft, int Adjus
 }
 
 CClient::CClient() :
-	m_DemoPlayer(&m_SnapshotDelta)
+	m_DemoPlayer(&m_SnapshotDelta, [&]() { UpdateDemoIntraTimers(); })
 {
 	for(auto &DemoRecorder : m_DemoRecorder)
 		DemoRecorder = CDemoRecorder(&m_SnapshotDelta);
@@ -2655,6 +2655,17 @@ void DemoPlayer()->SetPause(int paused)
 		demorec_playback_unpause();
 }*/
 
+void CClient::UpdateDemoIntraTimers()
+{
+	// update timers
+	const CDemoPlayer::CPlaybackInfo *pInfo = m_DemoPlayer.Info();
+	m_CurGameTick[g_Config.m_ClDummy] = pInfo->m_Info.m_CurrentTick;
+	m_PrevGameTick[g_Config.m_ClDummy] = pInfo->m_PreviousTick;
+	m_GameIntraTick[g_Config.m_ClDummy] = pInfo->m_IntraTick;
+	m_GameTickTime[g_Config.m_ClDummy] = pInfo->m_TickTime;
+	m_GameIntraTickSincePrev[g_Config.m_ClDummy] = pInfo->m_IntraTickSincePrev;
+};
+
 void CClient::Update()
 {
 	if(State() == IClient::STATE_DEMOPLAYBACK)
@@ -2780,6 +2791,7 @@ void CClient::Update()
 
 				m_GameIntraTick[g_Config.m_ClDummy] = (Now - PrevtickStart) / (float)(CurtickStart - PrevtickStart);
 				m_GameTickTime[g_Config.m_ClDummy] = (Now - PrevtickStart) / (float)Freq; //(float)SERVER_TICK_SPEED);
+				m_GameIntraTickSincePrev[g_Config.m_ClDummy] = (Now - PrevtickStart) / (float)(Freq / SERVER_TICK_SPEED);
 
 				CurtickStart = NewPredTick * time_freq() / 50;
 				PrevtickStart = PrevPredTick * time_freq() / 50;

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -278,6 +278,8 @@ class CClient : public IClient, public CDemoPlayer::IListener
 	IOHANDLE m_BenchmarkFile;
 	int64_t m_BenchmarkStopTime;
 
+	void UpdateDemoIntraTimers();
+
 public:
 	IEngine *Engine() { return m_pEngine; }
 	IEngineGraphics *Graphics() { return m_pGraphics; }

--- a/src/engine/shared/demo.h
+++ b/src/engine/shared/demo.h
@@ -7,8 +7,11 @@
 
 #include <engine/demo.h>
 #include <engine/shared/protocol.h>
+#include <functional>
 
 #include "snapshot.h"
+
+typedef std::function<void()> TUpdateIntraTimesFunc;
 
 class CDemoRecorder : public IDemoRecorder
 {
@@ -75,11 +78,14 @@ public:
 		int m_PreviousTick;
 
 		float m_IntraTick;
+		float m_IntraTickSincePrev;
 		float m_TickTime;
 	};
 
 private:
 	IListener *m_pListener;
+
+	TUpdateIntraTimesFunc m_UpdateIntraTimesFunc;
 
 	// Playback
 	struct CKeyFrame
@@ -120,6 +126,9 @@ private:
 
 public:
 	CDemoPlayer(class CSnapshotDelta *pSnapshotDelta);
+	CDemoPlayer(class CSnapshotDelta *pSnapshotDelta, TUpdateIntraTimesFunc &&UpdateIntraTimesFunc);
+
+	void Construct(class CSnapshotDelta *pSnapshotDelta);
 
 	void SetListener(IListener *pListener);
 

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -605,10 +605,10 @@ void CPlayers::RenderPlayer(
 		Graphics()->QuadsSetRotation(0);
 	}
 
-	if(g_Config.m_ClShowEmotes && !m_pClient->m_aClients[ClientID].m_EmoticonIgnore && m_pClient->m_aClients[ClientID].m_EmoticonStart != -1 && m_pClient->m_aClients[ClientID].m_EmoticonStart <= Client()->GameTick(g_Config.m_ClDummy) && m_pClient->m_aClients[ClientID].m_EmoticonStart + 2 * Client()->GameTickSpeed() > Client()->GameTick(g_Config.m_ClDummy))
+	if(g_Config.m_ClShowEmotes && !m_pClient->m_aClients[ClientID].m_EmoticonIgnore && m_pClient->m_aClients[ClientID].m_EmoticonStart != -1 && m_pClient->m_aClients[ClientID].m_EmoticonStart <= (double)Client()->GameTick(g_Config.m_ClDummy) + Client()->IntraGameTickSincePrev(g_Config.m_ClDummy) && m_pClient->m_aClients[ClientID].m_EmoticonStart + 2 * Client()->GameTickSpeed() > ((double)Client()->GameTick(g_Config.m_ClDummy) + Client()->IntraGameTickSincePrev(g_Config.m_ClDummy)))
 	{
-		int SinceStart = Client()->GameTick(g_Config.m_ClDummy) - m_pClient->m_aClients[ClientID].m_EmoticonStart;
-		int FromEnd = m_pClient->m_aClients[ClientID].m_EmoticonStart + 2 * Client()->GameTickSpeed() - Client()->GameTick(g_Config.m_ClDummy);
+		float SinceStart = (float)((double)Client()->GameTick(g_Config.m_ClDummy) + Client()->IntraGameTickSincePrev(g_Config.m_ClDummy)) - m_pClient->m_aClients[ClientID].m_EmoticonStart;
+		float FromEnd = m_pClient->m_aClients[ClientID].m_EmoticonStart + 2 * Client()->GameTickSpeed() - ((double)Client()->GameTick(g_Config.m_ClDummy) + Client()->IntraGameTickSincePrev(g_Config.m_ClDummy));
 
 		float a = 1;
 

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -739,7 +739,7 @@ void CGameClient::OnMessage(int MsgId, CUnpacker *pUnpacker, bool IsDummy)
 
 		// apply
 		m_aClients[pMsg->m_ClientID].m_Emoticon = pMsg->m_Emoticon;
-		m_aClients[pMsg->m_ClientID].m_EmoticonStart = Client()->GameTick(g_Config.m_ClDummy);
+		m_aClients[pMsg->m_ClientID].m_EmoticonStart = (double)Client()->GameTick(g_Config.m_ClDummy) + Client()->IntraGameTickSincePrev(g_Config.m_ClDummy);
 	}
 	else if(MsgId == NETMSGTYPE_SV_SOUNDGLOBAL)
 	{

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -334,7 +334,7 @@ public:
 		int m_SkinColor;
 		int m_Team;
 		int m_Emoticon;
-		int m_EmoticonStart;
+		double m_EmoticonStart;
 		bool m_Solo;
 		bool m_Jetpack;
 		bool m_NoCollision;


### PR DESCRIPTION
It's still not 100% the same as with high bandwidth, but atleast animation wise it should look the same.
The client doesn't predict if an emote actually is triggered, so it still only triggeres them every second tick without high bandwidth.

~Since this changes demo playing quite a bit, it should defs be tested~(not really xd)

fixes #4156

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
