### PR TITLE
Replaced float array with appropriate struct (vec or color)

### DIFF
--- a/src/base/color.h
+++ b/src/base/color.h
@@ -54,7 +54,10 @@ public:
 		float w, a;
 	};
 
-	color4_base() {}
+	color4_base() :
+		x(), y(), z(), a()
+	{
+	}
 
 	color4_base(const vec4 &v4)
 	{
@@ -97,6 +100,14 @@ public:
 	}
 
 	vec4 v4() const { return vec4(x, y, z, a); }
+	operator vec4() const { return vec4(x, y, z, a); }
+	float &operator[](int index)
+	{
+		return ((float *)this)[index];
+	}
+
+	bool operator==(const color4_base &col) const { return x == col.x && y == col.y && z == col.z && a == col.a; }
+	bool operator!=(const color4_base &col) const { return x != col.x || y != col.y || z != col.z || a != col.a; }
 
 	unsigned Pack(bool Alpha = true)
 	{

--- a/src/base/vmath.h
+++ b/src/base/vmath.h
@@ -171,15 +171,15 @@ class vector3_base
 public:
 	union
 	{
-		T x, r, h;
+		T x, r, h, u;
 	};
 	union
 	{
-		T y, g, s;
+		T y, g, s, v;
 	};
 	union
 	{
-		T z, b, v, l;
+		T z, b, l, w;
 	};
 
 	vector3_base() :

--- a/src/engine/client/backend/opengl/backend_opengl.cpp
+++ b/src/engine/client/backend/opengl/backend_opengl.cpp
@@ -2018,7 +2018,7 @@ void CCommandProcessorFragment_OpenGL2::Cmd_IndicesRequiredNumNotify(const CComm
 {
 }
 
-void CCommandProcessorFragment_OpenGL2::RenderBorderTileEmulation(SBufferContainer &BufferContainer, const CCommandBuffer::SState &State, const float *pColor, const char *pBuffOffset, unsigned int DrawNum, const vec2 &Offset, const vec2 &Dir, int JumpIndex)
+void CCommandProcessorFragment_OpenGL2::RenderBorderTileEmulation(SBufferContainer &BufferContainer, const CCommandBuffer::SState &State, const ColorRGBA &Color, const char *pBuffOffset, unsigned int DrawNum, const vec2 &Offset, const vec2 &Dir, int JumpIndex)
 {
 	if(m_HasShaders)
 	{
@@ -2071,11 +2071,11 @@ void CCommandProcessorFragment_OpenGL2::RenderBorderTileEmulation(SBufferContain
 
 			GL_SVertexTex3D &Vertex = m_aStreamVertices[VertexCount++];
 			Vertex.m_Pos = *pPos;
-			mem_copy(&Vertex.m_Color, pColor, sizeof(vec4));
+			Vertex.m_Color = Color;
 			if(IsTextured)
 			{
 				vec3 *pTex = (vec3 *)((uint8_t *)BufferObject.m_pData + VertOffset + (ptrdiff_t)sizeof(vec2));
-				mem_copy(&Vertex.m_Tex, pTex, sizeof(vec3));
+				Vertex.m_Tex = *pTex;
 			}
 
 			Vertex.m_Pos += Offset + Dir * vec2(XCount, YCount);
@@ -2102,7 +2102,7 @@ void CCommandProcessorFragment_OpenGL2::RenderBorderTileEmulation(SBufferContain
 	}
 }
 
-void CCommandProcessorFragment_OpenGL2::RenderBorderTileLineEmulation(SBufferContainer &BufferContainer, const CCommandBuffer::SState &State, const float *pColor, const char *pBuffOffset, unsigned int IndexDrawNum, unsigned int DrawNum, const vec2 &Offset, const vec2 &Dir)
+void CCommandProcessorFragment_OpenGL2::RenderBorderTileLineEmulation(SBufferContainer &BufferContainer, const CCommandBuffer::SState &State, const ColorRGBA &Color, const char *pBuffOffset, unsigned int IndexDrawNum, unsigned int DrawNum, const vec2 &Offset, const vec2 &Dir)
 {
 	if(m_HasShaders)
 	{
@@ -2153,11 +2153,11 @@ void CCommandProcessorFragment_OpenGL2::RenderBorderTileLineEmulation(SBufferCon
 
 			GL_SVertexTex3D &Vertex = m_aStreamVertices[VertexCount++];
 			Vertex.m_Pos = *pPos;
-			mem_copy(&Vertex.m_Color, pColor, sizeof(vec4));
+			Vertex.m_Color = Color;
 			if(IsTextured)
 			{
 				vec3 *pTex = (vec3 *)((uint8_t *)BufferObject.m_pData + VertOffset + (ptrdiff_t)sizeof(vec2));
-				mem_copy(&Vertex.m_Tex, pTex, sizeof(vec3));
+				Vertex.m_Tex = *pTex;
 			}
 
 			Vertex.m_Pos += Offset + Dir * i;
@@ -2193,7 +2193,7 @@ void CCommandProcessorFragment_OpenGL2::Cmd_RenderBorderTile(const CCommandBuffe
 
 	SBufferContainer &BufferContainer = m_vBufferContainers[Index];
 
-	RenderBorderTileEmulation(BufferContainer, pCommand->m_State, (float *)&pCommand->m_Color, pCommand->m_pIndicesOffset, pCommand->m_DrawNum, pCommand->m_Offset, pCommand->m_Dir, pCommand->m_JumpIndex);
+	RenderBorderTileEmulation(BufferContainer, pCommand->m_State, pCommand->m_Color, pCommand->m_pIndicesOffset, pCommand->m_DrawNum, pCommand->m_Offset, pCommand->m_Dir, pCommand->m_JumpIndex);
 }
 
 void CCommandProcessorFragment_OpenGL2::Cmd_RenderBorderTileLine(const CCommandBuffer::SCommand_RenderBorderTileLine *pCommand)
@@ -2205,7 +2205,7 @@ void CCommandProcessorFragment_OpenGL2::Cmd_RenderBorderTileLine(const CCommandB
 
 	SBufferContainer &BufferContainer = m_vBufferContainers[Index];
 
-	RenderBorderTileLineEmulation(BufferContainer, pCommand->m_State, (float *)&pCommand->m_Color, pCommand->m_pIndicesOffset, pCommand->m_IndexDrawNum, pCommand->m_DrawNum, pCommand->m_Offset, pCommand->m_Dir);
+	RenderBorderTileLineEmulation(BufferContainer, pCommand->m_State, pCommand->m_Color, pCommand->m_pIndicesOffset, pCommand->m_IndexDrawNum, pCommand->m_DrawNum, pCommand->m_Offset, pCommand->m_Dir);
 }
 
 void CCommandProcessorFragment_OpenGL2::Cmd_RenderTileLayer(const CCommandBuffer::SCommand_RenderTileLayer *pCommand)
@@ -2295,11 +2295,11 @@ void CCommandProcessorFragment_OpenGL2::Cmd_RenderTileLayer(const CCommandBuffer
 				vec2 *pPos = (vec2 *)((uint8_t *)BufferObject.m_pData + VertOffset);
 				GL_SVertexTex3D &Vertex = m_aStreamVertices[VertexCount++];
 				Vertex.m_Pos = *pPos;
-				mem_copy(&Vertex.m_Color, &pCommand->m_Color, sizeof(vec4));
+				Vertex.m_Color = pCommand->m_Color;
 				if(IsTextured)
 				{
 					vec3 *pTex = (vec3 *)((uint8_t *)BufferObject.m_pData + VertOffset + (ptrdiff_t)sizeof(vec2));
-					mem_copy(&Vertex.m_Tex, pTex, sizeof(vec3));
+					Vertex.m_Tex = *pTex;
 				}
 
 				if(VertexCount >= std::size(m_aStreamVertices))

--- a/src/engine/client/backend/opengl/backend_opengl.cpp
+++ b/src/engine/client/backend/opengl/backend_opengl.cpp
@@ -1263,10 +1263,10 @@ void CCommandProcessorFragment_OpenGL2::SetState(const CCommandBuffer::SState &S
 		}
 	}
 
-	if(pProgram->m_aLastScreen[0] != State.m_ScreenTL || pProgram->m_aLastScreen[1] != State.m_ScreenBR)
+	if(pProgram->m_LastScreenTL != State.m_ScreenTL || pProgram->m_LastScreenBR != State.m_ScreenBR)
 	{
-		pProgram->m_aLastScreen[0] = State.m_ScreenTL;
-		pProgram->m_aLastScreen[1] = State.m_ScreenBR;
+		pProgram->m_LastScreenTL = State.m_ScreenTL;
+		pProgram->m_LastScreenBR = State.m_ScreenBR;
 
 		// screen mapping
 		// orthographic projection matrix

--- a/src/engine/client/backend/opengl/backend_opengl.h
+++ b/src/engine/client/backend/opengl/backend_opengl.h
@@ -162,8 +162,8 @@ class CCommandProcessorFragment_OpenGL2 : public CCommandProcessorFragment_OpenG
 	bool DoAnalyzeStep(size_t StepN, size_t CheckCount, size_t VerticesCount, uint8_t aFakeTexture[], size_t SingleImageSize);
 	bool IsTileMapAnalysisSucceeded();
 
-	void RenderBorderTileEmulation(SBufferContainer &BufferContainer, const CCommandBuffer::SState &State, const float *pColor, const char *pBuffOffset, unsigned int DrawNum, const float *pOffset, const float *pDir, int JumpIndex);
-	void RenderBorderTileLineEmulation(SBufferContainer &BufferContainer, const CCommandBuffer::SState &State, const float *pColor, const char *pBuffOffset, unsigned int IndexDrawNum, unsigned int DrawNum, const float *pOffset, const float *pDir);
+	void RenderBorderTileEmulation(SBufferContainer &BufferContainer, const CCommandBuffer::SState &State, const float *pColor, const char *pBuffOffset, unsigned int DrawNum, const vec2 &Offset, const vec2 &Dir, int JumpIndex);
+	void RenderBorderTileLineEmulation(SBufferContainer &BufferContainer, const CCommandBuffer::SState &State, const float *pColor, const char *pBuffOffset, unsigned int IndexDrawNum, unsigned int DrawNum, const vec2 &Offset, const vec2 &Dir);
 #endif
 
 	void UseProgram(CGLSLTWProgram *pProgram);

--- a/src/engine/client/backend/opengl/backend_opengl.h
+++ b/src/engine/client/backend/opengl/backend_opengl.h
@@ -162,8 +162,8 @@ class CCommandProcessorFragment_OpenGL2 : public CCommandProcessorFragment_OpenG
 	bool DoAnalyzeStep(size_t StepN, size_t CheckCount, size_t VerticesCount, uint8_t aFakeTexture[], size_t SingleImageSize);
 	bool IsTileMapAnalysisSucceeded();
 
-	void RenderBorderTileEmulation(SBufferContainer &BufferContainer, const CCommandBuffer::SState &State, const float *pColor, const char *pBuffOffset, unsigned int DrawNum, const vec2 &Offset, const vec2 &Dir, int JumpIndex);
-	void RenderBorderTileLineEmulation(SBufferContainer &BufferContainer, const CCommandBuffer::SState &State, const float *pColor, const char *pBuffOffset, unsigned int IndexDrawNum, unsigned int DrawNum, const vec2 &Offset, const vec2 &Dir);
+	void RenderBorderTileEmulation(SBufferContainer &BufferContainer, const CCommandBuffer::SState &State, const ColorRGBA &Color, const char *pBuffOffset, unsigned int DrawNum, const vec2 &Offset, const vec2 &Dir, int JumpIndex);
+	void RenderBorderTileLineEmulation(SBufferContainer &BufferContainer, const CCommandBuffer::SState &State, const ColorRGBA &Color, const char *pBuffOffset, unsigned int IndexDrawNum, unsigned int DrawNum, const vec2 &Offset, const vec2 &Dir);
 #endif
 
 	void UseProgram(CGLSLTWProgram *pProgram);

--- a/src/engine/client/backend/opengl/backend_opengl3.cpp
+++ b/src/engine/client/backend/opengl/backend_opengl3.cpp
@@ -1230,7 +1230,7 @@ void CCommandProcessorFragment_OpenGL3_3::Cmd_RenderQuadLayer(const CCommandBuff
 
 		for(size_t i = 0; i < (size_t)ActualQuadCount; ++i)
 		{
-			mem_copy(&aColors[i], pCommand->m_pQuadInfo[i + QuadOffset].m_aColor, sizeof(vec4));
+			aColors[i] = pCommand->m_pQuadInfo[i + QuadOffset].m_Color;
 			aOffsets[i] = pCommand->m_pQuadInfo[i + QuadOffset].m_Offsets;
 			aRotations[i] = pCommand->m_pQuadInfo[i + QuadOffset].m_Rotation;
 		}
@@ -1246,7 +1246,7 @@ void CCommandProcessorFragment_OpenGL3_3::Cmd_RenderQuadLayer(const CCommandBuff
 	}
 }
 
-void CCommandProcessorFragment_OpenGL3_3::RenderText(const CCommandBuffer::SState &State, int DrawNum, int TextTextureIndex, int TextOutlineTextureIndex, int TextureSize, const float *pTextColor, const float *pTextOutlineColor)
+void CCommandProcessorFragment_OpenGL3_3::RenderText(const CCommandBuffer::SState &State, int DrawNum, int TextTextureIndex, int TextOutlineTextureIndex, int TextureSize, const ColorRGBA &TextColor, const ColorRGBA &TextOutlineColor)
 {
 	if(DrawNum == 0)
 	{
@@ -1284,22 +1284,16 @@ void CCommandProcessorFragment_OpenGL3_3::RenderText(const CCommandBuffer::SStat
 		m_pTextProgram->m_LastTextureSize = TextureSize;
 	}
 
-	if(m_pTextProgram->m_LastOutlineColor[0] != pTextOutlineColor[0] || m_pTextProgram->m_LastOutlineColor[1] != pTextOutlineColor[1] || m_pTextProgram->m_LastOutlineColor[2] != pTextOutlineColor[2] || m_pTextProgram->m_LastOutlineColor[3] != pTextOutlineColor[3])
+	if(m_pTextProgram->m_LastOutlineColor != TextOutlineColor)
 	{
-		m_pTextProgram->SetUniformVec4(m_pTextProgram->m_LocOutlineColor, 1, (float *)pTextOutlineColor);
-		m_pTextProgram->m_LastOutlineColor[0] = pTextOutlineColor[0];
-		m_pTextProgram->m_LastOutlineColor[1] = pTextOutlineColor[1];
-		m_pTextProgram->m_LastOutlineColor[2] = pTextOutlineColor[2];
-		m_pTextProgram->m_LastOutlineColor[3] = pTextOutlineColor[3];
+		m_pTextProgram->SetUniformVec4(m_pTextProgram->m_LocOutlineColor, 1, (float *)&TextOutlineColor);
+		m_pTextProgram->m_LastOutlineColor = TextOutlineColor;
 	}
 
-	if(m_pTextProgram->m_LastColor[0] != pTextColor[0] || m_pTextProgram->m_LastColor[1] != pTextColor[1] || m_pTextProgram->m_LastColor[2] != pTextColor[2] || m_pTextProgram->m_LastColor[3] != pTextColor[3])
+	if(m_pTextProgram->m_LastColor != TextColor)
 	{
-		m_pTextProgram->SetUniformVec4(m_pTextProgram->m_LocColor, 1, (float *)pTextColor);
-		m_pTextProgram->m_LastColor[0] = pTextColor[0];
-		m_pTextProgram->m_LastColor[1] = pTextColor[1];
-		m_pTextProgram->m_LastColor[2] = pTextColor[2];
-		m_pTextProgram->m_LastColor[3] = pTextColor[3];
+		m_pTextProgram->SetUniformVec4(m_pTextProgram->m_LocColor, 1, (float *)&TextColor);
+		m_pTextProgram->m_LastColor = TextColor;
 	}
 
 	glDrawElements(GL_TRIANGLES, DrawNum, GL_UNSIGNED_INT, (void *)(0));
@@ -1323,7 +1317,7 @@ void CCommandProcessorFragment_OpenGL3_3::Cmd_RenderText(const CCommandBuffer::S
 		BufferContainer.m_LastIndexBufferBound = m_QuadDrawIndexBufferID;
 	}
 
-	RenderText(pCommand->m_State, pCommand->m_DrawNum, pCommand->m_TextTextureIndex, pCommand->m_TextOutlineTextureIndex, pCommand->m_TextureSize, pCommand->m_aTextColor, pCommand->m_aTextOutlineColor);
+	RenderText(pCommand->m_State, pCommand->m_DrawNum, pCommand->m_TextTextureIndex, pCommand->m_TextOutlineTextureIndex, pCommand->m_TextureSize, pCommand->m_TextColor, pCommand->m_TextOutlineColor);
 }
 
 void CCommandProcessorFragment_OpenGL3_3::Cmd_RenderQuadContainer(const CCommandBuffer::SCommand_RenderQuadContainer *pCommand)
@@ -1410,13 +1404,10 @@ void CCommandProcessorFragment_OpenGL3_3::Cmd_RenderQuadContainerEx(const CComma
 		pProgram->m_LastRotation = pCommand->m_Rotation;
 	}
 
-	if(pProgram->m_LastVertciesColor[0] != pCommand->m_VertexColor.r || pProgram->m_LastVertciesColor[1] != pCommand->m_VertexColor.g || pProgram->m_LastVertciesColor[2] != pCommand->m_VertexColor.b || pProgram->m_LastVertciesColor[3] != pCommand->m_VertexColor.a)
+	if(pProgram->m_LastVerticesColor != pCommand->m_VertexColor)
 	{
 		pProgram->SetUniformVec4(pProgram->m_LocVertciesColor, 1, (float *)&pCommand->m_VertexColor);
-		pProgram->m_LastVertciesColor[0] = pCommand->m_VertexColor.r;
-		pProgram->m_LastVertciesColor[1] = pCommand->m_VertexColor.g;
-		pProgram->m_LastVertciesColor[2] = pCommand->m_VertexColor.b;
-		pProgram->m_LastVertciesColor[3] = pCommand->m_VertexColor.a;
+		pProgram->m_LastVerticesColor = pCommand->m_VertexColor;
 	}
 
 	glDrawElements(GL_TRIANGLES, pCommand->m_DrawNum, GL_UNSIGNED_INT, pCommand->m_pOffset);
@@ -1454,13 +1445,10 @@ void CCommandProcessorFragment_OpenGL3_3::Cmd_RenderQuadContainerAsSpriteMultipl
 		m_pSpriteProgramMultiple->m_LastCenter = pCommand->m_Center;
 	}
 
-	if(m_pSpriteProgramMultiple->m_LastVertciesColor[0] != pCommand->m_VertexColor.r || m_pSpriteProgramMultiple->m_LastVertciesColor[1] != pCommand->m_VertexColor.g || m_pSpriteProgramMultiple->m_LastVertciesColor[2] != pCommand->m_VertexColor.b || m_pSpriteProgramMultiple->m_LastVertciesColor[3] != pCommand->m_VertexColor.a)
+	if(m_pSpriteProgramMultiple->m_LastVerticesColor != pCommand->m_VertexColor)
 	{
 		m_pSpriteProgramMultiple->SetUniformVec4(m_pSpriteProgramMultiple->m_LocVertciesColor, 1, (float *)&pCommand->m_VertexColor);
-		m_pSpriteProgramMultiple->m_LastVertciesColor[0] = pCommand->m_VertexColor.r;
-		m_pSpriteProgramMultiple->m_LastVertciesColor[1] = pCommand->m_VertexColor.g;
-		m_pSpriteProgramMultiple->m_LastVertciesColor[2] = pCommand->m_VertexColor.b;
-		m_pSpriteProgramMultiple->m_LastVertciesColor[3] = pCommand->m_VertexColor.a;
+		m_pSpriteProgramMultiple->m_LastVerticesColor = pCommand->m_VertexColor;
 	}
 
 	int DrawCount = pCommand->m_DrawCount;

--- a/src/engine/client/backend/opengl/backend_opengl3.cpp
+++ b/src/engine/client/backend/opengl/backend_opengl3.cpp
@@ -1231,8 +1231,8 @@ void CCommandProcessorFragment_OpenGL3_3::Cmd_RenderQuadLayer(const CCommandBuff
 		for(size_t i = 0; i < (size_t)ActualQuadCount; ++i)
 		{
 			mem_copy(&aColors[i], pCommand->m_pQuadInfo[i + QuadOffset].m_aColor, sizeof(vec4));
-			mem_copy(&aOffsets[i], pCommand->m_pQuadInfo[i + QuadOffset].m_aOffsets, sizeof(vec2));
-			mem_copy(&aRotations[i], &pCommand->m_pQuadInfo[i + QuadOffset].m_Rotation, sizeof(float));
+			aOffsets[i] = pCommand->m_pQuadInfo[i + QuadOffset].m_Offsets;
+			aRotations[i] = pCommand->m_pQuadInfo[i + QuadOffset].m_Rotation;
 		}
 
 		pProgram->SetUniformVec4(pProgram->m_LocColors, ActualQuadCount, (float *)aColors);
@@ -1398,11 +1398,10 @@ void CCommandProcessorFragment_OpenGL3_3::Cmd_RenderQuadContainerEx(const CComma
 	UseProgram(pProgram);
 	SetState(pCommand->m_State, pProgram);
 
-	if(pCommand->m_Rotation != 0.0f && (pProgram->m_LastCenter[0] != pCommand->m_Center.x || pProgram->m_LastCenter[1] != pCommand->m_Center.y))
+	if(pCommand->m_Rotation != 0.0f && pProgram->m_LastCenter != pCommand->m_Center)
 	{
 		pProgram->SetUniformVec2(pProgram->m_LocCenter, 1, (float *)&pCommand->m_Center);
-		pProgram->m_LastCenter[0] = pCommand->m_Center.x;
-		pProgram->m_LastCenter[1] = pCommand->m_Center.y;
+		pProgram->m_LastCenter = pCommand->m_Center;
 	}
 
 	if(pProgram->m_LastRotation != pCommand->m_Rotation)
@@ -1449,11 +1448,10 @@ void CCommandProcessorFragment_OpenGL3_3::Cmd_RenderQuadContainerAsSpriteMultipl
 	UseProgram(m_pSpriteProgramMultiple);
 	SetState(pCommand->m_State, m_pSpriteProgramMultiple);
 
-	if((m_pSpriteProgramMultiple->m_LastCenter[0] != pCommand->m_Center.x || m_pSpriteProgramMultiple->m_LastCenter[1] != pCommand->m_Center.y))
+	if(m_pSpriteProgramMultiple->m_LastCenter != pCommand->m_Center)
 	{
 		m_pSpriteProgramMultiple->SetUniformVec2(m_pSpriteProgramMultiple->m_LocCenter, 1, (float *)&pCommand->m_Center);
-		m_pSpriteProgramMultiple->m_LastCenter[0] = pCommand->m_Center.x;
-		m_pSpriteProgramMultiple->m_LastCenter[1] = pCommand->m_Center.y;
+		m_pSpriteProgramMultiple->m_LastCenter = pCommand->m_Center;
 	}
 
 	if(m_pSpriteProgramMultiple->m_LastVertciesColor[0] != pCommand->m_VertexColor.r || m_pSpriteProgramMultiple->m_LastVertciesColor[1] != pCommand->m_VertexColor.g || m_pSpriteProgramMultiple->m_LastVertciesColor[2] != pCommand->m_VertexColor.b || m_pSpriteProgramMultiple->m_LastVertciesColor[3] != pCommand->m_VertexColor.a)

--- a/src/engine/client/backend/opengl/backend_opengl3.h
+++ b/src/engine/client/backend/opengl/backend_opengl3.h
@@ -80,7 +80,7 @@ protected:
 
 	void UseProgram(CGLSLTWProgram *pProgram);
 	void UploadStreamBufferData(unsigned int PrimitiveType, const void *pVertices, size_t VertSize, unsigned int PrimitiveCount, bool AsTex3D = false);
-	void RenderText(const CCommandBuffer::SState &State, int DrawNum, int TextTextureIndex, int TextOutlineTextureIndex, int TextureSize, const float *pTextColor, const float *pTextOutlineColor);
+	void RenderText(const CCommandBuffer::SState &State, int DrawNum, int TextTextureIndex, int TextOutlineTextureIndex, int TextureSize, const ColorRGBA &TextColor, const ColorRGBA &TextOutlineColor);
 
 	void TextureUpdate(int Slot, int X, int Y, int Width, int Height, int GLFormat, void *pTexData);
 	void TextureCreate(int Slot, int Width, int Height, int PixelSize, int GLFormat, int GLStoreFormat, int Flags, void *pTexData);

--- a/src/engine/client/backend/opengl/opengl_sl_program.h
+++ b/src/engine/client/backend/opengl/opengl_sl_program.h
@@ -10,6 +10,7 @@
 #define ENGINE_CLIENT_BACKEND_OPENGL_OPENGL_SL_PROGRAM_H_AS_ES
 #endif
 
+#include <base/vmath.h>
 #include <engine/client/graphics_defines.h>
 
 class CGLSL;
@@ -55,7 +56,7 @@ public:
 	CGLSLTWProgram() :
 		m_LocPos(-1), m_LocTextureSampler(-1), m_LastTextureSampler(-1), m_LastIsTextured(-1)
 	{
-		m_LastScreen[0] = m_LastScreen[1] = m_LastScreen[2] = m_LastScreen[3] = -1.f;
+		m_aLastScreen[0] = m_aLastScreen[1] = vec2(-1, -1);
 	}
 
 	int m_LocPos;
@@ -63,7 +64,7 @@ public:
 
 	int m_LastTextureSampler;
 	int m_LastIsTextured;
-	float m_LastScreen[4];
+	vec2 m_aLastScreen[2];
 };
 
 class CGLSLTextProgram : public CGLSLTWProgram
@@ -103,7 +104,7 @@ public:
 
 	{
 		m_LastRotation = 0.f;
-		m_LastCenter[0] = m_LastCenter[1] = 0.f;
+		m_LastCenter = vec2(0, 0);
 		m_LastVertciesColor[0] = m_LastVertciesColor[1] = m_LastVertciesColor[2] = m_LastVertciesColor[3] = -1.f;
 	}
 
@@ -112,7 +113,7 @@ public:
 	int m_LocVertciesColor;
 
 	float m_LastRotation;
-	float m_LastCenter[2];
+	vec2 m_LastCenter;
 	float m_LastVertciesColor[4];
 };
 
@@ -122,7 +123,7 @@ public:
 	CGLSLSpriteMultipleProgram()
 
 	{
-		m_LastCenter[0] = m_LastCenter[1] = 0.f;
+		m_LastCenter = vec2(0, 0);
 		m_LastVertciesColor[0] = m_LastVertciesColor[1] = m_LastVertciesColor[2] = m_LastVertciesColor[3] = -1.f;
 	}
 
@@ -130,7 +131,7 @@ public:
 	int m_LocCenter;
 	int m_LocVertciesColor;
 
-	float m_LastCenter[2];
+	vec2 m_LastCenter;
 	float m_LastVertciesColor[4];
 };
 

--- a/src/engine/client/backend/opengl/opengl_sl_program.h
+++ b/src/engine/client/backend/opengl/opengl_sl_program.h
@@ -10,6 +10,7 @@
 #define ENGINE_CLIENT_BACKEND_OPENGL_OPENGL_SL_PROGRAM_H_AS_ES
 #endif
 
+#include <base/color.h>
 #include <base/vmath.h>
 #include <engine/client/graphics_defines.h>
 
@@ -85,8 +86,8 @@ public:
 	int m_LocTextOutlineSampler;
 	int m_LocTextureSize;
 
-	float m_LastColor[4];
-	float m_LastOutlineColor[4];
+	ColorRGBA m_LastColor;
+	ColorRGBA m_LastOutlineColor;
 	int m_LastTextSampler;
 	int m_LastTextOutlineSampler;
 	int m_LastTextureSize;
@@ -105,7 +106,7 @@ public:
 	{
 		m_LastRotation = 0.f;
 		m_LastCenter = vec2(0, 0);
-		m_LastVertciesColor[0] = m_LastVertciesColor[1] = m_LastVertciesColor[2] = m_LastVertciesColor[3] = -1.f;
+		m_LastVerticesColor = ColorRGBA(-1, -1, -1, -1);
 	}
 
 	int m_LocRotation;
@@ -114,7 +115,7 @@ public:
 
 	float m_LastRotation;
 	vec2 m_LastCenter;
-	float m_LastVertciesColor[4];
+	ColorRGBA m_LastVerticesColor;
 };
 
 class CGLSLSpriteMultipleProgram : public CGLSLTWProgram
@@ -124,7 +125,7 @@ public:
 
 	{
 		m_LastCenter = vec2(0, 0);
-		m_LastVertciesColor[0] = m_LastVertciesColor[1] = m_LastVertciesColor[2] = m_LastVertciesColor[3] = -1.f;
+		m_LastVerticesColor = ColorRGBA(-1, -1, -1, -1);
 	}
 
 	int m_LocRSP;
@@ -132,7 +133,7 @@ public:
 	int m_LocVertciesColor;
 
 	vec2 m_LastCenter;
-	float m_LastVertciesColor[4];
+	ColorRGBA m_LastVerticesColor;
 };
 
 class CGLSLQuadProgram : public CGLSLTWProgram

--- a/src/engine/client/backend/opengl/opengl_sl_program.h
+++ b/src/engine/client/backend/opengl/opengl_sl_program.h
@@ -57,7 +57,7 @@ public:
 	CGLSLTWProgram() :
 		m_LocPos(-1), m_LocTextureSampler(-1), m_LastTextureSampler(-1), m_LastIsTextured(-1)
 	{
-		m_aLastScreen[0] = m_aLastScreen[1] = vec2(-1, -1);
+		m_LastScreenTL = m_LastScreenBR = vec2(-1, -1);
 	}
 
 	int m_LocPos;
@@ -65,7 +65,8 @@ public:
 
 	int m_LastTextureSampler;
 	int m_LastIsTextured;
-	vec2 m_aLastScreen[2];
+	vec2 m_LastScreenTL;
+	vec2 m_LastScreenBR;
 };
 
 class CGLSLTextProgram : public CGLSLTWProgram

--- a/src/engine/client/backend/vulkan/backend_vulkan.cpp
+++ b/src/engine/client/backend/vulkan/backend_vulkan.cpp
@@ -707,10 +707,7 @@ class CCommandProcessorFragment_Vulkan : public CCommandProcessorFragment_GLBase
 		float m_TextureSize;
 	};
 
-	struct SUniformTextGFragmentOffset
-	{
-		float m_Padding[3];
-	};
+	typedef vec3 SUniformTextGFragmentOffset;
 
 	struct SUniformTextGFragmentConstants
 	{
@@ -3259,15 +3256,15 @@ protected:
 
 		if(Type == 1)
 		{
-			mem_copy(&VertexPushConstants.m_Dir, &Dir, sizeof(Dir));
-			mem_copy(&VertexPushConstants.m_Offset, &Off, sizeof(Off));
+			VertexPushConstants.m_Dir = Dir;
+			VertexPushConstants.m_Offset = Off;
 			VertexPushConstants.m_JumpIndex = JumpIndex;
 			VertexPushConstantSize = sizeof(SUniformTileGPosBorder);
 		}
 		else if(Type == 2)
 		{
-			mem_copy(&VertexPushConstants.m_Dir, &Dir, sizeof(Dir));
-			mem_copy(&VertexPushConstants.m_Offset, &Off, sizeof(Off));
+			VertexPushConstants.m_Dir = Dir;
+			VertexPushConstants.m_Offset = Off;
 			VertexPushConstantSize = sizeof(SUniformTileGPosBorderLine);
 		}
 
@@ -6791,8 +6788,8 @@ public:
 	void Cmd_RenderBorderTile(const CCommandBuffer::SCommand_RenderBorderTile *pCommand, SRenderCommandExecuteBuffer &ExecBuffer)
 	{
 		int Type = 1;
-		vec2 Dir = {pCommand->m_Dir[0], pCommand->m_Dir[1]};
-		vec2 Off = {pCommand->m_Offset[0], pCommand->m_Offset[1]};
+		vec2 Dir = pCommand->m_Dir;
+		vec2 Off = pCommand->m_Offset;
 		unsigned int DrawNum = 6;
 		RenderTileLayer(ExecBuffer, pCommand->m_State, Type, pCommand->m_Color, Dir, Off, pCommand->m_JumpIndex, (size_t)1, &pCommand->m_pIndicesOffset, &DrawNum, pCommand->m_DrawNum);
 	}
@@ -6805,8 +6802,8 @@ public:
 	void Cmd_RenderBorderTileLine(const CCommandBuffer::SCommand_RenderBorderTileLine *pCommand, SRenderCommandExecuteBuffer &ExecBuffer)
 	{
 		int Type = 2;
-		vec2 Dir = {pCommand->m_Dir[0], pCommand->m_Dir[1]};
-		vec2 Off = {pCommand->m_Offset[0], pCommand->m_Offset[1]};
+		vec2 Dir = pCommand->m_Dir;
+		vec2 Off = pCommand->m_Offset;
 		RenderTileLayer(ExecBuffer, pCommand->m_State, Type, pCommand->m_Color, Dir, Off, 0, (size_t)1, &pCommand->m_pIndicesOffset, &pCommand->m_IndexDrawNum, pCommand->m_DrawNum);
 	}
 
@@ -7137,10 +7134,10 @@ public:
 			mem_copy(PushConstantColor.m_aColor, &pCommand->m_VertexColor, sizeof(PushConstantColor.m_aColor));
 
 			mem_copy(PushConstantVertex.m_aPos, m.data(), sizeof(PushConstantVertex.m_aPos));
-			mem_copy(&PushConstantVertex.m_Center, &pCommand->m_Center, sizeof(PushConstantVertex.m_Center));
+			PushConstantVertex.m_Center = pCommand->m_Center;
 
 			for(size_t i = 0; i < pCommand->m_DrawCount; ++i)
-				PushConstantVertex.m_aPSR[i] = vec4(pCommand->m_pRenderInfo[i].m_Pos[0], pCommand->m_pRenderInfo[i].m_Pos[1], pCommand->m_pRenderInfo[i].m_Scale, pCommand->m_pRenderInfo[i].m_Rotation);
+				PushConstantVertex.m_aPSR[i] = vec4(pCommand->m_pRenderInfo[i].m_Pos.x, pCommand->m_pRenderInfo[i].m_Pos.y, pCommand->m_pRenderInfo[i].m_Scale, pCommand->m_pRenderInfo[i].m_Rotation);
 
 			vkCmdPushConstants(CommandBuffer, PipeLayout, VK_SHADER_STAGE_VERTEX_BIT, 0, sizeof(SUniformSpriteMultiPushGPosBase) + sizeof(vec4) * pCommand->m_DrawCount, &PushConstantVertex);
 			vkCmdPushConstants(CommandBuffer, PipeLayout, VK_SHADER_STAGE_FRAGMENT_BIT, sizeof(SUniformSpriteMultiPushGPos), sizeof(PushConstantColor), &PushConstantColor);
@@ -7153,7 +7150,7 @@ public:
 			mem_copy(PushConstantColor.m_aColor, &pCommand->m_VertexColor, sizeof(PushConstantColor.m_aColor));
 
 			mem_copy(PushConstantVertex.m_aPos, m.data(), sizeof(PushConstantVertex.m_aPos));
-			mem_copy(&PushConstantVertex.m_Center, &pCommand->m_Center, sizeof(PushConstantVertex.m_Center));
+			PushConstantVertex.m_Center = pCommand->m_Center;
 
 			vkCmdPushConstants(CommandBuffer, PipeLayout, VK_SHADER_STAGE_VERTEX_BIT, 0, sizeof(PushConstantVertex), &PushConstantVertex);
 			vkCmdPushConstants(CommandBuffer, PipeLayout, VK_SHADER_STAGE_FRAGMENT_BIT, sizeof(SUniformSpriteMultiGPos) + sizeof(SUniformSpriteMultiGVertColorAlign), sizeof(PushConstantColor), &PushConstantColor);

--- a/src/engine/client/backend/vulkan/backend_vulkan.cpp
+++ b/src/engine/client/backend/vulkan/backend_vulkan.cpp
@@ -711,8 +711,8 @@ class CCommandProcessorFragment_Vulkan : public CCommandProcessorFragment_GLBase
 
 	struct SUniformTextGFragmentConstants
 	{
-		float m_aTextColor[4];
-		float m_aTextOutlineColor[4];
+		ColorRGBA m_TextColor;
+		ColorRGBA m_TextOutlineColor;
 	};
 
 	struct SUniformTextFragment
@@ -736,10 +736,7 @@ class CCommandProcessorFragment_Vulkan : public CCommandProcessorFragment_GLBase
 		int32_t m_JumpIndex;
 	};
 
-	struct SUniformTileGVertColor
-	{
-		float m_aColor[4];
-	};
+	typedef ColorRGBA SUniformTileGVertColor;
 
 	struct SUniformTileGVertColorAlign
 	{
@@ -757,10 +754,7 @@ class CCommandProcessorFragment_Vulkan : public CCommandProcessorFragment_GLBase
 		float m_Rotation;
 	};
 
-	struct SUniformPrimExGVertColor
-	{
-		float m_aColor[4];
-	};
+	typedef ColorRGBA SUniformPrimExGVertColor;
 
 	struct SUniformPrimExGVertColorAlign
 	{
@@ -773,10 +767,7 @@ class CCommandProcessorFragment_Vulkan : public CCommandProcessorFragment_GLBase
 		vec2 m_Center;
 	};
 
-	struct SUniformSpriteMultiGVertColor
-	{
-		float m_aColor[4];
-	};
+	typedef ColorRGBA SUniformSpriteMultiGVertColor;
 
 	struct SUniformSpriteMultiGVertColorAlign
 	{
@@ -795,10 +786,7 @@ class CCommandProcessorFragment_Vulkan : public CCommandProcessorFragment_GLBase
 		vec4 m_aPSR[1];
 	};
 
-	struct SUniformSpriteMultiPushGVertColor
-	{
-		float m_aColor[4];
-	};
+	typedef ColorRGBA SUniformSpriteMultiPushGVertColor;
 
 	struct SUniformQuadGPosBase
 	{
@@ -3252,7 +3240,7 @@ protected:
 		size_t FragPushConstantSize = sizeof(SUniformTileGVertColor);
 
 		mem_copy(VertexPushConstants.m_aPos, m.data(), m.size() * sizeof(float));
-		mem_copy(FragPushConstants.m_aColor, &Color, sizeof(FragPushConstants.m_aColor));
+		FragPushConstants = Color;
 
 		if(Type == 1)
 		{
@@ -6963,8 +6951,8 @@ public:
 
 		SUniformTextFragment FragmentConstants;
 
-		mem_copy(FragmentConstants.m_Constants.m_aTextColor, pCommand->m_aTextColor, sizeof(FragmentConstants.m_Constants.m_aTextColor));
-		mem_copy(FragmentConstants.m_Constants.m_aTextOutlineColor, pCommand->m_aTextOutlineColor, sizeof(FragmentConstants.m_Constants.m_aTextOutlineColor));
+		FragmentConstants.m_Constants.m_TextColor = pCommand->m_TextColor;
+		FragmentConstants.m_Constants.m_TextOutlineColor = pCommand->m_TextOutlineColor;
 		vkCmdPushConstants(CommandBuffer, PipeLayout, VK_SHADER_STAGE_FRAGMENT_BIT, sizeof(SUniformGTextPos) + sizeof(SUniformTextGFragmentOffset), sizeof(SUniformTextFragment), &FragmentConstants);
 
 		vkCmdDrawIndexed(CommandBuffer, static_cast<uint32_t>(pCommand->m_DrawNum), 1, 0, 0, 0);
@@ -7073,8 +7061,7 @@ public:
 		SUniformPrimExGPos PushConstantVertex;
 		size_t VertexPushConstantSize = sizeof(PushConstantVertex);
 
-		mem_copy(PushConstantColor.m_aColor, &pCommand->m_VertexColor, sizeof(PushConstantColor.m_aColor));
-
+		PushConstantColor = pCommand->m_VertexColor;
 		mem_copy(PushConstantVertex.m_aPos, m.data(), sizeof(PushConstantVertex.m_aPos));
 
 		if(!IsRotationless)
@@ -7131,7 +7118,7 @@ public:
 			SUniformSpriteMultiPushGVertColor PushConstantColor;
 			SUniformSpriteMultiPushGPos PushConstantVertex;
 
-			mem_copy(PushConstantColor.m_aColor, &pCommand->m_VertexColor, sizeof(PushConstantColor.m_aColor));
+			PushConstantColor = pCommand->m_VertexColor;
 
 			mem_copy(PushConstantVertex.m_aPos, m.data(), sizeof(PushConstantVertex.m_aPos));
 			PushConstantVertex.m_Center = pCommand->m_Center;
@@ -7147,7 +7134,7 @@ public:
 			SUniformSpriteMultiGVertColor PushConstantColor;
 			SUniformSpriteMultiGPos PushConstantVertex;
 
-			mem_copy(PushConstantColor.m_aColor, &pCommand->m_VertexColor, sizeof(PushConstantColor.m_aColor));
+			PushConstantColor = pCommand->m_VertexColor;
 
 			mem_copy(PushConstantVertex.m_aPos, m.data(), sizeof(PushConstantVertex.m_aPos));
 			PushConstantVertex.m_Center = pCommand->m_Center;

--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -1264,7 +1264,7 @@ void CGraphics_Threaded::RenderTileLayer(int BufferContainerIndex, float *pColor
 	// todo max indices group check!!
 }
 
-void CGraphics_Threaded::RenderBorderTiles(int BufferContainerIndex, float *pColor, char *pIndexBufferOffset, float *pOffset, float *pDir, int JumpIndex, unsigned int DrawNum)
+void CGraphics_Threaded::RenderBorderTiles(int BufferContainerIndex, float *pColor, char *pIndexBufferOffset, const vec2 &Offset, const vec2 &Dir, int JumpIndex, unsigned int DrawNum)
 {
 	if(DrawNum == 0)
 		return;
@@ -1278,10 +1278,8 @@ void CGraphics_Threaded::RenderBorderTiles(int BufferContainerIndex, float *pCol
 	Cmd.m_pIndicesOffset = pIndexBufferOffset;
 	Cmd.m_JumpIndex = JumpIndex;
 
-	Cmd.m_Offset[0] = pOffset[0];
-	Cmd.m_Offset[1] = pOffset[1];
-	Cmd.m_Dir[0] = pDir[0];
-	Cmd.m_Dir[1] = pDir[1];
+	Cmd.m_Offset = Offset;
+	Cmd.m_Dir = Dir;
 
 	// check if we have enough free memory in the commandbuffer
 	if(!AddCmd(
@@ -1293,7 +1291,7 @@ void CGraphics_Threaded::RenderBorderTiles(int BufferContainerIndex, float *pCol
 	m_pCommandBuffer->AddRenderCalls(1);
 }
 
-void CGraphics_Threaded::RenderBorderTileLines(int BufferContainerIndex, float *pColor, char *pIndexBufferOffset, float *pOffset, float *pDir, unsigned int IndexDrawNum, unsigned int RedrawNum)
+void CGraphics_Threaded::RenderBorderTileLines(int BufferContainerIndex, float *pColor, char *pIndexBufferOffset, const vec2 &Offset, const vec2 &Dir, unsigned int IndexDrawNum, unsigned int RedrawNum)
 {
 	if(IndexDrawNum == 0 || RedrawNum == 0)
 		return;
@@ -1307,10 +1305,8 @@ void CGraphics_Threaded::RenderBorderTileLines(int BufferContainerIndex, float *
 
 	Cmd.m_pIndicesOffset = pIndexBufferOffset;
 
-	Cmd.m_Offset[0] = pOffset[0];
-	Cmd.m_Offset[1] = pOffset[1];
-	Cmd.m_Dir[0] = pDir[0];
-	Cmd.m_Dir[1] = pDir[1];
+	Cmd.m_Offset = Offset;
+	Cmd.m_Dir = Dir;
 
 	// check if we have enough free memory in the commandbuffer
 	if(!AddCmd(
@@ -1840,7 +1836,7 @@ void CGraphics_Threaded::RenderQuadContainerAsSpriteMultiple(int ContainerIndex,
 		for(int i = 0; i < DrawCount; ++i)
 		{
 			QuadsSetRotation(pRenderInfo[i].m_Rotation);
-			RenderQuadContainerAsSprite(ContainerIndex, QuadOffset, pRenderInfo[i].m_Pos[0], pRenderInfo[i].m_Pos[1], pRenderInfo[i].m_Scale, pRenderInfo[i].m_Scale);
+			RenderQuadContainerAsSprite(ContainerIndex, QuadOffset, pRenderInfo[i].m_Pos.x, pRenderInfo[i].m_Pos.y, pRenderInfo[i].m_Scale, pRenderInfo[i].m_Scale);
 		}
 	}
 }

--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -1212,7 +1212,7 @@ void CGraphics_Threaded::QuadsText(float x, float y, float Size, const char *pTe
 	}
 }
 
-void CGraphics_Threaded::RenderTileLayer(int BufferContainerIndex, float *pColor, char **pOffsets, unsigned int *IndicedVertexDrawNum, size_t NumIndicesOffset)
+void CGraphics_Threaded::RenderTileLayer(int BufferContainerIndex, const ColorRGBA &Color, char **pOffsets, unsigned int *IndicedVertexDrawNum, size_t NumIndicesOffset)
 {
 	if(NumIndicesOffset == 0)
 		return;
@@ -1222,7 +1222,7 @@ void CGraphics_Threaded::RenderTileLayer(int BufferContainerIndex, float *pColor
 	Cmd.m_State = m_State;
 	Cmd.m_IndicesDrawNum = NumIndicesOffset;
 	Cmd.m_BufferContainerIndex = BufferContainerIndex;
-	mem_copy(&Cmd.m_Color, pColor, sizeof(Cmd.m_Color));
+	Cmd.m_Color = Color;
 
 	void *Data = m_pCommandBuffer->AllocData((sizeof(char *) + sizeof(unsigned int)) * NumIndicesOffset);
 	if(Data == 0x0)
@@ -1264,7 +1264,7 @@ void CGraphics_Threaded::RenderTileLayer(int BufferContainerIndex, float *pColor
 	// todo max indices group check!!
 }
 
-void CGraphics_Threaded::RenderBorderTiles(int BufferContainerIndex, float *pColor, char *pIndexBufferOffset, const vec2 &Offset, const vec2 &Dir, int JumpIndex, unsigned int DrawNum)
+void CGraphics_Threaded::RenderBorderTiles(int BufferContainerIndex, const ColorRGBA &Color, char *pIndexBufferOffset, const vec2 &Offset, const vec2 &Dir, int JumpIndex, unsigned int DrawNum)
 {
 	if(DrawNum == 0)
 		return;
@@ -1273,7 +1273,7 @@ void CGraphics_Threaded::RenderBorderTiles(int BufferContainerIndex, float *pCol
 	Cmd.m_State = m_State;
 	Cmd.m_DrawNum = DrawNum;
 	Cmd.m_BufferContainerIndex = BufferContainerIndex;
-	mem_copy(&Cmd.m_Color, pColor, sizeof(Cmd.m_Color));
+	Cmd.m_Color = Color;
 
 	Cmd.m_pIndicesOffset = pIndexBufferOffset;
 	Cmd.m_JumpIndex = JumpIndex;
@@ -1291,7 +1291,7 @@ void CGraphics_Threaded::RenderBorderTiles(int BufferContainerIndex, float *pCol
 	m_pCommandBuffer->AddRenderCalls(1);
 }
 
-void CGraphics_Threaded::RenderBorderTileLines(int BufferContainerIndex, float *pColor, char *pIndexBufferOffset, const vec2 &Offset, const vec2 &Dir, unsigned int IndexDrawNum, unsigned int RedrawNum)
+void CGraphics_Threaded::RenderBorderTileLines(int BufferContainerIndex, const ColorRGBA &Color, char *pIndexBufferOffset, const vec2 &Offset, const vec2 &Dir, unsigned int IndexDrawNum, unsigned int RedrawNum)
 {
 	if(IndexDrawNum == 0 || RedrawNum == 0)
 		return;
@@ -1301,7 +1301,7 @@ void CGraphics_Threaded::RenderBorderTileLines(int BufferContainerIndex, float *
 	Cmd.m_IndexDrawNum = IndexDrawNum;
 	Cmd.m_DrawNum = RedrawNum;
 	Cmd.m_BufferContainerIndex = BufferContainerIndex;
-	mem_copy(&Cmd.m_Color, pColor, sizeof(Cmd.m_Color));
+	Cmd.m_Color = Color;
 
 	Cmd.m_pIndicesOffset = pIndexBufferOffset;
 
@@ -1355,7 +1355,7 @@ void CGraphics_Threaded::RenderQuadLayer(int BufferContainerIndex, SQuadRenderIn
 	m_pCommandBuffer->AddRenderCalls(((QuadNum - 1) / gs_GraphicsMaxQuadsRenderCount) + 1);
 }
 
-void CGraphics_Threaded::RenderText(int BufferContainerIndex, int TextQuadNum, int TextureSize, int TextureTextIndex, int TextureTextOutlineIndex, float *pTextColor, float *pTextoutlineColor)
+void CGraphics_Threaded::RenderText(int BufferContainerIndex, int TextQuadNum, int TextureSize, int TextureTextIndex, int TextureTextOutlineIndex, const ColorRGBA &TextColor, const ColorRGBA &TextoutlineColor)
 {
 	if(BufferContainerIndex == -1)
 		return;
@@ -1367,8 +1367,8 @@ void CGraphics_Threaded::RenderText(int BufferContainerIndex, int TextQuadNum, i
 	Cmd.m_TextureSize = TextureSize;
 	Cmd.m_TextTextureIndex = TextureTextIndex;
 	Cmd.m_TextOutlineTextureIndex = TextureTextOutlineIndex;
-	mem_copy(Cmd.m_aTextColor, pTextColor, sizeof(Cmd.m_aTextColor));
-	mem_copy(Cmd.m_aTextOutlineColor, pTextoutlineColor, sizeof(Cmd.m_aTextOutlineColor));
+	Cmd.m_TextColor = TextColor;
+	Cmd.m_TextOutlineColor = TextoutlineColor;
 
 	if(!AddCmd(
 		   Cmd, [] { return true; }, "failed to allocate memory for render text command"))

--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -1355,7 +1355,7 @@ void CGraphics_Threaded::RenderQuadLayer(int BufferContainerIndex, SQuadRenderIn
 	m_pCommandBuffer->AddRenderCalls(((QuadNum - 1) / gs_GraphicsMaxQuadsRenderCount) + 1);
 }
 
-void CGraphics_Threaded::RenderText(int BufferContainerIndex, int TextQuadNum, int TextureSize, int TextureTextIndex, int TextureTextOutlineIndex, const ColorRGBA &TextColor, const ColorRGBA &TextoutlineColor)
+void CGraphics_Threaded::RenderText(int BufferContainerIndex, int TextQuadNum, int TextureSize, int TextureTextIndex, int TextureTextOutlineIndex, const ColorRGBA &TextColor, const ColorRGBA &TextOutlineColor)
 {
 	if(BufferContainerIndex == -1)
 		return;
@@ -1368,7 +1368,7 @@ void CGraphics_Threaded::RenderText(int BufferContainerIndex, int TextQuadNum, i
 	Cmd.m_TextTextureIndex = TextureTextIndex;
 	Cmd.m_TextOutlineTextureIndex = TextureTextOutlineIndex;
 	Cmd.m_TextColor = TextColor;
-	Cmd.m_TextOutlineColor = TextoutlineColor;
+	Cmd.m_TextOutlineColor = TextOutlineColor;
 
 	if(!AddCmd(
 		   Cmd, [] { return true; }, "failed to allocate memory for render text command"))

--- a/src/engine/client/graphics_threaded.h
+++ b/src/engine/client/graphics_threaded.h
@@ -1232,9 +1232,9 @@ public:
 
 	void RenderTileLayer(int BufferContainerIndex, const ColorRGBA &Color, char **pOffsets, unsigned int *IndicedVertexDrawNum, size_t NumIndicesOffset) override;
 	void RenderBorderTiles(int BufferContainerIndex, const ColorRGBA &Color, char *pIndexBufferOffset, const vec2 &Offset, const vec2 &Dir, int JumpIndex, unsigned int DrawNum) override;
-	void RenderBorderTileLines(int BufferContainerIndex, const ColorRGBA &Color, char *pIndexBufferOffset, const vec2 &Offset, const vec2 &pDir, unsigned int IndexDrawNum, unsigned int RedrawNum) override;
+	void RenderBorderTileLines(int BufferContainerIndex, const ColorRGBA &Color, char *pIndexBufferOffset, const vec2 &Offset, const vec2 &Dir, unsigned int IndexDrawNum, unsigned int RedrawNum) override;
 	void RenderQuadLayer(int BufferContainerIndex, SQuadRenderInfo *pQuadInfo, int QuadNum, int QuadOffset) override;
-	void RenderText(int BufferContainerIndex, int TextQuadNum, int TextureSize, int TextureTextIndex, int TextureTextOutlineIndex, const ColorRGBA &TextColor, const ColorRGBA &TextoutlineColor) override;
+	void RenderText(int BufferContainerIndex, int TextQuadNum, int TextureSize, int TextureTextIndex, int TextureTextOutlineIndex, const ColorRGBA &TextColor, const ColorRGBA &TextOutlineColor) override;
 
 	// modern GL functions
 	int CreateBufferObject(size_t UploadDataSize, void *pUploadData, int CreateFlags, bool IsMovedPointer = false) override;

--- a/src/engine/client/graphics_threaded.h
+++ b/src/engine/client/graphics_threaded.h
@@ -175,8 +175,8 @@ public:
 		WRAP_CLAMP,
 	};
 
-	typedef GL_SPoint SPoint;
-	typedef GL_STexCoord STexCoord;
+	typedef vec2 SPoint;
+	typedef vec2 STexCoord;
 	typedef GL_SColorf SColorf;
 	typedef GL_SColor SColor;
 	typedef GL_SVertex SVertex;
@@ -384,8 +384,8 @@ public:
 		unsigned int m_DrawNum;
 		int m_BufferContainerIndex;
 
-		float m_Offset[2];
-		float m_Dir[2];
+		vec2 m_Offset;
+		vec2 m_Dir;
 		int m_JumpIndex;
 	};
 
@@ -400,8 +400,8 @@ public:
 		unsigned int m_DrawNum;
 		int m_BufferContainerIndex;
 
-		float m_Offset[2];
-		float m_Dir[2];
+		vec2 m_Offset;
+		vec2 m_Dir;
 	};
 
 	struct SCommand_RenderQuadLayer : public SCommand
@@ -1231,8 +1231,8 @@ public:
 	void FlushVerticesTex3D() override;
 
 	void RenderTileLayer(int BufferContainerIndex, float *pColor, char **pOffsets, unsigned int *IndicedVertexDrawNum, size_t NumIndicesOffset) override;
-	void RenderBorderTiles(int BufferContainerIndex, float *pColor, char *pIndexBufferOffset, float *pOffset, float *pDir, int JumpIndex, unsigned int DrawNum) override;
-	void RenderBorderTileLines(int BufferContainerIndex, float *pColor, char *pIndexBufferOffset, float *pOffset, float *pDir, unsigned int IndexDrawNum, unsigned int RedrawNum) override;
+	void RenderBorderTiles(int BufferContainerIndex, float *pColor, char *pIndexBufferOffset, const vec2 &Offset, const vec2 &Dir, int JumpIndex, unsigned int DrawNum) override;
+	void RenderBorderTileLines(int BufferContainerIndex, float *pColor, char *pIndexBufferOffset, const vec2 &Offset, const vec2 &pDir, unsigned int IndexDrawNum, unsigned int RedrawNum) override;
 	void RenderQuadLayer(int BufferContainerIndex, SQuadRenderInfo *pQuadInfo, int QuadNum, int QuadOffset) override;
 	void RenderText(int BufferContainerIndex, int TextQuadNum, int TextureSize, int TextureTextIndex, int TextureTextOutlineIndex, float *pTextColor, float *pTextoutlineColor) override;
 

--- a/src/engine/client/graphics_threaded.h
+++ b/src/engine/client/graphics_threaded.h
@@ -429,8 +429,8 @@ public:
 		int m_TextOutlineTextureIndex;
 
 		int m_DrawNum;
-		float m_aTextColor[4];
-		float m_aTextOutlineColor[4];
+		ColorRGBA m_TextColor;
+		ColorRGBA m_TextOutlineColor;
 	};
 
 	struct SCommand_RenderQuadContainer : public SCommand
@@ -1230,11 +1230,11 @@ public:
 	void FlushVertices(bool KeepVertices = false) override;
 	void FlushVerticesTex3D() override;
 
-	void RenderTileLayer(int BufferContainerIndex, float *pColor, char **pOffsets, unsigned int *IndicedVertexDrawNum, size_t NumIndicesOffset) override;
-	void RenderBorderTiles(int BufferContainerIndex, float *pColor, char *pIndexBufferOffset, const vec2 &Offset, const vec2 &Dir, int JumpIndex, unsigned int DrawNum) override;
-	void RenderBorderTileLines(int BufferContainerIndex, float *pColor, char *pIndexBufferOffset, const vec2 &Offset, const vec2 &pDir, unsigned int IndexDrawNum, unsigned int RedrawNum) override;
+	void RenderTileLayer(int BufferContainerIndex, const ColorRGBA &Color, char **pOffsets, unsigned int *IndicedVertexDrawNum, size_t NumIndicesOffset) override;
+	void RenderBorderTiles(int BufferContainerIndex, const ColorRGBA &Color, char *pIndexBufferOffset, const vec2 &Offset, const vec2 &Dir, int JumpIndex, unsigned int DrawNum) override;
+	void RenderBorderTileLines(int BufferContainerIndex, const ColorRGBA &Color, char *pIndexBufferOffset, const vec2 &Offset, const vec2 &pDir, unsigned int IndexDrawNum, unsigned int RedrawNum) override;
 	void RenderQuadLayer(int BufferContainerIndex, SQuadRenderInfo *pQuadInfo, int QuadNum, int QuadOffset) override;
-	void RenderText(int BufferContainerIndex, int TextQuadNum, int TextureSize, int TextureTextIndex, int TextureTextOutlineIndex, float *pTextColor, float *pTextoutlineColor) override;
+	void RenderText(int BufferContainerIndex, int TextQuadNum, int TextureSize, int TextureTextIndex, int TextureTextOutlineIndex, const ColorRGBA &TextColor, const ColorRGBA &TextoutlineColor) override;
 
 	// modern GL functions
 	int CreateBufferObject(size_t UploadDataSize, void *pUploadData, int CreateFlags, bool IsMovedPointer = false) override;

--- a/src/engine/client/text.cpp
+++ b/src/engine/client/text.cpp
@@ -46,16 +46,13 @@ struct SFontSizeChar
 	FT_UInt m_GlyphIndex;
 };
 
-struct STextCharQuadVertexColor
-{
-	unsigned char m_R, m_G, m_B, m_A;
-};
+typedef vector4_base<unsigned char> STextCharQuadVertexColor;
 
 struct STextCharQuadVertex
 {
 	STextCharQuadVertex()
 	{
-		m_Color.m_R = m_Color.m_G = m_Color.m_B = m_Color.m_A = 255;
+		m_Color.r = m_Color.g = m_Color.b = m_Color.a = 255;
 	}
 	float m_X, m_Y;
 	// do not use normalized floats as coordinates, since the texture might grow
@@ -915,9 +912,9 @@ public:
 		{
 			if((pCursor->m_Flags & TEXTFLAG_RENDER) != 0)
 			{
-				STextRenderColor TextColor = DefaultTextColor();
-				STextRenderColor TextColorOutline = DefaultTextOutlineColor();
-				RenderTextContainer(TextCont, &TextColor, &TextColorOutline);
+				ColorRGBA TextColor = DefaultTextColor();
+				ColorRGBA TextColorOutline = DefaultTextOutlineColor();
+				RenderTextContainer(TextCont, TextColor, TextColorOutline);
 			}
 			DeleteTextContainer(TextCont);
 		}
@@ -1312,37 +1309,37 @@ public:
 						TextCharQuad.m_Vertices[0].m_Y = CharY;
 						TextCharQuad.m_Vertices[0].m_U = pChr->m_aUVs[0];
 						TextCharQuad.m_Vertices[0].m_V = pChr->m_aUVs[3];
-						TextCharQuad.m_Vertices[0].m_Color.m_R = (unsigned char)(m_Color.r * 255.f);
-						TextCharQuad.m_Vertices[0].m_Color.m_G = (unsigned char)(m_Color.g * 255.f);
-						TextCharQuad.m_Vertices[0].m_Color.m_B = (unsigned char)(m_Color.b * 255.f);
-						TextCharQuad.m_Vertices[0].m_Color.m_A = (unsigned char)(m_Color.a * 255.f);
+						TextCharQuad.m_Vertices[0].m_Color.r = (unsigned char)(m_Color.r * 255.f);
+						TextCharQuad.m_Vertices[0].m_Color.g = (unsigned char)(m_Color.g * 255.f);
+						TextCharQuad.m_Vertices[0].m_Color.b = (unsigned char)(m_Color.b * 255.f);
+						TextCharQuad.m_Vertices[0].m_Color.a = (unsigned char)(m_Color.a * 255.f);
 
 						TextCharQuad.m_Vertices[1].m_X = CharX + CharWidth;
 						TextCharQuad.m_Vertices[1].m_Y = CharY;
 						TextCharQuad.m_Vertices[1].m_U = pChr->m_aUVs[2];
 						TextCharQuad.m_Vertices[1].m_V = pChr->m_aUVs[3];
-						TextCharQuad.m_Vertices[1].m_Color.m_R = (unsigned char)(m_Color.r * 255.f);
-						TextCharQuad.m_Vertices[1].m_Color.m_G = (unsigned char)(m_Color.g * 255.f);
-						TextCharQuad.m_Vertices[1].m_Color.m_B = (unsigned char)(m_Color.b * 255.f);
-						TextCharQuad.m_Vertices[1].m_Color.m_A = (unsigned char)(m_Color.a * 255.f);
+						TextCharQuad.m_Vertices[1].m_Color.r = (unsigned char)(m_Color.r * 255.f);
+						TextCharQuad.m_Vertices[1].m_Color.g = (unsigned char)(m_Color.g * 255.f);
+						TextCharQuad.m_Vertices[1].m_Color.b = (unsigned char)(m_Color.b * 255.f);
+						TextCharQuad.m_Vertices[1].m_Color.a = (unsigned char)(m_Color.a * 255.f);
 
 						TextCharQuad.m_Vertices[2].m_X = CharX + CharWidth;
 						TextCharQuad.m_Vertices[2].m_Y = CharY - CharHeight;
 						TextCharQuad.m_Vertices[2].m_U = pChr->m_aUVs[2];
 						TextCharQuad.m_Vertices[2].m_V = pChr->m_aUVs[1];
-						TextCharQuad.m_Vertices[2].m_Color.m_R = (unsigned char)(m_Color.r * 255.f);
-						TextCharQuad.m_Vertices[2].m_Color.m_G = (unsigned char)(m_Color.g * 255.f);
-						TextCharQuad.m_Vertices[2].m_Color.m_B = (unsigned char)(m_Color.b * 255.f);
-						TextCharQuad.m_Vertices[2].m_Color.m_A = (unsigned char)(m_Color.a * 255.f);
+						TextCharQuad.m_Vertices[2].m_Color.r = (unsigned char)(m_Color.r * 255.f);
+						TextCharQuad.m_Vertices[2].m_Color.g = (unsigned char)(m_Color.g * 255.f);
+						TextCharQuad.m_Vertices[2].m_Color.b = (unsigned char)(m_Color.b * 255.f);
+						TextCharQuad.m_Vertices[2].m_Color.a = (unsigned char)(m_Color.a * 255.f);
 
 						TextCharQuad.m_Vertices[3].m_X = CharX;
 						TextCharQuad.m_Vertices[3].m_Y = CharY - CharHeight;
 						TextCharQuad.m_Vertices[3].m_U = pChr->m_aUVs[0];
 						TextCharQuad.m_Vertices[3].m_V = pChr->m_aUVs[1];
-						TextCharQuad.m_Vertices[3].m_Color.m_R = (unsigned char)(m_Color.r * 255.f);
-						TextCharQuad.m_Vertices[3].m_Color.m_G = (unsigned char)(m_Color.g * 255.f);
-						TextCharQuad.m_Vertices[3].m_Color.m_B = (unsigned char)(m_Color.b * 255.f);
-						TextCharQuad.m_Vertices[3].m_Color.m_A = (unsigned char)(m_Color.a * 255.f);
+						TextCharQuad.m_Vertices[3].m_Color.r = (unsigned char)(m_Color.r * 255.f);
+						TextCharQuad.m_Vertices[3].m_Color.g = (unsigned char)(m_Color.g * 255.f);
+						TextCharQuad.m_Vertices[3].m_Color.b = (unsigned char)(m_Color.b * 255.f);
+						TextCharQuad.m_Vertices[3].m_Color.a = (unsigned char)(m_Color.a * 255.f);
 					}
 
 					// calculate the full width from the last selection point to the end of this selection draw on screen
@@ -1572,7 +1569,7 @@ public:
 		}
 	}
 
-	void RenderTextContainer(int TextContainerIndex, STextRenderColor *pTextColor, STextRenderColor *pTextOutlineColor) override
+	void RenderTextContainer(int TextContainerIndex, const ColorRGBA &TextColor, const ColorRGBA &TextOutlineColor) override
 	{
 		STextContainer &TextContainer = GetTextContainer(TextContainerIndex);
 		CFont *pFont = TextContainer.m_pFont;
@@ -1594,7 +1591,7 @@ public:
 			{
 				Graphics()->TextureClear();
 				// render buffered text
-				Graphics()->RenderText(TextContainer.m_StringInfo.m_QuadBufferContainerIndex, TextContainer.m_StringInfo.m_QuadNum, pFont->m_CurTextureDimensions[0], pFont->m_aTextures[0].Id(), pFont->m_aTextures[1].Id(), (float *)pTextColor, (float *)pTextOutlineColor);
+				Graphics()->RenderText(TextContainer.m_StringInfo.m_QuadBufferContainerIndex, TextContainer.m_StringInfo.m_QuadNum, pFont->m_CurTextureDimensions[0], pFont->m_aTextures[0].Id(), pFont->m_aTextures[1].Id(), TextColor, TextOutlineColor);
 			}
 			else
 			{
@@ -1610,14 +1607,14 @@ public:
 				{
 					STextCharQuad &TextCharQuad = TextContainer.m_StringInfo.m_vCharacterQuads[i];
 
-					Graphics()->SetColor(TextCharQuad.m_Vertices[0].m_Color.m_R / 255.f * pTextOutlineColor->m_R, TextCharQuad.m_Vertices[0].m_Color.m_G / 255.f * pTextOutlineColor->m_G, TextCharQuad.m_Vertices[0].m_Color.m_B / 255.f * pTextOutlineColor->m_B, TextCharQuad.m_Vertices[0].m_Color.m_A / 255.f * pTextOutlineColor->m_A);
+					Graphics()->SetColor(TextCharQuad.m_Vertices[0].m_Color.r / 255.f * TextOutlineColor.r, TextCharQuad.m_Vertices[0].m_Color.g / 255.f * TextOutlineColor.g, TextCharQuad.m_Vertices[0].m_Color.b / 255.f * TextOutlineColor.b, TextCharQuad.m_Vertices[0].m_Color.a / 255.f * TextOutlineColor.a);
 
 					Graphics()->QuadsSetSubset(TextCharQuad.m_Vertices[0].m_U * UVScale, TextCharQuad.m_Vertices[0].m_V * UVScale, TextCharQuad.m_Vertices[2].m_U * UVScale, TextCharQuad.m_Vertices[2].m_V * UVScale);
 					IGraphics::CQuadItem QuadItem(TextCharQuad.m_Vertices[0].m_X, TextCharQuad.m_Vertices[0].m_Y, TextCharQuad.m_Vertices[1].m_X - TextCharQuad.m_Vertices[0].m_X, TextCharQuad.m_Vertices[2].m_Y - TextCharQuad.m_Vertices[0].m_Y);
 					Graphics()->QuadsDrawTL(&QuadItem, 1);
 				}
 
-				if(pTextColor->m_A != 0)
+				if(TextColor.a != 0)
 				{
 					Graphics()->QuadsEndKeepVertices();
 
@@ -1626,10 +1623,10 @@ public:
 					for(size_t i = 0; i < TextContainer.m_StringInfo.m_QuadNum; ++i)
 					{
 						STextCharQuad &TextCharQuad = TextContainer.m_StringInfo.m_vCharacterQuads[i];
-						unsigned char CR = (unsigned char)((float)(TextCharQuad.m_Vertices[0].m_Color.m_R) * pTextColor->m_R);
-						unsigned char CG = (unsigned char)((float)(TextCharQuad.m_Vertices[0].m_Color.m_G) * pTextColor->m_G);
-						unsigned char CB = (unsigned char)((float)(TextCharQuad.m_Vertices[0].m_Color.m_B) * pTextColor->m_B);
-						unsigned char CA = (unsigned char)((float)(TextCharQuad.m_Vertices[0].m_Color.m_A) * pTextColor->m_A);
+						unsigned char CR = (unsigned char)((float)(TextCharQuad.m_Vertices[0].m_Color.r) * TextColor.r);
+						unsigned char CG = (unsigned char)((float)(TextCharQuad.m_Vertices[0].m_Color.g) * TextColor.g);
+						unsigned char CB = (unsigned char)((float)(TextCharQuad.m_Vertices[0].m_Color.b) * TextColor.b);
+						unsigned char CA = (unsigned char)((float)(TextCharQuad.m_Vertices[0].m_Color.a) * TextColor.a);
 						Graphics()->ChangeColorOfQuadVertices((int)i, CR, CG, CB, CA);
 					}
 
@@ -1653,9 +1650,9 @@ public:
 				Graphics()->TextureClear();
 				if((CurTime - m_CursorRenderTime) > 500ms)
 				{
-					Graphics()->SetColor(*pTextOutlineColor);
+					Graphics()->SetColor(TextOutlineColor);
 					Graphics()->RenderQuadContainerEx(TextContainer.m_StringInfo.m_SelectionQuadContainerIndex, 0, 1, 0, 0);
-					Graphics()->SetColor(*pTextColor);
+					Graphics()->SetColor(TextColor);
 					Graphics()->RenderQuadContainerEx(TextContainer.m_StringInfo.m_SelectionQuadContainerIndex, 1, 1, 0, 0);
 				}
 				if((CurTime - m_CursorRenderTime) > 1s)
@@ -1665,7 +1662,7 @@ public:
 		}
 	}
 
-	void RenderTextContainer(int TextContainerIndex, STextRenderColor *pTextColor, STextRenderColor *pTextOutlineColor, float X, float Y) override
+	void RenderTextContainer(int TextContainerIndex, const ColorRGBA &TextColor, const ColorRGBA &TextOutlineColor, float X, float Y) override
 	{
 		STextContainer &TextContainer = GetTextContainer(TextContainerIndex);
 
@@ -1686,7 +1683,7 @@ public:
 		}
 
 		Graphics()->MapScreen(ScreenX0 - X, ScreenY0 - Y, ScreenX1 - X, ScreenY1 - Y);
-		RenderTextContainer(TextContainerIndex, pTextColor, pTextOutlineColor);
+		RenderTextContainer(TextContainerIndex, TextColor, TextOutlineColor);
 		Graphics()->MapScreen(ScreenX0, ScreenY0, ScreenX1, ScreenY1);
 	}
 

--- a/src/engine/graphics.h
+++ b/src/engine/graphics.h
@@ -324,9 +324,9 @@ public:
 	// specific render functions
 	virtual void RenderTileLayer(int BufferContainerIndex, const ColorRGBA &Color, char **pOffsets, unsigned int *IndicedVertexDrawNum, size_t NumIndicesOffset) = 0;
 	virtual void RenderBorderTiles(int BufferContainerIndex, const ColorRGBA &Color, char *pIndexBufferOffset, const vec2 &Offset, const vec2 &Dir, int JumpIndex, unsigned int DrawNum) = 0;
-	virtual void RenderBorderTileLines(int BufferContainerIndex, const ColorRGBA &Color, char *pIndexBufferOffset, const vec2 &Offset, const vec2 &pDir, unsigned int IndexDrawNum, unsigned int RedrawNum) = 0;
+	virtual void RenderBorderTileLines(int BufferContainerIndex, const ColorRGBA &Color, char *pIndexBufferOffset, const vec2 &Offset, const vec2 &Dir, unsigned int IndexDrawNum, unsigned int RedrawNum) = 0;
 	virtual void RenderQuadLayer(int BufferContainerIndex, SQuadRenderInfo *pQuadInfo, int QuadNum, int QuadOffset) = 0;
-	virtual void RenderText(int BufferContainerIndex, int TextQuadNum, int TextureSize, int TextureTextIndex, int TextureTextOutlineIndex, const ColorRGBA &TextColor, const ColorRGBA &TextoutlineColor) = 0;
+	virtual void RenderText(int BufferContainerIndex, int TextQuadNum, int TextureSize, int TextureTextIndex, int TextureTextOutlineIndex, const ColorRGBA &TextColor, const ColorRGBA &TextOutlineColor) = 0;
 
 	// opengl 3.3 functions
 

--- a/src/engine/graphics.h
+++ b/src/engine/graphics.h
@@ -39,7 +39,7 @@ struct SBufferContainerInfo
 
 struct SQuadRenderInfo
 {
-	float m_aColor[4];
+	ColorRGBA m_Color;
 	vec2 m_Offsets;
 	float m_Rotation;
 	// allows easier upload for uniform buffers because of the alignment requirements
@@ -322,11 +322,11 @@ public:
 	virtual void FlushVerticesTex3D() = 0;
 
 	// specific render functions
-	virtual void RenderTileLayer(int BufferContainerIndex, float *pColor, char **pOffsets, unsigned int *IndicedVertexDrawNum, size_t NumIndicesOffset) = 0;
-	virtual void RenderBorderTiles(int BufferContainerIndex, float *pColor, char *pIndexBufferOffset, const vec2 &Offset, const vec2 &Dir, int JumpIndex, unsigned int DrawNum) = 0;
-	virtual void RenderBorderTileLines(int BufferContainerIndex, float *pColor, char *pIndexBufferOffset, const vec2 &Offset, const vec2 &pDir, unsigned int IndexDrawNum, unsigned int RedrawNum) = 0;
+	virtual void RenderTileLayer(int BufferContainerIndex, const ColorRGBA &Color, char **pOffsets, unsigned int *IndicedVertexDrawNum, size_t NumIndicesOffset) = 0;
+	virtual void RenderBorderTiles(int BufferContainerIndex, const ColorRGBA &Color, char *pIndexBufferOffset, const vec2 &Offset, const vec2 &Dir, int JumpIndex, unsigned int DrawNum) = 0;
+	virtual void RenderBorderTileLines(int BufferContainerIndex, const ColorRGBA &Color, char *pIndexBufferOffset, const vec2 &Offset, const vec2 &pDir, unsigned int IndexDrawNum, unsigned int RedrawNum) = 0;
 	virtual void RenderQuadLayer(int BufferContainerIndex, SQuadRenderInfo *pQuadInfo, int QuadNum, int QuadOffset) = 0;
-	virtual void RenderText(int BufferContainerIndex, int TextQuadNum, int TextureSize, int TextureTextIndex, int TextureTextOutlineIndex, float *pTextColor, float *pTextoutlineColor) = 0;
+	virtual void RenderText(int BufferContainerIndex, int TextQuadNum, int TextureSize, int TextureTextIndex, int TextureTextOutlineIndex, const ColorRGBA &TextColor, const ColorRGBA &TextoutlineColor) = 0;
 
 	// opengl 3.3 functions
 

--- a/src/engine/graphics.h
+++ b/src/engine/graphics.h
@@ -40,7 +40,7 @@ struct SBufferContainerInfo
 struct SQuadRenderInfo
 {
 	float m_aColor[4];
-	float m_aOffsets[2];
+	vec2 m_Offsets;
 	float m_Rotation;
 	// allows easier upload for uniform buffers because of the alignment requirements
 	float m_Padding;
@@ -103,14 +103,9 @@ public:
 	uint32_t m_Format;
 };
 
-struct GL_SPoint
-{
-	float x, y;
-};
-struct GL_STexCoord
-{
-	float u, v;
-};
+typedef vec2 GL_SPoint;
+typedef vec2 GL_STexCoord;
+
 struct GL_STexCoord3D
 {
 	GL_STexCoord3D &operator=(const GL_STexCoord &TexCoord)
@@ -119,18 +114,21 @@ struct GL_STexCoord3D
 		v = TexCoord.v;
 		return *this;
 	}
+
+	GL_STexCoord3D &operator=(const vec3 &TexCoord)
+	{
+		u = TexCoord.u;
+		v = TexCoord.v;
+		w = TexCoord.w;
+		return *this;
+	}
+
 	float u, v, w;
 };
-struct GL_SColorf
-{
-	float r, g, b, a;
-};
 
+typedef ColorRGBA GL_SColorf;
 //use normalized color values
-struct GL_SColor
-{
-	unsigned char r, g, b, a;
-};
+typedef vector4_base<unsigned char> GL_SColor;
 
 struct GL_SVertex
 {
@@ -325,8 +323,8 @@ public:
 
 	// specific render functions
 	virtual void RenderTileLayer(int BufferContainerIndex, float *pColor, char **pOffsets, unsigned int *IndicedVertexDrawNum, size_t NumIndicesOffset) = 0;
-	virtual void RenderBorderTiles(int BufferContainerIndex, float *pColor, char *pIndexBufferOffset, float *pOffset, float *pDir, int JumpIndex, unsigned int DrawNum) = 0;
-	virtual void RenderBorderTileLines(int BufferContainerIndex, float *pColor, char *pIndexBufferOffset, float *pOffset, float *pDir, unsigned int IndexDrawNum, unsigned int RedrawNum) = 0;
+	virtual void RenderBorderTiles(int BufferContainerIndex, float *pColor, char *pIndexBufferOffset, const vec2 &Offset, const vec2 &Dir, int JumpIndex, unsigned int DrawNum) = 0;
+	virtual void RenderBorderTileLines(int BufferContainerIndex, float *pColor, char *pIndexBufferOffset, const vec2 &Offset, const vec2 &pDir, unsigned int IndexDrawNum, unsigned int RedrawNum) = 0;
 	virtual void RenderQuadLayer(int BufferContainerIndex, SQuadRenderInfo *pQuadInfo, int QuadNum, int QuadOffset) = 0;
 	virtual void RenderText(int BufferContainerIndex, int TextQuadNum, int TextureSize, int TextureTextIndex, int TextureTextOutlineIndex, float *pTextColor, float *pTextoutlineColor) = 0;
 
@@ -433,7 +431,7 @@ public:
 
 	struct SRenderSpriteInfo
 	{
-		float m_Pos[2];
+		vec2 m_Pos;
 		float m_Scale;
 		float m_Rotation;
 	};

--- a/src/engine/textrender.h
+++ b/src/engine/textrender.h
@@ -105,39 +105,6 @@ public:
 	int m_CursorCharacter;
 };
 
-struct STextRenderColor
-{
-	STextRenderColor() {}
-	STextRenderColor(float r, float g, float b, float a)
-	{
-		Set(r, g, b, a);
-	}
-	STextRenderColor(const ColorRGBA &TextColorRGBA)
-	{
-		Set(TextColorRGBA.r, TextColorRGBA.g, TextColorRGBA.b, TextColorRGBA.a);
-	}
-
-	void Set(float r, float g, float b, float a)
-	{
-		m_R = r;
-		m_G = g;
-		m_B = b;
-		m_A = a;
-	}
-
-	bool operator!=(const STextRenderColor &Other)
-	{
-		return m_R != Other.m_R || m_G != Other.m_G || m_B != Other.m_B || m_A != Other.m_A;
-	}
-
-	operator ColorRGBA()
-	{
-		return ColorRGBA(m_R, m_G, m_B, m_A);
-	}
-
-	float m_R, m_G, m_B, m_A;
-};
-
 class ITextRender : public IInterface
 {
 	MACRO_INTERFACE("textrender", 0)
@@ -172,8 +139,8 @@ public:
 
 	virtual void UploadTextContainer(int TextContainerIndex) = 0;
 
-	virtual void RenderTextContainer(int TextContainerIndex, STextRenderColor *pTextColor, STextRenderColor *pTextOutlineColor) = 0;
-	virtual void RenderTextContainer(int TextContainerIndex, STextRenderColor *pTextColor, STextRenderColor *pTextOutlineColor, float X, float Y) = 0;
+	virtual void RenderTextContainer(int TextContainerIndex, const ColorRGBA &TextColor, const ColorRGBA &TextOutlineColor) = 0;
+	virtual void RenderTextContainer(int TextContainerIndex, const ColorRGBA &TextColor, const ColorRGBA &TextOutlineColor, float X, float Y) = 0;
 
 	virtual void UploadEntityLayerText(void *pTexBuff, int ImageColorChannelCount, int TexWidth, int TexHeight, int TexSubWidth, int TexSubHeight, const char *pText, int Length, float x, float y, int FontHeight) = 0;
 	virtual int AdjustFontSize(const char *pText, int TextLength, int MaxSize, int MaxWidth) = 0;

--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -1350,9 +1350,9 @@ void CChat::OnRender()
 				RenderTools()->RenderTee(pIdleState, &RenderInfo, EMOTE_NORMAL, vec2(1, 0.1f), TeeRenderPos, Blend);
 			}
 
-			STextRenderColor TextOutline(0.f, 0.f, 0.f, 0.3f * Blend);
-			STextRenderColor Text(1.f, 1.f, 1.f, Blend);
-			TextRender()->RenderTextContainer(m_aLines[r].m_TextContainerIndex, &Text, &TextOutline, 0, (y + RealMsgPaddingY / 2.0f) - m_aLines[r].m_TextYOffset);
+			ColorRGBA TextOutline(0.f, 0.f, 0.f, 0.3f * Blend);
+			ColorRGBA Text(1.f, 1.f, 1.f, Blend);
+			TextRender()->RenderTextContainer(m_aLines[r].m_TextContainerIndex, Text, TextOutline, 0, (y + RealMsgPaddingY / 2.0f) - m_aLines[r].m_TextYOffset);
 		}
 	}
 }

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -240,9 +240,9 @@ void CHud::RenderScoreHud()
 				}
 				if(m_aScoreInfo[t].m_TextScoreContainerIndex != -1)
 				{
-					STextRenderColor TColor(1.f, 1.f, 1.f, 1.f);
-					STextRenderColor TOutlineColor(0.f, 0.f, 0.f, 0.3f);
-					TextRender()->RenderTextContainer(m_aScoreInfo[t].m_TextScoreContainerIndex, &TColor, &TOutlineColor);
+					ColorRGBA TColor(1.f, 1.f, 1.f, 1.f);
+					ColorRGBA TOutlineColor(0.f, 0.f, 0.f, 0.3f);
+					TextRender()->RenderTextContainer(m_aScoreInfo[t].m_TextScoreContainerIndex, TColor, TOutlineColor);
 				}
 
 				if(GameFlags & GAMEFLAG_FLAGS)
@@ -280,9 +280,9 @@ void CHud::RenderScoreHud()
 
 						if(m_aScoreInfo[t].m_OptionalNameTextContainerIndex != -1)
 						{
-							STextRenderColor TColor(1.f, 1.f, 1.f, 1.f);
-							STextRenderColor TOutlineColor(0.f, 0.f, 0.f, 0.3f);
-							TextRender()->RenderTextContainer(m_aScoreInfo[t].m_OptionalNameTextContainerIndex, &TColor, &TOutlineColor);
+							ColorRGBA TColor(1.f, 1.f, 1.f, 1.f);
+							ColorRGBA TOutlineColor(0.f, 0.f, 0.f, 0.3f);
+							TextRender()->RenderTextContainer(m_aScoreInfo[t].m_OptionalNameTextContainerIndex, TColor, TOutlineColor);
 						}
 
 						// draw tee of the flag holder
@@ -422,9 +422,9 @@ void CHud::RenderScoreHud()
 				// draw score
 				if(m_aScoreInfo[t].m_TextScoreContainerIndex != -1)
 				{
-					STextRenderColor TColor(1.f, 1.f, 1.f, 1.f);
-					STextRenderColor TOutlineColor(0.f, 0.f, 0.f, 0.3f);
-					TextRender()->RenderTextContainer(m_aScoreInfo[t].m_TextScoreContainerIndex, &TColor, &TOutlineColor);
+					ColorRGBA TColor(1.f, 1.f, 1.f, 1.f);
+					ColorRGBA TOutlineColor(0.f, 0.f, 0.f, 0.3f);
+					TextRender()->RenderTextContainer(m_aScoreInfo[t].m_TextScoreContainerIndex, TColor, TOutlineColor);
 				}
 
 				if(apPlayerInfo[t])
@@ -450,9 +450,9 @@ void CHud::RenderScoreHud()
 
 						if(m_aScoreInfo[t].m_OptionalNameTextContainerIndex != -1)
 						{
-							STextRenderColor TColor(1.f, 1.f, 1.f, 1.f);
-							STextRenderColor TOutlineColor(0.f, 0.f, 0.f, 0.3f);
-							TextRender()->RenderTextContainer(m_aScoreInfo[t].m_OptionalNameTextContainerIndex, &TColor, &TOutlineColor);
+							ColorRGBA TColor(1.f, 1.f, 1.f, 1.f);
+							ColorRGBA TOutlineColor(0.f, 0.f, 0.f, 0.3f);
+							TextRender()->RenderTextContainer(m_aScoreInfo[t].m_OptionalNameTextContainerIndex, TColor, TOutlineColor);
 						}
 
 						// draw tee
@@ -489,9 +489,9 @@ void CHud::RenderScoreHud()
 				}
 				if(m_aScoreInfo[t].m_TextRankContainerIndex != -1)
 				{
-					STextRenderColor TColor(1.f, 1.f, 1.f, 1.f);
-					STextRenderColor TOutlineColor(0.f, 0.f, 0.f, 0.3f);
-					TextRender()->RenderTextContainer(m_aScoreInfo[t].m_TextRankContainerIndex, &TColor, &TOutlineColor);
+					ColorRGBA TColor(1.f, 1.f, 1.f, 1.f);
+					ColorRGBA TOutlineColor(0.f, 0.f, 0.f, 0.3f);
+					TextRender()->RenderTextContainer(m_aScoreInfo[t].m_TextRankContainerIndex, TColor, TOutlineColor);
 				}
 
 				StartY += 8.0f;
@@ -550,17 +550,9 @@ void CHud::RenderTextInfo()
 		else
 			TextRender()->RecreateTextContainerSoft(&Cursor, m_FPSTextContainerIndex, aBuf);
 		TextRender()->SetRenderFlags(OldFlags);
-		STextRenderColor TColor;
-		TColor.m_R = 1.f;
-		TColor.m_G = 1.f;
-		TColor.m_B = 1.f;
-		TColor.m_A = 1.f;
-		STextRenderColor TOutColor;
-		TOutColor.m_R = 0.f;
-		TOutColor.m_G = 0.f;
-		TOutColor.m_B = 0.f;
-		TOutColor.m_A = 0.3f;
-		TextRender()->RenderTextContainer(m_FPSTextContainerIndex, &TColor, &TOutColor);
+		ColorRGBA TColor(1, 1, 1, 1);
+		ColorRGBA TOutColor(0, 0, 0, 0.3f);
+		TextRender()->RenderTextContainer(m_FPSTextContainerIndex, TColor, TOutColor);
 	}
 	if(g_Config.m_ClShowpred)
 	{

--- a/src/game/client/components/killmessages.cpp
+++ b/src/game/client/components/killmessages.cpp
@@ -200,21 +200,21 @@ void CKillMessages::OnRender()
 
 		float x = StartX;
 
-		STextRenderColor TColor(1.f, 1.f, 1.f, 1.f);
-		STextRenderColor TOutlineColor(0.f, 0.f, 0.f, 0.3f);
+		ColorRGBA TColor(1.f, 1.f, 1.f, 1.f);
+		ColorRGBA TOutlineColor(0.f, 0.f, 0.f, 0.3f);
 
 		// render victim name
 		x -= m_aKillmsgs[r].m_VitctimTextWidth;
 		if(m_aKillmsgs[r].m_VictimID >= 0 && g_Config.m_ClChatTeamColors && m_aKillmsgs[r].m_VictimDDTeam)
 		{
-			ColorRGBA rgb = color_cast<ColorRGBA>(ColorHSLA(m_aKillmsgs[r].m_VictimDDTeam / 64.0f, 1.0f, 0.75f));
-			TColor.Set(rgb.r, rgb.g, rgb.b, 1.0f);
+			TColor = color_cast<ColorRGBA>(ColorHSLA(m_aKillmsgs[r].m_VictimDDTeam / 64.0f, 1.0f, 0.75f));
+			TColor.a = 1.f;
 		}
 
 		CreateKillmessageNamesIfNotCreated(m_aKillmsgs[r]);
 
 		if(m_aKillmsgs[r].m_VictimTextContainerIndex != -1)
-			TextRender()->RenderTextContainer(m_aKillmsgs[r].m_VictimTextContainerIndex, &TColor, &TOutlineColor, x, y + (46.f - 36.f) / 2.f);
+			TextRender()->RenderTextContainer(m_aKillmsgs[r].m_VictimTextContainerIndex, TColor, TOutlineColor, x, y + (46.f - 36.f) / 2.f);
 
 		// render victim tee
 		x -= 24.0f;
@@ -299,7 +299,7 @@ void CKillMessages::OnRender()
 			x -= m_aKillmsgs[r].m_KillerTextWidth;
 
 			if(m_aKillmsgs[r].m_KillerTextContainerIndex != -1)
-				TextRender()->RenderTextContainer(m_aKillmsgs[r].m_KillerTextContainerIndex, &TColor, &TOutlineColor, x, y + (46.f - 36.f) / 2.f);
+				TextRender()->RenderTextContainer(m_aKillmsgs[r].m_KillerTextContainerIndex, TColor, TOutlineColor, x, y + (46.f - 36.f) / 2.f);
 		}
 
 		y += 46.0f;

--- a/src/game/client/components/maplayers.cpp
+++ b/src/game/client/components/maplayers.cpp
@@ -1103,7 +1103,7 @@ void CMapLayers::RenderTileLayer(int LayerIndex, ColorRGBA *pColor, CMapItemLaye
 		RenderTileBorder(LayerIndex, pColor, pTileLayer, pGroup, BorderX0, BorderY0, BorderX1, BorderY1, (int)(-floorf((-ScreenX1) / 32.f)) - BorderX0, (int)(-floorf((-ScreenY1) / 32.f)) - BorderY0);
 }
 
-void CMapLayers::RenderTileBorderCornerTiles(int WidthOffsetToOrigin, int HeightOffsetToOrigin, int TileCountWidth, int TileCountHeight, int BufferContainerIndex, float *pColor, offset_ptr_size IndexBufferOffset, float *pOffset, float *pDir)
+void CMapLayers::RenderTileBorderCornerTiles(int WidthOffsetToOrigin, int HeightOffsetToOrigin, int TileCountWidth, int TileCountHeight, int BufferContainerIndex, float *pColor, offset_ptr_size IndexBufferOffset, const vec2 &Offset, const vec2 &Dir)
 {
 	// if border is still in range of the original corner, it doesn't needs to be redrawn
 	bool CornerVisible = (WidthOffsetToOrigin - 1 < TileCountWidth) && (HeightOffsetToOrigin - 1 < TileCountHeight);
@@ -1113,7 +1113,7 @@ void CMapLayers::RenderTileBorderCornerTiles(int WidthOffsetToOrigin, int Height
 
 	int Count = (CountX * CountY) - (CornerVisible ? 1 : 0); // Don't draw the corner again
 
-	Graphics()->RenderBorderTiles(BufferContainerIndex, pColor, IndexBufferOffset, pOffset, pDir, CountX, Count);
+	Graphics()->RenderBorderTiles(BufferContainerIndex, pColor, IndexBufferOffset, Offset, Dir, CountX, Count);
 }
 
 void CMapLayers::RenderTileBorder(int LayerIndex, ColorRGBA *pColor, CMapItemLayerTilemap *pTileLayer, CMapItemGroup *pGroup, int BorderX0, int BorderY0, int BorderX1, int BorderY1, int ScreenWidthTileCount, int ScreenHeightTileCount)
@@ -1151,7 +1151,7 @@ void CMapLayers::RenderTileBorder(int LayerIndex, ColorRGBA *pColor, CMapItemLay
 				Dir.x = 32.f;
 				Dir.y = 32.f;
 
-				RenderTileBorderCornerTiles(absolute(BorderX0) + 1, absolute(BorderY0) + 1, CountWidth, CountHeight, Visuals.m_BufferContainerIndex, (float *)pColor, (offset_ptr_size)Visuals.m_BorderTopLeft.IndexBufferByteOffset(), (float *)&Offset, (float *)&Dir);
+				RenderTileBorderCornerTiles(absolute(BorderX0) + 1, absolute(BorderY0) + 1, CountWidth, CountHeight, Visuals.m_BufferContainerIndex, (float *)pColor, (offset_ptr_size)Visuals.m_BorderTopLeft.IndexBufferByteOffset(), Offset, Dir);
 			}
 		}
 		if(BorderY1 >= pTileLayer->m_Height - 1)
@@ -1165,7 +1165,7 @@ void CMapLayers::RenderTileBorder(int LayerIndex, ColorRGBA *pColor, CMapItemLay
 				Dir.x = 32.f;
 				Dir.y = -32.f;
 
-				RenderTileBorderCornerTiles(absolute(BorderX0) + 1, (BorderY1 - (pTileLayer->m_Height - 1)) + 1, CountWidth, CountHeight, Visuals.m_BufferContainerIndex, (float *)pColor, (offset_ptr_size)Visuals.m_BorderBottomLeft.IndexBufferByteOffset(), (float *)&Offset, (float *)&Dir);
+				RenderTileBorderCornerTiles(absolute(BorderX0) + 1, (BorderY1 - (pTileLayer->m_Height - 1)) + 1, CountWidth, CountHeight, Visuals.m_BufferContainerIndex, (float *)pColor, (offset_ptr_size)Visuals.m_BorderBottomLeft.IndexBufferByteOffset(), Offset, Dir);
 			}
 		}
 	}
@@ -1182,7 +1182,7 @@ void CMapLayers::RenderTileBorder(int LayerIndex, ColorRGBA *pColor, CMapItemLay
 			vec2 Dir;
 			Dir.x = 32.f;
 			Dir.y = 0.f;
-			Graphics()->RenderBorderTileLines(Visuals.m_BufferContainerIndex, (float *)pColor, pOffset, (float *)&Offset, (float *)&Dir, DrawNum, minimum(absolute(BorderX0), CountWidth));
+			Graphics()->RenderBorderTileLines(Visuals.m_BufferContainerIndex, (float *)pColor, pOffset, Offset, Dir, DrawNum, minimum(absolute(BorderX0), CountWidth));
 		}
 	}
 
@@ -1200,7 +1200,7 @@ void CMapLayers::RenderTileBorder(int LayerIndex, ColorRGBA *pColor, CMapItemLay
 				Dir.x = -32.f;
 				Dir.y = 32.f;
 
-				RenderTileBorderCornerTiles((BorderX1 - (pTileLayer->m_Width - 1)) + 1, absolute(BorderY0) + 1, CountWidth, CountHeight, Visuals.m_BufferContainerIndex, (float *)pColor, (offset_ptr_size)Visuals.m_BorderTopRight.IndexBufferByteOffset(), (float *)&Offset, (float *)&Dir);
+				RenderTileBorderCornerTiles((BorderX1 - (pTileLayer->m_Width - 1)) + 1, absolute(BorderY0) + 1, CountWidth, CountHeight, Visuals.m_BufferContainerIndex, (float *)pColor, (offset_ptr_size)Visuals.m_BorderTopRight.IndexBufferByteOffset(), Offset, Dir);
 			}
 		}
 		if(BorderY1 >= pTileLayer->m_Height - 1)
@@ -1214,7 +1214,7 @@ void CMapLayers::RenderTileBorder(int LayerIndex, ColorRGBA *pColor, CMapItemLay
 				Dir.x = -32.f;
 				Dir.y = -32.f;
 
-				RenderTileBorderCornerTiles((BorderX1 - (pTileLayer->m_Width - 1)) + 1, (BorderY1 - (pTileLayer->m_Height - 1)) + 1, CountWidth, CountHeight, Visuals.m_BufferContainerIndex, (float *)pColor, (offset_ptr_size)Visuals.m_BorderBottomRight.IndexBufferByteOffset(), (float *)&Offset, (float *)&Dir);
+				RenderTileBorderCornerTiles((BorderX1 - (pTileLayer->m_Width - 1)) + 1, (BorderY1 - (pTileLayer->m_Height - 1)) + 1, CountWidth, CountHeight, Visuals.m_BufferContainerIndex, (float *)pColor, (offset_ptr_size)Visuals.m_BorderBottomRight.IndexBufferByteOffset(), Offset, Dir);
 			}
 		}
 	}
@@ -1231,7 +1231,7 @@ void CMapLayers::RenderTileBorder(int LayerIndex, ColorRGBA *pColor, CMapItemLay
 			vec2 Dir;
 			Dir.x = -32.f;
 			Dir.y = 0.f;
-			Graphics()->RenderBorderTileLines(Visuals.m_BufferContainerIndex, (float *)pColor, pOffset, (float *)&Offset, (float *)&Dir, DrawNum, minimum((BorderX1 - (pTileLayer->m_Width - 1)), CountWidth));
+			Graphics()->RenderBorderTileLines(Visuals.m_BufferContainerIndex, (float *)pColor, pOffset, Offset, Dir, DrawNum, minimum((BorderX1 - (pTileLayer->m_Width - 1)), CountWidth));
 		}
 	}
 	if(BorderY0 < 0)
@@ -1247,7 +1247,7 @@ void CMapLayers::RenderTileBorder(int LayerIndex, ColorRGBA *pColor, CMapItemLay
 			vec2 Dir;
 			Dir.x = 0.f;
 			Dir.y = 32.f;
-			Graphics()->RenderBorderTileLines(Visuals.m_BufferContainerIndex, (float *)pColor, pOffset, (float *)&Offset, (float *)&Dir, DrawNum, minimum(absolute(BorderY0), CountHeight));
+			Graphics()->RenderBorderTileLines(Visuals.m_BufferContainerIndex, (float *)pColor, pOffset, Offset, Dir, DrawNum, minimum(absolute(BorderY0), CountHeight));
 		}
 	}
 	if(BorderY1 >= pTileLayer->m_Height)
