### PR TITLE
use the not deprecated XFERINFOFUNCTION instead of PROGRESSFUNCTION

### DIFF
--- a/src/engine/client/http.cpp
+++ b/src/engine/client/http.cpp
@@ -145,8 +145,8 @@ int CRequest::RunImpl(CURL *pHandle)
 	curl_easy_setopt(pHandle, CURLOPT_WRITEDATA, this);
 	curl_easy_setopt(pHandle, CURLOPT_WRITEFUNCTION, WriteCallback);
 	curl_easy_setopt(pHandle, CURLOPT_NOPROGRESS, 0L);
-	curl_easy_setopt(pHandle, CURLOPT_PROGRESSDATA, this);
-	curl_easy_setopt(pHandle, CURLOPT_PROGRESSFUNCTION, ProgressCallback);
+	curl_easy_setopt(pHandle, CURLOPT_XFERINFODATA, this);
+	curl_easy_setopt(pHandle, CURLOPT_XFERINFOFUNCTION, ProgressCallback);
 
 	if(curl_version_info(CURLVERSION_NOW)->version_num < 0x076800)
 	{


### PR DESCRIPTION
https://curl.se/libcurl/c/CURLOPT_XFERINFOFUNCTION.html

https://curl.se/libcurl/c/CURLOPT_PROGRESSFUNCTION.html

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
