### PR TITLE
Upstream refactoring: Add Spacing parameter to H/VSplitMid, use methods and parameter where easily possible

### DIFF
--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -616,9 +616,7 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 	if(*UseCustomColor)
 	{
 		CUIRect aRects[2];
-		Label.VSplitMid(&aRects[0], &aRects[1]);
-		aRects[0].VSplitRight(10.0f, &aRects[0], 0);
-		aRects[1].VSplitLeft(10.0f, 0, &aRects[1]);
+		Label.VSplitMid(&aRects[0], &aRects[1], 20.0f);
 
 		unsigned *paColors[2] = {ColorBody, ColorFeet};
 		const char *paParts[] = {Localize("Body"), Localize("Feet")};

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -2066,7 +2066,7 @@ void CMenus::RenderSettingsHUD(CUIRect MainView)
 		Section, SectionTwo;
 
 	MainView.HSplitTop(20, &TabLabel1, &MainView);
-	TabLabel1.VSplitLeft(TabLabel1.w / 2, &TabLabel1, &TabLabel2);
+	TabLabel1.VSplitMid(&TabLabel1, &TabLabel2);
 
 	static int s_aPageTabs[2] = {};
 
@@ -2167,7 +2167,7 @@ void CMenus::RenderSettingsHUD(CUIRect MainView)
 	else if(s_CurTab == 1)
 	{ // ***** CHAT TAB ***** //
 
-		MainView.VSplitLeft(MainView.w / 2, &MainView, &Column);
+		MainView.VSplitMid(&MainView, &Column);
 
 		if(DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClChatOld, Localize("Use old chat style"), &g_Config.m_ClChatOld, &MainView, LineMargin))
 			GameClient()->m_Chat.RebuildChat();

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -216,25 +216,26 @@ void CUI::ClipDisable()
 	Graphics()->ClipDisable();
 }
 
-void CUIRect::HSplitMid(CUIRect *pTop, CUIRect *pBottom) const
+void CUIRect::HSplitMid(CUIRect *pTop, CUIRect *pBottom, float Spacing) const
 {
 	CUIRect r = *this;
-	float Cut = r.h / 2;
+	const float Cut = r.h / 2;
+	const float HalfSpacing = Spacing / 2;
 
 	if(pTop)
 	{
 		pTop->x = r.x;
 		pTop->y = r.y;
 		pTop->w = r.w;
-		pTop->h = Cut;
+		pTop->h = Cut - HalfSpacing;
 	}
 
 	if(pBottom)
 	{
 		pBottom->x = r.x;
-		pBottom->y = r.y + Cut;
+		pBottom->y = r.y + Cut + HalfSpacing;
 		pBottom->w = r.w;
-		pBottom->h = r.h - Cut;
+		pBottom->h = r.h - Cut - HalfSpacing;
 	}
 }
 
@@ -282,25 +283,25 @@ void CUIRect::HSplitBottom(float Cut, CUIRect *pTop, CUIRect *pBottom) const
 	}
 }
 
-void CUIRect::VSplitMid(CUIRect *pLeft, CUIRect *pRight) const
+void CUIRect::VSplitMid(CUIRect *pLeft, CUIRect *pRight, float Spacing) const
 {
 	CUIRect r = *this;
-	float Cut = r.w / 2;
-	//	Cut *= Scale();
+	const float Cut = r.w / 2;
+	const float HalfSpacing = Spacing / 2;
 
 	if(pLeft)
 	{
 		pLeft->x = r.x;
 		pLeft->y = r.y;
-		pLeft->w = Cut;
+		pLeft->w = Cut - HalfSpacing;
 		pLeft->h = r.h;
 	}
 
 	if(pRight)
 	{
-		pRight->x = r.x + Cut;
+		pRight->x = r.x + Cut + HalfSpacing;
 		pRight->y = r.y;
-		pRight->w = r.w - Cut;
+		pRight->w = r.w - Cut - HalfSpacing;
 		pRight->h = r.h;
 	}
 }

--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -19,10 +19,11 @@ public:
 	/**
 	 * Splits 2 CUIRect inside *this* CUIRect horizontally. You can pass null pointers.
 	 *
-	 * @param pTop This rect will end up taking the top half of this CUIRect
-	 * @param pBottom This rect will end up taking the bottom half of this CUIRect
+	 * @param pTop This rect will end up taking the top half of this CUIRect.
+	 * @param pBottom This rect will end up taking the bottom half of this CUIRect.
+	 * @param Spacing Total size of margin between split rects.
 	 */
-	void HSplitMid(CUIRect *pTop, CUIRect *pBottom) const;
+	void HSplitMid(CUIRect *pTop, CUIRect *pBottom, float Spacing = 0.0f) const;
 	/**
 	 * Splits 2 CUIRect inside *this* CUIRect.
 	 *
@@ -52,8 +53,9 @@ public:
 	 *
 	 * @param pLeft This rect will take up the left half of *this* CUIRect.
 	 * @param pRight This rect will take up the right half of *this* CUIRect.
+	 * @param Spacing Total size of margin between split rects.
 	 */
-	void VSplitMid(CUIRect *pLeft, CUIRect *pRight) const;
+	void VSplitMid(CUIRect *pLeft, CUIRect *pRight, float Spacing = 0.0f) const;
 	/**
 	 * Splits 2 CUIRect inside *this* CUIRect.
 	 *

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -2920,9 +2920,7 @@ int CEditor::DoProperties(CUIRect *pToolBox, CProperty *pProps, int *pIDs, int *
 		else if(pProps[i].m_Type == PROPTYPE_SHIFT)
 		{
 			CUIRect Left, Right, Up, Down;
-			Shifter.VSplitMid(&Left, &Up);
-			Left.VSplitRight(1.0f, &Left, 0);
-			Up.VSplitLeft(1.0f, 0, &Up);
+			Shifter.VSplitMid(&Left, &Up, 2.0f);
 			Left.VSplitLeft(10.0f, &Left, &Shifter);
 			Shifter.VSplitRight(10.0f, &Shifter, &Right);
 			RenderTools()->DrawUIRect(&Shifter, ColorRGBA(1, 1, 1, 0.5f), 0, 0.0f);

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -827,10 +827,7 @@ void CEditor::DoToolbar(CUIRect ToolBar)
 	CUIRect TB_Top, TB_Bottom;
 	CUIRect Button;
 
-	ToolBar.HSplitTop(ToolBar.h / 2.0f, &TB_Top, &TB_Bottom);
-
-	TB_Top.HSplitBottom(2.5f, &TB_Top, 0);
-	TB_Bottom.HSplitTop(2.5f, 0, &TB_Bottom);
+	ToolBar.HSplitMid(&TB_Top, &TB_Bottom, 5.0f);
 
 	// top line buttons
 	{


### PR DESCRIPTION
Add optional `Spacing` parameter to `CUIRect::HSplitMid` and `CUIRect::VSplitMid`.

Use the new parameter and the middle-split methods in some obvious cases.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
