### PR TITLE
Fixed some useless double promotion

### DIFF
--- a/src/base/color.h
+++ b/src/base/color.h
@@ -177,8 +177,8 @@ inline ColorRGBA color_cast(const ColorHSLA &hsl)
 	vec3 rgb = vec3(0, 0, 0);
 
 	float h1 = hsl.h * 6;
-	float c = (1 - absolute(2 * hsl.l - 1)) * hsl.s;
-	float x = c * (1 - absolute(fmod(h1, 2) - 1));
+	float c = (1.f - absolute(2 * hsl.l - 1)) * hsl.s;
+	float x = c * (1.f - absolute(fmodf(h1, 2) - 1.f));
 
 	switch(round_truncate(h1))
 	{

--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -3253,7 +3253,7 @@ int str_time(int64_t centisecs, int format, char *buffer, int buffer_size)
 
 int str_time_float(float secs, int format, char *buffer, int buffer_size)
 {
-	return str_time(llroundf(secs * 100.0), format, buffer, buffer_size);
+	return str_time(llroundf(secs * 100), format, buffer, buffer_size);
 }
 
 void str_escape(char **dst, const char *src, const char *end)

--- a/src/game/client/components/debughud.cpp
+++ b/src/game/client/components/debughud.cpp
@@ -62,11 +62,11 @@ void CDebugHud::RenderNetCorrections()
 	w = TextRender()->TextWidth(0, Fontsize, aBuf, -1, -1.0f);
 	TextRender()->Text(0, x - w, y, Fontsize, aBuf, -1.0f);
 	y += 2 * LineHeight;
-	str_format(aBuf, sizeof(aBuf), "%.2f", static_cast<float>(m_pClient->m_Snap.m_pLocalCharacter->m_X) / 32.0f);
+	str_format(aBuf, sizeof(aBuf), "%.2f", m_pClient->m_Snap.m_pLocalCharacter->m_X / 32.0f);
 	w = TextRender()->TextWidth(0, Fontsize, aBuf, -1, -1.0f);
 	TextRender()->Text(0, x - w, y, Fontsize, aBuf, -1.0f);
 	y += LineHeight;
-	str_format(aBuf, sizeof(aBuf), "%.2f", static_cast<float>(m_pClient->m_Snap.m_pLocalCharacter->m_Y) / 32.0f);
+	str_format(aBuf, sizeof(aBuf), "%.2f", m_pClient->m_Snap.m_pLocalCharacter->m_Y / 32.0f);
 	w = TextRender()->TextWidth(0, Fontsize, aBuf, -1, -1.0f);
 	TextRender()->Text(0, x - w, y, Fontsize, aBuf, -1.0f);
 	y += LineHeight;

--- a/src/game/client/components/items.cpp
+++ b/src/game/client/components/items.cpp
@@ -394,7 +394,7 @@ void CItems::OnRender()
 				{
 					bool IsOtherTeam = m_pClient->IsOtherTeam(pProj->GetOwner());
 					if(pProj->m_LastRenderTick <= 0 && (pProj->m_Type != WEAPON_SHOTGUN || (!pProj->m_Freeze && !pProj->m_Explosive)) // skip ddrace shotgun bullets
-						&& (pProj->m_Type == WEAPON_SHOTGUN || fabs(length(pProj->m_Direction) - 1.f) < 0.02) // workaround to skip grenades on ball mod
+						&& (pProj->m_Type == WEAPON_SHOTGUN || fabs(length(pProj->m_Direction) - 1.f) < 0.02f) // workaround to skip grenades on ball mod
 						&& (pProj->GetOwner() < 0 || !GameClient()->m_aClients[pProj->GetOwner()].m_IsPredictedLocal || IsOtherTeam) // skip locally predicted projectiles
 						&& !Client()->SnapFindItem(IClient::SNAP_PREV, Item.m_Type, Item.m_ID))
 					{

--- a/src/game/client/components/maplayers.cpp
+++ b/src/game/client/components/maplayers.cpp
@@ -104,19 +104,19 @@ void CMapLayers::EnvelopeEval(int TimeOffsetMillis, int Env, float *pChannels, v
 				// get the lerp of the current tick and prev
 				int MinTick = pThis->Client()->PrevGameTick(g_Config.m_ClDummy) - pThis->m_pClient->m_Snap.m_pGameInfoObj->m_RoundStartTick;
 				int CurTick = pThis->Client()->GameTick(g_Config.m_ClDummy) - pThis->m_pClient->m_Snap.m_pGameInfoObj->m_RoundStartTick;
-				s_Time = (int64_t)(mix<float>(
+				s_Time = (int64_t)(mix<double>(
 							   0,
 							   (CurTick - MinTick),
-							   pThis->Client()->IntraGameTick(g_Config.m_ClDummy)) *
+							   (double)pThis->Client()->IntraGameTick(g_Config.m_ClDummy)) *
 						   TickToMicroSeconds) +
 					 MinTick * TickToMicroSeconds;
 			}
 			else
 			{
 				int MinTick = pThis->m_LastLocalTick;
-				s_Time = (int64_t)(mix<float>(0,
+				s_Time = (int64_t)(mix<double>(0,
 							   pThis->m_CurrentLocalTick - MinTick,
-							   pThis->Client()->IntraGameTick(g_Config.m_ClDummy)) *
+							   (double)pThis->Client()->IntraGameTick(g_Config.m_ClDummy)) *
 						   TickToMicroSeconds) +
 					 MinTick * TickToMicroSeconds;
 			}
@@ -132,10 +132,10 @@ void CMapLayers::EnvelopeEval(int TimeOffsetMillis, int Env, float *pChannels, v
 				// get the lerp of the current tick and prev
 				int MinTick = pThis->Client()->PrevGameTick(g_Config.m_ClDummy) - pThis->m_pClient->m_Snap.m_pGameInfoObj->m_RoundStartTick;
 				int CurTick = pThis->Client()->GameTick(g_Config.m_ClDummy) - pThis->m_pClient->m_Snap.m_pGameInfoObj->m_RoundStartTick;
-				s_Time = (int64_t)(mix<float>(
+				s_Time = (int64_t)(mix<double>(
 							   0,
 							   (CurTick - MinTick),
-							   pThis->Client()->IntraGameTick(g_Config.m_ClDummy)) *
+							   (double)pThis->Client()->IntraGameTick(g_Config.m_ClDummy)) *
 						   TickToMicroSeconds) +
 					 MinTick * TickToMicroSeconds;
 			}
@@ -1762,8 +1762,8 @@ void CMapLayers::OnRender()
 							if(IsGameLayer)
 							{
 								// slow blinking to hint that it's not a part of the map
-								float Seconds = time_get() / (float)time_freq();
-								ColorRGBA ColorHint = ColorRGBA(1.0f, 1.0f, 1.0f, 0.3f + 0.7f * (1.0f + sin(2.0f * pi * Seconds / 3.f)) / 2.0f);
+								double Seconds = time_get() / (double)time_freq();
+								ColorRGBA ColorHint = ColorRGBA(1.0f, 1.0f, 1.0f, 0.3 + 0.7 * (1 + sin(2 * (double)pi * Seconds / 3)) / 2);
 
 								RenderTools()->RenderTileRectangle(-201, -201, pTMap->m_Width + 402, pTMap->m_Height + 402,
 									0, TILE_DEATH, // display air inside, death outside
@@ -1781,8 +1781,8 @@ void CMapLayers::OnRender()
 							if(IsGameLayer)
 							{
 								// slow blinking to hint that it's not a part of the map
-								float Seconds = time_get() / (float)time_freq();
-								ColorRGBA ColorHint = ColorRGBA(1.0f, 1.0f, 1.0f, 0.3f + 0.7f * (1.0f + sin(2.0f * pi * Seconds / 3.f)) / 2.0f);
+								double Seconds = time_get() / (double)time_freq();
+								ColorRGBA ColorHint = ColorRGBA(1.0f, 1.0f, 1.0f, 0.3 + 0.7 * (1.0 + sin(2 * (double)pi * Seconds / 3)) / 2);
 
 								ColorRGBA ColorKill(Color.x * ColorHint.x, Color.y * ColorHint.y, Color.z * ColorHint.z, Color.w * ColorHint.w);
 								RenderKillTileBorder(TileLayerCounter - 1, &ColorKill, pTMap, pGroup);

--- a/src/game/client/components/maplayers.cpp
+++ b/src/game/client/components/maplayers.cpp
@@ -104,7 +104,7 @@ void CMapLayers::EnvelopeEval(int TimeOffsetMillis, int Env, float *pChannels, v
 				// get the lerp of the current tick and prev
 				int MinTick = pThis->Client()->PrevGameTick(g_Config.m_ClDummy) - pThis->m_pClient->m_Snap.m_pGameInfoObj->m_RoundStartTick;
 				int CurTick = pThis->Client()->GameTick(g_Config.m_ClDummy) - pThis->m_pClient->m_Snap.m_pGameInfoObj->m_RoundStartTick;
-				s_Time = (int64_t)(mix<double>(
+				s_Time = (int64_t)(mix<float>(
 							   0,
 							   (CurTick - MinTick),
 							   pThis->Client()->IntraGameTick(g_Config.m_ClDummy)) *
@@ -114,7 +114,7 @@ void CMapLayers::EnvelopeEval(int TimeOffsetMillis, int Env, float *pChannels, v
 			else
 			{
 				int MinTick = pThis->m_LastLocalTick;
-				s_Time = (int64_t)(mix<double>(0,
+				s_Time = (int64_t)(mix<float>(0,
 							   pThis->m_CurrentLocalTick - MinTick,
 							   pThis->Client()->IntraGameTick(g_Config.m_ClDummy)) *
 						   TickToMicroSeconds) +
@@ -132,7 +132,7 @@ void CMapLayers::EnvelopeEval(int TimeOffsetMillis, int Env, float *pChannels, v
 				// get the lerp of the current tick and prev
 				int MinTick = pThis->Client()->PrevGameTick(g_Config.m_ClDummy) - pThis->m_pClient->m_Snap.m_pGameInfoObj->m_RoundStartTick;
 				int CurTick = pThis->Client()->GameTick(g_Config.m_ClDummy) - pThis->m_pClient->m_Snap.m_pGameInfoObj->m_RoundStartTick;
-				s_Time = (int64_t)(mix<double>(
+				s_Time = (int64_t)(mix<float>(
 							   0,
 							   (CurTick - MinTick),
 							   pThis->Client()->IntraGameTick(g_Config.m_ClDummy)) *
@@ -1762,7 +1762,7 @@ void CMapLayers::OnRender()
 							if(IsGameLayer)
 							{
 								// slow blinking to hint that it's not a part of the map
-								double Seconds = time_get() / (double)time_freq();
+								float Seconds = time_get() / (float)time_freq();
 								ColorRGBA ColorHint = ColorRGBA(1.0f, 1.0f, 1.0f, 0.3f + 0.7f * (1.0f + sin(2.0f * pi * Seconds / 3.f)) / 2.0f);
 
 								RenderTools()->RenderTileRectangle(-201, -201, pTMap->m_Width + 402, pTMap->m_Height + 402,
@@ -1781,8 +1781,8 @@ void CMapLayers::OnRender()
 							if(IsGameLayer)
 							{
 								// slow blinking to hint that it's not a part of the map
-								double Seconds = time_get() / (double)time_freq();
-								ColorRGBA ColorHint = ColorRGBA(1.0f, 1.0f, 1.0f, 0.3f + 0.7f * (1.0 + sin(2.0f * pi * Seconds / 3.f)) / 2.0f);
+								float Seconds = time_get() / (float)time_freq();
+								ColorRGBA ColorHint = ColorRGBA(1.0f, 1.0f, 1.0f, 0.3f + 0.7f * (1.0f + sin(2.0f * pi * Seconds / 3.f)) / 2.0f);
 
 								ColorRGBA ColorKill(Color.x * ColorHint.x, Color.y * ColorHint.y, Color.z * ColorHint.z, Color.w * ColorHint.w);
 								RenderKillTileBorder(TileLayerCounter - 1, &ColorKill, pTMap, pGroup);

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -321,7 +321,7 @@ void CMenus::RenderPlayers(CUIRect MainView)
 		//Cursor.m_LineWidth = Button.w;
 		ColorRGBA Color(1.0f, 1.0f, 1.0f, 0.5f);
 		m_pClient->m_CountryFlags.Render(m_pClient->m_aClients[Index].m_Country, &Color,
-			Button2.x, Button2.y + Button2.h / 2.0f - 0.75 * Button2.h / 2.0f, 1.5f * Button2.h, 0.75f * Button2.h);
+			Button2.x, Button2.y + Button2.h / 2.0f - 0.75f * Button2.h / 2.0f, 1.5f * Button2.h, 0.75f * Button2.h);
 
 		// ignore chat button
 		Item.m_Rect.HMargin(2.0f, &Item.m_Rect);

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -2238,7 +2238,7 @@ void CMenus::RenderSettingsHUD(CUIRect MainView)
 	if(s_CurTab == 0)
 	{ // ***** GENERAL TAB ***** //
 
-		MainView.VSplitLeft(MainView.w * 0.55, &MainView, &Column);
+		MainView.VSplitLeft(MainView.w * 0.55f, &MainView, &Column);
 
 		MainView.HSplitTop(30.0f, &Section, &MainView);
 		UI()->DoLabelScaled(&Section, Localize("HUD"), 20.0f, TEXTALIGN_LEFT);

--- a/src/game/client/prediction/entities/projectile.cpp
+++ b/src/game/client/prediction/entities/projectile.cpp
@@ -119,9 +119,9 @@ void CProjectile::Tick()
 				m_Direction.x = -m_Direction.x;
 			else if(m_Bouncing == 2)
 				m_Direction.y = -m_Direction.y;
-			if(fabs(m_Direction.x) < 1e-6)
+			if(fabs(m_Direction.x) < 1e-6f)
 				m_Direction.x = 0;
-			if(fabs(m_Direction.y) < 1e-6)
+			if(fabs(m_Direction.y) < 1e-6f)
 				m_Direction.y = 0;
 			m_Pos += m_Direction;
 		}

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -1797,7 +1797,7 @@ void CEditor::DoQuadPoint(CQuad *pQuad, int QuadIndex, int V)
 
 float CEditor::TriangleArea(vec2 A, vec2 B, vec2 C)
 {
-	return abs(((B.x - A.x) * (C.y - A.y) - (C.x - A.x) * (B.y - A.y)) * 0.5);
+	return abs(((B.x - A.x) * (C.y - A.y) - (C.x - A.x) * (B.y - A.y)) * 0.5f);
 }
 
 bool CEditor::IsInTriangle(vec2 Point, vec2 A, vec2 B, vec2 C)
@@ -2350,7 +2350,7 @@ void CEditor::DoMapEditor(CUIRect View)
 	if(m_ShowPicker)
 	{
 		CUIRect Screen = *UI()->Screen();
-		float Size = 32.0 * 16.0f;
+		float Size = 32.0f * 16.0f;
 		float w = Size * (Screen.w / View.w);
 		float h = Size * (Screen.h / View.h);
 		float x = -(View.x / Screen.w) * w;

--- a/src/game/gamecore.cpp
+++ b/src/game/gamecore.cpp
@@ -402,8 +402,8 @@ void CCharacterCore::Tick(bool UseInput)
 
 					// make sure that we don't add excess force by checking the
 					// direction against the current velocity. if not zero.
-					if(length(m_Vel) > 0.0001)
-						Velocity = 1 - (dot(normalize(m_Vel), Dir) + 1) / 2;
+					if(length(m_Vel) > 0.0001f)
+						Velocity = 1.f - (dot(normalize(m_Vel), Dir) + 1.f) / 2;
 
 					m_Vel += Dir * a * (Velocity * 0.75f);
 					m_Vel *= 0.85f;

--- a/src/game/gamecore.cpp
+++ b/src/game/gamecore.cpp
@@ -403,7 +403,7 @@ void CCharacterCore::Tick(bool UseInput)
 					// make sure that we don't add excess force by checking the
 					// direction against the current velocity. if not zero.
 					if(length(m_Vel) > 0.0001f)
-						Velocity = 1.f - (dot(normalize(m_Vel), Dir) + 1.f) / 2;
+						Velocity = 1 - (dot(normalize(m_Vel), Dir) + 1) / 2; // Wdouble-promotion don't fix this as this might change game physics
 
 					m_Vel += Dir * a * (Velocity * 0.75f);
 					m_Vel *= 0.85f;

--- a/src/game/server/entities/projectile.cpp
+++ b/src/game/server/entities/projectile.cpp
@@ -226,9 +226,9 @@ void CProjectile::Tick()
 				m_Direction.x = -m_Direction.x;
 			else if(m_Bouncing == 2)
 				m_Direction.y = -m_Direction.y;
-			if(fabs(m_Direction.x) < 1e-6)
+			if(fabs(m_Direction.x) < 1e-6f)
 				m_Direction.x = 0;
-			if(fabs(m_Direction.y) < 1e-6)
+			if(fabs(m_Direction.y) < 1e-6f)
 				m_Direction.y = 0;
 			m_Pos += m_Direction;
 		}

--- a/src/game/server/gameworld.cpp
+++ b/src/game/server/gameworld.cpp
@@ -223,7 +223,7 @@ void CGameWorld::UpdatePlayerMaps()
 		{
 			if(pMap[j] == -1)
 				continue;
-			if(Dist[pMap[j]].first > 5e9)
+			if(Dist[pMap[j]].first > 5e9f)
 				pMap[j] = -1;
 			else
 				rMap[pMap[j]] = j;
@@ -236,7 +236,7 @@ void CGameWorld::UpdatePlayerMaps()
 		for(int j = 0; j < VANILLA_MAX_CLIENTS - 1; j++)
 		{
 			int k = Dist[j].second;
-			if(rMap[k] != -1 || Dist[j].first > 5e9)
+			if(rMap[k] != -1 || Dist[j].first > 5e9f)
 				continue;
 			while(Mapc < VANILLA_MAX_CLIENTS && pMap[Mapc] != -1)
 				Mapc++;

--- a/src/game/server/scoreworker.cpp
+++ b/src/game/server/scoreworker.cpp
@@ -647,7 +647,7 @@ bool CScoreWorker::ShowRank(IDbConnection *pSqlServer, const ISqlData *pGameData
 		int Rank = pSqlServer->GetInt(1);
 		float Time = pSqlServer->GetFloat(2);
 		// CEIL and FLOOR are not supported in SQLite
-		int BetterThanPercent = std::floor(100.0 - 100.0 * pSqlServer->GetFloat(3));
+		int BetterThanPercent = std::floor(100.0f - 100.0f * pSqlServer->GetFloat(3));
 		str_time_float(Time, TIME_HOURS_CENTISECS, aBuf, sizeof(aBuf));
 		if(g_Config.m_SvHideScore)
 		{
@@ -728,7 +728,7 @@ bool CScoreWorker::ShowTeamRank(IDbConnection *pSqlServer, const ISqlData *pGame
 		str_time_float(Time, TIME_HOURS_CENTISECS, aBuf, sizeof(aBuf));
 		int Rank = pSqlServer->GetInt(4);
 		// CEIL and FLOOR are not supported in SQLite
-		int BetterThanPercent = std::floor(100.0 - 100.0 * pSqlServer->GetFloat(5));
+		int BetterThanPercent = std::floor(100.0f - 100.0f * pSqlServer->GetFloat(5));
 		CTeamrank Teamrank;
 		if(Teamrank.NextSqlResult(pSqlServer, &End, pError, ErrorSize))
 		{


### PR DESCRIPTION
Double promotion occurs quite often when an operator is an hidden double, like constants written without the 'f' at the end. We might get a tiny micro improvement. Unfortunately, we can't do anything for all the double promotion occurring in printf like functions as it is the default for both C and C++.

Only this line might change physics:
https://github.com/ddnet/ddnet/commit/4d47fcda094c3452a5924aad8811fd6965362ee3#diff-d76009083687ba43c59dc7bb2c7357457c999c2eb9d913967d598e913c6fd01fR406

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
