### PR TITLE
Fix argument order in test, use constant

### DIFF
--- a/src/engine/shared/packer.cpp
+++ b/src/engine/shared/packer.cpp
@@ -19,7 +19,7 @@ void CPacker::AddInt(int i)
 		return;
 
 	// make sure that we have space enough
-	if(m_pEnd - m_pCurrent < 6)
+	if(m_pEnd - m_pCurrent <= CVariableInt::MAX_BYTES_PACKED)
 	{
 		dbg_break();
 		m_Error = 1;

--- a/src/engine/shared/snapshot.cpp
+++ b/src/engine/shared/snapshot.cpp
@@ -185,7 +185,7 @@ void CSnapshotDelta::UndiffItem(int *pPast, int *pDiff, int *pOut, int Size)
 			m_aSnapshotDataRate[m_SnapshotCurrent] += 1;
 		else
 		{
-			unsigned char aBuf[16];
+			unsigned char aBuf[CVariableInt::MAX_BYTES_PACKED];
 			unsigned char *pEnd = CVariableInt::Pack(aBuf, *pDiff);
 			m_aSnapshotDataRate[m_SnapshotCurrent] += (int)(pEnd - (unsigned char *)aBuf) * 8;
 		}

--- a/src/test/compression.cpp
+++ b/src/test/compression.cpp
@@ -48,7 +48,7 @@ TEST(CVariableInt, RoundtripCompressDecompress)
 	ASSERT_EQ(DecompressedSize, sizeof(DATA));
 	for(int i = 0; i < NUM; i++)
 	{
-		EXPECT_EQ(DATA[i], aDecompressed[i]);
+		EXPECT_EQ(aDecompressed[i], DATA[i]);
 	}
 }
 


### PR DESCRIPTION
- Use `CVariableInt::MAX_BYTES_PACKED` in two more places.
- Fix order of arguments in a test case.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
