### PR TITLE
Fix detect.h

### DIFF
--- a/src/base/detect.h
+++ b/src/base/detect.h
@@ -179,13 +179,7 @@
 #define PLATFORM_SUFFIX ""
 #endif
 
-#ifndef CONF_PLATFORM_STRING
-#define CONF_PLATFORM_STRING "unknown"
-#endif
-
-#ifndef PLATFORM_STRING
-#define PLATFORM_STRING "unknown"
-#endif
+#define CONF_PLATFORM_STRING PLATFORM_STRING PLATFORM_SUFFIX
 
 #ifndef CONF_ARCH_STRING
 #define CONF_ARCH_STRING "unknown"


### PR DESCRIPTION
broke by 
https://github.com/ddnet/ddnet/commit/3b1c0748423a4a493ae6eb7536d16507499de9bc#diff-86d59021cb4561b3911602552aed980edc3ddf8b4846d5e59f09b3e863fff8e5L182

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
