### PR TITLE
macOS fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,9 +3,9 @@ if(CMAKE_VERSION VERSION_LESS 3.12)
   cmake_policy(VERSION ${CMAKE_VERSION})
 endif()
 
-set(CMAKE_OSX_DEPLOYMENT_TARGET 10.9 CACHE INTERNAL "")
-if(CMAKE_OSX_DEPLOYMENT_TARGET VERSION_LESS 10.9)
-  message(WARNING "Building for macOS < 10.9 is not supported")
+set(CMAKE_OSX_DEPLOYMENT_TARGET 10.13 CACHE INTERNAL "")
+if(CMAKE_OSX_DEPLOYMENT_TARGET VERSION_LESS 10.13)
+  message(WARNING "Building for macOS < 10.13 is not supported")
 endif()
 
 file(STRINGS src/game/version.h VERSION_LINE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -255,7 +255,7 @@ if(CMAKE_GENERATOR STREQUAL "Ninja")
   add_cxx_compiler_flag_if_supported(OUR_FLAGS -fcolor-diagnostics)
 endif()
 
-if(NOT MSVC AND NOT HAIKU)
+if(NOT MSVC AND NOT HAIKU AND NOT TARGET_OS STREQUAL "mac")
   if(NOT FUSE_LD STREQUAL OFF)
     add_linker_flag_if_supported(OUR_FLAGS_LINK -fuse-ld=${FUSE_LD})
     if(FLAG_SUPPORTED_fuse_ld_${FUSE_LD})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -335,7 +335,6 @@ if(NOT MSVC AND NOT HAIKU AND NOT TARGET_OS STREQUAL "mac")
   add_cxx_compiler_flag_if_supported(OUR_FLAGS_OWN -Wformat=2) # Warn about format strings.
   add_c_compiler_flag_if_supported(OUR_FLAGS_DEP -Wno-implicit-function-declaration)
   add_cxx_compiler_flag_if_supported(OUR_FLAGS_OWN -Wno-nullability-completeness) # Mac OS build on github
-  add_cxx_compiler_flag_if_supported(OUR_FLAGS_OWN -Wno-tautological-constant-out-of-range-compare) # Check needed for x86, but warns on x86-64
   add_cxx_compiler_flag_if_supported(OUR_FLAGS_OWN -Wduplicated-cond)
   add_cxx_compiler_flag_if_supported(OUR_FLAGS_OWN -Wduplicated-branches)
   add_cxx_compiler_flag_if_supported(OUR_FLAGS_OWN -Wlogical-op)

--- a/src/game/client/components/maplayers.cpp
+++ b/src/game/client/components/maplayers.cpp
@@ -298,8 +298,11 @@ bool CMapLayers::STileLayerVisuals::Init(unsigned int Width, unsigned int Height
 {
 	m_Width = Width;
 	m_Height = Height;
-	if(Width == 0 || Height == 0 || Width >= std::numeric_limits<std::ptrdiff_t>::max() || Height >= std::numeric_limits<std::ptrdiff_t>::max())
+	if(Width == 0 || Height == 0)
 		return false;
+	if constexpr(sizeof(unsigned int) >= sizeof(ptrdiff_t))
+		if(Width >= std::numeric_limits<std::ptrdiff_t>::max() || Height >= std::numeric_limits<std::ptrdiff_t>::max())
+			return false;
 
 	m_pTilesOfLayer = new CMapLayers::STileLayerVisuals::STileVisual[Height * Width];
 

--- a/src/macos/server.mm
+++ b/src/macos/server.mm
@@ -71,7 +71,7 @@ void runServer()
 			// get a server config
 			NSOpenPanel *openDlg = [NSOpenPanel openPanel];
 			[openDlg setCanChooseFiles:YES];
-			if([openDlg runModal] != NSOKButton)
+			if([openDlg runModal] != NSModalResponseOK)
 				return;
 			NSString *filename = [[openDlg URL] path];
 			arguments = [NSArray arrayWithObjects: @"-f", filename, nil];
@@ -87,9 +87,9 @@ void runServer()
 
 	window = [[NSWindow alloc]
 		initWithContentRect: graphicsRect
-		styleMask: NSTitledWindowMask
-		| NSClosableWindowMask
-		| NSMiniaturizableWindowMask
+		styleMask: NSWindowStyleMaskTitled
+		| NSWindowStyleMaskClosable
+		| NSWindowStyleMaskMiniaturizable
 		backing: NSBackingStoreBuffered
 		defer: NO];
 


### PR DESCRIPTION
```
ld64.lld: warning: /opt/homebrew/opt/freetype/lib/libfreetype.6.dylib has version 12.0.0, which is newer than target minimum of 11.0.0
ld64.lld: error: LC_DYLD_INFO_ONLY not found in /opt/homebrew/opt/freetype/lib/libfreetype.6.dylib
ld64.lld: warning: /usr/local/lib/libGLEW.2.2.0.dylib has version 12.0.0, which is newer than target minimum of 11.0.0
ld64.lld: error: LC_DYLD_INFO_ONLY not found in /usr/local/lib/libGLEW.2.2.0.dylib
ld64.lld: warning: /opt/homebrew/Cellar/wavpack/5.4.0/lib/libwavpack.dylib has version 12.0.0, which is newer than target minimum of 11.0.0
ld64.lld: error: LC_DYLD_INFO_ONLY not found in /opt/homebrew/Cellar/wavpack/5.4.0/lib/libwavpack.dylib
ld64.lld: warning: /opt/homebrew/Cellar/ffmpeg/5.0.1/lib/libavformat.59.dylib has version 12.0.0, which is newer than target minimum of 11.0.0
ld64.lld: error: LC_DYLD_INFO_ONLY not found in /opt/homebrew/Cellar/ffmpeg/5.0.1/lib/libavformat.59.dylib
ld64.lld: warning: /opt/homebrew/Cellar/ffmpeg/5.0.1/lib/libavcodec.59.dylib has version 12.0.0, which is newer than target minimum of 11.0.0
ld64.lld: error: LC_DYLD_INFO_ONLY not found in /opt/homebrew/Cellar/ffmpeg/5.0.1/lib/libavcodec.59.dylib
ld64.lld: warning: /opt/homebrew/Cellar/ffmpeg/5.0.1/lib/libavutil.57.dylib has version 12.0.0, which is newer than target minimum of 11.0.0
ld64.lld: error: LC_DYLD_INFO_ONLY not found in /opt/homebrew/Cellar/ffmpeg/5.0.1/lib/libavutil.57.dylib
ld64.lld: warning: /opt/homebrew/Cellar/ffmpeg/5.0.1/lib/libswscale.6.dylib has version 12.0.0, which is newer than target minimum of 11.0.0
ld64.lld: error: LC_DYLD_INFO_ONLY not found in /opt/homebrew/Cellar/ffmpeg/5.0.1/lib/libswscale.6.dylib
ld64.lld: warning: /opt/homebrew/Cellar/ffmpeg/5.0.1/lib/libswresample.4.dylib has version 12.0.0, which is newer than target minimum of 11.0.0
ld64.lld: error: LC_DYLD_INFO_ONLY not found in /opt/homebrew/Cellar/ffmpeg/5.0.1/lib/libswresample.4.dylib
ld64.lld: warning: /opt/homebrew/Cellar/opusfile/0.12/lib/libopusfile.dylib has version 12.0.0, which is newer than target minimum of 11.0.0
ld64.lld: error: LC_DYLD_INFO_ONLY not found in /opt/homebrew/Cellar/opusfile/0.12/lib/libopusfile.dylib
ld64.lld: warning: /opt/homebrew/Cellar/opus/1.3.1/lib/libopus.dylib has version 12.0.0, which is newer than target minimum of 11.0.0
ld64.lld: error: LC_DYLD_INFO_ONLY not found in /opt/homebrew/Cellar/opus/1.3.1/lib/libopus.dylib
ld64.lld: warning: /opt/homebrew/Cellar/libogg/1.3.5/lib/libogg.dylib has version 12.0.0, which is newer than target minimum of 11.0.0
ld64.lld: error: LC_DYLD_INFO_ONLY not found in /opt/homebrew/Cellar/libogg/1.3.5/lib/libogg.dylib
ld64.lld: error: undefined symbol: ___glewBindSampler
>>> referenced by CMakeFiles/DDNet.dir/src/engine/client/backend/opengl/backend_opengl.cpp.o

ld64.lld: error: undefined symbol: ___glewBindSampler
>>> referenced by CMakeFiles/DDNet.dir/src/engine/client/backend/opengl/backend_opengl.cpp.o
[...]
```
<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
