### PR TITLE
Windows: Use current console background color, restore original color on exit, refactoring

### DIFF
--- a/src/base/log.cpp
+++ b/src/base/log.cpp
@@ -281,26 +281,26 @@ static int color_hsv_to_windows_console_color(const ColorHSVA &Hsv)
 			return FOREGROUND_INTENSITY;
 		return FOREGROUND_BLUE | FOREGROUND_GREEN | FOREGROUND_RED | FOREGROUND_INTENSITY;
 	}
-	else if(h >= 0 && h < 15)
-		return FOREGROUND_RED | FOREGROUND_INTENSITY;
-	else if(h >= 15 && h < 30)
-		return FOREGROUND_GREEN | FOREGROUND_RED;
-	else if(h >= 30 && h < 60)
-		return FOREGROUND_GREEN | FOREGROUND_RED | FOREGROUND_INTENSITY;
-	else if(h >= 60 && h < 110)
-		return FOREGROUND_GREEN | FOREGROUND_INTENSITY;
-	else if(h >= 110 && h < 140)
-		return FOREGROUND_BLUE | FOREGROUND_GREEN | FOREGROUND_INTENSITY;
-	else if(h >= 140 && h < 170)
-		return FOREGROUND_BLUE | FOREGROUND_INTENSITY;
-	else if(h >= 170 && h < 195)
-		return FOREGROUND_BLUE | FOREGROUND_RED;
-	else if(h >= 195 && h < 240)
-		return FOREGROUND_BLUE | FOREGROUND_RED | FOREGROUND_INTENSITY;
-	else if(h >= 240)
-		return FOREGROUND_RED | FOREGROUND_INTENSITY;
-	else
+	if(h < 0)
 		return FOREGROUND_BLUE | FOREGROUND_GREEN | FOREGROUND_RED | FOREGROUND_INTENSITY;
+	else if(h < 15)
+		return FOREGROUND_RED | FOREGROUND_INTENSITY;
+	else if(h < 30)
+		return FOREGROUND_GREEN | FOREGROUND_RED;
+	else if(h < 60)
+		return FOREGROUND_GREEN | FOREGROUND_RED | FOREGROUND_INTENSITY;
+	else if(h < 110)
+		return FOREGROUND_GREEN | FOREGROUND_INTENSITY;
+	else if(h < 140)
+		return FOREGROUND_BLUE | FOREGROUND_GREEN | FOREGROUND_INTENSITY;
+	else if(h < 170)
+		return FOREGROUND_BLUE | FOREGROUND_INTENSITY;
+	else if(h < 195)
+		return FOREGROUND_BLUE | FOREGROUND_RED;
+	else if(h < 240)
+		return FOREGROUND_BLUE | FOREGROUND_RED | FOREGROUND_INTENSITY;
+	else
+		return FOREGROUND_RED | FOREGROUND_INTENSITY;
 }
 
 class CWindowsConsoleLogger : public ILogger

--- a/src/base/log.cpp
+++ b/src/base/log.cpp
@@ -278,29 +278,29 @@ static int color_hsv_to_windows_console_color(const ColorHSVA &Hsv)
 	if(s >= 0 && s <= 10)
 	{
 		if(v <= 150)
-			return 8;
-		return 15;
+			return FOREGROUND_INTENSITY;
+		return FOREGROUND_BLUE | FOREGROUND_GREEN | FOREGROUND_RED | FOREGROUND_INTENSITY;
 	}
 	else if(h >= 0 && h < 15)
-		return 12;
+		return FOREGROUND_RED | FOREGROUND_INTENSITY;
 	else if(h >= 15 && h < 30)
-		return 6;
+		return FOREGROUND_GREEN | FOREGROUND_RED;
 	else if(h >= 30 && h < 60)
-		return 14;
+		return FOREGROUND_GREEN | FOREGROUND_RED | FOREGROUND_INTENSITY;
 	else if(h >= 60 && h < 110)
-		return 10;
+		return FOREGROUND_GREEN | FOREGROUND_INTENSITY;
 	else if(h >= 110 && h < 140)
-		return 11;
+		return FOREGROUND_BLUE | FOREGROUND_GREEN | FOREGROUND_INTENSITY;
 	else if(h >= 140 && h < 170)
-		return 9;
+		return FOREGROUND_BLUE | FOREGROUND_INTENSITY;
 	else if(h >= 170 && h < 195)
-		return 5;
+		return FOREGROUND_BLUE | FOREGROUND_RED;
 	else if(h >= 195 && h < 240)
-		return 13;
+		return FOREGROUND_BLUE | FOREGROUND_RED | FOREGROUND_INTENSITY;
 	else if(h >= 240)
-		return 12;
+		return FOREGROUND_RED | FOREGROUND_INTENSITY;
 	else
-		return 15;
+		return FOREGROUND_BLUE | FOREGROUND_GREEN | FOREGROUND_RED | FOREGROUND_INTENSITY;
 }
 
 class CWindowsConsoleLogger : public ILogger
@@ -340,7 +340,7 @@ public:
 		}
 		pWide[WLen++] = '\r';
 		pWide[WLen++] = '\n';
-		int Color = 15;
+		int Color = FOREGROUND_BLUE | FOREGROUND_GREEN | FOREGROUND_RED | FOREGROUND_INTENSITY;
 		if(pMessage->m_HaveColor)
 		{
 			ColorRGBA Rgba(1.0, 1.0, 1.0, 1.0);


### PR DESCRIPTION
- Remember initial console foreground and background color.
- Use the original background color with the message specific foreground color, so it looks better when the console background color isn't black.
- Restore the initial console foreground and background color on exit instead of leaving the color be whatever was last used.
- Add locks to ensure `Log`-calls from different threads don't overlap their output/color.
- Refactoring: Replace numbers with color constants defined in `wincon.h` (https://github.com/wine-mirror/wine/blob/4312d209232c701b0b78d9f8b463917c989005c5/include/wincon.h#L51-L67).
- Refactoring: Slightly reorder the `if`s and remove redundant checks which are ensured by the `else-if` structure.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
