### PR TITLE
Make UI inputs more secure

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -2393,6 +2393,8 @@ void CMenus::SetActive(bool Active)
 	{
 		ms_ColorPicker.m_Active = false;
 		Input()->SetIMEState(Active);
+		UI()->SetHotItem(nullptr);
+		UI()->SetActiveItem(nullptr);
 	}
 	m_MenuActive = Active;
 	if(!m_MenuActive)

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -155,6 +155,11 @@ void CUI::Update(float MouseX, float MouseY, float MouseWorldX, float MouseWorld
 	if(m_pActiveItem)
 		m_pHotItem = m_pActiveItem;
 	m_pBecomingHotItem = 0;
+	if(!Enabled())
+	{
+		m_pHotItem = nullptr;
+		m_pActiveItem = nullptr;
+	}
 }
 
 bool CUI::MouseInside(const CUIRect *pRect) const


### PR DESCRIPTION
fixes #3560 finally :) what a dream xD

This in addition also fixes an input bug, if you hold a mouse button on an input and then open f1 it no longer presses that button.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [x] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
