### PR TITLE
Only apply size and color if changed, when editing multiple layers

### DIFF
--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -586,10 +586,10 @@ public:
 
 	struct SCommonPropState
 	{
-		bool Modified = false;
-		int Width = -1;
-		int Height = -1;
-		int Color = 0;
+		bool m_Modified = false;
+		int m_Width = -1;
+		int m_Height = -1;
+		int m_Color = 0;
 	};
 	static int RenderCommonProperties(SCommonPropState &State, CEditor *pEditor, CUIRect *pToolbox, std::vector<CLayerTiles *> &vpLayers);
 

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -586,7 +586,12 @@ public:
 
 	struct SCommonPropState
 	{
-		bool m_Modified = false;
+		enum
+		{
+			MODIFIED_SIZE = 1 << 0,
+			MODIFIED_COLOR = 1 << 1,
+		};
+		int m_Modified = 0;
 		int m_Width = -1;
 		int m_Height = -1;
 		int m_Color = 0;

--- a/src/game/editor/layer_tiles.cpp
+++ b/src/game/editor/layer_tiles.cpp
@@ -920,7 +920,7 @@ int CLayerTiles::RenderProperties(CUIRect *pToolBox)
 
 int CLayerTiles::RenderCommonProperties(SCommonPropState &State, CEditor *pEditor, CUIRect *pToolbox, std::vector<CLayerTiles *> &vpLayers)
 {
-	if(State.Modified)
+	if(State.m_Modified)
 	{
 		CUIRect Commit;
 		pToolbox->HSplitBottom(20.0f, pToolbox, &Commit);
@@ -930,26 +930,26 @@ int CLayerTiles::RenderCommonProperties(SCommonPropState &State, CEditor *pEdito
 			dbg_msg("editor", "applying changes");
 			for(auto &pLayer : vpLayers)
 			{
-				pLayer->Resize(State.Width, State.Height);
+				pLayer->Resize(State.m_Width, State.m_Height);
 
-				pLayer->m_Color.r = (State.Color >> 24) & 0xff;
-				pLayer->m_Color.g = (State.Color >> 16) & 0xff;
-				pLayer->m_Color.b = (State.Color >> 8) & 0xff;
-				pLayer->m_Color.a = State.Color & 0xff;
+				pLayer->m_Color.r = (State.m_Color >> 24) & 0xff;
+				pLayer->m_Color.g = (State.m_Color >> 16) & 0xff;
+				pLayer->m_Color.b = (State.m_Color >> 8) & 0xff;
+				pLayer->m_Color.a = State.m_Color & 0xff;
 
 				pLayer->FlagModified(0, 0, pLayer->m_Width, pLayer->m_Height);
 			}
-			State.Modified = false;
+			State.m_Modified = false;
 		}
 	}
 	else
 	{
 		for(auto &pLayer : vpLayers)
 		{
-			if(pLayer->m_Width > State.Width)
-				State.Width = pLayer->m_Width;
-			if(pLayer->m_Height > State.Height)
-				State.Height = pLayer->m_Height;
+			if(pLayer->m_Width > State.m_Width)
+				State.m_Width = pLayer->m_Width;
+			if(pLayer->m_Height > State.m_Height)
+				State.m_Height = pLayer->m_Height;
 		}
 	}
 
@@ -977,11 +977,11 @@ int CLayerTiles::RenderCommonProperties(SCommonPropState &State, CEditor *pEdito
 	};
 
 	CProperty aProps[] = {
-		{"Width", State.Width, PROPTYPE_INT_SCROLL, 1, 100000},
-		{"Height", State.Height, PROPTYPE_INT_SCROLL, 1, 100000},
+		{"Width", State.m_Width, PROPTYPE_INT_SCROLL, 1, 100000},
+		{"Height", State.m_Height, PROPTYPE_INT_SCROLL, 1, 100000},
 		{"Shift", 0, PROPTYPE_SHIFT, 0, 0},
 		{"Shift by", pEditor->m_ShiftBy, PROPTYPE_INT_SCROLL, 1, 100000},
-		{"Color", State.Color, PROPTYPE_COLOR, 0, 0},
+		{"Color", State.m_Color, PROPTYPE_COLOR, 0, 0},
 		{nullptr},
 	};
 
@@ -997,7 +997,7 @@ int CLayerTiles::RenderCommonProperties(SCommonPropState &State, CEditor *pEdito
 			pEditor->m_PopupEventActivated = true;
 			pEditor->m_LargeLayerWasWarned = true;
 		}
-		State.Width = NewVal;
+		State.m_Width = NewVal;
 	}
 	else if(Prop == PROP_HEIGHT && NewVal > 1)
 	{
@@ -1007,7 +1007,7 @@ int CLayerTiles::RenderCommonProperties(SCommonPropState &State, CEditor *pEdito
 			pEditor->m_PopupEventActivated = true;
 			pEditor->m_LargeLayerWasWarned = true;
 		}
-		State.Height = NewVal;
+		State.m_Height = NewVal;
 	}
 	else if(Prop == PROP_SHIFT)
 	{
@@ -1018,12 +1018,12 @@ int CLayerTiles::RenderCommonProperties(SCommonPropState &State, CEditor *pEdito
 		pEditor->m_ShiftBy = NewVal;
 	else if(Prop == PROP_COLOR)
 	{
-		State.Color = NewVal;
+		State.m_Color = NewVal;
 	}
 
 	if(Prop != -1 && Prop != PROP_SHIFT)
 	{
-		State.Modified = true;
+		State.m_Modified = true;
 	}
 
 	return 0;

--- a/src/game/editor/layer_tiles.cpp
+++ b/src/game/editor/layer_tiles.cpp
@@ -930,16 +930,20 @@ int CLayerTiles::RenderCommonProperties(SCommonPropState &State, CEditor *pEdito
 			dbg_msg("editor", "applying changes");
 			for(auto &pLayer : vpLayers)
 			{
-				pLayer->Resize(State.m_Width, State.m_Height);
+				if((State.m_Modified & SCommonPropState::MODIFIED_SIZE) != 0)
+					pLayer->Resize(State.m_Width, State.m_Height);
 
-				pLayer->m_Color.r = (State.m_Color >> 24) & 0xff;
-				pLayer->m_Color.g = (State.m_Color >> 16) & 0xff;
-				pLayer->m_Color.b = (State.m_Color >> 8) & 0xff;
-				pLayer->m_Color.a = State.m_Color & 0xff;
+				if((State.m_Modified & SCommonPropState::MODIFIED_COLOR) != 0)
+				{
+					pLayer->m_Color.r = (State.m_Color >> 24) & 0xff;
+					pLayer->m_Color.g = (State.m_Color >> 16) & 0xff;
+					pLayer->m_Color.b = (State.m_Color >> 8) & 0xff;
+					pLayer->m_Color.a = State.m_Color & 0xff;
+				}
 
 				pLayer->FlagModified(0, 0, pLayer->m_Width, pLayer->m_Height);
 			}
-			State.m_Modified = false;
+			State.m_Modified = 0;
 		}
 	}
 	else
@@ -1021,10 +1025,10 @@ int CLayerTiles::RenderCommonProperties(SCommonPropState &State, CEditor *pEdito
 		State.m_Color = NewVal;
 	}
 
-	if(Prop != -1 && Prop != PROP_SHIFT)
-	{
-		State.m_Modified = true;
-	}
+	if(Prop == PROP_WIDTH || Prop == PROP_HEIGHT)
+		State.m_Modified |= SCommonPropState::MODIFIED_SIZE;
+	else if(Prop == PROP_COLOR)
+		State.m_Modified |= SCommonPropState::MODIFIED_COLOR;
 
 	return 0;
 }


### PR DESCRIPTION
To prevent the color of all layers from being reset to zero when changing just the size.

Closes #3734.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
