### PR TITLE
Update default tune zone, when no local character is alive and tune zones don't exist

### DIFF
--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -2203,6 +2203,10 @@ void CGameClient::UpdatePrediction()
 	m_GameWorld.m_WorldConfig.m_PredictFreeze = g_Config.m_ClPredictFreeze;
 	m_GameWorld.m_WorldConfig.m_PredictWeapons = AntiPingWeapons();
 
+	// always update default tune zone, even without character
+	if(!m_GameWorld.m_WorldConfig.m_UseTuneZones)
+		m_GameWorld.TuningList()[0] = m_Tuning[g_Config.m_ClDummy];
+
 	if(!m_Snap.m_pLocalCharacter)
 	{
 		if(CCharacter *pLocalChar = m_GameWorld.GetCharacterByID(m_Snap.m_LocalClientID))
@@ -2266,10 +2270,6 @@ void CGameClient::UpdatePrediction()
 			m_ExpectingTuningSince[g_Config.m_ClDummy] = 0;
 			m_ReceivedTuning[g_Config.m_ClDummy] = false;
 		}
-	}
-	else
-	{
-		m_GameWorld.TuningList()[0] = m_Tuning[g_Config.m_ClDummy];
 	}
 
 	// if ddnetcharacter is available, ignore server-wide tunings for hook and collision


### PR DESCRIPTION
fixes #4140

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
