### PR TITLE
Don't read from backend if Init failed

### DIFF
--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -2246,14 +2246,17 @@ int CGraphics_Threaded::IssueInit()
 
 	int r = m_pBackend->Init("DDNet Client", &g_Config.m_GfxScreen, &g_Config.m_GfxScreenWidth, &g_Config.m_GfxScreenHeight, &g_Config.m_GfxScreenRefreshRate, g_Config.m_GfxFsaaSamples, Flags, &g_Config.m_GfxDesktopWidth, &g_Config.m_GfxDesktopHeight, &m_ScreenWidth, &m_ScreenHeight, m_pStorage);
 	AddBackEndWarningIfExists();
-	m_GLUseTrianglesAsQuad = m_pBackend->UseTrianglesAsQuad();
-	m_GLTileBufferingEnabled = m_pBackend->HasTileBuffering();
-	m_GLQuadBufferingEnabled = m_pBackend->HasQuadBuffering();
-	m_GLQuadContainerBufferingEnabled = m_pBackend->HasQuadContainerBuffering();
-	m_GLTextBufferingEnabled = (m_GLQuadContainerBufferingEnabled && m_pBackend->HasTextBuffering());
-	m_GLHasTextureArrays = m_pBackend->Has2DTextureArrays();
-	m_ScreenHiDPIScale = m_ScreenWidth / (float)g_Config.m_GfxScreenWidth;
-	m_ScreenRefreshRate = g_Config.m_GfxScreenRefreshRate;
+	if(r == 0)
+	{
+		m_GLUseTrianglesAsQuad = m_pBackend->UseTrianglesAsQuad();
+		m_GLTileBufferingEnabled = m_pBackend->HasTileBuffering();
+		m_GLQuadBufferingEnabled = m_pBackend->HasQuadBuffering();
+		m_GLQuadContainerBufferingEnabled = m_pBackend->HasQuadContainerBuffering();
+		m_GLTextBufferingEnabled = (m_GLQuadContainerBufferingEnabled && m_pBackend->HasTextBuffering());
+		m_GLHasTextureArrays = m_pBackend->Has2DTextureArrays();
+		m_ScreenHiDPIScale = m_ScreenWidth / (float)g_Config.m_GfxScreenWidth;
+		m_ScreenRefreshRate = g_Config.m_GfxScreenRefreshRate;
+	}
 	return r;
 }
 


### PR DESCRIPTION
fixes #4981 

This `bug` should not create any uninitended behavior, since these values get reinitialized after the backend creation worked

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
