### PR TITLE
Organize includes: Include only what's necessary and only where necessary

### DIFF
--- a/datasrc/network.py
+++ b/datasrc/network.py
@@ -39,8 +39,6 @@ Authed = ["NO", "HELPER", "MOD", "ADMIN"]
 EntityClasses = ["PROJECTILE", "DOOR", "DRAGGER_WEAK", "DRAGGER_NORMAL", "DRAGGER_STRONG", "GUN_NORMAL", "GUN_EXPLOSIVE", "GUN_FREEZE", "GUN_UNFREEZE", "LIGHT", "PICKUP"]
 
 RawHeader = '''
-
-#include <engine/message.h>
 #include <engine/shared/teehistorian_ex.h>
 
 enum
@@ -69,7 +67,6 @@ enum
 '''
 
 RawSource = '''
-#include <engine/message.h>
 #include "protocol.h"
 '''
 

--- a/datasrc/seven/network.py
+++ b/datasrc/seven/network.py
@@ -23,8 +23,6 @@ GameMsgIDs = Enum("GAMEMSG", ["TEAM_SWAP", "SPEC_INVALIDID", "TEAM_SHUFFLE", "TE
 
 RawHeader = '''
 
-#include <engine/message.h>
-
 enum
 {
 	INPUT_STATE_MASK=0x3f
@@ -58,7 +56,6 @@ enum
 '''
 
 RawSource = '''
-#include <engine/message.h>
 #include "protocol.h"
 '''
 

--- a/src/base/hash_libtomcrypt.cpp
+++ b/src/base/hash_libtomcrypt.cpp
@@ -5,7 +5,6 @@
 
 #include "hash_ctxt.h"
 
-#include <cstddef>
 #include <cstdint>
 #include <cstring>
 

--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -15,9 +15,6 @@
 
 #include "logger.h"
 
-#if !defined(CONF_PLATFORM_MACOS)
-#include <base/color.h>
-#endif
 #include <sys/stat.h>
 #include <sys/types.h>
 

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -14,8 +14,6 @@
 #define __USE_GNU
 #endif
 
-#include <stddef.h>
-#include <stdint.h>
 #include <stdlib.h>
 #include <time.h>
 

--- a/src/engine/client/backend/glsl_shader_compiler.cpp
+++ b/src/engine/client/backend/glsl_shader_compiler.cpp
@@ -1,7 +1,7 @@
 #include "glsl_shader_compiler.h"
 
 #include <base/system.h>
-#include <engine/client/backend_sdl.h>
+#include <engine/graphics.h>
 
 CGLSLCompiler::CGLSLCompiler(int OpenGLVersionMajor, int OpenGLVersionMinor, int OpenGLVersionPatch, bool IsOpenGLES, float TextureLODBias)
 {

--- a/src/engine/client/backend/opengl/backend_opengl.cpp
+++ b/src/engine/client/backend/opengl/backend_opengl.cpp
@@ -7,6 +7,7 @@
 
 #include <engine/client/backend/opengl/opengl_sl.h>
 #include <engine/client/backend/opengl/opengl_sl_program.h>
+#include <engine/client/blocklist_driver.h>
 
 #include <engine/client/backend/glsl_shader_compiler.h>
 

--- a/src/engine/client/backend/opengl/backend_opengl.h
+++ b/src/engine/client/backend/opengl/backend_opengl.h
@@ -13,7 +13,6 @@
 #include <base/system.h>
 
 #include <engine/client/backend/backend_base.h>
-#include <engine/client/backend_sdl.h>
 
 class CGLSLProgram;
 class CGLSLTWProgram;

--- a/src/engine/client/backend/opengl/backend_opengl3.h
+++ b/src/engine/client/backend/opengl/backend_opengl3.h
@@ -10,8 +10,6 @@
 #define ENGINE_CLIENT_BACKEND_OPENGL_BACKEND_OPENGL3_H_AS_ES
 #endif
 
-#include <engine/client/backend_sdl.h>
-
 #include "backend_opengl.h"
 
 #define MAX_STREAM_BUFFER_COUNT 10

--- a/src/engine/client/backend/opengl/opengl_sl.cpp
+++ b/src/engine/client/backend/opengl/opengl_sl.cpp
@@ -10,9 +10,8 @@
 #include <string>
 #include <vector>
 
-#include <engine/client/backend_sdl.h>
-
 #include <engine/client/backend/glsl_shader_compiler.h>
+#include <engine/graphics.h>
 
 #ifndef BACKEND_AS_OPENGL_ES
 #include <GL/glew.h>

--- a/src/engine/client/backend/opengl/opengl_sl.h
+++ b/src/engine/client/backend/opengl/opengl_sl.h
@@ -10,12 +10,7 @@
 #define ENGINE_CLIENT_BACKEND_OPENGL_OPENGL_SL_H_AS_ES
 #endif
 
-#include <base/detect.h>
-
 #include <engine/client/graphics_defines.h>
-
-#include <string>
-#include <vector>
 
 class CGLSLCompiler;
 

--- a/src/engine/client/backend/opengl/opengl_sl_program.h
+++ b/src/engine/client/backend/opengl/opengl_sl_program.h
@@ -10,8 +10,6 @@
 #define ENGINE_CLIENT_BACKEND_OPENGL_OPENGL_SL_PROGRAM_H_AS_ES
 #endif
 
-#include <base/detect.h>
-
 #include <engine/client/graphics_defines.h>
 
 class CGLSL;

--- a/src/engine/client/backend/vulkan/backend_vulkan.cpp
+++ b/src/engine/client/backend/vulkan/backend_vulkan.cpp
@@ -35,8 +35,7 @@
 
 #include <unordered_map>
 
-#include <SDL.h>
-#include <SDL_error.h>
+#include <SDL_video.h>
 #include <SDL_vulkan.h>
 
 #include <vulkan/vulkan.h>

--- a/src/engine/client/backend/vulkan/backend_vulkan.h
+++ b/src/engine/client/backend/vulkan/backend_vulkan.h
@@ -1,8 +1,7 @@
 #ifndef ENGINE_CLIENT_BACKEND_VULKAN_BACKEND_VULKAN_H
 #define ENGINE_CLIENT_BACKEND_VULKAN_BACKEND_VULKAN_H
 
-#include <base/detect.h>
-#include <engine/client/backend_sdl.h>
+#include <engine/client/backend/backend_base.h>
 
 static constexpr int gs_BackendVulkanMajor = 1;
 static constexpr int gs_BackendVulkanMinor = 0;

--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -12,17 +12,14 @@
 
 #include <engine/storage.h>
 
-#include "SDL.h"
+#include <SDL.h>
+#include <SDL_hints.h>
+#include <SDL_pixels.h>
+#include <SDL_video.h>
 
-#include "SDL_syswm.h"
 #include <base/detect.h>
 #include <base/math.h>
-#include <cmath>
 #include <cstdlib>
-
-#include "SDL_hints.h"
-#include "SDL_pixels.h"
-#include "SDL_video.h"
 
 #include <engine/shared/config.h>
 
@@ -45,14 +42,10 @@
 #endif
 
 #if defined(CONF_BACKEND_VULKAN)
-#include <SDL_vulkan.h>
-
 #include "backend/vulkan/backend_vulkan.h"
 #endif
 
 #include "graphics_threaded.h"
-
-#include <engine/shared/image_manipulation.h>
 
 #include <engine/graphics.h>
 

--- a/src/engine/client/backend_sdl.h
+++ b/src/engine/client/backend_sdl.h
@@ -1,23 +1,17 @@
 #ifndef ENGINE_CLIENT_BACKEND_SDL_H
 #define ENGINE_CLIENT_BACKEND_SDL_H
 
-#include "SDL.h"
+#include <SDL_video.h>
 
 #include <base/detect.h>
 
 #include "engine/graphics.h"
 #include "graphics_defines.h"
-
-#include "blocklist_driver.h"
 #include "graphics_threaded.h"
-
-#include <base/tl/threading.h>
 
 #include <atomic>
 #include <condition_variable>
 #include <mutex>
-#include <thread>
-#include <vector>
 
 #if defined(CONF_PLATFORM_MACOS)
 #include <objc/objc-runtime.h>

--- a/src/engine/client/blocklist_driver.cpp
+++ b/src/engine/client/blocklist_driver.cpp
@@ -2,6 +2,8 @@
 
 #include <base/system.h>
 
+#include <cstddef>
+
 #define VERSION_PARTS 4
 
 struct SVersion

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -5,19 +5,15 @@
 
 #include <climits>
 #include <new>
-
-#include <cstdarg>
 #include <tuple>
 
 #include <base/hash_ctxt.h>
 #include <base/logger.h>
 #include <base/math.h>
 #include <base/system.h>
-#include <base/vmath.h>
 
 #include <game/client/components/menus.h>
-#include <game/client/gameclient.h>
-#include <game/editor/editor.h>
+#include <game/generated/protocol.h>
 
 #include <engine/client.h>
 #include <engine/config.h>
@@ -38,18 +34,15 @@
 #include <engine/shared/assertion_logger.h>
 #include <engine/shared/compression.h>
 #include <engine/shared/config.h>
-#include <engine/shared/datafile.h>
 #include <engine/shared/demo.h>
 #include <engine/shared/fifo.h>
 #include <engine/shared/filecollection.h>
 #include <engine/shared/http.h>
-#include <engine/shared/json.h>
 #include <engine/shared/masterserver.h>
 #include <engine/shared/network.h>
 #include <engine/shared/packer.h>
 #include <engine/shared/protocol.h>
 #include <engine/shared/protocol_ex.h>
-#include <engine/shared/ringbuffer.h>
 #include <engine/shared/snapshot.h>
 #include <engine/shared/uuid_manager.h>
 
@@ -58,7 +51,6 @@
 #include <game/version.h>
 
 #include <engine/client/demoedit.h>
-#include <engine/client/serverbrowser.h>
 
 #if defined(CONF_FAMILY_WINDOWS)
 #define WIN32_LEAN_AND_MEAN
@@ -73,15 +65,11 @@
 #include "video.h"
 #endif
 
-#include <zlib.h>
-
 #include "SDL.h"
 #ifdef main
 #undef main
 #endif
 
-// for android
-#include "SDL_rwops.h"
 #include "base/hash.h"
 
 // for msvc

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -48,6 +48,7 @@
 
 #include <base/system.h>
 
+#include <game/localization.h>
 #include <game/version.h>
 
 #include <engine/client/demoedit.h>

--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -15,7 +15,6 @@
 
 #include <engine/console.h>
 #include <engine/graphics.h>
-#include <engine/keys.h>
 #include <engine/shared/config.h>
 #include <engine/storage.h>
 #include <game/generated/client_data.h>
@@ -23,8 +22,6 @@
 #include <game/localization.h>
 
 #include <engine/shared/image_manipulation.h>
-
-#include <cmath> // cosf, sinf, log2f
 
 #if defined(CONF_VIDEORECORDER)
 #include "video.h"

--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -1,6 +1,10 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
-#include "SDL.h"
+#include <SDL_clipboard.h>
+#include <SDL_events.h>
+#include <SDL_keyboard.h>
+#include <SDL_mouse.h>
+#include <SDL_rect.h>
 
 #include <base/system.h>
 #include <engine/graphics.h>

--- a/src/engine/client/input.h
+++ b/src/engine/client/input.h
@@ -7,8 +7,6 @@
 #include <engine/input.h>
 #include <engine/keys.h>
 
-#include <stddef.h>
-
 class CInput : public IEngineInput
 {
 	IEngineGraphics *m_pGraphics;

--- a/src/engine/client/serverbrowser_ping_cache.cpp
+++ b/src/engine/client/serverbrowser_ping_cache.cpp
@@ -6,7 +6,6 @@
 #include <sqlite3.h>
 
 #include <algorithm>
-#include <cstdio>
 #include <vector>
 
 class CServerBrowserPingCache : public IServerBrowserPingCache

--- a/src/engine/client/sound.h
+++ b/src/engine/client/sound.h
@@ -7,7 +7,7 @@
 #include <engine/sound.h>
 #include <engine/storage.h>
 
-#include "SDL.h"
+#include <SDL_audio.h>
 
 class CSound : public IEngineSound
 {

--- a/src/engine/client/text.cpp
+++ b/src/engine/client/text.cpp
@@ -5,7 +5,6 @@
 #include <cstddef>
 #include <cstdint>
 #include <engine/graphics.h>
-#include <engine/shared/config.h>
 #include <engine/storage.h>
 #include <engine/textrender.h>
 

--- a/src/engine/client/updater.cpp
+++ b/src/engine/client/updater.cpp
@@ -3,9 +3,9 @@
 #include <engine/client.h>
 #include <engine/engine.h>
 #include <engine/external/json-parser/json.h>
+#include <engine/shared/http.h>
 #include <engine/shared/json.h>
 #include <engine/storage.h>
-#include <game/version.h>
 
 #include <cstdlib> // system
 

--- a/src/engine/client/updater.h
+++ b/src/engine/client/updater.h
@@ -1,7 +1,6 @@
 #ifndef ENGINE_CLIENT_UPDATER_H
 #define ENGINE_CLIENT_UPDATER_H
 
-#include <engine/shared/http.h>
 #include <engine/updater.h>
 #include <map>
 #include <string>

--- a/src/engine/client/video.cpp
+++ b/src/engine/client/video.cpp
@@ -7,6 +7,11 @@
 #include <engine/client/graphics_threaded.h>
 #include <engine/sound.h>
 
+extern "C" {
+#include <libavutil/avutil.h>
+#include <libavutil/opt.h>
+};
+
 #include <memory>
 #include <mutex>
 

--- a/src/engine/client/video.h
+++ b/src/engine/client/video.h
@@ -3,18 +3,13 @@
 
 #include <base/system.h>
 
-#include "graphics_defines.h"
-
 extern "C" {
 #include <libavcodec/avcodec.h>
 #include <libavformat/avformat.h>
-#include <libavutil/imgutils.h>
-#include <libavutil/opt.h>
 #include <libswresample/swresample.h>
 #include <libswscale/swscale.h>
 };
 
-#include <engine/shared/demo.h>
 #include <engine/shared/video.h>
 
 #include <atomic>

--- a/src/engine/ghost.h
+++ b/src/engine/ghost.h
@@ -2,7 +2,6 @@
 #define ENGINE_GHOST_H
 
 #include <base/hash.h>
-#include <engine/map.h>
 #include <engine/shared/protocol.h>
 
 #include "kernel.h"

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -19,7 +19,6 @@
 #include <engine/shared/assertion_logger.h>
 #include <engine/shared/compression.h>
 #include <engine/shared/config.h>
-#include <engine/shared/datafile.h>
 #include <engine/shared/demo.h>
 #include <engine/shared/econ.h>
 #include <engine/shared/fifo.h>

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -4,7 +4,6 @@
 #define ENGINE_SERVER_SERVER_H
 
 #include <base/hash.h>
-#include <base/math.h>
 
 #include <engine/engine.h>
 #include <engine/server.h>

--- a/src/engine/server/sql_string_helpers.cpp
+++ b/src/engine/server/sql_string_helpers.cpp
@@ -2,7 +2,6 @@
 
 #include <base/system.h>
 #include <cmath>
-#include <cstring>
 
 void sqlstr::FuzzyString(char *pString, int Size)
 {

--- a/src/engine/shared/console.cpp
+++ b/src/engine/shared/console.cpp
@@ -1,12 +1,10 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
-#include <new>
 
 #include <base/color.h>
 #include <base/log.h>
 #include <base/math.h>
 #include <base/system.h>
-#include <base/vmath.h>
 
 #include <engine/client/checksum.h>
 #include <engine/shared/protocol.h>
@@ -17,6 +15,7 @@
 #include "linereader.h"
 
 #include <array> // std::size
+#include <new>
 
 // todo: rework this
 

--- a/src/engine/shared/datafile.cpp
+++ b/src/engine/shared/datafile.cpp
@@ -4,7 +4,6 @@
 #include "datafile.h"
 
 #include <base/hash_ctxt.h>
-#include <base/math.h>
 #include <base/system.h>
 #include <engine/storage.h>
 

--- a/src/engine/shared/econ.h
+++ b/src/engine/shared/econ.h
@@ -3,9 +3,8 @@
 
 #include "network.h"
 
+#include <engine/config.h>
 #include <engine/console.h>
-
-class CConfig;
 
 class CEcon
 {

--- a/src/engine/shared/engine.cpp
+++ b/src/engine/shared/engine.cpp
@@ -10,8 +10,6 @@
 #include <engine/shared/network.h>
 #include <engine/storage.h>
 
-#include <engine/shared/assertion_logger.h>
-
 CHostLookup::CHostLookup() = default;
 
 CHostLookup::CHostLookup(const char *pHostname, int Nettype)

--- a/src/engine/shared/filecollection.h
+++ b/src/engine/shared/filecollection.h
@@ -5,7 +5,7 @@
 
 #include <engine/storage.h>
 
-#include <stddef.h>
+#include <stdint.h>
 
 class CFileCollection
 {

--- a/src/engine/shared/http.cpp
+++ b/src/engine/shared/http.cpp
@@ -3,7 +3,6 @@
 #include <base/log.h>
 #include <base/math.h>
 #include <base/system.h>
-#include <engine/engine.h>
 #include <engine/external/json-parser/json.h>
 #include <engine/shared/config.h>
 #include <engine/storage.h>
@@ -15,7 +14,6 @@
 
 #define WIN32_LEAN_AND_MEAN
 #include <curl/curl.h>
-#include <curl/easy.h>
 
 // TODO: Non-global pls?
 static CURLSH *gs_Share;

--- a/src/engine/shared/image_manipulation.h
+++ b/src/engine/shared/image_manipulation.h
@@ -1,7 +1,6 @@
 #ifndef ENGINE_SHARED_IMAGE_MANIPULATION_H
 #define ENGINE_SHARED_IMAGE_MANIPULATION_H
 
-#include <stddef.h>
 #include <stdint.h>
 
 void DilateImage(unsigned char *pImageBuff, int w, int h, int BPP);

--- a/src/engine/shared/jobs.h
+++ b/src/engine/shared/jobs.h
@@ -8,7 +8,6 @@
 #include <atomic>
 #include <memory>
 
-class IJob;
 class CJobPool;
 
 class IJob

--- a/src/engine/shared/network_console.cpp
+++ b/src/engine/shared/network_console.cpp
@@ -2,8 +2,6 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include <base/system.h>
 
-#include <engine/console.h>
-
 #include "netban.h"
 #include "network.h"
 

--- a/src/engine/shared/network_server.cpp
+++ b/src/engine/shared/network_server.cpp
@@ -3,14 +3,11 @@
 #include <base/hash_ctxt.h>
 #include <base/system.h>
 
-#include <engine/console.h>
-
 #include "config.h"
 #include "netban.h"
 #include "network.h"
 #include <engine/message.h>
 #include <engine/shared/protocol.h>
-#include <game/generated/protocol.h>
 
 const int DummyMapCrc = 0x6c760ac4;
 unsigned char g_aDummyMapData[] = {

--- a/src/engine/shared/packer.cpp
+++ b/src/engine/shared/packer.cpp
@@ -3,7 +3,6 @@
 #include <base/system.h>
 
 #include "compression.h"
-#include "config.h"
 #include "packer.h"
 
 void CPacker::Reset()

--- a/src/engine/shared/protocol_ex.cpp
+++ b/src/engine/shared/protocol_ex.cpp
@@ -1,7 +1,6 @@
 #include "protocol_ex.h"
 
 #include "config.h"
-#include "protocol.h"
 #include "uuid_manager.h"
 
 #include <new>

--- a/src/engine/shared/snapshot.cpp
+++ b/src/engine/shared/snapshot.cpp
@@ -6,7 +6,7 @@
 
 #include <climits>
 
-#include <game/generated/protocol.h>
+#include <base/system.h>
 #include <game/generated/protocolglue.h>
 
 // CSnapshot

--- a/src/engine/shared/snapshot.h
+++ b/src/engine/shared/snapshot.h
@@ -3,7 +3,7 @@
 #ifndef ENGINE_SHARED_SNAPSHOT_H
 #define ENGINE_SHARED_SNAPSHOT_H
 
-#include <base/system.h>
+#include <stdint.h>
 
 // CSnapshot
 

--- a/src/engine/shared/video.cpp
+++ b/src/engine/shared/video.cpp
@@ -1,7 +1,5 @@
 #if defined(CONF_VIDEORECORDER)
 
-#include <engine/shared/config.h>
-
 #include "video.h"
 
 IVideo *IVideo::ms_pCurrentVideo = 0;

--- a/src/game/client/animstate.cpp
+++ b/src/game/client/animstate.cpp
@@ -3,7 +3,6 @@
 
 #include <base/math.h>
 #include <game/generated/client_data.h>
-#include <game/generated/protocol.h>
 
 #include "animstate.h"
 

--- a/src/game/client/component.h
+++ b/src/game/client/component.h
@@ -7,14 +7,7 @@
 #include <engine/shared/video.h>
 #endif
 
-#include <base/color.h>
 #include <engine/input.h>
-
-#include <engine/client.h>
-#include <engine/console.h>
-#include <game/localization.h>
-
-#include <engine/config.h>
 
 class CGameClient;
 

--- a/src/game/client/components/background.cpp
+++ b/src/game/client/components/background.cpp
@@ -1,10 +1,8 @@
 #include <base/system.h>
 
-#include <engine/graphics.h>
 #include <engine/map.h>
 #include <engine/shared/config.h>
 
-#include <game/client/components/camera.h>
 #include <game/client/components/mapimages.h>
 #include <game/client/components/maplayers.h>
 

--- a/src/game/client/components/binds.h
+++ b/src/game/client/components/binds.h
@@ -2,10 +2,11 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #ifndef GAME_CLIENT_COMPONENTS_BINDS_H
 #define GAME_CLIENT_COMPONENTS_BINDS_H
-#include <engine/keys.h>
-#include <game/client/component.h>
 
-#include "console.h"
+#include <engine/console.h>
+#include <engine/keys.h>
+
+#include <game/client/component.h>
 
 class IConfigManager;
 

--- a/src/game/client/components/broadcast.cpp
+++ b/src/game/client/components/broadcast.cpp
@@ -3,7 +3,7 @@
 #include <engine/graphics.h>
 #include <engine/shared/config.h>
 #include <engine/textrender.h>
-#include <game/generated/client_data.h>
+
 #include <game/generated/protocol.h>
 
 #include <game/client/gameclient.h>

--- a/src/game/client/components/camera.cpp
+++ b/src/game/client/components/camera.cpp
@@ -4,14 +4,12 @@
 #include <engine/shared/config.h>
 
 #include <base/math.h>
-#include <game/client/component.h>
 #include <game/client/gameclient.h>
 #include <game/collision.h>
 
 #include "camera.h"
 #include "controls.h"
 
-#include <engine/serverbrowser.h>
 #include <limits>
 
 const float ZoomStep = 0.866025f;

--- a/src/game/client/components/camera.h
+++ b/src/game/client/components/camera.h
@@ -3,6 +3,10 @@
 #ifndef GAME_CLIENT_COMPONENTS_CAMERA_H
 #define GAME_CLIENT_COMPONENTS_CAMERA_H
 #include <base/vmath.h>
+
+#include <engine/client.h>
+#include <engine/console.h>
+
 #include <game/bezier.h>
 #include <game/client/component.h>
 

--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -2,14 +2,12 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 
 #include <engine/editor.h>
-#include <engine/engine.h>
 #include <engine/graphics.h>
 #include <engine/keys.h>
 #include <engine/shared/config.h>
 #include <engine/shared/csv.h>
 #include <engine/textrender.h>
 
-#include <game/generated/client_data.h>
 #include <game/generated/protocol.h>
 
 #include <game/client/animstate.h>

--- a/src/game/client/components/chat.h
+++ b/src/game/client/components/chat.h
@@ -4,6 +4,7 @@
 #define GAME_CLIENT_COMPONENTS_CHAT_H
 #include <vector>
 
+#include <engine/console.h>
 #include <engine/shared/config.h>
 #include <engine/shared/ringbuffer.h>
 

--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -14,21 +14,16 @@
 #include <engine/console.h>
 #include <engine/graphics.h>
 #include <engine/keys.h>
-#include <engine/serverbrowser.h>
 #include <engine/shared/config.h>
 #include <engine/shared/ringbuffer.h>
 #include <engine/storage.h>
 #include <engine/textrender.h>
 
-#include <cstdio>
-#include <cstring>
-
 #include <game/client/ui.h>
 
+#include <game/localization.h>
 #include <game/version.h>
 
-#include <game/client/components/controls.h>
-#include <game/client/components/menus.h>
 #include <game/client/lineinput.h>
 #include <game/client/render.h>
 

--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -4,10 +4,8 @@
 
 #include <SDL.h>
 
-#include <engine/serverbrowser.h>
 #include <engine/shared/config.h>
 
-#include <game/client/component.h>
 #include <game/client/components/camera.h>
 #include <game/client/components/chat.h>
 #include <game/client/components/menus.h>

--- a/src/game/client/components/controls.h
+++ b/src/game/client/components/controls.h
@@ -2,11 +2,14 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #ifndef GAME_CLIENT_COMPONENTS_CONTROLS_H
 #define GAME_CLIENT_COMPONENTS_CONTROLS_H
-#include <SDL_joystick.h>
-#include <base/system.h>
-#include <base/vmath.h>
-#include <game/client/component.h>
 
+#include <SDL_joystick.h>
+
+#include <base/vmath.h>
+
+#include <engine/client.h>
+
+#include <game/client/component.h>
 #include <game/generated/protocol.h>
 
 class CControls : public CComponent

--- a/src/game/client/components/countryflags.cpp
+++ b/src/game/client/components/countryflags.cpp
@@ -8,7 +8,6 @@
 #include <engine/shared/config.h>
 #include <engine/shared/linereader.h>
 #include <engine/storage.h>
-#include <engine/textrender.h>
 
 #include "countryflags.h"
 

--- a/src/game/client/components/countryflags.h
+++ b/src/game/client/components/countryflags.h
@@ -2,7 +2,7 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #ifndef GAME_CLIENT_COMPONENTS_COUNTRYFLAGS_H
 #define GAME_CLIENT_COMPONENTS_COUNTRYFLAGS_H
-#include <base/vmath.h>
+
 #include <game/client/component.h>
 #include <vector>
 

--- a/src/game/client/components/damageind.cpp
+++ b/src/game/client/components/damageind.cpp
@@ -7,7 +7,6 @@
 
 #include "damageind.h"
 #include <game/client/render.h>
-#include <game/client/ui.h>
 
 #include <game/client/gameclient.h>
 

--- a/src/game/client/components/debughud.cpp
+++ b/src/game/client/components/debughud.cpp
@@ -4,17 +4,12 @@
 #include <engine/shared/config.h>
 #include <engine/textrender.h>
 
-#include <game/generated/client_data.h>
 #include <game/generated/protocol.h>
 
-#include <game/layers.h>
-
-#include <game/client/animstate.h>
 #include <game/client/gameclient.h>
-#include <game/client/render.h>
+#include <game/client/prediction/entities/character.h>
+#include <game/localization.h>
 
-//#include "controls.h"
-//#include "camera.h"
 #include "debughud.h"
 
 void CDebugHud::RenderNetCorrections()

--- a/src/game/client/components/effects.cpp
+++ b/src/game/client/components/effects.cpp
@@ -2,7 +2,6 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 
 #include <engine/demo.h>
-#include <engine/engine.h>
 
 #include <engine/shared/config.h>
 
@@ -11,7 +10,6 @@
 #include <game/client/components/damageind.h>
 #include <game/client/components/flow.h>
 #include <game/client/components/particles.h>
-#include <game/client/components/skins.h>
 #include <game/client/components/sounds.h>
 #include <game/client/gameclient.h>
 

--- a/src/game/client/components/emoticon.cpp
+++ b/src/game/client/components/emoticon.cpp
@@ -1,9 +1,7 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include <engine/graphics.h>
-#include <engine/serverbrowser.h>
 #include <engine/shared/config.h>
-#include <game/generated/client_data.h>
 #include <game/generated/protocol.h>
 
 #include "chat.h"
@@ -11,7 +9,6 @@
 #include <game/client/animstate.h>
 #include <game/client/render.h>
 #include <game/client/ui.h>
-#include <game/gamecore.h> // get_angle
 
 #include <game/client/gameclient.h>
 

--- a/src/game/client/components/ghost.cpp
+++ b/src/game/client/components/ghost.cpp
@@ -1,7 +1,6 @@
 /* (c) Rajh, Redix and Sushi. */
 
 #include <engine/ghost.h>
-#include <engine/serverbrowser.h>
 #include <engine/shared/config.h>
 #include <engine/storage.h>
 

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -1,7 +1,6 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include <engine/graphics.h>
-#include <engine/serverbrowser.h>
 #include <engine/shared/config.h>
 #include <engine/textrender.h>
 
@@ -10,9 +9,10 @@
 #include <game/client/gameclient.h>
 #include <game/client/render.h>
 #include <game/generated/client_data.h>
-#include <game/generated/client_data7.h>
 #include <game/generated/protocol.h>
+
 #include <game/layers.h>
+#include <game/localization.h>
 
 #include <cmath>
 

--- a/src/game/client/components/items.cpp
+++ b/src/game/client/components/items.cpp
@@ -4,16 +4,17 @@
 #include <engine/graphics.h>
 #include <engine/shared/config.h>
 #include <game/generated/client_data.h>
-#include <game/generated/client_data7.h>
 #include <game/generated/protocol.h>
 
 #include <game/client/gameclient.h>
 #include <game/client/projectile_data.h>
 #include <game/client/render.h>
-#include <game/client/ui.h>
+
+#include <game/client/prediction/entities/laser.h>
+#include <game/client/prediction/entities/pickup.h>
+#include <game/client/prediction/entities/projectile.h>
 
 #include <game/client/components/effects.h>
-#include <game/client/components/flow.h>
 
 #include "items.h"
 

--- a/src/game/client/components/mapimages.cpp
+++ b/src/game/client/components/mapimages.cpp
@@ -2,10 +2,9 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include <engine/graphics.h>
 #include <engine/map.h>
-#include <engine/serverbrowser.h>
 #include <engine/storage.h>
 #include <engine/textrender.h>
-#include <game/client/component.h>
+#include <game/generated/client_data.h>
 #include <game/mapitems.h>
 
 #include <game/layers.h>

--- a/src/game/client/components/mapimages.h
+++ b/src/game/client/components/mapimages.h
@@ -2,6 +2,9 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #ifndef GAME_CLIENT_COMPONENTS_MAPIMAGES_H
 #define GAME_CLIENT_COMPONENTS_MAPIMAGES_H
+
+#include <engine/graphics.h>
+
 #include <game/client/component.h>
 
 enum EMapImageEntityLayerType

--- a/src/game/client/components/maplayers.cpp
+++ b/src/game/client/components/maplayers.cpp
@@ -7,15 +7,12 @@
 #include <engine/shared/config.h>
 #include <engine/storage.h>
 
-#include <game/client/component.h>
 #include <game/client/gameclient.h>
 #include <game/client/render.h>
 #include <game/layers.h>
 
 #include <game/client/components/camera.h>
 #include <game/client/components/mapimages.h>
-
-#include <game/generated/client_data.h>
 
 #include "maplayers.h"
 

--- a/src/game/client/components/mapsounds.cpp
+++ b/src/game/client/components/mapsounds.cpp
@@ -1,5 +1,4 @@
 #include <engine/demo.h>
-#include <engine/engine.h>
 #include <engine/sound.h>
 
 #include <game/client/components/camera.h>

--- a/src/game/client/components/menu_background.cpp
+++ b/src/game/client/components/menu_background.cpp
@@ -12,8 +12,6 @@
 
 #include <game/layers.h>
 
-#include <game/client/render.h>
-
 #include "menu_background.h"
 
 #include <chrono>

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -1,17 +1,15 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 
-#include <vector>
-
+#include <chrono>
 #include <cmath>
+#include <vector>
 
 #include <base/math.h>
 #include <base/system.h>
 #include <base/vmath.h>
 
-#include <engine/config.h>
 #include <engine/editor.h>
-#include <engine/engine.h>
 #include <engine/friends.h>
 #include <engine/graphics.h>
 #include <engine/keys.h>
@@ -21,7 +19,6 @@
 #include <engine/textrender.h>
 
 #include <game/generated/protocol.h>
-#include <game/version.h>
 
 #include <engine/client/updater.h>
 
@@ -30,18 +27,11 @@
 #include <game/client/components/menu_background.h>
 #include <game/client/components/sounds.h>
 #include <game/client/gameclient.h>
-#include <game/client/lineinput.h>
 #include <game/generated/client_data.h>
 #include <game/localization.h>
 
-#include "controls.h"
 #include "countryflags.h"
 #include "menus.h"
-#include "skins.h"
-
-#include <limits>
-
-#include <chrono>
 
 using namespace std::chrono_literals;
 

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -8,6 +8,7 @@
 #include <chrono>
 #include <vector>
 
+#include <engine/console.h>
 #include <engine/demo.h>
 #include <engine/friends.h>
 #include <engine/shared/config.h>

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1,23 +1,16 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
-#include <engine/config.h>
 #include <engine/friends.h>
-#include <engine/graphics.h>
 #include <engine/keys.h>
 #include <engine/serverbrowser.h>
 #include <engine/shared/config.h>
 #include <engine/textrender.h>
-#include <engine/updater.h>
-
-#include <game/generated/client_data.h>
-#include <game/generated/protocol.h>
 
 #include <game/client/components/console.h>
 #include <game/client/components/countryflags.h>
 #include <game/client/render.h>
 #include <game/client/ui.h>
 #include <game/localization.h>
-#include <game/version.h>
 
 #include <game/client/gameclient.h>
 

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -3,7 +3,6 @@
 #include <base/math.h>
 #include <base/system.h>
 
-#include <engine/config.h>
 #include <engine/demo.h>
 #include <engine/friends.h>
 #include <engine/ghost.h>

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -3,7 +3,6 @@
 #include <base/math.h>
 #include <base/system.h>
 
-#include <engine/engine.h>
 #include <engine/graphics.h>
 #include <engine/shared/config.h>
 #include <engine/shared/linereader.h>
@@ -11,7 +10,6 @@
 #include <engine/textrender.h>
 #include <engine/updater.h>
 
-#include <game/generated/client_data.h>
 #include <game/generated/protocol.h>
 
 #include <game/client/animstate.h>
@@ -24,20 +22,16 @@
 #include <game/localization.h>
 
 #include "binds.h"
-#include "camera.h"
 #include "countryflags.h"
 #include "menus.h"
 #include "skins.h"
 
-#include <memory>
-#include <string>
-#include <utility>
-#include <vector>
-
 #include <array>
-#include <numeric>
-
 #include <chrono>
+#include <memory>
+#include <numeric>
+#include <string>
+#include <vector>
 
 using namespace std::chrono_literals;
 

--- a/src/game/client/components/menus_settings_assets.cpp
+++ b/src/game/client/components/menus_settings_assets.cpp
@@ -1,12 +1,10 @@
-#include "binds.h"
-
 #include <base/system.h>
 
-#include <engine/engine.h>
 #include <engine/shared/config.h>
 #include <engine/storage.h>
 #include <engine/textrender.h>
 #include <game/client/gameclient.h>
+#include <game/localization.h>
 
 #include "menus.h"
 

--- a/src/game/client/components/menus_start.cpp
+++ b/src/game/client/components/menus_start.cpp
@@ -8,17 +8,17 @@
 #include <engine/client/updater.h>
 #include <engine/shared/config.h>
 
-#include <game/client/components/console.h>
-#include <game/client/render.h>
+#include <game/client/gameclient.h>
 #include <game/client/ui.h>
-#include <game/editor/editor.h>
-#include <game/version.h>
 
 #include <game/generated/client_data.h>
-
-#include <game/client/gameclient.h>
+#include <game/localization.h>
 
 #include "menus.h"
+
+#include <chrono>
+
+using namespace std::chrono_literals;
 
 void CMenus::RenderStartMenu(CUIRect MainView)
 {

--- a/src/game/client/components/motd.cpp
+++ b/src/game/client/components/motd.cpp
@@ -6,7 +6,6 @@
 #include <engine/textrender.h>
 
 #include <game/client/gameclient.h>
-#include <game/generated/client_data.h>
 #include <game/generated/protocol.h>
 
 #include "motd.h"

--- a/src/game/client/components/nameplates.cpp
+++ b/src/game/client/components/nameplates.cpp
@@ -9,8 +9,8 @@
 #include "camera.h"
 #include "controls.h"
 #include "nameplates.h"
-#include <game/client/animstate.h>
 #include <game/client/gameclient.h>
+#include <game/client/prediction/entities/character.h>
 
 #include "players.h"
 

--- a/src/game/client/components/nameplates.h
+++ b/src/game/client/components/nameplates.h
@@ -4,9 +4,7 @@
 #define GAME_CLIENT_COMPONENTS_NAMEPLATES_H
 #include <game/client/component.h>
 
-struct CNetObj_Character;
-struct CNetObj_PlayerInfo;
-struct CMapItemGroup;
+#include <game/generated/protocol.h>
 
 struct SPlayerNamePlate
 {

--- a/src/game/client/components/particles.cpp
+++ b/src/game/client/components/particles.cpp
@@ -6,7 +6,6 @@
 
 #include "particles.h"
 #include <game/client/render.h>
-#include <game/gamecore.h>
 #include <game/generated/client_data.h>
 
 #include <game/client/gameclient.h>

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -2,9 +2,7 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 
 #include <engine/demo.h>
-#include <engine/engine.h>
 #include <engine/graphics.h>
-#include <engine/serverbrowser.h>
 #include <engine/shared/config.h>
 #include <game/generated/client_data.h>
 #include <game/generated/protocol.h>
@@ -12,15 +10,12 @@
 #include <game/client/animstate.h>
 #include <game/client/gameclient.h>
 #include <game/client/render.h>
-#include <game/client/ui.h>
 
 #include <game/client/components/controls.h>
 #include <game/client/components/effects.h>
 #include <game/client/components/flow.h>
 #include <game/client/components/skins.h>
 #include <game/client/components/sounds.h>
-
-#include <engine/textrender.h>
 
 #include "players.h"
 

--- a/src/game/client/components/race_demo.cpp
+++ b/src/game/client/components/race_demo.cpp
@@ -3,7 +3,6 @@
 #include <cctype>
 
 #include <base/system.h>
-#include <engine/serverbrowser.h>
 #include <engine/shared/config.h>
 #include <engine/storage.h>
 

--- a/src/game/client/components/scoreboard.cpp
+++ b/src/game/client/components/scoreboard.cpp
@@ -5,21 +5,17 @@
 #include <engine/shared/config.h>
 #include <engine/textrender.h>
 
-#include <game/generated/client_data.h>
 #include <game/generated/protocol.h>
 
 #include <game/client/animstate.h>
 #include <game/client/components/countryflags.h>
 #include <game/client/components/motd.h>
-#include <game/client/components/skins.h>
 #include <game/client/components/statboard.h>
 #include <game/client/gameclient.h>
 #include <game/client/render.h>
 #include <game/localization.h>
 
 #include "scoreboard.h"
-
-#include <engine/serverbrowser.h>
 
 CScoreboard::CScoreboard()
 {

--- a/src/game/client/components/scoreboard.h
+++ b/src/game/client/components/scoreboard.h
@@ -2,6 +2,9 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #ifndef GAME_CLIENT_COMPONENTS_SCOREBOARD_H
 #define GAME_CLIENT_COMPONENTS_SCOREBOARD_H
+
+#include <engine/console.h>
+
 #include <game/client/component.h>
 
 class CScoreboard : public CComponent

--- a/src/game/client/components/skins.cpp
+++ b/src/game/client/components/skins.cpp
@@ -1,6 +1,5 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
-#include <cmath>
 
 #include <base/math.h>
 #include <base/system.h>

--- a/src/game/client/components/skins.h
+++ b/src/game/client/components/skins.h
@@ -2,8 +2,7 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #ifndef GAME_CLIENT_COMPONENTS_SKINS_H
 #define GAME_CLIENT_COMPONENTS_SKINS_H
-#include <base/color.h>
-#include <base/vmath.h>
+
 #include <engine/shared/http.h>
 #include <game/client/component.h>
 #include <game/client/skin.h>

--- a/src/game/client/components/sounds.h
+++ b/src/game/client/components/sounds.h
@@ -2,7 +2,9 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #ifndef GAME_CLIENT_COMPONENTS_SOUNDS_H
 #define GAME_CLIENT_COMPONENTS_SOUNDS_H
-#include <engine/engine.h>
+
+#include <base/vmath.h>
+#include <engine/shared/jobs.h>
 #include <engine/sound.h>
 #include <game/client/component.h>
 

--- a/src/game/client/components/spectator.cpp
+++ b/src/game/client/components/spectator.cpp
@@ -3,16 +3,15 @@
 
 #include <climits>
 
-#include <engine/demo.h>
 #include <engine/graphics.h>
 #include <engine/shared/config.h>
 #include <engine/textrender.h>
 
-#include <game/generated/client_data.h>
 #include <game/generated/protocol.h>
 
 #include <game/client/animstate.h>
 #include <game/client/render.h>
+#include <game/localization.h>
 
 #include "camera.h"
 #include "spectator.h"

--- a/src/game/client/components/statboard.cpp
+++ b/src/game/client/components/statboard.cpp
@@ -8,6 +8,7 @@
 #include <game/client/components/statboard.h>
 #include <game/client/gameclient.h>
 #include <game/generated/client_data.h>
+#include <game/localization.h>
 
 CStatboard::CStatboard()
 {

--- a/src/game/client/components/statboard.h
+++ b/src/game/client/components/statboard.h
@@ -1,6 +1,8 @@
 #ifndef GAME_CLIENT_COMPONENTS_STATBOARD_H
 #define GAME_CLIENT_COMPONENTS_STATBOARD_H
 
+#include <engine/console.h>
+
 #include <game/client/component.h>
 #include <string>
 

--- a/src/game/client/components/voting.cpp
+++ b/src/game/client/components/voting.cpp
@@ -3,7 +3,6 @@
 #include <engine/shared/config.h>
 
 #include "voting.h"
-#include <base/vmath.h>
 #include <game/client/components/sounds.h>
 #include <game/client/render.h>
 #include <game/generated/protocol.h>

--- a/src/game/client/components/voting.h
+++ b/src/game/client/components/voting.h
@@ -3,6 +3,7 @@
 #ifndef GAME_CLIENT_COMPONENTS_VOTING_H
 #define GAME_CLIENT_COMPONENTS_VOTING_H
 
+#include <engine/console.h>
 #include <engine/shared/memheap.h>
 
 #include <game/client/component.h>

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -13,7 +13,6 @@
 #include <engine/map.h>
 #include <engine/serverbrowser.h>
 #include <engine/shared/config.h>
-#include <engine/shared/demo.h>
 #include <engine/sound.h>
 #include <engine/storage.h>
 #include <engine/textrender.h>
@@ -24,6 +23,7 @@
 #include <game/generated/protocol.h>
 
 #include <base/math.h>
+#include <base/system.h>
 #include <base/vmath.h>
 
 #include "race.h"
@@ -45,8 +45,8 @@
 #include "components/debughud.h"
 #include "components/effects.h"
 #include "components/emoticon.h"
-#include "components/flow.h"
 #include "components/freezebars.h"
+#include "components/ghost.h"
 #include "components/hud.h"
 #include "components/items.h"
 #include "components/killmessages.h"
@@ -59,16 +59,15 @@
 #include "components/nameplates.h"
 #include "components/particles.h"
 #include "components/players.h"
+#include "components/race_demo.h"
 #include "components/scoreboard.h"
 #include "components/skins.h"
 #include "components/sounds.h"
 #include "components/spectator.h"
 #include "components/statboard.h"
 #include "components/voting.h"
-
-#include "components/ghost.h"
-#include "components/race_demo.h"
-#include <base/system.h>
+#include "prediction/entities/character.h"
+#include "prediction/entities/projectile.h"
 
 using namespace std::chrono_literals;
 

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -11,13 +11,9 @@
 #include <engine/shared/config.h>
 #include <game/gamecore.h>
 #include <game/layers.h>
-#include <game/localization.h>
 
 #include <game/teamscore.h>
 
-#include <game/client/prediction/entities/character.h>
-#include <game/client/prediction/entities/laser.h>
-#include <game/client/prediction/entities/pickup.h>
 #include <game/client/prediction/gameworld.h>
 
 // components

--- a/src/game/client/prediction/entities/character.cpp
+++ b/src/game/client/prediction/entities/character.cpp
@@ -1,8 +1,8 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include <engine/shared/config.h>
+#include <game/generated/client_data.h>
 #include <game/mapitems.h>
-#include <new>
 
 #include "character.h"
 #include "laser.h"

--- a/src/game/client/prediction/entities/character.h
+++ b/src/game/client/prediction/entities/character.h
@@ -3,11 +3,9 @@
 #ifndef GAME_CLIENT_PREDICTION_ENTITIES_CHARACTER_H
 #define GAME_CLIENT_PREDICTION_ENTITIES_CHARACTER_H
 
-#include "projectile.h"
 #include <game/client/prediction/entity.h>
 
 #include <game/gamecore.h>
-#include <game/generated/client_data.h>
 
 enum
 {

--- a/src/game/client/prediction/entities/laser.cpp
+++ b/src/game/client/prediction/entities/laser.cpp
@@ -3,6 +3,7 @@
 #include "laser.h"
 #include "character.h"
 #include <game/generated/protocol.h>
+#include <game/mapitems.h>
 
 #include <engine/shared/config.h>
 

--- a/src/game/client/prediction/entities/pickup.cpp
+++ b/src/game/client/prediction/entities/pickup.cpp
@@ -3,6 +3,7 @@
 #include "pickup.h"
 #include "character.h"
 #include <game/generated/protocol.h>
+#include <game/mapitems.h>
 
 void CPickup::Tick()
 {

--- a/src/game/client/prediction/entities/projectile.cpp
+++ b/src/game/client/prediction/entities/projectile.cpp
@@ -3,6 +3,7 @@
 #include "projectile.h"
 #include <game/client/projectile_data.h>
 #include <game/generated/protocol.h>
+#include <game/mapitems.h>
 
 #include <engine/shared/config.h>
 

--- a/src/game/client/prediction/entities/projectile.cpp
+++ b/src/game/client/prediction/entities/projectile.cpp
@@ -1,11 +1,13 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
-#include "projectile.h"
+#include <engine/shared/config.h>
+
 #include <game/client/projectile_data.h>
 #include <game/generated/protocol.h>
 #include <game/mapitems.h>
 
-#include <engine/shared/config.h>
+#include "character.h"
+#include "projectile.h"
 
 CProjectile::CProjectile(
 	CGameWorld *pGameWorld,

--- a/src/game/client/prediction/entities/projectile.h
+++ b/src/game/client/prediction/entities/projectile.h
@@ -3,7 +3,6 @@
 #ifndef GAME_CLIENT_PREDICTION_ENTITIES_PROJECTILE_H
 #define GAME_CLIENT_PREDICTION_ENTITIES_PROJECTILE_H
 
-#include "character.h"
 #include <game/client/prediction/entity.h>
 
 class CProjectileData;

--- a/src/game/client/prediction/entity.h
+++ b/src/game/client/prediction/entity.h
@@ -5,7 +5,6 @@
 
 #include "gameworld.h"
 #include <base/vmath.h>
-#include <new>
 
 #define MACRO_ALLOC_HEAP() \
 public: \

--- a/src/game/client/projectile_data.cpp
+++ b/src/game/client/projectile_data.cpp
@@ -3,7 +3,6 @@
 
 #include "projectile_data.h"
 
-#include <base/math.h>
 #include <engine/shared/snapshot.h>
 #include <game/client/prediction/gameworld.h>
 #include <game/generated/protocol.h>

--- a/src/game/client/race.cpp
+++ b/src/game/client/race.cpp
@@ -1,8 +1,6 @@
 #include <cctype>
 #include <list>
 
-#include <base/math.h>
-#include <engine/serverbrowser.h>
 #include <game/client/gameclient.h>
 #include <game/mapitems.h>
 

--- a/src/game/client/race.h
+++ b/src/game/client/race.h
@@ -1,7 +1,6 @@
 #ifndef GAME_CLIENT_RACE_H
 #define GAME_CLIENT_RACE_H
 
-#include <base/system.h>
 #include <base/vmath.h>
 
 class CRaceHelper

--- a/src/game/client/render.cpp
+++ b/src/game/client/render.cpp
@@ -7,14 +7,10 @@
 #include "animstate.h"
 #include "render.h"
 #include <engine/graphics.h>
-#include <engine/map.h>
 #include <engine/shared/config.h>
-#include <game/client/components/skins.h>
-#include <game/client/gameclient.h>
 #include <game/generated/client_data.h>
 #include <game/generated/client_data7.h>
 #include <game/generated/protocol.h>
-#include <game/layers.h>
 
 static float gs_SpriteWScale;
 static float gs_SpriteHScale;

--- a/src/game/client/render_map.cpp
+++ b/src/game/client/render_map.cpp
@@ -9,7 +9,6 @@
 #include <engine/shared/config.h>
 #include <engine/textrender.h>
 #include <game/generated/client_data.h>
-#include <game/generated/protocol.h>
 
 #include <chrono>
 

--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -3,7 +3,6 @@
 #ifndef GAME_CLIENT_UI_H
 #define GAME_CLIENT_UI_H
 
-#include <base/system.h>
 #include <engine/textrender.h>
 
 #include <chrono>

--- a/src/game/client/ui_ex.cpp
+++ b/src/game/client/ui_ex.cpp
@@ -5,7 +5,6 @@
 #include <base/math.h>
 #include <engine/textrender.h>
 
-#include <engine/client/input.h>
 #include <engine/keys.h>
 
 #include <game/client/lineinput.h>

--- a/src/game/client/ui_ex.h
+++ b/src/game/client/ui_ex.h
@@ -1,7 +1,6 @@
 #ifndef GAME_CLIENT_UI_EX_H
 #define GAME_CLIENT_UI_EX_H
 
-#include <base/system.h>
 #include <engine/input.h>
 #include <engine/kernel.h>
 #include <game/client/ui.h>

--- a/src/game/collision.cpp
+++ b/src/game/collision.cpp
@@ -7,7 +7,6 @@
 #include <antibot/antibot_data.h>
 
 #include <cmath>
-#include <engine/kernel.h>
 #include <engine/map.h>
 
 #include <game/collision.h>

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -16,16 +16,13 @@
 #include <engine/input.h>
 #include <engine/keys.h>
 #include <engine/shared/config.h>
-#include <engine/shared/datafile.h>
 #include <engine/storage.h>
 #include <engine/textrender.h>
 
 #include <game/client/components/camera.h>
 #include <game/client/gameclient.h>
-#include <game/client/lineinput.h>
 #include <game/client/render.h>
 #include <game/client/ui.h>
-#include <game/gamecore.h>
 #include <game/generated/client_data.h>
 #include <game/localization.h>
 

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -3,11 +3,9 @@
 #ifndef GAME_EDITOR_EDITOR_H
 #define GAME_EDITOR_EDITOR_H
 
-#include <math.h>
 #include <string>
 #include <vector>
 
-#include <base/math.h>
 #include <base/system.h>
 
 #include <game/client/render.h>
@@ -17,10 +15,6 @@
 
 #include <engine/editor.h>
 #include <engine/graphics.h>
-#include <engine/shared/config.h>
-#include <engine/shared/datafile.h>
-#include <engine/sound.h>
-#include <engine/storage.h>
 
 #include "auto_map.h"
 

--- a/src/game/editor/io.cpp
+++ b/src/game/editor/io.cpp
@@ -1,12 +1,14 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
-
 #include "editor.h"
 #include <engine/client.h>
 #include <engine/console.h>
 #include <engine/graphics.h>
 #include <engine/serverbrowser.h>
+#include <engine/shared/datafile.h>
+#include <engine/sound.h>
 #include <engine/storage.h>
+
 #include <game/gamecore.h>
 #include <game/mapitems_ex.h>
 

--- a/src/game/editor/layer_quads.cpp
+++ b/src/game/editor/layer_quads.cpp
@@ -2,13 +2,10 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include <base/math.h>
 
-#include <engine/console.h>
 #include <engine/graphics.h>
 
 #include "editor.h"
 #include <game/client/render.h>
-#include <game/generated/client_data.h>
-#include <game/localization.h>
 
 CLayerQuads::CLayerQuads()
 {

--- a/src/game/editor/layer_tiles.cpp
+++ b/src/game/editor/layer_tiles.cpp
@@ -8,9 +8,6 @@
 
 #include "editor.h"
 #include <game/client/render.h>
-#include <game/generated/client_data.h>
-
-#include <game/localization.h>
 
 #include <engine/input.h>
 #include <engine/keys.h>

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -7,6 +7,7 @@
 #include <engine/graphics.h>
 #include <engine/input.h>
 #include <engine/keys.h>
+#include <engine/shared/config.h>
 #include <engine/storage.h>
 
 #include "editor.h"

--- a/src/game/gamecore.cpp
+++ b/src/game/gamecore.cpp
@@ -1,6 +1,7 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include "gamecore.h"
+#include "mapitems.h"
 
 #include <engine/shared/config.h>
 

--- a/src/game/gamecore.h
+++ b/src/game/gamecore.h
@@ -3,7 +3,6 @@
 #ifndef GAME_GAMECORE_H
 #define GAME_GAMECORE_H
 
-#include <base/math.h>
 #include <base/system.h>
 
 #include <map>
@@ -13,9 +12,7 @@
 #include "collision.h"
 #include <engine/shared/protocol.h>
 #include <game/generated/protocol.h>
-#include <math.h>
 
-#include "mapitems.h"
 #include "prng.h"
 #include "teamscore.h"
 

--- a/src/game/layers.cpp
+++ b/src/game/layers.cpp
@@ -1,6 +1,7 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include "layers.h"
+#include <engine/map.h>
 
 CLayers::CLayers()
 {

--- a/src/game/layers.h
+++ b/src/game/layers.h
@@ -3,7 +3,6 @@
 #ifndef GAME_LAYERS_H
 #define GAME_LAYERS_H
 
-#include <engine/map.h>
 #include <game/mapitems.h>
 
 class CLayers

--- a/src/game/mapitems.h
+++ b/src/game/mapitems.h
@@ -3,8 +3,6 @@
 #ifndef GAME_MAPITEMS_H
 #define GAME_MAPITEMS_H
 
-#include <engine/shared/protocol.h>
-
 // layer types
 enum
 {

--- a/src/game/prng.cpp
+++ b/src/game/prng.cpp
@@ -1,5 +1,7 @@
 #include "prng.h"
 
+#include <base/system.h>
+
 // From https://en.wikipedia.org/w/index.php?title=Permuted_congruential_generator&oldid=901497400#Example_code.
 //
 // > The generator recommended for most users is PCG-XSH-RR with 64-bit state

--- a/src/game/prng.h
+++ b/src/game/prng.h
@@ -1,7 +1,7 @@
 #ifndef GAME_PRNG_H
 #define GAME_PRNG_H
 
-#include <base/system.h>
+#include <stdint.h>
 
 class CPrng
 {

--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -1,6 +1,5 @@
 /* (c) Shereef Marzouk. See "licence DDRace.txt" and the readme.txt in the root of the distribution for more information. */
 #include "gamecontext.h"
-#include <engine/engine.h>
 #include <engine/shared/config.h>
 #include <engine/shared/protocol.h>
 #include <game/server/gamemodes/DDRace.h>

--- a/src/game/server/ddracecommands.cpp
+++ b/src/game/server/ddracecommands.cpp
@@ -6,7 +6,6 @@
 #include <game/server/player.h>
 #include <game/server/save.h>
 #include <game/server/teams.h>
-#include <game/version.h>
 
 bool CheckClientID(int ClientID);
 

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -6,13 +6,11 @@
 #include <game/mapitems.h>
 #include <game/server/gamecontext.h>
 #include <game/server/player.h>
-#include <new>
 
 #include "character.h"
 #include "laser.h"
 #include "projectile.h"
 
-#include "light.h"
 #include <game/server/score.h>
 #include <game/server/teams.h>
 

--- a/src/game/server/entities/door.cpp
+++ b/src/game/server/entities/door.cpp
@@ -1,8 +1,6 @@
 /* (c) Shereef Marzouk. See "licence DDRace.txt" and the readme.txt in the root of the distribution for more information. */
-#include <engine/shared/config.h>
 #include <game/generated/protocol.h>
 #include <game/server/gamecontext.h>
-#include <game/server/gamemodes/DDRace.h>
 #include <game/server/player.h>
 #include <game/version.h>
 

--- a/src/game/server/entities/dragger.cpp
+++ b/src/game/server/entities/dragger.cpp
@@ -1,10 +1,8 @@
 /* (c) Shereef Marzouk. See "licence DDRace.txt" and the readme.txt in the root of the distribution for more information. */
-#include <engine/config.h>
 #include <engine/server.h>
 #include <engine/shared/config.h>
 #include <game/generated/protocol.h>
 #include <game/server/gamecontext.h>
-#include <game/server/gamemodes/DDRace.h>
 #include <game/server/player.h>
 #include <game/server/teams.h>
 #include <game/version.h>

--- a/src/game/server/entities/dragger_beam.cpp
+++ b/src/game/server/entities/dragger_beam.cpp
@@ -2,13 +2,10 @@
 #include "dragger_beam.h"
 #include "character.h"
 #include "dragger.h"
-#include <engine/config.h>
 #include <engine/server.h>
+#include <engine/shared/config.h>
 #include <game/generated/protocol.h>
 #include <game/server/gamecontext.h>
-#include <game/server/gamemodes/DDRace.h>
-#include <game/server/player.h>
-#include <game/server/teams.h>
 
 CDraggerBeam::CDraggerBeam(CGameWorld *pGameWorld, CDragger *pDragger, vec2 Pos, float Strength, bool IgnoreWalls,
 	int ForClientID, int Layer, int Number) :

--- a/src/game/server/entities/gun.h
+++ b/src/game/server/entities/gun.h
@@ -3,7 +3,6 @@
 #ifndef GAME_SERVER_ENTITIES_GUN_H
 #define GAME_SERVER_ENTITIES_GUN_H
 
-#include <game/gamecore.h>
 #include <game/server/entity.h>
 
 /**

--- a/src/game/server/entities/light.cpp
+++ b/src/game/server/entities/light.cpp
@@ -1,6 +1,5 @@
 /* (c) Shereef Marzouk. See "licence DDRace.txt" and the readme.txt in the root of the distribution for more information. */
 #include "light.h"
-#include <engine/config.h>
 #include <engine/server.h>
 #include <game/generated/protocol.h>
 #include <game/mapitems.h>

--- a/src/game/server/entities/pickup.cpp
+++ b/src/game/server/entities/pickup.cpp
@@ -5,7 +5,6 @@
 #include <game/server/gamecontext.h>
 #include <game/server/player.h>
 
-#include <game/server/teams.h>
 #include <game/version.h>
 
 #include "character.h"

--- a/src/game/server/entities/plasma.cpp
+++ b/src/game/server/entities/plasma.cpp
@@ -1,12 +1,8 @@
 /* (c) Shereef Marzouk. See "licence DDRace.txt" and the readme.txt in the root of the distribution for more information. */
 #include "plasma.h"
-#include <engine/config.h>
 #include <engine/server.h>
 #include <game/generated/protocol.h>
 #include <game/server/gamecontext.h>
-#include <game/server/gamemodes/DDRace.h>
-#include <game/server/player.h>
-#include <game/server/teams.h>
 
 #include "character.h"
 

--- a/src/game/server/entities/projectile.cpp
+++ b/src/game/server/entities/projectile.cpp
@@ -4,7 +4,6 @@
 #include <game/generated/protocol.h>
 #include <game/server/gamecontext.h>
 #include <game/server/gamemodes/DDRace.h>
-#include <game/server/player.h>
 #include <game/version.h>
 
 #include <engine/shared/config.h>

--- a/src/game/server/eventhandler.cpp
+++ b/src/game/server/eventhandler.cpp
@@ -4,7 +4,9 @@
 
 #include "entity.h"
 #include "gamecontext.h"
-#include "player.h"
+
+#include <base/system.h>
+#include <base/vmath.h>
 
 //////////////////////////////////////////////////
 // Event handler

--- a/src/game/server/eventhandler.h
+++ b/src/game/server/eventhandler.h
@@ -3,8 +3,7 @@
 #ifndef GAME_SERVER_EVENTHANDLER_H
 #define GAME_SERVER_EVENTHANDLER_H
 
-#include <base/system.h>
-#include <base/vmath.h>
+#include <stdint.h>
 
 class CEventHandler
 {

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -1,6 +1,5 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
-#include <iostream>
 #include <vector>
 
 #include "base/system.h"

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -12,7 +12,6 @@
 #include <game/voting.h>
 
 #include "eventhandler.h"
-//#include "gamecontroller.h"
 #include "game/generated/protocol.h"
 #include "gameworld.h"
 #include "teehistorian.h"

--- a/src/game/server/gamecontroller.cpp
+++ b/src/game/server/gamecontroller.cpp
@@ -16,7 +16,6 @@
 #include "entities/gun.h"
 #include "entities/light.h"
 #include "entities/projectile.h"
-#include <game/layers.h>
 
 IGameController::IGameController(class CGameContext *pGameServer)
 {

--- a/src/game/server/gamemodes/DDRace.h
+++ b/src/game/server/gamemodes/DDRace.h
@@ -1,7 +1,7 @@
 /* (c) Shereef Marzouk. See "licence DDRace.txt" and the readme.txt in the root of the distribution for more information. */
 #ifndef GAME_SERVER_GAMEMODES_DDRACE_H
 #define GAME_SERVER_GAMEMODES_DDRACE_H
-#include <game/server/entities/door.h>
+
 #include <game/server/gamecontroller.h>
 #include <game/server/teams.h>
 

--- a/src/game/server/save.cpp
+++ b/src/game/server/save.cpp
@@ -1,7 +1,6 @@
 #include "save.h"
 
 #include <cstdio>
-#include <new>
 
 #include "entities/character.h"
 #include "gamemodes/DDRace.h"

--- a/src/game/server/score.cpp
+++ b/src/game/server/score.cpp
@@ -1,5 +1,4 @@
 #include "score.h"
-#include "entities/character.h"
 #include "gamemodes/DDRace.h"
 #include "player.h"
 #include "save.h"
@@ -8,7 +7,6 @@
 #include <base/system.h>
 #include <engine/server/databases/connection.h>
 #include <engine/server/databases/connection_pool.h>
-#include <engine/server/sql_string_helpers.h>
 #include <engine/shared/config.h>
 #include <engine/shared/console.h>
 #include <engine/shared/linereader.h>
@@ -16,10 +14,7 @@
 #include <game/generated/wordlist.h>
 
 #include <algorithm>
-#include <cstring>
-#include <fstream>
 #include <memory>
-#include <random>
 
 std::shared_ptr<CScorePlayerResult> CScore::NewSqlPlayerResult(int ClientID)
 {

--- a/src/game/server/score.h
+++ b/src/game/server/score.h
@@ -1,10 +1,8 @@
 #ifndef GAME_SERVER_SCORE_H
 #define GAME_SERVER_SCORE_H
 
-#include <engine/map.h>
 #include <engine/server/databases/connection_pool.h>
 #include <game/prng.h>
-#include <game/voting.h>
 
 #include "save.h"
 #include "scoreworker.h"

--- a/src/game/server/scoreworker.h
+++ b/src/game/server/scoreworker.h
@@ -1,7 +1,6 @@
 #ifndef GAME_SERVER_SCOREWORKER_H
 #define GAME_SERVER_SCOREWORKER_H
 
-#include <atomic>
 #include <memory>
 #include <string>
 #include <utility>

--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -5,8 +5,6 @@
 #include <engine/shared/config.h>
 
 #include "entities/character.h"
-#include "entities/laser.h"
-#include "entities/projectile.h"
 #include "player.h"
 
 CGameTeams::CGameTeams(CGameContext *pGameContext) :

--- a/src/game/server/teams.h
+++ b/src/game/server/teams.h
@@ -4,10 +4,8 @@
 
 #include <engine/shared/config.h>
 #include <game/server/gamecontext.h>
-#include <game/server/score.h>
+#include <game/server/scoreworker.h>
 #include <game/teamscore.h>
-
-#include <utility>
 
 class CGameTeams
 {

--- a/src/game/server/teehistorian.h
+++ b/src/game/server/teehistorian.h
@@ -3,7 +3,6 @@
 
 #include <base/hash.h>
 #include <engine/console.h>
-#include <engine/shared/packer.h>
 #include <engine/shared/protocol.h>
 #include <game/generated/protocol.h>
 

--- a/src/game/teamscore.cpp
+++ b/src/game/teamscore.cpp
@@ -1,6 +1,5 @@
 /* (c) Shereef Marzouk. See "licence DDRace.txt" and the readme.txt in the root of the distribution for more information. */
 #include "teamscore.h"
-#include <base/math.h>
 #include <engine/shared/config.h>
 
 CTeamsCore::CTeamsCore()

--- a/src/test/color.cpp
+++ b/src/test/color.cpp
@@ -2,7 +2,6 @@
 #include <gtest/gtest.h>
 
 #include <base/color.h>
-#include <base/system.h>
 
 TEST(Color, HRHConv)
 {

--- a/src/tools/dilate.cpp
+++ b/src/tools/dilate.cpp
@@ -1,7 +1,6 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include <base/logger.h>
-#include <base/math.h>
 #include <base/system.h>
 #include <engine/shared/image_manipulation.h>
 #include <pnglite.h>

--- a/src/tools/map_convert_07.cpp
+++ b/src/tools/map_convert_07.cpp
@@ -2,7 +2,6 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.  */
 
 #include <base/logger.h>
-#include <base/math.h>
 #include <base/system.h>
 #include <engine/graphics.h>
 #include <engine/shared/datafile.h>

--- a/src/tools/map_diff.cpp
+++ b/src/tools/map_diff.cpp
@@ -5,8 +5,6 @@
 #include <game/gamecore.h>
 #include <game/mapitems.h>
 
-#include <pnglite.h>
-
 bool Process(IStorage *pStorage, const char **pMapNames)
 {
 	CDataFileReader Maps[2];

--- a/src/tools/map_optimize.cpp
+++ b/src/tools/map_optimize.cpp
@@ -1,13 +1,11 @@
 #include <algorithm>
 #include <base/logger.h>
-#include <base/math.h>
 #include <base/system.h>
 #include <cstdint>
 #include <engine/shared/datafile.h>
 #include <engine/shared/image_manipulation.h>
 #include <engine/storage.h>
 #include <game/mapitems.h>
-#include <utility>
 #include <vector>
 
 void ClearTransparentPixels(uint8_t *pImg, int Width, int Height)

--- a/src/tools/map_replace_image.cpp
+++ b/src/tools/map_replace_image.cpp
@@ -2,7 +2,6 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.  */
 
 #include <base/logger.h>
-#include <base/math.h>
 #include <base/system.h>
 #include <engine/graphics.h>
 #include <engine/shared/datafile.h>


### PR DESCRIPTION
I used https://github.com/include-what-you-use/include-what-you-use to find unused includes and then manually adjusted their usages.

Why? See https://github.com/include-what-you-use/include-what-you-use/blob/master/docs/WhyIWYU.md. This PR removes unused includes or moves the includes so they are used where necessary, to achieve the first two benefits listed there.
Eventually IWYU could be used to also add all includes that are transitively needed (thereby doing what the tool name implies), so refactoring could be made easier, as the includes of every file would be independent from those of other files.

We can have a separate discussion about organizing the includes further. For example how includes should be grouped and how those groups should be ordered. Right now clang-format just enforces alphabetical ordering for all includes in a group. Also to what extent should forward-declarations be used instead of includes.

IWYU usage after compiling and adding it to the path:

```
mkdir build
cd build
CC="clang" CXX="clang++" cmake -G "Unix Makefiles" -DCMAKE_CXX_INCLUDE_WHAT_YOU_USE="include-what-you-use;-Xiwyu;--no_comments;-Xiwyu;--no_fwd_decls;-Xiwyu;--quoted_includes_first" -B . ..
make 2> iwyu.log
```

Adding IWYU to the CI would likely be too much effort, as the changes that IWYU proposes need to be manually reviewed, as there are some false-positives, especially with conditional includes/usages of includes.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
