### PR TITLE
Print font name instead of address in log message, `pFont` -> `font`

### DIFF
--- a/src/engine/client/text.cpp
+++ b/src/engine/client/text.cpp
@@ -719,7 +719,7 @@ public:
 			return NULL;
 		}
 
-		dbg_msg("textrender", "loaded pFont from '%s'", pFilename);
+		dbg_msg("textrender", "loaded font from '%s'", pFilename);
 
 		pFont->m_pBuf = (void *)pBuf;
 		pFont->m_CurTextureDimensions[0] = 1024;
@@ -779,7 +779,7 @@ public:
 
 	void SetDefaultFont(CFont *pFont) override
 	{
-		dbg_msg("textrender", "default pFont set %p", pFont);
+		dbg_msg("textrender", "default font set to '%s'", pFont->m_aFilename);
 		m_pDefaultFont = pFont;
 		m_pCurFont = m_pDefaultFont;
 	}


### PR DESCRIPTION


## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
