### PR TITLE
Renamed all shadowed/shadowing variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,7 +250,8 @@ if(NOT MSVC AND NOT HAIKU)
   add_c_compiler_flag_if_supported(OUR_FLAGS_OWN -Wduplicated-branches)
   add_c_compiler_flag_if_supported(OUR_FLAGS_OWN -Wlogical-op)
   add_c_compiler_flag_if_supported(OUR_FLAGS_OWN -Wrestrict)
-  add_c_compiler_flag_if_supported(OUR_FLAGS_OWN -Wshadow=local) # global has too many occurences
+  add_c_compiler_flag_if_supported(OUR_FLAGS_OWN -Wshadow-all) # clang
+  add_c_compiler_flag_if_supported(OUR_FLAGS_OWN -Wshadow=global) # gcc
   add_c_compiler_flag_if_supported(OUR_FLAGS_OWN -Wthread-safety)
   # add_c_compiler_flag_if_supported(OUR_FLAGS_OWN -Wdouble-promotion) # Many occurences
   # add_c_compiler_flag_if_supported(OUR_FLAGS_OWN -Wnull-dereference) # Many occurences

--- a/src/base/vmath.h
+++ b/src/base/vmath.h
@@ -30,52 +30,52 @@ public:
 	}
 
 	vector2_base operator-() const { return vector2_base(-x, -y); }
-	vector2_base operator-(const vector2_base &v) const { return vector2_base(x - v.x, y - v.y); }
-	vector2_base operator+(const vector2_base &v) const { return vector2_base(x + v.x, y + v.y); }
-	vector2_base operator*(const T v) const { return vector2_base(x * v, y * v); }
-	vector2_base operator*(const vector2_base &v) const { return vector2_base(x * v.x, y * v.y); }
-	vector2_base operator/(const T v) const { return vector2_base(x / v, y / v); }
-	vector2_base operator/(const vector2_base &v) const { return vector2_base(x / v.x, y / v.y); }
+	vector2_base operator-(const vector2_base &vec) const { return vector2_base(x - vec.x, y - vec.y); }
+	vector2_base operator+(const vector2_base &vec) const { return vector2_base(x + vec.x, y + vec.y); }
+	vector2_base operator*(const T rhs) const { return vector2_base(x * rhs, y * rhs); }
+	vector2_base operator*(const vector2_base &vec) const { return vector2_base(x * vec.x, y * vec.y); }
+	vector2_base operator/(const T rhs) const { return vector2_base(x / rhs, y / rhs); }
+	vector2_base operator/(const vector2_base &vec) const { return vector2_base(x / vec.x, y / vec.y); }
 
-	const vector2_base &operator+=(const vector2_base &v)
+	const vector2_base &operator+=(const vector2_base &vec)
 	{
-		x += v.x;
-		y += v.y;
+		x += vec.x;
+		y += vec.y;
 		return *this;
 	}
-	const vector2_base &operator-=(const vector2_base &v)
+	const vector2_base &operator-=(const vector2_base &vec)
 	{
-		x -= v.x;
-		y -= v.y;
+		x -= vec.x;
+		y -= vec.y;
 		return *this;
 	}
-	const vector2_base &operator*=(const T v)
+	const vector2_base &operator*=(const T rhs)
 	{
-		x *= v;
-		y *= v;
+		x *= rhs;
+		y *= rhs;
 		return *this;
 	}
-	const vector2_base &operator*=(const vector2_base &v)
+	const vector2_base &operator*=(const vector2_base &vec)
 	{
-		x *= v.x;
-		y *= v.y;
+		x *= vec.x;
+		y *= vec.y;
 		return *this;
 	}
-	const vector2_base &operator/=(const T v)
+	const vector2_base &operator/=(const T rhs)
 	{
-		x /= v;
-		y /= v;
+		x /= rhs;
+		y /= rhs;
 		return *this;
 	}
-	const vector2_base &operator/=(const vector2_base &v)
+	const vector2_base &operator/=(const vector2_base &vec)
 	{
-		x /= v.x;
-		y /= v.y;
+		x /= vec.x;
+		y /= vec.y;
 		return *this;
 	}
 
-	bool operator==(const vector2_base &v) const { return x == v.x && y == v.y; } //TODO: do this with an eps instead
-	bool operator!=(const vector2_base &v) const { return x != v.x || y != v.y; }
+	bool operator==(const vector2_base &vec) const { return x == vec.x && y == vec.y; } //TODO: do this with an eps instead
+	bool operator!=(const vector2_base &vec) const { return x != vec.x || y != vec.y; }
 
 	T &operator[](const int index) { return index ? y : x; }
 };
@@ -184,59 +184,59 @@ public:
 		z = nz;
 	}
 
-	vector3_base operator-(const vector3_base &v) const { return vector3_base(x - v.x, y - v.y, z - v.z); }
+	vector3_base operator-(const vector3_base &vec) const { return vector3_base(x - vec.x, y - vec.y, z - vec.z); }
 	vector3_base operator-() const { return vector3_base(-x, -y, -z); }
