### PR TITLE
Move ddnet character display info in ddnet character

### DIFF
--- a/datasrc/compile.py
+++ b/datasrc/compile.py
@@ -141,8 +141,10 @@ def main():
 		int ClampInt(const char *pErrorMsg, int Value, int Min, int Max);
 
 		static const char *ms_apObjNames[];
+		static const char *ms_apExObjNames[];
 		static int ms_aObjSizes[];
 		static const char *ms_apMsgNames[];
+		static const char *ms_apExMsgNames[];
 
 	public:
 		CNetObjHandler();
@@ -201,8 +203,13 @@ def main():
 		lines += ['}']
 
 		lines += ["const char *CNetObjHandler::ms_apObjNames[] = {"]
-		lines += ['\t"invalid",']
+		lines += ['\t"EX/UUID",']
 		lines += ['\t"%s",' % o.name for o in network.Objects if o.ex is None]
+		lines += ['\t""', "};", ""]
+
+		lines += ["const char *CNetObjHandler::ms_apExObjNames[] = {"]
+		lines += ['\t"invalid",']
+		lines += ['\t"%s",' % o.name for o in network.Objects if o.ex is not None]
 		lines += ['\t""', "};", ""]
 
 		lines += ["int CNetObjHandler::ms_aObjSizes[] = {"]
@@ -213,17 +220,25 @@ def main():
 
 		lines += ['const char *CNetObjHandler::ms_apMsgNames[] = {']
 		lines += ['\t"invalid",']
-		for msg in network.Messages:
-			if msg.ex is None:
-				lines += ['\t"%s",' % msg.name]
-		lines += ['\t""']
-		lines += ['};']
-		lines += ['']
+		lines += ['\t"%s",' % msg.name for msg in network.Messages if msg.ex is None]
+		lines += ['\t""', "};", ""]
+
+		lines += ['const char *CNetObjHandler::ms_apExMsgNames[] = {']
+		lines += ['\t"invalid",']
+		lines += ['\t"%s",' % msg.name for msg in network.Messages if msg.ex is not None]
+		lines += ['\t""', "};", ""]
 
 		lines += ['const char *CNetObjHandler::GetObjName(int Type) const']
 		lines += ['{']
-		lines += ['\tif(Type < 0 || Type >= NUM_NETOBJTYPES) return "(out of range)";']
-		lines += ['\treturn ms_apObjNames[Type];']
+		lines += ['\tif(Type >= 0 && Type < NUM_NETOBJTYPES)']
+		lines += ['\t{']
+		lines += ['\t\treturn ms_apObjNames[Type];']
+		lines += ['\t}']
+		lines += ['\telse if(Type > __NETOBJTYPE_UUID_HELPER && Type < OFFSET_NETMSGTYPE_UUID)']
+		lines += ['\t{']
+		lines += ['\t\treturn ms_apExObjNames[Type - __NETOBJTYPE_UUID_HELPER];']
+		lines += ['\t}']
+		lines += ['\treturn "(out of range)";']
 		lines += ['}']
 		lines += ['']
 
@@ -234,14 +249,19 @@ def main():
 		lines += ['}']
 		lines += ['']
 
-
 		lines += ['const char *CNetObjHandler::GetMsgName(int Type) const']
 		lines += ['{']
-		lines += ['\tif(Type < 0 || Type >= NUM_NETMSGTYPES) return "(out of range)";']
-		lines += ['\treturn ms_apMsgNames[Type];']
+		lines += ['\tif(Type >= 0 && Type < NUM_NETMSGTYPES)']
+		lines += ['\t{']
+		lines += ['\t\treturn ms_apMsgNames[Type];']
+		lines += ['\t}']
+		lines += ['\telse if(Type > __NETMSGTYPE_UUID_HELPER && Type < OFFSET_MAPITEMTYPE_UUID)']
+		lines += ['\t{']
+		lines += ['\t\treturn ms_apExMsgNames[Type - __NETMSGTYPE_UUID_HELPER];']
+		lines += ['\t}']
+		lines += ['\treturn "(out of range)";']
 		lines += ['}']
 		lines += ['']
-
 
 		for l in lines:
 			print(l)

--- a/datasrc/compile.py
+++ b/datasrc/compile.py
@@ -297,21 +297,6 @@ def main():
 		for l in lines:
 			print(l)
 
-		# create validate tables
-			lines = []
-			lines += ['static int validate_invalid(void *data, int size) { return -1; }']
-			lines += ["typedef int(*VALIDATEFUNC)(void *data, int size);"]
-			lines += ["static VALIDATEFUNC validate_funcs[] = {"]
-			lines += ['\tvalidate_invalid,']
-			lines += ['\tvalidate_%s,' % o.name for o in network.Objects]
-			lines += ["\t0x0", "};", ""]
-
-			lines += ["int netobj_validate(int type, void *data, int size)"]
-			lines += ["{"]
-			lines += ["\tif(type < 0 || type >= NUM_NETOBJTYPES) return -1;"]
-			lines += ["\treturn validate_funcs[type](data, size);"]
-			lines += ["};", ""]
-
 		lines = []
 		lines += ['void *CNetObjHandler::SecureUnpackObj(int Type, CUnpacker *pUnpacker)']
 		lines += ['{']

--- a/datasrc/compile.py
+++ b/datasrc/compile.py
@@ -1,25 +1,26 @@
-import sys
-from datatypes import EmitDefinition, EmitTypeDeclaration
+import argparse
 import content
 import network
+
+from datatypes import EmitDefinition, EmitTypeDeclaration
 
 def create_enum_table(names, num):
 	lines = []
 	lines += ["enum", "{"]
 	for name in names:
-		lines += ["\t%s,"%name]
+		lines += ["\t%s," % name]
 	lines += ["\t%s" % num, "};"]
 	return lines
+
 
 def create_flags_table(names):
 	lines = []
 	lines += ["enum", "{"]
-	i = 0
-	for name in names:
-		lines += ["\t%s = 1<<%d," % (name,i)]
-		i += 1
+	for i, name in enumerate(names):
+		lines += ["\t%s = 1<<%d," % (name, i)]
 	lines += ["};"]
 	return lines
+
 
 def EmitEnum(names, num):
 	print("enum")
@@ -30,38 +31,347 @@ def EmitEnum(names, num):
 	print("\t%s" % num)
 	print("};")
 
+
 def EmitFlags(names):
 	print("enum")
 	print("{")
-	i = 0
-	for name in names:
-		print("\t%s = 1<<%d," % (name,i))
-		i += 1
+	for i, name in enumerate(names):
+		print("\t%s = 1<<%d," % (name, i))
 	print("};")
 
-def main():
-	gen_network_header = "network_header" in sys.argv
-	gen_network_source = "network_source" in sys.argv
-	gen_client_content_header = "client_content_header" in sys.argv
-	gen_client_content_source = "client_content_source" in sys.argv
-	gen_server_content_header = "server_content_header" in sys.argv
-	gen_server_content_source = "server_content_source" in sys.argv
 
-	if gen_client_content_header:
-		print("#ifndef CLIENT_CONTENT_HEADER")
-		print("#define CLIENT_CONTENT_HEADER")
+def gen_network_header():
+	print("#ifndef GAME_GENERATED_PROTOCOL_H")
+	print("#define GAME_GENERATED_PROTOCOL_H")
+	print("class CUnpacker;")
+	print("#include <engine/message.h>")
+	print(network.RawHeader)
 
-	if gen_server_content_header:
-		print("#ifndef SERVER_CONTENT_HEADER")
-		print("#define SERVER_CONTENT_HEADER")
+	for e in network.Enums:
+		for line in create_enum_table(["%s_%s"%(e.name, v) for v in e.values], 'NUM_%sS'%e.name): # pylint: disable=E1101
+			print(line)
+		print("")
+
+	for e in network.Flags:
+		for line in create_flags_table(["%s_%s" % (e.name, v) for v in e.values]):
+			print(line)
+		print("")
+
+	non_extended = [o for o in network.Objects if o.ex is None]
+	extended = [o for o in network.Objects if o.ex is not None]
+	for line in create_enum_table(["NETOBJTYPE_EX"]+[o.enum_name for o in non_extended], "NUM_NETOBJTYPES"):
+		print(line)
+	for line in create_enum_table(["__NETOBJTYPE_UUID_HELPER=OFFSET_GAME_UUID-1"]+[o.enum_name for o in extended], "OFFSET_NETMSGTYPE_UUID"):
+		print(line)
+	print("")
+
+	non_extended = [o for o in network.Messages if o.ex is None]
+	extended = [o for o in network.Messages if o.ex is not None]
+	for line in create_enum_table(["NETMSGTYPE_EX"]+[o.enum_name for o in non_extended], "NUM_NETMSGTYPES"):
+		print(line)
+	print("")
+	for line in create_enum_table(["__NETMSGTYPE_UUID_HELPER=OFFSET_NETMSGTYPE_UUID-1"]+[o.enum_name for o in extended], "OFFSET_MAPITEMTYPE_UUID"):
+		print(line)
+	print("")
+
+	for item in network.Objects + network.Messages:
+		for line in item.emit_declaration():
+			print(line)
+		print("")
+
+	EmitEnum(["SOUND_%s"%i.name.value.upper() for i in content.container.sounds.items], "NUM_SOUNDS")
+	EmitEnum(["WEAPON_%s"%i.name.value.upper() for i in content.container.weapons.id.items], "NUM_WEAPONS")
+
+	print("""
+class CNetObjHandler
+{
+	const char *m_pMsgFailedOn;
+	const char *m_pObjFailedOn;
+	const char *m_pObjCorrectedOn;
+	char m_aUnpackedData[1024 * 2];
+	int m_NumObjCorrections;
+	int ClampInt(const char *pErrorMsg, int Value, int Min, int Max);
+
+	static const char *ms_apObjNames[];
+	static const char *ms_apExObjNames[];
+	static int ms_aObjSizes[];
+	static int ms_aUnpackedObjSizes[];
+	static int ms_aUnpackedExObjSizes[];
+	static const char *ms_apMsgNames[];
+	static const char *ms_apExMsgNames[];
+
+public:
+	CNetObjHandler();
+
+	void *SecureUnpackObj(int Type, CUnpacker *pUnpacker);
+	const char *GetObjName(int Type) const;
+	int GetObjSize(int Type) const;
+	int GetUnpackedObjSize(int Type) const;
+	int NumObjCorrections() const;
+	const char *CorrectedObjOn() const;
+	const char *FailedObjOn() const;
+
+	const char *GetMsgName(int Type) const;
+	void *SecureUnpackMsg(int Type, CUnpacker *pUnpacker);
+	bool TeeHistorianRecordMsg(int Type);
+	const char *FailedMsgOn() const;
+};
+	""")
+
+	print("#endif // GAME_GENERATED_PROTOCOL_H")
 
 
-	if gen_client_content_header or gen_server_content_header:
-		# print some includes
-		print('#include <engine/graphics.h>')
+def gen_network_source():
 
