### PR TITLE
Fix undefined behavior in fixed point number conversion

### DIFF
--- a/src/base/math.h
+++ b/src/base/math.h
@@ -38,7 +38,10 @@ constexpr inline T mix(const T a, const T b, TB amount)
 	return a + (b - a) * amount;
 }
 
-inline float random_float() { return rand() / (float)(RAND_MAX); }
+inline float random_float()
+{
+	return rand() / (float)(RAND_MAX);
+}
 
 constexpr int fxpscale = 1 << 10;
 

--- a/src/base/math.h
+++ b/src/base/math.h
@@ -40,18 +40,26 @@ constexpr inline T mix(const T a, const T b, TB amount)
 
 inline float random_float() { return rand() / (float)(RAND_MAX); }
 
+constexpr int fxpscale = 1 << 10;
+
 // float to fixed
-constexpr inline int f2fx(float v) { return (int)(v * (float)(1 << 10)); }
-constexpr inline float fx2f(int v) { return v * (1.0f / (1 << 10)); }
+constexpr inline int f2fx(float v)
+{
+	return (int)(v * fxpscale);
+}
+constexpr inline float fx2f(int v)
+{
+	return v / (float)fxpscale;
+}
 
 // int to fixed
-inline int i2fx(int v)
+constexpr inline int i2fx(int v)
 {
-	return v << 10;
+	return v * fxpscale;
 }
-inline int fx2i(int v)
+constexpr inline int fx2i(int v)
 {
-	return v >> 10;
+	return v / fxpscale;
 }
 
 inline int gcd(int a, int b)
@@ -70,19 +78,32 @@ class fxp
 	int value;
 
 public:
-	void set(int v) { value = v; }
-	int get() const { return value; }
+	void set(int v)
+	{
+		value = v;
+	}
+	int get() const
+	{
+		return value;
+	}
 	fxp &operator=(int v)
 	{
-		value = v << 10;
+		value = i2fx(v);
 		return *this;
 	}
 	fxp &operator=(float v)
 	{
-		value = (int)(v * (float)(1 << 10));
+		value = f2fx(v);
 		return *this;
 	}
-	operator float() const { return value / (float)(1 << 10); }
+	operator int() const
+	{
+		return fx2i(value);
+	}
+	operator float() const
+	{
+		return fx2f(value);
+	}
 };
 
 constexpr float pi = 3.1415926535897932384626433f;


### PR DESCRIPTION
See #4970:

```
/home/runner/work/ddnet/ddnet/src/base/math.h:50:11: runtime error: left shift of negative value -32
    #0 0x198d955 in i2fx(int) /home/runner/work/ddnet/ddnet/src/base/math.h:50:11
    #1 0x197ebdf in CLayerQuads::NewQuad(int, int, int, int) /home/runner/work/ddnet/ddnet/src/game/editor/layer_quads.cpp:47:22
    #2 0x18ef8d3 in CEditor::Init() /home/runner/work/ddnet/ddnet/src/game/editor/editor.cpp:6360:18
    #3 0xa8e5be in CClient::Run() /home/runner/work/ddnet/ddnet/src/engine/client/client.cpp:2917:13
    #4 0xaf6726 in main /home/runner/work/ddnet/ddnet/src/engine/client/client.cpp:4458:11
    #5 0x7fadd9e610b2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x240b2)
    #6 0x43cefd in _start (/home/runner/work/ddnet/ddnet/san/DDNet+0x43cefd)
```

Upstream https://github.com/teeworlds/teeworlds/pull/3143.

## Checklist

- [X] Tested the change ingame (on upstream)
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [X] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
