### PR TITLE
Fix tooltip locations after window resize (fixes #5026)

### DIFF
--- a/src/game/client/components/tooltips.cpp
+++ b/src/game/client/components/tooltips.cpp
@@ -30,32 +30,19 @@ inline void CTooltips::ClearActiveTooltip()
 void CTooltips::DoToolTip(const void *pID, const CUIRect *pNearRect, const char *pText, float WidthHint)
 {
 	uintptr_t ID = reinterpret_cast<uintptr_t>(pID);
+	const auto result = m_Tooltips.emplace(ID, CTooltip{
+							   *pNearRect,
+							   pText,
+							   WidthHint});
+	CTooltip &Tooltip = result.first->second;
 
-	const auto &it = m_Tooltips.find(ID);
-
-	if(it == m_Tooltips.end())
+	if(!result.second)
 	{
-		CTooltip NewTooltip = {
-			*pNearRect,
-			pText,
-			WidthHint,
-		};
-
-		m_Tooltips[ID] = NewTooltip;
-
-		CTooltip &Tooltip = m_Tooltips[ID];
-
-		if(UI()->MouseInside(&Tooltip.m_Rect))
-		{
-			SetActiveTooltip(Tooltip);
-		}
+		Tooltip.m_Rect = *pNearRect; // update in case of window resize
 	}
-	else
+	if(UI()->MouseInside(&Tooltip.m_Rect))
 	{
-		if(UI()->MouseInside(&it->second.m_Rect))
-		{
-			SetActiveTooltip(it->second);
-		}
+		SetActiveTooltip(Tooltip);
 	}
 }
 


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
