### PR TITLE
Fix dummy intended tick sent to server

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -571,7 +571,7 @@ void CClient::SendInput()
 			// pack input
 			CMsgPacker Msg(NETMSG_INPUT, true);
 			Msg.AddInt(m_AckGameTick[i]);
-			Msg.AddInt(m_PredTick[i]);
+			Msg.AddInt(m_PredTick[g_Config.m_ClDummy]);
 			Msg.AddInt(Size);
 
 			m_aInputs[i][m_CurrentInput[i]].m_Tick = m_PredTick[g_Config.m_ClDummy];


### PR DESCRIPTION
fixes https://github.com/ddnet/ddnet/issues/5044

Currently the dummy gives the server the wrong IntendedTick aka PredTick which (I think) makes it impossible for the server to correctly order inputs if they come early (i.e. if you're playing with high prediction margin).

Currently with dummy copy if you switch dummy with high prediction margin it will almost always desync, with this change it doesn't desync. 

The only reason dummy works at all is because it relies on this code in the server to change the tick that was sent to be the current game tick, if you remove it then dummy hammer and dummy copy breaks but normal players are unaffected.

https://github.com/ddnet/ddnet/blob/e9b59e72ffbd84d4edee82f5cae83352e3142b98/src/engine/server/server.cpp#L1632-L1633 

I marked this PR as draft because it seems to cause some unexpected side effects:

with this change if you use dummy copy in solo part your dummy will be visually delayed, this doesn't change anything but it's different from how it was before and I don't understand why. 

the sound effects from hooking with dummy copy are also not as synced as they are with the wrong tick being sent (not sure why) 

I also didn't test all dummy mechanics or any advanced dummy binds which might somehow rely on the broken behavior. 


With wrong tick sent to server:

https://user-images.githubusercontent.com/22122579/168413464-92a3a44b-3b75-4894-8fb0-54e64ff421fa.mp4

With correct tick:

https://user-images.githubusercontent.com/22122579/168413459-eb6f299c-260a-4ddb-9972-3dea504aef41.mp4






## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
