### PR TITLE
Added default switch statement

### DIFF
--- a/datasrc/compile.py
+++ b/datasrc/compile.py
@@ -277,8 +277,10 @@ def main():
 			for line in item.emit_validate(base_item):
 				lines += ["\t" + line]
 			lines += ['\t']
+
+		lines += ['\tdefault:']
+		lines += ['\t\treturn -1;']
 		lines += ['\t}']
-		lines += ['\treturn -1;']
 		lines += ['}']
 		lines += ['']
 

--- a/datasrc/seven/compile.py
+++ b/datasrc/seven/compile.py
@@ -271,10 +271,11 @@ def main():
 
 		for item in network.Objects:
 			for line in item.emit_validate():
-				lines += ["\t" + line]
+				lines += ['\t' + line]
 			lines += ['\t']
+		lines += ['\tdefault:']
+		lines += ['\t\treturn -1;']
 		lines += ['\t}']
-		lines += ['\treturn -1;']
 		lines += ['};']
 		lines += ['']
 

--- a/src/base/color.h
+++ b/src/base/color.h
@@ -207,6 +207,8 @@ inline ColorRGBA color_cast(const ColorHSLA &hsl)
 		rgb.r = c;
 		rgb.b = x;
 		break;
+	default: // leave black color
+		break;
 	}
 
 	float m = hsl.l - (c / 2);

--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -2487,8 +2487,10 @@ int time_season()
 	case 9:
 	case 10:
 		return SEASON_AUTUMN;
+	default:
+		dbg_assert(false, "Invalid or unknown time data");
+		return SEASON_SPRING; // should never happen
 	}
-	return SEASON_SPRING; // should never happen
 }
 
 void str_append(char *dst, const char *src, int dst_size)
@@ -3213,9 +3215,10 @@ int str_time(int64_t centisecs, int format, char *buffer, int buffer_size)
 	case TIME_MINS_CENTISECS:
 		return str_format(buffer, buffer_size, "%02" PRId64 ":%02" PRId64 ".%02" PRId64, centisecs / min,
 			(centisecs % min) / sec, centisecs % sec);
+	default:
+		dbg_msg("time", "Invalid time formatting data");
+		return -1;
 	}
-
-	return -1;
 }
 
 int str_time_float(float secs, int format, char *buffer, int buffer_size)

--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -713,12 +713,16 @@ int CInput::Update()
 			case SDL_WINDOWEVENT_RESTORED:
 				Graphics()->WindowCreateNtf(Event.window.windowID);
 				break;
+			default:
+				break; // ignore other window events (LEAVE, ENTER, etc.)
 			}
 			break;
 
 		// other messages
 		case SDL_QUIT:
 			return 1;
+		default:
+			break; // ignore other events (system, etc.)
 		}
 
 		if(Scancode > KEY_FIRST && Scancode < g_MaxKeys && !IgnoreKeys && (!SDL_IsTextInputActive() || m_EditingTextLen == -1))

--- a/src/engine/client/sound.cpp
+++ b/src/engine/client/sound.cpp
@@ -208,6 +208,9 @@ static void Mix(short *pFinalOut, unsigned Frames)
 
 					break;
 				}
+				default:
+					dbg_assert(false, "Invalid or unknown sound shape");
+					break;
 				};
 
 				if(InVoiceField)

--- a/src/engine/server/databases/connection_pool.cpp
+++ b/src/engine/server/databases/connection_pool.cpp
@@ -222,6 +222,9 @@ void CDbConnectionPool::Worker()
 			}
 		}
 		break;
+		default:
+			dbg_assert(false, "Invalid or unknown mode access");
+			break;
 		}
 		if(!Success)
 			dbg_msg("sql", "%s failed on all databases", pThreadData->m_pName);
@@ -249,6 +252,9 @@ bool CDbConnectionPool::ExecSqlFunc(IDbConnection *pConnection, CSqlExecData *pD
 		break;
 	case CSqlExecData::WRITE_ACCESS:
 		Success = !pData->m_Ptr.m_pWriteFunc(pConnection, pData->m_pThreadData.get(), Failure, aError, sizeof(aError));
+		break;
+	default:
+		dbg_assert(false, "Invalid or unknown mode access");
 		break;
 	}
 	pConnection->Disconnect();

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -1750,6 +1750,9 @@ void CServer::ProcessClientPacket(CNetChunk *pPacket)
 							str_format(aBuf, sizeof(aBuf), "ClientID=%d authed with key=%s (helper)", ClientID, pIdent);
 							break;
 						}
