### PR TITLE
Try to use unique_ptr in tests so we can't forget to delete

### DIFF
--- a/src/test/datafile.cpp
+++ b/src/test/datafile.cpp
@@ -1,5 +1,6 @@
 #include "test.h"
 #include <gtest/gtest.h>
+#include <memory>
 
 #include <engine/shared/datafile.h>
 #include <engine/storage.h>
@@ -7,7 +8,7 @@
 
 TEST(Datafile, ExtendedType)
 {
-	IStorage *pStorage = CreateLocalStorage();
+	auto pStorage = std::unique_ptr<IStorage>(CreateLocalStorage());
 	CTestInfo Info;
 
 	CMapItemTest Test;
@@ -19,7 +20,7 @@ TEST(Datafile, ExtendedType)
 
 	{
 		CDataFileWriter Writer;
-		Writer.Open(pStorage, Info.m_aFilename);
+		Writer.Open(pStorage.get(), Info.m_aFilename);
 
 		Writer.AddItem(MAPITEMTYPE_TEST, 0x8000, sizeof(Test), &Test);
 
@@ -28,7 +29,7 @@ TEST(Datafile, ExtendedType)
 
 	{
 		CDataFileReader Reader;
-		Reader.Open(pStorage, Info.m_aFilename, IStorage::TYPE_ALL);
+		Reader.Open(pStorage.get(), Info.m_aFilename, IStorage::TYPE_ALL);
 
 		int Start, Num;
 		Reader.GetType(MAPITEMTYPE_TEST, &Start, &Num);
@@ -56,6 +57,4 @@ TEST(Datafile, ExtendedType)
 	{
 		pStorage->RemoveFile(Info.m_aFilename, IStorage::TYPE_SAVE);
 	}
-
-	delete pStorage;
 }

--- a/src/test/serverbrowser.cpp
+++ b/src/test/serverbrowser.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include <memory>
 
 #include <engine/client/serverbrowser_ping_cache.h>
 #include <engine/console.h>
@@ -10,9 +11,10 @@
 TEST(ServerBrowser, PingCache)
 {
 	CTestInfo Info;
-	IConsole *pConsole = CreateConsole(CFGFLAG_CLIENT);
-	IStorage *pStorage = Info.CreateTestStorage();
-	IServerBrowserPingCache *pPingCache = CreateServerBrowserPingCache(pConsole, pStorage);
+
+	auto pConsole = std::unique_ptr<IConsole>(CreateConsole(CFGFLAG_CLIENT));
+	auto pStorage = std::unique_ptr<IStorage>(Info.CreateTestStorage());
+	auto pPingCache = std::unique_ptr<IServerBrowserPingCache>(CreateServerBrowserPingCache(pConsole.get(), pStorage.get()));
 
 	const IServerBrowserPingCache::CEntry *pEntries;
 	int NumEntries;
@@ -84,8 +86,7 @@ TEST(ServerBrowser, PingCache)
 		EXPECT_EQ(pEntries[1].m_Ping, 345);
 	}
 
-	delete pPingCache;
-	pPingCache = CreateServerBrowserPingCache(pConsole, pStorage);
+	pPingCache.reset(CreateServerBrowserPingCache(pConsole.get(), pStorage.get()));
 
 	// Persistence.
 	pPingCache->Load();
@@ -98,10 +99,6 @@ TEST(ServerBrowser, PingCache)
 		EXPECT_EQ(pEntries[0].m_Ping, 1337);
 		EXPECT_EQ(pEntries[1].m_Ping, 345);
 	}
-
-	delete pPingCache;
-	delete pStorage;
-	delete pConsole;
 
 	Info.DeleteTestStorageFilesOnSuccess();
 }


### PR DESCRIPTION
Why is the PingCache test failing now???

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
