### PR TITLE
reintroduce shotgun bug

### DIFF
--- a/src/game/server/entities/laser.cpp
+++ b/src/game/server/entities/laser.cpp
@@ -34,6 +34,7 @@ CLaser::CLaser(CGameWorld *pGameWorld, vec2 Pos, vec2 Direction, float StartEner
 
 bool CLaser::HitCharacter(vec2 From, vec2 To)
 {
+	static const vec2 StackedLaserShotgunBugSpeed = vec2(-2147483648.0f, -2147483648.0f);
 	vec2 At;
 	CCharacter *pOwnerChar = GameServer()->GetPlayerChar(m_Owner);
 	CCharacter *pHit;
@@ -59,13 +60,35 @@ bool CLaser::HitCharacter(vec2 From, vec2 To)
 		else
 			Strength = GameServer()->TuningList()[m_TuneZone].m_ShotgunStrength;
 
+		vec2 &HitPos = pHit->Core()->m_Pos;
 		if(!g_Config.m_SvOldLaser)
-			Temp = pHit->Core()->m_Vel + normalize(m_PrevPos - pHit->Core()->m_Pos) * Strength;
-		else if(pOwnerChar)
-			Temp = pHit->Core()->m_Vel + normalize(pOwnerChar->Core()->m_Pos - pHit->Core()->m_Pos) * Strength;
+		{
+			if(m_PrevPos != HitPos)
+			{
+				Temp = pHit->Core()->m_Vel + normalize(m_PrevPos - HitPos) * Strength;
+				pHit->Core()->m_Vel = ClampVel(pHit->m_MoveRestrictions, Temp);
+			}
+			else
+			{
+				pHit->Core()->m_Vel = StackedLaserShotgunBugSpeed;
+			}
+		}
+		else if(g_Config.m_SvOldLaser && pOwnerChar)
+		{
+			if(pOwnerChar->Core()->m_Pos != HitPos)
+			{
+				Temp = pHit->Core()->m_Vel + normalize(pOwnerChar->Core()->m_Pos - HitPos) * Strength;
+				pHit->Core()->m_Vel = ClampVel(pHit->m_MoveRestrictions, Temp);
+			}
+			else
+			{
+				pHit->Core()->m_Vel = StackedLaserShotgunBugSpeed;
+			}
+		}
 		else
-			Temp = pHit->Core()->m_Vel;
-		pHit->Core()->m_Vel = ClampVel(pHit->m_MoveRestrictions, Temp);
+		{
+			pHit->Core()->m_Vel = ClampVel(pHit->m_MoveRestrictions, pHit->Core()->m_Vel);
+		}
 	}
 	else if(m_Type == WEAPON_LASER)
 	{


### PR DESCRIPTION
fixes #5258
bug got fixed by the math changes in https://github.com/ddnet/ddnet/commit/68bcd21eff9fbace8605eec8122f860499e03c21

This fix introduces a hard coded velocity that the player would get like before. (It could be that this has slightly other behaviour, because before the produced NaN values where converted to ints in CCharacterCore::Quantize (so some other logic may be confronted with the NaN values before), but it should most likely not be noticeable because it is fast enough)

We could now make this bug optional, by adding it to our mapbugs, or adding a server setting for it.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [x] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
