### PR TITLE
Improve performance of `SnapFindItem` for extended item types

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -981,21 +981,10 @@ void CClient::SnapInvalidateItem(int SnapID, int Index)
 
 void *CClient::SnapFindItem(int SnapID, int Type, int ID) const
 {
-	// TODO: linear search. should be fixed.
-	int i;
-
 	if(!m_aSnapshots[g_Config.m_ClDummy][SnapID])
 		return 0x0;
 
-	for(i = 0; i < m_aSnapshots[g_Config.m_ClDummy][SnapID]->m_pSnap->NumItems(); i++)
-	{
-		CSnapshotItem *pItem = m_aSnapshots[g_Config.m_ClDummy][SnapID]->m_pAltSnap->GetItem(i);
-		if(Type >= OFFSET_UUID && pItem->Type() >= CSnapshot::OFFSET_UUID_TYPE && m_aSnapshots[g_Config.m_ClDummy][SnapID]->m_pAltSnap->GetItemType(i) == Type && pItem->ID() == ID)
-			return (void *)pItem->Data();
-		else if(Type < OFFSET_UUID && pItem->Type() < CSnapshot::OFFSET_UUID_TYPE && pItem->Type() == Type && pItem->ID() == ID)
-			return (void *)pItem->Data();
-	}
-	return 0x0;
+	return m_aSnapshots[g_Config.m_ClDummy][SnapID]->m_pAltSnap->FindItem(Type, ID);
 }
 
 int CClient::SnapNumItems(int SnapID) const

--- a/src/engine/shared/snapshot.h
+++ b/src/engine/shared/snapshot.h
@@ -46,6 +46,7 @@ public:
 	int GetItemSize(int Index) const;
 	int GetItemIndex(int Key) const;
 	int GetItemType(int Index) const;
+	void *FindItem(int Type, int ID) const;
 
 	unsigned Crc();
 	void DebugDump();


### PR DESCRIPTION
Look up the internal type of the searched-for UUID type once, and then
just do integer comparisons to find the item.

CC #4300

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