@@ -1263,7 +1263,7 @@ void CMapLayers::RenderTileBorder(int LayerIndex, ColorRGBA *pColor, CMapItemLay
 			vec2 Dir;
 			Dir.x = 0.f;
 			Dir.y = -32.f;
-			Graphics()->RenderBorderTileLines(Visuals.m_BufferContainerIndex, (float *)pColor, pOffset, (float *)&Offset, (float *)&Dir, DrawNum, minimum((BorderY1 - (pTileLayer->m_Height - 1)), CountHeight));
+			Graphics()->RenderBorderTileLines(Visuals.m_BufferContainerIndex, (float *)pColor, pOffset, Offset, Dir, DrawNum, minimum((BorderY1 - (pTileLayer->m_Height - 1)), CountHeight));
 		}
 	}
 }
@@ -1328,7 +1328,7 @@ void CMapLayers::RenderKillTileBorder(int LayerIndex, ColorRGBA *pColor, CMapIte
 
 		int Count = (absolute(BorderX0) - 201) * (BorderY1 - BorderY0);
 
-		Graphics()->RenderBorderTiles(Visuals.m_BufferContainerIndex, (float *)pColor, (offset_ptr_size)Visuals.m_BorderKillTile.IndexBufferByteOffset(), (float *)&Offset, (float *)&Dir, (absolute(BorderX0) - 201), Count);
+		Graphics()->RenderBorderTiles(Visuals.m_BufferContainerIndex, (float *)pColor, (offset_ptr_size)Visuals.m_BorderKillTile.IndexBufferByteOffset(), Offset, Dir, (absolute(BorderX0) - 201), Count);
 	}
 	// Draw top kill tile border
 	if(BorderY0 < -201)
