### PR TITLE
Switch new players to DDNet config dir, support Teeworlds as fallback

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2670,6 +2670,8 @@ set(CPACK_GEN_FILES
 
 if(TARGET_OS STREQUAL "windows")
   list(APPEND CPACK_FILES other/config_directory.bat)
+else()
+  list(APPEND CPACK_FILES other/config_directory.sh)
 endif()
 
 if(NOT DEV)

--- a/other/config_directory.bat
+++ b/other/config_directory.bat
@@ -1,1 +1,5 @@
-@start explorer %APPDATA%\Teeworlds
+if exist %APPDATA%\DDNet\ (
+	@start explorer %APPDATA%\DDNet\
+) else (
+	@start explorer %APPDATA%\Teeworlds\
+)

--- a/other/config_directory.sh
+++ b/other/config_directory.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+case "$(uname -s)" in
+	CYGWIN*|MINGW*|MSYS*)
+		if [ -d "$APPDATA/DDNet/" ]; then
+			explorer "$APPDATA/DDNet/"
+		else
+			explorer "$APPDATA/Teeworlds/"
+		fi;;
+	Darwin*)
+		if [ -d "$HOME/Library/Application Support/DDNet/" ]; then
+			open "$HOME/Library/Application Support/DDNet/"
+		else
+			open "$HOME/Library/Application Support/Teeworlds/"
+		fi;;
+	*)
+		if [ -d "$HOME/.ddnet/" ]; then
+			xdg-open "$HOME/.ddnet/"
+		else
+			xdg-open "$HOME/.teeworlds/"
+		fi;;
+esac

--- a/other/config_directory.sh
+++ b/other/config_directory.sh
@@ -13,8 +13,9 @@ case "$(uname -s)" in
 			open "$HOME/Library/Application Support/Teeworlds/"
 		fi;;
 	*)
-		if [ -d "$HOME/.ddnet/" ]; then
-			xdg-open "$HOME/.ddnet/"
+		DATA_HOME="${XDG_DATA_HOME:-$HOME/.local/share}"
+		if [ -d "$DATA_HOME/ddnet/" ]; then
+			xdg-open "$DATA_HOME/ddnet/"
 		else
 			xdg-open "$HOME/.teeworlds/"
 		fi;;

--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -2346,14 +2346,23 @@ int fs_storage_path(const char *appname, char *path, int max)
 
 #if defined(CONF_PLATFORM_HAIKU)
 	str_format(path, max, "%s/config/settings/%s", home, appname);
-	return 0;
-#endif
-
-#if defined(CONF_PLATFORM_MACOS)
+#elif defined(CONF_PLATFORM_MACOS)
 	str_format(path, max, "%s/Library/Application Support/%s", home, appname);
 #else
-	str_format(path, max, "%s/.%s", home, appname);
-	for(int i = str_length(home) + 2; path[i]; i++)
+	if(str_comp(appname, "Teeworlds") == 0)
+	{
+		// fallback for old directory for Teeworlds compatibility
+		str_format(path, max, "%s/.%s", home, appname);
+	}
+	else
+	{
+		char *data_home = getenv("XDG_DATA_HOME");
+		if(data_home)
+			str_format(path, max, "%s/%s", data_home, appname);
+		else
+			str_format(path, max, "%s/.local/share/%s", home, appname);
+	}
+	for(int i = str_length(path) - str_length(appname); path[i]; i++)
 		path[i] = tolower((unsigned char)path[i]);
 #endif
 

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -1799,7 +1799,7 @@ int fs_rename(const char *oldname, const char *newname);
 		modified - Pointer to time_t
 
 	Returns:
-		0 on success non-zero on failure
+		0 on success, non-zero on failure
 
 	Remarks:
 		- Returned time is in seconds since UNIX Epoch

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -4325,7 +4325,7 @@ int main(int argc, const char **argv)
 	// create the components
 	IEngine *pEngine = CreateEngine(GAME_NAME, Silent, 2);
 	IConsole *pConsole = CreateConsole(CFGFLAG_CLIENT);
