### PR TITLE
Remove namespace tw

### DIFF
--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -939,11 +939,6 @@ int64_t time_freq()
 	return std::chrono::nanoseconds(1s).count();
 }
 
-int64_t time_get_nanoseconds()
-{
-	return time_get_impl();
-}
-
 /* -----  network ----- */
 static void netaddr_to_sockaddr_in(const NETADDR *src, struct sockaddr_in *dest)
 {
@@ -4101,14 +4096,12 @@ void set_exception_handler_log_file(const char *log_file_path)
 #endif
 }
 
-// pure cpp code for the cpp system wrapper
-
-std::chrono::nanoseconds tw::time_get()
+std::chrono::nanoseconds time_get_nanoseconds()
 {
-	return std::chrono::nanoseconds(time_get_nanoseconds());
+	return std::chrono::nanoseconds(time_get_impl());
 }
 
-int tw::net_socket_read_wait(NETSOCKET sock, std::chrono::nanoseconds nanoseconds)
+int net_socket_read_wait(NETSOCKET sock, std::chrono::nanoseconds nanoseconds)
 {
 	using namespace std::chrono_literals;
 	return ::net_socket_read_wait(sock, (nanoseconds / std::chrono::nanoseconds(1us).count()).count());

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -757,15 +757,6 @@ enum
 int time_season();
 
 /**
- * Fetches a sample from a high resolution timer and converts it in nanoseconds.
- *
- * @ingroup Time
- *
- * @return Current value of the timer in nanoseconds.
- */
-int64_t time_get_nanoseconds();
-
-/**
  * @defgroup Network-General
  */
 
@@ -2436,19 +2427,13 @@ void set_exception_handler_log_file(const char *log_file_path);
 }
 
 /**
-	Type safe wrappers for the c system
-*/
-
-namespace tw {
-
-/**
  * Fetches a sample from a high resolution timer and converts it in nanoseconds.
  *
  * @ingroup Time
  *
  * @return Current value of the timer in nanoseconds.
  */
-std::chrono::nanoseconds time_get();
+std::chrono::nanoseconds time_get_nanoseconds();
 
 int net_socket_read_wait(NETSOCKET sock, std::chrono::nanoseconds nanoseconds);
 
@@ -2473,7 +2458,5 @@ public:
 		cmdline_free(m_Argc, m_ppArgv);
 	}
 };
-
-} // namespace tw
 
 #endif

--- a/src/engine/client/backend/vulkan/backend_vulkan.cpp
+++ b/src/engine/client/backend/vulkan/backend_vulkan.cpp
@@ -7313,7 +7313,7 @@ public:
 			std::chrono::nanoseconds ThreadRenderTime = 0ns;
 			if(IsVerbose() && s_BenchmarkRenderThreads)
 			{
-				ThreadRenderTime = tw::time_get();
+				ThreadRenderTime = time_get_nanoseconds();
 			}
 
 			if(!pThread->m_Finished)
@@ -7333,7 +7333,7 @@ public:
 
 			if(IsVerbose() && s_BenchmarkRenderThreads)
 			{
-				dbg_msg("vulkan", "render thread %" PRIu64 " took %d ns to finish", ThreadIndex, (int)(tw::time_get() - ThreadRenderTime).count());
+				dbg_msg("vulkan", "render thread %" PRIu64 " took %d ns to finish", ThreadIndex, (int)(time_get_nanoseconds() - ThreadRenderTime).count());
 			}
 
 			pThread->m_IsRendering = false;

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -3050,7 +3050,7 @@ void CClient::Run()
 	bool LastE = false;
 	bool LastG = false;
 
-	auto LastTime = tw::time_get();
+	auto LastTime = time_get_nanoseconds();
 	int64_t LastRenderTime = time_get();
 
 	while(true)
@@ -3289,7 +3289,7 @@ void CClient::Run()
 #endif
 
 		// beNice
