### PR TITLE
Allow the ghost to carry any weapon | fix #4207

### DIFF
--- a/src/game/client/components/ghost.cpp
+++ b/src/game/client/components/ghost.cpp
@@ -52,7 +52,7 @@ void CGhost::GetNetObjCharacter(CNetObj_Character *pChar, const CGhostCharacter 
 	pChar->m_VelY = 0;
 	pChar->m_Angle = pGhostChar->m_Angle;
 	pChar->m_Direction = pGhostChar->m_Direction;
-	pChar->m_Weapon = pGhostChar->m_Weapon == WEAPON_GRENADE ? WEAPON_GRENADE : WEAPON_GUN;
+	pChar->m_Weapon = pGhostChar->m_Weapon;
 	pChar->m_HookState = pGhostChar->m_HookState;
 	pChar->m_HookX = pGhostChar->m_HookX;
 	pChar->m_HookY = pGhostChar->m_HookY;


### PR DESCRIPTION
I tried to reproduce another bug (https://github.com/ddnet/ddnet/issues/4207) and I noticed that ghosts are not allowed to carry any other weapons except grenade launcher and pistol. This is no longer necessary since we have been using the general renderer for players for a long time. We don't create projectiles for Ghosts, but it's always been like that and doesn't look worse than before.
![image](https://user-images.githubusercontent.com/14315968/156250428-3d8105d6-cf4a-4dd1-bf5c-cf1b9cab81d3.png)
![image](https://user-images.githubusercontent.com/14315968/156250490-02ac6d31-9146-47ff-89ac-9f4153d327a8.png)

So now you can see at least when the tee was frozen (before he was as seen in the linked issue with pistol in the freeze and alive)
![image](https://user-images.githubusercontent.com/14315968/156250525-857ca975-922f-48db-b38b-08ca86f5bd29.png)


## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
