### PR TITLE
Improve demo slice popup, minor refactoring of UI/menus

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -1603,10 +1603,7 @@ int CMenus::Render()
 		CUIRect Box, Part;
 		Box = Screen;
 		if(m_Popup != POPUP_FIRST_LAUNCH)
-		{
-			Box.VMargin(150.0f / UI()->Scale(), &Box);
-			Box.HMargin(150.0f / UI()->Scale(), &Box);
-		}
+			Box.Margin(150.0f / UI()->Scale(), &Box);
 
 		// render the box
 		RenderTools()->DrawUIRect(&Box, BgColor, CUI::CORNER_ALL, 15.0f);
@@ -1750,8 +1747,7 @@ int CMenus::Render()
 		else if(m_Popup == POPUP_CONNECTING)
 		{
 			Box = Screen;
-			Box.VMargin(150.0f, &Box);
-			Box.HMargin(150.0f, &Box);
+			Box.Margin(150.0f, &Box);
 			Box.HSplitBottom(20.f, &Box, &Part);
 			Box.HSplitBottom(24.f, &Box, &Part);
 			Part.VMargin(120.0f, &Part);
@@ -1817,8 +1813,7 @@ int CMenus::Render()
 		else if(m_Popup == POPUP_LANGUAGE)
 		{
 			Box = Screen;
-			Box.VMargin(150.0f, &Box);
-			Box.HMargin(150.0f, &Box);
+			Box.Margin(150.0f, &Box);
 			Box.HSplitTop(20.f, &Part, &Box);
 			Box.HSplitBottom(20.f, &Box, &Part);
 			Box.HSplitBottom(24.f, &Box, &Part);
@@ -1834,8 +1829,7 @@ int CMenus::Render()
 		else if(m_Popup == POPUP_COUNTRY)
 		{
 			Box = Screen;
-			Box.VMargin(150.0f, &Box);
-			Box.HMargin(150.0f, &Box);
+			Box.Margin(150.0f, &Box);
 			Box.HSplitTop(20.f, &Part, &Box);
 			Box.HSplitBottom(20.f, &Box, &Part);
 			Box.HSplitBottom(24.f, &Box, &Part);

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -80,8 +80,7 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 		CUIRect Screen = *UI()->Screen();
 		CUIRect Box, Part, Part2;
 		Box = Screen;
-		Box.VMargin(150.0f / UI()->Scale(), &Box);
-		Box.HMargin(150.0f / UI()->Scale(), &Box);
+		Box.Margin(150.0f / UI()->Scale(), &Box);
 
 		// render the box
 		RenderTools()->DrawUIRect(&Box, ColorRGBA(0, 0, 0, 0.5f), CUI::CORNER_ALL, 15.0f);

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -85,17 +85,17 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 		// render the box
 		RenderTools()->DrawUIRect(&Box, ColorRGBA(0, 0, 0, 0.5f), CUI::CORNER_ALL, 15.0f);
 
-		Box.HSplitTop(20.f / UI()->Scale(), &Part, &Box);
+		Box.HSplitTop(20.f / UI()->Scale(), 0, &Box);
 		Box.HSplitTop(24.f / UI()->Scale(), &Part, &Box);
 		UI()->DoLabelScaled(&Part, Localize("Select a name"), 24.f, TEXTALIGN_CENTER);
-		Box.HSplitTop(20.f / UI()->Scale(), &Part, &Box);
+		Box.HSplitTop(20.f / UI()->Scale(), 0, &Box);
 		Box.HSplitTop(24.f / UI()->Scale(), &Part, &Box);
 		Part.VMargin(20.f / UI()->Scale(), &Part);
 		UI()->DoLabelScaled(&Part, m_aDemoPlayerPopupHint, 24.f, TEXTALIGN_CENTER);
 
 		CUIRect Label, TextBox, Ok, Abort;
 
-		Box.HSplitBottom(20.f, &Box, &Part);
+		Box.HSplitBottom(20.f, &Box, 0);
 		Box.HSplitBottom(24.f, &Box, &Part);
 		Part.VMargin(80.0f, &Part);
 
@@ -140,8 +140,7 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 			}
 		}
 
-		Box.HSplitBottom(60.f, &Box, &Part);
-		Box.HSplitBottom(60.f, &Box, &Part2);
+		Box.HSplitBottom(120.f, &Box, 0);
 		Box.HSplitBottom(24.f, &Box, &Part2);
 		Box.HSplitBottom(24.f, &Box, &Part);
 

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -72,7 +72,6 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 	const float ButtonbarHeight = 20.0f;
 	const float NameBarHeight = 20.0f;
 	const float Margins = 5.0f;
-	float TotalHeight;
 	static int64_t LastSpeedChange = 0;
 
 	// render popups
@@ -236,7 +235,7 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 		}
 	}
 
