### PR TITLE
Add `CUI::CheckActiveItem`, preventing the UI from locking up

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -507,7 +507,7 @@ int CMenus::DoValueSelector(void *pID, CUIRect *pRect, const char *pLabel, bool 
 		if(!UI()->MouseButton(0))
 		{
 			//m_LockMouse = false;
-			UI()->SetActiveItem(0);
+			UI()->SetActiveItem(nullptr);
 			ms_ValueSelectorTextMode = false;
 		}
 	}
@@ -527,14 +527,14 @@ int CMenus::DoValueSelector(void *pID, CUIRect *pRect, const char *pLabel, bool 
 			else
 				Current = clamp(str_toint(s_NumStr), Min, Max);
 			//m_LockMouse = false;
-			UI()->SetActiveItem(0);
+			UI()->SetActiveItem(nullptr);
 			ms_ValueSelectorTextMode = false;
 		}
 
 		if(Input()->KeyIsPressed(KEY_ESCAPE))
 		{
 			//m_LockMouse = false;
-			UI()->SetActiveItem(0);
+			UI()->SetActiveItem(nullptr);
 			ms_ValueSelectorTextMode = false;
 		}
 	}
@@ -626,7 +626,7 @@ int CMenus::DoKeyReader(void *pID, const CUIRect *pRect, int Key, int ModifierCo
 				*NewModifierCombination = m_Binder.m_ModifierCombination;
 			}
 			m_Binder.m_GotKey = false;
-			UI()->SetActiveItem(0);
+			UI()->SetActiveItem(nullptr);
 			MouseReleased = false;
 			pGrabbedID = pID;
 		}
@@ -635,7 +635,7 @@ int CMenus::DoKeyReader(void *pID, const CUIRect *pRect, int Key, int ModifierCo
 		{
 			if(Inside)
 				NewKey = 0;
-			UI()->SetActiveItem(0);
+			UI()->SetActiveItem(nullptr);
 		}
 	}
 	else if(UI()->HotItem() == pID)
@@ -1060,7 +1060,7 @@ void CMenus::OnInit()
 void CMenus::PopupMessage(const char *pTopic, const char *pBody, const char *pButton)
 {
 	// reset active item
-	UI()->SetActiveItem(0);
+	UI()->SetActiveItem(nullptr);
 
 	str_copy(m_aMessageTopic, pTopic, sizeof(m_aMessageTopic));
 	str_copy(m_aMessageBody, pBody, sizeof(m_aMessageBody));
@@ -1073,7 +1073,7 @@ void CMenus::PopupWarning(const char *pTopic, const char *pBody, const char *pBu
 	dbg_msg(pTopic, "%s", pBody);
 
 	// reset active item
-	UI()->SetActiveItem(0);
+	UI()->SetActiveItem(nullptr);
 
 	str_copy(m_aMessageTopic, pTopic, sizeof(m_aMessageTopic));
 	str_copy(m_aMessageBody, pBody, sizeof(m_aMessageBody));
@@ -1096,7 +1096,7 @@ void CMenus::RenderColorPicker()
 	{
 		ms_ColorPicker.m_Active = false;
 		ms_ValueSelectorTextMode = false;
-		UI()->SetActiveItem(0);
+		UI()->SetActiveItem(nullptr);
 	}
 
 	if(!ms_ColorPicker.m_Active)
@@ -1113,7 +1113,7 @@ void CMenus::RenderColorPicker()
 	{
 		ms_ColorPicker.m_Active = false;
 		ms_ValueSelectorTextMode = false;
-		UI()->SetActiveItem(0);
+		UI()->SetActiveItem(nullptr);
 		return;
 	}
 
@@ -1151,7 +1151,7 @@ void CMenus::RenderColorPicker()
 	{
 		ms_ColorPicker.m_Active = false;
 		ms_ValueSelectorTextMode = false;
-		UI()->SetActiveItem(0);
+		UI()->SetActiveItem(nullptr);
 		return;
 	}
 
@@ -1446,7 +1446,7 @@ int CMenus::Render()
 	{
 		// make sure that other windows doesn't do anything funnay!
 		//UI()->SetHotItem(0);
-		//UI()->SetActiveItem(0);
+		//UI()->SetActiveItem(nullptr);
 		char aBuf[1536];
 		const char *pTitle = "";
 		const char *pExtraText = "";
@@ -2309,7 +2309,7 @@ int CMenus::Render()
 		}
 
 		if(m_Popup == POPUP_NONE)
-			UI()->SetActiveItem(0);
+			UI()->SetActiveItem(nullptr);
 	}
 	return 0;
 }
