### PR TITLE
Remove unnecessary trailing semicolons after method declarations

### DIFF
--- a/src/base/color.h
+++ b/src/base/color.h
@@ -96,7 +96,7 @@ public:
 		z = ((col >> 0) & 0xFF) / 255.0f;
 	}
 
-	vec4 v4() const { return vec4(x, y, z, a); };
+	vec4 v4() const { return vec4(x, y, z, a); }
 
 	unsigned Pack(bool Alpha = true)
 	{

--- a/src/engine/client/graphics_threaded_null.h
+++ b/src/engine/client/graphics_threaded_null.h
@@ -28,7 +28,7 @@ public:
 	void WrapNormal() override{};
 	void WrapClamp() override{};
 
-	int MemoryUsage() const override { return 0; };
+	int MemoryUsage() const override { return 0; }
 
 	void MapScreen(float TopLeftX, float TopLeftY, float BottomRightX, float BottomRightY) override{};
 	void GetScreen(float *pTopLeftX, float *pTopLeftY, float *pBottomRightX, float *pBottomRightY) override
@@ -43,24 +43,24 @@ public:
 	void LinesEnd() override{};
 	void LinesDraw(const CLineItem *pArray, int Num) override{};
 
-	int UnloadTexture(IGraphics::CTextureHandle *pIndex) override { return 0; };
-	IGraphics::CTextureHandle LoadTextureRaw(int Width, int Height, int Format, const void *pData, int StoreFormat, int Flags, const char *pTexName = NULL) override { return CreateTextureHandle(0); };
-	int LoadTextureRawSub(IGraphics::CTextureHandle TextureID, int x, int y, int Width, int Height, int Format, const void *pData) override { return 0; };
+	int UnloadTexture(IGraphics::CTextureHandle *pIndex) override { return 0; }
+	IGraphics::CTextureHandle LoadTextureRaw(int Width, int Height, int Format, const void *pData, int StoreFormat, int Flags, const char *pTexName = NULL) override { return CreateTextureHandle(0); }
+	int LoadTextureRawSub(IGraphics::CTextureHandle TextureID, int x, int y, int Width, int Height, int Format, const void *pData) override { return 0; }
 
-	CTextureHandle LoadSpriteTextureImpl(CImageInfo &FromImageInfo, int x, int y, int w, int h) { return CreateTextureHandle(0); };
-	CTextureHandle LoadSpriteTexture(CImageInfo &FromImageInfo, struct CDataSprite *pSprite) override { return CreateTextureHandle(0); };
-	CTextureHandle LoadSpriteTexture(CImageInfo &FromImageInfo, struct client_data7::CDataSprite *pSprite) override { return CreateTextureHandle(0); };
+	CTextureHandle LoadSpriteTextureImpl(CImageInfo &FromImageInfo, int x, int y, int w, int h) { return CreateTextureHandle(0); }
+	CTextureHandle LoadSpriteTexture(CImageInfo &FromImageInfo, struct CDataSprite *pSprite) override { return CreateTextureHandle(0); }
+	CTextureHandle LoadSpriteTexture(CImageInfo &FromImageInfo, struct client_data7::CDataSprite *pSprite) override { return CreateTextureHandle(0); }
 
-	bool IsImageSubFullyTransparent(CImageInfo &FromImageInfo, int x, int y, int w, int h) override { return false; };
-	bool IsSpriteTextureFullyTransparent(CImageInfo &FromImageInfo, struct client_data7::CDataSprite *pSprite) override { return false; };
+	bool IsImageSubFullyTransparent(CImageInfo &FromImageInfo, int x, int y, int w, int h) override { return false; }
+	bool IsSpriteTextureFullyTransparent(CImageInfo &FromImageInfo, struct client_data7::CDataSprite *pSprite) override { return false; }
 
 	// simple uncompressed RGBA loaders
-	IGraphics::CTextureHandle LoadTexture(const char *pFilename, int StorageType, int StoreFormat, int Flags) override { return CreateTextureHandle(0); };
-	int LoadPNG(CImageInfo *pImg, const char *pFilename, int StorageType) override { return 0; };
+	IGraphics::CTextureHandle LoadTexture(const char *pFilename, int StorageType, int StoreFormat, int Flags) override { return CreateTextureHandle(0); }
+	int LoadPNG(CImageInfo *pImg, const char *pFilename, int StorageType) override { return 0; }
 	void FreePNG(CImageInfo *pImg) override{};
 
-	bool CheckImageDivisibility(const char *pFileName, CImageInfo &Img, int DivX, int DivY, bool AllowResize) override { return false; };
-	bool IsImageFormatRGBA(const char *pFileName, CImageInfo &Img) override { return false; };
+	bool CheckImageDivisibility(const char *pFileName, CImageInfo &Img, int DivX, int DivY, bool AllowResize) override { return false; }
+	bool IsImageFormatRGBA(const char *pFileName, CImageInfo &Img) override { return false; }
 
 	void CopyTextureBufferSub(uint8_t *pDestBuffer, uint8_t *pSourceBuffer, int FullWidth, int FullHeight, int ColorChannelCount, int SubOffsetX, int SubOffsetY, int SubCopyWidth, int SubCopyHeight) override{};
 	void CopyTextureFromTextureBufferSub(uint8_t *pDestBuffer, int DestWidth, int DestHeight, uint8_t *pSourceBuffer, int SrcWidth, int SrcHeight, int ColorChannelCount, int SrcSubOffsetX, int SrcSubOffsetY, int SrcSubCopyWidth, int SrcSubCopyHeight) override{};
@@ -133,57 +133,57 @@ public:
 	void RenderText(int BufferContainerIndex, int TextQuadNum, int TextureSize, int TextureTextIndex, int TextureTextOutlineIndex, float *pTextColor, float *pTextoutlineColor) override{};
 
 	// opengl 3.3 functions
-	int CreateBufferObject(size_t UploadDataSize, void *pUploadData, bool IsMovedPointer = false) override { return 0; };
+	int CreateBufferObject(size_t UploadDataSize, void *pUploadData, bool IsMovedPointer = false) override { return 0; }
 	void RecreateBufferObject(int BufferIndex, size_t UploadDataSize, void *pUploadData, bool IsMovedPointer = false) override{};
 	void UpdateBufferObject(int BufferIndex, size_t UploadDataSize, void *pUploadData, void *pOffset, bool IsMovedPointer = false) override{};
 	void CopyBufferObject(int WriteBufferIndex, int ReadBufferIndex, size_t WriteOffset, size_t ReadOffset, size_t CopyDataSize) override{};
 	void DeleteBufferObject(int BufferIndex) override{};
 
-	int CreateBufferContainer(SBufferContainerInfo *pContainerInfo) override { return 0; };
+	int CreateBufferContainer(SBufferContainerInfo *pContainerInfo) override { return 0; }
 	// destroying all buffer objects means, that all referenced VBOs are destroyed automatically, so the user does not need to save references to them
 	void DeleteBufferContainer(int ContainerIndex, bool DestroyAllBO = true) override{};
 	void UpdateBufferContainer(int ContainerIndex, SBufferContainerInfo *pContainerInfo) override{};
 	void IndicesNumRequiredNotify(unsigned int RequiredIndicesCount) override{};
 
-	int GetNumScreens() const override { return 0; };
+	int GetNumScreens() const override { return 0; }
 	void Minimize() override{};
 	void Maximize() override{};
 	void SetWindowParams(int FullscreenMode, bool IsBorderless, bool AllowResizing) override{};
-	bool SetWindowScreen(int Index) override { return false; };
+	bool SetWindowScreen(int Index) override { return false; }
 	void Move(int x, int y) override{};
 	void Resize(int w, int h, int RefreshRate) override{};
 	void GotResized(int w, int h, int RefreshRate) override{};
 	void AddWindowResizeListener(WINDOW_RESIZE_FUNC pFunc, void *pUser) override{};
-	int GetWindowScreen() override { return 0; };
+	int GetWindowScreen() override { return 0; }
 
 	void WindowDestroyNtf(uint32_t WindowID) override{};
 	void WindowCreateNtf(uint32_t WindowID) override{};
 
-	int WindowActive() override { return 1; };
-	int WindowOpen() override { return 0; };
+	int WindowActive() override { return 1; }
+	int WindowOpen() override { return 0; }
 
 	void SetWindowGrab(bool Grab) override{};
 	void NotifyWindow() override{};
 
-	int Init() override { return 0; };
+	int Init() override { return 0; }
 	void Shutdown() override{};
 
 	void TakeScreenshot(const char *pFilename) override{};
 	void TakeCustomScreenshot(const char *pFilename) override{};
 	void Swap() override{};
-	bool SetVSync(bool State) override { return false; };
+	bool SetVSync(bool State) override { return false; }
 
-	int GetVideoModes(CVideoMode *pModes, int MaxModes, int Screen) override { return 0; };
+	int GetVideoModes(CVideoMode *pModes, int MaxModes, int Screen) override { return 0; }
 
 	virtual int GetDesktopScreenWidth() const { return g_Config.m_GfxDesktopWidth; }
 	virtual int GetDesktopScreenHeight() const { return g_Config.m_GfxDesktopHeight; }
 
 	// synchronization
 	void InsertSignal(CSemaphore *pSemaphore) override{};
-	bool IsIdle() const override { return true; };
+	bool IsIdle() const override { return true; }
 	void WaitForIdle() override{};
 
-	SWarning *GetCurWarning() override { return NULL; };
+	SWarning *GetCurWarning() override { return NULL; }
 
 	void GetDriverVersion(EGraphicsDriverAgeType DriverAgeType, int &Major, int &Minor, int &Patch) override {}
 	bool IsConfigModernAPI() override { return false; }
@@ -193,9 +193,9 @@ public:
 	bool IsQuadContainerBufferingEnabled() override { return false; }
 	bool HasTextureArrays() override { return false; }
 
-	const char *GetVendorString() override { return "headless"; };
-	const char *GetVersionString() override { return "headless"; };
-	const char *GetRendererString() override { return "headless"; };
+	const char *GetVendorString() override { return "headless"; }
+	const char *GetVersionString() override { return "headless"; }
+	const char *GetRendererString() override { return "headless"; }
 };
 
 #endif // ENGINE_CLIENT_GRAPHICS_THREADED_NULL_H

