### PR TITLE
Fix shader code vector size not being updated after copy

### DIFF
--- a/src/engine/client/backend/vulkan/backend_vulkan.cpp
+++ b/src/engine/client/backend/vulkan/backend_vulkan.cpp
@@ -4390,7 +4390,7 @@ public:
 				return false;
 
 			std::vector<uint8_t> vShaderBuff;
-			vShaderBuff.reserve(FileSize);
+			vShaderBuff.resize(FileSize);
 			mem_copy(vShaderBuff.data(), pShaderBuff, FileSize);
 			free(pShaderBuff);
 


### PR DESCRIPTION
Oops, I tried to be smart with `reserve` instead of `resize` but of course that wouldn't set the actual size of the vector after I copy in the data. 

Closes #5442.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
