### PR TITLE
Remove useless typedef in c++

### DIFF
--- a/src/base/hash.h
+++ b/src/base/hash.h
@@ -1,7 +1,7 @@
 #ifndef BASE_HASH_H
 #define BASE_HASH_H
 
-#include <stddef.h>
+#include <cstddef> // size_t
 
 enum
 {
@@ -11,15 +11,15 @@ enum
 	MD5_MAXSTRSIZE = 2 * MD5_DIGEST_LENGTH + 1,
 };
 
-typedef struct
+struct SHA256_DIGEST
 {
 	unsigned char data[SHA256_DIGEST_LENGTH];
-} SHA256_DIGEST;
+};
 
-typedef struct
+struct MD5_DIGEST
 {
 	unsigned char data[MD5_DIGEST_LENGTH];
-} MD5_DIGEST;
+};
 
 SHA256_DIGEST sha256(const void *message, size_t message_len);
 void sha256_str(SHA256_DIGEST digest, char *str, size_t max_len);

--- a/src/base/hash_ctxt.h
+++ b/src/base/hash_ctxt.h
@@ -3,7 +3,7 @@
 
 #include "hash.h"
 #include "system.h"
-#include <stdint.h>
+#include <cstdint>
 
 #if defined(CONF_OPENSSL)
 #include <openssl/md5.h>
@@ -15,13 +15,13 @@
 #if defined(CONF_OPENSSL)
 // SHA256_CTX is defined in <openssl/sha.h>
 #else
-typedef struct
+struct SHA256_CTX
 {
 	uint64_t length;
 	uint32_t state[8];
 	uint32_t curlen;
 	unsigned char buf[64];
-} SHA256_CTX;
+};
 typedef md5_state_t MD5_CTX;
 #endif
 

--- a/src/engine/client/video.h
+++ b/src/engine/client/video.h
@@ -24,7 +24,7 @@ class IStorage;
 extern LOCK g_WriteLock;
 
 // a wrapper around a single output AVStream
-typedef struct OutputStream
+struct OutputStream
 {
 	AVStream *pSt = nullptr;
 	AVCodecContext *pEnc = nullptr;
@@ -39,7 +39,7 @@ typedef struct OutputStream
 
 	std::vector<struct SwsContext *> m_vpSwsCtxs;
 	std::vector<struct SwrContext *> m_vpSwrCtxs;
-} OutputStream;
+};
 
 class CVideo : public IVideo
 {

--- a/src/engine/shared/websockets.cpp
+++ b/src/engine/shared/websockets.cpp
@@ -28,13 +28,13 @@ typedef CStaticRingBuffer<unsigned char, 4 * 1024,
 	CRingBufferBase::FLAG_RECYCLE>
 	TSendBuffer;
 
-typedef struct
+struct websocket_chunk
 {
 	size_t size;
 	size_t read;
 	sockaddr_in addr;
 	unsigned char data[0];
-} websocket_chunk;
+};
 
 struct per_session_data
 {

--- a/src/engine/sqlite.h
+++ b/src/engine/sqlite.h
@@ -2,8 +2,8 @@
 #define ENGINE_SQLITE_H
 #include <memory>
 
-typedef struct sqlite3 sqlite3;
-typedef struct sqlite3_stmt sqlite3_stmt;
+struct sqlite3;
+struct sqlite3_stmt;
 class IConsole;
 class IStorage;
 

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -495,11 +495,11 @@ enum
 	DIRECTION_DOWN = 8,
 };
 
-typedef struct
+struct RECTi
 {
 	int x, y;
 	int w, h;
-} RECTi;
+};
 
 class CLayerTiles : public CLayer
 {


### PR DESCRIPTION
## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