-	vector3_base operator+(const vector3_base &v) const { return vector3_base(x + v.x, y + v.y, z + v.z); }
-	vector3_base operator*(const T v) const { return vector3_base(x * v, y * v, z * v); }
-	vector3_base operator*(const vector3_base &v) const { return vector3_base(x * v.x, y * v.y, z * v.z); }
-	vector3_base operator/(const T v) const { return vector3_base(x / v, y / v, z / v); }
-	vector3_base operator/(const vector3_base &v) const { return vector3_base(x / v.x, y / v.y, z / v.z); }
+	vector3_base operator+(const vector3_base &vec) const { return vector3_base(x + vec.x, y + vec.y, z + vec.z); }
+	vector3_base operator*(const T rhs) const { return vector3_base(x * rhs, y * rhs, z * rhs); }
+	vector3_base operator*(const vector3_base &vec) const { return vector3_base(x * vec.x, y * vec.y, z * vec.z); }
+	vector3_base operator/(const T rhs) const { return vector3_base(x / rhs, y / rhs, z / rhs); }
+	vector3_base operator/(const vector3_base &vec) const { return vector3_base(x / vec.x, y / vec.y, z / vec.z); }
 
-	const vector3_base &operator+=(const vector3_base &v)
+	const vector3_base &operator+=(const vector3_base &vec)
 	{
-		x += v.x;
-		y += v.y;
-		z += v.z;
+		x += vec.x;
+		y += vec.y;
+		z += vec.z;
 		return *this;
 	}
-	const vector3_base &operator-=(const vector3_base &v)
+	const vector3_base &operator-=(const vector3_base &vec)
 	{
-		x -= v.x;
-		y -= v.y;
-		z -= v.z;
+		x -= vec.x;
+		y -= vec.y;
+		z -= vec.z;
 		return *this;
 	}
-	const vector3_base &operator*=(const T v)
+	const vector3_base &operator*=(const T rhs)
 	{
-		x *= v;
-		y *= v;
-		z *= v;
+		x *= rhs;
+		y *= rhs;
+		z *= rhs;
 		return *this;
 	}
-	const vector3_base &operator*=(const vector3_base &v)
+	const vector3_base &operator*=(const vector3_base &vec)
 	{
-		x *= v.x;
-		y *= v.y;
-		z *= v.z;
+		x *= vec.x;
+		y *= vec.y;
+		z *= vec.z;
 		return *this;
 	}
-	const vector3_base &operator/=(const T v)
+	const vector3_base &operator/=(const T rhs)
 	{
-		x /= v;
-		y /= v;
-		z /= v;
+		x /= rhs;
+		y /= rhs;
+		z /= rhs;
 		return *this;
 	}
-	const vector3_base &operator/=(const vector3_base &v)
+	const vector3_base &operator/=(const vector3_base &vec)
 	{
-		x /= v.x;
-		y /= v.y;
-		z /= v.z;
+		x /= vec.x;
+		y /= vec.y;
+		z /= vec.z;
 		return *this;
 	}
 
-	bool operator==(const vector3_base &v) const { return x == v.x && y == v.y && z == v.z; } //TODO: do this with an eps instead
-	bool operator!=(const vector3_base &v) const { return x != v.x || y != v.y || z != v.z; }
+	bool operator==(const vector3_base &vec) const { return x == vec.x && y == vec.y && z == vec.z; } //TODO: do this with an eps instead
+	bool operator!=(const vector3_base &vec) const { return x != vec.x || y != vec.y || z != vec.z; }
 };
 
 template<typename T>
@@ -308,64 +308,64 @@ public:
 		w = nw;
 	}
 
-	vector4_base operator+(const vector4_base &v) const { return vector4_base(x + v.x, y + v.y, z + v.z, w + v.w); }
-	vector4_base operator-(const vector4_base &v) const { return vector4_base(x - v.x, y - v.y, z - v.z, w - v.w); }
+	vector4_base operator+(const vector4_base &vec) const { return vector4_base(x + vec.x, y + vec.y, z + vec.z, w + vec.w); }
+	vector4_base operator-(const vector4_base &vec) const { return vector4_base(x - vec.x, y - vec.y, z - vec.z, w - vec.w); }
 	vector4_base operator-() const { return vector4_base(-x, -y, -z, -w); }
-	vector4_base operator*(const vector4_base &v) const { return vector4_base(x * v.x, y * v.y, z * v.z, w * v.w); }
-	vector4_base operator*(const T v) const { return vector4_base(x * v, y * v, z * v, w * v); }
-	vector4_base operator/(const vector4_base &v) const { return vector4_base(x / v.x, y / v.y, z / v.z, w / v.w); }
-	vector4_base operator/(const T v) const { return vector4_base(x / v, y / v, z / v, w / v); }
+	vector4_base operator*(const vector4_base &vec) const { return vector4_base(x * vec.x, y * vec.y, z * vec.z, w * vec.w); }
+	vector4_base operator*(const T rhs) const { return vector4_base(x * rhs, y * rhs, z * rhs, w * rhs); }
+	vector4_base operator/(const vector4_base &vec) const { return vector4_base(x / vec.x, y / vec.y, z / vec.z, w / vec.w); }
+	vector4_base operator/(const T vec) const { return vector4_base(x / vec, y / vec, z / vec, w / vec); }
 
-	const vector4_base &operator+=(const vector4_base &v)
+	const vector4_base &operator+=(const vector4_base &vec)
 	{
-		x += v.x;
-		y += v.y;
-		z += v.z;
-		w += v.w;
+		x += vec.x;
+		y += vec.y;
+		z += vec.z;
+		w += vec.w;
 		return *this;
 	}
-	const vector4_base &operator-=(const vector4_base &v)
+	const vector4_base &operator-=(const vector4_base &vec)
 	{
-		x -= v.x;
-		y -= v.y;
-		z -= v.z;
-		w -= v.w;
+		x -= vec.x;
+		y -= vec.y;
+		z -= vec.z;
+		w -= vec.w;
 		return *this;
 	}
