### PR TITLE
Enable -Wshadow=local

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -244,6 +244,7 @@ if(NOT MSVC AND NOT HAIKU)
   add_c_compiler_flag_if_supported(OUR_FLAGS_OWN -Wduplicated-branches)
   add_c_compiler_flag_if_supported(OUR_FLAGS_OWN -Wlogical-op)
   add_c_compiler_flag_if_supported(OUR_FLAGS_OWN -Wrestrict)
+  add_c_compiler_flag_if_supported(OUR_FLAGS_OWN -Wshadow=local)
   add_c_compiler_flag_if_supported(OUR_FLAGS_OWN -Wthread-safety)
   # TODO: Enable for C++ code except gtest
   #add_cxx_compiler_flag_if_supported(OUR_FLAGS_OWN "-Wuseless-cast")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -244,10 +244,11 @@ if(NOT MSVC AND NOT HAIKU)
   add_c_compiler_flag_if_supported(OUR_FLAGS_OWN -Wduplicated-branches)
   add_c_compiler_flag_if_supported(OUR_FLAGS_OWN -Wlogical-op)
   add_c_compiler_flag_if_supported(OUR_FLAGS_OWN -Wrestrict)
-  add_c_compiler_flag_if_supported(OUR_FLAGS_OWN -Wshadow=local)
+  add_c_compiler_flag_if_supported(OUR_FLAGS_OWN -Wshadow=local) # global has too many occurences
   add_c_compiler_flag_if_supported(OUR_FLAGS_OWN -Wthread-safety)
-  # TODO: Enable for C++ code except gtest
-  #add_cxx_compiler_flag_if_supported(OUR_FLAGS_OWN "-Wuseless-cast")
+  # add_c_compiler_flag_if_supported(OUR_FLAGS_OWN -Wdouble-promotion) # Many occurences
+  # add_c_compiler_flag_if_supported(OUR_FLAGS_OWN -Wnull-dereference) # Many occurences
+  # add_c_compiler_flag_if_supported(OUR_FLAGS_OWN -Wuseless-cast) # TODO: Enable for C++ code except gtest
 endif()
 
 if(MSVC)

