### PR TITLE
Add option to highlight self in kill messages

### DIFF
--- a/data/languages/french.txt
+++ b/data/languages/french.txt
@@ -1311,6 +1311,18 @@ Use modern OpenGL
 Show client IDs
 == Montrer les IDs
 
+Kill Messages
+== Messages d'élimination
+
+Highlight self in kill messages
+== Afficher son propre nom en surbrillance dans les messages d'élimination
+
+Kill Message Normal Color
+== Couleur normale des messages d'élimination
+
+Kill Message Highlight Color
+== Couleur de surbrillance des messages d'élimination
+
 Laser Outline Color
 == Couleur de la bordure du laser
 

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -278,7 +278,7 @@ MACRO_CONFIG_COL(ClMessageColor, cl_message_color, 255, CFGFLAG_CLIENT | CFGFLAG
 MACRO_CONFIG_COL(ClLaserInnerColor, cl_laser_inner_color, 11206591, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Laser inner color")
 MACRO_CONFIG_COL(ClLaserOutlineColor, cl_laser_outline_color, 11176233, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Laser outline color")
 MACRO_CONFIG_COL(ClKillMessageNormalColor, cl_kill_message_normal_color, 255, CFGFLAG_CLIENT | CFGFLAG_SAVE | CFGFLAG_COLALPHA, "Kill message normal color")
-MACRO_CONFIG_COL(ClKillMessageHighlightColor, cl_kill_message_highlight_color, 65433, CFGFLAG_CLIENT | CFGFLAG_SAVE | CFGFLAG_COLALPHA, "Kill message highlight color")
+MACRO_CONFIG_COL(ClKillMessageHighlightColor, cl_kill_message_highlight_color, 255, CFGFLAG_CLIENT | CFGFLAG_SAVE | CFGFLAG_COLALPHA, "Kill message highlight color")
 
 MACRO_CONFIG_INT(ClMessageFriend, cl_message_friend, 1, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Enable coloring and the heart for friends")
 MACRO_CONFIG_COL(ClMessageFriendColor, cl_message_friend_color, 65425, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Friend message color")

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -277,8 +277,8 @@ MACRO_CONFIG_COL(ClMessageTeamColor, cl_message_team_color, 5636050, CFGFLAG_CLI
 MACRO_CONFIG_COL(ClMessageColor, cl_message_color, 255, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Message color")
 MACRO_CONFIG_COL(ClLaserInnerColor, cl_laser_inner_color, 11206591, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Laser inner color")
 MACRO_CONFIG_COL(ClLaserOutlineColor, cl_laser_outline_color, 11176233, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Laser outline color")
-MACRO_CONFIG_COL(ClKillMessageNormalColor, cl_kill_message_normal_color, 65424, CFGFLAG_CLIENT | CFGFLAG_SAVE | CFGFLAG_COLALPHA, "Kill message normal color")
-MACRO_CONFIG_COL(ClKillMessageHighlightColor, cl_kill_message_highlight_color, 65424, CFGFLAG_CLIENT | CFGFLAG_SAVE | CFGFLAG_COLALPHA, "Kill message highlight color")
+MACRO_CONFIG_COL(ClKillMessageNormalColor, cl_kill_message_normal_color, 255, CFGFLAG_CLIENT | CFGFLAG_SAVE | CFGFLAG_COLALPHA, "Kill message normal color")
+MACRO_CONFIG_COL(ClKillMessageHighlightColor, cl_kill_message_highlight_color, 65433, CFGFLAG_CLIENT | CFGFLAG_SAVE | CFGFLAG_COLALPHA, "Kill message highlight color")
 
 MACRO_CONFIG_INT(ClMessageFriend, cl_message_friend, 1, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Enable coloring and the heart for friends")
 MACRO_CONFIG_COL(ClMessageFriendColor, cl_message_friend_color, 65425, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Friend message color")

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -277,6 +277,8 @@ MACRO_CONFIG_COL(ClMessageTeamColor, cl_message_team_color, 5636050, CFGFLAG_CLI
 MACRO_CONFIG_COL(ClMessageColor, cl_message_color, 255, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Message color")
 MACRO_CONFIG_COL(ClLaserInnerColor, cl_laser_inner_color, 11206591, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Laser inner color")
 MACRO_CONFIG_COL(ClLaserOutlineColor, cl_laser_outline_color, 11176233, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Laser outline color")
+MACRO_CONFIG_COL(ClKillMessageNormalColor, cl_kill_message_normal_color, 65424, CFGFLAG_CLIENT | CFGFLAG_SAVE | CFGFLAG_COLALPHA, "Kill message normal color")
+MACRO_CONFIG_COL(ClKillMessageHighlightColor, cl_kill_message_highlight_color, 65424, CFGFLAG_CLIENT | CFGFLAG_SAVE | CFGFLAG_COLALPHA, "Kill message highlight color")
 
 MACRO_CONFIG_INT(ClMessageFriend, cl_message_friend, 1, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Enable coloring and the heart for friends")
 MACRO_CONFIG_COL(ClMessageFriendColor, cl_message_friend_color, 65425, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Friend message color")

--- a/src/game/client/components/killmessages.cpp
+++ b/src/game/client/components/killmessages.cpp
@@ -76,6 +76,13 @@ void CKillMessages::CreateKillmessageNamesIfNotCreated(CKillMsg &Kill)
 		TextRender()->SetCursor(&Cursor, 0, 0, FontSize, TEXTFLAG_RENDER);
 		Cursor.m_LineWidth = -1;
 
+		unsigned color = g_Config.m_ClKillMessageNormalColor;
+		if(g_Config.m_ClKillMessageHighlightSelf && Kill.m_VictimID == m_pClient->m_Snap.m_pLocalInfo->m_ClientID)
+		{
+			color = g_Config.m_ClKillMessageHighlightColor;
+		}
+		TextRender()->TextColor(color_cast<ColorRGBA>(ColorHSLA(color)));
+
 		Kill.m_VictimTextContainerIndex = TextRender()->CreateTextContainer(&Cursor, Kill.m_aVictimName);
 	}
 
@@ -86,6 +93,13 @@ void CKillMessages::CreateKillmessageNamesIfNotCreated(CKillMsg &Kill)
 		CTextCursor Cursor;
 		TextRender()->SetCursor(&Cursor, 0, 0, FontSize, TEXTFLAG_RENDER);
 		Cursor.m_LineWidth = -1;
+
+		unsigned color = g_Config.m_ClKillMessageNormalColor;
+		if(g_Config.m_ClKillMessageHighlightSelf && Kill.m_KillerID == m_pClient->m_Snap.m_pLocalInfo->m_ClientID)
+		{
+			color = g_Config.m_ClKillMessageHighlightColor;
+		}
+		TextRender()->TextColor(color_cast<ColorRGBA>(ColorHSLA(color)));
 
 		Kill.m_KillerTextContainerIndex = TextRender()->CreateTextContainer(&Cursor, Kill.m_aKillerName);
 	}

--- a/src/game/client/components/killmessages.cpp
+++ b/src/game/client/components/killmessages.cpp
@@ -79,8 +79,7 @@ void CKillMessages::CreateKillmessageNamesIfNotCreated(CKillMsg &Kill)
 		unsigned color = g_Config.m_ClKillMessageNormalColor;
 		if(
 			g_Config.m_ClKillMessageHighlightSelf &&
-			m_pClient->m_Snap.m_pLocalInfo &&
-			Kill.m_VictimID == m_pClient->m_Snap.m_pLocalInfo->m_ClientID)
+			Kill.m_VictimID == m_pClient->m_Snap.m_LocalClientID)
 		{
 			color = g_Config.m_ClKillMessageHighlightColor;
 		}
@@ -100,8 +99,7 @@ void CKillMessages::CreateKillmessageNamesIfNotCreated(CKillMsg &Kill)
 		unsigned color = g_Config.m_ClKillMessageNormalColor;
 		if(
 			g_Config.m_ClKillMessageHighlightSelf &&
-			m_pClient->m_Snap.m_pLocalInfo &&
-			Kill.m_KillerID == m_pClient->m_Snap.m_pLocalInfo->m_ClientID)
+			Kill.m_KillerID == m_pClient->m_Snap.m_LocalClientID)
 		{
 			color = g_Config.m_ClKillMessageHighlightColor;
 		}

--- a/src/game/client/components/killmessages.cpp
+++ b/src/game/client/components/killmessages.cpp
@@ -77,7 +77,10 @@ void CKillMessages::CreateKillmessageNamesIfNotCreated(CKillMsg &Kill)
 		Cursor.m_LineWidth = -1;
 
 		unsigned color = g_Config.m_ClKillMessageNormalColor;
-		if(g_Config.m_ClKillMessageHighlightSelf && Kill.m_VictimID == m_pClient->m_Snap.m_pLocalInfo->m_ClientID)
+		if(
+			g_Config.m_ClKillMessageHighlightSelf &&
+			m_pClient->m_Snap.m_pLocalInfo &&
+			Kill.m_VictimID == m_pClient->m_Snap.m_pLocalInfo->m_ClientID)
 		{
 			color = g_Config.m_ClKillMessageHighlightColor;
 		}
@@ -95,7 +98,10 @@ void CKillMessages::CreateKillmessageNamesIfNotCreated(CKillMsg &Kill)
 		Cursor.m_LineWidth = -1;
 
 		unsigned color = g_Config.m_ClKillMessageNormalColor;
-		if(g_Config.m_ClKillMessageHighlightSelf && Kill.m_KillerID == m_pClient->m_Snap.m_pLocalInfo->m_ClientID)
+		if(
+			g_Config.m_ClKillMessageHighlightSelf &&
+			m_pClient->m_Snap.m_pLocalInfo &&
+			Kill.m_KillerID == m_pClient->m_Snap.m_pLocalInfo->m_ClientID)
 		{
 			color = g_Config.m_ClKillMessageHighlightColor;
 		}

--- a/src/game/client/components/killmessages.cpp
+++ b/src/game/client/components/killmessages.cpp
@@ -76,14 +76,12 @@ void CKillMessages::CreateKillmessageNamesIfNotCreated(CKillMsg &Kill)
 		TextRender()->SetCursor(&Cursor, 0, 0, FontSize, TEXTFLAG_RENDER);
 		Cursor.m_LineWidth = -1;
 
-		unsigned color = g_Config.m_ClKillMessageNormalColor;
-		if(
-			g_Config.m_ClKillMessageHighlightSelf &&
-			Kill.m_VictimID == m_pClient->m_Snap.m_LocalClientID)
+		unsigned Color = g_Config.m_ClKillMessageNormalColor;
+		if(Kill.m_VictimID == m_pClient->m_Snap.m_LocalClientID)
 		{
-			color = g_Config.m_ClKillMessageHighlightColor;
+			Color = g_Config.m_ClKillMessageHighlightColor;
 		}
-		TextRender()->TextColor(color_cast<ColorRGBA>(ColorHSLA(color)));
+		TextRender()->TextColor(color_cast<ColorRGBA>(ColorHSLA(Color)));
 
 		Kill.m_VictimTextContainerIndex = TextRender()->CreateTextContainer(&Cursor, Kill.m_aVictimName);
 	}
@@ -96,14 +94,12 @@ void CKillMessages::CreateKillmessageNamesIfNotCreated(CKillMsg &Kill)
 		TextRender()->SetCursor(&Cursor, 0, 0, FontSize, TEXTFLAG_RENDER);
 		Cursor.m_LineWidth = -1;
 
-		unsigned color = g_Config.m_ClKillMessageNormalColor;
-		if(
-			g_Config.m_ClKillMessageHighlightSelf &&
-			Kill.m_KillerID == m_pClient->m_Snap.m_LocalClientID)
+		unsigned Color = g_Config.m_ClKillMessageNormalColor;
+		if(Kill.m_KillerID == m_pClient->m_Snap.m_LocalClientID)
 		{
-			color = g_Config.m_ClKillMessageHighlightColor;
+			Color = g_Config.m_ClKillMessageHighlightColor;
 		}
-		TextRender()->TextColor(color_cast<ColorRGBA>(ColorHSLA(color)));
+		TextRender()->TextColor(color_cast<ColorRGBA>(ColorHSLA(Color)));
 
 		Kill.m_KillerTextContainerIndex = TextRender()->CreateTextContainer(&Cursor, Kill.m_aKillerName);
 	}

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -2108,10 +2108,10 @@ void CMenus::RenderSettingsHUD(CUIRect MainView)
 		MainView.HSplitTop(10.0f, 0x0, &MainView);
 
 		static int KillMessageNormalColorID;
-		DoLine_ColorPicker(&KillMessageNormalColorID, 25.0f, 250.0f, 13.0f, 5.0f, &MainView, Localize("Kill Message Normal Color"), &g_Config.m_ClKillMessageNormalColor, ColorRGBA(1.0f, 1.0f, 1.0f, 0.5f), false);
+		DoLine_ColorPicker(&KillMessageNormalColorID, 25.0f, 250.0f, 13.0f, 5.0f, &MainView, Localize("Kill Message Normal Color"), &g_Config.m_ClKillMessageNormalColor, ColorRGBA(1.0f, 1.0f, 1.0f), false);
 
 		static int KillMessageHighlightColorID;
-		DoLine_ColorPicker(&KillMessageHighlightColorID, 25.0f, 250.0f, 13.0f, 5.0f, &MainView, Localize("Kill Message Highlight Color"), &g_Config.m_ClKillMessageHighlightColor, ColorRGBA(1.0f, 0.5f, 0.5f), false);
+		DoLine_ColorPicker(&KillMessageHighlightColorID, 25.0f, 250.0f, 13.0f, 5.0f, &MainView, Localize("Kill Message Highlight Color"), &g_Config.m_ClKillMessageHighlightColor, ColorRGBA(1.0f, 0.2f, 0.2f), false);
 
 		// ***** Laser ***** //
 

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -2108,7 +2108,7 @@ void CMenus::RenderSettingsHUD(CUIRect MainView)
 		DoLine_ColorPicker(&KillMessageNormalColorID, 25.0f, 250.0f, 13.0f, 5.0f, &MainView, Localize("Kill Message Normal Color"), &g_Config.m_ClKillMessageNormalColor, ColorRGBA(1.0f, 1.0f, 1.0f), false);
 
 		static int KillMessageHighlightColorID;
-		DoLine_ColorPicker(&KillMessageHighlightColorID, 25.0f, 250.0f, 13.0f, 5.0f, &MainView, Localize("Kill Message Highlight Color"), &g_Config.m_ClKillMessageHighlightColor, ColorRGBA(1.0f, 0.2f, 0.2f), false);
+		DoLine_ColorPicker(&KillMessageHighlightColorID, 25.0f, 250.0f, 13.0f, 5.0f, &MainView, Localize("Kill Message Highlight Color"), &g_Config.m_ClKillMessageHighlightColor, ColorRGBA(1.0f, 1.0f, 1.0f), false);
 
 		// ***** Laser ***** //
 

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -2101,9 +2101,6 @@ void CMenus::RenderSettingsHUD(CUIRect MainView)
 		MainView.HSplitTop(30.0f, &Section, &MainView);
 		UI()->DoLabelScaled(&Section, Localize("Kill Messages"), 20.0f, -1);
 		MainView.VSplitLeft(5.0f, 0x0, &MainView);
-		MainView.HSplitTop(5.0f, 0x0, &MainView);
-
-		DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClKillMessageHighlightSelf, Localize("Highlight self in kill messages"), &g_Config.m_ClKillMessageHighlightSelf, &MainView, LineMargin);
 
 		MainView.HSplitTop(10.0f, 0x0, &MainView);
 

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -2053,286 +2053,332 @@ ColorHSLA CMenus::RenderHSLScrollbars(CUIRect *pRect, unsigned int *pColor, bool
 
 void CMenus::RenderSettingsHUD(CUIRect MainView)
 {
-	CUIRect HUD, Chat, Section, SectionTwo;
+	static int s_CurTab = 0;
 
-	MainView.VSplitMid(&HUD, &Chat);
+	CUIRect TabLabel1, TabLabel2, Column,
+		Section, SectionTwo;
 
-	HUD.HSplitTop(30.0f, &Section, &HUD);
-	UI()->DoLabelScaled(&Section, Localize("HUD"), 20.0f, -1);
-	HUD.VSplitLeft(5.0f, 0x0, &HUD);
-	HUD.HSplitTop(5.0f, 0x0, &HUD);
+	MainView.HSplitTop(20, &TabLabel1, &MainView);
+	TabLabel1.VSplitLeft(TabLabel1.w / 2, &TabLabel1, &TabLabel2);
 
-	Chat.HSplitTop(30.0f, &Section, &Chat);
-	UI()->DoLabelScaled(&Section, Localize("Chat"), 20.0f, -1);
-	Chat.VSplitLeft(5.0f, 0x0, &Chat);
-	Chat.HSplitTop(5.0f, 0x0, &Chat);
+	static int s_aPageTabs[2] = {};
+
+	if(DoButton_MenuTab((void *)&s_aPageTabs[0], Localize("General"), s_CurTab == 0, &TabLabel1, 5, NULL, NULL, NULL, NULL, 4))
+		s_CurTab = 0;
+	if(DoButton_MenuTab((void *)&s_aPageTabs[1], Localize("Chat"), s_CurTab == 1, &TabLabel2, 10, NULL, NULL, NULL, NULL, 4))
+		s_CurTab = 1;
+
+	MainView.HSplitTop(10.0f, 0x0, &MainView);
 
 	const float LineMargin = 20.0f;
 
-	// ***** HUD ***** //
+	if(s_CurTab == 0)
+	{ // ***** GENERAL TAB ***** //
 
-	DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClShowhud, Localize("Show ingame HUD"), &g_Config.m_ClShowhud, &HUD, LineMargin);
-	DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClDDRaceScoreBoard, Localize("Use DDRace Scoreboard"), &g_Config.m_ClDDRaceScoreBoard, &HUD, LineMargin);
-	DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClShowIDs, Localize("Show client IDs"), &g_Config.m_ClShowIDs, &HUD, LineMargin);
-	DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClShowhudScore, Localize("Show score"), &g_Config.m_ClShowhudScore, &HUD, LineMargin);
-	DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClShowhudHealthAmmo, Localize("Show health + ammo"), &g_Config.m_ClShowhudHealthAmmo, &HUD, LineMargin);
-	DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClShowChat, Localize("Show chat"), &g_Config.m_ClShowChat, &HUD, LineMargin);
-	DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClChatTeamColors, Localize("Show names in chat in team colors"), &g_Config.m_ClChatTeamColors, &HUD, LineMargin);
-	DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClShowKillMessages, Localize("Show kill messages"), &g_Config.m_ClShowKillMessages, &HUD, LineMargin);
-	DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClShowVotesAfterVoting, Localize("Show votes window after voting"), &g_Config.m_ClShowVotesAfterVoting, &HUD, LineMargin);
+		MainView.VSplitLeft(MainView.w * 0.55, &MainView, &Column);
 
-	// Laser
+		MainView.HSplitTop(30.0f, &Section, &MainView);
+		UI()->DoLabelScaled(&Section, Localize("HUD"), 20.0f, -1);
+		MainView.VSplitLeft(5.0f, 0x0, &MainView);
+		MainView.HSplitTop(5.0f, 0x0, &MainView);
 
-	HUD.HSplitTop(15.0f, 0x0, &HUD);
-	HUD.HSplitTop(50.0f, &Section, &HUD);
-	Section.VSplitRight(110.0f, &Section, 0x0);
-	HUD.HSplitTop(25.0f, &SectionTwo, &HUD);
+		// ***** HUD ***** //
 
-	static int LasterOutResetID, LaserInResetID;
+		DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClShowhud, Localize("Show ingame HUD"), &g_Config.m_ClShowhud, &MainView, LineMargin);
+		DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClDDRaceScoreBoard, Localize("Use DDRace Scoreboard"), &g_Config.m_ClDDRaceScoreBoard, &MainView, LineMargin);
+		DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClShowIDs, Localize("Show client IDs"), &g_Config.m_ClShowIDs, &MainView, LineMargin);
+		DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClShowhudScore, Localize("Show score"), &g_Config.m_ClShowhudScore, &MainView, LineMargin);
+		DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClShowhudHealthAmmo, Localize("Show health + ammo"), &g_Config.m_ClShowhudHealthAmmo, &MainView, LineMargin);
+		DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClShowChat, Localize("Show chat"), &g_Config.m_ClShowChat, &MainView, LineMargin);
+		DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClChatTeamColors, Localize("Show names in chat in team colors"), &g_Config.m_ClChatTeamColors, &MainView, LineMargin);
+		DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClShowVotesAfterVoting, Localize("Show votes window after voting"), &g_Config.m_ClShowVotesAfterVoting, &MainView, LineMargin);
+		DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClShowKillMessages, Localize("Show kill messages"), &g_Config.m_ClShowKillMessages, &MainView, LineMargin);
 
