### PR TITLE
Add margin for ping in server browser

### DIFF
--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -415,6 +415,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 			}
 			else if(ID == COL_PING)
 			{
+				Button.VMargin(4.0f, &Button);
 				FormatServerbrowserPing(aTemp, sizeof(aTemp), pItem);
 				if(g_Config.m_UiColorizePing)
 				{


### PR DESCRIPTION
as reported by Izanagi

Old:
<img width="1840" alt="Screenshot 2021-12-28 at 01 06 16" src="https://user-images.githubusercontent.com/2335377/147514748-de5bb347-fc15-4362-83f9-2ec5f90698cd.png">
New:
<img width="1840" alt="Screenshot 2021-12-28 at 01 05 18" src="https://user-images.githubusercontent.com/2335377/147514745-084e955d-ddcc-49df-b4f0-573c779f8eb3.png">

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
