### PR TITLE
Optimize ellipsis calculation a bit

### DIFF
--- a/src/engine/client/text.cpp
+++ b/src/engine/client/text.cpp
@@ -1256,13 +1256,16 @@ public:
 							if((RenderFlags & TEXT_RENDER_FLAG_KERNING) != 0)
 								CharKerningEllipsis = Kerning(TextContainer.m_pFont, pChr->m_GlyphIndex, pEllipsisChr->m_GlyphIndex) * Scale * Size;
 
-							const int WidthOfRemainingText = CalculateTextWidth(pTmp, str_length(pTmp), 0, 100);
-							if(DrawX + CharKerning + Advance + WidthOfRemainingText - pCursor->m_StartX > pCursor->m_LineWidth && DrawX + CharKerning + Advance + CharKerningEllipsis + AdvanceEllipsis - pCursor->m_StartX > pCursor->m_LineWidth)
+							if(DrawX + CharKerning + Advance + CharKerningEllipsis + AdvanceEllipsis - pCursor->m_StartX > pCursor->m_LineWidth)
 							{
-								// we hit the end, only render ellipsis and finish
-								pTmp = pEllipsis;
-								NextCharacter = 0x2026;
-								continue;
+								const int WidthOfRemainingText = CalculateTextWidth(pTmp, str_length(pTmp), 0, 100);
+								if(DrawX + CharKerning + Advance + WidthOfRemainingText - pCursor->m_StartX > pCursor->m_LineWidth)
+								{
+									// we hit the end, only render ellipsis and finish
+									pTmp = pEllipsis;
+									NextCharacter = 0x2026;
+									continue;
+								}
 							}
 						}
 						else


### PR DESCRIPTION
Jupeyy reports 1600 -> 70 fps with ellipsis in scoreboard now

For me it's 50 fps before this change, 160 with this change, 400 without ellipsis

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
