### PR TITLE
Work around Windows's definition of `min`/`max`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3013,6 +3013,7 @@ foreach(target ${TARGETS_OWN})
     target_compile_options(${target} PRIVATE /wd4800) # Implicit conversion of int to bool.
   endif()
   if(TARGET_OS STREQUAL "windows")
+    target_compile_definitions(${target} PRIVATE NOMINMAX) # windows.h shouldn't define min/max macros
     target_compile_definitions(${target} PRIVATE UNICODE) # Windows headers
     target_compile_definitions(${target} PRIVATE _UNICODE) # C-runtime
   endif()

--- a/src/base/math.h
+++ b/src/base/math.h
@@ -95,22 +95,22 @@ constexpr float pi = 3.1415926535897932384626433f;
 template<typename T>
 constexpr inline T minimum(T a, T b)
 {
-	return a < b ? a : b;
+	return std::min(a, b);
 }
 template<typename T>
 constexpr inline T minimum(T a, T b, T c)
 {
-	return minimum(minimum(a, b), c);
+	return std::min(std::min(a, b), c);
 }
 template<typename T>
 constexpr inline T maximum(T a, T b)
 {
-	return a > b ? a : b;
+	return std::max(a, b);
 }
 template<typename T>
 constexpr inline T maximum(T a, T b, T c)
 {
-	return maximum(maximum(a, b), c);
+	return std::max(std::max(a, b), c);
 }
 template<typename T>
 constexpr inline T absolute(T a)


### PR DESCRIPTION
This allows us to use `std::min`/`std::max`.

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
