### PR TITLE
no-goalshud

### DIFF
--- a/src/game/client/components/scoreboard.cpp
+++ b/src/game/client/components/scoreboard.cpp
@@ -90,10 +90,8 @@ void CScoreboard::RenderGoals(float x, float y, float w)
 	}
 }
 
-void CScoreboard::RenderSpectators(float x, float y, float w)
+void CScoreboard::RenderSpectators(float x, float y, float w, float h)
 {
-	float h = 140.0f;
-
 	// background
 	Graphics()->BlendNormal();
 	Graphics()->TextureClear();
@@ -686,9 +684,16 @@ void CScoreboard::OnRender()
 			RenderScoreboard(Width / 2 + 5.0f, 150.0f, w, TEAM_BLUE, pBlueClanName ? pBlueClanName : Localize("Blue team"), NumPlayers);
 		}
 	}
+	if(m_pClient->m_Snap.m_pGameInfoObj && (m_pClient->m_Snap.m_pGameInfoObj->m_ScoreLimit || m_pClient->m_Snap.m_pGameInfoObj->m_TimeLimit || (m_pClient->m_Snap.m_pGameInfoObj->m_RoundNum && m_pClient->m_Snap.m_pGameInfoObj->m_RoundCurrent)))
+	{
+		RenderGoals(Width / 2 - w / 2, 150 + 760 + 10, w);
+		RenderSpectators(Width / 2 - w / 2, 150 + 760 + 10 + 50 + 10, w, 160.0f);
+	}
+	else
+	{
+		RenderSpectators(Width / 2 - w / 2, 150 + 760 + 10, w, 200.0f);
+	}
 
-	RenderGoals(Width / 2 - w / 2, 150 + 760 + 10, w);
-	RenderSpectators(Width / 2 - w / 2, 150 + 760 + 10 + 50 + 10, w);
 	RenderRecordingNotification((Width / 7) * 4 + 20);
 }
 

--- a/src/game/client/components/scoreboard.h
+++ b/src/game/client/components/scoreboard.h
@@ -10,7 +10,7 @@
 class CScoreboard : public CComponent
 {
 	void RenderGoals(float x, float y, float w);
-	void RenderSpectators(float x, float y, float w);
+	void RenderSpectators(float x, float y, float w, float h);
 	void RenderScoreboard(float x, float y, float w, int Team, const char *pTitle, int NumPlayers = -1);
 	void RenderRecordingNotification(float x);
 


### PR DESCRIPTION
<s>do it using getgameinfo from gameclient introducting a new flag for ddrace</s>
use the same conditions as in the goalshudrender function, so don't render when empty

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
