### PR TITLE
 Improvement of the automatic completion of player names in chat

### DIFF
--- a/src/game/client/components/chat.h
+++ b/src/game/client/components/chat.h
@@ -4,9 +4,9 @@
 #define GAME_CLIENT_COMPONENTS_CHAT_H
 #include <engine/shared/config.h>
 #include <engine/shared/ringbuffer.h>
+
 #include <game/client/component.h>
 #include <game/client/lineinput.h>
-
 #include <game/client/skin.h>
 
 class CChat : public CComponent
@@ -80,6 +80,13 @@ class CChat : public CComponent
 	char m_aCompletionBuffer[256];
 	int m_PlaceholderOffset;
 	int m_PlaceholderLength;
+	struct CRateablePlayer
+	{
+		int ClientID;
+		int Score;
+	};
+	CRateablePlayer m_aPlayerCompletionList[MAX_CLIENTS];
+	int m_PlayerCompletionListLength;
 
 	struct CCommand
 	{


### PR DESCRIPTION
This should fix #659 or just improve the order of player names if you use automatic completion. 

So far it was so that first at the beginning of the name was searched for the input and then there was a second iteration through the alphabetically sorted list with names where the input does not appear at the beginning.

Now it is so that the position of the input in the name is used as an evaluation criterion to determine the position in the suggestion list. If the input is found at the beginning of the name, the score is 0 and the name is suggested first. If the input is found at position 6 in the name, the score is 6 and the name appears later in the suggestion list. If two names have the same score, the alphabetical sorting remains.


## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [x] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