+						default:
+							str_format(aBuf, sizeof(aBuf), "ClientID=%d invalid authentication level=%d", ClientID, AuthLevel);
+							break;
 						}
 						Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "server", aBuf);
 

--- a/src/engine/shared/protocol_ex.cpp
+++ b/src/engine/shared/protocol_ex.cpp
@@ -95,6 +95,8 @@ int UnpackMessageID(int *pID, bool *pSys, struct CUuid *pUuid, CUnpacker *pUnpac
 				dbg_msg("uuid", "peer: %s %s", aBuf, pName);
 			}
 			break;
+		default:
+			break;
 		}
 	}
 	return UNPACKMESSAGE_OK;

--- a/src/game/client/components/emoticon.cpp
+++ b/src/game/client/components/emoticon.cpp
@@ -208,6 +208,9 @@ void CEmoticon::EyeEmote(int Emote)
 	case EMOTE_BLINK:
 		str_format(aBuf, sizeof(aBuf), "/emote blink %d", g_Config.m_ClEyeDuration);
 		break;
+	default:
+		str_format(aBuf, sizeof(aBuf), "/emote normal %d", g_Config.m_ClEyeDuration);
+		break;
 	}
 	GameClient()->m_Chat.Say(0, aBuf);
 }

--- a/src/game/client/components/mapsounds.cpp
+++ b/src/game/client/components/mapsounds.cpp
@@ -145,6 +145,9 @@ void CMapSounds::OnRender()
 					Sound()->SetVoiceRectangle(Source.m_Voice, fx2f(Source.m_pSource->m_Shape.m_Rectangle.m_Width), fx2f(Source.m_pSource->m_Shape.m_Rectangle.m_Height));
 					break;
 				}
+				default:
+					dbg_assert(false, "Invalid or unknown sound shape");
+					break;
 				};
 			}
 		}

--- a/src/game/client/components/menu_background.cpp
+++ b/src/game/client/components/menu_background.cpp
@@ -218,6 +218,9 @@ void CMenuBackground::LoadMenuBackground(bool HasDayHint, bool HasNightHint)
 			case SEASON_NEWYEAR:
 				pMenuMap = "newyear";
 				break;
+			default:
+				pMenuMap = "heavens";
+				break;
 			}
 		}
 		else if(str_comp(pMenuMap, "rand") == 0)

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -626,6 +626,7 @@ void CPlayers::RenderPlayer(
 		case WEAPON_GUN: RenderHand(&RenderInfo, p, Direction, -3 * pi / 4, vec2(-15, 4), Alpha); break;
 		case WEAPON_SHOTGUN: RenderHand(&RenderInfo, p, Direction, -pi / 2, vec2(-5, 4), Alpha); break;
 		case WEAPON_GRENADE: RenderHand(&RenderInfo, p, Direction, -pi / 2, vec2(-4, 7), Alpha); break;
+		default: break; // don't render non projectile weapon
 		}
 	}
 

--- a/src/game/client/components/voting.cpp
+++ b/src/game/client/components/voting.cpp
@@ -237,7 +237,8 @@ void CVoting::OnMessage(int MsgType, void *pRawMsg)
 	{
 		CNetMsg_Sv_VoteOptionListAdd *pMsg = (CNetMsg_Sv_VoteOptionListAdd *)pRawMsg;
 		int NumOptions = pMsg->m_NumOptions;
-		for(int i = 0; i < NumOptions; ++i)
+		bool Stop = false;
+		for(int i = 0; i < NumOptions && !Stop; ++i)
 		{
 			switch(i)
 			{
@@ -255,7 +256,11 @@ void CVoting::OnMessage(int MsgType, void *pRawMsg)
 			case 11: AddOption(pMsg->m_pDescription11); break;
 			case 12: AddOption(pMsg->m_pDescription12); break;
 			case 13: AddOption(pMsg->m_pDescription13); break;
-			case 14: AddOption(pMsg->m_pDescription14);
+			case 14: AddOption(pMsg->m_pDescription14); break;
+			default:
+				dbg_msg("vote", "Too many options to add: %d", NumOptions);
+				Stop = true; // don't spam if NumOptions is really high
+				break;
 			}
 		}
 	}

--- a/src/game/client/prediction/entities/character.cpp
+++ b/src/game/client/prediction/entities/character.cpp
@@ -70,18 +70,12 @@ void CCharacter::HandleJetpack()
 		return;
 	}
 