-	ColorHSLA LaserOutlineColor = DoLine_ColorPicker(&LasterOutResetID, 25.0f, 194.0f, 13.0f, 5.0f, &SectionTwo, Localize("Laser Outline Color"), &g_Config.m_ClLaserOutlineColor, ColorRGBA(0.074402f, 0.074402f, 0.247166f, 1.0f), false);
+		MainView.HSplitTop(60.0f, 0x0, &MainView);
 
-	HUD.HSplitTop(5.0f, 0x0, &HUD);
-	HUD.HSplitTop(25.0f, &SectionTwo, &HUD);
+		// ***** Kill Messages ***** //
 
-	ColorHSLA LaserInnerColor = DoLine_ColorPicker(&LaserInResetID, 25.0f, 194.0f, 13.0f, 5.0f, &SectionTwo, Localize("Laser Inner Color"), &g_Config.m_ClLaserInnerColor, ColorRGBA(0.498039f, 0.498039f, 1.0f, 1.0f), false);
+		MainView.HSplitTop(30.0f, &Section, &MainView);
+		UI()->DoLabelScaled(&Section, Localize("Kill Messages"), 20.0f, -1);
+		MainView.VSplitLeft(5.0f, 0x0, &MainView);
+		MainView.HSplitTop(5.0f, 0x0, &MainView);
 
