### PR TITLE
Disable connection reuse in curl (fixes #4342)

### DIFF
--- a/src/engine/client/http.cpp
+++ b/src/engine/client/http.cpp
@@ -148,6 +148,12 @@ int CRequest::RunImpl(CURL *pHandle)
 	curl_easy_setopt(pHandle, CURLOPT_PROGRESSDATA, this);
 	curl_easy_setopt(pHandle, CURLOPT_PROGRESSFUNCTION, ProgressCallback);
 
+	if(curl_version_info(CURLVERSION_NOW)->version_num < 0x076800)
+	{
+		// Causes crashes, see https://github.com/ddnet/ddnet/issues/4342
+		curl_easy_setopt(pHandle, CURLOPT_FORBID_REUSE, 1L);
+	}
+
 #ifdef CONF_PLATFORM_ANDROID
 	curl_easy_setopt(pHandle, CURLOPT_CAINFO, "data/cacert.pem");
 #endif


### PR DESCRIPTION
Thanks to @godwhoa for report and testing the workaround!

I can't test this since I can't reproduce, but @godwhoa wrote:

> With connection reuse: 5/10 runs resulted in a crash.
> Without connection reuse: 0/10 runs resulted in a crash.

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
