### PR TITLE
Fix command line arguments with unicode on windows

### DIFF
--- a/src/base/system.h
+++ b/src/base/system.h
@@ -2174,6 +2174,43 @@ void uint_to_bytes_be(unsigned char *bytes, unsigned value);
 */
 int pid();
 
+/*
+	Function: cmdline_init
+		Initializes the command-line arguments so they are
+		available with cmdline_arg_num and cmdline_arg_get.
+
+	Parameters:
+		argc - The argc parameter that was passed to the main function.
+		argv - The argv parameter that was passed to the main function.
+*/
+void cmdline_init(int argc, char **argv);
+
+/*
+	Function: cmdline_arg_num
+		Gets the total number of command-line arguments.
+
+	Returns:
+		The number of command-line arguments. Always at least 1.
+*/
+int cmdline_arg_num();
+
+/*
+	Function: cmdline_arg_get
+		Gets a command-line argument as a utf8 string.
+
+	Parameters:
+		index - The index of the argument to retrieve.
+		argument - Pointer to a buffer that shall receive the string.
+		length - The size of the buffer.
+*/
+void cmdline_arg_get(int index, char *argument, int length);
+
+/*
+	Function: cmdline_free
+		Frees memory that was allocated by cmdline_init.
+*/
+void cmdline_free();
+
 #if defined(CONF_FAMILY_WINDOWS)
 typedef void *PROCESS;
 #else

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -4297,26 +4297,28 @@ void CClient::HandleMapPath(const char *pPath)
 */
 
 #if defined(CONF_PLATFORM_MACOS)
-extern "C" int TWMain(int argc, const char **argv) // ignore_convention
+extern "C" int TWMain(int argc, char **argv)
 #elif defined(CONF_PLATFORM_ANDROID)
 extern "C" __attribute__((visibility("default"))) int SDL_main(int argc, char *argv[]);
 extern "C" void InitAndroid();
 
 int SDL_main(int argc, char *argv[])
 #else
