### PR TITLE
Keep DDNet window responsive for loading tasks

### DIFF
--- a/src/engine/client.h
+++ b/src/engine/client.h
@@ -142,6 +142,8 @@ public:
 	virtual void LoadFont() = 0;
 	virtual void Notify(const char *pTitle, const char *pMessage) = 0;
 
+	virtual void UpdateAndSwap() = 0;
+
 	// networking
 	virtual void EnterGame(int Conn) = 0;
 

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -3851,6 +3851,13 @@ void CClient::BenchmarkQuit(int Seconds, const char *pFilename)
 	m_BenchmarkStopTime = time_get() + time_freq() * Seconds;
 }
 
+void CClient::UpdateAndSwap()
+{
+	Input()->Update();
+	Graphics()->Swap();
+	Graphics()->Clear(0, 0, 0);
+}
+
 void CClient::ServerBrowserUpdate()
 {
 	m_ResortServerBrowser = true;

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -494,6 +494,8 @@ public:
 	virtual void Notify(const char *pTitle, const char *pMessage);
 	void BenchmarkQuit(int Seconds, const char *pFilename);
 
+	virtual void UpdateAndSwap();
+
 	// DDRace
 
 	virtual void GenerateTimeoutSeed();

--- a/src/game/client/components/menu_background.cpp
+++ b/src/game/client/components/menu_background.cpp
@@ -130,6 +130,12 @@ int CMenuBackground::ThemeScan(const char *pName, int IsDir, int DirType, void *
 	str_format(aBuf, sizeof(aBuf), "added theme %s from themes/%s", aThemeName, pName);
 	pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "game", aBuf);
 	pSelf->m_lThemes.push_back(Theme);
+	int64_t TimeNow = time_get_microseconds();
+	if(TimeNow - pSelf->m_ThemeScanStartTime >= 1000000 / 60)
+	{
+		pSelf->Client()->UpdateAndSwap();
+		pSelf->m_ThemeScanStartTime = TimeNow;
+	}
 	return 0;
 }
 
