### PR TITLE
Refactor switch state, add prediction of switch state toggles

### DIFF
--- a/datasrc/datatypes.py
+++ b/datasrc/datatypes.py
@@ -359,3 +359,38 @@ class NetBool(NetIntRange):
 class NetTick(NetIntAny):
 	def __init__(self, name):
 		NetIntAny.__init__(self,name)
+
+class NetArray(NetVariable):
+	def __init__(self, var, size):
+		NetVariable.__init__(self,var.name)
+		self.base_name = var.name
+		self.var = var
+		self.size = size
+		self.name = self.base_name + "[%d]"%self.size
+	def emit_declaration(self):
+		self.var.name = self.name
+		return self.var.emit_declaration()
+	def emit_validate(self):
+		lines = []
+		for i in range(self.size):
+			self.var.name = self.base_name + "[%d]"%i
+			lines += self.var.emit_validate()
+		return lines
+	def emit_unpack(self):
+		lines = []
+		for i in range(self.size):
+			self.var.name = self.base_name + "[%d]"%i
+			lines += self.var.emit_unpack()
+		return lines
+	def emit_pack(self):
+		lines = []
+		for i in range(self.size):
+			self.var.name = self.base_name + "[%d]"%i
+			lines += self.var.emit_pack()
+		return lines
+	def emit_unpack_check(self):
+		lines = []
+		for i in range(self.size):
+			self.var.name = self.base_name + "[%d]"%i
+			lines += self.var.emit_unpack_check()
+		return lines

--- a/datasrc/network.py
+++ b/datasrc/network.py
@@ -317,6 +317,11 @@ Objects = [
 		NetArray(NetIntAny("m_Status"), 8),
 	]),
 
