### PR TITLE
Don't reset rcon password on "Reset server" (fixes #5113)

### DIFF
--- a/data/autoexec_server.cfg
+++ b/data/autoexec_server.cfg
@@ -24,7 +24,7 @@ password ""
 
 # rcon (F2) passwords for admin. If you don't set one, a random one will be
 # created and shown in the terminal window of the server.
-sv_rcon_password ""
+#sv_rcon_password ""
 
 # rcon (F2) password for moderator. If you don't set one, none exists.
 sv_rcon_mod_password ""


### PR DESCRIPTION
Since it clears out the randomly generated password

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
