### PR TITLE
Reset text color after kill messages are created

### DIFF
--- a/src/game/client/components/killmessages.cpp
+++ b/src/game/client/components/killmessages.cpp
@@ -103,6 +103,7 @@ void CKillMessages::CreateKillmessageNamesIfNotCreated(CKillMsg &Kill)
 
 		Kill.m_KillerTextContainerIndex = TextRender()->CreateTextContainer(&Cursor, Kill.m_aKillerName);
 	}
+	TextRender()->TextColor(TextRender()->DefaultTextColor());
 }
 
 void CKillMessages::OnMessage(int MsgType, void *pRawMsg)

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -2370,7 +2370,7 @@ void CMenus::RenderSettingsHUD(CUIRect MainView)
 		TextRender()->TextEx(&Cursor, "*** Echo command executed", -1);
 		TextRender()->SetCursorPosition(&Cursor, X, Y);
 
-		TextRender()->TextColor(1, 1, 1, 1);
+		TextRender()->TextColor(TextRender()->DefaultTextColor());
 	}
 }
 


### PR DESCRIPTION
I could imagine this fixes #4263

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