-	Section.VSplitLeft(30.0f, 0, &Section);
+		DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClKillMessageHighlightSelf, Localize("Highlight self in kill messages"), &g_Config.m_ClKillMessageHighlightSelf, &MainView, LineMargin);
 
-	DoLaserPreview(&Section, LaserOutlineColor, LaserInnerColor);
+		MainView.HSplitTop(10.0f, 0x0, &MainView);
 
-	HUD.HSplitTop(25.0f, 0x0, &HUD);
-	HUD.HSplitTop(20.0f, &SectionTwo, &HUD);
+		static int KillMessageNormalColorID;
 
-	UI()->DoLabelScaled(&SectionTwo, Localize("Hookline"), 20.0f, -1);
+		ColorHSLA KillMessageNormalColor = DoLine_ColorPicker(&KillMessageNormalColorID, 25.0f, 250.0f, 13.0f, 5.0f, &MainView, Localize("Kill Message Normal Color"), &g_Config.m_ClKillMessageNormalColor, ColorRGBA(1.0f, 1.0f, 1.0f, 0.5f), false);
 
-	HUD.HSplitTop(5.0f, 0x0, &HUD);
-	HUD.HSplitTop(25.0f, &SectionTwo, &HUD);
+		static int KillMessageHighlightColorID;
 
-	static int HookCollNoCollResetID, HookCollHookableCollResetID, HookCollTeeCollResetID;
-	DoLine_ColorPicker(&HookCollNoCollResetID, 25.0f, 194.0f, 13.0f, 5.0f, &SectionTwo, Localize("No hit"), &g_Config.m_ClHookCollColorNoColl, ColorRGBA(1.0f, 0.0f, 0.0f, 1.0f), false);
+		ColorHSLA KillMessageHighlightColor = DoLine_ColorPicker(&KillMessageHighlightColorID, 25.0f, 250.0f, 13.0f, 5.0f, &MainView, Localize("Kill Message Highlight Color"), &g_Config.m_ClKillMessageHighlightColor, ColorRGBA(1.0f, 0.5f, 0.5f), false);
 
-	HUD.HSplitTop(5.0f, 0x0, &HUD);
-	HUD.HSplitTop(25.0f, &SectionTwo, &HUD);
+		// ***** Laser ***** //
 
