### PR TITLE
Fix mouse select position in console when using different page

### DIFF
--- a/src/game/client/components/console.h
+++ b/src/game/client/components/console.h
@@ -94,6 +94,8 @@ class CGameConsole : public CComponent
 	bool m_HasSelection = false;
 	int m_NewLineCounter = 0;
 
+	int m_LastInputLineCount = 0;
+
 	void Toggle(int Type);
 	void Dump(int Type);
 


### PR DESCRIPTION
fixes #4246

Also noticed if you enter so much text that console input goes into the second line, it will move the whole console up, but i disabled selection in this case for now, because don't want to redesign the whole console rn and is a real edge case anyway.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
