### PR TITLE
Fix wrong quad offset for (not caused by transparent) flushes

### DIFF
--- a/src/game/client/components/maplayers.cpp
+++ b/src/game/client/components/maplayers.cpp
@@ -1410,8 +1410,12 @@ void CMapLayers::RenderQuadLayer(int LayerIndex, CMapItemLayerQuads *pQuadLayer,
 			// render quads of the current offset directly(cancel batching)
 			Graphics()->RenderQuadLayer(Visuals.m_BufferContainerIndex, &s_QuadRenderInfo[0], QuadsRenderCount, CurQuadOffset);
 			QuadsRenderCount = 0;
-			// since this quad is ignored, the offset is the next quad
-			CurQuadOffset = i + 1;
+			CurQuadOffset = i;
+			if(aColor[3] == 0)
+			{
+				// since this quad is ignored, the offset is the next quad
+				++CurQuadOffset;
+			}
 		}
 
 		if(aColor[3] > 0)


### PR DESCRIPTION
Fixes the issue from cheeser0613 in discord, that showed a quad that shouldnt exists.

The quadoffset is only +1 if the current quad is fully transparent(this was added a while ago to improve performance of the firework background).

This affects OpenGL 3.3 & Vulkan and was introduced with the Vulkan change.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
