### PR TITLE
Fix flashing colors in console when scrolling up continuously

### DIFF
--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -769,7 +769,9 @@ void CGameConsole::OnRender()
 			m_MouseIsPress = false;
 		}
 
-		for(int Page = 0; Page <= pConsole->m_BacklogCurPage; ++Page, OffsetY = 0.0f)
+		static int s_LastActivePage = pConsole->m_BacklogCurPage;
+		int TotalPages = 1;
+		for(int Page = 0; Page <= s_LastActivePage; ++Page, OffsetY = 0.0f)
 		{
 			while(pEntry)
 			{
@@ -798,7 +800,7 @@ void CGameConsole::OnRender()
 					break;
 
 				// just render output from current backlog page (render bottom up)
-				if(Page == pConsole->m_BacklogCurPage)
+				if(Page == s_LastActivePage)
 				{
 					TextRender()->SetCursor(&Cursor, 0.0f, y - OffsetY, FontSize, TEXTFLAG_RENDER);
 					Cursor.m_LineWidth = Screen.w - 10.0f;
@@ -843,22 +845,12 @@ void CGameConsole::OnRender()
 				Input()->SetClipboardText(SelectionString.c_str());
 			}
 
-			// current backlog page number is too high, render last available page (current checked one, render top down)
-			if(!pEntry && Page < pConsole->m_BacklogCurPage)
-			{
-				pConsole->m_BacklogCurPage = Page;
-				pEntry = pConsole->m_Backlog.First();
-				while(OffsetY > 0.0f && pEntry)
-				{
-					TextRender()->SetCursor(&Cursor, 0.0f, y - OffsetY, FontSize, TEXTFLAG_RENDER);
-					Cursor.m_LineWidth = Screen.w - 10.0f;
-					TextRender()->TextEx(&Cursor, pEntry->m_aText, -1);
-					OffsetY -= pEntry->m_YOffset;
-					pEntry = pConsole->m_Backlog.Next(pEntry);
-				}
+			if(!pEntry)
 				break;
-			}
+			TotalPages++;
 		}
+		pConsole->m_BacklogCurPage = clamp(pConsole->m_BacklogCurPage, 0, TotalPages - 1);
+		s_LastActivePage = pConsole->m_BacklogCurPage;
 
 		pConsole->m_BacklogLock.unlock();
 


### PR DESCRIPTION
When going beyond the last page it was previously redrawn in a hacky way, which was also not updated to use the correct console colors, so the colors would flash white when holding the page up key.

The underlying fix is the same as on upstream https://github.com/teeworlds/teeworlds/pull/3063. The rendered page will only be changed after the log has already been rendered, to ensure that the page can be clamped correctly.

Closes #5040.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