-	switch(m_Core.m_ActiveWeapon)
+	if(m_Core.m_ActiveWeapon == WEAPON_GUN && m_Jetpack)
 	{
-	case WEAPON_GUN:
-	{
-		if(m_Jetpack)
-		{
-			float Strength = GetTuning(m_TuneZone)->m_JetpackStrength;
-			if(!m_TuneZone)
-				Strength = m_LastJetpackStrength;
-			TakeDamage(Direction * -1.0f * (Strength / 100.0f / 6.11f), 0, GetCID(), m_Core.m_ActiveWeapon);
-		}
-	}
+		float Strength = GetTuning(m_TuneZone)->m_JetpackStrength;
+		if(!m_TuneZone)
+			Strength = m_LastJetpackStrength;
+		TakeDamage(Direction * -1.0f * (Strength / 100.0f / 6.11f), 0, GetCID(), m_Core.m_ActiveWeapon);
 	}
 }
 
@@ -450,6 +444,9 @@ void CCharacter::FireWeapon()
 		m_Core.m_Ninja.m_OldVelAmount = length(m_Core.m_Vel);
 	}
 	break;
+	default:
+		dbg_assert(false, "Invalid or unknown weapon");
+		break;
 	}
 
 	m_AttackTick = GameWorld()->GameTick();

--- a/src/game/client/prediction/entities/projectile.cpp
+++ b/src/game/client/prediction/entities/projectile.cpp
@@ -65,6 +65,8 @@ vec2 CProjectile::GetPos(float Time)
 		Curvature = pTuning->m_GunCurvature;
 		Speed = pTuning->m_GunSpeed;
 		break;
+	default:
+		break; // ignore non projectile weapons
 	}
 
 	return CalcPos(m_Pos, m_Direction, Curvature, Speed, Time);

--- a/src/game/client/prediction/gameworld.cpp
+++ b/src/game/client/prediction/gameworld.cpp
@@ -592,7 +592,7 @@ CEntity *CGameWorld::FindMatch(int ObjID, int ObjType, const void *pObjData)
 		CEntity *pEnt = GetEntity(ObjID, EntType); \
 		if(pEnt && EntClass(this, ObjID, (ObjClass *)pObjData).Match((EntClass *)pEnt)) \
 			return pEnt; \
-		return 0; \
+		return nullptr; \
 	}
 	switch(ObjType)
 	{
@@ -614,12 +614,14 @@ CEntity *CGameWorld::FindMatch(int ObjID, int ObjType, const void *pObjData)
 		{
 			return pEnt;
 		}
-		return 0;
+		return nullptr;
 	}
 	case NETOBJTYPE_LASER: FindType(ENTTYPE_LASER, CLaser, CNetObj_Laser);
 	case NETOBJTYPE_PICKUP: FindType(ENTTYPE_PICKUP, CPickup, CNetObj_Pickup);
+	default: // no match, return nullptr
+		return nullptr;
 	}
-	return 0;
+	return nullptr;
 }
 
 void CGameWorld::OnModified()

--- a/src/game/collision.cpp
+++ b/src/game/collision.cpp
@@ -194,6 +194,8 @@ static int GetMoveRestrictionsRaw(int Direction, int Tile, int Flags)
 		break;
 	case TILE_STOPA:
 		return CANTMOVE_LEFT | CANTMOVE_RIGHT | CANTMOVE_UP | CANTMOVE_DOWN;
+	default: // other tiles don't prevent movement
+		break;
 	}
 	return 0;
 }
@@ -207,7 +209,7 @@ static int GetMoveRestrictionsMask(int Direction)
 	case MR_DIR_DOWN: return CANTMOVE_DOWN;
 	case MR_DIR_LEFT: return CANTMOVE_LEFT;
 	case MR_DIR_UP: return CANTMOVE_UP;
-	default: dbg_assert(false, "invalid dir");
+	default: dbg_assert(false, "invalid direction");
 	}
 	return 0;
 }

--- a/src/game/editor/explanations.cpp
+++ b/src/game/editor/explanations.cpp
@@ -482,6 +482,8 @@ const char *CEditor::Explain(int ExplanationID, int Tile, int Layer) //TODO: Add
 			if(Layer == LAYER_GAME || Layer == LAYER_FRONT)
 				return "TELELASER OFF: Turn laser off as telegun weapon.";
 			break;
+		default:
+			break;
 		}
 		if(Tile >= TILE_CHECKPOINT_FIRST && Tile <= TILE_CHECKPOINT_LAST && (Layer == LAYER_GAME || Layer == LAYER_FRONT))
 			return "TIME CHECKPOINT: Compares your current race time with your record to show you whether you are running faster or slower.";
