### PR TITLE
Fix str_utf8_forward to not forward on incomplete utf8 (fixes #4463)

### DIFF
--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -3286,31 +3286,22 @@ int str_utf8_forward(const char *str, int cursor)
 		return cursor + 1;
 	else if((*buf & 0xE0) == 0xC0) /* 110xxxxx */
 	{
-		if(!buf[1])
-			return cursor + 1;
-		return cursor + 2;
+		if(buf[1])
+			return cursor + 2;
 	}
 	else if((*buf & 0xF0) == 0xE0) /* 1110xxxx */
 	{
-		if(!buf[1])
-			return cursor + 1;
-		if(!buf[2])
-			return cursor + 2;
-		return cursor + 3;
+		if(buf[1] && buf[2])
+			return cursor + 3;
 	}
 	else if((*buf & 0xF8) == 0xF0) /* 11110xxx */
 	{
-		if(!buf[1])
-			return cursor + 1;
-		if(!buf[2])
-			return cursor + 2;
-		if(!buf[3])
-			return cursor + 3;
-		return cursor + 4;
+		if(buf[1] && buf[2] && buf[3])
+			return cursor + 4;
 	}
 
 	/* invalid */
-	return cursor + 1;
+	return cursor;
 }
 
 int str_utf8_encode(char *ptr, int chr)

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -2009,6 +2009,8 @@ int str_utf8_rewind(const char *str, int cursor);
 
 	Remarks:
 		- Won't move the cursor beyond the zero termination marker
+		- Won't move the cursor forward when it encounters the zero termination in
+		  the next bytes required to decode the current Unicode codepoint.
 */
 int str_utf8_forward(const char *str, int cursor);
 

--- a/src/engine/client/text.cpp
+++ b/src/engine/client/text.cpp
@@ -264,6 +264,7 @@ class CTextRender : public IEngineTextRender
 	int WordLength(const char *pText)
 	{
 		int Length = 0;
+		int NewLength = 0;
 		while(1)
 		{
 			const char *pCursor = (pText + Length);
@@ -271,7 +272,10 @@ class CTextRender : public IEngineTextRender
 				return Length;
 			if(*pCursor == '\n' || *pCursor == '\t' || *pCursor == ' ')
 				return Length + 1;
-			Length = str_utf8_forward(pText, Length);
+			NewLength = str_utf8_forward(pText, Length);
+			if(NewLength == Length)
+				return Length;
+			Length = NewLength;
 		}
 	}
 

--- a/src/game/client/lineinput.cpp
+++ b/src/game/client/lineinput.cpp
@@ -186,9 +186,10 @@ int32_t CLineInput::Manipulate(IInput::CEvent Event, char *pStr, int StrMaxSize,
 				bool WasNonWordChar = IsNotAWordChar(pStr[CursorPos]);
 				while((!WasNonWordChar && !IsNotAWordChar(pStr[CursorPos])) || (WasNonWordChar && IsNotAWordChar(pStr[CursorPos])))
 				{
-					CursorPos = str_utf8_forward(pStr, CursorPos);
-					if(CursorPos >= Len)
+					int NewCursorPos = str_utf8_forward(pStr, CursorPos);
+					if(CursorPos >= Len || NewCursorPos == CursorPos)
 						break;
+					CursorPos = NewCursorPos;
 				}
 				Changes |= ELineInputChanges::LINE_INPUT_CHANGE_WARP_CURSOR;
 			}

--- a/src/test/str.cpp
+++ b/src/test/str.cpp
@@ -255,6 +255,15 @@ TEST(Str, StrCopyUtf8)
 	EXPECT_STREQ(aBuf, "DDNet最好了");
 }
 
+TEST(Str, StrUtf8AutoRename)
+{
+	char aNameTryBrokenEnd[16];
+	char aNameTry[16];
+	str_format(aNameTryBrokenEnd, sizeof(aNameTryBrokenEnd), "(%d)%s", 1, "Landmine地雷");
+	str_utf8_copy(aNameTry, aNameTryBrokenEnd, sizeof(aNameTry));
+	EXPECT_STREQ(aNameTry, "(1)Landmine地");
+}
+
 TEST(Str, Utf8Stats)
 {
 	int Size, Count;


### PR DESCRIPTION
<img width="1840" alt="Screenshot 2021-12-17 at 23 55 36" src="https://user-images.githubusercontent.com/2335377/146617121-0df69295-dba7-4129-bc73-a28abfdd2588.png">

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [x] Written a unit test if it works standalone, system.c especially
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [x] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
