### PR TITLE
Use std::make_unique (fixes #5166)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3008,6 +3008,7 @@ foreach(target ${TARGETS_OWN})
   if((CMAKE_VERSION VERSION_GREATER 3.1 OR CMAKE_VERSION VERSION_EQUAL 3.1))
     set_property(TARGET ${target} PROPERTY CXX_STANDARD 17)
     set_property(TARGET ${target} PROPERTY CXX_STANDARD_REQUIRED ON)
+    set_property(TARGET ${target} PROPERTY CXX_EXTENSIONS OFF)
   endif()
 
   if(MSVC)

--- a/src/base/log.cpp
+++ b/src/base/log.cpp
@@ -162,7 +162,7 @@ public:
 };
 std::unique_ptr<ILogger> log_logger_android()
 {
-	return std::unique_ptr<ILogger>(new CLoggerAndroid());
+	return std::make_unique<CLoggerAndroid>();
 }
 #else
 std::unique_ptr<ILogger> log_logger_android()
@@ -199,7 +199,7 @@ public:
 
 std::unique_ptr<ILogger> log_logger_collection(std::vector<std::shared_ptr<ILogger>> &&loggers)
 {
-	return std::unique_ptr<ILogger>(new CLoggerCollection(std::move(loggers)));
+	return std::make_unique<CLoggerCollection>(std::move(loggers));
 }
 
 class CLoggerAsync : public ILogger
@@ -261,7 +261,7 @@ public:
 
 std::unique_ptr<ILogger> log_logger_file(IOHANDLE logfile)
 {
-	return std::unique_ptr<ILogger>(new CLoggerAsync(logfile, false, true));
+	return std::make_unique<CLoggerAsync>(logfile, false, true);
 }
 
 #if defined(CONF_FAMILY_WINDOWS)
@@ -372,17 +372,17 @@ std::unique_ptr<ILogger> log_logger_stdout()
 	// TODO: Only enable true color when COLORTERM contains "truecolor".
 	// https://github.com/termstandard/colors/tree/65bf0cd1ece7c15fa33a17c17528b02c99f1ae0b#checking-for-colorterm
 	const bool colors = getenv("NO_COLOR") == nullptr && isatty(STDOUT_FILENO);
-	return std::unique_ptr<ILogger>(new CLoggerAsync(io_stdout(), colors, false));
+	return std::make_unique<CLoggerAsync>(io_stdout(), colors, false);
 #else
 	if(GetFileType(GetStdHandle(STD_OUTPUT_HANDLE)) == FILE_TYPE_UNKNOWN)
 		AttachConsole(ATTACH_PARENT_PROCESS);
 	HANDLE pOutput = GetStdHandle(STD_OUTPUT_HANDLE);
 	switch(GetFileType(pOutput))
 	{
-	case FILE_TYPE_CHAR: return std::unique_ptr<ILogger>(new CWindowsConsoleLogger(pOutput));
+	case FILE_TYPE_CHAR: return std::make_unique<CWindowsConsoleLogger>(pOutput);
 	case FILE_TYPE_PIPE: // fall through, writing to pipe works the same as writing to a file
-	case FILE_TYPE_DISK: return std::unique_ptr<ILogger>(new CWindowsFileLogger(pOutput));
-	default: return std::unique_ptr<ILogger>(new CLoggerAsync(io_stdout(), false, false));
+	case FILE_TYPE_DISK: return std::make_unique<CWindowsFileLogger>(pOutput);
+	default: return std::make_unique<CLoggerAsync>(io_stdout(), false, false);
 	}
 #endif
 }
@@ -400,7 +400,7 @@ public:
 };
 std::unique_ptr<ILogger> log_logger_windows_debugger()
 {
-	return std::unique_ptr<ILogger>(new CLoggerWindowsDebugger());
+	return std::make_unique<CLoggerWindowsDebugger>();
 }
 #else
 std::unique_ptr<ILogger> log_logger_windows_debugger()

