### PR TITLE
Cleaned const qualification when using -Wcast-qual

### DIFF
--- a/datasrc/seven/datatypes.py
+++ b/datasrc/seven/datatypes.py
@@ -229,7 +229,7 @@ class NetObject:
 	def emit_validate(self):
 		lines = ["case %s:" % self.enum_name]
 		lines += ["{"]
-		lines += ["\t%s *pObj = (%s *)pData;"%(self.struct_name, self.struct_name)]
+		lines += ["\tconst %s *pObj = (const %s *)pData;"%(self.struct_name, self.struct_name)]
 		lines += ["\tif(sizeof(*pObj) != Size) return -1;"]
 		for v in self.variables:
 			lines += ["\t"+line for line in v.emit_validate()]

--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -742,7 +742,7 @@ void aio_write_unlocked(ASYNCIO *aio, const void *buffer, unsigned size)
 		{
 			mem_copy(aio->buffer + aio->write_pos, buffer, remaining_contiguous);
 			size -= remaining_contiguous;
-			buffer = ((unsigned char *)buffer) + remaining_contiguous;
+			buffer = ((const unsigned char *)buffer) + remaining_contiguous;
 			aio->write_pos = 0;
 		}
 		mem_copy(aio->buffer + aio->write_pos, buffer, size);