-int main(int argc, const char **argv) // ignore_convention
+int main(int argc, char **argv)
 #endif
 {
-	bool Silent = false;
-	bool RandInitFailed = false;
+	cmdline_init(argc, argv);
 
-	for(int i = 1; i < argc; i++) // ignore_convention
+	bool Silent = false;
+	for(int i = 1; i < cmdline_arg_num(); i++)
 	{
-		if(str_comp("-s", argv[i]) == 0 || str_comp("--silent", argv[i]) == 0) // ignore_convention
+		char aArgument[32];
+		cmdline_arg_get(i, aArgument, sizeof(aArgument));
+		if(str_comp("-s", aArgument) == 0 || str_comp("--silent", aArgument) == 0)
 		{
 			Silent = true;
 		}
-		else if(str_comp("-c", argv[i]) == 0 || str_comp("--console", argv[i]) == 0) // ignore_convention
+		else if(str_comp("-c", aArgument) == 0 || str_comp("--console", aArgument) == 0)
 		{
 #if defined(CONF_FAMILY_WINDOWS)
 			AllocConsole();
@@ -4328,10 +4330,7 @@ int main(int argc, const char **argv) // ignore_convention
 	InitAndroid();
 #endif
 
-	if(secure_random_init() != 0)
-	{
-		RandInitFailed = true;
-	}
+	const bool RandInitFailed = secure_random_init() != 0;
 
 	NotificationsInit();
 
@@ -4343,7 +4342,7 @@ int main(int argc, const char **argv) // ignore_convention
 	// create the components
 	IEngine *pEngine = CreateEngine("DDNet", Silent, 2);
 	IConsole *pConsole = CreateConsole(CFGFLAG_CLIENT);
-	IStorage *pStorage = CreateStorage("Teeworlds", IStorage::STORAGETYPE_CLIENT, argc, (const char **)argv); // ignore_convention
+	IStorage *pStorage = CreateStorage("Teeworlds", IStorage::STORAGETYPE_CLIENT);
 	IConfigManager *pConfigManager = CreateConfigManager();
 	IEngineSound *pEngineSound = CreateEngineSound();
 	IEngineInput *pEngineInput = CreateEngineInput();
@@ -4448,14 +4447,22 @@ int main(int argc, const char **argv) // ignore_convention
 	g_Config.m_ClConfigVersion = 1;
 
 	// parse the command line arguments
-	if(argc == 2 && str_startswith(argv[1], CONNECTLINK))
-		pClient->HandleConnectLink(argv[1]);
-	else if(argc == 2 && str_endswith(argv[1], ".demo"))
-		pClient->HandleDemoPath(argv[1]);
-	else if(argc == 2 && str_endswith(argv[1], ".map"))
-		pClient->HandleMapPath(argv[1]);
-	else if(argc > 1) // ignore_convention
-		pConsole->ParseArguments(argc - 1, (const char **)&argv[1]); // ignore_convention
+	bool ArgumentsNotHandled = false;
+	if(cmdline_arg_num() == 2)
+	{
+		char aArgument[IO_MAX_PATH_LENGTH];
+		cmdline_arg_get(1, aArgument, sizeof(aArgument));
+		if(cmdline_arg_num() == 2 && str_startswith(aArgument, CONNECTLINK))
+			pClient->HandleConnectLink(aArgument);
+		else if(cmdline_arg_num() == 2 && str_endswith(aArgument, ".demo"))
+			pClient->HandleDemoPath(aArgument);
+		else if(cmdline_arg_num() == 2 && str_endswith(aArgument, ".map"))
+			pClient->HandleMapPath(aArgument);
+		else
+			ArgumentsNotHandled = true;
+	}
+	if(cmdline_arg_num() > 1 && ArgumentsNotHandled)
+		pConsole->ParseCommandLineArguments();
 
 	if(pSteam->GetConnectAddress())
 	{
@@ -4483,6 +4490,7 @@ int main(int argc, const char **argv) // ignore_convention
 	}
 
 	delete pKernel;
+	cmdline_free();
 
 #ifdef CONF_PLATFORM_ANDROID
 	// properly close this native thread, so globals are destructed

--- a/src/engine/console.h
+++ b/src/engine/console.h
@@ -87,7 +87,7 @@ public:
 	virtual const CCommandInfo *FirstCommandInfo(int AccessLevel, int Flagmask) const = 0;
 	virtual const CCommandInfo *GetCommandInfo(const char *pName, int FlagMask, bool Temp) = 0;
 	virtual void PossibleCommands(const char *pStr, int FlagMask, bool Temp, FPossibleCallback pfnCallback, void *pUser) = 0;
-	virtual void ParseArguments(int NumArgs, const char **ppArguments) = 0;
+	virtual void ParseCommandLineArguments() = 0;
 
 	virtual void Register(const char *pName, const char *pParams, int Flags, FCommandCallback pfnFunc, void *pUser, const char *pHelp) = 0;
 	virtual void RegisterTemp(const char *pName, const char *pParams, int Flags, const char *pHelp) = 0;

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -3536,13 +3536,17 @@ void CServer::SnapSetStaticsize(int ItemType, int Size)
 
 static CServer *CreateServer() { return new CServer(); }
 
-int main(int argc, const char **argv) // ignore_convention
+int main(int argc, char **argv)
 {
+	cmdline_init(argc, argv);
+
 	bool Silent = false;
 
-	for(int i = 1; i < argc; i++) // ignore_convention
+	for(int i = 1; i < cmdline_arg_num(); i++)
 	{
-		if(str_comp("-s", argv[i]) == 0 || str_comp("--silent", argv[i]) == 0) // ignore_convention
+		char aArgument[32];
+		cmdline_arg_get(i, aArgument, sizeof(aArgument));
+		if(str_comp("-s", aArgument) == 0 || str_comp("--silent", aArgument) == 0)
 		{
 			Silent = true;
 #if defined(CONF_FAMILY_WINDOWS)
@@ -3572,7 +3576,7 @@ int main(int argc, const char **argv) // ignore_convention
 	IGameServer *pGameServer = CreateGameServer();
 	IConsole *pConsole = CreateConsole(CFGFLAG_SERVER | CFGFLAG_ECON);
 	IEngineMasterServer *pEngineMasterServer = CreateEngineMasterServer();
-	IStorage *pStorage = CreateStorage("Teeworlds", IStorage::STORAGETYPE_SERVER, argc, argv); // ignore_convention
+	IStorage *pStorage = CreateStorage("Teeworlds", IStorage::STORAGETYPE_SERVER);
 	IConfigManager *pConfigManager = CreateConfigManager();
 	IEngineAntibot *pEngineAntibot = CreateEngineAntibot();
 
@@ -3623,8 +3627,7 @@ int main(int argc, const char **argv) // ignore_convention
 	}
 
 	// parse the command line arguments
-	if(argc > 1) // ignore_convention
-		pConsole->ParseArguments(argc - 1, &argv[1]); // ignore_convention
+	pConsole->ParseCommandLineArguments();
 
 	pConsole->Register("sv_test_cmds", "", CFGFLAG_SERVER, CServer::ConTestingCommands, pConsole, "Turns testing commands aka cheats on/off (setting only works in initial config)");
 	pConsole->Register("sv_rescue", "", CFGFLAG_SERVER, CServer::ConRescue, pConsole, "Allow /rescue command so players can teleport themselves out of freeze (setting only works in initial config)");
@@ -3639,6 +3642,7 @@ int main(int argc, const char **argv) // ignore_convention
 
 	// free
 	delete pKernel;
+	cmdline_free();
 
 	return Ret;
 }

--- a/src/engine/shared/console.cpp
+++ b/src/engine/shared/console.cpp
@@ -1008,18 +1008,24 @@ void CConsole::Init()
 #undef MACRO_CONFIG_STR
 }
 
-void CConsole::ParseArguments(int NumArgs, const char **ppArguments)
+void CConsole::ParseCommandLineArguments()
 {
-	for(int i = 0; i < NumArgs; i++)
+	for(int i = 1; i < cmdline_arg_num(); i++)
 	{
+		char aArgument[256];
+		cmdline_arg_get(i, aArgument, sizeof(aArgument));
 		// check for scripts to execute
-		if(ppArguments[i][0] == '-' && ppArguments[i][1] == 'f' && ppArguments[i][2] == 0)
+		if(str_comp("-f", aArgument) == 0)
 		{
-			if(NumArgs - i > 1)
-				ExecuteFile(ppArguments[i + 1], -1, true, IStorage::TYPE_ABSOLUTE);
+			if(cmdline_arg_num() - i > 1)
+			{
+				char aFileName[IO_MAX_PATH_LENGTH];
+				cmdline_arg_get(i + 1, aFileName, sizeof(aFileName));
+				ExecuteFile(aFileName, -1, true, IStorage::TYPE_ABSOLUTE);
+			}
 			i++;
 		}
-		else if(!str_comp("-s", ppArguments[i]) || !str_comp("--silent", ppArguments[i]))
+		else if(!str_comp("-s", aArgument) || !str_comp("--silent", aArgument))
 		{
 			// skip silent param
 			continue;
@@ -1027,7 +1033,7 @@ void CConsole::ParseArguments(int NumArgs, const char **ppArguments)
 		else
 		{
 			// search arguments for overrides
-			ExecuteLine(ppArguments[i]);
+			ExecuteLine(aArgument);
 		}
 	}
 }

--- a/src/engine/shared/console.h
+++ b/src/engine/shared/console.h
@@ -202,7 +202,7 @@ public:
 	virtual const CCommandInfo *GetCommandInfo(const char *pName, int FlagMask, bool Temp);
 	virtual void PossibleCommands(const char *pStr, int FlagMask, bool Temp, FPossibleCallback pfnCallback, void *pUser);
 
-	virtual void ParseArguments(int NumArgs, const char **ppArguments);
+	virtual void ParseCommandLineArguments();
 	virtual void Register(const char *pName, const char *pParams, int Flags, FCommandCallback pfnFunc, void *pUser, const char *pHelp);
 	virtual void RegisterTemp(const char *pName, const char *pParams, int Flags, const char *pHelp);
 	virtual void DeregisterTemp(const char *pName);

--- a/src/engine/storage.h
+++ b/src/engine/storage.h
@@ -41,7 +41,7 @@ public:
 	static void StripPathAndExtension(const char *pFilename, char *pBuffer, int BufferSize);
 };
 
-extern IStorage *CreateStorage(const char *pApplicationName, int StorageType, int NumArgs, const char **ppArguments);
+extern IStorage *CreateStorage(const char *pApplicationName, int StorageType);
 extern IStorage *CreateLocalStorage();
 extern IStorage *CreateTempStorage(const char *pDirectory);
 

--- a/src/macoslaunch/client.m
+++ b/src/macoslaunch/client.m
@@ -1,9 +1,9 @@
 #import <Cocoa/Cocoa.h>
 #include <base/system.h>
 
-extern int TWMain(int argc, const char **argv);
+extern int TWMain(int argc, char **argv);
 
-int main(int argc, const char **argv)
+int main(int argc, char **argv)
 {
 	BOOL FinderLaunch = argc >= 2 && !str_comp_num(argv[1], "-psn", 4);
 
@@ -15,7 +15,7 @@ int main(int argc, const char **argv)
 
 	if(FinderLaunch)
 	{
-		const char *paArgv[2] = { argv[0], NULL };
+		char *paArgv[2] = { argv[0], NULL };
 		return TWMain(1, paArgv);
 	}
 	else

--- a/src/mastersrv/mastersrv.cpp
+++ b/src/mastersrv/mastersrv.cpp
@@ -318,20 +318,20 @@ void ReloadBans()
 	m_pConsole->ExecuteFile("master.cfg", -1, true);
 }
 
-int main(int argc, const char **argv) // ignore_convention
+int main(int argc, char **argv)
 {
+	dbg_logger_stdout();
+	cmdline_init(argc, argv);
+	net_init();
+
 	int64_t LastBuild = 0, LastBanReload = 0;
 	ServerType Type = SERVERTYPE_INVALID;
-	NETADDR BindAddr;
-
-	dbg_logger_stdout();
-	net_init();
 
 	mem_copy(m_CountData.m_Header, SERVERBROWSE_COUNT, sizeof(SERVERBROWSE_COUNT));
 	mem_copy(m_CountDataLegacy.m_Header, SERVERBROWSE_COUNT_LEGACY, sizeof(SERVERBROWSE_COUNT_LEGACY));
 
 	IKernel *pKernel = IKernel::Create();
-	IStorage *pStorage = CreateStorage("Teeworlds", IStorage::STORAGETYPE_BASIC, argc, argv);
+	IStorage *pStorage = CreateStorage("Teeworlds", IStorage::STORAGETYPE_BASIC);
 	IConfigManager *pConfigManager = CreateConfigManager();
 	m_pConsole = CreateConsole(CFGFLAG_MASTER);
 
@@ -345,9 +345,9 @@ int main(int argc, const char **argv) // ignore_convention
 	pConfigManager->Init();
 	m_pConsole->Init();
 	m_NetBan.Init(m_pConsole, pStorage);
-	if(argc > 1) // ignore_convention
-		m_pConsole->ParseArguments(argc - 1, &argv[1]); // ignore_convention
+	m_pConsole->ParseCommandLineArguments();
 
+	NETADDR BindAddr;
 	if(g_Config.m_Bindaddr[0] && net_host_lookup(g_Config.m_Bindaddr, &BindAddr, NETTYPE_ALL) == 0)
 	{
 		// got bindaddr
@@ -539,5 +539,6 @@ int main(int argc, const char **argv) // ignore_convention
 		thread_sleep(1000);
 	}
 
+	cmdline_free();
 	return 0;
 }

--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -109,11 +109,14 @@ void CTestInfo::DeleteTestStorageFilesOnSuccess()
 int main(int argc, char **argv)
 {
 	::testing::InitGoogleTest(&argc, argv);
+	cmdline_init(argc, argv);
 	net_init();
 	if(secure_random_init())
 	{
 		fprintf(stderr, "random init failed\n");
 		return 1;
 	}
-	return RUN_ALL_TESTS();
+	int Result = RUN_ALL_TESTS();
+	cmdline_free();
+	return Result;
 }

--- a/src/tools/crapnet.cpp
+++ b/src/tools/crapnet.cpp
@@ -208,7 +208,7 @@ void Run(unsigned short Port, NETADDR Dest)
 	}
 }
 
-int main(int argc, char **argv) // ignore_convention
+int main(int argc, char **argv)
 {
 	NETADDR Addr = {NETTYPE_IPV4, {127, 0, 0, 1}, 8303};
 	dbg_logger_stdout();

--- a/src/tools/dilate.cpp
+++ b/src/tools/dilate.cpp
@@ -71,16 +71,26 @@ int DilateFile(const char *pFilename)
 	return 0;
 }
 
-int main(int argc, const char **argv)
+int main(int argc, char **argv)
 {
 	dbg_logger_stdout();
-	if(argc == 1)
+	cmdline_init(argc, argv);
+
+	if(cmdline_arg_num() == 1)
 	{
-		dbg_msg("usage", "%s FILE1 [ FILE2... ]", argv[0]);
+		char aExecutablePath[IO_MAX_PATH_LENGTH];
+		cmdline_arg_get(0, aExecutablePath, sizeof(aExecutablePath));
+		dbg_msg("usage", "%s FILE1 [ FILE2... ]", aExecutablePath);
 		return -1;
 	}
 
-	for(int i = 1; i < argc; i++)
-		DilateFile(argv[i]);
+	for(int i = 1; i < cmdline_arg_num(); i++)
+	{
+		char aPath[IO_MAX_PATH_LENGTH];
+		cmdline_arg_get(i, aPath, sizeof(aPath));
+		DilateFile(aPath);
+	}
+
+	cmdline_free();
 	return 0;
 }

--- a/src/tools/dummy_map.cpp
+++ b/src/tools/dummy_map.cpp
@@ -71,10 +71,12 @@ void CreateEmptyMap(IStorage *pStorage)
 	Writer.Finish();
 }
 
