### PR TITLE
Fix some Windows build warnings

### DIFF
--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -4187,12 +4187,12 @@ void init_exception_handler()
 	{
 		// Intentional
 #ifdef __MINGW32__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wcast-function-type"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-function-type"
 #endif
 		auto exc_hndl_init = (void APIENTRY (*)(void *))GetProcAddress(exception_handling_module, "ExcHndlInit");
 #ifdef __MINGW32__
-#pragma clang diagnostic pop
+#pragma GCC diagnostic pop
 #endif
 		void *exception_handling_offset = (void *)GetModuleHandle(NULL);
 		exc_hndl_init(exception_handling_offset);
@@ -4209,12 +4209,12 @@ void set_exception_handler_log_file(const char *log_file_path)
 	{
 		// Intentional
 #ifdef __MINGW32__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wcast-function-type"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-function-type"
 #endif
 		auto exception_log_file_path_func = (BOOL APIENTRY(*)(const char *))(GetProcAddress(exception_handling_module, "ExcHndlSetLogFileNameA"));
 #ifdef __MINGW32__
-#pragma clang diagnostic pop
+#pragma GCC diagnostic pop
 #endif
 		exception_log_file_path_func(log_file_path);
 	}

--- a/src/engine/client/backend/vulkan/backend_vulkan.cpp
+++ b/src/engine/client/backend/vulkan/backend_vulkan.cpp
@@ -47,6 +47,11 @@
 #define VK_API_VERSION_PATCH VK_VERSION_PATCH
 #endif
 
+// for msvc
+#ifndef PRIu64
+#define PRIu64 "I64u"
+#endif
+
 class CCommandProcessorFragment_Vulkan : public CCommandProcessorFragment_GLBase
 {
 	enum EMemoryBlockUsage
@@ -89,7 +94,7 @@ class CCommandProcessorFragment_Vulkan : public CCommandProcessorFragment_GLBase
 			break;
 		default: break;
 		}
-		dbg_msg("vulkan", "allocated chunk of memory with size: %zu for frame %zu (%s)", (size_t)Size, (size_t)m_CurImageIndex, pUsage);
+		dbg_msg("vulkan", "allocated chunk of memory with size: %" PRIu64 " for frame %" PRIu64 " (%s)", (size_t)Size, (size_t)m_CurImageIndex, pUsage);
 	}
 
 	void VerboseDeallocatedMemory(VkDeviceSize Size, size_t FrameImageIndex, EMemoryBlockUsage MemUsage)
@@ -111,7 +116,7 @@ class CCommandProcessorFragment_Vulkan : public CCommandProcessorFragment_GLBase
 			break;
 		default: break;
 		}
