### PR TITLE
Remove cl_show_console and -c / --console command line options, attach to existing console

### DIFF
--- a/src/base/log.cpp
+++ b/src/base/log.cpp
@@ -371,6 +371,8 @@ std::unique_ptr<ILogger> log_logger_stdout()
 	// https://github.com/termstandard/colors/tree/65bf0cd1ece7c15fa33a17c17528b02c99f1ae0b#checking-for-colorterm
 	return std::unique_ptr<ILogger>(new CLoggerAsync(io_stdout(), getenv("NO_COLOR") == nullptr, false));
 #else
+	if(GetFileType(GetStdHandle(STD_OUTPUT_HANDLE)) == FILE_TYPE_UNKNOWN)
+		AttachConsole(ATTACH_PARENT_PROCESS);
 	HANDLE pOutput = GetStdHandle(STD_OUTPUT_HANDLE);
 	switch(GetFileType(pOutput))
 	{

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -4383,12 +4383,6 @@ int main(int argc, const char **argv)
 		{
 			Silent = true;
 		}
-		else if(str_comp("-c", argv[i]) == 0 || str_comp("--console", argv[i]) == 0)
-		{
-#if defined(CONF_FAMILY_WINDOWS)
-			AllocConsole();
-#endif
-		}
 	}
 
 #if defined(CONF_PLATFORM_ANDROID)
@@ -4510,18 +4504,6 @@ int main(int argc, const char **argv)
 		io_close(File);
 		pConsole->ExecuteFile(CONFIG_FILE);
 	}
-
-#if defined(CONF_FAMILY_WINDOWS)
-	if(g_Config.m_ClShowConsole)
-	{
-		AllocConsole();
-		HANDLE hInput;
-		DWORD prev_mode;
-		hInput = GetStdHandle(STD_INPUT_HANDLE);
-		GetConsoleMode(hInput, &prev_mode);
-		SetConsoleMode(hInput, prev_mode & ENABLE_EXTENDED_FLAGS);
-	}
-#endif
 
 	// execute autoexec file
 	File = pStorage->OpenFile(AUTOEXEC_CLIENT_FILE, IOFLAG_READ, IStorage::TYPE_ALL);

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -397,9 +397,6 @@ MACRO_CONFIG_STR(ClTimeoutCode, cl_timeout_code, 64, "", CFGFLAG_SAVE | CFGFLAG_
 MACRO_CONFIG_STR(ClDummyTimeoutCode, cl_dummy_timeout_code, 64, "", CFGFLAG_SAVE | CFGFLAG_CLIENT, "Dummy Timeout code to use")
 MACRO_CONFIG_STR(ClTimeoutSeed, cl_timeout_seed, 64, "", CFGFLAG_SAVE | CFGFLAG_CLIENT, "Timeout seed")
 MACRO_CONFIG_STR(ClInputFifo, cl_input_fifo, 128, "", CFGFLAG_SAVE | CFGFLAG_CLIENT, "Fifo file to use as input for client console")
-#if defined(CONF_FAMILY_WINDOWS)
-MACRO_CONFIG_INT(ClShowConsole, cl_show_console, 0, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Show console window (Windows only)")
-#endif
 MACRO_CONFIG_INT(InpJoystick, inp_joystick, 0, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Try to use a joystick as input")
 MACRO_CONFIG_INT(ClConfigVersion, cl_config_version, 0, 0, 0, CFGFLAG_CLIENT | CFGFLAG_SAVE, "The config version. Helps newer clients fix bugs with older configs.")
 

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -75,11 +75,6 @@ bool CMenusKeyBinder::OnInput(IInput::CEvent Event)
 
 void CMenus::RenderSettingsGeneral(CUIRect MainView)
 {
-#if defined(CONF_FAMILY_WINDOWS)
-	bool CheckSettings = false;
-	static int s_ClShowConsole = g_Config.m_ClShowConsole;
-#endif
-
 	char aBuf[128 + IO_MAX_PATH_LENGTH];
 	CUIRect Label, Button, Left, Right, Game, Client;
 	MainView.HSplitTop(150.0f, &Game, &Client);
@@ -247,19 +242,6 @@ void CMenus::RenderSettingsGeneral(CUIRect MainView)
 		UI()->DoLabelScaled(&Label, aBuf, 13.0f, TEXTALIGN_LEFT);
 		Left.HSplitTop(20.0f, &Button, &Left);
 		g_Config.m_ClRefreshRate = static_cast<int>(UIEx()->DoScrollbarH(&g_Config.m_ClRefreshRate, &Button, g_Config.m_ClRefreshRate / 10000.0f) * 10000.0f + 0.1f);
-
-#if defined(CONF_FAMILY_WINDOWS)
-		Left.HSplitTop(10.0f, 0, &Left);
-		Left.HSplitTop(20.0f, &Button, &Left);
-		if(DoButton_CheckBox(&g_Config.m_ClShowConsole, Localize("Show console window"), g_Config.m_ClShowConsole, &Button))
-		{
-			g_Config.m_ClShowConsole ^= 1;
-			CheckSettings = true;
-		}
-
-		if(CheckSettings)
-			m_NeedRestartGeneral = s_ClShowConsole != g_Config.m_ClShowConsole;
-#endif
 
 		Left.HSplitTop(15.0f, 0, &Left);
 		CUIRect SettingsButton;


### PR DESCRIPTION
Alternative to #5154. 

Closes #5150.

If you want to open the client with a console window, instead create a new shortcut with the following target:

```
cmd /c "C:\path\to\your\DDNet.exe"
```

You can change the icon of the shortcut to the DDNet icon in the properties of the shortcut file.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
