### PR TITLE
Use DoScrollbarOption for mouse sens., name settings consistently

### DIFF
--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -999,12 +999,12 @@ float CMenus::RenderSettingsControlsJoystick(CUIRect View)
 			{
 				View.HSplitTop(Spacing, 0, &View);
 				View.HSplitTop(ButtonHeight, &Button, &View);
-				UIEx()->DoScrollbarOption(&g_Config.m_InpJoystickSens, &g_Config.m_InpJoystickSens, &Button, Localize("Ingame joystick sensitivity"), 1, 500, &CUIEx::ms_LogarithmicScrollbarScale, CUIEx::SCROLLBAR_OPTION_NOCLAMPVALUE);
+				UIEx()->DoScrollbarOption(&g_Config.m_InpJoystickSens, &g_Config.m_InpJoystickSens, &Button, Localize("Ingame joystick sens."), 1, 500, &CUIEx::ms_LogarithmicScrollbarScale, CUIEx::SCROLLBAR_OPTION_NOCLAMPVALUE);
 			}
 
 			View.HSplitTop(Spacing, 0, &View);
 			View.HSplitTop(ButtonHeight, &Button, &View);
-			UIEx()->DoScrollbarOption(&g_Config.m_UiJoystickSens, &g_Config.m_UiJoystickSens, &Button, Localize("Menu/Editor joystick sensitivity"), 1, 500, &CUIEx::ms_LogarithmicScrollbarScale, CUIEx::SCROLLBAR_OPTION_NOCLAMPVALUE);
+			UIEx()->DoScrollbarOption(&g_Config.m_UiJoystickSens, &g_Config.m_UiJoystickSens, &Button, Localize("UI joystick sens."), 1, 500, &CUIEx::ms_LogarithmicScrollbarScale, CUIEx::SCROLLBAR_OPTION_NOCLAMPVALUE);
 
 			View.HSplitTop(Spacing, 0, &View);
 			View.HSplitTop(ButtonHeight, &Button, &View);
@@ -1118,8 +1118,6 @@ void CMenus::DoJoystickBar(const CUIRect *pRect, float Current, float Tolerance,
 
 void CMenus::RenderSettingsControls(CUIRect MainView)
 {
-	char aBuf[128];
-
 	// this is kinda slow, but whatever
 	for(auto &Key : gs_aKeys)
 		Key.m_KeyId = Key.m_ModifierCombination = 0;
@@ -1173,29 +1171,14 @@ void CMenus::RenderSettingsControls(CUIRect MainView)
 
 		MouseSettings.HSplitTop(HeaderHeight, 0, &MouseSettings);
 
-		{
-			CUIRect Button, Label;
-			MouseSettings.HSplitTop(20.0f, &Button, &MouseSettings);
-			Button.VSplitLeft(160.0f, &Label, &Button);
-			str_format(aBuf, sizeof(aBuf), "%s: %i", Localize("Mouse sens."), g_Config.m_InpMousesens);
-			UI()->DoLabel(&Label, aBuf, FontSize, TEXTALIGN_LEFT);
-			int NewValue = (int)(UIEx()->DoScrollbarH(&g_Config.m_InpMousesens, &Button, (minimum(g_Config.m_InpMousesens, 500) - 1) / 500.0f) * 500.0f) + 1;
-			if(g_Config.m_InpMousesens < 500 || NewValue < 500)
-				g_Config.m_InpMousesens = minimum(NewValue, 500);
-		}
+		CUIRect Button;
+		MouseSettings.HSplitTop(20.0f, &Button, &MouseSettings);
+		UIEx()->DoScrollbarOption(&g_Config.m_InpMousesens, &g_Config.m_InpMousesens, &Button, Localize("Ingame mouse sens."), 1, 500, &CUIEx::ms_LogarithmicScrollbarScale, CUIEx::SCROLLBAR_OPTION_NOCLAMPVALUE);
 
 		MouseSettings.HSplitTop(2.0f, 0, &MouseSettings);
 
-		{
-			CUIRect Button, Label;
-			MouseSettings.HSplitTop(20.0f, &Button, &MouseSettings);
-			Button.VSplitLeft(160.0f, &Label, &Button);
-			str_format(aBuf, sizeof(aBuf), "%s: %i", Localize("UI mouse s."), g_Config.m_UiMousesens);
-			UI()->DoLabel(&Label, aBuf, FontSize, TEXTALIGN_LEFT);
-			int NewValue = (int)(UIEx()->DoScrollbarH(&g_Config.m_UiMousesens, &Button, (minimum(g_Config.m_UiMousesens, 500) - 1) / 500.0f) * 500.0f) + 1;
-			if(g_Config.m_UiMousesens < 500 || NewValue < 500)
-				g_Config.m_UiMousesens = minimum(NewValue, 500);
-		}
+		MouseSettings.HSplitTop(20.0f, &Button, &MouseSettings);
+		UIEx()->DoScrollbarOption(&g_Config.m_UiMousesens, &g_Config.m_UiMousesens, &Button, Localize("UI mouse sens."), 1, 500, &CUIEx::ms_LogarithmicScrollbarScale, CUIEx::SCROLLBAR_OPTION_NOCLAMPVALUE);
 	}
 
 	// joystick settings


### PR DESCRIPTION
Use logarithmic `DoScrollbarOption` for mouse sens. options.

Name mouse/joystick ingame/UI sens. settings more consistently.

Old:

![settings_controls_old](https://user-images.githubusercontent.com/23437060/173692598-f40658e7-9a9f-44eb-8b0d-0966c8ced864.png)

New:

![settings_controls_new](https://user-images.githubusercontent.com/23437060/173692601-61f65fe7-afa7-4031-8116-075c665d76d1.png)

## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
