### PR TITLE
Only enable UI editbox hotkeys when UI is enabled

### DIFF
--- a/src/game/client/ui_ex.cpp
+++ b/src/game/client/ui_ex.cpp
@@ -316,10 +316,11 @@ bool CUIEx::DoEditBox(const void *pID, const CUIRect *pRect, char *pStr, unsigne
 
 		m_CurCursor = minimum(str_length(pStr), m_CurCursor);
 
+		const bool Enabled = UI()->Enabled();
 		bool IsShiftPressed = Input()->KeyIsPressed(KEY_LSHIFT) || Input()->KeyIsPressed(KEY_RSHIFT);
 		bool IsModPressed = Input()->ModifierIsPressed();
 
-		if(!IsShiftPressed && IsModPressed && Input()->KeyPress(KEY_V))
+		if(Enabled && !IsShiftPressed && IsModPressed && Input()->KeyPress(KEY_V))
 		{
 			const char *pText = Input()->GetClipboardText();
 			if(pText)
@@ -376,7 +377,7 @@ bool CUIEx::DoEditBox(const void *pID, const CUIRect *pRect, char *pStr, unsigne
 			}
 		}
 
-		if(!IsShiftPressed && IsModPressed && (Input()->KeyPress(KEY_C) || Input()->KeyPress(KEY_X)))
+		if(Enabled && !IsShiftPressed && IsModPressed && (Input()->KeyPress(KEY_C) || Input()->KeyPress(KEY_X)))
 		{
 			if(m_HasSelection)
 			{
@@ -404,12 +405,12 @@ bool CUIEx::DoEditBox(const void *pID, const CUIRect *pRect, char *pStr, unsigne
 				Input()->SetClipboardText(pStr);
 		}
 
-		if(Properties.m_SelectText || (!IsShiftPressed && IsModPressed && Input()->KeyPress(KEY_A)))
+		if(Properties.m_SelectText || (Enabled && !IsShiftPressed && IsModPressed && Input()->KeyPress(KEY_A)))
 		{
 			SelectAllText();
 		}
 
-		if(!IsShiftPressed && IsModPressed && Input()->KeyPress(KEY_U))
+		if(Enabled && !IsShiftPressed && IsModPressed && Input()->KeyPress(KEY_U))
 		{
 			pStr[0] = '\0';
 			m_CurCursor = 0;


### PR DESCRIPTION
Fixes hotkeys triggering console input and UI editbox input at the same time when the console is open and a UI editbox is selected.

Closes #5467.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