@@ -2476,7 +2476,7 @@ bool CMenus::OnInput(IInput::CEvent e)
 void CMenus::OnStateChange(int NewState, int OldState)
 {
 	// reset active item
-	UI()->SetActiveItem(0);
+	UI()->SetActiveItem(nullptr);
 
 	if(NewState == IClient::STATE_OFFLINE)
 	{

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -502,7 +502,7 @@ int CMenus::DoValueSelector(void *pID, CUIRect *pRect, const char *pLabel, bool 
 			str_format(s_NumStr, sizeof(s_NumStr), "%d", Current);
 	}
 
-	if(UI()->ActiveItem() == pID)
+	if(UI()->CheckActiveItem(pID))
 	{
 		if(!UI()->MouseButton(0))
 		{
@@ -540,7 +540,7 @@ int CMenus::DoValueSelector(void *pID, CUIRect *pRect, const char *pLabel, bool 
 	}
 	else
 	{
-		if(UI()->ActiveItem() == pID)
+		if(UI()->CheckActiveItem(pID))
 		{
 			if(UseScroll)
 			{
@@ -615,7 +615,7 @@ int CMenus::DoKeyReader(void *pID, const CUIRect *pRect, int Key, int ModifierCo
 	if(!UI()->MouseButton(0) && !UI()->MouseButton(1) && pGrabbedID == pID)
 		MouseReleased = true;
 
-	if(UI()->ActiveItem() == pID)
+	if(UI()->CheckActiveItem(pID))
 	{
 		if(m_Binder.m_GotKey)
 		{
@@ -662,7 +662,7 @@ int CMenus::DoKeyReader(void *pID, const CUIRect *pRect, int Key, int ModifierCo
 		UI()->SetHotItem(pID);
 
 	// draw
-	if(UI()->ActiveItem() == pID && s_ButtonUsed == 0)
+	if(UI()->CheckActiveItem(pID) && s_ButtonUsed == 0)
 		DoButton_KeySelect(pID, "???", 0, pRect);
 	else
 	{
@@ -2518,6 +2518,8 @@ void CMenus::OnStateChange(int NewState, int OldState)
 
 void CMenus::OnRender()
 {
+	UI()->StartCheck();
+
 	if(Client()->State() != IClient::STATE_ONLINE && Client()->State() != IClient::STATE_DEMOPLAYBACK)
 		SetActive(true);
 
@@ -2609,6 +2611,8 @@ void CMenus::OnRender()
 		TextRender()->SetCursor(&Cursor, 10, 10, 10, TEXTFLAG_RENDER);
 		TextRender()->TextEx(&Cursor, aBuf, -1);
 	}
+
+	UI()->FinishCheck();
 
 	m_EscapePressed = false;
 	m_EnterPressed = false;

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -178,7 +178,7 @@ class CMenus : public CComponent
 		}
 		// render
 		size_t Index = 2;
-		if(UI()->ActiveItem() == pID)
+		if(UI()->CheckActiveItem(pID))
 			Index = 0;
 		else if(UI()->HotItem() == pID)
 			Index = 1;

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -312,7 +312,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 		{
 			// reset active item, if not visible
 			if(UI()->CheckActiveItem(pItem))
-				UI()->SetActiveItem(0);
+				UI()->SetActiveItem(nullptr);
 
 			// don't render invisible items
 			continue;

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -311,7 +311,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 		else
 		{
 			// reset active item, if not visible
-			if(UI()->ActiveItem() == pItem)
+			if(UI()->CheckActiveItem(pItem))
 				UI()->SetActiveItem(0);
 
 			// don't render invisible items

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -336,7 +336,7 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 		if(UI()->CheckActiveItem(id))
 		{
 			if(!UI()->MouseButton(0))
-				UI()->SetActiveItem(0);
+				UI()->SetActiveItem(nullptr);
 			else
 			{
 				static float PrevAmount = 0.0f;
@@ -652,7 +652,7 @@ CMenus::CListboxItem CMenus::UiDoListboxNextItem(const void *pId, bool Selected,
 			if(m_EnterPressed || (DoubleClickable && Input()->MouseDoubleClick()))
 			{
 				gs_ListBoxItemActivated = true;
-				UI()->SetActiveItem(0);
+				UI()->SetActiveItem(nullptr);
 			}
 			else if(KeyEvents)
 			{
@@ -1192,7 +1192,7 @@ void CMenus::RenderDemoList(CUIRect MainView)
 	bool Activated = false;
 	if(m_EnterPressed || (DoubleClicked && Input()->MouseDoubleClick()))
 	{
-		UI()->SetActiveItem(0);
+		UI()->SetActiveItem(nullptr);
 		Activated = true;
 	}
 
@@ -1238,7 +1238,7 @@ void CMenus::RenderDemoList(CUIRect MainView)
 					PopupMessage(Localize("Error"), str_comp(pError, "error loading demo") ? pError : Localize("Error loading demo"), Localize("Ok"));
 				else
 				{
-					UI()->SetActiveItem(0);
+					UI()->SetActiveItem(nullptr);
 					return;
 				}
 			}
@@ -1264,7 +1264,7 @@ void CMenus::RenderDemoList(CUIRect MainView)
 		{
 			if(m_DemolistSelectedIndex >= 0)
 			{
-				UI()->SetActiveItem(0);
+				UI()->SetActiveItem(nullptr);
 				m_Popup = POPUP_DELETE_DEMO;
 				return;
 			}
@@ -1275,7 +1275,7 @@ void CMenus::RenderDemoList(CUIRect MainView)
 		{
 			if(m_DemolistSelectedIndex >= 0)
 			{
-				UI()->SetActiveItem(0);
+				UI()->SetActiveItem(nullptr);
 				m_Popup = POPUP_RENAME_DEMO;
 				str_copy(m_aCurrentDemoFile, m_lDemos[m_DemolistSelectedIndex].m_aFilename, sizeof(m_aCurrentDemoFile));
 				return;
@@ -1288,7 +1288,7 @@ void CMenus::RenderDemoList(CUIRect MainView)
 		{
 			if(m_DemolistSelectedIndex >= 0)
 			{
-				UI()->SetActiveItem(0);
+				UI()->SetActiveItem(nullptr);
 				m_Popup = POPUP_RENDER_DEMO;
 				str_copy(m_aCurrentDemoFile, m_lDemos[m_DemolistSelectedIndex].m_aFilename, sizeof(m_aCurrentDemoFile));
 				return;

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -333,7 +333,7 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 		// do the logic
 		const bool Inside = UI()->MouseInside(&SeekBar);
 
-		if(UI()->ActiveItem() == id)
+		if(UI()->CheckActiveItem(id))
 		{
 			if(!UI()->MouseButton(0))
 				UI()->SetActiveItem(0);

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -399,7 +399,7 @@ void CMenus::RenderSettingsPlayer(CUIRect MainView)
 	}
 
 	static bool s_ListBoxUsed = false;
-	if(UI()->ActiveItem() == pClan || UI()->ActiveItem() == pName)
+	if(UI()->CheckActiveItem(pClan) || UI()->CheckActiveItem(pName))
 		s_ListBoxUsed = false;
 
 	// country flag selector

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -159,7 +159,7 @@ void CUI::ConvertMouseMove(float *x, float *y) const
 
 float CUI::ButtonColorMul(const void *pID)
 {
-	if(ActiveItem() == pID)
+	if(CheckActiveItem(pID))
 		return ButtonColorMulActive();
 	else if(HotItem() == pID)
 		return ButtonColorMulHot();
@@ -432,7 +432,7 @@ int CUI::DoButtonLogic(const void *pID, int Checked, const CUIRect *pRect)
 	const bool Inside = MouseHovered(pRect);
 	static int s_ButtonUsed = 0;
 
-	if(ActiveItem() == pID)
+	if(CheckActiveItem(pID))
 	{
 		if(!MouseButton(s_ButtonUsed))
 		{
@@ -467,10 +467,10 @@ int CUI::DoPickerLogic(const void *pID, const CUIRect *pRect, float *pX, float *
 	if(HotItem() == pID && MouseButtonClicked(0))
 		SetActiveItem(pID);
 
-	if(ActiveItem() == pID && !MouseButton(0))
+	if(CheckActiveItem(pID) && !MouseButton(0))
 		SetActiveItem(0);
 
-	if(ActiveItem() != pID)
+	if(!CheckActiveItem(pID))
 		return 0;
 
 	if(pX)

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -438,7 +438,7 @@ int CUI::DoButtonLogic(const void *pID, int Checked, const CUIRect *pRect)
 		{
 			if(Inside && Checked >= 0)
 				ReturnValue = 1 + s_ButtonUsed;
-			SetActiveItem(0);
+			SetActiveItem(nullptr);
 		}
 	}
 	else if(HotItem() == pID)
@@ -468,7 +468,7 @@ int CUI::DoPickerLogic(const void *pID, const CUIRect *pRect, float *pX, float *
 		SetActiveItem(pID);
 
 	if(CheckActiveItem(pID) && !MouseButton(0))
-		SetActiveItem(0);
+		SetActiveItem(nullptr);
 
 	if(!CheckActiveItem(pID))
 		return 0;

--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -197,6 +197,8 @@ class CUI
 	const void *m_pLastActiveItem;
 	const void *m_pBecomingHotItem;
 	const void *m_pActiveTooltipItem;
+	bool m_ActiveItemValid = false;
+
 	float m_MouseX, m_MouseY; // in gui space
 	float m_MouseDeltaX, m_MouseDeltaY; // in gui space
 	float m_MouseWorldX, m_MouseWorldY; // in world space
@@ -264,17 +266,34 @@ public:
 	void SetHotItem(const void *pID) { m_pBecomingHotItem = pID; }
 	void SetActiveItem(const void *pID)
 	{
+		m_ActiveItemValid = true;
 		m_pActiveItem = pID;
 		if(pID)
 			m_pLastActiveItem = pID;
 	}
+	bool CheckActiveItem(const void *pID)
+	{
+		if(m_pActiveItem == pID)
+		{
+			m_ActiveItemValid = true;
+			return true;
+		}
+		return false;
+	}
 	void SetActiveTooltipItem(const void *pID) { m_pActiveTooltipItem = pID; }
-	void ClearLastActiveItem() { m_pLastActiveItem = 0; }
+	void ClearLastActiveItem() { m_pLastActiveItem = nullptr; }
 	const void *HotItem() const { return m_pHotItem; }
 	const void *NextHotItem() const { return m_pBecomingHotItem; }
 	const void *ActiveItem() const { return m_pActiveItem; }
 	const void *ActiveTooltipItem() const { return m_pActiveTooltipItem; }
 	const void *LastActiveItem() const { return m_pLastActiveItem; }
+
+	void StartCheck() { m_ActiveItemValid = false; }
+	void FinishCheck()
+	{
+		if(!m_ActiveItemValid)
+			SetActiveItem(nullptr);
+	}
 
 	bool MouseInside(const CUIRect *pRect) const;
 	bool MouseInsideClip() const { return !IsClipped() || MouseInside(ClipArea()); }

--- a/src/game/client/ui_ex.cpp
+++ b/src/game/client/ui_ex.cpp
@@ -61,7 +61,7 @@ float CUIEx::DoScrollbarV(const void *pID, const CUIRect *pRect, float Current)
 	const bool InsideHandle = UI()->MouseHovered(&Handle);
 	bool Grabbed = false; // whether to apply the offset
 
-	if(UI()->ActiveItem() == pID)
+	if(UI()->CheckActiveItem(pID))
 	{
 		if(UI()->MouseButton(0))
 		{
@@ -108,7 +108,7 @@ float CUIEx::DoScrollbarV(const void *pID, const CUIRect *pRect, float Current)
 	RenderTools()->DrawUIRect(&Rail, ColorRGBA(1.0f, 1.0f, 1.0f, 0.25f), CUI::CORNER_ALL, Rail.w / 2.0f);
 
 	float ColorSlider;
-	if(UI()->ActiveItem() == pID)
+	if(UI()->CheckActiveItem(pID))
 		ColorSlider = 0.9f;
 	else if(UI()->HotItem() == pID)
 		ColorSlider = 1.0f;
@@ -141,7 +141,7 @@ float CUIEx::DoScrollbarH(const void *pID, const CUIRect *pRect, float Current, 
 	const bool InsideHandle = UI()->MouseHovered(&Handle);
 	bool Grabbed = false; // whether to apply the offset
 
-	if(UI()->ActiveItem() == pID)
+	if(UI()->CheckActiveItem(pID))
 	{
 		if(UI()->MouseButton(0))
 		{
@@ -199,7 +199,7 @@ float CUIEx::DoScrollbarH(const void *pID, const CUIRect *pRect, float Current, 
 		RenderTools()->DrawUIRect(&Rail, ColorRGBA(1.0f, 1.0f, 1.0f, 0.25f), CUI::CORNER_ALL, Rail.h / 2.0f);
 
 		float ColorSlider;
-		if(UI()->ActiveItem() == pID)
+		if(UI()->CheckActiveItem(pID))
 			ColorSlider = 0.9f;
 		else if(UI()->HotItem() == pID)
 			ColorSlider = 1.0f;
@@ -507,7 +507,7 @@ bool CUIEx::DoEditBox(const void *pID, const CUIRect *pRect, char *pStr, unsigne
 	DispCursorPos = minimum(DispCursorPos, str_length(pDisplayStr));
 
 	bool JustGotActive = false;
-	if(UI()->ActiveItem() == pID)
+	if(UI()->CheckActiveItem(pID))
 	{
 		if(!UI()->MouseButton(0))
 		{

--- a/src/game/client/ui_ex.cpp
+++ b/src/game/client/ui_ex.cpp
@@ -71,7 +71,7 @@ float CUIEx::DoScrollbarV(const void *pID, const CUIRect *pRect, float Current)
 		}
 		else
 		{
-			UI()->SetActiveItem(0);
+			UI()->SetActiveItem(nullptr);
 		}
 	}
 	else if(UI()->HotItem() == pID)
@@ -151,7 +151,7 @@ float CUIEx::DoScrollbarH(const void *pID, const CUIRect *pRect, float Current, 
 		}
 		else
 		{
-			UI()->SetActiveItem(0);
+			UI()->SetActiveItem(nullptr);
 		}
 	}
 	else if(UI()->HotItem() == pID)
@@ -511,7 +511,7 @@ bool CUIEx::DoEditBox(const void *pID, const CUIRect *pRect, char *pStr, unsigne
 	{
 		if(!UI()->MouseButton(0))
 		{
-			UI()->SetActiveItem(0);
+			UI()->SetActiveItem(nullptr);
 		}
 	}
 	else if(UI()->HotItem() == pID)

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -540,7 +540,7 @@ int CEditor::UiDoValueSelector(void *pID, CUIRect *pRect, const char *pLabel, in
 			str_format(s_aNumStr, sizeof(s_aNumStr), "%d", Current);
 	}
 
-	if(UI()->ActiveItem() == pID)
+	if(UI()->CheckActiveItem(pID))
 	{
 		if(!UI()->MouseButton(0))
 		{
@@ -580,7 +580,7 @@ int CEditor::UiDoValueSelector(void *pID, CUIRect *pRect, const char *pLabel, in
 	}
 	else
 	{
-		if(UI()->ActiveItem() == pID)
+		if(UI()->CheckActiveItem(pID))
 		{
 			if(UI()->MouseButton(0))
 			{
@@ -1243,7 +1243,7 @@ void CEditor::DoSoundSource(CSoundSource *pSource, int Index)
 	bool IgnoreGrid;
 	IgnoreGrid = Input()->KeyIsPressed(KEY_LALT) || Input()->KeyIsPressed(KEY_RALT);
 
-	if(UI()->ActiveItem() == pID)
+	if(UI()->CheckActiveItem(pID))
 	{
 		if(m_MouseDeltaWx * m_MouseDeltaWx + m_MouseDeltaWy * m_MouseDeltaWy > 0.0f)
 		{
@@ -1372,7 +1372,7 @@ void CEditor::DoQuad(CQuad *pQuad, int Index)
 		Graphics()->QuadsDraw(&QuadItem, 1);
 	}
 
-	if(UI()->ActiveItem() == pID)
+	if(UI()->CheckActiveItem(pID))
 	{
 		if(m_MouseDeltaWx * m_MouseDeltaWx + m_MouseDeltaWy * m_MouseDeltaWy > 0.0f)
 		{
@@ -1625,7 +1625,7 @@ void CEditor::DoQuadPoint(CQuad *pQuad, int QuadIndex, int V)
 	bool IgnoreGrid;
 	IgnoreGrid = Input()->KeyIsPressed(KEY_LALT) || Input()->KeyIsPressed(KEY_RALT);
 
-	if(UI()->ActiveItem() == pID)
+	if(UI()->CheckActiveItem(pID))
 	{
 		if(!s_Moved)
 		{
@@ -2184,7 +2184,7 @@ void CEditor::DoQuadEnvPoint(const CQuad *pQuad, int QIndex, int PIndex)
 
 	float dx = (CenterX - wx) / m_WorldZoom;
 	float dy = (CenterY - wy) / m_WorldZoom;
-	if(dx * dx + dy * dy < 50.0f && UI()->ActiveItem() == 0)
+	if(dx * dx + dy * dy < 50.0f && UI()->CheckActiveItem(nullptr))
 	{
 		UI()->SetHotItem(pID);
 		s_CurQIndex = QIndex;
@@ -2193,7 +2193,7 @@ void CEditor::DoQuadEnvPoint(const CQuad *pQuad, int QIndex, int PIndex)
 	bool IgnoreGrid;
 	IgnoreGrid = Input()->KeyIsPressed(KEY_LALT) || Input()->KeyIsPressed(KEY_RALT);
 
-	if(UI()->ActiveItem() == pID && s_CurQIndex == QIndex)
+	if(UI()->CheckActiveItem(pID) && s_CurQIndex == QIndex)
 	{
 		if(s_Operation == OP_MOVE)
 		{
@@ -2479,7 +2479,7 @@ void CEditor::DoMapEditor(CUIRect View)
 		UI()->SetHotItem(s_pEditorID);
 
 		// do global operations like pan and zoom
-		if(UI()->ActiveItem() == 0 && (UI()->MouseButton(0) || UI()->MouseButton(2)))
+		if(UI()->CheckActiveItem(nullptr) && (UI()->MouseButton(0) || UI()->MouseButton(2)))
 		{
 			s_StartWx = wx;
 			s_StartWy = wy;
@@ -2530,7 +2530,7 @@ void CEditor::DoMapEditor(CUIRect View)
 			else
 				m_pTooltip = "Use left mouse button to paint with the brush. Right button clears the brush.";
 
-			if(UI()->ActiveItem() == s_pEditorID)
+			if(UI()->CheckActiveItem(s_pEditorID))
 			{
 				CUIRect r;
 				r.x = s_StartWx;
@@ -2775,7 +2775,7 @@ void CEditor::DoMapEditor(CUIRect View)
 		}
 
 		// do panning
-		if(UI()->ActiveItem() == s_pEditorID)
+		if(UI()->CheckActiveItem(s_pEditorID))
 		{
 			if(s_Operation == OP_PAN_WORLD)
 			{
@@ -2810,7 +2810,7 @@ void CEditor::DoMapEditor(CUIRect View)
 				m_WorldOffsetY += PanSpeed * m_WorldZoom;
 		}
 	}
-	else if(UI()->ActiveItem() == s_pEditorID)
+	else if(UI()->CheckActiveItem(s_pEditorID))
 	{
 		// release mouse
 		if(!UI()->MouseButton(0))
@@ -5261,7 +5261,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 
 					float ColorMod = 1.0f;
 
-					if(UI()->ActiveItem() == pID)
+					if(UI()->CheckActiveItem(pID))
 					{
 						if(!UI()->MouseButton(0))
 						{
@@ -5355,7 +5355,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 						pEnvelope->m_lPoints[i].m_aValues[c] = f2fx(str_tofloat(s_aStrCurValue));
 					}
 
-					if(UI()->ActiveItem() == pID /* || UI()->HotItem() == pID*/)
+					if(UI()->CheckActiveItem(pID) /* || UI()->HotItem() == pID*/)
 					{
 						CurrentTime = pEnvelope->m_lPoints[i].m_Time;
 						CurrentValue = pEnvelope->m_lPoints[i].m_aValues[c];
@@ -6403,6 +6403,8 @@ void CEditor::UpdateAndRender()
 		m_AnimateTime = 0;
 	ms_pUiGotContext = 0;
 
+	UI()->StartCheck();
+
 	// handle mouse movement
 	float mx, my, Mwx, Mwy;
 	float rx = 0, ry = 0;
@@ -6469,6 +6471,7 @@ void CEditor::UpdateAndRender()
 		m_ShowMousePointer = true;
 	}
 
+	UI()->FinishCheck();
 	Input()->Clear();
 }
 

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -545,7 +545,7 @@ int CEditor::UiDoValueSelector(void *pID, CUIRect *pRect, const char *pLabel, in
 		if(!UI()->MouseButton(0))
 		{
 			m_LockMouse = false;
-			UI()->SetActiveItem(0);
+			UI()->SetActiveItem(nullptr);
 			s_TextMode = false;
 		}
 	}
@@ -567,14 +567,14 @@ int CEditor::UiDoValueSelector(void *pID, CUIRect *pRect, const char *pLabel, in
 			else
 				Current = clamp(str_toint(s_aNumStr), Min, Max);
 			m_LockMouse = false;
-			UI()->SetActiveItem(0);
+			UI()->SetActiveItem(nullptr);
 			s_TextMode = false;
 		}
 
 		if(Input()->KeyIsPressed(KEY_ESCAPE))
 		{
 			m_LockMouse = false;
-			UI()->SetActiveItem(0);
+			UI()->SetActiveItem(nullptr);
 			s_TextMode = false;
 		}
 	}
@@ -1286,7 +1286,7 @@ void CEditor::DoSoundSource(CSoundSource *pSource, int Index)
 					m_LockMouse = false;
 				}
 				s_Operation = OP_NONE;
-				UI()->SetActiveItem(0);
+				UI()->SetActiveItem(nullptr);
 			}
 		}
 		else
@@ -1295,7 +1295,7 @@ void CEditor::DoSoundSource(CSoundSource *pSource, int Index)
 			{
 				m_LockMouse = false;
 				s_Operation = OP_NONE;
-				UI()->SetActiveItem(0);
+				UI()->SetActiveItem(nullptr);
 			}
 		}
 
@@ -1481,7 +1481,7 @@ void CEditor::DoQuad(CQuad *pQuad, int Index)
 					m_LockMouse = false;
 				}
 				s_Operation = OP_NONE;
-				UI()->SetActiveItem(0);
+				UI()->SetActiveItem(nullptr);
 			}
 		}
 		else if(s_Operation == OP_DELETE)
@@ -1495,7 +1495,7 @@ void CEditor::DoQuad(CQuad *pQuad, int Index)
 					DeleteSelectedQuads();
 				}
 				s_Operation = OP_NONE;
-				UI()->SetActiveItem(0);
+				UI()->SetActiveItem(nullptr);
 			}
 		}
 		else
@@ -1504,7 +1504,7 @@ void CEditor::DoQuad(CQuad *pQuad, int Index)
 			{
 				m_LockMouse = false;
 				s_Operation = OP_NONE;
-				UI()->SetActiveItem(0);
+				UI()->SetActiveItem(nullptr);
 			}
 		}
 
@@ -1718,7 +1718,7 @@ void CEditor::DoQuadPoint(CQuad *pQuad, int QuadIndex, int V)
 					static int s_PointPopupID = 0;
 					UiInvokePopupMenu(&s_PointPopupID, 0, UI()->MouseX(), UI()->MouseY(), 120, 150, PopupPoint);
 				}
-				UI()->SetActiveItem(0);
+				UI()->SetActiveItem(nullptr);
 			}
 		}
 		else
@@ -1734,7 +1734,7 @@ void CEditor::DoQuadPoint(CQuad *pQuad, int QuadIndex, int V)
 				}
 
 				m_LockMouse = false;
-				UI()->SetActiveItem(0);
+				UI()->SetActiveItem(nullptr);
 			}
 		}
 
@@ -2228,7 +2228,7 @@ void CEditor::DoQuadEnvPoint(const CQuad *pQuad, int QIndex, int PIndex)
 		{
 			m_LockMouse = false;
 			s_Operation = OP_NONE;
-			UI()->SetActiveItem(0);
+			UI()->SetActiveItem(nullptr);
 		}
 
 		Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
@@ -2792,7 +2792,7 @@ void CEditor::DoMapEditor(CUIRect View)
 			if(!UI()->MouseButton(0))
 			{
 				s_Operation = OP_NONE;
-				UI()->SetActiveItem(0);
+				UI()->SetActiveItem(nullptr);
 			}
 		}
 		if(!Input()->KeyIsPressed(KEY_LSHIFT) && !Input()->KeyIsPressed(KEY_RSHIFT) &&
@@ -2816,7 +2816,7 @@ void CEditor::DoMapEditor(CUIRect View)
 		if(!UI()->MouseButton(0))
 		{
 			s_Operation = OP_NONE;
-			UI()->SetActiveItem(0);
+			UI()->SetActiveItem(nullptr);
 		}
 	}
 
@@ -4678,7 +4678,7 @@ void CEditor::RenderFileDialog()
 			m_FileDialogErrString[0] = 0;
 			static int s_NewFolderPopupID = 0;
 			UiInvokePopupMenu(&s_NewFolderPopupID, 0, Width / 2.0f - 200.0f, Height / 2.0f - 100.0f, 400.0f, 200.0f, PopupNewFolder);
-			UI()->SetActiveItem(0);
+			UI()->SetActiveItem(nullptr);
 		}
 	}
 
@@ -4694,7 +4694,7 @@ void CEditor::RenderFileDialog()
 			str_copy(m_Map.m_MapInfo.m_aLicenseTmp, m_Map.m_MapInfo.m_aLicense, sizeof(m_Map.m_MapInfo.m_aLicenseTmp));
 			static int s_MapInfoPopupID = 0;
 			UiInvokePopupMenu(&s_MapInfoPopupID, 0, Width / 2.0f - 200.0f, Height / 2.0f - 100.0f, 400.0f, 200.0f, PopupMapInfo);
-			UI()->SetActiveItem(0);
+			UI()->SetActiveItem(nullptr);
 		}
 	}
 }
@@ -5268,7 +5268,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 							m_SelectedQuadEnvelope = -1;
 							m_SelectedEnvelopePoint = -1;
 
-							UI()->SetActiveItem(0);
+							UI()->SetActiveItem(nullptr);
 						}
 						else
 						{

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -54,7 +54,7 @@ void CEditor::UiDoPopupMenu()
 		if(Inside)
 			m_MouseInsidePopup = true;
 
-		if(UI()->ActiveItem() == &s_UiPopups[i].m_pId)
+		if(UI()->CheckActiveItem(&s_UiPopups[i].m_pId))
 		{
 			if(!UI()->MouseButton(0))
 			{

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -63,7 +63,7 @@ void CEditor::UiDoPopupMenu()
 					g_UiNumPopups--;
 					m_PopupEventWasActivated = false;
 				}
-				UI()->SetActiveItem(0);
+				UI()->SetActiveItem(nullptr);
 			}
 		}
 		else if(UI()->HotItem() == &s_UiPopups[i].m_pId)
@@ -85,7 +85,7 @@ void CEditor::UiDoPopupMenu()
 		if(s_UiPopups[i].m_pfnFunc(this, r, s_UiPopups[i].m_pContext))
 		{
 			m_LockMouse = false;
-			UI()->SetActiveItem(0);
+			UI()->SetActiveItem(nullptr);
 			g_UiNumPopups--;
 			m_PopupEventWasActivated = false;
 		}
@@ -93,7 +93,7 @@ void CEditor::UiDoPopupMenu()
 		if(Input()->KeyPress(KEY_ESCAPE))
 		{
 			m_LockMouse = false;
-			UI()->SetActiveItem(0);
+			UI()->SetActiveItem(nullptr);
 			g_UiNumPopups--;
 			m_PopupEventWasActivated = false;
 		}


### PR DESCRIPTION
Port e98921593bf23886de32ffb2fce9b166a89d6c05 from upstream.

Closes #1884. I can consistently reproduce the locked up UI according to @Jupeyy's description and can confirm that this PR fixes this behavior:

>I think i found a way to reproduce it
> press left & right mouse click (hold them)
> press F5 (refresh)
> now you cannot click anything anymore

Minor refactoring: use `nullptr` instead of `0` for UI active item.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
