### PR TITLE
Remove obsolete ignore_convention comment

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -2853,7 +2853,7 @@ void CClient::Run()
 		}
 
 #ifndef CONF_PLATFORM_ANDROID
-		atexit(SDL_Quit); // ignore_convention
+		atexit(SDL_Quit);
 #endif
 	}
 
@@ -4233,14 +4233,14 @@ void CClient::HandleMapPath(const char *pPath)
 */
 
 #if defined(CONF_PLATFORM_MACOS)
-extern "C" int TWMain(int argc, const char **argv) // ignore_convention
+extern "C" int TWMain(int argc, const char **argv)
 #elif defined(CONF_PLATFORM_ANDROID)
 extern "C" __attribute__((visibility("default"))) int SDL_main(int argc, char *argv[]);
 extern "C" void InitAndroid();
 
 int SDL_main(int argc, char *argv2[])
 #else
-int main(int argc, const char **argv) // ignore_convention
+int main(int argc, const char **argv)
 #endif
 {
 #if defined(CONF_PLATFORM_ANDROID)
@@ -4250,13 +4250,13 @@ int main(int argc, const char **argv) // ignore_convention
 	bool Silent = false;
 	bool RandInitFailed = false;
 
-	for(int i = 1; i < argc; i++) // ignore_convention
+	for(int i = 1; i < argc; i++)
 	{
-		if(str_comp("-s", argv[i]) == 0 || str_comp("--silent", argv[i]) == 0) // ignore_convention
+		if(str_comp("-s", argv[i]) == 0 || str_comp("--silent", argv[i]) == 0)
 		{
 			Silent = true;
 		}
-		else if(str_comp("-c", argv[i]) == 0 || str_comp("--console", argv[i]) == 0) // ignore_convention
+		else if(str_comp("-c", argv[i]) == 0 || str_comp("--console", argv[i]) == 0)
 		{
 #if defined(CONF_FAMILY_WINDOWS)
 			AllocConsole();
@@ -4283,7 +4283,7 @@ int main(int argc, const char **argv) // ignore_convention
 	// create the components
 	IEngine *pEngine = CreateEngine(GAME_NAME, Silent, 2);
 	IConsole *pConsole = CreateConsole(CFGFLAG_CLIENT);
-	IStorage *pStorage = CreateStorage("Teeworlds", IStorage::STORAGETYPE_CLIENT, argc, (const char **)argv); // ignore_convention
+	IStorage *pStorage = CreateStorage("Teeworlds", IStorage::STORAGETYPE_CLIENT, argc, (const char **)argv);
 	IConfigManager *pConfigManager = CreateConfigManager();
 	IEngineSound *pEngineSound = CreateEngineSound();
 	IEngineInput *pEngineInput = CreateEngineInput();
@@ -4394,8 +4394,8 @@ int main(int argc, const char **argv) // ignore_convention
 		pClient->HandleDemoPath(argv[1]);
 	else if(argc == 2 && str_endswith(argv[1], ".map"))
 		pClient->HandleMapPath(argv[1]);
-	else if(argc > 1) // ignore_convention
-		pConsole->ParseArguments(argc - 1, (const char **)&argv[1]); // ignore_convention
+	else if(argc > 1)
+		pConsole->ParseArguments(argc - 1, (const char **)&argv[1]);
 
 	if(pSteam->GetConnectAddress())
 	{

--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -157,7 +157,7 @@ CGraphics_Threaded::CGraphics_Threaded()
 	m_RenderEnable = true;
 	m_DoScreenshot = false;
 
-	png_init(0, 0); // ignore_convention
+	png_init(0, 0);
 }
 
 void CGraphics_Threaded::ClipEnable(int x, int y, int w, int h)
@@ -512,8 +512,8 @@ int CGraphics_Threaded::LoadPNG(CImageInfo *pImg, const char *pFilename, int Sto
 		return 0;
 	}
 
-	png_t Png; // ignore_convention
-	int Error = png_open_read(&Png, 0, File); // ignore_convention
+	png_t Png;
+	int Error = png_open_read(&Png, 0, File);
 	if(Error != PNG_NO_ERROR)
 	{
 		dbg_msg("game/png", "failed to open file. filename='%s', pnglite: %s", aCompleteFilename, png_error_string(Error));
@@ -521,15 +521,15 @@ int CGraphics_Threaded::LoadPNG(CImageInfo *pImg, const char *pFilename, int Sto
 		return 0;
 	}
 
-	if(Png.depth != 8 || (Png.color_type != PNG_TRUECOLOR && Png.color_type != PNG_TRUECOLOR_ALPHA)) // ignore_convention
+	if(Png.depth != 8 || (Png.color_type != PNG_TRUECOLOR && Png.color_type != PNG_TRUECOLOR_ALPHA))
 	{
 		dbg_msg("game/png", "invalid format. filename='%s'", aCompleteFilename);
 		io_close(File);
 		return 0;
 	}
 
-	unsigned char *pBuffer = (unsigned char *)malloc((size_t)Png.width * Png.height * Png.bpp); // ignore_convention
-	Error = png_get_data(&Png, pBuffer); // ignore_convention
+	unsigned char *pBuffer = (unsigned char *)malloc((size_t)Png.width * Png.height * Png.bpp);
+	Error = png_get_data(&Png, pBuffer);
 	if(Error != PNG_NO_ERROR)
 	{
 		dbg_msg("game/png", "failed to read image. filename='%s', pnglite: %s", aCompleteFilename, png_error_string(Error));
@@ -539,11 +539,11 @@ int CGraphics_Threaded::LoadPNG(CImageInfo *pImg, const char *pFilename, int Sto
 	}
 	io_close(File);
 
-	pImg->m_Width = Png.width; // ignore_convention
-	pImg->m_Height = Png.height; // ignore_convention
-	if(Png.color_type == PNG_TRUECOLOR) // ignore_convention
+	pImg->m_Width = Png.width;
+	pImg->m_Height = Png.height;
+	if(Png.color_type == PNG_TRUECOLOR)
 		pImg->m_Format = CImageInfo::FORMAT_RGB;
-	else if(Png.color_type == PNG_TRUECOLOR_ALPHA) // ignore_convention
+	else if(Png.color_type == PNG_TRUECOLOR_ALPHA)
 		pImg->m_Format = CImageInfo::FORMAT_RGBA;
 	else
 	{
@@ -660,7 +660,7 @@ void CGraphics_Threaded::ScreenshotDirect()
 	{
 		// find filename
 		char aWholePath[1024];
-		png_t Png; // ignore_convention
+		png_t Png;
 
 		IOHANDLE File = m_pStorage->OpenFile(m_aScreenshotName, IOFLAG_WRITE, IStorage::TYPE_SAVE, aWholePath, sizeof(aWholePath));
 		if(!File)
@@ -673,9 +673,9 @@ void CGraphics_Threaded::ScreenshotDirect()
 			char aBuf[256];
 			str_format(aBuf, sizeof(aBuf), "saved screenshot to '%s'", aWholePath);
 			m_pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "client", aBuf, ColorRGBA(1.0f, 0.6f, 0.3f, 1.0f));
-			png_open_write(&Png, 0, File); // ignore_convention
-			png_set_data(&Png, Image.m_Width, Image.m_Height, 8, PNG_TRUECOLOR_ALPHA, (unsigned char *)Image.m_pData); // ignore_convention
-			io_close(File); // ignore_convention
+			png_open_write(&Png, 0, File);
+			png_set_data(&Png, Image.m_Width, Image.m_Height, 8, PNG_TRUECOLOR_ALPHA, (unsigned char *)Image.m_pData);
+			io_close(File);
 		}
 
 		free(Image.m_pData);

--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -312,23 +312,23 @@ int CInput::Update()
 			// fall through
 		case SDL_MOUSEBUTTONDOWN:
 			if(Event.button.button == SDL_BUTTON_LEFT)
-				Scancode = KEY_MOUSE_1; // ignore_convention
+				Scancode = KEY_MOUSE_1;
 			if(Event.button.button == SDL_BUTTON_RIGHT)
-				Scancode = KEY_MOUSE_2; // ignore_convention
+				Scancode = KEY_MOUSE_2;
 			if(Event.button.button == SDL_BUTTON_MIDDLE)
-				Scancode = KEY_MOUSE_3; // ignore_convention
+				Scancode = KEY_MOUSE_3;
 			if(Event.button.button == SDL_BUTTON_X1)
-				Scancode = KEY_MOUSE_4; // ignore_convention
+				Scancode = KEY_MOUSE_4;
 			if(Event.button.button == SDL_BUTTON_X2)
-				Scancode = KEY_MOUSE_5; // ignore_convention
+				Scancode = KEY_MOUSE_5;
 			if(Event.button.button == 6)
-				Scancode = KEY_MOUSE_6; // ignore_convention
+				Scancode = KEY_MOUSE_6;
 			if(Event.button.button == 7)
-				Scancode = KEY_MOUSE_7; // ignore_convention
+				Scancode = KEY_MOUSE_7;
 			if(Event.button.button == 8)
-				Scancode = KEY_MOUSE_8; // ignore_convention
+				Scancode = KEY_MOUSE_8;
 			if(Event.button.button == 9)
-				Scancode = KEY_MOUSE_9; // ignore_convention
+				Scancode = KEY_MOUSE_9;
 			if(Event.button.button == SDL_BUTTON_LEFT)
 			{
 				if(Event.button.clicks % 2 == 0)
@@ -340,13 +340,13 @@ int CInput::Update()
 
 		case SDL_MOUSEWHEEL:
 			if(Event.wheel.y > 0)
-				Scancode = KEY_MOUSE_WHEEL_UP; // ignore_convention
+				Scancode = KEY_MOUSE_WHEEL_UP;
 			if(Event.wheel.y < 0)
-				Scancode = KEY_MOUSE_WHEEL_DOWN; // ignore_convention
+				Scancode = KEY_MOUSE_WHEEL_DOWN;
 			if(Event.wheel.x > 0)
-				Scancode = KEY_MOUSE_WHEEL_LEFT; // ignore_convention
+				Scancode = KEY_MOUSE_WHEEL_LEFT;
 			if(Event.wheel.x < 0)
-				Scancode = KEY_MOUSE_WHEEL_RIGHT; // ignore_convention
+				Scancode = KEY_MOUSE_WHEEL_RIGHT;
 			Action |= IInput::FLAG_RELEASE;
 			break;
 

--- a/src/engine/client/sound.cpp
+++ b/src/engine/client/sound.cpp
@@ -312,12 +312,12 @@ int CSound::Init()
 	m_MixingRate = g_Config.m_SndRate;
 
 	// Set 16-bit stereo audio at 22Khz
-	Format.freq = g_Config.m_SndRate; // ignore_convention
-	Format.format = AUDIO_S16; // ignore_convention
-	Format.channels = 2; // ignore_convention
-	Format.samples = g_Config.m_SndBufferSize; // ignore_convention
-	Format.callback = SdlCallback; // ignore_convention
-	Format.userdata = NULL; // ignore_convention
+	Format.freq = g_Config.m_SndRate;
+	Format.format = AUDIO_S16;
+	Format.channels = 2;
+	Format.samples = g_Config.m_SndBufferSize;
+	Format.callback = SdlCallback;
+	Format.userdata = NULL;
 
 	// Open the audio device and start playing sound!
 	m_Device = SDL_OpenAudioDevice(NULL, 0, &Format, &FormatOut, 0);

--- a/src/engine/client/text.cpp
+++ b/src/engine/client/text.cpp
@@ -514,7 +514,7 @@ class CTextRender : public IEngineTextRender
 			return;
 		}
 
-		pBitmap = &FtFace->glyph->bitmap; // ignore_convention
+		pBitmap = &FtFace->glyph->bitmap;
 
 		unsigned int RealWidth = pBitmap->width;
 		unsigned int RealHeight = pBitmap->rows;
@@ -540,9 +540,9 @@ class CTextRender : public IEngineTextRender
 			// prepare glyph data
 			mem_zero(ms_aGlyphData, Width * Height);
 
-			for(py = 0; py < pBitmap->rows; py++) // ignore_convention
-				for(px = 0; px < pBitmap->width; px++) // ignore_convention
-					ms_aGlyphData[(py + y) * Width + px + x] = pBitmap->buffer[py * pBitmap->width + px]; // ignore_convention
+			for(py = 0; py < pBitmap->rows; py++)
+				for(px = 0; px < pBitmap->width; px++)
+					ms_aGlyphData[(py + y) * Width + px + x] = pBitmap->buffer[py * pBitmap->width + px];
 
 			// upload the glyph
 			while(!GetCharacterSpace(pFont, 0, (int)Width, (int)Height, X, Y))
@@ -571,9 +571,9 @@ class CTextRender : public IEngineTextRender
 			pFontchr->m_Width = Width;
 			pFontchr->m_CharHeight = RealHeight;
 			pFontchr->m_CharWidth = RealWidth;
-			pFontchr->m_OffsetX = (FtFace->glyph->metrics.horiBearingX >> 6); // ignore_convention
+			pFontchr->m_OffsetX = (FtFace->glyph->metrics.horiBearingX >> 6);
 			pFontchr->m_OffsetY = -((FtFace->glyph->metrics.height >> 6) - (FtFace->glyph->metrics.horiBearingY >> 6));
-			pFontchr->m_AdvanceX = (FtFace->glyph->advance.x >> 6); // ignore_convention
+			pFontchr->m_AdvanceX = (FtFace->glyph->advance.x >> 6);
 
 			pFontchr->m_aUVs[0] = X;
 			pFontchr->m_aUVs[1] = Y;
@@ -1682,7 +1682,7 @@ public:
 					continue;
 				}
 
-				pBitmap = &pFont->m_FtFace->glyph->bitmap; // ignore_convention
+				pBitmap = &pFont->m_FtFace->glyph->bitmap;
 
 				int SlotW = pBitmap->width;
 				int SlotH = pBitmap->rows;
@@ -1691,12 +1691,12 @@ public:
 				// prepare glyph data
 				mem_zero(ms_aGlyphData, SlotSize);
 
-				if(pBitmap->pixel_mode == FT_PIXEL_MODE_GRAY) // ignore_convention
+				if(pBitmap->pixel_mode == FT_PIXEL_MODE_GRAY)
 				{
-					for(py = 0; py < (unsigned)SlotH; py++) // ignore_convention
+					for(py = 0; py < (unsigned)SlotH; py++)
 						for(px = 0; px < (unsigned)SlotW; px++)
 						{
-							ms_aGlyphData[(py)*SlotW + px] = pBitmap->buffer[py * pBitmap->width + px]; // ignore_convention
+							ms_aGlyphData[(py)*SlotW + px] = pBitmap->buffer[py * pBitmap->width + px];
 						}
 				}
 

--- a/src/engine/client/video.cpp
+++ b/src/engine/client/video.cpp
@@ -598,10 +598,10 @@ bool CVideo::AddStream(OutputStream *pStream, AVFormatContext *pOC, const AVCode
 		// m_MixingRate = g_Config.m_SndRate;
 		//
 		// // Set 16-bit stereo audio at 22Khz
-		// Format.freq = g_Config.m_SndRate; // ignore_convention
-		// Format.format = AUDIO_S16; // ignore_convention
-		// Format.channels = 2; // ignore_convention
-		// Format.samples = g_Config.m_SndBufferSize; // ignore_convention
+		// Format.freq = g_Config.m_SndRate;
+		// Format.format = AUDIO_S16;
+		// Format.channels = 2;
+		// Format.samples = g_Config.m_SndBufferSize;
 
 		c->sample_fmt = (*ppCodec)->sample_fmts ? (*ppCodec)->sample_fmts[0] : AV_SAMPLE_FMT_FLTP;
 		c->bit_rate = g_Config.m_SndRate * 2 * 16;

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -3614,14 +3614,14 @@ void HandleSigIntTerm(int Param)
 	signal(SIGTERM, SIG_DFL);
 }
 
-int main(int argc, const char **argv) // ignore_convention
+int main(int argc, const char **argv)
 {
 	cmdline_fix(&argc, &argv);
 	bool Silent = false;
 
-	for(int i = 1; i < argc; i++) // ignore_convention
+	for(int i = 1; i < argc; i++)
 	{
-		if(str_comp("-s", argv[i]) == 0 || str_comp("--silent", argv[i]) == 0) // ignore_convention
+		if(str_comp("-s", argv[i]) == 0 || str_comp("--silent", argv[i]) == 0)
 		{
 			Silent = true;
 #if defined(CONF_FAMILY_WINDOWS)
@@ -3654,7 +3654,7 @@ int main(int argc, const char **argv) // ignore_convention
 	IGameServer *pGameServer = CreateGameServer();
 	IConsole *pConsole = CreateConsole(CFGFLAG_SERVER | CFGFLAG_ECON);
 	IEngineMasterServer *pEngineMasterServer = CreateEngineMasterServer();
-	IStorage *pStorage = CreateStorage("Teeworlds", IStorage::STORAGETYPE_SERVER, argc, argv); // ignore_convention
+	IStorage *pStorage = CreateStorage("Teeworlds", IStorage::STORAGETYPE_SERVER, argc, argv);
 	IConfigManager *pConfigManager = CreateConfigManager();
 	IEngineAntibot *pEngineAntibot = CreateEngineAntibot();
 
@@ -3705,8 +3705,8 @@ int main(int argc, const char **argv) // ignore_convention
 	}
 
 	// parse the command line arguments
-	if(argc > 1) // ignore_convention
-		pConsole->ParseArguments(argc - 1, &argv[1]); // ignore_convention
+	if(argc > 1)
+		pConsole->ParseArguments(argc - 1, &argv[1]);
 
 	pConsole->Register("sv_test_cmds", "", CFGFLAG_SERVER, CServer::ConTestingCommands, pConsole, "Turns testing commands aka cheats on/off (setting only works in initial config)");
 	pConsole->Register("sv_rescue", "", CFGFLAG_SERVER, CServer::ConRescue, pConsole, "Allow /rescue command so players can teleport themselves out of freeze (setting only works in initial config)");

--- a/src/engine/shared/datafile.cpp
+++ b/src/engine/shared/datafile.cpp
@@ -131,7 +131,7 @@ bool CDataFileReader::Open(class IStorage *pStorage, const char *pFilename, int 
 			unsigned Bytes = io_read(File, aBuffer, BUFFER_SIZE);
 			if(Bytes <= 0)
 				break;
-			Crc = crc32(Crc, aBuffer, Bytes); // ignore_convention
+			Crc = crc32(Crc, aBuffer, Bytes);
 			sha256_update(&Sha256Ctxt, aBuffer, Bytes);
 		}
 		Sha256 = sha256_finish(&Sha256Ctxt);
@@ -337,7 +337,7 @@ void *CDataFileReader::GetDataImpl(int Index, int Swap)
 
 			// decompress the data, TODO: check for errors
 			s = UncompressedSize;
-			uncompress((Bytef *)m_pDataFile->m_ppDataPtrs[Index], &s, (Bytef *)pTemp, DataSize); // ignore_convention
+			uncompress((Bytef *)m_pDataFile->m_ppDataPtrs[Index], &s, (Bytef *)pTemp, DataSize);
 #if defined(CONF_ARCH_ENDIAN_BIG)
 			SwapSize = s;
 #endif
@@ -686,7 +686,7 @@ int CDataFileWriter::AddData(int Size, void *pData, int CompressionLevel)
 	unsigned long s = compressBound(Size);
 	void *pCompData = malloc(s); // temporary buffer that we use during compression
 
-	int Result = compress2((Bytef *)pCompData, &s, (Bytef *)pData, Size, CompressionLevel); // ignore_convention
+	int Result = compress2((Bytef *)pCompData, &s, (Bytef *)pData, Size, CompressionLevel);
 	if(Result != Z_OK)
 	{
 		dbg_msg("datafile", "compression error %d", Result);

--- a/src/mastersrv/mastersrv.cpp
+++ b/src/mastersrv/mastersrv.cpp
@@ -318,7 +318,7 @@ void ReloadBans()
 	m_pConsole->ExecuteFile("master.cfg", -1, true);
 }
 
-int main(int argc, const char **argv) // ignore_convention
+int main(int argc, const char **argv)
 {
 	int64_t LastBuild = 0, LastBanReload = 0;
 	ServerType Type = SERVERTYPE_INVALID;
@@ -347,8 +347,8 @@ int main(int argc, const char **argv) // ignore_convention
 	pConfigManager->Init();
 	m_pConsole->Init();
 	m_NetBan.Init(m_pConsole, pStorage);
-	if(argc > 1) // ignore_convention
-		m_pConsole->ParseArguments(argc - 1, &argv[1]); // ignore_convention
+	if(argc > 1)
+		m_pConsole->ParseArguments(argc - 1, &argv[1]);
 
 	if(g_Config.m_Bindaddr[0] && net_host_lookup(g_Config.m_Bindaddr, &BindAddr, NETTYPE_ALL) == 0)
 	{

--- a/src/tools/crapnet.cpp
+++ b/src/tools/crapnet.cpp
@@ -208,7 +208,7 @@ void Run(unsigned short Port, NETADDR Dest)
 	}
 }
 
-int main(int argc, const char **argv) // ignore_convention
+int main(int argc, const char **argv)
 {
 	cmdline_fix(&argc, &argv);
 	NETADDR Addr = {NETTYPE_IPV4, {127, 0, 0, 1}, 8303};

--- a/src/tools/unicode_confusables.cpp
+++ b/src/tools/unicode_confusables.cpp
@@ -1,6 +1,6 @@
 #include <base/system.h>
 
-int main(int argc, const char **argv) // ignore_convention
+int main(int argc, const char **argv)
 {
 	cmdline_fix(&argc, &argv);
 	dbg_logger_stdout();

--- a/src/twping/twping.cpp
+++ b/src/twping/twping.cpp
@@ -7,7 +7,7 @@
 
 static CNetClient g_NetOp; // main
 
-int main(int argc, const char **argv) // ignore_convention
+int main(int argc, const char **argv)
 {
 	cmdline_fix(&argc, &argv);
 	NETADDR BindAddr;


### PR DESCRIPTION
I assume the `// ignore_convention` comments are obsolete as they are only used inconsistently and not being added in new code anymore. The script https://github.com/teeworlds/teeworlds/blob/master/scripts/refactor_count.py that checks for these annotations does not exist in ddnet.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
