### PR TITLE
Use nullptr in generated and editor

### DIFF
--- a/datasrc/seven/datatypes.py
+++ b/datasrc/seven/datatypes.py
@@ -119,7 +119,7 @@ class Array(BaseType):
 				lines += ["\t" + " ".join(itemlines).replace("\t", " ") + ","]
 			lines += ["};"]
 		else:
-			lines += ["static %s *%s = 0;"%(self.TypeName(), self.Identifyer())]
+			lines += ["static %s *%s = nullptr;"%(self.TypeName(), self.Identifyer())]
 
 		return lines
 	def EmitDefinition(self, _name):

--- a/src/engine/client.h
+++ b/src/engine/client.h
@@ -123,7 +123,7 @@ public:
 	inline float FrameTimeAvg() const { return m_FrameTimeAvg; }
 
 	// actions
-	virtual void Connect(const char *pAddress, const char *pPassword = NULL) = 0;
+	virtual void Connect(const char *pAddress, const char *pPassword = nullptr) = 0;
 	virtual void Disconnect() = 0;
 
 	// dummy

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -342,7 +342,7 @@ public:
 	void OnEnterGame(bool Dummy);
 	void EnterGame(int Conn) override;
 
-	void Connect(const char *pAddress, const char *pPassword = NULL) override;
+	void Connect(const char *pAddress, const char *pPassword = nullptr) override;
 	void DisconnectWithReason(const char *pReason);
 	void Disconnect() override;
 

--- a/src/engine/client/ghost.h
+++ b/src/engine/client/ghost.h
@@ -80,7 +80,7 @@ public:
 	int Stop(int Ticks, int Time) override;
 
 	void WriteData(int Type, const void *pData, int Size) override;
-	bool IsRecording() const override { return m_File != 0; }
+	bool IsRecording() const override { return m_File != nullptr; }
 };
 
 class CGhostLoader : public IGhostLoader

--- a/src/engine/client/updater.h
+++ b/src/engine/client/updater.h
@@ -54,7 +54,7 @@ class CUpdater : public IUpdater
 	std::map<std::string, bool> m_FileJobs;
 
 	void AddFileJob(const char *pFile, bool Job);
-	void FetchFile(const char *pFile, const char *pDestPath = 0);
+	void FetchFile(const char *pFile, const char *pDestPath = nullptr);
 	bool MoveFile(const char *pFile);
 
 	void ParseUpdate();

--- a/src/engine/graphics.h
+++ b/src/engine/graphics.h
@@ -303,7 +303,7 @@ public:
 	virtual void CopyTextureFromTextureBufferSub(uint8_t *pDestBuffer, int DestWidth, int DestHeight, uint8_t *pSourceBuffer, int SrcWidth, int SrcHeight, int ColorChannelCount, int SrcSubOffsetX, int SrcSubOffsetY, int SrcSubCopyWidth, int SrcSubCopyHeight) = 0;
 
 	virtual int UnloadTexture(CTextureHandle *pIndex) = 0;
-	virtual CTextureHandle LoadTextureRaw(int Width, int Height, int Format, const void *pData, int StoreFormat, int Flags, const char *pTexName = NULL) = 0;
+	virtual CTextureHandle LoadTextureRaw(int Width, int Height, int Format, const void *pData, int StoreFormat, int Flags, const char *pTexName = nullptr) = 0;
 	virtual int LoadTextureRawSub(CTextureHandle TextureID, int x, int y, int Width, int Height, int Format, const void *pData) = 0;
 	virtual CTextureHandle LoadTexture(const char *pFilename, int StorageType, int StoreFormat, int Flags) = 0;
 	virtual void TextureSet(CTextureHandle Texture) = 0;

--- a/src/engine/kernel.h
+++ b/src/engine/kernel.h
@@ -19,7 +19,7 @@ protected:
 
 public:
 	IInterface() :
-		m_pKernel(0) {}
+		m_pKernel(nullptr) {}
 	virtual ~IInterface() {}
 };
 

--- a/src/engine/shared/datafile.h
+++ b/src/engine/shared/datafile.h
@@ -27,10 +27,10 @@ class CDataFileReader
 
 public:
 	CDataFileReader() :
-		m_pDataFile(0) {}
+		m_pDataFile(nullptr) {}
 	~CDataFileReader() { Close(); }
 
-	bool IsOpen() const { return m_pDataFile != 0; }
+	bool IsOpen() const { return m_pDataFile != nullptr; }
 
 	bool Open(class IStorage *pStorage, const char *pFilename, int StorageType);
 	bool Close();

--- a/src/engine/shared/demo.h
+++ b/src/engine/shared/demo.h
@@ -38,14 +38,14 @@ public:
 	CDemoRecorder(class CSnapshotDelta *pSnapshotDelta, bool NoMapData = false);
 	CDemoRecorder() {}
 
-	int Start(class IStorage *pStorage, class IConsole *pConsole, const char *pFilename, const char *pNetversion, const char *pMap, SHA256_DIGEST *pSha256, unsigned MapCrc, const char *pType, unsigned MapSize, unsigned char *pMapData, IOHANDLE MapFile = 0, DEMOFUNC_FILTER pfnFilter = 0, void *pUser = 0);
+	int Start(class IStorage *pStorage, class IConsole *pConsole, const char *pFilename, const char *pNetversion, const char *pMap, SHA256_DIGEST *pSha256, unsigned MapCrc, const char *pType, unsigned MapSize, unsigned char *pMapData, IOHANDLE MapFile = nullptr, DEMOFUNC_FILTER pfnFilter = nullptr, void *pUser = nullptr);
 	int Stop() override;
 	void AddDemoMarker();
 
 	void RecordSnapshot(int Tick, const void *pData, int Size);
 	void RecordMessage(const void *pData, int Size);
 
-	bool IsRecording() const override { return m_File != 0; }
+	bool IsRecording() const override { return m_File != nullptr; }
 	char *GetCurrentFilename() override { return m_aCurrentFilename; }
 
 	int Length() const override { return (m_LastTickMarker - m_FirstTick) / SERVER_TICK_SPEED; }
@@ -150,7 +150,7 @@ public:
 	int Update(bool RealTime = true);
 
 	const CPlaybackInfo *Info() const { return &m_Info; }
-	bool IsPlaying() const override { return m_File != 0; }
+	bool IsPlaying() const override { return m_File != nullptr; }
 	const CMapInfo *GetMapInfo() { return &m_MapInfo; }
 };
 

--- a/src/engine/shared/network.h
+++ b/src/engine/shared/network.h
@@ -456,7 +456,7 @@ public:
 	int Close();
 
 	//
-	int Recv(char *pLine, int MaxLength, int *pClientID = 0);
+	int Recv(char *pLine, int MaxLength, int *pClientID = nullptr);
 	int Send(int ClientID, const char *pLine);
 	int Update();
 
@@ -529,7 +529,7 @@ public:
 	static void SendPacketConnless(NETSOCKET Socket, NETADDR *pAddr, const void *pData, int DataSize, bool Extended, unsigned char aExtra[4]);
 	static void SendPacket(NETSOCKET Socket, NETADDR *pAddr, CNetPacketConstruct *pPacket, SECURITY_TOKEN SecurityToken, bool Sixup = false, bool NoCompress = false);
 
-	static int UnpackPacket(unsigned char *pBuffer, int Size, CNetPacketConstruct *pPacket, bool &Sixup, SECURITY_TOKEN *pSecurityToken = 0, SECURITY_TOKEN *pResponseToken = 0);
+	static int UnpackPacket(unsigned char *pBuffer, int Size, CNetPacketConstruct *pPacket, bool &Sixup, SECURITY_TOKEN *pSecurityToken = nullptr, SECURITY_TOKEN *pResponseToken = nullptr);
 
 	// The backroom is ack-NET_MAX_SEQUENCE/2. Used for knowing if we acked a packet or not
 	static int IsSeqInBackroom(int Seq, int Ack);

--- a/src/engine/storage.h
+++ b/src/engine/storage.h
@@ -27,7 +27,7 @@ public:
 
 	virtual void ListDirectory(int Type, const char *pPath, FS_LISTDIR_CALLBACK pfnCallback, void *pUser) = 0;
 	virtual void ListDirectoryInfo(int Type, const char *pPath, FS_LISTDIR_CALLBACK_FILEINFO pfnCallback, void *pUser) = 0;
-	virtual IOHANDLE OpenFile(const char *pFilename, int Flags, int Type, char *pBuffer = 0, int BufferSize = 0) = 0;
+	virtual IOHANDLE OpenFile(const char *pFilename, int Flags, int Type, char *pBuffer = nullptr, int BufferSize = 0) = 0;
 	virtual bool FindFile(const char *pFilename, const char *pPath, int Type, char *pBuffer, int BufferSize) = 0;
 	virtual bool RemoveFile(const char *pFilename, int Type) = 0;
 	virtual bool RenameFile(const char *pOldFilename, const char *pNewFilename, int Type) = 0;

--- a/src/engine/textrender.h
+++ b/src/engine/textrender.h
@@ -191,7 +191,7 @@ public:
 	virtual void TextSelectionColor(float r, float g, float b, float a) = 0;
 	virtual void TextSelectionColor(ColorRGBA rgb) = 0;
 	virtual void Text(void *pFontSetV, float x, float y, float Size, const char *pText, float LineWidth) = 0;
-	virtual float TextWidth(void *pFontSetV, float Size, const char *pText, int StrLength, float LineWidth, float *pAlignedHeight = NULL, float *pMaxCharacterHeightInLine = NULL) = 0;
+	virtual float TextWidth(void *pFontSetV, float Size, const char *pText, int StrLength, float LineWidth, float *pAlignedHeight = nullptr, float *pMaxCharacterHeightInLine = nullptr) = 0;
 	virtual int TextLineCount(void *pFontSetV, float Size, const char *pText, float LineWidth) = 0;
 
 	virtual ColorRGBA GetTextColor() = 0;