-		# emit the type declarations
-		contentlines = open("datasrc/content.py", "rb").readlines()
+	print("""\
+#include "protocol.h"
+
+#include <engine/shared/packer.h>
+#include <engine/shared/protocol.h>
+#include <engine/shared/uuid_manager.h>
+
+#include <game/mapitems_ex.h>
+
+CNetObjHandler::CNetObjHandler()
+{
+	m_pMsgFailedOn = "";
+	m_pObjFailedOn = "";
+	m_pObjCorrectedOn = "";
+	m_NumObjCorrections = 0;
+}
+
+int CNetObjHandler::NumObjCorrections() const { return m_NumObjCorrections; }
+const char *CNetObjHandler::CorrectedObjOn() const { return m_pObjCorrectedOn; }
+const char *CNetObjHandler::FailedObjOn() const { return m_pObjFailedOn; }
+const char *CNetObjHandler::FailedMsgOn() const { return m_pMsgFailedOn; }
+
+static const int max_int = 0x7fffffff;
+static const int min_int = 0x80000000;
+
+int CNetObjHandler::ClampInt(const char *pErrorMsg, int Value, int Min, int Max)
+{
+	if(Value < Min) { m_pObjCorrectedOn = pErrorMsg; m_NumObjCorrections++; return Min; }
+	if(Value > Max) { m_pObjCorrectedOn = pErrorMsg; m_NumObjCorrections++; return Max; }
+	return Value;
+}
+	""")
+
+
+	lines = []
+	lines += ["const char *CNetObjHandler::ms_apObjNames[] = {"]
+	lines += ['\t"EX/UUID",']
+	lines += ['\t"%s",' % o.name for o in network.Objects if o.ex is None]
+	lines += ['\t""', "};", ""]
+
+	lines += ["const char *CNetObjHandler::ms_apExObjNames[] = {"]
+	lines += ['\t"invalid",']
+	lines += ['\t"%s",' % o.name for o in network.Objects if o.ex is not None]
+	lines += ['\t""', "};", ""]
+
+	lines += ["int CNetObjHandler::ms_aObjSizes[] = {"]
+	lines += ['\t0,']
+	lines += ['\tsizeof(%s),' % o.struct_name for o in network.Objects if o.ex is None]
+	lines += ['\t0', "};", ""]
+
+	lines += ["int CNetObjHandler::ms_aUnpackedObjSizes[] = {"]
+	lines += ['\t16,']
+	lines += ['\tsizeof(%s),' % o.struct_name for o in network.Objects if o.ex is None]
+	lines += ["};", ""]
+
+	lines += ["int CNetObjHandler::ms_aUnpackedExObjSizes[] = {"]
+	lines += ['\t0,']
+	lines += ['\tsizeof(%s),' % o.struct_name for o in network.Objects if o.ex is not None]
+	lines += ["};", ""]
+
+	lines += ['const char *CNetObjHandler::ms_apMsgNames[] = {']
+	lines += ['\t"invalid",']
+	lines += ['\t"%s",' % msg.name for msg in network.Messages if msg.ex is None]
+	lines += ['\t""', "};", ""]
+
+	lines += ['const char *CNetObjHandler::ms_apExMsgNames[] = {']
+	lines += ['\t"invalid",']
+	lines += ['\t"%s",' % msg.name for msg in network.Messages if msg.ex is not None]
+	lines += ['\t""', "};", ""]
+
+	for line in lines:
+		print(line)
+
+	print("""\
+const char *CNetObjHandler::GetObjName(int Type) const
+{
+	if(Type >= 0 && Type < NUM_NETOBJTYPES)
+	{
+		return ms_apObjNames[Type];
+	}
+	else if(Type > __NETOBJTYPE_UUID_HELPER && Type < OFFSET_NETMSGTYPE_UUID)
+	{
+		return ms_apExObjNames[Type - __NETOBJTYPE_UUID_HELPER];
+	}
+	return "(out of range)";
+}
+
+int CNetObjHandler::GetObjSize(int Type) const
+{
+	if(Type < 0 || Type >= NUM_NETOBJTYPES) return 0;
+	return ms_aObjSizes[Type];
+}
+
+int CNetObjHandler::GetUnpackedObjSize(int Type) const
+{
+	if(Type >= 0 && Type < NUM_NETOBJTYPES)
+	{
+		return ms_aUnpackedObjSizes[Type];
+	}
+	else if(Type > __NETOBJTYPE_UUID_HELPER && Type < OFFSET_NETMSGTYPE_UUID)
+	{
+		return ms_aUnpackedExObjSizes[Type - __NETOBJTYPE_UUID_HELPER];
+	}
+	return 0;
+}
+
+const char *CNetObjHandler::GetMsgName(int Type) const
+{
+	if(Type >= 0 && Type < NUM_NETMSGTYPES)
+	{
+		return ms_apMsgNames[Type];
+	}
+	else if(Type > __NETMSGTYPE_UUID_HELPER && Type < OFFSET_MAPITEMTYPE_UUID)
+	{
+		return ms_apExMsgNames[Type - __NETMSGTYPE_UUID_HELPER];
+	}
+	return "(out of range)";
+}
+	""")
+
+	lines = []
+	lines += ["""\
+void *CNetObjHandler::SecureUnpackObj(int Type, CUnpacker *pUnpacker)
+{
+	m_pObjFailedOn = 0;
+	switch(Type)
+	{
+	case NETOBJTYPE_EX:
+	{
+		const unsigned char *pPtr = pUnpacker->GetRaw(sizeof(CUuid));
+		if(pPtr != 0)
+		{
+			mem_copy(m_aUnpackedData, pPtr, sizeof(CUuid));
+		}
+		break;
+	}
+	"""]
+
+	for item in network.Objects:
+		base_item = None
+		if item.base:
+			base_item = next(i for i in network.Objects if i.name == item.base)
+		for line in item.emit_uncompressed_unpack_and_validate(base_item):
+			lines += ["\t" + line]
+		lines += ['\t']
+
+	lines += ["""\
+	default:
+		m_pObjFailedOn = "(type out of range)";
+		break;
+	}
+	
+	if(pUnpacker->Error())
+		m_pObjFailedOn = "(unpack error)";
+	
+	if(m_pObjFailedOn)
+		return 0;
+	m_pObjFailedOn = "";
+	return m_aUnpackedData;
+}
+	"""]
+	for line in lines:
+		print(line)
+
+
+	lines = []
+	lines += ["""\
+void *CNetObjHandler::SecureUnpackMsg(int Type, CUnpacker *pUnpacker)
+{
+	m_pMsgFailedOn = 0;
+	switch(Type)
+	{
+	"""]
+
+	for item in network.Messages:
+		for line in item.emit_unpack_msg():
+			lines += ["\t" + line]
+		lines += ['\t']
+
+	lines += ["""\
+	default:
+		m_pMsgFailedOn = "(type out of range)";
+		break;
+	}
+	
+	if(pUnpacker->Error())
+		m_pMsgFailedOn = "(unpack error)";
+	
+	if(m_pMsgFailedOn)
+		return 0;
+	m_pMsgFailedOn = "";
+	return m_aUnpackedData;
+}
+	"""]
+	for line in lines:
+		print(line)
+
+
+	lines = []
+	lines += ["""\
+bool CNetObjHandler::TeeHistorianRecordMsg(int Type)
+{
+	switch(Type)
+	{
+	"""]
+
+	empty = True
+	for msg in network.Messages:
+		if not msg.teehistorian:
+			lines += ['\tcase %s:' % msg.enum_name]
+			empty = False
+	if not empty:
+		lines += ['\t\treturn false;']
+
+	lines += ["""\
+	default:
+		return true;
+	}
+}
+	"""]
+	for line in lines:
+		print(line)
+
+
+	lines = []
+	lines += ["""\
+void RegisterGameUuids(CUuidManager *pManager)
+{
+	"""]
+
+	for item in network.Objects + network.Messages:
+		if item.ex is not None:
+			lines += ['\tpManager->RegisterName(%s, "%s");' % (item.enum_name, item.ex)]
+
+	lines += ["""
+	RegisterMapItemTypeUuids(pManager);
+}
+	"""]
+	for line in lines:
+		print(line)
+
+
+def gen_common_content_header():
+	# print some includes
+	print('#include <engine/graphics.h>')
+
+	# emit the type declarations
+	with open("datasrc/content.py", "rb") as content_file:
+		contentlines = content_file.readlines()
 		order = []
 		for line in contentlines:
 			line = line.strip()
@@ -70,331 +380,58 @@ def main():
 		for name in order:
 			EmitTypeDeclaration(content.__dict__[name])
 
-		# the container pointer
-		print('extern CDataContainer *g_pData;')
+	# the container pointer
+	print('extern CDataContainer *g_pData;')
 
-		# enums
-		EmitEnum(["IMAGE_%s"%i.name.value.upper() for i in content.container.images.items], "NUM_IMAGES")
-		EmitEnum(["ANIM_%s"%i.name.value.upper() for i in content.container.animations.items], "NUM_ANIMS")
-		EmitEnum(["SPRITE_%s"%i.name.value.upper() for i in content.container.sprites.items], "NUM_SPRITES")
+	# enums
+	EmitEnum(["IMAGE_%s"%i.name.value.upper() for i in content.container.images.items], "NUM_IMAGES")
+	EmitEnum(["ANIM_%s"%i.name.value.upper() for i in content.container.animations.items], "NUM_ANIMS")
+	EmitEnum(["SPRITE_%s"%i.name.value.upper() for i in content.container.sprites.items], "NUM_SPRITES")
 
-	if gen_client_content_source or gen_server_content_source:
-		if gen_client_content_source:
-			print('#include "client_data.h"')
-		if gen_server_content_source:
-			print('#include "server_data.h"')
-		EmitDefinition(content.container, "datacontainer")
-		print('CDataContainer *g_pData = &datacontainer;')
+def gen_common_content_source():
+	EmitDefinition(content.container, "datacontainer")
+	print('CDataContainer *g_pData = &datacontainer;')
 
