### PR TITLE
allow freecam to center on world border

### DIFF
--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -561,8 +561,8 @@ void CControls::ClampMousePos()
 {
 	if(m_pClient->m_Snap.m_SpecInfo.m_Active && m_pClient->m_Snap.m_SpecInfo.m_SpectatorID < 0)
 	{
-		m_MousePos[g_Config.m_ClDummy].x = clamp(m_MousePos[g_Config.m_ClDummy].x, 200.0f, Collision()->GetWidth() * 32 - 200.0f);
-		m_MousePos[g_Config.m_ClDummy].y = clamp(m_MousePos[g_Config.m_ClDummy].y, 200.0f, Collision()->GetHeight() * 32 - 200.0f);
+		m_MousePos[g_Config.m_ClDummy].x = clamp(m_MousePos[g_Config.m_ClDummy].x, 0.0f, Collision()->GetWidth() * 32.0f);
+		m_MousePos[g_Config.m_ClDummy].y = clamp(m_MousePos[g_Config.m_ClDummy].y, 0.0f, Collision()->GetHeight() * 32.0f);
 	}
 	else
 	{


### PR DESCRIPTION
fixes #4953

I think the 200 units or 6.25 blocks more should not bother anyone. 
![fix 2022-04-09_15-14](https://user-images.githubusercontent.com/14315968/162576159-7d73eb8c-b9c9-471b-bed0-7477568376d6.png)
under some circumstances, it will only move to x=1 (or in blocks 0.03) but this should be negligible.  

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [x] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
