### PR TITLE
Add some files & dirs to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ ninja_package
 pack_*/
 rules.ninja
 testrunner\[1\]_include.cmake
+vulkan_shaders_sha256.txt
 
 /SDL2.framework
 
@@ -73,7 +74,10 @@ versionsrv
 
 generated
 
+/build*
+
 # IDE project files
+.cache
 .cproject
 .cmake
 .idea


### PR DESCRIPTION
`.cache` is for clangd

`vulkan_shaders_sha256.txt`

also added `build*/` for all build dirs. Is there any drawback why we don't do that, is it bad style to do that?
I have quite a lot of stuff in my build dirs
callgrind info and so on


fixes #4865

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
