### PR TITLE
Use LTO when possible

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,10 @@ include(CheckCXXCompilerFlag)
 include(CheckSymbolExists)
 include(CheckAtomic)
 
+if(CMAKE_BUILD_TYPE MATCHES "^(Release|RelWithDebInfo)$")
+  set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE) # LTO
+endif()
+
 check_symbol_exists(__i386 "" TARGET_ARCH_X86_i386)
 if(TARGET_ARCH_X86_i386)
   set(TARGET_ARCH x86)


### PR DESCRIPTION
Not much of a difference but doesn't cost much either:
https://openbenchmarking.org/result/2201183-DEF-NONLTO6564
https://openbenchmarking.org/result/2201183-DEF-LTO6334352

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
