### PR TITLE
Pull some more refactoring from the upstream

### DIFF
--- a/src/engine/server.h
+++ b/src/engine/server.h
@@ -213,6 +213,7 @@ public:
 	virtual const char *GetAuthName(int ClientID) const = 0;
 	virtual void Kick(int ClientID, const char *pReason) = 0;
 	virtual void Ban(int ClientID, int Seconds, const char *pReason) = 0;
+	virtual void ChangeMap(const char *pMap) = 0;
 
 	virtual void DemoRecorder_HandleAutoStart() = 0;
 	virtual bool DemoRecorder_IsRecording() = 0;

--- a/src/engine/server.h
+++ b/src/engine/server.h
@@ -243,7 +243,7 @@ public:
 
 	virtual void SendMsgRaw(int ClientID, const void *pData, int Size, int Flags) = 0;
 
-	virtual char *GetMapName() const = 0;
+	virtual const char *GetMapName() const = 0;
 
 	virtual bool IsSixup(int ClientID) const = 0;
 };

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -2276,10 +2276,10 @@ void CServer::PumpNetwork(bool PacketWaiting)
 	m_Econ.Update();
 }
 
-char *CServer::GetMapName() const
+const char *CServer::GetMapName() const
 {
 	// get the name of the map without his path
-	char *pMapShortName = &g_Config.m_SvMap[0];
+	const char *pMapShortName = &g_Config.m_SvMap[0];
 	for(int i = 0; i < str_length(g_Config.m_SvMap) - 1; i++)
 	{
 		if(g_Config.m_SvMap[i] == '/' || g_Config.m_SvMap[i] == '\\')

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -287,6 +287,7 @@ void CServer::CClient::Reset()
 CServer::CServer() :
 	m_Register(false), m_RegSixup(true)
 {
+	m_pConfig = &g_Config;
 	for(int i = 0; i < MAX_CLIENTS; i++)
 		m_aDemoRecorder[i] = CDemoRecorder(&m_SnapshotDelta, true);
 	m_aDemoRecorder[MAX_CLIENTS] = CDemoRecorder(&m_SnapshotDelta, false);

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -2289,6 +2289,12 @@ const char *CServer::GetMapName() const
 	return pMapShortName;
 }
 
+void CServer::ChangeMap(const char *pMap)
+{
+	str_copy(Config()->m_SvMap, pMap, sizeof(Config()->m_SvMap));
+	m_MapReload = str_comp(Config()->m_SvMap, m_aCurrentMap) != 0;
+}
+
 int CServer::LoadMap(const char *pMapName)
 {
 	char aBuf[512];

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -362,6 +362,7 @@ public:
 
 	void PumpNetwork(bool PacketWaiting);
 
+	virtual void ChangeMap(const char *pMap);
 	const char *GetMapName() const;
 	int LoadMap(const char *pMapName);
 

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -364,7 +364,7 @@ public:
 
 	void PumpNetwork(bool PacketWaiting);
 
-	char *GetMapName() const;
+	const char *GetMapName() const;
 	int LoadMap(const char *pMapName);
 
 	void SaveDemo(int ClientID, float Time);

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -109,6 +109,7 @@ class CServer : public IServer
 public:
 	class IGameServer *GameServer() { return m_pGameServer; }
 	class CConfig *Config() { return m_pConfig; }
+	const CConfig *Config() const { return m_pConfig; }
 	class IConsole *Console() { return m_pConsole; }
 	class IStorage *Storage() { return m_pStorage; }
 	class IEngineAntibot *Antibot() { return m_pAntibot; }

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -227,15 +227,12 @@ public:
 
 	int m_RunServer;
 
-	int m_MapReload;
+	bool m_MapReload;
 	bool m_ReloadedWhenEmpty;
 	int m_RconClientID;
 	int m_RconAuthLevel;
 	int m_PrintCBIndex;
 	char m_aShutdownReason[128];
-
-	int64_t m_Lastheartbeat;
-	//static NETADDR4 master_server;
 
 	enum
 	{
@@ -414,6 +411,7 @@ public:
 	static void ConchainRconPasswordChange(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 	static void ConchainRconModPasswordChange(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 	static void ConchainRconHelperPasswordChange(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
+	static void ConchainMapUpdate(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 
 #if defined(CONF_FAMILY_UNIX)
 	static void ConchainConnLoggingServerChange(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);

--- a/src/engine/shared/console.h
+++ b/src/engine/shared/console.h
@@ -194,6 +194,8 @@ class CConsole : public IConsole
 	CCommand *FindCommand(const char *pName, int FlagMask);
 
 public:
+	CConfig *Config() { return m_pConfig; }
+
 	CConsole(int FlagMask);
 	~CConsole();
 

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -1054,7 +1054,7 @@ void CGameContext::OnTick()
 			if(PlayerExists(m_SqlRandomMapResult->m_ClientID) && m_SqlRandomMapResult->m_aMessage[0] != '\0')
 				SendChatTarget(m_SqlRandomMapResult->m_ClientID, m_SqlRandomMapResult->m_aMessage);
 			if(m_SqlRandomMapResult->m_aMap[0] != '\0')
-				str_copy(g_Config.m_SvMap, m_SqlRandomMapResult->m_aMap, sizeof(g_Config.m_SvMap));
+				Server()->ChangeMap(m_SqlRandomMapResult->m_aMap);
 			else
 				m_LastMapVote = 0;
 		}

--- a/src/game/server/gamecontroller.cpp
+++ b/src/game/server/gamecontroller.cpp
@@ -466,7 +466,7 @@ void IGameController::StartRound()
 
 void IGameController::ChangeMap(const char *pToMap)
 {
-	str_copy(g_Config.m_SvMap, pToMap, sizeof(g_Config.m_SvMap));
+	Server()->ChangeMap(pToMap);
 }
 
 void IGameController::OnReset()


### PR DESCRIPTION
The main motivation is making it easier to take (and push) patches to/from `teeworlds`

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)

I'm not that familiar with the code. Please let me know if this commit make sense or not:
https://github.com/teeworlds/teeworlds/pull/2594/commits/56900d7644c1f49aa6d085f57dd025a8f8416e5f

IIUC two other commits from https://github.com/teeworlds/teeworlds/pull/2594 are not relevant for DDNet (because we're reducing the CPU load differently).