@@ -586,6 +588,8 @@ const char *CEditor::Explain(int ExplanationID, int Tile, int Layer) //TODO: Add
 			if(Layer == LAYER_GAME)
 				return "SPIKE: Old FNG spikes. Deprecated.";
 			break;
+		default:
+			break;
 		}
 		if((Tile >= TILE_PUB_CREDITS1 && Tile <= TILE_PUB_CREDITS8) && Layer == LAYER_GAME)
 			return "CREDITS: Who designed the entities.";
@@ -654,11 +658,13 @@ const char *CEditor::Explain(int ExplanationID, int Tile, int Layer) //TODO: Add
 			if(Layer == LAYER_GAME)
 				return "LASER: Gives you laser weapon with 10 charges.";
 			break;
+		default:
+			break;
 		}
 		if((Tile >= TILE_PUB_CREDITS1 && Tile <= TILE_PUB_CREDITS8) && Layer == LAYER_GAME)
 			return "CREDITS: Who designed the entities.";
 		else if((Tile == TILE_PUB_ENTITIES_OFF1 || Tile == TILE_PUB_ENTITIES_OFF2) && Layer == LAYER_GAME)
 			return "ENTITIES OFF SIGN: Informs people playing with entities about important marks, tips, information or text on the map.";
 	}
-	return "";
+	return "Unknown or invalid tile";
 }

--- a/src/game/editor/layer_sounds.cpp
+++ b/src/game/editor/layer_sounds.cpp
@@ -62,6 +62,9 @@ void CLayerSounds::Render(bool Tileset)
 					Width * Falloff, Height * Falloff, 0.0f);
 			break;
 		}
+		default:
+			dbg_assert(false, "Invalid or unknown sound shape");
+			break;
 		}
 	}
 

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -747,6 +747,9 @@ int CEditor::PopupSource(CEditor *pEditor, CUIRect View, void *pContext)
 			pSource->m_Shape.m_Rectangle.m_Height = f2fx(800.0f);
 			break;
 		}
+		default:
+			dbg_assert(false, "Invalid or unknown sound shape");
+			break;
 		}
 	}
 
@@ -891,6 +894,9 @@ int CEditor::PopupSource(CEditor *pEditor, CUIRect View, void *pContext)
 
 		break;
 	}
+	default:
+		dbg_assert(false, "Invalid or unknown sound shape");
+		break;
 	}
 
 	return 0;

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -170,20 +170,14 @@ void CCharacter::HandleJetpack()
 		return;
 	}
 
-	switch(m_Core.m_ActiveWeapon)
+	if(m_Core.m_ActiveWeapon == WEAPON_GUN && m_Jetpack)
 	{
-	case WEAPON_GUN:
-	{
-		if(m_Jetpack)
-		{
-			float Strength;
-			if(!m_TuneZone)
-				Strength = GameServer()->Tuning()->m_JetpackStrength;
-			else
-				Strength = GameServer()->TuningList()[m_TuneZone].m_JetpackStrength;
-			TakeDamage(Direction * -1.0f * (Strength / 100.0f / 6.11f), 0, m_pPlayer->GetCID(), m_Core.m_ActiveWeapon);
-		}
-	}
+		float Strength;
+		if(!m_TuneZone)
+			Strength = GameServer()->Tuning()->m_JetpackStrength;
+		else
+			Strength = GameServer()->TuningList()[m_TuneZone].m_JetpackStrength;
+		TakeDamage(Direction * -1.0f * (Strength / 100.0f / 6.11f), 0, m_pPlayer->GetCID(), m_Core.m_ActiveWeapon);
 	}
 }
 
@@ -558,6 +552,9 @@ void CCharacter::FireWeapon()
 		GameServer()->CreateSound(m_Pos, SOUND_NINJA_FIRE, TeamMask());
 	}
 	break;
+	default:
+		dbg_assert(false, "Invalid or unknown weapon");
+		break;
 	}
 
 	m_AttackTick = Server()->Tick();

--- a/src/game/server/entities/projectile.cpp
+++ b/src/game/server/entities/projectile.cpp
@@ -102,6 +102,8 @@ vec2 CProjectile::GetPos(float Time)
 			Speed = GameServer()->TuningList()[m_TuneZone].m_GunSpeed;
 		}
 		break;
+	default:
+		break; // ignore non projectile weapons
 	}
 
 	return CalcPos(m_Pos, m_Direction, Curvature, Speed, Time);

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -1247,8 +1247,8 @@ void CGameContext::ProgressVoteOptions(int ClientID)
 
 	// get current vote option by index
 	CVoteOptionServer *pCurrent = GetVoteOption(pPl->m_SendVoteIndex);
