### PR TITLE
Validate variables of the snap-item base class

### DIFF
--- a/datasrc/compile.py
+++ b/datasrc/compile.py
@@ -271,7 +271,10 @@ def main():
 		lines += ['\t}']
 
 		for item in network.Objects:
-			for line in item.emit_validate():
+			base_item = None
+			if item.base:
+				base_item = next(i for i in network.Objects if i.name == item.base)
+			for line in item.emit_validate(base_item):
 				lines += ["\t" + line]
 			lines += ['\t']
 		lines += ['\t}']

--- a/datasrc/datatypes.py
+++ b/datasrc/datatypes.py
@@ -222,14 +222,17 @@ class NetObject:
 			lines += ["\t"+line for line in v.emit_declaration()]
 		lines += ["};"]
 		return lines
-	def emit_validate(self):
+	def emit_validate(self, base_item):
 		lines = ["case %s:" % self.enum_name]
 		lines += ["{"]
 		if self.validate_size:
 			lines += ["\t%s *pObj = (%s *)pData;"%(self.struct_name, self.struct_name)]
 			lines += ["\tif((int)sizeof(*pObj) > Size) return -1;"]
 		prev_len = len(lines)
-		for v in self.variables:
+		variables = self.variables
+		if base_item:
+			variables += base_item.variables
+		for v in variables:
 			lines += ["\t"+line for line in v.emit_validate()]
 		if not self.validate_size and prev_len != len(lines):
 			raise ValueError("Can't use members that need validation in a struct whose size isn't validated")

--- a/datasrc/network.py
+++ b/datasrc/network.py
@@ -176,7 +176,7 @@ Objects = [
 		NetIntRange("m_Direction", -1, 1),
 
 		NetIntRange("m_Jumped", 0, 3),
-		NetIntRange("m_HookedPlayer", 0, 'MAX_CLIENTS-1'),
+		NetIntRange("m_HookedPlayer", -1, 'MAX_CLIENTS-1'),
 		NetIntRange("m_HookState", -1, 5),
 		NetTick("m_HookTick"),
 


### PR DESCRIPTION
See https://github.com/teeworlds/teeworlds/pull/2688.

Fixes 

```
/src/game/client/components/players.cpp:95:102: runtime error: index 552473416 out of bounds for type 'CCharacterInfo [64]'
    #0 0x5575323d614b in CPlayers::RenderHook(CNetObj_Character const*, CNetObj_Character const*, CTeeRenderInfo const*, int, float) /src/game/client/components/players.cpp:95
    #1 0x557532401969 in CPlayers::OnRender() /src/game/client/components/players.cpp:701
    #2 0x5575324ec369 in CGameClient::OnRender() /src/game/client/gameclient.cpp:598
    #3 0x557531bf1310 in CClient::Render() /src/engine/client/client.cpp:1179
    #4 0x557531c42a48 in CClient::Run() /src/engine/client/client.cpp:3152
    #5 0x557531ca0c1a in main /src/engine/client/client.cpp:4424
    #6 0x7f6fc51340b2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x270b2)
    #7 0x557531a3576d in _start (/build-asan/DDNet+0x1bc076d)
```

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [X] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