@@ -1346,7 +1346,7 @@ void CMapLayers::RenderKillTileBorder(int LayerIndex, ColorRGBA *pColor, CMapIte
 
 		int Count = (OffX1 - OffX0) * (absolute(BorderY0) - 201);
 
-		Graphics()->RenderBorderTiles(Visuals.m_BufferContainerIndex, (float *)pColor, (offset_ptr_size)Visuals.m_BorderKillTile.IndexBufferByteOffset(), (float *)&Offset, (float *)&Dir, (OffX1 - OffX0), Count);
+		Graphics()->RenderBorderTiles(Visuals.m_BufferContainerIndex, (float *)pColor, (offset_ptr_size)Visuals.m_BorderKillTile.IndexBufferByteOffset(), Offset, Dir, (OffX1 - OffX0), Count);
 	}
 	if(BorderX1 >= pTileLayer->m_Width + 201)
 	{
@@ -1359,7 +1359,7 @@ void CMapLayers::RenderKillTileBorder(int LayerIndex, ColorRGBA *pColor, CMapIte
 
 		int Count = (BorderX1 - (pTileLayer->m_Width + 201)) * (BorderY1 - BorderY0);
 
-		Graphics()->RenderBorderTiles(Visuals.m_BufferContainerIndex, (float *)pColor, (offset_ptr_size)Visuals.m_BorderKillTile.IndexBufferByteOffset(), (float *)&Offset, (float *)&Dir, (BorderX1 - (pTileLayer->m_Width + 201)), Count);
+		Graphics()->RenderBorderTiles(Visuals.m_BufferContainerIndex, (float *)pColor, (offset_ptr_size)Visuals.m_BorderKillTile.IndexBufferByteOffset(), Offset, Dir, (BorderX1 - (pTileLayer->m_Width + 201)), Count);
 	}
 	if(BorderY1 >= pTileLayer->m_Height + 201)
 	{
@@ -1376,7 +1376,7 @@ void CMapLayers::RenderKillTileBorder(int LayerIndex, ColorRGBA *pColor, CMapIte
 
 		int Count = (OffX1 - OffX0) * (BorderY1 - (pTileLayer->m_Height + 201));
 
-		Graphics()->RenderBorderTiles(Visuals.m_BufferContainerIndex, (float *)pColor, (offset_ptr_size)Visuals.m_BorderKillTile.IndexBufferByteOffset(), (float *)&Offset, (float *)&Dir, (OffX1 - OffX0), Count);
+		Graphics()->RenderBorderTiles(Visuals.m_BufferContainerIndex, (float *)pColor, (offset_ptr_size)Visuals.m_BorderKillTile.IndexBufferByteOffset(), Offset, Dir, (OffX1 - OffX0), Count);
 	}
 }
 
@@ -1439,8 +1439,8 @@ void CMapLayers::RenderQuadLayer(int LayerIndex, CMapItemLayerQuads *pQuadLayer,
 		{
 			SQuadRenderInfo &QInfo = s_vQuadRenderInfo[QuadsRenderCount++];
 			mem_copy(QInfo.m_aColor, aColor, sizeof(aColor));
-			QInfo.m_aOffsets[0] = OffsetX;
-			QInfo.m_aOffsets[1] = OffsetY;
+			QInfo.m_Offsets.x = OffsetX;
+			QInfo.m_Offsets.y = OffsetY;
 			QInfo.m_Rotation = Rot;
 		}
 	}

--- a/src/game/client/components/maplayers.h
+++ b/src/game/client/components/maplayers.h
@@ -132,7 +132,7 @@ class CMapLayers : public CComponent
 
 	void LayersOfGroupCount(CMapItemGroup *pGroup, int &TileLayerCount, int &QuadLayerCount, bool &PassedGameLayer);
 
-	void RenderTileBorderCornerTiles(int WidthOffsetToOrigin, int HeightOffsetToOrigin, int TileCountWidth, int TileCountHeight, int BufferContainerIndex, float *pColor, offset_ptr_size IndexBufferOffset, float *pOffset, float *pDir);
+	void RenderTileBorderCornerTiles(int WidthOffsetToOrigin, int HeightOffsetToOrigin, int TileCountWidth, int TileCountHeight, int BufferContainerIndex, float *pColor, offset_ptr_size IndexBufferOffset, const vec2 &Offset, const vec2 &Dir);
 
 protected:
 	virtual bool CanRenderMenuBackground() { return true; }

--- a/src/game/client/components/maplayers.h
+++ b/src/game/client/components/maplayers.h
@@ -132,7 +132,7 @@ class CMapLayers : public CComponent
 
 	void LayersOfGroupCount(CMapItemGroup *pGroup, int &TileLayerCount, int &QuadLayerCount, bool &PassedGameLayer);
 
-	void RenderTileBorderCornerTiles(int WidthOffsetToOrigin, int HeightOffsetToOrigin, int TileCountWidth, int TileCountHeight, int BufferContainerIndex, float *pColor, offset_ptr_size IndexBufferOffset, const vec2 &Offset, const vec2 &Dir);
+	void RenderTileBorderCornerTiles(int WidthOffsetToOrigin, int HeightOffsetToOrigin, int TileCountWidth, int TileCountHeight, int BufferContainerIndex, const ColorRGBA &Color, offset_ptr_size IndexBufferOffset, const vec2 &Offset, const vec2 &Dir);
 
 protected:
 	virtual bool CanRenderMenuBackground() { return true; }
@@ -154,14 +154,14 @@ public:
 	virtual void OnRender() override;
 	virtual void OnMapLoad() override;
 
-	void RenderTileLayer(int LayerIndex, ColorRGBA *pColor, CMapItemLayerTilemap *pTileLayer, CMapItemGroup *pGroup);
-	void RenderTileBorder(int LayerIndex, ColorRGBA *pColor, CMapItemLayerTilemap *pTileLayer, CMapItemGroup *pGroup, int BorderX0, int BorderY0, int BorderX1, int BorderY1, int ScreenWidthTileCount, int ScreenHeightTileCount);
-	void RenderKillTileBorder(int LayerIndex, ColorRGBA *pColor, CMapItemLayerTilemap *pTileLayer, CMapItemGroup *pGroup);
+	void RenderTileLayer(int LayerIndex, ColorRGBA &Color, CMapItemLayerTilemap *pTileLayer, CMapItemGroup *pGroup);
+	void RenderTileBorder(int LayerIndex, const ColorRGBA &Color, CMapItemLayerTilemap *pTileLayer, CMapItemGroup *pGroup, int BorderX0, int BorderY0, int BorderX1, int BorderY1, int ScreenWidthTileCount, int ScreenHeightTileCount);
+	void RenderKillTileBorder(int LayerIndex, const ColorRGBA &Color, CMapItemLayerTilemap *pTileLayer, CMapItemGroup *pGroup);
 	void RenderQuadLayer(int LayerIndex, CMapItemLayerQuads *pQuadLayer, CMapItemGroup *pGroup, bool ForceRender = false);
 
 	void EnvelopeUpdate();
 
-	static void EnvelopeEval(int TimeOffsetMillis, int Env, float *pChannels, void *pUser);
+	static void EnvelopeEval(int TimeOffsetMillis, int Env, ColorRGBA &Channels, void *pUser);
 };
 
 #endif

