### PR TITLE
fix sound bug in back in time 3

### DIFF
--- a/src/engine/client/sound.cpp
+++ b/src/engine/client/sound.cpp
@@ -162,7 +162,7 @@ static void Mix(short *pFinalOut, unsigned Frames)
 					float r = Voice.m_Circle.m_Radius;
 					RangeX = r;
 
-					int Dist = (int)sqrtf((float)dx * dx + dy * dy); // nasty float
+					int Dist = (int)sqrtf((float)dx * dx + (float)dy * dy); // nasty float
 					if(Dist < r)
 					{
 						InVoiceField = true;


### PR DESCRIPTION

I don't know if there is an issue for this but I think we all know the sound bug at least since the release of Back in Time 3. Namely when you are in certain parts of a large map or as a spectator to the right edge of a large map then it comes to integer overflow and you hear all players in full volume (as if you would create the sounds yourself e.g. by your own shooting).

The integer overflow is even detected by our nice UndefinedBehaviorSanitizer:

And can look like this:
/home/daniel/Desktop/other_repos/ddnet/src/engine/client/sound.cpp:165:48: runtime error: signed integer overflow: -92336 * -92336 cannot be represented in type 'int'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /home/daniel/Desktop/other_repos/ddnet/src/engine/client/sound.cpp:165:48 in 

This is triggered even with smaller dy values, e.g. -46759 * -46759


The line looks like this:
int Dist = (int)sqrtf((float)dx * dx + dy * dy); // nasty float


Now there are many ways we could avoid such bugs in the future, but for now I did a symptom treatment and simply did the calculation as float as already done for dx which fixed the problem at least in my tests.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [x] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
