### PR TITLE
fix rendering of nameplates for spectating tees

### DIFF
--- a/src/game/client/components/nameplates.cpp
+++ b/src/game/client/components/nameplates.cpp
@@ -327,6 +327,10 @@ void CNamePlates::OnRender()
 
 		// don't render offscreen
 		vec2 *pRenderPos = &m_pClient->m_aClients[i].m_RenderPos;
+		if(m_pClient->m_aClients[i].m_SpecCharPresent)
+		{
+			pRenderPos = &m_pClient->m_aClients[i].m_SpecChar;
+		}
 		if(pRenderPos->x < ScreenX0 || pRenderPos->x > ScreenX1 || pRenderPos->y < ScreenY0 || pRenderPos->y > ScreenY1)
 		{
 			continue;
@@ -336,10 +340,9 @@ void CNamePlates::OnRender()
 		{
 			RenderNameplatePos(m_pClient->m_aClients[i].m_SpecChar, pInfo, 0.4f, true);
 		}
-
-		// only render active characters
-		if(m_pClient->m_Snap.m_aCharacters[i].m_Active)
+		else if(m_pClient->m_Snap.m_aCharacters[i].m_Active)
 		{
+			// only render nameplates for active characters
 			RenderNameplate(
 				&m_pClient->m_Snap.m_aCharacters[i].m_Prev,
 				&m_pClient->m_Snap.m_aCharacters[i].m_Cur,


### PR DESCRIPTION
bug was introduced by #4870

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [x] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