--- a/src/game/client/components/mapsounds.cpp
+++ b/src/game/client/components/mapsounds.cpp
@@ -198,10 +198,10 @@ void CMapSounds::OnRender()
 
 						if(Voice.m_pSource->m_PosEnv >= 0)
 						{
-							float aChannels[4];
-							CMapLayers::EnvelopeEval(Voice.m_pSource->m_PosEnvOffset, Voice.m_pSource->m_PosEnv, aChannels, &m_pClient->m_MapLayersBackGround);
-							OffsetX = aChannels[0];
-							OffsetY = aChannels[1];
+							ColorRGBA Channels;
+							CMapLayers::EnvelopeEval(Voice.m_pSource->m_PosEnvOffset, Voice.m_pSource->m_PosEnv, Channels, &m_pClient->m_MapLayersBackGround);
+							OffsetX = Channels.r;
+							OffsetY = Channels.g;
 						}
 
 						float x = fx2f(Voice.m_pSource->m_Position.x) + OffsetX;
@@ -217,9 +217,9 @@ void CMapSounds::OnRender()
 
 						if(Voice.m_pSource->m_SoundEnv >= 0)
 						{
-							float aChannels[4];
-							CMapLayers::EnvelopeEval(Voice.m_pSource->m_SoundEnvOffset, Voice.m_pSource->m_SoundEnv, aChannels, &m_pClient->m_MapLayersBackGround);
-							float Volume = clamp(aChannels[0], 0.0f, 1.0f);
+							ColorRGBA Channels;
+							CMapLayers::EnvelopeEval(Voice.m_pSource->m_SoundEnvOffset, Voice.m_pSource->m_SoundEnv, Channels, &m_pClient->m_MapLayersBackGround);
+							float Volume = clamp(Channels.r, 0.0f, 1.0f);
 
 							Sound()->SetVoiceVolume(Voice.m_Voice, Volume);
 						}

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -188,10 +188,10 @@ class CMenus : public CComponent
 			Index = 1;
 		Graphics()->TextureClear();
 		Graphics()->RenderQuadContainer(UIElement.Get(Index)->m_UIRectQuadContainer, -1);
