### PR TITLE
system: Add str_copy() template for fixed array destinations, do some small refactor

### DIFF
--- a/src/base/log.cpp
+++ b/src/base/log.cpp
@@ -102,7 +102,7 @@ void log_log_impl(LEVEL level, bool have_color, LOG_COLOR color, const char *sys
 	Msg.m_Color = color;
 	str_timestamp_format(Msg.m_aTimestamp, sizeof(Msg.m_aTimestamp), FORMAT_SPACE);
 	Msg.m_TimestampLength = str_length(Msg.m_aTimestamp);
-	str_copy(Msg.m_aSystem, sys, sizeof(Msg.m_aSystem));
+	str_copy(Msg.m_aSystem, sys);
 	Msg.m_SystemLength = str_length(Msg.m_aSystem);
 
 	// TODO: Add level?

--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -2024,7 +2024,7 @@ void net_unix_set_addr(UNIXSOCKETADDR *addr, const char *path)
 {
 	mem_zero(addr, sizeof(*addr));
 	addr->sun_family = AF_UNIX;
-	str_copy(addr->sun_path, path, sizeof(addr->sun_path));
+	str_copy(addr->sun_path, path);
 }
 
 void net_unix_close(UNIXSOCKET sock)
@@ -2220,7 +2220,7 @@ int fs_makedir_rec_for(const char *path)
 {
 	char buffer[1024 * 2];
 	char *p;
-	str_copy(buffer, path, sizeof(buffer));
+	str_copy(buffer, path);
 	for(p = buffer + 1; *p != '\0'; p++)
 	{
 		if(*p == '/' && *(p + 1) != '\0')

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -2502,4 +2502,21 @@ public:
 	}
 };
 
+/**
+ * Copies a string to a fixed-size array of chars.
+ *
+ * @ingroup Strings
+ *
+ * @param dst Array that shall receive the string.
+ * @param src String to be copied.
+ *
+ * @remark The strings are treated as zero-terminated strings.
+ * @remark Guarantees that dst string will contain zero-termination.
+ */
+template<int N>
+void str_copy(char (&dst)[N], const char *src)
+{
+	str_copy(dst, src, N);
+}
+
 #endif

--- a/src/engine/client/backend/opengl/backend_opengl.cpp
+++ b/src/engine/client/backend/opengl/backend_opengl.cpp
@@ -1758,8 +1758,8 @@ bool CCommandProcessorFragment_OpenGL2::Cmd_Init(const SCommand_Init *pCommand)
 			if(AnalysisCorrect)
 			{
 				g_Config.m_Gfx3DTextureAnalysisRan = 1;
-				str_copy(g_Config.m_Gfx3DTextureAnalysisRenderer, pCommand->m_pRendererString, std::size(g_Config.m_Gfx3DTextureAnalysisRenderer));
-				str_copy(g_Config.m_Gfx3DTextureAnalysisVersion, pCommand->m_pVersionString, std::size(g_Config.m_Gfx3DTextureAnalysisVersion));
+				str_copy(g_Config.m_Gfx3DTextureAnalysisRenderer, pCommand->m_pRendererString);
+				str_copy(g_Config.m_Gfx3DTextureAnalysisVersion, pCommand->m_pVersionString);
 			}
 		}
 	}

--- a/src/engine/client/backend/vulkan/backend_vulkan.cpp
+++ b/src/engine/client/backend/vulkan/backend_vulkan.cpp
@@ -3576,7 +3576,7 @@ public:
 			STWGraphicGPU::ETWGraphicsGPUType GPUType = VKGPUTypeToGraphicsGPUType(DeviceProp.deviceType);
 
 			STWGraphicGPU::STWGraphicGPUItem NewGPU;
-			str_copy(NewGPU.m_aName, DeviceProp.deviceName, minimum(sizeof(DeviceProp.deviceName), sizeof(NewGPU.m_aName)));
+			str_copy(NewGPU.m_aName, DeviceProp.deviceName);
 			NewGPU.m_GPUType = GPUType;
 			m_pGPUList->m_vGPUs.push_back(NewGPU);
 
@@ -3587,7 +3587,7 @@ public:
 
 			if(GPUType < AutoGPUType && (DevAPIMajor > gs_BackendVulkanMajor || (DevAPIMajor == gs_BackendVulkanMajor && DevAPIMinor >= gs_BackendVulkanMinor)))
 			{
-				str_copy(m_pGPUList->m_AutoGPU.m_aName, DeviceProp.deviceName, minimum(sizeof(DeviceProp.deviceName), sizeof(m_pGPUList->m_AutoGPU.m_aName)));
+				str_copy(m_pGPUList->m_AutoGPU.m_aName, DeviceProp.deviceName);
 				m_pGPUList->m_AutoGPU.m_GPUType = GPUType;
 
 				AutoGPUType = GPUType;

--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -883,7 +883,7 @@ int CGraphicsBackend_SDL_GL::Init(const char *pName, int *pScreen, int *pWidth, 
 		if(m_BackendType == BACKEND_TYPE_VULKAN)
 		{
 			// try default opengl settings
-			str_copy(g_Config.m_GfxBackend, "OpenGL", std::size(g_Config.m_GfxBackend));
+			str_copy(g_Config.m_GfxBackend, "OpenGL");
 			g_Config.m_GfxGLMajor = 3;
 			g_Config.m_GfxGLMinor = 0;
 			g_Config.m_GfxGLPatch = 0;
@@ -1209,7 +1209,7 @@ int CGraphicsBackend_SDL_GL::Init(const char *pName, int *pScreen, int *pWidth, 
 
 		if(pErrorStr != NULL)
 		{
-			str_copy(m_aErrorString, pErrorStr, std::size(m_aErrorString));
+			str_copy(m_aErrorString, pErrorStr);
 		}
 
 		return EGraphicsBackendErrorCodes::GRAPHICS_BACKEND_ERROR_CODE_GL_VERSION_FAILED;

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -520,7 +520,7 @@ void CClient::RconAuth(const char *pName, const char *pPassword)
 		return;
 
 	if(pPassword != m_aRconPassword)
-		str_copy(m_aRconPassword, pPassword, sizeof(m_aRconPassword));
+		str_copy(m_aRconPassword, pPassword);
 
 	CMsgPacker Msg(NETMSG_RCON_AUTH, true);
 	Msg.AddString(pName, 32);
@@ -745,8 +745,8 @@ void CClient::GenerateTimeoutCodes()
 	}
 	else
 	{
-		str_copy(m_aTimeoutCodes[0], g_Config.m_ClTimeoutCode, sizeof(m_aTimeoutCodes[0]));
-		str_copy(m_aTimeoutCodes[1], g_Config.m_ClDummyTimeoutCode, sizeof(m_aTimeoutCodes[1]));
+		str_copy(m_aTimeoutCodes[0], g_Config.m_ClTimeoutCode);
+		str_copy(m_aTimeoutCodes[1], g_Config.m_ClDummyTimeoutCode);
 	}
 }
 
@@ -759,7 +759,7 @@ void CClient::Connect(const char *pAddress, const char *pPassword)
 
 	m_ConnectionID = RandomUuid();
 	if(pAddress != m_aConnectAddressStr)
-		str_copy(m_aConnectAddressStr, pAddress, sizeof(m_aConnectAddressStr));
+		str_copy(m_aConnectAddressStr, pAddress);
 
 	str_format(aBuf, sizeof(aBuf), "connecting to '%s'", m_aConnectAddressStr);
 	m_pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "client", aBuf, gs_ClientNetworkPrintColor);
@@ -767,7 +767,7 @@ void CClient::Connect(const char *pAddress, const char *pPassword)
 	if(strncmp(m_aConnectAddressStr, "ws://", 5) == 0)
 	{
 		is_websocket = true;
-		str_copy(m_aConnectAddressStr, pAddress + 5, sizeof(m_aConnectAddressStr));
+		str_copy(m_aConnectAddressStr, pAddress + 5);
 	}
 
 	ServerInfoRequest();
@@ -781,13 +781,13 @@ void CClient::Connect(const char *pAddress, const char *pPassword)
 
 	if(m_SendPassword)
 	{
-		str_copy(m_aPassword, g_Config.m_Password, sizeof(m_aPassword));
+		str_copy(m_aPassword, g_Config.m_Password);
 		m_SendPassword = false;
 	}
 	else if(!pPassword)
 		m_aPassword[0] = 0;
 	else
-		str_copy(m_aPassword, pPassword, sizeof(m_aPassword));
+		str_copy(m_aPassword, pPassword);
 
 	m_CanReceiveServerCapabilities = true;
 	// Deregister Rcon commands from last connected server, might not have called
@@ -949,7 +949,7 @@ void CClient::GetServerInfo(CServerInfo *pServerInfo) const
 	mem_copy(pServerInfo, &m_CurrentServerInfo, sizeof(m_CurrentServerInfo));
 
 	if(m_DemoPlayer.IsPlaying() && g_Config.m_ClDemoAssumeRace)
-		str_copy(pServerInfo->m_aGameType, "DDraceNetwork", sizeof(pServerInfo->m_aGameType));
+		str_copy(pServerInfo->m_aGameType, "DDraceNetwork");
 }
 
 void CClient::ServerInfoRequest()
@@ -1258,8 +1258,8 @@ const char *CClient::LoadMap(const char *pName, const char *pFilename, SHA256_DI
 	m_pConsole->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "client", aBuf);
 	m_aReceivedSnapshots[g_Config.m_ClDummy] = 0;
 
-	str_copy(m_aCurrentMap, pName, sizeof(m_aCurrentMap));
-	str_copy(m_aCurrentMapPath, pFilename, sizeof(m_aCurrentMapPath));
+	str_copy(m_aCurrentMap, pName);
+	str_copy(m_aCurrentMapPath, pFilename);
 
 	return 0;
 }
@@ -1273,7 +1273,7 @@ static void FormatMapDownloadFilename(const char *pName, const SHA256_DIGEST *pS
 	}
 	else
 	{
-		str_copy(aSuffix, ".map", sizeof(aSuffix));
+		str_copy(aSuffix, ".map");
 	}
 
 	if(pSha256)
@@ -1650,7 +1650,7 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket, int Conn, bool Dummy)
 			}
 
 			m_MapDetailsPresent = true;
-			str_copy(m_aMapDetailsName, pMap, sizeof(m_aMapDetailsName));
+			str_copy(m_aMapDetailsName, pMap);
 			m_MapDetailsSha256 = *pMapSha256;
 			m_MapDetailsCrc = MapCrc;
 		}
@@ -1734,7 +1734,7 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket, int Conn, bool Dummy)
 					m_pConsole->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "client/network", aBuf);
 
 					m_MapdownloadChunk = 0;
-					str_copy(m_aMapdownloadName, pMap, sizeof(m_aMapdownloadName));
+					str_copy(m_aMapdownloadName, pMap);
 
 					m_MapdownloadSha256Present = (bool)pMapSha256;
 					m_MapdownloadSha256 = pMapSha256 ? *pMapSha256 : SHA256_ZEROED;
