### PR TITLE
Separate editor update and render to fix slow joystick input

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -2816,8 +2816,10 @@ void CClient::Update()
 	m_ServerBrowser.Update(m_ResortServerBrowser);
 	m_ResortServerBrowser = false;
 
-	// update gameclient
-	if(!m_EditorActive)
+	// update editor/gameclient
+	if(m_EditorActive)
+		m_pEditor->OnUpdate();
+	else
 		GameClient()->OnUpdate();
 
 	Discord()->Update();
@@ -3224,7 +3226,7 @@ void CClient::Run()
 							Render();
 						else
 						{
-							m_pEditor->UpdateAndRender();
+							m_pEditor->OnRender();
 							DebugRender();
 						}
 						m_pGraphics->Swap();
@@ -3237,7 +3239,7 @@ void CClient::Run()
 						Render();
 					else
 					{
-						m_pEditor->UpdateAndRender();
+						m_pEditor->OnRender();
 						DebugRender();
 					}
 					m_pGraphics->Swap();

--- a/src/engine/editor.h
+++ b/src/engine/editor.h
@@ -10,7 +10,8 @@ class IEditor : public IInterface
 public:
 	virtual ~IEditor() {}
 	virtual void Init() = 0;
-	virtual void UpdateAndRender() = 0;
+	virtual void OnUpdate() = 0;
+	virtual void OnRender() = 0;
 	virtual bool HasUnsavedData() const = 0;
 	virtual int Load(const char *pFilename, int StorageType) = 0;
 	virtual int Save(const char *pFilename) = 0;

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -811,7 +811,8 @@ public:
 	}
 
 	void Init() override;
-	void UpdateAndRender() override;
+	void OnUpdate() override;
+	void OnRender() override;
 	bool HasUnsavedData() const override { return m_Map.m_Modified; }
 	void UpdateMentions() override { m_Mentions++; }
 	void ResetMentions() override { m_Mentions = 0; }
@@ -942,6 +943,10 @@ public:
 	bool m_ShowMousePointer;
 	bool m_GuiActive;
 	bool m_ProofBorders;
+	float m_MouseX = 0.0f;
+	float m_MouseY = 0.0f;
+	float m_MouseWorldX = 0.0f;
+	float m_MouseWorldY = 0.0f;
 	float m_MouseDeltaX;
 	float m_MouseDeltaY;
 	float m_MouseDeltaWx;


### PR DESCRIPTION
Split `IEditor::UpdateAndEditor` into `OnUpdate` and `OnRender` and call the various input and UI methods in the same order as in the gameclient. This fixes the joystick input being slow in the editor. Closes #5422.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