-		STextRenderColor ColorText(TextRender()->DefaultTextColor());
-		STextRenderColor ColorTextOutline(TextRender()->DefaultTextOutlineColor());
+		ColorRGBA ColorText(TextRender()->DefaultTextColor());
+		ColorRGBA ColorTextOutline(TextRender()->DefaultTextOutlineColor());
 		if(UIElement.Get(0)->m_UITextContainer != -1)
-			TextRender()->RenderTextContainer(UIElement.Get(0)->m_UITextContainer, &ColorText, &ColorTextOutline);
+			TextRender()->RenderTextContainer(UIElement.Get(0)->m_UITextContainer, ColorText, ColorTextOutline);
 		return UI()->DoButtonLogic(pID, Checked, pRect);
 	}
 

--- a/src/game/client/components/nameplates.cpp
+++ b/src/game/client/components/nameplates.cpp
@@ -141,41 +141,41 @@ void CNamePlates::RenderNameplatePos(vec2 Position, const CNetObj_PlayerInfo *pP
 		if(g_Config.m_ClNameplatesTeamcolors && m_pClient->m_Teams.Team(ClientID))
 			rgb = color_cast<ColorRGBA>(ColorHSLA(m_pClient->m_Teams.Team(ClientID) / 64.0f, 1.0f, 0.75f));
 
-		STextRenderColor TColor;
-		STextRenderColor TOutlineColor;
+		ColorRGBA TColor;
+		ColorRGBA TOutlineColor;
 
 		if(OtherTeam && !ForceAlpha)
 		{
-			TOutlineColor.Set(0.0f, 0.0f, 0.0f, 0.2f * g_Config.m_ClShowOthersAlpha / 100.0f);
-			TColor.Set(rgb.r, rgb.g, rgb.b, g_Config.m_ClShowOthersAlpha / 100.0f);
+			TOutlineColor = ColorRGBA(0.0f, 0.0f, 0.0f, 0.2f * g_Config.m_ClShowOthersAlpha / 100.0f);
+			TColor = ColorRGBA(rgb.r, rgb.g, rgb.b, g_Config.m_ClShowOthersAlpha / 100.0f);
 		}
 		else
 		{
-			TOutlineColor.Set(0.0f, 0.0f, 0.0f, 0.5f * a);
-			TColor.Set(rgb.r, rgb.g, rgb.b, a);
+			TOutlineColor = ColorRGBA(0.0f, 0.0f, 0.0f, 0.5f * a);
+			TColor = ColorRGBA(rgb.r, rgb.g, rgb.b, a);
 		}
 		if(g_Config.m_ClNameplatesTeamcolors && m_pClient->m_Snap.m_pGameInfoObj && m_pClient->m_Snap.m_pGameInfoObj->m_GameFlags & GAMEFLAG_TEAMS)
 		{
 			if(m_pClient->m_aClients[ClientID].m_Team == TEAM_RED)
-				TColor.Set(1.0f, 0.5f, 0.5f, a);
+				TColor = ColorRGBA(1.0f, 0.5f, 0.5f, a);
 			else if(m_pClient->m_aClients[ClientID].m_Team == TEAM_BLUE)
-				TColor.Set(0.7f, 0.7f, 1.0f, a);
+				TColor = ColorRGBA(0.7f, 0.7f, 1.0f, a);
 		}
 
-		TOutlineColor.m_A *= Alpha;
-		TColor.m_A *= Alpha;
+		TOutlineColor.a *= Alpha;
+		TColor.a *= Alpha;
 
 		if(m_aNamePlates[ClientID].m_NameTextContainerIndex != -1)
 		{
 			YOffset -= FontSize;
-			TextRender()->RenderTextContainer(m_aNamePlates[ClientID].m_NameTextContainerIndex, &TColor, &TOutlineColor, Position.x - tw / 2.0f, YOffset);
+			TextRender()->RenderTextContainer(m_aNamePlates[ClientID].m_NameTextContainerIndex, TColor, TOutlineColor, Position.x - tw / 2.0f, YOffset);
 		}
 
 		if(g_Config.m_ClNameplatesClan)
 		{
 			YOffset -= FontSizeClan;
 			if(m_aNamePlates[ClientID].m_ClanNameTextContainerIndex != -1)
-				TextRender()->RenderTextContainer(m_aNamePlates[ClientID].m_ClanNameTextContainerIndex, &TColor, &TOutlineColor, Position.x - m_aNamePlates[ClientID].m_ClanNameTextWidth / 2.0f, YOffset);
+				TextRender()->RenderTextContainer(m_aNamePlates[ClientID].m_ClanNameTextContainerIndex, TColor, TOutlineColor, Position.x - m_aNamePlates[ClientID].m_ClanNameTextWidth / 2.0f, YOffset);
 		}
 
 		if(g_Config.m_ClNameplatesFriendMark && m_pClient->m_aClients[ClientID].m_Friend)

--- a/src/game/client/components/particles.cpp
+++ b/src/game/client/components/particles.cpp
@@ -226,7 +226,7 @@ void CParticles::RenderGroup(int Group)
 		int CurParticleRenderCount = 0;
 
 		// batching makes sense for stuff like ninja particles
-		float LastColor[4];
+		ColorRGBA LastColor;
 		int LastQuadOffset = 0;
 
 		if(i != -1)
@@ -237,10 +237,10 @@ void CParticles::RenderGroup(int Group)
 				float a = m_aParticles[i].m_Life / m_aParticles[i].m_LifeSpan;
 				Alpha = mix(m_aParticles[i].m_StartAlpha, m_aParticles[i].m_EndAlpha, a);
 			}
