### PR TITLE
Fix undefined behavior in byte packing functions, add tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2275,6 +2275,7 @@ if(GTEST_FOUND OR DOWNLOAD_GTEST)
     aio.cpp
     bezier.cpp
     blocklist_driver.cpp
+    bytes_be.cpp
     color.cpp
     compression.cpp
     csv.cpp

--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -3523,15 +3523,30 @@ const char *str_next_token(const char *str, const char *delim, char *buffer, int
 
 int bytes_be_to_int(const unsigned char *bytes)
 {
-	return ((bytes[0] & 0xff) << 24) | ((bytes[1] & 0xff) << 16) | ((bytes[2] & 0xff) << 8) | (bytes[3] & 0xff);
+	int Result;
+	unsigned char *pResult = (unsigned char *)&Result;
+	for(unsigned i = 0; i < sizeof(int); i++)
+	{
+#if defined(CONF_ARCH_ENDIAN_BIG)
+		pResult[i] = bytes[i];
+#else
+		pResult[i] = bytes[sizeof(int) - i - 1];
+#endif
+	}
+	return Result;
 }
 
 void int_to_bytes_be(unsigned char *bytes, int value)
 {
-	bytes[0] = (value >> 24) & 0xff;
-	bytes[1] = (value >> 16) & 0xff;
-	bytes[2] = (value >> 8) & 0xff;
-	bytes[3] = value & 0xff;
+	const unsigned char *pValue = (const unsigned char *)&value;
+	for(unsigned i = 0; i < sizeof(int); i++)
+	{
+#if defined(CONF_ARCH_ENDIAN_BIG)
+		bytes[i] = pValue[i];
+#else
+		bytes[sizeof(int) - i - 1] = pValue[i];
+#endif
+	}
 }
 
 unsigned bytes_be_to_uint(const unsigned char *bytes)

--- a/src/test/bytes_be.cpp
+++ b/src/test/bytes_be.cpp
@@ -1,0 +1,31 @@
+#include "test.h"
+
+#include <gtest/gtest.h>
+
+#include <base/system.h>
+
+static const int INT_DATA[] = {0, 1, -1, 32, 64, 256, -512, 12345, -123456, 1234567, 12345678, 123456789, 2147483647, (-2147483647 - 1)};
+static const int INT_NUM = sizeof(INT_DATA) / sizeof(int);
+
+static const unsigned UINT_DATA[] = {0u, 1u, 2u, 32u, 64u, 256u, 512u, 12345u, 123456u, 1234567u, 12345678u, 123456789u, 2147483647u, 2147483648u, 4294967295u};
+static const int UINT_NUM = sizeof(INT_DATA) / sizeof(unsigned);
+
+TEST(BytePacking, RoundtripInt)
+{
+	for(int i = 0; i < INT_NUM; i++)
+	{
+		unsigned char aPacked[4];
+		int_to_bytes_be(aPacked, INT_DATA[i]);
+		EXPECT_EQ(bytes_be_to_int(aPacked), INT_DATA[i]);
+	}
+}
+
+TEST(BytePacking, RoundtripUnsigned)
+{
+	for(int i = 0; i < UINT_NUM; i++)
+	{
+		unsigned char aPacked[4];
+		uint_to_bytes_be(aPacked, UINT_DATA[i]);
+		EXPECT_EQ(bytes_be_to_uint(aPacked), UINT_DATA[i]);
+	}
+}


### PR DESCRIPTION
- Fix undefined/implementation-specific behavior due to right shift of negative number in `int_to_bytes_be` and `bytes_be_to_int`, by instead copying the bytes without using any bit arithmetic.
- Add tests for all four byte packing functions.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [X] Written a unit test if it works standalone, system.c especially
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [X] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
