### PR TITLE
Fix rescue tee when swapping (fixes #4578)

### DIFF
--- a/src/game/server/save.cpp
+++ b/src/game/server/save.cpp
@@ -207,9 +207,12 @@ void CSaveTee::Load(CCharacter *pChr, int Team, bool IsSwap)
 
 	pChr->SetSolo(m_IsSolo);
 
-	// Always create a rescue tee at the exact location we loaded from so that
-	// the old one gets overwritten.
-	pChr->SetRescue();
+	if(!IsSwap)
+	{
+		// Always create a rescue tee at the exact location we loaded from so that
+		// the old one gets overwritten.
+		pChr->SetRescue();
+	}
 }
 
 char *CSaveTee::GetString(const CSaveTeam *pTeam)


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
