### PR TITLE
Only announce birthday once (fixes #5576)

### DIFF
--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -145,6 +145,7 @@ void CPlayer::Reset()
 	m_EligibleForFinishCheck = 0;
 	m_VotedForPractice = false;
 	m_SwapTargetsClientID = -1;
+	m_BirthdayAnnounced = false;
 }
 
 static int PlayerFlags_SixToSeven(int Flags)
@@ -887,7 +888,7 @@ void CPlayer::ProcessScoreResult(CScorePlayerResult &Result)
 				m_Score = -10000;
 			Server()->ExpireServerInfo();
 			int Birthday = Result.m_Data.m_Info.m_Birthday;
-			if(Birthday != 0)
+			if(Birthday != 0 && !m_BirthdayAnnounced)
 			{
 				char aBuf[512];
 				str_format(aBuf, sizeof(aBuf),
@@ -898,6 +899,7 @@ void CPlayer::ProcessScoreResult(CScorePlayerResult &Result)
 					"Happy DDNet birthday, %s!\nYou have finished your first map exactly %d year%s ago!",
 					Server()->ClientName(m_ClientID), Birthday, Birthday > 1 ? "s" : "");
 				GameServer()->SendBroadcast(aBuf, m_ClientID);
+				m_BirthdayAnnounced = true;
 			}
 			break;
 		}

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -214,6 +214,7 @@ public:
 	int64_t m_EligibleForFinishCheck;
 	bool m_VotedForPractice;
 	int m_SwapTargetsClientID; //Client ID of the swap target for the given player
+	bool m_BirthdayAnnounced;
 };
 
 #endif


### PR DESCRIPTION
No matter if you use /timecp or rename

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test if it works standalone, system.c especially
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
