### PR TITLE
Fix serverinfo json parser to work with system libjsonparser (fixes #4202)

### DIFF
--- a/src/engine/external/json-parser/json.h
+++ b/src/engine/external/json-parser/json.h
@@ -226,12 +226,6 @@ typedef struct _json_value
             };
          }
 
-         /* DDNet additions */
-         inline operator int () const
-         {
-            return (json_int_t) *this;
-         }
-
          inline operator bool () const
          {  
             if (type != json_boolean)

--- a/src/engine/shared/serverinfo.cpp
+++ b/src/engine/shared/serverinfo.cpp
@@ -80,8 +80,8 @@ bool CServerInfo2::FromJsonRaw(CServerInfo2 *pOut, const json_value *pJson)
 	{
 		return true;
 	}
-	pOut->m_MaxClients = MaxClients;
-	pOut->m_MaxPlayers = MaxPlayers;
+	pOut->m_MaxClients = json_int_get(&MaxClients);
+	pOut->m_MaxPlayers = json_int_get(&MaxPlayers);
 	pOut->m_Passworded = Passworded;
 	str_copy(pOut->m_aGameType, GameType, sizeof(pOut->m_aGameType));
 	str_copy(pOut->m_aName, Name, sizeof(pOut->m_aName));
@@ -113,8 +113,8 @@ bool CServerInfo2::FromJsonRaw(CServerInfo2 *pOut, const json_value *pJson)
 			CClient *pClient = &pOut->m_aClients[i];
 			str_copy(pClient->m_aName, Name, sizeof(pClient->m_aName));
 			str_copy(pClient->m_aClan, Clan, sizeof(pClient->m_aClan));
-			pClient->m_Country = Country;
-			pClient->m_Score = Score;
+			pClient->m_Country = json_int_get(&Country);
+			pClient->m_Score = json_int_get(&Score);
 			pClient->m_IsPlayer = IsPlayer;
 		}
 


### PR DESCRIPTION
Debian, Ubuntu, Fedora are using libjsonparser without our own changes,
thus we were doing garbage.

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
