### PR TITLE
Fix IPO build problems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,19 +96,17 @@ endif()
 
 set(AUTO_DEPENDENCIES_DEFAULT OFF)
 
-if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+if(CMAKE_BUILD_TYPE STREQUAL "Debug" OR DEV)
   set(AUTO_IPO OFF)
-else()
-  set(AUTO_IPO ON)
-endif()
-
-if(MSVC)
+elseif(MSVC)
   # For some reason on MSVC platform the client and server binaries
   # become even bigger with IPO enabled.
   set(AUTO_IPO OFF)
 elseif(MINGW AND TARGET_CPU_ARCHITECTURE STREQUAL "x86")
   # DWARF error: could not find variable specification and further failures
   set(AUTO_IPO OFF)
+else()
+  set(AUTO_IPO ON)
 endif()
 
 set(AUTO_VULKAN_BACKEND ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,9 @@ if(MSVC)
   # For some reason on MSVC platform the client and server binaries
   # become even bigger with IPO enabled.
   set(AUTO_IPO OFF)
+elseif(MINGW AND TARGET_CPU_ARCHITECTURE STREQUAL "x86")
+  # DWARF error: could not find variable specification and further failures
+  set(AUTO_IPO OFF)
 endif()
 
 set(AUTO_VULKAN_BACKEND ON)
@@ -281,6 +284,7 @@ if(NOT MSVC AND NOT HAIKU)
   add_c_compiler_flag_if_supported(OUR_FLAGS_OWN -Wformat=2) # Warn about format strings.
   add_c_compiler_flag_if_supported(OUR_FLAGS_DEP -Wno-implicit-function-declaration)
   add_c_compiler_flag_if_supported(OUR_FLAGS_OWN -Wno-nullability-completeness) # Mac OS build on github
+  add_c_compiler_flag_if_supported(OUR_FLAGS_OWN -Wno-tautological-constant-out-of-range-compare) # Check needed for x86, but warns on x86-64
   add_c_compiler_flag_if_supported(OUR_FLAGS_OWN -Wduplicated-cond)
   add_c_compiler_flag_if_supported(OUR_FLAGS_OWN -Wduplicated-branches)
   add_c_compiler_flag_if_supported(OUR_FLAGS_OWN -Wlogical-op)

--- a/src/game/client/components/maplayers.cpp
+++ b/src/game/client/components/maplayers.cpp
@@ -302,15 +302,8 @@ bool CMapLayers::STileLayerVisuals::Init(unsigned int Width, unsigned int Height
 {
 	m_Width = Width;
 	m_Height = Height;
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wtautological-constant-out-of-range-compare"
-#endif
 	if(Width == 0 || Height == 0 || Width >= std::numeric_limits<std::ptrdiff_t>::max() || Height >= std::numeric_limits<std::ptrdiff_t>::max())
 		return false;
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
 
 	m_pTilesOfLayer = new CMapLayers::STileLayerVisuals::STileVisual[Height * Width];
 

--- a/src/game/client/components/maplayers.cpp
+++ b/src/game/client/components/maplayers.cpp
@@ -302,8 +302,15 @@ bool CMapLayers::STileLayerVisuals::Init(unsigned int Width, unsigned int Height
 {
 	m_Width = Width;
 	m_Height = Height;
-	if(Width == 0 || Height == 0)
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wtautological-constant-out-of-range-compare"
+#endif
+	if(Width == 0 || Height == 0 || Width >= std::numeric_limits<std::ptrdiff_t>::max() || Height >= std::numeric_limits<std::ptrdiff_t>::max())
 		return false;
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 
 	m_pTilesOfLayer = new CMapLayers::STileLayerVisuals::STileVisual[Height * Width];
 


### PR DESCRIPTION
@Kaffeine 

Windows x86-64 with MinGW worked, previously:
```
-rwxr-xr-x 1 deen deen 755K May 15 11:38 config_retrieve.exe*
-rwxr-xr-x 1 deen deen 756K May 15 11:38 config_store.exe*
-rwxr-xr-x 1 deen deen 2.8M May 15 11:38 DDNet.exe*
-rwxr-xr-x 1 deen deen 2.1M May 15 11:38 DDNet-Server.exe*
-rwxr-xr-x 1 deen deen 761K May 15 11:38 dilate.exe*
-rwxr-xr-x 1 deen deen 763K May 15 11:38 map_convert_07.exe*
-rwxr-xr-x 1 deen deen 756K May 15 11:38 map_diff.exe*
-rwxr-xr-x 1 deen deen 761K May 15 11:38 map_extract.exe*
```
Now:
```
-rwxr-xr-x 1 deen deen 256K May 16 00:26 config_retrieve.exe*
-rwxr-xr-x 1 deen deen 282K May 16 00:26 config_store.exe*
-rwxr-xr-x 1 deen deen 2.8M May 16 00:26 DDNet.exe*
-rwxr-xr-x 1 deen deen 2.0M May 16 00:26 DDNet-Server.exe*
-rwxr-xr-x 1 deen deen 271K May 16 00:26 dilate.exe*
-rwxr-xr-x 1 deen deen 289K May 16 00:26 map_convert_07.exe*
-rwxr-xr-x 1 deen deen 261K May 16 00:26 map_diff.exe*
-rwxr-xr-x 1 deen deen 278K May 16 00:26 map_extract.exe*
```

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