--- a/src/game/client/components/maplayers.h
+++ b/src/game/client/components/maplayers.h
@@ -38,7 +38,7 @@ class CMapLayers : public CComponent
 	struct STileLayerVisuals
 	{
 		STileLayerVisuals() :
-			m_pTilesOfLayer(NULL), m_pBorderTop(NULL), m_pBorderLeft(NULL), m_pBorderRight(NULL), m_pBorderBottom(NULL)
+			m_pTilesOfLayer(nullptr), m_pBorderTop(nullptr), m_pBorderLeft(nullptr), m_pBorderRight(nullptr), m_pBorderBottom(nullptr)
 		{
 			m_Width = 0;
 			m_Height = 0;
@@ -108,7 +108,7 @@ class CMapLayers : public CComponent
 	struct SQuadLayerVisuals
 	{
 		SQuadLayerVisuals() :
-			m_QuadNum(0), m_pQuadsOfLayer(NULL), m_BufferContainerIndex(-1), m_IsTextured(false) {}
+			m_QuadNum(0), m_pQuadsOfLayer(nullptr), m_BufferContainerIndex(-1), m_IsTextured(false) {}
 
 		struct SQuadVisual
 		{

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -84,14 +84,14 @@ class CMenus : public CComponent
 	int DoButton_DemoPlayer(const void *pID, const char *pText, int Checked, const CUIRect *pRect);
 	int DoButton_Sprite(const void *pID, int ImageID, int SpriteID, int Checked, const CUIRect *pRect, int Corners);
 	int DoButton_Toggle(const void *pID, int Checked, const CUIRect *pRect, bool Active);
-	int DoButton_Menu(const void *pID, const char *pText, int Checked, const CUIRect *pRect, const char *pImageName = 0, int Corners = CUI::CORNER_ALL, float r = 5.0f, float FontFactor = 0.0f, vec4 ColorHot = vec4(1.0f, 1.0f, 1.0f, 0.75f), vec4 Color = vec4(1, 1, 1, 0.5f), int AlignVertically = 1, bool CheckForActiveColorPicker = false);
-	int DoButton_MenuTab(const void *pID, const char *pText, int Checked, const CUIRect *pRect, int Corners, SUIAnimator *pAnimator = NULL, const ColorRGBA *pDefaultColor = NULL, const ColorRGBA *pActiveColor = NULL, const ColorRGBA *pHoverColor = NULL, float EdgeRounding = 10, int AlignVertically = 1);
+	int DoButton_Menu(const void *pID, const char *pText, int Checked, const CUIRect *pRect, const char *pImageName = nullptr, int Corners = CUI::CORNER_ALL, float r = 5.0f, float FontFactor = 0.0f, vec4 ColorHot = vec4(1.0f, 1.0f, 1.0f, 0.75f), vec4 Color = vec4(1, 1, 1, 0.5f), int AlignVertically = 1, bool CheckForActiveColorPicker = false);
+	int DoButton_MenuTab(const void *pID, const char *pText, int Checked, const CUIRect *pRect, int Corners, SUIAnimator *pAnimator = nullptr, const ColorRGBA *pDefaultColor = nullptr, const ColorRGBA *pActiveColor = nullptr, const ColorRGBA *pHoverColor = nullptr, float EdgeRounding = 10, int AlignVertically = 1);
 
 	int DoButton_CheckBox_Common(const void *pID, const char *pText, const char *pBoxText, const CUIRect *pRect);
 	int DoButton_CheckBox(const void *pID, const char *pText, int Checked, const CUIRect *pRect);
 	int DoButton_CheckBoxAutoVMarginAndSet(const void *pID, const char *pText, int *pValue, CUIRect *pRect, float VMargin);
 	int DoButton_CheckBox_Number(const void *pID, const char *pText, int Checked, const CUIRect *pRect);
-	ColorHSLA DoLine_ColorPicker(int *pResetID, float LineSize, float WantedPickerPosition, float LabelSize, float BottomMargin, CUIRect *pMainRect, const char *pText, unsigned int *pColorValue, ColorRGBA DefaultColor, bool CheckBoxSpacing = true, bool UseCheckBox = false, int *pCheckBoxValue = NULL);
+	ColorHSLA DoLine_ColorPicker(int *pResetID, float LineSize, float WantedPickerPosition, float LabelSize, float BottomMargin, CUIRect *pMainRect, const char *pText, unsigned int *pColorValue, ColorRGBA DefaultColor, bool CheckBoxSpacing = true, bool UseCheckBox = false, int *pCheckBoxValue = nullptr);
 	void DoLaserPreview(const CUIRect *pRect, ColorHSLA OutlineColor, ColorHSLA InnerColor);
 	int DoValueSelector(void *pID, CUIRect *pRect, const char *pLabel, bool UseScroll, int Current, int Min, int Max, int Step, float Scale, bool IsHex, float Round, ColorRGBA *Color);
 	int DoButton_Icon(int ImageId, int SpriteId, const CUIRect *pRect);
@@ -125,7 +125,7 @@ class CMenus : public CComponent
 					}
 				}
 			}
-			const char *pText = NULL;
+			const char *pText = nullptr;
 			if(HintRequiresStringCheck)
 			{
 				if(UIElement.AreRectsInit())
@@ -166,7 +166,7 @@ class CMenus : public CComponent
 					NewRect.m_Height = pRect->h;
 					if(i == 0)
 					{
-						if(pText == NULL)
+						if(pText == nullptr)
 							pText = GetTextLambda();
 						NewRect.m_Text = pText;
 						SLabelProperties Props;
@@ -204,7 +204,7 @@ class CMenus : public CComponent
 		int ItemsPerRow, int SelectedIndex, float ScrollValue, bool LogicOnly = false);
 	CListboxItem UiDoListboxNextItem(const void *pID, bool Selected = false, bool KeyEvents = true, bool NoHoverEffects = false);
 	CListboxItem UiDoListboxNextRow();
-	int UiDoListboxEnd(float *pScrollValue, bool *pItemActivated, bool *pListBoxActive = 0);
+	int UiDoListboxEnd(float *pScrollValue, bool *pItemActivated, bool *pListBoxActive = nullptr);
 
 	int UiLogicGetCurrentClickedItem();
 

--- a/src/game/client/prediction/gameworld.h
+++ b/src/game/client/prediction/gameworld.h
@@ -34,7 +34,7 @@ public:
 	CEntity *FindFirst(int Type);
 	CEntity *FindLast(int Type);
 	int FindEntities(vec2 Pos, float Radius, CEntity **ppEnts, int Max, int Type);
-	class CCharacter *IntersectCharacter(vec2 Pos0, vec2 Pos1, float Radius, vec2 &NewPos, class CCharacter *pNotThis = 0, int CollideWith = -1, class CCharacter *pThisOnly = 0);
+	class CCharacter *IntersectCharacter(vec2 Pos0, vec2 Pos1, float Radius, vec2 &NewPos, class CCharacter *pNotThis = nullptr, int CollideWith = -1, class CCharacter *pThisOnly = nullptr);
 	void InsertEntity(CEntity *pEntity, bool Last = false);
 	void RemoveEntity(CEntity *pEntity);
 	void RemoveCharacter(CCharacter *pChar);
@@ -42,7 +42,7 @@ public:
 
 	// DDRace
 	void ReleaseHooked(int ClientID);
-	std::list<class CCharacter *> IntersectedCharacters(vec2 Pos0, vec2 Pos1, float Radius, class CEntity *pNotThis = 0);
+	std::list<class CCharacter *> IntersectedCharacters(vec2 Pos0, vec2 Pos1, float Radius, class CEntity *pNotThis = nullptr);
 
 	int m_GameTick;
 	int m_GameTickSpeed;
@@ -56,7 +56,7 @@ public:
 	std::vector<SSwitchers> &Switchers() { return m_Core.m_vSwitchers; }
 	CTuningParams *Tuning();
 	CEntity *GetEntity(int ID, int EntityType);
-	class CCharacter *GetCharacterByID(int ID) { return (ID >= 0 && ID < MAX_CLIENTS) ? m_apCharacters[ID] : 0; }
+	class CCharacter *GetCharacterByID(int ID) { return (ID >= 0 && ID < MAX_CLIENTS) ? m_apCharacters[ID] : nullptr; }
 
 	// from gamecontext
 	void CreateExplosion(vec2 Pos, int Owner, int Weapon, bool NoDamage, int ActivatedTeam, int64_t Mask);

--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -326,9 +326,9 @@ public:
 	float DoTextLabel(float x, float y, float w, float h, const char *pText, float Size, int Align, const SLabelProperties &LabelProps = {});
 	void DoLabel(const CUIRect *pRect, const char *pText, float Size, int Align, const SLabelProperties &LabelProps = {});
 
-	void DoLabel(CUIElement::SUIElementRect &RectEl, const CUIRect *pRect, const char *pText, float Size, int Align, const SLabelProperties &LabelProps, int StrLen = -1, class CTextCursor *pReadCursor = NULL);
-	void DoLabelStreamed(CUIElement::SUIElementRect &RectEl, float x, float y, float w, float h, const char *pText, float Size, int Align, float MaxWidth = -1, int AlignVertically = 1, bool StopAtEnd = false, int StrLen = -1, class CTextCursor *pReadCursor = NULL);
-	void DoLabelStreamed(CUIElement::SUIElementRect &RectEl, const CUIRect *pRect, const char *pText, float Size, int Align, float MaxWidth = -1, int AlignVertically = 1, bool StopAtEnd = false, int StrLen = -1, class CTextCursor *pReadCursor = NULL);
+	void DoLabel(CUIElement::SUIElementRect &RectEl, const CUIRect *pRect, const char *pText, float Size, int Align, const SLabelProperties &LabelProps, int StrLen = -1, class CTextCursor *pReadCursor = nullptr);
+	void DoLabelStreamed(CUIElement::SUIElementRect &RectEl, float x, float y, float w, float h, const char *pText, float Size, int Align, float MaxWidth = -1, int AlignVertically = 1, bool StopAtEnd = false, int StrLen = -1, class CTextCursor *pReadCursor = nullptr);
+	void DoLabelStreamed(CUIElement::SUIElementRect &RectEl, const CUIRect *pRect, const char *pText, float Size, int Align, float MaxWidth = -1, int AlignVertically = 1, bool StopAtEnd = false, int StrLen = -1, class CTextCursor *pReadCursor = nullptr);
 };
 
 #endif

--- a/src/game/client/ui_ex.h
+++ b/src/game/client/ui_ex.h
@@ -40,7 +40,7 @@ class CUIEx
 	bool m_MouseSlow;
 	int m_CurSelStart = 0;
 	int m_CurSelEnd = 0;
-	const void *m_pSelItem = NULL;
+	const void *m_pSelItem = nullptr;
 
 	int m_CurCursor = 0;
 
@@ -61,7 +61,7 @@ public:
 	void ResetMouseSlow() { m_MouseSlow = false; }
 
 	float DoScrollbarV(const void *pID, const CUIRect *pRect, float Current);
-	float DoScrollbarH(const void *pID, const CUIRect *pRect, float Current, const ColorRGBA *pColorInner = NULL);
+	float DoScrollbarH(const void *pID, const CUIRect *pRect, float Current, const ColorRGBA *pColorInner = nullptr);
 
 	bool DoEditBox(const void *pID, const CUIRect *pRect, char *pStr, unsigned StrSize, float FontSize, float *pOffset, bool Hidden = false, int Corners = CUI::CORNER_ALL, const SUIExEditBoxProperties &Properties = {});
 	bool DoClearableEditBox(const void *pID, const void *pClearID, const CUIRect *pRect, char *pStr, unsigned StrSize, float FontSize, float *pOffset, bool Hidden = false, int Corners = CUI::CORNER_ALL, const SUIExEditBoxProperties &Properties = {});

--- a/src/game/collision.h
+++ b/src/game/collision.h
@@ -65,7 +65,7 @@ public:
 	int GetMoveRestrictions(CALLBACK_SWITCHACTIVE pfnSwitchActive, void *pUser, vec2 Pos, float Distance = 18.0f, int OverrideCenterTileIndex = -1);
 	int GetMoveRestrictions(vec2 Pos, float Distance = 18.0f)
 	{
-		return GetMoveRestrictions(0, 0, Pos, Distance);
+		return GetMoveRestrictions(nullptr, nullptr, Pos, Distance);
 	}
 
 	int GetTile(int x, int y) const;

--- a/src/game/editor/auto_map.cpp
+++ b/src/game/editor/auto_map.cpp
@@ -54,9 +54,9 @@ void CAutoMapper::Load(const char *pTileName)
 	CLineReader LineReader;
 	LineReader.Init(RulesFile);
 
-	CConfiguration *pCurrentConf = 0;
-	CRun *pCurrentRun = 0;
-	CIndexRule *pCurrentIndex = 0;
+	CConfiguration *pCurrentConf = nullptr;
+	CRun *pCurrentRun = nullptr;
+	CIndexRule *pCurrentIndex = nullptr;
 
 	char aBuf[256];
 

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -83,14 +83,14 @@ CEditorImage::~CEditorImage()
 {
 	m_pEditor->Graphics()->UnloadTexture(&m_Texture);
 	free(m_pData);
-	m_pData = 0;
+	m_pData = nullptr;
 }
 
 CEditorSound::~CEditorSound()
 {
 	m_pEditor->Sound()->UnloadSample(m_SoundID);
 	free(m_pData);
-	m_pData = 0x0;
+	m_pData = nullptr;
 }
 
 CLayerGroup::CLayerGroup()
@@ -467,7 +467,7 @@ int CEditor::DoButton_ButtonDec(const void *pID, const char *pText, int Checked,
 int CEditor::DoButton_ColorPicker(const void *pID, const CUIRect *pRect, ColorRGBA *pColor, const char *pToolTip)
 {
 	RenderTools()->DrawUIRect(pRect, *pColor, 0, 0.0f);
-	return DoButton_Editor_Common(pID, 0x0, 0, pRect, 0, pToolTip);
+	return DoButton_Editor_Common(pID, nullptr, 0, pRect, 0, pToolTip);
 }
 
 void CEditor::RenderGrid(CLayerGroup *pGroup)
@@ -646,23 +646,23 @@ CLayerGroup *CEditor::GetSelectedGroup() const
 {
 	if(m_SelectedGroup >= 0 && m_SelectedGroup < (int)m_Map.m_vpGroups.size())
 		return m_Map.m_vpGroups[m_SelectedGroup];
-	return 0x0;
+	return nullptr;
 }
 
 CLayer *CEditor::GetSelectedLayer(int Index) const
 {
 	CLayerGroup *pGroup = GetSelectedGroup();
 	if(!pGroup)
-		return 0x0;
+		return nullptr;
 
 	if(Index < 0 || Index >= (int)m_vSelectedLayers.size())
-		return 0x0;
+		return nullptr;
 
 	int LayerIndex = m_vSelectedLayers[Index];
 
 	if(LayerIndex >= 0 && LayerIndex < (int)m_Map.m_vpGroups[m_SelectedGroup]->m_vpLayers.size())
 		return pGroup->m_vpLayers[LayerIndex];
-	return 0x0;
+	return nullptr;
 }
 
 CLayer *CEditor::GetSelectedLayerType(int Index, int Type) const
@@ -670,7 +670,7 @@ CLayer *CEditor::GetSelectedLayerType(int Index, int Type) const
 	CLayer *p = GetSelectedLayer(Index);
 	if(p && p->m_Type == Type)
 		return p;
-	return 0x0;
+	return nullptr;
 }
 
 std::vector<CQuad *> CEditor::GetSelectedQuads()
@@ -689,10 +689,10 @@ CSoundSource *CEditor::GetSelectedSource()
 {
 	CLayerSounds *pSounds = (CLayerSounds *)GetSelectedLayerType(0, LAYERTYPE_SOUNDS);
 	if(!pSounds)
-		return 0;
+		return nullptr;
 	if(m_SelectedSource >= 0 && m_SelectedSource < (int)pSounds->m_vSources.size())
 		return &pSounds->m_vSources[m_SelectedSource];
-	return 0;
+	return nullptr;
 }
 
 void CEditor::SelectLayer(int LayerIndex, int GroupIndex)
@@ -842,7 +842,7 @@ void CEditor::DoToolbar(CUIRect ToolBar)
 			m_ShowDetail = !m_ShowDetail;
 		}
 
-		TB_Top.VSplitLeft(5.0f, 0, &TB_Top);
+		TB_Top.VSplitLeft(5.0f, nullptr, &TB_Top);
 
 		// animation button
 		TB_Top.VSplitLeft(40.0f, &Button, &TB_Top);
@@ -854,7 +854,7 @@ void CEditor::DoToolbar(CUIRect ToolBar)
 			m_Animate = !m_Animate;
 		}
 
-		TB_Top.VSplitLeft(5.0f, 0, &TB_Top);
+		TB_Top.VSplitLeft(5.0f, nullptr, &TB_Top);
 
 		// proof button
 		TB_Top.VSplitLeft(40.0f, &Button, &TB_Top);
@@ -865,7 +865,7 @@ void CEditor::DoToolbar(CUIRect ToolBar)
 			m_ProofBorders = !m_ProofBorders;
 		}
 
-		TB_Top.VSplitLeft(5.0f, 0, &TB_Top);
+		TB_Top.VSplitLeft(5.0f, nullptr, &TB_Top);
 
 		// grid button
 		TB_Top.VSplitLeft(40.0f, &Button, &TB_Top);
@@ -876,7 +876,7 @@ void CEditor::DoToolbar(CUIRect ToolBar)
 			m_GridActive = !m_GridActive;
 		}
 
-		TB_Top.VSplitLeft(5.0f, 0, &TB_Top);
+		TB_Top.VSplitLeft(5.0f, nullptr, &TB_Top);
 
 		// tile info button
 		TB_Top.VSplitLeft(40.0f, &Button, &TB_Top);
@@ -888,7 +888,7 @@ void CEditor::DoToolbar(CUIRect ToolBar)
 			m_ShowEnvelopePreview = 0;
 		}
 
-		TB_Top.VSplitLeft(5.0f, 0, &TB_Top);
+		TB_Top.VSplitLeft(5.0f, nullptr, &TB_Top);
 
 		// allow place unused tiles button
 		TB_Top.VSplitLeft(40.0f, &Button, &TB_Top);