-# NETWORK
-	if gen_network_header:
-
-		print("#ifndef GAME_GENERATED_PROTOCOL_H")
-		print("#define GAME_GENERATED_PROTOCOL_H")
-		print("class CUnpacker;")
-		print("#include <engine/message.h>")
-		print(network.RawHeader)
-
-		for e in network.Enums:
-			for l in create_enum_table(["%s_%s"%(e.name, v) for v in e.values], 'NUM_%sS'%e.name): # pylint: disable=E1101
-				print(l)
-			print("")
-
-		for e in network.Flags:
-			for l in create_flags_table(["%s_%s" % (e.name, v) for v in e.values]):
-				print(l)
-			print("")
-
-		non_extended = [o for o in network.Objects if o.ex is None]
-		extended = [o for o in network.Objects if o.ex is not None]
-		for l in create_enum_table(["NETOBJTYPE_EX"]+[o.enum_name for o in non_extended], "NUM_NETOBJTYPES"):
-			print(l)
-		for l in create_enum_table(["__NETOBJTYPE_UUID_HELPER=OFFSET_GAME_UUID-1"]+[o.enum_name for o in extended], "OFFSET_NETMSGTYPE_UUID"):
-			print(l)
-		print("")
-
-		non_extended = [o for o in network.Messages if o.ex is None]
-		extended = [o for o in network.Messages if o.ex is not None]
-		for l in create_enum_table(["NETMSGTYPE_EX"]+[o.enum_name for o in non_extended], "NUM_NETMSGTYPES"):
-			print(l)
-		print("")
-		for l in create_enum_table(["__NETMSGTYPE_UUID_HELPER=OFFSET_NETMSGTYPE_UUID-1"]+[o.enum_name for o in extended], "OFFSET_MAPITEMTYPE_UUID"):
-			print(l)
-		print("")
-
-		for item in network.Objects + network.Messages:
-			for line in item.emit_declaration():
-				print(line)
-			print("")
-
-		EmitEnum(["SOUND_%s"%i.name.value.upper() for i in content.container.sounds.items], "NUM_SOUNDS")
-		EmitEnum(["WEAPON_%s"%i.name.value.upper() for i in content.container.weapons.id.items], "NUM_WEAPONS")
-
-		print("""
-
-	class CNetObjHandler
-	{
-		const char *m_pMsgFailedOn;
-		const char *m_pObjFailedOn;
-		const char *m_pObjCorrectedOn;
-		char m_aUnpackedData[1024 * 2];
-		int m_NumObjCorrections;
-		int ClampInt(const char *pErrorMsg, int Value, int Min, int Max);
-
-		static const char *ms_apObjNames[];
-		static const char *ms_apExObjNames[];
-		static int ms_aObjSizes[];
-		static int ms_aUnpackedObjSizes[];
-		static int ms_aUnpackedExObjSizes[];
-		static const char *ms_apMsgNames[];
-		static const char *ms_apExMsgNames[];
-
-	public:
-		CNetObjHandler();
-
-		void *SecureUnpackObj(int Type, CUnpacker *pUnpacker);
-		const char *GetObjName(int Type) const;
-		int GetObjSize(int Type) const;
-		int GetUnpackedObjSize(int Type) const;
-		int NumObjCorrections() const;
-		const char *CorrectedObjOn() const;
-		const char *FailedObjOn() const;
-
-		const char *GetMsgName(int Type) const;
-		void *SecureUnpackMsg(int Type, CUnpacker *pUnpacker);
-		bool TeeHistorianRecordMsg(int Type);
-		const char *FailedMsgOn() const;
-	};
-
-	""")
-
-		print("#endif // GAME_GENERATED_PROTOCOL_H")
+def gen_client_content_header():
+	print("#ifndef CLIENT_CONTENT_HEADER")
+	print("#define CLIENT_CONTENT_HEADER")
+	gen_common_content_header()
+	print("#endif")
 
 
-	if gen_network_source:
-		# create names
-		lines = []
-
-		lines += ['#include "protocol.h"']
-		lines += ['#include <engine/shared/packer.h>']
-		lines += ['#include <engine/shared/protocol.h>']
-		lines += ['#include <engine/shared/uuid_manager.h>']
-		lines += ['#include <game/mapitems_ex.h>']
-
-		lines += ['CNetObjHandler::CNetObjHandler()']
-		lines += ['{']
-		lines += ['\tm_pMsgFailedOn = "";']
-		lines += ['\tm_pObjFailedOn = "";']
-		lines += ['\tm_pObjCorrectedOn = "";']
-		lines += ['\tm_NumObjCorrections = 0;']
-		lines += ['}']
-		lines += ['']
-		lines += ['int CNetObjHandler::NumObjCorrections() const { return m_NumObjCorrections; }']
-		lines += ['const char *CNetObjHandler::CorrectedObjOn() const { return m_pObjCorrectedOn; }']
-		lines += ['const char *CNetObjHandler::FailedObjOn() const { return m_pObjFailedOn; }']
-		lines += ['const char *CNetObjHandler::FailedMsgOn() const { return m_pMsgFailedOn; }']
-		lines += ['']
-		lines += ['']
-		lines += ['']
-		lines += ['']
-		lines += ['']
-
-		lines += ['static const int max_int = 0x7fffffff;']
-		lines += ['static const int min_int = 0x80000000;']
-
-		lines += ['int CNetObjHandler::ClampInt(const char *pErrorMsg, int Value, int Min, int Max)']
-		lines += ['{']
-		lines += ['\tif(Value < Min) { m_pObjCorrectedOn = pErrorMsg; m_NumObjCorrections++; return Min; }']
-		lines += ['\tif(Value > Max) { m_pObjCorrectedOn = pErrorMsg; m_NumObjCorrections++; return Max; }']
-		lines += ['\treturn Value;']
-		lines += ['}']
-
-		lines += ["const char *CNetObjHandler::ms_apObjNames[] = {"]
-		lines += ['\t"EX/UUID",']
-		lines += ['\t"%s",' % o.name for o in network.Objects if o.ex is None]
-		lines += ['\t""', "};", ""]
-
-		lines += ["const char *CNetObjHandler::ms_apExObjNames[] = {"]
-		lines += ['\t"invalid",']
-		lines += ['\t"%s",' % o.name for o in network.Objects if o.ex is not None]
-		lines += ['\t""', "};", ""]
-
-		lines += ["int CNetObjHandler::ms_aObjSizes[] = {"]
-		lines += ['\t0,']
-		lines += ['\tsizeof(%s),' % o.struct_name for o in network.Objects if o.ex is None]
-		lines += ['\t0', "};", ""]
-
-		lines += ["int CNetObjHandler::ms_aUnpackedObjSizes[] = {"]
-		lines += ['\t16,']
-		lines += ['\tsizeof(%s),' % o.struct_name for o in network.Objects if o.ex is None]
-		lines += ["};", ""]
-
-		lines += ["int CNetObjHandler::ms_aUnpackedExObjSizes[] = {"]
-		lines += ['\t0,']
-		lines += ['\tsizeof(%s),' % o.struct_name for o in network.Objects if o.ex is not None]
-		lines += ["};", ""]
-
-		lines += ['const char *CNetObjHandler::ms_apMsgNames[] = {']
-		lines += ['\t"invalid",']
-		lines += ['\t"%s",' % msg.name for msg in network.Messages if msg.ex is None]
-		lines += ['\t""', "};", ""]
-
-		lines += ['const char *CNetObjHandler::ms_apExMsgNames[] = {']
-		lines += ['\t"invalid",']
-		lines += ['\t"%s",' % msg.name for msg in network.Messages if msg.ex is not None]
-		lines += ['\t""', "};", ""]
-
-		lines += ['const char *CNetObjHandler::GetObjName(int Type) const']
-		lines += ['{']
-		lines += ['\tif(Type >= 0 && Type < NUM_NETOBJTYPES)']
-		lines += ['\t{']
-		lines += ['\t\treturn ms_apObjNames[Type];']
-		lines += ['\t}']
-		lines += ['\telse if(Type > __NETOBJTYPE_UUID_HELPER && Type < OFFSET_NETMSGTYPE_UUID)']
-		lines += ['\t{']
-		lines += ['\t\treturn ms_apExObjNames[Type - __NETOBJTYPE_UUID_HELPER];']
-		lines += ['\t}']
-		lines += ['\treturn "(out of range)";']
-		lines += ['}']
-		lines += ['']
-
-		lines += ['int CNetObjHandler::GetObjSize(int Type) const']
-		lines += ['{']
-		lines += ['\tif(Type < 0 || Type >= NUM_NETOBJTYPES) return 0;']
-		lines += ['\treturn ms_aObjSizes[Type];']
-		lines += ['}']
-		lines += ['']
-
-		lines += ['int CNetObjHandler::GetUnpackedObjSize(int Type) const']
-		lines += ['{']
-		lines += ['\tif(Type >= 0 && Type < NUM_NETOBJTYPES)']
-		lines += ['\t{']
-		lines += ['\t\treturn ms_aUnpackedObjSizes[Type];']
-		lines += ['\t}']
-		lines += ['\telse if(Type > __NETOBJTYPE_UUID_HELPER && Type < OFFSET_NETMSGTYPE_UUID)']
-		lines += ['\t{']
-		lines += ['\t\treturn ms_aUnpackedExObjSizes[Type - __NETOBJTYPE_UUID_HELPER];']
-		lines += ['\t}']
-		lines += ['\treturn 0;']
-		lines += ['}']
-		lines += ['']
+def gen_client_content_source():
+	print('#include "client_data.h"')
+	gen_common_content_source()
 
 
-		lines += ['const char *CNetObjHandler::GetMsgName(int Type) const']
-		lines += ['{']
-		lines += ['\tif(Type >= 0 && Type < NUM_NETMSGTYPES)']
-		lines += ['\t{']
-		lines += ['\t\treturn ms_apMsgNames[Type];']
-		lines += ['\t}']
-		lines += ['\telse if(Type > __NETMSGTYPE_UUID_HELPER && Type < OFFSET_MAPITEMTYPE_UUID)']
-		lines += ['\t{']
-		lines += ['\t\treturn ms_apExMsgNames[Type - __NETMSGTYPE_UUID_HELPER];']
-		lines += ['\t}']
-		lines += ['\treturn "(out of range)";']
-		lines += ['}']
-		lines += ['']
-
-		for l in lines:
-			print(l)
-
-		lines = []
-		lines += ['void *CNetObjHandler::SecureUnpackObj(int Type, CUnpacker *pUnpacker)']
-		lines += ['{']
-		lines += ['\tm_pObjFailedOn = 0;']
-		lines += ['\tswitch(Type)']
-		lines += ['\t{']
-		lines += ['\tcase NETOBJTYPE_EX:']
-		lines += ['\t{']
-		lines += ['\t\tconst unsigned char *pPtr = pUnpacker->GetRaw(sizeof(CUuid));']
-		lines += ['\t\tif(pPtr != 0)']
-		lines += ['\t\t{']
-		lines += ['\t\t\tmem_copy(m_aUnpackedData, pPtr, sizeof(CUuid));']
-		lines += ['\t\t}']
-		lines += ['\t\tbreak;']
-		lines += ['\t}']
-
-		for item in network.Objects:
-			base_item = None
-			if item.base:
-				base_item = next(i for i in network.Objects if i.name == item.base)
-			for line in item.emit_uncompressed_unpack_and_validate(base_item):
-				lines += ["\t" + line]
-			lines += ['\t']
-
-		lines += ['\tdefault:']
-		lines += ['\t\tm_pObjFailedOn = "(type out of range)";']
-		lines += ['\t\tbreak;']
-		lines += ['\t}']
-		lines += ['\t']
-		lines += ['\tif(pUnpacker->Error())']
-		lines += ['\t\tm_pObjFailedOn = "(unpack error)";']
-		lines += ['\t']
-		lines += ['\tif(m_pObjFailedOn)']
-		lines += ['\t\treturn 0;']
-		lines += ['\tm_pObjFailedOn = "";']
-		lines += ['\treturn m_aUnpackedData;']
-		lines += ['}']
-		lines += ['']
+def gen_server_content_header():
+	print("#ifndef SERVER_CONTENT_HEADER")
+	print("#define SERVER_CONTENT_HEADER")
+	gen_common_content_header()
+	print("#endif")
 
 
-		lines += ['void *CNetObjHandler::SecureUnpackMsg(int Type, CUnpacker *pUnpacker)']
-		lines += ['{']
-		lines += ['\tm_pMsgFailedOn = 0;']
-		lines += ['\tswitch(Type)']
-		lines += ['\t{']
-
-		for item in network.Messages:
-			for line in item.emit_unpack_msg():
-				lines += ["\t" + line]
-			lines += ['\t']
-
-		lines += ['\tdefault:']
-		lines += ['\t\tm_pMsgFailedOn = "(type out of range)";']
-		lines += ['\t\tbreak;']
-		lines += ['\t}']
-		lines += ['\t']
-		lines += ['\tif(pUnpacker->Error())']
-		lines += ['\t\tm_pMsgFailedOn = "(unpack error)";']
-		lines += ['\t']
-		lines += ['\tif(m_pMsgFailedOn)']
-		lines += ['\t\treturn 0;']
-		lines += ['\tm_pMsgFailedOn = "";']
-		lines += ['\treturn m_aUnpackedData;']
-		lines += ['}']
-		lines += ['']
+def gen_server_content_source():
+	print('#include "server_data.h"')
+	gen_common_content_source()
 
 
-		lines += ['bool CNetObjHandler::TeeHistorianRecordMsg(int Type)']
-		lines += ['{']
-		lines += ['\tswitch(Type)']
-		lines += ['\t{']
-		empty = True
-		for msg in network.Messages:
-			if not msg.teehistorian:
-				lines += ['\tcase %s:' % msg.enum_name]
-				empty = False
-		if not empty:
-			lines += ['\t\treturn false;']
-		lines += ['\tdefault:']
-		lines += ['\t\treturn true;']
-		lines += ['\t}']
-		lines += ['}']
-		lines += ['']
+def main():
+	parser = argparse.ArgumentParser(
+		description=('Generate C++ Source Files for the Teeworlds Network Protocol')
+	)
+	FUNCTION_MAP = {
+						'network_header': gen_network_header,
+						'network_source': gen_network_source,
+						'client_content_header': gen_client_content_header,
+						'client_content_source': gen_client_content_source,
+						'server_content_header': gen_server_content_header,
+						'server_content_source': gen_server_content_source,
+					}
 
-		lines += ['void RegisterGameUuids(CUuidManager *pManager)']
-		lines += ['{']
-
-		for item in network.Objects + network.Messages:
-			if item.ex is not None:
-				lines += ['\tpManager->RegisterName(%s, "%s");' % (item.enum_name, item.ex)]
-		lines += ['\tRegisterMapItemTypeUuids(pManager);']
-		lines += ['}']
-
-		for l in lines:
-			print(l)
-
-	if gen_client_content_header or gen_server_content_header:
-		print("#endif")
+	parser.add_argument('file_to_generate', choices=FUNCTION_MAP.keys())
+	args = parser.parse_args()
+	FUNCTION_MAP[args.file_to_generate]()
 
 if __name__ == '__main__':
 	main()

