### PR TITLE
Swap: Don't spam-protect retrying with local messages only

### DIFF
--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -682,9 +682,6 @@ void CGameContext::ConSwap(IConsole::IResult *pResult, void *pUserData)
 	if(!pPlayer)
 		return;
 
-	if(pSelf->ProcessSpamProtection(pResult->m_ClientID))
-		return;
-
 	if(!g_Config.m_SvSwap)
 	{
 		pSelf->Console()->Print(
@@ -747,6 +744,9 @@ void CGameContext::ConSwap(IConsole::IResult *pResult, void *pUserData)
 	bool SwapPending = pSwapPlayer->m_SwapTargetsClientID != pResult->m_ClientID;
 	if(SwapPending)
 	{
+		if(pSelf->ProcessSpamProtection(pResult->m_ClientID))
+			return;
+
 		Teams.RequestTeamSwap(pPlayer, pSwapPlayer, Team);
 		return;
 	}


### PR DESCRIPTION
As suggested by 冷落:
> I have a advice./swap need wait 30s,and often someone will say /swap
> within 30 seconds,but kept saying it would be muted

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
