### PR TITLE
Fix timestamp in record_maps in test (fixes #4631)

### DIFF
--- a/src/test/score.cpp
+++ b/src/test/score.cpp
@@ -81,9 +81,10 @@ struct Score : public testing::TestWithParam<IDbConnection *>
 		char aBuf[512];
 		str_format(aBuf, sizeof(aBuf),
 			"%s into %s_maps(Map, Server, Mapper, Points, Stars, Timestamp) "
-			"VALUES (\"Kobra 3\", \"Novice\", \"Zerodin\", 5, 5, \"%s\")",
-			m_pConn->InsertIgnore(), m_pConn->GetPrefix(), aTimestamp);
+			"VALUES (\"Kobra 3\", \"Novice\", \"Zerodin\", 5, 5, %s)",
+			m_pConn->InsertIgnore(), m_pConn->GetPrefix(), m_pConn->InsertTimestampAsUtc());
 		ASSERT_FALSE(m_pConn->PrepareStatement(aBuf, m_aError, sizeof(m_aError))) << m_aError;
+		m_pConn->BindString(1, aTimestamp);
 		int NumInserted = 0;
 		ASSERT_FALSE(m_pConn->ExecuteUpdate(&NumInserted, m_aError, sizeof(m_aError))) << m_aError;
 		ASSERT_EQ(NumInserted, 1);


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
