### PR TITLE
Increase MAX_IDS to 32k (fixes #4723)

### DIFF
--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -37,7 +37,7 @@ class CSnapIDPool
 {
 	enum
 	{
-		MAX_IDS = 16 * 1024,
+		MAX_IDS = 32 * 1024,
 	};
 
 	class CID


### PR DESCRIPTION
Not sure I like it, otherwise we have to edit Game City.

Maybe we should fail this in map editor already instead of allowing to
create a map which requires > MAX_IDS

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
