### PR TITLE
[WIP] Make key presses scalable; Add option for old key presses position

### DIFF
--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -381,7 +381,7 @@ MACRO_CONFIG_INT(ClChatOld, cl_chat_old, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE,
 
 MACRO_CONFIG_INT(ClShowDirection, cl_show_direction, 1, 0, 2, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Show key presses (1 = other players', 2 = also your own)")
 MACRO_CONFIG_INT(ClShowDirectionSize, cl_show_direction_size, 100, 0, 100, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Size of key presses from 0 to 100%")
-MACRO_CONFIG_INT(ClOldShowDirectionPosition, cl_old_show_direction_position, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Key presses are displayed behind the player names")
+MACRO_CONFIG_INT(ClShowDirectionPosition, cl_show_direction_position, 0, 0, 3, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Key presses position (0 = above tee, 1 = nameplate middle, 2 = under nameplate, 3 = in tee)")
 MACRO_CONFIG_INT(ClHttpMapDownload, cl_http_map_download, 1, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Try fast HTTP map download first")
 MACRO_CONFIG_INT(ClOldGunPosition, cl_old_gun_position, 0, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Tees hold gun a bit higher like in TW 0.6.1 and older")
 MACRO_CONFIG_INT(ClConfirmDisconnectTime, cl_confirm_disconnect_time, 20, -1, 1440, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Confirmation popup before disconnecting after game time (in minutes, -1 to turn off, 0 to always turn on)")

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -380,6 +380,8 @@ MACRO_CONFIG_INT(ClChatReset, cl_chat_reset, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_S
 MACRO_CONFIG_INT(ClChatOld, cl_chat_old, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Old chat style: No tee, no background");
 
 MACRO_CONFIG_INT(ClShowDirection, cl_show_direction, 1, 0, 2, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Show key presses (1 = other players', 2 = also your own)")
+MACRO_CONFIG_INT(ClShowDirectionSize, cl_show_direction_size, 100, 0, 100, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Size of key presses from 0 to 100%")
+MACRO_CONFIG_INT(ClOldShowDirectionPosition, cl_old_show_direction_position, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Key presses are displayed behind the player names")
 MACRO_CONFIG_INT(ClHttpMapDownload, cl_http_map_download, 1, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Try fast HTTP map download first")
 MACRO_CONFIG_INT(ClOldGunPosition, cl_old_gun_position, 0, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Tees hold gun a bit higher like in TW 0.6.1 and older")
 MACRO_CONFIG_INT(ClConfirmDisconnectTime, cl_confirm_disconnect_time, 20, -1, 1440, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Confirmation popup before disconnecting after game time (in minutes, -1 to turn off, 0 to always turn on)")

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -2574,6 +2574,15 @@ void CMenus::RenderSettingsDDNet(CUIRect MainView)
 		g_Config.m_ClShowDirection = g_Config.m_ClShowDirection != 2 ? 2 : 1;
 	}
 
+	if(g_Config.m_ClShowDirection > 0)
+	{
+		Left.HSplitTop(20.0f, &Label, &Left);
+		Left.HSplitTop(20.0f, &Button, &Left);
+		str_format(aBuf, sizeof(aBuf), "%s: %i", Localize("Key presses size"), g_Config.m_ClShowDirectionSize);
+		UI()->DoLabelScaled(&Label, aBuf, 13.0f, TEXTALIGN_LEFT);
+		g_Config.m_ClShowDirectionSize = (int)(UIEx()->DoScrollbarH(&g_Config.m_ClShowDirectionSize, &Button, g_Config.m_ClShowDirectionSize / 100.0f) * 100.0f);
+	}
+
 	Left.HSplitTop(20.0f, &Button, &Left);
 	if(DoButton_CheckBox(&g_Config.m_InpMouseOld, Localize("Old mouse mode"), g_Config.m_InpMouseOld, &Button))
 	{

--- a/src/game/client/components/nameplates.cpp
+++ b/src/game/client/components/nameplates.cpp
@@ -63,35 +63,73 @@ void CNamePlates::RenderNameplatePos(vec2 Position, const CNetObj_PlayerInfo *pP
 
 		float Scale = g_Config.m_ClShowDirectionSize / 100.0f;
 		float ShowDirectionImgSize = 22.0f * Scale;
-		float ShowDirectionPosY;
-		if(g_Config.m_ClOldShowDirectionPosition)
+		float GapSize = 8.0f * Scale;
+
+		vec2 LeftArrow, UPArrow, RightArrow;
+		switch(g_Config.m_ClShowDirectionPosition)
 		{
-			ShowDirectionPosY = Position.y - 70;
+		default:
+		case SHOW_DIRECTION_ABOVE_TEE:
+		{
+			LeftArrow.x = Position.x - (ShowDirectionImgSize + GapSize + ShowDirectionImgSize / 2);
+			RightArrow.x = Position.x + (GapSize + ShowDirectionImgSize / 2);
+			UPArrow.x = Position.x - (ShowDirectionImgSize / 2);
+
+			// + 2 because the arrows themselves already have a transparent frame
+			YOffset -= (ShowDirectionImgSize - 2);
+
+			LeftArrow.y = RightArrow.y = UPArrow.y = YOffset;
 		}
-		else
+		break;
+		case SHOW_DIRECTION_IN_NAMEPLATE:
 		{
-			// + 6 because the arrows themselves already have a transparent frame
-			YOffset -= (ShowDirectionImgSize - 6);
-			ShowDirectionPosY = YOffset;
+			LeftArrow.x = Position.x - (ShowDirectionImgSize + GapSize + ShowDirectionImgSize / 2);
+			RightArrow.x = Position.x + (GapSize + ShowDirectionImgSize / 2);
+			UPArrow.x = Position.x - (ShowDirectionImgSize / 2);
+			LeftArrow.y = RightArrow.y = UPArrow.y = Position.y - 70;
+		}
+		break;
+		case SHOW_DIRECTION_UNDER_NAMEPLATE:
+		{
+			LeftArrow.x = Position.x - (ShowDirectionImgSize + GapSize + ShowDirectionImgSize / 2);
+			RightArrow.x = Position.x + (GapSize + ShowDirectionImgSize / 2);
+			UPArrow.x = Position.x - (ShowDirectionImgSize / 2);
+
+			// Y = Position.y - 32 - 4 because -4 is the default body animation
+			LeftArrow.y = RightArrow.y = UPArrow.y = Position.y - 36;
+		}
+		break;
+		case SHOW_DIRECTION_IN_TEE:
+		{
+			LeftArrow.x = Position.x - 32.f;
+			RightArrow.x = Position.x + 32.f - ShowDirectionImgSize;
+			UPArrow.x = Position.x - (ShowDirectionImgSize / 2);
+
+			LeftArrow.y = Position.y - (ShowDirectionImgSize / 2);
+			RightArrow.y = Position.y - (ShowDirectionImgSize / 2);
+			UPArrow.y = Position.y - 36;
+		}
+		break;
 		}
 
 		if(m_pClient->m_Snap.m_aCharacters[pPlayerInfo->m_ClientID].m_Cur.m_Direction == -1)
 		{
 			Graphics()->TextureSet(g_pData->m_aImages[IMAGE_ARROW].m_Id);
 			Graphics()->QuadsSetRotation(pi);
-			Graphics()->RenderQuadContainerAsSprite(m_DirectionQuadContainerIndex, 0, Position.x - (ShowDirectionImgSize + ShowDirectionImgSize / 2), ShowDirectionPosY, Scale, Scale);
+			Graphics()->RenderQuadContainerAsSprite(m_DirectionQuadContainerIndex, 0, LeftArrow.x, LeftArrow.y, Scale, Scale);
 		}
 		else if(m_pClient->m_Snap.m_aCharacters[pPlayerInfo->m_ClientID].m_Cur.m_Direction == 1)
 		{
 			Graphics()->TextureSet(g_pData->m_aImages[IMAGE_ARROW].m_Id);
-			Graphics()->RenderQuadContainerAsSprite(m_DirectionQuadContainerIndex, 0, Position.x + (ShowDirectionImgSize / 2), ShowDirectionPosY, Scale, Scale);
+			Graphics()->RenderQuadContainerAsSprite(m_DirectionQuadContainerIndex, 0, RightArrow.x, RightArrow.y, Scale, Scale);
 		}
 		if(m_pClient->m_Snap.m_aCharacters[pPlayerInfo->m_ClientID].m_Cur.m_Jumped & 1)
 		{
 			Graphics()->TextureSet(g_pData->m_aImages[IMAGE_ARROW].m_Id);
 			Graphics()->QuadsSetRotation(pi * 3 / 2);
-			Graphics()->RenderQuadContainerAsSprite(m_DirectionQuadContainerIndex, 0, Position.x - (ShowDirectionImgSize / 2), ShowDirectionPosY, Scale, Scale);
+			Graphics()->RenderQuadContainerAsSprite(m_DirectionQuadContainerIndex, 0, UPArrow.x, UPArrow.y, Scale, Scale);
 		}
+
 		Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
 		Graphics()->QuadsSetRotation(0);
 	}

--- a/src/game/client/components/nameplates.cpp
+++ b/src/game/client/components/nameplates.cpp
@@ -61,26 +61,36 @@ void CNamePlates::RenderNameplatePos(vec2 Position, const CNetObj_PlayerInfo *pP
 		Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
 		Graphics()->QuadsSetRotation(0);
 
-		const float ShowDirectionImgSize = 22.0f;
-		YOffset -= ShowDirectionImgSize;
-		vec2 ShowDirectionPos = vec2(Position.x - 11.0f, YOffset);
+		float Scale = g_Config.m_ClShowDirectionSize / 100.0f;
+		float ShowDirectionImgSize = 22.0f * Scale;
+		float ShowDirectionPosY;
+		if(g_Config.m_ClOldShowDirectionPosition)
+		{
+			ShowDirectionPosY = Position.y - 70;
+		}
+		else
+		{
+			// + 6 because the arrows themselves already have a transparent frame
+			YOffset -= (ShowDirectionImgSize - 6);
+			ShowDirectionPosY = YOffset;
+		}
 
 		if(m_pClient->m_Snap.m_aCharacters[pPlayerInfo->m_ClientID].m_Cur.m_Direction == -1)
 		{
 			Graphics()->TextureSet(g_pData->m_aImages[IMAGE_ARROW].m_Id);
 			Graphics()->QuadsSetRotation(pi);
-			Graphics()->RenderQuadContainerAsSprite(m_DirectionQuadContainerIndex, 0, ShowDirectionPos.x - 30.f, ShowDirectionPos.y);
+			Graphics()->RenderQuadContainerAsSprite(m_DirectionQuadContainerIndex, 0, Position.x - (ShowDirectionImgSize + ShowDirectionImgSize / 2), ShowDirectionPosY, Scale, Scale);
 		}
 		else if(m_pClient->m_Snap.m_aCharacters[pPlayerInfo->m_ClientID].m_Cur.m_Direction == 1)
 		{
 			Graphics()->TextureSet(g_pData->m_aImages[IMAGE_ARROW].m_Id);
-			Graphics()->RenderQuadContainerAsSprite(m_DirectionQuadContainerIndex, 0, ShowDirectionPos.x + 30.f, ShowDirectionPos.y);
+			Graphics()->RenderQuadContainerAsSprite(m_DirectionQuadContainerIndex, 0, Position.x + (ShowDirectionImgSize / 2), ShowDirectionPosY, Scale, Scale);
 		}
 		if(m_pClient->m_Snap.m_aCharacters[pPlayerInfo->m_ClientID].m_Cur.m_Jumped & 1)
 		{
 			Graphics()->TextureSet(g_pData->m_aImages[IMAGE_ARROW].m_Id);
 			Graphics()->QuadsSetRotation(pi * 3 / 2);
-			Graphics()->RenderQuadContainerAsSprite(m_DirectionQuadContainerIndex, 0, ShowDirectionPos.x, ShowDirectionPos.y);
+			Graphics()->RenderQuadContainerAsSprite(m_DirectionQuadContainerIndex, 0, Position.x - (ShowDirectionImgSize / 2), ShowDirectionPosY, Scale, Scale);
 		}
 		Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
 		Graphics()->QuadsSetRotation(0);

--- a/src/game/client/components/nameplates.h
+++ b/src/game/client/components/nameplates.h
@@ -8,6 +8,15 @@ struct CNetObj_Character;
 struct CNetObj_PlayerInfo;
 struct CMapItemGroup;
 
+// position of the movement direction arrows
+enum
+{
+	SHOW_DIRECTION_ABOVE_TEE = 0, // between the tee and the nameplate
+	SHOW_DIRECTION_IN_NAMEPLATE, // this is the old position - in the middle of the nameplate
+	SHOW_DIRECTION_UNDER_NAMEPLATE, // under the nameplate, thus at the top of the tee
+	SHOW_DIRECTION_IN_TEE, // side direction arrows on the side in the middle of the tee
+};
+
 struct SPlayerNamePlate
 {
 	SPlayerNamePlate()


### PR DESCRIPTION
This PR is the continuation of #4697

In the Discord, two players pointed out to me that due to the new position of the arrows, there are larger gaps between the tees and the player names (See https://discord.com/channels/252358080522747904/757720336274948198/945642195757707265). This PullRequest is intended to deal with this problem.


I have made 3 changes: 
1. I have made the arrows that are displayed for the key presses scalable. This can also be set in the menu or via the console (with `cl_show_direction_size`).
2. I added an option called `cl_show_direction_position`. This makes it possible to show the arrows of the key presses:
    -  between the tee and the nameplate. The nameplate is moved up by the size of the arrows
    -  at the old position - in the middle of the nameplate. 
    - under the nameplate, thus at the top of the tee
    - in the tee - side direction arrows on the side in the middle of the tee
4. In the new position I have moved the arrows down by 2 units, as the arrows have already a transparent frame.

The scaled arrows are centred around the middle and are separated by a spacer by 8 scaled units.

Opinions on the labelling in the menu and the descriptions of the configuration variables are also welcome. 

A few impressions:

<details> 
  <summary>The menu: </summary>

![grafik2](https://user-images.githubusercontent.com/14315968/155808260-49e73650-9589-4a02-b7e2-ad0889ca66ff.png)

The setting for the size disappears if the option is generally deactivated:

![grafik](https://user-images.githubusercontent.com/14315968/155808290-629b2c71-55cc-403e-8405-2188563ef208.png)

</details>

<details> 
  <summary>The console: </summary>

![image1](https://user-images.githubusercontent.com/14315968/155904080-cb386348-838b-4ed7-b1a9-7fc0d554db9c.png)

![image2](https://user-images.githubusercontent.com/14315968/155904093-0ae4a521-e436-4d72-bbf1-78a5ccabe3b8.png)

</details>


## Since four options are **too many** we want to have only one of these four options as default (and no control option to select the others).
## Please vote which of these options you like

Respond with these reactions (you may vote for multiple favorites):

 - :tada: `cl_show_direction_position 0` between the tee and the nameplate 
 - :heart:  `cl_show_direction_position 1` at the old position - in the middle of the nameplate
 - :rocket:  `cl_show_direction_position 2` under the nameplate, thus at the top of the tee
 - :eyes: `cl_show_direction_position 3` in the tee - side direction arrows on the side in the middle of the tee 


All images are with `zoom 10` and `cl_nameplates_size 0`:

<details> 
  <summary>How it is in release  15.9.1: </summary>
  
![00 current_release_show_direction_style](https://user-images.githubusercontent.com/14315968/155904148-ce296000-ae63-47c2-a193-bef2f04d1675.png)

</details>


<details> 
  <summary> `cl_show_direction_position 0` between the tee and the nameplate </summary>
  
  **notice how the nameplates move upwards**
  
![05 my_changes_old_new_show_direction_style](https://user-images.githubusercontent.com/14315968/155904930-0c85c040-537c-4cad-afe9-a4ef86fcaebf.png)

With 50% Scale:
![06 my_changes_old_new_show_direction_style_50%](https://user-images.githubusercontent.com/14315968/155904933-ecf5a214-9f5d-451f-8280-686d4ad73b31.png)

</details>

<details> 
  <summary> `cl_show_direction_position 1` at the old position - in the middle of the nameplate </summary>
  
![01 my_changes_old_show_direction_style](https://user-images.githubusercontent.com/14315968/155904327-fc6403af-afc2-4534-beda-32b66b022c53.png)


With 50% Scale:
![03 my_changes_old_show_direction_style_50%](https://user-images.githubusercontent.com/14315968/155904329-7f5f39d7-7fcc-4ca3-ac2e-1694bf523747.png)

</details>

<details> 
  <summary> `cl_show_direction_position 2` under the nameplate, thus at the top of the tee </summary>

![02 my_changes_new_show_direction_style](https://user-images.githubusercontent.com/14315968/155904503-2d1a1878-f0f8-4471-828d-65bbe99db7ff.png)

 
With 50% Scale:

![04 my_changes_new_show_direction_style_50%](https://user-images.githubusercontent.com/14315968/155904508-ba22d99c-1c11-46de-be60-62c36247d265.png)


</details>


<details> 
  <summary> `cl_show_direction_position 3` in the tee - side direction arrows on the side in the middle of the tee </summary>
  
 ![02 my_changes_new_show_direction_style](https://user-images.githubusercontent.com/14315968/155904377-e3a5fd61-3af2-42b3-8b6d-00b20291c974.png)

With 50% Scale:
![04 my_changes_new_show_direction_style_50%](https://user-images.githubusercontent.com/14315968/155904381-57bbe313-060b-41fc-9742-5768e408358e.png)

</details>


## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
