### PR TITLE
Enable cppcoreguidelines-pro-type-member-init

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -37,6 +37,7 @@ Checks: >
   -clang-analyzer-osx.cocoa.RetainCount,
   -clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling,
   -clang-analyzer-security.insecureAPI.rand,
+  cppcoreguidelines-pro-type-member-init,
   misc-*,
   -misc-no-recursion,
   -misc-non-private-member-variables-in-classes,

--- a/src/base/log.cpp
+++ b/src/base/log.cpp
@@ -81,7 +81,7 @@ void log_log_impl(LEVEL level, bool have_color, LOG_COLOR color, const char *sys
 		return;
 	}
 
-	CLogMessage Msg;
+	CLogMessage Msg{};
 	Msg.m_Level = level;
 	Msg.m_HaveColor = have_color;
 	Msg.m_Color = color;

--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -428,7 +428,7 @@ static void aio_thread(void *user)
 	lock_wait(aio->lock);
 	while(true)
 	{
-		struct BUFFERS buffers;
+		struct BUFFERS buffers{};
 		int result_io_error;
 		unsigned char local_buffer[ASYNC_LOCAL_BUFSIZE];
 		unsigned int local_buffer_len = 0;
@@ -579,7 +579,7 @@ void aio_write_unlocked(ASYNCIO *aio, const void *buffer, unsigned size)
 		unsigned int next_len = 0;
 		unsigned char *next_buffer = (unsigned char *)malloc(next_size);
 
-		struct BUFFERS buffers;
+		struct BUFFERS buffers{};
 		buffer_ptrs(aio, &buffers);
 		if(buffers.buf1)
 		{
@@ -1152,7 +1152,7 @@ static int priv_net_extract(const char *hostname, char *host, int max_host, int 
 
 int net_host_lookup(const char *hostname, NETADDR *addr, int types)
 {
-	struct addrinfo hints;
+	struct addrinfo hints{};
 	struct addrinfo *result = NULL;
 	int e;
 	char host[256];
@@ -1256,7 +1256,7 @@ int net_addr_from_str(NETADDR *addr, const char *string)
 	if(str[0] == '[')
 	{
 		/* ipv6 */
-		struct sockaddr_in6 sa6;
+		struct sockaddr_in6 sa6{};
 		char buf[128];
 		int i;
 		str++;
@@ -1453,7 +1453,7 @@ NETSOCKET net_udp_create(NETADDR bindaddr)
 
 	if(bindaddr.type & NETTYPE_IPV4)
 	{
-		struct sockaddr_in addr;
+		struct sockaddr_in addr{};
 		int socket = -1;
 
 		/* bind, we should check for error */
@@ -1501,7 +1501,7 @@ NETSOCKET net_udp_create(NETADDR bindaddr)
 
 	if(bindaddr.type & NETTYPE_IPV6)
 	{
-		struct sockaddr_in6 addr;
+		struct sockaddr_in6 addr{};
 		int socket = -1;
 
 		/* bind, we should check for error */
@@ -1544,7 +1544,7 @@ int net_udp_send(NETSOCKET sock, const NETADDR *addr, const void *data, int size
 	{
 		if(sock->ipv4sock >= 0)
 		{
-			struct sockaddr_in sa;
+			struct sockaddr_in sa{};
 			if(addr->type & NETTYPE_LINK_BROADCAST)
 			{
 				mem_zero(&sa, sizeof(sa));
@@ -1580,7 +1580,7 @@ int net_udp_send(NETSOCKET sock, const NETADDR *addr, const void *data, int size
 	{
 		if(sock->ipv6sock >= 0)
 		{
-			struct sockaddr_in6 sa;
+			struct sockaddr_in6 sa{};
 			if(addr->type & NETTYPE_LINK_BROADCAST)
 			{
 				mem_zero(&sa, sizeof(sa));
@@ -1740,7 +1740,7 @@ NETSOCKET net_tcp_create(NETADDR bindaddr)
 
 	if(bindaddr.type & NETTYPE_IPV4)
 	{
-		struct sockaddr_in addr;
+		struct sockaddr_in addr{};
 		int socket = -1;
 
 		/* bind, we should check for error */
@@ -1756,7 +1756,7 @@ NETSOCKET net_tcp_create(NETADDR bindaddr)
 
 	if(bindaddr.type & NETTYPE_IPV6)
 	{
-		struct sockaddr_in6 addr;
+		struct sockaddr_in6 addr{};
 		int socket = -1;
 
 		/* bind, we should check for error */
@@ -1845,7 +1845,7 @@ int net_tcp_accept(NETSOCKET sock, NETSOCKET *new_sock, NETADDR *a)
 
 	if(sock->ipv4sock >= 0)
 	{
-		struct sockaddr_in addr;
+		struct sockaddr_in addr{};
 		sockaddr_len = sizeof(addr);
 
 		s = accept(sock->ipv4sock, (struct sockaddr *)&addr, &sockaddr_len);
@@ -1864,7 +1864,7 @@ int net_tcp_accept(NETSOCKET sock, NETSOCKET *new_sock, NETADDR *a)
 
 	if(sock->ipv6sock >= 0)
 	{
-		struct sockaddr_in6 addr;
+		struct sockaddr_in6 addr{};
 		sockaddr_len = sizeof(addr);
 
 		s = accept(sock->ipv6sock, (struct sockaddr *)&addr, &sockaddr_len);
@@ -1887,14 +1887,14 @@ int net_tcp_connect(NETSOCKET sock, const NETADDR *a)
 {
 	if(a->type & NETTYPE_IPV4)
 	{
-		struct sockaddr_in addr;
+		struct sockaddr_in addr{};
 		netaddr_to_sockaddr_in(a, &addr);
 		return connect(sock->ipv4sock, (struct sockaddr *)&addr, sizeof(addr));
 	}
 
 	if(a->type & NETTYPE_IPV6)
 	{
-		struct sockaddr_in6 addr;
+		struct sockaddr_in6 addr{};
 		netaddr_to_sockaddr_in6(a, &addr);
 		return connect(sock->ipv6sock, (struct sockaddr *)&addr, sizeof(addr));
 	}
@@ -2244,7 +2244,7 @@ int fs_is_dir(const char *path)
 	DWORD attributes = GetFileAttributesW(wPath);
 	return attributes != INVALID_FILE_ATTRIBUTES && (attributes & FILE_ATTRIBUTE_DIRECTORY) ? 1 : 0;
 #else
-	struct stat sb;
+	struct stat sb{};
 	if(stat(path, &sb) == -1)
 		return 0;
 	return S_ISDIR(sb.st_mode) ? 1 : 0;
@@ -2348,7 +2348,7 @@ int fs_file_time(const char *name, time_t *created, time_t *modified)
 	*modified = filetime_to_unixtime(&finddata.ftLastWriteTime);
 	FindClose(handle);
 #elif defined(CONF_FAMILY_UNIX)
-	struct stat sb;
+	struct stat sb{};
 	if(stat(name, &sb))
 		return 1;
 
@@ -2389,7 +2389,7 @@ void swap_endian(void *data, unsigned elem_size, unsigned num)
 
 int net_socket_read_wait(NETSOCKET sock, int time)
 {
-	struct timeval tv;
+	struct timeval tv{};
 	fd_set readfds;
 	int sockid;
 
@@ -4021,7 +4021,7 @@ int os_version_str(char *version, int length)
 	free(data);
 	return 0;
 #else
-	struct utsname u;
+	struct utsname u{};
 	if(uname(&u))
 	{
 		return 1;

--- a/src/base/unicode/confusables.cpp
+++ b/src/base/unicode/confusables.cpp
@@ -66,7 +66,7 @@ int str_utf8_skeleton_next(struct SKELETON *skel)
 int str_utf8_to_skeleton(const char *str, int *buf, int buf_len)
 {
 	int i;
-	struct SKELETON skel;
+	struct SKELETON skel{};
 	str_utf8_skeleton_begin(&skel, str);
 	for(i = 0; i < buf_len; i++)
 	{
@@ -82,8 +82,8 @@ int str_utf8_to_skeleton(const char *str, int *buf, int buf_len)
 
 int str_utf8_comp_confusable(const char *str1, const char *str2)
 {
-	struct SKELETON skel1;
-	struct SKELETON skel2;
+	struct SKELETON skel1{};
+	struct SKELETON skel2{};
 
 	str_utf8_skeleton_begin(&skel1, str1);
 	str_utf8_skeleton_begin(&skel2, str2);

--- a/src/base/unicode/tolower.cpp
+++ b/src/base/unicode/tolower.cpp
@@ -12,7 +12,7 @@ static int compul(const void *a, const void *b)
 extern "C" {
 int str_utf8_tolower(int code)
 {
-	struct UPPER_LOWER key;
+	struct UPPER_LOWER key{};
 	struct UPPER_LOWER *res;
 	key.upper = code;
 	res = (UPPER_LOWER *)bsearch(&key, tolowermap, NUM_TOLOWER, sizeof(struct UPPER_LOWER), compul);

--- a/src/engine/client/backend/opengl/backend_opengl.h
+++ b/src/engine/client/backend/opengl/backend_opengl.h
@@ -54,27 +54,27 @@ protected:
 		float m_ResizeHeight;
 	};
 	std::vector<CTexture> m_Textures;
-	std::atomic<uint64_t> *m_pTextureMemoryUsage;
+	std::atomic<uint64_t> *m_pTextureMemoryUsage{};
 
 	uint32_t m_CanvasWidth = 0;
 	uint32_t m_CanvasHeight = 0;
 
-	TWGLint m_MaxTexSize;
+	TWGLint m_MaxTexSize{};
 
-	bool m_Has2DArrayTextures;
-	bool m_Has2DArrayTexturesAsExtension;
-	TWGLenum m_2DArrayTarget;
-	bool m_Has3DTextures;
-	bool m_HasMipMaps;
-	bool m_HasNPOTTextures;
+	bool m_Has2DArrayTextures{};
+	bool m_Has2DArrayTexturesAsExtension{};
+	TWGLenum m_2DArrayTarget{};
+	bool m_Has3DTextures{};
+	bool m_HasMipMaps{};
+	bool m_HasNPOTTextures{};
 
 	bool m_HasShaders;
-	int m_LastBlendMode; // avoid all possible opengl state changes
-	bool m_LastClipEnable;
+	int m_LastBlendMode{}; // avoid all possible opengl state changes
+	bool m_LastClipEnable{};
 
-	int m_OpenGLTextureLodBIAS;
+	int m_OpenGLTextureLodBIAS{};
 
-	bool m_IsOpenGLES;
+	bool m_IsOpenGLES{};
 
 	bool IsTexturedState(const CCommandBuffer::SState &State);
 

--- a/src/engine/client/backend/opengl/opengl_sl.cpp
+++ b/src/engine/client/backend/opengl/opengl_sl.cpp
@@ -82,7 +82,7 @@ bool CGLSL::LoadShader(CGLSLCompiler *pCompiler, IStorage *pStorage, const char 
 			Lines.emplace_back("#extension GL_EXT_texture_array : enable\r\n");
 		}
 
-		CLineReader LineReader;
+		CLineReader LineReader{};
 		LineReader.Init(f);
 		char *ReadLine = NULL;
 		while((ReadLine = LineReader.Get()))

--- a/src/engine/client/backend/opengl/opengl_sl.h
+++ b/src/engine/client/backend/opengl/opengl_sl.h
@@ -32,8 +32,8 @@ public:
 	virtual ~CGLSL();
 
 private:
-	TWGLuint m_ShaderID;
-	int m_Type;
+	TWGLuint m_ShaderID{};
+	int m_Type{};
 	bool m_IsLoaded;
 };
 

--- a/src/engine/client/backend/opengl/opengl_sl_program.h
+++ b/src/engine/client/backend/opengl/opengl_sl_program.h
@@ -47,7 +47,7 @@ public:
 	virtual ~CGLSLProgram();
 
 protected:
-	TWGLuint m_ProgramID;
+	TWGLuint m_ProgramID{};
 	bool m_IsLinked;
 };
 

--- a/src/engine/client/backend_sdl.h
+++ b/src/engine/client/backend_sdl.h
@@ -72,10 +72,10 @@ private:
 	std::mutex m_BufferSwapMutex;
 	std::condition_variable m_BufferSwapCond;
 	CCommandBuffer *m_pBuffer;
-	std::atomic_bool m_Shutdown;
+	std::atomic_bool m_Shutdown{};
 	bool m_Started = false;
-	std::atomic_bool m_BufferInProcess;
-	void *m_pThread;
+	std::atomic_bool m_BufferInProcess{};
+	void *m_pThread{};
 
 	static void ThreadFunc(void *pUser);
 };
@@ -116,8 +116,8 @@ struct SBackendCapabilites
 class CCommandProcessorFragment_SDL
 {
 	// SDL stuff
-	SDL_Window *m_pWindow;
-	SDL_GLContext m_GLContext;
+	SDL_Window *m_pWindow{};
+	SDL_GLContext m_GLContext{};
 
 public:
 	enum
@@ -175,7 +175,7 @@ static constexpr size_t gs_GPUInfoStringSize = 256;
 class CGraphicsBackend_SDL_GL : public CGraphicsBackend_Threaded
 {
 	SDL_Window *m_pWindow = NULL;
-	SDL_GLContext m_GLContext;
+	SDL_GLContext m_GLContext{};
 	ICommandProcessor *m_pProcessor = nullptr;
 	std::atomic<uint64_t> m_TextureMemoryUsage{0};
 	std::atomic<uint64_t> m_BufferMemoryUsage{0};
@@ -186,9 +186,9 @@ class CGraphicsBackend_SDL_GL : public CGraphicsBackend_Threaded
 
 	TGLBackendReadPresentedImageData m_ReadPresentedImageDataFunc;
 
-	int m_NumScreens;
+	int m_NumScreens{};
 
-	SBackendCapabilites m_Capabilites;
+	SBackendCapabilites m_Capabilites{};
 
 	char m_aVendorString[gs_GPUInfoStringSize] = {};
 	char m_aVersionString[gs_GPUInfoStringSize] = {};
@@ -196,7 +196,7 @@ class CGraphicsBackend_SDL_GL : public CGraphicsBackend_Threaded
 
 	EBackendType m_BackendType = BACKEND_TYPE_AUTO;
 
-	char m_aErrorString[256];
+	char m_aErrorString[256]{};
 
 	static EBackendType DetectBackend();
 	static void ClampDriverVersion(EBackendType BackendType);

--- a/src/engine/client/blocklist_driver.cpp
+++ b/src/engine/client/blocklist_driver.cpp
@@ -65,7 +65,7 @@ const char *ParseBlocklistDriverVersions(const char *pVendorStr, const char *pVe
 
 	char aVersionStrHelper[512]; // the size is random, but shouldn't be too small probably
 
-	SVersion Version;
+	SVersion Version{};
 	for(int &VersionPart : Version.m_Parts)
 	{
 		pVersionStrStart = str_next_token(pVersionStrStart, ".", aVersionStrHelper, sizeof(aVersionStrHelper));

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -449,13 +449,13 @@ static inline bool RepackMsg(const CMsgPacker *pMsg, CPacker &Packer)
 
 int CClient::SendMsg(int Conn, CMsgPacker *pMsg, int Flags)
 {
-	CNetChunk Packet;
+	CNetChunk Packet{};
 
 	if(State() == IClient::STATE_OFFLINE)
 		return 0;
 
 	// repack message (inefficient)
-	CPacker Pack;
+	CPacker Pack{};
 	if(RepackMsg(pMsg, Pack))
 		return 0;
 
@@ -1375,7 +1375,7 @@ void CClient::ProcessServerInfo(int RawType, NETADDR *pFrom, const void *pData, 
 
 	net_addr_str(pFrom, Info.m_aAddress, sizeof(Info.m_aAddress), true);
 
-	CUnpacker Up;
+	CUnpacker Up{};
 	Up.Reset(pData, DataSize);
 
 #define GET_STRING(array) str_copy(array, Up.GetString(CUnpacker::SANITIZE_CC | CUnpacker::SKIP_START_WHITESPACES), sizeof(array))
@@ -1572,7 +1572,7 @@ bool CClient::ShouldSendChatTimeoutCodeHeuristic()
 
 static CServerCapabilities GetServerCapabilities(int Version, int Flags)
 {
-	CServerCapabilities Result;
+	CServerCapabilities Result{};
 	bool DDNet = false;
 	if(Version >= 1)
 	{
@@ -1608,14 +1608,14 @@ static CServerCapabilities GetServerCapabilities(int Version, int Flags)
 
 void CClient::ProcessServerPacket(CNetChunk *pPacket, int Conn, bool Dummy)
 {
-	CUnpacker Unpacker;
+	CUnpacker Unpacker{};
 	Unpacker.Reset(pPacket->m_pData, pPacket->m_DataSize);
 	CMsgPacker Packer(NETMSG_EX, true);
 
 	// unpack msgid and system flag
 	int Msg;
 	bool Sys;
-	CUuid Uuid;
+	CUuid Uuid{};
 
 	int Result = UnpackMessageID(&Msg, &Sys, &Uuid, &Unpacker, &Packer);
 	if(Result == UNPACKMESSAGE_ERROR)
@@ -2125,7 +2125,7 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket, int Conn, bool Dummy)
 					{
 						if(m_ServerCapabilities.m_ChatTimeoutCode || ShouldSendChatTimeoutCodeHeuristic())
 						{
-							CNetMsg_Cl_Say MsgP;
+							CNetMsg_Cl_Say MsgP{};
 							MsgP.m_Team = 0;
 							char aBuf[128];
 							char aBufMsg[256];
@@ -2460,7 +2460,7 @@ void CClient::PumpNetwork()
 	}
 
 	// process packets
-	CNetChunk Packet;
+	CNetChunk Packet{};
 	for(int i = 0; i < NUM_CONNS; i++)
 	{
 		while(m_NetClient[i].Recv(&Packet))
@@ -2500,14 +2500,14 @@ void CClient::OnDemoPlayerSnapshot(void *pData, int Size)
 
 void CClient::OnDemoPlayerMessage(void *pData, int Size)
 {
-	CUnpacker Unpacker;
+	CUnpacker Unpacker{};
 	Unpacker.Reset(pData, Size);
 	CMsgPacker Packer(NETMSG_EX, true);
 
 	// unpack msgid and system flag
 	int Msg;
 	bool Sys;
-	CUuid Uuid;
+	CUuid Uuid{};
 
 	int Result = UnpackMessageID(&Msg, &Sys, &Uuid, &Unpacker, &Packer);
 	if(Result == UNPACKMESSAGE_ERROR)
@@ -3459,7 +3459,7 @@ void CClient::AutoScreenshot_Cleanup()
 		if(g_Config.m_ClAutoScreenshotMax)
 		{
 			// clean up auto taken screens
-			CFileCollection AutoScreens;
+			CFileCollection AutoScreens{};
 			AutoScreens.Init(Storage(), "screenshots/auto", "autoscreen", ".png", g_Config.m_ClAutoScreenshotMax);
 		}
 		m_AutoScreenshotRecycle = false;
@@ -3473,7 +3473,7 @@ void CClient::AutoStatScreenshot_Cleanup()
 		if(g_Config.m_ClAutoStatboardScreenshotMax)
 		{
 			// clean up auto taken screens
-			CFileCollection AutoScreens;
+			CFileCollection AutoScreens{};
 			AutoScreens.Init(Storage(), "screenshots/auto/stats", "autoscreen", ".png", g_Config.m_ClAutoStatboardScreenshotMax);
 		}
 		m_AutoStatScreenshotRecycle = false;
@@ -3493,7 +3493,7 @@ void CClient::AutoCSV_Cleanup()
 		if(g_Config.m_ClAutoCSVMax)
 		{
 			// clean up auto csvs
-			CFileCollection AutoRecord;
+			CFileCollection AutoRecord{};
 			AutoRecord.Init(Storage(), "record/csv", "autorecord", ".csv", g_Config.m_ClAutoCSVMax);
 		}
 		m_AutoCSVRecycle = false;
@@ -3853,7 +3853,7 @@ void CClient::DemoRecorder_HandleAutoStart()
 		if(g_Config.m_ClAutoDemoMax)
 		{
 			// clean up auto recorded demos
-			CFileCollection AutoDemos;
+			CFileCollection AutoDemos{};
 			AutoDemos.Init(Storage(), "demos/auto", "" /* empty for wild card */, ".demo", g_Config.m_ClAutoDemoMax);
 		}
 	}

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -97,7 +97,7 @@ public:
 class CClient : public IClient, public CDemoPlayer::IListener
 {
 	// needed interfaces
-	IEngine *m_pEngine;
+	IEngine *m_pEngine{};
 	IEditor *m_pEditor;
 	IEngineInput *m_pInput;
 	IEngineGraphics *m_pGraphics;
@@ -107,10 +107,10 @@ class CClient : public IClient, public CDemoPlayer::IListener
 	IConfigManager *m_pConfigManager;
 	CConfig *m_pConfig;
 	IConsole *m_pConsole;
-	IStorage *m_pStorage;
-	IUpdater *m_pUpdater;
-	IDiscord *m_pDiscord;
-	ISteam *m_pSteam;
+	IStorage *m_pStorage{};
+	IUpdater *m_pUpdater{};
+	IDiscord *m_pDiscord{};
+	ISteam *m_pSteam{};
 
 	enum
 	{
@@ -128,15 +128,15 @@ class CClient : public IClient, public CDemoPlayer::IListener
 	class CFriends m_Friends;
 	class CFriends m_Foes;
 
-	char m_aConnectAddressStr[256];
+	char m_aConnectAddressStr[256]{};
 
-	CUuid m_ConnectionID;
+	CUuid m_ConnectionID{};
 
 	bool m_HaveGlobalTcpAddr = false;
-	NETADDR m_GlobalTcpAddr;
+	NETADDR m_GlobalTcpAddr{};
 
-	unsigned m_SnapshotParts[NUM_DUMMIES];
-	int64_t m_LocalStartTime;
+	unsigned m_SnapshotParts[NUM_DUMMIES]{};
+	int64_t m_LocalStartTime{};
 
 	IGraphics::CTextureHandle m_DebugFont;
 	int m_DebugSoundIndex = 0;
@@ -146,66 +146,66 @@ class CClient : public IClient, public CDemoPlayer::IListener
 	float m_RenderFrameTimeHigh;
 	int m_RenderFrames;
 
-	NETADDR m_ServerAddress;
+	NETADDR m_ServerAddress{};
 	int m_SnapCrcErrors;
 	bool m_AutoScreenshotRecycle;
 	bool m_AutoStatScreenshotRecycle;
 	bool m_AutoCSVRecycle;
 	bool m_EditorActive;
-	bool m_SoundInitFailed;
-	bool m_ResortServerBrowser;
+	bool m_SoundInitFailed{};
+	bool m_ResortServerBrowser{};
 
-	int m_AckGameTick[NUM_DUMMIES];
-	int m_CurrentRecvTick[NUM_DUMMIES];
-	int m_RconAuthed[NUM_DUMMIES];
-	char m_RconPassword[32];
-	int m_UseTempRconCommands;
-	char m_Password[32];
-	bool m_SendPassword;
+	int m_AckGameTick[NUM_DUMMIES]{};
+	int m_CurrentRecvTick[NUM_DUMMIES]{};
+	int m_RconAuthed[NUM_DUMMIES]{};
+	char m_RconPassword[32]{};
+	int m_UseTempRconCommands{};
+	char m_Password[32]{};
+	bool m_SendPassword{};
 	bool m_ButtonRender = false;
 
 	// version-checking
-	char m_aVersionStr[10];
+	char m_aVersionStr[10]{};
 
 	// pinging
 	int64_t m_PingStartTime;
 
-	char m_aCurrentMap[IO_MAX_PATH_LENGTH];
-	char m_aCurrentMapPath[IO_MAX_PATH_LENGTH];
+	char m_aCurrentMap[IO_MAX_PATH_LENGTH]{};
+	char m_aCurrentMapPath[IO_MAX_PATH_LENGTH]{};
 
-	char m_aTimeoutCodes[NUM_DUMMIES][32];
-	bool m_CodeRunAfterJoin[NUM_DUMMIES];
+	char m_aTimeoutCodes[NUM_DUMMIES][32]{};
+	bool m_CodeRunAfterJoin[NUM_DUMMIES]{};
 	bool m_GenerateTimeoutSeed;
 
 	//
-	char m_aCmdConnect[256];
-	char m_aCmdPlayDemo[IO_MAX_PATH_LENGTH];
-	char m_aCmdEditMap[IO_MAX_PATH_LENGTH];
+	char m_aCmdConnect[256]{};
+	char m_aCmdPlayDemo[IO_MAX_PATH_LENGTH]{};
+	char m_aCmdEditMap[IO_MAX_PATH_LENGTH]{};
 
 	// map download
 	std::shared_ptr<CHttpRequest> m_pMapdownloadTask;
-	char m_aMapdownloadFilename[256];
-	char m_aMapdownloadFilenameTemp[256];
-	char m_aMapdownloadName[256];
+	char m_aMapdownloadFilename[256]{};
+	char m_aMapdownloadFilenameTemp[256]{};
+	char m_aMapdownloadName[256]{};
 	IOHANDLE m_MapdownloadFileTemp;
 	int m_MapdownloadChunk;
 	int m_MapdownloadCrc;
 	int m_MapdownloadAmount;
 	int m_MapdownloadTotalsize;
 	bool m_MapdownloadSha256Present;
-	SHA256_DIGEST m_MapdownloadSha256;
+	SHA256_DIGEST m_MapdownloadSha256{};
 
 	bool m_MapDetailsPresent;
-	char m_aMapDetailsName[256];
+	char m_aMapDetailsName[256]{};
 	int m_MapDetailsCrc;
-	SHA256_DIGEST m_MapDetailsSha256;
+	SHA256_DIGEST m_MapDetailsSha256{};
 
-	char m_aDDNetInfoTmp[64];
+	char m_aDDNetInfoTmp[64]{};
 	std::shared_ptr<CHttpRequest> m_pDDNetInfoTask;
 
 	// time
-	CSmoothTime m_GameTime[NUM_DUMMIES];
-	CSmoothTime m_PredictedTime;
+	CSmoothTime m_GameTime[NUM_DUMMIES]{};
+	CSmoothTime m_PredictedTime{};
 
 	// input
 	struct // TODO: handle input better
@@ -215,45 +215,45 @@ class CClient : public IClient, public CDemoPlayer::IListener
 		int64_t m_PredictedTime; // prediction latency when we sent this input
 		int64_t m_PredictionMargin; // prediction margin when we sent this input
 		int64_t m_Time;
-	} m_aInputs[NUM_DUMMIES][200];
+	} m_aInputs[NUM_DUMMIES][200]{};
 
-	int m_CurrentInput[NUM_DUMMIES];
+	int m_CurrentInput[NUM_DUMMIES]{};
 	bool m_LastDummy;
-	bool m_DummySendConnInfo;
+	bool m_DummySendConnInfo{};
 
 	// graphs
-	CGraph m_InputtimeMarginGraph;
-	CGraph m_GametimeMarginGraph;
-	CGraph m_FpsGraph;
+	CGraph m_InputtimeMarginGraph{};
+	CGraph m_GametimeMarginGraph{};
+	CGraph m_FpsGraph{};
 
 	// the game snapshots are modifiable by the game
 	class CSnapshotStorage m_SnapshotStorage[NUM_DUMMIES];
-	CSnapshotStorage::CHolder *m_aSnapshots[NUM_DUMMIES][NUM_SNAPSHOT_TYPES];
+	CSnapshotStorage::CHolder *m_aSnapshots[NUM_DUMMIES][NUM_SNAPSHOT_TYPES]{};
 
-	int m_ReceivedSnapshots[NUM_DUMMIES];
-	char m_aSnapshotIncomingData[CSnapshot::MAX_SIZE];
+	int m_ReceivedSnapshots[NUM_DUMMIES]{};
+	char m_aSnapshotIncomingData[CSnapshot::MAX_SIZE]{};
 
-	class CSnapshotStorage::CHolder m_aDemorecSnapshotHolders[NUM_SNAPSHOT_TYPES];
-	char *m_aDemorecSnapshotData[NUM_SNAPSHOT_TYPES][2][CSnapshot::MAX_SIZE];
+	class CSnapshotStorage::CHolder m_aDemorecSnapshotHolders[NUM_SNAPSHOT_TYPES]{};
+	char *m_aDemorecSnapshotData[NUM_SNAPSHOT_TYPES][2][CSnapshot::MAX_SIZE]{};
 
 	class CSnapshotDelta m_SnapshotDelta;
 
 	std::list<std::shared_ptr<CDemoEdit>> m_EditJobs;
 
 	//
-	bool m_CanReceiveServerCapabilities;
-	bool m_ServerSentCapabilities;
-	CServerCapabilities m_ServerCapabilities;
+	bool m_CanReceiveServerCapabilities{};
+	bool m_ServerSentCapabilities{};
+	CServerCapabilities m_ServerCapabilities{};
 
 	bool ShouldSendChatTimeoutCodeHeuristic();
 
-	class CServerInfo m_CurrentServerInfo;
+	class CServerInfo m_CurrentServerInfo{};
 	int64_t m_CurrentServerInfoRequestTime; // >= 0 should request, == -1 got info
 
 	int m_CurrentServerPingInfoType;
 	int m_CurrentServerPingBasicToken;
 	int m_CurrentServerPingToken;
-	CUuid m_CurrentServerPingUuid;
+	CUuid m_CurrentServerPingUuid{};
 	int64_t m_CurrentServerCurrentPingTime; // >= 0 request running
 	int64_t m_CurrentServerNextPingTime; // >= 0 should request
 
@@ -277,15 +277,15 @@ class CClient : public IClient, public CDemoPlayer::IListener
 	std::vector<SWarning> m_Warnings;
 
 #if defined(CONF_FAMILY_UNIX)
-	CFifo m_Fifo;
+	CFifo m_Fifo{};
 #endif
 
 	IOHANDLE m_BenchmarkFile;
 	int64_t m_BenchmarkStopTime;
 
-	CChecksum m_Checksum;
+	CChecksum m_Checksum{};
 	int m_OwnExecutableSize = 0;
-	IOHANDLE m_OwnExecutable;
+	IOHANDLE m_OwnExecutable{};
 
 	void UpdateDemoIntraTimers();
 	int MaxLatencyTicks() const;
@@ -352,7 +352,7 @@ public:
 	bool DummyConnected() override;
 	bool DummyConnecting() override;
 	bool DummyAllowed() override;
-	int m_DummyConnected;
+	int m_DummyConnected{};
 	int m_LastDummyConnectTime;
 
 	void GetServerInfo(CServerInfo *pServerInfo) const override;

--- a/src/engine/client/demoedit.h
+++ b/src/engine/client/demoedit.h
@@ -14,8 +14,8 @@ class CDemoEdit : public IJob
 
 	CDemoEditor m_DemoEditor;
 
-	char m_aDemo[256];
-	char m_aDst[256];
+	char m_aDemo[256]{};
+	char m_aDst[256]{};
 	int m_StartTick;
 	int m_EndTick;
 

--- a/src/engine/client/friends.h
+++ b/src/engine/client/friends.h
@@ -9,7 +9,7 @@
 
 class CFriends : public IFriends
 {
-	CFriendInfo m_aFriends[MAX_FRIENDS];
+	CFriendInfo m_aFriends[MAX_FRIENDS]{};
 	int m_Foes;
 	int m_NumFriends;
 

--- a/src/engine/client/ghost.cpp
+++ b/src/engine/client/ghost.cpp
@@ -38,7 +38,7 @@ int CGhostRecorder::Start(const char *pFilename, const char *pMap, SHA256_DIGEST
 	}
 
 	// write header
-	CGhostHeader Header;
+	CGhostHeader Header{};
 	mem_zero(&Header, sizeof(Header));
 	mem_copy(Header.m_aMarker, gs_aHeaderMarker, sizeof(Header.m_aMarker));
 	Header.m_Version = gs_CurVersion;
@@ -363,7 +363,7 @@ void CGhostLoader::Close()
 
 bool CGhostLoader::GetGhostInfo(const char *pFilename, CGhostInfo *pGhostInfo, const char *pMap, SHA256_DIGEST MapSha256, unsigned MapCrc)
 {
-	CGhostHeader Header;
+	CGhostHeader Header{};
 	mem_zero(&Header, sizeof(Header));
 
 	IOHANDLE File = m_pStorage->OpenFile(pFilename, IOFLAG_READ, IStorage::TYPE_SAVE);

--- a/src/engine/client/ghost.h
+++ b/src/engine/client/ghost.h
@@ -59,14 +59,14 @@ public:
 class CGhostRecorder : public IGhostRecorder
 {
 	IOHANDLE m_File;
-	class IConsole *m_pConsole;
-	class IStorage *m_pStorage;
+	class IConsole *m_pConsole{};
+	class IStorage *m_pStorage{};
 
 	CGhostItem m_LastItem;
 
-	char m_aBuffer[MAX_ITEM_SIZE * NUM_ITEMS_PER_CHUNK];
-	char *m_pBufferPos;
-	int m_BufferNumItems;
+	char m_aBuffer[MAX_ITEM_SIZE * NUM_ITEMS_PER_CHUNK]{};
+	char *m_pBufferPos{};
+	int m_BufferNumItems{};
 
 	void ResetBuffer();
 	void FlushChunk();
@@ -86,19 +86,19 @@ public:
 class CGhostLoader : public IGhostLoader
 {
 	IOHANDLE m_File;
-	class IConsole *m_pConsole;
-	class IStorage *m_pStorage;
+	class IConsole *m_pConsole{};
+	class IStorage *m_pStorage{};
 
-	CGhostHeader m_Header;
-	CGhostInfo m_Info;
+	CGhostHeader m_Header{};
+	CGhostInfo m_Info{};
 
 	CGhostItem m_LastItem;
 
-	char m_aBuffer[MAX_ITEM_SIZE * NUM_ITEMS_PER_CHUNK];
-	char *m_pBufferPos;
-	int m_BufferNumItems;
-	int m_BufferCurItem;
-	int m_BufferPrevItem;
+	char m_aBuffer[MAX_ITEM_SIZE * NUM_ITEMS_PER_CHUNK]{};
+	char *m_pBufferPos{};
+	int m_BufferNumItems{};
+	int m_BufferCurItem{};
+	int m_BufferPrevItem{};
 
 	void ResetBuffer();
 	int ReadChunk(int *pType);

--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -510,7 +510,7 @@ IGraphics::CTextureHandle CGraphics_Threaded::LoadTexture(const char *pFilename,
 {
 	int l = str_length(pFilename);
 	IGraphics::CTextureHandle ID;
-	CImageInfo Img;
+	CImageInfo Img{};
 
 	if(l < 3)
 		return CTextureHandle();
@@ -789,7 +789,7 @@ void CGraphics_Threaded::KickCommandBuffer()
 bool CGraphics_Threaded::ScreenshotDirect()
 {
 	// add swap command
-	CImageInfo Image;
+	CImageInfo Image{};
 	mem_zero(&Image, sizeof(Image));
 
 	bool DidSwap = false;
@@ -2531,7 +2531,7 @@ void CGraphics_Threaded::Maximize()
 void CGraphics_Threaded::SetWindowParams(int FullscreenMode, bool IsBorderless, bool AllowResizing)
 {
 	m_pBackend->SetWindowParams(FullscreenMode, IsBorderless, AllowResizing);
-	CVideoMode CurMode;
+	CVideoMode CurMode{};
 	m_pBackend->GetCurrentVideoMode(CurMode, m_ScreenHiDPIScale, g_Config.m_GfxDesktopWidth, g_Config.m_GfxDesktopHeight, g_Config.m_GfxScreen);
 	GotResized(CurMode.m_WindowWidth, CurMode.m_WindowHeight, CurMode.m_RefreshRate);
 }
@@ -2577,7 +2577,7 @@ void CGraphics_Threaded::Resize(int w, int h, int RefreshRate)
 	// if the size is changed manually, only set the window resize, a window size changed event is triggered anyway
 	if(m_pBackend->ResizeWindow(w, h, RefreshRate))
 	{
-		CVideoMode CurMode;
+		CVideoMode CurMode{};
 		m_pBackend->GetCurrentVideoMode(CurMode, m_ScreenHiDPIScale, g_Config.m_GfxDesktopWidth, g_Config.m_GfxDesktopHeight, g_Config.m_GfxScreen);
 		GotResized(w, h, RefreshRate);
 	}
@@ -2860,7 +2860,7 @@ int CGraphics_Threaded::GetVideoModes(CVideoMode *pModes, int MaxModes, int Scre
 	}
 
 	// add videomodes command
-	CImageInfo Image;
+	CImageInfo Image{};
 	mem_zero(&Image, sizeof(Image));
 
 	int NumModes = 0;

--- a/src/engine/client/graphics_threaded.h
+++ b/src/engine/client/graphics_threaded.h
@@ -783,43 +783,43 @@ class CGraphics_Threaded : public IEngineGraphics
 		DRAWING_TRIANGLES = 3
 	};
 
-	CCommandBuffer::SState m_State;
-	IGraphicsBackend *m_pBackend;
-	bool m_GLTileBufferingEnabled;
-	bool m_GLQuadBufferingEnabled;
-	bool m_GLTextBufferingEnabled;
-	bool m_GLQuadContainerBufferingEnabled;
-	bool m_GLHasTextureArrays;
-	bool m_GLUseTrianglesAsQuad;
+	CCommandBuffer::SState m_State{};
+	IGraphicsBackend *m_pBackend{};
+	bool m_GLTileBufferingEnabled{};
+	bool m_GLQuadBufferingEnabled{};
+	bool m_GLTextBufferingEnabled{};
+	bool m_GLQuadContainerBufferingEnabled{};
+	bool m_GLHasTextureArrays{};
+	bool m_GLUseTrianglesAsQuad{};
 
-	CCommandBuffer *m_apCommandBuffers[NUM_CMDBUFFERS];
+	CCommandBuffer *m_apCommandBuffers[NUM_CMDBUFFERS]{};
 	CCommandBuffer *m_pCommandBuffer;
 	unsigned m_CurrentCommandBuffer;
 
 	//
-	class IStorage *m_pStorage;
-	class IConsole *m_pConsole;
+	class IStorage *m_pStorage{};
+	class IConsole *m_pConsole{};
 
-	int m_CurIndex;
+	int m_CurIndex{};
 
-	CCommandBuffer::SVertex m_aVertices[CCommandBuffer::MAX_VERTICES];
-	CCommandBuffer::SVertexTex3DStream m_aVerticesTex3D[CCommandBuffer::MAX_VERTICES];
+	CCommandBuffer::SVertex m_aVertices[CCommandBuffer::MAX_VERTICES]{};
+	CCommandBuffer::SVertexTex3DStream m_aVerticesTex3D[CCommandBuffer::MAX_VERTICES]{};
 	int m_NumVertices;
 
-	CCommandBuffer::SColor m_aColor[4];
-	CCommandBuffer::STexCoord m_aTexture[4];
+	CCommandBuffer::SColor m_aColor[4]{};
+	CCommandBuffer::STexCoord m_aTexture[4]{};
 
 	bool m_RenderEnable;
 
 	float m_Rotation;
 	int m_Drawing;
 	bool m_DoScreenshot;
-	char m_aScreenshotName[128];
+	char m_aScreenshotName[128]{};
 
 	CTextureHandle m_InvalidTexture;
 
 	std::vector<int> m_TextureIndices;
-	int m_FirstFreeTexture;
+	int m_FirstFreeTexture{};
 	int m_TextureMemoryUsage;
 
 	std::vector<uint8_t> m_SpriteHelper;
@@ -840,10 +840,10 @@ class CGraphics_Threaded : public IEngineGraphics
 		int m_FreeIndex;
 	};
 	std::vector<SVertexArrayInfo> m_VertexArrayInfo;
-	int m_FirstFreeVertexArrayInfo;
+	int m_FirstFreeVertexArrayInfo{};
 
 	std::vector<int> m_BufferObjectIndices;
-	int m_FirstFreeBufferObjectIndex;
+	int m_FirstFreeBufferObjectIndex{};
 
 	struct SQuadContainer
 	{
@@ -871,7 +871,7 @@ class CGraphics_Threaded : public IEngineGraphics
 		bool m_AutomaticUpload;
 	};
 	std::vector<SQuadContainer> m_QuadContainers;
-	int m_FirstFreeQuadContainer;
+	int m_FirstFreeQuadContainer{};
 
 	struct SWindowResizeListener
 	{

--- a/src/engine/client/input.h
+++ b/src/engine/client/input.h
@@ -11,7 +11,7 @@
 
 class CInput : public IEngineInput
 {
-	IEngineGraphics *m_pGraphics;
+	IEngineGraphics *m_pGraphics{};
 
 	int m_LastX;
 	int m_LastY;
@@ -29,15 +29,15 @@ class CInput : public IEngineInput
 	bool IsEventValid(CEvent *pEvent) const override { return pEvent->m_InputCount == m_InputCounter; }
 
 	// quick access to input
-	unsigned short m_aInputCount[g_MaxKeys]; // tw-KEY
-	unsigned char m_aInputState[g_MaxKeys]; // SDL_SCANCODE
+	unsigned short m_aInputCount[g_MaxKeys]{}; // tw-KEY
+	unsigned char m_aInputState[g_MaxKeys]{}; // SDL_SCANCODE
 	int m_InputCounter;
 
 	// IME support
 	int m_NumTextInputInstances;
-	char m_aEditingText[INPUT_TEXT_SIZE];
+	char m_aEditingText[INPUT_TEXT_SIZE]{};
 	int m_EditingTextLen;
-	int m_EditingCursor;
+	int m_EditingCursor{};
 
 	bool KeyState(int Key) const;
 

--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -769,7 +769,7 @@ void CServerBrowser::Refresh(int Type)
 	if(Type == IServerBrowser::TYPE_LAN)
 	{
 		unsigned char Buffer[sizeof(SERVERBROWSE_GETINFO) + 1];
-		CNetChunk Packet;
+		CNetChunk Packet{};
 		int i;
 
 		/* do the broadcast version */
@@ -817,7 +817,7 @@ void CServerBrowser::Refresh(int Type)
 void CServerBrowser::RequestImpl(const NETADDR &Addr, CServerEntry *pEntry, int *pBasicToken, int *pToken, bool RandomToken) const
 {
 	unsigned char Buffer[sizeof(SERVERBROWSE_GETINFO) + 1];
-	CNetChunk Packet;
+	CNetChunk Packet{};
 
 	if(g_Config.m_Debug)
 	{
@@ -868,7 +868,7 @@ void CServerBrowser::RequestImpl(const NETADDR &Addr, CServerEntry *pEntry, int 
 void CServerBrowser::RequestImpl64(const NETADDR &Addr, CServerEntry *pEntry) const
 {
 	unsigned char Buffer[sizeof(SERVERBROWSE_GETINFO_64_LEGACY) + 1];
-	CNetChunk Packet;
+	CNetChunk Packet{};
 
 	if(g_Config.m_Debug)
 	{
@@ -1084,7 +1084,7 @@ void CServerBrowser::UpdateFromHttp()
 			}
 			aWantedAddresses[i].m_Got = true;
 			NETADDR Addr;
-			CServerInfo Info;
+			CServerInfo Info{};
 			m_pHttp->Server(aSortedServers[j], &Addr, &Info);
 			ServerBrowserFillEstimatedLatency(OwnLocation, pPingEntries, NumPingEntries, &p, Addr, &Info);
 			Info.m_HasRank = HasRank(Info.m_aMap);
@@ -1138,7 +1138,7 @@ void CServerBrowser::UpdateFromHttp()
 	for(int i = 0; i < NumServers; i++)
 	{
 		NETADDR Addr;
-		CServerInfo Info;
+		CServerInfo Info{};
 		m_pHttp->Server(i, &Addr, &Info);
 		ServerBrowserFillEstimatedLatency(OwnLocation, pPingEntries, NumPingEntries, &p, Addr, &Info);
 		Info.m_HasRank = HasRank(Info.m_aMap);

--- a/src/engine/client/serverbrowser.h
+++ b/src/engine/client/serverbrowser.h
@@ -145,12 +145,12 @@ public:
 	int GetCurrentType() override { return m_ServerlistType; }
 
 private:
-	CNetClient *m_pNetClient;
-	class IConsole *m_pConsole;
-	class IEngine *m_pEngine;
-	class IFriends *m_pFriends;
-	class IStorage *m_pStorage;
-	char m_aNetVersion[128];
+	CNetClient *m_pNetClient{};
+	class IConsole *m_pConsole{};
+	class IEngine *m_pEngine{};
+	class IFriends *m_pFriends{};
+	class IStorage *m_pStorage{};
+	char m_aNetVersion[128]{};
 
 	bool m_RefreshingHttp = false;
 	IServerBrowserHttp *m_pHttp = nullptr;
@@ -161,25 +161,25 @@ private:
 	CServerEntry **m_ppServerlist;
 	int *m_pSortedServerlist;
 
-	NETADDR m_aFavoriteServers[MAX_FAVORITES];
-	bool m_aFavoriteServersAllowPing[MAX_FAVORITES];
+	NETADDR m_aFavoriteServers[MAX_FAVORITES]{};
+	bool m_aFavoriteServersAllowPing[MAX_FAVORITES]{};
 	int m_NumFavoriteServers;
 
-	CNetwork m_aNetworks[NUM_NETWORKS];
+	CNetwork m_aNetworks[NUM_NETWORKS]{};
 	int m_OwnLocation = CServerInfo::LOC_UNKNOWN;
 
 	json_value *m_pDDNetInfo;
 
-	CServerEntry *m_aServerlistIp[256]; // ip hash list
+	CServerEntry *m_aServerlistIp[256]{}; // ip hash list
 
 	CServerEntry *m_pFirstReqServer; // request list
 	CServerEntry *m_pLastReqServer;
 	int m_NumRequests;
 
 	// used instead of g_Config.br_max_requests to get more servers
-	int m_CurrentMaxRequests;
+	int m_CurrentMaxRequests{};
 
-	int m_NeedRefresh;
+	int m_NeedRefresh{};
 
 	int m_NumSortedServers;
 	int m_NumSortedServersCapacity;
@@ -187,12 +187,12 @@ private:
 	int m_NumServerCapacity;
 
 	int m_Sorthash;
-	char m_aFilterString[64];
-	char m_aFilterGametypeString[128];
+	char m_aFilterString[64]{};
+	char m_aFilterGametypeString[128]{};
 
 	int m_ServerlistType;
 	int64_t m_BroadcastTime;
-	unsigned char m_aTokenSeed[16];
+	unsigned char m_aTokenSeed[16]{};
 
 	bool m_SortOnNextUpdate;
 

--- a/src/engine/client/serverbrowser_http.cpp
+++ b/src/engine/client/serverbrowser_http.cpp
@@ -44,9 +44,9 @@ private:
 	public:
 		std::atomic_int m_BestIndex{-1};
 		// Constant after construction.
-		VALIDATOR m_pfnValidator;
-		int m_NumUrls;
-		char m_aaUrls[MAX_URLS][256];
+		VALIDATOR m_pfnValidator{};
+		int m_NumUrls{};
+		char m_aaUrls[MAX_URLS][256]{};
 	};
 	class CJob : public IJob
 	{
@@ -434,7 +434,7 @@ bool CServerBrowserHttp::Parse(json_value *pJson, std::vector<CEntry> *paServers
 		const json_value &Info = Server["info"];
 		const json_value &Location = Server["location"];
 		int ParsedLocation = CServerInfo::LOC_UNKNOWN;
-		CServerInfo2 ParsedInfo;
+		CServerInfo2 ParsedInfo{};
 		if(Addresses.type != json_array || (Location.type != json_string && Location.type != json_none))
 		{
 			return true;
@@ -509,7 +509,7 @@ IServerBrowserHttp *CreateServerBrowserHttp(IEngine *pEngine, IConsole *pConsole
 	IOHANDLE File = pStorage->OpenFile("ddnet-serverlist-urls.cfg", IOFLAG_READ | IOFLAG_SKIP_BOM, IStorage::TYPE_ALL);
 	if(File)
 	{
-		CLineReader Lines;
+		CLineReader Lines{};
 		Lines.Init(File);
 		while(NumUrls < CChooseMaster::MAX_URLS)
 		{

--- a/src/engine/client/steam.cpp
+++ b/src/engine/client/steam.cpp
@@ -9,9 +9,9 @@ class CSteam : public ISteam
 	HSteamPipe m_SteamPipe;
 	ISteamApps *m_pSteamApps;
 	ISteamFriends *m_pSteamFriends;
-	char m_aPlayerName[16];
-	bool m_GotConnectAddr;
-	NETADDR m_ConnectAddr;
+	char m_aPlayerName[16]{};
+	bool m_GotConnectAddr{};
+	NETADDR m_ConnectAddr{};
 
 public:
 	CSteam()
@@ -88,7 +88,7 @@ public:
 	void Update() override
 	{
 		SteamAPI_ManualDispatch_RunFrame(m_SteamPipe);
-		CallbackMsg_t Callback;
+		CallbackMsg_t Callback{};
 		while(SteamAPI_ManualDispatch_GetNextCallback(m_SteamPipe, &Callback))
 		{
 			switch(Callback.m_iCallback)

--- a/src/engine/client/text.cpp
+++ b/src/engine/client/text.cpp
@@ -58,10 +58,10 @@ struct STextCharQuadVertex
 	{
 		m_Color.m_R = m_Color.m_G = m_Color.m_B = m_Color.m_A = 255;
 	}
-	float m_X, m_Y;
+	float m_X{}, m_Y{};
 	// do not use normalized floats as coordinates, since the texture might grow
-	float m_U, m_V;
-	STextCharQuadVertexColor m_Color;
+	float m_U{}, m_V{};
+	STextCharQuadVertexColor m_Color{};
 };
 
 struct STextCharQuad
@@ -77,8 +77,8 @@ struct STextureSkyline
 
 struct CFontSizeData
 {
-	int m_FontSize;
-	FT_Face *m_pFace;
+	int m_FontSize{};
+	FT_Face *m_pFace{};
 
 	std::map<int, SFontSizeChar> m_Chars;
 };
@@ -118,9 +118,9 @@ public:
 		return &m_aFontSizes[FontSize - MIN_FONT_SIZE];
 	}
 
-	void *m_pBuf;
-	char m_aFilename[IO_MAX_PATH_LENGTH];
-	FT_Face m_FtFace;
+	void *m_pBuf{};
+	char m_aFilename[IO_MAX_PATH_LENGTH]{};
+	FT_Face m_FtFace{};
 
 	struct SFontFallBack
 	{
@@ -135,20 +135,20 @@ public:
 
 	IGraphics::CTextureHandle m_aTextures[2];
 	// keep the full texture, because opengl doesn't provide texture copying
-	uint8_t *m_TextureData[2];
+	uint8_t *m_TextureData[2]{};
 
 	// width and height are the same
-	int m_CurTextureDimensions[2];
+	int m_CurTextureDimensions[2]{};
 
 	STextureSkyline m_TextureSkyline[2];
 };
 
 struct STextString
 {
-	int m_QuadBufferObjectIndex;
-	int m_QuadBufferContainerIndex;
-	size_t m_QuadNum;
-	int m_SelectionQuadContainerIndex;
+	int m_QuadBufferObjectIndex{};
+	int m_QuadBufferContainerIndex{};
+	size_t m_QuadNum{};
+	int m_SelectionQuadContainerIndex{};
 
 	std::vector<STextCharQuad> m_CharacterQuads;
 };
@@ -157,33 +157,33 @@ struct STextContainer
 {
 	STextContainer() { Reset(); }
 
-	CFont *m_pFont;
-	int m_FontSize;
+	CFont *m_pFont{};
+	int m_FontSize{};
 	STextString m_StringInfo;
 
 	// keep these values to calculate offsets
-	float m_AlignedStartX;
-	float m_AlignedStartY;
-	float m_X;
-	float m_Y;
+	float m_AlignedStartX{};
+	float m_AlignedStartY{};
+	float m_X{};
+	float m_Y{};
 
-	int m_Flags;
-	int m_LineCount;
-	int m_GlyphCount;
-	int m_CharCount;
-	int m_MaxLines;
+	int m_Flags{};
+	int m_LineCount{};
+	int m_GlyphCount{};
+	int m_CharCount{};
+	int m_MaxLines{};
 
-	float m_StartX;
-	float m_StartY;
-	float m_LineWidth;
-	float m_UnscaledFontSize;
+	float m_StartX{};
+	float m_StartY{};
+	float m_LineWidth{};
+	float m_UnscaledFontSize{};
 
-	int m_RenderFlags;
+	int m_RenderFlags{};
 
-	bool m_HasCursor;
-	bool m_HasSelection;
+	bool m_HasCursor{};
+	bool m_HasSelection{};
 
-	bool m_SingleTimeUse;
+	bool m_SingleTimeUse{};
 
 	void Reset()
 	{
@@ -219,14 +219,14 @@ class CTextRender : public IEngineTextRender
 
 	std::vector<STextContainer *> m_TextContainers;
 	std::vector<int> m_TextContainerIndices;
-	int m_FirstFreeTextContainerIndex;
+	int m_FirstFreeTextContainerIndex{};
 
 	SBufferContainerInfo m_DefaultTextContainerInfo;
 
 	std::vector<CFont *> m_Fonts;
 	CFont *m_pCurFont;
 
-	std::chrono::nanoseconds m_CursorRenderTime;
+	std::chrono::nanoseconds m_CursorRenderTime{};
 
 	int GetFreeTextContainerIndex()
 	{
@@ -390,8 +390,8 @@ class CTextRender : public IEngineTextRender
 	}
 
 	// 128k * 2 of data used for rendering glyphs
-	unsigned char ms_aGlyphData[(1024 / 4) * (1024 / 4)];
-	unsigned char ms_aGlyphDataOutlined[(1024 / 4) * (1024 / 4)];
+	unsigned char ms_aGlyphData[(1024 / 4) * (1024 / 4)]{};
+	unsigned char ms_aGlyphDataOutlined[(1024 / 4) * (1024 / 4)]{};
 
 	bool GetCharacterSpace(CFont *pFont, int TextureIndex, int Width, int Height, int &PosX, int &PosY)
 	{
@@ -744,7 +744,7 @@ public:
 
 	bool LoadFallbackFont(CFont *pFont, const char *pFilename, const unsigned char *pBuf, size_t Size) override
 	{
-		CFont::SFontFallBack FallbackFont;
+		CFont::SFontFallBack FallbackFont{};
 		FallbackFont.m_pBuf = (void *)pBuf;
 		str_copy(FallbackFont.m_aFilename, pFilename, sizeof(FallbackFont.m_aFilename));
 
@@ -835,7 +835,7 @@ public:
 
 	void Text(void *pFontSetV, float x, float y, float Size, const char *pText, float LineWidth) override
 	{
-		CTextCursor Cursor;
+		CTextCursor Cursor{};
 		SetCursor(&Cursor, x, y, Size, TEXTFLAG_RENDER);
 		Cursor.m_LineWidth = LineWidth;
 		int OldRenderFlags = m_RenderFlags;
@@ -847,7 +847,7 @@ public:
 
 	float TextWidth(void *pFontSetV, float Size, const char *pText, int StrLength, float LineWidth, float *pAlignedHeight = NULL, float *pMaxCharacterHeightInLine = NULL) override
 	{
-		CTextCursor Cursor;
+		CTextCursor Cursor{};
 		SetCursor(&Cursor, 0, 0, Size, 0);
 		Cursor.m_LineWidth = LineWidth;
 		int OldRenderFlags = m_RenderFlags;
@@ -864,7 +864,7 @@ public:
 
 	int TextLineCount(void *pFontSetV, float Size, const char *pText, float LineWidth) override
 	{
-		CTextCursor Cursor;
+		CTextCursor Cursor{};
 		SetCursor(&Cursor, 0, 0, Size, 0);
 		Cursor.m_LineWidth = LineWidth;
 		int OldRenderFlags = m_RenderFlags;

--- a/src/engine/client/updater.cpp
+++ b/src/engine/client/updater.cpp
@@ -14,8 +14,8 @@ using std::string;
 
 class CUpdaterFetchTask : public CHttpRequest
 {
-	char m_aBuf[256];
-	char m_aBuf2[256];
+	char m_aBuf[256]{};
+	char m_aBuf2[256]{};
 	CUpdater *m_pUpdater;
 
 	void OnProgress() override;

--- a/src/engine/client/updater.h
+++ b/src/engine/client/updater.h
@@ -43,14 +43,14 @@ class CUpdater : public IUpdater
 	LOCK m_Lock;
 
 	int m_State;
-	char m_aStatus[256] GUARDED_BY(m_Lock);
+	char m_aStatus[256] GUARDED_BY(m_Lock) {};
 	int m_Percent GUARDED_BY(m_Lock);
-	char m_aLastFile[256];
-	char m_aClientExecTmp[64];
-	char m_aServerExecTmp[64];
+	char m_aLastFile[256]{};
+	char m_aClientExecTmp[64]{};
+	char m_aServerExecTmp[64]{};
 
-	bool m_ClientUpdate;
-	bool m_ServerUpdate;
+	bool m_ClientUpdate{};
+	bool m_ServerUpdate{};
 
 	std::map<std::string, bool> m_FileJobs;
 

--- a/src/engine/client/video.h
+++ b/src/engine/client/video.h
@@ -90,11 +90,11 @@ private:
 
 	int m_Width;
 	int m_Height;
-	char m_Name[256];
+	char m_Name[256]{};
 	//FILE *m_dbgfile;
 	uint64_t m_VSeq = 0;
 	uint64_t m_ASeq = 0;
-	uint64_t m_Vframe;
+	uint64_t m_Vframe{};
 
 	int m_FPS;
 
@@ -141,10 +141,10 @@ private:
 
 	std::vector<std::unique_ptr<SAudioRecorderThread>> m_vAudioThreads;
 
-	std::atomic<int32_t> m_ProcessingVideoFrame;
-	std::atomic<int32_t> m_ProcessingAudioFrame;
+	std::atomic<int32_t> m_ProcessingVideoFrame{};
+	std::atomic<int32_t> m_ProcessingAudioFrame{};
 
-	std::atomic<bool> m_NextFrame;
+	std::atomic<bool> m_NextFrame{};
 
 	bool m_HasAudio;
 

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -18,10 +18,10 @@ public:
 	CHostLookup();
 	CHostLookup(const char *pHostname, int Nettype);
 
-	int m_Result;
-	char m_aHostname[128];
-	int m_Nettype;
-	NETADDR m_Addr;
+	int m_Result{};
+	char m_aHostname[128]{};
+	int m_Nettype{};
+	NETADDR m_Addr{};
 };
 
 class IEngine : public IInterface

--- a/src/engine/server/antibot.h
+++ b/src/engine/server/antibot.h
@@ -14,7 +14,7 @@ class CAntibot : public IEngineAntibot
 	class IConsole *Console() const { return m_pConsole; }
 	class IGameServer *GameServer() const { return m_pGameServer; }
 
-	CAntibotData m_Data;
+	CAntibotData m_Data{};
 	CAntibotRoundData m_RoundData;
 	bool m_Initialized;
 

--- a/src/engine/server/authmanager.cpp
+++ b/src/engine/server/authmanager.cpp
@@ -47,7 +47,7 @@ int CAuthManager::AddKeyHash(const char *pIdent, MD5_DIGEST Hash, const unsigned
 	if(FindKey(pIdent) >= 0)
 		return -1;
 
-	CKey Key;
+	CKey Key{};
 	str_copy(Key.m_aIdent, pIdent, sizeof(Key.m_aIdent));
 	Key.m_Pw = Hash;
 	mem_copy(Key.m_aSalt, pSalt, SALT_BYTES);

--- a/src/engine/server/authmanager.h
+++ b/src/engine/server/authmanager.h
@@ -18,7 +18,7 @@ private:
 	};
 	array<CKey> m_aKeys;
 
-	int m_aDefault[3];
+	int m_aDefault[3]{};
 	bool m_Generated;
 
 public:

--- a/src/engine/server/databases/connection_pool.cpp
+++ b/src/engine/server/databases/connection_pool.cpp
@@ -32,7 +32,7 @@ struct CSqlExecData
 	{
 		CDbConnectionPool::FRead m_pReadFunc;
 		CDbConnectionPool::FWrite m_pWriteFunc;
-	} m_Ptr;
+	} m_Ptr{};
 
 	std::unique_ptr<const ISqlData> m_pThreadData;
 	const char *m_pName;

--- a/src/engine/server/databases/mysql.cpp
+++ b/src/engine/server/databases/mysql.cpp
@@ -111,7 +111,7 @@ private:
 		void operator()(MYSQL_STMT *pStmt) const;
 	};
 
-	char m_aErrorDetail[128];
+	char m_aErrorDetail[128]{};
 	void StoreErrorMysql(const char *pContext);
 	void StoreErrorStmt(const char *pContext);
 	bool ConnectImpl();
@@ -127,16 +127,16 @@ private:
 
 	bool m_NewQuery = false;
 	bool m_HaveConnection = false;
-	MYSQL m_Mysql;
+	MYSQL m_Mysql{};
 	std::unique_ptr<MYSQL_STMT, CStmtDeleter> m_pStmt = nullptr;
 	std::vector<MYSQL_BIND> m_aStmtParameters;
 	std::vector<UParameterExtra> m_aStmtParameterExtras;
 
 	// copy of config vars
-	char m_aDatabase[64];
-	char m_aUser[64];
-	char m_aPass[64];
-	char m_aIp[64];
+	char m_aDatabase[64]{};
+	char m_aUser[64]{};
+	char m_aPass[64]{};
+	char m_aIp[64]{};
 	int m_Port;
 	bool m_Setup;
 

--- a/src/engine/server/databases/sqlite.cpp
+++ b/src/engine/server/databases/sqlite.cpp
@@ -56,7 +56,7 @@ public:
 
 private:
 	// copy of config vars
-	char m_aFilename[IO_MAX_PATH_LENGTH];
+	char m_aFilename[IO_MAX_PATH_LENGTH]{};
 	bool m_Setup;
 
 	sqlite3 *m_pDb;

--- a/src/engine/server/register.cpp
+++ b/src/engine/server/register.cpp
@@ -116,20 +116,20 @@ class CRegister : public IRegister
 	IConsole *m_pConsole;
 	IEngine *m_pEngine;
 	int m_ServerPort;
-	char m_aConnlessTokenHex[16];
+	char m_aConnlessTokenHex[16]{};
 
 	std::shared_ptr<CGlobal> m_pGlobal = std::make_shared<CGlobal>();
 	bool m_aProtocolEnabled[NUM_PROTOCOLS] = {true, true, true, true};
 	CProtocol m_aProtocols[NUM_PROTOCOLS];
 
 	int m_NumExtraHeaders = 0;
-	char m_aaExtraHeaders[8][128];
+	char m_aaExtraHeaders[8][128]{};
 
-	char m_aVerifyPacketPrefix[sizeof(SERVERBROWSE_CHALLENGE) + UUID_MAXSTRSIZE];
+	char m_aVerifyPacketPrefix[sizeof(SERVERBROWSE_CHALLENGE) + UUID_MAXSTRSIZE]{};
 	CUuid m_Secret = RandomUuid();
 	CUuid m_ChallengeSecret = RandomUuid();
 	bool m_GotServerInfo = false;
-	char m_aServerInfo[16384];
+	char m_aServerInfo[16384]{};
 
 public:
 	CRegister(CConfig *pConfig, IConsole *pConsole, IEngine *pEngine, int ServerPort, unsigned SixupSecurityToken);
@@ -568,7 +568,7 @@ bool CRegister::OnPacket(const CNetChunk *pPacket)
 	if(pPacket->m_DataSize >= (int)sizeof(m_aVerifyPacketPrefix) &&
 		mem_comp(pPacket->m_pData, m_aVerifyPacketPrefix, sizeof(m_aVerifyPacketPrefix)) == 0)
 	{
-		CUnpacker Unpacker;
+		CUnpacker Unpacker{};
 		Unpacker.Reset(pPacket->m_pData, pPacket->m_DataSize);
 		Unpacker.GetRaw(sizeof(m_aVerifyPacketPrefix));
 		const char *pProtocol = Unpacker.GetString(0);

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -837,7 +837,7 @@ static inline bool RepackMsg(const CMsgPacker *pMsg, CPacker &Packer, bool Sixup
 
 int CServer::SendMsg(CMsgPacker *pMsg, int Flags, int ClientID)
 {
-	CNetChunk Packet;
+	CNetChunk Packet{};
 	if(!pMsg)
 		return -1;
 
@@ -849,7 +849,7 @@ int CServer::SendMsg(CMsgPacker *pMsg, int Flags, int ClientID)
 
 	if(ClientID < 0)
 	{
-		CPacker Pack6, Pack7;
+		CPacker Pack6{}, Pack7{};
 		if(RepackMsg(pMsg, Pack6, false))
 			return -1;
 		if(RepackMsg(pMsg, Pack7, true))
@@ -880,7 +880,7 @@ int CServer::SendMsg(CMsgPacker *pMsg, int Flags, int ClientID)
 	}
 	else
 	{
-		CPacker Pack;
+		CPacker Pack{};
 		if(RepackMsg(pMsg, Pack, m_aClients[ClientID].m_Sixup))
 			return -1;
 
@@ -908,7 +908,7 @@ int CServer::SendMsg(CMsgPacker *pMsg, int Flags, int ClientID)
 
 void CServer::SendMsgRaw(int ClientID, const void *pData, int Size, int Flags)
 {
-	CNetChunk Packet;
+	CNetChunk Packet{};
 	mem_zero(&Packet, sizeof(CNetChunk));
 	Packet.m_ClientID = ClientID;
 	Packet.m_pData = pData;
@@ -1412,14 +1412,14 @@ static inline int MsgFromSixup(int Msg, bool System)
 void CServer::ProcessClientPacket(CNetChunk *pPacket)
 {
 	int ClientID = pPacket->m_ClientID;
-	CUnpacker Unpacker;
+	CUnpacker Unpacker{};
 	Unpacker.Reset(pPacket->m_pData, pPacket->m_DataSize);
 	CMsgPacker Packer(NETMSG_EX, true);
 
 	// unpack msgid and system flag
 	int Msg;
 	bool Sys;
-	CUuid Uuid;
+	CUuid Uuid{};
 
 	int Result = UnpackMessageID(&Msg, &Sys, &Uuid, &Unpacker, &Packer);
 	if(Result == UNPACKMESSAGE_ERROR)
@@ -1894,7 +1894,7 @@ void CServer::CacheServerInfo(CCache *pCache, int Type, bool SendClients)
 	pCache->Clear();
 
 	// One chance to improve the protocol!
-	CPacker p;
+	CPacker p{};
 	char aBuf[128];
 
 	// count the players
@@ -1980,7 +1980,7 @@ void CServer::CacheServerInfo(CCache *pCache, int Type, bool SendClients)
 	const void *pPrefix = p.Data();
 	int PrefixSize = p.Size();
 
-	CPacker q;
+	CPacker q{};
 	int ChunksStored = 0;
 	int PlayersStored = 0;
 
@@ -2089,7 +2089,7 @@ void CServer::CacheServerInfoSixup(CCache *pCache, bool SendClients)
 {
 	pCache->Clear();
 
-	CPacker Packer;
+	CPacker Packer{};
 	Packer.Reset();
 
 	// Could be moved to a separate function and cached
@@ -2149,7 +2149,7 @@ void CServer::CacheServerInfoSixup(CCache *pCache, bool SendClients)
 
 void CServer::SendServerInfo(const NETADDR *pAddr, int Token, int Type, bool SendClients)
 {
-	CPacker p;
+	CPacker p{};
 	char aBuf[128];
 	p.Reset();
 
@@ -2163,7 +2163,7 @@ void CServer::SendServerInfo(const NETADDR *pAddr, int Token, int Type, bool Sen
 		(p).AddString(aBuf, 0); \
 	} while(0)
 
-	CNetChunk Packet;
+	CNetChunk Packet{};
 	Packet.m_ClientID = -1;
 	Packet.m_Address = *pAddr;
 	Packet.m_Flags = NETSENDFLAG_CONNLESS;
@@ -2341,7 +2341,7 @@ void CServer::UpdateServerInfo(bool Resend)
 
 void CServer::PumpNetwork(bool PacketWaiting)
 {
-	CNetChunk Packet;
+	CNetChunk Packet{};
 	SECURITY_TOKEN ResponseToken;
 
 	m_NetServer.Update();
@@ -2377,14 +2377,14 @@ void CServer::PumpNetwork(bool PacketWaiting)
 					}
 					if(Type == SERVERINFO_VANILLA && ResponseToken != NET_SECURITY_TOKEN_UNKNOWN && Config()->m_SvSixup)
 					{
-						CUnpacker Unpacker;
+						CUnpacker Unpacker{};
 						Unpacker.Reset((unsigned char *)Packet.m_pData + sizeof(SERVERBROWSE_GETINFO), Packet.m_DataSize - sizeof(SERVERBROWSE_GETINFO));
 						int SrvBrwsToken = Unpacker.GetInt();
 						if(Unpacker.Error())
 							continue;
 
-						CPacker Packer;
-						CNetChunk Response;
+						CPacker Packer{};
+						CNetChunk Response{};
 
 						GetServerInfoSixup(&Packer, SrvBrwsToken, RateLimitServerInfoConnless());
 
@@ -3311,7 +3311,7 @@ void CServer::DemoRecorder_HandleAutoStart()
 		if(Config()->m_SvAutoDemoMax)
 		{
 			// clean up auto recorded demos
-			CFileCollection AutoDemos;
+			CFileCollection AutoDemos{};
 			AutoDemos.Init(Storage(), "demos/server", "autorecord", ".demo", Config()->m_SvAutoDemoMax);
 		}
 	}
@@ -3942,7 +3942,7 @@ const char *CServer::GetAnnouncementLine(char const *pFileName)
 
 	std::vector<char *> Lines;
 	char *pLine;
-	CLineReader Reader;
+	CLineReader Reader{};
 	Reader.Init(File);
 	while((pLine = Reader.Get()))
 		if(str_length(pLine))

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -59,13 +59,13 @@ class CSnapIDPool
 		int m_Timeout;
 	};
 
-	CID m_aIDs[MAX_IDS];
+	CID m_aIDs[MAX_IDS]{};
 
-	int m_FirstFree;
-	int m_FirstTimed;
-	int m_LastTimed;
-	int m_Usage;
-	int m_InUsage;
+	int m_FirstFree{};
+	int m_FirstTimed{};
+	int m_LastTimed{};
+	int m_Usage{};
+	int m_InUsage{};
 
 public:
 	CSnapIDPool();
@@ -103,19 +103,19 @@ class CServer : public IServer
 
 	class IGameServer *m_pGameServer;
 	class CConfig *m_pConfig;
-	class IConsole *m_pConsole;
-	class IStorage *m_pStorage;
-	class IEngineAntibot *m_pAntibot;
+	class IConsole *m_pConsole{};
+	class IStorage *m_pStorage{};
+	class IEngineAntibot *m_pAntibot{};
 	class IRegister *m_pRegister;
 
 #if defined(CONF_UPNP)
-	CUPnP m_UPnP;
+	CUPnP m_UPnP{};
 #endif
 
 #if defined(CONF_FAMILY_UNIX)
-	UNIXSOCKETADDR m_ConnLoggingDestAddr;
+	UNIXSOCKETADDR m_ConnLoggingDestAddr{};
 	bool m_ConnLoggingSocketCreated;
-	UNIXSOCKET m_ConnLoggingSocket;
+	UNIXSOCKET m_ConnLoggingSocket{};
 #endif
 
 	class CDbConnectionPool *m_pConnectionPool;
@@ -214,7 +214,7 @@ public:
 	};
 
 	CClient m_aClients[MAX_CLIENTS];
-	int m_aIdMap[MAX_CLIENTS * VANILLA_MAX_CLIENTS];
+	int m_aIdMap[MAX_CLIENTS * VANILLA_MAX_CLIENTS]{};
 
 	CSnapshotDelta m_SnapshotDelta;
 	CSnapshotBuilder m_SnapshotBuilder;
@@ -222,13 +222,13 @@ public:
 	CNetServer m_NetServer;
 	CEcon m_Econ;
 #if defined(CONF_FAMILY_UNIX)
-	CFifo m_Fifo;
+	CFifo m_Fifo{};
 #endif
 	CServerBan m_ServerBan;
 
-	IEngineMap *m_pMap;
+	IEngineMap *m_pMap{};
 
-	int64_t m_GameStartTime;
+	int64_t m_GameStartTime{};
 	//int m_CurrentGameTick;
 
 	enum
@@ -244,8 +244,8 @@ public:
 	bool m_ReloadedWhenEmpty;
 	int m_RconClientID;
 	int m_RconAuthLevel;
-	int m_PrintCBIndex;
-	char m_aShutdownReason[128];
+	int m_PrintCBIndex{};
+	char m_aShutdownReason[128]{};
 
 	enum
 	{
@@ -254,11 +254,11 @@ public:
 		NUM_MAP_TYPES
 	};
 
-	char m_aCurrentMap[IO_MAX_PATH_LENGTH];
-	SHA256_DIGEST m_aCurrentMapSha256[NUM_MAP_TYPES];
-	unsigned m_aCurrentMapCrc[NUM_MAP_TYPES];
-	unsigned char *m_apCurrentMapData[NUM_MAP_TYPES];
-	unsigned int m_aCurrentMapSize[NUM_MAP_TYPES];
+	char m_aCurrentMap[IO_MAX_PATH_LENGTH]{};
+	SHA256_DIGEST m_aCurrentMapSha256[NUM_MAP_TYPES]{};
+	unsigned m_aCurrentMapCrc[NUM_MAP_TYPES]{};
+	unsigned char *m_apCurrentMapData[NUM_MAP_TYPES]{};
+	unsigned int m_aCurrentMapSize[NUM_MAP_TYPES]{};
 
 	CDemoRecorder m_aDemoRecorder[MAX_CLIENTS + 1];
 	CAuthManager m_AuthManager;
@@ -266,7 +266,7 @@ public:
 	int64_t m_ServerInfoFirstRequest;
 	int m_ServerInfoNumRequests;
 
-	char m_aErrorShutdownReason[128];
+	char m_aErrorShutdownReason[128]{};
 
 	array<CNameBan> m_aNameBans;
 
@@ -439,9 +439,9 @@ public:
 	// DDRace
 
 	void GetClientAddr(int ClientID, NETADDR *pAddr) const override;
-	int m_aPrevStates[MAX_CLIENTS];
+	int m_aPrevStates[MAX_CLIENTS]{};
 	const char *GetAnnouncementLine(char const *pFileName) override;
-	unsigned m_AnnouncementLastLine;
+	unsigned m_AnnouncementLastLine{};
 
 	int *GetIdMap(int ClientID) override;
 

--- a/src/engine/shared/assertion_logger.cpp
+++ b/src/engine/shared/assertion_logger.cpp
@@ -19,8 +19,8 @@ class CAssertionLogger : public ILogger
 	std::mutex m_DbgMessageMutex;
 	CStaticRingBuffer<SDebugMessageItem, sizeof(SDebugMessageItem) * 64, CRingBufferBase::FLAG_RECYCLE> m_DbgMessages;
 
-	char m_aAssertLogPath[IO_MAX_PATH_LENGTH];
-	char m_aGameName[256];
+	char m_aAssertLogPath[IO_MAX_PATH_LENGTH]{};
+	char m_aGameName[256]{};
 
 public:
 	CAssertionLogger(const char *pAssertLogPath, const char *pGameName);

--- a/src/engine/shared/config.h
+++ b/src/engine/shared/config.h
@@ -60,7 +60,7 @@ class CConfigManager : public IConfigManager
 	class IStorage *m_pStorage;
 	IOHANDLE m_ConfigFile;
 	bool m_Failed;
-	CCallback m_aCallbacks[MAX_CALLBACKS];
+	CCallback m_aCallbacks[MAX_CALLBACKS]{};
 	int m_NumCallbacks;
 
 public:

--- a/src/engine/shared/console.cpp
+++ b/src/engine/shared/console.cpp
@@ -603,7 +603,7 @@ void CConsole::ExecuteFile(const char *pFilename, int ClientID, bool LogFailure,
 		return;
 
 	// push this one to the stack
-	CExecFile ThisFile;
+	CExecFile ThisFile{};
 	CExecFile *pPrev = m_pFirstExec;
 	ThisFile.m_pFilename = pFilename;
 	ThisFile.m_pPrev = m_pFirstExec;
@@ -616,7 +616,7 @@ void CConsole::ExecuteFile(const char *pFilename, int ClientID, bool LogFailure,
 	if(File)
 	{
 		char *pLine;
-		CLineReader Reader;
+		CLineReader Reader{};
 
 		str_format(aBuf, sizeof(aBuf), "executing '%s'", pFilename);
 		Print(IConsole::OUTPUT_LEVEL_STANDARD, "console", aBuf);

--- a/src/engine/shared/console.h
+++ b/src/engine/shared/console.h
@@ -35,7 +35,7 @@ class CConsole : public IConsole
 
 	int m_FlagMask;
 	bool m_StoreCommands;
-	const char *m_apStrokeStr[2];
+	const char *m_apStrokeStr[2]{};
 	CCommand *m_pFirstCommand;
 
 	class CExecFile
@@ -46,7 +46,7 @@ class CConsole : public IConsole
 	};
 
 	CExecFile *m_pFirstExec;
-	class CConfig *m_pConfig;
+	class CConfig *m_pConfig{};
 	class IStorage *m_pStorage;
 	int m_AccessLevel;
 

--- a/src/engine/shared/datafile.cpp
+++ b/src/engine/shared/datafile.cpp
@@ -23,7 +23,7 @@ struct CItemEx
 
 	static CItemEx FromUuid(CUuid Uuid)
 	{
-		CItemEx Result;
+		CItemEx Result{};
 		for(int i = 0; i < (int)sizeof(CUuid) / 4; i++)
 			Result.m_aUuid[i] = bytes_be_to_int(&Uuid.m_aData[i * 4]);
 		return Result;
@@ -31,7 +31,7 @@ struct CItemEx
 
 	CUuid ToUuid() const
 	{
-		CUuid Result;
+		CUuid Result{};
 		for(int i = 0; i < (int)sizeof(CUuid) / 4; i++)
 			int_to_bytes_be(&Result.m_aData[i * 4], m_aUuid[i]);
 		return Result;
@@ -140,7 +140,7 @@ bool CDataFileReader::Open(class IStorage *pStorage, const char *pFilename, int 
 	}
 
 	// TODO: change this header
-	CDatafileHeader Header;
+	CDatafileHeader Header{};
 	if(sizeof(Header) != io_read(File, &Header, sizeof(Header)))
 	{
 		dbg_msg("datafile", "couldn't load header");
@@ -725,7 +725,7 @@ int CDataFileWriter::Finish()
 	int ItemSize = 0;
 	int TypesSize, HeaderSize, OffsetSize, FileSize, SwapSize;
 	int DataSize = 0;
-	CDatafileHeader Header;
+	CDatafileHeader Header{};
 
 	// we should now write this file!
 	if(DEBUG)
@@ -784,7 +784,7 @@ int CDataFileWriter::Finish()
 		if(m_pItemTypes[i].m_Num)
 		{
 			// write info
-			CDatafileItemType Info;
+			CDatafileItemType Info{};
 			Info.m_Type = i;
 			Info.m_Start = Count;
 			Info.m_Num = m_pItemTypes[i].m_Num;
@@ -856,7 +856,7 @@ int CDataFileWriter::Finish()
 			int k = m_pItemTypes[i].m_First;
 			while(k != -1)
 			{
-				CDatafileItem Item;
+				CDatafileItem Item{};
 				Item.m_TypeAndID = (i << 16) | m_pItems[k].m_ID;
 				Item.m_Size = m_pItems[k].m_Size;
 				if(DEBUG)

--- a/src/engine/shared/datafile.h
+++ b/src/engine/shared/datafile.h
@@ -90,14 +90,14 @@ class CDataFileWriter
 	};
 
 	IOHANDLE m_File;
-	int m_NumItems;
-	int m_NumDatas;
-	int m_NumItemTypes;
-	int m_NumExtendedItemTypes;
+	int m_NumItems{};
+	int m_NumDatas{};
+	int m_NumItemTypes{};
+	int m_NumExtendedItemTypes{};
 	CItemTypeInfo *m_pItemTypes;
 	CItemInfo *m_pItems;
 	CDataInfo *m_pDatas;
-	int m_aExtendedItemTypes[MAX_EXTENDED_ITEM_TYPES];
+	int m_aExtendedItemTypes[MAX_EXTENDED_ITEM_TYPES]{};
 
 	int GetExtendedItemTypeIndex(int Type);
 

--- a/src/engine/shared/demo.cpp
+++ b/src/engine/shared/demo.cpp
@@ -65,8 +65,8 @@ int CDemoRecorder::Start(class IStorage *pStorage, class IConsole *pConsole, con
 		return -1;
 	}
 
-	CDemoHeader Header;
-	CTimelineMarkers TimelineMarkers;
+	CDemoHeader Header{};
+	CTimelineMarkers TimelineMarkers{};
 	if(m_File)
 	{
 		io_close(DemoFile);

--- a/src/engine/shared/demo.h
+++ b/src/engine/shared/demo.h
@@ -15,18 +15,18 @@ typedef std::function<void()> TUpdateIntraTimesFunc;
 
 class CDemoRecorder : public IDemoRecorder
 {
-	class IConsole *m_pConsole;
+	class IConsole *m_pConsole{};
 	IOHANDLE m_File;
-	char m_aCurrentFilename[256];
+	char m_aCurrentFilename[256]{};
 	int m_LastTickMarker;
-	int m_LastKeyFrame;
-	int m_FirstTick;
-	unsigned char m_aLastSnapshotData[CSnapshot::MAX_SIZE];
+	int m_LastKeyFrame{};
+	int m_FirstTick{};
+	unsigned char m_aLastSnapshotData[CSnapshot::MAX_SIZE]{};
 	class CSnapshotDelta *m_pSnapshotDelta;
-	int m_NumTimelineMarkers;
-	int m_aTimelineMarkers[MAX_TIMELINE_MARKERS];
+	int m_NumTimelineMarkers{};
+	int m_aTimelineMarkers[MAX_TIMELINE_MARKERS]{};
 	bool m_NoMapData;
-	unsigned char *m_pMapData;
+	unsigned char *m_pMapData{};
 
 	DEMOFUNC_FILTER m_pfnFilter;
 	void *m_pUser;
@@ -83,7 +83,7 @@ public:
 	};
 
 private:
-	IListener *m_pListener;
+	IListener *m_pListener{};
 
 	TUpdateIntraTimesFunc m_UpdateIntraTimesFunc;
 
@@ -100,19 +100,19 @@ private:
 		CKeyFrameSearch *m_pNext;
 	};
 
-	class IConsole *m_pConsole;
-	IOHANDLE m_File;
-	long m_MapOffset;
-	char m_aFilename[IO_MAX_PATH_LENGTH];
-	CKeyFrame *m_pKeyFrames;
-	CMapInfo m_MapInfo;
-	int m_SpeedIndex;
+	class IConsole *m_pConsole{};
+	IOHANDLE m_File{};
+	long m_MapOffset{};
+	char m_aFilename[IO_MAX_PATH_LENGTH]{};
+	CKeyFrame *m_pKeyFrames{};
+	CMapInfo m_MapInfo{};
+	int m_SpeedIndex{};
 
-	CPlaybackInfo m_Info;
-	int m_DemoType;
-	unsigned char m_aLastSnapshotData[CSnapshot::MAX_SIZE];
-	int m_LastSnapshotDataSize;
-	class CSnapshotDelta *m_pSnapshotDelta;
+	CPlaybackInfo m_Info{};
+	int m_DemoType{};
+	unsigned char m_aLastSnapshotData[CSnapshot::MAX_SIZE]{};
+	int m_LastSnapshotDataSize{};
+	class CSnapshotDelta *m_pSnapshotDelta{};
 
 	int ReadChunkHeader(int *pType, int *pSize, int *pTick);
 	void DoTick();

--- a/src/engine/shared/econ.h
+++ b/src/engine/shared/econ.h
@@ -28,15 +28,15 @@ class CEcon
 		int64_t m_TimeConnected;
 		int m_AuthTries;
 	};
-	CClient m_aClients[NET_MAX_CONSOLE_CLIENTS];
+	CClient m_aClients[NET_MAX_CONSOLE_CLIENTS]{};
 
-	CConfig *m_pConfig;
-	IConsole *m_pConsole;
+	CConfig *m_pConfig{};
+	IConsole *m_pConsole{};
 	CNetConsole m_NetConsole;
 
 	bool m_Ready;
-	int m_PrintCBIndex;
-	int m_UserClientID;
+	int m_PrintCBIndex{};
+	int m_UserClientID{};
 
 	static void SendLineCB(const char *pLine, void *pUserData, ColorRGBA PrintColor = {1, 1, 1, 1});
 	static void ConLogout(IConsole::IResult *pResult, void *pUserData);

--- a/src/engine/shared/engine.cpp
+++ b/src/engine/shared/engine.cpp
@@ -28,13 +28,13 @@ void CHostLookup::Run()
 class CEngine : public IEngine
 {
 public:
-	IConsole *m_pConsole;
-	IStorage *m_pStorage;
+	IConsole *m_pConsole{};
+	IStorage *m_pStorage{};
 	bool m_Logging;
 
 	std::shared_ptr<CFutureLogger> m_pFutureLogger;
 
-	char m_aAppName[256];
+	char m_aAppName[256]{};
 
 	static void Con_DbgLognetwork(IConsole::IResult *pResult, void *pUserData)
 	{

--- a/src/engine/shared/fifo.cpp
+++ b/src/engine/shared/fifo.cpp
@@ -24,7 +24,7 @@ void CFifo::Init(IConsole *pConsole, char *pFifoFile, int Flag)
 
 	mkfifo(m_aFilename, 0600);
 
-	struct stat Attribute;
+	struct stat Attribute{};
 	stat(m_aFilename, &Attribute);
 
 	if(!S_ISFIFO(Attribute.st_mode))

--- a/src/engine/shared/jobs.h
+++ b/src/engine/shared/jobs.h
@@ -43,11 +43,11 @@ class CJobPool
 		MAX_THREADS = 32
 	};
 	int m_NumThreads;
-	void *m_apThreads[MAX_THREADS];
-	std::atomic<bool> m_Shutdown;
+	void *m_apThreads[MAX_THREADS]{};
+	std::atomic<bool> m_Shutdown{};
 
 	LOCK m_Lock;
-	SEMAPHORE m_Semaphore;
+	SEMAPHORE m_Semaphore{};
 	std::shared_ptr<IJob> m_pFirstJob GUARDED_BY(m_Lock);
 	std::shared_ptr<IJob> m_pLastJob GUARDED_BY(m_Lock);
 

--- a/src/engine/shared/kernel.cpp
+++ b/src/engine/shared/kernel.cpp
@@ -20,7 +20,7 @@ class CKernel : public IKernel
 			m_AutoDestroy = false;
 		}
 
-		char m_aName[64];
+		char m_aName[64]{};
 		IInterface *m_pInterface;
 		bool m_AutoDestroy;
 	};

--- a/src/engine/shared/netban.cpp
+++ b/src/engine/shared/netban.cpp
@@ -453,7 +453,7 @@ void CNetBan::ConBanRange(IConsole::IResult *pResult, void *pUser)
 	int Minutes = pResult->NumArguments() > 2 ? clamp(pResult->GetInteger(2), 0, 525600) : 30;
 	const char *pReason = pResult->NumArguments() > 3 ? pResult->GetString(3) : "No reason given";
 
-	CNetRange Range;
+	CNetRange Range{};
 	if(net_addr_from_str(&Range.m_LB, pStr1) == 0 && net_addr_from_str(&Range.m_UB, pStr2) == 0)
 		pThis->BanRange(&Range, Minutes * 60, pReason);
 	else
@@ -484,7 +484,7 @@ void CNetBan::ConUnbanRange(IConsole::IResult *pResult, void *pUser)
 	const char *pStr1 = pResult->GetString(0);
 	const char *pStr2 = pResult->GetString(1);
 
-	CNetRange Range;
+	CNetRange Range{};
 	if(net_addr_from_str(&Range.m_LB, pStr1) == 0 && net_addr_from_str(&Range.m_UB, pStr2) == 0)
 		pThis->UnbanByRange(&Range);
 	else

--- a/src/engine/shared/network.cpp
+++ b/src/engine/shared/network.cpp
@@ -25,7 +25,7 @@ void CNetRecvUnpacker::Start(const NETADDR *pAddr, CNetConnection *pConnection, 
 // TODO: rename this function
 int CNetRecvUnpacker::FetchChunk(CNetChunk *pChunk)
 {
-	CNetChunkHeader Header;
+	CNetChunkHeader Header{};
 	unsigned char *pEnd = m_Data.m_aChunkData + m_Data.m_DataSize;
 
 	while(true)
@@ -306,7 +306,7 @@ int CNetBase::UnpackPacket(unsigned char *pBuffer, int Size, CNetPacketConstruct
 
 void CNetBase::SendControlMsg(NETSOCKET Socket, NETADDR *pAddr, int Ack, int ControlMsg, const void *pExtra, int ExtraSize, SECURITY_TOKEN SecurityToken, bool Sixup)
 {
-	CNetPacketConstruct Construct;
+	CNetPacketConstruct Construct{};
 	Construct.m_Flags = NET_PACKETFLAG_CONTROL;
 	Construct.m_Ack = Ack;
 	Construct.m_NumChunks = 0;

--- a/src/engine/shared/network.h
+++ b/src/engine/shared/network.h
@@ -173,11 +173,11 @@ class CStun
 	{
 		int m_Index;
 		NETSOCKET m_Socket;
-		CStunData m_Stun;
+		CStunData m_Stun{};
 		bool m_HaveStunServer = false;
-		NETADDR m_StunServer;
+		NETADDR m_StunServer{};
 		bool m_HaveAddr = false;
-		NETADDR m_Addr;
+		NETADDR m_Addr{};
 		int64_t m_LastResponse = -1;
 		int64_t m_NextTry = -1;
 		int m_NumUnsuccessfulTries = -1;

--- a/src/engine/shared/network_conn.cpp
+++ b/src/engine/shared/network_conn.cpp
@@ -116,7 +116,7 @@ int CNetConnection::QueueChunkEx(int Flags, int DataSize, const void *pData, int
 		Flush();
 
 	// pack all the data
-	CNetChunkHeader Header;
+	CNetChunkHeader Header{};
 	Header.m_Flags = Flags;
 	Header.m_Size = DataSize;
 	Header.m_Sequence = Sequence;

--- a/src/engine/shared/network_server.cpp
+++ b/src/engine/shared/network_server.cpp
@@ -284,14 +284,14 @@ int CNetServer::TryAcceptClient(NETADDR &Addr, SECURITY_TOKEN SecurityToken, boo
 
 void CNetServer::SendMsgs(NETADDR &Addr, const CMsgPacker *apMsgs[], int Num)
 {
-	CNetPacketConstruct Construct;
+	CNetPacketConstruct Construct{};
 	mem_zero(&Construct, sizeof(Construct));
 	unsigned char *pChunkData = &Construct.m_aChunkData[Construct.m_DataSize];
 
 	for(int i = 0; i < Num; i++)
 	{
 		const CMsgPacker *pMsg = apMsgs[i];
-		CNetChunkHeader Header;
+		CNetChunkHeader Header{};
 		Header.m_Flags = NET_CHUNKFLAG_VITAL;
 		Header.m_Size = pMsg->Size();
 		Header.m_Sequence = i + 1;
@@ -441,11 +441,11 @@ void CNetServer::OnPreConnMsg(NETADDR &Addr, CNetPacketConstruct &Packet)
 	}
 	else if(!IsCtrl && g_Config.m_SvVanillaAntiSpoof && g_Config.m_Password[0] == '\0')
 	{
-		CNetChunkHeader h;
+		CNetChunkHeader h{};
 
 		unsigned char *pData = Packet.m_aChunkData;
 		pData = h.Unpack(pData);
-		CUnpacker Unpacker;
+		CUnpacker Unpacker{};
 		Unpacker.Reset(pData, h.m_Size);
 		int Msg = Unpacker.GetInt() >> 1;
 

--- a/src/engine/shared/protocol_ex.cpp
+++ b/src/engine/shared/protocol_ex.cpp
@@ -52,7 +52,7 @@ int UnpackMessageID(int *pID, bool *pSys, struct CUuid *pUuid, CUnpacker *pUnpac
 		{
 		case NETMSG_WHATIS:
 		{
-			CUuid Uuid2;
+			CUuid Uuid2{};
 			int ID2 = g_UuidManager.UnpackUuid(pUnpacker, &Uuid2);
 			if(ID2 == UUID_INVALID)
 			{
@@ -74,7 +74,7 @@ int UnpackMessageID(int *pID, bool *pSys, struct CUuid *pUuid, CUnpacker *pUnpac
 		case NETMSG_IDONTKNOW:
 			if(g_Config.m_Debug)
 			{
-				CUuid Uuid2;
+				CUuid Uuid2{};
 				g_UuidManager.UnpackUuid(pUnpacker, &Uuid2);
 				if(pUnpacker->Error())
 					break;
@@ -86,7 +86,7 @@ int UnpackMessageID(int *pID, bool *pSys, struct CUuid *pUuid, CUnpacker *pUnpac
 		case NETMSG_ITIS:
 			if(g_Config.m_Debug)
 			{
-				CUuid Uuid2;
+				CUuid Uuid2{};
 				g_UuidManager.UnpackUuid(pUnpacker, &Uuid2);
 				const char *pName = pUnpacker->GetString(CUnpacker::SANITIZE_CC);
 				if(pUnpacker->Error())

--- a/src/engine/shared/snapshot.cpp
+++ b/src/engine/shared/snapshot.cpp
@@ -38,7 +38,7 @@ int CSnapshot::GetItemType(int Index) const
 	}
 
 	CSnapshotItem *pTypeItem = GetItem(TypeItemIndex);
-	CUuid Uuid;
+	CUuid Uuid{};
 	for(int i = 0; i < (int)sizeof(CUuid) / 4; i++)
 		int_to_bytes_be(&Uuid.m_aData[i * 4], pTypeItem->Data()[i]);
 

--- a/src/engine/shared/snapshot.h
+++ b/src/engine/shared/snapshot.h
@@ -73,10 +73,10 @@ private:
 	{
 		MAX_NETOBJSIZES = 64
 	};
-	short m_aItemSizes[MAX_NETOBJSIZES];
-	int m_aSnapshotDataRate[CSnapshot::MAX_TYPE + 1];
-	int m_aSnapshotDataUpdates[CSnapshot::MAX_TYPE + 1];
-	CData m_Empty;
+	short m_aItemSizes[MAX_NETOBJSIZES]{};
+	int m_aSnapshotDataRate[CSnapshot::MAX_TYPE + 1]{};
+	int m_aSnapshotDataUpdates[CSnapshot::MAX_TYPE + 1]{};
+	CData m_Empty{};
 
 	static void UndiffItem(int *pPast, int *pDiff, int *pOut, int Size, int *pDataRate);
 
@@ -130,19 +130,19 @@ class CSnapshotBuilder
 		MAX_EXTENDED_ITEM_TYPES = 64,
 	};
 
-	char m_aData[CSnapshot::MAX_SIZE];
-	int m_DataSize;
+	char m_aData[CSnapshot::MAX_SIZE]{};
+	int m_DataSize{};
 
-	int m_aOffsets[CSnapshot::MAX_ITEMS];
-	int m_NumItems;
+	int m_aOffsets[CSnapshot::MAX_ITEMS]{};
+	int m_NumItems{};
 
-	int m_aExtendedItemTypes[MAX_EXTENDED_ITEM_TYPES];
+	int m_aExtendedItemTypes[MAX_EXTENDED_ITEM_TYPES]{};
 	int m_NumExtendedItemTypes;
 
 	void AddExtendedItemType(int Index);
 	int GetExtendedItemTypeIndex(int TypeID);
 
-	bool m_Sixup;
+	bool m_Sixup{};
 
 public:
 	CSnapshotBuilder();

--- a/src/engine/shared/storage.cpp
+++ b/src/engine/shared/storage.cpp
@@ -13,12 +13,12 @@
 class CStorage : public IStorage
 {
 public:
-	char m_aaStoragePaths[MAX_PATHS][IO_MAX_PATH_LENGTH];
+	char m_aaStoragePaths[MAX_PATHS][IO_MAX_PATH_LENGTH]{};
 	int m_NumPaths;
-	char m_aDatadir[IO_MAX_PATH_LENGTH];
-	char m_aUserdir[IO_MAX_PATH_LENGTH];
-	char m_aCurrentdir[IO_MAX_PATH_LENGTH];
-	char m_aBinarydir[IO_MAX_PATH_LENGTH];
+	char m_aDatadir[IO_MAX_PATH_LENGTH]{};
+	char m_aUserdir[IO_MAX_PATH_LENGTH]{};
+	char m_aCurrentdir[IO_MAX_PATH_LENGTH]{};
+	char m_aBinarydir[IO_MAX_PATH_LENGTH]{};
 
 	CStorage()
 	{
@@ -124,7 +124,7 @@ public:
 		}
 
 		char *pLine;
-		CLineReader LineReader;
+		CLineReader LineReader{};
 		LineReader.Init(File);
 
 		while((pLine = LineReader.Get()))
@@ -452,7 +452,7 @@ public:
 
 		pBuffer[0] = 0;
 		char aBuf[IO_MAX_PATH_LENGTH];
-		CFindCBData Data;
+		CFindCBData Data{};
 		Data.m_pStorage = this;
 		Data.m_pFilename = pFilename;
 		Data.m_pPath = pPath;

--- a/src/engine/shared/uuid_manager.cpp
+++ b/src/engine/shared/uuid_manager.cpp
@@ -11,7 +11,7 @@ static const CUuid TEEWORLDS_NAMESPACE = {{// "e05ddaaa-c4e6-4cfb-b642-5d48e80c0
 
 CUuid RandomUuid()
 {
-	CUuid Result;
+	CUuid Result{};
 	secure_random_fill(&Result, sizeof(Result));
 
 	Result.m_aData[6] &= 0x0f;
@@ -31,7 +31,7 @@ CUuid CalculateUuid(const char *pName)
 	md5_update(&Md5, (const unsigned char *)pName, str_length(pName));
 	MD5_DIGEST Digest = md5_finish(&Md5);
 
-	CUuid Result;
+	CUuid Result{};
 	for(unsigned i = 0; i < sizeof(Result.m_aData); i++)
 	{
 		Result.m_aData[i] = Digest.data[i];
@@ -102,14 +102,14 @@ void CUuidManager::RegisterName(int ID, const char *pName)
 {
 	int Index = GetIndex(ID);
 	dbg_assert(Index == m_aNames.size(), "names must be registered with increasing ID");
-	CName Name;
+	CName Name{};
 	Name.m_pName = pName;
 	Name.m_Uuid = CalculateUuid(pName);
 	dbg_assert(LookupUuid(Name.m_Uuid) == -1, "duplicate uuid");
 
 	m_aNames.add(Name);
 
-	CNameIndexed NameIndexed;
+	CNameIndexed NameIndexed{};
 	NameIndexed.m_Uuid = Name.m_Uuid;
 	NameIndexed.m_ID = GetIndex(ID);
 	m_aNamesSorted.add(NameIndexed);
@@ -142,7 +142,7 @@ int CUuidManager::NumUuids() const
 
 int CUuidManager::UnpackUuid(CUnpacker *pUnpacker) const
 {
-	CUuid Temp;
+	CUuid Temp{};
 	return UnpackUuid(pUnpacker, &Temp);
 }
 

--- a/src/game/client/animstate.cpp
+++ b/src/game/client/animstate.cpp
@@ -76,7 +76,7 @@ void CAnimState::Set(CAnimation *pAnim, float Time)
 
 void CAnimState::Add(CAnimation *pAnim, float Time, float Amount)
 {
-	CAnimState Add;
+	CAnimState Add{};
 	Add.Set(pAnim, Time);
 	AnimAdd(this, &Add, Amount);
 }

--- a/src/game/client/components/background.h
+++ b/src/game/client/components/background.h
@@ -15,15 +15,15 @@ class CBackgroundEngineMap : public CMap
 class CBackground : public CMapLayers
 {
 protected:
-	IEngineMap *m_pMap;
+	IEngineMap *m_pMap{};
 	bool m_Loaded;
-	char m_aMapName[MAX_MAP_LENGTH];
+	char m_aMapName[MAX_MAP_LENGTH]{};
 
 	//to avoid spam when in menu
 	int64_t m_LastLoad;
 
 	//to avoid memory leak when switching to %current%
-	CBackgroundEngineMap *m_pBackgroundMap;
+	CBackgroundEngineMap *m_pBackgroundMap{};
 	CLayers *m_pBackgroundLayers;
 	CMapImages *m_pBackgroundImages;
 

--- a/src/game/client/components/binds.h
+++ b/src/game/client/components/binds.h
@@ -66,6 +66,6 @@ public:
 	void SetDDRaceBinds(bool FreeOnly);
 
 private:
-	char *m_aapKeyBindings[MODIFIER_COMBINATION_COUNT][KEY_LAST];
+	char *m_aapKeyBindings[MODIFIER_COMBINATION_COUNT][KEY_LAST]{};
 };
 #endif

--- a/src/game/client/components/broadcast.cpp
+++ b/src/game/client/components/broadcast.cpp
@@ -27,7 +27,7 @@ void CBroadcast::OnRender()
 
 	if(Client()->GameTick(g_Config.m_ClDummy) < m_BroadcastTick)
 	{
-		CTextCursor Cursor;
+		CTextCursor Cursor{};
 		TextRender()->SetCursor(&Cursor, m_BroadcastRenderOffset, 40.0f, 12.0f, TEXTFLAG_RENDER | TEXTFLAG_STOP_AT_END);
 		Cursor.m_LineWidth = 300 * Graphics()->ScreenAspect() - m_BroadcastRenderOffset;
 		TextRender()->TextEx(&Cursor, m_aBroadcastText, -1);
@@ -40,7 +40,7 @@ void CBroadcast::OnMessage(int MsgType, void *pRawMsg)
 	{
 		CNetMsg_Sv_Broadcast *pMsg = (CNetMsg_Sv_Broadcast *)pRawMsg;
 		str_copy(m_aBroadcastText, pMsg->m_pMessage, sizeof(m_aBroadcastText));
-		CTextCursor Cursor;
+		CTextCursor Cursor{};
 		TextRender()->SetCursor(&Cursor, 0, 0, 12.0f, TEXTFLAG_STOP_AT_END);
 		Cursor.m_LineWidth = 300 * Graphics()->ScreenAspect();
 		TextRender()->TextEx(&Cursor, m_aBroadcastText, -1);

--- a/src/game/client/components/camera.h
+++ b/src/game/client/components/camera.h
@@ -22,8 +22,8 @@ class CCamera : public CComponent
 	vec2 m_PrevCenter;
 
 	CCubicBezier m_ZoomSmoothing;
-	float m_ZoomSmoothingStart;
-	float m_ZoomSmoothingEnd;
+	float m_ZoomSmoothingStart{};
+	float m_ZoomSmoothingEnd{};
 
 	void ScaleZoom(float Factor);
 	void ChangeZoom(float Target);
@@ -37,7 +37,7 @@ public:
 	bool m_ZoomSet;
 	bool m_Zooming;
 	float m_Zoom;
-	float m_ZoomSmoothingTarget;
+	float m_ZoomSmoothingTarget{};
 
 	CCamera();
 	virtual int Sizeof() const override { return sizeof(*this); }

--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -975,7 +975,7 @@ void CChat::OnPrepareLines()
 	float HeightLimit = IsScoreBoardOpen ? 180.0f : m_PrevShowChat ? 50.0f : 200.0f;
 	float Begin = x;
 	float TextBegin = Begin + RealMsgPaddingX / 2.0f;
-	CTextCursor Cursor;
+	CTextCursor Cursor{};
 	int OffsetType = IsScoreBoardOpen ? 1 : 0;
 
 	for(int i = 0; i < MAX_LINES; i++)
@@ -1210,7 +1210,7 @@ void CChat::OnRender()
 	if(m_Mode != MODE_NONE)
 	{
 		// render chat input
-		CTextCursor Cursor;
+		CTextCursor Cursor{};
 		TextRender()->SetCursor(&Cursor, x, y, 8.0f, TEXTFLAG_RENDER);
 		Cursor.m_LineWidth = Width - 190.0f;
 		Cursor.m_MaxLines = 2;
@@ -1363,7 +1363,7 @@ void CChat::Say(int Team, const char *pLine)
 	m_LastChatSend = time();
 
 	// send chat message
-	CNetMsg_Cl_Say Msg;
+	CNetMsg_Cl_Say Msg{};
 	Msg.m_Team = Team;
 	Msg.m_pMessage = pLine;
 	Client()->SendPackMsgActive(&Msg, MSGFLAG_VITAL);

--- a/src/game/client/components/chat.h
+++ b/src/game/client/components/chat.h
@@ -52,11 +52,11 @@ class CChat : public CComponent
 		int m_TimesRepeated;
 	};
 
-	bool m_PrevScoreBoardShowed;
-	bool m_PrevShowChat;
+	bool m_PrevScoreBoardShowed{};
+	bool m_PrevShowChat{};
 
 	CLine m_aLines[MAX_LINES];
-	int m_CurrentLine;
+	int m_CurrentLine{};
 
 	// chat
 	enum
@@ -72,22 +72,22 @@ class CChat : public CComponent
 	};
 
 	int m_Mode;
-	bool m_Show;
-	bool m_InputUpdate;
-	int m_ChatStringOffset;
-	int m_OldChatStringLength;
-	bool m_CompletionUsed;
-	int m_CompletionChosen;
-	char m_aCompletionBuffer[256];
-	int m_PlaceholderOffset;
-	int m_PlaceholderLength;
+	bool m_Show{};
+	bool m_InputUpdate{};
+	int m_ChatStringOffset{};
+	int m_OldChatStringLength{};
+	bool m_CompletionUsed{};
+	int m_CompletionChosen{};
+	char m_aCompletionBuffer[256]{};
+	int m_PlaceholderOffset{};
+	int m_PlaceholderLength{};
 	struct CRateablePlayer
 	{
 		int ClientID;
 		int Score;
 	};
-	CRateablePlayer m_aPlayerCompletionList[MAX_CLIENTS];
-	int m_PlayerCompletionListLength;
+	CRateablePlayer m_aPlayerCompletionList[MAX_CLIENTS]{};
+	int m_PlayerCompletionListLength{};
 
 	struct CCommand
 	{
@@ -100,18 +100,18 @@ class CChat : public CComponent
 	};
 
 	sorted_array<CCommand> m_Commands;
-	bool m_ReverseTAB;
+	bool m_ReverseTAB{};
 
 	struct CHistoryEntry
 	{
 		int m_Team;
 		char m_aText[1];
 	};
-	CHistoryEntry *m_pHistoryEntry;
+	CHistoryEntry *m_pHistoryEntry{};
 	CStaticRingBuffer<CHistoryEntry, 64 * 1024, CRingBufferBase::FLAG_RECYCLE> m_History;
-	int m_PendingChatCounter;
-	int64_t m_LastChatSend;
-	int64_t m_aLastSoundPlayed[CHAT_NUM];
+	int m_PendingChatCounter{};
+	int64_t m_LastChatSend{};
+	int64_t m_aLastSoundPlayed[CHAT_NUM]{};
 
 	static void ConSay(IConsole::IResult *pResult, void *pUserData);
 	static void ConSayTeam(IConsole::IResult *pResult, void *pUserData);

--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -628,7 +628,7 @@ void CGameConsole::OnRender()
 		float x = 3;
 		float y = ConsoleHeight - RowHeight - 5.0f;
 
-		CRenderInfo Info;
+		CRenderInfo Info{};
 		Info.m_pSelf = this;
 		Info.m_WantedCompletion = pConsole->m_CompletionUsed ? pConsole->m_CompletionChosen : -1;
 		Info.m_EnumCount = 0;
@@ -639,7 +639,7 @@ void CGameConsole::OnRender()
 		Info.m_Cursor.m_LineWidth = std::numeric_limits<float>::max();
 
 		// render prompt
-		CTextCursor Cursor;
+		CTextCursor Cursor{};
 		TextRender()->SetCursor(&Cursor, x, y, FontSize, TEXTFLAG_RENDER);
 		const char *pPrompt = "> ";
 		if(m_ConsoleType == CONSOLETYPE_REMOTE)

--- a/src/game/client/components/console.h
+++ b/src/game/client/components/console.h
@@ -39,26 +39,26 @@ class CGameConsole : public CComponent
 
 		CLineInput m_Input;
 		int m_Type;
-		int m_CompletionEnumerationCount;
-		int m_BacklogCurPage;
+		int m_CompletionEnumerationCount{};
+		int m_BacklogCurPage{};
 
-		CGameConsole *m_pGameConsole;
+		CGameConsole *m_pGameConsole{};
 
-		char m_aCompletionBuffer[128];
+		char m_aCompletionBuffer[128]{};
 		bool m_CompletionUsed;
 		int m_CompletionChosen;
 		int m_CompletionFlagmask;
 		float m_CompletionRenderOffset;
 		bool m_ReverseTAB;
 
-		char m_aUser[32];
+		char m_aUser[32]{};
 		bool m_UserGot;
 		bool m_UsernameReq;
 
 		bool m_IsCommand;
-		char m_aCommandName[IConsole::TEMPCMD_NAME_LENGTH];
-		char m_aCommandHelp[IConsole::TEMPCMD_HELP_LENGTH];
-		char m_aCommandParams[IConsole::TEMPCMD_PARAMS_LENGTH];
+		char m_aCommandName[IConsole::TEMPCMD_NAME_LENGTH]{};
+		char m_aCommandHelp[IConsole::TEMPCMD_HELP_LENGTH]{};
+		char m_aCommandParams[IConsole::TEMPCMD_PARAMS_LENGTH]{};
 
 		CInstance(int t);
 		void Init(CGameConsole *pGameConsole);
@@ -76,7 +76,7 @@ class CGameConsole : public CComponent
 		static void PossibleCommandsCompleteCallback(const char *pStr, void *pUser);
 	};
 
-	class IConsole *m_pConsole;
+	class IConsole *m_pConsole{};
 	CConsoleLogger *m_pConsoleLogger = nullptr;
 
 	CInstance m_LocalConsole;

--- a/src/game/client/components/controls.h
+++ b/src/game/client/components/controls.h
@@ -14,23 +14,23 @@ class CControls : public CComponent
 public:
 	vec2 m_MousePos[NUM_DUMMIES];
 	vec2 m_TargetPos[NUM_DUMMIES];
-	float m_OldMouseX;
-	float m_OldMouseY;
+	float m_OldMouseX{};
+	float m_OldMouseY{};
 	SDL_Joystick *m_pJoystick;
-	bool m_JoystickFirePressed;
-	bool m_JoystickRunPressed;
-	int64_t m_JoystickTapTime;
+	bool m_JoystickFirePressed{};
+	bool m_JoystickRunPressed{};
+	int64_t m_JoystickTapTime{};
 
 	SDL_Joystick *m_pGamepad;
 	bool m_UsingGamepad;
 
-	int m_AmmoCount[NUM_WEAPONS];
+	int m_AmmoCount[NUM_WEAPONS]{};
 
-	CNetObj_PlayerInput m_InputData[NUM_DUMMIES];
-	CNetObj_PlayerInput m_LastData[NUM_DUMMIES];
-	int m_InputDirectionLeft[NUM_DUMMIES];
-	int m_InputDirectionRight[NUM_DUMMIES];
-	int m_ShowHookColl[NUM_DUMMIES];
+	CNetObj_PlayerInput m_InputData[NUM_DUMMIES]{};
+	CNetObj_PlayerInput m_LastData[NUM_DUMMIES]{};
+	int m_InputDirectionLeft[NUM_DUMMIES]{};
+	int m_InputDirectionRight[NUM_DUMMIES]{};
+	int m_ShowHookColl[NUM_DUMMIES]{};
 	int m_LastDummy;
 	int m_OtherFire;
 

--- a/src/game/client/components/countryflags.cpp
+++ b/src/game/client/components/countryflags.cpp
@@ -24,7 +24,7 @@ void CCountryFlags::LoadCountryflagsIndexfile()
 	}
 
 	char aOrigin[128];
-	CLineReader LineReader;
+	CLineReader LineReader{};
 	LineReader.Init(File);
 	char *pLine;
 	while((pLine = LineReader.Get()))
@@ -59,7 +59,7 @@ void CCountryFlags::LoadCountryflagsIndexfile()
 
 		// load the graphic file
 		char aBuf[128];
-		CImageInfo Info;
+		CImageInfo Info{};
 		str_format(aBuf, sizeof(aBuf), "countryflags/%s.png", aOrigin);
 		if(!Graphics()->LoadPNG(&Info, aBuf, IStorage::TYPE_ALL))
 		{

--- a/src/game/client/components/damageind.h
+++ b/src/game/client/components/damageind.h
@@ -27,7 +27,7 @@ class CDamageInd : public CComponent
 	CItem *CreateI();
 	void DestroyI(CItem *i);
 
-	int m_DmgIndQuadContainerIndex;
+	int m_DmgIndQuadContainerIndex{};
 
 public:
 	CDamageInd();

--- a/src/game/client/components/emoticon.cpp
+++ b/src/game/client/components/emoticon.cpp
@@ -183,7 +183,7 @@ void CEmoticon::OnRender()
 
 void CEmoticon::Emote(int Emoticon)
 {
-	CNetMsg_Cl_Emoticon Msg;
+	CNetMsg_Cl_Emoticon Msg{};
 	Msg.m_Emoticon = Emoticon;
 	Client()->SendPackMsgActive(&Msg, MSGFLAG_VITAL);
 

--- a/src/game/client/components/emoticon.h
+++ b/src/game/client/components/emoticon.h
@@ -9,12 +9,12 @@ class CEmoticon : public CComponent
 {
 	void DrawCircle(float x, float y, float r, int Segments);
 
-	bool m_WasActive;
-	bool m_Active;
+	bool m_WasActive{};
+	bool m_Active{};
 
 	vec2 m_SelectorMouse;
-	int m_SelectedEmote;
-	int m_SelectedEyeEmote;
+	int m_SelectedEmote{};
+	int m_SelectedEyeEmote{};
 
 	static void ConKeyEmoticon(IConsole::IResult *pResult, void *pUserData);
 	static void ConEmote(IConsole::IResult *pResult, void *pUserData);

--- a/src/game/client/components/ghost.cpp
+++ b/src/game/client/components/ghost.cpp
@@ -151,7 +151,7 @@ void CGhost::AddInfos(const CNetObj_Character *pChar)
 			GhostRecorder()->WriteData(GHOSTDATA_TYPE_CHARACTER, m_CurGhost.m_Path.Get(i), sizeof(CGhostCharacter));
 	}
 
-	CGhostCharacter GhostChar;
+	CGhostCharacter GhostChar{};
 	GetGhostCharacter(&GhostChar, pChar);
 	m_CurGhost.m_Path.Add(GhostChar);
 	if(GhostRecorder()->IsRecording())
@@ -332,7 +332,7 @@ void CGhost::OnRender()
 		if(Ghost.m_Path.Get(PrevPos)->m_Tick > GhostTick)
 			continue;
 
-		CNetObj_Character Player, Prev;
+		CNetObj_Character Player{}, Prev{};
 		GetNetObjCharacter(&Player, Ghost.m_Path.Get(CurPos));
 		GetNetObjCharacter(&Prev, Ghost.m_Path.Get(PrevPos));
 

--- a/src/game/client/components/ghost.h
+++ b/src/game/client/components/ghost.h
@@ -106,13 +106,13 @@ private:
 
 	static const char *ms_pGhostDir;
 
-	class IGhostLoader *m_pGhostLoader;
-	class IGhostRecorder *m_pGhostRecorder;
+	class IGhostLoader *m_pGhostLoader{};
+	class IGhostRecorder *m_pGhostRecorder{};
 
 	CGhostItem m_aActiveGhosts[MAX_ACTIVE_GHOSTS];
 	CGhostItem m_CurGhost;
 
-	char m_aTmpFilename[128];
+	char m_aTmpFilename[128]{};
 
 	int m_NewRenderTick;
 	int m_StartRenderTick;
@@ -121,7 +121,7 @@ private:
 	bool m_Recording;
 	bool m_Rendering;
 
-	bool m_RenderingStartedByServer;
+	bool m_RenderingStartedByServer{};
 
 	static void GetGhostSkin(CGhostSkin *pSkin, const char *pSkinName, int UseCustomColor, int ColorBody, int ColorFeet);
 	static void GetGhostCharacter(CGhostCharacter *pGhostChar, const CNetObj_Character *pChar);
@@ -146,7 +146,7 @@ private:
 	static void ConGPlay(IConsole::IResult *pResult, void *pUserData);
 
 public:
-	bool m_AllowRestart;
+	bool m_AllowRestart{};
 
 	CGhost();
 	virtual int Sizeof() const override { return sizeof(*this); }

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -233,7 +233,7 @@ void CHud::RenderScoreHud()
 					if(m_aScoreInfo[t].m_TextScoreContainerIndex != -1)
 						TextRender()->DeleteTextContainer(m_aScoreInfo[t].m_TextScoreContainerIndex);
 
-					CTextCursor Cursor;
+					CTextCursor Cursor{};
 					TextRender()->SetCursor(&Cursor, m_Width - ScoreWidthMax + (ScoreWidthMax - m_aScoreInfo[t].m_ScoreTextWidth) / 2 - Split, StartY + t * 20 + (18.f - 14.f) / 2.f, 14.0f, TEXTFLAG_RENDER);
 					Cursor.m_LineWidth = -1;
 					m_aScoreInfo[t].m_TextScoreContainerIndex = TextRender()->CreateTextContainer(&Cursor, aScoreTeam[t]);
@@ -272,7 +272,7 @@ void CHud::RenderScoreHud()
 
 							float w = TextRender()->TextWidth(0, 8.0f, pName, -1, -1.0f);
 
-							CTextCursor Cursor;
+							CTextCursor Cursor{};
 							TextRender()->SetCursor(&Cursor, minimum(m_Width - w - 1.0f, m_Width - ScoreWidthMax - ImageSize - 2 * Split), StartY + (t + 1) * 20.0f - 2.0f, 8.0f, TEXTFLAG_RENDER);
 							Cursor.m_LineWidth = -1;
 							m_aScoreInfo[t].m_OptionalNameTextContainerIndex = TextRender()->CreateTextContainer(&Cursor, pName);
@@ -414,7 +414,7 @@ void CHud::RenderScoreHud()
 					if(m_aScoreInfo[t].m_TextScoreContainerIndex != -1)
 						TextRender()->DeleteTextContainer(m_aScoreInfo[t].m_TextScoreContainerIndex);
 
-					CTextCursor Cursor;
+					CTextCursor Cursor{};
 					TextRender()->SetCursor(&Cursor, m_Width - ScoreWidthMax + (ScoreWidthMax - m_aScoreInfo[t].m_ScoreTextWidth) - Split, StartY + t * 20 + (18.f - 14.f) / 2.f, 14.0f, TEXTFLAG_RENDER);
 					Cursor.m_LineWidth = -1;
 					m_aScoreInfo[t].m_TextScoreContainerIndex = TextRender()->CreateTextContainer(&Cursor, aScore[t]);
@@ -443,7 +443,7 @@ void CHud::RenderScoreHud()
 
 							float w = TextRender()->TextWidth(0, 8.0f, pName, -1, -1.0f);
 
-							CTextCursor Cursor;
+							CTextCursor Cursor{};
 							TextRender()->SetCursor(&Cursor, minimum(m_Width - w - 1.0f, m_Width - ScoreWidthMax - ImageSize - 2 * Split - PosSize), StartY + (t + 1) * 20.0f - 2.0f, 8.0f, TEXTFLAG_RENDER);
 							Cursor.m_LineWidth = -1;
 							m_aScoreInfo[t].m_OptionalNameTextContainerIndex = TextRender()->CreateTextContainer(&Cursor, pName);
@@ -483,7 +483,7 @@ void CHud::RenderScoreHud()
 					if(m_aScoreInfo[t].m_TextRankContainerIndex != -1)
 						TextRender()->DeleteTextContainer(m_aScoreInfo[t].m_TextRankContainerIndex);
 
-					CTextCursor Cursor;
+					CTextCursor Cursor{};
 					TextRender()->SetCursor(&Cursor, m_Width - ScoreWidthMax - ImageSize - Split - PosSize, StartY + t * 20 + (18.f - 10.f) / 2.f, 10.0f, TEXTFLAG_RENDER);
 					Cursor.m_LineWidth = -1;
 					m_aScoreInfo[t].m_TextRankContainerIndex = TextRender()->CreateTextContainer(&Cursor, aBuf);
@@ -541,7 +541,7 @@ void CHud::RenderTextInfo()
 		int DigitIndex = GetDigitsIndex(FrameTime, 4);
 		//TextRender()->Text(0, m_Width-10-TextRender()->TextWidth(0,12,Buf,-1,-1.0f), 5, 12, Buf, -1.0f);
 
-		CTextCursor Cursor;
+		CTextCursor Cursor{};
 		TextRender()->SetCursor(&Cursor, m_Width - 10 - s_TextWidth[DigitIndex], 5, 12, TEXTFLAG_RENDER);
 		Cursor.m_LineWidth = -1;
 		auto OldFlags = TextRender()->GetRenderFlags();
@@ -615,7 +615,7 @@ void CHud::RenderVoting()
 
 	TextRender()->TextColor(1, 1, 1, 1);
 
-	CTextCursor Cursor;
+	CTextCursor Cursor{};
 	char aBuf[512];
 	str_format(aBuf, sizeof(aBuf), Localize("%ds left"), m_pClient->m_Voting.SecondsLeft());
 	float tw = TextRender()->TextWidth(0x0, 6, aBuf, -1, -1.0f);

--- a/src/game/client/components/hud.h
+++ b/src/game/client/components/hud.h
@@ -35,10 +35,10 @@ struct SScoreInfo
 
 class CHud : public CComponent
 {
-	float m_Width, m_Height;
+	float m_Width{}, m_Height{};
 	float m_FrameTimeAvg;
 
-	int m_HudQuadContainerIndex;
+	int m_HudQuadContainerIndex{};
 	SScoreInfo m_aScoreInfo[2];
 	int m_FPSTextContainerIndex;
 
@@ -85,52 +85,52 @@ public:
 private:
 	void RenderRecord();
 	void RenderDDRaceEffects();
-	float m_CheckpointDiff;
-	float m_ServerRecord;
-	float m_PlayerRecord[NUM_DUMMIES];
-	int m_DDRaceTime;
-	int m_LastReceivedTimeTick;
-	int m_CheckpointTick;
-	bool m_FinishTime;
-	bool m_DDRaceTimeReceived;
+	float m_CheckpointDiff{};
+	float m_ServerRecord{};
+	float m_PlayerRecord[NUM_DUMMIES]{};
+	int m_DDRaceTime{};
+	int m_LastReceivedTimeTick{};
+	int m_CheckpointTick{};
+	bool m_FinishTime{};
+	bool m_DDRaceTimeReceived{};
 
 	inline float GetMovementInformationBoxHeight();
 	inline int GetDigitsIndex(int Value, int Max);
 
 	// Quad Offsets
-	int m_AmmoOffset[NUM_WEAPONS];
-	int m_HealthOffset;
-	int m_EmptyHealthOffset;
-	int m_ArmorOffset;
-	int m_EmptyArmorOffset;
-	int m_CursorOffset[NUM_WEAPONS];
-	int m_FlagOffset;
-	int m_AirjumpOffset;
-	int m_AirjumpEmptyOffset;
-	int m_WeaponHammerOffset;
-	int m_WeaponGunOffset;
-	int m_WeaponShotgunOffset;
-	int m_WeaponGrenadeOffset;
-	int m_WeaponLaserOffset;
-	int m_WeaponNinjaOffset;
-	int m_EndlessJumpOffset;
-	int m_EndlessHookOffset;
-	int m_JetpackOffset;
-	int m_TeleportGrenadeOffset;
-	int m_TeleportGunOffset;
-	int m_TeleportLaserOffset;
-	int m_SoloOffset;
-	int m_NoCollisionOffset;
-	int m_NoHookHitOffset;
-	int m_NoHammerHitOffset;
-	int m_NoShotgunHitOffset;
-	int m_NoGrenadeHitOffset;
-	int m_NoLaserHitOffset;
-	int m_DeepFrozenOffset;
-	int m_LiveFrozenOffset;
-	int m_DummyHammerOffset;
-	int m_DummyCopyOffset;
-	int m_PracticeModeOffset;
+	int m_AmmoOffset[NUM_WEAPONS]{};
+	int m_HealthOffset{};
+	int m_EmptyHealthOffset{};
+	int m_ArmorOffset{};
+	int m_EmptyArmorOffset{};
+	int m_CursorOffset[NUM_WEAPONS]{};
+	int m_FlagOffset{};
+	int m_AirjumpOffset{};
+	int m_AirjumpEmptyOffset{};
+	int m_WeaponHammerOffset{};
+	int m_WeaponGunOffset{};
+	int m_WeaponShotgunOffset{};
+	int m_WeaponGrenadeOffset{};
+	int m_WeaponLaserOffset{};
+	int m_WeaponNinjaOffset{};
+	int m_EndlessJumpOffset{};
+	int m_EndlessHookOffset{};
+	int m_JetpackOffset{};
+	int m_TeleportGrenadeOffset{};
+	int m_TeleportGunOffset{};
+	int m_TeleportLaserOffset{};
+	int m_SoloOffset{};
+	int m_NoCollisionOffset{};
+	int m_NoHookHitOffset{};
+	int m_NoHammerHitOffset{};
+	int m_NoShotgunHitOffset{};
+	int m_NoGrenadeHitOffset{};
+	int m_NoLaserHitOffset{};
+	int m_DeepFrozenOffset{};
+	int m_LiveFrozenOffset{};
+	int m_DummyHammerOffset{};
+	int m_DummyCopyOffset{};
+	int m_PracticeModeOffset{};
 };
 
 #endif

--- a/src/game/client/components/items.cpp
+++ b/src/game/client/components/items.cpp
@@ -336,7 +336,7 @@ void CItems::OnRender()
 			auto *const pLaser = dynamic_cast<CLaser *>(pEnt);
 			if(!pLaser || pLaser->GetOwner() < 0 || !GameClient()->m_aClients[pLaser->GetOwner()].m_IsPredictedLocal)
 				continue;
-			CNetObj_Laser Data;
+			CNetObj_Laser Data{};
 			pLaser->FillInfo(&Data);
 			RenderLaser(&Data, true);
 		}
@@ -349,7 +349,7 @@ void CItems::OnRender()
 			{
 				if(auto *pPrev = (CPickup *)GameClient()->m_PrevPredictedWorld.GetEntity(pPickup->ID(), CGameWorld::ENTTYPE_PICKUP))
 				{
-					CNetObj_Pickup Data, Prev;
+					CNetObj_Pickup Data{}, Prev{};
 					pPickup->FillInfo(&Data);
 					pPrev->FillInfo(&Prev);
 					RenderPickup(&Prev, &Data, true);
@@ -463,7 +463,7 @@ void CItems::OnRender()
 	// render flag
 	for(int i = 0; i < Num; i++)
 	{
-		IClient::CSnapItem Item;
+		IClient::CSnapItem Item{};
 		const void *pData = Client()->SnapGetItem(IClient::SNAP_CURRENT, i, &Item);
 
 		if(Item.m_Type == NETOBJTYPE_FLAG)

--- a/src/game/client/components/killmessages.cpp
+++ b/src/game/client/components/killmessages.cpp
@@ -72,7 +72,7 @@ void CKillMessages::CreateKillmessageNamesIfNotCreated(CKillMsg &Kill)
 	{
 		Kill.m_VitctimTextWidth = TextRender()->TextWidth(0, FontSize, Kill.m_aVictimName, -1, -1.0f);
 
-		CTextCursor Cursor;
+		CTextCursor Cursor{};
 		TextRender()->SetCursor(&Cursor, 0, 0, FontSize, TEXTFLAG_RENDER);
 		Cursor.m_LineWidth = -1;
 
@@ -90,7 +90,7 @@ void CKillMessages::CreateKillmessageNamesIfNotCreated(CKillMsg &Kill)
 	{
 		Kill.m_KillerTextWidth = TextRender()->TextWidth(0, FontSize, Kill.m_aKillerName, -1, -1.0f);
 
-		CTextCursor Cursor;
+		CTextCursor Cursor{};
 		TextRender()->SetCursor(&Cursor, 0, 0, FontSize, TEXTFLAG_RENDER);
 		Cursor.m_LineWidth = -1;
 

--- a/src/game/client/components/mapimages.cpp
+++ b/src/game/client/components/mapimages.cpp
@@ -203,7 +203,7 @@ IGraphics::CTextureHandle CMapImages::GetEntities(EMapImageEntityLayerType Entit
 		if(Graphics()->IsTileBufferingEnabled())
 			TextureLoadFlag = (Graphics()->HasTextureArrays() ? IGraphics::TEXLOAD_TO_2D_ARRAY_TEXTURE : IGraphics::TEXLOAD_TO_3D_TEXTURE) | IGraphics::TEXLOAD_NO_2D_TEXTURE;
 
-		CImageInfo ImgInfo;
+		CImageInfo ImgInfo{};
 		bool ImagePNGLoaded = false;
 		if(Graphics()->LoadPNG(&ImgInfo, aPath, IStorage::TYPE_ALL))
 			ImagePNGLoaded = true;

--- a/src/game/client/components/mapimages.h
+++ b/src/game/client/components/mapimages.h
@@ -37,10 +37,10 @@ class CMapImages : public CComponent
 	friend class CMenuBackground;
 
 	IGraphics::CTextureHandle m_aTextures[64];
-	int m_aTextureUsedByTileOrQuadLayerFlag[64]; // 0: nothing, 1(as flag): tile layer, 2(as flag): quad layer
+	int m_aTextureUsedByTileOrQuadLayerFlag[64]{}; // 0: nothing, 1(as flag): tile layer, 2(as flag): quad layer
 	int m_Count;
 
-	char m_aEntitiesPath[IO_MAX_PATH_LENGTH];
+	char m_aEntitiesPath[IO_MAX_PATH_LENGTH]{};
 
 	bool HasFrontLayer(EMapImageModType ModType);
 	bool HasSpeedupLayer(EMapImageModType ModType);
@@ -75,7 +75,7 @@ public:
 	void ChangeEntitiesPath(const char *pPath);
 
 private:
-	bool m_EntitiesIsLoaded[MAP_IMAGE_MOD_TYPE_COUNT * 2];
+	bool m_EntitiesIsLoaded[MAP_IMAGE_MOD_TYPE_COUNT * 2]{};
 	bool m_SpeedupArrowIsLoaded;
 	IGraphics::CTextureHandle m_EntitiesTextures[MAP_IMAGE_MOD_TYPE_COUNT * 2][MAP_IMAGE_ENTITY_LAYER_TYPE_COUNT];
 	IGraphics::CTextureHandle m_SpeedupArrowTexture;

--- a/src/game/client/components/maplayers.cpp
+++ b/src/game/client/components/maplayers.cpp
@@ -1537,7 +1537,7 @@ void CMapLayers::OnRender()
 	if(m_OnlineOnly && Client()->State() != IClient::STATE_ONLINE && Client()->State() != IClient::STATE_DEMOPLAYBACK)
 		return;
 
-	CUIRect Screen;
+	CUIRect Screen{};
 	Graphics()->GetScreen(&Screen.x, &Screen.y, &Screen.w, &Screen.h);
 
 	vec2 Center = GetCurCamera()->m_Center;
@@ -1649,7 +1649,7 @@ void CMapLayers::OnRender()
 			{
 				CMapItemLayerTilemap *pTMap = (CMapItemLayerTilemap *)pLayer;
 				CTile *pTiles = (CTile *)m_pLayers->Map()->GetData(pTMap->m_Data);
-				CServerInfo CurrentServerInfo;
+				CServerInfo CurrentServerInfo{};
 				Client()->GetServerInfo(&CurrentServerInfo);
 				char aFilename[IO_MAX_PATH_LENGTH];
 				str_format(aFilename, sizeof(aFilename), "dumps/tilelayer_dump_%s-%d-%d-%dx%d.txt", CurrentServerInfo.m_aMap, g, l, pTMap->m_Width, pTMap->m_Height);

--- a/src/game/client/components/maplayers.h
+++ b/src/game/client/components/maplayers.h
@@ -27,7 +27,7 @@ class CMapLayers : public CComponent
 	friend class CMenuBackground;
 
 	CLayers *m_pLayers;
-	class CMapImages *m_pImages;
+	class CMapImages *m_pImages{};
 	int m_Type;
 	int m_CurrentLocalTick;
 	int m_LastLocalTick;

--- a/src/game/client/components/mapsounds.h
+++ b/src/game/client/components/mapsounds.h
@@ -11,7 +11,7 @@ struct CSoundSource;
 
 class CMapSounds : public CComponent
 {
-	int m_aSounds[64];
+	int m_aSounds[64]{};
 	int m_Count;
 
 	struct CSourceQueueEntry

--- a/src/game/client/components/menu_background.cpp
+++ b/src/game/client/components/menu_background.cpp
@@ -161,7 +161,7 @@ int CMenuBackground::ThemeIconScan(const char *pName, int IsDir, int DirType, vo
 		{
 			char aBuf[IO_MAX_PATH_LENGTH];
 			str_format(aBuf, sizeof(aBuf), "themes/%s", pName);
-			CImageInfo Info;
+			CImageInfo Info{};
 			if(!pSelf->Graphics()->LoadPNG(&Info, aBuf, DirType))
 			{
 				str_format(aBuf, sizeof(aBuf), "failed to load theme icon from %s", pName);

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -181,7 +181,7 @@ int CMenus::DoButton_Menu(const void *pID, const char *pText, int Checked, const
 	{
 		if(ms_ColorPicker.m_Active)
 		{
-			CUIRect PickerRect;
+			CUIRect PickerRect{};
 			PickerRect.x = ms_ColorPicker.m_X;
 			PickerRect.y = ms_ColorPicker.m_Y;
 			PickerRect.w = ms_ColorPicker.ms_Width;
@@ -197,7 +197,7 @@ int CMenus::DoButton_Menu(const void *pID, const char *pText, int Checked, const
 
 	if(pImageName)
 	{
-		CUIRect Image;
+		CUIRect Image{};
 		pRect->VSplitRight(pRect->h * 4.0f, &Text, &Image); // always correct ratio for image
 
 		// render image
@@ -230,7 +230,7 @@ int CMenus::DoButton_Menu(const void *pID, const char *pText, int Checked, const
 void CMenus::DoButton_KeySelect(const void *pID, const char *pText, int Checked, const CUIRect *pRect)
 {
 	RenderTools()->DrawUIRect(pRect, ColorRGBA(1, 1, 1, 0.5f * UI()->ButtonColorMul(pID)), CUI::CORNER_ALL, 5.0f);
-	CUIRect Temp;
+	CUIRect Temp{};
 	pRect->HMargin(1.0f, &Temp);
 	UI()->DoLabel(&Temp, pText, Temp.h * CUI::ms_FontmodHeight, TEXTALIGN_CENTER);
 }
@@ -308,7 +308,7 @@ int CMenus::DoButton_MenuTab(const void *pID, const char *pText, int Checked, co
 		}
 	}
 
-	CUIRect Temp;
+	CUIRect Temp{};
 	Rect.HMargin(2.0f, &Temp);
 	SLabelProperties Props;
 	Props.m_AlignVertically = AlignVertically;
@@ -323,7 +323,7 @@ int CMenus::DoButton_GridHeader(const void *pID, const char *pText, int Checked,
 		RenderTools()->DrawUIRect(pRect, ColorRGBA(1, 0.98f, 0.5f, 0.55f), CUI::CORNER_T, 5.0f);
 	else if(Checked)
 		RenderTools()->DrawUIRect(pRect, ColorRGBA(1, 1, 1, 0.5f), CUI::CORNER_T, 5.0f);
-	CUIRect t;
+	CUIRect t{};
 	pRect->VSplitLeft(5.0f, 0, &t);
 	UI()->DoLabel(&t, pText, pRect->h * CUI::ms_FontmodHeight, TEXTALIGN_LEFT);
 	return UI()->DoButtonLogic(pID, Checked, pRect);
@@ -410,7 +410,7 @@ void CMenus::DoLaserPreview(const CUIRect *pRect, const ColorHSLA LaserOutlineCo
 
 ColorHSLA CMenus::DoLine_ColorPicker(int *pResetID, const float LineSize, const float WantedPickerPosition, const float LabelSize, const float BottomMargin, CUIRect *pMainRect, const char *pText, unsigned int *pColorValue, const ColorRGBA DefaultColor, bool CheckBoxSpacing, bool UseCheckBox, int *pCheckBoxValue)
 {
-	CUIRect Section, Button, Label;
+	CUIRect Section{}, Button{}, Label{};
 
 	pMainRect->HSplitTop(LineSize, &Section, pMainRect);
 	pMainRect->HSplitTop(BottomMargin, 0x0, pMainRect);
@@ -422,7 +422,7 @@ ColorHSLA CMenus::DoLine_ColorPicker(int *pResetID, const float LineSize, const 
 
 	if(UseCheckBox)
 	{
-		CUIRect CheckBox;
+		CUIRect CheckBox{};
 		Button.Margin(2.0f, &CheckBox);
 
 		if(DoButton_CheckBox(pCheckBoxValue, "", *pCheckBoxValue, &CheckBox))
@@ -460,7 +460,7 @@ ColorHSLA CMenus::DoLine_ColorPicker(int *pResetID, const float LineSize, const 
 
 int CMenus::DoButton_CheckBoxAutoVMarginAndSet(const void *pID, const char *pText, int *pValue, CUIRect *pRect, float VMargin)
 {
-	CUIRect CheckBoxRect;
+	CUIRect CheckBoxRect{};
 	pRect->HSplitTop(VMargin, &CheckBoxRect, pRect);
 
 	int Logic = DoButton_CheckBox_Common(pID, pText, *pValue ? "X" : "", &CheckBoxRect);
@@ -687,7 +687,7 @@ int CMenus::DoKeyReader(void *pID, const CUIRect *pRect, int Key, int ModifierCo
 int CMenus::RenderMenubar(CUIRect r)
 {
 	CUIRect Box = r;
-	CUIRect Button;
+	CUIRect Button{};
 
 	m_ActivePage = m_MenuPage;
 	int NewPage = -1;
@@ -971,7 +971,7 @@ void CMenus::RenderLoading(bool IncreaseCounter, bool RenderLoadingBar)
 
 	const char *pCaption = Localize("Loading DDNet Client");
 
-	CUIRect r;
+	CUIRect r{};
 	r.x = x;
 	r.y = y + 20;
 	r.w = w;
@@ -999,7 +999,7 @@ void CMenus::RenderNews(CUIRect MainView)
 	MainView.HSplitTop(15.0f, 0, &MainView);
 	MainView.VSplitLeft(15.0f, 0, &MainView);
 
-	CUIRect Label;
+	CUIRect Label{};
 
 	const char *pStr = Client()->m_aNews;
 	char aLine[256];
@@ -1105,7 +1105,7 @@ void CMenus::RenderColorPicker()
 		return;
 
 	// First check if we should disable color picker
-	CUIRect PickerRect;
+	CUIRect PickerRect{};
 	PickerRect.x = ms_ColorPicker.m_X;
 	PickerRect.y = ms_ColorPicker.m_Y;
 	PickerRect.w = ms_ColorPicker.ms_Width;
@@ -1123,7 +1123,7 @@ void CMenus::RenderColorPicker()
 	ColorRGBA BackgroundColor(0.1f, 0.1f, 0.1f, 1.0f);
 	RenderTools()->DrawUIRect(&PickerRect, BackgroundColor, 0, 0);
 
-	CUIRect ColorsArea, HueArea, ValuesHitbox, BottomArea, HSVHRect, HSVSRect, HSVVRect, HEXRect, ALPHARect;
+	CUIRect ColorsArea{}, HueArea{}, ValuesHitbox{}, BottomArea{}, HSVHRect{}, HSVSRect{}, HSVVRect{}, HEXRect{}, ALPHARect{};
 	PickerRect.Margin(3, &ColorsArea);
 
 	ColorsArea.HSplitBottom(ms_ColorPicker.ms_Height - 140.0f, &ColorsArea, &ValuesHitbox);
@@ -1272,7 +1272,7 @@ void CMenus::RenderColorPicker()
 	Graphics()->QuadsEnd();
 
 	// Marker Hue Area
-	CUIRect HueMarker;
+	CUIRect HueMarker{};
 	HueArea.Margin(-2.5f, &HueMarker);
 	HueMarker.h = 6.5f;
 	HueMarker.y = (HueArea.y + HueArea.h * (1.0f - PickerColorHSV.x)) - HueMarker.h / 2.0f;
@@ -1339,8 +1339,8 @@ int CMenus::Render()
 		ms_ColorTabbarHover = ms_ColorTabbarHoverOutgame;
 	}
 
-	CUIRect TabBar;
-	CUIRect MainView;
+	CUIRect TabBar{};
+	CUIRect MainView{};
 
 	// some margin around the screen
 	Screen.Margin(10.0f, &Screen);
@@ -1630,7 +1630,7 @@ int CMenus::Render()
 			ExtraAlign = -1;
 		}
 
-		CUIRect Box, Part;
+		CUIRect Box{}, Part{};
 		Box = Screen;
 		if(m_Popup != POPUP_FIRST_LAUNCH)
 			Box.Margin(150.0f / UI()->Scale(), &Box);
@@ -1666,7 +1666,7 @@ int CMenus::Render()
 
 		if(m_Popup == POPUP_QUIT)
 		{
-			CUIRect Yes, No;
+			CUIRect Yes{}, No{};
 			Box.HSplitBottom(20.f, &Box, &Part);
 			Box.HSplitBottom(24.f, &Box, &Part);
 
@@ -1698,7 +1698,7 @@ int CMenus::Render()
 		}
 		else if(m_Popup == POPUP_DISCONNECT)
 		{
-			CUIRect Yes, No;
+			CUIRect Yes{}, No{};
 			Box.HSplitBottom(20.f, &Box, &Part);
 			Box.HSplitBottom(24.f, &Box, &Part);
 
@@ -1718,7 +1718,7 @@ int CMenus::Render()
 		}
 		else if(m_Popup == POPUP_DISCONNECT_DUMMY)
 		{
-			CUIRect Yes, No;
+			CUIRect Yes{}, No{};
 			Box.HSplitBottom(20.f, &Box, &Part);
 			Box.HSplitBottom(24.f, &Box, &Part);
 
@@ -1742,7 +1742,7 @@ int CMenus::Render()
 		}
 		else if(m_Popup == POPUP_PASSWORD)
 		{
-			CUIRect Label, TextBox, TryAgain, Abort;
+			CUIRect Label{}, TextBox{}, TryAgain{}, Abort{};
 
 			Box.HSplitBottom(20.f, &Box, &Part);
 			Box.HSplitBottom(24.f, &Box, &Part);
@@ -1882,7 +1882,7 @@ int CMenus::Render()
 				CListboxItem Item = UiDoListboxNextItem(&pEntry->m_CountryCode, OldSelected == i);
 				if(Item.m_Visible)
 				{
-					CUIRect Label;
+					CUIRect Label{};
 					Item.m_Rect.Margin(5.0f, &Item.m_Rect);
 					Item.m_Rect.HSplitBottom(10.0f, &Item.m_Rect, &Label);
 					float OldWidth = Item.m_Rect.w;
@@ -1916,7 +1916,7 @@ int CMenus::Render()
 		}
 		else if(m_Popup == POPUP_DELETE_DEMO)
 		{
-			CUIRect Yes, No;
+			CUIRect Yes{}, No{};
 			Box.HSplitBottom(20.f, &Box, &Part);
 			Box.HSplitBottom(24.f, &Box, &Part);
 			Part.VMargin(80.0f, &Part);
@@ -1950,7 +1950,7 @@ int CMenus::Render()
 		}
 		else if(m_Popup == POPUP_RENAME_DEMO)
 		{
-			CUIRect Label, TextBox, Ok, Abort;
+			CUIRect Label{}, TextBox{}, Ok{}, Abort{};
 
 			Box.HSplitBottom(20.f, &Box, &Part);
 			Box.HSplitBottom(24.f, &Box, &Part);
@@ -2004,7 +2004,7 @@ int CMenus::Render()
 #if defined(CONF_VIDEORECORDER)
 		else if(m_Popup == POPUP_RENDER_DEMO)
 		{
-			CUIRect Label, TextBox, Ok, Abort, IncSpeed, DecSpeed, Button, Buttons;
+			CUIRect Label{}, TextBox{}, Ok{}, Abort{}, IncSpeed{}, DecSpeed{}, Button{}, Buttons{};
 
 			Box.HSplitBottom(20.f, &Box, &Part);
 #if defined(__ANDROID__)
@@ -2126,7 +2126,7 @@ int CMenus::Render()
 		}
 		else if(m_Popup == POPUP_REPLACE_VIDEO)
 		{
-			CUIRect Yes, No;
+			CUIRect Yes{}, No{};
 			Box.HSplitBottom(20.f, &Box, &Part);
 #if defined(__ANDROID__)
 			Box.HSplitBottom(60.f, &Box, &Part);
@@ -2159,7 +2159,7 @@ int CMenus::Render()
 #endif
 		else if(m_Popup == POPUP_REMOVE_FRIEND)
 		{
-			CUIRect Yes, No;
+			CUIRect Yes{}, No{};
 			Box.HSplitBottom(20.f, &Box, &Part);
 			Box.HSplitBottom(24.f, &Box, &Part);
 			Part.VMargin(80.0f, &Part);
@@ -2189,7 +2189,7 @@ int CMenus::Render()
 		}
 		else if(m_Popup == POPUP_FIRST_LAUNCH)
 		{
-			CUIRect Label, TextBox, Skip, Join;
+			CUIRect Label{}, TextBox{}, Skip{}, Join{};
 
 			Box.HSplitBottom(20.f, &Box, &Part);
 			Box.HSplitBottom(24.f, &Box, &Part);
@@ -2240,7 +2240,7 @@ int CMenus::Render()
 		}
 		else if(m_Popup == POPUP_POINTS)
 		{
-			CUIRect Yes, No;
+			CUIRect Yes{}, No{};
 
 			Box.HSplitBottom(20.f, &Box, &Part);
 			Box.HSplitBottom(24.f, &Box, &Part);
@@ -2274,7 +2274,7 @@ int CMenus::Render()
 		}
 		else if(m_Popup == POPUP_SWITCH_SERVER)
 		{
-			CUIRect Yes, No;
+			CUIRect Yes{}, No{};
 			Box.HSplitBottom(20.f, &Box, &Part);
 			Box.HSplitBottom(24.f, &Box, &Part);
 
@@ -2343,7 +2343,7 @@ void CMenus::RenderThemeSelection(CUIRect MainView, bool Header)
 		if(!Item.m_Visible)
 			continue;
 
-		CUIRect Icon;
+		CUIRect Icon{};
 		Item.m_Rect.VSplitLeft(Item.m_Rect.h * 2.0f, &Icon, &Item.m_Rect);
 
 		// draw icon if it exists
@@ -2607,7 +2607,7 @@ void CMenus::OnRender()
 
 		char aBuf[512];
 		str_format(aBuf, sizeof(aBuf), "%p %p %p", UI()->HotItem(), UI()->ActiveItem(), UI()->LastActiveItem());
-		CTextCursor Cursor;
+		CTextCursor Cursor{};
 		TextRender()->SetCursor(&Cursor, 10, 10, 10, TEXTFLAG_RENDER);
 		TextRender()->TextEx(&Cursor, aBuf, -1);
 	}
@@ -2697,7 +2697,7 @@ int CMenus::MenuImageScan(const char *pName, int IsDir, int DirType, void *pUser
 
 	char aBuf[IO_MAX_PATH_LENGTH];
 	str_format(aBuf, sizeof(aBuf), "menuimages/%s", pName);
-	CImageInfo Info;
+	CImageInfo Info{};
 	if(!pSelf->Graphics()->LoadPNG(&Info, aBuf, DirType))
 	{
 		str_format(aBuf, sizeof(aBuf), "failed to load menu image from %s", pName);

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -50,7 +50,7 @@ class CMenusKeyBinder : public CComponent
 public:
 	bool m_TakeKey;
 	bool m_GotKey;
-	IInput::CEvent m_Key;
+	IInput::CEvent m_Key{};
 	int m_ModifierCombination;
 	CMenusKeyBinder();
 	virtual int Sizeof() const override { return sizeof(*this); }
@@ -73,7 +73,7 @@ class CMenus : public CComponent
 	static SColorPicker ms_ColorPicker;
 	static bool ms_ValueSelectorTextMode;
 
-	char m_aLocalStringHelper[1024];
+	char m_aLocalStringHelper[1024]{};
 
 	CUIEx m_UIEx;
 
@@ -286,7 +286,7 @@ protected:
 	vec2 m_MousePos;
 	bool m_JoinTutorial;
 
-	char m_aNextServer[256];
+	char m_aNextServer[256]{};
 
 	// images
 	struct CMenuImage
@@ -302,13 +302,13 @@ protected:
 	const CMenuImage *FindMenuImage(const char *pName);
 
 	// loading
-	int m_LoadCurrent;
-	int m_LoadTotal;
+	int m_LoadCurrent{};
+	int m_LoadTotal{};
 
 	//
-	char m_aMessageTopic[512];
-	char m_aMessageBody[512];
-	char m_aMessageButton[512];
+	char m_aMessageTopic[512]{};
+	char m_aMessageBody[512]{};
+	char m_aMessageButton[512]{};
 
 	CUIElement m_RefreshButton;
 	CUIElement m_ConnectButton;
@@ -329,15 +329,15 @@ protected:
 	static float ms_ListitemAdditionalHeight;
 
 	// for settings
-	bool m_NeedRestartGeneral;
-	bool m_NeedRestartSkins;
+	bool m_NeedRestartGeneral{};
+	bool m_NeedRestartSkins{};
 	bool m_NeedRestartGraphics;
 	bool m_NeedRestartSound;
-	bool m_NeedRestartUpdate;
-	bool m_NeedRestartDDNet;
+	bool m_NeedRestartUpdate{};
+	bool m_NeedRestartDDNet{};
 	bool m_NeedSendinfo;
 	bool m_NeedSendDummyinfo;
-	int m_SettingPlayerPage;
+	int m_SettingPlayerPage{};
 
 	//
 	bool m_EscapePressed;
@@ -345,16 +345,16 @@ protected:
 	bool m_DeletePressed;
 
 	// for map download popup
-	int64_t m_DownloadLastCheckTime;
-	int m_DownloadLastCheckSize;
-	float m_DownloadSpeed;
+	int64_t m_DownloadLastCheckTime{};
+	int m_DownloadLastCheckSize{};
+	float m_DownloadSpeed{};
 
 	// for call vote
-	int m_CallvoteSelectedOption;
-	int m_CallvoteSelectedPlayer;
-	char m_aCallvoteReason[VOTE_REASON_LENGTH];
-	char m_aFilterString[25];
-	bool m_ControlPageOpening;
+	int m_CallvoteSelectedOption{};
+	int m_CallvoteSelectedPlayer{};
+	char m_aCallvoteReason[VOTE_REASON_LENGTH]{};
+	char m_aFilterString[25]{};
+	bool m_ControlPageOpening{};
 
 	// demo
 	enum
@@ -429,11 +429,11 @@ protected:
 	};
 
 	//sorted_array<CDemoItem> m_lDemos;
-	char m_aCurrentDemoFolder[256];
-	char m_aCurrentDemoFile[64];
-	int m_DemolistSelectedIndex;
-	bool m_DemolistSelectedIsDir;
-	int m_DemolistStorageType;
+	char m_aCurrentDemoFolder[256]{};
+	char m_aCurrentDemoFile[64]{};
+	int m_DemolistSelectedIndex{};
+	bool m_DemolistSelectedIsDir{};
+	int m_DemolistStorageType{};
 	int m_Speed = 4;
 
 	std::chrono::nanoseconds m_DemoPopulateStartTime{0};
@@ -496,9 +496,9 @@ protected:
 	bool RenderServerControlServer(CUIRect MainView);
 
 	// found in menus_browser.cpp
-	int m_SelectedIndex;
+	int m_SelectedIndex{};
 	int m_DoubleClickIndex;
-	int m_ScrollOffset;
+	int m_ScrollOffset{};
 	void RenderServerbrowserServerList(CUIRect View);
 	void RenderServerbrowserServerDetail(CUIRect View);
 	void RenderServerbrowserFilters(CUIRect View);
@@ -527,7 +527,7 @@ protected:
 
 	bool CheckHotKey(int Key) const;
 
-	class CMenuBackground *m_pBackground;
+	class CMenuBackground *m_pBackground{};
 
 public:
 	void RenderBackground();
@@ -610,9 +610,9 @@ public:
 		SMALL_TAB_LENGTH,
 	};
 
-	SUIAnimator m_aAnimatorsBigPage[BIG_TAB_LENGTH];
-	SUIAnimator m_aAnimatorsSmallPage[SMALL_TAB_LENGTH];
-	SUIAnimator m_aAnimatorsSettingsTab[SETTINGS_LENGTH];
+	SUIAnimator m_aAnimatorsBigPage[BIG_TAB_LENGTH]{};
+	SUIAnimator m_aAnimatorsSmallPage[SMALL_TAB_LENGTH]{};
+	SUIAnimator m_aAnimatorsSettingsTab[SETTINGS_LENGTH]{};
 
 	// DDRace
 	int DoButton_CheckBox_DontCare(const void *pID, const char *pText, int Checked, const CUIRect *pRect);
@@ -656,11 +656,11 @@ public:
 
 	void PopupWarning(const char *pTopic, const char *pBody, const char *pButton, std::chrono::nanoseconds Duration);
 
-	std::chrono::nanoseconds m_PopupWarningLastTime;
-	std::chrono::nanoseconds m_PopupWarningDuration;
+	std::chrono::nanoseconds m_PopupWarningLastTime{};
+	std::chrono::nanoseconds m_PopupWarningDuration{};
 
 	int m_DemoPlayerState;
-	char m_aDemoPlayerPopupHint[256];
+	char m_aDemoPlayerPopupHint[256]{};
 
 	enum
 	{
@@ -708,6 +708,6 @@ private:
 
 	int RenderDropDown(int &CurDropDownState, CUIRect *pRect, int CurSelection, const void **pIDs, const char **pStr, int PickNum, const void *pID, float &ScrollVal);
 
-	CServerProcess m_ServerProcess;
+	CServerProcess m_ServerProcess{};
 };
 #endif

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -56,8 +56,8 @@ void FormatServerbrowserPing(char *pBuffer, int BufferLength, const CServerInfo 
 
 void CMenus::RenderServerbrowserServerList(CUIRect View)
 {
-	CUIRect Headers;
-	CUIRect Status;
+	CUIRect Headers{};
+	CUIRect Status{};
 
 	View.HSplitTop(ms_ListheaderHeight, &Headers, &View);
 	View.HSplitBottom(70.0f, &View, &Status);
@@ -68,14 +68,14 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 
 	struct CColumn
 	{
-		int m_ID;
-		int m_Sort;
+		int m_ID{};
+		int m_Sort{};
 		CLocConstString m_Caption;
-		int m_Direction;
-		float m_Width;
-		int m_Flags;
-		CUIRect m_Rect;
-		CUIRect m_Spacer;
+		int m_Direction{};
+		float m_Width{};
+		int m_Flags{};
+		CUIRect m_Rect{};
+		CUIRect m_Spacer{};
 	};
 
 	enum
@@ -170,7 +170,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 
 	RenderTools()->DrawUIRect(&View, ColorRGBA(0, 0, 0, 0.15f), 0, 0);
 
-	CUIRect Scroll;
+	CUIRect Scroll{};
 	View.VSplitRight(20.0f, &View, &Scroll);
 
 	int NumServers = ServerBrowser()->NumSortedServers();
@@ -244,7 +244,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 		int ItemIndex = i;
 		const CServerInfo *pItem = ServerBrowser()->SortedGet(ItemIndex);
 		NumPlayers += pItem->m_NumFilteredPlayers;
-		CUIRect Row;
+		CUIRect Row{};
 
 		const int UIRectCount = 2 + (COL_VERSION + 1) * 3;
 		//initialize
@@ -320,7 +320,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 
 		for(int c = 0; c < NumCols; c++)
 		{
-			CUIRect Button;
+			CUIRect Button{};
 			char aTemp[64];
 			Button.x = s_aCols[c].m_Rect.x;
 			Button.y = Row.y;
@@ -377,7 +377,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 			{
 				if(g_Config.m_UiPage == PAGE_DDNET)
 				{
-					CUIRect Icon;
+					CUIRect Icon{};
 					Button.VMargin(4.0f, &Button);
 					Button.VSplitLeft(Button.h, &Icon, &Button);
 					Icon.Margin(2.0f, &Icon);
@@ -410,7 +410,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 			}
 			else if(ID == COL_PLAYERS)
 			{
-				CUIRect Icon;
+				CUIRect Icon{};
 				Button.VMargin(4.0f, &Button);
 				if(pItem->m_FriendState != IFriends::FRIEND_NO)
 				{
@@ -502,14 +502,14 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 	//RenderTools()->DrawUIRect(&Status, ms_ColorTabbarActive, CUI::CORNER_B, 5.0f);
 	Status.Margin(5.0f, &Status);
 
-	CUIRect SearchInfoAndAddr, ServersAndConnect, Status3;
+	CUIRect SearchInfoAndAddr{}, ServersAndConnect{}, Status3{};
 	Status.VSplitRight(250.0f, &SearchInfoAndAddr, &ServersAndConnect);
 	if(SearchInfoAndAddr.w > 350.0f)
 		SearchInfoAndAddr.VSplitLeft(350.0f, &SearchInfoAndAddr, NULL);
-	CUIRect SearchAndInfo, ServerAddr, ConnectButtons;
+	CUIRect SearchAndInfo{}, ServerAddr{}, ConnectButtons{};
 	SearchInfoAndAddr.HSplitTop(40.0f, &SearchAndInfo, &ServerAddr);
 	ServersAndConnect.HSplitTop(35.0f, &Status3, &ConnectButtons);
-	CUIRect QuickSearch, QuickExclude;
+	CUIRect QuickSearch{}, QuickExclude{};
 
 	SearchAndInfo.HSplitTop(20.f, &QuickSearch, &QuickExclude);
 	QuickSearch.Margin(2.f, &QuickSearch);
@@ -597,7 +597,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 	else
 		str_format(aBufPyr, sizeof(aBufPyr), Localize("%d player"), NumPlayers);
 
-	CUIRect SvrsOnline, PlysOnline;
+	CUIRect SvrsOnline{}, PlysOnline{};
 	Status3.HSplitTop(20.f, &PlysOnline, &SvrsOnline);
 	PlysOnline.VSplitRight(TextRender()->TextWidth(0, 12.0f, aBufPyr, -1, -1.0f), 0, &PlysOnline);
 	UI()->DoLabelScaled(&PlysOnline, aBufPyr, 12.0f, TEXTALIGN_LEFT);
@@ -606,7 +606,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 
 	// status box
 	{
-		CUIRect ButtonRefresh, ButtonConnect, ButtonArea;
+		CUIRect ButtonRefresh{}, ButtonConnect{}, ButtonArea{};
 
 		ServerAddr.Margin(2.0f, &ServerAddr);
 
@@ -679,7 +679,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 
 void CMenus::RenderServerbrowserFilters(CUIRect View)
 {
-	CUIRect ServerFilter = View, FilterHeader;
+	CUIRect ServerFilter = View, FilterHeader{};
 	const float FontSize = 12.0f;
 	ServerFilter.HSplitBottom(0.0f, &ServerFilter, 0);
 
@@ -689,7 +689,7 @@ void CMenus::RenderServerbrowserFilters(CUIRect View)
 
 	RenderTools()->DrawUIRect(&ServerFilter, ColorRGBA(0, 0, 0, 0.15f), CUI::CORNER_B, 4.0f);
 	UI()->DoLabelScaled(&FilterHeader, Localize("Server filter"), FontSize + 2.0f, TEXTALIGN_CENTER);
-	CUIRect Button, Button2;
+	CUIRect Button{}, Button2{};
 
 	ServerFilter.VSplitLeft(5.0f, 0, &ServerFilter);
 	ServerFilter.Margin(3.0f, &ServerFilter);
@@ -740,7 +740,7 @@ void CMenus::RenderServerbrowserFilters(CUIRect View)
 
 	// player country
 	{
-		CUIRect Rect;
+		CUIRect Rect{};
 		ServerFilter.HSplitTop(3.0f, 0, &ServerFilter);
 		ServerFilter.HSplitTop(26.0f, &Button, &ServerFilter);
 		Button.VSplitRight(60.0f, &Button, &Rect);
@@ -762,10 +762,10 @@ void CMenus::RenderServerbrowserFilters(CUIRect View)
 	if(DoButton_CheckBox(&g_Config.m_BrFilterConnectingPlayers, Localize("Filter connecting players"), g_Config.m_BrFilterConnectingPlayers, &Button))
 		g_Config.m_BrFilterConnectingPlayers ^= 1;
 
-	CUIRect FilterTabs;
+	CUIRect FilterTabs{};
 	ServerFilter.HSplitBottom(23, &ServerFilter, &FilterTabs);
 
-	CUIRect ResetButton;
+	CUIRect ResetButton{};
 
 	//ServerFilter.HSplitBottom(5.0f, &ServerFilter, 0);
 	ServerFilter.HSplitBottom(ms_ButtonHeight - 5.0f, &ServerFilter, &ResetButton);
@@ -833,7 +833,7 @@ void CMenus::RenderServerbrowserFilters(CUIRect View)
 			const float TypesWidth = 40.0f;
 			const float TypesHeight = ServerFilter.h / ceil(MaxTypes / (float)PerLine);
 
-			CUIRect TypesRect, Left, Right;
+			CUIRect TypesRect{}, Left{}, Right{};
 
 			static int s_aTypeButtons[64];
 
@@ -854,7 +854,7 @@ void CMenus::RenderServerbrowserFilters(CUIRect View)
 					Pos.x -= TypesWidth / 2.0f;
 
 					// create button logic
-					CUIRect Rect;
+					CUIRect Rect{};
 
 					Rect.x = Pos.x;
 					Rect.y = Pos.y;
@@ -927,7 +927,7 @@ void CMenus::RenderServerbrowserFilters(CUIRect View)
 			int NumFlags = ServerBrowser()->NumCountries(Network);
 			int PerLine = MaxFlags > 8 ? 5 : 4;
 
-			CUIRect FlagsRect;
+			CUIRect FlagsRect{};
 
 			static int s_aFlagButtons[64];
 
@@ -949,7 +949,7 @@ void CMenus::RenderServerbrowserFilters(CUIRect View)
 					Pos.y -= FlagHeight / 2.0f;
 
 					// create button logic
-					CUIRect Rect;
+					CUIRect Rect{};
 
 					Rect.x = Pos.x;
 					Rect.y = Pos.y;
@@ -1040,7 +1040,7 @@ void CMenus::RenderServerbrowserFilters(CUIRect View)
 void CMenus::RenderServerbrowserServerDetail(CUIRect View)
 {
 	CUIRect ServerDetails = View;
-	CUIRect ServerScoreBoard, ServerHeader;
+	CUIRect ServerScoreBoard{}, ServerHeader{};
 
 	const CServerInfo *pSelectedServer = ServerBrowser()->SortedGet(m_SelectedIndex);
 
@@ -1049,7 +1049,7 @@ void CMenus::RenderServerbrowserServerDetail(CUIRect View)
 	ServerDetails.HSplitBottom(2.5f, &ServerDetails, 0x0);
 
 	// server details
-	CTextCursor Cursor;
+	CTextCursor Cursor{};
 	const float FontSize = 12.0f;
 	ServerDetails.HSplitTop(ms_ListheaderHeight, &ServerHeader, &ServerDetails);
 	RenderTools()->DrawUIRect(&ServerHeader, ColorRGBA(1, 1, 1, 0.25f), CUI::CORNER_T, 4.0f);
@@ -1061,21 +1061,21 @@ void CMenus::RenderServerbrowserServerDetail(CUIRect View)
 		ServerDetails.VSplitLeft(5.0f, 0, &ServerDetails);
 		ServerDetails.Margin(3.0f, &ServerDetails);
 
-		CUIRect Row;
+		CUIRect Row{};
 		static CLocConstString s_aLabels[] = {
 			"Version", // Localize - these strings are localized within CLocConstString
 			"Game type",
 			"Ping"};
 
-		CUIRect LeftColumn;
-		CUIRect RightColumn;
+		CUIRect LeftColumn{};
+		CUIRect RightColumn{};
 
 		//
 		{
-			CUIRect Button;
+			CUIRect Button{};
 			ServerDetails.HSplitBottom(20.0f, &ServerDetails, &Button);
-			CUIRect ButtonAddFav;
-			CUIRect ButtonLeakIp;
+			CUIRect ButtonAddFav{};
+			CUIRect ButtonLeakIp{};
 			Button.VSplitMid(&ButtonAddFav, &ButtonLeakIp);
 			ButtonAddFav.VSplitLeft(5.0f, 0, &ButtonAddFav);
 			static int s_AddFavButton = 0;
@@ -1148,7 +1148,7 @@ void CMenus::RenderServerbrowserServerDetail(CUIRect View)
 			if(!Item.m_Visible)
 				continue;
 
-			CUIRect Name, Clan, Score, Flag;
+			CUIRect Name{}, Clan{}, Score{}, Flag{};
 			Item.m_Rect.HSplitTop(25.0f, &Name, &Item.m_Rect);
 			if(UiLogicGetCurrentClickedItem() == i)
 			{
@@ -1251,7 +1251,7 @@ void CMenus::FriendlistOnUpdate()
 	m_lFriends.clear();
 	for(int i = 0; i < m_pClient->Friends()->NumFriends(); ++i)
 	{
-		CFriendItem Item;
+		CFriendItem Item{};
 		Item.m_pFriendInfo = m_pClient->Friends()->GetFriend(i);
 		Item.m_NumFound = 0;
 		m_lFriends.add_unsorted(Item);
@@ -1268,7 +1268,7 @@ void CMenus::RenderServerbrowserFriends(CUIRect View)
 		s_Inited = 1;
 	}
 
-	CUIRect ServerFriends = View, FilterHeader;
+	CUIRect ServerFriends = View, FilterHeader{};
 	const float FontSize = 10.0f;
 
 	ServerFriends.HSplitBottom(18.0f, &ServerFriends, NULL);
@@ -1278,7 +1278,7 @@ void CMenus::RenderServerbrowserFriends(CUIRect View)
 	RenderTools()->DrawUIRect(&FilterHeader, ColorRGBA(1, 1, 1, 0.25f), CUI::CORNER_T, 4.0f);
 	RenderTools()->DrawUIRect(&ServerFriends, ColorRGBA(0, 0, 0, 0.15f), 0, 4.0f);
 	UI()->DoLabelScaled(&FilterHeader, Localize("Friends"), FontSize + 4.0f, TEXTALIGN_CENTER);
-	CUIRect Button, List;
+	CUIRect Button{}, List{};
 
 	ServerFriends.Margin(3.0f, &ServerFriends);
 	ServerFriends.VMargin(3.0f, &ServerFriends);
@@ -1298,7 +1298,7 @@ void CMenus::RenderServerbrowserFriends(CUIRect View)
 		if(Item.m_Visible)
 		{
 			Item.m_Rect.Margin(1.5f, &Item.m_Rect);
-			CUIRect OnState;
+			CUIRect OnState{};
 			Item.m_Rect.VSplitRight(30.0f, &Item.m_Rect, &OnState);
 			RenderTools()->DrawUIRect(&Item.m_Rect, ColorRGBA(1.0f, 1.0f, 1.0f, 0.1f), CUI::CORNER_L, 4.0f);
 
@@ -1403,7 +1403,7 @@ void CMenus::RenderServerbrowser(CUIRect MainView)
 			status box	tab	+-------+
 	*/
 
-	CUIRect ServerList, ToolBox;
+	CUIRect ServerList{}, ToolBox{};
 
 	// background
 	RenderTools()->DrawUIRect(&MainView, ms_ColorTabbarActive, CUI::CORNER_B, 10.0f);
@@ -1434,9 +1434,9 @@ void CMenus::RenderServerbrowser(CUIRect MainView)
 
 	// tab bar
 	{
-		CUIRect TabBar;
+		CUIRect TabBar{};
 		ToolBox.HSplitBottom(18, &ToolBox, &TabBar);
-		CUIRect TabButton0, TabButton1, TabButton2;
+		CUIRect TabButton0{}, TabButton1{}, TabButton2{};
 		float CurTabBarWidth = ToolBox.w;
 		TabBar.VSplitLeft(0.333f * CurTabBarWidth, &TabButton0, &TabBar);
 		TabBar.VSplitLeft(0.333f * CurTabBarWidth, &TabButton1, &TabBar);

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -57,7 +57,7 @@ bool CMenus::DemoFilterChat(const void *pData, int Size, void *pUser)
 		return false;
 	}
 
-	CUnpacker Unpacker;
+	CUnpacker Unpacker{};
 	Unpacker.Reset(pData, Size);
 
 	int Msg = Unpacker.GetInt();
@@ -81,7 +81,7 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 	if(m_DemoPlayerState == DEMOPLAYER_SLICE_SAVE)
 	{
 		CUIRect Screen = *UI()->Screen();
-		CUIRect Box, Part, Part2;
+		CUIRect Box{}, Part{}, Part2{};
 		Box = Screen;
 		Box.Margin(150.0f / UI()->Scale(), &Box);
 
@@ -97,7 +97,7 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 		UI()->DoLabelScaled(&Part, m_aDemoPlayerPopupHint, 20.f, TEXTALIGN_CENTER);
 		Box.HSplitTop(20.f / UI()->Scale(), 0, &Box);
 
-		CUIRect Label, TextBox, Ok, Abort;
+		CUIRect Label{}, TextBox{}, Ok{}, Abort{};
 
 		Box.HSplitBottom(20.f, &Box, 0);
 		Box.HSplitBottom(24.f, &Box, &Part);
@@ -260,7 +260,7 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 
 	MainView.Margin(5.0f, &MainView);
 
-	CUIRect SeekBar, ButtonBar, NameBar;
+	CUIRect SeekBar{}, ButtonBar{}, NameBar{};
 
 	int CurrentTick = pInfo->m_CurrentTick - pInfo->m_FirstTick;
 	int TotalTicks = pInfo->m_LastTick - pInfo->m_FirstTick;
@@ -388,7 +388,7 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 	bool IncreaseDemoSpeed = false, DecreaseDemoSpeed = false;
 
 	// do buttons
-	CUIRect Button;
+	CUIRect Button{};
 
 	// combined play and pause button
 	ButtonBar.VSplitLeft(ButtonbarHeight, &Button, &ButtonBar);
@@ -485,7 +485,7 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 	DemoPlayer()->GetDemoName(aDemoName, sizeof(aDemoName));
 	char aBuf[128];
 	str_format(aBuf, sizeof(aBuf), Localize("Demofile: %s"), aDemoName);
-	CTextCursor Cursor;
+	CTextCursor Cursor{};
 	TextRender()->SetCursor(&Cursor, NameBar.x, NameBar.y + (NameBar.h - (Button.h * 0.5f)) / 2.f, Button.h * 0.5f, TEXTFLAG_RENDER | TEXTFLAG_STOP_AT_END);
 	Cursor.m_LineWidth = MainView.w;
 	TextRender()->TextEx(&Cursor, aBuf, -1);
@@ -518,7 +518,7 @@ static bool gs_ListBoxClicked;
 void CMenus::UiDoListboxStart(const void *pID, const CUIRect *pRect, float RowHeight, const char *pTitle, const char *pBottomText, int NumItems,
 	int ItemsPerRow, int SelectedIndex, float ScrollValue, bool LogicOnly)
 {
-	CUIRect Scroll, Row;
+	CUIRect Scroll{}, Row{};
 	CUIRect View = *pRect;
 
 	if(!LogicOnly)
@@ -750,7 +750,7 @@ int CMenus::DemolistFetchCallback(const CFsFileInfo *pInfo, int IsDir, int Stora
 		return 0;
 	}
 
-	CDemoItem Item;
+	CDemoItem Item{};
 	str_copy(Item.m_aFilename, pInfo->m_pName, sizeof(Item.m_aFilename));
 	if(IsDir)
 	{
@@ -870,10 +870,10 @@ void CMenus::RenderDemoList(CUIRect MainView)
 	MainView.Margin(10.0f, &MainView);
 
 #if defined(CONF_VIDEORECORDER)
-	CUIRect RenderRect;
+	CUIRect RenderRect{};
 #endif
-	CUIRect ButtonBar, RefreshRect, FetchRect, PlayRect, DeleteRect, RenameRect, LabelRect, ListBox;
-	CUIRect ButtonBar2, DirectoryButton;
+	CUIRect ButtonBar{}, RefreshRect{}, FetchRect{}, PlayRect{}, DeleteRect{}, RenameRect{}, LabelRect{}, ListBox{};
+	CUIRect ButtonBar2{}, DirectoryButton{};
 
 	MainView.HSplitBottom((ms_ButtonHeight + 5.0f) * 2.0f, &MainView, &ButtonBar2);
 	ButtonBar2.HSplitTop(5.0f, 0, &ButtonBar2);
@@ -903,7 +903,7 @@ void CMenus::RenderDemoList(CUIRect MainView)
 	RenderTools()->DrawUIRect(&MainView, ColorRGBA(0, 0, 0, 0.15f), CUI::CORNER_B, 4.0f);
 	if(!m_DemolistSelectedIsDir && m_DemolistSelectedIndex >= 0 && m_lDemos[m_DemolistSelectedIndex].m_Valid)
 	{
-		CUIRect Left, Right, Labels;
+		CUIRect Left{}, Right{}, Labels{};
 		MainView.VMargin(20.0f, &MainView);
 		MainView.HMargin(10.0f, &MainView);
 		MainView.VSplitMid(&Labels, &MainView);
@@ -985,20 +985,20 @@ void CMenus::RenderDemoList(CUIRect MainView)
 
 	// demo list
 
-	CUIRect Headers;
+	CUIRect Headers{};
 
 	ListBox.HSplitTop(ms_ListheaderHeight, &Headers, &ListBox);
 
 	struct CColumn
 	{
-		int m_ID;
-		int m_Sort;
+		int m_ID{};
+		int m_Sort{};
 		CLocConstString m_Caption;
-		int m_Direction;
-		float m_Width;
-		int m_Flags;
-		CUIRect m_Rect;
-		CUIRect m_Spacer;
+		int m_Direction{};
+		float m_Width{};
+		int m_Flags{};
+		CUIRect m_Rect{};
+		CUIRect m_Spacer{};
 	};
 
 	enum
@@ -1076,7 +1076,7 @@ void CMenus::RenderDemoList(CUIRect MainView)
 	}
 
 	// scrollbar
-	CUIRect Scroll;
+	CUIRect Scroll{};
 	ListBox.VSplitRight(20.0f, &ListBox, &Scroll);
 
 	static float s_ScrollValue = 0;
@@ -1105,7 +1105,7 @@ void CMenus::RenderDemoList(CUIRect MainView)
 	{
 		ItemIndex++;
 
-		CUIRect Row;
+		CUIRect Row{};
 		ListBox.HSplitTop(ms_ListheaderHeight, &Row, &ListBox);
 
 		int Selected = ItemIndex == m_DemolistSelectedIndex;
@@ -1142,7 +1142,7 @@ void CMenus::RenderDemoList(CUIRect MainView)
 
 		for(int c = 0; c < NumCols; c++)
 		{
-			CUIRect Button;
+			CUIRect Button{};
 			Button.x = s_aCols[c].m_Rect.x;
 			Button.y = Row.y;
 			Button.h = Row.h;
@@ -1156,7 +1156,7 @@ void CMenus::RenderDemoList(CUIRect MainView)
 			}
 			else if(ID == COL_DEMONAME)
 			{
-				CTextCursor Cursor;
+				CTextCursor Cursor{};
 				TextRender()->SetCursor(&Cursor, Button.x, Button.y + (Button.h - 12.0f * UI()->Scale()) / 2.f, 12.0f * UI()->Scale(), TEXTFLAG_RENDER | TEXTFLAG_STOP_AT_END);
 				Cursor.m_LineWidth = Button.w;
 

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -36,7 +36,7 @@ using namespace std::chrono_literals;
 
 void CMenus::RenderGame(CUIRect MainView)
 {
-	CUIRect Button, ButtonBar, ButtonBar2;
+	CUIRect Button{}, ButtonBar{}, ButtonBar2{};
 	MainView.HSplitTop(45.0f, &ButtonBar, &MainView);
 	RenderTools()->DrawUIRect(&ButtonBar, ms_ColorTabbarActive, CUI::CORNER_B, 10.0f);
 
@@ -208,7 +208,7 @@ void CMenus::RenderGame(CUIRect MainView)
 
 void CMenus::RenderPlayers(CUIRect MainView)
 {
-	CUIRect Button, Button2, ButtonBar, Options, Player;
+	CUIRect Button{}, Button2{}, ButtonBar{}, Options{}, Player{};
 	RenderTools()->DrawUIRect(&MainView, ms_ColorTabbarActive, CUI::CORNER_B, 10.0f);
 
 	// player options
@@ -312,7 +312,7 @@ void CMenus::RenderPlayers(CUIRect MainView)
 		Player.HSplitTop(1.5f, 0, &Player);
 		Player.VSplitMid(&Player, &Button);
 		Item.m_Rect.VSplitRight(200.0f, &Button2, &Item.m_Rect);
-		CTextCursor Cursor;
+		CTextCursor Cursor{};
 		TextRender()->SetCursor(&Cursor, Player.x, Player.y + (Player.h - 14.f) / 2.f, 14.0f, TEXTFLAG_RENDER | TEXTFLAG_STOP_AT_END);
 		Cursor.m_LineWidth = Player.w;
 		TextRender()->TextEx(&Cursor, m_pClient->m_aClients[Index].m_aName, -1);
@@ -420,13 +420,13 @@ void CMenus::RenderServerInfo(CUIRect MainView)
 		return;
 
 	// fetch server info
-	CServerInfo CurrentServerInfo;
+	CServerInfo CurrentServerInfo{};
 	Client()->GetServerInfo(&CurrentServerInfo);
 
 	// render background
 	RenderTools()->DrawUIRect(&MainView, ms_ColorTabbarActive, CUI::CORNER_B, 10.0f);
 
-	CUIRect View, ServerInfo, GameInfo, Motd;
+	CUIRect View{}, ServerInfo{}, GameInfo{}, Motd{};
 
 	float x = 0.0f;
 	float y = 0.0f;
@@ -467,7 +467,7 @@ void CMenus::RenderServerInfo(CUIRect MainView)
 	TextRender()->Text(0, ServerInfo.x + x, ServerInfo.y + y, 20, aBuf, 250.0f);
 
 	{
-		CUIRect Button;
+		CUIRect Button{};
 		int IsFavorite = ServerBrowser()->IsFavorite(CurrentServerInfo.m_NetAddr);
 		ServerInfo.HSplitBottom(20.0f, &ServerInfo, &Button);
 		static int s_AddFavButton = 0;
@@ -627,7 +627,7 @@ void CMenus::RenderServerControl(CUIRect MainView)
 	static int s_ControlPage = 0;
 
 	// render background
-	CUIRect Bottom, RconExtension, TabBar, Button;
+	CUIRect Bottom{}, RconExtension{}, TabBar{}, Button{};
 	MainView.HSplitTop(20.0f, &Bottom, &MainView);
 	RenderTools()->DrawUIRect(&Bottom, ms_ColorTabbarActive, 0, 10.0f);
 	MainView.HSplitTop(20.0f, &TabBar, &MainView);
@@ -668,7 +668,7 @@ void CMenus::RenderServerControl(CUIRect MainView)
 
 	// vote menu
 	{
-		CUIRect QuickSearch;
+		CUIRect QuickSearch{};
 
 		// render quick search
 		{
@@ -733,7 +733,7 @@ void CMenus::RenderServerControl(CUIRect MainView)
 		}
 
 		// render kick reason
-		CUIRect Reason;
+		CUIRect Reason{};
 		Bottom.VSplitRight(40.0f, &Bottom, 0);
 		Bottom.VSplitRight(160.0f, &Bottom, &Reason);
 		Reason.HSplitTop(5.0f, 0, &Reason);
@@ -828,7 +828,7 @@ void CMenus::RenderServerControl(CUIRect MainView)
 void CMenus::RenderInGameNetwork(CUIRect MainView)
 {
 	CUIRect Box = MainView;
-	CUIRect Button;
+	CUIRect Button{};
 
 	int Page = g_Config.m_UiPage;
 	int NewPage = -1;
@@ -909,7 +909,7 @@ int CMenus::GhostlistFetchCallback(const char *pName, int IsDir, int StorageType
 	char aFilename[IO_MAX_PATH_LENGTH];
 	str_format(aFilename, sizeof(aFilename), "%s/%s", pSelf->m_pClient->m_Ghost.GetGhostDir(), pName);
 
-	CGhostInfo Info;
+	CGhostInfo Info{};
 	if(!pSelf->m_pClient->m_Ghost.GhostLoader()->GetGhostInfo(aFilename, &Info, pMap, pSelf->Client()->GetCurrentMapSha256(), pSelf->Client()->GetCurrentMapCrc()))
 		return 0;
 
@@ -992,7 +992,7 @@ void CMenus::RenderGhost(CUIRect MainView)
 	MainView.VSplitLeft(5.0f, 0, &MainView);
 	MainView.VSplitRight(5.0f, &MainView, 0);
 
-	CUIRect Headers, Status;
+	CUIRect Headers{}, Status{};
 	CUIRect View = MainView;
 
 	View.HSplitTop(17.0f, &Headers, &View);
@@ -1004,11 +1004,11 @@ void CMenus::RenderGhost(CUIRect MainView)
 
 	struct CColumn
 	{
-		int m_Id;
+		int m_Id{};
 		CLocConstString m_Caption;
-		float m_Width;
-		CUIRect m_Rect;
-		CUIRect m_Spacer;
+		float m_Width{};
+		CUIRect m_Rect{};
+		CUIRect m_Spacer{};
 	};
 
 	enum
@@ -1042,7 +1042,7 @@ void CMenus::RenderGhost(CUIRect MainView)
 
 	RenderTools()->DrawUIRect(&View, ColorRGBA(0, 0, 0, 0.15f), 0, 0);
 
-	CUIRect Scroll;
+	CUIRect Scroll{};
 	View.VSplitRight(20.0f, &View, &Scroll);
 
 	static float s_ScrollValue = 0;
@@ -1066,7 +1066,7 @@ void CMenus::RenderGhost(CUIRect MainView)
 	for(int i = 0; i < NumGhosts; i++)
 	{
 		const CGhostItem *pItem = &m_lGhosts[i];
-		CUIRect Row;
+		CUIRect Row{};
 		View.HSplitTop(17.0f, &Row, &View);
 
 		// make sure that only those in view can be selected
@@ -1095,7 +1095,7 @@ void CMenus::RenderGhost(CUIRect MainView)
 
 		for(int c = 0; c < NumCols; c++)
 		{
-			CUIRect Button;
+			CUIRect Button{};
 			Button.x = s_aCols[c].m_Rect.x;
 			Button.y = Row.y;
 			Button.h = Row.h;
@@ -1119,7 +1119,7 @@ void CMenus::RenderGhost(CUIRect MainView)
 			}
 			else if(Id == COL_NAME)
 			{
-				CTextCursor Cursor;
+				CTextCursor Cursor{};
 				TextRender()->SetCursor(&Cursor, Button.x, Button.y + (Button.h - 12.0f * UI()->Scale()) / 2.f, 12.0f * UI()->Scale(), TEXTFLAG_RENDER | TEXTFLAG_STOP_AT_END);
 				Cursor.m_LineWidth = Button.w;
 
@@ -1127,7 +1127,7 @@ void CMenus::RenderGhost(CUIRect MainView)
 			}
 			else if(Id == COL_TIME)
 			{
-				CTextCursor Cursor;
+				CTextCursor Cursor{};
 				TextRender()->SetCursor(&Cursor, Button.x, Button.y + (Button.h - 12.0f * UI()->Scale()) / 2.f, 12.0f * UI()->Scale(), TEXTFLAG_RENDER | TEXTFLAG_STOP_AT_END);
 				Cursor.m_LineWidth = Button.w;
 
@@ -1148,7 +1148,7 @@ void CMenus::RenderGhost(CUIRect MainView)
 	RenderTools()->DrawUIRect(&Status, ColorRGBA(1, 1, 1, 0.25f), CUI::CORNER_B, 5.0f);
 	Status.Margin(5.0f, &Status);
 
-	CUIRect Button;
+	CUIRect Button{};
 	Status.VSplitLeft(120.0f, &Button, &Status);
 
 	static int s_ReloadButton = 0;

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -76,7 +76,7 @@ bool CMenusKeyBinder::OnInput(IInput::CEvent Event)
 void CMenus::RenderSettingsGeneral(CUIRect MainView)
 {
 	char aBuf[128 + IO_MAX_PATH_LENGTH];
-	CUIRect Label, Button, Left, Right, Game, Client;
+	CUIRect Label{}, Button{}, Left{}, Right{}, Game{}, Client{};
 	MainView.HSplitTop(150.0f, &Game, &Client);
 
 	// game
@@ -238,7 +238,7 @@ void CMenus::RenderSettingsGeneral(CUIRect MainView)
 		g_Config.m_ClRefreshRate = static_cast<int>(UIEx()->DoScrollbarH(&g_Config.m_ClRefreshRate, &Button, g_Config.m_ClRefreshRate / 10000.0f) * 10000.0f + 0.1f);
 
 		Left.HSplitTop(15.0f, 0, &Left);
-		CUIRect SettingsButton;
+		CUIRect SettingsButton{};
 		Left.HSplitBottom(25.0f, &Left, &SettingsButton);
 
 		SettingsButton.HSplitTop(5.0f, 0, &SettingsButton);
@@ -253,7 +253,7 @@ void CMenus::RenderSettingsGeneral(CUIRect MainView)
 		}
 
 		Left.HSplitTop(15.0f, 0, &Left);
-		CUIRect ConfigButton;
+		CUIRect ConfigButton{};
 		Left.HSplitBottom(25.0f, &Left, &ConfigButton);
 
 		ConfigButton.HSplitTop(5.0f, 0, &ConfigButton);
@@ -268,7 +268,7 @@ void CMenus::RenderSettingsGeneral(CUIRect MainView)
 		}
 
 		Left.HSplitTop(15.0f, 0, &Left);
-		CUIRect DirectoryButton;
+		CUIRect DirectoryButton{};
 		Left.HSplitBottom(25.0f, &Left, &DirectoryButton);
 		RenderThemeSelection(Left);
 
@@ -348,7 +348,7 @@ void CMenus::SetNeedSendInfo()
 
 void CMenus::RenderSettingsPlayer(CUIRect MainView)
 {
-	CUIRect Button, Label, Dummy;
+	CUIRect Button{}, Label{}, Dummy{};
 	MainView.HSplitTop(10.0f, 0, &MainView);
 
 	char *pName = g_Config.m_PlayerName;
@@ -458,7 +458,7 @@ struct CUISkin
 
 void CMenus::RenderSettingsTee(CUIRect MainView)
 {
-	CUIRect Button, Label, Dummy, DummyLabel, SkinList, QuickSearch, QuickSearchClearButton, SkinDB, SkinPrefix, SkinPrefixLabel, DirectoryButton, RefreshButton, Eyes, EyesLabel, EyesTee, EyesRight;
+	CUIRect Button{}, Label{}, Dummy{}, DummyLabel{}, SkinList{}, QuickSearch{}, QuickSearchClearButton{}, SkinDB{}, SkinPrefix{}, SkinPrefixLabel{}, DirectoryButton{}, RefreshButton{}, Eyes{}, EyesLabel{}, EyesTee{}, EyesRight{};
 
 	static bool s_InitSkinlist = true;
 	MainView.HSplitTop(10.0f, 0, &MainView);
@@ -836,12 +836,12 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 	TextRender()->SetCurFont(NULL);
 }
 
-typedef struct
+typedef struct CKeyInfo
 {
 	CLocConstString m_Name;
-	const char *m_pCommand;
-	int m_KeyId;
-	int m_ModifierCombination;
+	const char *m_pCommand{};
+	int m_KeyId{};
+	int m_ModifierCombination{};
 } CKeyInfo;
 
 static CKeyInfo gs_aKeys[] =
@@ -915,7 +915,7 @@ void CMenus::DoSettingsControlsButtons(int Start, int Stop, CUIRect View, CUIRec
 	for(int i = Start; i < Stop; i++)
 	{
 		CKeyInfo &Key = gs_aKeys[i];
-		CUIRect Button, Label;
+		CUIRect Button{}, Label{};
 		View.HSplitTop(20.0f, &Button, &View);
 		Button.VSplitLeft(135.0f, &Label, &Button);
 
@@ -972,7 +972,7 @@ void CMenus::RenderSettingsControls(CUIRect MainView)
 	// fits the current size of controls settings
 	UiDoListboxStart(&s_ControlsList, &MainView, 10.0f, Localize("Controls"), "", 72, 1, s_SelectedControl, s_ScrollValue);
 
-	CUIRect MovementSettings, WeaponSettings, VotingSettings, ChatSettings, DummySettings, MiscSettings, ResetButton;
+	CUIRect MovementSettings{}, WeaponSettings{}, VotingSettings{}, ChatSettings{}, DummySettings{}, MiscSettings{}, ResetButton{};
 	CListboxItem Item = UiDoListboxNextItem(&s_OldSelected, false, false, true);
 	Item.m_Rect.HSplitTop(10.0f, 0, &Item.m_Rect);
 	Item.m_Rect.VSplitMid(&MovementSettings, &VotingSettings);
@@ -989,7 +989,7 @@ void CMenus::RenderSettingsControls(CUIRect MainView)
 		MovementSettings.HSplitTop(14.0f + 5.0f + 10.0f, 0, &MovementSettings);
 
 		{
-			CUIRect Button, Label;
+			CUIRect Button{}, Label{};
 			MovementSettings.HSplitTop(20.0f, &Button, &MovementSettings);
 			Button.VSplitLeft(160.0f, &Label, &Button);
 			str_format(aBuf, sizeof(aBuf), "%s: %i", Localize("Mouse sens."), g_Config.m_InpMousesens);
@@ -1001,7 +1001,7 @@ void CMenus::RenderSettingsControls(CUIRect MainView)
 		}
 
 		{
-			CUIRect Button, Label;
+			CUIRect Button{}, Label{};
 			MovementSettings.HSplitTop(20.0f, &Button, &MovementSettings);
 			Button.VSplitLeft(160.0f, &Label, &Button);
 			str_format(aBuf, sizeof(aBuf), "%s: %i", Localize("UI mouse s."), g_Config.m_UiMousesens);
@@ -1100,7 +1100,7 @@ int CMenus::RenderDropDown(int &CurDropDownState, CUIRect *pRect, int CurSelecti
 {
 	if(CurDropDownState != 0)
 	{
-		CUIRect ListRect;
+		CUIRect ListRect{};
 		pRect->HSplitTop(24.0f * PickNum, &ListRect, pRect);
 		char aBuf[1024];
 		UiDoListboxStart(&pID, &ListRect, 24.0f, "", aBuf, PickNum, 1, CurSelection, ScrollVal);
@@ -1125,7 +1125,7 @@ int CMenus::RenderDropDown(int &CurDropDownState, CUIRect *pRect, int CurSelecti
 	}
 	else
 	{
-		CUIRect Button;
+		CUIRect Button{};
 		pRect->HSplitTop(24.0f, &Button, pRect);
 		if(DoButton_MenuTab(pID, CurSelection > -1 ? pStr[CurSelection] : "", 0, &Button, CUI::CORNER_ALL, NULL, NULL, NULL, NULL, 4.0f))
 			CurDropDownState = 1;
@@ -1144,7 +1144,7 @@ int CMenus::RenderDropDown(int &CurDropDownState, CUIRect *pRect, int CurSelecti
 
 void CMenus::RenderSettingsGraphics(CUIRect MainView)
 {
-	CUIRect Button, Label;
+	CUIRect Button{}, Label{};
 	char aBuf[128];
 	bool CheckSettings = false;
 
@@ -1177,7 +1177,7 @@ void CMenus::RenderSettingsGraphics(CUIRect MainView)
 		s_InitDisplayAllVideoModes = g_Config.m_GfxDisplayAllVideoModes;
 	}
 
-	CUIRect ModeList, ModeLabel;
+	CUIRect ModeList{}, ModeLabel{};
 	MainView.VSplitLeft(350.0f, &MainView, &ModeList);
 	ModeList.HSplitTop(24.0f, &ModeLabel, &ModeList);
 	MainView.VSplitLeft(340.0f, &MainView, 0);
@@ -1344,7 +1344,7 @@ void CMenus::RenderSettingsGraphics(CUIRect MainView)
 	if(g_Config.m_GfxRefreshRate <= 1000 || NewRefreshRate < 1000)
 		g_Config.m_GfxRefreshRate = NewRefreshRate;
 
-	CUIRect Text;
+	CUIRect Text{};
 	MainView.HSplitTop(20.0f, 0, &MainView);
 	MainView.HSplitTop(20.0f, &Text, &MainView);
 	//text.VSplitLeft(15.0f, 0, &text);
@@ -1561,7 +1561,7 @@ void CMenus::RenderSettingsGraphics(CUIRect MainView)
 
 void CMenus::RenderSettingsSound(CUIRect MainView)
 {
-	CUIRect Button, Label;
+	CUIRect Button{}, Label{};
 	static int s_SndEnable = g_Config.m_SndEnable;
 	static int s_SndRate = g_Config.m_SndRate;
 
@@ -1699,7 +1699,7 @@ public:
 
 	std::string m_Name;
 	std::string m_FileName;
-	int m_CountryCode;
+	int m_CountryCode{};
 
 	bool operator<(const CLanguage &Other) const { return m_Name < Other.m_Name; }
 };
@@ -1715,7 +1715,7 @@ void LoadLanguageIndexfile(IStorage *pStorage, IConsole *pConsole, sorted_array<
 
 	char aOrigin[128];
 	char aReplacement[128];
-	CLineReader LineReader;
+	CLineReader LineReader{};
 	LineReader.Init(File);
 	char *pLine;
 	while((pLine = LineReader.Get()))
@@ -1793,7 +1793,7 @@ void CMenus::RenderLanguageSelection(CUIRect MainView)
 
 		if(Item.m_Visible)
 		{
-			CUIRect Rect;
+			CUIRect Rect{};
 			Item.m_Rect.VSplitLeft(Item.m_Rect.h * 2.0f, &Rect, &Item.m_Rect);
 			Rect.VMargin(6.0f, &Rect);
 			Rect.HMargin(3.0f, &Rect);
@@ -1817,7 +1817,7 @@ void CMenus::RenderLanguageSelection(CUIRect MainView)
 void CMenus::RenderSettings(CUIRect MainView)
 {
 	// render background
-	CUIRect Temp, TabBar, RestartWarning;
+	CUIRect Temp{}, TabBar{}, RestartWarning{};
 	MainView.VSplitRight(120.0f, &MainView, &TabBar);
 	RenderTools()->DrawUIRect(&MainView, ms_ColorTabbarActive, CUI::CORNER_B, 10.0f);
 	MainView.Margin(10.0f, &MainView);
@@ -1827,7 +1827,7 @@ void CMenus::RenderSettings(CUIRect MainView)
 
 	MainView.HSplitTop(10.0f, 0, &MainView);
 
-	CUIRect Button;
+	CUIRect Button{};
 
 	const char *aTabs[] = {
 		Localize("Language"),
@@ -1929,7 +1929,7 @@ ColorHSLA CMenus::RenderHSLColorPicker(const CUIRect *pRect, unsigned int *pColo
 	const float OutlineSize = 3.0f;
 	Outline.a *= UI()->ButtonColorMul(pColor);
 
-	CUIRect Rect;
+	CUIRect Rect{};
 	pRect->Margin(OutlineSize, &Rect);
 
 	RenderTools()->DrawUIRect(pRect, Outline, CUI::CORNER_ALL, 4.0f);
@@ -1939,7 +1939,7 @@ ColorHSLA CMenus::RenderHSLColorPicker(const CUIRect *pRect, unsigned int *pColo
 	{
 		if(ms_ColorPicker.m_Active)
 		{
-			CUIRect PickerRect;
+			CUIRect PickerRect{};
 			PickerRect.x = ms_ColorPicker.m_X;
 			PickerRect.y = ms_ColorPicker.m_Y;
 			PickerRect.w = ms_ColorPicker.ms_Width;
@@ -1964,7 +1964,7 @@ ColorHSLA CMenus::RenderHSLColorPicker(const CUIRect *pRect, unsigned int *pColo
 ColorHSLA CMenus::RenderHSLScrollbars(CUIRect *pRect, unsigned int *pColor, bool Alpha, bool ClampedLight)
 {
 	ColorHSLA Color(*pColor, Alpha);
-	CUIRect Preview, Button, Label;
+	CUIRect Preview{}, Button{}, Label{};
 	char aBuf[32];
 	float *paComponent[] = {&Color.h, &Color.s, &Color.l, &Color.a};
 	const char *aLabels[] = {Localize("Hue"), Localize("Sat."), Localize("Lht."), Localize("Alpha")};
@@ -2254,7 +2254,7 @@ ColorHSLA CMenus::RenderHSLScrollbars(CUIRect *pRect, unsigned int *pColor, bool
 
 		RenderTools()->DrawUIRect(&Button, ColorRGBA(0.15f, 0.15f, 0.15f, 1.0f), CUI::CORNER_ALL, 1.0f);
 
-		CUIRect Rail;
+		CUIRect Rail{};
 		Button.Margin(2.0f, &Rail);
 
 		str_format(aBuf, sizeof(aBuf), "%s: %03d", aLabels[i], (int)(*paComponent[i] * 255));
@@ -2304,8 +2304,8 @@ void CMenus::RenderSettingsHUD(CUIRect MainView)
 {
 	static int s_CurTab = 0;
 
-	CUIRect TabLabel1, TabLabel2, Column,
-		Section, SectionTwo;
+	CUIRect TabLabel1{}, TabLabel2{}, Column{},
+		Section{}, SectionTwo{};
 
 	MainView.HSplitTop(20, &TabLabel1, &MainView);
 	TabLabel1.VSplitMid(&TabLabel1, &TabLabel2);
@@ -2399,7 +2399,7 @@ void CMenus::RenderSettingsHUD(CUIRect MainView)
 		MainView.Margin(5.0f, &MainView);
 
 		{
-			CUIRect Button, Label;
+			CUIRect Button{}, Label{};
 			MainView.HSplitTop(5.0f, &Button, &MainView);
 			MainView.HSplitTop(20.0f, &Button, &MainView);
 			Button.VSplitLeft(45.0f, &Label, &Button);
@@ -2408,7 +2408,7 @@ void CMenus::RenderSettingsHUD(CUIRect MainView)
 		}
 
 		{
-			CUIRect Button, Label;
+			CUIRect Button{}, Label{};
 			MainView.HSplitTop(5.0f, &Button, &MainView);
 			MainView.HSplitTop(20.0f, &Button, &MainView);
 			Button.VSplitLeft(45.0f, &Label, &Button);
@@ -2497,7 +2497,7 @@ void CMenus::RenderSettingsHUD(CUIRect MainView)
 		const float X = 5.0f + RealMsgPaddingX / 2.0f + MainView.x;
 		float Y = MainView.y;
 
-		CTextCursor Cursor;
+		CTextCursor Cursor{};
 		TextRender()->SetCursor(&Cursor, X, Y, RealFontSize, TEXTFLAG_RENDER);
 
 		str_copy(aBuf, Client()->PlayerName(), sizeof(aBuf));
@@ -2652,7 +2652,7 @@ void CMenus::RenderSettingsHUD(CUIRect MainView)
 
 void CMenus::RenderSettingsDDNet(CUIRect MainView)
 {
-	CUIRect Button, Left, Right, LeftLeft, Demo, Gameplay, Miscellaneous, Label, Background;
+	CUIRect Button{}, Left{}, Right{}, LeftLeft{}, Demo{}, Gameplay{}, Miscellaneous{}, Label{}, Background{};
 
 	bool CheckSettings = false;
 	static int s_InpMouseOld = g_Config.m_InpMouseOld;
@@ -2858,7 +2858,7 @@ void CMenus::RenderSettingsDDNet(CUIRect MainView)
 	Left.VSplitRight(10.0f, &Left, 0x0);
 	Right.VSplitLeft(10.0f, 0x0, &Right);
 	Left.HSplitTop(25.0f, 0x0, &Left);
-	CUIRect TempLabel;
+	CUIRect TempLabel{};
 	Left.HSplitTop(25.0f, &TempLabel, &Left);
 	Left.HSplitTop(5.0f, 0x0, &Left);
 

--- a/src/game/client/components/menus_settings_assets.cpp
+++ b/src/game/client/components/menus_settings_assets.cpp
@@ -18,7 +18,7 @@ typedef std::function<void()> TMenuAssetScanLoadedFunc;
 
 struct SMenuAssetScanUser
 {
-	void *m_pUser;
+	void *m_pUser{};
 	TMenuAssetScanLoadedFunc m_LoadedFunc;
 };
 
@@ -44,7 +44,7 @@ void CMenus::LoadEntities(SCustomEntities *pEntitiesItem, void *pUser)
 		for(int i = 0; i < MAP_IMAGE_MOD_TYPE_COUNT; ++i)
 		{
 			str_format(aBuff, sizeof(aBuff), "editor/entities_clear/%s.png", gs_aModEntitiesNames[i]);
-			CImageInfo ImgInfo;
+			CImageInfo ImgInfo{};
 			if(pThis->Graphics()->LoadPNG(&ImgInfo, aBuff, IStorage::TYPE_ALL))
 			{
 				pEntitiesItem->m_aImages[i].m_Texture = pThis->Graphics()->LoadTextureRaw(ImgInfo.m_Width, ImgInfo.m_Height, ImgInfo.m_Format, ImgInfo.m_pData, ImgInfo.m_Format, 0);
@@ -60,7 +60,7 @@ void CMenus::LoadEntities(SCustomEntities *pEntitiesItem, void *pUser)
 		for(int i = 0; i < MAP_IMAGE_MOD_TYPE_COUNT; ++i)
 		{
 			str_format(aBuff, sizeof(aBuff), "assets/entities/%s/%s.png", pEntitiesItem->m_aName, gs_aModEntitiesNames[i]);
-			CImageInfo ImgInfo;
+			CImageInfo ImgInfo{};
 			if(pThis->Graphics()->LoadPNG(&ImgInfo, aBuff, IStorage::TYPE_ALL))
 			{
 				pEntitiesItem->m_aImages[i].m_Texture = pThis->Graphics()->LoadTextureRaw(ImgInfo.m_Width, ImgInfo.m_Height, ImgInfo.m_Format, ImgInfo.m_pData, ImgInfo.m_Format, 0);
@@ -133,7 +133,7 @@ static void LoadAsset(TName *pAssetItem, const char *pAssetName, IGraphics *pGra
 	if(str_comp(pAssetItem->m_aName, "default") == 0)
 	{
 		str_format(aBuff, sizeof(aBuff), "%s.png", pAssetName);
-		CImageInfo ImgInfo;
+		CImageInfo ImgInfo{};
 		if(pGraphics->LoadPNG(&ImgInfo, aBuff, IStorage::TYPE_ALL))
 		{
 			pAssetItem->m_RenderTexture = pGraphics->LoadTextureRaw(ImgInfo.m_Width, ImgInfo.m_Height, ImgInfo.m_Format, ImgInfo.m_pData, ImgInfo.m_Format, 0);
@@ -143,7 +143,7 @@ static void LoadAsset(TName *pAssetItem, const char *pAssetName, IGraphics *pGra
 	else
 	{
 		str_format(aBuff, sizeof(aBuff), "assets/%s/%s.png", pAssetName, pAssetItem->m_aName);
-		CImageInfo ImgInfo;
+		CImageInfo ImgInfo{};
 		if(pGraphics->LoadPNG(&ImgInfo, aBuff, IStorage::TYPE_ALL))
 		{
 			pAssetItem->m_RenderTexture = pGraphics->LoadTextureRaw(ImgInfo.m_Width, ImgInfo.m_Height, ImgInfo.m_Format, ImgInfo.m_pData, ImgInfo.m_Format, 0);
@@ -366,7 +366,7 @@ int InitSearchList(sorted_array<const TName *> &SearchList, sorted_array<TName> 
 
 void CMenus::RenderSettingsCustom(CUIRect MainView)
 {
-	CUIRect Label, CustomList, QuickSearch, QuickSearchClearButton, DirectoryButton, Page1Tab, Page2Tab, Page3Tab, Page4Tab, Page5Tab, ReloadButton;
+	CUIRect Label{}, CustomList{}, QuickSearch{}, QuickSearchClearButton{}, DirectoryButton{}, Page1Tab{}, Page2Tab{}, Page3Tab{}, Page4Tab{}, Page5Tab{}, ReloadButton{};
 
 	MainView.HSplitTop(20, &Label, &MainView);
 	float TabsW = Label.w;
@@ -538,7 +538,7 @@ void CMenus::RenderSettingsCustom(CUIRect MainView)
 		ItemRect.Margin(Margin / 2, &ItemRect);
 		if(Item.m_Visible)
 		{
-			CUIRect TextureRect;
+			CUIRect TextureRect{};
 			ItemRect.HSplitTop(15, &ItemRect, &TextureRect);
 			TextureRect.HSplitTop(10, NULL, &TextureRect);
 			UI()->DoLabelScaled(&ItemRect, s->m_aName, ItemRect.h - 2, TEXTALIGN_CENTER);

--- a/src/game/client/components/menus_start.cpp
+++ b/src/game/client/components/menus_start.cpp
@@ -33,10 +33,10 @@ void CMenus::RenderStartMenu(CUIRect MainView)
 	const float Rounding = 10.0f;
 	const float VMargin = MainView.w / 2 - 190.0f;
 
-	CUIRect Button;
+	CUIRect Button{};
 	int NewPage = -1;
 
-	CUIRect ExtMenu;
+	CUIRect ExtMenu{};
 	MainView.VSplitLeft(30.0f, 0, &ExtMenu);
 	ExtMenu.VSplitLeft(100.0f, &ExtMenu, 0);
 
@@ -107,7 +107,7 @@ void CMenus::RenderStartMenu(CUIRect MainView)
 	if(DoButton_Menu(&s_NewsButton, Localize("News"), 0, &Button, 0, CUI::CORNER_ALL, 5.0f, 0.0f, vec4(0.0f, 0.0f, 0.0f, 0.5f), g_Config.m_UiUnreadNews ? vec4(0.0f, 1.0f, 0.0f, 0.25f) : vec4(0.0f, 0.0f, 0.0f, 0.25f)) || CheckHotKey(KEY_N))
 		NewPage = PAGE_NEWS;
 
-	CUIRect Menu;
+	CUIRect Menu{};
 	MainView.VMargin(VMargin, &Menu);
 	Menu.HSplitBottom(25.0f, &Menu, 0);
 
@@ -191,7 +191,7 @@ void CMenus::RenderStartMenu(CUIRect MainView)
 	}
 
 	// render version
-	CUIRect VersionUpdate, CurVersion;
+	CUIRect VersionUpdate{}, CurVersion{};
 	MainView.HSplitBottom(30.0f, 0, 0);
 	MainView.HSplitBottom(20.0f, 0, &VersionUpdate);
 

--- a/src/game/client/components/nameplates.cpp
+++ b/src/game/client/components/nameplates.cpp
@@ -95,7 +95,7 @@ void CNamePlates::RenderNameplatePos(vec2 Position, const CNetObj_PlayerInfo *pP
 			if(m_aNamePlates[ClientID].m_NameTextContainerIndex != -1)
 				TextRender()->DeleteTextContainer(m_aNamePlates[ClientID].m_NameTextContainerIndex);
 
-			CTextCursor Cursor;
+			CTextCursor Cursor{};
 			TextRender()->SetCursor(&Cursor, 0, 0, FontSize, TEXTFLAG_RENDER);
 			Cursor.m_LineWidth = -1;
 
@@ -121,7 +121,7 @@ void CNamePlates::RenderNameplatePos(vec2 Position, const CNetObj_PlayerInfo *pP
 				if(m_aNamePlates[ClientID].m_ClanNameTextContainerIndex != -1)
 					TextRender()->DeleteTextContainer(m_aNamePlates[ClientID].m_ClanNameTextContainerIndex);
 
-				CTextCursor Cursor;
+				CTextCursor Cursor{};
 				TextRender()->SetCursor(&Cursor, 0, 0, FontSizeClan, TEXTFLAG_RENDER);
 				Cursor.m_LineWidth = -1;
 

--- a/src/game/client/components/particles.h
+++ b/src/game/client/components/particles.h
@@ -71,7 +71,7 @@ public:
 	virtual void OnInit() override;
 
 private:
-	int m_ParticleQuadContainerIndex;
+	int m_ParticleQuadContainerIndex{};
 
 	enum
 	{
@@ -79,8 +79,8 @@ private:
 	};
 
 	CParticle m_aParticles[MAX_PARTICLES];
-	int m_FirstFree;
-	int m_aFirstPart[NUM_GROUPS];
+	int m_FirstFree{};
+	int m_aFirstPart[NUM_GROUPS]{};
 
 	void RenderGroup(int Group);
 	void Update(float TimePassed);

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -130,8 +130,8 @@ void CPlayers::RenderHookCollLine(
 	int ClientID,
 	float Intra)
 {
-	CNetObj_Character Prev;
-	CNetObj_Character Player;
+	CNetObj_Character Prev{};
+	CNetObj_Character Player{};
 	Prev = *pPrevChar;
 	Player = *pPlayerChar;
 
@@ -275,8 +275,8 @@ void CPlayers::RenderHook(
 	int ClientID,
 	float Intra)
 {
-	CNetObj_Character Prev;
-	CNetObj_Character Player;
+	CNetObj_Character Prev{};
+	CNetObj_Character Player{};
 	Prev = *pPrevChar;
 	Player = *pPlayerChar;
 
@@ -356,8 +356,8 @@ void CPlayers::RenderPlayer(
 	int ClientID,
 	float Intra)
 {
-	CNetObj_Character Prev;
-	CNetObj_Character Player;
+	CNetObj_Character Prev{};
+	CNetObj_Character Player{};
 	Prev = *pPrevChar;
 	Player = *pPlayerChar;
 
@@ -427,7 +427,7 @@ void CPlayers::RenderPlayer(
 		// Don't do a moon walk outside the left border
 		WalkTime += 1;
 	}
-	CAnimState State;
+	CAnimState State{};
 	State.Set(&g_pData->m_aAnimations[ANIM_BASE], 0);
 
 	if(InAir)

--- a/src/game/client/components/race_demo.cpp
+++ b/src/game/client/components/race_demo.cpp
@@ -198,7 +198,7 @@ int CRaceDemo::RaceDemolistFetchCallback(const CFsFileInfo *pInfo, int IsDir, in
 	if(IsDir || !str_endswith(pInfo->m_pName, ".demo") || !str_startswith(pInfo->m_pName, pParam->pMap) || pInfo->m_pName[MapLen] != '_')
 		return 0;
 
-	CDemoItem Item;
+	CDemoItem Item{};
 	str_truncate(Item.m_aName, sizeof(Item.m_aName), pInfo->m_pName, str_length(pInfo->m_pName) - 5);
 
 	const char *pTime = Item.m_aName + MapLen + 1;
@@ -235,7 +235,7 @@ bool CRaceDemo::CheckDemo(int Time)
 	std::vector<CDemoItem> lDemos;
 	CDemoListParam Param = {this, &lDemos, Client()->GetCurrentMap()};
 	m_RaceDemosLoadStartTime = tw::time_get();
-	SRaceDemoFetchUser User;
+	SRaceDemoFetchUser User{};
 	User.m_pParam = &Param;
 	User.m_pThis = this;
 	Storage()->ListDirectoryInfo(IStorage::TYPE_SAVE, ms_pRaceDemoDir, RaceDemolistFetchCallback, &User);

--- a/src/game/client/components/race_demo.h
+++ b/src/game/client/components/race_demo.h
@@ -19,7 +19,7 @@ class CRaceDemo : public CComponent
 
 	static const char *ms_pRaceDemoDir;
 
-	char m_aTmpFilename[128];
+	char m_aTmpFilename[128]{};
 
 	int m_RaceState;
 	int m_RaceStartTick;
@@ -36,7 +36,7 @@ class CRaceDemo : public CComponent
 	bool CheckDemo(int Time);
 
 public:
-	bool m_AllowRestart;
+	bool m_AllowRestart{};
 
 	CRaceDemo();
 	virtual int Sizeof() const override { return sizeof(*this); }

--- a/src/game/client/components/scoreboard.cpp
+++ b/src/game/client/components/scoreboard.cpp
@@ -114,7 +114,7 @@ void CScoreboard::RenderSpectators(float x, float y, float w)
 	y += 30.0f;
 	bool Multiple = false;
 
-	CTextCursor Cursor;
+	CTextCursor Cursor{};
 	TextRender()->SetCursor(&Cursor, x + 10.0f, y, 22.0f, TEXTFLAG_RENDER);
 	Cursor.m_LineWidth = w - 20.0f;
 	Cursor.m_MaxLines = 4;
@@ -321,7 +321,7 @@ void CScoreboard::RenderScoreboard(float x, float y, float w, int Team, const ch
 
 	// render player entries
 	y += HeadlineFontsize * 2.0f;
-	CTextCursor Cursor;
+	CTextCursor Cursor{};
 
 	int rendered = 0;
 	if(upper16)

--- a/src/game/client/components/scoreboard.h
+++ b/src/game/client/components/scoreboard.h
@@ -15,7 +15,7 @@ class CScoreboard : public CComponent
 
 	const char *GetClanName(int Team);
 
-	bool m_Active;
+	bool m_Active{};
 
 public:
 	CScoreboard();
@@ -32,7 +32,7 @@ public:
 	virtual void OnMessage(int MsgType, void *pRawMsg) override;
 
 private:
-	float m_ServerRecord;
+	float m_ServerRecord{};
 };
 
 #endif

--- a/src/game/client/components/skins.cpp
+++ b/src/game/client/components/skins.cpp
@@ -49,7 +49,7 @@ CSkins::CGetPngFile::CGetPngFile(CSkins *pSkins, const char *pUrl, IStorage *pSt
 
 struct SSkinScanUser
 {
-	CSkins *m_pThis;
+	CSkins *m_pThis{};
 	CSkins::TSkinLoadedCBFunc m_SkinLoadedFunc;
 };
 
@@ -118,7 +118,7 @@ static void CheckMetrics(CSkin::SSkinMetricVariable &Metrics, uint8_t *pImg, int
 
 int CSkins::LoadSkin(const char *pName, const char *pPath, int DirType)
 {
-	CImageInfo Info;
+	CImageInfo Info{};
 	if(!LoadSkinPNG(Info, pName, pPath, DirType))
 		return 0;
 	return LoadSkin(pName, Info);

--- a/src/game/client/components/skins.h
+++ b/src/game/client/components/skins.h
@@ -21,7 +21,7 @@ public:
 
 	public:
 		CGetPngFile(CSkins *pSkins, const char *pUrl, IStorage *pStorage, const char *pDest);
-		CImageInfo m_Info;
+		CImageInfo m_Info{};
 	};
 
 	struct CDownloadSkin

--- a/src/game/client/components/sounds.cpp
+++ b/src/game/client/components/sounds.cpp
@@ -186,7 +186,7 @@ void CSounds::Enqueue(int Channel, int SetId)
 
 void CSounds::PlayAndRecord(int Channel, int SetId, float Vol, vec2 Pos)
 {
-	CNetMsg_Sv_SoundGlobal Msg;
+	CNetMsg_Sv_SoundGlobal Msg{};
 	Msg.m_SoundID = SetId;
 	Client()->SendPackMsgActive(&Msg, MSGFLAG_NOSEND | MSGFLAG_RECORD);
 

--- a/src/game/client/components/spectator.cpp
+++ b/src/game/client/components/spectator.cpp
@@ -464,7 +464,7 @@ void CSpectator::Spectate(int SpectatorID)
 	if(m_pClient->m_Snap.m_SpecInfo.m_SpectatorID == SpectatorID)
 		return;
 
-	CNetMsg_Cl_SetSpectatorMode Msg;
+	CNetMsg_Cl_SetSpectatorMode Msg{};
 	Msg.m_SpectatorID = SpectatorID;
 	Client()->SendPackMsgActive(&Msg, MSGFLAG_VITAL);
 }

--- a/src/game/client/components/spectator.h
+++ b/src/game/client/components/spectator.h
@@ -13,10 +13,10 @@ class CSpectator : public CComponent
 		NO_SELECTION = -3,
 	};
 
-	bool m_Active;
-	bool m_WasActive;
+	bool m_Active{};
+	bool m_WasActive{};
 
-	int m_SelectedSpectatorID;
+	int m_SelectedSpectatorID{};
 	vec2 m_SelectorMouse;
 
 	float m_OldMouseX;

--- a/src/game/client/components/statboard.cpp
+++ b/src/game/client/components/statboard.cpp
@@ -289,7 +289,7 @@ void CStatboard::RenderGlobalStats()
 		RenderTools()->RenderTee(pIdleState, &Teeinfo, EMOTE_NORMAL, vec2(1, 0), TeeRenderPos);
 
 		char aBuf[128];
-		CTextCursor Cursor;
+		CTextCursor Cursor{};
 		TextRender()->SetCursor(&Cursor, x + 64, y + (LineHeight * 0.95f - FontSize) / 2.f, FontSize, TEXTFLAG_RENDER | TEXTFLAG_STOP_AT_END);
 		Cursor.m_LineWidth = 220;
 		TextRender()->TextEx(&Cursor, m_pClient->m_aClients[pInfo->m_ClientID].m_aName, -1);
@@ -441,7 +441,7 @@ std::string CStatboard::ReplaceCommata(char *pStr)
 void CStatboard::FormatStats(char *pDest, size_t DestSize)
 {
 	// server stats
-	CServerInfo CurrentServerInfo;
+	CServerInfo CurrentServerInfo{};
 	Client()->GetServerInfo(&CurrentServerInfo);
 	char aServerStats[1024];
 	str_format(aServerStats, sizeof(aServerStats), "Servername,Game-type,Map\n%s,%s,%s", ReplaceCommata(CurrentServerInfo.m_aName).c_str(), ReplaceCommata(CurrentServerInfo.m_aGameType).c_str(), ReplaceCommata(CurrentServerInfo.m_aMap).c_str());

--- a/src/game/client/components/tooltips.cpp
+++ b/src/game/client/components/tooltips.cpp
@@ -73,7 +73,7 @@ void CTooltips::OnRender()
 
 		const float MARGIN = 5.0f;
 
-		CUIRect Rect;
+		CUIRect Rect{};
 		Rect.w = Tooltip.m_WidthHint;
 		if(Tooltip.m_WidthHint < 0.0f)
 			Rect.w = TextRender()->TextWidth(0, 14.0f, Tooltip.m_pText, -1, -1.0f) + 4.0f;

--- a/src/game/client/components/tooltips.h
+++ b/src/game/client/components/tooltips.h
@@ -25,7 +25,7 @@ class CTooltips : public CComponent
 {
 	std::unordered_map<uintptr_t, CTooltip> m_Tooltips;
 	std::optional<std::reference_wrapper<CTooltip>> m_ActiveTooltip;
-	int64_t HoverTime;
+	int64_t HoverTime{};
 
 	/**
      * The passed tooltip is only actually set if there is no currently active tooltip.

--- a/src/game/client/components/voting.h
+++ b/src/game/client/components/voting.h
@@ -17,8 +17,8 @@ class CVoting : public CComponent
 	static void ConVote(IConsole::IResult *pResult, void *pUserData);
 
 	int64_t m_Closetime;
-	char m_aDescription[VOTE_DESC_LENGTH];
-	char m_aReason[VOTE_REASON_LENGTH];
+	char m_aDescription[VOTE_DESC_LENGTH]{};
+	char m_aReason[VOTE_REASON_LENGTH]{};
 	int m_Voted;
 	int m_Yes, m_No, m_Pass, m_Total;
 
@@ -27,12 +27,12 @@ class CVoting : public CComponent
 	void Callvote(const char *pType, const char *pValue, const char *pReason);
 
 public:
-	int m_NumVoteOptions;
-	CVoteOptionClient *m_pFirst;
-	CVoteOptionClient *m_pLast;
+	int m_NumVoteOptions{};
+	CVoteOptionClient *m_pFirst{};
+	CVoteOptionClient *m_pLast{};
 
-	CVoteOptionClient *m_pRecycleFirst;
-	CVoteOptionClient *m_pRecycleLast;
+	CVoteOptionClient *m_pRecycleFirst{};
+	CVoteOptionClient *m_pRecycleLast{};
 
 	CVoting();
 	virtual int Sizeof() const override { return sizeof(*this); }

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -903,7 +903,7 @@ void CGameClient::ProcessEvents()
 	int Num = Client()->SnapNumItems(SnapType);
 	for(int Index = 0; Index < Num; Index++)
 	{
-		IClient::CSnapItem Item;
+		IClient::CSnapItem Item{};
 		const void *pData = Client()->SnapGetItem(SnapType, Index, &Item);
 
 		if(Item.m_Type == NETEVENTTYPE_DAMAGEIND)
@@ -1011,7 +1011,7 @@ static CGameInfo GetGameInfo(const CNetObj_GameInfoEx *pInfoEx, int InfoExSize, 
 		Race = Race || FastCap || DDRace;
 	}
 
-	CGameInfo Info;
+	CGameInfo Info{};
 	Info.m_FlagStartsRace = FastCap;
 	Info.m_TimeScore = Race;
 	Info.m_UnlimitedAmmo = Race;
@@ -1125,7 +1125,7 @@ void CGameClient::OnNewSnapshot()
 		int Num = Client()->SnapNumItems(IClient::SNAP_CURRENT);
 		for(int Index = 0; Index < Num; Index++)
 		{
-			IClient::CSnapItem Item;
+			IClient::CSnapItem Item{};
 			void *pData = Client()->SnapGetItem(IClient::SNAP_CURRENT, Index, &Item);
 			if(m_NetObjHandler.ValidateObj(Item.m_Type, pData, Item.m_DataSize) != 0)
 			{
@@ -1153,7 +1153,7 @@ void CGameClient::OnNewSnapshot()
 				aMessage[i] = (char)('a' + (rand() % ('z' - 'a')));
 			aMessage[MsgLen] = 0;
 
-			CNetMsg_Cl_Say Msg;
+			CNetMsg_Cl_Say Msg{};
 			Msg.m_Team = rand() & 1;
 			Msg.m_pMessage = aMessage;
 			Client()->SendPackMsgActive(&Msg, MSGFLAG_VITAL);
@@ -1177,7 +1177,7 @@ void CGameClient::OnNewSnapshot()
 		int Num = Client()->SnapNumItems(IClient::SNAP_CURRENT);
 		for(int i = 0; i < Num; i++)
 		{
-			IClient::CSnapItem Item;
+			IClient::CSnapItem Item{};
 			const void *pData = Client()->SnapGetItem(IClient::SNAP_CURRENT, i, &Item);
 
 			if(Item.m_Type == NETOBJTYPE_CLIENTINFO)
@@ -1411,7 +1411,7 @@ void CGameClient::OnNewSnapshot()
 					continue;
 				}
 				FoundGameInfoEx = true;
-				CServerInfo ServerInfo;
+				CServerInfo ServerInfo{};
 				Client()->GetServerInfo(&ServerInfo);
 				m_GameInfo = GetGameInfo((const CNetObj_GameInfoEx *)pData, Client()->SnapItemSize(IClient::SNAP_CURRENT, i), &ServerInfo);
 			}
@@ -1494,7 +1494,7 @@ void CGameClient::OnNewSnapshot()
 
 	if(!FoundGameInfoEx)
 	{
-		CServerInfo ServerInfo;
+		CServerInfo ServerInfo{};
 		Client()->GetServerInfo(&ServerInfo);
 		m_GameInfo = GetGameInfo(0, 0, &ServerInfo);
 	}
@@ -1599,7 +1599,7 @@ void CGameClient::OnNewSnapshot()
 		}
 	}
 
-	CServerInfo CurrentServerInfo;
+	CServerInfo CurrentServerInfo{};
 	Client()->GetServerInfo(&CurrentServerInfo);
 	CTuningParams StandardTuning;
 	if(CurrentServerInfo.m_aGameType[0] != '0')
@@ -1648,7 +1648,7 @@ void CGameClient::OnNewSnapshot()
 	if(m_ShowOthers[g_Config.m_ClDummy] == SHOW_OTHERS_NOT_SET || (m_ShowOthers[g_Config.m_ClDummy] != SHOW_OTHERS_NOT_SET && m_ShowOthers[g_Config.m_ClDummy] != g_Config.m_ClShowOthers))
 	{
 		{
-			CNetMsg_Cl_ShowOthers Msg;
+			CNetMsg_Cl_ShowOthers Msg{};
 			Msg.m_Show = g_Config.m_ClShowOthers;
 			Client()->SendPackMsgActive(&Msg, MSGFLAG_VITAL);
 		}
@@ -1668,7 +1668,7 @@ void CGameClient::OnNewSnapshot()
 
 	if(ZoomToSend != m_LastZoom || Graphics()->ScreenAspect() != m_LastScreenAspect || (Client()->DummyConnected() && !m_LastDummyConnected))
 	{
-		CNetMsg_Cl_ShowDistance Msg;
+		CNetMsg_Cl_ShowDistance Msg{};
 		float x, y;
 		RenderTools()->CalcScreenParams(Graphics()->ScreenAspect(), ZoomToSend, &x, &y);
 		Msg.m_X = x;
@@ -2055,7 +2055,7 @@ void CGameClient::CClientData::Reset()
 
 void CGameClient::SendSwitchTeam(int Team)
 {
-	CNetMsg_Cl_SetTeam Msg;
+	CNetMsg_Cl_SetTeam Msg{};
 	Msg.m_Team = Team;
 	Client()->SendPackMsgActive(&Msg, MSGFLAG_VITAL);
 
@@ -2067,7 +2067,7 @@ void CGameClient::SendInfo(bool Start)
 {
 	if(Start)
 	{
-		CNetMsg_Cl_StartInfo Msg;
+		CNetMsg_Cl_StartInfo Msg{};
 		Msg.m_pName = Client()->PlayerName();
 		Msg.m_pClan = g_Config.m_PlayerClan;
 		Msg.m_Country = g_Config.m_PlayerCountry;
@@ -2082,7 +2082,7 @@ void CGameClient::SendInfo(bool Start)
 	}
 	else
 	{
-		CNetMsg_Cl_ChangeInfo Msg;
+		CNetMsg_Cl_ChangeInfo Msg{};
 		Msg.m_pName = Client()->PlayerName();
 		Msg.m_pClan = g_Config.m_PlayerClan;
 		Msg.m_Country = g_Config.m_PlayerCountry;
@@ -2101,7 +2101,7 @@ void CGameClient::SendDummyInfo(bool Start)
 {
 	if(Start)
 	{
-		CNetMsg_Cl_StartInfo Msg;
+		CNetMsg_Cl_StartInfo Msg{};
 		Msg.m_pName = Client()->DummyName();
 		Msg.m_pClan = g_Config.m_ClDummyClan;
 		Msg.m_Country = g_Config.m_ClDummyCountry;
@@ -2116,7 +2116,7 @@ void CGameClient::SendDummyInfo(bool Start)
 	}
 	else
 	{
-		CNetMsg_Cl_ChangeInfo Msg;
+		CNetMsg_Cl_ChangeInfo Msg{};
 		Msg.m_pName = Client()->DummyName();
 		Msg.m_pClan = g_Config.m_ClDummyClan;
 		Msg.m_Country = g_Config.m_ClDummyCountry;
@@ -2787,7 +2787,7 @@ void CGameClient::LoadGameSkin(const char *pPath, bool AsDir)
 			str_format(aPath, sizeof(aPath), "assets/game/%s.png", pPath);
 	}
 
-	CImageInfo ImgInfo;
+	CImageInfo ImgInfo{};
 	bool PngLoaded = Graphics()->LoadPNG(&ImgInfo, aPath, IStorage::TYPE_ALL);
 	if(!PngLoaded && !IsDefault)
 	{
@@ -2949,7 +2949,7 @@ void CGameClient::LoadEmoticonsSkin(const char *pPath, bool AsDir)
 			str_format(aPath, sizeof(aPath), "assets/emoticons/%s.png", pPath);
 	}
 
-	CImageInfo ImgInfo;
+	CImageInfo ImgInfo{};
 	bool PngLoaded = Graphics()->LoadPNG(&ImgInfo, aPath, IStorage::TYPE_ALL);
 	if(!PngLoaded && !IsDefault)
 	{
@@ -3003,7 +3003,7 @@ void CGameClient::LoadParticlesSkin(const char *pPath, bool AsDir)
 			str_format(aPath, sizeof(aPath), "assets/particles/%s.png", pPath);
 	}
 
-	CImageInfo ImgInfo;
+	CImageInfo ImgInfo{};
 	bool PngLoaded = Graphics()->LoadPNG(&ImgInfo, aPath, IStorage::TYPE_ALL);
 	if(!PngLoaded && !IsDefault)
 	{
@@ -3089,7 +3089,7 @@ void CGameClient::LoadHudSkin(const char *pPath, bool AsDir)
 			str_format(aPath, sizeof(aPath), "assets/hud/%s.png", pPath);
 	}
 
-	CImageInfo ImgInfo;
+	CImageInfo ImgInfo{};
 	bool PngLoaded = Graphics()->LoadPNG(&ImgInfo, aPath, IStorage::TYPE_ALL);
 	if(!PngLoaded && !IsDefault)
 	{
@@ -3259,7 +3259,7 @@ void CGameClient::SnapCollectEntities()
 
 	for(int Index = 0; Index < NumSnapItems; Index++)
 	{
-		IClient::CSnapItem Item;
+		IClient::CSnapItem Item{};
 		const void *pData = Client()->SnapGetItem(IClient::SNAP_CURRENT, Index, &Item);
 		if(Item.m_Type == NETOBJTYPE_ENTITYEX)
 			aItemEx.push_back({Item, pData, 0});

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -161,7 +161,7 @@ private:
 		CStack();
 		void Add(class CComponent *pComponent);
 
-		class CComponent *m_paComponents[MAX_COMPONENTS];
+		class CComponent *m_paComponents[MAX_COMPONENTS]{};
 		int m_Num;
 	};
 
@@ -417,23 +417,23 @@ public:
 
 	class CClientStats
 	{
-		int m_IngameTicks;
-		int m_JoinTick;
-		bool m_Active;
+		int m_IngameTicks{};
+		int m_JoinTick{};
+		bool m_Active{};
 
 	public:
 		CClientStats();
 
-		int m_aFragsWith[NUM_WEAPONS];
-		int m_aDeathsFrom[NUM_WEAPONS];
-		int m_Frags;
-		int m_Deaths;
-		int m_Suicides;
-		int m_BestSpree;
-		int m_CurrentSpree;
+		int m_aFragsWith[NUM_WEAPONS]{};
+		int m_aDeathsFrom[NUM_WEAPONS]{};
+		int m_Frags{};
+		int m_Deaths{};
+		int m_Suicides{};
+		int m_BestSpree{};
+		int m_CurrentSpree{};
 
-		int m_FlagGrabs;
-		int m_FlagCaptures;
+		int m_FlagGrabs{};
+		int m_FlagCaptures{};
 
 		void Reset();
 

--- a/src/game/client/lineinput.h
+++ b/src/game/client/lineinput.h
@@ -13,14 +13,14 @@ class CLineInput
 		MAX_SIZE = 512,
 		MAX_CHARS = MAX_SIZE / 2,
 	};
-	char m_aStr[MAX_SIZE];
-	int m_Len;
-	int m_CursorPos;
-	int m_NumChars;
+	char m_aStr[MAX_SIZE]{};
+	int m_Len{};
+	int m_CursorPos{};
+	int m_NumChars{};
 
-	char m_aDisplayStr[MAX_SIZE + IInput::INPUT_TEXT_SIZE + 2];
-	int m_FakeLen;
-	int m_FakeCursorPos;
+	char m_aDisplayStr[MAX_SIZE + IInput::INPUT_TEXT_SIZE + 2]{};
+	int m_FakeLen{};
+	int m_FakeCursorPos{};
 
 public:
 	enum ELineInputChanges

--- a/src/game/client/prediction/entities/character.h
+++ b/src/game/client/prediction/entities/character.h
@@ -75,14 +75,14 @@ public:
 	bool CanCollide(int ClientID);
 	bool SameTeam(int ClientID);
 	bool m_Super;
-	bool m_SuperJump;
-	bool m_Jetpack;
-	bool m_NinjaJetpack;
-	int m_FreezeTime;
-	bool m_FrozenLastTick;
-	bool m_DeepFreeze;
-	bool m_LiveFreeze;
-	bool m_EndlessHook;
+	bool m_SuperJump{};
+	bool m_Jetpack{};
+	bool m_NinjaJetpack{};
+	int m_FreezeTime{};
+	bool m_FrozenLastTick{};
+	bool m_DeepFreeze{};
+	bool m_LiveFreeze{};
+	bool m_EndlessHook{};
 	enum
 	{
 		HIT_ALL = 0,
@@ -91,16 +91,16 @@ public:
 		DISABLE_HIT_GRENADE = 4,
 		DISABLE_HIT_LASER = 8
 	};
-	int m_Hit;
-	int m_TuneZone;
+	int m_Hit{};
+	int m_TuneZone{};
 	vec2 m_PrevPos;
 	vec2 m_PrevPrevPos;
 	int m_TeleCheckpoint;
 
-	int m_TileIndex;
-	int m_TileFIndex;
+	int m_TileIndex{};
+	int m_TileFIndex{};
 
-	int m_MoveRestrictions;
+	int m_MoveRestrictions{};
 	bool m_LastRefillJumps;
 
 	// Setters/Getters because i don't want to modify vanilla vars access modifiers
@@ -136,10 +136,10 @@ public:
 	void Read(CNetObj_Character *pChar, CNetObj_DDNetCharacter *pExtended, CNetObj_DDNetCharacterDisplayInfo *pExtendedDisplayInfo, bool IsLocal);
 	void SetCoreWorld(CGameWorld *pGameWorld);
 
-	int m_LastSnapWeapon;
+	int m_LastSnapWeapon{};
 	int m_LastJetpackStrength;
-	bool m_KeepHooked;
-	int m_GameTeam;
+	bool m_KeepHooked{};
+	int m_GameTeam{};
 	bool m_CanMoveInFreeze;
 
 	bool Match(CCharacter *pChar);
@@ -149,25 +149,25 @@ public:
 
 private:
 	// weapon info
-	int m_aHitObjects[10];
+	int m_aHitObjects[10]{};
 	int m_NumObjectsHit;
 
 	int m_LastWeapon;
 	int m_QueuedWeapon;
 
 	int m_ReloadTimer;
-	int m_AttackTick;
+	int m_AttackTick{};
 
 	// these are non-heldback inputs
-	CNetObj_PlayerInput m_LatestPrevInput;
-	CNetObj_PlayerInput m_LatestInput;
+	CNetObj_PlayerInput m_LatestPrevInput{};
+	CNetObj_PlayerInput m_LatestInput{};
 
 	// input
-	CNetObj_PlayerInput m_PrevInput;
-	CNetObj_PlayerInput m_Input;
-	CNetObj_PlayerInput m_SavedInput;
+	CNetObj_PlayerInput m_PrevInput{};
+	CNetObj_PlayerInput m_Input{};
+	CNetObj_PlayerInput m_SavedInput{};
 
-	int m_NumInputs;
+	int m_NumInputs{};
 
 	// the player core for the physics
 	CCharacterCore m_Core;
@@ -185,8 +185,8 @@ private:
 
 	int m_StrongWeakID;
 
-	int m_LastWeaponSwitchTick;
-	int m_LastTuneZoneTick;
+	int m_LastWeaponSwitchTick{};
+	int m_LastTuneZoneTick{};
 };
 
 enum

--- a/src/game/client/prediction/entities/laser.h
+++ b/src/game/client/prediction/entities/laser.h
@@ -29,9 +29,9 @@ private:
 	vec2 m_From;
 	vec2 m_Dir;
 	vec2 m_TelePos;
-	bool m_WasTele;
+	bool m_WasTele{};
 	float m_Energy;
-	int m_Bounces;
+	int m_Bounces{};
 	int m_EvalTick;
 	int m_Owner;
 

--- a/src/game/client/prediction/entities/projectile.h
+++ b/src/game/client/prediction/entities/projectile.h
@@ -47,13 +47,13 @@ private:
 	int m_Owner;
 	int m_Type;
 	int m_SoundImpact;
-	float m_Force;
+	float m_Force{};
 	int m_StartTick;
 	bool m_Explosive;
 
 	// DDRace
 
-	int m_Bouncing;
+	int m_Bouncing{};
 	bool m_Freeze;
 	int m_TuneZone;
 };

--- a/src/game/client/prediction/entity.h
+++ b/src/game/client/prediction/entity.h
@@ -56,8 +56,8 @@ public:
 	bool GameLayerClipped(vec2 CheckPos);
 	float m_ProximityRadius;
 	vec2 m_Pos;
-	int m_Number;
-	int m_Layer;
+	int m_Number{};
+	int m_Layer{};
 
 	int m_SnapTicks;
 	int m_DestroyTick;

--- a/src/game/client/prediction/gameworld.h
+++ b/src/game/client/prediction/gameworld.h
@@ -44,7 +44,7 @@ public:
 	std::list<class CCharacter *> IntersectedCharacters(vec2 Pos0, vec2 Pos1, float Radius, class CEntity *pNotThis = 0);
 
 	int m_GameTick;
-	int m_GameTickSpeed;
+	int m_GameTickSpeed{};
 	CCollision *m_pCollision;
 
 	// getter for server variables
@@ -73,9 +73,9 @@ public:
 		bool m_IsSolo;
 		bool m_UseTuneZones;
 		bool m_BugDDRaceInput;
-	} m_WorldConfig;
+	} m_WorldConfig{};
 
-	bool m_IsValidCopy;
+	bool m_IsValidCopy{};
 	CGameWorld *m_pParent;
 	CGameWorld *m_pChild;
 
@@ -88,7 +88,7 @@ public:
 	CEntity *FindMatch(int ObjID, int ObjType, const void *pObjData);
 	void Clear();
 
-	CTuningParams *m_pTuningList;
+	CTuningParams *m_pTuningList{};
 	CTuningParams *TuningList() { return m_pTuningList; }
 	CTuningParams *GetTuning(int i) { return &TuningList()[i]; }
 
@@ -96,9 +96,9 @@ private:
 	void RemoveEntities();
 
 	CEntity *m_pNextTraverseEntity = nullptr;
-	CEntity *m_apFirstEntityTypes[NUM_ENTTYPES];
+	CEntity *m_apFirstEntityTypes[NUM_ENTTYPES]{};
 
-	class CCharacter *m_apCharacters[MAX_CLIENTS];
+	class CCharacter *m_apCharacters[MAX_CLIENTS]{};
 };
 
 class CCharOrder

--- a/src/game/client/projectile_data.cpp
+++ b/src/game/client/projectile_data.cpp
@@ -17,7 +17,7 @@ CProjectileData ExtractProjectileInfo(const CNetObj_Projectile *pProj, CGameWorl
 {
 	if(UseProjectileExtraInfo(pProj))
 	{
-		CNetObj_DDNetProjectile Proj;
+		CNetObj_DDNetProjectile Proj{};
 		mem_copy(&Proj, pProj, sizeof(Proj));
 		return ExtractProjectileInfoDDNet(&Proj, pGameWorld);
 	}

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -211,7 +211,7 @@ void CUI::ClipEnable(const CUIRect *pRect)
 	if(IsClipped())
 	{
 		const CUIRect *pOldRect = ClipArea();
-		CUIRect Intersection;
+		CUIRect Intersection{};
 		Intersection.x = std::max(pRect->x, pOldRect->x);
 		Intersection.y = std::max(pRect->y, pOldRect->y);
 		Intersection.w = std::min(pRect->x + pRect->w, pOldRect->x + pOldRect->w) - pRect->x;
@@ -522,7 +522,7 @@ float CUI::DoTextLabel(float x, float y, float w, float h, const char *pText, fl
 		AlignmentHori = x + w - tw;
 	}
 
-	CTextCursor Cursor;
+	CTextCursor Cursor{};
 	TextRender()->SetCursor(&Cursor, AlignmentHori, AlignmentVert, Size, Flags);
 	Cursor.m_LineWidth = (float)LabelProps.m_MaxWidth;
 	if(LabelProps.m_pSelCursor)
@@ -578,7 +578,7 @@ void CUI::DoLabel(CUIElement::SUIElementRect &RectEl, const CUIRect *pRect, cons
 	float AlignmentVert = pRect->y + (pRect->h - AlignedSize) / 2.f;
 	float AlignmentHori = 0;
 
-	CTextCursor Cursor;
+	CTextCursor Cursor{};
 
 	int Flags = TEXTFLAG_RENDER | (LabelProps.m_StopAtEnd ? TEXTFLAG_STOP_AT_END : 0);
 
@@ -661,7 +661,7 @@ void CUI::DoLabelStreamed(CUIElement::SUIElementRect &RectEl, float x, float y, 
 		else
 			RectEl.m_Text.clear();
 
-		CUIRect TmpRect;
+		CUIRect TmpRect{};
 		TmpRect.x = x;
 		TmpRect.y = y;
 		TmpRect.w = w;

--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -135,17 +135,17 @@ public:
 	struct SUIElementRect
 	{
 	public:
-		int m_UIRectQuadContainer;
-		int m_UITextContainer;
+		int m_UIRectQuadContainer{};
+		int m_UITextContainer{};
 
-		float m_X;
-		float m_Y;
-		float m_Width;
-		float m_Height;
+		float m_X{};
+		float m_Y{};
+		float m_Width{};
+		float m_Height{};
 
 		std::string m_Text;
 
-		CTextCursor m_Cursor;
+		CTextCursor m_Cursor{};
 
 		STextRenderColor m_TextColor;
 		STextRenderColor m_TextOutlineColor;
@@ -198,18 +198,18 @@ class CUI
 	const void *m_pBecomingHotItem;
 	const void *m_pActiveTooltipItem;
 	float m_MouseX, m_MouseY; // in gui space
-	float m_MouseDeltaX, m_MouseDeltaY; // in gui space
+	float m_MouseDeltaX{}, m_MouseDeltaY{}; // in gui space
 	float m_MouseWorldX, m_MouseWorldY; // in world space
 	unsigned m_MouseButtons;
 	unsigned m_LastMouseButtons;
 
-	CUIRect m_Screen;
+	CUIRect m_Screen{};
 
 	std::vector<CUIRect> m_Clips;
 	void UpdateClipping();
 
-	class IGraphics *m_pGraphics;
-	class ITextRender *m_pTextRender;
+	class IGraphics *m_pGraphics{};
+	class ITextRender *m_pTextRender{};
 
 	std::vector<CUIElement *> m_OwnUIElements; // ui elements maintained by CUI class
 	std::vector<CUIElement *> m_UIElements;

--- a/src/game/client/ui_ex.cpp
+++ b/src/game/client/ui_ex.cpp
@@ -48,10 +48,10 @@ float CUIEx::DoScrollbarV(const void *pID, const CUIRect *pRect, float Current)
 	Current = clamp(Current, 0.0f, 1.0f);
 
 	// layout
-	CUIRect Rail;
+	CUIRect Rail{};
 	pRect->Margin(5.0f, &Rail);
 
-	CUIRect Handle;
+	CUIRect Handle{};
 	Rail.HSplitTop(clamp(33.0f, Rail.w, Rail.h / 3.0f), &Handle, 0);
 	Handle.y = Rail.y + (Rail.h - Handle.h) * Current;
 
@@ -125,13 +125,13 @@ float CUIEx::DoScrollbarH(const void *pID, const CUIRect *pRect, float Current, 
 	Current = clamp(Current, 0.0f, 1.0f);
 
 	// layout
-	CUIRect Rail;
+	CUIRect Rail{};
 	if(pColorInner)
 		Rail = *pRect;
 	else
 		pRect->HMargin(5.0f, &Rail);
 
-	CUIRect Handle;
+	CUIRect Handle{};
 	Rail.VSplitLeft(pColorInner ? 8.0f : clamp(33.0f, Rail.h, Rail.w / 3.0f), &Handle, 0);
 	Handle.x += (Rail.w - Handle.w) * Current;
 
@@ -187,7 +187,7 @@ float CUIEx::DoScrollbarH(const void *pID, const CUIRect *pRect, float Current, 
 	// render
 	if(pColorInner)
 	{
-		CUIRect Slider;
+		CUIRect Slider{};
 		Handle.VMargin(-2.0f, &Slider);
 		Slider.HMargin(-3.0f, &Slider);
 		RenderTools()->DrawUIRect(&Slider, ColorRGBA(0.15f, 0.15f, 0.15f, 1.0f), CUI::CORNER_ALL, 5.0f);
@@ -549,7 +549,7 @@ bool CUIEx::DoEditBox(const void *pID, const CUIRect *pRect, char *pStr, unsigne
 	UI()->ClipEnable(pRect);
 	Textbox.x -= *pOffset;
 
-	CTextCursor SelCursor;
+	CTextCursor SelCursor{};
 	TextRender()->SetCursor(&SelCursor, 0, 0, 16, 0);
 
 	bool HasMouseSel = false;
@@ -627,8 +627,8 @@ bool CUIEx::DoEditBox(const void *pID, const CUIRect *pRect, char *pStr, unsigne
 
 bool CUIEx::DoClearableEditBox(const void *pID, const void *pClearID, const CUIRect *pRect, char *pStr, unsigned StrSize, float FontSize, float *pOffset, bool Hidden, int Corners, const SUIExEditBoxProperties &Properties)
 {
-	CUIRect EditBox;
-	CUIRect ClearButton;
+	CUIRect EditBox{};
+	CUIRect ClearButton{};
 	pRect->VSplitRight(15.0f, &EditBox, &ClearButton);
 	bool ReturnValue = DoEditBox(pID, &EditBox, pStr, StrSize, FontSize, pOffset, Hidden, Corners & ~CUI::CORNER_R, Properties);
 

--- a/src/game/client/ui_ex.h
+++ b/src/game/client/ui_ex.h
@@ -21,15 +21,15 @@ struct SUIExEditBoxProperties
 
 class CUIEx
 {
-	CUI *m_pUI;
-	IInput *m_pInput;
-	ITextRender *m_pTextRender;
-	IKernel *m_pKernel;
-	IGraphics *m_pGraphics;
-	CRenderTools *m_pRenderTools;
+	CUI *m_pUI{};
+	IInput *m_pInput{};
+	ITextRender *m_pTextRender{};
+	IKernel *m_pKernel{};
+	IGraphics *m_pGraphics{};
+	CRenderTools *m_pRenderTools{};
 
-	IInput::CEvent *m_pInputEventsArray;
-	int *m_pInputEventCount;
+	IInput::CEvent *m_pInputEventsArray{};
+	int *m_pInputEventCount{};
 
 	bool m_MouseIsPress = false;
 	bool m_HasSelection = false;

--- a/src/game/collision.h
+++ b/src/game/collision.h
@@ -114,7 +114,7 @@ public:
 	class CSwitchTile *SwitchLayer() { return m_pSwitch; }
 	class CTuneTile *TuneLayer() { return m_pTune; }
 	class CLayers *Layers() { return m_pLayers; }
-	int m_NumSwitchers;
+	int m_NumSwitchers{};
 
 	struct SSwitchers
 	{

--- a/src/game/editor/auto_map.cpp
+++ b/src/game/editor/auto_map.cpp
@@ -51,7 +51,7 @@ void CAutoMapper::Load(const char *pTileName)
 	if(!RulesFile)
 		return;
 
-	CLineReader LineReader;
+	CLineReader LineReader{};
 	LineReader.Init(RulesFile);
 
 	CConfiguration *pCurrentConf = 0;
@@ -186,7 +186,7 @@ void CAutoMapper::Load(const char *pTileName)
 						char aOrientation4[128] = "";
 						sscanf(str_trim_words(pLine, pWord), "%d %127s %127s %127s %127s", &ID, aOrientation1, aOrientation2, aOrientation3, aOrientation4);
 
-						CIndexInfo NewIndexInfo;
+						CIndexInfo NewIndexInfo{};
 						NewIndexInfo.m_ID = ID;
 						NewIndexInfo.m_Flag = 0;
 						NewIndexInfo.m_TestFlag = false;

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -824,8 +824,8 @@ void CEditor::DoToolbar(CUIRect ToolBar)
 	bool ModPressed = Input()->ModifierIsPressed();
 	bool ShiftPressed = Input()->KeyIsPressed(KEY_LSHIFT) || Input()->KeyIsPressed(KEY_RSHIFT);
 
-	CUIRect TB_Top, TB_Bottom;
-	CUIRect Button;
+	CUIRect TB_Top{}, TB_Bottom{};
+	CUIRect Button{};
 
 	ToolBar.HSplitMid(&TB_Top, &TB_Bottom, 5.0f);
 
@@ -2532,7 +2532,7 @@ void CEditor::DoMapEditor(CUIRect View)
 
 			if(UI()->ActiveItem() == s_pEditorID)
 			{
-				CUIRect r;
+				CUIRect r{};
 				r.x = s_StartWx;
 				r.y = s_StartWy;
 				r.w = wx - s_StartWx;
@@ -2828,7 +2828,7 @@ void CEditor::DoMapEditor(CUIRect View)
 		Graphics()->TextureClear();
 		Graphics()->LinesBegin();
 
-		CUIRect r;
+		CUIRect r{};
 		r.x = GetSelectedGroup()->m_ClipX;
 		r.y = GetSelectedGroup()->m_ClipY;
 		r.w = GetSelectedGroup()->m_ClipW;
@@ -2910,7 +2910,7 @@ void CEditor::DoMapEditor(CUIRect View)
 					m_WorldOffsetX, m_WorldOffsetY,
 					100.0f, 100.0f, 0.0f, 0.0f, Aspect, 1.0f, aPoints);
 
-				CUIRect r;
+				CUIRect r{};
 				r.x = aPoints[0];
 				r.y = aPoints[1];
 				r.w = aPoints[2] - aPoints[0];
@@ -2977,16 +2977,16 @@ int CEditor::DoProperties(CUIRect *pToolBox, CProperty *pProps, int *pIDs, int *
 
 	for(int i = 0; pProps[i].m_pName; i++)
 	{
-		CUIRect Slot;
+		CUIRect Slot{};
 		pToolBox->HSplitTop(13.0f, &Slot, pToolBox);
-		CUIRect Label, Shifter;
+		CUIRect Label{}, Shifter{};
 		Slot.VSplitMid(&Label, &Shifter);
 		Shifter.HMargin(1.0f, &Shifter);
 		UI()->DoLabel(&Label, pProps[i].m_pName, 10.0f, TEXTALIGN_LEFT);
 
 		if(pProps[i].m_Type == PROPTYPE_INT_STEP)
 		{
-			CUIRect Inc, Dec;
+			CUIRect Inc{}, Dec{};
 			char aBuf[64];
 
 			Shifter.VSplitRight(10.0f, &Shifter, &Inc);
@@ -3011,7 +3011,7 @@ int CEditor::DoProperties(CUIRect *pToolBox, CProperty *pProps, int *pIDs, int *
 		}
 		else if(pProps[i].m_Type == PROPTYPE_BOOL)
 		{
-			CUIRect No, Yes;
+			CUIRect No{}, Yes{};
 			Shifter.VSplitMid(&No, &Yes);
 			if(DoButton_ButtonDec(&pIDs[i], "No", !pProps[i].m_Value, &No, 0, ""))
 			{
@@ -3035,7 +3035,7 @@ int CEditor::DoProperties(CUIRect *pToolBox, CProperty *pProps, int *pIDs, int *
 		}
 		else if(pProps[i].m_Type == PROPTYPE_ANGLE_SCROLL)
 		{
-			CUIRect Inc, Dec;
+			CUIRect Inc{}, Dec{};
 			Shifter.VSplitRight(10.0f, &Shifter, &Inc);
 			Shifter.VSplitLeft(10.0f, &Dec, &Shifter);
 			bool Shift = Input()->KeyIsPressed(KEY_LSHIFT) || Input()->KeyIsPressed(KEY_RSHIFT);
@@ -3065,7 +3065,7 @@ int CEditor::DoProperties(CUIRect *pToolBox, CProperty *pProps, int *pIDs, int *
 			int NewColor = 0;
 
 			// extra space
-			CUIRect ColorBox, ColorSlots;
+			CUIRect ColorBox{}, ColorSlots{};
 
 			pToolBox->HSplitTop(3.0f * 13.0f, &Slot, pToolBox);
 			Slot.VSplitMid(&ColorBox, &ColorSlots);
@@ -3145,7 +3145,7 @@ int CEditor::DoProperties(CUIRect *pToolBox, CProperty *pProps, int *pIDs, int *
 		}
 		else if(pProps[i].m_Type == PROPTYPE_SHIFT)
 		{
-			CUIRect Left, Right, Up, Down;
+			CUIRect Left{}, Right{}, Up{}, Down{};
 			Shifter.VSplitMid(&Left, &Up, 2.0f);
 			Left.VSplitLeft(10.0f, &Left, &Shifter);
 			Shifter.VSplitRight(10.0f, &Shifter, &Right);
@@ -3216,7 +3216,7 @@ int CEditor::DoProperties(CUIRect *pToolBox, CProperty *pProps, int *pIDs, int *
 		}
 		else if(pProps[i].m_Type == PROPTYPE_ENVELOPE)
 		{
-			CUIRect Inc, Dec;
+			CUIRect Inc{}, Dec{};
 			char aBuf[64];
 			int CurValue = pProps[i].m_Value;
 
@@ -3256,7 +3256,7 @@ void CEditor::RenderLayers(CUIRect ToolBox, CUIRect View)
 		return;
 
 	CUIRect LayersBox = ToolBox;
-	CUIRect Slot, Button;
+	CUIRect Slot{}, Button{};
 	char aBuf[64];
 
 	float LayersHeight = 12.0f; // Height of AddGroup button
@@ -3275,7 +3275,7 @@ void CEditor::RenderLayers(CUIRect ToolBox, CUIRect View)
 
 	if(LayersHeight > LayersBox.h) // Do we even need a scrollbar?
 	{
-		CUIRect Scroll;
+		CUIRect Scroll{};
 		LayersBox.VSplitRight(20.0f, &LayersBox, &Scroll);
 		s_ScrollValue = UIEx()->DoScrollbarV(&s_ScrollValue, &Scroll, s_ScrollValue);
 
@@ -3311,7 +3311,7 @@ void CEditor::RenderLayers(CUIRect ToolBox, CUIRect View)
 				continue;
 			}
 
-			CUIRect VisibleToggle;
+			CUIRect VisibleToggle{};
 			if(LayerCur >= LayerStartAt)
 			{
 				LayersBox.HSplitTop(12.0f, &Slot, &LayersBox);
@@ -3842,7 +3842,7 @@ int CEditor::PopupImage(CEditor *pEditor, CUIRect View, void *pContext)
 	static int s_ReplaceButton = 0;
 	static int s_RemoveButton = 0;
 
-	CUIRect Slot;
+	CUIRect Slot{};
 	View.HSplitTop(2.0f, &Slot, &View);
 	View.HSplitTop(12.0f, &Slot, &View);
 	CEditorImage *pImg = pEditor->m_Map.m_lImages[pEditor->m_SelectedImage];
@@ -3894,7 +3894,7 @@ int CEditor::PopupSound(CEditor *pEditor, CUIRect View, void *pContext)
 	static int s_ReplaceButton = 0;
 	static int s_RemoveButton = 0;
 
-	CUIRect Slot;
+	CUIRect Slot{};
 	View.HSplitTop(2.0f, &Slot, &View);
 	View.HSplitTop(12.0f, &Slot, &View);
 	if(pEditor->DoButton_MenuItem(&s_ReplaceButton, "Replace", 0, &Slot, 0, "Replaces the sound with a new one"))
@@ -3982,7 +3982,7 @@ void CEditor::RenderImages(CUIRect ToolBox, CUIRect View)
 
 	if(ImagesHeight > ToolBox.h) // Do we even need a scrollbar?
 	{
-		CUIRect Scroll;
+		CUIRect Scroll{};
 		ToolBox.VSplitRight(20.0f, &ToolBox, &Scroll);
 		s_ScrollValue = UIEx()->DoScrollbarV(&s_ScrollValue, &Scroll, s_ScrollValue);
 
@@ -4008,7 +4008,7 @@ void CEditor::RenderImages(CUIRect ToolBox, CUIRect View)
 
 	for(int e = 0; e < 2; e++) // two passes, first embedded, then external
 	{
-		CUIRect Slot;
+		CUIRect Slot{};
 
 		if(ImageCur > ImageStopAt)
 			break;
@@ -4158,7 +4158,7 @@ void CEditor::RenderImages(CUIRect ToolBox, CUIRect View)
 	int i = m_SelectedImage;
 	if(i != -1 && i < m_Map.m_lImages.size())
 	{
-		CUIRect r;
+		CUIRect r{};
 		View.Margin(10.0f, &r);
 		if(r.h < r.w)
 			r.w = r.h;
@@ -4179,7 +4179,7 @@ void CEditor::RenderImages(CUIRect ToolBox, CUIRect View)
 	//if(ImageCur + 27.0f > ImageStopAt)
 	//	return;
 
-	CUIRect Slot;
+	CUIRect Slot{};
 	ToolBox.HSplitTop(5.0f, &Slot, &ToolBox);
 
 	// new image
@@ -4200,7 +4200,7 @@ void CEditor::RenderSounds(CUIRect ToolBox, CUIRect View)
 
 	if(SoundsHeight > ToolBox.h) // Do we even need a scrollbar?
 	{
-		CUIRect Scroll;
+		CUIRect Scroll{};
 		ToolBox.VSplitRight(20.0f, &ToolBox, &Scroll);
 		s_ScrollValue = UIEx()->DoScrollbarV(&s_ScrollValue, &Scroll, s_ScrollValue);
 
@@ -4224,7 +4224,7 @@ void CEditor::RenderSounds(CUIRect ToolBox, CUIRect View)
 	float SoundStopAt = SoundsHeight - ScrollDifference * (1 - s_ScrollValue);
 	float SoundCur = 0.0f;
 
-	CUIRect Slot;
+	CUIRect Slot{};
 
 	ToolBox.HSplitTop(15.0f, &Slot, &ToolBox);
 	UI()->DoLabel(&Slot, "Embedded", 12.0f, TEXTALIGN_CENTER);
@@ -4319,7 +4319,7 @@ static int EditorListdirCallback(const char *pName, int IsDir, int StorageType, 
 				   (pEditor->m_FileDialogFileType == CEditor::FILETYPE_SOUND && !str_endswith(pName, ".opus")))))
 		return 0;
 
-	CEditor::CFilelistItem Item;
+	CEditor::CFilelistItem Item{};
 	str_copy(Item.m_aFilename, pName, sizeof(Item.m_aFilename));
 	if(IsDir)
 		str_format(Item.m_aName, sizeof(Item.m_aName), "%s/", pName);
@@ -4342,7 +4342,7 @@ void CEditor::AddFileDialogEntry(int Index, CUIRect *pView)
 	if(m_FilesCur - 1 < m_FilesStartAt || m_FilesCur >= m_FilesStopAt)
 		return;
 
-	CUIRect Button, FileIcon;
+	CUIRect Button{}, FileIcon{};
 	pView->HSplitTop(15.0f, &Button, pView);
 	pView->HSplitTop(2.0f, 0, pView);
 	Button.VSplitLeft(Button.h, &FileIcon, &Button);
@@ -4372,7 +4372,7 @@ void CEditor::RenderFileDialog()
 	// GUI coordsys
 	UI()->MapScreen();
 	CUIRect View = *UI()->Screen();
-	CUIRect Preview;
+	CUIRect Preview{};
 	float Width = View.w, Height = View.h;
 
 	RenderTools()->DrawUIRect(&View, ColorRGBA(0, 0, 0, 0.25f), 0, 0);
@@ -4381,7 +4381,7 @@ void CEditor::RenderFileDialog()
 	RenderTools()->DrawUIRect(&View, ColorRGBA(0, 0, 0, 0.75f), CUI::CORNER_ALL, 5.0f);
 	View.Margin(10.0f, &View);
 
-	CUIRect Title, FileBox, FileBoxLabel, ButtonBar, Scroll, PathBox;
+	CUIRect Title{}, FileBox{}, FileBoxLabel{}, ButtonBar{}, Scroll{}, PathBox{};
 	View.HSplitTop(18.0f, &Title, &View);
 	View.HSplitTop(5.0f, 0, &View); // some spacing
 	View.HSplitBottom(14.0f, &View, &ButtonBar);
@@ -4430,7 +4430,7 @@ void CEditor::RenderFileDialog()
 	{
 		//searchbox
 		FileBox.VSplitRight(250, &FileBox, 0);
-		CUIRect ClearBox;
+		CUIRect ClearBox{};
 		FileBox.VSplitRight(15, &FileBox, &ClearBox);
 
 		UI()->DoLabel(&FileBoxLabel, "Search:", 10.0f, TEXTALIGN_LEFT);
@@ -4610,7 +4610,7 @@ void CEditor::RenderFileDialog()
 	static int s_NewFolderButton = 0;
 	static int s_MapInfoButton = 0;
 
-	CUIRect Button;
+	CUIRect Button{};
 	ButtonBar.VSplitRight(50.0f, &ButtonBar, &Button);
 	bool IsDir = m_FilesSelectedIndex >= 0 && m_FileList[m_FilesSelectedIndex].m_IsDir;
 	if(DoButton_Editor(&s_OkButton, IsDir ? "Open" : m_pFileDialogButtonText, 0, &Button, 0, 0) || m_FileDialogActivate)
@@ -4704,7 +4704,7 @@ void CEditor::FilelistPopulate(int StorageType)
 	m_FileList.clear();
 	if(m_FileDialogStorageType != IStorage::TYPE_SAVE && !str_comp(m_pFileDialogPath, "maps"))
 	{
-		CFilelistItem Item;
+		CFilelistItem Item{};
 		str_copy(Item.m_aFilename, "downloadedmaps", sizeof(Item.m_aFilename));
 		str_copy(Item.m_aName, "downloadedmaps/", sizeof(Item.m_aName));
 		Item.m_IsDir = true;
@@ -4755,7 +4755,7 @@ void CEditor::InvokeFileDialog(int StorageType, int FileType, const char *pTitle
 
 void CEditor::RenderModebar(CUIRect View)
 {
-	CUIRect Button;
+	CUIRect Button{};
 
 	// mode buttons
 	{
@@ -4797,7 +4797,7 @@ void CEditor::RenderModebar(CUIRect View)
 
 void CEditor::RenderStatusbar(CUIRect View)
 {
-	CUIRect Button;
+	CUIRect Button{};
 	View.VSplitRight(60.0f, &View, &Button);
 	static int s_EnvelopeButton = 0;
 	int MouseButton = DoButton_Editor(&s_EnvelopeButton, "Envelopes", m_ShowEnvelopeEditor, &Button, 0, "Toggles the envelope editor.");
@@ -4885,7 +4885,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 	if(m_SelectedEnvelope >= 0 && m_SelectedEnvelope < m_Map.m_lEnvelopes.size())
 		pEnvelope = m_Map.m_lEnvelopes[m_SelectedEnvelope];
 
-	CUIRect ToolBar, CurveBar, ColorBar;
+	CUIRect ToolBar{}, CurveBar{}, ColorBar{};
 	View.HSplitTop(15.0f, &ToolBar, &View);
 	View.HSplitTop(15.0f, &CurveBar, &View);
 	ToolBar.Margin(2.0f, &ToolBar);
@@ -4895,7 +4895,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 
 	// do the toolbar
 	{
-		CUIRect Button;
+		CUIRect Button{};
 		CEnvelope *pNewEnv = 0;
 
 		ToolBar.VSplitRight(50.0f, &ToolBar, &Button);
@@ -4954,7 +4954,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 			}
 		}
 
-		CUIRect Shifter, Inc, Dec;
+		CUIRect Shifter{}, Inc{}, Dec{};
 		ToolBar.VSplitLeft(60.0f, &Shifter, &ToolBar);
 		Shifter.VSplitRight(15.0f, &Shifter, &Inc);
 		Shifter.VSplitLeft(15.0f, &Dec, &Shifter);
@@ -5027,7 +5027,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 
 		if(pEnvelope)
 		{
-			CUIRect Button;
+			CUIRect Button{};
 
 			ToolBar.VSplitLeft(15.0f, &Button, &ToolBar);
 
@@ -5158,7 +5158,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 
 				//dbg_msg("", "%f", end_time);
 
-				CUIRect v;
+				CUIRect v{};
 				v.x = CurveBar.x + (t0 + (t1 - t0) * 0.5f) * CurveBar.w;
 				v.y = CurveBar.y;
 				v.h = CurveBar.h;
@@ -5201,7 +5201,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 				//				float y0 = (fx2f(envelope->points[i].values[c])-bottom)/(top-bottom);
 				float x1 = pEnvelope->m_lPoints[i + 1].m_Time / 1000.0f / EndTime;
 				//float y1 = (fx2f(envelope->points[i+1].values[c])-bottom)/(top-bottom);
-				CUIRect v;
+				CUIRect v{};
 				v.x = ColorBar.x + x0 * ColorBar.w;
 				v.y = ColorBar.y;
 				v.w = (x1 - x0) * ColorBar.w;
@@ -5245,7 +5245,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 				{
 					float x0 = pEnvelope->m_lPoints[i].m_Time / 1000.0f / EndTime;
 					float y0 = (fx2f(pEnvelope->m_lPoints[i].m_aValues[c]) - Bottom) / (Top - Bottom);
-					CUIRect Final;
+					CUIRect Final{};
 					Final.x = View.x + x0 * View.w;
 					Final.y = View.y + View.h - y0 * View.h;
 					Final.x -= 2.0f;
@@ -5374,8 +5374,8 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 			}
 			Graphics()->QuadsEnd();
 
-			CUIRect ToolBar1;
-			CUIRect ToolBar2;
+			CUIRect ToolBar1{};
+			CUIRect ToolBar2{};
 
 			ToolBar.VSplitMid(&ToolBar1, &ToolBar2);
 			if(ToolBar.w > ToolBar.h * 21)
@@ -5383,8 +5383,8 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 				ToolBar1.VMargin(3.0f, &ToolBar1);
 				ToolBar2.VMargin(3.0f, &ToolBar2);
 
-				CUIRect Label1;
-				CUIRect Label2;
+				CUIRect Label1{};
+				CUIRect Label2{};
 
 				ToolBar1.VSplitMid(&Label1, &ToolBar1);
 				ToolBar2.VSplitMid(&Label2, &ToolBar2);
@@ -5405,13 +5405,13 @@ void CEditor::RenderServerSettingsEditor(CUIRect View, bool ShowServerSettingsEd
 {
 	static int s_CommandSelectedIndex = -1;
 
-	CUIRect ToolBar;
+	CUIRect ToolBar{};
 	View.HSplitTop(20.0f, &ToolBar, &View);
 	ToolBar.Margin(2.0f, &ToolBar);
 
 	// do the toolbar
 	{
-		CUIRect Button;
+		CUIRect Button{};
 
 		// command line
 		ToolBar.VSplitLeft(5.0f, 0, &Button);
@@ -5442,7 +5442,7 @@ void CEditor::RenderServerSettingsEditor(CUIRect View, bool ShowServerSettingsEd
 
 				if(!Found)
 				{
-					CEditorMap::CSetting Setting;
+					CEditorMap::CSetting Setting{};
 					str_copy(Setting.m_aCommand, m_aSettingsCommand, sizeof(Setting.m_aCommand));
 					m_Map.m_lSettings.add(Setting);
 					s_CommandSelectedIndex = m_Map.m_lSettings.size() - 1;
@@ -5517,7 +5517,7 @@ void CEditor::RenderServerSettingsEditor(CUIRect View, bool ShowServerSettingsEd
 	View.HSplitTop(2.0f, 0, &View);
 	RenderBackground(View, m_CheckerTexture, 32.0f, 0.1f);
 
-	CUIRect ListBox;
+	CUIRect ListBox{};
 	View.Margin(1.0f, &ListBox);
 
 	float ListHeight = 17.0f * m_Map.m_lSettings.size();
@@ -5527,7 +5527,7 @@ void CEditor::RenderServerSettingsEditor(CUIRect View, bool ShowServerSettingsEd
 
 	if(ListHeight > ListBox.h) // Do we even need a scrollbar?
 	{
-		CUIRect Scroll;
+		CUIRect Scroll{};
 		ListBox.VSplitRight(20.0f, &ListBox, &Scroll);
 		s_ScrollValue = UIEx()->DoScrollbarV(&s_ScrollValue, &Scroll, s_ScrollValue);
 
@@ -5559,7 +5559,7 @@ void CEditor::RenderServerSettingsEditor(CUIRect View, bool ShowServerSettingsEd
 
 		if(ListCur >= ListStartAt)
 		{
-			CUIRect Button;
+			CUIRect Button{};
 			ListBox.HSplitTop(15.0f, &Button, &ListBox);
 			ListBox.HSplitTop(2.0f, 0, &ListBox);
 			Button.VSplitLeft(5.0f, 0, &Button);
@@ -5587,7 +5587,7 @@ int CEditor::PopupMenuFile(CEditor *pEditor, CUIRect View, void *pContext)
 	static int s_AppendButton = 0;
 	static int s_ExitButton = 0;
 
-	CUIRect Slot;
+	CUIRect Slot{};
 	View.HSplitTop(2.0f, &Slot, &View);
 	View.HSplitTop(12.0f, &Slot, &View);
 	if(pEditor->DoButton_MenuItem(&s_NewMapButton, "New", 0, &Slot, 0, "Creates a new map (ctrl+n)"))
@@ -5711,7 +5711,7 @@ void CEditor::RenderMenubar(CUIRect MenuBar)
 		(void)0;
 		*/
 
-	CUIRect Info, Close;
+	CUIRect Info{}, Close{};
 	MenuBar.VSplitLeft(40.0f, 0, &MenuBar);
 	MenuBar.VSplitRight(20.0f, &MenuBar, &Close);
 	Close.VSplitLeft(5.0f, 0, &Close);
@@ -5750,7 +5750,7 @@ void CEditor::Render()
 	// render checker
 	RenderBackground(View, m_CheckerTexture, 32.0f, 1.0f);
 
-	CUIRect MenuBar, CModeBar, ToolBar, StatusBar, ExtraEditor, ToolBox;
+	CUIRect MenuBar{}, CModeBar{}, ToolBar{}, StatusBar{}, ExtraEditor{}, ToolBox{};
 	m_ShowPicker = Input()->KeyIsPressed(KEY_SPACE) != 0 && m_Dialog == DIALOG_NONE && m_EditBoxActive == 0 && UI()->LastActiveItem() != &m_CommandBox && m_lSelectedLayers.size() == 1;
 
 	if(m_GuiActive)
@@ -6052,7 +6052,7 @@ void CEditor::Render()
 	if(g_Config.m_EdShowkeys)
 	{
 		UI()->MapScreen();
-		CTextCursor Cursor;
+		CTextCursor Cursor{};
 		TextRender()->SetCursor(&Cursor, View.x + 10, View.y + View.h - 24 - 10, 24.0f, TEXTFLAG_RENDER);
 
 		int NKeys = 0;

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -179,7 +179,7 @@ public:
 class CLayerGroup
 {
 public:
-	class CEditorMap *m_pMap;
+	class CEditorMap *m_pMap{};
 
 	array<CLayer *> m_lLayers;
 
@@ -195,7 +195,7 @@ public:
 	int m_ClipW;
 	int m_ClipH;
 
-	char m_aName[12];
+	char m_aName[12]{};
 	bool m_GameGroup;
 	bool m_Visible;
 	bool m_Collapse;
@@ -573,7 +573,7 @@ public:
 	int m_Image;
 	int m_Width;
 	int m_Height;
-	CColor m_Color;
+	CColor m_Color{};
 	int m_ColorEnv;
 	int m_ColorEnvOffset;
 	CTile *m_pTiles;
@@ -588,7 +588,7 @@ public:
 	int m_Front;
 	int m_Switch;
 	int m_Tune;
-	char m_aFileName[IO_MAX_PATH_LENGTH];
+	char m_aFileName[IO_MAX_PATH_LENGTH]{};
 };
 
 class CLayerQuads : public CLayer
@@ -1186,7 +1186,7 @@ public:
 	~CLayerTele();
 
 	CTeleTile *m_pTeleTile;
-	unsigned char m_TeleNum;
+	unsigned char m_TeleNum{};
 
 	void Resize(int NewW, int NewH) override;
 	void Shift(int Direction) override;
@@ -1206,9 +1206,9 @@ public:
 	~CLayerSpeedup();
 
 	CSpeedupTile *m_pSpeedupTile;
-	int m_SpeedupForce;
-	int m_SpeedupMaxSpeed;
-	int m_SpeedupAngle;
+	int m_SpeedupForce{};
+	int m_SpeedupMaxSpeed{};
+	int m_SpeedupAngle{};
 
 	void Resize(int NewW, int NewH) override;
 	void Shift(int Direction) override;
@@ -1236,8 +1236,8 @@ public:
 	~CLayerSwitch();
 
 	CSwitchTile *m_pSwitchTile;
-	unsigned char m_SwitchNumber;
-	unsigned char m_SwitchDelay;
+	unsigned char m_SwitchNumber{};
+	unsigned char m_SwitchDelay{};
 
 	void Resize(int NewW, int NewH) override;
 	void Shift(int Direction) override;
@@ -1257,7 +1257,7 @@ public:
 	~CLayerTune();
 
 	CTuneTile *m_pTuneTile;
-	unsigned char m_TuningNumber;
+	unsigned char m_TuningNumber{};
 
 	void Resize(int NewW, int NewH) override;
 	void Shift(int Direction) override;

--- a/src/game/editor/io.cpp
+++ b/src/game/editor/io.cpp
@@ -234,14 +234,14 @@ int CEditorMap::Save(class IStorage *pStorage, const char *pFileName)
 
 	// save version
 	{
-		CMapItemVersion Item;
+		CMapItemVersion Item{};
 		Item.m_Version = 1;
 		df.AddItem(MAPITEMTYPE_VERSION, 0, sizeof(Item), &Item);
 	}
 
 	// save map info
 	{
-		CMapItemInfoSettings Item;
+		CMapItemInfoSettings Item{};
 		Item.m_Version = 1;
 
 		if(m_MapInfo.m_aAuthor[0])
@@ -294,7 +294,7 @@ int CEditorMap::Save(class IStorage *pStorage, const char *pFileName)
 		// TODO!
 		pImg->AnalyseTileFlags();
 
-		CMapItemImage Item;
+		CMapItemImage Item{};
 		Item.m_Version = 1;
 
 		Item.m_Width = pImg->m_Width;
@@ -333,7 +333,7 @@ int CEditorMap::Save(class IStorage *pStorage, const char *pFileName)
 	{
 		CEditorSound *pSound = m_lSounds[i];
 
-		CMapItemSound Item;
+		CMapItemSound Item{};
 		Item.m_Version = 1;
 
 		Item.m_External = 0;
@@ -350,7 +350,7 @@ int CEditorMap::Save(class IStorage *pStorage, const char *pFileName)
 	for(int g = 0; g < m_lGroups.size(); g++)
 	{
 		CLayerGroup *pGroup = m_lGroups[g];
-		CMapItemGroup GItem;
+		CMapItemGroup GItem{};
 		GItem.m_Version = CMapItemGroup::CURRENT_VERSION;
 
 		GItem.m_ParallaxX = pGroup->m_ParallaxX;
@@ -376,7 +376,7 @@ int CEditorMap::Save(class IStorage *pStorage, const char *pFileName)
 				CLayerTiles *pLayer = (CLayerTiles *)pGroup->m_lLayers[l];
 				pLayer->PrepareForSave();
 
-				CMapItemLayerTilemap Item;
+				CMapItemLayerTilemap Item{};
 				Item.m_Version = 3;
 
 				Item.m_Layer.m_Version = 0; // was previously uninitialized, do not rely on it being 0
@@ -442,7 +442,7 @@ int CEditorMap::Save(class IStorage *pStorage, const char *pFileName)
 				// save auto mapper of each tile layer (not physics layer)
 				if(!Item.m_Flags)
 				{
-					CMapItemAutoMapperConfig ItemAutomapper;
+					CMapItemAutoMapperConfig ItemAutomapper{};
 					ItemAutomapper.m_Version = CMapItemAutoMapperConfig::CURRENT_VERSION;
 					ItemAutomapper.m_GroupId = GroupCount;
 					ItemAutomapper.m_LayerId = GItem.m_NumLayers;
@@ -465,7 +465,7 @@ int CEditorMap::Save(class IStorage *pStorage, const char *pFileName)
 				CLayerQuads *pLayer = (CLayerQuads *)pGroup->m_lLayers[l];
 				if(pLayer->m_lQuads.size())
 				{
-					CMapItemLayerQuads Item;
+					CMapItemLayerQuads Item{};
 					Item.m_Version = 2;
 					Item.m_Layer.m_Version = 0; // was previously uninitialized, do not rely on it being 0
 					Item.m_Layer.m_Flags = pLayer->m_Flags;
@@ -494,7 +494,7 @@ int CEditorMap::Save(class IStorage *pStorage, const char *pFileName)
 				CLayerSounds *pLayer = (CLayerSounds *)pGroup->m_lLayers[l];
 				if(pLayer->m_lSources.size())
 				{
-					CMapItemLayerSounds Item;
+					CMapItemLayerSounds Item{};
 					Item.m_Version = CMapItemLayerSounds::CURRENT_VERSION;
 					Item.m_Layer.m_Version = 0; // was previously uninitialized, do not rely on it being 0
 					Item.m_Layer.m_Flags = pLayer->m_Flags;
@@ -522,7 +522,7 @@ int CEditorMap::Save(class IStorage *pStorage, const char *pFileName)
 	int PointCount = 0;
 	for(int e = 0; e < m_lEnvelopes.size(); e++)
 	{
-		CMapItemEnvelope Item;
+		CMapItemEnvelope Item{};
 		Item.m_Version = CMapItemEnvelope::CURRENT_VERSION;
 		Item.m_Channels = m_lEnvelopes[e]->m_Channels;
 		Item.m_StartPoint = PointCount;
@@ -556,7 +556,7 @@ int CEditorMap::Save(class IStorage *pStorage, const char *pFileName)
 	// send rcon.. if we can
 	if(m_pEditor->Client()->RconAuthed())
 	{
-		CServerInfo CurrentServerInfo;
+		CServerInfo CurrentServerInfo{};
 		m_pEditor->Client()->GetServerInfo(&CurrentServerInfo);
 		const unsigned char ipv4Localhost[16] = {127, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 		const unsigned char ipv6Localhost[16] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1};
@@ -649,7 +649,7 @@ int CEditorMap::Load(class IStorage *pStorage, const char *pFileName, int Storag
 				while(pNext < pSettings + Size)
 				{
 					int StrSize = str_length(pNext) + 1;
-					CSetting Setting;
+					CSetting Setting{};
 					str_copy(Setting.m_aCommand, pNext, sizeof(Setting.m_aCommand));
 					m_lSettings.add(Setting);
 					pNext += StrSize;

--- a/src/game/editor/layer_quads.cpp
+++ b/src/game/editor/layer_quads.cpp
@@ -119,7 +119,7 @@ int CLayerQuads::BrushGrab(CLayerGroup *pBrush, CUIRect Rect)
 
 		if(px > Rect.x && px < Rect.x + Rect.w && py > Rect.y && py < Rect.y + Rect.h)
 		{
-			CQuad n;
+			CQuad n{};
 			n = *q;
 
 			for(auto &Point : n.m_aPoints)

--- a/src/game/editor/layer_sounds.cpp
+++ b/src/game/editor/layer_sounds.cpp
@@ -158,7 +158,7 @@ int CLayerSounds::BrushGrab(CLayerGroup *pBrush, CUIRect Rect)
 
 		if(px > Rect.x && px < Rect.x + Rect.w && py > Rect.y && py < Rect.y + Rect.h)
 		{
-			CSoundSource n;
+			CSoundSource n{};
 			n = *pSource;
 
 			n.m_Position.x -= f2fx(Rect.x);

--- a/src/game/editor/layer_tiles.cpp
+++ b/src/game/editor/layer_tiles.cpp
@@ -688,7 +688,7 @@ void CLayerTiles::ShowInfo()
 
 int CLayerTiles::RenderProperties(CUIRect *pToolBox)
 {
-	CUIRect Button;
+	CUIRect Button{};
 
 	bool IsGameLayer = (m_pEditor->m_Map.m_pGameLayer == this || m_pEditor->m_Map.m_pTeleLayer == this || m_pEditor->m_Map.m_pSpeedupLayer == this || m_pEditor->m_Map.m_pFrontLayer == this || m_pEditor->m_Map.m_pSwitchLayer == this || m_pEditor->m_Map.m_pTuneLayer == this);
 
@@ -802,7 +802,7 @@ int CLayerTiles::RenderProperties(CUIRect *pToolBox)
 			pToolBox->HSplitBottom(12.0f, pToolBox, &Button);
 			if(m_Seed != 0)
 			{
-				CUIRect ButtonAuto;
+				CUIRect ButtonAuto{};
 				Button.VSplitRight(16.0f, &Button, &ButtonAuto);
 				Button.VSplitRight(2.0f, &Button, 0);
 				if(m_pEditor->DoButton_Editor(&s_AutoMapperButtonAuto, "A", m_AutoAutoMap, &ButtonAuto, 0, "Automatically run automap after modifications."))
@@ -961,7 +961,7 @@ int CLayerTiles::RenderCommonProperties(SCommonPropState &State, CEditor *pEdito
 {
 	if(State.Modified)
 	{
-		CUIRect Commit;
+		CUIRect Commit{};
 		pToolbox->HSplitBottom(20.0f, pToolbox, &Commit);
 		static int s_CommitButton = 0;
 		if(pEditor->DoButton_Editor(&s_CommitButton, "Commit", 0, &Commit, 0, "Applies the changes"))
@@ -991,7 +991,7 @@ int CLayerTiles::RenderCommonProperties(SCommonPropState &State, CEditor *pEdito
 	}
 
 	{
-		CUIRect Warning;
+		CUIRect Warning{};
 		pToolbox->HSplitTop(13.0f, &Warning, pToolbox);
 		Warning.HMargin(0.5f, &Warning);
 

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -119,7 +119,7 @@ bool CEditor::UiPopupOpen()
 int CEditor::PopupGroup(CEditor *pEditor, CUIRect View, void *pContext)
 {
 	// remove group button
-	CUIRect Button;
+	CUIRect Button{};
 	View.HSplitBottom(12.0f, &View, &Button);
 	static int s_DeleteButton = 0;
 
@@ -388,7 +388,7 @@ int CEditor::PopupLayer(CEditor *pEditor, CUIRect View, void *pContext)
 	CLayerPopupContext *pPopup = (CLayerPopupContext *)pContext;
 
 	// remove layer button
-	CUIRect Button;
+	CUIRect Button{};
 	View.HSplitBottom(12.0f, &View, &Button);
 	static int s_DeleteButton = 0;
 
@@ -490,7 +490,7 @@ int CEditor::PopupQuad(CEditor *pEditor, CUIRect View, void *pContext)
 	array<CQuad *> lQuads = pEditor->GetSelectedQuads();
 	CQuad *pCurrentQuad = lQuads[pEditor->m_SelectedQuadIndex];
 
-	CUIRect Button;
+	CUIRect Button{};
 
 	// delete button
 	View.HSplitBottom(12.0f, &View, &Button);
@@ -698,7 +698,7 @@ int CEditor::PopupSource(CEditor *pEditor, CUIRect View, void *pContext)
 {
 	CSoundSource *pSource = pEditor->GetSelectedSource();
 
-	CUIRect Button;
+	CUIRect Button{};
 
 	// delete button
 	View.HSplitBottom(12.0f, &View, &Button);
@@ -716,7 +716,7 @@ int CEditor::PopupSource(CEditor *pEditor, CUIRect View, void *pContext)
 	}
 
 	// Sound shape button
-	CUIRect ShapeButton;
+	CUIRect ShapeButton{};
 	View.HSplitBottom(3.0f, &View, 0x0);
 	View.HSplitBottom(12.0f, &View, &ShapeButton);
 	static int s_ShapeTypeButton = 0;
@@ -981,7 +981,7 @@ int CEditor::PopupPoint(CEditor *pEditor, CUIRect View, void *pContext)
 
 int CEditor::PopupNewFolder(CEditor *pEditor, CUIRect View, void *pContext)
 {
-	CUIRect Label, ButtonBar;
+	CUIRect Label{}, ButtonBar{};
 
 	// title
 	View.HSplitTop(10.0f, 0, &View);
@@ -1052,7 +1052,7 @@ int CEditor::PopupNewFolder(CEditor *pEditor, CUIRect View, void *pContext)
 
 int CEditor::PopupMapInfo(CEditor *pEditor, CUIRect View, void *pContext)
 {
-	CUIRect Label, ButtonBar, Button;
+	CUIRect Label{}, ButtonBar{}, Button{};
 
 	// title
 	View.HSplitTop(10.0f, 0, &View);
@@ -1120,7 +1120,7 @@ int CEditor::PopupMapInfo(CEditor *pEditor, CUIRect View, void *pContext)
 
 int CEditor::PopupEvent(CEditor *pEditor, CUIRect View, void *pContext)
 {
-	CUIRect Label, ButtonBar;
+	CUIRect Label{}, ButtonBar{};
 
 	// title
 	View.HSplitTop(10.0f, 0, &View);
@@ -1216,7 +1216,7 @@ static int g_SelectImageCurrent = -100;
 
 int CEditor::PopupSelectImage(CEditor *pEditor, CUIRect View, void *pContext)
 {
-	CUIRect ButtonBar, ImageView;
+	CUIRect ButtonBar{}, ImageView{};
 	View.VSplitLeft(80.0f, &ButtonBar, &View);
 	View.Margin(10.0f, &ImageView);
 
@@ -1228,7 +1228,7 @@ int CEditor::PopupSelectImage(CEditor *pEditor, CUIRect View, void *pContext)
 
 	if(pEditor->m_Map.m_lImages.size() > 20) // Do we need a scrollbar?
 	{
-		CUIRect Scroll;
+		CUIRect Scroll{};
 		ButtonBar.VSplitRight(20.0f, &ButtonBar, &Scroll);
 		s_ScrollValue = pEditor->UIEx()->DoScrollbarV(&s_ScrollValue, &Scroll, s_ScrollValue);
 
@@ -1262,7 +1262,7 @@ int CEditor::PopupSelectImage(CEditor *pEditor, CUIRect View, void *pContext)
 		}
 		ImageCur += 14.0f;
 
-		CUIRect Button;
+		CUIRect Button{};
 		ButtonBar.HSplitTop(14.0f, &Button, &ButtonBar);
 
 		if(pEditor->UI()->MouseInside(&Button))
@@ -1325,7 +1325,7 @@ static int g_SelectSoundCurrent = -100;
 
 int CEditor::PopupSelectSound(CEditor *pEditor, CUIRect View, void *pContext)
 {
-	CUIRect ButtonBar, SoundView;
+	CUIRect ButtonBar{}, SoundView{};
 	View.VSplitLeft(80.0f, &ButtonBar, &View);
 	View.Margin(10.0f, &SoundView);
 
@@ -1335,7 +1335,7 @@ int CEditor::PopupSelectSound(CEditor *pEditor, CUIRect View, void *pContext)
 
 	if(pEditor->m_Map.m_lSounds.size() > 20) // Do we need a scrollbar?
 	{
-		CUIRect Scroll;
+		CUIRect Scroll{};
 		ButtonBar.VSplitRight(20.0f, &ButtonBar, &Scroll);
 		s_ScrollValue = pEditor->UIEx()->DoScrollbarV(&s_ScrollValue, &Scroll, s_ScrollValue);
 
@@ -1369,7 +1369,7 @@ int CEditor::PopupSelectSound(CEditor *pEditor, CUIRect View, void *pContext)
 		}
 		SoundCur += 14.0f;
 
-		CUIRect Button;
+		CUIRect Button{};
 		ButtonBar.HSplitTop(14.0f, &Button, &ButtonBar);
 
 		//if(pEditor->UI()->MouseInside(&Button))
@@ -1428,7 +1428,7 @@ int CEditor::PopupSelectGametileOp(CEditor *pEditor, CUIRect View, void *pContex
 		"Live Unfreeze",
 	};
 	static unsigned s_NumButtons = std::size(s_pButtonNames);
-	CUIRect Button;
+	CUIRect Button{};
 
 	for(unsigned i = 0; i < s_NumButtons; ++i)
 	{
@@ -1464,7 +1464,7 @@ static int s_AutoMapConfigCurrent = -100;
 int CEditor::PopupSelectConfigAutoMap(CEditor *pEditor, CUIRect View, void *pContext)
 {
 	CLayerTiles *pLayer = static_cast<CLayerTiles *>(pEditor->GetSelectedLayer(0));
-	CUIRect Button;
+	CUIRect Button{};
 	static int s_AutoMapperConfigButtons[256];
 	CAutoMapper *pAutoMapper = &pEditor->m_Map.m_lImages[pLayer->m_Image]->m_AutoMapper;
 
@@ -1480,7 +1480,7 @@ int CEditor::PopupSelectConfigAutoMap(CEditor *pEditor, CUIRect View, void *pCon
 	// Disable scrollbar if not needed.
 	if(ListHeight > View.h)
 	{
-		CUIRect Scroll;
+		CUIRect Scroll{};
 		View.VSplitRight(20.0f, &View, &Scroll);
 		s_ScrollValue = pEditor->UIEx()->DoScrollbarV(&s_ScrollValue, &Scroll, s_ScrollValue);
 
@@ -1561,8 +1561,8 @@ int CEditor::PopupTele(CEditor *pEditor, CUIRect View, void *pContext)
 {
 	static int s_PreviousNumber = -1;
 
-	CUIRect NumberPicker;
-	CUIRect FindEmptySlot;
+	CUIRect NumberPicker{};
+	CUIRect FindEmptySlot{};
 
 	View.VSplitRight(15.f, &NumberPicker, &FindEmptySlot);
 	NumberPicker.VSplitRight(2.f, &NumberPicker, 0);
@@ -1625,7 +1625,7 @@ int CEditor::PopupTele(CEditor *pEditor, CUIRect View, void *pContext)
 
 int CEditor::PopupSpeedup(CEditor *pEditor, CUIRect View, void *pContext)
 {
-	CUIRect Button;
+	CUIRect Button{};
 	View.HSplitBottom(12.0f, &View, &Button);
 
 	enum
@@ -1661,10 +1661,10 @@ int CEditor::PopupSwitch(CEditor *pEditor, CUIRect View, void *pContext)
 {
 	static int s_PreviousNumber = -1;
 
-	CUIRect NumberPicker;
-	CUIRect FindEmptySlot;
+	CUIRect NumberPicker{};
+	CUIRect FindEmptySlot{};
 
-	CUIRect DelayPicker;
+	CUIRect DelayPicker{};
 
 	View.HSplitMid(&NumberPicker, &DelayPicker);
 	NumberPicker.VSplitRight(15.f, &NumberPicker, &FindEmptySlot);
@@ -1734,7 +1734,7 @@ int CEditor::PopupSwitch(CEditor *pEditor, CUIRect View, void *pContext)
 
 int CEditor::PopupTune(CEditor *pEditor, CUIRect View, void *pContext)
 {
-	CUIRect Button;
+	CUIRect Button{};
 	View.HSplitBottom(12.0f, &View, &Button);
 
 	enum
@@ -1760,7 +1760,7 @@ int CEditor::PopupTune(CEditor *pEditor, CUIRect View, void *pContext)
 
 int CEditor::PopupColorPicker(CEditor *pEditor, CUIRect View, void *pContext)
 {
-	CUIRect SVPicker, HuePicker;
+	CUIRect SVPicker{}, HuePicker{};
 	View.VSplitRight(20.0f, &SVPicker, &HuePicker);
 	HuePicker.VSplitLeft(4.0f, 0x0, &HuePicker);
 
@@ -1864,7 +1864,7 @@ int CEditor::PopupEntities(CEditor *pEditor, CUIRect View, void *pContext)
 {
 	for(int i = 0; i < (int)pEditor->m_SelectEntitiesFiles.size(); i++)
 	{
-		CUIRect Button;
+		CUIRect Button{};
 		View.HSplitTop(14.0f, &Button, &View);
 
 		const char *Name = pEditor->m_SelectEntitiesFiles[i].c_str();

--- a/src/game/gamecore.cpp
+++ b/src/game/gamecore.cpp
@@ -613,7 +613,7 @@ void CCharacterCore::ReadDDNetDisplayInfo(const CNetObj_DDNetCharacterDisplayInf
 
 void CCharacterCore::Quantize()
 {
-	CNetObj_CharacterCore Core;
+	CNetObj_CharacterCore Core{};
 	Write(&Core);
 	ReadCharacterCore(&Core);
 }

--- a/src/game/localization.cpp
+++ b/src/game/localization.cpp
@@ -38,7 +38,7 @@ CLocalizationDatabase::CLocalizationDatabase()
 
 void CLocalizationDatabase::AddString(const char *pOrgStr, const char *pNewStr, const char *pContext)
 {
-	CString s;
+	CString s{};
 	s.m_Hash = str_quickhash(pOrgStr);
 	s.m_ContextHash = str_quickhash(pContext);
 	s.m_pReplacement = m_StringsHeap.StoreString(*pNewStr ? pNewStr : pOrgStr);
@@ -68,7 +68,7 @@ bool CLocalizationDatabase::Load(const char *pFilename, IStorage *pStorage, ICon
 
 	char aContext[512];
 	char aOrigin[512];
-	CLineReader LineReader;
+	CLineReader LineReader{};
 	LineReader.Init(IoHandle);
 	char *pLine;
 	int Line = 0;
@@ -125,7 +125,7 @@ bool CLocalizationDatabase::Load(const char *pFilename, IStorage *pStorage, ICon
 
 const char *CLocalizationDatabase::FindString(unsigned Hash, unsigned ContextHash) const
 {
-	CString String;
+	CString String{};
 	String.m_Hash = Hash;
 	String.m_ContextHash = ContextHash;
 	String.m_pReplacement = 0x0;

--- a/src/game/localization.h
+++ b/src/game/localization.h
@@ -41,9 +41,9 @@ extern CLocalizationDatabase g_Localization;
 class CLocConstString
 {
 	const char *m_pDefaultStr;
-	const char *m_pCurrentStr;
+	const char *m_pCurrentStr{};
 	unsigned m_Hash;
-	unsigned m_ContextHash;
+	unsigned m_ContextHash{};
 	int m_Version;
 
 public:

--- a/src/game/mapbugs.cpp
+++ b/src/game/mapbugs.cpp
@@ -48,7 +48,7 @@ static CMapBugsInternal MAP_BUGS[] =
 CMapBugs GetMapBugs(const char *pName, int Size, SHA256_DIGEST Sha256)
 {
 	CMapDescription Map = {pName, Size, Sha256};
-	CMapBugs Result;
+	CMapBugs Result{};
 	Result.m_Extra = 0;
 	for(auto &MapBug : MAP_BUGS)
 	{

--- a/src/game/prng.h
+++ b/src/game/prng.h
@@ -22,11 +22,11 @@ public:
 	unsigned int RandomBits();
 
 private:
-	char m_aDescription[64];
+	char m_aDescription[64]{};
 
 	bool m_Seeded;
-	uint64_t m_State;
-	uint64_t m_Increment;
+	uint64_t m_State{};
+	uint64_t m_Increment{};
 };
 
 #endif // GAME_PRNG_H

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -792,7 +792,7 @@ void CCharacter::TickDefered()
 		{
 			float f;
 			unsigned u;
-		} StartPosX, StartPosY, StartVelX, StartVelY;
+		} StartPosX{}, StartPosY{}, StartVelX{}, StartVelY{};
 
 		StartPosX.f = StartPos.x;
 		StartPosY.f = StartPos.y;
@@ -843,8 +843,8 @@ void CCharacter::TickDefered()
 
 	// update the m_SendCore if needed
 	{
-		CNetObj_Character Predicted;
-		CNetObj_Character Current;
+		CNetObj_Character Predicted{};
+		CNetObj_Character Current{};
 		mem_zero(&Predicted, sizeof(Predicted));
 		mem_zero(&Current, sizeof(Current));
 		m_ReckoningCore.Write(&Predicted);
@@ -905,7 +905,7 @@ void CCharacter::Die(int Killer, int Weapon)
 	GameServer()->Console()->Print(IConsole::OUTPUT_LEVEL_DEBUG, "game", aBuf);
 
 	// send the kill message
-	CNetMsg_Sv_KillMsg Msg;
+	CNetMsg_Sv_KillMsg Msg{};
 	Msg.m_Killer = Killer;
 	Msg.m_Victim = m_pPlayer->GetCID();
 	Msg.m_Weapon = Weapon;
@@ -1471,7 +1471,7 @@ void CCharacter::HandleTiles(int Index)
 		if(m_pPlayer->GetClientVersion() >= VERSION_DDRACE)
 		{
 			CPlayerData *pData = GameServer()->Score()->PlayerData(m_pPlayer->GetCID());
-			CNetMsg_Sv_DDRaceTime Msg;
+			CNetMsg_Sv_DDRaceTime Msg{};
 			Msg.m_Time = (int)m_Time;
 			Msg.m_Check = 0;
 			Msg.m_Finish = 0;
@@ -1497,7 +1497,7 @@ void CCharacter::HandleTiles(int Index)
 		if(m_pPlayer->GetClientVersion() >= VERSION_DDRACE)
 		{
 			CPlayerData *pData = GameServer()->Score()->PlayerData(m_pPlayer->GetCID());
-			CNetMsg_Sv_DDRaceTime Msg;
+			CNetMsg_Sv_DDRaceTime Msg{};
 			Msg.m_Time = (int)m_Time;
 			Msg.m_Check = 0;
 			Msg.m_Finish = 0;

--- a/src/game/server/entities/character.h
+++ b/src/game/server/entities/character.h
@@ -88,44 +88,44 @@ public:
 
 private:
 	// player controlling this character
-	class CPlayer *m_pPlayer;
+	class CPlayer *m_pPlayer{};
 
-	bool m_Alive;
-	bool m_Paused;
-	int m_NeededFaketuning;
+	bool m_Alive{};
+	bool m_Paused{};
+	int m_NeededFaketuning{};
 
 	// weapon info
-	CEntity *m_apHitObjects[10];
-	int m_NumObjectsHit;
+	CEntity *m_apHitObjects[10]{};
+	int m_NumObjectsHit{};
 
-	int m_LastWeapon;
-	int m_QueuedWeapon;
+	int m_LastWeapon{};
+	int m_QueuedWeapon{};
 
-	int m_ReloadTimer;
-	int m_AttackTick;
+	int m_ReloadTimer{};
+	int m_AttackTick{};
 
-	int m_DamageTaken;
+	int m_DamageTaken{};
 
-	int m_EmoteType;
-	int m_EmoteStop;
+	int m_EmoteType{};
+	int m_EmoteStop{};
 
 	// last tick that the player took any action ie some input
-	int m_LastAction;
-	int m_LastNoAmmoSound;
+	int m_LastAction{};
+	int m_LastNoAmmoSound{};
 
 	// these are non-heldback inputs
-	CNetObj_PlayerInput m_LatestPrevPrevInput;
-	CNetObj_PlayerInput m_LatestPrevInput;
-	CNetObj_PlayerInput m_LatestInput;
+	CNetObj_PlayerInput m_LatestPrevPrevInput{};
+	CNetObj_PlayerInput m_LatestPrevInput{};
+	CNetObj_PlayerInput m_LatestInput{};
 
 	// input
-	CNetObj_PlayerInput m_PrevInput;
-	CNetObj_PlayerInput m_Input;
-	CNetObj_PlayerInput m_SavedInput;
-	int m_NumInputs;
-	int m_Jumped;
+	CNetObj_PlayerInput m_PrevInput{};
+	CNetObj_PlayerInput m_Input{};
+	CNetObj_PlayerInput m_SavedInput{};
+	int m_NumInputs{};
+	int m_Jumped{};
 
-	int m_DamageTakenTick;
+	int m_DamageTakenTick{};
 
 	int m_Health;
 	int m_Armor;
@@ -138,7 +138,7 @@ private:
 	std::map<int, std::vector<vec2>> *m_pTeleCheckOuts = nullptr;
 
 	// info for dead reckoning
-	int m_ReckoningTick; // tick that we are performing dead reckoning From
+	int m_ReckoningTick{}; // tick that we are performing dead reckoning From
 	CCharacterCore m_SendCore; // core that we should send
 	CCharacterCore m_ReckoningCore; // the dead reckoning core
 
@@ -147,8 +147,8 @@ private:
 	void SnapCharacter(int SnappingClient, int ID);
 	static bool IsSwitchActiveCb(int Number, void *pUser);
 	void HandleTiles(int Index);
-	float m_Time;
-	int m_LastBroadcast;
+	float m_Time{};
+	int m_LastBroadcast{};
 	void DDRaceInit();
 	void HandleSkippableTiles(int Index);
 	void SetRescue();
@@ -159,9 +159,9 @@ private:
 	void SendZoneMsgs();
 	IAntibot *Antibot();
 
-	bool m_SetSavePos;
+	bool m_SetSavePos{};
 	CSaveTee m_RescueTee;
-	bool m_Solo;
+	bool m_Solo{};
 
 public:
 	CGameTeams *Teams() { return m_pTeams; }
@@ -175,21 +175,21 @@ public:
 	bool UnFreeze();
 	void GiveAllWeapons();
 	void ResetPickups();
-	int m_DDRaceState;
+	int m_DDRaceState{};
 	int Team();
 	bool CanCollide(int ClientID);
 	bool SameTeam(int ClientID);
-	bool m_Super;
-	bool m_SuperJump;
-	bool m_Jetpack;
-	bool m_NinjaJetpack;
-	int m_TeamBeforeSuper;
-	int m_FreezeTime;
-	bool m_FrozenLastTick;
-	bool m_DeepFreeze;
-	bool m_LiveFreeze;
-	bool m_EndlessHook;
-	bool m_FreezeHammer;
+	bool m_Super{};
+	bool m_SuperJump{};
+	bool m_Jetpack{};
+	bool m_NinjaJetpack{};
+	int m_TeamBeforeSuper{};
+	int m_FreezeTime{};
+	bool m_FrozenLastTick{};
+	bool m_DeepFreeze{};
+	bool m_LiveFreeze{};
+	bool m_EndlessHook{};
+	bool m_FreezeHammer{};
 	enum
 	{
 		HIT_ALL = 0,
@@ -198,36 +198,36 @@ public:
 		DISABLE_HIT_GRENADE = 4,
 		DISABLE_HIT_LASER = 8
 	};
-	int m_Hit;
-	int m_TuneZone;
-	int m_TuneZoneOld;
-	int m_PainSoundTimer;
-	int m_LastMove;
-	int m_StartTime;
+	int m_Hit{};
+	int m_TuneZone{};
+	int m_TuneZoneOld{};
+	int m_PainSoundTimer{};
+	int m_LastMove{};
+	int m_StartTime{};
 	vec2 m_PrevPos;
-	int m_TeleCheckpoint;
-	int m_CpTick;
-	int m_CpActive;
-	int m_CpLastBroadcast;
-	float m_CpCurrent[25];
-	int m_TileIndex;
-	int m_TileFIndex;
+	int m_TeleCheckpoint{};
+	int m_CpTick{};
+	int m_CpActive{};
+	int m_CpLastBroadcast{};
+	float m_CpCurrent[25]{};
+	int m_TileIndex{};
+	int m_TileFIndex{};
 
-	int m_MoveRestrictions;
+	int m_MoveRestrictions{};
 
 	vec2 m_Intersection;
-	int64_t m_LastStartWarning;
-	int64_t m_LastRescue;
-	bool m_LastRefillJumps;
-	bool m_LastPenalty;
-	bool m_LastBonus;
+	int64_t m_LastStartWarning{};
+	int64_t m_LastRescue{};
+	bool m_LastRefillJumps{};
+	bool m_LastPenalty{};
+	bool m_LastBonus{};
 	vec2 m_TeleGunPos;
-	bool m_TeleGunTeleport;
-	bool m_IsBlueTeleGunTeleport;
+	bool m_TeleGunTeleport{};
+	bool m_IsBlueTeleGunTeleport{};
 	int m_StrongWeakID;
 
-	int m_SpawnTick;
-	int m_WeaponChangeTick;
+	int m_SpawnTick{};
+	int m_WeaponChangeTick{};
 
 	// Setters/Getters because i don't want to modify vanilla vars access modifiers
 	int GetLastWeapon() { return m_LastWeapon; }

--- a/src/game/server/entities/dragger.h
+++ b/src/game/server/entities/dragger.h
@@ -27,8 +27,8 @@ class CDragger : public CEntity
 	bool m_IgnoreWalls;
 	int m_EvalTick;
 
-	int m_TargetIdInTeam[MAX_CLIENTS];
-	CDraggerBeam *m_apDraggerBeam[MAX_CLIENTS];
+	int m_TargetIdInTeam[MAX_CLIENTS]{};
+	CDraggerBeam *m_apDraggerBeam[MAX_CLIENTS]{};
 
 	void LookForPlayersToDrag();
 

--- a/src/game/server/entities/gun.h
+++ b/src/game/server/entities/gun.h
@@ -26,8 +26,8 @@ class CGun : public CEntity
 	bool m_Freeze;
 	bool m_Explosive;
 	int m_EvalTick;
-	int m_LastFireTeam[MAX_CLIENTS];
-	int m_LastFireSolo[MAX_CLIENTS];
+	int m_LastFireTeam[MAX_CLIENTS]{};
+	int m_LastFireSolo[MAX_CLIENTS]{};
 
 	void Fire();
 

--- a/src/game/server/entities/light.h
+++ b/src/game/server/entities/light.h
@@ -19,10 +19,10 @@ class CLight : public CEntity
 	void Step();
 
 public:
-	int m_CurveLength;
-	int m_LengthL;
-	float m_AngularSpeed;
-	int m_Speed;
+	int m_CurveLength{};
+	int m_LengthL{};
+	float m_AngularSpeed{};
+	int m_Speed{};
 	int m_Length;
 
 	CLight(CGameWorld *pGameWorld, vec2 Pos, float Rotation, int Length,

--- a/src/game/server/entities/projectile.cpp
+++ b/src/game/server/entities/projectile.cpp
@@ -338,7 +338,7 @@ void CProjectile::Snap(int SnappingClient)
 	if(SnappingClient != SERVER_DEMO_CLIENT && m_Owner != -1 && !CmaskIsSet(TeamMask, SnappingClient))
 		return;
 
-	CNetObj_DDNetProjectile DDNetProjectile;
+	CNetObj_DDNetProjectile DDNetProjectile{};
 	if(SnappingClientVersion >= VERSION_DDNET_ANTIPING_PROJECTILE && FillExtraInfo(&DDNetProjectile))
 	{
 		int Type = SnappingClientVersion < VERSION_DDNET_MSG_LEGACY ? (int)NETOBJTYPE_PROJECTILE : NETOBJTYPE_DDNETPROJECTILE;

--- a/src/game/server/entities/projectile.h
+++ b/src/game/server/entities/projectile.h
@@ -44,7 +44,7 @@ private:
 
 	// DDRace
 
-	int m_Bouncing;
+	int m_Bouncing{};
 	bool m_Freeze;
 	int m_TuneZone;
 	bool m_BelongsToPracticeTeam;

--- a/src/game/server/entity.h
+++ b/src/game/server/entity.h
@@ -148,8 +148,8 @@ public: // TODO: Maybe make protected
 	bool GetNearestAirPos(vec2 Pos, vec2 PrevPos, vec2 *pOutPos);
 	bool GetNearestAirPosPlayer(vec2 PlayerPos, vec2 *OutPos);
 
-	int m_Number;
-	int m_Layer;
+	int m_Number{};
+	int m_Layer{};
 };
 
 bool NetworkClipped(const CGameContext *pGameServer, int SnappingClient, vec2 CheckPos);

--- a/src/game/server/eventhandler.h
+++ b/src/game/server/eventhandler.h
@@ -11,16 +11,16 @@ class CEventHandler
 	static const int MAX_EVENTS = 128;
 	static const int MAX_DATASIZE = 128 * 64;
 
-	int m_aTypes[MAX_EVENTS]; // TODO: remove some of these arrays
-	int m_aOffsets[MAX_EVENTS];
-	int m_aSizes[MAX_EVENTS];
-	int64_t m_aClientMasks[MAX_EVENTS];
-	char m_aData[MAX_DATASIZE];
+	int m_aTypes[MAX_EVENTS]{}; // TODO: remove some of these arrays
+	int m_aOffsets[MAX_EVENTS]{};
+	int m_aSizes[MAX_EVENTS]{};
+	int64_t m_aClientMasks[MAX_EVENTS]{};
+	char m_aData[MAX_DATASIZE]{};
 
 	class CGameContext *m_pGameServer;
 
-	int m_CurrentOffset;
-	int m_NumEvents;
+	int m_CurrentOffset{};
+	int m_NumEvents{};
 
 public:
 	CGameContext *GameServer() const { return m_pGameServer; }

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -354,7 +354,7 @@ void CGameContext::CreateSoundGlobal(int Sound, int Target)
 	if(Sound < 0)
 		return;
 
-	CNetMsg_Sv_SoundGlobal Msg;
+	CNetMsg_Sv_SoundGlobal Msg{};
 	Msg.m_SoundID = Sound;
 	if(Target == -2)
 		Server()->SendPackMsg(&Msg, MSGFLAG_NOSEND, -1);
@@ -392,7 +392,7 @@ void CGameContext::CallVote(int ClientID, const char *pDesc, const char *pCmd, c
 
 void CGameContext::SendChatTarget(int To, const char *pText, int Flags)
 {
-	CNetMsg_Sv_Chat Msg;
+	CNetMsg_Sv_Chat Msg{};
 	Msg.m_Team = 0;
 	Msg.m_ClientID = -1;
 	Msg.m_pMessage = pText;
@@ -450,7 +450,7 @@ void CGameContext::SendChat(int ChatterClientID, int Team, const char *pText, in
 
 	if(Team == CHAT_ALL)
 	{
-		CNetMsg_Sv_Chat Msg;
+		CNetMsg_Sv_Chat Msg{};
 		Msg.m_Team = 0;
 		Msg.m_ClientID = ChatterClientID;
 		Msg.m_pMessage = aText;
@@ -474,7 +474,7 @@ void CGameContext::SendChat(int ChatterClientID, int Team, const char *pText, in
 	else
 	{
 		CTeamsCore *Teams = &((CGameControllerDDRace *)m_pController)->m_Teams.m_Core;
-		CNetMsg_Sv_Chat Msg;
+		CNetMsg_Sv_Chat Msg{};
 		Msg.m_Team = 1;
 		Msg.m_ClientID = ChatterClientID;
 		Msg.m_pMessage = aText;
@@ -519,7 +519,7 @@ void CGameContext::SendStartWarning(int ClientID, const char *pMessage)
 
 void CGameContext::SendEmoticon(int ClientID, int Emoticon)
 {
-	CNetMsg_Sv_Emoticon Msg;
+	CNetMsg_Sv_Emoticon Msg{};
 	Msg.m_ClientID = ClientID;
 	Msg.m_Emoticon = Emoticon;
 	Server()->SendPackMsg(&Msg, MSGFLAG_VITAL, -1);
@@ -527,14 +527,14 @@ void CGameContext::SendEmoticon(int ClientID, int Emoticon)
 
 void CGameContext::SendWeaponPickup(int ClientID, int Weapon)
 {
-	CNetMsg_Sv_WeaponPickup Msg;
+	CNetMsg_Sv_WeaponPickup Msg{};
 	Msg.m_Weapon = Weapon;
 	Server()->SendPackMsg(&Msg, MSGFLAG_VITAL, ClientID);
 }
 
 void CGameContext::SendMotd(int ClientID)
 {
-	CNetMsg_Sv_Motd Msg;
+	CNetMsg_Sv_Motd Msg{};
 	Msg.m_pMessage = g_Config.m_SvMotd;
 	Server()->SendPackMsg(&Msg, MSGFLAG_VITAL, ClientID);
 }
@@ -543,7 +543,7 @@ void CGameContext::SendSettings(int ClientID)
 {
 	if(Server()->IsSixup(ClientID))
 	{
-		protocol7::CNetMsg_Sv_ServerSettings Msg;
+		protocol7::CNetMsg_Sv_ServerSettings Msg{};
 		Msg.m_KickVote = g_Config.m_SvVoteKick;
 		Msg.m_KickMin = g_Config.m_SvVoteKickMin;
 		Msg.m_SpecVote = g_Config.m_SvVoteSpectate;
@@ -556,7 +556,7 @@ void CGameContext::SendSettings(int ClientID)
 
 void CGameContext::SendBroadcast(const char *pText, int ClientID, bool IsImportant)
 {
-	CNetMsg_Sv_Broadcast Msg;
+	CNetMsg_Sv_Broadcast Msg{};
 	Msg.m_pMessage = pText;
 
 	if(ClientID == -1)
@@ -618,8 +618,8 @@ void CGameContext::EndVote()
 
 void CGameContext::SendVoteSet(int ClientID)
 {
-	::CNetMsg_Sv_VoteSet Msg6;
-	protocol7::CNetMsg_Sv_VoteSet Msg7;
+	::CNetMsg_Sv_VoteSet Msg6{};
+	protocol7::CNetMsg_Sv_VoteSet Msg7{};
 
 	Msg7.m_ClientID = m_VoteCreator;
 	if(m_VoteCloseTime)
@@ -1133,7 +1133,7 @@ void CGameContext::OnTick()
 		{
 			if(m_apPlayers[i] && m_apPlayers[i]->GetCharacter())
 			{
-				CNetObj_CharacterCore Char;
+				CNetObj_CharacterCore Char{};
 				m_apPlayers[i]->GetCharacter()->GetCore().Write(&Char);
 				m_TeeHistorian.RecordPlayer(i, &Char);
 			}
@@ -1244,7 +1244,7 @@ void CGameContext::ProgressVoteOptions(int ClientID)
 	// build vote option list msg
 	int CurIndex = 0;
 
-	CNetMsg_Sv_VoteOptionListAdd OptionMsg;
+	CNetMsg_Sv_VoteOptionListAdd OptionMsg{};
 	OptionMsg.m_pDescription0 = "";
 	OptionMsg.m_pDescription1 = "";
 	OptionMsg.m_pDescription2 = "";
@@ -1307,7 +1307,7 @@ void CGameContext::OnClientEnter(int ClientID)
 	if(Server()->IsSixup(ClientID))
 	{
 		{
-			protocol7::CNetMsg_Sv_GameInfo Msg;
+			protocol7::CNetMsg_Sv_GameInfo Msg{};
 			Msg.m_GameFlags = protocol7::GAMEFLAG_RACE;
 			Msg.m_MatchCurrent = 1;
 			Msg.m_MatchNum = 0;
@@ -1318,7 +1318,7 @@ void CGameContext::OnClientEnter(int ClientID)
 
 		// /team is essential
 		{
-			protocol7::CNetMsg_Sv_CommandInfoRemove Msg;
+			protocol7::CNetMsg_Sv_CommandInfoRemove Msg{};
 			Msg.m_Name = "team";
 			Server()->SendPackMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_NORECORD, ClientID);
 		}
@@ -1333,7 +1333,7 @@ void CGameContext::OnClientEnter(int ClientID)
 			if(!str_comp_nocase(pCmd->m_pName, "r"))
 				pName = "rescue";
 
-			protocol7::CNetMsg_Sv_CommandInfo Msg;
+			protocol7::CNetMsg_Sv_CommandInfo Msg{};
 			Msg.m_Name = pName;
 			Msg.m_ArgsFormat = pCmd->m_pParams;
 			Msg.m_HelpText = pCmd->m_pHelp;
@@ -1351,7 +1351,7 @@ void CGameContext::OnClientEnter(int ClientID)
 				break;
 			}
 		}
-		CNetMsg_Sv_Chat Msg;
+		CNetMsg_Sv_Chat Msg{};
 		Msg.m_Team = 0;
 		Msg.m_ClientID = Empty;
 		Msg.m_pMessage = "Do you know someone who uses a bot? Please report them to the moderators.";
@@ -1359,7 +1359,7 @@ void CGameContext::OnClientEnter(int ClientID)
 		Server()->SendPackMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_NORECORD, ClientID);
 	}
 
-	IServer::CClientInfo Info;
+	IServer::CClientInfo Info{};
 	Server()->GetClientInfo(ClientID, &Info);
 	if(Info.m_GotDDNetVersion)
 	{
@@ -1393,7 +1393,7 @@ void CGameContext::OnClientEnter(int ClientID)
 	m_aPlayerHasInput[ClientID] = false;
 
 	// new info for others
-	protocol7::CNetMsg_Sv_ClientInfo NewClientInfoMsg;
+	protocol7::CNetMsg_Sv_ClientInfo NewClientInfoMsg{};
 	NewClientInfoMsg.m_ClientID = ClientID;
 	NewClientInfoMsg.m_Local = 0;
 	NewClientInfoMsg.m_Team = pNewPlayer->GetTeam();
@@ -1423,7 +1423,7 @@ void CGameContext::OnClientEnter(int ClientID)
 		if(Server()->IsSixup(ClientID))
 		{
 			// existing infos for new player
-			protocol7::CNetMsg_Sv_ClientInfo ClientInfoMsg;
+			protocol7::CNetMsg_Sv_ClientInfo ClientInfoMsg{};
 			ClientInfoMsg.m_ClientID = i;
 			ClientInfoMsg.m_Local = 0;
 			ClientInfoMsg.m_Team = pPlayer->GetTeam();
@@ -1541,7 +1541,7 @@ void CGameContext::OnClientDrop(int ClientID, const char *pReason)
 			pPlayer->m_LastWhisperTo = -1;
 	}
 
-	protocol7::CNetMsg_Sv_ClientDrop Msg;
+	protocol7::CNetMsg_Sv_ClientDrop Msg{};
 	Msg.m_ClientID = ClientID;
 	Msg.m_pReason = pReason;
 	Msg.m_Silent = false;
@@ -1568,7 +1568,7 @@ void CGameContext::OnClientEngineDrop(int ClientID, const char *pReason)
 
 bool CGameContext::OnClientDDNetVersionKnown(int ClientID)
 {
-	IServer::CClientInfo Info;
+	IServer::CClientInfo Info{};
 	Server()->GetClientInfo(ClientID, &Info);
 	int ClientVersion = Info.m_DDNetVersion;
 	dbg_msg("ddnet", "cid=%d version=%d", ClientID, ClientVersion);
@@ -1679,7 +1679,7 @@ void *CGameContext::PreProcessMsg(int *MsgID, CUnpacker *pUnpacker, int ClientID
 			Info.FromSixup();
 			pPlayer->m_TeeInfos = Info;
 
-			protocol7::CNetMsg_Sv_SkinChange Msg;
+			protocol7::CNetMsg_Sv_SkinChange Msg{};
 			Msg.m_ClientID = ClientID;
 			for(int p = 0; p < 6; p++)
 			{
@@ -2252,7 +2252,7 @@ void CGameContext::OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID)
 		}
 		else if(MsgID == NETMSGTYPE_CL_ISDDNETLEGACY)
 		{
-			IServer::CClientInfo Info;
+			IServer::CClientInfo Info{};
 			Server()->GetClientInfo(ClientID, &Info);
 			if(Info.m_GotDDNetVersion)
 			{
@@ -2359,12 +2359,12 @@ void CGameContext::OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID)
 
 			if(SixupNeedsUpdate)
 			{
-				protocol7::CNetMsg_Sv_ClientDrop Drop;
+				protocol7::CNetMsg_Sv_ClientDrop Drop{};
 				Drop.m_ClientID = ClientID;
 				Drop.m_pReason = "";
 				Drop.m_Silent = true;
 
-				protocol7::CNetMsg_Sv_ClientInfo Info;
+				protocol7::CNetMsg_Sv_ClientInfo Info{};
 				Info.m_ClientID = ClientID;
 				Info.m_pName = Server()->ClientName(ClientID);
 				Info.m_Country = pMsg->m_Country;
@@ -2391,7 +2391,7 @@ void CGameContext::OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID)
 			}
 			else
 			{
-				protocol7::CNetMsg_Sv_SkinChange Msg;
+				protocol7::CNetMsg_Sv_SkinChange Msg{};
 				Msg.m_ClientID = ClientID;
 				for(int p = 0; p < 6; p++)
 				{
@@ -3107,7 +3107,7 @@ int CGameContext::MapScan(const char *pName, int IsDir, int DirType, void *pUser
 	if(IsDir || !str_endswith(pName, ".map"))
 		return 0;
 
-	CMapNameItem Item;
+	CMapNameItem Item{};
 	int Length = str_length(pName);
 	str_truncate(Item.m_aName, sizeof(Item.m_aName), pName, Length - 4);
 	pMapList->add(Item);
@@ -3301,7 +3301,7 @@ void CGameContext::OnInit(/*class IKernel *pKernel*/)
 	}
 	else
 	{
-		CLineReader LineReader;
+		CLineReader LineReader{};
 		LineReader.Init(File);
 		char *pLine;
 		while((pLine = LineReader.Get()))
@@ -3342,7 +3342,7 @@ void CGameContext::OnInit(/*class IKernel *pKernel*/)
 		{
 			str_format(aVersion, sizeof(aVersion), "%s", GAME_VERSION);
 		}
-		CTeeHistorian::CGameInfo GameInfo;
+		CTeeHistorian::CGameInfo GameInfo{};
 		GameInfo.m_GameUuid = m_GameUuid;
 		GameInfo.m_pServerVersion = aVersion;
 		GameInfo.m_StartTime = time(0);
@@ -3515,7 +3515,7 @@ void CGameContext::OnMapChange(char *pNewMapName, int MapNameSize)
 		// No map-specific config, just return.
 		return;
 	}
-	CLineReader LineReader;
+	CLineReader LineReader{};
 	LineReader.Init(File);
 
 	array<char *> aLines;
@@ -3555,7 +3555,7 @@ void CGameContext::OnMapChange(char *pNewMapName, int MapNameSize)
 		int ItemID;
 		int *pData = (int *)Reader.GetItem(i, &TypeID, &ItemID);
 		int Size = Reader.GetItemSize(i);
-		CMapItemInfoSettings MapInfo;
+		CMapItemInfoSettings MapInfo{};
 		if(TypeID == MAPITEMTYPE_INFO && ItemID == 0)
 		{
 			FoundInfo = true;
@@ -3596,7 +3596,7 @@ void CGameContext::OnMapChange(char *pNewMapName, int MapNameSize)
 
 	if(!FoundInfo)
 	{
-		CMapItemInfoSettings Info;
+		CMapItemInfoSettings Info{};
 		Info.m_Version = 1;
 		Info.m_Author = -1;
 		Info.m_MapVersion = -1;
@@ -3791,8 +3791,8 @@ void CGameContext::OnSetAuthed(int ClientID, int Level)
 
 void CGameContext::SendRecord(int ClientID)
 {
-	CNetMsg_Sv_Record Msg;
-	CNetMsg_Sv_RecordLegacy MsgLegacy;
+	CNetMsg_Sv_Record Msg{};
+	CNetMsg_Sv_RecordLegacy MsgLegacy{};
 	MsgLegacy.m_PlayerTimeBest = Msg.m_PlayerTimeBest = Score()->PlayerData(ClientID)->m_BestTime * 100.0f;
 	MsgLegacy.m_ServerTimeBest = Msg.m_ServerTimeBest = m_pController->m_CurrentRecord * 100.0f; //TODO: finish this
 	Server()->SendPackMsg(&Msg, MSGFLAG_VITAL, ClientID);
@@ -3999,7 +3999,7 @@ void CGameContext::WhisperID(int ClientID, int VictimID, const char *pMessage)
 
 	if(Server()->IsSixup(ClientID))
 	{
-		protocol7::CNetMsg_Sv_Chat Msg;
+		protocol7::CNetMsg_Sv_Chat Msg{};
 		Msg.m_ClientID = ClientID;
 		Msg.m_Mode = protocol7::CHAT_WHISPER;
 		Msg.m_pMessage = aCensoredMessage;
@@ -4009,7 +4009,7 @@ void CGameContext::WhisperID(int ClientID, int VictimID, const char *pMessage)
 	}
 	else if(GetClientVersion(ClientID) >= VERSION_DDNET_WHISPER)
 	{
-		CNetMsg_Sv_Chat Msg;
+		CNetMsg_Sv_Chat Msg{};
 		Msg.m_Team = CHAT_WHISPER_SEND;
 		Msg.m_ClientID = VictimID;
 		Msg.m_pMessage = aCensoredMessage;
@@ -4026,7 +4026,7 @@ void CGameContext::WhisperID(int ClientID, int VictimID, const char *pMessage)
 
 	if(Server()->IsSixup(VictimID))
 	{
-		protocol7::CNetMsg_Sv_Chat Msg;
+		protocol7::CNetMsg_Sv_Chat Msg{};
 		Msg.m_ClientID = ClientID;
 		Msg.m_Mode = protocol7::CHAT_WHISPER;
 		Msg.m_pMessage = aCensoredMessage;
@@ -4036,7 +4036,7 @@ void CGameContext::WhisperID(int ClientID, int VictimID, const char *pMessage)
 	}
 	else if(GetClientVersion(VictimID) >= VERSION_DDNET_WHISPER)
 	{
-		CNetMsg_Sv_Chat Msg2;
+		CNetMsg_Sv_Chat Msg2{};
 		Msg2.m_Team = CHAT_WHISPER_RECV;
 		Msg2.m_ClientID = ClientID;
 		Msg2.m_pMessage = aCensoredMessage;

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -62,12 +62,12 @@ struct CScoreRandomMapResult;
 
 class CGameContext : public IGameServer
 {
-	IServer *m_pServer;
-	CConfig *m_pConfig;
-	IConsole *m_pConsole;
-	IEngine *m_pEngine;
-	IStorage *m_pStorage;
-	IAntibot *m_pAntibot;
+	IServer *m_pServer{};
+	CConfig *m_pConfig{};
+	IConsole *m_pConsole{};
+	IEngine *m_pEngine{};
+	IStorage *m_pStorage{};
+	IAntibot *m_pAntibot{};
 	CLayers m_Layers;
 	CCollision m_Collision;
 	protocol7::CNetObjHandler m_NetObjHandler7;
@@ -76,14 +76,14 @@ class CGameContext : public IGameServer
 	CTuningParams m_aTuningList[NUM_TUNEZONES];
 	array<std::string> m_aCensorlist;
 
-	bool m_TeeHistorianActive;
+	bool m_TeeHistorianActive{};
 	CTeeHistorian m_TeeHistorian;
-	ASYNCIO *m_pTeeHistorianFile;
-	CUuid m_GameUuid;
-	CMapBugs m_MapBugs;
+	ASYNCIO *m_pTeeHistorianFile{};
+	CUuid m_GameUuid{};
+	CMapBugs m_MapBugs{};
 	CPrng m_Prng;
 
-	bool m_Resetting;
+	bool m_Resetting{};
 
 	static void CommandCallback(int ClientID, int FlagMask, const char *pCmd, IConsole::IResult *pResult, void *pUser);
 	static void TeeHistorianWrite(const void *pData, int DataSize, void *pUser);
@@ -149,16 +149,16 @@ public:
 	void Clear();
 
 	CEventHandler m_Events;
-	CPlayer *m_apPlayers[MAX_CLIENTS];
+	CPlayer *m_apPlayers[MAX_CLIENTS]{};
 	// keep last input to always apply when none is sent
-	CNetObj_PlayerInput m_aLastPlayerInput[MAX_CLIENTS];
-	bool m_aPlayerHasInput[MAX_CLIENTS];
+	CNetObj_PlayerInput m_aLastPlayerInput[MAX_CLIENTS]{};
+	bool m_aPlayerHasInput[MAX_CLIENTS]{};
 
 	// returns last input if available otherwise nulled PlayerInput object
 	// ClientID has to be valid
 	CNetObj_PlayerInput GetLastPlayerInput(int ClientID) const;
 
-	IGameController *m_pController;
+	IGameController *m_pController{};
 	CGameWorld m_World;
 
 	// helper functions
@@ -172,21 +172,21 @@ public:
 	void SendVoteStatus(int ClientID, int Total, int Yes, int No);
 	void AbortVoteKickOnDisconnect(int ClientID);
 
-	int m_VoteCreator;
-	int m_VoteType;
-	int64_t m_VoteCloseTime;
-	bool m_VoteUpdate;
-	int m_VotePos;
-	char m_aVoteDescription[VOTE_DESC_LENGTH];
-	char m_aSixupVoteDescription[VOTE_DESC_LENGTH];
-	char m_aVoteCommand[VOTE_CMD_LENGTH];
-	char m_aVoteReason[VOTE_REASON_LENGTH];
-	int m_NumVoteOptions;
-	int m_VoteEnforce;
-	char m_aaZoneEnterMsg[NUM_TUNEZONES][256]; // 0 is used for switching from or to area without tunings
-	char m_aaZoneLeaveMsg[NUM_TUNEZONES][256];
+	int m_VoteCreator{};
+	int m_VoteType{};
+	int64_t m_VoteCloseTime{};
+	bool m_VoteUpdate{};
+	int m_VotePos{};
+	char m_aVoteDescription[VOTE_DESC_LENGTH]{};
+	char m_aSixupVoteDescription[VOTE_DESC_LENGTH]{};
+	char m_aVoteCommand[VOTE_CMD_LENGTH]{};
+	char m_aVoteReason[VOTE_REASON_LENGTH]{};
+	int m_NumVoteOptions{};
+	int m_VoteEnforce{};
+	char m_aaZoneEnterMsg[NUM_TUNEZONES][256]{}; // 0 is used for switching from or to area without tunings
+	char m_aaZoneLeaveMsg[NUM_TUNEZONES][256]{};
 
-	char m_aDeleteTempfile[128];
+	char m_aDeleteTempfile[128]{};
 	void DeleteTempfile();
 
 	enum
@@ -196,9 +196,9 @@ public:
 		VOTE_ENFORCE_YES,
 		VOTE_ENFORCE_ABORT,
 	};
-	CHeap *m_pVoteOptionHeap;
-	CVoteOptionServer *m_pVoteOptionFirst;
-	CVoteOptionServer *m_pVoteOptionLast;
+	CHeap *m_pVoteOptionHeap{};
+	CVoteOptionServer *m_pVoteOptionFirst{};
+	CVoteOptionServer *m_pVoteOptionLast{};
 
 	// helper functions
 	void CreateDamageInd(vec2 Pos, float AngleMod, int Amount, int64_t Mask = -1);
@@ -288,8 +288,8 @@ public:
 	int ProcessSpamProtection(int ClientID, bool RespectChatInitialDelay = true);
 	int GetDDRaceTeam(int ClientID);
 	// Describes the time when the first player joined the server.
-	int64_t m_NonEmptySince;
-	int64_t m_LastMapVote;
+	int64_t m_NonEmptySince{};
+	int64_t m_LastMapVote{};
 	int GetClientVersion(int ClientID) const;
 	bool PlayerExists(int ClientID) const override { return m_apPlayers[ClientID]; }
 	// Returns true if someone is actively moderating.
@@ -305,8 +305,8 @@ public:
 private:
 	// starting 1 to make 0 the special value "no client id"
 	uint32_t NextUniqueClientID = 1;
-	bool m_VoteWillPass;
-	class CScore *m_pScore;
+	bool m_VoteWillPass{};
+	class CScore *m_pScore{};
 
 	//DDRace Console Commands
 
@@ -429,10 +429,10 @@ private:
 		bool m_InitialChatDelay;
 	};
 
-	CMute m_aMutes[MAX_MUTES];
-	int m_NumMutes;
-	CMute m_aVoteMutes[MAX_VOTE_MUTES];
-	int m_NumVoteMutes;
+	CMute m_aMutes[MAX_MUTES]{};
+	int m_NumMutes{};
+	CMute m_aVoteMutes[MAX_VOTE_MUTES]{};
+	int m_NumVoteMutes{};
 	bool TryMute(const NETADDR *pAddr, int Secs, const char *pReason, bool InitialChatDelay);
 	void Mute(const NETADDR *pAddr, int Secs, const char *pDisplayName, const char *pReason = "", bool InitialChatDelay = false);
 	bool TryVoteMute(const NETADDR *pAddr, int Secs);
@@ -458,8 +458,8 @@ public:
 		VOTE_TYPE_KICK,
 		VOTE_TYPE_SPECTATE,
 	};
-	int m_VoteVictim;
-	int m_VoteEnforcer;
+	int m_VoteVictim{};
+	int m_VoteEnforcer{};
 
 	inline bool IsOptionVote() const { return m_VoteType == VOTE_TYPE_OPTION; }
 	inline bool IsKickVote() const { return m_VoteType == VOTE_TYPE_KICK; }

--- a/src/game/server/gamecontroller.h
+++ b/src/game/server/gamecontroller.h
@@ -16,7 +16,7 @@ class IGameController
 	friend class CSaveTeam; // need access to GameServer() and Server()
 
 	vec2 m_aaSpawnPoints[3][64];
-	int m_aNumSpawnPoints[3];
+	int m_aNumSpawnPoints[3]{};
 
 	class CGameContext *m_pGameServer;
 	class CConfig *m_pConfig;
@@ -49,13 +49,13 @@ protected:
 
 	void ResetGame();
 
-	char m_aMapWish[MAX_MAP_LENGTH];
+	char m_aMapWish[MAX_MAP_LENGTH]{};
 
 	int m_RoundStartTick;
 	int m_GameOverTick;
 	int m_SuddenDeath;
 
-	int m_Warmup;
+	int m_Warmup{};
 	int m_RoundCount;
 
 	int m_GameFlags;

--- a/src/game/server/gameworld.h
+++ b/src/game/server/gameworld.h
@@ -33,7 +33,7 @@ private:
 	void RemoveEntities();
 
 	CEntity *m_pNextTraverseEntity = nullptr;
-	CEntity *m_apFirstEntityTypes[NUM_ENTTYPES];
+	CEntity *m_apFirstEntityTypes[NUM_ENTTYPES]{};
 
 	class CGameContext *m_pGameServer;
 	class CConfig *m_pConfig;

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -205,7 +205,7 @@ void CPlayer::Tick()
 
 	// do latency stuff
 	{
-		IServer::CClientInfo Info;
+		IServer::CClientInfo Info{};
 		if(Server()->GetClientInfo(m_ClientID, &Info))
 		{
 			m_Latency.m_Accum += Info.m_Latency;
@@ -611,7 +611,7 @@ void CPlayer::SetTeam(int Team, bool DoChatMsg)
 	m_LastActionTick = Server()->Tick();
 	m_SpectatorID = SPEC_FREEVIEW;
 
-	protocol7::CNetMsg_Sv_Team Msg;
+	protocol7::CNetMsg_Sv_Team Msg{};
 	Msg.m_ClientID = m_ClientID;
 	Msg.m_Team = m_Team;
 	Msg.m_Silent = !DoChatMsg;
@@ -843,7 +843,7 @@ int CPlayer::Pause(int State, bool Force)
 		m_LastPause = Server()->Tick();
 
 		// Sixup needs a teamchange
-		protocol7::CNetMsg_Sv_Team Msg;
+		protocol7::CNetMsg_Sv_Team Msg{};
 		Msg.m_ClientID = m_ClientID;
 		Msg.m_CooldownTick = Server()->Tick();
 		Msg.m_Silent = true;

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -58,49 +58,49 @@ public:
 	//---------------------------------------------------------
 	// this is used for snapping so we know how we can clip the view for the player
 	vec2 m_ViewPos;
-	int m_TuneZone;
-	int m_TuneZoneOld;
+	int m_TuneZone{};
+	int m_TuneZoneOld{};
 
 	// states if the client is chatting, accessing a menu etc.
-	int m_PlayerFlags;
+	int m_PlayerFlags{};
 
 	// used for snapping to just update latency if the scoreboard is active
-	int m_aCurLatency[MAX_CLIENTS];
+	int m_aCurLatency[MAX_CLIENTS]{};
 
 	// used for spectator mode
-	int m_SpectatorID;
+	int m_SpectatorID{};
 
-	bool m_IsReady;
+	bool m_IsReady{};
 
 	//
-	int m_Vote;
-	int m_VotePos;
+	int m_Vote{};
+	int m_VotePos{};
 	//
-	int m_LastVoteCall;
-	int m_LastVoteTry;
-	int m_LastChat;
-	int m_LastSetTeam;
-	int m_LastSetSpectatorMode;
-	int m_LastChangeInfo;
-	int m_LastEmote;
-	int m_LastKill;
-	int m_LastCommands[4];
-	int m_LastCommandPos;
-	int m_LastWhisperTo;
-	int m_LastInvited;
+	int m_LastVoteCall{};
+	int m_LastVoteTry{};
+	int m_LastChat{};
+	int m_LastSetTeam{};
+	int m_LastSetSpectatorMode{};
+	int m_LastChangeInfo{};
+	int m_LastEmote{};
+	int m_LastKill{};
+	int m_LastCommands[4]{};
+	int m_LastCommandPos{};
+	int m_LastWhisperTo{};
+	int m_LastInvited{};
 
-	int m_SendVoteIndex;
+	int m_SendVoteIndex{};
 
 	CTeeInfo m_TeeInfos;
 
-	int m_DieTick;
-	int m_PreviousDieTick;
-	int m_Score;
-	int m_JoinTick;
-	bool m_ForceBalanced;
-	int m_LastActionTick;
-	int m_TeamChangeTick;
-	bool m_SentSemicolonTip;
+	int m_DieTick{};
+	int m_PreviousDieTick{};
+	int m_Score{};
+	int m_JoinTick{};
+	bool m_ForceBalanced{};
+	int m_LastActionTick{};
+	int m_TeamChangeTick{};
+	bool m_SentSemicolonTip{};
 
 	// network latency calculations
 	struct
@@ -111,11 +111,11 @@ public:
 		int m_Avg;
 		int m_Min;
 		int m_Max;
-	} m_Latency;
+	} m_Latency{};
 
 private:
 	const uint32_t m_UniqueClientID;
-	CCharacter *m_pCharacter;
+	CCharacter *m_pCharacter{};
 	int m_NumInputs;
 	CGameContext *m_pGameServer;
 
@@ -123,19 +123,19 @@ private:
 	IServer *Server() const;
 
 	//
-	bool m_Spawning;
-	bool m_WeakHookSpawn;
+	bool m_Spawning{};
+	bool m_WeakHookSpawn{};
 	int m_ClientID;
 	int m_Team;
 
-	int m_Paused;
-	int64_t m_ForcePauseTime;
-	int64_t m_LastPause;
+	int m_Paused{};
+	int64_t m_ForcePauseTime{};
+	int64_t m_LastPause{};
 
-	int m_DefEmote;
-	int m_OverrideEmote;
-	int m_OverrideEmoteReset;
-	bool m_Halloween;
+	int m_DefEmote{};
+	int m_OverrideEmote{};
+	int m_OverrideEmoteReset{};
+	bool m_Halloween{};
 
 public:
 	enum
@@ -155,9 +155,9 @@ public:
 		TIMERTYPE_NONE,
 	};
 
-	bool m_DND;
-	int64_t m_FirstVoteTick;
-	char m_aTimeoutCode[64];
+	bool m_DND{};
+	int64_t m_FirstVoteTick{};
+	char m_aTimeoutCode[64]{};
 
 	void ProcessPause();
 	int Pause(int State, bool Force);
@@ -165,53 +165,53 @@ public:
 	int IsPaused();
 
 	bool IsPlaying();
-	int64_t m_Last_KickVote;
-	int64_t m_Last_Team;
-	int m_ShowOthers;
-	bool m_ShowAll;
+	int64_t m_Last_KickVote{};
+	int64_t m_Last_Team{};
+	int m_ShowOthers{};
+	bool m_ShowAll{};
 	vec2 m_ShowDistance;
-	bool m_SpecTeam;
-	bool m_NinjaJetpack;
-	bool m_Afk;
-	bool m_HasFinishScore;
+	bool m_SpecTeam{};
+	bool m_NinjaJetpack{};
+	bool m_Afk{};
+	bool m_HasFinishScore{};
 
-	int m_ChatScore;
+	int m_ChatScore{};
 
-	bool m_Moderating;
+	bool m_Moderating{};
 
 	bool AfkTimer(CNetObj_PlayerInput *pNewTarget); // returns true if kicked
 	void UpdatePlaytime();
 	void AfkVoteTimer(CNetObj_PlayerInput *pNewTarget);
-	int64_t m_LastPlaytime;
-	int64_t m_LastEyeEmote;
-	int64_t m_LastBroadcast;
-	bool m_LastBroadcastImportance;
+	int64_t m_LastPlaytime{};
+	int64_t m_LastEyeEmote{};
+	int64_t m_LastBroadcast{};
+	bool m_LastBroadcastImportance{};
 
-	CNetObj_PlayerInput *m_pLastTarget;
-	bool m_LastTargetInit;
+	CNetObj_PlayerInput *m_pLastTarget{};
+	bool m_LastTargetInit{};
 	/* 
 		afk timer's 1st warning after 50% of sv_max_afk_time
 		2nd warning after 90%
 		kick after reaching 100% of sv_max_afk_time
 	*/
-	bool m_SentAfkWarning[2];
+	bool m_SentAfkWarning[2]{};
 
-	bool m_EyeEmoteEnabled;
-	int m_TimerType;
+	bool m_EyeEmoteEnabled{};
+	int m_TimerType{};
 
 	int GetDefaultEmote() const;
 	void OverrideDefaultEmote(int Emote, int Tick);
 	bool CanOverrideDefaultEmote() const;
 
-	bool m_FirstPacket;
-	int64_t m_LastSQLQuery;
+	bool m_FirstPacket{};
+	int64_t m_LastSQLQuery{};
 	void ProcessScoreResult(CScorePlayerResult &Result);
 	std::shared_ptr<CScorePlayerResult> m_ScoreQueryResult;
 	std::shared_ptr<CScorePlayerResult> m_ScoreFinishResult;
-	bool m_NotEligibleForFinish;
-	int64_t m_EligibleForFinishCheck;
-	bool m_VotedForPractice;
-	int m_SwapTargetsClientID; //Client ID of the swap target for the given player
+	bool m_NotEligibleForFinish{};
+	int64_t m_EligibleForFinishCheck{};
+	bool m_VotedForPractice{};
+	int m_SwapTargetsClientID{}; //Client ID of the swap target for the given player
 };
 
 #endif

--- a/src/game/server/save.h
+++ b/src/game/server/save.h
@@ -27,19 +27,19 @@ public:
 	void SetClientID(int ClientID) { m_ClientID = ClientID; }
 
 private:
-	int m_ClientID;
+	int m_ClientID{};
 
-	char m_aString[2048];
-	char m_aName[16];
+	char m_aString[2048]{};
+	char m_aName[16]{};
 
-	int m_Alive;
-	int m_Paused;
-	int m_NeededFaketuning;
+	int m_Alive{};
+	int m_Paused{};
+	int m_NeededFaketuning{};
 
 	// Teamstuff
-	int m_TeeStarted;
-	int m_TeeFinished;
-	int m_IsSolo;
+	int m_TeeStarted{};
+	int m_TeeFinished{};
+	int m_IsSolo{};
 
 	struct WeaponStat
 	{
@@ -47,67 +47,67 @@ private:
 		int m_Ammo;
 		int m_Ammocost;
 		int m_Got;
-	} m_aWeapons[NUM_WEAPONS];
+	} m_aWeapons[NUM_WEAPONS]{};
 
-	int m_LastWeapon;
-	int m_QueuedWeapon;
+	int m_LastWeapon{};
+	int m_QueuedWeapon{};
 
-	int m_SuperJump;
-	int m_Jetpack;
-	int m_NinjaJetpack;
-	int m_FreezeTime;
-	int m_FreezeTick;
-	int m_DeepFreeze;
-	int m_LiveFreeze;
-	int m_EndlessHook;
-	int m_DDRaceState;
+	int m_SuperJump{};
+	int m_Jetpack{};
+	int m_NinjaJetpack{};
+	int m_FreezeTime{};
+	int m_FreezeTick{};
+	int m_DeepFreeze{};
+	int m_LiveFreeze{};
+	int m_EndlessHook{};
+	int m_DDRaceState{};
 
-	int m_Hit;
-	int m_Collision;
-	int m_TuneZone;
-	int m_TuneZoneOld;
-	int m_Hook;
-	int m_Time;
+	int m_Hit{};
+	int m_Collision{};
+	int m_TuneZone{};
+	int m_TuneZoneOld{};
+	int m_Hook{};
+	int m_Time{};
 	vec2 m_Pos;
 	vec2 m_PrevPos;
-	int m_TeleCheckpoint;
-	int m_LastPenalty;
+	int m_TeleCheckpoint{};
+	int m_LastPenalty{};
 
-	int m_CpTime;
-	int m_CpActive;
-	int m_CpLastBroadcast;
-	float m_aCpCurrent[25];
+	int m_CpTime{};
+	int m_CpActive{};
+	int m_CpLastBroadcast{};
+	float m_aCpCurrent[25]{};
 
-	int m_NotEligibleForFinish;
+	int m_NotEligibleForFinish{};
 
-	int m_HasTelegunGun;
-	int m_HasTelegunGrenade;
-	int m_HasTelegunLaser;
+	int m_HasTelegunGun{};
+	int m_HasTelegunGrenade{};
+	int m_HasTelegunLaser{};
 
 	// Core
 	vec2 m_CorePos;
 	vec2 m_Vel;
-	int m_ActiveWeapon;
-	int m_Jumped;
-	int m_JumpedTotal;
-	int m_Jumps;
+	int m_ActiveWeapon{};
+	int m_Jumped{};
+	int m_JumpedTotal{};
+	int m_Jumps{};
 	vec2 m_HookPos;
 	vec2 m_HookDir;
 	vec2 m_HookTeleBase;
-	int m_HookTick;
-	int m_HookState;
-	int m_HookedPlayer;
-	int m_NewHook;
+	int m_HookTick{};
+	int m_HookState{};
+	int m_HookedPlayer{};
+	int m_NewHook{};
 
 	// player input
-	int m_InputDirection;
-	int m_InputJump;
-	int m_InputFire;
-	int m_InputHook;
+	int m_InputDirection{};
+	int m_InputJump{};
+	int m_InputFire{};
+	int m_InputHook{};
 
-	int m_ReloadTimer;
+	int m_ReloadTimer{};
 
-	char m_aGameUuid[UUID_MAXSTRSIZE];
+	char m_aGameUuid[UUID_MAXSTRSIZE]{};
 };
 
 class CSaveTeam
@@ -133,7 +133,7 @@ private:
 
 	IGameController *m_pController;
 
-	char m_aString[65536];
+	char m_aString[65536]{};
 
 	struct SSimpleSwitchers
 	{
@@ -143,11 +143,11 @@ private:
 	};
 	SSimpleSwitchers *m_pSwitchers;
 
-	int m_TeamState;
-	int m_MembersCount;
-	int m_NumSwitchers;
-	int m_TeamLocked;
-	int m_Practice;
+	int m_TeamState{};
+	int m_MembersCount{};
+	int m_NumSwitchers{};
+	int m_TeamLocked{};
+	int m_Practice{};
 };
 
 #endif // GAME_SERVER_SAVE_H

--- a/src/game/server/score.cpp
+++ b/src/game/server/score.cpp
@@ -90,7 +90,7 @@ CScore::CScore(CGameContext *pGameServer, CDbConnectionPool *pPool) :
 	IOHANDLE File = GameServer()->Storage()->OpenFile("wordlist.txt", IOFLAG_READ | IOFLAG_SKIP_BOM, IStorage::TYPE_ALL);
 	if(File)
 	{
-		CLineReader LineReader;
+		CLineReader LineReader{};
 		LineReader.Init(File);
 		char *pLine;
 		while((pLine = LineReader.Get()))

--- a/src/game/server/scoreworker.cpp
+++ b/src/game/server/scoreworker.cpp
@@ -62,7 +62,7 @@ bool CTeamrank::NextSqlResult(IDbConnection *pSqlServer, bool *pEnd, char *pErro
 	bool End = false;
 	while(!pSqlServer->Step(&End, pError, ErrorSize) && !End)
 	{
-		CUuid TeamID;
+		CUuid TeamID{};
 		pSqlServer->GetBlob(1, TeamID.m_aData, sizeof(TeamID.m_aData));
 		if(m_TeamID != TeamID)
 		{

--- a/src/game/server/scoreworker.h
+++ b/src/game/server/scoreworker.h
@@ -39,7 +39,7 @@ struct CScorePlayerResult : ISqlResult
 		BROADCAST,
 		MAP_VOTE,
 		PLAYER_INFO,
-	} m_MessageKind;
+	} m_MessageKind{DIRECT};
 	union
 	{
 		char m_aaMessages[MAX_MESSAGES][512];
@@ -58,7 +58,7 @@ struct CScorePlayerResult : ISqlResult
 			char m_aServer[32 + 1];
 			char m_aMap[MAX_MAP_LENGTH + 1];
 		} m_MapVote;
-	} m_Data; // PLAYER_INFO
+	} m_Data{}; // PLAYER_INFO
 
 	void SetVariant(Variant v);
 };
@@ -253,8 +253,8 @@ public:
 
 struct CTeamrank
 {
-	CUuid m_TeamID;
-	char m_aaNames[MAX_CLIENTS][MAX_NAME_LENGTH];
+	CUuid m_TeamID{};
+	char m_aaNames[MAX_CLIENTS][MAX_NAME_LENGTH]{};
 	unsigned int m_NumNames;
 	CTeamrank();
 

--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -770,8 +770,8 @@ void CGameTeams::OnFinish(CPlayer *Player, float Time, const char *pTimestamp)
 	}
 
 	{
-		CNetMsg_Sv_DDRaceTime Msg;
-		CNetMsg_Sv_DDRaceTimeLegacy MsgLegacy;
+		CNetMsg_Sv_DDRaceTime Msg{};
+		CNetMsg_Sv_DDRaceTimeLegacy MsgLegacy{};
 		MsgLegacy.m_Time = Msg.m_Time = (int)(Time * 100.0f);
 		MsgLegacy.m_Check = Msg.m_Check = 0;
 		MsgLegacy.m_Finish = Msg.m_Finish = 1;
@@ -790,7 +790,7 @@ void CGameTeams::OnFinish(CPlayer *Player, float Time, const char *pTimestamp)
 	}
 
 	{
-		protocol7::CNetMsg_Sv_RaceFinish Msg;
+		protocol7::CNetMsg_Sv_RaceFinish Msg{};
 		Msg.m_ClientID = ClientID;
 		Msg.m_Time = Time * 1000;
 		Msg.m_Diff = Diff * 1000 * (Time < pData->m_BestTime ? -1 : 1);

--- a/src/game/server/teams.h
+++ b/src/game/server/teams.h
@@ -18,22 +18,22 @@ class CGameTeams
 	// could go around the startline on a map, leave one tee behind at
 	// start, go to the finish line, let the tee start and kill, allowing
 	// the team to finish instantly.
-	bool m_TeeStarted[MAX_CLIENTS];
-	bool m_TeeFinished[MAX_CLIENTS];
-	int m_LastChat[MAX_CLIENTS];
+	bool m_TeeStarted[MAX_CLIENTS]{};
+	bool m_TeeFinished[MAX_CLIENTS]{};
+	int m_LastChat[MAX_CLIENTS]{};
 
-	int m_TeamState[NUM_TEAMS];
-	bool m_TeamLocked[NUM_TEAMS];
-	uint64_t m_Invited[NUM_TEAMS];
-	bool m_Practice[NUM_TEAMS];
+	int m_TeamState[NUM_TEAMS]{};
+	bool m_TeamLocked[NUM_TEAMS]{};
+	uint64_t m_Invited[NUM_TEAMS]{};
+	bool m_Practice[NUM_TEAMS]{};
 	std::shared_ptr<CScoreSaveResult> m_pSaveTeamResult[NUM_TEAMS];
-	uint64_t m_LastSwap[NUM_TEAMS];
-	bool m_TeamSentStartWarning[NUM_TEAMS];
+	uint64_t m_LastSwap[NUM_TEAMS]{};
+	bool m_TeamSentStartWarning[NUM_TEAMS]{};
 	// `m_TeamUnfinishableKillTick` is -1 by default and gets set when a
 	// team becomes unfinishable. If the team hasn't entered practice mode
 	// by that time, it'll get killed to prevent people not understanding
 	// the message from playing for a long time in an unfinishable team.
-	int m_TeamUnfinishableKillTick[NUM_TEAMS];
+	int m_TeamUnfinishableKillTick[NUM_TEAMS]{};
 
 	class CGameContext *m_pGameContext;
 

--- a/src/game/server/teehistorian.cpp
+++ b/src/game/server/teehistorian.cpp
@@ -200,7 +200,7 @@ void CTeeHistorian::WriteExtra(CUuid Uuid, const void *pData, int DataSize)
 {
 	EnsureTickWritten();
 
-	CPacker Ex;
+	CPacker Ex{};
 	Ex.Reset();
 	Ex.AddInt(-TEEHISTORIAN_EX);
 	Ex.AddRaw(&Uuid, sizeof(Uuid));
@@ -262,7 +262,7 @@ void CTeeHistorian::RecordPlayer(int ClientID, const CNetObj_CharacterCore *pCha
 	{
 		EnsureTickWrittenPlayerData(ClientID);
 
-		CPacker Buffer;
+		CPacker Buffer{};
 		Buffer.Reset();
 		if(pPrev->m_Alive)
 		{
@@ -305,7 +305,7 @@ void CTeeHistorian::RecordDeadPlayer(int ClientID)
 	{
 		EnsureTickWrittenPlayerData(ClientID);
 
-		CPacker Buffer;
+		CPacker Buffer{};
 		Buffer.Reset();
 		Buffer.AddInt(-TEEHISTORIAN_PLAYER_OLD);
 		Buffer.AddInt(ClientID);
@@ -326,7 +326,7 @@ void CTeeHistorian::RecordPlayerTeam(int ClientID, int Team)
 
 		EnsureTickWritten();
 
-		CPacker Buffer;
+		CPacker Buffer{};
 		Buffer.Reset();
 		Buffer.AddInt(ClientID);
 		Buffer.AddInt(Team);
@@ -348,7 +348,7 @@ void CTeeHistorian::RecordTeamPractice(int Team, bool Practice)
 
 		EnsureTickWritten();
 
-		CPacker Buffer;
+		CPacker Buffer{};
 		Buffer.Reset();
 		Buffer.AddInt(Team);
 		Buffer.AddInt(Practice);
@@ -377,7 +377,7 @@ void CTeeHistorian::EnsureTickWritten()
 
 void CTeeHistorian::WriteTick()
 {
-	CPacker TickPacker;
+	CPacker TickPacker{};
 	TickPacker.Reset();
 
 	int dt = m_Tick - m_LastWrittenTick - 1;
@@ -409,10 +409,10 @@ void CTeeHistorian::BeginInputs()
 
 void CTeeHistorian::RecordPlayerInput(int ClientID, uint32_t UniqueClientID, const CNetObj_PlayerInput *pInput)
 {
-	CPacker Buffer;
+	CPacker Buffer{};
 
 	CTeehistorianPlayer *pPrev = &m_aPrevPlayers[ClientID];
-	CNetObj_PlayerInput DiffInput;
+	CNetObj_PlayerInput DiffInput{};
 	if(pPrev->m_UniqueClientID == UniqueClientID)
 	{
 		if(mem_comp(&pPrev->m_Input, pInput, sizeof(pPrev->m_Input)) == 0)
@@ -458,7 +458,7 @@ void CTeeHistorian::RecordPlayerMessage(int ClientID, const void *pMsg, int MsgS
 {
 	EnsureTickWritten();
 
-	CPacker Buffer;
+	CPacker Buffer{};
 	Buffer.Reset();
 	Buffer.AddInt(-TEEHISTORIAN_MESSAGE);
 	Buffer.AddInt(ClientID);
@@ -467,7 +467,7 @@ void CTeeHistorian::RecordPlayerMessage(int ClientID, const void *pMsg, int MsgS
 
 	if(m_Debug)
 	{
-		CUnpacker Unpacker;
+		CUnpacker Unpacker{};
 		Unpacker.Reset(pMsg, MsgSize);
 		int MsgID = Unpacker.GetInt();
 		int Sys = MsgID & 1;
@@ -484,7 +484,7 @@ void CTeeHistorian::RecordPlayerJoin(int ClientID, int Protocol)
 	EnsureTickWritten();
 
 	{
-		CPacker Buffer;
+		CPacker Buffer{};
 		Buffer.Reset();
 		Buffer.AddInt(ClientID);
 		if(m_Debug)
@@ -495,7 +495,7 @@ void CTeeHistorian::RecordPlayerJoin(int ClientID, int Protocol)
 		WriteExtra(Uuid, Buffer.Data(), Buffer.Size());
 	}
 
-	CPacker Buffer;
+	CPacker Buffer{};
 	Buffer.Reset();
 	Buffer.AddInt(-TEEHISTORIAN_JOIN);
 	Buffer.AddInt(ClientID);
@@ -512,7 +512,7 @@ void CTeeHistorian::RecordPlayerReady(int ClientID)
 {
 	EnsureTickWritten();
 
-	CPacker Buffer;
+	CPacker Buffer{};
 	Buffer.Reset();
 	Buffer.AddInt(ClientID);
 
@@ -528,7 +528,7 @@ void CTeeHistorian::RecordPlayerDrop(int ClientID, const char *pReason)
 {
 	EnsureTickWritten();
 
-	CPacker Buffer;
+	CPacker Buffer{};
 	Buffer.Reset();
 	Buffer.AddInt(-TEEHISTORIAN_DROP);
 	Buffer.AddInt(ClientID);
@@ -546,7 +546,7 @@ void CTeeHistorian::RecordConsoleCommand(int ClientID, int FlagMask, const char 
 {
 	EnsureTickWritten();
 
-	CPacker Buffer;
+	CPacker Buffer{};
 	Buffer.Reset();
 	Buffer.AddInt(-TEEHISTORIAN_CONSOLE_COMMAND);
 	Buffer.AddInt(ClientID);
@@ -580,7 +580,7 @@ void CTeeHistorian::RecordPlayerSwap(int ClientID1, int ClientID2)
 {
 	EnsureTickWritten();
 
-	CPacker Buffer;
+	CPacker Buffer{};
 	Buffer.Reset();
 	Buffer.AddInt(ClientID1);
 	Buffer.AddInt(ClientID2);
@@ -592,7 +592,7 @@ void CTeeHistorian::RecordTeamSaveSuccess(int Team, CUuid SaveID, const char *pT
 {
 	EnsureTickWritten();
 
-	CPacker Buffer;
+	CPacker Buffer{};
 	Buffer.Reset();
 	Buffer.AddInt(Team);
 	Buffer.AddRaw(&SaveID, sizeof(SaveID));
@@ -612,7 +612,7 @@ void CTeeHistorian::RecordTeamSaveFailure(int Team)
 {
 	EnsureTickWritten();
 
-	CPacker Buffer;
+	CPacker Buffer{};
 	Buffer.Reset();
 	Buffer.AddInt(Team);
 
@@ -628,7 +628,7 @@ void CTeeHistorian::RecordTeamLoadSuccess(int Team, CUuid SaveID, const char *pT
 {
 	EnsureTickWritten();
 
-	CPacker Buffer;
+	CPacker Buffer{};
 	Buffer.Reset();
 	Buffer.AddInt(Team);
 	Buffer.AddRaw(&SaveID, sizeof(SaveID));
@@ -648,7 +648,7 @@ void CTeeHistorian::RecordTeamLoadFailure(int Team)
 {
 	EnsureTickWritten();
 
-	CPacker Buffer;
+	CPacker Buffer{};
 	Buffer.Reset();
 	Buffer.AddInt(Team);
 
@@ -675,7 +675,7 @@ void CTeeHistorian::EndTick()
 
 void CTeeHistorian::RecordDDNetVersionOld(int ClientID, int DDNetVersion)
 {
-	CPacker Buffer;
+	CPacker Buffer{};
 	Buffer.Reset();
 	Buffer.AddInt(ClientID);
 	Buffer.AddInt(DDNetVersion);
@@ -690,7 +690,7 @@ void CTeeHistorian::RecordDDNetVersionOld(int ClientID, int DDNetVersion)
 
 void CTeeHistorian::RecordDDNetVersion(int ClientID, CUuid ConnectionID, int DDNetVersion, const char *pDDNetVersionStr)
 {
-	CPacker Buffer;
+	CPacker Buffer{};
 	Buffer.Reset();
 	Buffer.AddInt(ClientID);
 	Buffer.AddRaw(&ConnectionID, sizeof(ConnectionID));
@@ -709,7 +709,7 @@ void CTeeHistorian::RecordDDNetVersion(int ClientID, CUuid ConnectionID, int DDN
 
 void CTeeHistorian::RecordAuthInitial(int ClientID, int Level, const char *pAuthName)
 {
-	CPacker Buffer;
+	CPacker Buffer{};
 	Buffer.Reset();
 	Buffer.AddInt(ClientID);
 	Buffer.AddInt(Level);
@@ -725,7 +725,7 @@ void CTeeHistorian::RecordAuthInitial(int ClientID, int Level, const char *pAuth
 
 void CTeeHistorian::RecordAuthLogin(int ClientID, int Level, const char *pAuthName)
 {
-	CPacker Buffer;
+	CPacker Buffer{};
 	Buffer.Reset();
 	Buffer.AddInt(ClientID);
 	Buffer.AddInt(Level);
@@ -741,7 +741,7 @@ void CTeeHistorian::RecordAuthLogin(int ClientID, int Level, const char *pAuthNa
 
 void CTeeHistorian::RecordAuthLogout(int ClientID)
 {
-	CPacker Buffer;
+	CPacker Buffer{};
 	Buffer.Reset();
 	Buffer.AddInt(ClientID);
 
@@ -766,7 +766,7 @@ void CTeeHistorian::Finish()
 		EndTick();
 	}
 
-	CPacker Buffer;
+	CPacker Buffer{};
 	Buffer.Reset();
 	Buffer.AddInt(-TEEHISTORIAN_FINISH);
 

--- a/src/game/server/teehistorian.h
+++ b/src/game/server/teehistorian.h
@@ -86,7 +86,7 @@ public:
 	void RecordAuthLogin(int ClientID, int Level, const char *pAuthName);
 	void RecordAuthLogout(int ClientID);
 
-	int m_Debug; // Possible values: 0, 1, 2.
+	int m_Debug{}; // Possible values: 0, 1, 2.
 
 private:
 	void WriteHeader(const CGameInfo *pGameInfo);
@@ -131,13 +131,13 @@ private:
 
 	int m_State;
 
-	int m_LastWrittenTick;
-	bool m_TickWritten;
-	int m_Tick;
-	int m_PrevMaxClientID;
-	int m_MaxClientID;
-	CTeehistorianPlayer m_aPrevPlayers[MAX_CLIENTS];
-	CTeam m_aPrevTeams[MAX_CLIENTS];
+	int m_LastWrittenTick{};
+	bool m_TickWritten{};
+	int m_Tick{};
+	int m_PrevMaxClientID{};
+	int m_MaxClientID{};
+	CTeehistorianPlayer m_aPrevPlayers[MAX_CLIENTS]{};
+	CTeam m_aPrevTeams[MAX_CLIENTS]{};
 };
 
 #endif // GAME_SERVER_TEEHISTORIAN_H

--- a/src/game/teamscore.h
+++ b/src/game/teamscore.h
@@ -23,11 +23,11 @@ enum
 
 class CTeamsCore
 {
-	int m_Team[MAX_CLIENTS];
-	bool m_IsSolo[MAX_CLIENTS];
+	int m_Team[MAX_CLIENTS]{};
+	bool m_IsSolo[MAX_CLIENTS]{};
 
 public:
-	bool m_IsDDRace16;
+	bool m_IsDDRace16{};
 
 	CTeamsCore();
 

--- a/src/tools/config_store.cpp
+++ b/src/tools/config_store.cpp
@@ -16,7 +16,7 @@ void Process(IStorage *pStorage, const char *pMapName, const char *pConfigName)
 		return;
 	}
 
-	CLineReader LineReader;
+	CLineReader LineReader{};
 	LineReader.Init(File);
 
 	char *pLine;
@@ -55,7 +55,7 @@ void Process(IStorage *pStorage, const char *pMapName, const char *pConfigName)
 		int ItemID;
 		int *pData = (int *)Reader.GetItem(i, &TypeID, &ItemID);
 		int Size = Reader.GetItemSize(i);
-		CMapItemInfoSettings MapInfo;
+		CMapItemInfoSettings MapInfo{};
 		if(TypeID == MAPITEMTYPE_INFO && ItemID == 0)
 		{
 			FoundInfo = true;
@@ -99,7 +99,7 @@ void Process(IStorage *pStorage, const char *pMapName, const char *pConfigName)
 
 	if(!FoundInfo)
 	{
-		CMapItemInfoSettings Info;
+		CMapItemInfoSettings Info{};
 		Info.m_Version = 1;
 		Info.m_Author = -1;
 		Info.m_MapVersion = -1;

--- a/src/tools/dummy_map.cpp
+++ b/src/tools/dummy_map.cpp
@@ -13,7 +13,7 @@ void CreateEmptyMap(IStorage *pStorage)
 		dbg_msg("empty_map", "couldn't open map file 'dummy3.map' for writing");
 		return;
 	}
-	CMapItemGroup_v1 Group;
+	CMapItemGroup_v1 Group{};
 	Group.m_Version = 1;
 	Group.m_OffsetX = 0;
 	Group.m_OffsetY = 0;
@@ -23,7 +23,7 @@ void CreateEmptyMap(IStorage *pStorage)
 	Group.m_NumLayers = 2;
 	Writer.AddItem(MAPITEMTYPE_GROUP, 0, sizeof(Group), &Group);
 
-	CMapItemLayerTilemap GameLayer;
+	CMapItemLayerTilemap GameLayer{};
 	GameLayer.m_Layer.m_Version = 0; // Not set by the official client.
 	GameLayer.m_Layer.m_Type = LAYERTYPE_TILES;
 	GameLayer.m_Layer.m_Flags = 0;
@@ -41,7 +41,7 @@ void CreateEmptyMap(IStorage *pStorage)
 	GameLayer.m_Data = 0;
 	Writer.AddItem(MAPITEMTYPE_LAYER, 0, sizeof(GameLayer) - sizeof(GameLayer.m_aName), &GameLayer);
 
-	CMapItemLayerTilemap Layer;
+	CMapItemLayerTilemap Layer{};
 	Layer.m_Layer.m_Version = 0;
 	Layer.m_Layer.m_Type = LAYERTYPE_TILES;
 	Layer.m_Layer.m_Flags = 0;

--- a/src/tools/map_convert_07.cpp
+++ b/src/tools/map_convert_07.cpp
@@ -114,7 +114,7 @@ void *ReplaceImageItem(void *pItem, int Type, CMapItemImage *pNewImgItem)
 	char *pName = (char *)g_DataReader.GetData(pImgItem->m_ImageName);
 	dbg_msg("map_convert_07", "embedding image '%s'", pName);
 
-	CImageInfo ImgInfo;
+	CImageInfo ImgInfo{};
 	char aStr[64];
 	str_format(aStr, sizeof(aStr), "data/mapres/%s.png", pName);
 	if(!LoadPNG(&ImgInfo, aStr))
@@ -220,7 +220,7 @@ int main(int argc, const char **argv)
 	// add all items
 	for(int Index = 0; Index < g_DataReader.NumItems(); Index++)
 	{
-		CMapItemImage NewImageItem;
+		CMapItemImage NewImageItem{};
 		pItem = g_DataReader.GetItem(Index, &Type, &ID);
 		Size = g_DataReader.GetItemSize(Index);
 

--- a/src/tools/map_optimize.cpp
+++ b/src/tools/map_optimize.cpp
@@ -201,7 +201,7 @@ int main(int argc, const char **argv)
 			CMapItemImage *pImg = (CMapItemImage *)pPtr;
 			if(!pImg->m_External)
 			{
-				SMapOptimizeItem Item;
+				SMapOptimizeItem Item{};
 				Item.m_pImage = pImg;
 				Item.m_Index = i;
 				Item.m_Data = pImg->m_ImageData;

--- a/src/tools/map_replace_image.cpp
+++ b/src/tools/map_replace_image.cpp
@@ -90,7 +90,7 @@ void *ReplaceImageItem(void *pItem, int Type, const char *pImgName, const char *
 
 	dbg_msg("map_replace_image", "found image '%s'", pImgName);
 
-	CImageInfo ImgInfo;
+	CImageInfo ImgInfo{};
 	if(!LoadPNG(&ImgInfo, pImgFile))
 		return 0;
 
@@ -159,7 +159,7 @@ int main(int argc, const char **argv)
 	// add all items
 	for(int Index = 0; Index < g_DataReader.NumItems(); Index++)
 	{
-		CMapItemImage NewImageItem;
+		CMapItemImage NewImageItem{};
 		pItem = g_DataReader.GetItem(Index, &Type, &ID);
 		Size = g_DataReader.GetItemSize(Index);
 

--- a/src/tools/stun.cpp
+++ b/src/tools/stun.cpp
@@ -32,7 +32,7 @@ int main(int argc, const char **argv)
 		return 2;
 	}
 
-	CStunData Stun;
+	CStunData Stun{};
 	unsigned char aRequest[32];
 	int RequestSize = StunMessagePrepare(aRequest, sizeof(aRequest), &Stun);
 	if(net_udp_send(Socket, &Addr, aRequest, RequestSize) == -1)


### PR DESCRIPTION
Strictly enforces initialization of members, could be considered too
extreme, but at least we'd end up with fewer uninitialized member
accesses:
https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines-pro-type-member-init.html

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
