### PR TITLE
Enhance teehistorian test output a bit

### DIFF
--- a/src/test/teehistorian.cpp
+++ b/src/test/teehistorian.cpp
@@ -155,13 +155,10 @@ protected:
 					Start = i + 1;
 				continue;
 			}
-			if(Start + i != 0)
-			{
-				if((Start + i) % 10 == 0)
-					printf("\n\t");
-				else
-					printf(", ");
-			}
+			if((i - Start) % 10 == 0)
+				printf("\n\t");
+			else
+				printf(", ");
 			printf("0x%.2x", m_Buffer.Data()[i]);
 		}
 		printf("\n}\n");


### PR DESCRIPTION
Looks cleaner now, e.g. for TeamPractice:

```
[ RUN      ] TeeHistorian.TeamPractice
pOutput = {
	0x41, 0x00, 0x4a, 0x57, 0x92, 0x83, 0x4e, 0x81, 0xd1, 0x34
	0xc9, 0xa2, 0x9b, 0xb5, 0xff, 0x25, 0xda, 0xc3, 0xbc, 0x02
	0x17, 0x01, 0x41, 0x00, 0x4a, 0x57, 0x92, 0x83, 0x4e, 0x81
	0xd1, 0x34, 0xc9, 0xa2, 0x9b, 0xb5, 0xff, 0x25, 0xda, 0xc3
	0xbc, 0x02, 0x01, 0x01, 0x4a, 0x57, 0x92, 0x83, 0x4e, 0x81
	0xd1, 0x34, 0xc9, 0xa2, 0x9b, 0xb5, 0xff, 0x25, 0xda, 0xc3
	0xbc, 0x02, 0x17, 0x00, 0x40
}
[       OK ] TeeHistorian.TeamPractice (0 ms)
```

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