+	NetObjectEx("SwitchTimeState", "switch-time-state@netobj.ddnet.tw", [
+		NetArray(NetIntAny("m_SwitchNumber"), 4),
+		NetArray(NetIntAny("m_EndTick"), 4),
+	]),
+
 	# Switch info for map items
 	NetObjectEx("EntityEx", "entity-ex@netobj.ddnet.tw", [
 		NetIntAny("m_SwitchNumber"),

--- a/datasrc/network.py
+++ b/datasrc/network.py
@@ -312,15 +312,13 @@ Objects = [
 
 	# Switch state for a player team.
 	NetObjectEx("SwitchState", "switch-state@netobj.ddnet.tw", [
-		NetIntRange("m_HighestSwitchNumber", 0, 256),
+		NetIntAny("m_HighestSwitchNumber"),
 		# 256 switches / 32 bits = 8 int32
-		NetArray(NetIntAny("m_Status"), 8),
-	]),
-
-	NetObjectEx("SwitchTimeState", "switch-time-state@netobj.ddnet.tw", [
-		NetArray(NetIntAny("m_SwitchNumber"), 4),
-		NetArray(NetIntAny("m_EndTick"), 4),
-	]),
+		NetArray(NetIntAny("m_aStatus"), 8),
+		# send the endtick of up to 4 timed switchers
+		NetArray(NetIntAny("m_aSwitchNumbers"), 4),
+		NetArray(NetIntAny("m_aEndTicks"), 4),
+	], validate_size=False),
 
 	# Switch info for map items
 	NetObjectEx("EntityEx", "entity-ex@netobj.ddnet.tw", [

--- a/datasrc/network.py
+++ b/datasrc/network.py
@@ -1,7 +1,7 @@
 # pylint: skip-file
 # See https://github.com/ddnet/ddnet/issues/3507
 
-from datatypes import Enum, Flags, NetBool, NetEvent, NetIntAny, NetIntRange, NetMessage, NetMessageEx, NetObject, NetObjectEx, NetString, NetStringHalfStrict, NetStringStrict, NetTick
+from datatypes import Enum, Flags, NetArray, NetBool, NetEvent, NetIntAny, NetIntRange, NetMessage, NetMessageEx, NetObject, NetObjectEx, NetString, NetStringHalfStrict, NetStringStrict, NetTick
 
 Emotes = ["NORMAL", "PAIN", "HAPPY", "SURPRISE", "ANGRY", "BLINK"]
 PlayerFlags = ["PLAYING", "IN_MENU", "CHATTING", "SCOREBOARD", "AIM"]
@@ -314,14 +314,7 @@ Objects = [
 	NetObjectEx("SwitchState", "switch-state@netobj.ddnet.tw", [
 		NetIntRange("m_NumSwitchers", 0, 256),
 		# 256 switches / 32 bits = 8 int32
-		NetIntAny("m_Status1"),
-		NetIntAny("m_Status2"),
-		NetIntAny("m_Status3"),
-		NetIntAny("m_Status4"),
-		NetIntAny("m_Status5"),
-		NetIntAny("m_Status6"),
-		NetIntAny("m_Status7"),
-		NetIntAny("m_Status8"),
+		NetArray(NetIntAny("m_Status"), 8),
 	]),
 
 	# Switch info for map items

--- a/datasrc/network.py
+++ b/datasrc/network.py
@@ -312,7 +312,7 @@ Objects = [
 
 	# Switch state for a player team.
 	NetObjectEx("SwitchState", "switch-state@netobj.ddnet.tw", [
-		NetIntRange("m_NumSwitchers", 0, 256),
+		NetIntRange("m_HighestSwitchNumber", 0, 256),
 		# 256 switches / 32 bits = 8 int32
 		NetArray(NetIntAny("m_Status"), 8),
 	]),

--- a/src/game/client/components/items.cpp
+++ b/src/game/client/components/items.cpp
@@ -327,7 +327,7 @@ void CItems::OnRender()
 	{
 		for(auto *pProj = (CProjectile *)GameClient()->m_PredictedWorld.FindFirst(CGameWorld::ENTTYPE_PROJECTILE); pProj; pProj = (CProjectile *)pProj->NextEntity())
 		{
-			if(!IsSuper && pProj->m_Number > 0 && pProj->m_Number < Collision()->m_NumSwitchers + 1 && !aSwitchers[pProj->m_Number].m_Status[SwitcherTeam] && (pProj->m_Explosive ? BlinkingProjEx : BlinkingProj))
+			if(!IsSuper && pProj->m_Number > 0 && pProj->m_Number < (int)aSwitchers.size() && !aSwitchers[pProj->m_Number].m_Status[SwitcherTeam] && (pProj->m_Explosive ? BlinkingProjEx : BlinkingProj))
 				continue;
 
 			CProjectileData Data = pProj->GetData();
@@ -344,7 +344,7 @@ void CItems::OnRender()
 		}
 		for(auto *pPickup = (CPickup *)GameClient()->m_PredictedWorld.FindFirst(CGameWorld::ENTTYPE_PICKUP); pPickup; pPickup = (CPickup *)pPickup->NextEntity())
 		{
-			if(!IsSuper && pPickup->m_Layer == LAYER_SWITCH && pPickup->m_Number > 0 && pPickup->m_Number < Collision()->m_NumSwitchers + 1 && !aSwitchers[pPickup->m_Number].m_Status[SwitcherTeam] && BlinkingPickup)
+			if(!IsSuper && pPickup->m_Layer == LAYER_SWITCH && pPickup->m_Number > 0 && pPickup->m_Number < (int)aSwitchers.size() && !aSwitchers[pPickup->m_Number].m_Status[SwitcherTeam] && BlinkingPickup)
 				continue;
 
 			if(pPickup->InDDNetTile())
@@ -368,7 +368,7 @@ void CItems::OnRender()
 
 		bool Inactive = false;
 		if(pEntEx)
-			Inactive = !IsSuper && pEntEx->m_SwitchNumber > 0 && pEntEx->m_SwitchNumber < Collision()->m_NumSwitchers + 1 && !aSwitchers[pEntEx->m_SwitchNumber].m_Status[SwitcherTeam];
+			Inactive = !IsSuper && pEntEx->m_SwitchNumber > 0 && pEntEx->m_SwitchNumber < (int)aSwitchers.size() && !aSwitchers[pEntEx->m_SwitchNumber].m_Status[SwitcherTeam];
 
 		if(Item.m_Type == NETOBJTYPE_PROJECTILE || Item.m_Type == NETOBJTYPE_DDNETPROJECTILE)
 		{

--- a/src/game/client/components/items.cpp
+++ b/src/game/client/components/items.cpp
@@ -322,11 +322,12 @@ void CItems::OnRender()
 	int GunStartTick = (Client()->GameTick(g_Config.m_ClDummy) / 7) * 7;
 
 	bool UsePredicted = GameClient()->Predict() && GameClient()->AntiPingGunfire();
+	auto &aSwitchers = GameClient()->Switchers();
 	if(UsePredicted)
 	{
 		for(auto *pProj = (CProjectile *)GameClient()->m_PredictedWorld.FindFirst(CGameWorld::ENTTYPE_PROJECTILE); pProj; pProj = (CProjectile *)pProj->NextEntity())
 		{
-			if(!IsSuper && pProj->m_Number > 0 && pProj->m_Number < Collision()->m_NumSwitchers + 1 && !Collision()->m_pSwitchers[pProj->m_Number].m_Status[SwitcherTeam] && (pProj->m_Explosive ? BlinkingProjEx : BlinkingProj))
+			if(!IsSuper && pProj->m_Number > 0 && pProj->m_Number < Collision()->m_NumSwitchers + 1 && !aSwitchers[pProj->m_Number].m_Status[SwitcherTeam] && (pProj->m_Explosive ? BlinkingProjEx : BlinkingProj))
 				continue;
 
 			CProjectileData Data = pProj->GetData();
@@ -343,7 +344,7 @@ void CItems::OnRender()
 		}
 		for(auto *pPickup = (CPickup *)GameClient()->m_PredictedWorld.FindFirst(CGameWorld::ENTTYPE_PICKUP); pPickup; pPickup = (CPickup *)pPickup->NextEntity())
 		{
-			if(!IsSuper && pPickup->m_Layer == LAYER_SWITCH && pPickup->m_Number > 0 && pPickup->m_Number < Collision()->m_NumSwitchers + 1 && !Collision()->m_pSwitchers[pPickup->m_Number].m_Status[SwitcherTeam] && BlinkingPickup)
+			if(!IsSuper && pPickup->m_Layer == LAYER_SWITCH && pPickup->m_Number > 0 && pPickup->m_Number < Collision()->m_NumSwitchers + 1 && !aSwitchers[pPickup->m_Number].m_Status[SwitcherTeam] && BlinkingPickup)
 				continue;
 
 			if(pPickup->InDDNetTile())
@@ -367,7 +368,7 @@ void CItems::OnRender()
 
 		bool Inactive = false;
 		if(pEntEx)
-			Inactive = !IsSuper && pEntEx->m_SwitchNumber > 0 && pEntEx->m_SwitchNumber < Collision()->m_NumSwitchers + 1 && !Collision()->m_pSwitchers[pEntEx->m_SwitchNumber].m_Status[SwitcherTeam];
+			Inactive = !IsSuper && pEntEx->m_SwitchNumber > 0 && pEntEx->m_SwitchNumber < Collision()->m_NumSwitchers + 1 && !aSwitchers[pEntEx->m_SwitchNumber].m_Status[SwitcherTeam];
 
 		if(Item.m_Type == NETOBJTYPE_PROJECTILE || Item.m_Type == NETOBJTYPE_DDNETPROJECTILE)
 		{

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -445,6 +445,7 @@ void CGameClient::OnConnected()
 {
 	m_Layers.Init(Kernel());
 	m_Collision.Init(Layers());
+	m_GameWorld.m_Core.InitSwitchers(m_Collision.m_NumSwitchers);
 
 	CRaceHelper::ms_aFlagIndex[0] = -1;
 	CRaceHelper::ms_aFlagIndex[1] = -1;
@@ -1438,23 +1439,22 @@ void CGameClient::OnNewSnapshot()
 				int Team = clamp(Item.m_ID, (int)TEAM_FLOCK, (int)TEAM_SUPER - 1);
 
 				int NumSwitchers = clamp(pSwitchStateData->m_NumSwitchers, 0, 255);
-				if(!Collision()->m_pSwitchers || NumSwitchers != Collision()->m_NumSwitchers)
+				if(Switchers().empty() || NumSwitchers != (int)Switchers().size())
 				{
-					delete[] Collision()->m_pSwitchers;
-					Collision()->m_pSwitchers = new CCollision::SSwitchers[NumSwitchers + 1];
+					m_GameWorld.m_Core.InitSwitchers(NumSwitchers);
 					Collision()->m_NumSwitchers = NumSwitchers;
 				}
 
 				for(int j = 0; j < NumSwitchers + 1; j++)
 				{
-					Collision()->m_pSwitchers[j].m_Status[Team] = (pSwitchStateData->m_Status[j / 32] >> (j % 32)) & 1;
+					Switchers()[j].m_Status[Team] = (pSwitchStateData->m_Status[j / 32] >> (j % 32)) & 1;
 
 					// update
-					if(Collision()->m_pSwitchers[j].m_Status[Team])
-						Collision()->m_pSwitchers[j].m_Type[Team] = TILE_SWITCHOPEN;
+					if(Switchers()[j].m_Status[Team])
+						Switchers()[j].m_Type[Team] = TILE_SWITCHOPEN;
 					else
-						Collision()->m_pSwitchers[j].m_Type[Team] = TILE_SWITCHCLOSE;
-					Collision()->m_pSwitchers[j].m_EndTick[Team] = 0;
+						Switchers()[j].m_Type[Team] = TILE_SWITCHCLOSE;
+					Switchers()[j].m_EndTick[Team] = 0;
 				}
 
 				if(!GotSwitchStateTeam)

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1447,22 +1447,7 @@ void CGameClient::OnNewSnapshot()
 
 				for(int j = 0; j < NumSwitchers + 1; j++)
 				{
-					if(j < 32)
-						Collision()->m_pSwitchers[j].m_Status[Team] = pSwitchStateData->m_Status1 & (1 << j);
-					else if(j < 64)
-						Collision()->m_pSwitchers[j].m_Status[Team] = pSwitchStateData->m_Status2 & (1 << (j - 32));
-					else if(j < 96)
-						Collision()->m_pSwitchers[j].m_Status[Team] = pSwitchStateData->m_Status3 & (1 << (j - 64));
-					else if(j < 128)
-						Collision()->m_pSwitchers[j].m_Status[Team] = pSwitchStateData->m_Status4 & (1 << (j - 96));
-					else if(j < 160)
-						Collision()->m_pSwitchers[j].m_Status[Team] = pSwitchStateData->m_Status5 & (1 << (j - 128));
-					else if(j < 192)
-						Collision()->m_pSwitchers[j].m_Status[Team] = pSwitchStateData->m_Status6 & (1 << (j - 160));
-					else if(j < 224)
-						Collision()->m_pSwitchers[j].m_Status[Team] = pSwitchStateData->m_Status7 & (1 << (j - 192));
-					else if(j < 256)
-						Collision()->m_pSwitchers[j].m_Status[Team] = pSwitchStateData->m_Status8 & (1 << (j - 224));
+					Collision()->m_pSwitchers[j].m_Status[Team] = (pSwitchStateData->m_Status[j / 32] >> (j % 32)) & 1;
 
 					// update
 					if(Collision()->m_pSwitchers[j].m_Status[Team])

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -509,6 +509,9 @@ public:
 	CGameWorld m_PredictedWorld;
 	CGameWorld m_PrevPredictedWorld;
 
+	std::vector<SSwitchers> &Switchers() { return m_GameWorld.m_Core.m_aSwitchers; }
+	std::vector<SSwitchers> &PredSwitchers() { return m_PredictedWorld.m_Core.m_aSwitchers; }
+
 	void DummyResetInput() override;
 	void Echo(const char *pString) override;
 	bool IsOtherTeam(int ClientID);

--- a/src/game/client/prediction/entities/character.cpp
+++ b/src/game/client/prediction/entities/character.cpp
@@ -699,7 +699,35 @@ void CCharacter::HandleTiles(int Index)
 	}
 
 	// handle switch tiles
-	if(Collision()->GetSwitchType(MapIndex) == TILE_FREEZE && Team() != TEAM_SUPER)
+	if(Collision()->GetSwitchType(MapIndex) == TILE_SWITCHOPEN && Team() != TEAM_SUPER && Collision()->GetSwitchNumber(MapIndex) > 0)
+	{
+		Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()] = true;
+		Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_EndTick[Team()] = 0;
+		Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_Type[Team()] = TILE_SWITCHOPEN;
+		Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_LastUpdateTick[Team()] = GameWorld()->GameTick();
+	}
+	else if(Collision()->GetSwitchType(MapIndex) == TILE_SWITCHTIMEDOPEN && Team() != TEAM_SUPER && Collision()->GetSwitchNumber(MapIndex) > 0)
+	{
+		Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()] = true;
+		Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_EndTick[Team()] = GameWorld()->GameTick() + 1 + Collision()->GetSwitchDelay(MapIndex) * GameWorld()->GameTickSpeed();
+		Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_Type[Team()] = TILE_SWITCHTIMEDOPEN;
+		Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_LastUpdateTick[Team()] = GameWorld()->GameTick();
+	}
+	else if(Collision()->GetSwitchType(MapIndex) == TILE_SWITCHTIMEDCLOSE && Team() != TEAM_SUPER && Collision()->GetSwitchNumber(MapIndex) > 0)
+	{
+		Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()] = false;
+		Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_EndTick[Team()] = GameWorld()->GameTick() + 1 + Collision()->GetSwitchDelay(MapIndex) * GameWorld()->GameTickSpeed();
+		Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_Type[Team()] = TILE_SWITCHTIMEDCLOSE;
+		Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_LastUpdateTick[Team()] = GameWorld()->GameTick();
+	}
+	else if(Collision()->GetSwitchType(MapIndex) == TILE_SWITCHCLOSE && Team() != TEAM_SUPER && Collision()->GetSwitchNumber(MapIndex) > 0)
+	{
+		Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()] = false;
+		Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_EndTick[Team()] = 0;
+		Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_Type[Team()] = TILE_SWITCHCLOSE;
+		Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_LastUpdateTick[Team()] = GameWorld()->GameTick();
+	}
+	else if(Collision()->GetSwitchType(MapIndex) == TILE_FREEZE && Team() != TEAM_SUPER)
 	{
 		if(Collision()->GetSwitchNumber(MapIndex) == 0 || Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()])
 		{

--- a/src/game/client/prediction/entities/character.cpp
+++ b/src/game/client/prediction/entities/character.cpp
@@ -670,8 +670,8 @@ void CCharacter::HandleSkippableTiles(int Index)
 bool CCharacter::IsSwitchActiveCb(int Number, void *pUser)
 {
 	CCharacter *pThis = (CCharacter *)pUser;
-	CCollision *pCollision = pThis->Collision();
-	return pCollision->m_pSwitchers && pThis->Team() != TEAM_SUPER && pCollision->m_pSwitchers[Number].m_Status[pThis->Team()];
+	auto &aSwitchers = pThis->Switchers();
+	return !aSwitchers.empty() && pThis->Team() != TEAM_SUPER && aSwitchers[Number].m_Status[pThis->Team()];
 }
 
 void CCharacter::HandleTiles(int Index)
@@ -701,19 +701,19 @@ void CCharacter::HandleTiles(int Index)
 	// handle switch tiles
 	if(Collision()->GetSwitchType(MapIndex) == TILE_FREEZE && Team() != TEAM_SUPER)
 	{
-		if(Collision()->GetSwitchNumber(MapIndex) == 0 || Collision()->m_pSwitchers[Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()])
+		if(Collision()->GetSwitchNumber(MapIndex) == 0 || Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()])
 		{
 			Freeze(Collision()->GetSwitchDelay(MapIndex));
 		}
 	}
 	else if(Collision()->GetSwitchType(MapIndex) == TILE_DFREEZE && Team() != TEAM_SUPER)
 	{
-		if(Collision()->GetSwitchNumber(MapIndex) == 0 || Collision()->m_pSwitchers[Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()])
+		if(Collision()->GetSwitchNumber(MapIndex) == 0 || Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()])
 			m_DeepFreeze = true;
 	}
 	else if(Collision()->GetSwitchType(MapIndex) == TILE_DUNFREEZE && Team() != TEAM_SUPER)
 	{
-		if(Collision()->GetSwitchNumber(MapIndex) == 0 || Collision()->m_pSwitchers[Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()])
+		if(Collision()->GetSwitchNumber(MapIndex) == 0 || Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()])
 			m_DeepFreeze = false;
 	}
 	else if(Collision()->GetSwitchType(MapIndex) == TILE_HIT_ENABLE && m_Hit & DISABLE_HIT_HAMMER && Collision()->GetSwitchDelay(MapIndex) == WEAPON_HAMMER)
@@ -769,7 +769,7 @@ void CCharacter::HandleTiles(int Index)
 	}
 	else if(Collision()->GetSwitchType(MapIndex) == TILE_LFREEZE && Team() != TEAM_SUPER)
 	{
-		if(Collision()->GetSwitchNumber(MapIndex) == 0 || Collision()->m_pSwitchers[Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()])
+		if(Collision()->GetSwitchNumber(MapIndex) == 0 || Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()])
 		{
 			m_LiveFreeze = true;
 			m_Core.m_LiveFrozen = true;
@@ -777,7 +777,7 @@ void CCharacter::HandleTiles(int Index)
 	}
 	else if(Collision()->GetSwitchType(MapIndex) == TILE_LUNFREEZE && Team() != TEAM_SUPER)
 	{
-		if(Collision()->GetSwitchNumber(MapIndex) == 0 || Collision()->m_pSwitchers[Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()])
+		if(Collision()->GetSwitchNumber(MapIndex) == 0 || Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()])
 		{
 			m_LiveFreeze = false;
 			m_Core.m_LiveFrozen = false;

--- a/src/game/client/prediction/entities/pickup.cpp
+++ b/src/game/client/prediction/entities/pickup.cpp
@@ -18,7 +18,7 @@ void CPickup::Tick()
 		{
 			if(GameWorld()->m_WorldConfig.m_IsVanilla && distance(m_Pos, pChr->m_Pos) >= 20.0f * 2) // pickup distance is shorter on vanilla due to using ClosestEntity
 				continue;
-			if(m_Layer == LAYER_SWITCH && m_Number > 0 && m_Number < Collision()->m_NumSwitchers + 1 && !Switchers()[m_Number].m_Status[pChr->Team()])
+			if(m_Layer == LAYER_SWITCH && m_Number > 0 && m_Number < (int)Switchers().size() && !Switchers()[m_Number].m_Status[pChr->Team()])
 				continue;
 			bool sound = false;
 			// player picked us up, is someone was hooking us, let them go

--- a/src/game/client/prediction/entities/pickup.cpp
+++ b/src/game/client/prediction/entities/pickup.cpp
@@ -18,7 +18,7 @@ void CPickup::Tick()
 		{
 			if(GameWorld()->m_WorldConfig.m_IsVanilla && distance(m_Pos, pChr->m_Pos) >= 20.0f * 2) // pickup distance is shorter on vanilla due to using ClosestEntity
 				continue;
-			if(m_Layer == LAYER_SWITCH && m_Number > 0 && m_Number < Collision()->m_NumSwitchers + 1 && !GameWorld()->Collision()->m_pSwitchers[m_Number].m_Status[pChr->Team()])
+			if(m_Layer == LAYER_SWITCH && m_Number > 0 && m_Number < Collision()->m_NumSwitchers + 1 && !Switchers()[m_Number].m_Status[pChr->Team()])
 				continue;
 			bool sound = false;
 			// player picked us up, is someone was hooking us, let them go

--- a/src/game/client/prediction/entities/projectile.cpp
+++ b/src/game/client/prediction/entities/projectile.cpp
@@ -109,7 +109,7 @@ void CProjectile::Tick()
 			CCharacter *apEnts[MAX_CLIENTS];
 			int Num = GameWorld()->FindEntities(CurPos, 1.0f, (CEntity **)apEnts, MAX_CLIENTS, CGameWorld::ENTTYPE_CHARACTER);
 			for(int i = 0; i < Num; ++i)
-				if(apEnts[i] && (m_Layer != LAYER_SWITCH || (m_Layer == LAYER_SWITCH && m_Number > 0 && m_Number < Collision()->m_NumSwitchers + 1 && Switchers()[m_Number].m_Status[apEnts[i]->Team()])))
+				if(apEnts[i] && (m_Layer != LAYER_SWITCH || (m_Layer == LAYER_SWITCH && m_Number > 0 && m_Number < (int)Switchers().size() && Switchers()[m_Number].m_Status[apEnts[i]->Team()])))
 					apEnts[i]->Freeze();
 		}
 		if(Collide && m_Bouncing != 0)

--- a/src/game/client/prediction/entities/projectile.cpp
+++ b/src/game/client/prediction/entities/projectile.cpp
@@ -109,7 +109,7 @@ void CProjectile::Tick()
 			CCharacter *apEnts[MAX_CLIENTS];
 			int Num = GameWorld()->FindEntities(CurPos, 1.0f, (CEntity **)apEnts, MAX_CLIENTS, CGameWorld::ENTTYPE_CHARACTER);
 			for(int i = 0; i < Num; ++i)
-				if(apEnts[i] && (m_Layer != LAYER_SWITCH || (m_Layer == LAYER_SWITCH && m_Number > 0 && m_Number < Collision()->m_NumSwitchers + 1 && GameWorld()->Collision()->m_pSwitchers[m_Number].m_Status[apEnts[i]->Team()])))
+				if(apEnts[i] && (m_Layer != LAYER_SWITCH || (m_Layer == LAYER_SWITCH && m_Number > 0 && m_Number < Collision()->m_NumSwitchers + 1 && Switchers()[m_Number].m_Status[apEnts[i]->Team()])))
 					apEnts[i]->Freeze();
 		}
 		if(Collide && m_Bouncing != 0)

--- a/src/game/client/prediction/entity.h
+++ b/src/game/client/prediction/entity.h
@@ -38,6 +38,7 @@ public:
 	CEntity(CGameWorld *pGameWorld, int Objtype, vec2 Pos = vec2(0, 0), int ProximityRadius = 0);
 	virtual ~CEntity();
 
+	std::vector<SSwitchers> &Switchers() { return m_pGameWorld->Switchers(); }
 	class CGameWorld *GameWorld() { return m_pGameWorld; }
 	CTuningParams *Tuning() { return GameWorld()->Tuning(); }
 	CTuningParams *TuningList() { return GameWorld()->TuningList(); }

--- a/src/game/client/prediction/gameworld.cpp
+++ b/src/game/client/prediction/gameworld.cpp
@@ -199,6 +199,29 @@ void CGameWorld::Tick()
 
 	RemoveEntities();
 
+	// update switch state
+	if(Collision()->m_NumSwitchers > 0)
+	{
+		for(int i = 0; i < (int)Switchers().size(); ++i)
+		{
+			for(int j = 0; j < MAX_CLIENTS; ++j)
+			{
+				if(Switchers()[i].m_EndTick[j] <= GameTick() && Switchers()[i].m_Type[j] == TILE_SWITCHTIMEDOPEN)
+				{
+					Switchers()[i].m_Status[j] = false;
+					Switchers()[i].m_EndTick[j] = 0;
+					Switchers()[i].m_Type[j] = TILE_SWITCHCLOSE;
+				}
+				else if(Switchers()[i].m_EndTick[j] <= GameTick() && Switchers()[i].m_Type[j] == TILE_SWITCHTIMEDCLOSE)
+				{
+					Switchers()[i].m_Status[j] = true;
+					Switchers()[i].m_EndTick[j] = 0;
+					Switchers()[i].m_Type[j] = TILE_SWITCHOPEN;
+				}
+			}
+		}
+	}
+
 	OnModified();
 }
 

--- a/src/game/client/prediction/gameworld.cpp
+++ b/src/game/client/prediction/gameworld.cpp
@@ -200,24 +200,21 @@ void CGameWorld::Tick()
 	RemoveEntities();
 
 	// update switch state
-	if(Collision()->m_NumSwitchers > 0)
+	for(auto &Switcher : Switchers())
 	{
-		for(int i = 0; i < (int)Switchers().size(); ++i)
+		for(int j = 0; j < MAX_CLIENTS; ++j)
 		{
-			for(int j = 0; j < MAX_CLIENTS; ++j)
+			if(Switcher.m_EndTick[j] <= GameTick() && Switcher.m_Type[j] == TILE_SWITCHTIMEDOPEN)
 			{
-				if(Switchers()[i].m_EndTick[j] <= GameTick() && Switchers()[i].m_Type[j] == TILE_SWITCHTIMEDOPEN)
-				{
-					Switchers()[i].m_Status[j] = false;
-					Switchers()[i].m_EndTick[j] = 0;
-					Switchers()[i].m_Type[j] = TILE_SWITCHCLOSE;
-				}
-				else if(Switchers()[i].m_EndTick[j] <= GameTick() && Switchers()[i].m_Type[j] == TILE_SWITCHTIMEDCLOSE)
-				{
-					Switchers()[i].m_Status[j] = true;
-					Switchers()[i].m_EndTick[j] = 0;
-					Switchers()[i].m_Type[j] = TILE_SWITCHOPEN;
-				}
+				Switcher.m_Status[j] = false;
+				Switcher.m_EndTick[j] = 0;
+				Switcher.m_Type[j] = TILE_SWITCHCLOSE;
+			}
+			else if(Switcher.m_EndTick[j] <= GameTick() && Switcher.m_Type[j] == TILE_SWITCHTIMEDCLOSE)
+			{
+				Switcher.m_Status[j] = true;
+				Switcher.m_EndTick[j] = 0;
+				Switcher.m_Type[j] = TILE_SWITCHOPEN;
 			}
 		}
 	}

--- a/src/game/client/prediction/gameworld.cpp
+++ b/src/game/client/prediction/gameworld.cpp
@@ -10,6 +10,7 @@
 #include <algorithm>
 #include <engine/shared/config.h>
 #include <game/client/projectile_data.h>
+#include <game/mapitems.h>
 #include <utility>
 
 //////////////////////////////////////////////////

--- a/src/game/client/prediction/gameworld.cpp
+++ b/src/game/client/prediction/gameworld.cpp
@@ -530,6 +530,7 @@ void CGameWorld::CopyWorld(CGameWorld *pFrom)
 	}
 	m_pTuningList = pFrom->m_pTuningList;
 	m_Teams = pFrom->m_Teams;
+	m_Core.m_aSwitchers = pFrom->m_Core.m_aSwitchers;
 	// delete the previous entities
 	for(auto &pFirstEntityType : m_apFirstEntityTypes)
 		while(pFirstEntityType)

--- a/src/game/client/prediction/gameworld.h
+++ b/src/game/client/prediction/gameworld.h
@@ -53,6 +53,7 @@ public:
 	int GameTickSpeed() { return m_GameTickSpeed; }
 	class CCollision *Collision() { return m_pCollision; }
 	CTeamsCore *Teams() { return &m_Teams; }
+	std::vector<SSwitchers> &Switchers() { return m_Core.m_aSwitchers; }
 	CTuningParams *Tuning();
 	CEntity *GetEntity(int ID, int EntityType);
 	class CCharacter *GetCharacterByID(int ID) { return (ID >= 0 && ID < MAX_CLIENTS) ? m_apCharacters[ID] : 0; }

--- a/src/game/collision.cpp
+++ b/src/game/collision.cpp
@@ -59,7 +59,7 @@ CCollision::~CCollision()
 void CCollision::Init(class CLayers *pLayers)
 {
 	Dest();
-	m_NumSwitchers = 0;
+	m_HighestSwitchNumber = 0;
 	m_pLayers = pLayers;
 	m_Width = m_pLayers->GameLayer()->m_Width;
 	m_Height = m_pLayers->GameLayer()->m_Height;
@@ -112,8 +112,8 @@ void CCollision::Init(class CLayers *pLayers)
 		int Index;
 		if(m_pSwitch)
 		{
-			if(m_pSwitch[i].m_Number > m_NumSwitchers)
-				m_NumSwitchers = m_pSwitch[i].m_Number;
+			if(m_pSwitch[i].m_Number > m_HighestSwitchNumber)
+				m_HighestSwitchNumber = m_pSwitch[i].m_Number;
 
 			if(m_pSwitch[i].m_Number)
 				m_pDoor[i].m_Number = m_pSwitch[i].m_Number;

--- a/src/game/collision.cpp
+++ b/src/game/collision.cpp
@@ -48,7 +48,6 @@ CCollision::CCollision()
 	m_pFront = 0;
 	m_pSwitch = 0;
 	m_pDoor = 0;
-	m_pSwitchers = 0;
 	m_pTune = 0;
 }
 
@@ -92,7 +91,6 @@ void CCollision::Init(class CLayers *pLayers)
 	else
 	{
 		m_pDoor = 0;
-		m_pSwitchers = 0;
 	}
 
 	if(m_pLayers->TuneLayer())
@@ -130,22 +128,6 @@ void CCollision::Init(class CLayers *pLayers)
 					m_pSwitch[i].m_Type = Index;
 				else
 					m_pSwitch[i].m_Type = 0;
-			}
-		}
-	}
-
-	if(m_NumSwitchers)
-	{
-		m_pSwitchers = new SSwitchers[m_NumSwitchers + 1];
-
-		for(int i = 0; i < m_NumSwitchers + 1; ++i)
-		{
-			m_pSwitchers[i].m_Initial = true;
-			for(int j = 0; j < MAX_CLIENTS; ++j)
-			{
-				m_pSwitchers[i].m_Status[j] = true;
-				m_pSwitchers[i].m_EndTick[j] = 0;
-				m_pSwitchers[i].m_Type[j] = 0;
 			}
 		}
 	}
@@ -566,7 +548,6 @@ void CCollision::MoveBox(vec2 *pInoutPos, vec2 *pInoutVel, vec2 Size, float Elas
 void CCollision::Dest()
 {
 	delete[] m_pDoor;
-	delete[] m_pSwitchers;
 	m_pTiles = 0;
 	m_Width = 0;
 	m_Height = 0;
@@ -577,7 +558,6 @@ void CCollision::Dest()
 	m_pSwitch = 0;
 	m_pTune = 0;
 	m_pDoor = 0;
-	m_pSwitchers = 0;
 }
 
 int CCollision::IsSolid(int x, int y) const

--- a/src/game/collision.h
+++ b/src/game/collision.h
@@ -114,7 +114,7 @@ public:
 	class CSwitchTile *SwitchLayer() { return m_pSwitch; }
 	class CTuneTile *TuneLayer() { return m_pTune; }
 	class CLayers *Layers() { return m_pLayers; }
-	int m_NumSwitchers;
+	int m_HighestSwitchNumber;
 
 private:
 	class CTeleTile *m_pTele;

--- a/src/game/collision.h
+++ b/src/game/collision.h
@@ -116,15 +116,6 @@ public:
 	class CLayers *Layers() { return m_pLayers; }
 	int m_NumSwitchers;
 
-	struct SSwitchers
-	{
-		bool m_Status[MAX_CLIENTS];
-		bool m_Initial;
-		int m_EndTick[MAX_CLIENTS];
-		int m_Type[MAX_CLIENTS];
-	};
-	SSwitchers *m_pSwitchers;
-
 private:
 	class CTeleTile *m_pTele;
 	class CSpeedupTile *m_pSpeedup;

--- a/src/game/gamecore.cpp
+++ b/src/game/gamecore.cpp
@@ -670,6 +670,7 @@ void CWorldCore::InitSwitchers(int NumSwitchers)
 			m_aSwitchers[i].m_Status[j] = true;
 			m_aSwitchers[i].m_EndTick[j] = 0;
 			m_aSwitchers[i].m_Type[j] = 0;
+			m_aSwitchers[i].m_LastUpdateTick[j] = 0;
 		}
 	}
 }