--- a/datasrc/compile.py
+++ b/datasrc/compile.py
@@ -136,7 +136,7 @@ def main():
 	{
 		const char *m_pMsgFailedOn;
 		const char *m_pObjCorrectedOn;
-		char m_aMsgData[1024];
+		char m_aMsgData[1024 * 2];
 		int m_NumObjCorrections;
 		int ClampInt(const char *pErrorMsg, int Value, int Min, int Max);
 

--- a/datasrc/datatypes.py
+++ b/datasrc/datatypes.py
@@ -213,36 +213,41 @@ class NetObject:
 		self.variables = variables
 		self.ex = ex
 		self.validate_size = validate_size
+
 	def emit_declaration(self):
+		lines = []
 		if self.base:
-			lines = ["struct %s : public %s"%(self.struct_name,self.base_struct_name), "{"]
+			lines += ["struct %s : public %s"%(self.struct_name,self.base_struct_name), "{"]
 		else:
-			lines = ["struct %s"%self.struct_name, "{"]
+			lines += ["struct %s"%self.struct_name, "{"]
 		for v in self.variables:
 			lines += ["\t"+line for line in v.emit_declaration()]
 		lines += ["};"]
 		return lines
-	def emit_validate(self, base_item):
-		lines = ["case %s:" % self.enum_name]
-		lines += ["{"]
 
-		variables = self.variables
+	def emit_uncompressed_unpack_and_validate(self, base_item):
+		lines = []
+		lines += ["case %s:" % self.enum_name]
+		lines += ["{"]
+		lines += ["\t%s *pData = (%s *)m_aUnpackedData;" % (self.struct_name, self.struct_name)]
+		unpack_lines = []
+
+		variables = []
 		if base_item:
 			variables += base_item.variables
-		validate_variables_lines = []
+		variables += self.variables
 		for v in variables:
-			validate_variable_lines = ["\t"+line for line in v.emit_validate()]
-			if not self.validate_size and len(validate_variable_lines) > 0 and v.default is None:
-				raise ValueError("Members that require validation and do not have a default value cannot be used in a structure whose size is not validated")
-			validate_variables_lines += validate_variable_lines
+			if not self.validate_size and v.default is None:
+				raise ValueError(f"{v.name} in {self.name} has no default value. Member variables that do not have a default value cannot be used in a structure whose size is not validated.")
+			unpack_lines += ["\t"+line for line in v.emit_uncompressed_unpack_obj()]
+		for v in variables:
+			unpack_lines += ["\t"+line for line in v.emit_validate_obj()]
 
-		if self.validate_size or validate_variables_lines:
-			lines += ["\t%s *pObj = (%s *)pData;"%(self.struct_name, self.struct_name)]
-		if self.validate_size:
-			lines += ["\tif((int)sizeof(*pObj) > Size) return -1;"]
-		lines += validate_variables_lines
-		lines += ["\treturn 0;"]
-		lines += ["}"]
+		if len(unpack_lines) > 0:
+			lines += unpack_lines
+		else:
+			lines += ["\t(void)pData;"]
+		lines += ["} break;"]
 		return lines
 
 class NetEvent(NetObject):
@@ -259,18 +264,26 @@ class NetMessage(NetObject):
 		self.struct_name = "CNetMsg_%s" % self.name
 		self.enum_name = "NETMSGTYPE_%s" % self.name.upper()
 		self.teehistorian = teehistorian
-	def emit_unpack(self):
+
+	def emit_unpack_msg(self):
 		lines = []
 		lines += ["case %s:" % self.enum_name]
 		lines += ["{"]
-		lines += ["\t%s *pMsg = (%s *)m_aMsgData;" % (self.struct_name, self.struct_name)]
-		lines += ["\t(void)pMsg;"]
+		lines += ["\t%s *pData = (%s *)m_aUnpackedData;" % (self.struct_name, self.struct_name)]
+
+		unpack_lines = []
 		for v in self.variables:
-			lines += ["\t"+line for line in v.emit_unpack()]
+			unpack_lines += ["\t"+line for line in v.emit_unpack_msg()]
 		for v in self.variables:
-			lines += ["\t"+line for line in v.emit_unpack_check()]
+			unpack_lines += ["\t"+line for line in v.emit_unpack_msg_check()]
+
+		if len(unpack_lines) > 0:
+			lines += unpack_lines
+		else:
+			lines += ["\t(void)pData;"]
 		lines += ["} break;"]
 		return lines
+
 	def emit_declaration(self):
 		extra = []
 		extra += ["\tint MsgID() const { return %s; }" % self.enum_name]
@@ -282,7 +295,6 @@ class NetMessage(NetObject):
 			extra += ["\t\t"+line for line in v.emit_pack()]
 		extra += ["\t\treturn pPacker->Error() != 0;"]
 		extra += ["\t}"]
-
 
 		lines = NetObject.emit_declaration(self)
 		lines = lines[:-1] + extra + lines[-1:]
@@ -307,46 +319,58 @@ class NetVariable:
 		self.default = None if default is None else str(default)
 	def emit_declaration(self):
 		return []
-	def emit_validate(self):
+	def emit_validate_obj(self):
+		return []
+	def emit_uncompressed_unpack_obj(self):
 		return []
 	def emit_pack(self):
 		return []
-	def emit_unpack(self):
+	def emit_unpack_msg(self):
 		return []
-	def emit_unpack_check(self):
+	def emit_unpack_msg_check(self):
 		return []
 
 class NetString(NetVariable):
 	def emit_declaration(self):
 		return ["const char *%s;"%self.name]
-	def emit_unpack(self):
-		return ["pMsg->%s = pUnpacker->GetString();" % self.name]
+	def emit_uncompressed_unpack_obj(self):
+		return self.emit_unpack_msg()
+	def emit_unpack_msg(self):
+		return ["pData->%s = pUnpacker->GetString();" % self.name]
 	def emit_pack(self):
 		return ["pPacker->AddString(%s, -1);" % self.name]
 
 class NetStringHalfStrict(NetVariable):
 	def emit_declaration(self):
 		return ["const char *%s;"%self.name]
-	def emit_unpack(self):
-		return ["pMsg->%s = pUnpacker->GetString(CUnpacker::SANITIZE_CC);" % self.name]
+	def emit_uncompressed_unpack_obj(self):
+		return self.emit_unpack_msg()
+	def emit_unpack_msg(self):
+		return ["pData->%s = pUnpacker->GetString(CUnpacker::SANITIZE_CC);" % self.name]
 	def emit_pack(self):
 		return ["pPacker->AddString(%s, -1);" % self.name]
 
 class NetStringStrict(NetVariable):
 	def emit_declaration(self):
 		return ["const char *%s;"%self.name]
-	def emit_unpack(self):
-		return ["pMsg->%s = pUnpacker->GetString(CUnpacker::SANITIZE_CC|CUnpacker::SKIP_START_WHITESPACES);" % self.name]
+	def emit_uncompressed_unpack_obj(self):
+		return self.emit_unpack_msg()
+	def emit_unpack_msg(self):
+		return ["pData->%s = pUnpacker->GetString(CUnpacker::SANITIZE_CC|CUnpacker::SKIP_START_WHITESPACES);" % self.name]
 	def emit_pack(self):
 		return ["pPacker->AddString(%s, -1);" % self.name]
 
 class NetIntAny(NetVariable):
 	def emit_declaration(self):
 		return ["int %s;"%self.name]
-	def emit_unpack(self):
+	def emit_uncompressed_unpack_obj(self):
 		if self.default is None:
-			return ["pMsg->%s = pUnpacker->GetInt();" % self.name]
-		return ["pMsg->%s = pUnpacker->GetIntOrDefault(%s);" % (self.name, self.default)]
+			return ["pData->%s = pUnpacker->GetUncompressedInt();" % self.name]
+		return ["pData->%s = pUnpacker->GetUncompressedIntOrDefault(%s);" % (self.name, self.default)]
+	def emit_unpack_msg(self):
+		if self.default is None:
+			return ["pData->%s = pUnpacker->GetInt();" % self.name]
+		return ["pData->%s = pUnpacker->GetIntOrDefault(%s);" % (self.name, self.default)]
 	def emit_pack(self):
 		return ["pPacker->AddInt(%s);" % self.name]
 
@@ -355,10 +379,10 @@ class NetIntRange(NetIntAny):
 		NetIntAny.__init__(self,name,default=default)
 		self.min = str(min_val)
 		self.max = str(max_val)
-	def emit_validate(self):
-		return ["pObj->%s = ClampInt(\"%s\", pObj->%s, %s, %s);"%(self.name, self.name, self.name, self.min, self.max)]
-	def emit_unpack_check(self):
-		return ["if(pMsg->%s < %s || pMsg->%s > %s) { m_pMsgFailedOn = \"%s\"; break; }" % (self.name, self.min, self.name, self.max, self.name)]
+	def emit_validate_obj(self):
+		return ["pData->%s = ClampInt(\"%s\", pData->%s, %s, %s);"%(self.name, self.name, self.name, self.min, self.max)]
+	def emit_unpack_msg_check(self):
+		return ["if(pData->%s < %s || pData->%s > %s) { m_pMsgFailedOn = \"%s\"; break; }" % (self.name, self.min, self.name, self.max, self.name)]
 
 class NetBool(NetIntRange):
 	def __init__(self, name, default=None):
@@ -371,7 +395,7 @@ class NetTick(NetIntAny):
 
 class NetArray(NetVariable):
 	def __init__(self, var, size):
-		NetVariable.__init__(self,var.name)
+		NetVariable.__init__(self,var.name,var.default)
 		self.base_name = var.name
 		self.var = var
 		self.size = size
@@ -379,17 +403,23 @@ class NetArray(NetVariable):
 	def emit_declaration(self):
 		self.var.name = self.name
 		return self.var.emit_declaration()
-	def emit_validate(self):
+	def emit_uncompressed_unpack_obj(self):
 		lines = []
 		for i in range(self.size):
 			self.var.name = self.base_name + "[%d]"%i
-			lines += self.var.emit_validate()
+			lines += self.var.emit_uncompressed_unpack_obj()
 		return lines
-	def emit_unpack(self):
+	def emit_validate_obj(self):
 		lines = []
 		for i in range(self.size):
 			self.var.name = self.base_name + "[%d]"%i
-			lines += self.var.emit_unpack()
+			lines += self.var.emit_validate_obj()
+		return lines
+	def emit_unpack_msg(self):
+		lines = []
+		for i in range(self.size):
+			self.var.name = self.base_name + "[%d]"%i
+			lines += self.var.emit_unpack_msg()
 		return lines
 	def emit_pack(self):
 		lines = []
@@ -397,9 +427,9 @@ class NetArray(NetVariable):
 			self.var.name = self.base_name + "[%d]"%i
 			lines += self.var.emit_pack()
 		return lines
-	def emit_unpack_check(self):
+	def emit_unpack_msg_check(self):
 		lines = []
 		for i in range(self.size):
 			self.var.name = self.base_name + "[%d]"%i
-			lines += self.var.emit_unpack_check()
+			lines += self.var.emit_unpack_msg_check()
 		return lines

--- a/datasrc/network.py
+++ b/datasrc/network.py
@@ -235,10 +235,10 @@ Objects = [
 	]),
 
 	NetObjectEx("DDNetCharacter", "character@netobj.ddnet.tw", [
-		NetIntAny("m_Flags"),
-		NetTick("m_FreezeEnd"),
+		NetIntAny("m_Flags", 0),
+		NetTick("m_FreezeEnd", 0),
 		NetIntRange("m_Jumps", -1, 255, 2),
-		NetIntAny("m_TeleCheckpoint"),
+		NetIntAny("m_TeleCheckpoint", -1),
 		NetIntRange("m_StrongWeakID", 0, 'MAX_CLIENTS-1', 0),
 
 		# New data fields for jump display, freeze bar and ninja bar
@@ -257,9 +257,9 @@ Objects = [
 	]),
 
 	NetObjectEx("GameInfoEx", "gameinfo@netobj.ddnet.tw", [
-		NetIntAny("m_Flags"),
-		NetIntAny("m_Version"),
-		NetIntAny("m_Flags2"),
+		NetIntAny("m_Flags", 0),
+		NetIntAny("m_Version", 0),
+		NetIntAny("m_Flags2", 0),
 	], validate_size=False),
 
 	# The code assumes that this has the same in-memory representation as
@@ -312,12 +312,12 @@ Objects = [
 
 	# Switch state for a player team.
 	NetObjectEx("SwitchState", "switch-state@netobj.ddnet.tw", [
-		NetIntAny("m_HighestSwitchNumber"),
+		NetIntAny("m_HighestSwitchNumber", 0),
 		# 256 switches / 32 bits = 8 int32
-		NetArray(NetIntAny("m_aStatus"), 8),
+		NetArray(NetIntAny("m_aStatus", 0), 8),
 		# send the endtick of up to 4 timed switchers
-		NetArray(NetIntAny("m_aSwitchNumbers"), 4),
-		NetArray(NetIntAny("m_aEndTicks"), 4),
+		NetArray(NetIntAny("m_aSwitchNumbers", 0), 4),
+		NetArray(NetIntAny("m_aEndTicks", 0), 4),
 	], validate_size=False),
 
 	# Switch info for map items

--- a/datasrc/network.py
+++ b/datasrc/network.py
@@ -246,10 +246,9 @@ Objects = [
 		NetIntRange("m_JumpedTotal", -1, 255, -1),
 		NetTick("m_NinjaActivationTick", -1),
 		NetTick("m_FreezeStart", -1),
-		# New data fields for improved target accuracy and speed display
+		# New data fields for improved target accuracy
 		NetIntAny("m_TargetX", 0),
 		NetIntAny("m_TargetY", 0),
-		NetIntAny("m_RampValue", 1),
 	], validate_size=False),
 
 	NetObjectEx("DDNetPlayer", "player@netobj.ddnet.tw", [

--- a/datasrc/network.py
+++ b/datasrc/network.py
@@ -11,7 +11,7 @@ CharacterFlags = ["SOLO", "JETPACK", "NO_COLLISION", "ENDLESS_HOOK", "ENDLESS_JU
                   "NO_HAMMER_HIT", "NO_SHOTGUN_HIT", "NO_GRENADE_HIT", "NO_LASER_HIT", "NO_HOOK",
                   "TELEGUN_GUN", "TELEGUN_GRENADE", "TELEGUN_LASER",
                   "WEAPON_HAMMER", "WEAPON_GUN", "WEAPON_SHOTGUN", "WEAPON_GRENADE", "WEAPON_LASER", "WEAPON_NINJA",
-				  "NO_MOVEMENTS"]
+				  "NO_MOVEMENTS", "IN_FREEZE", "PRACTICE_MODE"]
 GameInfoFlags = [
 	"TIMESCORE", "GAMETYPE_RACE", "GAMETYPE_FASTCAP", "GAMETYPE_FNG",
 	"GAMETYPE_DDRACE", "GAMETYPE_DDNET", "GAMETYPE_BLOCK_WORLDS",
@@ -237,21 +237,20 @@ Objects = [
 	NetObjectEx("DDNetCharacter", "character@netobj.ddnet.tw", [
 		NetIntAny("m_Flags"),
 		NetTick("m_FreezeEnd"),
-		NetIntRange("m_Jumps", -1, 255),
+		NetIntRange("m_Jumps", -1, 255, 2),
 		NetIntAny("m_TeleCheckpoint"),
-		NetIntRange("m_StrongWeakID", 0, 'MAX_CLIENTS-1'),
-	]),
+		NetIntRange("m_StrongWeakID", 0, 'MAX_CLIENTS-1', 0),
 
-	NetObjectEx("DDNetCharacterDisplayInfo", "character-display-info@netobj.ddnet.tw", [
-		NetIntRange("m_JumpedTotal", 0, 255),
-		NetTick("m_NinjaActivationTick"),
-		NetTick("m_FreezeTick"),
-		NetBool("m_IsInFreeze"),
-		NetBool("m_IsInPracticeMode"),
-		NetIntAny("m_TargetX"),
-		NetIntAny("m_TargetY"),
-		NetIntAny("m_RampValue"),
-	]),
+		# New data fields for jump display, freeze bar and ninja bar
+		# Default values indicate that these values should not be used
+		NetIntRange("m_JumpedTotal", -1, 255, -1),
+		NetTick("m_NinjaActivationTick", -1),
+		NetTick("m_FreezeStart", -1),
+		# New data fields for improved target accuracy and speed display
+		NetIntAny("m_TargetX", 0),
+		NetIntAny("m_TargetY", 0),
+		NetIntAny("m_RampValue", 1),
+	], validate_size=False),
 
 	NetObjectEx("DDNetPlayer", "player@netobj.ddnet.tw", [
 		NetIntAny("m_Flags"),

--- a/src/engine/client.h
+++ b/src/engine/client.h
@@ -7,6 +7,9 @@
 #include "graphics.h"
 #include "message.h"
 #include <base/hash.h>
+
+#include <game/generated/protocol.h>
+
 #include <engine/friends.h>
 
 struct SWarning;
@@ -292,6 +295,8 @@ public:
 	virtual void Echo(const char *pString) = 0;
 	virtual bool CanDisplayWarning() = 0;
 	virtual bool IsDisplayingWarning() = 0;
+
+	virtual CNetObjHandler *GetNetObjHandler() = 0;
 };
 
 void SnapshotRemoveExtraProjectileInfo(unsigned char *pData);

--- a/src/engine/client.h
+++ b/src/engine/client.h
@@ -186,7 +186,8 @@ public:
 	enum
 	{
 		SNAP_CURRENT = 0,
-		SNAP_PREV = 1
+		SNAP_PREV = 1,
+		NUM_SNAPSHOT_TYPES = 2,
 	};
 
 	// TODO: Refactor: should redo this a bit i think, too many virtual calls

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -17,7 +17,6 @@
 #include <game/client/components/menus.h>
 #include <game/generated/protocol.h>
 
-#include <engine/client.h>
 #include <engine/config.h>
 #include <engine/console.h>
 #include <engine/discord.h>
@@ -1941,19 +1940,25 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket, int Conn, bool Dummy)
 				{
 					m_SnapshotParts[Conn] = 0;
 					m_CurrentRecvTick[Conn] = GameTick;
+					m_SnapshotIncomingDataSize[Conn] = 0;
 				}
 
-				mem_copy((char *)m_aSnapshotIncomingData + Part * MAX_SNAPSHOT_PACKSIZE, pData, clamp(PartSize, 0, (int)sizeof(m_aSnapshotIncomingData) - Part * MAX_SNAPSHOT_PACKSIZE));
-				m_SnapshotParts[Conn] |= 1 << Part;
+				mem_copy((char *)m_aSnapshotIncomingData[Conn] + Part * MAX_SNAPSHOT_PACKSIZE, pData, clamp(PartSize, 0, (int)sizeof(m_aSnapshotIncomingData[Conn]) - Part * MAX_SNAPSHOT_PACKSIZE));
+				m_SnapshotParts[Conn] |= (uint64_t)(1) << Part;
 
-				if(m_SnapshotParts[Conn] == (unsigned)((1 << NumParts) - 1))
+				if(Part == NumParts - 1)
+				{
+					m_SnapshotIncomingDataSize[Conn] = (NumParts - 1) * MAX_SNAPSHOT_PACKSIZE + PartSize;
+				}
+
+				if((NumParts < CSnapshot::MAX_PARTS && m_SnapshotParts[Conn] == (((uint64_t)(1) << NumParts) - 1)) ||
+					(NumParts == CSnapshot::MAX_PARTS && m_SnapshotParts[Conn] == std::numeric_limits<uint64_t>::max()))
 				{
 					static CSnapshot Emptysnap;
 					CSnapshot *pDeltaShot = &Emptysnap;
 					unsigned char aTmpBuffer2[CSnapshot::MAX_SIZE];
 					unsigned char aTmpBuffer3[CSnapshot::MAX_SIZE];
 					CSnapshot *pTmpBuffer3 = (CSnapshot *)aTmpBuffer3; // Fix compiler warning for strict-aliasing
-					const int CompleteSize = (NumParts - 1) * MAX_SNAPSHOT_PACKSIZE + PartSize;
 
 					// reset snapshoting
 					m_SnapshotParts[Conn] = 0;
@@ -1978,8 +1983,8 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket, int Conn, bool Dummy)
 							}
 
 							// ack snapshot
-							// TODO: combine this with the input message
 							m_AckGameTick[Conn] = -1;
+							SendInput();
 							return;
 						}
 					}
