### PR TITLE
Fix integration test waiting for client to close

### DIFF
--- a/scripts/integration_test.sh
+++ b/scripts/integration_test.sh
@@ -170,6 +170,7 @@ $tool ./DDNet \
 	"cl_input_fifo client1.fifo;
 	player_name client1;
 	cl_download_skins 0;
+	gfx_fullscreen 0;
 	$client_args
 	connect localhost:$port" &> client1.log || fail client1 "$?" &
 
@@ -183,6 +184,7 @@ $tool ./DDNet \
 	"cl_input_fifo client2.fifo;
 	player_name client2;
 	cl_download_skins 0;
+	gfx_fullscreen 0;
 	$client_args
 	connect localhost:$port" &> client2.log || fail client2 "$?" &
 


### PR DESCRIPTION
As described in #5295, the integration test script waits for the client
to close before launching the next one. I don't know what causes this,
but disabling full-screen mode works around the issue.

I don't know if this is okay. @ChillerDragon?

Fixes #5295.

## Checklist

- [x] Tested the change ~~ingame~~
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
