### PR TITLE
Don't print the first "Waiting for score threads to complete"

### DIFF
--- a/src/engine/server/databases/connection_pool.cpp
+++ b/src/engine/server/databases/connection_pool.cpp
@@ -109,8 +109,10 @@ void CDbConnectionPool::OnShutdown()
 	while(m_Shutdown.load())
 	{
 		// print a log about every two seconds
-		if(i % 20 == 0)
-			dbg_msg("sql", "Waiting for score-threads to complete (%ds)", i / 10);
+		if(i % 20 == 0 && i > 0)
+		{
+			dbg_msg("sql", "Waiting for score threads to complete (%ds)", i / 10);
+		}
 		++i;
 		thread_sleep(100000);
 	}


### PR DESCRIPTION
Looks nicer IMO if you don't show the message if there's no actual
waiting.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
