### PR TITLE
Fix editor value scrollers not working and panning being slow

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -6373,8 +6373,8 @@ void CEditor::OnUpdate()
 
 	// handle cursor movement
 	{
-		static double s_MouseX = 0.0f;
-		static double s_MouseY = 0.0f;
+		static float s_MouseX = 0.0f;
+		static float s_MouseY = 0.0f;
 
 		float MouseRelX = 0.0f, MouseRelY = 0.0f;
 		IInput::ECursorType CursorType = Input()->CursorRelative(&MouseRelX, &MouseRelY);

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -6382,6 +6382,9 @@ void CEditor::OnUpdate()
 			UIEx()->ConvertMouseMove(&MouseRelX, &MouseRelY, CursorType);
 		UIEx()->ResetMouseSlow();
 
+		m_MouseDeltaX += MouseRelX;
+		m_MouseDeltaY += MouseRelY;
+
 		if(!m_LockMouse)
 		{
 			s_MouseX = clamp<float>(s_MouseX + MouseRelX, 0.0f, Graphics()->WindowWidth());
@@ -6404,6 +6407,8 @@ void CEditor::OnUpdate()
 
 			m_MouseWorldX = aPoints[0] + WorldWidth * (s_MouseX / Graphics()->WindowWidth());
 			m_MouseWorldY = aPoints[1] + WorldHeight * (s_MouseY / Graphics()->WindowHeight());
+			m_MouseDeltaWx = m_MouseDeltaX * (WorldWidth / Graphics()->WindowWidth());
+			m_MouseDeltaWy = m_MouseDeltaY * (WorldHeight / Graphics()->WindowHeight());
 		}
 		else
 		{
@@ -6430,13 +6435,14 @@ void CEditor::OnRender()
 	ms_pUiGotContext = nullptr;
 	UI()->StartCheck();
 
-	m_MouseDeltaX = m_MouseX - UI()->MouseX();
-	m_MouseDeltaY = m_MouseY - UI()->MouseY();
-	m_MouseDeltaWx = m_MouseWorldX - UI()->MouseWorldX();
-	m_MouseDeltaWy = m_MouseWorldY - UI()->MouseWorldY();
 	UI()->Update(m_MouseX, m_MouseY, m_MouseWorldX, m_MouseWorldY);
 
 	Render();
+
+	m_MouseDeltaX = 0.0f;
+	m_MouseDeltaY = 0.0f;
+	m_MouseDeltaWx = 0.0f;
+	m_MouseDeltaWy = 0.0f;
 
 	if(Input()->KeyPress(KEY_F10))
 	{

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -6371,7 +6371,7 @@ void CEditor::OnUpdate()
 		Reset();
 	}
 
-	// handle mouse movement
+	// handle cursor movement
 	{
 		static double s_MouseX = 0.0f;
 		static double s_MouseY = 0.0f;


### PR DESCRIPTION
Accumulate the mouse deltas and reset them at the end of the frame to fix editor panning being slowed down and value scrollers (layer width etc.) not working anymore.

Closes #5441.

And minor cleanup.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
