### PR TITLE
Fix websocket crash on client connect

### DIFF
--- a/src/engine/shared/websockets.cpp
+++ b/src/engine/shared/websockets.cpp
@@ -94,7 +94,10 @@ static int websocket_callback(struct lws *wsi, enum lws_callback_reasons reason,
 
 		dbg_msg("websockets", "connection established with %s", addr_str);
 
-		pss->addr_str = addr_str;
+		std::string addr_str_final;
+		addr_str_final.append(addr_str);
+
+		pss->addr_str = addr_str_final;
 		ctx_data->port_map[pss->addr_str] = pss;
 	}
 	break;

--- a/src/engine/shared/websockets.cpp
+++ b/src/engine/shared/websockets.cpp
@@ -87,15 +87,14 @@ static int websocket_callback(struct lws *wsi, enum lws_callback_reasons reason,
 		getpeername(fd, (struct sockaddr *)&pss->addr, &addr_size);
 		int orig_port = ntohs(pss->addr.sin_port);
 		pss->send_buffer.Init();
+
 		char addr_str[NETADDR_MAXSTRSIZE];
 		int ip_uint32 = pss->addr.sin_addr.s_addr;
-		str_format(addr_str, sizeof(addr_str), "%d.%d.%d.%d", (ip_uint32)&0xff, (ip_uint32 >> 8) & 0xff, (ip_uint32 >> 16) & 0xff, (ip_uint32 >> 24) & 0xff);
-		dbg_msg("websockets",
-			"connection established with %s:%d",
-			addr_str, orig_port);
-		char buf[100];
-		snprintf(buf, sizeof(buf), "%s:%d", addr_str, orig_port);
-		pss->addr_str = std::string(buf);
+		str_format(addr_str, sizeof(addr_str), "%d.%d.%d.%d:%d", (ip_uint32)&0xff, (ip_uint32 >> 8) & 0xff, (ip_uint32 >> 16) & 0xff, (ip_uint32 >> 24) & 0xff, orig_port);
+
+		dbg_msg("websockets", "connection established with %s", addr_str);
+
+		pss->addr_str = addr_str;
 		ctx_data->port_map[pss->addr_str] = pss;
 	}
 	break;


### PR DESCRIPTION
Currently when a client tries to connect using websocket it will throw a segmentation fault. This is happening because of the std::string is trying to convert a char array with empty values to string directly.

```
==2305850== Invalid write of size 8
==2305850==    at 0x48401E9: memcpy@GLIBC_2.2.5 (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==2305850==    by 0x1E762D: websocket_callback(lws*, lws_callback_reasons, void*, void*, unsigned long) (in /home/ploi/ddnet/build/DDNet-Server)
==2305850==    by 0x4C7FB98: ??? (in /usr/lib/x86_64-linux-gnu/libwebsockets.so.15)
==2305850==    by 0x4C82F61: ??? (in /usr/lib/x86_64-linux-gnu/libwebsockets.so.15)
==2305850==    by 0x4C83206: ??? (in /usr/lib/x86_64-linux-gnu/libwebsockets.so.15)
==2305850==    by 0x4C9B84B: ??? (in /usr/lib/x86_64-linux-gnu/libwebsockets.so.15)
==2305850==    by 0x4C7E0B4: ??? (in /usr/lib/x86_64-linux-gnu/libwebsockets.so.15)
==2305850==    by 0x4C7E5C9: ??? (in /usr/lib/x86_64-linux-gnu/libwebsockets.so.15)
==2305850==    by 0x4C77EC6: lws_service_fd_tsi (in /usr/lib/x86_64-linux-gnu/libwebsockets.so.15)
==2305850==    by 0x4C9728A: ??? (in /usr/lib/x86_64-linux-gnu/libwebsockets.so.15)
==2305850==    by 0x4C974CC: ??? (in /usr/lib/x86_64-linux-gnu/libwebsockets.so.15)
==2305850==    by 0x4C78114: lws_service (in /usr/lib/x86_64-linux-gnu/libwebsockets.so.15)
==2305850==  Address 0x0 is not stack'd, malloc'd or (recently) free'd
```

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
