### PR TITLE
Fix integer overflow in CHud when server time exceeds around 248 days

### DIFF
--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -125,7 +125,7 @@ void CHud::RenderGameTimer()
 		else
 			Time = (Client()->GameTick(g_Config.m_ClDummy) - m_pClient->m_Snap.m_pGameInfoObj->m_RoundStartTick) / Client()->GameTickSpeed();
 
-		str_time(Time * 100, TIME_DAYS, aBuf, sizeof(aBuf));
+		str_time((int64_t)Time * 100, TIME_DAYS, aBuf, sizeof(aBuf));
 		float FontSize = 10.0f;
 		float w = TextRender()->TextWidth(0, FontSize,
 			Time >= 3600 * 24 ? "00d 00:00:00" : Time >= 3600 ? "00:00:00" : "00:00",


### PR DESCRIPTION
Fixes the server timer in the HUD showing 00:00 when the server time exceeds around 248 days.

Tested on "Vanilla Teeworlds Server - CTF":

![303d](https://user-images.githubusercontent.com/23437060/156249076-d3f20853-cd0a-4545-a459-493f123eb5bc.png)

Otherwise connecting to this server causes:

```
/src/game/client/components/hud.cpp:128:17: runtime error: signed integer overflow: 26254443 * 100 cannot be represented in type 'int'
    #0 0x55c8b6722e7d in CHud::RenderGameTimer() /src/game/client/components/hud.cpp:128
    #1 0x55c8b675cdfc in CHud::OnRender() /src/game/client/components/hud.cpp:855
    #2 0x55c8b6babec7 in CGameClient::OnRender() /src/game/client/gameclient.cpp:598
    #3 0x55c8b62b0330 in CClient::Render() /src/engine/client/client.cpp:1179
    #4 0x55c8b6301a62 in CClient::Run() /src/engine/client/client.cpp:3155
    #5 0x55c8b635fc34 in main /src/engine/client/client.cpp:4427
    #6 0x7f581a6150b2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x270b2)
    #7 0x55c8b60f478d in _start (/build-asan/DDNet+0x1bd978d)
```

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [X] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
