### PR TITLE
Properly export antibot DLL symbols on Windows, this time for real

### DIFF
--- a/src/antibot/antibot_null.cpp
+++ b/src/antibot/antibot_null.cpp
@@ -1,6 +1,6 @@
 #define ANTIBOTAPI DYNAMIC_EXPORT
 
-#include "antibot_data.h"
+#include "antibot_interface.h"
 
 static CAntibotData *g_pData;
 


### PR DESCRIPTION
0750ae0fbd79f66aedfbb7ff1092007ae69a6d9c was missing the function
prototypes that used `ANTIBOTAPI`.

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
