### PR TITLE
Revert LFREEZE-LUNFREEZE explanation on editor for Switch layer

### DIFF
--- a/src/game/editor/explanations.cpp
+++ b/src/game/editor/explanations.cpp
@@ -46,13 +46,13 @@ const char *CEditor::Explain(int ExplanationID, int Tile, int Layer) //TODO: Add
 				return "JUMP: Sets defined amount of jumps (default is 2).";
 			break;
 		case TILE_FREEZE:
-			if(Layer == LAYER_GAME || Layer == LAYER_FRONT || Layer == LAYER_SWITCH)
+			if(Layer == LAYER_GAME || Layer == LAYER_FRONT)
 				return "FREEZE: Freezes tees for 3 seconds.";
 			if(Layer == LAYER_SWITCH)
 				return "FREEZE: Freezes tees for defined amount of seconds.";
 			break;
 		case TILE_UNFREEZE:
-			if(Layer == LAYER_GAME || Layer == LAYER_FRONT || Layer == LAYER_SWITCH)
+			if(Layer == LAYER_GAME || Layer == LAYER_FRONT)
 				return "UNFREEZE: Unfreezes tees immediately.";
 			break;
 		case TILE_TELEINEVIL:


### PR DESCRIPTION
Thank @fokkonaut
Revert two lines to original.

Commit to be reverted:
https://github.com/ddnet/ddnet/commit/2017464282aa55fc21c90229a5acc3376ce5ecac#diff-6ecdf8a78005b8c2541e54e3532ebec8f3f4ef2ec69ba8a6a281ce4421562570


## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
