### PR TITLE
Fix local shellcheck warnings in android/files/build.sh

### DIFF
--- a/scripts/android/files/build.sh
+++ b/scripts/android/files/build.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 
-[ x"$1" == x ] && {
+[ "$1" == "" ] && {
     printf '\e[31mDid not pass ANDROID_SDK_ROOT to build script\e[30m\n'
 	exit 1
 }
 
-[ x"$2" == x ] && {
+[ "$2" == "" ] && {
     printf '\e[31mDid not pass APK name to build script\e[30m\n'
 	exit 1
 }
 
-[ x"$3" == x ] && {
+[ "$3" == "" ] && {
     printf '\e[31mDid not pass build type to build script\e[30m\n'
 	exit 1
 }


### PR DESCRIPTION
```
In ./scripts/android/files/build.sh line 3:
[ x"$1" == x ] && {
  ^---^ SC2268 (style): Avoid x-prefix in comparisons as it no longer serves a purpose.

Did you mean:
[ "$1" == "" ] && {
```
<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
