### PR TITLE
Don't call uuid lookup, if the expected type isn't an uuid extended type anyway

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -990,7 +990,9 @@ void *CClient::SnapFindItem(int SnapID, int Type, int ID) const
 	for(i = 0; i < m_aSnapshots[g_Config.m_ClDummy][SnapID]->m_pSnap->NumItems(); i++)
 	{
 		CSnapshotItem *pItem = m_aSnapshots[g_Config.m_ClDummy][SnapID]->m_pAltSnap->GetItem(i);
-		if(m_aSnapshots[g_Config.m_ClDummy][SnapID]->m_pAltSnap->GetItemType(i) == Type && pItem->ID() == ID)
+		if(Type >= OFFSET_UUID && pItem->Type() >= CSnapshot::OFFSET_UUID_TYPE && m_aSnapshots[g_Config.m_ClDummy][SnapID]->m_pAltSnap->GetItemType(i) == Type && pItem->ID() == ID)
+			return (void *)pItem->Data();
+		else if(Type < OFFSET_UUID && pItem->Type() < CSnapshot::OFFSET_UUID_TYPE && pItem->Type() == Type && pItem->ID() == ID)
 			return (void *)pItem->Data();
 	}
 	return 0x0;


### PR DESCRIPTION


Most performance loss currently comes from the simple fact that lookupuuid is slow.
This addresses the problem by making sure its only called for net messages, that are extended anyway

@trml or @heinrich5991 can you check if that makes sense without breaking something?

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
