### PR TITLE
Add optional save_replay parameter, filename

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -3538,13 +3538,18 @@ void CClient::Con_SaveReplay(IConsole::IResult *pResult, void *pUserData)
 		if(Length <= 0)
 			pSelf->m_pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "replay", "ERROR: length must be greater than 0 second.");
 		else
-			pSelf->SaveReplay(Length);
+		{
+			if(pResult->NumArguments() >= 2)
+				pSelf->SaveReplay(Length, pResult->GetString(1));
+			else
+				pSelf->SaveReplay(Length);
+		}
 	}
 	else
 		pSelf->SaveReplay(g_Config.m_ClReplayLength);
 }
 
-void CClient::SaveReplay(const int Length)
+void CClient::SaveReplay(const int Length, const char Filename[])
 {
 	if(!g_Config.m_ClReplays)
 	{
@@ -3566,7 +3571,11 @@ void CClient::SaveReplay(const int Length)
 		char aDate[64];
 		str_timestamp(aDate, sizeof(aDate));
 
-		str_format(aFilename, sizeof(aFilename), "demos/replays/%s_%s (replay).demo", m_aCurrentMap, aDate);
+		if(str_comp(Filename, "") == 0)
+			str_format(aFilename, sizeof(aFilename), "demos/replays/%s_%s (replay).demo", m_aCurrentMap, aDate);
+		else
+			str_format(aFilename, sizeof(aFilename), "demos/replays/%s.demo", Filename);
+
 		char *pSrc = (&m_DemoRecorder[RECORDER_REPLAYS])->GetCurrentFilename();
 
 		// Slice the demo to get only the last cl_replay_length seconds
@@ -4172,7 +4181,7 @@ void CClient::RegisterCommands()
 	m_pConsole->Register("demo_play", "", CFGFLAG_CLIENT, Con_DemoPlay, this, "Play demo");
 	m_pConsole->Register("demo_speed", "i[speed]", CFGFLAG_CLIENT, Con_DemoSpeed, this, "Set demo speed");
 
-	m_pConsole->Register("save_replay", "?i[length]", CFGFLAG_CLIENT, Con_SaveReplay, this, "Save a replay of the last defined amount of seconds");
+	m_pConsole->Register("save_replay", "?i[length] ?s[filename]", CFGFLAG_CLIENT, Con_SaveReplay, this, "Save a replay of the last defined amount of seconds");
 	m_pConsole->Register("benchmark_quit", "i[seconds] r[file]", CFGFLAG_CLIENT | CFGFLAG_STORE, Con_BenchmarkQuit, this, "Benchmark frame times for number of seconds to file, then quit");
 
 	m_pConsole->Chain("cl_timeout_seed", ConchainTimeoutSeed, this);

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -3549,7 +3549,7 @@ void CClient::Con_SaveReplay(IConsole::IResult *pResult, void *pUserData)
 		pSelf->SaveReplay(g_Config.m_ClReplayLength);
 }
 
-void CClient::SaveReplay(const int Length, const char Filename[])
+void CClient::SaveReplay(const int Length, const char *pFilename)
 {
 	if(!g_Config.m_ClReplays)
 	{
@@ -3571,10 +3571,10 @@ void CClient::SaveReplay(const int Length, const char Filename[])
 		char aDate[64];
 		str_timestamp(aDate, sizeof(aDate));
 
-		if(str_comp(Filename, "") == 0)
+		if(str_comp(pFilename, "") == 0)
 			str_format(aFilename, sizeof(aFilename), "demos/replays/%s_%s (replay).demo", m_aCurrentMap, aDate);
 		else
-			str_format(aFilename, sizeof(aFilename), "demos/replays/%s.demo", Filename);
+			str_format(aFilename, sizeof(aFilename), "demos/replays/%s.demo", pFilename);
 
 		char *pSrc = (&m_DemoRecorder[RECORDER_REPLAYS])->GetCurrentFilename();
 

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -513,7 +513,7 @@ public:
 	virtual void DemoSliceBegin();
 	virtual void DemoSliceEnd();
 	virtual void DemoSlice(const char *pDstPath, CLIENTFUNC_FILTER pfnFilter, void *pUser);
-	virtual void SaveReplay(int Length);
+	virtual void SaveReplay(int Length, const char Filename[] = "");
 
 	virtual bool EditorHasUnsavedData() const { return m_pEditor->HasUnsavedData(); }
 

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -513,7 +513,7 @@ public:
 	virtual void DemoSliceBegin();
 	virtual void DemoSliceEnd();
 	virtual void DemoSlice(const char *pDstPath, CLIENTFUNC_FILTER pfnFilter, void *pUser);
-	virtual void SaveReplay(int Length, const char Filename[] = "");
+	virtual void SaveReplay(int Length, const char *pFilename = "");
 
 	virtual bool EditorHasUnsavedData() const { return m_pEditor->HasUnsavedData(); }
 


### PR DESCRIPTION
As suggested by bencie
> suggestion: would it be possible to add an optional parameter to save_replay so you could define the demo's name? save_replay [length] [demo name]

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
