### PR TITLE
Swap: Also switch rescue tees for /r

### DIFF
--- a/src/game/server/entities/character.h
+++ b/src/game/server/entities/character.h
@@ -246,30 +246,32 @@ public:
 	int m_WeaponChangeTick;
 
 	// Setters/Getters because i don't want to modify vanilla vars access modifiers
-	int GetLastWeapon() { return m_LastWeapon; };
-	void SetLastWeapon(int LastWeap) { m_LastWeapon = LastWeap; };
-	int GetActiveWeapon() { return m_Core.m_ActiveWeapon; };
-	void SetActiveWeapon(int ActiveWeap) { m_Core.m_ActiveWeapon = ActiveWeap; };
-	void SetLastAction(int LastAction) { m_LastAction = LastAction; };
-	int GetArmor() { return m_Armor; };
-	void SetArmor(int Armor) { m_Armor = Armor; };
-	CCharacterCore GetCore() { return m_Core; };
-	void SetCore(CCharacterCore Core) { m_Core = Core; };
-	CCharacterCore *Core() { return &m_Core; };
-	bool GetWeaponGot(int Type) { return m_aWeapons[Type].m_Got; };
-	void SetWeaponGot(int Type, bool Value) { m_aWeapons[Type].m_Got = Value; };
-	int GetWeaponAmmo(int Type) { return m_aWeapons[Type].m_Ammo; };
-	void SetWeaponAmmo(int Type, int Value) { m_aWeapons[Type].m_Ammo = Value; };
-	bool IsAlive() { return m_Alive; };
-	void SetNinjaActivationDir(vec2 ActivationDir) { m_Ninja.m_ActivationDir = ActivationDir; };
-	void SetNinjaActivationTick(int ActivationTick) { m_Ninja.m_ActivationTick = ActivationTick; };
-	void SetNinjaCurrentMoveTime(int CurrentMoveTime) { m_Ninja.m_CurrentMoveTime = CurrentMoveTime; };
+	int GetLastWeapon() { return m_LastWeapon; }
+	void SetLastWeapon(int LastWeap) { m_LastWeapon = LastWeap; }
+	int GetActiveWeapon() { return m_Core.m_ActiveWeapon; }
+	void SetActiveWeapon(int ActiveWeap) { m_Core.m_ActiveWeapon = ActiveWeap; }
+	void SetLastAction(int LastAction) { m_LastAction = LastAction; }
+	int GetArmor() { return m_Armor; }
+	void SetArmor(int Armor) { m_Armor = Armor; }
+	CCharacterCore GetCore() { return m_Core; }
+	void SetCore(CCharacterCore Core) { m_Core = Core; }
+	CCharacterCore *Core() { return &m_Core; }
+	bool GetWeaponGot(int Type) { return m_aWeapons[Type].m_Got; }
+	void SetWeaponGot(int Type, bool Value) { m_aWeapons[Type].m_Got = Value; }
+	int GetWeaponAmmo(int Type) { return m_aWeapons[Type].m_Ammo; }
+	void SetWeaponAmmo(int Type, int Value) { m_aWeapons[Type].m_Ammo = Value; }
+	bool IsAlive() { return m_Alive; }
+	void SetNinjaActivationDir(vec2 ActivationDir) { m_Ninja.m_ActivationDir = ActivationDir; }
+	void SetNinjaActivationTick(int ActivationTick) { m_Ninja.m_ActivationTick = ActivationTick; }
+	void SetNinjaCurrentMoveTime(int CurrentMoveTime) { m_Ninja.m_CurrentMoveTime = CurrentMoveTime; }
 
 	int GetLastAction() const { return m_LastAction; }
 
-	bool HasTelegunGun() { return m_Core.m_HasTelegunGun; };
-	bool HasTelegunGrenade() { return m_Core.m_HasTelegunGrenade; };
-	bool HasTelegunLaser() { return m_Core.m_HasTelegunLaser; };
+	bool HasTelegunGun() { return m_Core.m_HasTelegunGun; }
+	bool HasTelegunGrenade() { return m_Core.m_HasTelegunGrenade; }
+	bool HasTelegunLaser() { return m_Core.m_HasTelegunLaser; }
+
+	CSaveTee &GetRescueTeeRef() { return m_RescueTee; }
 };
 
 enum

--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -890,6 +890,7 @@ void CGameTeams::SwapTeamCharacters(CPlayer *pPlayer, CPlayer *pTargetPlayer, in
 
 	swap(m_TeeStarted[pPlayer->GetCID()], m_TeeStarted[pTargetPlayer->GetCID()]);
 	swap(m_TeeFinished[pPlayer->GetCID()], m_TeeFinished[pTargetPlayer->GetCID()]);
+	swap(pPlayer->GetCharacter()->GetRescueTeeRef(), pTargetPlayer->GetCharacter()->GetRescueTeeRef());
 
 	GameServer()->m_World.SwapClients(pPlayer->GetCID(), pTargetPlayer->GetCID());
 


### PR DESCRIPTION
As reported by cheeser0613:

2player, 1die in freeze
swap 2 player by /swap
the other 1 also go die in freeze
/practice
one of them cant use /r

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
