### PR TITLE
Fix heap-use-after-free in `CGameWorld::RemoveEntity`

### DIFF
--- a/src/game/client/prediction/entity.cpp
+++ b/src/game/client/prediction/entity.cpp
@@ -24,7 +24,8 @@ CEntity::CEntity(CGameWorld *pGameWorld, int ObjType, vec2 Pos, int ProximityRad
 	m_SnapTicks = -1;
 
 	// DDRace
-	m_pParent = 0;
+	m_pParent = nullptr;
+	m_pChild = nullptr;
 	m_DestroyTick = -1;
 	m_LastRenderTick = -1;
 }

--- a/src/game/client/prediction/entity.h
+++ b/src/game/client/prediction/entity.h
@@ -62,6 +62,7 @@ public:
 	int m_DestroyTick;
 	int m_LastRenderTick;
 	CEntity *m_pParent;
+	CEntity *m_pChild;
 	CEntity *NextEntity() { return m_pNextTypeEntity; }
 	int ID() { return m_ID; }
 	void Keep()

--- a/src/game/client/prediction/gameworld.cpp
+++ b/src/game/client/prediction/gameworld.cpp
@@ -559,9 +559,7 @@ void CGameWorld::CopyWorld(CGameWorld *pFrom)
 	m_Teams = pFrom->m_Teams;
 	m_Core.m_vSwitchers = pFrom->m_Core.m_vSwitchers;
 	// delete the previous entities
-	for(auto &pFirstEntityType : m_apFirstEntityTypes)
-		while(pFirstEntityType)
-			delete pFirstEntityType;
+	Clear();
 	for(int i = 0; i < MAX_CLIENTS; i++)
 	{
 		m_apCharacters[i] = 0;

--- a/src/game/client/prediction/gameworld.cpp
+++ b/src/game/client/prediction/gameworld.cpp
@@ -30,10 +30,7 @@ CGameWorld::CGameWorld()
 
 CGameWorld::~CGameWorld()
 {
-	// delete all entities
-	for(auto &pFirstEntityType : m_apFirstEntityTypes)
-		while(pFirstEntityType)
-			delete pFirstEntityType;
+	Clear();
 	if(m_pChild && m_pChild->m_pParent == this)
 	{
 		OnModified();
@@ -143,9 +140,18 @@ void CGameWorld::RemoveEntity(CEntity *pEnt)
 	pEnt->m_pNextTypeEntity = 0;
 	pEnt->m_pPrevTypeEntity = 0;
 
-	if(m_IsValidCopy && m_pParent && m_pParent->m_pChild == this && pEnt->m_pParent)
-		pEnt->m_pParent->m_DestroyTick = GameTick();
-	pEnt->m_pParent = 0;
+	if(pEnt->m_pParent)
+	{
+		if(m_IsValidCopy && m_pParent && m_pParent->m_pChild == this)
+			pEnt->m_pParent->m_DestroyTick = GameTick();
+		pEnt->m_pParent->m_pChild = nullptr;
+		pEnt->m_pParent = nullptr;
+	}
+	if(pEnt->m_pChild)
+	{
+		pEnt->m_pChild->m_pParent = nullptr;
+		pEnt->m_pChild = nullptr;
+	}
 }
 
 void CGameWorld::RemoveCharacter(CCharacter *pChar)
@@ -578,6 +584,7 @@ void CGameWorld::CopyWorld(CGameWorld *pFrom)
 			if(pCopy)
 			{
 				pCopy->m_pParent = pEnt;
+				pEnt->m_pChild = pCopy;
 				this->InsertEntity(pCopy);
 			}
 		}


### PR DESCRIPTION
Entities have a pointer to their parent entity. If the parent entity is freed first, then freeing the child will cause access to the already freed parent (at `pEnt->m_pParent->m_DestroyTick = GameTick();`).

This is fixed by adding a child pointer and clearing the child and parent pointers when either child or parent is freed.

I can consistently get the crash in `CGameWorld::RemoveEntity` with the integration test at fbfd938f326390048368bc169442c5e5ba2e42e5 (10/10 runs crashed). With these changes I get no crashes anymore (0/10 runs crashed).

Closes #5478. Closes #4317. Closes #4328. Closes #4390. Not sure about #3179.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [X] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