-	DoLine_ColorPicker(&HookCollHookableCollResetID, 25.0f, 194.0f, 13.0f, 5.0f, &SectionTwo, Localize("Hookable"), &g_Config.m_ClHookCollColorHookableColl, ColorRGBA(130.0f / 255.0f, 232.0f / 255.0f, 160.0f / 255.0f, 1.0f), false);
+		MainView = Column;
 
-	HUD.HSplitTop(5.0f, 0x0, &HUD);
-	HUD.HSplitTop(25.0f, &SectionTwo, &HUD);
+		MainView.HSplitTop(30.0f, &Section, &MainView);
+		UI()->DoLabelScaled(&Section, Localize("Laser"), 20.0f, -1);
+		MainView.VSplitLeft(5.0f, 0x0, &MainView);
+		MainView.HSplitTop(5.0f, 0x0, &MainView);
 
-	DoLine_ColorPicker(&HookCollTeeCollResetID, 25.0f, 194.0f, 13.0f, 5.0f, &SectionTwo, Localize("Tee"), &g_Config.m_ClHookCollColorTeeColl, ColorRGBA(1.0f, 1.0f, 0.0f, 1.0f), false);
+		MainView.HSplitTop(50.0f, &Section, &MainView);
+		Section.VSplitLeft(300.0f, &Section, 0x0);
+		MainView.HSplitTop(25.0f, &SectionTwo, &MainView);
 
-	// ***** Chat ***** //
+		static int LasterOutResetID, LaserInResetID;
 
-	if(DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClChatOld, Localize("Use old chat style"), &g_Config.m_ClChatOld, &Chat, LineMargin))
-		GameClient()->m_Chat.RebuildChat();
+		ColorHSLA LaserOutlineColor = DoLine_ColorPicker(&LasterOutResetID, 25.0f, 235.0f, 13.0f, 5.0f, &SectionTwo, Localize("Laser Outline Color"), &g_Config.m_ClLaserOutlineColor, ColorRGBA(0.074402f, 0.074402f, 0.247166f, 1.0f), false);
 
-	Chat.HSplitTop(30.0f, 0x0, &Chat);
+		MainView.HSplitTop(5.0f, 0x0, &MainView);
+		MainView.HSplitTop(25.0f, &SectionTwo, &MainView);
 
-	// Message Colors and extra
+		ColorHSLA LaserInnerColor = DoLine_ColorPicker(&LaserInResetID, 25.0f, 235.0f, 13.0f, 5.0f, &SectionTwo, Localize("Laser Inner Color"), &g_Config.m_ClLaserInnerColor, ColorRGBA(0.498039f, 0.498039f, 1.0f, 1.0f), false);
 
-	Chat.HSplitTop(20.0f, &Section, &Chat);
-	Chat.HSplitTop(10.0f, 0x0, &Chat);
+		Section.VSplitLeft(30.0f, 0, &Section);
 
-	UI()->DoLabelScaled(&Section, Localize("Messages"), 20.0f, -1);
+		DoLaserPreview(&Section, LaserOutlineColor, LaserInnerColor);
 
-	const float LineSize = 25.0f;
-	const float WantedPickerPosition = 194.0f;
-	const float LabelSize = 13.0f;
-	const float LineSpacing = 5.0f;
+		MainView.HSplitTop(25.0f, 0x0, &MainView);
+		MainView.HSplitTop(20.0f, &SectionTwo, &MainView);
 
-	char aBuf[64];
+		UI()->DoLabelScaled(&SectionTwo, Localize("Hookline"), 20.0f, -1);
 
-	int i = 0;
-	static int ResetIDs[24];
+		MainView.HSplitTop(5.0f, 0x0, &MainView);
+		MainView.HSplitTop(25.0f, &SectionTwo, &MainView);
 
-	DoLine_ColorPicker(&ResetIDs[i++], LineSize, WantedPickerPosition, LabelSize, LineSpacing, &Chat, Localize("System message"), &g_Config.m_ClMessageSystemColor, ColorRGBA(1.0f, 1.0f, 0.5f), true, true, &g_Config.m_ClShowChatSystem);
-	DoLine_ColorPicker(&ResetIDs[i++], LineSize, WantedPickerPosition, LabelSize, LineSpacing, &Chat, Localize("Highlighted message"), &g_Config.m_ClMessageHighlightColor, ColorRGBA(1.0f, 0.5f, 0.5f));
-	DoLine_ColorPicker(&ResetIDs[i++], LineSize, WantedPickerPosition, LabelSize, LineSpacing, &Chat, Localize("Team message"), &g_Config.m_ClMessageTeamColor, ColorRGBA(0.65f, 1.0f, 0.65f));
-	DoLine_ColorPicker(&ResetIDs[i++], LineSize, WantedPickerPosition, LabelSize, LineSpacing, &Chat, Localize("Friend message"), &g_Config.m_ClMessageFriendColor, ColorRGBA(1.0f, 0.137f, 0.137f), true, true, &g_Config.m_ClMessageFriend);
-	DoLine_ColorPicker(&ResetIDs[i++], LineSize, WantedPickerPosition, LabelSize, LineSpacing, &Chat, Localize("Normal message"), &g_Config.m_ClMessageColor, ColorRGBA(1.0f, 1.0f, 1.0f));
+		static int HookCollNoCollResetID, HookCollHookableCollResetID, HookCollTeeCollResetID;
+		DoLine_ColorPicker(&HookCollNoCollResetID, 25.0f, 235.0f, 13.0f, 5.0f, &SectionTwo, Localize("No hit"), &g_Config.m_ClHookCollColorNoColl, ColorRGBA(1.0f, 0.0f, 0.0f, 1.0f), false);
 
-	str_format(aBuf, sizeof(aBuf), "%s (echo)", Localize("Client message"));
-	DoLine_ColorPicker(&ResetIDs[i++], LineSize, WantedPickerPosition, LabelSize, LineSpacing, &Chat, aBuf, &g_Config.m_ClMessageClientColor, ColorRGBA(0.5f, 0.78f, 1.0f));
+		MainView.HSplitTop(5.0f, 0x0, &MainView);
+		MainView.HSplitTop(25.0f, &SectionTwo, &MainView);
 
-	// ***** Chat Preview ***** //
+		DoLine_ColorPicker(&HookCollHookableCollResetID, 25.0f, 235.0f, 13.0f, 5.0f, &SectionTwo, Localize("Hookable"), &g_Config.m_ClHookCollColorHookableColl, ColorRGBA(130.0f / 255.0f, 232.0f / 255.0f, 160.0f / 255.0f, 1.0f), false);
 
-	Chat.HSplitTop(10.0f, 0x0, &Chat);
-	Chat.HSplitTop(20.0f, &Section, &Chat);
+		MainView.HSplitTop(5.0f, 0x0, &MainView);
+		MainView.HSplitTop(25.0f, &SectionTwo, &MainView);
 
-	UI()->DoLabelScaled(&Section, Localize("Preview"), 20.0f, -1);
+		DoLine_ColorPicker(&HookCollTeeCollResetID, 25.0f, 235.0f, 13.0f, 5.0f, &SectionTwo, Localize("Tee"), &g_Config.m_ClHookCollColorTeeColl, ColorRGBA(1.0f, 1.0f, 0.0f, 1.0f), false);
+	}
+	else if(s_CurTab == 1)
+	{ // ***** CHAT TAB ***** //
 
-	Chat.HSplitTop(10.0f, 0x0, &Chat);
-	RenderTools()->DrawUIRect(&Chat, ColorRGBA(1, 1, 1, 0.1f), CUI::CORNER_ALL, 8.0f);
-	Chat.HSplitTop(10.0f, 0x0, &Chat);
+		MainView.VSplitLeft(MainView.w / 2, &MainView, &Column);
 
-	ColorRGBA SystemColor = color_cast<ColorRGBA, ColorHSLA>(ColorHSLA(g_Config.m_ClMessageSystemColor));
-	ColorRGBA HighlightedColor = color_cast<ColorRGBA, ColorHSLA>(ColorHSLA(g_Config.m_ClMessageHighlightColor));
-	ColorRGBA TeamColor = color_cast<ColorRGBA, ColorHSLA>(ColorHSLA(g_Config.m_ClMessageTeamColor));
-	ColorRGBA FriendColor = color_cast<ColorRGBA, ColorHSLA>(ColorHSLA(g_Config.m_ClMessageFriendColor));
-	ColorRGBA NormalColor = color_cast<ColorRGBA, ColorHSLA>(ColorHSLA(g_Config.m_ClMessageColor));
-	ColorRGBA ClientColor = color_cast<ColorRGBA, ColorHSLA>(ColorHSLA(g_Config.m_ClMessageClientColor));
-	ColorRGBA DefaultNameColor(0.8f, 0.8f, 0.8f, 1.0f);
+		if(DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClChatOld, Localize("Use old chat style"), &g_Config.m_ClChatOld, &MainView, LineMargin))
+			GameClient()->m_Chat.RebuildChat();
 
