### PR TITLE
Add basic extensible gitlab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,2 @@
+include: '.gitlab/*.yml'
+

--- a/.gitlab/build.yml
+++ b/.gitlab/build.yml
@@ -1,0 +1,25 @@
+image: ubuntu:22.04
+
+stages:
+  - test
+
+
+build_cmake:
+  before_script:
+    - apt-get update -y
+    - apt-get upgrade -y
+    - apt-get install
+      pkg-config
+      clang
+      cmake ninja-build
+      libfreetype6-dev libnotify-dev libsdl2-dev libsqlite3-dev libvulkan-dev
+      glslang-tools spirv-tools libavcodec-dev libavformat-dev libavutil-dev libswresample-dev libswscale-dev
+      libx264-dev libpng-dev
+      libcurl4 libcurl3-gnutls libcurl4-openssl-dev libcurlpp-dev
+      libogg-dev libopus-dev libopusfile-dev
+      valgrind -y
+  stage: test
+  script:
+    - mkdir build && cd build
+    - cmake ..
+    - make -j$(nproc)


### PR DESCRIPTION
Add a very simple CI for gitlab. This is for ddnet forks that are hosted on gitlab. They can quickly get started with a simple ddnet pipeline that checks the build. And can be extend by adding files in `.gitlab/*.yml` without getting git conflicts with this upstream repository.