### PR TITLE
Explicitly disable notch area for fullscreen on macOS (fixes #4533)

### DIFF
--- a/other/bundle/client/Info.plist.in
+++ b/other/bundle/client/Info.plist.in
@@ -20,5 +20,7 @@
 		<string>org.DDNetClient.app</string>
 		<key>NSHighResolutionCapable</key>
 		<true/>
+		<key>NSPrefersDisplaySafeAreaCompatibilityMode</key>
+		<true/>
 	</dict>
 </plist>


### PR DESCRIPTION
See https://developer.apple.com/documentation/bundleresources/information_property_list/nsprefersdisplaysafeareacompatibilitymode?language=objc

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
