### PR TITLE
Reset practice when loading team (fixes #4894)

### DIFF
--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -667,7 +667,7 @@ void CGameContext::ConPractice(IConsole::IResult *pResult, void *pUserData)
 
 	if(NumCurrentVotes >= NumRequiredVotes)
 	{
-		Teams.EnablePractice(Team);
+		Teams.SetPractice(Team, true);
 		pSelf->SendChatTeam(Team, "Practice mode enabled for your team, happy practicing!");
 	}
 }

--- a/src/game/server/save.cpp
+++ b/src/game/server/save.cpp
@@ -517,8 +517,7 @@ void CSaveTeam::Load(int Team, bool KeepCurrentWeakStrong)
 
 	pTeams->ChangeTeamState(Team, m_TeamState);
 	pTeams->SetTeamLock(Team, m_TeamLocked);
-	if(m_Practice)
-		pTeams->EnablePractice(Team);
+	pTeams->SetPractice(Team, m_Practice);
 
 	for(int i = m_MembersCount; i-- > 0;)
 	{

--- a/src/game/server/teams.h
+++ b/src/game/server/teams.h
@@ -183,14 +183,14 @@ public:
 		return m_pSaveTeamResult[TeamID] != nullptr;
 	}
 
-	void EnablePractice(int Team)
+	void SetPractice(int Team, bool Enabled)
 	{
 		if(Team < TEAM_FLOCK || Team >= TEAM_SUPER)
 			return;
 		if(g_Config.m_SvTeam != SV_TEAM_FORCED_SOLO && Team == TEAM_FLOCK)
 			return;
 
-		m_Practice[Team] = true;
+		m_Practice[Team] = Enabled;
 	}
 
 	bool IsPractice(int Team)


### PR DESCRIPTION
I hope this doesn't give a chance to cheat. We also reset practice when
killing a team, so loading can be considered as similar to killing?

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
