### PR TITLE
Don't clamp "zoom" command, we already clamp in ChangeZoom

### DIFF
--- a/src/game/client/components/camera.cpp
+++ b/src/game/client/components/camera.cpp
@@ -211,7 +211,7 @@ void CCamera::ConZoomMinus(IConsole::IResult *pResult, void *pUserData)
 }
 void CCamera::ConZoom(IConsole::IResult *pResult, void *pUserData)
 {
-	float TargetLevel = pResult->NumArguments() ? clamp<float>(pResult->GetFloat(0), 0, 20) : g_Config.m_ClDefaultZoom;
+	float TargetLevel = pResult->NumArguments() ? pResult->GetFloat(0) : g_Config.m_ClDefaultZoom;
 	((CCamera *)pUserData)->ChangeZoom(pow(ZoomStep, TargetLevel - 10));
 }
 void CCamera::ConSetView(IConsole::IResult *pResult, void *pUserData)


### PR DESCRIPTION
Thanks to chillerdragon for noticing

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
