### PR TITLE
Fix pasting crash in edit box (fixes #4230)

### DIFF
--- a/src/game/client/ui_ex.cpp
+++ b/src/game/client/ui_ex.cpp
@@ -51,7 +51,7 @@ int CUIEx::DoEditBox(void *pID, const CUIRect *pRect, char *pStr, unsigned StrSi
 			const char *pText = Input()->GetClipboardText();
 			if(pText)
 			{
-				int OffsetL = minimum(str_length(pStr), m_CurCursor);
+				int OffsetL = clamp(m_CurCursor, 0, str_length(pStr));
 				int OffsetR = OffsetL;
 
 				if(m_HasSelection)


### PR DESCRIPTION
Don't allocate string with -1 size

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
