### PR TITLE
Make opening files for reading on windows case insensitive (again)

### DIFF
--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -314,39 +314,13 @@ IOHANDLE io_open(const char *filename, int flags)
 	dbg_assert(flags == IOFLAG_READ || flags == IOFLAG_WRITE || flags == IOFLAG_APPEND, "flags must be read, write or append");
 #if defined(CONF_FAMILY_WINDOWS)
 	WCHAR wBuffer[IO_MAX_PATH_LENGTH];
+	MultiByteToWideChar(CP_UTF8, 0, filename, IO_MAX_PATH_LENGTH, wBuffer, IO_MAX_PATH_LENGTH);
 	if(flags == IOFLAG_READ)
-	{
-		// check for filename case sensitive
-		WIN32_FIND_DATAW finddata;
-		HANDLE handle;
-		char buffer[IO_MAX_PATH_LENGTH];
-
-		int length = str_length(filename);
-		if(!filename || !length || filename[length - 1] == '\\')
-			return 0x0;
-		MultiByteToWideChar(CP_UTF8, 0, filename, IO_MAX_PATH_LENGTH, wBuffer, IO_MAX_PATH_LENGTH);
-		handle = FindFirstFileW(wBuffer, &finddata);
-		if(handle == INVALID_HANDLE_VALUE)
-			return 0x0;
-		WideCharToMultiByte(CP_UTF8, 0, finddata.cFileName, -1, buffer, IO_MAX_PATH_LENGTH, NULL, NULL);
-		if(str_comp(filename + length - str_length(buffer), buffer) != 0)
-		{
-			FindClose(handle);
-			return 0x0;
-		}
-		FindClose(handle);
 		return (IOHANDLE)_wfsopen(wBuffer, L"rb", _SH_DENYNO);
-	}
 	if(flags == IOFLAG_WRITE)
-	{
-		MultiByteToWideChar(CP_UTF8, 0, filename, IO_MAX_PATH_LENGTH, wBuffer, IO_MAX_PATH_LENGTH);
 		return (IOHANDLE)_wfsopen(wBuffer, L"wb", _SH_DENYNO);
-	}
 	if(flags == IOFLAG_APPEND)
-	{
-		MultiByteToWideChar(CP_UTF8, 0, filename, IO_MAX_PATH_LENGTH, wBuffer, IO_MAX_PATH_LENGTH);
 		return (IOHANDLE)_wfsopen(wBuffer, L"ab", _SH_DENYNO);
-	}
 	return 0x0;
 #else
 	if(flags == IOFLAG_READ)


### PR DESCRIPTION
I don't know what the reason for https://github.com/teeworlds/teeworlds/commit/2a570196ef7dd66f475a3379b9cc5b6abf915e09 was, but this reverts it so files are opened case insensitively on Windows again. I assume it was done for consistency so file operations on all operating systems would be case sensitive, but then again I don't understand why it was only being applied when opening files for reading.

While NTFS is actually case sensitive, the normal Windows file API puts a case insensitive abstraction on top.
Previously, if you had multiple files with the same name but different capitalization it would open the file with the correct capitalization, in the unlikely case that you circumwented the file API to create those files. Now it opens the first one it finds non-deterministically, but will also consider a file with different capitalization.

This reverts to the previous behavior, before all the unicode changes, so I suppose it closes #4343.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
