### PR TITLE
Use [[fallthrough]] attribute rather than comment

### DIFF
--- a/src/base/log.cpp
+++ b/src/base/log.cpp
@@ -422,7 +422,7 @@ std::unique_ptr<ILogger> log_logger_stdout()
 	switch(GetFileType(pOutput))
 	{
 	case FILE_TYPE_CHAR: return std::make_unique<CWindowsConsoleLogger>(pOutput);
-	case FILE_TYPE_PIPE: // fall through, writing to pipe works the same as writing to a file
+	case FILE_TYPE_PIPE: [[fallthrough]]; // writing to pipe works the same as writing to a file
 	case FILE_TYPE_DISK: return std::make_unique<CWindowsFileLogger>(pOutput);
 	default: return std::make_unique<CLoggerAsync>(io_stdout(), false, false);
 	}

--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -3231,12 +3231,12 @@ int str_time(int64_t centisecs, int format, char *buffer, int buffer_size)
 		if(centisecs >= day)
 			return str_format(buffer, buffer_size, "%" PRId64 "d %02" PRId64 ":%02" PRId64 ":%02" PRId64, centisecs / day,
 				(centisecs % day) / hour, (centisecs % hour) / min, (centisecs % min) / sec);
-		// fall through
+	[[fallthrough]];
 	case TIME_HOURS:
 		if(centisecs >= hour)
 			return str_format(buffer, buffer_size, "%02" PRId64 ":%02" PRId64 ":%02" PRId64, centisecs / hour,
 				(centisecs % hour) / min, (centisecs % min) / sec);
-		// fall through
+	[[fallthrough]];
 	case TIME_MINS:
 		return str_format(buffer, buffer_size, "%02" PRId64 ":%02" PRId64, centisecs / min,
 			(centisecs % min) / sec);
@@ -3244,7 +3244,7 @@ int str_time(int64_t centisecs, int format, char *buffer, int buffer_size)
 		if(centisecs >= hour)
 			return str_format(buffer, buffer_size, "%02" PRId64 ":%02" PRId64 ":%02" PRId64 ".%02" PRId64, centisecs / hour,
 				(centisecs % hour) / min, (centisecs % min) / sec, centisecs % sec);
-		// fall through
+	[[fallthrough]];
 	case TIME_MINS_CENTISECS:
 		return str_format(buffer, buffer_size, "%02" PRId64 ":%02" PRId64 ".%02" PRId64, centisecs / min,
 			(centisecs % min) / sec, centisecs % sec);

--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -3231,12 +3231,12 @@ int str_time(int64_t centisecs, int format, char *buffer, int buffer_size)
 		if(centisecs >= day)
 			return str_format(buffer, buffer_size, "%" PRId64 "d %02" PRId64 ":%02" PRId64 ":%02" PRId64, centisecs / day,
 				(centisecs % day) / hour, (centisecs % hour) / min, (centisecs % min) / sec);
-	[[fallthrough]];
+		[[fallthrough]];
 	case TIME_HOURS:
 		if(centisecs >= hour)
 			return str_format(buffer, buffer_size, "%02" PRId64 ":%02" PRId64 ":%02" PRId64, centisecs / hour,
 				(centisecs % hour) / min, (centisecs % min) / sec);
-	[[fallthrough]];
+		[[fallthrough]];
 	case TIME_MINS:
 		return str_format(buffer, buffer_size, "%02" PRId64 ":%02" PRId64, centisecs / min,
 			(centisecs % min) / sec);
@@ -3244,7 +3244,7 @@ int str_time(int64_t centisecs, int format, char *buffer, int buffer_size)
 		if(centisecs >= hour)
 			return str_format(buffer, buffer_size, "%02" PRId64 ":%02" PRId64 ":%02" PRId64 ".%02" PRId64, centisecs / hour,
 				(centisecs % hour) / min, (centisecs % min) / sec, centisecs % sec);
-	[[fallthrough]];
+		[[fallthrough]];
 	case TIME_MINS_CENTISECS:
 		return str_format(buffer, buffer_size, "%02" PRId64 ":%02" PRId64 ".%02" PRId64, centisecs / min,
 			(centisecs % min) / sec, centisecs % sec);

