### PR TITLE
Fix memory leak of OpenGL 2 buffer object data

### DIFF
--- a/src/engine/client/backend/opengl/backend_opengl.cpp
+++ b/src/engine/client/backend/opengl/backend_opengl.cpp
@@ -1819,6 +1819,8 @@ void CCommandProcessorFragment_OpenGL2::Cmd_Shutdown(const SCommand_Shutdown *pC
 	delete m_pTileProgramTextured;
 	delete m_pPrimitive3DProgram;
 	delete m_pPrimitive3DProgramTextured;
+	for(auto &BufferObject : m_vBufferObjectIndices)
+		free(BufferObject.m_pData);
 }
 
 void CCommandProcessorFragment_OpenGL2::Cmd_RenderTex3D(const CCommandBuffer::SCommand_RenderTex3D *pCommand)


### PR DESCRIPTION
```
Direct leak of 216320 byte(s) in 3 object(s) allocated from:
    #0 0x7f5e05924808 in __interceptor_malloc ../../../../src/libsanitizer/asan/asan_malloc_linux.cc:144
    #1 0x559b8ca66278 in CCommandProcessorFragment_OpenGL2::Cmd_CreateBufferObject(CCommandBuffer::SCommand_CreateBufferObject const*) src/engine/client/backend/opengl/backend_opengl.cpp:1901
    #2 0x559b8ca47fe7 in CCommandProcessorFragment_OpenGL::RunCommand(CCommandBuffer::SCommand const*) src/engine/client/backend/opengl/backend_opengl.cpp:1107
    #3 0x559b8cdf811b in CCommandProcessor_SDL_GL::RunBuffer(CCommandBuffer*) src/engine/client/backend_sdl.cpp:248
    #4 0x559b8cdf4262 in CGraphicsBackend_Threaded::ThreadFunc(void*) src/engine/client/backend_sdl.cpp:77
    #5 0x559b8dfc58a5 in thread_run src/base/system.cpp:721
    #6 0x7f5e03bf6608 in start_thread /build/glibc-SzIz7B/glibc-2.31/nptl/pthread_create.c:477
```

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [X] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
