### PR TITLE
Refactoring: move RenderTilemapGenerateSkip to CLayers, Add CLayers::NumLayers

### DIFF
--- a/src/game/client/components/background.cpp
+++ b/src/game/client/components/background.cpp
@@ -78,7 +78,6 @@ void CBackground::LoadBackground()
 	else if(m_pMap->Load(aBuf))
 	{
 		m_pLayers->InitBackground(m_pMap);
-		RenderTools()->RenderTilemapGenerateSkip(m_pLayers);
 		NeedImageLoading = true;
 		m_Loaded = true;
 	}

--- a/src/game/client/components/menu_background.cpp
+++ b/src/game/client/components/menu_background.cpp
@@ -255,7 +255,6 @@ void CMenuBackground::LoadMenuBackground(bool HasDayHint, bool HasNightHint)
 		if(m_Loaded)
 		{
 			m_pLayers->InitBackground(m_pMap);
-			RenderTools()->RenderTilemapGenerateSkip(m_pLayers);
 			NeedImageLoading = true;
 
 			CMapLayers::OnMapLoad();

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -422,8 +422,6 @@ void CGameClient::OnConnected()
 	m_Layers.Init(Kernel());
 	m_Collision.Init(Layers());
 
-	RenderTools()->RenderTilemapGenerateSkip(Layers());
-
 	CRaceHelper::ms_aFlagIndex[0] = -1;
 	CRaceHelper::ms_aFlagIndex[1] = -1;
 

--- a/src/game/client/render.cpp
+++ b/src/game/client/render.cpp
@@ -774,37 +774,3 @@ void CRenderTools::MapscreenToWorld(float CenterX, float CenterY, float Parallax
 	pPoints[2] = pPoints[0] + Width;
 	pPoints[3] = pPoints[1] + Height;
 }
-
-void CRenderTools::RenderTilemapGenerateSkip(class CLayers *pLayers)
-{
-	for(int g = 0; g < pLayers->NumGroups(); g++)
-	{
-		CMapItemGroup *pGroup = pLayers->GetGroup(g);
-
-		for(int l = 0; l < pGroup->m_NumLayers; l++)
-		{
-			CMapItemLayer *pLayer = pLayers->GetLayer(pGroup->m_StartLayer + l);
-
-			if(pLayer->m_Type == LAYERTYPE_TILES)
-			{
-				CMapItemLayerTilemap *pTmap = (CMapItemLayerTilemap *)pLayer;
-				CTile *pTiles = (CTile *)pLayers->Map()->GetData(pTmap->m_Data);
-				for(int y = 0; y < pTmap->m_Height; y++)
-				{
-					for(int x = 1; x < pTmap->m_Width;)
-					{
-						int sx;
-						for(sx = 1; x + sx < pTmap->m_Width && sx < 255; sx++)
-						{
-							if(pTiles[y * pTmap->m_Width + x + sx].m_Index)
-								break;
-						}
-
-						pTiles[y * pTmap->m_Width + x].m_Skip = sx - 1;
-						x += sx;
-					}
-				}
-			}
-		}
-	}
-}

--- a/src/game/client/render.h
+++ b/src/game/client/render.h
@@ -103,8 +103,6 @@ public:
 	void DrawCircle(float x, float y, float r, int Segments);
 
 	// larger rendering methods
-	void RenderTilemapGenerateSkip(class CLayers *pLayers);
-
 	void GetRenderTeeBodySize(class CAnimState *pAnim, CTeeRenderInfo *pInfo, vec2 &BodyOffset, float &Width, float &Height);
 	void GetRenderTeeFeetSize(class CAnimState *pAnim, CTeeRenderInfo *pInfo, vec2 &FeetOffset, float &Width, float &Height);
 

--- a/src/game/layers.cpp
+++ b/src/game/layers.cpp
@@ -167,29 +167,29 @@ void CLayers::InitTilemapSkip()
 {
 	for(int g = 0; g < NumGroups(); g++)
 	{
-		CMapItemGroup *pGroup = GetGroup(g);
+		const CMapItemGroup *pGroup = GetGroup(g);
 
 		for(int l = 0; l < pGroup->m_NumLayers; l++)
 		{
-			CMapItemLayer *pLayer = GetLayer(pGroup->m_StartLayer + l);
+			const CMapItemLayer *pLayer = GetLayer(pGroup->m_StartLayer + l);
 
 			if(pLayer->m_Type == LAYERTYPE_TILES)
 			{
-				CMapItemLayerTilemap *pTmap = (CMapItemLayerTilemap *)pLayer;
-				CTile *pTiles = (CTile *)m_pMap->GetData(pTmap->m_Data);
-				for(int y = 0; y < pTmap->m_Height; y++)
+				const CMapItemLayerTilemap *pTilemap = (CMapItemLayerTilemap *)pLayer;
+				CTile *pTiles = (CTile *)m_pMap->GetData(pTilemap->m_Data);
+				for(int y = 0; y < pTilemap->m_Height; y++)
 				{
-					for(int x = 1; x < pTmap->m_Width;)
+					for(int x = 1; x < pTilemap->m_Width;)
 					{
-						int sx;
-						for(sx = 1; x + sx < pTmap->m_Width && sx < 255; sx++)
+						int SkippedX;
+						for(SkippedX = 1; x + SkippedX < pTilemap->m_Width && SkippedX < 255; SkippedX++)
 						{
-							if(pTiles[y * pTmap->m_Width + x + sx].m_Index)
+							if(pTiles[y * pTilemap->m_Width + x + SkippedX].m_Index)
 								break;
 						}
 
-						pTiles[y * pTmap->m_Width + x].m_Skip = sx - 1;
-						x += sx;
+						pTiles[y * pTilemap->m_Width + x].m_Skip = SkippedX - 1;
+						x += SkippedX;
 					}
 				}
 			}

--- a/src/game/layers.cpp
+++ b/src/game/layers.cpp
@@ -107,6 +107,8 @@ void CLayers::Init(class IKernel *pKernel)
 			}
 		}
 	}
+
+	InitTilemapSkip();
 }
 
 void CLayers::InitBackground(class IMap *pMap)
