### PR TITLE
Update str_utf8_stats documentation, minor refactoring

### DIFF
--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -3458,16 +3458,13 @@ void str_utf8_stats(const char *str, int max_size, int max_count, int *size, int
 {
 	*size = 0;
 	*count = 0;
-	while(str[*size] && *size < max_size && *count < max_count)
+	while(*size < max_size && *count < max_count)
 	{
 		int new_size = str_utf8_forward(str, *size);
-		if(new_size != *size)
-		{
-			if(new_size >= max_size || *count >= max_count)
-				break;
-			*size = new_size;
-			++(*count);
-		}
+		if(new_size == *size || new_size >= max_size || *count >= max_count)
+			break;
+		*size = new_size;
+		++(*count);
 	}
 }
 

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -2091,7 +2091,7 @@ void str_utf8_copy(char *dst, const char *src, int dst_size);
 
 /*
 	Function: str_utf8_stats
-		Determines the byte size and utf8 character count of a string.
+		Determines the byte size and utf8 character count of a utf8 string.
 
 	Parameters:
 		str - Pointer to the string.
@@ -2101,8 +2101,8 @@ void str_utf8_copy(char *dst, const char *src, int dst_size);
 		count - Pointer to store count of utf8 characters of the string.
 
 	Remarks:
-		- Assumes nothing about the encoding of the string.
-		  It's the users responsibility to make sure the bounds are aligned.
+		- The string is treated as zero-terminated utf8 string.
+		- It's the user's responsibility to make sure the bounds are aligned.
 */
 void str_utf8_stats(const char *str, int max_size, int max_count, int *size, int *count);
 

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -2109,13 +2109,16 @@ void str_utf8_stats(const char *str, int max_size, int max_count, int *size, int
 /*
 	Function: str_next_token
 		Writes the next token after str into buf, returns the rest of the string.
+
 	Parameters:
 		str - Pointer to string.
 		delim - Delimiter for tokenization.
 		buffer - Buffer to store token in.
 		buffer_size - Size of the buffer.
+
 	Returns:
 		Pointer to rest of the string.
+
 	Remarks:
 		- The token is always null-terminated.
 */
@@ -2287,6 +2290,7 @@ int secure_rand_below(int below);
 /*
 	Function: set_console_msg_color
 		Sets the console color.
+
 	Parameters:
 		rgb - If NULL it will reset the console color to default, else it will transform the rgb color to a console color
 */


### PR DESCRIPTION
This removes the check for the null-terminator from the while loop, as this is also checked in `str_utf8_forward`, which returns an unchanged size in this case. The comparison `new_size != *size` was previously redundant for that reason.

Update comments and add some empty lines for consistency.

@heinrich5991 

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
