### PR TITLE
Add sanitizer runs to bors too, ignore pnglite shift ubsan issue

### DIFF
--- a/.github/workflows/clang-sanitizer.yml
+++ b/.github/workflows/clang-sanitizer.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Run server and headless client with ASan and UBSan
       run: |
         cd san
-        export UBSAN_OPTIONS=log_path=./SAN:print_stacktrace=1:halt_on_errors=0 ASAN_OPTIONS=log_path=./SAN:print_stacktrace=1:check_initialization_order=1:detect_leaks=1:halt_on_errors=0
+        export UBSAN_OPTIONS=suppressions=../ubsan.supp:log_path=./SAN:print_stacktrace=1:halt_on_errors=0 ASAN_OPTIONS=log_path=./SAN:print_stacktrace=1:check_initialization_order=1:detect_leaks=1:halt_on_errors=0
         ./DDNet "cl_download_skins 0;quit" || true
         ./DDNet-Server shutdown || true
         if test -n "$(find . -maxdepth 1 -name 'SAN.*' -print -quit)"

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ make
 ```
 and run with:
 ```bash
-UBSAN_OPTIONS=log_path=./SAN:print_stacktrace=1:halt_on_errors=0 ASAN_OPTIONS=log_path=./SAN:print_stacktrace=1:check_initialization_order=1:detect_leaks=1:halt_on_errors=0 ./DDNet
+UBSAN_OPTIONS=suppressions=./ubsan.supp:log_path=./SAN:print_stacktrace=1:halt_on_errors=0 ASAN_OPTIONS=log_path=./SAN:print_stacktrace=1:check_initialization_order=1:detect_leaks=1:halt_on_errors=0 ./DDNet
 ```
 
 Check the SAN.\* files afterwards. This finds more problems than memcheck, runs faster, but requires a modern GCC/Clang compiler.

--- a/bors.toml
+++ b/bors.toml
@@ -3,6 +3,7 @@ status = [
   "build-cmake (ubuntu-20.04)",
   "build-cmake (macOS-latest)",
   "build-cmake (windows-latest)",
+  "check-clang-san",
   "check-clang-tidy",
   "check-style",
 ]

--- a/ubsan.supp
+++ b/ubsan.supp
@@ -1,0 +1,1 @@
+shift-base:pnglite.c

--- a/ubsan.supp
+++ b/ubsan.supp
@@ -1,1 +1,2 @@
 shift-base:pnglite.c
+null:json.c


### PR DESCRIPTION
@ChillerDragon 

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
