### PR TITLE
Add UBSan and ASan to CI

### DIFF
--- a/.github/workflows/clang-sanitizer.yml
+++ b/.github/workflows/clang-sanitizer.yml
@@ -1,0 +1,44 @@
+name: Check ASan & UBSan
+
+on:
+  push:
+    branches-ignore:
+      - master
+      - staging.tmp
+      - trying.tmp
+      - staging-squash-merge.tmp
+  pull_request:
+
+jobs:
+  check-clang-san:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+
+    - name: Prepare linux
+      run: |
+        sudo apt-get update -y
+        sudo apt-get install pkg-config cmake ninja-build libfreetype6-dev libnotify-dev libsdl2-dev libsqlite3-dev libavcodec-dev libavformat-dev libavutil-dev libswresample-dev libswscale-dev libx264-dev libvulkan-dev glslang-tools spirv-tools -y
+    - name: Build with ASan and UBSan
+      run: |
+        mkdir san
+        cd san
+        export CC=clang
+        export CXX=clang++
+        export CXXFLAGS="-fsanitize=address,undefined -fsanitize-recover=address,undefined -fno-omit-frame-pointer"
+        export CFLAGS="-fsanitize=address,undefined -fsanitize-recover=address,undefined -fno-omit-frame-pointer"
+        cmake -DCMAKE_BUILD_TYPE=Debug -DHEADLESS_CLIENT=ON ..
+        make -j"$(nproc)"
+    - name: Run server and headless client with ASan and UBSan
+      run: |
+        cd san
+        export UBSAN_OPTIONS=log_path=./SAN:print_stacktrace=1:halt_on_errors=0 ASAN_OPTIONS=log_path=./SAN:print_stacktrace=1:check_initialization_order=1:detect_leaks=1:halt_on_errors=0
+        ./DDNet "cl_download_skins 0;quit" || true
+        ./DDNet-Server shutdown || true
+        if test -n "$(find . -maxdepth 1 -name 'SAN.*' -print -quit)"
+        then
+          cat ./SAN.*
+          exit 1
+        fi


### PR DESCRIPTION
Start server and headless client once and see if it gets some ubsan or asan hits.
The headless client might have less or different violations of the holy c++ standard but its the best way to get some client code runtime in the CI.

Related issue https://github.com/ddnet/ddnet/issues/3050