### PR TITLE
Fix invalid downcast to CCharacter

### DIFF
--- a/src/game/client/prediction/gameworld.cpp
+++ b/src/game/client/prediction/gameworld.cpp
@@ -144,12 +144,15 @@ void CGameWorld::RemoveEntity(CEntity *pEnt)
 
 	if(pEnt->m_ObjType == ENTTYPE_CHARACTER)
 	{
-		CCharacter *pChar = (CCharacter *)pEnt;
-		int ID = pChar->GetCID();
-		if(ID >= 0 && ID < MAX_CLIENTS)
+		CCharacter *pChar = dynamic_cast<CCharacter *>(pEnt);
+		if(pChar)
 		{
-			m_apCharacters[ID] = 0;
-			m_Core.m_apCharacters[ID] = 0;
+			int ID = pChar->GetCID();
+			if(ID >= 0 && ID < MAX_CLIENTS)
+			{
+				m_apCharacters[ID] = 0;
+				m_Core.m_apCharacters[ID] = 0;
+			}
 		}
 	}
 


### PR DESCRIPTION
```
/Users/deen/git/ddnet/src/game/client/prediction/gameworld.cpp:147:23: runtime error: downcast of address 0x000144c98d80 which does not point to an object of type 'CCharacter'
0x000144c98d80: note: object is of type 'CEntity'
 00 00 00 00  b0 41 6f 05 01 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  40 89 15 0d
              ^~~~~~~~~~~~~~~~~~~~~~~
              vptr for 'CEntity'

/Users/deen/git/ddnet/src/game/client/prediction/gameworld.cpp:148:19: runtime error: member call on address 0x000144c98d80 which does not point to an object of type 'CCharacter'
0x000144c98d80: note: object is of type 'CEntity'
 00 00 00 00  b0 41 6f 05 01 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  40 89 15 0d
              ^~~~~~~~~~~~~~~~~~~~~~~
              vptr for 'CEntity'
```
<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
