### PR TITLE
Lower chance of losing written files by syncing them to disk on close, my try

### DIFF
--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -462,14 +462,6 @@ unsigned io_write_newline(IOHANDLE io)
 
 int io_close(IOHANDLE io)
 {
-	if(io_flush(io) != 0)
-	{
-		dbg_msg("file", "flushing stream failed: %d", errno);
-	}
-	if(io_fsync(io) != 0)
-	{
-		dbg_msg("file", "flushing file to disk failed: %d", errno);
-	}
 	return fclose((FILE *)io) != 0;
 }
 
@@ -478,12 +470,16 @@ int io_flush(IOHANDLE io)
 	return fflush((FILE *)io);
 }
 
-int io_fsync(IOHANDLE io)
+int io_sync(IOHANDLE io)
 {
+	if(io_flush(io))
+	{
+		return 1;
+	}
 #if defined(CONF_FAMILY_WINDOWS)
-	return FlushFileBuffers((HANDLE)_get_osfhandle(_fileno((FILE *)io)));
+	return FlushFileBuffers((HANDLE)_get_osfhandle(_fileno((FILE *)io))) == 0;
 #else
-	return fsync(fileno((FILE *)io));
+	return fsync(fileno((FILE *)io)) != 0;
 #endif
 }
 

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -304,6 +304,18 @@ int io_close(IOHANDLE io);
 int io_flush(IOHANDLE io);
 
 /*
+	Function: io_fsync
+		Synchronize file changes to disk
+
+	Parameters:
+		io - Handle to the file.
+
+	Returns:
+		Returns 0 on success.
+*/
+int io_fsync(IOHANDLE io);
+
+/*
 	Function: io_error
 		Checks whether an error occurred during I/O with the file.
 

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -304,8 +304,8 @@ int io_close(IOHANDLE io);
 int io_flush(IOHANDLE io);
 
 /*
-	Function: io_fsync
-		Synchronize file changes to disk
+	Function: io_sync
+		Synchronize file changes to disk.
 
 	Parameters:
 		io - Handle to the file.
@@ -313,7 +313,7 @@ int io_flush(IOHANDLE io);
 	Returns:
 		Returns 0 on success.
 */
-int io_fsync(IOHANDLE io);
+int io_sync(IOHANDLE io);
 
 /*
 	Function: io_error

--- a/src/engine/shared/config.cpp
+++ b/src/engine/shared/config.cpp
@@ -110,6 +110,11 @@ bool CConfigManager::Save()
 	for(int i = 0; i < m_NumCallbacks; i++)
 		m_aCallbacks[i].m_pfnFunc(this, m_aCallbacks[i].m_pUserData);
 
+	if(io_sync(m_ConfigFile) != 0)
+	{
+		m_Failed = true;
+	}
+
 	if(io_close(m_ConfigFile) != 0)
 		m_Failed = true;
 

--- a/src/test/io.cpp
+++ b/src/test/io.cpp
@@ -68,3 +68,13 @@ TEST(Io, CurrentExe)
 	EXPECT_GE(io_length(CurrentExe), 1024);
 	io_close(CurrentExe);
 }
+TEST(Io, SyncWorks)
+{
+	CTestInfo Info;
+	IOHANDLE File = io_open(Info.m_aFilename, IOFLAG_WRITE);
+	ASSERT_TRUE(File);
+	EXPECT_EQ(io_write(File, "abc\n", 4), 4);
+	EXPECT_FALSE(io_sync(File));
+	EXPECT_FALSE(io_close(File));
+	EXPECT_FALSE(fs_remove(Info.m_aFilename));
+}


### PR DESCRIPTION
Not sure if it helps, but now it only syncs the config file.

Would supersede #4407.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [x] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
