### PR TITLE
Don't write aAnsi when it's not filled (fixes #5340)

### DIFF
--- a/src/base/log.cpp
+++ b/src/base/log.cpp
@@ -234,13 +234,14 @@ public:
 					pMessage->m_Color.r,
 					pMessage->m_Color.g,
 					pMessage->m_Color.b);
+				aio_write_unlocked(m_pAio, aAnsi, str_length(aAnsi));
 			}
-			aio_write_unlocked(m_pAio, aAnsi, str_length(aAnsi));
 		}
 		aio_write_unlocked(m_pAio, pMessage->m_aLine, pMessage->m_LineLength);
 		if(m_AnsiTruecolor && pMessage->m_HaveColor)
 		{
-			aio_write_unlocked(m_pAio, "\x1b[0m", 4); // reset
+			const char aResetColor[] = "\x1b[0m";
+			aio_write_unlocked(m_pAio, aResetColor, sizeof(aResetColor)); // reset
 		}
 		aio_write_newline_unlocked(m_pAio);
 		aio_unlock(m_pAio);


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
