### PR TITLE
Switch to nanoseconds

### DIFF
--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -9,6 +9,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <ctime>
+#include <thread>
 
 #include "system.h"
 
@@ -744,20 +745,6 @@ void thread_yield()
 #endif
 }
 
-void thread_sleep(int microseconds)
-{
-#if defined(CONF_FAMILY_UNIX)
-	int result = usleep(microseconds);
-	/* ignore signal interruption */
-	if(result == -1 && errno != EINTR)
-		dbg_msg("thread", "sleep failed: %d", errno);
-#elif defined(CONF_FAMILY_WINDOWS)
-	Sleep(microseconds / 1000);
-#else
-#error not implemented
-#endif
-}
-
 void thread_detach(void *thread)
 {
 #if defined(CONF_FAMILY_UNIX)
@@ -929,12 +916,12 @@ void set_new_tick()
 
 /* -----  time ----- */
 static_assert(std::chrono::steady_clock::is_steady, "Compiler does not support steady clocks, it might be out of date.");
-static_assert(std::chrono::steady_clock::period::den / std::chrono::steady_clock::period::num >= 1000000, "Compiler has a bad timer precision and might be out of date.");
+static_assert(std::chrono::steady_clock::period::den / std::chrono::steady_clock::period::num >= 1000000000, "Compiler has a bad timer precision and might be out of date.");
 static const std::chrono::time_point<std::chrono::steady_clock> tw_start_time = std::chrono::steady_clock::now();
 
 int64_t time_get_impl()
 {
-	return std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now() - tw_start_time).count();
+	return std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now() - tw_start_time).count();
 }
 
 int64_t time_get()
@@ -951,12 +938,13 @@ int64_t time_get()
 
 int64_t time_freq()
 {
-	return 1000000;
+	using namespace std::chrono_literals;
+	return std::chrono::nanoseconds(1s).count();
 }
 
-int64_t time_get_microseconds()
+int64_t time_get_nanoseconds()
 {
-	return time_get_impl() / (time_freq() / 1000 / 1000);
+	return time_get_impl();
 }
 
 /* -----  network ----- */
@@ -4130,4 +4118,17 @@ void set_exception_handler_log_file(const char *log_file_path)
 #endif
 }
 #endif
+}
+
+// pure cpp code for the cpp system wrapper
+
+std::chrono::nanoseconds tw::time_get()
+{
+	return std::chrono::nanoseconds(time_get_nanoseconds());
+}
+
+int tw::net_socket_read_wait(NETSOCKET sock, std::chrono::nanoseconds nanoseconds)
+{
+	using namespace std::chrono_literals;
+	return ::net_socket_read_wait(sock, (nanoseconds / std::chrono::nanoseconds(1us).count()).count());
 }

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -28,9 +28,9 @@
 #include <sys/socket.h>
 #endif
 
