### PR TITLE
Pass output parameter to WriteFile that is required on Windows 7

### DIFF
--- a/src/base/log.cpp
+++ b/src/base/log.cpp
@@ -398,8 +398,9 @@ public:
 	void Log(const CLogMessage *pMessage) override
 	{
 		m_OutputLock.lock();
-		WriteFile(m_pFile, pMessage->m_aLine, pMessage->m_LineLength, NULL, NULL);
-		WriteFile(m_pFile, "\r\n", 2, NULL, NULL);
+		DWORD Written; // we don't care about the value, but Windows 7 crashes if we pass NULL
+		WriteFile(m_pFile, pMessage->m_aLine, pMessage->m_LineLength, &Written, NULL);
+		WriteFile(m_pFile, "\r\n", 2, &Written, NULL);
 		m_OutputLock.unlock();
 	}
 };


### PR DESCRIPTION
Maybe closes #5322. I can't reproduce the crash. Can you try if this fixes it, @Chairn?

Looks like Windows 7 needs this parameter.

Alternative to #5331.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
