### PR TITLE
Don't divide by 0 with sv_plasma_per_sec

### DIFF
--- a/src/game/server/entities/gun.cpp
+++ b/src/game/server/entities/gun.cpp
@@ -106,7 +106,7 @@ void CGun::Tick()
 		}
 		m_Pos += m_Core;
 	}
-	if(m_LastFire + Server()->TickSpeed() / g_Config.m_SvPlasmaPerSec <= Server()->Tick())
+	if(g_Config.m_SvPlasmaPerSec == 0 || m_LastFire + Server()->TickSpeed() / g_Config.m_SvPlasmaPerSec <= Server()->Tick())
 		Fire();
 }
 


### PR DESCRIPTION
Thread 1 "DDNet-Server" received signal SIGFPE, Arithmetic exception.
0x000055555560d65f in CGun::Tick (this=0x55555583b440) at /media/ddnet/src/game/server/entities/gun.cpp:109
109		if(m_LastFire + Server()->TickSpeed() / g_Config.m_SvPlasmaPerSec <= Server()->Tick())

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
