### PR TITLE
Fix OOB access in CSnapshotDelta::UnpackDelta, cleanup

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -1869,7 +1869,6 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket)
 			int DeltaTick = GameTick - Unpacker.GetInt();
 			int PartSize = 0;
 			unsigned int Crc = 0;
-			int CompleteSize = 0;
 			const char *pData = 0;
 
 			// only allow packets from the server we actually want
@@ -1912,15 +1911,10 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket)
 				{
 					static CSnapshot Emptysnap;
 					CSnapshot *pDeltaShot = &Emptysnap;
-					int PurgeTick;
-					void *pDeltaData;
-					int DeltaSize;
 					unsigned char aTmpBuffer2[CSnapshot::MAX_SIZE];
 					unsigned char aTmpBuffer3[CSnapshot::MAX_SIZE];
 					CSnapshot *pTmpBuffer3 = (CSnapshot *)aTmpBuffer3; // Fix compiler warning for strict-aliasing
-					int SnapSize;
-
-					CompleteSize = (NumParts - 1) * MAX_SNAPSHOT_PACKSIZE + PartSize;
+					const int CompleteSize = (NumParts - 1) * MAX_SNAPSHOT_PACKSIZE + PartSize;
 
 					// reset snapshoting
 					m_SnapshotParts[g_Config.m_ClDummy] = 0;
@@ -1952,8 +1946,8 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket)
 					}
 
 					// decompress snapshot
-					pDeltaData = m_SnapshotDelta.EmptyDelta();
-					DeltaSize = sizeof(int) * 3;
+					const void *pDeltaData = m_SnapshotDelta.EmptyDelta();
+					int DeltaSize = sizeof(int) * 3;
 
 					if(CompleteSize)
 					{
@@ -1967,7 +1961,7 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket)
 					}
 
 					// unpack delta
-					SnapSize = m_SnapshotDelta.UnpackDelta(pDeltaShot, pTmpBuffer3, pDeltaData, DeltaSize);
+					const int SnapSize = m_SnapshotDelta.UnpackDelta(pDeltaShot, pTmpBuffer3, pDeltaData, DeltaSize);
 					if(SnapSize < 0)
 					{
 						dbg_msg("client", "delta unpack failed!=%d", SnapSize);
@@ -2001,7 +1995,7 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket)
 					}
 
 					// purge old snapshots
-					PurgeTick = DeltaTick;
+					int PurgeTick = DeltaTick;
 					if(m_aSnapshots[g_Config.m_ClDummy][SNAP_PREV] && m_aSnapshots[g_Config.m_ClDummy][SNAP_PREV]->m_Tick < PurgeTick)
 						PurgeTick = m_aSnapshots[g_Config.m_ClDummy][SNAP_PREV]->m_Tick;
 					if(m_aSnapshots[g_Config.m_ClDummy][SNAP_CURRENT] && m_aSnapshots[g_Config.m_ClDummy][SNAP_CURRENT]->m_Tick < PurgeTick)
