### PR TITLE
Assert client id in SetSolo

### DIFF
--- a/src/game/teamscore.h
+++ b/src/game/teamscore.h
@@ -42,6 +42,7 @@ public:
 	void Reset();
 	void SetSolo(int ClientID, bool Value)
 	{
+		dbg_assert(ClientID >= 0 && ClientID < MAX_CLIENTS, "Invalid client id");
 		m_IsSolo[ClientID] = Value;
 	}
 


### PR DESCRIPTION
I could not find a way that an invalid client ID is used here, but
compiler warns anyway:
```
In member function ‘void CTeamsCore::SetSolo(int, bool)’,
    inlined from ‘void CCharacter::SetSolo(bool)’ at src/game/client/prediction/entities/character.cpp:29:22,
    inlined from ‘void CCharacter::HandleTiles(int)’ at src/game/client/prediction/entities/character.cpp:882:10:
src/game/teamscore.h:45:34: warning: array subscript [0, 63] is outside array bounds of ‘bool [64]’ [-Warray-bounds]
   45 |                 m_IsSolo[ClientID] = Value;
      |                 ~~~~~~~~~~~~~~~~~^
src/game/teamscore.h: In member function ‘void CCharacter::HandleTiles(int)’:
src/game/teamscore.h:27:14: note: while referencing ‘CTeamsCore::m_IsSolo’
   27 |         bool m_IsSolo[MAX_CLIENTS];
      |              ^~~~~~~~
```
<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
