### PR TITLE
do not snap dragger beam, if the target is out of reach

### DIFF
--- a/src/game/server/entities/dragger_beam.cpp
+++ b/src/game/server/entities/dragger_beam.cpp
@@ -87,7 +87,7 @@ void CDraggerBeam::Snap(int SnappingClient)
 	}
 	// Only players with the dragger beam in their field of view or who want to see everything will receive the snap
 	vec2 TargetPos = vec2(pTarget->m_Pos.x, pTarget->m_Pos.y);
-	if(NetworkClippedLine(SnappingClient, m_Pos, TargetPos))
+	if(distance(pTarget->m_Pos, m_Pos) >= g_Config.m_SvDraggerRange || NetworkClippedLine(SnappingClient, m_Pos, TargetPos))
 	{
 		return;
 	}


### PR DESCRIPTION
fixes #5216

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [x] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
