### PR TITLE
Let the names in the mini score hud overflow to the left

### DIFF
--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -442,8 +442,9 @@ void CHud::RenderScoreHud()
 								TextRender()->DeleteTextContainer(m_aScoreInfo[t].m_OptionalNameTextContainerIndex);
 
 							CTextCursor Cursor;
-							TextRender()->SetCursor(&Cursor, m_Width - ScoreWidthMax - ImageSize - 2 * Split - PosSize, StartY + (t + 1) * 20.0f - 2.0f, 8.0f, TEXTFLAG_RENDER | TEXTFLAG_ELLIPSIS_AT_END);
-							Cursor.m_LineWidth = m_Width - Cursor.m_X - Split;
+							float w = TextRender()->TextWidth(0, 8.0f, pName, -1, -1.0f);
+							TextRender()->SetCursor(&Cursor, minimum(m_Width - w - 1.0f, m_Width - ScoreWidthMax - ImageSize - 2 * Split - PosSize), StartY + (t + 1) * 20.0f - 2.0f, 8.0f, TEXTFLAG_RENDER);
+							Cursor.m_LineWidth = -1;
 							m_aScoreInfo[t].m_OptionalNameTextContainerIndex = TextRender()->CreateTextContainer(&Cursor, pName);
 						}
 


### PR DESCRIPTION
## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [x] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
