### PR TITLE
Add functions for packing/unpacking int/unsigned using char arrays

### DIFF
--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -3547,6 +3547,32 @@ const char *str_next_token(const char *str, const char *delim, char *buffer, int
 	return tok + len;
 }
 
+int bytes_be_to_int(const unsigned char *bytes)
+{
+	return ((bytes[0] & 0xff) << 24) | ((bytes[1] & 0xff) << 16) | ((bytes[2] & 0xff) << 8) | (bytes[3] & 0xff);
+}
+
+void int_to_bytes_be(unsigned char *bytes, int value)
+{
+	bytes[0] = (value >> 24) & 0xff;
+	bytes[1] = (value >> 16) & 0xff;
+	bytes[2] = (value >> 8) & 0xff;
+	bytes[3] = value & 0xff;
+}
+
+unsigned bytes_be_to_uint(const unsigned char *bytes)
+{
+	return ((bytes[0] & 0xffu) << 24u) | ((bytes[1] & 0xffu) << 16u) | ((bytes[2] & 0xffu) << 8u) | (bytes[3] & 0xffu);
+}
+
+void uint_to_bytes_be(unsigned char *bytes, unsigned value)
+{
+	bytes[0] = (value >> 24u) & 0xffu;
+	bytes[1] = (value >> 16u) & 0xffu;
+	bytes[2] = (value >> 8u) & 0xffu;
+	bytes[3] = value & 0xffu;
+}
+
 int pid()
 {
 #if defined(CONF_FAMILY_WINDOWS)

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -2126,6 +2126,52 @@ const char *str_next_token(const char *str, const char *delim, char *buffer, int
 int str_in_list(const char *list, const char *delim, const char *needle);
 
 /*
+	Function: bytes_be_to_int
+		Packs 4 big endian bytes into an int
+
+	Returns:
+		The packed int
+
+	Remarks:
+		- Assumes the passed array is 4 bytes
+		- Assumes int is 4 bytes
+*/
+int bytes_be_to_int(const unsigned char *bytes);
+
+/*
+	Function: int_to_bytes_be
+		Packs an int into 4 big endian bytes
+
+	Remarks:
+		- Assumes the passed array is 4 bytes
+		- Assumes int is 4 bytes
+*/
+void int_to_bytes_be(unsigned char *bytes, int value);
+
+/*
+	Function: bytes_be_to_uint
+		Packs 4 big endian bytes into an unsigned
+
+	Returns:
+		The packed unsigned
+
+	Remarks:
+		- Assumes the passed array is 4 bytes
+		- Assumes unsigned is 4 bytes
+*/
+unsigned bytes_be_to_uint(const unsigned char *bytes);
+
+/*
+	Function: uint_to_bytes_be
+		Packs an unsigned into 4 big endian bytes
+
+	Remarks:
+		- Assumes the passed array is 4 bytes
+		- Assumes unsigned is 4 bytes
+*/
+void uint_to_bytes_be(unsigned char *bytes, unsigned value);
+
+/*
 	Function: pid
 		Returns the pid of the current process.
 	

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -3767,7 +3767,6 @@ void CClient::DemoSlice(const char *pDstPath, CLIENTFUNC_FILTER pfnFilter, void 
 
 const char *CClient::DemoPlayer_Play(const char *pFilename, int StorageType)
 {
-	int Crc;
 	const char *pError;
 
 	IOHANDLE File = Storage()->OpenFile(pFilename, IOFLAG_READ, StorageType);
@@ -3786,7 +3785,7 @@ const char *CClient::DemoPlayer_Play(const char *pFilename, int StorageType)
 		return "error loading demo";
 
 	// load map
-	Crc = m_DemoPlayer.GetMapInfo()->m_Crc;
+	int Crc = m_DemoPlayer.GetMapInfo()->m_Crc;
 	SHA256_DIGEST Sha = m_DemoPlayer.GetMapInfo()->m_Sha256;
 	pError = LoadMapSearch(m_DemoPlayer.Info()->m_Header.m_aMapName, Sha != SHA256_ZEROED ? &Sha : nullptr, Crc);
 	if(pError)

--- a/src/engine/client/ghost.cpp
+++ b/src/engine/client/ghost.cpp
@@ -141,23 +141,16 @@ int CGhostRecorder::Stop(int Ticks, int Time)
 
 	FlushChunk();
 
-	unsigned char aNumTicks[4];
-	unsigned char aTime[4];
-
-	aNumTicks[0] = (Ticks >> 24) & 0xff;
-	aNumTicks[1] = (Ticks >> 16) & 0xff;
-	aNumTicks[2] = (Ticks >> 8) & 0xff;
-	aNumTicks[3] = (Ticks)&0xff;
-
-	aTime[0] = (Time >> 24) & 0xff;
-	aTime[1] = (Time >> 16) & 0xff;
-	aTime[2] = (Time >> 8) & 0xff;
-	aTime[3] = (Time)&0xff;
-
 	// write down num shots and time
 	io_seek(m_File, gs_NumTicksOffset, IOSEEK_START);
-	io_write(m_File, &aNumTicks, sizeof(aNumTicks));
-	io_write(m_File, &aTime, sizeof(aTime));
+
+	unsigned char aNumTicks[4];
+	int_to_bytes_be(aNumTicks, Ticks);
+	io_write(m_File, aNumTicks, sizeof(aNumTicks));
+
+	unsigned char aTime[4];
+	int_to_bytes_be(aTime, Time);
+	io_write(m_File, aTime, sizeof(aTime));
 
 	io_close(m_File);
 	m_File = 0;
@@ -246,7 +239,7 @@ int CGhostLoader::Load(const char *pFilename, const char *pMap, SHA256_DIGEST Ma
 	else
 	{
 		io_skip(m_File, -(int)sizeof(SHA256_DIGEST));
-		unsigned GhostMapCrc = (m_Header.m_aZeroes[0] << 24) | (m_Header.m_aZeroes[1] << 16) | (m_Header.m_aZeroes[2] << 8) | (m_Header.m_aZeroes[3]);
+		unsigned GhostMapCrc = bytes_be_to_uint(m_Header.m_aZeroes);
 		if(str_comp(m_Header.m_aMap, pMap) != 0 || GhostMapCrc != MapCrc)
 		{
 			char aBuf[256];
@@ -396,7 +389,7 @@ bool CGhostLoader::GetGhostInfo(const char *pFilename, CGhostInfo *pInfo, const 
 	}
 	else
 	{
-		unsigned GhostMapCrc = (Header.m_aZeroes[0] << 24) | (Header.m_aZeroes[1] << 16) | (Header.m_aZeroes[2] << 8) | (Header.m_aZeroes[3]);
+		unsigned GhostMapCrc = bytes_be_to_uint(Header.m_aZeroes);
 		if(GhostMapCrc != MapCrc)
 		{
 			return false;

--- a/src/engine/client/ghost.h
+++ b/src/engine/client/ghost.h
@@ -23,12 +23,12 @@ struct CGhostHeader
 
 	int GetTicks() const
 	{
-		return (m_aNumTicks[0] << 24) | (m_aNumTicks[1] << 16) | (m_aNumTicks[2] << 8) | (m_aNumTicks[3]);
+		return bytes_be_to_int(m_aNumTicks);
 	}
 
 	int GetTime() const
 	{
-		return (m_aTime[0] << 24) | (m_aTime[1] << 16) | (m_aTime[2] << 8) | (m_aTime[3]);
+		return bytes_be_to_int(m_aTime);
 	}
 
 	CGhostInfo ToGhostInfo() const

--- a/src/engine/demo.h
+++ b/src/engine/demo.h
@@ -33,14 +33,14 @@ struct CDemoHeader
 	unsigned char m_aMapSize[4];
 	unsigned char m_aMapCrc[4];
 	char m_aType[8];
-	char m_aLength[4];
+	unsigned char m_aLength[4];
 	char m_aTimestamp[20];
 };
 
 struct CTimelineMarkers
 {
-	char m_aNumTimelineMarkers[4];
-	char m_aTimelineMarkers[MAX_TIMELINE_MARKERS][4];
+	unsigned char m_aNumTimelineMarkers[4];
+	unsigned char m_aTimelineMarkers[MAX_TIMELINE_MARKERS][4];
 };
 
 struct CMapInfo

--- a/src/engine/shared/datafile.cpp
+++ b/src/engine/shared/datafile.cpp
@@ -25,13 +25,7 @@ struct CItemEx
 	{
 		CItemEx Result;
 		for(int i = 0; i < (int)sizeof(CUuid) / 4; i++)
-		{
-			Result.m_aUuid[i] =
-				(Uuid.m_aData[i * 4 + 0] << 24) |
-				(Uuid.m_aData[i * 4 + 1] << 16) |
-				(Uuid.m_aData[i * 4 + 2] << 8) |
-				(Uuid.m_aData[i * 4 + 3]);
-		}
+			Result.m_aUuid[i] = bytes_be_to_int(&Uuid.m_aData[i * 4]);
 		return Result;
 	}
 
@@ -39,12 +33,7 @@ struct CItemEx
 	{
 		CUuid Result;
 		for(int i = 0; i < (int)sizeof(CUuid) / 4; i++)
-		{
-			Result.m_aData[i * 4 + 0] = m_aUuid[i] >> 24;
-			Result.m_aData[i * 4 + 1] = m_aUuid[i] >> 16;
-			Result.m_aData[i * 4 + 2] = m_aUuid[i] >> 8;
-			Result.m_aData[i * 4 + 3] = m_aUuid[i];
-		}
+			int_to_bytes_be(&Result.m_aData[i * 4], m_aUuid[i]);
 		return Result;
 	}
 };

--- a/src/engine/shared/demo.cpp
+++ b/src/engine/shared/demo.cpp
@@ -42,7 +42,7 @@ CDemoRecorder::CDemoRecorder(class CSnapshotDelta *pSnapshotDelta, bool NoMapDat
 }
 
 // Record
-int CDemoRecorder::Start(class IStorage *pStorage, class IConsole *pConsole, const char *pFilename, const char *pNetVersion, const char *pMap, SHA256_DIGEST *pSha256, unsigned Crc, const char *pType, unsigned int MapSize, unsigned char *pMapData, IOHANDLE MapFile, DEMOFUNC_FILTER pfnFilter, void *pUser)
+int CDemoRecorder::Start(class IStorage *pStorage, class IConsole *pConsole, const char *pFilename, const char *pNetVersion, const char *pMap, SHA256_DIGEST *pSha256, unsigned Crc, const char *pType, unsigned MapSize, unsigned char *pMapData, IOHANDLE MapFile, DEMOFUNC_FILTER pfnFilter, void *pUser)
 {
 	m_pfnFilter = pfnFilter;
 	m_pUser = pUser;
@@ -130,14 +130,8 @@ int CDemoRecorder::Start(class IStorage *pStorage, class IConsole *pConsole, con
 	Header.m_Version = s_CurVersion;
 	str_copy(Header.m_aNetversion, pNetVersion, sizeof(Header.m_aNetversion));
 	str_copy(Header.m_aMapName, pMap, sizeof(Header.m_aMapName));
-	Header.m_aMapSize[0] = (MapSize >> 24) & 0xff;
-	Header.m_aMapSize[1] = (MapSize >> 16) & 0xff;
-	Header.m_aMapSize[2] = (MapSize >> 8) & 0xff;
-	Header.m_aMapSize[3] = (MapSize)&0xff;
-	Header.m_aMapCrc[0] = (Crc >> 24) & 0xff;
-	Header.m_aMapCrc[1] = (Crc >> 16) & 0xff;
-	Header.m_aMapCrc[2] = (Crc >> 8) & 0xff;
-	Header.m_aMapCrc[3] = (Crc)&0xff;
+	uint_to_bytes_be(Header.m_aMapSize, MapSize);
+	uint_to_bytes_be(Header.m_aMapCrc, Crc);
 	str_copy(Header.m_aType, pType, sizeof(Header.m_aType));
 	// Header.m_Length - add this on stop
 	str_timestamp(Header.m_aTimestamp, sizeof(Header.m_aTimestamp));
@@ -225,10 +219,7 @@ void CDemoRecorder::WriteTickMarker(int Tick, int Keyframe)
 	{
 		unsigned char aChunk[5];
 		aChunk[0] = CHUNKTYPEFLAG_TICKMARKER;
-		aChunk[1] = (Tick >> 24) & 0xff;
-		aChunk[2] = (Tick >> 16) & 0xff;
-		aChunk[3] = (Tick >> 8) & 0xff;
-		aChunk[4] = (Tick)&0xff;
+		uint_to_bytes_be(aChunk + 1, Tick);
 
 		if(Keyframe)
 			aChunk[0] |= CHUNKTICKFLAG_KEYFRAME;
@@ -349,30 +340,19 @@ int CDemoRecorder::Stop()
 
 	// add the demo length to the header
 	io_seek(m_File, s_LengthOffset, IOSEEK_START);
-	int DemoLength = Length();
-	char aLength[4];
-	aLength[0] = (DemoLength >> 24) & 0xff;
-	aLength[1] = (DemoLength >> 16) & 0xff;
-	aLength[2] = (DemoLength >> 8) & 0xff;
-	aLength[3] = (DemoLength)&0xff;
+	unsigned char aLength[4];
+	int_to_bytes_be(aLength, Length());
 	io_write(m_File, aLength, sizeof(aLength));
 
 	// add the timeline markers to the header
 	io_seek(m_File, s_NumMarkersOffset, IOSEEK_START);
-	char aNumMarkers[4];
-	aNumMarkers[0] = (m_NumTimelineMarkers >> 24) & 0xff;
-	aNumMarkers[1] = (m_NumTimelineMarkers >> 16) & 0xff;
-	aNumMarkers[2] = (m_NumTimelineMarkers >> 8) & 0xff;
-	aNumMarkers[3] = (m_NumTimelineMarkers)&0xff;
+	unsigned char aNumMarkers[4];
+	int_to_bytes_be(aNumMarkers, m_NumTimelineMarkers);
 	io_write(m_File, aNumMarkers, sizeof(aNumMarkers));
 	for(int i = 0; i < m_NumTimelineMarkers; i++)
 	{
-		int Marker = m_aTimelineMarkers[i];
-		char aMarker[4];
-		aMarker[0] = (Marker >> 24) & 0xff;
-		aMarker[1] = (Marker >> 16) & 0xff;
-		aMarker[2] = (Marker >> 8) & 0xff;
-		aMarker[3] = (Marker)&0xff;
+		unsigned char aMarker[4];
+		int_to_bytes_be(aMarker, m_aTimelineMarkers[i]);
 		io_write(m_File, aMarker, sizeof(aMarker));
 	}
 
@@ -466,7 +446,7 @@ int CDemoPlayer::ReadChunkHeader(int *pType, int *pSize, int *pTick)
 			unsigned char aTickdata[4];
 			if(io_read(m_File, aTickdata, sizeof(aTickdata)) != sizeof(aTickdata))
 				return -1;
-			*pTick = (aTickdata[0] << 24) | (aTickdata[1] << 16) | (aTickdata[2] << 8) | aTickdata[3];
+			*pTick = bytes_be_to_int(aTickdata);
 		}
 	}
 	else
@@ -800,11 +780,11 @@ int CDemoPlayer::Load(class IStorage *pStorage, class IConsole *pConsole, const 
 		m_DemoType = DEMOTYPE_INVALID;
 
 	// read map
-	unsigned MapSize = (m_Info.m_Header.m_aMapSize[0] << 24) | (m_Info.m_Header.m_aMapSize[1] << 16) | (m_Info.m_Header.m_aMapSize[2] << 8) | (m_Info.m_Header.m_aMapSize[3]);
+	unsigned MapSize = bytes_be_to_uint(m_Info.m_Header.m_aMapSize);
 
 	// check if we already have the map
 	// TODO: improve map checking (maps folder, check crc)
-	unsigned Crc = (m_Info.m_Header.m_aMapCrc[0] << 24) | (m_Info.m_Header.m_aMapCrc[1] << 16) | (m_Info.m_Header.m_aMapCrc[2] << 8) | (m_Info.m_Header.m_aMapCrc[3]);
+	unsigned Crc = bytes_be_to_uint(m_Info.m_Header.m_aMapCrc);
 
 	// save byte offset of map for later use
 	m_MapOffset = io_tell(m_File);
@@ -819,14 +799,11 @@ int CDemoPlayer::Load(class IStorage *pStorage, class IConsole *pConsole, const 
 	if(m_Info.m_Header.m_Version > s_OldVersion)
 	{
 		// get timeline markers
-		int Num = ((m_Info.m_TimelineMarkers.m_aNumTimelineMarkers[0] << 24) & 0xFF000000) | ((m_Info.m_TimelineMarkers.m_aNumTimelineMarkers[1] << 16) & 0xFF0000) |
-			  ((m_Info.m_TimelineMarkers.m_aNumTimelineMarkers[2] << 8) & 0xFF00) | (m_Info.m_TimelineMarkers.m_aNumTimelineMarkers[3] & 0xFF);
+		int Num = bytes_be_to_int(m_Info.m_TimelineMarkers.m_aNumTimelineMarkers);
 		m_Info.m_Info.m_NumTimelineMarkers = minimum(Num, (int)MAX_TIMELINE_MARKERS);
 		for(int i = 0; i < m_Info.m_Info.m_NumTimelineMarkers; i++)
 		{
-			char *pTimelineMarker = m_Info.m_TimelineMarkers.m_aTimelineMarkers[i];
-			m_Info.m_Info.m_aTimelineMarkers[i] = ((pTimelineMarker[0] << 24) & 0xFF000000) | ((pTimelineMarker[1] << 16) & 0xFF0000) |
-							      ((pTimelineMarker[2] << 8) & 0xFF00) | (pTimelineMarker[3] & 0xFF);
+			m_Info.m_Info.m_aTimelineMarkers[i] = bytes_be_to_int(m_Info.m_TimelineMarkers.m_aTimelineMarkers[i]);
 		}
 	}
 
@@ -1101,7 +1078,7 @@ bool CDemoPlayer::GetDemoInfo(class IStorage *pStorage, const char *pFilename, i
 	io_read(File, pTimelineMarkers, sizeof(CTimelineMarkers));
 
 	str_copy(pMapInfo->m_aName, pDemoHeader->m_aMapName, sizeof(pMapInfo->m_aName));
-	pMapInfo->m_Crc = (pDemoHeader->m_aMapCrc[0] << 24) | (pDemoHeader->m_aMapCrc[1] << 16) | (pDemoHeader->m_aMapCrc[2] << 8) | (pDemoHeader->m_aMapCrc[3]);
+	pMapInfo->m_Crc = bytes_be_to_int(pDemoHeader->m_aMapCrc);
 
 	SHA256_DIGEST Sha256 = SHA256_ZEROED;
 	if(pDemoHeader->m_Version >= s_Sha256Version)
@@ -1122,7 +1099,7 @@ bool CDemoPlayer::GetDemoInfo(class IStorage *pStorage, const char *pFilename, i
 	}
 	pMapInfo->m_Sha256 = Sha256;
 
-	pMapInfo->m_Size = (pDemoHeader->m_aMapSize[0] << 24) | (pDemoHeader->m_aMapSize[1] << 16) | (pDemoHeader->m_aMapSize[2] << 8) | (pDemoHeader->m_aMapSize[3]);
+	pMapInfo->m_Size = bytes_be_to_int(pDemoHeader->m_aMapSize);
 
 	io_close(File);
 	return !(mem_comp(pDemoHeader->m_aMarker, s_aHeaderMarker, sizeof(s_aHeaderMarker)) || pDemoHeader->m_Version < s_OldVersion);

--- a/src/engine/shared/demo.h
+++ b/src/engine/shared/demo.h
@@ -38,7 +38,7 @@ public:
 	CDemoRecorder(class CSnapshotDelta *pSnapshotDelta, bool NoMapData = false);
 	CDemoRecorder() {}
 
-	int Start(class IStorage *pStorage, class IConsole *pConsole, const char *pFilename, const char *pNetversion, const char *pMap, SHA256_DIGEST *pSha256, unsigned MapCrc, const char *pType, unsigned int MapSize, unsigned char *pMapData, IOHANDLE MapFile = 0, DEMOFUNC_FILTER pfnFilter = 0, void *pUser = 0);
+	int Start(class IStorage *pStorage, class IConsole *pConsole, const char *pFilename, const char *pNetversion, const char *pMap, SHA256_DIGEST *pSha256, unsigned MapCrc, const char *pType, unsigned MapSize, unsigned char *pMapData, IOHANDLE MapFile = 0, DEMOFUNC_FILTER pfnFilter = 0, void *pUser = 0);
 	int Stop();
 	void AddDemoMarker();
 

--- a/src/engine/shared/snapshot.cpp
+++ b/src/engine/shared/snapshot.cpp
@@ -38,12 +38,7 @@ int CSnapshot::GetItemType(int Index) const
 	CSnapshotItem *pTypeItem = GetItem(TypeItemIndex);
 	CUuid Uuid;
 	for(int i = 0; i < (int)sizeof(CUuid) / 4; i++)
-	{
-		Uuid.m_aData[i * 4 + 0] = pTypeItem->Data()[i] >> 24;
-		Uuid.m_aData[i * 4 + 1] = pTypeItem->Data()[i] >> 16;
-		Uuid.m_aData[i * 4 + 2] = pTypeItem->Data()[i] >> 8;
-		Uuid.m_aData[i * 4 + 3] = pTypeItem->Data()[i];
-	}
+		int_to_bytes_be(&Uuid.m_aData[i * 4], pTypeItem->Data()[i]);
 
 	return g_UuidManager.LookupUuid(Uuid);
 }
@@ -67,13 +62,8 @@ void *CSnapshot::FindItem(int Type, int ID) const
 		CUuid TypeUuid = g_UuidManager.GetUuid(Type);
 		int aTypeUuidItem[sizeof(CUuid) / 4];
 		for(int i = 0; i < (int)sizeof(CUuid) / 4; i++)
-		{
-			aTypeUuidItem[i] =
-				(TypeUuid.m_aData[i * 4 + 0] << 24) |
-				(TypeUuid.m_aData[i * 4 + 1] << 16) |
-				(TypeUuid.m_aData[i * 4 + 2] << 8) |
-				(TypeUuid.m_aData[i * 4 + 3]);
-		}
+			aTypeUuidItem[i] = bytes_be_to_int(&TypeUuid.m_aData[i * 4]);
+
 		bool Found = false;
 		for(int i = 0; i < m_NumItems; i++)
 		{
@@ -630,13 +620,7 @@ void CSnapshotBuilder::AddExtendedItemType(int Index)
 	if(pUuidItem)
 	{
 		for(int i = 0; i < (int)sizeof(CUuid) / 4; i++)
-		{
-			pUuidItem[i] =
-				(Uuid.m_aData[i * 4 + 0] << 24) |
-				(Uuid.m_aData[i * 4 + 1] << 16) |
-				(Uuid.m_aData[i * 4 + 2] << 8) |
-				(Uuid.m_aData[i * 4 + 3]);
-		}
+			pUuidItem[i] = bytes_be_to_int(&Uuid.m_aData[i * 4]);
 	}
 }
 

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -385,14 +385,17 @@ protected:
 
 		int NumMarkers() const
 		{
-			return ((m_TimelineMarkers.m_aNumTimelineMarkers[0] << 24) & 0xFF000000) | ((m_TimelineMarkers.m_aNumTimelineMarkers[1] << 16) & 0xFF0000) |
-			       ((m_TimelineMarkers.m_aNumTimelineMarkers[2] << 8) & 0xFF00) | (m_TimelineMarkers.m_aNumTimelineMarkers[3] & 0xFF);
+			return bytes_be_to_int(m_TimelineMarkers.m_aNumTimelineMarkers);
 		}
 
 		int Length() const
 		{
-			return ((m_Info.m_aLength[0] << 24) & 0xFF000000) | ((m_Info.m_aLength[1] << 16) & 0xFF0000) |
-			       ((m_Info.m_aLength[2] << 8) & 0xFF00) | (m_Info.m_aLength[3] & 0xFF);
+			return bytes_be_to_int(m_Info.m_aLength);
+		}
+
+		unsigned Size() const
+		{
+			return bytes_be_to_uint(m_Info.m_aMapSize);
 		}
 
 		bool operator<(const CDemoItem &Other) const

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -945,12 +945,11 @@ void CMenus::RenderDemoList(CUIRect MainView)
 		Labels.HSplitTop(20.0f, &Left, &Labels);
 		Left.VSplitLeft(150.0f, &Left, &Right);
 		UI()->DoLabelScaled(&Left, Localize("Size:"), 14.0f, -1);
-		unsigned Size = (m_lDemos[m_DemolistSelectedIndex].m_Info.m_aMapSize[0] << 24) | (m_lDemos[m_DemolistSelectedIndex].m_Info.m_aMapSize[1] << 16) |
-				(m_lDemos[m_DemolistSelectedIndex].m_Info.m_aMapSize[2] << 8) | (m_lDemos[m_DemolistSelectedIndex].m_Info.m_aMapSize[3]);
-		if(Size > 1024 * 1024)
-			str_format(aBuf, sizeof(aBuf), Localize("%.2f MiB"), float(Size) / (1024 * 1024));
+		const float Size = m_lDemos[m_DemolistSelectedIndex].Size() / 1024.0f;
+		if(Size > 1024)
+			str_format(aBuf, sizeof(aBuf), Localize("%.2f MiB"), Size / 1024.0f);
 		else
-			str_format(aBuf, sizeof(aBuf), Localize("%.2f KiB"), float(Size) / 1024);
+			str_format(aBuf, sizeof(aBuf), Localize("%.2f KiB"), Size);
 		UI()->DoLabelScaled(&Right, aBuf, 14.0f, -1);
 		Labels.HSplitTop(5.0f, 0, &Labels);
 		Labels.HSplitTop(20.0f, &Left, &Labels);


### PR DESCRIPTION
Add `uint_to_bytes_be` and `bytes_be_to_uint` functions from upstream and use them where applicable to reduce duplicate code.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
