### PR TITLE
Fix skindownload by only allowing move assignments

### DIFF
--- a/src/game/client/components/skins.cpp
+++ b/src/game/client/components/skins.cpp
@@ -450,6 +450,6 @@ int CSkins::FindImpl(const char *pName)
 	str_format(Skin.m_aPath, sizeof(Skin.m_aPath), "downloadedskins/%s", IStorage::FormatTmpPath(aBuf, sizeof(aBuf), pName));
 	Skin.m_pTask = std::make_shared<CGetPngFile>(this, aUrl, Storage(), Skin.m_aPath);
 	m_pClient->Engine()->AddJob(Skin.m_pTask);
-	m_vDownloadSkins.insert(std::lower_bound(m_vDownloadSkins.begin(), m_vDownloadSkins.end(), Skin), Skin);
+	m_vDownloadSkins.insert(std::lower_bound(m_vDownloadSkins.begin(), m_vDownloadSkins.end(), Skin), std::move(Skin));
 	return -1;
 }

--- a/src/game/client/components/skins.h
+++ b/src/game/client/components/skins.h
@@ -29,6 +29,9 @@ public:
 		char m_aPath[IO_MAX_PATH_LENGTH];
 		char m_aName[24];
 
+		CDownloadSkin(CDownloadSkin &&Other) = default;
+		CDownloadSkin() = default;
+
 		~CDownloadSkin()
 		{
 			if(m_pTask)
@@ -37,6 +40,8 @@ public:
 		bool operator<(const CDownloadSkin &Other) const { return str_comp(m_aName, Other.m_aName) < 0; }
 		bool operator<(const char *pOther) const { return str_comp(m_aName, pOther) < 0; }
 		bool operator==(const char *pOther) const { return !str_comp(m_aName, pOther); }
+
+		CDownloadSkin &operator=(CDownloadSkin &&Other) = default;
 	};
 
 	typedef std::function<void(int)> TSkinLoadedCBFunc;


### PR DESCRIPTION
fixes #5551

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
