### PR TITLE
Don't shutdown server when there are outstanding sql queries to be executed

### DIFF
--- a/src/engine/server/databases/connection_pool.cpp
+++ b/src/engine/server/databases/connection_pool.cpp
@@ -108,12 +108,6 @@ void CDbConnectionPool::OnShutdown()
 	int i = 0;
 	while(m_Shutdown.load())
 	{
-		if(i > 600)
-		{
-			dbg_msg("sql", "Waited 60 seconds for score-threads to complete, quitting anyway");
-			break;
-		}
-
 		// print a log about every two seconds
 		if(i % 20 == 0)
 			dbg_msg("sql", "Waiting for score-threads to complete (%ds)", i / 10);


### PR DESCRIPTION
Quick fix to loose less ranks. Further fixes incoming, but I've split this out, because it is easy to review and already helpful on its own. For #4424 

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