@@ -1988,11 +1993,11 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket, int Conn, bool Dummy)
 					const void *pDeltaData = m_SnapshotDelta.EmptyDelta();
 					int DeltaSize = sizeof(int) * 3;
 
-					if(CompleteSize)
+					if(m_SnapshotIncomingDataSize[Conn])
 					{
-						int IntSize = CVariableInt::Decompress(m_aSnapshotIncomingData, CompleteSize, aTmpBuffer2, sizeof(aTmpBuffer2));
+						int IntSize = CVariableInt::Decompress(m_aSnapshotIncomingData[Conn], m_SnapshotIncomingDataSize[Conn], aTmpBuffer2, sizeof(aTmpBuffer2));
 
-						if(IntSize < 0) // failure during decompression, bail
+						if(IntSize < 0) // failure during decompression
 							return;
 
 						pDeltaData = aTmpBuffer2;
@@ -2013,7 +2018,7 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket, int Conn, bool Dummy)
 						{
 							char aBuf[256];
 							str_format(aBuf, sizeof(aBuf), "snapshot crc error #%d - tick=%d wantedcrc=%d gotcrc=%d compressed_size=%d delta_tick=%d",
-								m_SnapCrcErrors, GameTick, Crc, pTmpBuffer3->Crc(), CompleteSize, DeltaTick);
+								m_SnapCrcErrors, GameTick, Crc, pTmpBuffer3->Crc(), m_SnapshotIncomingDataSize[Conn], DeltaTick);
 							m_pConsole->Print(IConsole::OUTPUT_LEVEL_DEBUG, "client", aBuf);
 						}
 

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -1079,14 +1079,38 @@ void CClient::DebugRender()
 	// render rates
 	{
 		int y = 0;
-		for(int i = 0; i < 256; i++)
+		str_format(aBuffer, sizeof(aBuffer), "%5s %20s: %8s %8s %8s", "ID", "Name", "Rate", "Updates", "R/U");
+		Graphics()->QuadsText(2, 100 + y * 12, 16, aBuffer);
+		y++;
+		for(int i = 0; i < NUM_NETOBJTYPES; i++)
 		{
 			if(m_SnapshotDelta.GetDataRate(i))
 			{
-				str_format(aBuffer, sizeof(aBuffer), "%4d %20s: %8d %8d %8d", i, GameClient()->GetItemName(i), m_SnapshotDelta.GetDataRate(i) / 8, m_SnapshotDelta.GetDataUpdates(i),
+				str_format(aBuffer, sizeof(aBuffer), "%5d %20s: %8d %8d %8d", i, GameClient()->GetItemName(i), m_SnapshotDelta.GetDataRate(i) / 8, m_SnapshotDelta.GetDataUpdates(i),
 					(m_SnapshotDelta.GetDataRate(i) / m_SnapshotDelta.GetDataUpdates(i)) / 8);
 				Graphics()->QuadsText(2, 100 + y * 12, 16, aBuffer);
 				y++;
+			}
+		}
+		for(int i = CSnapshot::MAX_TYPE; i > (CSnapshot::MAX_TYPE - 64); i--)
+		{
+			if(m_SnapshotDelta.GetDataRate(i) && m_aSnapshots[g_Config.m_ClDummy][IClient::SNAP_CURRENT])
+			{
+				int Type = m_aSnapshots[g_Config.m_ClDummy][IClient::SNAP_CURRENT]->m_pAltSnap->GetExternalItemType(i);
+				if(Type == -1)
+				{
+					str_format(aBuffer, sizeof(aBuffer), "%5d %20s: %8d %8d %8d", i, "Unknown UUID", m_SnapshotDelta.GetDataRate(i) / 8, m_SnapshotDelta.GetDataUpdates(i),
+						(m_SnapshotDelta.GetDataRate(i) / m_SnapshotDelta.GetDataUpdates(i)) / 8);
+					Graphics()->QuadsText(2, 100 + y * 12, 16, aBuffer);
+					y++;
+				}
+				else if(Type != i)
+				{
+					str_format(aBuffer, sizeof(aBuffer), "%5d %20s: %8d %8d %8d", Type, GameClient()->GetItemName(Type), m_SnapshotDelta.GetDataRate(i) / 8, m_SnapshotDelta.GetDataUpdates(i),
+						(m_SnapshotDelta.GetDataRate(i) / m_SnapshotDelta.GetDataUpdates(i)) / 8);
+					Graphics()->QuadsText(2, 100 + y * 12, 16, aBuffer);
+					y++;
+				}
 			}
 		}
 	}
@@ -2047,7 +2071,7 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket, int Conn, bool Dummy)
 					m_SnapshotStorage[Conn].PurgeUntil(PurgeTick);
 
 					// add new
-					m_SnapshotStorage[Conn].Add(GameTick, time_get(), SnapSize, pTmpBuffer3, 1);
+					m_SnapshotStorage[Conn].Add(GameTick, time_get(), SnapSize, pTmpBuffer3, true);
 
 					if(!Dummy)
 					{

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -120,11 +120,6 @@ class CClient : public IClient, public CDemoPlayer::IListener
 	IDiscord *m_pDiscord;
 	ISteam *m_pSteam;
 
-	enum
-	{
-		NUM_SNAPSHOT_TYPES = 2,
-	};
-
 	CNetClient m_NetClient[NUM_CONNS];
 	CDemoPlayer m_DemoPlayer;
 	CDemoRecorder m_DemoRecorder[RECORDER_MAX];
@@ -143,7 +138,7 @@ class CClient : public IClient, public CDemoPlayer::IListener
 	bool m_HaveGlobalTcpAddr = false;
 	NETADDR m_GlobalTcpAddr;
 
-	unsigned m_SnapshotParts[NUM_DUMMIES];
+	uint64_t m_SnapshotParts[NUM_DUMMIES];
 	int64_t m_LocalStartTime;
 
 	IGraphics::CTextureHandle m_DebugFont;
@@ -239,7 +234,8 @@ class CClient : public IClient, public CDemoPlayer::IListener
 	CSnapshotStorage::CHolder *m_aSnapshots[NUM_DUMMIES][NUM_SNAPSHOT_TYPES];
 
 	int m_ReceivedSnapshots[NUM_DUMMIES];
-	char m_aSnapshotIncomingData[CSnapshot::MAX_SIZE];
+	char m_aSnapshotIncomingData[NUM_DUMMIES][CSnapshot::MAX_SIZE];
+	int m_SnapshotIncomingDataSize[NUM_DUMMIES];
 
 	CSnapshotStorage::CHolder m_aDemorecSnapshotHolders[NUM_SNAPSHOT_TYPES];
 	char *m_aDemorecSnapshotData[NUM_SNAPSHOT_TYPES][2][CSnapshot::MAX_SIZE];

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -390,6 +390,8 @@ public:
 	void ProcessServerInfo(int Type, NETADDR *pFrom, const void *pData, int DataSize);
 	void ProcessServerPacket(CNetChunk *pPacket, int Conn, bool Dummy);
 
+	int UnpackAndValidateSnapshot(CSnapshot *pFrom, CSnapshot *pTo);
+
 	void ResetMapDownload();
 	void FinishMapDownload();
 

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -3745,10 +3745,6 @@ void CServer::SnapFreeID(int ID)
 
 void *CServer::SnapNewItem(int Type, int ID, int Size)
 {
-	if(Type > 0xffff)
-	{
-		g_UuidManager.GetUuid(Type);
-	}
 	dbg_assert(ID >= -1 && ID <= 0xffff, "incorrect id");
 	return ID < 0 ? 0 : m_SnapshotBuilder.NewItem(Type, ID, Size);
 }

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -974,11 +974,11 @@ void CServer::DoSnapshot()
 
 			int Crc = pData->Crc();
 
-			// remove old snapshos
+			// remove old snapshots
 			// keep 3 seconds worth of snapshots
 			m_aClients[i].m_Snapshots.PurgeUntil(m_CurrentGameTick - SERVER_TICK_SPEED * 3);
 
-			// save it the snapshot
+			// save the snapshot
 			m_aClients[i].m_Snapshots.Add(m_CurrentGameTick, time_get(), SnapshotSize, pData, 0);
 
 			// find snapshot that we can perform delta against

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -979,7 +979,7 @@ void CServer::DoSnapshot()
 			m_aClients[i].m_Snapshots.PurgeUntil(m_CurrentGameTick - SERVER_TICK_SPEED * 3);
 
 			// save the snapshot
-			m_aClients[i].m_Snapshots.Add(m_CurrentGameTick, time_get(), SnapshotSize, pData, false);
+			m_aClients[i].m_Snapshots.Add(m_CurrentGameTick, time_get(), SnapshotSize, pData, 0, nullptr);
 
 			// find snapshot that we can perform delta against
 			static CSnapshot s_EmptySnap;

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -979,7 +979,7 @@ void CServer::DoSnapshot()
 			m_aClients[i].m_Snapshots.PurgeUntil(m_CurrentGameTick - SERVER_TICK_SPEED * 3);
 
 			// save the snapshot
-			m_aClients[i].m_Snapshots.Add(m_CurrentGameTick, time_get(), SnapshotSize, pData, 0);
+			m_aClients[i].m_Snapshots.Add(m_CurrentGameTick, time_get(), SnapshotSize, pData, false);
 
 			// find snapshot that we can perform delta against
 			static CSnapshot s_EmptySnap;

--- a/src/engine/shared/packer.cpp
+++ b/src/engine/shared/packer.cpp
@@ -123,6 +123,35 @@ int CUnpacker::GetIntOrDefault(int Default)
 	return GetInt();
 }
 
