### PR TITLE
Fix save typing when server settings are open in editor

### DIFF
--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -47,7 +47,7 @@ CUI::CUI()
 	m_pHotItem = 0;
 	m_pActiveItem = 0;
 	m_pLastActiveItem = 0;
-	m_pBecommingHotItem = 0;
+	m_pBecomingHotItem = 0;
 
 	m_MouseX = 0;
 	m_MouseY = 0;
@@ -128,10 +128,10 @@ int CUI::Update(float Mx, float My, float Mwx, float Mwy, int Buttons)
 	m_MouseWorldY = Mwy;
 	m_LastMouseButtons = m_MouseButtons;
 	m_MouseButtons = Buttons;
-	m_pHotItem = m_pBecommingHotItem;
+	m_pHotItem = m_pBecomingHotItem;
 	if(m_pActiveItem)
 		m_pHotItem = m_pActiveItem;
-	m_pBecommingHotItem = 0;
+	m_pBecomingHotItem = 0;
 	return 0;
 }
 

--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -180,7 +180,7 @@ class CUI
 	const void *m_pHotItem;
 	const void *m_pActiveItem;
 	const void *m_pLastActiveItem;
-	const void *m_pBecommingHotItem;
+	const void *m_pBecomingHotItem;
 	float m_MouseX, m_MouseY; // in gui space
 	float m_MouseDeltaX, m_MouseDeltaY; // in gui space
 	float m_MouseWorldX, m_MouseWorldY; // in world space
@@ -243,7 +243,7 @@ public:
 	int MouseButtonClicked(int Index) const { return MouseButton(Index) && !((m_LastMouseButtons >> Index) & 1); }
 	int MouseButtonReleased(int Index) const { return ((m_LastMouseButtons >> Index) & 1) && !MouseButton(Index); }
 
-	void SetHotItem(const void *pID) { m_pBecommingHotItem = pID; }
+	void SetHotItem(const void *pID) { m_pBecomingHotItem = pID; }
 	void SetActiveItem(const void *pID)
 	{
 		m_pActiveItem = pID;
@@ -252,7 +252,7 @@ public:
 	}
 	void ClearLastActiveItem() { m_pLastActiveItem = 0; }
 	const void *HotItem() const { return m_pHotItem; }
-	const void *NextHotItem() const { return m_pBecommingHotItem; }
+	const void *NextHotItem() const { return m_pBecomingHotItem; }
 	const void *ActiveItem() const { return m_pActiveItem; }
 	const void *LastActiveItem() const { return m_pLastActiveItem; }
 

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -4248,6 +4248,9 @@ void CEditor::RenderFileDialog()
 					str_copy(&m_aFileDialogFileName[i], &m_aFileDialogFileName[i + 1], (int)(sizeof(m_aFileDialogFileName)) - i);
 			m_FilesSelectedIndex = -1;
 		}
+
+		if(m_FileDialogOpening)
+			UI()->SetActiveItem(&s_FileBoxID);
 	}
 	else
 	{


### PR DESCRIPTION
As reported by louis:

> while saving a mapname while having the "Server Settings" tab open,
> pressing "m" while typing the mapname will unfocus the cursor from the
> mapname field onto the server settings field

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
