### PR TITLE
Add teleport/tp chat command to teleport yourself

### DIFF
--- a/src/game/ddracechat.h
+++ b/src/game/ddracechat.h
@@ -59,6 +59,8 @@ CHAT_COMMAND("time", "", CFGFLAG_CHAT | CFGFLAG_SERVER, ConTime, this, "Privatel
 CHAT_COMMAND("timer", "?s['gametimer'|'broadcast'|'both'|'none'|'cycle']", CFGFLAG_CHAT | CFGFLAG_SERVER, ConSetTimerType, this, "Personal Setting of showing time in either broadcast or game/round timer, timer s, where s = broadcast for broadcast, gametimer for game/round timer, cycle for cycle, both for both, none for no timer and nothing to show current status")
 CHAT_COMMAND("r", "", CFGFLAG_CHAT | CFGFLAG_SERVER, ConRescue, this, "Teleport yourself out of freeze (use sv_rescue 1 to enable this feature)")
 CHAT_COMMAND("rescue", "", CFGFLAG_CHAT | CFGFLAG_SERVER, ConRescue, this, "Teleport yourself out of freeze (use sv_rescue 1 to enable this feature)")
+CHAT_COMMAND("tp", "?r[player name]", CFGFLAG_CHAT | CFGFLAG_SERVER, ConTele, this, "Teleport yourself to player or to where you are spectating if no player name is given")
+CHAT_COMMAND("teleport", "?r[player name]", CFGFLAG_CHAT | CFGFLAG_SERVER, ConTele, this, "Teleport yourself to player or to where you are spectating if no player name is given")
 
 CHAT_COMMAND("kill", "", CFGFLAG_CHAT | CFGFLAG_SERVER, ConProtectedKill, this, "Kill yourself when kill-protected during a long game (use f1, kill for regular kill)")
 

--- a/src/game/server/ddracecommands.cpp
+++ b/src/game/server/ddracecommands.cpp
@@ -277,6 +277,14 @@ void CGameContext::ModifyWeapons(IConsole::IResult *pResult, void *pUserData,
 	pChr->m_DDRaceState = DDRACE_CHEAT;
 }
 
+void CGameContext::Teleport(CCharacter *pChr, vec2 Pos)
+{
+	pChr->Core()->m_Pos = Pos;
+	pChr->m_Pos = Pos;
+	pChr->m_PrevPos = Pos;
+	pChr->m_DDRaceState = DDRACE_CHEAT;
+}
+
 void CGameContext::ConToTeleporter(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
@@ -289,11 +297,7 @@ void CGameContext::ConToTeleporter(IConsole::IResult *pResult, void *pUserData)
 		if(pChr)
 		{
 			int TeleOut = pSelf->m_World.m_Core.RandomOr0(pGameControllerDDRace->m_TeleOuts[TeleTo - 1].size());
-			vec2 TelePos = pGameControllerDDRace->m_TeleOuts[TeleTo - 1][TeleOut];
-			pChr->Core()->m_Pos = TelePos;
-			pChr->m_Pos = TelePos;
-			pChr->m_PrevPos = TelePos;
-			pChr->m_DDRaceState = DDRACE_CHEAT;
+			pSelf->Teleport(pChr, pGameControllerDDRace->m_TeleOuts[TeleTo - 1][TeleOut]);
 		}
 	}
 }
@@ -310,11 +314,7 @@ void CGameContext::ConToCheckTeleporter(IConsole::IResult *pResult, void *pUserD
 		if(pChr)
 		{
 			int TeleOut = pSelf->m_World.m_Core.RandomOr0(pGameControllerDDRace->m_TeleCheckOuts[TeleTo - 1].size());
-			vec2 TelePos = pGameControllerDDRace->m_TeleCheckOuts[TeleTo - 1][TeleOut];
-			pChr->Core()->m_Pos = TelePos;
-			pChr->m_Pos = TelePos;
-			pChr->m_PrevPos = TelePos;
-			pChr->m_DDRaceState = DDRACE_CHEAT;
+			pSelf->Teleport(pChr, pGameControllerDDRace->m_TeleCheckOuts[TeleTo - 1][TeleOut]);
 			pChr->m_TeleCheckpoint = TeleTo;
 		}
 	}
@@ -336,10 +336,7 @@ void CGameContext::ConTeleport(IConsole::IResult *pResult, void *pUserData)
 	CCharacter *pChr = pSelf->GetPlayerChar(Tele);
 	if(pChr && pSelf->GetPlayerChar(TeleTo))
 	{
-		pChr->Core()->m_Pos = pSelf->m_apPlayers[TeleTo]->m_ViewPos;
-		pChr->m_Pos = pSelf->m_apPlayers[TeleTo]->m_ViewPos;
-		pChr->m_PrevPos = pSelf->m_apPlayers[TeleTo]->m_ViewPos;
-		pChr->m_DDRaceState = DDRACE_CHEAT;
+		pSelf->Teleport(pChr, pSelf->m_apPlayers[TeleTo]->m_ViewPos);
 	}
 }
 

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -333,7 +333,7 @@ private:
 
 	static void ConToTeleporter(IConsole::IResult *pResult, void *pUserData);
 	static void ConToCheckTeleporter(IConsole::IResult *pResult, void *pUserData);
-	void Teleport(CCharacter *pChar, vec2 Pos);
+	void Teleport(CCharacter *pChr, vec2 Pos);
 	static void ConTeleport(IConsole::IResult *pResult, void *pUserData);
 
 	static void ConCredits(IConsole::IResult *pResult, void *pUserData);

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -333,6 +333,7 @@ private:
 
 	static void ConToTeleporter(IConsole::IResult *pResult, void *pUserData);
 	static void ConToCheckTeleporter(IConsole::IResult *pResult, void *pUserData);
+	void Teleport(CCharacter *pChar, vec2 Pos);
 	static void ConTeleport(IConsole::IResult *pResult, void *pUserData);
 
 	static void ConCredits(IConsole::IResult *pResult, void *pUserData);
@@ -383,6 +384,7 @@ private:
 	static void ConTime(IConsole::IResult *pResult, void *pUserData);
 	static void ConSetTimerType(IConsole::IResult *pResult, void *pUserData);
 	static void ConRescue(IConsole::IResult *pResult, void *pUserData);
+	static void ConTele(IConsole::IResult *pResult, void *pUserData);
 	static void ConProtectedKill(IConsole::IResult *pResult, void *pUserData);
 
 	static void ConVoteMute(IConsole::IResult *pResult, void *pUserData);

--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -240,7 +240,7 @@ void CGameTeams::Tick()
 	{
 		CCharacter *pChar = GameServer()->m_apPlayers[i] ? GameServer()->m_apPlayers[i]->GetCharacter() : nullptr;
 		int Team = m_Core.Team(i);
-		if(!pChar || m_TeamState[Team] != TEAMSTATE_STARTED || m_TeeStarted[i])
+		if(!pChar || m_TeamState[Team] != TEAMSTATE_STARTED || m_TeeStarted[i] || m_Practice[m_Core.Team(i)])
 		{
 			continue;
 		}


### PR DESCRIPTION
to another player or spectated location. Requires /practice mode

As suggested by Rockus on Discord

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
