### PR TITLE
Swap projectile owners when using /swap

### DIFF
--- a/src/game/client/components/items.cpp
+++ b/src/game/client/components/items.cpp
@@ -325,9 +325,10 @@ void CItems::OnRender()
 			CProjectileData Data = pProj->GetData();
 			RenderProjectile(&Data, pProj->ID());
 		}
-		for(auto *pLaser = (CLaser *)GameClient()->m_PredictedWorld.FindFirst(CGameWorld::ENTTYPE_LASER); pLaser; pLaser = (CLaser *)pLaser->NextEntity())
+		for(CEntity *pEnt = GameClient()->m_PredictedWorld.FindFirst(CGameWorld::ENTTYPE_LASER); pEnt; pEnt = pEnt->NextEntity())
 		{
-			if(pLaser->GetOwner() < 0 || !GameClient()->m_aClients[pLaser->GetOwner()].m_IsPredictedLocal)
+			auto *const pLaser = dynamic_cast<CLaser *>(pEnt);
+			if(!pLaser || pLaser->GetOwner() < 0 || !GameClient()->m_aClients[pLaser->GetOwner()].m_IsPredictedLocal)
 				continue;
 			CNetObj_Laser Data;
 			pLaser->FillInfo(&Data);
@@ -414,7 +415,7 @@ void CItems::OnRender()
 		{
 			if(UsePredicted)
 			{
-				auto *pLaser = (CLaser *)GameClient()->m_GameWorld.FindMatch(Item.m_ID, Item.m_Type, pData);
+				auto *pLaser = dynamic_cast<CLaser *>(GameClient()->m_GameWorld.FindMatch(Item.m_ID, Item.m_Type, pData));
 				if(pLaser && pLaser->GetOwner() >= 0 && GameClient()->m_aClients[pLaser->GetOwner()].m_IsPredictedLocal)
 					continue;
 			}

--- a/src/game/client/prediction/gameworld.cpp
+++ b/src/game/client/prediction/gameworld.cpp
@@ -446,14 +446,15 @@ void CGameWorld::NetObjAdd(int ObjID, int ObjType, const void *pObjData, const C
 	{
 		CLaser NetLaser = CLaser(this, ObjID, (CNetObj_Laser *)pObjData);
 		CLaser *pMatching = 0;
-		if(CLaser *pLaser = (CLaser *)GetEntity(ObjID, ENTTYPE_LASER))
+		if(CLaser *pLaser = dynamic_cast<CLaser *>(GetEntity(ObjID, ENTTYPE_LASER)))
 			if(NetLaser.Match(pLaser))
 				pMatching = pLaser;
 		if(!pMatching)
 		{
-			for(CLaser *pLaser = (CLaser *)FindFirst(CGameWorld::ENTTYPE_LASER); pLaser; pLaser = (CLaser *)pLaser->TypeNext())
+			for(CEntity *pEnt = FindFirst(CGameWorld::ENTTYPE_LASER); pEnt; pEnt = pEnt->TypeNext())
 			{
-				if(pLaser->m_ID == -1 && NetLaser.Match(pLaser))
+				auto *const pLaser = dynamic_cast<CLaser *>(pEnt);
+				if(pLaser && pLaser->m_ID == -1 && NetLaser.Match(pLaser))
 				{
 					pMatching = pLaser;
 					pMatching->m_ID = ObjID;

--- a/src/game/server/entities/laser.cpp
+++ b/src/game/server/entities/laser.cpp
@@ -285,3 +285,8 @@ void CLaser::Snap(int SnappingClient)
 	pObj->m_FromY = (int)m_From.y;
 	pObj->m_StartTick = m_EvalTick;
 }
+
+void CLaser::SwapClients(int Client1, int Client2)
+{
+	m_Owner = m_Owner == Client1 ? Client2 : m_Owner == Client2 ? Client1 : m_Owner;
+}

--- a/src/game/server/entities/laser.h
+++ b/src/game/server/entities/laser.h
@@ -7,15 +7,14 @@
 
 class CLaser : public CEntity
 {
-	friend class CGameTeams;
-
 public:
 	CLaser(CGameWorld *pGameWorld, vec2 Pos, vec2 Direction, float StartEnergy, int Owner, int Type);
 
-	virtual void Reset();
-	virtual void Tick();
-	virtual void TickPaused();
-	virtual void Snap(int SnappingClient);
+	virtual void Reset() override;
+	virtual void Tick() override;
+	virtual void TickPaused() override;
+	virtual void Snap(int SnappingClient) override;
+	virtual void SwapClients(int Client1, int Client2) override;
 
 protected:
 	bool HitCharacter(vec2 From, vec2 To);

--- a/src/game/server/entities/laser.h
+++ b/src/game/server/entities/laser.h
@@ -7,6 +7,8 @@
 
 class CLaser : public CEntity
 {
+	friend class CGameTeams;
+
 public:
 	CLaser(CGameWorld *pGameWorld, vec2 Pos, vec2 Direction, float StartEnergy, int Owner, int Type);
 

--- a/src/game/server/entities/projectile.cpp
+++ b/src/game/server/entities/projectile.cpp
@@ -357,6 +357,11 @@ void CProjectile::Snap(int SnappingClient)
 	}
 }
 
+void CProjectile::SwapClients(int Client1, int Client2)
+{
+	m_Owner = m_Owner == Client1 ? Client2 : m_Owner == Client2 ? Client1 : m_Owner;
+}
+
 // DDRace
 
 void CProjectile::SetBouncing(int Value)

--- a/src/game/server/entities/projectile.h
+++ b/src/game/server/entities/projectile.h
@@ -7,8 +7,6 @@
 
 class CProjectile : public CEntity
 {
-	friend class CGameTeams;
-
 public:
 	CProjectile(
 		CGameWorld *pGameWorld,
@@ -27,10 +25,11 @@ public:
 	vec2 GetPos(float Time);
 	void FillInfo(CNetObj_Projectile *pProj);
 
-	virtual void Reset();
-	virtual void Tick();
-	virtual void TickPaused();
-	virtual void Snap(int SnappingClient);
+	virtual void Reset() override;
+	virtual void Tick() override;
+	virtual void TickPaused() override;
+	virtual void Snap(int SnappingClient) override;
+	virtual void SwapClients(int Client1, int Client2) override;
 
 private:
 	vec2 m_Direction;

--- a/src/game/server/entities/projectile.h
+++ b/src/game/server/entities/projectile.h
@@ -7,6 +7,8 @@
 
 class CProjectile : public CEntity
 {
+	friend class CGameTeams;
+
 public:
 	CProjectile(
 		CGameWorld *pGameWorld,

--- a/src/game/server/entity.h
+++ b/src/game/server/entity.h
@@ -115,6 +115,16 @@ public:
 	virtual void Snap(int SnappingClient) {}
 
 	/*
+		Function: SwapClients
+			Called when two players have swapped their client ids.
+
+		Arguments:
+			Client1 - First client ID
+			Client2 - Second client ID
+	*/
+	virtual void SwapClients(int Client1, int Client2) {}
+
+	/*
 		Function: NetworkClipped
 			Performs a series of test to see if a client can see the
 			entity.

--- a/src/game/server/gameworld.cpp
+++ b/src/game/server/gameworld.cpp
@@ -306,6 +306,18 @@ void CGameWorld::Tick()
 	}
 }
 
+void CGameWorld::SwapClients(int Client1, int Client2)
+{
+	// update all objects
+	for(auto *pEnt : m_apFirstEntityTypes)
+		for(; pEnt;)
+		{
+			m_pNextTraverseEntity = pEnt->m_pNextTypeEntity;
+			pEnt->SwapClients(Client1, Client2);
+			pEnt = m_pNextTraverseEntity;
+		}
+}
+
 // TODO: should be more general
 //CCharacter *CGameWorld::IntersectCharacter(vec2 Pos0, vec2 Pos1, float Radius, vec2& NewPos, CEntity *pNotThis)
 CCharacter *CGameWorld::IntersectCharacter(vec2 Pos0, vec2 Pos1, float Radius, vec2 &NewPos, CCharacter *pNotThis, int CollideWith, class CCharacter *pThisOnly)

--- a/src/game/server/gameworld.h
+++ b/src/game/server/gameworld.h
@@ -58,16 +58,16 @@ public:
 	CEntity *FindFirst(int Type);
 
 	/*
-		Function: find_entities
+		Function: FindEntities
 			Finds entities close to a position and returns them in a list.
 
 		Arguments:
-			pos - Position.
-			radius - How close the entities have to be.
-			ents - Pointer to a list that should be filled with the pointers
+			Pos - Position.
+			Radius - How close the entities have to be.
+			ppEnts - Pointer to a list that should be filled with the pointers
 				to the entities.
-			max - Number of entities that fits into the ents array.
-			type - Type of the entities to find.
+			Max - Number of entities that fits into the ents array.
+			Type - Type of the entities to find.
 
 		Returns:
 			Number of entities found and added to the ents array.
@@ -79,11 +79,11 @@ public:
 			Finds the CCharacters that intersects the line. // made for types lasers=1 and doors=0
 
 		Arguments:
-			pos0 - Start position
-			pos2 - End position
-			radius - How for from the line the CCharacter is allowed to be.
-			new_pos - Intersection position
-			notthis - Entity to ignore intersecting with
+			Pos0 - Start position
+			Pos1 - End position
+			Radius - How for from the line the CCharacter is allowed to be.
+			NewPos - Intersection position
+			pNotThis - Entity to ignore intersecting with
 
 		Returns:
 			Returns a pointer to the closest hit or NULL of there is no intersection.
@@ -91,13 +91,13 @@ public:
 	//class CCharacter *IntersectCharacter(vec2 Pos0, vec2 Pos1, float Radius, vec2 &NewPos, class CEntity *pNotThis = 0);
 	class CCharacter *IntersectCharacter(vec2 Pos0, vec2 Pos1, float Radius, vec2 &NewPos, class CCharacter *pNotThis = 0, int CollideWith = -1, class CCharacter *pThisOnly = 0);
 	/*
-		Function: closest_CCharacter
+		Function: ClosestCharacter
 			Finds the closest CCharacter to a specific point.
 
 		Arguments:
-			pos - The center position.
-			radius - How far off the CCharacter is allowed to be
-			notthis - Entity to ignore
+			Pos - The center position.
+			Radius - How far off the CCharacter is allowed to be
+			ppNotThis - Entity to ignore
 
 		Returns:
 			Returns a pointer to the closest CCharacter or NULL if no CCharacter is close enough.
@@ -105,55 +105,60 @@ public:
 	class CCharacter *ClosestCharacter(vec2 Pos, float Radius, CEntity *ppNotThis);
 
 	/*
-		Function: insert_entity
+		Function: InsertEntity
 			Adds an entity to the world.
 
 		Arguments:
-			entity - Entity to add
+			pEntity - Entity to add
 	*/
 	void InsertEntity(CEntity *pEntity);
 
 	/*
-		Function: remove_entity
+		Function: RemoveEntity
 			Removes an entity from the world.
 
 		Arguments:
-			entity - Entity to remove
+			pEntity - Entity to remove
 	*/
 	void RemoveEntity(CEntity *pEntity);
 
 	/*
-		Function: snap
-			Calls snap on all the entities in the world to create
+		Function: Snap
+			Calls Snap on all the entities in the world to create
 			the snapshot.
 
 		Arguments:
-			snapping_client - ID of the client which snapshot
+			SnappingClient - ID of the client which snapshot
 			is being created.
 	*/
 	void Snap(int SnappingClient);
 
 	/*
-		Function: tick
-			Calls tick on all the entities in the world to progress
+		Function: Tick
+			Calls Tick on all the entities in the world to progress
 			the world to the next tick.
-
 	*/
 	void Tick();
+
+	/*
+		Function: SwapClients
+			Calls SwapClients on all the entities in the world to ensure that /swap
+			command is handled safely.
+	*/
+	void SwapClients(int Client1, int Client2);
 
 	// DDRace
 	void ReleaseHooked(int ClientID);
 
 	/*
-		Function: interserct_CCharacters
+		Function: IntersectedCharacters
 			Finds all CCharacters that intersect the line.
 
 		Arguments:
-			pos0 - Start position
-			pos2 - End position
-			radius - How for from the line the CCharacter is allowed to be.
-			new_pos - Intersection position
-			notthis - Entity to ignore intersecting with
+			Pos0 - Start position
+			Pos1 - End position
+			Radius - How for from the line the CCharacter is allowed to be.
+			pNotThis - Entity to ignore intersecting with
 
 		Returns:
 			Returns list with all Characters on line.

--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -891,17 +891,7 @@ void CGameTeams::SwapTeamCharacters(CPlayer *pPlayer, CPlayer *pTargetPlayer, in
 	swap(m_TeeStarted[pPlayer->GetCID()], m_TeeStarted[pTargetPlayer->GetCID()]);
 	swap(m_TeeFinished[pPlayer->GetCID()], m_TeeFinished[pTargetPlayer->GetCID()]);
 
-	for(CProjectile *pProj = (CProjectile *)GameServer()->m_World.FindFirst(CGameWorld::ENTTYPE_PROJECTILE); pProj; pProj = (CProjectile *)pProj->TypeNext())
-	{
-		pProj->m_Owner = pProj->m_Owner == pPlayer->GetCID() ? pTargetPlayer->GetCID() : pProj->m_Owner == pTargetPlayer->GetCID() ? pPlayer->GetCID() : pProj->m_Owner;
-	}
-	for(CEntity *pEnt = GameServer()->m_World.FindFirst(CGameWorld::ENTTYPE_LASER); pEnt; pEnt = pEnt->TypeNext())
-	{
-		if(auto *const pLaser = dynamic_cast<CLaser *>(pEnt))
-		{
-			pLaser->m_Owner = pLaser->m_Owner == pPlayer->GetCID() ? pTargetPlayer->GetCID() : pLaser->m_Owner == pTargetPlayer->GetCID() ? pPlayer->GetCID() : pLaser->m_Owner;
-		}
-	}
+	GameServer()->m_World.SwapClients(pPlayer->GetCID(), pTargetPlayer->GetCID());
 
 	str_format(aBuf, sizeof(aBuf),
 		"%s has swapped with %s.",

--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -5,6 +5,7 @@
 #include <engine/shared/config.h>
 
 #include "entities/character.h"
+#include "entities/projectile.h"
 #include "player.h"
 
 CGameTeams::CGameTeams(CGameContext *pGameContext) :
@@ -888,6 +889,11 @@ void CGameTeams::SwapTeamCharacters(CPlayer *pPlayer, CPlayer *pTargetPlayer, in
 
 	swap(m_TeeStarted[pPlayer->GetCID()], m_TeeStarted[pTargetPlayer->GetCID()]);
 	swap(m_TeeFinished[pPlayer->GetCID()], m_TeeFinished[pTargetPlayer->GetCID()]);
+
+	for(CProjectile *pProj = (CProjectile *)GameServer()->m_World.FindFirst(CGameWorld::ENTTYPE_PROJECTILE); pProj; pProj = (CProjectile *)pProj->TypeNext())
+	{
+		pProj->m_Owner = pProj->m_Owner == pPlayer->GetCID() ? pTargetPlayer->GetCID() : pProj->m_Owner == pTargetPlayer->GetCID() ? pPlayer->GetCID() : pProj->m_Owner;
+	}
 
 	str_format(aBuf, sizeof(aBuf),
 		"%s has swapped with %s.",

--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -5,6 +5,7 @@
 #include <engine/shared/config.h>
 
 #include "entities/character.h"
+#include "entities/laser.h"
 #include "entities/projectile.h"
 #include "player.h"
 
@@ -893,6 +894,13 @@ void CGameTeams::SwapTeamCharacters(CPlayer *pPlayer, CPlayer *pTargetPlayer, in
 	for(CProjectile *pProj = (CProjectile *)GameServer()->m_World.FindFirst(CGameWorld::ENTTYPE_PROJECTILE); pProj; pProj = (CProjectile *)pProj->TypeNext())
 	{
 		pProj->m_Owner = pProj->m_Owner == pPlayer->GetCID() ? pTargetPlayer->GetCID() : pProj->m_Owner == pTargetPlayer->GetCID() ? pPlayer->GetCID() : pProj->m_Owner;
+	}
+	for(CEntity *pEnt = GameServer()->m_World.FindFirst(CGameWorld::ENTTYPE_LASER); pEnt; pEnt = pEnt->TypeNext())
+	{
+		if(auto *const pLaser = dynamic_cast<CLaser *>(pEnt))
+		{
+			pLaser->m_Owner = pLaser->m_Owner == pPlayer->GetCID() ? pTargetPlayer->GetCID() : pLaser->m_Owner == pTargetPlayer->GetCID() ? pPlayer->GetCID() : pLaser->m_Owner;
+		}
 	}
 
 	str_format(aBuf, sizeof(aBuf),


### PR DESCRIPTION
Thanks to Soapy Sandwich for responsibly disclosing this issue.
https://user-images.githubusercontent.com/2335377/145693247-c5c1ab2e-6353-4a4a-afab-c73f2d7eebc1.mp4
/swap is currently disabled until this is merged.

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [x] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