@@ -899,7 +899,7 @@ void CEditor::DoToolbar(CUIRect ToolBar)
 			m_AllowPlaceUnusedTiles = !m_AllowPlaceUnusedTiles;
 		}
 
-		TB_Top.VSplitLeft(5.0f, 0, &TB_Top);
+		TB_Top.VSplitLeft(5.0f, nullptr, &TB_Top);
 
 		TB_Top.VSplitLeft(40.0f, &Button, &TB_Top);
 		static int s_ColorBrushButton = 0;
@@ -908,7 +908,7 @@ void CEditor::DoToolbar(CUIRect ToolBar)
 			m_BrushColorEnabled = !m_BrushColorEnabled;
 		}
 
-		TB_Top.VSplitLeft(5.0f, 0, &TB_Top);
+		TB_Top.VSplitLeft(5.0f, nullptr, &TB_Top);
 
 		TB_Top.VSplitLeft(45.0f, &Button, &TB_Top);
 		static int s_EntitiesButtonID = 0;
@@ -923,7 +923,7 @@ void CEditor::DoToolbar(CUIRect ToolBar)
 				250, m_vSelectEntitiesFiles.size() * 14 + 10, PopupEntities);
 		}
 
-		TB_Top.VSplitLeft(5.0f, 0, &TB_Top);
+		TB_Top.VSplitLeft(5.0f, nullptr, &TB_Top);
 
 		// zoom group
 		TB_Top.VSplitLeft(30.0f, &Button, &TB_Top);
@@ -945,7 +945,7 @@ void CEditor::DoToolbar(CUIRect ToolBar)
 		if(DoButton_Ex(&s_ZoomInButton, "ZI", 0, &Button, 0, "[NumPad+] Zoom in", CUI::CORNER_R))
 			m_ZoomLevel -= 50;
 
-		TB_Top.VSplitLeft(5.0f, 0, &TB_Top);
+		TB_Top.VSplitLeft(5.0f, nullptr, &TB_Top);
 
 		// brush manipulation
 		{
@@ -1064,7 +1064,7 @@ void CEditor::DoToolbar(CUIRect ToolBar)
 				m_WorldOffsetX = 0;
 				m_WorldOffsetY = 0;
 			}
-			TB_Bottom.VSplitLeft(5.0f, 0, &TB_Bottom);
+			TB_Bottom.VSplitLeft(5.0f, nullptr, &TB_Bottom);
 		}
 
 		// tile manipulation
@@ -1074,7 +1074,7 @@ void CEditor::DoToolbar(CUIRect ToolBar)
 
 			// no border for tele layer, speedup, front and switch
 			if(pT && (pT->m_Tele || pT->m_Speedup || pT->m_Switch || pT->m_Front || pT->m_Tune))
-				pT = 0;
+				pT = nullptr;
 
 			if(pT)
 			{
@@ -1089,8 +1089,8 @@ void CEditor::DoToolbar(CUIRect ToolBar)
 
 			// do tele/tune/switch/speedup button
 			{
-				int (*pPopupFunc)(CEditor * peditor, CUIRect View, void *pContext) = NULL;
-				const char *aButtonName = 0;
+				int (*pPopupFunc)(CEditor * peditor, CUIRect View, void *pContext) = nullptr;
+				const char *aButtonName = nullptr;
 				float Height = 0.0f;
 				CLayerTiles *pS = (CLayerTiles *)GetSelectedLayerType(0, LAYERTYPE_TILES);
 				if(pS)
@@ -1120,7 +1120,7 @@ void CEditor::DoToolbar(CUIRect ToolBar)
 						Height = 23;
 					}
 
-					if(aButtonName != 0)
+					if(aButtonName != nullptr)
 					{
 						static char aBuf[64];
 						str_format(aBuf, sizeof(aBuf), "[ctrl+a] %s", aButtonName);
@@ -1135,7 +1135,7 @@ void CEditor::DoToolbar(CUIRect ToolBar)
 								UiInvokePopupMenu(&s_ModifierPopupID, 0, Button.x, Button.y + Button.h, 120, Height, pPopupFunc);
 							}
 						}
-						TB_Bottom.VSplitLeft(5.0f, 0, &TB_Bottom);
+						TB_Bottom.VSplitLeft(5.0f, nullptr, &TB_Bottom);
 					}
 				}
 			}