--- a/src/game/gamecore.cpp
+++ b/src/game/gamecore.cpp
@@ -658,19 +658,22 @@ bool CCharacterCore::IsSwitchActiveCb(int Number, void *pUser)
 	return false;
 }
 
-void CWorldCore::InitSwitchers(int NumSwitchers)
+void CWorldCore::InitSwitchers(int HighestSwitchNumber)
 {
-	m_aSwitchers.resize(NumSwitchers + 1);
+	if(HighestSwitchNumber > 0)
+		m_aSwitchers.resize(HighestSwitchNumber + 1);
+	else
+		m_aSwitchers.clear();
 
-	for(int i = 0; i < NumSwitchers + 1; i++)
+	for(auto &Switcher : m_aSwitchers)
 	{
-		m_aSwitchers[i].m_Initial = true;
+		Switcher.m_Initial = true;
 		for(int j = 0; j < MAX_CLIENTS; j++)
 		{
-			m_aSwitchers[i].m_Status[j] = true;
-			m_aSwitchers[i].m_EndTick[j] = 0;
-			m_aSwitchers[i].m_Type[j] = 0;
-			m_aSwitchers[i].m_LastUpdateTick[j] = 0;
+			Switcher.m_Status[j] = true;
+			Switcher.m_EndTick[j] = 0;
+			Switcher.m_Type[j] = 0;
+			Switcher.m_LastUpdateTick[j] = 0;
 		}
 	}
 }

