### PR TITLE
Fix console line y offsets when resizing

### DIFF
--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -73,6 +73,16 @@ void CGameConsole::CInstance::ClearBacklog()
 	m_BacklogActPage = 0;
 }
 
+void CGameConsole::CInstance::ClearBacklogYOffsets()
+{
+	auto *pEntry = m_Backlog.First();
+	while(pEntry)
+	{
+		pEntry->m_YOffset = -1.0f;
+		pEntry = m_Backlog.Next(pEntry);
+	}
+}
+
 void CGameConsole::CInstance::ClearHistory()
 {
 	m_History.Init();
@@ -991,6 +1001,17 @@ void CGameConsole::OnConsoleInit()
 	Console()->Register("console_page_down", "", CFGFLAG_CLIENT, ConConsolePageDown, this, "Next page in console");
 
 	Console()->Chain("console_output_level", ConchainConsoleOutputLevelUpdate, this);
+}
+
+void CGameConsole::OnInit()
+{
+	// add resize event
+	Graphics()->AddWindowResizeListener([this](void *) {
+		m_LocalConsole.ClearBacklogYOffsets();
+		m_RemoteConsole.ClearBacklogYOffsets();
+		m_HasSelection = false;
+	},
+		nullptr);
 }
 
 void CGameConsole::OnStateChange(int NewState, int OldState)

--- a/src/game/client/components/console.h
+++ b/src/game/client/components/console.h
@@ -59,6 +59,7 @@ class CGameConsole : public CComponent
 		void Init(CGameConsole *pGameConsole);
 
 		void ClearBacklog();
+		void ClearBacklogYOffsets();
 		void ClearHistory();
 
 		void ExecuteLine(const char *pLine);
@@ -125,6 +126,7 @@ public:
 
 	virtual void OnStateChange(int NewState, int OldState);
 	virtual void OnConsoleInit();
+	virtual void OnInit();
 	virtual void OnReset();
 	virtual void OnRender();
 	virtual void OnMessage(int MsgType, void *pRawMsg);


### PR DESCRIPTION
Hopefully fixes #4319
I can only imagine it happening bcs of resizing

## Checklist

- [x] Tested the change ingame (only tested with resizing)
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