-	IStorage *pStorage = CreateStorage("Teeworlds", IStorage::STORAGETYPE_CLIENT, argc, (const char **)argv);
+	IStorage *pStorage = CreateStorage(IStorage::STORAGETYPE_CLIENT, argc, (const char **)argv);
 	IConfigManager *pConfigManager = CreateConfigManager();
 	IEngineSound *pEngineSound = CreateEngineSound();
 	IEngineInput *pEngineInput = CreateEngineInput();

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -3646,7 +3646,7 @@ int main(int argc, const char **argv)
 	IGameServer *pGameServer = CreateGameServer();
 	IConsole *pConsole = CreateConsole(CFGFLAG_SERVER | CFGFLAG_ECON);
 	IEngineMasterServer *pEngineMasterServer = CreateEngineMasterServer();
-	IStorage *pStorage = CreateStorage("Teeworlds", IStorage::STORAGETYPE_SERVER, argc, argv);
+	IStorage *pStorage = CreateStorage(IStorage::STORAGETYPE_SERVER, argc, argv);
 	IConfigManager *pConfigManager = CreateConfigManager();
 	IEngineAntibot *pEngineAntibot = CreateEngineAntibot();
 

--- a/src/engine/shared/storage.cpp
+++ b/src/engine/shared/storage.cpp
@@ -60,7 +60,7 @@ public:
 		}
 
 		// add save directories
-		if(StorageType != STORAGETYPE_BASIC && m_NumPaths && (!m_aaStoragePaths[TYPE_SAVE][0] || !fs_makedir(m_aaStoragePaths[TYPE_SAVE])))
+		if(StorageType != STORAGETYPE_BASIC && m_NumPaths && (!m_aaStoragePaths[TYPE_SAVE][0] || !fs_makedir_rec_for(m_aaStoragePaths[TYPE_SAVE]) || !fs_makedir(m_aaStoragePaths[TYPE_SAVE])))
 		{
 			char aPath[IO_MAX_PATH_LENGTH];
 			if(StorageType == STORAGETYPE_CLIENT)

--- a/src/engine/shared/storage.cpp
+++ b/src/engine/shared/storage.cpp
@@ -28,10 +28,17 @@ public:
 		m_aUserdir[0] = 0;
 	}
 
-	int Init(const char *pApplicationName, int StorageType, int NumArgs, const char **ppArguments)
+	int Init(int StorageType, int NumArgs, const char **ppArguments)
 	{
 		// get userdir
-		fs_storage_path(pApplicationName, m_aUserdir, sizeof(m_aUserdir));
+		char aFallbackUserdir[IO_MAX_PATH_LENGTH];
+		fs_storage_path("DDNet", m_aUserdir, sizeof(m_aUserdir));
+		fs_storage_path("Teeworlds", aFallbackUserdir, sizeof(aFallbackUserdir));
+
+		if(!fs_is_dir(m_aUserdir) && fs_is_dir(aFallbackUserdir))
+		{
+			str_copy(m_aUserdir, aFallbackUserdir, sizeof(m_aUserdir));
+		}
 
 		// get datadir
 		FindDatadir(ppArguments[0]);
@@ -559,10 +566,10 @@ public:
 		return pBuffer;
 	}
 
