### PR TITLE
Extract CCmdlineFix to call cmdline_fix and cmdline_free automatically

### DIFF
--- a/src/base/system.h
+++ b/src/base/system.h
@@ -99,7 +99,7 @@ dbg_break();
  * @remark Also works in release mode.
  *
  * @see dbg_assert
-*/
+ */
 void dbg_msg(const char *sys, const char *fmt, ...)
 	GNUC_ATTRIBUTE((format(printf, 2, 3)));
 
@@ -194,7 +194,7 @@ typedef struct IOINTERNAL *IOHANDLE;
  * @ingroup File-IO
  *
  * @param File to open.
- * @param flags A set of IOFLAG flags. 
+ * @param flags A set of IOFLAG flags.
  *
  * @sa IOFLAG_READ, IOFLAG_WRITE, IOFLAG_APPEND, IOFLAG_SKIP_BOM.
  *
@@ -479,7 +479,7 @@ void aio_wait(ASYNCIO *aio);
  *
  * @param aio Handle to the file.
  *
-i */
+ */
 void aio_free(ASYNCIO *aio);
 
 /**
@@ -524,7 +524,7 @@ void thread_yield();
  * @ingroup Threads
  *
  * @param thread Thread to detach
-*/
+ */
 void thread_detach(void *thread);
 
 /**
@@ -762,7 +762,7 @@ int time_season();
  * @ingroup Time
  *
  * @return Current value of the timer in nanoseconds.
-*/
+ */
 int64_t time_get_nanoseconds();
 
 /**
@@ -1175,7 +1175,7 @@ void str_truncate(char *dst, int dst_size, const char *src, int truncation_len);
  * @param str Pointer to the string.
  *
  * @return Length of string in bytes excluding the zero termination.
-*/
+ */
 int str_length(const char *str);
 
 /**
@@ -1231,7 +1231,7 @@ void str_sanitize_cc(char *str);
  * @param str String to sanitize.
  *
  * @remark The strings are treated as zero-terminated strings.
-*/
+ */
 void str_sanitize(char *str);
 
 /**
@@ -1240,7 +1240,7 @@ void str_sanitize(char *str);
  * @param str String to sanitize.
  *
  * @remark The strings are treated as zero-terminated strings.
-*/
+ */
 void str_sanitize_filename(char *str);
 
 /**
@@ -1285,7 +1285,7 @@ const char *str_skip_to_whitespace_const(const char *str);
  * within the string.
  *
  * @remark The strings are treated as zero-terminated strings.
-*/
+ */
 char *str_skip_whitespaces(char *str);
 
 /**
@@ -1360,7 +1360,7 @@ int str_comp(const char *a, const char *b);
  * @return `> 0` - String a is greater than string b
  *
  * @remark The strings are treated as zero-terminated strings.
-*/
+ */
 int str_comp_num(const char *a, const char *b, int num);
 
 /**
@@ -1454,7 +1454,7 @@ const char *str_endswith(const char *str, const char *suffix);
  * @return The edit distance between the both strings.
  *
  * @remark The strings are treated as zero-terminated strings.
-*/
+ */
 int str_utf8_dist(const char *a, const char *b);
 
 /**
@@ -1472,7 +1472,7 @@ int str_utf8_dist(const char *a, const char *b);
  * @return The edit distance between the both strings.
  *
  * @remark The strings are treated as zero-terminated strings.
-*/
+ */
 int str_utf8_dist_buffer(const char *a, const char *b, int *buf, int buf_len);
 
 /*
@@ -2271,7 +2271,7 @@ void uint_to_bytes_be(unsigned char *bytes, unsigned value);
 /*
 	Function: pid
 		Returns the pid of the current process.
-	
+
 	Returns:
 		pid of the current process
 */
