### PR TITLE
Don't access out of bounds in linereader (fixes #4308)

### DIFF
--- a/src/engine/shared/linereader.cpp
+++ b/src/engine/shared/linereader.cpp
@@ -4,7 +4,7 @@
 
 void CLineReader::Init(IOHANDLE File)
 {
-	m_BufferMaxSize = sizeof(m_aBuffer);
+	m_BufferMaxSize = sizeof(m_aBuffer) - 1;
 	m_BufferSize = 0;
 	m_BufferPos = 0;
 	m_File = File;

--- a/src/engine/shared/linereader.h
+++ b/src/engine/shared/linereader.h
@@ -7,7 +7,7 @@
 // buffered stream for reading lines, should perhaps be something smaller
 class CLineReader
 {
-	char m_aBuffer[4 * 8192];
+	char m_aBuffer[4 * 8192 + 1]; // 1 additional byte for null termination
 	unsigned m_BufferPos;
 	unsigned m_BufferSize;
 	unsigned m_BufferMaxSize;


### PR DESCRIPTION
If someone wants to look more closely, maybe there is a better fix

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
