### PR TITLE
Only print zone messages when there is one

### DIFF
--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -2010,7 +2010,7 @@ void CCharacter::SendZoneMsgs()
 {
 	// send zone leave msg
 	// (m_TuneZoneOld >= 0: avoid zone leave msgs on spawn)
-	if(m_TuneZoneOld >= 0 && GameServer()->m_aaZoneLeaveMsg[m_TuneZoneOld])
+	if(m_TuneZoneOld >= 0 && GameServer()->m_aaZoneLeaveMsg[m_TuneZoneOld][0])
 	{
 		const char *pCur = GameServer()->m_aaZoneLeaveMsg[m_TuneZoneOld];
 		const char *pPos;
@@ -2025,7 +2025,7 @@ void CCharacter::SendZoneMsgs()
 		GameServer()->SendChatTarget(m_pPlayer->GetCID(), pCur);
 	}
 	// send zone enter msg
-	if(GameServer()->m_aaZoneEnterMsg[m_TuneZone])
+	if(GameServer()->m_aaZoneEnterMsg[m_TuneZone][0])
 	{
 		const char *pCur = GameServer()->m_aaZoneEnterMsg[m_TuneZone];
 		const char *pPos;


### PR DESCRIPTION
```
src/game/server/entities/character.cpp: In member function ‘void CCharacter::SendZoneMsgs()’:
src/game/server/entities/character.cpp:2013:78: warning: the address of ‘CGameContext::m_aaZoneLeaveMsg’ will never be NULL [-Waddress]
 2013 |         if(m_TuneZoneOld >= 0 && GameServer()->m_aaZoneLeaveMsg[m_TuneZoneOld])
      |                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
In file included from src/game/server/entities/character.cpp:7:
src/game/server/gamecontext.h:179:14: note: ‘CGameContext::m_aaZoneLeaveMsg’ declared here
  179 |         char m_aaZoneLeaveMsg[NUM_TUNEZONES][256];
      |              ^~~~~~~~~~~~~~~~
src/game/server/entities/character.cpp:2028:53: warning: the address of ‘CGameContext::m_aaZoneEnterMsg’ will never be NULL [-Waddress]
 2028 |         if(GameServer()->m_aaZoneEnterMsg[m_TuneZone])
      |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
src/game/server/gamecontext.h:178:14: note: ‘CGameContext::m_aaZoneEnterMsg’ declared here
  178 |         char m_aaZoneEnterMsg[NUM_TUNEZONES][256]; // 0 is used for switching from or to area without tunings
      |              ^~~~~~~~~~~~~~~~
```
<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