--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -620,7 +620,7 @@ int CInput::Update()
 		case SDL_MOUSEBUTTONUP:
 			Action = IInput::FLAG_RELEASE;
 
-			// fall through
+		[[fallthrough]];
 		case SDL_MOUSEBUTTONDOWN:
 			if(Event.button.button == SDL_BUTTON_LEFT)
 				Scancode = KEY_MOUSE_1;
@@ -704,7 +704,7 @@ int CInput::Update()
 				MouseModeAbsolute();
 				MouseModeRelative();
 #endif
-				// fallthrough
+			[[fallthrough]];
 			case SDL_WINDOWEVENT_RESTORED:
 				Graphics()->WindowCreateNtf(Event.window.windowID);
 				break;

--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -620,7 +620,7 @@ int CInput::Update()
 		case SDL_MOUSEBUTTONUP:
 			Action = IInput::FLAG_RELEASE;
 
-		[[fallthrough]];
+			[[fallthrough]];
 		case SDL_MOUSEBUTTONDOWN:
 			if(Event.button.button == SDL_BUTTON_LEFT)
 				Scancode = KEY_MOUSE_1;
@@ -704,7 +704,7 @@ int CInput::Update()
 				MouseModeAbsolute();
 				MouseModeRelative();
 #endif
-			[[fallthrough]];
+				[[fallthrough]];
 			case SDL_WINDOWEVENT_RESTORED:
 				Graphics()->WindowCreateNtf(Event.window.windowID);
 				break;

