### PR TITLE
Lower chance of losing written files by syncing them to disk on close

### DIFF
--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -67,6 +67,7 @@
 #include <direct.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <io.h>
 #include <process.h>
 #include <share.h>
 #include <shellapi.h>
@@ -418,12 +419,29 @@ unsigned io_write_newline(IOHANDLE io)
 
 int io_close(IOHANDLE io)
 {
+	if(io_flush(io) != 0)
+	{
+		dbg_msg("file", "flushing stream failed: %d", errno);
+	}
+	if(io_fsync(io) != 0)
+	{
+		dbg_msg("file", "flushing file to disk failed: %d", errno);
+	}
 	return fclose((FILE *)io) != 0;
 }
 
 int io_flush(IOHANDLE io)
 {
 	return fflush((FILE *)io);
+}
+
+int io_fsync(IOHANDLE io)
+{
+#if defined(CONF_FAMILY_WINDOWS)
+	return FlushFileBuffers((HANDLE)_get_osfhandle(_fileno((FILE *)io)));
+#else
+	return fsync(fileno((FILE *)io));
+#endif
 }
 
 #define ASYNC_BUFSIZE 8 * 1024

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -304,6 +304,18 @@ int io_close(IOHANDLE io);
 int io_flush(IOHANDLE io);
 
 /*
+	Function: io_fsync
+		Synchronize file changes to disk
+
+	Parameters:
+		io - Handle to the file.
+
+	Returns:
+		Returns 0 on success.
+*/
+int io_fsync(IOHANDLE io);
+
+/*
 	Function: io_error
 		Checks whether an error occurred during I/O with the file.
 


### PR DESCRIPTION
I'm wondering if this helps. Overhead exists, but is not that much (on
my system): 333 ms for initialization instead of 311 ms

If we only want to do this for files written to, then we need to keep
track of how the file was opened.

(I'm afraid that this could cause lags since we're doing it main thread)

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