--- a/src/game/gamecore.cpp
+++ b/src/game/gamecore.cpp
@@ -652,8 +652,24 @@ void CCharacterCore::SetTeleOuts(std::map<int, std::vector<vec2>> *pTeleOuts)
 bool CCharacterCore::IsSwitchActiveCb(int Number, void *pUser)
 {
 	CCharacterCore *pThis = (CCharacterCore *)pUser;
-	if(pThis->Collision()->m_pSwitchers)
+	if(pThis->m_pWorld && !pThis->m_pWorld->m_aSwitchers.empty())
 		if(pThis->m_Id != -1 && pThis->m_pTeams->Team(pThis->m_Id) != (pThis->m_pTeams->m_IsDDRace16 ? VANILLA_TEAM_SUPER : TEAM_SUPER))
-			return pThis->Collision()->m_pSwitchers[Number].m_Status[pThis->m_pTeams->Team(pThis->m_Id)];
+			return pThis->m_pWorld->m_aSwitchers[Number].m_Status[pThis->m_pTeams->Team(pThis->m_Id)];
 	return false;
+}
+
+void CWorldCore::InitSwitchers(int NumSwitchers)
+{
+	m_aSwitchers.resize(NumSwitchers + 1);
+
+	for(int i = 0; i < NumSwitchers + 1; i++)
+	{
+		m_aSwitchers[i].m_Initial = true;
+		for(int j = 0; j < MAX_CLIENTS; j++)
+		{
+			m_aSwitchers[i].m_Status[j] = true;
+			m_aSwitchers[i].m_EndTick[j] = 0;
+			m_aSwitchers[i].m_Type[j] = 0;
+		}
+	}
 }

--- a/src/game/gamecore.h
+++ b/src/game/gamecore.h
@@ -208,7 +208,7 @@ public:
 	class CCharacterCore *m_apCharacters[MAX_CLIENTS];
 	CPrng *m_pPrng;
 
-	void InitSwitchers(int Num);
+	void InitSwitchers(int HighestSwitchNumber);
 	std::vector<SSwitchers> m_aSwitchers;
 };
 

--- a/src/game/gamecore.h
+++ b/src/game/gamecore.h
@@ -174,6 +174,14 @@ enum
 	SHOW_OTHERS_ONLY_TEAM = 2 // show players that are in solo and are in the same team
 };
 
+struct SSwitchers
+{
+	bool m_Status[MAX_CLIENTS];
+	bool m_Initial;
+	int m_EndTick[MAX_CLIENTS];
+	int m_Type[MAX_CLIENTS];
+};
+
 class CWorldCore
 {
 public:
@@ -198,6 +206,9 @@ public:
 	CTuningParams m_Tuning[2];
 	class CCharacterCore *m_apCharacters[MAX_CLIENTS];
 	CPrng *m_pPrng;
+
+	void InitSwitchers(int Num);
+	std::vector<SSwitchers> m_aSwitchers;
 };
 
 class CCharacterCore

--- a/src/game/gamecore.h
+++ b/src/game/gamecore.h
@@ -180,6 +180,7 @@ struct SSwitchers
 	bool m_Initial;
 	int m_EndTick[MAX_CLIENTS];
 	int m_Type[MAX_CLIENTS];
