### PR TITLE
Adopt vanilla scrollbar colors and sizes, minor code style changes

### DIFF
--- a/src/game/client/ui_ex.cpp
+++ b/src/game/client/ui_ex.cpp
@@ -45,17 +45,18 @@ void CUIEx::ConvertMouseMove(float *pX, float *pY) const
 
 float CUIEx::DoScrollbarV(const void *pID, const CUIRect *pRect, float Current)
 {
-	static float s_OffsetY;
+	Current = clamp(Current, 0.0f, 1.0f);
 
+	// layout
 	CUIRect Rail;
 	pRect->Margin(5.0f, &Rail);
 
 	CUIRect Handle;
-	Rail.HSplitTop(clamp(33.0f, Rail.h / 8.0f, Rail.h), &Handle, 0);
-	Current = clamp(Current, 0.0f, 1.0f);
+	Rail.HSplitTop(clamp(33.0f, Rail.w, Rail.h / 8.0f), &Handle, 0);
 	Handle.y = Rail.y + (Rail.h - Handle.h) * Current;
 
 	// logic
+	static float s_OffsetY;
 	const bool InsideRail = UI()->MouseInside(&Rail);
 	const bool InsideHandle = UI()->MouseInside(&Handle);
 	bool Grabbed = false; // whether to apply the offset
@@ -85,12 +86,14 @@ float CUIEx::DoScrollbarV(const void *pID, const CUIRect *pRect, float Current)
 	else if(UI()->MouseButtonClicked(0) && !InsideHandle && InsideRail)
 	{
 		UI()->SetActiveItem(pID);
-		s_OffsetY = Handle.h * 0.5f;
+		s_OffsetY = Handle.h / 2.0f;
 		Grabbed = true;
 	}
 
 	if(InsideHandle)
+	{
 		UI()->SetHotItem(pID);
+	}
 
 	float ReturnValue = Current;
 	if(Grabbed)
@@ -102,25 +105,26 @@ float CUIEx::DoScrollbarV(const void *pID, const CUIRect *pRect, float Current)
 	}
 
 	// render
-	RenderTools()->DrawUIRect(&Rail, ColorRGBA(0, 0, 0, 0.25f), CUI::CORNER_ALL, Rail.w / 2.0f);
+	RenderTools()->DrawUIRect(&Rail, ColorRGBA(1.0f, 1.0f, 1.0f, 0.25f), CUI::CORNER_ALL, Rail.w / 2.0f);
 
 	float ColorSlider;
 	if(UI()->ActiveItem() == pID)
-		ColorSlider = 1.0f;
-	else if(UI()->HotItem() == pID)
 		ColorSlider = 0.9f;
+	else if(UI()->HotItem() == pID)
+		ColorSlider = 1.0f;
 	else
-		ColorSlider = 0.75f;
+		ColorSlider = 0.8f;
 
-	RenderTools()->DrawUIRect(&Handle, ColorRGBA(ColorSlider, ColorSlider, ColorSlider, 0.75f), CUI::CORNER_ALL, Handle.w / 2.0f);
+	RenderTools()->DrawUIRect(&Handle, ColorRGBA(ColorSlider, ColorSlider, ColorSlider, 1.0f), CUI::CORNER_ALL, Handle.w / 2.0f);
 
 	return ReturnValue;
 }
 
 float CUIEx::DoScrollbarH(const void *pID, const CUIRect *pRect, float Current, const ColorRGBA *pColorInner)
 {
-	static float s_OffsetX;
+	Current = clamp(Current, 0.0f, 1.0f);
 
+	// layout
 	CUIRect Rail;
 	if(pColorInner)
 		Rail = *pRect;
@@ -128,11 +132,11 @@ float CUIEx::DoScrollbarH(const void *pID, const CUIRect *pRect, float Current, 
 		pRect->HMargin(5.0f, &Rail);
 
 	CUIRect Handle;
-	Rail.VSplitLeft(pColorInner ? 8.0f : clamp(33.0f, Rail.w / 8.0f, Rail.w), &Handle, 0);
-	Current = clamp(Current, 0.0f, 1.0f);
+	Rail.VSplitLeft(pColorInner ? 8.0f : clamp(33.0f, Rail.h, Rail.w / 8.0f), &Handle, 0);
 	Handle.x += (Rail.w - Handle.w) * Current;
 
 	// logic
+	static float s_OffsetX;
 	const bool InsideRail = UI()->MouseInside(&Rail);
 	const bool InsideHandle = UI()->MouseInside(&Handle);
 	bool Grabbed = false; // whether to apply the offset
@@ -162,12 +166,14 @@ float CUIEx::DoScrollbarH(const void *pID, const CUIRect *pRect, float Current, 
 	else if(UI()->MouseButtonClicked(0) && !InsideHandle && InsideRail)
 	{
 		UI()->SetActiveItem(pID);
-		s_OffsetX = Handle.w * 0.5f;
+		s_OffsetX = Handle.w / 2.0f;
 		Grabbed = true;
 	}
 
 	if(InsideHandle)
+	{
 		UI()->SetHotItem(pID);
+	}
 
 	float ReturnValue = Current;
 	if(Grabbed)
@@ -190,17 +196,17 @@ float CUIEx::DoScrollbarH(const void *pID, const CUIRect *pRect, float Current, 
 	}
 	else
 	{
-		RenderTools()->DrawUIRect(&Rail, ColorRGBA(0, 0, 0, 0.25f), CUI::CORNER_ALL, Rail.h / 2.0f);
+		RenderTools()->DrawUIRect(&Rail, ColorRGBA(1.0f, 1.0f, 1.0f, 0.25f), CUI::CORNER_ALL, Rail.h / 2.0f);
 
 		float ColorSlider;
 		if(UI()->ActiveItem() == pID)
-			ColorSlider = 1.0f;
-		else if(UI()->HotItem() == pID)
 			ColorSlider = 0.9f;
+		else if(UI()->HotItem() == pID)
+			ColorSlider = 1.0f;
 		else
-			ColorSlider = 0.75f;
+			ColorSlider = 0.8f;
 
-		RenderTools()->DrawUIRect(&Handle, ColorRGBA(ColorSlider, ColorSlider, ColorSlider, 0.75f), CUI::CORNER_ALL, Handle.h / 2.0f);
+		RenderTools()->DrawUIRect(&Handle, ColorRGBA(ColorSlider, ColorSlider, ColorSlider, 1.0f), CUI::CORNER_ALL, Handle.h / 2.0f);
 	}
 
 	return ReturnValue;


### PR DESCRIPTION
Adopt the vanilla color scheme for scrollbars, making the rails white instead of black for increased visibility.

Fix the calculation of the handle size, so it is consistent with vanilla, making the handles slightly smaller compared to before.

Minor refactoring / style changes.

## Screenshots (before, after)

![screenshot_2021-12-09_22-52-20](https://user-images.githubusercontent.com/23437060/145482944-2ddc1b1e-f99c-4a17-bd50-6d0d76949c2e.png)

![screenshot_2021-12-09_22-54-59](https://user-images.githubusercontent.com/23437060/145482958-67c379df-d82d-493f-92df-757a4ac78a5e.png)


## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
