### PR TITLE
Update menu music state when the config variables change via console, various refactoring

### DIFF
--- a/src/engine/client/sound.cpp
+++ b/src/engine/client/sound.cpp
@@ -288,7 +288,7 @@ int CSound::Init()
 
 	if(SDL_InitSubSystem(SDL_INIT_AUDIO) < 0)
 	{
-		dbg_msg("gfx", "unable to init SDL audio: %s", SDL_GetError());
+		dbg_msg("client/sound", "unable to init SDL audio: %s", SDL_GetError());
 		return -1;
 	}
 

--- a/src/engine/client/sound.cpp
+++ b/src/engine/client/sound.cpp
@@ -966,10 +966,8 @@ void CSound::StopVoice(CVoiceHandle Voice)
 	if(m_aVoices[VoiceID].m_Age != Voice.Age())
 		return;
 
-	{
-		m_aVoices[VoiceID].m_pSample = 0;
-		m_aVoices[VoiceID].m_Age++;
-	}
+	m_aVoices[VoiceID].m_pSample = 0;
+	m_aVoices[VoiceID].m_Age++;
 }
 
 bool CSound::IsPlaying(int SampleID)

--- a/src/engine/client/sound.cpp
+++ b/src/engine/client/sound.cpp
@@ -533,7 +533,12 @@ int CSound::DecodeWV(int SampleID, const void *pData, unsigned DataSize)
 		}
 
 		int *pBuffer = (int *)calloc((size_t)NumSamples * NumChannels, sizeof(int));
-		WavpackUnpackSamples(pContext, pBuffer, NumSamples); // TODO: check return value
+		if(!WavpackUnpackSamples(pContext, pBuffer, NumSamples))
+		{
+			free(pBuffer);
+			dbg_msg("sound/wv", "WavpackUnpackSamples failed. NumSamples=%d, NumChannels=%d", NumSamples, NumChannels);
+			return -1;
+		}
 		int *pSrc = pBuffer;
 
 		pSample->m_pData = (short *)calloc((size_t)NumSamples * NumChannels, sizeof(short));

--- a/src/engine/client/sound.cpp
+++ b/src/engine/client/sound.cpp
@@ -277,7 +277,7 @@ static void SdlCallback(void *pUnused, Uint8 *pStream, int Len)
 
 int CSound::Init()
 {
-	m_SoundEnabled = 0;
+	m_SoundEnabled = false;
 	m_pGraphics = Kernel()->RequestInterface<IEngineGraphics>();
 	m_pStorage = Kernel()->RequestInterface<IStorage>();
 
@@ -321,7 +321,7 @@ int CSound::Init()
 
 	SDL_PauseAudioDevice(m_Device, 0);
 
-	m_SoundEnabled = 1;
+	m_SoundEnabled = true;
 	Update(); // update the volume
 	return 0;
 }

--- a/src/engine/client/sound.cpp
+++ b/src/engine/client/sound.cpp
@@ -864,11 +864,11 @@ ISound::CVoiceHandle CSound::Play(int ChannelID, int SampleID, int Flags, float 
 	int VoiceID = -1;
 	for(int i = 0; i < NUM_VOICES; i++)
 	{
-		int id = (m_NextVoice + i) % NUM_VOICES;
-		if(!m_aVoices[id].m_pSample)
+		int NextID = (m_NextVoice + i) % NUM_VOICES;
+		if(!m_aVoices[NextID].m_pSample)
 		{
-			VoiceID = id;
-			m_NextVoice = id + 1;
+			VoiceID = NextID;
+			m_NextVoice = NextID + 1;
 			break;
 		}
 	}

--- a/src/engine/client/sound.cpp
+++ b/src/engine/client/sound.cpp
@@ -972,6 +972,13 @@ void CSound::StopVoice(CVoiceHandle Voice)
 	}
 }
 
