### PR TITLE
Fix HUD on KOG and do no longer show new DDRace HUD on old DDRace Servers

### DIFF
--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1062,9 +1062,9 @@ static CGameInfo GetGameInfo(const CNetObj_GameInfoEx *pInfoEx, int InfoExSize, 
 	Info.m_DontMaskEntities = !DDNet;
 	Info.m_AllowXSkins = false;
 	Info.m_EntitiesFDDrace = FDDrace;
-	Info.m_HudHealthArmor = !DDNet;
-	Info.m_HudAmmo = !DDNet;
-	Info.m_HudDDRace = DDNet;
+	Info.m_HudHealthArmor = true;
+	Info.m_HudAmmo = true;
+	Info.m_HudDDRace = false;
 
 	if(Version >= 0)
 	{


### PR DESCRIPTION
I tested it on KOG and some other servers. Seems fine

I personally would have shown the new HUD also on old server. But I guess it is fine to show the old HUD on old servers.


If we decide for this solution... we can merge it also into 16.2 so that a HUD is shown on KoG servers

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [x] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