--- a/src/engine/client/input.h
+++ b/src/engine/client/input.h
@@ -26,7 +26,7 @@ class CInput : public IEngineInput
 
 	void AddEvent(char *pText, int Key, int Flags);
 	void Clear();
-	bool IsEventValid(CEvent *pEvent) const { return pEvent->m_InputCount == m_InputCounter; };
+	bool IsEventValid(CEvent *pEvent) const { return pEvent->m_InputCount == m_InputCounter; }
 
 	// quick access to input
 	unsigned short m_aInputCount[g_MaxKeys]; // tw-KEY

--- a/src/engine/client/serverbrowser.h
+++ b/src/engine/client/serverbrowser.h
@@ -116,12 +116,12 @@ public:
 	void LoadDDNetInfoJson();
 	const json_value *LoadDDNetInfo();
 	int HasRank(const char *pMap);
-	int NumCountries(int Network) { return m_aNetworks[Network].m_NumCountries; };
-	int GetCountryFlag(int Network, int Index) { return m_aNetworks[Network].m_aCountries[Index].m_FlagID; };
-	const char *GetCountryName(int Network, int Index) { return m_aNetworks[Network].m_aCountries[Index].m_aName; };
+	int NumCountries(int Network) { return m_aNetworks[Network].m_NumCountries; }
+	int GetCountryFlag(int Network, int Index) { return m_aNetworks[Network].m_aCountries[Index].m_FlagID; }
+	const char *GetCountryName(int Network, int Index) { return m_aNetworks[Network].m_aCountries[Index].m_aName; }
 
