### PR TITLE
Rework HTTP to use curl-multi interface

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -95,7 +95,7 @@ jobs:
       if: contains(matrix.os, 'macOS')
       run: |
         brew update || true
-        brew install pkg-config sdl2 ffmpeg python3 ninja molten-vk vulkan-headers glslang spirv-tools
+        brew install pkg-config sdl2 ffmpeg python3 ninja molten-vk vulkan-headers glslang spirv-tools curl
         brew upgrade freetype
         pip3 install dmgbuild
         sudo rm -rf /Library/Developer/CommandLineTools

--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -1449,6 +1449,12 @@ int net_socket_type(NETSOCKET sock)
 	return sock->type;
 }
 
+int net_socket_v4_getraw(NETSOCKET sock)
+{
+	dbg_assert(sock->type & NETTYPE_IPV4 && sock->ipv4sock > 0, "Non ipv4 socket");
+	return sock->ipv4sock;
+}
+
 NETSOCKET net_udp_create(NETADDR bindaddr)
 {
 	NETSOCKET sock = (NETSOCKET_INTERNAL *)malloc(sizeof(*sock));

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -196,7 +196,7 @@ typedef struct IOINTERNAL *IOHANDLE;
  * @ingroup File-IO
  *
  * @param File to open.
- * @param flags A set of IOFLAG flags. 
+ * @param flags A set of IOFLAG flags.
  *
  * @sa IOFLAG_READ, IOFLAG_WRITE, IOFLAG_APPEND, IOFLAG_SKIP_BOM.
  *
@@ -976,6 +976,18 @@ int net_udp_close(NETSOCKET sock);
  * @return On success it returns an handle to the socket. On failure it returns NETSOCKET_INVALID.
  */
 NETSOCKET net_tcp_create(NETADDR bindaddr);
+
+/**
+ * Creates a TCP socketpair.
+ *
+ * @ingroup Network-TCP
+ *
+ * @param socks Array to write the sockets to
+ *
+ * @return On success it returns true. On failure it returns false.
+ * @remark On failure unlike socketpair(2) on linux, socks will be guaranteed to contain two NETSOCKET_INVALID.
+ */
+bool net_tcp_socketpair(NETSOCKET socks[2]);
 
 /**
  * Makes the socket start listening for new connections.
@@ -1881,7 +1893,11 @@ int net_tcp_connect_non_blocking(NETSOCKET sock, NETADDR bindaddr);
 /*
 	Function: net_set_non_blocking
 
-	DOCTODO: serp
+	Parameters:
+		sock - The socket
+
+	Returns:
+		0 on success, -1 on failure
 */
 int net_set_non_blocking(NETSOCKET sock);
 
@@ -2288,7 +2304,7 @@ void uint_to_bytes_be(unsigned char *bytes, unsigned value);
 /*
 	Function: pid
 		Returns the pid of the current process.
-	
+
 	Returns:
 		pid of the current process
 */

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -907,6 +907,15 @@ int net_addr_from_str(NETADDR *addr, const char *string);
 int net_socket_type(NETSOCKET sock);
 
 /*
+	Function: net_socket_v4_getraw
+		Get an ipv4 sockets underlying socket id.
+
+	Parameters:
+		sock - Socket to get the id from.
+*/
+int net_socket_v4_getraw(NETSOCKET sock);
+
+/*
 	Function: net_udp_create
 		Creates a UDP socket and binds it to a port.
 

--- a/src/engine/client.h
+++ b/src/engine/client.h
@@ -7,6 +7,7 @@
 #include "graphics.h"
 #include "message.h"
 #include <base/hash.h>
+#include <engine/shared/http.h>
 #include <engine/friends.h>
 
 struct SWarning;
@@ -252,6 +253,7 @@ public:
 	virtual CChecksumData *ChecksumData() = 0;
 	virtual bool InfoTaskRunning() = 0;
 	virtual int UdpConnectivity(int NetType) = 0;
+	virtual CHttp *Http() = 0;
 };
 
 class IGameClient : public IInterface

--- a/src/engine/client.h
+++ b/src/engine/client.h
@@ -7,8 +7,8 @@
 #include "graphics.h"
 #include "message.h"
 #include <base/hash.h>
-#include <engine/shared/http.h>
 #include <engine/friends.h>
+#include <engine/shared/http.h>
 
 struct SWarning;
 

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -1739,13 +1739,13 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket, int Conn, bool Dummy)
 					{
 						char aUrl[256];
 						char aEscaped[256];
-						EscapeUrl(aEscaped, sizeof(aEscaped), m_aMapdownloadFilename + 15); // cut off downloadedmaps/
+						CHttp::EscapeUrl(aEscaped, sizeof(aEscaped), m_aMapdownloadFilename + 15); // cut off downloadedmaps/
 						bool UseConfigUrl = str_comp(g_Config.m_ClMapDownloadUrl, "https://maps2.ddnet.tw") != 0 || m_aMapDownloadUrl[0] == '\0';
 						str_format(aUrl, sizeof(aUrl), "%s/%s", UseConfigUrl ? g_Config.m_ClMapDownloadUrl : m_aMapDownloadUrl, aEscaped);
 
 						m_pMapdownloadTask = HttpGetFile(aUrl, Storage(), m_aMapdownloadFilenameTemp, IStorage::TYPE_SAVE);
 						m_pMapdownloadTask->Timeout(CTimeout{g_Config.m_ClMapDownloadConnectTimeoutMs, g_Config.m_ClMapDownloadLowSpeedLimit, g_Config.m_ClMapDownloadLowSpeedTime});
-						Engine()->AddJob(m_pMapdownloadTask);
+						Http()->AddRequest(m_pMapdownloadTask);
 					}
 					else
 						SendMapRequest();
@@ -2893,9 +2893,8 @@ void CClient::InitInterfaces()
 
 	m_DemoEditor.Init(m_pGameClient->NetVersion(), &m_SnapshotDelta, m_pConsole, m_pStorage);
 
-	m_ServerBrowser.SetBaseInfo(&m_NetClient[CONN_CONTACT], m_pGameClient->NetVersion());
-
-	HttpInit(m_pStorage);
+	m_Http.Init();
+	m_ServerBrowser.SetBaseInfo(&m_NetClient[CONN_CONTACT], m_pGameClient->NetVersion(), &m_Http);
 
 #if defined(CONF_AUTOUPDATE)
 	m_Updater.Init();
@@ -4637,7 +4636,7 @@ void CClient::RequestDDNetInfo()
 	if(g_Config.m_BrIndicateFinished)
 	{
 		char aEscaped[128];
-		EscapeUrl(aEscaped, sizeof(aEscaped), PlayerName());
+		CHttp::EscapeUrl(aEscaped, sizeof(aEscaped), PlayerName());
 		str_append(aUrl, "?name=", sizeof(aUrl));
 		str_append(aUrl, aEscaped, sizeof(aUrl));
 	}
@@ -4646,7 +4645,7 @@ void CClient::RequestDDNetInfo()
 	m_pDDNetInfoTask = HttpGetFile(aUrl, Storage(), m_aDDNetInfoTmp, IStorage::TYPE_SAVE);
 	m_pDDNetInfoTask->Timeout(CTimeout{10000, 500, 10});
 	m_pDDNetInfoTask->IpResolve(IPRESOLVE::V4);
-	Engine()->AddJob(m_pDDNetInfoTask);
+	Http()->AddRequest(m_pDDNetInfoTask);
 }
 
 int CClient::GetPredictionTime()

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -127,6 +127,7 @@ class CClient : public IClient, public CDemoPlayer::IListener
 	class CUpdater m_Updater;
 	class CFriends m_Friends;
 	class CFriends m_Foes;
+	CHttp m_Http;
 
 	char m_aConnectAddressStr[256];
 
@@ -303,6 +304,8 @@ public:
 	IUpdater *Updater() { return m_pUpdater; }
 	IDiscord *Discord() { return m_pDiscord; }
 	ISteam *Steam() { return m_pSteam; }
+
+	virtual CHttp *Http() { return &m_Http; }
 
 	CClient();
 

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -305,7 +305,7 @@ public:
 	IDiscord *Discord() { return m_pDiscord; }
 	ISteam *Steam() { return m_pSteam; }
 
-	virtual CHttp *Http() { return &m_Http; }
+	CHttp *Http() override { return &m_Http; }
 
 	CClient();
 

--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -87,7 +87,7 @@ CServerBrowser::~CServerBrowser()
 	m_pPingCache = nullptr;
 }
 
-void CServerBrowser::SetBaseInfo(class CNetClient *pClient, const char *pNetVersion)
+void CServerBrowser::SetBaseInfo(class CNetClient *pClient, const char *pNetVersion, CHttp *pHttpClient)
 {
 	m_pNetClient = pClient;
 	str_copy(m_aNetVersion, pNetVersion, sizeof(m_aNetVersion));
@@ -100,12 +100,13 @@ void CServerBrowser::SetBaseInfo(class CNetClient *pClient, const char *pNetVers
 		pConfigManager->RegisterCallback(ConfigSaveCallback, this);
 	m_pPingCache = CreateServerBrowserPingCache(m_pConsole, m_pStorage);
 
+	m_pHttpClient = pHttpClient;
 	RegisterCommands();
 }
 
 void CServerBrowser::OnInit()
 {
-	m_pHttp = CreateServerBrowserHttp(m_pEngine, m_pConsole, m_pStorage, g_Config.m_BrCachedBestServerinfoUrl);
+	m_pHttp = CreateServerBrowserHttp(m_pEngine, m_pConsole, m_pHttpClient, m_pStorage, g_Config.m_BrCachedBestServerinfoUrl);
 }
 
 void CServerBrowser::RegisterCommands()

--- a/src/engine/client/serverbrowser.h
+++ b/src/engine/client/serverbrowser.h
@@ -136,7 +136,7 @@ public:
 	void RequestCurrentServerWithRandomToken(const NETADDR &Addr, int *pBasicToken, int *pToken) const;
 	void SetCurrentServerPing(const NETADDR &Addr, int Ping);
 
-	void SetBaseInfo(class CNetClient *pClient, const char *pNetVersion);
+	void SetBaseInfo(class CNetClient *pClient, const char *pNetVersion, CHttp *pHttp);
 	void OnInit();
 
 	void RequestImpl64(const NETADDR &Addr, CServerEntry *pEntry) const;
@@ -150,6 +150,7 @@ private:
 	class IEngine *m_pEngine;
 	class IFriends *m_pFriends;
 	class IStorage *m_pStorage;
+	class CHttp *m_pHttpClient;
 	char m_aNetVersion[128];
 
 	bool m_RefreshingHttp = false;

--- a/src/engine/client/serverbrowser_http.cpp
+++ b/src/engine/client/serverbrowser_http.cpp
@@ -309,7 +309,6 @@ private:
 	static bool Validate(json_value *pJson);
 	static bool Parse(json_value *pJson, std::vector<CEntry> *paServers, std::vector<NETADDR> *paLegacyServers);
 
-	IEngine *m_pEngine;
 	IConsole *m_pConsole;
 	CHttp *m_pHttp;
 
@@ -322,7 +321,6 @@ private:
 };
 
 CServerBrowserHttp::CServerBrowserHttp(IEngine *pEngine, IConsole *pConsole, CHttp *pHttp, const char **ppUrls, int NumUrls, int PreviousBestIndex) :
-	m_pEngine(pEngine),
 	m_pConsole(pConsole),
 	m_pHttp(pHttp),
 	m_pChooseMaster(new CChooseMaster(pEngine, pHttp, Validate, ppUrls, NumUrls, PreviousBestIndex))

--- a/src/engine/client/serverbrowser_http.h
+++ b/src/engine/client/serverbrowser_http.h
@@ -6,6 +6,7 @@ class CServerInfo;
 class IConsole;
 class IEngine;
 class IStorage;
+class CHttp;
 
 class IServerBrowserHttp
 {
@@ -26,5 +27,5 @@ public:
 	virtual const NETADDR &LegacyServer(int Index) const = 0;
 };
 
-IServerBrowserHttp *CreateServerBrowserHttp(IEngine *pEngine, IConsole *pConsole, IStorage *pStorage, const char *pPreviousBestUrl);
+IServerBrowserHttp *CreateServerBrowserHttp(IEngine *pEngine, IConsole *pConsole, CHttp *pHttp, IStorage *pStorage, const char *pPreviousBestUrl);
 #endif // ENGINE_CLIENT_SERVERBROWSER_HTTP_H

--- a/src/engine/client/updater.cpp
+++ b/src/engine/client/updater.cpp
@@ -21,7 +21,7 @@ class CUpdaterFetchTask : public CHttpRequest
 	void OnProgress() override;
 
 protected:
-	int OnCompletion(int State) override;
+	void OnCompletion() override;
 
 public:
 	CUpdaterFetchTask(CUpdater *pUpdater, const char *pFile, const char *pDestPath);
@@ -58,10 +58,9 @@ void CUpdaterFetchTask::OnProgress()
 	lock_unlock(m_pUpdater->m_Lock);
 }
 
-int CUpdaterFetchTask::OnCompletion(int State)
+void CUpdaterFetchTask::OnCompletion()
 {
-	State = CHttpRequest::OnCompletion(State);
-
+	int State = this->State();
 	const char *b = 0;
 	for(const char *a = Dest(); *a; a++)
 		if(*a == '/')
@@ -81,8 +80,6 @@ int CUpdaterFetchTask::OnCompletion(int State)
 		else if(State == HTTP_ERROR)
 			m_pUpdater->SetCurrentState(IUpdater::FAIL);
 	}
-
-	return State;
 }
 
 CUpdater::CUpdater()
@@ -142,7 +139,7 @@ int CUpdater::GetCurrentPercent()
 
 void CUpdater::FetchFile(const char *pFile, const char *pDestPath)
 {
-	m_pEngine->AddJob(std::make_shared<CUpdaterFetchTask>(this, pFile, pDestPath));
+	m_pClient->Http()->AddRequest(std::make_shared<CUpdaterFetchTask>(this, pFile, pDestPath));
 }
 
 bool CUpdater::MoveFile(const char *pFile)

--- a/src/engine/server/register.h
+++ b/src/engine/server/register.h
@@ -4,6 +4,7 @@
 class CConfig;
 class IConsole;
 class IEngine;
+class CHttp;
 struct CNetChunk;
 
 class IRegister
@@ -22,6 +23,6 @@ public:
 	virtual void OnNewInfo(const char *pInfo) = 0;
 };
 
-IRegister *CreateRegister(CConfig *pConfig, IConsole *pConsole, IEngine *pEngine, int ServerPort, unsigned SixupSecurityToken);
+IRegister *CreateRegister(CConfig *pConfig, IConsole *pConsole, IEngine *pEngine, CHttp *pHttp, int ServerPort, unsigned SixupSecurityToken);
 
 #endif

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -2557,6 +2557,7 @@ int CServer::Run()
 	if(m_RunServer == UNINITIALIZED)
 		m_RunServer = RUNNING;
 
+	m_Http.Init();
 	m_AuthManager.Init();
 
 	if(Config()->m_Debug)
@@ -2623,7 +2624,7 @@ int CServer::Run()
 #endif
 
 	IEngine *pEngine = Kernel()->RequestInterface<IEngine>();
-	m_pRegister = CreateRegister(&g_Config, m_pConsole, pEngine, this->Port(), m_NetServer.GetGlobalToken());
+	m_pRegister = CreateRegister(&g_Config, m_pConsole, pEngine, &m_Http, this->Port(), m_NetServer.GetGlobalToken());
 
 	m_NetServer.SetCallbacks(NewClientCallback, NewClientNoAuthCallback, ClientRejoinCallback, DelClientCallback, this);
 

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -3690,8 +3690,6 @@ void CServer::RegisterCommands()
 	m_pStorage = Kernel()->RequestInterface<IStorage>();
 	m_pAntibot = Kernel()->RequestInterface<IEngineAntibot>();
 
-	HttpInit(m_pStorage);
-
 	// register console commands
 	Console()->Register("kick", "i[id] ?r[reason]", CFGFLAG_SERVER, ConKick, this, "Kick player with specified id for any reason");
 	Console()->Register("status", "?r[name]", CFGFLAG_SERVER, ConStatus, this, "List players containing name or all players");

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -15,6 +15,7 @@
 #include <engine/shared/demo.h>
 #include <engine/shared/econ.h>
 #include <engine/shared/fifo.h>
+#include <engine/shared/http.h>
 #include <engine/shared/netban.h>
 #include <engine/shared/network.h>
 #include <engine/shared/protocol.h>
@@ -107,6 +108,7 @@ class CServer : public IServer
 	class IStorage *m_pStorage;
 	class IEngineAntibot *m_pAntibot;
 	class IRegister *m_pRegister;
+	CHttp m_Http;
 
 #if defined(CONF_UPNP)
 	CUPnP m_UPnP;

--- a/src/engine/shared/http.cpp
+++ b/src/engine/shared/http.cpp
@@ -401,7 +401,7 @@ void CHttp::Run()
 		return; //TODO: Report the error somehow
 	}
 
-	curl_waitfd ExtraFds[] = {{net_socket_v4_getraw(m_WaitSocket), CURL_POLL_IN, 0}};
+	curl_waitfd ExtraFds[] = {{static_cast<curl_socket_t>(net_socket_v4_getraw(m_WaitSocket)), CURL_POLL_IN, 0}};
 	while(!m_Shutdown.load(std::memory_order_seq_cst))
 	{
 		int Running = 0;

--- a/src/engine/shared/http.cpp
+++ b/src/engine/shared/http.cpp
@@ -431,10 +431,16 @@ void CHttp::Run()
 
 	for(auto &ReqPair : m_RunningRequests)
 	{
-		CURL *pHandle = ReqPair.first;
+		auto &[pHandle, pRequest] = ReqPair;
 		curl_multi_remove_handle(m_pHandle, pHandle);
 		curl_easy_cleanup(pHandle);
+
+		// Emulate CURLE_ABORTED_BY_CALLBACK
+		str_copy(pRequest->m_aErr, "Shutting down", sizeof(pRequest->m_aErr));
+		pRequest->OnCompletionInternal(CURLE_ABORTED_BY_CALLBACK);
 	}
+
+	m_RunningRequests.clear();
 
 	curl_share_cleanup(m_pShare);
 	curl_multi_cleanup(m_pHandle);

--- a/src/engine/shared/http.h
+++ b/src/engine/shared/http.h
@@ -213,7 +213,7 @@ public:
 	void AddRequest(std::shared_ptr<CHttpRequest> pRequest);
 
 	static void EscapeUrl(char *pBuf, int Size, const char *pStr);
-	static int CurlDebug(CURL *pHandle, curl_infotype Type, char *pData, size_t DataSize, void *pUser);
+	static int CurlDebug(CURL *pHandle, unsigned int Type, char *pData, size_t DataSize, void *pUser);
 
 private:
 	static void ThreadMain(void *pUser);

--- a/src/engine/shared/http.h
+++ b/src/engine/shared/http.h
@@ -200,6 +200,9 @@ class CHttp
 	void *m_pThread = nullptr;
 	std::atomic<bool> m_Shutdown = false;
 
+	NETSOCKET m_WaitSocket = nullptr;
+	NETSOCKET m_InterruptSocket = nullptr;
+
 	std::mutex m_Lock;
 	std::queue<std::shared_ptr<CHttpRequest>> m_PendingRequests;
 
@@ -209,7 +212,7 @@ class CHttp
 
 public:
 	~CHttp();
-	void Init();
+	bool Init();
 	void AddRequest(std::shared_ptr<CHttpRequest> pRequest);
 
 	static void EscapeUrl(char *pBuf, int Size, const char *pStr);
@@ -218,6 +221,7 @@ public:
 private:
 	static void ThreadMain(void *pUser);
 	void Run();
+	void WakeUp();
 };
 
 #endif // ENGINE_SHARED_HTTP_H

--- a/src/game/client/components/skins.h
+++ b/src/game/client/components/skins.h
@@ -17,11 +17,13 @@ public:
 		CSkins *m_pSkins;
 
 	protected:
-		virtual int OnCompletion(int State) override;
+		virtual void OnCompletion() override;
 
 	public:
-		CGetPngFile(CSkins *pSkins, const char *pUrl, IStorage *pStorage, const char *pDest);
+		bool m_Loaded{false};
 		CImageInfo m_Info;
+
+		CGetPngFile(CSkins *pSkins, const char *pUrl, IStorage *pStorage, const char *pDest);
 	};
 
 	struct CDownloadSkin


### PR DESCRIPTION
This PR tries to rework the http interface to utilize the curl-multi interface. In the process we lost the `IJob` interface.

I experimented with getting rid of the `std::unordered_map` using `CURLOPT_PRIVATE` [here](https://github.com/Learath2/ddnet/commit/9770f1d39510036e7bbbec2c0607113282539a3c). I don't really like the end result, it might look a little better with `boost::intrusive::list` if we want boost or maybe if I tread the list through `CHttpRequest` itself.

Remaining concerns:
- How should errors be handled within `CHttp::Run`
- Changes within `serverbrowser_http` I'm a bit unsure about
- Need to add TSan. Couldn't figure out how to get it to work with `std::mutex`

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [x] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [x] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
