### PR TITLE
Fix double clicking on folders in demo browser

### DIFF
--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -1194,8 +1194,7 @@ void CMenus::RenderDemoList(CUIRect MainView)
 	UI()->ClipDisable();
 
 	bool Activated = false;
-
-	if(m_EnterPressed || (UI()->HotItem() == m_lDemos[m_DemolistSelectedIndex].m_aName && Input()->MouseDoubleClick()))
+	if(m_EnterPressed || (NewSelected >= 0 && Input()->MouseDoubleClick()))
 	{
 		UI()->SetActiveItem(0);
 		Activated = true;


### PR DESCRIPTION
Double clicking a folder in the demo browser may activate the current or a different item twice.

I assume it's a regression from #4607. Vanilla also had https://github.com/teeworlds/teeworlds/pull/1913/commits/37f288e211d7f7cab14d71655edc0ce3835c7c30 where I took the idea for this fix: the check is change so instead of `HotItem` (or `ActiveItem`) the activation of the underlying button is checked (here by `NewSelected >= 0`). So now the double click will only register when the mouse is _released_ for the second time. Previously both the second press and the release event where causing the double click to happen.


## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
