### PR TITLE
Fix editor crash

### DIFF
--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -170,6 +170,7 @@ void CUI::ConvertMouseMove(float *pX, float *pY, IInput::ECursorType CursorType)
 	switch(CursorType)
 	{
 	case IInput::CURSOR_MOUSE:
+	case IInput::CURSOR_NONE:
 		Factor = g_Config.m_UiMousesens / 100.0f;
 		break;
 	case IInput::CURSOR_JOYSTICK:


### PR DESCRIPTION
I don't see anything working badly (using mouse)

@Robyt3 This might not be the proper fix. I think editor doesn't use
relative mouse mode, thus it returns CURSOR_NONE in CursorRelative.

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