-		auto Now = tw::time_get();
+		auto Now = time_get_nanoseconds();
 		decltype(Now) SleepTimeInNanoSeconds{0};
 		bool Slept = false;
 		if(
@@ -3306,7 +3306,7 @@ void CClient::Run()
 		{
 			SleepTimeInNanoSeconds = (std::chrono::nanoseconds(1s) / (int64_t)g_Config.m_ClRefreshRate) - (Now - LastTime);
 			if(SleepTimeInNanoSeconds > 0ns)
-				tw::net_socket_read_wait(m_NetClient[CONN_MAIN].m_Socket, SleepTimeInNanoSeconds);
+				net_socket_read_wait(m_NetClient[CONN_MAIN].m_Socket, SleepTimeInNanoSeconds);
 			Slept = true;
 		}
 		if(Slept)
@@ -4357,7 +4357,7 @@ int main(int argc, const char **argv)
 #if defined(CONF_PLATFORM_ANDROID)
 	const char **argv = const_cast<const char **>(argv2);
 #endif
-	tw::CCmdlineFix CmdlineFix(&argc, &argv);
+	CCmdlineFix CmdlineFix(&argc, &argv);
 	bool Silent = false;
 	bool RandInitFailed = false;
 

--- a/src/engine/client/serverbrowser_http.cpp
+++ b/src/engine/client/serverbrowser_http.cpp
@@ -189,7 +189,7 @@ void CChooseMaster::CJob::Run()
 		{
 			continue;
 		}
-		auto StartTime = tw::time_get();
+		auto StartTime = time_get_nanoseconds();
 		CHttpRequest *pGet = HttpGet(pUrl).release();
 		pGet->Timeout(Timeout);
 		pGet->LogProgress(HTTPLOG::FAILURE);
@@ -198,7 +198,7 @@ void CChooseMaster::CJob::Run()
 			m_pGet = std::unique_ptr<CHttpRequest>(pGet);
 		}
 		IEngine::RunJobBlocking(pGet);
-		auto Time = std::chrono::duration_cast<std::chrono::milliseconds>(tw::time_get() - StartTime);
+		auto Time = std::chrono::duration_cast<std::chrono::milliseconds>(time_get_nanoseconds() - StartTime);
 		if(pHead->State() == HTTP_ABORTED)
 		{
 			dbg_msg("serverbrowse_http", "master chooser aborted");

--- a/src/engine/client/text.cpp
+++ b/src/engine/client/text.cpp
@@ -626,7 +626,7 @@ public:
 		m_FTLibrary = 0;
 
 		m_RenderFlags = 0;
-		m_CursorRenderTime = tw::time_get();
+		m_CursorRenderTime = time_get_nanoseconds();
 	}
 
 	virtual ~CTextRender()
