### PR TITLE
Additional binds for control over copy moves

### DIFF
--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -256,18 +256,33 @@ int CControls::SnapInput(int *pData)
 		if(g_Config.m_ClDummyCopyMoves)
 		{
 			CNetObj_PlayerInput *pDummyInput = &m_pClient->m_DummyInput;
-			pDummyInput->m_Direction = m_InputData[g_Config.m_ClDummy].m_Direction;
-			pDummyInput->m_Hook = m_InputData[g_Config.m_ClDummy].m_Hook;
-			pDummyInput->m_Jump = m_InputData[g_Config.m_ClDummy].m_Jump;
+			if(g_Config.m_ClDummyCopyDirection)
+				pDummyInput->m_Direction = m_InputData[g_Config.m_ClDummy].m_Direction;
+
+			if(g_Config.m_ClDummyCopyHook)
+				pDummyInput->m_Hook = m_InputData[g_Config.m_ClDummy].m_Hook;
+
+			if(g_Config.m_ClDummyCopyJump)
+				pDummyInput->m_Jump = m_InputData[g_Config.m_ClDummy].m_Jump;
+
+			if(g_Config.m_ClDummyCopyAim)
+			{
+				pDummyInput->m_TargetX = m_InputData[g_Config.m_ClDummy].m_TargetX;
+				pDummyInput->m_TargetY = m_InputData[g_Config.m_ClDummy].m_TargetY;
+				m_MousePos[!g_Config.m_ClDummy] = m_MousePos[g_Config.m_ClDummy];
+			}
+			
+			if(g_Config.m_ClDummyCopyFire)
+				pDummyInput->m_Fire += m_InputData[g_Config.m_ClDummy].m_Fire - m_LastData[g_Config.m_ClDummy].m_Fire;
+
+			if(g_Config.m_ClDummyCopyWeapon)
+			{
+				pDummyInput->m_WantedWeapon = m_InputData[g_Config.m_ClDummy].m_WantedWeapon;
+				pDummyInput->m_NextWeapon += m_InputData[g_Config.m_ClDummy].m_NextWeapon - m_LastData[g_Config.m_ClDummy].m_NextWeapon;
+				pDummyInput->m_PrevWeapon += m_InputData[g_Config.m_ClDummy].m_PrevWeapon - m_LastData[g_Config.m_ClDummy].m_PrevWeapon;
+			}
+
 			pDummyInput->m_PlayerFlags = m_InputData[g_Config.m_ClDummy].m_PlayerFlags;
-			pDummyInput->m_TargetX = m_InputData[g_Config.m_ClDummy].m_TargetX;
-			pDummyInput->m_TargetY = m_InputData[g_Config.m_ClDummy].m_TargetY;
-			pDummyInput->m_WantedWeapon = m_InputData[g_Config.m_ClDummy].m_WantedWeapon;
-
-			pDummyInput->m_Fire += m_InputData[g_Config.m_ClDummy].m_Fire - m_LastData[g_Config.m_ClDummy].m_Fire;
-			pDummyInput->m_NextWeapon += m_InputData[g_Config.m_ClDummy].m_NextWeapon - m_LastData[g_Config.m_ClDummy].m_NextWeapon;
-			pDummyInput->m_PrevWeapon += m_InputData[g_Config.m_ClDummy].m_PrevWeapon - m_LastData[g_Config.m_ClDummy].m_PrevWeapon;
-
 			m_InputData[!g_Config.m_ClDummy] = *pDummyInput;
 		}
 

--- a/src/game/variables.h
+++ b/src/game/variables.h
@@ -144,6 +144,12 @@ MACRO_CONFIG_INT(ClDummyHammer, cl_dummy_hammer, 0, 0, 1, CFGFLAG_CLIENT | CFGFL
 MACRO_CONFIG_INT(ClDummyResetOnSwitch, cl_dummy_resetonswitch, 0, 0, 2, CFGFLAG_CLIENT | CFGFLAG_SAVE | CFGFLAG_INSENSITIVE, "Whether dummy or player should stop pressing keys when you switch. 0 = off, 1 = dummy, 2 = player")
 MACRO_CONFIG_INT(ClDummyRestoreWeapon, cl_dummy_restore_weapon, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE | CFGFLAG_INSENSITIVE, "Whether dummy should switch to last weapon after hammerfly")
 MACRO_CONFIG_INT(ClDummyCopyMoves, cl_dummy_copy_moves, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_INSENSITIVE, "Whether dummy should copy your moves")
+MACRO_CONFIG_INT(ClDummyCopyDirection, cl_dummy_copy_direction, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_INSENSITIVE, "Whether dummy should copy your direction (requires cl_dummy_copy_moves 1)")
+MACRO_CONFIG_INT(ClDummyCopyJump, cl_dummy_copy_jump, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_INSENSITIVE, "Whether dummy should copy your jump (requires cl_dummy_copy_moves 1)")
+MACRO_CONFIG_INT(ClDummyCopyFire, cl_dummy_copy_fire, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_INSENSITIVE, "Whether dummy should copy your fire (requires cl_dummy_copy_moves 1)")
+MACRO_CONFIG_INT(ClDummyCopyHook, cl_dummy_copy_hook, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_INSENSITIVE, "Whether dummy should copy your hook (requires cl_dummy_copy_moves 1)")
+MACRO_CONFIG_INT(ClDummyCopyAim, cl_dummy_copy_aim, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_INSENSITIVE, "Whether dummy should copy your aim (requires cl_dummy_copy_moves 1)")
+MACRO_CONFIG_INT(ClDummyCopyWeapon, cl_dummy_copy_weapon, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_INSENSITIVE, "Whether dummy should copy your selected weapon (requires cl_dummy_copy_moves 1)")
 
 // more controlable dummy command
 MACRO_CONFIG_INT(ClDummyControl, cl_dummy_control, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_INSENSITIVE, "Whether can you control dummy at the same time (cl_dummy_jump, cl_dummy_fire, cl_dummy_hook)")


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request -->
These simple changes give you complete control over what the dummy should or not copy when using "cl_dummy_copy_moves". This will be helpful for copy fly with dummy for example.

Added on line 272     m_MousePos[!g_Config.m_ClDummy] = m_MousePos[g_Config.m_ClDummy];
This places the mouse in the same direction as it was when copying moves. To prevent jerking of the weapon when switching to a dummy

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