-	constexpr float RealFontSize = CChat::FONT_SIZE * 2;
-	const float RealMsgPaddingX = (!g_Config.m_ClChatOld ? CChat::MESSAGE_PADDING_X : 0) * 2;
-	const float RealMsgPaddingY = (!g_Config.m_ClChatOld ? CChat::MESSAGE_PADDING_Y : 0) * 2;
-	const float RealMsgPaddingTee = (!g_Config.m_ClChatOld ? CChat::MESSAGE_TEE_SIZE + CChat::MESSAGE_TEE_PADDING_RIGHT : 0) * 2;
-	const float RealOffsetY = RealFontSize + RealMsgPaddingY;
+		MainView.HSplitTop(30.0f, 0x0, &MainView);
 
-	const float X = 5.0f + RealMsgPaddingX / 2.0f + Chat.x;
-	float Y = Chat.y;
+		// Message Colors and extra
 
-	CTextCursor Cursor;
-	TextRender()->SetCursor(&Cursor, X, Y, RealFontSize, TEXTFLAG_RENDER);
+		MainView.HSplitTop(20.0f, &Section, &MainView);
+		MainView.HSplitTop(10.0f, 0x0, &MainView);
 
-	str_copy(aBuf, Client()->PlayerName(), sizeof(aBuf));
+		UI()->DoLabelScaled(&Section, Localize("Messages"), 20.0f, -1);
 
-	CAnimState *pIdleState = CAnimState::GetIdle();
-	constexpr int PreviewTeeCount = 4;
-	constexpr float RealTeeSize = CChat::MESSAGE_TEE_SIZE * 2;
-	constexpr float RealTeeSizeHalved = CChat::MESSAGE_TEE_SIZE;
-	constexpr float TWSkinUnreliableOffset = -0.25f;
-	constexpr float OffsetTeeY = RealTeeSizeHalved;
-	const float FullHeightMinusTee = RealOffsetY - RealTeeSize;
+		const float LineSize = 25.0f;
+		const float WantedPickerPosition = 210.0f;
+		const float LabelSize = 13.0f;
+		const float LineSpacing = 5.0f;
 
-	CTeeRenderInfo RenderInfo[PreviewTeeCount];
+		char aBuf[64];
 
