### PR TITLE
Show key presses in nameplates

### DIFF
--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -380,7 +380,6 @@ MACRO_CONFIG_INT(ClChatReset, cl_chat_reset, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_S
 MACRO_CONFIG_INT(ClChatOld, cl_chat_old, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Old chat style: No tee, no background");
 
 MACRO_CONFIG_INT(ClShowDirection, cl_show_direction, 1, 0, 2, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Show key presses (1 = other players', 2 = also your own)")
-MACRO_CONFIG_INT(ClShowDirectionBelow, cl_show_direction_below, 0, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Position of the shown key presses (0 = above players, 1 = below players)")
 MACRO_CONFIG_INT(ClHttpMapDownload, cl_http_map_download, 1, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Try fast HTTP map download first")
 MACRO_CONFIG_INT(ClOldGunPosition, cl_old_gun_position, 0, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Tees hold gun a bit higher like in TW 0.6.1 and older")
 MACRO_CONFIG_INT(ClConfirmDisconnectTime, cl_confirm_disconnect_time, 20, -1, 1440, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Confirmation popup before disconnecting after game time (in minutes, -1 to turn off, 0 to always turn on)")

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -380,6 +380,7 @@ MACRO_CONFIG_INT(ClChatReset, cl_chat_reset, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_S
 MACRO_CONFIG_INT(ClChatOld, cl_chat_old, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Old chat style: No tee, no background");
 
 MACRO_CONFIG_INT(ClShowDirection, cl_show_direction, 1, 0, 2, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Show key presses (1 = other players', 2 = also your own)")
+MACRO_CONFIG_INT(ClShowDirectionBelow, cl_show_direction_below, 0, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Position of the shown key presses (0 = above players, 1 = below players)")
 MACRO_CONFIG_INT(ClHttpMapDownload, cl_http_map_download, 1, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Try fast HTTP map download first")
 MACRO_CONFIG_INT(ClOldGunPosition, cl_old_gun_position, 0, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Tees hold gun a bit higher like in TW 0.6.1 and older")
 MACRO_CONFIG_INT(ClConfirmDisconnectTime, cl_confirm_disconnect_time, 20, -1, 1440, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Confirmation popup before disconnecting after game time (in minutes, -1 to turn off, 0 to always turn on)")

--- a/src/game/client/components/nameplates.cpp
+++ b/src/game/client/components/nameplates.cpp
@@ -51,8 +51,6 @@ void CNamePlates::RenderNameplatePos(vec2 Position, const CNetObj_PlayerInfo *pP
 	ColorRGBA rgb = ColorRGBA(1.0f, 1.0f, 1.0f);
 
 	// render players' key presses
-	Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
-	Graphics()->QuadsSetRotation(0);
 	int ShowDirection = g_Config.m_ClShowDirection;
 #if defined(CONF_VIDEORECORDER)
 	if(IVideo::Current())
@@ -60,6 +58,9 @@ void CNamePlates::RenderNameplatePos(vec2 Position, const CNetObj_PlayerInfo *pP
 #endif
 	if((pPlayerInfo->m_Local && ShowDirection == 2) || (!pPlayerInfo->m_Local && ShowDirection >= 1))
 	{
+		Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
+		Graphics()->QuadsSetRotation(0);
+
 		const float ShowDirectionImgSize = 22.0f;
 		YOffset -= ShowDirectionImgSize;
 		vec2 ShowDirectionPos = vec2(Position.x - 11.0f, YOffset);
@@ -86,7 +87,7 @@ void CNamePlates::RenderNameplatePos(vec2 Position, const CNetObj_PlayerInfo *pP
 	}
 
 	// render name plate
-	if(!pPlayerInfo->m_Local || g_Config.m_ClNameplatesOwn)
+	if((!pPlayerInfo->m_Local || g_Config.m_ClNameplatesOwn) && g_Config.m_ClNameplates)
 	{
 		float a = 1;
 		if(g_Config.m_ClNameplatesAlways == 0)
@@ -238,7 +239,7 @@ void CNamePlates::RenderNameplatePos(vec2 Position, const CNetObj_PlayerInfo *pP
 		}
 	}
 
-	if(g_Config.m_Debug || g_Config.m_ClNameplatesStrong)
+	if((g_Config.m_Debug || g_Config.m_ClNameplatesStrong) && g_Config.m_ClNameplates)
 	{
 		if(m_pClient->m_Snap.m_aCharacters[pPlayerInfo->m_ClientID].m_HasExtendedData && m_pClient->m_Snap.m_aCharacters[m_pClient->m_Snap.m_LocalClientID].m_HasExtendedData)
 		{
@@ -296,7 +297,12 @@ void CNamePlates::RenderNameplatePos(vec2 Position, const CNetObj_PlayerInfo *pP
 
 void CNamePlates::OnRender()
 {
-	if(!g_Config.m_ClNameplates)
+	int ShowDirection = g_Config.m_ClShowDirection;
+#if defined(CONF_VIDEORECORDER)
+	if(IVideo::Current())
+		ShowDirection = g_Config.m_ClVideoShowDirection;
+#endif
+	if(!g_Config.m_ClNameplates && ShowDirection == 0)
 		return;
 
 	for(int i = 0; i < MAX_CLIENTS; i++)

--- a/src/game/client/components/nameplates.cpp
+++ b/src/game/client/components/nameplates.cpp
@@ -61,14 +61,8 @@ void CNamePlates::RenderNameplatePos(vec2 Position, const CNetObj_PlayerInfo *pP
 	if((pPlayerInfo->m_Local && ShowDirection == 2) || (!pPlayerInfo->m_Local && ShowDirection >= 1))
 	{
 		const float ShowDirectionImgSize = 22.0f;
-		vec2 ShowDirectionPos;
-		if(g_Config.m_ClShowDirectionBelow)
-			ShowDirectionPos = vec2(Position.x - 11.0f, Position.y + ShowDirectionImgSize);
-		else
-		{
-			YOffset -= ShowDirectionImgSize;
-			ShowDirectionPos = vec2(Position.x - 11.0f, YOffset);
-		}
+		YOffset -= ShowDirectionImgSize;
+		vec2 ShowDirectionPos = vec2(Position.x - 11.0f, YOffset);
 
 		if(m_pClient->m_Snap.m_aCharacters[pPlayerInfo->m_ClientID].m_Cur.m_Direction == -1)
 		{

--- a/src/game/client/components/nameplates.cpp
+++ b/src/game/client/components/nameplates.cpp
@@ -50,6 +50,47 @@ void CNamePlates::RenderNameplatePos(vec2 Position, const CNetObj_PlayerInfo *pP
 	float YOffset = Position.y - 38;
 	ColorRGBA rgb = ColorRGBA(1.0f, 1.0f, 1.0f);
 
+	// render players' key presses
+	Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
+	Graphics()->QuadsSetRotation(0);
+	int ShowDirection = g_Config.m_ClShowDirection;
+#if defined(CONF_VIDEORECORDER)
+	if(IVideo::Current())
+		ShowDirection = g_Config.m_ClVideoShowDirection;
+#endif
+	if((pPlayerInfo->m_Local && ShowDirection == 2) || (!pPlayerInfo->m_Local && ShowDirection >= 1))
+	{
+		const float ShowDirectionImgSize = 22.0f;
+		vec2 ShowDirectionPos;
+		if(g_Config.m_ClShowDirectionBelow)
+			ShowDirectionPos = vec2(Position.x - 11.0f, Position.y + ShowDirectionImgSize);
+		else
+		{
+			YOffset -= ShowDirectionImgSize;
+			ShowDirectionPos = vec2(Position.x - 11.0f, YOffset);
+		}
+
+		if(m_pClient->m_Snap.m_aCharacters[pPlayerInfo->m_ClientID].m_Cur.m_Direction == -1)
+		{
+			Graphics()->TextureSet(g_pData->m_aImages[IMAGE_ARROW].m_Id);
+			Graphics()->QuadsSetRotation(pi);
+			Graphics()->RenderQuadContainerAsSprite(m_DirectionQuadContainerIndex, 0, ShowDirectionPos.x - 30.f, ShowDirectionPos.y);
+		}
+		else if(m_pClient->m_Snap.m_aCharacters[pPlayerInfo->m_ClientID].m_Cur.m_Direction == 1)
+		{
+			Graphics()->TextureSet(g_pData->m_aImages[IMAGE_ARROW].m_Id);
+			Graphics()->RenderQuadContainerAsSprite(m_DirectionQuadContainerIndex, 0, ShowDirectionPos.x + 30.f, ShowDirectionPos.y);
+		}
+		if(m_pClient->m_Snap.m_aCharacters[pPlayerInfo->m_ClientID].m_Cur.m_Jumped & 1)
+		{
+			Graphics()->TextureSet(g_pData->m_aImages[IMAGE_ARROW].m_Id);
+			Graphics()->QuadsSetRotation(pi * 3 / 2);
+			Graphics()->RenderQuadContainerAsSprite(m_DirectionQuadContainerIndex, 0, ShowDirectionPos.x, ShowDirectionPos.y);
+		}
+		Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
+		Graphics()->QuadsSetRotation(0);
+	}
+
 	// render name plate
 	if(!pPlayerInfo->m_Local || g_Config.m_ClNameplatesOwn)
 	{
@@ -314,4 +355,11 @@ void CNamePlates::OnWindowResize()
 void CNamePlates::OnInit()
 {
 	ResetNamePlates();
+
+	// the direction
+	m_DirectionQuadContainerIndex = Graphics()->CreateQuadContainer(false);
+
+	IGraphics::CQuadItem QuadItem(0.f, 0.f, 22.f, 22.f);
+	Graphics()->QuadContainerAddQuads(m_DirectionQuadContainerIndex, &QuadItem, 1);
+	Graphics()->QuadContainerUpload(m_DirectionQuadContainerIndex);
 }

--- a/src/game/client/components/nameplates.h
+++ b/src/game/client/components/nameplates.h
@@ -50,6 +50,8 @@ class CNamePlates : public CComponent
 
 	void ResetNamePlates();
 
+	int m_DirectionQuadContainerIndex;
+
 public:
 	virtual int Sizeof() const override { return sizeof(*this); }
 	virtual void OnWindowResize() override;

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -552,37 +552,6 @@ void CPlayers::RenderPlayer(
 
 	RenderInfo.m_Size = 64.0f; // force some settings
 
-	Graphics()->SetColor(1.0f, 1.0f, 1.0f, Alpha);
-	Graphics()->QuadsSetRotation(0);
-	int ShowDirection = g_Config.m_ClShowDirection;
-#if defined(CONF_VIDEORECORDER)
-	if(IVideo::Current())
-		ShowDirection = g_Config.m_ClVideoShowDirection;
-#endif
-	vec2 ShowDirectionPos(Position.x - 11.0f, Position.y - 70.f);
-	if((Local && ShowDirection == 2) || (!Local && ShowDirection >= 1))
-	{
-		if(Player.m_Direction == -1)
-		{
-			Graphics()->TextureSet(g_pData->m_aImages[IMAGE_ARROW].m_Id);
-			Graphics()->QuadsSetRotation(pi);
-			Graphics()->RenderQuadContainerAsSprite(m_DirectionQuadContainerIndex, 0, ShowDirectionPos.x - 30.f, ShowDirectionPos.y);
-		}
-		else if(Player.m_Direction == 1)
-		{
-			Graphics()->TextureSet(g_pData->m_aImages[IMAGE_ARROW].m_Id);
-			Graphics()->RenderQuadContainerAsSprite(m_DirectionQuadContainerIndex, 0, ShowDirectionPos.x + 30.f, ShowDirectionPos.y);
-		}
-		if(Player.m_Jumped & 1)
-		{
-			Graphics()->TextureSet(g_pData->m_aImages[IMAGE_ARROW].m_Id);
-			Graphics()->QuadsSetRotation(pi * 3 / 2);
-			Graphics()->RenderQuadContainerAsSprite(m_DirectionQuadContainerIndex, 0, ShowDirectionPos.x, ShowDirectionPos.y);
-		}
-		Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
-		Graphics()->QuadsSetRotation(0);
-	}
-
 	RenderTools()->RenderTee(&State, &RenderInfo, Player.m_Emote, Direction, Position, Alpha);
 
 	int QuadOffsetToEmoticon = NUM_WEAPONS * 2 + 2 + 2;
@@ -811,10 +780,4 @@ void CPlayers::OnInit()
 
 	Graphics()->QuadsSetSubset(0.f, 0.f, 1.f, 1.f);
 	Graphics()->QuadsSetRotation(0.f);
-	// the direction
-	m_DirectionQuadContainerIndex = Graphics()->CreateQuadContainer(false);
-
-	IGraphics::CQuadItem QuadItem(0.f, 0.f, 22.f, 22.f);
-	Graphics()->QuadContainerAddQuads(m_DirectionQuadContainerIndex, &QuadItem, 1);
-	Graphics()->QuadContainerUpload(m_DirectionQuadContainerIndex);
 }

--- a/src/game/client/components/players.h
+++ b/src/game/client/components/players.h
@@ -28,7 +28,6 @@ class CPlayers : public CComponent
 		float Intra = 0.f);
 
 	int m_WeaponEmoteQuadContainerIndex;
-	int m_DirectionQuadContainerIndex;
 	int m_WeaponSpriteMuzzleQuadContainerIndex[NUM_WEAPONS];
 
 public:


### PR DESCRIPTION

As described in [x](https://github.com/ddnet/ddnet/issues/4589) the arrows that show the key presses of the players are not visible in many situations, this is now my attempt to fix this by including the arrows in the nametags.

~~Also, I created a new option called `cl_show_direction_below` to show the arrows below the player. We can discuss whether this is useful, or whether it should simply be displayed as before only above the player.~~

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
https://streamable.com/czk2ht
See also https://github.com/ddnet/ddnet/issues/4589
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