@@ -1648,7 +1648,7 @@ public:
 		{
 			if(TextContainer.m_HasCursor)
 			{
-				auto CurTime = tw::time_get();
+				auto CurTime = time_get_nanoseconds();
 
 				Graphics()->TextureClear();
 				if((CurTime - m_CursorRenderTime) > 500ms)
@@ -1659,7 +1659,7 @@ public:
 					Graphics()->RenderQuadContainerEx(TextContainer.m_StringInfo.m_SelectionQuadContainerIndex, 1, 1, 0, 0);
 				}
 				if((CurTime - m_CursorRenderTime) > 1s)
-					m_CursorRenderTime = tw::time_get();
+					m_CursorRenderTime = time_get_nanoseconds();
 				Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
 			}
 		}

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -3765,7 +3765,7 @@ void HandleSigIntTerm(int Param)
 
 int main(int argc, const char **argv)
 {
-	tw::CCmdlineFix CmdlineFix(&argc, &argv);
+	CCmdlineFix CmdlineFix(&argc, &argv);
 	bool Silent = false;
 
 	for(int i = 1; i < argc; i++)

--- a/src/game/client/components/maplayers.cpp
+++ b/src/game/client/components/maplayers.cpp
@@ -80,7 +80,7 @@ void CMapLayers::EnvelopeEval(int TimeOffsetMillis, int Env, float *pChannels, v
 	const auto TickToNanoSeconds = std::chrono::nanoseconds(1s) / (int64_t)pThis->Client()->GameTickSpeed();
 
 	static std::chrono::nanoseconds s_Time{0};
-	static auto s_LastLocalTime = tw::time_get();
+	static auto s_LastLocalTime = time_get_nanoseconds();
 	if(pThis->Client()->State() == IClient::STATE_DEMOPLAYBACK)
 	{
 		const IDemoPlayer::CInfo *pInfo = pThis->DemoPlayer()->BaseInfo();
@@ -135,7 +135,7 @@ void CMapLayers::EnvelopeEval(int TimeOffsetMillis, int Env, float *pChannels, v
 		}
 		else
 		{
-			auto CurTime = tw::time_get();
+			auto CurTime = time_get_nanoseconds();
 			s_Time += CurTime - s_LastLocalTime;
 			s_LastLocalTime = CurTime;
 		}

--- a/src/game/client/components/menu_background.cpp
+++ b/src/game/client/components/menu_background.cpp
@@ -126,7 +126,7 @@ int CMenuBackground::ThemeScan(const char *pName, int IsDir, int DirType, void *
 	str_format(aBuf, sizeof(aBuf), "added theme %s from themes/%s", aThemeName, pName);
 	pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "game", aBuf);
 	pSelf->m_vThemes.push_back(Theme);
-	auto TimeNow = tw::time_get();
+	auto TimeNow = time_get_nanoseconds();
 	if(TimeNow - pSelf->m_ThemeScanStartTime >= std::chrono::nanoseconds(1s) / 60)
 	{
 		pSelf->Client()->UpdateAndSwap();
@@ -142,7 +142,7 @@ int CMenuBackground::ThemeIconScan(const char *pName, int IsDir, int DirType, vo
 	if(IsDir || !pSuffix)
 		return 0;
 
-	auto TimeNow = tw::time_get();
+	auto TimeNow = time_get_nanoseconds();
 	if(TimeNow - pSelf->m_ThemeScanStartTime >= std::chrono::nanoseconds(1s) / 60)
 	{
 		pSelf->Client()->UpdateAndSwap();
@@ -403,7 +403,7 @@ std::vector<CTheme> &CMenuBackground::GetThemes()
 		m_vThemes.emplace_back("auto", true, true); // auto theme
 		m_vThemes.emplace_back("rand", true, true); // random theme
 
-		m_ThemeScanStartTime = tw::time_get();
+		m_ThemeScanStartTime = time_get_nanoseconds();
 		Storage()->ListDirectory(IStorage::TYPE_ALL, "themes", ThemeScan, (CMenuBackground *)this);
 		Storage()->ListDirectory(IStorage::TYPE_ALL, "themes", ThemeIconScan, (CMenuBackground *)this);
 

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -229,7 +229,7 @@ int CMenus::DoButton_MenuTab(const void *pID, const char *pText, int Checked, co
 
 	if(pAnimator != NULL)
 	{
-		auto Time = tw::time_get();
+		auto Time = time_get_nanoseconds();
 
 		if(pAnimator->m_Time + 100ms < Time)
 		{
@@ -927,10 +927,10 @@ void CMenus::RenderLoading(bool IncreaseCounter, bool RenderLoadingBar)
 
 	// make sure that we don't render for each little thing we load
 	// because that will slow down loading if we have vsync
-	if(tw::time_get() - LastLoadRender < std::chrono::nanoseconds(1s) / 60l)
+	if(time_get_nanoseconds() - LastLoadRender < std::chrono::nanoseconds(1s) / 60l)
 		return;
 
-	LastLoadRender = tw::time_get();
+	LastLoadRender = time_get_nanoseconds();
 
 	// need up date this here to get correct
 	ms_GuiColor = color_cast<ColorRGBA>(ColorHSLA(g_Config.m_UiColor, true));
@@ -1071,7 +1071,7 @@ void CMenus::PopupWarning(const char *pTopic, const char *pBody, const char *pBu
 	SetActive(true);
 
 	m_PopupWarningDuration = Duration;
-	m_PopupWarningLastTime = tw::time_get();
+	m_PopupWarningLastTime = time_get_nanoseconds();
 }
 
 bool CMenus::CanDisplayWarning()
@@ -2253,7 +2253,7 @@ int CMenus::Render()
 			Part.VMargin(120.0f, &Part);
 
 			static int s_Button = 0;
-			if(DoButton_Menu(&s_Button, pButtonText, 0, &Part) || m_EscapePressed || m_EnterPressed || (tw::time_get() - m_PopupWarningLastTime >= m_PopupWarningDuration))
+			if(DoButton_Menu(&s_Button, pButtonText, 0, &Part) || m_EscapePressed || m_EnterPressed || (time_get_nanoseconds() - m_PopupWarningLastTime >= m_PopupWarningDuration))
 			{
 				m_Popup = POPUP_NONE;
 				SetActive(false);

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -769,7 +769,7 @@ int CMenus::DemolistFetchCallback(const CFsFileInfo *pInfo, int IsDir, int Stora
 	Item.m_StorageType = StorageType;
 	pSelf->m_vDemos.push_back(Item);
 
-	if(tw::time_get() - pSelf->m_DemoPopulateStartTime > 500ms)
+	if(time_get_nanoseconds() - pSelf->m_DemoPopulateStartTime > 500ms)
 	{
 		pSelf->GameClient()->m_Menus.RenderLoading(false, false);
 	}
@@ -782,7 +782,7 @@ void CMenus::DemolistPopulate()
 	m_vDemos.clear();
 	if(!str_comp(m_aCurrentDemoFolder, "demos"))
 		m_DemolistStorageType = IStorage::TYPE_ALL;
-	m_DemoPopulateStartTime = tw::time_get();
+	m_DemoPopulateStartTime = time_get_nanoseconds();
 	Storage()->ListDirectoryInfo(m_DemolistStorageType, m_aCurrentDemoFolder, DemolistFetchCallback, this);
 
 	if(g_Config.m_BrDemoFetchInfo)

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -869,7 +869,7 @@ int CMenus::GhostlistFetchCallback(const char *pName, int IsDir, int StorageType
 	if(Item.m_Time > 0)
 		pSelf->m_vGhosts.push_back(Item);
 
-	if(tw::time_get() - pSelf->m_GhostPopulateStartTime > 500ms)
+	if(time_get_nanoseconds() - pSelf->m_GhostPopulateStartTime > 500ms)
 	{
 		pSelf->GameClient()->m_Menus.RenderLoading(false, false);
 	}
@@ -880,7 +880,7 @@ int CMenus::GhostlistFetchCallback(const char *pName, int IsDir, int StorageType
 void CMenus::GhostlistPopulate()
 {
 	m_vGhosts.clear();
-	m_GhostPopulateStartTime = tw::time_get();
+	m_GhostPopulateStartTime = time_get_nanoseconds();
 	Storage()->ListDirectory(IStorage::TYPE_ALL, m_pClient->m_Ghost.GetGhostDir(), GhostlistFetchCallback, this);
 	std::sort(m_vGhosts.begin(), m_vGhosts.end());
 

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -818,10 +818,10 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 		// reset render flags for possible loading screen
 		TextRender()->SetRenderFlags(0);
 		TextRender()->SetCurFont(NULL);
-		auto SkinStartLoadTime = tw::time_get();
+		auto SkinStartLoadTime = time_get_nanoseconds();
 		m_pClient->m_Skins.Refresh([&](int) {
 			// if skin refreshing takes to long, swap to a loading screen
-			if(tw::time_get() - SkinStartLoadTime > 500ms)
+			if(time_get_nanoseconds() - SkinStartLoadTime > 500ms)
 			{
 				RenderLoading(false, false);
 			}

--- a/src/game/client/components/menus_settings_assets.cpp
+++ b/src/game/client/components/menus_settings_assets.cpp
@@ -387,11 +387,11 @@ void CMenus::RenderSettingsCustom(CUIRect MainView)
 	if(DoButton_MenuTab((void *)&s_aPageTabs[4], Localize("HUD"), s_CurCustomTab == ASSETS_TAB_HUD, &Page5Tab, 10, NULL, NULL, NULL, NULL, 4))
 		s_CurCustomTab = ASSETS_TAB_HUD;
 
-	auto LoadStartTime = tw::time_get();
+	auto LoadStartTime = time_get_nanoseconds();
 	SMenuAssetScanUser User;
 	User.m_pUser = this;
 	User.m_LoadedFunc = [&]() {
-		if(tw::time_get() - LoadStartTime > 500ms)
+		if(time_get_nanoseconds() - LoadStartTime > 500ms)
 			RenderLoading(false, false);
 	};
 	if(s_CurCustomTab == ASSETS_TAB_ENTITIES)

--- a/src/game/client/components/race_demo.cpp
+++ b/src/game/client/components/race_demo.cpp
@@ -221,7 +221,7 @@ int CRaceDemo::RaceDemolistFetchCallback(const CFsFileInfo *pInfo, int IsDir, in
 	if(Item.m_Time > 0)
 		pParam->m_pvDemos->push_back(Item);
 
-	if(tw::time_get() - pRealUser->m_pThis->m_RaceDemosLoadStartTime > 500ms)
+	if(time_get_nanoseconds() - pRealUser->m_pThis->m_RaceDemosLoadStartTime > 500ms)
 	{
 		pRealUser->m_pThis->GameClient()->m_Menus.RenderLoading(false, false);
 	}
@@ -233,7 +233,7 @@ bool CRaceDemo::CheckDemo(int Time)
 {
 	std::vector<CDemoItem> lDemos;
 	CDemoListParam Param = {this, &lDemos, Client()->GetCurrentMap()};
-	m_RaceDemosLoadStartTime = tw::time_get();
+	m_RaceDemosLoadStartTime = time_get_nanoseconds();
 	SRaceDemoFetchUser User;
 	User.m_pParam = &Param;
 	User.m_pThis = this;

--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -114,7 +114,7 @@ CTestInfo::~CTestInfo()
 
 int main(int argc, const char **argv)
 {
-	tw::CCmdlineFix CmdlineFix(&argc, &argv);
+	CCmdlineFix CmdlineFix(&argc, &argv);
 	log_set_global_logger_default();
 	::testing::InitGoogleTest(&argc, const_cast<char **>(argv));
 	net_init();

--- a/src/tools/config_common.h
+++ b/src/tools/config_common.h
@@ -47,7 +47,7 @@ static int ListdirCallback(const char *pItemName, int IsDir, int StorageType, vo
 
 int main(int argc, const char **argv) // NOLINT(misc-definitions-in-headers)
 {
-	tw::CCmdlineFix CmdlineFix(&argc, &argv);
+	CCmdlineFix CmdlineFix(&argc, &argv);
 	log_set_global_logger_default();
 
 	IStorage *pStorage = CreateLocalStorage();

--- a/src/tools/crapnet.cpp
+++ b/src/tools/crapnet.cpp
@@ -200,7 +200,7 @@ void Run(unsigned short Port, NETADDR Dest)
 
 int main(int argc, const char **argv)
 {
-	tw::CCmdlineFix CmdlineFix(&argc, &argv);
+	CCmdlineFix CmdlineFix(&argc, &argv);
 	log_set_global_logger_default();
 	NETADDR Addr = {NETTYPE_IPV4, {127, 0, 0, 1}, 8303};
 	Run(8302, Addr);

--- a/src/tools/dilate.cpp
+++ b/src/tools/dilate.cpp
@@ -72,7 +72,7 @@ int DilateFile(const char *pFilename)
 
 int main(int argc, const char **argv)
 {
-	tw::CCmdlineFix CmdlineFix(&argc, &argv);
+	CCmdlineFix CmdlineFix(&argc, &argv);
 	log_set_global_logger_default();
 	if(argc == 1)
 	{

--- a/src/tools/dummy_map.cpp
+++ b/src/tools/dummy_map.cpp
@@ -73,7 +73,7 @@ void CreateEmptyMap(IStorage *pStorage)
 
 int main(int argc, const char **argv)
 {
-	tw::CCmdlineFix CmdlineFix(&argc, &argv);
+	CCmdlineFix CmdlineFix(&argc, &argv);
 	log_set_global_logger_default();
 	IStorage *pStorage = CreateStorage(IStorage::STORAGETYPE_SERVER, argc, argv);
 	if(!pStorage)

--- a/src/tools/map_convert_07.cpp
+++ b/src/tools/map_convert_07.cpp
@@ -134,7 +134,7 @@ void *ReplaceImageItem(void *pItem, int Type, CMapItemImage *pNewImgItem)
 
 int main(int argc, const char **argv)
 {
-	tw::CCmdlineFix CmdlineFix(&argc, &argv);
+	CCmdlineFix CmdlineFix(&argc, &argv);
 	log_set_global_logger_default();
 
 	if(argc < 2 || argc > 3)

--- a/src/tools/map_diff.cpp
+++ b/src/tools/map_diff.cpp
@@ -95,7 +95,7 @@ bool Process(IStorage *pStorage, const char **pMapNames)
 
 int main(int argc, const char *argv[])
 {
-	tw::CCmdlineFix CmdlineFix(&argc, &argv);
+	CCmdlineFix CmdlineFix(&argc, &argv);
 	std::vector<std::shared_ptr<ILogger>> vpLoggers;
 	vpLoggers.push_back(std::shared_ptr<ILogger>(log_logger_stdout()));
 	IOHANDLE LogFile = io_open("map_diff.txt", IOFLAG_WRITE);

--- a/src/tools/map_extract.cpp
+++ b/src/tools/map_extract.cpp
@@ -95,7 +95,7 @@ bool Process(IStorage *pStorage, const char *pMapName, const char *pPathSave)
 
 int main(int argc, const char *argv[])
 {
-	tw::CCmdlineFix CmdlineFix(&argc, &argv);
+	CCmdlineFix CmdlineFix(&argc, &argv);
 	log_set_global_logger_default();
 
 	IStorage *pStorage = CreateLocalStorage();

--- a/src/tools/map_optimize.cpp
+++ b/src/tools/map_optimize.cpp
@@ -75,7 +75,7 @@ void GetImageSHA256(uint8_t *pImgBuff, int ImgSize, int Width, int Height, char 
 
 int main(int argc, const char **argv)
 {
-	tw::CCmdlineFix CmdlineFix(&argc, &argv);
+	CCmdlineFix CmdlineFix(&argc, &argv);
 	log_set_global_logger_default();
 
 	IStorage *pStorage = CreateStorage(IStorage::STORAGETYPE_BASIC, argc, argv);

--- a/src/tools/map_replace_image.cpp
+++ b/src/tools/map_replace_image.cpp
@@ -109,7 +109,7 @@ void *ReplaceImageItem(void *pItem, int Type, const char *pImgName, const char *
 
 int main(int argc, const char **argv)
 {
-	tw::CCmdlineFix CmdlineFix(&argc, &argv);
+	CCmdlineFix CmdlineFix(&argc, &argv);
 	log_set_global_logger_default();
 
 	if(argc != 5)

--- a/src/tools/map_resave.cpp
+++ b/src/tools/map_resave.cpp
@@ -6,7 +6,7 @@
 
 int main(int argc, const char **argv)
 {
-	tw::CCmdlineFix CmdlineFix(&argc, &argv);
+	CCmdlineFix CmdlineFix(&argc, &argv);
 
 	IStorage *pStorage = CreateStorage(IStorage::STORAGETYPE_BASIC, argc, argv);
 	if(!pStorage || argc != 3)

--- a/src/tools/packetgen.cpp
+++ b/src/tools/packetgen.cpp
@@ -33,7 +33,7 @@ void Run(NETADDR Dest)
 
 int main(int argc, const char **argv)
 {
-	tw::CCmdlineFix CmdlineFix(&argc, &argv);
+	CCmdlineFix CmdlineFix(&argc, &argv);
 	NETADDR Dest = {NETTYPE_IPV4, {127, 0, 0, 1}, 8303};
 	Run(Dest);
 	return 0;

--- a/src/tools/stun.cpp
+++ b/src/tools/stun.cpp
@@ -4,7 +4,7 @@
 
 int main(int argc, const char **argv)
 {
-	tw::CCmdlineFix CmdlineFix(&argc, &argv);
+	CCmdlineFix CmdlineFix(&argc, &argv);
 
 	secure_random_init();
 	log_set_global_logger_default();

--- a/src/tools/unicode_confusables.cpp
+++ b/src/tools/unicode_confusables.cpp
@@ -3,7 +3,7 @@
 
 int main(int argc, const char **argv)
 {
-	tw::CCmdlineFix CmdlineFix(&argc, &argv);
+	CCmdlineFix CmdlineFix(&argc, &argv);
 	log_set_global_logger_default();
 	if(argc < 1 + 2)
 	{

--- a/src/tools/uuid.cpp
+++ b/src/tools/uuid.cpp
@@ -2,7 +2,7 @@
 #include <engine/shared/uuid_manager.h>
 int main(int argc, const char **argv)
 {
-	tw::CCmdlineFix CmdlineFix(&argc, &argv);
+	CCmdlineFix CmdlineFix(&argc, &argv);
 	log_set_global_logger_default();
 	if(argc != 2)
 	{

--- a/src/twping/twping.cpp
+++ b/src/twping/twping.cpp
@@ -9,7 +9,7 @@ static CNetClient g_NetOp; // main
 
 int main(int argc, const char **argv)
 {
-	tw::CCmdlineFix CmdlineFix(&argc, &argv);
+	CCmdlineFix CmdlineFix(&argc, &argv);
 	NETADDR BindAddr;
 	mem_zero(&BindAddr, sizeof(BindAddr));
 	BindAddr.type = NETTYPE_ALL;


### PR DESCRIPTION
It didn't have a clear role, it just acted as a distinguisher between
two functions with the same name.

Rename `tw::time_get` to `time_get_nanoseconds` and delete the old
`time_get_nanoseconds`. Move `CCmdlineFix` and the typed
`net_socket_read_wait` function to the global namespace.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
