### PR TITLE
Add basic driver version parsing for Vulkan

### DIFF
--- a/src/engine/client/backend/vulkan/backend_vulkan.cpp
+++ b/src/engine/client/backend/vulkan/backend_vulkan.cpp
@@ -3521,6 +3521,41 @@ public:
 		return STWGraphicGPU::ETWGraphicsGPUType::GRAPHICS_GPU_TYPE_CPU;
 	}
 
+	// from: https://github.com/SaschaWillems/vulkan.gpuinfo.org/blob/5c3986798afc39d736b825bf8a5fbf92b8d9ed49/includes/functions.php#L364
+	const char *GetDriverVerson(char (&aBuff)[256], uint32_t DriverVersion, uint32_t VendorID)
+	{
+		// NVIDIA
+		if(VendorID == 4318)
+		{
+			str_format(aBuff, std::size(aBuff), "%d.%d.%d.%d",
+				(DriverVersion >> 22) & 0x3ff,
+				(DriverVersion >> 14) & 0x0ff,
+				(DriverVersion >> 6) & 0x0ff,
+				(DriverVersion)&0x003f);
+		}
+#ifdef CONF_FAMILY_WINDOWS
+		// windows only
+		else if(VendorID == 0x8086)
+		{
+			str_format(aBuff, std::size(aBuff),
+				"%d.%d",
+				(DriverVersion >> 14),
+				(DriverVersion)&0x3fff);
+		}
+#endif
+		else
+		{
+			// Use Vulkan version conventions if vendor mapping is not available
+			str_format(aBuff, std::size(aBuff),
+				"%d.%d.%d",
+				(DriverVersion >> 22),
+				(DriverVersion >> 12) & 0x3ff,
+				DriverVersion & 0xfff);
+		}
+
+		return aBuff;
+	}
+
 	bool SelectGPU(char *pRendererName, char *pVendorName, char *pVersionName)
 	{
 		uint32_t DevicesCount = 0;
@@ -3621,8 +3656,10 @@ public:
 				pVendorNameStr = "unknown";
 				break;
 			}
+
+			char aBuff[256];
 			str_copy(pVendorName, pVendorNameStr, gs_GPUInfoStringSize);
-			str_format(pVersionName, gs_GPUInfoStringSize, "Vulkan %d.%d.%d", DevAPIMajor, DevAPIMinor, DevAPIPatch);
+			str_format(pVersionName, gs_GPUInfoStringSize, "Vulkan %d.%d.%d (driver: %s)", DevAPIMajor, DevAPIMinor, DevAPIPatch, GetDriverVerson(aBuff, DeviceProp.driverVersion, DeviceProp.vendorID));
 
 			// get important device limits
 			m_NonCoherentMemAlignment = DeviceProp.limits.nonCoherentAtomSize;


### PR DESCRIPTION
From https://github.com/SaschaWillems/vulkan.gpuinfo.org/blob/5c3986798afc39d736b825bf8a5fbf92b8d9ed49/includes/functions.php#L364

I dunno how reliable that is, but https://gpuinfo.org is quite good, so probs reliable enough for our needs :D

Similar to how OpenGL also prints the driver version in the GL_VERSION string. Can be quite useful and is easier for the end user

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
