### PR TITLE
Fix deleting envelopes not updating sounds

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -6190,6 +6190,21 @@ void CEditorMap::DeleteEnvelope(int Index)
 				if(pLayerTiles->m_ColorEnv > Index)
 					pLayerTiles->m_ColorEnv--;
 			}
+			else if(pLayer->m_Type == LAYERTYPE_SOUNDS)
+			{
+				CLayerSounds *pLayerSounds = static_cast<CLayerSounds *>(pLayer);
+				for(auto &Source : pLayerSounds->m_lSources)
+				{
+					if(Source.m_PosEnv == Index)
+						Source.m_PosEnv = -1;
+					else if(Source.m_PosEnv > Index)
+						Source.m_PosEnv--;
+					if(Source.m_SoundEnv == Index)
+						Source.m_SoundEnv = -1;
+					else if(Source.m_SoundEnv > Index)
+						Source.m_SoundEnv--;
+				}
+			}
 
 	m_lEnvelopes.erase(m_lEnvelopes.begin() + Index);
 }


### PR DESCRIPTION
Original fix by Ravie... updated to latest code

I do not really know how to trigger the bug, but for me adding and deleting sounds to the map, worked.... Since it is only the updated version from Ravie I think it works
@HiRavie maybe you can test it again

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