-	const vector4_base &operator*=(const T v)
+	const vector4_base &operator*=(const T rhs)
 	{
-		x *= v;
-		y *= v;
-		z *= v;
-		w *= v;
+		x *= rhs;
+		y *= rhs;
+		z *= rhs;
+		w *= rhs;
 		return *this;
 	}
-	const vector4_base &operator*=(const vector4_base &v)
+	const vector4_base &operator*=(const vector4_base &vec)
 	{
-		x *= v.x;
-		y *= v.y;
-		z *= v.z;
-		w *= v.w;
+		x *= vec.x;
+		y *= vec.y;
+		z *= vec.z;
+		w *= vec.w;
 		return *this;
 	}
-	const vector4_base &operator/=(const T v)
+	const vector4_base &operator/=(const T rhs)
 	{
-		x /= v;
-		y /= v;
-		z /= v;
-		w /= v;
+		x /= rhs;
+		y /= rhs;
+		z /= rhs;
+		w /= rhs;
 		return *this;
 	}
-	const vector4_base &operator/=(const vector4_base &v)
+	const vector4_base &operator/=(const vector4_base &vec)
 	{
-		x /= v.x;
-		y /= v.y;
-		z /= v.z;
-		w /= v.w;
+		x /= vec.x;
+		y /= vec.y;
+		z /= vec.z;
+		w /= vec.w;
 		return *this;
 	}
 
-	bool operator==(const vector4_base &v) const { return x == v.x && y == v.y && z == v.z && w == v.w; } //TODO: do this with an eps instead
+	bool operator==(const vector4_base &vec) const { return x == vec.x && y == vec.y && z == vec.z && w == vec.w; } //TODO: do this with an eps instead
 };
 
 typedef vector4_base<float> vec4;

--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -751,10 +751,10 @@ static void DisplayToVideoMode(CVideoMode *pVMode, SDL_DisplayMode *pMode, int H
 	pVMode->m_Format = pMode->format;
 }
 
