### PR TITLE
Fix shift + tab selecting second last index in console, player name c…

### DIFF
--- a/src/game/client/components/chat.h
+++ b/src/game/client/components/chat.h
@@ -75,6 +75,7 @@ class CChat : public CComponent
 	bool m_InputUpdate;
 	int m_ChatStringOffset;
 	int m_OldChatStringLength;
+	bool m_CompletionUsed;
 	int m_CompletionChosen;
 	char m_aCompletionBuffer[256];
 	int m_PlaceholderOffset;

--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -47,6 +47,7 @@ CGameConsole::CInstance::CInstance(int Type)
 		m_CompletionFlagmask = CFGFLAG_SERVER;
 
 	m_aCompletionBuffer[0] = 0;
+	m_CompletionUsed = false;
 	m_CompletionChosen = -1;
 	m_CompletionRenderOffset = 0.0f;
 	m_ReverseTAB = false;
@@ -255,12 +256,14 @@ void CGameConsole::CInstance::OnInput(IInput::CEvent Event)
 		{
 			if(m_Type == CGameConsole::CONSOLETYPE_LOCAL || m_pGameConsole->Client()->RconAuthed())
 			{
-				if(m_ReverseTAB)
+				if(m_ReverseTAB && m_CompletionUsed)
 					m_CompletionChosen--;
-				else
+				else if(!m_ReverseTAB)
 					m_CompletionChosen++;
 				m_CompletionEnumerationCount = 0;
 				m_pGameConsole->m_pConsole->PossibleCommands(m_aCompletionBuffer, m_CompletionFlagmask, m_Type != CGameConsole::CONSOLETYPE_LOCAL && m_pGameConsole->Client()->RconAuthed() && m_pGameConsole->Client()->UseTempRconCommands(), PossibleCommandsCompleteCallback, this);
+
+				m_CompletionUsed = true;
 
 				// handle wrapping
 				if(m_CompletionEnumerationCount && (m_CompletionChosen >= m_CompletionEnumerationCount || m_CompletionChosen < 0))
@@ -310,6 +313,7 @@ void CGameConsole::CInstance::OnInput(IInput::CEvent Event)
 	{
 		if((Event.m_Key != KEY_TAB) && (Event.m_Key != KEY_LSHIFT))
 		{
+			m_CompletionUsed = false;
 			m_CompletionChosen = -1;
 			str_copy(m_aCompletionBuffer, m_Input.GetString(), sizeof(m_aCompletionBuffer));
 			m_CompletionRenderOffset = 0.0f;
@@ -540,7 +544,7 @@ void CGameConsole::OnRender()
 
 		CRenderInfo Info;
 		Info.m_pSelf = this;
-		Info.m_WantedCompletion = pConsole->m_CompletionChosen;
+		Info.m_WantedCompletion = pConsole->m_CompletionUsed ? pConsole->m_CompletionChosen : -1;
 		Info.m_EnumCount = 0;
 		Info.m_Offset = pConsole->m_CompletionRenderOffset;
 		Info.m_Width = Screen.w;

--- a/src/game/client/components/console.h
+++ b/src/game/client/components/console.h
@@ -40,6 +40,7 @@ class CGameConsole : public CComponent
 		CGameConsole *m_pGameConsole;
 
 		char m_aCompletionBuffer[128];
+		bool m_CompletionUsed;
 		int m_CompletionChosen;
 		int m_CompletionFlagmask;
 		float m_CompletionRenderOffset;


### PR DESCRIPTION
…hat & command chat

example:
- In console type `scoreboard`and press shift+tab and you wont get the last element
- in chat:
 - with player names it would be noticable on a full server, since it goes from index 62
 - with commands type `/` and shift + tab will give `/w`, but pressing tab again gives `/whisper` so second last

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
