### PR TITLE
Try to fix SDL2 assertion failure (fixes #4434)

### DIFF
--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -1160,12 +1160,12 @@ int CGraphicsBackend_SDL_OpenGL::GetWindowScreen()
 
 int CGraphicsBackend_SDL_OpenGL::WindowActive()
 {
-	return SDL_GetWindowFlags(m_pWindow) & SDL_WINDOW_INPUT_FOCUS;
+	return m_pWindow && SDL_GetWindowFlags(m_pWindow) & SDL_WINDOW_INPUT_FOCUS;
 }
 
 int CGraphicsBackend_SDL_OpenGL::WindowOpen()
 {
-	return SDL_GetWindowFlags(m_pWindow) & SDL_WINDOW_SHOWN;
+	return m_pWindow && SDL_GetWindowFlags(m_pWindow) & SDL_WINDOW_SHOWN;
 }
 
 void CGraphicsBackend_SDL_OpenGL::SetWindowGrab(bool Grab)
@@ -1176,35 +1176,35 @@ void CGraphicsBackend_SDL_OpenGL::SetWindowGrab(bool Grab)
 void CGraphicsBackend_SDL_OpenGL::ResizeWindow(int w, int h, int RefreshRate)
 {
 	// don't call resize events when the window is at fullscreen desktop
-	if((SDL_GetWindowFlags(m_pWindow) & SDL_WINDOW_FULLSCREEN_DESKTOP) != SDL_WINDOW_FULLSCREEN_DESKTOP)
+	if(!m_pWindow || (SDL_GetWindowFlags(m_pWindow) & SDL_WINDOW_FULLSCREEN_DESKTOP) == SDL_WINDOW_FULLSCREEN_DESKTOP)
+		return;
+
+	// if the window is at fullscreen use SDL_SetWindowDisplayMode instead, suggested by SDL
+	if(SDL_GetWindowFlags(m_pWindow) & SDL_WINDOW_FULLSCREEN)
 	{
-		// if the window is at fullscreen use SDL_SetWindowDisplayMode instead, suggested by SDL
-		if(SDL_GetWindowFlags(m_pWindow) & SDL_WINDOW_FULLSCREEN)
-		{
 #ifdef CONF_PLATFORM_WINDOWS
-			// in windows make the window windowed mode first, this prevents strange window glitches (other games probably do something similar)
-			SetWindowParams(0, 1);
+		// in windows make the window windowed mode first, this prevents strange window glitches (other games probably do something similar)
+		SetWindowParams(0, 1);
 #endif
-			SDL_DisplayMode SetMode = {};
-			SDL_DisplayMode ClosestMode = {};
-			SetMode.format = 0;
-			SetMode.w = w;
-			SetMode.h = h;
-			SetMode.refresh_rate = RefreshRate;
-			SDL_SetWindowDisplayMode(m_pWindow, SDL_GetClosestDisplayMode(g_Config.m_GfxScreen, &SetMode, &ClosestMode));
+		SDL_DisplayMode SetMode = {};
+		SDL_DisplayMode ClosestMode = {};
+		SetMode.format = 0;
+		SetMode.w = w;
+		SetMode.h = h;
+		SetMode.refresh_rate = RefreshRate;
+		SDL_SetWindowDisplayMode(m_pWindow, SDL_GetClosestDisplayMode(g_Config.m_GfxScreen, &SetMode, &ClosestMode));
 #ifdef CONF_PLATFORM_WINDOWS
-			// now change it back to fullscreen, this will restore the above set state, bcs SDL saves fullscreen modes appart from other video modes (as of SDL 2.0.16)
-			// see implementation of SDL_SetWindowDisplayMode
-			SetWindowParams(1, 0);
+		// now change it back to fullscreen, this will restore the above set state, bcs SDL saves fullscreen modes appart from other video modes (as of SDL 2.0.16)
+		// see implementation of SDL_SetWindowDisplayMode
+		SetWindowParams(1, 0);
 #endif
-		}
-		else
-		{
-			SDL_SetWindowSize(m_pWindow, w, h);
-			if(SDL_GetWindowFlags(m_pWindow) & SDL_WINDOW_MAXIMIZED)
-				// remove maximize flag
-				SDL_RestoreWindow(m_pWindow);
-		}
+	}
+	else
+	{
+		SDL_SetWindowSize(m_pWindow, w, h);
+		if(SDL_GetWindowFlags(m_pWindow) & SDL_WINDOW_MAXIMIZED)
+			// remove maximize flag
+			SDL_RestoreWindow(m_pWindow);
 	}
 }
 


### PR DESCRIPTION
I can't really reproduce it:

Assertion failure at SDL_GetWindowFlags_REAL (/home/deen/isos/ddnet/debian6/root/mac64/SDL2-2.0.16/src/video/SDL_video.c:1905), triggered 1 time:
'window && window->magic == &_this->window_magic'

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