--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -1051,13 +1051,13 @@ int CGraphicsBackend_SDL_OpenGL::Init(const char *pName, int *pScreen, int *pWid
 	}
 
 	{
-		CCommandBuffer::SCommand_Update_Viewport CmdSDL;
-		CmdSDL.m_X = 0;
-		CmdSDL.m_Y = 0;
+		CCommandBuffer::SCommand_Update_Viewport CmdSDL2;
+		CmdSDL2.m_X = 0;
+		CmdSDL2.m_Y = 0;
 
-		CmdSDL.m_Width = *pCurrentWidth;
-		CmdSDL.m_Height = *pCurrentHeight;
-		CmdBuffer.AddCommandUnsafe(CmdSDL);
+		CmdSDL2.m_Width = *pCurrentWidth;
+		CmdSDL2.m_Height = *pCurrentHeight;
+		CmdBuffer.AddCommandUnsafe(CmdSDL2);
 		RunBuffer(&CmdBuffer);
 		WaitForIdle();
 		CmdBuffer.Reset();

--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -1121,7 +1121,7 @@ void CGraphics_Threaded::RenderTileLayer(int BufferContainerIndex, float *pColor
 		// kick command buffer and try again
 		KickCommandBuffer();
 
-		void *Data = m_pCommandBuffer->AllocData((sizeof(char *) + sizeof(unsigned int)) * NumIndicesOffet);
+		Data = m_pCommandBuffer->AllocData((sizeof(char *) + sizeof(unsigned int)) * NumIndicesOffet);
 		if(Data == 0x0)
 		{
 			dbg_msg("graphics", "failed to allocate data for vertices");

--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -678,10 +678,10 @@ void CServerBrowser::Set(const NETADDR &Addr, int Type, int Token, const CServer
 			NETADDR Broadcast;
 			mem_zero(&Broadcast, sizeof(Broadcast));
 			Broadcast.type = m_pNetClient->NetType() | NETTYPE_LINK_BROADCAST;
-			int Token = GenerateToken(Broadcast);
+			int TokenBC = GenerateToken(Broadcast);
 			bool Drop = false;
-			Drop = Drop || BasicToken != GetBasicToken(Token);
-			Drop = Drop || (pInfo->m_Type == SERVERINFO_EXTENDED && ExtraToken != GetExtraToken(Token));
+			Drop = Drop || BasicToken != GetBasicToken(TokenBC);
+			Drop = Drop || (pInfo->m_Type == SERVERINFO_EXTENDED && ExtraToken != GetExtraToken(TokenBC));
 			if(Drop)
 			{
 				return;
@@ -696,10 +696,10 @@ void CServerBrowser::Set(const NETADDR &Addr, int Type, int Token, const CServer
 			{
 				return;
 			}
-			int Token = GenerateToken(Addr);
+			int TokenAddr = GenerateToken(Addr);
 			bool Drop = false;
-			Drop = Drop || BasicToken != GetBasicToken(Token);
-			Drop = Drop || (pInfo->m_Type == SERVERINFO_EXTENDED && ExtraToken != GetExtraToken(Token));
+			Drop = Drop || BasicToken != GetBasicToken(TokenAddr);
+			Drop = Drop || (pInfo->m_Type == SERVERINFO_EXTENDED && ExtraToken != GetExtraToken(TokenAddr));
 			if(Drop)
 			{
 				return;
@@ -1619,11 +1619,11 @@ void CServerBrowser::CountryFilterClean(int Network)
 	char aNewList[128];
 	aNewList[0] = '\0';
 
-	for(auto &Network : m_aNetworks)
+	for(auto &Net : m_aNetworks)
 	{
-		for(int i = 0; i < Network.m_NumCountries; i++)
+		for(int i = 0; i < Net.m_NumCountries; i++)
 		{
-			const char *pName = Network.m_aCountries[i].m_aName;
+			const char *pName = Net.m_aCountries[i].m_aName;
 			if(DDNetFiltered(pExcludeCountries, pName))
 			{
 				char aBuf[128];

--- a/src/engine/client/text.cpp
+++ b/src/engine/client/text.cpp
@@ -1086,18 +1086,18 @@ public:
 		int SelectionStartChar = -1;
 		int SelectionEndChar = -1;
 
-		auto &&CheckInsideChar = [&](bool CheckOuter, int CursorX, int CursorY, float LastCharX, float LastCharWidth, float CharX, float CharWidth, float CharY) -> bool {
-			return (LastCharX - LastCharWidth / 2 <= CursorX &&
-				       CharX + CharWidth / 2 > CursorX &&
-				       CharY - Size <= CursorY &&
-				       CharY > CursorY) ||
+		auto &&CheckInsideChar = [&](bool CheckOuter, int CursorX_, int CursorY_, float LastCharX, float LastCharWidth, float CharX, float CharWidth, float CharY) -> bool {
+			return (LastCharX - LastCharWidth / 2 <= CursorX_ &&
+				       CharX + CharWidth / 2 > CursorX_ &&
+				       CharY - Size <= CursorY_ &&
+				       CharY > CursorY_) ||
 			       (CheckOuter &&
-				       CharY - Size > CursorY);
+				       CharY - Size > CursorY_);
 		};
-		auto &&CheckSelectionStart = [&](bool CheckOuter, int CursorX, int CursorY, int &SelectionChar, bool &SelectionUsedCase, float LastCharX, float LastCharWidth, float CharX, float CharWidth, float CharY) {
+		auto &&CheckSelectionStart = [&](bool CheckOuter, int CursorX_, int CursorY_, int &SelectionChar, bool &SelectionUsedCase, float LastCharX, float LastCharWidth, float CharX, float CharWidth, float CharY) {
 			if(!SelectionStarted && !SelectionUsedCase)
 			{
-				if(CheckInsideChar(CheckOuter, CursorX, CursorY, LastCharX, LastCharWidth, CharX, CharWidth, CharY))
+				if(CheckInsideChar(CheckOuter, CursorX_, CursorY_, LastCharX, LastCharWidth, CharX, CharWidth, CharY))
 				{
 					SelectionChar = CharacterCounter;
 					SelectionStarted = !SelectionStarted;
@@ -1105,17 +1105,17 @@ public:
 				}
 			}
 		};
-		auto &&CheckOutsideChar = [&](bool CheckOuter, int CursorX, int CursorY, float CharX, float CharWidth, float CharY) -> bool {
-			return (CharX + CharWidth / 2 > CursorX &&
-				       CharY - Size <= CursorY &&
-				       CharY > CursorY) ||
+		auto &&CheckOutsideChar = [&](bool CheckOuter, int CursorX_, int CursorY_, float CharX, float CharWidth, float CharY) -> bool {
+			return (CharX + CharWidth / 2 > CursorX_ &&
+				       CharY - Size <= CursorY_ &&
+				       CharY > CursorY_) ||
 			       (CheckOuter &&
-				       CharY <= CursorY);
+				       CharY <= CursorY_);
 		};
-		auto &&CheckSelectionEnd = [&](bool CheckOuter, int CursorX, int CursorY, int &SelectionChar, bool &SelectionUsedCase, float CharX, float CharWidth, float CharY) {
+		auto &&CheckSelectionEnd = [&](bool CheckOuter, int CursorX_, int CursorY_, int &SelectionChar, bool &SelectionUsedCase, float CharX, float CharWidth, float CharY) {
 			if(SelectionStarted && !SelectionUsedCase)
 			{
-				if(CheckOutsideChar(CheckOuter, CursorX, CursorY, CharX, CharWidth, CharY))
+				if(CheckOutsideChar(CheckOuter, CursorX_, CursorY_, CharX, CharWidth, CharY))
 				{
 					SelectionChar = CharacterCounter;
 					SelectionStarted = !SelectionStarted;

--- a/src/engine/client/video.cpp
+++ b/src/engine/client/video.cpp
@@ -146,9 +146,9 @@ void CVideo::Start()
 		int Ret = avio_open(&m_pFormatContext->pb, aWholePath, AVIO_FLAG_WRITE);
 		if(Ret < 0)
 		{
-			char aBuf[AV_ERROR_MAX_STRING_SIZE];
-			av_strerror(Ret, aBuf, sizeof(aBuf));
-			dbg_msg("video_recorder", "Could not open '%s': %s", aWholePath, aBuf);
+			char aError[AV_ERROR_MAX_STRING_SIZE];
+			av_strerror(Ret, aError, sizeof(aError));
+			dbg_msg("video_recorder", "Could not open '%s': %s", aWholePath, aError);
 			return;
 		}
 	}
@@ -166,9 +166,9 @@ void CVideo::Start()
 	int Ret = avformat_write_header(m_pFormatContext, &m_pOptDict);
 	if(Ret < 0)
 	{
-		char aBuf[AV_ERROR_MAX_STRING_SIZE];
-		av_strerror(Ret, aBuf, sizeof(aBuf));
-		dbg_msg("video_recorder", "Error occurred when opening output file: %s", aBuf);
+		char aError[AV_ERROR_MAX_STRING_SIZE];
+		av_strerror(Ret, aError, sizeof(aError));
+		dbg_msg("video_recorder", "Error occurred when opening output file: %s", aError);
 		return;
 	}
 	m_Recording = true;

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -848,12 +848,11 @@ void CServer::DoSnapshot()
 	if(m_aDemoRecorder[MAX_CLIENTS].IsRecording())
 	{
 		char aData[CSnapshot::MAX_SIZE];
-		int SnapshotSize;
 
 		// build snap and possibly add some messages
 		m_SnapshotBuilder.Init();
 		GameServer()->OnSnap(-1);
-		SnapshotSize = m_SnapshotBuilder.Finish(aData);
+		int SnapshotSize = m_SnapshotBuilder.Finish(aData);
 
 		// write snapshot
 		m_aDemoRecorder[MAX_CLIENTS].RecordSnapshot(Tick(), aData, SnapshotSize);
@@ -879,7 +878,6 @@ void CServer::DoSnapshot()
 			CSnapshot *pData = (CSnapshot *)aData; // Fix compiler warning for strict-aliasing
 			char aDeltaData[CSnapshot::MAX_SIZE];
 			char aCompData[CSnapshot::MAX_SIZE];
-			int SnapshotSize;
 			int Crc;
 			static CSnapshot s_EmptySnap;
 			CSnapshot *pDeltashot = &s_EmptySnap;
@@ -892,7 +890,7 @@ void CServer::DoSnapshot()
 			GameServer()->OnSnap(i);
 
 			// finish snapshot
-			SnapshotSize = m_SnapshotBuilder.Finish(pData);
+			int SnapshotSize = m_SnapshotBuilder.Finish(pData);
 
 			if(m_aDemoRecorder[i].IsRecording())
 			{
@@ -932,7 +930,6 @@ void CServer::DoSnapshot()
 			if(DeltaSize)
 			{
 				// compress it
-				int SnapshotSize;
 				const int MaxSize = MAX_SNAPSHOT_PACKSIZE;
 				int NumPackets;
 
@@ -1512,9 +1509,9 @@ void CServer::ProcessClientPacket(CNetChunk *pPacket)
 				m_aClients[ClientID].m_State = CClient::STATE_INGAME;
 				if(IsSixup(ClientID))
 				{
-					CMsgPacker Msg(4, true, true); //NETMSG_SERVERINFO //TODO: Import the shared protocol from 7 aswell
-					GetServerInfoSixup(&Msg, -1, false);
-					SendMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_FLUSH, ClientID);
+					CMsgPacker Msgp(4, true, true); //NETMSG_SERVERINFO //TODO: Import the shared protocol from 7 aswell
+					GetServerInfoSixup(&Msgp, -1, false);
+					SendMsg(&Msgp, MSGFLAG_VITAL | MSGFLAG_FLUSH, ClientID);
 				}
 				GameServer()->OnClientEnter(ClientID);
 			}
@@ -1544,10 +1541,10 @@ void CServer::ProcessClientPacket(CNetChunk *pPacket)
 			{
 				int TimeLeft = ((TickStartTime(IntendedTick) - time_get()) * 1000) / time_freq();
 
-				CMsgPacker Msg(NETMSG_INPUTTIMING, true);
-				Msg.AddInt(IntendedTick);
-				Msg.AddInt(TimeLeft);
-				SendMsg(&Msg, 0, ClientID);
+				CMsgPacker Msgp(NETMSG_INPUTTIMING, true);
+				Msgp.AddInt(IntendedTick);
+				Msgp.AddInt(TimeLeft);
+				SendMsg(&Msgp, 0, ClientID);
 			}
 
 			m_aClients[ClientID].m_LastInputTick = IntendedTick;
@@ -1641,15 +1638,15 @@ void CServer::ProcessClientPacket(CNetChunk *pPacket)
 					{
 						if(!IsSixup(ClientID))
 						{
-							CMsgPacker Msg(NETMSG_RCON_AUTH_STATUS, true);
-							Msg.AddInt(1); //authed
-							Msg.AddInt(1); //cmdlist
-							SendMsg(&Msg, MSGFLAG_VITAL, ClientID);
+							CMsgPacker Msgp(NETMSG_RCON_AUTH_STATUS, true);
+							Msgp.AddInt(1); //authed
+							Msgp.AddInt(1); //cmdlist
+							SendMsg(&Msgp, MSGFLAG_VITAL, ClientID);
 						}
 						else
 						{
-							CMsgPacker Msg(11, true, true); //NETMSG_RCON_AUTH_ON
-							SendMsg(&Msg, MSGFLAG_VITAL, ClientID);
+							CMsgPacker Msgp(11, true, true); //NETMSG_RCON_AUTH_ON
+							SendMsg(&Msgp, MSGFLAG_VITAL, ClientID);
 						}
 
 						m_aClients[ClientID].m_Authed = AuthLevel; // Keeping m_Authed around is unwise...
@@ -1710,8 +1707,8 @@ void CServer::ProcessClientPacket(CNetChunk *pPacket)
 		}
 		else if(Msg == NETMSG_PING)
 		{
-			CMsgPacker Msg(NETMSG_PING_REPLY, true);
-			SendMsg(&Msg, 0, ClientID);
+			CMsgPacker Msgp(NETMSG_PING_REPLY, true);
+			SendMsg(&Msgp, 0, ClientID);
 		}
 		else if(Msg == NETMSG_PINGEX)
 		{
@@ -1720,9 +1717,9 @@ void CServer::ProcessClientPacket(CNetChunk *pPacket)
 			{
 				return;
 			}
-			CMsgPacker Msg(NETMSG_PONGEX, true);
-			Msg.AddRaw(pID, sizeof(*pID));
-			SendMsg(&Msg, MSGFLAG_FLUSH, ClientID);
+			CMsgPacker Msgp(NETMSG_PONGEX, true);
+			Msgp.AddRaw(pID, sizeof(*pID));
+			SendMsg(&Msgp, MSGFLAG_FLUSH, ClientID);
 		}
 		else
 		{
@@ -2268,7 +2265,6 @@ void CServer::PumpNetwork(bool PacketWaiting)
 	{
 		unsigned char aBuffer[NET_MAX_PAYLOAD];
 		int Flags;
-		CNetChunk Packet;
 		mem_zero(&Packet, sizeof(Packet));
 		Packet.m_pData = aBuffer;
 		while(Antibot()->OnEngineSimulateClientMessage(&Packet.m_ClientID, aBuffer, sizeof(aBuffer), &Packet.m_DataSize, &Flags))
@@ -2492,7 +2488,6 @@ int CServer::Run()
 	Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "server", "version " GAME_RELEASE_VERSION " on " CONF_PLATFORM_STRING " " CONF_ARCH_STRING);
 	if(GIT_SHORTREV_HASH)
 	{
-		char aBuf[64];
 		str_format(aBuf, sizeof(aBuf), "git revision hash: %s", GIT_SHORTREV_HASH);
 		Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "server", aBuf);
 	}
@@ -2607,8 +2602,6 @@ int CServer::Run()
 							char aAddrStr[NETADDR_MAXSTRSIZE];
 							net_addr_str(m_NetServer.ClientAddr(ClientID), aAddrStr, sizeof(aAddrStr), true);
 
-							char aBuf[256];
-
 							str_format(aBuf, sizeof(aBuf), "ClientID=%d addr=<{%s}> secure=%s blacklisted", ClientID, aAddrStr, m_NetServer.HasSecurityToken(ClientID) ? "yes" : "no");
 
 							Console()->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "dnsbl", aBuf);
@@ -2712,7 +2705,7 @@ int CServer::Run()
 				m_ReloadedWhenEmpty = false;
 
 				set_new_tick();
-				int64_t t = time_get();
+				t = time_get();
 				int x = (TickStartTime(m_CurrentGameTick + 1) - t) * 1000000 / time_freq() + 1;
 
 				PacketWaiting = x > 0 ? net_socket_read_wait(m_NetServer.Socket(), x) : true;

--- a/src/engine/shared/netban.cpp
+++ b/src/engine/shared/netban.cpp
@@ -373,11 +373,11 @@ int CNetBan::UnbanByIndex(int Index)
 	}
 	else
 	{
-		CBanRange *pBan = m_BanRangePool.Get(Index - m_BanAddrPool.Num());
-		if(pBan)
+		CBanRange *pBanRange = m_BanRangePool.Get(Index - m_BanAddrPool.Num());
+		if(pBanRange)
 		{
-			NetToString(&pBan->m_Data, aBuf, sizeof(aBuf));
-			Result = m_BanRangePool.Remove(pBan);
+			NetToString(&pBanRange->m_Data, aBuf, sizeof(aBuf));
+			Result = m_BanRangePool.Remove(pBanRange);
 		}
 		else
 		{
@@ -416,11 +416,11 @@ bool CNetBan::IsBanned(const NETADDR *pOrigAddr, char *pBuf, unsigned BufferSize
 	// check ban ranges
 	for(int i = Length - 1; i >= 0; --i)
 	{
-		for(CBanRange *pBan = m_BanRangePool.First(&aHash[i]); pBan; pBan = pBan->m_pHashNext)
+		for(CBanRange *pBanRange = m_BanRangePool.First(&aHash[i]); pBanRange; pBanRange = pBanRange->m_pHashNext)
 		{
-			if(NetMatch(&pBan->m_Data, pAddr, i, Length))
+			if(NetMatch(&pBanRange->m_Data, pAddr, i, Length))
 			{
-				MakeBanInfo(pBan, pBuf, BufferSize, MSGTYPE_PLAYER);
+				MakeBanInfo(pBanRange, pBuf, BufferSize, MSGTYPE_PLAYER);
 				return true;
 			}
 		}

--- a/src/engine/shared/serverinfo.cpp
+++ b/src/engine/shared/serverinfo.cpp
@@ -93,13 +93,13 @@ bool CServerInfo2::FromJsonRaw(CServerInfo2 *pOut, const json_value *pJson)
 	for(unsigned i = 0; i < Clients.u.array.length; i++)
 	{
 		const json_value &Client = Clients[i];
-		const json_value &Name = Client["name"];
+		const json_value &ClientName = Client["name"];
 		const json_value &Clan = Client["clan"];
 		const json_value &Country = Client["country"];
 		const json_value &Score = Client["score"];
 		const json_value &IsPlayer = Client["is_player"];
 		Error = false;
-		Error = Error || Name.type != json_string;
+		Error = Error || ClientName.type != json_string;
 		Error = Error || Clan.type != json_string;
 		Error = Error || Country.type != json_integer;
 		Error = Error || Score.type != json_integer;
@@ -111,7 +111,7 @@ bool CServerInfo2::FromJsonRaw(CServerInfo2 *pOut, const json_value *pJson)
 		if(i < SERVERINFO_MAX_CLIENTS)
 		{
 			CClient *pClient = &pOut->m_aClients[i];
-			str_copy(pClient->m_aName, Name, sizeof(pClient->m_aName));
+			str_copy(pClient->m_aName, ClientName, sizeof(pClient->m_aName));
 			str_copy(pClient->m_aClan, Clan, sizeof(pClient->m_aClan));
 			pClient->m_Country = json_int_get(&Country);
 			pClient->m_Score = json_int_get(&Score);

--- a/src/engine/shared/websockets.cpp
+++ b/src/engine/shared/websockets.cpp
@@ -120,13 +120,13 @@ static int websocket_callback(struct lws *wsi, enum lws_callback_reasons reason,
 		websocket_chunk *chunk = (websocket_chunk *)pss->send_buffer.First();
 		if(chunk == NULL)
 			break;
-		int len = chunk->size - chunk->read;
+		int chunk_len = chunk->size - chunk->read;
 		int n =
 			lws_write(wsi, &chunk->data[LWS_SEND_BUFFER_PRE_PADDING + chunk->read],
 				chunk->size - chunk->read, LWS_WRITE_BINARY);
 		if(n < 0)
 			return 1;
-		if(n < len)
+		if(n < chunk_len)
 		{
 			chunk->read += n;
 			lws_callback_on_writable(wsi);

--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -693,36 +693,36 @@ void CChat::AddLine(int ClientID, int Team, const char *pLine)
 	if(*p == 0)
 		return;
 
-	auto &&FChatMsgCheckAndPrint = [this](CLine *pLine) {
-		if(pLine->m_ClientID < 0) // server or client message
+	auto &&FChatMsgCheckAndPrint = [this](CLine *pLine_) {
+		if(pLine_->m_ClientID < 0) // server or client message
 		{
 			if(Client()->State() != IClient::STATE_DEMOPLAYBACK)
-				StoreSave(pLine->m_aText);
+				StoreSave(pLine_->m_aText);
 		}
 
 		char aBuf[1024];
-		str_format(aBuf, sizeof(aBuf), "%s%s%s", pLine->m_aName, pLine->m_ClientID >= 0 ? ": " : "", pLine->m_aText);
+		str_format(aBuf, sizeof(aBuf), "%s%s%s", pLine_->m_aName, pLine_->m_ClientID >= 0 ? ": " : "", pLine_->m_aText);
 
 		ColorRGBA ChatLogColor{1, 1, 1, 1};
-		if(pLine->m_Highlighted)
+		if(pLine_->m_Highlighted)
 		{
 			ChatLogColor = color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClMessageHighlightColor));
 		}
 		else
 		{
-			if(pLine->m_Friend && g_Config.m_ClMessageFriend)
+			if(pLine_->m_Friend && g_Config.m_ClMessageFriend)
 				ChatLogColor = color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClMessageFriendColor));
-			else if(pLine->m_Team)
+			else if(pLine_->m_Team)
 				ChatLogColor = color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClMessageTeamColor));
-			else if(pLine->m_ClientID == -1) // system
+			else if(pLine_->m_ClientID == -1) // system
 				ChatLogColor = color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClMessageSystemColor));
-			else if(pLine->m_ClientID == -2) // client
+			else if(pLine_->m_ClientID == -2) // client
 				ChatLogColor = color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClMessageClientColor));
 			else // regular message
 				ChatLogColor = color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClMessageColor));
 		}
 
-		Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, pLine->m_Whisper ? "whisper" : (pLine->m_Team ? "teamchat" : "chat"), aBuf, ChatLogColor);
+		Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, pLine_->m_Whisper ? "whisper" : (pLine_->m_Team ? "teamchat" : "chat"), aBuf, ChatLogColor);
 	};
 
 	while(*p)

--- a/src/game/client/components/effects.cpp
+++ b/src/game/client/components/effects.cpp
@@ -227,7 +227,6 @@ void CEffects::Explosion(vec2 Pos)
 	// add the smoke
 	for(int i = 0; i < 24; i++)
 	{
-		CParticle p;
 		p.SetDefault();
 		p.m_Spr = SPRITE_PART_SMOKE;
 		p.m_Pos = Pos;

--- a/src/game/client/components/emoticon.cpp
+++ b/src/game/client/components/emoticon.cpp
@@ -189,9 +189,9 @@ void CEmoticon::Emote(int Emoticon)
 
 	if(g_Config.m_ClDummyCopyMoves)
 	{
-		CMsgPacker Msg(NETMSGTYPE_CL_EMOTICON, false);
-		Msg.AddInt(Emoticon);
-		Client()->SendMsg(!g_Config.m_ClDummy, &Msg, MSGFLAG_VITAL);
+		CMsgPacker MsgDummy(NETMSGTYPE_CL_EMOTICON, false);
+		MsgDummy.AddInt(Emoticon);
+		Client()->SendMsg(!g_Config.m_ClDummy, &MsgDummy, MSGFLAG_VITAL);
 	}
 }
 

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -159,7 +159,7 @@ int CMenus::DoButton_Toggle(const void *pID, int Checked, const CUIRect *pRect, 
 	if(UI()->HotItem() == pID && Active)
 	{
 		RenderTools()->SelectSprite(SPRITE_GUIBUTTON_HOVER);
-		IGraphics::CQuadItem QuadItem(pRect->x, pRect->y, pRect->w, pRect->h);
+		QuadItem = IGraphics::CQuadItem(pRect->x, pRect->y, pRect->w, pRect->h);
 		Graphics()->QuadsDrawTL(&QuadItem, 1);
 	}
 	Graphics()->QuadsEnd();
@@ -1635,7 +1635,6 @@ int CMenus::Render()
 			Box.VMargin(20.f / UI()->Scale(), &Box);
 			if(m_pClient->Editor()->HasUnsavedData())
 			{
-				char aBuf[256];
 				str_format(aBuf, sizeof(aBuf), "%s\n%s", Localize("There's an unsaved map in the editor, you might want to save it before you quit the game."), Localize("Quit anyway?"));
 				Props.m_MaxWidth = Part.w - 20.0f;
 				UI()->DoLabelScaled(&Box, aBuf, 20.f, TEXTALIGN_LEFT, Props);
@@ -1902,7 +1901,6 @@ int CMenus::Render()
 				// delete demo
 				if(m_DemolistSelectedIndex >= 0 && !m_DemolistSelectedIsDir)
 				{
-					char aBuf[512];
 					str_format(aBuf, sizeof(aBuf), "%s/%s", m_aCurrentDemoFolder, m_lDemos[m_DemolistSelectedIndex].m_aFilename);
 					if(Storage()->RemoveFile(aBuf, m_lDemos[m_DemolistSelectedIndex].m_StorageType))
 					{
@@ -2115,7 +2113,6 @@ int CMenus::Render()
 			{
 				m_Popup = POPUP_NONE;
 				// render video
-				char aBuf[512];
 				str_format(aBuf, sizeof(aBuf), "%s/%s", m_aCurrentDemoFolder, m_lDemos[m_DemolistSelectedIndex].m_aFilename);
 				const char *pError = Client()->DemoPlayer_Render(aBuf, m_lDemos[m_DemolistSelectedIndex].m_StorageType, m_aCurrentDemoFile, m_Speed);
 				m_Speed = 4;
@@ -2178,7 +2175,6 @@ int CMenus::Render()
 			Box.HSplitBottom(24.f, &Box, &Part);
 
 			Part.VSplitLeft(30.0f, 0, &Part);
-			char aBuf[128];
 			str_format(aBuf, sizeof(aBuf), "%s\n(%s)",
 				Localize("Show DDNet map finishes in server browser"),
 				Localize("transmits your player name to info2.ddnet.tw"));
@@ -2609,7 +2605,7 @@ void CMenus::RenderBackground()
 		for(int x = -2; x < (int)(sh / Size); x++)
 		{
 			Graphics()->SetColor(0, 0, 0, 0.045f);
-			IGraphics::CQuadItem QuadItem((x - OffsetTime) * Size * 2 + (y & 1) * Size, (y + OffsetTime) * Size, Size, Size);
+			QuadItem = IGraphics::CQuadItem((x - OffsetTime) * Size * 2 + (y & 1) * Size, (y + OffsetTime) * Size, Size, Size);
 			Graphics()->QuadsDrawTL(&QuadItem, 1);
 		}
 	Graphics()->QuadsEnd();

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -848,8 +848,8 @@ void CMenus::RenderServerbrowserFilters(CUIRect View)
 					Rect.w = TypesWidth;
 					Rect.h = TypesHeight;
 
-					int Button = UI()->DoButtonLogic(&s_aTypeButtons[TypeIndex], "", 0, &Rect);
-					if(Button == 1 || Button == 2)
+					int Click = UI()->DoButtonLogic(&s_aTypeButtons[TypeIndex], "", 0, &Rect);
+					if(Click == 1 || Click == 2)
 					{
 						// left/right click to toggle filter
 						if(pFilterExcludeTypes[0] == '\0')
@@ -889,7 +889,7 @@ void CMenus::RenderServerbrowserFilters(CUIRect View)
 
 						ServerBrowser()->Refresh(ServerBrowser()->GetCurrentType());
 					}
-					else if(Button == 3)
+					else if(Click == 3)
 					{
 						// middle click to reset (re-enable all)
 						pFilterExcludeTypes[0] = '\0';
@@ -943,8 +943,8 @@ void CMenus::RenderServerbrowserFilters(CUIRect View)
 					Rect.w = FlagWidth;
 					Rect.h = FlagHeight;
 
-					int Button = UI()->DoButtonLogic(&s_aFlagButtons[CountryIndex], "", 0, &Rect);
-					if(Button == 1 || Button == 2)
+					int Click = UI()->DoButtonLogic(&s_aFlagButtons[CountryIndex], "", 0, &Rect);
+					if(Click == 1 || Click == 2)
 					{
 						// left/right click to toggle filter
 						if(pFilterExcludeCountries[0] == '\0')
@@ -984,7 +984,7 @@ void CMenus::RenderServerbrowserFilters(CUIRect View)
 
 						ServerBrowser()->Refresh(ServerBrowser()->GetCurrentType());
 					}
-					else if(Button == 3)
+					else if(Click == 3)
 					{
 						// middle click to reset (re-enable all)
 						pFilterExcludeCountries[0] = '\0';

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -339,17 +339,16 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 			else
 			{
 				static float PrevAmount = 0.0f;
-				float Amount = (UI()->MouseX() - SeekBar.x) / SeekBar.w;
+				float AmountSeek = (UI()->MouseX() - SeekBar.x) / SeekBar.w;
 
 				if(Input()->KeyIsPressed(KEY_LSHIFT) || Input()->KeyIsPressed(KEY_RSHIFT))
 				{
-					Amount = PrevAmount + (Amount - PrevAmount) * 0.05f;
+					AmountSeek = PrevAmount + (AmountSeek - PrevAmount) * 0.05f;
 
-					if(Amount > 0.0f && Amount < 1.0f && absolute(PrevAmount - Amount) >= 0.0001f)
+					if(AmountSeek > 0.0f && AmountSeek < 1.0f && absolute(PrevAmount - AmountSeek) >= 0.0001f)
 					{
-						//PrevAmount = Amount;
 						m_pClient->m_SuppressEvents = true;
-						DemoPlayer()->SeekPercent(Amount);
+						DemoPlayer()->SeekPercent(AmountSeek);
 						m_pClient->m_SuppressEvents = false;
 						m_pClient->m_MapLayersBackGround.EnvelopeUpdate();
 						m_pClient->m_MapLayersForeGround.EnvelopeUpdate();
@@ -357,11 +356,11 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 				}
 				else
 				{
-					if(Amount > 0.0f && Amount < 1.0f && absolute(PrevAmount - Amount) >= 0.001f)
+					if(AmountSeek > 0.0f && AmountSeek < 1.0f && absolute(PrevAmount - AmountSeek) >= 0.001f)
 					{
-						PrevAmount = Amount;
+						PrevAmount = AmountSeek;
 						m_pClient->m_SuppressEvents = true;
-						DemoPlayer()->SeekPercent(Amount);
+						DemoPlayer()->SeekPercent(AmountSeek);
 						m_pClient->m_SuppressEvents = false;
 						m_pClient->m_MapLayersBackGround.EnvelopeUpdate();
 						m_pClient->m_MapLayersForeGround.EnvelopeUpdate();
@@ -1112,15 +1111,15 @@ void CMenus::RenderDemoList(CUIRect MainView)
 		{
 			if(Selected)
 			{
-				CUIRect r = Row;
-				r.Margin(0.5f, &r);
-				RenderTools()->DrawUIRect(&r, ColorRGBA(1, 1, 1, 0.5f), CUI::CORNER_ALL, 4.0f);
+				CUIRect Rect = Row;
+				Rect.Margin(0.5f, &Rect);
+				RenderTools()->DrawUIRect(&Rect, ColorRGBA(1, 1, 1, 0.5f), CUI::CORNER_ALL, 4.0f);
 			}
 			else if(UI()->MouseInside(&SelectHitBox))
 			{
-				CUIRect r = Row;
-				r.Margin(0.5f, &r);
-				RenderTools()->DrawUIRect(&r, ColorRGBA(1, 1, 1, 0.25f), CUI::CORNER_ALL, 4.0f);
+				CUIRect Rect = Row;
+				Rect.Margin(0.5f, &Rect);
+				RenderTools()->DrawUIRect(&Rect, ColorRGBA(1, 1, 1, 0.25f), CUI::CORNER_ALL, 4.0f);
 			}
 
 			// clip the selection

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -664,7 +664,7 @@ void CMenus::RenderServerControl(CUIRect MainView)
 
 	// vote menu
 	{
-		CUIRect Button, QuickSearch;
+		CUIRect QuickSearch;
 
 		// render quick search
 		{

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -71,7 +71,7 @@ void CMenus::RenderSettingsGeneral(CUIRect MainView)
 	static int s_ClShowConsole = g_Config.m_ClShowConsole;
 #endif
 
-	char aBuf[128];
+	char aBuf[128 + IO_MAX_PATH_LENGTH];
 	CUIRect Label, Button, Left, Right, Game, Client;
 	MainView.HSplitTop(150.0f, &Game, &Client);
 
@@ -206,7 +206,6 @@ void CMenus::RenderSettingsGeneral(CUIRect MainView)
 				g_Config.m_ClAutoDemoRecord ^= 1;
 
 			Right.HSplitTop(20.0f, &Label, &Right);
-			char aBuf[64];
 			if(g_Config.m_ClAutoDemoMax)
 				str_format(aBuf, sizeof(aBuf), "%s: %i", Localize("Max demos"), g_Config.m_ClAutoDemoMax);
 			else
@@ -232,7 +231,6 @@ void CMenus::RenderSettingsGeneral(CUIRect MainView)
 
 		Left.HSplitTop(10.0f, 0, &Left);
 		Left.HSplitTop(20.0f, &Label, &Left);
-		char aBuf[64];
 		if(g_Config.m_ClRefreshRate)
 			str_format(aBuf, sizeof(aBuf), "%s: %i Hz", Localize("Refresh Rate"), g_Config.m_ClRefreshRate);
 		else
@@ -262,7 +260,6 @@ void CMenus::RenderSettingsGeneral(CUIRect MainView)
 		static int s_SettingsButtonID = 0;
 		if(DoButton_Menu(&s_SettingsButtonID, Localize("Settings file"), 0, &SettingsButton))
 		{
-			char aBuf[IO_MAX_PATH_LENGTH];
 			Storage()->GetCompletePath(IStorage::TYPE_SAVE, CONFIG_FILE, aBuf, sizeof(aBuf));
 			if(!open_file(aBuf))
 			{
@@ -278,7 +275,6 @@ void CMenus::RenderSettingsGeneral(CUIRect MainView)
 		static int s_ConfigButtonID = 0;
 		if(DoButton_Menu(&s_ConfigButtonID, Localize("Config directory"), 0, &ConfigButton))
 		{
-			char aBuf[IO_MAX_PATH_LENGTH];
 			Storage()->GetCompletePath(IStorage::TYPE_SAVE, "", aBuf, sizeof(aBuf));
 			if(!open_file(aBuf))
 			{
@@ -295,7 +291,6 @@ void CMenus::RenderSettingsGeneral(CUIRect MainView)
 		static int s_ThemesButtonID = 0;
 		if(DoButton_Menu(&s_ThemesButtonID, Localize("Themes directory"), 0, &DirectoryButton))
 		{
-			char aBuf[IO_MAX_PATH_LENGTH];
 			Storage()->GetCompletePath(IStorage::TYPE_SAVE, "themes", aBuf, sizeof(aBuf));
 			Storage()->CreateFolder("themes", IStorage::TYPE_SAVE);
 			if(!open_file(aBuf))
@@ -437,7 +432,6 @@ void CMenus::RenderSettingsPlayer(CUIRect MainView)
 		CListboxItem Item = UiDoListboxNextItem(&pEntry->m_CountryCode, OldSelected == i, s_ListBoxUsed);
 		if(Item.m_Visible)
 		{
-			CUIRect Label;
 			Item.m_Rect.Margin(5.0f, &Item.m_Rect);
 			Item.m_Rect.HSplitBottom(10.0f, &Item.m_Rect, &Label);
 			float OldWidth = Item.m_Rect.w;
@@ -521,7 +515,7 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 	Label.VSplitLeft(230.0f, &Label, 0);
 	Dummy.VSplitLeft(170.0f, &Dummy, &SkinPrefix);
 	SkinPrefix.VSplitLeft(120.0f, &SkinPrefix, 0);
-	char aBuf[128];
+	char aBuf[128 + IO_MAX_PATH_LENGTH];
 	str_format(aBuf, sizeof(aBuf), "%s:", Localize("Your skin"));
 	UI()->DoLabelScaled(&Label, aBuf, 14.0f, TEXTALIGN_LEFT);
 
@@ -569,7 +563,6 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 		static const char *s_aSkinPrefixes[] = {"kitty", "santa"};
 		for(auto &pPrefix : s_aSkinPrefixes)
 		{
-			CUIRect Button;
 			SkinPrefix.HSplitTop(20.0f, &Button, &SkinPrefix);
 			Button.HMargin(2.0f, &Button);
 			if(DoButton_Menu(&pPrefix, pPrefix, 0, &Button))
@@ -682,7 +675,6 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 			OldSelected = i;
 
 		CListboxItem Item = UiDoListboxNextItem(s_paSkinList[i].m_pSkin, OldSelected == i);
-		char aBuf[128];
 		if(Item.m_Visible)
 		{
 			CTeeRenderInfo Info = OwnSkinInfo;
@@ -739,17 +731,17 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 		QuickSearch.VSplitLeft(wSearch, 0, &QuickSearch);
 		QuickSearch.VSplitLeft(5.0f, 0, &QuickSearch);
 		QuickSearch.VSplitLeft(QuickSearch.w - 15.0f, &QuickSearch, &QuickSearchClearButton);
-		static int s_ClearButton = 0;
+		static int s_ClearButtonSearch = 0;
 		static float s_Offset = 0.0f;
-		SUIExEditBoxProperties EditProps;
+		SUIExEditBoxProperties EditPropsSearch;
 		if(Input()->KeyPress(KEY_F) && Input()->ModifierIsPressed())
 		{
 			UI()->SetActiveItem(&g_Config.m_ClSkinFilterString);
 
-			EditProps.m_SelectText = true;
+			EditPropsSearch.m_SelectText = true;
 		}
-		EditProps.m_pEmptyText = Localize("Search");
-		if(UIEx()->DoClearableEditBox(&g_Config.m_ClSkinFilterString, &s_ClearButton, &QuickSearch, g_Config.m_ClSkinFilterString, sizeof(g_Config.m_ClSkinFilterString), 14.0f, &s_Offset, false, CUI::CORNER_ALL, EditProps))
+		EditPropsSearch.m_pEmptyText = Localize("Search");
+		if(UIEx()->DoClearableEditBox(&g_Config.m_ClSkinFilterString, &s_ClearButtonSearch, &QuickSearch, g_Config.m_ClSkinFilterString, sizeof(g_Config.m_ClSkinFilterString), 14.0f, &s_Offset, false, CUI::CORNER_ALL, EditPropsSearch))
 			s_InitSkinlist = true;
 	}
 
@@ -771,7 +763,6 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 	static int s_DirectoryButtonID = 0;
 	if(DoButton_Menu(&s_DirectoryButtonID, Localize("Skins directory"), 0, &DirectoryButton))
 	{
-		char aBuf[IO_MAX_PATH_LENGTH];
 		Storage()->GetCompletePath(IStorage::TYPE_SAVE, "skins", aBuf, sizeof(aBuf));
 		Storage()->CreateFolder("skins", IStorage::TYPE_SAVE);
 		if(!open_file(aBuf))
@@ -1142,8 +1133,10 @@ void CMenus::RenderSettingsGraphics(CUIRect MainView)
 	static const float sc_FontSizeResListHeader = 12.0f;
 	static const float sc_FontSizeResList = 10.0f;
 	int OldSelected = -1;
-	int G = gcd(g_Config.m_GfxScreenWidth, g_Config.m_GfxScreenHeight);
-	str_format(aBuf, sizeof(aBuf), "%s: %dx%d @%dhz %d bit (%d:%d)", Localize("Current"), int(g_Config.m_GfxScreenWidth * Graphics()->ScreenHiDPIScale()), int(g_Config.m_GfxScreenHeight * Graphics()->ScreenHiDPIScale()), g_Config.m_GfxScreenRefreshRate, g_Config.m_GfxColorDepth, g_Config.m_GfxScreenWidth / G, g_Config.m_GfxScreenHeight / G);
+	{
+		int G = gcd(g_Config.m_GfxScreenWidth, g_Config.m_GfxScreenHeight);
+		str_format(aBuf, sizeof(aBuf), "%s: %dx%d @%dhz %d bit (%d:%d)", Localize("Current"), int(g_Config.m_GfxScreenWidth * Graphics()->ScreenHiDPIScale()), int(g_Config.m_GfxScreenHeight * Graphics()->ScreenHiDPIScale()), g_Config.m_GfxScreenRefreshRate, g_Config.m_GfxColorDepth, g_Config.m_GfxScreenWidth / G, g_Config.m_GfxScreenHeight / G);
+	}
 
 	UI()->DoLabelScaled(&ModeLabel, aBuf, sc_FontSizeResListHeader, TEXTALIGN_CENTER);
 	UiDoListboxStart(&s_NumNodes, &ModeList, sc_RowHeightResList, Localize("Display Modes"), aBuf, s_NumNodes - 1, 1, OldSelected, s_ScrollValue);
@@ -1326,7 +1319,7 @@ void CMenus::RenderSettingsGraphics(CUIRect MainView)
 
 void CMenus::RenderSettingsSound(CUIRect MainView)
 {
-	CUIRect Button;
+	CUIRect Button, Label;
 	static int s_SndEnable = g_Config.m_SndEnable;
 	static int s_SndRate = g_Config.m_SndRate;
 
@@ -1411,7 +1404,6 @@ void CMenus::RenderSettingsSound(CUIRect MainView)
 
 	// volume slider
 	{
-		CUIRect Button, Label;
 		MainView.HSplitTop(5.0f, &Button, &MainView);
 		MainView.HSplitTop(20.0f, &Button, &MainView);
 		Button.VSplitLeft(190.0f, &Label, &Button);
@@ -1421,7 +1413,6 @@ void CMenus::RenderSettingsSound(CUIRect MainView)
 
 	// volume slider game sounds
 	{
-		CUIRect Button, Label;
 		MainView.HSplitTop(5.0f, &Button, &MainView);
 		MainView.HSplitTop(20.0f, &Button, &MainView);
 		Button.VSplitLeft(190.0f, &Label, &Button);
@@ -1431,7 +1422,6 @@ void CMenus::RenderSettingsSound(CUIRect MainView)
 
 	// volume slider gui sounds
 	{
-		CUIRect Button, Label;
 		MainView.HSplitTop(5.0f, &Button, &MainView);
 		MainView.HSplitTop(20.0f, &Button, &MainView);
 		Button.VSplitLeft(190.0f, &Label, &Button);
@@ -1441,7 +1431,6 @@ void CMenus::RenderSettingsSound(CUIRect MainView)
 
 	// volume slider map sounds
 	{
-		CUIRect Button, Label;
 		MainView.HSplitTop(5.0f, &Button, &MainView);
 		MainView.HSplitTop(20.0f, &Button, &MainView);
 		Button.VSplitLeft(190.0f, &Label, &Button);
@@ -1451,7 +1440,6 @@ void CMenus::RenderSettingsSound(CUIRect MainView)
 
 	// volume slider background music
 	{
-		CUIRect Button, Label;
 		MainView.HSplitTop(5.0f, &Button, &MainView);
 		MainView.HSplitTop(20.0f, &Button, &MainView);
 		Button.VSplitLeft(190.0f, &Label, &Button);
@@ -1958,8 +1946,8 @@ ColorHSLA CMenus::RenderHSLScrollbars(CUIRect *pRect, unsigned int *pColor, bool
 			LeftColor.b = 0;
 			RightColor.b = ColorHSLA::DARKEST_LGT;
 
-			ColorRGBA RightColorRGBA = color_cast<ColorRGBA>(RightColor);
-			ColorRGBA LeftColorRGBA = color_cast<ColorRGBA>(LeftColor);
+			RightColorRGBA = color_cast<ColorRGBA>(RightColor);
+			LeftColorRGBA = color_cast<ColorRGBA>(LeftColor);
 
 			IGraphics::CColorVertex Array[4] = {
 				IGraphics::CColorVertex(0, LeftColorRGBA.r, LeftColorRGBA.g, LeftColorRGBA.b, 1),
@@ -2317,19 +2305,19 @@ void CMenus::RenderSettingsHUD(CUIRect MainView)
 
 			int DefaultInd = GameClient()->m_Skins.Find("default");
 
-			for(auto &i : RenderInfo)
+			for(auto &Info : RenderInfo)
 			{
-				i.m_Size = RealTeeSize;
-				i.m_CustomColoredSkin = false;
+				Info.m_Size = RealTeeSize;
+				Info.m_CustomColoredSkin = false;
 			}
 
 			int ind = -1;
-			int i = 0;
+			int pos = 0;
 
-			RenderInfo[i++].m_OriginalRenderSkin = GameClient()->m_Skins.Get(DefaultInd)->m_OriginalSkin;
-			RenderInfo[i++].m_OriginalRenderSkin = (ind = GameClient()->m_Skins.Find("pinky")) != -1 ? GameClient()->m_Skins.Get(ind)->m_OriginalSkin : RenderInfo[0].m_OriginalRenderSkin;
-			RenderInfo[i++].m_OriginalRenderSkin = (ind = GameClient()->m_Skins.Find("cammostripes")) != -1 ? GameClient()->m_Skins.Get(ind)->m_OriginalSkin : RenderInfo[0].m_OriginalRenderSkin;
-			RenderInfo[i++].m_OriginalRenderSkin = (ind = GameClient()->m_Skins.Find("beast")) != -1 ? GameClient()->m_Skins.Get(ind)->m_OriginalSkin : RenderInfo[0].m_OriginalRenderSkin;
+			RenderInfo[pos++].m_OriginalRenderSkin = GameClient()->m_Skins.Get(DefaultInd)->m_OriginalSkin;
+			RenderInfo[pos++].m_OriginalRenderSkin = (ind = GameClient()->m_Skins.Find("pinky")) != -1 ? GameClient()->m_Skins.Get(ind)->m_OriginalSkin : RenderInfo[0].m_OriginalRenderSkin;
+			RenderInfo[pos++].m_OriginalRenderSkin = (ind = GameClient()->m_Skins.Find("cammostripes")) != -1 ? GameClient()->m_Skins.Get(ind)->m_OriginalSkin : RenderInfo[0].m_OriginalRenderSkin;
+			RenderInfo[pos++].m_OriginalRenderSkin = (ind = GameClient()->m_Skins.Find("beast")) != -1 ? GameClient()->m_Skins.Get(ind)->m_OriginalSkin : RenderInfo[0].m_OriginalRenderSkin;
 		}
 
 		// System
@@ -2429,7 +2417,6 @@ void CMenus::RenderSettingsDDNet(CUIRect MainView)
 	}
 
 	{
-		CUIRect Button, Label;
 		Left.HSplitTop(20.0f, &Button, &Left);
 
 		if(DoButton_CheckBox(&g_Config.m_ClReplays, Localize("Enable replays"), g_Config.m_ClReplays, &Button))
@@ -2489,7 +2476,6 @@ void CMenus::RenderSettingsDDNet(CUIRect MainView)
 	Right.VMargin(5.0f, &Right);
 
 	{
-		CUIRect Button, Label;
 		Left.HSplitTop(20.0f, &Button, &Left);
 		Button.VSplitLeft(120.0f, &Label, &Button);
 		UI()->DoLabelScaled(&Label, Localize("Overlay entities"), 14.0f, TEXTALIGN_LEFT);
@@ -2497,7 +2483,6 @@ void CMenus::RenderSettingsDDNet(CUIRect MainView)
 	}
 
 	{
-		CUIRect Button, Label;
 		Left.HSplitTop(20.0f, &Button, &Left);
 		Button.VSplitMid(&LeftLeft, &Button);
 
@@ -2512,7 +2497,6 @@ void CMenus::RenderSettingsDDNet(CUIRect MainView)
 	}
 
 	{
-		CUIRect Button, Label;
 		Left.HSplitTop(20.0f, &Button, &Left);
 		Button.VSplitMid(&LeftLeft, &Button);
 
@@ -2541,7 +2525,7 @@ void CMenus::RenderSettingsDDNet(CUIRect MainView)
 
 	Right.HSplitTop(20.0f, &Label, &Right);
 	Label.VSplitLeft(130.0f, &Label, &Button);
-	char aBuf[64];
+	char aBuf[256];
 	str_format(aBuf, sizeof(aBuf), "%s: %i", Localize("Default zoom"), g_Config.m_ClDefaultZoom);
 	UI()->DoLabelScaled(&Label, aBuf, 14.0f, TEXTALIGN_LEFT);
 	g_Config.m_ClDefaultZoom = static_cast<int>(UIEx()->DoScrollbarH(&g_Config.m_ClDefaultZoom, &Button, g_Config.m_ClDefaultZoom / 20.0f) * 20.0f + 0.1f);
@@ -2685,7 +2669,6 @@ void CMenus::RenderSettingsDDNet(CUIRect MainView)
 		Left.w += 20.0f;
 		Left.HSplitBottom(20.0f, 0x0, &Label);
 		bool NeedUpdate = str_comp(Client()->LatestVersion(), "0");
-		char aBuf[256];
 		int State = Updater()->GetCurrentState();
 
 		// Update Button

--- a/src/game/client/components/menus_settings_assets.cpp
+++ b/src/game/client/components/menus_settings_assets.cpp
@@ -46,7 +46,6 @@ void CMenus::LoadEntities(SCustomEntities *pEntitiesItem, void *pUser)
 			else
 			{
 				str_format(aBuff, sizeof(aBuff), "assets/entities/%s.png", pEntitiesItem->m_aName);
-				CImageInfo ImgInfo;
 				if(pThis->Graphics()->LoadPNG(&ImgInfo, aBuff, IStorage::TYPE_ALL))
 				{
 					pEntitiesItem->m_aImages[i].m_Texture = pThis->Graphics()->LoadTextureRaw(ImgInfo.m_Width, ImgInfo.m_Height, ImgInfo.m_Format, ImgInfo.m_pData, ImgInfo.m_Format, 0);
@@ -124,7 +123,6 @@ static void LoadAsset(TName *pAssetItem, const char *pAssetName, IGraphics *pGra
 		else
 		{
 			str_format(aBuff, sizeof(aBuff), "assets/%s/%s/%s.png", pAssetName, pAssetItem->m_aName, pAssetName);
-			CImageInfo ImgInfo;
 			if(pGraphics->LoadPNG(&ImgInfo, aBuff, IStorage::TYPE_ALL))
 			{
 				pAssetItem->m_RenderTexture = pGraphics->LoadTextureRaw(ImgInfo.m_Width, ImgInfo.m_Height, ImgInfo.m_Format, ImgInfo.m_pData, ImgInfo.m_Format, 0);

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -449,7 +449,6 @@ void CPlayers::RenderPlayer(
 				}
 				if(g_pData->m_Weapons.m_aId[iw].m_aSpriteMuzzles[IteX])
 				{
-					vec2 Dir;
 					if(PredictLocalWeapons)
 						Dir = vec2(pPlayerChar->m_X, pPlayerChar->m_Y) - vec2(pPrevChar->m_X, pPrevChar->m_Y);
 					else
@@ -465,7 +464,7 @@ void CPlayers::RenderPlayer(
 						Dir = vec2(1, 0);
 					}
 					Graphics()->QuadsSetRotation(HadOkenAngle);
-					int QuadOffset = IteX * 2;
+					QuadOffset = IteX * 2;
 					vec2 DirY(-Dir.y, Dir.x);
 					p = Position;
 					float OffsetX = g_pData->m_Weapons.m_aId[iw].m_Muzzleoffsetx;
@@ -533,7 +532,7 @@ void CPlayers::RenderPlayer(
 				if(AlphaMuzzle > 0.0f && g_pData->m_Weapons.m_aId[iw].m_aSpriteMuzzles[IteX])
 				{
 					float OffsetY = -g_pData->m_Weapons.m_aId[iw].m_Muzzleoffsety;
-					int QuadOffset = IteX * 2 + (Direction.x < 0 ? 1 : 0);
+					QuadOffset = IteX * 2 + (Direction.x < 0 ? 1 : 0);
 					if(Direction.x < 0)
 						OffsetY = -OffsetY;
 

--- a/src/game/client/components/scoreboard.cpp
+++ b/src/game/client/components/scoreboard.cpp
@@ -392,7 +392,6 @@ void CScoreboard::RenderScoreboard(float x, float y, float w, int Team, const ch
 
 			if(NextDDTeam != DDTeam)
 			{
-				char aBuf[64];
 				if(m_pClient->m_Snap.m_aTeamSize[0] > 8)
 				{
 					str_format(aBuf, sizeof(aBuf), "%d", DDTeam);
@@ -674,8 +673,8 @@ void CScoreboard::OnRender()
 						str_copy(aText, Localize("Blue team wins!"), sizeof(aText));
 				}
 
-				float w = TextRender()->TextWidth(0, 86.0f, aText, -1, -1.0f);
-				TextRender()->Text(0, Width / 2 - w / 2, 39, 86.0f, aText, -1.0f);
+				float TextWidth = TextRender()->TextWidth(0, 86.0f, aText, -1, -1.0f);
+				TextRender()->Text(0, Width / 2 - TextWidth / 2, 39, 86.0f, aText, -1.0f);
 			}
 
 			//decrease width, because team games use additional offsets

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -420,9 +420,9 @@ int CGameClient::OnSnapInput(int *pData, bool Dummy, bool Force)
 			m_DummyInput.m_WantedWeapon = WEAPON_HAMMER + 1;
 		}
 
-		vec2 Main = m_LocalCharacterPos;
-		vec2 Dummy = m_aClients[m_LocalIDs[!g_Config.m_ClDummy]].m_Predicted.m_Pos;
-		vec2 Dir = Main - Dummy;
+		vec2 MainPos = m_LocalCharacterPos;
+		vec2 DummyPos = m_aClients[m_LocalIDs[!g_Config.m_ClDummy]].m_Predicted.m_Pos;
+		vec2 Dir = MainPos - DummyPos;
 		m_HammerInput.m_TargetX = (int)(Dir.x);
 		m_HammerInput.m_TargetY = (int)(Dir.y);
 
@@ -1428,31 +1428,31 @@ void CGameClient::OnNewSnapshot()
 					Collision()->m_NumSwitchers = NumSwitchers;
 				}
 
-				for(int i = 0; i < NumSwitchers + 1; i++)
+				for(int j = 0; j < NumSwitchers + 1; j++)
 				{
-					if(i < 32)
-						Collision()->m_pSwitchers[i].m_Status[Team] = pSwitchStateData->m_Status1 & (1 << i);
-					else if(i < 64)
-						Collision()->m_pSwitchers[i].m_Status[Team] = pSwitchStateData->m_Status2 & (1 << (i - 32));
-					else if(i < 96)
-						Collision()->m_pSwitchers[i].m_Status[Team] = pSwitchStateData->m_Status3 & (1 << (i - 64));
-					else if(i < 128)
-						Collision()->m_pSwitchers[i].m_Status[Team] = pSwitchStateData->m_Status4 & (1 << (i - 96));
-					else if(i < 160)
-						Collision()->m_pSwitchers[i].m_Status[Team] = pSwitchStateData->m_Status5 & (1 << (i - 128));
-					else if(i < 192)
-						Collision()->m_pSwitchers[i].m_Status[Team] = pSwitchStateData->m_Status6 & (1 << (i - 160));
-					else if(i < 224)
-						Collision()->m_pSwitchers[i].m_Status[Team] = pSwitchStateData->m_Status7 & (1 << (i - 192));
-					else if(i < 256)
-						Collision()->m_pSwitchers[i].m_Status[Team] = pSwitchStateData->m_Status8 & (1 << (i - 224));
+					if(j < 32)
+						Collision()->m_pSwitchers[j].m_Status[Team] = pSwitchStateData->m_Status1 & (1 << j);
+					else if(j < 64)
+						Collision()->m_pSwitchers[j].m_Status[Team] = pSwitchStateData->m_Status2 & (1 << (j - 32));
+					else if(j < 96)
+						Collision()->m_pSwitchers[j].m_Status[Team] = pSwitchStateData->m_Status3 & (1 << (j - 64));
+					else if(j < 128)
+						Collision()->m_pSwitchers[j].m_Status[Team] = pSwitchStateData->m_Status4 & (1 << (j - 96));
+					else if(j < 160)
+						Collision()->m_pSwitchers[j].m_Status[Team] = pSwitchStateData->m_Status5 & (1 << (j - 128));
+					else if(j < 192)
+						Collision()->m_pSwitchers[j].m_Status[Team] = pSwitchStateData->m_Status6 & (1 << (j - 160));
+					else if(j < 224)
+						Collision()->m_pSwitchers[j].m_Status[Team] = pSwitchStateData->m_Status7 & (1 << (j - 192));
+					else if(j < 256)
+						Collision()->m_pSwitchers[j].m_Status[Team] = pSwitchStateData->m_Status8 & (1 << (j - 224));
 
 					// update
-					if(Collision()->m_pSwitchers[i].m_Status[Team])
-						Collision()->m_pSwitchers[i].m_Type[Team] = TILE_SWITCHOPEN;
+					if(Collision()->m_pSwitchers[j].m_Status[Team])
+						Collision()->m_pSwitchers[j].m_Type[Team] = TILE_SWITCHOPEN;
 					else
-						Collision()->m_pSwitchers[i].m_Type[Team] = TILE_SWITCHCLOSE;
-					Collision()->m_pSwitchers[i].m_EndTick[Team] = 0;
+						Collision()->m_pSwitchers[j].m_Type[Team] = TILE_SWITCHCLOSE;
+					Collision()->m_pSwitchers[j].m_EndTick[Team] = 0;
 				}
 
 				if(!GotSwitchStateTeam)
@@ -2112,8 +2112,8 @@ void CGameClient::SendKill(int ClientID)
 
 	if(g_Config.m_ClDummyCopyMoves)
 	{
-		CMsgPacker Msg(NETMSGTYPE_CL_KILL, false);
-		Client()->SendMsg(!g_Config.m_ClDummy, &Msg, MSGFLAG_VITAL);
+		CMsgPacker MsgP(NETMSGTYPE_CL_KILL, false);
+		Client()->SendMsg(!g_Config.m_ClDummy, &MsgP, MSGFLAG_VITAL);
 	}
 }
 

--- a/src/game/client/prediction/entities/pickup.cpp
+++ b/src/game/client/prediction/entities/pickup.cpp
@@ -32,12 +32,12 @@ void CPickup::Tick()
 					continue;
 				if(pChr->m_Super)
 					continue;
-				for(int i = WEAPON_SHOTGUN; i < NUM_WEAPONS; i++)
+				for(int j = WEAPON_SHOTGUN; j < NUM_WEAPONS; j++)
 				{
-					if(pChr->GetWeaponGot(i))
+					if(pChr->GetWeaponGot(j))
 					{
-						pChr->SetWeaponGot(i, false);
-						pChr->SetWeaponAmmo(i, 0);
+						pChr->SetWeaponGot(j, false);
+						pChr->SetWeaponAmmo(j, 0);
 						sound = true;
 					}
 				}

--- a/src/game/client/prediction/entities/projectile.cpp
+++ b/src/game/client/prediction/entities/projectile.cpp
@@ -86,7 +86,6 @@ void CProjectile::Tick()
 	if(m_LifeSpan > -1)
 		m_LifeSpan--;
 
-	int64_t TeamMask = -1LL;
 	bool isWeaponCollide = false;
 	if(
 		pOwnerChar &&
@@ -102,8 +101,7 @@ void CProjectile::Tick()
 	{
 		if(m_Explosive && (!pTargetChr || (pTargetChr && (!m_Freeze || (m_Type == WEAPON_SHOTGUN && Collide)))))
 		{
-			GameWorld()->CreateExplosion(ColPos, m_Owner, m_Type, m_Owner == -1, (!pTargetChr ? -1 : pTargetChr->Team()),
-				(m_Owner != -1) ? TeamMask : -1LL);
+			GameWorld()->CreateExplosion(ColPos, m_Owner, m_Type, m_Owner == -1, (!pTargetChr ? -1 : pTargetChr->Team()), -1LL);
 		}
 		else if(m_Freeze)
 		{
@@ -141,10 +139,7 @@ void CProjectile::Tick()
 			if(m_Owner >= 0)
 				pOwnerChar = GameWorld()->GetCharacterByID(m_Owner);
 
-			int64_t TeamMask = -1LL;
-
-			GameWorld()->CreateExplosion(ColPos, m_Owner, m_Type, m_Owner == -1, (!pOwnerChar ? -1 : pOwnerChar->Team()),
-				(m_Owner != -1) ? TeamMask : -1LL);
+			GameWorld()->CreateExplosion(ColPos, m_Owner, m_Type, m_Owner == -1, (!pOwnerChar ? -1 : pOwnerChar->Team()), -1LL);
 		}
 		m_MarkedForDestroy = true;
 	}

--- a/src/game/client/render.cpp
+++ b/src/game/client/render.cpp
@@ -345,25 +345,25 @@ void CRenderTools::DrawRoundRectExt4(float x, float y, float w, float h, vec4 Co
 	if(!(Corners & 1))
 	{
 		Graphics()->SetColor(ColorTopLeft.r, ColorTopLeft.g, ColorTopLeft.b, ColorTopLeft.a);
-		IGraphics::CQuadItem ItemQ = IGraphics::CQuadItem(x, y, r, r); // TL
+		ItemQ = IGraphics::CQuadItem(x, y, r, r); // TL
 		Graphics()->QuadsDrawTL(&ItemQ, 1);
 	}
 	if(!(Corners & 2))
 	{
 		Graphics()->SetColor(ColorTopRight.r, ColorTopRight.g, ColorTopRight.b, ColorTopRight.a);
-		IGraphics::CQuadItem ItemQ = IGraphics::CQuadItem(x + w, y, -r, r); // TR
+		ItemQ = IGraphics::CQuadItem(x + w, y, -r, r); // TR
 		Graphics()->QuadsDrawTL(&ItemQ, 1);
 	}
 	if(!(Corners & 4))
 	{
 		Graphics()->SetColor(ColorBottomLeft.r, ColorBottomLeft.g, ColorBottomLeft.b, ColorBottomLeft.a);
-		IGraphics::CQuadItem ItemQ = IGraphics::CQuadItem(x, y + h, r, -r); // BL
+		ItemQ = IGraphics::CQuadItem(x, y + h, r, -r); // BL
 		Graphics()->QuadsDrawTL(&ItemQ, 1);
 	}
 	if(!(Corners & 8))
 	{
 		Graphics()->SetColor(ColorBottomRight.r, ColorBottomRight.g, ColorBottomRight.b, ColorBottomRight.a);
-		IGraphics::CQuadItem ItemQ = IGraphics::CQuadItem(x + w, y + h, -r, -r); // BR
+		ItemQ = IGraphics::CQuadItem(x + w, y + h, -r, -r); // BR
 		Graphics()->QuadsDrawTL(&ItemQ, 1);
 	}
 }

--- a/src/game/editor/auto_map.cpp
+++ b/src/game/editor/auto_map.cpp
@@ -502,9 +502,9 @@ void CAutoMapper::Proceed(CLayerTiles *pLayer, int ConfigID, int Seed, int SeedO
 						if(pRule->m_Value == CPosRule::INDEX)
 						{
 							RespectRules = false;
-							for(int i = 0; i < pRule->m_aIndexList.size(); ++i)
+							for(int k = 0; k < pRule->m_aIndexList.size(); ++k)
 							{
-								if(CheckIndex == pRule->m_aIndexList[i].m_ID && (!pRule->m_aIndexList[i].m_TestFlag || CheckFlags == pRule->m_aIndexList[i].m_Flag))
+								if(CheckIndex == pRule->m_aIndexList[k].m_ID && (!pRule->m_aIndexList[k].m_TestFlag || CheckFlags == pRule->m_aIndexList[k].m_Flag))
 								{
 									RespectRules = true;
 									break;
@@ -513,9 +513,9 @@ void CAutoMapper::Proceed(CLayerTiles *pLayer, int ConfigID, int Seed, int SeedO
 						}
 						else if(pRule->m_Value == CPosRule::NOTINDEX)
 						{
-							for(int i = 0; i < pRule->m_aIndexList.size(); ++i)
+							for(int k = 0; k < pRule->m_aIndexList.size(); ++k)
 							{
-								if(CheckIndex == pRule->m_aIndexList[i].m_ID && (!pRule->m_aIndexList[i].m_TestFlag || CheckFlags == pRule->m_aIndexList[i].m_Flag))
+								if(CheckIndex == pRule->m_aIndexList[k].m_ID && (!pRule->m_aIndexList[k].m_TestFlag || CheckFlags == pRule->m_aIndexList[k].m_Flag))
 								{
 									RespectRules = false;
 									break;

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -2387,10 +2387,10 @@ void CEditor::DoMapEditor(CUIRect View)
 		}
 		else
 		{
-			CLayerQuads *t = (CLayerQuads *)GetSelectedLayerType(0, LAYERTYPE_QUADS);
-			if(t)
+			CLayerQuads *q = (CLayerQuads *)GetSelectedLayerType(0, LAYERTYPE_QUADS);
+			if(q)
 			{
-				m_QuadsetPicker.m_Image = t->m_Image;
+				m_QuadsetPicker.m_Image = q->m_Image;
 				m_QuadsetPicker.m_lQuads[0].m_aPoints[0].x = f2fx(View.x);
 				m_QuadsetPicker.m_lQuads[0].m_aPoints[0].y = f2fx(View.y);
 				m_QuadsetPicker.m_lQuads[0].m_aPoints[1].x = f2fx((View.x + View.w));
@@ -3092,14 +3092,14 @@ int CEditor::DoProperties(CUIRect *pToolBox, CProperty *pProps, int *pIDs, int *
 			NewColorHex |= UiDoValueSelector(((char *)&pIDs[i] - 1), &Shifter, "", (pProps[i].m_Value >> 8) & 0xFFFFFF, 0, 0xFFFFFF, 1, 1.0f, "Use left mouse button to drag and change the color value. Hold shift to be more precise. Rightclick to edit as text.", false, true) << 8;
 
 			// color picker
-			ColorRGBA Color = ColorRGBA(
+			ColorRGBA ColorPick = ColorRGBA(
 				((pProps[i].m_Value >> s_aShift[0]) & 0xff) / 255.0f,
 				((pProps[i].m_Value >> s_aShift[1]) & 0xff) / 255.0f,
 				((pProps[i].m_Value >> s_aShift[2]) & 0xff) / 255.0f,
 				1.0f);
 
 			static int s_ColorPicker, s_ColorPickerID;
-			if(DoButton_ColorPicker(&s_ColorPicker, &ColorBox, &Color))
+			if(DoButton_ColorPicker(&s_ColorPicker, &ColorBox, &ColorPick))
 			{
 				ms_PickerColor = color_cast<ColorHSVA>(Color);
 				UiInvokePopupMenu(&s_ColorPickerID, 0, UI()->MouseX(), UI()->MouseY(), 180, 150, PopupColorPicker);
@@ -3457,10 +3457,10 @@ void CEditor::RenderLayers(CUIRect ToolBox, CUIRect View)
 						if(m_lSelectedLayers.size() > 1)
 						{
 							bool AllTile = true;
-							for(int i = 0; AllTile && i < m_lSelectedLayers.size(); i++)
+							for(int j = 0; AllTile && j < m_lSelectedLayers.size(); j++)
 							{
-								if(m_Map.m_lGroups[m_SelectedGroup]->m_lLayers[m_lSelectedLayers[i]]->m_Type == LAYERTYPE_TILES)
-									s_LayerPopupContext.m_aLayers.add((CLayerTiles *)m_Map.m_lGroups[m_SelectedGroup]->m_lLayers[m_lSelectedLayers[i]]);
+								if(m_Map.m_lGroups[m_SelectedGroup]->m_lLayers[m_lSelectedLayers[j]]->m_Type == LAYERTYPE_TILES)
+									s_LayerPopupContext.m_aLayers.add((CLayerTiles *)m_Map.m_lGroups[m_SelectedGroup]->m_lLayers[m_lSelectedLayers[j]]);
 								else
 									AllTile = false;
 							}
@@ -4449,10 +4449,10 @@ void CEditor::RenderFileDialog()
 			{
 				//scroll
 				float IndexY = View.y - m_FileDialogScrollValue * ScrollNum * 17.0f + NewIndex * 17.0f;
-				int Scroll = View.y > IndexY ? -1 : View.y + View.h < IndexY + 17.0f ? 1 : 0;
-				if(Scroll)
+				int ScrollPos = View.y > IndexY ? -1 : View.y + View.h < IndexY + 17.0f ? 1 : 0;
+				if(ScrollPos)
 				{
-					if(Scroll < 0)
+					if(ScrollPos < 0)
 						m_FileDialogScrollValue = ((float)(NewIndex) + 0.5f) / ScrollNum;
 					else
 						m_FileDialogScrollValue = ((float)(NewIndex - Num) + 2.5f) / ScrollNum;
@@ -5744,27 +5744,27 @@ void CEditor::Render()
 				if(m_apSavedBrushes[Slot])
 				{
 					CLayerGroup *pPrev = m_apSavedBrushes[Slot];
-					for(int i = 0; i < pPrev->m_lLayers.size(); i++)
+					for(int j = 0; j < pPrev->m_lLayers.size(); j++)
 					{
-						if(pPrev->m_lLayers[i]->m_BrushRefCount == 1)
-							delete pPrev->m_lLayers[i];
+						if(pPrev->m_lLayers[j]->m_BrushRefCount == 1)
+							delete pPrev->m_lLayers[j];
 						else
-							pPrev->m_lLayers[i]->m_BrushRefCount--;
+							pPrev->m_lLayers[j]->m_BrushRefCount--;
 					}
 				}
 				delete m_apSavedBrushes[Slot];
 				m_apSavedBrushes[Slot] = new CLayerGroup(m_Brush);
 
-				for(int i = 0; i < m_apSavedBrushes[Slot]->m_lLayers.size(); i++)
-					m_apSavedBrushes[Slot]->m_lLayers[i]->m_BrushRefCount++;
+				for(int j = 0; j < m_apSavedBrushes[Slot]->m_lLayers.size(); j++)
+					m_apSavedBrushes[Slot]->m_lLayers[j]->m_BrushRefCount++;
 			}
 			else if(m_apSavedBrushes[Slot])
 			{
 				dbg_msg("editor", "loading brush from slot %d", Slot);
 
 				CLayerGroup *pNew = m_apSavedBrushes[Slot];
-				for(int i = 0; i < pNew->m_lLayers.size(); i++)
-					pNew->m_lLayers[i]->m_BrushRefCount++;
+				for(int j = 0; j < pNew->m_lLayers.size(); j++)
+					pNew->m_lLayers[j]->m_BrushRefCount++;
 
 				m_Brush = *pNew;
 			}

--- a/src/game/editor/io.cpp
+++ b/src/game/editor/io.cpp
@@ -310,12 +310,12 @@ int CEditorMap::Save(class IStorage *pStorage, const char *pFileName)
 				// Convert to RGBA
 				unsigned char *pDataRGBA = (unsigned char *)malloc((size_t)Item.m_Width * Item.m_Height * 4);
 				unsigned char *pDataRGB = (unsigned char *)pImg->m_pData;
-				for(int i = 0; i < Item.m_Width * Item.m_Height; i++)
+				for(int j = 0; j < Item.m_Width * Item.m_Height; j++)
 				{
-					pDataRGBA[i * 4] = pDataRGB[i * 3];
-					pDataRGBA[i * 4 + 1] = pDataRGB[i * 3 + 1];
-					pDataRGBA[i * 4 + 2] = pDataRGB[i * 3 + 2];
-					pDataRGBA[i * 4 + 3] = 255;
+					pDataRGBA[j * 4] = pDataRGB[j * 3];
+					pDataRGBA[j * 4 + 1] = pDataRGB[j * 3 + 1];
+					pDataRGBA[j * 4 + 2] = pDataRGB[j * 3 + 2];
+					pDataRGBA[j * 4 + 3] = 255;
 				}
 				Item.m_ImageData = df.AddData(Item.m_Width * Item.m_Height * 4, pDataRGBA);
 				free(pDataRGBA);
@@ -602,8 +602,8 @@ int CEditorMap::Load(class IStorage *pStorage, const char *pFileName, int Storag
 	Clean();
 
 	// check version
-	CMapItemVersion *pItem = (CMapItemVersion *)DataFile.FindItem(MAPITEMTYPE_VERSION, 0);
-	if(!pItem)
+	CMapItemVersion *pItemVersion = (CMapItemVersion *)DataFile.FindItem(MAPITEMTYPE_VERSION, 0);
+	if(!pItemVersion)
 	{
 		// import old map
 		/*MAP old_mapstuff;
@@ -612,7 +612,7 @@ int CEditorMap::Load(class IStorage *pStorage, const char *pFileName, int Storag
 		*/
 		return 0;
 	}
-	else if(pItem->m_Version == 1)
+	else if(pItemVersion->m_Version == 1)
 	{
 		//editor.reset(false);
 
@@ -882,7 +882,6 @@ int CEditorMap::Load(class IStorage *pStorage, const char *pFileName, int Storag
 
 						pGroup->AddLayer(pTiles);
 						void *pData = DataFile.GetData(pTilemapItem->m_Data);
-						unsigned int Size = DataFile.GetDataSize(pTilemapItem->m_Data);
 						pTiles->m_Image = pTilemapItem->m_Image;
 						pTiles->m_Game = pTilemapItem->m_Flags & TILESLAYERFLAG_GAME;
 
@@ -1019,6 +1018,7 @@ int CEditorMap::Load(class IStorage *pStorage, const char *pFileName, int Storag
 						}
 						else // regular tile layer or game layer
 						{
+							unsigned int Size = DataFile.GetDataSize(pTilemapItem->m_Data);
 							if(Size >= (size_t)pTiles->m_Width * pTiles->m_Height * sizeof(CTile))
 							{
 								mem_copy(pTiles->m_pTiles, pData, (size_t)pTiles->m_Width * pTiles->m_Height * sizeof(CTile));
@@ -1292,14 +1292,14 @@ int CEditorMap::Load(class IStorage *pStorage, const char *pFileName, int Storag
 						CLayer *pLayer = m_lGroups[pItem->m_GroupId]->m_lLayers[pItem->m_LayerId];
 						if(pLayer->m_Type == LAYERTYPE_TILES)
 						{
-							CLayerTiles *pLayer = (CLayerTiles *)m_lGroups[pItem->m_GroupId]->m_lLayers[pItem->m_LayerId];
+							CLayerTiles *pTiles = (CLayerTiles *)m_lGroups[pItem->m_GroupId]->m_lLayers[pItem->m_LayerId];
 							// only load auto mappers for tile layers (not physics layers)
-							if(!(pLayer->m_Game || pLayer->m_Tele || pLayer->m_Speedup ||
-								   pLayer->m_Front || pLayer->m_Switch || pLayer->m_Tune))
+							if(!(pTiles->m_Game || pTiles->m_Tele || pTiles->m_Speedup ||
+								   pTiles->m_Front || pTiles->m_Switch || pTiles->m_Tune))
 							{
-								pLayer->m_AutoMapperConfig = pItem->m_AutomapperConfig;
-								pLayer->m_Seed = pItem->m_AutomapperSeed;
-								pLayer->m_AutoAutoMap = !!(pItem->m_Flags & CMapItemAutoMapperConfig::FLAG_AUTOMATIC);
+								pTiles->m_AutoMapperConfig = pItem->m_AutomapperConfig;
+								pTiles->m_Seed = pItem->m_AutomapperSeed;
+								pTiles->m_AutoAutoMap = !!(pItem->m_Flags & CMapItemAutoMapperConfig::FLAG_AUTOMATIC);
 							}
 						}
 					}

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -1839,7 +1839,7 @@ int CEditor::PopupColorPicker(CEditor *pEditor, CUIRect View, void *pContext)
 		ColorArray[2] = IGraphics::CColorVertex(2, ColorBottom.r, ColorBottom.g, ColorBottom.b, ColorBottom.a);
 		ColorArray[3] = IGraphics::CColorVertex(3, ColorBottom.r, ColorBottom.g, ColorBottom.b, ColorBottom.a);
 		pEditor->Graphics()->SetColorVertex(ColorArray, 4);
-		IGraphics::CQuadItem QuadItem(HuePicker.x, HuePicker.y + Offset * j, HuePicker.w, Offset);
+		QuadItem = IGraphics::CQuadItem(HuePicker.x, HuePicker.y + Offset * j, HuePicker.w, Offset);
 		pEditor->Graphics()->QuadsDrawTL(&QuadItem, 1);
 	}
 

--- a/src/game/gamecore.cpp
+++ b/src/game/gamecore.cpp
@@ -414,17 +414,17 @@ void CCharacterCore::Tick(bool UseInput)
 				{
 					if(Distance > PhysSize * 1.50f) // TODO: fix tweakable variable
 					{
-						float Accel = m_Tuning.m_HookDragAccel * (Distance / m_Tuning.m_HookLength);
+						float HookAccel = m_Tuning.m_HookDragAccel * (Distance / m_Tuning.m_HookLength);
 						float DragSpeed = m_Tuning.m_HookDragSpeed;
 
 						vec2 Temp;
 						// add force to the hooked player
-						Temp.x = SaturatedAdd(-DragSpeed, DragSpeed, pCharCore->m_Vel.x, Accel * Dir.x * 1.5f);
-						Temp.y = SaturatedAdd(-DragSpeed, DragSpeed, pCharCore->m_Vel.y, Accel * Dir.y * 1.5f);
+						Temp.x = SaturatedAdd(-DragSpeed, DragSpeed, pCharCore->m_Vel.x, HookAccel * Dir.x * 1.5f);
+						Temp.y = SaturatedAdd(-DragSpeed, DragSpeed, pCharCore->m_Vel.y, HookAccel * Dir.y * 1.5f);
 						pCharCore->m_Vel = ClampVel(pCharCore->m_MoveRestrictions, Temp);
 						// add a little bit force to the guy who has the grip
-						Temp.x = SaturatedAdd(-DragSpeed, DragSpeed, m_Vel.x, -Accel * Dir.x * 0.25f);
-						Temp.y = SaturatedAdd(-DragSpeed, DragSpeed, m_Vel.y, -Accel * Dir.y * 0.25f);
+						Temp.x = SaturatedAdd(-DragSpeed, DragSpeed, m_Vel.x, -HookAccel * Dir.x * 0.25f);
+						Temp.y = SaturatedAdd(-DragSpeed, DragSpeed, m_Vel.y, -HookAccel * Dir.y * 0.25f);
 						m_Vel = ClampVel(m_MoveRestrictions, Temp);
 					}
 				}

--- a/src/game/server/entities/pickup.cpp
+++ b/src/game/server/entities/pickup.cpp
@@ -72,12 +72,12 @@ void CPickup::Tick()
 			case POWERUP_ARMOR:
 				if(pChr->Team() == TEAM_SUPER)
 					continue;
-				for(int i = WEAPON_SHOTGUN; i < NUM_WEAPONS; i++)
+				for(int j = WEAPON_SHOTGUN; j < NUM_WEAPONS; j++)
 				{
-					if(pChr->GetWeaponGot(i))
+					if(pChr->GetWeaponGot(j))
 					{
-						pChr->SetWeaponGot(i, false);
-						pChr->SetWeaponAmmo(i, 0);
+						pChr->SetWeaponGot(j, false);
+						pChr->SetWeaponAmmo(j, 0);
 						Sound = true;
 					}
 				}

--- a/src/game/server/entities/projectile.cpp
+++ b/src/game/server/entities/projectile.cpp
@@ -254,7 +254,7 @@ void CProjectile::Tick()
 			if(m_Owner >= 0)
 				pOwnerChar = GameServer()->GetPlayerChar(m_Owner);
 
-			int64_t TeamMask = -1LL;
+			TeamMask = -1LL;
 			if(pOwnerChar && pOwnerChar->IsAlive())
 			{
 				TeamMask = pOwnerChar->Teams()->TeamMask(pOwnerChar->Team(), -1, m_Owner);

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -3251,8 +3251,8 @@ void CGameContext::OnInit(/*class IKernel *pKernel*/)
 		char aFilename[IO_MAX_PATH_LENGTH];
 		str_format(aFilename, sizeof(aFilename), "teehistorian/%s.teehistorian", aGameUuid);
 
-		IOHANDLE File = Storage()->OpenFile(aFilename, IOFLAG_WRITE, IStorage::TYPE_SAVE);
-		if(!File)
+		IOHANDLE THFile = Storage()->OpenFile(aFilename, IOFLAG_WRITE, IStorage::TYPE_SAVE);
+		if(!THFile)
 		{
 			dbg_msg("teehistorian", "failed to open '%s'", aFilename);
 			Server()->SetErrorShutdown("teehistorian open error");
@@ -3262,7 +3262,7 @@ void CGameContext::OnInit(/*class IKernel *pKernel*/)
 		{
 			dbg_msg("teehistorian", "recording to '%s'", aFilename);
 		}
-		m_pTeeHistorianFile = aio_new(File);
+		m_pTeeHistorianFile = aio_new(THFile);
 
 		char aVersion[128];
 		if(GIT_SHORTREV_HASH)

--- a/src/game/server/gamecontroller.cpp
+++ b/src/game/server/gamecontroller.cpp
@@ -182,9 +182,6 @@ bool IGameController::OnEntity(int Index, vec2 Pos, int Layer, int Flags, int Nu
 	if(Index < 0)
 		return false;
 
-	int Type = -1;
-	int SubType = 0;
-
 	int x, y;
 	x = (Pos.x - 16.0f) / 32.0f;
 	y = (Pos.y - 16.0f) / 32.0f;
@@ -275,6 +272,9 @@ bool IGameController::OnEntity(int Index, vec2 Pos, int Layer, int Flags, int Nu
 			Number);
 		bullet->SetBouncing(2 - (Dir % 2));
 	}
+
+	int Type = -1;
+	int SubType = 0;
 
 	if(Index == ENTITY_ARMOR_1)
 		Type = POWERUP_ARMOR;

--- a/src/game/server/scoreworker.cpp
+++ b/src/game/server/scoreworker.cpp
@@ -418,12 +418,12 @@ bool CScoreWorker::SaveScore(IDbConnection *pSqlServer, const ISqlData *pGameDat
 		}
 		pSqlServer->BindString(1, pData->m_aMap);
 
-		bool End;
-		if(pSqlServer->Step(&End, pError, ErrorSize))
+		bool End2;
+		if(pSqlServer->Step(&End2, pError, ErrorSize))
 		{
 			return true;
 		}
-		if(!End)
+		if(!End2)
 		{
 			int Points = pSqlServer->GetInt(1);
 			if(pSqlServer->AddPoints(pData->m_aName, Points, pError, ErrorSize))

--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -779,8 +779,8 @@ void CGameTeams::OnFinish(CPlayer *Player, float Time, const char *pTimestamp)
 
 		if(pData->m_BestTime)
 		{
-			float Diff = (Time - pData->m_BestTime) * 100;
-			MsgLegacy.m_Check = Msg.m_Check = (int)Diff;
+			float Diff100 = (Time - pData->m_BestTime) * 100;
+			MsgLegacy.m_Check = Msg.m_Check = (int)Diff100;
 		}
 
 		Server()->SendPackMsg(&Msg, MSGFLAG_VITAL, ClientID);

--- a/src/tools/map_optimize.cpp
+++ b/src/tools/map_optimize.cpp
@@ -82,7 +82,7 @@ int main(int argc, const char **argv)
 	dbg_logger_stdout();
 
 	IStorage *pStorage = CreateStorage("Teeworlds", IStorage::STORAGETYPE_BASIC, argc, argv);
-	int Index, ID = 0, Type = 0, Size;
+	int ID = 0, Type = 0, Size;
 	void *pPtr;
 	char aFileName[IO_MAX_PATH_LENGTH];
 	CDataFileReader DataFile;
@@ -142,8 +142,7 @@ int main(int argc, const char **argv)
 	std::vector<SMapOptimizeItem> DataFindHelper;
 
 	// add all items
-	int i = 0;
-	for(int Index = 0; Index < DataFile.NumItems(); Index++)
+	for(int Index = 0, i = 0; Index < DataFile.NumItems(); Index++)
 	{
 		pPtr = DataFile.GetItem(Index, &Type, &ID);
 		Size = DataFile.GetItemSize(Index);
@@ -165,11 +164,11 @@ int main(int argc, const char **argv)
 					aImageFlags[pTLayer->m_Image] |= 1;
 					// check tiles that are used in this image
 					int DataIndex = pTLayer->m_Data;
-					unsigned int Size = DataFile.GetDataSize(DataIndex);
+					unsigned int DataSize = DataFile.GetDataSize(DataIndex);
 					void *pTiles = DataFile.GetData(DataIndex);
 					unsigned int TileSize = sizeof(CTile);
 
-					if(Size >= pTLayer->m_Width * pTLayer->m_Height * TileSize)
+					if(DataSize >= pTLayer->m_Width * pTLayer->m_Height * TileSize)
 					{
 						int x = 0;
 						int y = 0;
@@ -217,6 +216,7 @@ int main(int argc, const char **argv)
 	}
 
 	// add all data
+	int Index;
 	for(Index = 0; Index < DataFile.NumData(); Index++)
 	{
 		bool DeletePtr = false;


### PR DESCRIPTION
> Warn when a local variable shadows another local variable or parameter.

Found one actual bug in graphics_threaded.cpp

Should reduce confusion in the future when reading source code

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
