### PR TITLE
Fail database queries faster

### DIFF
--- a/src/base/tl/threading.h
+++ b/src/base/tl/threading.h
@@ -9,21 +9,21 @@ class CSemaphore
 	SEMAPHORE m_Sem;
 	// implement the counter seperatly, because the `sem_getvalue`-API is
 	// deprecated on macOS: https://stackoverflow.com/a/16655541
-	std::atomic_int count;
+	std::atomic_int m_Count{0};
 
 public:
 	CSemaphore() { sphore_init(&m_Sem); }
 	~CSemaphore() { sphore_destroy(&m_Sem); }
 	CSemaphore(const CSemaphore &) = delete;
-	int GetApproximateValue() { return count.load(); }
+	int GetApproximateValue() { return m_Count.load(); }
 	void Wait()
 	{
 		sphore_wait(&m_Sem);
-		count.fetch_sub(1);
+		m_Count.fetch_sub(1);
 	}
 	void Signal()
 	{
-		count.fetch_add(1);
+		m_Count.fetch_add(1);
 		sphore_signal(&m_Sem);
 	}
 };

--- a/src/engine/server/databases/connection_pool.cpp
+++ b/src/engine/server/databases/connection_pool.cpp
@@ -145,6 +145,11 @@ void CDbConnectionPool::Worker()
 		{
 			for(int i = 0; i < (int)m_aapDbConnections[Mode::READ].size(); i++)
 			{
+				if(m_Shutdown)
+				{
+					dbg_msg("sql", "%s dismissed read request during shutdown", pThreadData->m_pName);
+					break;
+				}
 				int CurServer = (ReadServer + i) % (int)m_aapDbConnections[Mode::READ].size();
 				if(ExecSqlFunc(m_aapDbConnections[Mode::READ][CurServer].get(), pThreadData.get(), false))
 				{
@@ -160,6 +165,10 @@ void CDbConnectionPool::Worker()
 		{
 			for(int i = 0; i < (int)m_aapDbConnections[Mode::WRITE].size(); i++)
 			{
+				if(m_Shutdown && !m_aapDbConnections[Mode::WRITE_BACKUP].empty()) {
+					dbg_msg("sql", "%s skipped to backup database during shutdown", pThreadData->m_pName);
+					break;
+				}
 				int CurServer = (WriteServer + i) % (int)m_aapDbConnections[Mode::WRITE].size();
 				if(ExecSqlFunc(m_aapDbConnections[Mode::WRITE][i].get(), pThreadData.get(), false))
 				{

--- a/src/engine/server/databases/connection_pool.h
+++ b/src/engine/server/databases/connection_pool.h
@@ -75,7 +75,7 @@ private:
 	void Worker();
 	bool ExecSqlFunc(IDbConnection *pConnection, struct CSqlExecData *pData, bool Failure);
 
-	std::atomic_bool m_Shutdown;
+	std::atomic_bool m_Shutdown{false};
 	CSemaphore m_NumElem;
 	int FirstElem;
 	int LastElem;


### PR DESCRIPTION
Makes ddos situations more bearable during tournaments. Redo of #4429, but this time the tested version. I somehow mixed my two git environments (Laptop and PC) last time and some changes were missing from the PR last time (the initialization of the shutdown variable and m_count variable).

Changed the logic a bit from last time to only go into FailMode if the query fails on all database servers.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
