### PR TITLE
Warn about pnglite-incompatible PNGs on load

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -2501,6 +2501,8 @@ void CClient::LoadDDNetInfo()
 			log_debug("info", "got global tcp ip address: %s", (const char *)ConnectingIp);
 		}
 	}
+	const json_value &WarnPngliteIncompatibleImages = DDNetInfo["warn-pnglite-incompatible-images"];
+	Graphics()->WarnPngliteIncompatibleImages(WarnPngliteIncompatibleImages.type == json_boolean && (bool)WarnPngliteIncompatibleImages);
 }
 
 int CClient::ConnectNetTypes() const
@@ -3125,6 +3127,10 @@ void CClient::Run()
 		m_pEditor->Save(arg);
 	return;*/
 
+	m_ServerBrowser.OnInit();
+	// loads the existing ddnet info file if it exists
+	LoadDDNetInfo();
+
 	// load data
 	if(!LoadData())
 		return;
@@ -3135,7 +3141,6 @@ void CClient::Run()
 	}
 
 	GameClient()->OnInit();
-	m_ServerBrowser.OnInit();
 
 	m_pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "client", "version " GAME_RELEASE_VERSION " on " CONF_PLATFORM_STRING " " CONF_ARCH_STRING, ColorRGBA(0.7f, 0.7f, 1, 1.0f));
 	if(GIT_SHORTREV_HASH)
@@ -3168,9 +3173,7 @@ void CClient::Run()
 	InitChecksum();
 	m_pConsole->InitChecksum(ChecksumData());
 
-	// loads the existing ddnet info file if it exists
-	LoadDDNetInfo();
-	// but still request the new one from server
+	// request the new ddnet info from server if already past the welcome dialog
 	if(g_Config.m_ClShowWelcome)
 		g_Config.m_ClShowWelcome = 0;
 	else

--- a/src/engine/client/graphics_threaded.h
+++ b/src/engine/client/graphics_threaded.h
@@ -824,6 +824,8 @@ class CGraphics_Threaded : public IEngineGraphics
 
 	std::vector<uint8_t> m_vSpriteHelper;
 
+	bool m_WarnPngliteIncompatibleImages = false;
+
 	std::vector<SWarning> m_vWarnings;
 
 	// is a non full windowed (in a sense that the viewport won't include the whole window),
@@ -1249,6 +1251,7 @@ public:
 	int GetNumScreens() const override;
 	void Minimize() override;
 	void Maximize() override;
+	void WarnPngliteIncompatibleImages(bool Warn) override;
 	void SetWindowParams(int FullscreenMode, bool IsBorderless, bool AllowResizing) override;
 	bool SetWindowScreen(int Index) override;
 	void Move(int x, int y) override;

--- a/src/engine/client/graphics_threaded.h
+++ b/src/engine/client/graphics_threaded.h
@@ -7,8 +7,8 @@
 #include <cstddef>
 #include <vector>
 
