### PR TITLE
Add buttons that copy a report template to your clipboard

### DIFF
--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1038,7 +1038,7 @@ void CMenus::RenderServerbrowserServerDetail(CUIRect View)
 	const CServerInfo *pSelectedServer = ServerBrowser()->SortedGet(m_SelectedIndex);
 
 	// split off a piece to use for scoreboard
-	ServerDetails.HSplitTop(90.0f, &ServerDetails, &ServerScoreBoard);
+	ServerDetails.HSplitTop(110.0f, &ServerDetails, &ServerScoreBoard);
 	ServerDetails.HSplitBottom(2.5f, &ServerDetails, 0x0);
 
 	// server details
@@ -1048,6 +1048,8 @@ void CMenus::RenderServerbrowserServerDetail(CUIRect View)
 	RenderTools()->DrawUIRect(&ServerHeader, ColorRGBA(1, 1, 1, 0.25f), CUI::CORNER_T, 4.0f);
 	RenderTools()->DrawUIRect(&ServerDetails, ColorRGBA(0, 0, 0, 0.15f), CUI::CORNER_B, 4.0f);
 	UI()->DoLabel(&ServerHeader, Localize("Server details"), FontSize + 2.0f, TEXTALIGN_CENTER);
+
+	char aBuf[1024];
 
 	if(pSelectedServer)
 	{
@@ -1063,7 +1065,29 @@ void CMenus::RenderServerbrowserServerDetail(CUIRect View)
 		CUIRect LeftColumn;
 		CUIRect RightColumn;
 
-		//
+		// copy clipboard button
+		{
+			CUIRect Button;
+			ServerDetails.HSplitBottom(15.0f, &ServerDetails, &Button);
+			static int s_CopyClipboardButton = 0;
+			if(DoButton_Menu(&s_CopyClipboardButton, Localize("Copy server info"), 0, &Button))
+			{	
+				mem_zero(aBuf, sizeof(aBuf));
+				str_format(
+					aBuf,
+					sizeof(aBuf),
+					"@Moderator\r\n"
+					"%s\r\n"
+					"Address: %s\r\n"
+					"My IGN: %s\r\n",
+					pSelectedServer->m_aName,
+					pSelectedServer->m_aAddress,
+					g_Config.m_PlayerName);
+				Input()->SetClipboardText(aBuf);
+			}
+		}
+
+		// add fav checkbox
 		{
 			CUIRect Button;
 			ServerDetails.HSplitBottom(20.0f, &ServerDetails, &Button);

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1070,7 +1070,7 @@ void CMenus::RenderServerbrowserServerDetail(CUIRect View)
 			CUIRect Button;
 			ServerDetails.HSplitBottom(15.0f, &ServerDetails, &Button);
 			static int s_CopyClipboardButton = 0;
-			if(DoButton_Menu(&s_CopyClipboardButton, Localize("Copy server info"), 0, &Button))
+			if(DoButton_Menu(&s_CopyClipboardButton, Localize("Copy report template"), 0, &Button))
 			{	
 				mem_zero(aBuf, sizeof(aBuf));
 				str_format(

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -415,6 +415,30 @@ void CMenus::RenderServerInfo(CUIRect MainView)
 
 	TextRender()->Text(0, ServerInfo.x + x, ServerInfo.y + y, 20, aBuf, 250.0f);
 
+	// copy clipboard button
+	{
+		CUIRect Button;
+		ServerInfo.HSplitBottom(20.0f, &ServerInfo, &Button);
+		Button.VSplitRight(200.0f, &ServerInfo, &Button);
+		static int s_CopyClipboardButton = 0;
+		if(DoButton_Menu(&s_CopyClipboardButton, Localize("Copy server info"), 0, &Button))
+		{	
+			mem_zero(aBuf, sizeof(aBuf));
+			str_format(
+				aBuf,
+				sizeof(aBuf),
+				"@Moderator\r\n"
+				"%s\r\n"
+				"Address: %s\r\n"
+				"My IGN: %s\r\n",
+				CurrentServerInfo.m_aName,
+				CurrentServerInfo.m_aAddress,
+				g_Config.m_PlayerName);
+			Input()->SetClipboardText(aBuf);
+		}
+	}
+
+	// add fav checkbox
 	{
 		CUIRect Button;
 		int IsFavorite = ServerBrowser()->IsFavorite(CurrentServerInfo.m_NetAddr);

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -421,7 +421,7 @@ void CMenus::RenderServerInfo(CUIRect MainView)
 		ServerInfo.HSplitBottom(20.0f, &ServerInfo, &Button);
 		Button.VSplitRight(200.0f, &ServerInfo, &Button);
 		static int s_CopyClipboardButton = 0;
-		if(DoButton_Menu(&s_CopyClipboardButton, Localize("Copy server info"), 0, &Button))
+		if(DoButton_Menu(&s_CopyClipboardButton, Localize("Copy report template"), 0, &Button))
 		{	
 			mem_zero(aBuf, sizeof(aBuf));
 			str_format(


### PR DESCRIPTION
Suggested by [Murpi](https://github.com/murpii) in [#5440](https://github.com/ddnet/ddnet/issues/5440).
> This may help people trying to report others for not following the server rules on discord, and moderators a quick way to connect to the server.

Adds 2 buttons for copying a report template to your clipboard.
Allows for simple and somewhat standardized discord reports.
The locations of these buttons are shown in the images below.

Clipboard formatting:
> `@Moderator`
> _DDNet NLD - Solo_
> Address: _185.107.57.240:8332_
> My IGN: _nameless tee_

![browser](https://user-images.githubusercontent.com/59069944/175459429-6891bd16-3641-43ba-8ee3-678039cabcfa.png)

![ingame](https://user-images.githubusercontent.com/59069944/175459423-0d758849-844b-49e4-bb83-57b894ec1656.png)

Closes [#5440](https://github.com/ddnet/ddnet/issues/5440)

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)