+int CUnpacker::GetUncompressedInt()
+{
+	if(m_Error)
+		return 0;
+
+	if(m_pCurrent + 4 > m_pEnd)
+	{
+		m_Error = 1;
+		return 0;
+	}
+
+	int i = *(int *)m_pCurrent;
+	m_pCurrent += 4;
+	return i;
+}
+
+int CUnpacker::GetUncompressedIntOrDefault(int Default)
+{
+	if(m_Error)
+	{
+		return 0;
+	}
+	if(m_pCurrent == m_pEnd)
+	{
+		return Default;
+	}
+	return GetUncompressedInt();
+}
+
 const char *CUnpacker::GetString(int SanitizeType)
 {
 	if(m_Error)

--- a/src/engine/shared/packer.h
+++ b/src/engine/shared/packer.h
@@ -46,6 +46,8 @@ public:
 	void Reset(const void *pData, int Size);
 	int GetInt();
 	int GetIntOrDefault(int Default);
+	int GetUncompressedInt();
+	int GetUncompressedIntOrDefault(int Default);
 	const char *GetString(int SanitizeType = SANITIZE);
 	const unsigned char *GetRaw(int Size);
 	bool Error() const { return m_Error; }

--- a/src/engine/shared/snapshot.cpp
+++ b/src/engine/shared/snapshot.cpp
@@ -27,6 +27,11 @@ int CSnapshot::GetItemSize(int Index) const
 int CSnapshot::GetItemType(int Index) const
 {
 	int InternalType = GetItem(Index)->Type();
+	return GetExternalItemType(InternalType);
+}
+
+int CSnapshot::GetExternalItemType(int InternalType) const
+{
 	if(InternalType < OFFSET_UUID_TYPE)
 	{
 		return InternalType;
@@ -37,7 +42,6 @@ int CSnapshot::GetItemType(int Index) const
 	{
 		return InternalType;
 	}
-
 	CSnapshotItem *pTypeItem = GetItem(TypeItemIndex);
 	CUuid Uuid;
 	for(int i = 0; i < (int)sizeof(CUuid) / 4; i++)
@@ -471,7 +475,7 @@ void CSnapshotStorage::PurgeUntil(int Tick)
 	m_pLast = 0;
 }
 
-void CSnapshotStorage::Add(int Tick, int64_t Tagtime, int DataSize, void *pData, int CreateAlt)
+void CSnapshotStorage::Add(int Tick, int64_t Tagtime, int DataSize, void *pData, bool CreateAlt)
 {
 	// allocate memory for holder + snapshot_data
 	int TotalSize = sizeof(CHolder) + DataSize;

--- a/src/engine/shared/snapshot.cpp
+++ b/src/engine/shared/snapshot.cpp
@@ -475,13 +475,15 @@ void CSnapshotStorage::PurgeUntil(int Tick)
 	m_pLast = 0;
 }
 
-void CSnapshotStorage::Add(int Tick, int64_t Tagtime, int DataSize, void *pData, bool CreateAlt)
+void CSnapshotStorage::Add(int Tick, int64_t Tagtime, int DataSize, void *pData, int AltDataSize, void *pAltData)
 {
 	// allocate memory for holder + snapshot_data
 	int TotalSize = sizeof(CHolder) + DataSize;
 
-	if(CreateAlt)
-		TotalSize += DataSize;
+	if(AltDataSize > 0)
+	{
+		TotalSize += AltDataSize;
+	}
 
 	CHolder *pHolder = (CHolder *)malloc(TotalSize);
 
@@ -492,13 +494,17 @@ void CSnapshotStorage::Add(int Tick, int64_t Tagtime, int DataSize, void *pData,
 	pHolder->m_pSnap = (CSnapshot *)(pHolder + 1);
 	mem_copy(pHolder->m_pSnap, pData, DataSize);
 
-	if(CreateAlt) // create alternative if wanted
+	if(AltDataSize > 0) // create alternative if wanted
 	{
 		pHolder->m_pAltSnap = (CSnapshot *)(((char *)pHolder->m_pSnap) + DataSize);
-		mem_copy(pHolder->m_pAltSnap, pData, DataSize);
+		mem_copy(pHolder->m_pAltSnap, pAltData, AltDataSize);
+		pHolder->m_AltSnapSize = AltDataSize;
 	}
 	else
+	{
 		pHolder->m_pAltSnap = 0;
+		pHolder->m_AltSnapSize = 0;
+	}
 
 	// link
 	pHolder->m_pNext = 0;

--- a/src/engine/shared/snapshot.h
+++ b/src/engine/shared/snapshot.h
@@ -108,6 +108,8 @@ public:
 		int m_Tick;
 
 		int m_SnapSize;
+		int m_AltSnapSize;
+
 		CSnapshot *m_pSnap;
 		CSnapshot *m_pAltSnap;
 	};
@@ -120,7 +122,7 @@ public:
 	void Init();
 	void PurgeAll();
 	void PurgeUntil(int Tick);
-	void Add(int Tick, int64_t Tagtime, int DataSize, void *pData, bool CreateAlt);
+	void Add(int Tick, int64_t Tagtime, int DataSize, void *pData, int AltDataSize, void *pAltData);
 	int Get(int Tick, int64_t *pTagtime, CSnapshot **ppData, CSnapshot **ppAltData);
 };
 

--- a/src/engine/shared/snapshot.h
+++ b/src/engine/shared/snapshot.h
@@ -48,6 +48,7 @@ public:
 	int GetItemSize(int Index) const;
 	int GetItemIndex(int Key) const;
 	int GetItemType(int Index) const;
+	int GetExternalItemType(int InternalType) const;
 	void *FindItem(int Type, int ID) const;
 
 	unsigned Crc();
@@ -119,7 +120,7 @@ public:
 	void Init();
 	void PurgeAll();
 	void PurgeUntil(int Tick);
-	void Add(int Tick, int64_t Tagtime, int DataSize, void *pData, int CreateAlt);
+	void Add(int Tick, int64_t Tagtime, int DataSize, void *pData, bool CreateAlt);
 	int Get(int Tick, int64_t *pTagtime, CSnapshot **ppData, CSnapshot **ppAltData);
 };
 

--- a/src/game/client/components/freezebars.cpp
+++ b/src/game/client/components/freezebars.cpp
@@ -10,13 +10,14 @@ void CFreezeBars::RenderFreezeBar(const int ClientID)
 
 	// pCharacter contains the predicted character for local players or the last snap for players who are spectated
 	CCharacterCore *pCharacter = &m_pClient->m_aClients[ClientID].m_Predicted;
-	if(pCharacter->m_FreezeEnd <= 0.0f || pCharacter->m_FreezeTick == 0 || !m_pClient->m_Snap.m_aCharacters[ClientID].m_HasExtendedDisplayInfo || (pCharacter->m_IsInFreeze && g_Config.m_ClFreezeBarsAlphaInsideFreeze == 0))
+
+	if(pCharacter->m_FreezeEnd <= 0.0f || pCharacter->m_FreezeStart == 0 || !m_pClient->m_Snap.m_aCharacters[ClientID].m_HasExtendedDisplayInfo || (pCharacter->m_IsInFreeze && g_Config.m_ClFreezeBarsAlphaInsideFreeze == 0))
 	{
 		return;
 	}
 
-	const int Max = pCharacter->m_FreezeEnd - pCharacter->m_FreezeTick;
-	float FreezeProgress = clamp(Max - (Client()->GameTick(g_Config.m_ClDummy) - pCharacter->m_FreezeTick), 0, Max) / (float)Max;
+	const int Max = pCharacter->m_FreezeEnd - pCharacter->m_FreezeStart;
+	float FreezeProgress = clamp(Max - (Client()->GameTick(g_Config.m_ClDummy) - pCharacter->m_FreezeStart), 0, Max) / (float)Max;
 	if(FreezeProgress <= 0.0f)
 	{
 		return;

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -1126,7 +1126,7 @@ void CHud::RenderPlayerState(const int ClientID)
 	{
 		y += 12;
 	}
-	if(m_pClient->m_Snap.m_aCharacters[ClientID].m_HasExtendedDisplayInfo && m_pClient->m_Snap.m_aCharacters[ClientID].m_ExtendedDisplayInfo.m_IsInPracticeMode)
+	if(m_pClient->m_Snap.m_aCharacters[ClientID].m_HasExtendedDisplayInfo && m_pClient->m_Snap.m_aCharacters[ClientID].m_ExtendedData.m_Flags & CHARACTERFLAG_PRACTICE_MODE)
 	{
 		Graphics()->TextureSet(m_pClient->m_HudSkin.m_SpriteHudPracticeMode);
 		Graphics()->RenderQuadContainerAsSprite(m_HudQuadContainerIndex, m_PracticeModeOffset, x, y);
@@ -1424,15 +1424,15 @@ void CHud::RenderMovementInformation(const int ClientID)
 	if(m_pClient->m_Snap.m_aCharacters[ClientID].m_HasExtendedDisplayInfo)
 	{
 		// On DDNet servers the actual speed on X axis is displayed, i.e. VelspeedX * Ramp
-		DisplaySpeedX *= (m_pClient->m_Snap.m_aCharacters[ClientID].m_ExtendedDisplayInfo.m_RampValue / 1000.0f);
+		DisplaySpeedX *= (m_pClient->m_Snap.m_aCharacters[ClientID].m_ExtendedData.m_RampValue / 1000.0f);
 	}
 
 	float Angle = 0.0f;
 	if(m_pClient->m_Snap.m_aCharacters[ClientID].m_HasExtendedDisplayInfo)
 	{
 		// On DDNet servers the more accurate angle is displayed, calculated from the target coordinates
-		CNetObj_DDNetCharacterDisplayInfo *CharacterDisplayInfo = &m_pClient->m_Snap.m_aCharacters[ClientID].m_ExtendedDisplayInfo;
-		Angle = atan2f(CharacterDisplayInfo->m_TargetY, CharacterDisplayInfo->m_TargetX);
+		CNetObj_DDNetCharacter *ExtendedData = &m_pClient->m_Snap.m_aCharacters[ClientID].m_ExtendedData;
+		Angle = atan2f(ExtendedData->m_TargetY, ExtendedData->m_TargetX);
 	}
 	else
 	{

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -1420,12 +1420,12 @@ void CHud::RenderMovementInformation(const int ClientID)
 	}
 	// We show the speed in Blocks per Second (Bps) and therefore have to divide by the block size
 	float DisplaySpeedX = VelspeedX / 32;
+	float VelspeedLength = length(vec2(Character->m_VelX / 256.0f, Character->m_VelY / 256.0f)) * TicksPerSecond;
+	// Todo: Use Velramp tuning of each individual player
+	// Since these tuning parameters are almost never changed, the default values are sufficient in most cases
+	float Ramp = VelocityRamp(VelspeedLength, m_pClient->m_Tuning[g_Config.m_ClDummy].m_VelrampStart, m_pClient->m_Tuning[g_Config.m_ClDummy].m_VelrampRange, m_pClient->m_Tuning[g_Config.m_ClDummy].m_VelrampCurvature);
+	DisplaySpeedX *= Ramp;
 	float DisplaySpeedY = VelspeedY / 32;
-	if(m_pClient->m_Snap.m_aCharacters[ClientID].m_HasExtendedDisplayInfo)
-	{
-		// On DDNet servers the actual speed on X axis is displayed, i.e. VelspeedX * Ramp
-		DisplaySpeedX *= (m_pClient->m_Snap.m_aCharacters[ClientID].m_ExtendedData.m_RampValue / 1000.0f);
-	}
 
 	float Angle = 0.0f;
 	if(m_pClient->m_Snap.m_aCharacters[ClientID].m_HasExtendedDisplayInfo)

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -84,19 +84,19 @@ float CPlayers::GetPlayerTargetAngle(
 		AngleIntraTick = Client()->IntraGameTick(g_Config.m_ClDummy);
 	if(ClientID >= 0 && m_pClient->m_Snap.m_aCharacters[ClientID].m_HasExtendedDisplayInfo)
 	{
-		CNetObj_DDNetCharacterDisplayInfo *CharacterDisplayInfo = &m_pClient->m_Snap.m_aCharacters[ClientID].m_ExtendedDisplayInfo;
-		if(m_pClient->m_Snap.m_aCharacters[ClientID].m_PrevExtendedDisplayInfo)
+		CNetObj_DDNetCharacter *ExtendedData = &m_pClient->m_Snap.m_aCharacters[ClientID].m_ExtendedData;
+		if(m_pClient->m_Snap.m_aCharacters[ClientID].m_PrevExtendedData)
 		{
-			const CNetObj_DDNetCharacterDisplayInfo *PrevCharacterDisplayInfo = m_pClient->m_Snap.m_aCharacters[ClientID].m_PrevExtendedDisplayInfo;
+			const CNetObj_DDNetCharacter *PrevExtendedData = m_pClient->m_Snap.m_aCharacters[ClientID].m_PrevExtendedData;
 
-			float MixX = mix((float)PrevCharacterDisplayInfo->m_TargetX, (float)CharacterDisplayInfo->m_TargetX, AngleIntraTick);
-			float MixY = mix((float)PrevCharacterDisplayInfo->m_TargetY, (float)CharacterDisplayInfo->m_TargetY, AngleIntraTick);
+			float MixX = mix((float)PrevExtendedData->m_TargetX, (float)ExtendedData->m_TargetX, AngleIntraTick);
+			float MixY = mix((float)PrevExtendedData->m_TargetY, (float)ExtendedData->m_TargetY, AngleIntraTick);
 
 			return angle(vec2(MixX, MixY));
 		}
 		else
 		{
-			return angle(vec2(CharacterDisplayInfo->m_TargetX, CharacterDisplayInfo->m_TargetY));
+			return angle(vec2(ExtendedData->m_TargetX, ExtendedData->m_TargetY));
 		}
 	}
 	else

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1324,7 +1324,7 @@ void CGameClient::OnNewSnapshot()
 					m_Snap.m_aCharacters[Item.m_ID].m_PrevExtendedData = (const CNetObj_DDNetCharacter *)Client()->SnapFindItem(IClient::SNAP_PREV, NETOBJTYPE_DDNETCHARACTER, Item.m_ID);
 					m_Snap.m_aCharacters[Item.m_ID].m_HasExtendedData = true;
 					m_Snap.m_aCharacters[Item.m_ID].m_HasExtendedDisplayInfo = false;
-					if(Item.m_DataSize >= 44)
+					if(Item.m_DataSize >= 40)
 					{
 						m_Snap.m_aCharacters[Item.m_ID].m_HasExtendedDisplayInfo = true;
 					}

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1123,26 +1123,6 @@ void CGameClient::OnNewSnapshot()
 
 	m_NewTick = true;
 
-	// secure snapshot
-	{
-		int Num = Client()->SnapNumItems(IClient::SNAP_CURRENT);
-		for(int Index = 0; Index < Num; Index++)
-		{
-			IClient::CSnapItem Item;
-			void *pData = Client()->SnapGetItem(IClient::SNAP_CURRENT, Index, &Item);
-			if(m_NetObjHandler.ValidateObj(Item.m_Type, pData, Item.m_DataSize) != 0)
-			{
-				if(g_Config.m_Debug && Item.m_Type != UUID_UNKNOWN)
-				{
-					char aBuf[256];
-					str_format(aBuf, sizeof(aBuf), "invalidated index=%d type=%d (%s) size=%d id=%d", Index, Item.m_Type, m_NetObjHandler.GetObjName(Item.m_Type), Item.m_DataSize, Item.m_ID);
-					Console()->Print(IConsole::OUTPUT_LEVEL_DEBUG, "game", aBuf);
-				}
-				Client()->SnapInvalidateItem(IClient::SNAP_CURRENT, Index);
-			}
-		}
-	}
-
 	ProcessEvents();
 
 #ifdef CONF_DEBUG
@@ -1324,7 +1304,7 @@ void CGameClient::OnNewSnapshot()
 					m_Snap.m_aCharacters[Item.m_ID].m_PrevExtendedData = (const CNetObj_DDNetCharacter *)Client()->SnapFindItem(IClient::SNAP_PREV, NETOBJTYPE_DDNETCHARACTER, Item.m_ID);
 					m_Snap.m_aCharacters[Item.m_ID].m_HasExtendedData = true;
 					m_Snap.m_aCharacters[Item.m_ID].m_HasExtendedDisplayInfo = false;
-					if(Item.m_DataSize >= 40)
+					if(pCharacterData->m_JumpedTotal != -1)
 					{
 						m_Snap.m_aCharacters[Item.m_ID].m_HasExtendedDisplayInfo = true;
 					}
@@ -3270,6 +3250,11 @@ bool CGameClient::CanDisplayWarning()
 bool CGameClient::IsDisplayingWarning()
 {
 	return m_Menus.GetCurPopup() == CMenus::POPUP_WARNING;
+}
+
+CNetObjHandler *CGameClient::GetNetObjHandler()
+{
+	return &m_NetObjHandler;
 }
 
 void CGameClient::SnapCollectEntities()

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1321,8 +1321,13 @@ void CGameClient::OnNewSnapshot()
 				if(Item.m_ID < MAX_CLIENTS)
 				{
 					m_Snap.m_aCharacters[Item.m_ID].m_ExtendedData = *pCharacterData;
+					m_Snap.m_aCharacters[Item.m_ID].m_PrevExtendedData = (const CNetObj_DDNetCharacter *)Client()->SnapFindItem(IClient::SNAP_PREV, NETOBJTYPE_DDNETCHARACTER, Item.m_ID);
 					m_Snap.m_aCharacters[Item.m_ID].m_HasExtendedData = true;
-
+					m_Snap.m_aCharacters[Item.m_ID].m_HasExtendedDisplayInfo = false;
+					if(Item.m_DataSize >= 44)
+					{
+						m_Snap.m_aCharacters[Item.m_ID].m_HasExtendedDisplayInfo = true;
+					}
 					CClientData *pClient = &m_aClients[Item.m_ID];
 					// Collision
 					pClient->m_Solo = pCharacterData->m_Flags & CHARACTERFLAG_SOLO;
@@ -1350,20 +1355,6 @@ void CGameClient::OnNewSnapshot()
 					pClient->m_HasTelegunLaser = pCharacterData->m_Flags & CHARACTERFLAG_TELEGUN_LASER;
 
 					pClient->m_Predicted.ReadDDNet(pCharacterData);
-				}
-			}
-			else if(Item.m_Type == NETOBJTYPE_DDNETCHARACTERDISPLAYINFO)
-			{
-				const CNetObj_DDNetCharacterDisplayInfo *pCharacterDisplayInfo = (const CNetObj_DDNetCharacterDisplayInfo *)pData;
-
-				if(Item.m_ID < MAX_CLIENTS)
-				{
-					m_Snap.m_aCharacters[Item.m_ID].m_ExtendedDisplayInfo = *pCharacterDisplayInfo;
-					m_Snap.m_aCharacters[Item.m_ID].m_PrevExtendedDisplayInfo = (const CNetObj_DDNetCharacterDisplayInfo *)Client()->SnapFindItem(IClient::SNAP_PREV, NETOBJTYPE_DDNETCHARACTERDISPLAYINFO, Item.m_ID);
-					m_Snap.m_aCharacters[Item.m_ID].m_HasExtendedDisplayInfo = true;
-
-					CClientData *pClient = &m_aClients[Item.m_ID];
-					pClient->m_Predicted.ReadDDNetDisplayInfo(pCharacterDisplayInfo);
 				}
 			}
 			else if(Item.m_Type == NETOBJTYPE_SPECCHAR)
@@ -2432,7 +2423,6 @@ void CGameClient::UpdatePrediction()
 			int GameTeam = (m_Snap.m_pGameInfoObj->m_GameFlags & GAMEFLAG_TEAMS) ? m_aClients[i].m_Team : i;
 			m_GameWorld.NetCharAdd(i, &m_Snap.m_aCharacters[i].m_Cur,
 				m_Snap.m_aCharacters[i].m_HasExtendedData ? &m_Snap.m_aCharacters[i].m_ExtendedData : 0,
-				m_Snap.m_aCharacters[i].m_HasExtendedDisplayInfo ? &m_Snap.m_aCharacters[i].m_ExtendedDisplayInfo : 0,
 				GameTeam, IsLocal);
 		}
 

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -305,10 +305,8 @@ public:
 			CNetObj_Character m_Cur;
 
 			CNetObj_DDNetCharacter m_ExtendedData;
+			const CNetObj_DDNetCharacter *m_PrevExtendedData;
 			bool m_HasExtendedData;
-
-			const CNetObj_DDNetCharacterDisplayInfo *m_PrevExtendedDisplayInfo;
-			CNetObj_DDNetCharacterDisplayInfo m_ExtendedDisplayInfo;
 			bool m_HasExtendedDisplayInfo;
 
 			// interpolated position

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -522,6 +522,7 @@ public:
 	bool IsLocalCharSuper();
 	bool CanDisplayWarning() override;
 	bool IsDisplayingWarning() override;
+	CNetObjHandler *GetNetObjHandler() override;
 
 	void LoadGameSkin(const char *pPath, bool AsDir = false);
 	void LoadEmoticonsSkin(const char *pPath, bool AsDir = false);

--- a/src/game/client/prediction/entities/character.cpp
+++ b/src/game/client/prediction/entities/character.cpp
@@ -1050,10 +1050,10 @@ bool CCharacter::Freeze(int Seconds)
 		return false;
 	if((Seconds <= 0 || m_Super || m_FreezeTime == -1 || m_FreezeTime > Seconds * GameWorld()->GameTickSpeed()) && Seconds != -1)
 		return false;
-	if(m_Core.m_FreezeTick < GameWorld()->GameTick() - GameWorld()->GameTickSpeed() || Seconds == -1)
+	if(m_Core.m_FreezeStart < GameWorld()->GameTick() - GameWorld()->GameTickSpeed() || Seconds == -1)
 	{
 		m_FreezeTime = Seconds == -1 ? Seconds : Seconds * GameWorld()->GameTickSpeed();
-		m_Core.m_FreezeTick = GameWorld()->GameTick();
+		m_Core.m_FreezeStart = GameWorld()->GameTick();
 		return true;
 	}
 	return false;
@@ -1071,7 +1071,7 @@ bool CCharacter::UnFreeze()
 		if(!m_Core.m_aWeapons[m_Core.m_ActiveWeapon].m_Got)
 			m_Core.m_ActiveWeapon = WEAPON_GUN;
 		m_FreezeTime = 0;
-		m_Core.m_FreezeTick = 0;
+		m_Core.m_FreezeStart = 0;
 		m_FrozenLastTick = true;
 		return true;
 	}
@@ -1115,7 +1115,7 @@ CTeamsCore *CCharacter::TeamsCore()
 	return m_Core.m_pTeams;
 }
 
