### PR TITLE
Fix segfault in `SDL_JoystickClose` on client quit

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -3351,6 +3351,7 @@ void CClient::Run()
 		m_NetClient[i].Close();
 
 	delete m_pEditor;
+	m_pInput->Shutdown();
 	m_pGraphics->Shutdown();
 
 	// shutdown SDL

--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -62,12 +62,6 @@ CInput::CInput()
 	m_aEditingText[0] = 0;
 }
 
-CInput::~CInput()
-{
-	SDL_free(m_pClipboardText);
-	CloseJoysticks();
-}
-
 void CInput::Init()
 {
 	m_pGraphics = Kernel()->RequestInterface<IEngineGraphics>();
@@ -78,6 +72,12 @@ void CInput::Init()
 	MouseModeRelative();
 
 	InitJoysticks();
+}
+
+void CInput::Shutdown()
+{
+	SDL_free(m_pClipboardText);
+	CloseJoysticks();
 }
 
 void CInput::InitJoysticks()
@@ -167,16 +167,11 @@ CInput::CJoystick::CJoystick(CInput *pInput, int Index, SDL_Joystick *pDelegate)
 
 void CInput::CloseJoysticks()
 {
-	for(auto &Joystick : m_vJoysticks)
-		Joystick.Close();
+	if(SDL_WasInit(SDL_INIT_JOYSTICK))
+		SDL_QuitSubSystem(SDL_INIT_JOYSTICK);
+
 	m_vJoysticks.clear();
 	m_pActiveJoystick = nullptr;
-}
-
-void CInput::CJoystick::Close()
-{
-	if(SDL_JoystickGetAttached(m_pDelegate))
-		SDL_JoystickClose(m_pDelegate);
 }
 
 void CInput::SelectNextJoystick()

--- a/src/engine/client/input.h
+++ b/src/engine/client/input.h
@@ -42,7 +42,6 @@ public:
 		int GetHatValue(int Hat) override;
 		bool Relative(float *pX, float *pY) override;
 		bool Absolute(float *pX, float *pY) override;
-		void Close();
 
 		static int GetJoystickHatKey(int Hat, int HatValue);
 	};
@@ -96,9 +95,9 @@ private:
 
 public:
 	CInput();
-	~CInput();
 
 	void Init() override;
+	void Shutdown() override;
 
 	bool ModifierIsPressed() const override { return KeyState(KEY_LCTRL) || KeyState(KEY_RCTRL) || KeyState(KEY_LGUI) || KeyState(KEY_RGUI); }
 	bool KeyIsPressed(int Key) const override { return KeyState(Key); }

--- a/src/engine/input.h
+++ b/src/engine/input.h
@@ -128,6 +128,7 @@ class IEngineInput : public IInput
 	MACRO_INTERFACE("engineinput", 0)
 public:
 	virtual void Init() = 0;
+	virtual void Shutdown() = 0;
 	virtual int Update() = 0;
 	virtual int VideoRestartNeeded() = 0;
 };


### PR DESCRIPTION
Instead of closing the joysticks manually, use `SDL_QuitSubSystem(SDL_INIT_JOYSTICK)` to quit the entire subsystem, which will also close all joysticks correctly.

The engine input destructor is replaced with a `Shutdown` method so we can control when it is called, i.e. before calling `SDL_Quit`, which forcefully quits all subsystems.

`CJoystick::Close` is removed as we don't need to close joysticks manually anymore.

Closes #5452.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
