### PR TITLE
Move create/destroy window ntf dbg_msg to log_debug

### DIFF
--- a/src/engine/client/backend/vulkan/backend_vulkan.cpp
+++ b/src/engine/client/backend/vulkan/backend_vulkan.cpp
@@ -10,6 +10,7 @@
 #include <engine/shared/image_manipulation.h>
 #include <engine/storage.h>
 
+#include <base/log.h>
 #include <base/math.h>
 #include <base/system.h>
 
@@ -7148,7 +7149,7 @@ public:
 
 	void Cmd_WindowCreateNtf(const CCommandBuffer::SCommand_WindowCreateNtf *pCommand)
 	{
-		dbg_msg("vulkan", "creating new surface.");
+		log_debug("vulkan", "creating new surface.");
 		m_pWindow = SDL_GetWindowFromID(pCommand->m_WindowID);
 		if(m_RenderingPaused)
 		{
@@ -7164,7 +7165,7 @@ public:
 
 	void Cmd_WindowDestroyNtf(const CCommandBuffer::SCommand_WindowDestroyNtf *pCommand)
 	{
-		dbg_msg("vulkan", "surface got destroyed.");
+		log_debug("vulkan", "surface got destroyed.");
 		if(!m_RenderingPaused)
 		{
 			WaitFrame();


### PR DESCRIPTION
Most messages in the backend are warnings.
At least these two are send every time you minimize/maximize the window, so kinda annoying 


## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
