### PR TITLE
Don't output as much in normal STUN behavior

### DIFF
--- a/src/engine/shared/network_stun.cpp
+++ b/src/engine/shared/network_stun.cpp
@@ -73,7 +73,7 @@ void CStun::CProtocol::Update()
 	int Size = StunMessagePrepare(aBuf, sizeof(aBuf), &m_Stun);
 	if(net_udp_send(m_Socket, &m_StunServer, aBuf, Size) == -1)
 	{
-		log_error(IndexToSystem(m_Index), "couldn't send stun request");
+		log_debug(IndexToSystem(m_Index), "couldn't send stun request");
 		return;
 	}
 }

--- a/src/engine/shared/network_stun.cpp
+++ b/src/engine/shared/network_stun.cpp
@@ -90,16 +90,14 @@ bool CStun::CProtocol::OnPacket(NETADDR Addr, unsigned char *pData, int DataSize
 	{
 		return false;
 	}
-	int64_t Now = time_get();
-	int64_t Freq = time_freq();
-	m_LastResponse = Now;
+	m_LastResponse = time_get();
 	if(!Success)
 	{
 		m_HaveAddr = false;
 		log_debug(IndexToSystem(m_Index), "got error response");
 		return true;
 	}
-	m_NextTry = Now + 600 * Freq;
+	m_NextTry = -1;
 	m_NumUnsuccessfulTries = -1;
 	m_HaveAddr = true;
 	m_Addr = StunAddr;


### PR DESCRIPTION
Log send errors with debug instead of error severity. They're normal in case a protocol stack isn't initialized supported by the host or if there's no route.

Don't periodically retry STUN if successful. Trying again for each connection establishment is enough. Previously, it
was re-requested every 10 minutes.

Fixes #5273.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
