### PR TITLE
Quad knife tool

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -1805,11 +1805,11 @@ float CEditor::TriangleArea(vec2 A, vec2 B, vec2 C)
 bool CEditor::IsInTriangle(vec2 Point, vec2 A, vec2 B, vec2 C)
 {
 	// Normalize to increase precision
-	vec2 Min(minimum(A.x, minimum(B.x, C.x)), minimum(A.y, minimum(B.y, C.y)));
-	vec2 Max(maximum(A.x, maximum(B.x, C.x)), maximum(A.y, maximum(B.y, C.y)));
+	vec2 Min(minimum(A.x, B.x, C.x), minimum(A.y, B.y, C.y));
+	vec2 Max(maximum(A.x, B.x, C.x), maximum(A.y, B.y, C.y));
 	vec2 Size(Max.x - Min.x, Max.y - Min.y);
 
-	if(Size.x < FLT_EPSILON || Size.y < FLT_EPSILON)
+	if(Size.x < 0.0000001f || Size.y < 0.0000001f)
 		return false;
 
 	vec2 Normal(1.f / Size.x, 1.f / Size.y);
@@ -1866,7 +1866,7 @@ void CEditor::DoQuadKnife(int QuadIndex)
 				vec2 Min(minimum(v[i].x, v[j].x), minimum(v[i].y, v[j].y));
 				vec2 Max(maximum(v[i].x, v[j].x), maximum(v[i].y, v[j].y));
 
-				if(in_range(OnGrid.y, Min.y, Max.y) && Max.y - Min.y > FLT_EPSILON)
+				if(in_range(OnGrid.y, Min.y, Max.y) && Max.y - Min.y > 0.0000001f)
 				{
 					vec2 OnEdge(v[i].x + (OnGrid.y - v[i].y) / (v[j].y - v[i].y) * (v[j].x - v[i].x), OnGrid.y);
 					float Distance = abs(OnGrid.x - OnEdge.x);
@@ -1878,7 +1878,7 @@ void CEditor::DoQuadKnife(int QuadIndex)
 					}
 				}
 				