-
-	while(CurIndex < NumVotesToSend && pCurrent != NULL)
+	bool Stop = false;
+	while(CurIndex < NumVotesToSend && pCurrent != NULL && !Stop)
 	{
 		switch(CurIndex)
 		{
@@ -1267,6 +1267,10 @@ void CGameContext::ProgressVoteOptions(int ClientID)
 		case 12: OptionMsg.m_pDescription12 = pCurrent->m_aDescription; break;
 		case 13: OptionMsg.m_pDescription13 = pCurrent->m_aDescription; break;
 		case 14: OptionMsg.m_pDescription14 = pCurrent->m_aDescription; break;
+		default:
+			dbg_msg("vote", "Votes to send too big: %d", NumVotesToSend);
+			Stop = true;
+			break;
 		}
 
 		CurIndex++;

--- a/src/game/server/gamecontroller.cpp
+++ b/src/game/server/gamecontroller.cpp
@@ -89,6 +89,10 @@ void IGameController::DoActivityCheck()
 					// kick the player
 					Server()->Kick(i, "Kicked for inactivity");
 				}
+				break;
+				default:
+					dbg_assert(false, "Invalid or unknown value for SvInactiveKick");
+					break;
 				}
 			}
 		}

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -780,6 +780,9 @@ int CPlayer::Pause(int State, bool Force)
 				GameServer()->SendChat(-1, CGameContext::CHAT_ALL, aBuf);
 			}
 			break;
+		default:
+			dbg_assert(false, "Invalid or unknown player pause state");
+			break;
 		}
 
 		// Update state
@@ -888,6 +891,7 @@ void CPlayer::ProcessScoreResult(CScorePlayerResult &Result)
 			GameServer()->CallVote(m_ClientID, Result.m_Data.m_MapVote.m_aMap, aCmd, "/map", aChatmsg);
 			break;
 		case CScorePlayerResult::PLAYER_INFO:
+		{
 			GameServer()->Score()->PlayerData(m_ClientID)->Set(Result.m_Data.m_Info.m_Time, Result.m_Data.m_Info.m_CpTime);
 			m_Score = Result.m_Data.m_Info.m_Score;
 			m_HasFinishScore = Result.m_Data.m_Info.m_HasFinishScore;
@@ -910,6 +914,10 @@ void CPlayer::ProcessScoreResult(CScorePlayerResult &Result)
 					Server()->ClientName(m_ClientID), Birthday, Birthday > 1 ? "s" : "");
 				GameServer()->SendBroadcast(aBuf, m_ClientID);
 			}
+		}
+			break;
+		default:
+			dbg_assert(false, "Invalid or unknown message kind");
 			break;
 		}
 	}

--- a/src/game/server/scoreworker.cpp
+++ b/src/game/server/scoreworker.cpp
@@ -43,6 +43,10 @@ void CScorePlayerResult::SetVariant(Variant v)
 		m_Data.m_Info.m_Time = 0;
 		for(float &CpTime : m_Data.m_Info.m_CpTime)
 			CpTime = 0;
+		break;
+	default:
+		dbg_assert(false, "Invalid or unknown message kind");
+		break;
 	}
 }
 

--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -985,6 +985,9 @@ void CGameTeams::ProcessSaveTeam()
 			if(m_pSaveTeamResult[Team]->m_aMessage[0] != '\0')
 				GameServer()->SendChatTarget(m_pSaveTeamResult[Team]->m_RequestingPlayer, m_pSaveTeamResult[Team]->m_aMessage);
 			break;
+		default:
+			dbg_assert(false, "Invalid or unknown save result");
+			break;
 		}
 		m_pSaveTeamResult[Team] = nullptr;
 	}


### PR DESCRIPTION
Added default switch statement either with a comment or with a call to dbg_msg. During my tests, i couldn't trigger any of them, but its better to have a default case anyway.

I didn't add default case in https://github.com/ddnet/ddnet/blob/master/src/engine/shared/protocol_ex.cpp#L51, https://github.com/ddnet/ddnet/blob/master/datasrc/compile.py#L266-L281, https://github.com/ddnet/ddnet/blob/master/datasrc/seven/compile.py and https://github.com/ddnet/ddnet/blob/master/src/game/collision.cpp#L183-L215 as the code is either too obscure (protocol) or clear enough (collision).

Tested with gcc 7 and clang 13.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
