### PR TITLE
Use new ddnet.org domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-[![DDraceNetwork](https://ddnet.tw/ddnet-small.png)](https://ddnet.tw) [![](https://github.com/ddnet/ddnet/workflows/Build/badge.svg)](https://github.com/ddnet/ddnet/actions?query=workflow%3ABuild+event%3Apush+branch%3Amaster)
+[![DDraceNetwork](https://ddnet.org/ddnet-small.png)](https://ddnet.org) [![](https://github.com/ddnet/ddnet/workflows/Build/badge.svg)](https://github.com/ddnet/ddnet/actions?query=workflow%3ABuild+event%3Apush+branch%3Amaster)
 
-Our own flavor of DDRace, a Teeworlds mod. See the [website](https://ddnet.tw) for more information.
+Our own flavor of DDRace, a Teeworlds mod. See the [website](https://ddnet.org) for more information.
 
 Development discussions happen on #ddnet on Quakenet ([Webchat](http://webchat.quakenet.org/?channels=ddnet&uio=d4)) or on [Discord in the developer channel](https://discord.gg/xsEd9xu).
 
-You can get binary releases on the [DDNet website](https://ddnet.tw/downloads/), find it on [Steam](https://store.steampowered.com/app/412220/DDraceNetwork/) or [install from repository](#installation-from-repository).
+You can get binary releases on the [DDNet website](https://ddnet.org/downloads/), find it on [Steam](https://store.steampowered.com/app/412220/DDraceNetwork/) or [install from repository](#installation-from-repository).
 
-- [Code Browser](https://ddnet.tw/codebrowser/DDNet/)
-- [Source Code Documentation](https://codedoc.ddnet.tw/) (very incomplete, only a few items are documented)
+- [Code Browser](https://ddnet.org/codebrowser/DDNet/)
+- [Source Code Documentation](https://codedoc.ddnet.org/) (very incomplete, only a few items are documented)
 
-If you want to learn about the source code, you can check the [Development](https://wiki.ddnet.tw/wiki/Development) article on the wiki.
+If you want to learn about the source code, you can check the [Development](https://wiki.ddnet.org/wiki/Development) article on the wiki.
 
 Cloning
 -------
@@ -246,7 +246,7 @@ Importing the official DDNet Database
 -------------------------------------
 
 ```bash
-$ wget https://ddnet.tw/stats/ddnet-sql.zip
+$ wget https://ddnet.org/stats/ddnet-sql.zip
 $ unzip ddnet-sql.zip
 $ yaourt -S mariadb mysql-connector-c++
 $ mysql_install_db --user=mysql --basedir=/usr --datadir=/var/lib/mysql

--- a/data/autoexec_server.cfg
+++ b/data/autoexec_server.cfg
@@ -1,7 +1,7 @@
 #
 # autoexec_server.cfg
 #
-# See https://ddnet.tw/settingscommands/ for all available settings.
+# See https://ddnet.org/settingscommands/ for all available settings.
 # Everything following a # is considered a comment and ignored by the server.
 # When an option can be enabled or disabled, it's enabled with 1, disabled with 0.
 #
@@ -128,7 +128,7 @@ sv_reset_file "reset.cfg"
 # name, because each vote text has to be unique.
 # Example: add_vote " " "info"
 #
-# You can learn more about tunes on http://ddnet.tw/settingscommands/#tunings
+# You can learn more about tunes on http://ddnet.org/settingscommands/#tunings
 
 add_map_votes
 add_vote " " "info"

--- a/data/languages/arabic.txt
+++ b/data/languages/arabic.txt
@@ -990,8 +990,8 @@ Default length: %d
 Pause
 == ﺔﺒﻗﺍﺮﻣ
 
-transmits your player name to info2.ddnet.tw
-== ﻰﻟﺇ ﻚﺑ ﺹﺎﺨﻟﺍ ﺐﻋﻼﻟﺍ ﻢﺳﺍ ﻞﻘﻨﻳ info2.ddnet.tw
+transmits your player name to info.ddnet.org
+== ﻰﻟﺇ ﻚﺑ ﺹﺎﺨﻟﺍ ﺐﻋﻼﻟﺍ ﻢﺳﺍ ﻞﻘﻨﻳ info.ddnet.org
 
 Server best:
 == :ﺮﻓﺮﻴﺳ ﻞﻀﻓﺍ
@@ -1135,8 +1135,8 @@ Particles
 Assets directory
 == ﻝﺎﻜﺷﻻﺍ ﻒﻠﻣ ﺢﺘﻓ
 
-https://wiki.ddnet.tw/
-== https://wiki.ddnet.tw/
+https://wiki.ddnet.org/
+== https://wiki.ddnet.org/
 
 Saving ddnet-settings.cfg failed
 == ﻆﻔﺤﻟﺍ ﻞﺸﻓ ddnet-settings.cfg
@@ -1533,7 +1533,7 @@ Loading assets
 Discord
 == 
 
-https://ddnet.tw/discord
+https://ddnet.org/discord
 == 
 
 Tutorial

--- a/data/languages/belarusian.txt
+++ b/data/languages/belarusian.txt
@@ -769,7 +769,7 @@ Skip Tutorial
 Show DDNet map finishes in server browser
 == 
 
-transmits your player name to info2.ddnet.tw
+transmits your player name to info.ddnet.org
 == 
 
 Theme
@@ -1446,13 +1446,13 @@ Assets directory
 Discord
 == 
 
-https://ddnet.tw/discord
+https://ddnet.org/discord
 == 
 
 Learn
 == 
 
-https://wiki.ddnet.tw/
+https://wiki.ddnet.org/
 == 
 
 Tutorial

--- a/data/languages/bosnian.txt
+++ b/data/languages/bosnian.txt
@@ -679,8 +679,8 @@ Video name:
 Show DDNet map finishes in server browser
 == Prikaži završene DDNet mape u pretraživaču za servere
 
-transmits your player name to info2.ddnet.tw
-== prenosi tvoje ime na info2.ddnet.tw
+transmits your player name to info.ddnet.org
+== prenosi tvoje ime na info.ddnet.org
 
 Search
 == Pretraži
@@ -1494,10 +1494,10 @@ Assets directory
 Discord
 == 
 
-https://ddnet.tw/discord
+https://ddnet.org/discord
 == 
 
-https://wiki.ddnet.tw/
+https://wiki.ddnet.org/
 == 
 
 Tutorial

--- a/data/languages/brazilian_portuguese.txt
+++ b/data/languages/brazilian_portuguese.txt
@@ -915,8 +915,8 @@ Date
 Show DDNet map finishes in server browser
 == Mostrar finalizações de mapas do DDNet no navegador do servidor
 
-transmits your player name to info2.ddnet.tw
-== transmite seu nome de jogador para info2.ddnet.tw
+transmits your player name to info.ddnet.org
+== transmite seu nome de jogador para info.ddnet.org
 
 Reload
 == Recarregar
@@ -1107,8 +1107,8 @@ Skip the main menu
 Download skins
 == Baixar skins
 
-https://wiki.ddnet.tw/
-== https://wiki.ddnet.tw/wiki/Main_Page/pt-br
+https://wiki.ddnet.org/
+== https://wiki.ddnet.org/wiki/Main_Page/pt-br
 
 Website
 == Site
@@ -1273,8 +1273,8 @@ Desktop fullscreen
 Discord
 == Discord
 
-https://ddnet.tw/discord
-== https://ddnet.tw/discord
+https://ddnet.org/discord
+== https://ddnet.org/discord
 
 Are you sure that you want to disconnect and switch to a different server?
 == Tem certeza que deseja desconectar e trocar pata um servidor diferente?

--- a/data/languages/bulgarian.txt
+++ b/data/languages/bulgarian.txt
@@ -766,7 +766,7 @@ Skip Tutorial
 Show DDNet map finishes in server browser
 == 
 
-transmits your player name to info2.ddnet.tw
+transmits your player name to info.ddnet.org
 == 
 
 Theme
@@ -1446,13 +1446,13 @@ Assets directory
 Discord
 == 
 
-https://ddnet.tw/discord
+https://ddnet.org/discord
 == 
 
 Learn
 == 
 
-https://wiki.ddnet.tw/
+https://wiki.ddnet.org/
 == 
 
 Tutorial

--- a/data/languages/catalan.txt
+++ b/data/languages/catalan.txt
@@ -891,8 +891,8 @@ Date
 Show DDNet map finishes in server browser
 == Mostrar finalitzacions de mapes en el buscador de servidors
 
-transmits your player name to info2.ddnet.tw
-== retransmet el teu nom de jugar a info2.ddnet.tw
+transmits your player name to info.ddnet.org
+== retransmet el teu nom de jugar a info.ddnet.org
 
 Reload
 == Recarga
@@ -1215,11 +1215,11 @@ Assets directory
 Discord
 == Discord
 
-https://ddnet.tw/discord
-== https://ddnet.tw/discord
+https://ddnet.org/discord
+== https://ddnet.org/discord
 
-https://wiki.ddnet.tw/
-== https://wiki.ddnet.tw/wiki/Main_Page/ca
+https://wiki.ddnet.org/
+== https://wiki.ddnet.org/wiki/Main_Page/ca
 
 Website
 == Página Web

--- a/data/languages/chuvash.txt
+++ b/data/languages/chuvash.txt
@@ -769,7 +769,7 @@ Skip Tutorial
 Show DDNet map finishes in server browser
 == 
 
-transmits your player name to info2.ddnet.tw
+transmits your player name to info.ddnet.org
 == 
 
 Theme
@@ -1446,13 +1446,13 @@ Assets directory
 Discord
 == 
 
-https://ddnet.tw/discord
+https://ddnet.org/discord
 == 
 
 Learn
 == 
 
-https://wiki.ddnet.tw/
+https://wiki.ddnet.org/
 == 
 
 Tutorial

--- a/data/languages/czech.txt
+++ b/data/languages/czech.txt
@@ -1089,8 +1089,8 @@ Country / Region
 Speed
 == Rychlost
 
-transmits your player name to info2.ddnet.tw
-== přenese vaše jméno hráče na info2.ddnet.tw
+transmits your player name to info.ddnet.org
+== přenese vaše jméno hráče na info.ddnet.org
 
 Theme
 == Téma
@@ -1165,8 +1165,8 @@ Particles
 Assets directory
 == Adresář aktiv
 
-https://wiki.ddnet.tw/
-== https://wiki.ddnet.tw/
+https://wiki.ddnet.org/
+== https://wiki.ddnet.org/
 
 Website
 == webová stránka
@@ -1540,7 +1540,7 @@ Loading assets
 Discord
 == 
 
-https://ddnet.tw/discord
+https://ddnet.org/discord
 == 
 
 Tutorial

--- a/data/languages/danish.txt
+++ b/data/languages/danish.txt
@@ -698,8 +698,8 @@ Video name:
 Show DDNet map finishes in server browser
 == Vis DDNet kort færdig i serverbrowseren
 
-transmits your player name to info2.ddnet.tw
-== sender dit spillernavn til info2.ddnet.tw
+transmits your player name to info.ddnet.org
+== sender dit spillernavn til info.ddnet.org
 
 Theme
 == Tema
@@ -1100,8 +1100,8 @@ Assets directory
 Learn
 == Lære
 
-https://wiki.ddnet.tw/
-== https://wiki.ddnet.tw/
+https://wiki.ddnet.org/
+== https://wiki.ddnet.org/
 
 Website
 == Internet side
@@ -1538,7 +1538,7 @@ Loading assets
 Discord
 == 
 
-https://ddnet.tw/discord
+https://ddnet.org/discord
 == 
 
 Tutorial

--- a/data/languages/dutch.txt
+++ b/data/languages/dutch.txt
@@ -686,8 +686,8 @@ Video name:
 Show DDNet map finishes in server browser
 == Laat gefinishte maps zien in de verkenner
 
-transmits your player name to info2.ddnet.tw
-== verzendt je speler naam naar info2.ddnet.tw
+transmits your player name to info.ddnet.org
+== verzendt je speler naam naar info.ddnet.org
 
 Search
 == Zoek
@@ -1312,11 +1312,11 @@ Assets directory
 Discord
 == Discord
 
-https://ddnet.tw/discord
-== https://ddnet.tw/discord
+https://ddnet.org/discord
+== https://ddnet.org/discord
 
-https://wiki.ddnet.tw/
-== https://wiki.ddnet.tw/
+https://wiki.ddnet.org/
+== https://wiki.ddnet.org/
 
 Tutorial
 == Tutorial

--- a/data/languages/esperanto.txt
+++ b/data/languages/esperanto.txt
@@ -195,8 +195,8 @@ Join Tutorial Server
 Skip Tutorial
 == Pasi la lernilo
 
-transmits your player name to info2.ddnet.tw
-== sendas vian ludantnomon al info2.ddnet.tw
+transmits your player name to info2.ddnet.org
+== sendas vian ludantnomon al info2.ddnet.org
 
 Nickname
 == Kromnomo
@@ -526,14 +526,14 @@ Check now
 Discord
 == Diskordo
 
-https://ddnet.tw/discord
-== https://ddnet.tw/discord
+https://ddnet.org/discord
+== https://ddnet.org/discord
 
 Learn
 == Lerni
 
-https://wiki.ddnet.tw/
-== https://wiki.ddnet.tw/
+https://wiki.ddnet.org/
+== https://wiki.ddnet.org/
 
 Tutorial
 == Lernilo

--- a/data/languages/finnish.txt
+++ b/data/languages/finnish.txt
@@ -703,8 +703,8 @@ Video name:
 Show DDNet map finishes in server browser
 == Näytä DDNet kenttäläpäisyt palvelinselaimessa
 
-transmits your player name to info2.ddnet.tw
-== lähettää nimimerkkisi osoitteeseen info2.ddnet.tw
+transmits your player name to info.ddnet.org
+== lähettää nimimerkkisi osoitteeseen info.ddnet.org
 
 Theme
 == Teema
@@ -1099,14 +1099,14 @@ Emoticons
 Discord
 == Discord
 
-https://ddnet.tw/discord
-== https://ddnet.tw/discord
+https://ddnet.org/discord
+== https://ddnet.org/discord
 
 Learn
 == Opi
 
-https://wiki.ddnet.tw/
-== https://wiki.ddnet.tw/
+https://wiki.ddnet.org/
+== https://wiki.ddnet.org/
 
 Website
 == Verkkosivu

--- a/data/languages/french.txt
+++ b/data/languages/french.txt
@@ -1073,8 +1073,8 @@ Please enter your nickname below.
 Show DDNet map finishes in server browser
 == Afficher les cartes de DDNet terminées dans le navigateur
 
-transmits your player name to info2.ddnet.tw
-== transmet votre pseudonyme à info2.ddnet.tw
+transmits your player name to info.ddnet.org
+== transmet votre pseudonyme à info.ddnet.org
 
 Saving ddnet-settings.cfg failed
 == L'enregistrement de ddnet-settings.cfg a échoué
@@ -1151,8 +1151,8 @@ Particles
 Assets directory
 == Répertoire des assets
 
-https://wiki.ddnet.tw/
-== https://wiki.ddnet.tw/
+https://wiki.ddnet.org/
+== https://wiki.ddnet.org/
 
 Website
 == Site web
@@ -1281,8 +1281,8 @@ Regular Background Color
 Discord
 == Discord
 
-https://ddnet.tw/discord
-== https://ddnet.tw/discord
+https://ddnet.org/discord
+== https://ddnet.org/discord
 
 Are you sure that you want to disconnect and switch to a different server?
 == Êtes vous sur de vouloir vous déconnecter et changer de serveur?

--- a/data/languages/german.txt
+++ b/data/languages/german.txt
@@ -1049,8 +1049,8 @@ Default length: %d
 Pause
 == Pause
 
-transmits your player name to info2.ddnet.tw
-== überträgt deinen Spielernamen an info2.ddnet.tw
+transmits your player name to info.ddnet.org
+== überträgt deinen Spielernamen an info.ddnet.org
 
 Server best:
 == Serverbeste:
@@ -1194,8 +1194,8 @@ Particles
 Assets directory
 == Assets-Ordner
 
-https://wiki.ddnet.tw/
-== https://wiki.ddnet.tw/wiki/Main_Page/de
+https://wiki.ddnet.org/
+== https://wiki.ddnet.org/wiki/Main_Page/de
 
 Saving ddnet-settings.cfg failed
 == ddnet-settings.cfg zu speichern ist fehlgeschlagen
@@ -1269,8 +1269,8 @@ Chat command
 Discord
 == Discord
 
-https://ddnet.tw/discord
-== https://ddnet.tw/discord
+https://ddnet.org/discord
+== https://ddnet.org/discord
 
 AFR
 == AFR

--- a/data/languages/greek.txt
+++ b/data/languages/greek.txt
@@ -772,7 +772,7 @@ Skip Tutorial
 Show DDNet map finishes in server browser
 == 
 
-transmits your player name to info2.ddnet.tw
+transmits your player name to info.ddnet.org
 == 
 
 Theme
@@ -1446,13 +1446,13 @@ Assets directory
 Discord
 == 
 
-https://ddnet.tw/discord
+https://ddnet.org/discord
 == 
 
 Learn
 == 
 
-https://wiki.ddnet.tw/
+https://wiki.ddnet.org/
 == 
 
 Tutorial

--- a/data/languages/hungarian.txt
+++ b/data/languages/hungarian.txt
@@ -898,8 +898,8 @@ Date
 Show DDNet map finishes in server browser
 == Mutassa a befejezett pályákat a keresőben
 
-transmits your player name to info2.ddnet.tw
-== továbbítja a játékosnevedet az info2.ddnet.tw oldalra
+transmits your player name to info.ddnet.org
+== továbbítja a játékosnevedet az info.ddnet.org oldalra
 
 Reload
 == Újratöltés
@@ -1265,11 +1265,11 @@ Show local player's key presses
 Discord
 == Discord
 
-https://ddnet.tw/discord
-== https://ddnet.tw/discord
+https://ddnet.org/discord
+== https://ddnet.org/discord
 
-https://wiki.ddnet.tw/
-== https://wiki.ddnet.tw/
+https://wiki.ddnet.org/
+== https://wiki.ddnet.org/
 
 The format of texture %s is not RGBA which will cause visual bugs.
 == A %s textúra formátuma nem RGBA, ami vizuális hibákat okozhat. (Nem megfelelően lesz elosztva a kép színvilága.)

--- a/data/languages/italian.txt
+++ b/data/languages/italian.txt
@@ -749,9 +749,9 @@ Video name:
 Show DDNet map finishes in server browser
 == Mostra le mappe finite in DDNet nel tuo browser dei server
 
-transmits your player name to info2.ddnet.tw
+transmits your player name to info.ddnet.org
 
-== Trasmette il tuo nome da giocatore a info2.ddnet.tw
+== Trasmette il tuo nome da giocatore a info.ddnet.org
 
 
 Theme
@@ -1129,8 +1129,8 @@ Assets directory
 Learn
 == Impara
 
-https://wiki.ddnet.tw/
-== https://wiki.ddnet.tw/
+https://wiki.ddnet.org/
+== https://wiki.ddnet.org/
 
 
 Website
@@ -1571,7 +1571,7 @@ Loading assets
 Discord
 == 
 
-https://ddnet.tw/discord
+https://ddnet.org/discord
 == 
 
 Tutorial

--- a/data/languages/japanese.txt
+++ b/data/languages/japanese.txt
@@ -700,8 +700,8 @@ Video name:
 Show DDNet map finishes in server browser
 == サーバー・ブラウザーで完成した DDNet マップを表示する
 
-transmits your player name to info2.ddnet.tw
-== ハンドルネームを info2.ddnet.tw に送信します
+transmits your player name to info.ddnet.org
+== ハンドルネームを info.ddnet.org に送信します
 
 Theme
 == テーマ
@@ -1141,14 +1141,14 @@ Assets directory
 Discord
 == Discord
 
-https://ddnet.tw/discord
-== https://ddnet.tw/discord
+https://ddnet.org/discord
+== https://ddnet.org/discord
 
 Learn
 == チュートリアル
 
-https://wiki.ddnet.tw/
-== https://wiki.ddnet.tw/
+https://wiki.ddnet.org/
+== https://wiki.ddnet.org/
 
 Website
 == ウェブ

--- a/data/languages/korean.txt
+++ b/data/languages/korean.txt
@@ -714,8 +714,8 @@ Video name:
 Show DDNet map finishes in server browser
 == DDNet 맵 완주를 서버 브라우저에 표시
 
-transmits your player name to info2.ddnet.tw
-== info2.ddnet.tw에 당신의 닉네임을 전송함
+transmits your player name to info.ddnet.org
+== info.ddnet.org에 당신의 닉네임을 전송함
 
 Theme
 == 테마
@@ -1173,14 +1173,14 @@ Assets directory
 Discord
 == 디스코드
 
-https://ddnet.tw/discord
-== https://ddnet.tw/discord
+https://ddnet.org/discord
+== https://ddnet.org/discord
 
 Learn
 == 학습터
 
-https://wiki.ddnet.tw/
-== https://wiki.ddnet.tw/
+https://wiki.ddnet.org/
+== https://wiki.ddnet.org/
 
 Website
 == 웹사이트

--- a/data/languages/kyrgyz.txt
+++ b/data/languages/kyrgyz.txt
@@ -763,7 +763,7 @@ Skip Tutorial
 Show DDNet map finishes in server browser
 == 
 
-transmits your player name to info2.ddnet.tw
+transmits your player name to info.ddnet.org
 == 
 
 Theme
@@ -1437,13 +1437,13 @@ Assets directory
 Discord
 == 
 
-https://ddnet.tw/discord
+https://ddnet.org/discord
 == 
 
 Learn
 == 
 
-https://wiki.ddnet.tw/
+https://wiki.ddnet.org/
 == 
 
 Tutorial

--- a/data/languages/norwegian.txt
+++ b/data/languages/norwegian.txt
@@ -675,8 +675,8 @@ Video name:
 Show DDNet map finishes in server browser
 == Vis fullførte DDNet-baner i serverlisten
 
-transmits your player name to info2.ddnet.tw
-== sender spillnavnet ditt til info2.ddnet.tw
+transmits your player name to info.ddnet.org
+== sender spillnavnet ditt til info.ddnet.org
 
 Search
 == Søk
@@ -1167,8 +1167,8 @@ Particles
 Assets directory
 == Ressursmappe
 
-https://wiki.ddnet.tw/
-== https://wiki.ddnet.tw/
+https://wiki.ddnet.org/
+== https://wiki.ddnet.org/
 
 Website
 == Webside
@@ -1539,7 +1539,7 @@ Loading assets
 Discord
 == 
 
-https://ddnet.tw/discord
+https://ddnet.org/discord
 == 
 
 Tutorial

--- a/data/languages/persian.txt
+++ b/data/languages/persian.txt
@@ -885,7 +885,7 @@ Join Tutorial Server
 Skip Tutorial
 == 
 
-transmits your player name to info2.ddnet.tw
+transmits your player name to info.ddnet.org
 == 
 
 Loading menu images
@@ -1373,10 +1373,10 @@ Loading assets
 Assets directory
 == 
 
-https://ddnet.tw/discord
+https://ddnet.org/discord
 == 
 
-https://wiki.ddnet.tw/
+https://wiki.ddnet.org/
 == 
 
 Tutorial

--- a/data/languages/polish.txt
+++ b/data/languages/polish.txt
@@ -1052,8 +1052,8 @@ Please enter your nickname below.
 Show DDNet map finishes in server browser
 == Pokazuj ukończone mapy DDNet w wyszukiwarce
 
-transmits your player name to info2.ddnet.tw
-== przenosi twój nick do info2.ddnet.tw
+transmits your player name to info.ddnet.org
+== przenosi twój nick do info.ddnet.org
 
 Indicate map finish
 == Pokazuj ukończone mapy
@@ -1169,8 +1169,8 @@ Particles
 Assets directory
 == Katalog zasobów
 
-https://wiki.ddnet.tw/
-== https://wiki.ddnet.tw/
+https://wiki.ddnet.org/
+== https://wiki.ddnet.org/
 
 Website
 == Strona
@@ -1335,8 +1335,8 @@ Chat command (e.g. showall 1)
 Discord
 == Discord
 
-https://ddnet.tw/discord
-== https://ddnet.tw/discord
+https://ddnet.org/discord
+== https://ddnet.org/discord
 
 Tutorial
 == Samouczek

--- a/data/languages/portuguese.txt
+++ b/data/languages/portuguese.txt
@@ -861,8 +861,8 @@ Speed
 Video name:
 == Nome do vídeo:
 
-transmits your player name to info2.ddnet.tw
-== transmite o teu nome de jogador para info2.ddnet.tw
+transmits your player name to info.ddnet.org
+== transmite o teu nome de jogador para info.ddnet.org
 
 Theme
 == Tema
@@ -951,14 +951,14 @@ Particles
 Discord
 == Discord
 
-https://ddnet.tw/discord
-== https://ddnet.tw/discord
+https://ddnet.org/discord
+== https://ddnet.org/discord
 
 Learn
 == Aprender
 
-https://wiki.ddnet.tw/
-== https://wiki.ddnet.tw/
+https://wiki.ddnet.org/
+== https://wiki.ddnet.org/
 
 Website
 == Website

--- a/data/languages/romanian.txt
+++ b/data/languages/romanian.txt
@@ -778,7 +778,7 @@ Skip Tutorial
 Show DDNet map finishes in server browser
 == 
 
-transmits your player name to info2.ddnet.tw
+transmits your player name to info.ddnet.org
 == 
 
 Theme
@@ -1452,13 +1452,13 @@ Assets directory
 Discord
 == 
 
-https://ddnet.tw/discord
+https://ddnet.org/discord
 == 
 
 Learn
 == 
 
-https://wiki.ddnet.tw/
+https://wiki.ddnet.org/
 == 
 
 Tutorial

--- a/data/languages/russian.txt
+++ b/data/languages/russian.txt
@@ -807,8 +807,8 @@ Video name:
 Show DDNet map finishes in server browser
 == Показывать в браузере статус завершения карты
 
-transmits your player name to info2.ddnet.tw
-== передает ваш псевдоним на info2.ddnet.tw
+transmits your player name to info.ddnet.org
+== передает ваш псевдоним на info.ddnet.org
 
 Exclude
 == Исключить
@@ -1077,8 +1077,8 @@ Markers
 Skip the main menu
 == Пропускать главное меню
 
-https://wiki.ddnet.tw/
-== https://wiki.ddnet.tw/wiki/Main_Page/ru
+https://wiki.ddnet.org/
+== https://wiki.ddnet.org/wiki/Main_Page/ru
 
 Website
 == Сайт
@@ -1228,8 +1228,8 @@ Chat command
 Discord
 == Дискорд
 
-https://ddnet.tw/discord
-== https://ddnet.tw/discord
+https://ddnet.org/discord
+== https://ddnet.org/discord
 
 AFR
 == AFR

--- a/data/languages/serbian.txt
+++ b/data/languages/serbian.txt
@@ -709,8 +709,8 @@ Video name:
 Show DDNet map finishes in server browser
 == Prikaži završetka DDNet mape u pregledaču servera
 
-transmits your player name to info2.ddnet.tw
-== prenosi ime vašeg igrača na info2.ddnet.tw
+transmits your player name to info2.ddnet.org
+== prenosi ime vašeg igrača na info2.ddnet.org
 
 Theme
 == Tema
@@ -1076,8 +1076,8 @@ Assets directory
 Learn
 == Uputstvo
 
-https://wiki.ddnet.tw/
-== https://wiki.ddnet.tw/
+https://wiki.ddnet.org/
+== https://wiki.ddnet.org/
 
 Website
 == Veb sajt
@@ -1541,8 +1541,8 @@ Loading assets
 Discord
 == Discord
 
-https://ddnet.tw/discord
-== https://ddnet.tw/discord
+https://ddnet.org/discord
+== https://ddnet.org/discord
 
 Tutorial
 == Uvod

--- a/data/languages/serbian_cyrillic.txt
+++ b/data/languages/serbian_cyrillic.txt
@@ -705,8 +705,8 @@ Video name:
 Show DDNet map finishes in server browser
 == Прикажи завршетка DDNet мапе у прегледачу сервера
 
-transmits your player name to info2.ddnet.tw
-== преноси име вашег играча на info2.ddnet.tw
+transmits your player name to info.ddnet.org
+== преноси име вашег играча на info.ddnet.org
 
 Theme
 == Тема
@@ -1072,8 +1072,8 @@ Assets directory
 Learn
 == Упутство
 
-https://wiki.ddnet.tw/
-== https://wiki.ddnet.tw/
+https://wiki.ddnet.org/
+== https://wiki.ddnet.org/
 
 Website
 == Веб сајт
@@ -1537,8 +1537,8 @@ Loading assets
 Discord
 == Discord
 
-https://ddnet.tw/discord
-== https://ddnet.tw/discord
+https://ddnet.org/discord
+== https://ddnet.org/discord
 
 Tutorial
 == Увод

--- a/data/languages/simplified_chinese.txt
+++ b/data/languages/simplified_chinese.txt
@@ -926,8 +926,8 @@ Date
 Show DDNet map finishes in server browser
 == 在服务器浏览器中显示已完成的 DDNet 地图
 
-transmits your player name to info2.ddnet.tw
-== 将会发送你的玩家昵称到 info2.ddnet.tw
+transmits your player name to info.ddnet.org
+== 将会发送你的玩家昵称到 info.ddnet.org
 
 Reload
 == 刷新
@@ -1094,7 +1094,7 @@ Use k key to kill (restart), q to pause and watch other players. See settings fo
 Country / Region
 == 国家 / 地区
 
-https://wiki.ddnet.tw/
+https://wiki.ddnet.org/
 == https://docs.qq.com/doc/DWGFrV0xPRmVWVkla
 
 Warning
@@ -1218,7 +1218,7 @@ Particles
 Assets directory
 == 资源目录
 
-https://ddnet.tw/discord
+https://ddnet.org/discord
 == http://chat.teeworlds.cn/
 
 Discord

--- a/data/languages/slovak.txt
+++ b/data/languages/slovak.txt
@@ -769,7 +769,7 @@ Skip Tutorial
 Show DDNet map finishes in server browser
 == 
 
-transmits your player name to info2.ddnet.tw
+transmits your player name to info.ddnet.org
 == 
 
 Theme
@@ -1446,13 +1446,13 @@ Assets directory
 Discord
 == 
 
-https://ddnet.tw/discord
+https://ddnet.org/discord
 == 
 
 Learn
 == 
 
-https://wiki.ddnet.tw/
+https://wiki.ddnet.org/
 == 
 
 Tutorial

--- a/data/languages/spanish.txt
+++ b/data/languages/spanish.txt
@@ -690,8 +690,8 @@ Video name:
 Show DDNet map finishes in server browser
 == Marcar los mapas DDNet acabados en el navegador de servidores
 
-transmits your player name to info2.ddnet.tw
-== transmite tu nombre de jugador a info2.ddnet.tw
+transmits your player name to info.ddnet.org
+== transmite tu nombre de jugador a info.ddnet.org
 
 Search
 == Buscar
@@ -1167,8 +1167,8 @@ Particles
 Assets directory
 == Directorio de recursos
 
-https://wiki.ddnet.tw/
-== https://wiki.ddnet.tw/
+https://wiki.ddnet.org/
+== https://wiki.ddnet.org/
 
 Website
 == Página web
@@ -1270,8 +1270,8 @@ Regular Background Color
 Discord
 == Discord
 
-https://ddnet.tw/discord
-== https://ddnet.tw/discord
+https://ddnet.org/discord
+== https://ddnet.org/discord
 
 Are you sure that you want to disconnect and switch to a different server?
 == ¿Seguro que quieres desconectarte y cambiar de servidor?

--- a/data/languages/swedish.txt
+++ b/data/languages/swedish.txt
@@ -714,8 +714,8 @@ Personal best:
 Show DDNet map finishes in server browser
 == Visa DDNet bana avklarningar i server bläddraren
 
-transmits your player name to info2.ddnet.tw
-== skickar ditt spel namn till info2.ddnet.tw
+transmits your player name to info.ddnet.org
+== skickar ditt spel namn till info.ddnet.org
 
 9+ new mentions
 == 9+ nya nämningar
@@ -1092,8 +1092,8 @@ Download skins
 Client message
 == Klientmeddelande
 
-https://wiki.ddnet.tw/
-== https://wiki.ddnet.tw/
+https://wiki.ddnet.org/
+== https://wiki.ddnet.org/
 
 Website
 == Hemsida
@@ -1285,8 +1285,8 @@ Assets directory
 Discord
 == Discord
 
-https://ddnet.tw/discord
-== https://ddnet.tw/discord
+https://ddnet.org/discord
+== https://ddnet.org/discord
 
 The format of texture %s is not RGBA which will cause visual bugs.
 == 

--- a/data/languages/traditional_chinese.txt
+++ b/data/languages/traditional_chinese.txt
@@ -915,8 +915,8 @@ Date
 Show DDNet map finishes in server browser
 == 在伺服器瀏覽器中顯示已完成的 DDNet 地圖
 
-transmits your player name to info2.ddnet.tw
-== 將會發送您的玩家名稱到 info2.ddnet.tw
+transmits your player name to info.ddnet.org
+== 將會發送您的玩家名稱到 info.ddnet.org
 
 Reload
 == 重新整理
@@ -1083,7 +1083,7 @@ Use k key to kill (restart), q to pause and watch other players. See settings fo
 Country / Region
 == 國家/地區
 
-https://wiki.ddnet.tw/
+https://wiki.ddnet.org/
 == https://docs.qq.com/doc/DWGFrV0xPRmVWVkla
 
 Warning
@@ -1273,8 +1273,8 @@ Regular Background Color
 Discord
 == Discord
 
-https://ddnet.tw/discord
-== https://ddnet.tw/discord
+https://ddnet.org/discord
+== https://ddnet.org/discord
 
 Are you sure that you want to disconnect and switch to a different server?
 == 您確定要中斷此伺服器并嘗試加入其他伺服器嗎？

--- a/data/languages/turkish.txt
+++ b/data/languages/turkish.txt
@@ -678,8 +678,8 @@ Video name:
 Show DDNet map finishes in server browser
 == Tamamlanan DDNet haritalarını sunucu listesinde göster
 
-transmits your player name to info2.ddnet.tw
-== oyuncu adını info2.ddnet.tw ile paylaşır
+transmits your player name to info.ddnet.org
+== oyuncu adını info.ddnet.org ile paylaşır
 
 Search
 == Ara
@@ -1517,10 +1517,10 @@ Assets directory
 Discord
 == 
 
-https://ddnet.tw/discord
+https://ddnet.org/discord
 == 
 
-https://wiki.ddnet.tw/
+https://wiki.ddnet.org/
 == 
 
 Tutorial

--- a/data/languages/ukrainian.txt
+++ b/data/languages/ukrainian.txt
@@ -550,8 +550,8 @@ Video name:
 Show DDNet map finishes in server browser
 == Показувати завершені карти DDNet в браузері сервера
 
-transmits your player name to info2.ddnet.tw
-== передає Ваш нікнейм на info2.ddnet.tw
+transmits your player name to info.ddnet.org
+== передає Ваш нікнейм на info.ddnet.org
 
 Search
 == Пошук
@@ -1243,11 +1243,11 @@ Assets directory
 Discord
 == Діскорд
 
-https://ddnet.tw/discord
-== https://ddnet.tw/discord
+https://ddnet.org/discord
+== https://ddnet.org/discord
 
-https://wiki.ddnet.tw/
-== https://wiki.ddnet.tw/
+https://wiki.ddnet.org/
+== https://wiki.ddnet.org/
 
 Website
 == Вебсайт

--- a/man/DDNet.adoc
+++ b/man/DDNet.adoc
@@ -35,13 +35,13 @@ a *Teeworlds* modification with a unique cooperative gameplay.
 Load _CONFIGURATION_FILE_ instead of default _settings_ddnet.cfg_
 
 === Other options
-All options can be found here: https://ddnet.tw/settingscommands/
+All options can be found here: https://ddnet.org/settingscommands/
 
 == RESOURCES
-- *Website*: https://ddnet.tw/
-- *RSS*: https://ddnet.tw/feed/
-- *Forum*: https://forum.ddnet.tw/
-- *Discord*: https://ddnet.tw/discord
+- *Website*: https://ddnet.org/
+- *RSS*: https://ddnet.org/feed/
+- *Forum*: https://forum.ddnet.org/
+- *Discord*: https://ddnet.org/discord
 - *Source*: https://github.com/ddnet/ddnet
 
 == REPORTING BUGS

--- a/man/DDNetServer.adoc
+++ b/man/DDNetServer.adoc
@@ -35,13 +35,13 @@ a *Teeworlds* modification with a unique cooperative gameplay.
 Load _CONFIGURATION_FILE_ instead of default _autoexec_server.cfg_
 
 === Other options
-All options can be found here: https://ddnet.tw/settingscommands/
+All options can be found here: https://ddnet.org/settingscommands/
 
 == RESOURCES
-- *Website*: https://ddnet.tw/
-- *RSS*: https://ddnet.tw/feed/
-- *Forum*: https://forum.ddnet.tw/
-- *Discord*: https://ddnet.tw/discord
+- *Website*: https://ddnet.org/
+- *RSS*: https://ddnet.org/feed/
+- *Forum*: https://forum.ddnet.org/
+- *Discord*: https://ddnet.org/discord
 - *Source*: https://github.com/ddnet/ddnet
 
 == REPORTING BUGS

--- a/other/ddnet.appdata.xml
+++ b/other/ddnet.appdata.xml
@@ -18,13 +18,13 @@
     </description>
     <screenshots>
         <screenshot type="default">
-            <image>https://ddnet.tw/screenshots/1.png</image>
+            <image>https://ddnet.org/screenshots/1.png</image>
         </screenshot>
         <screenshot>
-            <image>https://ddnet.tw/screenshots/2.png</image>
+            <image>https://ddnet.org/screenshots/2.png</image>
         </screenshot>
         <screenshot>
-            <image>https://ddnet.tw/screenshots/3.png</image>
+            <image>https://ddnet.org/screenshots/3.png</image>
         </screenshot>
     </screenshots>
     <keywords>
@@ -82,7 +82,7 @@
         <release date="2020-05-01" version="13.1"/>
         <release date="2020-04-10" version="13.0.2"/>
     </releases>
-    <url type="homepage">https://ddnet.tw/</url>
+    <url type="homepage">https://ddnet.org/</url>
     <url type="bugtracker">https://github.com/ddnet/ddnet/issues</url>
     <url type="donation">https://www.paypal.me/ddnet</url>
     <provides>

--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -905,8 +905,10 @@ void sphore_destroy(SEMAPHORE *sem) { CloseHandle((HANDLE)*sem); }
 void sphore_init(SEMAPHORE *sem)
 {
 	char aBuf[64];
-	str_format(aBuf, sizeof(aBuf), "/%d-ddnet.tw-%p", pid(), (void *)sem);
+	str_format(aBuf, sizeof(aBuf), "%p", (void *)sem);
 	*sem = sem_open(aBuf, O_CREAT | O_EXCL, S_IRWXU | S_IRWXG, 0);
+	if(*sem == SEM_FAILED)
+		dbg_msg("sphore", "init failed: %d", errno);
 }
 void sphore_wait(SEMAPHORE *sem) { sem_wait(*sem); }
 void sphore_signal(SEMAPHORE *sem) { sem_post(*sem); }
@@ -914,7 +916,7 @@ void sphore_destroy(SEMAPHORE *sem)
 {
 	char aBuf[64];
 	sem_close(*sem);
-	str_format(aBuf, sizeof(aBuf), "/%d-ddnet.tw-%p", pid(), (void *)sem);
+	str_format(aBuf, sizeof(aBuf), "%p", (void *)sem);
 	sem_unlink(aBuf);
 }
 #elif defined(CONF_FAMILY_UNIX)

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -1764,7 +1764,7 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket, int Conn, bool Dummy)
 						char aUrl[256];
 						char aEscaped[256];
 						EscapeUrl(aEscaped, sizeof(aEscaped), m_aMapdownloadFilename + 15); // cut off downloadedmaps/
-						bool UseConfigUrl = str_comp(g_Config.m_ClMapDownloadUrl, "https://maps2.ddnet.tw") != 0 || m_aMapDownloadUrl[0] == '\0';
+						bool UseConfigUrl = str_comp(g_Config.m_ClMapDownloadUrl, "https://maps.ddnet.org") != 0 || m_aMapDownloadUrl[0] == '\0';
 						str_format(aUrl, sizeof(aUrl), "%s/%s", UseConfigUrl ? g_Config.m_ClMapDownloadUrl : m_aMapDownloadUrl, aEscaped);
 
 						m_pMapdownloadTask = HttpGetFile(aUrl, Storage(), m_aMapdownloadFilenameTemp, IStorage::TYPE_SAVE);
@@ -4148,7 +4148,7 @@ void CClient::InitChecksum()
 }
 
 #ifndef DDNET_CHECKSUM_SALT
-// salt@checksum.ddnet.tw: db877f2b-2ddb-3ba6-9f67-a6d169ec671d
+// salt@checksum.ddnet.org: db877f2b-2ddb-3ba6-9f67-a6d169ec671d
 #define DDNET_CHECKSUM_SALT \
 	{ \
 		{ \
@@ -4833,7 +4833,7 @@ bool CClient::RaceRecord_IsRecording()
 void CClient::RequestDDNetInfo()
 {
 	char aUrl[256];
-	str_copy(aUrl, "https://info2.ddnet.tw/info");
+	str_copy(aUrl, "https://info.ddnet.org/info");
 
 	if(g_Config.m_BrIndicateFinished)
 	{

--- a/src/engine/client/serverbrowser_http.cpp
+++ b/src/engine/client/serverbrowser_http.cpp
@@ -491,10 +491,10 @@ bool CServerBrowserHttp::Parse(json_value *pJson, std::vector<CServerInfo> *pvSe
 }
 
 static const char *DEFAULT_SERVERLIST_URLS[] = {
-	"https://master1.ddnet.tw/ddnet/15/servers.json",
-	"https://master2.ddnet.tw/ddnet/15/servers.json",
-	"https://master3.ddnet.tw/ddnet/15/servers.json",
-	"https://master4.ddnet.tw/ddnet/15/servers.json",
+	"https://master1.ddnet.org/ddnet/15/servers.json",
+	"https://master2.ddnet.org/ddnet/15/servers.json",
+	"https://master3.ddnet.org/ddnet/15/servers.json",
+	"https://master4.ddnet.org/ddnet/15/servers.json",
 };
 
 IServerBrowserHttp *CreateServerBrowserHttp(IEngine *pEngine, IConsole *pConsole, IStorage *pStorage, const char *pPreviousBestUrl)

--- a/src/engine/client/updater.cpp
+++ b/src/engine/client/updater.cpp
@@ -30,7 +30,7 @@ public:
 
 static const char *GetUpdaterUrl(char *pBuf, int BufSize, const char *pFile)
 {
-	str_format(pBuf, BufSize, "https://update6.ddnet.tw/%s", pFile);
+	str_format(pBuf, BufSize, "https://update.ddnet.org/%s", pFile);
 	return pBuf;
 }
 

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -61,7 +61,7 @@ MACRO_CONFIG_INT(BrFilterUnfinishedMap, br_filter_unfinished_map, 0, 0, 1, CFGFL
 
 MACRO_CONFIG_STR(BrFilterExcludeCountries, br_filter_exclude_countries, 128, "", CFGFLAG_SAVE | CFGFLAG_CLIENT, "Filter out DDNet servers by country")
 MACRO_CONFIG_STR(BrFilterExcludeTypes, br_filter_exclude_types, 128, "", CFGFLAG_SAVE | CFGFLAG_CLIENT, "Filter out DDNet servers by type (mod)")
-MACRO_CONFIG_INT(BrIndicateFinished, br_indicate_finished, 1, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Show whether you have finished a DDNet map (transmits your player name to info2.ddnet.tw/info)")
+MACRO_CONFIG_INT(BrIndicateFinished, br_indicate_finished, 1, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Show whether you have finished a DDNet map (transmits your player name to info.ddnet.org/info)")
 MACRO_CONFIG_STR(BrLocation, br_location, 16, "auto", CFGFLAG_SAVE | CFGFLAG_CLIENT, "Override location for ping estimation, available: auto, af, as, as:cn, eu, na, oc, sa (Automatic, Africa, Asia, China, Europe, North America, Oceania/Australia, South America")
 MACRO_CONFIG_STR(BrCachedBestServerinfoUrl, br_cached_best_serverinfo_url, 256, "", CFGFLAG_SAVE | CFGFLAG_CLIENT, "Do not set this variable, instead create a ddnet-serverlist-urls.cfg next to settings_ddnet.cfg to specify all possible serverlist URLs")
 
@@ -157,7 +157,7 @@ MACRO_CONFIG_INT(SvMaxClientsPerIP, sv_max_clients_per_ip, 4, 1, MAX_CLIENTS, CF
 MACRO_CONFIG_INT(SvHighBandwidth, sv_high_bandwidth, 0, 0, 1, CFGFLAG_SERVER, "Use high bandwidth mode. Doubles the bandwidth required for the server. LAN use only")
 MACRO_CONFIG_STR(SvRegister, sv_register, 16, "1", CFGFLAG_SERVER, "Register server with master server for public listing, can also accept a comma-separated list of protocols to register on, like 'ipv4,ipv6'")
 MACRO_CONFIG_STR(SvRegisterExtra, sv_register_extra, 256, "", CFGFLAG_SERVER, "Extra headers to send to the register endpoint, comma separated 'Header: Value' pairs")
-MACRO_CONFIG_STR(SvRegisterUrl, sv_register_url, 128, "https://master1.ddnet.tw/ddnet/15/register", CFGFLAG_SERVER, "Masterserver URL to register to")
+MACRO_CONFIG_STR(SvRegisterUrl, sv_register_url, 128, "https://master1.ddnet.org/ddnet/15/register", CFGFLAG_SERVER, "Masterserver URL to register to")
 MACRO_CONFIG_STR(SvRconPassword, sv_rcon_password, 32, "", CFGFLAG_SERVER | CFGFLAG_NONTEEHISTORIC, "Remote console password (full access)")
 MACRO_CONFIG_STR(SvRconModPassword, sv_rcon_mod_password, 32, "", CFGFLAG_SERVER | CFGFLAG_NONTEEHISTORIC, "Remote console password for moderators (limited access)")
 MACRO_CONFIG_STR(SvRconHelperPassword, sv_rcon_helper_password, 32, "", CFGFLAG_SERVER | CFGFLAG_NONTEEHISTORIC, "Remote console password for helpers (limited access)")

--- a/src/engine/shared/protocol_ex_msgs.h
+++ b/src/engine/shared/protocol_ex_msgs.h
@@ -11,7 +11,7 @@
 // 1) `i-unfreeze-you@ddnet.tw`
 // 2) `creeper@minetee`
 //
-// The first example applies if you own the `ddnet.tw` domain, that is, if you
+// The first example applies if you own the `ddnet.org` domain, that is, if you
 // are adding this message on behalf of the DDNet team.
 //
 // The second example shows how you could add a message if you don't own a

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -2204,7 +2204,7 @@ int CMenus::Render()
 			Part.VSplitLeft(30.0f, 0, &Part);
 			str_format(aBuf, sizeof(aBuf), "%s\n(%s)",
 				Localize("Show DDNet map finishes in server browser"),
-				Localize("transmits your player name to info2.ddnet.tw"));
+				Localize("transmits your player name to info.ddnet.org"));
 
 			if(DoButton_CheckBox(&g_Config.m_BrIndicateFinished, aBuf, g_Config.m_BrIndicateFinished, &Part))
 				g_Config.m_BrIndicateFinished ^= 1;

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -767,7 +767,7 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 	static CButtonContainer s_SkinDBDirID;
 	if(DoButton_Menu(&s_SkinDBDirID, Localize("Skin Database"), 0, &SkinDB))
 	{
-		const char *pLink = "https://ddnet.tw/skins/";
+		const char *pLink = "https://ddnet.org/skins/";
 		if(!open_link(pLink))
 		{
 			dbg_msg("menus", "couldn't open link '%s'", pLink);

--- a/src/game/client/components/menus_start.cpp
+++ b/src/game/client/components/menus_start.cpp
@@ -44,7 +44,7 @@ void CMenus::RenderStartMenu(CUIRect MainView)
 	static CButtonContainer s_DiscordButton;
 	if(DoButton_Menu(&s_DiscordButton, Localize("Discord"), 0, &Button, 0, IGraphics::CORNER_ALL, 5.0f, 0.0f, vec4(0.0f, 0.0f, 0.0f, 0.5f), vec4(0.0f, 0.0f, 0.0f, 0.25f)))
 	{
-		const char *pLink = Localize("https://ddnet.tw/discord");
+		const char *pLink = Localize("https://ddnet.org/discord");
 		if(!open_link(pLink))
 		{
 			dbg_msg("menus", "couldn't open link '%s'", pLink);
@@ -57,7 +57,7 @@ void CMenus::RenderStartMenu(CUIRect MainView)
 	static CButtonContainer s_LearnButton;
 	if(DoButton_Menu(&s_LearnButton, Localize("Learn"), 0, &Button, 0, IGraphics::CORNER_ALL, 5.0f, 0.0f, vec4(0.0f, 0.0f, 0.0f, 0.5f), vec4(0.0f, 0.0f, 0.0f, 0.25f)))
 	{
-		const char *pLink = Localize("https://wiki.ddnet.tw/");
+		const char *pLink = Localize("https://wiki.ddnet.org/");
 		if(!open_link(pLink))
 		{
 			dbg_msg("menus", "couldn't open link '%s'", pLink);
@@ -96,7 +96,7 @@ void CMenus::RenderStartMenu(CUIRect MainView)
 	static CButtonContainer s_WebsiteButton;
 	if(DoButton_Menu(&s_WebsiteButton, Localize("Website"), 0, &Button, 0, IGraphics::CORNER_ALL, 5.0f, 0.0f, vec4(0.0f, 0.0f, 0.0f, 0.5f), vec4(0.0f, 0.0f, 0.0f, 0.25f)))
 	{
-		const char *pLink = "https://ddnet.tw/";
+		const char *pLink = "https://ddnet.org/";
 		if(!open_link(pLink))
 		{
 			dbg_msg("menus", "couldn't open link '%s'", pLink);

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -508,7 +508,7 @@ void CPlayer::OnPredictedInput(CNetObj_PlayerInput *pNewInput)
 	if(m_NumInputs == 20 && g_Config.m_SvClientSuggestion[0] != '\0' && GetClientVersion() <= VERSION_DDNET_OLD)
 		GameServer()->SendBroadcast(g_Config.m_SvClientSuggestion, m_ClientID);
 	else if(m_NumInputs == 200 && Server()->IsSixup(m_ClientID))
-		GameServer()->SendBroadcast("This server uses an experimental translation from Teeworlds 0.7 to 0.6. Please report bugs on ddnet.tw/discord", m_ClientID);
+		GameServer()->SendBroadcast("This server uses an experimental translation from Teeworlds 0.7 to 0.6. Please report bugs on ddnet.org/discord", m_ClientID);
 }
 
 void CPlayer::OnDirectInput(CNetObj_PlayerInput *pNewInput)

--- a/src/game/variables.h
+++ b/src/game/variables.h
@@ -97,14 +97,14 @@ MACRO_CONFIG_INT(ClShowWelcome, cl_show_welcome, 1, 0, 1, CFGFLAG_CLIENT | CFGFL
 MACRO_CONFIG_INT(ClMotdTime, cl_motd_time, 10, 0, 100, CFGFLAG_CLIENT | CFGFLAG_SAVE, "How long to show the server message of the day")
 
 // http map download
-MACRO_CONFIG_STR(ClMapDownloadUrl, cl_map_download_url, 100, "https://maps2.ddnet.tw", CFGFLAG_CLIENT | CFGFLAG_SAVE, "URL used to download maps (can start with http:// or https://)")
+MACRO_CONFIG_STR(ClMapDownloadUrl, cl_map_download_url, 100, "https://maps.ddnet.org", CFGFLAG_CLIENT | CFGFLAG_SAVE, "URL used to download maps (can start with http:// or https://)")
 MACRO_CONFIG_INT(ClMapDownloadConnectTimeoutMs, cl_map_download_connect_timeout_ms, 2000, 0, 100000, CFGFLAG_CLIENT | CFGFLAG_SAVE, "HTTP map downloads: timeout for the connect phase in milliseconds (0 to disable)")
 MACRO_CONFIG_INT(ClMapDownloadLowSpeedLimit, cl_map_download_low_speed_limit, 4000, 0, 100000, CFGFLAG_CLIENT | CFGFLAG_SAVE, "HTTP map downloads: Set low speed limit in bytes per second (0 to disable)")
 MACRO_CONFIG_INT(ClMapDownloadLowSpeedTime, cl_map_download_low_speed_time, 3, 0, 100000, CFGFLAG_CLIENT | CFGFLAG_SAVE, "HTTP map downloads: Set low speed limit time period (0 to disable)")
 
 MACRO_CONFIG_STR(ClLanguagefile, cl_languagefile, 255, "", CFGFLAG_CLIENT | CFGFLAG_SAVE, "What language file to use")
-MACRO_CONFIG_STR(ClSkinDownloadUrl, cl_skin_download_url, 100, "https://skins.ddnet.tw/skin/", CFGFLAG_CLIENT | CFGFLAG_SAVE, "URL used to download skins")
-MACRO_CONFIG_STR(ClSkinCommunityDownloadUrl, cl_skin_community_download_url, 100, "https://skins.ddnet.tw/skin/community/", CFGFLAG_CLIENT | CFGFLAG_SAVE, "URL used to download community skins")
+MACRO_CONFIG_STR(ClSkinDownloadUrl, cl_skin_download_url, 100, "https://skins.ddnet.org/skin/", CFGFLAG_CLIENT | CFGFLAG_SAVE, "URL used to download skins")
+MACRO_CONFIG_STR(ClSkinCommunityDownloadUrl, cl_skin_community_download_url, 100, "https://skins.ddnet.org/skin/community/", CFGFLAG_CLIENT | CFGFLAG_SAVE, "URL used to download community skins")
 MACRO_CONFIG_INT(ClVanillaSkinsOnly, cl_vanilla_skins_only, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Only show skins available in Vanilla Teeworlds")
 MACRO_CONFIG_INT(ClDownloadSkins, cl_download_skins, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Download skins from cl_skin_download_url on-the-fly")
 MACRO_CONFIG_INT(ClDownloadCommunitySkins, cl_download_community_skins, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Allow to download skins created by the community. Uses cl_skin_community_download_url instead of cl_skin_download_url for the download")


### PR DESCRIPTION
I prefer the new ddnet.org domain, looks cleaner, makes it clear this is not a Taiwanese project. (The .tw = Teeworlds connection was cute, but we might have outgrown it.)
Missing: wiki.ddnet.org @edg-l 
We are still using netobj.ddnet.tw and @ddnet.tw for teehistorian
The sites currently redirect temporarily to ddnet.tw equivalents. Next step will be to switch that around so that ddnet.org are official and ddnet.tw permanently redirect to ddnet.tw. This should coincide with the release of this version to keep latency low for most users.
## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
