### PR TITLE
Revert "Increase console backlog size from 64 KB to 1 MB" (fixes #4595)

### DIFF
--- a/src/game/client/components/console.h
+++ b/src/game/client/components/console.h
@@ -27,7 +27,7 @@ class CGameConsole : public CComponent
 			ColorRGBA m_PrintColor;
 			char m_aText[1];
 		};
-		CStaticRingBuffer<CBacklogEntry, 1024 * 1024, CRingBufferBase::FLAG_RECYCLE> m_Backlog;
+		CStaticRingBuffer<CBacklogEntry, 64 * 1024, CRingBufferBase::FLAG_RECYCLE> m_Backlog;
 		CStaticRingBuffer<char, 64 * 1024, CRingBufferBase::FLAG_RECYCLE> m_History;
 		char *m_pHistoryEntry;
 


### PR DESCRIPTION
Since we have to iterate over all entries on each render

This reverts commit f5eaf393dab04726bbd267400974f51a27f05551.

(Not sure it's that bad since this reduces fps only when console is open I believe)

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