-CCharacter::CCharacter(CGameWorld *pGameWorld, int ID, CNetObj_Character *pChar, CNetObj_DDNetCharacter *pExtended, CNetObj_DDNetCharacterDisplayInfo *pExtendedDisplayInfo) :
+CCharacter::CCharacter(CGameWorld *pGameWorld, int ID, CNetObj_Character *pChar, CNetObj_DDNetCharacter *pExtended) :
 	CEntity(pGameWorld, CGameWorld::ENTTYPE_CHARACTER, vec2(0, 0), CCharacterCore::PhysicalSize())
 {
 	m_ID = ID;
@@ -1148,7 +1148,7 @@ CCharacter::CCharacter(CGameWorld *pGameWorld, int ID, CNetObj_Character *pChar,
 	m_LatestPrevInput = m_LatestInput = m_PrevInput = m_SavedInput = m_Input;
 
 	ResetPrediction();
-	Read(pChar, pExtended, pExtendedDisplayInfo, false);
+	Read(pChar, pExtended, false);
 }
 
 void CCharacter::ResetPrediction()
@@ -1164,7 +1164,7 @@ void CCharacter::ResetPrediction()
 	m_Core.m_NoCollision = false;
 	m_NumInputs = 0;
 	m_FreezeTime = 0;
-	m_Core.m_FreezeTick = 0;
+	m_Core.m_FreezeStart = 0;
 	m_Core.m_IsInFreeze = false;
 	m_DeepFreeze = false;
 	m_LiveFreeze = false;
@@ -1184,15 +1184,13 @@ void CCharacter::ResetPrediction()
 	m_LastTuneZoneTick = 0;
 }
 