-#if defined(__cplusplus)
+#include <chrono>
+
 extern "C" {
-#endif
 
 /**
  * @defgroup Debug
@@ -492,15 +492,6 @@ void aio_free(ASYNCIO *aio);
  */
 
 /**
- * Suspends the current thread for a given period.
- *
- * @ingroup Threads
- *
- * @param microseconds Number of microseconds to sleep.
- */
-void thread_sleep(int microseconds);
-
-/**
  * Creates a new thread.
  *
  * @ingroup Threads
@@ -768,13 +759,13 @@ enum
 int time_season();
 
 /**
- * Fetches a sample from a high resolution timer and converts it in microseconds.
+ * Fetches a sample from a high resolution timer and converts it in nanoseconds.
  *
  * @ingroup Time
  *
- * @return Current value of the timer in microseconds.
+ * @return Current value of the timer in nanoseconds.
 */
-int64_t time_get_microseconds();
+int64_t time_get_nanoseconds();
 
 /**
  * @defgroup Network-General
@@ -2459,9 +2450,25 @@ int os_version_str(char *version, int length);
 void init_exception_handler();
 void set_exception_handler_log_file(const char *log_file_path);
 #endif
-
-#if defined(__cplusplus)
 }
-#endif
+
+/**
+	Type safe wrappers for the c system
+*/
+
+namespace tw {
+
+/**
+ * Fetches a sample from a high resolution timer and converts it in nanoseconds.
+ *
+ * @ingroup Time
+ *
+ * @return Current value of the timer in nanoseconds.
+*/
+std::chrono::nanoseconds time_get();
+
+int net_socket_read_wait(NETSOCKET sock, std::chrono::nanoseconds nanoseconds);
+
+} // namespace tw
 
 #endif

--- a/src/engine/client/backend/vulkan/backend_vulkan.cpp
+++ b/src/engine/client/backend/vulkan/backend_vulkan.cpp
@@ -52,6 +52,8 @@
 #define PRIu64 "I64u"
 #endif
 
+using namespace std::chrono_literals;
+
 class CCommandProcessorFragment_Vulkan : public CCommandProcessorFragment_GLBase
 {
 	enum EMemoryBlockUsage
@@ -7309,10 +7311,10 @@ public:
 
 			// set this to true, if you want to benchmark the render thread times
 			static constexpr bool s_BenchmarkRenderThreads = false;
-			int64_t ThreadRenderTime = 0;
+			std::chrono::nanoseconds ThreadRenderTime = 0ns;
 			if(IsVerbose() && s_BenchmarkRenderThreads)
 			{
-				ThreadRenderTime = time_get_microseconds();
+				ThreadRenderTime = tw::time_get();
 			}
 
 			if(!pThread->m_Finished)
@@ -7332,7 +7334,7 @@ public:
 
 			if(IsVerbose() && s_BenchmarkRenderThreads)
 			{
-				dbg_msg("vulkan", "render thread %" PRIu64 " took %d microseconds to finish", ThreadIndex, (int)(time_get_microseconds() - ThreadRenderTime));
+				dbg_msg("vulkan", "render thread %" PRIu64 " took %d ns to finish", ThreadIndex, (int)(tw::time_get() - ThreadRenderTime).count());
 			}
 
 			pThread->m_IsRendering = false;

--- a/src/engine/client/text.cpp
+++ b/src/engine/client/text.cpp
@@ -24,6 +24,10 @@ enum
 #include <map>
 #include <vector>
 
+#include <chrono>
+
+using namespace std::chrono_literals;
+
 struct SFontSizeChar
 {
 	int m_ID;
@@ -222,7 +226,7 @@ class CTextRender : public IEngineTextRender
 	std::vector<CFont *> m_Fonts;
 	CFont *m_pCurFont;
 
-	int64_t m_CursorRenderTime;
+	std::chrono::nanoseconds m_CursorRenderTime;
 
 	int GetFreeTextContainerIndex()
 	{
@@ -623,7 +627,7 @@ public:
 		m_FTLibrary = 0;
 
 		m_RenderFlags = 0;
-		m_CursorRenderTime = time_get_microseconds();
+		m_CursorRenderTime = tw::time_get();
 	}
 
 	virtual ~CTextRender()
@@ -1613,18 +1617,18 @@ public:
 		{
 			if(TextContainer.m_HasCursor)
 			{
-				int64_t CurTime = time_get_microseconds();
+				auto CurTime = tw::time_get();
 
 				Graphics()->TextureClear();
-				if((CurTime - m_CursorRenderTime) > 500000)
+				if((CurTime - m_CursorRenderTime) > 500ms)
 				{
 					Graphics()->SetColor(*pTextOutlineColor);
 					Graphics()->RenderQuadContainerEx(TextContainer.m_StringInfo.m_SelectionQuadContainerIndex, 0, 1, 0, 0);
 					Graphics()->SetColor(*pTextColor);
 					Graphics()->RenderQuadContainerEx(TextContainer.m_StringInfo.m_SelectionQuadContainerIndex, 1, 1, 0, 0);
 				}
-				if((CurTime - m_CursorRenderTime) > 1000000)
-					m_CursorRenderTime = time_get_microseconds();
+				if((CurTime - m_CursorRenderTime) > 1s)
+					m_CursorRenderTime = tw::time_get();
 				Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
 			}
 		}

--- a/src/engine/client/video.cpp
+++ b/src/engine/client/video.cpp
@@ -12,6 +12,11 @@
 
 #include "video.h"
 
+#include <chrono>
+#include <thread>
+
+using namespace std::chrono_literals;
+
 // This code is mostly stolen from https://github.com/FFmpeg/FFmpeg/blob/master/doc/examples/muxing.c
 
 #define STREAM_PIX_FMT AV_PIX_FMT_YUV420P /* default pix_fmt */
@@ -257,7 +262,7 @@ void CVideo::Stop()
 	m_vAudioThreads.clear();
 
 	while(m_ProcessingVideoFrame > 0 || m_ProcessingAudioFrame > 0)
-		thread_sleep(10);
+		std::this_thread::sleep_for(10us);
 
 	m_Recording = false;
 
@@ -352,21 +357,10 @@ void CVideo::NextVideoFrame()
 {
 	if(m_Recording)
 	{
-		// #ifdef CONF_PLATFORM_MACOS
-		// 	CAutoreleasePool AutoreleasePool;
-		// #endif
-
-		//dbg_msg("video_recorder", "called");
-
 		ms_Time += ms_TickTime;
 		ms_LocalTime = (ms_Time - ms_LocalStartTime) / (float)time_freq();
 		m_NextFrame = true;
 		m_Vframe += 1;
-
-		// m_pGraphics->KickCommandBuffer();
-		//thread_sleep(500);
-
-		// m_Semaphore.wait();
 	}
 }
 

--- a/src/engine/server/databases/connection_pool.cpp
+++ b/src/engine/server/databases/connection_pool.cpp
@@ -5,6 +5,11 @@
 
 #include <memory>
 
+#include <chrono>
+#include <thread>
+
+using namespace std::chrono_literals;
+
 // helper struct to hold thread data
 struct CSqlExecData
 {
@@ -114,7 +119,7 @@ void CDbConnectionPool::OnShutdown()
 			dbg_msg("sql", "Waiting for score threads to complete (%ds)", i / 10);
 		}
 		++i;
-		thread_sleep(100000);
+		std::this_thread::sleep_for(100ms);
 	}
 }
 

--- a/src/engine/shared/demo.cpp
+++ b/src/engine/shared/demo.cpp
@@ -404,9 +404,6 @@ void CDemoPlayer::Construct(class CSnapshotDelta *pSnapshotDelta)
 	m_pKeyFrames = 0;
 	m_SpeedIndex = 4;
 
-	m_TickTime = 0;
-	m_Time = 0;
-
 	m_pSnapshotDelta = pSnapshotDelta;
 	m_LastSnapshotDataSize = -1;
 }
