### PR TITLE
Put assert for text containers after printing all non empty text cont…

### DIFF
--- a/src/engine/client/text.cpp
+++ b/src/engine/client/text.cpp
@@ -1904,14 +1904,17 @@ public:
 
 	void OnWindowResize() override
 	{
+		bool HasNonEmptyTextContainer = false;
 		for(auto *pTextContainer : m_TextContainers)
 		{
 			if(pTextContainer->m_StringInfo.m_QuadBufferContainerIndex != -1)
 			{
-				dbg_msg("textrender", "Found non empty text container with index %d", pTextContainer->m_StringInfo.m_QuadBufferContainerIndex);
-				dbg_assert(false, "text container was not empty");
+				dbg_msg("textrender", "Found non empty text container with index %d with %d quads", pTextContainer->m_StringInfo.m_QuadBufferContainerIndex, (int)pTextContainer->m_StringInfo.m_QuadNum);
+				HasNonEmptyTextContainer = true;
 			}
 		}
+
+		dbg_assert(!HasNonEmptyTextContainer, "text container was not empty");
 
 		for(auto &pFont : m_Fonts)
 		{


### PR DESCRIPTION
…ainers

No idea how to reproduce this, gerdoe also has this and send me his config, but no chance
Tho since the text container index is so high, i kinda assume its not the only non cleared text container.
Maybe estimating the character count based on the quads used can also help, since then i can see what text is potentially the cause

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