-			LastColor[0] = m_aParticles[i].m_Color.r;
-			LastColor[1] = m_aParticles[i].m_Color.g;
-			LastColor[2] = m_aParticles[i].m_Color.b;
-			LastColor[3] = Alpha;
+			LastColor.r = m_aParticles[i].m_Color.r;
+			LastColor.g = m_aParticles[i].m_Color.g;
+			LastColor.b = m_aParticles[i].m_Color.b;
+			LastColor.a = Alpha;
 
 			Graphics()->SetColor(
 				m_aParticles[i].m_Color.r,
@@ -266,7 +266,7 @@ void CParticles::RenderGroup(int Group)
 			// the current position, respecting the size, is inside the viewport, render it, else ignore
 			if(ParticleIsVisibleOnScreen(p, Size))
 			{
-				if((size_t)CurParticleRenderCount == gs_GraphicsMaxParticlesRenderCount || LastColor[0] != m_aParticles[i].m_Color.r || LastColor[1] != m_aParticles[i].m_Color.g || LastColor[2] != m_aParticles[i].m_Color.b || LastColor[3] != Alpha || LastQuadOffset != QuadOffset)
+				if((size_t)CurParticleRenderCount == gs_GraphicsMaxParticlesRenderCount || LastColor.r != m_aParticles[i].m_Color.r || LastColor.g != m_aParticles[i].m_Color.g || LastColor.b != m_aParticles[i].m_Color.b || LastColor.a != Alpha || LastQuadOffset != QuadOffset)
 				{
 					Graphics()->TextureSet(aParticles[LastQuadOffset - FirstParticleOffset]);
 					Graphics()->RenderQuadContainerAsSpriteMultiple(ParticleQuadContainerIndex, LastQuadOffset - FirstParticleOffset, CurParticleRenderCount, s_aParticleRenderInfo);
@@ -279,10 +279,10 @@ void CParticles::RenderGroup(int Group)
 						m_aParticles[i].m_Color.b,
 						Alpha);
 
-					LastColor[0] = m_aParticles[i].m_Color.r;
-					LastColor[1] = m_aParticles[i].m_Color.g;
-					LastColor[2] = m_aParticles[i].m_Color.b;
-					LastColor[3] = Alpha;
+					LastColor.r = m_aParticles[i].m_Color.r;
+					LastColor.g = m_aParticles[i].m_Color.g;
+					LastColor.b = m_aParticles[i].m_Color.b;
+					LastColor.a = Alpha;
 				}
 
 				s_aParticleRenderInfo[CurParticleRenderCount].m_Pos[0] = p.x;

--- a/src/game/client/render.h
+++ b/src/game/client/render.h
@@ -69,7 +69,7 @@ enum
 	TILERENDERFLAG_EXTEND = 4,
 };
 
