### PR TITLE
Fix steam names being cut off inside utf8 codepoints

### DIFF
--- a/src/engine/client/steam.cpp
+++ b/src/engine/client/steam.cpp
@@ -22,7 +22,7 @@ public:
 		m_pSteamFriends = SteamAPI_SteamFriends_v017();
 
 		ReadLaunchCommandLine();
-		str_copy(m_aPlayerName, SteamAPI_ISteamFriends_GetPersonaName(m_pSteamFriends), sizeof(m_aPlayerName));
+		str_utf8_copy(m_aPlayerName, SteamAPI_ISteamFriends_GetPersonaName(m_pSteamFriends), sizeof(m_aPlayerName));
 	}
 	~CSteam()
 	{


### PR DESCRIPTION
Untested, but I'm assuming this closes #4345.

The name "ｃａｇｅｎｔ󠀡" is 7 unicode codepoints (including an invisible one at the end) which convert to 22 bytes with UTF-8.
This does not fit the current buffer size of 16, resulting in a unicode codepoint getting cut off, which probably causes arbitrary behavior with text input.

Google search shows the maximum length of a Steam username should be 32 bytes. I set the new buffer size to 48 for null termination and additional leeway.

This also makes sure that the username from Steam API is copied while checking for complete codepoints, in case the maximum length of a Steam username is ever increased in the future.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