-int main(int argc, const char **argv)
+int main(int argc, char **argv)
 {
 	dbg_logger_stdout();
-	IStorage *pStorage = CreateStorage("Teeworlds", IStorage::STORAGETYPE_SERVER, argc, argv);
+	cmdline_init(argc, argv);
+	IStorage *pStorage = CreateStorage("Teeworlds", IStorage::STORAGETYPE_SERVER);
 	CreateEmptyMap(pStorage);
+	cmdline_free();
 	return 0;
 }

--- a/src/tools/map_convert_07.cpp
+++ b/src/tools/map_convert_07.cpp
@@ -133,13 +133,14 @@ void *ReplaceImageItem(void *pItem, int Type, CMapItemImage *pNewImgItem)
 	return (void *)pNewImgItem;
 }
 
-int main(int argc, const char **argv)
+int main(int argc, char **argv)
 {
 	dbg_logger_stdout();
+	cmdline_init(argc, argv);
 
-	IStorage *pStorage = CreateStorage("Teeworlds", IStorage::STORAGETYPE_BASIC, argc, argv);
+	IStorage *pStorage = CreateStorage("Teeworlds", IStorage::STORAGETYPE_BASIC);
 
-	if(argc < 2 || argc > 3)
+	if(cmdline_arg_num() < 2 || cmdline_arg_num() > 3)
 	{
 		dbg_msg("map_convert_07", "Invalid arguments");
 		dbg_msg("map_convert_07", "Usage: map_convert_07 <source map filepath> [<dest map filepath>]");
@@ -152,21 +153,20 @@ int main(int argc, const char **argv)
 		return -1;
 	}
 
-	const char *pSourceFileName = argv[1];
+	char aSourceFileName[IO_MAX_PATH_LENGTH];
+	cmdline_arg_get(1, aSourceFileName, sizeof(aSourceFileName));
 
-	const char *pDestFileName;
 	char aDestFileName[IO_MAX_PATH_LENGTH];
-
-	if(argc == 3)
+	if(cmdline_arg_num() == 3)
 	{
-		pDestFileName = argv[2];
+		cmdline_arg_get(2, aDestFileName, sizeof(aDestFileName));
 	}
 	else
 	{
 		char aBuf[IO_MAX_PATH_LENGTH];
-		IStorage::StripPathAndExtension(pSourceFileName, aBuf, sizeof(aBuf));
+		IStorage::StripPathAndExtension(aSourceFileName, aBuf, sizeof(aBuf));
 		str_format(aDestFileName, sizeof(aDestFileName), "data/maps7/%s.map", aBuf);
-		pDestFileName = aDestFileName;
+
 		if(fs_makedir("data") != 0)
 		{
 			dbg_msg("map_convert_07", "failed to create data directory");
@@ -180,21 +180,15 @@ int main(int argc, const char **argv)
 		}
 	}
 
-	int ID = 0;
-	int Type = 0;
-	int Size = 0;
-	void *pItem = 0;
-	void *pData = 0;
-
-	if(!g_DataReader.Open(pStorage, pSourceFileName, IStorage::TYPE_ABSOLUTE))
+	if(!g_DataReader.Open(pStorage, aSourceFileName, IStorage::TYPE_ABSOLUTE))
 	{
-		dbg_msg("map_convert_07", "failed to open source map. filename='%s'", pSourceFileName);
+		dbg_msg("map_convert_07", "failed to open source map. filename='%s'", aSourceFileName);
 		return -1;
 	}
 
-	if(!g_DataWriter.Open(pStorage, pDestFileName, IStorage::TYPE_ABSOLUTE))
+	if(!g_DataWriter.Open(pStorage, aDestFileName, IStorage::TYPE_ABSOLUTE))
 	{
-		dbg_msg("map_convert_07", "failed to open destination map. filename='%s'", pDestFileName);
+		dbg_msg("map_convert_07", "failed to open destination map. filename='%s'", aDestFileName);
 		return -1;
 	}
 
@@ -202,25 +196,31 @@ int main(int argc, const char **argv)
 
 	g_NextDataItemID = g_DataReader.NumData();
 
-	int i = 0;
+	int ImageIndex = 0;
 	for(int Index = 0; Index < g_DataReader.NumItems(); Index++)
 	{
+		int Type, ID;
 		g_DataReader.GetItem(Index, &Type, &ID);
 		if(Type == MAPITEMTYPE_IMAGE)
-			g_aImageIDs[i++] = Index;
+		{
+			g_aImageIDs[ImageIndex] = Index;
+			++ImageIndex;
+		}
 	}
 
 	bool Success = true;
 
-	if(i > 64)
-		dbg_msg("map_convert_07", "%s: Uses more textures than the client maximum of 64.", pSourceFileName);
+	const int MaxClientTextures = 64;
+	if(ImageIndex > MaxClientTextures)
+		dbg_msg("map_convert_07", "%s: Uses more textures than the client maximum of %d (%d).", aSourceFileName, MaxClientTextures, ImageIndex);
 
 	// add all items
 	for(int Index = 0; Index < g_DataReader.NumItems(); Index++)
 	{
 		CMapItemImage NewImageItem;
-		pItem = g_DataReader.GetItem(Index, &Type, &ID);
-		Size = g_DataReader.GetItemSize(Index);
+		int Type, ID;
+		void *pItem = g_DataReader.GetItem(Index, &Type, &ID);
+		int Size = g_DataReader.GetItemSize(Index);
 
 		// filter ITEMTYPE_EX items, they will be automatically added again
 		if(Type == ITEMTYPE_EX)
@@ -228,7 +228,7 @@ int main(int argc, const char **argv)
 			continue;
 		}
 
-		Success &= CheckImageDimensions(pItem, Type, pSourceFileName);
+		Success &= CheckImageDimensions(pItem, Type, aSourceFileName);
 
 		pItem = ReplaceImageItem(pItem, Type, &NewImageItem);
 		if(!pItem)
@@ -239,19 +239,21 @@ int main(int argc, const char **argv)
 	// add all data
 	for(int Index = 0; Index < g_DataReader.NumData(); Index++)
 	{
-		pData = g_DataReader.GetData(Index);
-		Size = g_DataReader.GetDataSize(Index);
+		void *pData = g_DataReader.GetData(Index);
+		int Size = g_DataReader.GetDataSize(Index);
 		g_DataWriter.AddData(Size, pData);
 	}
 
 	for(int Index = 0; Index < g_Index; Index++)
 	{
-		pData = g_pNewData[Index];
-		Size = g_NewDataSize[Index];
+		void *pData = g_pNewData[Index];
+		int Size = g_NewDataSize[Index];
 		g_DataWriter.AddData(Size, pData);
 	}
 
 	g_DataReader.Close();
 	g_DataWriter.Finish();
+
+	cmdline_free();
 	return Success ? 0 : -1;
 }

