### PR TITLE
Adopt upstream input (especially double click) handling, refactoring

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -3355,8 +3355,6 @@ void CClient::Run()
 					}
 					m_pGraphics->Swap();
 				}
-
-				Input()->NextFrame();
 			}
 			else if(!IsRenderActive)
 			{

--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -164,17 +164,6 @@ bool CInput::KeyState(int Key) const
 	return m_aInputState[Key];
 }
 
-void CInput::NextFrame()
-{
-	int i;
-	const Uint8 *pState = SDL_GetKeyboardState(&i);
-	if(i >= KEY_LAST)
-		i = KEY_LAST - 1;
-	mem_copy(m_aInputState, pState, i);
-	if(m_EditingTextLen == 0)
-		m_EditingTextLen = -1;
-}
-
 bool CInput::GetIMEState()
 {
 	return m_NumTextInputInstances > 0;
@@ -233,6 +222,16 @@ int CInput::Update()
 {
 	// keep the counter between 1..0xFFFF, 0 means not pressed
 	m_InputCounter = (m_InputCounter % 0xFFFF) + 1;
+
+	{
+		int i;
+		const Uint8 *pState = SDL_GetKeyboardState(&i);
+		if(i >= KEY_LAST)
+			i = KEY_LAST - 1;
+		mem_copy(m_aInputState, pState, i);
+		if(m_EditingTextLen == 0)
+			m_EditingTextLen = -1;
+	}
 
 	// these states must always be updated manually because they are not in the GetKeyState from SDL
 	int i = SDL_GetMouseState(NULL, NULL);

--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -223,15 +223,14 @@ int CInput::Update()
 	// keep the counter between 1..0xFFFF, 0 means not pressed
 	m_InputCounter = (m_InputCounter % 0xFFFF) + 1;
 
-	{
-		int i;
-		const Uint8 *pState = SDL_GetKeyboardState(&i);
-		if(i >= KEY_LAST)
-			i = KEY_LAST - 1;
-		mem_copy(m_aInputState, pState, i);
-		if(m_EditingTextLen == 0)
-			m_EditingTextLen = -1;
-	}
+	int NumKeyStates;
+	const Uint8 *pState = SDL_GetKeyboardState(&NumKeyStates);
+	if(NumKeyStates >= KEY_MOUSE_1)
+		NumKeyStates = KEY_MOUSE_1;
+	mem_copy(m_aInputState, pState, NumKeyStates);
+	mem_zero(m_aInputState + NumKeyStates, KEY_LAST - NumKeyStates);
+	if(m_EditingTextLen == 0)
+		m_EditingTextLen = -1;
 
 	// these states must always be updated manually because they are not in the GetKeyState from SDL
 	const int MouseState = SDL_GetMouseState(NULL, NULL);

--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -40,8 +40,7 @@ CInput::CInput()
 	m_InputCounter = 1;
 	m_InputGrabbed = 0;
 
-	m_LastRelease = 0;
-	m_ReleaseDelta = -1;
+	m_MouseDoubleClick = false;
 
 	m_NumEvents = 0;
 	m_MouseFocus = true;
@@ -126,10 +125,9 @@ bool CInput::NativeMousePressed(int index)
 
 int CInput::MouseDoubleClick()
 {
-	if(m_ReleaseDelta >= 0 && m_ReleaseDelta < (time_freq() / 3))
+	if(m_MouseDoubleClick)
 	{
-		m_LastRelease = 0;
-		m_ReleaseDelta = -1;
+		m_MouseDoubleClick = false;
 		return 1;
 	}
 	return 0;
@@ -311,12 +309,6 @@ int CInput::Update()
 		case SDL_MOUSEBUTTONUP:
 			Action = IInput::FLAG_RELEASE;
 
-			if(Event.button.button == 1) // ignore_convention
-			{
-				m_ReleaseDelta = time_get() - m_LastRelease;
-				m_LastRelease = time_get();
-			}
-
 			// fall through
 		case SDL_MOUSEBUTTONDOWN:
 			if(Event.button.button == SDL_BUTTON_LEFT)
@@ -337,6 +329,8 @@ int CInput::Update()
 				Scancode = KEY_MOUSE_8; // ignore_convention
 			if(Event.button.button == 9)
 				Scancode = KEY_MOUSE_9; // ignore_convention
+			if(Event.button.clicks % 2 == 0 && Event.button.button == SDL_BUTTON_LEFT)
+				m_MouseDoubleClick = true;
 			break;
 
 		case SDL_MOUSEWHEEL:

--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -234,24 +234,24 @@ int CInput::Update()
 	}
 
 	// these states must always be updated manually because they are not in the GetKeyState from SDL
-	int i = SDL_GetMouseState(NULL, NULL);
-	if(i & SDL_BUTTON(1))
-		m_aInputState[KEY_MOUSE_1] = 1; // 1 is left
-	if(i & SDL_BUTTON(3))
-		m_aInputState[KEY_MOUSE_2] = 1; // 3 is right
-	if(i & SDL_BUTTON(2))
-		m_aInputState[KEY_MOUSE_3] = 1; // 2 is middle
-	if(i & SDL_BUTTON(4))
+	const int MouseState = SDL_GetMouseState(NULL, NULL);
+	if(MouseState & SDL_BUTTON(SDL_BUTTON_LEFT))
+		m_aInputState[KEY_MOUSE_1] = 1;
+	if(MouseState & SDL_BUTTON(SDL_BUTTON_RIGHT))
+		m_aInputState[KEY_MOUSE_2] = 1;
+	if(MouseState & SDL_BUTTON(SDL_BUTTON_MIDDLE))
+		m_aInputState[KEY_MOUSE_3] = 1;
+	if(MouseState & SDL_BUTTON(SDL_BUTTON_X1))
 		m_aInputState[KEY_MOUSE_4] = 1;
-	if(i & SDL_BUTTON(5))
+	if(MouseState & SDL_BUTTON(SDL_BUTTON_X2))
 		m_aInputState[KEY_MOUSE_5] = 1;
-	if(i & SDL_BUTTON(6))
+	if(MouseState & SDL_BUTTON(6))
 		m_aInputState[KEY_MOUSE_6] = 1;
-	if(i & SDL_BUTTON(7))
+	if(MouseState & SDL_BUTTON(7))
 		m_aInputState[KEY_MOUSE_7] = 1;
-	if(i & SDL_BUTTON(8))
+	if(MouseState & SDL_BUTTON(8))
 		m_aInputState[KEY_MOUSE_8] = 1;
-	if(i & SDL_BUTTON(9))
+	if(MouseState & SDL_BUTTON(9))
 		m_aInputState[KEY_MOUSE_9] = 1;
 
 	{

--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -329,8 +329,13 @@ int CInput::Update()
 				Scancode = KEY_MOUSE_8; // ignore_convention
 			if(Event.button.button == 9)
 				Scancode = KEY_MOUSE_9; // ignore_convention
-			if(Event.button.clicks % 2 == 0 && Event.button.button == SDL_BUTTON_LEFT)
-				m_MouseDoubleClick = true;
+			if(Event.button.button == SDL_BUTTON_LEFT)
+			{
+				if(Event.button.clicks % 2 == 0)
+					m_MouseDoubleClick = true;
+				if(Event.button.clicks == 1)
+					m_MouseDoubleClick = false;
+			}
 			break;
 
 		case SDL_MOUSEWHEEL:

--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -123,14 +123,14 @@ bool CInput::NativeMousePressed(int index)
 	return (i & SDL_BUTTON(index)) != 0;
 }
 
-int CInput::MouseDoubleClick()
+bool CInput::MouseDoubleClick()
 {
 	if(m_MouseDoubleClick)
 	{
 		m_MouseDoubleClick = false;
-		return 1;
+		return true;
 	}
-	return 0;
+	return false;
 }
 
 const char *CInput::GetClipboardText()

--- a/src/engine/client/input.h
+++ b/src/engine/client/input.h
@@ -57,7 +57,7 @@ public:
 	virtual void MouseModeRelative();
 	virtual void NativeMousePos(int *x, int *y) const;
 	virtual bool NativeMousePressed(int index);
-	virtual int MouseDoubleClick();
+	virtual bool MouseDoubleClick();
 	virtual const char *GetClipboardText();
 	virtual void SetClipboardText(const char *Text);
 

--- a/src/engine/client/input.h
+++ b/src/engine/client/input.h
@@ -19,10 +19,9 @@ class CInput : public IEngineInput
 	int m_InputGrabbed;
 	char *m_pClipboardText;
 
-	int64_t m_LastRelease;
-	int64_t m_ReleaseDelta;
-
 	bool m_MouseFocus;
+	bool m_MouseDoubleClick;
+
 	int m_VideoRestartNeeded;
 
 	void AddEvent(char *pText, int Key, int Flags);

--- a/src/engine/client/input.h
+++ b/src/engine/client/input.h
@@ -63,7 +63,6 @@ public:
 	virtual void SetClipboardText(const char *Text);
 
 	virtual int Update();
-	virtual void NextFrame();
 
 	virtual int VideoRestartNeeded();
 

--- a/src/engine/input.h
+++ b/src/engine/input.h
@@ -93,7 +93,6 @@ class IEngineInput : public IInput
 public:
 	virtual void Init() = 0;
 	virtual int Update() = 0;
-	virtual void NextFrame() = 0;
 	virtual int VideoRestartNeeded() = 0;
 };
 

--- a/src/engine/input.h
+++ b/src/engine/input.h
@@ -73,7 +73,7 @@ public:
 	virtual bool NativeMousePressed(int index) = 0;
 	virtual void MouseModeRelative() = 0;
 	virtual void MouseModeAbsolute() = 0;
-	virtual int MouseDoubleClick() = 0;
+	virtual bool MouseDoubleClick() = 0;
 	virtual const char *GetClipboardText() = 0;
 	virtual void SetClipboardText(const char *Text) = 0;
 

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -1195,7 +1195,7 @@ void CMenus::RenderDemoList(CUIRect MainView)
 
 	bool Activated = false;
 
-	if(m_EnterPressed || (Input()->MouseDoubleClick() && UI()->HotItem() == m_lDemos[m_DemolistSelectedIndex].m_aName))
+	if(m_EnterPressed || (UI()->HotItem() == m_lDemos[m_DemolistSelectedIndex].m_aName && Input()->MouseDoubleClick()))
 	{
 		UI()->SetActiveItem(0);
 		Activated = true;


### PR DESCRIPTION
This adopts the 0.7 way of handling double clicks, by checking `Event.button.clicks` of the `SDL_Event`. The double click is stored as a flag which is cleared when the `MouseDoubleClick()` function is called (d215c732062cbc73b9922ce270be70c36d00bb9d and 7977b46d36aee6e0eb4676ed1f9a14859d9f5408).

This reverts 72a6e20, as this hack is no longer required (closes #1745). Double clicking a friend in the friend list still works (#444) with both `gfx_asyncrender_old 0` and `1`.

Refactorings and minor fixes synchronizing with upstream:

- Only copy SDL keystate of _keyboard_ keys and mem_zero the rest to ensure out of bounds SDL keys don't trigger mouse keys.
- Rename variables and use SDL constants.
- Reduce unnecessary indentation.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [X] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
