### PR TITLE
Fix windows macro and split the resize events

### DIFF
--- a/src/engine/client/backend_sdl.h
+++ b/src/engine/client/backend_sdl.h
@@ -260,7 +260,7 @@ public:
 	virtual int WindowActive();
 	virtual int WindowOpen();
 	virtual void SetWindowGrab(bool Grab);
-	virtual void ResizeWindow(int w, int h, int RefreshRate);
+	virtual bool ResizeWindow(int w, int h, int RefreshRate);
 	virtual void GetViewportSize(int &w, int &h);
 	virtual void NotifyWindow();
 

--- a/src/engine/client/graphics_threaded.h
+++ b/src/engine/client/graphics_threaded.h
@@ -676,7 +676,8 @@ public:
 	virtual int WindowActive() = 0;
 	virtual int WindowOpen() = 0;
 	virtual void SetWindowGrab(bool Grab) = 0;
-	virtual void ResizeWindow(int w, int h, int RefreshRate) = 0;
+	// returns true, if the video mode changed
+	virtual bool ResizeWindow(int w, int h, int RefreshRate) = 0;
 	virtual void GetViewportSize(int &w, int &h) = 0;
 	virtual void NotifyWindow() = 0;
 
@@ -1168,7 +1169,8 @@ public:
 	void SetWindowParams(int FullscreenMode, bool IsBorderless) override;
 	bool SetWindowScreen(int Index) override;
 	void Move(int x, int y) override;
-	void Resize(int w, int h, int RefreshRate, bool SetWindowSize = false, bool ForceResizeEvent = false) override;
+	void Resize(int w, int h, int RefreshRate) override;
+	void GotResized(int w, int h, int RefreshRate) override;
 	void AddWindowResizeListener(WINDOW_RESIZE_FUNC pFunc, void *pUser) override;
 	int GetWindowScreen() override;
 

--- a/src/engine/client/graphics_threaded_null.h
+++ b/src/engine/client/graphics_threaded_null.h
@@ -150,7 +150,8 @@ public:
 	void SetWindowParams(int FullscreenMode, bool IsBorderless) override{};
 	bool SetWindowScreen(int Index) override { return false; };
 	void Move(int x, int y) override{};
-	void Resize(int w, int h, int RefreshRate, bool SetWindowSize = false, bool ForceResizeEvent = false) override{};
+	void Resize(int w, int h, int RefreshRate) override{};
+	void GotResized(int w, int h, int RefreshRate) override{};
 	void AddWindowResizeListener(WINDOW_RESIZE_FUNC pFunc, void *pUser) override{};
 	int GetWindowScreen() override { return 0; };
 

--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -364,7 +364,7 @@ int CInput::Update()
 					break;
 				// listen to size changes, this includes our manual changes and the ones by the window manager
 				case SDL_WINDOWEVENT_SIZE_CHANGED:
-					Graphics()->Resize(Event.window.data1, Event.window.data2, -1);
+					Graphics()->GotResized(Event.window.data1, Event.window.data2, -1);
 					break;
 				case SDL_WINDOWEVENT_FOCUS_GAINED:
 					if(m_InputGrabbed)

--- a/src/engine/graphics.h
+++ b/src/engine/graphics.h
@@ -214,7 +214,8 @@ public:
 	virtual bool SetVSync(bool State) = 0;
 	virtual int GetWindowScreen() = 0;
 	virtual void Move(int x, int y) = 0;
-	virtual void Resize(int w, int h, int RefreshRate, bool SetWindowSize = false, bool ForceResizeEvent = false) = 0;
+	virtual void Resize(int w, int h, int RefreshRate) = 0;
+	virtual void GotResized(int w, int h, int RefreshRate) = 0;
 	virtual void AddWindowResizeListener(WINDOW_RESIZE_FUNC pFunc, void *pUser) = 0;
 
 	virtual void WindowDestroyNtf(uint32_t WindowID) = 0;

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -1167,7 +1167,7 @@ void CMenus::RenderSettingsGraphics(CUIRect MainView)
 		g_Config.m_GfxScreenWidth = s_aModes[NewSelected].m_WindowWidth;
 		g_Config.m_GfxScreenHeight = s_aModes[NewSelected].m_WindowHeight;
 		g_Config.m_GfxScreenRefreshRate = s_aModes[NewSelected].m_RefreshRate;
-		Graphics()->Resize(g_Config.m_GfxScreenWidth, g_Config.m_GfxScreenHeight, g_Config.m_GfxScreenRefreshRate, true);
+		Graphics()->Resize(g_Config.m_GfxScreenWidth, g_Config.m_GfxScreenHeight, g_Config.m_GfxScreenRefreshRate);
 	}
 
 	// switches


### PR DESCRIPTION
I noticed that the resize backend used the wrong macros `CONF_PLATFORM_WINDOWS` instead `CONF_FAMILY_WINDOWS`(windows seems to be the only one in detect.h that splits platform between 32bit and 64bit, maybe we should change that)

maybe this fixes #4351, because actually the workaround for windows was exactly inside the wrong macro to fix resizing in fullscreen.

I also split the resize functions, so its less confusing Resize (actively resize in the resolution list) vs GotResized (reported by SDL) and made some things a bit clearer

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
