### PR TITLE
Fix ingame menu button behavior when holding mouse button

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -2542,6 +2542,7 @@ void CMenus::OnRender()
 		m_EnterPressed = false;
 		m_DeletePressed = false;
 		m_NumInputEvents = 0;
+		UI()->FinishCheck();
 		return;
 	}
 

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -430,15 +430,16 @@ int CUI::DoButtonLogic(const void *pID, int Checked, const CUIRect *pRect)
 	// logic
 	int ReturnValue = 0;
 	const bool Inside = MouseHovered(pRect);
-	static int s_ButtonUsed = 0;
+	static int s_ButtonUsed = -1;
 
 	if(CheckActiveItem(pID))
 	{
-		if(!MouseButton(s_ButtonUsed))
+		if(s_ButtonUsed >= 0 && !MouseButton(s_ButtonUsed))
 		{
 			if(Inside && Checked >= 0)
 				ReturnValue = 1 + s_ButtonUsed;
 			SetActiveItem(nullptr);
+			s_ButtonUsed = -1;
 		}
 	}
 	else if(HotItem() == pID)
@@ -453,7 +454,7 @@ int CUI::DoButtonLogic(const void *pID, int Checked, const CUIRect *pRect)
 		}
 	}
 
-	if(Inside)
+	if(Inside && !MouseButton(0) && !MouseButton(1) && !MouseButton(2))
 		SetHotItem(pID);
 
 	return ReturnValue;

--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -291,8 +291,12 @@ public:
 	void StartCheck() { m_ActiveItemValid = false; }
 	void FinishCheck()
 	{
-		if(!m_ActiveItemValid)
+		if(!m_ActiveItemValid && m_pActiveItem != nullptr)
+		{
 			SetActiveItem(nullptr);
+			m_pHotItem = nullptr;
+			m_pBecomingHotItem = nullptr;
+		}
 	}
 
 	bool MouseInside(const CUIRect *pRect) const;


### PR DESCRIPTION
Fixes the following behavior:

1. Player is ingame and the ingame menu is opened with Esc
2. A mouse button is held down on one of the ingame menu buttons (e.g. the spectate button)
3. The ingame menu is closed without moving the mouse away from the button
4. The mouse button is released while ingame
5. The menu is opened again
    - Current behavior: The hovered button is immediately activated, as soon as the menu opens, due to the released mouse state being handled as a click.
    - Fixed behavior: The button is not activated. Instead another call to `FinishCheck` is added so it's also called when the menu is not active, to clear the active UI item in that case.

As well as the following:

1. The menu is closed while the mouse cursor is hovering over a button.
2. The mouse button is pressed and held while the menu is closed.
3. The menu is opened again.
   - Current behavior: The menu button is already held down and when the player releases the mouse button it will immediately be activated.
   - Fixed behavior: The button is not activated immediately, by clearing the hot item and next hot item variables in `FinishCheck`.

The latter behavior can still occur when entering the editor instead of closing the ingame menu.

Closes #3560. Closes #5229.

The first two commits are identical to upstream https://github.com/teeworlds/teeworlds/pull/3158, where those issues also exist. The last commit adapts upstream behavior so buttons can only become hot when the mouse is not pressed.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
