### PR TITLE
Remove predicted character from gameworld before calling base class d…

### DIFF
--- a/src/game/client/prediction/entities/character.cpp
+++ b/src/game/client/prediction/entities/character.cpp
@@ -1379,3 +1379,9 @@ void CCharacter::SetTuneZone(int Zone)
 	m_TuneZone = Zone;
 	m_LastTuneZoneTick = GameWorld()->GameTick();
 }
+
+CCharacter::~CCharacter()
+{
+	if(GameWorld())
+		GameWorld()->RemoveCharacter(this);
+}

--- a/src/game/client/prediction/entities/character.h
+++ b/src/game/client/prediction/entities/character.h
@@ -33,6 +33,8 @@ class CCharacter : public CEntity
 	friend class CGameWorld;
 
 public:
+	~CCharacter();
+
 	//character's size
 	static const int ms_PhysSize = 28;
 

--- a/src/game/client/prediction/gameworld.cpp
+++ b/src/game/client/prediction/gameworld.cpp
@@ -142,22 +142,19 @@ void CGameWorld::RemoveEntity(CEntity *pEnt)
 	pEnt->m_pNextTypeEntity = 0;
 	pEnt->m_pPrevTypeEntity = 0;
 
-	if(pEnt->m_ObjType == ENTTYPE_CHARACTER)
-	{
-		if(CCharacter *pChar = dynamic_cast<CCharacter *>(pEnt))
-		{
-			int ID = pChar->GetCID();
-			if(ID >= 0 && ID < MAX_CLIENTS)
-			{
-				m_apCharacters[ID] = 0;
-				m_Core.m_apCharacters[ID] = 0;
-			}
-		}
-	}
-
 	if(m_IsValidCopy && m_pParent && m_pParent->m_pChild == this && pEnt->m_pParent)
 		pEnt->m_pParent->m_DestroyTick = GameTick();
 	pEnt->m_pParent = 0;
+}
+
+void CGameWorld::RemoveCharacter(CCharacter *pChar)
+{
+	int ID = pChar->GetCID();
+	if(ID >= 0 && ID < MAX_CLIENTS)
+	{
+		m_apCharacters[ID] = 0;
+		m_Core.m_apCharacters[ID] = 0;
+	}
 }
 
 void CGameWorld::RemoveEntities()

--- a/src/game/client/prediction/gameworld.h
+++ b/src/game/client/prediction/gameworld.h
@@ -37,6 +37,7 @@ public:
 	class CCharacter *IntersectCharacter(vec2 Pos0, vec2 Pos1, float Radius, vec2 &NewPos, class CCharacter *pNotThis = 0, int CollideWith = -1, class CCharacter *pThisOnly = 0);
 	void InsertEntity(CEntity *pEntity, bool Last = false);
 	void RemoveEntity(CEntity *pEntity);
+	void RemoveCharacter(CCharacter *pChar);
 	void Tick();
 
 	// DDRace


### PR DESCRIPTION
…estructor

cc #5241

I believe this fixes #5238. Edit: Seems to fix #5239 as well (no longer crashes in OnPredict while being in a map and zooming in/out).

After looking at the code I think it could need a larger cleanup (and Im not 100% happy with this solution), so I plan to look more into this and the related code afterwards.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