-				if(in_range(OnGrid.x, Min.x, Max.x) && Max.x - Min.x > FLT_EPSILON)
+				if(in_range(OnGrid.x, Min.x, Max.x) && Max.x - Min.x > 0.0000001f)
 				{
 					vec2 OnEdge(OnGrid.x, v[i].y + (OnGrid.x - v[i].x) / (v[j].x - v[i].x) * (v[j].y - v[i].y));
 					float Distance = abs(OnGrid.y - OnEdge.y);
@@ -1935,8 +1935,11 @@ void CEditor::DoQuadKnife(int QuadIndex)
 
 	bool ValidPosition = IsInTriangle(Point, v[0], v[1], v[2]) || IsInTriangle(Point, v[0], v[3], v[2]);
 
-	if(UI()->MouseButtonClicked(0) && ValidPosition)
-		m_aQuadKnifePoints[m_QuadKnifeCount++] = Point;
+	if (UI()->MouseButtonClicked(0) && ValidPosition)
+	{
+		m_aQuadKnifePoints[m_QuadKnifeCount] = Point;
+		m_QuadKnifeCount++;
+	}
 
 	if(m_QuadKnifeCount == 4)
 	{
@@ -2007,12 +2010,19 @@ void CEditor::DoQuadKnife(int QuadIndex)
 	{
 		// Preview
 		if(m_QuadKnifeCount > 0)
-			aLines[LineCount++] = IGraphics::CLineItem(Point.x, Point.y, m_aQuadKnifePoints[LineCount].x, m_aQuadKnifePoints[LineCount].y);
+		{
+			aLines[LineCount] = IGraphics::CLineItem(Point.x, Point.y, m_aQuadKnifePoints[LineCount].x, m_aQuadKnifePoints[LineCount].y);
+			LineCount++;
+		}
 
-		if(m_QuadKnifeCount == 3)
-			aLines[LineCount++] = IGraphics::CLineItem(Point.x, Point.y, m_aQuadKnifePoints[0].x, m_aQuadKnifePoints[0].y);
+		if (m_QuadKnifeCount == 3)
+		{
+			aLines[LineCount] = IGraphics::CLineItem(Point.x, Point.y, m_aQuadKnifePoints[0].x, m_aQuadKnifePoints[0].y);
+			LineCount++;
+		}
 
-		aMarkers[MarkerCount++] = IGraphics::CQuadItem(Point.x, Point.y, 5.f * m_WorldZoom, 5.f * m_WorldZoom);
+		aMarkers[MarkerCount] = IGraphics::CQuadItem(Point.x, Point.y, 5.f * m_WorldZoom, 5.f * m_WorldZoom);
+		MarkerCount++;
 	}
 
 	Graphics()->TextureClear();

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -1988,11 +1988,17 @@ void CEditor::DoQuadKnife(int QuadIndex)
 	}
 
 	// Render
+	Graphics()->TextureClear();
+	Graphics()->LinesBegin();	
+
 	IGraphics::CLineItem aEdges[4] = {
 		IGraphics::CLineItem(v[0].x, v[0].y, v[1].x, v[1].y),
 		IGraphics::CLineItem(v[1].x, v[1].y, v[2].x, v[2].y),
 		IGraphics::CLineItem(v[2].x, v[2].y, v[3].x, v[3].y),
 		IGraphics::CLineItem(v[3].x, v[3].y, v[0].x, v[0].y)};
+
+	Graphics()->SetColor(1.f, 0.5f, 0.f, 1.f);
+	Graphics()->LinesDraw(aEdges, 4);
 
 	IGraphics::CLineItem aLines[4];
 	int LineCount = maximum(m_QuadKnifeCount - 1, 0);
@@ -2000,43 +2006,41 @@ void CEditor::DoQuadKnife(int QuadIndex)
 	for(int i = 0; i < LineCount; i++)
 		aLines[i] = IGraphics::CLineItem(m_aQuadKnifePoints[i].x, m_aQuadKnifePoints[i].y, m_aQuadKnifePoints[i + 1].x, m_aQuadKnifePoints[i + 1].y);
 
-	IGraphics::CQuadItem aMarkers[4];
-	int MarkerCount = m_QuadKnifeCount;
-
-	for(int i = 0; i < MarkerCount; i++)
-		aMarkers[i] = IGraphics::CQuadItem(m_aQuadKnifePoints[i].x, m_aQuadKnifePoints[i].y, 5.f * m_WorldZoom, 5.f * m_WorldZoom);
+	Graphics()->SetColor(1.f, 1.f, 1.f, 1.f);
+	Graphics()->LinesDraw(aLines, LineCount);
 
 	if(ValidPosition)
 	{
-		// Preview
 		if(m_QuadKnifeCount > 0)
 		{
-			aLines[LineCount] = IGraphics::CLineItem(Point.x, Point.y, m_aQuadKnifePoints[LineCount].x, m_aQuadKnifePoints[LineCount].y);
-			LineCount++;
+			IGraphics::CLineItem LineCurrent(Point.x, Point.y, m_aQuadKnifePoints[m_QuadKnifeCount - 1].x, m_aQuadKnifePoints[m_QuadKnifeCount - 1].y);
+			Graphics()->LinesDraw(&LineCurrent, 1);
 		}
 
-		if (m_QuadKnifeCount == 3)
+		if(m_QuadKnifeCount == 3)
 		{
-			aLines[LineCount] = IGraphics::CLineItem(Point.x, Point.y, m_aQuadKnifePoints[0].x, m_aQuadKnifePoints[0].y);
-			LineCount++;
+			IGraphics::CLineItem LineClose(Point.x, Point.y, m_aQuadKnifePoints[0].x, m_aQuadKnifePoints[0].y);
+			Graphics()->LinesDraw(&LineClose, 1);
 		}
-
-		aMarkers[MarkerCount] = IGraphics::CQuadItem(Point.x, Point.y, 5.f * m_WorldZoom, 5.f * m_WorldZoom);
-		MarkerCount++;
 	}
 
-	Graphics()->TextureClear();
-
-	Graphics()->LinesBegin();	
-	Graphics()->SetColor(1.f, 0.5f, 0.f, 1.f);
-	Graphics()->LinesDraw(aEdges, 4);
-	Graphics()->SetColor(1.f, 1.f, 1.f, 1.f);
-	Graphics()->LinesDraw(aLines, LineCount);
 	Graphics()->LinesEnd();
-
 	Graphics()->QuadsBegin();
+
+	IGraphics::CQuadItem aMarkers[4];
+
+	for(int i = 0; i < m_QuadKnifeCount; i++)
+		aMarkers[i] = IGraphics::CQuadItem(m_aQuadKnifePoints[i].x, m_aQuadKnifePoints[i].y, 5.f * m_WorldZoom, 5.f * m_WorldZoom);
+
 	Graphics()->SetColor(0.f, 0.f, 1.f, 1.f);
-	Graphics()->QuadsDraw(aMarkers, MarkerCount);
+	Graphics()->QuadsDraw(aMarkers, m_QuadKnifeCount);
+
+	if(ValidPosition)
+	{
+		IGraphics::CQuadItem MarkerCurrent(Point.x, Point.y, 5.f * m_WorldZoom, 5.f * m_WorldZoom);
+		Graphics()->QuadsDraw(&MarkerCurrent, 1);
+	}
+	
 	Graphics()->QuadsEnd();
 }
 

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -1847,14 +1847,14 @@ void CEditor::DoQuadKnife(int QuadIndex)
 		m_QuadKnifeActive = false;
 		return;
 	}