--- a/src/engine/server/databases/mysql.cpp
+++ b/src/engine/server/databases/mysql.cpp
@@ -713,7 +713,7 @@ std::unique_ptr<IDbConnection> CreateMysqlConnection(
 	int Port,
 	bool Setup)
 {
-	return std::unique_ptr<IDbConnection>(new CMysqlConnection(pDatabase, pPrefix, pUser, pPass, pIp, Port, Setup));
+	return std::make_unique<CMysqlConnection>(pDatabase, pPrefix, pUser, pPass, pIp, Port, Setup);
 }
 #else
 int MysqlInit()

--- a/src/engine/server/databases/sqlite.cpp
+++ b/src/engine/server/databases/sqlite.cpp
@@ -387,5 +387,5 @@ bool CSqliteConnection::AddPoints(const char *pPlayer, int Points, char *pError,
 
 std::unique_ptr<IDbConnection> CreateSqliteConnection(const char *pFilename, bool Setup)
 {
-	return std::unique_ptr<IDbConnection>(new CSqliteConnection(pFilename, Setup));
+	return std::make_unique<CSqliteConnection>(pFilename, Setup);
 }

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -3908,7 +3908,7 @@ int main(int argc, const char **argv)
 			dbg_msg("client", "failed to open '%s' for logging", g_Config.m_Logfile);
 		}
 	}
-	pEngine->SetAdditionalLogger(std::unique_ptr<ILogger>(new CServerLogger(pServer)));
+	pEngine->SetAdditionalLogger(std::make_unique<CServerLogger>(pServer));
 
 	// run the server
 	dbg_msg("server", "starting...");

--- a/src/engine/shared/assertion_logger.cpp
+++ b/src/engine/shared/assertion_logger.cpp
@@ -77,5 +77,5 @@ std::unique_ptr<ILogger> CreateAssertionLogger(IStorage *pStorage, const char *p
 {
 	char aAssertLogPath[IO_MAX_PATH_LENGTH];
 	pStorage->GetCompletePath(IStorage::TYPE_SAVE, "dumps/", aAssertLogPath, sizeof(aAssertLogPath));
-	return std::unique_ptr<ILogger>(new CAssertionLogger(aAssertLogPath, pGameName));
+	return std::make_unique<CAssertionLogger>(aAssertLogPath, pGameName);
 }

--- a/src/engine/shared/http.h
+++ b/src/engine/shared/http.h
@@ -154,14 +154,14 @@ public:
 
 inline std::unique_ptr<CHttpRequest> HttpHead(const char *pUrl)
 {
-	std::unique_ptr<CHttpRequest> pResult = std::unique_ptr<CHttpRequest>(new CHttpRequest(pUrl));
+	auto pResult = std::make_unique<CHttpRequest>(pUrl);
 	pResult->Head();
 	return pResult;
 }
 
 inline std::unique_ptr<CHttpRequest> HttpGet(const char *pUrl)
 {
-	return std::unique_ptr<CHttpRequest>(new CHttpRequest(pUrl));
+	return std::make_unique<CHttpRequest>(pUrl);
 }
 
 inline std::unique_ptr<CHttpRequest> HttpGetFile(const char *pUrl, IStorage *pStorage, const char *pOutputFile, int StorageType)
@@ -174,14 +174,14 @@ inline std::unique_ptr<CHttpRequest> HttpGetFile(const char *pUrl, IStorage *pSt
 
 inline std::unique_ptr<CHttpRequest> HttpPost(const char *pUrl, const unsigned char *pData, size_t DataLength)
 {
-	std::unique_ptr<CHttpRequest> pResult = std::unique_ptr<CHttpRequest>(new CHttpRequest(pUrl));
+	auto pResult = std::make_unique<CHttpRequest>(pUrl);
 	pResult->Post(pData, DataLength);
 	return pResult;
 }
 
 inline std::unique_ptr<CHttpRequest> HttpPostJson(const char *pUrl, const char *pJson)
 {
-	std::unique_ptr<CHttpRequest> pResult = std::unique_ptr<CHttpRequest>(new CHttpRequest(pUrl));
+	auto pResult = std::make_unique<CHttpRequest>(pUrl);
 	pResult->PostJson(pJson);
 	return pResult;
 }


### PR DESCRIPTION
No idea why clang-tidy's modernize-... didn't work

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