@@ -2159,14 +2153,8 @@ void CClient::ProcessServerPacketDummy(CNetChunk *pPacket)
 		}
 		else if(Msg == NETMSG_SNAP || Msg == NETMSG_SNAPSINGLE || Msg == NETMSG_SNAPEMPTY)
 		{
-			int NumParts = 1;
-			int Part = 0;
 			int GameTick = Unpacker.GetInt();
 			int DeltaTick = GameTick - Unpacker.GetInt();
-			int PartSize = 0;
-			unsigned int Crc = 0;
-			int CompleteSize = 0;
-			const char *pData = 0;
 
 			// only allow packets from the server we actually want
 			if(net_addr_comp(&pPacket->m_Address, &m_ServerAddress))
@@ -2176,19 +2164,23 @@ void CClient::ProcessServerPacketDummy(CNetChunk *pPacket)
 			if(State() < IClient::STATE_LOADING)
 				return;
 
+			int NumParts = 1;
+			int Part = 0;
 			if(Msg == NETMSG_SNAP)
 			{
 				NumParts = Unpacker.GetInt();
 				Part = Unpacker.GetInt();
 			}
 
+			unsigned int Crc = 0;
+			int PartSize = 0;
 			if(Msg != NETMSG_SNAPEMPTY)
 			{
 				Crc = Unpacker.GetInt();
 				PartSize = Unpacker.GetInt();
 			}
 
-			pData = (const char *)Unpacker.GetRaw(PartSize);
+			const char *pData = (const char *)Unpacker.GetRaw(PartSize);
 
 			if(Unpacker.Error() || NumParts < 1 || NumParts > CSnapshot::MAX_PARTS || Part < 0 || Part >= NumParts || PartSize < 0 || PartSize > MAX_SNAPSHOT_PACKSIZE)
 				return;
@@ -2208,15 +2200,11 @@ void CClient::ProcessServerPacketDummy(CNetChunk *pPacket)
 				{
 					static CSnapshot Emptysnap;
 					CSnapshot *pDeltaShot = &Emptysnap;
-					int PurgeTick;
-					void *pDeltaData;
-					int DeltaSize;
 					unsigned char aTmpBuffer2[CSnapshot::MAX_SIZE];
 					unsigned char aTmpBuffer3[CSnapshot::MAX_SIZE];
 					CSnapshot *pTmpBuffer3 = (CSnapshot *)aTmpBuffer3; // Fix compiler warning for strict-aliasing
-					int SnapSize;
 
-					CompleteSize = (NumParts - 1) * MAX_SNAPSHOT_PACKSIZE + PartSize;
+					const int CompleteSize = (NumParts - 1) * MAX_SNAPSHOT_PACKSIZE + PartSize;
 
 					// reset snapshoting
 					m_SnapshotParts[!g_Config.m_ClDummy] = 0;
@@ -2248,8 +2236,8 @@ void CClient::ProcessServerPacketDummy(CNetChunk *pPacket)
 					}
 
 					// decompress snapshot
-					pDeltaData = m_SnapshotDelta.EmptyDelta();
-					DeltaSize = sizeof(int) * 3;
+					const void *pDeltaData = m_SnapshotDelta.EmptyDelta();
+					int DeltaSize = sizeof(int) * 3;
 
 					if(CompleteSize)
 					{
@@ -2263,7 +2251,7 @@ void CClient::ProcessServerPacketDummy(CNetChunk *pPacket)
 					}
 
 					// unpack delta
-					SnapSize = m_SnapshotDelta.UnpackDelta(pDeltaShot, pTmpBuffer3, pDeltaData, DeltaSize);
+					const int SnapSize = m_SnapshotDelta.UnpackDelta(pDeltaShot, pTmpBuffer3, pDeltaData, DeltaSize);
 					if(SnapSize < 0)
 					{
 						m_pConsole->Print(IConsole::OUTPUT_LEVEL_DEBUG, "client", "delta unpack failed!");
@@ -2297,7 +2285,7 @@ void CClient::ProcessServerPacketDummy(CNetChunk *pPacket)
 					}
 
 					// purge old snapshots
-					PurgeTick = DeltaTick;
+					int PurgeTick = DeltaTick;
 					if(m_aSnapshots[!g_Config.m_ClDummy][SNAP_PREV] && m_aSnapshots[!g_Config.m_ClDummy][SNAP_PREV]->m_Tick < PurgeTick)
 						PurgeTick = m_aSnapshots[!g_Config.m_ClDummy][SNAP_PREV]->m_Tick;
 					if(m_aSnapshots[!g_Config.m_ClDummy][SNAP_CURRENT] && m_aSnapshots[!g_Config.m_ClDummy][SNAP_CURRENT]->m_Tick < PurgeTick)

--- a/src/engine/shared/snapshot.h
+++ b/src/engine/shared/snapshot.h
@@ -32,6 +32,8 @@ public:
 	{
 		OFFSET_UUID_TYPE = 0x4000,
 		MAX_TYPE = 0x7fff,
+		MAX_ID = 0xffff,
+		MAX_ITEMS = 1024,
 		MAX_PARTS = 64,
 		MAX_SIZE = MAX_PARTS * 1024
 	};
@@ -50,7 +52,6 @@ public:
 
 	unsigned Crc();
 	void DebugDump();
-	static void RemoveExtraInfo(unsigned char *pData);
 };
 
 // CSnapshotDelta
