### PR TITLE
Change log format

### DIFF
--- a/scripts/integration_test.sh
+++ b/scripts/integration_test.sh
@@ -272,9 +272,7 @@ kill_all
 wait
 sleep 1
 
-# TODO: remove the first grep after https://github.com/ddnet/ddnet/pull/5036 is merged
-if ! grep -qE '^\[[0-9]{4}-[0-9]{2}-[0-9]{2} ([0-9]{2}:){2}[0-9]{2}\]\[chat\]: 0:-2:client1: hello world$' server.log && \
-	! grep -qE '^[0-9]{4}-[0-9]{2}-[0-9]{2} ([0-9]{2}:){2}[0-9]{2} D chat: 0:-2:client1: hello world$' server.log
+if ! grep -qE '^[0-9]{4}-[0-9]{2}-[0-9]{2} ([0-9]{2}:){2}[0-9]{2} I chat: 0:-2:client1: hello world$' server.log
 then
 	touch fail_chat.txt
 	echo "[-] Error: chat message not found in server log"
@@ -295,12 +293,12 @@ then
 	echo "[-] Error: admin message not found in server log"
 fi
 
-if ! grep -q "\[demo_player\]: Stopped playback" client1.log
+if ! grep -q "demo_player: Stopped playback" client1.log
 then
 	touch fail_demo_server.txt
 	echo "[-] Error: demo playback of server demo in client 1 was not started/finished"
 fi
-if ! grep -q "\[demo_player\]: Stopped playback" client2.log
+if ! grep -q "demo_player: Stopped playback" client2.log
 then
 	touch fail_demo_client.txt
 	echo "[-] Error: demo playback of client demo in client 2 was not started/finished"

--- a/src/base/log.cpp
+++ b/src/base/log.cpp
@@ -106,7 +106,7 @@ void log_log_impl(LEVEL level, bool have_color, LOG_COLOR color, const char *sys
 	Msg.m_SystemLength = str_length(Msg.m_aSystem);
 
 	// TODO: Add level?
-	str_format(Msg.m_aLine, sizeof(Msg.m_aLine), "[%s][%s]: ", Msg.m_aTimestamp, Msg.m_aSystem);
+	str_format(Msg.m_aLine, sizeof(Msg.m_aLine), "%s %c %s: ", Msg.m_aTimestamp, "EWIDT"[level], Msg.m_aSystem);
 	Msg.m_LineMessageOffset = str_length(Msg.m_aLine);
 
 	char *pMessage = Msg.m_aLine + Msg.m_LineMessageOffset;


### PR DESCRIPTION
Remove square brackets to reduce the amount of space used.

Add log level indicator. The position between timestamp and system was
chosen because it is at a fixed position (unlike after the system) but
the log still remains naively sortable (which wouldn't happen if we were
to place it in front of the timestamp.

Before:
```
[2022-04-29 15:25:37][engine]: running on unix-linux-amd64
[2022-04-29 15:25:37][engine]: arch is little endian
[2022-04-29 15:25:37][storage]: added path '$USERDIR' ('/path/to/home/.teeworlds')
[2022-04-29 15:25:37][storage]: added path '$DATADIR' ('data')
[2022-04-29 15:25:37][storage]: added path '$CURRENTDIR' ('/path/to/ddnet')
[2022-04-29 15:25:37][host_lookup]: host='localhost' port=0 1
[2022-04-29 15:25:37][host_lookup]: host='localhost' port=0 2
[2022-04-29 15:25:37][console]: executing 'autoexec_server.cfg'
```

After:
```
2022-04-29 15:25:37 I engine: running on unix-linux-amd64
2022-04-29 15:25:37 I engine: arch is little endian
2022-04-29 15:25:37 I storage: added path '$USERDIR' ('/path/to/home/.teeworlds')
2022-04-29 15:25:37 I storage: added path '$DATADIR' ('data')
2022-04-29 15:25:37 I storage: added path '$CURRENTDIR' ('/path/to/ddnet')
2022-04-29 15:25:37 I host_lookup: host='localhost' port=0 1
2022-04-29 15:25:37 I host_lookup: host='localhost' port=0 2
2022-04-29 15:25:37 I console: executing 'autoexec_server.cfg'