### PR TITLE
Add sql BindInt64

### DIFF
--- a/src/engine/server/databases/connection.h
+++ b/src/engine/server/databases/connection.h
@@ -54,6 +54,7 @@ public:
 	virtual void BindString(int Idx, const char *pString) = 0;
 	virtual void BindBlob(int Idx, unsigned char *pBlob, int Size) = 0;
 	virtual void BindInt(int Idx, int Value) = 0;
+	virtual void BindInt64(int Idx, int64_t Value) = 0;
 	virtual void BindFloat(int Idx, float Value) = 0;
 
 	// Print expanded sql statement

--- a/src/engine/server/databases/mysql.cpp
+++ b/src/engine/server/databases/mysql.cpp
@@ -82,6 +82,7 @@ public:
 	virtual void BindString(int Idx, const char *pString);
 	virtual void BindBlob(int Idx, unsigned char *pBlob, int Size);
 	virtual void BindInt(int Idx, int Value);
+	virtual void BindInt64(int Idx, int64_t Value);
 	virtual void BindFloat(int Idx, float Value);
 
 	virtual void Print() {}
@@ -392,6 +393,23 @@ void CMysqlConnection::BindInt(int Idx, int Value)
 	m_aStmtParameterExtras[Idx].i = Value;
 	MYSQL_BIND *pParam = &m_aStmtParameters[Idx];
 	pParam->buffer_type = MYSQL_TYPE_LONG;
+	pParam->buffer = &m_aStmtParameterExtras[Idx].i;
+	pParam->buffer_length = sizeof(m_aStmtParameterExtras[Idx].i);
+	pParam->length = nullptr;
+	pParam->is_null = nullptr;
+	pParam->is_unsigned = false;
+	pParam->error = nullptr;
+}
+
+void CMysqlConnection::BindInt64(int Idx, int64_t Value)
+{
+	m_NewQuery = true;
+	Idx -= 1;
+	dbg_assert(0 <= Idx && Idx < (int)m_aStmtParameters.size(), "index out of bounds");
+
+	m_aStmtParameterExtras[Idx].i = Value;
+	MYSQL_BIND *pParam = &m_aStmtParameters[Idx];
+	pParam->buffer_type = MYSQL_TYPE_LONGLONG;
 	pParam->buffer = &m_aStmtParameterExtras[Idx].i;
 	pParam->buffer_length = sizeof(m_aStmtParameterExtras[Idx].i);
 	pParam->length = nullptr;

--- a/src/engine/server/databases/sqlite.cpp
+++ b/src/engine/server/databases/sqlite.cpp
@@ -32,6 +32,7 @@ public:
 	virtual void BindString(int Idx, const char *pString);
 	virtual void BindBlob(int Idx, unsigned char *pBlob, int Size);
 	virtual void BindInt(int Idx, int Value);
+	virtual void BindInt64(int Idx, int64_t Value);
 	virtual void BindFloat(int Idx, float Value);
 
 	virtual void Print();
@@ -193,6 +194,13 @@ void CSqliteConnection::BindBlob(int Idx, unsigned char *pBlob, int Size)
 void CSqliteConnection::BindInt(int Idx, int Value)
 {
 	int Result = sqlite3_bind_int(m_pStmt, Idx, Value);
+	AssertNoError(Result);
+	m_Done = false;
+}
+
+void CSqliteConnection::BindInt64(int Idx, int64_t Value)
+{
+	int Result = sqlite3_bind_int64(m_pStmt, Idx, Value);
 	AssertNoError(Result);
 	m_Done = false;
 }


### PR DESCRIPTION
Comes in handy for my downstream

Follow up to https://github.com/ddnet/ddnet/pull/4334

Tested with sqlite3

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
