### PR TITLE
Fix IME issue (fixes #4888)

### DIFF
--- a/src/game/client/lineinput.cpp
+++ b/src/game/client/lineinput.cpp
@@ -70,6 +70,7 @@ void CLineInput::Editing(const char *pString, int Cursor)
 		m_aDisplayStr[i + FillCharLen] = m_aDisplayStr[i];
 	for(int i = 0; i < FillCharLen; i++)
 		m_aDisplayStr[m_CursorPos + i] = aEditingText[i];
+	m_aDisplayStr[m_CursorPos + FillCharLen] = '\0';
 	m_FakeLen = str_length(m_aDisplayStr);
 	m_FakeCursorPos = m_CursorPos + Cursor + 1;
 }

--- a/src/game/client/lineinput.cpp
+++ b/src/game/client/lineinput.cpp
@@ -60,17 +60,17 @@ void CLineInput::SetRange(const char *pString, int Begin, int End)
 
 void CLineInput::Editing(const char *pString, int Cursor)
 {
-	str_copy(m_DisplayStr, m_aStr, sizeof(m_DisplayStr));
+	str_copy(m_aDisplayStr, m_aStr, sizeof(m_aDisplayStr));
 	char aEditingText[IInput::INPUT_TEXT_SIZE + 2];
 	str_format(aEditingText, sizeof(aEditingText), "[%s]", pString);
 	int NewTextLen = str_length(aEditingText);
-	int CharsLeft = (int)sizeof(m_DisplayStr) - str_length(m_DisplayStr) - 1;
+	int CharsLeft = (int)sizeof(m_aDisplayStr) - str_length(m_aDisplayStr) - 1;
 	int FillCharLen = NewTextLen < CharsLeft ? NewTextLen : CharsLeft;
-	for(int i = str_length(m_DisplayStr) - 1; i >= m_CursorPos; i--)
-		m_DisplayStr[i + FillCharLen] = m_DisplayStr[i];
+	for(int i = str_length(m_aDisplayStr) - 1; i >= m_CursorPos; i--)
+		m_aDisplayStr[i + FillCharLen] = m_aDisplayStr[i];
 	for(int i = 0; i < FillCharLen; i++)
-		m_DisplayStr[m_CursorPos + i] = aEditingText[i];
-	m_FakeLen = str_length(m_DisplayStr);
+		m_aDisplayStr[m_CursorPos + i] = aEditingText[i];
+	m_FakeLen = str_length(m_aDisplayStr);
 	m_FakeCursorPos = m_CursorPos + Cursor + 1;
 }
 

--- a/src/game/client/lineinput.h
+++ b/src/game/client/lineinput.h
@@ -18,7 +18,7 @@ class CLineInput
 	int m_CursorPos;
 	int m_NumChars;
 
-	char m_DisplayStr[MAX_SIZE + IInput::INPUT_TEXT_SIZE + 2];
+	char m_aDisplayStr[MAX_SIZE + IInput::INPUT_TEXT_SIZE + 2];
 	int m_FakeLen;
 	int m_FakeCursorPos;
 
@@ -48,7 +48,7 @@ public:
 	void SetRange(const char *pString, int Begin, int End);
 	void Insert(const char *pString, int Begin);
 	void Append(const char *pString);
-	const char *GetString(bool Editing = false) const { return Editing ? m_DisplayStr : m_aStr; }
+	const char *GetString(bool Editing = false) const { return Editing ? m_aDisplayStr : m_aStr; }
 	int GetLength(bool Editing = false) const { return Editing ? m_FakeLen : m_Len; }
 	int GetCursorOffset(bool Editing = false) const { return Editing ? m_FakeCursorPos : m_CursorPos; }
 	void SetCursorOffset(int Offset) { m_CursorPos = Offset > m_Len ? m_Len : Offset < 0 ? 0 : Offset; }


### PR DESCRIPTION
by terminating string instead of assuming that rest of chars are \0, which was just luckily true before.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