+bool CSound::IsPlaying(int SampleID)
+{
+	std::unique_lock<std::mutex> Lock(m_SoundLock);
+	const CSample *pSample = &m_aSamples[SampleID];
+	return std::any_of(std::begin(m_aVoices), std::end(m_aVoices), [pSample](const auto &Voice) { return Voice.m_pSample == pSample; });
+}
+
 ISoundMixFunc CSound::GetSoundMixFunc()
 {
 	return Mix;

--- a/src/engine/client/sound.h
+++ b/src/engine/client/sound.h
@@ -59,6 +59,7 @@ public:
 	void Stop(int SampleID) override;
 	void StopAll() override;
 	void StopVoice(CVoiceHandle Voice) override;
+	bool IsPlaying(int SampleID) override;
 
 	ISoundMixFunc GetSoundMixFunc() override;
 	void PauseAudioDevice() override;

--- a/src/engine/client/sound.h
+++ b/src/engine/client/sound.h
@@ -16,14 +16,9 @@ class CSound : public IEngineSound
 	bool m_SoundEnabled;
 	SDL_AudioDeviceID m_Device;
 
-public:
 	IEngineGraphics *m_pGraphics;
 	IStorage *m_pStorage;
 
-	int Init() override;
-
-	int Update() override;
-	int Shutdown() override;
 	int AllocID();
 
 	static void RateConvert(int SampleID);
@@ -31,6 +26,11 @@ public:
 	// TODO: Refactor: clean this mess up
 	static int DecodeWV(int SampleID, const void *pData, unsigned DataSize);
 	static int DecodeOpus(int SampleID, const void *pData, unsigned DataSize);
+
+public:
+	int Init() override;
+	int Update() override;
+	int Shutdown() override;
 
 	bool IsSoundEnabled() override { return m_SoundEnabled; }
 

--- a/src/engine/client/sound.h
+++ b/src/engine/client/sound.h
@@ -13,7 +13,7 @@ class IStorage;
 
 class CSound : public IEngineSound
 {
-	int m_SoundEnabled;
+	bool m_SoundEnabled;
 	SDL_AudioDeviceID m_Device;
 
 public:
@@ -32,7 +32,7 @@ public:
 	static int DecodeWV(int SampleID, const void *pData, unsigned DataSize);
 	static int DecodeOpus(int SampleID, const void *pData, unsigned DataSize);
 
-	bool IsSoundEnabled() override { return m_SoundEnabled != 0; }
+	bool IsSoundEnabled() override { return m_SoundEnabled; }
 
 	int LoadWV(const char *pFilename) override;
 	int LoadWVFromMem(const void *pData, unsigned DataSize, bool FromEditor) override;

--- a/src/engine/sound.h
+++ b/src/engine/sound.h
@@ -87,6 +87,7 @@ public:
 	virtual void Stop(int SampleID) = 0;
 	virtual void StopAll() = 0;
 	virtual void StopVoice(CVoiceHandle Voice) = 0;
+	virtual bool IsPlaying(int SampleID) = 0;
 
 	virtual ISoundMixFunc GetSoundMixFunc() = 0;
 	// useful for thread synchronization

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -492,6 +492,8 @@ protected:
 	//void render_loading(float percent);
 	int RenderMenubar(CUIRect r);
 	void RenderNews(CUIRect MainView);
+	static void ConchainUpdateMusicState(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
+	void UpdateMusicState();
 
 	// found in menus_demo.cpp
 	static bool DemoFilterChat(const void *pData, int Size, void *pUser);

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -1775,13 +1775,7 @@ void CMenus::RenderSettingsSound(CUIRect MainView)
 	if(DoButton_CheckBox(&g_Config.m_SndEnable, Localize("Use sounds"), g_Config.m_SndEnable, &Button))
 	{
 		g_Config.m_SndEnable ^= 1;
-		if(g_Config.m_SndEnable)
-		{
-			if(g_Config.m_SndMusic && Client()->State() == IClient::STATE_OFFLINE)
-				m_pClient->m_Sounds.Play(CSounds::CHN_MUSIC, SOUND_MENU, 1.0f);
-		}
-		else
-			m_pClient->m_Sounds.Stop(SOUND_MENU);
+		UpdateMusicState();
 		m_NeedRestartSound = g_Config.m_SndEnable && (!s_SndEnable || s_SndRate != g_Config.m_SndRate);
 	}
 
@@ -1792,13 +1786,7 @@ void CMenus::RenderSettingsSound(CUIRect MainView)
 	if(DoButton_CheckBox(&g_Config.m_SndMusic, Localize("Play background music"), g_Config.m_SndMusic, &Button))
 	{
 		g_Config.m_SndMusic ^= 1;
-		if(Client()->State() == IClient::STATE_OFFLINE)
-		{
-			if(g_Config.m_SndMusic)
-				m_pClient->m_Sounds.Play(CSounds::CHN_MUSIC, SOUND_MENU, 1.0f);
-			else
-				m_pClient->m_Sounds.Stop(SOUND_MENU);
-		}
+		UpdateMusicState();
 	}
 
 	MainView.HSplitTop(20.0f, &Button, &MainView);

--- a/src/game/client/components/sounds.cpp
+++ b/src/game/client/components/sounds.cpp
@@ -228,10 +228,10 @@ void CSounds::Stop(int SetId)
 	if(m_WaitForSoundJob || SetId < 0 || SetId >= g_pData->m_NumSounds)
 		return;
 
-	CDataSoundset *pSet = &g_pData->m_aSounds[SetId];
-
+	const CDataSoundset *pSet = &g_pData->m_aSounds[SetId];
 	for(int i = 0; i < pSet->m_NumSounds; i++)
-		Sound()->Stop(pSet->m_aSounds[i].m_Id);
+		if(pSet->m_aSounds[i].m_Id != -1)
+			Sound()->Stop(pSet->m_aSounds[i].m_Id);
 }
 
 bool CSounds::IsPlaying(int SetId)

--- a/src/game/client/components/sounds.cpp
+++ b/src/game/client/components/sounds.cpp
@@ -234,6 +234,18 @@ void CSounds::Stop(int SetId)
 		Sound()->Stop(pSet->m_aSounds[i].m_Id);
 }
 
+bool CSounds::IsPlaying(int SetId)
+{
+	if(m_WaitForSoundJob || SetId < 0 || SetId >= g_pData->m_NumSounds)
+		return false;
+
+	const CDataSoundset *pSet = &g_pData->m_aSounds[SetId];
+	for(int i = 0; i < pSet->m_NumSounds; i++)
+		if(pSet->m_aSounds[i].m_Id != -1 && Sound()->IsPlaying(pSet->m_aSounds[i].m_Id))
+			return true;
+	return false;
+}
+
 ISound::CVoiceHandle CSounds::PlaySample(int Channel, int SampleId, float Vol, int Flags)
 {
 	if((Channel == CHN_MUSIC && !g_Config.m_SndMusic) || SampleId == -1)

--- a/src/game/client/components/sounds.h
+++ b/src/game/client/components/sounds.h
@@ -64,6 +64,7 @@ public:
 	void PlayAt(int Channel, int SetId, float Vol, vec2 Pos);
 	void PlayAndRecord(int Channel, int SetId, float Vol, vec2 Pos);
 	void Stop(int SetId);
+	bool IsPlaying(int SetId);
 
 	ISound::CVoiceHandle PlaySample(int Channel, int SampleId, float Vol, int Flags = 0);
 	ISound::CVoiceHandle PlaySampleAt(int Channel, int SampleId, float Vol, vec2 Pos, int Flags = 0);


### PR DESCRIPTION
Also update the background music when `snd_enable` or `snd_enable_music` change via console or bind. Closes #2911.

For this purpose, add `IsPlaying` method to engine sound and client sound component to check whether a specific sound sample is already playing.

Various refactoring in engine sound.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
