### PR TITLE
Add *.csv and *.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,6 +102,7 @@ tags
 
 *.a
 *.cmd
+*.csv
 *.dll
 *.dmg
 *.dtb
@@ -109,6 +110,7 @@ tags
 *.exe
 *.fifo
 *.filters
+*.json
 *.lnk
 *.log
 *.opensdf


### PR DESCRIPTION
Both file types are used in conjunction with the HTTPS master.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
