### PR TITLE
Only show port forward message if there's a problem

### DIFF
--- a/src/engine/server/register.cpp
+++ b/src/engine/server/register.cpp
@@ -401,7 +401,7 @@ void CRegister::CProtocol::CJob::Run()
 	{
 		log_debug(ProtocolToSystem(m_Protocol), "status: %s", (const char *)StatusString);
 	}
-	if(Status == m_pShared->m_LatestResponseStatus)
+	if(Status == m_pShared->m_LatestResponseStatus && Status == STATUS_NEEDCHALLENGE)
 	{
 		log_error(ProtocolToSystem(m_Protocol), "ERROR: the master server reports that clients can not connect to this server.");
 		log_error(ProtocolToSystem(m_Protocol), "ERROR: configure your firewall/nat to let through udp on port %d.", m_ServerPort);


### PR DESCRIPTION
Previously, it was always shown.

Fixes #5203.

## Checklist

- [x] Tested the change ~~ingame~~
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