-typedef void (*ENVELOPE_EVAL)(int TimeOffsetMillis, int Env, float *pChannels, void *pUser);
+typedef void (*ENVELOPE_EVAL)(int TimeOffsetMillis, int Env, ColorRGBA &Channels, void *pUser);
 
 class CRenderTools
 {
@@ -130,7 +130,7 @@ public:
 	void RenderTee(class CAnimState *pAnim, CTeeRenderInfo *pInfo, int Emote, vec2 Dir, vec2 Pos, float Alpha = 1.0f);
 
 	// map render methods (render_map.cpp)
-	static void RenderEvalEnvelope(CEnvPoint *pPoints, int NumPoints, int Channels, std::chrono::nanoseconds TimeNanos, float *pResult);
+	static void RenderEvalEnvelope(CEnvPoint *pPoints, int NumPoints, int Channels, std::chrono::nanoseconds TimeNanos, ColorRGBA &Result);
 	void RenderQuads(CQuad *pQuads, int NumQuads, int Flags, ENVELOPE_EVAL pfnEval, void *pUser);
 	void ForceRenderQuads(CQuad *pQuads, int NumQuads, int Flags, ENVELOPE_EVAL pfnEval, void *pUser, float Alpha = 1.0f);
 	void RenderTilemap(CTile *pTiles, int w, int h, float Scale, ColorRGBA Color, int RenderFlags, ENVELOPE_EVAL pfnEval, void *pUser, int ColorEnv, int ColorEnvOffset);

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -35,8 +35,8 @@ void CUIElement::SUIElementRect::Reset()
 	m_Height = -1;
 	m_Text.clear();
 	mem_zero(&m_Cursor, sizeof(m_Cursor));
-	m_TextColor.Set(-1, -1, -1, -1);
-	m_TextOutlineColor.Set(-1, -1, -1, -1);
+	m_TextColor = ColorRGBA(-1, -1, -1, -1);
+	m_TextOutlineColor = ColorRGBA(-1, -1, -1, -1);
 	m_QuadColor = ColorRGBA(-1, -1, -1, -1);
 }
 
