### PR TITLE
Fix unsafe defines

### DIFF
--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -385,8 +385,8 @@ int io_sync(IOHANDLE io)
 #endif
 }
 
-#define ASYNC_BUFSIZE 8 * 1024
-#define ASYNC_LOCAL_BUFSIZE 64 * 1024
+#define ASYNC_BUFSIZE (8 * 1024)
+#define ASYNC_LOCAL_BUFSIZE (64 * 1024)
 
 // TODO: Use Thread Safety Analysis when this file is converted to C++
 struct ASYNCIO

--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -20,7 +20,7 @@
 
 // support older SDL version (pre 2.0.6)
 #ifndef SDL_JOYSTICK_AXIS_MIN
-#define SDL_JOYSTICK_AXIS_MIN -32768
+#define SDL_JOYSTICK_AXIS_MIN (-32768)
 #endif
 #ifndef SDL_JOYSTICK_AXIS_MAX
 #define SDL_JOYSTICK_AXIS_MAX 32767

--- a/src/engine/client/text.cpp
+++ b/src/engine/client/text.cpp
@@ -84,7 +84,7 @@ struct CFontSizeData
 
 #define MIN_FONT_SIZE 6
 #define MAX_FONT_SIZE 128
-#define NUM_FONT_SIZES MAX_FONT_SIZE - MIN_FONT_SIZE + 1
+#define NUM_FONT_SIZES (MAX_FONT_SIZE - MIN_FONT_SIZE + 1)
 
 class CFont
 {


### PR DESCRIPTION
These are unsafe define that should be parenthesized due to operator precedency that can change operation order in expression such as:
```c++
#define ABCD 1 + 2
int foo = 36/ABCD; // foo is actually 38 and not 12
```

I didn't change engine/client/graphics_threaded/h as it is included in https://github.com/ddnet/ddnet/pull/5520

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
