### PR TITLE
Execute the dragger_beam tick one tick earlier. And stop it one tick earlier

### DIFF
--- a/src/game/server/entities/dragger.cpp
+++ b/src/game/server/entities/dragger.cpp
@@ -142,6 +142,10 @@ void CDragger::LookForPlayersToDrag()
 		if(IsTarget[i] && m_apDraggerBeam[i] == nullptr)
 		{
 			m_apDraggerBeam[i] = new CDraggerBeam(&GameServer()->m_World, this, m_Pos, m_Strength, m_IgnoreWalls, i, m_Layer, m_Number);
+			// The generated dragger beam is placed in the first position in the tick sequence and would therefore
+			// no longer be executed automatically in this tick. To execute the dragger beam nevertheless already
+			// this tick we call it manually (we do this to keep the old game logic)
+			m_apDraggerBeam[i]->Tick();
 		}
 		// Remove dragger beams that have not yet been deleted
 		else if(!IsTarget[i] && m_apDraggerBeam[i] != nullptr)

--- a/src/game/server/entities/dragger_beam.cpp
+++ b/src/game/server/entities/dragger_beam.cpp
@@ -42,13 +42,18 @@ void CDraggerBeam::Tick()
 		return;
 	}
 
-	// The following checks are necessary, because the checks in CDragger::LookForPlayersToDrag only take place every 150ms
-	// When the dragger is disabled for the target player's team, the dragger beam dissolves
-	if(m_Layer == LAYER_SWITCH && m_Number > 0 &&
-		!GameServer()->Collision()->m_pSwitchers[m_Number].m_Status[pTarget->Team()])
+	// The following checks are necessary, because the checks in CDragger::LookForPlayersToDrag only take place
+	// after CDraggerBeam::Tick and only every 150ms
+	// When the dragger is disabled for the target player's team, the dragger beam dissolves. The check if a dragger
+	// is disabled is only executed every 150ms, so the beam can stay activated up to 6 extra ticks
+	if(Server()->Tick() % int(Server()->TickSpeed() * 0.15f) == 0)
 	{
-		Reset();
-		return;
+		if(m_Layer == LAYER_SWITCH && m_Number > 0 &&
+			!GameServer()->Collision()->m_pSwitchers[m_Number].m_Status[pTarget->Team()])
+		{
+			Reset();
+			return;
+		}
 	}
 
 	// When the dragger can no longer reach the target player, the dragger beam dissolves


### PR DESCRIPTION
fixes #5263

@bencie  could you please confirm it fixes the problem?

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [x] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
