### PR TITLE
Free some opengl2 pointers

### DIFF
--- a/src/engine/client/backend/opengl/backend_opengl.cpp
+++ b/src/engine/client/backend/opengl/backend_opengl.cpp
@@ -1635,6 +1635,11 @@ bool CCommandProcessorFragment_OpenGL2::Cmd_Init(const SCommand_Init *pCommand)
 	if(!CCommandProcessorFragment_OpenGL::Cmd_Init(pCommand))
 		return false;
 
+	m_pTileProgram = nullptr;
+	m_pTileProgramTextured = nullptr;
+	m_pPrimitive3DProgram = nullptr;
+	m_pPrimitive3DProgramTextured = nullptr;
+
 	m_OpenGLTextureLodBIAS = g_Config.m_GfxGLTextureLODBIAS;
 
 	m_HasShaders = pCommand->m_pCapabilities->m_ShaderSupport;
@@ -1801,6 +1806,15 @@ bool CCommandProcessorFragment_OpenGL2::Cmd_Init(const SCommand_Init *pCommand)
 	}
 
 	return true;
+}
+
+void CCommandProcessorFragment_OpenGL2::Cmd_Shutdown(const SCommand_Shutdown *pCommand)
+{
+	// TODO: cleanup the OpenGL context too
+	delete m_pTileProgram;
+	delete m_pTileProgramTextured;
+	delete m_pPrimitive3DProgram;
+	delete m_pPrimitive3DProgramTextured;
 }
 
 void CCommandProcessorFragment_OpenGL2::Cmd_RenderTex3D(const CCommandBuffer::SCommand_RenderTex3D *pCommand)

--- a/src/engine/client/backend/opengl/backend_opengl.h
+++ b/src/engine/client/backend/opengl/backend_opengl.h
@@ -177,6 +177,7 @@ protected:
 
 #ifndef BACKEND_GL_MODERN_API
 	bool Cmd_Init(const SCommand_Init *pCommand) override;
+	void Cmd_Shutdown(const SCommand_Shutdown *pCommand) override;
 
 	void Cmd_RenderTex3D(const CCommandBuffer::SCommand_RenderTex3D *pCommand) override;
 


### PR DESCRIPTION
Fixes these memory leaks on my system (default opengl 3.0.3 renderer debian 11)

