### PR TITLE
CVariableInt: Limit to 31 bits to fit into int (fixes #4280)

### DIFF
--- a/src/engine/shared/compression.cpp
+++ b/src/engine/shared/compression.cpp
@@ -55,7 +55,7 @@ const unsigned char *CVariableInt::Unpack(const unsigned char *pSrc, int *pInOut
 		if(!(*pSrc & 0x80))
 			break;
 		pSrc++;
-		*pInOut |= (*pSrc & (0x7F)) << (6 + 7 + 7 + 7);
+		*pInOut |= (*pSrc & (0x1F)) << (6 + 7 + 7 + 7);
 	} while(0);
 
 	pSrc++;


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
