### PR TITLE
Unfreeze character after teleporting in practice

### DIFF
--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -1515,6 +1515,7 @@ void CGameContext::ConTele(IConsole::IResult *pResult, void *pUserData)
 	}
 
 	pSelf->Teleport(pChr, Pos);
+	pChr->UnFreeze();
 }
 
 void CGameContext::ConProtectedKill(IConsole::IResult *pResult, void *pUserData)


### PR DESCRIPTION
From my experience and seeing others play, this would be more convenient. Currently teleporting (while being frozen) to retry a part that doesn't have much space or a platform to stand on is a bit hard, often requiring the player to teleport quickly to a position in air multiple times till the character is unfrozen or teleporting to a different part till the character is ready to be put in the original part again. This can also save some time when practicing in general, and will make /tp feel more like /r. This was added only for the /tp command so it shouldn't affect other teleportation methods.
Something to note is that the character teleported into freeze will have the 1 tick unfreeze to jump or so, but it's practice mode so doesn't seem like something to consider.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