-#define CMD_BUFFER_DATA_BUFFER_SIZE 1024 * 1024 * 2
-#define CMD_BUFFER_CMD_BUFFER_SIZE 1024 * 256
+constexpr int CMD_BUFFER_DATA_BUFFER_SIZE = 1024 * 1024 * 2;
+constexpr int CMD_BUFFER_CMD_BUFFER_SIZE = 1024 * 256;
 
 class CCommandBuffer
 {

--- a/src/engine/gfx/image_loader.cpp
+++ b/src/engine/gfx/image_loader.cpp
@@ -26,8 +26,8 @@ static void LibPNGWarning(png_structp png_ptr, png_const_charp warning_msg)
 
 static bool FileMatchesImageType(SImageByteBuffer &ByteLoader)
 {
-	if(ByteLoader.m_pLoadedImageBytes->size() >= 8)
-		return png_sig_cmp((png_bytep)ByteLoader.m_pLoadedImageBytes->data(), 0, 8) == 0;
+	if(ByteLoader.m_pvLoadedImageBytes->size() >= 8)
+		return png_sig_cmp((png_bytep)ByteLoader.m_pvLoadedImageBytes->data(), 0, 8) == 0;
 	return false;
 }
 
@@ -37,9 +37,9 @@ static void ReadDataFromLoadedBytes(png_structp pPNGStruct, png_bytep pOutBytes,
 
 	SImageByteBuffer *pByteLoader = (SImageByteBuffer *)pIO_Ptr;
 
-	if(pByteLoader->m_pLoadedImageBytes->size() >= pByteLoader->m_LoadOffset + (size_t)ByteCountToRead)
+	if(pByteLoader->m_pvLoadedImageBytes->size() >= pByteLoader->m_LoadOffset + (size_t)ByteCountToRead)
 	{
-		mem_copy(pOutBytes, &(*pByteLoader->m_pLoadedImageBytes)[pByteLoader->m_LoadOffset], (size_t)ByteCountToRead);
+		mem_copy(pOutBytes, &(*pByteLoader->m_pvLoadedImageBytes)[pByteLoader->m_LoadOffset], (size_t)ByteCountToRead);
 
 		pByteLoader->m_LoadOffset += (size_t)ByteCountToRead;
 	}
@@ -254,9 +254,9 @@ static void WriteDataFromLoadedBytes(png_structp pPNGStruct, png_bytep pOutBytes
 		SImageByteBuffer *pByteLoader = (SImageByteBuffer *)pIO_Ptr;
 
 		size_t NewSize = pByteLoader->m_LoadOffset + (size_t)ByteCountToWrite;
-		pByteLoader->m_pLoadedImageBytes->resize(NewSize);
+		pByteLoader->m_pvLoadedImageBytes->resize(NewSize);
 
-		mem_copy(&(*pByteLoader->m_pLoadedImageBytes)[pByteLoader->m_LoadOffset], pOutBytes, (size_t)ByteCountToWrite);
+		mem_copy(&(*pByteLoader->m_pvLoadedImageBytes)[pByteLoader->m_LoadOffset], pOutBytes, (size_t)ByteCountToWrite);
 		pByteLoader->m_LoadOffset = NewSize;
 	}
 }
@@ -295,7 +295,7 @@ bool SavePNG(EImageFormat ImageFormat, const uint8_t *pRawBuffer, SImageByteBuff
 	}
 
 	WrittenBytes.m_LoadOffset = 0;
-	WrittenBytes.m_pLoadedImageBytes->clear();
+	WrittenBytes.m_pvLoadedImageBytes->clear();
 
 	png_set_write_fn(pPNGStruct, (png_bytep)&WrittenBytes, WriteDataFromLoadedBytes, FlushPNGWrite);
 

--- a/src/engine/gfx/image_loader.h
+++ b/src/engine/gfx/image_loader.h
@@ -22,7 +22,16 @@ struct SImageByteBuffer
 	int m_Err;
 };
 
-bool LoadPNG(SImageByteBuffer &ByteLoader, const char *pFileName, int &Width, int &Height, uint8_t *&pImageBuff, EImageFormat &ImageFormat);
+enum
+{
+	PNGLITE_COLOR_TYPE = 1 << 0,
+	PNGLITE_BIT_DEPTH = 1 << 1,
+	PNGLITE_INTERLACE_TYPE = 1 << 2,
+	PNGLITE_COMPRESSION_TYPE = 1 << 3,
+	PNGLITE_FILTER_TYPE = 1 << 4,
+};
+
+bool LoadPNG(SImageByteBuffer &ByteLoader, const char *pFileName, int &PngliteIncompatible, int &Width, int &Height, uint8_t *&pImageBuff, EImageFormat &ImageFormat);
 bool SavePNG(EImageFormat ImageFormat, const uint8_t *pRawBuffer, SImageByteBuffer &WrittenBytes, int Width, int Height);
 
 #endif // ENGINE_GFX_IMAGE_LOADER_H

