### PR TITLE
Try to fix dump_local_console (fixes #5488)

### DIFF
--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -285,7 +285,7 @@ void CGameConsole::CInstance::OnInput(IInput::CEvent Event)
 				if(m_Type == CONSOLETYPE_LOCAL || m_pGameConsole->Client()->RconAuthed())
 				{
 					char *pEntry = m_History.Allocate(m_Input.GetLength() + 1);
-					str_copy(pEntry, m_Input.GetString(), m_Input.GetLength());
+					str_copy(pEntry, m_Input.GetString(), m_Input.GetLength() + 1);
 				}
 				ExecuteLine(m_Input.GetString());
 				m_Input.Clear();

--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -285,7 +285,7 @@ void CGameConsole::CInstance::OnInput(IInput::CEvent Event)
 				if(m_Type == CONSOLETYPE_LOCAL || m_pGameConsole->Client()->RconAuthed())
 				{
 					char *pEntry = m_History.Allocate(m_Input.GetLength() + 1);
-					mem_copy(pEntry, m_Input.GetString(), m_Input.GetLength() + 1);
+					str_copy(pEntry, m_Input.GetString(), m_Input.GetLength());
 				}
 				ExecuteLine(m_Input.GetString());
 				m_Input.Clear();
@@ -425,7 +425,7 @@ void CGameConsole::CInstance::PrintLine(const char *pLine, int Len, ColorRGBA Pr
 	CBacklogEntry *pEntry = m_Backlog.Allocate(sizeof(CBacklogEntry) + Len);
 	pEntry->m_YOffset = -1.0f;
 	pEntry->m_PrintColor = PrintColor;
-	mem_copy(pEntry->m_aText, pLine, Len);
+	str_copy(pEntry->m_aText, pLine, Len);
 	pEntry->m_aText[Len] = 0;
 	if(m_pGameConsole->m_ConsoleType == m_Type)
 		m_pGameConsole->m_NewLineCounter++;

--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -425,8 +425,7 @@ void CGameConsole::CInstance::PrintLine(const char *pLine, int Len, ColorRGBA Pr
 	CBacklogEntry *pEntry = m_Backlog.Allocate(sizeof(CBacklogEntry) + Len);
 	pEntry->m_YOffset = -1.0f;
 	pEntry->m_PrintColor = PrintColor;
-	str_copy(pEntry->m_aText, pLine, Len);
-	pEntry->m_aText[Len] = 0;
+	str_copy(pEntry->m_aText, pLine, Len + 1);
 	if(m_pGameConsole->m_ConsoleType == m_Type)
 		m_pGameConsole->m_NewLineCounter++;
 	m_BacklogLock.unlock();


### PR DESCRIPTION
Untested, but my hunch is that by not cutting off the last part the text
file will be correctly recognized as valid utf8

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
