### PR TITLE
Remove compatible version filter

### DIFF
--- a/data/languages/arabic.txt
+++ b/data/languages/arabic.txt
@@ -80,9 +80,6 @@ Client
 Close
 == ﻕﻼﻏﺍ
 
-Compatible version
-== ﻲﻟﺎﺤﻟﺍ ﺭﺍﺪﺻﻻﺍ
-
 Connect
 == ﻝﺎﺼﺗﺍ
 

--- a/data/languages/belarusian.txt
+++ b/data/languages/belarusian.txt
@@ -85,9 +85,6 @@ Client
 Close
 == Выйсці
 
-Compatible version
-== Сумяшчальная версія
-
 Connect
 == Падлучыцца
 

--- a/data/languages/bosnian.txt
+++ b/data/languages/bosnian.txt
@@ -88,9 +88,6 @@ Client
 Close
 == Zatvori
 
-Compatible version
-== Kompatibilna verzija
-
 Connect
 == Konektuj
 

--- a/data/languages/brazilian_portuguese.txt
+++ b/data/languages/brazilian_portuguese.txt
@@ -103,9 +103,6 @@ Client
 Close
 == Fechar
 
-Compatible version
-== Versão compatível
-
 Connect
 == Conectar
 

--- a/data/languages/bulgarian.txt
+++ b/data/languages/bulgarian.txt
@@ -85,9 +85,6 @@ Client
 Close
 == Затвори
 
-Compatible version
-== Съвместима версия
-
 Connect
 == Впиши
 

--- a/data/languages/catalan.txt
+++ b/data/languages/catalan.txt
@@ -81,9 +81,6 @@ Client
 Close
 == Tancar
 
-Compatible version
-== Versió compatible
-
 Connect
 == Connectar
 

--- a/data/languages/chuvash.txt
+++ b/data/languages/chuvash.txt
@@ -85,9 +85,6 @@ Client
 Close
 == Хупма
 
-Compatible version
-== Пĕрле ĕçлекен верси
-
 Connect
 == Çых
 

--- a/data/languages/czech.txt
+++ b/data/languages/czech.txt
@@ -88,9 +88,6 @@ Client
 Close
 == Zavřít
 
-Compatible version
-== Kompatibilní verze
-
 Connect
 == Připojit
 

--- a/data/languages/danish.txt
+++ b/data/languages/danish.txt
@@ -86,9 +86,6 @@ Client
 Close
 == Luk
 
-Compatible version
-== Kompatibel version
-
 Connect
 == Tilslut
 

--- a/data/languages/dutch.txt
+++ b/data/languages/dutch.txt
@@ -97,9 +97,6 @@ Client
 Close
 == Sluiten
 
-Compatible version
-== Samenwerkende versie
-
 Connect
 == Verbinden
 

--- a/data/languages/finnish.txt
+++ b/data/languages/finnish.txt
@@ -87,9 +87,6 @@ Client
 Close
 == Sulje
 
-Compatible version
-== Yhteensopiva versio
-
 Connect
 == Yhdistä
 

--- a/data/languages/french.txt
+++ b/data/languages/french.txt
@@ -101,9 +101,6 @@ Client
 Close
 == Fermer
 
-Compatible version
-== Version compatible
-
 Connect
 == Se connecter
 

--- a/data/languages/german.txt
+++ b/data/languages/german.txt
@@ -99,9 +99,6 @@ Client
 Close
 == Schließ.
 
-Compatible version
-== Kompatible Version
-
 Connect
 == Verbinden
 

--- a/data/languages/greek.txt
+++ b/data/languages/greek.txt
@@ -85,9 +85,6 @@ Client
 Close
 == Κλείσιμο
 
-Compatible version
-== Συμβατή έκδοση
-
 Connect
 == Σύνδεση
 

--- a/data/languages/hungarian.txt
+++ b/data/languages/hungarian.txt
@@ -86,9 +86,6 @@ Client
 Close
 == Bezárás
 
-Compatible version
-== Kompatibilis Verzió
-
 Connect
 == Csatlakozás
 

--- a/data/languages/italian.txt
+++ b/data/languages/italian.txt
@@ -90,9 +90,6 @@ Client
 Close
 == Chiudi
 
-Compatible version
-== Versione compatibile
-
 Connect
 == Connetti
 

--- a/data/languages/japanese.txt
+++ b/data/languages/japanese.txt
@@ -85,9 +85,6 @@ Client
 Close
 == 閉じる
 
-Compatible version
-== 互換性のあるバージョン
-
 Connect
 == 接続
 