--- a/src/tools/map_diff.cpp
+++ b/src/tools/map_diff.cpp
@@ -6,9 +6,12 @@
 
 #include <pnglite.h>
 
-bool Process(IStorage *pStorage, char **pMapNames)
+bool Process(IStorage *pStorage, char *pMapName1, char *pMapName2)
 {
 	CDataFileReader Maps[2];
+	char *pMapNames[] = {
+		pMapName1,
+		pMapName2};
 
 	for(int i = 0; i < 2; ++i)
 	{
@@ -98,20 +101,27 @@ bool Process(IStorage *pStorage, char **pMapNames)
 	return true;
 }
 
-int main(int argc, char *argv[])
+int main(int argc, char **argv)
 {
 	dbg_logger_stdout();
 	dbg_logger_file("map_diff.txt");
+	cmdline_init(argc, argv);
 
 	IStorage *pStorage = CreateLocalStorage();
 
-	if(argc == 3)
+	if(cmdline_arg_num() == 3)
 	{
-		return Process(pStorage, &argv[1]) ? 0 : 1;
+		char aMap1[IO_MAX_PATH_LENGTH];
+		cmdline_arg_get(1, aMap1, sizeof(aMap1));
+		char aMap2[IO_MAX_PATH_LENGTH];
+		cmdline_arg_get(2, aMap2, sizeof(aMap2));
+		return Process(pStorage, aMap1, aMap2) ? 0 : 1;
 	}
 	else
 	{
-		dbg_msg("usage", "%s map1 map2", argv[0]);
+		char aExecutablePath[IO_MAX_PATH_LENGTH];
+		cmdline_arg_get(0, aExecutablePath, sizeof(aExecutablePath));
+		dbg_msg("usage", "%s map1 map2", aExecutablePath);
 		return -1;
 	}
 }

--- a/src/tools/map_extract.cpp
+++ b/src/tools/map_extract.cpp
@@ -46,7 +46,7 @@ bool Process(IStorage *pStorage, const char *pMapName, const char *pPathSave)
 		if(pItem->m_External)
 			continue;
 
-		char aBuf[512];
+		char aBuf[IO_MAX_PATH_LENGTH];
 		str_format(aBuf, sizeof(aBuf), "%s/%s.png", pPathSave, pName);
 		dbg_msg("map_extract", "writing image: %s (%dx%d)", aBuf, pItem->m_Width, pItem->m_Height);
 
@@ -81,7 +81,7 @@ bool Process(IStorage *pStorage, const char *pMapName, const char *pPathSave)
 		if(pItem->m_External)
 			continue;
 
-		char aBuf[512];
+		char aBuf[IO_MAX_PATH_LENGTH];
 		str_format(aBuf, sizeof(aBuf), "%s/%s.opus", pPathSave, pName);
 		dbg_msg("map_extract", "writing sound: %s (%d B)", aBuf, pItem->m_SoundDataSize);
 
@@ -93,28 +93,31 @@ bool Process(IStorage *pStorage, const char *pMapName, const char *pPathSave)
 	return Map.Close();
 }
 
