### PR TITLE
Refactoring: Extract CLayerTiles::ShiftImpl, BrushFlipXImpl and BrushFlipYImpl to reduce duplicate code

### DIFF
--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -540,6 +540,20 @@ protected:
 			}
 		}
 	}
+	template<typename T>
+	void BrushFlipXImpl(T *pTiles)
+	{
+		for(int y = 0; y < m_Height; y++)
+			for(int x = 0; x < m_Width / 2; x++)
+				std::swap(pTiles[y * m_Width + x], pTiles[(y + 1) * m_Width - 1 - x]);
+	}
+	template<typename T>
+	void BrushFlipYImpl(T *pTiles)
+	{
+		for(int y = 0; y < m_Height / 2; y++)
+			for(int x = 0; x < m_Width; x++)
+				std::swap(pTiles[y * m_Width + x], pTiles[(m_Height - 1 - y) * m_Width + x]);
+	}
 
 public:
 	CLayerTiles(int w, int h);

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -505,6 +505,42 @@ typedef struct
 
 class CLayerTiles : public CLayer
 {
+protected:
+	template<typename T>
+	void ShiftImpl(T *pTiles, int Direction, int ShiftBy)
+	{
+		switch(Direction)
+		{
+		case DIRECTION_LEFT:
+			for(int y = 0; y < m_Height; ++y)
+			{
+				mem_move(&pTiles[y * m_Width], &pTiles[y * m_Width + ShiftBy], (m_Width - ShiftBy) * sizeof(T));
+				mem_zero(&pTiles[y * m_Width + (m_Width - ShiftBy)], ShiftBy * sizeof(T));
+			}
+			break;
+		case DIRECTION_RIGHT:
+			for(int y = 0; y < m_Height; ++y)
+			{
+				mem_move(&pTiles[y * m_Width + ShiftBy], &pTiles[y * m_Width], (m_Width - ShiftBy) * sizeof(T));
+				mem_zero(&pTiles[y * m_Width], ShiftBy * sizeof(T));
+			}
+			break;
+		case DIRECTION_UP:
+			for(int y = 0; y < m_Height - ShiftBy; ++y)
+			{
+				mem_copy(&pTiles[y * m_Width], &pTiles[(y + ShiftBy) * m_Width], m_Width * sizeof(T));
+				mem_zero(&pTiles[(y + ShiftBy) * m_Width], m_Width * sizeof(T));
+			}
+			break;
+		case DIRECTION_DOWN:
+			for(int y = m_Height - 1; y >= ShiftBy; --y)
+			{
+				mem_copy(&pTiles[y * m_Width], &pTiles[(y - ShiftBy) * m_Width], m_Width * sizeof(T));
+				mem_zero(&pTiles[(y - ShiftBy) * m_Width], m_Width * sizeof(T));
+			}
+		}
+	}
+
 public:
 	CLayerTiles(int w, int h);
 	~CLayerTiles();

--- a/src/game/editor/layer_tiles.cpp
+++ b/src/game/editor/layer_tiles.cpp
@@ -503,9 +503,7 @@ void CLayerTiles::BrushDraw(CLayer *pBrush, float wx, float wy)
 
 void CLayerTiles::BrushFlipX()
 {
-	for(int y = 0; y < m_Height; y++)
-		for(int x = 0; x < m_Width / 2; x++)
-			std::swap(m_pTiles[y * m_Width + x], m_pTiles[y * m_Width + m_Width - 1 - x]);
+	BrushFlipXImpl(m_pTiles);
 
 	if(m_Tele || m_Speedup || m_Tune)
 		return;
@@ -521,9 +519,7 @@ void CLayerTiles::BrushFlipX()
 
 void CLayerTiles::BrushFlipY()
 {
-	for(int y = 0; y < m_Height / 2; y++)
-		for(int x = 0; x < m_Width; x++)
-			std::swap(m_pTiles[y * m_Width + x], m_pTiles[(m_Height - 1 - y) * m_Width + x]);
+	BrushFlipYImpl(m_pTiles);
 
 	if(m_Tele || m_Speedup || m_Tune)
 		return;
@@ -1168,19 +1164,13 @@ void CLayerTele::BrushDraw(CLayer *pBrush, float wx, float wy)
 void CLayerTele::BrushFlipX()
 {
 	CLayerTiles::BrushFlipX();
-
-	for(int y = 0; y < m_Height; y++)
-		for(int x = 0; x < m_Width / 2; x++)
-			std::swap(m_pTeleTile[y * m_Width + x], m_pTeleTile[y * m_Width + m_Width - 1 - x]);
+	BrushFlipXImpl(m_pTeleTile);
 }
 
 void CLayerTele::BrushFlipY()
 {
 	CLayerTiles::BrushFlipY();
-
-	for(int y = 0; y < m_Height / 2; y++)
-		for(int x = 0; x < m_Width; x++)
-			std::swap(m_pTeleTile[y * m_Width + x], m_pTeleTile[(m_Height - 1 - y) * m_Width + x]);
+	BrushFlipYImpl(m_pTeleTile);
 }
 
 void CLayerTele::BrushRotate(float Amount)
@@ -1420,19 +1410,13 @@ void CLayerSpeedup::BrushDraw(CLayer *pBrush, float wx, float wy)
 void CLayerSpeedup::BrushFlipX()
 {
 	CLayerTiles::BrushFlipX();
-
-	for(int y = 0; y < m_Height; y++)
-		for(int x = 0; x < m_Width / 2; x++)
-			std::swap(m_pSpeedupTile[y * m_Width + x], m_pSpeedupTile[y * m_Width + m_Width - 1 - x]);
+	BrushFlipXImpl(m_pSpeedupTile);
 }
 
 void CLayerSpeedup::BrushFlipY()
 {
 	CLayerTiles::BrushFlipY();
-
-	for(int y = 0; y < m_Height / 2; y++)
-		for(int x = 0; x < m_Width; x++)
-			std::swap(m_pSpeedupTile[y * m_Width + x], m_pSpeedupTile[(m_Height - 1 - y) * m_Width + x]);
+	BrushFlipYImpl(m_pSpeedupTile);
 }
 
 void CLayerSpeedup::BrushRotate(float Amount)
@@ -1708,19 +1692,13 @@ void CLayerSwitch::BrushDraw(CLayer *pBrush, float wx, float wy)
 void CLayerSwitch::BrushFlipX()
 {
 	CLayerTiles::BrushFlipX();
-
-	for(int y = 0; y < m_Height; y++)
-		for(int x = 0; x < m_Width / 2; x++)
-			std::swap(m_pSwitchTile[y * m_Width + x], m_pSwitchTile[y * m_Width + m_Width - 1 - x]);
+	BrushFlipXImpl(m_pSwitchTile);
 }
 
 void CLayerSwitch::BrushFlipY()
 {
 	CLayerTiles::BrushFlipY();
-
-	for(int y = 0; y < m_Height / 2; y++)
-		for(int x = 0; x < m_Width; x++)
-			std::swap(m_pSwitchTile[y * m_Width + x], m_pSwitchTile[(m_Height - 1 - y) * m_Width + x]);
+	BrushFlipYImpl(m_pSwitchTile);
 }
 
 void CLayerSwitch::BrushRotate(float Amount)
@@ -1959,19 +1937,13 @@ void CLayerTune::BrushDraw(CLayer *pBrush, float wx, float wy)
 void CLayerTune::BrushFlipX()
 {
 	CLayerTiles::BrushFlipX();
-
-	for(int y = 0; y < m_Height; y++)
-		for(int x = 0; x < m_Width / 2; x++)
-			std::swap(m_pTuneTile[y * m_Width + x], m_pTuneTile[y * m_Width + m_Width - 1 - x]);
+	BrushFlipXImpl(m_pTuneTile);
 }
 
 void CLayerTune::BrushFlipY()
 {
 	CLayerTiles::BrushFlipY();
-
-	for(int y = 0; y < m_Height / 2; y++)
-		for(int x = 0; x < m_Width; x++)
-			std::swap(m_pTuneTile[y * m_Width + x], m_pTuneTile[(m_Height - 1 - y) * m_Width + x]);
+	BrushFlipYImpl(m_pTuneTile);
 }
 
 void CLayerTune::BrushRotate(float Amount)

--- a/src/game/editor/layer_tiles.cpp
+++ b/src/game/editor/layer_tiles.cpp
@@ -613,38 +613,7 @@ void CLayerTiles::Resize(int NewW, int NewH)
 
 void CLayerTiles::Shift(int Direction)
 {
-	int o = m_pEditor->m_ShiftBy;
-
-	switch(Direction)
-	{
-	case DIRECTION_LEFT:
-		for(int y = 0; y < m_Height; ++y)
-		{
-			mem_move(&m_pTiles[y * m_Width], &m_pTiles[y * m_Width + o], (m_Width - o) * sizeof(CTile));
-			mem_zero(&m_pTiles[y * m_Width + (m_Width - o)], o * sizeof(CTile));
-		}
-		break;
-	case DIRECTION_RIGHT:
-		for(int y = 0; y < m_Height; ++y)
-		{
-			mem_move(&m_pTiles[y * m_Width + o], &m_pTiles[y * m_Width], (m_Width - o) * sizeof(CTile));
-			mem_zero(&m_pTiles[y * m_Width], o * sizeof(CTile));
-		}
-		break;
-	case DIRECTION_UP:
-		for(int y = 0; y < m_Height - o; ++y)
-		{
-			mem_copy(&m_pTiles[y * m_Width], &m_pTiles[(y + o) * m_Width], m_Width * sizeof(CTile));
-			mem_zero(&m_pTiles[(y + o) * m_Width], m_Width * sizeof(CTile));
-		}
-		break;
-	case DIRECTION_DOWN:
-		for(int y = m_Height - 1; y >= o; --y)
-		{
-			mem_copy(&m_pTiles[y * m_Width], &m_pTiles[(y - o) * m_Width], m_Width * sizeof(CTile));
-			mem_zero(&m_pTiles[(y - o) * m_Width], m_Width * sizeof(CTile));
-		}
-	}
+	ShiftImpl(m_pTiles, Direction, m_pEditor->m_ShiftBy);
 }
 
 void CLayerTiles::ShowInfo()
@@ -1124,38 +1093,7 @@ void CLayerTele::Resize(int NewW, int NewH)
 void CLayerTele::Shift(int Direction)
 {
 	CLayerTiles::Shift(Direction);
-	int o = m_pEditor->m_ShiftBy;
-
-	switch(Direction)
-	{
-	case DIRECTION_LEFT:
-		for(int y = 0; y < m_Height; ++y)
-		{
-			mem_move(&m_pTeleTile[y * m_Width], &m_pTeleTile[y * m_Width + o], (m_Width - o) * sizeof(CTeleTile));
-			mem_zero(&m_pTeleTile[y * m_Width + (m_Width - o)], o * sizeof(CTeleTile));
-		}
-		break;
-	case DIRECTION_RIGHT:
-		for(int y = 0; y < m_Height; ++y)
-		{
-			mem_move(&m_pTeleTile[y * m_Width + o], &m_pTeleTile[y * m_Width], (m_Width - o) * sizeof(CTeleTile));
-			mem_zero(&m_pTeleTile[y * m_Width], o * sizeof(CTeleTile));
-		}
-		break;
-	case DIRECTION_UP:
-		for(int y = 0; y < m_Height - o; ++y)
-		{
-			mem_copy(&m_pTeleTile[y * m_Width], &m_pTeleTile[(y + o) * m_Width], m_Width * sizeof(CTeleTile));
-			mem_zero(&m_pTeleTile[(y + o) * m_Width], m_Width * sizeof(CTeleTile));
-		}
-		break;
-	case DIRECTION_DOWN:
-		for(int y = m_Height - 1; y >= o; --y)
-		{
-			mem_copy(&m_pTeleTile[y * m_Width], &m_pTeleTile[(y - o) * m_Width], m_Width * sizeof(CTeleTile));
-			mem_zero(&m_pTeleTile[(y - o) * m_Width], m_Width * sizeof(CTeleTile));
-		}
-	}
+	ShiftImpl(m_pTeleTile, Direction, m_pEditor->m_ShiftBy);
 }
 
 bool CLayerTele::IsEmpty(CLayerTiles *pLayer)
@@ -1390,38 +1328,7 @@ void CLayerSpeedup::Resize(int NewW, int NewH)
 void CLayerSpeedup::Shift(int Direction)
 {
 	CLayerTiles::Shift(Direction);
-	int o = m_pEditor->m_ShiftBy;
-
-	switch(Direction)
-	{
-	case DIRECTION_LEFT:
-		for(int y = 0; y < m_Height; ++y)
-		{
-			mem_move(&m_pSpeedupTile[y * m_Width], &m_pSpeedupTile[y * m_Width + o], (m_Width - o) * sizeof(CSpeedupTile));
-			mem_zero(&m_pSpeedupTile[y * m_Width + (m_Width - o)], o * sizeof(CSpeedupTile));
-		}
-		break;
-	case DIRECTION_RIGHT:
-		for(int y = 0; y < m_Height; ++y)
-		{
-			mem_move(&m_pSpeedupTile[y * m_Width + o], &m_pSpeedupTile[y * m_Width], (m_Width - o) * sizeof(CSpeedupTile));
-			mem_zero(&m_pSpeedupTile[y * m_Width], o * sizeof(CSpeedupTile));
-		}
-		break;
-	case DIRECTION_UP:
-		for(int y = 0; y < m_Height - o; ++y)
-		{
-			mem_copy(&m_pSpeedupTile[y * m_Width], &m_pSpeedupTile[(y + o) * m_Width], m_Width * sizeof(CSpeedupTile));
-			mem_zero(&m_pSpeedupTile[(y + o) * m_Width], m_Width * sizeof(CSpeedupTile));
-		}
-		break;
-	case DIRECTION_DOWN:
-		for(int y = m_Height - 1; y >= o; --y)
-		{
-			mem_copy(&m_pSpeedupTile[y * m_Width], &m_pSpeedupTile[(y - o) * m_Width], m_Width * sizeof(CSpeedupTile));
-			mem_zero(&m_pSpeedupTile[(y - o) * m_Width], m_Width * sizeof(CSpeedupTile));
-		}
-	}
+	ShiftImpl(m_pSpeedupTile, Direction, m_pEditor->m_ShiftBy);
 }
 
 bool CLayerSpeedup::IsEmpty(CLayerTiles *pLayer)
@@ -1712,38 +1619,7 @@ void CLayerSwitch::Resize(int NewW, int NewH)
 void CLayerSwitch::Shift(int Direction)
 {
 	CLayerTiles::Shift(Direction);
-	int o = m_pEditor->m_ShiftBy;
-
-	switch(Direction)
-	{
-	case DIRECTION_LEFT:
-		for(int y = 0; y < m_Height; ++y)
-		{
-			mem_move(&m_pSwitchTile[y * m_Width], &m_pSwitchTile[y * m_Width + o], (m_Width - o) * sizeof(CSwitchTile));
-			mem_zero(&m_pSwitchTile[y * m_Width + (m_Width - o)], o * sizeof(CSwitchTile));
-		}
-		break;
-	case DIRECTION_RIGHT:
-		for(int y = 0; y < m_Height; ++y)
-		{
-			mem_move(&m_pSwitchTile[y * m_Width + o], &m_pSwitchTile[y * m_Width], (m_Width - o) * sizeof(CSwitchTile));
-			mem_zero(&m_pSwitchTile[y * m_Width], o * sizeof(CSwitchTile));
-		}
-		break;
-	case DIRECTION_UP:
-		for(int y = 0; y < m_Height - o; ++y)
-		{
-			mem_copy(&m_pSwitchTile[y * m_Width], &m_pSwitchTile[(y + o) * m_Width], m_Width * sizeof(CSwitchTile));
-			mem_zero(&m_pSwitchTile[(y + o) * m_Width], m_Width * sizeof(CSwitchTile));
-		}
-		break;
-	case DIRECTION_DOWN:
-		for(int y = m_Height - 1; y >= o; --y)
-		{
-			mem_copy(&m_pSwitchTile[y * m_Width], &m_pSwitchTile[(y - o) * m_Width], m_Width * sizeof(CSwitchTile));
-			mem_zero(&m_pSwitchTile[(y - o) * m_Width], m_Width * sizeof(CSwitchTile));
-		}
-	}
+	ShiftImpl(m_pSwitchTile, Direction, m_pEditor->m_ShiftBy);
 }
 
 bool CLayerSwitch::IsEmpty(CLayerTiles *pLayer)
@@ -2006,38 +1882,7 @@ void CLayerTune::Resize(int NewW, int NewH)
 void CLayerTune::Shift(int Direction)
 {
 	CLayerTiles::Shift(Direction);
-	int o = m_pEditor->m_ShiftBy;
-
-	switch(Direction)
-	{
-	case DIRECTION_LEFT:
-		for(int y = 0; y < m_Height; ++y)
-		{
-			mem_move(&m_pTuneTile[y * m_Width], &m_pTuneTile[y * m_Width + o], (m_Width - o) * sizeof(CTuneTile));
-			mem_zero(&m_pTuneTile[y * m_Width + (m_Width - o)], o * sizeof(CTuneTile));
-		}
-		break;
-	case DIRECTION_RIGHT:
-		for(int y = 0; y < m_Height; ++y)
-		{
-			mem_move(&m_pTuneTile[y * m_Width + o], &m_pTuneTile[y * m_Width], (m_Width - o) * sizeof(CTuneTile));
-			mem_zero(&m_pTuneTile[y * m_Width], o * sizeof(CTuneTile));
-		}
-		break;
-	case DIRECTION_UP:
-		for(int y = 0; y < m_Height - o; ++y)
-		{
-			mem_copy(&m_pTuneTile[y * m_Width], &m_pTuneTile[(y + o) * m_Width], m_Width * sizeof(CTuneTile));
-			mem_zero(&m_pTuneTile[(y + o) * m_Width], m_Width * sizeof(CTuneTile));
-		}
-		break;
-	case DIRECTION_DOWN:
-		for(int y = m_Height - 1; y >= o; --y)
-		{
-			mem_copy(&m_pTuneTile[y * m_Width], &m_pTuneTile[(y - o) * m_Width], m_Width * sizeof(CTuneTile));
-			mem_zero(&m_pTuneTile[(y - o) * m_Width], m_Width * sizeof(CTuneTile));
-		}
-	}
+	ShiftImpl(m_pTuneTile, Direction, m_pEditor->m_ShiftBy);
 }
 
 bool CLayerTune::IsEmpty(CLayerTiles *pLayer)


### PR DESCRIPTION
There is still more duplicate code but it's tricky to extract.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
