### PR TITLE
Refactor: Distinguish between two concepts previously called "Dummy"

### DIFF
--- a/src/engine/client.h
+++ b/src/engine/client.h
@@ -64,10 +64,10 @@ public:
 
 	enum
 	{
-		CLIENT_MAIN = 0,
-		CLIENT_DUMMY,
-		CLIENT_CONTACT,
-		NUM_CLIENTS,
+		CONN_MAIN = 0,
+		CONN_DUMMY,
+		CONN_CONTACT,
+		NUM_CONNS,
 	};
 
 	/* Constants: Client States
@@ -94,13 +94,13 @@ public:
 	inline int State() const { return m_State; }
 
 	// tick time access
-	inline int PrevGameTick(int Client) const { return m_PrevGameTick[Client]; }
-	inline int GameTick(int Client) const { return m_CurGameTick[Client]; }
-	inline int PredGameTick(int Client) const { return m_PredTick[Client]; }
-	inline float IntraGameTick(int Client) const { return m_GameIntraTick[Client]; }
-	inline float PredIntraGameTick(int Client) const { return m_PredIntraTick[Client]; }
-	inline float IntraGameTickSincePrev(int Client) const { return m_GameIntraTickSincePrev[Client]; }
-	inline float GameTickTime(int Client) const { return m_GameTickTime[Client]; }
+	inline int PrevGameTick(int Conn) const { return m_PrevGameTick[Conn]; }
+	inline int GameTick(int Conn) const { return m_CurGameTick[Conn]; }
+	inline int PredGameTick(int Conn) const { return m_PredTick[Conn]; }
+	inline float IntraGameTick(int Conn) const { return m_GameIntraTick[Conn]; }
+	inline float PredIntraGameTick(int Conn) const { return m_PredIntraTick[Conn]; }
+	inline float IntraGameTickSincePrev(int Conn) const { return m_GameIntraTickSincePrev[Conn]; }
+	inline float GameTickTime(int Conn) const { return m_GameTickTime[Conn]; }
 	inline int GameTickSpeed() const { return m_GameTickSpeed; }
 
 	// other time access
@@ -142,7 +142,7 @@ public:
 	virtual void Notify(const char *pTitle, const char *pMessage) = 0;
 
 	// networking
-	virtual void EnterGame(int Client) = 0;
+	virtual void EnterGame(int Conn) = 0;
 
 	//
 	virtual const char *MapDownloadName() const = 0;
@@ -181,7 +181,7 @@ public:
 
 	virtual void SnapSetStaticsize(int ItemType, int Size) = 0;
 
-	virtual int SendMsg(int Client, CMsgPacker *pMsg, int Flags) = 0;
+	virtual int SendMsg(int Conn, CMsgPacker *pMsg, int Flags) = 0;
 	virtual int SendMsgActive(CMsgPacker *pMsg, int Flags) = 0;
 
 	template<class T>
@@ -251,7 +251,7 @@ public:
 	virtual void OnUpdate() = 0;
 	virtual void OnStateChange(int NewState, int OldState) = 0;
 	virtual void OnConnected() = 0;
-	virtual void OnMessage(int MsgID, CUnpacker *pUnpacker, int Client, bool Dummy) = 0;
+	virtual void OnMessage(int MsgID, CUnpacker *pUnpacker, int Conn, bool Dummy) = 0;
 	virtual void OnPredict() = 0;
 	virtual void OnActivateEditor() = 0;
 

--- a/src/engine/client.h
+++ b/src/engine/client.h
@@ -62,6 +62,14 @@ public:
 		int m_DataSize;
 	};
 
+	enum
+	{
+		CLIENT_MAIN = 0,
+		CLIENT_DUMMY,
+		CLIENT_CONTACT,
+		NUM_CLIENTS,
+	};
+
 	/* Constants: Client States
 		STATE_OFFLINE - The client is offline.
 		STATE_CONNECTING - The client is trying to connect to a server.
@@ -86,13 +94,13 @@ public:
 	inline int State() const { return m_State; }
 
 	// tick time access
-	inline int PrevGameTick(int Dummy) const { return m_PrevGameTick[Dummy]; }
-	inline int GameTick(int Dummy) const { return m_CurGameTick[Dummy]; }
-	inline int PredGameTick(int Dummy) const { return m_PredTick[Dummy]; }
-	inline float IntraGameTick(int Dummy) const { return m_GameIntraTick[Dummy]; }
-	inline float PredIntraGameTick(int Dummy) const { return m_PredIntraTick[Dummy]; }
-	inline float IntraGameTickSincePrev(int Dummy) const { return m_GameIntraTickSincePrev[Dummy]; }
-	inline float GameTickTime(int Dummy) const { return m_GameTickTime[Dummy]; }
+	inline int PrevGameTick(int Client) const { return m_PrevGameTick[Client]; }
+	inline int GameTick(int Client) const { return m_CurGameTick[Client]; }
+	inline int PredGameTick(int Client) const { return m_PredTick[Client]; }
+	inline float IntraGameTick(int Client) const { return m_GameIntraTick[Client]; }
+	inline float PredIntraGameTick(int Client) const { return m_PredIntraTick[Client]; }
+	inline float IntraGameTickSincePrev(int Client) const { return m_GameIntraTickSincePrev[Client]; }
+	inline float GameTickTime(int Client) const { return m_GameTickTime[Client]; }
 	inline int GameTickSpeed() const { return m_GameTickSpeed; }
 
 	// other time access
@@ -134,7 +142,7 @@ public:
 	virtual void Notify(const char *pTitle, const char *pMessage) = 0;
 
 	// networking
-	virtual void EnterGame(bool Dummy) = 0;
+	virtual void EnterGame(int Client) = 0;
 
 	//
 	virtual const char *MapDownloadName() const = 0;
@@ -173,16 +181,16 @@ public:
 
 	virtual void SnapSetStaticsize(int ItemType, int Size) = 0;
 
-	virtual int SendMsg(CMsgPacker *pMsg, int Flags) = 0;
-	virtual int SendMsgY(CMsgPacker *pMsg, int Flags, int NetClient = 1) = 0;
+	virtual int SendMsg(int Client, CMsgPacker *pMsg, int Flags) = 0;
+	virtual int SendMsgActive(CMsgPacker *pMsg, int Flags) = 0;
 
 	template<class T>
-	int SendPackMsg(T *pMsg, int Flags)
+	int SendPackMsgActive(T *pMsg, int Flags)
 	{
 		CMsgPacker Packer(pMsg->MsgID(), false);
 		if(pMsg->Pack(&Packer))
 			return -1;
-		return SendMsg(&Packer, Flags);
+		return SendMsgActive(&Packer, Flags);
 	}
 
 	//
@@ -243,7 +251,7 @@ public:
 	virtual void OnUpdate() = 0;
 	virtual void OnStateChange(int NewState, int OldState) = 0;
 	virtual void OnConnected() = 0;
-	virtual void OnMessage(int MsgID, CUnpacker *pUnpacker, bool Dummy = 0) = 0;
+	virtual void OnMessage(int MsgID, CUnpacker *pUnpacker, int Client, bool Dummy) = 0;
 	virtual void OnPredict() = 0;
 	virtual void OnActivateEditor() = 0;
 

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -1778,12 +1778,12 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket, int Client, bool Dummy)
 			if(m_RconAuthed[0])
 				RconAuth("", m_RconPassword);
 		}
-		else if(!Dummy && Msg == NETMSG_PING)
+		else if(Msg == NETMSG_PING)
 		{
 			CMsgPacker Msg(NETMSG_PING_REPLY, true);
 			SendMsg(Client, &Msg, 0);
 		}
-		else if(!Dummy && Msg == NETMSG_PINGEX)
+		else if(Msg == NETMSG_PINGEX)
 		{
 			CUuid *pID = (CUuid *)Unpacker.GetRaw(sizeof(*pID));
 			if(Unpacker.Error())
@@ -1844,13 +1844,13 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket, int Client, bool Dummy)
 			if(Unpacker.Error() == 0)
 				GameClient()->OnRconLine(pLine);
 		}
-		else if(!Dummy && Msg == NETMSG_PING_REPLY)
+		else if(Client == CLIENT_MAIN && Msg == NETMSG_PING_REPLY)
 		{
 			char aBuf[256];
 			str_format(aBuf, sizeof(aBuf), "latency %.2f", (time_get() - m_PingStartTime) * 1000 / (float)time_freq());
 			m_pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "client/network", aBuf);
 		}
-		else if(!Dummy && Msg == NETMSG_INPUTTIMING)
+		else if(Msg == NETMSG_INPUTTIMING)
 		{
 			int InputPredTick = Unpacker.GetInt();
 			int TimeLeft = Unpacker.GetInt();
@@ -2048,12 +2048,12 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket, int Client, bool Dummy)
 						m_GameTime[Client].Init((GameTick - 1) * time_freq() / 50);
 						m_aSnapshots[Client][SNAP_PREV] = m_SnapshotStorage[Client].m_pFirst;
 						m_aSnapshots[Client][SNAP_CURRENT] = m_SnapshotStorage[Client].m_pLast;
-						m_LocalStartTime = time_get(); // TODO: why reset this for dummy?
-#if defined(CONF_VIDEORECORDER)
-						IVideo::SetLocalStartTime(m_LocalStartTime); // TODO: why reset this for dummy?
-#endif
 						if(!Dummy)
 						{
+							m_LocalStartTime = time_get();
+#if defined(CONF_VIDEORECORDER)
+							IVideo::SetLocalStartTime(m_LocalStartTime);
+#endif
 							GameClient()->OnNewSnapshot();
 						}
 						SetState(IClient::STATE_ONLINE);
@@ -2100,7 +2100,7 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket, int Client, bool Dummy)
 				}
 			}
 		}
-		else if(!Dummy && Msg == NETMSG_RCONTYPE)
+		else if(Client == CLIENT_MAIN && Msg == NETMSG_RCONTYPE)
 		{
 			bool UsernameReq = Unpacker.GetInt() & 1;
 			GameClient()->OnRconType(UsernameReq);

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -116,14 +116,6 @@ class CClient : public IClient, public CDemoPlayer::IListener
 		NUM_SNAPSHOT_TYPES = 2,
 	};
 
-	enum
-	{
-		CLIENT_MAIN = 0,
-		CLIENT_DUMMY,
-		CLIENT_CONTACT,
-		NUM_CLIENTS,
-	};
-
 	class CNetClient m_NetClient[NUM_CLIENTS];
 	class CDemoPlayer m_DemoPlayer;
 	class CDemoRecorder m_DemoRecorder[RECORDER_MAX];
@@ -307,11 +299,12 @@ public:
 	CClient();
 
 	// ----- send functions -----
-	virtual int SendMsg(CMsgPacker *pMsg, int Flags);
-	virtual int SendMsgY(CMsgPacker *pMsg, int Flags, int NetClient = 1);
+	virtual int SendMsg(int Client, CMsgPacker *pMsg, int Flags);
+	// Send via the currently active client (main/dummy)
+	virtual int SendMsgActive(CMsgPacker *pMsg, int Flags);
 
 	void SendInfo();
-	void SendEnterGame(bool Dummy);
+	void SendEnterGame(int Client);
 	void SendReady();
 	void SendMapRequest();
 
@@ -340,7 +333,7 @@ public:
 
 	// called when the map is loaded and we should init for a new round
 	void OnEnterGame(bool Dummy);
-	virtual void EnterGame(bool Dummy);
+	virtual void EnterGame(int Client);
 
 	virtual void Connect(const char *pAddress, const char *pPassword = NULL);
 	void DisconnectWithReason(const char *pReason);
@@ -384,8 +377,7 @@ public:
 
 	void ProcessConnlessPacket(CNetChunk *pPacket);
 	void ProcessServerInfo(int Type, NETADDR *pFrom, const void *pData, int DataSize);
-	void ProcessServerPacket(CNetChunk *pPacket);
-	void ProcessServerPacketDummy(CNetChunk *pPacket);
+	void ProcessServerPacket(CNetChunk *pPacket, int Client, bool Dummy);
 
 	void ResetMapDownload();
 	void FinishMapDownload();

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -116,7 +116,7 @@ class CClient : public IClient, public CDemoPlayer::IListener
 		NUM_SNAPSHOT_TYPES = 2,
 	};
 
-	class CNetClient m_NetClient[NUM_CLIENTS];
+	class CNetClient m_NetClient[NUM_CONNS];
 	class CDemoPlayer m_DemoPlayer;
 	class CDemoRecorder m_DemoRecorder[RECORDER_MAX];
 	class CDemoEditor m_DemoEditor;
@@ -299,12 +299,12 @@ public:
 	CClient();
 
 	// ----- send functions -----
-	virtual int SendMsg(int Client, CMsgPacker *pMsg, int Flags);
+	virtual int SendMsg(int Conn, CMsgPacker *pMsg, int Flags);
 	// Send via the currently active client (main/dummy)
 	virtual int SendMsgActive(CMsgPacker *pMsg, int Flags);
 
 	void SendInfo();
-	void SendEnterGame(int Client);
+	void SendEnterGame(int Conn);
 	void SendReady();
 	void SendMapRequest();
 
@@ -333,7 +333,7 @@ public:
 
 	// called when the map is loaded and we should init for a new round
 	void OnEnterGame(bool Dummy);
-	virtual void EnterGame(int Client);
+	virtual void EnterGame(int Conn);
 
 	virtual void Connect(const char *pAddress, const char *pPassword = NULL);
 	void DisconnectWithReason(const char *pReason);
@@ -377,7 +377,7 @@ public:
 
 	void ProcessConnlessPacket(CNetChunk *pPacket);
 	void ProcessServerInfo(int Type, NETADDR *pFrom, const void *pData, int DataSize);
-	void ProcessServerPacket(CNetChunk *pPacket, int Client, bool Dummy);
+	void ProcessServerPacket(CNetChunk *pPacket, int Conn, bool Dummy);
 
 	void ResetMapDownload();
 	void FinishMapDownload();

--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -1357,7 +1357,7 @@ void CChat::Say(int Team, const char *pLine)
 	CNetMsg_Cl_Say Msg;
 	Msg.m_Team = Team;
 	Msg.m_pMessage = pLine;
-	Client()->SendPackMsg(&Msg, MSGFLAG_VITAL);
+	Client()->SendPackMsgActive(&Msg, MSGFLAG_VITAL);
 }
 
 void CChat::SayChat(const char *pLine)

--- a/src/game/client/components/emoticon.cpp
+++ b/src/game/client/components/emoticon.cpp
@@ -185,13 +185,13 @@ void CEmoticon::Emote(int Emoticon)
 {
 	CNetMsg_Cl_Emoticon Msg;
 	Msg.m_Emoticon = Emoticon;
-	Client()->SendPackMsg(&Msg, MSGFLAG_VITAL);
+	Client()->SendPackMsgActive(&Msg, MSGFLAG_VITAL);
 
 	if(g_Config.m_ClDummyCopyMoves)
 	{
 		CMsgPacker Msg(NETMSGTYPE_CL_EMOTICON, false);
 		Msg.AddInt(Emoticon);
-		Client()->SendMsgY(&Msg, MSGFLAG_VITAL, !g_Config.m_ClDummy);
+		Client()->SendMsg(!g_Config.m_ClDummy, &Msg, MSGFLAG_VITAL);
 	}
 }
 

--- a/src/game/client/components/sounds.cpp
+++ b/src/game/client/components/sounds.cpp
@@ -184,7 +184,7 @@ void CSounds::PlayAndRecord(int Chn, int SetId, float Vol, vec2 Pos)
 {
 	CNetMsg_Sv_SoundGlobal Msg;
 	Msg.m_SoundID = SetId;
-	Client()->SendPackMsg(&Msg, MSGFLAG_NOSEND | MSGFLAG_RECORD);
+	Client()->SendPackMsgActive(&Msg, MSGFLAG_NOSEND | MSGFLAG_RECORD);
 
 	Play(Chn, SetId, Vol);
 }

--- a/src/game/client/components/spectator.cpp
+++ b/src/game/client/components/spectator.cpp
@@ -466,5 +466,5 @@ void CSpectator::Spectate(int SpectatorID)
 
 	CNetMsg_Cl_SetSpectatorMode Msg;
 	Msg.m_SpectatorID = SpectatorID;
-	Client()->SendPackMsg(&Msg, MSGFLAG_VITAL);
+	Client()->SendPackMsgActive(&Msg, MSGFLAG_VITAL);
 }

--- a/src/game/client/components/voting.cpp
+++ b/src/game/client/components/voting.cpp
@@ -31,7 +31,7 @@ void CVoting::Callvote(const char *pType, const char *pValue, const char *pReaso
 	Msg.m_Type = pType;
 	Msg.m_Value = pValue;
 	Msg.m_Reason = pReason;
-	Client()->SendPackMsg(&Msg, MSGFLAG_VITAL);
+	Client()->SendPackMsgActive(&Msg, MSGFLAG_VITAL);
 }
 
 void CVoting::CallvoteSpectate(int ClientID, const char *pReason, bool ForceVote)
@@ -133,7 +133,7 @@ void CVoting::Vote(int v)
 {
 	m_Voted = v;
 	CNetMsg_Cl_Vote Msg = {v};
-	Client()->SendPackMsg(&Msg, MSGFLAG_VITAL);
+	Client()->SendPackMsgActive(&Msg, MSGFLAG_VITAL);
 }
 
 CVoting::CVoting()

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -659,7 +659,7 @@ void CGameClient::OnRelease()
 		m_All.m_paComponents[i]->OnRelease();
 }
 
-void CGameClient::OnMessage(int MsgId, CUnpacker *pUnpacker, int Client, bool Dummy)
+void CGameClient::OnMessage(int MsgId, CUnpacker *pUnpacker, int Conn, bool Dummy)
 {
 	// special messages
 	if(MsgId == NETMSGTYPE_SV_TUNEPARAMS)
@@ -682,9 +682,9 @@ void CGameClient::OnMessage(int MsgId, CUnpacker *pUnpacker, int Client, bool Du
 
 		m_ServerMode = SERVERMODE_PURE;
 
-		m_ReceivedTuning[Client] = true;
+		m_ReceivedTuning[Conn] = true;
 		// apply new tuning
-		m_Tuning[Client] = NewTuning;
+		m_Tuning[Conn] = NewTuning;
 		return;
 	}
 
@@ -717,7 +717,7 @@ void CGameClient::OnMessage(int MsgId, CUnpacker *pUnpacker, int Client, bool Du
 
 	if(MsgId == NETMSGTYPE_SV_READYTOENTER)
 	{
-		this->Client()->EnterGame(Client);
+		Client()->EnterGame(Conn);
 	}
 	else if(MsgId == NETMSGTYPE_SV_EMOTICON)
 	{
@@ -725,8 +725,8 @@ void CGameClient::OnMessage(int MsgId, CUnpacker *pUnpacker, int Client, bool Du
 
 		// apply
 		m_aClients[pMsg->m_ClientID].m_Emoticon = pMsg->m_Emoticon;
-		m_aClients[pMsg->m_ClientID].m_EmoticonStartTick = this->Client()->GameTick(Client);
-		m_aClients[pMsg->m_ClientID].m_EmoticonStartFraction = this->Client()->IntraGameTickSincePrev(Client);
+		m_aClients[pMsg->m_ClientID].m_EmoticonStartTick = Client()->GameTick(Conn);
+		m_aClients[pMsg->m_ClientID].m_EmoticonStartFraction = Client()->IntraGameTickSincePrev(Conn);
 	}
 	else if(MsgId == NETMSGTYPE_SV_SOUNDGLOBAL)
 	{
@@ -1579,7 +1579,7 @@ void CGameClient::OnNewSnapshot()
 		{
 			continue;
 		}
-		if(i == IClient::CLIENT_DUMMY && !Client()->DummyConnected())
+		if(i == IClient::CONN_DUMMY && !Client()->DummyConnected())
 		{
 			continue;
 		}
@@ -1620,9 +1620,9 @@ void CGameClient::OnNewSnapshot()
 		CMsgPacker Packer(Msg.MsgID(), false);
 		Msg.Pack(&Packer);
 		if(ZoomToSend != m_LastZoom)
-			Client()->SendMsg(IClient::CLIENT_MAIN, &Packer, MSGFLAG_VITAL);
+			Client()->SendMsg(IClient::CONN_MAIN, &Packer, MSGFLAG_VITAL);
 		if(Client()->DummyConnected())
-			Client()->SendMsg(IClient::CLIENT_DUMMY, &Packer, MSGFLAG_VITAL);
+			Client()->SendMsg(IClient::CONN_DUMMY, &Packer, MSGFLAG_VITAL);
 		m_LastZoom = ZoomToSend;
 		m_LastScreenAspect = Graphics()->ScreenAspect();
 	}
@@ -2022,7 +2022,7 @@ void CGameClient::SendInfo(bool Start)
 		Msg.m_ColorFeet = g_Config.m_ClPlayerColorFeet;
 		CMsgPacker Packer(Msg.MsgID(), false);
 		Msg.Pack(&Packer);
-		Client()->SendMsg(IClient::CLIENT_MAIN, &Packer, MSGFLAG_VITAL);
+		Client()->SendMsg(IClient::CONN_MAIN, &Packer, MSGFLAG_VITAL);
 		m_CheckInfo[0] = -1;
 	}
 	else
@@ -2037,7 +2037,7 @@ void CGameClient::SendInfo(bool Start)
 		Msg.m_ColorFeet = g_Config.m_ClPlayerColorFeet;
 		CMsgPacker Packer(Msg.MsgID(), false);
 		Msg.Pack(&Packer);
-		Client()->SendMsg(IClient::CLIENT_MAIN, &Packer, MSGFLAG_VITAL);
+		Client()->SendMsg(IClient::CONN_MAIN, &Packer, MSGFLAG_VITAL);
 		m_CheckInfo[0] = Client()->GameTickSpeed();
 	}
 }
@@ -2056,7 +2056,7 @@ void CGameClient::SendDummyInfo(bool Start)
 		Msg.m_ColorFeet = g_Config.m_ClDummyColorFeet;
 		CMsgPacker Packer(Msg.MsgID(), false);
 		Msg.Pack(&Packer);
-		Client()->SendMsg(IClient::CLIENT_DUMMY, &Packer, MSGFLAG_VITAL);
+		Client()->SendMsg(IClient::CONN_DUMMY, &Packer, MSGFLAG_VITAL);
 		m_CheckInfo[1] = -1;
 	}
 	else
@@ -2071,7 +2071,7 @@ void CGameClient::SendDummyInfo(bool Start)
 		Msg.m_ColorFeet = g_Config.m_ClDummyColorFeet;
 		CMsgPacker Packer(Msg.MsgID(), false);
 		Msg.Pack(&Packer);
-		Client()->SendMsg(IClient::CLIENT_DUMMY, &Packer, MSGFLAG_VITAL);
+		Client()->SendMsg(IClient::CONN_DUMMY, &Packer, MSGFLAG_VITAL);
 		m_CheckInfo[1] = Client()->GameTickSpeed();
 	}
 }

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -457,7 +457,7 @@ public:
 	virtual void OnInit();
 	virtual void OnConsoleInit();
 	virtual void OnStateChange(int NewState, int OldState);
-	virtual void OnMessage(int MsgId, CUnpacker *pUnpacker, int Client, bool Dummy);
+	virtual void OnMessage(int MsgId, CUnpacker *pUnpacker, int Conn, bool Dummy);
 	virtual void InvalidateSnapshot();
 	virtual void OnNewSnapshot();
 	virtual void OnPredict();

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -457,7 +457,7 @@ public:
 	virtual void OnInit();
 	virtual void OnConsoleInit();
 	virtual void OnStateChange(int NewState, int OldState);
-	virtual void OnMessage(int MsgId, CUnpacker *pUnpacker, bool IsDummy = 0);
+	virtual void OnMessage(int MsgId, CUnpacker *pUnpacker, int Client, bool Dummy);
 	virtual void InvalidateSnapshot();
 	virtual void OnNewSnapshot();
 	virtual void OnPredict();


### PR DESCRIPTION
On the one hand variables called "Dummy" would tell us whether the
current action refers to the currently inactive tee ("dummy"). On the
other hand, these variables could tell us whether the current action
refers to the main connection to the server, or the secondary one. The
latter use case is now renamed to "Client", with the choices
`CLIENT_MAIN`, `CLIENT_DUMMY` (and `CLIENT_CONTACT`).

Perhaps better names could be found, especially since `Client` also
refers to the engine client class in the game code.

Also fix a few bugs in dummy handling.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