+	int m_LastUpdateTick[MAX_CLIENTS];
 };
 
 class CWorldCore

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -1599,88 +1599,52 @@ void CCharacter::HandleTiles(int Index)
 	// handle switch tiles
 	if(Collision()->GetSwitchType(MapIndex) == TILE_SWITCHOPEN && Team() != TEAM_SUPER && Collision()->GetSwitchNumber(MapIndex) > 0)
 	{
-<<<<<<< HEAD
-		Collision()->m_pSwitchers[Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()] = true;
-		Collision()->m_pSwitchers[Collision()->GetSwitchNumber(MapIndex)].m_EndTick[Team()] = 0;
-		Collision()->m_pSwitchers[Collision()->GetSwitchNumber(MapIndex)].m_Type[Team()] = TILE_SWITCHOPEN;
-=======
-		Switchers()[GameServer()->Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()] = true;
-		Switchers()[GameServer()->Collision()->GetSwitchNumber(MapIndex)].m_EndTick[Team()] = 0;
-		Switchers()[GameServer()->Collision()->GetSwitchNumber(MapIndex)].m_Type[Team()] = TILE_SWITCHOPEN;
->>>>>>> b7ea8837e (Move switch state to gamecore)
+		Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()] = true;
+		Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_EndTick[Team()] = 0;
+		Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_Type[Team()] = TILE_SWITCHOPEN;
+		Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_LastUpdateTick[Team()] = Server()->Tick();
 	}
 	else if(Collision()->GetSwitchType(MapIndex) == TILE_SWITCHTIMEDOPEN && Team() != TEAM_SUPER && Collision()->GetSwitchNumber(MapIndex) > 0)
 	{
-<<<<<<< HEAD
-		Collision()->m_pSwitchers[Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()] = true;
-		Collision()->m_pSwitchers[Collision()->GetSwitchNumber(MapIndex)].m_EndTick[Team()] = Server()->Tick() + 1 + Collision()->GetSwitchDelay(MapIndex) * Server()->TickSpeed();
-		Collision()->m_pSwitchers[Collision()->GetSwitchNumber(MapIndex)].m_Type[Team()] = TILE_SWITCHTIMEDOPEN;
-=======
-		Switchers()[GameServer()->Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()] = true;
-		Switchers()[GameServer()->Collision()->GetSwitchNumber(MapIndex)].m_EndTick[Team()] = Server()->Tick() + 1 + GameServer()->Collision()->GetSwitchDelay(MapIndex) * Server()->TickSpeed();
-		Switchers()[GameServer()->Collision()->GetSwitchNumber(MapIndex)].m_Type[Team()] = TILE_SWITCHTIMEDOPEN;
->>>>>>> b7ea8837e (Move switch state to gamecore)
+		Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()] = true;
+		Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_EndTick[Team()] = Server()->Tick() + 1 + Collision()->GetSwitchDelay(MapIndex) * Server()->TickSpeed();
+		Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_Type[Team()] = TILE_SWITCHTIMEDOPEN;
+		Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_LastUpdateTick[Team()] = Server()->Tick();
 	}
 	else if(Collision()->GetSwitchType(MapIndex) == TILE_SWITCHTIMEDCLOSE && Team() != TEAM_SUPER && Collision()->GetSwitchNumber(MapIndex) > 0)
 	{
-<<<<<<< HEAD
-		Collision()->m_pSwitchers[Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()] = false;
-		Collision()->m_pSwitchers[Collision()->GetSwitchNumber(MapIndex)].m_EndTick[Team()] = Server()->Tick() + 1 + Collision()->GetSwitchDelay(MapIndex) * Server()->TickSpeed();
-		Collision()->m_pSwitchers[Collision()->GetSwitchNumber(MapIndex)].m_Type[Team()] = TILE_SWITCHTIMEDCLOSE;
-=======
-		Switchers()[GameServer()->Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()] = false;
-		Switchers()[GameServer()->Collision()->GetSwitchNumber(MapIndex)].m_EndTick[Team()] = Server()->Tick() + 1 + GameServer()->Collision()->GetSwitchDelay(MapIndex) * Server()->TickSpeed();
-		Switchers()[GameServer()->Collision()->GetSwitchNumber(MapIndex)].m_Type[Team()] = TILE_SWITCHTIMEDCLOSE;
->>>>>>> b7ea8837e (Move switch state to gamecore)
+		Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()] = false;
+		Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_EndTick[Team()] = Server()->Tick() + 1 + Collision()->GetSwitchDelay(MapIndex) * Server()->TickSpeed();
+		Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_Type[Team()] = TILE_SWITCHTIMEDCLOSE;
+		Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_LastUpdateTick[Team()] = Server()->Tick();
 	}
 	else if(Collision()->GetSwitchType(MapIndex) == TILE_SWITCHCLOSE && Team() != TEAM_SUPER && Collision()->GetSwitchNumber(MapIndex) > 0)
 	{
-<<<<<<< HEAD
-		Collision()->m_pSwitchers[Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()] = false;
-		Collision()->m_pSwitchers[Collision()->GetSwitchNumber(MapIndex)].m_EndTick[Team()] = 0;
-		Collision()->m_pSwitchers[Collision()->GetSwitchNumber(MapIndex)].m_Type[Team()] = TILE_SWITCHCLOSE;
-=======
-		Switchers()[GameServer()->Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()] = false;
-		Switchers()[GameServer()->Collision()->GetSwitchNumber(MapIndex)].m_EndTick[Team()] = 0;
-		Switchers()[GameServer()->Collision()->GetSwitchNumber(MapIndex)].m_Type[Team()] = TILE_SWITCHCLOSE;
->>>>>>> b7ea8837e (Move switch state to gamecore)
+		Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()] = false;
+		Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_EndTick[Team()] = 0;
+		Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_Type[Team()] = TILE_SWITCHCLOSE;
+		Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_LastUpdateTick[Team()] = Server()->Tick();
 	}
 	else if(Collision()->GetSwitchType(MapIndex) == TILE_FREEZE && Team() != TEAM_SUPER)
 	{
-<<<<<<< HEAD
-		if(Collision()->GetSwitchNumber(MapIndex) == 0 || Collision()->m_pSwitchers[Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()])
-=======
-		if(GameServer()->Collision()->GetSwitchNumber(MapIndex) == 0 || Switchers()[GameServer()->Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()])
->>>>>>> b7ea8837e (Move switch state to gamecore)
+		if(Collision()->GetSwitchNumber(MapIndex) == 0 || Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()])
 		{
 			Freeze(Collision()->GetSwitchDelay(MapIndex));
 		}
 	}
 	else if(Collision()->GetSwitchType(MapIndex) == TILE_DFREEZE && Team() != TEAM_SUPER)
 	{
-<<<<<<< HEAD
-		if(Collision()->GetSwitchNumber(MapIndex) == 0 || Collision()->m_pSwitchers[Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()])
-=======
-		if(GameServer()->Collision()->GetSwitchNumber(MapIndex) == 0 || Switchers()[GameServer()->Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()])
->>>>>>> b7ea8837e (Move switch state to gamecore)
+		if(Collision()->GetSwitchNumber(MapIndex) == 0 || Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()])
 			m_DeepFreeze = true;
 	}
 	else if(Collision()->GetSwitchType(MapIndex) == TILE_DUNFREEZE && Team() != TEAM_SUPER)
 	{
-<<<<<<< HEAD
-		if(Collision()->GetSwitchNumber(MapIndex) == 0 || Collision()->m_pSwitchers[Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()])
-=======
-		if(GameServer()->Collision()->GetSwitchNumber(MapIndex) == 0 || Switchers()[GameServer()->Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()])
->>>>>>> b7ea8837e (Move switch state to gamecore)
+		if(Collision()->GetSwitchNumber(MapIndex) == 0 || Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()])
 			m_DeepFreeze = false;
 	}
 	else if(Collision()->GetSwitchType(MapIndex) == TILE_LFREEZE && Team() != TEAM_SUPER)
 	{
-<<<<<<< HEAD
-		if(Collision()->GetSwitchNumber(MapIndex) == 0 || Collision()->m_pSwitchers[Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()])
-=======
-		if(GameServer()->Collision()->GetSwitchNumber(MapIndex) == 0 || Switchers()[GameServer()->Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()])
->>>>>>> b7ea8837e (Move switch state to gamecore)
+		if(Collision()->GetSwitchNumber(MapIndex) == 0 || Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()])
 		{
 			m_LiveFreeze = true;
 			m_Core.m_LiveFrozen = true;
@@ -1688,11 +1652,7 @@ void CCharacter::HandleTiles(int Index)
 	}
 	else if(Collision()->GetSwitchType(MapIndex) == TILE_LUNFREEZE && Team() != TEAM_SUPER)
 	{
-<<<<<<< HEAD
-		if(Collision()->GetSwitchNumber(MapIndex) == 0 || Collision()->m_pSwitchers[Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()])
-=======
-		if(GameServer()->Collision()->GetSwitchNumber(MapIndex) == 0 || Switchers()[GameServer()->Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()])
->>>>>>> b7ea8837e (Move switch state to gamecore)
+		if(Collision()->GetSwitchNumber(MapIndex) == 0 || Switchers()[Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()])
 		{
 			m_LiveFreeze = false;
 			m_Core.m_LiveFrozen = false;

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -1327,8 +1327,8 @@ void CCharacter::HandleSkippableTiles(int Index)
 bool CCharacter::IsSwitchActiveCb(int Number, void *pUser)
 {
 	CCharacter *pThis = (CCharacter *)pUser;
-	CCollision *pCollision = pThis->Collision();
-	return pCollision->m_pSwitchers && pThis->Team() != TEAM_SUPER && pCollision->m_pSwitchers[Number].m_Status[pThis->Team()];
+	auto &aSwitchers = pThis->Switchers();
+	return !aSwitchers.empty() && pThis->Team() != TEAM_SUPER && aSwitchers[Number].m_Status[pThis->Team()];
 }
 
 void CCharacter::HandleTiles(int Index)
@@ -1599,48 +1599,88 @@ void CCharacter::HandleTiles(int Index)
 	// handle switch tiles
 	if(Collision()->GetSwitchType(MapIndex) == TILE_SWITCHOPEN && Team() != TEAM_SUPER && Collision()->GetSwitchNumber(MapIndex) > 0)
 	{
+<<<<<<< HEAD
 		Collision()->m_pSwitchers[Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()] = true;
 		Collision()->m_pSwitchers[Collision()->GetSwitchNumber(MapIndex)].m_EndTick[Team()] = 0;
 		Collision()->m_pSwitchers[Collision()->GetSwitchNumber(MapIndex)].m_Type[Team()] = TILE_SWITCHOPEN;
+=======
+		Switchers()[GameServer()->Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()] = true;
+		Switchers()[GameServer()->Collision()->GetSwitchNumber(MapIndex)].m_EndTick[Team()] = 0;
+		Switchers()[GameServer()->Collision()->GetSwitchNumber(MapIndex)].m_Type[Team()] = TILE_SWITCHOPEN;
+>>>>>>> b7ea8837e (Move switch state to gamecore)
 	}
 	else if(Collision()->GetSwitchType(MapIndex) == TILE_SWITCHTIMEDOPEN && Team() != TEAM_SUPER && Collision()->GetSwitchNumber(MapIndex) > 0)
 	{
+<<<<<<< HEAD
 		Collision()->m_pSwitchers[Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()] = true;
 		Collision()->m_pSwitchers[Collision()->GetSwitchNumber(MapIndex)].m_EndTick[Team()] = Server()->Tick() + 1 + Collision()->GetSwitchDelay(MapIndex) * Server()->TickSpeed();
 		Collision()->m_pSwitchers[Collision()->GetSwitchNumber(MapIndex)].m_Type[Team()] = TILE_SWITCHTIMEDOPEN;
+=======
+		Switchers()[GameServer()->Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()] = true;
+		Switchers()[GameServer()->Collision()->GetSwitchNumber(MapIndex)].m_EndTick[Team()] = Server()->Tick() + 1 + GameServer()->Collision()->GetSwitchDelay(MapIndex) * Server()->TickSpeed();
+		Switchers()[GameServer()->Collision()->GetSwitchNumber(MapIndex)].m_Type[Team()] = TILE_SWITCHTIMEDOPEN;
+>>>>>>> b7ea8837e (Move switch state to gamecore)
 	}
 	else if(Collision()->GetSwitchType(MapIndex) == TILE_SWITCHTIMEDCLOSE && Team() != TEAM_SUPER && Collision()->GetSwitchNumber(MapIndex) > 0)
 	{
+<<<<<<< HEAD
 		Collision()->m_pSwitchers[Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()] = false;
 		Collision()->m_pSwitchers[Collision()->GetSwitchNumber(MapIndex)].m_EndTick[Team()] = Server()->Tick() + 1 + Collision()->GetSwitchDelay(MapIndex) * Server()->TickSpeed();
 		Collision()->m_pSwitchers[Collision()->GetSwitchNumber(MapIndex)].m_Type[Team()] = TILE_SWITCHTIMEDCLOSE;
+=======
+		Switchers()[GameServer()->Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()] = false;
+		Switchers()[GameServer()->Collision()->GetSwitchNumber(MapIndex)].m_EndTick[Team()] = Server()->Tick() + 1 + GameServer()->Collision()->GetSwitchDelay(MapIndex) * Server()->TickSpeed();
+		Switchers()[GameServer()->Collision()->GetSwitchNumber(MapIndex)].m_Type[Team()] = TILE_SWITCHTIMEDCLOSE;
+>>>>>>> b7ea8837e (Move switch state to gamecore)
 	}
 	else if(Collision()->GetSwitchType(MapIndex) == TILE_SWITCHCLOSE && Team() != TEAM_SUPER && Collision()->GetSwitchNumber(MapIndex) > 0)
 	{
+<<<<<<< HEAD
 		Collision()->m_pSwitchers[Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()] = false;
 		Collision()->m_pSwitchers[Collision()->GetSwitchNumber(MapIndex)].m_EndTick[Team()] = 0;
 		Collision()->m_pSwitchers[Collision()->GetSwitchNumber(MapIndex)].m_Type[Team()] = TILE_SWITCHCLOSE;
+=======
+		Switchers()[GameServer()->Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()] = false;
+		Switchers()[GameServer()->Collision()->GetSwitchNumber(MapIndex)].m_EndTick[Team()] = 0;
+		Switchers()[GameServer()->Collision()->GetSwitchNumber(MapIndex)].m_Type[Team()] = TILE_SWITCHCLOSE;
+>>>>>>> b7ea8837e (Move switch state to gamecore)
 	}
 	else if(Collision()->GetSwitchType(MapIndex) == TILE_FREEZE && Team() != TEAM_SUPER)
 	{
+<<<<<<< HEAD
 		if(Collision()->GetSwitchNumber(MapIndex) == 0 || Collision()->m_pSwitchers[Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()])
+=======
+		if(GameServer()->Collision()->GetSwitchNumber(MapIndex) == 0 || Switchers()[GameServer()->Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()])
+>>>>>>> b7ea8837e (Move switch state to gamecore)
 		{
 			Freeze(Collision()->GetSwitchDelay(MapIndex));
 		}
 	}
 	else if(Collision()->GetSwitchType(MapIndex) == TILE_DFREEZE && Team() != TEAM_SUPER)
 	{
+<<<<<<< HEAD
 		if(Collision()->GetSwitchNumber(MapIndex) == 0 || Collision()->m_pSwitchers[Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()])
+=======
+		if(GameServer()->Collision()->GetSwitchNumber(MapIndex) == 0 || Switchers()[GameServer()->Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()])
+>>>>>>> b7ea8837e (Move switch state to gamecore)
 			m_DeepFreeze = true;
 	}
 	else if(Collision()->GetSwitchType(MapIndex) == TILE_DUNFREEZE && Team() != TEAM_SUPER)
 	{
+<<<<<<< HEAD
 		if(Collision()->GetSwitchNumber(MapIndex) == 0 || Collision()->m_pSwitchers[Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()])
+=======
+		if(GameServer()->Collision()->GetSwitchNumber(MapIndex) == 0 || Switchers()[GameServer()->Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()])
+>>>>>>> b7ea8837e (Move switch state to gamecore)
 			m_DeepFreeze = false;
 	}
 	else if(Collision()->GetSwitchType(MapIndex) == TILE_LFREEZE && Team() != TEAM_SUPER)
 	{
+<<<<<<< HEAD
 		if(Collision()->GetSwitchNumber(MapIndex) == 0 || Collision()->m_pSwitchers[Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()])
+=======
+		if(GameServer()->Collision()->GetSwitchNumber(MapIndex) == 0 || Switchers()[GameServer()->Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()])
+>>>>>>> b7ea8837e (Move switch state to gamecore)
 		{
 			m_LiveFreeze = true;
 			m_Core.m_LiveFrozen = true;
@@ -1648,7 +1688,11 @@ void CCharacter::HandleTiles(int Index)
 	}
 	else if(Collision()->GetSwitchType(MapIndex) == TILE_LUNFREEZE && Team() != TEAM_SUPER)
 	{
+<<<<<<< HEAD
 		if(Collision()->GetSwitchNumber(MapIndex) == 0 || Collision()->m_pSwitchers[Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()])
+=======
+		if(GameServer()->Collision()->GetSwitchNumber(MapIndex) == 0 || Switchers()[GameServer()->Collision()->GetSwitchNumber(MapIndex)].m_Status[Team()])
+>>>>>>> b7ea8837e (Move switch state to gamecore)
 		{
 			m_LiveFreeze = false;
 			m_Core.m_LiveFrozen = false;

--- a/src/game/server/entities/door.cpp
+++ b/src/game/server/entities/door.cpp
@@ -75,7 +75,7 @@ void CDoor::Snap(int SnappingClient)
 		if(SnappingClient != SERVER_DEMO_CLIENT && (GameServer()->m_apPlayers[SnappingClient]->GetTeam() == TEAM_SPECTATORS || GameServer()->m_apPlayers[SnappingClient]->IsPaused()) && GameServer()->m_apPlayers[SnappingClient]->m_SpectatorID != SPEC_FREEVIEW)
 			Char = GameServer()->GetPlayerChar(GameServer()->m_apPlayers[SnappingClient]->m_SpectatorID);
 
-		if(Char && Char->Team() != TEAM_SUPER && Char->IsAlive() && GameServer()->Collision()->m_NumSwitchers > 0 && Switchers()[m_Number].m_Status[Char->Team()])
+		if(Char && Char->Team() != TEAM_SUPER && Char->IsAlive() && !Switchers().empty() && Switchers()[m_Number].m_Status[Char->Team()])
 		{
 			pObj->m_FromX = (int)m_To.x;
 			pObj->m_FromY = (int)m_To.y;

--- a/src/game/server/entities/door.cpp
+++ b/src/game/server/entities/door.cpp
@@ -75,7 +75,7 @@ void CDoor::Snap(int SnappingClient)
 		if(SnappingClient != SERVER_DEMO_CLIENT && (GameServer()->m_apPlayers[SnappingClient]->GetTeam() == TEAM_SPECTATORS || GameServer()->m_apPlayers[SnappingClient]->IsPaused()) && GameServer()->m_apPlayers[SnappingClient]->m_SpectatorID != SPEC_FREEVIEW)
 			Char = GameServer()->GetPlayerChar(GameServer()->m_apPlayers[SnappingClient]->m_SpectatorID);
 
-		if(Char && Char->Team() != TEAM_SUPER && Char->IsAlive() && GameServer()->Collision()->m_NumSwitchers > 0 && GameServer()->Collision()->m_pSwitchers[m_Number].m_Status[Char->Team()])
+		if(Char && Char->Team() != TEAM_SUPER && Char->IsAlive() && GameServer()->Collision()->m_NumSwitchers > 0 && Switchers()[m_Number].m_Status[Char->Team()])
 		{
 			pObj->m_FromX = (int)m_To.x;
 			pObj->m_FromY = (int)m_To.y;

--- a/src/game/server/entities/dragger.cpp
+++ b/src/game/server/entities/dragger.cpp
@@ -90,7 +90,7 @@ void CDragger::LookForPlayersToDrag()
 		}
 		// If the dragger is disabled for the target's team, no dragger beam will be generated
 		if(m_Layer == LAYER_SWITCH && m_Number > 0 &&
-			!GameServer()->Collision()->m_pSwitchers[m_Number].m_Status[TargetTeam])
+			!Switchers()[m_Number].m_Status[TargetTeam])
 		{
 			continue;
 		}
@@ -211,7 +211,7 @@ void CDragger::Snap(int SnappingClient)
 
 		int Tick = (Server()->Tick() % Server()->TickSpeed()) % 11;
 		if(pChar && m_Layer == LAYER_SWITCH && m_Number > 0 &&
-			!GameServer()->Collision()->m_pSwitchers[m_Number].m_Status[pChar->Team()] && (!Tick))
+			!Switchers()[m_Number].m_Status[pChar->Team()] && !Tick)
 			return;
 	}
 

--- a/src/game/server/entities/dragger_beam.cpp
+++ b/src/game/server/entities/dragger_beam.cpp
@@ -46,7 +46,7 @@ void CDraggerBeam::Tick()
 	if(Server()->Tick() % int(Server()->TickSpeed() * 0.15f) == 0)
 	{
 		if(m_Layer == LAYER_SWITCH && m_Number > 0 &&
-			!GameServer()->Collision()->m_pSwitchers[m_Number].m_Status[pTarget->Team()])
+			!Switchers()[m_Number].m_Status[pTarget->Team()])
 		{
 			Reset();
 			return;

--- a/src/game/server/entities/gun.cpp
+++ b/src/game/server/entities/gun.cpp
@@ -76,7 +76,7 @@ void CGun::Fire()
 		}
 		// If the turret is disabled for the target's team, the turret will not fire
 		if(m_Layer == LAYER_SWITCH && m_Number > 0 &&
-			!GameServer()->Collision()->m_pSwitchers[m_Number].m_Status[TargetTeam])
+			!Switchers()[m_Number].m_Status[TargetTeam])
 		{
 			continue;
 		}
@@ -182,7 +182,7 @@ void CGun::Snap(int SnappingClient)
 
 		int Tick = (Server()->Tick() % Server()->TickSpeed()) % 11;
 		if(pChar && m_Layer == LAYER_SWITCH && m_Number > 0 &&
-			!GameServer()->Collision()->m_pSwitchers[m_Number].m_Status[pChar->Team()] && (!Tick))
+			!Switchers()[m_Number].m_Status[pChar->Team()] && (!Tick))
 			return;
 	}
 

