### PR TITLE
Fix compiler warning with new ffmpeg version (currently built from git)

### DIFF
--- a/src/engine/client/video.cpp
+++ b/src/engine/client/video.cpp
@@ -563,7 +563,7 @@ bool CVideo::OpenAudio()
 }
 
 /* Add an output stream. */
-bool CVideo::AddStream(OutputStream *pStream, AVFormatContext *pOC, AVCodec **ppCodec, enum AVCodecID CodecId)
+bool CVideo::AddStream(OutputStream *pStream, AVFormatContext *pOC, const AVCodec **ppCodec, enum AVCodecID CodecId)
 {
 	AVCodecContext *c;
 

--- a/src/engine/client/video.h
+++ b/src/engine/client/video.h
@@ -75,7 +75,7 @@ private:
 	void FinishFrames(OutputStream *pStream);
 	void CloseStream(OutputStream *pStream);
 
-	bool AddStream(OutputStream *pStream, AVFormatContext *pOC, AVCodec **ppCodec, enum AVCodecID CodecId);
+	bool AddStream(OutputStream *pStream, AVFormatContext *pOC, const AVCodec **ppCodec, enum AVCodecID CodecId);
 
 	class CGraphics_Threaded *m_pGraphics;
 	class IStorage *m_pStorage;
@@ -107,13 +107,13 @@ private:
 	OutputStream m_VideoStream;
 	OutputStream m_AudioStream;
 
-	AVCodec *m_VideoCodec;
-	AVCodec *m_AudioCodec;
+	const AVCodec *m_VideoCodec;
+	const AVCodec *m_AudioCodec;
 
 	AVDictionary *m_pOptDict;
 
 	AVFormatContext *m_pFormatContext;
-	AVOutputFormat *m_pFormat;
+	const AVOutputFormat *m_pFormat;
 
 	uint8_t *m_pRGB;
 


### PR DESCRIPTION
```
src/engine/client/video.cpp:102:32: error: assigning to 'AVOutputFormat *' from 'const struct AVOutputFormat *' discards qualifiers
        m_pFormat = m_pFormatContext->oformat;
                    ~~~~~~~~~~~~~~~~~~^~~~~~~
src/engine/client/video.cpp:571:13: error: assigning to 'AVCodec *' from 'const AVCodec *' discards qualifiers
        *ppCodec = avcodec_find_encoder(CodecId);
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
