### PR TITLE
Delay double click handling one frame after item activation

### DIFF
--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -215,7 +215,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 	View.y -= s_ScrollValue * ScrollNum * s_aCols[0].m_Rect.h;
 
 	int NewSelected = -1;
-	int DoubleClicked = 0;
+	bool DoubleClicked = false;
 	int NumPlayers = 0;
 
 	m_SelectedIndex = -1;
@@ -300,7 +300,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 			{
 				NewSelected = ItemIndex;
 				if(NewSelected == m_DoubleClickIndex)
-					DoubleClicked = 1;
+					DoubleClicked = true;
 				m_DoubleClickIndex = NewSelected;
 			}
 		}
@@ -474,7 +474,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 		// select the new server
 		const CServerInfo *pItem = ServerBrowser()->SortedGet(NewSelected);
 		str_copy(g_Config.m_UiServerAddress, pItem->m_aAddress, sizeof(g_Config.m_UiServerAddress));
-		if(Input()->MouseDoubleClick() && DoubleClicked)
+		if(DoubleClicked && Input()->MouseDoubleClick())
 		{
 			if(Client()->State() == IClient::STATE_ONLINE && Client()->GetCurrentRaceTime() / 60 >= g_Config.m_ClConfirmDisconnectTime && g_Config.m_ClConfirmDisconnectTime >= 0)
 			{

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -1090,8 +1090,8 @@ void CMenus::RenderDemoList(CUIRect MainView)
 	int ScrollNum = maximum(m_lDemos.size() - Num + 1, 0);
 	ListBox.y -= s_ScrollValue * ScrollNum * s_aCols[0].m_Rect.h;
 
-	int NewSelected = -1;
 	int ItemIndex = -1;
+	bool DoubleClicked = false;
 
 	for(sorted_array<CDemoItem>::range r = m_lDemos.all(); !r.empty(); r.pop_front())
 	{
@@ -1132,10 +1132,10 @@ void CMenus::RenderDemoList(CUIRect MainView)
 
 			if(UI()->DoButtonLogic(r.front().m_aName /* TODO: */, "", Selected, &SelectHitBox))
 			{
-				NewSelected = ItemIndex;
+				DoubleClicked |= ItemIndex == m_DoubleClickIndex;
 				str_copy(g_Config.m_UiDemoSelected, r.front().m_aName, sizeof(g_Config.m_UiDemoSelected));
 				DemolistOnUpdate(false);
-				m_DoubleClickIndex = NewSelected;
+				m_DoubleClickIndex = ItemIndex;
 			}
 		}
 		else
@@ -1194,7 +1194,7 @@ void CMenus::RenderDemoList(CUIRect MainView)
 	UI()->ClipDisable();
 
 	bool Activated = false;
-	if(m_EnterPressed || (NewSelected >= 0 && Input()->MouseDoubleClick()))
+	if(m_EnterPressed || (DoubleClicked && Input()->MouseDoubleClick()))
 	{
 		UI()->SetActiveItem(0);
 		Activated = true;

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -1046,6 +1046,7 @@ void CMenus::RenderGhost(CUIRect MainView)
 	View.y -= s_ScrollValue * ScrollNum * s_aCols[0].m_Rect.h;
 
 	int NewSelected = -1;
+	bool DoubleClicked = false;
 
 	for(int i = 0; i < NumGhosts; i++)
 	{
@@ -1078,6 +1079,8 @@ void CMenus::RenderGhost(CUIRect MainView)
 			if(UI()->DoButtonLogic(pItem, "", 0, &SelectHitBox))
 			{
 				NewSelected = i;
+				DoubleClicked |= NewSelected == m_DoubleClickIndex;
+				m_DoubleClickIndex = NewSelected;
 			}
 		}
 
@@ -1165,7 +1168,7 @@ void CMenus::RenderGhost(CUIRect MainView)
 
 		static int s_GhostButton = 0;
 		const char *pText = pGhost->Active() ? Localize("Deactivate") : Localize("Activate");
-		if(DoButton_Menu(&s_GhostButton, pText, 0, &Button) || (NewSelected != -1 && Input()->MouseDoubleClick()))
+		if(DoButton_Menu(&s_GhostButton, pText, 0, &Button) || (DoubleClicked && Input()->MouseDoubleClick()))
 		{
 			if(pGhost->Active())
 			{

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -4042,11 +4042,9 @@ void CEditor::AddFileDialogEntry(int Index, CUIRect *pView)
 			str_copy(m_aFileDialogFileName, m_FileList[Index].m_aFilename, sizeof(m_aFileDialogFileName));
 		else
 			m_aFileDialogFileName[0] = 0;
-		m_FilesSelectedIndex = Index;
 		m_PreviewImageIsLoaded = false;
-
-		if(Input()->MouseDoubleClick())
-			m_FileDialogActivate = true;
+		m_FileDialogActivate |= Index == m_FilesSelectedIndex && Input()->MouseDoubleClick();
+		m_FilesSelectedIndex = Index;
 	}
 }
 


### PR DESCRIPTION
Fix list items being activated by double clicks too fast.

This applies the fix that was already used for the server browser to demo browser, editor file list and ghost list.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
