### PR TITLE
Fix queries for MySQL 8.0

### DIFF
--- a/src/game/server/scoreworker.cpp
+++ b/src/game/server/scoreworker.cpp
@@ -591,13 +591,13 @@ bool CScoreWorker::ShowRank(IDbConnection *pSqlServer, const ISqlData *pGameData
 	// check sort method
 	char aBuf[600];
 	str_format(aBuf, sizeof(aBuf),
-		"SELECT Rank, Time, PercentRank "
+		"SELECT `Rank`, Time, PercentRank "
 		"FROM ("
-		"  SELECT RANK() OVER w AS Rank, PERCENT_RANK() OVER w as PercentRank, Name, MIN(Time) AS Time "
+		"  SELECT RANK() OVER w AS `Rank`, PERCENT_RANK() OVER w as PercentRank, Name, MIN(Time) AS Time "
 		"  FROM %s_race "
 		"  WHERE Map = ? "
 		"  AND Server LIKE ?"
-		"  GROUP BY Name "
+		"  GROUP BY Name, Time "
 		"  WINDOW w AS (ORDER BY Time)"
 		") as a "
 		"WHERE Name = ?",
@@ -693,12 +693,12 @@ bool CScoreWorker::ShowTeamRank(IDbConnection *pSqlServer, const ISqlData *pGame
 	char aBuf[2400];
 
 	str_format(aBuf, sizeof(aBuf),
-		"SELECT l.ID, Name, Time, Rank, PercentRank "
+		"SELECT l.ID, Name, Time, `Rank`, PercentRank "
 		"FROM (" // teamrank score board
-		"  SELECT RANK() OVER w AS Rank, PERCENT_RANK() OVER w AS PercentRank, ID "
+		"  SELECT RANK() OVER w AS `Rank`, PERCENT_RANK() OVER w AS PercentRank, ID "
 		"  FROM %s_teamrace "
 		"  WHERE Map = ? "
-		"  GROUP BY ID "
+		"  GROUP BY ID, Time "
 		"  WINDOW w AS (ORDER BY Time)"
 		") AS TeamRank INNER JOIN (" // select rank with Name in team
 		"  SELECT ID "
@@ -779,16 +779,16 @@ bool CScoreWorker::ShowTop(IDbConnection *pSqlServer, const ISqlData *pGameData,
 	// check sort method
 	char aBuf[512];
 	str_format(aBuf, sizeof(aBuf),
-		"SELECT Name, Time, Rank, Server "
+		"SELECT Name, Time, `Rank`, Server "
 		"FROM ("
-		"  SELECT RANK() OVER w AS Rank, Name, MIN(Time) AS Time, Server "
+		"  SELECT RANK() OVER w AS `Rank`, Name, MIN(Time) AS Time, Server "
 		"  FROM %s_race "
 		"  WHERE Map = ? "
 		"  AND Server LIKE ? "
-		"  GROUP BY Name "
+		"  GROUP BY Name, Time, Server "
 		"  WINDOW w AS (ORDER BY Time)"
 		") as a "
-		"ORDER BY Rank %s "
+		"ORDER BY `Rank` %s "
 		"LIMIT %d, ?",
 		pSqlServer->GetPrefix(),
 		pOrder,
@@ -881,21 +881,21 @@ bool CScoreWorker::ShowTeamTop5(IDbConnection *pSqlServer, const ISqlData *pGame
 	char aBuf[512];
 
 	str_format(aBuf, sizeof(aBuf),
-		"SELECT Name, Time, Rank, TeamSize "
+		"SELECT Name, Time, `Rank`, TeamSize "
 		"FROM (" // limit to 5
-		"  SELECT TeamSize, Rank, ID "
+		"  SELECT TeamSize, `Rank`, ID "
 		"  FROM (" // teamrank score board
-		"    SELECT RANK() OVER w AS Rank, ID, COUNT(*) AS Teamsize "
+		"    SELECT RANK() OVER w AS `Rank`, ID, COUNT(*) AS Teamsize "
 		"    FROM %s_teamrace "
 		"    WHERE Map = ? "
-		"    GROUP BY Id "
+		"    GROUP BY ID, Time "
 		"    WINDOW w AS (ORDER BY Time)"
 		"  ) as l1 "
-		"  ORDER BY Rank %s "
+		"  ORDER BY `Rank` %s "
 		"  LIMIT %d, 5"
 		") as l2 "
 		"INNER JOIN %s_teamrace as r ON l2.ID = r.ID "
-		"ORDER BY Rank %s, r.ID, Name ASC",
+		"ORDER BY `Rank` %s, r.ID, Name ASC",
 		pSqlServer->GetPrefix(), pOrder, LimitStart, pSqlServer->GetPrefix(), pOrder);
 	if(pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
 	{
@@ -1172,8 +1172,8 @@ bool CScoreWorker::ShowPoints(IDbConnection *pSqlServer, const ISqlData *pGameDa
 	str_format(aBuf, sizeof(aBuf),
 		"SELECT ("
 		"  SELECT COUNT(Name) + 1 FROM %s_points WHERE Points > ("
-		"    SELECT points FROM %s_points WHERE Name = ?"
-		")) as Rank, Points, Name "
+		"    SELECT Points FROM %s_points WHERE Name = ?"
+		")) as `Rank`, Points, Name "
 		"FROM %s_points WHERE Name = ?",
 		pSqlServer->GetPrefix(), pSqlServer->GetPrefix(), pSqlServer->GetPrefix());
 	if(pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
@@ -1217,13 +1217,13 @@ bool CScoreWorker::ShowTopPoints(IDbConnection *pSqlServer, const ISqlData *pGam
 
 	char aBuf[512];
 	str_format(aBuf, sizeof(aBuf),
-		"SELECT RANK() OVER (ORDER BY a.Points DESC) as Rank, Points, Name "
+		"SELECT RANK() OVER (ORDER BY a.Points DESC) as `Rank`, Points, Name "
 		"FROM ("
 		"  SELECT Points, Name "
 		"  FROM %s_points "
 		"  ORDER BY Points DESC LIMIT ?"
 		") as a "
-		"ORDER BY Rank ASC, Name ASC LIMIT ?, 5",
+		"ORDER BY `Rank` ASC, Name ASC LIMIT ?, 5",
 		pSqlServer->GetPrefix());
 	if(pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
 	{

--- a/src/game/server/scoreworker.cpp
+++ b/src/game/server/scoreworker.cpp
@@ -785,8 +785,8 @@ bool CScoreWorker::ShowTop(IDbConnection *pSqlServer, const ISqlData *pGameData,
 		"  FROM %s_race "
 		"  WHERE Map = ? "
 		"  AND Server LIKE ? "
-		"  GROUP BY Name, Time, Server "
-		"  WINDOW w AS (ORDER BY Time)"
+		"  GROUP BY Name, Server "
+		"  WINDOW w AS (ORDER BY MIN(Time))"
 		") as a "
 		"ORDER BY `Rank` %s "
 		"LIMIT %d, ?",

--- a/src/game/server/scoreworker.cpp
+++ b/src/game/server/scoreworker.cpp
@@ -591,9 +591,9 @@ bool CScoreWorker::ShowRank(IDbConnection *pSqlServer, const ISqlData *pGameData
 	// check sort method
 	char aBuf[600];
 	str_format(aBuf, sizeof(aBuf),
-		"SELECT `Rank`, Time, PercentRank "
+		"SELECT Ranking, Time, PercentRank "
 		"FROM ("
-		"  SELECT RANK() OVER w AS `Rank`, PERCENT_RANK() OVER w as PercentRank, Name, MIN(Time) AS Time "
+		"  SELECT RANK() OVER w AS Ranking, PERCENT_RANK() OVER w as PercentRank, Name, MIN(Time) AS Time "
 		"  FROM %s_race "
 		"  WHERE Map = ? "
 		"  AND Server LIKE ?"
@@ -693,9 +693,9 @@ bool CScoreWorker::ShowTeamRank(IDbConnection *pSqlServer, const ISqlData *pGame
 	char aBuf[2400];
 
 	str_format(aBuf, sizeof(aBuf),
-		"SELECT l.ID, Name, Time, `Rank`, PercentRank "
+		"SELECT l.ID, Name, Time, Ranking, PercentRank "
 		"FROM (" // teamrank score board
-		"  SELECT RANK() OVER w AS `Rank`, PERCENT_RANK() OVER w AS PercentRank, ID "
+		"  SELECT RANK() OVER w AS Ranking, PERCENT_RANK() OVER w AS PercentRank, ID "
 		"  FROM %s_teamrace "
 		"  WHERE Map = ? "
 		"  GROUP BY ID, Time "
@@ -779,16 +779,16 @@ bool CScoreWorker::ShowTop(IDbConnection *pSqlServer, const ISqlData *pGameData,
 	// check sort method
 	char aBuf[512];
 	str_format(aBuf, sizeof(aBuf),
-		"SELECT Name, Time, `Rank`, Server "
+		"SELECT Name, Time, Ranking, Server "
 		"FROM ("
-		"  SELECT RANK() OVER w AS `Rank`, Name, MIN(Time) AS Time, Server "
+		"  SELECT RANK() OVER w AS Ranking, Name, MIN(Time) AS Time, Server "
 		"  FROM %s_race "
 		"  WHERE Map = ? "
 		"  AND Server LIKE ? "
 		"  GROUP BY Name, Server "
 		"  WINDOW w AS (ORDER BY MIN(Time))"
 		") as a "
-		"ORDER BY `Rank` %s "
+		"ORDER BY Ranking %s "
 		"LIMIT %d, ?",
 		pSqlServer->GetPrefix(),
 		pOrder,
@@ -881,21 +881,21 @@ bool CScoreWorker::ShowTeamTop5(IDbConnection *pSqlServer, const ISqlData *pGame
 	char aBuf[512];
 
 	str_format(aBuf, sizeof(aBuf),
-		"SELECT Name, Time, `Rank`, TeamSize "
+		"SELECT Name, Time, Ranking, TeamSize "
 		"FROM (" // limit to 5
-		"  SELECT TeamSize, `Rank`, ID "
+		"  SELECT TeamSize, Ranking, ID "
 		"  FROM (" // teamrank score board
-		"    SELECT RANK() OVER w AS `Rank`, ID, COUNT(*) AS Teamsize "
+		"    SELECT RANK() OVER w AS Ranking, ID, COUNT(*) AS Teamsize "
 		"    FROM %s_teamrace "
 		"    WHERE Map = ? "
 		"    GROUP BY ID, Time "
 		"    WINDOW w AS (ORDER BY Time)"
 		"  ) as l1 "
-		"  ORDER BY `Rank` %s "
+		"  ORDER BY Ranking %s "
 		"  LIMIT %d, 5"
 		") as l2 "
 		"INNER JOIN %s_teamrace as r ON l2.ID = r.ID "
-		"ORDER BY `Rank` %s, r.ID, Name ASC",
+		"ORDER BY Ranking %s, r.ID, Name ASC",
 		pSqlServer->GetPrefix(), pOrder, LimitStart, pSqlServer->GetPrefix(), pOrder);
 	if(pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
 	{
@@ -1173,7 +1173,7 @@ bool CScoreWorker::ShowPoints(IDbConnection *pSqlServer, const ISqlData *pGameDa
 		"SELECT ("
 		"  SELECT COUNT(Name) + 1 FROM %s_points WHERE Points > ("
 		"    SELECT Points FROM %s_points WHERE Name = ?"
-		")) as `Rank`, Points, Name "
+		")) as Ranking, Points, Name "
 		"FROM %s_points WHERE Name = ?",
 		pSqlServer->GetPrefix(), pSqlServer->GetPrefix(), pSqlServer->GetPrefix());
 	if(pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
@@ -1217,13 +1217,13 @@ bool CScoreWorker::ShowTopPoints(IDbConnection *pSqlServer, const ISqlData *pGam
 
 	char aBuf[512];
 	str_format(aBuf, sizeof(aBuf),
-		"SELECT RANK() OVER (ORDER BY a.Points DESC) as `Rank`, Points, Name "
+		"SELECT RANK() OVER (ORDER BY a.Points DESC) as Ranking, Points, Name "
 		"FROM ("
 		"  SELECT Points, Name "
 		"  FROM %s_points "
 		"  ORDER BY Points DESC LIMIT ?"
 		") as a "
-		"ORDER BY `Rank` ASC, Name ASC LIMIT ?, 5",
+		"ORDER BY Ranking ASC, Name ASC LIMIT ?, 5",
 		pSqlServer->GetPrefix());
 	if(pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
 	{

--- a/src/game/server/scoreworker.cpp
+++ b/src/game/server/scoreworker.cpp
@@ -597,8 +597,8 @@ bool CScoreWorker::ShowRank(IDbConnection *pSqlServer, const ISqlData *pGameData
 		"  FROM %s_race "
 		"  WHERE Map = ? "
 		"  AND Server LIKE ?"
-		"  GROUP BY Name, Time "
-		"  WINDOW w AS (ORDER BY Time)"
+		"  GROUP BY Name "
+		"  WINDOW w AS (ORDER BY MIN(Time))"
 		") as a "
 		"WHERE Name = ?",
 		pSqlServer->GetPrefix());


### PR DESCRIPTION
Fixes #4815 

**What was changed:**
- All Rank columns name were scapped since MySQL 8.0 interprets the word "Rank" as a internal function or constant (A good practice would be if all column names were escaped).
- All group by have been modified to have all columns that need to be grouped, in order to respect the `ONLY_FULL_GROUP_BY` flag set by default on MySQL 8.0. On these group bys were also included the columns that are used in the `window`, since are also required by the same tag.

**What is missing on this pull request:**
- "Add a mysql installation in .github workflow so we test this in addition to mariadb, then we don't break it again so easily."

**The behavior of all queries remains the same.**

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