-	
+
 	// Handle snapping
 	if(m_GridActive && !IgnoreGrid)
 	{
 		float CellSize = (float)GetLineDistance();
 		vec2 OnGrid = vec2(roundf(Mouse.x / CellSize) * CellSize, roundf(Mouse.y / CellSize) * CellSize);
 
-		if (IsInTriangle(OnGrid, v[0], v[1], v[2]) || IsInTriangle(OnGrid, v[0], v[3], v[2]))
+		if(IsInTriangle(OnGrid, v[0], v[1], v[2]) || IsInTriangle(OnGrid, v[0], v[3], v[2]))
 			Point = OnGrid;
 		else
 		{
@@ -1877,7 +1877,7 @@ void CEditor::DoQuadKnife(int QuadIndex)
 						Point = OnEdge;
 					}
 				}
-				
+
 				if(in_range(OnGrid.x, Min.x, Max.x) && Max.x - Min.x > 0.0000001f)
 				{
 					vec2 OnEdge(OnGrid.x, v[i].y + (OnGrid.x - v[i].x) / (v[j].x - v[i].x) * (v[j].y - v[i].y));
@@ -1897,18 +1897,18 @@ void CEditor::DoQuadKnife(int QuadIndex)
 		float MinDistance = -1.f;
 
 		// Try snapping to corners
-		for(int i = 0; i < 4; i++)
+		for(const auto &x : v)
 		{
-			float Distance = distance(Mouse, v[i]);
+			float Distance = distance(Mouse, x);
 
 			if(Distance <= SnapRadius && (Distance < MinDistance || MinDistance < 0.f))
 			{
 				MinDistance = Distance;
-				Point = v[i];
+				Point = x;
 			}
 		}
 
-		if (MinDistance < 0.f)
+		if(MinDistance < 0.f)
 		{
 			// Try snapping to edges
 			for(int i = 0; i < 4; i++)
@@ -1935,7 +1935,7 @@ void CEditor::DoQuadKnife(int QuadIndex)
 
 	bool ValidPosition = IsInTriangle(Point, v[0], v[1], v[2]) || IsInTriangle(Point, v[0], v[3], v[2]);
 
-	if (UI()->MouseButtonClicked(0) && ValidPosition)
+	if(UI()->MouseButtonClicked(0) && ValidPosition)
 	{
 		m_aQuadKnifePoints[m_QuadKnifeCount] = Point;
 		m_QuadKnifeCount++;
@@ -1959,7 +1959,7 @@ void CEditor::DoQuadKnife(int QuadIndex)
 		for(int i = 0; i < 4; i++)
 		{
 			int t = IsInTriangle(m_aQuadKnifePoints[i], v[0], v[3], v[2]) ? 2 : 1;
-				
+
 			vec2 A = vec2(fx2f(pQuad->m_aPoints[0].x), fx2f(pQuad->m_aPoints[0].y));
 			vec2 B = vec2(fx2f(pQuad->m_aPoints[3].x), fx2f(pQuad->m_aPoints[3].y));
 			vec2 C = vec2(fx2f(pQuad->m_aPoints[t].x), fx2f(pQuad->m_aPoints[t].y));
@@ -1989,7 +1989,7 @@ void CEditor::DoQuadKnife(int QuadIndex)
 
 	// Render
 	Graphics()->TextureClear();
-	Graphics()->LinesBegin();	
+	Graphics()->LinesBegin();
 
 	IGraphics::CLineItem aEdges[4] = {
 		IGraphics::CLineItem(v[0].x, v[0].y, v[1].x, v[1].y),
@@ -2040,7 +2040,7 @@ void CEditor::DoQuadKnife(int QuadIndex)
 		IGraphics::CQuadItem MarkerCurrent(Point.x, Point.y, 5.f * m_WorldZoom, 5.f * m_WorldZoom);
 		Graphics()->QuadsDraw(&MarkerCurrent, 1);
 	}
-	
+
 	Graphics()->QuadsEnd();
 }
 

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -722,6 +722,9 @@ public:
 		m_SelectedQuadEnvelope = -1;
 		m_SelectedEnvelopePoint = -1;
 
+		m_QuadKnifeActive = false;
+		m_QuadKnifeCount = 0;
+
 		m_CommandBox = 0.0f;
 		m_aSettingsCommand[0] = 0;
 
@@ -770,6 +773,7 @@ public:
 	CLayerGroup *GetSelectedGroup() const;
 	CSoundSource *GetSelectedSource();
 	void SelectLayer(int LayerIndex, int GroupIndex = -1);
+	void AddSelectedLayer(int LayerIndex);
 	void SelectQuad(int Index);
 	void DeleteSelectedQuads();
 	bool IsQuadSelected(int Index) const;
@@ -905,6 +909,10 @@ public:
 	int m_SelectedSound;
 	int m_SelectedSource;
 
+	bool m_QuadKnifeActive;
+	int m_QuadKnifeCount;
+	vec2 m_aQuadKnifePoints[4];
+
 	IGraphics::CTextureHandle m_CheckerTexture;
 	IGraphics::CTextureHandle m_BackgroundTexture;
 	IGraphics::CTextureHandle m_CursorTexture;
@@ -999,6 +1007,10 @@ public:
 	void DoQuadEnvelopes(const array<CQuad> &m_lQuads, IGraphics::CTextureHandle Texture = IGraphics::CTextureHandle());
 	void DoQuadEnvPoint(const CQuad *pQuad, int QIndex, int pIndex);
 	void DoQuadPoint(CQuad *pQuad, int QuadIndex, int v);
+
+	float TriangleArea(vec2 A, vec2 B, vec2 C);
+	bool IsInTriangle(vec2 Point, vec2 A, vec2 B, vec2 C);
+	void DoQuadKnife(int QuadIndex);
 
 	void DoSoundSource(CSoundSource *pSource, int Index);
 

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -603,6 +603,17 @@ int CEditor::PopupQuad(CEditor *pEditor, CUIRect View, void *pContext)
 		return 1;
 	}
 
+	// slice button
+	View.HSplitBottom(6.0f, &View, &Button);
+	View.HSplitBottom(12.0f, &View, &Button);
+	static int s_SliceButton = 0;
+	if(pEditor->DoButton_Editor(&s_SliceButton, "Slice", 0, &Button, 0, "Enables quad knife mode"))
+	{
+		pEditor->m_QuadKnifeCount = 0;
+		pEditor->m_QuadKnifeActive = true;
+		return 1;
+	}
+
 	enum
 	{
 		PROP_POS_X = 0,


### PR DESCRIPTION
A new way to slice quads that doesn't make mappers pull their hair out.
To use it, open the quad context menu and click the _Slice_ button, check out the tooltip for more instructions.
Snaps automatically to corners and edges if close enough or to grid.

![gif](https://user-images.githubusercontent.com/65019210/155854241-9e07a5b2-1915-41d4-86c9-b2084ff6b929.gif)

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
