### PR TITLE
Fix SQL duplicated top and player team top 5

### DIFF
--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -409,7 +409,7 @@ void CGameContext::ConTeamTop5(IConsole::IResult *pResult, void *pUserData)
 			const char *pRequestedName = (str_comp(pResult->GetString(0), "me") == 0) ?
 							     pSelf->Server()->ClientName(pResult->m_ClientID) :
 							     pResult->GetString(0);
-			pSelf->Score()->ShowTeamTop5(pResult->m_ClientID, pRequestedName, 0);
+			pSelf->Score()->ShowPlayerTeamTop5(pResult->m_ClientID, pRequestedName, 0);
 		}
 	}
 	else if(pResult->NumArguments() == 2 && pResult->GetInteger(1) != 0)
@@ -417,7 +417,7 @@ void CGameContext::ConTeamTop5(IConsole::IResult *pResult, void *pUserData)
 		const char *pRequestedName = (str_comp(pResult->GetString(0), "me") == 0) ?
 						     pSelf->Server()->ClientName(pResult->m_ClientID) :
 						     pResult->GetString(0);
-		pSelf->Score()->ShowTeamTop5(pResult->m_ClientID, pRequestedName, pResult->GetInteger(1));
+		pSelf->Score()->ShowPlayerTeamTop5(pResult->m_ClientID, pRequestedName, pResult->GetInteger(1));
 	}
 	else
 	{

--- a/src/game/server/score.cpp
+++ b/src/game/server/score.cpp
@@ -210,7 +210,7 @@ void CScore::ShowTeamTop5(int ClientID, int Offset)
 	ExecPlayerThread(CScoreWorker::ShowTeamTop5, "show team top5", ClientID, "", Offset);
 }
 
-void CScore::ShowTeamTop5(int ClientID, const char *pName, int Offset)
+void CScore::ShowPlayerTeamTop5(int ClientID, const char *pName, int Offset)
 {
 	if(RateLimitPlayer(ClientID))
 		return;

--- a/src/game/server/score.h
+++ b/src/game/server/score.h
@@ -55,7 +55,7 @@ public:
 	void ShowRank(int ClientID, const char *pName);
 
 	void ShowTeamTop5(int ClientID, int Offset = 1);
-	void ShowTeamTop5(int ClientID, const char *pName, int Offset = 1);
+	void ShowPlayerTeamTop5(int ClientID, const char *pName, int Offset = 1);
 	void ShowTeamRank(int ClientID, const char *pName);
 
 	void ShowTopPoints(int ClientID, int Offset = 1);

--- a/src/game/server/scoreworker.cpp
+++ b/src/game/server/scoreworker.cpp
@@ -593,10 +593,10 @@ bool CScoreWorker::ShowRank(IDbConnection *pSqlServer, const ISqlData *pGameData
 	str_format(aBuf, sizeof(aBuf),
 		"SELECT Ranking, Time, PercentRank "
 		"FROM ("
-		"  SELECT RANK() OVER w AS Ranking, PERCENT_RANK() OVER w as PercentRank, Name, MIN(Time) AS Time "
+		"  SELECT RANK() OVER w AS Ranking, PERCENT_RANK() OVER w as PercentRank, MIN(Time) AS Time, Name "
 		"  FROM %s_race "
 		"  WHERE Map = ? "
-		"  AND Server LIKE ?"
+		"  AND Server LIKE ? "
 		"  GROUP BY Name "
 		"  WINDOW w AS (ORDER BY MIN(Time))"
 		") as a "
@@ -698,8 +698,8 @@ bool CScoreWorker::ShowTeamRank(IDbConnection *pSqlServer, const ISqlData *pGame
 		"  SELECT RANK() OVER w AS Ranking, PERCENT_RANK() OVER w AS PercentRank, ID "
 		"  FROM %s_teamrace "
 		"  WHERE Map = ? "
-		"  GROUP BY ID, Time "
-		"  WINDOW w AS (ORDER BY Time)"
+		"  GROUP BY ID "
+		"  WINDOW w AS (ORDER BY Min(Time))"
 		") AS TeamRank INNER JOIN (" // select rank with Name in team
 		"  SELECT ID "
 		"  FROM %s_teamrace "
@@ -781,11 +781,11 @@ bool CScoreWorker::ShowTop(IDbConnection *pSqlServer, const ISqlData *pGameData,
 	str_format(aBuf, sizeof(aBuf),
 		"SELECT Name, Time, Ranking, Server "
 		"FROM ("
-		"  SELECT RANK() OVER w AS Ranking, Name, MIN(Time) AS Time, Server "
+		"  SELECT RANK() OVER w AS Ranking, MIN(Time) AS Time, MAX(Server) AS Server, Name "
 		"  FROM %s_race "
 		"  WHERE Map = ? "
 		"  AND Server LIKE ? "
-		"  GROUP BY Name, Server "
+		"  GROUP BY Name "
 		"  WINDOW w AS (ORDER BY MIN(Time))"
 		") as a "
 		"ORDER BY Ranking %s "
@@ -885,11 +885,11 @@ bool CScoreWorker::ShowTeamTop5(IDbConnection *pSqlServer, const ISqlData *pGame
 		"FROM (" // limit to 5
 		"  SELECT TeamSize, Ranking, ID "
 		"  FROM (" // teamrank score board
-		"    SELECT RANK() OVER w AS Ranking, ID, COUNT(*) AS Teamsize "
+		"    SELECT RANK() OVER w AS Ranking, COUNT(*) AS Teamsize, ID "
 		"    FROM %s_teamrace "
 		"    WHERE Map = ? "
-		"    GROUP BY ID, Time "
-		"    WINDOW w AS (ORDER BY Time)"
+		"    GROUP BY ID "
+		"    WINDOW w AS (ORDER BY Min(Time))"
 		"  ) as l1 "
 		"  ORDER BY Ranking %s "
 		"  LIMIT %d, 5"
@@ -968,13 +968,13 @@ bool CScoreWorker::ShowPlayerTeamTop5(IDbConnection *pSqlServer, const ISqlData 
 	char aBuf[2400];
 
 	str_format(aBuf, sizeof(aBuf),
-		"SELECT l.ID, Name, Time, Rank "
+		"SELECT l.ID, Name, Time, Ranking "
 		"FROM (" // teamrank score board
-		"  SELECT RANK() OVER w AS Rank, ID "
+		"  SELECT RANK() OVER w AS Ranking, ID "
 		"  FROM %s_teamrace "
 		"  WHERE Map = ? "
 		"  GROUP BY ID "
-		"  WINDOW w AS (ORDER BY Time)"
+		"  WINDOW w AS (ORDER BY Min(Time))"
 		") AS TeamRank INNER JOIN (" // select rank with Name in team
 		"  SELECT ID "
 		"  FROM %s_teamrace "


### PR DESCRIPTION
Fixes #4903

- I hadn't seen the `ShowPlayerTeamTop5` function in the `scoreworker` in the last pull request, because in the `score` it has the same name as TeamTop5. A name change was made to make it easier to differentiate the two and fixed it for MySQL 8.0. It is not necessary to make this name change in the tests, since the tests use the `scoreworker` class directly.
- Ranking queries showing the duplicated rank were fixed. for this context it is not applicable to use distinct, since the `distinct` in SQL always checks all columns at the same time.

I'm going to leave this pull request in draft because getting the Server column in the same query as the show top still doesn't sound right to me. I used `MAX()` to match the same behavior before the change made by #4849, but it still doesn't seem right to get this column in this context.

Also no testes were added to check the duplicated behavior.

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
