### PR TITLE
Make tele predictable by seeding the current tick

### DIFF
--- a/src/game/gamecore.h
+++ b/src/game/gamecore.h
@@ -200,6 +200,7 @@ public:
 	CTuningParams m_Tuning[2];
 	class CCharacterCore *m_apCharacters[MAX_CLIENTS];
 	CPrng *m_pPrng;
+	CPrng *m_TelePrng;
 };
 
 class CCharacterCore

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -1921,7 +1921,16 @@ void CCharacter::HandleTiles(int Index)
 		{
 			if(!(*m_pTeleCheckOuts)[k].empty())
 			{
-				int TeleOut = m_Core.m_pWorld->RandomOr0((*m_pTeleCheckOuts)[k].size());
+				//int TeleOut = m_Core.m_pWorld->RandomOr0((*m_pTeleCheckOuts)[k].size());
+				int TeleOut = 0;
+				
+				if(GameWorld()->m_Core.m_TelePrng)
+				{
+					auto Tick = static_cast<uint64_t>(GameServer()->Server()->Tick());
+					GameWorld()->m_Core.m_TelePrng->Seed(&Tick);
+					TeleOut = GameWorld()->m_Core.m_TelePrng->RandomBits() % (*m_pTeleCheckOuts)[k].size();
+				}
+				
 				m_Core.m_Pos = (*m_pTeleCheckOuts)[k][TeleOut];
 				m_Core.m_Vel = vec2(0, 0);
 

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -1923,14 +1923,14 @@ void CCharacter::HandleTiles(int Index)
 			{
 				//int TeleOut = m_Core.m_pWorld->RandomOr0((*m_pTeleCheckOuts)[k].size());
 				int TeleOut = 0;
-				
+
 				if(GameWorld()->m_Core.m_TelePrng)
 				{
 					auto Tick = static_cast<uint64_t>(GameServer()->Server()->Tick());
 					GameWorld()->m_Core.m_TelePrng->Seed(&Tick);
 					TeleOut = GameWorld()->m_Core.m_TelePrng->RandomBits() % (*m_pTeleCheckOuts)[k].size();
 				}
-				
+
 				m_Core.m_Pos = (*m_pTeleCheckOuts)[k][TeleOut];
 				m_Core.m_Vel = vec2(0, 0);
 

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -3129,7 +3129,9 @@ void CGameContext::OnInit(/*class IKernel *pKernel*/)
 	uint64_t aSeed[2];
 	secure_random_fill(aSeed, sizeof(aSeed));
 	m_Prng.Seed(aSeed);
+	m_TelePrng.Seed(aSeed);
 	m_World.m_Core.m_pPrng = &m_Prng;
+	m_World.m_Core.m_TelePrng = &m_TelePrng;
 
 	DeleteTempfile();
 

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -81,6 +81,7 @@ class CGameContext : public IGameServer
 	CUuid m_GameUuid;
 	CMapBugs m_MapBugs;
 	CPrng m_Prng;
+	CPrng m_TelePrng;
 
 	bool m_Resetting;
 


### PR DESCRIPTION
I'm not sure if this is the correct way to do it.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
