### PR TITLE
Better forced viewport handling

### DIFF
--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -845,7 +845,7 @@ void CGraphics_Threaded::Clear(float r, float g, float b, bool ForceClearNow)
 	Cmd.m_Color.g = g;
 	Cmd.m_Color.b = b;
 	Cmd.m_Color.a = 0;
-	Cmd.m_ForceClear = ForceClearNow || m_IsForcedViewport;
+	Cmd.m_ForceClear = ForceClearNow;
 	AddCmd(
 		Cmd, [] { return true; }, "failed to clear graphics.");
 }

--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -2270,23 +2270,28 @@ void CGraphics_Threaded::AdjustViewport(bool SendViewportChangeToBackend)
 
 		if(SendViewportChangeToBackend)
 		{
-			CCommandBuffer::SCommand_Update_Viewport Cmd;
-			Cmd.m_X = 0;
-			Cmd.m_Y = 0;
-			Cmd.m_Width = m_ScreenWidth;
-			Cmd.m_Height = m_ScreenHeight;
-			Cmd.m_ByResize = true;
-
-			if(!AddCmd(
-				   Cmd, [] { return true; }, "failed to add resize command"))
-			{
-				return;
-			}
+			UpdateViewport(0, 0, m_ScreenWidth, m_ScreenWidth, true);
 		}
 	}
 	else
 	{
 		m_IsForcedViewport = false;
+	}
+}
+
+void CGraphics_Threaded::UpdateViewport(int X, int Y, int W, int H, bool ByResize)
+{
+	CCommandBuffer::SCommand_Update_Viewport Cmd;
+	Cmd.m_X = X;
+	Cmd.m_Y = Y;
+	Cmd.m_Width = W;
+	Cmd.m_Height = H;
+	Cmd.m_ByResize = ByResize;
+
+	if(!AddCmd(
+		   Cmd, [] { return true; }, "failed to add resize command"))
+	{
+		return;
 	}
 }
 
@@ -2589,18 +2594,7 @@ void CGraphics_Threaded::GotResized(int w, int h, int RefreshRate)
 	g_Config.m_GfxScreenRefreshRate = m_ScreenRefreshRate;
 	m_ScreenHiDPIScale = m_ScreenWidth / (float)g_Config.m_GfxScreenWidth;
 
-	CCommandBuffer::SCommand_Update_Viewport Cmd;
-	Cmd.m_X = 0;
-	Cmd.m_Y = 0;
-	Cmd.m_Width = m_ScreenWidth;
-	Cmd.m_Height = m_ScreenHeight;
-	Cmd.m_ByResize = true;
-
-	if(!AddCmd(
-		   Cmd, [] { return true; }, "failed to add resize command"))
-	{
-		return;
-	}
+	UpdateViewport(0, 0, m_ScreenWidth, m_ScreenWidth, true);
 
 	// kick the command buffer and wait
 	KickCommandBuffer();

--- a/src/engine/client/graphics_threaded.h
+++ b/src/engine/client/graphics_threaded.h
@@ -1246,6 +1246,7 @@ public:
 	void Move(int x, int y) override;
 	void Resize(int w, int h, int RefreshRate) override;
 	void GotResized(int w, int h, int RefreshRate) override;
+	void UpdateViewport(int X, int Y, int W, int H, bool ByResize) override;
 	void AddWindowResizeListener(WINDOW_RESIZE_FUNC pFunc, void *pUser) override;
 	int GetWindowScreen() override;
 

--- a/src/engine/graphics.h
+++ b/src/engine/graphics.h
@@ -249,6 +249,7 @@ public:
 	virtual void Move(int x, int y) = 0;
 	virtual void Resize(int w, int h, int RefreshRate) = 0;
 	virtual void GotResized(int w, int h, int RefreshRate) = 0;
+	virtual void UpdateViewport(int X, int Y, int W, int H, bool ByResize) = 0;
 	virtual void AddWindowResizeListener(WINDOW_RESIZE_FUNC pFunc, void *pUser) = 0;
 
 	virtual void WindowDestroyNtf(uint32_t WindowID) = 0;


### PR DESCRIPTION
For #4939

For the performance warnings refering `vkCmdClearAttachments` ignore them, because this function is only called when:
- clear color is changed(open/close editor, switch between entities) to directly flush a clear with the new color
- ~~a viewport is used that is "worse" than 5:4 (I don't really want to switch to non renderpass clear completly, since it *can* improve performance -- https://community.arm.com/arm-community-blogs/b/graphics-gaming-and-vr-blog/posts/vulkan-samples "Therefore, avoid using LOAD_OP_LOAD and vkCmdClearAttachments and use LOAD_OP_CLEAR or LOAD_OP_DONT_CARE whenever possible.")~~
thinking about it, maybe i can also drop this call now, since its dynamic viewport anyway

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
