### PR TITLE
Use uint64_t for network stats (fixes #4309)

### DIFF
--- a/src/base/system.h
+++ b/src/base/system.h
@@ -1845,10 +1845,10 @@ void dbg_logger_file(const char *filename);
 
 typedef struct
 {
-	int sent_packets;
-	int sent_bytes;
-	int recv_packets;
-	int recv_bytes;
+	uint64_t sent_packets;
+	uint64_t sent_bytes;
+	uint64_t recv_packets;
+	uint64_t recv_bytes;
 } NETSTATS;
 
 void net_stats(NETSTATS *stats);

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -80,6 +80,11 @@
 #include "SDL_rwops.h"
 #include "base/hash.h"
 
+// for msvc
+#ifndef PRIu64
+#define PRIu64 "I64u"
+#endif
+
 static const ColorRGBA ClientNetworkPrintColor{0.7f, 1, 0.7f, 1.0f};
 static const ColorRGBA ClientNetworkErrPrintColor{1.0f, 0.25f, 0.25f, 1.0f};
 
@@ -1045,18 +1050,18 @@ void CClient::DebugRender()
 	Graphics()->QuadsText(2, 2, 16, aBuffer);
 
 	{
-		int SendPackets = (Current.sent_packets - Prev.sent_packets);
-		int SendBytes = (Current.sent_bytes - Prev.sent_bytes);
-		int SendTotal = SendBytes + SendPackets * 42;
-		int RecvPackets = (Current.recv_packets - Prev.recv_packets);
-		int RecvBytes = (Current.recv_bytes - Prev.recv_bytes);
-		int RecvTotal = RecvBytes + RecvPackets * 42;
+		uint64_t SendPackets = (Current.sent_packets - Prev.sent_packets);
+		uint64_t SendBytes = (Current.sent_bytes - Prev.sent_bytes);
+		uint64_t SendTotal = SendBytes + SendPackets * 42;
+		uint64_t RecvPackets = (Current.recv_packets - Prev.recv_packets);
+		uint64_t RecvBytes = (Current.recv_bytes - Prev.recv_bytes);
+		uint64_t RecvTotal = RecvBytes + RecvPackets * 42;
 
 		if(!SendPackets)
 			SendPackets++;
 		if(!RecvPackets)
 			RecvPackets++;
-		str_format(aBuffer, sizeof(aBuffer), "send: %3d %5d+%4d=%5d (%3d kbps) avg: %5d\nrecv: %3d %5d+%4d=%5d (%3d kbps) avg: %5d",
+		str_format(aBuffer, sizeof(aBuffer), "send: %3" PRIu64 " %5" PRIu64 "+%4" PRIu64 "=%5" PRIu64 " (%3" PRIu64 " kbps) avg: %5" PRIu64 "\nrecv: %3" PRIu64 " %5" PRIu64 "+%4" PRIu64 "=%5" PRIu64 " (%3" PRIu64 " kbps) avg: %5" PRIu64,
 			SendPackets, SendBytes, SendPackets * 42, SendTotal, (SendTotal * 8) / 1024, SendBytes / SendPackets,
 			RecvPackets, RecvBytes, RecvPackets * 42, RecvTotal, (RecvTotal * 8) / 1024, RecvBytes / RecvPackets);
 		Graphics()->QuadsText(2, 14, 16, aBuffer);


### PR DESCRIPTION
Doesn't overflow so quickly, if it overflows has deterministic behavior
at least.

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
