### PR TITLE
Use fewer threads on 32-bit to save memory

### DIFF
--- a/src/engine/client/video.cpp
+++ b/src/engine/client/video.cpp
@@ -98,9 +98,16 @@ void CVideo::Start()
 
 	m_pFormat = m_pFormatContext->oformat;
 
+#if defined(CONF_ARCH_IA32) || defined(CONF_ARCH_ARM)
+	// use only the minimum of 2 threads on 32-bit to save memory
+	m_VideoThreads = 2;
+	m_AudioThreads = 2;
+#else
 	m_VideoThreads = std::thread::hardware_concurrency() + 2;
 	// audio gets a bit less
 	m_AudioThreads = (std::thread::hardware_concurrency() / 2) + 2;
+#endif
+
 	m_CurVideoThreadIndex = 0;
 	m_CurAudioThreadIndex = 0;
 
@@ -818,6 +825,11 @@ bool CVideo::AddStream(OutputStream *pStream, AVFormatContext *pOC, const AVCode
 		return false;
 	}
 	pStream->pEnc = c;
+
+#if defined(CONF_ARCH_IA32) || defined(CONF_ARCH_ARM)
+	// use only 1 ffmpeg thread on 32-bit to save memory
+	c->thread_count = 1;
+#endif
 
 	switch((*ppCodec)->type)
 	{


### PR DESCRIPTION
Guess we should still let eeetadam test this

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
