### PR TITLE
test/serverbrowser: delete pConsole

### DIFF
--- a/src/test/serverbrowser.cpp
+++ b/src/test/serverbrowser.cpp
@@ -101,6 +101,7 @@ TEST(ServerBrowser, PingCache)
 
 	delete pPingCache;
 	delete pStorage;
+	delete pConsole;
 
 	Info.DeleteTestStorageFilesOnSuccess();
 }


### PR DESCRIPTION
```
==235823==ERROR: LeakSanitizer: detected memory leaks

Indirect leak of 65632 byte(s) in 1 object(s) allocated from:
    #0 0x563636cc2fc9 in malloc (/media/ddnet/testrunner+0x37afc9)
    #1 0x563636e0fd89 in CHeap::NewChunk() /media/ddnet/src/engine/shared/memheap.cpp:14:17
    #2 0x563636e10aee in CHeap::Reset() /media/ddnet/src/engine/shared/memheap.cpp:63:2
    #3 0x563636d954a5 in CConsole::CExecutionQueue::Reset() /media/ddnet/src/engine/shared/console.h:188:12
    #4 0x563636d4a272 in CConsole::CConsole(int) /media/ddnet/src/engine/shared/console.cpp:937:19
    #5 0x563636d88a98 in CreateConsole(int) /media/ddnet/src/engine/shared/console.cpp:1230:59
    #6 0x563636fbe915 in ServerBrowser_PingCache_Test::TestBody() /media/ddnet/src/test/serverbrowser.cpp:13:23
    #7 0x7f0a2f87fe26 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (/usr/lib/libgtest.so.1.11.0+0x54e26)
```
<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