-void CGraphicsBackend_SDL_GL::GetVideoModes(CVideoMode *pModes, int MaxModes, int *pNumModes, int HiDPIScale, int MaxWindowWidth, int MaxWindowHeight, int Screen)
+void CGraphicsBackend_SDL_GL::GetVideoModes(CVideoMode *pModes, int MaxModes, int *pNumModes, int HiDPIScale, int MaxWindowWidth, int MaxWindowHeight, int ScreenID)
 {
 	SDL_DisplayMode DesktopMode;
-	int maxModes = SDL_GetNumDisplayModes(Screen);
+	int maxModes = SDL_GetNumDisplayModes(ScreenID);
 	int numModes = 0;
 
 	// Only collect fullscreen modes when requested, that makes sure in windowed mode no refresh rates are shown that aren't supported without
@@ -762,7 +762,7 @@ void CGraphicsBackend_SDL_GL::GetVideoModes(CVideoMode *pModes, int MaxModes, in
 	bool IsFullscreenDestkop = m_pWindow != NULL && (((SDL_GetWindowFlags(m_pWindow) & SDL_WINDOW_FULLSCREEN_DESKTOP) == SDL_WINDOW_FULLSCREEN_DESKTOP) || g_Config.m_GfxFullscreen == 3);
 	bool CollectFullscreenModes = m_pWindow == NULL || ((SDL_GetWindowFlags(m_pWindow) & SDL_WINDOW_FULLSCREEN) != 0 && !IsFullscreenDestkop);
 
-	if(SDL_GetDesktopDisplayMode(Screen, &DesktopMode) < 0)
+	if(SDL_GetDesktopDisplayMode(ScreenID, &DesktopMode) < 0)
 	{
 		dbg_msg("gfx", "unable to get display mode: %s", SDL_GetError());
 	}
@@ -773,7 +773,7 @@ void CGraphicsBackend_SDL_GL::GetVideoModes(CVideoMode *pModes, int MaxModes, in
 	for(int i = 0; i < maxModes && NumModes < ModeCount; i++)
 	{
 		SDL_DisplayMode mode;
-		if(SDL_GetDisplayMode(Screen, i, &mode) < 0)
+		if(SDL_GetDisplayMode(ScreenID, i, &mode) < 0)
 		{
 			dbg_msg("gfx", "unable to get display mode: %s", SDL_GetError());
 			continue;
@@ -815,20 +815,20 @@ void CGraphicsBackend_SDL_GL::GetVideoModes(CVideoMode *pModes, int MaxModes, in
 	*pNumModes = numModes;
 }
 
-void CGraphicsBackend_SDL_GL::GetCurrentVideoMode(CVideoMode &CurMode, int HiDPIScale, int MaxWindowWidth, int MaxWindowHeight, int Screen)
+void CGraphicsBackend_SDL_GL::GetCurrentVideoMode(CVideoMode &CurMode, int HiDPIScale, int MaxWindowWidth, int MaxWindowHeight, int ScreenID)
 {
 	SDL_DisplayMode DPMode;
 	// if "real" fullscreen, obtain the video mode for that
 	if((SDL_GetWindowFlags(m_pWindow) & SDL_WINDOW_FULLSCREEN_DESKTOP) == SDL_WINDOW_FULLSCREEN)
 	{
-		if(SDL_GetCurrentDisplayMode(Screen, &DPMode))
+		if(SDL_GetCurrentDisplayMode(ScreenID, &DPMode))
 		{
 			dbg_msg("gfx", "unable to get display mode: %s", SDL_GetError());
 		}
 	}
 	else
 	{
-		if(SDL_GetDesktopDisplayMode(Screen, &DPMode) < 0)
+		if(SDL_GetDesktopDisplayMode(ScreenID, &DPMode) < 0)
 		{
 			dbg_msg("gfx", "unable to get display mode: %s", SDL_GetError());
 		}

--- a/src/engine/client/backend_sdl.h
+++ b/src/engine/client/backend_sdl.h
@@ -203,7 +203,7 @@ class CGraphicsBackend_SDL_GL : public CGraphicsBackend_Threaded
 
 public:
 	CGraphicsBackend_SDL_GL();
-	virtual int Init(const char *pName, int *Screen, int *pWidth, int *pHeight, int *pRefreshRate, int FsaaSamples, int Flags, int *pDesktopWidth, int *pDesktopHeight, int *pCurrentWidth, int *pCurrentHeight, class IStorage *pStorage);
+	virtual int Init(const char *pName, int *pScreen, int *pWidth, int *pHeight, int *pRefreshRate, int FsaaSamples, int Flags, int *pDesktopWidth, int *pDesktopHeight, int *pCurrentWidth, int *pCurrentHeight, class IStorage *pStorage);
 	virtual int Shutdown();
 
 	virtual uint64_t TextureMemoryUsage() const;
@@ -215,8 +215,8 @@ public:
 
 	virtual int GetNumScreens() const { return m_NumScreens; }
 
-	virtual void GetVideoModes(CVideoMode *pModes, int MaxModes, int *pNumModes, int HiDPIScale, int MaxWindowWidth, int MaxWindowHeight, int Screen);
-	virtual void GetCurrentVideoMode(CVideoMode &CurMode, int HiDPIScale, int MaxWindowWidth, int MaxWindowHeight, int Screen);
+	virtual void GetVideoModes(CVideoMode *pModes, int MaxModes, int *pNumModes, int HiDPIScale, int MaxWindowWidth, int MaxWindowHeight, int ScreenID);
+	virtual void GetCurrentVideoMode(CVideoMode &CurMode, int HiDPIScale, int MaxWindowWidth, int MaxWindowHeight, int ScreenID);
 
 	virtual void Minimize();
 	virtual void Maximize();

--- a/src/engine/server/authmanager.cpp
+++ b/src/engine/server/authmanager.cpp
@@ -1,6 +1,7 @@
 #include "authmanager.h"
 #include <base/hash_ctxt.h>
 #include <engine/shared/config.h>
+#include <game/generated/protocol.h>
 
 #define ADMIN_IDENT "default_admin"
 #define MOD_IDENT "default_mod"

--- a/src/engine/server/authmanager.h
+++ b/src/engine/server/authmanager.h
@@ -9,13 +9,6 @@
 class CAuthManager
 {
 private:
-	enum
-	{
-		AUTHED_NO = 0,
-		AUTHED_HELPER,
-		AUTHED_MOD,
-		AUTHED_ADMIN
-	};
 	struct CKey
 	{
 		char m_aIdent[64];

--- a/src/engine/shared/storage.cpp
+++ b/src/engine/shared/storage.cpp
@@ -282,10 +282,10 @@ public:
 #if defined(CONF_PLATFORM_MACOS)
 					str_append(m_aBinarydir, "/../../../DDNet-Server.app/Contents/MacOS", sizeof(m_aBinarydir));
 					str_format(aBuf, sizeof(aBuf), "%s/" PLAT_SERVER_EXEC, m_aBinarydir);
-					IOHANDLE File = io_open(aBuf, IOFLAG_READ);
-					if(File)
+					IOHANDLE FileBis = io_open(aBuf, IOFLAG_READ);
+					if(FileBis)
 					{
-						io_close(File);
+						io_close(FileBis);
 						return;
 					}
 					else

--- a/src/game/bezier.h
+++ b/src/game/bezier.h
@@ -12,13 +12,9 @@ class CCubicBezier
 	float b;
 	float c;
 	float d;
-	CCubicBezier(float a, float b, float c, float d)
-	{
-		this->a = a;
-		this->b = b;
-		this->c = c;
-		this->d = d;
-	}
+	CCubicBezier(float a_, float b_, float c_, float d_)
+        : a(a_), b(b_), c(c_), d(d_)
+	{}
 
 public:
 	CCubicBezier() {}

--- a/src/game/bezier.h
+++ b/src/game/bezier.h
@@ -12,9 +12,10 @@ class CCubicBezier
 	float b;
 	float c;
 	float d;
-	CCubicBezier(float a_, float b_, float c_, float d_)
-        : a(a_), b(b_), c(c_), d(d_)
-	{}
+	CCubicBezier(float a_, float b_, float c_, float d_) :
+		a(a_), b(b_), c(c_), d(d_)
+	{
+	}
 
 public:
 	CCubicBezier() {}

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -384,9 +384,9 @@ void CUIRect::HMargin(float Cut, CUIRect *pOtherRect) const
 	pOtherRect->h = r.h - 2 * Cut;
 }
 
-bool CUIRect::Inside(float x, float y) const
+bool CUIRect::Inside(float x_, float y_) const
 {
-	return x >= this->x && x < this->x + this->w && y >= this->y && y < this->y + this->h;
+	return x_ >= this->x && x_ < this->x + this->w && y_ >= this->y && y_ < this->y + this->h;
 }
 
 int CUI::DoButtonLogic(const void *pID, const char *pText, int Checked, const CUIRect *pRect)

--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -103,7 +103,7 @@ public:
 	 */
 	void HMargin(float Cut, CUIRect *pOtherRect) const;
 
-	bool Inside(float x, float y) const;
+	bool Inside(float x_, float y_) const;
 };
 
 struct SUIAnimator

--- a/src/test/datafile.cpp
+++ b/src/test/datafile.cpp
@@ -11,18 +11,18 @@ TEST(Datafile, ExtendedType)
 	auto pStorage = std::unique_ptr<IStorage>(CreateLocalStorage());
 	CTestInfo Info;
 
-	CMapItemTest Test;
-	Test.m_Version = CMapItemTest::CURRENT_VERSION;
-	Test.m_aFields[0] = 1234;
-	Test.m_aFields[1] = 5678;
-	Test.m_Field3 = 9876;
-	Test.m_Field4 = 5432;
+	CMapItemTest ItemTest;
+	ItemTest.m_Version = CMapItemTest::CURRENT_VERSION;
+	ItemTest.m_aFields[0] = 1234;
+	ItemTest.m_aFields[1] = 5678;
+	ItemTest.m_Field3 = 9876;
+	ItemTest.m_Field4 = 5432;
 
 	{
 		CDataFileWriter Writer;
 		Writer.Open(pStorage.get(), Info.m_aFilename);
 
-		Writer.AddItem(MAPITEMTYPE_TEST, 0x8000, sizeof(Test), &Test);
+		Writer.AddItem(MAPITEMTYPE_TEST, 0x8000, sizeof(ItemTest), &ItemTest);
 
 		Writer.Finish();
 	}
@@ -38,7 +38,7 @@ TEST(Datafile, ExtendedType)
 		int Index = Reader.FindItemIndex(MAPITEMTYPE_TEST, 0x8000);
 		EXPECT_EQ(Start, Index);
 		ASSERT_GE(Index, 0);
-		ASSERT_EQ(Reader.GetItemSize(Index), (int)sizeof(Test));
+		ASSERT_EQ(Reader.GetItemSize(Index), (int)sizeof(ItemTest));
 
 		int Type, ID;
 		const CMapItemTest *pTest = (const CMapItemTest *)Reader.GetItem(Index, &Type, &ID);
@@ -46,11 +46,11 @@ TEST(Datafile, ExtendedType)
 		EXPECT_EQ(Type, MAPITEMTYPE_TEST);
 		EXPECT_EQ(ID, 0x8000);
 
-		EXPECT_EQ(pTest->m_Version, Test.m_Version);
-		EXPECT_EQ(pTest->m_aFields[0], Test.m_aFields[0]);
-		EXPECT_EQ(pTest->m_aFields[1], Test.m_aFields[1]);
-		EXPECT_EQ(pTest->m_Field3, Test.m_Field3);
-		EXPECT_EQ(pTest->m_Field4, Test.m_Field4);
+		EXPECT_EQ(pTest->m_Version, ItemTest.m_Version);
+		EXPECT_EQ(pTest->m_aFields[0], ItemTest.m_aFields[0]);
+		EXPECT_EQ(pTest->m_aFields[1], ItemTest.m_aFields[1]);
+		EXPECT_EQ(pTest->m_Field3, ItemTest.m_Field3);
+		EXPECT_EQ(pTest->m_Field4, ItemTest.m_Field4);
 	}
 
 	if(!HasFailure())

--- a/src/test/score.cpp
+++ b/src/test/score.cpp
@@ -125,8 +125,8 @@ struct Score : public testing::TestWithParam<IDbConnection *>
 
 	IDbConnection *m_pConn{GetParam()};
 	char m_aError[256] = {};
-	std::shared_ptr<CScorePlayerResult> pPlayerResult{std::make_shared<CScorePlayerResult>()};
-	CSqlPlayerRequest m_PlayerRequest{pPlayerResult};
+	std::shared_ptr<CScorePlayerResult> m_pPlayerResult{std::make_shared<CScorePlayerResult>()};
+	CSqlPlayerRequest m_PlayerRequest{m_pPlayerResult};
 };
 
 struct SingleScore : public Score
@@ -145,7 +145,7 @@ struct SingleScore : public Score
 TEST_P(SingleScore, Top)
 {
 	ASSERT_FALSE(CScoreWorker::ShowTop(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
-	ExpectLines(pPlayerResult,
+	ExpectLines(m_pPlayerResult,
 		{"------------ Global Top ------------",
 			"1. nameless tee Time: 01:40.00",
 			"------------ GER Top ------------"});
@@ -154,14 +154,14 @@ TEST_P(SingleScore, Top)
 TEST_P(SingleScore, Rank)
 {
 	ASSERT_FALSE(CScoreWorker::ShowRank(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
-	ExpectLines(pPlayerResult, {"nameless tee - 01:40.00 - better than 100% - requested by brainless tee", "Global rank 1 - GER unranked"}, true);
+	ExpectLines(m_pPlayerResult, {"nameless tee - 01:40.00 - better than 100% - requested by brainless tee", "Global rank 1 - GER unranked"}, true);
 }
 
 TEST_P(SingleScore, TopServer)
 {
 	str_copy(m_PlayerRequest.m_aServer, "USA", sizeof(m_PlayerRequest.m_aServer));
 	ASSERT_FALSE(CScoreWorker::ShowTop(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
-	ExpectLines(pPlayerResult,
+	ExpectLines(m_pPlayerResult,
 		{"------------ Global Top ------------",
 			"1. nameless tee Time: 01:40.00",
 			"---------------------------------------"});
@@ -171,24 +171,24 @@ TEST_P(SingleScore, RankServer)
 {
 	str_copy(m_PlayerRequest.m_aServer, "USA", sizeof(m_PlayerRequest.m_aServer));
 	ASSERT_FALSE(CScoreWorker::ShowRank(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
-	ExpectLines(pPlayerResult, {"nameless tee - 01:40.00 - better than 100% - requested by brainless tee", "Global rank 1 - USA rank 1"}, true);
+	ExpectLines(m_pPlayerResult, {"nameless tee - 01:40.00 - better than 100% - requested by brainless tee", "Global rank 1 - USA rank 1"}, true);
 }
 
 TEST_P(SingleScore, TimesExists)
 {
 	ASSERT_FALSE(CScoreWorker::ShowTimes(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
-	EXPECT_EQ(pPlayerResult->m_MessageKind, CScorePlayerResult::DIRECT);
-	EXPECT_STREQ(pPlayerResult->m_Data.m_aaMessages[0], "------------- Last Times -------------");
+	EXPECT_EQ(m_pPlayerResult->m_MessageKind, CScorePlayerResult::DIRECT);
+	EXPECT_STREQ(m_pPlayerResult->m_Data.m_aaMessages[0], "------------- Last Times -------------");
 	char aBuf[128];
-	str_copy(aBuf, pPlayerResult->m_Data.m_aaMessages[1], 7);
+	str_copy(aBuf, m_pPlayerResult->m_Data.m_aaMessages[1], 7);
 	EXPECT_STREQ(aBuf, "[USA] ");
 
-	str_copy(aBuf, pPlayerResult->m_Data.m_aaMessages[1] + str_length(pPlayerResult->m_Data.m_aaMessages[1]) - 10, 11);
+	str_copy(aBuf, m_pPlayerResult->m_Data.m_aaMessages[1] + str_length(m_pPlayerResult->m_Data.m_aaMessages[1]) - 10, 11);
 	EXPECT_STREQ(aBuf, ", 01:40.00");
-	EXPECT_STREQ(pPlayerResult->m_Data.m_aaMessages[2], "----------------------------------------------------");
+	EXPECT_STREQ(m_pPlayerResult->m_Data.m_aaMessages[2], "----------------------------------------------------");
 	for(int i = 3; i < CScorePlayerResult::MAX_MESSAGES; i++)
 	{
-		EXPECT_STREQ(pPlayerResult->m_Data.m_aaMessages[i], "");
+		EXPECT_STREQ(m_pPlayerResult->m_Data.m_aaMessages[i], "");
 	}
 }
 
@@ -196,7 +196,7 @@ TEST_P(SingleScore, TimesDoesntExist)
 {
 	str_copy(m_PlayerRequest.m_aName, "foo", sizeof(m_PlayerRequest.m_aMap));
 	ASSERT_FALSE(CScoreWorker::ShowTimes(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
-	ExpectLines(pPlayerResult, {"There are no times in the specified range"});
+	ExpectLines(m_pPlayerResult, {"There are no times in the specified range"});
 }
 
 struct TeamScore : public Score
@@ -222,7 +222,7 @@ struct TeamScore : public Score
 TEST_P(TeamScore, All)
 {
 	ASSERT_FALSE(CScoreWorker::ShowTeamTop5(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
-	ExpectLines(pPlayerResult,
+	ExpectLines(m_pPlayerResult,
 		{"------- Team Top 5 -------",
 			"1. brainless tee & nameless tee Team Time: 01:40.00",
 			"-------------------------------"});
@@ -232,7 +232,7 @@ TEST_P(TeamScore, PlayerExists)
 {
 	str_copy(m_PlayerRequest.m_aName, "brainless tee", sizeof(m_PlayerRequest.m_aMap));
 	ASSERT_FALSE(CScoreWorker::ShowPlayerTeamTop5(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
-	ExpectLines(pPlayerResult,
+	ExpectLines(m_pPlayerResult,
 		{"------- Team Top 5 -------",
 			"1. brainless tee & nameless tee Team Time: 01:40.00",
 			"-------------------------------"});
@@ -242,7 +242,7 @@ TEST_P(TeamScore, PlayerDoesntExist)
 {
 	str_copy(m_PlayerRequest.m_aName, "foo", sizeof(m_PlayerRequest.m_aMap));
 	ASSERT_FALSE(CScoreWorker::ShowPlayerTeamTop5(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
-	ExpectLines(pPlayerResult, {"foo has no team ranks"});
+	ExpectLines(m_pPlayerResult, {"foo has no team ranks"});
 }
 
 struct MapInfo : public Score
@@ -258,11 +258,11 @@ TEST_P(MapInfo, ExactNoFinish)
 	str_copy(m_PlayerRequest.m_aName, "Kobra 3", sizeof(m_PlayerRequest.m_aName));
 	ASSERT_FALSE(CScoreWorker::MapInfo(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
 
-	EXPECT_EQ(pPlayerResult->m_MessageKind, CScorePlayerResult::DIRECT);
-	EXPECT_THAT(pPlayerResult->m_Data.m_aaMessages[0], testing::MatchesRegex("\"Kobra 3\" by Zerodin on Novice, ★★★★★, 5 points, released .* ago, 0 finishes by 0 tees"));
+	EXPECT_EQ(m_pPlayerResult->m_MessageKind, CScorePlayerResult::DIRECT);
+	EXPECT_THAT(m_pPlayerResult->m_Data.m_aaMessages[0], testing::MatchesRegex("\"Kobra 3\" by Zerodin on Novice, ★★★★★, 5 points, released .* ago, 0 finishes by 0 tees"));
 	for(int i = 1; i < CScorePlayerResult::MAX_MESSAGES; i++)
 	{
-		EXPECT_STREQ(pPlayerResult->m_Data.m_aaMessages[i], "");
+		EXPECT_STREQ(m_pPlayerResult->m_Data.m_aaMessages[i], "");
 	}
 }
 
@@ -272,11 +272,11 @@ TEST_P(MapInfo, ExactFinish)
 	str_copy(m_PlayerRequest.m_aName, "Kobra 3", sizeof(m_PlayerRequest.m_aName));
 	ASSERT_FALSE(CScoreWorker::MapInfo(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
 
-	EXPECT_EQ(pPlayerResult->m_MessageKind, CScorePlayerResult::DIRECT);
-	EXPECT_THAT(pPlayerResult->m_Data.m_aaMessages[0], testing::MatchesRegex("\"Kobra 3\" by Zerodin on Novice, ★★★★★, 5 points, released .* ago, 1 finish by 1 tee in 01:40 median"));
+	EXPECT_EQ(m_pPlayerResult->m_MessageKind, CScorePlayerResult::DIRECT);
+	EXPECT_THAT(m_pPlayerResult->m_Data.m_aaMessages[0], testing::MatchesRegex("\"Kobra 3\" by Zerodin on Novice, ★★★★★, 5 points, released .* ago, 1 finish by 1 tee in 01:40 median"));
 	for(int i = 1; i < CScorePlayerResult::MAX_MESSAGES; i++)
 	{
-		EXPECT_STREQ(pPlayerResult->m_Data.m_aaMessages[i], "");
+		EXPECT_STREQ(m_pPlayerResult->m_Data.m_aaMessages[i], "");
 	}
 }
 
@@ -286,11 +286,11 @@ TEST_P(MapInfo, Fuzzy)
 	str_copy(m_PlayerRequest.m_aName, "k3", sizeof(m_PlayerRequest.m_aName));
 	ASSERT_FALSE(CScoreWorker::MapInfo(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
 
-	EXPECT_EQ(pPlayerResult->m_MessageKind, CScorePlayerResult::DIRECT);
-	EXPECT_THAT(pPlayerResult->m_Data.m_aaMessages[0], testing::MatchesRegex("\"Kobra 3\" by Zerodin on Novice, ★★★★★, 5 points, released .* ago, 1 finish by 1 tee in 01:40 median"));
+	EXPECT_EQ(m_pPlayerResult->m_MessageKind, CScorePlayerResult::DIRECT);
+	EXPECT_THAT(m_pPlayerResult->m_Data.m_aaMessages[0], testing::MatchesRegex("\"Kobra 3\" by Zerodin on Novice, ★★★★★, 5 points, released .* ago, 1 finish by 1 tee in 01:40 median"));
 	for(int i = 1; i < CScorePlayerResult::MAX_MESSAGES; i++)
 	{
-		EXPECT_STREQ(pPlayerResult->m_Data.m_aaMessages[i], "");
+		EXPECT_STREQ(m_pPlayerResult->m_Data.m_aaMessages[i], "");
 	}
 }
 
@@ -298,7 +298,7 @@ TEST_P(MapInfo, DoesntExit)
 {
 	str_copy(m_PlayerRequest.m_aName, "f", sizeof(m_PlayerRequest.m_aName));
 	ASSERT_FALSE(CScoreWorker::MapInfo(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
-	ExpectLines(pPlayerResult, {"No map like \"f\" found."});
+	ExpectLines(m_pPlayerResult, {"No map like \"f\" found."});
 }
 
 struct MapVote : public Score
@@ -313,27 +313,27 @@ TEST_P(MapVote, Exact)
 {
 	str_copy(m_PlayerRequest.m_aName, "Kobra 3", sizeof(m_PlayerRequest.m_aName));
 	ASSERT_FALSE(CScoreWorker::MapVote(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
-	EXPECT_EQ(pPlayerResult->m_MessageKind, CScorePlayerResult::MAP_VOTE);
-	EXPECT_STREQ(pPlayerResult->m_Data.m_MapVote.m_aMap, "Kobra 3");
-	EXPECT_STREQ(pPlayerResult->m_Data.m_MapVote.m_aReason, "/map");
-	EXPECT_STREQ(pPlayerResult->m_Data.m_MapVote.m_aServer, "novice");
+	EXPECT_EQ(m_pPlayerResult->m_MessageKind, CScorePlayerResult::MAP_VOTE);
+	EXPECT_STREQ(m_pPlayerResult->m_Data.m_MapVote.m_aMap, "Kobra 3");
+	EXPECT_STREQ(m_pPlayerResult->m_Data.m_MapVote.m_aReason, "/map");
+	EXPECT_STREQ(m_pPlayerResult->m_Data.m_MapVote.m_aServer, "novice");
 }
 
 TEST_P(MapVote, Fuzzy)
 {
 	str_copy(m_PlayerRequest.m_aName, "k3", sizeof(m_PlayerRequest.m_aName));
 	ASSERT_FALSE(CScoreWorker::MapVote(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
-	EXPECT_EQ(pPlayerResult->m_MessageKind, CScorePlayerResult::MAP_VOTE);
-	EXPECT_STREQ(pPlayerResult->m_Data.m_MapVote.m_aMap, "Kobra 3");
-	EXPECT_STREQ(pPlayerResult->m_Data.m_MapVote.m_aReason, "/map");
-	EXPECT_STREQ(pPlayerResult->m_Data.m_MapVote.m_aServer, "novice");
+	EXPECT_EQ(m_pPlayerResult->m_MessageKind, CScorePlayerResult::MAP_VOTE);
+	EXPECT_STREQ(m_pPlayerResult->m_Data.m_MapVote.m_aMap, "Kobra 3");
+	EXPECT_STREQ(m_pPlayerResult->m_Data.m_MapVote.m_aReason, "/map");
+	EXPECT_STREQ(m_pPlayerResult->m_Data.m_MapVote.m_aServer, "novice");
 }
 
 TEST_P(MapVote, DoesntExist)
 {
 	str_copy(m_PlayerRequest.m_aName, "f", sizeof(m_PlayerRequest.m_aName));
 	ASSERT_FALSE(CScoreWorker::MapVote(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
-	ExpectLines(pPlayerResult, {"No map like \"f\" found. Try adding a '%' at the start if you don't know the first character. Example: /map %castle for \"Out of Castle\""});
+	ExpectLines(m_pPlayerResult, {"No map like \"f\" found. Try adding a '%' at the start if you don't know the first character. Example: /map %castle for \"Out of Castle\""});
 }
 
 struct Points : public Score
@@ -349,13 +349,13 @@ struct Points : public Score
 TEST_P(Points, NoPoints)
 {
 	ASSERT_FALSE(CScoreWorker::ShowPoints(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
-	ExpectLines(pPlayerResult, {"nameless tee has not collected any points so far"});
+	ExpectLines(m_pPlayerResult, {"nameless tee has not collected any points so far"});
 }
 
 TEST_P(Points, NoPointsTop)
 {
 	ASSERT_FALSE(CScoreWorker::ShowTopPoints(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
-	ExpectLines(pPlayerResult, {"-------- Top Points --------",
+	ExpectLines(m_pPlayerResult, {"-------- Top Points --------",
 					   "-------------------------------"});
 }
 
@@ -363,14 +363,14 @@ TEST_P(Points, OnePoints)
 {
 	m_pConn->AddPoints("nameless tee", 2, m_aError, sizeof(m_aError));
 	ASSERT_FALSE(CScoreWorker::ShowPoints(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
-	ExpectLines(pPlayerResult, {"1. nameless tee Points: 2, requested by brainless tee"}, true);
+	ExpectLines(m_pPlayerResult, {"1. nameless tee Points: 2, requested by brainless tee"}, true);
 }
 
 TEST_P(Points, OnePointsTop)
 {
 	m_pConn->AddPoints("nameless tee", 2, m_aError, sizeof(m_aError));
 	ASSERT_FALSE(CScoreWorker::ShowTopPoints(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
-	ExpectLines(pPlayerResult,
+	ExpectLines(m_pPlayerResult,
 		{"-------- Top Points --------",
 			"1. nameless tee Points: 2",
 			"-------------------------------"});
@@ -381,7 +381,7 @@ TEST_P(Points, TwoPoints)
 	m_pConn->AddPoints("nameless tee", 2, m_aError, sizeof(m_aError));
 	m_pConn->AddPoints("brainless tee", 3, m_aError, sizeof(m_aError));
 	ASSERT_FALSE(CScoreWorker::ShowPoints(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
-	ExpectLines(pPlayerResult, {"2. nameless tee Points: 2, requested by brainless tee"}, true);
+	ExpectLines(m_pPlayerResult, {"2. nameless tee Points: 2, requested by brainless tee"}, true);
 }
 
 TEST_P(Points, TwoPointsTop)
@@ -389,7 +389,7 @@ TEST_P(Points, TwoPointsTop)
 	m_pConn->AddPoints("nameless tee", 2, m_aError, sizeof(m_aError));
 	m_pConn->AddPoints("brainless tee", 3, m_aError, sizeof(m_aError));
 	ASSERT_FALSE(CScoreWorker::ShowTopPoints(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
-	ExpectLines(pPlayerResult,
+	ExpectLines(m_pPlayerResult,
 		{"-------- Top Points --------",
 			"1. brainless tee Points: 3",
 			"2. nameless tee Points: 2",
@@ -402,7 +402,7 @@ TEST_P(Points, EqualPoints)
 	m_pConn->AddPoints("brainless tee", 3, m_aError, sizeof(m_aError));
 	m_pConn->AddPoints("nameless tee", 1, m_aError, sizeof(m_aError));
 	ASSERT_FALSE(CScoreWorker::ShowPoints(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
-	ExpectLines(pPlayerResult, {"1. nameless tee Points: 3, requested by brainless tee"}, true);
+	ExpectLines(m_pPlayerResult, {"1. nameless tee Points: 3, requested by brainless tee"}, true);
 }
 
 TEST_P(Points, EqualPointsTop)
@@ -411,7 +411,7 @@ TEST_P(Points, EqualPointsTop)
 	m_pConn->AddPoints("brainless tee", 3, m_aError, sizeof(m_aError));
 	m_pConn->AddPoints("nameless tee", 1, m_aError, sizeof(m_aError));
 	ASSERT_FALSE(CScoreWorker::ShowTopPoints(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
-	ExpectLines(pPlayerResult,
+	ExpectLines(m_pPlayerResult,
 		{"-------- Top Points --------",
 			"1. brainless tee Points: 3",
 			"1. nameless tee Points: 3",

--- a/src/test/score.cpp
+++ b/src/test/score.cpp
@@ -356,7 +356,7 @@ TEST_P(Points, NoPointsTop)
 {
 	ASSERT_FALSE(CScoreWorker::ShowTopPoints(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
 	ExpectLines(m_pPlayerResult, {"-------- Top Points --------",
-					   "-------------------------------"});
+					     "-------------------------------"});
 }
 
 TEST_P(Points, OnePoints)


### PR DESCRIPTION
Get rid of all the shadowing that was reported by both gcc and clang. How both compiler can not see the same though they include same headers is a mystery.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