--- a/src/engine/shared/websockets.cpp
+++ b/src/engine/shared/websockets.cpp
@@ -78,7 +78,7 @@ static int websocket_callback(struct lws *wsi, enum lws_callback_reasons reason,
 		{
 			return 0;
 		}
-		/* FALLTHRU */
+	[[fallthrough]];
 	case LWS_CALLBACK_ESTABLISHED:
 	{
 		pss->wsi = wsi;
@@ -116,7 +116,7 @@ static int websocket_callback(struct lws *wsi, enum lws_callback_reasons reason,
 	break;
 
 	case LWS_CALLBACK_CLIENT_WRITEABLE:
-		/* FALLTHRU */
+	[[fallthrough]];
 	case LWS_CALLBACK_SERVER_WRITEABLE:
 	{
 		websocket_chunk *chunk = (websocket_chunk *)pss->send_buffer.First();
@@ -140,7 +140,7 @@ static int websocket_callback(struct lws *wsi, enum lws_callback_reasons reason,
 	break;
 
 	case LWS_CALLBACK_CLIENT_RECEIVE:
-		/* FALLTHRU */
+	[[fallthrough]];
 	case LWS_CALLBACK_RECEIVE:
 		if(pss->addr_str.empty())
 			return -1;

--- a/src/engine/shared/websockets.cpp
+++ b/src/engine/shared/websockets.cpp
@@ -78,7 +78,7 @@ static int websocket_callback(struct lws *wsi, enum lws_callback_reasons reason,
 		{
 			return 0;
 		}
-	[[fallthrough]];
+		[[fallthrough]];
 	case LWS_CALLBACK_ESTABLISHED:
 	{
 		pss->wsi = wsi;
@@ -116,7 +116,7 @@ static int websocket_callback(struct lws *wsi, enum lws_callback_reasons reason,
 	break;
 
 	case LWS_CALLBACK_CLIENT_WRITEABLE:
-	[[fallthrough]];
+		[[fallthrough]];
 	case LWS_CALLBACK_SERVER_WRITEABLE:
 	{
 		websocket_chunk *chunk = (websocket_chunk *)pss->send_buffer.First();
@@ -140,7 +140,7 @@ static int websocket_callback(struct lws *wsi, enum lws_callback_reasons reason,
 	break;
 
 	case LWS_CALLBACK_CLIENT_RECEIVE:
-	[[fallthrough]];
+		[[fallthrough]];
 	case LWS_CALLBACK_RECEIVE:
 		if(pss->addr_str.empty())
 			return -1;

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -778,7 +778,7 @@ int CPlayer::Pause(int State, bool Force)
 				m_ViewPos = m_pCharacter->m_Pos;
 				GameServer()->CreatePlayerSpawn(m_pCharacter->m_Pos, GameServer()->m_pController->GetMaskForPlayerWorldEvent(m_ClientID));
 			}
-		[[fallthrough]];
+			[[fallthrough]];
 		case PAUSE_SPEC:
 			if(g_Config.m_SvPauseMessages)
 			{

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -778,7 +778,7 @@ int CPlayer::Pause(int State, bool Force)
 				m_ViewPos = m_pCharacter->m_Pos;
 				GameServer()->CreatePlayerSpawn(m_pCharacter->m_Pos, GameServer()->m_pController->GetMaskForPlayerWorldEvent(m_ClientID));
 			}
-			// fall-thru
+		[[fallthrough]];
 		case PAUSE_SPEC:
 			if(g_Config.m_SvPauseMessages)
 			{

--- a/src/game/server/save.cpp
+++ b/src/game/server/save.cpp
@@ -369,13 +369,13 @@ int CSaveTee::FromString(const char *String)
 	{
 	case 96:
 		m_NotEligibleForFinish = false;
-	[[fallthrough]];
+		[[fallthrough]];
 	case 97:
 		m_HasTelegunGrenade = 0;
 		m_HasTelegunLaser = 0;
 		m_HasTelegunGun = 0;
 		FormatUuid(CalculateUuid("game-uuid-nonexistent@ddnet.tw"), m_aGameUuid, sizeof(m_aGameUuid));
-	[[fallthrough]];
+		[[fallthrough]];
 	case 101:
 		m_HookedPlayer = -1;
 		m_NewHook = false;
@@ -386,13 +386,13 @@ int CSaveTee::FromString(const char *String)
 		m_InputFire = 0;
 		m_InputHook = 0;
 		m_ReloadTimer = 0;
-	[[fallthrough]];
+		[[fallthrough]];
 	case 108:
 		m_TeeStarted = true;
-	[[fallthrough]];
+		[[fallthrough]];
 	case 109:
 		m_LiveFreeze = 0;
-	[[fallthrough]];
+		[[fallthrough]];
 	case 110:
 		return 0;
 	default:
@@ -613,7 +613,7 @@ int CSaveTeam::FromString(const char *String)
 		{
 		case 4:
 			m_Practice = false;
-		[[fallthrough]];
+			[[fallthrough]];
 		case 5:
 			break;
 		default:

--- a/src/game/server/save.cpp
+++ b/src/game/server/save.cpp
@@ -369,13 +369,13 @@ int CSaveTee::FromString(const char *String)
 	{
 	case 96:
 		m_NotEligibleForFinish = false;
-		// fall through
+	[[fallthrough]];
 	case 97:
 		m_HasTelegunGrenade = 0;
 		m_HasTelegunLaser = 0;
 		m_HasTelegunGun = 0;
 		FormatUuid(CalculateUuid("game-uuid-nonexistent@ddnet.tw"), m_aGameUuid, sizeof(m_aGameUuid));
-		// fall through
+	[[fallthrough]];
 	case 101:
 		m_HookedPlayer = -1;
 		m_NewHook = false;
@@ -386,13 +386,13 @@ int CSaveTee::FromString(const char *String)
 		m_InputFire = 0;
 		m_InputHook = 0;
 		m_ReloadTimer = 0;
-		// fall through
+	[[fallthrough]];
 	case 108:
 		m_TeeStarted = true;
-		// fall through
+	[[fallthrough]];
 	case 109:
 		m_LiveFreeze = 0;
-		// fall through
+	[[fallthrough]];
 	case 110:
 		return 0;
 	default:
@@ -613,7 +613,7 @@ int CSaveTeam::FromString(const char *String)
 		{
 		case 4:
 			m_Practice = false;
-			// fallthrough
+		[[fallthrough]];
 		case 5:
 			break;
 		default:


### PR DESCRIPTION
We could even add implicit fallthrough warning, but it is triggered in external json.c

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