@@ -1030,7 +1027,6 @@ int CDemoPlayer::Update(bool RealTime)
 				m_pConsole->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "demo_player", aBuf);
 			}
 		}
-		m_Time += m_TickTime;
 	}
 	return 0;
 }

--- a/src/engine/shared/demo.h
+++ b/src/engine/shared/demo.h
@@ -121,9 +121,6 @@ private:
 
 	int64_t time();
 
-	int64_t m_TickTime;
-	int64_t m_Time;
-
 public:
 	CDemoPlayer(class CSnapshotDelta *pSnapshotDelta);
 	CDemoPlayer(class CSnapshotDelta *pSnapshotDelta, TUpdateIntraTimesFunc &&UpdateIntraTimesFunc);

--- a/src/game/client/components/maplayers.cpp
+++ b/src/game/client/components/maplayers.cpp
@@ -19,6 +19,10 @@
 
 #include "maplayers.h"
 
+#include <chrono>
+
+using namespace std::chrono_literals;
+
 CMapLayers::CMapLayers(int t, bool OnlineOnly)
 {
 	m_Type = t;
@@ -87,7 +91,7 @@ void CMapLayers::EnvelopeEval(int TimeOffsetMillis, int Env, float *pChannels, v
 	const int64_t TickToMicroSeconds = (1000000ll / (int64_t)pThis->Client()->GameTickSpeed());
 
 	static int64_t s_Time = 0;
-	static int64_t s_LastLocalTime = time_get_microseconds();
+	static int64_t s_LastLocalTime = time_get_nanoseconds();
 	if(pThis->Client()->State() == IClient::STATE_DEMOPLAYBACK)
 	{
 		const IDemoPlayer::CInfo *pInfo = pThis->DemoPlayer()->BaseInfo();
@@ -142,11 +146,11 @@ void CMapLayers::EnvelopeEval(int TimeOffsetMillis, int Env, float *pChannels, v
 		}
 		else
 		{
-			int64_t CurTime = time_get_microseconds();
+			int64_t CurTime = time_get_nanoseconds();
 			s_Time += CurTime - s_LastLocalTime;
 			s_LastLocalTime = CurTime;
 		}
-		CRenderTools::RenderEvalEnvelope(pPoints + pItem->m_StartPoint, pItem->m_NumPoints, 4, s_Time + (int64_t)TimeOffsetMillis * 1000ll, pChannels);
+		CRenderTools::RenderEvalEnvelope(pPoints + pItem->m_StartPoint, pItem->m_NumPoints, 4, s_Time + (int64_t)std::chrono::nanoseconds(std::chrono::milliseconds(TimeOffsetMillis)).count(), pChannels);
 	}
 }
 

--- a/src/game/client/components/menu_background.cpp
+++ b/src/game/client/components/menu_background.cpp
@@ -16,6 +16,10 @@
 
 #include "menu_background.h"
 
+#include <chrono>
+
+using namespace std::chrono_literals;
+
 CMenuBackground::CMenuBackground() :
 	CBackground(CMapLayers::TYPE_FULL_DESIGN, false)
 {
@@ -130,8 +134,8 @@ int CMenuBackground::ThemeScan(const char *pName, int IsDir, int DirType, void *
 	str_format(aBuf, sizeof(aBuf), "added theme %s from themes/%s", aThemeName, pName);
 	pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "game", aBuf);
 	pSelf->m_lThemes.push_back(Theme);
-	int64_t TimeNow = time_get_microseconds();
-	if(TimeNow - pSelf->m_ThemeScanStartTime >= 1000000 / 60)
+	auto TimeNow = tw::time_get();
+	if(TimeNow - pSelf->m_ThemeScanStartTime >= std::chrono::nanoseconds(1s) / 60)
 	{
 		pSelf->Client()->UpdateAndSwap();
 		pSelf->m_ThemeScanStartTime = TimeNow;
@@ -146,8 +150,8 @@ int CMenuBackground::ThemeIconScan(const char *pName, int IsDir, int DirType, vo
 	if(IsDir || !pSuffix)
 		return 0;
 
-	int64_t TimeNow = time_get_microseconds();
-	if(TimeNow - pSelf->m_ThemeScanStartTime >= 1000000 / 60)
+	auto TimeNow = tw::time_get();
+	if(TimeNow - pSelf->m_ThemeScanStartTime >= std::chrono::nanoseconds(1s) / 60)
 	{
 		pSelf->Client()->UpdateAndSwap();
 		pSelf->m_ThemeScanStartTime = TimeNow;
@@ -407,7 +411,7 @@ std::vector<CTheme> &CMenuBackground::GetThemes()
 		m_lThemes.emplace_back("auto", true, true); // auto theme
 		m_lThemes.emplace_back("rand", true, true); // random theme
 
-		m_ThemeScanStartTime = time_get_microseconds();
+		m_ThemeScanStartTime = tw::time_get();
 		Storage()->ListDirectory(IStorage::TYPE_ALL, "themes", ThemeScan, (CMenuBackground *)this);
 		Storage()->ListDirectory(IStorage::TYPE_ALL, "themes", ThemeIconScan, (CMenuBackground *)this);
 

--- a/src/game/client/components/menu_background.h
+++ b/src/game/client/components/menu_background.h
@@ -4,6 +4,7 @@
 #include <game/client/components/background.h>
 #include <game/client/components/camera.h>
 
+#include <chrono>
 #include <string>
 #include <vector>
 
@@ -29,7 +30,7 @@ public:
 
 class CMenuBackground : public CBackground
 {
-	int64_t m_ThemeScanStartTime = 0;
+	std::chrono::nanoseconds m_ThemeScanStartTime{0};
 
 public:
 	enum

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -6,6 +6,7 @@
 #include <base/tl/sorted_array.h>
 #include <base/vmath.h>
 
+#include <chrono>
 #include <engine/demo.h>
 #include <engine/friends.h>
 #include <engine/shared/config.h>
@@ -435,7 +436,7 @@ protected:
 	int m_DemolistStorageType;
 	int m_Speed = 4;
 
-	int64_t m_DemoPopulateStartTime = 0;
+	std::chrono::nanoseconds m_DemoPopulateStartTime{0};
 
 	void DemolistOnUpdate(bool Reset);
 	//void DemolistPopulate();
@@ -642,7 +643,7 @@ public:
 
 	sorted_array<CGhostItem> m_lGhosts;
 
-	int64_t m_GhostPopulateStartTime = 0;
+	std::chrono::nanoseconds m_GhostPopulateStartTime{0};
 
 	void GhostlistPopulate();
 	CGhostItem *GetOwnGhost();
@@ -653,10 +654,10 @@ public:
 	int GetCurPopup() { return m_Popup; }
 	bool CanDisplayWarning();
 
-	void PopupWarning(const char *pTopic, const char *pBody, const char *pButton, int64_t Duration);
+	void PopupWarning(const char *pTopic, const char *pBody, const char *pButton, std::chrono::nanoseconds Duration);
 
-	int64_t m_PopupWarningLastTime;
-	int64_t m_PopupWarningDuration;
+	std::chrono::nanoseconds m_PopupWarningLastTime;
+	std::chrono::nanoseconds m_PopupWarningDuration;
 
 	int m_DemoPlayerState;
 	char m_aDemoPlayerPopupHint[256];

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -3,6 +3,7 @@
 
 #include <base/hash.h>
 #include <base/math.h>
+#include <base/system.h>
 
 #include <engine/demo.h>
 #include <engine/graphics.h>
@@ -21,6 +22,10 @@
 
 #include "maplayers.h"
 #include "menus.h"
+
+#include <chrono>
+
+using namespace std::chrono_literals;
 
 int CMenus::DoButton_DemoPlayer(const void *pID, const char *pText, int Checked, const CUIRect *pRect)
 {
@@ -764,7 +769,7 @@ int CMenus::DemolistFetchCallback(const CFsFileInfo *pInfo, int IsDir, int Stora
 	Item.m_StorageType = StorageType;
 	pSelf->m_lDemos.add_unsorted(Item);
 
-	if(time_get_microseconds() - pSelf->m_DemoPopulateStartTime > 500000)
+	if(tw::time_get() - pSelf->m_DemoPopulateStartTime > 500ms)
 	{
 		pSelf->GameClient()->m_Menus.RenderLoading(false, false);
 	}
@@ -777,7 +782,7 @@ void CMenus::DemolistPopulate()
 	m_lDemos.clear();
 	if(!str_comp(m_aCurrentDemoFolder, "demos"))
 		m_DemolistStorageType = IStorage::TYPE_ALL;
-	m_DemoPopulateStartTime = time_get_microseconds();
+	m_DemoPopulateStartTime = tw::time_get();
 	Storage()->ListDirectoryInfo(m_DemolistStorageType, m_aCurrentDemoFolder, DemolistFetchCallback, this);
 
 	if(g_Config.m_BrDemoFetchInfo)

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -1,6 +1,7 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include <base/math.h>
+#include <base/system.h>
 
 #include <engine/config.h>
 #include <engine/demo.h>
@@ -28,6 +29,10 @@
 #include "ghost.h"
 #include <engine/keys.h>
 #include <engine/storage.h>
+
+#include <chrono>
+
+using namespace std::chrono_literals;
 
 void CMenus::RenderGame(CUIRect MainView)
 {
@@ -915,7 +920,7 @@ int CMenus::GhostlistFetchCallback(const char *pName, int IsDir, int StorageType
 	if(Item.m_Time > 0)
 		pSelf->m_lGhosts.add(Item);
 
-	if(time_get_microseconds() - pSelf->m_GhostPopulateStartTime > 500000)
+	if(tw::time_get() - pSelf->m_GhostPopulateStartTime > 500ms)
 	{
 		pSelf->GameClient()->m_Menus.RenderLoading(false, false);
 	}
@@ -927,7 +932,7 @@ void CMenus::GhostlistPopulate()
 {
 	CGhostItem *pOwnGhost = 0;
 	m_lGhosts.clear();
-	m_GhostPopulateStartTime = time_get_microseconds();
+	m_GhostPopulateStartTime = tw::time_get();
 	Storage()->ListDirectory(IStorage::TYPE_ALL, m_pClient->m_Ghost.GetGhostDir(), GhostlistFetchCallback, this);
 
 	for(int i = 0; i < m_lGhosts.size(); i++)

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -1,6 +1,7 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include <base/math.h>
+#include <base/system.h>
 
 #include <engine/engine.h>
 #include <engine/graphics.h>
@@ -22,7 +23,6 @@
 #include <game/client/ui.h>
 #include <game/localization.h>
 
-#include "base/system.h"
 #include "binds.h"
 #include "camera.h"
 #include "countryflags.h"
@@ -36,6 +36,10 @@
 
 #include <array>
 #include <numeric>
+
+#include <chrono>
+
+using namespace std::chrono_literals;
 
 CMenusKeyBinder CMenus::m_Binder;
 
@@ -838,10 +842,10 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 		// reset render flags for possible loading screen
 		TextRender()->SetRenderFlags(0);
 		TextRender()->SetCurFont(NULL);
-		int64_t SkinStartLoadTime = time_get_microseconds();
+		auto SkinStartLoadTime = tw::time_get();
 		m_pClient->m_Skins.Refresh([&](int) {
 			// if skin refreshing takes to long, swap to a loading screen
-			if(time_get_microseconds() - SkinStartLoadTime > 500000)
+			if(tw::time_get() - SkinStartLoadTime > 500ms)
 			{
 				RenderLoading(false, false);
 			}

--- a/src/game/client/components/menus_settings_assets.cpp
+++ b/src/game/client/components/menus_settings_assets.cpp
@@ -1,4 +1,7 @@
 #include "binds.h"
+
+#include <base/system.h>
+
 #include <engine/engine.h>
 #include <engine/shared/config.h>
 #include <engine/storage.h>
@@ -6,6 +9,10 @@
 #include <game/client/gameclient.h>
 
 #include "menus.h"
+
+#include <chrono>
+
+using namespace std::chrono_literals;
 
 typedef std::function<void()> TMenuAssetScanLoadedFunc;
 
@@ -380,11 +387,11 @@ void CMenus::RenderSettingsCustom(CUIRect MainView)
 	if(DoButton_MenuTab((void *)&s_aPageTabs[4], Localize("HUD"), s_CurCustomTab == ASSETS_TAB_HUD, &Page5Tab, 10, NULL, NULL, NULL, NULL, 4))
 		s_CurCustomTab = ASSETS_TAB_HUD;
 
-	int64_t LoadStartTime = time_get_microseconds();
+	auto LoadStartTime = tw::time_get();
 	SMenuAssetScanUser User;
 	User.m_pUser = this;
 	User.m_LoadedFunc = [&]() {
-		if(time_get_microseconds() - LoadStartTime > 500000)
+		if(tw::time_get() - LoadStartTime > 500ms)
 			RenderLoading(false, false);
 	};
 	if(s_CurCustomTab == ASSETS_TAB_ENTITIES)

--- a/src/game/client/components/menus_start.cpp
+++ b/src/game/client/components/menus_start.cpp
@@ -83,7 +83,7 @@ void CMenus::RenderStartMenu(CUIRect MainView)
 		}
 		else
 		{
-			PopupWarning(Localize("Warning"), Localize("Can't find a Tutorial server"), Localize("Ok"), 10000000);
+			PopupWarning(Localize("Warning"), Localize("Can't find a Tutorial server"), Localize("Ok"), 10s);
 			s_JoinTutorialTime = 0.0f;
 		}
 		m_DoubleClickIndex = -1;
@@ -152,7 +152,7 @@ void CMenus::RenderStartMenu(CUIRect MainView)
 			}
 			else
 			{
-				PopupWarning(Localize("Warning"), Localize("Server executable not found, can't run server"), Localize("Ok"), 10000000);
+				PopupWarning(Localize("Warning"), Localize("Server executable not found, can't run server"), Localize("Ok"), 10s);
 			}
 		}
 	}

--- a/src/game/client/components/race_demo.cpp
+++ b/src/game/client/components/race_demo.cpp
@@ -13,6 +13,10 @@
 
 #include <game/client/gameclient.h>
 
+#include <chrono>
+
+using namespace std::chrono_literals;
+
 const char *CRaceDemo::ms_pRaceDemoDir = "demos/auto/race";
 
 struct CDemoItem
@@ -218,7 +222,7 @@ int CRaceDemo::RaceDemolistFetchCallback(const CFsFileInfo *pInfo, int IsDir, in
 	if(Item.m_Time > 0)
 		pParam->m_plDemos->push_back(Item);
 
-	if(time_get_microseconds() - pRealUser->m_pThis->m_RaceDemosLoadStartTime > 500000)
+	if(tw::time_get() - pRealUser->m_pThis->m_RaceDemosLoadStartTime > 500ms)
 	{
 		pRealUser->m_pThis->GameClient()->m_Menus.RenderLoading(false, false);
 	}
@@ -230,7 +234,7 @@ bool CRaceDemo::CheckDemo(int Time)
 {
 	std::vector<CDemoItem> lDemos;
 	CDemoListParam Param = {this, &lDemos, Client()->GetCurrentMap()};
-	m_RaceDemosLoadStartTime = time_get_microseconds();
+	m_RaceDemosLoadStartTime = tw::time_get();
 	SRaceDemoFetchUser User;
 	User.m_pParam = &Param;
 	User.m_pThis = this;

--- a/src/game/client/components/race_demo.h
+++ b/src/game/client/components/race_demo.h
@@ -3,6 +3,7 @@
 #ifndef GAME_CLIENT_COMPONENTS_RACE_DEMO_H
 #define GAME_CLIENT_COMPONENTS_RACE_DEMO_H
 
+#include <chrono>
 #include <game/client/component.h>
 
 class CRaceDemo : public CComponent
@@ -25,7 +26,7 @@ class CRaceDemo : public CComponent
 	int m_RecordStopTick;
 	int m_Time;
 
-	int64_t m_RaceDemosLoadStartTime = 0;
+	std::chrono::nanoseconds m_RaceDemosLoadStartTime{0};
 
 	static int RaceDemolistFetchCallback(const CFsFileInfo *pInfo, int IsDir, int StorageType, void *pUser);
 

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1,6 +1,7 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 
+#include <chrono>
 #include <limits>
 
 #include <engine/client/checksum.h>
@@ -68,6 +69,8 @@
 #include "components/ghost.h"
 #include "components/race_demo.h"
 #include <base/system.h>
+
+using namespace std::chrono_literals;
 
 CGameClient::CStack::CStack() { m_Num = 0; }
 void CGameClient::CStack::Add(class CComponent *pComponent) { m_paComponents[m_Num++] = pComponent; }
@@ -601,7 +604,7 @@ void CGameClient::OnRender()
 	{
 		if(pWarning != NULL && m_Menus.CanDisplayWarning())
 		{
-			m_Menus.PopupWarning(Localize("Warning"), pWarning->m_aWarningMsg, "Ok", 10000000);
+			m_Menus.PopupWarning(Localize("Warning"), pWarning->m_aWarningMsg, "Ok", 10s);
 			pWarning->m_WasShown = true;
 		}
 	}

--- a/src/game/client/render.h
+++ b/src/game/client/render.h
@@ -108,7 +108,7 @@ public:
 	void RenderTee(class CAnimState *pAnim, CTeeRenderInfo *pInfo, int Emote, vec2 Dir, vec2 Pos, float Alpha = 1.0f);
 
 	// map render methods (render_map.cpp)
-	static void RenderEvalEnvelope(CEnvPoint *pPoints, int NumPoints, int Channels, int64_t TimeMicros, float *pResult);
+	static void RenderEvalEnvelope(CEnvPoint *pPoints, int NumPoints, int Channels, int64_t TimeNanos, float *pResult);
 	void RenderQuads(CQuad *pQuads, int NumQuads, int Flags, ENVELOPE_EVAL pfnEval, void *pUser);
 	void ForceRenderQuads(CQuad *pQuads, int NumQuads, int Flags, ENVELOPE_EVAL pfnEval, void *pUser, float Alpha = 1.0f);
 	void RenderTilemap(CTile *pTiles, int w, int h, float Scale, ColorRGBA Color, int RenderFlags, ENVELOPE_EVAL pfnEval, void *pUser, int ColorEnv, int ColorEnvOffset);

--- a/src/game/client/render_map.cpp
+++ b/src/game/client/render_map.cpp
@@ -11,7 +11,11 @@
 #include <game/generated/client_data.h>
 #include <game/generated/protocol.h>
 
-void CRenderTools::RenderEvalEnvelope(CEnvPoint *pPoints, int NumPoints, int Channels, int64_t TimeMicros, float *pResult)
+#include <chrono>
+
+using namespace std::chrono_literals;
+
+void CRenderTools::RenderEvalEnvelope(CEnvPoint *pPoints, int NumPoints, int Channels, int64_t TimeNanos, float *pResult)
 {
 	if(NumPoints == 0)
 	{
@@ -31,19 +35,19 @@ void CRenderTools::RenderEvalEnvelope(CEnvPoint *pPoints, int NumPoints, int Cha
 		return;
 	}
 
-	int64_t MaxPointTime = (int64_t)pPoints[NumPoints - 1].m_Time * 1000ll;
+	int64_t MaxPointTime = (int64_t)pPoints[NumPoints - 1].m_Time * std::chrono::nanoseconds(1ms).count();
 	if(MaxPointTime > 0) // TODO: remove this check when implementing a IO check for maps(in this case broken envelopes)
-		TimeMicros = TimeMicros % MaxPointTime;
+		TimeNanos = TimeNanos % MaxPointTime;
 	else
-		TimeMicros = 0;
+		TimeNanos = 0;
 
-	int TimeMillis = (int)(TimeMicros / 1000ll);
+	int TimeMillis = (int)(TimeNanos / std::chrono::nanoseconds(1ms).count());
 	for(int i = 0; i < NumPoints - 1; i++)
 	{
 		if(TimeMillis >= pPoints[i].m_Time && TimeMillis <= pPoints[i + 1].m_Time)
 		{
 			float Delta = pPoints[i + 1].m_Time - pPoints[i].m_Time;
-			float a = (float)(((double)TimeMicros / 1000.0) - pPoints[i].m_Time) / Delta;
+			float a = (float)(((double)TimeNanos / (double)std::chrono::nanoseconds(1ms).count()) - pPoints[i].m_Time) / Delta;
 
 			if(pPoints[i].m_Curvetype == CURVETYPE_SMOOTH)
 				a = -2 * a * a * a + 3 * a * a; // second hermite basis

--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -5,6 +5,8 @@
 
 #include <base/system.h>
 #include <engine/textrender.h>
+
+#include <chrono>
 #include <string>
 #include <vector>
 
@@ -112,7 +114,7 @@ struct SUIAnimator
 	bool m_ScaleLabel;
 	bool m_RepositionLabel;
 
-	int64_t m_Time;
+	std::chrono::nanoseconds m_Time;
 	float m_Value;
 
 	float m_XOffset;

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -28,6 +28,10 @@
 
 #include "auto_map.h"
 
+#include <chrono>
+
+using namespace std::chrono_literals;
+
 typedef void (*INDEX_MODIFY_FUNC)(int *pIndex);
 
 //CRenderTools m_RenderTools;
@@ -89,7 +93,7 @@ public:
 
 	int Eval(float Time, float *pResult)
 	{
-		CRenderTools::RenderEvalEnvelope(m_lPoints.base_ptr(), m_lPoints.size(), m_Channels, (int64_t)((double)Time * 1000000.0), pResult);
+		CRenderTools::RenderEvalEnvelope(m_lPoints.base_ptr(), m_lPoints.size(), m_Channels, (int64_t)((double)Time * (double)std::chrono::nanoseconds(1s).count()), pResult);
 		return m_Channels;
 	}
 

--- a/src/macoslaunch/client.m
+++ b/src/macoslaunch/client.m
@@ -1,11 +1,10 @@
 #import <Cocoa/Cocoa.h>
-#include <base/system.h>
 
 extern int TWMain(int argc, const char **argv);
 
 int main(int argc, const char **argv)
 {
-	BOOL FinderLaunch = argc >= 2 && !str_comp_num(argv[1], "-psn", 4);
+	BOOL FinderLaunch = argc >= 2 && !strncmp(argv[1], "-psn", 4);
 
 	NSString *resourcePath = [[NSBundle mainBundle] resourcePath];
 	if(!resourcePath)

--- a/src/mastersrv/main_mastersrv.cpp
+++ b/src/mastersrv/main_mastersrv.cpp
@@ -12,6 +12,9 @@
 #include <engine/shared/netban.h>
 #include <engine/shared/network.h>
 
+#include <chrono>
+#include <thread>
+
 #include "mastersrv.h"
 
 enum
@@ -539,7 +542,7 @@ int main(int argc, const char **argv)
 		}
 
 		// be nice to the CPU
-		thread_sleep(1000);
+		std::this_thread::sleep_for(std::chrono::microseconds(1000));
 	}
 
 	return 0;

--- a/src/tools/crapnet.cpp
+++ b/src/tools/crapnet.cpp
@@ -6,6 +6,8 @@
 #include <array> // std::size
 #include <cstdlib>
 
+#include <thread>
+
 struct CPacket
 {
 	CPacket *m_pPrev;
@@ -203,7 +205,7 @@ void Run(unsigned short Port, NETADDR Dest)
 			}
 		}
 
-		thread_sleep(1000);
+		std::this_thread::sleep_for(std::chrono::microseconds(1000));
 	}
 }
 

--- a/src/tools/fake_server.cpp
+++ b/src/tools/fake_server.cpp
@@ -6,6 +6,8 @@
 #include <engine/shared/network.h>
 #include <mastersrv/mastersrv.h>
 
+#include <thread>
+
 CNetServer *pNet;
 
 int Progression = 50;
@@ -145,7 +147,7 @@ static int Run()
 			SendHeartBeats();
 		}
 
-		thread_sleep(100000);
+		std::this_thread::sleep_for(std::chrono::microseconds(100000));
 	}
 }
 


### PR DESCRIPTION
Modern hardware is too fast, updates sometimes take less than a few microseconds.
It's easier in the long run if we use a bigger range to avoid calculation problems.

possibly f i x e s #5051 (needs testing from bencie for the main bug, but fixes what @sjrc6 found)

Also took the moment to use more chrono so we can at some point switch to a typesafe time.

Hopefully I didnt miss any value ^^

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
