### PR TITLE
revert to ground jump at the same tick

### DIFF
--- a/src/game/gamecore.cpp
+++ b/src/game/gamecore.cpp
@@ -154,14 +154,14 @@ void CCharacterCore::Tick(bool UseInput)
 		// m_Jumps == -1: A tee may only make one ground jump. Second jumped bit is always set
 		// m_Jumps == 0: A tee may not make a jump. Second jumped bit is always set
 		// m_Jumps == 1: A tee may do either a ground jump or an air jump. Second jumped bit is set after the first jump
-		// The second jump bit can be overridden by special tiles so that the tee can nevertheless jump.
+		// The second jumped bit can be overridden by special tiles so that the tee can nevertheless jump.
 
 		// handle jump
 		if(m_Input.m_Jump)
 		{
 			if(!(m_Jumped & 1))
 			{
-				if(Grounded && (!(m_Jumped & 2) || m_Jumps == -1))
+				if(Grounded && (!(m_Jumped & 2) || m_Jumps != 0))
 				{
 					m_TriggeredEvents |= COREEVENT_GROUND_JUMP;
 					m_Vel.y = -m_Tuning.m_GroundJumpImpulse;
@@ -215,7 +215,6 @@ void CCharacterCore::Tick(bool UseInput)
 	// 2 bit = to track if all air-jumps have been used up (tee gets dark feet)
 	if(Grounded)
 	{
-		// A tee must touch the ground for one tick before it can jump again.
 		m_Jumped &= ~2;
 		m_JumpedTotal = 0;
 	}


### PR DESCRIPTION
Sorry I did make a mistake in #5172  I tricked myself, the code block I moved back down below the jumping physic (where it original was):
https://github.com/ddnet/ddnet/blob/79f377b1338728de8cde936e0b10d0a1946a00b4/src/game/gamecore.cpp#L216-L221
did not prevent instant ground jump, i somehow thought wrong and maybe combined it wrong with my new condition.

i tested everything again with 15.9.1 (and 16.0.3) and looked at the old code and noticed that it was allowed to make a ground jump directly in the same tick as you have contact with the ground. Therefore I revert this herewith (by fixing the condition)

xD is really a tricky thing to make changes at the gamecore, and keeping everything as it should be
Sorry!!

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [x] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