-	int NumTypes(int Network) { return m_aNetworks[Network].m_NumTypes; };
-	const char *GetType(int Network, int Index) { return m_aNetworks[Network].m_aTypes[Index]; };
+	int NumTypes(int Network) { return m_aNetworks[Network].m_NumTypes; }
+	const char *GetType(int Network, int Index) { return m_aNetworks[Network].m_aTypes[Index]; }
 
 	void DDNetFilterAdd(char *pFilter, const char *pName);
 	void DDNetFilterRem(char *pFilter, const char *pName);
@@ -142,7 +142,7 @@ public:
 	void RequestImpl64(const NETADDR &Addr, CServerEntry *pEntry) const;
 	void QueueRequest(CServerEntry *pEntry);
 	CServerEntry *Find(const NETADDR &Addr);
-	int GetCurrentType() { return m_ServerlistType; };
+	int GetCurrentType() { return m_ServerlistType; }
 
 private:
 	CNetClient *m_pNetClient;

--- a/src/engine/client/text.cpp
+++ b/src/engine/client/text.cpp
@@ -880,7 +880,7 @@ public:
 		m_Color.b = b;
 		m_Color.a = a;
 	}
-	virtual void TextColor(ColorRGBA rgb) { m_Color = rgb; };
+	virtual void TextColor(ColorRGBA rgb) { m_Color = rgb; }
 
 	virtual void TextOutlineColor(float r, float g, float b, float a)
 	{
@@ -889,7 +889,7 @@ public:
 		m_OutlineColor.b = b;
 		m_OutlineColor.a = a;
 	}