-	// Backgrounds first
-	if(!g_Config.m_ClChatOld)
-	{
-		Graphics()->TextureClear();
-		Graphics()->QuadsBegin();
-		Graphics()->SetColor(0, 0, 0, 0.12f);
+		int i = 0;
+		static int ResetIDs[24];
 
-		char LineBuilder[128];
-		float Width;
-		float TempY = Y;
-		constexpr float RealBackgroundRounding = CChat::MESSAGE_ROUNDING * 2.0f;
+		DoLine_ColorPicker(&ResetIDs[i++], LineSize, WantedPickerPosition, LabelSize, LineSpacing, &MainView, Localize("System message"), &g_Config.m_ClMessageSystemColor, ColorRGBA(1.0f, 1.0f, 0.5f), true, true, &g_Config.m_ClShowChatSystem);
+		DoLine_ColorPicker(&ResetIDs[i++], LineSize, WantedPickerPosition, LabelSize, LineSpacing, &MainView, Localize("Highlighted message"), &g_Config.m_ClMessageHighlightColor, ColorRGBA(1.0f, 0.5f, 0.5f));
+		DoLine_ColorPicker(&ResetIDs[i++], LineSize, WantedPickerPosition, LabelSize, LineSpacing, &MainView, Localize("Team message"), &g_Config.m_ClMessageTeamColor, ColorRGBA(0.65f, 1.0f, 0.65f));
+		DoLine_ColorPicker(&ResetIDs[i++], LineSize, WantedPickerPosition, LabelSize, LineSpacing, &MainView, Localize("Friend message"), &g_Config.m_ClMessageFriendColor, ColorRGBA(1.0f, 0.137f, 0.137f), true, true, &g_Config.m_ClMessageFriend);
+		DoLine_ColorPicker(&ResetIDs[i++], LineSize, WantedPickerPosition, LabelSize, LineSpacing, &MainView, Localize("Normal message"), &g_Config.m_ClMessageColor, ColorRGBA(1.0f, 1.0f, 1.0f));
 
+		str_format(aBuf, sizeof(aBuf), "%s (echo)", Localize("Client message"));
+		DoLine_ColorPicker(&ResetIDs[i++], LineSize, WantedPickerPosition, LabelSize, LineSpacing, &MainView, aBuf, &g_Config.m_ClMessageClientColor, ColorRGBA(0.5f, 0.78f, 1.0f));
+
+		// ***** Chat Preview ***** //
+
+		MainView = Column;
+
+		MainView.HSplitTop(10.0f, 0x0, &MainView);
+		MainView.HSplitTop(20.0f, &Section, &MainView);
+
+		UI()->DoLabelScaled(&Section, Localize("Preview"), 20.0f, -1);
+
+		MainView.HSplitTop(10.0f, 0x0, &MainView);
+		RenderTools()->DrawUIRect(&MainView, ColorRGBA(1, 1, 1, 0.1f), CUI::CORNER_ALL, 8.0f);
+		MainView.HSplitTop(10.0f, 0x0, &MainView);
+
+		ColorRGBA SystemColor = color_cast<ColorRGBA, ColorHSLA>(ColorHSLA(g_Config.m_ClMessageSystemColor));
+		ColorRGBA HighlightedColor = color_cast<ColorRGBA, ColorHSLA>(ColorHSLA(g_Config.m_ClMessageHighlightColor));
+		ColorRGBA TeamColor = color_cast<ColorRGBA, ColorHSLA>(ColorHSLA(g_Config.m_ClMessageTeamColor));
+		ColorRGBA FriendColor = color_cast<ColorRGBA, ColorHSLA>(ColorHSLA(g_Config.m_ClMessageFriendColor));
+		ColorRGBA NormalColor = color_cast<ColorRGBA, ColorHSLA>(ColorHSLA(g_Config.m_ClMessageColor));
+		ColorRGBA ClientColor = color_cast<ColorRGBA, ColorHSLA>(ColorHSLA(g_Config.m_ClMessageClientColor));
+		ColorRGBA DefaultNameColor(0.8f, 0.8f, 0.8f, 1.0f);
+
+		constexpr float RealFontSize = CChat::FONT_SIZE * 2;
+		const float RealMsgPaddingX = (!g_Config.m_ClChatOld ? CChat::MESSAGE_PADDING_X : 0) * 2;
+		const float RealMsgPaddingY = (!g_Config.m_ClChatOld ? CChat::MESSAGE_PADDING_Y : 0) * 2;
+		const float RealMsgPaddingTee = (!g_Config.m_ClChatOld ? CChat::MESSAGE_TEE_SIZE + CChat::MESSAGE_TEE_PADDING_RIGHT : 0) * 2;
+		const float RealOffsetY = RealFontSize + RealMsgPaddingY;
+
+		const float X = 5.0f + RealMsgPaddingX / 2.0f + MainView.x;
+		float Y = MainView.y;
+
+		CTextCursor Cursor;
+		TextRender()->SetCursor(&Cursor, X, Y, RealFontSize, TEXTFLAG_RENDER);
+
+		str_copy(aBuf, Client()->PlayerName(), sizeof(aBuf));
+
+		CAnimState *pIdleState = CAnimState::GetIdle();
+		constexpr int PreviewTeeCount = 4;
+		constexpr float RealTeeSize = CChat::MESSAGE_TEE_SIZE * 2;
+		constexpr float RealTeeSizeHalved = CChat::MESSAGE_TEE_SIZE;
+		constexpr float TWSkinUnreliableOffset = -0.25f;
+		constexpr float OffsetTeeY = RealTeeSizeHalved;
+		const float FullHeightMinusTee = RealOffsetY - RealTeeSize;
+
+		CTeeRenderInfo RenderInfo[PreviewTeeCount];
+
+		// Backgrounds first
+		if(!g_Config.m_ClChatOld)
+		{
+			Graphics()->TextureClear();
+			Graphics()->QuadsBegin();
+			Graphics()->SetColor(0, 0, 0, 0.12f);
+
+			char LineBuilder[128];
+			float Width;
+			float TempY = Y;
+			constexpr float RealBackgroundRounding = CChat::MESSAGE_ROUNDING * 2.0f;
+
+			if(g_Config.m_ClShowChatSystem)
+			{
+				str_format(LineBuilder, sizeof(LineBuilder), "*** '%s' entered and joined the game", aBuf);
+				Width = TextRender()->TextWidth(0, RealFontSize, LineBuilder, -1, -1);
+				RenderTools()->DrawRoundRectExt(X - RealMsgPaddingX / 2.0f, TempY - RealMsgPaddingY / 2.0f, Width + RealMsgPaddingX, RealFontSize + RealMsgPaddingY, RealBackgroundRounding, CUI::CORNER_ALL);
+				TempY += RealOffsetY;
+			}
+
+			str_format(LineBuilder, sizeof(LineBuilder), "%sRandom Tee: Hey, how are you %s?", g_Config.m_ClShowIDs ? " 7: " : "", aBuf);
+			Width = TextRender()->TextWidth(0, RealFontSize, LineBuilder, -1, -1);
+			RenderTools()->DrawRoundRectExt(X - RealMsgPaddingX / 2.0f, TempY - RealMsgPaddingY / 2.0f, Width + RealMsgPaddingX + RealMsgPaddingTee, RealFontSize + RealMsgPaddingY, RealBackgroundRounding, CUI::CORNER_ALL);
+			TempY += RealOffsetY;
+
+			str_format(LineBuilder, sizeof(LineBuilder), "%sYour Teammate: Let's speedrun this!", g_Config.m_ClShowIDs ? "11: " : "");
+			Width = TextRender()->TextWidth(0, RealFontSize, LineBuilder, -1, -1);
+			RenderTools()->DrawRoundRectExt(X - RealMsgPaddingX / 2.0f, TempY - RealMsgPaddingY / 2.0f, Width + RealMsgPaddingX + RealMsgPaddingTee, RealFontSize + RealMsgPaddingY, RealBackgroundRounding, CUI::CORNER_ALL);
+			TempY += RealOffsetY;
+
+			str_format(LineBuilder, sizeof(LineBuilder), "%s%sFriend: Hello there", g_Config.m_ClMessageFriend ? "♥ " : "", g_Config.m_ClShowIDs ? " 8: " : "");
+			Width = TextRender()->TextWidth(0, RealFontSize, LineBuilder, -1, -1);
+			RenderTools()->DrawRoundRectExt(X - RealMsgPaddingX / 2.0f, TempY - RealMsgPaddingY / 2.0f, Width + RealMsgPaddingX + RealMsgPaddingTee, RealFontSize + RealMsgPaddingY, RealBackgroundRounding, CUI::CORNER_ALL);
+			TempY += RealOffsetY;
+
+			str_format(LineBuilder, sizeof(LineBuilder), "%sSpammer [6]: Hey fools, I'm spamming here!", g_Config.m_ClShowIDs ? " 9: " : "");
+			Width = TextRender()->TextWidth(0, RealFontSize, LineBuilder, -1, -1);
+			RenderTools()->DrawRoundRectExt(X - RealMsgPaddingX / 2.0f, TempY - RealMsgPaddingY / 2.0f, Width + RealMsgPaddingX + RealMsgPaddingTee, RealFontSize + RealMsgPaddingY, RealBackgroundRounding, CUI::CORNER_ALL);
+			TempY += RealOffsetY;
+
+			Width = TextRender()->TextWidth(0, RealFontSize, "*** Echo command executed", -1, -1);
+			RenderTools()->DrawRoundRectExt(X - RealMsgPaddingX / 2.0f, TempY - RealMsgPaddingY / 2.0f, Width + RealMsgPaddingX, RealFontSize + RealMsgPaddingY, RealBackgroundRounding, CUI::CORNER_ALL);
+
+			Graphics()->QuadsEnd();
+
+			// Load skins
+
+			int DefaultInd = GameClient()->m_Skins.Find("default");
+
+			for(auto &i : RenderInfo)
+			{
+				i.m_Size = RealTeeSize;
+				i.m_CustomColoredSkin = false;
+			}
+
+			int ind = -1;
+			int i = 0;
+
+			RenderInfo[i++].m_OriginalRenderSkin = GameClient()->m_Skins.Get(DefaultInd)->m_OriginalSkin;
+			RenderInfo[i++].m_OriginalRenderSkin = (ind = GameClient()->m_Skins.Find("pinky")) != -1 ? GameClient()->m_Skins.Get(ind)->m_OriginalSkin : RenderInfo[0].m_OriginalRenderSkin;
+			RenderInfo[i++].m_OriginalRenderSkin = (ind = GameClient()->m_Skins.Find("cammostripes")) != -1 ? GameClient()->m_Skins.Get(ind)->m_OriginalSkin : RenderInfo[0].m_OriginalRenderSkin;
+			RenderInfo[i++].m_OriginalRenderSkin = (ind = GameClient()->m_Skins.Find("beast")) != -1 ? GameClient()->m_Skins.Get(ind)->m_OriginalSkin : RenderInfo[0].m_OriginalRenderSkin;
+		}
+
+		// System
 		if(g_Config.m_ClShowChatSystem)
 		{
-			str_format(LineBuilder, sizeof(LineBuilder), "*** '%s' entered and joined the game", aBuf);
-			Width = TextRender()->TextWidth(0, RealFontSize, LineBuilder, -1, -1);
-			RenderTools()->DrawRoundRectExt(X - RealMsgPaddingX / 2.0f, TempY - RealMsgPaddingY / 2.0f, Width + RealMsgPaddingX, RealFontSize + RealMsgPaddingY, RealBackgroundRounding, CUI::CORNER_ALL);
-			TempY += RealOffsetY;
+			TextRender()->TextColor(SystemColor);
+			TextRender()->TextEx(&Cursor, "*** '", -1);
+			TextRender()->TextEx(&Cursor, aBuf, -1);
+			TextRender()->TextEx(&Cursor, "' entered and joined the game", -1);
+			TextRender()->SetCursorPosition(&Cursor, X, Y += RealOffsetY);
 		}
 
-		str_format(LineBuilder, sizeof(LineBuilder), "%sRandom Tee: Hey, how are you %s?", g_Config.m_ClShowIDs ? " 7: " : "", aBuf);
-		Width = TextRender()->TextWidth(0, RealFontSize, LineBuilder, -1, -1);
-		RenderTools()->DrawRoundRectExt(X - RealMsgPaddingX / 2.0f, TempY - RealMsgPaddingY / 2.0f, Width + RealMsgPaddingX + RealMsgPaddingTee, RealFontSize + RealMsgPaddingY, RealBackgroundRounding, CUI::CORNER_ALL);
-		TempY += RealOffsetY;
-
-		str_format(LineBuilder, sizeof(LineBuilder), "%sYour Teammate: Let's speedrun this!", g_Config.m_ClShowIDs ? "11: " : "");
-		Width = TextRender()->TextWidth(0, RealFontSize, LineBuilder, -1, -1);
-		RenderTools()->DrawRoundRectExt(X - RealMsgPaddingX / 2.0f, TempY - RealMsgPaddingY / 2.0f, Width + RealMsgPaddingX + RealMsgPaddingTee, RealFontSize + RealMsgPaddingY, RealBackgroundRounding, CUI::CORNER_ALL);
-		TempY += RealOffsetY;
-
-		str_format(LineBuilder, sizeof(LineBuilder), "%s%sFriend: Hello there", g_Config.m_ClMessageFriend ? "♥ " : "", g_Config.m_ClShowIDs ? " 8: " : "");
-		Width = TextRender()->TextWidth(0, RealFontSize, LineBuilder, -1, -1);
-		RenderTools()->DrawRoundRectExt(X - RealMsgPaddingX / 2.0f, TempY - RealMsgPaddingY / 2.0f, Width + RealMsgPaddingX + RealMsgPaddingTee, RealFontSize + RealMsgPaddingY, RealBackgroundRounding, CUI::CORNER_ALL);
-		TempY += RealOffsetY;
-
-		str_format(LineBuilder, sizeof(LineBuilder), "%sSpammer [6]: Hey fools, I'm spamming here!", g_Config.m_ClShowIDs ? " 9: " : "");
-		Width = TextRender()->TextWidth(0, RealFontSize, LineBuilder, -1, -1);
-		RenderTools()->DrawRoundRectExt(X - RealMsgPaddingX / 2.0f, TempY - RealMsgPaddingY / 2.0f, Width + RealMsgPaddingX + RealMsgPaddingTee, RealFontSize + RealMsgPaddingY, RealBackgroundRounding, CUI::CORNER_ALL);
-		TempY += RealOffsetY;
-
-		Width = TextRender()->TextWidth(0, RealFontSize, "*** Echo command executed", -1, -1);
-		RenderTools()->DrawRoundRectExt(X - RealMsgPaddingX / 2.0f, TempY - RealMsgPaddingY / 2.0f, Width + RealMsgPaddingX, RealFontSize + RealMsgPaddingY, RealBackgroundRounding, CUI::CORNER_ALL);
-
-		Graphics()->QuadsEnd();
-
-		// Load skins
-
-		int DefaultInd = GameClient()->m_Skins.Find("default");
-
-		for(auto &i : RenderInfo)
-		{
-			i.m_Size = RealTeeSize;
-			i.m_CustomColoredSkin = false;
-		}
-
-		int ind = -1;
-		int i = 0;
-
-		RenderInfo[i++].m_OriginalRenderSkin = GameClient()->m_Skins.Get(DefaultInd)->m_OriginalSkin;
-		RenderInfo[i++].m_OriginalRenderSkin = (ind = GameClient()->m_Skins.Find("pinky")) != -1 ? GameClient()->m_Skins.Get(ind)->m_OriginalSkin : RenderInfo[0].m_OriginalRenderSkin;
-		RenderInfo[i++].m_OriginalRenderSkin = (ind = GameClient()->m_Skins.Find("cammostripes")) != -1 ? GameClient()->m_Skins.Get(ind)->m_OriginalSkin : RenderInfo[0].m_OriginalRenderSkin;
-		RenderInfo[i++].m_OriginalRenderSkin = (ind = GameClient()->m_Skins.Find("beast")) != -1 ? GameClient()->m_Skins.Get(ind)->m_OriginalSkin : RenderInfo[0].m_OriginalRenderSkin;
-	}
-
-	// System
-	if(g_Config.m_ClShowChatSystem)
-	{
-		TextRender()->TextColor(SystemColor);
-		TextRender()->TextEx(&Cursor, "*** '", -1);
+		// Highlighted
+		TextRender()->MoveCursor(&Cursor, RealMsgPaddingTee, 0);
+		TextRender()->TextColor(DefaultNameColor);
+		if(g_Config.m_ClShowIDs)
+			TextRender()->TextEx(&Cursor, " 7: ", -1);
+		TextRender()->TextEx(&Cursor, "Random Tee: ", -1);
+		TextRender()->TextColor(HighlightedColor);
+		TextRender()->TextEx(&Cursor, "Hey, how are you ", -1);
 		TextRender()->TextEx(&Cursor, aBuf, -1);
-		TextRender()->TextEx(&Cursor, "' entered and joined the game", -1);
+		TextRender()->TextEx(&Cursor, "?", -1);
+		if(!g_Config.m_ClChatOld)
+			RenderTools()->RenderTee(pIdleState, &RenderInfo[1], EMOTE_NORMAL, vec2(1, 0.1f), vec2(X + RealTeeSizeHalved, Y + OffsetTeeY + FullHeightMinusTee / 2.0f + TWSkinUnreliableOffset));
 		TextRender()->SetCursorPosition(&Cursor, X, Y += RealOffsetY);
+
+		// Team
+		TextRender()->MoveCursor(&Cursor, RealMsgPaddingTee, 0);
+		TextRender()->TextColor(TeamColor);
+		if(g_Config.m_ClShowIDs)
+			TextRender()->TextEx(&Cursor, "11: ", -1);
+		TextRender()->TextEx(&Cursor, "Your Teammate: Let's speedrun this!", -1);
+		if(!g_Config.m_ClChatOld)
+			RenderTools()->RenderTee(pIdleState, &RenderInfo[0], EMOTE_NORMAL, vec2(1, 0.1f), vec2(X + RealTeeSizeHalved, Y + OffsetTeeY + FullHeightMinusTee / 2.0f + TWSkinUnreliableOffset));
+		TextRender()->SetCursorPosition(&Cursor, X, Y += RealOffsetY);
+
+		// Friend
+		TextRender()->MoveCursor(&Cursor, RealMsgPaddingTee, 0);
+		if(g_Config.m_ClMessageFriend)
+		{
+			TextRender()->TextColor(FriendColor);
+			TextRender()->TextEx(&Cursor, "♥ ", -1);
+		}
+		TextRender()->TextColor(DefaultNameColor);
+		if(g_Config.m_ClShowIDs)
+			TextRender()->TextEx(&Cursor, " 8: ", -1);
+		TextRender()->TextEx(&Cursor, "Friend: ", -1);
+		TextRender()->TextColor(NormalColor);
+		TextRender()->TextEx(&Cursor, "Hello there", -1);
+		if(!g_Config.m_ClChatOld)
+			RenderTools()->RenderTee(pIdleState, &RenderInfo[2], EMOTE_NORMAL, vec2(1, 0.1f), vec2(X + RealTeeSizeHalved, Y + OffsetTeeY + FullHeightMinusTee / 2.0f + TWSkinUnreliableOffset));
+		TextRender()->SetCursorPosition(&Cursor, X, Y += RealOffsetY);
+
+		// Normal
+		TextRender()->MoveCursor(&Cursor, RealMsgPaddingTee, 0);
+		TextRender()->TextColor(DefaultNameColor);
+		if(g_Config.m_ClShowIDs)
+			TextRender()->TextEx(&Cursor, " 9: ", -1);
+		TextRender()->TextEx(&Cursor, "Spammer ", -1);
+		TextRender()->TextColor(1.0f, 1.0f, 1.0f, 0.3f);
+		TextRender()->TextEx(&Cursor, "[6]", -1);
+		TextRender()->TextColor(NormalColor);
+		TextRender()->TextEx(&Cursor, ": Hey fools, I'm spamming here!", -1);
+		if(!g_Config.m_ClChatOld)
+			RenderTools()->RenderTee(pIdleState, &RenderInfo[3], EMOTE_NORMAL, vec2(1, 0.1f), vec2(X + RealTeeSizeHalved, Y + OffsetTeeY + FullHeightMinusTee / 2.0f + TWSkinUnreliableOffset));
+		TextRender()->SetCursorPosition(&Cursor, X, Y += RealOffsetY);
+
+		// Client
+		TextRender()->TextColor(ClientColor);
+		TextRender()->TextEx(&Cursor, "*** Echo command executed", -1);
+		TextRender()->SetCursorPosition(&Cursor, X, Y);
+
+		TextRender()->TextColor(1, 1, 1, 1);
 	}
