### PR TITLE
Change default ban reason and ban duration if none is given

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -227,8 +227,8 @@ void CServerBan::ConBanExt(IConsole::IResult *pResult, void *pUser)
 	CServerBan *pThis = static_cast<CServerBan *>(pUser);
 
 	const char *pStr = pResult->GetString(0);
-	int Minutes = pResult->NumArguments() > 1 ? clamp(pResult->GetInteger(1), 0, 525600) : 30;
-	const char *pReason = pResult->NumArguments() > 2 ? pResult->GetString(2) : "No reason given";
+	int Minutes = pResult->NumArguments() > 1 ? clamp(pResult->GetInteger(1), 0, 525600) : 10;
+	const char *pReason = pResult->NumArguments() > 2 ? pResult->GetString(2) : "Follow the server rules. Type /rules into the chat.";
 
 	if(str_isallnum(pStr))
 	{


### PR DESCRIPTION
> [17:20] murpi: @heinrich5991 would it be possible to default the ban reason to just say 'follow the server rules' or '/rules' instead of 'no reason given'?
[17:34] heinrich5991: @murpi is this about rcon or votes? or the global bans?
[17:35] murpi: rcon
[17:37] heinrich5991: the motivation is that this is your most frequent ban reason and it'd allow you to type less?
[17:38] murpi: Yes!
[17:38] m!ki: Lazy sheep

Reduced the default time from 30 minutes to 10 minutes.

SS:

![DDNet_aUzBvXA7AV](https://user-images.githubusercontent.com/60477660/138151397-4868d152-8ac3-4a2c-afa7-c94d6ce96bc5.png)

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)