-	virtual void TextOutlineColor(ColorRGBA rgb) { m_OutlineColor = rgb; };
+	virtual void TextOutlineColor(ColorRGBA rgb) { m_OutlineColor = rgb; }
 
 	virtual void TextSelectionColor(float r, float g, float b, float a)
 	{
@@ -898,7 +898,7 @@ public:
 		m_SelectionColor.b = b;
 		m_SelectionColor.a = a;
 	}
-	virtual void TextSelectionColor(ColorRGBA rgb) { m_SelectionColor = rgb; };
+	virtual void TextSelectionColor(ColorRGBA rgb) { m_SelectionColor = rgb; }
 
 	virtual ColorRGBA GetTextColor() { return m_Color; }
 	virtual ColorRGBA GetTextOutlineColor() { return m_OutlineColor; }

--- a/src/engine/server/databases/mysql.cpp
+++ b/src/engine/server/databases/mysql.cpp
@@ -70,8 +70,8 @@ public:
 	virtual void ToUnixTimestamp(const char *pTimestamp, char *aBuf, unsigned int BufferSize);
 	virtual const char *InsertTimestampAsUtc() const { return "?"; }
 	virtual const char *CollateNocase() const { return "CONVERT(? USING utf8mb4) COLLATE utf8mb4_general_ci"; }
-	virtual const char *InsertIgnore() const { return "INSERT IGNORE"; };
-	virtual const char *Random() const { return "RAND()"; };
+	virtual const char *InsertIgnore() const { return "INSERT IGNORE"; }
+	virtual const char *Random() const { return "RAND()"; }
 	virtual const char *MedianMapTime(char *pBuffer, int BufferSize) const;
 	virtual const char *False() const { return "FALSE"; }
 	virtual const char *True() const { return "TRUE"; }

--- a/src/engine/server/databases/sqlite.cpp
+++ b/src/engine/server/databases/sqlite.cpp
@@ -20,8 +20,8 @@ public:
 	virtual void ToUnixTimestamp(const char *pTimestamp, char *aBuf, unsigned int BufferSize);
 	virtual const char *InsertTimestampAsUtc() const { return "DATETIME(?, 'utc')"; }
 	virtual const char *CollateNocase() const { return "? COLLATE NOCASE"; }
-	virtual const char *InsertIgnore() const { return "INSERT OR IGNORE"; };
-	virtual const char *Random() const { return "RANDOM()"; };
+	virtual const char *InsertIgnore() const { return "INSERT OR IGNORE"; }
+	virtual const char *Random() const { return "RANDOM()"; }
 	virtual const char *MedianMapTime(char *pBuffer, int BufferSize) const;
 	// Since SQLite 3.23.0 true/false literals are recognized, but still cleaner to use 1/0, because:
 	// > For compatibility, if there exist columns named "true" or "false", then

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -452,11 +452,11 @@ public:
 	}
 
 	void AuthRemoveKey(int KeySlot);
-	bool ClientPrevIngame(int ClientID) { return m_aPrevStates[ClientID] == CClient::STATE_INGAME; };
-	const char *GetNetErrorString(int ClientID) { return m_NetServer.ErrorString(ClientID); };
-	void ResetNetErrorString(int ClientID) { m_NetServer.ResetErrorString(ClientID); };
+	bool ClientPrevIngame(int ClientID) { return m_aPrevStates[ClientID] == CClient::STATE_INGAME; }
+	const char *GetNetErrorString(int ClientID) { return m_NetServer.ErrorString(ClientID); }
+	void ResetNetErrorString(int ClientID) { m_NetServer.ResetErrorString(ClientID); }
 	bool SetTimedOut(int ClientID, int OrigID);
