### PR TITLE
Fix input getter for dummy

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -622,7 +622,7 @@ int *CClient::GetInput(int Tick, int IsDummy) const
 	}
 
 	if(Best != -1)
-		return (int *)m_aInputs[g_Config.m_ClDummy][Best].m_aData;
+		return (int *)m_aInputs[d][Best].m_aData;
 	return 0;
 }
 


### PR DESCRIPTION
Bug reported on discord by Broso56 that dummy is wrongly predicted with deepfly (and when standing still).

Looked at it and found that it was caused by GetInput not returning the dummy input as intended. (Before my last pr a different getter was used, which didn't have that problem)

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
