### PR TITLE
Revert "Get rid of optional, not available on Debian9 build"

### DIFF
--- a/src/game/client/components/tooltips.cpp
+++ b/src/game/client/components/tooltips.cpp
@@ -15,16 +15,16 @@ void CTooltips::OnReset()
 
 void CTooltips::SetActiveTooltip(CTooltip &Tooltip)
 {
-	if(m_pActiveTooltip != nullptr)
+	if(m_ActiveTooltip.has_value())
 		return;
 
-	m_pActiveTooltip = &Tooltip;
+	m_ActiveTooltip.emplace(Tooltip);
 	HoverTime = time_get();
 }
 
 inline void CTooltips::ClearActiveTooltip()
 {
-	m_pActiveTooltip = nullptr;
+	m_ActiveTooltip.reset();
 }
 
 void CTooltips::DoToolTip(const void *pID, const CUIRect *pNearRect, const char *pText, float WidthHint)
@@ -48,9 +48,9 @@ void CTooltips::DoToolTip(const void *pID, const CUIRect *pNearRect, const char 
 
 void CTooltips::OnRender()
 {
-	if(m_pActiveTooltip != nullptr)
+	if(m_ActiveTooltip.has_value())
 	{
-		CTooltip &Tooltip = *m_pActiveTooltip;
+		CTooltip &Tooltip = m_ActiveTooltip.value();
 
 		if(!UI()->MouseInside(&Tooltip.m_Rect))
 		{

--- a/src/game/client/components/tooltips.h
+++ b/src/game/client/components/tooltips.h
@@ -5,6 +5,7 @@
 #include <game/client/component.h>
 #include <game/client/ui.h>
 
+#include <optional>
 #include <unordered_map>
 
 struct CTooltip
@@ -22,7 +23,7 @@ struct CTooltip
 class CTooltips : public CComponent
 {
 	std::unordered_map<uintptr_t, CTooltip> m_Tooltips;
-	CTooltip *m_pActiveTooltip;
+	std::optional<std::reference_wrapper<CTooltip>> m_ActiveTooltip;
 	int64_t HoverTime;
 
 	/**


### PR DESCRIPTION
This reverts commit 4e3d5c562617913548ca6d3f61813200e292c962.

Should work again with clang++-7 and libc++-7. See
https://github.com/ddnet/ddnet-scripts/commit/2534d627ac47dc52af7fc5222d0ce5763b1c202e

So I discovered that clang 7 is available on Debian 9, and it claims to have full C++17 support.

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
