### PR TITLE
Option to disallow dummys (#4305)

### DIFF
--- a/datasrc/network.py
+++ b/datasrc/network.py
@@ -25,6 +25,7 @@ GameInfoFlags = [
 ]
 GameInfoFlags2 = [
 	"ALLOW_X_SKINS", "GAMETYPE_CITY", "GAMETYPE_FDDRACE", "ENTITIES_FDDRACE",
+	"ALLOW_DUMMY",
 ]
 ExPlayerFlags = ["AFK", "PAUSED", "SPEC"]
 ProjectileFlags = ["CLIENTID_BIT{}".format(i) for i in range(8)] + [
@@ -64,7 +65,7 @@ enum
 
 enum
 {
-	GAMEINFO_CURVERSION=6,
+	GAMEINFO_CURVERSION=7,
 };
 '''
 

--- a/src/engine/client.h
+++ b/src/engine/client.h
@@ -10,6 +10,7 @@
 #include <engine/friends.h>
 
 struct SWarning;
+class CGameInfo;
 
 enum
 {
@@ -262,6 +263,7 @@ public:
 	virtual void Echo(const char *pString) = 0;
 	virtual bool CanDisplayWarning() = 0;
 	virtual bool IsDisplayingWarning() = 0;
+	virtual CGameInfo *GameInfo() = 0;
 };
 
 void SnapshotRemoveExtraProjectileInfo(unsigned char *pData);

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -860,10 +860,10 @@ void CClient::DummyConnect()
 {
 	if(m_LastDummyConnectTime > 0 && m_LastDummyConnectTime + GameTickSpeed() * 5 > GameTick(g_Config.m_ClDummy))
 		return;
-
+	if(!GameClient()->GameInfo()->m_AllowDummy)
+		return;
 	if(m_NetClient[CLIENT_MAIN].State() != NET_CONNSTATE_ONLINE && m_NetClient[CLIENT_MAIN].State() != NET_CONNSTATE_PENDING)
 		return;
-
 	if(m_DummyConnected)
 		return;
 

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -64,7 +64,11 @@ void CMenus::RenderGame(CUIRect MainView)
 
 	bool DummyConnecting = Client()->DummyConnecting();
 	static int s_DummyButton = 0;
-	if(DummyConnecting)
+	if(!GameClient()->m_GameInfo.m_AllowDummy && !Client()->DummyConnected())
+	{
+		DoButton_Menu(&s_DummyButton, Localize("Connect Dummy"), 1, &Button, 0, 15, 5.0f, 0.0f, vec4(1.0f, 0.5f, 0.5f, 0.75f), vec4(1, 0.5f, 0.5f, 0.5f));
+	}
+	else if(DummyConnecting)
 	{
 		DoButton_Menu(&s_DummyButton, Localize("Connecting dummy"), 1, &Button);
 	}

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1022,6 +1022,7 @@ static CGameInfo GetGameInfo(const CNetObj_GameInfoEx *pInfoEx, int InfoExSize, 
 	Info.m_DontMaskEntities = !DDNet;
 	Info.m_AllowXSkins = false;
 	Info.m_EntitiesFDDrace = FDDrace;
+	Info.m_AllowDummy = true;
 
 	if(Version >= 0)
 	{
@@ -1066,6 +1067,10 @@ static CGameInfo GetGameInfo(const CNetObj_GameInfoEx *pInfoEx, int InfoExSize, 
 	if(Version >= 6)
 	{
 		Info.m_EntitiesFDDrace = Flags2 & GAMEINFOFLAG2_ENTITIES_FDDRACE;
+	}
+	if(Version >= 7)
+	{
+		Info.m_AllowDummy = Flags2 & GAMEINFOFLAG2_ALLOW_DUMMY;
 	}
 	return Info;
 }

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -67,6 +67,7 @@ public:
 	bool m_AllowEyeWheel;
 	bool m_AllowHookColl;
 	bool m_AllowZoom;
+	bool m_AllowDummy;
 
 	bool m_BugDDRaceGhost;
 	bool m_BugDDRaceInput;
@@ -502,6 +503,7 @@ public:
 	int IntersectCharacter(vec2 Pos0, vec2 Pos1, vec2 &NewPos, int ownID);
 
 	virtual int GetLastRaceTick();
+	virtual CGameInfo *GameInfo() { return &m_GameInfo; }
 
 	bool IsTeamPlay() { return m_Snap.m_pGameInfoObj && m_Snap.m_pGameInfoObj->m_GameFlags & GAMEFLAG_TEAMS; }
 

--- a/src/game/server/gamecontroller.cpp
+++ b/src/game/server/gamecontroller.cpp
@@ -600,7 +600,7 @@ void IGameController::Snap(int SnappingClient)
 		GAMEINFOFLAG_ENTITIES_DDRACE |
 		GAMEINFOFLAG_ENTITIES_RACE |
 		GAMEINFOFLAG_RACE;
-	pGameInfoEx->m_Flags2 = 0;
+	pGameInfoEx->m_Flags2 = GAMEINFOFLAG2_ALLOW_DUMMY;
 	pGameInfoEx->m_Version = GAMEINFO_CURVERSION;
 
 	if(Server()->IsSixup(SnappingClient))


### PR DESCRIPTION
#4305

Since the ddnet client dummy has an aimbot and other advantages some server owners maybe also in pvp might not want that.

![screenshot_2021-11-06_17-01-48](https://user-images.githubusercontent.com/20344300/140615972-e2099c80-1068-48ee-83f1-ccc70d38ddd3.png)

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
