### PR TITLE
Fix deleting envelopes not updating sounds

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -6204,6 +6204,21 @@ void CEditorMap::DeleteEnvelope(int Index)
 				if(pLayer->m_ColorEnv > Index)
 					pLayer->m_ColorEnv--;
 			}
+			else if (m_lGroups[i]->m_lLayers[j]->m_Type == LAYERTYPE_SOUNDS)
+			{
+				CLayerSounds *pLayer = static_cast<CLayerSounds *>(m_lGroups[i]->m_lLayers[j]);
+				for(int k = 0; k < pLayer->m_lSources.size(); ++k)
+				{
+					if(pLayer->m_lSources[k].m_PosEnv == Index)
+						pLayer->m_lSources[k].m_PosEnv = -1;
+					else if(pLayer->m_lSources[k].m_PosEnv > Index)
+						pLayer->m_lSources[k].m_PosEnv--;
+					if(pLayer->m_lSources[k].m_SoundEnv == Index)
+						pLayer->m_lSources[k].m_SoundEnv = -1;
+					else if(pLayer->m_lSources[k].m_SoundEnv > Index)
+						pLayer->m_lSources[k].m_SoundEnv--;
+				}
+			}
 
 	m_lEnvelopes.remove_index(Index);
 }


### PR DESCRIPTION
Deleting envelopes can lead to sounds having an invalid envelope index.

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
