### PR TITLE
Add missing `CursorType != IInput::CURSOR_NONE` check in editor

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -6410,7 +6410,8 @@ void CEditor::UpdateAndRender()
 	float rx = 0, ry = 0;
 	{
 		IInput::ECursorType CursorType = Input()->CursorRelative(&rx, &ry);
-		UIEx()->ConvertMouseMove(&rx, &ry, CursorType);
+		if(CursorType != IInput::CURSOR_NONE)
+			UIEx()->ConvertMouseMove(&rx, &ry, CursorType);
 		UIEx()->ResetMouseSlow();
 
 		m_MouseDeltaX = rx;


### PR DESCRIPTION
Fixes the editor crash. `CURSOR_NONE` is returned when the cursor was not moved. Closes #5418. Closes #5417.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
