### PR TITLE
fix local hookline direction when mouse is exactly centerered

### DIFF
--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -138,8 +138,13 @@ void CPlayers::RenderHookCollLine(
 			vec2 ExDirection = Direction;
 
 			if(Local && Client()->State() != IClient::STATE_DEMOPLAYBACK)
+			{
 				ExDirection = normalize(vec2((int)m_pClient->m_Controls.m_MousePos[g_Config.m_ClDummy].x, (int)m_pClient->m_Controls.m_MousePos[g_Config.m_ClDummy].y));
 
+				// fix direction if mouse is exactly in the center
+				if(!(int)m_pClient->m_Controls.m_MousePos[g_Config.m_ClDummy].x && !(int)m_pClient->m_Controls.m_MousePos[g_Config.m_ClDummy].y)
+					ExDirection = vec2(1, 0);
+			}
 			Graphics()->TextureClear();
 			vec2 InitPos = Position;
 			vec2 FinishPos = InitPos + ExDirection * (m_pClient->m_Tuning[g_Config.m_ClDummy].m_HookLength - 42.0f);


### PR DESCRIPTION
@C0D3D3V Mentioned this issue in comments of previous PR
https://github.com/ddnet/ddnet/pull/4760#issuecomment-1094307657

If you use the bind which limits your cursor range for 45 degree angles and constantly push your cursor to the left it will cause the angle to be inaccurate.  <s> I believe this is because of NaNs from division by zero but I'm not totally sure. </s>.  The cursor gets moved away from 0,0 whenever we send an input but it's allowed to be there in between ticks which causes this issue. 

I just copied this fix from other places in the code that deal with the same issue.

https://user-images.githubusercontent.com/14315968/162629342-c8bdeea4-f06f-472f-94b3-e7cccd597eb8.mp4

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
