### PR TITLE
Fixed typo in variable name

### DIFF
--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -1272,7 +1272,7 @@ int CGraphics_Threaded::CreateQuadContainer(bool AutomaticUpload)
 void CGraphics_Threaded::QuadContainerChangeAutomaticUpload(int ContainerIndex, bool AutomaticUpload)
 {
 	SQuadContainer &Container = m_QuadContainers[ContainerIndex];
-	Container.m_AutomicUpload = AutomaticUpload;
+	Container.m_AutomaticUpload = AutomaticUpload;
 }
 
 void CGraphics_Threaded::QuadContainerUpload(int ContainerIndex)
@@ -1371,7 +1371,7 @@ void CGraphics_Threaded::QuadContainerAddQuads(int ContainerIndex, CQuadItem *pA
 		}
 	}
 
-	if(Container.m_AutomicUpload)
+	if(Container.m_AutomaticUpload)
 		QuadContainerUpload(ContainerIndex);
 }
 
@@ -1408,7 +1408,7 @@ void CGraphics_Threaded::QuadContainerAddQuads(int ContainerIndex, CFreeformItem
 		SetColor(&Quad.m_aVertices[3], 2);
 	}
 
-	if(Container.m_AutomicUpload)
+	if(Container.m_AutomaticUpload)
 		QuadContainerUpload(ContainerIndex);
 }
 

--- a/src/engine/client/graphics_threaded.h
+++ b/src/engine/client/graphics_threaded.h
@@ -770,13 +770,13 @@ class CGraphics_Threaded : public IEngineGraphics
 
 	struct SQuadContainer
 	{
-		SQuadContainer(bool AutomicUpload = true)
+		SQuadContainer(bool AutomaticUpload = true)
 		{
 			m_Quads.clear();
 			m_QuadBufferObjectIndex = m_QuadBufferContainerIndex = -1;
 			m_FreeIndex = -1;
 
-			m_AutomicUpload = AutomicUpload;
+			m_AutomaticUpload = AutomaticUpload;
 		}
 
 		struct SQuad
@@ -791,7 +791,7 @@ class CGraphics_Threaded : public IEngineGraphics
 
 		int m_FreeIndex;
 
-		bool m_AutomicUpload;
+		bool m_AutomaticUpload;
 	};
 	std::vector<SQuadContainer> m_QuadContainers;
 	int m_FirstFreeQuadContainer;


### PR DESCRIPTION
Fixed typo 'Automic' --> 'Automatic' in graphics_threaded. I thought i made a comment on the PR (https://github.com/ddnet/ddnet/pull/4160), but seems like i didnt send it in the end.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
