### PR TITLE
Editor: ctrl+leftclick tile to select layer

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -3559,6 +3559,73 @@ void CEditor::RenderLayers(CUIRect ToolBox, CUIRect View)
 			m_SelectedGroup = m_Map.m_lGroups.size() - 1;
 		}
 	}
+
+	SelectLayerByTile(s_ScrollValue);
+}
+
+void CEditor::SelectLayerByTile(float &Scroll)
+{
+	// ctrl+leftclick a map index to select the layer that has a tile there
+	static bool s_CtrlClick = false;
+	static int s_Selected = 0;
+	int MatchedGroup = -1;
+	int MatchedLayer = -1;
+	int Matches = 0;
+	bool IsFound = false;
+	int TotalLayers = 0;
+	int SelectedLayer = 0;
+	if(UI()->MouseButton(1) && Input()->ModifierIsPressed())
+	{
+		if(s_CtrlClick)
+			return;
+		s_CtrlClick = true;
+		for(int g = 0; g < m_Map.m_lGroups.size(); g++)
+		{
+			for(int l = 0; l < m_Map.m_lGroups[g]->m_lLayers.size(); l++)
+			{
+				TotalLayers++;
+				if(IsFound)
+					continue;
+				if(m_Map.m_lGroups[g]->m_lLayers[l]->m_Type != LAYERTYPE_TILES)
+					continue;
+
+				CLayerTiles *pTiles = (CLayerTiles *)m_Map.m_lGroups[g]->m_lLayers[l];
+				int x = (int)UI()->MouseWorldX() / 32 + m_Map.m_lGroups[g]->m_OffsetX;
+				int y = (int)UI()->MouseWorldY() / 32 + m_Map.m_lGroups[g]->m_OffsetY;
+				if(x < 0 || x >= pTiles->m_Width)
+					continue;
+				if(y < 0 || y >= pTiles->m_Height)
+					continue;
+				CTile Tile = pTiles->GetTile(x, y);
+				if(Tile.m_Index)
+				{
+					if(MatchedGroup == -1)
+					{
+						MatchedGroup = g;
+						MatchedLayer = l;
+						SelectedLayer = TotalLayers;
+					}
+					if(++Matches > s_Selected)
+					{
+						s_Selected++;
+						MatchedGroup = g;
+						MatchedLayer = l;
+						IsFound = true;
+						SelectedLayer = TotalLayers;
+					}
+				}
+			}
+		}
+		if(MatchedGroup != -1 && MatchedLayer != -1)
+		{
+			if(!IsFound)
+				s_Selected = 1;
+			Scroll = (float)SelectedLayer / (float)TotalLayers;
+			SelectLayer(MatchedLayer, MatchedGroup);
+		}
+	}
+	else
+		s_CtrlClick = false;
 }
 
 void CEditor::ReplaceImage(const char *pFileName, int StorageType, void *pUser)

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -2525,7 +2525,7 @@ void CEditor::DoMapEditor(CUIRect View)
 					m_pTooltip = Explain(EXPLANATION_VANILLA, (int)wx / 32 + (int)wy / 32 * 16, Layer);
 			}
 			else if(m_Brush.IsEmpty())
-				m_pTooltip = "Use left mouse button to drag and create a brush. Hold shift to select multiple quads.";
+				m_pTooltip = "Use left mouse button to drag and create a brush. Hold shift to select multiple quads. Use ctrl+left mouse to select layer.";
 			else
 				m_pTooltip = "Use left mouse button to paint with the brush. Right button clears the brush.";
 

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -1061,6 +1061,7 @@ public:
 	void AddFileDialogEntry(int Index, CUIRect *pView);
 	void SelectGameLayer();
 	void SortImages();
+	void SelectLayerByTile(float &Scroll);
 
 	//Tile Numbers For Explanations - TODO: Add/Improve tiles and explanations
 	enum


### PR DESCRIPTION
https://user-images.githubusercontent.com/20344300/162440855-c716f6ba-4828-4c4b-97d2-e8e3da3ab4ea.mp4

Ctrl+leftclick on a tile in the map to select the layer that has tiles placed there. Useful if there are a lot of overlapping layers. Or plenty of doodads layers for example.

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [x] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