@@ -139,6 +145,13 @@ int CMenuBackground::ThemeIconScan(const char *pName, int IsDir, int DirType, vo
 	const char *pSuffix = str_endswith(pName, ".png");
 	if(IsDir || !pSuffix)
 		return 0;
+
+	int64_t TimeNow = time_get_microseconds();
+	if(TimeNow - pSelf->m_ThemeScanStartTime >= 1000000 / 60)
+	{
+		pSelf->Client()->UpdateAndSwap();
+		pSelf->m_ThemeScanStartTime = TimeNow;
+	}
 
 	char aThemeName[128];
 	str_truncate(aThemeName, sizeof(aThemeName), pName, pSuffix - pName);
@@ -394,6 +407,7 @@ std::vector<CTheme> &CMenuBackground::GetThemes()
 		m_lThemes.emplace_back("auto", true, true); // auto theme
 		m_lThemes.emplace_back("rand", true, true); // random theme
 
+		m_ThemeScanStartTime = time_get_microseconds();
 		Storage()->ListDirectory(IStorage::TYPE_ALL, "themes", ThemeScan, (CMenuBackground *)this);
 		Storage()->ListDirectory(IStorage::TYPE_ALL, "themes", ThemeIconScan, (CMenuBackground *)this);
 

--- a/src/game/client/components/menu_background.h
+++ b/src/game/client/components/menu_background.h
@@ -28,6 +28,8 @@ public:
 
 class CMenuBackground : public CBackground
 {
+	int64_t m_ThemeScanStartTime = 0;
+
 public:
 	enum
 	{

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -926,19 +926,22 @@ int CMenus::RenderMenubar(CUIRect r)
 	return 0;
 }
 
-void CMenus::RenderLoading()
+void CMenus::RenderLoading(bool IncreaseCounter, bool RenderLoadingBar)
 {
 	// TODO: not supported right now due to separate render thread
 
 	static int64_t LastLoadRender = 0;
-	float Percent = m_LoadCurrent++ / (float)m_LoadTotal;
+	auto CurLoadRenderCount = m_LoadCurrent;
+	if(IncreaseCounter)
+		++m_LoadCurrent;
+	float Percent = CurLoadRenderCount / (float)m_LoadTotal;
 
 	// make sure that we don't render for each little thing we load
 	// because that will slow down loading if we have vsync
-	if(time_get() - LastLoadRender < time_freq() / 60)
+	if(time_get_microseconds() - LastLoadRender < 1000000 / 60)
 		return;
 
-	LastLoadRender = time_get();
+	LastLoadRender = time_get_microseconds();
 
 	// need up date this here to get correct
 	ms_GuiColor = color_cast<ColorRGBA>(ColorHSLA(g_Config.m_UiColor, true));
@@ -973,13 +976,16 @@ void CMenus::RenderLoading()
 	r.h = h - 130;
 	UI()->DoLabel(&r, pCaption, 48.0f, TEXTALIGN_CENTER);
 
-	Graphics()->TextureClear();
-	Graphics()->QuadsBegin();
-	Graphics()->SetColor(1, 1, 1, 0.75f);
-	RenderTools()->DrawRoundRect(x + 40, y + h - 75, (w - 80) * Percent, 25, 5.0f);
-	Graphics()->QuadsEnd();
+	if(RenderLoadingBar)
+	{
+		Graphics()->TextureClear();
+		Graphics()->QuadsBegin();
+		Graphics()->SetColor(1, 1, 1, 0.75f);
+		RenderTools()->DrawRoundRect(x + 40, y + h - 75, (w - 80) * Percent, 25, 5.0f);
+		Graphics()->QuadsEnd();
+	}
 
-	Graphics()->Swap();
+	Client()->UpdateAndSwap();
 }
 
 void CMenus::RenderNews(CUIRect MainView)
@@ -1042,6 +1048,8 @@ void CMenus::OnInit()
 	m_LoadTotal = g_pData->m_NumImages + NumMenuImages;
 	if(!g_Config.m_ClThreadsoundloading)
 		m_LoadTotal += g_pData->m_NumSounds;
+
+	m_IsInit = true;
 
 	// load menu images
 	m_lMenuImages.clear();
@@ -2655,56 +2663,6 @@ int CMenus::DoButton_CheckBox_DontCare(const void *pID, const char *pText, int C
 	}
 }
 
-void CMenus::RenderUpdating(const char *pCaption, int current, int total)
-{
-	// make sure that we don't render for each little thing we load
-	// because that will slow down loading if we have vsync
-	static int64_t LastLoadRender = 0;
-	if(time_get() - LastLoadRender < time_freq() / 60)
-		return;
-	LastLoadRender = time_get();
-
-	// need up date this here to get correct
-	ms_GuiColor = color_cast<ColorRGBA>(ColorHSLA(g_Config.m_UiColor, true));
-
-	CUIRect Screen = *UI()->Screen();
-	UI()->MapScreen();
-
-	RenderBackground();
-
-	float w = 700;
-	float h = 200;
-	float x = Screen.w / 2 - w / 2;
-	float y = Screen.h / 2 - h / 2;
-
-	Graphics()->TextureClear();
-	Graphics()->QuadsBegin();
-	Graphics()->SetColor(0, 0, 0, 0.50f);
-	RenderTools()->DrawRoundRect(0, y, Screen.w, h, 0.0f);
-	Graphics()->QuadsEnd();
-
-	CUIRect r;
-	r.x = x;
-	r.y = y + 20;
-	r.w = w;
-	r.h = h;
-	UI()->DoLabel(&r, Localize(pCaption), 32.0f, TEXTALIGN_CENTER);
-
-	if(total > 0)
-	{
-		float Percent = current / (float)total;
-		Graphics()->TextureClear();
-		Graphics()->QuadsBegin();
-		Graphics()->SetColor(0.15f, 0.15f, 0.15f, 0.75f);
-		RenderTools()->DrawRoundRect(x + 40, y + h - 75, w - 80, 30, 5.0f);
-		Graphics()->SetColor(1, 1, 1, 0.75f);
-		RenderTools()->DrawRoundRect(x + 45, y + h - 70, (w - 85) * Percent, 20, 5.0f);
-		Graphics()->QuadsEnd();
-	}
-
-	Graphics()->Swap();
-}
-
 int CMenus::MenuImageScan(const char *pName, int IsDir, int DirType, void *pUser)
 {
 	CMenus *pSelf = (CMenus *)pUser;
@@ -2781,7 +2739,7 @@ int CMenus::MenuImageScan(const char *pName, int IsDir, int DirType, void *pUser
 	// set menu image data
 	str_truncate(MenuImage.m_aName, sizeof(MenuImage.m_aName), pName, str_length(pName) - 4);
 	pSelf->m_lMenuImages.add(MenuImage);
-	pSelf->RenderLoading();
+	pSelf->RenderLoading(true);
 
 	return 0;
 }

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -243,6 +243,8 @@ protected:
 	sorted_array<SCustomEmoticon> m_EmoticonList;
 	sorted_array<SCustomParticle> m_ParticlesList;
 
+	bool m_IsInit = false;
+
 	static void LoadEntities(struct SCustomEntities *pEntitiesItem, void *pUser);
 	static int EntitiesScan(const char *pName, int IsDir, int DirType, void *pUser);
 
@@ -417,6 +419,8 @@ protected:
 	int m_DemolistStorageType;
 	int m_Speed = 4;
 
+	int64_t m_DemoPopulateStartTime = 0;
+
 	void DemolistOnUpdate(bool Reset);
 	//void DemolistPopulate();
 	static int DemolistFetchCallback(const CFsFileInfo *pInfo, int IsDir, int StorageType, void *pUser);
@@ -520,8 +524,9 @@ public:
 	CMenus();
 	virtual int Sizeof() const override { return sizeof(*this); }
 
-	void RenderLoading();
-	void RenderUpdating(const char *pCaption, int current = 0, int total = 0);
+	void RenderLoading(bool IncreaseCounter, bool RenderLoadingBar = true);
+
+	bool IsInit() { return m_IsInit; }
 
 	bool IsActive() const { return m_MenuActive; }
 	void KillServer();
@@ -620,6 +625,8 @@ public:
 	};
 
 	sorted_array<CGhostItem> m_lGhosts;
+
+	int64_t m_GhostPopulateStartTime = 0;
 
 	void GhostlistPopulate();
 	CGhostItem *GetOwnGhost();

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -768,6 +768,11 @@ int CMenus::DemolistFetchCallback(const CFsFileInfo *pInfo, int IsDir, int Stora
 	Item.m_StorageType = StorageType;
 	pSelf->m_lDemos.add_unsorted(Item);
 
+	if(time_get_microseconds() - pSelf->m_DemoPopulateStartTime > 500000)
+	{
+		pSelf->GameClient()->m_Menus.RenderLoading(false, false);
+	}
+
 	return 0;
 }
 
@@ -776,6 +781,7 @@ void CMenus::DemolistPopulate()
 	m_lDemos.clear();
 	if(!str_comp(m_aCurrentDemoFolder, "demos"))
 		m_DemolistStorageType = IStorage::TYPE_ALL;
+	m_DemoPopulateStartTime = time_get_microseconds();
 	Storage()->ListDirectoryInfo(m_DemolistStorageType, m_aCurrentDemoFolder, DemolistFetchCallback, this);
 
 	if(g_Config.m_BrDemoFetchInfo)

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -915,6 +915,12 @@ int CMenus::GhostlistFetchCallback(const char *pName, int IsDir, int StorageType
 	Item.m_Time = Info.m_Time;
 	if(Item.m_Time > 0)
 		pSelf->m_lGhosts.add(Item);
+
+	if(time_get_microseconds() - pSelf->m_GhostPopulateStartTime > 500000)
+	{
+		pSelf->GameClient()->m_Menus.RenderLoading(false, false);
+	}
+
 	return 0;
 }
 
@@ -922,6 +928,7 @@ void CMenus::GhostlistPopulate()
 {
 	CGhostItem *pOwnGhost = 0;
 	m_lGhosts.clear();
+	m_GhostPopulateStartTime = time_get_microseconds();
 	Storage()->ListDirectory(IStorage::TYPE_ALL, m_pClient->m_Ghost.GetGhostDir(), GhostlistFetchCallback, this);
 
 	for(int i = 0; i < m_lGhosts.size(); i++)

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -781,7 +781,17 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 	static int s_SkinRefreshButtonID = 0;
 	if(DoButton_Menu(&s_SkinRefreshButtonID, "\xEF\x80\x9E", 0, &RefreshButton, NULL, 15, 5, 0, vec4(1.0f, 1.0f, 1.0f, 0.75f), vec4(1, 1, 1, 0.5f), 0))
 	{
-		m_pClient->m_Skins.Refresh();
+		// reset render flags for possible loading screen
+		TextRender()->SetRenderFlags(0);
+		TextRender()->SetCurFont(NULL);
+		int64_t SkinStartLoadTime = time_get_microseconds();
+		m_pClient->m_Skins.Refresh([&](int) {
+			// if skin refreshing takes to long, swap to a loading screen
+			if(time_get_microseconds() - SkinStartLoadTime > 500000)
+			{
+				RenderLoading(false, false);
+			}
+		});
 		s_InitSkinlist = true;
 		if(Client()->State() >= IClient::STATE_ONLINE)
 		{

--- a/src/game/client/components/race_demo.h
+++ b/src/game/client/components/race_demo.h
@@ -25,12 +25,14 @@ class CRaceDemo : public CComponent
 	int m_RecordStopTick;
 	int m_Time;
 
+	int64_t m_RaceDemosLoadStartTime = 0;
+
 	static int RaceDemolistFetchCallback(const CFsFileInfo *pInfo, int IsDir, int StorageType, void *pUser);
 
 	void GetPath(char *pBuf, int Size, int Time = -1) const;
 
 	void StopRecord(int Time = -1);
-	bool CheckDemo(int Time) const;
+	bool CheckDemo(int Time);
 
 public:
 	bool m_AllowRestart;

--- a/src/game/client/components/skins.h
+++ b/src/game/client/components/skins.h
@@ -35,10 +35,12 @@ public:
 		bool operator==(const char *pOther) const { return !str_comp(m_aName, pOther); }
 	};
 
+	typedef std::function<void(int)> TSkinLoadedCBFunc;
+
 	virtual int Sizeof() const override { return sizeof(*this); }
 	void OnInit() override;
 
-	void Refresh();
+	void Refresh(TSkinLoadedCBFunc &&SkinLoadedFunc);
 	int Num();
 	const CSkin *Get(int Index);
 	int Find(const char *pName);

--- a/src/game/client/components/sounds.cpp
+++ b/src/game/client/components/sounds.cpp
@@ -26,10 +26,13 @@ void CSoundLoading::Run()
 		{
 			int Id = m_pGameClient->Sound()->LoadWV(g_pData->m_aSounds[s].m_aSounds[i].m_pFilename);
 			g_pData->m_aSounds[s].m_aSounds[i].m_Id = Id;
+			// try to render a frame
+			if(m_Render)
+				m_pGameClient->m_Menus.RenderLoading(false);
 		}
 
 		if(m_Render)
-			m_pGameClient->m_Menus.RenderLoading();
+			m_pGameClient->m_Menus.RenderLoading(true);
 	}
 }
 
@@ -79,6 +82,7 @@ void CSounds::OnInit()
 		m_pSoundJob = std::make_shared<CSoundLoading>(m_pClient, false);
 		m_pClient->Engine()->AddJob(m_pSoundJob);
 		m_WaitForSoundJob = true;
+		m_pClient->m_Menus.RenderLoading(true);
 	}
 	else
 	{

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -245,9 +245,17 @@ void CGameClient::OnInit()
 
 	Client()->LoadFont();
 
+	// update and swap after font loading, they are quite huge
+	Client()->UpdateAndSwap();
+
 	// init all components
 	for(int i = m_All.m_Num - 1; i >= 0; --i)
+	{
 		m_All.m_paComponents[i]->OnInit();
+		// try to render a frame after each component, also flushes GPU uploads
+		if(m_Menus.IsInit())
+			m_Menus.RenderLoading(false);
+	}
 
 	char aBuf[256];
 
@@ -266,7 +274,7 @@ void CGameClient::OnInit()
 			LoadParticlesSkin(g_Config.m_ClAssetParticles);
 		else
 			g_pData->m_aImages[i].m_Id = Graphics()->LoadTexture(g_pData->m_aImages[i].m_pFilename, IStorage::TYPE_ALL, CImageInfo::FORMAT_AUTO, 0);
-		m_Menus.RenderLoading();
+		m_Menus.RenderLoading(false);
 	}
 
 	for(int i = 0; i < m_All.m_Num; i++)


### PR DESCRIPTION
This will keep the DDNet window responsive, especially when loading the client the first time this is important, so that SDL2 events aren't lost.

Menu's RenderLoading allows up to 60 frames per second, so calling it too often cannot really happen.

For reloading (skins&assets) / demo loading etc. it only swaps to the render screen after half a second passed. Even if this might not be the nicest, it's still better than just freezing the window.

I hope this addresses issues from #4936



## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
