### PR TITLE
Refactoring: Use MultiByteToWideChar instead of str_utf16le_encode

### DIFF
--- a/src/base/log.cpp
+++ b/src/base/log.cpp
@@ -332,12 +332,17 @@ public:
 	{
 		int WLen = MultiByteToWideChar(CP_UTF8, 0, pMessage->m_aLine, pMessage->m_LineLength, NULL, 0);
 		if(!WLen)
+		{
+			WCHAR aError[] = L"Failed to obtain length of log message\r\n";
+			WriteConsoleW(m_pConsole, aError, std::size(aError) - 1, NULL, NULL);
 			return;
-
+		}
 		WCHAR *pWide = (WCHAR *)malloc((WLen + 2) * sizeof(*pWide));
 		WLen = MultiByteToWideChar(CP_UTF8, 0, pMessage->m_aLine, pMessage->m_LineLength, pWide, WLen);
 		if(!WLen)
 		{
+			WCHAR aError[] = L"Failed to convert log message encoding\r\n";
+			WriteConsoleW(m_pConsole, aError, std::size(aError) - 1, NULL, NULL);
 			free(pWide);
 			return;
 		}

--- a/src/base/log.cpp
+++ b/src/base/log.cpp
@@ -330,32 +330,20 @@ public:
 	}
 	void Log(const CLogMessage *pMessage) override
 	{
-		wchar_t *pWide = (wchar_t *)malloc((pMessage->m_LineLength + 2) * sizeof(*pWide));
-		const char *p = pMessage->m_aLine;
-		int WLen = 0;
+		int WLen = MultiByteToWideChar(CP_UTF8, 0, pMessage->m_aLine, pMessage->m_LineLength, NULL, 0);
+		if(!WLen)
+			return;
 
-		mem_zero(pWide, (pMessage->m_LineLength + 2) * sizeof(*pWide));
-
-		for(int Codepoint = 0; (Codepoint = str_utf8_decode(&p)); WLen++)
+		WCHAR *pWide = (WCHAR *)malloc((WLen + 2) * sizeof(*pWide));
+		WLen = MultiByteToWideChar(CP_UTF8, 0, pMessage->m_aLine, pMessage->m_LineLength, pWide, WLen);
+		if(!WLen)
 		{
-			char aU16[4] = {0};
-
-			if(Codepoint < 0)
-			{
-				free(pWide);
-				return;
-			}
-
-			if(str_utf16le_encode(aU16, Codepoint) != 2)
-			{
-				free(pWide);
-				return;
-			}
-
-			mem_copy(&pWide[WLen], aU16, 2);
+			free(pWide);
+			return;
 		}
 		pWide[WLen++] = '\r';
 		pWide[WLen++] = '\n';
+
 		int Color = m_BackgroundColor;
 		if(pMessage->m_HaveColor)
 		{

--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -3474,32 +3474,6 @@ int str_utf8_encode(char *ptr, int chr)
 	return 0;
 }
 
-int str_utf16le_encode(char *ptr, int chr)
-{
-	if(chr < 0x10000)
-	{
-		ptr[0] = chr;
-		ptr[1] = chr >> 0x8;
-		return 2;
-	}
-	else if(chr <= 0x10FFFF)
-	{
-		int U = chr - 0x10000;
-		int W1 = 0xD800, W2 = 0xDC00;
-
-		W1 |= ((U >> 10) & 0x3FF);
-		W2 |= (U & 0x3FF);
-
-		ptr[0] = W1;
-		ptr[1] = W1 >> 0x8;
-		ptr[2] = W2;
-		ptr[3] = W2 >> 0x8;
-		return 4;
-	}
-
-	return 0;
-}
-
 static unsigned char str_byte_next(const char **ptr)
 {
 	unsigned char byte = **ptr;

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -2157,21 +2157,6 @@ int str_utf8_decode(const char **ptr);
 int str_utf8_encode(char *ptr, int chr);
 
 /*
-	Function: str_utf16le_encode
-		Encode an utf8 character
-
-	Parameters:
-		ptr - Pointer to a buffer that should receive the data. Should be able to hold at least 4 bytes.
-
-	Returns:
-		Number of bytes put into the buffer.
-
-	Remarks:
-		- Does not do zero termination of the string.
-*/
-int str_utf16le_encode(char *ptr, int chr);
-
-/*
 	Function: str_utf8_check
 		Checks if a strings contains just valid utf8 characters.
 


### PR DESCRIPTION


## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
