### PR TITLE
Fix initialization of CUIEx::m_MouseSlow

### DIFF
--- a/src/game/client/ui_ex.cpp
+++ b/src/game/client/ui_ex.cpp
@@ -13,10 +13,8 @@
 
 #include <limits>
 
-CUIEx::CUIEx(CUI *pUI, IKernel *pKernel, CRenderTools *pRenderTools, IInput::CEvent *pInputEventsArray, int *pInputEventCount)
+CUIEx::CUIEx()
 {
-	Init(pUI, pKernel, pRenderTools, pInputEventsArray, pInputEventCount);
-
 	m_MouseSlow = false;
 }
 

--- a/src/game/client/ui_ex.h
+++ b/src/game/client/ui_ex.h
@@ -48,8 +48,7 @@ protected:
 	CRenderTools *RenderTools() const { return m_pRenderTools; }
 
 public:
-	CUIEx(CUI *pUI, IKernel *pKernel, CRenderTools *pRenderTools, IInput::CEvent *pInputEventsArray, int *pInputEventCount);
-	CUIEx() {}
+	CUIEx();
 
 	void Init(CUI *pUI, IKernel *pKernel, CRenderTools *pRenderTools, IInput::CEvent *pInputEventsArray, int *pInputEventCount);
 


### PR DESCRIPTION
The `CUIEx` constructor with arguments is unused and only the default constructor was used but hidden away in the header file therefore missing the initialization.

Closes #4408.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
