### PR TITLE
Replace localtime by thread-safe localtime_r

### DIFF
--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -6,7 +6,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <time.h>
 
 #include "system.h"
 #if !defined(CONF_PLATFORM_MACOS)
@@ -2489,20 +2488,33 @@ int time_timestamp()
 int time_houroftheday()
 {
 	time_t time_data;
-	struct tm *time_info;
 
 	time(&time_data);
+#if defined(CONF_FAMILY_WINDOWS)
+	struct tm *time_info;
 	time_info = localtime(&time_data);
 	return time_info->tm_hour;
+#else
+	struct tm time_info;
+	localtime_r(&time_data, &time_info);
+	return time_info.tm_hour;
+#endif
 }
 
 int time_season()
 {
 	time_t time_data;
-	struct tm *time_info;
 
 	time(&time_data);
+	struct tm *time_info;
+#if defined(CONF_FAMILY_WINDOWS)
+	struct tm *time_info;
 	time_info = localtime(&time_data);
+#else
+	struct tm _time_info;
+	localtime_r(&time_data, &_time_info);
+	time_info = &_time_info;
+#endif
 
 	if((time_info->tm_mon == 11 && time_info->tm_mday == 31) || (time_info->tm_mon == 0 && time_info->tm_mday == 1))
 	{
@@ -3021,9 +3033,15 @@ int str_hex_decode(void *dst, int dst_size, const char *src)
 #endif
 void str_timestamp_ex(time_t time_data, char *buffer, int buffer_size, const char *format)
 {
+#if defined(CONF_FAMILY_WINDOWS)
 	struct tm *time_info;
 	time_info = localtime(&time_data);
 	strftime(buffer, buffer_size, format, time_info);
+#else
+	struct tm time_info;
+	localtime_r(&time_data, &time_info);
+	strftime(buffer, buffer_size, format, &time_info);
+#endif
 	buffer[buffer_size - 1] = 0; /* assure null termination */
 }
 

--- a/src/game/client/components/skins.cpp
+++ b/src/game/client/components/skins.cpp
@@ -297,9 +297,16 @@ void CSkins::OnInit()
 	if(g_Config.m_Events)
 	{
 		time_t rawtime;
-		struct tm *timeinfo;
 		std::time(&rawtime);
+		struct tm *timeinfo;
+#if defined(CONF_FAMILY_WINDOWS)
+		struct tm *timeinfo;
 		timeinfo = localtime(&rawtime);
+#else
+		struct tm _timeinfo;
+		localtime_r(&rawtime, &_timeinfo);
+		timeinfo = &_timeinfo;
+#endif
 		if(timeinfo->tm_mon == 11 && timeinfo->tm_mday >= 24 && timeinfo->tm_mday <= 26)
 		{ // Christmas
 			str_copy(m_EventSkinPrefix, "santa", sizeof(m_EventSkinPrefix));

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -81,9 +81,16 @@ void CPlayer::Reset()
 	if(g_Config.m_Events)
 	{
 		time_t rawtime;
-		struct tm *timeinfo;
 		time(&rawtime);
+		struct tm *timeinfo;
+#if defined(CONF_FAMILY_WINDOWS)
+		struct tm *timeinfo;
 		timeinfo = localtime(&rawtime);
+#else
+		struct tm _timeinfo;
+		localtime_r(&rawtime, &_timeinfo);
+		timeinfo = &_timeinfo;
+#endif
 		if((timeinfo->tm_mon == 11 && timeinfo->tm_mday == 31) || (timeinfo->tm_mon == 0 && timeinfo->tm_mday == 1))
 		{ // New Year
 			m_DefEmote = EMOTE_HAPPY;


### PR DESCRIPTION
From the man page:

The four functions asctime(), ctime(), gmtime(), and localtime()
return a pointer to static data and hence are not thread-safe.  The
thread-safe versions, asctime_r(), ctime_r(), gmtime_r(), and
localtime_r(), are specified by SUSv2.

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