-	void SetTimeoutProtected(int ClientID) { m_NetServer.SetTimeoutProtected(ClientID); };
+	void SetTimeoutProtected(int ClientID) { m_NetServer.SetTimeoutProtected(ClientID); }
 
 	void SendMsgRaw(int ClientID, const void *pData, int Size, int Flags);
 

--- a/src/engine/shared/demo.h
+++ b/src/engine/shared/demo.h
@@ -147,14 +147,14 @@ public:
 	const CInfo *BaseInfo() const { return &m_Info.m_Info; }
 	void GetDemoName(char *pBuffer, int BufferSize) const;
 	bool GetDemoInfo(class IStorage *pStorage, const char *pFilename, int StorageType, CDemoHeader *pDemoHeader, CTimelineMarkers *pTimelineMarkers, CMapInfo *pMapInfo) const;
-	const char *GetDemoFileName() { return m_aFilename; };
+	const char *GetDemoFileName() { return m_aFilename; }
 	int GetDemoType() const;
 
 	int Update(bool RealTime = true);
 
 	const CPlaybackInfo *Info() const { return &m_Info; }
 	virtual bool IsPlaying() const { return m_File != 0; }
-	const CMapInfo *GetMapInfo() { return &m_MapInfo; };
+	const CMapInfo *GetMapInfo() { return &m_MapInfo; }
 };
 
 class CDemoEditor : public IDemoEditor, public CDemoPlayer::IListener

--- a/src/engine/shared/network.h
+++ b/src/engine/shared/network.h
@@ -229,7 +229,7 @@ public:
 	int AckSequence() const { return m_Ack; }
 	int SeqSequence() const { return m_Sequence; }
 	int SecurityToken() const { return m_SecurityToken; }
-	CStaticRingBuffer<CNetChunkResend, NET_CONN_BUFFERSIZE> *ResendBuffer() { return &m_Buffer; };
+	CStaticRingBuffer<CNetChunkResend, NET_CONN_BUFFERSIZE> *ResendBuffer() { return &m_Buffer; }
 
 	void SetTimedOut(const NETADDR *pAddr, int Sequence, int Ack, SECURITY_TOKEN SecurityToken, CStaticRingBuffer<CNetChunkResend, NET_CONN_BUFFERSIZE> *pResendBuffer, bool Sixup);
 
@@ -335,7 +335,7 @@ class CNetServer
 	int OnSixupCtrlMsg(NETADDR &Addr, CNetChunk *pChunk, int ControlMsg, const CNetPacketConstruct &Packet, SECURITY_TOKEN &ResponseToken, SECURITY_TOKEN Token);
 	void OnPreConnMsg(NETADDR &Addr, CNetPacketConstruct &Packet);
 	void OnConnCtrlMsg(NETADDR &Addr, int ClientID, int ControlMsg, const CNetPacketConstruct &Packet);
-	bool ClientExists(const NETADDR &Addr) { return GetClientSlot(Addr) != -1; };
+	bool ClientExists(const NETADDR &Addr) { return GetClientSlot(Addr) != -1; }
 	int GetClientSlot(const NETADDR &Addr);
 	void SendControl(NETADDR &Addr, int ControlMsg, const void *pExtra, int ExtraSize, SECURITY_TOKEN SecurityToken);
 

--- a/src/engine/shared/snapshot.h
+++ b/src/engine/shared/snapshot.h
@@ -114,8 +114,8 @@ public:
 	CHolder *m_pFirst;
 	CHolder *m_pLast;
 
-	CSnapshotStorage() { Init(); };
-	~CSnapshotStorage() { PurgeAll(); };
+	CSnapshotStorage() { Init(); }
+	~CSnapshotStorage() { PurgeAll(); }
 	void Init();
 	void PurgeAll();
 	void PurgeUntil(int Tick);

--- a/src/game/client/animstate.h
+++ b/src/game/client/animstate.h
@@ -13,10 +13,10 @@ class CAnimState
 	CAnimKeyframe m_Attach;
 
 public:
-	CAnimKeyframe *GetBody() { return &m_Body; };
-	CAnimKeyframe *GetBackFoot() { return &m_BackFoot; };
-	CAnimKeyframe *GetFrontFoot() { return &m_FrontFoot; };
-	CAnimKeyframe *GetAttach() { return &m_Attach; };
+	CAnimKeyframe *GetBody() { return &m_Body; }
+	CAnimKeyframe *GetBackFoot() { return &m_BackFoot; }
+	CAnimKeyframe *GetFrontFoot() { return &m_FrontFoot; }
+	CAnimKeyframe *GetAttach() { return &m_Attach; }
 	void Set(CAnimation *pAnim, float Time);
 	void Add(CAnimation *pAnim, float Time, float Amount);
 

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -229,8 +229,8 @@ public:
 	class IDemoRecorder *DemoRecorder(int Recorder) const { return Client()->DemoRecorder(Recorder); }
 	class IServerBrowser *ServerBrowser() const { return m_pServerBrowser; }
 	class CRenderTools *RenderTools() { return &m_RenderTools; }
-	class CLayers *Layers() { return &m_Layers; };
-	class CCollision *Collision() { return &m_Collision; };
+	class CLayers *Layers() { return &m_Layers; }
+	class CCollision *Collision() { return &m_Collision; }
 	class IEditor *Editor() { return m_pEditor; }
 	class IFriends *Friends() { return m_pFriends; }
 	class IFriends *Foes() { return m_pFoes; }
@@ -439,8 +439,8 @@ public:
 			m_Active = false;
 			m_IngameTicks += Tick - m_JoinTick;
 		};
-		int GetIngameTicks(int Tick) const { return m_IngameTicks + Tick - m_JoinTick; };
-		float GetFPM(int Tick, int TickSpeed) const { return (float)(m_Frags * TickSpeed * 60) / GetIngameTicks(Tick); };
+		int GetIngameTicks(int Tick) const { return m_IngameTicks + Tick - m_JoinTick; }
+		float GetFPM(int Tick, int TickSpeed) const { return (float)(m_Frags * TickSpeed * 60) / GetIngameTicks(Tick); }
 	};
 
 	CClientStats m_aStats[MAX_CLIENTS];

--- a/src/game/client/prediction/entities/character.h
+++ b/src/game/client/prediction/entities/character.h
@@ -105,20 +105,20 @@ public:
 	bool m_LastRefillJumps;
 
 	// Setters/Getters because i don't want to modify vanilla vars access modifiers
-	int GetLastWeapon() { return m_LastWeapon; };
-	void SetLastWeapon(int LastWeap) { m_LastWeapon = LastWeap; };
-	int GetActiveWeapon() { return m_Core.m_ActiveWeapon; };
+	int GetLastWeapon() { return m_LastWeapon; }
+	void SetLastWeapon(int LastWeap) { m_LastWeapon = LastWeap; }
+	int GetActiveWeapon() { return m_Core.m_ActiveWeapon; }
 	void SetActiveWeapon(int ActiveWeap);