--- a/data/languages/korean.txt
+++ b/data/languages/korean.txt
@@ -84,9 +84,6 @@ Client
 Close
 == 닫기
 
-Compatible version
-== 버전 호환
-
 Connect
 == 연결
 

--- a/data/languages/kyrgyz.txt
+++ b/data/languages/kyrgyz.txt
@@ -81,9 +81,6 @@ Client
 Close
 == Чыгуу
 
-Compatible version
-== Батышуучу версия
-
 Connect
 == Туташуу
 

--- a/data/languages/norwegian.txt
+++ b/data/languages/norwegian.txt
@@ -87,9 +87,6 @@ Client
 Close
 == Lukk
 
-Compatible version
-== Kompitabel versjon
-
 Connect
 == Koble til
 

--- a/data/languages/persian.txt
+++ b/data/languages/persian.txt
@@ -55,8 +55,6 @@ Client
 == ﺖﻨﯾﻼﻛ
 Close
 == ﻦﺘﺴﺑ
-Compatible version
-== ﺭﺎﮔﺯﺎﺳ ﻪﺨﺴﻧ
 Connect
 == ﻥﺪﺷ ﻞﺻﻭ
 Connecting to

--- a/data/languages/polish.txt
+++ b/data/languages/polish.txt
@@ -88,9 +88,6 @@ Client
 Close
 == Zamknij
 
-Compatible version
-== Kompatybilna wersja
-
 Connect
 == Połącz
 

--- a/data/languages/portuguese.txt
+++ b/data/languages/portuguese.txt
@@ -88,9 +88,6 @@ Client
 Close
 == Fechar
 
-Compatible version
-== Versão compatível
-
 Connect
 == Ligar
 

--- a/data/languages/romanian.txt
+++ b/data/languages/romanian.txt
@@ -91,9 +91,6 @@ Client
 Close
 == Închide
 
-Compatible version
-== Versiune compatibilă
-
 Connect
 == Conectează
 

--- a/data/languages/russian.txt
+++ b/data/languages/russian.txt
@@ -95,9 +95,6 @@ Client
 Close
 == Закрыть
 
-Compatible version
-== Совместимая версия
-
 Connect
 == Подключиться
 

--- a/data/languages/serbian.txt
+++ b/data/languages/serbian.txt
@@ -88,9 +88,6 @@ Client
 Close
 == Zatvori
 
-Compatible version
-== Kompatibilna verzija
-
 Connect
 == Konektuj
 

--- a/data/languages/serbian_cyrillic.txt
+++ b/data/languages/serbian_cyrillic.txt
@@ -85,9 +85,6 @@ Client
 Close
 == Затвори
 
-Compatible version
-== Компатибилна верзија
-
 Connect
 == Повежи се
 

--- a/data/languages/simplified_chinese.txt
+++ b/data/languages/simplified_chinese.txt
@@ -97,9 +97,6 @@ Client
 Close
 == 关闭
 
-Compatible version
-== 兼容的版本
-
 Connect
 == 连接
 

--- a/data/languages/slovak.txt
+++ b/data/languages/slovak.txt
@@ -85,9 +85,6 @@ Client
 Close
 == Zavrieť
 
-Compatible version
-== Kompatibilná verzia
-
 Connect
 == Pripojiť
 

--- a/data/languages/spanish.txt
+++ b/data/languages/spanish.txt
@@ -94,9 +94,6 @@ Client
 Close
 == Cerrar
 
-Compatible version
-== Versión compatible
-
 Connect
 == Conectar
 

--- a/data/languages/swedish.txt
+++ b/data/languages/swedish.txt
@@ -88,9 +88,6 @@ Client
 Close
 == Stäng
 
-Compatible version
-== Kompatibel version
-
 Connect
 == Anslut
 

--- a/data/languages/traditional_chinese.txt
+++ b/data/languages/traditional_chinese.txt
@@ -90,9 +90,6 @@ Client
 Close
 == 關閉
 
-Compatible version
-== 相容的版本
-
 Connect
 == 連線
 

--- a/data/languages/turkish.txt
+++ b/data/languages/turkish.txt
@@ -90,9 +90,6 @@ Client
 Close
 == Kapat
 
-Compatible version
-== Uyumlu versiyon
-
 Connect
 == Bağlan
 

--- a/data/languages/ukrainian.txt
+++ b/data/languages/ukrainian.txt
@@ -43,9 +43,6 @@ Chat
 Close
 == Зачинити
 
-Compatible version
-== Сумісна версія
-
 Connect
 == Під’єднатись
 

