### PR TITLE
Remove redundant *count >= max_count check

### DIFF
--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -3461,7 +3461,7 @@ void str_utf8_stats(const char *str, int max_size, int max_count, int *size, int
 	while(*size < max_size && *count < max_count)
 	{
 		int new_size = str_utf8_forward(str, *size);
-		if(new_size == *size || new_size >= max_size || *count >= max_count)
+		if(new_size == *size || new_size >= max_size)
 			break;
 		*size = new_size;
 		++(*count);


### PR DESCRIPTION
`count` and `max_count` don't change after the check in the while loop.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