-void CCharacter::Read(CNetObj_Character *pChar, CNetObj_DDNetCharacter *pExtended, CNetObj_DDNetCharacterDisplayInfo *pExtendedDisplayInfo, bool IsLocal)
+void CCharacter::Read(CNetObj_Character *pChar, CNetObj_DDNetCharacter *pExtended, bool IsLocal)
 {
 	m_Core.ReadCharacterCore((const CNetObj_CharacterCore *)pChar);
 	m_IsLocal = IsLocal;
 
 	if(pExtended)
 	{
-		m_Core.ReadDDNet(pExtended);
-
 		SetSolo(pExtended->m_Flags & CHARACTERFLAG_SOLO);
 		m_Super = pExtended->m_Flags & CHARACTERFLAG_SUPER;
 		if(m_Super)
@@ -1235,6 +1233,8 @@ void CCharacter::Read(CNetObj_Character *pChar, CNetObj_DDNetCharacter *pExtende
 		}
 		else
 			UnFreeze();
+
+		m_Core.ReadDDNet(pExtended);
 	}
 	else
 	{
@@ -1306,7 +1306,7 @@ void CCharacter::Read(CNetObj_Character *pChar, CNetObj_DDNetCharacter *pExtende
 		// detect unfreeze (in case the player was frozen in the tile prediction and not correctly unfrozen)
 		if(pChar->m_Emote != EMOTE_PAIN && pChar->m_Emote != EMOTE_NORMAL)
 			m_DeepFreeze = false;
-		if(pChar->m_Weapon != WEAPON_NINJA || pChar->m_AttackTick > m_Core.m_FreezeTick || absolute(pChar->m_VelX) == 256 * 10 || !GameWorld()->m_WorldConfig.m_PredictFreeze)
+		if(pChar->m_Weapon != WEAPON_NINJA || pChar->m_AttackTick > m_Core.m_FreezeStart || absolute(pChar->m_VelX) == 256 * 10 || !GameWorld()->m_WorldConfig.m_PredictFreeze)
 		{
 			m_DeepFreeze = false;
 			UnFreeze();
@@ -1344,8 +1344,17 @@ void CCharacter::Read(CNetObj_Character *pChar, CNetObj_DDNetCharacter *pExtende
 		mem_zero(&m_SavedInput, sizeof(m_SavedInput));
 		m_Input.m_Direction = m_SavedInput.m_Direction = m_Core.m_Direction;
 		m_Input.m_Hook = m_SavedInput.m_Hook = (m_Core.m_HookState != HOOK_IDLE);
-		m_Input.m_TargetX = m_SavedInput.m_TargetX = cosf(pChar->m_Angle / 256.0f) * 256.0f;
-		m_Input.m_TargetY = m_SavedInput.m_TargetY = sinf(pChar->m_Angle / 256.0f) * 256.0f;
+
+		if(pExtended)
+		{
+			m_Input.m_TargetX = m_SavedInput.m_TargetX = pExtended->m_TargetX;
+			m_Input.m_TargetY = m_SavedInput.m_TargetY = pExtended->m_TargetY;
+		}
+		else
+		{
+			m_Input.m_TargetX = m_SavedInput.m_TargetX = cosf(pChar->m_Angle / 256.0f) * 256.0f;
+			m_Input.m_TargetY = m_SavedInput.m_TargetY = sinf(pChar->m_Angle / 256.0f) * 256.0f;
+		}
 	}
 
 	// in most cases the reload timer can be determined from the last attack tick
@@ -1358,22 +1367,6 @@ void CCharacter::Read(CNetObj_Character *pChar, CNetObj_DDNetCharacter *pExtende
 			GetTuning(m_TuneZone)->Get(38 + m_Core.m_ActiveWeapon, &FireDelay);
 			const int FireDelayTicks = FireDelay * GameWorld()->GameTickSpeed() / 1000;
 			m_ReloadTimer = maximum(0, m_AttackTick + FireDelayTicks - GameWorld()->GameTick());
-		}
-	}
-
-	if(pExtendedDisplayInfo)
-	{
-		if(GameWorld()->m_WorldConfig.m_PredictFreeze)
-		{
-			m_Core.m_FreezeTick = pExtendedDisplayInfo->m_FreezeTick;
-		}
-		m_Core.m_IsInFreeze = pExtendedDisplayInfo->m_IsInFreeze;
-		m_Core.m_Ninja.m_ActivationTick = pExtendedDisplayInfo->m_NinjaActivationTick;
-		m_Core.m_JumpedTotal = pExtendedDisplayInfo->m_JumpedTotal;
-		if(!IsLocal)
-		{
-			m_Input.m_TargetX = pExtendedDisplayInfo->m_TargetX;
-			m_Input.m_TargetY = pExtendedDisplayInfo->m_TargetY;
 		}
 	}
 }

--- a/src/game/client/prediction/entities/character.cpp
+++ b/src/game/client/prediction/entities/character.cpp
@@ -1345,7 +1345,7 @@ void CCharacter::Read(CNetObj_Character *pChar, CNetObj_DDNetCharacter *pExtende
 		m_Input.m_Direction = m_SavedInput.m_Direction = m_Core.m_Direction;
 		m_Input.m_Hook = m_SavedInput.m_Hook = (m_Core.m_HookState != HOOK_IDLE);
 
-		if(pExtended)
+		if(pExtended && pExtended->m_TargetX != 0 && pExtended->m_TargetY != 0)
 		{
 			m_Input.m_TargetX = m_SavedInput.m_TargetX = pExtended->m_TargetX;
 			m_Input.m_TargetY = m_SavedInput.m_TargetY = pExtended->m_TargetY;

--- a/src/game/client/prediction/entities/character.h
+++ b/src/game/client/prediction/entities/character.h
@@ -129,8 +129,8 @@ public:
 	int GetAttackTick() { return m_AttackTick; }
 	int GetStrongWeakID() { return m_StrongWeakID; }
 
-	CCharacter(CGameWorld *pGameWorld, int ID, CNetObj_Character *pChar, CNetObj_DDNetCharacter *pExtended = 0, CNetObj_DDNetCharacterDisplayInfo *pExtendedDisplayInfo = 0);
-	void Read(CNetObj_Character *pChar, CNetObj_DDNetCharacter *pExtended, CNetObj_DDNetCharacterDisplayInfo *pExtendedDisplayInfo, bool IsLocal);
+	CCharacter(CGameWorld *pGameWorld, int ID, CNetObj_Character *pChar, CNetObj_DDNetCharacter *pExtended = 0);
+	void Read(CNetObj_Character *pChar, CNetObj_DDNetCharacter *pExtended, bool IsLocal);
 	void SetCoreWorld(CGameWorld *pGameWorld);
 
 	int m_LastSnapWeapon;

--- a/src/game/client/prediction/gameworld.cpp
+++ b/src/game/client/prediction/gameworld.cpp
@@ -371,17 +371,17 @@ void CGameWorld::NetObjBegin()
 	OnModified();
 }
 
-void CGameWorld::NetCharAdd(int ObjID, CNetObj_Character *pCharObj, CNetObj_DDNetCharacter *pExtended, CNetObj_DDNetCharacterDisplayInfo *pExtendedDisplayInfo, int GameTeam, bool IsLocal)
+void CGameWorld::NetCharAdd(int ObjID, CNetObj_Character *pCharObj, CNetObj_DDNetCharacter *pExtended, int GameTeam, bool IsLocal)
 {
 	CCharacter *pChar;
 	if((pChar = (CCharacter *)GetEntity(ObjID, ENTTYPE_CHARACTER)))
 	{
-		pChar->Read(pCharObj, pExtended, pExtendedDisplayInfo, IsLocal);
+		pChar->Read(pCharObj, pExtended, IsLocal);
 		pChar->Keep();
 	}
 	else
 	{
-		pChar = new CCharacter(this, ObjID, pCharObj, pExtended, pExtendedDisplayInfo);
+		pChar = new CCharacter(this, ObjID, pCharObj, pExtended);
 		InsertEntity(pChar);
 	}
 

--- a/src/game/client/prediction/gameworld.h
+++ b/src/game/client/prediction/gameworld.h
@@ -85,7 +85,7 @@ public:
 
 	void OnModified();
 	void NetObjBegin();
-	void NetCharAdd(int ObjID, CNetObj_Character *pChar, CNetObj_DDNetCharacter *pExtended, CNetObj_DDNetCharacterDisplayInfo *pExtendedDisplayInfo, int GameTeam, bool IsLocal);
+	void NetCharAdd(int ObjID, CNetObj_Character *pChar, CNetObj_DDNetCharacter *pExtended, int GameTeam, bool IsLocal);
 	void NetObjAdd(int ObjID, int ObjType, const void *pObjData, const CNetObj_EntityEx *pDataEx);
 	void NetObjEnd(int LocalID);
 	void CopyWorld(CGameWorld *pFrom);

--- a/src/game/gamecore.cpp
+++ b/src/game/gamecore.cpp
@@ -105,7 +105,7 @@ void CCharacterCore::Reset()
 	m_HasTelegunGun = false;
 	m_HasTelegunGrenade = false;
 	m_HasTelegunLaser = false;
-	m_FreezeTick = 0;
+	m_FreezeStart = 0;
 	m_FreezeEnd = 0;
 	m_IsInFreeze = false;
 	m_DeepFrozen = false;
@@ -599,14 +599,22 @@ void CCharacterCore::ReadDDNet(const CNetObj_DDNetCharacter *pObjDDNet)
 
 	// Available jumps
 	m_Jumps = pObjDDNet->m_Jumps;
-}
 
-void CCharacterCore::ReadDDNetDisplayInfo(const CNetObj_DDNetCharacterDisplayInfo *pObjDDNet)
-{
-	m_JumpedTotal = pObjDDNet->m_JumpedTotal;
-	m_Ninja.m_ActivationTick = pObjDDNet->m_NinjaActivationTick;
-	m_FreezeTick = pObjDDNet->m_FreezeTick;
-	m_IsInFreeze = pObjDDNet->m_IsInFreeze;
+	// Display Information
+	// We only accept the display information when it is received, which means it is not -1 in each case.
+	if(pObjDDNet->m_JumpedTotal != -1)
+	{
+		m_JumpedTotal = pObjDDNet->m_JumpedTotal;
+	}
+	if(pObjDDNet->m_NinjaActivationTick != -1)
+	{
+		m_Ninja.m_ActivationTick = pObjDDNet->m_NinjaActivationTick;
+	}
+	if(pObjDDNet->m_FreezeStart != -1)
+	{
+		m_FreezeStart = pObjDDNet->m_FreezeStart;
+		m_IsInFreeze = pObjDDNet->m_Flags & CHARACTERFLAG_IN_FREEZE;
+	}
 }
 
 void CCharacterCore::Quantize()

--- a/src/game/gamecore.h
+++ b/src/game/gamecore.h
@@ -291,7 +291,6 @@ public:
 	void SetTeamsCore(CTeamsCore *pTeams);
 	void SetTeleOuts(std::map<int, std::vector<vec2>> *pTeleOuts);
 	void ReadDDNet(const CNetObj_DDNetCharacter *pObjDDNet);
-	void ReadDDNetDisplayInfo(const CNetObj_DDNetCharacterDisplayInfo *pObjDDNet);
 	bool m_Solo;
 	bool m_Jetpack;
 	bool m_NoCollision;
@@ -306,7 +305,7 @@ public:
 	bool m_HasTelegunGun;
 	bool m_HasTelegunGrenade;
 	bool m_HasTelegunLaser;
-	int m_FreezeTick;
+	int m_FreezeStart;
 	int m_FreezeEnd;
 	bool m_IsInFreeze;
 	bool m_DeepFrozen;

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -1181,7 +1181,6 @@ void CCharacter::Snap(int SnappingClient)
 	}
 	pDDNetCharacter->m_TargetX = m_Core.m_Input.m_TargetX;
 	pDDNetCharacter->m_TargetY = m_Core.m_Input.m_TargetY;
-	pDDNetCharacter->m_RampValue = round_to_int(VelocityRamp(length(m_Core.m_Vel) * 50, m_Core.m_Tuning.m_VelrampStart, m_Core.m_Tuning.m_VelrampRange, m_Core.m_Tuning.m_VelrampCurvature) * 1000.0f);
 }
 
 // DDRace

--- a/src/game/server/save.cpp
+++ b/src/game/server/save.cpp
@@ -38,7 +38,7 @@ void CSaveTee::Save(CCharacter *pChr)
 	m_Jetpack = pChr->m_Jetpack;
 	m_NinjaJetpack = pChr->m_NinjaJetpack;
 	m_FreezeTime = pChr->m_FreezeTime;
-	m_FreezeTick = pChr->Server()->Tick() - pChr->m_Core.m_FreezeTick;
+	m_FreezeStart = pChr->Server()->Tick() - pChr->m_Core.m_FreezeStart;
 
 	m_DeepFreeze = pChr->m_DeepFreeze;
 	m_LiveFreeze = pChr->m_LiveFreeze;
@@ -133,7 +133,7 @@ void CSaveTee::Load(CCharacter *pChr, int Team, bool IsSwap)
 	pChr->m_Jetpack = m_Jetpack;
 	pChr->m_NinjaJetpack = m_NinjaJetpack;
 	pChr->m_FreezeTime = m_FreezeTime;
-	pChr->m_Core.m_FreezeTick = pChr->Server()->Tick() - m_FreezeTick;
+	pChr->m_Core.m_FreezeStart = pChr->Server()->Tick() - m_FreezeStart;
 
 	pChr->m_DeepFreeze = m_DeepFreeze;
 	pChr->m_LiveFreeze = m_LiveFreeze;
@@ -269,7 +269,7 @@ char *CSaveTee::GetString(const CSaveTeam *pTeam)
 		m_aWeapons[5].m_AmmoRegenStart, m_aWeapons[5].m_Ammo, m_aWeapons[5].m_Ammocost, m_aWeapons[5].m_Got,
 		m_LastWeapon, m_QueuedWeapon,
 		// tee states
-		m_SuperJump, m_Jetpack, m_NinjaJetpack, m_FreezeTime, m_FreezeTick, m_DeepFreeze, m_EndlessHook,
+		m_SuperJump, m_Jetpack, m_NinjaJetpack, m_FreezeTime, m_FreezeStart, m_DeepFreeze, m_EndlessHook,
 		m_DDRaceState, m_Hit, m_Collision, m_TuneZone, m_TuneZoneOld, m_Hook, m_Time,
 		(int)m_Pos.x, (int)m_Pos.y, (int)m_PrevPos.x, (int)m_PrevPos.y,
 		m_TeleCheckpoint, m_LastPenalty,
@@ -342,7 +342,7 @@ int CSaveTee::FromString(const char *String)
 		&m_aWeapons[5].m_AmmoRegenStart, &m_aWeapons[5].m_Ammo, &m_aWeapons[5].m_Ammocost, &m_aWeapons[5].m_Got,
 		&m_LastWeapon, &m_QueuedWeapon,
 		// tee states
-		&m_SuperJump, &m_Jetpack, &m_NinjaJetpack, &m_FreezeTime, &m_FreezeTick, &m_DeepFreeze, &m_EndlessHook,
+		&m_SuperJump, &m_Jetpack, &m_NinjaJetpack, &m_FreezeTime, &m_FreezeStart, &m_DeepFreeze, &m_EndlessHook,
 		&m_DDRaceState, &m_Hit, &m_Collision, &m_TuneZone, &m_TuneZoneOld, &m_Hook, &m_Time,
 		&m_Pos.x, &m_Pos.y, &m_PrevPos.x, &m_PrevPos.y,
 		&m_TeleCheckpoint, &m_LastPenalty,

--- a/src/game/server/save.h
+++ b/src/game/server/save.h
@@ -57,7 +57,7 @@ private:
 	int m_Jetpack;
 	int m_NinjaJetpack;
 	int m_FreezeTime;
-	int m_FreezeTick;
+	int m_FreezeStart;
 	int m_DeepFreeze;
 	int m_LiveFreeze;
 	int m_EndlessHook;

--- a/src/game/variables.h
+++ b/src/game/variables.h
@@ -45,7 +45,7 @@ MACRO_CONFIG_INT(ClShowhudDummyActions, cl_showhud_dummy_actions, 1, 0, 1, CFGFL
 MACRO_CONFIG_INT(ClShowhudPlayerPosition, cl_showhud_player_position, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show ingame HUD (Player Position)")
 MACRO_CONFIG_INT(ClShowhudPlayerSpeed, cl_showhud_player_speed, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show ingame HUD (Player Speed)")
 MACRO_CONFIG_INT(ClShowhudPlayerAngle, cl_showhud_player_angle, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show ingame HUD (Player Aim Angle)")
-MACRO_CONFIG_INT(ClFreezeBarsAlphaInsideFreeze, cl_freezebars_alpha_inside_freeze, 100, 0, 100, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Opacity of freeze bars inside freeze (0 invisible, 100 fully visible)")
+MACRO_CONFIG_INT(ClFreezeBarsAlphaInsideFreeze, cl_freezebars_alpha_inside_freeze, 0, 0, 100, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Opacity of freeze bars inside freeze (0 invisible, 100 fully visible)")
 MACRO_CONFIG_INT(ClShowRecord, cl_showrecord, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show old style DDRace client records")
 MACRO_CONFIG_INT(ClShowNotifications, cl_shownotifications, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Make the client notify when someone highlights you")
 MACRO_CONFIG_INT(ClShowEmotes, cl_showemotes, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show tee emotes")


### PR DESCRIPTION
- I also added the default value mechanic for Net Objects that have set `validate_size=False`
- I removed the ramp value from the snap, because currently all maps use the default tuning parameters for it
- I renamed `m_FreezeTick` to `m_FreezeStart` 

- Added Extended Net Objects to the debug HUD (Also added a Headline):
![grafik](https://user-images.githubusercontent.com/14315968/175284419-3014bc06-96a0-407d-b170-15e06350caa7.png)
(out of range) is in the screenshot the old DDNetCharacterDisplayInfo

fixes #5455

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [x] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
