### PR TITLE
Limit evolving to 3 seconds

### DIFF
--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1247,8 +1247,12 @@ void CGameClient::OnNewSnapshot()
 						m_Snap.m_aCharacters[Item.m_ID].m_Active = true;
 						m_Snap.m_aCharacters[Item.m_ID].m_Prev = *((const CNetObj_Character *)pOld);
 
+						// limit evolving to 3 seconds
+						int EvolvePrevTick = minimum(m_Snap.m_aCharacters[Item.m_ID].m_Prev.m_Tick + Client()->GameTickSpeed() * 3, Client()->PrevGameTick(g_Config.m_ClDummy));
+						int EvolveCurTick = minimum(m_Snap.m_aCharacters[Item.m_ID].m_Cur.m_Tick + Client()->GameTickSpeed() * 3, Client()->GameTick(g_Config.m_ClDummy));
+
 						// reuse the result from the previous evolve if the snapped character didn't change since the previous snapshot
-						if(m_aClients[Item.m_ID].m_Evolved.m_Tick == Client()->PrevGameTick(g_Config.m_ClDummy))
+						if(m_aClients[Item.m_ID].m_Evolved.m_Tick == EvolvePrevTick)
 						{
 							if(mem_comp(&m_Snap.m_aCharacters[Item.m_ID].m_Prev, &m_aClients[Item.m_ID].m_Snapped, sizeof(CNetObj_Character)) == 0)
 								m_Snap.m_aCharacters[Item.m_ID].m_Prev = m_aClients[Item.m_ID].m_Evolved;
@@ -1257,9 +1261,9 @@ void CGameClient::OnNewSnapshot()
 						}
 
 						if(m_Snap.m_aCharacters[Item.m_ID].m_Prev.m_Tick)
-							Evolve(&m_Snap.m_aCharacters[Item.m_ID].m_Prev, Client()->PrevGameTick(g_Config.m_ClDummy));
+							Evolve(&m_Snap.m_aCharacters[Item.m_ID].m_Prev, EvolvePrevTick);
 						if(m_Snap.m_aCharacters[Item.m_ID].m_Cur.m_Tick)
-							Evolve(&m_Snap.m_aCharacters[Item.m_ID].m_Cur, Client()->GameTick(g_Config.m_ClDummy));
+							Evolve(&m_Snap.m_aCharacters[Item.m_ID].m_Cur, EvolveCurTick);
 
 						m_aClients[Item.m_ID].m_Snapped = *((const CNetObj_Character *)pData);
 						m_aClients[Item.m_ID].m_Evolved = m_Snap.m_aCharacters[Item.m_ID].m_Cur;


### PR DESCRIPTION
Took from upstream
https://github.com/teeworlds/teeworlds/commit/5d44714e9206e2b12d5fa4b0af9ac80c30dd19b6#diff-597779b4eb51af9adfedd04b8a235afff01091a4ba741daa604cb5cbeda4e3daR1306-R1321

Fixes client freezes if the server sends funny ticks

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