@@ -73,23 +74,22 @@ private:
 		MAX_NETOBJSIZES = 64
 	};
 	short m_aItemSizes[MAX_NETOBJSIZES];
-	int m_aSnapshotDataRate[0xffff];
-	int m_aSnapshotDataUpdates[0xffff];
-	int m_SnapshotCurrent;
+	int m_aSnapshotDataRate[CSnapshot::MAX_TYPE + 1];
+	int m_aSnapshotDataUpdates[CSnapshot::MAX_TYPE + 1];
 	CData m_Empty;
 
-	void UndiffItem(int *pPast, int *pDiff, int *pOut, int Size);
+	static void UndiffItem(int *pPast, int *pDiff, int *pOut, int Size, int *pDataRate);
 
 public:
 	static int DiffItem(int *pPast, int *pCurrent, int *pOut, int Size);
 	CSnapshotDelta();
 	CSnapshotDelta(const CSnapshotDelta &Old);
-	int GetDataRate(int Index) { return m_aSnapshotDataRate[Index]; }
-	int GetDataUpdates(int Index) { return m_aSnapshotDataUpdates[Index]; }
+	int GetDataRate(int Index) const { return m_aSnapshotDataRate[Index]; }
+	int GetDataUpdates(int Index) const { return m_aSnapshotDataUpdates[Index]; }
 	void SetStaticsize(int ItemType, int Size);
-	CData *EmptyDelta();
+	const CData *EmptyDelta() const;
 	int CreateDelta(class CSnapshot *pFrom, class CSnapshot *pTo, void *pData);
-	int UnpackDelta(class CSnapshot *pFrom, class CSnapshot *pTo, void *pData, int DataSize);
+	int UnpackDelta(class CSnapshot *pFrom, class CSnapshot *pTo, const void *pData, int DataSize);
 };
 
 // CSnapshotStorage
@@ -127,14 +127,13 @@ class CSnapshotBuilder
 {
 	enum
 	{
-		MAX_ITEMS = 1024,
 		MAX_EXTENDED_ITEM_TYPES = 64,
 	};
 
 	char m_aData[CSnapshot::MAX_SIZE];
 	int m_DataSize;
 
-	int m_aOffsets[MAX_ITEMS];
+	int m_aOffsets[CSnapshot::MAX_ITEMS];
 	int m_NumItems;
 
 	int m_aExtendedItemTypes[MAX_EXTENDED_ITEM_TYPES];


### PR DESCRIPTION
The `Type` unpacked from the snapshot delta is stored in `m_SnapshotCurrent`, which is validated to be in range `0 - 0xffff`, but the arrays `m_aSnapshotDataUpdates` and `m_aSnapshotDataRate` being index with this are sized 1 too small with length `0xffff`. Hence, snapshot deltas with `Type == 0xffff` cause OOB accesses.

This is fixed by adding validation for `Type` to be in range `0 - CSnapshot::MAX_TYPE` (`0x7fff`) and changing the lengths of the arrays to `CSnapshot::MAX_TYPE + 1`. Validation for `ID` is also added to keep it in range `0 - 0xffff`.
This validation also prevents undefined behavior in subsequent `(Type << 16) | ID`.

Refactoring:

- Declare `CSnapshotDelta::UndiffItem` as `static` and add output parameter `int *pDataRate` as replacement for usage of member variables. Remove `CSnapshotDelta::m_SnapshotCurrent` that was only used for this purpose.
- Use `const` where possible.
- Merge variable declaration with first assignment. Move declarations closer to where variables are used.
- Remove dead code.


## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
