### PR TITLE
Allow compilation with MinGW

### DIFF
--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -1755,14 +1755,22 @@ int net_udp_recv(NETSOCKET sock, NETADDR *addr, void *buffer, int maxsize, MMSGS
 	if(bytes == 0 && sock.ipv4sock >= 0)
 	{
 		socklen_t fromlen = sizeof(struct sockaddr_in);
+#ifdef __MINGW32__
+		bytes = recvfrom(sock.ipv4sock, (char *)buffer, maxsize, 0, (struct sockaddr *)&sockaddrbuf, (int*)&fromlen);
+#else
 		bytes = recvfrom(sock.ipv4sock, (char *)buffer, maxsize, 0, (struct sockaddr *)&sockaddrbuf, &fromlen);
+#endif
 		*data = (unsigned char *)buffer;
 	}
 
 	if(bytes <= 0 && sock.ipv6sock >= 0)
 	{
 		socklen_t fromlen = sizeof(struct sockaddr_in6);
+#ifdef __MINGW32__
+		bytes = recvfrom(sock.ipv6sock, (char *)buffer, maxsize, 0, (struct sockaddr *)&sockaddrbuf, (int*)&fromlen);
+#else
 		bytes = recvfrom(sock.ipv6sock, (char *)buffer, maxsize, 0, (struct sockaddr *)&sockaddrbuf, &fromlen);
+#endif
 		*data = (unsigned char *)buffer;
 	}
 #endif
@@ -1910,7 +1918,11 @@ int net_tcp_accept(NETSOCKET sock, NETSOCKET *new_sock, NETADDR *a)
 		struct sockaddr_in addr;
 		sockaddr_len = sizeof(addr);
 
+#ifdef __MINGW32__
+		s = accept(sock.ipv4sock, (struct sockaddr *)&addr, (int*)&sockaddr_len);
+#else
 		s = accept(sock.ipv4sock, (struct sockaddr *)&addr, &sockaddr_len);
+#endif
 
 		if(s != -1)
 		{
@@ -1926,7 +1938,11 @@ int net_tcp_accept(NETSOCKET sock, NETSOCKET *new_sock, NETADDR *a)
 		struct sockaddr_in6 addr;
 		sockaddr_len = sizeof(addr);
 
+#ifdef __MINGW32__
+		s = accept(sock.ipv6sock, (struct sockaddr *)&addr, (int*)&sockaddr_len);
+#else
 		s = accept(sock.ipv6sock, (struct sockaddr *)&addr, &sockaddr_len);
+#endif
 
 		if(s != -1)
 		{


### PR DESCRIPTION
This allow to compile the client and the server with MinGW because socklen_t is defined as unsigned int while rcvfrom expect an int* with this platform which crash the compilation.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
