### PR TITLE
disable dragger beams soon, not only every 150ms

### DIFF
--- a/src/game/server/entities/dragger.cpp
+++ b/src/game/server/entities/dragger.cpp
@@ -141,7 +141,7 @@ void CDragger::LookForPlayersToDrag()
 		// Create Dragger Beams which have not been created yet
 		if(IsTarget[i] && m_apDraggerBeam[i] == nullptr)
 		{
-			m_apDraggerBeam[i] = new CDraggerBeam(&GameServer()->m_World, this, m_Pos, m_Strength, m_IgnoreWalls, i);
+			m_apDraggerBeam[i] = new CDraggerBeam(&GameServer()->m_World, this, m_Pos, m_Strength, m_IgnoreWalls, i, m_Layer, m_Number);
 		}
 		// Remove dragger beams that have not yet been deleted
 		else if(!IsTarget[i] && m_apDraggerBeam[i] != nullptr)

--- a/src/game/server/entities/dragger_beam.h
+++ b/src/game/server/entities/dragger_beam.h
@@ -29,7 +29,7 @@ class CDraggerBeam : public CEntity
 	bool m_Active;
 
 public:
-	CDraggerBeam(CGameWorld *pGameWorld, CDragger *pDragger, vec2 Pos, float Strength, bool IgnoreWalls, int ForClientID);
+	CDraggerBeam(CGameWorld *pGameWorld, CDragger *pDragger, vec2 Pos, float Strength, bool IgnoreWalls, int ForClientID, int Layer, int Number);
 
 	void SetPos(vec2 Pos);
 


### PR DESCRIPTION
The check whether a dragger is active, I somehow forgot in the dragger beams. Sorry! Actually, I should have noticed this during testing. But when I tested Fall into the Future today, it seemed strange to me (already at the first part). I should have noticed it when I tested it. I have compared that in any case with 15.9.1 and looked at the code again and saw that there the check is made every tick.


## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [x] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
