### PR TITLE
Use valid sort comparator

### DIFF
--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -3085,37 +3085,43 @@ void CGameClient::SnapCollectEntities()
 	int NumSnapItems = Client()->SnapNumItems(IClient::SNAP_CURRENT);
 
 	std::vector<CSnapEntities> aItemData;
+	std::vector<CSnapEntities> aItemEx;
+
 	for(int Index = 0; Index < NumSnapItems; Index++)
 	{
 		IClient::CSnapItem Item;
 		const void *pData = Client()->SnapGetItem(IClient::SNAP_CURRENT, Index, &Item);
-		if(Item.m_Type == NETOBJTYPE_ENTITYEX || Item.m_Type == NETOBJTYPE_PROJECTILE || Item.m_Type == NETOBJTYPE_PICKUP || Item.m_Type == NETOBJTYPE_LASER || Item.m_Type == NETOBJTYPE_DDNETPROJECTILE)
+		if(Item.m_Type == NETOBJTYPE_ENTITYEX)
+			aItemEx.push_back({Item, pData, 0});
+		else if(Item.m_Type == NETOBJTYPE_PICKUP || Item.m_Type == NETOBJTYPE_LASER || Item.m_Type == NETOBJTYPE_PROJECTILE || Item.m_Type == NETOBJTYPE_DDNETPROJECTILE)
 			aItemData.push_back({Item, pData, 0});
 	}
 
-	// sort by id, with non-extended items before extended items of the same id
-	std::sort(aItemData.begin(), aItemData.end(), [](const CSnapEntities &lhs, const CSnapEntities &rhs) {
-		if(lhs.m_Item.m_ID == rhs.m_Item.m_ID)
-			return lhs.m_Item.m_Type != NETOBJTYPE_ENTITYEX;
-		return lhs.m_Item.m_ID < rhs.m_Item.m_ID;
-	});
+	// sort by id
+	class CEntComparer
+	{
+	public:
+		bool operator()(const CSnapEntities &lhs, const CSnapEntities &rhs) const
+		{
+			return lhs.m_Item.m_ID < rhs.m_Item.m_ID;
+		}
+	};
+
+	std::sort(aItemData.begin(), aItemData.end(), CEntComparer());
+	std::sort(aItemEx.begin(), aItemEx.end(), CEntComparer());
 
 	// merge extended items with items they belong to
 	m_aSnapEntities.clear();
-	for(size_t Index = 0; Index < aItemData.size(); Index++)
+
+	size_t IndexEx = 0;
+	for(const CSnapEntities &Ent : aItemData)
 	{
-		if(aItemData[Index].m_Item.m_Type == NETOBJTYPE_ENTITYEX)
-			continue;
-
-		const IClient::CSnapItem Item = aItemData[Index].m_Item;
-		const void *pData = (const void *)aItemData[Index].m_pData;
 		const CNetObj_EntityEx *pDataEx = 0;
+		while(IndexEx < aItemEx.size() && aItemEx[IndexEx].m_Item.m_ID < Ent.m_Item.m_ID)
+			IndexEx++;
+		if(IndexEx < aItemEx.size() && aItemEx[IndexEx].m_Item.m_ID == Ent.m_Item.m_ID)
+			pDataEx = (const CNetObj_EntityEx *)aItemEx[IndexEx].m_pData;
 
-		if(Index + 1 < aItemData.size() && aItemData[Index + 1].m_Item.m_ID == Item.m_ID && aItemData[Index + 1].m_Item.m_Type == NETOBJTYPE_ENTITYEX)
-		{
-			pDataEx = (const CNetObj_EntityEx *)aItemData[Index + 1].m_pData;
-			Index++;
-		}
-		m_aSnapEntities.push_back({Item, pData, pDataEx});
+		m_aSnapEntities.push_back({Ent.m_Item, Ent.m_pData, pDataEx});
 	}
 }


### PR DESCRIPTION
Changed the sort calls to use a single comparison instead, which ended up looking at bit cleaner. (I believe the previous version didn't satisfy strict weak ordering)

I'm not able to reproduce #4317, but this hopefully fixes it. @Jupeyy can you test this?

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
