### PR TITLE
Pass OVERLAPPED parameter to WriteFile according to specification

### DIFF
--- a/src/base/log.cpp
+++ b/src/base/log.cpp
@@ -398,8 +398,10 @@ public:
 	void Log(const CLogMessage *pMessage) override
 	{
 		m_OutputLock.lock();
-		WriteFile(m_pFile, pMessage->m_aLine, pMessage->m_LineLength, NULL, NULL);
-		WriteFile(m_pFile, "\r\n", 2, NULL, NULL);
+		OVERLAPPED Overlapped1{};
+		WriteFile(m_pFile, pMessage->m_aLine, pMessage->m_LineLength, NULL, &Overlapped1);
+		OVERLAPPED Overlapped2{};
+		WriteFile(m_pFile, "\r\n", 2, NULL, &Overlapped2);
 		m_OutputLock.unlock();
 	}
 };


### PR DESCRIPTION
Maybe closes #5322. I can't reproduce the crash. Can you try if this fixes it, @Chairn?

Alternative to #5332.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