--- a/src/game/server/entities/light.cpp
+++ b/src/game/server/entities/light.cpp
@@ -32,7 +32,7 @@ bool CLight::HitCharacter()
 		return false;
 	for(auto *Char : HitCharacters)
 	{
-		if(m_Layer == LAYER_SWITCH && m_Number > 0 && !GameServer()->Collision()->m_pSwitchers[m_Number].m_Status[Char->Team()])
+		if(m_Layer == LAYER_SWITCH && m_Number > 0 && !Switchers()[m_Number].m_Status[Char->Team()])
 			continue;
 		Char->Freeze();
 	}
@@ -123,7 +123,7 @@ void CLight::Snap(int SnappingClient)
 	else
 	{
 		int Tick = (Server()->Tick() % Server()->TickSpeed()) % 6;
-		if(Char && Char->IsAlive() && m_Layer == LAYER_SWITCH && m_Number > 0 && !GameServer()->Collision()->m_pSwitchers[m_Number].m_Status[Char->Team()] && Tick)
+		if(Char && Char->IsAlive() && m_Layer == LAYER_SWITCH && m_Number > 0 && !Switchers()[m_Number].m_Status[Char->Team()] && Tick)
 			return;
 	}
 
@@ -141,7 +141,7 @@ void CLight::Snap(int SnappingClient)
 		pObj->m_FromX = (int)m_Pos.x;
 		pObj->m_FromY = (int)m_Pos.y;
 	}
