### PR TITLE
Fix joining pw-protected server via Steam (fixes #4502)

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -2969,9 +2969,7 @@ void CClient::Update()
 	Steam()->Update();
 	if(Steam()->GetConnectAddress())
 	{
-		char aAddress[NETADDR_MAXSTRSIZE];
-		net_addr_str(Steam()->GetConnectAddress(), aAddress, sizeof(aAddress), true);
-		Connect(aAddress);
+		HandleConnectAddress(Steam()->GetConnectAddress());
 		Steam()->ClearConnectAddress();
 	}
 


### PR DESCRIPTION
Tested by copying DDNet executable from package into Steam directory and running it via steam://run/412220//ger2.ddnet.tw:8001/ directly and when client is running already. (UI had another server selected)

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
