### PR TITLE
Fix notify on xmonad

### DIFF
--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -1206,7 +1206,7 @@ void CGraphicsBackend_SDL_OpenGL::GetViewportSize(int &w, int &h)
 void CGraphicsBackend_SDL_OpenGL::NotifyWindow()
 {
 #if SDL_MAJOR_VERSION > 2 || (SDL_MAJOR_VERSION == 2 && SDL_PATCHLEVEL >= 16)
-	if(SDL_FlashWindow(m_pWindow, SDL_FlashOperation::SDL_FLASH_BRIEFLY) != 0)
+	if(SDL_FlashWindow(m_pWindow, SDL_FlashOperation::SDL_FLASH_UNTIL_FOCUSED) != 0)
 	{
 		// fails if SDL hasn't implemented it
 		return;


### PR DESCRIPTION
I don't get a notification otherwise, not sure if this is the better
default or we need an option

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
