### PR TITLE
Fix pos1 only scrolling up one page in console

### DIFF
--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -770,6 +770,8 @@ void CGameConsole::OnRender()
 		}
 
 		static int s_LastActivePage = pConsole->m_BacklogCurPage;
+		if(pConsole->m_BacklogCurPage == INT_MAX)
+			s_LastActivePage = INT_MAX;
 		int TotalPages = 1;
 		for(int Page = 0; Page <= s_LastActivePage; ++Page, OffsetY = 0.0f)
 		{


### PR DESCRIPTION
Holding down the pos1 key will still make the console text flash though.

Fixing that would require to first calculate the total number of pages in a separate pass before rendering the current page.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
