### PR TITLE
Support nesting CUI clipping regions and other UI elements, smooth clipping of controls settings list, refactoring

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -290,8 +290,6 @@ int CMenus::DoButton_MenuTab(const void *pID, const char *pText, int Checked, co
 		}
 	}
 
-	CUIRect Temp;
-
 	if(pAnimator != NULL)
 	{
 		if(pAnimator->m_RepositionLabel)
@@ -307,6 +305,7 @@ int CMenus::DoButton_MenuTab(const void *pID, const char *pText, int Checked, co
 		}
 	}
 
+	CUIRect Temp;
 	Rect.HMargin(2.0f, &Temp);
 	SLabelProperties Props;
 	Props.m_AlignVertically = AlignVertically;

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -607,7 +607,7 @@ int CMenus::DoKeyReader(void *pID, const CUIRect *pRect, int Key, int ModifierCo
 	// process
 	static void *pGrabbedID = 0;
 	static bool MouseReleased = true;
-	static int ButtonUsed = 0;
+	static int s_ButtonUsed = 0;
 	const bool Inside = UI()->MouseInside(pRect);
 	int NewKey = Key;
 	*NewModifierCombination = ModifierCombination;
@@ -631,7 +631,7 @@ int CMenus::DoKeyReader(void *pID, const CUIRect *pRect, int Key, int ModifierCo
 			pGrabbedID = pID;
 		}
 
-		if(ButtonUsed == 1 && !UI()->MouseButton(1))
+		if(s_ButtonUsed == 1 && !UI()->MouseButton(1))
 		{
 			if(Inside)
 				NewKey = 0;
@@ -647,13 +647,13 @@ int CMenus::DoKeyReader(void *pID, const CUIRect *pRect, int Key, int ModifierCo
 				m_Binder.m_TakeKey = true;
 				m_Binder.m_GotKey = false;
 				UI()->SetActiveItem(pID);
-				ButtonUsed = 0;
+				s_ButtonUsed = 0;
 			}
 
 			if(UI()->MouseButton(1))
 			{
 				UI()->SetActiveItem(pID);
-				ButtonUsed = 1;
+				s_ButtonUsed = 1;
 			}
 		}
 	}
