### PR TITLE
Fix undefined behavior in default eyes string formating

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -2104,15 +2104,17 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket, int Conn, bool Dummy)
 						{
 							CNetMsg_Cl_Say MsgP;
 							MsgP.m_Team = 0;
-							char aBuf[256];
+							char aBuf[128];
+							char aBufMsg[256];
 							if(!g_Config.m_ClRunOnJoin[0] && !g_Config.m_ClDummyDefaultEyes && !g_Config.m_ClPlayerDefaultEyes)
-								str_format(aBuf, sizeof(aBuf), "/timeout %s", m_aTimeoutCodes[Conn]);
+								str_format(aBufMsg, sizeof(aBufMsg), "/timeout %s", m_aTimeoutCodes[Conn]);
 							else
-								str_format(aBuf, sizeof(aBuf), "/mc;timeout %s", m_aTimeoutCodes[Conn]);
+								str_format(aBufMsg, sizeof(aBufMsg), "/mc;timeout %s", m_aTimeoutCodes[Conn]);
 
 							if(g_Config.m_ClRunOnJoin[0])
 							{
-								str_format(aBuf, sizeof(aBuf), "%s;%s", aBuf, g_Config.m_ClRunOnJoin);
+								str_format(aBuf, sizeof(aBuf), ";%s", g_Config.m_ClRunOnJoin);
+								str_append(aBufMsg, aBuf, sizeof(aBufMsg));
 							}
 							if(g_Config.m_ClDummyDefaultEyes || g_Config.m_ClPlayerDefaultEyes)
 							{
@@ -2140,9 +2142,12 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket, int Conn, bool Dummy)
 									break;
 								}
 								if(aBufEmote[0])
-									str_format(aBuf, sizeof(aBuf), "%s;%s", aBuf, aBufEmote);
+								{
+									str_format(aBuf, sizeof(aBuf), ";%s", aBufEmote);
+									str_append(aBufMsg, aBuf, sizeof(aBufMsg));
+								}
 							}
-							MsgP.m_pMessage = aBuf;
+							MsgP.m_pMessage = aBufMsg;
 							CMsgPacker PackerTimeout(MsgP.MsgID(), false);
 							MsgP.Pack(&PackerTimeout);
 							SendMsg(Conn, &PackerTimeout, MSGFLAG_VITAL);


### PR DESCRIPTION
fixes #5056
stop using the same buffer as dest and source.

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
