### PR TITLE
Don't ever skip any frame

### DIFF
--- a/src/engine/client/video.cpp
+++ b/src/engine/client/video.cpp
@@ -47,8 +47,6 @@ CVideo::CVideo(CGraphics_Threaded *pGraphics, ISound *pSound, IStorage *pStorage
 	m_ProcessingVideoFrame = 0;
 	m_ProcessingAudioFrame = 0;
 
-	m_NextFrame = false;
-
 	m_HasAudio = g_Config.m_ClVideoSndEnable;
 
 	dbg_assert(ms_pCurrentVideo == 0, "ms_pCurrentVideo is NOT set to NULL while creating a new Video.");
@@ -294,7 +292,7 @@ void CVideo::Stop()
 
 void CVideo::NextVideoFrameThread()
 {
-	if(m_NextFrame && m_Recording)
+	if(m_Recording)
 	{
 		// #ifdef CONF_PLATFORM_MACOS
 		// 	CAutoreleasePool AutoreleasePool;
@@ -347,7 +345,6 @@ void CVideo::NextVideoFrameThread()
 				m_CurVideoThreadIndex = 0;
 		}
 
-		m_NextFrame = false;
 		// sync_barrier();
 		// m_Semaphore.signal();
 	}
@@ -359,7 +356,6 @@ void CVideo::NextVideoFrame()
 	{
 		ms_Time += ms_TickTime;
 		ms_LocalTime = (ms_Time - ms_LocalStartTime) / (float)time_freq();
-		m_NextFrame = true;
 		m_Vframe += 1;
 	}
 }

--- a/src/engine/client/video.h
+++ b/src/engine/client/video.h
@@ -144,8 +144,6 @@ private:
 	std::atomic<int32_t> m_ProcessingVideoFrame;
 	std::atomic<int32_t> m_ProcessingAudioFrame;
 
-	std::atomic<bool> m_NextFrame;
-
 	bool m_HasAudio;
 
 	struct SVideoSoundBuffer


### PR DESCRIPTION
Fixes #5051
With the video recorder rework, start and ending video rendering waits for the graphics threads anyway, additionally we never skip a frame while videos are rendering, so these checks are not needed anymore.

Basically like this
![image](https://user-images.githubusercontent.com/6654924/170735490-93ae44f1-4b5e-4f4c-9a72-3727302b05b8.png)

Update (sets true) => frame starts(but is not finished)
=> next update (sets to true again, but video frame still not finished) => frame starts(but swap waits for last frame).. last frame sets to false => this frame is fast, but var is false => frame skipped

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
