### PR TITLE
Revert "Hook collision calculation each frame"

### DIFF
--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -137,7 +137,7 @@ void CPlayers::RenderHookCollLine(
 			vec2 ExDirection = Direction;
 
 			if(Local && Client()->State() != IClient::STATE_DEMOPLAYBACK)
-				ExDirection = normalize(vec2((int)m_pClient->m_Controls.m_MousePos[g_Config.m_ClDummy].x, (int)m_pClient->m_Controls.m_MousePos[g_Config.m_ClDummy].y));
+				ExDirection = normalize(vec2(m_pClient->m_Controls.m_InputData[g_Config.m_ClDummy].m_TargetX, m_pClient->m_Controls.m_InputData[g_Config.m_ClDummy].m_TargetY));
 
 			Graphics()->TextureClear();
 			vec2 InitPos = Position;


### PR DESCRIPTION
This reverts commit ccc23161f639bab498fcdbe9f2cd14d0ceffa89d.

Caused inaccuracies. I tried checking what calculations the server does,
but couldn't figure it out quickly. @sjrc6 

Reported by Zeral:
https://user-images.githubusercontent.com/2335377/160875760-e639c752-d2e1-4ace-b98f-772dce689186.mp4

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