@@ -153,6 +155,42 @@ void CLayers::InitBackground(class IMap *pMap)
 						m_pGameGroup->m_ClipH = 0;
 					}
 					//We don't care about tile layers.
+				}
+			}
+		}
+	}
+
+	InitTilemapSkip();
+}
+
+void CLayers::InitTilemapSkip()
+{
+	for(int g = 0; g < NumGroups(); g++)
+	{
+		CMapItemGroup *pGroup = GetGroup(g);
+
+		for(int l = 0; l < pGroup->m_NumLayers; l++)
+		{
+			CMapItemLayer *pLayer = GetLayer(pGroup->m_StartLayer + l);
+
+			if(pLayer->m_Type == LAYERTYPE_TILES)
+			{
+				CMapItemLayerTilemap *pTmap = (CMapItemLayerTilemap *)pLayer;
+				CTile *pTiles = (CTile *)m_pMap->GetData(pTmap->m_Data);
+				for(int y = 0; y < pTmap->m_Height; y++)
+				{
+					for(int x = 1; x < pTmap->m_Width;)
+					{
+						int sx;
+						for(sx = 1; x + sx < pTmap->m_Width && sx < 255; sx++)
+						{
+							if(pTiles[y * pTmap->m_Width + x + sx].m_Index)
+								break;
+						}
+
+						pTiles[y * pTmap->m_Width + x].m_Skip = sx - 1;
+						x += sx;
+					}
 				}
 			}
 		}

--- a/src/game/layers.h
+++ b/src/game/layers.h
@@ -22,21 +22,21 @@ public:
 	CLayers();
 	void Init(class IKernel *pKernel);
 	void InitBackground(class IMap *pMap);
-	int NumGroups() const { return m_GroupsNum; };
+	int NumGroups() const { return m_GroupsNum; }
 	int NumLayers() const { return m_LayersNum; }
-	class IMap *Map() const { return m_pMap; };
-	CMapItemGroup *GameGroup() const { return m_pGameGroup; };
-	CMapItemLayerTilemap *GameLayer() const { return m_pGameLayer; };
+	class IMap *Map() const { return m_pMap; }
+	CMapItemGroup *GameGroup() const { return m_pGameGroup; }
+	CMapItemLayerTilemap *GameLayer() const { return m_pGameLayer; }
 	CMapItemGroup *GetGroup(int Index) const;
 	CMapItemLayer *GetLayer(int Index) const;
 
 	// DDRace
 
-	CMapItemLayerTilemap *TeleLayer() const { return m_pTeleLayer; };
-	CMapItemLayerTilemap *SpeedupLayer() const { return m_pSpeedupLayer; };
-	CMapItemLayerTilemap *FrontLayer() const { return m_pFrontLayer; };
-	CMapItemLayerTilemap *SwitchLayer() const { return m_pSwitchLayer; };
-	CMapItemLayerTilemap *TuneLayer() const { return m_pTuneLayer; };
+	CMapItemLayerTilemap *TeleLayer() const { return m_pTeleLayer; }
+	CMapItemLayerTilemap *SpeedupLayer() const { return m_pSpeedupLayer; }
+	CMapItemLayerTilemap *FrontLayer() const { return m_pFrontLayer; }
+	CMapItemLayerTilemap *SwitchLayer() const { return m_pSwitchLayer; }
+	CMapItemLayerTilemap *TuneLayer() const { return m_pTuneLayer; }
 
 private:
 	CMapItemLayerTilemap *m_pTeleLayer;

--- a/src/game/layers.h
+++ b/src/game/layers.h
@@ -16,6 +16,8 @@ class CLayers
 	CMapItemLayerTilemap *m_pGameLayer;
 	class IMap *m_pMap;
 
+	void InitTilemapSkip();
+
 public:
 	CLayers();
 	void Init(class IKernel *pKernel);

--- a/src/game/layers.h
+++ b/src/game/layers.h
@@ -23,6 +23,7 @@ public:
 	void Init(class IKernel *pKernel);
 	void InitBackground(class IMap *pMap);
 	int NumGroups() const { return m_GroupsNum; };
+	int NumLayers() const { return m_LayersNum; }
 	class IMap *Map() const { return m_pMap; };
 	CMapItemGroup *GameGroup() const { return m_pGameGroup; };
 	CMapItemLayerTilemap *GameLayer() const { return m_pGameLayer; };


### PR DESCRIPTION
- Move `CRenderTools::RenderTilemapGenerateSkip` to `CLayers::InitTilemapSkip`, as it can be a private function in `CLayers`.
- Add missing `CLayers::NumLayers` accessor.
- Improve code style.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
