### PR TITLE
Allocate console before creating logger, hide console later if necessary

### DIFF
--- a/src/base/log.cpp
+++ b/src/base/log.cpp
@@ -371,6 +371,9 @@ std::unique_ptr<ILogger> log_logger_stdout()
 	// https://github.com/termstandard/colors/tree/65bf0cd1ece7c15fa33a17c17528b02c99f1ae0b#checking-for-colorterm
 	return std::unique_ptr<ILogger>(new CLoggerAsync(io_stdout(), getenv("NO_COLOR") == nullptr, false));
 #else
+	if(GetFileType(GetStdHandle(STD_OUTPUT_HANDLE)) == FILE_TYPE_UNKNOWN)
+		if(!AttachConsole(ATTACH_PARENT_PROCESS))
+			AllocConsole();
 	HANDLE pOutput = GetStdHandle(STD_OUTPUT_HANDLE);
 	switch(GetFileType(pOutput))
 	{

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -4383,13 +4383,12 @@ int main(int argc, const char **argv)
 		{
 			Silent = true;
 		}
-		else if(str_comp("-c", argv[i]) == 0 || str_comp("--console", argv[i]) == 0)
-		{
-#if defined(CONF_FAMILY_WINDOWS)
-			AllocConsole();
-#endif
-		}
 	}
+
+#if defined(CONF_FAMILY_WINDOWS)
+	if(Silent)
+		FreeConsole();
+#endif
 
 #if defined(CONF_PLATFORM_ANDROID)
 	InitAndroid();
@@ -4514,12 +4513,14 @@ int main(int argc, const char **argv)
 #if defined(CONF_FAMILY_WINDOWS)
 	if(g_Config.m_ClShowConsole)
 	{
-		AllocConsole();
-		HANDLE hInput;
-		DWORD prev_mode;
-		hInput = GetStdHandle(STD_INPUT_HANDLE);
-		GetConsoleMode(hInput, &prev_mode);
-		SetConsoleMode(hInput, prev_mode & ENABLE_EXTENDED_FLAGS);
+		HANDLE hInput = GetStdHandle(STD_INPUT_HANDLE);
+		DWORD ConsoleMode;
+		if(GetConsoleMode(hInput, &ConsoleMode))
+			SetConsoleMode(hInput, ConsoleMode & ENABLE_EXTENDED_FLAGS);
+	}
+	else if(!Silent) // already freed earlier
+	{
+		FreeConsole();
 	}
 #endif
 


### PR DESCRIPTION
The issue is that all three types of loggers which are used on Windows are initialized only once in the beginning. Initially the `GetStdHandle(STD_OUTPUT_HANDLE)` will return an invalid handle, as no console has initially been created.

This causes the fallback `CLoggerAsync` to be used, but it is also initialized only once with `io_stdout()`, so it will not use the new console.

`AllocConsole` is later called to create a console (with `-c` or `--console` command line options or with config `cl_show_console 1`) but the handles of this console are not used.

A workaround is to create the console in the logger already and later destroy it if we don't need it.

This has the drawback of flashing the console window for a brief moment until the config is loaded to determine whether the console should be hidden.

The `-c` or `--console` command line options are removed, as the console will always be open initially. Instead `cl_show_console 1` can be passed as command line option to keep the console open. As before, `-s` or `--silent` can also be used to hide the console from the beginning.

The client will now also first try to attach itself to a parent console (when called from command line), so the client won't create a second console window when launched from the console.

Closes #5150.

More details: https://stackoverflow.com/questions/15952892/using-the-console-in-a-gui-app-in-windows-only-if-its-run-from-a-console/15955276#15955276

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