--- a/src/engine/gfx/image_loader.h
+++ b/src/engine/gfx/image_loader.h
@@ -15,10 +15,10 @@ enum EImageFormat
 typedef std::vector<uint8_t> TImageByteBuffer;
 struct SImageByteBuffer
 {
-	SImageByteBuffer(TImageByteBuffer *pBuff) :
-		m_LoadOffset(0), m_pLoadedImageBytes(pBuff), m_Err(0) {}
+	SImageByteBuffer(std::vector<uint8_t> *pvBuff) :
+		m_LoadOffset(0), m_pvLoadedImageBytes(pvBuff), m_Err(0) {}
 	size_t m_LoadOffset;
-	TImageByteBuffer *m_pLoadedImageBytes;
+	std::vector<uint8_t> *m_pvLoadedImageBytes;
 	int m_Err;
 };
 

--- a/src/engine/graphics.h
+++ b/src/engine/graphics.h
@@ -251,6 +251,7 @@ public:
 	int WindowWidth() const { return m_ScreenWidth / m_ScreenHiDPIScale; }
 	int WindowHeight() const { return m_ScreenHeight / m_ScreenHiDPIScale; }
 
+	virtual void WarnPngliteIncompatibleImages(bool Warn) = 0;
 	virtual void SetWindowParams(int FullscreenMode, bool IsBorderless, bool AllowResizing) = 0;
 	virtual bool SetWindowScreen(int Index) = 0;
 	virtual bool SetVSync(bool State) = 0;

--- a/src/tools/dilate.cpp
+++ b/src/tools/dilate.cpp
@@ -26,7 +26,8 @@ int DilateFile(const char *pFilename)
 
 		uint8_t *pImgBuffer = NULL;
 		EImageFormat ImageFormat;
-		if(LoadPNG(ImageByteBuffer, pFilename, Img.m_Width, Img.m_Height, pImgBuffer, ImageFormat))
+		int PngliteIncompatible;
+		if(LoadPNG(ImageByteBuffer, pFilename, PngliteIncompatible, Img.m_Width, Img.m_Height, pImgBuffer, ImageFormat))
 		{
 			if(ImageFormat != IMAGE_FORMAT_RGBA)
 			{

--- a/src/tools/map_convert_07.cpp
+++ b/src/tools/map_convert_07.cpp
@@ -43,7 +43,8 @@ int LoadPNG(CImageInfo *pImg, const char *pFilename)
 
 		uint8_t *pImgBuffer = NULL;
 		EImageFormat ImageFormat;
-		if(LoadPNG(ImageByteBuffer, pFilename, pImg->m_Width, pImg->m_Height, pImgBuffer, ImageFormat))
+		int PngliteIncompatible;
+		if(LoadPNG(ImageByteBuffer, pFilename, PngliteIncompatible, pImg->m_Width, pImg->m_Height, pImgBuffer, ImageFormat))
 		{
 			pImg->m_pData = pImgBuffer;
 

--- a/src/tools/map_replace_image.cpp
+++ b/src/tools/map_replace_image.cpp
@@ -41,7 +41,8 @@ int LoadPNG(CImageInfo *pImg, const char *pFilename)
 
 		uint8_t *pImgBuffer = NULL;
 		EImageFormat ImageFormat;
-		if(LoadPNG(ImageByteBuffer, pFilename, pImg->m_Width, pImg->m_Height, pImgBuffer, ImageFormat))
+		int PngliteIncompatible;
+		if(LoadPNG(ImageByteBuffer, pFilename, PngliteIncompatible, pImg->m_Width, pImg->m_Height, pImgBuffer, ImageFormat))
 		{
 			if((ImageFormat == IMAGE_FORMAT_RGBA || ImageFormat == IMAGE_FORMAT_RGB) && pImg->m_Width <= (2 << 13) && pImg->m_Height <= (2 << 13))
 			{


### PR DESCRIPTION
This allows a larger range of PNGs to be loaded while still maintaining
backward compatibility with older clients by annoying the user.

This warning can be enabled by the `warn-pnglite-incompatible-images`
key in the https://info2.ddnet.tw/info JSON, if the key is not there or
the JSON hasn't been obtained yet, the warning is disabled. Since the
JSON is cached across restarts, it'll be effective for initially loaded
images from the second start.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
