### PR TITLE
Add sql GetID()

### DIFF
--- a/src/engine/server/databases/connection.h
+++ b/src/engine/server/databases/connection.h
@@ -69,6 +69,15 @@ public:
 	// returns true on failure
 	virtual bool ExecuteUpdate(int *pNumUpdated, char *pError, int ErrorSize) = 0;
 
+	virtual int GetColumnCount() = 0;
+	virtual int GetID(const char *pCol) = 0;
+
+	virtual bool IsNull(const char *pCol) { return IsNull(GetID(pCol)); };
+	virtual float GetFloat(const char *pCol) { return GetFloat(GetID(pCol)); };
+	virtual int GetInt(const char *pCol) { return GetInt(GetID(pCol)); };
+	virtual void GetString(const char *pCol, char *pBuffer, int BufferSize) { GetString(GetID(pCol), pBuffer, BufferSize); };
+	virtual void GetBlob(const char *pCol, unsigned char *pBuffer, int BufferSize) { GetBlob(GetID(pCol), pBuffer, BufferSize); };
+
 	virtual bool IsNull(int Col) = 0;
 	virtual float GetFloat(int Col) = 0;
 	virtual int GetInt(int Col) = 0;

--- a/src/engine/server/databases/sqlite.cpp
+++ b/src/engine/server/databases/sqlite.cpp
@@ -38,6 +38,9 @@ public:
 	virtual bool Step(bool *pEnd, char *pError, int ErrorSize);
 	virtual bool ExecuteUpdate(int *pNumUpdated, char *pError, int ErrorSize);
 
+	virtual int GetColumnCount();
+	virtual int GetID(const char *pCol);
+
 	virtual bool IsNull(int Col);
 	virtual float GetFloat(int Col);
 	virtual int GetInt(int Col);
@@ -259,9 +262,24 @@ bool CSqliteConnection::ExecuteUpdate(int *pNumUpdated, char *pError, int ErrorS
 	return false;
 }
 
+int CSqliteConnection::GetColumnCount()
+{
+	return sqlite3_column_count(m_pStmt);
+}
+
 bool CSqliteConnection::IsNull(int Col)
 {
 	return sqlite3_column_type(m_pStmt, Col - 1) == SQLITE_NULL;
+}
+
+int CSqliteConnection::GetID(const char *pCol)
+{
+	for(int i = 0; i < GetColumnCount(); i++)
+	{
+		if(str_comp(sqlite3_column_name(m_pStmt, i), pCol) == 0)
+			return i + 1;
+	}
+	return -1;
 }
 
 float CSqliteConnection::GetFloat(int Col)

--- a/src/game/server/score.cpp
+++ b/src/game/server/score.cpp
@@ -267,7 +267,7 @@ bool CScore::LoadPlayerDataThread(IDbConnection *pSqlServer, const ISqlData *pGa
 	if(!End)
 	{
 		// get the best time
-		float Time = pSqlServer->GetFloat(1);
+		float Time = pSqlServer->GetFloat("Time");
 		pResult->m_Data.m_Info.m_Time = Time;
 		pResult->m_Data.m_Info.m_Score = -Time;
 		pResult->m_Data.m_Info.m_HasFinishScore = true;


### PR DESCRIPTION
Allows to use strings instead of index for sql results.

Tested with mysql and sqlite3

float Time = pSqlServer->GetFloat(1);
float Time = pSqlServer->GetFloat("Time");

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
