### PR TITLE
Close sockets

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -3271,6 +3271,10 @@ void CClient::Run()
 	GameClient()->OnShutdown();
 	Disconnect();
 
+	// close socket
+	for(unsigned int i = 0; i < std::size(m_NetClient); i++)
+		m_NetClient[i].Close();
+
 	delete m_pEditor;
 	m_pGraphics->Shutdown();
 

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -2747,6 +2747,8 @@ int CServer::Run()
 		free(Client.m_pPersistentData);
 	}
 
+	m_NetServer.Close();
+
 	return ErrorShutdown();
 }
 

--- a/src/engine/shared/network_client.cpp
+++ b/src/engine/shared/network_client.cpp
@@ -23,8 +23,9 @@ bool CNetClient::Open(NETADDR BindAddr)
 
 int CNetClient::Close()
 {
-	// TODO: implement me
-	return 0;
+	if(!m_Socket)
+		return 0;
+	return net_udp_close(m_Socket);
 }
 
 int CNetClient::Disconnect(const char *pReason)

--- a/src/engine/shared/network_server.cpp
+++ b/src/engine/shared/network_server.cpp
@@ -96,8 +96,9 @@ int CNetServer::SetCallbacks(NETFUNC_NEWCLIENT pfnNewClient, NETFUNC_NEWCLIENT_N
 
 int CNetServer::Close()
 {
-	// TODO: implement me
-	return 0;
+	if(!m_Socket)
+		return 0;
+	return net_udp_close(m_Socket);
 }
 
 int CNetServer::Drop(int ClientID, const char *pReason)


### PR DESCRIPTION
https://github.com/ddnet/ddnet/pull/4970

Fixes

```
 Direct leak of 205848 byte(s) in 1 object(s) allocated from:
    #0 0x4a200d in malloc (/home/runner/work/ddnet/ddnet/san/DDNet-Server+0x4a200d)
    #1 0xc7fe3f in net_udp_create /home/runner/work/ddnet/ddnet/src/base/system.cpp:1640:41
    #2 0xbf2d0b in CNetServer::Open(NETADDR, CNetBan*, int, int) /home/runner/work/ddnet/ddnet/src/engine/shared/network_server.cpp:55:13
    #3 0x568cdc in CServer::Run() /home/runner/work/ddnet/ddnet/src/engine/server/server.cpp:2448:60
    #4 0x5a922b in main /home/runner/work/ddnet/ddnet/src/engine/server/server.cpp:3718:21
    #5 0x7ff75f52c0b2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x240b2)
```

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [x] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
