### PR TITLE
Add size checks to CVariableInt::Pack and ::Unpack, refactoring

### DIFF
--- a/src/engine/shared/compression.cpp
+++ b/src/engine/shared/compression.cpp
@@ -5,8 +5,12 @@
 #include "compression.h"
 
 // Format: ESDDDDDD EDDDDDDD EDD... Extended, Data, Sign
-unsigned char *CVariableInt::Pack(unsigned char *pDst, int i)
+unsigned char *CVariableInt::Pack(unsigned char *pDst, int i, int DstSize)
 {
+	if(DstSize <= 0)
+		return 0;
+
+	DstSize--;
 	*pDst = 0;
 	if(i < 0)
 	{
@@ -18,7 +22,10 @@ unsigned char *CVariableInt::Pack(unsigned char *pDst, int i)
 	i >>= 6; // discard 6 bits
 	while(i)
 	{
+		if(DstSize <= 0)
+			return 0;
 		*pDst |= 0x80; // set extend bit
+		DstSize--;
 		pDst++;
 		*pDst = i & 0x7F; // pack 7bit
 		i >>= 7; // discard 7 bits
@@ -28,33 +35,28 @@ unsigned char *CVariableInt::Pack(unsigned char *pDst, int i)
 	return pDst;
 }
 
-const unsigned char *CVariableInt::Unpack(const unsigned char *pSrc, int *pInOut)
+const unsigned char *CVariableInt::Unpack(const unsigned char *pSrc, int *pInOut, int SrcSize)
 {
+	if(SrcSize <= 0)
+		return 0;
+
 	const int Sign = (*pSrc >> 6) & 1;
 	*pInOut = *pSrc & 0x3F;
+	SrcSize--;
 
-	do
+	const static int s_aMasks[] = {0x7F, 0x7F, 0x7F, 0x0F};
+	const static int s_aShifts[] = {6, 6 + 7, 6 + 7 + 7, 6 + 7 + 7 + 7};
+
+	for(unsigned i = 0; i < sizeof(s_aMasks) / sizeof(int); i++)
 	{
 		if(!(*pSrc & 0x80))
 			break;
+		if(SrcSize <= 0)
+			return 0;
+		SrcSize--;
 		pSrc++;
-		*pInOut |= (*pSrc & 0x7F) << 6;
-
-		if(!(*pSrc & 0x80))
-			break;
-		pSrc++;
-		*pInOut |= (*pSrc & 0x7F) << (6 + 7);
-
-		if(!(*pSrc & 0x80))
-			break;
-		pSrc++;
-		*pInOut |= (*pSrc & 0x7F) << (6 + 7 + 7);
-
-		if(!(*pSrc & 0x80))
-			break;
-		pSrc++;
-		*pInOut |= (*pSrc & 0x0F) << (6 + 7 + 7 + 7);
-	} while(false);
+		*pInOut |= (*pSrc & s_aMasks[i]) << s_aShifts[i];
+	}
 
 	pSrc++;
 	*pInOut ^= -Sign; // if(sign) *i = ~(*i)
@@ -66,14 +68,16 @@ long CVariableInt::Decompress(const void *pSrc_, int SrcSize, void *pDst_, int D
 	dbg_assert(DstSize % sizeof(int) == 0, "invalid bounds");
 
 	const unsigned char *pSrc = (unsigned char *)pSrc_;
-	const unsigned char *pEnd = pSrc + SrcSize;
+	const unsigned char *pSrcEnd = pSrc + SrcSize;
 	int *pDst = (int *)pDst_;
 	const int *pDstEnd = pDst + DstSize / sizeof(int);
-	while(pSrc < pEnd)
+	while(pSrc < pSrcEnd)
 	{
 		if(pDst >= pDstEnd)
 			return -1;
-		pSrc = CVariableInt::Unpack(pSrc, pDst);
+		pSrc = CVariableInt::Unpack(pSrc, pDst, pSrcEnd - pSrc);
+		if(!pSrc)
+			return -1;
 		pDst++;
 	}
 	return (long)((unsigned char *)pDst - (unsigned char *)pDst_);
@@ -89,9 +93,9 @@ long CVariableInt::Compress(const void *pSrc_, int SrcSize, void *pDst_, int Dst
 	SrcSize /= sizeof(int);
 	while(SrcSize)
 	{
-		if(pDstEnd - pDst <= MAX_BYTES_PACKED)
+		pDst = CVariableInt::Pack(pDst, *pSrc, pDstEnd - pDst);
+		if(!pDst)
 			return -1;
-		pDst = CVariableInt::Pack(pDst, *pSrc);
 		SrcSize--;
 		pSrc++;
 	}

--- a/src/engine/shared/compression.cpp
+++ b/src/engine/shared/compression.cpp
@@ -7,23 +7,21 @@
 // Format: ESDDDDDD EDDDDDDD EDD... Extended, Data, Sign
 unsigned char *CVariableInt::Pack(unsigned char *pDst, int i)
 {
-	*pDst = (i >> 25) & 0x40; // set sign bit if i<0
-	i ^= i >> 31; // if(i<0) i = ~i
+	*pDst = 0;
+	if(i < 0)
+	{
+		*pDst |= 0x40; // set sign bit
+		i = ~i;
+	}
 
 	*pDst |= i & 0x3F; // pack 6bit into dst
 	i >>= 6; // discard 6 bits
-	if(i)
+	while(i)
 	{
 		*pDst |= 0x80; // set extend bit
-		while(true)
-		{
-			pDst++;
-			*pDst = i & 0x7F; // pack 7bit
-			i >>= 7; // discard 7 bits
-			*pDst |= (i != 0) << 7; // set extend bit (may branch)
-			if(!i)
-				break;
-		}
+		pDst++;
+		*pDst = i & 0x7F; // pack 7bit
+		i >>= 7; // discard 7 bits
 	}
 
 	pDst++;

--- a/src/engine/shared/compression.h
+++ b/src/engine/shared/compression.h
@@ -12,8 +12,8 @@ public:
 		MAX_BYTES_PACKED = 5, // maximum number of bytes in a packed int
 	};
 
-	static unsigned char *Pack(unsigned char *pDst, int i);
-	static const unsigned char *Unpack(const unsigned char *pSrc, int *pInOut);
+	static unsigned char *Pack(unsigned char *pDst, int i, int DstSize);
+	static const unsigned char *Unpack(const unsigned char *pSrc, int *pInOut, int SrcSize);
 
 	static long Compress(const void *pSrc, int SrcSize, void *pDst, int DstSize);
 	static long Decompress(const void *pSrc, int SrcSize, void *pDst, int DstSize);

--- a/src/engine/shared/packer.cpp
+++ b/src/engine/shared/packer.cpp
@@ -18,14 +18,13 @@ void CPacker::AddInt(int i)
 	if(m_Error)
 		return;
 
-	// make sure that we have space enough
-	if(m_pEnd - m_pCurrent <= CVariableInt::MAX_BYTES_PACKED)
+	unsigned char *pNext = CVariableInt::Pack(m_pCurrent, i, m_pEnd - m_pCurrent);
+	if(!pNext)
 	{
-		dbg_break();
 		m_Error = 1;
+		return;
 	}
-	else
-		m_pCurrent = CVariableInt::Pack(m_pCurrent, i);
+	m_pCurrent = pNext;
 }
 
 void CPacker::AddString(const char *pStr, int Limit)
@@ -102,12 +101,13 @@ int CUnpacker::GetInt()
 	}
 
 	int i;
-	m_pCurrent = CVariableInt::Unpack(m_pCurrent, &i);
-	if(m_pCurrent > m_pEnd)
+	const unsigned char *pNext = CVariableInt::Unpack(m_pCurrent, &i, m_pEnd - m_pCurrent);
+	if(!pNext)
 	{
 		m_Error = 1;
 		return 0;
 	}
+	m_pCurrent = pNext;
 	return i;
 }
 

--- a/src/engine/shared/snapshot.cpp
+++ b/src/engine/shared/snapshot.cpp
@@ -188,7 +188,7 @@ void CSnapshotDelta::UndiffItem(int *pPast, int *pDiff, int *pOut, int Size, int
 		else
 		{
 			unsigned char aBuf[CVariableInt::MAX_BYTES_PACKED];
-			unsigned char *pEnd = CVariableInt::Pack(aBuf, *pDiff);
+			unsigned char *pEnd = CVariableInt::Pack(aBuf, *pDiff, sizeof(aBuf));
 			*pDataRate += (int)(pEnd - (unsigned char *)aBuf) * 8;
 		}
 

--- a/src/test/compression.cpp
+++ b/src/test/compression.cpp
@@ -12,8 +12,8 @@ TEST(CVariableInt, RoundtripPackUnpack)
 	{
 		unsigned char aPacked[CVariableInt::MAX_BYTES_PACKED];
 		int Result;
-		EXPECT_EQ(int(CVariableInt::Pack(aPacked, DATA[i]) - aPacked), SIZES[i]);
-		EXPECT_EQ(int(CVariableInt::Unpack(aPacked, &Result) - aPacked), SIZES[i]);
+		EXPECT_EQ(int(CVariableInt::Pack(aPacked, DATA[i], sizeof(aPacked)) - aPacked), SIZES[i]);
+		EXPECT_EQ(int(CVariableInt::Unpack(aPacked, &Result, sizeof(aPacked)) - aPacked), SIZES[i]);
 		EXPECT_EQ(Result, DATA[i]);
 	}
 }
@@ -21,17 +21,33 @@ TEST(CVariableInt, RoundtripPackUnpack)
 TEST(CVariableInt, UnpackInvalid)
 {
 	unsigned char aPacked[CVariableInt::MAX_BYTES_PACKED];
-	for(int i = 0; i < CVariableInt::MAX_BYTES_PACKED; i++)
+	for(unsigned i = 0; i < sizeof(aPacked); i++)
 		aPacked[i] = 0xFF;
 
 	int Result;
-	EXPECT_EQ(int(CVariableInt::Unpack(aPacked, &Result) - aPacked), int(CVariableInt::MAX_BYTES_PACKED));
+	EXPECT_EQ(int(CVariableInt::Unpack(aPacked, &Result, sizeof(aPacked)) - aPacked), int(CVariableInt::MAX_BYTES_PACKED));
 	EXPECT_EQ(Result, (-2147483647 - 1));
 
 	aPacked[0] &= ~0x40; // unset sign bit
 
-	EXPECT_EQ(int(CVariableInt::Unpack(aPacked, &Result) - aPacked), int(CVariableInt::MAX_BYTES_PACKED));
+	EXPECT_EQ(int(CVariableInt::Unpack(aPacked, &Result, sizeof(aPacked)) - aPacked), int(CVariableInt::MAX_BYTES_PACKED));
 	EXPECT_EQ(Result, 2147483647);
+}
+
+TEST(CVariableInt, PackBufferTooSmall)
+{
+	unsigned char aPacked[CVariableInt::MAX_BYTES_PACKED / 2]; // too small
+	EXPECT_EQ(CVariableInt::Pack(aPacked, 2147483647, sizeof(aPacked)), (const unsigned char *)0x0);
+}
+
+TEST(CVariableInt, UnpackBufferTooSmall)
+{
+	unsigned char aPacked[CVariableInt::MAX_BYTES_PACKED / 2];
+	for(unsigned i = 0; i < sizeof(aPacked); i++)
+		aPacked[i] = 0xFF; // extended bits are set, but buffer ends too early
+
+	int UnusedResult;
+	EXPECT_EQ(CVariableInt::Unpack(aPacked, &UnusedResult, sizeof(aPacked)), (const unsigned char *)0x0);
 }
 
 TEST(CVariableInt, RoundtripCompressDecompress)


### PR DESCRIPTION
- Refactor `CVariableInt::Pack` some more according to upstream:
   - avoid right shift of negative number
   - rewrite loop smarter
- Add size parameters to `CVariableInt::Pack` and `CVariableInt::Unpack`. Adjust tests and add tests with too small buffer sizes.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [X] Written a unit test if it works standalone, system.c especially
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
