### PR TITLE
Various text input refactorings

### DIFF
--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -3454,6 +3454,23 @@ void str_utf8_copy(char *dst, const char *src, int dst_size)
 	str_utf8_truncate(dst, dst_size, src, dst_size);
 }
 
+void str_utf8_stats(const char *str, int max_size, int max_count, int *size, int *count)
+{
+	*size = 0;
+	*count = 0;
+	while(str[*size] && *size < max_size && *count < max_count)
+	{
+		int new_size = str_utf8_forward(str, *size);
+		if(new_size != *size)
+		{
+			if(new_size >= max_size || *count >= max_count)
+				break;
+			*size = new_size;
+			++(*count);
+		}
+	}
+}
+
 unsigned str_quickhash(const char *str)
 {
 	unsigned hash = 5381;

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -2090,6 +2090,23 @@ int str_utf8_check(const char *str);
 void str_utf8_copy(char *dst, const char *src, int dst_size);
 
 /*
+	Function: str_utf8_stats
+		Determines the byte size and utf8 character count of a string.
+
+	Parameters:
+		str - Pointer to the string.
+		max_size - Maximum number of bytes to count.
+		max_count - Maximum number of utf8 characters to count.
+		size - Pointer to store size (number of non-zero bytes) of the string.
+		count - Pointer to store count of utf8 characters of the string.
+
+	Remarks:
+		- Assumes nothing about the encoding of the string.
+		  It's the users responsibility to make sure the bounds are aligned.
+*/
+void str_utf8_stats(const char *str, int max_size, int max_count, int *size, int *count);
+
+/*
 	Function: str_next_token
 		Writes the next token after str into buf, returns the rest of the string.
 	Parameters:

--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -201,7 +201,7 @@ bool CChat::OnInput(IInput::CEvent Event)
 			}
 			int max = minimum(i - Begin + 1, (int)sizeof(aLine));
 			str_utf8_copy(aLine, Text + Begin, max);
-			m_Input.Add(aLine);
+			m_Input.Append(aLine);
 		}
 	}
 

--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -217,11 +217,11 @@ void CGameConsole::CInstance::OnInput(IInput::CEvent Event)
 	}
 	else if(m_pGameConsole->Input()->KeyIsPressed(KEY_LCTRL) && m_pGameConsole->Input()->KeyPress(KEY_U))
 	{
-		m_Input.DeleteUntilCursor();
+		m_Input.SetRange("", 0, m_Input.GetCursorOffset());
 	}
 	else if(m_pGameConsole->Input()->KeyIsPressed(KEY_LCTRL) && m_pGameConsole->Input()->KeyPress(KEY_K))
 	{
-		m_Input.DeleteFromCursor();
+		m_Input.SetRange("", m_Input.GetCursorOffset(), m_Input.GetLength());
 	}
 
 	if(Event.m_Flags & IInput::FLAG_PRESS)

--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -200,7 +200,7 @@ void CGameConsole::CInstance::OnInput(IInput::CEvent Event)
 			}
 			int max = minimum(i - Begin + 1, (int)sizeof(aLine));
 			str_copy(aLine, Text + Begin, max);
-			m_Input.Add(aLine);
+			m_Input.Append(aLine);
 		}
 	}
 	else if(m_pGameConsole->Input()->KeyIsPressed(KEY_LCTRL) && m_pGameConsole->Input()->KeyPress(KEY_C))

--- a/src/game/client/lineinput.cpp
+++ b/src/game/client/lineinput.cpp
@@ -10,10 +10,7 @@ CLineInput::CLineInput()
 
 void CLineInput::Clear()
 {
-	mem_zero(m_aStr, sizeof(m_aStr));
-	m_Len = 0;
-	m_CursorPos = 0;
-	m_NumChars = 0;
+	Set("");
 }
 
 void CLineInput::Set(const char *pString)

--- a/src/game/client/lineinput.cpp
+++ b/src/game/client/lineinput.cpp
@@ -74,9 +74,14 @@ void CLineInput::Editing(const char *pString, int Cursor)
 	m_FakeCursorPos = m_CursorPos + Cursor + 1;
 }
 
+void CLineInput::Insert(const char *pString, int Begin)
+{
+	SetRange(pString, Begin, Begin);
+}
+
 void CLineInput::Append(const char *pString)
 {
-	SetRange(pString, m_Len, m_Len);
+	Insert(pString, m_Len);
 }
 
 static bool IsNotAWordChar(signed char c)

--- a/src/game/client/lineinput.cpp
+++ b/src/game/client/lineinput.cpp
@@ -19,15 +19,8 @@ void CLineInput::Clear()
 void CLineInput::Set(const char *pString)
 {
 	str_copy(m_aStr, pString, sizeof(m_aStr));
-	m_Len = str_length(m_aStr);
+	str_utf8_stats(m_aStr, MAX_SIZE, MAX_CHARS, &m_Len, &m_NumChars);
 	m_CursorPos = m_Len;
-	m_NumChars = 0;
-	int Offset = 0;
-	while(pString[Offset])
-	{
-		Offset = str_utf8_forward(pString, Offset);
-		++m_NumChars;
-	}
 }
 
 void CLineInput::Editing(const char *pString, int Cursor)

--- a/src/game/client/lineinput.cpp
+++ b/src/game/client/lineinput.cpp
@@ -74,13 +74,9 @@ void CLineInput::Editing(const char *pString, int Cursor)
 	m_FakeCursorPos = m_CursorPos + Cursor + 1;
 }
 
-void CLineInput::Add(const char *pString)
+void CLineInput::Append(const char *pString)
 {
-	if((int)sizeof(m_aStr) - m_Len <= str_length(pString))
-		return;
-	str_copy(m_aStr + m_Len, pString, sizeof(m_aStr) - m_Len);
-	m_Len = str_length(m_aStr);
-	m_CursorPos = m_Len;
+	SetRange(pString, m_Len, m_Len);
 }
 
 static bool IsNotAWordChar(signed char c)

--- a/src/game/client/lineinput.cpp
+++ b/src/game/client/lineinput.cpp
@@ -218,22 +218,6 @@ int32_t CLineInput::Manipulate(IInput::CEvent Event, char *pStr, int StrMaxSize,
 	return Changes;
 }
 
-void CLineInput::DeleteUntilCursor()
-{
-	char aBuf[MAX_SIZE];
-	str_copy(aBuf, &m_aStr[m_CursorPos], sizeof(aBuf));
-	Set(aBuf);
-	SetCursorOffset(0);
-}
-
-void CLineInput::DeleteFromCursor()
-{
-	char aBuf[MAX_SIZE];
-	str_copy(aBuf, m_aStr, sizeof(aBuf));
-	aBuf[m_CursorPos] = '\0';
-	Set(aBuf);
-}
-
 void CLineInput::ProcessInput(IInput::CEvent e)
 {
 	Manipulate(e, m_aStr, MAX_SIZE, MAX_CHARS, &m_Len, &m_CursorPos, &m_NumChars, 0, 0);

--- a/src/game/client/lineinput.cpp
+++ b/src/game/client/lineinput.cpp
@@ -65,15 +65,7 @@ int32_t CLineInput::Manipulate(IInput::CEvent Event, char *pStr, int StrMaxSize,
 		// gather string stats
 		int CharCount = 0;
 		int CharSize = 0;
-		while(Event.m_aText[CharSize])
-		{
-			int NewCharSize = str_utf8_forward(Event.m_aText, CharSize);
-			if(NewCharSize != CharSize)
-			{
-				++CharCount;
-				CharSize = NewCharSize;
-			}
-		}
+		str_utf8_stats(Event.m_aText, MAX_SIZE, MAX_CHARS, &CharSize, &CharCount);
 
 		// add new string
 		if(CharCount)

--- a/src/game/client/lineinput.h
+++ b/src/game/client/lineinput.h
@@ -40,13 +40,6 @@ public:
 	};
 	static int32_t Manipulate(IInput::CEvent e, char *pStr, int StrMaxSize, int StrMaxChars, int *pStrLenPtr, int *pCursorPosPtr, int *pNumCharsPtr, int32_t ModifyFlags, int ModifierKey);
 
-	class CCallback
-	{
-	public:
-		virtual ~CCallback() {}
-		virtual bool Event(IInput::CEvent e) = 0;
-	};
-
 	CLineInput();
 	void Clear();
 	void ProcessInput(IInput::CEvent e);

--- a/src/game/client/lineinput.h
+++ b/src/game/client/lineinput.h
@@ -53,7 +53,7 @@ public:
 	void Editing(const char *pString, int Cursor);
 	void Set(const char *pString);
 	void SetRange(const char *pString, int Begin, int End);
-	void Add(const char *pString);
+	void Append(const char *pString);
 	const char *GetString(bool Editing = false) const { return Editing ? m_DisplayStr : m_aStr; }
 	int GetLength(bool Editing = false) const { return Editing ? m_FakeLen : m_Len; }
 	int GetCursorOffset(bool Editing = false) const { return Editing ? m_FakeCursorPos : m_CursorPos; }

--- a/src/game/client/lineinput.h
+++ b/src/game/client/lineinput.h
@@ -52,8 +52,6 @@ public:
 	int GetLength(bool Editing = false) const { return Editing ? m_FakeLen : m_Len; }
 	int GetCursorOffset(bool Editing = false) const { return Editing ? m_FakeCursorPos : m_CursorPos; }
 	void SetCursorOffset(int Offset) { m_CursorPos = Offset > m_Len ? m_Len : Offset < 0 ? 0 : Offset; }
-	void DeleteUntilCursor();
-	void DeleteFromCursor();
 };
 
 #endif

--- a/src/game/client/lineinput.h
+++ b/src/game/client/lineinput.h
@@ -52,6 +52,7 @@ public:
 	void ProcessInput(IInput::CEvent e);
 	void Editing(const char *pString, int Cursor);
 	void Set(const char *pString);
+	void SetRange(const char *pString, int Begin, int End);
 	void Add(const char *pString);
 	const char *GetString(bool Editing = false) const { return Editing ? m_DisplayStr : m_aStr; }
 	int GetLength(bool Editing = false) const { return Editing ? m_FakeLen : m_Len; }

--- a/src/game/client/lineinput.h
+++ b/src/game/client/lineinput.h
@@ -53,6 +53,7 @@ public:
 	void Editing(const char *pString, int Cursor);
 	void Set(const char *pString);
 	void SetRange(const char *pString, int Begin, int End);
+	void Insert(const char *pString, int Begin);
 	void Append(const char *pString);
 	const char *GetString(bool Editing = false) const { return Editing ? m_DisplayStr : m_aStr; }
 	int GetLength(bool Editing = false) const { return Editing ? m_FakeLen : m_Len; }

--- a/src/test/str.cpp
+++ b/src/test/str.cpp
@@ -255,6 +255,43 @@ TEST(Str, StrCopyUtf8)
 	EXPECT_STREQ(aBuf, "DDNet最好了");
 }
 
+TEST(Str, Utf8Stats)
+{
+	int Size, Count;
+
+	str_utf8_stats("abc", 4, 3, &Size, &Count);
+	EXPECT_EQ(Size, 3);
+	EXPECT_EQ(Count, 3);
+
+	str_utf8_stats("abc", 2, 3, &Size, &Count);
+	EXPECT_EQ(Size, 1);
+	EXPECT_EQ(Count, 1);
+
+	str_utf8_stats("", 1, 0, &Size, &Count);
+	EXPECT_EQ(Size, 0);
+	EXPECT_EQ(Count, 0);
+
+	str_utf8_stats("abcde", 6, 5, &Size, &Count);
+	EXPECT_EQ(Size, 5);
+	EXPECT_EQ(Count, 5);
+
+	str_utf8_stats("любовь", 13, 6, &Size, &Count);
+	EXPECT_EQ(Size, 12);
+	EXPECT_EQ(Count, 6);
+
+	str_utf8_stats("abc愛", 7, 4, &Size, &Count);
+	EXPECT_EQ(Size, 6);
+	EXPECT_EQ(Count, 4);
+
+	str_utf8_stats("abc愛", 6, 4, &Size, &Count);
+	EXPECT_EQ(Size, 3);
+	EXPECT_EQ(Count, 3);
+
+	str_utf8_stats("любовь", 13, 3, &Size, &Count);
+	EXPECT_EQ(Size, 6);
+	EXPECT_EQ(Count, 3);
+}
+
 TEST(Str, StrTime)
 {
 	char aBuf[32] = "foobar";


### PR DESCRIPTION
Various refactorings and cherry-picks to `CLineInput` from the upstream PR. No issues fixed except for `CLineInput::Add` (now named `Append`) not updating `m_NumChars` before.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [X] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
