### PR TITLE
Small optimization of EntityEx snapping

### DIFF
--- a/src/game/client/components/items.cpp
+++ b/src/game/client/components/items.cpp
@@ -312,6 +312,7 @@ void CItems::OnRender()
 	bool BlinkingLight = (Ticks % 6) < 2;
 	int OwnTeam = m_pClient->OwnTeam();
 	int DraggerStartTick = maximum((Client()->GameTick(g_Config.m_ClDummy) / 7) * 7, Client()->GameTick(g_Config.m_ClDummy) - 4);
+	int GunStartTick = (Client()->GameTick(g_Config.m_ClDummy) / 7) * 7;
 
 	bool UsePredicted = GameClient()->Predict() && GameClient()->AntiPingGunfire();
 	if(UsePredicted)
@@ -418,10 +419,18 @@ void CItems::OnRender()
 
 			if(pEntEx)
 			{
-				if(pEntEx->m_EntityClass == ENTITYCLASS_LIGHT && Inactive && BlinkingLight)
-					continue;
-				if(pEntEx->m_EntityClass >= ENTITYCLASS_GUN_NORMAL && pEntEx->m_EntityClass <= ENTITYCLASS_GUN_UNFREEZE && Inactive && BlinkingGun)
-					continue;
+				if(pEntEx->m_EntityClass == ENTITYCLASS_LIGHT)
+				{
+					if(Inactive && BlinkingLight)
+						continue;
+					Laser.m_StartTick = DraggerStartTick;
+				}
+				if(pEntEx->m_EntityClass >= ENTITYCLASS_GUN_NORMAL && pEntEx->m_EntityClass <= ENTITYCLASS_GUN_UNFREEZE)
+				{
+					if(Inactive && BlinkingGun)
+						continue;
+					Laser.m_StartTick = GunStartTick;
+				}
 				if(pEntEx->m_EntityClass >= ENTITYCLASS_DRAGGER_WEAK && pEntEx->m_EntityClass <= ENTITYCLASS_DRAGGER_STRONG)
 				{
 					if(Inactive && BlinkingDragger)

--- a/src/game/server/entities/door.cpp
+++ b/src/game/server/entities/door.cpp
@@ -45,14 +45,6 @@ void CDoor::Snap(int SnappingClient)
 	if(NetworkClipped(SnappingClient, m_Pos) && NetworkClipped(SnappingClient, m_To))
 		return;
 
-	CNetObj_EntityEx *pEntData = static_cast<CNetObj_EntityEx *>(Server()->SnapNewItem(NETOBJTYPE_ENTITYEX, GetID(), sizeof(CNetObj_EntityEx)));
-	if(!pEntData)
-		return;
-
-	pEntData->m_SwitchNumber = m_Number;
-	pEntData->m_Layer = m_Layer;
-	pEntData->m_EntityClass = ENTITYCLASS_DOOR;
-
 	CNetObj_Laser *pObj = static_cast<CNetObj_Laser *>(Server()->SnapNewItem(
 		NETOBJTYPE_LASER, GetID(), sizeof(CNetObj_Laser)));
 
@@ -64,8 +56,16 @@ void CDoor::Snap(int SnappingClient)
 
 	int SnappingClientVersion = SnappingClient >= 0 ? GameServer()->GetClientVersion(SnappingClient) : CLIENT_VERSIONNR;
 
+	CNetObj_EntityEx *pEntData = 0;
 	if(SnappingClientVersion >= VERSION_DDNET_SWITCH)
+		pEntData = static_cast<CNetObj_EntityEx *>(Server()->SnapNewItem(NETOBJTYPE_ENTITYEX, GetID(), sizeof(CNetObj_EntityEx)));
+
+	if(pEntData)
 	{
+		pEntData->m_SwitchNumber = m_Number;
+		pEntData->m_Layer = m_Layer;
+		pEntData->m_EntityClass = ENTITYCLASS_DOOR;
+
 		pObj->m_FromX = (int)m_To.x;
 		pObj->m_FromY = (int)m_To.y;
 		pObj->m_StartTick = 0;

--- a/src/game/server/entities/dragger.cpp
+++ b/src/game/server/entities/dragger.cpp
@@ -174,6 +174,18 @@ void CDragger::Snap(int SnappingClient)
 
 	int SnappingClientVersion = SnappingClient >= 0 ? GameServer()->GetClientVersion(SnappingClient) : CLIENT_VERSIONNR;
 
+	CNetObj_EntityEx *pEntData = 0;
+	if(SnappingClientVersion >= VERSION_DDNET_SWITCH)
+	{
+		pEntData = static_cast<CNetObj_EntityEx *>(Server()->SnapNewItem(NETOBJTYPE_ENTITYEX, GetID(), sizeof(CNetObj_EntityEx)));
+		if(pEntData)
+		{
+			pEntData->m_SwitchNumber = m_Number;
+			pEntData->m_Layer = m_Layer;
+			pEntData->m_EntityClass = clamp(ENTITYCLASS_DRAGGER_WEAK + round_to_int(m_Strength) - 1, (int)ENTITYCLASS_DRAGGER_WEAK, (int)ENTITYCLASS_DRAGGER_STRONG);
+		}
+	}
+
 	CCharacter *pTarget = m_TargetID < 0 ? 0 : GameServer()->GetPlayerChar(m_TargetID);
 
 	for(int &SoloID : m_SoloIDs)
@@ -238,14 +250,6 @@ void CDragger::Snap(int SnappingClient)
 		{
 			obj = static_cast<CNetObj_Laser *>(Server()->SnapNewItem(
 				NETOBJTYPE_LASER, GetID(), sizeof(CNetObj_Laser)));
-
-			CNetObj_EntityEx *pEntData = static_cast<CNetObj_EntityEx *>(Server()->SnapNewItem(NETOBJTYPE_ENTITYEX, GetID(), sizeof(CNetObj_EntityEx)));
-			if(!pEntData)
-				return;
-
-			pEntData->m_SwitchNumber = m_Number;
-			pEntData->m_Layer = m_Layer;
-			pEntData->m_EntityClass = clamp(ENTITYCLASS_DRAGGER_WEAK + round_to_int(m_Strength) - 1, (int)ENTITYCLASS_DRAGGER_WEAK, (int)ENTITYCLASS_DRAGGER_STRONG);
 		}
 		else
 		{
@@ -270,7 +274,11 @@ void CDragger::Snap(int SnappingClient)
 			obj->m_FromY = (int)m_Pos.y;
 		}
 
-		if(i != -1 || SnappingClientVersion < VERSION_DDNET_SWITCH)
+		if(pEntData && i == -1)
+		{
+			obj->m_StartTick = 0;
+		}
+		else
 		{
 			int StartTick = m_EvalTick;
 			if(StartTick < Server()->Tick() - 4)
@@ -278,10 +286,6 @@ void CDragger::Snap(int SnappingClient)
 			else if(StartTick > Server()->Tick())
 				StartTick = Server()->Tick();
 			obj->m_StartTick = StartTick;
-		}
-		else
-		{
-			obj->m_StartTick = 0;
 		}
 	}
 }

--- a/src/game/server/entities/pickup.cpp
+++ b/src/game/server/entities/pickup.cpp
@@ -160,16 +160,19 @@ void CPickup::Snap(int SnappingClient)
 	if(SnappingClient > -1 && (GameServer()->m_apPlayers[SnappingClient]->GetTeam() == -1 || GameServer()->m_apPlayers[SnappingClient]->IsPaused()) && GameServer()->m_apPlayers[SnappingClient]->m_SpectatorID != SPEC_FREEVIEW)
 		Char = GameServer()->GetPlayerChar(GameServer()->m_apPlayers[SnappingClient]->m_SpectatorID);
 
-	CNetObj_EntityEx *pEntData = static_cast<CNetObj_EntityEx *>(Server()->SnapNewItem(NETOBJTYPE_ENTITYEX, GetID(), sizeof(CNetObj_EntityEx)));
-	if(!pEntData)
-		return;
-
-	pEntData->m_SwitchNumber = m_Number;
-	pEntData->m_Layer = m_Layer;
-	pEntData->m_EntityClass = ENTITYCLASS_PICKUP;
-
 	int SnappingClientVersion = SnappingClient >= 0 ? GameServer()->GetClientVersion(SnappingClient) : CLIENT_VERSIONNR;
-	if(SnappingClientVersion < VERSION_DDNET_SWITCH)
+
+	CNetObj_EntityEx *pEntData = 0;
+	if(SnappingClientVersion >= VERSION_DDNET_SWITCH && (m_Layer == LAYER_SWITCH || length(m_Core) > 0))
+		pEntData = static_cast<CNetObj_EntityEx *>(Server()->SnapNewItem(NETOBJTYPE_ENTITYEX, GetID(), sizeof(CNetObj_EntityEx)));
+
+	if(pEntData)
+	{
+		pEntData->m_SwitchNumber = m_Number;
+		pEntData->m_Layer = m_Layer;
+		pEntData->m_EntityClass = ENTITYCLASS_PICKUP;
+	}
+	else
 	{
 		int Tick = (Server()->Tick() % Server()->TickSpeed()) % 11;
 		if(Char && Char->IsAlive() && m_Layer == LAYER_SWITCH && m_Number > 0 && !GameServer()->Collision()->m_pSwitchers[m_Number].m_Status[Char->Team()] && !Tick)


### PR DESCRIPTION
This drops sending entityex to old client versions, and for stationary pickups not in switch layer (since they don't benefit from entity ex for prediction).

It also slightly changes how m_StartTick is snapped for CLight and CGun when EntityEx is present (always sets it to 0, which could reduce network traffic slightly). However, this might cause misprediction (or invisible lights/guns) for clients who have already changed their version to 15.6, so can omit this part if wanted.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
