### PR TITLE
Pr sql fail fast

### DIFF
--- a/src/base/tl/threading.h
+++ b/src/base/tl/threading.h
@@ -2,17 +2,30 @@
 #define BASE_TL_THREADING_H
 
 #include "../system.h"
+#include <atomic>
 
 class CSemaphore
 {
 	SEMAPHORE m_Sem;
+	// implement the counter seperatly, because the `sem_getvalue`-API is
+	// deprecated on macOS: https://stackoverflow.com/a/16655541
+	std::atomic_int count;
 
 public:
 	CSemaphore() { sphore_init(&m_Sem); }
 	~CSemaphore() { sphore_destroy(&m_Sem); }
 	CSemaphore(const CSemaphore &) = delete;
-	void Wait() { sphore_wait(&m_Sem); }
-	void Signal() { sphore_signal(&m_Sem); }
+	int GetApproximateValue() { return count.load(); }
+	void Wait()
+	{
+		sphore_wait(&m_Sem);
+		count.fetch_sub(1);
+	}
+	void Signal()
+	{
+		count.fetch_add(1);
+		sphore_signal(&m_Sem);
+	}
 };
 
 class SCOPED_CAPABILITY CLock

--- a/src/engine/server/databases/connection_pool.cpp
+++ b/src/engine/server/databases/connection_pool.cpp
@@ -151,6 +151,11 @@ void CDbConnectionPool::Worker()
 		{
 			for(int i = 0; i < (int)m_aapDbConnections[Mode::READ].size(); i++)
 			{
+				if(m_Shutdown)
+				{
+					dbg_msg("sql", "%s dismissed read request during shutdown", pThreadData->m_pName);
+					break;
+				}
 				int CurServer = (ReadServer + i) % (int)m_aapDbConnections[Mode::READ].size();
 				if(ExecSqlFunc(m_aapDbConnections[Mode::READ][CurServer].get(), pThreadData.get(), false))
 				{
@@ -166,6 +171,10 @@ void CDbConnectionPool::Worker()
 		{
 			for(int i = 0; i < (int)m_aapDbConnections[Mode::WRITE].size(); i++)
 			{
+				if(m_Shutdown && !m_aapDbConnections[Mode::WRITE_BACKUP].empty()) {
+					dbg_msg("sql", "%s skipped to backup database during shutdown", pThreadData->m_pName);
+					break;
+				}
 				int CurServer = (WriteServer + i) % (int)m_aapDbConnections[Mode::WRITE].size();
 				if(ExecSqlFunc(m_aapDbConnections[Mode::WRITE][i].get(), pThreadData.get(), false))
 				{

--- a/src/engine/server/databases/connection_pool.cpp
+++ b/src/engine/server/databases/connection_pool.cpp
@@ -133,8 +133,15 @@ void CDbConnectionPool::Worker()
 	// remember last working server and try to connect to it first
 	int ReadServer = 0;
 	int WriteServer = 0;
+	// enter fail mode when a sql request fails, skip read request during it and
+	// write to the backup database until all requests are handled
+	bool FailMode = false;
 	while(1)
 	{
+		if(FailMode && m_NumElem.GetApproximateValue() == 0)
+		{
+			FailMode = false;
+		}
 		m_NumElem.Wait();
 		auto pThreadData = std::move(m_aTasks[LastElem++]);
 		// work through all database jobs after OnShutdown is called before exiting the thread
@@ -156,6 +163,11 @@ void CDbConnectionPool::Worker()
 					dbg_msg("sql", "%s dismissed read request during shutdown", pThreadData->m_pName);
 					break;
 				}
+				if(FailMode)
+				{
+					dbg_msg("sql", "%s dismissed read request during FailMode", pThreadData->m_pName);
+					break;
+				}
 				int CurServer = (ReadServer + i) % (int)m_aapDbConnections[Mode::READ].size();
 				if(ExecSqlFunc(m_aapDbConnections[Mode::READ][CurServer].get(), pThreadData.get(), false))
 				{
@@ -164,6 +176,10 @@ void CDbConnectionPool::Worker()
 					Success = true;
 					break;
 				}
+				else
+				{
+					FailMode = true;
+				}
 			}
 		}
 		break;
@@ -171,8 +187,14 @@ void CDbConnectionPool::Worker()
 		{
 			for(int i = 0; i < (int)m_aapDbConnections[Mode::WRITE].size(); i++)
 			{
-				if(m_Shutdown && !m_aapDbConnections[Mode::WRITE_BACKUP].empty()) {
+				if(m_Shutdown && !m_aapDbConnections[Mode::WRITE_BACKUP].empty())
+				{
 					dbg_msg("sql", "%s skipped to backup database during shutdown", pThreadData->m_pName);
+					break;
+				}
+				if(FailMode && !m_aapDbConnections[Mode::WRITE_BACKUP].empty())
+				{
+					dbg_msg("sql", "%s skipped to backup database during FailMode", pThreadData->m_pName);
 					break;
 				}
 				int CurServer = (WriteServer + i) % (int)m_aapDbConnections[Mode::WRITE].size();
@@ -182,6 +204,10 @@ void CDbConnectionPool::Worker()
 					dbg_msg("sql", "%s done on write database %d", pThreadData->m_pName, CurServer);
 					Success = true;
 					break;
+				}
+				else
+				{
+					FailMode = true;
 				}
 			}
 			if(!Success)

--- a/src/engine/server/databases/mysql.cpp
+++ b/src/engine/server/databases/mysql.cpp
@@ -257,9 +257,12 @@ bool CMysqlConnection::ConnectImpl()
 	}
 
 	m_pStmt = nullptr;
-	unsigned int OptConnectTimeout = 60;
-	unsigned int OptReadTimeout = 60;
-	unsigned int OptWriteTimeout = 120;
+	unsigned int OptConnectTimeout = 30;
+	unsigned int OptReadTimeout = 10;
+	// The timeout in seconds for each attempt to write to the server. There
+	// is a retry if necessary, so the total effective timeout value is two
+	// times the option value.
+	unsigned int OptWriteTimeout = 10;
 	my_bool OptReconnect = true;
 	mysql_options(&m_Mysql, MYSQL_OPT_CONNECT_TIMEOUT, &OptConnectTimeout);
 	mysql_options(&m_Mysql, MYSQL_OPT_READ_TIMEOUT, &OptReadTimeout);


### PR DESCRIPTION
Remaining changes for #4424. Improving sql write times during shutdown and slow mysql responses/timeouts. I still want to test this change, especially for the last commit. Might have time for testing this evening. Thoughts and feedback on this patchset welcome.

## Checklist

- [ ] Tested the change ingame
   - [x] in mysql mod
   - [ ] in sqlite3 mode
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