-	CCharacterCore GetCore() { return m_Core; };
-	void SetCore(CCharacterCore Core) { m_Core = Core; };
-	CCharacterCore *Core() { return &m_Core; };
-	bool GetWeaponGot(int Type) { return m_aWeapons[Type].m_Got; };
-	void SetWeaponGot(int Type, bool Value) { m_aWeapons[Type].m_Got = Value; };
-	int GetWeaponAmmo(int Type) { return m_aWeapons[Type].m_Ammo; };
-	void SetWeaponAmmo(int Type, int Value) { m_aWeapons[Type].m_Ammo = Value; };
-	void SetNinjaActivationDir(vec2 ActivationDir) { m_Ninja.m_ActivationDir = ActivationDir; };
-	void SetNinjaActivationTick(int ActivationTick) { m_Ninja.m_ActivationTick = ActivationTick; };
-	void SetNinjaCurrentMoveTime(int CurrentMoveTime) { m_Ninja.m_CurrentMoveTime = CurrentMoveTime; };
+	CCharacterCore GetCore() { return m_Core; }
+	void SetCore(CCharacterCore Core) { m_Core = Core; }
+	CCharacterCore *Core() { return &m_Core; }
+	bool GetWeaponGot(int Type) { return m_aWeapons[Type].m_Got; }
+	void SetWeaponGot(int Type, bool Value) { m_aWeapons[Type].m_Got = Value; }
+	int GetWeaponAmmo(int Type) { return m_aWeapons[Type].m_Ammo; }
+	void SetWeaponAmmo(int Type, int Value) { m_aWeapons[Type].m_Ammo = Value; }
+	void SetNinjaActivationDir(vec2 ActivationDir) { m_Ninja.m_ActivationDir = ActivationDir; }
+	void SetNinjaActivationTick(int ActivationTick) { m_Ninja.m_ActivationTick = ActivationTick; }
+	void SetNinjaCurrentMoveTime(int CurrentMoveTime) { m_Ninja.m_CurrentMoveTime = CurrentMoveTime; }
 	int GetCID() { return m_ID; }
 	void SetInput(CNetObj_PlayerInput *pNewInput)
 	{

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -634,14 +634,14 @@ class CEditor : public IEditor
 	CUIEx m_UIEx;
 
 public:
-	class IInput *Input() { return m_pInput; };
-	class IClient *Client() { return m_pClient; };
+	class IInput *Input() { return m_pInput; }
+	class IClient *Client() { return m_pClient; }
 	class CConfig *Config() { return m_pConfig; }
-	class IConsole *Console() { return m_pConsole; };
-	class IGraphics *Graphics() { return m_pGraphics; };
+	class IConsole *Console() { return m_pConsole; }
+	class IGraphics *Graphics() { return m_pGraphics; }
 	class ISound *Sound() { return m_pSound; }
-	class ITextRender *TextRender() { return m_pTextRender; };
-	class IStorage *Storage() { return m_pStorage; };
+	class ITextRender *TextRender() { return m_pTextRender; }
+	class IStorage *Storage() { return m_pStorage; }
 	CUI *UI() { return &m_UI; }
 	CUIEx *UIEx() { return &m_UIEx; }
 	CRenderTools *RenderTools() { return &m_RenderTools; }

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -449,9 +449,9 @@ public:
 	int m_VoteVictim;
 	int m_VoteEnforcer;
 
-	inline bool IsOptionVote() const { return m_VoteType == VOTE_TYPE_OPTION; };
-	inline bool IsKickVote() const { return m_VoteType == VOTE_TYPE_KICK; };
-	inline bool IsSpecVote() const { return m_VoteType == VOTE_TYPE_SPECTATE; };
+	inline bool IsOptionVote() const { return m_VoteType == VOTE_TYPE_OPTION; }
+	inline bool IsKickVote() const { return m_VoteType == VOTE_TYPE_KICK; }
+	inline bool IsSpecVote() const { return m_VoteType == VOTE_TYPE_SPECTATE; }
 
 	void SendRecord(int ClientID);
 	static void SendChatResponse(const char *pLine, void *pUser, ColorRGBA PrintColor = {1, 1, 1, 1});

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -31,8 +31,8 @@ public:
 	void Respawn(bool WeakHook = false); // with WeakHook == true the character will be spawned after all calls of Tick from other Players
 	CCharacter *ForceSpawn(vec2 Pos); // required for loading savegames
 	void SetTeam(int Team, bool DoChatMsg = true);
-	int GetTeam() const { return m_Team; };
-	int GetCID() const { return m_ClientID; };
+	int GetTeam() const { return m_Team; }
+	int GetCID() const { return m_ClientID; }
 	int GetClientVersion() const;
 	bool SetTimerType(int TimerType);
 

--- a/src/game/server/save.h
+++ b/src/game/server/save.h
@@ -24,7 +24,7 @@ public:
 	vec2 GetPos() const { return m_Pos; }
 	const char *GetName() const { return m_aName; }
 	int GetClientID() const { return m_ClientID; }
-	void SetClientID(int ClientID) { m_ClientID = ClientID; };
+	void SetClientID(int ClientID) { m_ClientID = ClientID; }
 
 private:
 	int m_ClientID;


### PR DESCRIPTION
For consistency with upstream (https://github.com/teeworlds/teeworlds/pull/2840) and

> to fix warnings in some IDEs and code analyzers.

I didn't find an option for clang format/tidy to enforce this.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
