### PR TITLE
Don't crash when no ids are left (fixes #4565)

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -95,9 +95,11 @@ int CSnapIDPool::NewID()
 		RemoveFirstTimeout();
 
 	int ID = m_FirstFree;
-	dbg_assert(ID != -1, "id error");
 	if(ID == -1)
+	{
+		dbg_msg("server", "invalid id");
 		return ID;
+	}
 	m_FirstFree = m_aIDs[m_FirstFree].m_Next;
 	m_aIDs[ID].m_State = 1;
 	m_Usage++;

--- a/src/engine/shared/snapshot.cpp
+++ b/src/engine/shared/snapshot.cpp
@@ -642,6 +642,11 @@ int CSnapshotBuilder::GetExtendedItemTypeIndex(int TypeID)
 
 void *CSnapshotBuilder::NewItem(int Type, int ID, int Size)
 {
+	if(ID == -1)
+	{
+		return 0;
+	}
+
 	if(m_DataSize + sizeof(CSnapshotItem) + Size >= CSnapshot::MAX_SIZE ||
 		m_NumItems + 1 >= MAX_ITEMS)
 	{


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
