### PR TITLE
Fix load of uninitialized member variable

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -1556,6 +1556,7 @@ static CServerCapabilities GetServerCapabilities(int Version, int Flags)
 	Result.m_AnyPlayerFlag = DDNet;
 	Result.m_PingEx = false;
 	Result.m_AllowDummy = true;
+	Result.m_SyncWeaponInput = false;
 	if(Version >= 1)
 	{
 		Result.m_ChatTimeoutCode = Flags & SERVERCAPFLAG_CHATTIMEOUTCODE;


### PR DESCRIPTION
Fixes

```
/src/engine/client/client.cpp:4395:30: runtime error: load of value 143, which is not a valid value for type 'bool'
    #0 0x55b6e885efba in CClient::PredictionMargin() const /src/engine/client/client.cpp:4395
    #1 0x55b6e87dc51e in CClient::ProcessServerPacket(CNetChunk*, int, bool) /src/engine/client/client.cpp:2049
    #2 0x55b6e87e8f79 in CClient::PumpNetwork() /src/engine/client/client.cpp:2368
    #3 0x55b6e87f7d07 in CClient::Update() /src/engine/client/client.cpp:2676
    #4 0x55b6e880c7da in CClient::Run() /src/engine/client/client.cpp:3066
    #5 0x55b6e8858561 in main /src/engine/client/client.cpp:4268
```


## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [X] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
