### PR TITLE
Fix #4714

### DIFF
--- a/src/engine/server/databases/sqlite.cpp
+++ b/src/engine/server/databases/sqlite.cpp
@@ -229,7 +229,7 @@ extern char *sqlite3_expanded_sql(sqlite3_stmt *pStmt) __attribute__((weak)); //
 
 void CSqliteConnection::Print()
 {
-	if(m_pStmt != nullptr)
+	if(m_pStmt != nullptr && sqlite3_expanded_sql != nullptr)
 	{
 		char *pExpandedStmt = sqlite3_expanded_sql(m_pStmt);
 		dbg_msg("sql", "SQLite statement: %s", pExpandedStmt);


### PR DESCRIPTION
sqlite on Windows doesn't seem to have this function
<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