-
-	// Highlighted
-	TextRender()->MoveCursor(&Cursor, RealMsgPaddingTee, 0);
-	TextRender()->TextColor(DefaultNameColor);
-	if(g_Config.m_ClShowIDs)
-		TextRender()->TextEx(&Cursor, " 7: ", -1);
-	TextRender()->TextEx(&Cursor, "Random Tee: ", -1);
-	TextRender()->TextColor(HighlightedColor);
-	TextRender()->TextEx(&Cursor, "Hey, how are you ", -1);
-	TextRender()->TextEx(&Cursor, aBuf, -1);
-	TextRender()->TextEx(&Cursor, "?", -1);
-	if(!g_Config.m_ClChatOld)
-		RenderTools()->RenderTee(pIdleState, &RenderInfo[1], EMOTE_NORMAL, vec2(1, 0.1f), vec2(X + RealTeeSizeHalved, Y + OffsetTeeY + FullHeightMinusTee / 2.0f + TWSkinUnreliableOffset));
-	TextRender()->SetCursorPosition(&Cursor, X, Y += RealOffsetY);
-
-	// Team
-	TextRender()->MoveCursor(&Cursor, RealMsgPaddingTee, 0);
-	TextRender()->TextColor(TeamColor);
-	if(g_Config.m_ClShowIDs)
-		TextRender()->TextEx(&Cursor, "11: ", -1);
-	TextRender()->TextEx(&Cursor, "Your Teammate: Let's speedrun this!", -1);
-	if(!g_Config.m_ClChatOld)
-		RenderTools()->RenderTee(pIdleState, &RenderInfo[0], EMOTE_NORMAL, vec2(1, 0.1f), vec2(X + RealTeeSizeHalved, Y + OffsetTeeY + FullHeightMinusTee / 2.0f + TWSkinUnreliableOffset));
-	TextRender()->SetCursorPosition(&Cursor, X, Y += RealOffsetY);
-
-	// Friend
-	TextRender()->MoveCursor(&Cursor, RealMsgPaddingTee, 0);
-	if(g_Config.m_ClMessageFriend)
-	{
-		TextRender()->TextColor(FriendColor);
-		TextRender()->TextEx(&Cursor, "♥ ", -1);
-	}
-	TextRender()->TextColor(DefaultNameColor);
-	if(g_Config.m_ClShowIDs)
-		TextRender()->TextEx(&Cursor, " 8: ", -1);
-	TextRender()->TextEx(&Cursor, "Friend: ", -1);
-	TextRender()->TextColor(NormalColor);
-	TextRender()->TextEx(&Cursor, "Hello there", -1);
-	if(!g_Config.m_ClChatOld)
-		RenderTools()->RenderTee(pIdleState, &RenderInfo[2], EMOTE_NORMAL, vec2(1, 0.1f), vec2(X + RealTeeSizeHalved, Y + OffsetTeeY + FullHeightMinusTee / 2.0f + TWSkinUnreliableOffset));
-	TextRender()->SetCursorPosition(&Cursor, X, Y += RealOffsetY);
-
-	// Normal
-	TextRender()->MoveCursor(&Cursor, RealMsgPaddingTee, 0);
-	TextRender()->TextColor(DefaultNameColor);
-	if(g_Config.m_ClShowIDs)
-		TextRender()->TextEx(&Cursor, " 9: ", -1);
-	TextRender()->TextEx(&Cursor, "Spammer ", -1);
-	TextRender()->TextColor(1.0f, 1.0f, 1.0f, 0.3f);
-	TextRender()->TextEx(&Cursor, "[6]", -1);
-	TextRender()->TextColor(NormalColor);
-	TextRender()->TextEx(&Cursor, ": Hey fools, I'm spamming here!", -1);
-	if(!g_Config.m_ClChatOld)
-		RenderTools()->RenderTee(pIdleState, &RenderInfo[3], EMOTE_NORMAL, vec2(1, 0.1f), vec2(X + RealTeeSizeHalved, Y + OffsetTeeY + FullHeightMinusTee / 2.0f + TWSkinUnreliableOffset));
-	TextRender()->SetCursorPosition(&Cursor, X, Y += RealOffsetY);
-
-	// Client
-	TextRender()->TextColor(ClientColor);
-	TextRender()->TextEx(&Cursor, "*** Echo command executed", -1);
-	TextRender()->SetCursorPosition(&Cursor, X, Y);
-
-	TextRender()->TextColor(1, 1, 1, 1);
 }
 
 void CMenus::RenderSettingsDDNet(CUIRect MainView)

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -2108,12 +2108,10 @@ void CMenus::RenderSettingsHUD(CUIRect MainView)
 		MainView.HSplitTop(10.0f, 0x0, &MainView);
 
 		static int KillMessageNormalColorID;
