### PR TITLE
Revert "Use temporary file when saving editor file (fixes #4476)"

### DIFF
--- a/src/game/editor/io.cpp
+++ b/src/game/editor/io.cpp
@@ -221,15 +221,13 @@ int CEditor::Save(const char *pFilename)
 
 int CEditorMap::Save(class IStorage *pStorage, const char *pFileName)
 {
-	char aFileNameTmp[IO_MAX_PATH_LENGTH];
-	str_format(aFileNameTmp, sizeof(aFileNameTmp), "%s.%d.tmp", pFileName, pid());
-	char aBuf[IO_MAX_PATH_LENGTH];
-	str_format(aBuf, sizeof(aBuf), "saving to '%s'...", aFileNameTmp);
+	char aBuf[256];
+	str_format(aBuf, sizeof(aBuf), "saving to '%s'...", pFileName);
 	m_pEditor->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "editor", aBuf);
 	CDataFileWriter df;
-	if(!df.Open(pStorage, aFileNameTmp))
+	if(!df.Open(pStorage, pFileName))
 	{
-		str_format(aBuf, sizeof(aBuf), "failed to open file '%s'...", aFileNameTmp);
+		str_format(aBuf, sizeof(aBuf), "failed to open file '%s'...", pFileName);
 		m_pEditor->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "editor", aBuf);
 		return 0;
 	}
@@ -554,13 +552,6 @@ int CEditorMap::Save(class IStorage *pStorage, const char *pFileName)
 	// finish the data file
 	df.Finish();
 	m_pEditor->Console()->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "editor", "saving done");
-
-	str_format(aBuf, sizeof(aBuf), "moving '%s' to '%s'", aFileNameTmp, pFileName);
-	m_pEditor->Console()->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "editor", aBuf);
-	if(!pStorage->RenameFile(aFileNameTmp, pFileName, IStorage::TYPE_SAVE))
-	{
-		return 0;
-	}
 
 	// send rcon.. if we can
 	if(m_pEditor->Client()->RconAuthed())


### PR DESCRIPTION
Doesn't work on Windows, not so easy to overwrite a file already open in
editor. Not sure how our old approach works, but apparently it did
better than the new one. As reported by texnonik on Discord

This reverts commit e2084e1e9dff6f6e816ac63f02c49fb8ae9178b2.

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
