### PR TITLE
Get rid of optional, not available on Debian9 build

### DIFF
--- a/src/game/client/components/tooltips.cpp
+++ b/src/game/client/components/tooltips.cpp
@@ -15,16 +15,16 @@ void CTooltips::OnReset()
 
 void CTooltips::SetActiveTooltip(CTooltip &Tooltip)
 {
-	if(m_ActiveTooltip.has_value())
+	if(m_pActiveTooltip != nullptr)
 		return;
 
-	m_ActiveTooltip.emplace(Tooltip);
+	m_pActiveTooltip = &Tooltip;
 	HoverTime = time_get();
 }
 
 inline void CTooltips::ClearActiveTooltip()
 {
-	m_ActiveTooltip.reset();
+	m_pActiveTooltip = nullptr;
 }
 
 void CTooltips::DoToolTip(const void *pID, const CUIRect *pNearRect, const char *pText, float WidthHint)
@@ -61,9 +61,9 @@ void CTooltips::DoToolTip(const void *pID, const CUIRect *pNearRect, const char 
 
 void CTooltips::OnRender()
 {
-	if(m_ActiveTooltip.has_value())
+	if(m_pActiveTooltip != nullptr)
 	{
-		CTooltip &Tooltip = m_ActiveTooltip.value();
+		CTooltip &Tooltip = *m_pActiveTooltip;
 
 		if(!UI()->MouseInside(&Tooltip.m_Rect))
 		{

--- a/src/game/client/components/tooltips.h
+++ b/src/game/client/components/tooltips.h
@@ -5,7 +5,6 @@
 #include <game/client/component.h>
 #include <game/client/ui.h>
 
-#include <optional>
 #include <unordered_map>
 
 struct CTooltip
@@ -23,7 +22,7 @@ struct CTooltip
 class CTooltips : public CComponent
 {
 	std::unordered_map<uintptr_t, CTooltip> m_Tooltips;
-	std::optional<std::reference_wrapper<CTooltip>> m_ActiveTooltip;
+	CTooltip *m_pActiveTooltip;
 	int64_t HoverTime;
 
 	/**


### PR DESCRIPTION
Since we don't have full C++17 support with the GCC version there.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