--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -282,8 +282,6 @@ void CServerBrowser::Filter()
 			Filtered = 1;
 		else if(g_Config.m_BrFilterPw && m_ppServerlist[i]->m_Info.m_Flags & SERVER_FLAG_PASSWORD)
 			Filtered = 1;
-		else if(g_Config.m_BrFilterCompatversion && str_comp_num(m_ppServerlist[i]->m_Info.m_aVersion, m_aNetVersion, 3) != 0)
-			Filtered = 1;
 		else if(g_Config.m_BrFilterServerAddress[0] && !str_find_nocase(m_ppServerlist[i]->m_Info.m_aAddress, g_Config.m_BrFilterServerAddress))
 			Filtered = 1;
 		else if(g_Config.m_BrFilterGametypeStrict && g_Config.m_BrFilterGametype[0] && str_comp_nocase(m_ppServerlist[i]->m_Info.m_aGameType, g_Config.m_BrFilterGametype))
@@ -397,7 +395,6 @@ int CServerBrowser::SortHash() const
 	i |= g_Config.m_BrFilterFriends << 7;
 	i |= g_Config.m_BrFilterPw << 8;
 	i |= g_Config.m_BrSortOrder << 9;
-	i |= g_Config.m_BrFilterCompatversion << 11;
 	i |= g_Config.m_BrFilterGametypeStrict << 12;
 	i |= g_Config.m_BrFilterUnfinishedMap << 13;
 	i |= g_Config.m_BrFilterCountry << 14;

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -56,7 +56,6 @@ MACRO_CONFIG_STR(BrFilterGametype, br_filter_gametype, 128, "", CFGFLAG_SAVE | C
 MACRO_CONFIG_INT(BrFilterGametypeStrict, br_filter_gametype_strict, 0, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Strict gametype filter")
 MACRO_CONFIG_INT(BrFilterConnectingPlayers, br_filter_connecting_players, 1, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Filter connecting players")
 MACRO_CONFIG_STR(BrFilterServerAddress, br_filter_serveraddress, 128, "", CFGFLAG_SAVE | CFGFLAG_CLIENT, "Server address to filter")
-MACRO_CONFIG_INT(BrFilterCompatversion, br_filter_compatversion, 0, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Filter out non-compatible servers in browser")
 MACRO_CONFIG_INT(BrFilterUnfinishedMap, br_filter_unfinished_map, 0, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Show only servers with unfinished maps")
 
 MACRO_CONFIG_STR(BrFilterExcludeCountries, br_filter_exclude_countries, 128, "", CFGFLAG_SAVE | CFGFLAG_CLIENT, "Filter out DDNet servers by country")

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -692,10 +692,6 @@ void CMenus::RenderServerbrowserFilters(CUIRect View)
 		g_Config.m_BrFilterPw ^= 1;
 
 	ServerFilter.HSplitTop(20.0f, &Button, &ServerFilter);
-	if(DoButton_CheckBox(&g_Config.m_BrFilterCompatversion, Localize("Compatible version"), g_Config.m_BrFilterCompatversion, &Button))
-		g_Config.m_BrFilterCompatversion ^= 1;
-
-	ServerFilter.HSplitTop(20.0f, &Button, &ServerFilter);
 	if(DoButton_CheckBox(&g_Config.m_BrFilterGametypeStrict, Localize("Strict gametype filter"), g_Config.m_BrFilterGametypeStrict, &Button))
 		g_Config.m_BrFilterGametypeStrict ^= 1;
 
@@ -1008,7 +1004,6 @@ void CMenus::RenderServerbrowserFilters(CUIRect View)
 		g_Config.m_BrFilterConnectingPlayers = 1;
 		g_Config.m_BrFilterUnfinishedMap = 0;
 		g_Config.m_BrFilterServerAddress[0] = 0;
-		g_Config.m_BrFilterCompatversion = 0;
 		g_Config.m_BrFilterExcludeCountries[0] = 0;
 		g_Config.m_BrFilterExcludeTypes[0] = 0;
 		if(g_Config.m_UiPage == PAGE_DDNET || g_Config.m_UiPage == PAGE_KOG)


### PR DESCRIPTION
It doesn't do anything right now, all servers advertise a compatible
version.

It might become a compatibility hazard in the future, e.g. DDNet servers
try to advertise a different version string to 0.6 than to 0.7 clients,
because the compatible version filter on 0.6 insists that it starts with
"0.6" and on 0.7 that it starts with "0.7", clearly incompatible.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
