### PR TITLE
Explicitly delete game server from list on shutdown

### DIFF
--- a/src/engine/server/register.h
+++ b/src/engine/server/register.h
@@ -20,6 +20,7 @@ public:
 	virtual bool OnPacket(const CNetChunk *pPacket) = 0;
 	// `pInfo` must be an encoded JSON object.
 	virtual void OnNewInfo(const char *pInfo) = 0;
+	virtual void OnShutdown() = 0;
 };
 
 IRegister *CreateRegister(CConfig *pConfig, IConsole *pConsole, IEngine *pEngine, int ServerPort, unsigned SixupSecurityToken);

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -2919,6 +2919,8 @@ int CServer::Run()
 
 	m_NetServer.Close();
 
+	m_pRegister->OnShutdown();
+
 	return ErrorShutdown();
 }
 


### PR DESCRIPTION
Also delete it explicitly when `sv_register` is set to register via less
protocols.

On shutdown, wait at most 1 second for the masterserver to respond,
otherwise allow up to 15 seconds.

Fixes https://github.com/ddnet/ddnet/issues/5157.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