-	else if(Char && m_Layer == LAYER_SWITCH && GameServer()->Collision()->m_pSwitchers[m_Number].m_Status[Char->Team()])
+	else if(Char && m_Layer == LAYER_SWITCH && Switchers()[m_Number].m_Status[Char->Team()])
 	{
 		pObj->m_FromX = (int)m_To.x;
 		pObj->m_FromY = (int)m_To.y;

--- a/src/game/server/entities/pickup.cpp
+++ b/src/game/server/entities/pickup.cpp
@@ -42,7 +42,7 @@ void CPickup::Tick()
 
 		if(pChr && pChr->IsAlive())
 		{
-			if(m_Layer == LAYER_SWITCH && m_Number > 0 && !GameServer()->Collision()->m_pSwitchers[m_Number].m_Status[pChr->Team()])
+			if(m_Layer == LAYER_SWITCH && m_Number > 0 && !Switchers()[m_Number].m_Status[pChr->Team()])
 				continue;
 			bool Sound = false;
 			// player picked us up, is someone was hooking us, let them go
@@ -187,7 +187,7 @@ void CPickup::Snap(int SnappingClient)
 	else
 	{
 		int Tick = (Server()->Tick() % Server()->TickSpeed()) % 11;
-		if(Char && Char->IsAlive() && m_Layer == LAYER_SWITCH && m_Number > 0 && !GameServer()->Collision()->m_pSwitchers[m_Number].m_Status[Char->Team()] && !Tick)
+		if(Char && Char->IsAlive() && m_Layer == LAYER_SWITCH && m_Number > 0 && !Switchers()[m_Number].m_Status[Char->Team()] && !Tick)
 			return;
 	}
 

--- a/src/game/server/entities/projectile.cpp
+++ b/src/game/server/entities/projectile.cpp
@@ -172,7 +172,7 @@ void CProjectile::Tick()
 			CCharacter *apEnts[MAX_CLIENTS];
 			int Num = GameWorld()->FindEntities(CurPos, 1.0f, (CEntity **)apEnts, MAX_CLIENTS, CGameWorld::ENTTYPE_CHARACTER);
 			for(int i = 0; i < Num; ++i)
-				if(apEnts[i] && (m_Layer != LAYER_SWITCH || (m_Layer == LAYER_SWITCH && m_Number > 0 && GameServer()->Collision()->m_pSwitchers[m_Number].m_Status[apEnts[i]->Team()])))
+				if(apEnts[i] && (m_Layer != LAYER_SWITCH || (m_Layer == LAYER_SWITCH && m_Number > 0 && Switchers()[m_Number].m_Status[apEnts[i]->Team()])))
 					apEnts[i]->Freeze();
 		}
 
@@ -321,7 +321,7 @@ void CProjectile::Snap(int SnappingClient)
 	{
 		CCharacter *pSnapChar = GameServer()->GetPlayerChar(SnappingClient);
 		int Tick = (Server()->Tick() % Server()->TickSpeed()) % ((m_Explosive) ? 6 : 20);
-		if(pSnapChar && pSnapChar->IsAlive() && (m_Layer == LAYER_SWITCH && m_Number > 0 && !GameServer()->Collision()->m_pSwitchers[m_Number].m_Status[pSnapChar->Team()] && (!Tick)))
+		if(pSnapChar && pSnapChar->IsAlive() && (m_Layer == LAYER_SWITCH && m_Number > 0 && !Switchers()[m_Number].m_Status[pSnapChar->Team()] && (!Tick)))
 			return;
 	}
 

--- a/src/game/server/entity.h
+++ b/src/game/server/entity.h
@@ -58,6 +58,7 @@ public: // TODO: Maybe make protected
 	virtual ~CEntity();
 
 	/* Objects */
+	std::vector<SSwitchers> &Switchers() { return m_pGameWorld->m_Core.m_aSwitchers; }
 	class CGameWorld *GameWorld() { return m_pGameWorld; }
 	class CConfig *Config() { return m_pGameWorld->Config(); }
 	class CGameContext *GameServer() { return m_pGameWorld->GameServer(); }

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -1083,17 +1083,17 @@ void CGameContext::OnTick()
 		{
 			for(int j = 0; j < MAX_CLIENTS; ++j)
 			{
-				if(Collision()->m_pSwitchers[i].m_EndTick[j] <= Server()->Tick() && Collision()->m_pSwitchers[i].m_Type[j] == TILE_SWITCHTIMEDOPEN)
+				if(Switchers()[i].m_EndTick[j] <= Server()->Tick() && Switchers()[i].m_Type[j] == TILE_SWITCHTIMEDOPEN)
 				{
-					Collision()->m_pSwitchers[i].m_Status[j] = false;
-					Collision()->m_pSwitchers[i].m_EndTick[j] = 0;
-					Collision()->m_pSwitchers[i].m_Type[j] = TILE_SWITCHCLOSE;
+					Switchers()[i].m_Status[j] = false;
+					Switchers()[i].m_EndTick[j] = 0;
+					Switchers()[i].m_Type[j] = TILE_SWITCHCLOSE;
 				}
-				else if(Collision()->m_pSwitchers[i].m_EndTick[j] <= Server()->Tick() && Collision()->m_pSwitchers[i].m_Type[j] == TILE_SWITCHTIMEDCLOSE)
+				else if(Switchers()[i].m_EndTick[j] <= Server()->Tick() && Switchers()[i].m_Type[j] == TILE_SWITCHTIMEDCLOSE)
 				{
-					Collision()->m_pSwitchers[i].m_Status[j] = true;
-					Collision()->m_pSwitchers[i].m_EndTick[j] = 0;
-					Collision()->m_pSwitchers[i].m_Type[j] = TILE_SWITCHOPEN;
+					Switchers()[i].m_Status[j] = true;
+					Switchers()[i].m_EndTick[j] = 0;
+					Switchers()[i].m_Type[j] = TILE_SWITCHOPEN;
 				}
 			}
 		}
@@ -2729,7 +2729,7 @@ void CGameContext::ConSwitchOpen(IConsole::IResult *pResult, void *pUserData)
 
 	if(pSelf->Collision()->m_NumSwitchers > 0 && Switch >= 0 && Switch < pSelf->Collision()->m_NumSwitchers + 1)
 	{
-		pSelf->Collision()->m_pSwitchers[Switch].m_Initial = false;
+		pSelf->Switchers()[Switch].m_Initial = false;
 		char aBuf[256];
 		str_format(aBuf, sizeof(aBuf), "switch %d opened by default", Switch);
 		pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "server", aBuf);
@@ -3203,6 +3203,7 @@ void CGameContext::OnInit(/*class IKernel *pKernel*/)
 
 	m_Layers.Init(Kernel());
 	m_Collision.Init(&m_Layers);
+	m_World.m_Core.InitSwitchers(m_Collision.m_NumSwitchers);
 
 	char aMapName[IO_MAX_PATH_LENGTH];
 	int MapSize;
@@ -3260,7 +3261,7 @@ void CGameContext::OnInit(/*class IKernel *pKernel*/)
 
 		if(Collision()->m_NumSwitchers > 0)
 			for(int i = 0; i < Collision()->m_NumSwitchers + 1; ++i)
-				Collision()->m_pSwitchers[i].m_Initial = true;
+				Switchers()[i].m_Initial = true;
 	}
 
 	Console()->ExecuteFile(g_Config.m_SvResetFile, -1);

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -161,6 +161,7 @@ public:
 	// helper functions
 	class CCharacter *GetPlayerChar(int ClientID);
 	bool EmulateBug(int Bug);
+	std::vector<SSwitchers> &Switchers() { return m_World.m_Core.m_aSwitchers; }
 
 	// voting
 	void StartVote(const char *pDesc, const char *pCommand, const char *pReason, const char *pSixupDesc);

--- a/src/game/server/gamecontroller.cpp
+++ b/src/game/server/gamecontroller.cpp
@@ -646,12 +646,12 @@ void IGameController::Snap(int SnappingClient)
 		if(!pSwitchState)
 			return;
 
-		pSwitchState->m_NumSwitchers = clamp(GameServer()->Collision()->m_NumSwitchers, 0, 255);
+		pSwitchState->m_HighestSwitchNumber = clamp((int)GameServer()->Switchers().size() - 1, 0, 255);
 		mem_zero(pSwitchState->m_Status, sizeof(pSwitchState->m_Status));
 
 		std::vector<std::pair<int, int>> aEndTicks; // <EndTick, SwitchNumber>
 
-		for(int i = 0; i < pSwitchState->m_NumSwitchers + 1; i++)
+		for(int i = 0; i <= pSwitchState->m_HighestSwitchNumber; i++)
 		{
 			int Status = (int)GameServer()->Switchers()[i].m_Status[Team];
 			pSwitchState->m_Status[i / 32] |= (Status << (i % 32));
@@ -660,7 +660,7 @@ void IGameController::Snap(int SnappingClient)
 			if(EndTick > 0 && EndTick < Server()->Tick() + 3 * Server()->TickSpeed() && GameServer()->Switchers()[i].m_LastUpdateTick[Team] < Server()->Tick())
 			{
 				// only keep track of EndTicks that have less than three second left and are not currently being updated by a player being present on a switch tile, to limit how often these are sent
-				aEndTicks.push_back({GameServer()->Switchers()[i].m_EndTick[Team], i});
+				aEndTicks.emplace_back(std::pair<int, int>(GameServer()->Switchers()[i].m_EndTick[Team], i));
 			}
 		}
 

--- a/src/game/server/gamecontroller.cpp
+++ b/src/game/server/gamecontroller.cpp
@@ -647,35 +647,12 @@ void IGameController::Snap(int SnappingClient)
 			return;
 
 		pSwitchState->m_NumSwitchers = clamp(GameServer()->Collision()->m_NumSwitchers, 0, 255);
-		pSwitchState->m_Status1 = 0;
-		pSwitchState->m_Status2 = 0;
-		pSwitchState->m_Status3 = 0;
-		pSwitchState->m_Status4 = 0;
-		pSwitchState->m_Status5 = 0;
-		pSwitchState->m_Status6 = 0;
-		pSwitchState->m_Status7 = 0;
-		pSwitchState->m_Status8 = 0;
+		mem_zero(pSwitchState->m_Status, sizeof(pSwitchState->m_Status));
 
 		for(int i = 0; i < pSwitchState->m_NumSwitchers + 1; i++)
 		{
 			int Status = (int)GameServer()->Collision()->m_pSwitchers[i].m_Status[Team];
-
-			if(i < 32)
-				pSwitchState->m_Status1 |= Status << i;
-			else if(i < 64)
-				pSwitchState->m_Status2 |= Status << (i - 32);
-			else if(i < 96)
-				pSwitchState->m_Status3 |= Status << (i - 64);
-			else if(i < 128)
-				pSwitchState->m_Status4 |= Status << (i - 96);
-			else if(i < 160)
-				pSwitchState->m_Status5 |= Status << (i - 128);
-			else if(i < 192)
-				pSwitchState->m_Status6 |= Status << (i - 160);
-			else if(i < 224)
-				pSwitchState->m_Status7 |= Status << (i - 192);
-			else if(i < 256)
-				pSwitchState->m_Status8 |= Status << (i - 224);
+			pSwitchState->m_Status[i / 32] |= (Status << (i % 32));
 		}
 	}
 }

--- a/src/game/server/gamecontroller.cpp
+++ b/src/game/server/gamecontroller.cpp
@@ -632,7 +632,7 @@ void IGameController::Snap(int SnappingClient)
 		pRaceData->m_RaceFlags = protocol7::RACEFLAG_HIDE_KILLMSG | protocol7::RACEFLAG_KEEP_WANTED_WEAPON;
 	}
 
-	if(GameServer()->Collision()->m_pSwitchers)
+	if(!GameServer()->Switchers().empty())
 	{
 		int Team = pPlayer && pPlayer->GetCharacter() ? pPlayer->GetCharacter()->Team() : 0;
 
@@ -651,7 +651,7 @@ void IGameController::Snap(int SnappingClient)
 
 		for(int i = 0; i < pSwitchState->m_NumSwitchers + 1; i++)
 		{
-			int Status = (int)GameServer()->Collision()->m_pSwitchers[i].m_Status[Team];
+			int Status = (int)GameServer()->Switchers()[i].m_Status[Team];
 			pSwitchState->m_Status[i / 32] |= (Status << (i % 32));
 		}
 	}

