### PR TITLE
fix solo plasma turrets

### DIFF
--- a/src/game/server/entities/dragger.cpp
+++ b/src/game/server/entities/dragger.cpp
@@ -83,15 +83,16 @@ void CDragger::Move()
 
 		if(Res == 0)
 		{
-			int Len = length(Temp->m_Pos - m_Pos);
-			if(MinLen == 0 || MinLen > Len)
-			{
-				MinLen = Len;
-				Id = i;
-			}
-
 			if(!Temp->Teams()->m_Core.GetSolo(Temp->GetPlayer()->GetCID()))
+			{
+				int Len = length(Temp->m_Pos - m_Pos);
+				if(MinLen == 0 || MinLen > Len)
+				{
+					MinLen = Len;
+					Id = i;
+				}
 				m_SoloEntIDs[i] = -1;
+			}
 		}
 		else
 		{
@@ -115,15 +116,17 @@ void CDragger::Move()
 
 void CDragger::Drag()
 {
-	if(m_TargetID < 0)
-		return;
-
-	CCharacter *pTarget = GameServer()->GetPlayerChar(m_TargetID);
-
+	CCharacter *pTarget = nullptr;
 	for(int i = -1; i < MAX_CLIENTS; i++)
 	{
 		if(i >= 0)
+		{
 			pTarget = GameServer()->GetPlayerChar(m_SoloEntIDs[i]);
+		}
+		else if(m_TargetID >= 0)
+		{
+			pTarget = GameServer()->GetPlayerChar(m_TargetID);
+		}
 
 		if(!pTarget)
 			continue;

--- a/src/game/server/entities/gun.cpp
+++ b/src/game/server/entities/gun.cpp
@@ -73,16 +73,18 @@ void CGun::Fire()
 	for(int i = 0; i < Num; i++)
 	{
 		CCharacter *Target = Ents[i];
+		//now gun doesn't affect on super in solo
+		if(Target->Team() == TEAM_SUPER)
+			continue;
+		if(m_Layer == LAYER_SWITCH && m_Number > 0 && !GameServer()->Collision()->m_pSwitchers[m_Number].m_Status[Target->Team()])
+			continue;
 		if(Target->IsAlive() && Target->Teams()->m_Core.GetSolo(Target->GetPlayer()->GetCID()))
 		{
-			if(IdInTeam[Target->Team()] != i)
+			int res = GameServer()->Collision()->IntersectLine(m_Pos, Target->m_Pos, 0, 0);
+			if(!res)
 			{
-				int res = GameServer()->Collision()->IntersectLine(m_Pos, Target->m_Pos, 0, 0);
-				if(!res)
-				{
-					new CPlasma(&GameServer()->m_World, m_Pos, normalize(Target->m_Pos - m_Pos), m_Freeze, m_Explosive, Target->Team());
-					m_LastFire = Server()->Tick();
-				}
+				new CPlasma(&GameServer()->m_World, m_Pos, normalize(Target->m_Pos - m_Pos), m_Freeze, m_Explosive, Target->Team());
+				m_LastFire = Server()->Tick();
 			}
 		}
 	}


### PR DESCRIPTION
this should not be directly merged as it changes the physics of maps

When a player was solo, plasma turrets always fired whether they were on or off. This changes the physics of all maps that use Plasma Turrets in a solo part. And fixes the physics for solo maps that use plasma turrets. 

on solo maps this was only since the following commit, because only then the solo status of a player was set: https://github.com/ddnet/ddnet/commit/fbf5edfdcbca8810471c0689339066702f879a0c

This means solo maps released before 13 Jun 2019 will get their correct physics back, ranks on such maps would probably have to be removed after this date. 

Maps that use turrets with switches in solo parts now have correct physics. 

Which maps are all affected we still have to look at, I will try to find out with libtw. 

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