@@ -1174,22 +1174,22 @@ static void sockaddr_to_netaddr(const struct sockaddr *src, NETADDR *dst)
 	{
 		mem_zero(dst, sizeof(NETADDR));
 		dst->type = NETTYPE_IPV4;
-		dst->port = htons(((struct sockaddr_in *)src)->sin_port);
-		mem_copy(dst->ip, &((struct sockaddr_in *)src)->sin_addr.s_addr, 4);
+		dst->port = htons(((const struct sockaddr_in *)src)->sin_port);
+		mem_copy(dst->ip, &((const struct sockaddr_in *)src)->sin_addr.s_addr, 4);
 	}
 	else if(src->sa_family == AF_WEBSOCKET_INET)
 	{
 		mem_zero(dst, sizeof(NETADDR));
 		dst->type = NETTYPE_WEBSOCKET_IPV4;
-		dst->port = htons(((struct sockaddr_in *)src)->sin_port);
-		mem_copy(dst->ip, &((struct sockaddr_in *)src)->sin_addr.s_addr, 4);
+		dst->port = htons(((const struct sockaddr_in *)src)->sin_port);
+		mem_copy(dst->ip, &((const struct sockaddr_in *)src)->sin_addr.s_addr, 4);
 	}
 	else if(src->sa_family == AF_INET6)
 	{
 		mem_zero(dst, sizeof(NETADDR));
 		dst->type = NETTYPE_IPV6;
-		dst->port = htons(((struct sockaddr_in6 *)src)->sin6_port);
-		mem_copy(dst->ip, &((struct sockaddr_in6 *)src)->sin6_addr.s6_addr, 16);
+		dst->port = htons(((const struct sockaddr_in6 *)src)->sin6_port);
+		mem_copy(dst->ip, &((const struct sockaddr_in6 *)src)->sin6_addr.s6_addr, 16);
 	}
 	else
 	{
@@ -3401,11 +3401,11 @@ const char *str_utf8_skip_whitespaces(const char *str)
 
 void str_utf8_trim_right(char *param)
 {
-	const char *str = param;
+	const char *str = param; // Wcast-qual
 	char *end = 0;
 	while(*str)
 	{
-		char *str_old = (char *)str;
+		char *str_old = (char *)str; // Wcast-qual
 		int code = str_utf8_decode(&str);
 
 		// check if unicode is not empty
@@ -3787,7 +3787,7 @@ void cmdline_free(int argc, const char **argv)
 #endif
 }
 
-PROCESS shell_execute(const char *file)
+PROCESS shell_execute(char *file)
 {
 #if defined(CONF_FAMILY_WINDOWS)
 	WCHAR wBuffer[512];
@@ -4161,7 +4161,7 @@ int os_version_str(char *version, int length)
 			}
 			offset = found - buf + 1;
 		}
-		newline = (char *)str_find(buf + offset, "\n");
+		newline = (char *)str_find(buf + offset, "\n"); // Wcast-qual
 		if(newline)
 		{
 			*newline = 0;

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -2238,7 +2238,7 @@ void uint_to_bytes_be(unsigned char *bytes, unsigned value);
 /*
 	Function: pid
 		Returns the pid of the current process.
-	
+
 	Returns:
 		pid of the current process
 */
@@ -2283,7 +2283,7 @@ typedef pid_t PROCESS;
 	Returns:
 		handle/pid of the new process
 */
-PROCESS shell_execute(const char *file);
+PROCESS shell_execute(char *file);
 
 /*
 	Function: kill_process

--- a/src/base/unicode/tolower.cpp
+++ b/src/base/unicode/tolower.cpp
@@ -4,8 +4,8 @@
 
 static int compul(const void *a, const void *b)
 {
-	struct UPPER_LOWER *ul_a = (struct UPPER_LOWER *)a;
-	struct UPPER_LOWER *ul_b = (struct UPPER_LOWER *)b;
+	const struct UPPER_LOWER *ul_a = (const struct UPPER_LOWER *)a;
+	const struct UPPER_LOWER *ul_b = (const struct UPPER_LOWER *)b;
 	return ul_a->upper - ul_b->upper;
 }
 

--- a/src/engine/client/backend/opengl/backend_opengl.cpp
+++ b/src/engine/client/backend/opengl/backend_opengl.cpp
@@ -2179,7 +2179,7 @@ void CCommandProcessorFragment_OpenGL2::Cmd_RenderBorderTile(const CCommandBuffe
 
 	SBufferContainer &BufferContainer = m_BufferContainers[Index];
 
-	RenderBorderTileEmulation(BufferContainer, pCommand->m_State, (float *)&pCommand->m_Color, pCommand->m_pIndicesOffset, pCommand->m_DrawNum, pCommand->m_Offset, pCommand->m_Dir, pCommand->m_JumpIndex);
+	RenderBorderTileEmulation(BufferContainer, pCommand->m_State, (const float *)&pCommand->m_Color, pCommand->m_pIndicesOffset, pCommand->m_DrawNum, pCommand->m_Offset, pCommand->m_Dir, pCommand->m_JumpIndex);
 }
 
 void CCommandProcessorFragment_OpenGL2::Cmd_RenderBorderTileLine(const CCommandBuffer::SCommand_RenderBorderTileLine *pCommand)
@@ -2191,7 +2191,7 @@ void CCommandProcessorFragment_OpenGL2::Cmd_RenderBorderTileLine(const CCommandB
 
 	SBufferContainer &BufferContainer = m_BufferContainers[Index];
 
-	RenderBorderTileLineEmulation(BufferContainer, pCommand->m_State, (float *)&pCommand->m_Color, pCommand->m_pIndicesOffset, pCommand->m_IndexDrawNum, pCommand->m_DrawNum, pCommand->m_Offset, pCommand->m_Dir);
+	RenderBorderTileLineEmulation(BufferContainer, pCommand->m_State, (const float *)&pCommand->m_Color, pCommand->m_pIndicesOffset, pCommand->m_IndexDrawNum, pCommand->m_DrawNum, pCommand->m_Offset, pCommand->m_Dir);
 }
 
 void CCommandProcessorFragment_OpenGL2::Cmd_RenderTileLayer(const CCommandBuffer::SCommand_RenderTileLayer *pCommand)
@@ -2221,7 +2221,7 @@ void CCommandProcessorFragment_OpenGL2::Cmd_RenderTileLayer(const CCommandBuffer
 		UseProgram(pProgram);
 
 		SetState(pCommand->m_State, pProgram, true);
-		pProgram->SetUniformVec4(pProgram->m_LocColor, 1, (float *)&pCommand->m_Color);
+		pProgram->SetUniformVec4(pProgram->m_LocColor, 1, (const float *)&pCommand->m_Color);
 	}
 	else
 	{

--- a/src/engine/client/backend/opengl/backend_opengl3.cpp
+++ b/src/engine/client/backend/opengl/backend_opengl3.cpp
@@ -1130,10 +1130,10 @@ void CCommandProcessorFragment_OpenGL3_3::Cmd_RenderBorderTile(const CCommandBuf
 	UseProgram(pProgram);
 
 	SetState(pCommand->m_State, pProgram, true);
-	pProgram->SetUniformVec4(pProgram->m_LocColor, 1, (float *)&pCommand->m_Color);
+	pProgram->SetUniformVec4(pProgram->m_LocColor, 1, (const float *)&pCommand->m_Color);
 
-	pProgram->SetUniformVec2(pProgram->m_LocOffset, 1, (float *)&pCommand->m_Offset);
-	pProgram->SetUniformVec2(pProgram->m_LocDir, 1, (float *)&pCommand->m_Dir);
+	pProgram->SetUniformVec2(pProgram->m_LocOffset, 1, (const float *)&pCommand->m_Offset);
+	pProgram->SetUniformVec2(pProgram->m_LocDir, 1, (const float *)&pCommand->m_Dir);
 	pProgram->SetUniform(pProgram->m_LocJumpIndex, (int)pCommand->m_JumpIndex);
 
 	glBindVertexArray(BufferContainer.m_VertArrayID);
@@ -1166,9 +1166,9 @@ void CCommandProcessorFragment_OpenGL3_3::Cmd_RenderBorderTileLine(const CComman
 	UseProgram(pProgram);
 
 	SetState(pCommand->m_State, pProgram, true);
-	pProgram->SetUniformVec4(pProgram->m_LocColor, 1, (float *)&pCommand->m_Color);
-	pProgram->SetUniformVec2(pProgram->m_LocOffset, 1, (float *)&pCommand->m_Offset);
-	pProgram->SetUniformVec2(pProgram->m_LocDir, 1, (float *)&pCommand->m_Dir);
+	pProgram->SetUniformVec4(pProgram->m_LocColor, 1, (const float *)&pCommand->m_Color);
+	pProgram->SetUniformVec2(pProgram->m_LocOffset, 1, (const float *)&pCommand->m_Offset);
+	pProgram->SetUniformVec2(pProgram->m_LocDir, 1, (const float *)&pCommand->m_Dir);
 
 	glBindVertexArray(BufferContainer.m_VertArrayID);
 	if(BufferContainer.m_LastIndexBufferBound != m_QuadDrawIndexBufferID)
@@ -1206,7 +1206,7 @@ void CCommandProcessorFragment_OpenGL3_3::Cmd_RenderTileLayer(const CCommandBuff
 	UseProgram(pProgram);
 
 	SetState(pCommand->m_State, pProgram, true);
-	pProgram->SetUniformVec4(pProgram->m_LocColor, 1, (float *)&pCommand->m_Color);
+	pProgram->SetUniformVec4(pProgram->m_LocColor, 1, (const float *)&pCommand->m_Color);
 
 	glBindVertexArray(BufferContainer.m_VertArrayID);
 	if(BufferContainer.m_LastIndexBufferBound != m_QuadDrawIndexBufferID)
@@ -1351,7 +1351,7 @@ void CCommandProcessorFragment_OpenGL3_3::RenderText(const CCommandBuffer::SStat
 
 	if(m_pTextProgram->m_LastOutlineColor[0] != pTextOutlineColor[0] || m_pTextProgram->m_LastOutlineColor[1] != pTextOutlineColor[1] || m_pTextProgram->m_LastOutlineColor[2] != pTextOutlineColor[2] || m_pTextProgram->m_LastOutlineColor[3] != pTextOutlineColor[3])
 	{
-		m_pTextProgram->SetUniformVec4(m_pTextProgram->m_LocOutlineColor, 1, (float *)pTextOutlineColor);
+		m_pTextProgram->SetUniformVec4(m_pTextProgram->m_LocOutlineColor, 1, (const float *)pTextOutlineColor);
 		m_pTextProgram->m_LastOutlineColor[0] = pTextOutlineColor[0];
 		m_pTextProgram->m_LastOutlineColor[1] = pTextOutlineColor[1];
 		m_pTextProgram->m_LastOutlineColor[2] = pTextOutlineColor[2];
@@ -1360,7 +1360,7 @@ void CCommandProcessorFragment_OpenGL3_3::RenderText(const CCommandBuffer::SStat
 
 	if(m_pTextProgram->m_LastColor[0] != pTextColor[0] || m_pTextProgram->m_LastColor[1] != pTextColor[1] || m_pTextProgram->m_LastColor[2] != pTextColor[2] || m_pTextProgram->m_LastColor[3] != pTextColor[3])
 	{
-		m_pTextProgram->SetUniformVec4(m_pTextProgram->m_LocColor, 1, (float *)pTextColor);
+		m_pTextProgram->SetUniformVec4(m_pTextProgram->m_LocColor, 1, (const float *)pTextColor);
 		m_pTextProgram->m_LastColor[0] = pTextColor[0];
 		m_pTextProgram->m_LastColor[1] = pTextColor[1];
 		m_pTextProgram->m_LastColor[2] = pTextColor[2];
@@ -1488,7 +1488,7 @@ void CCommandProcessorFragment_OpenGL3_3::Cmd_RenderQuadContainerEx(const CComma
 
 	if(pCommand->m_Rotation != 0.0f && (pProgram->m_LastCenter[0] != pCommand->m_Center.x || pProgram->m_LastCenter[1] != pCommand->m_Center.y))
 	{
-		pProgram->SetUniformVec2(pProgram->m_LocCenter, 1, (float *)&pCommand->m_Center);
+		pProgram->SetUniformVec2(pProgram->m_LocCenter, 1, (const float *)&pCommand->m_Center);
 		pProgram->m_LastCenter[0] = pCommand->m_Center.x;
 		pProgram->m_LastCenter[1] = pCommand->m_Center.y;
 	}
@@ -1501,7 +1501,7 @@ void CCommandProcessorFragment_OpenGL3_3::Cmd_RenderQuadContainerEx(const CComma
 
 	if(pProgram->m_LastVertciesColor[0] != pCommand->m_VertexColor.r || pProgram->m_LastVertciesColor[1] != pCommand->m_VertexColor.g || pProgram->m_LastVertciesColor[2] != pCommand->m_VertexColor.b || pProgram->m_LastVertciesColor[3] != pCommand->m_VertexColor.a)
 	{
-		pProgram->SetUniformVec4(pProgram->m_LocVertciesColor, 1, (float *)&pCommand->m_VertexColor);
+		pProgram->SetUniformVec4(pProgram->m_LocVertciesColor, 1, (const float *)&pCommand->m_VertexColor);
 		pProgram->m_LastVertciesColor[0] = pCommand->m_VertexColor.r;
 		pProgram->m_LastVertciesColor[1] = pCommand->m_VertexColor.g;
 		pProgram->m_LastVertciesColor[2] = pCommand->m_VertexColor.b;
@@ -1539,14 +1539,14 @@ void CCommandProcessorFragment_OpenGL3_3::Cmd_RenderQuadContainerAsSpriteMultipl
 
 	if((m_pSpriteProgramMultiple->m_LastCenter[0] != pCommand->m_Center.x || m_pSpriteProgramMultiple->m_LastCenter[1] != pCommand->m_Center.y))
 	{
-		m_pSpriteProgramMultiple->SetUniformVec2(m_pSpriteProgramMultiple->m_LocCenter, 1, (float *)&pCommand->m_Center);
+		m_pSpriteProgramMultiple->SetUniformVec2(m_pSpriteProgramMultiple->m_LocCenter, 1, (const float *)&pCommand->m_Center);
 		m_pSpriteProgramMultiple->m_LastCenter[0] = pCommand->m_Center.x;
 		m_pSpriteProgramMultiple->m_LastCenter[1] = pCommand->m_Center.y;
 	}
 
 	if(m_pSpriteProgramMultiple->m_LastVertciesColor[0] != pCommand->m_VertexColor.r || m_pSpriteProgramMultiple->m_LastVertciesColor[1] != pCommand->m_VertexColor.g || m_pSpriteProgramMultiple->m_LastVertciesColor[2] != pCommand->m_VertexColor.b || m_pSpriteProgramMultiple->m_LastVertciesColor[3] != pCommand->m_VertexColor.a)
 	{
-		m_pSpriteProgramMultiple->SetUniformVec4(m_pSpriteProgramMultiple->m_LocVertciesColor, 1, (float *)&pCommand->m_VertexColor);
+		m_pSpriteProgramMultiple->SetUniformVec4(m_pSpriteProgramMultiple->m_LocVertciesColor, 1, (const float *)&pCommand->m_VertexColor);
 		m_pSpriteProgramMultiple->m_LastVertciesColor[0] = pCommand->m_VertexColor.r;
 		m_pSpriteProgramMultiple->m_LastVertciesColor[1] = pCommand->m_VertexColor.g;
 		m_pSpriteProgramMultiple->m_LastVertciesColor[2] = pCommand->m_VertexColor.b;

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -611,7 +611,7 @@ int *CClient::GetInput(int Tick, int IsDummy) const
 	}
 
 	if(Best != -1)
-		return (int *)m_aInputs[g_Config.m_ClDummy][Best].m_aData;
+		return (int *)m_aInputs[g_Config.m_ClDummy][Best].m_aData; // Wcast-qual
 	return 0;
 }
 
@@ -620,7 +620,7 @@ int *CClient::GetDirectInput(int Tick, int IsDummy) const
 	const int d = IsDummy ^ g_Config.m_ClDummy;
 	for(int i = 0; i < 200; i++)
 		if(m_aInputs[d][i].m_Tick == Tick)
-			return (int *)m_aInputs[d][i].m_aData;
+			return (int *)m_aInputs[d][i].m_aData; // Wcast-qual
 	return 0;
 }
 
@@ -714,9 +714,9 @@ void GenerateTimeoutCode(char *pBuffer, unsigned Size, char *pSeed, const NETADD
 	MD5_CTX Md5;
 	md5_init(&Md5);
 	const char *pDummy = Dummy ? "dummy" : "normal";
-	md5_update(&Md5, (unsigned char *)pDummy, str_length(pDummy) + 1);
-	md5_update(&Md5, (unsigned char *)pSeed, str_length(pSeed) + 1);
-	md5_update(&Md5, (unsigned char *)&Addr, sizeof(Addr));
+	md5_update(&Md5, (const unsigned char *)pDummy, str_length(pDummy) + 1);
+	md5_update(&Md5, (const unsigned char *)pSeed, str_length(pSeed) + 1);
+	md5_update(&Md5, (const unsigned char *)&Addr, sizeof(Addr));
 	MD5_DIGEST Digest = md5_finish(&Md5);
 
 	unsigned short Random[8];
@@ -1321,7 +1321,7 @@ void CClient::ProcessConnlessPacket(CNetChunk *pPacket)
 
 		if(Type != -1)
 		{
-			void *pData = (unsigned char *)pPacket->m_pData + sizeof(SERVERBROWSE_INFO);
+			const void *pData = (const unsigned char *)pPacket->m_pData + sizeof(SERVERBROWSE_INFO);
 			int DataSize = pPacket->m_DataSize - sizeof(SERVERBROWSE_INFO);
 			ProcessServerInfo(Type, &pPacket->m_Address, pData, DataSize);
 		}
@@ -1610,7 +1610,7 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket, int Conn, bool Dummy)
 		if(Conn == CONN_MAIN && (pPacket->m_Flags & NET_CHUNKFLAG_VITAL) != 0 && Msg == NETMSG_MAP_DETAILS)
 		{
 			const char *pMap = Unpacker.GetString(CUnpacker::SANITIZE_CC | CUnpacker::SKIP_START_WHITESPACES);
-			SHA256_DIGEST *pMapSha256 = (SHA256_DIGEST *)Unpacker.GetRaw(sizeof(*pMapSha256));
+			const SHA256_DIGEST *pMapSha256 = (const SHA256_DIGEST *)Unpacker.GetRaw(sizeof(*pMapSha256));
 			int MapCrc = Unpacker.GetInt();
 
 			if(Unpacker.Error())
@@ -1789,7 +1789,7 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket, int Conn, bool Dummy)
 		}
 		else if(Msg == NETMSG_PINGEX)
 		{
-			CUuid *pID = (CUuid *)Unpacker.GetRaw(sizeof(*pID));
+			const CUuid *pID = (const CUuid *)Unpacker.GetRaw(sizeof(*pID));
 			if(Unpacker.Error())
 			{
 				return;
@@ -1800,7 +1800,7 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket, int Conn, bool Dummy)
 		}
 		else if(Conn == CONN_MAIN && Msg == NETMSG_PONGEX)
 		{
-			CUuid *pID = (CUuid *)Unpacker.GetRaw(sizeof(*pID));
+			const CUuid *pID = (const CUuid *)Unpacker.GetRaw(sizeof(*pID));
 			if(Unpacker.Error())
 			{
 				return;
@@ -1818,7 +1818,7 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket, int Conn, bool Dummy)
 		}
 		else if(Msg == NETMSG_CHECKSUM_REQUEST)
 		{
-			CUuid *pUuid = (CUuid *)Unpacker.GetRaw(sizeof(*pUuid));
+			const CUuid *pUuid = (const CUuid *)Unpacker.GetRaw(sizeof(*pUuid));
 			if(Unpacker.Error())
 			{
 				return;
@@ -4446,7 +4446,7 @@ int main(int argc, const char **argv)
 	if(Restarting)
 	{
 		char aBuf[512];
-		shell_execute(pStorage->GetBinaryPath(PLAT_CLIENT_EXEC, aBuf, sizeof aBuf));
+		shell_execute(const_cast<char*>(pStorage->GetBinaryPath(PLAT_CLIENT_EXEC, aBuf, sizeof aBuf))); // Wcast-qual
 	}
 
 	delete pKernel;

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -4446,7 +4446,7 @@ int main(int argc, const char **argv)
 	if(Restarting)
 	{
 		char aBuf[512];
-		shell_execute(const_cast<char*>(pStorage->GetBinaryPath(PLAT_CLIENT_EXEC, aBuf, sizeof aBuf))); // Wcast-qual
+		shell_execute(const_cast<char *>(pStorage->GetBinaryPath(PLAT_CLIENT_EXEC, aBuf, sizeof aBuf))); // Wcast-qual
 	}
 
 	delete pKernel;

--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -180,7 +180,7 @@ int CServerBrowser::GenerateToken(const NETADDR &Addr) const
 	SHA256_CTX Sha256;
 	sha256_init(&Sha256);
 	sha256_update(&Sha256, m_aTokenSeed, sizeof(m_aTokenSeed));
-	sha256_update(&Sha256, (unsigned char *)&Addr, sizeof(Addr));
+	sha256_update(&Sha256, (const unsigned char *)&Addr, sizeof(Addr));
 	SHA256_DIGEST Digest = sha256_finish(&Sha256);
 	return (Digest.data[0] << 16) | (Digest.data[1] << 8) | Digest.data[2];
 }
@@ -461,7 +461,7 @@ void CServerBrowser::RemoveRequest(CServerEntry *pEntry)
 	}
 }
 
-CServerBrowser::CServerEntry *CServerBrowser::Find(const NETADDR &Addr)
+CServerBrowser::CServerEntry *CServerBrowser::Find(const NETADDR &Addr) const
 {
 	CServerEntry *pEntry = m_aServerlistIp[Addr.ip[0]];
 
@@ -1264,7 +1264,7 @@ int CServerBrowser::FindFavorite(const NETADDR &Addr) const
 
 bool CServerBrowser::GotInfo(const NETADDR &Addr) const
 {
-	CServerEntry *pEntry = ((CServerBrowser *)this)->Find(Addr);
+	const CServerEntry *pEntry = Find(Addr);
 	return pEntry && pEntry->m_GotInfo;
 }
 

--- a/src/engine/client/serverbrowser.h
+++ b/src/engine/client/serverbrowser.h
@@ -142,7 +142,7 @@ public:
 
 	void RequestImpl64(const NETADDR &Addr, CServerEntry *pEntry) const;
 	void QueueRequest(CServerEntry *pEntry);
-	CServerEntry *Find(const NETADDR &Addr);
+	CServerEntry *Find(const NETADDR &Addr) const;
 	int GetCurrentType() { return m_ServerlistType; }
 
 private:

--- a/src/engine/client/text.cpp
+++ b/src/engine/client/text.cpp
@@ -719,7 +719,7 @@ public:
 
 		dbg_msg("textrender", "loaded pFont from '%s'", pFilename);
 
-		pFont->m_pBuf = const_cast<unsigned char*>(pBuf);
+		pFont->m_pBuf = const_cast<unsigned char *>(pBuf);
 		pFont->m_CurTextureDimensions[0] = 1024;
 		pFont->m_TextureData[0] = new unsigned char[pFont->m_CurTextureDimensions[0] * pFont->m_CurTextureDimensions[0]];
 		mem_zero(pFont->m_TextureData[0], (size_t)pFont->m_CurTextureDimensions[0] * pFont->m_CurTextureDimensions[0] * sizeof(unsigned char));
@@ -743,7 +743,7 @@ public:
 	virtual bool LoadFallbackFont(CFont *pFont, const char *pFilename, const unsigned char *pBuf, size_t Size)
 	{
 		CFont::SFontFallBack FallbackFont;
-		FallbackFont.m_pBuf = const_cast<unsigned char*>(pBuf);
+		FallbackFont.m_pBuf = const_cast<unsigned char *>(pBuf);
 		str_copy(FallbackFont.m_aFilename, pFilename, sizeof(FallbackFont.m_aFilename));
 
 		if(FT_New_Memory_Face(m_FTLibrary, pBuf, Size, 0, &FallbackFont.m_FtFace) == 0)

--- a/src/engine/client/text.cpp
+++ b/src/engine/client/text.cpp
@@ -719,7 +719,7 @@ public:
 
 		dbg_msg("textrender", "loaded pFont from '%s'", pFilename);
 
-		pFont->m_pBuf = (void *)pBuf;
+		pFont->m_pBuf = const_cast<unsigned char*>(pBuf);
 		pFont->m_CurTextureDimensions[0] = 1024;
 		pFont->m_TextureData[0] = new unsigned char[pFont->m_CurTextureDimensions[0] * pFont->m_CurTextureDimensions[0]];
 		mem_zero(pFont->m_TextureData[0], (size_t)pFont->m_CurTextureDimensions[0] * pFont->m_CurTextureDimensions[0] * sizeof(unsigned char));
@@ -743,7 +743,7 @@ public:
 	virtual bool LoadFallbackFont(CFont *pFont, const char *pFilename, const unsigned char *pBuf, size_t Size)
 	{
 		CFont::SFontFallBack FallbackFont;
-		FallbackFont.m_pBuf = (void *)pBuf;
+		FallbackFont.m_pBuf = const_cast<unsigned char*>(pBuf);
 		str_copy(FallbackFont.m_aFilename, pFilename, sizeof(FallbackFont.m_aFilename));
 
 		if(FT_New_Memory_Face(m_FTLibrary, pBuf, Size, 0, &FallbackFont.m_FtFace) == 0)
@@ -1049,7 +1049,7 @@ public:
 
 		float Scale = 1.0f / pSizeData->m_FontSize;
 
-		const char *pCurrent = (char *)pText;
+		const char *pCurrent = (const char *)pText;
 		const char *pEnd = pCurrent + Length;
 
 		int RenderFlags = TextContainer.m_RenderFlags;
@@ -1163,7 +1163,7 @@ public:
 			const char *pBatchEnd = pEnd;
 			if(pCursor->m_LineWidth > 0 && !(pCursor->m_Flags & TEXTFLAG_STOP_AT_END))
 			{
-				int Wlen = minimum(WordLength((char *)pCurrent), (int)(pEnd - pCurrent));
+				int Wlen = minimum(WordLength((const char *)pCurrent), (int)(pEnd - pCurrent));
 				CTextCursor Compare = *pCursor;
 				Compare.m_CalculateSelectionMode = TEXT_CURSOR_SELECTION_MODE_NONE;
 				Compare.m_CursorMode = TEXT_CURSOR_CURSOR_MODE_NONE;
@@ -1658,7 +1658,7 @@ public:
 		if(FontSize < 1)
 			return;
 
-		const char *pCurrent = (char *)pText;
+		const char *pCurrent = (const char *)pText;
 		const char *pEnd = pCurrent + Length;
 		CFont *pFont = m_pDefaultFont;
 		FT_Bitmap *pBitmap;
@@ -1770,7 +1770,7 @@ public:
 	virtual int CalculateTextWidth(const char *pText, int TextLength, int FontWidth, int FontHeight)
 	{
 		CFont *pFont = m_pDefaultFont;
-		const char *pCurrent = (char *)pText;
+		const char *pCurrent = (const char *)pText;
 		const char *pEnd = pCurrent + TextLength;
 
 		int WidthOfText = 0;

--- a/src/engine/client/video.cpp
+++ b/src/engine/client/video.cpp
@@ -333,7 +333,7 @@ void CVideo::NextAudioFrame(void (*Mix)(short *pFinalOut, unsigned Frames))
 			m_AudioStream.pSwrCtx,
 			m_AudioStream.pFrame->data,
 			m_AudioStream.pFrame->nb_samples,
-			(const uint8_t **)m_AudioStream.pTmpFrame->data,
+			const_cast<const uint8_t**>(m_AudioStream.pTmpFrame->data),
 			m_AudioStream.pTmpFrame->nb_samples);
 
 		if(Ret < 0)

--- a/src/engine/client/video.cpp
+++ b/src/engine/client/video.cpp
@@ -333,7 +333,7 @@ void CVideo::NextAudioFrame(void (*Mix)(short *pFinalOut, unsigned Frames))
 			m_AudioStream.pSwrCtx,
 			m_AudioStream.pFrame->data,
 			m_AudioStream.pFrame->nb_samples,
-			const_cast<const uint8_t**>(m_AudioStream.pTmpFrame->data),
+			const_cast<const uint8_t **>(m_AudioStream.pTmpFrame->data),
 			m_AudioStream.pTmpFrame->nb_samples);
 
 		if(Ret < 0)

--- a/src/engine/server/authmanager.cpp
+++ b/src/engine/server/authmanager.cpp
@@ -11,7 +11,7 @@ static MD5_DIGEST HashPassword(const char *pPassword, const unsigned char aSalt[
 	// Hash the password and the salt
 	MD5_CTX Md5;
 	md5_init(&Md5);
-	md5_update(&Md5, (unsigned char *)pPassword, str_length(pPassword));
+	md5_update(&Md5, pPassword, str_length(pPassword));
 	md5_update(&Md5, aSalt, SALT_BYTES);
 	return md5_finish(&Md5);
 }

--- a/src/engine/server/register.cpp
+++ b/src/engine/server/register.cpp
@@ -105,7 +105,7 @@ void CRegister::RegisterSendCountRequest(NETADDR Addr, SECURITY_TOKEN ResponseTo
 
 void CRegister::RegisterGotCount(CNetChunk *pChunk)
 {
-	unsigned char *pData = (unsigned char *)pChunk->m_pData;
+	const unsigned char *pData = (const unsigned char *)pChunk->m_pData;
 	int Count = (pData[sizeof(SERVERBROWSE_COUNT)] << 8) | pData[sizeof(SERVERBROWSE_COUNT) + 1];
 
 	for(auto &MasterserverInfo : m_aMasterserverInfo)

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -1384,7 +1384,7 @@ void CServer::ProcessClientPacket(CNetChunk *pPacket)
 		{
 			if((pPacket->m_Flags & NET_CHUNKFLAG_VITAL) != 0 && m_aClients[ClientID].m_State == CClient::STATE_PREAUTH)
 			{
-				CUuid *pConnectionID = (CUuid *)Unpacker.GetRaw(sizeof(*pConnectionID));
+				const CUuid *pConnectionID = (const CUuid *)Unpacker.GetRaw(sizeof(*pConnectionID));
 				int DDNetVersion = Unpacker.GetInt();
 				const char *pDDNetVersionStr = Unpacker.GetString(CUnpacker::SANITIZE_CC);
 				if(Unpacker.Error() || !str_utf8_check(pDDNetVersionStr) || DDNetVersion < 0)
@@ -1712,7 +1712,7 @@ void CServer::ProcessClientPacket(CNetChunk *pPacket)
 		}
 		else if(Msg == NETMSG_PINGEX)
 		{
-			CUuid *pID = (CUuid *)Unpacker.GetRaw(sizeof(*pID));
+			const CUuid *pID = (const CUuid *)Unpacker.GetRaw(sizeof(*pID));
 			if(Unpacker.Error())
 			{
 				return;
@@ -2221,7 +2221,7 @@ void CServer::PumpNetwork(bool PacketWaiting)
 					if(Type == SERVERINFO_VANILLA && ResponseToken != NET_SECURITY_TOKEN_UNKNOWN && Config()->m_SvSixup)
 					{
 						CUnpacker Unpacker;
-						Unpacker.Reset((unsigned char *)Packet.m_pData + sizeof(SERVERBROWSE_GETINFO), Packet.m_DataSize - sizeof(SERVERBROWSE_GETINFO));
+						Unpacker.Reset((const unsigned char *)Packet.m_pData + sizeof(SERVERBROWSE_GETINFO), Packet.m_DataSize - sizeof(SERVERBROWSE_GETINFO));
 						int SrvBrwsToken = Unpacker.GetInt();
 						if(Unpacker.Error())
 							continue;
@@ -2240,7 +2240,7 @@ void CServer::PumpNetwork(bool PacketWaiting)
 					}
 					else if(Type != -1)
 					{
-						int Token = ((unsigned char *)Packet.m_pData)[sizeof(SERVERBROWSE_GETINFO)];
+						int Token = ((const unsigned char *)Packet.m_pData)[sizeof(SERVERBROWSE_GETINFO)];
 						Token |= ExtraToken << 8;
 						SendServerInfoConnless(&Packet.m_Address, Token, Type);
 					}

--- a/src/engine/shared/compression.cpp
+++ b/src/engine/shared/compression.cpp
@@ -67,7 +67,7 @@ long CVariableInt::Decompress(const void *pSrc_, int SrcSize, void *pDst_, int D
 {
 	dbg_assert(DstSize % sizeof(int) == 0, "invalid bounds");
 
-	const unsigned char *pSrc = (unsigned char *)pSrc_;
+	const unsigned char *pSrc = (const unsigned char *)pSrc_;
 	const unsigned char *pSrcEnd = pSrc + SrcSize;
 	int *pDst = (int *)pDst_;
 	const int *pDstEnd = pDst + DstSize / sizeof(int);
@@ -87,7 +87,7 @@ long CVariableInt::Compress(const void *pSrc_, int SrcSize, void *pDst_, int Dst
 {
 	dbg_assert(SrcSize % sizeof(int) == 0, "invalid bounds");
 
-	const int *pSrc = (int *)pSrc_;
+	const int *pSrc = (const int *)pSrc_;
 	unsigned char *pDst = (unsigned char *)pDst_;
 	const unsigned char *pDstEnd = pDst + DstSize;
 	SrcSize /= sizeof(int);

--- a/src/engine/shared/demo.cpp
+++ b/src/engine/shared/demo.cpp
@@ -311,7 +311,7 @@ void CDemoRecorder::RecordSnapshot(int Tick, const void *pData, int Size)
 		// write tickmarker
 		WriteTickMarker(Tick, 0);
 
-		DeltaSize = m_pSnapshotDelta->CreateDelta((CSnapshot *)m_aLastSnapshotData, (CSnapshot *)pData, &aDeltaData);
+		DeltaSize = m_pSnapshotDelta->CreateDelta((const CSnapshot *)m_aLastSnapshotData, (const CSnapshot *)pData, &aDeltaData);
 		if(DeltaSize)
 		{
 			// record delta

--- a/src/engine/shared/huffman.cpp
+++ b/src/engine/shared/huffman.cpp
@@ -150,9 +150,9 @@ int CHuffman::Compress(const void *pInput, int InputSize, void *pOutput, int Out
 
 	// setup buffer pointers
 	const unsigned char *pSrc = (const unsigned char *)pInput;
-	const unsigned char *pSrcEnd = pSrc + InputSize;
+	const unsigned char *const pSrcEnd = pSrc + InputSize;
 	unsigned char *pDst = (unsigned char *)pOutput;
-	unsigned char *pDstEnd = pDst + OutputSize;
+	const unsigned char *const pDstEnd = pDst + OutputSize;
 
 	// symbol variables
 	unsigned Bits = 0;
@@ -201,9 +201,9 @@ int CHuffman::Decompress(const void *pInput, int InputSize, void *pOutput, int O
 {
 	// setup buffer pointers
 	unsigned char *pDst = (unsigned char *)pOutput;
-	unsigned char *pSrc = (unsigned char *)pInput;
-	unsigned char *pDstEnd = pDst + OutputSize;
-	unsigned char *pSrcEnd = pSrc + InputSize;
+	const unsigned char *pSrc = (const unsigned char *)pInput;
+	const unsigned char *const pDstEnd = pDst + OutputSize;
+	const unsigned char *const pSrcEnd = pSrc + InputSize;
 
 	unsigned Bits = 0;
 	unsigned Bitcount = 0;

--- a/src/engine/shared/network_server.cpp
+++ b/src/engine/shared/network_server.cpp
@@ -138,8 +138,8 @@ SECURITY_TOKEN CNetServer::GetToken(const NETADDR &Addr)
 {
 	SHA256_CTX Sha256;
 	sha256_init(&Sha256);
-	sha256_update(&Sha256, (unsigned char *)m_aSecurityTokenSeed, sizeof(m_aSecurityTokenSeed));
-	sha256_update(&Sha256, (unsigned char *)&Addr, 20); // omit port, bad idea!
+	sha256_update(&Sha256, (const void *)m_aSecurityTokenSeed, sizeof(m_aSecurityTokenSeed));
+	sha256_update(&Sha256, (const void *)&Addr, 20); // omit port, bad idea!
 
 	SECURITY_TOKEN SecurityToken = ToSecurityToken(sha256_finish(&Sha256).data);
 

--- a/src/engine/shared/packer.cpp
+++ b/src/engine/shared/packer.cpp
@@ -86,7 +86,7 @@ void CUnpacker::Reset(const void *pData, int Size)
 	m_Error = 0;
 	m_pStart = (const unsigned char *)pData;
 	m_pEnd = m_pStart + Size;
-	m_pCurrent = const_cast<unsigned char*>(m_pStart);
+	m_pCurrent = const_cast<unsigned char *>(m_pStart);
 }
 
 int CUnpacker::GetInt()
@@ -107,7 +107,7 @@ int CUnpacker::GetInt()
 		m_Error = 1;
 		return 0;
 	}
-	m_pCurrent = const_cast<unsigned char*>(pNext);
+	m_pCurrent = const_cast<unsigned char *>(pNext);
 	return i;
 }
 

--- a/src/engine/shared/packer.cpp
+++ b/src/engine/shared/packer.cpp
@@ -86,7 +86,7 @@ void CUnpacker::Reset(const void *pData, int Size)
 	m_Error = 0;
 	m_pStart = (const unsigned char *)pData;
 	m_pEnd = m_pStart + Size;
-	m_pCurrent = m_pStart;
+	m_pCurrent = const_cast<unsigned char*>(m_pStart);
 }
 
 int CUnpacker::GetInt()
@@ -107,7 +107,7 @@ int CUnpacker::GetInt()
 		m_Error = 1;
 		return 0;
 	}
-	m_pCurrent = pNext;
+	m_pCurrent = const_cast<unsigned char*>(pNext);
 	return i;
 }
 

--- a/src/engine/shared/packer.h
+++ b/src/engine/shared/packer.h
@@ -31,7 +31,7 @@ public:
 class CUnpacker
 {
 	const unsigned char *m_pStart;
-	const unsigned char *m_pCurrent;
+	unsigned char *m_pCurrent;
 	const unsigned char *m_pEnd;
 	int m_Error;
 

--- a/src/engine/shared/snapshot.cpp
+++ b/src/engine/shared/snapshot.cpp
@@ -13,7 +13,7 @@
 
 CSnapshotItem *CSnapshot::GetItem(int Index) const
 {
-	return const_cast<CSnapshotItem *>((const CSnapshotItem*)(DataStart() + Offsets()[Index])); // Wcast-qual
+	return const_cast<CSnapshotItem *>((const CSnapshotItem *)(DataStart() + Offsets()[Index])); // Wcast-qual
 }
 
 int CSnapshot::GetItemSize(int Index) const
@@ -321,7 +321,7 @@ static int RangeCheck(const void *pEnd, const void *pPtr, const int Size)
 int CSnapshotDelta::UnpackDelta(const CSnapshot *pFrom, CSnapshot *pTo, const void *pSrcData, int DataSize)
 {
 	const CData *pDelta = (const CData *)pSrcData;
-	int *pData = const_cast<int*>(pDelta->m_aData); // Wcast-qual
+	int *pData = const_cast<int *>(pDelta->m_aData); // Wcast-qual
 	const int *pEnd = (const int *)(((const char *)pSrcData + DataSize));
 
 	CSnapshotBuilder Builder;

--- a/src/engine/shared/snapshot.cpp
+++ b/src/engine/shared/snapshot.cpp
@@ -13,7 +13,7 @@
 
 CSnapshotItem *CSnapshot::GetItem(int Index) const
 {
-	return (CSnapshotItem *)(DataStart() + Offsets()[Index]);
+	return const_cast<CSnapshotItem *>((const CSnapshotItem*)(DataStart() + Offsets()[Index])); // Wcast-qual
 }
 
 int CSnapshot::GetItemSize(int Index) const
@@ -131,7 +131,7 @@ enum
 	HASHLIST_SIZE = 256,
 };
 
-static void GenerateHash(CItemList *pHashlist, CSnapshot *pSnapshot)
+static void GenerateHash(CItemList *pHashlist, const CSnapshot *pSnapshot)
 {
 	for(int i = 0; i < HASHLIST_SIZE; i++)
 		pHashlist[i].m_Num = 0;
@@ -161,7 +161,7 @@ static int GetItemIndexHashed(int Key, const CItemList *pHashlist)
 	return -1;
 }
 
-int CSnapshotDelta::DiffItem(int *pPast, int *pCurrent, int *pOut, int Size)
+int CSnapshotDelta::DiffItem(const int *pPast, const int *pCurrent, int *pOut, int Size)
 {
 	int Needed = 0;
 	while(Size)
@@ -177,7 +177,7 @@ int CSnapshotDelta::DiffItem(int *pPast, int *pCurrent, int *pOut, int Size)
 	return Needed;
 }
 
-void CSnapshotDelta::UndiffItem(int *pPast, int *pDiff, int *pOut, int Size, int *pDataRate)
+void CSnapshotDelta::UndiffItem(const int *pPast, const int *pDiff, int *pOut, int Size, int *pDataRate)
 {
 	while(Size)
 	{
@@ -228,7 +228,7 @@ const CSnapshotDelta::CData *CSnapshotDelta::EmptyDelta() const
 }
 
 // TODO: OPT: this should be made much faster
-int CSnapshotDelta::CreateDelta(CSnapshot *pFrom, CSnapshot *pTo, void *pDstData)
+int CSnapshotDelta::CreateDelta(const CSnapshot *pFrom, const CSnapshot *pTo, void *pDstData)
 {
 	CData *pDelta = (CData *)pDstData;
 	int *pData = (int *)pDelta->m_aData;
@@ -311,18 +311,18 @@ int CSnapshotDelta::CreateDelta(CSnapshot *pFrom, CSnapshot *pTo, void *pDstData
 	return (int)((char *)pData - (char *)pDstData);
 }
 
-static int RangeCheck(void *pEnd, void *pPtr, int Size)
+static int RangeCheck(const void *pEnd, const void *pPtr, const int Size)
 {
 	if((const char *)pPtr + Size > (const char *)pEnd)
 		return -1;
 	return 0;
 }
 
-int CSnapshotDelta::UnpackDelta(CSnapshot *pFrom, CSnapshot *pTo, const void *pSrcData, int DataSize)
+int CSnapshotDelta::UnpackDelta(const CSnapshot *pFrom, CSnapshot *pTo, const void *pSrcData, int DataSize)
 {
-	CData *pDelta = (CData *)pSrcData;
-	int *pData = (int *)pDelta->m_aData;
-	int *pEnd = (int *)(((char *)pSrcData + DataSize));
+	const CData *pDelta = (const CData *)pSrcData;
+	int *pData = const_cast<int*>(pDelta->m_aData); // Wcast-qual
+	const int *pEnd = (const int *)(((const char *)pSrcData + DataSize));
 
 	CSnapshotBuilder Builder;
 	Builder.Init();

--- a/src/engine/shared/snapshot.h
+++ b/src/engine/shared/snapshot.h
@@ -24,7 +24,7 @@ class CSnapshot
 	int m_DataSize;
 	int m_NumItems;
 
-	int *Offsets()    const { return (int *)(this + 1); } // Wcast-qual
+	int *Offsets() const { return (int *)(this + 1); } // Wcast-qual
 	char *DataStart() const { return (char *)(Offsets() + m_NumItems); } // Wcast-qual
 
 public:

--- a/src/engine/shared/snapshot.h
+++ b/src/engine/shared/snapshot.h
@@ -24,8 +24,8 @@ class CSnapshot
 	int m_DataSize;
 	int m_NumItems;
 
-	int *Offsets() const { return (int *)(this + 1); }
-	char *DataStart() const { return (char *)(Offsets() + m_NumItems); }
+	int *Offsets()    const { return (int *)(this + 1); } // Wcast-qual
+	char *DataStart() const { return (char *)(Offsets() + m_NumItems); } // Wcast-qual
 
 public:
 	enum
@@ -78,18 +78,18 @@ private:
 	int m_aSnapshotDataUpdates[CSnapshot::MAX_TYPE + 1];
 	CData m_Empty;
 
-	static void UndiffItem(int *pPast, int *pDiff, int *pOut, int Size, int *pDataRate);
+	static void UndiffItem(const int *pPast, const int *pDiff, int *pOut, int Size, int *pDataRate);
 
 public:
-	static int DiffItem(int *pPast, int *pCurrent, int *pOut, int Size);
+	static int DiffItem(const int *pPast, const int *pCurrent, int *pOut, int Size);
 	CSnapshotDelta();
 	CSnapshotDelta(const CSnapshotDelta &Old);
 	int GetDataRate(int Index) const { return m_aSnapshotDataRate[Index]; }
 	int GetDataUpdates(int Index) const { return m_aSnapshotDataUpdates[Index]; }
 	void SetStaticsize(int ItemType, int Size);
 	const CData *EmptyDelta() const;
-	int CreateDelta(class CSnapshot *pFrom, class CSnapshot *pTo, void *pDstData);
-	int UnpackDelta(class CSnapshot *pFrom, class CSnapshot *pTo, const void *pSrcData, int DataSize);
+	int CreateDelta(const class CSnapshot *pFrom, const class CSnapshot *pTo, void *pDstData);
+	int UnpackDelta(const class CSnapshot *pFrom, class CSnapshot *pTo, const void *pSrcData, int DataSize);
 };
 
 // CSnapshotStorage

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -892,32 +892,32 @@ void CGameClient::ProcessEvents()
 
 		if(Item.m_Type == NETEVENTTYPE_DAMAGEIND)
 		{
-			CNetEvent_DamageInd *ev = (CNetEvent_DamageInd *)pData;
+			const CNetEvent_DamageInd *ev = (const CNetEvent_DamageInd *)pData;
 			m_Effects.DamageIndicator(vec2(ev->m_X, ev->m_Y), direction(ev->m_Angle / 256.0f));
 		}
 		else if(Item.m_Type == NETEVENTTYPE_EXPLOSION)
 		{
-			CNetEvent_Explosion *ev = (CNetEvent_Explosion *)pData;
+			const CNetEvent_Explosion *ev = (const CNetEvent_Explosion *)pData;
 			m_Effects.Explosion(vec2(ev->m_X, ev->m_Y));
 		}
 		else if(Item.m_Type == NETEVENTTYPE_HAMMERHIT)
 		{
-			CNetEvent_HammerHit *ev = (CNetEvent_HammerHit *)pData;
+			const CNetEvent_HammerHit *ev = (const CNetEvent_HammerHit *)pData;
 			m_Effects.HammerHit(vec2(ev->m_X, ev->m_Y));
 		}
 		else if(Item.m_Type == NETEVENTTYPE_SPAWN)
 		{
-			CNetEvent_Spawn *ev = (CNetEvent_Spawn *)pData;
+			const CNetEvent_Spawn *ev = (const CNetEvent_Spawn *)pData;
 			m_Effects.PlayerSpawn(vec2(ev->m_X, ev->m_Y));
 		}
 		else if(Item.m_Type == NETEVENTTYPE_DEATH)
 		{
-			CNetEvent_Death *ev = (CNetEvent_Death *)pData;
+			const CNetEvent_Death *ev = (const CNetEvent_Death *)pData;
 			m_Effects.PlayerDeath(vec2(ev->m_X, ev->m_Y), ev->m_ClientID);
 		}
 		else if(Item.m_Type == NETEVENTTYPE_SOUNDWORLD)
 		{
-			CNetEvent_SoundWorld *ev = (CNetEvent_SoundWorld *)pData;
+			const CNetEvent_SoundWorld *ev = (const CNetEvent_SoundWorld *)pData;
 			if(!Config()->m_SndGame)
 				continue;
 

--- a/src/game/client/prediction/entities/character.cpp
+++ b/src/game/client/prediction/entities/character.cpp
@@ -1047,7 +1047,7 @@ CTeamsCore *CCharacter::TeamsCore()
 	return m_Core.m_pTeams;
 }
 
-CCharacter::CCharacter(CGameWorld *pGameWorld, int ID, CNetObj_Character *pChar, CNetObj_DDNetCharacter *pExtended) :
+CCharacter::CCharacter(CGameWorld *pGameWorld, int ID, const CNetObj_Character *pChar, CNetObj_DDNetCharacter *pExtended) :
 	CEntity(pGameWorld, CGameWorld::ENTTYPE_CHARACTER)
 {
 	m_ID = ID;
@@ -1119,9 +1119,9 @@ void CCharacter::ResetPrediction()
 	m_LastTuneZoneTick = 0;
 }
 
-void CCharacter::Read(CNetObj_Character *pChar, CNetObj_DDNetCharacter *pExtended, bool IsLocal)
+void CCharacter::Read(const CNetObj_Character *pChar, CNetObj_DDNetCharacter *pExtended, bool IsLocal)
 {
-	m_Core.Read((CNetObj_CharacterCore *)pChar);
+	m_Core.Read((const CNetObj_CharacterCore *)pChar);
 	m_IsLocal = IsLocal;
 
 	if(pExtended)

--- a/src/game/client/prediction/entities/character.h
+++ b/src/game/client/prediction/entities/character.h
@@ -133,8 +133,8 @@ public:
 	int GetAttackTick() { return m_AttackTick; }
 	int GetStrongWeakID() { return m_StrongWeakID; }
 
-	CCharacter(CGameWorld *pGameWorld, int ID, CNetObj_Character *pChar, CNetObj_DDNetCharacter *pExtended = 0);
-	void Read(CNetObj_Character *pChar, CNetObj_DDNetCharacter *pExtended, bool IsLocal);
+	CCharacter(CGameWorld *pGameWorld, int ID, const CNetObj_Character *pChar, CNetObj_DDNetCharacter *pExtended = 0);
+	void Read(const CNetObj_Character *pChar, CNetObj_DDNetCharacter *pExtended, bool IsLocal);
 	void SetCoreWorld(CGameWorld *pGameWorld);
 
 	int m_LastSnapWeapon;

--- a/src/game/client/prediction/entities/laser.cpp
+++ b/src/game/client/prediction/entities/laser.cpp
@@ -150,7 +150,7 @@ void CLaser::Tick()
 	}
 }
 
-CLaser::CLaser(CGameWorld *pGameWorld, int ID, CNetObj_Laser *pLaser) :
+CLaser::CLaser(CGameWorld *pGameWorld, int ID, const CNetObj_Laser *pLaser) :
 	CEntity(pGameWorld, CGameWorld::ENTTYPE_LASER)
 {
 	m_Pos.x = pLaser->m_X;

--- a/src/game/client/prediction/entities/laser.h
+++ b/src/game/client/prediction/entities/laser.h
@@ -17,7 +17,7 @@ public:
 	const vec2 &GetFrom() { return m_From; }
 	const int &GetOwner() { return m_Owner; }
 	const int &GetEvalTick() { return m_EvalTick; }
-	CLaser(CGameWorld *pGameWorld, int ID, CNetObj_Laser *pLaser);
+	CLaser(CGameWorld *pGameWorld, int ID, const CNetObj_Laser *pLaser);
 	void FillInfo(CNetObj_Laser *pLaser);
 	bool Match(CLaser *pLaser);
 

--- a/src/game/client/prediction/entities/pickup.cpp
+++ b/src/game/client/prediction/entities/pickup.cpp
@@ -84,7 +84,7 @@ void CPickup::Move()
 	}
 }
 
-CPickup::CPickup(CGameWorld *pGameWorld, int ID, CNetObj_Pickup *pPickup, const CNetObj_EntityEx *pEntEx) :
+CPickup::CPickup(CGameWorld *pGameWorld, int ID, const CNetObj_Pickup *pPickup, const CNetObj_EntityEx *pEntEx) :
 	CEntity(pGameWorld, CGameWorld::ENTTYPE_PICKUP)
 {
 	m_Pos.x = pPickup->m_X;

--- a/src/game/client/prediction/entities/pickup.h
+++ b/src/game/client/prediction/entities/pickup.h
@@ -12,7 +12,7 @@ class CPickup : public CEntity
 public:
 	virtual void Tick();
 
-	CPickup(CGameWorld *pGameWorld, int ID, CNetObj_Pickup *pPickup, const CNetObj_EntityEx *pEntEx = 0);
+	CPickup(CGameWorld *pGameWorld, int ID, const CNetObj_Pickup *pPickup, const CNetObj_EntityEx *pEntEx = 0);
 	void FillInfo(CNetObj_Pickup *pPickup);
 	bool Match(CPickup *pPickup);
 	bool InDDNetTile() { return m_IsCoreActive; }

--- a/src/game/client/prediction/gameworld.cpp
+++ b/src/game/client/prediction/gameworld.cpp
@@ -347,7 +347,7 @@ void CGameWorld::NetObjBegin()
 	OnModified();
 }
 
-void CGameWorld::NetCharAdd(int ObjID, CNetObj_Character *pCharObj, CNetObj_DDNetCharacter *pExtended, int GameTeam, bool IsLocal)
+void CGameWorld::NetCharAdd(int ObjID, const CNetObj_Character *pCharObj, CNetObj_DDNetCharacter *pExtended, int GameTeam, bool IsLocal)
 {
 	CCharacter *pChar;
 	if((pChar = (CCharacter *)GetEntity(ObjID, ENTTYPE_CHARACTER)))
@@ -429,7 +429,7 @@ void CGameWorld::NetObjAdd(int ObjID, int ObjType, const void *pObjData, const C
 	}
 	else if(ObjType == NETOBJTYPE_PICKUP && m_WorldConfig.m_PredictWeapons)
 	{
-		CPickup NetPickup = CPickup(this, ObjID, (CNetObj_Pickup *)pObjData, pDataEx);
+		CPickup NetPickup = CPickup(this, ObjID, (const CNetObj_Pickup *)pObjData, pDataEx);
 		if(CPickup *pPickup = (CPickup *)GetEntity(ObjID, ENTTYPE_PICKUP))
 		{
 			if(NetPickup.Match(pPickup))
@@ -444,7 +444,7 @@ void CGameWorld::NetObjAdd(int ObjID, int ObjType, const void *pObjData, const C
 	}
 	else if(ObjType == NETOBJTYPE_LASER && m_WorldConfig.m_PredictWeapons)
 	{
-		CLaser NetLaser = CLaser(this, ObjID, (CNetObj_Laser *)pObjData);
+		CLaser NetLaser = CLaser(this, ObjID, (const CNetObj_Laser *)pObjData);
 		CLaser *pMatching = 0;
 		if(CLaser *pLaser = dynamic_cast<CLaser *>(GetEntity(ObjID, ENTTYPE_LASER)))
 			if(NetLaser.Match(pLaser))
@@ -568,7 +568,7 @@ CEntity *CGameWorld::FindMatch(int ObjID, int ObjType, const void *pObjData)
 #define FindType(EntType, EntClass, ObjClass) \
 	{ \
 		CEntity *pEnt = GetEntity(ObjID, EntType); \
-		if(pEnt && EntClass(this, ObjID, (ObjClass *)pObjData).Match((EntClass *)pEnt)) \
+		if(pEnt && EntClass(this, ObjID, (const ObjClass *)pObjData).Match((EntClass *)pEnt)) \
 			return pEnt; \
 		return 0; \
 	}

--- a/src/game/client/prediction/gameworld.h
+++ b/src/game/client/prediction/gameworld.h
@@ -80,7 +80,7 @@ public:
 
 	void OnModified();
 	void NetObjBegin();
-	void NetCharAdd(int ObjID, CNetObj_Character *pChar, CNetObj_DDNetCharacter *pExtended, int GameTeam, bool IsLocal);
+	void NetCharAdd(int ObjID, const CNetObj_Character *pChar, CNetObj_DDNetCharacter *pExtended, int GameTeam, bool IsLocal);
 	void NetObjAdd(int ObjID, int ObjType, const void *pObjData, const CNetObj_EntityEx *pDataEx);
 	void NetObjEnd(int LocalID);
 	void CopyWorld(CGameWorld *pFrom);

--- a/src/game/gamecore.cpp
+++ b/src/game/gamecore.cpp
@@ -23,7 +23,7 @@ bool CTuningParams::Get(int Index, float *pValue) const
 {
 	if(Index < 0 || Index >= Num())
 		return false;
-	*pValue = (float)((CTuneParam *)this)[Index];
+	*pValue = (float)((const CTuneParam *)this)[Index];
 	return true;
 }
 

--- a/src/game/layers.cpp
+++ b/src/game/layers.cpp
@@ -175,7 +175,7 @@ void CLayers::InitTilemapSkip()
 
 			if(pLayer->m_Type == LAYERTYPE_TILES)
 			{
-				const CMapItemLayerTilemap *pTilemap = (CMapItemLayerTilemap *)pLayer;
+				const CMapItemLayerTilemap *pTilemap = (const CMapItemLayerTilemap *)pLayer;
 				CTile *pTiles = (CTile *)m_pMap->GetData(pTilemap->m_Data);
 				for(int y = 0; y < pTilemap->m_Height; y++)
 				{

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -1702,7 +1702,7 @@ void CGameContext::CensorMessage(char *pCensoredMessage, const char *pMessage, i
 		char *pCurLoc = pCensoredMessage;
 		do
 		{
-			pCurLoc = const_cast<char*>(str_utf8_find_nocase(pCurLoc, m_aCensorlist[i].cstr()));
+			pCurLoc = const_cast<char *>(str_utf8_find_nocase(pCurLoc, m_aCensorlist[i].cstr()));
 			if(pCurLoc)
 			{
 				memset(pCurLoc, '*', str_length(m_aCensorlist[i].cstr()));

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -1702,7 +1702,7 @@ void CGameContext::CensorMessage(char *pCensoredMessage, const char *pMessage, i
 		char *pCurLoc = pCensoredMessage;
 		do
 		{
-			pCurLoc = (char *)str_utf8_find_nocase(pCurLoc, m_aCensorlist[i].cstr());
+			pCurLoc = const_cast<char*>(str_utf8_find_nocase(pCurLoc, m_aCensorlist[i].cstr()));
 			if(pCurLoc)
 			{
 				memset(pCurLoc, '*', str_length(m_aCensorlist[i].cstr()));

--- a/src/game/server/teehistorian.cpp
+++ b/src/game/server/teehistorian.cpp
@@ -422,7 +422,7 @@ void CTeeHistorian::RecordPlayerInput(int ClientID, const CNetObj_PlayerInput *p
 		Buffer.Reset();
 
 		Buffer.AddInt(-TEEHISTORIAN_INPUT_DIFF);
-		CSnapshotDelta::DiffItem((int *)&pPrev->m_Input, (int *)pInput, (int *)&DiffInput, sizeof(DiffInput) / sizeof(int));
+		CSnapshotDelta::DiffItem((const int *)&pPrev->m_Input, (const int *)pInput, (int *)&DiffInput, sizeof(DiffInput) / sizeof(int));
 		if(m_Debug)
 		{
 			const int *pData = (const int *)&DiffInput;


### PR DESCRIPTION
Code is full of const data being cast to non const, not sure if safe. I couldn't fix all so i marked them with a comment.

Tested with gcc 7 and clang 13.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