```
Direct leak of 72 byte(s) in 1 object(s) allocated from:
    #0 0x4eac0d in operator new(unsigned long) (/home/chiller/Desktop/git/ddnet/asan/DDNet+0x4eac0d)
    #1 0x537ebc in CCommandProcessorFragment_OpenGL2::Cmd_Init(CCommandProcessorFragment_GLBase::SCommand_Init const*) /home/chiller/Desktop/git/ddnet/src/engine/client/backend/opengl/backend_opengl.cpp:1672:21
    #2 0x51f4ed in CCommandProcessorFragment_OpenGL::RunCommand(CCommandBuffer::SCommand const*) /home/chiller/Desktop/git/ddnet/src/engine/client/backend/opengl/backend_opengl.cpp:1061:3
    #3 0x9e9d5e in CCommandProcessor_SDL_GL::RunBuffer(CCommandBuffer*) /home/chiller/Desktop/git/ddnet/src/engine/client/backend_sdl.cpp:250:20
    #4 0x9e57ab in CGraphicsBackend_Threaded::ThreadFunc(void*) /home/chiller/Desktop/git/ddnet/src/engine/client/backend_sdl.cpp:80:25
    #5 0x1d49c45 in thread_run(void*) /home/chiller/Desktop/git/ddnet/src/base/system.cpp:867:2
    #6 0x7fe2a3b8fea6 in start_thread nptl/pthread_create.c:477:8

Direct leak of 72 byte(s) in 1 object(s) allocated from:
    #0 0x4eac0d in operator new(unsigned long) (/home/chiller/Desktop/git/ddnet/asan/DDNet+0x4eac0d)
    #1 0x537ff6 in CCommandProcessorFragment_OpenGL2::Cmd_Init(CCommandProcessorFragment_GLBase::SCommand_Init const*) /home/chiller/Desktop/git/ddnet/src/engine/client/backend/opengl/backend_opengl.cpp:1673:29
    #2 0x51f4ed in CCommandProcessorFragment_OpenGL::RunCommand(CCommandBuffer::SCommand const*) /home/chiller/Desktop/git/ddnet/src/engine/client/backend/opengl/backend_opengl.cpp:1061:3
    #3 0x9e9d5e in CCommandProcessor_SDL_GL::RunBuffer(CCommandBuffer*) /home/chiller/Desktop/git/ddnet/src/engine/client/backend_sdl.cpp:250:20
    #4 0x9e57ab in CGraphicsBackend_Threaded::ThreadFunc(void*) /home/chiller/Desktop/git/ddnet/src/engine/client/backend_sdl.cpp:80:25
    #5 0x1d49c45 in thread_run(void*) /home/chiller/Desktop/git/ddnet/src/base/system.cpp:867:2
    #6 0x7fe2a3b8fea6 in start_thread nptl/pthread_create.c:477:8

Direct leak of 48 byte(s) in 1 object(s) allocated from:
    #0 0x4eac0d in operator new(unsigned long) (/home/chiller/Desktop/git/ddnet/asan/DDNet+0x4eac0d)
    #1 0x53826a in CCommandProcessorFragment_OpenGL2::Cmd_Init(CCommandProcessorFragment_GLBase::SCommand_Init const*) /home/chiller/Desktop/git/ddnet/src/engine/client/backend/opengl/backend_opengl.cpp:1675:36
    #2 0x51f4ed in CCommandProcessorFragment_OpenGL::RunCommand(CCommandBuffer::SCommand const*) /home/chiller/Desktop/git/ddnet/src/engine/client/backend/opengl/backend_opengl.cpp:1061:3
    #3 0x9e9d5e in CCommandProcessor_SDL_GL::RunBuffer(CCommandBuffer*) /home/chiller/Desktop/git/ddnet/src/engine/client/backend_sdl.cpp:250:20
    #4 0x9e57ab in CGraphicsBackend_Threaded::ThreadFunc(void*) /home/chiller/Desktop/git/ddnet/src/engine/client/backend_sdl.cpp:80:25
    #5 0x1d49c45 in thread_run(void*) /home/chiller/Desktop/git/ddnet/src/base/system.cpp:867:2
    #6 0x7fe2a3b8fea6 in start_thread nptl/pthread_create.c:477:8

Direct leak of 48 byte(s) in 1 object(s) allocated from:
    #0 0x4eac0d in operator new(unsigned long) (/home/chiller/Desktop/git/ddnet/asan/DDNet+0x4eac0d)
    #1 0x538130 in CCommandProcessorFragment_OpenGL2::Cmd_Init(CCommandProcessorFragment_GLBase::SCommand_Init const*) /home/chiller/Desktop/git/ddnet/src/engine/client/backend/opengl/backend_opengl.cpp:1674:28
    #2 0x51f4ed in CCommandProcessorFragment_OpenGL::RunCommand(CCommandBuffer::SCommand const*) /home/chiller/Desktop/git/ddnet/src/engine/client/backend/opengl/backend_opengl.cpp:1061:3
    #3 0x9e9d5e in CCommandProcessor_SDL_GL::RunBuffer(CCommandBuffer*) /home/chiller/Desktop/git/ddnet/src/engine/client/backend_sdl.cpp:250:20
    #4 0x9e57ab in CGraphicsBackend_Threaded::ThreadFunc(void*) /home/chiller/Desktop/git/ddnet/src/engine/client/backend_sdl.cpp:80:25
    #5 0x1d49c45 in thread_run(void*) /home/chiller/Desktop/git/ddnet/src/base/system.cpp:867:2
    #6 0x7fe2a3b8fea6 in start_thread nptl/pthread_create.c:477:8
```

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [x] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
