### PR TITLE
Init all class members

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -337,6 +337,7 @@ if(NOT MSVC AND NOT HAIKU)
   add_cxx_compiler_flag_if_supported(OUR_FLAGS_OWN -Wformat=2) # Warn about format strings.
   add_c_compiler_flag_if_supported(OUR_FLAGS_DEP -Wno-implicit-function-declaration)
   add_cxx_compiler_flag_if_supported(OUR_FLAGS_OWN -Wno-nullability-completeness) # Mac OS build on github
+  add_cxx_compiler_flag_if_supported(OUR_FLAGS_OWN -Wclass-memaccess)
   add_cxx_compiler_flag_if_supported(OUR_FLAGS_OWN -Wduplicated-cond)
   add_cxx_compiler_flag_if_supported(OUR_FLAGS_OWN -Wduplicated-branches)
   add_cxx_compiler_flag_if_supported(OUR_FLAGS_OWN -Wlogical-op)

--- a/datasrc/compile.py
+++ b/datasrc/compile.py
@@ -85,11 +85,11 @@ def gen_network_header():
 	print("""
 class CNetObjHandler
 {
-	const char *m_pMsgFailedOn;
-	const char *m_pObjFailedOn;
-	const char *m_pObjCorrectedOn;
-	char m_aUnpackedData[1024 * 2];
-	int m_NumObjCorrections;
+	const char *m_pMsgFailedOn = nullptr;
+	const char *m_pObjFailedOn = nullptr;
+	const char *m_pObjCorrectedOn = nullptr;
+	char m_aUnpackedData[1024 * 2] = {0};
+	int m_NumObjCorrections = 0;
 	int ClampInt(const char *pErrorMsg, int Value, int Min, int Max);
 
 	static const char *ms_apObjNames[];
@@ -274,10 +274,10 @@ void *CNetObjHandler::SecureUnpackObj(int Type, CUnpacker *pUnpacker)
 		m_pObjFailedOn = "(type out of range)";
 		break;
 	}
-	
+
 	if(pUnpacker->Error())
 		m_pObjFailedOn = "(unpack error)";
-	
+
 	if(m_pObjFailedOn)
 		return 0;
 	m_pObjFailedOn = "";
@@ -307,10 +307,10 @@ void *CNetObjHandler::SecureUnpackMsg(int Type, CUnpacker *pUnpacker)
 		m_pMsgFailedOn = "(type out of range)";
 		break;
 	}
-	
+
 	if(pUnpacker->Error())
 		m_pMsgFailedOn = "(unpack error)";
-	
+
 	if(m_pMsgFailedOn)
 		return 0;
 	m_pMsgFailedOn = "";

--- a/datasrc/datatypes.py
+++ b/datasrc/datatypes.py
@@ -101,8 +101,8 @@ class Array(BaseType):
 			raise "bah"
 		self.items += [instance]
 	def EmitDeclaration(self, name):
-		return ["int m_Num%s;"%(FixCasing(name)),
-			"%s *%s;"%(self.TypeName(), FormatName("[]", name))]
+		return ["int m_Num%s = 0;"%(FixCasing(name)),
+			"%s *%s = nullptr;"%(self.TypeName(), FormatName("[]", name))]
 	def EmitPreDefinition(self, target_name):
 		BaseType.EmitPreDefinition(self, target_name)
 
@@ -119,7 +119,7 @@ class Array(BaseType):
 				lines += ["\t" + " ".join(itemlines).replace("\t", " ") + ","]
 			lines += ["};"]
 		else:
-			lines += ["static %s *%s = 0;"%(self.TypeName(), self.Identifyer())]
+			lines += ["static %s *%s = nullptr;"%(self.TypeName(), self.Identifyer())]
 
 		return lines
 	def EmitDefinition(self, _name):
@@ -133,6 +133,8 @@ class Int(BaseType):
 		self.value = value
 	def Set(self, value):
 		self.value = value
+	def EmitDeclaration(self, name):
+		return ["%s %s = 0;"%(self.TypeName(), FormatName(self.TypeName(), name))]
 	def EmitDefinition(self, _name):
 		return ["%d"%self.value]
 		#return ["%d /* %s */"%(self.value, self._target_name)]
@@ -143,6 +145,8 @@ class Float(BaseType):
 		self.value = value
 	def Set(self, value):
 		self.value = value
+	def EmitDeclaration(self, name):
+		return ["%s %s = 0;"%(self.TypeName(), FormatName(self.TypeName(), name))]
 	def EmitDefinition(self, _name):
 		return ["%ff"%self.value]
 		#return ["%d /* %s */"%(self.value, self._target_name)]
@@ -153,6 +157,8 @@ class String(BaseType):
 		self.value = value
 	def Set(self, value):
 		self.value = value
+	def EmitDeclaration(self, name):
+		return ["%s %s = nullptr;"%(self.TypeName(), FormatName(self.TypeName(), name))]
 	def EmitDefinition(self, _name):
 		return ['"'+self.value+'"']
 
@@ -162,6 +168,8 @@ class Pointer(BaseType):
 		self.target = target
 	def Set(self, target):
 		self.target = target
+	def EmitDeclaration(self, name):
+		return ["%s %s = nullptr;"%(self.TypeName(), FormatName(self.TypeName(), name))]
 	def EmitDefinition(self, _name):
 		return ["&"+self.target.TargetName()]
 
@@ -317,7 +325,7 @@ class NetVariable:
 	def __init__(self, name, default=None):
 		self.name = name
 		self.default = None if default is None else str(default)
-	def emit_declaration(self):
+	def emit_declaration(self, _array=0):
 		return []
 	def emit_validate_obj(self):
 		return []
@@ -331,8 +339,8 @@ class NetVariable:
 		return []
 
 class NetString(NetVariable):
-	def emit_declaration(self):
-		return ["const char *%s;"%self.name]
+	def emit_declaration(self, array=0):
+		return ["const char *%s = "%self.name + "{"*array + "nullptr" + "}"*array + ";"]
 	def emit_uncompressed_unpack_obj(self):
 		return self.emit_unpack_msg()
 	def emit_unpack_msg(self):
@@ -341,8 +349,8 @@ class NetString(NetVariable):
 		return ["pPacker->AddString(%s, -1);" % self.name]
 
 class NetStringHalfStrict(NetVariable):
-	def emit_declaration(self):
-		return ["const char *%s;"%self.name]
+	def emit_declaration(self, array=0):
+		return ["const char *%s = "%self.name + "{"*array + "nullptr" + "}"*array + ";"]
 	def emit_uncompressed_unpack_obj(self):
 		return self.emit_unpack_msg()
 	def emit_unpack_msg(self):
@@ -351,8 +359,8 @@ class NetStringHalfStrict(NetVariable):
 		return ["pPacker->AddString(%s, -1);" % self.name]
 
 class NetStringStrict(NetVariable):
-	def emit_declaration(self):
-		return ["const char *%s;"%self.name]
+	def emit_declaration(self, array=0):
+		return ["const char *%s = "%self.name + "{"*array + "nullptr" + "}"*array + ";"]
 	def emit_uncompressed_unpack_obj(self):
 		return self.emit_unpack_msg()
 	def emit_unpack_msg(self):
@@ -361,8 +369,8 @@ class NetStringStrict(NetVariable):
 		return ["pPacker->AddString(%s, -1);" % self.name]
 
 class NetIntAny(NetVariable):
-	def emit_declaration(self):
-		return ["int %s;"%self.name]
+	def emit_declaration(self, array=0):
+		return ["int %s = "%self.name + "{"*array + "0" + "}"*array + ";"]
 	def emit_uncompressed_unpack_obj(self):
 		if self.default is None:
 			return ["pData->%s = pUnpacker->GetUncompressedInt();" % self.name]
@@ -400,9 +408,9 @@ class NetArray(NetVariable):
 		self.var = var
 		self.size = size
 		self.name = self.base_name + "[%d]"%self.size
-	def emit_declaration(self):
+	def emit_declaration(self, array=0):
 		self.var.name = self.name
-		return self.var.emit_declaration()
+		return self.var.emit_declaration(array+1)
 	def emit_uncompressed_unpack_obj(self):
 		lines = []
 		for i in range(self.size):

--- a/datasrc/datatypes.py
+++ b/datasrc/datatypes.py
@@ -195,9 +195,6 @@ def EmitDefinition(root, name):
 
 # Network stuff after this
 
-class Object:
-	pass
-
 class Enum:
 	def __init__(self, name, values):
 		self.name = name

--- a/datasrc/seven/compile.py
+++ b/datasrc/seven/compile.py
@@ -145,10 +145,10 @@ def main():
 
 	class CNetObjHandler
 	{
-		const char *m_pMsgFailedOn;
-		char m_aMsgData[1024];
-		const char *m_pObjFailedOn;
-		int m_NumObjFailures;
+		const char *m_pMsgFailedOn = nullptr;
+		char m_aMsgData[1024] = {0};
+		const char *m_pObjFailedOn = nullptr;
+		int m_NumObjFailures = 0;
 		bool CheckInt(const char *pErrorMsg, int Value, int Min, int Max);
 		bool CheckFlag(const char *pErrorMsg, int Value, int Mask);
 

--- a/src/a.cpp
+++ b/src/a.cpp
@@ -1,0 +1,35 @@
+#include <iostream>
+
+int main(int argc, char** argv)
+{
+    int m_aTest[512];
+    decltype(m_aTest) a;
+    int *retest[512];
+    decltype(retest) b;
+    int m_aaTest[10][20];
+    decltype(m_aaTest) c;
+    int *m_aapTest[10][20];
+    decltype(m_aapTest) d;
+
+    std::cout << typeid(decltype(m_aTest)).name() << std::endl;
+    std::cout << sizeof(a) << std::endl;
+    std::cout << typeid(std::remove_pointer<decltype(m_aTest)>::type).name() << std::endl << std::endl;
+
+    std::cout << typeid(decltype(retest)).name() << std::endl;
+    std::cout << sizeof(b) << std::endl;
+    std::cout << typeid(std::remove_pointer<decltype(retest)>::type).name() << std::endl << std::endl;
+
+    std::cout << typeid(decltype(m_aaTest)).name() << std::endl;
+    std::cout << sizeof(c) << std::endl;
+    std::cout << typeid(std::remove_pointer<decltype(m_aaTest)>::type).name() << std::endl << std::endl;
+
+    std::cout << typeid(decltype(m_aapTest)).name() << std::endl;
+    std::cout << sizeof(d) << std::endl;
+    std::cout << typeid(std::remove_pointer<decltype(m_aapTest)>::type).name() << std::endl << std::endl;
+
+    std::cout << &m_aTest << std::endl << m_aTest << std::endl;
+    std::cout << typeid(decltype(&m_aTest)).name() << std::endl;
+    std::cout << sizeof(int) << std::endl;
+
+    return 0;
+}

--- a/src/antibot/antibot_data.h
+++ b/src/antibot/antibot_data.h
@@ -16,15 +16,15 @@ enum
 
 struct CAntibotMapData
 {
-	int m_Width;
-	int m_Height;
-	unsigned char *m_pTiles;
+	int m_Width = 0;
+	int m_Height = 0;
+	unsigned char *m_pTiles = nullptr;
 };
 
 struct CAntibotInputData
 {
-	int m_TargetX;
-	int m_TargetY;
+	int m_TargetX = 0;
+	int m_TargetY = 0;
 };
 
 // Defined by the network protocol, unlikely to change.
@@ -37,31 +37,31 @@ struct CAntibotInputData
 
 struct CAntibotCharacterData
 {
-	char m_aName[16];
+	char m_aName[16] = {0};
 	CAntibotInputData m_aLatestInputs[3];
 
-	bool m_Alive;
-	bool m_Pause;
-	int m_Team;
+	bool m_Alive = false;
+	bool m_Pause = false;
+	int m_Team = 0;
 
 	vec2 m_Pos;
 	vec2 m_Vel;
-	int m_Angle;
-	int m_HookedPlayer;
-	int m_SpawnTick;
-	int m_WeaponChangeTick;
+	int m_Angle = 0;
+	int m_HookedPlayer = 0;
+	int m_SpawnTick = 0;
+	int m_WeaponChangeTick = 0;
 };
 
 struct CAntibotVersion
 {
-	int m_AbiVersion;
-	int m_Size;
+	int m_AbiVersion = 0;
+	int m_Size = 0;
 
-	int m_SizeData;
-	int m_SizeCharacterData;
-	int m_SizeInputData;
-	int m_SizeMapData;
-	int m_SizeRoundData;
+	int m_SizeData = 0;
+	int m_SizeCharacterData = 0;
+	int m_SizeInputData = 0;
+	int m_SizeMapData = 0;
+	int m_SizeRoundData = 0;
 };
 
 #define ANTIBOT_VERSION \
@@ -79,16 +79,16 @@ struct CAntibotData
 {
 	CAntibotVersion m_Version;
 
-	int64_t m_Now;
-	int64_t m_Freq;
+	int64_t m_Now = 0;
+	int64_t m_Freq = 0;
 	void (*m_pfnLog)(const char *pMessage, void *pUser);
 	void (*m_pfnReport)(int ClientID, const char *pMessage, void *pUser);
 	void (*m_pfnSend)(int ClientID, const void *pData, int DataSize, int Flags, void *pUser);
-	void *m_pUser;
+	void *m_pUser = nullptr;
 };
 struct CAntibotRoundData
 {
-	int m_Tick;
+	int m_Tick = 0;
 	CAntibotCharacterData m_aCharacters[ANTIBOT_MAX_CLIENTS];
 	CAntibotMapData m_Map;
 };

--- a/src/base/hash.h
+++ b/src/base/hash.h
@@ -13,12 +13,12 @@ enum
 
 struct SHA256_DIGEST
 {
-	unsigned char data[SHA256_DIGEST_LENGTH];
+	unsigned char data[SHA256_DIGEST_LENGTH] = {0};
 };
 
 struct MD5_DIGEST
 {
-	unsigned char data[MD5_DIGEST_LENGTH];
+	unsigned char data[MD5_DIGEST_LENGTH] = {0};
 };
 
 SHA256_DIGEST sha256(const void *message, size_t message_len);

--- a/src/base/hash_ctxt.h
+++ b/src/base/hash_ctxt.h
@@ -17,10 +17,10 @@
 #else
 struct SHA256_CTX
 {
-	uint64_t length;
-	uint32_t state[8];
-	uint32_t curlen;
-	unsigned char buf[64];
+	uint64_t length = 0;
+	uint32_t state[8] = {0};
+	uint32_t curlen = 0;
+	unsigned char buf[64] = {0};
 };
 typedef md5_state_t MD5_CTX;
 #endif

--- a/src/base/log.cpp
+++ b/src/base/log.cpp
@@ -217,9 +217,9 @@ std::unique_ptr<ILogger> log_logger_collection(std::vector<std::shared_ptr<ILogg
 
 class CLoggerAsync : public ILogger
 {
-	ASYNCIO *m_pAio;
-	bool m_AnsiTruecolor;
-	bool m_Close;
+	ASYNCIO *m_pAio = nullptr;
+	bool m_AnsiTruecolor = false;
+	bool m_Close = false;
 
 public:
 	CLoggerAsync(IOHANDLE File, bool AnsiTruecolor, bool Close) :
@@ -314,9 +314,9 @@ static int color_hsv_to_windows_console_color(const ColorHSVA &Hsv)
 
 class CWindowsConsoleLogger : public ILogger
 {
-	HANDLE m_pConsole;
-	int m_BackgroundColor;
-	int m_ForegroundColor;
+	HANDLE m_pConsole = nullptr;
+	int m_BackgroundColor = 0;
+	int m_ForegroundColor = 0;
 	std::mutex m_OutputLock;
 	bool m_Finished = false;
 
@@ -389,7 +389,7 @@ public:
 };
 class CWindowsFileLogger : public ILogger
 {
-	HANDLE m_pFile;
+	HANDLE m_pFile = nullptr;
 	std::mutex m_OutputLock;
 
 public:

--- a/src/base/log.h
+++ b/src/base/log.h
@@ -25,9 +25,9 @@ enum LEVEL : char
 
 struct LOG_COLOR
 {
-	uint8_t r;
-	uint8_t g;
-	uint8_t b;
+	uint8_t r = 0;
+	uint8_t g = 0;
+	uint8_t b = 0;
 };
 
 #define log_error(sys, ...) log_log(LEVEL_ERROR, sys, __VA_ARGS__)

--- a/src/base/logger.h
+++ b/src/base/logger.h
@@ -23,25 +23,25 @@ public:
 	 * Severity
 	 */
 	LEVEL m_Level;
-	bool m_HaveColor;
+	bool m_HaveColor = false;
 	/**
 	 * The requested color of the log message. Only useful if `m_HaveColor`
 	 * is set.
 	 */
 	LOG_COLOR m_Color;
-	char m_aTimestamp[80];
-	char m_aSystem[32];
+	char m_aTimestamp[80] = {0};
+	char m_aSystem[32] = {0};
 	/**
 	 * The actual log message including the timestamp and the system.
 	 */
-	char m_aLine[4096];
-	int m_TimestampLength;
-	int m_SystemLength;
+	char m_aLine[4096] = {0};
+	int m_TimestampLength = 0;
+	int m_SystemLength = 0;
 	/**
 	 * Length of the log message including timestamp and the system.
 	 */
-	int m_LineLength;
-	int m_LineMessageOffset;
+	int m_LineLength = 0;
+	int m_LineMessageOffset = 0;
 
 	/**
 	 * The actual log message excluding timestamp and the system.
@@ -205,7 +205,7 @@ std::unique_ptr<ILogger> log_logger_windows_debugger();
 class CFutureLogger : public ILogger
 {
 private:
-	std::atomic<ILogger *> m_pLogger;
+	std::atomic<ILogger *> m_pLogger = nullptr;
 	std::vector<CLogMessage> m_vPending;
 	std::mutex m_PendingLock;
 
@@ -228,8 +228,8 @@ public:
  */
 class CLogScope
 {
-	ILogger *old_scope_logger;
-	ILogger *new_scope_logger;
+	ILogger *old_scope_logger = nullptr;
+	ILogger *new_scope_logger = nullptr;
 
 public:
 	CLogScope(ILogger *logger) :

--- a/src/base/math.h
+++ b/src/base/math.h
@@ -59,7 +59,7 @@ constexpr inline int fx2i(int v)
 
 class fxp
 {
-	int value;
+	int value = 0;
 
 public:
 	void set(int v)

--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -198,20 +198,21 @@ void dbg_msg(const char *sys, const char *fmt, ...)
 
 /* */
 
-void mem_copy(void *dest, const void *source, unsigned size)
-{
-	memcpy(dest, source, size);
-}
+//void mem_copy(void *dest, const void *source, unsigned size)
+//{
+//	memcpy(dest, source, size);
+//}
 
-void mem_move(void *dest, const void *source, unsigned size)
-{
-	memmove(dest, source, size);
-}
+//void mem_move(void *dest, const void *source, unsigned size)
+//{
+//	memmove(dest, source, size);
+//}
 
-void mem_zero(void *block, unsigned size)
-{
-	memset(block, 0, size);
-}
+//template<>
+//void mem_zero<void>(void *block, unsigned size)
+//{
+//	memset(block, 0, size);
+//}
 
 IOHANDLE io_open_impl(const char *filename, int flags)
 {
@@ -3295,10 +3296,10 @@ void str_escape(char **dst, const char *src, const char *end)
 	**dst = 0;
 }
 
-int mem_comp(const void *a, const void *b, int size)
-{
-	return memcmp(a, b, size);
-}
+//int mem_comp(const void *a, const void *b, int size)
+//{
+//	return memcmp(a, b, size);
+//}
 
 int mem_has_null(const void *block, unsigned size)
 {
@@ -4180,4 +4181,18 @@ int net_socket_read_wait(NETSOCKET sock, std::chrono::nanoseconds nanoseconds)
 size_t std::hash<NETADDR>::operator()(const NETADDR &Addr) const noexcept
 {
 	return std::hash<std::string_view>{}(std::string_view((const char *)&Addr, sizeof(Addr)));
+}
+
+int mem_is_null(const void* block, size_t size)
+{
+	const unsigned char *bytes = (const unsigned char *)block;
+	size_t i;
+	for(i = 0; i < size; i++)
+	{
+		if(bytes[i] != 0)
+		{
+			return 0;
+		}
+	}
+	return 1;
 }

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -2490,8 +2490,8 @@ int net_socket_read_wait(NETSOCKET sock, std::chrono::nanoseconds nanoseconds);
  */
 class CCmdlineFix
 {
-	int m_Argc;
-	const char **m_ppArgv;
+	int m_Argc = 0;
+	const char **m_ppArgv = nullptr;
 
 public:
 	CCmdlineFix(int *pArgc, const char ***pppArgv)

--- a/src/base/unicode/tolower.h
+++ b/src/base/unicode/tolower.h
@@ -2,8 +2,8 @@
 
 struct UPPER_LOWER
 {
-	int32_t upper;
-	int32_t lower;
+	int32_t upper = 0;
+	int32_t lower = 0;
 };
 
 enum

--- a/src/engine/client.h
+++ b/src/engine/client.h
@@ -69,41 +69,41 @@ public:
 
 protected:
 	// quick access to state of the client
-	EClientState m_State;
-	ELoadingStateDetail m_LoadingStateDetail;
-	int64_t m_StateStartTime;
+	EClientState m_State = STATE_OFFLINE;
+	ELoadingStateDetail m_LoadingStateDetail = LOADING_STATE_DETAIL_INITIAL;
+	int64_t m_StateStartTime = 0;
 
 	// quick access to time variables
-	int m_aPrevGameTick[NUM_DUMMIES];
-	int m_aCurGameTick[NUM_DUMMIES];
-	float m_aGameIntraTick[NUM_DUMMIES];
-	float m_aGameTickTime[NUM_DUMMIES];
-	float m_aGameIntraTickSincePrev[NUM_DUMMIES];
+	int m_aPrevGameTick[NUM_DUMMIES] = {0};
+	int m_aCurGameTick[NUM_DUMMIES] = {0};
+	float m_aGameIntraTick[NUM_DUMMIES] = {0};
+	float m_aGameTickTime[NUM_DUMMIES] = {0};
+	float m_aGameIntraTickSincePrev[NUM_DUMMIES] = {0};
 
-	int m_aPredTick[NUM_DUMMIES];
-	float m_aPredIntraTick[NUM_DUMMIES];
+	int m_aPredTick[NUM_DUMMIES] = {0};
+	float m_aPredIntraTick[NUM_DUMMIES] = {0};
 
-	float m_LocalTime;
-	float m_RenderFrameTime;
+	float m_LocalTime = 0;
+	float m_RenderFrameTime = 0;
 
-	int m_GameTickSpeed;
+	int m_GameTickSpeed = 0;
 
-	float m_FrameTimeAvg;
+	float m_FrameTimeAvg = 0;
 
 	TMapLoadingCallbackFunc m_MapLoadingCBFunc;
 
 public:
-	char m_aNews[3000];
-	char m_aMapDownloadUrl[256];
-	int m_Points;
-	int64_t m_ReconnectTime;
+	char m_aNews[3000] = {0};
+	char m_aMapDownloadUrl[256] = {0};
+	int m_Points = 0;
+	int64_t m_ReconnectTime = 0;
 
 	class CSnapItem
 	{
 	public:
-		int m_Type;
-		int m_ID;
-		int m_DataSize;
+		int m_Type = 0;
+		int m_ID = 0;
+		int m_DataSize = 0;
 	};
 
 	enum

--- a/src/engine/client/backend/backend_base.h
+++ b/src/engine/client/backend/backend_base.h
@@ -53,15 +53,15 @@ public:
 		SCommand_PreInit() :
 			SCommand(CMD_PRE_INIT) {}
 
-		SDL_Window *m_pWindow;
-		uint32_t m_Width;
-		uint32_t m_Height;
+		SDL_Window *m_pWindow = nullptr;
+		uint32_t m_Width = 0;
+		uint32_t m_Height = 0;
 
-		char *m_pVendorString;
-		char *m_pVersionString;
-		char *m_pRendererString;
+		char *m_pVendorString = nullptr;
+		char *m_pVersionString = nullptr;
+		char *m_pRendererString = nullptr;
 
-		TTWGraphicsGPUList *m_pGPUList;
+		TTWGraphicsGPUList *m_pGPUList = nullptr;
 	};
 
 	struct SCommand_Init : public CCommandBuffer::SCommand
@@ -69,38 +69,38 @@ public:
 		SCommand_Init() :
 			SCommand(CMD_INIT) {}
 
-		SDL_Window *m_pWindow;
-		uint32_t m_Width;
-		uint32_t m_Height;
+		SDL_Window *m_pWindow = nullptr;
+		uint32_t m_Width = 0;
+		uint32_t m_Height = 0;
 
-		class IStorage *m_pStorage;
-		std::atomic<uint64_t> *m_pTextureMemoryUsage;
-		std::atomic<uint64_t> *m_pBufferMemoryUsage;
-		std::atomic<uint64_t> *m_pStreamMemoryUsage;
-		std::atomic<uint64_t> *m_pStagingMemoryUsage;
+		class IStorage *m_pStorage = nullptr;
+		std::atomic<uint64_t> *m_pTextureMemoryUsage = nullptr;
+		std::atomic<uint64_t> *m_pBufferMemoryUsage = nullptr;
+		std::atomic<uint64_t> *m_pStreamMemoryUsage = nullptr;
+		std::atomic<uint64_t> *m_pStagingMemoryUsage = nullptr;
 
-		TTWGraphicsGPUList *m_pGPUList;
+		TTWGraphicsGPUList *m_pGPUList = nullptr;
 
-		TGLBackendReadPresentedImageData *m_pReadPresentedImageDataFunc;
+		TGLBackendReadPresentedImageData *m_pReadPresentedImageDataFunc = nullptr;
 
-		SBackendCapabilites *m_pCapabilities;
-		int *m_pInitError;
+		SBackendCapabilites *m_pCapabilities = nullptr;
+		int *m_pInitError = nullptr;
 
-		const char **m_pErrStringPtr;
+		const char **m_pErrStringPtr = nullptr;
 
-		char *m_pVendorString;
-		char *m_pVersionString;
-		char *m_pRendererString;
+		char *m_pVendorString = nullptr;
+		char *m_pVersionString = nullptr;
+		char *m_pRendererString = nullptr;
 
-		int m_RequestedMajor;
-		int m_RequestedMinor;
-		int m_RequestedPatch;
+		int m_RequestedMajor = 0;
+		int m_RequestedMinor = 0;
+		int m_RequestedPatch = 0;
 
-		EBackendType m_RequestedBackend;
+		EBackendType m_RequestedBackend = BACKEND_TYPE_OPENGL;
 
-		int m_GlewMajor;
-		int m_GlewMinor;
-		int m_GlewPatch;
+		int m_GlewMajor = 0;
+		int m_GlewMinor = 0;
+		int m_GlewPatch = 0;
 	};
 
 	struct SCommand_Shutdown : public CCommandBuffer::SCommand

--- a/src/engine/client/backend/glsl_shader_compiler.h
+++ b/src/engine/client/backend/glsl_shader_compiler.h
@@ -28,16 +28,16 @@ private:
 
 	std::vector<SGLSLCompilerDefine> m_vDefines;
 
-	int m_OpenGLVersionMajor;
-	int m_OpenGLVersionMinor;
-	int m_OpenGLVersionPatch;
+	int m_OpenGLVersionMajor = 0;
+	int m_OpenGLVersionMinor = 0;
+	int m_OpenGLVersionPatch = 0;
 
-	bool m_IsOpenGLES;
+	bool m_IsOpenGLES = false;
 
-	float m_TextureLODBias;
+	float m_TextureLODBias = 0;
 
-	bool m_HasTextureArray;
-	int m_TextureReplaceType; // @see EGLSLCompilerTextureReplaceType
+	bool m_HasTextureArray = false;
+	int m_TextureReplaceType = 0; // @see EGLSLCompilerTextureReplaceType
 public:
 	CGLSLCompiler(int OpenGLVersionMajor, int OpenGLVersionMinor, int OpenGLVersionPatch, bool IsOpenGLES, float TextureLODBias);
 	void SetHasTextureArray(bool TextureArray) { m_HasTextureArray = TextureArray; }

--- a/src/engine/client/backend/opengl/backend_opengl.h
+++ b/src/engine/client/backend/opengl/backend_opengl.h
@@ -35,42 +35,42 @@ protected:
 		{
 		}
 
-		TWGLuint m_Tex;
-		TWGLuint m_Tex2DArray; // or 3D texture as fallback
-		TWGLuint m_Sampler;
-		TWGLuint m_Sampler2DArray; // or 3D texture as fallback
-		int m_LastWrapMode;
+		TWGLuint m_Tex = 0;
+		TWGLuint m_Tex2DArray = 0; // or 3D texture as fallback
+		TWGLuint m_Sampler = 0;
+		TWGLuint m_Sampler2DArray = 0; // or 3D texture as fallback
+		int m_LastWrapMode = 0;
 
-		int m_MemSize;
+		int m_MemSize = 0;
 
-		int m_Width;
-		int m_Height;
-		int m_RescaleCount;
-		float m_ResizeWidth;
-		float m_ResizeHeight;
+		int m_Width = 0;
+		int m_Height = 0;
+		int m_RescaleCount = 0;
+		float m_ResizeWidth = 0;
+		float m_ResizeHeight = 0;
 	};
 	std::vector<CTexture> m_vTextures;
-	std::atomic<uint64_t> *m_pTextureMemoryUsage;
+	std::atomic<uint64_t> *m_pTextureMemoryUsage = nullptr;
 
 	uint32_t m_CanvasWidth = 0;
 	uint32_t m_CanvasHeight = 0;
 
-	TWGLint m_MaxTexSize;
+	TWGLint m_MaxTexSize = 0;
 
-	bool m_Has2DArrayTextures;
-	bool m_Has2DArrayTexturesAsExtension;
-	TWGLenum m_2DArrayTarget;
-	bool m_Has3DTextures;
-	bool m_HasMipMaps;
-	bool m_HasNPOTTextures;
+	bool m_Has2DArrayTextures = false;
+	bool m_Has2DArrayTexturesAsExtension = false;
+	TWGLenum m_2DArrayTarget = 0;
+	bool m_Has3DTextures = false;
+	bool m_HasMipMaps = false;
+	bool m_HasNPOTTextures = false;
 
-	bool m_HasShaders;
-	int m_LastBlendMode; // avoid all possible opengl state changes
-	bool m_LastClipEnable;
+	bool m_HasShaders = false;
+	int m_LastBlendMode = 0; // avoid all possible opengl state changes
+	bool m_LastClipEnable = false;
 
-	int m_OpenGLTextureLodBIAS;
+	int m_OpenGLTextureLodBIAS = 0;
 
-	bool m_IsOpenGLES;
+	bool m_IsOpenGLES = false;
 
 	bool IsTexturedState(const CCommandBuffer::SState &State);
 
@@ -151,9 +151,9 @@ class CCommandProcessorFragment_OpenGL2 : public CCommandProcessorFragment_OpenG
 			m_pData = NULL;
 			m_DataSize = 0;
 		}
-		TWGLuint m_BufferObjectID;
-		void *m_pData;
-		size_t m_DataSize;
+		TWGLuint m_BufferObjectID = 0;
+		void *m_pData = nullptr;
+		size_t m_DataSize = 0;
 	};
 
 	std::vector<SBufferObject> m_vBufferObjectIndices;
@@ -193,10 +193,10 @@ protected:
 	void Cmd_RenderBorderTileLine(const CCommandBuffer::SCommand_RenderBorderTileLine *pCommand) override;
 #endif
 
-	CGLSLTileProgram *m_pTileProgram;
-	CGLSLTileProgram *m_pTileProgramTextured;
-	CGLSLPrimitiveProgram *m_pPrimitive3DProgram;
-	CGLSLPrimitiveProgram *m_pPrimitive3DProgramTextured;
+	CGLSLTileProgram *m_pTileProgram = nullptr;
+	CGLSLTileProgram *m_pTileProgramTextured = nullptr;
+	CGLSLPrimitiveProgram *m_pPrimitive3DProgram = nullptr;
+	CGLSLPrimitiveProgram *m_pPrimitive3DProgramTextured = nullptr;
 };
 
 class CCommandProcessorFragment_OpenGL3 : public CCommandProcessorFragment_OpenGL2

--- a/src/engine/client/backend/opengl/backend_opengl3.h
+++ b/src/engine/client/backend/opengl/backend_opengl3.h
@@ -23,37 +23,37 @@ class CGLSLTextProgram;
 class CCommandProcessorFragment_OpenGL3_3 : public CCommandProcessorFragment_OpenGL3
 {
 protected:
-	int m_MaxQuadsAtOnce;
+	int m_MaxQuadsAtOnce = 0;
 	static const int ms_MaxQuadsPossible = 256;
 
-	CGLSLPrimitiveProgram *m_pPrimitiveProgram;
-	CGLSLPrimitiveProgram *m_pPrimitiveProgramTextured;
-	CGLSLTileProgram *m_pBorderTileProgram;
-	CGLSLTileProgram *m_pBorderTileProgramTextured;
-	CGLSLTileProgram *m_pBorderTileLineProgram;
-	CGLSLTileProgram *m_pBorderTileLineProgramTextured;
-	CGLSLQuadProgram *m_pQuadProgram;
-	CGLSLQuadProgram *m_pQuadProgramTextured;
-	CGLSLTextProgram *m_pTextProgram;
-	CGLSLPrimitiveExProgram *m_pPrimitiveExProgram;
-	CGLSLPrimitiveExProgram *m_pPrimitiveExProgramTextured;
-	CGLSLPrimitiveExProgram *m_pPrimitiveExProgramRotationless;
-	CGLSLPrimitiveExProgram *m_pPrimitiveExProgramTexturedRotationless;
-	CGLSLSpriteMultipleProgram *m_pSpriteProgramMultiple;
+	CGLSLPrimitiveProgram *m_pPrimitiveProgram = nullptr;
+	CGLSLPrimitiveProgram *m_pPrimitiveProgramTextured = nullptr;
+	CGLSLTileProgram *m_pBorderTileProgram = nullptr;
+	CGLSLTileProgram *m_pBorderTileProgramTextured = nullptr;
+	CGLSLTileProgram *m_pBorderTileLineProgram = nullptr;
+	CGLSLTileProgram *m_pBorderTileLineProgramTextured = nullptr;
+	CGLSLQuadProgram *m_pQuadProgram = nullptr;
+	CGLSLQuadProgram *m_pQuadProgramTextured = nullptr;
+	CGLSLTextProgram *m_pTextProgram = nullptr;
+	CGLSLPrimitiveExProgram *m_pPrimitiveExProgram = nullptr;
+	CGLSLPrimitiveExProgram *m_pPrimitiveExProgramTextured = nullptr;
+	CGLSLPrimitiveExProgram *m_pPrimitiveExProgramRotationless = nullptr;
+	CGLSLPrimitiveExProgram *m_pPrimitiveExProgramTexturedRotationless = nullptr;
+	CGLSLSpriteMultipleProgram *m_pSpriteProgramMultiple = nullptr;
 
-	TWGLuint m_LastProgramID;
+	TWGLuint m_LastProgramID = 0;
 
-	TWGLuint m_aPrimitiveDrawVertexID[MAX_STREAM_BUFFER_COUNT];
-	TWGLuint m_PrimitiveDrawVertexIDTex3D;
-	TWGLuint m_aPrimitiveDrawBufferID[MAX_STREAM_BUFFER_COUNT];
-	TWGLuint m_PrimitiveDrawBufferIDTex3D;
+	TWGLuint m_aPrimitiveDrawVertexID[MAX_STREAM_BUFFER_COUNT] = {0};
+	TWGLuint m_PrimitiveDrawVertexIDTex3D = 0;
+	TWGLuint m_aPrimitiveDrawBufferID[MAX_STREAM_BUFFER_COUNT] = {0};
+	TWGLuint m_PrimitiveDrawBufferIDTex3D = 0;
 
-	TWGLuint m_aLastIndexBufferBound[MAX_STREAM_BUFFER_COUNT];
+	TWGLuint m_aLastIndexBufferBound[MAX_STREAM_BUFFER_COUNT] = {0};
 
-	int m_LastStreamBuffer;
+	int m_LastStreamBuffer = 0;
 
-	TWGLuint m_QuadDrawIndexBufferID;
-	unsigned int m_CurrentIndicesInBuffer;
+	TWGLuint m_QuadDrawIndexBufferID = 0;
+	unsigned int m_CurrentIndicesInBuffer = 0;
 
 	void DestroyBufferContainer(int Index, bool DeleteBOs = true);
 
@@ -63,8 +63,8 @@ protected:
 	{
 		SBufferContainer() :
 			m_VertArrayID(0), m_LastIndexBufferBound(0) {}
-		TWGLuint m_VertArrayID;
-		TWGLuint m_LastIndexBufferBound;
+		TWGLuint m_VertArrayID = 0;
+		TWGLuint m_LastIndexBufferBound = 0;
 		SBufferContainerInfo m_ContainerInfo;
 	};
 	std::vector<SBufferContainer> m_vBufferContainers;

--- a/src/engine/client/backend/opengl/opengl_sl.h
+++ b/src/engine/client/backend/opengl/opengl_sl.h
@@ -27,9 +27,9 @@ public:
 	virtual ~CGLSL();
 
 private:
-	TWGLuint m_ShaderID;
-	int m_Type;
-	bool m_IsLoaded;
+	TWGLuint m_ShaderID = 0;
+	int m_Type = 0;
+	bool m_IsLoaded = false;
 };
 
 #endif

--- a/src/engine/client/backend/opengl/opengl_sl_program.h
+++ b/src/engine/client/backend/opengl/opengl_sl_program.h
@@ -47,8 +47,8 @@ public:
 	virtual ~CGLSLProgram();
 
 protected:
-	TWGLuint m_ProgramID;
-	bool m_IsLinked;
+	TWGLuint m_ProgramID = 0;
+	bool m_IsLinked = false;
 };
 
 class CGLSLTWProgram : public CGLSLProgram
@@ -60,11 +60,11 @@ public:
 		m_LastScreenTL = m_LastScreenBR = vec2(-1, -1);
 	}
 
-	int m_LocPos;
-	int m_LocTextureSampler;
+	int m_LocPos = 0;
+	int m_LocTextureSampler = 0;
 
-	int m_LastTextureSampler;
-	int m_LastIsTextured;
+	int m_LastTextureSampler = 0;
+	int m_LastIsTextured = 0;
 	vec2 m_LastScreenTL;
 	vec2 m_LastScreenBR;
 };
@@ -81,17 +81,17 @@ public:
 		m_LastTextureSize = -1;
 	}
 
-	int m_LocColor;
-	int m_LocOutlineColor;
-	int m_LocTextSampler;
-	int m_LocTextOutlineSampler;
-	int m_LocTextureSize;
+	int m_LocColor = 0;
+	int m_LocOutlineColor = 0;
+	int m_LocTextSampler = 0;
+	int m_LocTextOutlineSampler = 0;
+	int m_LocTextureSize = 0;
 
 	ColorRGBA m_LastColor;
 	ColorRGBA m_LastOutlineColor;
-	int m_LastTextSampler;
-	int m_LastTextOutlineSampler;
-	int m_LastTextureSize;
+	int m_LastTextSampler = 0;
+	int m_LastTextOutlineSampler = 0;
+	int m_LastTextureSize = 0;
 };
 
 class CGLSLPrimitiveProgram : public CGLSLTWProgram
@@ -110,11 +110,11 @@ public:
 		m_LastVerticesColor = ColorRGBA(-1, -1, -1, -1);
 	}
 
-	int m_LocRotation;
-	int m_LocCenter;
-	int m_LocVertciesColor;
+	int m_LocRotation = 0;
+	int m_LocCenter = 0;
+	int m_LocVertciesColor = 0;
 
-	float m_LastRotation;
+	float m_LastRotation = 0;
 	vec2 m_LastCenter;
 	ColorRGBA m_LastVerticesColor;
 };
@@ -129,9 +129,9 @@ public:
 		m_LastVerticesColor = ColorRGBA(-1, -1, -1, -1);
 	}
 
-	int m_LocRSP;
-	int m_LocCenter;
-	int m_LocVertciesColor;
+	int m_LocRSP = 0;
+	int m_LocCenter = 0;
+	int m_LocVertciesColor = 0;
 
 	vec2 m_LastCenter;
 	ColorRGBA m_LastVerticesColor;
@@ -140,10 +140,10 @@ public:
 class CGLSLQuadProgram : public CGLSLTWProgram
 {
 public:
-	int m_LocColors;
-	int m_LocOffsets;
-	int m_LocRotations;
-	int m_LocQuadOffset;
+	int m_LocColors = 0;
+	int m_LocOffsets = 0;
+	int m_LocRotations = 0;
+	int m_LocQuadOffset = 0;
 };
 
 class CGLSLTileProgram : public CGLSLTWProgram
@@ -152,11 +152,11 @@ public:
 	CGLSLTileProgram() :
 		m_LocColor(-1), m_LocOffset(-1), m_LocDir(-1), m_LocNum(-1), m_LocJumpIndex(-1) {}
 
-	int m_LocColor;
-	int m_LocOffset;
-	int m_LocDir;
-	int m_LocNum;
-	int m_LocJumpIndex;
+	int m_LocColor = 0;
+	int m_LocOffset = 0;
+	int m_LocDir = 0;
+	int m_LocNum = 0;
+	int m_LocJumpIndex = 0;
 };
 
 #endif

--- a/src/engine/client/backend/vulkan/backend_vulkan.cpp
+++ b/src/engine/client/backend/vulkan/backend_vulkan.cpp
@@ -800,6 +800,16 @@ class CCommandProcessorFragment_Vulkan : public CCommandProcessorFragment_GLBase
 		vec2 m_Offset;
 		float m_Rotation = 0;
 		float m_Padding = 0;
+
+		SUniformQuadPushGBufferObject& operator=(const SQuadRenderInfo &QuadInfo)
+		{
+			m_VertColor = QuadInfo.m_Color;
+			m_Offset = QuadInfo.m_Offsets;
+			m_Rotation = QuadInfo.m_Rotation;
+			m_Padding = QuadInfo.m_Padding;
+
+			return *this;
+		}
 	};
 
 	struct SUniformQuadPushGPos
@@ -6853,7 +6863,7 @@ public:
 		{
 			SUniformQuadPushGPos PushConstantVertex;
 
-			mem_copy(&PushConstantVertex.m_BOPush, &pCommand->m_pQuadInfo[0], sizeof(PushConstantVertex.m_BOPush));
+			PushConstantVertex.m_BOPush = pCommand->m_pQuadInfo[0];
 
 			mem_copy(PushConstantVertex.m_aPos, m.data(), sizeof(PushConstantVertex.m_aPos));
 			PushConstantVertex.m_QuadOffset = pCommand->m_QuadOffset;

--- a/src/engine/client/backend/vulkan/backend_vulkan.cpp
+++ b/src/engine/client/backend/vulkan/backend_vulkan.cpp
@@ -129,7 +129,7 @@ class CCommandProcessorFragment_Vulkan : public CCommandProcessorFragment_GLBase
 	{
 		VkDeviceMemory m_Mem = VK_NULL_HANDLE;
 		VkDeviceSize m_Size = 0;
-		EMemoryBlockUsage m_UsageType;
+		EMemoryBlockUsage m_UsageType = MEMORY_BLOCK_USAGE_TEXTURE;
 	};
 
 	struct SDeviceDescriptorPools;
@@ -161,12 +161,12 @@ class CCommandProcessorFragment_Vulkan : public CCommandProcessorFragment_GLBase
 		struct SMemoryHeapElement;
 		struct SMemoryHeapQueueElement
 		{
-			size_t m_AllocationSize;
+			size_t m_AllocationSize = 0;
 			// only useful information for the heap
-			size_t m_OffsetInHeap;
+			size_t m_OffsetInHeap = 0;
 			// useful for the user of this element
-			size_t m_OffsetToAlign;
-			SMemoryHeapElement *m_pElementInHeap;
+			size_t m_OffsetToAlign = 0;
+			SMemoryHeapElement *m_pElementInHeap = nullptr;
 			bool operator>(const SMemoryHeapQueueElement &Other) const { return m_AllocationSize > Other.m_AllocationSize; }
 		};
 
@@ -174,13 +174,13 @@ class CCommandProcessorFragment_Vulkan : public CCommandProcessorFragment_GLBase
 
 		struct SMemoryHeapElement
 		{
-			size_t m_AllocationSize;
-			size_t m_Offset;
-			SMemoryHeapElement *m_pParent;
-			std::unique_ptr<SMemoryHeapElement> m_pLeft;
-			std::unique_ptr<SMemoryHeapElement> m_pRight;
+			size_t m_AllocationSize = 0;
+			size_t m_Offset = 0;
+			SMemoryHeapElement *m_pParent = nullptr;
+			std::unique_ptr<SMemoryHeapElement> m_pLeft = nullptr;
+			std::unique_ptr<SMemoryHeapElement> m_pRight = nullptr;
 
-			bool m_InUse;
+			bool m_InUse = false;
 			TMemoryHeapQueue::iterator m_InQueue;
 		};
 
@@ -315,22 +315,22 @@ class CCommandProcessorFragment_Vulkan : public CCommandProcessorFragment_GLBase
 	{
 		SMemoryHeap::SMemoryHeapQueueElement m_HeapData;
 
-		VkDeviceSize m_UsedSize;
+		VkDeviceSize m_UsedSize = 0;
 
 		// optional
 		VkBuffer m_Buffer;
 
 		SDeviceMemoryBlock m_BufferMem;
-		void *m_pMappedBuffer;
+		void *m_pMappedBuffer = nullptr;
 
-		bool m_IsCached;
-		SMemoryHeap *m_pHeap;
+		bool m_IsCached = false;
+		SMemoryHeap *m_pHeap = nullptr;
 	};
 
 	template<size_t ID>
 	struct SMemoryImageBlock : public SMemoryBlock<ID>
 	{
-		uint32_t m_ImageMemoryBits;
+		uint32_t m_ImageMemoryBits = 0;
 	};
 
 	template<size_t ID>
@@ -344,7 +344,7 @@ class CCommandProcessorFragment_Vulkan : public CCommandProcessorFragment_GLBase
 				VkBuffer m_Buffer;
 
 				SDeviceMemoryBlock m_BufferMem;
-				void *m_pMappedBuffer;
+				void *m_pMappedBuffer = nullptr;
 			};
 			std::vector<SMemoryCacheHeap *> m_vpMemoryHeaps;
 		};
@@ -477,7 +477,7 @@ class CCommandProcessorFragment_Vulkan : public CCommandProcessorFragment_GLBase
 
 	struct SBufferContainer
 	{
-		int m_BufferObjectIndex;
+		int m_BufferObjectIndex = 0;
 	};
 
 	struct SFrameBuffers
@@ -485,9 +485,9 @@ class CCommandProcessorFragment_Vulkan : public CCommandProcessorFragment_GLBase
 		VkBuffer m_Buffer;
 		SDeviceMemoryBlock m_BufferMem;
 		size_t m_OffsetInBuffer = 0;
-		size_t m_Size;
-		size_t m_UsedSize;
-		void *m_pMappedBufferData;
+		size_t m_Size = 0;
+		size_t m_UsedSize = 0;
+		void *m_pMappedBufferData = nullptr;
 
 		SFrameBuffers(VkBuffer Buffer, SDeviceMemoryBlock BufferMem, size_t OffsetInBuffer, size_t Size, size_t UsedSize, void *pMappedBufferData) :
 			m_Buffer(Buffer), m_BufferMem(BufferMem), m_OffsetInBuffer(OffsetInBuffer), m_Size(Size), m_UsedSize(UsedSize), m_pMappedBufferData(pMappedBufferData)
@@ -698,13 +698,13 @@ class CCommandProcessorFragment_Vulkan : public CCommandProcessorFragment_GLBase
 
 	struct SUniformGPos
 	{
-		float m_aPos[4 * 2];
+		float m_aPos[4 * 2] = {0};
 	};
 
 	struct SUniformGTextPos
 	{
-		float m_aPos[4 * 2];
-		float m_TextureSize;
+		float m_aPos[4 * 2] = {0};
+		float m_TextureSize = 0;
 	};
 
 	typedef vec3 SUniformTextGFragmentOffset;
@@ -722,7 +722,7 @@ class CCommandProcessorFragment_Vulkan : public CCommandProcessorFragment_GLBase
 
 	struct SUniformTileGPos
 	{
-		float m_aPos[4 * 2];
+		float m_aPos[4 * 2] = {0};
 	};
 
 	struct SUniformTileGPosBorderLine : public SUniformTileGPos
@@ -733,37 +733,37 @@ class CCommandProcessorFragment_Vulkan : public CCommandProcessorFragment_GLBase
 
 	struct SUniformTileGPosBorder : public SUniformTileGPosBorderLine
 	{
-		int32_t m_JumpIndex;
+		int32_t m_JumpIndex = 0;
 	};
 
 	typedef ColorRGBA SUniformTileGVertColor;
 
 	struct SUniformTileGVertColorAlign
 	{
-		float m_aPad[(64 - 52) / 4];
+		float m_aPad[(64 - 52) / 4] = {0};
 	};
 
 	struct SUniformPrimExGPosRotationless
 	{
-		float m_aPos[4 * 2];
+		float m_aPos[4 * 2] = {0};
 	};
 
 	struct SUniformPrimExGPos : public SUniformPrimExGPosRotationless
 	{
 		vec2 m_Center;
-		float m_Rotation;
+		float m_Rotation = 0;
 	};
 
 	typedef ColorRGBA SUniformPrimExGVertColor;
 
 	struct SUniformPrimExGVertColorAlign
 	{
-		float m_aPad[(48 - 44) / 4];
+		float m_aPad[(48 - 44) / 4] = {0};
 	};
 
 	struct SUniformSpriteMultiGPos
 	{
-		float m_aPos[4 * 2];
+		float m_aPos[4 * 2] = {0};
 		vec2 m_Center;
 	};
 
@@ -771,12 +771,12 @@ class CCommandProcessorFragment_Vulkan : public CCommandProcessorFragment_GLBase
 
 	struct SUniformSpriteMultiGVertColorAlign
 	{
-		float m_aPad[(48 - 40) / 4];
+		float m_aPad[(48 - 40) / 4] = {0};
 	};
 
 	struct SUniformSpriteMultiPushGPosBase
 	{
-		float m_aPos[4 * 2];
+		float m_aPos[4 * 2] = {0};
 		vec2 m_Center;
 		vec2 m_Padding;
 	};
@@ -790,29 +790,29 @@ class CCommandProcessorFragment_Vulkan : public CCommandProcessorFragment_GLBase
 
 	struct SUniformQuadGPosBase
 	{
-		float m_aPos[4 * 2];
-		int32_t m_QuadOffset;
+		float m_aPos[4 * 2] = {0};
+		int32_t m_QuadOffset = 0;
 	};
 
 	struct SUniformQuadPushGBufferObject
 	{
 		vec4 m_VertColor;
 		vec2 m_Offset;
-		float m_Rotation;
-		float m_Padding;
+		float m_Rotation = 0;
+		float m_Padding = 0;
 	};
 
 	struct SUniformQuadPushGPos
 	{
-		float m_aPos[4 * 2];
+		float m_aPos[4 * 2] = {0};
 		SUniformQuadPushGBufferObject m_BOPush;
-		int32_t m_QuadOffset;
+		int32_t m_QuadOffset = 0;
 	};
 
 	struct SUniformQuadGPos
 	{
-		float m_aPos[4 * 2];
-		int32_t m_QuadOffset;
+		float m_aPos[4 * 2] = {0};
+		int32_t m_QuadOffset = 0;
 	};
 
 	enum ESupportedSamplerTypes
@@ -874,14 +874,14 @@ class CCommandProcessorFragment_Vulkan : public CCommandProcessorFragment_GLBase
 
 	std::vector<CTexture> m_vTextures;
 
-	std::atomic<uint64_t> *m_pTextureMemoryUsage;
-	std::atomic<uint64_t> *m_pBufferMemoryUsage;
-	std::atomic<uint64_t> *m_pStreamMemoryUsage;
-	std::atomic<uint64_t> *m_pStagingMemoryUsage;
+	std::atomic<uint64_t> *m_pTextureMemoryUsage = nullptr;
+	std::atomic<uint64_t> *m_pBufferMemoryUsage = nullptr;
+	std::atomic<uint64_t> *m_pStreamMemoryUsage = nullptr;
+	std::atomic<uint64_t> *m_pStagingMemoryUsage = nullptr;
 
-	TTWGraphicsGPUList *m_pGPUList;
+	TTWGraphicsGPUList *m_pGPUList = nullptr;
 
-	int m_GlobalTextureLodBIAS;
+	int m_GlobalTextureLodBIAS = 0;
 	uint32_t m_MultiSamplingCount = 1;
 
 	uint32_t m_NextMultiSamplingCount = std::numeric_limits<uint32_t>::max();
@@ -903,15 +903,15 @@ class CCommandProcessorFragment_Vulkan : public CCommandProcessorFragment_GLBase
 
 	VkBuffer m_RenderIndexBuffer;
 	SDeviceMemoryBlock m_RenderIndexBufferMemory;
-	size_t m_CurRenderIndexPrimitiveCount;
+	size_t m_CurRenderIndexPrimitiveCount = 0;
 
-	VkDeviceSize m_NonCoherentMemAlignment;
-	VkDeviceSize m_OptimalImageCopyMemAlignment;
-	uint32_t m_MaxTextureSize;
-	uint32_t m_MaxSamplerAnisotropy;
+	VkDeviceSize m_NonCoherentMemAlignment = 0;
+	VkDeviceSize m_OptimalImageCopyMemAlignment = 0;
+	uint32_t m_MaxTextureSize = 0;
+	uint32_t m_MaxSamplerAnisotropy = 0;
 	VkSampleCountFlags m_MaxMultiSample;
 
-	uint32_t m_MinUniformAlign;
+	uint32_t m_MinUniformAlign = 0;
 
 	std::vector<uint8_t> m_vScreenshotHelper;
 
@@ -926,7 +926,7 @@ class CCommandProcessorFragment_Vulkan : public CCommandProcessorFragment_GLBase
 
 	std::array<VkSampler, SUPPORTED_SAMPLER_TYPE_COUNT> m_aSamplers;
 
-	class IStorage *m_pStorage;
+	class IStorage *m_pStorage = nullptr;
 
 	struct SDelayedBufferCleanupItem
 	{
@@ -983,7 +983,7 @@ private:
 	uint64_t m_CurFrame = 0;
 	std::vector<uint64_t> m_vImageLastFrameCheck;
 
-	uint32_t m_LastPresentedSwapChainImageIndex;
+	uint32_t m_LastPresentedSwapChainImageIndex = 0;
 
 	std::vector<SBufferObjectFrame> m_vBufferObjects;
 
@@ -1046,25 +1046,25 @@ private:
 	uint32_t m_CurFrames = 0;
 	uint32_t m_CurImageIndex = 0;
 
-	uint32_t m_CanvasWidth;
-	uint32_t m_CanvasHeight;
+	uint32_t m_CanvasWidth = 0;
+	uint32_t m_CanvasHeight = 0;
 
-	SDL_Window *m_pWindow;
+	SDL_Window *m_pWindow = nullptr;
 
 	std::array<float, 4> m_aClearColor = {0, 0, 0, 0};
 
 	struct SRenderCommandExecuteBuffer
 	{
-		CCommandBuffer::ECommandBufferCMD m_Command;
-		const CCommandBuffer::SCommand *m_pRawCommand;
-		uint32_t m_ThreadIndex;
+		CCommandBuffer::ECommandBufferCMD m_Command = CCommandBuffer::ECommandBufferCMD::CMDGROUP_CORE;
+		const CCommandBuffer::SCommand *m_pRawCommand = nullptr;
+		uint32_t m_ThreadIndex = 0;
 
 		// must be calculated when the buffer gets filled
 		size_t m_EstimatedRenderCallCount = 0;
 
 		// usefull data
 		VkBuffer m_Buffer;
-		size_t m_BufferOff;
+		size_t m_BufferOff = 0;
 		std::array<SDeviceDescriptorSet, 2> m_aDescriptors;
 
 		VkBuffer m_IndexBuffer;
@@ -1087,7 +1087,7 @@ private:
 
 	struct SCommandCallback
 	{
-		bool m_IsRenderCommand;
+		bool m_IsRenderCommand = false;
 		TCommandBufferFillExecuteBufferFunc m_FillExecuteBuffer;
 		TCommandBufferCommandCallback m_CommandCB;
 	};
@@ -1098,7 +1098,7 @@ protected:
 	* ERROR MANAGMENT
 	************************/
 
-	char m_aError[1024];
+	char m_aError[1024] = {0};
 	bool m_HasError = false;
 	bool m_CanAssert = false;
 

--- a/src/engine/client/backend_sdl.h
+++ b/src/engine/client/backend_sdl.h
@@ -63,14 +63,14 @@ protected:
 	void StopProcessor();
 
 private:
-	ICommandProcessor *m_pProcessor;
+	ICommandProcessor *m_pProcessor = nullptr;
 	std::mutex m_BufferSwapMutex;
 	std::condition_variable m_BufferSwapCond;
-	CCommandBuffer *m_pBuffer;
-	std::atomic_bool m_Shutdown;
+	CCommandBuffer *m_pBuffer = nullptr;
+	std::atomic_bool m_Shutdown = false;
 	bool m_Started = false;
-	std::atomic_bool m_BufferInProcess;
-	void *m_pThread;
+	std::atomic_bool m_BufferInProcess = false;
+	void *m_pThread = nullptr;
 
 	static void ThreadFunc(void *pUser);
 };
@@ -87,31 +87,31 @@ public:
 
 struct SBackendCapabilites
 {
-	bool m_TileBuffering;
-	bool m_QuadBuffering;
-	bool m_TextBuffering;
-	bool m_QuadContainerBuffering;
+	bool m_TileBuffering = false;
+	bool m_QuadBuffering = false;
+	bool m_TextBuffering = false;
+	bool m_QuadContainerBuffering = false;
 
-	bool m_MipMapping;
-	bool m_NPOTTextures;
-	bool m_3DTextures;
-	bool m_2DArrayTextures;
-	bool m_2DArrayTexturesAsExtension;
-	bool m_ShaderSupport;
+	bool m_MipMapping = false;
+	bool m_NPOTTextures = false;
+	bool m_3DTextures = false;
+	bool m_2DArrayTextures = false;
+	bool m_2DArrayTexturesAsExtension = false;
+	bool m_ShaderSupport = false;
 
 	// use quads as much as possible, even if the user config says otherwise
-	bool m_TrianglesAsQuads;
+	bool m_TrianglesAsQuads = false;
 
-	int m_ContextMajor;
-	int m_ContextMinor;
-	int m_ContextPatch;
+	int m_ContextMajor = 0;
+	int m_ContextMinor = 0;
+	int m_ContextPatch = 0;
 };
 
 // takes care of sdl related commands
 class CCommandProcessorFragment_SDL
 {
 	// SDL stuff
-	SDL_Window *m_pWindow;
+	SDL_Window *m_pWindow = nullptr;
 	SDL_GLContext m_GLContext;
 
 public:
@@ -125,7 +125,7 @@ public:
 	{
 		SCommand_Init() :
 			SCommand(CMD_INIT) {}
-		SDL_Window *m_pWindow;
+		SDL_Window *m_pWindow = nullptr;
 		SDL_GLContext m_GLContext;
 	};
 
@@ -152,11 +152,11 @@ public:
 // command processor impelementation, uses the fragments to combine into one processor
 class CCommandProcessor_SDL_GL : public CGraphicsBackend_Threaded::ICommandProcessor
 {
-	class CCommandProcessorFragment_GLBase *m_pGLBackend;
+	class CCommandProcessorFragment_GLBase *m_pGLBackend = nullptr;
 	CCommandProcessorFragment_SDL m_SDL;
 	CCommandProcessorFragment_General m_General;
 
-	EBackendType m_BackendType;
+	EBackendType m_BackendType = BACKEND_TYPE_OPENGL;
 
 public:
 	CCommandProcessor_SDL_GL(EBackendType BackendType, int GLMajor, int GLMinor, int GLPatch);
@@ -181,7 +181,7 @@ class CGraphicsBackend_SDL_GL : public CGraphicsBackend_Threaded
 
 	TGLBackendReadPresentedImageData m_ReadPresentedImageDataFunc;
 
-	int m_NumScreens;
+	int m_NumScreens = 0;
 
 	SBackendCapabilites m_Capabilites;
 
@@ -191,7 +191,7 @@ class CGraphicsBackend_SDL_GL : public CGraphicsBackend_Threaded
 
 	EBackendType m_BackendType = BACKEND_TYPE_AUTO;
 
-	char m_aErrorString[256];
+	char m_aErrorString[256] = {0};
 
 	static EBackendType DetectBackend();
 	static void ClampDriverVersion(EBackendType BackendType);

--- a/src/engine/client/blocklist_driver.cpp
+++ b/src/engine/client/blocklist_driver.cpp
@@ -8,7 +8,7 @@
 
 struct SVersion
 {
-	int m_aParts[VERSION_PARTS];
+	int m_aParts[VERSION_PARTS] = {0};
 
 	bool operator<=(const SVersion &Other) const
 	{
@@ -32,22 +32,22 @@ enum EBackendDriverBlockListType
 /* TODO: generalize it more for other drivers / vendors */
 struct SBackEndDriverBlockList
 {
-	EBackendDriverBlockListType m_BlockListType;
+	EBackendDriverBlockListType m_BlockListType = BACKEND_DRIVER_BLOCKLIST_TYPE_VERSION;
 
 	SVersion m_VersionMin;
 	SVersion m_VersionMax;
 
-	const char *m_pVendorName;
+	const char *m_pVendorName = nullptr;
 
 	// the OpenGL version, that is supported
-	int m_AllowedMajor;
-	int m_AllowedMinor;
-	int m_AllowedPatch;
+	int m_AllowedMajor = 0;
+	int m_AllowedMinor = 0;
+	int m_AllowedPatch = 0;
 
-	const char *m_pReason;
+	const char *m_pReason = nullptr;
 
-	bool m_DisplayReason;
-	const char *m_pOSName;
+	bool m_DisplayReason = false;
+	const char *m_pOSName = nullptr;
 };
 
 static SBackEndDriverBlockList gs_aBlockList[] = {

--- a/src/engine/client/checksum.h
+++ b/src/engine/client/checksum.h
@@ -5,32 +5,37 @@
 
 struct CChecksumData
 {
-	int m_SizeofData;
-	char m_aVersionStr[128];
-	int m_Version;
-	char m_aOsVersion[256];
-	int64_t m_Start;
-	int m_Random;
-	int m_SizeofClient;
-	int m_SizeofGameClient;
-	float m_Zoom;
-	int m_SizeofConfig;
+	int m_SizeofData = 0;
+	char m_aVersionStr[128] = {0};
+	int m_Version = 0;
+	char m_aOsVersion[256] = {0};
+	int64_t m_Start = 0;
+	int m_Random = 0;
+	int m_SizeofClient = 0;
+	int m_SizeofGameClient = 0;
+	float m_Zoom = 0;
+	int m_SizeofConfig = 0;
 	CConfig m_Config;
-	int m_NumCommands;
-	int m_aCommandsChecksum[1024];
-	int m_NumComponents;
-	int m_aComponentsChecksum[64];
-	int m_NumFiles;
-	int m_NumExtra;
-	unsigned m_aFiles[1024];
+	int m_NumCommands = 0;
+	int m_aCommandsChecksum[1024] = {0};
+	int m_NumComponents = 0;
+	int m_aComponentsChecksum[64] = {0};
+	int m_NumFiles = 0;
+	int m_NumExtra = 0;
+	unsigned m_aFiles[1024] = {0};
 
 	void InitFiles();
 };
 
 union CChecksum
 {
-	char m_aBytes[sizeof(CChecksumData)];
+	char m_aBytes[sizeof(CChecksumData)] /* = {0} */;
 	CChecksumData m_Data;
+
+	CChecksum()
+	{
+		mem_zero(this, sizeof(this));
+	};
 };
 
 #endif // ENGINE_CLIENT_CHECKSUM_H

--- a/src/engine/client/checksum.h
+++ b/src/engine/client/checksum.h
@@ -29,13 +29,13 @@ struct CChecksumData
 
 union CChecksum
 {
-	char m_aBytes[sizeof(CChecksumData)] /* = {0} */;
 	CChecksumData m_Data;
+	char m_aBytes[sizeof(CChecksumData)] /* = {0} */;
 
-	CChecksum()
-	{
-		mem_zero(this, sizeof(this));
-	};
+    CChecksum()
+    {
+        mem_zero(m_aBytes, sizeof(CChecksum));
+    }
 };
 
 #endif // ENGINE_CLIENT_CHECKSUM_H

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -115,9 +115,9 @@ void CGraph::Add(float v, float r, float g, float b)
 {
 	m_Index = (m_Index + 1) & (MAX_VALUES - 1);
 	m_aValues[m_Index] = v;
-	m_aColors[m_Index][0] = r;
-	m_aColors[m_Index][1] = g;
-	m_aColors[m_Index][2] = b;
+	m_aaColors[m_Index][0] = r;
+	m_aaColors[m_Index][1] = g;
+	m_aaColors[m_Index][2] = b;
 }
 
 bool CGraph::InsertAt(int i, float v, float r, float g, float b)
@@ -127,9 +127,9 @@ bool CGraph::InsertAt(int i, float v, float r, float g, float b)
 		return false;
 	}
 	m_aValues[i] = v;
-	m_aColors[i][0] = r;
-	m_aColors[i][1] = g;
-	m_aColors[i][2] = b;
+	m_aaColors[i][0] = r;
+	m_aaColors[i][1] = g;
+	m_aaColors[i][2] = b;
 	return true;
 }
 
@@ -165,8 +165,8 @@ void CGraph::Render(IGraphics *pGraphics, IGraphics::CTextureHandle FontTexture,
 		float v1 = (m_aValues[i1] - m_Min) / (m_Max - m_Min);
 
 		IGraphics::CColorVertex ArrayV[2] = {
-			IGraphics::CColorVertex(0, m_aColors[i0][0], m_aColors[i0][1], m_aColors[i0][2], 0.75f),
-			IGraphics::CColorVertex(1, m_aColors[i1][0], m_aColors[i1][1], m_aColors[i1][2], 0.75f)};
+			IGraphics::CColorVertex(0, m_aaColors[i0][0], m_aaColors[i0][1], m_aaColors[i0][2], 0.75f),
+			IGraphics::CColorVertex(1, m_aaColors[i1][0], m_aaColors[i1][1], m_aaColors[i1][2], 0.75f)};
 		pGraphics->SetColorVertex(ArrayV, 2);
 		IGraphics::CLineItem LineItem2(x + a0 * w, y + h - v0 * h, x + a1 * w, y + h - v1 * h);
 		pGraphics->LinesDraw(&LineItem2, 1);
@@ -738,17 +738,17 @@ void CClient::GenerateTimeoutCodes(const NETADDR *pAddrs, int NumAddrs)
 	{
 		for(int i = 0; i < 2; i++)
 		{
-			GenerateTimeoutCode(m_aTimeoutCodes[i], sizeof(m_aTimeoutCodes[i]), g_Config.m_ClTimeoutSeed, pAddrs, NumAddrs, i);
+			GenerateTimeoutCode(m_aaTimeoutCodes[i], sizeof(m_aaTimeoutCodes[i]), g_Config.m_ClTimeoutSeed, pAddrs, NumAddrs, i);
 
 			char aBuf[64];
-			str_format(aBuf, sizeof(aBuf), "timeout code '%s' (%s)", m_aTimeoutCodes[i], i == 0 ? "normal" : "dummy");
+			str_format(aBuf, sizeof(aBuf), "timeout code '%s' (%s)", m_aaTimeoutCodes[i], i == 0 ? "normal" : "dummy");
 			m_pConsole->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "client", aBuf);
 		}
 	}
 	else
 	{
-		str_copy(m_aTimeoutCodes[0], g_Config.m_ClTimeoutCode);
-		str_copy(m_aTimeoutCodes[1], g_Config.m_ClDummyTimeoutCode);
+		str_copy(m_aaTimeoutCodes[0], g_Config.m_ClTimeoutCode);
+		str_copy(m_aaTimeoutCodes[1], g_Config.m_ClDummyTimeoutCode);
 	}
 }
 
@@ -2173,9 +2173,9 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket, int Conn, bool Dummy)
 							char aBuf[128];
 							char aBufMsg[256];
 							if(!g_Config.m_ClRunOnJoin[0] && !g_Config.m_ClDummyDefaultEyes && !g_Config.m_ClPlayerDefaultEyes)
-								str_format(aBufMsg, sizeof(aBufMsg), "/timeout %s", m_aTimeoutCodes[Conn]);
+								str_format(aBufMsg, sizeof(aBufMsg), "/timeout %s", m_aaTimeoutCodes[Conn]);
 							else
-								str_format(aBufMsg, sizeof(aBufMsg), "/mc;timeout %s", m_aTimeoutCodes[Conn]);
+								str_format(aBufMsg, sizeof(aBufMsg), "/mc;timeout %s", m_aaTimeoutCodes[Conn]);
 
 							if(g_Config.m_ClRunOnJoin[0])
 							{

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -48,11 +48,11 @@ public:
 		MAX_VALUES = 128,
 	};
 
-	float m_Min, m_Max;
-	float m_MinRange, m_MaxRange;
-	float m_aValues[MAX_VALUES];
-	float m_aColors[MAX_VALUES][3];
-	int m_Index;
+	float m_Min = 0, m_Max = 0;
+	float m_MinRange = 0, m_MaxRange = 0;
+	float m_aValues[MAX_VALUES] = {0};
+	float m_aaColors[MAX_VALUES][3] = {{0}};
+	int m_Index = 0;
 
 	void Init(float Min, float Max);
 
@@ -66,19 +66,19 @@ public:
 
 class CSmoothTime
 {
-	int64_t m_Snap;
-	int64_t m_Current;
-	int64_t m_Target;
+	int64_t m_Snap = 0;
+	int64_t m_Current = 0;
+	int64_t m_Target = 0;
 
-	int64_t m_SnapMargin;
-	int64_t m_CurrentMargin;
-	int64_t m_TargetMargin;
+	int64_t m_SnapMargin = 0;
+	int64_t m_CurrentMargin = 0;
+	int64_t m_TargetMargin = 0;
 
 	CGraph m_Graph;
 
-	int m_SpikeCounter;
+	int m_SpikeCounter = 0;
 
-	float m_aAdjustSpeed[2]; // 0 = down, 1 = up
+	float m_aAdjustSpeed[2] = {0}; // 0 = down, 1 = up
 public:
 	void Init(int64_t Target);
 	void SetAdjustSpeed(int Direction, float Value);
@@ -95,31 +95,31 @@ public:
 class CServerCapabilities
 {
 public:
-	bool m_ChatTimeoutCode;
-	bool m_AnyPlayerFlag;
-	bool m_PingEx;
-	bool m_AllowDummy;
-	bool m_SyncWeaponInput;
+	bool m_ChatTimeoutCode = false;
+	bool m_AnyPlayerFlag = false;
+	bool m_PingEx = false;
+	bool m_AllowDummy = false;
+	bool m_SyncWeaponInput = false;
 };
 
 class CClient : public IClient, public CDemoPlayer::IListener
 {
 	// needed interfaces
-	IEngine *m_pEngine;
-	IEditor *m_pEditor;
-	IEngineInput *m_pInput;
-	IEngineGraphics *m_pGraphics;
-	IEngineSound *m_pSound;
-	IFavorites *m_pFavorites;
-	IGameClient *m_pGameClient;
-	IEngineMap *m_pMap;
-	IConfigManager *m_pConfigManager;
-	CConfig *m_pConfig;
-	IConsole *m_pConsole;
-	IStorage *m_pStorage;
-	IUpdater *m_pUpdater;
-	IDiscord *m_pDiscord;
-	ISteam *m_pSteam;
+	IEngine *m_pEngine = nullptr;
+	IEditor *m_pEditor = nullptr;
+	IEngineInput *m_pInput = nullptr;
+	IEngineGraphics *m_pGraphics = nullptr;
+	IEngineSound *m_pSound = nullptr;
+	IFavorites *m_pFavorites = nullptr;
+	IGameClient *m_pGameClient = nullptr;
+	IEngineMap *m_pMap = nullptr;
+	IConfigManager *m_pConfigManager = nullptr;
+	CConfig *m_pConfig = nullptr;
+	IConsole *m_pConsole = nullptr;
+	IStorage *m_pStorage = nullptr;
+	IUpdater *m_pUpdater = nullptr;
+	IDiscord *m_pDiscord = nullptr;
+	ISteam *m_pSteam = nullptr;
 
 	CNetClient m_aNetClient[NUM_CONNS];
 	CDemoPlayer m_DemoPlayer;
@@ -132,79 +132,79 @@ class CClient : public IClient, public CDemoPlayer::IListener
 	CFriends m_Friends;
 	CFriends m_Foes;
 
-	char m_aConnectAddressStr[MAX_SERVER_ADDRESSES * NETADDR_MAXSTRSIZE];
+	char m_aConnectAddressStr[MAX_SERVER_ADDRESSES * NETADDR_MAXSTRSIZE] = {0};
 
 	CUuid m_ConnectionID;
 
 	bool m_HaveGlobalTcpAddr = false;
 	NETADDR m_GlobalTcpAddr;
 
-	uint64_t m_aSnapshotParts[NUM_DUMMIES];
-	int64_t m_LocalStartTime;
+	uint64_t m_aSnapshotParts[NUM_DUMMIES] = {0};
+	int64_t m_LocalStartTime = 0;
 
 	IGraphics::CTextureHandle m_DebugFont;
 	int m_DebugSoundIndex = 0;
 
-	int64_t m_LastRenderTime;
-	float m_RenderFrameTimeLow;
-	float m_RenderFrameTimeHigh;
-	int m_RenderFrames;
+	int64_t m_LastRenderTime = 0;
+	float m_RenderFrameTimeLow = 0;
+	float m_RenderFrameTimeHigh = 0;
+	int m_RenderFrames = 0;
 
-	int m_SnapCrcErrors;
-	bool m_AutoScreenshotRecycle;
-	bool m_AutoStatScreenshotRecycle;
-	bool m_AutoCSVRecycle;
-	bool m_EditorActive;
-	bool m_SoundInitFailed;
-	bool m_ResortServerBrowser;
+	int m_SnapCrcErrors = 0;
+	bool m_AutoScreenshotRecycle = false;
+	bool m_AutoStatScreenshotRecycle = false;
+	bool m_AutoCSVRecycle = false;
+	bool m_EditorActive = false;
+	bool m_SoundInitFailed = false;
+	bool m_ResortServerBrowser = false;
 
-	int m_aAckGameTick[NUM_DUMMIES];
-	int m_aCurrentRecvTick[NUM_DUMMIES];
-	int m_aRconAuthed[NUM_DUMMIES];
-	char m_aRconPassword[32];
-	int m_UseTempRconCommands;
-	char m_aPassword[32];
-	bool m_SendPassword;
+	int m_aAckGameTick[NUM_DUMMIES] = {0};
+	int m_aCurrentRecvTick[NUM_DUMMIES] = {0};
+	int m_aRconAuthed[NUM_DUMMIES] = {0};
+	char m_aRconPassword[32] = {0};
+	int m_UseTempRconCommands = 0;
+	char m_aPassword[32] = {0};
+	bool m_SendPassword = false;
 	bool m_ButtonRender = false;
 
 	// version-checking
-	char m_aVersionStr[10];
+	char m_aVersionStr[10] = {0};
 
 	// pinging
-	int64_t m_PingStartTime;
+	int64_t m_PingStartTime = 0;
 
-	char m_aCurrentMap[IO_MAX_PATH_LENGTH];
-	char m_aCurrentMapPath[IO_MAX_PATH_LENGTH];
+	char m_aCurrentMap[IO_MAX_PATH_LENGTH] = {0};
+	char m_aCurrentMapPath[IO_MAX_PATH_LENGTH] = {0};
 
-	char m_aTimeoutCodes[NUM_DUMMIES][32];
-	bool m_aCodeRunAfterJoin[NUM_DUMMIES];
-	bool m_GenerateTimeoutSeed;
+	char m_aaTimeoutCodes[NUM_DUMMIES][32] = {{0}};
+	bool m_aCodeRunAfterJoin[NUM_DUMMIES] = {false};
+	bool m_GenerateTimeoutSeed = false;
 
 	//
-	char m_aCmdConnect[256];
-	char m_aCmdPlayDemo[IO_MAX_PATH_LENGTH];
-	char m_aCmdEditMap[IO_MAX_PATH_LENGTH];
+	char m_aCmdConnect[256] = {0};
+	char m_aCmdPlayDemo[IO_MAX_PATH_LENGTH] = {0};
+	char m_aCmdEditMap[IO_MAX_PATH_LENGTH] = {0};
 
 	// map download
-	std::shared_ptr<CHttpRequest> m_pMapdownloadTask;
-	char m_aMapdownloadFilename[256];
-	char m_aMapdownloadFilenameTemp[256];
-	char m_aMapdownloadName[256];
+	std::shared_ptr<CHttpRequest> m_pMapdownloadTask = nullptr;
+	char m_aMapdownloadFilename[256] = {0};
+	char m_aMapdownloadFilenameTemp[256] = {0};
+	char m_aMapdownloadName[256] = {0};
 	IOHANDLE m_MapdownloadFileTemp;
-	int m_MapdownloadChunk;
-	int m_MapdownloadCrc;
-	int m_MapdownloadAmount;
-	int m_MapdownloadTotalsize;
-	bool m_MapdownloadSha256Present;
+	int m_MapdownloadChunk = 0;
+	int m_MapdownloadCrc = 0;
+	int m_MapdownloadAmount = 0;
+	int m_MapdownloadTotalsize = 0;
+	bool m_MapdownloadSha256Present = false;
 	SHA256_DIGEST m_MapdownloadSha256;
 
-	bool m_MapDetailsPresent;
-	char m_aMapDetailsName[256];
-	int m_MapDetailsCrc;
+	bool m_MapDetailsPresent = false;
+	char m_aMapDetailsName[256] = {0};
+	int m_MapDetailsCrc = 0;
 	SHA256_DIGEST m_MapDetailsSha256;
 
-	char m_aDDNetInfoTmp[64];
-	std::shared_ptr<CHttpRequest> m_pDDNetInfoTask;
+	char m_aDDNetInfoTmp[64] = {0};
+	std::shared_ptr<CHttpRequest> m_pDDNetInfoTask = nullptr;
 
 	// time
 	CSmoothTime m_aGameTime[NUM_DUMMIES];
@@ -213,16 +213,16 @@ class CClient : public IClient, public CDemoPlayer::IListener
 	// input
 	struct // TODO: handle input better
 	{
-		int m_aData[MAX_INPUT_SIZE]; // the input data
-		int m_Tick; // the tick that the input is for
-		int64_t m_PredictedTime; // prediction latency when we sent this input
-		int64_t m_PredictionMargin; // prediction margin when we sent this input
-		int64_t m_Time;
+		int m_aData[MAX_INPUT_SIZE] = {0}; // the input data
+		int m_Tick = 0; // the tick that the input is for
+		int64_t m_PredictedTime = 0; // prediction latency when we sent this input
+		int64_t m_PredictionMargin = 0; // prediction margin when we sent this input
+		int64_t m_Time = 0;
 	} m_aInputs[NUM_DUMMIES][200];
 
-	int m_aCurrentInput[NUM_DUMMIES];
-	bool m_LastDummy;
-	bool m_DummySendConnInfo;
+	int m_aCurrentInput[NUM_DUMMIES] = {0};
+	bool m_LastDummy = false;
+	bool m_DummySendConnInfo = false;
 
 	// graphs
 	CGraph m_InputtimeMarginGraph;
@@ -231,35 +231,33 @@ class CClient : public IClient, public CDemoPlayer::IListener
 
 	// the game snapshots are modifiable by the game
 	CSnapshotStorage m_aSnapshotStorage[NUM_DUMMIES];
-	CSnapshotStorage::CHolder *m_aapSnapshots[NUM_DUMMIES][NUM_SNAPSHOT_TYPES];
+	CSnapshotStorage::CHolder *m_aapSnapshots[NUM_DUMMIES][NUM_SNAPSHOT_TYPES] = {{nullptr}};
 
-	int m_aReceivedSnapshots[NUM_DUMMIES];
-	char m_aaSnapshotIncomingData[NUM_DUMMIES][CSnapshot::MAX_SIZE];
-	int m_aSnapshotIncomingDataSize[NUM_DUMMIES];
+	int m_aReceivedSnapshots[NUM_DUMMIES] = {0};
+	char m_aaSnapshotIncomingData[NUM_DUMMIES][CSnapshot::MAX_SIZE] = {{0}};
+	int m_aSnapshotIncomingDataSize[NUM_DUMMIES] = {0};
 
 	CSnapshotStorage::CHolder m_aDemorecSnapshotHolders[NUM_SNAPSHOT_TYPES];
-	char *m_aaapDemorecSnapshotData[NUM_SNAPSHOT_TYPES][2][CSnapshot::MAX_SIZE];
-
+	char *m_aaapDemorecSnapshotData[NUM_SNAPSHOT_TYPES][2][CSnapshot::MAX_SIZE] = {{{nullptr}}};
 	CSnapshotDelta m_SnapshotDelta;
 
 	std::list<std::shared_ptr<CDemoEdit>> m_lpEditJobs;
 
 	//
-	bool m_CanReceiveServerCapabilities;
-	bool m_ServerSentCapabilities;
+	bool m_CanReceiveServerCapabilities = false;
+	bool m_ServerSentCapabilities = false;
 	CServerCapabilities m_ServerCapabilities;
 
 	bool ShouldSendChatTimeoutCodeHeuristic();
 
 	CServerInfo m_CurrentServerInfo;
-	int64_t m_CurrentServerInfoRequestTime; // >= 0 should request, == -1 got info
-
-	int m_CurrentServerPingInfoType;
-	int m_CurrentServerPingBasicToken;
-	int m_CurrentServerPingToken;
+	int64_t m_CurrentServerInfoRequestTime = 0; // >= 0 should request, == -1 got info
+	int m_CurrentServerPingInfoType = 0;
+	int m_CurrentServerPingBasicToken = 0;
+	int m_CurrentServerPingToken = 0;
 	CUuid m_CurrentServerPingUuid;
-	int64_t m_CurrentServerCurrentPingTime; // >= 0 request running
-	int64_t m_CurrentServerNextPingTime; // >= 0 should request
+	int64_t m_CurrentServerCurrentPingTime = 0; // >= 0 request running
+	int64_t m_CurrentServerNextPingTime = 0; // >= 0 should request
 
 	// version info
 	struct CVersionInfo
@@ -271,7 +269,7 @@ class CClient : public IClient, public CDemoPlayer::IListener
 			STATE_READY,
 		};
 
-		int m_State;
+		int m_State = 0;
 		class CHostLookup m_VersionServeraddr;
 	} m_VersionInfo;
 
@@ -285,7 +283,7 @@ class CClient : public IClient, public CDemoPlayer::IListener
 #endif
 
 	IOHANDLE m_BenchmarkFile;
-	int64_t m_BenchmarkStopTime;
+	int64_t m_BenchmarkStopTime = 0;
 
 	CChecksum m_Checksum;
 	int m_OwnExecutableSize = 0;
@@ -361,8 +359,8 @@ public:
 	bool DummyConnected() override;
 	bool DummyConnecting() override;
 	bool DummyAllowed() override;
-	int m_DummyConnected;
-	int m_LastDummyConnectTime;
+	int m_DummyConnected = 0;
+	int m_LastDummyConnectTime = 0;
 
 	void GetServerInfo(CServerInfo *pServerInfo) const override;
 	void ServerInfoRequest();

--- a/src/engine/client/demoedit.h
+++ b/src/engine/client/demoedit.h
@@ -10,14 +10,14 @@ class IStorage;
 class CDemoEdit : public IJob
 {
 	CSnapshotDelta m_SnapshotDelta;
-	IStorage *m_pStorage;
+	IStorage *m_pStorage = nullptr;
 
 	CDemoEditor m_DemoEditor;
 
-	char m_aDemo[256];
-	char m_aDst[256];
-	int m_StartTick;
-	int m_EndTick;
+	char m_aDemo[256] = {0};
+	char m_aDst[256] = {0};
+	int m_StartTick = 0;
+	int m_EndTick = 0;
 
 public:
 	CDemoEdit(const char *pNetVersion, CSnapshotDelta *pSnapshotDelta, IStorage *pStorage, const char *pDemo, const char *pDst, int StartTick, int EndTick);

--- a/src/engine/client/discord.cpp
+++ b/src/engine/client/discord.cpp
@@ -28,9 +28,9 @@ FDiscordCreate GetDiscordCreate()
 
 class CDiscord : public IDiscord
 {
-	IDiscordCore *m_pCore;
+	IDiscordCore *m_pCore = nullptr;
 	IDiscordActivityEvents m_ActivityEvents;
-	IDiscordActivityManager *m_pActivityManager;
+	IDiscordActivityManager *m_pActivityManager = nullptr;
 
 public:
 	bool Init(FDiscordCreate pfnDiscordCreate)

--- a/src/engine/client/favorites.cpp
+++ b/src/engine/client/favorites.cpp
@@ -156,7 +156,7 @@ void CFavorites::Add(const NETADDR *pAddrs, int NumAddrs)
 	}
 	// Add the new entry.
 	CEntry NewEntry;
-	mem_zero(&NewEntry, sizeof(NewEntry));
+	mem_zero(NewEntry.m_aAddrs, sizeof(NewEntry.m_aAddrs));
 	NewEntry.m_NumAddrs = std::min(NumAddrs, (int)std::size(NewEntry.m_aAddrs));
 	for(int i = 0; i < NewEntry.m_NumAddrs; i++)
 	{

--- a/src/engine/client/friends.cpp
+++ b/src/engine/client/friends.cpp
@@ -11,7 +11,7 @@
 
 CFriends::CFriends()
 {
-	mem_zero(m_aFriends, sizeof(m_aFriends));
+	new(m_aFriends) std::remove_pointer<decltype(m_aFriends)>::type;
 	m_NumFriends = 0;
 	m_Foes = false;
 }

--- a/src/engine/client/friends.h
+++ b/src/engine/client/friends.h
@@ -11,8 +11,8 @@ class IConfigManager;
 class CFriends : public IFriends
 {
 	CFriendInfo m_aFriends[MAX_FRIENDS];
-	int m_Foes;
-	int m_NumFriends;
+	int m_Foes = 0;
+	int m_NumFriends = 0;
 
 	static void ConAddFriend(IConsole::IResult *pResult, void *pUserData);
 	static void ConRemoveFriend(IConsole::IResult *pResult, void *pUserData);

--- a/src/engine/client/ghost.cpp
+++ b/src/engine/client/ghost.cpp
@@ -39,7 +39,7 @@ int CGhostRecorder::Start(const char *pFilename, const char *pMap, SHA256_DIGEST
 
 	// write header
 	CGhostHeader Header;
-	mem_zero(&Header, sizeof(Header));
+	dbg_assert(mem_is_null(&Header, sizeof(Header)), "mem not null");
 	mem_copy(Header.m_aMarker, gs_aHeaderMarker, sizeof(Header.m_aMarker));
 	Header.m_Version = gs_CurVersion;
 	str_copy(Header.m_aOwner, pName);
@@ -189,7 +189,7 @@ int CGhostLoader::Load(const char *pFilename, const char *pMap, SHA256_DIGEST Ma
 	}
 
 	// read the header
-	mem_zero(&m_Header, sizeof(m_Header));
+	m_Header = CGhostHeader();
 	io_read(m_File, &m_Header, sizeof(CGhostHeader));
 	if(mem_comp(m_Header.m_aMarker, gs_aHeaderMarker, sizeof(gs_aHeaderMarker)) != 0)
 	{
@@ -364,7 +364,7 @@ void CGhostLoader::Close()
 bool CGhostLoader::GetGhostInfo(const char *pFilename, CGhostInfo *pGhostInfo, const char *pMap, SHA256_DIGEST MapSha256, unsigned MapCrc)
 {
 	CGhostHeader Header;
-	mem_zero(&Header, sizeof(Header));
+	dbg_assert(mem_is_null(&Header, sizeof(Header)), "mem not null");
 
 	IOHANDLE File = m_pStorage->OpenFile(pFilename, IOFLAG_READ, IStorage::TYPE_SAVE);
 	if(!File)

--- a/src/engine/client/ghost.h
+++ b/src/engine/client/ghost.h
@@ -12,13 +12,13 @@ enum
 // version 4-6
 struct CGhostHeader
 {
-	unsigned char m_aMarker[8];
-	unsigned char m_Version;
-	char m_aOwner[MAX_NAME_LENGTH];
-	char m_aMap[64];
-	unsigned char m_aZeroes[4]; // Crc before version 6
-	unsigned char m_aNumTicks[4];
-	unsigned char m_aTime[4];
+	unsigned char m_aMarker[8] = {0};
+	unsigned char m_Version = 0;
+	char m_aOwner[MAX_NAME_LENGTH] = {0};
+	char m_aMap[64] = {0};
+	unsigned char m_aZeroes[4] = {0}; // Crc before version 6
+	unsigned char m_aNumTicks[4] = {0};
+	unsigned char m_aTime[4] = {0};
 	SHA256_DIGEST m_MapSha256;
 
 	int GetTicks() const
@@ -46,8 +46,8 @@ struct CGhostHeader
 class CGhostItem
 {
 public:
-	unsigned char m_aData[MAX_ITEM_SIZE];
-	int m_Type;
+	unsigned char m_aData[MAX_ITEM_SIZE] = {0};
+	int m_Type = 0;
 
 	CGhostItem() :
 		m_Type(-1) {}
@@ -59,14 +59,14 @@ public:
 class CGhostRecorder : public IGhostRecorder
 {
 	IOHANDLE m_File;
-	class IConsole *m_pConsole;
-	class IStorage *m_pStorage;
+	class IConsole *m_pConsole = nullptr;
+	class IStorage *m_pStorage = nullptr;
 
 	CGhostItem m_LastItem;
 
-	char m_aBuffer[MAX_ITEM_SIZE * NUM_ITEMS_PER_CHUNK];
-	char *m_pBufferPos;
-	int m_BufferNumItems;
+	char m_aBuffer[MAX_ITEM_SIZE * NUM_ITEMS_PER_CHUNK] = {0};
+	char *m_pBufferPos = nullptr;
+	int m_BufferNumItems = 0;
 
 	void ResetBuffer();
 	void FlushChunk();
@@ -86,19 +86,19 @@ public:
 class CGhostLoader : public IGhostLoader
 {
 	IOHANDLE m_File;
-	class IConsole *m_pConsole;
-	class IStorage *m_pStorage;
+	class IConsole *m_pConsole = nullptr;
+	class IStorage *m_pStorage = nullptr;
 
 	CGhostHeader m_Header;
 	CGhostInfo m_Info;
 
 	CGhostItem m_LastItem;
 
-	char m_aBuffer[MAX_ITEM_SIZE * NUM_ITEMS_PER_CHUNK];
-	char *m_pBufferPos;
-	int m_BufferNumItems;
-	int m_BufferCurItem;
-	int m_BufferPrevItem;
+	char m_aBuffer[MAX_ITEM_SIZE * NUM_ITEMS_PER_CHUNK] = {0};
+	char *m_pBufferPos = nullptr;
+	int m_BufferNumItems = 0;
+	int m_BufferCurItem = 0;
+	int m_BufferPrevItem = 0;
 
 	void ResetBuffer();
 	int ReadChunk(int *pType);

--- a/src/engine/client/ghost.h
+++ b/src/engine/client/ghost.h
@@ -34,7 +34,7 @@ struct CGhostHeader
 	CGhostInfo ToGhostInfo() const
 	{
 		CGhostInfo Result;
-		mem_zero(&Result, sizeof(Result));
+		dbg_assert(mem_is_null(&Result, sizeof(Result)), "mem not null");
 		str_copy(Result.m_aOwner, m_aOwner);
 		str_copy(Result.m_aMap, m_aMap);
 		Result.m_NumTicks = GetTicks();

--- a/src/engine/client/graphics_threaded.h
+++ b/src/engine/client/graphics_threaded.h
@@ -14,15 +14,15 @@ class CCommandBuffer
 {
 	class CBuffer
 	{
-		unsigned char *m_pData;
-		unsigned m_Size;
-		unsigned m_Used;
+		unsigned char *m_pData = nullptr;
+		unsigned m_Size = 0;
+		unsigned m_Used = 0;
 
 	public:
 		CBuffer(unsigned BufferSize)
 		{
 			m_Size = BufferSize;
-			m_pData = new unsigned char[m_Size];
+			m_pData = new unsigned char[m_Size]{0};
 			m_Used = 0;
 		}
 
@@ -188,26 +188,26 @@ public:
 	public:
 		SCommand(unsigned Cmd) :
 			m_Cmd(Cmd), m_pNext(nullptr) {}
-		unsigned m_Cmd;
-		SCommand *m_pNext;
+		unsigned m_Cmd = 0;
+		SCommand *m_pNext = nullptr;
 	};
-	SCommand *m_pCmdBufferHead;
-	SCommand *m_pCmdBufferTail;
+	SCommand *m_pCmdBufferHead = nullptr;
+	SCommand *m_pCmdBufferTail = nullptr;
 
 	struct SState
 	{
-		int m_BlendMode;
-		int m_WrapMode;
-		int m_Texture;
+		int m_BlendMode = 0;
+		int m_WrapMode = 0;
+		int m_Texture = 0;
 		SPoint m_ScreenTL;
 		SPoint m_ScreenBR;
 
 		// clip
-		bool m_ClipEnable;
-		int m_ClipX;
-		int m_ClipY;
-		int m_ClipW;
-		int m_ClipH;
+		bool m_ClipEnable = false;
+		int m_ClipX = 0;
+		int m_ClipY = 0;
+		int m_ClipW = 0;
+		int m_ClipH = 0;
 	};
 
 	struct SCommand_Clear : public SCommand
@@ -215,21 +215,21 @@ public:
 		SCommand_Clear() :
 			SCommand(CMD_CLEAR) {}
 		SColorf m_Color;
-		bool m_ForceClear;
+		bool m_ForceClear = false;
 	};
 
 	struct SCommand_Signal : public SCommand
 	{
 		SCommand_Signal() :
 			SCommand(CMD_SIGNAL) {}
-		CSemaphore *m_pSemaphore;
+		CSemaphore *m_pSemaphore = nullptr;
 	};
 
 	struct SCommand_RunBuffer : public SCommand
 	{
 		SCommand_RunBuffer() :
 			SCommand(CMD_RUNBUFFER) {}
-		CCommandBuffer *m_pOtherBuffer;
+		CCommandBuffer *m_pOtherBuffer = nullptr;
 	};
 
 	struct SCommand_Render : public SCommand
@@ -237,9 +237,9 @@ public:
 		SCommand_Render() :
 			SCommand(CMD_RENDER) {}
 		SState m_State;
-		unsigned m_PrimType;
-		unsigned m_PrimCount;
-		SVertex *m_pVertices; // you should use the command buffer data to allocate vertices for this command
+		unsigned m_PrimType = 0;
+		unsigned m_PrimCount = 0;
+		SVertex *m_pVertices = nullptr; // you should use the command buffer data to allocate vertices for this command
 	};
 
 	struct SCommand_RenderTex3D : public SCommand
@@ -247,9 +247,9 @@ public:
 		SCommand_RenderTex3D() :
 			SCommand(CMD_RENDER_TEX3D) {}
 		SState m_State;
-		unsigned m_PrimType;
-		unsigned m_PrimCount;
-		SVertexTex3DStream *m_pVertices; // you should use the command buffer data to allocate vertices for this command
+		unsigned m_PrimType = 0;
+		unsigned m_PrimCount = 0;
+		SVertexTex3DStream *m_pVertices = nullptr; // you should use the command buffer data to allocate vertices for this command
 	};
 
 	struct SCommand_CreateBufferObject : public SCommand
@@ -257,13 +257,13 @@ public:
 		SCommand_CreateBufferObject() :
 			SCommand(CMD_CREATE_BUFFER_OBJECT) {}
 
-		int m_BufferIndex;
+		int m_BufferIndex = 0;
 
-		bool m_DeletePointer;
-		void *m_pUploadData;
-		size_t m_DataSize;
+		bool m_DeletePointer = false;
+		void *m_pUploadData = nullptr;
+		size_t m_DataSize = 0;
 
-		int m_Flags; // @see EBufferObjectCreateFlags
+		int m_Flags = 0; // @see EBufferObjectCreateFlags
 	};
 
 	struct SCommand_RecreateBufferObject : public SCommand
@@ -271,13 +271,13 @@ public:
 		SCommand_RecreateBufferObject() :
 			SCommand(CMD_RECREATE_BUFFER_OBJECT) {}
 
-		int m_BufferIndex;
+		int m_BufferIndex = 0;
 
-		bool m_DeletePointer;
-		void *m_pUploadData;
-		size_t m_DataSize;
+		bool m_DeletePointer = false;
+		void *m_pUploadData = nullptr;
+		size_t m_DataSize = 0;
 
-		int m_Flags; // @see EBufferObjectCreateFlags
+		int m_Flags = 0; // @see EBufferObjectCreateFlags
 	};
 
 	struct SCommand_UpdateBufferObject : public SCommand
@@ -285,12 +285,12 @@ public:
 		SCommand_UpdateBufferObject() :
 			SCommand(CMD_UPDATE_BUFFER_OBJECT) {}
 
-		int m_BufferIndex;
+		int m_BufferIndex = 0;
 
-		bool m_DeletePointer;
-		void *m_pOffset;
-		void *m_pUploadData;
-		size_t m_DataSize;
+		bool m_DeletePointer = false;
+		void *m_pOffset = nullptr;
+		void *m_pUploadData = nullptr;
+		size_t m_DataSize = 0;
 	};
 
 	struct SCommand_CopyBufferObject : public SCommand
@@ -298,12 +298,12 @@ public:
 		SCommand_CopyBufferObject() :
 			SCommand(CMD_COPY_BUFFER_OBJECT) {}
 
-		int m_WriteBufferIndex;
-		int m_ReadBufferIndex;
+		int m_WriteBufferIndex = 0;
+		int m_ReadBufferIndex = 0;
 
-		size_t m_ReadOffset;
-		size_t m_WriteOffset;
-		size_t m_CopySize;
+		size_t m_ReadOffset = 0;
+		size_t m_WriteOffset = 0;
+		size_t m_CopySize = 0;
 	};
 
 	struct SCommand_DeleteBufferObject : public SCommand
@@ -311,7 +311,7 @@ public:
 		SCommand_DeleteBufferObject() :
 			SCommand(CMD_DELETE_BUFFER_OBJECT) {}
 
-		int m_BufferIndex;
+		int m_BufferIndex = 0;
 	};
 
 	struct SCommand_CreateBufferContainer : public SCommand
@@ -319,13 +319,13 @@ public:
 		SCommand_CreateBufferContainer() :
 			SCommand(CMD_CREATE_BUFFER_CONTAINER) {}
 
-		int m_BufferContainerIndex;
+		int m_BufferContainerIndex = 0;
 
-		int m_Stride;
-		int m_VertBufferBindingIndex;
+		int m_Stride = 0;
+		int m_VertBufferBindingIndex = 0;
 
-		int m_AttrCount;
-		SBufferContainerInfo::SAttribute *m_pAttributes;
+		int m_AttrCount = 0;
+		SBufferContainerInfo::SAttribute *m_pAttributes = nullptr;
 	};
 
 	struct SCommand_UpdateBufferContainer : public SCommand
@@ -333,13 +333,13 @@ public:
 		SCommand_UpdateBufferContainer() :
 			SCommand(CMD_UPDATE_BUFFER_CONTAINER) {}
 
-		int m_BufferContainerIndex;
+		int m_BufferContainerIndex = 0;
 
-		int m_Stride;
-		int m_VertBufferBindingIndex;
+		int m_Stride = 0;
+		int m_VertBufferBindingIndex = 0;
 
-		int m_AttrCount;
-		SBufferContainerInfo::SAttribute *m_pAttributes;
+		int m_AttrCount = 0;
+		SBufferContainerInfo::SAttribute *m_pAttributes = nullptr;
 	};
 
 	struct SCommand_DeleteBufferContainer : public SCommand
@@ -347,8 +347,8 @@ public:
 		SCommand_DeleteBufferContainer() :
 			SCommand(CMD_DELETE_BUFFER_CONTAINER) {}
 
-		int m_BufferContainerIndex;
-		bool m_DestroyAllBO;
+		int m_BufferContainerIndex = 0;
+		bool m_DestroyAllBO = false;
 	};
 
 	struct SCommand_IndicesRequiredNumNotify : public SCommand
@@ -356,7 +356,7 @@ public:
 		SCommand_IndicesRequiredNumNotify() :
 			SCommand(CMD_INDICES_REQUIRED_NUM_NOTIFY) {}
 
-		unsigned int m_RequiredIndicesNum;
+		unsigned int m_RequiredIndicesNum = 0;
 	};
 
 	struct SCommand_RenderTileLayer : public SCommand
@@ -367,11 +367,11 @@ public:
 		SColorf m_Color; // the color of the whole tilelayer -- already envelopped
 
 		// the char offset of all indices that should be rendered, and the amount of renders
-		char **m_pIndicesOffsets;
-		unsigned int *m_pDrawCount;
+		char **m_pIndicesOffsets = nullptr;
+		unsigned int *m_pDrawCount = nullptr;
 
-		int m_IndicesDrawNum;
-		int m_BufferContainerIndex;
+		int m_IndicesDrawNum = 0;
+		int m_BufferContainerIndex = 0;
 	};
 
 	struct SCommand_RenderBorderTile : public SCommand
@@ -380,13 +380,13 @@ public:
 			SCommand(CMD_RENDER_BORDER_TILE) {}
 		SState m_State;
 		SColorf m_Color; // the color of the whole tilelayer -- already envelopped
-		char *m_pIndicesOffset; // you should use the command buffer data to allocate vertices for this command
-		unsigned int m_DrawNum;
-		int m_BufferContainerIndex;
+		char *m_pIndicesOffset = nullptr; // you should use the command buffer data to allocate vertices for this command
+		unsigned int m_DrawNum = 0;
+		int m_BufferContainerIndex = 0;
 
 		vec2 m_Offset;
 		vec2 m_Dir;
-		int m_JumpIndex;
+		int m_JumpIndex = 0;
 	};
 
 	struct SCommand_RenderBorderTileLine : public SCommand
@@ -395,10 +395,10 @@ public:
 			SCommand(CMD_RENDER_BORDER_TILE_LINE) {}
 		SState m_State;
 		SColorf m_Color; // the color of the whole tilelayer -- already envelopped
-		char *m_pIndicesOffset; // you should use the command buffer data to allocate vertices for this command
-		unsigned int m_IndexDrawNum;
-		unsigned int m_DrawNum;
-		int m_BufferContainerIndex;
+		char *m_pIndicesOffset = nullptr; // you should use the command buffer data to allocate vertices for this command
+		unsigned int m_IndexDrawNum = 0;
+		unsigned int m_DrawNum = 0;
+		int m_BufferContainerIndex = 0;
 
 		vec2 m_Offset;
 		vec2 m_Dir;
@@ -410,10 +410,10 @@ public:
 			SCommand(CMD_RENDER_QUAD_LAYER) {}
 		SState m_State;
 
-		int m_BufferContainerIndex;
-		SQuadRenderInfo *m_pQuadInfo;
-		int m_QuadNum;
-		int m_QuadOffset;
+		int m_BufferContainerIndex = 0;
+		SQuadRenderInfo *m_pQuadInfo = nullptr;
+		int m_QuadNum = 0;
+		int m_QuadOffset = 0;
 	};
 
 	struct SCommand_RenderText : public SCommand
@@ -422,13 +422,13 @@ public:
 			SCommand(CMD_RENDER_TEXT) {}
 		SState m_State;
 
-		int m_BufferContainerIndex;
-		int m_TextureSize;
+		int m_BufferContainerIndex = 0;
+		int m_TextureSize = 0;
 
-		int m_TextTextureIndex;
-		int m_TextOutlineTextureIndex;
+		int m_TextTextureIndex = 0;
+		int m_TextOutlineTextureIndex = 0;
 
-		int m_DrawNum;
+		int m_DrawNum = 0;
 		ColorRGBA m_TextColor;
 		ColorRGBA m_TextOutlineColor;
 	};
@@ -439,10 +439,10 @@ public:
 			SCommand(CMD_RENDER_QUAD_CONTAINER) {}
 		SState m_State;
 
-		int m_BufferContainerIndex;
+		int m_BufferContainerIndex = 0;
 
-		unsigned int m_DrawNum;
-		void *m_pOffset;
+		unsigned int m_DrawNum = 0;
+		void *m_pOffset = nullptr;
 	};
 
 	struct SCommand_RenderQuadContainerEx : public SCommand
@@ -451,15 +451,15 @@ public:
 			SCommand(CMD_RENDER_QUAD_CONTAINER_EX) {}
 		SState m_State;
 
-		int m_BufferContainerIndex;
+		int m_BufferContainerIndex = 0;
 
-		float m_Rotation;
+		float m_Rotation = 0;
 		SPoint m_Center;
 
 		SColorf m_VertexColor;
 
-		unsigned int m_DrawNum;
-		void *m_pOffset;
+		unsigned int m_DrawNum = 0;
+		void *m_pOffset = nullptr;
 	};
 
 	struct SCommand_RenderQuadContainerAsSpriteMultiple : public SCommand
@@ -468,24 +468,24 @@ public:
 			SCommand(CMD_RENDER_QUAD_CONTAINER_SPRITE_MULTIPLE) {}
 		SState m_State;
 
-		int m_BufferContainerIndex;
+		int m_BufferContainerIndex = 0;
 
-		IGraphics::SRenderSpriteInfo *m_pRenderInfo;
+		IGraphics::SRenderSpriteInfo *m_pRenderInfo = nullptr;
 
 		SPoint m_Center;
 		SColorf m_VertexColor;
 
-		unsigned int m_DrawNum;
-		unsigned int m_DrawCount;
-		void *m_pOffset;
+		unsigned int m_DrawNum = 0;
+		unsigned int m_DrawCount = 0;
+		void *m_pOffset = nullptr;
 	};
 
 	struct SCommand_TrySwapAndScreenshot : public SCommand
 	{
 		SCommand_TrySwapAndScreenshot() :
 			SCommand(CMD_TRY_SWAP_AND_SCREENSHOT) {}
-		CImageInfo *m_pImage; // processor will fill this out, the one who adds this command must free the data as well
-		bool *m_pSwapped;
+		CImageInfo *m_pImage = nullptr; // processor will fill this out, the one who adds this command must free the data as well
+		bool *m_pSwapped = nullptr;
 	};
 
 	struct SCommand_Swap : public SCommand
@@ -505,8 +505,8 @@ public:
 		SCommand_VSync() :
 			SCommand(CMD_VSYNC) {}
 
-		int m_VSync;
-		bool *m_pRetOk;
+		int m_VSync = 0;
+		bool *m_pRetOk = nullptr;
 	};
 
 	struct SCommand_MultiSampling : public SCommand
@@ -514,9 +514,9 @@ public:
 		SCommand_MultiSampling() :
 			SCommand(CMD_MULTISAMPLING) {}
 
-		uint32_t m_RequestedMultiSamplingCount;
-		uint32_t *m_pRetMultiSamplingCount;
-		bool *m_pRetOk;
+		uint32_t m_RequestedMultiSamplingCount = 0;
+		uint32_t *m_pRetMultiSamplingCount = nullptr;
+		bool *m_pRetOk = nullptr;
 	};
 
 	struct SCommand_Update_Viewport : public SCommand
@@ -524,11 +524,11 @@ public:
 		SCommand_Update_Viewport() :
 			SCommand(CMD_UPDATE_VIEWPORT) {}
 
-		int m_X;
-		int m_Y;
-		int m_Width;
-		int m_Height;
-		bool m_ByResize; // resized by an resize event.. a hint to make clear that the viewport update can be deferred if wanted
+		int m_X = 0;
+		int m_Y = 0;
+		int m_Width = 0;
+		int m_Height = 0;
+		bool m_ByResize = false; // resized by an resize event.. a hint to make clear that the viewport update can be deferred if wanted
 	};
 
 	struct SCommand_Texture_Create : public SCommand
@@ -537,15 +537,15 @@ public:
 			SCommand(CMD_TEXTURE_CREATE) {}
 
 		// texture information
-		int m_Slot;
+		int m_Slot = 0;
 
-		int m_Width;
-		int m_Height;
-		int m_PixelSize;
-		int m_Format;
-		int m_StoreFormat;
-		int m_Flags;
-		void *m_pData; // will be freed by the command processor
+		int m_Width = 0;
+		int m_Height = 0;
+		int m_PixelSize = 0;
+		int m_Format = 0;
+		int m_StoreFormat = 0;
+		int m_Flags = 0;
+		void *m_pData = nullptr; // will be freed by the command processor
 	};
 
 	struct SCommand_Texture_Update : public SCommand
@@ -554,14 +554,14 @@ public:
 			SCommand(CMD_TEXTURE_UPDATE) {}
 
 		// texture information
-		int m_Slot;
+		int m_Slot = 0;
 
-		int m_X;
-		int m_Y;
-		int m_Width;
-		int m_Height;
-		int m_Format;
-		void *m_pData; // will be freed by the command processor
+		int m_X = 0;
+		int m_Y = 0;
+		int m_Width = 0;
+		int m_Height = 0;
+		int m_Format = 0;
+		void *m_pData = nullptr; // will be freed by the command processor
 	};
 
 	struct SCommand_Texture_Destroy : public SCommand
@@ -570,7 +570,7 @@ public:
 			SCommand(CMD_TEXTURE_DESTROY) {}
 
 		// texture information
-		int m_Slot;
+		int m_Slot = 0;
 	};
 
 	struct SCommand_TextTextures_Create : public SCommand
@@ -579,14 +579,14 @@ public:
 			SCommand(CMD_TEXT_TEXTURES_CREATE) {}
 
 		// texture information
-		int m_Slot;
-		int m_SlotOutline;
+		int m_Slot = 0;
+		int m_SlotOutline = 0;
 
-		int m_Width;
-		int m_Height;
+		int m_Width = 0;
+		int m_Height = 0;
 
-		void *m_pTextData;
-		void *m_pTextOutlineData;
+		void *m_pTextData = nullptr;
+		void *m_pTextOutlineData = nullptr;
 	};
 
 	struct SCommand_TextTextures_Destroy : public SCommand
@@ -595,8 +595,8 @@ public:
 			SCommand(CMD_TEXT_TEXTURES_DESTROY) {}
 
 		// texture information
-		int m_Slot;
-		int m_SlotOutline;
+		int m_Slot = 0;
+		int m_SlotOutline = 0;
 	};
 
 	struct SCommand_TextTexture_Update : public SCommand
@@ -605,13 +605,13 @@ public:
 			SCommand(CMD_TEXT_TEXTURE_UPDATE) {}
 
 		// texture information
-		int m_Slot;
+		int m_Slot = 0;
 
-		int m_X;
-		int m_Y;
-		int m_Width;
-		int m_Height;
-		void *m_pData; // will be freed by the command processor
+		int m_X = 0;
+		int m_Y = 0;
+		int m_Width = 0;
+		int m_Height = 0;
+		void *m_pData = nullptr; // will be freed by the command processor
 	};
 
 	struct SCommand_WindowCreateNtf : public CCommandBuffer::SCommand
@@ -619,7 +619,7 @@ public:
 		SCommand_WindowCreateNtf() :
 			SCommand(CMD_WINDOW_CREATE_NTF) {}
 
-		uint32_t m_WindowID;
+		uint32_t m_WindowID = 0;
 	};
 
 	struct SCommand_WindowDestroyNtf : public CCommandBuffer::SCommand
@@ -627,7 +627,7 @@ public:
 		SCommand_WindowDestroyNtf() :
 			SCommand(CMD_WINDOW_DESTROY_NTF) {}
 
-		uint32_t m_WindowID;
+		uint32_t m_WindowID = 0;
 	};
 
 	//
@@ -784,43 +784,43 @@ class CGraphics_Threaded : public IEngineGraphics
 	};
 
 	CCommandBuffer::SState m_State;
-	IGraphicsBackend *m_pBackend;
-	bool m_GLTileBufferingEnabled;
-	bool m_GLQuadBufferingEnabled;
-	bool m_GLTextBufferingEnabled;
-	bool m_GLQuadContainerBufferingEnabled;
-	bool m_GLHasTextureArrays;
-	bool m_GLUseTrianglesAsQuad;
+	IGraphicsBackend *m_pBackend = nullptr;
+	bool m_GLTileBufferingEnabled = false;
+	bool m_GLQuadBufferingEnabled = false;
+	bool m_GLTextBufferingEnabled = false;
+	bool m_GLQuadContainerBufferingEnabled = false;
+	bool m_GLHasTextureArrays = false;
+	bool m_GLUseTrianglesAsQuad = false;
 
-	CCommandBuffer *m_apCommandBuffers[NUM_CMDBUFFERS];
-	CCommandBuffer *m_pCommandBuffer;
-	unsigned m_CurrentCommandBuffer;
+	CCommandBuffer *m_apCommandBuffers[NUM_CMDBUFFERS] = {nullptr};
+	CCommandBuffer *m_pCommandBuffer = nullptr;
+	unsigned m_CurrentCommandBuffer = 0;
 
 	//
-	class IStorage *m_pStorage;
-	class IConsole *m_pConsole;
+	class IStorage *m_pStorage = nullptr;
+	class IConsole *m_pConsole = nullptr;
 
-	int m_CurIndex;
+	int m_CurIndex = 0;
 
 	CCommandBuffer::SVertex m_aVertices[CCommandBuffer::MAX_VERTICES];
 	CCommandBuffer::SVertexTex3DStream m_aVerticesTex3D[CCommandBuffer::MAX_VERTICES];
-	int m_NumVertices;
+	int m_NumVertices = 0;
 
 	CCommandBuffer::SColor m_aColor[4];
 	CCommandBuffer::STexCoord m_aTexture[4];
 
-	bool m_RenderEnable;
+	bool m_RenderEnable = false;
 
-	float m_Rotation;
-	int m_Drawing;
-	bool m_DoScreenshot;
-	char m_aScreenshotName[128];
+	float m_Rotation = 0;
+	int m_Drawing = 0;
+	bool m_DoScreenshot = false;
+	char m_aScreenshotName[128] = {0};
 
 	CTextureHandle m_InvalidTexture;
 
 	std::vector<int> m_vTextureIndices;
-	int m_FirstFreeTexture;
-	int m_TextureMemoryUsage;
+	int m_FirstFreeTexture = 0;
+	int m_TextureMemoryUsage = 0;
 
 	std::vector<uint8_t> m_vSpriteHelper;
 
@@ -837,15 +837,15 @@ class CGraphics_Threaded : public IEngineGraphics
 		SVertexArrayInfo() :
 			m_FreeIndex(-1) {}
 		// keep a reference to it, so we can free the ID
-		int m_AssociatedBufferObjectIndex;
+		int m_AssociatedBufferObjectIndex = 0;
 
-		int m_FreeIndex;
+		int m_FreeIndex = 0;
 	};
 	std::vector<SVertexArrayInfo> m_vVertexArrayInfo;
-	int m_FirstFreeVertexArrayInfo;
+	int m_FirstFreeVertexArrayInfo = 0;
 
 	std::vector<int> m_vBufferObjectIndices;
-	int m_FirstFreeBufferObjectIndex;
+	int m_FirstFreeBufferObjectIndex = 0;
 
 	struct SQuadContainer
 	{
@@ -865,22 +865,22 @@ class CGraphics_Threaded : public IEngineGraphics
 
 		std::vector<SQuad> m_vQuads;
 
-		int m_QuadBufferObjectIndex;
-		int m_QuadBufferContainerIndex;
+		int m_QuadBufferObjectIndex = 0;
+		int m_QuadBufferContainerIndex = 0;
 
-		int m_FreeIndex;
+		int m_FreeIndex = 0;
 
-		bool m_AutomaticUpload;
+		bool m_AutomaticUpload = false;
 	};
 	std::vector<SQuadContainer> m_vQuadContainers;
-	int m_FirstFreeQuadContainer;
+	int m_FirstFreeQuadContainer = 0;
 
 	struct SWindowResizeListener
 	{
 		SWindowResizeListener(WINDOW_RESIZE_FUNC pFunc, void *pUser) :
 			m_pFunc(std::move(pFunc)), m_pUser(pUser) {}
-		WINDOW_RESIZE_FUNC m_pFunc;
-		void *m_pUser;
+		WINDOW_RESIZE_FUNC m_pFunc = nullptr;
+		void *m_pUser = nullptr;
 	};
 	std::vector<SWindowResizeListener> m_vResizeListeners;
 
@@ -896,7 +896,7 @@ class CGraphics_Threaded : public IEngineGraphics
 		float c = cosf(m_Rotation);
 		float s = sinf(m_Rotation);
 		float x, y;
-		int i;
+		int i = 0;
 
 		TName *pVertices = pPoints;
 		for(i = 0; i < NumPoints; i++)

--- a/src/engine/client/input.h
+++ b/src/engine/client/input.h
@@ -13,16 +13,16 @@ class CInput : public IEngineInput
 public:
 	class CJoystick : public IJoystick
 	{
-		CInput *m_pInput;
-		int m_Index;
-		char m_aName[64];
-		char m_aGUID[34];
+		CInput *m_pInput = nullptr;
+		int m_Index = 0;
+		char m_aName[64] = {0};
+		char m_aGUID[34] = {0};
 		SDL_JoystickID m_InstanceID;
-		int m_NumAxes;
-		int m_NumButtons;
-		int m_NumBalls;
-		int m_NumHats;
-		SDL_Joystick *m_pDelegate;
+		int m_NumAxes = 0;
+		int m_NumButtons = 0;
+		int m_NumBalls = 0;
+		int m_NumHats = 0;
+		SDL_Joystick *m_pDelegate = nullptr;
 
 		CInput *Input() { return m_pInput; }
 
@@ -48,8 +48,8 @@ public:
 	};
 
 private:
-	IEngineGraphics *m_pGraphics;
-	IConsole *m_pConsole;
+	IEngineGraphics *m_pGraphics = nullptr;
+	IConsole *m_pConsole = nullptr;
 
 	IEngineGraphics *Graphics() { return m_pGraphics; }
 	IConsole *Console() { return m_pConsole; }
@@ -63,22 +63,22 @@ private:
 	static void ConchainJoystickGuidChanged(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 	float GetJoystickDeadzone();
 
-	int m_InputGrabbed;
-	char *m_pClipboardText;
+	int m_InputGrabbed = 0;
+	char *m_pClipboardText = nullptr;
 
-	bool m_MouseFocus;
-	bool m_MouseDoubleClick;
+	bool m_MouseFocus = false;
+	bool m_MouseDoubleClick = false;
 
-	int m_VideoRestartNeeded;
+	int m_VideoRestartNeeded = 0;
 
 	void AddEvent(char *pText, int Key, int Flags);
 	void Clear() override;
 	bool IsEventValid(CEvent *pEvent) const override { return pEvent->m_InputCount == m_InputCounter; }
 
 	// quick access to input
-	unsigned short m_aInputCount[g_MaxKeys]; // tw-KEY
-	unsigned char m_aInputState[g_MaxKeys]; // SDL_SCANCODE
-	int m_InputCounter;
+	unsigned short m_aInputCount[g_MaxKeys] = {0}; // tw-KEY
+	unsigned char m_aInputState[g_MaxKeys] = {0}; // SDL_SCANCODE
+	int m_InputCounter = 0;
 
 	void UpdateMouseState();
 	void UpdateJoystickState();
@@ -87,10 +87,10 @@ private:
 	void HandleJoystickHatMotionEvent(const SDL_Event &Event);
 
 	// IME support
-	int m_NumTextInputInstances;
-	char m_aEditingText[INPUT_TEXT_SIZE];
-	int m_EditingTextLen;
-	int m_EditingCursor;
+	int m_NumTextInputInstances = 0;
+	char m_aEditingText[INPUT_TEXT_SIZE] = {0};
+	int m_EditingTextLen = 0;
+	int m_EditingCursor = 0;
 
 	bool KeyState(int Key) const;
 

--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -37,8 +37,8 @@
 class SortWrap
 {
 	typedef bool (CServerBrowser::*SortFunc)(int, int) const;
-	SortFunc m_pfnSort;
-	CServerBrowser *m_pThis;
+	SortFunc m_pfnSort = nullptr;
+	CServerBrowser *m_pThis = nullptr;
 
 public:
 	SortWrap(CServerBrowser *pServer, SortFunc Func) :
@@ -120,7 +120,7 @@ void CServerBrowser::Con_LeakIpAddress(IConsole::IResult *pResult, void *pUserDa
 	class CAddrComparer
 	{
 	public:
-		CServerBrowser *m_pThis;
+		CServerBrowser *m_pThis = nullptr;
 		bool operator()(int i, int j)
 		{
 			NETADDR Addr1 = m_pThis->m_ppServerlist[i]->m_Info.m_aAddresses[0];
@@ -975,7 +975,7 @@ void CServerBrowser::UpdateFromHttp()
 					if(g >= pCntr->m_NumServers)
 						continue;
 
-					if(DDNetFiltered(pExcludeTypes, pCntr->m_aTypes[g]))
+					if(DDNetFiltered(pExcludeTypes, pCntr->m_aaTypes[g]))
 						continue;
 					WantedAddrs.insert(pCntr->m_aServers[g]);
 				}
@@ -1223,12 +1223,12 @@ void CServerBrowser::LoadDDNetServers()
 					int Pos;
 					for(Pos = 0; Pos < pNet->m_NumTypes; Pos++)
 					{
-						if(!str_comp(pNet->m_aTypes[Pos], pType))
+						if(!str_comp(pNet->m_aaTypes[Pos], pType))
 							break;
 					}
 					if(Pos == pNet->m_NumTypes)
 					{
-						str_copy(pNet->m_aTypes[pNet->m_NumTypes], pType);
+						str_copy(pNet->m_aaTypes[pNet->m_NumTypes], pType);
 						pNet->m_NumTypes++;
 					}
 				}
@@ -1244,7 +1244,7 @@ void CServerBrowser::LoadDDNetServers()
 					}
 					const char *pStr = json_string_get(pAddr);
 					net_addr_from_str(&pCntr->m_aServers[pCntr->m_NumServers], pStr);
-					str_copy(pCntr->m_aTypes[pCntr->m_NumServers], pType);
+					str_copy(pCntr->m_aaTypes[pCntr->m_NumServers], pType);
 				}
 			}
 
@@ -1470,7 +1470,7 @@ void CServerBrowser::TypeFilterClean(int Network)
 
 	for(int i = 0; i < m_aNetworks[Network].m_NumTypes; i++)
 	{
-		const char *pName = m_aNetworks[Network].m_aTypes[i];
+		const char *pName = m_aNetworks[Network].m_aaTypes[i];
 		if(DDNetFiltered(pExcludeTypes, pName))
 		{
 			char aBuf[128];

--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -598,7 +598,9 @@ CServerBrowser::CServerEntry *CServerBrowser::Add(const NETADDR *pAddrs, int Num
 
 	// create new pEntry
 	pEntry = (CServerEntry *)m_ServerlistHeap.Allocate(sizeof(CServerEntry));
-	mem_zero(pEntry, sizeof(CServerEntry));
+	*pEntry = CServerEntry();
+	mem_zero(pEntry->m_Info.m_aAddresses, sizeof(pEntry->m_Info.m_aAddresses));
+	dbg_assert(mem_is_null(pEntry, sizeof(pEntry)), "mem not null");
 
 	// set the info
 	mem_copy(pEntry->m_Info.m_aAddresses, pAddrs, NumAddrs * sizeof(pAddrs[0]));
@@ -767,8 +769,7 @@ void CServerBrowser::Refresh(int Type)
 		int i;
 
 		/* do the broadcast version */
-		Packet.m_ClientID = -1;
-		mem_zero(&Packet, sizeof(Packet));
+		mem_zero(&Packet.m_Address, sizeof(NETADDR)); 
 		Packet.m_Address.type = m_pNetClient->NetType() | NETTYPE_LINK_BROADCAST;
 		Packet.m_Flags = NETSENDFLAG_CONNLESS | NETSENDFLAG_EXTENDED;
 		Packet.m_DataSize = sizeof(aBuffer);

--- a/src/engine/client/serverbrowser.h
+++ b/src/engine/client/serverbrowser.h
@@ -29,14 +29,14 @@ public:
 	class CServerEntry
 	{
 	public:
-		int64_t m_RequestTime;
-		bool m_RequestIgnoreInfo;
-		int m_GotInfo;
-		bool m_Request64Legacy;
+		int64_t m_RequestTime = 0;
+		bool m_RequestIgnoreInfo = false;
+		int m_GotInfo = 0;
+		bool m_Request64Legacy = false;
 		CServerInfo m_Info;
 
-		CServerEntry *m_pPrevReq; // request list
-		CServerEntry *m_pNextReq;
+		CServerEntry *m_pPrevReq = nullptr; // request list
+		CServerEntry *m_pNextReq = nullptr;
 	};
 
 	struct CNetworkCountry
@@ -46,11 +46,11 @@ public:
 			MAX_SERVERS = 1024
 		};
 
-		char m_aName[256];
-		int m_FlagID;
+		char m_aName[256] = {0};
+		int m_FlagID = 0;
 		NETADDR m_aServers[MAX_SERVERS];
-		char m_aTypes[MAX_SERVERS][32];
-		int m_NumServers;
+		char m_aaTypes[MAX_SERVERS][32] = {{0}};
+		int m_NumServers = 0;
 
 		void Reset()
 		{
@@ -70,10 +70,10 @@ public:
 	struct CNetwork
 	{
 		CNetworkCountry m_aCountries[MAX_COUNTRIES];
-		int m_NumCountries;
+		int m_NumCountries = 0;
 
-		char m_aTypes[MAX_TYPES][32];
-		int m_NumTypes;
+		char m_aaTypes[MAX_TYPES][32] = {{0}};
+		int m_NumTypes = 0;
 	};
 
 	CServerBrowser();
@@ -112,7 +112,7 @@ public:
 	const char *GetCountryName(int Network, int Index) override { return m_aNetworks[Network].m_aCountries[Index].m_aName; }
 
 	int NumTypes(int Network) override { return m_aNetworks[Network].m_NumTypes; }
-	const char *GetType(int Network, int Index) override { return m_aNetworks[Network].m_aTypes[Index]; }
+	const char *GetType(int Network, int Index) override { return m_aNetworks[Network].m_aaTypes[Index]; }
 
 	void DDNetFilterAdd(char *pFilter, const char *pName) override;
 	void DDNetFilterRem(char *pFilter, const char *pName) override;
@@ -143,7 +143,7 @@ private:
 	IFriends *m_pFriends = nullptr;
 	IFavorites *m_pFavorites = nullptr;
 	IStorage *m_pStorage = nullptr;
-	char m_aNetVersion[128];
+	char m_aNetVersion[128] = {0};
 
 	bool m_RefreshingHttp = false;
 	IServerBrowserHttp *m_pHttp = nullptr;
@@ -151,38 +151,38 @@ private:
 	const char *m_pHttpPrevBestUrl = nullptr;
 
 	CHeap m_ServerlistHeap;
-	CServerEntry **m_ppServerlist;
-	int *m_pSortedServerlist;
+	CServerEntry **m_ppServerlist = nullptr;
+	int *m_pSortedServerlist = nullptr;
 	std::unordered_map<NETADDR, int> m_ByAddr;
 
 	CNetwork m_aNetworks[NUM_NETWORKS];
 	int m_OwnLocation = CServerInfo::LOC_UNKNOWN;
 
-	json_value *m_pDDNetInfo;
+	json_value *m_pDDNetInfo = nullptr;
 
-	CServerEntry *m_pFirstReqServer; // request list
-	CServerEntry *m_pLastReqServer;
-	int m_NumRequests;
+	CServerEntry *m_pFirstReqServer = nullptr; // request list
+	CServerEntry *m_pLastReqServer = nullptr;
+	int m_NumRequests = 0;
 
 	// used instead of g_Config.br_max_requests to get more servers
-	int m_CurrentMaxRequests;
+	int m_CurrentMaxRequests = 0;
 
-	int m_NeedRefresh;
+	int m_NeedRefresh = 0;
 
-	int m_NumSortedServers;
-	int m_NumSortedServersCapacity;
-	int m_NumServers;
-	int m_NumServerCapacity;
+	int m_NumSortedServers = 0;
+	int m_NumSortedServersCapacity = 0;
+	int m_NumServers = 0;
+	int m_NumServerCapacity = 0;
 
-	int m_Sorthash;
-	char m_aFilterString[64];
-	char m_aFilterGametypeString[128];
+	int m_Sorthash = 0;
+	char m_aFilterString[64] = {0};
+	char m_aFilterGametypeString[128] = {0};
 
-	int m_ServerlistType;
-	int64_t m_BroadcastTime;
-	unsigned char m_aTokenSeed[16];
+	int m_ServerlistType = 0;
+	int64_t m_BroadcastTime = 0;
+	unsigned char m_aTokenSeed[16] = {0};
 
-	bool m_SortOnNextUpdate;
+	bool m_SortOnNextUpdate = false;
 
 	int GenerateToken(const NETADDR &Addr) const;
 	static int GetBasicToken(int Token);

--- a/src/engine/client/serverbrowser_http.cpp
+++ b/src/engine/client/serverbrowser_http.cpp
@@ -46,15 +46,15 @@ private:
 		std::atomic_int m_BestIndex{-1};
 		// Constant after construction.
 		VALIDATOR m_pfnValidator;
-		int m_NumUrls;
-		char m_aaUrls[MAX_URLS][256];
+		int m_NumUrls = 0;
+		char m_aaUrls[MAX_URLS][256] = {{0}};
 	};
 	class CJob : public IJob
 	{
 		LOCK m_Lock;
-		std::shared_ptr<CData> m_pData;
-		std::unique_ptr<CHttpRequest> m_pHead PT_GUARDED_BY(m_Lock);
-		std::unique_ptr<CHttpRequest> m_pGet PT_GUARDED_BY(m_Lock);
+		std::shared_ptr<CData> m_pData = nullptr;
+		std::unique_ptr<CHttpRequest> m_pHead PT_GUARDED_BY(m_Lock) = nullptr;
+		std::unique_ptr<CHttpRequest> m_pGet PT_GUARDED_BY(m_Lock) = nullptr;
 		void Run() override REQUIRES(!m_Lock);
 
 	public:
@@ -64,10 +64,10 @@ private:
 		void Abort() REQUIRES(!m_Lock);
 	};
 
-	IEngine *m_pEngine;
-	int m_PreviousBestIndex;
-	std::shared_ptr<CData> m_pData;
-	std::shared_ptr<CJob> m_pJob;
+	IEngine *m_pEngine = nullptr;
+	int m_PreviousBestIndex = 0;
+	std::shared_ptr<CData> m_pData = nullptr;
+	std::shared_ptr<CJob> m_pJob = nullptr;
 };
 
 CChooseMaster::CChooseMaster(IEngine *pEngine, VALIDATOR pfnValidator, const char **ppUrls, int NumUrls, int PreviousBestIndex) :
@@ -285,12 +285,12 @@ private:
 	static bool Validate(json_value *pJson);
 	static bool Parse(json_value *pJson, std::vector<CServerInfo> *pvServers, std::vector<NETADDR> *pvLegacyServers);
 
-	IEngine *m_pEngine;
-	IConsole *m_pConsole;
+	IEngine *m_pEngine = nullptr;
+	IConsole *m_pConsole = nullptr;
 
 	int m_State = STATE_DONE;
-	std::shared_ptr<CHttpRequest> m_pGetServers;
-	std::unique_ptr<CChooseMaster> m_pChooseMaster;
+	std::shared_ptr<CHttpRequest> m_pGetServers = nullptr;
+	std::unique_ptr<CChooseMaster> m_pChooseMaster = nullptr;
 
 	std::vector<CServerInfo> m_vServers;
 	std::vector<NETADDR> m_vLegacyServers;

--- a/src/engine/client/serverbrowser_ping_cache.cpp
+++ b/src/engine/client/serverbrowser_ping_cache.cpp
@@ -15,7 +15,7 @@ public:
 	{
 	public:
 		NETADDR m_Addr;
-		int m_Ping;
+		int m_Ping = 0;
 	};
 
 	CServerBrowserPingCache(IConsole *pConsole, IStorage *pStorage);
@@ -28,7 +28,7 @@ public:
 	int GetPing(const NETADDR *pAddrs, int NumAddrs) const override;
 
 private:
-	IConsole *m_pConsole;
+	IConsole *m_pConsole = nullptr;
 
 	CSqlite m_pDisk;
 	CSqliteStmt m_pLoadStmt;

--- a/src/engine/client/sound.cpp
+++ b/src/engine/client/sound.cpp
@@ -32,33 +32,34 @@ enum
 
 struct CSample
 {
-	short *m_pData;
-	int m_NumFrames;
-	int m_Rate;
-	int m_Channels;
-	int m_LoopStart;
-	int m_LoopEnd;
-	int m_PausedAt;
+	short *m_pData = nullptr;
+	int m_NumFrames = 0;
+	int m_Rate = 0;
+	int m_Channels = 0;
+	int m_LoopStart = 0;
+	int m_LoopEnd = 0;
+	int m_PausedAt = 0;
 };
 
 struct CChannel
 {
-	int m_Vol;
-	int m_Pan;
+	int m_Vol = 0;
+	int m_Pan = 0;
 };
 
 struct CVoice
 {
-	CSample *m_pSample;
-	CChannel *m_pChannel;
-	int m_Age; // increases when reused
-	int m_Tick;
-	int m_Vol; // 0 - 255
-	int m_Flags;
-	int m_X, m_Y;
-	float m_Falloff; // [0.0, 1.0]
+	CSample *m_pSample = nullptr;
+	CChannel *m_pChannel = nullptr;
+	int m_Age = 0; // increases when reused
+	int m_Tick = 0;
+	int m_Vol = 0; // 0 - 255
+	int m_Flags = 0;
+	int m_X = 0;
+	int m_Y = 0;
+	float m_Falloff = 0; // [0.0, 1.0]
 
-	int m_Shape;
+	int m_Shape = 0;
 	union
 	{
 		ISound::CVoiceShapeCircle m_Circle;

--- a/src/engine/client/sound.h
+++ b/src/engine/client/sound.h
@@ -13,11 +13,11 @@ class IStorage;
 
 class CSound : public IEngineSound
 {
-	bool m_SoundEnabled;
+	bool m_SoundEnabled = false;
 	SDL_AudioDeviceID m_Device;
 
-	IEngineGraphics *m_pGraphics;
-	IStorage *m_pStorage;
+	IEngineGraphics *m_pGraphics = nullptr;
+	IStorage *m_pStorage = nullptr;
 
 	int AllocID();
 

--- a/src/engine/client/steam.cpp
+++ b/src/engine/client/steam.cpp
@@ -7,10 +7,10 @@
 class CSteam : public ISteam
 {
 	HSteamPipe m_SteamPipe;
-	ISteamApps *m_pSteamApps;
-	ISteamFriends *m_pSteamFriends;
-	char m_aPlayerName[16];
-	bool m_GotConnectAddr;
+	ISteamApps *m_pSteamApps = nullptr;
+	ISteamFriends *m_pSteamFriends = nullptr;
+	char m_aPlayerName[16] = {0};
+	bool m_GotConnectAddr = false;
 	NETADDR m_ConnectAddr;
 
 public:

--- a/src/engine/client/text.cpp
+++ b/src/engine/client/text.cpp
@@ -792,7 +792,8 @@ public:
 
 	void SetCursor(CTextCursor *pCursor, float x, float y, float FontSize, int Flags) override
 	{
-		mem_zero(pCursor, sizeof(*pCursor));
+		*pCursor = CTextCursor();
+		dbg_assert(mem_is_null(pCursor, sizeof(*pCursor)), "mem not null");
 		pCursor->m_FontSize = FontSize;
 		pCursor->m_StartX = x;
 		pCursor->m_StartY = y;

--- a/src/engine/client/text.cpp
+++ b/src/engine/client/text.cpp
@@ -29,20 +29,20 @@ using namespace std::chrono_literals;
 
 struct SFontSizeChar
 {
-	int m_ID;
+	int m_ID = 0;
 
 	// these values are scaled to the pFont size
 	// width * font_size == real_size
-	float m_Width;
-	float m_Height;
-	float m_CharWidth;
-	float m_CharHeight;
-	float m_OffsetX;
-	float m_OffsetY;
-	float m_AdvanceX;
+	float m_Width = 0;
+	float m_Height = 0;
+	float m_CharWidth = 0;
+	float m_CharHeight = 0;
+	float m_OffsetX = 0;
+	float m_OffsetY = 0;
+	float m_AdvanceX = 0;
 
-	float m_aUVs[4];
-	int64_t m_TouchTime;
+	float m_aUVs[4] = {0};
+	int64_t m_TouchTime = 0;
 	FT_UInt m_GlyphIndex;
 };
 
@@ -54,9 +54,9 @@ struct STextCharQuadVertex
 	{
 		m_Color.r = m_Color.g = m_Color.b = m_Color.a = 255;
 	}
-	float m_X, m_Y;
+	float m_X = 0, m_Y = 0;
 	// do not use normalized floats as coordinates, since the texture might grow
-	float m_U, m_V;
+	float m_U = 0, m_V = 0;
 	STextCharQuadVertexColor m_Color;
 };
 
@@ -73,8 +73,8 @@ struct STextureSkyline
 
 struct CFontSizeData
 {
-	int m_FontSize;
-	FT_Face *m_pFace;
+	int m_FontSize = 0;
+	FT_Face *m_pFace = nullptr;
 
 	std::map<int, SFontSizeChar> m_Chars;
 };
@@ -114,14 +114,14 @@ public:
 		return &m_aFontSizes[FontSize - MIN_FONT_SIZE];
 	}
 
-	void *m_pBuf;
-	char m_aFilename[IO_MAX_PATH_LENGTH];
+	void *m_pBuf = nullptr;
+	char m_aFilename[IO_MAX_PATH_LENGTH] = {0};
 	FT_Face m_FtFace;
 
 	struct SFontFallBack
 	{
-		void *m_pBuf;
-		char m_aFilename[IO_MAX_PATH_LENGTH];
+		void *m_pBuf = nullptr;
+		char m_aFilename[IO_MAX_PATH_LENGTH] = {0};
 		FT_Face m_FtFace;
 	};
 
@@ -131,20 +131,20 @@ public:
 
 	IGraphics::CTextureHandle m_aTextures[2];
 	// keep the full texture, because opengl doesn't provide texture copying
-	uint8_t *m_apTextureData[2];
+	uint8_t *m_apTextureData[2] = {nullptr};
 
 	// width and height are the same
-	int m_aCurTextureDimensions[2];
+	int m_aCurTextureDimensions[2] = {0};
 
 	STextureSkyline m_aTextureSkyline[2];
 };
 
 struct STextString
 {
-	int m_QuadBufferObjectIndex;
-	int m_QuadBufferContainerIndex;
-	size_t m_QuadNum;
-	int m_SelectionQuadContainerIndex;
+	int m_QuadBufferObjectIndex = 0;
+	int m_QuadBufferContainerIndex = 0;
+	size_t m_QuadNum = 0;
+	int m_SelectionQuadContainerIndex = 0;
 
 	std::vector<STextCharQuad> m_vCharacterQuads;
 };
@@ -153,33 +153,33 @@ struct STextContainer
 {
 	STextContainer() { Reset(); }
 
-	CFont *m_pFont;
-	int m_FontSize;
+	CFont *m_pFont = nullptr;
+	int m_FontSize = 0;
 	STextString m_StringInfo;
 
 	// keep these values to calculate offsets
-	float m_AlignedStartX;
-	float m_AlignedStartY;
-	float m_X;
-	float m_Y;
+	float m_AlignedStartX = 0;
+	float m_AlignedStartY = 0;
+	float m_X = 0;
+	float m_Y = 0;
 
-	int m_Flags;
-	int m_LineCount;
-	int m_GlyphCount;
-	int m_CharCount;
-	int m_MaxLines;
+	int m_Flags = 0;
+	int m_LineCount = 0;
+	int m_GlyphCount = 0;
+	int m_CharCount = 0;
+	int m_MaxLines = 0;
 
-	float m_StartX;
-	float m_StartY;
-	float m_LineWidth;
-	float m_UnscaledFontSize;
+	float m_StartX = 0;
+	float m_StartY = 0;
+	float m_LineWidth = 0;
+	float m_UnscaledFontSize = 0;
 
-	int m_RenderFlags;
+	int m_RenderFlags = 0;
 
-	bool m_HasCursor;
-	bool m_HasSelection;
+	bool m_HasCursor = false;
+	bool m_HasSelection = false;
 
-	bool m_SingleTimeUse;
+	bool m_SingleTimeUse = false;
 
 	void Reset()
 	{
@@ -208,21 +208,21 @@ struct STextContainer
 
 class CTextRender : public IEngineTextRender
 {
-	IGraphics *m_pGraphics;
+	IGraphics *m_pGraphics = nullptr;
 	IGraphics *Graphics() { return m_pGraphics; }
 
-	unsigned int m_RenderFlags;
+	unsigned int m_RenderFlags = 0;
 
 	std::vector<STextContainer *> m_vpTextContainers;
 	std::vector<int> m_vTextContainerIndices;
-	int m_FirstFreeTextContainerIndex;
+	int m_FirstFreeTextContainerIndex = 0;
 
 	SBufferContainerInfo m_DefaultTextContainerInfo;
 
 	std::vector<CFont *> m_vpFonts;
-	CFont *m_pCurFont;
+	CFont *m_pCurFont = nullptr;
 
-	std::chrono::nanoseconds m_CursorRenderTime;
+	std::chrono::nanoseconds m_CursorRenderTime = std::chrono::nanoseconds::zero();
 
 	int GetFreeTextContainerIndex()
 	{
@@ -282,7 +282,7 @@ class CTextRender : public IEngineTextRender
 	ColorRGBA m_Color;
 	ColorRGBA m_OutlineColor;
 	ColorRGBA m_SelectionColor;
-	CFont *m_pDefaultFont;
+	CFont *m_pDefaultFont = nullptr;
 
 	FT_Library m_FTLibrary;
 

--- a/src/engine/client/updater.cpp
+++ b/src/engine/client/updater.cpp
@@ -15,9 +15,9 @@ using std::string;
 
 class CUpdaterFetchTask : public CHttpRequest
 {
-	char m_aBuf[256];
-	char m_aBuf2[256];
-	CUpdater *m_pUpdater;
+	char m_aBuf[256] = {0};
+	char m_aBuf2[256] = {0};
+	CUpdater *m_pUpdater = nullptr;
 
 	void OnProgress() override;
 

--- a/src/engine/client/updater.h
+++ b/src/engine/client/updater.h
@@ -35,21 +35,21 @@ class CUpdater : public IUpdater
 {
 	friend class CUpdaterFetchTask;
 
-	class IClient *m_pClient;
-	class IStorage *m_pStorage;
-	class IEngine *m_pEngine;
+	class IClient *m_pClient = nullptr;
+	class IStorage *m_pStorage = nullptr;
+	class IEngine *m_pEngine = nullptr;
 
 	LOCK m_Lock;
 
-	int m_State;
+	int m_State = 0;
 	char m_aStatus[256] GUARDED_BY(m_Lock);
 	int m_Percent GUARDED_BY(m_Lock);
-	char m_aLastFile[256];
-	char m_aClientExecTmp[64];
-	char m_aServerExecTmp[64];
+	char m_aLastFile[256] = {0};
+	char m_aClientExecTmp[64] = {0};
+	char m_aServerExecTmp[64] = {0};
 
-	bool m_ClientUpdate;
-	bool m_ServerUpdate;
+	bool m_ClientUpdate = false;
+	bool m_ServerUpdate = false;
 
 	std::map<std::string, bool> m_FileJobs;
 

--- a/src/engine/client/video.h
+++ b/src/engine/client/video.h
@@ -81,22 +81,22 @@ private:
 
 	bool AddStream(OutputStream *pStream, AVFormatContext *pOC, const AVCodec **ppCodec, enum AVCodecID CodecId);
 
-	CGraphics_Threaded *m_pGraphics;
-	IStorage *m_pStorage;
-	ISound *m_pSound;
+	CGraphics_Threaded *m_pGraphics = nullptr;
+	IStorage *m_pStorage = nullptr;
+	ISound *m_pSound = nullptr;
 
-	int m_Width;
-	int m_Height;
-	char m_aName[256];
-	//FILE *m_dbgfile;
+	int m_Width = 0;
+	int m_Height = 0;
+	char m_aName[256] = {0};
+	//FILE *m_dbgfile = nullptr;
 	uint64_t m_VSeq = 0;
 	uint64_t m_ASeq = 0;
-	uint64_t m_Vframe;
+	uint64_t m_Vframe = 0;
 
-	int m_FPS;
+	int m_FPS = 0;
 
-	bool m_Started;
-	bool m_Recording;
+	bool m_Started = false;
+	bool m_Recording = false;
 
 	size_t m_VideoThreads = 2;
 	size_t m_CurVideoThreadIndex = 0;
@@ -138,14 +138,14 @@ private:
 
 	std::vector<std::unique_ptr<SAudioRecorderThread>> m_vAudioThreads;
 
-	std::atomic<int32_t> m_ProcessingVideoFrame;
-	std::atomic<int32_t> m_ProcessingAudioFrame;
+	std::atomic<int32_t> m_ProcessingVideoFrame = 0;
+	std::atomic<int32_t> m_ProcessingAudioFrame = 0;
 
-	bool m_HasAudio;
+	bool m_HasAudio = false;
 
 	struct SVideoSoundBuffer
 	{
-		int16_t m_aBuffer[ALEN * 2];
+		int16_t m_aBuffer[ALEN * 2] = {0};
 	};
 	std::vector<SVideoSoundBuffer> m_vBuffer;
 	std::vector<std::vector<uint8_t>> m_vPixelHelper;
@@ -153,13 +153,13 @@ private:
 	OutputStream m_VideoStream;
 	OutputStream m_AudioStream;
 
-	const AVCodec *m_pVideoCodec;
-	const AVCodec *m_pAudioCodec;
+	const AVCodec *m_pVideoCodec = nullptr;
+	const AVCodec *m_pAudioCodec = nullptr;
 
-	AVDictionary *m_pOptDict;
+	AVDictionary *m_pOptDict = nullptr;
 
-	AVFormatContext *m_pFormatContext;
-	const AVOutputFormat *m_pFormat;
+	AVFormatContext *m_pFormatContext = nullptr;
+	const AVOutputFormat *m_pFormat = nullptr;
 };
 
 #endif

--- a/src/engine/console.h
+++ b/src/engine/console.h
@@ -42,7 +42,7 @@ public:
 	class IResult
 	{
 	protected:
-		unsigned m_NumArgs;
+		unsigned m_NumArgs = 0;
 
 	public:
 		IResult() { m_NumArgs = 0; }
@@ -56,7 +56,7 @@ public:
 		virtual void RemoveArgument(unsigned Index) = 0;
 
 		int NumArguments() const { return m_NumArgs; }
-		int m_ClientID;
+		int m_ClientID = 0;
 
 		// DDRace
 
@@ -66,14 +66,14 @@ public:
 	class CCommandInfo
 	{
 	protected:
-		int m_AccessLevel;
+		int m_AccessLevel = 0;
 
 	public:
 		CCommandInfo() { m_AccessLevel = ACCESS_LEVEL_ADMIN; }
 		virtual ~CCommandInfo() {}
-		const char *m_pName;
-		const char *m_pHelp;
-		const char *m_pParams;
+		const char *m_pName = nullptr;
+		const char *m_pHelp = nullptr;
+		const char *m_pParams = nullptr;
 
 		virtual const CCommandInfo *NextCommandInfo(int AccessLevel, int FlagMask) const = 0;
 
@@ -118,7 +118,7 @@ public:
 
 	// DDRace
 
-	bool m_Cheated;
+	bool m_Cheated = false;
 	virtual void SetFlagMask(int FlagMask) = 0;
 };
 

--- a/src/engine/demo.h
+++ b/src/engine/demo.h
@@ -25,29 +25,29 @@ extern const CUuid SHA256_EXTENSION;
 
 struct CDemoHeader
 {
-	unsigned char m_aMarker[7];
-	unsigned char m_Version;
-	char m_aNetversion[64];
-	char m_aMapName[64];
-	unsigned char m_aMapSize[4];
-	unsigned char m_aMapCrc[4];
-	char m_aType[8];
-	unsigned char m_aLength[4];
-	char m_aTimestamp[20];
+	unsigned char m_aMarker[7] = {0};
+	unsigned char m_Version = 0;
+	char m_aNetversion[64] = {0};
+	char m_aMapName[64] = {0};
+	unsigned char m_aMapSize[4] = {0};
+	unsigned char m_aMapCrc[4] = {0};
+	char m_aType[8] = {0};
+	unsigned char m_aLength[4] = {0};
+	char m_aTimestamp[20] = {0};
 };
 
 struct CTimelineMarkers
 {
-	unsigned char m_aNumTimelineMarkers[4];
-	unsigned char m_aTimelineMarkers[MAX_TIMELINE_MARKERS][4];
+	unsigned char m_aNumTimelineMarkers[4] = {0};
+	unsigned char m_aaTimelineMarkers[MAX_TIMELINE_MARKERS][4] = {{0}};
 };
 
 struct CMapInfo
 {
-	char m_aName[MAX_MAP_LENGTH];
+	char m_aName[MAX_MAP_LENGTH] = {0};
 	SHA256_DIGEST m_Sha256;
-	int m_Crc;
-	int m_Size;
+	int m_Crc = 0;
+	int m_Size = 0;
 };
 
 class IDemoPlayer : public IInterface
@@ -57,15 +57,15 @@ public:
 	class CInfo
 	{
 	public:
-		bool m_Paused;
-		float m_Speed;
+		bool m_Paused = false;
+		float m_Speed = 0;
 
-		int m_FirstTick;
-		int m_CurrentTick;
-		int m_LastTick;
+		int m_FirstTick = 0;
+		int m_CurrentTick = 0;
+		int m_LastTick = 0;
 
-		int m_NumTimelineMarkers;
-		int m_aTimelineMarkers[MAX_TIMELINE_MARKERS];
+		int m_NumTimelineMarkers = 0;
+		int m_aTimelineMarkers[MAX_TIMELINE_MARKERS] = {0};
 	};
 
 	enum

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -18,9 +18,9 @@ public:
 	CHostLookup();
 	CHostLookup(const char *pHostname, int Nettype);
 
-	int m_Result;
-	char m_aHostname[128];
-	int m_Nettype;
+	int m_Result = 0;
+	char m_aHostname[128] = {0};
+	int m_Nettype = 0;
 	NETADDR m_Addr;
 };
 

--- a/src/engine/favorites.h
+++ b/src/engine/favorites.h
@@ -21,9 +21,9 @@ public:
 	class CEntry
 	{
 	public:
-		int m_NumAddrs;
+		int m_NumAddrs = 0;
 		NETADDR m_aAddrs[MAX_SERVER_ADDRESSES];
-		bool m_AllowPing;
+		bool m_AllowPing = false;
 	};
 
 	virtual ~IFavorites() {}

--- a/src/engine/friends.h
+++ b/src/engine/friends.h
@@ -9,10 +9,10 @@
 
 struct CFriendInfo
 {
-	char m_aName[MAX_NAME_LENGTH];
-	char m_aClan[MAX_CLAN_LENGTH];
-	unsigned m_NameHash;
-	unsigned m_ClanHash;
+	char m_aName[MAX_NAME_LENGTH] = {0};
+	char m_aClan[MAX_CLAN_LENGTH] = {0};
+	unsigned m_NameHash = 0;
+	unsigned m_ClanHash = 0;
 };
 
 class IFriends : public IInterface

--- a/src/engine/gfx/image_loader.cpp
+++ b/src/engine/gfx/image_loader.cpp
@@ -7,21 +7,21 @@
 
 struct SLibPNGWarningItem
 {
-	SImageByteBuffer *m_pByteLoader;
-	const char *pFileName;
+	SImageByteBuffer *m_pByteLoader = nullptr;
+	const char *m_pFileName = nullptr;
 };
 
 static void LibPNGError(png_structp png_ptr, png_const_charp error_msg)
 {
 	SLibPNGWarningItem *pUserStruct = (SLibPNGWarningItem *)png_get_error_ptr(png_ptr);
 	pUserStruct->m_pByteLoader->m_Err = -1;
-	dbg_msg("libpng", "error for file \"%s\": %s", pUserStruct->pFileName, error_msg);
+	dbg_msg("libpng", "error for file \"%s\": %s", pUserStruct->m_pFileName, error_msg);
 }
 
 static void LibPNGWarning(png_structp png_ptr, png_const_charp warning_msg)
 {
 	SLibPNGWarningItem *pUserStruct = (SLibPNGWarningItem *)png_get_error_ptr(png_ptr);
-	dbg_msg("libpng", "warning for file \"%s\": %s", pUserStruct->pFileName, warning_msg);
+	dbg_msg("libpng", "warning for file \"%s\": %s", pUserStruct->m_pFileName, warning_msg);
 }
 
 static bool FileMatchesImageType(SImageByteBuffer &ByteLoader)

--- a/src/engine/gfx/image_loader.h
+++ b/src/engine/gfx/image_loader.h
@@ -17,9 +17,9 @@ struct SImageByteBuffer
 {
 	SImageByteBuffer(std::vector<uint8_t> *pvBuff) :
 		m_LoadOffset(0), m_pvLoadedImageBytes(pvBuff), m_Err(0) {}
-	size_t m_LoadOffset;
-	std::vector<uint8_t> *m_pvLoadedImageBytes;
-	int m_Err;
+	size_t m_LoadOffset = 0;
+	std::vector<uint8_t> *m_pvLoadedImageBytes = nullptr;
+	int m_Err = 0;
 };
 
 enum

--- a/src/engine/ghost.h
+++ b/src/engine/ghost.h
@@ -9,10 +9,10 @@
 class CGhostInfo
 {
 public:
-	char m_aOwner[MAX_NAME_LENGTH];
-	char m_aMap[64];
-	int m_NumTicks;
-	int m_Time;
+	char m_aOwner[MAX_NAME_LENGTH] = {0};
+	char m_aMap[64] = {0};
+	int m_NumTicks = 0;
+	int m_Time = 0;
 };
 
 class IGhostRecorder : public IInterface

--- a/src/engine/graphics.h
+++ b/src/engine/graphics.h
@@ -20,19 +20,19 @@
 #define GRAPHICS_TYPE_FLOAT 0x1406
 struct SBufferContainerInfo
 {
-	int m_Stride;
-	int m_VertBufferBindingIndex;
+	int m_Stride = 0;
+	int m_VertBufferBindingIndex = 0;
 
 	// the attributes of the container
 	struct SAttribute
 	{
-		int m_DataTypeCount;
-		unsigned int m_Type;
-		bool m_Normalized;
-		void *m_pOffset;
+		int m_DataTypeCount = 0;
+		unsigned int m_Type = 0;
+		bool m_Normalized = false;
+		void *m_pOffset = nullptr;
 
 		//0: float, 1:integer
-		unsigned int m_FuncType;
+		unsigned int m_FuncType = 0;
 	};
 	std::vector<SAttribute> m_vAttributes;
 };
@@ -41,9 +41,9 @@ struct SQuadRenderInfo
 {
 	ColorRGBA m_Color;
 	vec2 m_Offsets;
-	float m_Rotation;
+	float m_Rotation = 0;
 	// allows easier upload for uniform buffers because of the alignment requirements
-	float m_Padding;
+	float m_Padding = 0;
 };
 
 struct SGraphicTile
@@ -75,19 +75,19 @@ public:
 
 	/* Variable: width
 		Contains the width of the image */
-	int m_Width;
+	int m_Width = 0;
 
 	/* Variable: height
 		Contains the height of the image */
-	int m_Height;
+	int m_Height = 0;
 
 	/* Variable: format
 		Contains the format of the image. See <Image Formats> for more information. */
-	int m_Format;
+	int m_Format = 0;
 
 	/* Variable: data
 		Pointer to the image data. */
-	void *m_pData;
+	void *m_pData = nullptr;
 };
 
 /*
@@ -96,11 +96,11 @@ public:
 class CVideoMode
 {
 public:
-	int m_CanvasWidth, m_CanvasHeight;
-	int m_WindowWidth, m_WindowHeight;
-	int m_RefreshRate;
-	int m_Red, m_Green, m_Blue;
-	uint32_t m_Format;
+	int m_CanvasWidth = 0, m_CanvasHeight = 0;
+	int m_WindowWidth = 0, m_WindowHeight = 0;
+	int m_RefreshRate = 0;
+	int m_Red = 0, m_Green = 0, m_Blue = 0;
+	uint32_t m_Format = 0;
 };
 
 typedef vec2 GL_SPoint;
@@ -123,7 +123,7 @@ struct GL_STexCoord3D
 		return *this;
 	}
 
-	float u, v, w;
+	float u = 0, v = 0, w = 0;
 };
 
 typedef ColorRGBA GL_SColorf;
@@ -190,8 +190,8 @@ struct STWGraphicGPU
 
 	struct STWGraphicGPUItem
 	{
-		char m_aName[256];
-		ETWGraphicsGPUType m_GPUType;
+		char m_aName[256] = {0};
+		ETWGraphicsGPUType m_GPUType = GRAPHICS_GPU_TYPE_DISCRETE;
 	};
 	std::vector<STWGraphicGPUItem> m_vGPUs;
 	STWGraphicGPUItem m_AutoGPU;
@@ -211,10 +211,10 @@ class IGraphics : public IInterface
 {
 	MACRO_INTERFACE("graphics", 0)
 protected:
-	int m_ScreenWidth;
-	int m_ScreenHeight;
-	int m_ScreenRefreshRate;
-	float m_ScreenHiDPIScale;
+	int m_ScreenWidth = 0;
+	int m_ScreenHeight = 0;
+	int m_ScreenRefreshRate = 0;
+	float m_ScreenHiDPIScale = 0;
 
 public:
 	enum
@@ -362,7 +362,7 @@ public:
 
 	struct CLineItem
 	{
-		float m_X0, m_Y0, m_X1, m_Y1;
+		float m_X0 = 0, m_Y0 = 0, m_X1 = 0, m_Y1 = 0;
 		CLineItem() {}
 		CLineItem(float x0, float y0, float x1, float y1) :
 			m_X0(x0), m_Y0(y0), m_X1(x1), m_Y1(y1) {}
@@ -385,7 +385,7 @@ public:
 
 	struct CFreeformItem
 	{
-		float m_X0, m_Y0, m_X1, m_Y1, m_X2, m_Y2, m_X3, m_Y3;
+		float m_X0 = 0, m_Y0 = 0, m_X1 = 0, m_Y1 = 0, m_X2 = 0, m_Y2 = 0, m_X3 = 0, m_Y3 = 0;
 		CFreeformItem() {}
 		CFreeformItem(float x0, float y0, float x1, float y1, float x2, float y2, float x3, float y3) :
 			m_X0(x0), m_Y0(y0), m_X1(x1), m_Y1(y1), m_X2(x2), m_Y2(y2), m_X3(x3), m_Y3(y3) {}
@@ -393,7 +393,7 @@ public:
 
 	struct CQuadItem
 	{
-		float m_X, m_Y, m_Width, m_Height;
+		float m_X = 0, m_Y = 0, m_Width = 0, m_Height = 0;
 		CQuadItem() {}
 		CQuadItem(float x, float y, float w, float h) :
 			m_X(x), m_Y(y), m_Width(w), m_Height(h) {}
@@ -433,8 +433,8 @@ public:
 	struct SRenderSpriteInfo
 	{
 		vec2 m_Pos;
-		float m_Scale;
-		float m_Rotation;
+		float m_Scale = 0;
+		float m_Rotation = 0;
 	};
 
 	virtual void RenderQuadContainerAsSpriteMultiple(int ContainerIndex, int QuadOffset, int DrawCount, SRenderSpriteInfo *pRenderInfo) = 0;
@@ -444,8 +444,8 @@ public:
 
 	struct CColorVertex
 	{
-		int m_Index;
-		float m_R, m_G, m_B, m_A;
+		int m_Index = 0;
+		float m_R = 0, m_G = 0, m_B = 0, m_A = 0;
 		CColorVertex() {}
 		CColorVertex(int i, float r, float g, float b, float a) :
 			m_Index(i), m_R(r), m_G(g), m_B(b), m_A(a) {}

--- a/src/engine/graphics.h
+++ b/src/engine/graphics.h
@@ -231,7 +231,7 @@ public:
 	class CTextureHandle
 	{
 		friend class IGraphics;
-		int m_Id;
+		int m_Id = -1;
 
 	public:
 		CTextureHandle() :

--- a/src/engine/input.h
+++ b/src/engine/input.h
@@ -20,10 +20,10 @@ public:
 	class CEvent
 	{
 	public:
-		int m_Flags;
-		int m_Key;
-		char m_aText[INPUT_TEXT_SIZE];
-		int m_InputCount;
+		int m_Flags = 0;
+		int m_Key = 0;
+		char m_aText[INPUT_TEXT_SIZE] = {0};
+		int m_InputCount = 0;
 	};
 
 protected:
@@ -33,7 +33,7 @@ protected:
 	};
 
 	// quick access to events
-	int m_NumEvents;
+	int m_NumEvents = 0;
 	IInput::CEvent m_aInputEvents[INPUT_BUFFER_SIZE];
 
 public:

--- a/src/engine/kernel.h
+++ b/src/engine/kernel.h
@@ -12,7 +12,7 @@ class IInterface
 {
 	// friend with the kernel implementation
 	friend class CKernel;
-	IKernel *m_pKernel;
+	IKernel *m_pKernel = nullptr;
 
 protected:
 	IKernel *Kernel() { return m_pKernel; }

--- a/src/engine/message.h
+++ b/src/engine/message.h
@@ -9,9 +9,9 @@
 class CMsgPacker : public CPacker
 {
 public:
-	int m_MsgID;
-	bool m_System;
-	bool m_NoTranslate;
+	int m_MsgID = 0;
+	bool m_System = false;
+	bool m_NoTranslate = false;
 	CMsgPacker(int Type, bool System = false, bool NoTranslate = false) :
 		m_MsgID(Type), m_System(System), m_NoTranslate(NoTranslate)
 	{

--- a/src/engine/server.h
+++ b/src/engine/server.h
@@ -28,8 +28,8 @@ class IServer : public IInterface
 {
 	MACRO_INTERFACE("server", 0)
 protected:
-	int m_CurrentGameTick;
-	int m_TickSpeed;
+	int m_CurrentGameTick = 0;
+	int m_TickSpeed = 0;
 
 public:
 	/*
@@ -37,12 +37,12 @@ public:
 	*/
 	struct CClientInfo
 	{
-		const char *m_pName;
-		int m_Latency;
-		bool m_GotDDNetVersion;
-		int m_DDNetVersion;
-		const char *m_pDDNetVersionStr;
-		const CUuid *m_pConnectionID;
+		const char *m_pName = nullptr;
+		int m_Latency = 0;
+		bool m_GotDDNetVersion = false;
+		int m_DDNetVersion = 0;
+		const char *m_pDDNetVersionStr = nullptr;
+		const CUuid *m_pConnectionID = nullptr;
 	};
 
 	int Tick() const { return m_CurrentGameTick; }

--- a/src/engine/server/antibot.cpp
+++ b/src/engine/server/antibot.cpp
@@ -56,7 +56,7 @@ void CAntibot::Init()
 	dbg_assert(m_pServer && m_pConsole, "antibot requires server and console");
 	dbg_assert(AntibotAbiVersion() == ANTIBOT_ABI_VERSION, "antibot abi version mismatch");
 
-	mem_zero(&m_Data, sizeof(m_Data));
+	m_Data = CAntibotData();
 	CAntibotVersion Version = ANTIBOT_VERSION;
 	m_Data.m_Version = Version;
 
@@ -73,7 +73,7 @@ void CAntibot::Init()
 void CAntibot::RoundStart(IGameServer *pGameServer)
 {
 	m_pGameServer = pGameServer;
-	mem_zero(&m_RoundData, sizeof(m_RoundData));
+	m_RoundData = CAntibotRoundData();
 	m_RoundData.m_Map.m_pTiles = 0;
 	AntibotRoundStart(&m_RoundData);
 	Update();

--- a/src/engine/server/antibot.h
+++ b/src/engine/server/antibot.h
@@ -6,9 +6,9 @@
 
 class CAntibot : public IEngineAntibot
 {
-	class IServer *m_pServer;
-	class IConsole *m_pConsole;
-	class IGameServer *m_pGameServer;
+	class IServer *m_pServer = nullptr;
+	class IConsole *m_pConsole = nullptr;
+	class IGameServer *m_pGameServer = nullptr;
 
 	class IServer *Server() const { return m_pServer; }
 	class IConsole *Console() const { return m_pConsole; }
@@ -16,7 +16,7 @@ class CAntibot : public IEngineAntibot
 
 	CAntibotData m_Data;
 	CAntibotRoundData m_RoundData;
-	bool m_Initialized;
+	bool m_Initialized = false;
 
 	void Update();
 	static void Send(int ClientID, const void *pData, int Size, int Flags, void *pUser);

--- a/src/engine/server/authmanager.h
+++ b/src/engine/server/authmanager.h
@@ -12,15 +12,15 @@ class CAuthManager
 private:
 	struct CKey
 	{
-		char m_aIdent[64];
+		char m_aIdent[64] = {0};
 		MD5_DIGEST m_Pw;
-		unsigned char m_aSalt[SALT_BYTES];
-		int m_Level;
+		unsigned char m_aSalt[SALT_BYTES] = {0};
+		int m_Level = 0;
 	};
 	std::vector<CKey> m_vKeys;
 
-	int m_aDefault[3];
-	bool m_Generated;
+	int m_aDefault[3] = {0};
+	bool m_Generated = false;
 
 public:
 	typedef void (*FListCallback)(const char *pIdent, int Level, void *pUser);

--- a/src/engine/server/databases/connection.h
+++ b/src/engine/server/databases/connection.h
@@ -87,7 +87,7 @@ public:
 	virtual bool AddPoints(const char *pPlayer, int Points, char *pError, int ErrorSize) = 0;
 
 private:
-	char m_aPrefix[64];
+	char m_aPrefix[64] = {0};
 
 protected:
 	void FormatCreateRace(char *aBuf, unsigned int BufferSize);

--- a/src/engine/server/databases/connection_pool.h
+++ b/src/engine/server/databases/connection_pool.h
@@ -28,7 +28,7 @@ struct ISqlData
 	}
 	virtual ~ISqlData(){};
 
-	mutable std::shared_ptr<ISqlResult> m_pResult;
+	mutable std::shared_ptr<ISqlResult> m_pResult = nullptr;
 };
 
 class IConsole;
@@ -77,9 +77,9 @@ private:
 
 	std::atomic_bool m_Shutdown{false};
 	CSemaphore m_NumElem;
-	int m_FirstElem;
-	int m_LastElem;
-	std::unique_ptr<struct CSqlExecData> m_aTasks[512];
+	int m_FirstElem = 0;
+	int m_LastElem = 0;
+	std::unique_ptr<struct CSqlExecData> m_apTasks[512]; // cannot be initialized due to incomplete type
 };
 
 #endif // ENGINE_SERVER_DATABASES_CONNECTION_POOL_H

--- a/src/engine/server/databases/mysql.cpp
+++ b/src/engine/server/databases/mysql.cpp
@@ -112,7 +112,7 @@ private:
 		void operator()(MYSQL_STMT *pStmt) const;
 	};
 
-	char m_aErrorDetail[128];
+	char m_aErrorDetail[128] = {0};
 	void StoreErrorMysql(const char *pContext);
 	void StoreErrorStmt(const char *pContext);
 	bool ConnectImpl();
@@ -134,14 +134,14 @@ private:
 	std::vector<UParameterExtra> m_vStmtParameterExtras;
 
 	// copy of config vars
-	char m_aDatabase[64];
-	char m_aUser[64];
-	char m_aPass[64];
-	char m_aIp[64];
-	int m_Port;
-	bool m_Setup;
+	char m_aDatabase[64] = {0};
+	char m_aUser[64] = {0};
+	char m_aPass[64] = {0};
+	char m_aIp[64] = {0};
+	int m_Port = 0;
+	bool m_Setup = false;
 
-	std::atomic_bool m_InUse;
+	std::atomic_bool m_InUse = false;
 };
 
 void CMysqlConnection::CStmtDeleter::operator()(MYSQL_STMT *pStmt) const

--- a/src/engine/server/databases/sqlite.cpp
+++ b/src/engine/server/databases/sqlite.cpp
@@ -56,12 +56,12 @@ public:
 
 private:
 	// copy of config vars
-	char m_aFilename[IO_MAX_PATH_LENGTH];
-	bool m_Setup;
+	char m_aFilename[IO_MAX_PATH_LENGTH] = {0};
+	bool m_Setup = false;
 
-	sqlite3 *m_pDb;
-	sqlite3_stmt *m_pStmt;
-	bool m_Done; // no more rows available for Step
+	sqlite3 *m_pDb = nullptr;
+	sqlite3_stmt *m_pStmt = nullptr;
+	bool m_Done = false; // no more rows available for Step
 	// returns false, if the query succeeded
 	bool Execute(const char *pQuery, char *pError, int ErrorSize);
 
@@ -69,7 +69,7 @@ private:
 	bool FormatError(int Result, char *pError, int ErrorSize);
 	void AssertNoError(int Result);
 
-	std::atomic_bool m_InUse;
+	std::atomic_bool m_InUse = false;
 };
 
 CSqliteConnection::CSqliteConnection(const char *pFilename, bool Setup) :

--- a/src/engine/server/name_ban.h
+++ b/src/engine/server/name_ban.h
@@ -23,12 +23,12 @@ public:
 		m_SkeletonLength = str_utf8_to_skeleton(m_aName, m_aSkeleton, std::size(m_aSkeleton));
 		str_copy(m_aReason, pReason);
 	}
-	char m_aName[MAX_NAME_LENGTH];
-	char m_aReason[MAX_NAMEBAN_REASON_LENGTH];
-	int m_aSkeleton[MAX_NAME_SKELETON_LENGTH];
-	int m_SkeletonLength;
-	int m_Distance;
-	int m_IsSubstring;
+	char m_aName[MAX_NAME_LENGTH] = {0};
+	char m_aReason[MAX_NAMEBAN_REASON_LENGTH] = {0};
+	int m_aSkeleton[MAX_NAME_SKELETON_LENGTH] = {0};
+	int m_SkeletonLength = 0;
+	int m_Distance = 0;
+	int m_IsSubstring = 0;
 };
 
 CNameBan *IsNameBanned(const char *pName, std::vector<CNameBan> &vNameBans);

--- a/src/engine/server/register.cpp
+++ b/src/engine/server/register.cpp
@@ -64,7 +64,7 @@ class CRegister : public IRegister
 				lock_destroy(m_Lock);
 			}
 
-			std::shared_ptr<CGlobal> m_pGlobal;
+			std::shared_ptr<CGlobal> m_pGlobal = nullptr;
 			LOCK m_Lock = lock_create();
 			int m_NumTotalRequests GUARDED_BY(m_Lock) = 0;
 			int m_LatestResponseStatus GUARDED_BY(m_Lock) = STATUS_NONE;
@@ -73,12 +73,12 @@ class CRegister : public IRegister
 
 		class CJob : public IJob
 		{
-			int m_Protocol;
-			int m_ServerPort;
-			int m_Index;
-			int m_InfoSerial;
-			std::shared_ptr<CShared> m_pShared;
-			std::unique_ptr<CHttpRequest> m_pRegister;
+			int m_Protocol = 0;
+			int m_ServerPort = 0;
+			int m_Index = 0;
+			int m_InfoSerial = 0;
+			std::shared_ptr<CShared> m_pShared = nullptr;
+			std::unique_ptr<CHttpRequest> m_pRegister = nullptr;
 			void Run() override;
 
 		public:
@@ -94,10 +94,10 @@ class CRegister : public IRegister
 			virtual ~CJob() = default;
 		};
 
-		CRegister *m_pParent;
-		int m_Protocol;
+		CRegister *m_pParent = nullptr;
+		int m_Protocol = 0;
 
-		std::shared_ptr<CShared> m_pShared;
+		std::shared_ptr<CShared> m_pShared = nullptr;
 		bool m_NewChallengeToken = false;
 		bool m_HaveChallengeToken = false;
 		char m_aChallengeToken[128] = {0};
@@ -115,24 +115,24 @@ class CRegister : public IRegister
 		void Update();
 	};
 
-	CConfig *m_pConfig;
-	IConsole *m_pConsole;
-	IEngine *m_pEngine;
-	int m_ServerPort;
-	char m_aConnlessTokenHex[16];
+	CConfig *m_pConfig = nullptr;
+	IConsole *m_pConsole = nullptr;
+	IEngine *m_pEngine = nullptr;
+	int m_ServerPort = 0;
+	char m_aConnlessTokenHex[16] = {0};
 
 	std::shared_ptr<CGlobal> m_pGlobal = std::make_shared<CGlobal>();
 	bool m_aProtocolEnabled[NUM_PROTOCOLS] = {true, true, true, true};
 	CProtocol m_aProtocols[NUM_PROTOCOLS];
 
 	int m_NumExtraHeaders = 0;
-	char m_aaExtraHeaders[8][128];
+	char m_aaExtraHeaders[8][128] = {{0}};
 
-	char m_aVerifyPacketPrefix[sizeof(SERVERBROWSE_CHALLENGE) + UUID_MAXSTRSIZE];
+	char m_aVerifyPacketPrefix[sizeof(SERVERBROWSE_CHALLENGE) + UUID_MAXSTRSIZE] = {0};
 	CUuid m_Secret = RandomUuid();
 	CUuid m_ChallengeSecret = RandomUuid();
 	bool m_GotServerInfo = false;
-	char m_aServerInfo[16384];
+	char m_aServerInfo[16384] = {0};
 
 public:
 	CRegister(CConfig *pConfig, IConsole *pConsole, IEngine *pEngine, int ServerPort, unsigned SixupSecurityToken);

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -352,7 +352,8 @@ void CServer::CClient::Reset()
 	for(auto &Input : m_aInputs)
 		Input.m_GameTick = -1;
 	m_CurrentInput = 0;
-	mem_zero(&m_LatestInput, sizeof(m_LatestInput));
+	m_LatestInput = CInput();
+	dbg_assert(mem_is_null(&m_LatestInput, sizeof(m_LatestInput)), "mem not null");
 
 	m_Snapshots.PurgeAll();
 	m_LastAckedSnapshot = -1;
@@ -835,7 +836,7 @@ static inline bool RepackMsg(const CMsgPacker *pMsg, CPacker &Packer, bool Sixup
 int CServer::SendMsg(CMsgPacker *pMsg, int Flags, int ClientID)
 {
 	CNetChunk Packet;
-	mem_zero(&Packet, sizeof(CNetChunk));
+	mem_zero(&Packet.m_Address, sizeof(NETADDR));
 	if(Flags & MSGFLAG_VITAL)
 		Packet.m_Flags |= NETSENDFLAG_VITAL;
 	if(Flags & MSGFLAG_FLUSH)
@@ -903,7 +904,7 @@ int CServer::SendMsg(CMsgPacker *pMsg, int Flags, int ClientID)
 void CServer::SendMsgRaw(int ClientID, const void *pData, int Size, int Flags)
 {
 	CNetChunk Packet;
-	mem_zero(&Packet, sizeof(CNetChunk));
+	mem_zero(&Packet.m_Address, sizeof(NETADDR));
 	Packet.m_ClientID = ClientID;
 	Packet.m_pData = pData;
 	Packet.m_DataSize = Size;
@@ -2417,7 +2418,8 @@ void CServer::PumpNetwork(bool PacketWaiting)
 	{
 		unsigned char aBuffer[NET_MAX_PAYLOAD];
 		int Flags;
-		mem_zero(&Packet, sizeof(Packet));
+		Packet = CNetChunk();
+		mem_zero(&Packet.m_Address, sizeof(NETADDR));
 		Packet.m_pData = aBuffer;
 		while(Antibot()->OnEngineSimulateClientMessage(&Packet.m_ClientID, aBuffer, sizeof(aBuffer), &Packet.m_DataSize, &Flags))
 		{

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -277,7 +277,7 @@ void CServerBan::ConBanRegionRange(IConsole::IResult *pResult, void *pUser)
 
 class CServerLogger : public ILogger
 {
-	CServer *m_pServer;
+	CServer *m_pServer = nullptr;
 	std::mutex m_PendingLock;
 	std::vector<CLogMessage> m_vPending;
 	std::thread::id m_MainThread;
@@ -329,8 +329,8 @@ void CServerLogger::OnServerDeletion()
 // Not thread-safe!
 class CRconClientLogger : public ILogger
 {
-	CServer *m_pServer;
-	int m_ClientID;
+	CServer *m_pServer = nullptr;
+	int m_ClientID = 0;
 
 public:
 	CRconClientLogger(CServer *pServer, int ClientID) :

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -54,18 +54,18 @@ class CSnapIDPool
 	class CID
 	{
 	public:
-		short m_Next;
-		short m_State; // 0 = free, 1 = allocated, 2 = timed
-		int m_Timeout;
+		short m_Next = 0;
+		short m_State = 0; // 0 = free, 1 = allocated, 2 = timed
+		int m_Timeout = 0;
 	};
 
 	CID m_aIDs[MAX_IDS];
 
-	int m_FirstFree;
-	int m_FirstTimed;
-	int m_LastTimed;
-	int m_Usage;
-	int m_InUsage;
+	int m_FirstFree = 0;
+	int m_FirstTimed = 0;
+	int m_LastTimed = 0;
+	int m_Usage = 0;
+	int m_InUsage = 0;
 
 public:
 	CSnapIDPool();
@@ -79,7 +79,7 @@ public:
 
 class CServerBan : public CNetBan
 {
-	class CServer *m_pServer;
+	class CServer *m_pServer = nullptr;
 
 	template<class T>
 	int BanExt(T *pBanPool, const typename T::CDataType *pData, int Seconds, const char *pReason);
@@ -101,12 +101,12 @@ class CServer : public IServer
 {
 	friend class CServerLogger;
 
-	class IGameServer *m_pGameServer;
-	class CConfig *m_pConfig;
-	class IConsole *m_pConsole;
-	class IStorage *m_pStorage;
-	class IEngineAntibot *m_pAntibot;
-	class IRegister *m_pRegister;
+	class IGameServer *m_pGameServer = nullptr;
+	class CConfig *m_pConfig = nullptr;
+	class IConsole *m_pConsole = nullptr;
+	class IStorage *m_pStorage = nullptr;
+	class IEngineAntibot *m_pAntibot = nullptr;
+	class IRegister *m_pRegister = nullptr;
 
 #if defined(CONF_UPNP)
 	CUPnP m_UPnP;
@@ -114,11 +114,11 @@ class CServer : public IServer
 
 #if defined(CONF_FAMILY_UNIX)
 	UNIXSOCKETADDR m_ConnLoggingDestAddr;
-	bool m_ConnLoggingSocketCreated;
+	bool m_ConnLoggingSocketCreated = false;
 	UNIXSOCKET m_ConnLoggingSocket;
 #endif
 
-	class CDbConnectionPool *m_pConnectionPool;
+	class CDbConnectionPool *m_pConnectionPool = nullptr;
 
 public:
 	class IGameServer *GameServer() { return m_pGameServer; }
@@ -159,62 +159,62 @@ public:
 		class CInput
 		{
 		public:
-			int m_aData[MAX_INPUT_SIZE];
-			int m_GameTick; // the tick that was chosen for the input
+			int m_aData[MAX_INPUT_SIZE] = {0};
+			int m_GameTick = 0; // the tick that was chosen for the input
 		};
 
 		// connection state info
-		int m_State;
-		int m_Latency;
-		int m_SnapRate;
+		int m_State = 0;
+		int m_Latency = 0;
+		int m_SnapRate = 0;
 
-		double m_Traffic;
-		int64_t m_TrafficSince;
+		double m_Traffic = 0;
+		int64_t m_TrafficSince = 0;
 
-		int m_LastAckedSnapshot;
-		int m_LastInputTick;
+		int m_LastAckedSnapshot = 0;
+		int m_LastInputTick = 0;
 		CSnapshotStorage m_Snapshots;
 
 		CInput m_LatestInput;
 		CInput m_aInputs[200]; // TODO: handle input better
-		int m_CurrentInput;
+		int m_CurrentInput = 0;
 
-		char m_aName[MAX_NAME_LENGTH];
-		char m_aClan[MAX_CLAN_LENGTH];
-		int m_Country;
-		int m_Score;
-		int m_Authed;
-		int m_AuthKey;
-		int m_AuthTries;
-		int m_NextMapChunk;
-		int m_Flags;
-		bool m_ShowIps;
+		char m_aName[MAX_NAME_LENGTH] = {0};
+		char m_aClan[MAX_CLAN_LENGTH] = {0};
+		int m_Country = 0;
+		int m_Score = 0;
+		int m_Authed = 0;
+		int m_AuthKey = 0;
+		int m_AuthTries = 0;
+		int m_NextMapChunk = 0;
+		int m_Flags = 0;
+		bool m_ShowIps = false;
 
-		const IConsole::CCommandInfo *m_pRconCmdToSend;
+		const IConsole::CCommandInfo *m_pRconCmdToSend = nullptr;
 
-		bool m_HasPersistentData;
-		void *m_pPersistentData;
+		bool m_HasPersistentData = false;
+		void *m_pPersistentData = nullptr;
 
 		void Reset();
 
 		// DDRace
 
 		NETADDR m_Addr;
-		bool m_GotDDNetVersionPacket;
-		bool m_DDNetVersionSettled;
-		int m_DDNetVersion;
-		char m_aDDNetVersionStr[64];
+		bool m_GotDDNetVersionPacket = false;
+		bool m_DDNetVersionSettled = false;
+		int m_DDNetVersion = 0;
+		char m_aDDNetVersionStr[64] = {0};
 		CUuid m_ConnectionID;
 
 		// DNSBL
-		int m_DnsblState;
-		std::shared_ptr<CHostLookup> m_pDnsblLookup;
+		int m_DnsblState = 0;
+		std::shared_ptr<CHostLookup> m_pDnsblLookup = nullptr;
 
-		bool m_Sixup;
+		bool m_Sixup = false;
 	};
 
 	CClient m_aClients[MAX_CLIENTS];
-	int m_aIdMap[MAX_CLIENTS * VANILLA_MAX_CLIENTS];
+	int m_aIdMap[MAX_CLIENTS * VANILLA_MAX_CLIENTS] = {0};
 
 	CSnapshotDelta m_SnapshotDelta;
 	CSnapshotBuilder m_SnapshotBuilder;
@@ -226,10 +226,10 @@ public:
 #endif
 	CServerBan m_ServerBan;
 
-	IEngineMap *m_pMap;
+	IEngineMap *m_pMap = nullptr;
 
-	int64_t m_GameStartTime;
-	//int m_CurrentGameTick;
+	int64_t m_GameStartTime = 0;
+	//int m_CurrentGameTick = 0;
 
 	enum
 	{
@@ -238,14 +238,14 @@ public:
 		STOPPING = 2
 	};
 
-	int m_RunServer;
+	int m_RunServer = 0;
 
-	bool m_MapReload;
-	bool m_ReloadedWhenEmpty;
-	int m_RconClientID;
-	int m_RconAuthLevel;
-	int m_PrintCBIndex;
-	char m_aShutdownReason[128];
+	bool m_MapReload = false;
+	bool m_ReloadedWhenEmpty = false;
+	int m_RconClientID = 0;
+	int m_RconAuthLevel = 0;
+	int m_PrintCBIndex = 0;
+	char m_aShutdownReason[128] = {0};
 
 	enum
 	{
@@ -254,19 +254,19 @@ public:
 		NUM_MAP_TYPES
 	};
 
-	char m_aCurrentMap[IO_MAX_PATH_LENGTH];
+	char m_aCurrentMap[IO_MAX_PATH_LENGTH] = {0};
 	SHA256_DIGEST m_aCurrentMapSha256[NUM_MAP_TYPES];
-	unsigned m_aCurrentMapCrc[NUM_MAP_TYPES];
-	unsigned char *m_apCurrentMapData[NUM_MAP_TYPES];
-	unsigned int m_aCurrentMapSize[NUM_MAP_TYPES];
+	unsigned m_aCurrentMapCrc[NUM_MAP_TYPES] = {0};
+	unsigned char *m_apCurrentMapData[NUM_MAP_TYPES] = {nullptr};
+	unsigned int m_aCurrentMapSize[NUM_MAP_TYPES] = {0};
 
 	CDemoRecorder m_aDemoRecorder[MAX_CLIENTS + 1];
 	CAuthManager m_AuthManager;
 
-	int64_t m_ServerInfoFirstRequest;
-	int m_ServerInfoNumRequests;
+	int64_t m_ServerInfoFirstRequest = 0;
+	int m_ServerInfoNumRequests = 0;
 
-	char m_aErrorShutdownReason[128];
+	char m_aErrorShutdownReason[128] = {0};
 
 	std::vector<CNameBan> m_vNameBans;
 
@@ -360,7 +360,7 @@ public:
 	};
 	CCache m_aServerInfoCache[3 * 2];
 	CCache m_aSixupServerInfoCache[2];
-	bool m_ServerInfoNeedsUpdate;
+	bool m_ServerInfoNeedsUpdate = false;
 
 	void ExpireServerInfo() override;
 	void CacheServerInfo(CCache *pCache, int Type, bool SendClients);
@@ -440,9 +440,9 @@ public:
 	// DDRace
 
 	void GetClientAddr(int ClientID, NETADDR *pAddr) const override;
-	int m_aPrevStates[MAX_CLIENTS];
+	int m_aPrevStates[MAX_CLIENTS] = {0};
 	const char *GetAnnouncementLine(char const *pFileName) override;
-	unsigned m_AnnouncementLastLine;
+	unsigned m_AnnouncementLastLine = 0;
 
 	int *GetIdMap(int ClientID) override;
 

--- a/src/engine/server/upnp.h
+++ b/src/engine/server/upnp.h
@@ -5,10 +5,10 @@
 class CUPnP
 {
 	NETADDR m_Addr;
-	struct UPNPUrls *m_pUPnPUrls;
-	struct IGDdatas *m_pUPnPData;
-	struct UPNPDev *m_pUPnPDevice;
-	bool m_Enabled;
+	struct UPNPUrls *m_pUPnPUrls = nullptr;
+	struct IGDdatas *m_pUPnPData = nullptr;
+	struct UPNPDev *m_pUPnPDevice = nullptr;
+	bool m_Enabled = false;
 
 public:
 	void Open(NETADDR Address);

--- a/src/engine/serverbrowser.h
+++ b/src/engine/serverbrowser.h
@@ -36,50 +36,50 @@ public:
 	class CClient
 	{
 	public:
-		char m_aName[MAX_NAME_LENGTH];
-		char m_aClan[MAX_CLAN_LENGTH];
-		int m_Country;
-		int m_Score;
-		bool m_Player;
+		char m_aName[MAX_NAME_LENGTH] = {0};
+		char m_aClan[MAX_CLAN_LENGTH] = {0};
+		int m_Country = 0;
+		int m_Score = 0;
+		bool m_Player = false;
 
-		int m_FriendState;
+		int m_FriendState = 0;
 	};
 
-	int m_ServerIndex;
+	int m_ServerIndex = 0;
 
-	int m_Type;
-	uint64_t m_ReceivedPackets;
-	int m_NumReceivedClients;
+	int m_Type = 0;
+	uint64_t m_ReceivedPackets = 0;
+	int m_NumReceivedClients = 0;
 
-	int m_NumAddresses;
+	int m_NumAddresses = 0;
 	NETADDR m_aAddresses[MAX_SERVER_ADDRESSES];
 
-	int m_QuickSearchHit;
-	int m_FriendState;
+	int m_QuickSearchHit = 0;
+	int m_FriendState = 0;
 
-	int m_MaxClients;
-	int m_NumClients;
-	int m_MaxPlayers;
-	int m_NumPlayers;
-	int m_Flags;
-	TRISTATE m_Favorite;
-	TRISTATE m_FavoriteAllowPing;
-	bool m_Official;
-	int m_Location;
-	bool m_LatencyIsEstimated;
-	int m_Latency; // in ms
-	int m_HasRank;
-	char m_aGameType[16];
-	char m_aName[64];
-	char m_aMap[MAX_MAP_LENGTH];
-	int m_MapCrc;
-	int m_MapSize;
-	char m_aVersion[32];
-	char m_aAddress[MAX_SERVER_ADDRESSES * NETADDR_MAXSTRSIZE];
+	int m_MaxClients = 0;
+	int m_NumClients = 0;
+	int m_MaxPlayers = 0;
+	int m_NumPlayers = 0;
+	int m_Flags = 0;
+	TRISTATE m_Favorite = TRISTATE::NONE;
+	TRISTATE m_FavoriteAllowPing = TRISTATE::NONE;
+	bool m_Official = false;
+	int m_Location = 0;
+	bool m_LatencyIsEstimated = false;
+	int m_Latency = 0; // in ms
+	int m_HasRank = 0;
+	char m_aGameType[16] = {0};
+	char m_aName[64] = {0};
+	char m_aMap[MAX_MAP_LENGTH] = {0};
+	int m_MapCrc = 0;
+	int m_MapSize = 0;
+	char m_aVersion[32] = {0};
+	char m_aAddress[MAX_SERVER_ADDRESSES * NETADDR_MAXSTRSIZE] = {0};
 	CClient m_aClients[SERVERINFO_MAX_CLIENTS];
-	mutable int m_NumFilteredPlayers;
+	mutable int m_NumFilteredPlayers = 0;
 
-	mutable CUIElement *m_pUIElement;
+	mutable CUIElement *m_pUIElement = nullptr;
 
 	static int EstimateLatency(int Loc1, int Loc2);
 	static bool ParseLocation(int *pResult, const char *pString);

--- a/src/engine/shared/assertion_logger.cpp
+++ b/src/engine/shared/assertion_logger.cpp
@@ -13,14 +13,14 @@ class CAssertionLogger : public ILogger
 
 	struct SDebugMessageItem
 	{
-		char m_aMessage[1024];
+		char m_aMessage[1024] = {0};
 	};
 
 	std::mutex m_DbgMessageMutex;
 	CStaticRingBuffer<SDebugMessageItem, sizeof(SDebugMessageItem) * 64, CRingBufferBase::FLAG_RECYCLE> m_DbgMessages;
 
-	char m_aAssertLogPath[IO_MAX_PATH_LENGTH];
-	char m_aGameName[256];
+	char m_aAssertLogPath[IO_MAX_PATH_LENGTH] = {0};
+	char m_aGameName[256] = {0};
 
 public:
 	CAssertionLogger(const char *pAssertLogPath, const char *pGameName);

--- a/src/engine/shared/config.h
+++ b/src/engine/shared/config.h
@@ -5,6 +5,7 @@
 
 #include <base/detect.h>
 #include <engine/config.h>
+#include <engine/shared/protocol.h>
 
 #define CONFIG_FILE "settings_ddnet.cfg"
 #define AUTOEXEC_FILE "autoexec.cfg"
@@ -14,9 +15,9 @@
 class CConfig
 {
 public:
-#define MACRO_CONFIG_INT(Name, ScriptName, Def, Min, Max, Save, Desc) int m_##Name;
-#define MACRO_CONFIG_COL(Name, ScriptName, Def, Save, Desc) unsigned m_##Name;
-#define MACRO_CONFIG_STR(Name, ScriptName, Len, Def, Save, Desc) char m_##Name[Len]; // Flawfinder: ignore
+#define MACRO_CONFIG_INT(Name, ScriptName, Def, Min, Max, Save, Desc) int m_##Name = Def;
+#define MACRO_CONFIG_COL(Name, ScriptName, Def, Save, Desc) unsigned m_##Name = Def;
+#define MACRO_CONFIG_STR(Name, ScriptName, Len, Def, Save, Desc) char m_##Name[Len] = Def; // Flawfinder: ignore
 #include "config_variables.h"
 #undef MACRO_CONFIG_INT
 #undef MACRO_CONFIG_COL
@@ -53,15 +54,15 @@ class CConfigManager : public IConfigManager
 
 	struct CCallback
 	{
-		SAVECALLBACKFUNC m_pfnFunc;
-		void *m_pUserData;
+		SAVECALLBACKFUNC m_pfnFunc = nullptr;
+		void *m_pUserData = nullptr;
 	};
 
-	class IStorage *m_pStorage;
+	class IStorage *m_pStorage = nullptr;
 	IOHANDLE m_ConfigFile;
-	bool m_Failed;
+	bool m_Failed = false;
 	CCallback m_aCallbacks[MAX_CALLBACKS];
-	int m_NumCallbacks;
+	int m_NumCallbacks = 0;
 
 public:
 	CConfigManager();

--- a/src/engine/shared/console.cpp
+++ b/src/engine/shared/console.cpp
@@ -725,28 +725,28 @@ void CConsole::ConUserCommandStatus(IResult *pResult, void *pUser)
 
 struct CIntVariableData
 {
-	IConsole *m_pConsole;
-	int *m_pVariable;
-	int m_Min;
-	int m_Max;
-	int m_OldValue;
+	IConsole *m_pConsole = nullptr;
+	int *m_pVariable = nullptr;
+	int m_Min = 0;
+	int m_Max = 0;
+	int m_OldValue = 0;
 };
 
 struct CColVariableData
 {
-	IConsole *m_pConsole;
-	unsigned *m_pVariable;
-	bool m_Light;
-	bool m_Alpha;
-	unsigned m_OldValue;
+	IConsole *m_pConsole = nullptr;
+	unsigned *m_pVariable = nullptr;
+	bool m_Light = false;
+	bool m_Alpha = false;
+	unsigned m_OldValue = 0;
 };
 
 struct CStrVariableData
 {
-	IConsole *m_pConsole;
-	char *m_pStr;
-	int m_MaxSize;
-	char *m_pOldValue;
+	IConsole *m_pConsole = nullptr;
+	char *m_pStr = nullptr;
+	int m_MaxSize = 0;
+	char *m_pOldValue = nullptr;
 };
 
 static void IntVariableCommand(IConsole::IResult *pResult, void *pUserData)

--- a/src/engine/shared/console.h
+++ b/src/engine/shared/console.h
@@ -13,11 +13,11 @@ class CConsole : public IConsole
 	class CCommand : public CCommandInfo
 	{
 	public:
-		CCommand *m_pNext;
-		int m_Flags;
-		bool m_Temp;
-		FCommandCallback m_pfnCallback;
-		void *m_pUserData;
+		CCommand *m_pNext = nullptr;
+		int m_Flags = 0;
+		bool m_Temp = false;
+		FCommandCallback m_pfnCallback = nullptr;
+		void *m_pUserData = nullptr;
 
 		const CCommandInfo *NextCommandInfo(int AccessLevel, int FlagMask) const override;
 
@@ -27,30 +27,30 @@ class CConsole : public IConsole
 	class CChain
 	{
 	public:
-		FChainCommandCallback m_pfnChainCallback;
-		FCommandCallback m_pfnCallback;
-		void *m_pCallbackUserData;
-		void *m_pUserData;
+		FChainCommandCallback m_pfnChainCallback = nullptr;
+		FCommandCallback m_pfnCallback = nullptr;
+		void *m_pCallbackUserData = nullptr;
+		void *m_pUserData = nullptr;
 	};
 
-	int m_FlagMask;
-	bool m_StoreCommands;
-	const char *m_apStrokeStr[2];
-	CCommand *m_pFirstCommand;
+	int m_FlagMask = 0;
+	bool m_StoreCommands = false;
+	const char *m_apStrokeStr[2] = {nullptr};
+	CCommand *m_pFirstCommand = nullptr;
 
 	class CExecFile
 	{
 	public:
-		const char *m_pFilename;
-		CExecFile *m_pPrev;
+		const char *m_pFilename = nullptr;
+		CExecFile *m_pPrev = nullptr;
 	};
 
-	CExecFile *m_pFirstExec;
-	class CConfig *m_pConfig;
-	class IStorage *m_pStorage;
-	int m_AccessLevel;
+	CExecFile *m_pFirstExec = nullptr;
+	class CConfig *m_pConfig = nullptr;
+	class IStorage *m_pStorage = nullptr;
+	int m_AccessLevel = 0;
 
-	CCommand *m_pRecycleList;
+	CCommand *m_pRecycleList = nullptr;
 	CHeap m_TempCommands;
 
 	static void TraverseChain(FCommandCallback *ppfnCallback, void **ppUserData);
@@ -65,8 +65,8 @@ class CConsole : public IConsole
 
 	void ExecuteLineStroked(int Stroke, const char *pStr, int ClientID = -1, bool InterpretSemicolons = true) override;
 
-	FTeeHistorianCommandCallback m_pfnTeeHistorianCommandCallback;
-	void *m_pTeeHistorianCommandUserdata;
+	FTeeHistorianCommandCallback m_pfnTeeHistorianCommandCallback = nullptr;
+	void *m_pTeeHistorianCommandUserdata = nullptr;
 
 	enum
 	{
@@ -77,11 +77,11 @@ class CConsole : public IConsole
 	class CResult : public IResult
 	{
 	public:
-		char m_aStringStorage[CONSOLE_MAX_STR_LENGTH + 1];
-		char *m_pArgsStart;
+		char m_aStringStorage[CONSOLE_MAX_STR_LENGTH + 1] = {0};
+		char *m_pArgsStart = nullptr;
 
-		const char *m_pCommand;
-		const char *m_apArgs[MAX_PARTS];
+		const char *m_pCommand = nullptr;
+		const char *m_apArgs[MAX_PARTS] = {nullptr};
 
 		CResult()
 
@@ -134,7 +134,7 @@ class CConsole : public IConsole
 			VICTIM_ALL = -1,
 		};
 
-		int m_Victim;
+		int m_Victim = 0;
 		void ResetVictim();
 		bool HasVictim();
 		void SetVictim(int Victim);
@@ -160,11 +160,11 @@ class CConsole : public IConsole
 	public:
 		struct CQueueEntry
 		{
-			CQueueEntry *m_pNext;
-			FCommandCallback m_pfnCommandCallback;
-			void *m_pCommandUserData;
+			CQueueEntry *m_pNext = nullptr;
+			FCommandCallback m_pfnCommandCallback = nullptr;
+			void *m_pCommandUserData = nullptr;
 			CResult m_Result;
-		} * m_pFirst, *m_pLast;
+		} *m_pFirst = nullptr, *m_pLast = nullptr;
 
 		void AddEntry()
 		{

--- a/src/engine/shared/datafile.cpp
+++ b/src/engine/shared/datafile.cpp
@@ -561,7 +561,8 @@ void CDataFileWriter::Init()
 	m_NumDatas = 0;
 	m_NumItemTypes = 0;
 	m_NumExtendedItemTypes = 0;
-	mem_zero(m_pItemTypes, sizeof(CItemTypeInfo) * MAX_ITEM_TYPES);
+	new(m_pItemTypes) CItemTypeInfo[MAX_ITEM_TYPES];
+	dbg_assert(mem_is_null(m_pItemTypes, sizeof(CItemTypeInfo)*MAX_ITEM_TYPES), "mem not null");
 	mem_zero(m_aExtendedItemTypes, sizeof(m_aExtendedItemTypes));
 
 	for(int i = 0; i < MAX_ITEM_TYPES; i++)

--- a/src/engine/shared/datafile.cpp
+++ b/src/engine/shared/datafile.cpp
@@ -20,7 +20,7 @@ enum
 
 struct CItemEx
 {
-	int m_aUuid[sizeof(CUuid) / 4];
+	int m_aUuid[sizeof(CUuid) / 4] = {0};
 
 	static CItemEx FromUuid(CUuid Uuid)
 	{
@@ -41,61 +41,61 @@ struct CItemEx
 
 struct CDatafileItemType
 {
-	int m_Type;
-	int m_Start;
-	int m_Num;
+	int m_Type = 0;
+	int m_Start = 0;
+	int m_Num = 0;
 };
 
 struct CDatafileItem
 {
-	int m_TypeAndID;
-	int m_Size;
+	int m_TypeAndID = 0;
+	int m_Size = 0;
 };
 
 struct CDatafileHeader
 {
-	char m_aID[4];
-	int m_Version;
-	int m_Size;
-	int m_Swaplen;
-	int m_NumItemTypes;
-	int m_NumItems;
-	int m_NumRawData;
-	int m_ItemSize;
-	int m_DataSize;
+	char m_aID[4] = {0};
+	int m_Version = 0;
+	int m_Size = 0;
+	int m_Swaplen = 0;
+	int m_NumItemTypes = 0;
+	int m_NumItems = 0;
+	int m_NumRawData = 0;
+	int m_ItemSize = 0;
+	int m_DataSize = 0;
 };
 
 struct CDatafileData
 {
-	int m_NumItemTypes;
-	int m_NumItems;
-	int m_NumRawData;
-	int m_ItemSize;
-	int m_DataSize;
-	char m_aStart[4];
+	int m_NumItemTypes = 0;
+	int m_NumItems = 0;
+	int m_NumRawData = 0;
+	int m_ItemSize = 0;
+	int m_DataSize = 0;
+	char m_aStart[4] = {0};
 };
 
 struct CDatafileInfo
 {
-	CDatafileItemType *m_pItemTypes;
-	int *m_pItemOffsets;
-	int *m_pDataOffsets;
-	int *m_pDataSizes;
+	CDatafileItemType *m_pItemTypes = nullptr;
+	int *m_pItemOffsets = nullptr;
+	int *m_pDataOffsets = nullptr;
+	int *m_pDataSizes = nullptr;
 
-	char *m_pItemStart;
-	char *m_pDataStart;
+	char *m_pItemStart = nullptr;
+	char *m_pDataStart = nullptr;
 };
 
 struct CDatafile
 {
 	IOHANDLE m_File;
 	SHA256_DIGEST m_Sha256;
-	unsigned m_Crc;
+	unsigned m_Crc = 0;
 	CDatafileInfo m_Info;
 	CDatafileHeader m_Header;
-	int m_DataStartOffset;
-	char **m_ppDataPtrs;
-	char *m_pData;
+	int m_DataStartOffset = 0;
+	char **m_ppDataPtrs = nullptr;
+	char *m_pData = nullptr;
 };
 
 bool CDataFileReader::Open(class IStorage *pStorage, const char *pFilename, int StorageType)

--- a/src/engine/shared/datafile.h
+++ b/src/engine/shared/datafile.h
@@ -18,7 +18,7 @@ enum
 // raw datafile access
 class CDataFileReader
 {
-	struct CDatafile *m_pDataFile;
+	struct CDatafile *m_pDataFile = nullptr;
 	void *GetDataImpl(int Index, int Swap);
 	int GetFileDataSize(int Index);
 
@@ -59,26 +59,26 @@ class CDataFileWriter
 {
 	struct CDataInfo
 	{
-		int m_UncompressedSize;
-		int m_CompressedSize;
-		void *m_pCompressedData;
+		int m_UncompressedSize = 0;
+		int m_CompressedSize = 0;
+		void *m_pCompressedData = nullptr;
 	};
 
 	struct CItemInfo
 	{
-		int m_Type;
-		int m_ID;
-		int m_Size;
-		int m_Next;
-		int m_Prev;
-		void *m_pData;
+		int m_Type = 0;
+		int m_ID = 0;
+		int m_Size = 0;
+		int m_Next = 0;
+		int m_Prev = 0;
+		void *m_pData = nullptr;
 	};
 
 	struct CItemTypeInfo
 	{
-		int m_Num;
-		int m_First;
-		int m_Last;
+		int m_Num = 0;
+		int m_First = 0;
+		int m_Last = 0;
 	};
 
 	enum
@@ -90,14 +90,14 @@ class CDataFileWriter
 	};
 
 	IOHANDLE m_File;
-	int m_NumItems;
-	int m_NumDatas;
-	int m_NumItemTypes;
-	int m_NumExtendedItemTypes;
-	CItemTypeInfo *m_pItemTypes;
-	CItemInfo *m_pItems;
-	CDataInfo *m_pDatas;
-	int m_aExtendedItemTypes[MAX_EXTENDED_ITEM_TYPES];
+	int m_NumItems = 0;
+	int m_NumDatas = 0;
+	int m_NumItemTypes = 0;
+	int m_NumExtendedItemTypes = 0;
+	CItemTypeInfo *m_pItemTypes = nullptr;
+	CItemInfo *m_pItems = nullptr;
+	CDataInfo *m_pDatas = nullptr;
+	int m_aExtendedItemTypes[MAX_EXTENDED_ITEM_TYPES] = {0};
 
 	int GetExtendedItemTypeIndex(int Type);
 	int GetTypeFromIndex(int Index);

--- a/src/engine/shared/demo.cpp
+++ b/src/engine/shared/demo.cpp
@@ -128,7 +128,7 @@ int CDemoRecorder::Start(class IStorage *pStorage, class IConsole *pConsole, con
 		MapSize = io_length(MapFile);
 
 	// write header
-	mem_zero(&Header, sizeof(Header));
+	Header = CDemoHeader();
 	mem_copy(Header.m_aMarker, gs_aHeaderMarker, sizeof(Header.m_aMarker));
 	Header.m_Version = gs_CurVersion;
 	str_copy(Header.m_aNetversion, pNetVersion);
@@ -708,7 +708,7 @@ int CDemoPlayer::Load(class IStorage *pStorage, class IConsole *pConsole, const 
 	str_copy(m_aFilename, pFilename);
 
 	// clear the playback info
-	mem_zero(&m_Info, sizeof(m_Info));
+	m_Info = CDemoPlayer::CPlaybackInfo();
 	m_Info.m_Info.m_FirstTick = -1;
 	m_Info.m_Info.m_LastTick = -1;
 	m_Info.m_NextTick = -1;
@@ -1067,8 +1067,8 @@ bool CDemoPlayer::GetDemoInfo(class IStorage *pStorage, const char *pFilename, i
 	if(!pDemoHeader || !pTimelineMarkers || !pMapInfo)
 		return false;
 
-	mem_zero(pDemoHeader, sizeof(CDemoHeader));
-	mem_zero(pTimelineMarkers, sizeof(CTimelineMarkers));
+	*pDemoHeader = CDemoHeader();
+	*pTimelineMarkers = CTimelineMarkers();
 
 	IOHANDLE File = pStorage->OpenFile(pFilename, IOFLAG_READ, StorageType);
 	if(!File)

--- a/src/engine/shared/demo.cpp
+++ b/src/engine/shared/demo.cpp
@@ -799,7 +799,7 @@ int CDemoPlayer::Load(class IStorage *pStorage, class IConsole *pConsole, const 
 		m_Info.m_Info.m_NumTimelineMarkers = clamp<int>(Num, 0, MAX_TIMELINE_MARKERS);
 		for(int i = 0; i < m_Info.m_Info.m_NumTimelineMarkers; i++)
 		{
-			m_Info.m_Info.m_aTimelineMarkers[i] = bytes_be_to_int(m_Info.m_TimelineMarkers.m_aTimelineMarkers[i]);
+			m_Info.m_Info.m_aTimelineMarkers[i] = bytes_be_to_int(m_Info.m_TimelineMarkers.m_aaTimelineMarkers[i]);
 		}
 	}
 

--- a/src/engine/shared/demo.h
+++ b/src/engine/shared/demo.h
@@ -15,21 +15,21 @@ typedef std::function<void()> TUpdateIntraTimesFunc;
 
 class CDemoRecorder : public IDemoRecorder
 {
-	class IConsole *m_pConsole;
+	class IConsole *m_pConsole = nullptr;
 	IOHANDLE m_File;
-	char m_aCurrentFilename[256];
-	int m_LastTickMarker;
-	int m_LastKeyFrame;
-	int m_FirstTick;
-	unsigned char m_aLastSnapshotData[CSnapshot::MAX_SIZE];
-	class CSnapshotDelta *m_pSnapshotDelta;
-	int m_NumTimelineMarkers;
-	int m_aTimelineMarkers[MAX_TIMELINE_MARKERS];
-	bool m_NoMapData;
-	unsigned char *m_pMapData;
+	char m_aCurrentFilename[256] = {0};
+	int m_LastTickMarker = 0;
+	int m_LastKeyFrame = 0;
+	int m_FirstTick = 0;
+	unsigned char m_aLastSnapshotData[CSnapshot::MAX_SIZE] = {0};
+	class CSnapshotDelta *m_pSnapshotDelta = nullptr;
+	int m_NumTimelineMarkers = 0;
+	int m_aTimelineMarkers[MAX_TIMELINE_MARKERS] = {0};
+	bool m_NoMapData = false;
+	unsigned char *m_pMapData = nullptr;
 
-	DEMOFUNC_FILTER m_pfnFilter;
-	void *m_pUser;
+	DEMOFUNC_FILTER m_pfnFilter = nullptr;
+	void *m_pUser = nullptr;
 
 	void WriteTickMarker(int Tick, int Keyframe);
 	void Write(int Type, const void *pData, int Size);
@@ -69,50 +69,50 @@ public:
 
 		IDemoPlayer::CInfo m_Info;
 
-		int64_t m_LastUpdate;
-		int64_t m_CurrentTime;
+		int64_t m_LastUpdate = 0;
+		int64_t m_CurrentTime = 0;
 
-		int m_SeekablePoints;
+		int m_SeekablePoints = 0;
 
-		int m_NextTick;
-		int m_PreviousTick;
+		int m_NextTick = 0;
+		int m_PreviousTick = 0;
 
-		float m_IntraTick;
-		float m_IntraTickSincePrev;
-		float m_TickTime;
+		float m_IntraTick = 0;
+		float m_IntraTickSincePrev = 0;
+		float m_TickTime = 0;
 	};
 
 private:
-	IListener *m_pListener;
+	IListener *m_pListener = nullptr;
 
 	TUpdateIntraTimesFunc m_UpdateIntraTimesFunc;
 
 	// Playback
 	struct CKeyFrame
 	{
-		long m_Filepos;
-		int m_Tick;
+		long m_Filepos = 0;
+		int m_Tick = 0;
 	};
 
 	struct CKeyFrameSearch
 	{
 		CKeyFrame m_Frame;
-		CKeyFrameSearch *m_pNext;
+		CKeyFrameSearch *m_pNext = nullptr;
 	};
 
-	class IConsole *m_pConsole;
+	class IConsole *m_pConsole = nullptr;
 	IOHANDLE m_File;
-	long m_MapOffset;
-	char m_aFilename[IO_MAX_PATH_LENGTH];
-	CKeyFrame *m_pKeyFrames;
+	long m_MapOffset = 0;
+	char m_aFilename[IO_MAX_PATH_LENGTH] = {0};
+	CKeyFrame *m_pKeyFrames = nullptr;
 	CMapInfo m_MapInfo;
-	int m_SpeedIndex;
+	int m_SpeedIndex = 0;
 
 	CPlaybackInfo m_Info;
-	int m_DemoType;
-	unsigned char m_aLastSnapshotData[CSnapshot::MAX_SIZE];
-	int m_LastSnapshotDataSize;
-	class CSnapshotDelta *m_pSnapshotDelta;
+	int m_DemoType = 0;
+	unsigned char m_aLastSnapshotData[CSnapshot::MAX_SIZE] = {0};
+	int m_LastSnapshotDataSize = 0;
+	class CSnapshotDelta *m_pSnapshotDelta = nullptr;
 
 	int ReadChunkHeader(int *pType, int *pSize, int *pTick);
 	void DoTick();
@@ -156,16 +156,16 @@ public:
 
 class CDemoEditor : public IDemoEditor, public CDemoPlayer::IListener
 {
-	CDemoPlayer *m_pDemoPlayer;
-	CDemoRecorder *m_pDemoRecorder;
-	IConsole *m_pConsole;
-	IStorage *m_pStorage;
-	class CSnapshotDelta *m_pSnapshotDelta;
-	const char *m_pNetVersion;
+	CDemoPlayer *m_pDemoPlayer = nullptr;
+	CDemoRecorder *m_pDemoRecorder = nullptr;
+	IConsole *m_pConsole = nullptr;
+	IStorage *m_pStorage = nullptr;
+	class CSnapshotDelta *m_pSnapshotDelta = nullptr;
+	const char *m_pNetVersion = nullptr;
 
-	bool m_Stop;
-	int m_SliceFrom;
-	int m_SliceTo;
+	bool m_Stop = false;
+	int m_SliceFrom = 0;
+	int m_SliceTo = 0;
 
 public:
 	virtual void Init(const char *pNetVersion, class CSnapshotDelta *pSnapshotDelta, class IConsole *pConsole, class IStorage *pStorage);

--- a/src/engine/shared/econ.h
+++ b/src/engine/shared/econ.h
@@ -26,19 +26,19 @@ class CEcon
 			STATE_AUTHED,
 		};
 
-		int m_State;
-		int64_t m_TimeConnected;
-		int m_AuthTries;
+		int m_State = 0;
+		int64_t m_TimeConnected = 0;
+		int m_AuthTries = 0;
 	};
 	CClient m_aClients[NET_MAX_CONSOLE_CLIENTS];
 
-	CConfig *m_pConfig;
-	IConsole *m_pConsole;
+	CConfig *m_pConfig = nullptr;
+	IConsole *m_pConsole = nullptr;
 	CNetConsole m_NetConsole;
 
-	bool m_Ready;
-	int m_PrintCBIndex;
-	int m_UserClientID;
+	bool m_Ready = false;
+	int m_PrintCBIndex = 0;
+	int m_UserClientID = 0;
 
 	static void SendLineCB(const char *pLine, void *pUserData, ColorRGBA PrintColor = {1, 1, 1, 1});
 	static void ConLogout(IConsole::IResult *pResult, void *pUserData);

--- a/src/engine/shared/engine.cpp
+++ b/src/engine/shared/engine.cpp
@@ -26,13 +26,13 @@ void CHostLookup::Run()
 class CEngine : public IEngine
 {
 public:
-	IConsole *m_pConsole;
-	IStorage *m_pStorage;
-	bool m_Logging;
+	IConsole *m_pConsole = nullptr;
+	IStorage *m_pStorage = nullptr;
+	bool m_Logging = false;
 
-	std::shared_ptr<CFutureLogger> m_pFutureLogger;
+	std::shared_ptr<CFutureLogger> m_pFutureLogger = nullptr;
 
-	char m_aAppName[256];
+	char m_aAppName[256] = {0};
 
 	static void Con_DbgLognetwork(IConsole::IResult *pResult, void *pUserData)
 	{

--- a/src/engine/shared/fifo.h
+++ b/src/engine/shared/fifo.h
@@ -7,10 +7,10 @@
 
 class CFifo
 {
-	IConsole *m_pConsole;
-	char m_aFilename[IO_MAX_PATH_LENGTH];
-	int m_Flag;
-	int m_File;
+	IConsole *m_pConsole = nullptr;
+	char m_aFilename[IO_MAX_PATH_LENGTH] = {0};
+	int m_Flag = 0;
+	int m_File = 0;
 
 public:
 	void Init(IConsole *pConsole, char *pFifoFile, int Flag);

--- a/src/engine/shared/filecollection.h
+++ b/src/engine/shared/filecollection.h
@@ -17,16 +17,16 @@ class CFileCollection
 		TIMESTAMP_LENGTH = 20, // _YYYY-MM-DD_HH-MM-SS
 	};
 
-	int64_t m_aTimestamps[MAX_ENTRIES];
-	int m_NumTimestamps;
-	int m_MaxEntries;
-	char m_aFileDesc[128];
-	int m_FileDescLength;
-	char m_aFileExt[32];
-	int m_FileExtLength;
-	char m_aPath[IO_MAX_PATH_LENGTH];
-	IStorage *m_pStorage;
-	int64_t m_Remove; // Timestamp we want to remove
+	int64_t m_aTimestamps[MAX_ENTRIES] = {0};
+	int m_NumTimestamps = 0;
+	int m_MaxEntries = 0;
+	char m_aFileDesc[128] = {0};
+	int m_FileDescLength = 0;
+	char m_aFileExt[32] = {0};
+	int m_FileExtLength = 0;
+	char m_aPath[IO_MAX_PATH_LENGTH] = {0};
+	IStorage *m_pStorage = nullptr;
+	int64_t m_Remove = 0; // Timestamp we want to remove
 
 	bool IsFilenameValid(const char *pFilename);
 	int64_t ExtractTimestamp(const char *pTimestring);

--- a/src/engine/shared/http.h
+++ b/src/engine/shared/http.h
@@ -33,10 +33,10 @@ enum class IPRESOLVE
 
 struct CTimeout
 {
-	long ConnectTimeoutMs;
-	long TimeoutMs;
-	long LowSpeedLimit;
-	long LowSpeedTime;
+	long ConnectTimeoutMs = 0;
+	long TimeoutMs = 0;
+	long LowSpeedLimit = 0;
+	long LowSpeedTime = 0;
 };
 
 class CHttpRequest : public IJob
@@ -120,13 +120,13 @@ public:
 	void Header(const char *pNameColonValue);
 	void HeaderString(const char *pName, const char *pValue)
 	{
-		char aHeader[256];
+		char aHeader[256] = {0};
 		str_format(aHeader, sizeof(aHeader), "%s: %s", pName, pValue);
 		Header(aHeader);
 	}
 	void HeaderInt(const char *pName, int Value)
 	{
-		char aHeader[256];
+		char aHeader[256] = {0};
 		str_format(aHeader, sizeof(aHeader), "%s: %d", pName, Value);
 		Header(aHeader);
 	}

--- a/src/engine/shared/huffman.cpp
+++ b/src/engine/shared/huffman.cpp
@@ -21,8 +21,8 @@ const unsigned CHuffman::ms_aFreqTable[HUFFMAN_MAX_SYMBOLS] = {
 
 struct CHuffmanConstructNode
 {
-	unsigned short m_NodeId;
-	int m_Frequency;
+	unsigned short m_NodeId = 0;
+	int m_Frequency = 0;
 };
 
 bool CompareNodesByFrequencyDesc(const CHuffmanConstructNode *pNode1, const CHuffmanConstructNode *pNode2)

--- a/src/engine/shared/huffman.cpp
+++ b/src/engine/shared/huffman.cpp
@@ -93,7 +93,7 @@ void CHuffman::ConstructTree(const unsigned *pFrequencies)
 void CHuffman::Init(const unsigned *pFrequencies)
 {
 	// make sure to cleanout every thing
-	mem_zero(m_aNodes, sizeof(m_aNodes));
+	new(m_aNodes) std::remove_pointer<decltype(m_aNodes)>::type;
 	mem_zero(m_apDecodeLut, sizeof(m_apDecodeLut));
 	m_pStartNode = 0x0;
 	m_NumNodes = 0;

--- a/src/engine/shared/huffman.h
+++ b/src/engine/shared/huffman.h
@@ -20,22 +20,22 @@ class CHuffman
 	struct CNode
 	{
 		// symbol
-		unsigned m_Bits;
-		unsigned m_NumBits;
+		unsigned m_Bits = 0;
+		unsigned m_NumBits = 0;
 
 		// don't use pointers for this. shorts are smaller so we can fit more data into the cache
-		unsigned short m_aLeafs[2];
+		unsigned short m_aLeafs[2] = {0};
 
 		// what the symbol represents
-		unsigned char m_Symbol;
+		unsigned char m_Symbol = 0;
 	};
 
 	static const unsigned ms_aFreqTable[HUFFMAN_MAX_SYMBOLS];
 
 	CNode m_aNodes[HUFFMAN_MAX_NODES];
-	CNode *m_apDecodeLut[HUFFMAN_LUTSIZE];
-	CNode *m_pStartNode;
-	int m_NumNodes;
+	CNode *m_apDecodeLut[HUFFMAN_LUTSIZE] = {nullptr};
+	CNode *m_pStartNode = nullptr;
+	int m_NumNodes = 0;
 
 	void Setbits_r(CNode *pNode, int Bits, unsigned Depth);
 	void ConstructTree(const unsigned *pFrequencies);

--- a/src/engine/shared/jobs.h
+++ b/src/engine/shared/jobs.h
@@ -15,9 +15,9 @@ class IJob
 	friend CJobPool;
 
 private:
-	std::shared_ptr<IJob> m_pNext;
+	std::shared_ptr<IJob> m_pNext = nullptr;
 
-	std::atomic<int> m_Status;
+	std::atomic<int> m_Status = 0;
 	virtual void Run() = 0;
 
 public:
@@ -41,14 +41,14 @@ class CJobPool
 	{
 		MAX_THREADS = 32
 	};
-	int m_NumThreads;
-	void *m_apThreads[MAX_THREADS];
-	std::atomic<bool> m_Shutdown;
+	int m_NumThreads = 0;
+	void *m_apThreads[MAX_THREADS] = {nullptr};
+	std::atomic<bool> m_Shutdown = false;
 
 	LOCK m_Lock;
 	SEMAPHORE m_Semaphore;
-	std::shared_ptr<IJob> m_pFirstJob GUARDED_BY(m_Lock);
-	std::shared_ptr<IJob> m_pLastJob GUARDED_BY(m_Lock);
+	std::shared_ptr<IJob> m_pFirstJob GUARDED_BY(m_Lock) = nullptr;
+	std::shared_ptr<IJob> m_pLastJob GUARDED_BY(m_Lock) = nullptr;
 
 	static void WorkerThread(void *pUser) NO_THREAD_SAFETY_ANALYSIS;
 

--- a/src/engine/shared/kernel.cpp
+++ b/src/engine/shared/kernel.cpp
@@ -20,13 +20,13 @@ class CKernel : public IKernel
 			m_AutoDestroy = false;
 		}
 
-		char m_aName[64];
-		IInterface *m_pInterface;
-		bool m_AutoDestroy;
+		char m_aName[64] = {0};
+		IInterface *m_pInterface = nullptr;
+		bool m_AutoDestroy = false;
 	};
 
 	CInterfaceInfo m_aInterfaces[MAX_INTERFACES];
-	int m_NumInterfaces;
+	int m_NumInterfaces = 0;
 
 	CInterfaceInfo *FindInterfaceInfo(const char *pName)
 	{

--- a/src/engine/shared/linereader.h
+++ b/src/engine/shared/linereader.h
@@ -7,10 +7,10 @@
 // buffered stream for reading lines, should perhaps be something smaller
 class CLineReader
 {
-	char m_aBuffer[4 * 8192 + 1]; // 1 additional byte for null termination
-	unsigned m_BufferPos;
-	unsigned m_BufferSize;
-	unsigned m_BufferMaxSize;
+	char m_aBuffer[4 * 8192 + 1] = {0}; // 1 additional byte for null termination
+	unsigned m_BufferPos = 0;
+	unsigned m_BufferSize = 0;
+	unsigned m_BufferMaxSize = 0;
 	IOHANDLE m_File;
 
 public:

--- a/src/engine/shared/memheap.h
+++ b/src/engine/shared/memheap.h
@@ -8,10 +8,10 @@ class CHeap
 {
 	struct CChunk
 	{
-		char *m_pMemory;
-		char *m_pCurrent;
-		char *m_pEnd;
-		CChunk *m_pNext;
+		char *m_pMemory = nullptr;
+		char *m_pCurrent = nullptr;
+		char *m_pEnd = nullptr;
+		CChunk *m_pNext = nullptr;
 	};
 
 	enum
@@ -20,7 +20,7 @@ class CHeap
 		CHUNK_SIZE = 1025 * 64,
 	};
 
-	CChunk *m_pCurrent;
+	CChunk *m_pCurrent = nullptr;
 
 	void Clear();
 	void NewChunk();

--- a/src/engine/shared/netban.cpp
+++ b/src/engine/shared/netban.cpp
@@ -202,7 +202,7 @@ template<class T, int HashCount>
 void CNetBan::CBanPool<T, HashCount>::Reset()
 {
 	mem_zero(m_aapHashList, sizeof(m_aapHashList));
-	mem_zero(m_aBans, sizeof(m_aBans));
+	new(m_aBans) typename std::remove_pointer<decltype(m_aBans)>::type;
 	m_pFirstUsed = 0;
 	m_CountUsed = 0;
 

--- a/src/engine/shared/netban.h
+++ b/src/engine/shared/netban.h
@@ -45,7 +45,7 @@ protected:
 
 	const char *NetToString(const NETADDR *pData, char *pBuffer, unsigned BufferSize) const
 	{
-		char aAddrStr[NETADDR_MAXSTRSIZE];
+		char aAddrStr[NETADDR_MAXSTRSIZE] = {0};
 		net_addr_str(pData, aAddrStr, sizeof(aAddrStr), false);
 		str_format(pBuffer, BufferSize, "'%s'", aAddrStr);
 		return pBuffer;
@@ -63,8 +63,8 @@ protected:
 	class CNetHash
 	{
 	public:
-		int m_Hash;
-		int m_HashIndex; // matching parts for ranges, 0 for addr
+		int m_Hash = 0;
+		int m_HashIndex = 0; // matching parts for ranges, 0 for addr
 
 		CNetHash() {}
 		CNetHash(const NETADDR *pAddr);
@@ -80,8 +80,8 @@ protected:
 			EXPIRES_NEVER = -1,
 			REASON_LENGTH = 64,
 		};
-		int m_Expires;
-		char m_aReason[REASON_LENGTH];
+		int m_Expires = 0;
+		char m_aReason[REASON_LENGTH] = {0};
 	};
 
 	template<class T>
@@ -92,12 +92,12 @@ protected:
 		CNetHash m_NetHash;
 
 		// hash list
-		CBan *m_pHashNext;
-		CBan *m_pHashPrev;
+		CBan *m_pHashNext = nullptr;
+		CBan *m_pHashPrev = nullptr;
 
 		// used or free list
-		CBan *m_pNext;
-		CBan *m_pPrev;
+		CBan *m_pNext = nullptr;
+		CBan *m_pPrev = nullptr;
 	};
 
 	template<class T, int HashCount>
@@ -134,11 +134,11 @@ protected:
 			MAX_BANS = 1024,
 		};
 
-		CBan<CDataType> *m_aapHashList[HashCount][256];
+		CBan<CDataType> *m_aapHashList[HashCount][256] = {{nullptr}};
 		CBan<CDataType> m_aBans[MAX_BANS];
-		CBan<CDataType> *m_pFirstFree;
-		CBan<CDataType> *m_pFirstUsed;
-		int m_CountUsed;
+		CBan<CDataType> *m_pFirstFree = nullptr;
+		CBan<CDataType> *m_pFirstUsed = nullptr;
+		int m_CountUsed = 0;
 	};
 
 	typedef CBanPool<NETADDR, 1> CBanAddrPool;
@@ -153,8 +153,8 @@ protected:
 	template<class T>
 	int Unban(T *pBanPool, const typename T::CDataType *pData);
 
-	class IConsole *m_pConsole;
-	class IStorage *m_pStorage;
+	class IConsole *m_pConsole = nullptr;
+	class IStorage *m_pStorage = nullptr;
 	CBanAddrPool m_BanAddrPool;
 	CBanRangePool m_BanRangePool;
 	NETADDR m_LocalhostIPV4, m_LocalhostIPV6;
@@ -203,12 +203,12 @@ void CNetBan::MakeBanInfo(const CBan<T> *pBan, char *pBuf, unsigned BuffSize, in
 	}
 
 	// build type based part
-	char aBuf[256];
+	char aBuf[256] = {0};
 	if(Type == MSGTYPE_PLAYER)
 		str_copy(aBuf, "You have been banned");
 	else
 	{
-		char aTemp[256];
+		char aTemp[256] = {0};
 		switch(Type)
 		{
 		case MSGTYPE_LIST:

--- a/src/engine/shared/network.h
+++ b/src/engine/shared/network.h
@@ -117,21 +117,21 @@ struct CNetChunk
 {
 	// -1 means that it's a stateless packet
 	// 0 on the client means the server
-	int m_ClientID;
+	int m_ClientID = 0;
 	NETADDR m_Address; // only used when client_id == -1
-	int m_Flags;
-	int m_DataSize;
-	const void *m_pData;
+	int m_Flags = 0;
+	int m_DataSize = 0;
+	const void *m_pData = nullptr;
 	// only used if the flags contain NETSENDFLAG_EXTENDED and NETSENDFLAG_CONNLESS
-	unsigned char m_aExtraData[4];
+	unsigned char m_aExtraData[4] = {0};
 };
 
 class CNetChunkHeader
 {
 public:
-	int m_Flags;
-	int m_Size;
-	int m_Sequence;
+	int m_Flags = 0;
+	int m_Size = 0;
+	int m_Sequence = 0;
 
 	unsigned char *Pack(unsigned char *pData, int Split = 4);
 	unsigned char *Unpack(unsigned char *pData, int Split = 4);
@@ -140,24 +140,24 @@ public:
 class CNetChunkResend
 {
 public:
-	int m_Flags;
-	int m_DataSize;
-	unsigned char *m_pData;
+	int m_Flags = 0;
+	int m_DataSize = 0;
+	unsigned char *m_pData = nullptr;
 
-	int m_Sequence;
-	int64_t m_LastSendTime;
-	int64_t m_FirstSendTime;
+	int m_Sequence = 0;
+	int64_t m_LastSendTime = 0;
+	int64_t m_FirstSendTime = 0;
 };
 
 class CNetPacketConstruct
 {
 public:
-	int m_Flags;
-	int m_Ack;
-	int m_NumChunks;
-	int m_DataSize;
-	unsigned char m_aChunkData[NET_MAX_PAYLOAD];
-	unsigned char m_aExtraData[4];
+	int m_Flags = 0;
+	int m_Ack = 0;
+	int m_NumChunks = 0;
+	int m_DataSize = 0;
+	unsigned char m_aChunkData[NET_MAX_PAYLOAD] = {0};
+	unsigned char m_aExtraData[4] = {0};
 };
 
 enum class CONNECTIVITY
@@ -173,7 +173,7 @@ class CStun
 {
 	class CProtocol
 	{
-		int m_Index;
+		int m_Index = 0;
 		NETSOCKET m_Socket;
 		CStunData m_Stun;
 		bool m_HaveStunServer = false;
@@ -211,28 +211,28 @@ class CNetConnection
 	friend class CNetRecvUnpacker;
 
 private:
-	unsigned short m_Sequence;
-	unsigned short m_Ack;
-	unsigned short m_PeerAck;
-	unsigned m_State;
+	unsigned short m_Sequence = 0;
+	unsigned short m_Ack = 0;
+	unsigned short m_PeerAck = 0;
+	unsigned m_State = 0;
 
 	SECURITY_TOKEN m_SecurityToken;
-	int m_RemoteClosed;
-	bool m_BlockCloseMsg;
-	bool m_UnknownSeq;
+	int m_RemoteClosed = 0;
+	bool m_BlockCloseMsg = false;
+	bool m_UnknownSeq = false;
 
 	CStaticRingBuffer<CNetChunkResend, NET_CONN_BUFFERSIZE> m_Buffer;
 
-	int64_t m_LastUpdateTime;
-	int64_t m_LastRecvTime;
-	int64_t m_LastSendTime;
+	int64_t m_LastUpdateTime = 0;
+	int64_t m_LastRecvTime = 0;
+	int64_t m_LastSendTime = 0;
 
-	char m_aErrorString[256];
+	char m_aErrorString[256] = {0};
 
 	CNetPacketConstruct m_Construct;
 
 	NETADDR m_aConnectAddrs[16];
-	int m_NumConnectAddrs;
+	int m_NumConnectAddrs = 0;
 	NETADDR m_PeerAddr;
 	NETSOCKET m_Socket;
 	NETSTATS m_Stats;
@@ -249,8 +249,8 @@ private:
 	void Resend();
 
 public:
-	bool m_TimeoutProtected;
-	bool m_TimeoutSituation;
+	bool m_TimeoutProtected = false;
+	bool m_TimeoutSituation = false;
 
 	void Reset(bool Rejoin = false);
 	void Init(NETSOCKET Socket, bool BlockCloseMsg);
@@ -292,25 +292,25 @@ public:
 	void SetUnknownSeq() { m_UnknownSeq = true; }
 	void SetSequence(int Sequence) { m_Sequence = Sequence; }
 
-	bool m_Sixup;
+	bool m_Sixup = false;
 	SECURITY_TOKEN m_Token;
 };
 
 class CConsoleNetConnection
 {
 private:
-	int m_State;
+	int m_State = 0;
 
 	NETADDR m_PeerAddr;
 	NETSOCKET m_Socket;
 
-	char m_aBuffer[NET_MAX_PACKETSIZE];
-	int m_BufferOffset;
+	char m_aBuffer[NET_MAX_PACKETSIZE] = {0};
+	int m_BufferOffset = 0;
 
-	char m_aErrorString[256];
+	char m_aErrorString[256] = {0};
 
-	bool m_LineEndingDetected;
-	char m_aLineEnding[3];
+	bool m_LineEndingDetected = false;
+	char m_aLineEnding[3] = {0};
 
 public:
 	void Init(NETSOCKET Socket, const NETADDR *pAddr);
@@ -329,14 +329,14 @@ public:
 class CNetRecvUnpacker
 {
 public:
-	bool m_Valid;
+	bool m_Valid = false;
 
 	NETADDR m_Addr;
-	CNetConnection *m_pConnection;
-	int m_CurrentChunk;
-	int m_ClientID;
+	CNetConnection *m_pConnection = nullptr;
+	int m_CurrentChunk = 0;
+	int m_ClientID = 0;
 	CNetPacketConstruct m_Data;
-	unsigned char m_aBuffer[NET_MAX_PACKETSIZE];
+	unsigned char m_aBuffer[NET_MAX_PACKETSIZE] = {0};
 
 	CNetRecvUnpacker() { Clear(); }
 	void Clear();
@@ -356,30 +356,30 @@ class CNetServer
 	struct CSpamConn
 	{
 		NETADDR m_Addr;
-		int64_t m_Time;
-		int m_Conns;
+		int64_t m_Time = 0;
+		int m_Conns = 0;
 	};
 
 	NETADDR m_Address;
 	NETSOCKET m_Socket;
-	CNetBan *m_pNetBan;
+	CNetBan *m_pNetBan = nullptr;
 	CSlot m_aSlots[NET_MAX_CLIENTS];
-	int m_MaxClients;
-	int m_MaxClientsPerIP;
+	int m_MaxClients = 0;
+	int m_MaxClientsPerIP = 0;
 
-	NETFUNC_NEWCLIENT m_pfnNewClient;
-	NETFUNC_NEWCLIENT_NOAUTH m_pfnNewClientNoAuth;
-	NETFUNC_DELCLIENT m_pfnDelClient;
-	NETFUNC_CLIENTREJOIN m_pfnClientRejoin;
-	void *m_pUser;
+	NETFUNC_NEWCLIENT m_pfnNewClient = nullptr;
+	NETFUNC_NEWCLIENT_NOAUTH m_pfnNewClientNoAuth = nullptr;
+	NETFUNC_DELCLIENT m_pfnDelClient = nullptr;
+	NETFUNC_CLIENTREJOIN m_pfnClientRejoin = nullptr;
+	void *m_pUser = nullptr;
 
-	int m_NumConAttempts; // log flooding attacks
-	int64_t m_TimeNumConAttempts;
-	unsigned char m_aSecurityTokenSeed[16];
+	int m_NumConAttempts = 0; // log flooding attacks
+	int64_t m_TimeNumConAttempts = 0;
+	unsigned char m_aSecurityTokenSeed[16] = {0};
 
 	// vanilla connect flood detection
-	int64_t m_VConnFirst;
-	int m_VConnNum;
+	int64_t m_VConnFirst = 0;
+	int m_VConnNum = 0;
 
 	CSpamConn m_aSpamConns[NET_CONNLIMIT_IPS];
 
@@ -449,12 +449,12 @@ class CNetConsole
 	};
 
 	NETSOCKET m_Socket;
-	CNetBan *m_pNetBan;
+	CNetBan *m_pNetBan = nullptr;
 	CSlot m_aSlots[NET_MAX_CONSOLE_CLIENTS];
 
-	NETFUNC_NEWCLIENT_CON m_pfnNewClient;
-	NETFUNC_DELCLIENT m_pfnDelClient;
-	void *m_pUser;
+	NETFUNC_NEWCLIENT_CON m_pfnNewClient = nullptr;
+	NETFUNC_DELCLIENT m_pfnDelClient = nullptr;
+	void *m_pUser = nullptr;
 
 	CNetRecvUnpacker m_RecvUnpacker;
 

--- a/src/engine/shared/network_client.cpp
+++ b/src/engine/shared/network_client.cpp
@@ -12,7 +12,7 @@ bool CNetClient::Open(NETADDR BindAddr)
 		return false;
 
 	// clean it
-	mem_zero(this, sizeof(*this));
+	*this = CNetClient();
 
 	// init
 	m_Socket = Socket;

--- a/src/engine/shared/network_conn.cpp
+++ b/src/engine/shared/network_conn.cpp
@@ -45,7 +45,7 @@ void CNetConnection::Reset(bool Rejoin)
 
 	m_Buffer.Init();
 
-	mem_zero(&m_Construct, sizeof(m_Construct));
+	m_Construct = CNetPacketConstruct();
 }
 
 const char *CNetConnection::ErrorString()
@@ -102,7 +102,7 @@ int CNetConnection::Flush()
 	m_LastSendTime = time_get();
 
 	// clear construct so we can start building a new package
-	mem_zero(&m_Construct, sizeof(m_Construct));
+	m_Construct = CNetPacketConstruct();
 	return NumChunks;
 }
 

--- a/src/engine/shared/network_console.cpp
+++ b/src/engine/shared/network_console.cpp
@@ -8,7 +8,7 @@
 bool CNetConsole::Open(NETADDR BindAddr, CNetBan *pNetBan)
 {
 	// zero out the whole structure
-	mem_zero(this, sizeof(*this));
+	*this = CNetConsole();
 	m_pNetBan = pNetBan;
 
 	// open socket

--- a/src/engine/shared/network_server.cpp
+++ b/src/engine/shared/network_server.cpp
@@ -46,7 +46,7 @@ static SECURITY_TOKEN ToSecurityToken(const unsigned char *pData)
 bool CNetServer::Open(NETADDR BindAddr, CNetBan *pNetBan, int MaxClients, int MaxClientsPerIP)
 {
 	// zero out the whole structure
-	mem_zero(this, sizeof(*this));
+	*this = CNetServer();
 
 	// open socket
 	m_Socket = net_udp_create(BindAddr);
@@ -276,7 +276,7 @@ int CNetServer::TryAcceptClient(NETADDR &Addr, SECURITY_TOKEN SecurityToken, boo
 void CNetServer::SendMsgs(NETADDR &Addr, const CMsgPacker *apMsgs[], int Num)
 {
 	CNetPacketConstruct Construct;
-	mem_zero(&Construct, sizeof(Construct));
+	dbg_assert(mem_is_null(&Construct, sizeof(Construct)), "mem not null");
 	unsigned char *pChunkData = &Construct.m_aChunkData[Construct.m_DataSize];
 
 	for(int i = 0; i < Num; i++)

--- a/src/engine/shared/packer.h
+++ b/src/engine/shared/packer.h
@@ -12,10 +12,10 @@ public:
 	};
 
 private:
-	unsigned char m_aBuffer[PACKER_BUFFER_SIZE];
-	unsigned char *m_pCurrent;
-	unsigned char *m_pEnd;
-	int m_Error;
+	unsigned char m_aBuffer[PACKER_BUFFER_SIZE] = {0};
+	unsigned char *m_pCurrent = nullptr;
+	unsigned char *m_pEnd = nullptr;
+	int m_Error = 0;
 
 public:
 	void Reset();
@@ -30,10 +30,10 @@ public:
 
 class CUnpacker
 {
-	const unsigned char *m_pStart;
-	const unsigned char *m_pCurrent;
-	const unsigned char *m_pEnd;
-	int m_Error;
+	const unsigned char *m_pStart = nullptr;
+	const unsigned char *m_pCurrent = nullptr;
+	const unsigned char *m_pEnd = nullptr;
+	int m_Error = 0;
 
 public:
 	enum

--- a/src/engine/shared/protocol_ex.cpp
+++ b/src/engine/shared/protocol_ex.cpp
@@ -18,7 +18,7 @@ int UnpackMessageID(int *pID, bool *pSys, CUuid *pUuid, CUnpacker *pUnpacker, CM
 {
 	*pID = 0;
 	*pSys = false;
-	mem_zero(pUuid, sizeof(*pUuid));
+	*pUuid = CUuid();
 
 	int MsgID = pUnpacker->GetInt();
 

--- a/src/engine/shared/ringbuffer.h
+++ b/src/engine/shared/ringbuffer.h
@@ -8,20 +8,20 @@ class CRingBufferBase
 	class CItem
 	{
 	public:
-		CItem *m_pPrev;
-		CItem *m_pNext;
-		int m_Free;
-		int m_Size;
+		CItem *m_pPrev = nullptr;
+		CItem *m_pNext = nullptr;
+		int m_Free = 0;
+		int m_Size = 0;
 	};
 
-	CItem *m_pProduce;
-	CItem *m_pConsume;
+	CItem *m_pProduce = nullptr;
+	CItem *m_pConsume = nullptr;
 
-	CItem *m_pFirst;
-	CItem *m_pLast;
+	CItem *m_pFirst = nullptr;
+	CItem *m_pLast = nullptr;
 
-	int m_Size;
-	int m_Flags;
+	int m_Size = 0;
+	int m_Flags = 0;
 
 	CItem *NextBlock(CItem *pItem);
 	CItem *PrevBlock(CItem *pItem);
@@ -49,7 +49,7 @@ public:
 template<typename T, int TSIZE, int TFLAGS = 0>
 class CStaticRingBuffer : public CRingBufferBase
 {
-	unsigned char m_aBuffer[TSIZE];
+	unsigned char m_aBuffer[TSIZE] = {0};
 
 public:
 	CStaticRingBuffer() { Init(); }

--- a/src/engine/shared/serverinfo.cpp
+++ b/src/engine/shared/serverinfo.cpp
@@ -58,7 +58,8 @@ bool CServerInfo2::Validate() const
 
 bool CServerInfo2::FromJsonRaw(CServerInfo2 *pOut, const json_value *pJson)
 {
-	mem_zero(pOut, sizeof(*pOut));
+	*pOut = CServerInfo2();
+	// dbg_assert(mem_is_null(pOut, sizeof(*pOut)), "mem not null");
 	bool Error;
 
 	const json_value &ServerInfo = *pJson;

--- a/src/engine/shared/serverinfo.h
+++ b/src/engine/shared/serverinfo.h
@@ -13,23 +13,23 @@ public:
 	class CClient
 	{
 	public:
-		char m_aName[MAX_NAME_LENGTH];
-		char m_aClan[MAX_CLAN_LENGTH];
-		int m_Country;
-		int m_Score;
-		bool m_IsPlayer;
+		char m_aName[MAX_NAME_LENGTH] = {0};
+		char m_aClan[MAX_CLAN_LENGTH] = {0};
+		int m_Country = 0;
+		int m_Score = 0;
+		bool m_IsPlayer = false;
 	};
 
 	CClient m_aClients[SERVERINFO_MAX_CLIENTS];
-	int m_MaxClients;
-	int m_NumClients; // Indirectly serialized.
-	int m_MaxPlayers;
-	int m_NumPlayers; // Not serialized.
-	bool m_Passworded;
-	char m_aGameType[16];
-	char m_aName[64];
-	char m_aMapName[MAX_MAP_LENGTH];
-	char m_aVersion[32];
+	int m_MaxClients = 0;
+	int m_NumClients = 0; // Indirectly serialized.
+	int m_MaxPlayers = 0;
+	int m_NumPlayers = 0; // Not serialized.
+	bool m_Passworded = false;
+	char m_aGameType[16] = {0};
+	char m_aName[64] = {0};
+	char m_aMapName[MAX_MAP_LENGTH] = {0};
+	char m_aVersion[32] = {0};
 
 	bool operator==(const CServerInfo2 &Other) const;
 	bool operator!=(const CServerInfo2 &Other) const { return !(*this == Other); }

--- a/src/engine/shared/snapshot.cpp
+++ b/src/engine/shared/snapshot.cpp
@@ -209,7 +209,7 @@ CSnapshotDelta::CSnapshotDelta()
 	mem_zero(m_aItemSizes, sizeof(m_aItemSizes));
 	mem_zero(m_aSnapshotDataRate, sizeof(m_aSnapshotDataRate));
 	mem_zero(m_aSnapshotDataUpdates, sizeof(m_aSnapshotDataUpdates));
-	mem_zero(&m_Empty, sizeof(m_Empty));
+	m_Empty = CData();
 }
 
 CSnapshotDelta::CSnapshotDelta(const CSnapshotDelta &Old)
@@ -217,7 +217,7 @@ CSnapshotDelta::CSnapshotDelta(const CSnapshotDelta &Old)
 	mem_copy(m_aItemSizes, Old.m_aItemSizes, sizeof(m_aItemSizes));
 	mem_copy(m_aSnapshotDataRate, Old.m_aSnapshotDataRate, sizeof(m_aSnapshotDataRate));
 	mem_copy(m_aSnapshotDataUpdates, Old.m_aSnapshotDataUpdates, sizeof(m_aSnapshotDataUpdates));
-	mem_zero(&m_Empty, sizeof(m_Empty));
+	m_Empty = CData();
 }
 
 void CSnapshotDelta::SetStaticsize(int ItemType, int Size)
@@ -653,7 +653,7 @@ void *CSnapshotBuilder::NewItem(int Type, int ID, int Size)
 			return pObj;
 	}
 
-	mem_zero(pObj, sizeof(CSnapshotItem) + Size);
+	mem_zero((void*)pObj, sizeof(CSnapshotItem) + Size);
 	pObj->m_TypeAndID = (Type << 16) | ID;
 	m_aOffsets[m_NumItems] = m_DataSize;
 	m_DataSize += sizeof(CSnapshotItem) + Size;

--- a/src/engine/shared/snapshot.cpp
+++ b/src/engine/shared/snapshot.cpp
@@ -126,9 +126,9 @@ void CSnapshot::DebugDump()
 
 struct CItemList
 {
-	int m_Num;
-	int m_aKeys[64];
-	int m_aIndex[64];
+	int m_Num = 0;
+	int m_aKeys[64] = {0};
+	int m_aIndex[64] = {0};
 };
 
 enum

--- a/src/engine/shared/snapshot.h
+++ b/src/engine/shared/snapshot.h
@@ -10,7 +10,7 @@
 class CSnapshotItem
 {
 public:
-	int m_TypeAndID;
+	int m_TypeAndID = 0;
 
 	int *Data() { return (int *)(this + 1); }
 	int Type() const { return m_TypeAndID >> 16; }
@@ -21,8 +21,8 @@ public:
 class CSnapshot
 {
 	friend class CSnapshotBuilder;
-	int m_DataSize;
-	int m_NumItems;
+	int m_DataSize = 0;
+	int m_NumItems = 0;
 
 	int *Offsets() const { return (int *)(this + 1); }
 	char *DataStart() const { return (char *)(Offsets() + m_NumItems); }
@@ -63,10 +63,10 @@ public:
 	class CData
 	{
 	public:
-		int m_NumDeletedItems;
-		int m_NumUpdateItems;
-		int m_NumTempItems; // needed?
-		int m_aData[1];
+		int m_NumDeletedItems = 0;
+		int m_NumUpdateItems = 0;
+		int m_NumTempItems = 0; // needed?
+		int m_aData[1] = {0};
 	};
 
 private:
@@ -74,9 +74,9 @@ private:
 	{
 		MAX_NETOBJSIZES = 64
 	};
-	short m_aItemSizes[MAX_NETOBJSIZES];
-	int m_aSnapshotDataRate[CSnapshot::MAX_TYPE + 1];
-	int m_aSnapshotDataUpdates[CSnapshot::MAX_TYPE + 1];
+	short m_aItemSizes[MAX_NETOBJSIZES] = {0};
+	int m_aSnapshotDataRate[CSnapshot::MAX_TYPE + 1] = {0};
+	int m_aSnapshotDataUpdates[CSnapshot::MAX_TYPE + 1] = {0};
 	CData m_Empty;
 
 	static void UndiffItem(int *pPast, int *pDiff, int *pOut, int Size, int *pDataRate);
@@ -101,21 +101,21 @@ public:
 	class CHolder
 	{
 	public:
-		CHolder *m_pPrev;
-		CHolder *m_pNext;
+		CHolder *m_pPrev = nullptr;
+		CHolder *m_pNext = nullptr;
 
-		int64_t m_Tagtime;
-		int m_Tick;
+		int64_t m_Tagtime = 0;
+		int m_Tick = 0;
 
-		int m_SnapSize;
-		int m_AltSnapSize;
+		int m_SnapSize = 0;
+		int m_AltSnapSize = 0;
 
-		CSnapshot *m_pSnap;
-		CSnapshot *m_pAltSnap;
+		CSnapshot *m_pSnap = nullptr;
+		CSnapshot *m_pAltSnap = nullptr;
 	};
 
-	CHolder *m_pFirst;
-	CHolder *m_pLast;
+	CHolder *m_pFirst = nullptr;
+	CHolder *m_pLast = nullptr;
 
 	CSnapshotStorage() { Init(); }
 	~CSnapshotStorage() { PurgeAll(); }
@@ -133,20 +133,20 @@ class CSnapshotBuilder
 		MAX_EXTENDED_ITEM_TYPES = 64,
 	};
 
-	char m_aData[CSnapshot::MAX_SIZE];
-	int m_DataSize;
+	char m_aData[CSnapshot::MAX_SIZE] = {0};
+	int m_DataSize = 0;
 
-	int m_aOffsets[CSnapshot::MAX_ITEMS];
-	int m_NumItems;
+	int m_aOffsets[CSnapshot::MAX_ITEMS] = {0};
+	int m_NumItems = 0;
 
-	int m_aExtendedItemTypes[MAX_EXTENDED_ITEM_TYPES];
-	int m_NumExtendedItemTypes;
+	int m_aExtendedItemTypes[MAX_EXTENDED_ITEM_TYPES] = {0};
+	int m_NumExtendedItemTypes = 0;
 
 	void AddExtendedItemType(int Index);
 	int GetExtendedItemTypeIndex(int TypeID);
 	int GetTypeFromIndex(int Index);
 
-	bool m_Sixup;
+	bool m_Sixup = false;
 
 public:
 	CSnapshotBuilder();

--- a/src/engine/shared/storage.cpp
+++ b/src/engine/shared/storage.cpp
@@ -13,12 +13,12 @@
 class CStorage : public IStorage
 {
 public:
-	char m_aaStoragePaths[MAX_PATHS][IO_MAX_PATH_LENGTH];
-	int m_NumPaths;
-	char m_aDatadir[IO_MAX_PATH_LENGTH];
-	char m_aUserdir[IO_MAX_PATH_LENGTH];
-	char m_aCurrentdir[IO_MAX_PATH_LENGTH];
-	char m_aBinarydir[IO_MAX_PATH_LENGTH];
+	char m_aaStoragePaths[MAX_PATHS][IO_MAX_PATH_LENGTH] = {{0}};
+	int m_NumPaths = 0;
+	char m_aDatadir[IO_MAX_PATH_LENGTH] = {0};
+	char m_aUserdir[IO_MAX_PATH_LENGTH] = {0};
+	char m_aCurrentdir[IO_MAX_PATH_LENGTH] = {0};
+	char m_aBinarydir[IO_MAX_PATH_LENGTH] = {0};
 
 	CStorage()
 	{
@@ -430,11 +430,11 @@ public:
 
 	struct CFindCBData
 	{
-		CStorage *m_pStorage;
-		const char *m_pFilename;
-		const char *m_pPath;
-		char *m_pBuffer;
-		int m_BufferSize;
+		CStorage *m_pStorage = nullptr;
+		const char *m_pFilename = nullptr;
+		const char *m_pPath = nullptr;
+		char *m_pBuffer = nullptr;
+		int m_BufferSize = 0;
 	};
 
 	static int FindFileCallback(const char *pName, int IsDir, int Type, void *pUser)

--- a/src/engine/shared/stun.h
+++ b/src/engine/shared/stun.h
@@ -7,7 +7,7 @@ struct NETADDR;
 class CStunData
 {
 public:
-	unsigned char m_aSecret[12];
+	unsigned char m_aSecret[12] = {0};
 };
 
 size_t StunMessagePrepare(unsigned char *pBuffer, size_t BufferSize, CStunData *pData);

--- a/src/engine/shared/uuid_manager.h
+++ b/src/engine/shared/uuid_manager.h
@@ -17,7 +17,7 @@ enum
 
 struct CUuid
 {
-	unsigned char m_aData[16];
+	unsigned char m_aData[16] = {0};
 
 	bool operator==(const CUuid &Other) const;
 	bool operator!=(const CUuid &Other) const;
@@ -34,13 +34,13 @@ int ParseUuid(CUuid *pUuid, const char *pBuffer);
 struct CName
 {
 	CUuid m_Uuid;
-	const char *m_pName;
+	const char *m_pName = nullptr;
 };
 
 struct CNameIndexed
 {
 	CUuid m_Uuid;
-	int m_ID;
+	int m_ID = 0;
 
 	bool operator<(const CNameIndexed &Other) const { return m_Uuid < Other.m_Uuid; }
 	bool operator==(const CNameIndexed &Other) const { return m_Uuid == Other.m_Uuid; }

--- a/src/engine/sound.h
+++ b/src/engine/sound.h
@@ -28,25 +28,25 @@ public:
 	// unused
 	struct CSampleHandle
 	{
-		int m_SampleID;
+		int m_SampleID = 0;
 	};
 
 	struct CVoiceShapeCircle
 	{
-		float m_Radius;
+		float m_Radius = 0;
 	};
 
 	struct CVoiceShapeRectangle
 	{
-		float m_Width;
-		float m_Height;
+		float m_Width = 0;
+		float m_Height = 0;
 	};
 
 	class CVoiceHandle
 	{
 		friend class ISound;
-		int m_Id;
-		int m_Age;
+		int m_Id = 0;
+		int m_Age = 0;
 
 	public:
 		CVoiceHandle() :

--- a/src/engine/textrender.h
+++ b/src/engine/textrender.h
@@ -103,6 +103,7 @@ public:
 	ETextCursorCursorMode m_CursorMode = TEXT_CURSOR_CURSOR_MODE_NONE;
 	// note this is the decoded character offset
 	int m_CursorCharacter = 0;
+	int m_Padding = 0;
 };
 
 class ITextRender : public IInterface

--- a/src/engine/textrender.h
+++ b/src/engine/textrender.h
@@ -68,41 +68,41 @@ enum ETextCursorCursorMode
 class CTextCursor
 {
 public:
-	int m_Flags;
-	int m_LineCount;
-	int m_GlyphCount;
-	int m_CharCount;
-	int m_MaxLines;
+	int m_Flags = 0;
+	int m_LineCount = 0;
+	int m_GlyphCount = 0;
+	int m_CharCount = 0;
+	int m_MaxLines = 0;
 
-	float m_StartX;
-	float m_StartY;
-	float m_LineWidth;
-	float m_X, m_Y;
-	float m_MaxCharacterHeight;
+	float m_StartX = 0;
+	float m_StartY = 0;
+	float m_LineWidth = 0;
+	float m_X = 0, m_Y = 0;
+	float m_MaxCharacterHeight = 0;
 
-	float m_LongestLineWidth;
+	float m_LongestLineWidth = 0;
 
-	CFont *m_pFont;
-	float m_FontSize;
-	float m_AlignedFontSize;
+	CFont *m_pFont = nullptr;
+	float m_FontSize = 0;
+	float m_AlignedFontSize = 0;
 
-	ETextCursorSelectionMode m_CalculateSelectionMode;
+	ETextCursorSelectionMode m_CalculateSelectionMode = TEXT_CURSOR_SELECTION_MODE_NONE;
 
 	// these coordinates are repsected if selection mode is set to calculate @see ETextCursorSelectionMode
-	int m_PressMouseX;
-	int m_PressMouseY;
+	int m_PressMouseX = 0;
+	int m_PressMouseY = 0;
 	// these coordinates are repsected if selection/cursor mode is set to calculate @see ETextCursorSelectionMode / @see ETextCursorCursorMode
-	int m_ReleaseMouseX;
-	int m_ReleaseMouseY;
+	int m_ReleaseMouseX = 0;
+	int m_ReleaseMouseY = 0;
 
 	// note m_SelectionStart can be bigger than m_SelectionEnd, depending on how the mouse cursor was dragged
 	// also note, that these are the character offsets decoded
-	int m_SelectionStart;
-	int m_SelectionEnd;
+	int m_SelectionStart = 0;
+	int m_SelectionEnd = 0;
 
-	ETextCursorCursorMode m_CursorMode;
+	ETextCursorCursorMode m_CursorMode = TEXT_CURSOR_CURSOR_MODE_NONE;
 	// note this is the decoded character offset
-	int m_CursorCharacter;
+	int m_CursorCharacter = 0;
 };
 
 class ITextRender : public IInterface

--- a/src/engine/warning.h
+++ b/src/engine/warning.h
@@ -10,8 +10,8 @@ struct SWarning
 	{
 		str_copy(m_aWarningMsg, pMsg, sizeof(m_aWarningMsg));
 	}
-	char m_aWarningMsg[256];
-	bool m_WasShown;
+	char m_aWarningMsg[256] = {0};
+	bool m_WasShown = false;
 };
 
 #endif

--- a/src/game/bezier.h
+++ b/src/game/bezier.h
@@ -8,10 +8,10 @@
 // f(t) = (1-t)³ a + 3(1-t)²t b + 3(1-t)t² c + t³ d
 class CCubicBezier
 {
-	float a;
-	float b;
-	float c;
-	float d;
+	float a = 0;
+	float b = 0;
+	float c = 0;
+	float d = 0;
 	CCubicBezier(float a_, float b_, float c_, float d_) :
 		a(a_), b(b_), c(c_), d(d_)
 	{

--- a/src/game/client/component.h
+++ b/src/game/client/component.h
@@ -21,7 +21,7 @@ class CComponent
 protected:
 	friend class CGameClient;
 
-	CGameClient *m_pClient;
+	CGameClient *m_pClient = nullptr;
 
 	// perhaps propagate pointers for these as well
 

--- a/src/game/client/components/background.h
+++ b/src/game/client/components/background.h
@@ -21,17 +21,17 @@ class CBackgroundEngineMap : public CMap
 class CBackground : public CMapLayers
 {
 protected:
-	IEngineMap *m_pMap;
-	bool m_Loaded;
-	char m_aMapName[MAX_MAP_LENGTH];
+	IEngineMap *m_pMap = nullptr;
+	bool m_Loaded = false;
+	char m_aMapName[MAX_MAP_LENGTH] = {0};
 
 	//to avoid spam when in menu
-	int64_t m_LastLoad;
+	int64_t m_LastLoad = 0;
 
 	//to avoid memory leak when switching to %current%
-	CBackgroundEngineMap *m_pBackgroundMap;
-	CLayers *m_pBackgroundLayers;
-	CMapImages *m_pBackgroundImages;
+	CBackgroundEngineMap *m_pBackgroundMap = nullptr;
+	CLayers *m_pBackgroundLayers = nullptr;
+	CMapImages *m_pBackgroundImages = nullptr;
 
 	virtual CBackgroundEngineMap *CreateBGMap();
 

--- a/src/game/client/components/binds.h
+++ b/src/game/client/components/binds.h
@@ -30,7 +30,7 @@ public:
 	class CBindsSpecial : public CComponent
 	{
 	public:
-		CBinds *m_pBinds;
+		CBinds *m_pBinds = nullptr;
 		virtual int Sizeof() const override { return sizeof(*this); }
 		virtual bool OnInput(IInput::CEvent Event) override;
 	};
@@ -67,6 +67,6 @@ public:
 	void SetDDRaceBinds(bool FreeOnly);
 
 private:
-	char *m_aapKeyBindings[MODIFIER_COMBINATION_COUNT][KEY_LAST];
+	char *m_aapKeyBindings[MODIFIER_COMBINATION_COUNT][KEY_LAST] = {{nullptr}};
 };
 #endif

--- a/src/game/client/components/broadcast.h
+++ b/src/game/client/components/broadcast.h
@@ -7,9 +7,9 @@
 class CBroadcast : public CComponent
 {
 	// broadcasts
-	char m_aBroadcastText[1024];
-	int m_BroadcastTick;
-	float m_BroadcastRenderOffset;
+	char m_aBroadcastText[1024] = {0};
+	int m_BroadcastTick = 0;
+	float m_BroadcastRenderOffset = 0;
 
 public:
 	virtual int Sizeof() const override { return sizeof(*this); }

--- a/src/game/client/components/camera.h
+++ b/src/game/client/components/camera.h
@@ -21,13 +21,13 @@ class CCamera : public CComponent
 		CAMTYPE_PLAYER,
 	};
 
-	int m_CamType;
+	int m_CamType = 0;
 	vec2 m_aLastPos[NUM_DUMMIES];
 	vec2 m_PrevCenter;
 
 	CCubicBezier m_ZoomSmoothing;
-	float m_ZoomSmoothingStart;
-	float m_ZoomSmoothingEnd;
+	float m_ZoomSmoothingStart = 0;
+	float m_ZoomSmoothingEnd = 0;
 
 	void ScaleZoom(float Factor);
 	void ChangeZoom(float Target);
@@ -38,10 +38,10 @@ class CCamera : public CComponent
 
 public:
 	vec2 m_Center;
-	bool m_ZoomSet;
-	bool m_Zooming;
-	float m_Zoom;
-	float m_ZoomSmoothingTarget;
+	bool m_ZoomSet = false;
+	bool m_Zooming = false;
+	float m_Zoom = 0;
+	float m_ZoomSmoothingTarget = 0;
 
 	CCamera();
 	virtual int Sizeof() const override { return sizeof(*this); }

--- a/src/game/client/components/chat.h
+++ b/src/game/client/components/chat.h
@@ -28,39 +28,39 @@ class CChat : public CComponent
 
 	struct CLine
 	{
-		int64_t m_Time;
-		float m_aYOffset[2];
-		int m_ClientID;
-		int m_TeamNumber;
-		bool m_Team;
-		bool m_Whisper;
-		int m_NameColor;
-		char m_aName[64];
-		char m_aText[512];
-		bool m_Friend;
-		bool m_Highlighted;
+		int64_t m_Time = 0;
+		float m_aYOffset[2] = {0};
+		int m_ClientID = 0;
+		int m_TeamNumber = 0;
+		bool m_Team = false;
+		bool m_Whisper = false;
+		int m_NameColor = 0;
+		char m_aName[64] = {0};
+		char m_aText[512] = {0};
+		bool m_Friend = false;
+		bool m_Highlighted = false;
 
-		int m_TextContainerIndex;
-		int m_QuadContainerIndex;
+		int m_TextContainerIndex = 0;
+		int m_QuadContainerIndex = 0;
 
-		char m_aSkinName[std::size(g_Config.m_ClPlayerSkin)];
+		char m_aSkinName[std::size(g_Config.m_ClPlayerSkin)] = {0};
 		CSkin::SSkinTextures m_RenderSkin;
 		CSkin::SSkinMetrics m_RenderSkinMetrics;
-		bool m_CustomColoredSkin;
+		bool m_CustomColoredSkin = false;
 		ColorRGBA m_ColorBody;
 		ColorRGBA m_ColorFeet;
 
-		bool m_HasRenderTee;
-		float m_TextYOffset;
+		bool m_HasRenderTee = false;
+		float m_TextYOffset = 0;
 
-		int m_TimesRepeated;
+		int m_TimesRepeated = 0;
 	};
 
-	bool m_PrevScoreBoardShowed;
-	bool m_PrevShowChat;
+	bool m_PrevScoreBoardShowed = false;
+	bool m_PrevShowChat = false;
 
 	CLine m_aLines[MAX_LINES];
-	int m_CurrentLine;
+	int m_CurrentLine = 0;
 
 	// chat
 	enum
@@ -75,28 +75,28 @@ class CChat : public CComponent
 		CHAT_NUM,
 	};
 
-	int m_Mode;
-	bool m_Show;
-	bool m_InputUpdate;
-	int m_ChatStringOffset;
-	int m_OldChatStringLength;
-	bool m_CompletionUsed;
-	int m_CompletionChosen;
-	char m_aCompletionBuffer[256];
-	int m_PlaceholderOffset;
-	int m_PlaceholderLength;
+	int m_Mode = 0;
+	bool m_Show = false;
+	bool m_InputUpdate = false;
+	int m_ChatStringOffset = 0;
+	int m_OldChatStringLength = 0;
+	bool m_CompletionUsed = false;
+	int m_CompletionChosen = 0;
+	char m_aCompletionBuffer[256] = {0};
+	int m_PlaceholderOffset = 0;
+	int m_PlaceholderLength = 0;
 	struct CRateablePlayer
 	{
-		int ClientID;
-		int Score;
+		int ClientID = 0;
+		int Score = 0;
 	};
 	CRateablePlayer m_aPlayerCompletionList[MAX_CLIENTS];
-	int m_PlayerCompletionListLength;
+	int m_PlayerCompletionListLength = 0;
 
 	struct CCommand
 	{
-		const char *m_pName;
-		const char *m_pParams;
+		const char *m_pName = nullptr;
+		const char *m_pParams = nullptr;
 
 		CCommand() = default;
 		CCommand(const char *pName, const char *pParams) :
@@ -110,18 +110,18 @@ class CChat : public CComponent
 	};
 
 	std::vector<CCommand> m_vCommands;
-	bool m_ReverseTAB;
+	bool m_ReverseTAB = false;
 
 	struct CHistoryEntry
 	{
-		int m_Team;
-		char m_aText[1];
+		int m_Team = 0;
+		char m_aText[1] = {0};
 	};
-	CHistoryEntry *m_pHistoryEntry;
+	CHistoryEntry *m_pHistoryEntry = nullptr;
 	CStaticRingBuffer<CHistoryEntry, 64 * 1024, CRingBufferBase::FLAG_RECYCLE> m_History;
-	int m_PendingChatCounter;
-	int64_t m_LastChatSend;
-	int64_t m_aLastSoundPlayed[CHAT_NUM];
+	int m_PendingChatCounter = 0;
+	int64_t m_LastChatSend = 0;
+	int64_t m_aLastSoundPlayed[CHAT_NUM] = {0};
 
 	static void ConSay(IConsole::IResult *pResult, void *pUserData);
 	static void ConSayTeam(IConsole::IResult *pResult, void *pUserData);

--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -35,7 +35,7 @@
 
 class CConsoleLogger : public ILogger
 {
-	CGameConsole *m_pConsole;
+	CGameConsole *m_pConsole = nullptr;
 	std::mutex m_ConsoleMutex;
 
 public:
@@ -472,13 +472,13 @@ static float ConsoleScaleFunc(float t)
 
 struct CRenderInfo
 {
-	CGameConsole *m_pSelf;
+	CGameConsole *m_pSelf = nullptr;
 	CTextCursor m_Cursor;
-	const char *m_pCurrentCmd;
-	int m_WantedCompletion;
-	int m_EnumCount;
-	float m_Offset;
-	float m_Width;
+	const char *m_pCurrentCmd = nullptr;
+	int m_WantedCompletion = 0;
+	int m_EnumCount = 0;
+	float m_Offset = 0;
+	float m_Width = 0;
 };
 
 void CGameConsole::PossibleCommandsRenderCallback(const char *pStr, void *pUser)

--- a/src/game/client/components/console.h
+++ b/src/game/client/components/console.h
@@ -28,37 +28,37 @@ class CGameConsole : public CComponent
 	public:
 		struct CBacklogEntry
 		{
-			float m_YOffset;
+			float m_YOffset = 0;
 			ColorRGBA m_PrintColor;
-			char m_aText[1];
+			char m_aText[1] = {0};
 		};
 		std::mutex m_BacklogLock;
 		CStaticRingBuffer<CBacklogEntry, 1024 * 1024, CRingBufferBase::FLAG_RECYCLE> m_Backlog;
 		CStaticRingBuffer<char, 64 * 1024, CRingBufferBase::FLAG_RECYCLE> m_History;
-		char *m_pHistoryEntry;
+		char *m_pHistoryEntry = nullptr;
 
 		CLineInput m_Input;
-		int m_Type;
-		int m_CompletionEnumerationCount;
-		int m_BacklogCurPage;
+		int m_Type = 0;
+		int m_CompletionEnumerationCount = 0;
+		int m_BacklogCurPage = 0;
 
-		CGameConsole *m_pGameConsole;
+		CGameConsole *m_pGameConsole = nullptr;
 
-		char m_aCompletionBuffer[128];
-		bool m_CompletionUsed;
-		int m_CompletionChosen;
-		int m_CompletionFlagmask;
-		float m_CompletionRenderOffset;
-		bool m_ReverseTAB;
+		char m_aCompletionBuffer[128] = {0};
+		bool m_CompletionUsed = false;
+		int m_CompletionChosen = 0;
+		int m_CompletionFlagmask = 0;
+		float m_CompletionRenderOffset = 0;
+		bool m_ReverseTAB = false;
 
-		char m_aUser[32];
-		bool m_UserGot;
-		bool m_UsernameReq;
+		char m_aUser[32] = {0};
+		bool m_UserGot = false;
+		bool m_UsernameReq = false;
 
-		bool m_IsCommand;
-		char m_aCommandName[IConsole::TEMPCMD_NAME_LENGTH];
-		char m_aCommandHelp[IConsole::TEMPCMD_HELP_LENGTH];
-		char m_aCommandParams[IConsole::TEMPCMD_PARAMS_LENGTH];
+		bool m_IsCommand = false;
+		char m_aCommandName[IConsole::TEMPCMD_NAME_LENGTH] = {0};
+		char m_aCommandHelp[IConsole::TEMPCMD_HELP_LENGTH] = {0};
+		char m_aCommandParams[IConsole::TEMPCMD_PARAMS_LENGTH] = {0};
 
 		CInstance(int t);
 		void Init(CGameConsole *pGameConsole);
@@ -76,7 +76,7 @@ class CGameConsole : public CComponent
 		static void PossibleCommandsCompleteCallback(const char *pStr, void *pUser);
 	};
 
-	class IConsole *m_pConsole;
+	class IConsole *m_pConsole = nullptr;
 	CConsoleLogger *m_pConsoleLogger = nullptr;
 
 	CInstance m_LocalConsole;
@@ -85,10 +85,10 @@ class CGameConsole : public CComponent
 	CInstance *CurrentConsole();
 	float TimeNow();
 
-	int m_ConsoleType;
-	int m_ConsoleState;
-	float m_StateChangeEnd;
-	float m_StateChangeDuration;
+	int m_ConsoleType = 0;
+	int m_ConsoleState = 0;
+	float m_StateChangeEnd = 0;
+	float m_StateChangeDuration = 0;
 
 	bool m_MouseIsPress = false;
 	int m_MousePressX = 0;

--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -60,9 +60,9 @@ void CControls::OnPlayerDeath()
 
 struct CInputState
 {
-	CControls *m_pControls;
-	int *m_pVariable1;
-	int *m_pVariable2;
+	CControls *m_pControls = nullptr;
+	int *m_pVariable1 = nullptr;
+	int *m_pVariable2 = nullptr;
 };
 
 static void ConKeyInputState(IConsole::IResult *pResult, void *pUserData)
@@ -98,10 +98,10 @@ static void ConKeyInputCounter(IConsole::IResult *pResult, void *pUserData)
 
 struct CInputSet
 {
-	CControls *m_pControls;
-	int *m_pVariable1;
-	int *m_pVariable2;
-	int m_Value;
+	CControls *m_pControls = nullptr;
+	int *m_pVariable1 = nullptr;
+	int *m_pVariable2 = nullptr;
+	int m_Value = 0;
 };
 
 static void ConKeyInputSet(IConsole::IResult *pResult, void *pUserData)

--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -17,7 +17,7 @@
 
 CControls::CControls()
 {
-	mem_zero(&m_aLastData, sizeof(m_aLastData));
+	new(&m_aLastData) std::remove_pointer<decltype(m_aLastData)>::type;
 	m_LastDummy = 0;
 	m_OtherFire = 0;
 }
@@ -284,7 +284,7 @@ int CControls::SnapInput(int *pData)
 		if(g_Config.m_DbgStress)
 		{
 			float t = Client()->LocalTime();
-			mem_zero(&m_aInputData[g_Config.m_ClDummy], sizeof(m_aInputData[0]));
+			m_aInputData[g_Config.m_ClDummy] = CNetObj_PlayerInput();
 
 			m_aInputData[g_Config.m_ClDummy].m_Direction = ((int)t / 2) & 1;
 			m_aInputData[g_Config.m_ClDummy].m_Jump = ((int)t);

--- a/src/game/client/components/controls.h
+++ b/src/game/client/components/controls.h
@@ -17,18 +17,18 @@ class CControls : public CComponent
 public:
 	vec2 m_aMousePos[NUM_DUMMIES];
 	vec2 m_aTargetPos[NUM_DUMMIES];
-	float m_OldMouseX;
-	float m_OldMouseY;
+	float m_OldMouseX = 0;
+	float m_OldMouseY = 0;
 
-	int m_aAmmoCount[NUM_WEAPONS];
+	int m_aAmmoCount[NUM_WEAPONS] = {0};
 
 	CNetObj_PlayerInput m_aInputData[NUM_DUMMIES];
 	CNetObj_PlayerInput m_aLastData[NUM_DUMMIES];
-	int m_aInputDirectionLeft[NUM_DUMMIES];
-	int m_aInputDirectionRight[NUM_DUMMIES];
-	int m_aShowHookColl[NUM_DUMMIES];
-	int m_LastDummy;
-	int m_OtherFire;
+	int m_aInputDirectionLeft[NUM_DUMMIES] = {0};
+	int m_aInputDirectionRight[NUM_DUMMIES] = {0};
+	int m_aShowHookColl[NUM_DUMMIES] = {0};
+	int m_LastDummy = 0;
+	int m_OtherFire = 0;
 
 	CControls();
 	virtual int Sizeof() const override { return sizeof(*this); }

--- a/src/game/client/components/countryflags.h
+++ b/src/game/client/components/countryflags.h
@@ -11,8 +11,8 @@ class CCountryFlags : public CComponent
 public:
 	struct CCountryFlag
 	{
-		int m_CountryCode;
-		char m_aCountryCodeString[8];
+		int m_CountryCode = 0;
+		char m_aCountryCodeString[8] = {0};
 		IGraphics::CTextureHandle m_Texture;
 
 		bool operator<(const CCountryFlag &Other) const { return str_comp(m_aCountryCodeString, Other.m_aCountryCodeString) < 0; }
@@ -34,9 +34,9 @@ private:
 		CODE_RANGE = CODE_UB - CODE_LB + 1,
 	};
 	std::vector<CCountryFlag> m_vCountryFlags;
-	size_t m_aCodeIndexLUT[CODE_RANGE];
+	size_t m_aCodeIndexLUT[CODE_RANGE] = {0};
 
-	int m_FlagsQuadContainerIndex;
+	int m_FlagsQuadContainerIndex = 0;
 
 	void LoadCountryflagsIndexfile();
 };

--- a/src/game/client/components/damageind.h
+++ b/src/game/client/components/damageind.h
@@ -7,13 +7,13 @@
 
 class CDamageInd : public CComponent
 {
-	int64_t m_Lastupdate;
+	int64_t m_Lastupdate = 0;
 	struct CItem
 	{
 		vec2 m_Pos;
 		vec2 m_Dir;
-		float m_StartTime;
-		float m_StartAngle;
+		float m_StartTime = 0;
+		float m_StartAngle = 0;
 	};
 
 	enum
@@ -22,12 +22,12 @@ class CDamageInd : public CComponent
 	};
 
 	CItem m_aItems[MAX_ITEMS];
-	int m_NumItems;
+	int m_NumItems = 0;
 
 	CItem *CreateI();
 	void DestroyI(CItem *pItem);
 
-	int m_DmgIndQuadContainerIndex;
+	int m_DmgIndQuadContainerIndex = 0;
 
 public:
 	CDamageInd();

--- a/src/game/client/components/debughud.h
+++ b/src/game/client/components/debughud.h
@@ -14,11 +14,11 @@ class CDebugHud : public CComponent
 
 	CGraph m_RampGraph;
 	CGraph m_ZoomedInGraph;
-	float m_SpeedTurningPoint;
-	float MiddleOfZoomedInGraph;
-	float m_OldVelrampStart;
-	float m_OldVelrampRange;
-	float m_OldVelrampCurvature;
+	float m_SpeedTurningPoint = 0;
+	float MiddleOfZoomedInGraph = 0;
+	float m_OldVelrampStart = 0;
+	float m_OldVelrampRange = 0;
+	float m_OldVelrampCurvature = 0;
 
 public:
 	virtual int Sizeof() const override { return sizeof(*this); }

--- a/src/game/client/components/effects.h
+++ b/src/game/client/components/effects.h
@@ -6,9 +6,9 @@
 
 class CEffects : public CComponent
 {
-	bool m_Add5hz;
-	bool m_Add50hz;
-	bool m_Add100hz;
+	bool m_Add5hz = false;
+	bool m_Add50hz = false;
+	bool m_Add100hz = false;
 
 public:
 	CEffects();

--- a/src/game/client/components/emoticon.h
+++ b/src/game/client/components/emoticon.h
@@ -9,12 +9,12 @@ class CEmoticon : public CComponent
 {
 	void DrawCircle(float x, float y, float r, int Segments);
 
-	bool m_WasActive;
-	bool m_Active;
+	bool m_WasActive = false;
+	bool m_Active = false;
 
 	vec2 m_SelectorMouse;
-	int m_SelectedEmote;
-	int m_SelectedEyeEmote;
+	int m_SelectedEmote = 0;
+	int m_SelectedEyeEmote = 0;
 
 	static void ConKeyEmoticon(IConsole::IResult *pResult, void *pUserData);
 	static void ConEmote(IConsole::IResult *pResult, void *pUserData);

--- a/src/game/client/components/flow.h
+++ b/src/game/client/components/flow.h
@@ -12,10 +12,10 @@ class CFlow : public CComponent
 		vec2 m_Vel;
 	};
 
-	CCell *m_pCells;
-	int m_Height;
-	int m_Width;
-	int m_Spacing;
+	CCell *m_pCells = nullptr;
+	int m_Height = 0;
+	int m_Width = 0;
+	int m_Spacing = 0;
 
 	void DbgRender();
 	void Init();

--- a/src/game/client/components/ghost.cpp
+++ b/src/game/client/components/ghost.cpp
@@ -49,7 +49,8 @@ void CGhost::GetGhostCharacter(CGhostCharacter *pGhostChar, const CNetObj_Charac
 
 void CGhost::GetNetObjCharacter(CNetObj_Character *pChar, const CGhostCharacter *pGhostChar)
 {
-	mem_zero(pChar, sizeof(CNetObj_Character));
+	*pChar = CNetObj_Character();
+	dbg_assert(mem_is_null(pChar, sizeof(*pChar)), "mem not null");
 	pChar->m_X = pGhostChar->m_X;
 	pChar->m_Y = pGhostChar->m_Y;
 	pChar->m_VelX = pGhostChar->m_VelX;

--- a/src/game/client/components/ghost.h
+++ b/src/game/client/components/ghost.h
@@ -21,35 +21,35 @@ enum
 
 struct CGhostSkin
 {
-	int m_Skin0;
-	int m_Skin1;
-	int m_Skin2;
-	int m_Skin3;
-	int m_Skin4;
-	int m_Skin5;
-	int m_UseCustomColor;
-	int m_ColorBody;
-	int m_ColorFeet;
+	int m_Skin0 = 0;
+	int m_Skin1 = 0;
+	int m_Skin2 = 0;
+	int m_Skin3 = 0;
+	int m_Skin4 = 0;
+	int m_Skin5 = 0;
+	int m_UseCustomColor = 0;
+	int m_ColorBody = 0;
+	int m_ColorFeet = 0;
 };
 
 struct CGhostCharacter_NoTick
 {
-	int m_X;
-	int m_Y;
-	int m_VelX;
-	int m_VelY;
-	int m_Angle;
-	int m_Direction;
-	int m_Weapon;
-	int m_HookState;
-	int m_HookX;
-	int m_HookY;
-	int m_AttackTick;
+	int m_X = 0;
+	int m_Y = 0;
+	int m_VelX = 0;
+	int m_VelY = 0;
+	int m_Angle = 0;
+	int m_Direction = 0;
+	int m_Weapon = 0;
+	int m_HookState = 0;
+	int m_HookX = 0;
+	int m_HookY = 0;
+	int m_AttackTick = 0;
 };
 
 struct CGhostCharacter : public CGhostCharacter_NoTick
 {
-	int m_Tick;
+	int m_Tick = 0;
 };
 
 class CGhost : public CComponent
@@ -62,8 +62,8 @@ private:
 
 	class CGhostPath
 	{
-		int m_ChunkSize;
-		int m_NumItems;
+		int m_ChunkSize = 0;
+		int m_NumItems = 0;
 
 		std::vector<CGhostCharacter *> m_vpChunks;
 
@@ -90,9 +90,9 @@ private:
 		CTeeRenderInfo m_RenderInfo;
 		CGhostSkin m_Skin;
 		CGhostPath m_Path;
-		int m_StartTick;
-		char m_aPlayer[MAX_NAME_LENGTH];
-		int m_PlaybackPos;
+		int m_StartTick = 0;
+		char m_aPlayer[MAX_NAME_LENGTH] = {0};
+		int m_PlaybackPos = 0;
 
 		CGhostItem() { Reset(); }
 
@@ -107,22 +107,22 @@ private:
 
 	static const char *ms_pGhostDir;
 
-	class IGhostLoader *m_pGhostLoader;
-	class IGhostRecorder *m_pGhostRecorder;
+	class IGhostLoader *m_pGhostLoader = nullptr;
+	class IGhostRecorder *m_pGhostRecorder = nullptr;
 
 	CGhostItem m_aActiveGhosts[MAX_ACTIVE_GHOSTS];
 	CGhostItem m_CurGhost;
 
-	char m_aTmpFilename[128];
+	char m_aTmpFilename[128] = {0};
 
-	int m_NewRenderTick;
-	int m_StartRenderTick;
-	int m_LastDeathTick;
-	int m_LastRaceTick;
-	bool m_Recording;
-	bool m_Rendering;
+	int m_NewRenderTick = 0;
+	int m_StartRenderTick = 0;
+	int m_LastDeathTick = 0;
+	int m_LastRaceTick = 0;
+	bool m_Recording = false;
+	bool m_Rendering = false;
 
-	bool m_RenderingStartedByServer;
+	bool m_RenderingStartedByServer = false;
 
 	static void GetGhostSkin(CGhostSkin *pSkin, const char *pSkinName, int UseCustomColor, int ColorBody, int ColorFeet);
 	static void GetGhostCharacter(CGhostCharacter *pGhostChar, const CNetObj_Character *pChar, const CNetObj_DDNetCharacter *pDDnetChar);
@@ -147,7 +147,7 @@ private:
 	static void ConGPlay(IConsole::IResult *pResult, void *pUserData);
 
 public:
-	bool m_AllowRestart;
+	bool m_AllowRestart = false;
 
 	CGhost();
 	virtual int Sizeof() const override { return sizeof(*this); }

--- a/src/game/client/components/hud.h
+++ b/src/game/client/components/hud.h
@@ -21,26 +21,26 @@ struct SScoreInfo
 		m_Initialized = false;
 	}
 
-	int m_TextRankContainerIndex;
-	int m_TextScoreContainerIndex;
-	float m_ScoreTextWidth;
-	char m_aScoreText[16];
-	char m_aRankText[16];
-	char m_aPlayerNameText[MAX_NAME_LENGTH];
-	int m_RoundRectQuadContainerIndex;
-	int m_OptionalNameTextContainerIndex;
+	int m_TextRankContainerIndex = 0;
+	int m_TextScoreContainerIndex = 0;
+	float m_ScoreTextWidth = 0;
+	char m_aScoreText[16] = {0};
+	char m_aRankText[16] = {0};
+	char m_aPlayerNameText[MAX_NAME_LENGTH] = {0};
+	int m_RoundRectQuadContainerIndex = 0;
+	int m_OptionalNameTextContainerIndex = 0;
 
-	bool m_Initialized;
+	bool m_Initialized = false;
 };
 
 class CHud : public CComponent
 {
-	float m_Width, m_Height;
-	float m_FrameTimeAvg;
+	float m_Width = 0, m_Height = 0;
+	float m_FrameTimeAvg = 0;
 
-	int m_HudQuadContainerIndex;
+	int m_HudQuadContainerIndex = 0;
 	SScoreInfo m_aScoreInfo[2];
-	int m_FPSTextContainerIndex;
+	int m_FPSTextContainerIndex = 0;
 
 	void RenderCursor();
 
@@ -85,53 +85,53 @@ public:
 private:
 	void RenderRecord();
 	void RenderDDRaceEffects();
-	float m_TimeCpDiff;
-	float m_ServerRecord;
-	float m_aPlayerRecord[NUM_DUMMIES];
-	float m_FinishTimeDiff;
-	int m_DDRaceTime;
-	int m_FinishTimeLastReceivedTick;
-	int m_TimeCpLastReceivedTick;
-	bool m_ShowFinishTime;
+	float m_TimeCpDiff = 0;
+	float m_ServerRecord = 0;
+	float m_aPlayerRecord[NUM_DUMMIES] = {0};
+	float m_FinishTimeDiff = 0;
+	int m_DDRaceTime = 0;
+	int m_FinishTimeLastReceivedTick = 0;
+	int m_TimeCpLastReceivedTick = 0;
+	bool m_ShowFinishTime = false;
 
 	inline float GetMovementInformationBoxHeight();
 	inline int GetDigitsIndex(int Value, int Max);
 
 	// Quad Offsets
-	int m_aAmmoOffset[NUM_WEAPONS];
-	int m_HealthOffset;
-	int m_EmptyHealthOffset;
-	int m_ArmorOffset;
-	int m_EmptyArmorOffset;
-	int m_aCursorOffset[NUM_WEAPONS];
-	int m_FlagOffset;
-	int m_AirjumpOffset;
-	int m_AirjumpEmptyOffset;
-	int m_WeaponHammerOffset;
-	int m_WeaponGunOffset;
-	int m_WeaponShotgunOffset;
-	int m_WeaponGrenadeOffset;
-	int m_WeaponLaserOffset;
-	int m_WeaponNinjaOffset;
-	int m_EndlessJumpOffset;
-	int m_EndlessHookOffset;
-	int m_JetpackOffset;
-	int m_TeleportGrenadeOffset;
-	int m_TeleportGunOffset;
-	int m_TeleportLaserOffset;
-	int m_SoloOffset;
-	int m_CollisionDisabledOffset;
-	int m_HookHitDisabledOffset;
-	int m_HammerHitDisabledOffset;
-	int m_GunHitDisabledOffset;
-	int m_ShotgunHitDisabledOffset;
-	int m_GrenadeHitDisabledOffset;
-	int m_LaserHitDisabledOffset;
-	int m_DeepFrozenOffset;
-	int m_LiveFrozenOffset;
-	int m_DummyHammerOffset;
-	int m_DummyCopyOffset;
-	int m_PracticeModeOffset;
+	int m_aAmmoOffset[NUM_WEAPONS] = {0};
+	int m_HealthOffset = 0;
+	int m_EmptyHealthOffset = 0;
+	int m_ArmorOffset = 0;
+	int m_EmptyArmorOffset = 0;
+	int m_aCursorOffset[NUM_WEAPONS] = {0};
+	int m_FlagOffset = 0;
+	int m_AirjumpOffset = 0;
+	int m_AirjumpEmptyOffset = 0;
+	int m_WeaponHammerOffset = 0;
+	int m_WeaponGunOffset = 0;
+	int m_WeaponShotgunOffset = 0;
+	int m_WeaponGrenadeOffset = 0;
+	int m_WeaponLaserOffset = 0;
+	int m_WeaponNinjaOffset = 0;
+	int m_EndlessJumpOffset = 0;
+	int m_EndlessHookOffset = 0;
+	int m_JetpackOffset = 0;
+	int m_TeleportGrenadeOffset = 0;
+	int m_TeleportGunOffset = 0;
+	int m_TeleportLaserOffset = 0;
+	int m_SoloOffset = 0;
+	int m_CollisionDisabledOffset = 0;
+	int m_HookHitDisabledOffset = 0;
+	int m_HammerHitDisabledOffset = 0;
+	int m_GunHitDisabledOffset = 0;
+	int m_ShotgunHitDisabledOffset = 0;
+	int m_GrenadeHitDisabledOffset = 0;
+	int m_LaserHitDisabledOffset = 0;
+	int m_DeepFrozenOffset = 0;
+	int m_LiveFrozenOffset = 0;
+	int m_DummyHammerOffset = 0;
+	int m_DummyCopyOffset = 0;
+	int m_PracticeModeOffset = 0;
 };
 
 #endif

--- a/src/game/client/components/items.h
+++ b/src/game/client/components/items.h
@@ -14,7 +14,7 @@ class CItems : public CComponent
 	void RenderFlag(const CNetObj_Flag *pPrev, const CNetObj_Flag *pCurrent, const CNetObj_GameData *pPrevGameData, const CNetObj_GameData *pCurGameData);
 	void RenderLaser(const struct CNetObj_Laser *pCurrent, bool IsPredicted = false);
 
-	int m_ItemsQuadContainerIndex;
+	int m_ItemsQuadContainerIndex = 0;
 
 public:
 	virtual int Sizeof() const override { return sizeof(*this); }
@@ -24,15 +24,15 @@ public:
 	void ReconstructSmokeTrail(const CProjectileData *pCurrent, int DestroyTick);
 
 private:
-	int m_BlueFlagOffset;
-	int m_RedFlagOffset;
-	int m_PickupHealthOffset;
-	int m_PickupArmorOffset;
-	int m_aPickupWeaponOffset[NUM_WEAPONS];
-	int m_PickupNinjaOffset;
-	int m_aPickupWeaponArmorOffset[4];
-	int m_aProjectileOffset[NUM_WEAPONS];
-	int m_aParticleSplatOffset[3];
+	int m_BlueFlagOffset = 0;
+	int m_RedFlagOffset = 0;
+	int m_PickupHealthOffset = 0;
+	int m_PickupArmorOffset = 0;
+	int m_aPickupWeaponOffset[NUM_WEAPONS] = {0};
+	int m_PickupNinjaOffset = 0;
+	int m_aPickupWeaponArmorOffset[4] = {0};
+	int m_aProjectileOffset[NUM_WEAPONS] = {0};
+	int m_aParticleSplatOffset[3] = {0};
 };
 
 #endif

--- a/src/game/client/components/killmessages.h
+++ b/src/game/client/components/killmessages.h
@@ -8,7 +8,7 @@
 
 class CKillMessages : public CComponent
 {
-	int m_SpriteQuadContainerIndex;
+	int m_SpriteQuadContainerIndex = 0;
 
 public:
 	// kill messages
@@ -19,26 +19,26 @@ public:
 			m_KillerTextContainerIndex = m_VictimTextContainerIndex = -1;
 		}
 
-		int m_Weapon;
+		int m_Weapon = 0;
 
-		int m_VictimID;
-		int m_VictimTeam;
-		int m_VictimDDTeam;
-		char m_aVictimName[64];
-		int m_VictimTextContainerIndex;
-		float m_VitctimTextWidth;
+		int m_VictimID = 0;
+		int m_VictimTeam = 0;
+		int m_VictimDDTeam = 0;
+		char m_aVictimName[64] = {0};
+		int m_VictimTextContainerIndex = 0;
+		float m_VitctimTextWidth = 0;
 		CTeeRenderInfo m_VictimRenderInfo;
 
-		int m_KillerID;
-		int m_KillerTeam;
-		char m_aKillerName[64];
-		int m_KillerTextContainerIndex;
-		float m_KillerTextWidth;
+		int m_KillerID = 0;
+		int m_KillerTeam = 0;
+		char m_aKillerName[64] = {0};
+		int m_KillerTextContainerIndex = 0;
+		float m_KillerTextWidth = 0;
 		CTeeRenderInfo m_KillerRenderInfo;
 
-		int m_ModeSpecial; // for CTF, if the guy is carrying a flag for example
-		int m_Tick;
-		int m_FlagCarrierBlue;
+		int m_ModeSpecial = 0; // for CTF, if the guy is carrying a flag for example
+		int m_Tick = 0;
+		int m_FlagCarrierBlue = 0;
 	};
 
 	enum
@@ -51,7 +51,7 @@ private:
 
 public:
 	CKillMsg m_aKillmsgs[MAX_KILLMSGS];
-	int m_KillmsgCurrent;
+	int m_KillmsgCurrent = 0;
 
 	virtual int Sizeof() const override { return sizeof(*this); }
 	virtual void OnWindowResize() override;

--- a/src/game/client/components/mapimages.h
+++ b/src/game/client/components/mapimages.h
@@ -40,10 +40,10 @@ class CMapImages : public CComponent
 	friend class CMenuBackground;
 
 	IGraphics::CTextureHandle m_aTextures[64];
-	int m_aTextureUsedByTileOrQuadLayerFlag[64]; // 0: nothing, 1(as flag): tile layer, 2(as flag): quad layer
-	int m_Count;
+	int m_aTextureUsedByTileOrQuadLayerFlag[64] = {0}; // 0: nothing, 1(as flag): tile layer, 2(as flag): quad layer
+	int m_Count = 0;
 
-	char m_aEntitiesPath[IO_MAX_PATH_LENGTH];
+	char m_aEntitiesPath[IO_MAX_PATH_LENGTH] = {0};
 
 	bool HasFrontLayer(EMapImageModType ModType);
 	bool HasSpeedupLayer(EMapImageModType ModType);
@@ -78,15 +78,15 @@ public:
 	void ChangeEntitiesPath(const char *pPath);
 
 private:
-	bool m_aEntitiesIsLoaded[MAP_IMAGE_MOD_TYPE_COUNT * 2];
-	bool m_SpeedupArrowIsLoaded;
+	bool m_aEntitiesIsLoaded[MAP_IMAGE_MOD_TYPE_COUNT * 2] = {false};
+	bool m_SpeedupArrowIsLoaded = false;
 	IGraphics::CTextureHandle m_aaEntitiesTextures[MAP_IMAGE_MOD_TYPE_COUNT * 2][MAP_IMAGE_ENTITY_LAYER_TYPE_COUNT];
 	IGraphics::CTextureHandle m_SpeedupArrowTexture;
 	IGraphics::CTextureHandle m_OverlayBottomTexture;
 	IGraphics::CTextureHandle m_OverlayTopTexture;
 	IGraphics::CTextureHandle m_OverlayCenterTexture;
 	IGraphics::CTextureHandle m_TransparentTexture;
-	int m_TextureScale;
+	int m_TextureScale = 0;
 
 	void InitOverlayTextures();
 	IGraphics::CTextureHandle UploadEntityLayerText(int TextureSize, int MaxWidth, int YOffset);

--- a/src/game/client/components/maplayers.cpp
+++ b/src/game/client/components/maplayers.cpp
@@ -356,15 +356,15 @@ bool AddTile(std::vector<SGraphicTile> &vTmpTiles, std::vector<SGraphicTileTexur
 
 struct STmpQuadVertexTextured
 {
-	float m_X, m_Y, m_CenterX, m_CenterY;
-	unsigned char m_R, m_G, m_B, m_A;
-	float m_U, m_V;
+	float m_X = 0, m_Y = 0, m_CenterX = 0, m_CenterY = 0;
+	unsigned char m_R = 0, m_G = 0, m_B = 0, m_A = 0;
+	float m_U = 0, m_V = 0;
 };
 
 struct STmpQuadVertex
 {
-	float m_X, m_Y, m_CenterX, m_CenterY;
-	unsigned char m_R, m_G, m_B, m_A;
+	float m_X = 0, m_Y = 0, m_CenterX = 0, m_CenterY = 0;
+	unsigned char m_R = 0, m_G = 0, m_B = 0, m_A = 0;
 };
 
 struct STmpQuad

--- a/src/game/client/components/maplayers.h
+++ b/src/game/client/components/maplayers.h
@@ -28,14 +28,14 @@ class CMapLayers : public CComponent
 	friend class CBackground;
 	friend class CMenuBackground;
 
-	CLayers *m_pLayers;
-	CMapImages *m_pImages;
-	int m_Type;
-	int m_CurrentLocalTick;
-	int m_LastLocalTick;
-	bool m_EnvelopeUpdate;
+	CLayers *m_pLayers = nullptr;
+	CMapImages *m_pImages = nullptr;
+	int m_Type = 0;
+	int m_CurrentLocalTick = 0;
+	int m_LastLocalTick = 0;
+	bool m_EnvelopeUpdate = false;
 
-	bool m_OnlineOnly;
+	bool m_OnlineOnly = false;
 
 	struct STileLayerVisuals
 	{
@@ -58,7 +58,7 @@ class CMapLayers : public CComponent
 				m_IndexBufferByteOffset(0) {}
 
 		private:
-			offset_ptr32 m_IndexBufferByteOffset;
+			offset_ptr32 m_IndexBufferByteOffset = 0;
 
 		public:
 			bool DoDraw()
@@ -86,7 +86,7 @@ class CMapLayers : public CComponent
 				m_IndexBufferByteOffset = ((m_IndexBufferByteOffset & 0xFFFFFFFE) + IndexBufferByteOff) | (m_IndexBufferByteOffset & 0x00000001);
 			}
 		};
-		STileVisual *m_pTilesOfLayer;
+		STileVisual *m_pTilesOfLayer = nullptr;
 
 		STileVisual m_BorderTopLeft;
 		STileVisual m_BorderTopRight;
@@ -95,15 +95,15 @@ class CMapLayers : public CComponent
 
 		STileVisual m_BorderKillTile; //end of map kill tile -- game layer only
 
-		STileVisual *m_pBorderTop;
-		STileVisual *m_pBorderLeft;
-		STileVisual *m_pBorderRight;
-		STileVisual *m_pBorderBottom;
+		STileVisual *m_pBorderTop = nullptr;
+		STileVisual *m_pBorderLeft = nullptr;
+		STileVisual *m_pBorderRight = nullptr;
+		STileVisual *m_pBorderBottom = nullptr;
 
-		unsigned int m_Width;
-		unsigned int m_Height;
-		int m_BufferContainerIndex;
-		bool m_IsTextured;
+		unsigned int m_Width = 0;
+		unsigned int m_Height = 0;
+		int m_BufferContainerIndex = 0;
+		bool m_IsTextured = false;
 	};
 	std::vector<STileLayerVisuals *> m_vpTileLayerVisuals;
 
@@ -117,14 +117,14 @@ class CMapLayers : public CComponent
 			SQuadVisual() :
 				m_IndexBufferByteOffset(0) {}
 
-			offset_ptr m_IndexBufferByteOffset;
+			offset_ptr m_IndexBufferByteOffset = 0;
 		};
 
-		int m_QuadNum;
-		SQuadVisual *m_pQuadsOfLayer;
+		int m_QuadNum = 0;
+		SQuadVisual *m_pQuadsOfLayer = nullptr;
 
-		int m_BufferContainerIndex;
-		bool m_IsTextured;
+		int m_BufferContainerIndex = 0;
+		bool m_IsTextured = false;
 	};
 	std::vector<SQuadLayerVisuals *> m_vpQuadLayerVisuals;
 

--- a/src/game/client/components/mapsounds.h
+++ b/src/game/client/components/mapsounds.h
@@ -11,15 +11,15 @@ struct CSoundSource;
 
 class CMapSounds : public CComponent
 {
-	int m_aSounds[64];
-	int m_Count;
+	int m_aSounds[64] = {0};
+	int m_Count = 0;
 
 	struct CSourceQueueEntry
 	{
-		int m_Sound;
-		bool m_HighDetail;
+		int m_Sound = 0;
+		bool m_HighDetail = false;
 		ISound::CVoiceHandle m_Voice;
-		CSoundSource *m_pSource;
+		CSoundSource *m_pSource = nullptr;
 
 		bool operator==(const CSourceQueueEntry &Other) const { return (m_Sound == Other.m_Sound) && (m_Voice == Other.m_Voice) && (m_pSource == Other.m_pSource); }
 	};

--- a/src/game/client/components/menu_background.h
+++ b/src/game/client/components/menu_background.h
@@ -22,8 +22,8 @@ public:
 		m_Name(pName), m_HasDay(HasDay), m_HasNight(HasNight) {}
 
 	std::string m_Name;
-	bool m_HasDay;
-	bool m_HasNight;
+	bool m_HasDay = false;
+	bool m_HasNight = false;
 	IGraphics::CTextureHandle m_IconTexture;
 	bool operator<(const CTheme &Other) const { return m_Name < Other.m_Name; }
 };
@@ -84,12 +84,12 @@ public:
 	vec2 m_MenuCenter;
 	vec2 m_RotationCenter;
 	vec2 m_aPositions[NUM_POS];
-	int m_CurrentPosition;
+	int m_CurrentPosition = 0;
 	vec2 m_AnimationStartPos;
-	bool m_ChangedPosition;
-	float m_MoveTime;
+	bool m_ChangedPosition = false;
+	float m_MoveTime = 0;
 
-	bool m_IsInit;
+	bool m_IsInit = false;
 
 	void ResetPositions();
 

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -27,7 +27,7 @@
 struct CServerProcess
 {
 	PROCESS Process;
-	bool Initialized;
+	bool Initialized = false;
 	CLineReader LineReader;
 };
 
@@ -37,24 +37,24 @@ public:
 	const float ms_Width = 160.0f;
 	const float ms_Height = 186.0f;
 
-	float m_X;
-	float m_Y;
+	float m_X = 0;
+	float m_Y = 0;
 
-	bool m_Active;
+	bool m_Active = false;
 
 	CUIRect m_AttachedRect;
-	unsigned int *m_pColor;
-	unsigned int m_HSVColor;
+	unsigned int *m_pColor = nullptr;
+	unsigned int m_HSVColor = 0;
 };
 
 // compnent to fetch keypresses, override all other input
 class CMenusKeyBinder : public CComponent
 {
 public:
-	bool m_TakeKey;
-	bool m_GotKey;
+	bool m_TakeKey = false;
+	bool m_GotKey = false;
 	IInput::CEvent m_Key;
-	int m_ModifierCombination;
+	int m_ModifierCombination = 0;
 	CMenusKeyBinder();
 	virtual int Sizeof() const override { return sizeof(*this); }
 	virtual bool OnInput(IInput::CEvent Event) override;
@@ -76,7 +76,7 @@ class CMenus : public CComponent
 	static SColorPicker ms_ColorPicker;
 	static bool ms_ValueSelectorTextMode;
 
-	char m_aLocalStringHelper[1024];
+	char m_aLocalStringHelper[1024] = {0};
 
 	CUIEx m_UIEx;
 
@@ -198,8 +198,8 @@ class CMenus : public CComponent
 
 	struct CListboxItem
 	{
-		int m_Visible;
-		int m_Selected;
+		int m_Visible = 0;
+		int m_Selected = 0;
 		CUIRect m_Rect;
 		CUIRect m_HitRect;
 	};
@@ -227,7 +227,7 @@ public:
 	{
 		IGraphics::CTextureHandle m_RenderTexture;
 
-		char m_aName[50];
+		char m_aName[50] = {0};
 
 		bool operator<(const SCustomItem &Other) const { return str_comp(m_aName, Other.m_aName) < 0; }
 	};
@@ -289,21 +289,21 @@ protected:
 
 	void ClearCustomItems(int CurTab);
 
-	int m_MenuPage;
-	int m_GamePage;
-	int m_Popup;
-	int m_ActivePage;
-	bool m_ShowStart;
-	bool m_MenuActive;
+	int m_MenuPage = 0;
+	int m_GamePage = 0;
+	int m_Popup = 0;
+	int m_ActivePage = 0;
+	bool m_ShowStart = false;
+	bool m_MenuActive = false;
 	vec2 m_MousePos;
-	bool m_JoinTutorial;
+	bool m_JoinTutorial = false;
 
-	char m_aNextServer[256];
+	char m_aNextServer[256] = {0};
 
 	// images
 	struct CMenuImage
 	{
-		char m_aName[64];
+		char m_aName[64] = {0};
 		IGraphics::CTextureHandle m_OrgTexture;
 		IGraphics::CTextureHandle m_GreyTexture;
 	};
@@ -314,13 +314,13 @@ protected:
 	const CMenuImage *FindMenuImage(const char *pName);
 
 	// loading
-	int m_LoadCurrent;
-	int m_LoadTotal;
+	int m_LoadCurrent = 0;
+	int m_LoadTotal = 0;
 
 	//
-	char m_aMessageTopic[512];
-	char m_aMessageBody[512];
-	char m_aMessageButton[512];
+	char m_aMessageTopic[512] = {0};
+	char m_aMessageBody[512] = {0};
+	char m_aMessageButton[512] = {0};
 
 	CUIElement m_RefreshButton;
 	CUIElement m_ConnectButton;
@@ -341,32 +341,32 @@ protected:
 	static float ms_ListitemAdditionalHeight;
 
 	// for settings
-	bool m_NeedRestartGeneral;
-	bool m_NeedRestartSkins;
-	bool m_NeedRestartGraphics;
-	bool m_NeedRestartSound;
-	bool m_NeedRestartUpdate;
-	bool m_NeedRestartDDNet;
-	bool m_NeedSendinfo;
-	bool m_NeedSendDummyinfo;
-	int m_SettingPlayerPage;
+	bool m_NeedRestartGeneral = false;
+	bool m_NeedRestartSkins = false;
+	bool m_NeedRestartGraphics = false;
+	bool m_NeedRestartSound = false;
+	bool m_NeedRestartUpdate = false;
+	bool m_NeedRestartDDNet = false;
+	bool m_NeedSendinfo = false;
+	bool m_NeedSendDummyinfo = false;
+	int m_SettingPlayerPage = 0;
 
 	//
-	bool m_EscapePressed;
-	bool m_EnterPressed;
-	bool m_DeletePressed;
+	bool m_EscapePressed = false;
+	bool m_EnterPressed = false;
+	bool m_DeletePressed = false;
 
 	// for map download popup
-	int64_t m_DownloadLastCheckTime;
-	int m_DownloadLastCheckSize;
-	float m_DownloadSpeed;
+	int64_t m_DownloadLastCheckTime = 0;
+	int m_DownloadLastCheckSize = 0;
+	float m_DownloadSpeed = 0;
 
 	// for call vote
-	int m_CallvoteSelectedOption;
-	int m_CallvoteSelectedPlayer;
-	char m_aCallvoteReason[VOTE_REASON_LENGTH];
-	char m_aFilterString[25];
-	bool m_ControlPageOpening;
+	int m_CallvoteSelectedOption = 0;
+	int m_CallvoteSelectedPlayer = 0;
+	char m_aCallvoteReason[VOTE_REASON_LENGTH] = {0};
+	char m_aFilterString[25] = {0};
+	bool m_ControlPageOpening = false;
 
 	// demo
 	enum
@@ -379,14 +379,14 @@ protected:
 
 	struct CDemoItem
 	{
-		char m_aFilename[IO_MAX_PATH_LENGTH];
-		char m_aName[128];
-		bool m_IsDir;
-		int m_StorageType;
-		time_t m_Date;
+		char m_aFilename[IO_MAX_PATH_LENGTH] = {0};
+		char m_aName[128] = {0};
+		bool m_IsDir = false;
+		int m_StorageType = 0;
+		time_t m_Date = 0;
 
-		bool m_InfosLoaded;
-		bool m_Valid;
+		bool m_InfosLoaded = false;
+		bool m_Valid = false;
 		CDemoHeader m_Info;
 		CTimelineMarkers m_TimelineMarkers;
 		CMapInfo m_MapInfo;
@@ -440,11 +440,11 @@ protected:
 		}
 	};
 
-	char m_aCurrentDemoFolder[256];
-	char m_aCurrentDemoFile[64];
-	int m_DemolistSelectedIndex;
-	bool m_DemolistSelectedIsDir;
-	int m_DemolistStorageType;
+	char m_aCurrentDemoFolder[256] = {0};
+	char m_aCurrentDemoFile[64] = {0};
+	int m_DemolistSelectedIndex = 0;
+	bool m_DemolistSelectedIsDir = false;
+	int m_DemolistStorageType = 0;
 	int m_Speed = 4;
 
 	std::chrono::nanoseconds m_DemoPopulateStartTime{0};
@@ -456,8 +456,8 @@ protected:
 	// friends
 	struct CFriendItem
 	{
-		const CFriendInfo *m_pFriendInfo;
-		int m_NumFound;
+		const CFriendInfo *m_pFriendInfo = nullptr;
+		int m_NumFound = 0;
 
 		CFriendItem() {}
 		CFriendItem(const CFriendInfo *pFriendInfo) :
@@ -483,7 +483,7 @@ protected:
 	};
 
 	std::vector<CFriendItem> m_vFriends;
-	int m_FriendlistSelectedIndex;
+	int m_FriendlistSelectedIndex = 0;
 
 	void FriendlistOnUpdate();
 
@@ -515,9 +515,9 @@ protected:
 	bool RenderServerControlServer(CUIRect MainView);
 
 	// found in menus_browser.cpp
-	int m_SelectedIndex;
-	int m_DoubleClickIndex;
-	int m_ScrollOffset;
+	int m_SelectedIndex = 0;
+	int m_DoubleClickIndex = 0;
+	int m_ScrollOffset = 0;
 	void RenderServerbrowserServerList(CUIRect View);
 	void RenderServerbrowserServerDetail(CUIRect View);
 	void RenderServerbrowserFilters(CUIRect View);
@@ -546,7 +546,7 @@ protected:
 
 	bool CheckHotKey(int Key) const;
 
-	class CMenuBackground *m_pBackground;
+	class CMenuBackground *m_pBackground = nullptr;
 
 public:
 	void RenderBackground();
@@ -635,19 +635,19 @@ public:
 	int DoButton_CheckBox_Tristate(const void *pID, const char *pText, TRISTATE Checked, const CUIRect *pRect);
 	std::vector<CDemoItem> m_vDemos;
 	void DemolistPopulate();
-	bool m_Dummy;
+	bool m_Dummy = false;
 
 	const char *GetCurrentDemoFolder() const { return m_aCurrentDemoFolder; }
 
 	// Ghost
 	struct CGhostItem
 	{
-		char m_aFilename[IO_MAX_PATH_LENGTH];
-		char m_aPlayer[MAX_NAME_LENGTH];
+		char m_aFilename[IO_MAX_PATH_LENGTH] = {0};
+		char m_aPlayer[MAX_NAME_LENGTH] = {0};
 
-		int m_Time;
-		int m_Slot;
-		bool m_Own;
+		int m_Time = 0;
+		int m_Slot = 0;
+		bool m_Own = false;
 
 		CGhostItem() :
 			m_Slot(-1), m_Own(false) { m_aFilename[0] = 0; }
@@ -673,11 +673,11 @@ public:
 
 	void PopupWarning(const char *pTopic, const char *pBody, const char *pButton, std::chrono::nanoseconds Duration);
 
-	std::chrono::nanoseconds m_PopupWarningLastTime;
-	std::chrono::nanoseconds m_PopupWarningDuration;
+	std::chrono::nanoseconds m_PopupWarningLastTime = std::chrono::nanoseconds::zero();
+	std::chrono::nanoseconds m_PopupWarningDuration = std::chrono::nanoseconds::zero();
 
-	int m_DemoPlayerState;
-	char m_aDemoPlayerPopupHint[256];
+	int m_DemoPlayerState = 0;
+	char m_aDemoPlayerPopupHint[256] = {0};
 
 	enum
 	{

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -64,12 +64,12 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 
 	struct CColumn
 	{
-		int m_ID;
-		int m_Sort;
+		int m_ID = 0;
+		int m_Sort = 0;
 		CLocConstString m_Caption;
-		int m_Direction;
-		float m_Width;
-		int m_Flags;
+		int m_Direction = 0;
+		float m_Width = 0;
+		int m_Flags = 0;
 		CUIRect m_Rect;
 		CUIRect m_Spacer;
 	};

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -991,12 +991,12 @@ void CMenus::RenderDemoList(CUIRect MainView)
 
 	struct CColumn
 	{
-		int m_ID;
-		int m_Sort;
+		int m_ID = 0;
+		int m_Sort = 0;
 		CLocConstString m_Caption;
-		int m_Direction;
-		float m_Width;
-		int m_Flags;
+		int m_Direction = 0;
+		float m_Width = 0;
+		int m_Flags = 0;
 		CUIRect m_Rect;
 		CUIRect m_Spacer;
 	};

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -940,8 +940,8 @@ void CMenus::RenderGhost(CUIRect MainView)
 	struct CColumn
 	{
 		CLocConstString m_Caption;
-		int m_Id;
-		float m_Width;
+		int m_Id = 0;
+		float m_Width = 0;
 		CUIRect m_Rect;
 		CUIRect m_Spacer;
 	};

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -396,7 +396,7 @@ void CMenus::RenderSettingsPlayer(CUIRect MainView)
 
 struct CUISkin
 {
-	const CSkin *m_pSkin;
+	const CSkin *m_pSkin = nullptr;
 
 	CUISkin() :
 		m_pSkin(nullptr) {}
@@ -796,13 +796,13 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 	TextRender()->SetCurFont(NULL);
 }
 
-typedef struct
+struct CKeyInfo
 {
 	CLocConstString m_Name;
-	const char *m_pCommand;
-	int m_KeyId;
-	int m_ModifierCombination;
-} CKeyInfo;
+	const char *m_pCommand = nullptr;
+	int m_KeyId = 0;
+	int m_ModifierCombination = 0;
+};
 
 static CKeyInfo gs_aKeys[] =
 	{
@@ -1856,7 +1856,7 @@ public:
 
 	std::string m_Name;
 	std::string m_FileName;
-	int m_CountryCode;
+	int m_CountryCode = 0;
 
 	bool operator<(const CLanguage &Other) const { return m_Name < Other.m_Name; }
 };

--- a/src/game/client/components/menus_settings_assets.cpp
+++ b/src/game/client/components/menus_settings_assets.cpp
@@ -16,7 +16,7 @@ typedef std::function<void()> TMenuAssetScanLoadedFunc;
 
 struct SMenuAssetScanUser
 {
-	void *m_pUser;
+	void *m_pUser = nullptr;
 	TMenuAssetScanLoadedFunc m_LoadedFunc;
 };
 

--- a/src/game/client/components/motd.h
+++ b/src/game/client/components/motd.h
@@ -7,10 +7,10 @@
 class CMotd : public CComponent
 {
 	// motd
-	int64_t m_ServerMotdTime;
+	int64_t m_ServerMotdTime = 0;
 
 public:
-	char m_aServerMotd[900];
+	char m_aServerMotd[900] = {0};
 
 	virtual int Sizeof() const override { return sizeof(*this); }
 	void Clear();

--- a/src/game/client/components/nameplates.h
+++ b/src/game/client/components/nameplates.h
@@ -27,15 +27,15 @@ struct SPlayerNamePlate
 		m_NameTextFontSize = m_ClanNameTextFontSize = 0;
 	}
 
-	char m_aName[MAX_NAME_LENGTH];
-	float m_NameTextWidth;
-	int m_NameTextContainerIndex;
-	float m_NameTextFontSize;
+	char m_aName[MAX_NAME_LENGTH] = {0};
+	float m_NameTextWidth = 0;
+	int m_NameTextContainerIndex = 0;
+	float m_NameTextFontSize = 0;
 
-	char m_aClanName[MAX_CLAN_LENGTH];
-	float m_ClanNameTextWidth;
-	int m_ClanNameTextContainerIndex;
-	float m_ClanNameTextFontSize;
+	char m_aClanName[MAX_CLAN_LENGTH] = {0};
+	float m_ClanNameTextWidth = 0;
+	int m_ClanNameTextContainerIndex = 0;
+	float m_ClanNameTextFontSize = 0;
 };
 
 class CNamePlates : public CComponent
@@ -47,11 +47,11 @@ class CNamePlates : public CComponent
 	void RenderNameplatePos(vec2 Position, const CNetObj_PlayerInfo *pPlayerInfo, float Alpha, bool ForceAlpha = false);
 
 	SPlayerNamePlate m_aNamePlates[MAX_CLIENTS];
-	class CPlayers *m_pPlayers;
+	class CPlayers *m_pPlayers = nullptr;
 
 	void ResetNamePlates();
 
-	int m_DirectionQuadContainerIndex;
+	int m_DirectionQuadContainerIndex = 0;
 
 public:
 	virtual int Sizeof() const override { return sizeof(*this); }

--- a/src/game/client/components/particles.h
+++ b/src/game/client/components/particles.h
@@ -29,33 +29,33 @@ struct CParticle
 	vec2 m_Pos;
 	vec2 m_Vel;
 
-	int m_Spr;
+	int m_Spr = 0;
 
-	float m_FlowAffected;
+	float m_FlowAffected = 0;
 
-	float m_LifeSpan;
+	float m_LifeSpan = 0;
 
-	float m_StartSize;
-	float m_EndSize;
+	float m_StartSize = 0;
+	float m_EndSize = 0;
 
-	bool m_UseAlphaFading;
-	float m_StartAlpha;
-	float m_EndAlpha;
+	bool m_UseAlphaFading = false;
+	float m_StartAlpha = 0;
+	float m_EndAlpha = 0;
 
-	float m_Rot;
-	float m_Rotspeed;
+	float m_Rot = 0;
+	float m_Rotspeed = 0;
 
-	float m_Gravity;
-	float m_Friction;
+	float m_Gravity = 0;
+	float m_Friction = 0;
 
 	ColorRGBA m_Color;
 
-	bool m_Collides;
+	bool m_Collides = false;
 
 	// set by the particle system
-	float m_Life;
-	int m_PrevPart;
-	int m_NextPart;
+	float m_Life = 0;
+	int m_PrevPart = 0;
+	int m_NextPart = 0;
 };
 
 class CParticles : public CComponent
@@ -82,8 +82,8 @@ public:
 	virtual void OnInit() override;
 
 private:
-	int m_ParticleQuadContainerIndex;
-	int m_ExtraParticleQuadContainerIndex;
+	int m_ParticleQuadContainerIndex = 0;
+	int m_ExtraParticleQuadContainerIndex = 0;
 
 	enum
 	{
@@ -91,8 +91,8 @@ private:
 	};
 
 	CParticle m_aParticles[MAX_PARTICLES];
-	int m_FirstFree;
-	int m_aFirstPart[NUM_GROUPS];
+	int m_FirstFree = 0;
+	int m_aFirstPart[NUM_GROUPS] = {0};
 
 	void RenderGroup(int Group);
 	void Update(float TimePassed);
@@ -101,7 +101,7 @@ private:
 	class CRenderGroup : public CComponent
 	{
 	public:
-		CParticles *m_pParts;
+		CParticles *m_pParts = nullptr;
 		virtual int Sizeof() const override { return sizeof(*this); }
 		virtual void OnRender() override { m_pParts->RenderGroup(TGROUP); }
 	};

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -85,9 +85,9 @@ float CPlayers::GetPlayerTargetAngle(
 	if(ClientID >= 0 && m_pClient->m_Snap.m_aCharacters[ClientID].m_HasExtendedDisplayInfo)
 	{
 		CNetObj_DDNetCharacter *pExtendedData = &m_pClient->m_Snap.m_aCharacters[ClientID].m_ExtendedData;
-		if(m_pClient->m_Snap.m_aCharacters[ClientID].m_PrevExtendedData)
+		if(m_pClient->m_Snap.m_aCharacters[ClientID].m_pPrevExtendedData)
 		{
-			const CNetObj_DDNetCharacter *PrevExtendedData = m_pClient->m_Snap.m_aCharacters[ClientID].m_PrevExtendedData;
+			const CNetObj_DDNetCharacter *PrevExtendedData = m_pClient->m_Snap.m_aCharacters[ClientID].m_pPrevExtendedData;
 
 			float MixX = mix((float)PrevExtendedData->m_TargetX, (float)pExtendedData->m_TargetX, AngleIntraTick);
 			float MixY = mix((float)PrevExtendedData->m_TargetY, (float)pExtendedData->m_TargetY, AngleIntraTick);

--- a/src/game/client/components/players.h
+++ b/src/game/client/components/players.h
@@ -38,8 +38,8 @@ class CPlayers : public CComponent
 		float Intra = 0.f);
 	bool IsPlayerInfoAvailable(int ClientID) const;
 
-	int m_WeaponEmoteQuadContainerIndex;
-	int m_aWeaponSpriteMuzzleQuadContainerIndex[NUM_WEAPONS];
+	int m_WeaponEmoteQuadContainerIndex = 0;
+	int m_aWeaponSpriteMuzzleQuadContainerIndex[NUM_WEAPONS] = {0};
 
 public:
 	virtual int Sizeof() const override { return sizeof(*this); }

--- a/src/game/client/components/race_demo.cpp
+++ b/src/game/client/components/race_demo.cpp
@@ -21,15 +21,15 @@ const char *CRaceDemo::ms_pRaceDemoDir = "demos/auto/race";
 
 struct CDemoItem
 {
-	char m_aName[128];
-	int m_Time;
+	char m_aName[128] = {0};
+	int m_Time = 0;
 };
 
 struct CDemoListParam
 {
-	const CRaceDemo *m_pThis;
-	std::vector<CDemoItem> *m_pvDemos;
-	const char *pMap;
+	const CRaceDemo *m_pThis = nullptr;
+	std::vector<CDemoItem> *m_pvDemos = nullptr;
+	const char *pMap = nullptr;
 };
 
 CRaceDemo::CRaceDemo() :
@@ -186,8 +186,8 @@ void CRaceDemo::StopRecord(int Time)
 
 struct SRaceDemoFetchUser
 {
-	CRaceDemo *m_pThis;
-	CDemoListParam *m_pParam;
+	CRaceDemo *m_pThis = nullptr;
+	CDemoListParam *m_pParam = nullptr;
 };
 
 int CRaceDemo::RaceDemolistFetchCallback(const CFsFileInfo *pInfo, int IsDir, int StorageType, void *pUser)

--- a/src/game/client/components/race_demo.h
+++ b/src/game/client/components/race_demo.h
@@ -19,12 +19,12 @@ class CRaceDemo : public CComponent
 
 	static const char *ms_pRaceDemoDir;
 
-	char m_aTmpFilename[128];
+	char m_aTmpFilename[128] = {0};
 
-	int m_RaceState;
-	int m_RaceStartTick;
-	int m_RecordStopTick;
-	int m_Time;
+	int m_RaceState = 0;
+	int m_RaceStartTick = 0;
+	int m_RecordStopTick = 0;
+	int m_Time = 0;
 
 	std::chrono::nanoseconds m_RaceDemosLoadStartTime{0};
 
@@ -36,7 +36,7 @@ class CRaceDemo : public CComponent
 	bool CheckDemo(int Time);
 
 public:
-	bool m_AllowRestart;
+	bool m_AllowRestart = false;
 
 	CRaceDemo();
 	virtual int Sizeof() const override { return sizeof(*this); }

--- a/src/game/client/components/scoreboard.h
+++ b/src/game/client/components/scoreboard.h
@@ -18,7 +18,7 @@ class CScoreboard : public CComponent
 
 	const char *GetClanName(int Team);
 
-	bool m_Active;
+	bool m_Active = false;
 
 public:
 	CScoreboard();
@@ -35,7 +35,7 @@ public:
 	virtual void OnMessage(int MsgType, void *pRawMsg) override;
 
 private:
-	float m_ServerRecord;
+	float m_ServerRecord = 0;
 };
 
 #endif

--- a/src/game/client/components/skins.cpp
+++ b/src/game/client/components/skins.cpp
@@ -403,7 +403,6 @@ int CSkins::Find(const char *pName)
 int CSkins::FindImpl(const char *pName)
 {
 	CSkin Needle;
-	mem_zero(&Needle, sizeof(Needle));
 	str_copy(Needle.m_aName, pName);
 	auto Range = std::equal_range(m_vSkins.begin(), m_vSkins.end(), Needle);
 	if(std::distance(Range.first, Range.second) == 1)
@@ -419,7 +418,7 @@ int CSkins::FindImpl(const char *pName)
 		return -1;
 
 	CDownloadSkin DownloadNeedle;
-	mem_zero(&DownloadNeedle, sizeof(DownloadNeedle));
+	dbg_assert(mem_is_null(&DownloadNeedle, sizeof(DownloadNeedle)), "mem not null");
 	str_copy(DownloadNeedle.m_aName, pName);
 	const auto &[RangeBegin, RangeEnd] = std::equal_range(m_vDownloadSkins.begin(), m_vDownloadSkins.end(), DownloadNeedle);
 	if(std::distance(RangeBegin, RangeEnd) == 1)

--- a/src/game/client/components/skins.cpp
+++ b/src/game/client/components/skins.cpp
@@ -49,7 +49,7 @@ CSkins::CGetPngFile::CGetPngFile(CSkins *pSkins, const char *pUrl, IStorage *pSt
 
 struct SSkinScanUser
 {
-	CSkins *m_pThis;
+	CSkins *m_pThis = nullptr;
 	CSkins::TSkinLoadedCBFunc m_SkinLoadedFunc;
 };
 

--- a/src/game/client/components/skins.h
+++ b/src/game/client/components/skins.h
@@ -13,7 +13,7 @@ class CSkins : public CComponent
 public:
 	class CGetPngFile : public CHttpRequest
 	{
-		CSkins *m_pSkins;
+		CSkins *m_pSkins = nullptr;
 
 	protected:
 		virtual int OnCompletion(int State) override;
@@ -25,9 +25,9 @@ public:
 
 	struct CDownloadSkin
 	{
-		std::shared_ptr<CSkins::CGetPngFile> m_pTask;
-		char m_aPath[IO_MAX_PATH_LENGTH];
-		char m_aName[24];
+		std::shared_ptr<CSkins::CGetPngFile> m_pTask = nullptr;
+		char m_aPath[IO_MAX_PATH_LENGTH] = {0};
+		char m_aName[24] = {0};
 
 		CDownloadSkin(CDownloadSkin &&Other) = default;
 		CDownloadSkin() = default;
@@ -57,7 +57,7 @@ public:
 private:
 	std::vector<CSkin> m_vSkins;
 	std::vector<CDownloadSkin> m_vDownloadSkins;
-	char m_aEventSkinPrefix[24];
+	char m_aEventSkinPrefix[24] = {0};
 
 	bool LoadSkinPNG(CImageInfo &Info, const char *pName, const char *pPath, int DirType);
 	int LoadSkin(const char *pName, const char *pPath, int DirType);

--- a/src/game/client/components/sounds.cpp
+++ b/src/game/client/components/sounds.cpp
@@ -169,7 +169,8 @@ void CSounds::OnRender()
 
 void CSounds::ClearQueue()
 {
-	mem_zero(m_aQueue, sizeof(m_aQueue));
+	new(m_aQueue) std::remove_pointer<decltype(m_aQueue)>::type;
+	dbg_assert(mem_is_null(m_aQueue, sizeof(*m_aQueue)), "mem not null");
 	m_QueuePos = 0;
 	m_QueueWaitTime = time();
 }

--- a/src/game/client/components/sounds.h
+++ b/src/game/client/components/sounds.h
@@ -10,8 +10,8 @@
 
 class CSoundLoading : public IJob
 {
-	CGameClient *m_pGameClient;
-	bool m_Render;
+	CGameClient *m_pGameClient = nullptr;
+	bool m_Render = false;
 
 public:
 	CSoundLoading(CGameClient *pGameClient, bool Render);
@@ -26,20 +26,20 @@ class CSounds : public CComponent
 	};
 	struct QueueEntry
 	{
-		int m_Channel;
-		int m_SetId;
+		int m_Channel = 0;
+		int m_SetId = 0;
 	} m_aQueue[QUEUE_SIZE];
-	int m_QueuePos;
-	int64_t m_QueueWaitTime;
-	std::shared_ptr<CSoundLoading> m_pSoundJob;
-	bool m_WaitForSoundJob;
+	int m_QueuePos = 0;
+	int64_t m_QueueWaitTime = 0;
+	std::shared_ptr<CSoundLoading> m_pSoundJob = nullptr;
+	bool m_WaitForSoundJob = false;
 
 	int GetSampleId(int SetId);
 
-	float m_GuiSoundVolume;
-	float m_GameSoundVolume;
-	float m_MapSoundVolume;
-	float m_BackgroundMusicVolume;
+	float m_GuiSoundVolume = 0;
+	float m_GameSoundVolume = 0;
+	float m_MapSoundVolume = 0;
+	float m_BackgroundMusicVolume = 0;
 
 public:
 	// sound channels

--- a/src/game/client/components/spectator.h
+++ b/src/game/client/components/spectator.h
@@ -13,14 +13,14 @@ class CSpectator : public CComponent
 		NO_SELECTION = -3,
 	};
 
-	bool m_Active;
-	bool m_WasActive;
+	bool m_Active = false;
+	bool m_WasActive = false;
 
-	int m_SelectedSpectatorID;
+	int m_SelectedSpectatorID = 0;
 	vec2 m_SelectorMouse;
 
-	float m_OldMouseX;
-	float m_OldMouseY;
+	float m_OldMouseX = 0;
+	float m_OldMouseY = 0;
 
 	bool CanChangeSpectator();
 	void SpectateNext(bool Reverse);

--- a/src/game/client/components/statboard.h
+++ b/src/game/client/components/statboard.h
@@ -9,9 +9,9 @@
 class CStatboard : public CComponent
 {
 private:
-	bool m_Active;
-	bool m_ScreenshotTaken;
-	int64_t m_ScreenshotTime;
+	bool m_Active = false;
+	bool m_ScreenshotTaken = false;
+	int64_t m_ScreenshotTime = 0;
 	static void ConKeyStats(IConsole::IResult *pResult, void *pUserData);
 	void RenderGlobalStats();
 	void AutoStatScreenshot();

--- a/src/game/client/components/tooltips.h
+++ b/src/game/client/components/tooltips.h
@@ -11,9 +11,9 @@
 struct CTooltip
 {
 	CUIRect m_Rect;
-	const char *m_pText;
-	float m_WidthHint;
-	bool m_OnScreen; // used to know if the tooltip should be rendered.
+	const char *m_pText = nullptr;
+	float m_WidthHint = 0;
+	bool m_OnScreen = false; // used to know if the tooltip should be rendered.
 };
 
 /**
@@ -25,7 +25,7 @@ class CTooltips : public CComponent
 {
 	std::unordered_map<uintptr_t, CTooltip> m_Tooltips;
 	std::optional<std::reference_wrapper<CTooltip>> m_ActiveTooltip;
-	int64_t m_HoverTime;
+	int64_t m_HoverTime = 0;
 
 	/**
 	 * The passed tooltip is only actually set if there is no currently active tooltip.

--- a/src/game/client/components/voting.h
+++ b/src/game/client/components/voting.h
@@ -20,23 +20,23 @@ class CVoting : public CComponent
 	static void ConCallvote(IConsole::IResult *pResult, void *pUserData);
 	static void ConVote(IConsole::IResult *pResult, void *pUserData);
 
-	int64_t m_Closetime;
-	char m_aDescription[VOTE_DESC_LENGTH];
-	char m_aReason[VOTE_REASON_LENGTH];
-	int m_Voted;
-	int m_Yes, m_No, m_Pass, m_Total;
+	int64_t m_Closetime = 0;
+	char m_aDescription[VOTE_DESC_LENGTH] = {0};
+	char m_aReason[VOTE_REASON_LENGTH] = {0};
+	int m_Voted = 0;
+	int m_Yes = 0, m_No = 0, m_Pass = 0, m_Total = 0;
 
 	void AddOption(const char *pDescription);
 	void ClearOptions();
 	void Callvote(const char *pType, const char *pValue, const char *pReason);
 
 public:
-	int m_NumVoteOptions;
-	CVoteOptionClient *m_pFirst;
-	CVoteOptionClient *m_pLast;
+	int m_NumVoteOptions = 0;
+	CVoteOptionClient *m_pFirst = nullptr;
+	CVoteOptionClient *m_pLast = nullptr;
 
-	CVoteOptionClient *m_pRecycleFirst;
-	CVoteOptionClient *m_pRecycleLast;
+	CVoteOptionClient *m_pRecycleFirst = nullptr;
+	CVoteOptionClient *m_pRecycleLast = nullptr;
 
 	CVoting();
 	virtual int Sizeof() const override { return sizeof(*this); }

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1331,7 +1331,7 @@ void CGameClient::OnNewSnapshot()
 				if(Item.m_ID < MAX_CLIENTS)
 				{
 					m_Snap.m_aCharacters[Item.m_ID].m_ExtendedData = *pCharacterData;
-					m_Snap.m_aCharacters[Item.m_ID].m_PrevExtendedData = (const CNetObj_DDNetCharacter *)Client()->SnapFindItem(IClient::SNAP_PREV, NETOBJTYPE_DDNETCHARACTER, Item.m_ID);
+					m_Snap.m_aCharacters[Item.m_ID].m_pPrevExtendedData = (const CNetObj_DDNetCharacter *)Client()->SnapFindItem(IClient::SNAP_PREV, NETOBJTYPE_DDNETCHARACTER, Item.m_ID);
 					m_Snap.m_aCharacters[Item.m_ID].m_HasExtendedData = true;
 					m_Snap.m_aCharacters[Item.m_ID].m_HasExtendedDisplayInfo = false;
 					if(pCharacterData->m_JumpedTotal != -1)

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -79,6 +79,32 @@ int CGameClient::DDNetVersion() const { return CLIENT_VERSIONNR; }
 const char *CGameClient::DDNetVersionStr() const { return m_aDDNetVersionStr; }
 const char *CGameClient::GetItemName(int Type) const { return m_NetObjHandler.GetObjName(Type); }
 
+bool operator==(const CNetObj_Character &lhs, const CNetObj_Character &rhs)
+{
+	return lhs.m_Tick == rhs.m_Tick &&
+	lhs.m_X == rhs.m_X &&
+	lhs.m_Y == rhs.m_Y &&
+	lhs.m_VelX == rhs.m_VelX &&
+	lhs.m_VelY == rhs.m_VelY &&
+	lhs.m_Angle == rhs.m_Angle &&
+	lhs.m_Direction == rhs.m_Direction &&
+	lhs.m_Jumped == rhs.m_Jumped &&
+	lhs.m_HookedPlayer == rhs.m_HookedPlayer &&
+	lhs.m_HookState == rhs.m_HookState &&
+	lhs.m_HookTick == rhs.m_HookTick &&
+	lhs.m_HookX == rhs.m_HookX &&
+	lhs.m_HookY == rhs.m_HookY &&
+	lhs.m_HookDx == rhs.m_HookDx &&
+	lhs.m_HookDy == rhs.m_HookDy &&
+	lhs.m_PlayerFlags == rhs.m_PlayerFlags &&
+	lhs.m_Health == rhs.m_Health &&
+	lhs.m_Armor == rhs.m_Armor &&
+	lhs.m_AmmoCount == rhs.m_AmmoCount &&
+	lhs.m_Weapon == rhs.m_Weapon &&
+	lhs.m_Emote == rhs.m_Emote &&
+	lhs.m_AttackTick == rhs.m_AttackTick;
+}
+
 void CGameClient::OnConsoleInit()
 {
 	m_pEngine = Kernel()->RequestInterface<IEngine>();
@@ -512,7 +538,8 @@ void CGameClient::OnConnected()
 
 	m_GameWorld.Clear();
 	m_GameWorld.m_WorldConfig.m_InfiniteAmmo = true;
-	mem_zero(&m_GameInfo, sizeof(m_GameInfo));
+	m_GameInfo = CGameInfo();
+	dbg_assert(mem_is_null(&m_GameInfo, sizeof(m_GameInfo)), "mem not null");
 	m_PredictedDummyID = -1;
 	LoadMapSettings();
 
@@ -1124,7 +1151,7 @@ static CGameInfo GetGameInfo(const CNetObj_GameInfoEx *pInfoEx, int InfoExSize, 
 void CGameClient::InvalidateSnapshot()
 {
 	// clear all pointers
-	mem_zero(&m_Snap, sizeof(m_Snap));
+	m_Snap = CGameClient::CSnapState();
 	m_Snap.m_LocalClientID = -1;
 	SnapCollectEntities();
 }
@@ -1304,9 +1331,9 @@ void CGameClient::OnNewSnapshot()
 						// reuse the result from the previous evolve if the snapped character didn't change since the previous snapshot
 						if(EvolveCur && m_aClients[Item.m_ID].m_Evolved.m_Tick == Client()->PrevGameTick(g_Config.m_ClDummy))
 						{
-							if(mem_comp(&m_Snap.m_aCharacters[Item.m_ID].m_Prev, &m_aClients[Item.m_ID].m_Snapped, sizeof(CNetObj_Character)) == 0)
+							if(m_Snap.m_aCharacters[Item.m_ID].m_Prev == m_aClients[Item.m_ID].m_Snapped)
 								m_Snap.m_aCharacters[Item.m_ID].m_Prev = m_aClients[Item.m_ID].m_Evolved;
-							if(mem_comp(&m_Snap.m_aCharacters[Item.m_ID].m_Cur, &m_aClients[Item.m_ID].m_Snapped, sizeof(CNetObj_Character)) == 0)
+							if(m_Snap.m_aCharacters[Item.m_ID].m_Cur == m_aClients[Item.m_ID].m_Snapped)
 								m_Snap.m_aCharacters[Item.m_ID].m_Cur = m_aClients[Item.m_ID].m_Evolved;
 						}
 

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -57,51 +57,51 @@
 class CGameInfo
 {
 public:
-	bool m_FlagStartsRace;
-	bool m_TimeScore;
-	bool m_UnlimitedAmmo;
-	bool m_DDRaceRecordMessage;
-	bool m_RaceRecordMessage;
-	bool m_RaceSounds;
+	bool m_FlagStartsRace = false;
+	bool m_TimeScore = false;
+	bool m_UnlimitedAmmo = false;
+	bool m_DDRaceRecordMessage = false;
+	bool m_RaceRecordMessage = false;
+	bool m_RaceSounds = false;
 
-	bool m_AllowEyeWheel;
-	bool m_AllowHookColl;
-	bool m_AllowZoom;
+	bool m_AllowEyeWheel = false;
+	bool m_AllowHookColl = false;
+	bool m_AllowZoom = false;
 
-	bool m_BugDDRaceGhost;
-	bool m_BugDDRaceInput;
-	bool m_BugFNGLaserRange;
-	bool m_BugVanillaBounce;
+	bool m_BugDDRaceGhost = false;
+	bool m_BugDDRaceInput = false;
+	bool m_BugFNGLaserRange = false;
+	bool m_BugVanillaBounce = false;
 
-	bool m_PredictFNG;
-	bool m_PredictDDRace;
-	bool m_PredictDDRaceTiles;
-	bool m_PredictVanilla;
+	bool m_PredictFNG = false;
+	bool m_PredictDDRace = false;
+	bool m_PredictDDRaceTiles = false;
+	bool m_PredictVanilla = false;
 
-	bool m_EntitiesDDNet;
-	bool m_EntitiesDDRace;
-	bool m_EntitiesRace;
-	bool m_EntitiesFNG;
-	bool m_EntitiesVanilla;
-	bool m_EntitiesBW;
-	bool m_EntitiesFDDrace;
+	bool m_EntitiesDDNet = false;
+	bool m_EntitiesDDRace = false;
+	bool m_EntitiesRace = false;
+	bool m_EntitiesFNG = false;
+	bool m_EntitiesVanilla = false;
+	bool m_EntitiesBW = false;
+	bool m_EntitiesFDDrace = false;
 
-	bool m_Race;
+	bool m_Race = false;
 
-	bool m_DontMaskEntities;
-	bool m_AllowXSkins;
+	bool m_DontMaskEntities = false;
+	bool m_AllowXSkins = false;
 
-	bool m_HudHealthArmor;
-	bool m_HudAmmo;
-	bool m_HudDDRace;
+	bool m_HudHealthArmor = false;
+	bool m_HudAmmo = false;
+	bool m_HudDDRace = false;
 };
 
 class CSnapEntities
 {
 public:
 	IClient::CSnapItem m_Item;
-	const void *m_pData;
-	const CNetObj_EntityEx *m_pDataEx;
+	const void *m_pData = nullptr;
+	const CNetObj_EntityEx *m_pDataEx = nullptr;
 };
 
 class CGameClient : public IGameClient
@@ -155,23 +155,23 @@ private:
 	std::vector<class CComponent *> m_vpInput;
 	CNetObjHandler m_NetObjHandler;
 
-	class IEngine *m_pEngine;
-	class IInput *m_pInput;
-	class IGraphics *m_pGraphics;
-	class ITextRender *m_pTextRender;
-	class IClient *m_pClient;
-	class ISound *m_pSound;
-	class CConfig *m_pConfig;
-	class IConsole *m_pConsole;
-	class IStorage *m_pStorage;
-	class IDemoPlayer *m_pDemoPlayer;
-	class IFavorites *m_pFavorites;
-	class IServerBrowser *m_pServerBrowser;
-	class IEditor *m_pEditor;
-	class IFriends *m_pFriends;
-	class IFriends *m_pFoes;
+	class IEngine *m_pEngine = nullptr;
+	class IInput *m_pInput = nullptr;
+	class IGraphics *m_pGraphics = nullptr;
+	class ITextRender *m_pTextRender = nullptr;
+	class IClient *m_pClient = nullptr;
+	class ISound *m_pSound = nullptr;
+	class CConfig *m_pConfig = nullptr;
+	class IConsole *m_pConsole = nullptr;
+	class IStorage *m_pStorage = nullptr;
+	class IDemoPlayer *m_pDemoPlayer = nullptr;
+	class IFavorites *m_pFavorites = nullptr;
+	class IServerBrowser *m_pServerBrowser = nullptr;
+	class IEditor *m_pEditor = nullptr;
+	class IFriends *m_pFriends = nullptr;
+	class IFriends *m_pFoes = nullptr;
 #if defined(CONF_AUTOUPDATE)
-	class IUpdater *m_pUpdater;
+	class IUpdater *m_pUpdater = nullptr;
 #endif
 
 	CLayers m_Layers;
@@ -181,17 +181,17 @@ private:
 	void ProcessEvents();
 	void UpdatePositions();
 
-	int m_PredictedTick;
-	int m_aLastNewPredictedTick[NUM_DUMMIES];
+	int m_PredictedTick = 0;
+	int m_aLastNewPredictedTick[NUM_DUMMIES] = {0};
 
-	int m_LastRoundStartTick;
+	int m_LastRoundStartTick = 0;
 
-	int m_LastFlagCarrierRed;
-	int m_LastFlagCarrierBlue;
+	int m_LastFlagCarrierRed = 0;
+	int m_LastFlagCarrierBlue = 0;
 
-	int m_aCheckInfo[NUM_DUMMIES];
+	int m_aCheckInfo[NUM_DUMMIES] = {0};
 
-	char m_aDDNetVersionStr[64];
+	char m_aDDNetVersionStr[64] = {0};
 
 	static void ConTeam(IConsole::IResult *pResult, void *pUserData);
 	static void ConKill(IConsole::IResult *pResult, void *pUserData);
@@ -240,10 +240,10 @@ public:
 	}
 	const char *NetobjCorrectedOn() { return m_NetObjHandler.CorrectedObjOn(); }
 
-	bool m_SuppressEvents;
-	bool m_NewTick;
-	bool m_NewPredictedTick;
-	int m_aFlagDropTick[2];
+	bool m_SuppressEvents = false;
+	bool m_NewTick = false;
+	bool m_NewPredictedTick = false;
+	int m_aFlagDropTick[2] = {0};
 
 	// TODO: move this
 	CTuningParams m_aTuning[NUM_DUMMIES];
@@ -254,10 +254,10 @@ public:
 		SERVERMODE_MOD,
 		SERVERMODE_PUREMOD,
 	};
-	int m_ServerMode;
+	int m_ServerMode = 0;
 	CGameInfo m_GameInfo;
 
-	int m_DemoSpecID;
+	int m_DemoSpecID = 0;
 
 	vec2 m_LocalCharacterPos;
 
@@ -268,48 +268,48 @@ public:
 	// snap pointers
 	struct CSnapState
 	{
-		const CNetObj_Character *m_pLocalCharacter;
-		const CNetObj_Character *m_pLocalPrevCharacter;
-		const CNetObj_PlayerInfo *m_pLocalInfo;
-		const CNetObj_SpectatorInfo *m_pSpectatorInfo;
-		const CNetObj_SpectatorInfo *m_pPrevSpectatorInfo;
-		const CNetObj_Flag *m_apFlags[2];
-		const CNetObj_GameInfo *m_pGameInfoObj;
-		const CNetObj_GameData *m_pGameDataObj;
-		int m_GameDataSnapID;
+		const CNetObj_Character *m_pLocalCharacter = nullptr;
+		const CNetObj_Character *m_pLocalPrevCharacter = nullptr;
+		const CNetObj_PlayerInfo *m_pLocalInfo = nullptr;
+		const CNetObj_SpectatorInfo *m_pSpectatorInfo = nullptr;
+		const CNetObj_SpectatorInfo *m_pPrevSpectatorInfo = nullptr;
+		const CNetObj_Flag *m_apFlags[2] = {nullptr};
+		const CNetObj_GameInfo *m_pGameInfoObj = nullptr;
+		const CNetObj_GameData *m_pGameDataObj = nullptr;
+		int m_GameDataSnapID = 0;
 
-		const CNetObj_PlayerInfo *m_apPlayerInfos[MAX_CLIENTS];
-		const CNetObj_PlayerInfo *m_apInfoByScore[MAX_CLIENTS];
-		const CNetObj_PlayerInfo *m_apInfoByName[MAX_CLIENTS];
-		const CNetObj_PlayerInfo *m_apInfoByDDTeamScore[MAX_CLIENTS];
-		const CNetObj_PlayerInfo *m_apInfoByDDTeamName[MAX_CLIENTS];
+		const CNetObj_PlayerInfo *m_apPlayerInfos[MAX_CLIENTS] = {nullptr};
+		const CNetObj_PlayerInfo *m_apInfoByScore[MAX_CLIENTS] = {nullptr};
+		const CNetObj_PlayerInfo *m_apInfoByName[MAX_CLIENTS] = {nullptr};
+		const CNetObj_PlayerInfo *m_apInfoByDDTeamScore[MAX_CLIENTS] = {nullptr};
+		const CNetObj_PlayerInfo *m_apInfoByDDTeamName[MAX_CLIENTS] = {nullptr};
 
-		int m_LocalClientID;
-		int m_NumPlayers;
-		int m_aTeamSize[2];
+		int m_LocalClientID = 0;
+		int m_NumPlayers = 0;
+		int m_aTeamSize[2] = {0};
 
 		// spectate data
 		struct CSpectateInfo
 		{
-			bool m_Active;
-			int m_SpectatorID;
-			bool m_UsePosition;
+			bool m_Active = false;
+			int m_SpectatorID = 0;
+			bool m_UsePosition = false;
 			vec2 m_Position;
 		} m_SpecInfo;
 
 		//
 		struct CCharacterInfo
 		{
-			bool m_Active;
+			bool m_Active = false;
 
 			// snapshots
 			CNetObj_Character m_Prev;
 			CNetObj_Character m_Cur;
 
 			CNetObj_DDNetCharacter m_ExtendedData;
-			const CNetObj_DDNetCharacter *m_PrevExtendedData;
-			bool m_HasExtendedData;
-			bool m_HasExtendedDisplayInfo;
+			const CNetObj_DDNetCharacter *m_pPrevExtendedData = nullptr;
+			bool m_HasExtendedData = false;
+			bool m_HasExtendedDisplayInfo = false;
 
 			// interpolated position
 			vec2 m_Position;
@@ -319,44 +319,44 @@ public:
 	};
 
 	CSnapState m_Snap;
-	int m_aLocalTuneZone[NUM_DUMMIES];
-	bool m_aReceivedTuning[NUM_DUMMIES];
-	int m_aExpectingTuningForZone[NUM_DUMMIES];
-	int m_aExpectingTuningSince[NUM_DUMMIES];
+	int m_aLocalTuneZone[NUM_DUMMIES] = {0};
+	bool m_aReceivedTuning[NUM_DUMMIES] = {false};
+	int m_aExpectingTuningForZone[NUM_DUMMIES] = {0};
+	int m_aExpectingTuningSince[NUM_DUMMIES] = {0};
 
 	// client data
 	struct CClientData
 	{
-		int m_UseCustomColor;
-		int m_ColorBody;
-		int m_ColorFeet;
+		int m_UseCustomColor = 0;
+		int m_ColorBody = 0;
+		int m_ColorFeet = 0;
 
-		char m_aName[MAX_NAME_LENGTH];
-		char m_aClan[MAX_CLAN_LENGTH];
-		int m_Country;
-		char m_aSkinName[64];
-		int m_SkinColor;
-		int m_Team;
-		int m_Emoticon;
-		float m_EmoticonStartFraction;
-		int m_EmoticonStartTick;
-		bool m_Solo;
-		bool m_Jetpack;
-		bool m_CollisionDisabled;
-		bool m_EndlessHook;
-		bool m_EndlessJump;
-		bool m_HammerHitDisabled;
-		bool m_GrenadeHitDisabled;
-		bool m_LaserHitDisabled;
-		bool m_ShotgunHitDisabled;
-		bool m_HookHitDisabled;
-		bool m_Super;
-		bool m_HasTelegunGun;
-		bool m_HasTelegunGrenade;
-		bool m_HasTelegunLaser;
-		int m_FreezeEnd;
-		bool m_DeepFrozen;
-		bool m_LiveFrozen;
+		char m_aName[MAX_NAME_LENGTH] = {0};
+		char m_aClan[MAX_CLAN_LENGTH] = {0};
+		int m_Country = 0;
+		char m_aSkinName[64] = {0};
+		int m_SkinColor = 0;
+		int m_Team = 0;
+		int m_Emoticon = 0;
+		float m_EmoticonStartFraction = 0;
+		int m_EmoticonStartTick = 0;
+		bool m_Solo = false;
+		bool m_Jetpack = false;
+		bool m_CollisionDisabled = false;
+		bool m_EndlessHook = false;
+		bool m_EndlessJump = false;
+		bool m_HammerHitDisabled = false;
+		bool m_GrenadeHitDisabled = false;
+		bool m_LaserHitDisabled = false;
+		bool m_ShotgunHitDisabled = false;
+		bool m_HookHitDisabled = false;
+		bool m_Super = false;
+		bool m_HasTelegunGun = false;
+		bool m_HasTelegunGrenade = false;
+		bool m_HasTelegunLaser = false;
+		int m_FreezeEnd = 0;
+		bool m_DeepFrozen = false;
+		bool m_LiveFrozen = false;
 
 		CCharacterCore m_Predicted;
 		CCharacterCore m_PrevPredicted;
@@ -364,20 +364,20 @@ public:
 		CTeeRenderInfo m_SkinInfo; // this is what the server reports
 		CTeeRenderInfo m_RenderInfo; // this is what we use
 
-		float m_Angle;
-		bool m_Active;
-		bool m_ChatIgnore;
-		bool m_EmoticonIgnore;
-		bool m_Friend;
-		bool m_Foe;
+		float m_Angle = 0;
+		bool m_Active = false;
+		bool m_ChatIgnore = false;
+		bool m_EmoticonIgnore = false;
+		bool m_Friend = false;
+		bool m_Foe = false;
 
-		int m_AuthLevel;
-		bool m_Afk;
-		bool m_Paused;
-		bool m_Spec;
+		int m_AuthLevel = 0;
+		bool m_Afk = false;
+		bool m_Paused = false;
+		bool m_Spec = false;
 
 		// Editor allows 256 switches for now.
-		bool m_aSwitchStates[256];
+		bool m_aSwitchStates[256] = {false};
 
 		CNetObj_Character m_Snapped;
 		CNetObj_Character m_Evolved;
@@ -389,13 +389,13 @@ public:
 		CNetObj_Character m_RenderCur;
 		CNetObj_Character m_RenderPrev;
 		vec2 m_RenderPos;
-		bool m_IsPredicted;
-		bool m_IsPredictedLocal;
-		int64_t m_aSmoothStart[2];
-		int64_t m_aSmoothLen[2];
+		bool m_IsPredicted = false;
+		bool m_IsPredictedLocal = false;
+		int64_t m_aSmoothStart[2] = {0};
+		int64_t m_aSmoothLen[2] = {0};
 		vec2 m_aPredPos[200];
-		int m_aPredTick[200];
-		bool m_SpecCharPresent;
+		int m_aPredTick[200] = {0};
+		bool m_SpecCharPresent = false;
 		vec2 m_SpecChar;
 	};
 
@@ -403,23 +403,23 @@ public:
 
 	class CClientStats
 	{
-		int m_IngameTicks;
-		int m_JoinTick;
-		bool m_Active;
+		int m_IngameTicks = 0;
+		int m_JoinTick = 0;
+		bool m_Active = false;
 
 	public:
 		CClientStats();
 
-		int m_aFragsWith[NUM_WEAPONS];
-		int m_aDeathsFrom[NUM_WEAPONS];
-		int m_Frags;
-		int m_Deaths;
-		int m_Suicides;
-		int m_BestSpree;
-		int m_CurrentSpree;
+		int m_aFragsWith[NUM_WEAPONS] = {0};
+		int m_aDeathsFrom[NUM_WEAPONS] = {0};
+		int m_Frags = 0;
+		int m_Deaths = 0;
+		int m_Suicides = 0;
+		int m_BestSpree = 0;
+		int m_CurrentSpree = 0;
 
-		int m_FlagGrabs;
-		int m_FlagCaptures;
+		int m_FlagGrabs = 0;
+		int m_FlagCaptures = 0;
 
 		void Reset();
 
@@ -490,11 +490,11 @@ public:
 
 	// DDRace
 
-	int m_aLocalIDs[NUM_DUMMIES];
+	int m_aLocalIDs[NUM_DUMMIES] = {0};
 	CNetObj_PlayerInput m_DummyInput;
 	CNetObj_PlayerInput m_HammerInput;
-	unsigned int m_DummyFire;
-	bool m_ReceivedDDNetPlayer;
+	unsigned int m_DummyFire = 0;
+	bool m_ReceivedDDNetPlayer = false;
 
 	class CTeamsCore m_Teams;
 
@@ -623,7 +623,7 @@ public:
 	};
 
 	SClientGameSkin m_GameSkin;
-	bool m_GameSkinLoaded;
+	bool m_GameSkinLoaded = false;
 
 	struct SClientParticlesSkin
 	{
@@ -639,7 +639,7 @@ public:
 	};
 
 	SClientParticlesSkin m_ParticlesSkin;
-	bool m_ParticlesSkinLoaded;
+	bool m_ParticlesSkinLoaded = false;
 
 	struct SClientEmoticonsSkin
 	{
@@ -647,7 +647,7 @@ public:
 	};
 
 	SClientEmoticonsSkin m_EmoticonsSkin;
-	bool m_EmoticonsSkinLoaded;
+	bool m_EmoticonsSkinLoaded = false;
 
 	struct SClientHudSkin
 	{
@@ -683,7 +683,7 @@ public:
 	};
 
 	SClientHudSkin m_HudSkin;
-	bool m_HudSkinLoaded;
+	bool m_HudSkinLoaded = false;
 
 	struct SClientExtrasSkin
 	{
@@ -692,7 +692,7 @@ public:
 	};
 
 	SClientExtrasSkin m_ExtrasSkin;
-	bool m_ExtrasSkinLoaded;
+	bool m_ExtrasSkinLoaded = false;
 
 	const std::vector<CSnapEntities> &SnapEntities() { return m_vSnapEntities; }
 
@@ -700,18 +700,18 @@ private:
 	std::vector<CSnapEntities> m_vSnapEntities;
 	void SnapCollectEntities();
 
-	bool m_aDDRaceMsgSent[NUM_DUMMIES];
-	int m_aShowOthers[NUM_DUMMIES];
+	bool m_aDDRaceMsgSent[NUM_DUMMIES] = {false};
+	int m_aShowOthers[NUM_DUMMIES] = {0};
 
 	void UpdatePrediction();
 	void UpdateRenderedCharacters();
 	void DetectStrongHook();
 	vec2 GetSmoothPos(int ClientID);
 
-	int m_PredictedDummyID;
-	int m_IsDummySwapping;
+	int m_PredictedDummyID = 0;
+	int m_IsDummySwapping = 0;
 	CCharOrder m_CharOrder;
-	int m_aSwitchStateTeam[NUM_DUMMIES];
+	int m_aSwitchStateTeam[NUM_DUMMIES] = {0};
 
 	enum
 	{
@@ -721,9 +721,9 @@ private:
 	CTuningParams m_aTuningList[NUM_TUNEZONES];
 	CTuningParams *TuningList() { return m_aTuningList; }
 
-	float m_LastZoom;
-	float m_LastScreenAspect;
-	float m_LastDummyConnected;
+	float m_LastZoom = 0;
+	float m_LastScreenAspect = 0;
+	float m_LastDummyConnected = 0;
 };
 
 ColorRGBA CalculateNameColor(ColorHSLA TextColorHSL);

--- a/src/game/client/lineinput.h
+++ b/src/game/client/lineinput.h
@@ -13,14 +13,14 @@ class CLineInput
 		MAX_SIZE = 512,
 		MAX_CHARS = MAX_SIZE / 2,
 	};
-	char m_aStr[MAX_SIZE];
-	int m_Len;
-	int m_CursorPos;
-	int m_NumChars;
+	char m_aStr[MAX_SIZE] = {0};
+	int m_Len = 0;
+	int m_CursorPos = 0;
+	int m_NumChars = 0;
 
-	char m_aDisplayStr[MAX_SIZE + IInput::INPUT_TEXT_SIZE + 2];
-	int m_FakeLen;
-	int m_FakeCursorPos;
+	char m_aDisplayStr[MAX_SIZE + IInput::INPUT_TEXT_SIZE + 2] = {0};
+	int m_FakeLen = 0;
+	int m_FakeCursorPos = 0;
 
 public:
 	enum ELineInputChanges

--- a/src/game/client/prediction/entities/character.cpp
+++ b/src/game/client/prediction/entities/character.cpp
@@ -1117,9 +1117,8 @@ CCharacter::CCharacter(CGameWorld *pGameWorld, int ID, CNetObj_Character *pChar,
 	m_Core.Reset();
 	m_Core.Init(&GameWorld()->m_Core, GameWorld()->Collision(), GameWorld()->Teams());
 	m_Core.m_Id = ID;
-	mem_zero(&m_Core.m_Ninja, sizeof(m_Core.m_Ninja));
-	mem_zero(&m_SavedInput, sizeof(m_SavedInput));
-	m_LatestInput = m_LatestPrevInput = m_PrevInput = m_Input = m_SavedInput;
+	m_Core.m_Ninja = CCharacterCore::SNinja();
+	m_LatestInput = m_LatestPrevInput = m_PrevInput = m_Input = m_SavedInput = CNetObj_PlayerInput();
 	m_Core.m_LeftWall = true;
 	m_ReloadTimer = 0;
 	m_NumObjectsHit = 0;
@@ -1317,8 +1316,7 @@ void CCharacter::Read(CNetObj_Character *pChar, CNetObj_DDNetCharacter *pExtende
 	// reset all input except direction and hook for non-local players (as in vanilla prediction)
 	if(!IsLocal)
 	{
-		mem_zero(&m_Input, sizeof(m_Input));
-		mem_zero(&m_SavedInput, sizeof(m_SavedInput));
+		m_Input = m_SavedInput = CNetObj_PlayerInput();
 		m_Input.m_Direction = m_SavedInput.m_Direction = m_Core.m_Direction;
 		m_Input.m_Hook = m_SavedInput.m_Hook = (m_Core.m_HookState != HOOK_IDLE);
 

--- a/src/game/client/prediction/entities/character.h
+++ b/src/game/client/prediction/entities/character.h
@@ -62,7 +62,7 @@ public:
 	void GiveNinja();
 	void RemoveNinja();
 
-	bool m_IsLocal;
+	bool m_IsLocal = false;
 
 	CTeamsCore *TeamsCore();
 	bool Freeze(int Seconds);
@@ -72,19 +72,19 @@ public:
 	int Team();
 	bool CanCollide(int ClientID);
 	bool SameTeam(int ClientID);
-	bool m_NinjaJetpack;
-	int m_FreezeTime;
-	bool m_FrozenLastTick;
-	int m_TuneZone;
+	bool m_NinjaJetpack = false;
+	int m_FreezeTime = 0;
+	bool m_FrozenLastTick = false;
+	int m_TuneZone = 0;
 	vec2 m_PrevPos;
 	vec2 m_PrevPrevPos;
-	int m_TeleCheckpoint;
+	int m_TeleCheckpoint = 0;
 
-	int m_TileIndex;
-	int m_TileFIndex;
+	int m_TileIndex = 0;
+	int m_TileFIndex = 0;
 
-	int m_MoveRestrictions;
-	bool m_LastRefillJumps;
+	int m_MoveRestrictions = 0;
+	bool m_LastRefillJumps = false;
 
 	// Setters/Getters because i don't want to modify vanilla vars access modifiers
 	int GetLastWeapon() { return m_LastWeapon; }
@@ -119,11 +119,11 @@ public:
 	void Read(CNetObj_Character *pChar, CNetObj_DDNetCharacter *pExtended, bool IsLocal);
 	void SetCoreWorld(CGameWorld *pGameWorld);
 
-	int m_LastSnapWeapon;
-	int m_LastJetpackStrength;
-	bool m_KeepHooked;
-	int m_GameTeam;
-	bool m_CanMoveInFreeze;
+	int m_LastSnapWeapon = 0;
+	int m_LastJetpackStrength = 0;
+	bool m_KeepHooked = false;
+	int m_GameTeam = 0;
+	bool m_CanMoveInFreeze = false;
 
 	bool Match(CCharacter *pChar);
 	void ResetPrediction();
@@ -138,14 +138,14 @@ public:
 
 private:
 	// weapon info
-	int m_aHitObjects[10];
-	int m_NumObjectsHit;
+	int m_aHitObjects[10] = {0};
+	int m_NumObjectsHit = 0;
 
-	int m_LastWeapon;
-	int m_QueuedWeapon;
+	int m_LastWeapon = 0;
+	int m_QueuedWeapon = 0;
 
-	int m_ReloadTimer;
-	int m_AttackTick;
+	int m_ReloadTimer = 0;
+	int m_AttackTick = 0;
 
 	// these are non-heldback inputs
 	CNetObj_PlayerInput m_LatestPrevInput;
@@ -156,7 +156,7 @@ private:
 	CNetObj_PlayerInput m_Input;
 	CNetObj_PlayerInput m_SavedInput;
 
-	int m_NumInputs;
+	int m_NumInputs = 0;
 
 	// the player core for the physics
 	CCharacterCore m_Core;
@@ -172,10 +172,10 @@ private:
 
 	CTuningParams *CharacterTuning();
 
-	int m_StrongWeakID;
+	int m_StrongWeakID = 0;
 
-	int m_LastWeaponSwitchTick;
-	int m_LastTuneZoneTick;
+	int m_LastWeaponSwitchTick = 0;
+	int m_LastTuneZoneTick = 0;
 };
 
 enum

--- a/src/game/client/prediction/entities/laser.h
+++ b/src/game/client/prediction/entities/laser.h
@@ -29,18 +29,18 @@ private:
 	vec2 m_From;
 	vec2 m_Dir;
 	vec2 m_TelePos;
-	bool m_WasTele;
-	float m_Energy;
-	int m_Bounces;
-	int m_EvalTick;
-	int m_Owner;
-	bool m_ZeroEnergyBounceInLastTick;
+	bool m_WasTele = false;
+	float m_Energy = 0;
+	int m_Bounces = 0;
+	int m_EvalTick = 0;
+	int m_Owner = 0;
+	bool m_ZeroEnergyBounceInLastTick = false;
 
 	// DDRace
 
 	vec2 m_PrevPos;
-	int m_Type;
-	int m_TuneZone;
+	int m_Type = 0;
+	int m_TuneZone = 0;
 };
 
 #endif

--- a/src/game/client/prediction/entities/pickup.h
+++ b/src/game/client/prediction/entities/pickup.h
@@ -16,14 +16,14 @@ public:
 	bool InDDNetTile() { return m_IsCoreActive; }
 
 private:
-	int m_Type;
-	int m_Subtype;
+	int m_Type = 0;
+	int m_Subtype = 0;
 
 	// DDRace
 
 	void Move();
 	vec2 m_Core;
-	bool m_IsCoreActive;
+	bool m_IsCoreActive = false;
 };
 
 #endif

--- a/src/game/client/prediction/entities/projectile.h
+++ b/src/game/client/prediction/entities/projectile.h
@@ -42,19 +42,19 @@ public:
 
 private:
 	vec2 m_Direction;
-	int m_LifeSpan;
-	int m_Owner;
-	int m_Type;
-	int m_SoundImpact;
-	float m_Force;
-	int m_StartTick;
-	bool m_Explosive;
+	int m_LifeSpan = 0;
+	int m_Owner = 0;
+	int m_Type = 0;
+	int m_SoundImpact = 0;
+	float m_Force = 0;
+	int m_StartTick = 0;
+	bool m_Explosive = false;
 
 	// DDRace
 
-	int m_Bouncing;
-	bool m_Freeze;
-	int m_TuneZone;
+	int m_Bouncing = 0;
+	bool m_Freeze = false;
+	int m_TuneZone = 0;
 };
 
 #endif

--- a/src/game/client/prediction/entity.h
+++ b/src/game/client/prediction/entity.h
@@ -25,14 +25,14 @@ class CEntity
 {
 	MACRO_ALLOC_HEAP()
 	friend class CGameWorld; // entity list handling
-	CEntity *m_pPrevTypeEntity;
-	CEntity *m_pNextTypeEntity;
+	CEntity *m_pPrevTypeEntity = nullptr;
+	CEntity *m_pNextTypeEntity = nullptr;
 
 protected:
-	class CGameWorld *m_pGameWorld;
-	bool m_MarkedForDestroy;
-	int m_ID;
-	int m_ObjType;
+	class CGameWorld *m_pGameWorld = nullptr;
+	bool m_MarkedForDestroy = false;
+	int m_ID = 0;
+	int m_ObjType = 0;
 
 public:
 	int GetID() const { return m_ID; }
@@ -56,16 +56,16 @@ public:
 	virtual void TickDefered() {}
 
 	bool GameLayerClipped(vec2 CheckPos);
-	float m_ProximityRadius;
+	float m_ProximityRadius = 0;
 	vec2 m_Pos;
-	int m_Number;
-	int m_Layer;
+	int m_Number = 0;
+	int m_Layer = 0;
 
-	int m_SnapTicks;
-	int m_DestroyTick;
-	int m_LastRenderTick;
-	CEntity *m_pParent;
-	CEntity *m_pChild;
+	int m_SnapTicks = 0;
+	int m_DestroyTick = 0;
+	int m_LastRenderTick = 0;
+	CEntity *m_pParent = nullptr;
+	CEntity *m_pChild = nullptr;
 	CEntity *NextEntity() { return m_pNextTypeEntity; }
 	void Keep()
 	{

--- a/src/game/client/prediction/gameworld.cpp
+++ b/src/game/client/prediction/gameworld.cpp
@@ -513,7 +513,7 @@ void CGameWorld::NetObjEnd(int LocalID)
 					{
 						pHookedChar->m_Pos = pHookedChar->m_Core.m_Pos = pChar->m_Core.m_HookPos;
 						pHookedChar->m_Core.m_Vel = vec2(0, 0);
-						mem_zero(&pHookedChar->m_SavedInput, sizeof(pHookedChar->m_SavedInput));
+						pHookedChar->m_SavedInput = CNetObj_PlayerInput();
 						pHookedChar->m_SavedInput.m_TargetY = -1;
 						pHookedChar->m_KeepHooked = true;
 						pHookedChar->m_MarkedForDestroy = false;

--- a/src/game/client/prediction/gameworld.h
+++ b/src/game/client/prediction/gameworld.h
@@ -46,9 +46,9 @@ public:
 	void ReleaseHooked(int ClientID);
 	std::list<CCharacter *> IntersectedCharacters(vec2 Pos0, vec2 Pos1, float Radius, CEntity *pNotThis = nullptr);
 
-	int m_GameTick;
-	int m_GameTickSpeed;
-	CCollision *m_pCollision;
+	int m_GameTick = 0;
+	int m_GameTickSpeed = 0;
+	CCollision *m_pCollision = nullptr;
 
 	// getter for server variables
 	int GameTick() { return m_GameTick; }
@@ -66,22 +66,22 @@ public:
 	// for client side prediction
 	struct
 	{
-		bool m_IsDDRace;
-		bool m_IsVanilla;
-		bool m_IsFNG;
-		bool m_InfiniteAmmo;
-		bool m_PredictTiles;
-		int m_PredictFreeze;
-		bool m_PredictWeapons;
-		bool m_PredictDDRace;
-		bool m_IsSolo;
-		bool m_UseTuneZones;
-		bool m_BugDDRaceInput;
+		bool m_IsDDRace = false;
+		bool m_IsVanilla = false;
+		bool m_IsFNG = false;
+		bool m_InfiniteAmmo = false;
+		bool m_PredictTiles = false;
+		int m_PredictFreeze = 0;
+		bool m_PredictWeapons = false;
+		bool m_PredictDDRace = false;
+		bool m_IsSolo = false;
+		bool m_UseTuneZones = false;
+		bool m_BugDDRaceInput = false;
 	} m_WorldConfig;
 
-	bool m_IsValidCopy;
-	CGameWorld *m_pParent;
-	CGameWorld *m_pChild;
+	bool m_IsValidCopy = false;
+	CGameWorld *m_pParent = nullptr;
+	CGameWorld *m_pChild = nullptr;
 
 	void OnModified();
 	void NetObjBegin();
@@ -92,7 +92,7 @@ public:
 	CEntity *FindMatch(int ObjID, int ObjType, const void *pObjData);
 	void Clear();
 
-	CTuningParams *m_pTuningList;
+	CTuningParams *m_pTuningList = nullptr;
 	CTuningParams *TuningList() { return m_pTuningList; }
 	CTuningParams *GetTuning(int i) { return &TuningList()[i]; }
 
@@ -100,9 +100,9 @@ private:
 	void RemoveEntities();
 
 	CEntity *m_pNextTraverseEntity = nullptr;
-	CEntity *m_apFirstEntityTypes[NUM_ENTTYPES];
+	CEntity *m_apFirstEntityTypes[NUM_ENTTYPES] = {nullptr};
 
-	CCharacter *m_apCharacters[MAX_CLIENTS];
+	CCharacter *m_apCharacters[MAX_CLIENTS] = {nullptr};
 };
 
 class CCharOrder

--- a/src/game/client/projectile_data.cpp
+++ b/src/game/client/projectile_data.cpp
@@ -19,7 +19,9 @@ CProjectileData ExtractProjectileInfo(const CNetObj_Projectile *pProj, CGameWorl
 	if(UseProjectileExtraInfo(pProj))
 	{
 		CNetObj_DDNetProjectile Proj;
-		mem_copy(&Proj, pProj, sizeof(Proj));
+		static_assert(sizeof(CNetObj_DDNetProjectile) == sizeof(CNetObj_Projectile),
+					  "CNetObj_DDNetProjectile must have same layout as CNetObj_Projectile");
+		mem_copy((void*)&Proj, pProj, sizeof(Proj));
 		return ExtractProjectileInfoDDNet(&Proj, pGameWorld);
 	}
 

--- a/src/game/client/projectile_data.h
+++ b/src/game/client/projectile_data.h
@@ -13,16 +13,16 @@ class CProjectileData
 public:
 	vec2 m_StartPos;
 	vec2 m_StartVel;
-	int m_Type;
-	int m_StartTick;
-	bool m_ExtraInfo;
+	int m_Type = 0;
+	int m_StartTick = 0;
+	bool m_ExtraInfo = false;
 	// The rest is only set if m_ExtraInfo is true.
-	int m_Owner;
-	bool m_Explosive;
-	int m_Bouncing;
-	bool m_Freeze;
+	int m_Owner = 0;
+	bool m_Explosive = false;
+	int m_Bouncing = 0;
+	bool m_Freeze = false;
 	// TuneZone is introduced locally
-	int m_TuneZone;
+	int m_TuneZone = 0;
 };
 
 CProjectileData ExtractProjectileInfo(const CNetObj_Projectile *pProj, class CGameWorld *pGameWorld);

--- a/src/game/client/render.h
+++ b/src/game/client/render.h
@@ -40,14 +40,14 @@ public:
 
 	CSkin::SSkinMetrics m_SkinMetrics;
 
-	bool m_CustomColoredSkin;
+	bool m_CustomColoredSkin = false;
 	ColorRGBA m_BloodColor;
 
 	ColorRGBA m_ColorBody;
 	ColorRGBA m_ColorFeet;
-	float m_Size;
-	int m_GotAirJump;
-	int m_TeeRenderFlags;
+	float m_Size = 0;
+	int m_GotAirJump = 0;
+	int m_TeeRenderFlags = 0;
 };
 
 // Tee Render Flags
@@ -73,10 +73,10 @@ typedef void (*ENVELOPE_EVAL)(int TimeOffsetMillis, int Env, ColorRGBA &Channels
 
 class CRenderTools
 {
-	class IGraphics *m_pGraphics;
-	class ITextRender *m_pTextRender;
+	class IGraphics *m_pGraphics = nullptr;
+	class ITextRender *m_pTextRender = nullptr;
 
-	int m_TeeQuadContainerIndex;
+	int m_TeeQuadContainerIndex = 0;
 
 	void GetRenderTeeBodyScale(float BaseSize, float &BodyScale);
 	void GetRenderTeeFeetScale(float BaseSize, float &FeetScaleWidth, float &FeetScaleHeight);

--- a/src/game/client/skin.h
+++ b/src/game/client/skin.h
@@ -8,7 +8,7 @@
 // do this better and nicer
 struct CSkin
 {
-	bool m_IsVanilla;
+	bool m_IsVanilla = false;
 
 	struct SSkinTextures
 	{
@@ -38,13 +38,13 @@ struct CSkin
 
 	SSkinTextures m_OriginalSkin;
 	SSkinTextures m_ColorableSkin;
-	char m_aName[24];
+	char m_aName[24] = {0};
 	ColorRGBA m_BloodColor;
 
 	template<bool IsSizeType>
 	struct SSkinMetricVariableInt
 	{
-		int m_Value;
+		int m_Value = 0;
 		operator int() { return m_Value; }
 		SSkinMetricVariableInt &operator=(int NewVal)
 		{

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -34,7 +34,8 @@ void CUIElement::SUIElementRect::Reset()
 	m_Width = -1;
 	m_Height = -1;
 	m_Text.clear();
-	mem_zero(&m_Cursor, sizeof(m_Cursor));
+	m_Cursor = CTextCursor();
+	dbg_assert(mem_is_null(&m_Cursor, sizeof(m_Cursor)), "mem not null");
 	m_TextColor = ColorRGBA(-1, -1, -1, -1);
 	m_TextOutlineColor = ColorRGBA(-1, -1, -1, -1);
 	m_QuadColor = ColorRGBA(-1, -1, -1, -1);

--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -13,7 +13,7 @@
 class CUIRect
 {
 public:
-	float x, y, w, h;
+	float x = 0, y = 0, w = 0, h = 0;
 
 	/**
 	 * Splits 2 CUIRect inside *this* CUIRect horizontally. You can pass null pointers.
@@ -107,17 +107,17 @@ public:
 
 struct SUIAnimator
 {
-	bool m_Active;
-	bool m_ScaleLabel;
-	bool m_RepositionLabel;
+	bool m_Active = false;
+	bool m_ScaleLabel = false;
+	bool m_RepositionLabel = false;
 
-	std::chrono::nanoseconds m_Time;
-	float m_Value;
+	std::chrono::nanoseconds m_Time = std::chrono::nanoseconds::zero();
+	float m_Value = 0;
 
-	float m_XOffset;
-	float m_YOffset;
-	float m_WOffset;
-	float m_HOffset;
+	float m_XOffset = 0;
+	float m_YOffset = 0;
+	float m_WOffset = 0;
+	float m_HOffset = 0;
 };
 
 class CUI;
@@ -132,13 +132,13 @@ public:
 	struct SUIElementRect
 	{
 	public:
-		int m_UIRectQuadContainer;
-		int m_UITextContainer;
+		int m_UIRectQuadContainer = 0;
+		int m_UITextContainer = 0;
 
-		float m_X;
-		float m_Y;
-		float m_Width;
-		float m_Height;
+		float m_X = 0;
+		float m_Y = 0;
+		float m_Width = 0;
+		float m_Height = 0;
 
 		std::string m_Text;
 
@@ -158,7 +158,7 @@ protected:
 	std::vector<SUIElementRect> m_vUIRects;
 
 	// used for marquees or other user implemented things
-	int64_t m_ElementTime;
+	int64_t m_ElementTime = 0;
 
 public:
 	CUIElement() = default;
@@ -193,29 +193,29 @@ class CButtonContainer
 
 class CUI
 {
-	bool m_Enabled;
+	bool m_Enabled = false;
 
-	const void *m_pHotItem;
-	const void *m_pActiveItem;
-	const void *m_pLastActiveItem;
-	const void *m_pBecomingHotItem;
-	const void *m_pActiveTooltipItem;
+	const void *m_pHotItem = nullptr;
+	const void *m_pActiveItem = nullptr;
+	const void *m_pLastActiveItem = nullptr;
+	const void *m_pBecomingHotItem = nullptr;
+	const void *m_pActiveTooltipItem = nullptr;
 	bool m_ActiveItemValid = false;
 
-	float m_MouseX, m_MouseY; // in gui space
-	float m_MouseDeltaX, m_MouseDeltaY; // in gui space
-	float m_MouseWorldX, m_MouseWorldY; // in world space
-	unsigned m_MouseButtons;
-	unsigned m_LastMouseButtons;
+	float m_MouseX = 0, m_MouseY = 0; // in gui space
+	float m_MouseDeltaX = 0, m_MouseDeltaY = 0; // in gui space
+	float m_MouseWorldX = 0, m_MouseWorldY = 0; // in world space
+	unsigned m_MouseButtons = 0;
+	unsigned m_LastMouseButtons = 0;
 
 	CUIRect m_Screen;
 
 	std::vector<CUIRect> m_vClips;
 	void UpdateClipping();
 
-	class IInput *m_pInput;
-	class IGraphics *m_pGraphics;
-	class ITextRender *m_pTextRender;
+	class IInput *m_pInput = nullptr;
+	class IGraphics *m_pGraphics = nullptr;
+	class ITextRender *m_pTextRender = nullptr;
 
 	std::vector<CUIElement *> m_vpOwnUIElements; // ui elements maintained by CUI class
 	std::vector<CUIElement *> m_vpUIElements;

--- a/src/game/client/ui_ex.h
+++ b/src/game/client/ui_ex.h
@@ -30,7 +30,7 @@ public:
 class CLogarithmicScrollbarScale : public IScrollbarScale
 {
 private:
-	int m_MinAdjustment;
+	int m_MinAdjustment = 0;
 
 public:
 	CLogarithmicScrollbarScale(int MinAdjustment)
@@ -68,15 +68,15 @@ struct SUIExEditBoxProperties
 
 class CUIEx
 {
-	CUI *m_pUI;
-	IInput *m_pInput;
-	ITextRender *m_pTextRender;
-	IKernel *m_pKernel;
-	IGraphics *m_pGraphics;
-	CRenderTools *m_pRenderTools;
+	CUI *m_pUI = nullptr;
+	IInput *m_pInput = nullptr;
+	ITextRender *m_pTextRender = nullptr;
+	IKernel *m_pKernel = nullptr;
+	IGraphics *m_pGraphics = nullptr;
+	CRenderTools *m_pRenderTools = nullptr;
 
-	IInput::CEvent *m_pInputEventsArray;
-	int *m_pInputEventCount;
+	IInput::CEvent *m_pInputEventsArray = nullptr;
+	int *m_pInputEventCount = nullptr;
 
 	bool m_MouseIsPress = false;
 	bool m_HasSelection = false;
@@ -85,7 +85,7 @@ class CUIEx
 	int m_MousePressY = 0;
 	int m_MouseCurX = 0;
 	int m_MouseCurY = 0;
-	bool m_MouseSlow;
+	bool m_MouseSlow = false;
 	int m_CurSelStart = 0;
 	int m_CurSelEnd = 0;
 	const void *m_pSelItem = nullptr;

--- a/src/game/collision.cpp
+++ b/src/game/collision.cpp
@@ -86,7 +86,7 @@ void CCollision::Init(class CLayers *pLayers)
 			m_pSwitch = static_cast<CSwitchTile *>(m_pLayers->Map()->GetData(m_pLayers->SwitchLayer()->m_Switch));
 
 		m_pDoor = new CDoorTile[m_Width * m_Height];
-		mem_zero(m_pDoor, (size_t)m_Width * m_Height * sizeof(CDoorTile));
+		// dbg_assert(mem_is_null(m_pDoor, sizeof(CDoorTile)*m_Width*m_Height), "mem not null");
 	}
 	else
 	{

--- a/src/game/collision.h
+++ b/src/game/collision.h
@@ -23,10 +23,10 @@ struct CAntibotMapData;
 
 class CCollision
 {
-	class CTile *m_pTiles;
-	int m_Width;
-	int m_Height;
-	class CLayers *m_pLayers;
+	class CTile *m_pTiles = nullptr;
+	int m_Width = 0;
+	int m_Height = 0;
+	class CLayers *m_pLayers = nullptr;
 
 public:
 	CCollision();
@@ -114,15 +114,15 @@ public:
 	class CSwitchTile *SwitchLayer() { return m_pSwitch; }
 	class CTuneTile *TuneLayer() { return m_pTune; }
 	class CLayers *Layers() { return m_pLayers; }
-	int m_HighestSwitchNumber;
+	int m_HighestSwitchNumber = 0;
 
 private:
-	class CTeleTile *m_pTele;
-	class CSpeedupTile *m_pSpeedup;
-	class CTile *m_pFront;
-	class CSwitchTile *m_pSwitch;
-	class CTuneTile *m_pTune;
-	class CDoorTile *m_pDoor;
+	class CTeleTile *m_pTele = nullptr;
+	class CSpeedupTile *m_pSpeedup = nullptr;
+	class CTile *m_pFront = nullptr;
+	class CSwitchTile *m_pSwitch = nullptr;
+	class CTuneTile *m_pTune = nullptr;
+	class CDoorTile *m_pDoor = nullptr;
 };
 
 void ThroughOffset(vec2 Pos0, vec2 Pos1, int *pOffsetX, int *pOffsetY);

--- a/src/game/editor/auto_map.h
+++ b/src/game/editor/auto_map.h
@@ -7,16 +7,16 @@ class CAutoMapper
 {
 	struct CIndexInfo
 	{
-		int m_ID;
-		int m_Flag;
-		bool m_TestFlag;
+		int m_ID = 0;
+		int m_Flag = 0;
+		bool m_TestFlag = false;
 	};
 
 	struct CPosRule
 	{
-		int m_X;
-		int m_Y;
-		int m_Value;
+		int m_X = 0;
+		int m_Y = 0;
+		int m_Value = 0;
 		std::vector<CIndexInfo> m_vIndexList;
 
 		enum
@@ -29,29 +29,29 @@ class CAutoMapper
 
 	struct CIndexRule
 	{
-		int m_ID;
+		int m_ID = 0;
 		std::vector<CPosRule> m_vRules;
-		int m_Flag;
-		float m_RandomProbability;
-		bool m_DefaultRule;
-		bool m_SkipEmpty;
-		bool m_SkipFull;
+		int m_Flag = 0;
+		float m_RandomProbability = 0;
+		bool m_DefaultRule = false;
+		bool m_SkipEmpty = false;
+		bool m_SkipFull = false;
 	};
 
 	struct CRun
 	{
 		std::vector<CIndexRule> m_vIndexRules;
-		bool m_AutomapCopy;
+		bool m_AutomapCopy = false;
 	};
 
 	struct CConfiguration
 	{
 		std::vector<CRun> m_vRuns;
-		char m_aName[128];
-		int m_StartX;
-		int m_StartY;
-		int m_EndX;
-		int m_EndY;
+		char m_aName[128] = {0};
+		int m_StartX = 0;
+		int m_StartY = 0;
+		int m_EndX = 0;
+		int m_EndY = 0;
 	};
 
 public:
@@ -68,8 +68,8 @@ public:
 
 private:
 	std::vector<CConfiguration> m_vConfigs;
-	class CEditor *m_pEditor;
-	bool m_FileLoaded;
+	class CEditor *m_pEditor = nullptr;
+	bool m_FileLoaded = false;
 };
 
 #endif

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -513,28 +513,32 @@ protected:
 			for(int y = 0; y < m_Height; ++y)
 			{
 				mem_move(&pTiles[y * m_Width], &pTiles[y * m_Width + ShiftBy], (m_Width - ShiftBy) * sizeof(T));
-				mem_zero(&pTiles[y * m_Width + (m_Width - ShiftBy)], ShiftBy * sizeof(T));
+				new(&pTiles[y * m_Width + (m_Width - ShiftBy)]) T[ShiftBy]{};
+				dbg_assert(mem_is_null(&pTiles[y * m_Width + (m_Width - ShiftBy)], ShiftBy*sizeof(T)), "mem not null");
 			}
 			break;
 		case DIRECTION_RIGHT:
 			for(int y = 0; y < m_Height; ++y)
 			{
 				mem_move(&pTiles[y * m_Width + ShiftBy], &pTiles[y * m_Width], (m_Width - ShiftBy) * sizeof(T));
-				mem_zero(&pTiles[y * m_Width], ShiftBy * sizeof(T));
+				new(&pTiles[y * m_Width]) T[ShiftBy]{};
+				dbg_assert(mem_is_null(&pTiles[y * m_Width], ShiftBy*sizeof(T)), "mem not null");
 			}
 			break;
 		case DIRECTION_UP:
 			for(int y = 0; y < m_Height - ShiftBy; ++y)
 			{
 				mem_copy(&pTiles[y * m_Width], &pTiles[(y + ShiftBy) * m_Width], m_Width * sizeof(T));
-				mem_zero(&pTiles[(y + ShiftBy) * m_Width], m_Width * sizeof(T));
+				new(&pTiles[(y + ShiftBy) * m_Width]) T[m_Width]{};
+				dbg_assert(mem_is_null(&pTiles[(y + ShiftBy) * m_Width], m_Width * sizeof(T)), "mem not null");
 			}
 			break;
 		case DIRECTION_DOWN:
 			for(int y = m_Height - 1; y >= ShiftBy; --y)
 			{
 				mem_copy(&pTiles[y * m_Width], &pTiles[(y - ShiftBy) * m_Width], m_Width * sizeof(T));
-				mem_zero(&pTiles[(y - ShiftBy) * m_Width], m_Width * sizeof(T));
+				new(&pTiles[(y - ShiftBy) * m_Width]) T[m_Width]{};
+				dbg_assert(mem_is_null(&pTiles[(y - ShiftBy) * m_Width], m_Width * sizeof(T)), "mem not null");
 			}
 		}
 	}

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -40,11 +40,11 @@ enum
 class CEnvelope
 {
 public:
-	int m_Channels;
+	int m_Channels = 0;
 	std::vector<CEnvPoint> m_vPoints;
-	char m_aName[32];
-	float m_Bottom, m_Top;
-	bool m_Synchronized;
+	char m_aName[32] = {0};
+	float m_Bottom = 0, m_Top = 0;
+	bool m_Synchronized = false;
 
 	CEnvelope(int Chan)
 	{
@@ -113,7 +113,7 @@ class CLayerGroup;
 class CLayer
 {
 public:
-	class CEditor *m_pEditor;
+	class CEditor *m_pEditor = nullptr;
 	class IGraphics *Graphics();
 	class ITextRender *TextRender();
 
@@ -154,39 +154,39 @@ public:
 		*pHeight = 0;
 	}
 
-	char m_aName[12];
-	int m_Type;
-	int m_Flags;
+	char m_aName[12] = {0};
+	int m_Type = 0;
+	int m_Flags = 0;
 
-	bool m_Readonly;
-	bool m_Visible;
+	bool m_Readonly = false;
+	bool m_Visible = false;
 
-	int m_BrushRefCount;
+	int m_BrushRefCount = 0;
 };
 
 class CLayerGroup
 {
 public:
-	class CEditorMap *m_pMap;
+	class CEditorMap *m_pMap = nullptr;
 
 	std::vector<CLayer *> m_vpLayers;
 
-	int m_OffsetX;
-	int m_OffsetY;
+	int m_OffsetX = 0;
+	int m_OffsetY = 0;
 
-	int m_ParallaxX;
-	int m_ParallaxY;
+	int m_ParallaxX = 0;
+	int m_ParallaxY = 0;
 
-	int m_UseClipping;
-	int m_ClipX;
-	int m_ClipY;
-	int m_ClipW;
-	int m_ClipH;
+	int m_UseClipping = 0;
+	int m_ClipX = 0;
+	int m_ClipY = 0;
+	int m_ClipW = 0;
+	int m_ClipH = 0;
 
-	char m_aName[12];
-	bool m_GameGroup;
-	bool m_Visible;
-	bool m_Collapse;
+	char m_aName[12] = {0};
+	bool m_GameGroup = false;
+	bool m_Visible = false;
+	bool m_Collapse = false;
 
 	CLayerGroup();
 	~CLayerGroup();
@@ -270,7 +270,7 @@ public:
 class CEditorImage : public CImageInfo
 {
 public:
-	CEditor *m_pEditor;
+	CEditor *m_pEditor = nullptr;
 
 	CEditorImage(CEditor *pEditor) :
 		m_AutoMapper(pEditor)
@@ -289,16 +289,16 @@ public:
 	void AnalyseTileFlags();
 
 	IGraphics::CTextureHandle m_Texture;
-	int m_External;
-	char m_aName[128];
-	unsigned char m_aTileFlags[256];
+	int m_External = 0;
+	char m_aName[128] = {0};
+	unsigned char m_aTileFlags[256] = {0};
 	class CAutoMapper m_AutoMapper;
 };
 
 class CEditorSound
 {
 public:
-	CEditor *m_pEditor;
+	CEditor *m_pEditor = nullptr;
 
 	CEditorSound(CEditor *pEditor)
 	{
@@ -312,11 +312,11 @@ public:
 
 	~CEditorSound();
 
-	int m_SoundID;
-	char m_aName[128];
+	int m_SoundID = 0;
+	char m_aName[128] = {0};
 
-	void *m_pData;
-	unsigned m_DataSize;
+	void *m_pData = nullptr;
+	unsigned m_DataSize = 0;
 };
 
 class CEditorMap
@@ -325,8 +325,8 @@ class CEditorMap
 	void MakeGameLayer(CLayer *pLayer);
 
 public:
-	CEditor *m_pEditor;
-	bool m_Modified;
+	CEditor *m_pEditor = nullptr;
+	bool m_Modified = false;
 
 	CEditorMap()
 	{
@@ -346,15 +346,15 @@ public:
 	class CMapInfo
 	{
 	public:
-		char m_aAuthorTmp[32];
-		char m_aVersionTmp[16];
-		char m_aCreditsTmp[128];
-		char m_aLicenseTmp[32];
+		char m_aAuthorTmp[32] = {0};
+		char m_aVersionTmp[16] = {0};
+		char m_aCreditsTmp[128] = {0};
+		char m_aLicenseTmp[32] = {0};
 
-		char m_aAuthor[32];
-		char m_aVersion[16];
-		char m_aCredits[128];
-		char m_aLicense[32];
+		char m_aAuthor[32] = {0};
+		char m_aVersion[16] = {0};
+		char m_aCredits[128] = {0};
+		char m_aLicense[32] = {0};
 
 		void Reset()
 		{
@@ -373,12 +373,12 @@ public:
 
 	struct CSetting
 	{
-		char m_aCommand[256];
+		char m_aCommand[256] = {0};
 	};
 	std::vector<CSetting> m_vSettings;
 
-	class CLayerGame *m_pGameLayer;
-	CLayerGroup *m_pGameGroup;
+	class CLayerGame *m_pGameLayer = nullptr;
+	CLayerGroup *m_pGameGroup = nullptr;
 
 	CEnvelope *NewEnvelope(int Channels)
 	{
@@ -451,11 +451,11 @@ public:
 
 	// DDRace
 
-	class CLayerTele *m_pTeleLayer;
-	class CLayerSpeedup *m_pSpeedupLayer;
-	class CLayerFront *m_pFrontLayer;
-	class CLayerSwitch *m_pSwitchLayer;
-	class CLayerTune *m_pTuneLayer;
+	class CLayerTele *m_pTeleLayer = nullptr;
+	class CLayerSpeedup *m_pSpeedupLayer = nullptr;
+	class CLayerFront *m_pFrontLayer = nullptr;
+	class CLayerSwitch *m_pSwitchLayer = nullptr;
+	class CLayerTune *m_pTuneLayer = nullptr;
 	void MakeTeleLayer(CLayer *pLayer);
 	void MakeSpeedupLayer(CLayer *pLayer);
 	void MakeFrontLayer(CLayer *pLayer);
@@ -465,11 +465,11 @@ public:
 
 struct CProperty
 {
-	const char *m_pName;
-	int m_Value;
-	int m_Type;
-	int m_Min;
-	int m_Max;
+	const char *m_pName = nullptr;
+	int m_Value = 0;
+	int m_Type = 0;
+	int m_Min = 0;
+	int m_Max = 0;
 };
 
 enum
@@ -612,26 +612,26 @@ public:
 	void FlagModified(int x, int y, int w, int h);
 
 	IGraphics::CTextureHandle m_Texture;
-	int m_Game;
-	int m_Image;
-	int m_Width;
-	int m_Height;
+	int m_Game = 0;
+	int m_Image = 0;
+	int m_Width = 0;
+	int m_Height = 0;
 	CColor m_Color;
-	int m_ColorEnv;
-	int m_ColorEnvOffset;
-	CTile *m_pTiles;
+	int m_ColorEnv = 0;
+	int m_ColorEnvOffset = 0;
+	CTile *m_pTiles = nullptr;
 
 	// DDRace
 
-	int m_AutoMapperConfig;
-	int m_Seed;
-	bool m_AutoAutoMap;
-	int m_Tele;
-	int m_Speedup;
-	int m_Front;
-	int m_Switch;
-	int m_Tune;
-	char m_aFileName[IO_MAX_PATH_LENGTH];
+	int m_AutoMapperConfig = 0;
+	int m_Seed = 0;
+	bool m_AutoAutoMap = false;
+	int m_Tele = 0;
+	int m_Speedup = 0;
+	int m_Front = 0;
+	int m_Switch = 0;
+	int m_Tune = 0;
+	char m_aFileName[IO_MAX_PATH_LENGTH] = {0};
 };
 
 class CLayerQuads : public CLayer
@@ -657,7 +657,7 @@ public:
 
 	void GetSize(float *pWidth, float *pHeight) override;
 
-	int m_Image;
+	int m_Image = 0;
 	std::vector<CQuad> m_vQuads;
 };
 
@@ -675,14 +675,14 @@ public:
 
 class CEditor : public IEditor
 {
-	class IInput *m_pInput;
-	class IClient *m_pClient;
-	class CConfig *m_pConfig;
-	class IConsole *m_pConsole;
-	class IGraphics *m_pGraphics;
-	class ITextRender *m_pTextRender;
-	class ISound *m_pSound;
-	class IStorage *m_pStorage;
+	class IInput *m_pInput = nullptr;
+	class IClient *m_pClient = nullptr;
+	class CConfig *m_pConfig = nullptr;
+	class IConsole *m_pConsole = nullptr;
+	class IGraphics *m_pGraphics = nullptr;
+	class ITextRender *m_pTextRender = nullptr;
+	class ISound *m_pSound = nullptr;
+	class IStorage *m_pStorage = nullptr;
 	CRenderTools m_RenderTools;
 	CUI m_UI;
 	CUIEx m_UIEx;
@@ -820,7 +820,7 @@ public:
 	void UpdateMentions() override { m_Mentions++; }
 	void ResetMentions() override { m_Mentions = 0; }
 
-	CLayerGroup *m_apSavedBrushes[10];
+	CLayerGroup *m_apSavedBrushes[10] = {nullptr};
 
 	void FilelistPopulate(int StorageType);
 	void InvokeFileDialog(int StorageType, int FileType, const char *pTitle, const char *pButtonText,
@@ -849,19 +849,19 @@ public:
 	float ScaleFontSize(char *pText, int TextSize, float FontSize, int Width);
 	int DoProperties(CUIRect *pToolbox, CProperty *pProps, int *pIDs, int *pNewVal, ColorRGBA Color = ColorRGBA(1, 1, 1, 0.5f));
 
-	int m_Mode;
-	int m_Dialog;
-	int m_EditBoxActive;
-	const char *m_pTooltip;
+	int m_Mode = 0;
+	int m_Dialog = 0;
+	int m_EditBoxActive = 0;
+	const char *m_pTooltip = nullptr;
 
-	bool m_GridActive;
-	int m_GridFactor;
+	bool m_GridActive = false;
+	int m_GridFactor = 0;
 
-	bool m_BrushColorEnabled;
+	bool m_BrushColorEnabled = false;
 
-	char m_aFileName[IO_MAX_PATH_LENGTH];
-	char m_aFileSaveName[IO_MAX_PATH_LENGTH];
-	bool m_ValidSaveFilename;
+	char m_aFileName[IO_MAX_PATH_LENGTH] = {0};
+	char m_aFileSaveName[IO_MAX_PATH_LENGTH] = {0};
+	bool m_ValidSaveFilename = false;
 
 	enum
 	{
@@ -877,16 +877,16 @@ public:
 		POPEVENT_PLACE_BORDER_TILES
 	};
 
-	int m_PopupEventType;
-	int m_PopupEventActivated;
-	int m_PopupEventWasActivated;
-	bool m_MouseInsidePopup;
-	bool m_LargeLayerWasWarned;
-	bool m_PreventUnusedTilesWasWarned;
-	int m_AllowPlaceUnusedTiles;
-	bool m_BrushDrawDestructive;
+	int m_PopupEventType = 0;
+	int m_PopupEventActivated = 0;
+	int m_PopupEventWasActivated = 0;
+	bool m_MouseInsidePopup = false;
+	bool m_LargeLayerWasWarned = false;
+	bool m_PreventUnusedTilesWasWarned = false;
+	int m_AllowPlaceUnusedTiles = 0;
+	bool m_BrushDrawDestructive = false;
 
-	int m_Mentions;
+	int m_Mentions = 0;
 
 	enum
 	{
@@ -895,93 +895,93 @@ public:
 		FILETYPE_SOUND,
 	};
 
-	int m_FileDialogStorageType;
-	const char *m_pFileDialogTitle;
-	const char *m_pFileDialogButtonText;
+	int m_FileDialogStorageType = 0;
+	const char *m_pFileDialogTitle = nullptr;
+	const char *m_pFileDialogButtonText = nullptr;
 	void (*m_pfnFileDialogFunc)(const char *pFileName, int StorageType, void *pUser);
-	void *m_pFileDialogUser;
-	char m_aFileDialogFileName[IO_MAX_PATH_LENGTH];
-	char m_aFileDialogCurrentFolder[IO_MAX_PATH_LENGTH];
-	char m_aFileDialogCurrentLink[IO_MAX_PATH_LENGTH];
-	char m_aFileDialogSearchText[64];
-	char m_aFileDialogPrevSearchText[64];
-	char *m_pFileDialogPath;
-	bool m_FileDialogActivate;
-	int m_FileDialogFileType;
-	float m_FileDialogScrollValue;
-	int m_FilesSelectedIndex;
-	char m_aFileDialogNewFolderName[64];
-	char m_aFileDialogErrString[64];
+	void *m_pFileDialogUser = nullptr;
+	char m_aFileDialogFileName[IO_MAX_PATH_LENGTH] = {0};
+	char m_aFileDialogCurrentFolder[IO_MAX_PATH_LENGTH] = {0};
+	char m_aFileDialogCurrentLink[IO_MAX_PATH_LENGTH] = {0};
+	char m_aFileDialogSearchText[64] = {0};
+	char m_aFileDialogPrevSearchText[64] = {0};
+	char *m_pFileDialogPath = nullptr;
+	bool m_FileDialogActivate = false;
+	int m_FileDialogFileType = 0;
+	float m_FileDialogScrollValue = 0;
+	int m_FilesSelectedIndex = 0;
+	char m_aFileDialogNewFolderName[64] = {0};
+	char m_aFileDialogErrString[64] = {0};
 	IGraphics::CTextureHandle m_FilePreviewImage;
-	bool m_PreviewImageIsLoaded;
+	bool m_PreviewImageIsLoaded = false;
 	CImageInfo m_FilePreviewImageInfo;
-	bool m_FileDialogOpening;
+	bool m_FileDialogOpening = false;
 
 	struct CFilelistItem
 	{
-		char m_aFilename[IO_MAX_PATH_LENGTH];
-		char m_aName[128];
-		bool m_IsDir;
-		bool m_IsLink;
-		int m_StorageType;
-		bool m_IsVisible;
+		char m_aFilename[IO_MAX_PATH_LENGTH] = {0};
+		char m_aName[128] = {0};
+		bool m_IsDir = false;
+		bool m_IsLink = false;
+		int m_StorageType = 0;
+		bool m_IsVisible = false;
 
 		bool operator<(const CFilelistItem &Other) const { return !str_comp(m_aFilename, "..") ? true : !str_comp(Other.m_aFilename, "..") ? false : m_IsDir && !Other.m_IsDir ? true : !m_IsDir && Other.m_IsDir ? false : str_comp_nocase(m_aFilename, Other.m_aFilename) < 0; }
 	};
 	std::vector<CFilelistItem> m_vFileList;
-	int m_FilesStartAt;
-	int m_FilesCur;
-	int m_FilesStopAt;
+	int m_FilesStartAt = 0;
+	int m_FilesCur = 0;
+	int m_FilesStopAt = 0;
 
 	std::vector<std::string> m_vSelectEntitiesFiles;
 	std::string m_SelectEntitiesImage;
 
-	float m_WorldOffsetX;
-	float m_WorldOffsetY;
-	float m_EditorOffsetX;
-	float m_EditorOffsetY;
-	float m_WorldZoom;
-	int m_ZoomLevel;
-	bool m_LockMouse;
-	bool m_ShowMousePointer;
-	bool m_GuiActive;
-	bool m_ProofBorders;
+	float m_WorldOffsetX = 0;
+	float m_WorldOffsetY = 0;
+	float m_EditorOffsetX = 0;
+	float m_EditorOffsetY = 0;
+	float m_WorldZoom = 0;
+	int m_ZoomLevel = 0;
+	bool m_LockMouse = false;
+	bool m_ShowMousePointer = false;
+	bool m_GuiActive = false;
+	bool m_ProofBorders = false;
 	float m_MouseX = 0.0f;
 	float m_MouseY = 0.0f;
 	float m_MouseWorldX = 0.0f;
 	float m_MouseWorldY = 0.0f;
-	float m_MouseDeltaX;
-	float m_MouseDeltaY;
-	float m_MouseDeltaWx;
-	float m_MouseDeltaWy;
+	float m_MouseDeltaX = 0;
+	float m_MouseDeltaY = 0;
+	float m_MouseDeltaWx = 0;
+	float m_MouseDeltaWy = 0;
 
-	bool m_ShowTileInfo;
-	bool m_ShowDetail;
-	bool m_Animate;
-	int64_t m_AnimateStart;
-	float m_AnimateTime;
-	float m_AnimateSpeed;
+	bool m_ShowTileInfo = false;
+	bool m_ShowDetail = false;
+	bool m_Animate = false;
+	int64_t m_AnimateStart = 0;
+	float m_AnimateTime = 0;
+	float m_AnimateSpeed = 0;
 
-	int m_ShowEnvelopeEditor;
-	int m_ShowEnvelopePreview; //Values: 0-Off|1-Selected Envelope|2-All
-	bool m_ShowServerSettingsEditor;
-	bool m_ShowPicker;
+	int m_ShowEnvelopeEditor = 0;
+	int m_ShowEnvelopePreview = 0; //Values: 0-Off|1-Selected Envelope|2-All
+	bool m_ShowServerSettingsEditor = false;
+	bool m_ShowPicker = false;
 
 	std::vector<int> m_vSelectedLayers;
 	std::vector<int> m_vSelectedQuads;
-	int m_SelectedQuadPoint;
-	int m_SelectedQuadIndex;
-	int m_SelectedGroup;
-	int m_SelectedPoints;
-	int m_SelectedEnvelope;
-	int m_SelectedEnvelopePoint;
-	int m_SelectedQuadEnvelope;
-	int m_SelectedImage;
-	int m_SelectedSound;
-	int m_SelectedSource;
+	int m_SelectedQuadPoint = 0;
+	int m_SelectedQuadIndex = 0;
+	int m_SelectedGroup = 0;
+	int m_SelectedPoints = 0;
+	int m_SelectedEnvelope = 0;
+	int m_SelectedEnvelopePoint = 0;
+	int m_SelectedQuadEnvelope = 0;
+	int m_SelectedImage = 0;
+	int m_SelectedSound = 0;
+	int m_SelectedSource = 0;
 
-	bool m_QuadKnifeActive;
-	int m_QuadKnifeCount;
+	bool m_QuadKnifeActive = false;
+	int m_QuadKnifeCount = 0;
 	vec2 m_aQuadKnifePoints[4];
 
 	IGraphics::CTextureHandle m_CheckerTexture;
@@ -997,12 +997,12 @@ public:
 	static const void *ms_pUiGotContext;
 
 	CEditorMap m_Map;
-	int m_ShiftBy;
+	int m_ShiftBy = 0;
 
 	static void EnvelopeEval(int TimeOffsetMillis, int Env, ColorRGBA &Channels, void *pUser);
 
-	float m_CommandBox;
-	char m_aSettingsCommand[256];
+	float m_CommandBox = 0;
+	char m_aSettingsCommand[256] = {0};
 
 	void PlaceBorderTiles();
 	int DoButton_Editor_Common(const void *pID, const char *pText, int Checked, const CUIRect *pRect, int Flags, const char *pToolTip);
@@ -1209,16 +1209,16 @@ public:
 	static int PopupSpeedup(CEditor *pEditor, CUIRect View, void *pContext);
 	static int PopupSwitch(CEditor *pEditor, CUIRect View, void *pContext);
 	static int PopupTune(CEditor *pEditor, CUIRect View, void *pContext);
-	unsigned char m_TeleNumber;
+	unsigned char m_TeleNumber = 0;
 
-	unsigned char m_TuningNum;
+	unsigned char m_TuningNum = 0;
 
-	unsigned char m_SpeedupForce;
-	unsigned char m_SpeedupMaxSpeed;
-	short m_SpeedupAngle;
+	unsigned char m_SpeedupForce = 0;
+	unsigned char m_SpeedupMaxSpeed = 0;
+	short m_SpeedupAngle = 0;
 
-	unsigned char m_SwitchNum;
-	unsigned char m_SwitchDelay;
+	unsigned char m_SwitchNum = 0;
+	unsigned char m_SwitchDelay = 0;
 };
 
 // make sure to inline this function
@@ -1233,8 +1233,8 @@ public:
 	CLayerTele(int w, int h);
 	~CLayerTele();
 
-	CTeleTile *m_pTeleTile;
-	unsigned char m_TeleNum;
+	CTeleTile *m_pTeleTile = nullptr;
+	unsigned char m_TeleNum = 0;
 
 	void Resize(int NewW, int NewH) override;
 	void Shift(int Direction) override;
@@ -1253,10 +1253,10 @@ public:
 	CLayerSpeedup(int w, int h);
 	~CLayerSpeedup();
 
-	CSpeedupTile *m_pSpeedupTile;
-	int m_SpeedupForce;
-	int m_SpeedupMaxSpeed;
-	int m_SpeedupAngle;
+	CSpeedupTile *m_pSpeedupTile = nullptr;
+	int m_SpeedupForce = 0;
+	int m_SpeedupMaxSpeed = 0;
+	int m_SpeedupAngle = 0;
 
 	void Resize(int NewW, int NewH) override;
 	void Shift(int Direction) override;
@@ -1283,9 +1283,9 @@ public:
 	CLayerSwitch(int w, int h);
 	~CLayerSwitch();
 
-	CSwitchTile *m_pSwitchTile;
-	unsigned char m_SwitchNumber;
-	unsigned char m_SwitchDelay;
+	CSwitchTile *m_pSwitchTile = nullptr;
+	unsigned char m_SwitchNumber = 0;
+	unsigned char m_SwitchDelay = 0;
 
 	void Resize(int NewW, int NewH) override;
 	void Shift(int Direction) override;
@@ -1304,8 +1304,8 @@ public:
 	CLayerTune(int w, int h);
 	~CLayerTune();
 
-	CTuneTile *m_pTuneTile;
-	unsigned char m_TuningNumber;
+	CTuneTile *m_pTuneTile = nullptr;
+	unsigned char m_TuningNumber = 0;
 
 	void Resize(int NewW, int NewH) override;
 	void Shift(int Direction) override;
@@ -1335,7 +1335,7 @@ public:
 	void ModifyEnvelopeIndex(INDEX_MODIFY_FUNC pfnFunc) override;
 	void ModifySoundIndex(INDEX_MODIFY_FUNC pfnFunc) override;
 
-	int m_Sound;
+	int m_Sound = 0;
 	std::vector<CSoundSource> m_vSources;
 };
 

--- a/src/game/editor/io.cpp
+++ b/src/game/editor/io.cpp
@@ -22,13 +22,13 @@ static int MakeVersion(int i, const T &v)
 struct CSoundSource_DEPRECATED
 {
 	CPoint m_Position;
-	int m_Loop;
-	int m_TimeDelay; // in s
-	int m_FalloffDistance;
-	int m_PosEnv;
-	int m_PosEnvOffset;
-	int m_SoundEnv;
-	int m_SoundEnvOffset;
+	int m_Loop = 0;
+	int m_TimeDelay = 0; // in s
+	int m_FalloffDistance = 0;
+	int m_PosEnv = 0;
+	int m_PosEnvOffset = 0;
+	int m_SoundEnv = 0;
+	int m_SoundEnvOffset = 0;
 };
 
 int CEditor::Save(const char *pFilename)

--- a/src/game/editor/io.cpp
+++ b/src/game/editor/io.cpp
@@ -232,7 +232,8 @@ int CEditorMap::Save(class IStorage *pStorage, const char *pFileName)
 				if(Item.m_Flags && !(pLayerTiles->m_Game))
 				{
 					CTile *pEmptyTiles = (CTile *)calloc((size_t)pLayerTiles->m_Width * pLayerTiles->m_Height, sizeof(CTile));
-					mem_zero(pEmptyTiles, (size_t)pLayerTiles->m_Width * pLayerTiles->m_Height * sizeof(CTile));
+					new(pEmptyTiles) CTile[(size_t)pLayerTiles->m_Width * pLayerTiles->m_Height];
+					dbg_assert(mem_is_null(pEmptyTiles, sizeof(*pEmptyTiles)), "mem not null");
 					Item.m_Data = df.AddData((size_t)pLayerTiles->m_Width * pLayerTiles->m_Height * sizeof(CTile), pEmptyTiles);
 					free(pEmptyTiles);
 

--- a/src/game/editor/layer_tiles.cpp
+++ b/src/game/editor/layer_tiles.cpp
@@ -37,7 +37,7 @@ CLayerTiles::CLayerTiles(int w, int h)
 	m_AutoAutoMap = false;
 
 	m_pTiles = new CTile[m_Width * m_Height];
-	mem_zero(m_pTiles, (size_t)m_Width * m_Height * sizeof(CTile));
+	dbg_assert(mem_is_null(m_pTiles, sizeof(*m_pTiles)), "mem not null");
 }
 
 CLayerTiles::~CLayerTiles()
@@ -574,7 +574,7 @@ void CLayerTiles::BrushRotate(float Amount)
 void CLayerTiles::Resize(int NewW, int NewH)
 {
 	CTile *pNewData = new CTile[NewW * NewH];
-	mem_zero(pNewData, (size_t)NewW * NewH * sizeof(CTile));
+	dbg_assert(mem_is_null(pNewData, sizeof(*pNewData)), "mem not null");
 
 	// copy old data
 	for(int y = 0; y < minimum(NewH, m_Height); y++)
@@ -1060,7 +1060,7 @@ CLayerTele::CLayerTele(int w, int h) :
 	m_Tele = 1;
 
 	m_pTeleTile = new CTeleTile[w * h];
-	mem_zero(m_pTeleTile, (size_t)w * h * sizeof(CTeleTile));
+	dbg_assert(mem_is_null(m_pTeleTile, sizeof(*m_pTeleTile)), "mem not null");
 }
 
 CLayerTele::~CLayerTele()
@@ -1072,7 +1072,7 @@ void CLayerTele::Resize(int NewW, int NewH)
 {
 	// resize tele data
 	CTeleTile *pNewTeleData = new CTeleTile[NewW * NewH];
-	mem_zero(pNewTeleData, (size_t)NewW * NewH * sizeof(CTeleTile));
+	dbg_assert(mem_is_null(pNewTeleData, sizeof(*pNewTeleData)), "mem not null");
 
 	// copy old data
 	for(int y = 0; y < minimum(NewH, m_Height); y++)
@@ -1289,7 +1289,7 @@ CLayerSpeedup::CLayerSpeedup(int w, int h) :
 	m_Speedup = 1;
 
 	m_pSpeedupTile = new CSpeedupTile[w * h];
-	mem_zero(m_pSpeedupTile, (size_t)w * h * sizeof(CSpeedupTile));
+	dbg_assert(mem_is_null(m_pSpeedupTile, sizeof(*m_pSpeedupTile)), "mem not null");
 }
 
 CLayerSpeedup::~CLayerSpeedup()
@@ -1301,7 +1301,7 @@ void CLayerSpeedup::Resize(int NewW, int NewH)
 {
 	// resize speedup data
 	CSpeedupTile *pNewSpeedupData = new CSpeedupTile[NewW * NewH];
-	mem_zero(pNewSpeedupData, (size_t)NewW * NewH * sizeof(CSpeedupTile));
+	dbg_assert(mem_is_null(pNewSpeedupData, sizeof(*pNewSpeedupData)), "mem not null");
 
 	// copy old data
 	for(int y = 0; y < minimum(NewH, m_Height); y++)
@@ -1574,7 +1574,7 @@ CLayerSwitch::CLayerSwitch(int w, int h) :
 	m_Switch = 1;
 
 	m_pSwitchTile = new CSwitchTile[w * h];
-	mem_zero(m_pSwitchTile, (size_t)w * h * sizeof(CSwitchTile));
+	dbg_assert(mem_is_null(m_pSwitchTile, sizeof(*m_pSwitchTile)), "mem not null");
 }
 
 CLayerSwitch::~CLayerSwitch()
@@ -1586,7 +1586,7 @@ void CLayerSwitch::Resize(int NewW, int NewH)
 {
 	// resize switch data
 	CSwitchTile *pNewSwitchData = new CSwitchTile[NewW * NewH];
-	mem_zero(pNewSwitchData, (size_t)NewW * NewH * sizeof(CSwitchTile));
+	dbg_assert(mem_is_null(pNewSwitchData, sizeof(*pNewSwitchData)), "mem not null");
 
 	// copy old data
 	for(int y = 0; y < minimum(NewH, m_Height); y++)
@@ -1831,7 +1831,7 @@ CLayerTune::CLayerTune(int w, int h) :
 	m_Tune = 1;
 
 	m_pTuneTile = new CTuneTile[w * h];
-	mem_zero(m_pTuneTile, (size_t)w * h * sizeof(CTuneTile));
+	dbg_assert(mem_is_null(m_pTuneTile, sizeof(*m_pTuneTile)), "mem not null");
 }
 
 CLayerTune::~CLayerTune()
@@ -1843,7 +1843,7 @@ void CLayerTune::Resize(int NewW, int NewH)
 {
 	// resize Tune data
 	CTuneTile *pNewTuneData = new CTuneTile[NewW * NewH];
-	mem_zero(pNewTuneData, (size_t)NewW * NewH * sizeof(CTuneTile));
+	dbg_assert(mem_is_null(pNewTuneData, sizeof(*pNewTuneData)), "mem not null");
 
 	// copy old data
 	for(int y = 0; y < minimum(NewH, m_Height); y++)

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -16,10 +16,10 @@
 static struct
 {
 	CUIRect m_Rect;
-	void *m_pId;
+	void *m_pId = nullptr;
 	int (*m_pfnFunc)(CEditor *pEditor, CUIRect Rect, void *pContext);
-	int m_IsMenu;
-	void *m_pContext;
+	int m_IsMenu = 0;
+	void *m_pContext = nullptr;
 } s_UiPopups[8];
 
 static int g_UiNumPopups = 0;

--- a/src/game/gamecore.h
+++ b/src/game/gamecore.h
@@ -20,7 +20,7 @@ class CTeamsCore;
 
 class CTuneParam
 {
-	int m_Value;
+	int m_Value = 0;
 
 public:
 	void Set(int v) { m_Value = v; }
@@ -178,11 +178,11 @@ enum
 
 struct SSwitchers
 {
-	bool m_aStatus[MAX_CLIENTS];
-	bool m_Initial;
-	int m_aEndTick[MAX_CLIENTS];
-	int m_aType[MAX_CLIENTS];
-	int m_aLastUpdateTick[MAX_CLIENTS];
+	bool m_aStatus[MAX_CLIENTS] = {false};
+	bool m_Initial = false;
+	int m_aEndTick[MAX_CLIENTS] = {0};
+	int m_aType[MAX_CLIENTS] = {0};
+	int m_aLastUpdateTick[MAX_CLIENTS] = {0};
 };
 
 class CWorldCore
@@ -207,8 +207,8 @@ public:
 	}
 
 	CTuningParams m_aTuning[2];
-	class CCharacterCore *m_apCharacters[MAX_CLIENTS];
-	CPrng *m_pPrng;
+	class CCharacterCore *m_apCharacters[MAX_CLIENTS] = {nullptr};
+	CPrng *m_pPrng = nullptr;
 
 	void InitSwitchers(int HighestSwitchNumber);
 	std::vector<SSwitchers> m_vSwitchers;
@@ -218,8 +218,8 @@ class CCharacterCore
 {
 	friend class CCharacter;
 	CWorldCore *m_pWorld = nullptr;
-	CCollision *m_pCollision;
-	std::map<int, std::vector<vec2>> *m_pTeleOuts;
+	CCollision *m_pCollision = nullptr;
+	std::map<int, std::vector<vec2>> *m_pTeleOuts = nullptr;
 
 public:
 	static constexpr float PhysicalSize() { return 28.0f; };
@@ -230,42 +230,42 @@ public:
 	vec2 m_HookPos;
 	vec2 m_HookDir;
 	vec2 m_HookTeleBase;
-	int m_HookTick;
-	int m_HookState;
-	int m_HookedPlayer;
+	int m_HookTick = 0;
+	int m_HookState = 0;
+	int m_HookedPlayer = 0;
 	std::set<int> m_AttachedPlayers;
 	void SetHookedPlayer(int HookedPlayer);
 
-	int m_ActiveWeapon;
+	int m_ActiveWeapon = 0;
 	struct WeaponStat
 	{
-		int m_AmmoRegenStart;
-		int m_Ammo;
-		int m_Ammocost;
-		bool m_Got;
+		int m_AmmoRegenStart = 0;
+		int m_Ammo = 0;
+		int m_Ammocost = 0;
+		bool m_Got = false;
 	} m_aWeapons[NUM_WEAPONS];
 
 	// ninja
 	struct
 	{
 		vec2 m_ActivationDir;
-		int m_ActivationTick;
-		int m_CurrentMoveTime;
-		int m_OldVelAmount;
+		int m_ActivationTick = 0;
+		int m_CurrentMoveTime = 0;
+		int m_OldVelAmount = 0;
 	} m_Ninja;
 
-	bool m_NewHook;
+	bool m_NewHook = false;
 
-	int m_Jumped;
+	int m_Jumped = 0;
 	// m_JumpedTotal counts the jumps performed in the air
-	int m_JumpedTotal;
-	int m_Jumps;
+	int m_JumpedTotal = 0;
+	int m_Jumps = 0;
 
-	int m_Direction;
-	int m_Angle;
+	int m_Direction = 0;
+	int m_Angle = 0;
 	CNetObj_PlayerInput m_Input;
 
-	int m_TriggeredEvents;
+	int m_TriggeredEvents = 0;
 
 	void Init(CWorldCore *pWorld, CCollision *pCollision, CTeamsCore *pTeams = nullptr, std::map<int, std::vector<vec2>> *pTeleOuts = nullptr);
 	void Reset();
@@ -277,50 +277,50 @@ public:
 	void Quantize();
 
 	// DDRace
-	int m_Id;
-	bool m_Reset;
+	int m_Id = 0;
+	bool m_Reset = false;
 	CCollision *Collision() { return m_pCollision; }
 
 	vec2 m_LastVel;
-	int m_Colliding;
-	bool m_LeftWall;
+	int m_Colliding = 0;
+	bool m_LeftWall = false;
 
 	// DDNet Character
 	void SetTeamsCore(CTeamsCore *pTeams);
 	void SetTeleOuts(std::map<int, std::vector<vec2>> *pTeleOuts);
 	void ReadDDNet(const CNetObj_DDNetCharacter *pObjDDNet);
-	bool m_Solo;
-	bool m_Jetpack;
-	bool m_CollisionDisabled;
-	bool m_EndlessHook;
-	bool m_EndlessJump;
-	bool m_HammerHitDisabled;
-	bool m_GrenadeHitDisabled;
-	bool m_LaserHitDisabled;
-	bool m_ShotgunHitDisabled;
-	bool m_HookHitDisabled;
-	bool m_Super;
-	bool m_HasTelegunGun;
-	bool m_HasTelegunGrenade;
-	bool m_HasTelegunLaser;
-	int m_FreezeStart;
-	int m_FreezeEnd;
-	bool m_IsInFreeze;
-	bool m_DeepFrozen;
-	bool m_LiveFrozen;
+	bool m_Solo = false;
+	bool m_Jetpack = false;
+	bool m_CollisionDisabled = false;
+	bool m_EndlessHook = false;
+	bool m_EndlessJump = false;
+	bool m_HammerHitDisabled = false;
+	bool m_GrenadeHitDisabled = false;
+	bool m_LaserHitDisabled = false;
+	bool m_ShotgunHitDisabled = false;
+	bool m_HookHitDisabled = false;
+	bool m_Super = false;
+	bool m_HasTelegunGun = false;
+	bool m_HasTelegunGrenade = false;
+	bool m_HasTelegunLaser = false;
+	int m_FreezeStart = 0;
+	int m_FreezeEnd = 0;
+	bool m_IsInFreeze = false;
+	bool m_DeepFrozen = false;
+	bool m_LiveFrozen = false;
 	CTuningParams m_Tuning;
 
 private:
-	CTeamsCore *m_pTeams;
-	int m_MoveRestrictions;
+	CTeamsCore *m_pTeams = nullptr;
+	int m_MoveRestrictions = 0;
 	static bool IsSwitchActiveCb(int Number, void *pUser);
 };
 
 //input count
 struct CInputCount
 {
-	int m_Presses;
-	int m_Releases;
+	int m_Presses = 0;
+	int m_Releases = 0;
 };
 
 inline CInputCount CountInput(int Prev, int Cur)

--- a/src/game/gamecore.h
+++ b/src/game/gamecore.h
@@ -246,7 +246,7 @@ public:
 	} m_aWeapons[NUM_WEAPONS];
 
 	// ninja
-	struct
+	struct SNinja
 	{
 		vec2 m_ActivationDir;
 		int m_ActivationTick = 0;

--- a/src/game/layers.h
+++ b/src/game/layers.h
@@ -12,13 +12,13 @@ struct CMapItemLayerTilemap;
 
 class CLayers
 {
-	int m_GroupsNum;
-	int m_GroupsStart;
-	int m_LayersNum;
-	int m_LayersStart;
-	CMapItemGroup *m_pGameGroup;
-	CMapItemLayerTilemap *m_pGameLayer;
-	IMap *m_pMap;
+	int m_GroupsNum = 0;
+	int m_GroupsStart = 0;
+	int m_LayersNum = 0;
+	int m_LayersStart = 0;
+	CMapItemGroup *m_pGameGroup = nullptr;
+	CMapItemLayerTilemap *m_pGameLayer = nullptr;
+	IMap *m_pMap = nullptr;
 
 	void InitTilemapSkip();
 
@@ -43,11 +43,11 @@ public:
 	CMapItemLayerTilemap *TuneLayer() const { return m_pTuneLayer; }
 
 private:
-	CMapItemLayerTilemap *m_pTeleLayer;
-	CMapItemLayerTilemap *m_pSpeedupLayer;
-	CMapItemLayerTilemap *m_pFrontLayer;
-	CMapItemLayerTilemap *m_pSwitchLayer;
-	CMapItemLayerTilemap *m_pTuneLayer;
+	CMapItemLayerTilemap *m_pTeleLayer = nullptr;
+	CMapItemLayerTilemap *m_pSpeedupLayer = nullptr;
+	CMapItemLayerTilemap *m_pFrontLayer = nullptr;
+	CMapItemLayerTilemap *m_pSwitchLayer = nullptr;
+	CMapItemLayerTilemap *m_pTuneLayer = nullptr;
 };
 
 #endif

--- a/src/game/localization.h
+++ b/src/game/localization.h
@@ -12,9 +12,9 @@ class CLocalizationDatabase
 	class CString
 	{
 	public:
-		unsigned m_Hash;
-		unsigned m_ContextHash;
-		const char *m_pReplacement;
+		unsigned m_Hash = 0;
+		unsigned m_ContextHash = 0;
+		const char *m_pReplacement = nullptr;
 
 		CString() {}
 		CString(unsigned Hash, unsigned ContextHash, const char *pReplacement) :
@@ -29,8 +29,8 @@ class CLocalizationDatabase
 
 	std::vector<CString> m_vStrings;
 	CHeap m_StringsHeap;
-	int m_VersionCounter;
-	int m_CurrentVersion;
+	int m_VersionCounter = 0;
+	int m_CurrentVersion = 0;
 
 public:
 	CLocalizationDatabase();
@@ -47,11 +47,11 @@ extern CLocalizationDatabase g_Localization;
 
 class CLocConstString
 {
-	const char *m_pDefaultStr;
-	const char *m_pCurrentStr;
-	unsigned m_Hash;
-	unsigned m_ContextHash;
-	int m_Version;
+	const char *m_pDefaultStr = nullptr;
+	const char *m_pCurrentStr = nullptr;
+	unsigned m_Hash = 0;
+	unsigned m_ContextHash = 0;
+	int m_Version = 0;
 
 public:
 	CLocConstString(const char *pStr, const char *pContext = "");

--- a/src/game/mapbugs.cpp
+++ b/src/game/mapbugs.cpp
@@ -4,8 +4,8 @@
 
 struct CMapDescription
 {
-	const char *m_pName;
-	int m_Size;
+	const char *m_pName = nullptr;
+	int m_Size = 0;
 	SHA256_DIGEST m_Sha256;
 
 	bool operator==(const CMapDescription &Other) const
@@ -18,7 +18,7 @@ struct CMapDescription
 struct CMapBugsInternal
 {
 	CMapDescription m_Map;
-	unsigned int m_BugFlags;
+	unsigned int m_BugFlags = 0;
 };
 
 static unsigned int BugToFlag(int Bug)

--- a/src/game/mapbugs.h
+++ b/src/game/mapbugs.h
@@ -21,8 +21,8 @@ enum
 class CMapBugs
 {
 	friend CMapBugs GetMapBugs(const char *pName, int Size, SHA256_DIGEST Sha256);
-	void *m_pData;
-	unsigned int m_Extra;
+	void *m_pData = nullptr;
+	unsigned int m_Extra = 0;
 
 public:
 	bool Contains(int Bug) const;

--- a/src/game/mapitems.h
+++ b/src/game/mapitems.h
@@ -1,5 +1,5 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
-/* If you are missing that file, acquire a complete release at teeworlds.com.                */
+/* If you are missing that file, acquire a complete release at teeworlds.com.				*/
 #ifndef GAME_MAPITEMS_H
 #define GAME_MAPITEMS_H
 
@@ -222,56 +222,56 @@ struct CQuad
 	CColor m_aColors[4];
 	CPoint m_aTexcoords[4];
 
-	int m_PosEnv;
-	int m_PosEnvOffset;
+	int m_PosEnv = 0;
+	int m_PosEnvOffset = 0;
 
-	int m_ColorEnv;
-	int m_ColorEnvOffset;
+	int m_ColorEnv = 0;
+	int m_ColorEnvOffset = 0;
 };
 
 class CTile
 {
 public:
-	unsigned char m_Index;
-	unsigned char m_Flags;
-	unsigned char m_Skip;
-	unsigned char m_Reserved;
+	unsigned char m_Index = 0;
+	unsigned char m_Flags = 0;
+	unsigned char m_Skip = 0;
+	unsigned char m_Reserved = 0;
 };
 
 struct CMapItemInfo
 {
-	int m_Version;
-	int m_Author;
-	int m_MapVersion;
-	int m_Credits;
-	int m_License;
+	int m_Version = 0;
+	int m_Author = 0;
+	int m_MapVersion = 0;
+	int m_Credits = 0;
+	int m_License = 0;
 };
 
 struct CMapItemInfoSettings : CMapItemInfo
 {
-	int m_Settings;
+	int m_Settings = 0;
 };
 
 struct CMapItemImage
 {
-	int m_Version;
-	int m_Width;
-	int m_Height;
-	int m_External;
-	int m_ImageName;
-	int m_ImageData;
+	int m_Version = 0;
+	int m_Width = 0;
+	int m_Height = 0;
+	int m_External = 0;
+	int m_ImageName = 0;
+	int m_ImageData = 0;
 };
 
 struct CMapItemGroup_v1
 {
-	int m_Version;
-	int m_OffsetX;
-	int m_OffsetY;
-	int m_ParallaxX;
-	int m_ParallaxY;
+	int m_Version = 0;
+	int m_OffsetX = 0;
+	int m_OffsetY = 0;
+	int m_ParallaxX = 0;
+	int m_ParallaxY = 0;
 
-	int m_StartLayer;
-	int m_NumLayers;
+	int m_StartLayer = 0;
+	int m_NumLayers = 0;
 };
 
 struct CMapItemGroup : public CMapItemGroup_v1
@@ -281,82 +281,82 @@ struct CMapItemGroup : public CMapItemGroup_v1
 		CURRENT_VERSION = 3
 	};
 
-	int m_UseClipping;
-	int m_ClipX;
-	int m_ClipY;
-	int m_ClipW;
-	int m_ClipH;
+	int m_UseClipping = 0;
+	int m_ClipX = 0;
+	int m_ClipY = 0;
+	int m_ClipW = 0;
+	int m_ClipH = 0;
 
-	int m_aName[3];
+	int m_aName[3] = {0};
 };
 
 struct CMapItemLayer
 {
-	int m_Version;
-	int m_Type;
-	int m_Flags;
+	int m_Version = 0;
+	int m_Type = 0;
+	int m_Flags = 0;
 };
 
 struct CMapItemLayerTilemap
 {
 	CMapItemLayer m_Layer;
-	int m_Version;
+	int m_Version = 0;
 
-	int m_Width;
-	int m_Height;
-	int m_Flags;
+	int m_Width = 0;
+	int m_Height = 0;
+	int m_Flags = 0;
 
 	CColor m_Color;
-	int m_ColorEnv;
-	int m_ColorEnvOffset;
+	int m_ColorEnv = 0;
+	int m_ColorEnvOffset = 0;
 
-	int m_Image;
-	int m_Data;
+	int m_Image = 0;
+	int m_Data = 0;
 
-	int m_aName[3];
+	int m_aName[3] = {0};
 
 	// DDRace
 
-	int m_Tele;
-	int m_Speedup;
-	int m_Front;
-	int m_Switch;
-	int m_Tune;
+	int m_Tele = 0;
+	int m_Speedup = 0;
+	int m_Front = 0;
+	int m_Switch = 0;
+	int m_Tune = 0;
 };
 
 struct CMapItemLayerQuads
 {
 	CMapItemLayer m_Layer;
-	int m_Version;
+	int m_Version = 0;
 
-	int m_NumQuads;
-	int m_Data;
-	int m_Image;
+	int m_NumQuads = 0;
+	int m_Data = 0;
+	int m_Image = 0;
 
-	int m_aName[3];
+	int m_aName[3] = {0};
 };
 
 struct CMapItemVersion
 {
-	int m_Version;
+	int m_Version = 0;
 };
 
 struct CEnvPoint
 {
-	int m_Time; // in ms
-	int m_Curvetype;
-	int m_aValues[4]; // 1-4 depending on envelope (22.10 fixed point)
+	int m_Time = 0; // in ms
+	int m_Curvetype = 0;
+	int m_aValues[4] = {0}; // 1-4 depending on envelope (22.10 fixed point)
 
 	bool operator<(const CEnvPoint &Other) const { return m_Time < Other.m_Time; }
 };
 
 struct CMapItemEnvelope_v1
 {
-	int m_Version;
-	int m_Channels;
-	int m_StartPoint;
-	int m_NumPoints;
-	int m_aName[8];
+	int m_Version = 0;
+	int m_Channels = 0;
+	int m_StartPoint = 0;
+	int m_NumPoints = 0;
+	int m_aName[8] = {0};
 };
 
 struct CMapItemEnvelope : public CMapItemEnvelope_v1
@@ -365,7 +365,7 @@ struct CMapItemEnvelope : public CMapItemEnvelope_v1
 	{
 		CURRENT_VERSION = 2
 	};
-	int m_Synchronized;
+	int m_Synchronized = 0;
 };
 
 struct CSoundShape
@@ -379,35 +379,37 @@ struct CSoundShape
 
 	struct CRectangle
 	{
-		int m_Width, m_Height; // fxp 22.10
+		int m_Width = 0, m_Height = 0; // fxp 22.10
 	};
 
 	struct CCircle
 	{
-		int m_Radius;
+		int m_Radius = 0;
 	};
 
-	int m_Type;
+	int m_Type = 0;
 
 	union
 	{
 		CRectangle m_Rectangle;
 		CCircle m_Circle;
 	};
+
+	CSoundShape() {} // required due to union
 };
 
 struct CSoundSource
 {
-	CPoint m_Position;
-	int m_Loop;
-	int m_Pan; // 0 - no panning, 1 - panning
-	int m_TimeDelay; // in s
-	int m_Falloff; // [0,255] // 0 - No falloff, 255 - full
+	CPoint m_Position = {0, 0};
+	int m_Loop = 0;
+	int m_Pan = 0; // 0 - no panning, 1 - panning
+	int m_TimeDelay = 0; // in s
+	int m_Falloff = 0; // [0,255] // 0 - No falloff, 255 - full
 
-	int m_PosEnv;
-	int m_PosEnvOffset;
-	int m_SoundEnv;
-	int m_SoundEnvOffset;
+	int m_PosEnv = 0;
+	int m_PosEnvOffset = 0;
+	int m_SoundEnv = 0;
+	int m_SoundEnvOffset = 0;
 
 	CSoundShape m_Shape;
 };
@@ -420,24 +422,24 @@ struct CMapItemLayerSounds
 	};
 
 	CMapItemLayer m_Layer;
-	int m_Version;
+	int m_Version = 0;
 
-	int m_NumSources;
-	int m_Data;
-	int m_Sound;
+	int m_NumSources = 0;
+	int m_Data = 0;
+	int m_Sound = 0;
 
-	int m_aName[3];
+	int m_aName[3] = {0};
 };
 
 struct CMapItemSound
 {
-	int m_Version;
+	int m_Version = 0;
 
-	int m_External;
+	int m_External = 0;
 
-	int m_SoundName;
-	int m_SoundData;
-	int m_SoundDataSize;
+	int m_SoundName = 0;
+	int m_SoundData = 0;
+	int m_SoundDataSize = 0;
 };
 
 // DDRace
@@ -445,41 +447,41 @@ struct CMapItemSound
 class CTeleTile
 {
 public:
-	unsigned char m_Number;
-	unsigned char m_Type;
+	unsigned char m_Number = 0;
+	unsigned char m_Type = 0;
 };
 
 class CSpeedupTile
 {
 public:
-	unsigned char m_Force;
-	unsigned char m_MaxSpeed;
-	unsigned char m_Type;
-	short m_Angle;
+	unsigned char m_Force = 0;
+	unsigned char m_MaxSpeed = 0;
+	unsigned char m_Type = 0;
+	short m_Angle = 0;
 };
 
 class CSwitchTile
 {
 public:
-	unsigned char m_Number;
-	unsigned char m_Type;
-	unsigned char m_Flags;
-	unsigned char m_Delay;
+	unsigned char m_Number = 0;
+	unsigned char m_Type = 0;
+	unsigned char m_Flags = 0;
+	unsigned char m_Delay = 0;
 };
 
 class CDoorTile
 {
 public:
-	unsigned char m_Index;
-	unsigned char m_Flags;
-	int m_Number;
+	unsigned char m_Index = 0;
+	unsigned char m_Flags = 0;
+	int m_Number = 0;
 };
 
 class CTuneTile
 {
 public:
-	unsigned char m_Number;
-	unsigned char m_Type;
+	unsigned char m_Number = 0;
+	unsigned char m_Type = 0;
 };
 
 bool IsValidGameTile(int Index);

--- a/src/game/mapitems_ex.h
+++ b/src/game/mapitems_ex.h
@@ -18,10 +18,10 @@ struct CMapItemTest
 		CURRENT_VERSION = 1
 	};
 
-	int m_Version;
-	int m_aFields[2];
-	int m_Field3;
-	int m_Field4;
+	int m_Version = 0;
+	int m_aFields[2] = {0};
+	int m_Field3 = 0;
+	int m_Field4 = 0;
 };
 
 struct CMapItemAutoMapperConfig
@@ -35,12 +35,12 @@ struct CMapItemAutoMapperConfig
 		FLAG_AUTOMATIC = 1
 	};
 
-	int m_Version;
-	int m_GroupId;
-	int m_LayerId;
-	int m_AutomapperConfig;
-	int m_AutomapperSeed;
-	int m_Flags;
+	int m_Version = 0;
+	int m_GroupId = 0;
+	int m_LayerId = 0;
+	int m_AutomapperConfig = 0;
+	int m_AutomapperSeed = 0;
+	int m_Flags = 0;
 };
 
 void RegisterMapItemTypeUuids(class CUuidManager *pManager);

--- a/src/game/prng.h
+++ b/src/game/prng.h
@@ -22,11 +22,11 @@ public:
 	unsigned int RandomBits();
 
 private:
-	char m_aDescription[64];
+	char m_aDescription[64] = {0};
 
-	bool m_Seeded;
-	uint64_t m_State;
-	uint64_t m_Increment;
+	bool m_Seeded = false;
+	uint64_t m_State = 0;
+	uint64_t m_Increment = 0;
 };
 
 #endif // GAME_PRNG_H

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -66,7 +66,7 @@ bool CCharacter::Spawn(CPlayer *pPlayer, vec2 Pos)
 	m_pPlayer = pPlayer;
 	m_Pos = Pos;
 
-	mem_zero(&m_LatestPrevPrevInput, sizeof(m_LatestPrevPrevInput));
+	m_LatestPrevPrevInput = CNetObj_PlayerInput();
 	m_LatestPrevPrevInput.m_TargetY = -1;
 	m_NumInputs = 0;
 	m_SpawnTick = Server()->Tick();
@@ -848,13 +848,11 @@ void CCharacter::TickDefered()
 	{
 		CNetObj_Character Predicted;
 		CNetObj_Character Current;
-		mem_zero(&Predicted, sizeof(Predicted));
-		mem_zero(&Current, sizeof(Current));
 		m_ReckoningCore.Write(&Predicted);
 		m_Core.Write(&Current);
 
 		// only allow dead reackoning for a top of 3 seconds
-		if(m_Core.m_Reset || m_ReckoningTick + Server()->TickSpeed() * 3 < Server()->Tick() || mem_comp(&Predicted, &Current, sizeof(CNetObj_Character)) != 0)
+		if(m_Core.m_Reset || m_ReckoningTick + Server()->TickSpeed() * 3 < Server()->Tick() || mem_comp((void*)&Predicted, (void*)&Current, sizeof(CNetObj_Character)) != 0)
 		{
 			m_ReckoningTick = Server()->Tick();
 			m_SendCore = m_Core;

--- a/src/game/server/entities/character.h
+++ b/src/game/server/entities/character.h
@@ -88,30 +88,30 @@ public:
 
 private:
 	// player controlling this character
-	class CPlayer *m_pPlayer;
+	class CPlayer *m_pPlayer = nullptr;
 
-	bool m_Alive;
-	bool m_Paused;
-	int m_NeededFaketuning;
+	bool m_Alive = false;
+	bool m_Paused = false;
+	int m_NeededFaketuning = 0;
 
 	// weapon info
-	CEntity *m_apHitObjects[10];
-	int m_NumObjectsHit;
+	CEntity *m_apHitObjects[10] = {nullptr};
+	int m_NumObjectsHit = 0;
 
-	int m_LastWeapon;
-	int m_QueuedWeapon;
+	int m_LastWeapon = 0;
+	int m_QueuedWeapon = 0;
 
-	int m_ReloadTimer;
-	int m_AttackTick;
+	int m_ReloadTimer = 0;
+	int m_AttackTick = 0;
 
-	int m_DamageTaken;
+	int m_DamageTaken = 0;
 
-	int m_EmoteType;
-	int m_EmoteStop;
+	int m_EmoteType = 0;
+	int m_EmoteStop = 0;
 
 	// last tick that the player took any action ie some input
-	int m_LastAction;
-	int m_LastNoAmmoSound;
+	int m_LastAction = 0;
+	int m_LastNoAmmoSound = 0;
 
 	// these are non-heldback inputs
 	CNetObj_PlayerInput m_LatestPrevPrevInput;
@@ -122,12 +122,12 @@ private:
 	CNetObj_PlayerInput m_PrevInput;
 	CNetObj_PlayerInput m_Input;
 	CNetObj_PlayerInput m_SavedInput;
-	int m_NumInputs;
+	int m_NumInputs = 0;
 
-	int m_DamageTakenTick;
+	int m_DamageTakenTick = 0;
 
-	int m_Health;
-	int m_Armor;
+	int m_Health = 0;
+	int m_Armor = 0;
 
 	// the player core for the physics
 	CCharacterCore m_Core;
@@ -137,7 +137,7 @@ private:
 	std::map<int, std::vector<vec2>> *m_pTeleCheckOuts = nullptr;
 
 	// info for dead reckoning
-	int m_ReckoningTick; // tick that we are performing dead reckoning From
+	int m_ReckoningTick = 0; // tick that we are performing dead reckoning From
 	CCharacterCore m_SendCore; // core that we should send
 	CCharacterCore m_ReckoningCore; // the dead reckoning core
 
@@ -147,8 +147,8 @@ private:
 	static bool IsSwitchActiveCb(int Number, void *pUser);
 	void SetTimeCheckpoint(int TimeCheckpoint);
 	void HandleTiles(int Index);
-	float m_Time;
-	int m_LastBroadcast;
+	float m_Time = 0;
+	int m_LastBroadcast = 0;
 	void DDRaceInit();
 	void HandleSkippableTiles(int Index);
 	void SetRescue();
@@ -159,7 +159,7 @@ private:
 	void SendZoneMsgs();
 	IAntibot *Antibot();
 
-	bool m_SetSavePos;
+	bool m_SetSavePos = false;
 	CSaveTee m_RescueTee;
 
 public:
@@ -174,46 +174,46 @@ public:
 	bool UnFreeze();
 	void GiveAllWeapons();
 	void ResetPickups();
-	int m_DDRaceState;
+	int m_DDRaceState = 0;
 	int Team();
 	bool CanCollide(int ClientID);
 	bool SameTeam(int ClientID);
-	bool m_NinjaJetpack;
-	int m_TeamBeforeSuper;
-	int m_FreezeTime;
-	bool m_FrozenLastTick;
-	bool m_FreezeHammer;
-	int m_TuneZone;
-	int m_TuneZoneOld;
-	int m_PainSoundTimer;
-	int m_LastMove;
-	int m_StartTime;
+	bool m_NinjaJetpack = false;
+	int m_TeamBeforeSuper = 0;
+	int m_FreezeTime = 0;
+	bool m_FrozenLastTick = false;
+	bool m_FreezeHammer = false;
+	int m_TuneZone = 0;
+	int m_TuneZoneOld = 0;
+	int m_PainSoundTimer = 0;
+	int m_LastMove = 0;
+	int m_StartTime = 0;
 	vec2 m_PrevPos;
-	int m_TeleCheckpoint;
+	int m_TeleCheckpoint = 0;
 
-	int m_TimeCpBroadcastEndTick;
-	int m_LastTimeCp;
-	int m_LastTimeCpBroadcasted;
-	float m_aCurrentTimeCp[MAX_CHECKPOINTS];
+	int m_TimeCpBroadcastEndTick = 0;
+	int m_LastTimeCp = 0;
+	int m_LastTimeCpBroadcasted = 0;
+	float m_aCurrentTimeCp[MAX_CHECKPOINTS] = {0};
 
-	int m_TileIndex;
-	int m_TileFIndex;
+	int m_TileIndex = 0;
+	int m_TileFIndex = 0;
 
-	int m_MoveRestrictions;
+	int m_MoveRestrictions = 0;
 
 	vec2 m_Intersection;
-	int64_t m_LastStartWarning;
-	int64_t m_LastRescue;
-	bool m_LastRefillJumps;
-	bool m_LastPenalty;
-	bool m_LastBonus;
+	int64_t m_LastStartWarning = 0;
+	int64_t m_LastRescue = 0;
+	bool m_LastRefillJumps = false;
+	bool m_LastPenalty = false;
+	bool m_LastBonus = false;
 	vec2 m_TeleGunPos;
-	bool m_TeleGunTeleport;
-	bool m_IsBlueTeleGunTeleport;
-	int m_StrongWeakID;
+	bool m_TeleGunTeleport = false;
+	bool m_IsBlueTeleGunTeleport = false;
+	int m_StrongWeakID = 0;
 
-	int m_SpawnTick;
-	int m_WeaponChangeTick;
+	int m_SpawnTick = 0;
+	int m_WeaponChangeTick = 0;
 
 	// Setters/Getters because i don't want to modify vanilla vars access modifiers
 	int GetLastWeapon() { return m_LastWeapon; }

--- a/src/game/server/entities/door.h
+++ b/src/game/server/entities/door.h
@@ -10,7 +10,7 @@ class CDoor : public CEntity
 {
 	vec2 m_To;
 	void ResetCollision();
-	int m_Length;
+	int m_Length = 0;
 	vec2 m_Direction;
 
 public:

--- a/src/game/server/entities/dragger.cpp
+++ b/src/game/server/entities/dragger.cpp
@@ -61,25 +61,17 @@ void CDragger::Tick()
 void CDragger::LookForPlayersToDrag()
 {
 	// Create a list of players who are in the range of the dragger
-	CCharacter *apPlayersInRange[MAX_CLIENTS];
-	mem_zero(apPlayersInRange, sizeof(apPlayersInRange));
+	CCharacter *apPlayersInRange[MAX_CLIENTS] = {nullptr};
 
 	int NumPlayersInRange = GameServer()->m_World.FindEntities(m_Pos,
 		g_Config.m_SvDraggerRange - CCharacterCore::PhysicalSize(),
 		(CEntity **)apPlayersInRange, MAX_CLIENTS, CGameWorld::ENTTYPE_CHARACTER);
 
 	// The closest player (within range) in a team is selected as the target
-	int aClosestTargetIdInTeam[MAX_CLIENTS];
-	bool aCanStillBeTeamTarget[MAX_CLIENTS];
-	bool aIsTarget[MAX_CLIENTS];
-	int aMinDistInTeam[MAX_CLIENTS];
-	mem_zero(aCanStillBeTeamTarget, sizeof(aCanStillBeTeamTarget));
-	mem_zero(aMinDistInTeam, sizeof(aMinDistInTeam));
-	mem_zero(aIsTarget, sizeof(aIsTarget));
-	for(int &TargetId : aClosestTargetIdInTeam)
-	{
-		TargetId = -1;
-	}
+	int aClosestTargetIdInTeam[MAX_CLIENTS] = {-1};
+	bool aCanStillBeTeamTarget[MAX_CLIENTS] = {false};
+	bool aIsTarget[MAX_CLIENTS] = {false};
+	int aMinDistInTeam[MAX_CLIENTS] = {0};
 
 	for(int i = 0; i < NumPlayersInRange; i++)
 	{

--- a/src/game/server/entities/dragger.h
+++ b/src/game/server/entities/dragger.h
@@ -23,12 +23,12 @@ class CDragger : public CEntity
 {
 	// m_Core is the direction vector by which a dragger is shifted at each movement tick (every 150ms)
 	vec2 m_Core;
-	float m_Strength;
-	bool m_IgnoreWalls;
-	int m_EvalTick;
+	float m_Strength = 0;
+	bool m_IgnoreWalls = false;
+	int m_EvalTick = 0;
 
-	int m_aTargetIdInTeam[MAX_CLIENTS];
-	CDraggerBeam *m_apDraggerBeam[MAX_CLIENTS];
+	int m_aTargetIdInTeam[MAX_CLIENTS] = {0};
+	CDraggerBeam *m_apDraggerBeam[MAX_CLIENTS] = {nullptr};
 
 	void LookForPlayersToDrag();
 

--- a/src/game/server/entities/dragger_beam.h
+++ b/src/game/server/entities/dragger_beam.h
@@ -23,12 +23,12 @@ class CGameWorld;
  */
 class CDraggerBeam : public CEntity
 {
-	CDragger *m_pDragger;
-	float m_Strength;
-	bool m_IgnoreWalls;
-	int m_ForClientID;
-	int m_EvalTick;
-	bool m_Active;
+	CDragger *m_pDragger = nullptr;
+	float m_Strength = 0;
+	bool m_IgnoreWalls = false;
+	int m_ForClientID = 0;
+	int m_EvalTick = 0;
+	bool m_Active = false;
 
 public:
 	CDraggerBeam(CGameWorld *pGameWorld, CDragger *pDragger, vec2 Pos, float Strength, bool IgnoreWalls, int ForClientID, int Layer, int Number);

--- a/src/game/server/entities/flag.h
+++ b/src/game/server/entities/flag.h
@@ -10,14 +10,14 @@ class CFlag : public CEntity
 {
 public:
 	static const int ms_PhysSize = 14;
-	CCharacter *m_pCarryingCharacter;
+	CCharacter *m_pCarryingCharacter = nullptr;
 	vec2 m_Vel;
 	vec2 m_StandPos;
 
-	int m_Team;
-	int m_AtStand;
-	int m_DropTick;
-	int m_GrabTick;
+	int m_Team = 0;
+	int m_AtStand = 0;
+	int m_DropTick = 0;
+	int m_GrabTick = 0;
 
 	CFlag(CGameWorld *pGameWorld, int Team);
 

--- a/src/game/server/entities/gun.cpp
+++ b/src/game/server/entities/gun.cpp
@@ -58,15 +58,10 @@ void CGun::Fire()
 		(CEntity **)apPlayersInRange, MAX_CLIENTS, CGameWorld::ENTTYPE_CHARACTER);
 
 	// The closest player (within range) in a team is selected as the target
-	int aTargetIdInTeam[MAX_CLIENTS];
-	bool aIsTarget[MAX_CLIENTS];
-	int aMinDistInTeam[MAX_CLIENTS];
-	mem_zero(aMinDistInTeam, sizeof(aMinDistInTeam));
-	mem_zero(aIsTarget, sizeof(aIsTarget));
-	for(int &TargetId : aTargetIdInTeam)
-	{
-		TargetId = -1;
-	}
+	int aTargetIdInTeam[MAX_CLIENTS] = {-1};
+	bool aIsTarget[MAX_CLIENTS] = {false};
+	dbg_assert(mem_is_null(aIsTarget, sizeof aIsTarget), "mem not null");
+	int aMinDistInTeam[MAX_CLIENTS] = {0};
 
 	for(int i = 0; i < NumPlayersInRange; i++)
 	{
@@ -133,6 +128,7 @@ void CGun::Fire()
 		if(aIsTarget[i])
 		{
 			CCharacter *pTarget = GameServer()->GetPlayerChar(i);
+			dbg_msg("abvcd", "%p", pTarget);
 			new CPlasma(&GameServer()->m_World, m_Pos, normalize(pTarget->m_Pos - m_Pos), m_Freeze, m_Explosive, i);
 		}
 	}

--- a/src/game/server/entities/gun.h
+++ b/src/game/server/entities/gun.h
@@ -22,11 +22,11 @@
 class CGun : public CEntity
 {
 	vec2 m_Core;
-	bool m_Freeze;
-	bool m_Explosive;
-	int m_EvalTick;
-	int m_aLastFireTeam[MAX_CLIENTS];
-	int m_aLastFireSolo[MAX_CLIENTS];
+	bool m_Freeze = false;
+	bool m_Explosive = false;
+	int m_EvalTick = 0;
+	int m_aLastFireTeam[MAX_CLIENTS] = {0};
+	int m_aLastFireSolo[MAX_CLIENTS] = {0};
 
 	void Fire();
 

--- a/src/game/server/entities/laser.h
+++ b/src/game/server/entities/laser.h
@@ -24,22 +24,22 @@ private:
 	vec2 m_From;
 	vec2 m_Dir;
 	vec2 m_TelePos;
-	bool m_WasTele;
-	float m_Energy;
-	int m_Bounces;
-	int m_EvalTick;
-	int m_Owner;
-	int m_TeamMask;
-	bool m_ZeroEnergyBounceInLastTick;
+	bool m_WasTele = false;
+	float m_Energy = 0;
+	int m_Bounces = 0;
+	int m_EvalTick = 0;
+	int m_Owner = 0;
+	int m_TeamMask = 0;
+	bool m_ZeroEnergyBounceInLastTick = false;
 
 	// DDRace
 
 	vec2 m_PrevPos;
-	int m_Type;
-	int m_TuneZone;
-	bool m_TeleportCancelled;
-	bool m_IsBlueTeleport;
-	bool m_BelongsToPracticeTeam;
+	int m_Type = 0;
+	int m_TuneZone = 0;
+	bool m_TeleportCancelled = false;
+	bool m_IsBlueTeleport = false;
+	bool m_BelongsToPracticeTeam = false;
 };
 
 #endif

--- a/src/game/server/entities/light.h
+++ b/src/game/server/entities/light.h
@@ -6,24 +6,24 @@
 
 class CLight : public CEntity
 {
-	float m_Rotation;
+	float m_Rotation = 0;
 	vec2 m_To;
 	vec2 m_Core;
 
-	int m_EvalTick;
+	int m_EvalTick = 0;
 
-	int m_Tick;
+	int m_Tick = 0;
 
 	bool HitCharacter();
 	void Move();
 	void Step();
 
 public:
-	int m_CurveLength;
-	int m_LengthL;
-	float m_AngularSpeed;
-	int m_Speed;
-	int m_Length;
+	int m_CurveLength = 0;
+	int m_LengthL = 0;
+	float m_AngularSpeed = 0;
+	int m_Speed = 0;
+	int m_Length = 0;
 
 	CLight(CGameWorld *pGameWorld, vec2 Pos, float Rotation, int Length,
 		int Layer = 0, int Number = 0);

--- a/src/game/server/entities/pickup.h
+++ b/src/game/server/entities/pickup.h
@@ -16,9 +16,9 @@ public:
 	void Snap(int SnappingClient) override;
 
 private:
-	int m_Type;
-	int m_Subtype;
-	//int m_SpawnTick;
+	int m_Type = 0;
+	int m_Subtype = 0;
+	//int m_SpawnTick = 0;
 
 	// DDRace
 

--- a/src/game/server/entities/plasma.h
+++ b/src/game/server/entities/plasma.h
@@ -6,7 +6,7 @@
 
 /**
  * Plasma Bullets are projectiles fired from turrets at a specific target
- * 
+ *
  * When hitting a tee, plasma bullets can either freeze or unfreeze the player
  * Also, plasma projectiles can explode on impact. However, the player affected by the explosion is not necessarily the
  * one the plasma collided with, but if the affected player is not a solo player, then the team-mate with the lowest
@@ -23,11 +23,11 @@
 class CPlasma : public CEntity
 {
 	vec2 m_Core;
-	int m_Freeze;
-	bool m_Explosive;
-	int m_ForClientID;
-	int m_EvalTick;
-	int m_LifeTime;
+	int m_Freeze = 0;
+	bool m_Explosive = false;
+	int m_ForClientID = 0;
+	int m_EvalTick = 0;
+	int m_LifeTime = 0;
 
 	void Move();
 	bool HitCharacter(CCharacter *pTarget);

--- a/src/game/server/entities/projectile.h
+++ b/src/game/server/entities/projectile.h
@@ -33,21 +33,21 @@ public:
 
 private:
 	vec2 m_Direction;
-	int m_LifeSpan;
-	int m_Owner;
-	int m_Type;
-	//int m_Damage;
-	int m_SoundImpact;
-	float m_Force;
-	int m_StartTick;
-	bool m_Explosive;
+	int m_LifeSpan = 0;
+	int m_Owner = 0;
+	int m_Type = 0;
+	//int m_Damage = 0;
+	int m_SoundImpact = 0;
+	float m_Force = 0;
+	int m_StartTick = 0;
+	bool m_Explosive = false;
 
 	// DDRace
 
-	int m_Bouncing;
-	bool m_Freeze;
-	int m_TuneZone;
-	bool m_BelongsToPracticeTeam;
+	int m_Bouncing = 0;
+	bool m_Freeze = false;
+	int m_TuneZone = 0;
+	bool m_BelongsToPracticeTeam = false;
 
 public:
 	void SetBouncing(int Value);

--- a/src/game/server/entity.h
+++ b/src/game/server/entity.h
@@ -21,25 +21,25 @@ class CEntity
 
 private:
 	friend CGameWorld; // entity list handling
-	CEntity *m_pPrevTypeEntity;
-	CEntity *m_pNextTypeEntity;
+	CEntity *m_pPrevTypeEntity = nullptr;
+	CEntity *m_pNextTypeEntity = nullptr;
 
 	/* Identity */
-	CGameWorld *m_pGameWorld;
-	CCollision *m_pCCollision;
+	CGameWorld *m_pGameWorld = nullptr;
+	CCollision *m_pCCollision = nullptr;
 
-	int m_ID;
-	int m_ObjType;
+	int m_ID = 0;
+	int m_ObjType = 0;
 
 	/*
 		Variable: m_ProximityRadius
 			Contains the physical size of the entity.
 	*/
-	float m_ProximityRadius;
+	float m_ProximityRadius = 0;
 
 protected:
 	/* State */
-	bool m_MarkedForDestroy;
+	bool m_MarkedForDestroy = false;
 
 public: // TODO: Maybe make protected
 	/*
@@ -153,8 +153,8 @@ public: // TODO: Maybe make protected
 	bool GetNearestAirPos(vec2 Pos, vec2 PrevPos, vec2 *pOutPos);
 	bool GetNearestAirPosPlayer(vec2 PlayerPos, vec2 *pOutPos);
 
-	int m_Number;
-	int m_Layer;
+	int m_Number = 0;
+	int m_Layer = 0;
 };
 
 bool NetworkClipped(const CGameContext *pGameServer, int SnappingClient, vec2 CheckPos);

--- a/src/game/server/eventhandler.h
+++ b/src/game/server/eventhandler.h
@@ -13,16 +13,16 @@ class CEventHandler
 		MAX_DATASIZE = 128 * 64,
 	};
 
-	int m_aTypes[MAX_EVENTS]; // TODO: remove some of these arrays
-	int m_aOffsets[MAX_EVENTS];
-	int m_aSizes[MAX_EVENTS];
-	int64_t m_aClientMasks[MAX_EVENTS];
-	char m_aData[MAX_DATASIZE];
+	int m_aTypes[MAX_EVENTS] = {0}; // TODO: remove some of these arrays
+	int m_aOffsets[MAX_EVENTS] = {0};
+	int m_aSizes[MAX_EVENTS] = {0};
+	int64_t m_aClientMasks[MAX_EVENTS] = {0};
+	char m_aData[MAX_DATASIZE] = {0};
 
-	class CGameContext *m_pGameServer;
+	class CGameContext *m_pGameServer = nullptr;
 
-	int m_CurrentOffset;
-	int m_NumEvents;
+	int m_CurrentOffset = 0;
+	int m_NumEvents = 0;
 
 public:
 	CGameContext *GameServer() const { return m_pGameServer; }

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -75,7 +75,7 @@ void CGameContext::Construct(int Resetting)
 	for(auto &pPlayer : m_apPlayers)
 		pPlayer = 0;
 
-	mem_zero(&m_aLastPlayerInput, sizeof(m_aLastPlayerInput));
+	new(m_aLastPlayerInput) std::remove_pointer<decltype(m_aLastPlayerInput)>::type;
 	mem_zero(&m_aPlayerHasInput, sizeof(m_aPlayerHasInput));
 
 	m_pController = 0;
@@ -192,7 +192,7 @@ void CGameContext::FillAntibot(CAntibotRoundData *pData)
 		Collision()->FillAntibot(&pData->m_Map);
 	}
 	pData->m_Tick = Server()->Tick();
-	mem_zero(pData->m_aCharacters, sizeof(pData->m_aCharacters));
+	new(pData->m_aCharacters) std::remove_pointer<decltype(pData->m_aCharacters)>::type;
 	for(int i = 0; i < MAX_CLIENTS; i++)
 	{
 		CAntibotCharacterData *pChar = &pData->m_aCharacters[i];
@@ -1394,7 +1394,7 @@ void CGameContext::OnClientEnter(int ClientID)
 	Server()->ExpireServerInfo();
 
 	CPlayer *pNewPlayer = m_apPlayers[ClientID];
-	mem_zero(&m_aLastPlayerInput[ClientID], sizeof(m_aLastPlayerInput[ClientID]));
+	m_aLastPlayerInput[ClientID] = CNetObj_PlayerInput();
 	m_aPlayerHasInput[ClientID] = false;
 
 	// new info for others

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -35,9 +35,9 @@
 // Not thread-safe!
 class CClientChatLogger : public ILogger
 {
-	CGameContext *m_pGameServer;
-	int m_ClientID;
-	ILogger *m_pOuterLogger;
+	CGameContext *m_pGameServer = nullptr;
+	int m_ClientID = 0;
+	ILogger *m_pOuterLogger = nullptr;
 
 public:
 	CClientChatLogger(CGameContext *pGameServer, int ClientID, ILogger *pOuterLogger) :
@@ -87,7 +87,7 @@ void CGameContext::Construct(int Resetting)
 	m_NumVoteOptions = 0;
 	m_LastMapVote = 0;
 
-	m_SqlRandomMapResult = nullptr;
+	m_pSqlRandomMapResult = nullptr;
 
 	m_pScore = nullptr;
 	m_NumMutes = 0;
@@ -1086,18 +1086,18 @@ void CGameContext::OnTick()
 		}
 	}
 
-	if(m_SqlRandomMapResult != nullptr && m_SqlRandomMapResult->m_Completed)
+	if(m_pSqlRandomMapResult != nullptr && m_pSqlRandomMapResult->m_Completed)
 	{
-		if(m_SqlRandomMapResult->m_Success)
+		if(m_pSqlRandomMapResult->m_Success)
 		{
-			if(PlayerExists(m_SqlRandomMapResult->m_ClientID) && m_SqlRandomMapResult->m_aMessage[0] != '\0')
-				SendChatTarget(m_SqlRandomMapResult->m_ClientID, m_SqlRandomMapResult->m_aMessage);
-			if(m_SqlRandomMapResult->m_aMap[0] != '\0')
-				Server()->ChangeMap(m_SqlRandomMapResult->m_aMap);
+			if(PlayerExists(m_pSqlRandomMapResult->m_ClientID) && m_pSqlRandomMapResult->m_aMessage[0] != '\0')
+				SendChatTarget(m_pSqlRandomMapResult->m_ClientID, m_pSqlRandomMapResult->m_aMessage);
+			if(m_pSqlRandomMapResult->m_aMap[0] != '\0')
+				Server()->ChangeMap(m_pSqlRandomMapResult->m_aMap);
 			else
 				m_LastMapVote = 0;
 		}
-		m_SqlRandomMapResult = nullptr;
+		m_pSqlRandomMapResult = nullptr;
 	}
 
 #ifdef CONF_DEBUG
@@ -1409,7 +1409,7 @@ void CGameContext::OnClientEnter(int ClientID)
 
 	for(int p = 0; p < 6; p++)
 	{
-		NewClientInfoMsg.m_apSkinPartNames[p] = pNewPlayer->m_TeeInfos.m_apSkinPartNames[p];
+		NewClientInfoMsg.m_apSkinPartNames[p] = &pNewPlayer->m_TeeInfos.m_aaSkinPartNames[p][0];
 		NewClientInfoMsg.m_aUseCustomColors[p] = pNewPlayer->m_TeeInfos.m_aUseCustomColors[p];
 		NewClientInfoMsg.m_aSkinPartColors[p] = pNewPlayer->m_TeeInfos.m_aSkinPartColors[p];
 	}
@@ -1439,7 +1439,7 @@ void CGameContext::OnClientEnter(int ClientID)
 
 			for(int p = 0; p < 6; p++)
 			{
-				ClientInfoMsg.m_apSkinPartNames[p] = pPlayer->m_TeeInfos.m_apSkinPartNames[p];
+				ClientInfoMsg.m_apSkinPartNames[p] = &pPlayer->m_TeeInfos.m_aaSkinPartNames[p][0];
 				ClientInfoMsg.m_aUseCustomColors[p] = pPlayer->m_TeeInfos.m_aUseCustomColors[p];
 				ClientInfoMsg.m_aSkinPartColors[p] = pPlayer->m_TeeInfos.m_aSkinPartColors[p];
 			}
@@ -2380,7 +2380,7 @@ void CGameContext::OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID)
 
 				for(int p = 0; p < 6; p++)
 				{
-					Info.m_apSkinPartNames[p] = pPlayer->m_TeeInfos.m_apSkinPartNames[p];
+					Info.m_apSkinPartNames[p] = &pPlayer->m_TeeInfos.m_aaSkinPartNames[p][0];
 					Info.m_aSkinPartColors[p] = pPlayer->m_TeeInfos.m_aSkinPartColors[p];
 					Info.m_aUseCustomColors[p] = pPlayer->m_TeeInfos.m_aUseCustomColors[p];
 				}
@@ -2400,7 +2400,7 @@ void CGameContext::OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID)
 				Msg.m_ClientID = ClientID;
 				for(int p = 0; p < 6; p++)
 				{
-					Msg.m_apSkinPartNames[p] = pPlayer->m_TeeInfos.m_apSkinPartNames[p];
+					Msg.m_apSkinPartNames[p] = &pPlayer->m_TeeInfos.m_aaSkinPartNames[p][0];
 					Msg.m_aSkinPartColors[p] = pPlayer->m_TeeInfos.m_aSkinPartColors[p];
 					Msg.m_aUseCustomColors[p] = pPlayer->m_TeeInfos.m_aUseCustomColors[p];
 				}
@@ -3072,7 +3072,7 @@ void CGameContext::ConClearVotes(IConsole::IResult *pResult, void *pUserData)
 
 struct CMapNameItem
 {
-	char m_aName[IO_MAX_PATH_LENGTH - 4];
+	char m_aName[IO_MAX_PATH_LENGTH - 4] = {0};
 
 	bool operator<(const CMapNameItem &Other) const { return str_comp_nocase(m_aName, Other.m_aName) < 0; }
 };

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -61,12 +61,12 @@ struct CScoreRandomMapResult;
 
 class CGameContext : public IGameServer
 {
-	IServer *m_pServer;
-	CConfig *m_pConfig;
-	IConsole *m_pConsole;
-	IEngine *m_pEngine;
-	IStorage *m_pStorage;
-	IAntibot *m_pAntibot;
+	IServer *m_pServer = nullptr;
+	CConfig *m_pConfig = nullptr;
+	IConsole *m_pConsole = nullptr;
+	IEngine *m_pEngine = nullptr;
+	IStorage *m_pStorage = nullptr;
+	IAntibot *m_pAntibot = nullptr;
 	CLayers m_Layers;
 	CCollision m_Collision;
 	protocol7::CNetObjHandler m_NetObjHandler7;
@@ -75,14 +75,14 @@ class CGameContext : public IGameServer
 	CTuningParams m_aTuningList[NUM_TUNEZONES];
 	std::vector<std::string> m_vCensorlist;
 
-	bool m_TeeHistorianActive;
+	bool m_TeeHistorianActive = false;
 	CTeeHistorian m_TeeHistorian;
-	ASYNCIO *m_pTeeHistorianFile;
+	ASYNCIO *m_pTeeHistorianFile = nullptr;
 	CUuid m_GameUuid;
 	CMapBugs m_MapBugs;
 	CPrng m_Prng;
 
-	bool m_Resetting;
+	bool m_Resetting = false;
 
 	static void CommandCallback(int ClientID, int FlagMask, const char *pCmd, IConsole::IResult *pResult, void *pUser);
 	static void TeeHistorianWrite(const void *pData, int DataSize, void *pUser);
@@ -125,7 +125,7 @@ class CGameContext : public IGameServer
 
 	struct CPersistentClientData
 	{
-		bool m_IsSpectator;
+		bool m_IsSpectator = false;
 	};
 
 public:
@@ -148,16 +148,16 @@ public:
 	void Clear();
 
 	CEventHandler m_Events;
-	CPlayer *m_apPlayers[MAX_CLIENTS];
+	CPlayer *m_apPlayers[MAX_CLIENTS] = {nullptr};
 	// keep last input to always apply when none is sent
 	CNetObj_PlayerInput m_aLastPlayerInput[MAX_CLIENTS];
-	bool m_aPlayerHasInput[MAX_CLIENTS];
+	bool m_aPlayerHasInput[MAX_CLIENTS] = {false};
 
 	// returns last input if available otherwise nulled PlayerInput object
 	// ClientID has to be valid
 	CNetObj_PlayerInput GetLastPlayerInput(int ClientID) const;
 
-	IGameController *m_pController;
+	IGameController *m_pController = nullptr;
 	CGameWorld m_World;
 
 	// helper functions
@@ -172,21 +172,21 @@ public:
 	void SendVoteStatus(int ClientID, int Total, int Yes, int No);
 	void AbortVoteKickOnDisconnect(int ClientID);
 
-	int m_VoteCreator;
-	int m_VoteType;
-	int64_t m_VoteCloseTime;
-	bool m_VoteUpdate;
-	int m_VotePos;
-	char m_aVoteDescription[VOTE_DESC_LENGTH];
-	char m_aSixupVoteDescription[VOTE_DESC_LENGTH];
-	char m_aVoteCommand[VOTE_CMD_LENGTH];
-	char m_aVoteReason[VOTE_REASON_LENGTH];
-	int m_NumVoteOptions;
-	int m_VoteEnforce;
-	char m_aaZoneEnterMsg[NUM_TUNEZONES][256]; // 0 is used for switching from or to area without tunings
-	char m_aaZoneLeaveMsg[NUM_TUNEZONES][256];
+	int m_VoteCreator = 0;
+	int m_VoteType = 0;
+	int64_t m_VoteCloseTime = 0;
+	bool m_VoteUpdate = false;
+	int m_VotePos = 0;
+	char m_aVoteDescription[VOTE_DESC_LENGTH] = {0};
+	char m_aSixupVoteDescription[VOTE_DESC_LENGTH] = {0};
+	char m_aVoteCommand[VOTE_CMD_LENGTH] = {0};
+	char m_aVoteReason[VOTE_REASON_LENGTH] = {0};
+	int m_NumVoteOptions = 0;
+	int m_VoteEnforce = 0;
+	char m_aaZoneEnterMsg[NUM_TUNEZONES][256] = {{0}}; // 0 is used for switching from or to area without tunings
+	char m_aaZoneLeaveMsg[NUM_TUNEZONES][256] = {{0}};
 
-	char m_aDeleteTempfile[128];
+	char m_aDeleteTempfile[128] = {0};
 	void DeleteTempfile();
 
 	enum
@@ -196,9 +196,9 @@ public:
 		VOTE_ENFORCE_YES,
 		VOTE_ENFORCE_ABORT,
 	};
-	CHeap *m_pVoteOptionHeap;
-	CVoteOptionServer *m_pVoteOptionFirst;
-	CVoteOptionServer *m_pVoteOptionLast;
+	CHeap *m_pVoteOptionHeap = nullptr;
+	CVoteOptionServer *m_pVoteOptionFirst = nullptr;
+	CVoteOptionServer *m_pVoteOptionLast = nullptr;
 
 	// helper functions
 	void CreateDamageInd(vec2 Pos, float AngleMod, int Amount, int64_t Mask = -1);
@@ -289,8 +289,8 @@ public:
 	int ProcessSpamProtection(int ClientID, bool RespectChatInitialDelay = true);
 	int GetDDRaceTeam(int ClientID);
 	// Describes the time when the first player joined the server.
-	int64_t m_NonEmptySince;
-	int64_t m_LastMapVote;
+	int64_t m_NonEmptySince = 0;
+	int64_t m_LastMapVote = 0;
 	int GetClientVersion(int ClientID) const;
 	int64_t ClientsMaskExcludeClientVersionAndHigher(int Version);
 	bool PlayerExists(int ClientID) const override { return m_apPlayers[ClientID]; }
@@ -302,13 +302,13 @@ public:
 	bool RateLimitPlayerVote(int ClientID);
 	bool RateLimitPlayerMapVote(int ClientID);
 
-	std::shared_ptr<CScoreRandomMapResult> m_SqlRandomMapResult;
+	std::shared_ptr<CScoreRandomMapResult> m_pSqlRandomMapResult = nullptr;
 
 private:
 	// starting 1 to make 0 the special value "no client id"
 	uint32_t NextUniqueClientID = 1;
-	bool m_VoteWillPass;
-	CScore *m_pScore;
+	bool m_VoteWillPass = false;
+	CScore *m_pScore = nullptr;
 
 	//DDRace Console Commands
 
@@ -427,15 +427,15 @@ private:
 	struct CMute
 	{
 		NETADDR m_Addr;
-		int m_Expire;
-		char m_aReason[128];
-		bool m_InitialChatDelay;
+		int m_Expire = 0;
+		char m_aReason[128] = {0};
+		bool m_InitialChatDelay = false;
 	};
 
 	CMute m_aMutes[MAX_MUTES];
-	int m_NumMutes;
+	int m_NumMutes = 0;
 	CMute m_aVoteMutes[MAX_VOTE_MUTES];
-	int m_NumVoteMutes;
+	int m_NumVoteMutes = 0;
 	bool TryMute(const NETADDR *pAddr, int Secs, const char *pReason, bool InitialChatDelay);
 	void Mute(const NETADDR *pAddr, int Secs, const char *pDisplayName, const char *pReason = "", bool InitialChatDelay = false);
 	bool TryVoteMute(const NETADDR *pAddr, int Secs);
@@ -461,8 +461,8 @@ public:
 		VOTE_TYPE_KICK,
 		VOTE_TYPE_SPECTATE,
 	};
-	int m_VoteVictim;
-	int m_VoteEnforcer;
+	int m_VoteVictim = 0;
+	int m_VoteEnforcer = 0;
 
 	inline bool IsOptionVote() const { return m_VoteType == VOTE_TYPE_OPTION; }
 	inline bool IsKickVote() const { return m_VoteType == VOTE_TYPE_KICK; }

--- a/src/game/server/gamecontroller.h
+++ b/src/game/server/gamecontroller.h
@@ -16,11 +16,11 @@ class IGameController
 	friend class CSaveTeam; // need access to GameServer() and Server()
 
 	vec2 m_aaSpawnPoints[3][64];
-	int m_aNumSpawnPoints[3];
+	int m_aNumSpawnPoints[3] = {0};
 
-	class CGameContext *m_pGameServer;
-	class CConfig *m_pConfig;
-	class IServer *m_pServer;
+	class CGameContext *m_pGameServer = nullptr;
+	class CConfig *m_pConfig = nullptr;
+	class IServer *m_pServer = nullptr;
 
 protected:
 	CGameContext *GameServer() const { return m_pGameServer; }
@@ -39,9 +39,9 @@ protected:
 		}
 
 		vec2 m_Pos;
-		bool m_Got;
-		int m_FriendlyTeam;
-		float m_Score;
+		bool m_Got = false;
+		int m_FriendlyTeam = 0;
+		float m_Score = 0;
 	};
 
 	float EvaluateSpawnPos(CSpawnEval *pEval, vec2 Pos, int DDTeam);
@@ -49,21 +49,21 @@ protected:
 
 	void ResetGame();
 
-	char m_aMapWish[MAX_MAP_LENGTH];
+	char m_aMapWish[MAX_MAP_LENGTH] = {0};
 
-	int m_RoundStartTick;
-	int m_GameOverTick;
-	int m_SuddenDeath;
+	int m_RoundStartTick = 0;
+	int m_GameOverTick = 0;
+	int m_SuddenDeath = 0;
 
-	int m_Warmup;
-	int m_RoundCount;
+	int m_Warmup = 0;
+	int m_RoundCount = 0;
 
-	int m_GameFlags;
-	int m_UnbalancedTick;
-	bool m_ForceBalanced;
+	int m_GameFlags = 0;
+	int m_UnbalancedTick = 0;
+	bool m_ForceBalanced = false;
 
 public:
-	const char *m_pGameType;
+	const char *m_pGameType = nullptr;
 
 	IGameController(class CGameContext *pGameServer);
 	virtual ~IGameController();
@@ -146,7 +146,7 @@ public:
 
 	// DDRace
 
-	float m_CurrentRecord;
+	float m_CurrentRecord = 0;
 };
 
 #endif

--- a/src/game/server/gamemodes/DDRace.h
+++ b/src/game/server/gamemodes/DDRace.h
@@ -38,6 +38,6 @@ public:
 	std::map<int, std::vector<vec2>> m_TeleOuts;
 	std::map<int, std::vector<vec2>> m_TeleCheckOuts;
 
-	std::shared_ptr<CScoreInitResult> m_pInitResult;
+	std::shared_ptr<CScoreInitResult> m_pInitResult = nullptr;
 };
 #endif // GAME_SERVER_GAMEMODES_DDRACE_H

--- a/src/game/server/gameworld.h
+++ b/src/game/server/gameworld.h
@@ -33,11 +33,11 @@ private:
 	void RemoveEntities();
 
 	CEntity *m_pNextTraverseEntity = nullptr;
-	CEntity *m_apFirstEntityTypes[NUM_ENTTYPES];
+	CEntity *m_apFirstEntityTypes[NUM_ENTTYPES] = {nullptr};
 
-	class CGameContext *m_pGameServer;
-	class CConfig *m_pConfig;
-	class IServer *m_pServer;
+	class CGameContext *m_pGameServer = nullptr;
+	class CConfig *m_pConfig = nullptr;
+	class IServer *m_pServer = nullptr;
 
 	void UpdatePlayerMaps();
 
@@ -46,8 +46,8 @@ public:
 	class CConfig *Config() { return m_pConfig; }
 	class IServer *Server() { return m_pServer; }
 
-	bool m_ResetRequested;
-	bool m_Paused;
+	bool m_ResetRequested = false;
+	bool m_Paused = false;
 	CWorldCore m_Core;
 
 	CGameWorld();

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -126,8 +126,8 @@ void CPlayer::Reset()
 	// Variable initialized:
 	m_Last_Team = 0;
 	m_LastSQLQuery = 0;
-	m_ScoreQueryResult = nullptr;
-	m_ScoreFinishResult = nullptr;
+	m_pScoreQueryResult = nullptr;
+	m_pScoreFinishResult = nullptr;
 
 	int64_t Now = Server()->Tick();
 	int64_t TickSpeed = Server()->TickSpeed();
@@ -161,15 +161,15 @@ static int PlayerFlags_SixToSeven(int Flags)
 
 void CPlayer::Tick()
 {
-	if(m_ScoreQueryResult != nullptr && m_ScoreQueryResult->m_Completed)
+	if(m_pScoreQueryResult != nullptr && m_pScoreQueryResult->m_Completed)
 	{
-		ProcessScoreResult(*m_ScoreQueryResult);
-		m_ScoreQueryResult = nullptr;
+		ProcessScoreResult(*m_pScoreQueryResult);
+		m_pScoreQueryResult = nullptr;
 	}
-	if(m_ScoreFinishResult != nullptr && m_ScoreFinishResult->m_Completed)
+	if(m_pScoreFinishResult != nullptr && m_pScoreFinishResult->m_Completed)
 	{
-		ProcessScoreResult(*m_ScoreFinishResult);
-		m_ScoreFinishResult = nullptr;
+		ProcessScoreResult(*m_pScoreFinishResult);
+		m_pScoreFinishResult = nullptr;
 	}
 
 	bool ClientIngame = Server()->ClientIngame(m_ClientID);

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -67,84 +67,84 @@ public:
 	//---------------------------------------------------------
 	// this is used for snapping so we know how we can clip the view for the player
 	vec2 m_ViewPos;
-	int m_TuneZone;
-	int m_TuneZoneOld;
+	int m_TuneZone = 0;
+	int m_TuneZoneOld = 0;
 
 	// states if the client is chatting, accessing a menu etc.
-	int m_PlayerFlags;
+	int m_PlayerFlags = 0;
 
 	// used for snapping to just update latency if the scoreboard is active
-	int m_aCurLatency[MAX_CLIENTS];
+	int m_aCurLatency[MAX_CLIENTS] = {0};
 
 	// used for spectator mode
-	int m_SpectatorID;
+	int m_SpectatorID = 0;
 
-	bool m_IsReady;
+	bool m_IsReady = false;
 
 	//
-	int m_Vote;
-	int m_VotePos;
+	int m_Vote = 0;
+	int m_VotePos = 0;
 	//
-	int m_LastVoteCall;
-	int m_LastVoteTry;
-	int m_LastChat;
-	int m_LastSetTeam;
-	int m_LastSetSpectatorMode;
-	int m_LastChangeInfo;
-	int m_LastEmote;
-	int m_LastKill;
-	int m_aLastCommands[4];
-	int m_LastCommandPos;
-	int m_LastWhisperTo;
-	int m_LastInvited;
+	int m_LastVoteCall = 0;
+	int m_LastVoteTry = 0;
+	int m_LastChat = 0;
+	int m_LastSetTeam = 0;
+	int m_LastSetSpectatorMode = 0;
+	int m_LastChangeInfo = 0;
+	int m_LastEmote = 0;
+	int m_LastKill = 0;
+	int m_aLastCommands[4] = {0};
+	int m_LastCommandPos = 0;
+	int m_LastWhisperTo = 0;
+	int m_LastInvited = 0;
 
-	int m_SendVoteIndex;
+	int m_SendVoteIndex = 0;
 
 	CTeeInfo m_TeeInfos;
 
-	int m_DieTick;
-	int m_PreviousDieTick;
-	int m_Score;
-	int m_JoinTick;
-	bool m_ForceBalanced;
-	int m_LastActionTick;
-	int m_TeamChangeTick;
-	bool m_SentSemicolonTip;
+	int m_DieTick = 0;
+	int m_PreviousDieTick = 0;
+	int m_Score = 0;
+	int m_JoinTick = 0;
+	bool m_ForceBalanced = false;
+	int m_LastActionTick = 0;
+	int m_TeamChangeTick = 0;
+	bool m_SentSemicolonTip = false;
 
 	// network latency calculations
 	struct
 	{
-		int m_Accum;
-		int m_AccumMin;
-		int m_AccumMax;
-		int m_Avg;
-		int m_Min;
-		int m_Max;
+		int m_Accum = 0;
+		int m_AccumMin = 0;
+		int m_AccumMax = 0;
+		int m_Avg = 0;
+		int m_Min = 0;
+		int m_Max = 0;
 	} m_Latency;
 
 private:
-	const uint32_t m_UniqueClientID;
-	CCharacter *m_pCharacter;
-	int m_NumInputs;
-	CGameContext *m_pGameServer;
+	const uint32_t m_UniqueClientID = 0;
+	CCharacter *m_pCharacter = nullptr;
+	int m_NumInputs = 0;
+	CGameContext *m_pGameServer = nullptr;
 
 	CGameContext *GameServer() const { return m_pGameServer; }
 	IServer *Server() const;
 
 	//
-	bool m_Spawning;
-	bool m_WeakHookSpawn;
-	int m_ClientID;
-	int m_Team;
+	bool m_Spawning = false;
+	bool m_WeakHookSpawn = false;
+	int m_ClientID = 0;
+	int m_Team = 0;
 
-	int m_Paused;
-	int64_t m_ForcePauseTime;
-	int64_t m_LastPause;
+	int m_Paused = 0;
+	int64_t m_ForcePauseTime = 0;
+	int64_t m_LastPause = 0;
 
-	int m_DefEmote;
-	int m_OverrideEmote;
-	int m_OverrideEmoteReset;
-	bool m_Halloween;
+	int m_DefEmote = 0;
+	int m_OverrideEmote = 0;
+	int m_OverrideEmoteReset = 0;
+	bool m_Halloween = false;
 
 public:
 	enum
@@ -164,9 +164,9 @@ public:
 		TIMERTYPE_NONE,
 	};
 
-	bool m_DND;
-	int64_t m_FirstVoteTick;
-	char m_aTimeoutCode[64];
+	bool m_DND = false;
+	int64_t m_FirstVoteTick = 0;
+	char m_aTimeoutCode[64] = {0};
 
 	void ProcessPause();
 	int Pause(int State, bool Force);
@@ -174,47 +174,47 @@ public:
 	int IsPaused();
 
 	bool IsPlaying();
-	int64_t m_Last_KickVote;
-	int64_t m_Last_Team;
-	int m_ShowOthers;
-	bool m_ShowAll;
+	int64_t m_Last_KickVote = 0;
+	int64_t m_Last_Team = 0;
+	int m_ShowOthers = 0;
+	bool m_ShowAll = false;
 	vec2 m_ShowDistance;
-	bool m_SpecTeam;
-	bool m_NinjaJetpack;
-	bool m_Afk;
-	bool m_HasFinishScore;
+	bool m_SpecTeam = false;
+	bool m_NinjaJetpack = false;
+	bool m_Afk = false;
+	bool m_HasFinishScore = false;
 
-	int m_ChatScore;
+	int m_ChatScore = 0;
 
-	bool m_Moderating;
+	bool m_Moderating = false;
 
 	void UpdatePlaytime();
 	void AfkTimer();
-	int64_t m_LastPlaytime;
-	int64_t m_LastEyeEmote;
-	int64_t m_LastBroadcast;
-	bool m_LastBroadcastImportance;
+	int64_t m_LastPlaytime = 0;
+	int64_t m_LastEyeEmote = 0;
+	int64_t m_LastBroadcast = 0;
+	bool m_LastBroadcastImportance = false;
 
-	CNetObj_PlayerInput *m_pLastTarget;
-	bool m_LastTargetInit;
+	CNetObj_PlayerInput *m_pLastTarget = nullptr;
+	bool m_LastTargetInit = false;
 
-	bool m_EyeEmoteEnabled;
-	int m_TimerType;
+	bool m_EyeEmoteEnabled = false;
+	int m_TimerType = 0;
 
 	int GetDefaultEmote() const;
 	void OverrideDefaultEmote(int Emote, int Tick);
 	bool CanOverrideDefaultEmote() const;
 
-	bool m_FirstPacket;
-	int64_t m_LastSQLQuery;
+	bool m_FirstPacket = false;
+	int64_t m_LastSQLQuery = 0;
 	void ProcessScoreResult(CScorePlayerResult &Result);
-	std::shared_ptr<CScorePlayerResult> m_ScoreQueryResult;
-	std::shared_ptr<CScorePlayerResult> m_ScoreFinishResult;
-	bool m_NotEligibleForFinish;
-	int64_t m_EligibleForFinishCheck;
-	bool m_VotedForPractice;
-	int m_SwapTargetsClientID; //Client ID of the swap target for the given player
-	bool m_BirthdayAnnounced;
+	std::shared_ptr<CScorePlayerResult> m_pScoreQueryResult = nullptr;
+	std::shared_ptr<CScorePlayerResult> m_pScoreFinishResult = nullptr;
+	bool m_NotEligibleForFinish = false;
+	int64_t m_EligibleForFinishCheck = 0;
+	bool m_VotedForPractice = false;
+	int m_SwapTargetsClientID = 0; //Client ID of the swap target for the given player
+	bool m_BirthdayAnnounced = false;
 };
 
 #endif

--- a/src/game/server/save.h
+++ b/src/game/server/save.h
@@ -37,87 +37,87 @@ public:
 	};
 
 private:
-	int m_ClientID;
+	int m_ClientID = 0;
 
-	char m_aString[2048];
-	char m_aName[16];
+	char m_aString[2048] = {0};
+	char m_aName[16] = {0};
 
-	int m_Alive;
-	int m_Paused;
-	int m_NeededFaketuning;
+	int m_Alive = 0;
+	int m_Paused = 0;
+	int m_NeededFaketuning = 0;
 
 	// Teamstuff
-	int m_TeeStarted;
-	int m_TeeFinished;
-	int m_IsSolo;
+	int m_TeeStarted = 0;
+	int m_TeeFinished = 0;
+	int m_IsSolo = 0;
 
 	struct WeaponStat
 	{
-		int m_AmmoRegenStart;
-		int m_Ammo;
-		int m_Ammocost;
-		int m_Got;
+		int m_AmmoRegenStart = 0;
+		int m_Ammo = 0;
+		int m_Ammocost = 0;
+		int m_Got = 0;
 	} m_aWeapons[NUM_WEAPONS];
 
-	int m_LastWeapon;
-	int m_QueuedWeapon;
+	int m_LastWeapon = 0;
+	int m_QueuedWeapon = 0;
 
-	int m_EndlessJump;
-	int m_Jetpack;
-	int m_NinjaJetpack;
-	int m_FreezeTime;
-	int m_FreezeStart;
-	int m_DeepFrozen;
-	int m_LiveFrozen;
-	int m_EndlessHook;
-	int m_DDRaceState;
+	int m_EndlessJump = 0;
+	int m_Jetpack = 0;
+	int m_NinjaJetpack = 0;
+	int m_FreezeTime = 0;
+	int m_FreezeStart = 0;
+	int m_DeepFrozen = 0;
+	int m_LiveFrozen = 0;
+	int m_EndlessHook = 0;
+	int m_DDRaceState = 0;
 
-	int m_HitDisabledFlags;
-	int m_CollisionEnabled;
-	int m_TuneZone;
-	int m_TuneZoneOld;
-	int m_HookHitEnabled;
-	int m_Time;
+	int m_HitDisabledFlags = 0;
+	int m_CollisionEnabled = 0;
+	int m_TuneZone = 0;
+	int m_TuneZoneOld = 0;
+	int m_HookHitEnabled = 0;
+	int m_Time = 0;
 	vec2 m_Pos;
 	vec2 m_PrevPos;
-	int m_TeleCheckpoint;
-	int m_LastPenalty;
+	int m_TeleCheckpoint = 0;
+	int m_LastPenalty = 0;
 
-	int m_TimeCpBroadcastEndTime;
-	int m_LastTimeCp;
-	int m_LastTimeCpBroadcasted;
-	float m_aCurrentTimeCp[MAX_CHECKPOINTS];
+	int m_TimeCpBroadcastEndTime = 0;
+	int m_LastTimeCp = 0;
+	int m_LastTimeCpBroadcasted = 0;
+	float m_aCurrentTimeCp[MAX_CHECKPOINTS] = {0};
 
-	int m_NotEligibleForFinish;
+	int m_NotEligibleForFinish = 0;
 
-	int m_HasTelegunGun;
-	int m_HasTelegunGrenade;
-	int m_HasTelegunLaser;
+	int m_HasTelegunGun = 0;
+	int m_HasTelegunGrenade = 0;
+	int m_HasTelegunLaser = 0;
 
 	// Core
 	vec2 m_CorePos;
 	vec2 m_Vel;
-	int m_ActiveWeapon;
-	int m_Jumped;
-	int m_JumpedTotal;
-	int m_Jumps;
+	int m_ActiveWeapon = 0;
+	int m_Jumped = 0;
+	int m_JumpedTotal = 0;
+	int m_Jumps = 0;
 	vec2 m_HookPos;
 	vec2 m_HookDir;
 	vec2 m_HookTeleBase;
-	int m_HookTick;
-	int m_HookState;
-	int m_HookedPlayer;
-	int m_NewHook;
+	int m_HookTick = 0;
+	int m_HookState = 0;
+	int m_HookedPlayer = 0;
+	int m_NewHook = 0;
 
 	// player input
-	int m_InputDirection;
-	int m_InputJump;
-	int m_InputFire;
-	int m_InputHook;
+	int m_InputDirection = 0;
+	int m_InputJump = 0;
+	int m_InputFire = 0;
+	int m_InputHook = 0;
 
-	int m_ReloadTimer;
+	int m_ReloadTimer = 0;
 
-	char m_aGameUuid[UUID_MAXSTRSIZE];
+	char m_aGameUuid[UUID_MAXSTRSIZE] = {0};
 };
 
 class CSaveTeam
@@ -133,7 +133,7 @@ public:
 	bool MatchPlayers(const char (*paNames)[MAX_NAME_LENGTH], const int *pClientID, int NumPlayer, char *pMessage, int MessageLen);
 	int Save(int Team);
 	void Load(int Team, bool KeepCurrentWeakStrong);
-	CSaveTee *m_pSavedTees;
+	CSaveTee *m_pSavedTees = nullptr;
 
 	// returns true if an error occured
 	static bool HandleSaveError(int Result, int ClientID, CGameContext *pGameContext);
@@ -141,23 +141,23 @@ public:
 private:
 	CCharacter *MatchCharacter(int ClientID, int SaveID, bool KeepCurrentCharacter);
 
-	IGameController *m_pController;
+	IGameController *m_pController = nullptr;
 
-	char m_aString[65536];
+	char m_aString[65536] = {0};
 
 	struct SSimpleSwitchers
 	{
-		int m_Status;
-		int m_EndTime;
-		int m_Type;
+		int m_Status = 0;
+		int m_EndTime = 0;
+		int m_Type = 0;
 	};
-	SSimpleSwitchers *m_pSwitchers;
+	SSimpleSwitchers *m_pSwitchers = nullptr;
 
-	int m_TeamState;
-	int m_MembersCount;
-	int m_HighestSwitchNumber;
-	int m_TeamLocked;
-	int m_Practice;
+	int m_TeamState = 0;
+	int m_MembersCount = 0;
+	int m_HighestSwitchNumber = 0;
+	int m_TeamLocked = 0;
+	int m_Practice = 0;
 };
 
 #endif // GAME_SERVER_SAVE_H

--- a/src/game/server/score.cpp
+++ b/src/game/server/score.cpp
@@ -19,10 +19,10 @@ class IDbConnection;
 std::shared_ptr<CScorePlayerResult> CScore::NewSqlPlayerResult(int ClientID)
 {
 	CPlayer *pCurPlayer = GameServer()->m_apPlayers[ClientID];
-	if(pCurPlayer->m_ScoreQueryResult != nullptr) // TODO: send player a message: "too many requests"
+	if(pCurPlayer->m_pScoreQueryResult != nullptr) // TODO: send player a message: "too many requests"
 		return nullptr;
-	pCurPlayer->m_ScoreQueryResult = std::make_shared<CScorePlayerResult>();
-	return pCurPlayer->m_ScoreQueryResult;
+	pCurPlayer->m_pScoreQueryResult = std::make_shared<CScorePlayerResult>();
+	return pCurPlayer->m_pScoreQueryResult;
 }
 
 void CScore::ExecPlayerThread(
@@ -139,10 +139,10 @@ void CScore::SaveScore(int ClientID, float Time, const char *pTimestamp, float a
 		return;
 
 	CPlayer *pCurPlayer = GameServer()->m_apPlayers[ClientID];
-	if(pCurPlayer->m_ScoreFinishResult != nullptr)
+	if(pCurPlayer->m_pScoreFinishResult != nullptr)
 		dbg_msg("sql", "WARNING: previous save score result didn't complete, overwriting it now");
-	pCurPlayer->m_ScoreFinishResult = std::make_shared<CScorePlayerResult>();
-	auto Tmp = std::make_unique<CSqlScoreData>(pCurPlayer->m_ScoreFinishResult);
+	pCurPlayer->m_pScoreFinishResult = std::make_shared<CScorePlayerResult>();
+	auto Tmp = std::make_unique<CSqlScoreData>(pCurPlayer->m_pScoreFinishResult);
 	str_copy(Tmp->m_aMap, g_Config.m_SvMap, sizeof(Tmp->m_aMap));
 	FormatUuid(GameServer()->GameUuid(), Tmp->m_aGameUuid, sizeof(Tmp->m_aGameUuid));
 	Tmp->m_ClientID = ClientID;
@@ -243,7 +243,7 @@ void CScore::ShowTopPoints(int ClientID, int Offset)
 void CScore::RandomMap(int ClientID, int Stars)
 {
 	auto pResult = std::make_shared<CScoreRandomMapResult>(ClientID);
-	GameServer()->m_SqlRandomMapResult = pResult;
+	GameServer()->m_pSqlRandomMapResult = pResult;
 
 	auto Tmp = std::make_unique<CSqlRandomMapRequest>(pResult);
 	Tmp->m_Stars = Stars;
@@ -257,7 +257,7 @@ void CScore::RandomMap(int ClientID, int Stars)
 void CScore::RandomUnfinishedMap(int ClientID, int Stars)
 {
 	auto pResult = std::make_shared<CScoreRandomMapResult>(ClientID);
-	GameServer()->m_SqlRandomMapResult = pResult;
+	GameServer()->m_pSqlRandomMapResult = pResult;
 
 	auto Tmp = std::make_unique<CSqlRandomMapRequest>(pResult);
 	Tmp->m_Stars = Stars;
@@ -328,7 +328,7 @@ void CScore::LoadTeam(const char *pCode, int ClientID)
 		if(pController->m_Teams.m_Core.Team(i) == Team)
 		{
 			// put all names at the beginning of the array
-			str_copy(Tmp->m_aClientNames[Tmp->m_NumPlayer], Server()->ClientName(i), sizeof(Tmp->m_aClientNames[Tmp->m_NumPlayer]));
+			str_copy(Tmp->m_aaClientNames[Tmp->m_NumPlayer], Server()->ClientName(i), sizeof(Tmp->m_aaClientNames[Tmp->m_NumPlayer]));
 			Tmp->m_aClientID[Tmp->m_NumPlayer] = i;
 			Tmp->m_NumPlayer++;
 		}

--- a/src/game/server/score.h
+++ b/src/game/server/score.h
@@ -14,12 +14,12 @@ struct ISqlData;
 class CScore
 {
 	CPlayerData m_aPlayerData[MAX_CLIENTS];
-	CDbConnectionPool *m_pPool;
+	CDbConnectionPool *m_pPool = nullptr;
 
 	CGameContext *GameServer() const { return m_pGameServer; }
 	IServer *Server() const { return m_pServer; }
-	CGameContext *m_pGameServer;
-	IServer *m_pServer;
+	CGameContext *m_pGameServer = nullptr;
+	IServer *m_pServer = nullptr;
 
 	std::vector<std::string> m_vWordlist;
 	CPrng m_Prng;

--- a/src/game/server/scoreworker.cpp
+++ b/src/game/server/scoreworker.cpp
@@ -1544,7 +1544,7 @@ bool CScoreWorker::LoadTeam(IDbConnection *pSqlServer, const ISqlData *pGameData
 	}
 
 	bool CanLoad = pResult->m_SavedTeam.MatchPlayers(
-		pData->m_aClientNames, pData->m_aClientID, pData->m_NumPlayer,
+		pData->m_aaClientNames, pData->m_aClientID, pData->m_NumPlayer,
 		pResult->m_aMessage, sizeof(pResult->m_aMessage));
 
 	if(!CanLoad)

--- a/src/game/server/scoreworker.cpp
+++ b/src/game/server/scoreworker.cpp
@@ -51,7 +51,7 @@ CTeamrank::CTeamrank() :
 {
 	for(auto &aName : m_aaNames)
 		aName[0] = '\0';
-	mem_zero(&m_TeamID.m_aData, sizeof(m_TeamID));
+	m_TeamID = CUuid();
 }
 
 bool CTeamrank::NextSqlResult(IDbConnection *pSqlServer, bool *pEnd, char *pError, int ErrorSize)

--- a/src/game/server/scoreworker.h
+++ b/src/game/server/scoreworker.h
@@ -45,22 +45,18 @@ struct CScorePlayerResult : ISqlResult
 		char m_aBroadcast[1024] /* = {0} */;
 		struct
 		{
-			float m_Time = 0;
-			float m_aTimeCp[NUM_CHECKPOINTS] = {0};
-			int m_Score = 0;
-			int m_HasFinishScore = 0;
-			int m_Birthday = 0; // 0 indicates no birthday
+			float m_Time;
+			float m_aTimeCp[NUM_CHECKPOINTS];
+			int m_Score;
+			int m_HasFinishScore;
+			int m_Birthday; // 0 indicates no birthday
 		} m_Info;
 		struct
 		{
-			char m_aReason[VOTE_REASON_LENGTH] = {0};
-			char m_aServer[32 + 1] = {0};
-			char m_aMap[MAX_MAP_LENGTH + 1] = {0};
+			char m_aReason[VOTE_REASON_LENGTH];
+			char m_aServer[32 + 1];
+			char m_aMap[MAX_MAP_LENGTH + 1];
 		} m_MapVote;
-		UPlayerInfo()
-		{
-			mem_zero(this, sizeof(*this));
-		}
 	} m_Data; // PLAYER_INFO
 
 	void SetVariant(Variant v);

--- a/src/game/server/scoreworker.h
+++ b/src/game/server/scoreworker.h
@@ -39,24 +39,28 @@ struct CScorePlayerResult : ISqlResult
 		MAP_VOTE,
 		PLAYER_INFO,
 	} m_MessageKind;
-	union
+	union UPlayerInfo
 	{
-		char m_aaMessages[MAX_MESSAGES][512];
-		char m_aBroadcast[1024];
+		char m_aaMessages[MAX_MESSAGES][512] = {{0}};
+		char m_aBroadcast[1024] /* = {0} */;
 		struct
 		{
-			float m_Time;
-			float m_aTimeCp[NUM_CHECKPOINTS];
-			int m_Score;
-			int m_HasFinishScore;
-			int m_Birthday; // 0 indicates no birthday
+			float m_Time = 0;
+			float m_aTimeCp[NUM_CHECKPOINTS] = {0};
+			int m_Score = 0;
+			int m_HasFinishScore = 0;
+			int m_Birthday = 0; // 0 indicates no birthday
 		} m_Info;
 		struct
 		{
-			char m_aReason[VOTE_REASON_LENGTH];
-			char m_aServer[32 + 1];
-			char m_aMap[MAX_MAP_LENGTH + 1];
+			char m_aReason[VOTE_REASON_LENGTH] = {0};
+			char m_aServer[32 + 1] = {0};
+			char m_aMap[MAX_MAP_LENGTH + 1] = {0};
 		} m_MapVote;
+		UPlayerInfo()
+		{
+			mem_zero(this, sizeof(*this));
+		}
 	} m_Data; // PLAYER_INFO
 
 	void SetVariant(Variant v);
@@ -68,7 +72,7 @@ struct CScoreInitResult : ISqlResult
 		m_CurrentRecord(0)
 	{
 	}
-	float m_CurrentRecord;
+	float m_CurrentRecord = 0;
 };
 
 struct CSqlInitData : ISqlData
@@ -79,7 +83,7 @@ struct CSqlInitData : ISqlData
 	}
 
 	// current map
-	char m_aMap[MAX_MAP_LENGTH];
+	char m_aMap[MAX_MAP_LENGTH] = {0};
 };
 
 struct CSqlPlayerRequest : ISqlData
@@ -90,13 +94,13 @@ struct CSqlPlayerRequest : ISqlData
 	}
 
 	// object being requested, either map (128 bytes) or player (16 bytes)
-	char m_aName[MAX_MAP_LENGTH];
+	char m_aName[MAX_MAP_LENGTH] = {0};
 	// current map
-	char m_aMap[MAX_MAP_LENGTH];
-	char m_aRequestingPlayer[MAX_NAME_LENGTH];
+	char m_aMap[MAX_MAP_LENGTH] = {0};
+	char m_aRequestingPlayer[MAX_NAME_LENGTH] = {0};
 	// relevant for /top5 kind of requests
-	int m_Offset;
-	char m_aServer[5];
+	int m_Offset = 0;
+	char m_aServer[5] = {0};
 };
 
 struct CScoreRandomMapResult : ISqlResult
@@ -107,9 +111,9 @@ struct CScoreRandomMapResult : ISqlResult
 		m_aMap[0] = '\0';
 		m_aMessage[0] = '\0';
 	}
-	int m_ClientID;
-	char m_aMap[MAX_MAP_LENGTH];
-	char m_aMessage[512];
+	int m_ClientID = 0;
+	char m_aMap[MAX_MAP_LENGTH] = {0};
+	char m_aMessage[512] = {0};
 };
 
 struct CSqlRandomMapRequest : ISqlData
@@ -119,10 +123,10 @@ struct CSqlRandomMapRequest : ISqlData
 	{
 	}
 
-	char m_aServerType[32];
-	char m_aCurrentMap[MAX_MAP_LENGTH];
-	char m_aRequestingPlayer[MAX_NAME_LENGTH];
-	int m_Stars;
+	char m_aServerType[32] = {0};
+	char m_aCurrentMap[MAX_MAP_LENGTH] = {0};
+	char m_aRequestingPlayer[MAX_NAME_LENGTH] = {0};
+	int m_Stars = 0;
 };
 
 struct CSqlScoreData : ISqlData
@@ -134,17 +138,17 @@ struct CSqlScoreData : ISqlData
 
 	virtual ~CSqlScoreData(){};
 
-	char m_aMap[MAX_MAP_LENGTH];
-	char m_aGameUuid[UUID_MAXSTRSIZE];
-	char m_aName[MAX_MAP_LENGTH];
+	char m_aMap[MAX_MAP_LENGTH] = {0};
+	char m_aGameUuid[UUID_MAXSTRSIZE] = {0};
+	char m_aName[MAX_MAP_LENGTH] = {0};
 
-	int m_ClientID;
-	float m_Time;
-	char m_aTimestamp[TIMESTAMP_STR_LENGTH];
-	float m_aCurrentTimeCp[NUM_CHECKPOINTS];
-	int m_Num;
-	bool m_Search;
-	char m_aRequestingPlayer[MAX_NAME_LENGTH];
+	int m_ClientID = 0;
+	float m_Time = 0;
+	char m_aTimestamp[TIMESTAMP_STR_LENGTH] = {0};
+	float m_aCurrentTimeCp[NUM_CHECKPOINTS] = {0};
+	int m_Num = 0;
+	bool m_Search = false;
+	char m_aRequestingPlayer[MAX_NAME_LENGTH] = {0};
 };
 
 struct CScoreSaveResult : ISqlResult
@@ -165,10 +169,10 @@ struct CScoreSaveResult : ISqlResult
 		LOAD_SUCCESS,
 		LOAD_FAILED,
 	} m_Status;
-	char m_aMessage[512];
-	char m_aBroadcast[512];
+	char m_aMessage[512] = {0};
+	char m_aBroadcast[512] = {0};
 	CSaveTeam m_SavedTeam;
-	int m_RequestingPlayer;
+	int m_RequestingPlayer = 0;
 	CUuid m_SaveID;
 };
 
@@ -179,12 +183,12 @@ struct CSqlTeamScoreData : ISqlData
 	{
 	}
 
-	char m_aGameUuid[UUID_MAXSTRSIZE];
-	char m_aMap[MAX_MAP_LENGTH];
-	float m_Time;
-	char m_aTimestamp[TIMESTAMP_STR_LENGTH];
-	unsigned int m_Size;
-	char m_aaNames[MAX_CLIENTS][MAX_NAME_LENGTH];
+	char m_aGameUuid[UUID_MAXSTRSIZE] = {0};
+	char m_aMap[MAX_MAP_LENGTH] = {0};
+	float m_Time = 0;
+	char m_aTimestamp[TIMESTAMP_STR_LENGTH] = {0};
+	unsigned int m_Size = 0;
+	char m_aaNames[MAX_CLIENTS][MAX_NAME_LENGTH] = {{0}};
 };
 
 struct CSqlTeamSave : ISqlData
@@ -195,11 +199,11 @@ struct CSqlTeamSave : ISqlData
 	}
 	virtual ~CSqlTeamSave(){};
 
-	char m_aClientName[MAX_NAME_LENGTH];
-	char m_aMap[MAX_MAP_LENGTH];
-	char m_aCode[128];
-	char m_aGeneratedCode[128];
-	char m_aServer[5];
+	char m_aClientName[MAX_NAME_LENGTH] = {0};
+	char m_aMap[MAX_MAP_LENGTH] = {0};
+	char m_aCode[128] = {0};
+	char m_aGeneratedCode[128] = {0};
+	char m_aServer[5] = {0};
 };
 
 struct CSqlTeamLoad : ISqlData
@@ -210,14 +214,14 @@ struct CSqlTeamLoad : ISqlData
 	}
 	virtual ~CSqlTeamLoad(){};
 
-	char m_aCode[128];
-	char m_aMap[MAX_MAP_LENGTH];
-	char m_aRequestingPlayer[MAX_NAME_LENGTH];
-	int m_ClientID;
+	char m_aCode[128] = {0};
+	char m_aMap[MAX_MAP_LENGTH] = {0};
+	char m_aRequestingPlayer[MAX_NAME_LENGTH] = {0};
+	int m_ClientID = 0;
 	// struct holding all player names in the team or an empty string
-	char m_aClientNames[MAX_CLIENTS][MAX_NAME_LENGTH];
-	int m_aClientID[MAX_CLIENTS];
-	int m_NumPlayer;
+	char m_aaClientNames[MAX_CLIENTS][MAX_NAME_LENGTH] = {{0}};
+	int m_aClientID[MAX_CLIENTS] = {0};
+	int m_NumPlayer = 0;
 };
 
 class CPlayerData
@@ -243,15 +247,15 @@ public:
 			m_aBestTimeCp[i] = aTimeCp[i];
 	}
 
-	float m_BestTime;
-	float m_aBestTimeCp[NUM_CHECKPOINTS];
+	float m_BestTime = 0;
+	float m_aBestTimeCp[NUM_CHECKPOINTS] = {0};
 };
 
 struct CTeamrank
 {
 	CUuid m_TeamID;
-	char m_aaNames[MAX_CLIENTS][MAX_NAME_LENGTH];
-	unsigned int m_NumNames;
+	char m_aaNames[MAX_CLIENTS][MAX_NAME_LENGTH] = {{0}};
+	unsigned int m_NumNames = 0;
 	CTeamrank();
 
 	// Assumes that a database query equivalent to

--- a/src/game/server/teams.h
+++ b/src/game/server/teams.h
@@ -19,24 +19,24 @@ class CGameTeams
 	// could go around the startline on a map, leave one tee behind at
 	// start, go to the finish line, let the tee start and kill, allowing
 	// the team to finish instantly.
-	bool m_aTeeStarted[MAX_CLIENTS];
-	bool m_aTeeFinished[MAX_CLIENTS];
-	int m_aLastChat[MAX_CLIENTS];
+	bool m_aTeeStarted[MAX_CLIENTS] = {false};
+	bool m_aTeeFinished[MAX_CLIENTS] = {false};
+	int m_aLastChat[MAX_CLIENTS] = {0};
 
-	int m_aTeamState[NUM_TEAMS];
-	bool m_aTeamLocked[NUM_TEAMS];
-	uint64_t m_aInvited[NUM_TEAMS];
-	bool m_aPractice[NUM_TEAMS];
-	std::shared_ptr<CScoreSaveResult> m_apSaveTeamResult[NUM_TEAMS];
-	uint64_t m_aLastSwap[NUM_TEAMS];
-	bool m_aTeamSentStartWarning[NUM_TEAMS];
+	int m_aTeamState[NUM_TEAMS] = {0};
+	bool m_aTeamLocked[NUM_TEAMS] = {false};
+	uint64_t m_aInvited[NUM_TEAMS] = {0};
+	bool m_aPractice[NUM_TEAMS] = {false};
+	std::shared_ptr<CScoreSaveResult> m_apSaveTeamResult[NUM_TEAMS] = {nullptr};
+	uint64_t m_aLastSwap[NUM_TEAMS] = {0};
+	bool m_aTeamSentStartWarning[NUM_TEAMS] = {false};
 	// `m_aTeamUnfinishableKillTick` is -1 by default and gets set when a
 	// team becomes unfinishable. If the team hasn't entered practice mode
 	// by that time, it'll get killed to prevent people not understanding
 	// the message from playing for a long time in an unfinishable team.
-	int m_aTeamUnfinishableKillTick[NUM_TEAMS];
+	int m_aTeamUnfinishableKillTick[NUM_TEAMS] = {0};
 
-	class CGameContext *m_pGameContext;
+	class CGameContext *m_pGameContext = nullptr;
 
 	/**
 	* Kill the whole team.

--- a/src/game/server/teehistorian.h
+++ b/src/game/server/teehistorian.h
@@ -20,22 +20,22 @@ public:
 	struct CGameInfo
 	{
 		CUuid m_GameUuid;
-		const char *m_pServerVersion;
-		time_t m_StartTime;
-		const char *m_pPrngDescription;
+		const char *m_pServerVersion = nullptr;
+		time_t m_StartTime = 0;
+		const char *m_pPrngDescription = nullptr;
 
-		const char *m_pServerName;
-		int m_ServerPort;
-		const char *m_pGameType;
+		const char *m_pServerName = nullptr;
+		int m_ServerPort = 0;
+		const char *m_pGameType = nullptr;
 
-		const char *m_pMapName;
-		int m_MapSize;
+		const char *m_pMapName = nullptr;
+		int m_MapSize = 0;
 		SHA256_DIGEST m_MapSha256;
-		int m_MapCrc;
+		int m_MapCrc = 0;
 
-		CConfig *m_pConfig;
-		CTuningParams *m_pTuning;
-		CUuidManager *m_pUuids;
+		CConfig *m_pConfig = nullptr;
+		CTuningParams *m_pTuning = nullptr;
+		CUuidManager *m_pUuids = nullptr;
 	};
 
 	enum
@@ -84,7 +84,7 @@ public:
 	void RecordAuthLogin(int ClientID, int Level, const char *pAuthName);
 	void RecordAuthLogout(int ClientID);
 
-	int m_Debug; // Possible values: 0, 1, 2.
+	int m_Debug = 0; // Possible values: 0, 1, 2.
 
 private:
 	void WriteHeader(const CGameInfo *pGameInfo);
@@ -108,32 +108,32 @@ private:
 
 	struct CTeehistorianPlayer
 	{
-		bool m_Alive;
-		int m_X;
-		int m_Y;
+		bool m_Alive = false;
+		int m_X = 0;
+		int m_Y = 0;
 
 		CNetObj_PlayerInput m_Input;
-		uint32_t m_UniqueClientID;
+		uint32_t m_UniqueClientID = 0;
 
 		// DDNet team
-		int m_Team;
+		int m_Team = 0;
 	};
 
 	struct CTeam
 	{
-		bool m_Practice;
+		bool m_Practice = false;
 	};
 
-	WRITE_CALLBACK m_pfnWriteCallback;
-	void *m_pWriteCallbackUserdata;
+	WRITE_CALLBACK m_pfnWriteCallback = nullptr;
+	void *m_pWriteCallbackUserdata = nullptr;
 
-	int m_State;
+	int m_State = 0;
 
-	int m_LastWrittenTick;
-	bool m_TickWritten;
-	int m_Tick;
-	int m_PrevMaxClientID;
-	int m_MaxClientID;
+	int m_LastWrittenTick = 0;
+	bool m_TickWritten = false;
+	int m_Tick = 0;
+	int m_PrevMaxClientID = 0;
+	int m_MaxClientID = 0;
 	CTeehistorianPlayer m_aPrevPlayers[MAX_CLIENTS];
 	CTeam m_aPrevTeams[MAX_CLIENTS];
 };

--- a/src/game/server/teeinfo.cpp
+++ b/src/game/server/teeinfo.cpp
@@ -5,10 +5,10 @@
 
 struct StdSkin
 {
-	char m_aSkinName[64];
-	char m_apSkinPartNames[6][24];
-	bool m_aUseCustomColors[6];
-	int m_aSkinPartColors[6];
+	char m_aSkinName[64] = {0};
+	char m_aaSkinPartNames[6][24] = {{0}};
+	bool m_aUseCustomColors[6] = {false};
+	int m_aSkinPartColors[6] = {0};
 };
 
 static StdSkin g_aStdSkins[] = {
@@ -41,7 +41,7 @@ CTeeInfo::CTeeInfo(const char *apSkinPartNames[6], int *pUseCustomColors, int *p
 {
 	for(int i = 0; i < 6; i++)
 	{
-		str_copy(m_apSkinPartNames[i], apSkinPartNames[i], sizeof(m_apSkinPartNames[i]));
+		str_copy(m_aaSkinPartNames[i], apSkinPartNames[i], sizeof(m_aaSkinPartNames[i]));
 		m_aUseCustomColors[i] = pUseCustomColors[i];
 		m_aSkinPartColors[i] = pSkinPartColors[i];
 	}
@@ -52,7 +52,7 @@ void CTeeInfo::ToSixup()
 	// reset to default skin
 	for(int p = 0; p < 6; p++)
 	{
-		str_copy(m_apSkinPartNames[p], g_aStdSkins[0].m_apSkinPartNames[p], 24);
+		str_copy(m_aaSkinPartNames[p], g_aStdSkins[0].m_aaSkinPartNames[p], 24);
 		m_aUseCustomColors[p] = g_aStdSkins[0].m_aUseCustomColors[p];
 		m_aSkinPartColors[p] = g_aStdSkins[0].m_aSkinPartColors[p];
 	}
@@ -64,7 +64,7 @@ void CTeeInfo::ToSixup()
 		{
 			for(int p = 0; p < 6; p++)
 			{
-				str_copy(m_apSkinPartNames[p], StdSkin.m_apSkinPartNames[p], 24);
+				str_copy(m_aaSkinPartNames[p], StdSkin.m_aaSkinPartNames[p], 24);
 				m_aUseCustomColors[p] = StdSkin.m_aUseCustomColors[p];
 				m_aSkinPartColors[p] = StdSkin.m_aSkinPartColors[p];
 			}
@@ -103,7 +103,7 @@ void CTeeInfo::FromSixup()
 		bool match = true;
 		for(int p = 0; p < 6; p++)
 		{
-			if(str_comp(m_apSkinPartNames[p], StdSkin.m_apSkinPartNames[p]) || m_aUseCustomColors[p] != StdSkin.m_aUseCustomColors[p] || (m_aUseCustomColors[p] && m_aSkinPartColors[p] != StdSkin.m_aSkinPartColors[p]))
+			if(str_comp(m_aaSkinPartNames[p], StdSkin.m_aaSkinPartNames[p]) || m_aUseCustomColors[p] != StdSkin.m_aUseCustomColors[p] || (m_aUseCustomColors[p] && m_aSkinPartColors[p] != StdSkin.m_aSkinPartColors[p]))
 			{
 				match = false;
 				break;
@@ -123,7 +123,7 @@ void CTeeInfo::FromSixup()
 	{
 		int matches = 0;
 		for(int p = 0; p < 3; p++)
-			if(str_comp(m_apSkinPartNames[p], g_aStdSkins[s].m_apSkinPartNames[p]) == 0)
+			if(str_comp(m_aaSkinPartNames[p], g_aStdSkins[s].m_aaSkinPartNames[p]) == 0)
 				matches++;
 
 		if(matches > best_matches)

--- a/src/game/server/teeinfo.h
+++ b/src/game/server/teeinfo.h
@@ -12,7 +12,7 @@ public:
 	int m_ColorFeet = 0;
 
 	// 0.7
-	char m_apSkinPartNames[6][24] = {"", "", "", "", "", ""};
+	char m_aaSkinPartNames[6][24] = {"", "", "", "", "", ""};
 	bool m_aUseCustomColors[6] = {false, false, false, false, false, false};
 	int m_aSkinPartColors[6] = {0, 0, 0, 0, 0, 0};
 

--- a/src/game/teamscore.h
+++ b/src/game/teamscore.h
@@ -23,11 +23,11 @@ enum
 
 class CTeamsCore
 {
-	int m_aTeam[MAX_CLIENTS];
-	bool m_aIsSolo[MAX_CLIENTS];
+	int m_aTeam[MAX_CLIENTS] = {0};
+	bool m_aIsSolo[MAX_CLIENTS] = {false};
 
 public:
-	bool m_IsDDRace16;
+	bool m_IsDDRace16 = false;
 
 	CTeamsCore();
 

--- a/src/game/voting.h
+++ b/src/game/voting.h
@@ -14,17 +14,17 @@ enum
 
 struct CVoteOptionClient
 {
-	CVoteOptionClient *m_pNext;
-	CVoteOptionClient *m_pPrev;
-	char m_aDescription[VOTE_DESC_LENGTH];
+	CVoteOptionClient *m_pNext = nullptr;
+	CVoteOptionClient *m_pPrev = nullptr;
+	char m_aDescription[VOTE_DESC_LENGTH] = {0};
 };
 
 struct CVoteOptionServer
 {
-	CVoteOptionServer *m_pNext;
-	CVoteOptionServer *m_pPrev;
-	char m_aDescription[VOTE_DESC_LENGTH];
-	char m_aCommand[1];
+	CVoteOptionServer *m_pNext = nullptr;
+	CVoteOptionServer *m_pPrev = nullptr;
+	char m_aDescription[VOTE_DESC_LENGTH] = {0};
+	char m_aCommand[1] = {0};
 };
 
 #endif

--- a/src/steam/steam_api_flat.h
+++ b/src/steam/steam_api_flat.h
@@ -18,9 +18,9 @@ typedef int32_t HSteamUser;
 struct CallbackMsg_t
 {
 	HSteamUser m_hSteamUser;
-	int m_iCallback;
-	unsigned char *m_pubParam;
-	int m_cubParam;
+	int m_iCallback = 0;
+	unsigned char *m_pubParam = nullptr;
+	int m_cubParam = 0;
 };
 
 struct GameRichPresenceJoinRequested_t
@@ -29,8 +29,8 @@ struct GameRichPresenceJoinRequested_t
 	{
 		k_iCallback = 337
 	};
-	CSteamID m_steamIDFriend;
-	char m_aRGCHConnect[256];
+	CSteamID m_steamIDFriend = 0;
+	char m_aRGCHConnect[256] = {0};
 };
 
 struct NewUrlLaunchParameters_t
@@ -39,7 +39,7 @@ struct NewUrlLaunchParameters_t
 	{
 		k_iCallback = 1014
 	};
-	unsigned char m_EmptyStructDontUse;
+	unsigned char m_EmptyStructDontUse = 0;
 };
 
 struct ISteamApps;

--- a/src/test/aio.cpp
+++ b/src/test/aio.cpp
@@ -8,9 +8,9 @@ static const int BUF_SIZE = 64 * 1024;
 class Async : public ::testing::Test
 {
 protected:
-	ASYNCIO *m_pAio;
+	ASYNCIO *m_pAio = nullptr;
 	CTestInfo m_Info;
-	bool Delete;
+	bool Delete = false;
 
 	void SetUp() override
 	{

--- a/src/test/teehistorian.cpp
+++ b/src/test/teehistorian.cpp
@@ -30,16 +30,16 @@ protected:
 
 	TeeHistorian()
 	{
-		mem_zero(&m_Config, sizeof(m_Config));
-#define MACRO_CONFIG_INT(Name, ScriptName, Def, Min, Max, Save, Desc) \
-	m_Config.m_##Name = (Def);
-#define MACRO_CONFIG_COL(Name, ScriptName, Def, Save, Desc) MACRO_CONFIG_INT(Name, ScriptName, Def, 0, 0, Save, Desc)
-#define MACRO_CONFIG_STR(Name, ScriptName, Len, Def, Save, Desc) \
-	str_copy(m_Config.m_##Name, (Def), sizeof(m_Config.m_##Name));
-#include <engine/shared/config_variables.h>
-#undef MACRO_CONFIG_STR
-#undef MACRO_CONFIG_COL
-#undef MACRO_CONFIG_INT
+		m_Config = CConfig();
+// #define MACRO_CONFIG_INT(Name, ScriptName, Def, Min, Max, Save, Desc) \
+// 	m_Config.m_##Name = (Def);
+// #define MACRO_CONFIG_COL(Name, ScriptName, Def, Save, Desc) MACRO_CONFIG_INT(Name, ScriptName, Def, 0, 0, Save, Desc)
+// #define MACRO_CONFIG_STR(Name, ScriptName, Len, Def, Save, Desc) \
+// 	str_copy(m_Config.m_##Name, (Def), sizeof(m_Config.m_##Name));
+// #include <engine/shared/config_variables.h>
+// #undef MACRO_CONFIG_STR
+// #undef MACRO_CONFIG_COL
+// #undef MACRO_CONFIG_INT
 
 		RegisterUuids(&m_UuidManager);
 		RegisterTeehistorianUuids(&m_UuidManager);
@@ -50,7 +50,7 @@ protected:
 			0x01, 0x23, 0x45, 0x67, 0x89, 0x01, 0x23, 0x45, 0x67, 0x89,
 			0x01, 0x23}};
 
-		mem_zero(&m_GameInfo, sizeof(m_GameInfo));
+		m_GameInfo = CTeeHistorian::CGameInfo();
 
 		m_GameInfo.m_GameUuid = CalculateUuid("test@ddnet.tw");
 		m_GameInfo.m_pServerVersion = "DDNet test";
@@ -207,7 +207,6 @@ protected:
 	void Player(int ClientID, int x, int y)
 	{
 		CNetObj_CharacterCore Char;
-		mem_zero(&Char, sizeof(Char));
 		Char.m_X = x;
 		Char.m_Y = y;
 		m_TH.RecordPlayer(ClientID, &Char);

--- a/src/test/teehistorian.cpp
+++ b/src/test/teehistorian.cpp
@@ -26,7 +26,7 @@ protected:
 		STATE_INPUTS,
 	};
 
-	int m_State;
+	int m_State = 0;
 
 	TeeHistorian()
 	{

--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -30,8 +30,8 @@ IStorage *CTestInfo::CreateTestStorage()
 class CTestInfoPath
 {
 public:
-	bool m_IsDirectory;
-	char m_aData[IO_MAX_PATH_LENGTH];
+	bool m_IsDirectory = false;
+	char m_aData[IO_MAX_PATH_LENGTH] = {0};
 
 	bool operator<(const CTestInfoPath &Other) const
 	{
@@ -46,8 +46,8 @@ public:
 class CTestCollectData
 {
 public:
-	char m_aCurrentDir[IO_MAX_PATH_LENGTH];
-	std::vector<CTestInfoPath> *m_pvEntries;
+	char m_aCurrentDir[IO_MAX_PATH_LENGTH] = {0};
+	std::vector<CTestInfoPath> *m_pvEntries = nullptr;
 };
 
 int TestCollect(const char *pName, int IsDir, int Unused, void *pUser)

--- a/src/test/test.h
+++ b/src/test/test.h
@@ -10,6 +10,6 @@ public:
 	~CTestInfo();
 	IStorage *CreateTestStorage();
 	bool m_DeleteTestStorageFilesOnSuccess = false;
-	char m_aFilename[64];
+	char m_aFilename[64] = {0};
 };
 #endif // TEST_TEST_H

--- a/src/tools/config_common.h
+++ b/src/tools/config_common.h
@@ -4,13 +4,13 @@
 
 struct SListDirectoryContext
 {
-	const char *m_pPath;
-	IStorage *m_pStorage;
+	const char *m_pPath = nullptr;
+	IStorage *m_pStorage = nullptr;
 };
 
 inline void ProcessItem(const char *pItemName, IStorage *pStorage)
 {
-	char aConfig[2048];
+	char aConfig[2048] = {0};
 
 	size_t Len = (size_t)str_length(pItemName) + 1; // including '\0'
 	if(Len > sizeof(aConfig))

--- a/src/tools/crapnet.cpp
+++ b/src/tools/crapnet.cpp
@@ -10,14 +10,14 @@
 
 struct SPacket
 {
-	SPacket *m_pPrev;
-	SPacket *m_pNext;
+	SPacket *m_pPrev = nullptr;
+	SPacket *m_pNext = nullptr;
 
 	NETADDR m_SendTo;
-	int64_t m_Timestamp;
-	int m_ID;
-	int m_DataSize;
-	char m_aData[1];
+	int64_t m_Timestamp = 0;
+	int m_ID = 0;
+	int m_DataSize = 0;
+	char m_aData[1] = {0};
 };
 
 static SPacket *g_pFirst = (SPacket *)0;
@@ -26,12 +26,12 @@ static int g_CurrentLatency = 0;
 
 struct SPingConfig
 {
-	int m_Base;
-	int m_Flux;
-	int m_Spike;
-	int m_Loss;
-	int m_Delay;
-	int m_DelayFreq;
+	int m_Base = 0;
+	int m_Flux = 0;
+	int m_Spike = 0;
+	int m_Loss = 0;
+	int m_Delay = 0;
+	int m_DelayFreq = 0;
 };
 
 static SPingConfig g_aConfigPings[] = {

--- a/src/tools/map_optimize.cpp
+++ b/src/tools/map_optimize.cpp
@@ -127,10 +127,10 @@ int main(int argc, const char **argv)
 
 	struct SMapOptimizeItem
 	{
-		CMapItemImage *m_pImage;
-		int m_Index;
-		int m_Data;
-		int m_Text;
+		CMapItemImage *m_pImage = nullptr;
+		int m_Index = 0;
+		int m_Data = 0;
+		int m_Text = 0;
 	};
 
 	std::vector<SMapOptimizeItem> vDataFindHelper;

--- a/src/tools/map_replace_area.cpp
+++ b/src/tools/map_replace_area.cpp
@@ -14,13 +14,13 @@ struct MapObject // quad pivot or tile layer
 {
 	static constexpr float ms_aStandardScreen[2] = {1430 / 2.f, 1050 / 2.f};
 
-	float m_aLayerOffset[2];
-	bool m_UseClipping;
-	float m_aaClipArea[2][2];
-	float m_aSpeed[2];
-	float m_aaScreenOffset[2][2];
-	float m_aaBaseArea[2][2]; // adapted to offset
-	float m_aaExtendedArea[2][2]; // extended with parallax
+	float m_aLayerOffset[2] = {0};
+	bool m_UseClipping = false;
+	float m_aaClipArea[2][2] = {{0}};
+	float m_aSpeed[2] = {0};
+	float m_aaScreenOffset[2][2] = {{0}};
+	float m_aaBaseArea[2][2] = {{0}}; // adapted to offset
+	float m_aaExtendedArea[2][2] = {{0}}; // extended with parallax
 };
 
 bool ReplaceArea(IStorage *, const char[][64], const float[][2][2]);


### PR DESCRIPTION
Init all class members to prevent further bug due to non initialised member, following discussion from https://github.com/ddnet/ddnet/issues/5247.

CPP reference: 

- https://en.cppreference.com/w/cpp/language/constructor
- https://en.cppreference.com/w/cpp/language/data_members#Member_initialization
- https://stackoverflow.com/questions/2417065/does-the-default-constructor-initialize-built-in-types

I tested this very lightly. There's still some manual work to do for member classes and struct, as well as for some array of classes. I also need to make sure there are no to little performance loss due to all this initialisation :) .
Commits are a little bit messy, i can clean if needed.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
