### PR TITLE
Ignore non-zero offset to null pointer in json.c (fixes #5031)

### DIFF
--- a/ubsan.supp
+++ b/ubsan.supp
@@ -1,2 +1,3 @@
 shift-base:pnglite.c
 null:json.c
+pointer-overflow:json.c


### PR DESCRIPTION
Since we have no control over this library

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
