### PR TITLE
Always clear stars, also when entering dummy (fixes #4554)

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -658,8 +658,9 @@ void CClient::OnEnterGame(bool Dummy)
 	if(Dummy == 0)
 	{
 		m_LastDummyConnectTime = 0;
-		GameClient()->OnEnterGame();
 	}
+
+	GameClient()->OnEnterGame();
 }
 
 void CClient::EnterGame(bool Dummy)


### PR DESCRIPTION
otherwise they get stuck. Thanks to Skeith reproduction steps:

> Basically, to consistently reproduce the bug, you put your tee in
> freeze, then you connect your dummy right as the stars appear when
> frozen. It also happens with the stars that pop out when you shoot your
> pistol @deen

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