@@ -675,10 +675,10 @@ void CUI::DoLabelStreamed(CUIElement::SUIElementRect &RectEl, float x, float y, 
 		DoLabel(RectEl, &TmpRect, pText, Size, Align, Props, StrLen, pReadCursor);
 	}
 
-	STextRenderColor ColorText(RectEl.m_TextColor);
-	STextRenderColor ColorTextOutline(RectEl.m_TextOutlineColor);
+	ColorRGBA ColorText(RectEl.m_TextColor);
+	ColorRGBA ColorTextOutline(RectEl.m_TextOutlineColor);
 	if(RectEl.m_UITextContainer != -1)
-		TextRender()->RenderTextContainer(RectEl.m_UITextContainer, &ColorText, &ColorTextOutline);
+		TextRender()->RenderTextContainer(RectEl.m_UITextContainer, ColorText, ColorTextOutline);
 }
 
 void CUI::DoLabelStreamed(CUIElement::SUIElementRect &RectEl, const CUIRect *pRect, const char *pText, float Size, int Align, float MaxWidth, int AlignVertically, bool StopAtEnd, int StrLen, CTextCursor *pReadCursor)

--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -144,8 +144,8 @@ public:
 
 		CTextCursor m_Cursor;
 
-		STextRenderColor m_TextColor;
-		STextRenderColor m_TextOutlineColor;
+		ColorRGBA m_TextColor;
+		ColorRGBA m_TextOutlineColor;
 
 		SUIElementRect();
 

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -270,15 +270,12 @@ void CEditorImage::AnalyseTileFlags()
 	}
 }
 
-void CEditor::EnvelopeEval(int TimeOffsetMillis, int Env, float *pChannels, void *pUser)
+void CEditor::EnvelopeEval(int TimeOffsetMillis, int Env, ColorRGBA &Channels, void *pUser)
 {
 	CEditor *pThis = (CEditor *)pUser;
 	if(Env < 0 || Env >= (int)pThis->m_Map.m_vpEnvelopes.size())
 	{
-		pChannels[0] = 0;
-		pChannels[1] = 0;
-		pChannels[2] = 0;
-		pChannels[3] = 0;
+		Channels = ColorRGBA();
 		return;
 	}
 
@@ -286,7 +283,7 @@ void CEditor::EnvelopeEval(int TimeOffsetMillis, int Env, float *pChannels, void
 	float t = pThis->m_AnimateTime;
 	t *= pThis->m_AnimateSpeed;
 	t += (TimeOffsetMillis / 1000.0f);
-	e->Eval(t, pChannels);
+	e->Eval(t, Channels);
 }
 
 /********************************************************
@@ -5074,11 +5071,11 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 					// add point
 					int Time = (int)(((UI()->MouseX() - View.x) * TimeScale) * 1000.0f);
 					//float env_y = (UI()->MouseY()-view.y)/TimeScale;
-					float aChannels[4];
-					pEnvelope->Eval(Time / 1000.0f, aChannels);
+					ColorRGBA Channels;
+					pEnvelope->Eval(Time / 1000.0f, Channels);
 					pEnvelope->AddPoint(Time,
-						f2fx(aChannels[0]), f2fx(aChannels[1]),
-						f2fx(aChannels[2]), f2fx(aChannels[3]));
+						f2fx(Channels.r), f2fx(Channels.g),
+						f2fx(Channels.b), f2fx(Channels.a));
 					m_Map.m_Modified = true;
 				}
 
@@ -5100,16 +5097,16 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 					Graphics()->SetColor(aColors[c].r * 0.5f, aColors[c].g * 0.5f, aColors[c].b * 0.5f, 1);
 
 				float PrevX = 0;
-				float aResults[4];
-				pEnvelope->Eval(0.000001f, aResults);
-				float PrevValue = aResults[c];
+				ColorRGBA Channels;
+				pEnvelope->Eval(0.000001f, Channels);
+				float PrevValue = Channels[c];
 
 				int Steps = (int)((View.w / UI()->Screen()->w) * Graphics()->ScreenWidth());
 				for(int i = 1; i <= Steps; i++)
 				{
 					float a = i / (float)Steps;
-					pEnvelope->Eval(a * EndTime, aResults);
-					float v = aResults[c];
+					pEnvelope->Eval(a * EndTime, Channels);
+					float v = Channels[c];
 					v = (v - Bottom) / (Top - Bottom);
 
 					IGraphics::CLineItem LineItem(View.x + PrevX * View.w, View.y + View.h - PrevValue * View.h, View.x + a * View.w, View.y + View.h - v * View.h);

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -81,9 +81,9 @@ public:
 		}
 	}
 
-	int Eval(float Time, float *pResult)
+	int Eval(float Time, ColorRGBA &Color)
 	{
-		CRenderTools::RenderEvalEnvelope(&m_vPoints[0], m_vPoints.size(), m_Channels, std::chrono::nanoseconds((int64_t)((double)Time * (double)std::chrono::nanoseconds(1s).count())), pResult);
+		CRenderTools::RenderEvalEnvelope(&m_vPoints[0], m_vPoints.size(), m_Channels, std::chrono::nanoseconds((int64_t)((double)Time * (double)std::chrono::nanoseconds(1s).count())), Color);
 		return m_Channels;
 	}
 
@@ -999,7 +999,7 @@ public:
 	CEditorMap m_Map;
 	int m_ShiftBy;
 
-	static void EnvelopeEval(int TimeOffsetMillis, int Env, float *pChannels, void *pUser);
+	static void EnvelopeEval(int TimeOffsetMillis, int Env, ColorRGBA &Channels, void *pUser);
 
 	float m_CommandBox;
 	char m_aSettingsCommand[256];

--- a/src/game/editor/layer_sounds.cpp
+++ b/src/game/editor/layer_sounds.cpp
@@ -30,10 +30,10 @@ void CLayerSounds::Render(bool Tileset)
 
 		if(Source.m_PosEnv >= 0)
 		{
-			float aChannels[4];
-			m_pEditor->EnvelopeEval(Source.m_PosEnvOffset, Source.m_PosEnv, aChannels, m_pEditor);
-			OffsetX = aChannels[0];
-			OffsetY = aChannels[1];
+			ColorRGBA Channels;
+			m_pEditor->EnvelopeEval(Source.m_PosEnvOffset, Source.m_PosEnv, Channels, m_pEditor);
+			OffsetX = Channels.r;
+			OffsetY = Channels.g;
 		}
 
 		switch(Source.m_Shape.m_Type)
@@ -80,10 +80,10 @@ void CLayerSounds::Render(bool Tileset)
 
 		if(Source.m_PosEnv >= 0)
 		{
-			float aChannels[4];
-			m_pEditor->EnvelopeEval(Source.m_PosEnvOffset, Source.m_PosEnv, aChannels, m_pEditor);
-			OffsetX = aChannels[0];
-			OffsetY = aChannels[1];
+			ColorRGBA Channels;
+			m_pEditor->EnvelopeEval(Source.m_PosEnvOffset, Source.m_PosEnv, Channels, m_pEditor);
+			OffsetX = Channels.r;
+			OffsetY = Channels.g;
 		}
 
 		m_pEditor->RenderTools()->DrawSprite(fx2f(Source.m_Position.x) + OffsetX, fx2f(Source.m_Position.y) + OffsetY, s_SourceVisualSize * m_pEditor->m_WorldZoom);

--- a/src/game/mapitems.h
+++ b/src/game/mapitems.h
@@ -3,6 +3,8 @@
 #ifndef GAME_MAPITEMS_H
 #define GAME_MAPITEMS_H
 
+#include <base/vmath.h>
+
 // layer types
 enum
 {
@@ -211,15 +213,8 @@ enum
 	ENTITY_OFFSET = 255 - 16 * 4,
 };
 
-struct CPoint
-{
-	int x, y; // 22.10 fixed point
-};
-
-struct CColor
-{
-	int r, g, b, a;
-};
+typedef ivec2 CPoint; // 22.10 fixed point
+typedef ivec4 CColor;
 
 struct CQuad
 {


### PR DESCRIPTION
I mostly touched the code in the graphic part for array of 2 floats into vec2.
For color, i replaced array of 4 floats with ColorRGBA where it made sense.

I had to change the logic order in `src/engine/client/graphics_threaded.cpp:1113` due to operator= from vec2 to vec3. I didn't see any visual change.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [x] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
