### PR TITLE
SmartPause feature, automatically unpause if moved.

### DIFF
--- a/src/game/client/components/binds.cpp
+++ b/src/game/client/components/binds.cpp
@@ -493,6 +493,7 @@ void CBinds::SetDDRaceBinds(bool FreeOnly)
 		Bind(KEY_MOUSE_3, "+spectate", FreeOnly);
 		Bind(KEY_MINUS, "spectate_previous", FreeOnly);
 		Bind(KEY_EQUALS, "spectate_next", FreeOnly);
+		Bind(KEY_P, "cl_next_pause_is_unpause_if_moved 1; say /pause", FreeOnly, (1<<MODIFIER_CTRL));
 	}
 
 	g_Config.m_ClDDRaceBindsSet = 1;

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -197,6 +197,14 @@ private:
 	int m_LastFlagCarrierRed;
 	int m_LastFlagCarrierBlue;
 
+	bool m_SmartPauseReq[2];
+	bool m_UnpauseCmdSent[2];
+	bool m_SmartPauseStarting[2];
+	bool m_SmartPauseArmed[2];
+	int  m_SmartPauseStartingCnt[2];
+	int  m_SmartPauseStartingCntEnd[2];
+	vec2 m_LocalCharacterPosBeforePause[2];
+
 	int m_CheckInfo[NUM_DUMMIES];
 
 	char m_aDDNetVersionStr[64];
@@ -654,6 +662,7 @@ private:
 	void UpdateRenderedCharacters();
 	void DetectStrongHook();
 	vec2 GetSmoothPos(int ClientID);
+	void SmartPauseCheck();
 
 	int m_PredictedDummyID;
 	int m_IsDummySwapping;

--- a/src/game/variables.h
+++ b/src/game/variables.h
@@ -15,6 +15,8 @@ MACRO_CONFIG_INT(ClAntiPingWeapons, cl_antiping_weapons, 1, 0, 1, CFGFLAG_CLIENT
 MACRO_CONFIG_INT(ClAntiPingSmooth, cl_antiping_smooth, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Make the prediction of other player's movement smoother")
 MACRO_CONFIG_INT(ClAntiPingGunfire, cl_antiping_gunfire, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Predict gunfire and show predicted weapon physics (with cl_antiping_grenade 1 and cl_antiping_weapons 1)")
 MACRO_CONFIG_INT(ClPredictionMargin, cl_prediction_margin, 10, 1, 2000, CFGFLAG_CLIENT, "Prediction margin in ms (adds latency, can reduce lag from ping jumps)")
+MACRO_CONFIG_INT(ClNextPauseIsUnpauseIfMoved, cl_next_pause_is_unpause_if_moved, 0, 0, 1, CFGFLAG_CLIENT, "If set, next pause is Smart Pause: unpause if moved (self-clear variable, force /showall)")
+MACRO_CONFIG_INT(ClShowallAfterSmartpause, cl_showall_after_smartpause, 0, 0, 1, CFGFLAG_CLIENT, "Set /showall value after Smart Pause")
 
 MACRO_CONFIG_INT(ClNameplates, cl_nameplates, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show name plates")
 MACRO_CONFIG_INT(ClAfkEmote, cl_afk_emote, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show zzz emote next to afk players")


### PR DESCRIPTION
This feature is binded to CTRL+P.
There is a documentation part in the top of CGameClient::SmartPauseCheck function.
It needs just a function to check tee position every new tick.
Feature discussed on discord, I will add video permanent link from discord.

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