-	static IStorage *Create(const char *pApplicationName, int StorageType, int NumArgs, const char **ppArguments)
+	static IStorage *Create(int StorageType, int NumArgs, const char **ppArguments)
 	{
 		CStorage *p = new CStorage();
-		if(p && p->Init(pApplicationName, StorageType, NumArgs, ppArguments))
+		if(p && p->Init(StorageType, NumArgs, ppArguments))
 		{
 			dbg_msg("storage", "initialisation failed");
 			delete p;
@@ -600,9 +607,9 @@ const char *IStorage::FormatTmpPath(char *aBuf, unsigned BufSize, const char *pP
 	return aBuf;
 }
 
-IStorage *CreateStorage(const char *pApplicationName, int StorageType, int NumArgs, const char **ppArguments)
+IStorage *CreateStorage(int StorageType, int NumArgs, const char **ppArguments)
 {
-	return CStorage::Create(pApplicationName, StorageType, NumArgs, ppArguments);
+	return CStorage::Create(StorageType, NumArgs, ppArguments);
 }
 
 IStorage *CreateLocalStorage()

--- a/src/engine/shared/storage.cpp
+++ b/src/engine/shared/storage.cpp
@@ -60,7 +60,7 @@ public:
 		}
 
 		// add save directories
-		if(StorageType != STORAGETYPE_BASIC && m_NumPaths && (!m_aaStoragePaths[TYPE_SAVE][0] || !fs_makedir_rec_for(m_aaStoragePaths[TYPE_SAVE]) || !fs_makedir(m_aaStoragePaths[TYPE_SAVE])))
+		if(StorageType != STORAGETYPE_BASIC && m_NumPaths && (!m_aaStoragePaths[TYPE_SAVE][0] || fs_makedir_rec_for(m_aaStoragePaths[TYPE_SAVE]) || !fs_makedir(m_aaStoragePaths[TYPE_SAVE])))
 		{
 			char aPath[IO_MAX_PATH_LENGTH];
 			if(StorageType == STORAGETYPE_CLIENT)

--- a/src/engine/storage.h
+++ b/src/engine/storage.h
@@ -42,7 +42,7 @@ public:
 	static const char *FormatTmpPath(char *aBuf, unsigned BufSize, const char *pPath);
 };
 
-extern IStorage *CreateStorage(const char *pApplicationName, int StorageType, int NumArgs, const char **ppArguments);
+extern IStorage *CreateStorage(int StorageType, int NumArgs, const char **ppArguments);
 extern IStorage *CreateLocalStorage();
 extern IStorage *CreateTempStorage(const char *pDirectory);
 

--- a/src/mastersrv/main_mastersrv.cpp
+++ b/src/mastersrv/main_mastersrv.cpp
@@ -333,7 +333,7 @@ int main(int argc, const char **argv)
 	mem_copy(m_CountDataLegacy.m_Header, SERVERBROWSE_COUNT_LEGACY, sizeof(SERVERBROWSE_COUNT_LEGACY));
 
 	IKernel *pKernel = IKernel::Create();
-	IStorage *pStorage = CreateStorage("Teeworlds", IStorage::STORAGETYPE_BASIC, argc, argv);
+	IStorage *pStorage = CreateStorage(IStorage::STORAGETYPE_BASIC, argc, argv);
 	IConfigManager *pConfigManager = CreateConfigManager();
 	m_pConsole = CreateConsole(CFGFLAG_MASTER);
 

--- a/src/tools/dummy_map.cpp
+++ b/src/tools/dummy_map.cpp
@@ -75,7 +75,7 @@ int main(int argc, const char **argv)
 {
 	cmdline_fix(&argc, &argv);
 	dbg_logger_stdout();
-	IStorage *pStorage = CreateStorage("Teeworlds", IStorage::STORAGETYPE_SERVER, argc, argv);
+	IStorage *pStorage = CreateStorage(IStorage::STORAGETYPE_SERVER, argc, argv);
 	CreateEmptyMap(pStorage);
 	cmdline_free(argc, argv);
 	return 0;

--- a/src/tools/map_convert_07.cpp
+++ b/src/tools/map_convert_07.cpp
@@ -138,7 +138,7 @@ int main(int argc, const char **argv)
 	cmdline_fix(&argc, &argv);
 	dbg_logger_stdout();
 
-	IStorage *pStorage = CreateStorage("Teeworlds", IStorage::STORAGETYPE_BASIC, argc, argv);
+	IStorage *pStorage = CreateStorage(IStorage::STORAGETYPE_BASIC, argc, argv);
 
 	if(argc < 2 || argc > 3)
 	{

--- a/src/tools/map_optimize.cpp
+++ b/src/tools/map_optimize.cpp
@@ -81,7 +81,7 @@ int main(int argc, const char **argv)
 	cmdline_fix(&argc, &argv);
 	dbg_logger_stdout();
 
-	IStorage *pStorage = CreateStorage("Teeworlds", IStorage::STORAGETYPE_BASIC, argc, argv);
+	IStorage *pStorage = CreateStorage(IStorage::STORAGETYPE_BASIC, argc, argv);
 	int ID = 0, Type = 0, Size;
 	void *pPtr;
 	char aFileName[IO_MAX_PATH_LENGTH];

--- a/src/tools/map_replace_image.cpp
+++ b/src/tools/map_replace_image.cpp
@@ -113,7 +113,7 @@ int main(int argc, const char **argv)
 	cmdline_fix(&argc, &argv);
 	dbg_logger_stdout();
 
-	IStorage *pStorage = CreateStorage("Teeworlds", IStorage::STORAGETYPE_BASIC, argc, argv);
+	IStorage *pStorage = CreateStorage(IStorage::STORAGETYPE_BASIC, argc, argv);
 
 	if(argc != 5)
 	{

--- a/src/tools/map_resave.cpp
+++ b/src/tools/map_resave.cpp
@@ -7,7 +7,7 @@
 int main(int argc, const char **argv)
 {
 	cmdline_fix(&argc, &argv);
-	IStorage *pStorage = CreateStorage("Teeworlds", IStorage::STORAGETYPE_BASIC, argc, argv);
+	IStorage *pStorage = CreateStorage(IStorage::STORAGETYPE_BASIC, argc, argv);
 	int Index, ID = 0, Type = 0, Size;
 	void *pPtr;
 	char aFileName[IO_MAX_PATH_LENGTH];

--- a/storage.cfg
+++ b/storage.cfg
@@ -1,5 +1,5 @@
 ####
-# This specifies where and in which order Teeworlds looks
+# This specifies where and in which order DDNet looks
 # for its data (sounds, skins, ...). The search goes top
 # down which means the first path has the highest priority.
 # Furthermore the top entry also defines the save path where
@@ -7,8 +7,9 @@
 # There are 3 special paths available:
 #	$USERDIR
 #	- ~/.appname on UNIX based systems
-#	- ~/Library/Applications Support/appname on macOS
+#	- ~/Library/Applications Support/Appname on macOS
 #	- %APPDATA%/Appname on Windows based systems
+#	Appname is DDNet, if that doesn't exist Teeworlds is used as a fallback
 #	$DATADIR
 #	- the 'data' directory which is part of an official
 #	release

--- a/storage.cfg
+++ b/storage.cfg
@@ -6,10 +6,10 @@
 # all data (settings.cfg, screenshots, ...) are stored.
 # There are 3 special paths available:
 #	$USERDIR
-#	- ~/.appname on UNIX based systems
+#	- $XDG_DATA_HOME/appname (Usually ~/.local/share/appname) on UNIX based systems
 #	- ~/Library/Applications Support/Appname on macOS
 #	- %APPDATA%/Appname on Windows based systems
-#	Appname is DDNet, if that doesn't exist Teeworlds is used as a fallback
+#	Appname is DDNet, if that doesn't exist but Teeworlds does, it is used as a fallback
 #	$DATADIR
 #	- the 'data' directory which is part of an official
 #	release


### PR DESCRIPTION
This way new players will get DDNet directory, old ones can switch
directory if they want, or keep using the old one.

If we ever enforce a switch in a future version, this will make it
easier since older DDNet versions will also support the DDNet directory
already.

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
