### PR TITLE
add AllowMoreTeams to GameInfo; use it to avoid duplicate messages

### DIFF
--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -715,7 +715,7 @@ void CGameClient::OnMessage(int MsgId, CUnpacker *pUnpacker, int Conn, bool Dumm
 		{
 			CNetMsg_Sv_Chat *pMsg = (CNetMsg_Sv_Chat *)pRawMsg;
 
-			if((pMsg->m_Team == 1 && (m_aClients[m_LocalIDs[0]].m_Team != m_aClients[m_LocalIDs[1]].m_Team || m_Teams.Team(m_LocalIDs[0]) != m_Teams.Team(m_LocalIDs[1]))) || pMsg->m_Team > 1)
+			if((pMsg->m_Team == 1 && ((!m_GameInfo.m_AllowMoreTeams && m_aClients[m_LocalIDs[0]].m_Team != m_aClients[m_LocalIDs[1]].m_Team) || ((m_aClients[m_LocalIDs[0]].m_Team == TEAM_SPECTATORS && !m_aClients[m_LocalIDs[0]].m_Paused && !m_aClients[m_LocalIDs[0]].m_Spec) != (m_aClients[m_LocalIDs[1]].m_Team == TEAM_SPECTATORS && !m_aClients[m_LocalIDs[1]].m_Paused && !m_aClients[m_LocalIDs[1]].m_Spec)) || m_Teams.Team(m_LocalIDs[0]) != m_Teams.Team(m_LocalIDs[1]))) || pMsg->m_Team > 1)
 			{
 				m_Chat.OnMessage(MsgId, pRawMsg);
 			}
@@ -789,6 +789,7 @@ void CGameClient::OnMessage(int MsgId, CUnpacker *pUnpacker, int Conn, bool Dumm
 
 		m_Ghost.m_AllowRestart = true;
 		m_RaceDemo.m_AllowRestart = true;
+		m_GameInfo.m_AllowMoreTeams = true;
 	}
 	else if(MsgId == NETMSGTYPE_SV_KILLMSG)
 	{
@@ -999,6 +1000,7 @@ static CGameInfo GetGameInfo(const CNetObj_GameInfoEx *pInfoEx, int InfoExSize, 
 	Info.m_AllowEyeWheel = DDRace || BlockWorlds || City || Plus;
 	Info.m_AllowHookColl = DDRace;
 	Info.m_AllowZoom = Race || BlockWorlds || City;
+	Info.m_AllowMoreTeams = DDRace;
 	Info.m_BugDDRaceGhost = DDRace;
 	Info.m_BugDDRaceInput = DDRace;
 	Info.m_BugFNGLaserRange = FNG;

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -67,6 +67,7 @@ public:
 	bool m_AllowEyeWheel;
 	bool m_AllowHookColl;
 	bool m_AllowZoom;
+	bool m_AllowMoreTeams;
 
 	bool m_BugDDRaceGhost;
 	bool m_BugDDRaceInput;


### PR DESCRIPTION
Fixes #259
I do not know what mods use more than the vanilla teams. But for now I just assumed DDRace and if a NETMSGTYPE_SV_TEAMSSTATE message comes the info will be adjusted.

We can use this info to distinguish if the game uses the vanilla teams or if more teams are allowed. 

In m_Team of a m_aClient the vanilla team is stored, which is -1 if the player is in /pause or /spec or a real spectator. m_Teams however still returns the correct team.


## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
 