### PR TITLE
Fix crash because of hooks on non ddnet server

### DIFF
--- a/src/game/gamecore.cpp
+++ b/src/game/gamecore.cpp
@@ -550,7 +550,7 @@ void CCharacterCore::ReadCharacterCore(const CNetObj_CharacterCore *pObjCore)
 	m_HookPos.y = pObjCore->m_HookY;
 	m_HookDir.x = pObjCore->m_HookDx / 256.0f;
 	m_HookDir.y = pObjCore->m_HookDy / 256.0f;
-	SetHookedPlayer(pObjCore->m_HookedPlayer);
+	m_HookedPlayer = pObjCore->m_HookedPlayer;
 	m_Jumped = pObjCore->m_Jumped;
 	m_Direction = pObjCore->m_Direction;
 	m_Angle = pObjCore->m_Angle;

--- a/src/game/gamecore.h
+++ b/src/game/gamecore.h
@@ -206,7 +206,7 @@ public:
 class CCharacterCore
 {
 	friend class CCharacter;
-	CWorldCore *m_pWorld;
+	CWorldCore *m_pWorld = nullptr;
 	CCollision *m_pCollision;
 	std::map<int, std::vector<vec2>> *m_pTeleOuts;
 


### PR DESCRIPTION
Reported by @Ясно Понятно 
on non ddnet server, this code gets run to detect strong-weak ids:
https://github.com/C0D3D3V/ddnet/blob/6a5673aa04c216948ce76de1a505c419d0715b1e/src/game/client/gameclient.cpp#L2540-L2541
which causes a crash because this CCharacterCore is not bound to a gameworld 
the check for m_pWorld failed because m_pWorld is full of random data
https://github.com/ddnet/ddnet/blob/ac15943e85b04f29fc8e85096222c5f6a85ac7f1/src/game/gamecore.cpp#L625
So I would also like to initialize it with a nullpointer 

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [x] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
