### PR TITLE
Add module offset

### DIFF
--- a/scripts/parse_drmingw.sh
+++ b/scripts/parse_drmingw.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+if [ -z ${1+x} ]; then
+    printf "\e[31m%s\e[30m\n" "Did not pass executable file (full path)"
+    printf "\e[31m%s\e[30m\n" "Usage: ./parse_drmingw.sh <executable> <crash_log>"
+    exit 1
+fi
+
+if [ -z ${2+x} ]; then
+    printf "\e[31m%s\e[30m\n" "Did not pass crash log file (full path)"
+    printf "\e[31m%s\e[30m\n" "Usage: ./parse_drmingw.sh <executable> <crash_log>"
+    exit 1
+fi
+
+TMP_OFFSET=$(cat "$2" | grep -E -o "\(with offset [0-9A-F]*\)" | grep -E -o "[A-F0-9]*")
+
+ADDR_PC_REGEX='[0-9A-F]+ [0-9A-F]+ [0-9A-F]+ [0-9A-F]+'
+while read -r line
+do
+    if [[ $line =~ $ADDR_PC_REGEX ]]
+    then
+		TMP_ADDR=$(echo "$line" | grep -E -o -m 1 "[A-F0-9]+ " | head -1)
+		ADDR_BASE=$(winedump -f "$1" | grep -E -o "image base[ ]*0x[0-9A-Fa-f]*" | grep -E -o "[0-9A-Fa-f]+" | tail -1)
+		REAL_ADDR=$(printf '%X\n' "$(((0x$TMP_ADDR-0x$TMP_OFFSET)+0x$ADDR_BASE))")
+		echo "Parsing address: $REAL_ADDR (img base: $ADDR_BASE)"
+		addr2line -e "$1" "$REAL_ADDR"
+    fi
+done < "$2"
+

--- a/scripts/parse_drmingw.sh
+++ b/scripts/parse_drmingw.sh
@@ -12,7 +12,7 @@ if [ -z ${2+x} ]; then
     exit 1
 fi
 
-TMP_OFFSET=$(cat "$2" | grep -E -o "\(with offset [0-9A-F]*\)" | grep -E -o "[A-F0-9]*")
+TMP_OFFSET=$(grep -E -o "\(with offset [0-9A-F]*\)" "$2" | grep -E -o "[A-F0-9]*")
 
 ADDR_PC_REGEX='[0-9A-F]+ [0-9A-F]+ [0-9A-F]+ [0-9A-F]+'
 while read -r line

--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -4072,8 +4072,17 @@ void init_exception_handler()
 	gs_ExceptionHandlingModule = LoadLibraryA("exchndl.dll");
 	if(gs_ExceptionHandlingModule != nullptr)
 	{
-		auto pfnExcHndlInit = (void APIENTRY (*)())GetProcAddress(gs_ExceptionHandlingModule, "ExcHndlInit");
-		pfnExcHndlInit();
+		// Intentional
+#ifdef __MINGW32__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcast-function-type"
+#endif
+		auto pfnExcHndlInit = (void APIENTRY (*)(void *))GetProcAddress(gs_ExceptionHandlingModule, "ExcHndlInit");
+#ifdef __MINGW32__
+#pragma clang diagnostic pop
+#endif
+		void *pExceptionHandlingOffset = (void *)GetModuleHandle(NULL);
+		pfnExcHndlInit(pExceptionHandlingOffset);
 	}
 #else
 #error exception handling not implemented


### PR DESCRIPTION
Get module offset, so we can at least recover the DDNet.exe paths:
`Error occurred on Wednesday, February 23, 2022 at 20:34:57. (with offset 00007FF7C4A00000)`
(Address - Offset) + (Image-Base)
(ImageBase  = winedump -f DDNet.exe (image base: usually 0x140000000)

Tested on windows 64-bit

https://github.com/Jupeyy/drmingw/commit/08ab91c4897c04b5919d14fc2d7c215015d0fb94

ez download from github actions:
https://github.com/Jupeyy/drmingw/actions/runs/1889238377

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