-	TotalHeight = SeekBarHeight + ButtonbarHeight + NameBarHeight + Margins * 3;
+	float TotalHeight = SeekBarHeight + ButtonbarHeight + NameBarHeight + Margins * 3;
 
 	// render speed info
 	if(g_Config.m_ClDemoShowSpeed && time_get() - LastSpeedChange < time_freq() * 1)

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -89,9 +89,10 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 		Box.HSplitTop(24.f / UI()->Scale(), &Part, &Box);
 		UI()->DoLabelScaled(&Part, Localize("Select a name"), 24.f, TEXTALIGN_CENTER);
 		Box.HSplitTop(20.f / UI()->Scale(), 0, &Box);
-		Box.HSplitTop(24.f / UI()->Scale(), &Part, &Box);
+		Box.HSplitTop(20.f / UI()->Scale(), &Part, &Box);
 		Part.VMargin(20.f / UI()->Scale(), &Part);
-		UI()->DoLabelScaled(&Part, m_aDemoPlayerPopupHint, 24.f, TEXTALIGN_CENTER);
+		UI()->DoLabelScaled(&Part, m_aDemoPlayerPopupHint, 20.f, TEXTALIGN_CENTER);
+		Box.HSplitTop(20.f / UI()->Scale(), 0, &Box);
 
 		CUIRect Label, TextBox, Ok, Abort;
 
@@ -140,9 +141,9 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 			}
 		}
 
-		Box.HSplitBottom(120.f, &Box, 0);
-		Box.HSplitBottom(24.f, &Box, &Part2);
-		Box.HSplitBottom(24.f, &Box, &Part);
+		Box.HSplitTop(24.f, &Part, &Box);
+		Box.HSplitTop(10.f, 0, &Box);
+		Box.HSplitTop(24.f, &Part2, &Box);
 
 		Part2.VSplitLeft(60.0f, 0, &Label);
 		if(DoButton_CheckBox(&s_RemoveChat, Localize("Remove chat"), s_RemoveChat, &Label))
@@ -154,7 +155,7 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 		Label.VSplitLeft(120.0f, 0, &TextBox);
 		TextBox.VSplitLeft(20.0f, 0, &TextBox);
 		TextBox.VSplitRight(60.0f, &TextBox, 0);
-		UI()->DoLabel(&Label, Localize("New name:"), 18.0f, TEXTALIGN_LEFT);
+		UI()->DoLabelScaled(&Label, Localize("New name:"), 18.0f, TEXTALIGN_LEFT);
 		static float s_Offset = 0.0f;
 		if(UIEx()->DoEditBox(&s_Offset, &TextBox, m_aCurrentDemoFile, sizeof(m_aCurrentDemoFile), 12.0f, &s_Offset))
 		{

--- a/src/game/client/ui_ex.cpp
+++ b/src/game/client/ui_ex.cpp
@@ -451,8 +451,7 @@ bool CUIEx::DoEditBox(const void *pID, const CUIRect *pRect, char *pStr, unsigne
 
 	CUIRect Textbox = *pRect;
 	RenderTools()->DrawUIRect(&Textbox, ColorRGBA(1, 1, 1, 0.5f), Corners, 3.0f);
-	Textbox.VMargin(2.0f, &Textbox);
-	Textbox.HMargin(2.0f, &Textbox);
+	Textbox.Margin(2.0f, &Textbox);
 
 	const char *pDisplayStr = pStr;
 	char aStars[128];


### PR DESCRIPTION
Improve demo slice popup:
- add more margins
- decrease font size of error message slightly
- correct handling of all allowed UI scale values:
   - fix overlapping elements on some UI scales by laying out all CUIRects (except the buttons) from top to bottom
   - make `New name:` label scaled

Refactoring:
- Use `CUI::Margin` instead of both `HMargin` and `VMargin`, when the margin value is identical.
- Pass 0 instead of CUIRect pointer in some cases where the value is never used, i.e. never read and overridden in the next line.

Before:

![screenshot_2022-05-01_00-18-26](https://user-images.githubusercontent.com/23437060/166140703-1050b122-bb8f-49a4-b398-f7b0b6e677a7.png)

After:

![screenshot_2022-05-01_12-05-00](https://user-images.githubusercontent.com/23437060/166141455-50876142-13f9-4563-af0f-9f78a519ed60.png)

Tested with `ui_scale 50/90/100/110/150`.

## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [X] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
