### PR TITLE
Fix exception in GetAnnouncementLine with empty list

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -3667,7 +3667,12 @@ const char *CServer::GetAnnouncementLine(char const *pFileName)
 		if(str_length(pLine))
 			if(pLine[0] != '#')
 				Lines.push_back(pLine);
-	if(Lines.size() == 1)
+
+	if(Lines.empty())
+	{
+		return 0;
+	}
+	else if(Lines.size() == 1)
 	{
 		m_AnnouncementLastLine = 0;
 	}
@@ -3680,8 +3685,9 @@ const char *CServer::GetAnnouncementLine(char const *pFileName)
 	{
 		unsigned Rand;
 		do
+		{
 			Rand = rand() % Lines.size();
-		while(Rand == m_AnnouncementLastLine);
+		} while(Rand == m_AnnouncementLastLine);
 
 		m_AnnouncementLastLine = Rand;
 	}


### PR DESCRIPTION
Fix division by zero in `GetAnnouncementLine` when the announcement file exists but is empty or only contains empty lines or comments.

Closes #4206. The crash is unrelated to the setting `sv_announcement_interval 0`, as this setting is impossible and the value will automatically be clamped to 1 by the console.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