--- a/src/game/server/save.cpp
+++ b/src/game/server/save.cpp
@@ -471,12 +471,12 @@ int CSaveTeam::Save(int Team)
 
 			for(int i = 1; i < m_pController->GameServer()->Collision()->m_NumSwitchers + 1; i++)
 			{
-				m_pSwitchers[i].m_Status = m_pController->GameServer()->Collision()->m_pSwitchers[i].m_Status[Team];
-				if(m_pController->GameServer()->Collision()->m_pSwitchers[i].m_EndTick[Team])
-					m_pSwitchers[i].m_EndTime = m_pController->Server()->Tick() - m_pController->GameServer()->Collision()->m_pSwitchers[i].m_EndTick[Team];
+				m_pSwitchers[i].m_Status = m_pController->GameServer()->Switchers()[i].m_Status[Team];
+				if(m_pController->GameServer()->Switchers()[i].m_EndTick[Team])
+					m_pSwitchers[i].m_EndTime = m_pController->Server()->Tick() - m_pController->GameServer()->Switchers()[i].m_EndTick[Team];
 				else
 					m_pSwitchers[i].m_EndTime = 0;
-				m_pSwitchers[i].m_Type = m_pController->GameServer()->Collision()->m_pSwitchers[i].m_Type[Team];
+				m_pSwitchers[i].m_Type = m_pController->GameServer()->Switchers()[i].m_Type[Team];
 			}
 		}
 		return 0;
@@ -532,10 +532,10 @@ void CSaveTeam::Load(int Team, bool KeepCurrentWeakStrong)
 	{
 		for(int i = 1; i < minimum(m_NumSwitchers, m_pController->GameServer()->Collision()->m_NumSwitchers) + 1; i++)
 		{
-			m_pController->GameServer()->Collision()->m_pSwitchers[i].m_Status[Team] = m_pSwitchers[i].m_Status;
+			m_pController->GameServer()->Switchers()[i].m_Status[Team] = m_pSwitchers[i].m_Status;
 			if(m_pSwitchers[i].m_EndTime)
-				m_pController->GameServer()->Collision()->m_pSwitchers[i].m_EndTick[Team] = m_pController->Server()->Tick() - m_pSwitchers[i].m_EndTime;
-			m_pController->GameServer()->Collision()->m_pSwitchers[i].m_Type[Team] = m_pSwitchers[i].m_Type;
+				m_pController->GameServer()->Switchers()[i].m_EndTick[Team] = m_pController->Server()->Tick() - m_pSwitchers[i].m_EndTime;
+			m_pController->GameServer()->Switchers()[i].m_Type[Team] = m_pSwitchers[i].m_Type;
 		}
 	}
 }

--- a/src/game/server/save.cpp
+++ b/src/game/server/save.cpp
@@ -446,7 +446,7 @@ int CSaveTeam::Save(int Team)
 			return 4;
 		}
 
-		m_NumSwitchers = m_pController->GameServer()->Collision()->m_NumSwitchers;
+		m_HighestSwitchNumber = m_pController->GameServer()->Collision()->m_HighestSwitchNumber;
 		m_TeamLocked = Teams->TeamLocked(Team);
 		m_Practice = Teams->IsPractice(Team);
 
@@ -465,11 +465,11 @@ int CSaveTeam::Save(int Team)
 		if(m_MembersCount != j)
 			return 3;
 
-		if(m_pController->GameServer()->Collision()->m_NumSwitchers)
+		if(m_pController->GameServer()->Collision()->m_HighestSwitchNumber)
 		{
-			m_pSwitchers = new SSimpleSwitchers[m_pController->GameServer()->Collision()->m_NumSwitchers + 1];
+			m_pSwitchers = new SSimpleSwitchers[m_pController->GameServer()->Collision()->m_HighestSwitchNumber + 1];
 
-			for(int i = 1; i < m_pController->GameServer()->Collision()->m_NumSwitchers + 1; i++)
+			for(int i = 1; i < m_pController->GameServer()->Collision()->m_HighestSwitchNumber + 1; i++)
 			{
 				m_pSwitchers[i].m_Status = m_pController->GameServer()->Switchers()[i].m_Status[Team];
 				if(m_pController->GameServer()->Switchers()[i].m_EndTick[Team])
@@ -528,9 +528,9 @@ void CSaveTeam::Load(int Team, bool KeepCurrentWeakStrong)
 		}
 	}
 
-	if(m_pController->GameServer()->Collision()->m_NumSwitchers)
+	if(m_pController->GameServer()->Collision()->m_HighestSwitchNumber)
 	{
-		for(int i = 1; i < minimum(m_NumSwitchers, m_pController->GameServer()->Collision()->m_NumSwitchers) + 1; i++)
+		for(int i = 1; i < minimum(m_HighestSwitchNumber, m_pController->GameServer()->Collision()->m_HighestSwitchNumber) + 1; i++)
 		{
 			m_pController->GameServer()->Switchers()[i].m_Status[Team] = m_pSwitchers[i].m_Status;
 			if(m_pSwitchers[i].m_EndTime)
@@ -553,7 +553,7 @@ CCharacter *CSaveTeam::MatchCharacter(int ClientID, int SaveID, bool KeepCurrent
 
 char *CSaveTeam::GetString()
 {
-	str_format(m_aString, sizeof(m_aString), "%d\t%d\t%d\t%d\t%d", m_TeamState, m_MembersCount, m_NumSwitchers, m_TeamLocked, m_Practice);
+	str_format(m_aString, sizeof(m_aString), "%d\t%d\t%d\t%d\t%d", m_TeamState, m_MembersCount, m_HighestSwitchNumber, m_TeamLocked, m_Practice);
 
 	for(int i = 0; i < m_MembersCount; i++)
 	{
@@ -562,9 +562,9 @@ char *CSaveTeam::GetString()
 		str_append(m_aString, aBuf, sizeof(m_aString));
 	}
 
-	if(m_pSwitchers && m_NumSwitchers)
+	if(m_pSwitchers && m_HighestSwitchNumber)
 	{
-		for(int i = 1; i < m_NumSwitchers + 1; i++)
+		for(int i = 1; i < m_HighestSwitchNumber + 1; i++)
 		{
 			char aBuf[64];
 			str_format(aBuf, sizeof(aBuf), "\n%d\t%d\t%d", m_pSwitchers[i].m_Status, m_pSwitchers[i].m_EndTime, m_pSwitchers[i].m_Type);
@@ -608,7 +608,7 @@ int CSaveTeam::FromString(const char *String)
 	if(StrSize < sizeof(aTeamStats))
 	{
 		str_copy(aTeamStats, CopyPos, StrSize);
-		int Num = sscanf(aTeamStats, "%d\t%d\t%d\t%d\t%d", &m_TeamState, &m_MembersCount, &m_NumSwitchers, &m_TeamLocked, &m_Practice);
+		int Num = sscanf(aTeamStats, "%d\t%d\t%d\t%d\t%d", &m_TeamState, &m_MembersCount, &m_HighestSwitchNumber, &m_TeamLocked, &m_Practice);
 		switch(Num) // Don't forget to update this when you save / load more / less.
 		{
 		case 4:
@@ -687,10 +687,10 @@ int CSaveTeam::FromString(const char *String)
 		m_pSwitchers = 0;
 	}
 
-	if(m_NumSwitchers)
-		m_pSwitchers = new SSimpleSwitchers[m_NumSwitchers + 1];
+	if(m_HighestSwitchNumber)
+		m_pSwitchers = new SSimpleSwitchers[m_HighestSwitchNumber + 1];
 
-	for(int n = 1; n < m_NumSwitchers + 1; n++)
+	for(int n = 1; n < m_HighestSwitchNumber + 1; n++)
 	{
 		while(m_aString[Pos] != '\n' && Pos < sizeof(m_aString) && m_aString[Pos]) // find next \n or \0
 			Pos++;

--- a/src/game/server/save.h
+++ b/src/game/server/save.h
@@ -145,7 +145,7 @@ private:
 
 	int m_TeamState;
 	int m_MembersCount;
-	int m_NumSwitchers;
+	int m_HighestSwitchNumber;
 	int m_TeamLocked;
 	int m_Practice;
 };

--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -57,14 +57,11 @@ void CGameTeams::ResetRoundState(int Team)
 
 void CGameTeams::ResetSwitchers(int Team)
 {
-	if(GameServer()->Collision()->m_NumSwitchers > 0)
+	for(auto &Switcher : GameServer()->Switchers())
 	{
-		for(int i = 0; i < GameServer()->Collision()->m_NumSwitchers + 1; ++i)
-		{
-			GameServer()->Switchers()[i].m_Status[Team] = GameServer()->Switchers()[i].m_Initial;
-			GameServer()->Switchers()[i].m_EndTick[Team] = 0;
-			GameServer()->Switchers()[i].m_Type[Team] = TILE_SWITCHOPEN;
-		}
+		Switcher.m_Status[Team] = Switcher.m_Initial;
+		Switcher.m_EndTick[Team] = 0;
+		Switcher.m_Type[Team] = TILE_SWITCHOPEN;
 	}
 }
 

--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -61,9 +61,9 @@ void CGameTeams::ResetSwitchers(int Team)
 	{
 		for(int i = 0; i < GameServer()->Collision()->m_NumSwitchers + 1; ++i)
 		{
-			GameServer()->Collision()->m_pSwitchers[i].m_Status[Team] = GameServer()->Collision()->m_pSwitchers[i].m_Initial;
-			GameServer()->Collision()->m_pSwitchers[i].m_EndTick[Team] = 0;
-			GameServer()->Collision()->m_pSwitchers[i].m_Type[Team] = TILE_SWITCHOPEN;
+			GameServer()->Switchers()[i].m_Status[Team] = GameServer()->Switchers()[i].m_Initial;
+			GameServer()->Switchers()[i].m_EndTick[Team] = 0;
+			GameServer()->Switchers()[i].m_Type[Team] = TILE_SWITCHOPEN;
 		}
 	}
 }


### PR DESCRIPTION
This is an attempt to fix #4702, and also ended up being a more general attempt at predicting switch on/off tiles as well as timed switchers (with delay). A few things:

- Refactored the switch state array from CCollision to CGameCore (second commit)

The idea here was that CCollision holds information about the map that is immutable and there only exists one copy of it, while the switch state is mutable and would have both a predicted and non-predicted state in the client. While strictly not necessary, having it in the gamecore seems to represent the mutable state better and would be useful to avoid having to put the snapshot switch state back into the gameworld on each new prediction as well as to more easily keep track of the two copies.

A concern here is whether this could in any way change server behavior (time of initialization and/or destruction of switch states), so this change would require quite a bit of testing and/or review. However, from what I could tell from the code, CCollision is only initialized once and at that time where the gamecore already exists.

- Added a new extended netobject containing the end tick of switches (third commit)

This would be needed for adding general prediction for timed switchers. The idea is to only send it for a limited number of switchers (those with the lowest time left before they toggle back), since there will most likely be a limited number of timed switchers active at any point, and I randomly selected 4 as a number here. Ideally, this netobject should be merged with the previous one for simpler parsing of the information, but that would sacrifice compatibility with older servers (and/or clients). (Another possibility here would have been to treat timed switchers as regular on/off tiles and make the addition of the netobject a separate pr)

- Used NetArray from datasrc/seven/datatypes.py to simplify both the new and old switch state netobjects (first commit)

(Haven't checked if there might be reasons not to use it? But it did seem to be backwards compatible with older ddnet clients when keeping the memory layout the same)

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