@@ -2447,7 +2447,7 @@ namespace tw {
  * @ingroup Time
  *
  * @return Current value of the timer in nanoseconds.
-*/
+ */
 std::chrono::nanoseconds time_get();
 
 int net_socket_read_wait(NETSOCKET sock, std::chrono::nanoseconds nanoseconds);

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -2452,6 +2452,28 @@ std::chrono::nanoseconds time_get();
 
 int net_socket_read_wait(NETSOCKET sock, std::chrono::nanoseconds nanoseconds);
 
+/**
+ * Fixes the command line arguments to be encoded in UTF-8 on all systems.
+ * This is a RAII wrapper for cmdline_fix and cmdline_free.
+ */
+class CCmdlineFix
+{
+	int m_Argc;
+	const char **m_ppArgv;
+
+public:
+	CCmdlineFix(int *pArgc, const char ***pppArgv)
+	{
+		cmdline_fix(pArgc, pppArgv);
+		m_Argc = *pArgc;
+		m_ppArgv = *pppArgv;
+	}
+	~CCmdlineFix()
+	{
+		cmdline_free(m_Argc, m_ppArgv);
+	}
+};
+
 } // namespace tw
 
 #endif

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -4357,7 +4357,7 @@ int main(int argc, const char **argv)
 #if defined(CONF_PLATFORM_ANDROID)
 	const char **argv = const_cast<const char **>(argv2);
 #endif
-	cmdline_fix(&argc, &argv);
+	tw::CCmdlineFix CmdlineFix(&argc, &argv);
 	bool Silent = false;
 	bool RandInitFailed = false;
 
@@ -4561,7 +4561,6 @@ int main(int argc, const char **argv)
 
 	delete pKernel;
 
-	cmdline_free(argc, argv);
 #ifdef CONF_PLATFORM_ANDROID
 	// properly close this native thread, so globals are destructed
 	std::exit(0);

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -3765,7 +3765,7 @@ void HandleSigIntTerm(int Param)
 
 int main(int argc, const char **argv)
 {
-	cmdline_fix(&argc, &argv);
+	tw::CCmdlineFix CmdlineFix(&argc, &argv);
 	bool Silent = false;
 
 	for(int i = 1; i < argc; i++)
@@ -3909,7 +3909,6 @@ int main(int argc, const char **argv)
 	// free
 	delete pKernel;
 
-	cmdline_free(argc, argv);
 	return Ret;
 }
 

--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -114,7 +114,7 @@ CTestInfo::~CTestInfo()
 
 int main(int argc, const char **argv)
 {
-	cmdline_fix(&argc, &argv);
+	tw::CCmdlineFix CmdlineFix(&argc, &argv);
 	log_set_global_logger_default();
 	::testing::InitGoogleTest(&argc, const_cast<char **>(argv));
 	net_init();
@@ -125,6 +125,5 @@ int main(int argc, const char **argv)
 	}
 	int Result = RUN_ALL_TESTS();
 	secure_random_uninit();
-	cmdline_free(argc, argv);
 	return Result;
 }

