### PR TITLE
Also make gameclient aware that snapshots have been purged (fixes #5571)

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -677,6 +677,8 @@ void CClient::OnEnterGame(bool Dummy)
 	m_aSnapshots[Dummy][SNAP_CURRENT] = 0;
 	m_aSnapshots[Dummy][SNAP_PREV] = 0;
 	m_SnapshotStorage[Dummy].PurgeAll();
+	// Also make gameclient aware that snapshots have been purged
+	GameClient()->InvalidateSnapshot();
 	m_ReceivedSnapshots[Dummy] = 0;
 	m_SnapshotParts[Dummy] = 0;
 	m_PredTick[Dummy] = 0;

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1124,6 +1124,7 @@ void CGameClient::InvalidateSnapshot()
 	// clear all pointers
 	mem_zero(&m_Snap, sizeof(m_Snap));
 	m_Snap.m_LocalClientID = -1;
+	SnapCollectEntities();
 }
 
 void CGameClient::OnNewSnapshot()


### PR DESCRIPTION
Recreates SnapEntities internally

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
