### PR TITLE
Remove alpha threshold from map_optmize

### DIFF
--- a/src/engine/shared/image_manipulation.cpp
+++ b/src/engine/shared/image_manipulation.cpp
@@ -2,6 +2,8 @@
 #include <base/math.h>
 #include <base/system.h>
 
+#define TW_DILATE_ALPHA_THRESHOLD 10
+
 static void Dilate(int w, int h, int BPP, unsigned char *pSrc, unsigned char *pDest, unsigned char AlphaThreshold = TW_DILATE_ALPHA_THRESHOLD)
 {
 	int ix, iy;

--- a/src/engine/shared/image_manipulation.h
+++ b/src/engine/shared/image_manipulation.h
@@ -4,8 +4,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#define TW_DILATE_ALPHA_THRESHOLD 10
-
 void DilateImage(unsigned char *pImageBuff, int w, int h, int BPP);
 void DilateImageSub(unsigned char *pImageBuff, int w, int h, int BPP, int x, int y, int sw, int sh);
 

--- a/src/tools/map_optimize.cpp
+++ b/src/tools/map_optimize.cpp
@@ -34,7 +34,7 @@ void CopyOpaquePixels(uint8_t *pDestImg, uint8_t *pSrcImg, int Width, int Height
 		for(int x = 0; x < Width; ++x)
 		{
 			int Index = y * Width * 4 + x * 4;
-			if(pSrcImg[Index + 3] > TW_DILATE_ALPHA_THRESHOLD)
+			if(pSrcImg[Index + 3] > 0)
 				mem_copy(&pDestImg[Index], &pSrcImg[Index], sizeof(uint8_t) * 4);
 			else
 				mem_zero(&pDestImg[Index], sizeof(uint8_t) * 4);
@@ -66,9 +66,7 @@ void GetImageSHA256(uint8_t *pImgBuff, int ImgSize, int Width, int Height, char 
 {
 	uint8_t *pNewImgBuff = (uint8_t *)malloc(ImgSize);
 
-	// Get all image pixels, that have a alpha threshold over the default threshold,
-	// all other pixels are cleared to zero.
-	// This is required since dilate modifies pixels under the alpha threshold, which would alter the SHA.
+	// Clear fully transparent pixels, so the SHA is easier to identify with the original image
 	CopyOpaquePixels(pNewImgBuff, pImgBuff, Width, Height);
 	SHA256_DIGEST SHAStr = sha256(pNewImgBuff, (size_t)ImgSize);
 


### PR DESCRIPTION
Since it was removed from dilate's copy values, and also makes more sense anyway.
Images should always be identifiable by all visible pixels

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
