### PR TITLE
penalty tiles can be used to get a time of 00:00:01, this is fixed by letting the tees die, before that happens

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -2679,7 +2679,7 @@ int CServer::Run()
 			int NewTicks = 0;
 
 			// load new map TODO: don't poll this
-			if(m_MapReload)
+			if(m_MapReload || m_CurrentGameTick >= 0x6FFFFFFF) // force reload to make sure the ticks stay within a valid range
 			{
 				// load map
 				if(LoadMap(Config()->m_SvMap))

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -718,6 +718,15 @@ void CCharacter::Tick()
 		m_pPlayer->m_ForceBalanced = false;
 	}*/
 
+	if(m_StartTime > Server()->Tick())
+	{
+		// Prevent the player from getting a negative time
+		// The main reason why this can happen is because of time penalty tiles
+		// However, other reasons are hereby also excluded
+		GameServer()->SendChatTarget(m_pPlayer->GetCID(), "You died of old age");
+		Die(m_pPlayer->GetCID(), WEAPON_WORLD);
+	}
+
 	if(m_Paused)
 		return;
 


### PR DESCRIPTION
Also map gets reloaded if the server tick overflows. We could add a warning, that the server reloads soon, or save all players and load them after map reload. But I think that is such a rare event, we can just reload the map without these nice things.

fixes #5170

we should check the following maps for cheated times:
- just every fly
- puzzle partners
- time shop

## Checklist

- [x] Tested the change ingame See https://youtu.be/lQPU60XN8Nk
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
