### PR TITLE
Fix editor animation offset time being affected by the animation spee…

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -280,8 +280,9 @@ void CEditor::EnvelopeEval(int TimeOffsetMillis, int Env, float *pChannels, void
 	}
 
 	CEnvelope *e = pThis->m_Map.m_lEnvelopes[Env];
-	float t = pThis->m_AnimateTime + (TimeOffsetMillis / 1000.0f);
+	float t = pThis->m_AnimateTime;
 	t *= pThis->m_AnimateSpeed;
+	t += (TimeOffsetMillis / 1000.0f);
 	e->Eval(t, pChannels);
 }
 


### PR DESCRIPTION
…d factor

As reported by Derp in Discord:

The animation offset should not be affected by the time scale, the offset is a static offset, unrelated to how the animation works

WRONG:

![Screenshot_39](https://user-images.githubusercontent.com/6654924/163543537-8b243234-2e1a-4173-b43c-175d4b335512.png)
![Screenshot_40](https://user-images.githubusercontent.com/6654924/163543544-b226affc-2d22-472b-802e-9716b90eca29.png)

RIGHT:

![screenshot_2022-04-15_10-04-31](https://user-images.githubusercontent.com/6654924/163543669-13847136-de5a-454a-bafe-16feddd94396.png)
![screenshot_2022-04-15_10-04-36](https://user-images.githubusercontent.com/6654924/163543675-337349a9-2abf-4b20-9b42-dc4ee44367c4.png)


## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
