### PR TITLE
Use delete[] for m_pSwitchers

### DIFF
--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1409,7 +1409,7 @@ void CGameClient::OnNewSnapshot()
 				int NumSwitchers = clamp(pSwitchStateData->m_NumSwitchers, 0, 255);
 				if(!Collision()->m_pSwitchers || NumSwitchers != Collision()->m_NumSwitchers)
 				{
-					delete Collision()->m_pSwitchers;
+					delete[] Collision()->m_pSwitchers;
 					Collision()->m_pSwitchers = new CCollision::SSwitchers[NumSwitchers + 1];
 					Collision()->m_NumSwitchers = NumSwitchers;
 				}


### PR DESCRIPTION
described in #4317 but unrelated to the issue i think

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