--- a/src/tools/config_common.h
+++ b/src/tools/config_common.h
@@ -47,7 +47,7 @@ static int ListdirCallback(const char *pItemName, int IsDir, int StorageType, vo
 
 int main(int argc, const char **argv) // NOLINT(misc-definitions-in-headers)
 {
-	cmdline_fix(&argc, &argv);
+	tw::CCmdlineFix CmdlineFix(&argc, &argv);
 	log_set_global_logger_default();
 
 	IStorage *pStorage = CreateLocalStorage();
@@ -70,6 +70,5 @@ int main(int argc, const char **argv) // NOLINT(misc-definitions-in-headers)
 	{
 		ProcessItem(argv[i], pStorage);
 	}
-	cmdline_free(argc, argv);
 	return 0;
 }

--- a/src/tools/crapnet.cpp
+++ b/src/tools/crapnet.cpp
@@ -200,10 +200,9 @@ void Run(unsigned short Port, NETADDR Dest)
 
 int main(int argc, const char **argv)
 {
-	cmdline_fix(&argc, &argv);
+	tw::CCmdlineFix CmdlineFix(&argc, &argv);
 	log_set_global_logger_default();
 	NETADDR Addr = {NETTYPE_IPV4, {127, 0, 0, 1}, 8303};
 	Run(8302, Addr);
-	cmdline_free(argc, argv);
 	return 0;
 }

--- a/src/tools/dilate.cpp
+++ b/src/tools/dilate.cpp
@@ -72,7 +72,7 @@ int DilateFile(const char *pFilename)
 
 int main(int argc, const char **argv)
 {
-	cmdline_fix(&argc, &argv);
+	tw::CCmdlineFix CmdlineFix(&argc, &argv);
 	log_set_global_logger_default();
 	if(argc == 1)
 	{
@@ -82,6 +82,6 @@ int main(int argc, const char **argv)
 
 	for(int i = 1; i < argc; i++)
 		DilateFile(argv[i]);
-	cmdline_free(argc, argv);
+
 	return 0;
 }

--- a/src/tools/dummy_map.cpp
+++ b/src/tools/dummy_map.cpp
@@ -73,12 +73,11 @@ void CreateEmptyMap(IStorage *pStorage)
 
 int main(int argc, const char **argv)
 {
-	cmdline_fix(&argc, &argv);
+	tw::CCmdlineFix CmdlineFix(&argc, &argv);
 	log_set_global_logger_default();
 	IStorage *pStorage = CreateStorage(IStorage::STORAGETYPE_SERVER, argc, argv);
 	if(!pStorage)
 		return -1;
 	CreateEmptyMap(pStorage);
-	cmdline_free(argc, argv);
 	return 0;
 }

--- a/src/tools/map_convert_07.cpp
+++ b/src/tools/map_convert_07.cpp
@@ -134,7 +134,7 @@ void *ReplaceImageItem(void *pItem, int Type, CMapItemImage *pNewImgItem)
 
 int main(int argc, const char **argv)
 {
-	cmdline_fix(&argc, &argv);
+	tw::CCmdlineFix CmdlineFix(&argc, &argv);
 	log_set_global_logger_default();
 
 	if(argc < 2 || argc > 3)
@@ -243,6 +243,5 @@ int main(int argc, const char **argv)
 
 	g_DataReader.Close();
 	g_DataWriter.Finish();
-	cmdline_free(argc, argv);
 	return Success ? 0 : -1;
 }

--- a/src/tools/map_diff.cpp
+++ b/src/tools/map_diff.cpp
@@ -95,7 +95,7 @@ bool Process(IStorage *pStorage, const char **pMapNames)
 
 int main(int argc, const char *argv[])
 {
-	cmdline_fix(&argc, &argv);
+	tw::CCmdlineFix CmdlineFix(&argc, &argv);
 	std::vector<std::shared_ptr<ILogger>> vpLoggers;
 	vpLoggers.push_back(std::shared_ptr<ILogger>(log_logger_stdout()));
 	IOHANDLE LogFile = io_open("map_diff.txt", IOFLAG_WRITE);
@@ -115,7 +115,5 @@ int main(int argc, const char *argv[])
 	if(!pStorage)
 		return -1;
 
-	int Result = Process(pStorage, &argv[1]) ? 0 : 1;
-	cmdline_free(argc, argv);
-	return Result;
+	return Process(pStorage, &argv[1]) ? 0 : 1;
 }

--- a/src/tools/map_extract.cpp
+++ b/src/tools/map_extract.cpp
@@ -95,7 +95,7 @@ bool Process(IStorage *pStorage, const char *pMapName, const char *pPathSave)
 
 int main(int argc, const char *argv[])
 {
-	cmdline_fix(&argc, &argv);
+	tw::CCmdlineFix CmdlineFix(&argc, &argv);
 	log_set_global_logger_default();
 
 	IStorage *pStorage = CreateLocalStorage();
@@ -126,6 +126,5 @@ int main(int argc, const char *argv[])
 	png_init(0, 0);
 
 	int Result = Process(pStorage, argv[1], pDir) ? 0 : 1;
-	cmdline_free(argc, argv);
 	return Result;
 }

--- a/src/tools/map_optimize.cpp
+++ b/src/tools/map_optimize.cpp
@@ -75,7 +75,7 @@ void GetImageSHA256(uint8_t *pImgBuff, int ImgSize, int Width, int Height, char 
 
 int main(int argc, const char **argv)
 {
-	cmdline_fix(&argc, &argv);
+	tw::CCmdlineFix CmdlineFix(&argc, &argv);
 	log_set_global_logger_default();
 
 	IStorage *pStorage = CreateStorage(IStorage::STORAGETYPE_BASIC, argc, argv);
@@ -315,6 +315,5 @@ int main(int argc, const char **argv)
 	Reader.Close();
 	Writer.Finish();
 
-	cmdline_free(argc, argv);
 	return 0;
 }

--- a/src/tools/map_replace_image.cpp
+++ b/src/tools/map_replace_image.cpp
@@ -109,7 +109,7 @@ void *ReplaceImageItem(void *pItem, int Type, const char *pImgName, const char *
 
 int main(int argc, const char **argv)
 {
-	cmdline_fix(&argc, &argv);
+	tw::CCmdlineFix CmdlineFix(&argc, &argv);
 	log_set_global_logger_default();
 
 	if(argc != 5)
@@ -201,6 +201,5 @@ int main(int argc, const char **argv)
 	Writer.Finish();
 
 	dbg_msg("map_replace_image", "image '%s' replaced", pImageName);
-	cmdline_free(argc, argv);
 	return 0;
 }

--- a/src/tools/map_resave.cpp
+++ b/src/tools/map_resave.cpp
@@ -6,7 +6,7 @@
 
 int main(int argc, const char **argv)
 {
-	cmdline_fix(&argc, &argv);
+	tw::CCmdlineFix CmdlineFix(&argc, &argv);
 
 	IStorage *pStorage = CreateStorage(IStorage::STORAGETYPE_BASIC, argc, argv);
 	if(!pStorage || argc != 3)
@@ -44,6 +44,5 @@ int main(int argc, const char **argv)
 
 	Reader.Close();
 	Writer.Finish();
-	cmdline_free(argc, argv);
 	return 0;
 }

--- a/src/tools/packetgen.cpp
+++ b/src/tools/packetgen.cpp
@@ -33,9 +33,8 @@ void Run(NETADDR Dest)
 
 int main(int argc, const char **argv)
 {
-	cmdline_fix(&argc, &argv);
+	tw::CCmdlineFix CmdlineFix(&argc, &argv);
 	NETADDR Dest = {NETTYPE_IPV4, {127, 0, 0, 1}, 8303};
 	Run(Dest);
-	cmdline_free(argc, argv);
 	return 0;
 }

--- a/src/tools/stun.cpp
+++ b/src/tools/stun.cpp
@@ -4,7 +4,7 @@
 
 int main(int argc, const char **argv)
 {
-	cmdline_fix(&argc, &argv);
+	tw::CCmdlineFix CmdlineFix(&argc, &argv);
 
 	secure_random_init();
 	log_set_global_logger_default();
@@ -89,6 +89,4 @@ int main(int argc, const char **argv)
 			break;
 		}
 	}
-
-	cmdline_free(argc, argv);
 }

--- a/src/tools/unicode_confusables.cpp
+++ b/src/tools/unicode_confusables.cpp
@@ -3,7 +3,7 @@
 
 int main(int argc, const char **argv)
 {
-	cmdline_fix(&argc, &argv);
+	tw::CCmdlineFix CmdlineFix(&argc, &argv);
 	log_set_global_logger_default();
 	if(argc < 1 + 2)
 	{
@@ -11,6 +11,5 @@ int main(int argc, const char **argv)
 		return -1;
 	}
 	dbg_msg("conf", "not_confusable=%d", str_utf8_comp_confusable(argv[1], argv[2]));
-	cmdline_free(argc, argv);
 	return 0;
 }

--- a/src/tools/uuid.cpp
+++ b/src/tools/uuid.cpp
@@ -2,7 +2,7 @@
 #include <engine/shared/uuid_manager.h>
 int main(int argc, const char **argv)
 {
-	cmdline_fix(&argc, &argv);
+	tw::CCmdlineFix CmdlineFix(&argc, &argv);
 	log_set_global_logger_default();
 	if(argc != 2)
 	{
@@ -13,6 +13,5 @@ int main(int argc, const char **argv)
 	char aBuf[UUID_MAXSTRSIZE];
 	FormatUuid(Uuid, aBuf, sizeof(aBuf));
 	dbg_msg("uuid", "%s", aBuf);
-	cmdline_free(argc, argv);
 	return 0;
 }

--- a/src/twping/twping.cpp
+++ b/src/twping/twping.cpp
@@ -9,7 +9,7 @@ static CNetClient g_NetOp; // main
 
 int main(int argc, const char **argv)
 {
-	cmdline_fix(&argc, &argv);
+	tw::CCmdlineFix CmdlineFix(&argc, &argv);
 	NETADDR BindAddr;
 	mem_zero(&BindAddr, sizeof(BindAddr));
 	BindAddr.type = NETTYPE_ALL;
@@ -69,6 +69,5 @@ int main(int argc, const char **argv)
 			printf("%g ms\n", (double)(endTime - startTime) / time_freq() * 1000);
 		}
 	}
-	cmdline_free(argc, argv);
 	return 0;
 }


### PR DESCRIPTION
Use `CCmdlineFix` RAII wrapper to encapsulate `cmdline_fix` and `cmdline_free` handling. This fixes memory leaks when client/server/tools exit early, as `cmdline_free` was only called on the happy code path.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