@@ -2418,12 +2418,12 @@ void CClient::LoadDDNetInfo()
 	if(CurrentVersion.type == json_string)
 	{
 		char aNewVersionStr[64];
-		str_copy(aNewVersionStr, CurrentVersion, sizeof(aNewVersionStr));
+		str_copy(aNewVersionStr, CurrentVersion);
 		char aCurVersionStr[64];
-		str_copy(aCurVersionStr, GAME_RELEASE_VERSION, sizeof(aCurVersionStr));
+		str_copy(aCurVersionStr, GAME_RELEASE_VERSION);
 		if(ToVersion(aNewVersionStr) > ToVersion(aCurVersionStr))
 		{
-			str_copy(m_aVersionStr, CurrentVersion, sizeof(m_aVersionStr));
+			str_copy(m_aVersionStr, CurrentVersion);
 		}
 		else
 		{
@@ -2439,13 +2439,13 @@ void CClient::LoadDDNetInfo()
 		if(m_aNews[0] && str_find(m_aNews, News) == nullptr)
 			g_Config.m_UiUnreadNews = true;
 
-		str_copy(m_aNews, News, sizeof(m_aNews));
+		str_copy(m_aNews, News);
 	}
 
 	const json_value &MapDownloadUrl = DDNetInfo["map-download-url"];
 	if(MapDownloadUrl.type == json_string)
 	{
-		str_copy(m_aMapDownloadUrl, MapDownloadUrl, sizeof(m_aMapDownloadUrl));
+		str_copy(m_aMapDownloadUrl, MapDownloadUrl);
 	}
 
 	const json_value &Points = DDNetInfo["points"];
@@ -3098,7 +3098,7 @@ void CClient::Run()
 
 	if(Steam()->GetPlayerName())
 	{
-		str_copy(g_Config.m_SteamName, Steam()->GetPlayerName(), sizeof(g_Config.m_SteamName));
+		str_copy(g_Config.m_SteamName, Steam()->GetPlayerName());
 	}
 
 	GameClient()->OnInit();
@@ -3157,7 +3157,7 @@ void CClient::Run()
 		// handle pending connects
 		if(m_aCmdConnect[0])
 		{
-			str_copy(g_Config.m_UiServerAddress, m_aCmdConnect, sizeof(g_Config.m_UiServerAddress));
+			str_copy(g_Config.m_UiServerAddress, m_aCmdConnect);
 			Connect(m_aCmdConnect);
 			m_aCmdConnect[0] = 0;
 		}
@@ -3469,7 +3469,7 @@ bool CClient::CtrlShiftKey(int Key, bool &Last)
 void CClient::Con_Connect(IConsole::IResult *pResult, void *pUserData)
 {
 	CClient *pSelf = (CClient *)pUserData;
-	str_copy(pSelf->m_aCmdConnect, pResult->GetString(0), sizeof(pSelf->m_aCmdConnect));
+	str_copy(pSelf->m_aCmdConnect, pResult->GetString(0));
 }
 
 void CClient::Con_Disconnect(IConsole::IResult *pResult, void *pUserData)
@@ -4042,7 +4042,7 @@ void CClient::InitChecksum()
 {
 	CChecksumData *pData = &m_Checksum.m_Data;
 	pData->m_SizeofData = sizeof(*pData);
-	str_copy(pData->m_aVersionStr, GAME_NAME " " GAME_RELEASE_VERSION " (" CONF_PLATFORM_STRING "; " CONF_ARCH_STRING ")", sizeof(pData->m_aVersionStr));
+	str_copy(pData->m_aVersionStr, GAME_NAME " " GAME_RELEASE_VERSION " (" CONF_PLATFORM_STRING "; " CONF_ARCH_STRING ")");
 	pData->m_Start = time_get();
 	os_version_str(pData->m_aOsVersion, sizeof(pData->m_aOsVersion));
 	secure_random_fill(&pData->m_Random, sizeof(pData->m_Random));
@@ -4430,17 +4430,17 @@ void CClient::HandleConnectAddress(const NETADDR *pAddr)
 
 void CClient::HandleConnectLink(const char *pLink)
 {
-	str_copy(m_aCmdConnect, pLink + sizeof(CONNECTLINK) - 1, sizeof(m_aCmdConnect));
+	str_copy(m_aCmdConnect, pLink + sizeof(CONNECTLINK) - 1);
 }
 
 void CClient::HandleDemoPath(const char *pPath)
 {
-	str_copy(m_aCmdPlayDemo, pPath, sizeof(m_aCmdPlayDemo));
+	str_copy(m_aCmdPlayDemo, pPath);
 }
 
 void CClient::HandleMapPath(const char *pPath)
 {
-	str_copy(m_aCmdEditMap, pPath, sizeof(m_aCmdEditMap));
+	str_copy(m_aCmdEditMap, pPath);
 }
 
 /*
@@ -4729,7 +4729,7 @@ bool CClient::RaceRecord_IsRecording()
 void CClient::RequestDDNetInfo()
 {
 	char aUrl[256];
-	str_copy(aUrl, "https://info2.ddnet.tw/info", sizeof(aUrl));
+	str_copy(aUrl, "https://info2.ddnet.tw/info");
 
 	if(g_Config.m_BrIndicateFinished)
 	{

--- a/src/engine/client/demoedit.cpp
+++ b/src/engine/client/demoedit.cpp
@@ -7,8 +7,8 @@ CDemoEdit::CDemoEdit(const char *pNetVersion, class CSnapshotDelta *pSnapshotDel
 	m_SnapshotDelta(*pSnapshotDelta),
 	m_pStorage(pStorage)
 {
-	str_copy(m_aDemo, pDemo, sizeof(m_aDemo));
-	str_copy(m_aDst, pDst, sizeof(m_aDst));
+	str_copy(m_aDemo, pDemo);
+	str_copy(m_aDst, pDst);
 
 	m_StartTick = StartTick;
 	m_EndTick = EndTick;

--- a/src/engine/client/friends.cpp
+++ b/src/engine/client/friends.cpp
@@ -113,8 +113,8 @@ void CFriends::AddFriend(const char *pName, const char *pClan)
 			return;
 	}
 
-	str_copy(m_aFriends[m_NumFriends].m_aName, pName, sizeof(m_aFriends[m_NumFriends].m_aName));
-	str_copy(m_aFriends[m_NumFriends].m_aClan, pClan, sizeof(m_aFriends[m_NumFriends].m_aClan));
+	str_copy(m_aFriends[m_NumFriends].m_aName, pName);
+	str_copy(m_aFriends[m_NumFriends].m_aClan, pClan);
 	m_aFriends[m_NumFriends].m_NameHash = NameHash;
 	m_aFriends[m_NumFriends].m_ClanHash = ClanHash;
 	++m_NumFriends;
@@ -166,7 +166,7 @@ void CFriends::ConfigSaveCallback(IConfigManager *pConfigManager, void *pUserDat
 	const char *pEnd = aBuf + sizeof(aBuf) - 4;
 	for(int i = 0; i < pSelf->m_NumFriends; ++i)
 	{
-		str_copy(aBuf, pSelf->m_Foes ? "add_foe " : "add_friend ", sizeof(aBuf));
+		str_copy(aBuf, pSelf->m_Foes ? "add_foe " : "add_friend ");
 
 		str_append(aBuf, "\"", sizeof(aBuf));
 		char *pDst = aBuf + str_length(aBuf);

--- a/src/engine/client/ghost.cpp
+++ b/src/engine/client/ghost.cpp
@@ -42,8 +42,8 @@ int CGhostRecorder::Start(const char *pFilename, const char *pMap, SHA256_DIGEST
 	mem_zero(&Header, sizeof(Header));
 	mem_copy(Header.m_aMarker, gs_aHeaderMarker, sizeof(Header.m_aMarker));
 	Header.m_Version = gs_CurVersion;
-	str_copy(Header.m_aOwner, pName, sizeof(Header.m_aOwner));
-	str_copy(Header.m_aMap, pMap, sizeof(Header.m_aMap));
+	str_copy(Header.m_aOwner, pName);
+	str_copy(Header.m_aMap, pMap);
 	Header.m_MapSha256 = MapSha256;
 	io_write(m_File, &Header, sizeof(Header));
 

--- a/src/engine/client/ghost.h
+++ b/src/engine/client/ghost.h
@@ -35,8 +35,8 @@ struct CGhostHeader
 	{
 		CGhostInfo Result;
 		mem_zero(&Result, sizeof(Result));
-		str_copy(Result.m_aOwner, m_aOwner, sizeof(Result.m_aOwner));
-		str_copy(Result.m_aMap, m_aMap, sizeof(Result.m_aMap));
+		str_copy(Result.m_aOwner, m_aOwner);
+		str_copy(Result.m_aMap, m_aMap);
 		Result.m_NumTicks = GetTicks();
 		Result.m_Time = GetTime();
 		return Result;

--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -2678,7 +2678,7 @@ void CGraphics_Threaded::TakeScreenshot(const char *pFilename)
 
 void CGraphics_Threaded::TakeCustomScreenshot(const char *pFilename)
 {
-	str_copy(m_aScreenshotName, pFilename, sizeof(m_aScreenshotName));
+	str_copy(m_aScreenshotName, pFilename);
 	m_DoScreenshot = true;
 }
 

--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -35,7 +35,7 @@ void CInput::AddEvent(char *pText, int Key, int Flags)
 		if(!pText)
 			m_aInputEvents[m_NumEvents].m_aText[0] = 0;
 		else
-			str_copy(m_aInputEvents[m_NumEvents].m_aText, pText, sizeof(m_aInputEvents[m_NumEvents].m_aText));
+			str_copy(m_aInputEvents[m_NumEvents].m_aText, pText);
 		m_aInputEvents[m_NumEvents].m_InputCount = m_InputCounter;
 		m_NumEvents++;
 	}
@@ -160,7 +160,7 @@ CInput::CJoystick::CJoystick(CInput *pInput, int Index, SDL_Joystick *pDelegate)
 	m_NumButtons = SDL_JoystickNumButtons(pDelegate);
 	m_NumBalls = SDL_JoystickNumBalls(pDelegate);
 	m_NumHats = SDL_JoystickNumHats(pDelegate);
-	str_copy(m_aName, SDL_JoystickName(pDelegate), sizeof(m_aName));
+	str_copy(m_aName, SDL_JoystickName(pDelegate));
 	SDL_JoystickGetGUIDString(SDL_JoystickGetGUID(pDelegate), m_aGUID, sizeof(m_aGUID));
 	m_InstanceID = SDL_JoystickInstanceID(pDelegate);
 }
@@ -180,7 +180,7 @@ void CInput::SelectNextJoystick()
 	if(Num > 1)
 	{
 		m_pActiveJoystick = &m_vJoysticks[(m_pActiveJoystick->GetIndex() + 1) % Num];
-		str_copy(g_Config.m_InpControllerGUID, m_pActiveJoystick->GetGUID(), sizeof(g_Config.m_InpControllerGUID));
+		str_copy(g_Config.m_InpControllerGUID, m_pActiveJoystick->GetGUID());
 	}
 }
 
@@ -561,7 +561,7 @@ int CInput::Update()
 			m_EditingTextLen = str_length(Event.edit.text);
 			if(m_EditingTextLen)
 			{
-				str_copy(m_aEditingText, Event.edit.text, sizeof(m_aEditingText));
+				str_copy(m_aEditingText, Event.edit.text);
 				m_EditingCursor = 0;
 				for(int i = 0; i < Event.edit.start; i++)
 					m_EditingCursor = str_utf8_forward(m_aEditingText, m_EditingCursor);

--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -90,7 +90,7 @@ CServerBrowser::~CServerBrowser()
 void CServerBrowser::SetBaseInfo(class CNetClient *pClient, const char *pNetVersion)
 {
 	m_pNetClient = pClient;
-	str_copy(m_aNetVersion, pNetVersion, sizeof(m_aNetVersion));
+	str_copy(m_aNetVersion, pNetVersion);
 	m_pConsole = Kernel()->RequestInterface<IConsole>();
 	m_pEngine = Kernel()->RequestInterface<IEngine>();
 	m_pFriends = Kernel()->RequestInterface<IFriends>();
@@ -438,8 +438,8 @@ void CServerBrowser::Sort()
 	else if(g_Config.m_BrSort == IServerBrowser::SORT_GAMETYPE)
 		std::stable_sort(m_pSortedServerlist, m_pSortedServerlist + m_NumSortedServers, SortWrap(this, &CServerBrowser::SortCompareGametype));
 
-	str_copy(m_aFilterGametypeString, g_Config.m_BrFilterGametype, sizeof(m_aFilterGametypeString));
-	str_copy(m_aFilterString, g_Config.m_BrFilterString, sizeof(m_aFilterString));
+	str_copy(m_aFilterGametypeString, g_Config.m_BrFilterGametype);
+	str_copy(m_aFilterString, g_Config.m_BrFilterString);
 	m_Sorthash = SortHash();
 }
 
@@ -560,7 +560,7 @@ CServerBrowser::CServerEntry *CServerBrowser::Add(const NETADDR &Addr)
 	pEntry->m_Info.m_Latency = 999;
 	pEntry->m_Info.m_HasRank = -1;
 	net_addr_str(&Addr, pEntry->m_Info.m_aAddress, sizeof(pEntry->m_Info.m_aAddress), true);
-	str_copy(pEntry->m_Info.m_aName, pEntry->m_Info.m_aAddress, sizeof(pEntry->m_Info.m_aName));
+	str_copy(pEntry->m_Info.m_aName, pEntry->m_Info.m_aAddress);
 
 	// check if it's a favorite
 	pEntry->m_Info.m_Favorite = IsFavorite(Addr);
@@ -1172,7 +1172,7 @@ void CServerBrowser::Update(bool ForceResort)
 	const char *pHttpBestUrl;
 	if(!m_pHttp->GetBestUrl(&pHttpBestUrl) && pHttpBestUrl != m_pHttpPrevBestUrl)
 	{
-		str_copy(g_Config.m_BrCachedBestServerinfoUrl, pHttpBestUrl, sizeof(g_Config.m_BrCachedBestServerinfoUrl));
+		str_copy(g_Config.m_BrCachedBestServerinfoUrl, pHttpBestUrl);
 		m_pHttpPrevBestUrl = pHttpBestUrl;
 	}
 
@@ -1374,7 +1374,7 @@ void CServerBrowser::LoadDDNetServers()
 
 			pCntr->Reset();
 
-			str_copy(pCntr->m_aName, json_string_get(pName), sizeof(pCntr->m_aName));
+			str_copy(pCntr->m_aName, json_string_get(pName));
 			pCntr->m_FlagID = json_int_get(pFlagID);
 
 			// add country
@@ -1400,7 +1400,7 @@ void CServerBrowser::LoadDDNetServers()
 					}
 					if(Pos == pNet->m_NumTypes)
 					{
-						str_copy(pNet->m_aTypes[pNet->m_NumTypes], pType, sizeof(pNet->m_aTypes[pNet->m_NumTypes]));
+						str_copy(pNet->m_aTypes[pNet->m_NumTypes], pType);
 						pNet->m_NumTypes++;
 					}
 				}
@@ -1416,7 +1416,7 @@ void CServerBrowser::LoadDDNetServers()
 					}
 					const char *pStr = json_string_get(pAddr);
 					net_addr_from_str(&pCntr->m_aServers[pCntr->m_NumServers], pStr);
-					str_copy(pCntr->m_aTypes[pCntr->m_NumServers], pType, sizeof(pCntr->m_aTypes[pCntr->m_NumServers]));
+					str_copy(pCntr->m_aTypes[pCntr->m_NumServers], pType);
 				}
 			}
 
@@ -1615,7 +1615,7 @@ void CServerBrowser::DDNetFilterRem(char *pFilter, const char *pName)
 	// rewrite exclude/filter list
 	char aBuf[128];
 
-	str_copy(aBuf, pFilter, sizeof(aBuf));
+	str_copy(aBuf, pFilter);
 	pFilter[0] = '\0';
 
 	char aToken[128];

--- a/src/engine/client/serverbrowser_http.cpp
+++ b/src/engine/client/serverbrowser_http.cpp
@@ -83,7 +83,7 @@ CChooseMaster::CChooseMaster(IEngine *pEngine, VALIDATOR pfnValidator, const cha
 	m_pData->m_NumUrls = NumUrls;
 	for(int i = 0; i < m_pData->m_NumUrls; i++)
 	{
-		str_copy(m_pData->m_aaUrls[i], ppUrls[i], sizeof(m_pData->m_aaUrls[i]));
+		str_copy(m_pData->m_aaUrls[i], ppUrls[i]);
 	}
 }
 
@@ -520,7 +520,7 @@ IServerBrowserHttp *CreateServerBrowserHttp(IEngine *pEngine, IConsole *pConsole
 			{
 				break;
 			}
-			str_copy(aaUrls[NumUrls], pLine, sizeof(aaUrls[NumUrls]));
+			str_copy(aaUrls[NumUrls], pLine);
 			apUrls[NumUrls] = aaUrls[NumUrls];
 			NumUrls += 1;
 		}

--- a/src/engine/client/steam.cpp
+++ b/src/engine/client/steam.cpp
@@ -22,7 +22,7 @@ public:
 		m_pSteamFriends = SteamAPI_SteamFriends_v017();
 
 		ReadLaunchCommandLine();
-		str_copy(m_aPlayerName, SteamAPI_ISteamFriends_GetPersonaName(m_pSteamFriends), sizeof(m_aPlayerName));
+		str_copy(m_aPlayerName, SteamAPI_ISteamFriends_GetPersonaName(m_pSteamFriends));
 	}
 	~CSteam()
 	{

--- a/src/engine/client/text.cpp
+++ b/src/engine/client/text.cpp
@@ -709,7 +709,7 @@ public:
 	{
 		CFont *pFont = new CFont();
 
-		str_copy(pFont->m_aFilename, pFilename, sizeof(pFont->m_aFilename));
+		str_copy(pFont->m_aFilename, pFilename);
 
 		if(FT_New_Memory_Face(m_FTLibrary, pBuf, Size, 0, &pFont->m_FtFace))
 		{
@@ -743,7 +743,7 @@ public:
 	{
 		CFont::SFontFallBack FallbackFont;
 		FallbackFont.m_pBuf = (void *)pBuf;
-		str_copy(FallbackFont.m_aFilename, pFilename, sizeof(FallbackFont.m_aFilename));
+		str_copy(FallbackFont.m_aFilename, pFilename);
 
 		if(FT_New_Memory_Face(m_FTLibrary, pBuf, Size, 0, &FallbackFont.m_FtFace) == 0)
 		{

--- a/src/engine/client/updater.cpp
+++ b/src/engine/client/updater.cpp
@@ -54,7 +54,7 @@ CUpdaterFetchTask::CUpdaterFetchTask(CUpdater *pUpdater, const char *pFile, cons
 void CUpdaterFetchTask::OnProgress()
 {
 	CLockScope ls(m_pUpdater->m_Lock);
-	str_copy(m_pUpdater->m_aStatus, Dest(), sizeof(m_pUpdater->m_aStatus));
+	str_copy(m_pUpdater->m_aStatus, Dest());
 	m_pUpdater->m_Percent = Progress();
 }
 
@@ -352,7 +352,7 @@ void CUpdater::PerformUpdate()
 		pLastFile = m_aClientExecTmp;
 	}
 
-	str_copy(m_aLastFile, pLastFile, sizeof(m_aLastFile));
+	str_copy(m_aLastFile, pLastFile);
 }
 
 void CUpdater::CommitUpdate()

--- a/src/engine/client/video.cpp
+++ b/src/engine/client/video.cpp
@@ -45,7 +45,7 @@ CVideo::CVideo(CGraphics_Threaded *pGraphics, ISound *pSound, IStorage *pStorage
 
 	m_Width = Width;
 	m_Height = Height;
-	str_copy(m_aName, pName, sizeof(m_aName));
+	str_copy(m_aName, pName);
 
 	m_FPS = g_Config.m_ClVideoRecorderFPS;
 

--- a/src/engine/server/authmanager.cpp
+++ b/src/engine/server/authmanager.cpp
@@ -48,7 +48,7 @@ int CAuthManager::AddKeyHash(const char *pIdent, MD5_DIGEST Hash, const unsigned
 		return -1;
 
 	CKey Key;
-	str_copy(Key.m_aIdent, pIdent, sizeof(Key.m_aIdent));
+	str_copy(Key.m_aIdent, pIdent);
 	Key.m_Pw = Hash;
 	mem_copy(Key.m_aSalt, pSalt, SALT_BYTES);
 	Key.m_Level = AuthLevel;

--- a/src/engine/server/databases/connection.h
+++ b/src/engine/server/databases/connection.h
@@ -13,7 +13,7 @@ class IDbConnection
 public:
 	IDbConnection(const char *pPrefix)
 	{
-		str_copy(m_aPrefix, pPrefix, sizeof(m_aPrefix));
+		str_copy(m_aPrefix, pPrefix);
 	}
 	virtual ~IDbConnection() {}
 	IDbConnection &operator=(const IDbConnection &) = delete;

--- a/src/engine/server/databases/sqlite.cpp
+++ b/src/engine/server/databases/sqlite.cpp
@@ -80,7 +80,7 @@ CSqliteConnection::CSqliteConnection(const char *pFilename, bool Setup) :
 	m_Done(true),
 	m_InUse(false)
 {
-	str_copy(m_aFilename, pFilename, sizeof(m_aFilename));
+	str_copy(m_aFilename, pFilename);
 }
 
 CSqliteConnection::~CSqliteConnection()

--- a/src/engine/server/name_ban.cpp
+++ b/src/engine/server/name_ban.cpp
@@ -3,7 +3,7 @@
 CNameBan *IsNameBanned(const char *pName, std::vector<CNameBan> &vNameBans)
 {
 	char aTrimmed[MAX_NAME_LENGTH];
-	str_copy(aTrimmed, str_utf8_skip_whitespaces(pName), sizeof(aTrimmed));
+	str_copy(aTrimmed, str_utf8_skip_whitespaces(pName));
 	str_utf8_trim_right(aTrimmed);
 
 	int aSkeleton[MAX_NAME_SKELETON_LENGTH];

--- a/src/engine/server/name_ban.h
+++ b/src/engine/server/name_ban.h
@@ -19,9 +19,9 @@ public:
 	CNameBan(const char *pName, int Distance, int IsSubstring, const char *pReason = "") :
 		m_Distance(Distance), m_IsSubstring(IsSubstring)
 	{
-		str_copy(m_aName, pName, sizeof(m_aName));
+		str_copy(m_aName, pName);
 		m_SkeletonLength = str_utf8_to_skeleton(m_aName, m_aSkeleton, std::size(m_aSkeleton));
-		str_copy(m_aReason, pReason, sizeof(m_aReason));
+		str_copy(m_aReason, pReason);
 	}
 	char m_aName[MAX_NAME_LENGTH];
 	char m_aReason[MAX_NAMEBAN_REASON_LENGTH];

--- a/src/engine/server/register.cpp
+++ b/src/engine/server/register.cpp
@@ -400,7 +400,7 @@ void CRegister::CProtocol::OnToken(const char *pToken)
 {
 	m_NewChallengeToken = true;
 	m_HaveChallengeToken = true;
-	str_copy(m_aChallengeToken, pToken, sizeof(m_aChallengeToken));
+	str_copy(m_aChallengeToken, pToken);
 
 	CheckChallengeStatus();
 	if(time_get() >= m_NextRegister)
@@ -602,7 +602,7 @@ void CRegister::OnConfigChange()
 			log_warn("register", "header '%s' doesn't contain mandatory ': ', ignoring", aHeader);
 			continue;
 		}
-		str_copy(m_aaExtraHeaders[m_NumExtraHeaders], aHeader, sizeof(m_aaExtraHeaders));
+		str_copy(m_aaExtraHeaders[m_NumExtraHeaders], aHeader);
 		m_NumExtraHeaders += 1;
 	}
 	for(int i = 0; i < NUM_PROTOCOLS; i++)
@@ -664,7 +664,7 @@ void CRegister::OnNewInfo(const char *pInfo)
 	}
 
 	m_GotServerInfo = true;
-	str_copy(m_aServerInfo, pInfo, sizeof(m_aServerInfo));
+	str_copy(m_aServerInfo, pInfo);
 	{
 		CLockScope ls(m_pGlobal->m_Lock);
 		m_pGlobal->m_InfoSerial += 1;

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -469,7 +469,7 @@ bool CServer::SetClientNameImpl(int ClientID, const char *pNameRequest, bool Set
 			}
 			else
 			{
-				str_copy(aBuf, "Kicked (your name is banned)", sizeof(aBuf));
+				str_copy(aBuf, "Kicked (your name is banned)");
 			}
 			Kick(ClientID, aBuf);
 		}
@@ -478,11 +478,11 @@ bool CServer::SetClientNameImpl(int ClientID, const char *pNameRequest, bool Set
 
 	// trim the name
 	char aTrimmedName[MAX_NAME_LENGTH];
-	str_copy(aTrimmedName, str_utf8_skip_whitespaces(pNameRequest), sizeof(aTrimmedName));
+	str_copy(aTrimmedName, str_utf8_skip_whitespaces(pNameRequest));
 	str_utf8_trim_right(aTrimmedName);
 
 	char aNameTry[MAX_NAME_LENGTH];
-	str_copy(aNameTry, aTrimmedName, sizeof(aNameTry));
+	str_copy(aNameTry, aTrimmedName);
 
 	if(!IsClientNameAvailable(ClientID, aNameTry))
 	{
@@ -500,7 +500,7 @@ bool CServer::SetClientNameImpl(int ClientID, const char *pNameRequest, bool Set
 	if(Set)
 	{
 		// set the client name
-		str_copy(m_aClients[ClientID].m_aName, aNameTry, MAX_NAME_LENGTH);
+		str_copy(m_aClients[ClientID].m_aName, aNameTry);
 	}
 
 	return Changed;
@@ -521,7 +521,7 @@ void CServer::SetClientClan(int ClientID, const char *pClan)
 	if(ClientID < 0 || ClientID >= MAX_CLIENTS || m_aClients[ClientID].m_State < CClient::STATE_READY || !pClan)
 		return;
 
-	str_copy(m_aClients[ClientID].m_aClan, pClan, MAX_CLAN_LENGTH);
+	str_copy(m_aClients[ClientID].m_aClan, pClan);
 }
 
 void CServer::SetClientCountry(int ClientID, int Country)
@@ -1469,7 +1469,7 @@ void CServer::ProcessClientPacket(CNetChunk *pPacket)
 				}
 				m_aClients[ClientID].m_ConnectionID = *pConnectionID;
 				m_aClients[ClientID].m_DDNetVersion = DDNetVersion;
-				str_copy(m_aClients[ClientID].m_aDDNetVersionStr, pDDNetVersionStr, sizeof(m_aClients[ClientID].m_aDDNetVersionStr));
+				str_copy(m_aClients[ClientID].m_aDDNetVersionStr, pDDNetVersionStr);
 				m_aClients[ClientID].m_DDNetVersionSettled = true;
 				m_aClients[ClientID].m_GotDDNetVersionPacket = true;
 				m_aClients[ClientID].m_State = CClient::STATE_AUTH;
@@ -2451,7 +2451,7 @@ const char *CServer::GetMapName() const
 
 void CServer::ChangeMap(const char *pMap)
 {
-	str_copy(Config()->m_SvMap, pMap, sizeof(Config()->m_SvMap));
+	str_copy(Config()->m_SvMap, pMap);
 	m_MapReload = str_comp(Config()->m_SvMap, m_aCurrentMap) != 0;
 }
 
@@ -2495,7 +2495,7 @@ int CServer::LoadMap(const char *pMapName)
 	str_format(aBufMsg, sizeof(aBufMsg), "%s sha256 is %s", aBuf, aSha256);
 	Console()->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "server", aBufMsg);
 
-	str_copy(m_aCurrentMap, pMapName, sizeof(m_aCurrentMap));
+	str_copy(m_aCurrentMap, pMapName);
 
 	// load complete map into memory for download
 	{
@@ -2718,7 +2718,7 @@ int CServer::Run()
 				{
 					str_format(aBuf, sizeof(aBuf), "failed to load map. mapname='%s'", Config()->m_SvMap);
 					Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "server", aBuf);
-					str_copy(Config()->m_SvMap, m_aCurrentMap, sizeof(Config()->m_SvMap));
+					str_copy(Config()->m_SvMap, m_aCurrentMap);
 				}
 			}
 
@@ -3235,7 +3235,7 @@ void CServer::ConNameBan(IConsole::IResult *pResult, void *pUser)
 			pThis->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "name_ban", aBuf);
 			Ban.m_Distance = Distance;
 			Ban.m_IsSubstring = IsSubstring;
-			str_copy(Ban.m_aReason, pReason, sizeof(Ban.m_aReason));
+			str_copy(Ban.m_aReason, pReason);
 			return;
 		}
 	}
@@ -3282,7 +3282,7 @@ void CServer::ConShutdown(IConsole::IResult *pResult, void *pUser)
 	const char *pReason = pResult->GetString(0);
 	if(pReason[0])
 	{
-		str_copy(pThis->m_aShutdownReason, pReason, sizeof(pThis->m_aShutdownReason));
+		str_copy(pThis->m_aShutdownReason, pReason);
 	}
 }
 
@@ -3997,5 +3997,5 @@ bool CServer::SetTimedOut(int ClientID, int OrigID)
 
 void CServer::SetErrorShutdown(const char *pReason)
 {
-	str_copy(m_aErrorShutdownReason, pReason, sizeof(m_aErrorShutdownReason));
+	str_copy(m_aErrorShutdownReason, pReason);
 }

--- a/src/engine/server/sql_string_helpers.cpp
+++ b/src/engine/server/sql_string_helpers.cpp
@@ -76,7 +76,7 @@ void sqlstr::AgoTimeToString(int AgoTime, char *pAgoString, int Size)
 	for(i = 0; i < 7; i++)
 	{
 		Seconds = aTimes[i];
-		str_copy(aName, aaNames[i], sizeof(aName));
+		str_copy(aName, aaNames[i]);
 
 		Count = std::floor((float)AgoTime / (float)Seconds);
 		if(Count != 0)
@@ -100,7 +100,7 @@ void sqlstr::AgoTimeToString(int AgoTime, char *pAgoString, int Size)
 		// getting second piece now
 		int Seconds2 = aTimes[i + 1];
 		char aName2[6];
-		str_copy(aName2, aaNames[i + 1], sizeof(aName2));
+		str_copy(aName2, aaNames[i + 1]);
 
 		// add second piece if it's greater than 0
 		int Count2 = std::floor((float)(AgoTime - (Seconds * Count)) / (float)Seconds2);

--- a/src/engine/shared/assertion_logger.cpp
+++ b/src/engine/shared/assertion_logger.cpp
@@ -32,7 +32,7 @@ void CAssertionLogger::Log(const CLogMessage *pMessage)
 {
 	std::unique_lock<std::mutex> Lock(m_DbgMessageMutex);
 	SDebugMessageItem *pMsgItem = (SDebugMessageItem *)m_DbgMessages.Allocate(sizeof(SDebugMessageItem));
-	str_copy(pMsgItem->m_aMessage, pMessage->m_aLine, std::size(pMsgItem->m_aMessage));
+	str_copy(pMsgItem->m_aMessage, pMessage->m_aLine);
 }
 
 void CAssertionLogger::GlobalFinish()
@@ -69,8 +69,8 @@ void CAssertionLogger::Dump()
 
 CAssertionLogger::CAssertionLogger(const char *pAssertLogPath, const char *pGameName)
 {
-	str_copy(m_aAssertLogPath, pAssertLogPath, std::size(m_aAssertLogPath));
-	str_copy(m_aGameName, pGameName, std::size(m_aGameName));
+	str_copy(m_aAssertLogPath, pAssertLogPath);
+	str_copy(m_aGameName, pGameName);
 }
 
 std::unique_ptr<ILogger> CreateAssertionLogger(IStorage *pStorage, const char *pGameName)

--- a/src/engine/shared/console.cpp
+++ b/src/engine/shared/console.cpp
@@ -702,7 +702,7 @@ void CConsole::ConCommandStatus(IResult *pResult, void *pUser)
 			{
 				pConsole->Print(OUTPUT_LEVEL_STANDARD, "chatresp", aBuf);
 				mem_zero(aBuf, sizeof(aBuf));
-				str_copy(aBuf, pCommand->m_pName, sizeof(aBuf));
+				str_copy(aBuf, pCommand->m_pName);
 				Used = Length;
 			}
 		}

--- a/src/engine/shared/demo.cpp
+++ b/src/engine/shared/demo.cpp
@@ -131,11 +131,11 @@ int CDemoRecorder::Start(class IStorage *pStorage, class IConsole *pConsole, con
 	mem_zero(&Header, sizeof(Header));
 	mem_copy(Header.m_aMarker, gs_aHeaderMarker, sizeof(Header.m_aMarker));
 	Header.m_Version = gs_CurVersion;
-	str_copy(Header.m_aNetversion, pNetVersion, sizeof(Header.m_aNetversion));
-	str_copy(Header.m_aMapName, pMap, sizeof(Header.m_aMapName));
+	str_copy(Header.m_aNetversion, pNetVersion);
+	str_copy(Header.m_aMapName, pMap);
 	uint_to_bytes_be(Header.m_aMapSize, MapSize);
 	uint_to_bytes_be(Header.m_aMapCrc, Crc);
-	str_copy(Header.m_aType, pType, sizeof(Header.m_aType));
+	str_copy(Header.m_aType, pType);
 	// Header.m_Length - add this on stop
 	str_timestamp(Header.m_aTimestamp, sizeof(Header.m_aTimestamp));
 	io_write(DemoFile, &Header, sizeof(Header));
@@ -182,7 +182,7 @@ int CDemoRecorder::Start(class IStorage *pStorage, class IConsole *pConsole, con
 		m_pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "demo_recorder", aBuf, gs_DemoPrintColor);
 	}
 	m_File = DemoFile;
-	str_copy(m_aCurrentFilename, pFilename, sizeof(m_aCurrentFilename));
+	str_copy(m_aCurrentFilename, pFilename);
 
 	return 0;
 }
@@ -705,7 +705,7 @@ int CDemoPlayer::Load(class IStorage *pStorage, class IConsole *pConsole, const 
 	}
 
 	// store the filename
-	str_copy(m_aFilename, pFilename, sizeof(m_aFilename));
+	str_copy(m_aFilename, pFilename);
 
 	// clear the playback info
 	mem_zero(&m_Info, sizeof(m_Info));
@@ -790,7 +790,7 @@ int CDemoPlayer::Load(class IStorage *pStorage, class IConsole *pConsole, const 
 	m_MapInfo.m_Crc = Crc;
 	m_MapInfo.m_Sha256 = Sha256;
 	m_MapInfo.m_Size = MapSize;
-	str_copy(m_MapInfo.m_aName, m_Info.m_Header.m_aMapName, sizeof(m_MapInfo.m_aName));
+	str_copy(m_MapInfo.m_aName, m_Info.m_Header.m_aMapName);
 
 	if(m_Info.m_Header.m_Version > gs_OldVersion)
 	{
@@ -1041,7 +1041,7 @@ int CDemoPlayer::Stop()
 	m_File = 0;
 	free(m_pKeyFrames);
 	m_pKeyFrames = 0;
-	str_copy(m_aFilename, "", sizeof(m_aFilename));
+	str_copy(m_aFilename, "");
 	return 0;
 }
 
@@ -1077,7 +1077,7 @@ bool CDemoPlayer::GetDemoInfo(class IStorage *pStorage, const char *pFilename, i
 	io_read(File, pDemoHeader, sizeof(CDemoHeader));
 	io_read(File, pTimelineMarkers, sizeof(CTimelineMarkers));
 
-	str_copy(pMapInfo->m_aName, pDemoHeader->m_aMapName, sizeof(pMapInfo->m_aName));
+	str_copy(pMapInfo->m_aName, pDemoHeader->m_aMapName);
 	pMapInfo->m_Crc = bytes_be_to_int(pDemoHeader->m_aMapCrc);
 
 	SHA256_DIGEST Sha256 = SHA256_ZEROED;

--- a/src/engine/shared/engine.cpp
+++ b/src/engine/shared/engine.cpp
@@ -14,7 +14,7 @@ CHostLookup::CHostLookup() = default;
 
 CHostLookup::CHostLookup(const char *pHostname, int Nettype)
 {
-	str_copy(m_aHostname, pHostname, sizeof(m_aHostname));
+	str_copy(m_aHostname, pHostname);
 	m_Nettype = Nettype;
 }
 
@@ -59,7 +59,7 @@ public:
 	CEngine(bool Test, const char *pAppname, std::shared_ptr<CFutureLogger> pFutureLogger, int Jobs) :
 		m_pFutureLogger(std::move(pFutureLogger))
 	{
-		str_copy(m_aAppName, pAppname, std::size(m_aAppName));
+		str_copy(m_aAppName, pAppname);
 		if(!Test)
 		{
 			//

--- a/src/engine/shared/fifo.cpp
+++ b/src/engine/shared/fifo.cpp
@@ -19,7 +19,7 @@ void CFifo::Init(IConsole *pConsole, char *pFifoFile, int Flag)
 	if(pFifoFile[0] == '\0')
 		return;
 
-	str_copy(m_aFilename, pFifoFile, sizeof(m_aFilename));
+	str_copy(m_aFilename, pFifoFile);
 	m_Flag = Flag;
 
 	mkfifo(m_aFilename, 0600);

--- a/src/engine/shared/filecollection.cpp
+++ b/src/engine/shared/filecollection.cpp
@@ -129,11 +129,11 @@ void CFileCollection::Init(IStorage *pStorage, const char *pPath, const char *pF
 	// MAX_ENTRIES - 1 to make sure that we can insert one entry into the sorted
 	// list and then remove the oldest one
 	m_MaxEntries = clamp(MaxEntries, 1, static_cast<int>(MAX_ENTRIES) - 1);
-	str_copy(m_aFileDesc, pFileDesc, sizeof(m_aFileDesc));
+	str_copy(m_aFileDesc, pFileDesc);
 	m_FileDescLength = str_length(m_aFileDesc);
-	str_copy(m_aFileExt, pFileExt, sizeof(m_aFileExt));
+	str_copy(m_aFileExt, pFileExt);
 	m_FileExtLength = str_length(m_aFileExt);
-	str_copy(m_aPath, pPath, sizeof(m_aPath));
+	str_copy(m_aPath, pPath);
 	m_pStorage = pStorage;
 
 	m_pStorage->ListDirectory(IStorage::TYPE_SAVE, m_aPath, FilelistCallback, this);

--- a/src/engine/shared/http.cpp
+++ b/src/engine/shared/http.cpp
@@ -118,7 +118,7 @@ void EscapeUrl(char *pBuf, int Size, const char *pStr)
 
 CHttpRequest::CHttpRequest(const char *pUrl)
 {
-	str_copy(m_aUrl, pUrl, sizeof(m_aUrl));
+	str_copy(m_aUrl, pUrl);
 }
 
 CHttpRequest::~CHttpRequest()
@@ -333,7 +333,7 @@ int CHttpRequest::OnCompletion(int State)
 void CHttpRequest::WriteToFile(IStorage *pStorage, const char *pDest, int StorageType)
 {
 	m_WriteToFile = true;
-	str_copy(m_aDest, pDest, sizeof(m_aDest));
+	str_copy(m_aDest, pDest);
 	if(StorageType == -2)
 	{
 		pStorage->GetBinaryPath(m_aDest, m_aDestAbsolute, sizeof(m_aDestAbsolute));

--- a/src/engine/shared/kernel.cpp
+++ b/src/engine/shared/kernel.cpp
@@ -80,7 +80,7 @@ public:
 
 		pInterface->m_pKernel = this;
 		m_aInterfaces[m_NumInterfaces].m_pInterface = pInterface;
-		str_copy(m_aInterfaces[m_NumInterfaces].m_aName, pName, sizeof(m_aInterfaces[m_NumInterfaces].m_aName));
+		str_copy(m_aInterfaces[m_NumInterfaces].m_aName, pName);
 		m_aInterfaces[m_NumInterfaces].m_AutoDestroy = Destroy;
 		m_NumInterfaces++;
 

--- a/src/engine/shared/netban.cpp
+++ b/src/engine/shared/netban.cpp
@@ -247,7 +247,7 @@ int CNetBan::Ban(T *pBanPool, const typename T::CDataType *pData, int Seconds, c
 	// set up info
 	CBanInfo Info = {0};
 	Info.m_Expires = Stamp;
-	str_copy(Info.m_aReason, pReason, sizeof(Info.m_aReason));
+	str_copy(Info.m_aReason, pReason);
 
 	// check if it already exists
 	CNetHash NetHash(pData);

--- a/src/engine/shared/netban.h
+++ b/src/engine/shared/netban.h
@@ -205,7 +205,7 @@ void CNetBan::MakeBanInfo(const CBan<T> *pBan, char *pBuf, unsigned BuffSize, in
 	// build type based part
 	char aBuf[256];
 	if(Type == MSGTYPE_PLAYER)
-		str_copy(aBuf, "You have been banned", sizeof(aBuf));
+		str_copy(aBuf, "You have been banned");
 	else
 	{
 		char aTemp[256];

--- a/src/engine/shared/network_conn.cpp
+++ b/src/engine/shared/network_conn.cpp
@@ -53,7 +53,7 @@ const char *CNetConnection::ErrorString()
 
 void CNetConnection::SetError(const char *pString)
 {
-	str_copy(m_aErrorString, pString, sizeof(m_aErrorString));
+	str_copy(m_aErrorString, pString);
 }
 
 void CNetConnection::Init(NETSOCKET Socket, bool BlockCloseMsg)
@@ -214,7 +214,7 @@ void CNetConnection::Disconnect(const char *pReason)
 		{
 			m_aErrorString[0] = 0;
 			if(pReason)
-				str_copy(m_aErrorString, pReason, sizeof(m_aErrorString));
+				str_copy(m_aErrorString, pReason);
 		}
 	}
 

--- a/src/engine/shared/network_console.cpp
+++ b/src/engine/shared/network_console.cpp
@@ -66,7 +66,7 @@ int CNetConsole::AcceptClient(NETSOCKET Socket, const NETADDR *pAddr)
 		{
 			if(net_addr_comp(pAddr, m_aSlots[i].m_Connection.PeerAddress()) == 0)
 			{
-				str_copy(aError, "only one client per IP allowed", sizeof(aError));
+				str_copy(aError, "only one client per IP allowed");
 				break;
 			}
 		}
@@ -83,7 +83,7 @@ int CNetConsole::AcceptClient(NETSOCKET Socket, const NETADDR *pAddr)
 
 	// reject client
 	if(!aError[0])
-		str_copy(aError, "no free slot available", sizeof(aError));
+		str_copy(aError, "no free slot available");
 
 	net_tcp_send(Socket, aError, str_length(aError));
 	net_tcp_close(Socket);

--- a/src/engine/shared/network_console_conn.cpp
+++ b/src/engine/shared/network_console_conn.cpp
@@ -56,7 +56,7 @@ int CConsoleNetConnection::Update()
 		if((int)(sizeof(m_aBuffer)) <= m_BufferOffset)
 		{
 			m_State = NET_CONNSTATE_ERROR;
-			str_copy(m_aErrorString, "too weak connection (out of buffer)", sizeof(m_aErrorString));
+			str_copy(m_aErrorString, "too weak connection (out of buffer)");
 			return -1;
 		}
 
@@ -72,13 +72,13 @@ int CConsoleNetConnection::Update()
 				return 0;
 
 			m_State = NET_CONNSTATE_ERROR; // error
-			str_copy(m_aErrorString, "connection failure", sizeof(m_aErrorString));
+			str_copy(m_aErrorString, "connection failure");
 			return -1;
 		}
 		else
 		{
 			m_State = NET_CONNSTATE_ERROR;
-			str_copy(m_aErrorString, "remote end closed the connection", sizeof(m_aErrorString));
+			str_copy(m_aErrorString, "remote end closed the connection");
 			return -1;
 		}
 	}
@@ -169,7 +169,7 @@ int CConsoleNetConnection::Send(const char *pLine)
 		if(Send < 0)
 		{
 			m_State = NET_CONNSTATE_ERROR;
-			str_copy(m_aErrorString, "failed to send packet", sizeof(m_aErrorString));
+			str_copy(m_aErrorString, "failed to send packet");
 			return -1;
 		}
 

--- a/src/engine/shared/serverinfo.cpp
+++ b/src/engine/shared/serverinfo.cpp
@@ -86,10 +86,10 @@ bool CServerInfo2::FromJsonRaw(CServerInfo2 *pOut, const json_value *pJson)
 	pOut->m_MaxClients = json_int_get(&MaxClients);
 	pOut->m_MaxPlayers = json_int_get(&MaxPlayers);
 	pOut->m_Passworded = Passworded;
-	str_copy(pOut->m_aGameType, GameType, sizeof(pOut->m_aGameType));
-	str_copy(pOut->m_aName, Name, sizeof(pOut->m_aName));
-	str_copy(pOut->m_aMapName, MapName, sizeof(pOut->m_aMapName));
-	str_copy(pOut->m_aVersion, Version, sizeof(pOut->m_aVersion));
+	str_copy(pOut->m_aGameType, GameType);
+	str_copy(pOut->m_aName, Name);
+	str_copy(pOut->m_aMapName, MapName);
+	str_copy(pOut->m_aVersion, Version);
 
 	pOut->m_NumClients = 0;
 	pOut->m_NumPlayers = 0;
@@ -114,8 +114,8 @@ bool CServerInfo2::FromJsonRaw(CServerInfo2 *pOut, const json_value *pJson)
 		if(i < SERVERINFO_MAX_CLIENTS)
 		{
 			CClient *pClient = &pOut->m_aClients[i];
-			str_copy(pClient->m_aName, ClientName, sizeof(pClient->m_aName));
-			str_copy(pClient->m_aClan, Clan, sizeof(pClient->m_aClan));
+			str_copy(pClient->m_aName, ClientName);
+			str_copy(pClient->m_aClan, Clan);
 			pClient->m_Country = json_int_get(&Country);
 			pClient->m_Score = json_int_get(&Score);
 			pClient->m_IsPlayer = IsPlayer;
@@ -171,15 +171,15 @@ CServerInfo2::operator CServerInfo() const
 	Result.m_MaxPlayers = m_MaxPlayers;
 	Result.m_NumPlayers = m_NumPlayers;
 	Result.m_Flags = m_Passworded ? SERVER_FLAG_PASSWORD : 0;
-	str_copy(Result.m_aGameType, m_aGameType, sizeof(Result.m_aGameType));
-	str_copy(Result.m_aName, m_aName, sizeof(Result.m_aName));
-	str_copy(Result.m_aMap, m_aMapName, sizeof(Result.m_aMap));
-	str_copy(Result.m_aVersion, m_aVersion, sizeof(Result.m_aVersion));
+	str_copy(Result.m_aGameType, m_aGameType);
+	str_copy(Result.m_aName, m_aName);
+	str_copy(Result.m_aMap, m_aMapName);
+	str_copy(Result.m_aVersion, m_aVersion);
 
 	for(int i = 0; i < minimum(m_NumClients, (int)SERVERINFO_MAX_CLIENTS); i++)
 	{
-		str_copy(Result.m_aClients[i].m_aName, m_aClients[i].m_aName, sizeof(Result.m_aClients[i].m_aName));
-		str_copy(Result.m_aClients[i].m_aClan, m_aClients[i].m_aClan, sizeof(Result.m_aClients[i].m_aClan));
+		str_copy(Result.m_aClients[i].m_aName, m_aClients[i].m_aName);
+		str_copy(Result.m_aClients[i].m_aClan, m_aClients[i].m_aClan);
 		Result.m_aClients[i].m_Country = m_aClients[i].m_Country;
 		Result.m_aClients[i].m_Score = m_aClients[i].m_Score;
 		Result.m_aClients[i].m_Player = m_aClients[i].m_IsPlayer;

--- a/src/engine/shared/storage.cpp
+++ b/src/engine/shared/storage.cpp
@@ -37,7 +37,7 @@ public:
 
 		if(!fs_is_dir(m_aUserdir) && fs_is_dir(aFallbackUserdir))
 		{
-			str_copy(m_aUserdir, aFallbackUserdir, sizeof(m_aUserdir));
+			str_copy(m_aUserdir, aFallbackUserdir);
 		}
 
 		// get datadir
@@ -159,7 +159,7 @@ public:
 		{
 			if(m_aUserdir[0])
 			{
-				str_copy(m_aaStoragePaths[m_NumPaths++], m_aUserdir, IO_MAX_PATH_LENGTH);
+				str_copy(m_aaStoragePaths[m_NumPaths++], m_aUserdir);
 				dbg_msg("storage", "added path '$USERDIR' ('%s')", m_aUserdir);
 			}
 		}
@@ -167,7 +167,7 @@ public:
 		{
 			if(m_aDatadir[0])
 			{
-				str_copy(m_aaStoragePaths[m_NumPaths++], m_aDatadir, IO_MAX_PATH_LENGTH);
+				str_copy(m_aaStoragePaths[m_NumPaths++], m_aDatadir);
 				dbg_msg("storage", "added path '$DATADIR' ('%s')", m_aDatadir);
 			}
 		}
@@ -180,7 +180,7 @@ public:
 		{
 			if(fs_is_dir(pPath))
 			{
-				str_copy(m_aaStoragePaths[m_NumPaths++], pPath, IO_MAX_PATH_LENGTH);
+				str_copy(m_aaStoragePaths[m_NumPaths++], pPath);
 				dbg_msg("storage", "added path '%s'", pPath);
 			}
 		}
@@ -191,7 +191,7 @@ public:
 		// 1) use data-dir in PWD if present
 		if(fs_is_dir("data/mapres"))
 		{
-			str_copy(m_aDatadir, "data", sizeof(m_aDatadir));
+			str_copy(m_aDatadir, "data");
 			return;
 		}
 

--- a/src/engine/shared/uuid_manager.cpp
+++ b/src/engine/shared/uuid_manager.cpp
@@ -61,7 +61,7 @@ int ParseUuid(CUuid *pUuid, const char *pBuffer)
 		return 2;
 	}
 	char aCopy[UUID_MAXSTRSIZE];
-	str_copy(aCopy, pBuffer, sizeof(aCopy));
+	str_copy(aCopy, pBuffer);
 	// 01234567-9012-4567-9012-456789012345
 	if(aCopy[8] != '-' || aCopy[13] != '-' || aCopy[18] != '-' || aCopy[23] != '-')
 	{

--- a/src/game/client/components/background.cpp
+++ b/src/game/client/components/background.cpp
@@ -60,7 +60,7 @@ void CBackground::LoadBackground()
 
 	bool NeedImageLoading = false;
 
-	str_copy(m_aMapName, g_Config.m_ClBackgroundEntities, sizeof(m_aMapName));
+	str_copy(m_aMapName, g_Config.m_ClBackgroundEntities);
 	char aBuf[128];
 	str_format(aBuf, sizeof(aBuf), "maps/%s", g_Config.m_ClBackgroundEntities);
 	if(str_comp(g_Config.m_ClBackgroundEntities, CURRENT_MAP) == 0)

--- a/src/game/client/components/broadcast.cpp
+++ b/src/game/client/components/broadcast.cpp
@@ -39,7 +39,7 @@ void CBroadcast::OnMessage(int MsgType, void *pRawMsg)
 	if(MsgType == NETMSGTYPE_SV_BROADCAST)
 	{
 		CNetMsg_Sv_Broadcast *pMsg = (CNetMsg_Sv_Broadcast *)pRawMsg;
-		str_copy(m_aBroadcastText, pMsg->m_pMessage, sizeof(m_aBroadcastText));
+		str_copy(m_aBroadcastText, pMsg->m_pMessage);
 		CTextCursor Cursor;
 		TextRender()->SetCursor(&Cursor, 0, 0, 12.0f, TEXTFLAG_STOP_AT_END);
 		Cursor.m_LineWidth = 300 * Graphics()->ScreenAspect();

--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -800,7 +800,7 @@ void CChat::AddLine(int ClientID, int Team, const char *pLine)
 
 		if(pCurrentLine->m_ClientID < 0) // server or client message
 		{
-			str_copy(pCurrentLine->m_aName, "*** ", sizeof(pCurrentLine->m_aName));
+			str_copy(pCurrentLine->m_aName, "*** ");
 			str_format(pCurrentLine->m_aText, sizeof(pCurrentLine->m_aText), "%s", pLine);
 		}
 		else
@@ -851,7 +851,7 @@ void CChat::AddLine(int ClientID, int Team, const char *pLine)
 				else
 					pCurrentLine->m_RenderSkin = m_pClient->m_aClients[pCurrentLine->m_ClientID].m_RenderInfo.m_OriginalRenderSkin;
 
-				str_copy(pCurrentLine->m_aSkinName, m_pClient->m_aClients[pCurrentLine->m_ClientID].m_aSkinName, sizeof(pCurrentLine->m_aSkinName));
+				str_copy(pCurrentLine->m_aSkinName, m_pClient->m_aClients[pCurrentLine->m_ClientID].m_aSkinName);
 				pCurrentLine->m_ColorBody = m_pClient->m_aClients[pCurrentLine->m_ClientID].m_RenderInfo.m_ColorBody;
 				pCurrentLine->m_ColorFeet = m_pClient->m_aClients[pCurrentLine->m_ClientID].m_RenderInfo.m_ColorFeet;
 

--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -144,7 +144,7 @@ void CGameConsole::CInstance::ExecuteLine(const char *pLine)
 			if(!m_UserGot && m_UsernameReq)
 			{
 				m_UserGot = true;
-				str_copy(m_aUser, pLine, sizeof m_aUser);
+				str_copy(m_aUser, pLine);
 			}
 			else
 			{
@@ -388,7 +388,7 @@ void CGameConsole::CInstance::OnInput(IInput::CEvent Event)
 		{
 			m_CompletionUsed = false;
 			m_CompletionChosen = -1;
-			str_copy(m_aCompletionBuffer, m_Input.GetString(), sizeof(m_aCompletionBuffer));
+			str_copy(m_aCompletionBuffer, m_Input.GetString());
 			m_CompletionRenderOffset = 0.0f;
 		}
 
@@ -406,9 +406,9 @@ void CGameConsole::CInstance::OnInput(IInput::CEvent Event)
 			if(pCommand)
 			{
 				m_IsCommand = true;
-				str_copy(m_aCommandName, pCommand->m_pName, IConsole::TEMPCMD_NAME_LENGTH);
-				str_copy(m_aCommandHelp, pCommand->m_pHelp, IConsole::TEMPCMD_HELP_LENGTH);
-				str_copy(m_aCommandParams, pCommand->m_pParams, IConsole::TEMPCMD_PARAMS_LENGTH);
+				str_copy(m_aCommandName, pCommand->m_pName);
+				str_copy(m_aCommandHelp, pCommand->m_pHelp);
+				str_copy(m_aCommandParams, pCommand->m_pParams);
 			}
 			else
 				m_IsCommand = false;
@@ -676,7 +676,7 @@ void CGameConsole::OnRender()
 
 		//hide rcon password
 		char aInputString[512];
-		str_copy(aInputString, pConsole->m_Input.GetString(Editing), sizeof(aInputString));
+		str_copy(aInputString, pConsole->m_Input.GetString(Editing));
 		if(m_ConsoleType == CONSOLETYPE_REMOTE && Client()->State() == IClient::STATE_ONLINE && !Client()->RconAuthed() && (pConsole->m_UserGot || !pConsole->m_UsernameReq))
 		{
 			for(int i = 0; i < pConsole->m_Input.GetLength(Editing); ++i)
@@ -857,7 +857,7 @@ void CGameConsole::OnRender()
 		TextRender()->Text(0, 10.0f, FontSize / 2.f, FontSize, aBuf, -1.0f);
 
 		// render version
-		str_copy(aBuf, "v" GAME_VERSION " on " CONF_PLATFORM_STRING " " CONF_ARCH_STRING, sizeof(aBuf));
+		str_copy(aBuf, "v" GAME_VERSION " on " CONF_PLATFORM_STRING " " CONF_ARCH_STRING);
 		float Width = TextRender()->TextWidth(0, FontSize, aBuf, -1, -1.0f);
 		TextRender()->Text(0, Screen.w - Width - 10.0f, FontSize / 2.f, FontSize, aBuf, -1.0f);
 	}

--- a/src/game/client/components/countryflags.cpp
+++ b/src/game/client/components/countryflags.cpp
@@ -31,7 +31,7 @@ void CCountryFlags::LoadCountryflagsIndexfile()
 		if(!str_length(pLine) || pLine[0] == '#') // skip empty lines and comments
 			continue;
 
-		str_copy(aOrigin, pLine, sizeof(aOrigin));
+		str_copy(aOrigin, pLine);
 		char *pReplacement = LineReader.Get();
 		if(!pReplacement)
 		{
@@ -71,7 +71,7 @@ void CCountryFlags::LoadCountryflagsIndexfile()
 		// add entry
 		CCountryFlag CountryFlag;
 		CountryFlag.m_CountryCode = CountryCode;
-		str_copy(CountryFlag.m_aCountryCodeString, aOrigin, sizeof(CountryFlag.m_aCountryCodeString));
+		str_copy(CountryFlag.m_aCountryCodeString, aOrigin);
 		CountryFlag.m_Texture = Graphics()->LoadTextureRaw(Info.m_Width, Info.m_Height, Info.m_Format, Info.m_pData, Info.m_Format, 0, aOrigin);
 		Graphics()->FreePNG(&Info);
 

--- a/src/game/client/components/debughud.cpp
+++ b/src/game/client/components/debughud.cpp
@@ -57,7 +57,7 @@ void CDebugHud::RenderNetCorrections()
 	if(pCharacter)
 		str_format(aBuf, sizeof(aBuf), "%d", pCharacter->m_TeleCheckpoint);
 	else
-		str_copy(aBuf, "-1", sizeof(aBuf));
+		str_copy(aBuf, "-1");
 	w = TextRender()->TextWidth(0, Fontsize, aBuf, -1, -1.0f);
 	TextRender()->Text(0, x - w, y, Fontsize, aBuf, -1.0f);
 	y += 2 * LineHeight;

--- a/src/game/client/components/ghost.cpp
+++ b/src/game/client/components/ghost.cpp
@@ -130,7 +130,7 @@ void CGhost::GetPath(char *pBuf, int Size, const char *pPlayerName, int Time) co
 	sha256_str(Sha256, aSha256, sizeof(aSha256));
 
 	char aPlayerName[MAX_NAME_LENGTH];
-	str_copy(aPlayerName, pPlayerName, sizeof(aPlayerName));
+	str_copy(aPlayerName, pPlayerName);
 	str_sanitize_filename(aPlayerName);
 
 	if(Time < 0)
@@ -415,7 +415,7 @@ void CGhost::StartRecord(int Tick)
 	m_CurGhost.m_StartTick = Tick;
 
 	const CGameClient::CClientData *pData = &m_pClient->m_aClients[m_pClient->m_Snap.m_LocalClientID];
-	str_copy(m_CurGhost.m_aPlayer, Client()->PlayerName(), sizeof(m_CurGhost.m_aPlayer));
+	str_copy(m_CurGhost.m_aPlayer, Client()->PlayerName());
 	GetGhostSkin(&m_CurGhost.m_Skin, pData->m_aSkinName, pData->m_UseCustomColor, pData->m_ColorBody, pData->m_ColorFeet);
 	InitRenderInfos(&m_CurGhost);
 }
@@ -443,7 +443,7 @@ void CGhost::StopRecord(int Time)
 		CMenus::CGhostItem Item;
 		if(RecordingToFile)
 			GetPath(Item.m_aFilename, sizeof(Item.m_aFilename), m_CurGhost.m_aPlayer, Time);
-		str_copy(Item.m_aPlayer, m_CurGhost.m_aPlayer, sizeof(Item.m_aPlayer));
+		str_copy(Item.m_aPlayer, m_CurGhost.m_aPlayer);
 		Item.m_Time = Time;
 		Item.m_Slot = Slot;
 
@@ -499,7 +499,7 @@ int CGhost::Load(const char *pFilename)
 	pGhost->Reset();
 	pGhost->m_Path.SetSize(pInfo->m_NumTicks);
 
-	str_copy(pGhost->m_aPlayer, pInfo->m_aOwner, sizeof(pGhost->m_aPlayer));
+	str_copy(pGhost->m_aPlayer, pInfo->m_aOwner);
 
 	int Index = 0;
 	bool FoundSkin = false;

--- a/src/game/client/components/killmessages.cpp
+++ b/src/game/client/components/killmessages.cpp
@@ -114,7 +114,7 @@ void CKillMessages::OnMessage(int MsgType, void *pRawMsg)
 		{
 			Kill.m_VictimTeam = m_pClient->m_aClients[Kill.m_VictimID].m_Team;
 			Kill.m_VictimDDTeam = m_pClient->m_Teams.Team(Kill.m_VictimID);
-			str_copy(Kill.m_aVictimName, m_pClient->m_aClients[Kill.m_VictimID].m_aName, sizeof(Kill.m_aVictimName));
+			str_copy(Kill.m_aVictimName, m_pClient->m_aClients[Kill.m_VictimID].m_aName);
 			Kill.m_VictimRenderInfo = m_pClient->m_aClients[Kill.m_VictimID].m_RenderInfo;
 		}
 
@@ -122,7 +122,7 @@ void CKillMessages::OnMessage(int MsgType, void *pRawMsg)
 		if(Kill.m_KillerID >= 0 && Kill.m_KillerID < MAX_CLIENTS)
 		{
 			Kill.m_KillerTeam = m_pClient->m_aClients[Kill.m_KillerID].m_Team;
-			str_copy(Kill.m_aKillerName, m_pClient->m_aClients[Kill.m_KillerID].m_aName, sizeof(Kill.m_aKillerName));
+			str_copy(Kill.m_aKillerName, m_pClient->m_aClients[Kill.m_KillerID].m_aName);
 			Kill.m_KillerRenderInfo = m_pClient->m_aClients[Kill.m_KillerID].m_RenderInfo;
 		}
 

--- a/src/game/client/components/mapimages.cpp
+++ b/src/game/client/components/mapimages.cpp
@@ -37,7 +37,7 @@ CMapImages::CMapImages(int TextureSize)
 
 	mem_zero(m_aTextureUsedByTileOrQuadLayerFlag, sizeof(m_aTextureUsedByTileOrQuadLayerFlag));
 
-	str_copy(m_aEntitiesPath, "editor/entities_clear", sizeof(m_aEntitiesPath));
+	str_copy(m_aEntitiesPath, "editor/entities_clear");
 
 	static_assert(std::size(gs_apModEntitiesNames) == MAP_IMAGE_MOD_TYPE_COUNT, "Mod name string count is not equal to mod type count");
 }
@@ -47,7 +47,7 @@ void CMapImages::OnInit()
 	InitOverlayTextures();
 
 	if(str_comp(g_Config.m_ClAssetsEntites, "default") == 0)
-		str_copy(m_aEntitiesPath, "editor/entities_clear", sizeof(m_aEntitiesPath));
+		str_copy(m_aEntitiesPath, "editor/entities_clear");
 	else
 	{
 		str_format(m_aEntitiesPath, sizeof(m_aEntitiesPath), "assets/entities/%s", g_Config.m_ClAssetsEntites);
@@ -381,7 +381,7 @@ IGraphics::CTextureHandle CMapImages::GetOverlayCenter()
 void CMapImages::ChangeEntitiesPath(const char *pPath)
 {
 	if(str_comp(pPath, "default") == 0)
-		str_copy(m_aEntitiesPath, "editor/entities_clear", sizeof(m_aEntitiesPath));
+		str_copy(m_aEntitiesPath, "editor/entities_clear");
 	else
 	{
 		str_format(m_aEntitiesPath, sizeof(m_aEntitiesPath), "assets/entities/%s", pPath);

--- a/src/game/client/components/maplayers.cpp
+++ b/src/game/client/components/maplayers.cpp
@@ -182,7 +182,7 @@ void FillTmpTileSpeedup(SGraphicTile *pTmpTile, SGraphicTileTexureCoords *pTmpTe
 	}
 
 	//same as in rotate from Graphics()
-	float Angle = (float)AngleRotate * (3.14159265f / 180.0f);
+	float Angle = (float)AngleRotate * (pi / 180.0f);
 	float c = cosf(Angle);
 	float s = sinf(Angle);
 	float xR, yR;

--- a/src/game/client/components/menu_background.cpp
+++ b/src/game/client/components/menu_background.cpp
@@ -103,7 +103,7 @@ int CMenuBackground::ThemeScan(const char *pName, int IsDir, int DirType, void *
 		IsNight = true;
 	}
 	else
-		str_copy(aThemeName, aFullName, sizeof(aThemeName));
+		str_copy(aThemeName, aFullName);
 
 	if(str_comp(aThemeName, "none") == 0 || str_comp(aThemeName, "auto") == 0 || str_comp(aThemeName, "rand") == 0) // "none", "auto" and "rand" reserved, disallowed for maps
 		return 0;
@@ -195,7 +195,7 @@ void CMenuBackground::LoadMenuBackground(bool HasDayHint, bool HasNightHint)
 
 	bool NeedImageLoading = false;
 
-	str_copy(m_aMapName, g_Config.m_ClMenuMap, sizeof(m_aMapName));
+	str_copy(m_aMapName, g_Config.m_ClMenuMap);
 
 	if(g_Config.m_ClMenuMap[0] != '\0')
 	{

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -77,7 +77,7 @@ CMenus::CMenus()
 	m_DeletePressed = false;
 	m_NumInputEvents = 0;
 
-	str_copy(m_aCurrentDemoFolder, "demos", sizeof(m_aCurrentDemoFolder));
+	str_copy(m_aCurrentDemoFolder, "demos");
 	m_aCallvoteReason[0] = 0;
 
 	m_FriendlistSelectedIndex = -1;
@@ -1046,9 +1046,9 @@ void CMenus::PopupMessage(const char *pTopic, const char *pBody, const char *pBu
 	// reset active item
 	UI()->SetActiveItem(nullptr);
 
-	str_copy(m_aMessageTopic, pTopic, sizeof(m_aMessageTopic));
-	str_copy(m_aMessageBody, pBody, sizeof(m_aMessageBody));
-	str_copy(m_aMessageButton, pButton, sizeof(m_aMessageButton));
+	str_copy(m_aMessageTopic, pTopic);
+	str_copy(m_aMessageBody, pBody);
+	str_copy(m_aMessageButton, pButton);
 	m_Popup = POPUP_MESSAGE;
 }
 
@@ -1059,9 +1059,9 @@ void CMenus::PopupWarning(const char *pTopic, const char *pBody, const char *pBu
 	// reset active item
 	UI()->SetActiveItem(nullptr);
 
-	str_copy(m_aMessageTopic, pTopic, sizeof(m_aMessageTopic));
-	str_copy(m_aMessageBody, pBody, sizeof(m_aMessageBody));
-	str_copy(m_aMessageButton, pButton, sizeof(m_aMessageButton));
+	str_copy(m_aMessageTopic, pTopic);
+	str_copy(m_aMessageBody, pBody);
+	str_copy(m_aMessageButton, pButton);
 	m_Popup = POPUP_WARNING;
 	SetActive(true);
 
@@ -2046,7 +2046,7 @@ int CMenus::Render()
 						str_format(aBufNew, sizeof(aBufNew), "%s", m_aCurrentDemoFile);
 					char aWholePath[1024];
 					// store new video filename to origin buffer
-					str_copy(m_aCurrentDemoFile, aBufNew, sizeof(m_aCurrentDemoFile));
+					str_copy(m_aCurrentDemoFile, aBufNew);
 					if(Storage()->FindFile(m_aCurrentDemoFile, "videos", IStorage::TYPE_ALL, aWholePath, sizeof(aWholePath)))
 					{
 						PopupMessage(Localize("Error"), Localize("Destination file already exist"), Localize("Ok"));
@@ -2366,11 +2366,11 @@ void CMenus::RenderThemeSelection(CUIRect MainView, bool Header)
 
 		char aName[128];
 		if(Theme.m_Name.empty())
-			str_copy(aName, "(none)", sizeof(aName));
+			str_copy(aName, "(none)");
 		else if(str_comp(Theme.m_Name.c_str(), "auto") == 0)
-			str_copy(aName, "(seasons)", sizeof(aName));
+			str_copy(aName, "(seasons)");
 		else if(str_comp(Theme.m_Name.c_str(), "rand") == 0)
-			str_copy(aName, "(random)", sizeof(aName));
+			str_copy(aName, "(random)");
 		else if(Theme.m_HasDay && Theme.m_HasNight)
 			str_format(aName, sizeof(aName), "%s", Theme.m_Name.c_str());
 		else if(Theme.m_HasDay && !Theme.m_HasNight)

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -196,7 +196,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 	if(HandleListInputs(View, s_ScrollValue, 3.0f, &m_ScrollOffset, s_aCols[0].m_Rect.h, m_SelectedIndex, NumServers))
 	{
 		const CServerInfo *pItem = ServerBrowser()->SortedGet(m_SelectedIndex);
-		str_copy(g_Config.m_UiServerAddress, pItem->m_aAddress, sizeof(g_Config.m_UiServerAddress));
+		str_copy(g_Config.m_UiServerAddress, pItem->m_aAddress);
 	}
 
 	// set clipping
@@ -479,13 +479,13 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 	{
 		// select the new server
 		const CServerInfo *pItem = ServerBrowser()->SortedGet(NewSelected);
-		str_copy(g_Config.m_UiServerAddress, pItem->m_aAddress, sizeof(g_Config.m_UiServerAddress));
+		str_copy(g_Config.m_UiServerAddress, pItem->m_aAddress);
 		if(DoubleClicked && Input()->MouseDoubleClick())
 		{
 			if(Client()->State() == IClient::STATE_ONLINE && Client()->GetCurrentRaceTime() / 60 >= g_Config.m_ClConfirmDisconnectTime && g_Config.m_ClConfirmDisconnectTime >= 0)
 			{
 				m_Popup = POPUP_SWITCH_SERVER;
-				str_copy(m_aNextServer, g_Config.m_UiServerAddress, sizeof(m_aNextServer));
+				str_copy(m_aNextServer, g_Config.m_UiServerAddress);
 			}
 			else
 				Client()->Connect(g_Config.m_UiServerAddress);
@@ -622,9 +622,9 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 			if(ServerBrowser()->IsRefreshing())
 				str_format(m_aLocalStringHelper, sizeof(m_aLocalStringHelper), "%s (%d%%)", Localize("Refresh"), ServerBrowser()->LoadingProgression());
 			else if(ServerBrowser()->IsGettingServerlist())
-				str_copy(m_aLocalStringHelper, Localize("Refreshing..."), sizeof(m_aLocalStringHelper));
+				str_copy(m_aLocalStringHelper, Localize("Refreshing..."));
 			else
-				str_copy(m_aLocalStringHelper, Localize("Refresh"), sizeof(m_aLocalStringHelper));
+				str_copy(m_aLocalStringHelper, Localize("Refresh"));
 
 			return m_aLocalStringHelper;
 		};
@@ -661,7 +661,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 			if(Client()->State() == IClient::STATE_ONLINE && Client()->GetCurrentRaceTime() / 60 >= g_Config.m_ClConfirmDisconnectTime && g_Config.m_ClConfirmDisconnectTime >= 0)
 			{
 				m_Popup = POPUP_SWITCH_SERVER;
-				str_copy(m_aNextServer, g_Config.m_UiServerAddress, sizeof(m_aNextServer));
+				str_copy(m_aNextServer, g_Config.m_UiServerAddress);
 			}
 			else
 				Client()->Connect(g_Config.m_UiServerAddress);
@@ -1167,7 +1167,7 @@ void CMenus::RenderServerbrowserServerDetail(CUIRect View)
 			char aTemp[16];
 
 			if(!pSelectedServer->m_aClients[i].m_Player)
-				str_copy(aTemp, "SPEC", sizeof(aTemp));
+				str_copy(aTemp, "SPEC");
 			else if(IsRace(pSelectedServer) && g_Config.m_ClDDRaceScoreBoard)
 			{
 				if(pSelectedServer->m_aClients[i].m_Score == -9999 || pSelectedServer->m_aClients[i].m_Score == 0)
@@ -1325,7 +1325,7 @@ void CMenus::RenderServerbrowserFriends(CUIRect View)
 						(!m_vFriends[m_FriendlistSelectedIndex].m_pFriendInfo->m_aName[0] ||
 							str_quickhash(pItem->m_aClients[j].m_aName) == m_vFriends[m_FriendlistSelectedIndex].m_pFriendInfo->m_NameHash))
 					{
-						str_copy(g_Config.m_UiServerAddress, pItem->m_aAddress, sizeof(g_Config.m_UiServerAddress));
+						str_copy(g_Config.m_UiServerAddress, pItem->m_aAddress);
 						m_ScrollOffset = ItemIndex;
 						m_SelectedIndex = ItemIndex;
 						Found = true;

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -118,7 +118,7 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 		if(DoButton_Menu(&s_ButtonOk, Localize("Ok"), 0, &Ok) || m_EnterPressed)
 		{
 			if(str_comp(m_vDemos[m_DemolistSelectedIndex].m_aFilename, m_aCurrentDemoFile) == 0)
-				str_copy(m_aDemoPlayerPopupHint, Localize("Please use a different name"), sizeof(m_aDemoPlayerPopupHint));
+				str_copy(m_aDemoPlayerPopupHint, Localize("Please use a different name"));
 			else
 			{
 				if(!str_endswith(m_aCurrentDemoFile, ".demo"))
@@ -132,7 +132,7 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 				if(DemoFile && str_comp(m_aDemoPlayerPopupHint, pStr) != 0)
 				{
 					io_close(DemoFile);
-					str_copy(m_aDemoPlayerPopupHint, pStr, sizeof(m_aDemoPlayerPopupHint));
+					str_copy(m_aDemoPlayerPopupHint, pStr);
 				}
 				else
 				{
@@ -456,7 +456,7 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 	static int s_SliceSaveButton = 0;
 	if(DoButton_Sprite(&s_SliceSaveButton, IMAGE_FILEICONS, SPRITE_FILE_DEMO2, 0, &Button, CUI::CORNER_ALL))
 	{
-		str_copy(m_aCurrentDemoFile, m_vDemos[m_DemolistSelectedIndex].m_aFilename, sizeof(m_aCurrentDemoFile));
+		str_copy(m_aCurrentDemoFile, m_vDemos[m_DemolistSelectedIndex].m_aFilename);
 		m_aDemoPlayerPopupHint[0] = '\0';
 		m_DemoPlayerState = DEMOPLAYER_SLICE_SAVE;
 	}
@@ -751,7 +751,7 @@ int CMenus::DemolistFetchCallback(const CFsFileInfo *pInfo, int IsDir, int Stora
 	}
 
 	CDemoItem Item;
-	str_copy(Item.m_aFilename, pInfo->m_pName, sizeof(Item.m_aFilename));
+	str_copy(Item.m_aFilename, pInfo->m_pName);
 	if(IsDir)
 	{
 		str_format(Item.m_aName, sizeof(Item.m_aName), "%s/", pInfo->m_pName);
@@ -856,13 +856,13 @@ void CMenus::RenderDemoList(CUIRect MainView)
 	{
 		CDemoItem &Item = m_vDemos[m_DemolistSelectedIndex];
 		if(str_comp(Item.m_aFilename, "..") == 0)
-			str_copy(aFooterLabel, Localize("Parent Folder"), sizeof(aFooterLabel));
+			str_copy(aFooterLabel, Localize("Parent Folder"));
 		else if(m_DemolistSelectedIsDir)
-			str_copy(aFooterLabel, Localize("Folder"), sizeof(aFooterLabel));
+			str_copy(aFooterLabel, Localize("Folder"));
 		else if(!FetchHeader(Item))
-			str_copy(aFooterLabel, Localize("Invalid Demo"), sizeof(aFooterLabel));
+			str_copy(aFooterLabel, Localize("Invalid Demo"));
 		else
-			str_copy(aFooterLabel, Localize("Demo details"), sizeof(aFooterLabel));
+			str_copy(aFooterLabel, Localize("Demo details"));
 	}
 
 	// render background
@@ -1084,7 +1084,7 @@ void CMenus::RenderDemoList(CUIRect MainView)
 	HandleListInputs(ListBox, s_ScrollValue, 3.0f, &m_ScrollOffset, s_aCols[0].m_Rect.h, m_DemolistSelectedIndex, m_vDemos.size());
 	if(PreviousIndex != m_DemolistSelectedIndex)
 	{
-		str_copy(g_Config.m_UiDemoSelected, m_vDemos[m_DemolistSelectedIndex].m_aName, sizeof(g_Config.m_UiDemoSelected));
+		str_copy(g_Config.m_UiDemoSelected, m_vDemos[m_DemolistSelectedIndex].m_aName);
 		DemolistOnUpdate(false);
 	}
 
@@ -1127,7 +1127,7 @@ void CMenus::RenderDemoList(CUIRect MainView)
 			if(UI()->DoButtonLogic(Item.m_aName, Selected, &Row))
 			{
 				DoubleClicked |= ItemIndex == m_DoubleClickIndex;
-				str_copy(g_Config.m_UiDemoSelected, Item.m_aName, sizeof(g_Config.m_UiDemoSelected));
+				str_copy(g_Config.m_UiDemoSelected, Item.m_aName);
 				DemolistOnUpdate(false);
 				m_DoubleClickIndex = ItemIndex;
 			}
@@ -1229,7 +1229,7 @@ void CMenus::RenderDemoList(CUIRect MainView)
 				else // sub folder
 				{
 					char aTemp[256];
-					str_copy(aTemp, m_aCurrentDemoFolder, sizeof(aTemp));
+					str_copy(aTemp, m_aCurrentDemoFolder);
 					str_format(m_aCurrentDemoFolder, sizeof(m_aCurrentDemoFolder), "%s/%s", aTemp, m_vDemos[m_DemolistSelectedIndex].m_aFilename);
 					m_DemolistStorageType = m_vDemos[m_DemolistSelectedIndex].m_StorageType;
 				}
@@ -1284,7 +1284,7 @@ void CMenus::RenderDemoList(CUIRect MainView)
 			{
 				UI()->SetActiveItem(nullptr);
 				m_Popup = POPUP_RENAME_DEMO;
-				str_copy(m_aCurrentDemoFile, m_vDemos[m_DemolistSelectedIndex].m_aFilename, sizeof(m_aCurrentDemoFile));
+				str_copy(m_aCurrentDemoFile, m_vDemos[m_DemolistSelectedIndex].m_aFilename);
 				return;
 			}
 		}
@@ -1297,7 +1297,7 @@ void CMenus::RenderDemoList(CUIRect MainView)
 			{
 				UI()->SetActiveItem(nullptr);
 				m_Popup = POPUP_RENDER_DEMO;
-				str_copy(m_aCurrentDemoFile, m_vDemos[m_DemolistSelectedIndex].m_aFilename, sizeof(m_aCurrentDemoFile));
+				str_copy(m_aCurrentDemoFile, m_vDemos[m_DemolistSelectedIndex].m_aFilename);
 				return;
 			}
 		}

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -69,7 +69,7 @@ void CMenus::RenderGame(CUIRect MainView)
 	static int s_DummyButton = 0;
 	if(!Client()->DummyAllowed())
 	{
-		DoButton_Menu(&s_DummyButton, Localize("Connect Dummy"), 1, &Button, 0, 15, 5.0f, 0.0f, vec4(1.0f, 0.5f, 0.5f, 0.75f), vec4(1, 0.5f, 0.5f, 0.5f));
+		DoButton_Menu(&s_DummyButton, Localize("Connect Dummy"), 1, &Button, nullptr, CUI::CORNER_ALL, 5.0f, 0.0f, vec4(1.0f, 0.5f, 0.5f, 0.75f), vec4(1, 0.5f, 0.5f, 0.5f));
 	}
 	else if(DummyConnecting)
 	{

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -937,8 +937,8 @@ void CMenus::RenderGhost(CUIRect MainView)
 
 	struct CColumn
 	{
-		int m_Id;
 		CLocConstString m_Caption;
+		int m_Id;
 		float m_Width;
 		CUIRect m_Rect;
 		CUIRect m_Spacer;
@@ -952,10 +952,10 @@ void CMenus::RenderGhost(CUIRect MainView)
 	};
 
 	static CColumn s_aCols[] = {
-		{-1, " ", 2.0f, {0}, {0}},
-		{COL_ACTIVE, " ", 30.0f, {0}, {0}},
-		{COL_NAME, "Name", 300.0f, {0}, {0}}, // Localize("Name")
-		{COL_TIME, "Time", 200.0f, {0}, {0}}, // Localize("Time")
+		{" ", -1, 2.0f, {0}, {0}},
+		{" ", COL_ACTIVE, 30.0f, {0}, {0}},
+		{"Name", COL_NAME, 300.0f, {0}, {0}}, // Localize("Name")
+		{"Time", COL_TIME, 200.0f, {0}, {0}}, // Localize("Time")
 	};
 
 	int NumCols = std::size(s_aCols);

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -848,8 +848,8 @@ int CMenus::GhostlistFetchCallback(const char *pName, int IsDir, int StorageType
 		return 0;
 
 	CGhostItem Item;
-	str_copy(Item.m_aFilename, aFilename, sizeof(Item.m_aFilename));
-	str_copy(Item.m_aPlayer, Info.m_aOwner, sizeof(Item.m_aPlayer));
+	str_copy(Item.m_aFilename, aFilename);
+	str_copy(Item.m_aPlayer, Info.m_aOwner);
 	Item.m_Time = Info.m_Time;
 	if(Item.m_Time > 0)
 		pSelf->m_vGhosts.push_back(Item);

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -772,7 +772,7 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 	TextRender()->SetCurFont(TextRender()->GetFont(TEXT_FONT_ICON_FONT));
 	TextRender()->SetRenderFlags(ETextRenderFlags::TEXT_RENDER_FLAG_ONLY_ADVANCE_WIDTH | ETextRenderFlags::TEXT_RENDER_FLAG_NO_X_BEARING | ETextRenderFlags::TEXT_RENDER_FLAG_NO_Y_BEARING | ETextRenderFlags::TEXT_RENDER_FLAG_NO_PIXEL_ALIGMENT | ETextRenderFlags::TEXT_RENDER_FLAG_NO_OVERSIZE);
 	static int s_SkinRefreshButtonID = 0;
-	if(DoButton_Menu(&s_SkinRefreshButtonID, "\xEF\x80\x9E", 0, &RefreshButton, NULL, 15, 5, 0, vec4(1.0f, 1.0f, 1.0f, 0.75f), vec4(1, 1, 1, 0.5f), 0))
+	if(DoButton_Menu(&s_SkinRefreshButtonID, "\xEF\x80\x9E", 0, &RefreshButton, nullptr, CUI::CORNER_ALL, 5, 0, vec4(1.0f, 1.0f, 1.0f, 0.75f), vec4(1, 1, 1, 0.5f), 0))
 	{
 		// reset render flags for possible loading screen
 		TextRender()->SetRenderFlags(0);
@@ -2481,7 +2481,7 @@ void CMenus::RenderSettingsAppearance(CUIRect MainView)
 
 	static int s_aPageTabs[NUMBER_OF_APPEARANCE_TABS] = {};
 
-	if(DoButton_MenuTab((void *)&s_aPageTabs[APPEARANCE_TAB_HUD], Localize("HUD"), s_CurTab == APPEARANCE_TAB_HUD, &Page1Tab, 5, NULL, NULL, NULL, NULL, 4))
+	if(DoButton_MenuTab((void *)&s_aPageTabs[APPEARANCE_TAB_HUD], Localize("HUD"), s_CurTab == APPEARANCE_TAB_HUD, &Page1Tab, CUI::CORNER_L, NULL, NULL, NULL, NULL, 4))
 		s_CurTab = APPEARANCE_TAB_HUD;
 	if(DoButton_MenuTab((void *)&s_aPageTabs[APPEARANCE_TAB_CHAT], Localize("Chat"), s_CurTab == APPEARANCE_TAB_CHAT, &Page2Tab, 0, NULL, NULL, NULL, NULL, 4))
 		s_CurTab = APPEARANCE_TAB_CHAT;
@@ -2491,7 +2491,7 @@ void CMenus::RenderSettingsAppearance(CUIRect MainView)
 		s_CurTab = APPEARANCE_TAB_HOOK_COLLISION;
 	if(DoButton_MenuTab((void *)&s_aPageTabs[APPEARANCE_TAB_KILL_MESSAGES], Localize("Kill Messages"), s_CurTab == APPEARANCE_TAB_KILL_MESSAGES, &Page5Tab, 0, NULL, NULL, NULL, NULL, 4))
 		s_CurTab = APPEARANCE_TAB_KILL_MESSAGES;
-	if(DoButton_MenuTab((void *)&s_aPageTabs[APPEARANCE_TAB_LASER], Localize("Laser"), s_CurTab == APPEARANCE_TAB_LASER, &Page6Tab, 10, NULL, NULL, NULL, NULL, 4))
+	if(DoButton_MenuTab((void *)&s_aPageTabs[APPEARANCE_TAB_LASER], Localize("Laser"), s_CurTab == APPEARANCE_TAB_LASER, &Page6Tab, CUI::CORNER_R, NULL, NULL, NULL, NULL, 4))
 		s_CurTab = APPEARANCE_TAB_LASER;
 
 	MainView.HSplitTop(10.0f, 0x0, &MainView); // Margin

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -513,7 +513,7 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 			Button.HMargin(2.0f, &Button);
 			if(DoButton_Menu(&pPrefix, pPrefix, 0, &Button))
 			{
-				str_copy(g_Config.m_ClSkinPrefix, pPrefix, sizeof(g_Config.m_ClSkinPrefix));
+				str_copy(g_Config.m_ClSkinPrefix, pPrefix);
 			}
 		}
 	}
@@ -1639,7 +1639,7 @@ void CMenus::RenderSettingsGraphics(CUIRect MainView)
 		const int NewBackend = RenderDropDown(s_BackendDropDownState, &MainView, OldSelectedBackend, vBackendIDPtrs.data(), vBackendIDNamesCStr.data(), s_BackendCount, &s_BackendCount, s_ScrollValueDropBackend);
 		if(OldSelectedBackend != NewBackend)
 		{
-			str_copy(g_Config.m_GfxBackend, vBackendInfos[NewBackend].m_pBackendName, sizeof(g_Config.m_GfxBackend));
+			str_copy(g_Config.m_GfxBackend, vBackendInfos[NewBackend].m_pBackendName);
 			g_Config.m_GfxGLMajor = vBackendInfos[NewBackend].m_Major;
 			g_Config.m_GfxGLMinor = vBackendInfos[NewBackend].m_Minor;
 			g_Config.m_GfxGLPatch = vBackendInfos[NewBackend].m_Patch;
@@ -1706,9 +1706,9 @@ void CMenus::RenderSettingsGraphics(CUIRect MainView)
 		if(OldSelectedGPU != NewGPU)
 		{
 			if(NewGPU == 0)
-				str_copy(g_Config.m_GfxGPUName, "auto", sizeof(g_Config.m_GfxGPUName));
+				str_copy(g_Config.m_GfxGPUName, "auto");
 			else
-				str_copy(g_Config.m_GfxGPUName, GPUList.m_vGPUs[NewGPU - 1].m_aName, sizeof(g_Config.m_GfxGPUName));
+				str_copy(g_Config.m_GfxGPUName, GPUList.m_vGPUs[NewGPU - 1].m_aName);
 			CheckSettings = true;
 			s_GfxGPUChanged = NewGPU != s_OldSelectedGPU;
 		}
@@ -1876,7 +1876,7 @@ void LoadLanguageIndexfile(IStorage *pStorage, IConsole *pConsole, std::vector<C
 		if(!str_length(pLine) || pLine[0] == '#') // skip empty lines and comments
 			continue;
 
-		str_copy(aOrigin, pLine, sizeof(aOrigin));
+		str_copy(aOrigin, pLine);
 
 		pLine = LineReader.Get();
 		if(!pLine)
@@ -1893,7 +1893,7 @@ void LoadLanguageIndexfile(IStorage *pStorage, IConsole *pConsole, std::vector<C
 			(void)LineReader.Get();
 			continue;
 		}
-		str_copy(aReplacement, pLine + 3, sizeof(aReplacement));
+		str_copy(aReplacement, pLine + 3);
 
 		pLine = LineReader.Get();
 		if(!pLine)
@@ -1961,7 +1961,7 @@ void CMenus::RenderLanguageSelection(CUIRect MainView)
 
 	if(OldSelected != s_SelectedLanguage)
 	{
-		str_copy(g_Config.m_ClLanguagefile, s_vLanguages[s_SelectedLanguage].m_FileName.c_str(), sizeof(g_Config.m_ClLanguagefile));
+		str_copy(g_Config.m_ClLanguagefile, s_vLanguages[s_SelectedLanguage].m_FileName.c_str());
 		g_Localization.Load(s_vLanguages[s_SelectedLanguage].m_FileName.c_str(), Storage(), Console());
 		GameClient()->OnLanguageChange();
 	}
@@ -2663,7 +2663,7 @@ void CMenus::RenderSettingsAppearance(CUIRect MainView)
 		CTextCursor Cursor;
 		TextRender()->SetCursor(&Cursor, X, Y, RealFontSize, TEXTFLAG_RENDER);
 
-		str_copy(aBuf, Client()->PlayerName(), sizeof(aBuf));
+		str_copy(aBuf, Client()->PlayerName());
 
 		CAnimState *pIdleState = CAnimState::GetIdle();
 		constexpr int PreviewTeeCount = 4;
@@ -3169,7 +3169,7 @@ void CMenus::RenderSettingsDDNet(CUIRect MainView)
 		if(UseCurrentMap)
 			g_Config.m_ClBackgroundEntities[0] = '\0';
 		else
-			str_copy(g_Config.m_ClBackgroundEntities, CURRENT_MAP, sizeof(g_Config.m_ClBackgroundEntities));
+			str_copy(g_Config.m_ClBackgroundEntities, CURRENT_MAP);
 	}
 
 	Left.HSplitTop(20.0f, &Button, &Left);

--- a/src/game/client/components/menus_settings_assets.cpp
+++ b/src/game/client/components/menus_settings_assets.cpp
@@ -99,7 +99,7 @@ int CMenus::EntitiesScan(const char *pName, int IsDir, int DirType, void *pUser)
 			return 0;
 
 		SCustomEntities EntitiesItem;
-		str_copy(EntitiesItem.m_aName, pName, sizeof(EntitiesItem.m_aName));
+		str_copy(EntitiesItem.m_aName, pName);
 		CMenus::LoadEntities(&EntitiesItem, pUser);
 		pThis->m_vEntitiesList.push_back(EntitiesItem);
 	}
@@ -114,7 +114,7 @@ int CMenus::EntitiesScan(const char *pName, int IsDir, int DirType, void *pUser)
 				return 0;
 
 			SCustomEntities EntitiesItem;
-			str_copy(EntitiesItem.m_aName, aName, sizeof(EntitiesItem.m_aName));
+			str_copy(EntitiesItem.m_aName, aName);
 			CMenus::LoadEntities(&EntitiesItem, pUser);
 			pThis->m_vEntitiesList.push_back(EntitiesItem);
 		}
@@ -175,7 +175,7 @@ static int AssetScan(const char *pName, int IsDir, int DirType, std::vector<TNam
 			return 0;
 
 		TName AssetItem;
-		str_copy(AssetItem.m_aName, pName, sizeof(AssetItem.m_aName));
+		str_copy(AssetItem.m_aName, pName);
 		LoadAsset(&AssetItem, pAssetName, pGraphics, pUser);
 		vAssetList.push_back(AssetItem);
 	}
@@ -190,7 +190,7 @@ static int AssetScan(const char *pName, int IsDir, int DirType, std::vector<TNam
 				return 0;
 
 			TName AssetItem;
-			str_copy(AssetItem.m_aName, aName, sizeof(AssetItem.m_aName));
+			str_copy(AssetItem.m_aName, aName);
 			LoadAsset(&AssetItem, pAssetName, pGraphics, pUser);
 			vAssetList.push_back(AssetItem);
 		}
@@ -352,7 +352,7 @@ void InitAssetList(std::vector<TName> &vAssetList, const char *pAssetPath, const
 	if(vAssetList.empty())
 	{
 		TName AssetItem;
-		str_copy(AssetItem.m_aName, "default", sizeof(AssetItem.m_aName));
+		str_copy(AssetItem.m_aName, "default");
 		LoadAsset(&AssetItem, pAssetName, pGraphics, Caller);
 		vAssetList.push_back(AssetItem);
 
@@ -421,7 +421,7 @@ void CMenus::RenderSettingsCustom(CUIRect MainView)
 		if(m_vEntitiesList.empty())
 		{
 			SCustomEntities EntitiesItem;
-			str_copy(EntitiesItem.m_aName, "default", sizeof(EntitiesItem.m_aName));
+			str_copy(EntitiesItem.m_aName, "default");
 			LoadEntities(&EntitiesItem, &User);
 			m_vEntitiesList.push_back(EntitiesItem);
 
@@ -601,32 +601,32 @@ void CMenus::RenderSettingsCustom(CUIRect MainView)
 		{
 			if(s_CurCustomTab == ASSETS_TAB_ENTITIES)
 			{
-				str_copy(g_Config.m_ClAssetsEntites, GetCustomItem(s_CurCustomTab, NewSelected)->m_aName, sizeof(g_Config.m_ClAssetsEntites));
+				str_copy(g_Config.m_ClAssetsEntites, GetCustomItem(s_CurCustomTab, NewSelected)->m_aName);
 				m_pClient->m_MapImages.ChangeEntitiesPath(GetCustomItem(s_CurCustomTab, NewSelected)->m_aName);
 			}
 			else if(s_CurCustomTab == ASSETS_TAB_GAME)
 			{
-				str_copy(g_Config.m_ClAssetGame, GetCustomItem(s_CurCustomTab, NewSelected)->m_aName, sizeof(g_Config.m_ClAssetGame));
+				str_copy(g_Config.m_ClAssetGame, GetCustomItem(s_CurCustomTab, NewSelected)->m_aName);
 				GameClient()->LoadGameSkin(g_Config.m_ClAssetGame);
 			}
 			else if(s_CurCustomTab == ASSETS_TAB_EMOTICONS)
 			{
-				str_copy(g_Config.m_ClAssetEmoticons, GetCustomItem(s_CurCustomTab, NewSelected)->m_aName, sizeof(g_Config.m_ClAssetEmoticons));
+				str_copy(g_Config.m_ClAssetEmoticons, GetCustomItem(s_CurCustomTab, NewSelected)->m_aName);
 				GameClient()->LoadEmoticonsSkin(g_Config.m_ClAssetEmoticons);
 			}
 			else if(s_CurCustomTab == ASSETS_TAB_PARTICLES)
 			{
-				str_copy(g_Config.m_ClAssetParticles, GetCustomItem(s_CurCustomTab, NewSelected)->m_aName, sizeof(g_Config.m_ClAssetParticles));
+				str_copy(g_Config.m_ClAssetParticles, GetCustomItem(s_CurCustomTab, NewSelected)->m_aName);
 				GameClient()->LoadParticlesSkin(g_Config.m_ClAssetParticles);
 			}
 			else if(s_CurCustomTab == ASSETS_TAB_HUD)
 			{
-				str_copy(g_Config.m_ClAssetHud, GetCustomItem(s_CurCustomTab, NewSelected)->m_aName, sizeof(g_Config.m_ClAssetHud));
+				str_copy(g_Config.m_ClAssetHud, GetCustomItem(s_CurCustomTab, NewSelected)->m_aName);
 				GameClient()->LoadHudSkin(g_Config.m_ClAssetHud);
 			}
 			else if(s_CurCustomTab == ASSETS_TAB_EXTRAS)
 			{
-				str_copy(g_Config.m_ClAssetExtras, GetCustomItem(s_CurCustomTab, NewSelected)->m_aName, sizeof(g_Config.m_ClAssetExtras));
+				str_copy(g_Config.m_ClAssetExtras, GetCustomItem(s_CurCustomTab, NewSelected)->m_aName);
 				GameClient()->LoadExtrasSkin(g_Config.m_ClAssetExtras);
 			}
 		}
@@ -673,17 +673,17 @@ void CMenus::RenderSettingsCustom(CUIRect MainView)
 		char aBuf[IO_MAX_PATH_LENGTH];
 		char aBufFull[IO_MAX_PATH_LENGTH + 7];
 		if(s_CurCustomTab == ASSETS_TAB_ENTITIES)
-			str_copy(aBufFull, "assets/entities", sizeof(aBufFull));
+			str_copy(aBufFull, "assets/entities");
 		else if(s_CurCustomTab == ASSETS_TAB_GAME)
-			str_copy(aBufFull, "assets/game", sizeof(aBufFull));
+			str_copy(aBufFull, "assets/game");
 		else if(s_CurCustomTab == ASSETS_TAB_EMOTICONS)
-			str_copy(aBufFull, "assets/emoticons", sizeof(aBufFull));
+			str_copy(aBufFull, "assets/emoticons");
 		else if(s_CurCustomTab == ASSETS_TAB_PARTICLES)
-			str_copy(aBufFull, "assets/particles", sizeof(aBufFull));
+			str_copy(aBufFull, "assets/particles");
 		else if(s_CurCustomTab == ASSETS_TAB_HUD)
-			str_copy(aBufFull, "assets/hud", sizeof(aBufFull));
+			str_copy(aBufFull, "assets/hud");
 		else if(s_CurCustomTab == ASSETS_TAB_EXTRAS)
-			str_copy(aBufFull, "assets/extras", sizeof(aBufFull));
+			str_copy(aBufFull, "assets/extras");
 		Storage()->GetCompletePath(IStorage::TYPE_SAVE, aBufFull, aBuf, sizeof(aBuf));
 		Storage()->CreateFolder("assets", IStorage::TYPE_SAVE);
 		Storage()->CreateFolder(aBufFull, IStorage::TYPE_SAVE);

--- a/src/game/client/components/menus_settings_assets.cpp
+++ b/src/game/client/components/menus_settings_assets.cpp
@@ -396,7 +396,7 @@ void CMenus::RenderSettingsCustom(CUIRect MainView)
 
 	static int s_aPageTabs[NUMBER_OF_ASSETS_TABS] = {};
 
-	if(DoButton_MenuTab((void *)&s_aPageTabs[ASSETS_TAB_ENTITIES], Localize("Entities"), s_CurCustomTab == ASSETS_TAB_ENTITIES, &Page1Tab, 5, NULL, NULL, NULL, NULL, 4))
+	if(DoButton_MenuTab((void *)&s_aPageTabs[ASSETS_TAB_ENTITIES], Localize("Entities"), s_CurCustomTab == ASSETS_TAB_ENTITIES, &Page1Tab, CUI::CORNER_L, NULL, NULL, NULL, NULL, 4))
 		s_CurCustomTab = ASSETS_TAB_ENTITIES;
 	if(DoButton_MenuTab((void *)&s_aPageTabs[ASSETS_TAB_GAME], Localize("Game"), s_CurCustomTab == ASSETS_TAB_GAME, &Page2Tab, 0, NULL, NULL, NULL, NULL, 4))
 		s_CurCustomTab = ASSETS_TAB_GAME;
@@ -406,7 +406,7 @@ void CMenus::RenderSettingsCustom(CUIRect MainView)
 		s_CurCustomTab = ASSETS_TAB_PARTICLES;
 	if(DoButton_MenuTab((void *)&s_aPageTabs[ASSETS_TAB_HUD], Localize("HUD"), s_CurCustomTab == ASSETS_TAB_HUD, &Page5Tab, 0, NULL, NULL, NULL, NULL, 4))
 		s_CurCustomTab = ASSETS_TAB_HUD;
-	if(DoButton_MenuTab((void *)&s_aPageTabs[ASSETS_TAB_EXTRAS], Localize("Extras"), s_CurCustomTab == ASSETS_TAB_EXTRAS, &Page6Tab, 10, NULL, NULL, NULL, NULL, 4))
+	if(DoButton_MenuTab((void *)&s_aPageTabs[ASSETS_TAB_EXTRAS], Localize("Extras"), s_CurCustomTab == ASSETS_TAB_EXTRAS, &Page6Tab, CUI::CORNER_R, NULL, NULL, NULL, NULL, 4))
 		s_CurCustomTab = ASSETS_TAB_EXTRAS;
 
 	auto LoadStartTime = time_get_nanoseconds();
@@ -696,7 +696,7 @@ void CMenus::RenderSettingsCustom(CUIRect MainView)
 	TextRender()->SetCurFont(TextRender()->GetFont(TEXT_FONT_ICON_FONT));
 	TextRender()->SetRenderFlags(ETextRenderFlags::TEXT_RENDER_FLAG_ONLY_ADVANCE_WIDTH | ETextRenderFlags::TEXT_RENDER_FLAG_NO_X_BEARING | ETextRenderFlags::TEXT_RENDER_FLAG_NO_Y_BEARING | ETextRenderFlags::TEXT_RENDER_FLAG_NO_PIXEL_ALIGMENT | ETextRenderFlags::TEXT_RENDER_FLAG_NO_OVERSIZE);
 	static int s_AssetsReloadBtnID = 0;
-	if(DoButton_Menu(&s_AssetsReloadBtnID, "\xEF\x80\x9E", 0, &ReloadButton, NULL, 15, 5, 0, vec4(1.0f, 1.0f, 1.0f, 0.75f), vec4(1, 1, 1, 0.5f), 0))
+	if(DoButton_Menu(&s_AssetsReloadBtnID, "\xEF\x80\x9E", 0, &ReloadButton, nullptr, CUI::CORNER_ALL, 5, 0, vec4(1.0f, 1.0f, 1.0f, 0.75f), vec4(1, 1, 1, 0.5f), 0))
 	{
 		ClearCustomItems(s_CurCustomTab);
 	}

--- a/src/game/client/components/race_demo.cpp
+++ b/src/game/client/components/race_demo.cpp
@@ -40,7 +40,7 @@ void CRaceDemo::GetPath(char *pBuf, int Size, int Time) const
 	const char *pMap = Client()->GetCurrentMap();
 
 	char aPlayerName[MAX_NAME_LENGTH];
-	str_copy(aPlayerName, Client()->PlayerName(), sizeof(aPlayerName));
+	str_copy(aPlayerName, Client()->PlayerName());
 	str_sanitize_filename(aPlayerName);
 
 	if(Time < 0)
@@ -209,7 +209,7 @@ int CRaceDemo::RaceDemolistFetchCallback(const CFsFileInfo *pInfo, int IsDir, in
 	if(g_Config.m_ClDemoName)
 	{
 		char aPlayerName[MAX_NAME_LENGTH];
-		str_copy(aPlayerName, pParam->m_pThis->Client()->PlayerName(), sizeof(aPlayerName));
+		str_copy(aPlayerName, pParam->m_pThis->Client()->PlayerName());
 		str_sanitize_filename(aPlayerName);
 
 		if(pTEnd[0] != '_' || str_comp(pTEnd + 1, aPlayerName) != 0)

--- a/src/game/client/components/scoreboard.cpp
+++ b/src/game/client/components/scoreboard.cpp
@@ -198,7 +198,7 @@ void CScoreboard::RenderScoreboard(float x, float y, float w, int Team, const ch
 			pTitle = Localize("Game over");
 		else
 		{
-			str_copy(aBuf, Client()->GetCurrentMap(), sizeof(aBuf));
+			str_copy(aBuf, Client()->GetCurrentMap());
 			while(TextRender()->TextWidth(0, TitleFontsize, aBuf, -1, -1.0f) > TitleWidth)
 				aBuf[str_length(aBuf) - 1] = '\0';
 			if(str_comp(aBuf, Client()->GetCurrentMap()))
@@ -387,7 +387,7 @@ void CScoreboard::RenderScoreboard(float x, float y, float w, int Team, const ch
 				if(m_pClient->m_Snap.m_aTeamSize[0] > 8)
 				{
 					if(DDTeam == TEAM_SUPER)
-						str_copy(aBuf, Localize("Super"), sizeof(aBuf));
+						str_copy(aBuf, Localize("Super"));
 					else
 						str_format(aBuf, sizeof(aBuf), "%d", DDTeam);
 					TextRender()->SetCursor(&Cursor, x - 10.0f, y + Spacing + FontSize - (FontSize / 1.5f), FontSize / 1.5f, TEXTFLAG_RENDER | TEXTFLAG_STOP_AT_END);
@@ -396,7 +396,7 @@ void CScoreboard::RenderScoreboard(float x, float y, float w, int Team, const ch
 				else
 				{
 					if(DDTeam == TEAM_SUPER)
-						str_copy(aBuf, Localize("Super"), sizeof(aBuf));
+						str_copy(aBuf, Localize("Super"));
 					else
 						str_format(aBuf, sizeof(aBuf), Localize("Team %d"), DDTeam);
 					tw = TextRender()->TextWidth(0, FontSize, aBuf, -1, -1.0f);
@@ -654,21 +654,21 @@ void CScoreboard::OnRender()
 			if(m_pClient->m_Snap.m_pGameInfoObj->m_GameStateFlags & GAMESTATEFLAG_GAMEOVER && m_pClient->m_Snap.m_pGameDataObj)
 			{
 				char aText[256];
-				str_copy(aText, Localize("Draw!"), sizeof(aText));
+				str_copy(aText, Localize("Draw!"));
 
 				if(m_pClient->m_Snap.m_pGameDataObj->m_TeamscoreRed > m_pClient->m_Snap.m_pGameDataObj->m_TeamscoreBlue)
 				{
 					if(pRedClanName)
 						str_format(aText, sizeof(aText), Localize("%s wins!"), pRedClanName);
 					else
-						str_copy(aText, Localize("Red team wins!"), sizeof(aText));
+						str_copy(aText, Localize("Red team wins!"));
 				}
 				else if(m_pClient->m_Snap.m_pGameDataObj->m_TeamscoreBlue > m_pClient->m_Snap.m_pGameDataObj->m_TeamscoreRed)
 				{
 					if(pBlueClanName)
 						str_format(aText, sizeof(aText), Localize("%s wins!"), pBlueClanName);
 					else
-						str_copy(aText, Localize("Blue team wins!"), sizeof(aText));
+						str_copy(aText, Localize("Blue team wins!"));
 				}
 
 				float TextWidth = TextRender()->TextWidth(0, 86.0f, aText, -1, -1.0f);

--- a/src/game/client/components/skins.cpp
+++ b/src/game/client/components/skins.cpp
@@ -62,7 +62,7 @@ int CSkins::SkinScan(const char *pName, int IsDir, int DirType, void *pUser)
 		return 0;
 
 	char aNameWithoutPng[128];
-	str_copy(aNameWithoutPng, pName, sizeof(aNameWithoutPng));
+	str_copy(aNameWithoutPng, pName);
 	aNameWithoutPng[str_length(aNameWithoutPng) - 4] = 0;
 
 	// Don't add duplicate skins (one from user's config directory, other from
@@ -288,7 +288,7 @@ int CSkins::LoadSkin(const char *pName, CImageInfo &Info)
 	Graphics()->FreePNG(&Info);
 
 	// set skin data
-	str_copy(Skin.m_aName, pName, sizeof(Skin.m_aName));
+	str_copy(Skin.m_aName, pName);
 	if(g_Config.m_Debug)
 	{
 		str_format(aBuf, sizeof(aBuf), "load skin %s", Skin.m_aName);
@@ -312,7 +312,7 @@ void CSkins::OnInit()
 		pTimeInfo = localtime(&RawTime);
 		if(pTimeInfo->tm_mon == 11 && pTimeInfo->tm_mday >= 24 && pTimeInfo->tm_mday <= 26)
 		{ // Christmas
-			str_copy(m_aEventSkinPrefix, "santa", sizeof(m_aEventSkinPrefix));
+			str_copy(m_aEventSkinPrefix, "santa");
 		}
 	}
 
@@ -356,7 +356,7 @@ void CSkins::Refresh(TSkinLoadedCBFunc &&SkinLoadedFunc)
 		Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "gameclient", "failed to load skins. folder='skins/'");
 		CSkin DummySkin;
 		DummySkin.m_IsVanilla = true;
-		str_copy(DummySkin.m_aName, "dummy", sizeof(DummySkin.m_aName));
+		str_copy(DummySkin.m_aName, "dummy");
 		DummySkin.m_BloodColor = ColorRGBA(1.0f, 1.0f, 1.0f);
 		m_vSkins.push_back(DummySkin);
 	}
@@ -404,7 +404,7 @@ int CSkins::FindImpl(const char *pName)
 {
 	CSkin Needle;
 	mem_zero(&Needle, sizeof(Needle));
-	str_copy(Needle.m_aName, pName, sizeof(Needle.m_aName));
+	str_copy(Needle.m_aName, pName);
 	auto Range = std::equal_range(m_vSkins.begin(), m_vSkins.end(), Needle);
 	if(std::distance(Range.first, Range.second) == 1)
 		return Range.first - m_vSkins.begin();
@@ -420,7 +420,7 @@ int CSkins::FindImpl(const char *pName)
 
 	CDownloadSkin DownloadNeedle;
 	mem_zero(&DownloadNeedle, sizeof(DownloadNeedle));
-	str_copy(DownloadNeedle.m_aName, pName, sizeof(DownloadNeedle.m_aName));
+	str_copy(DownloadNeedle.m_aName, pName);
 	const auto &[RangeBegin, RangeEnd] = std::equal_range(m_vDownloadSkins.begin(), m_vDownloadSkins.end(), DownloadNeedle);
 	if(std::distance(RangeBegin, RangeEnd) == 1)
 	{
@@ -440,7 +440,7 @@ int CSkins::FindImpl(const char *pName)
 	}
 
 	CDownloadSkin Skin;
-	str_copy(Skin.m_aName, pName, sizeof(Skin.m_aName));
+	str_copy(Skin.m_aName, pName);
 
 	char aUrl[IO_MAX_PATH_LENGTH];
 	char aEscapedName[256];

--- a/src/game/client/components/voting.cpp
+++ b/src/game/client/components/voting.cpp
@@ -75,7 +75,7 @@ void CVoting::CallvoteOption(int OptionID, const char *pReason, bool ForceVote)
 			if(ForceVote)
 			{
 				char aBuf[128];
-				str_copy(aBuf, "force_vote option \"", sizeof(aBuf));
+				str_copy(aBuf, "force_vote option \"");
 				char *pDst = aBuf + str_length(aBuf);
 				str_escape(&pDst, pOption->m_aDescription, aBuf + sizeof(aBuf));
 				str_append(aBuf, "\" \"", sizeof(aBuf));
@@ -102,7 +102,7 @@ void CVoting::RemovevoteOption(int OptionID)
 		if(OptionID == 0)
 		{
 			char aBuf[128];
-			str_copy(aBuf, "remove_vote \"", sizeof(aBuf));
+			str_copy(aBuf, "remove_vote \"");
 			char *pDst = aBuf + str_length(aBuf);
 			str_escape(&pDst, pOption->m_aDescription, aBuf + sizeof(aBuf));
 			str_append(aBuf, "\"", sizeof(aBuf));
@@ -118,7 +118,7 @@ void CVoting::RemovevoteOption(int OptionID)
 void CVoting::AddvoteOption(const char *pDescription, const char *pCommand)
 {
 	char aBuf[128];
-	str_copy(aBuf, "add_vote \"", sizeof(aBuf));
+	str_copy(aBuf, "add_vote \"");
 	char *pDst = aBuf + str_length(aBuf);
 	str_escape(&pDst, pDescription, aBuf + sizeof(aBuf));
 	str_append(aBuf, "\" \"", sizeof(aBuf));
@@ -169,7 +169,7 @@ void CVoting::AddOption(const char *pDescription)
 	if(!m_pFirst)
 		m_pFirst = pOption;
 
-	str_copy(pOption->m_aDescription, pDescription, sizeof(pOption->m_aDescription));
+	str_copy(pOption->m_aDescription, pDescription);
 	++m_NumVoteOptions;
 }
 
@@ -208,8 +208,8 @@ void CVoting::OnMessage(int MsgType, void *pRawMsg)
 		OnReset();
 		if(pMsg->m_Timeout)
 		{
-			str_copy(m_aDescription, pMsg->m_pDescription, sizeof(m_aDescription));
-			str_copy(m_aReason, pMsg->m_pReason, sizeof(m_aReason));
+			str_copy(m_aDescription, pMsg->m_pDescription);
+			str_copy(m_aReason, pMsg->m_pReason);
 			m_Closetime = time() + time_freq() * pMsg->m_Timeout;
 
 			if(Client()->RconAuthed())

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1211,7 +1211,7 @@ void CGameClient::OnNewSnapshot()
 
 					// prepare the info
 					if(!m_GameInfo.m_AllowXSkins && (pClient->m_aSkinName[0] == 'x' && pClient->m_aSkinName[1] == '_'))
-						str_copy(pClient->m_aSkinName, "default", 64);
+						str_copy(pClient->m_aSkinName, "default");
 
 					pClient->m_SkinInfo.m_ColorBody = color_cast<ColorRGBA>(ColorHSLA(pClient->m_ColorBody).UnclampLighting());
 					pClient->m_SkinInfo.m_ColorFeet = color_cast<ColorRGBA>(ColorHSLA(pClient->m_ColorFeet).UnclampLighting());

--- a/src/game/client/lineinput.cpp
+++ b/src/game/client/lineinput.cpp
@@ -18,7 +18,7 @@ void CLineInput::Clear()
 
 void CLineInput::Set(const char *pString)
 {
-	str_copy(m_aStr, pString, sizeof(m_aStr));
+	str_copy(m_aStr, pString);
 	str_utf8_stats(m_aStr, MAX_SIZE, MAX_CHARS, &m_Len, &m_NumChars);
 	m_CursorPos = m_Len;
 }
@@ -59,7 +59,7 @@ void CLineInput::SetRange(const char *pString, int Begin, int End)
 
 void CLineInput::Editing(const char *pString, int Cursor)
 {
-	str_copy(m_aDisplayStr, m_aStr, sizeof(m_aDisplayStr));
+	str_copy(m_aDisplayStr, m_aStr);
 	char aEditingText[IInput::INPUT_TEXT_SIZE + 2];
 	str_format(aEditingText, sizeof(aEditingText), "[%s]", pString);
 	int NewTextLen = str_length(aEditingText);

--- a/src/game/client/render_map.cpp
+++ b/src/game/client/render_map.cpp
@@ -512,7 +512,7 @@ void CRenderTools::RenderSpeedupOverlay(CSpeedupTile *pSpeedup, int w, int h, fl
 				Graphics()->SetColor(255.0f, 255.0f, 255.0f, Alpha);
 
 				SelectSprite(SPRITE_SPEEDUP_ARROW);
-				Graphics()->QuadsSetRotation(pSpeedup[c].m_Angle * (3.14159265f / 180.0f));
+				Graphics()->QuadsSetRotation(pSpeedup[c].m_Angle * (pi / 180.0f));
 				DrawSprite(mx * Scale + 16, my * Scale + 16, 35.0f);
 
 				Graphics()->QuadsEnd();

--- a/src/game/client/ui_ex.cpp
+++ b/src/game/client/ui_ex.cpp
@@ -547,12 +547,12 @@ bool CUIEx::DoEditBox(const void *pID, const CUIRect *pRect, char *pStr, unsigne
 	if(UI()->LastActiveItem() == pID && Input()->GetIMEEditingTextLength() > -1)
 	{
 		int EditingTextCursor = Input()->GetEditingCursor();
-		str_copy(aDispEditingText, pDisplayStr, sizeof(aDispEditingText));
+		str_copy(aDispEditingText, pDisplayStr);
 		char aEditingText[IInput::INPUT_TEXT_SIZE + 2];
 		if(Hidden)
 		{
 			// Do not show editing text in password field
-			str_copy(aEditingText, "[*]", sizeof(aEditingText));
+			str_copy(aEditingText, "[*]");
 			EditingTextCursor = 1;
 		}
 		else

--- a/src/game/variables.h
+++ b/src/game/variables.h
@@ -4,6 +4,13 @@
 #define GAME_VARIABLES_H
 #undef GAME_VARIABLES_H // this file will be included several times
 
+#ifndef MACRO_CONFIG_INT
+#error "The config macros must be defined"
+#define MACRO_CONFIG_INT(Name, ScriptName, Def, Min, Max, Save, Desc) ;
+#define MACRO_CONFIG_COL(Name, ScriptName, Def, Save, Desc) ;
+#define MACRO_CONFIG_STR(Name, ScriptName, Len, Def, Save, Desc) ;
+#endif
+
 // client
 MACRO_CONFIG_INT(ClPredict, cl_predict, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Predict client movements")
 MACRO_CONFIG_INT(ClPredictDummy, cl_predict_dummy, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Predict dummy movements")


### PR DESCRIPTION
The commits are self-descriptional. The only note I need to say is that I didn't port whole codebase. It takes significant time to check `str_copy()` call arguments and doing all 500 cases in row would cost me eyes. The remaining parts are game/editor, game/server and tools.

I hope for a fast acceptance because the massive change can not be wrong: I'm removing the `dest size` argument from calls and if the dest size can not be figured out automatically then the code just won't compile.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