-int main(int argc, char *argv[])
+int main(int argc, char **argv)
 {
 	dbg_logger_stdout();
-
-	char aMap[512];
-	char aDir[512];
+	cmdline_init(argc, argv);
 
 	IStorage *pStorage = CreateLocalStorage();
 
-	if(argc == 2)
+	char aMap[IO_MAX_PATH_LENGTH];
+	char aDir[IO_MAX_PATH_LENGTH];
+
+	if(cmdline_arg_num() == 2)
 	{
-		str_copy(aMap, argv[1], sizeof(aMap));
-		str_copy(aDir, ".", sizeof(aMap));
+		cmdline_arg_get(1, aMap, sizeof(aMap));
+		str_copy(aDir, ".", sizeof(aDir));
 	}
-	else if(argc == 3)
+	else if(cmdline_arg_num() == 3)
 	{
-		str_copy(aMap, argv[1], sizeof(aMap));
-		str_copy(aDir, argv[2], sizeof(aDir));
+		cmdline_arg_get(1, aMap, sizeof(aMap));
+		cmdline_arg_get(2, aDir, sizeof(aDir));
 	}
 	else
 	{
-		dbg_msg("usage", "%s map [directory]", argv[0]);
+		char aExecutablePath[IO_MAX_PATH_LENGTH];
+		cmdline_arg_get(0, aExecutablePath, sizeof(aExecutablePath));
+		dbg_msg("usage", "%s map [directory]", aExecutablePath);
 		return -1;
 	}
 
@@ -126,5 +129,8 @@ int main(int argc, char *argv[])
 
 	png_init(0, 0);
 
-	return Process(pStorage, aMap, aDir) ? 0 : 1;
+	int Result = Process(pStorage, aMap, aDir) ? 0 : 1;
+
+	cmdline_free();
+	return Result;
 }

