### PR TITLE
Fix crash in macOS when moving screen (fixes #4435)

### DIFF
--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -2387,7 +2387,7 @@ void CGraphics_Threaded::Resize(int w, int h, int RefreshRate, bool SetWindowSiz
 			return;
 		}
 
-		// kick the command buffer
+		// kick the command buffer and wait
 		KickCommandBuffer();
 		WaitForIdle();
 
@@ -2506,6 +2506,11 @@ void CGraphics_Threaded::Swap()
 
 	// kick the command buffer
 	KickCommandBuffer();
+	// TODO: Remove when https://github.com/libsdl-org/SDL/issues/5203 is fixed
+#ifdef CONF_PLATFORM_MACOS
+	if(str_find(GetVersionString(), "Metal"))
+		WaitForIdle();
+#endif
 }
 
 bool CGraphics_Threaded::SetVSync(bool State)


### PR DESCRIPTION
Thanks to Jupeyy for the suggestion

Normally it crashes after a few seconds, tried moving window around, resizing, moving between screens like crazy and no crashes after 1-2 min.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
