### PR TITLE
Fix laser clipping. Closes #2176

### DIFF
--- a/src/game/server/entities/laser.cpp
+++ b/src/game/server/entities/laser.cpp
@@ -259,7 +259,7 @@ void CLaser::TickPaused()
 
 void CLaser::Snap(int SnappingClient)
 {
-	if(NetworkClipped(SnappingClient))
+	if(NetworkClipped(SnappingClient) && NetworkClipped(SnappingClient, m_From))
 		return;
 	CCharacter *OwnerChar = 0;
 	if(m_Owner >= 0)


### PR DESCRIPTION
I've found this bug in a different mod and fixed it. Then I've got idea to check if any of the upstreams (this and tw)is  affected and it turned out that this is already [fixed](https://github.com/teeworlds/teeworlds/commit/f3a1e68df912520381d978dc43c46d48370f6e1c) in teeworlds.
I've dropped my change and did cherry-pick to reduce the difference between codebases.