### PR TITLE
Add UNICODE defines on windows, misc. unicode fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2769,6 +2769,10 @@ foreach(target ${TARGETS_OWN})
     target_compile_options(${target} PRIVATE /wd4267) # Possible loss of data (size_t - int on win64).
     target_compile_options(${target} PRIVATE /wd4800) # Implicit conversion of int to bool.
   endif()
+  if(TARGET_OS STREQUAL "windows")
+    target_compile_definitions(${target} PRIVATE UNICODE) # Windows headers
+    target_compile_definitions(${target} PRIVATE _UNICODE) # C-runtime
+  endif()
   if(OUR_FLAGS_OWN)
     target_compile_options(${target} PRIVATE ${OUR_FLAGS_OWN})
   endif()


### PR DESCRIPTION
Add `UNICODE` and `_UNICODE` defines on Windows and use either the A or the W variant of the Windows API methods explicitly where it was left unspecified.

I supposed this fixes `shell_execute` for unicode paths (e.g. username with unicode) and fixes debug logger output with unicode.

I renamed `logger_debugger` to `logger_win_debugger` to make it clear that it's only available on windows. 

I'm using the A-variant for `WSAStringToAddress` and `FormatMessage` because they don't really need to handle unicode, but there is probably a region specific winsock error message containing unicode.

Does not fix unicode commandline arguments.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
