### PR TITLE
fix WalkTime for negativ positions

### DIFF
--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -397,7 +397,12 @@ void CPlayers::RenderPlayer(
 	bool WantOtherDir = (Player.m_Direction == -1 && Vel.x > 0) || (Player.m_Direction == 1 && Vel.x < 0);
 
 	// evaluate animation
-	float WalkTime = fmod(absolute(Position.x), 100.0f) / 100.0f;
+	float WalkTime = fmod(Position.x, 100.0f) / 100.0f;
+	if(WalkTime < 0)
+	{
+		// Don't do a moon walk outside the left border
+		WalkTime += 1;
+	}
 	CAnimState State;
 	State.Set(&g_pData->m_aAnimations[ANIM_BASE], 0);
 


### PR DESCRIPTION
I am not sure if there is a more elegant solution, the problem is that fmod in cpp does not return a positive value. maybe we can just use a mod function that always returns positive values.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [x] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
