### PR TITLE
fix calculation of m_Angle of CCharacterCore

### DIFF
--- a/src/game/gamecore.cpp
+++ b/src/game/gamecore.cpp
@@ -138,16 +138,15 @@ void CCharacterCore::Tick(bool UseInput)
 		m_Direction = m_Input.m_Direction;
 
 		// setup angle
-		float a = 0;
-		if(m_Input.m_TargetX == 0)
-			a = atanf((float)m_Input.m_TargetY);
+		float tmp_angle = atan2f(m_Input.m_TargetY, m_Input.m_TargetX);
+		if(tmp_angle < -(pi / 2.0f))
+		{
+			m_Angle = (int)((tmp_angle + (2.0f * pi)) * 256.0f);
+		}
 		else
-			a = atanf((float)m_Input.m_TargetY / (float)m_Input.m_TargetX);
-
-		if(m_Input.m_TargetX < 0)
-			a = a + pi;
-
-		m_Angle = (int)(a * 256.0f);
+		{
+			m_Angle = (int)(tmp_angle * 256.0f);
+		}
 
 		// handle jump
 		if(m_Input.m_Jump)

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -1132,6 +1132,10 @@ void CCharacter::SnapCharacter(int SnappingClient, int ID)
 			return;
 
 		pCore->Write(reinterpret_cast<CNetObj_CharacterCore *>(static_cast<protocol7::CNetObj_CharacterCore *>(pCharacter)));
+		if(pCharacter->m_Angle > (int)(pi * 256.0f))
+		{
+			pCharacter->m_Angle -= (int)(2.0f * pi * 256.0f);
+		}
 
 		pCharacter->m_Tick = Tick;
 		pCharacter->m_Emote = Emote;


### PR DESCRIPTION
fixes #4969
fixes #4138
The problem of #4138 can be seen in the following picture:
![image](https://user-images.githubusercontent.com/14315968/162630858-2a1a813d-0551-4739-9f8a-9ed9017fdb9b.png)


we have a strange angle circle, it was fixed in 0.7. For 0.7 to interpolate correctly between two network packets we should send the correct angle circle. 

The poblem from #4969 I have already described and follows directly from the wrong calculation. 

The PR fixes both problems. Here is a video, first I show how it behaves now in our client, then in a 0.7 client.

https://user-images.githubusercontent.com/14315968/162630563-83847e3f-4d29-48d9-adc1-fb3ba20cc387.mp4


## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [x] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
