### PR TITLE
Don't access switchers out of bounds (fixes #4386)

### DIFF
--- a/src/game/server/save.cpp
+++ b/src/game/server/save.cpp
@@ -528,7 +528,7 @@ void CSaveTeam::Load(int Team, bool KeepCurrentWeakStrong)
 
 	if(m_pController->GameServer()->Collision()->m_NumSwitchers)
 	{
-		for(int i = 1; i < m_pController->GameServer()->Collision()->m_NumSwitchers + 1; i++)
+		for(int i = 1; i < minimum(m_NumSwitchers, m_pController->GameServer()->Collision()->m_NumSwitchers) + 1; i++)
 		{
 			m_pController->GameServer()->Collision()->m_pSwitchers[i].m_Status[Team] = m_pSwitchers[i].m_Status;
 			if(m_pSwitchers[i].m_EndTime)


### PR DESCRIPTION
It's possible that a map was saved with a different amount of switchers
than it has at the moment. Happened on Jao Shooter. I'll check with
mapper if they changed the number of switchers.

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