-		dbg_msg("vulkan", "deallocated chunk of memory with size: %zu for frame %zu (%s)", (size_t)Size, (size_t)m_CurImageIndex, pUsage);
+		dbg_msg("vulkan", "deallocated chunk of memory with size: %" PRIu64 " for frame %" PRIu64 " (%s)", (size_t)Size, (size_t)m_CurImageIndex, pUsage);
 	}
 
 	/************************
@@ -1956,7 +1961,7 @@ protected:
 			m_pStagingMemoryUsage->store(m_pStagingMemoryUsage->load(std::memory_order_relaxed) - FreeedMemory, std::memory_order_relaxed);
 			if(IsVerbose())
 			{
-				dbg_msg("vulkan", "deallocated chunks of memory with size: %zu from all frames (staging buffer)", (size_t)FreeedMemory);
+				dbg_msg("vulkan", "deallocated chunks of memory with size: %" PRIu64 " from all frames (staging buffer)", (size_t)FreeedMemory);
 			}
 		}
 		FreeedMemory = 0;
@@ -1966,7 +1971,7 @@ protected:
 			m_pBufferMemoryUsage->store(m_pBufferMemoryUsage->load(std::memory_order_relaxed) - FreeedMemory, std::memory_order_relaxed);
 			if(IsVerbose())
 			{
-				dbg_msg("vulkan", "deallocated chunks of memory with size: %zu from all frames (buffer)", (size_t)FreeedMemory);
+				dbg_msg("vulkan", "deallocated chunks of memory with size: %" PRIu64 " from all frames (buffer)", (size_t)FreeedMemory);
 			}
 		}
 		FreeedMemory = 0;
@@ -1977,7 +1982,7 @@ protected:
 			m_pTextureMemoryUsage->store(m_pTextureMemoryUsage->load(std::memory_order_relaxed) - FreeedMemory, std::memory_order_relaxed);
 			if(IsVerbose())
 			{
-				dbg_msg("vulkan", "deallocated chunks of memory with size: %zu from all frames (texture)", (size_t)FreeedMemory);
+				dbg_msg("vulkan", "deallocated chunks of memory with size: %" PRIu64 " from all frames (texture)", (size_t)FreeedMemory);
 			}
 		}
 	}
@@ -3530,7 +3535,7 @@ public:
 
 			if(IsVerbose())
 			{
-				dbg_msg("vulkan", "device prop: non-coherent align: %zu, optimal image copy align: %zu, max texture size: %u, max sampler anisotropy: %u", (size_t)m_NonCoherentMemAlignment, (size_t)m_OptimalImageCopyMemAlignment, m_MaxTextureSize, m_MaxSamplerAnisotropy);
+				dbg_msg("vulkan", "device prop: non-coherent align: %" PRIu64 ", optimal image copy align: %" PRIu64 ", max texture size: %u, max sampler anisotropy: %u", (size_t)m_NonCoherentMemAlignment, (size_t)m_OptimalImageCopyMemAlignment, m_MaxTextureSize, m_MaxSamplerAnisotropy);
 				dbg_msg("vulkan", "device prop: min uniform align: %u, multi sample: %u", m_MinUniformAlign, (uint32_t)m_MaxMultiSample);
 			}
 		}
@@ -7044,7 +7049,7 @@ public:
 
 			if(IsVerbose() && s_BenchmarkRenderThreads)
 			{
-				dbg_msg("vulkan", "render thread %zu took %d microseconds to finish", ThreadIndex, (int)(time_get_microseconds() - ThreadRenderTime));
+				dbg_msg("vulkan", "render thread %" PRIu64 " took %d microseconds to finish", ThreadIndex, (int)(time_get_microseconds() - ThreadRenderTime));
 			}
 
 			pThread->m_IsRendering = false;

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -4331,13 +4331,13 @@ int main(int argc, const char **argv)
 	ISteam *pSteam = CreateSteam();
 
 #if defined(CONF_EXCEPTION_HANDLING)
-	char aBuf[IO_MAX_PATH_LENGTH];
+	char aBufPath[IO_MAX_PATH_LENGTH];
 	char aBufName[IO_MAX_PATH_LENGTH];
 	char aDate[64];
 	str_timestamp(aDate, sizeof(aDate));
 	str_format(aBufName, sizeof(aBufName), "dumps/" GAME_NAME "_crash_log_%d_%s.RTP", pid(), aDate);
-	pStorage->GetCompletePath(IStorage::TYPE_SAVE, aBufName, aBuf, sizeof(aBuf));
-	set_exception_handler_log_file(aBuf);
+	pStorage->GetCompletePath(IStorage::TYPE_SAVE, aBufName, aBufPath, sizeof(aBufPath));
+	set_exception_handler_log_file(aBufPath);
 #endif
 
 	if(RandInitFailed)


### PR DESCRIPTION
```
/home/deen/isos/ddnet/ddnet-source/src/engine/client/backend/vulkan/backend_vulkan.cpp: In member function ‘void CCommandProcessorFragment_Vulkan::VerboseAllocatedMemory(VkDeviceSize, size_t, CCommandProcessorFragment_Vulkan::EMemoryBlockUsage)’:
/home/deen/isos/ddnet/ddnet-source/src/engine/client/backend/vulkan/backend_vulkan.cpp:92:74: warning: unknown conversion type character ‘z’ in format [-Wformat=]
   92 |                 dbg_msg("vulkan", "allocated chunk of memory with size: %zu for frame %zu (%s)", (size_t)Size, (size_t)m_CurImageIndex, pUsage);
      |                                                                          ^
/home/deen/isos/ddnet/ddnet-source/src/engine/client/backend/vulkan/backend_vulkan.cpp:92:88: warning: unknown conversion type character ‘z’ in format [-Wformat=]
   92 |                 dbg_msg("vulkan", "allocated chunk of memory with size: %zu for frame %zu (%s)", (size_t)Size, (size_t)m_CurImageIndex, pUsage);
      |                                                                                        ^
/home/deen/isos/ddnet/ddnet-source/src/engine/client/backend/vulkan/backend_vulkan.cpp:92:93: warning: format ‘%s’ expects argument of type ‘char*’, but argument 3 has type ‘VkDeviceSize’ {aka ‘long long unsigned int’} [-Wformat=]
   92 |                 dbg_msg("vulkan", "allocated chunk of memory with size: %zu for frame %zu (%s)", (size_t)Size, (size_t)m_CurImageIndex, pUsage);
      |                                                                                            ~^    ~~~~~~~~~~~~
      |                                                                                             |    |
      |                                                                                             |    VkDeviceSize {aka long long unsigned int}
      |                                                                                             char*
      |                                                                                            %lld
/home/deen/isos/ddnet/ddnet-source/src/engine/client/backend/vulkan/backend_vulkan.cpp:92:35: warning: too many arguments for format [-Wformat-extra-args]
   92 |                 dbg_msg("vulkan", "allocated chunk of memory with size: %zu for frame %zu (%s)", (size_t)Size, (size_t)m_CurImageIndex, pUsage);
      |                                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