@@ -2958,7 +2958,7 @@ void CEditor::DoMapEditor(CUIRect View)
 
 float CEditor::ScaleFontSize(char *pText, int TextSize, float FontSize, int Width)
 {
-	while(TextRender()->TextWidth(0, FontSize, pText, -1, -1.0f) > Width)
+	while(TextRender()->TextWidth(nullptr, FontSize, pText, -1, -1.0f) > Width)
 	{
 		if(FontSize > 6.0f)
 		{
@@ -3000,12 +3000,12 @@ int CEditor::DoProperties(CUIRect *pToolBox, CProperty *pProps, int *pIDs, int *
 				*pNewVal = NewValue;
 				Change = i;
 			}
-			if(DoButton_ButtonDec((char *)&pIDs[i] + 1, 0, 0, &Dec, 0, "Decrease"))
+			if(DoButton_ButtonDec((char *)&pIDs[i] + 1, nullptr, 0, &Dec, 0, "Decrease"))
 			{
 				*pNewVal = pProps[i].m_Value - 1;
 				Change = i;
 			}
-			if(DoButton_ButtonInc(((char *)&pIDs[i]) + 2, 0, 0, &Inc, 0, "Increase"))
+			if(DoButton_ButtonInc(((char *)&pIDs[i]) + 2, nullptr, 0, &Inc, 0, "Increase"))
 			{
 				*pNewVal = pProps[i].m_Value + 1;
 				Change = i;
@@ -3045,13 +3045,13 @@ int CEditor::DoProperties(CUIRect *pToolBox, CProperty *pProps, int *pIDs, int *
 			int Value = pProps[i].m_Value;
 
 			int NewValue = UiDoValueSelector(&pIDs[i], &Shifter, "", Value, pProps[i].m_Min, pProps[i].m_Max, Shift ? 1 : 45, Shift ? 1.0f : 10.0f, "Use left mouse button to drag and change the value. Hold shift to be more precise. Rightclick to edit as text.", false, false, 0);
-			if(DoButton_ButtonDec(&pIDs[i] + 1, 0, 0, &Dec, 0, "Decrease"))
+			if(DoButton_ButtonDec(&pIDs[i] + 1, nullptr, 0, &Dec, 0, "Decrease"))
 			{
 				NewValue = (round_ceil((pProps[i].m_Value / (float)Step)) - 1) * Step;
 				if(NewValue < 0)
 					NewValue += 360;
 			}
-			if(DoButton_ButtonInc(&pIDs[i] + 2, 0, 0, &Inc, 0, "Increase"))
+			if(DoButton_ButtonInc(&pIDs[i] + 2, nullptr, 0, &Inc, 0, "Increase"))
 				NewValue = (pProps[i].m_Value + Step) / Step * Step;
 
 			if(NewValue != pProps[i].m_Value)
@@ -3088,7 +3088,7 @@ int CEditor::DoProperties(CUIRect *pToolBox, CProperty *pProps, int *pIDs, int *
 
 			// hex
 			pToolBox->HSplitTop(13.0f, &Slot, pToolBox);
-			Slot.VSplitMid(0x0, &Shifter);
+			Slot.VSplitMid(nullptr, &Shifter);
 			Shifter.HMargin(1.0f, &Shifter);
 
 			int NewColorHex = pProps[i].m_Value & 0xff;
@@ -3135,7 +3135,7 @@ int CEditor::DoProperties(CUIRect *pToolBox, CProperty *pProps, int *pIDs, int *
 				str_format(aBuf, sizeof(aBuf), "%s", m_Map.m_vpImages[pProps[i].m_Value]->m_aName);
 
 			float FontSize = ScaleFontSize(aBuf, sizeof(aBuf), 10.0f, Shifter.w);
-			if(DoButton_Ex(&pIDs[i], aBuf, 0, &Shifter, 0, 0, CUI::CORNER_ALL, FontSize))
+			if(DoButton_Ex(&pIDs[i], aBuf, 0, &Shifter, 0, nullptr, CUI::CORNER_ALL, FontSize))
 				PopupSelectImageInvoke(pProps[i].m_Value, UI()->MouseX(), UI()->MouseY());
 
 			int r = PopupSelectImageResult();
@@ -3187,7 +3187,7 @@ int CEditor::DoProperties(CUIRect *pToolBox, CProperty *pProps, int *pIDs, int *
 				str_format(aBuf, sizeof(aBuf), "%s", m_Map.m_vpSounds[pProps[i].m_Value]->m_aName);
 
 			float FontSize = ScaleFontSize(aBuf, sizeof(aBuf), 10.0f, Shifter.w);
-			if(DoButton_Ex(&pIDs[i], aBuf, 0, &Shifter, 0, 0, CUI::CORNER_ALL, FontSize))
+			if(DoButton_Ex(&pIDs[i], aBuf, 0, &Shifter, 0, nullptr, CUI::CORNER_ALL, FontSize))
 				PopupSelectSoundInvoke(pProps[i].m_Value, UI()->MouseX(), UI()->MouseY());
 
 			int r = PopupSelectSoundResult();
@@ -3206,7 +3206,7 @@ int CEditor::DoProperties(CUIRect *pToolBox, CProperty *pProps, int *pIDs, int *
 				str_format(aBuf, sizeof(aBuf), "%s", m_Map.m_vpImages[pProps[i].m_Min]->m_AutoMapper.GetConfigName(pProps[i].m_Value));
 
 			float FontSize = ScaleFontSize(aBuf, sizeof(aBuf), 10.0f, Shifter.w);
-			if(DoButton_Ex(&pIDs[i], aBuf, 0, &Shifter, 0, 0, CUI::CORNER_ALL, FontSize))
+			if(DoButton_Ex(&pIDs[i], aBuf, 0, &Shifter, 0, nullptr, CUI::CORNER_ALL, FontSize))
 				PopupSelectConfigAutoMapInvoke(pProps[i].m_Value, UI()->MouseX(), UI()->MouseY());
 
 			int r = PopupSelectConfigAutoMapResult();
@@ -3236,12 +3236,12 @@ int CEditor::DoProperties(CUIRect *pToolBox, CProperty *pProps, int *pIDs, int *
 			RenderTools()->DrawUIRect(&Shifter, Color, 0, 5.0f);
 			UI()->DoLabel(&Shifter, aBuf, FontSize, TEXTALIGN_CENTER);
 
-			if(DoButton_ButtonDec((char *)&pIDs[i] + 1, 0, 0, &Dec, 0, "Previous Envelope"))
+			if(DoButton_ButtonDec((char *)&pIDs[i] + 1, nullptr, 0, &Dec, 0, "Previous Envelope"))
 			{
 				*pNewVal = pProps[i].m_Value - 1;
 				Change = i;
 			}
-			if(DoButton_ButtonInc(((char *)&pIDs[i]) + 2, 0, 0, &Inc, 0, "Next Envelope"))
+			if(DoButton_ButtonInc(((char *)&pIDs[i]) + 2, nullptr, 0, &Inc, 0, "Next Envelope"))
 			{
 				*pNewVal = pProps[i].m_Value + 1;
 				Change = i;
@@ -3323,7 +3323,7 @@ void CEditor::RenderLayers(CUIRect ToolBox, CUIRect View)
 
 				str_format(aBuf, sizeof(aBuf), "#%d %s", g, m_Map.m_vpGroups[g]->m_aName);
 				float FontSize = 10.0f;
-				while(TextRender()->TextWidth(0, FontSize, aBuf, -1, -1.0f) > Slot.w)
+				while(TextRender()->TextWidth(nullptr, FontSize, aBuf, -1, -1.0f) > Slot.w)
 					FontSize--;
 				if(int Result = DoButton_Ex(&m_Map.m_vpGroups[g], aBuf, g == m_SelectedGroup, &Slot,
 					   BUTTON_CONTEXT, m_Map.m_vpGroups[g]->m_Collapse ? "Select group. Shift click to select all layers. Double click to expand." : "Select group. Shift click to select all layers. Double click to collapse.", CUI::CORNER_R, FontSize))
@@ -3366,7 +3366,7 @@ void CEditor::RenderLayers(CUIRect ToolBox, CUIRect View)
 
 				//visible
 				LayersBox.HSplitTop(12.0f, &Slot, &LayersBox);
-				Slot.VSplitLeft(12.0f, 0, &Button);
+				Slot.VSplitLeft(12.0f, nullptr, &Button);
 				Button.VSplitLeft(15, &VisibleToggle, &Button);
 
 				if(DoButton_Ex(&m_Map.m_vpGroups[g]->m_vpLayers[i]->m_Visible, m_Map.m_vpGroups[g]->m_vpLayers[i]->m_Visible ? "V" : "H", 0, &VisibleToggle, 0, "Toggle layer visibility", CUI::CORNER_L, 10.0f, 0))
@@ -3396,7 +3396,7 @@ void CEditor::RenderLayers(CUIRect ToolBox, CUIRect View)
 				}
 
 				float FontSize = 10.0f;
-				while(TextRender()->TextWidth(0, FontSize, aBuf, -1, -1.0f) > Button.w)
+				while(TextRender()->TextWidth(nullptr, FontSize, aBuf, -1, -1.0f) > Button.w)
 					FontSize--;
 				int Checked = 0;
 				if(g == m_SelectedGroup)
@@ -3644,7 +3644,7 @@ void CEditor::ReplaceImage(const char *pFileName, int StorageType, void *pUser)
 	CEditorImage *pImg = pEditor->m_Map.m_vpImages[pEditor->m_SelectedImage];
 	pEditor->Graphics()->UnloadTexture(&(pImg->m_Texture));
 	free(pImg->m_pData);
-	pImg->m_pData = 0;
+	pImg->m_pData = nullptr;
 	*pImg = ImgInfo;
 	IStorage::StripPathAndExtension(pFileName, pImg->m_aName, sizeof(pImg->m_aName));
 	pImg->m_External = IsVanillaImage(pImg->m_aName);
@@ -3663,7 +3663,7 @@ void CEditor::ReplaceImage(const char *pFileName, int StorageType, void *pUser)
 	if(ImgInfo.m_Width % 16 != 0 || ImgInfo.m_Height % 16 != 0)
 		TextureLoadFlag = 0;
 	pImg->m_Texture = pEditor->Graphics()->LoadTextureRaw(ImgInfo.m_Width, ImgInfo.m_Height, ImgInfo.m_Format, ImgInfo.m_pData, CImageInfo::FORMAT_AUTO, TextureLoadFlag, pFileName);
-	ImgInfo.m_pData = 0;
+	ImgInfo.m_pData = nullptr;
 	pEditor->SortImages();
 	for(size_t i = 0; i < pEditor->m_Map.m_vpImages.size(); ++i)
 	{
@@ -3713,7 +3713,7 @@ void CEditor::AddImage(const char *pFileName, int StorageType, void *pUser)
 	if(ImgInfo.m_Width % 16 != 0 || ImgInfo.m_Height % 16 != 0)
 		TextureLoadFlag = 0;
 	pImg->m_Texture = pEditor->Graphics()->LoadTextureRaw(ImgInfo.m_Width, ImgInfo.m_Height, ImgInfo.m_Format, ImgInfo.m_pData, CImageInfo::FORMAT_AUTO, TextureLoadFlag, pFileName);
-	ImgInfo.m_pData = 0;
+	ImgInfo.m_pData = nullptr;
 	str_copy(pImg->m_aName, aBuf, sizeof(pImg->m_aName));
 	pImg->m_AutoMapper.Load(pImg->m_aName);
 	pEditor->m_Map.m_vpImages.push_back(pImg);
@@ -3822,7 +3822,7 @@ void CEditor::ReplaceSound(const char *pFileName, int StorageType, void *pUser)
 	// unload sample
 	pEditor->Sound()->UnloadSample(pSound->m_SoundID);
 	free(pSound->m_pData);
-	pSound->m_pData = 0x0;
+	pSound->m_pData = nullptr;
 
 	// replace sound
 	IStorage::StripPathAndExtension(pFileName, pSound->m_aName, sizeof(pSound->m_aName));
@@ -3943,7 +3943,7 @@ static bool ImageNameLess(const CEditorImage *const &a, const CEditorImage *cons
 	return str_comp(a->m_aName, b->m_aName) < 0;
 }
 
-static int *gs_pSortedIndex = 0;
+static int *gs_pSortedIndex = nullptr;
 static void ModifySortedIndex(int *pIndex)
 {
 	if(*pIndex >= 0)
@@ -3972,7 +3972,7 @@ void CEditor::SortImages()
 		m_Map.ModifyImageIndex(ModifySortedIndex);
 
 		delete[] gs_pSortedIndex;
-		gs_pSortedIndex = 0;
+		gs_pSortedIndex = nullptr;
 	}
 }
 
@@ -4072,7 +4072,7 @@ void CEditor::RenderImages(CUIRect ToolBox, CUIRect View)
 			}
 
 			float FontSize = 10.0f;
-			while(TextRender()->TextWidth(0, FontSize, aBuf, -1, -1.0f) > Slot.w)
+			while(TextRender()->TextWidth(nullptr, FontSize, aBuf, -1, -1.0f) > Slot.w)
 				FontSize--;
 
 			if(int Result = DoButton_Ex(&m_Map.m_vpImages[i], aBuf, Selected, &Slot,
@@ -4093,7 +4093,7 @@ void CEditor::RenderImages(CUIRect ToolBox, CUIRect View)
 				}
 			}
 
-			ToolBox.HSplitTop(2.0f, 0, &ToolBox);
+			ToolBox.HSplitTop(2.0f, nullptr, &ToolBox);
 		}
 
 		// separator
@@ -4259,7 +4259,7 @@ void CEditor::RenderSounds(CUIRect ToolBox, CUIRect View)
 			Selected += 2; // Sound is unused
 
 		float FontSize = 10.0f;
-		while(TextRender()->TextWidth(0, FontSize, aBuf, -1, -1.0f) > Slot.w)
+		while(TextRender()->TextWidth(nullptr, FontSize, aBuf, -1, -1.0f) > Slot.w)
 			FontSize--;
 
 		if(int Result = DoButton_Ex(&m_Map.m_vpSounds[i], aBuf, Selected, &Slot,
@@ -4272,7 +4272,7 @@ void CEditor::RenderSounds(CUIRect ToolBox, CUIRect View)
 				UiInvokePopupMenu(&s_PopupSoundID, 0, UI()->MouseX(), UI()->MouseY(), 120, 43, PopupSound);
 		}
 
-		ToolBox.HSplitTop(2.0f, 0, &ToolBox);
+		ToolBox.HSplitTop(2.0f, nullptr, &ToolBox);
 	}
 
 	// separator
@@ -4345,9 +4345,9 @@ void CEditor::AddFileDialogEntry(int Index, CUIRect *pView)
 
 	CUIRect Button, FileIcon;
 	pView->HSplitTop(15.0f, &Button, pView);
-	pView->HSplitTop(2.0f, 0, pView);
+	pView->HSplitTop(2.0f, nullptr, pView);
 	Button.VSplitLeft(Button.h, &FileIcon, &Button);
-	Button.VSplitLeft(5.0f, 0, &Button);
+	Button.VSplitLeft(5.0f, nullptr, &Button);
 
 	Graphics()->TextureSet(g_pData->m_aImages[IMAGE_FILEICONS].m_Id);
 	Graphics()->QuadsBegin();
@@ -4356,7 +4356,7 @@ void CEditor::AddFileDialogEntry(int Index, CUIRect *pView)
 	Graphics()->QuadsDrawTL(&QuadItem, 1);
 	Graphics()->QuadsEnd();
 
-	if(DoButton_File(&m_vFileList[Index], m_vFileList[Index].m_aName, m_FilesSelectedIndex == Index, &Button, 0, 0))
+	if(DoButton_File(&m_vFileList[Index], m_vFileList[Index].m_aName, m_FilesSelectedIndex == Index, &Button, 0, nullptr))
 	{
 		if(!m_vFileList[Index].m_IsDir)
 			str_copy(m_aFileDialogFileName, m_vFileList[Index].m_aFilename, sizeof(m_aFileDialogFileName));
@@ -4384,14 +4384,14 @@ void CEditor::RenderFileDialog()
 
 	CUIRect Title, FileBox, FileBoxLabel, ButtonBar, Scroll, PathBox;
 	View.HSplitTop(18.0f, &Title, &View);
-	View.HSplitTop(5.0f, 0, &View); // some spacing
+	View.HSplitTop(5.0f, nullptr, &View); // some spacing
 	View.HSplitBottom(14.0f, &View, &ButtonBar);
-	View.HSplitBottom(10.0f, &View, 0); // some spacing
+	View.HSplitBottom(10.0f, &View, nullptr); // some spacing
 	View.HSplitBottom(14.0f, &View, &PathBox);
-	View.HSplitBottom(5.0f, &View, 0); // some spacing
+	View.HSplitBottom(5.0f, &View, nullptr); // some spacing
 	View.HSplitBottom(14.0f, &View, &FileBox);
 	FileBox.VSplitLeft(55.0f, &FileBoxLabel, &FileBox);
-	View.HSplitBottom(10.0f, &View, 0); // some spacing
+	View.HSplitBottom(10.0f, &View, nullptr); // some spacing
 	if(m_FileDialogFileType == CEditor::FILETYPE_IMG)
 		View.VSplitMid(&View, &Preview);
 	View.VSplitRight(20.0f, &View, &Scroll);
@@ -4430,7 +4430,7 @@ void CEditor::RenderFileDialog()
 	else
 	{
 		//searchbox
-		FileBox.VSplitRight(250, &FileBox, 0);
+		FileBox.VSplitRight(250, &FileBox, nullptr);
 		CUIRect ClearBox;
 		FileBox.VSplitRight(15, &FileBox, &ClearBox);
 
@@ -4547,7 +4547,7 @@ void CEditor::RenderFileDialog()
 				{
 					m_FilePreviewImage = Graphics()->LoadTextureRaw(m_FilePreviewImageInfo.m_Width, m_FilePreviewImageInfo.m_Height, m_FilePreviewImageInfo.m_Format, m_FilePreviewImageInfo.m_pData, m_FilePreviewImageInfo.m_Format, 0);
 					CImageInfo DummyInfo = m_FilePreviewImageInfo;
-					m_FilePreviewImageInfo.m_pData = NULL;
+					m_FilePreviewImageInfo.m_pData = nullptr;
 					Graphics()->FreePNG(&DummyInfo);
 					m_PreviewImageIsLoaded = true;
 				}
@@ -4614,7 +4614,7 @@ void CEditor::RenderFileDialog()
 	CUIRect Button;
 	ButtonBar.VSplitRight(50.0f, &ButtonBar, &Button);
 	bool IsDir = m_FilesSelectedIndex >= 0 && m_vFileList[m_FilesSelectedIndex].m_IsDir;
-	if(DoButton_Editor(&s_OkButton, IsDir ? "Open" : m_pFileDialogButtonText, 0, &Button, 0, 0) || m_FileDialogActivate)
+	if(DoButton_Editor(&s_OkButton, IsDir ? "Open" : m_pFileDialogButtonText, 0, &Button, 0, nullptr) || m_FileDialogActivate)
 	{
 		m_FileDialogActivate = false;
 		if(IsDir) // folder
@@ -4667,13 +4667,13 @@ void CEditor::RenderFileDialog()
 
 	ButtonBar.VSplitRight(40.0f, &ButtonBar, &Button);
 	ButtonBar.VSplitRight(50.0f, &ButtonBar, &Button);
-	if(DoButton_Editor(&s_CancelButton, "Cancel", 0, &Button, 0, 0) || Input()->KeyIsPressed(KEY_ESCAPE))
+	if(DoButton_Editor(&s_CancelButton, "Cancel", 0, &Button, 0, nullptr) || Input()->KeyIsPressed(KEY_ESCAPE))
 		m_Dialog = DIALOG_NONE;
 
 	if(m_FileDialogStorageType == IStorage::TYPE_SAVE)
 	{
 		ButtonBar.VSplitLeft(70.0f, &Button, &ButtonBar);
-		if(DoButton_Editor(&s_NewFolderButton, "New folder", 0, &Button, 0, 0))
+		if(DoButton_Editor(&s_NewFolderButton, "New folder", 0, &Button, 0, nullptr))
 		{
 			m_aFileDialogNewFolderName[0] = 0;
 			m_FileDialogErrString[0] = 0;
@@ -4685,9 +4685,9 @@ void CEditor::RenderFileDialog()
 
 	if(m_FileDialogStorageType == IStorage::TYPE_SAVE)
 	{
-		ButtonBar.VSplitLeft(40.0f, 0, &ButtonBar);
+		ButtonBar.VSplitLeft(40.0f, nullptr, &ButtonBar);
 		ButtonBar.VSplitLeft(70.0f, &Button, &ButtonBar);
-		if(DoButton_Editor(&s_MapInfoButton, "Map details", 0, &Button, 0, 0))
+		if(DoButton_Editor(&s_MapInfoButton, "Map details", 0, &Button, 0, nullptr))
 		{
 			str_copy(m_Map.m_MapInfo.m_aAuthorTmp, m_Map.m_MapInfo.m_aAuthor, sizeof(m_Map.m_MapInfo.m_aAuthorTmp));
 			str_copy(m_Map.m_MapInfo.m_aVersionTmp, m_Map.m_MapInfo.m_aVersion, sizeof(m_Map.m_MapInfo.m_aVersionTmp));
@@ -4762,7 +4762,7 @@ void CEditor::RenderModebar(CUIRect View)
 	// mode buttons
 	{
 		View.VSplitLeft(65.0f, &Button, &View);
-		Button.HSplitTop(30.0f, 0, &Button);
+		Button.HSplitTop(30.0f, nullptr, &Button);
 		static int s_Button = 0;
 		const char *pButName = "";
 
@@ -4794,7 +4794,7 @@ void CEditor::RenderModebar(CUIRect View)
 		}
 	}
 
-	View.VSplitLeft(5.0f, 0, &View);
+	View.VSplitLeft(5.0f, nullptr, &View);
 }
 
 void CEditor::RenderStatusbar(CUIRect View)
@@ -4814,7 +4814,7 @@ void CEditor::RenderStatusbar(CUIRect View)
 	}
 
 	View.VSplitRight(100.0f, &View, &Button);
-	Button.VSplitRight(10.0f, &Button, 0);
+	Button.VSplitRight(10.0f, &Button, nullptr);
 	static int s_SettingsButton = 0;
 	if(DoButton_Editor(&s_SettingsButton, "Server settings", m_ShowServerSettingsEditor, &Button, 0, "Toggles the server settings editor."))
 	{
@@ -4883,7 +4883,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 	if(m_SelectedEnvelope >= (int)m_Map.m_vpEnvelopes.size())
 		m_SelectedEnvelope = m_Map.m_vpEnvelopes.size() - 1;
 
-	CEnvelope *pEnvelope = 0;
+	CEnvelope *pEnvelope = nullptr;
 	if(m_SelectedEnvelope >= 0 && m_SelectedEnvelope < (int)m_Map.m_vpEnvelopes.size())
 		pEnvelope = m_Map.m_vpEnvelopes[m_SelectedEnvelope];
 
@@ -4898,7 +4898,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 	// do the toolbar
 	{
 		CUIRect Button;
-		CEnvelope *pNewEnv = 0;
+		CEnvelope *pNewEnv = nullptr;
 
 		ToolBar.VSplitRight(50.0f, &ToolBar, &Button);
 		static int s_NewSoundButton = 0;
@@ -4938,7 +4938,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 				m_Map.DeleteEnvelope(m_SelectedEnvelope);
 				if(m_SelectedEnvelope >= (int)m_Map.m_vpEnvelopes.size())
 					m_SelectedEnvelope = m_Map.m_vpEnvelopes.size() - 1;
-				pEnvelope = m_SelectedEnvelope >= 0 ? m_Map.m_vpEnvelopes[m_SelectedEnvelope] : 0;
+				pEnvelope = m_SelectedEnvelope >= 0 ? m_Map.m_vpEnvelopes[m_SelectedEnvelope] : nullptr;
 			}
 		}
 
@@ -4975,7 +4975,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 		UI()->DoLabel(&Shifter, aBuf, 10.0f, TEXTALIGN_CENTER);
 
 		static int s_PrevButton = 0;
-		if(DoButton_ButtonDec(&s_PrevButton, 0, 0, &Dec, 0, "Previous Envelope"))
+		if(DoButton_ButtonDec(&s_PrevButton, nullptr, 0, &Dec, 0, "Previous Envelope"))
 		{
 			m_SelectedEnvelope--;
 			if(m_SelectedEnvelope < 0)
@@ -4984,7 +4984,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 		}
 
 		static int s_NextButton = 0;
-		if(DoButton_ButtonInc(&s_NextButton, 0, 0, &Inc, 0, "Next Envelope"))
+		if(DoButton_ButtonInc(&s_NextButton, nullptr, 0, &Inc, 0, "Next Envelope"))
 		{
 			m_SelectedEnvelope++;
 			if(m_SelectedEnvelope >= (int)m_Map.m_vpEnvelopes.size())
@@ -5214,7 +5214,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 		// render handles
 
 		// keep track of last Env
-		static void *s_pID = 0;
+		static void *s_pID = nullptr;
 
 		// chars for textinput
 		static char s_aStrCurTime[32] = "0.000";
@@ -5222,7 +5222,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 
 		if(CurrentEnvelopeSwitched)
 		{
-			s_pID = 0;
+			s_pID = nullptr;
 
 			// update displayed text
 			str_format(s_aStrCurTime, sizeof(s_aStrCurTime), "0.000");
@@ -5316,7 +5316,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 						{
 							if(s_pID == pID)
 							{
-								s_pID = 0;
+								s_pID = nullptr;
 
 								// update displayed text
 								str_format(s_aStrCurTime, sizeof(s_aStrCurTime), "0.000");
@@ -5412,11 +5412,11 @@ void CEditor::RenderServerSettingsEditor(CUIRect View, bool ShowServerSettingsEd
 		CUIRect Button;
 
 		// command line
-		ToolBar.VSplitLeft(5.0f, 0, &Button);
+		ToolBar.VSplitLeft(5.0f, nullptr, &Button);
 		UI()->DoLabel(&Button, "Command:", 12.0f, TEXTALIGN_LEFT);
 
-		Button.VSplitLeft(70.0f, 0, &Button);
-		Button.VSplitLeft(180.0f, &Button, 0);
+		Button.VSplitLeft(70.0f, nullptr, &Button);
+		Button.VSplitLeft(180.0f, &Button, nullptr);
 		static int s_ClearButton = 0;
 		DoClearableEditBox(&m_CommandBox, &s_ClearButton, &Button, m_aSettingsCommand, sizeof(m_aSettingsCommand), 12.0f, &m_CommandBox, false, CUI::CORNER_ALL);
 
@@ -5452,7 +5452,7 @@ void CEditor::RenderServerSettingsEditor(CUIRect View, bool ShowServerSettingsEd
 		if(!m_Map.m_vSettings.empty() && s_CommandSelectedIndex >= 0 && (size_t)s_CommandSelectedIndex < m_Map.m_vSettings.size())
 		{
 			ToolBar.VSplitRight(50.0f, &ToolBar, &Button);
-			Button.VSplitRight(5.0f, &Button, 0);
+			Button.VSplitRight(5.0f, &Button, nullptr);
 			static int s_ModButton = 0;
 			if(DoButton_Editor(&s_ModButton, "Mod", 0, &Button, 0, "Modify a command from the command list.") || (Input()->KeyPress(KEY_M) && UI()->LastActiveItem() != &m_CommandBox && m_Dialog == DIALOG_NONE))
 			{
@@ -5480,7 +5480,7 @@ void CEditor::RenderServerSettingsEditor(CUIRect View, bool ShowServerSettingsEd
 			}
 
 			ToolBar.VSplitRight(50.0f, &ToolBar, &Button);
-			Button.VSplitRight(5.0f, &Button, 0);
+			Button.VSplitRight(5.0f, &Button, nullptr);
 			static int s_DelButton = 0;
 			if(DoButton_Editor(&s_DelButton, "Del", 0, &Button, 0, "Delete a command from the command list.") || (Input()->KeyPress(KEY_DELETE) && UI()->LastActiveItem() != &m_CommandBox && m_Dialog == DIALOG_NONE))
 			{
@@ -5493,7 +5493,7 @@ void CEditor::RenderServerSettingsEditor(CUIRect View, bool ShowServerSettingsEd
 			}
 
 			ToolBar.VSplitRight(25.0f, &ToolBar, &Button);
-			Button.VSplitRight(5.0f, &Button, 0);
+			Button.VSplitRight(5.0f, &Button, nullptr);
 			static int s_DownButton = 0;
 			if(s_CommandSelectedIndex < (int)m_Map.m_vSettings.size() - 1 && DoButton_Editor(&s_DownButton, "▼", 0, &Button, 0, "Move command down"))
 			{
@@ -5502,7 +5502,7 @@ void CEditor::RenderServerSettingsEditor(CUIRect View, bool ShowServerSettingsEd
 			}
 
 			ToolBar.VSplitRight(25.0f, &ToolBar, &Button);
-			Button.VSplitRight(5.0f, &Button, 0);
+			Button.VSplitRight(5.0f, &Button, nullptr);
 			static int s_UpButton = 0;
 			if(s_CommandSelectedIndex > 0 && DoButton_Editor(&s_UpButton, "▲", 0, &Button, 0, "Move command up"))
 			{
@@ -5512,7 +5512,7 @@ void CEditor::RenderServerSettingsEditor(CUIRect View, bool ShowServerSettingsEd
 		}
 	}
 
-	View.HSplitTop(2.0f, 0, &View);
+	View.HSplitTop(2.0f, nullptr, &View);
 	RenderBackground(View, m_CheckerTexture, 32.0f, 0.1f);
 
 	CUIRect ListBox;
@@ -5559,10 +5559,10 @@ void CEditor::RenderServerSettingsEditor(CUIRect View, bool ShowServerSettingsEd
 		{
 			CUIRect Button;
 			ListBox.HSplitTop(15.0f, &Button, &ListBox);
-			ListBox.HSplitTop(2.0f, 0, &ListBox);
-			Button.VSplitLeft(5.0f, 0, &Button);
+			ListBox.HSplitTop(2.0f, nullptr, &ListBox);
+			Button.VSplitLeft(5.0f, nullptr, &Button);
 
-			if(DoButton_MenuItem(&m_Map.m_vSettings[i], m_Map.m_vSettings[i].m_aCommand, s_CommandSelectedIndex >= 0 && (size_t)s_CommandSelectedIndex == i, &Button, 0, 0))
+			if(DoButton_MenuItem(&m_Map.m_vSettings[i], m_Map.m_vSettings[i].m_aCommand, s_CommandSelectedIndex >= 0 && (size_t)s_CommandSelectedIndex == i, &Button, 0, nullptr))
 			{
 				s_CommandSelectedIndex = i;
 				str_copy(m_aSettingsCommand, m_Map.m_vSettings[i].m_aCommand, sizeof(m_aSettingsCommand));
@@ -5694,13 +5694,13 @@ void CEditor::RenderMenubar(CUIRect MenuBar)
 	CUIRect FileButton;
 	static int s_FileButton = 0;
 	MenuBar.VSplitLeft(60.0f, &FileButton, &MenuBar);
-	if(DoButton_Menu(&s_FileButton, "File", 0, &FileButton, 0, 0))
+	if(DoButton_Menu(&s_FileButton, "File", 0, &FileButton, 0, nullptr))
 		UiInvokePopupMenu(&s_FileButton, 1, FileButton.x, FileButton.y + FileButton.h - 1.0f, 120, 160, PopupMenuFile, this);
 
 	CUIRect Info, Close;
-	MenuBar.VSplitLeft(40.0f, 0, &MenuBar);
+	MenuBar.VSplitLeft(40.0f, nullptr, &MenuBar);
 	MenuBar.VSplitRight(20.0f, &MenuBar, &Close);
-	Close.VSplitLeft(5.0f, 0, &Close);
+	Close.VSplitLeft(5.0f, nullptr, &Close);
 	MenuBar.VSplitLeft(MenuBar.w * 0.75f, &MenuBar, &Info);
 	char aBuf[128];
 	str_format(aBuf, sizeof(aBuf), "File: %s", m_aFileName);
@@ -5728,7 +5728,7 @@ void CEditor::Render()
 	float Height = View.h;
 
 	// reset tip
-	m_pTooltip = 0;
+	m_pTooltip = nullptr;
 
 	if(m_EditBoxActive)
 		--m_EditBoxActive;
@@ -5861,7 +5861,7 @@ void CEditor::Render()
 		}
 
 		TextRender()->TextColor(1.0f, 0.0f, 0.0f, 1.0f);
-		TextRender()->Text(0, 5.0f, 27.0f, 10.0f, aBuf, -1.0f);
+		TextRender()->Text(nullptr, 5.0f, 27.0f, 10.0f, aBuf, -1.0f);
 		TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
 	}
 
@@ -6238,16 +6238,16 @@ void CEditorMap::Clean()
 
 	m_vSettings.clear();
 
-	m_pGameLayer = 0x0;
-	m_pGameGroup = 0x0;
+	m_pGameLayer = nullptr;
+	m_pGameGroup = nullptr;
 
 	m_Modified = false;
 
-	m_pTeleLayer = 0x0;
-	m_pSpeedupLayer = 0x0;
-	m_pFrontLayer = 0x0;
-	m_pSwitchLayer = 0x0;
-	m_pTuneLayer = 0x0;
+	m_pTeleLayer = nullptr;
+	m_pSpeedupLayer = nullptr;
+	m_pFrontLayer = nullptr;
+	m_pSwitchLayer = nullptr;
+	m_pTuneLayer = nullptr;
 }
 
 void CEditorMap::CreateDefault(IGraphics::CTextureHandle EntitiesTexture)
@@ -6272,11 +6272,11 @@ void CEditorMap::CreateDefault(IGraphics::CTextureHandle EntitiesTexture)
 	MakeGameLayer(new CLayerGame(50, 50));
 	m_pGameGroup->AddLayer(m_pGameLayer);
 
-	m_pFrontLayer = 0x0;
-	m_pTeleLayer = 0x0;
-	m_pSpeedupLayer = 0x0;
-	m_pSwitchLayer = 0x0;
-	m_pTuneLayer = 0x0;
+	m_pFrontLayer = nullptr;
+	m_pTeleLayer = nullptr;
+	m_pSpeedupLayer = nullptr;
+	m_pSwitchLayer = nullptr;
+	m_pTuneLayer = nullptr;
 }
 
 int CEditor::GetTextureUsageFlag()
@@ -6401,7 +6401,7 @@ void CEditor::UpdateAndRender()
 		m_AnimateTime = (time_get() - m_AnimateStart) / (float)time_freq();
 	else
 		m_AnimateTime = 0;
-	ms_pUiGotContext = 0;
+	ms_pUiGotContext = nullptr;
 
 	UI()->StartCheck();
 
@@ -6459,7 +6459,7 @@ void CEditor::UpdateAndRender()
 
 	if(Input()->KeyPress(KEY_F10))
 	{
-		Graphics()->TakeScreenshot(0);
+		Graphics()->TakeScreenshot(nullptr);
 		m_ShowMousePointer = true;
 	}
 

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -126,7 +126,7 @@ public:
 		m_Visible = true;
 		m_Readonly = false;
 		m_Flags = 0;
-		m_pEditor = 0;
+		m_pEditor = nullptr;
 		m_BrushRefCount = 0;
 	}
 
@@ -282,7 +282,7 @@ public:
 		m_External = 0;
 		m_Width = 0;
 		m_Height = 0;
-		m_pData = 0;
+		m_pData = nullptr;
 		m_Format = 0;
 	}
 
@@ -308,7 +308,7 @@ public:
 		m_aName[0] = 0;
 		m_SoundID = 0;
 
-		m_pData = 0x0;
+		m_pData = nullptr;
 		m_DataSize = 0;
 	}
 
@@ -712,16 +712,16 @@ public:
 	CEditor() :
 		m_TilesetPicker(16, 16)
 	{
-		m_pInput = 0;
-		m_pClient = 0;
-		m_pGraphics = 0;
-		m_pTextRender = 0;
-		m_pSound = 0;
+		m_pInput = nullptr;
+		m_pClient = nullptr;
+		m_pGraphics = nullptr;
+		m_pTextRender = nullptr;
+		m_pSound = nullptr;
 
 		m_Mode = MODE_LAYERS;
 		m_Dialog = 0;
 		m_EditBoxActive = 0;
-		m_pTooltip = 0;
+		m_pTooltip = nullptr;
 
 		m_GridActive = false;
 		m_GridFactor = 1;
@@ -737,9 +737,9 @@ public:
 		m_MouseInsidePopup = false;
 
 		m_FileDialogStorageType = 0;
-		m_pFileDialogTitle = 0;
-		m_pFileDialogButtonText = 0;
-		m_pFileDialogUser = 0;
+		m_pFileDialogTitle = nullptr;
+		m_pFileDialogButtonText = nullptr;
+		m_pFileDialogUser = nullptr;
 		m_aFileDialogFileName[0] = 0;
 		m_aFileDialogCurrentFolder[0] = 0;
 		m_aFileDialogCurrentLink[0] = 0;
@@ -791,7 +791,7 @@ public:
 		m_CommandBox = 0.0f;
 		m_aSettingsCommand[0] = 0;
 
-		ms_pUiGotContext = 0;
+		ms_pUiGotContext = nullptr;
 
 		// DDRace
 
@@ -1009,9 +1009,9 @@ public:
 	int DoButton_File(const void *pID, const char *pText, int Checked, const CUIRect *pRect, int Flags, const char *pToolTip);
 
 	int DoButton_Menu(const void *pID, const char *pText, int Checked, const CUIRect *pRect, int Flags, const char *pToolTip);
-	int DoButton_MenuItem(const void *pID, const char *pText, int Checked, const CUIRect *pRect, int Flags = 0, const char *pToolTip = 0);
+	int DoButton_MenuItem(const void *pID, const char *pText, int Checked, const CUIRect *pRect, int Flags = 0, const char *pToolTip = nullptr);
 
-	int DoButton_ColorPicker(const void *pID, const CUIRect *pRect, ColorRGBA *pColor, const char *pToolTip = 0);
+	int DoButton_ColorPicker(const void *pID, const CUIRect *pRect, ColorRGBA *pColor, const char *pToolTip = nullptr);
 
 	bool DoEditBox(void *pID, const CUIRect *pRect, char *pStr, unsigned StrSize, float FontSize, float *pOffset, bool Hidden = false, int Corners = CUI::CORNER_ALL);
 	bool DoClearableEditBox(void *pID, void *pClearID, const CUIRect *pRect, char *pStr, unsigned StrSize, float FontSize, float *pOffset, bool Hidden, int Corners);
@@ -1020,12 +1020,12 @@ public:
 
 	void RenderGrid(CLayerGroup *pGroup);
 
-	void UiInvokePopupMenu(void *pID, int Flags, float X, float Y, float W, float H, int (*pfnFunc)(CEditor *pEditor, CUIRect Rect, void *pContext), void *pContext = 0);
+	void UiInvokePopupMenu(void *pID, int Flags, float X, float Y, float W, float H, int (*pfnFunc)(CEditor *pEditor, CUIRect Rect, void *pContext), void *pContext = nullptr);
 	void UiDoPopupMenu();
 	bool UiPopupExists(void *pID);
 	bool UiPopupOpen();
 
-	int UiDoValueSelector(void *pID, CUIRect *pRect, const char *pLabel, int Current, int Min, int Max, int Step, float Scale, const char *pToolTip, bool IsDegree = false, bool IsHex = false, int corners = CUI::CORNER_ALL, ColorRGBA *Color = 0);
+	int UiDoValueSelector(void *pID, CUIRect *pRect, const char *pLabel, int Current, int Min, int Max, int Step, float Scale, const char *pToolTip, bool IsDegree = false, bool IsHex = false, int corners = CUI::CORNER_ALL, ColorRGBA *Color = nullptr);
 
 	static int PopupGroup(CEditor *pEditor, CUIRect View, void *pContext);
 

--- a/src/game/editor/io.cpp
+++ b/src/game/editor/io.cpp
@@ -432,7 +432,7 @@ int CEditorMap::Load(class IStorage *pStorage, const char *pFileName, int Storag
 			{
 				int ItemSize = DataFile.GetItemSize(Start);
 				int ItemID;
-				CMapItemInfoSettings *pItem = (CMapItemInfoSettings *)DataFile.GetItem(i, 0, &ItemID);
+				CMapItemInfoSettings *pItem = (CMapItemInfoSettings *)DataFile.GetItem(i, nullptr, &ItemID);
 				if(!pItem || ItemID != 0)
 					continue;
 
@@ -471,7 +471,7 @@ int CEditorMap::Load(class IStorage *pStorage, const char *pFileName, int Storag
 			DataFile.GetType(MAPITEMTYPE_IMAGE, &Start, &Num);
 			for(int i = 0; i < Num; i++)
 			{
-				CMapItemImage *pItem = (CMapItemImage *)DataFile.GetItem(Start + i, 0, 0);
+				CMapItemImage *pItem = (CMapItemImage *)DataFile.GetItem(Start + i, nullptr, nullptr);
 				char *pName = (char *)DataFile.GetData(pItem->m_ImageName);
 
 				// copy base info
@@ -492,7 +492,7 @@ int CEditorMap::Load(class IStorage *pStorage, const char *pFileName, int Storag
 						if(ImgInfo.m_Width % 16 != 0 || ImgInfo.m_Height % 16 != 0)
 							TextureLoadFlag = 0;
 						pImg->m_Texture = m_pEditor->Graphics()->LoadTextureRaw(ImgInfo.m_Width, ImgInfo.m_Height, ImgInfo.m_Format, ImgInfo.m_pData, CImageInfo::FORMAT_AUTO, TextureLoadFlag, aBuf);
-						ImgInfo.m_pData = 0;
+						ImgInfo.m_pData = nullptr;
 						pImg->m_External = 1;
 					}
 				}
@@ -533,7 +533,7 @@ int CEditorMap::Load(class IStorage *pStorage, const char *pFileName, int Storag
 			DataFile.GetType(MAPITEMTYPE_SOUND, &Start, &Num);
 			for(int i = 0; i < Num; i++)
 			{
-				CMapItemSound *pItem = (CMapItemSound *)DataFile.GetItem(Start + i, 0, 0);
+				CMapItemSound *pItem = (CMapItemSound *)DataFile.GetItem(Start + i, nullptr, nullptr);
 				char *pName = (char *)DataFile.GetData(pItem->m_SoundName);
 
 				// copy base info
@@ -595,7 +595,7 @@ int CEditorMap::Load(class IStorage *pStorage, const char *pFileName, int Storag
 			DataFile.GetType(MAPITEMTYPE_GROUP, &Start, &Num);
 			for(int g = 0; g < Num; g++)
 			{
-				CMapItemGroup *pGItem = (CMapItemGroup *)DataFile.GetItem(Start + g, 0, 0);
+				CMapItemGroup *pGItem = (CMapItemGroup *)DataFile.GetItem(Start + g, nullptr, nullptr);
 
 				if(pGItem->m_Version < 1 || pGItem->m_Version > CMapItemGroup::CURRENT_VERSION)
 					continue;
@@ -621,15 +621,15 @@ int CEditorMap::Load(class IStorage *pStorage, const char *pFileName, int Storag
 
 				for(int l = 0; l < pGItem->m_NumLayers; l++)
 				{
-					CLayer *pLayer = 0;
-					CMapItemLayer *pLayerItem = (CMapItemLayer *)DataFile.GetItem(LayersStart + pGItem->m_StartLayer + l, 0, 0);
+					CLayer *pLayer = nullptr;
+					CMapItemLayer *pLayerItem = (CMapItemLayer *)DataFile.GetItem(LayersStart + pGItem->m_StartLayer + l, nullptr, nullptr);
 					if(!pLayerItem)
 						continue;
 
 					if(pLayerItem->m_Type == LAYERTYPE_TILES)
 					{
 						CMapItemLayerTilemap *pTilemapItem = (CMapItemLayerTilemap *)pLayerItem;
-						CLayerTiles *pTiles = 0;
+						CLayerTiles *pTiles = nullptr;
 
 						if(pTilemapItem->m_Flags & TILESLAYERFLAG_GAME)
 						{
@@ -946,20 +946,20 @@ int CEditorMap::Load(class IStorage *pStorage, const char *pFileName, int Storag
 
 		// load envelopes
 		{
-			CEnvPoint *pPoints = 0;
+			CEnvPoint *pPoints = nullptr;
 
 			{
 				int Start, Num;
 				DataFile.GetType(MAPITEMTYPE_ENVPOINTS, &Start, &Num);
 				if(Num)
-					pPoints = (CEnvPoint *)DataFile.GetItem(Start, 0, 0);
+					pPoints = (CEnvPoint *)DataFile.GetItem(Start, nullptr, nullptr);
 			}
 
 			int Start, Num;
 			DataFile.GetType(MAPITEMTYPE_ENVELOPE, &Start, &Num);
 			for(int e = 0; e < Num; e++)
 			{
-				CMapItemEnvelope *pItem = (CMapItemEnvelope *)DataFile.GetItem(Start + e, 0, 0);
+				CMapItemEnvelope *pItem = (CMapItemEnvelope *)DataFile.GetItem(Start + e, nullptr, nullptr);
 				CEnvelope *pEnv = new CEnvelope(pItem->m_Channels);
 				pEnv->m_vPoints.resize(pItem->m_NumPoints);
 				mem_copy(&pEnv->m_vPoints[0], &pPoints[pItem->m_StartPoint], sizeof(CEnvPoint) * pItem->m_NumPoints);
@@ -976,7 +976,7 @@ int CEditorMap::Load(class IStorage *pStorage, const char *pFileName, int Storag
 			DataFile.GetType(MAPITEMTYPE_AUTOMAPPER_CONFIG, &Start, &Num);
 			for(int i = 0; i < Num; i++)
 			{
-				CMapItemAutoMapperConfig *pItem = (CMapItemAutoMapperConfig *)DataFile.GetItem(Start + i, 0, 0);
+				CMapItemAutoMapperConfig *pItem = (CMapItemAutoMapperConfig *)DataFile.GetItem(Start + i, nullptr, nullptr);
 				if(pItem->m_Version == CMapItemAutoMapperConfig::CURRENT_VERSION)
 				{
 					if(pItem->m_GroupId >= 0 && (size_t)pItem->m_GroupId < m_vpGroups.size() &&

--- a/src/game/editor/layer_quads.cpp
+++ b/src/game/editor/layer_quads.cpp
@@ -222,7 +222,7 @@ int CLayerQuads::RenderProperties(CUIRect *pToolBox)
 
 	CProperty aProps[] = {
 		{"Image", m_Image, PROPTYPE_IMAGE, -1, 0},
-		{0},
+		{nullptr},
 	};
 
 	static int s_aIds[NUM_PROPS] = {0};

--- a/src/game/editor/layer_sounds.cpp
+++ b/src/game/editor/layer_sounds.cpp
@@ -186,7 +186,7 @@ int CLayerSounds::RenderProperties(CUIRect *pToolBox)
 
 	CProperty aProps[] = {
 		{"Sound", m_Sound, PROPTYPE_SOUND, -1, 0},
-		{0},
+		{nullptr},
 	};
 
 	static int s_aIds[NUM_PROPS] = {0};

--- a/src/game/editor/layer_tiles.cpp
+++ b/src/game/editor/layer_tiles.cpp
@@ -187,7 +187,7 @@ void CLayerTiles::BrushSelecting(CUIRect Rect)
 	m_pEditor->Graphics()->QuadsEnd();
 	char aBuf[16];
 	str_format(aBuf, sizeof(aBuf), "%d,%d", ConvertX(Rect.w), ConvertY(Rect.h));
-	TextRender()->Text(0, Rect.x + 3.0f, Rect.y + 3.0f, m_pEditor->m_ShowPicker ? 15.0f : 15.0f * m_pEditor->m_WorldZoom, aBuf, -1.0f);
+	TextRender()->Text(nullptr, Rect.x + 3.0f, Rect.y + 3.0f, m_pEditor->m_ShowPicker ? 15.0f : 15.0f * m_pEditor->m_WorldZoom, aBuf, -1.0f);
 }
 
 int CLayerTiles::BrushGrab(CLayerGroup *pBrush, CUIRect Rect)
@@ -759,13 +759,13 @@ int CLayerTiles::RenderProperties(CUIRect *pToolBox)
 		{
 			static int s_AutoMapperButton = 0;
 			static int s_AutoMapperButtonAuto = 0;
-			pToolBox->HSplitBottom(2.0f, pToolBox, 0);
+			pToolBox->HSplitBottom(2.0f, pToolBox, nullptr);
 			pToolBox->HSplitBottom(12.0f, pToolBox, &Button);
 			if(m_Seed != 0)
 			{
 				CUIRect ButtonAuto;
 				Button.VSplitRight(16.0f, &Button, &ButtonAuto);
-				Button.VSplitRight(2.0f, &Button, 0);
+				Button.VSplitRight(2.0f, &Button, nullptr);
 				if(m_pEditor->DoButton_Editor(&s_AutoMapperButtonAuto, "A", m_AutoAutoMap, &ButtonAuto, 0, "Automatically run automap after modifications."))
 				{
 					m_AutoAutoMap = !m_AutoAutoMap;
@@ -812,19 +812,19 @@ int CLayerTiles::RenderProperties(CUIRect *pToolBox)
 		{"Color TO", m_ColorEnvOffset, PROPTYPE_INT_SCROLL, -1000000, 1000000},
 		{"Auto Rule", m_AutoMapperConfig, PROPTYPE_AUTOMAPPER, m_Image, 0},
 		{"Seed", m_Seed, PROPTYPE_INT_SCROLL, 0, 1000000000},
-		{0},
+		{nullptr},
 	};
 
 	if(IsGameLayer) // remove the image and color properties if this is a game layer
 	{
-		aProps[PROP_IMAGE].m_pName = 0;
-		aProps[PROP_COLOR].m_pName = 0;
-		aProps[PROP_AUTOMAPPER].m_pName = 0;
+		aProps[PROP_IMAGE].m_pName = nullptr;
+		aProps[PROP_COLOR].m_pName = nullptr;
+		aProps[PROP_AUTOMAPPER].m_pName = nullptr;
 	}
 	if(m_Image == -1)
 	{
-		aProps[PROP_AUTOMAPPER].m_pName = 0;
-		aProps[PROP_SEED].m_pName = 0;
+		aProps[PROP_AUTOMAPPER].m_pName = nullptr;
+		aProps[PROP_SEED].m_pName = nullptr;
 	}
 
 	static int s_aIds[NUM_PROPS] = {0};
@@ -963,7 +963,7 @@ int CLayerTiles::RenderCommonProperties(SCommonPropState &State, CEditor *pEdito
 		Props.m_MaxWidth = Warning.w;
 		pEditor->UI()->DoLabel(&Warning, "Editing multiple layers", 9.0f, TEXTALIGN_LEFT, Props);
 		pEditor->TextRender()->TextColor(ColorRGBA(1.0f, 1.0f, 1.0f, 1.0f));
-		pToolbox->HSplitTop(2.0f, 0, pToolbox);
+		pToolbox->HSplitTop(2.0f, nullptr, pToolbox);
 	}
 
 	enum
@@ -982,7 +982,7 @@ int CLayerTiles::RenderCommonProperties(SCommonPropState &State, CEditor *pEdito
 		{"Shift", 0, PROPTYPE_SHIFT, 0, 0},
 		{"Shift by", pEditor->m_ShiftBy, PROPTYPE_INT_SCROLL, 1, 100000},
 		{"Color", State.Color, PROPTYPE_COLOR, 0, 0},
-		{0},
+		{nullptr},
 	};
 
 	static int s_aIds[NUM_PROPS] = {0};

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -307,7 +307,7 @@ int CEditor::PopupGroup(CEditor *pEditor, CUIRect View, void *pContext)
 		View.HSplitBottom(5.0f, &View, &Button);
 		View.HSplitBottom(12.0f, &View, &Button);
 		pEditor->UI()->DoLabel(&Button, "Name:", 10.0f, TEXTALIGN_LEFT);
-		Button.VSplitLeft(40.0f, 0, &Button);
+		Button.VSplitLeft(40.0f, nullptr, &Button);
 		static float s_Name = 0;
 		if(pEditor->DoEditBox(&s_Name, &Button, pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_aName, sizeof(pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_aName), 10.0f, &s_Name))
 			pEditor->m_Map.m_Modified = true;
@@ -340,7 +340,7 @@ int CEditor::PopupGroup(CEditor *pEditor, CUIRect View, void *pContext)
 		{"Clip Y", pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_ClipY, PROPTYPE_INT_SCROLL, -1000000, 1000000},
 		{"Clip W", pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_ClipW, PROPTYPE_INT_SCROLL, 0, 1000000},
 		{"Clip H", pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_ClipH, PROPTYPE_INT_SCROLL, 0, 1000000},
-		{0},
+		{nullptr},
 	};
 
 	static int s_aIds[NUM_PROPS] = {0};
@@ -348,7 +348,7 @@ int CEditor::PopupGroup(CEditor *pEditor, CUIRect View, void *pContext)
 
 	// cut the properties that isn't needed
 	if(pEditor->GetSelectedGroup()->m_GameGroup)
-		aProps[PROP_POS_X].m_pName = 0;
+		aProps[PROP_POS_X].m_pName = nullptr;
 
 	int Prop = pEditor->DoProperties(&View, aProps, s_aIds, &NewVal);
 	if(Prop != -1)
@@ -402,15 +402,15 @@ int CEditor::PopupLayer(CEditor *pEditor, CUIRect View, void *pContext)
 		pEditor->DoButton_Editor(&s_DeleteButton, "Delete layer", 0, &Button, 0, "Deletes the layer"))
 	{
 		if(pEditor->GetSelectedLayer(0) == pEditor->m_Map.m_pFrontLayer)
-			pEditor->m_Map.m_pFrontLayer = 0x0;
+			pEditor->m_Map.m_pFrontLayer = nullptr;
 		if(pEditor->GetSelectedLayer(0) == pEditor->m_Map.m_pTeleLayer)
-			pEditor->m_Map.m_pTeleLayer = 0x0;
+			pEditor->m_Map.m_pTeleLayer = nullptr;
 		if(pEditor->GetSelectedLayer(0) == pEditor->m_Map.m_pSpeedupLayer)
-			pEditor->m_Map.m_pSpeedupLayer = 0x0;
+			pEditor->m_Map.m_pSpeedupLayer = nullptr;
 		if(pEditor->GetSelectedLayer(0) == pEditor->m_Map.m_pSwitchLayer)
-			pEditor->m_Map.m_pSwitchLayer = 0x0;
+			pEditor->m_Map.m_pSwitchLayer = nullptr;
 		if(pEditor->GetSelectedLayer(0) == pEditor->m_Map.m_pTuneLayer)
-			pEditor->m_Map.m_pTuneLayer = 0x0;
+			pEditor->m_Map.m_pTuneLayer = nullptr;
 		pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->DeleteLayer(pEditor->m_vSelectedLayers[0]);
 		return 1;
 	}
@@ -422,13 +422,13 @@ int CEditor::PopupLayer(CEditor *pEditor, CUIRect View, void *pContext)
 		View.HSplitBottom(5.0f, &View, &Button);
 		View.HSplitBottom(12.0f, &View, &Button);
 		pEditor->UI()->DoLabel(&Button, "Name:", 10.0f, TEXTALIGN_LEFT);
-		Button.VSplitLeft(40.0f, 0, &Button);
+		Button.VSplitLeft(40.0f, nullptr, &Button);
 		static float s_Name = 0;
 		if(pEditor->DoEditBox(&s_Name, &Button, pEditor->GetSelectedLayer(0)->m_aName, sizeof(pEditor->GetSelectedLayer(0)->m_aName), 10.0f, &s_Name))
 			pEditor->m_Map.m_Modified = true;
 	}
 
-	View.HSplitBottom(10.0f, &View, 0);
+	View.HSplitBottom(10.0f, &View, nullptr);
 
 	CLayerGroup *pCurrentGroup = pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup];
 	CLayer *pCurrentLayer = pEditor->GetSelectedLayer(0);
@@ -445,7 +445,7 @@ int CEditor::PopupLayer(CEditor *pEditor, CUIRect View, void *pContext)
 		{"Group", pEditor->m_SelectedGroup, PROPTYPE_INT_STEP, 0, (int)pEditor->m_Map.m_vpGroups.size() - 1},
 		{"Order", pEditor->m_vSelectedLayers[0], PROPTYPE_INT_STEP, 0, (int)pCurrentGroup->m_vpLayers.size()},
 		{"Detail", pCurrentLayer && pCurrentLayer->m_Flags & LAYERFLAG_DETAIL, PROPTYPE_BOOL, 0, 1},
-		{0},
+		{nullptr},
 	};
 
 	// if(pEditor->m_Map.m_pGameLayer == pEditor->GetSelectedLayer(0)) // don't use Group and Detail from the selection if this is the game layer
@@ -635,7 +635,7 @@ int CEditor::PopupQuad(CEditor *pEditor, CUIRect View, void *pContext)
 		{"Color Env", pCurrentQuad->m_ColorEnv + 1, PROPTYPE_ENVELOPE, 0, 0},
 		{"Color TO", pCurrentQuad->m_ColorEnvOffset, PROPTYPE_INT_SCROLL, -1000000, 1000000},
 
-		{0},
+		{nullptr},
 	};
 
 	static int s_aIds[NUM_PROPS] = {0};
@@ -719,7 +719,7 @@ int CEditor::PopupSource(CEditor *pEditor, CUIRect View, void *pContext)
 
 	// Sound shape button
 	CUIRect ShapeButton;
-	View.HSplitBottom(3.0f, &View, 0x0);
+	View.HSplitBottom(3.0f, &View, nullptr);
 	View.HSplitBottom(12.0f, &View, &ShapeButton);
 	static int s_ShapeTypeButton = 0;
 
@@ -777,7 +777,7 @@ int CEditor::PopupSource(CEditor *pEditor, CUIRect View, void *pContext)
 		{"Sound Env", pSource->m_SoundEnv + 1, PROPTYPE_ENVELOPE, 0, 0},
 		{"Sound. TO", pSource->m_SoundEnvOffset, PROPTYPE_INT_SCROLL, -1000000, 1000000},
 
-		{0},
+		{nullptr},
 	};
 
 	static int s_aIds[NUM_PROPS] = {0};
@@ -845,7 +845,7 @@ int CEditor::PopupSource(CEditor *pEditor, CUIRect View, void *pContext)
 		CProperty aCircleProps[] = {
 			{"Radius", pSource->m_Shape.m_Circle.m_Radius, PROPTYPE_INT_SCROLL, 0, 1000000},
 
-			{0},
+			{nullptr},
 		};
 
 		static int s_aCircleIds[NUM_CIRCLE_PROPS] = {0};
@@ -874,7 +874,7 @@ int CEditor::PopupSource(CEditor *pEditor, CUIRect View, void *pContext)
 			{"Width", pSource->m_Shape.m_Rectangle.m_Width / 1024, PROPTYPE_INT_SCROLL, 0, 1000000},
 			{"Height", pSource->m_Shape.m_Rectangle.m_Height / 1024, PROPTYPE_INT_SCROLL, 0, 1000000},
 
-			{0},
+			{nullptr},
 		};
 
 		static int s_aRectangleIds[NUM_RECTANGLE_PROPS] = {0};
@@ -928,7 +928,7 @@ int CEditor::PopupPoint(CEditor *pEditor, CUIRect View, void *pContext)
 		{"Color", Color, PROPTYPE_COLOR, -1, (int)pEditor->m_Map.m_vpEnvelopes.size()},
 		{"Tex U", tu, PROPTYPE_INT_SCROLL, -1000000, 1000000},
 		{"Tex V", tv, PROPTYPE_INT_SCROLL, -1000000, 1000000},
-		{0},
+		{nullptr},
 	};
 
 	static int s_aIds[NUM_PROPS] = {0};
@@ -986,17 +986,17 @@ int CEditor::PopupNewFolder(CEditor *pEditor, CUIRect View, void *pContext)
 	CUIRect Label, ButtonBar;
 
 	// title
-	View.HSplitTop(10.0f, 0, &View);
+	View.HSplitTop(10.0f, nullptr, &View);
 	View.HSplitTop(30.0f, &Label, &View);
 	pEditor->UI()->DoLabel(&Label, "Create new folder", 20.0f, TEXTALIGN_CENTER);
 
-	View.HSplitBottom(10.0f, &View, 0);
+	View.HSplitBottom(10.0f, &View, nullptr);
 	View.HSplitBottom(20.0f, &View, &ButtonBar);
 
 	if(pEditor->m_FileDialogErrString[0] == 0)
 	{
 		// interaction box
-		View.HSplitBottom(40.0f, &View, 0);
+		View.HSplitBottom(40.0f, &View, nullptr);
 		View.VMargin(40.0f, &View);
 		View.HSplitBottom(20.0f, &View, &Label);
 		static float s_FolderBox = 0;
@@ -1005,10 +1005,10 @@ int CEditor::PopupNewFolder(CEditor *pEditor, CUIRect View, void *pContext)
 		pEditor->UI()->DoLabel(&Label, "Name:", 10.0f, TEXTALIGN_LEFT);
 
 		// button bar
-		ButtonBar.VSplitLeft(30.0f, 0, &ButtonBar);
+		ButtonBar.VSplitLeft(30.0f, nullptr, &ButtonBar);
 		ButtonBar.VSplitLeft(110.0f, &Label, &ButtonBar);
 		static int s_CreateButton = 0;
-		if(pEditor->DoButton_Editor(&s_CreateButton, "Create", 0, &Label, 0, 0) || pEditor->Input()->KeyPress(KEY_RETURN) || pEditor->Input()->KeyPress(KEY_KP_ENTER))
+		if(pEditor->DoButton_Editor(&s_CreateButton, "Create", 0, &Label, 0, nullptr) || pEditor->Input()->KeyPress(KEY_RETURN) || pEditor->Input()->KeyPress(KEY_KP_ENTER))
 		{
 			// create the folder
 			if(pEditor->m_aFileDialogNewFolderName[0])
@@ -1024,16 +1024,16 @@ int CEditor::PopupNewFolder(CEditor *pEditor, CUIRect View, void *pContext)
 					str_copy(pEditor->m_FileDialogErrString, "Unable to create the folder", sizeof(pEditor->m_FileDialogErrString));
 			}
 		}
-		ButtonBar.VSplitRight(30.0f, &ButtonBar, 0);
+		ButtonBar.VSplitRight(30.0f, &ButtonBar, nullptr);
 		ButtonBar.VSplitRight(110.0f, &ButtonBar, &Label);
 		static int s_AbortButton = 0;
-		if(pEditor->DoButton_Editor(&s_AbortButton, "Abort", 0, &Label, 0, 0))
+		if(pEditor->DoButton_Editor(&s_AbortButton, "Abort", 0, &Label, 0, nullptr))
 			return 1;
 	}
 	else
 	{
 		// error text
-		View.HSplitTop(30.0f, 0, &View);
+		View.HSplitTop(30.0f, nullptr, &View);
 		View.VMargin(40.0f, &View);
 		View.HSplitTop(20.0f, &Label, &View);
 		pEditor->UI()->DoLabel(&Label, "Error:", 10.0f, TEXTALIGN_LEFT);
@@ -1045,7 +1045,7 @@ int CEditor::PopupNewFolder(CEditor *pEditor, CUIRect View, void *pContext)
 		// button
 		ButtonBar.VMargin(ButtonBar.w / 2.0f - 55.0f, &ButtonBar);
 		static int s_CreateButton = 0;
-		if(pEditor->DoButton_Editor(&s_CreateButton, "Ok", 0, &ButtonBar, 0, 0))
+		if(pEditor->DoButton_Editor(&s_CreateButton, "Ok", 0, &ButtonBar, 0, nullptr))
 			return 1;
 	}
 
@@ -1057,11 +1057,11 @@ int CEditor::PopupMapInfo(CEditor *pEditor, CUIRect View, void *pContext)
 	CUIRect Label, ButtonBar, Button;
 
 	// title
-	View.HSplitTop(10.0f, 0, &View);
+	View.HSplitTop(10.0f, nullptr, &View);
 	View.HSplitTop(30.0f, &Label, &View);
 	pEditor->UI()->DoLabel(&Label, "Map details", 20.0f, TEXTALIGN_CENTER);
 
-	View.HSplitBottom(10.0f, &View, 0);
+	View.HSplitBottom(10.0f, &View, nullptr);
 	View.HSplitBottom(20.0f, &View, &ButtonBar);
 
 	View.VMargin(40.0f, &View);
@@ -1069,7 +1069,7 @@ int CEditor::PopupMapInfo(CEditor *pEditor, CUIRect View, void *pContext)
 	// author box
 	View.HSplitTop(20.0f, &Label, &View);
 	pEditor->UI()->DoLabel(&Label, "Author:", 10.0f, TEXTALIGN_LEFT);
-	Label.VSplitLeft(45.0f, 0, &Button);
+	Label.VSplitLeft(45.0f, nullptr, &Button);
 	Button.HMargin(3, &Button);
 	static float s_AuthorBox = 0;
 	pEditor->DoEditBox(&s_AuthorBox, &Button, pEditor->m_Map.m_MapInfo.m_aAuthorTmp, sizeof(pEditor->m_Map.m_MapInfo.m_aAuthorTmp), 10.0f, &s_AuthorBox);
@@ -1077,7 +1077,7 @@ int CEditor::PopupMapInfo(CEditor *pEditor, CUIRect View, void *pContext)
 	// version box
 	View.HSplitTop(20.0f, &Label, &View);
 	pEditor->UI()->DoLabel(&Label, "Version:", 10.0f, TEXTALIGN_LEFT);
-	Label.VSplitLeft(45.0f, 0, &Button);
+	Label.VSplitLeft(45.0f, nullptr, &Button);
 	Button.HMargin(3, &Button);
 	static float s_VersionBox = 0;
 	pEditor->DoEditBox(&s_VersionBox, &Button, pEditor->m_Map.m_MapInfo.m_aVersionTmp, sizeof(pEditor->m_Map.m_MapInfo.m_aVersionTmp), 10.0f, &s_VersionBox);
@@ -1085,7 +1085,7 @@ int CEditor::PopupMapInfo(CEditor *pEditor, CUIRect View, void *pContext)
 	// credits box
 	View.HSplitTop(20.0f, &Label, &View);
 	pEditor->UI()->DoLabel(&Label, "Credits:", 10.0f, TEXTALIGN_LEFT);
-	Label.VSplitLeft(45.0f, 0, &Button);
+	Label.VSplitLeft(45.0f, nullptr, &Button);
 	Button.HMargin(3, &Button);
 	static float s_CreditsBox = 0;
 	pEditor->DoEditBox(&s_CreditsBox, &Button, pEditor->m_Map.m_MapInfo.m_aCreditsTmp, sizeof(pEditor->m_Map.m_MapInfo.m_aCreditsTmp), 10.0f, &s_CreditsBox);
@@ -1093,16 +1093,16 @@ int CEditor::PopupMapInfo(CEditor *pEditor, CUIRect View, void *pContext)
 	// license box
 	View.HSplitTop(20.0f, &Label, &View);
 	pEditor->UI()->DoLabel(&Label, "License:", 10.0f, TEXTALIGN_LEFT);
-	Label.VSplitLeft(45.0f, 0, &Button);
+	Label.VSplitLeft(45.0f, nullptr, &Button);
 	Button.HMargin(3, &Button);
 	static float s_LicenseBox = 0;
 	pEditor->DoEditBox(&s_LicenseBox, &Button, pEditor->m_Map.m_MapInfo.m_aLicenseTmp, sizeof(pEditor->m_Map.m_MapInfo.m_aLicenseTmp), 10.0f, &s_LicenseBox);
 
 	// button bar
-	ButtonBar.VSplitLeft(30.0f, 0, &ButtonBar);
+	ButtonBar.VSplitLeft(30.0f, nullptr, &ButtonBar);
 	ButtonBar.VSplitLeft(110.0f, &Label, &ButtonBar);
 	static int s_CreateButton = 0;
-	if(pEditor->DoButton_Editor(&s_CreateButton, "Ok", 0, &Label, 0, 0))
+	if(pEditor->DoButton_Editor(&s_CreateButton, "Ok", 0, &Label, 0, nullptr))
 	{
 		str_copy(pEditor->m_Map.m_MapInfo.m_aAuthor, pEditor->m_Map.m_MapInfo.m_aAuthorTmp, sizeof(pEditor->m_Map.m_MapInfo.m_aAuthor));
 		str_copy(pEditor->m_Map.m_MapInfo.m_aVersion, pEditor->m_Map.m_MapInfo.m_aVersionTmp, sizeof(pEditor->m_Map.m_MapInfo.m_aVersion));
@@ -1111,10 +1111,10 @@ int CEditor::PopupMapInfo(CEditor *pEditor, CUIRect View, void *pContext)
 		return 1;
 	}
 
-	ButtonBar.VSplitRight(30.0f, &ButtonBar, 0);
+	ButtonBar.VSplitRight(30.0f, &ButtonBar, nullptr);
 	ButtonBar.VSplitRight(110.0f, &ButtonBar, &Label);
 	static int s_AbortButton = 0;
-	if(pEditor->DoButton_Editor(&s_AbortButton, "Abort", 0, &Label, 0, 0))
+	if(pEditor->DoButton_Editor(&s_AbortButton, "Abort", 0, &Label, 0, nullptr))
 		return 1;
 
 	return 0;
@@ -1125,7 +1125,7 @@ int CEditor::PopupEvent(CEditor *pEditor, CUIRect View, void *pContext)
 	CUIRect Label, ButtonBar;
 
 	// title
-	View.HSplitTop(10.0f, 0, &View);
+	View.HSplitTop(10.0f, nullptr, &View);
 	View.HSplitTop(30.0f, &Label, &View);
 	if(pEditor->m_PopupEventType == POPEVENT_EXIT)
 		pEditor->UI()->DoLabel(&Label, "Exit the editor", 20.0f, TEXTALIGN_CENTER);
@@ -1146,11 +1146,11 @@ int CEditor::PopupEvent(CEditor *pEditor, CUIRect View, void *pContext)
 	else if(pEditor->m_PopupEventType == POPEVENT_PLACE_BORDER_TILES)
 		pEditor->UI()->DoLabel(&Label, "Place border tiles", 20.0f, TEXTALIGN_CENTER);
 
-	View.HSplitBottom(10.0f, &View, 0);
+	View.HSplitBottom(10.0f, &View, nullptr);
 	View.HSplitBottom(20.0f, &View, &ButtonBar);
 
 	// notification text
-	View.HSplitTop(30.0f, 0, &View);
+	View.HSplitTop(30.0f, nullptr, &View);
 	View.VMargin(40.0f, &View);
 	View.HSplitTop(20.0f, &Label, &View);
 	SLabelProperties Props;
@@ -1175,10 +1175,10 @@ int CEditor::PopupEvent(CEditor *pEditor, CUIRect View, void *pContext)
 		pEditor->UI()->DoLabel(&Label, "This is going to overwrite any existing tiles around the edges of the layer.\nContinue?", 10.0f, TEXTALIGN_LEFT, Props);
 
 	// button bar
-	ButtonBar.VSplitLeft(30.0f, 0, &ButtonBar);
+	ButtonBar.VSplitLeft(30.0f, nullptr, &ButtonBar);
 	ButtonBar.VSplitLeft(110.0f, &Label, &ButtonBar);
 	static int s_OkButton = 0;
-	if(pEditor->DoButton_Editor(&s_OkButton, "Ok", 0, &Label, 0, 0) || pEditor->Input()->KeyPress(KEY_RETURN) || pEditor->Input()->KeyPress(KEY_KP_ENTER))
+	if(pEditor->DoButton_Editor(&s_OkButton, "Ok", 0, &Label, 0, nullptr) || pEditor->Input()->KeyPress(KEY_RETURN) || pEditor->Input()->KeyPress(KEY_KP_ENTER))
 	{
 		if(pEditor->m_PopupEventType == POPEVENT_EXIT)
 			g_Config.m_ClEditor = 0;
@@ -1198,12 +1198,12 @@ int CEditor::PopupEvent(CEditor *pEditor, CUIRect View, void *pContext)
 		pEditor->m_PopupEventWasActivated = false;
 		return 1;
 	}
-	ButtonBar.VSplitRight(30.0f, &ButtonBar, 0);
+	ButtonBar.VSplitRight(30.0f, &ButtonBar, nullptr);
 	ButtonBar.VSplitRight(110.0f, &ButtonBar, &Label);
 	if(pEditor->m_PopupEventType != POPEVENT_LARGELAYER && pEditor->m_PopupEventType != POPEVENT_PREVENTUNUSEDTILES && pEditor->m_PopupEventType != POPEVENT_IMAGEDIV16 && pEditor->m_PopupEventType != POPEVENT_IMAGE_MAX)
 	{
 		static int s_AbortButton = 0;
-		if(pEditor->DoButton_Editor(&s_AbortButton, "Abort", 0, &Label, 0, 0) || pEditor->Input()->KeyPress(KEY_ESCAPE))
+		if(pEditor->DoButton_Editor(&s_AbortButton, "Abort", 0, &Label, 0, nullptr) || pEditor->Input()->KeyPress(KEY_ESCAPE))
 		{
 			pEditor->m_PopupEventWasActivated = false;
 			return 1;
@@ -1434,9 +1434,9 @@ int CEditor::PopupSelectGametileOp(CEditor *pEditor, CUIRect View, void *pContex
 
 	for(unsigned i = 0; i < s_NumButtons; ++i)
 	{
-		View.HSplitTop(2.0f, 0, &View);
+		View.HSplitTop(2.0f, nullptr, &View);
 		View.HSplitTop(12.0f, &Button, &View);
-		if(pEditor->DoButton_Editor(&s_pButtonNames[i], s_pButtonNames[i], 0, &Button, 0, 0))
+		if(pEditor->DoButton_Editor(&s_pButtonNames[i], s_pButtonNames[i], 0, &Button, 0, nullptr))
 			s_GametileOpSelected = i;
 	}
 
@@ -1499,7 +1499,7 @@ int CEditor::PopupSelectConfigAutoMap(CEditor *pEditor, CUIRect View, void *pCon
 		}
 
 		// Margin for scrollbar
-		View.VSplitRight(2.0f, &View, 0);
+		View.VSplitRight(2.0f, &View, nullptr);
 	}
 
 	float ListStartAt = ScrollDifference * s_ScrollValue;
@@ -1519,9 +1519,9 @@ int CEditor::PopupSelectConfigAutoMap(CEditor *pEditor, CUIRect View, void *pCon
 
 		if(ListCur >= ListStartAt)
 		{
-			View.HSplitTop(ButtonMargin, 0, &View);
+			View.HSplitTop(ButtonMargin, nullptr, &View);
 			View.HSplitTop(ButtonHeight, &Button, &View);
-			if(pEditor->DoButton_MenuItem(&s_AutoMapperConfigButtons[i], i == 0 ? "None" : pAutoMapper->GetConfigName(i - 1), i == s_AutoMapConfigCurrent, &Button, 0, 0))
+			if(pEditor->DoButton_MenuItem(&s_AutoMapperConfigButtons[i], i == 0 ? "None" : pAutoMapper->GetConfigName(i - 1), i == s_AutoMapConfigCurrent, &Button, 0, nullptr))
 			{
 				s_AutoMapConfigSelected = i;
 			}
@@ -1567,7 +1567,7 @@ int CEditor::PopupTele(CEditor *pEditor, CUIRect View, void *pContext)
 	CUIRect FindEmptySlot;
 
 	View.VSplitRight(15.f, &NumberPicker, &FindEmptySlot);
-	NumberPicker.VSplitRight(2.f, &NumberPicker, 0);
+	NumberPicker.VSplitRight(2.f, &NumberPicker, nullptr);
 
 	// find empty number button
 	{
@@ -1602,7 +1602,7 @@ int CEditor::PopupTele(CEditor *pEditor, CUIRect View, void *pContext)
 		};
 		CProperty aProps[] = {
 			{"Number", pEditor->m_TeleNumber, PROPTYPE_INT_STEP, 1, 255},
-			{0},
+			{nullptr},
 		};
 
 		static int s_aIds[NUM_PROPS] = {0};
@@ -1642,7 +1642,7 @@ int CEditor::PopupSpeedup(CEditor *pEditor, CUIRect View, void *pContext)
 		{"Force", pEditor->m_SpeedupForce, PROPTYPE_INT_STEP, 0, 255},
 		{"Max Speed", pEditor->m_SpeedupMaxSpeed, PROPTYPE_INT_STEP, 0, 255},
 		{"Angle", pEditor->m_SpeedupAngle, PROPTYPE_ANGLE_SCROLL, 0, 359},
-		{0},
+		{nullptr},
 	};
 
 	static int s_aIds[NUM_PROPS] = {0};
@@ -1670,7 +1670,7 @@ int CEditor::PopupSwitch(CEditor *pEditor, CUIRect View, void *pContext)
 
 	View.HSplitMid(&NumberPicker, &DelayPicker);
 	NumberPicker.VSplitRight(15.f, &NumberPicker, &FindEmptySlot);
-	NumberPicker.VSplitRight(2.f, &NumberPicker, 0);
+	NumberPicker.VSplitRight(2.f, &NumberPicker, nullptr);
 
 	// find empty number button
 	{
@@ -1708,7 +1708,7 @@ int CEditor::PopupSwitch(CEditor *pEditor, CUIRect View, void *pContext)
 		CProperty aProps[] = {
 			{"Number", pEditor->m_SwitchNum, PROPTYPE_INT_STEP, 1, 255},
 			{"Delay", pEditor->m_SwitchDelay, PROPTYPE_INT_STEP, 0, 255},
-			{0},
+			{nullptr},
 		};
 
 		static int s_aIds[NUM_PROPS] = {0};
@@ -1747,7 +1747,7 @@ int CEditor::PopupTune(CEditor *pEditor, CUIRect View, void *pContext)
 
 	CProperty aProps[] = {
 		{"Zone", pEditor->m_TuningNum, PROPTYPE_INT_STEP, 1, 255},
-		{0},
+		{nullptr},
 	};
 
 	static int s_aIds[NUM_PROPS] = {0};
@@ -1764,7 +1764,7 @@ int CEditor::PopupColorPicker(CEditor *pEditor, CUIRect View, void *pContext)
 {
 	CUIRect SVPicker, HuePicker;
 	View.VSplitRight(20.0f, &SVPicker, &HuePicker);
-	HuePicker.VSplitLeft(4.0f, 0x0, &HuePicker);
+	HuePicker.VSplitLeft(4.0f, nullptr, &HuePicker);
 
 	pEditor->Graphics()->TextureClear();
 	pEditor->Graphics()->QuadsBegin();

--- a/src/game/gamecore.h
+++ b/src/game/gamecore.h
@@ -189,7 +189,7 @@ public:
 	CWorldCore()
 	{
 		mem_zero(m_apCharacters, sizeof(m_apCharacters));
-		m_pPrng = 0;
+		m_pPrng = nullptr;
 	}
 
 	int RandomOr0(int BelowThis)


### PR DESCRIPTION
There is currently `0`, `0x0`, `NULL` and `nullptr` mixed in the code.

The flag `-Wzero-as-null-pointer-constant` suggests to use `nullptr`. It is in a zillion places so I started with the editor.


## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
