### PR TITLE
Sort CI logs before diff to fix race condition

### DIFF
--- a/scripts/integration_test.sh
+++ b/scripts/integration_test.sh
@@ -285,7 +285,7 @@ do
 		touch fail_logs.txt
 		continue
 	fi
-	logdiff="$(diff -u "$logfile" "stdout_$(basename "$logfile" .log).txt")"
+	logdiff="$(diff -u <(sort "$logfile") <(sort "stdout_$(basename "$logfile" .log).txt"))"
 	if [ "$logdiff" != "" ]
 	then
 		echo "[-] Error: logfile '$logfile' differs from stdout"


### PR DESCRIPTION
Logging to file and to stdout might order differently
due to multiple threads

Should fix issues like these

```
[-] Error: logfile 'server.log' differs from stdout
--- server.log	2022-06-28 13:46:38.703149594 +0000
+++ stdout_server.txt	2022-06-28 13:46:38.703149594 +0000
@@ -150,8 +150,8 @@
 [2022-06-28 13:46:30][sql]: SQLite statement: INSERT OR IGNORE INTO record_race(	Map, Name, Timestamp, Time, Server, 	cp1, cp2, cp3, cp4, cp5, cp6, cp7, cp8, cp9, cp10, cp11, cp12, cp13, 	cp14, cp15, cp16, cp17, cp18, cp19, cp20, cp21, cp22, cp23, cp24, cp25, 	GameID, DDNet7) VALUES ('coverage', 'client1', DATETIME('2022-06-28 13:46:30', 'utc'), 1.18, 'UNK', 	0.44, 0.52, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 	0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 	0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 	'41c154ac-326f-41b6-bc30-11534f5026ec', 0)
 [2022-06-28 13:46:30][sql]: save score done on write database 0
 [2022-06-28 13:46:31][server]: player has entered the game. ClientID=1 addr=<{[::1]:31439}> sixup=0
-[2022-06-28 13:46:31][sql]: load player data done on read database 0
 [2022-06-28 13:46:31][chat]: *** 'client2' entered and joined the game
+[2022-06-28 13:46:31][sql]: load player data done on read database 0
 [2022-06-28 13:46:31][ddnet]: cid=1 version=16020
 [2022-06-28 13:46:33][chat]: 0:-2:client1: hello world
 [2022-06-28 13:46:33][server]: ClientID=0 authed with key=default_admin (admin)
 ```