### PR TITLE
Call `HttpInit` in server

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -24,6 +24,7 @@
 #include <engine/shared/econ.h>
 #include <engine/shared/fifo.h>
 #include <engine/shared/filecollection.h>
+#include <engine/shared/http.h>
 #include <engine/shared/json.h>
 #include <engine/shared/masterserver.h>
 #include <engine/shared/netban.h>
@@ -3687,6 +3688,8 @@ void CServer::RegisterCommands()
 	m_pMap = Kernel()->RequestInterface<IEngineMap>();
 	m_pStorage = Kernel()->RequestInterface<IStorage>();
 	m_pAntibot = Kernel()->RequestInterface<IEngineAntibot>();
+
+	HttpInit(m_pStorage);
 
 	// register console commands
 	Console()->Register("kick", "i[id] ?r[reason]", CFGFLAG_SERVER, ConKick, this, "Kick player with specified id for any reason");

--- a/src/engine/shared/http.cpp
+++ b/src/engine/shared/http.cpp
@@ -20,6 +20,7 @@
 // TODO: Non-global pls?
 static CURLSH *gs_Share;
 static LOCK gs_aLocks[CURL_LOCK_DATA_LAST + 1];
+static bool gs_Initialized = false;
 
 static int GetLockIndex(int Data)
 {
@@ -105,6 +106,8 @@ bool HttpInit(IStorage *pStorage)
 	signal(SIGPIPE, SIG_IGN);
 #endif
 
+	gs_Initialized = true;
+
 	return false;
 }
 
@@ -141,6 +144,7 @@ CHttpRequest::~CHttpRequest()
 
 void CHttpRequest::Run()
 {
+	dbg_assert(gs_Initialized, "must initialize HTTP before running HTTP requests");
 	int FinalState;
 	if(!BeforeInit())
 	{


### PR DESCRIPTION
Otherwise `curl_global_init` would be called from the first
`curl_easy_init`, but `curl_global_init` isn't threadsafe.

Fixes #5195.

## Checklist

- [x] Tested the change <s>ingame</s>
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