--- a/src/tools/map_replace_image.cpp
+++ b/src/tools/map_replace_image.cpp
@@ -108,13 +108,14 @@ void *ReplaceImageItem(void *pItem, int Type, const char *pImgName, const char *
 	return (void *)pNewImgItem;
 }
 
-int main(int argc, const char **argv)
+int main(int argc, char **argv)
 {
 	dbg_logger_stdout();
+	cmdline_init(argc, argv);
 
-	IStorage *pStorage = CreateStorage("Teeworlds", IStorage::STORAGETYPE_BASIC, argc, argv);
+	IStorage *pStorage = CreateStorage("Teeworlds", IStorage::STORAGETYPE_BASIC);
 
-	if(argc != 5)
+	if(cmdline_arg_num() != 5)
 	{
 		dbg_msg("map_replace_image", "Invalid arguments");
 		dbg_msg("map_replace_image", "Usage: map_replace_image <source map filepath> <dest map filepath> <current image name> <new image filepath>");
@@ -129,26 +130,24 @@ int main(int argc, const char **argv)
 		return -1;
 	}
 
-	const char *pSourceFileName = argv[1];
-	const char *pDestFileName = argv[2];
-	const char *pImageName = argv[3];
-	const char *pImageFile = argv[4];
+	char aSourceFileName[IO_MAX_PATH_LENGTH];
+	cmdline_arg_get(1, aSourceFileName, sizeof(aSourceFileName));
+	char aDestFileName[IO_MAX_PATH_LENGTH];
+	cmdline_arg_get(2, aDestFileName, sizeof(aDestFileName));
+	char aImageName[IO_MAX_PATH_LENGTH];
+	cmdline_arg_get(3, aImageName, sizeof(aImageName));
+	char aImageFile[IO_MAX_PATH_LENGTH];
+	cmdline_arg_get(4, aImageFile, sizeof(aImageFile));
 
-	int ID = 0;
-	int Type = 0;
-	int Size = 0;
-	void *pItem = 0;
-	void *pData = 0;
-
-	if(!g_DataReader.Open(pStorage, pSourceFileName, IStorage::TYPE_ALL))
+	if(!g_DataReader.Open(pStorage, aSourceFileName, IStorage::TYPE_ALL))
 	{
-		dbg_msg("map_replace_image", "failed to open source map. filename='%s'", pSourceFileName);
+		dbg_msg("map_replace_image", "failed to open source map. filename='%s'", aSourceFileName);
 		return -1;
 	}
 
-	if(!g_DataWriter.Open(pStorage, pDestFileName))
+	if(!g_DataWriter.Open(pStorage, aDestFileName))
 	{
-		dbg_msg("map_replace_image", "failed to open destination map. filename='%s'", pDestFileName);
+		dbg_msg("map_replace_image", "failed to open destination map. filename='%s'", aDestFileName);
 		return -1;
 	}
 
@@ -158,8 +157,9 @@ int main(int argc, const char **argv)
 	for(int Index = 0; Index < g_DataReader.NumItems(); Index++)
 	{
 		CMapItemImage NewImageItem;
-		pItem = g_DataReader.GetItem(Index, &Type, &ID);
-		Size = g_DataReader.GetItemSize(Index);
+		int Type, ID;
+		void *pItem = g_DataReader.GetItem(Index, &Type, &ID);
+		int Size = g_DataReader.GetItemSize(Index);
 
 		// filter ITEMTYPE_EX items, they will be automatically added again
 		if(Type == ITEMTYPE_EX)
@@ -167,7 +167,7 @@ int main(int argc, const char **argv)
 			continue;
 		}
 
-		pItem = ReplaceImageItem(pItem, Type, pImageName, pImageFile, &NewImageItem);
+		pItem = ReplaceImageItem(pItem, Type, aImageName, aImageFile, &NewImageItem);
 		if(!pItem)
 			return -1;
 		g_DataWriter.AddItem(Type, ID, Size, pItem);
@@ -175,13 +175,15 @@ int main(int argc, const char **argv)
 
 	if(g_NewDataID == -1)
 	{
-		dbg_msg("map_replace_image", "image '%s' not found on source map '%s'.", pImageName, pSourceFileName);
+		dbg_msg("map_replace_image", "image '%s' not found on source map '%s'.", aImageName, aSourceFileName);
 		return -1;
 	}
 
 	// add all data
 	for(int Index = 0; Index < g_DataReader.NumItems(); Index++)
 	{
+		void *pData;
+		int Size;
 		if(Index == g_NewDataID)
 		{
 			pData = g_pNewData;
@@ -204,6 +206,7 @@ int main(int argc, const char **argv)
 	g_DataReader.Close();
 	g_DataWriter.Finish();
 
-	dbg_msg("map_replace_image", "image '%s' replaced", pImageName);
+	dbg_msg("map_replace_image", "image '%s' replaced", aImageName);
+	cmdline_free();
 	return 0;
 }

--- a/src/tools/map_resave.cpp
+++ b/src/tools/map_resave.cpp
@@ -4,49 +4,63 @@
 #include <engine/shared/datafile.h>
 #include <engine/storage.h>
 
-int main(int argc, const char **argv)
+int main(int argc, char **argv)
 {
-	IStorage *pStorage = CreateStorage("Teeworlds", IStorage::STORAGETYPE_BASIC, argc, argv);
-	int Index, ID = 0, Type = 0, Size;
-	void *pPtr;
-	char aFileName[IO_MAX_PATH_LENGTH];
-	CDataFileReader DataFile;
-	CDataFileWriter df;
+	dbg_logger_stdout();
+	cmdline_init(argc, argv);
 
-	if(!pStorage || argc != 3)
+	IStorage *pStorage = CreateStorage("Teeworlds", IStorage::STORAGETYPE_BASIC);
+	if(!pStorage)
 		return -1;
+	if(cmdline_arg_num() != 3)
+	{
+		dbg_msg("map_resave", "usage: map_resave existing.map newname.map");
+		return -1;
+	}
 
-	str_format(aFileName, sizeof(aFileName), "%s", argv[2]);
+	char aInputPath[IO_MAX_PATH_LENGTH];
+	cmdline_arg_get(1, aInputPath, sizeof(aInputPath));
+	CDataFileReader Reader;
+	if(!Reader.Open(pStorage, aInputPath, IStorage::TYPE_ABSOLUTE))
+	{
+		dbg_msg("map_resave", "failed to open input map '%s'", aInputPath);
+		return -1;
+	}
 
-	if(!DataFile.Open(pStorage, argv[1], IStorage::TYPE_ABSOLUTE))
+	char aOutputPath[IO_MAX_PATH_LENGTH];
+	cmdline_arg_get(2, aOutputPath, sizeof(aOutputPath));
+	CDataFileWriter Writer;
+	if(!Writer.Open(pStorage, aOutputPath))
+	{
+		dbg_msg("map_resave", "failed to open output map '%s'", aOutputPath);
 		return -1;
-	if(!df.Open(pStorage, aFileName))
-		return -1;
+	}
 
 	// add all items
-	for(Index = 0; Index < DataFile.NumItems(); Index++)
+	for(int Index = 0; Index < Reader.NumItems(); Index++)
 	{
-		pPtr = DataFile.GetItem(Index, &Type, &ID);
-		Size = DataFile.GetItemSize(Index);
+		int Type, ID;
+		void *pPtr = Reader.GetItem(Index, &Type, &ID);
+		int Size = Reader.GetItemSize(Index);
 
 		// filter ITEMTYPE_EX items, they will be automatically added again
 		if(Type == ITEMTYPE_EX)
-		{
 			continue;
-		}
 
-		df.AddItem(Type, ID, Size, pPtr);
+		Writer.AddItem(Type, ID, Size, pPtr);
 	}
 
 	// add all data
-	for(Index = 0; Index < DataFile.NumData(); Index++)
+	for(int Index = 0; Index < Reader.NumData(); Index++)
 	{
-		pPtr = DataFile.GetData(Index);
-		Size = DataFile.GetDataSize(Index);
-		df.AddData(Size, pPtr);
+		void *pPtr = Reader.GetData(Index);
+		int Size = Reader.GetDataSize(Index);
+		Writer.AddData(Size, pPtr);
 	}
 
-	DataFile.Close();
-	df.Finish();
+	Reader.Close();
+	Writer.Finish();
+
+	cmdline_free();
 	return 0;
 }

--- a/src/tools/unicode_confusables.cpp
+++ b/src/tools/unicode_confusables.cpp
@@ -1,13 +1,24 @@
 #include <base/system.h>
 
-int main(int argc, const char **argv) // ignore_convention
+int main(int argc, char **argv)
 {
 	dbg_logger_stdout();
-	if(argc < 1 + 2)
+	cmdline_init(argc, argv);
+
+	if(cmdline_arg_num() < 1 + 2)
 	{
-		dbg_msg("usage", "%s STR1 STR2", argv[0] ? argv[0] : "unicode_confusables");
+		char aExecutablePath[IO_MAX_PATH_LENGTH];
+		cmdline_arg_get(0, aExecutablePath, sizeof(aExecutablePath));
+		dbg_msg("usage", "%s STR1 STR2", aExecutablePath);
 		return -1;
 	}
-	dbg_msg("conf", "not_confusable=%d", str_utf8_comp_confusable(argv[1], argv[2]));
+
+	char aStr1[128];
+	char aStr2[128];
+	cmdline_arg_get(1, aStr1, sizeof(aStr1));
+	cmdline_arg_get(2, aStr2, sizeof(aStr2));
+	dbg_msg("conf", "not_confusable=%d", str_utf8_comp_confusable(aStr1, aStr2));
+
+	cmdline_free();
 	return 0;
 }

--- a/src/twping/twping.cpp
+++ b/src/twping/twping.cpp
@@ -7,7 +7,7 @@
 
 static CNetClient g_NetOp; // main
 
-int main(int argc, char **argv) // ignore_convention
+int main(int argc, char **argv)
 {
 	NETADDR BindAddr;
 	mem_zero(&BindAddr, sizeof(BindAddr));


### PR DESCRIPTION
Add `cmdline_init`, `cmdline_arg_num`, `cmdline_arg_get` and `cmdline_free` functions to handle command line arguments in utf8 on windows.
The original `argc` and `argv` need to be passed to `cmdline_init` in the beginning and are stored in global variables for non-Windows systems.
On windows the API functions are used to retrieve the arguments as a wide string, but if `CommandLineToArgvW` fails, it will fall back to the original `argv` string.
The wide string is then retrieved in utf8 via `cmdline_arg_get`.

The functions are used for client, server and almost all tools, except for some that looked outdated or like they don't need to be aware of unicode.

Refactoring/code style/consistency:
- Refactor/Cleanup some of the tools.
- Change `const char **argv` and `char *argv[]` to `char **argv` everywhere. 
- Remove `// ignore_convention` from a lot of places.

Closes #4369.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