@@ -662,7 +662,7 @@ int CMenus::DoKeyReader(void *pID, const CUIRect *pRect, int Key, int ModifierCo
 		UI()->SetHotItem(pID);
 
 	// draw
-	if(UI()->ActiveItem() == pID && ButtonUsed == 0)
+	if(UI()->ActiveItem() == pID && s_ButtonUsed == 0)
 		DoButton_KeySelect(pID, "???", 0, pRect);
 	else
 	{

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -338,10 +338,10 @@ int CMenus::DoButton_CheckBox_Common(const void *pID, const char *pText, const c
 	c.Margin(2.0f, &c);
 	RenderTools()->DrawUIRect(&c, ColorRGBA(1, 1, 1, 0.25f * UI()->ButtonColorMul(pID)), CUI::CORNER_ALL, 3.0f);
 
-	bool CheckAble = *pBoxText == 'X';
+	const bool Checkable = *pBoxText == 'X';
 	SLabelProperties Props;
 	Props.m_AlignVertically = 0;
-	if(CheckAble)
+	if(Checkable)
 	{
 		TextRender()->SetRenderFlags(ETextRenderFlags::TEXT_RENDER_FLAG_ONLY_ADVANCE_WIDTH | ETextRenderFlags::TEXT_RENDER_FLAG_NO_X_BEARING | ETextRenderFlags::TEXT_RENDER_FLAG_NO_Y_BEARING | ETextRenderFlags::TEXT_RENDER_FLAG_NO_OVERSIZE | ETextRenderFlags::TEXT_RENDER_FLAG_NO_PIXEL_ALIGMENT);
 		TextRender()->SetCurFont(TextRender()->GetFont(TEXT_FONT_ICON_FONT));

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -487,7 +487,7 @@ int CMenus::DoValueSelector(void *pID, CUIRect *pRect, const char *pLabel, bool 
 	static float s_Value;
 	static char s_NumStr[64];
 	static void *s_LastTextpID = pID;
-	int Inside = UI()->MouseInside(pRect);
+	const bool Inside = UI()->MouseInside(pRect);
 
 	if(Inside)
 		UI()->SetHotItem(pID);
@@ -608,7 +608,7 @@ int CMenus::DoKeyReader(void *pID, const CUIRect *pRect, int Key, int ModifierCo
 	static void *pGrabbedID = 0;
 	static bool MouseReleased = true;
 	static int ButtonUsed = 0;
-	int Inside = UI()->MouseInside(pRect);
+	const bool Inside = UI()->MouseInside(pRect);
 	int NewKey = Key;
 	*NewModifierCombination = ModifierCombination;
 

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -607,7 +607,7 @@ int CMenus::DoKeyReader(void *pID, const CUIRect *pRect, int Key, int ModifierCo
 	static void *pGrabbedID = 0;
 	static bool MouseReleased = true;
 	static int s_ButtonUsed = 0;
-	const bool Inside = UI()->MouseInside(pRect);
+	const bool Inside = UI()->MouseHovered(pRect);
 	int NewKey = Key;
 	*NewModifierCombination = ModifierCombination;
 

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -234,7 +234,7 @@ void CMenus::DoButton_KeySelect(const void *pID, const char *pText, int Checked,
 
 int CMenus::DoButton_MenuTab(const void *pID, const char *pText, int Checked, const CUIRect *pRect, int Corners, SUIAnimator *pAnimator, const ColorRGBA *pDefaultColor, const ColorRGBA *pActiveColor, const ColorRGBA *pHoverColor, float EdgeRounding, int AlignVertically)
 {
-	bool MouseInside = UI()->MouseInside(pRect);
+	const bool MouseInside = UI()->MouseInside(pRect);
 	CUIRect Rect = *pRect;
 
 	if(pAnimator != NULL)
@@ -272,7 +272,7 @@ int CMenus::DoButton_MenuTab(const void *pID, const char *pText, int Checked, co
 	}
 	else
 	{
-		if(UI()->MouseInside(pRect))
+		if(MouseInside)
 		{
 			ColorRGBA HoverColorMenuTab = ms_ColorTabbarHover;
 			if(pHoverColor)

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -97,7 +97,7 @@ class CMenus : public CComponent
 	void DoButton_KeySelect(const void *pID, const char *pText, int Checked, const CUIRect *pRect);
 	int DoKeyReader(void *pID, const CUIRect *pRect, int Key, int ModifierCombination, int *NewModifierCombination);
 
-	void UiDoGetButtons(int Start, int Stop, CUIRect View, CUIRect ScopeView);
+	void DoSettingsControlsButtons(int Start, int Stop, CUIRect View, CUIRect ScopeView);
 
 	void RenderColorPicker();
 

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -245,7 +245,6 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 		const CServerInfo *pItem = ServerBrowser()->SortedGet(ItemIndex);
 		NumPlayers += pItem->m_NumFilteredPlayers;
 		CUIRect Row;
-		CUIRect SelectHitBox;
 
 		const int UIRectCount = 2 + (COL_VERSION + 1) * 3;
 		//initialize
@@ -257,7 +256,6 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 		int Selected = str_comp(pItem->m_aAddress, g_Config.m_UiServerAddress) == 0; //selected_index==ItemIndex;
 
 		View.HSplitTop(ms_ListheaderHeight, &Row, &View);
-		SelectHitBox = Row;
 
 		if(Selected)
 			m_SelectedIndex = i;
@@ -295,23 +293,14 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 				RenderTools()->DrawUIElRect(*pItem->m_pUIElement->Get(0), &r, ColorRGBA(1, 1, 1, 0.5f), CUI::CORNER_ALL, 4.0f);
 			}
 
-			// clip the selection
-			if(SelectHitBox.y < OriginalView.y) // top
-			{
-				SelectHitBox.h -= OriginalView.y - SelectHitBox.y;
-				SelectHitBox.y = OriginalView.y;
-			}
-			else if(SelectHitBox.y + SelectHitBox.h > OriginalView.y + OriginalView.h) // bottom
-				SelectHitBox.h = OriginalView.y + OriginalView.h - SelectHitBox.y;
-
-			if(!Selected && UI()->MouseInside(&SelectHitBox))
+			if(!Selected && UI()->MouseHovered(&Row))
 			{
 				CUIRect r = Row;
 				r.Margin(0.5f, &r);
 				RenderTools()->DrawUIElRect(*pItem->m_pUIElement->Get(1), &r, ColorRGBA(1, 1, 1, 0.25f), CUI::CORNER_ALL, 4.0f);
 			}
 
-			if(UI()->DoButtonLogic(pItem, "", Selected, &SelectHitBox))
+			if(UI()->DoButtonLogic(pItem, "", Selected, &Row))
 			{
 				NewSelected = ItemIndex;
 				if(NewSelected == m_DoubleClickIndex)

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -326,7 +326,7 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 		UI()->DoLabel(&SeekBar, aBuffer, SeekBar.h * 0.70f, TEXTALIGN_CENTER);
 
 		// do the logic
-		int Inside = UI()->MouseInside(&SeekBar);
+		const bool Inside = UI()->MouseInside(&SeekBar);
 
 		if(UI()->ActiveItem() == id)
 		{

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -1101,10 +1101,7 @@ void CMenus::RenderDemoList(CUIRect MainView)
 		ItemIndex++;
 
 		CUIRect Row;
-		CUIRect SelectHitBox;
-
 		ListBox.HSplitTop(ms_ListheaderHeight, &Row, &ListBox);
-		SelectHitBox = Row;
 
 		int Selected = ItemIndex == m_DemolistSelectedIndex;
 
@@ -1117,23 +1114,14 @@ void CMenus::RenderDemoList(CUIRect MainView)
 				Rect.Margin(0.5f, &Rect);
 				RenderTools()->DrawUIRect(&Rect, ColorRGBA(1, 1, 1, 0.5f), CUI::CORNER_ALL, 4.0f);
 			}
-			else if(UI()->MouseInside(&SelectHitBox))
+			else if(UI()->MouseHovered(&Row))
 			{
 				CUIRect Rect = Row;
 				Rect.Margin(0.5f, &Rect);
 				RenderTools()->DrawUIRect(&Rect, ColorRGBA(1, 1, 1, 0.25f), CUI::CORNER_ALL, 4.0f);
 			}
 
-			// clip the selection
-			if(SelectHitBox.y < OriginalView.y) // top
-			{
-				SelectHitBox.h -= OriginalView.y - SelectHitBox.y;
-				SelectHitBox.y = OriginalView.y;
-			}
-			else if(SelectHitBox.y + SelectHitBox.h > OriginalView.y + OriginalView.h) // bottom
-				SelectHitBox.h = OriginalView.y + OriginalView.h - SelectHitBox.y;
-
-			if(UI()->DoButtonLogic(r.front().m_aName /* TODO: */, "", Selected, &SelectHitBox))
+			if(UI()->DoButtonLogic(r.front().m_aName /* TODO: */, "", Selected, &Row))
 			{
 				DoubleClicked |= ItemIndex == m_DoubleClickIndex;
 				str_copy(g_Config.m_UiDemoSelected, r.front().m_aName, sizeof(g_Config.m_UiDemoSelected));

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -1062,10 +1062,7 @@ void CMenus::RenderGhost(CUIRect MainView)
 	{
 		const CGhostItem *pItem = &m_lGhosts[i];
 		CUIRect Row;
-		CUIRect SelectHitBox;
-
 		View.HSplitTop(17.0f, &Row, &View);
-		SelectHitBox = Row;
 
 		// make sure that only those in view can be selected
 		if(Row.y + Row.h > OriginalView.y && Row.y < OriginalView.y + OriginalView.h)
@@ -1077,16 +1074,7 @@ void CMenus::RenderGhost(CUIRect MainView)
 				RenderTools()->DrawUIRect(&r, ColorRGBA(1, 1, 1, 0.5f), CUI::CORNER_ALL, 4.0f);
 			}
 
-			// clip the selection
-			if(SelectHitBox.y < OriginalView.y) // top
-			{
-				SelectHitBox.h -= OriginalView.y - SelectHitBox.y;
-				SelectHitBox.y = OriginalView.y;
-			}
-			else if(SelectHitBox.y + SelectHitBox.h > OriginalView.y + OriginalView.h) // bottom
-				SelectHitBox.h = OriginalView.y + OriginalView.h - SelectHitBox.y;
-
-			if(UI()->DoButtonLogic(pItem, "", 0, &SelectHitBox))
+			if(UI()->DoButtonLogic(pItem, "", 0, &Row))
 			{
 				NewSelected = i;
 				DoubleClicked |= NewSelected == m_DoubleClickIndex;

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -939,21 +939,18 @@ void CMenus::DoSettingsControlsButtons(int Start, int Stop, CUIRect View, CUIRec
 		View.HSplitTop(20.0f, &Button, &View);
 		Button.VSplitLeft(135.0f, &Label, &Button);
 
-		if(Button.y >= ScopeView.y && Button.y + Button.h <= ScopeView.y + ScopeView.h)
-		{
-			char aBuf[64];
-			str_format(aBuf, sizeof(aBuf), "%s:", Localize((const char *)Key.m_Name));
+		char aBuf[64];
+		str_format(aBuf, sizeof(aBuf), "%s:", Localize((const char *)Key.m_Name));
 
-			UI()->DoLabelScaled(&Label, aBuf, 13.0f, TEXTALIGN_LEFT);
-			int OldId = Key.m_KeyId, OldModifierCombination = Key.m_ModifierCombination, NewModifierCombination;
-			int NewId = DoKeyReader((void *)&Key.m_Name, &Button, OldId, OldModifierCombination, &NewModifierCombination);
-			if(NewId != OldId || NewModifierCombination != OldModifierCombination)
-			{
-				if(OldId != 0 || NewId == 0)
-					m_pClient->m_Binds.Bind(OldId, "", false, OldModifierCombination);
-				if(NewId != 0)
-					m_pClient->m_Binds.Bind(NewId, gs_aKeys[i].m_pCommand, false, NewModifierCombination);
-			}
+		UI()->DoLabelScaled(&Label, aBuf, 13.0f, TEXTALIGN_LEFT);
+		int OldId = Key.m_KeyId, OldModifierCombination = Key.m_ModifierCombination, NewModifierCombination;
+		int NewId = DoKeyReader((void *)&Key.m_Name, &Button, OldId, OldModifierCombination, &NewModifierCombination);
+		if(NewId != OldId || NewModifierCombination != OldModifierCombination)
+		{
+			if(OldId != 0 || NewId == 0)
+				m_pClient->m_Binds.Bind(OldId, "", false, OldModifierCombination);
+			if(NewId != 0)
+				m_pClient->m_Binds.Bind(NewId, gs_aKeys[i].m_pCommand, false, NewModifierCombination);
 		}
 
 		View.HSplitTop(2.0f, 0, &View);

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -930,7 +930,7 @@ static CKeyInfo gs_aKeys[] =
 	Localize("Lock team");Localize("Show entities");Localize("Show HUD");Localize("Chat command");
 */
 
-void CMenus::UiDoGetButtons(int Start, int Stop, CUIRect View, CUIRect ScopeView)
+void CMenus::DoSettingsControlsButtons(int Start, int Stop, CUIRect View, CUIRect ScopeView)
 {
 	for(int i = Start; i < Stop; i++)
 	{
@@ -1035,7 +1035,7 @@ void CMenus::RenderSettingsControls(CUIRect MainView)
 			MovementSettings.HSplitTop(20.0f, 0, &MovementSettings);
 		}
 
-		UiDoGetButtons(0, 15, MovementSettings, MainView);
+		DoSettingsControlsButtons(0, 15, MovementSettings, MainView);
 	}
 
 	// weapon settings
@@ -1048,7 +1048,7 @@ void CMenus::RenderSettingsControls(CUIRect MainView)
 		TextRender()->Text(0, WeaponSettings.x, WeaponSettings.y + (14.0f + 5.0f + 10.0f - 14.0f * UI()->Scale()) / 2.f, 14.0f * UI()->Scale(), Localize("Weapon"), -1.0f);
 
 		WeaponSettings.HSplitTop(14.0f + 5.0f + 10.0f, 0, &WeaponSettings);
-		UiDoGetButtons(15, 22, WeaponSettings, MainView);
+		DoSettingsControlsButtons(15, 22, WeaponSettings, MainView);
 	}
 
 	// defaults
@@ -1074,7 +1074,7 @@ void CMenus::RenderSettingsControls(CUIRect MainView)
 		TextRender()->Text(0, VotingSettings.x, VotingSettings.y + (14.0f + 5.0f + 10.0f - 14.0f * UI()->Scale()) / 2.f, 14.0f * UI()->Scale(), Localize("Voting"), -1.0f);
 
 		VotingSettings.HSplitTop(14.0f + 5.0f + 10.0f, 0, &VotingSettings);
-		UiDoGetButtons(22, 24, VotingSettings, MainView);
+		DoSettingsControlsButtons(22, 24, VotingSettings, MainView);
 	}
 
 	// chat settings
@@ -1087,7 +1087,7 @@ void CMenus::RenderSettingsControls(CUIRect MainView)
 		TextRender()->Text(0, ChatSettings.x, ChatSettings.y + (14.0f + 5.0f + 10.0f - 14.0f * UI()->Scale()) / 2.f, 14.0f * UI()->Scale(), Localize("Chat"), -1.0f);
 
 		ChatSettings.HSplitTop(14.0f + 5.0f + 10.0f, 0, &ChatSettings);
-		UiDoGetButtons(24, 29, ChatSettings, MainView);
+		DoSettingsControlsButtons(24, 29, ChatSettings, MainView);
 	}
 
 	// dummy settings
@@ -1100,7 +1100,7 @@ void CMenus::RenderSettingsControls(CUIRect MainView)
 		TextRender()->Text(0, DummySettings.x, DummySettings.y + (14.0f + 5.0f + 10.0f - 14.0f * UI()->Scale()) / 2.f, 14.0f * UI()->Scale(), Localize("Dummy"), -1.0f);
 
 		DummySettings.HSplitTop(14.0f + 5.0f + 10.0f, 0, &DummySettings);
-		UiDoGetButtons(29, 32, DummySettings, MainView);
+		DoSettingsControlsButtons(29, 32, DummySettings, MainView);
 	}
 
 	// misc settings
@@ -1113,7 +1113,7 @@ void CMenus::RenderSettingsControls(CUIRect MainView)
 		TextRender()->Text(0, MiscSettings.x, MiscSettings.y + (14.0f + 5.0f + 10.0f - 14.0f * UI()->Scale()) / 2.f, 14.0f * UI()->Scale(), Localize("Miscellaneous"), -1.0f);
 
 		MiscSettings.HSplitTop(14.0f + 5.0f + 10.0f, 0, &MiscSettings);
-		UiDoGetButtons(32, 44, MiscSettings, MainView);
+		DoSettingsControlsButtons(32, 44, MiscSettings, MainView);
 	}
 
 	UiDoListboxEnd(&s_ScrollValue, 0);

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -434,7 +434,7 @@ int CUI::DoButtonLogic(const void *pID, int Checked, const CUIRect *pRect)
 {
 	// logic
 	int ReturnValue = 0;
-	const bool Inside = MouseInside(pRect);
+	const bool Inside = MouseHovered(pRect);
 	static int s_ButtonUsed = 0;
 
 	if(ActiveItem() == pID)

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -434,7 +434,7 @@ int CUI::DoButtonLogic(const void *pID, int Checked, const CUIRect *pRect)
 {
 	// logic
 	int ReturnValue = 0;
-	int Inside = MouseInside(pRect);
+	const bool Inside = MouseInside(pRect);
 	static int ButtonUsed = 0;
 
 	if(ActiveItem() == pID)
@@ -466,7 +466,7 @@ int CUI::DoButtonLogic(const void *pID, int Checked, const CUIRect *pRect)
 
 int CUI::DoPickerLogic(const void *pID, const CUIRect *pRect, float *pX, float *pY)
 {
-	int Inside = MouseInside(pRect);
+	const bool Inside = MouseInside(pRect);
 
 	if(Inside)
 		SetHotItem(pID);

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -435,14 +435,14 @@ int CUI::DoButtonLogic(const void *pID, int Checked, const CUIRect *pRect)
 	// logic
 	int ReturnValue = 0;
 	const bool Inside = MouseInside(pRect);
-	static int ButtonUsed = 0;
+	static int s_ButtonUsed = 0;
 
 	if(ActiveItem() == pID)
 	{
-		if(!MouseButton(ButtonUsed))
+		if(!MouseButton(s_ButtonUsed))
 		{
 			if(Inside && Checked >= 0)
-				ReturnValue = 1 + ButtonUsed;
+				ReturnValue = 1 + s_ButtonUsed;
 			SetActiveItem(0);
 		}
 	}
@@ -453,7 +453,7 @@ int CUI::DoButtonLogic(const void *pID, int Checked, const CUIRect *pRect)
 			if(MouseButton(i))
 			{
 				SetActiveItem(pID);
-				ButtonUsed = i;
+				s_ButtonUsed = i;
 			}
 		}
 	}

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -466,9 +466,7 @@ int CUI::DoButtonLogic(const void *pID, int Checked, const CUIRect *pRect)
 
 int CUI::DoPickerLogic(const void *pID, const CUIRect *pRect, float *pX, float *pY)
 {
-	const bool Inside = MouseInside(pRect);
-
-	if(Inside)
+	if(MouseHovered(pRect))
 		SetHotItem(pID);
 
 	if(HotItem() == pID && MouseButtonClicked(0))

--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -202,6 +202,10 @@ class CUI
 	unsigned m_LastMouseButtons;
 
 	CUIRect m_Screen;
+
+	std::vector<CUIRect> m_Clips;
+	void UpdateClipping();
+
 	class IGraphics *m_pGraphics;
 	class ITextRender *m_pTextRender;
 
@@ -281,8 +285,11 @@ public:
 	CUIRect *Screen();
 	void MapScreen();
 	float PixelSize();
+
 	void ClipEnable(const CUIRect *pRect);
 	void ClipDisable();
+	const CUIRect *ClipArea() const;
+	inline bool IsClipped() const { return !m_Clips.empty(); }
 
 	// TODO: Refactor: Redo UI scaling
 	void SetScale(float s);

--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -275,6 +275,8 @@ public:
 	const void *LastActiveItem() const { return m_pLastActiveItem; }
 
 	bool MouseInside(const CUIRect *pRect) const;
+	bool MouseInsideClip() const { return !IsClipped() || MouseInside(ClipArea()); }
+	bool MouseHovered(const CUIRect *pRect) const { return MouseInside(pRect) && MouseInsideClip(); }
 	void ConvertMouseMove(float *x, float *y) const;
 
 	float ButtonColorMulActive() { return 0.5f; }

--- a/src/game/client/ui_ex.cpp
+++ b/src/game/client/ui_ex.cpp
@@ -57,8 +57,8 @@ float CUIEx::DoScrollbarV(const void *pID, const CUIRect *pRect, float Current)
 
 	// logic
 	static float s_OffsetY;
-	const bool InsideRail = UI()->MouseInside(&Rail);
-	const bool InsideHandle = UI()->MouseInside(&Handle);
+	const bool InsideRail = UI()->MouseHovered(&Rail);
+	const bool InsideHandle = UI()->MouseHovered(&Handle);
 	bool Grabbed = false; // whether to apply the offset
 
 	if(UI()->ActiveItem() == pID)
@@ -137,8 +137,8 @@ float CUIEx::DoScrollbarH(const void *pID, const CUIRect *pRect, float Current, 
 
 	// logic
 	static float s_OffsetX;
-	const bool InsideRail = UI()->MouseInside(&Rail);
-	const bool InsideHandle = UI()->MouseInside(&Handle);
+	const bool InsideRail = UI()->MouseHovered(&Rail);
+	const bool InsideHandle = UI()->MouseHovered(&Handle);
 	bool Grabbed = false; // whether to apply the offset
 
 	if(UI()->ActiveItem() == pID)
@@ -214,7 +214,7 @@ float CUIEx::DoScrollbarH(const void *pID, const CUIRect *pRect, float Current, 
 
 bool CUIEx::DoEditBox(const void *pID, const CUIRect *pRect, char *pStr, unsigned StrSize, float FontSize, float *pOffset, bool Hidden, int Corners, const SUIExEditBoxProperties &Properties)
 {
-	const bool Inside = UI()->MouseInside(pRect);
+	const bool Inside = UI()->MouseHovered(pRect);
 	bool ReturnValue = false;
 	bool UpdateOffset = false;
 

--- a/src/game/client/ui_ex.cpp
+++ b/src/game/client/ui_ex.cpp
@@ -214,7 +214,7 @@ float CUIEx::DoScrollbarH(const void *pID, const CUIRect *pRect, float Current, 
 
 bool CUIEx::DoEditBox(const void *pID, const CUIRect *pRect, char *pStr, unsigned StrSize, float FontSize, float *pOffset, bool Hidden, int Corners, const SUIExEditBoxProperties &Properties)
 {
-	int Inside = UI()->MouseInside(pRect);
+	const bool Inside = UI()->MouseInside(pRect);
 	bool ReturnValue = false;
 	bool UpdateOffset = false;
 

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -528,7 +528,7 @@ int CEditor::UiDoValueSelector(void *pID, CUIRect *pRect, const char *pLabel, in
 	static char s_aNumStr[64];
 	static bool s_TextMode = false;
 	static void *s_LastTextpID = pID;
-	int Inside = UI()->MouseInside(pRect);
+	const bool Inside = UI()->MouseInside(pRect);
 
 	if(UI()->MouseButton(1) && UI()->HotItem() == pID)
 	{
@@ -2326,7 +2326,7 @@ void CEditor::DoMapEditor(CUIRect View)
 	}
 
 	static void *s_pEditorID = (void *)&s_pEditorID;
-	int Inside = UI()->MouseInside(&View);
+	const bool Inside = UI()->MouseInside(&View);
 
 	// fetch mouse position
 	float wx = UI()->MouseWorldX();


### PR DESCRIPTION
Various CUI refactorings adapted from upstream:

- Support nesting CUI clipping/scrolling regions.
- Add `CUI::MouseHovered` which works like `MouseInside` and also ensures that the position is not clipped.
  - This is used to refactor all scrolling lists, removing duplicate code that manually intersects the clipping rectangle.
  - It's also used to make clipping of the key reader buttons in the controls settings list smoother, as the buttons were previously not rendered at all when clipped.
  - Nesting other common UI elements (editboxes, pickers, scrollbars) in clipping regions is also possible now.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