-
-		ColorHSLA KillMessageNormalColor = DoLine_ColorPicker(&KillMessageNormalColorID, 25.0f, 250.0f, 13.0f, 5.0f, &MainView, Localize("Kill Message Normal Color"), &g_Config.m_ClKillMessageNormalColor, ColorRGBA(1.0f, 1.0f, 1.0f, 0.5f), false);
+		DoLine_ColorPicker(&KillMessageNormalColorID, 25.0f, 250.0f, 13.0f, 5.0f, &MainView, Localize("Kill Message Normal Color"), &g_Config.m_ClKillMessageNormalColor, ColorRGBA(1.0f, 1.0f, 1.0f, 0.5f), false);
 
 		static int KillMessageHighlightColorID;
-
-		ColorHSLA KillMessageHighlightColor = DoLine_ColorPicker(&KillMessageHighlightColorID, 25.0f, 250.0f, 13.0f, 5.0f, &MainView, Localize("Kill Message Highlight Color"), &g_Config.m_ClKillMessageHighlightColor, ColorRGBA(1.0f, 0.5f, 0.5f), false);
+		DoLine_ColorPicker(&KillMessageHighlightColorID, 25.0f, 250.0f, 13.0f, 5.0f, &MainView, Localize("Kill Message Highlight Color"), &g_Config.m_ClKillMessageHighlightColor, ColorRGBA(1.0f, 0.5f, 0.5f), false);
 
 		// ***** Laser ***** //
 

--- a/src/game/variables.h
+++ b/src/game/variables.h
@@ -49,7 +49,6 @@ MACRO_CONFIG_INT(ClShowChat, cl_showchat, 1, 0, 2, CFGFLAG_CLIENT | CFGFLAG_SAVE
 MACRO_CONFIG_INT(ClShowChatFriends, cl_show_chat_friends, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show only chat messages from friends")
 MACRO_CONFIG_INT(ClShowChatSystem, cl_show_chat_system, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show chat messages from the server")
 MACRO_CONFIG_INT(ClShowKillMessages, cl_showkillmessages, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show kill messages")
-MACRO_CONFIG_INT(ClKillMessageHighlightSelf, cl_killmessage_highlightself, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Highlight self in kill messages")
 MACRO_CONFIG_INT(ClShowVotesAfterVoting, cl_show_votes_after_voting, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show votes window after voting")
 MACRO_CONFIG_INT(ClShowLocalTimeAlways, cl_show_local_time_always, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Always show local time")
 MACRO_CONFIG_INT(ClShowfps, cl_showfps, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show ingame FPS counter")

--- a/src/game/variables.h
+++ b/src/game/variables.h
@@ -49,6 +49,7 @@ MACRO_CONFIG_INT(ClShowChat, cl_showchat, 1, 0, 2, CFGFLAG_CLIENT | CFGFLAG_SAVE
 MACRO_CONFIG_INT(ClShowChatFriends, cl_show_chat_friends, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show only chat messages from friends")
 MACRO_CONFIG_INT(ClShowChatSystem, cl_show_chat_system, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show chat messages from the server")
 MACRO_CONFIG_INT(ClShowKillMessages, cl_showkillmessages, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show kill messages")
+MACRO_CONFIG_INT(ClKillMessageHighlightSelf, cl_killmessage_highlightself, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Highlight self in kill messages")
 MACRO_CONFIG_INT(ClShowVotesAfterVoting, cl_show_votes_after_voting, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show votes window after voting")
 MACRO_CONFIG_INT(ClShowLocalTimeAlways, cl_show_local_time_always, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Always show local time")
 MACRO_CONFIG_INT(ClShowfps, cl_showfps, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show ingame FPS counter")


### PR DESCRIPTION
Motivation: #4186

List of changes:
- Add options clKillMessageHighlightSelf, clKillMessageNormalColor, clKillMessageHighlightColor
- Rework HUD panel in settings

![hud_0](https://user-images.githubusercontent.com/17968319/135732345-b8152c74-f754-4722-9b60-46a1ba7cc9c8.png)

![hud_1](https://user-images.githubusercontent.com/17968319/135732346-814a918b-1828-4860-a3c7-372869b79575.png)

![in_game](https://user-images.githubusercontent.com/17968319/135732347-6e9cf148-29b8-4fc4-8dba-647e049f961a.png)

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [x] Written a unit test if it works standalone, system.c especially (not standalone)
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
