### PR TITLE
Move message copy inside `SendPackMsgTranslate`

### DIFF
--- a/datasrc/datatypes.py
+++ b/datasrc/datatypes.py
@@ -288,7 +288,7 @@ class NetMessage(NetObject):
 		extra = []
 		extra += ["\tint MsgID() const { return %s; }" % self.enum_name]
 		extra += ["\t"]
-		extra += ["\tbool Pack(CMsgPacker *pPacker)"]
+		extra += ["\tbool Pack(CMsgPacker *pPacker) const"]
 		extra += ["\t{"]
 		#extra += ["\t\tmsg_pack_start(%s, flags);"%self.enum_name]
 		for v in self.variables:

--- a/datasrc/seven/datatypes.py
+++ b/datasrc/seven/datatypes.py
@@ -268,7 +268,7 @@ class NetMessage(NetObject):
 		extra += ["\tusing is_sixup = char;"]
 		extra += ["\tint MsgID() const { return %s; }" % self.enum_name]
 		extra += ["\t"]
-		extra += ["\tbool Pack(CMsgPacker *pPacker)"]
+		extra += ["\tbool Pack(CMsgPacker *pPacker) const"]
 		extra += ["\t{"]
 		#extra += ["\t\tmsg_pack_start(%s, flags);"%self.enum_name]
 		for v in self.variables:

--- a/src/engine/server.h
+++ b/src/engine/server.h
@@ -64,29 +64,24 @@ public:
 	virtual int SendMsg(CMsgPacker *pMsg, int Flags, int ClientID) = 0;
 
 	template<class T, typename std::enable_if<!protocol7::is_sixup<T>::value, int>::type = 0>
-	inline int SendPackMsg(T *pMsg, int Flags, int ClientID)
+	inline int SendPackMsg(const T *pMsg, int Flags, int ClientID)
 	{
 		int Result = 0;
-		T tmp;
 		if(ClientID == -1)
 		{
 			for(int i = 0; i < MaxClients(); i++)
 				if(ClientIngame(i))
-				{
-					mem_copy(&tmp, pMsg, sizeof(T));
-					Result = SendPackMsgTranslate(&tmp, Flags, i);
-				}
+					Result = SendPackMsgTranslate(pMsg, Flags, i);
 		}
 		else
 		{
-			mem_copy(&tmp, pMsg, sizeof(T));
-			Result = SendPackMsgTranslate(&tmp, Flags, ClientID);
+			Result = SendPackMsgTranslate(pMsg, Flags, ClientID);
 		}
 		return Result;
 	}
 
 	template<class T, typename std::enable_if<protocol7::is_sixup<T>::value, int>::type = 1>
-	inline int SendPackMsg(T *pMsg, int Flags, int ClientID)
+	inline int SendPackMsg(const T *pMsg, int Flags, int ClientID)
 	{
 		int Result = 0;
 		if(ClientID == -1)
@@ -102,50 +97,57 @@ public:
 	}
 
 	template<class T>
-	int SendPackMsgTranslate(T *pMsg, int Flags, int ClientID)
+	int SendPackMsgTranslate(const T *pMsg, int Flags, int ClientID)
 	{
 		return SendPackMsgOne(pMsg, Flags, ClientID);
 	}
 
-	int SendPackMsgTranslate(CNetMsg_Sv_Emoticon *pMsg, int Flags, int ClientID)
+	int SendPackMsgTranslate(const CNetMsg_Sv_Emoticon *pMsg, int Flags, int ClientID)
 	{
-		return Translate(pMsg->m_ClientID, ClientID) && SendPackMsgOne(pMsg, Flags, ClientID);
+		CNetMsg_Sv_Emoticon MsgCopy;
+		mem_copy(&MsgCopy, pMsg, sizeof(MsgCopy));
+		return Translate(MsgCopy.m_ClientID, ClientID) && SendPackMsgOne(&MsgCopy, Flags, ClientID);
 	}
 
-	int SendPackMsgTranslate(CNetMsg_Sv_Chat *pMsg, int Flags, int ClientID)
+	int SendPackMsgTranslate(const CNetMsg_Sv_Chat *pMsg, int Flags, int ClientID)
 	{
+		CNetMsg_Sv_Chat MsgCopy;
+		mem_copy(&MsgCopy, pMsg, sizeof(MsgCopy));
+
 		char aBuf[1000];
-		if(pMsg->m_ClientID >= 0 && !Translate(pMsg->m_ClientID, ClientID))
+		if(MsgCopy.m_ClientID >= 0 && !Translate(MsgCopy.m_ClientID, ClientID))
 		{
-			str_format(aBuf, sizeof(aBuf), "%s: %s", ClientName(pMsg->m_ClientID), pMsg->m_pMessage);
-			pMsg->m_pMessage = aBuf;
-			pMsg->m_ClientID = VANILLA_MAX_CLIENTS - 1;
+			str_format(aBuf, sizeof(aBuf), "%s: %s", ClientName(MsgCopy.m_ClientID), MsgCopy.m_pMessage);
+			MsgCopy.m_pMessage = aBuf;
+			MsgCopy.m_ClientID = VANILLA_MAX_CLIENTS - 1;
 		}
 
 		if(IsSixup(ClientID))
 		{
 			protocol7::CNetMsg_Sv_Chat Msg7;
-			Msg7.m_ClientID = pMsg->m_ClientID;
-			Msg7.m_pMessage = pMsg->m_pMessage;
-			Msg7.m_Mode = pMsg->m_Team > 0 ? protocol7::CHAT_TEAM : protocol7::CHAT_ALL;
+			Msg7.m_ClientID = MsgCopy.m_ClientID;
+			Msg7.m_pMessage = MsgCopy.m_pMessage;
+			Msg7.m_Mode = MsgCopy.m_Team > 0 ? protocol7::CHAT_TEAM : protocol7::CHAT_ALL;
 			Msg7.m_TargetID = -1;
 			return SendPackMsgOne(&Msg7, Flags, ClientID);
 		}
 
-		return SendPackMsgOne(pMsg, Flags, ClientID);
+		return SendPackMsgOne(&MsgCopy, Flags, ClientID);
 	}
 
-	int SendPackMsgTranslate(CNetMsg_Sv_KillMsg *pMsg, int Flags, int ClientID)
+	int SendPackMsgTranslate(const CNetMsg_Sv_KillMsg *pMsg, int Flags, int ClientID)
 	{
-		if(!Translate(pMsg->m_Victim, ClientID))
+		CNetMsg_Sv_KillMsg MsgCopy;
+		mem_copy(&MsgCopy, pMsg, sizeof(MsgCopy));
+		if(!Translate(MsgCopy.m_Victim, ClientID))
 			return 0;
-		if(!Translate(pMsg->m_Killer, ClientID))
-			pMsg->m_Killer = pMsg->m_Victim;
-		return SendPackMsgOne(pMsg, Flags, ClientID);
+		if(!Translate(MsgCopy.m_Killer, ClientID))
+			MsgCopy.m_Killer = MsgCopy.m_Victim;
+		return SendPackMsgOne(&MsgCopy, Flags, ClientID);
 	}
 
 	template<class T>
-	int SendPackMsgOne(T *pMsg, int Flags, int ClientID)
+	int SendPackMsgOne(const T *pMsg, int Flags, int ClientID)
 	{
 		dbg_assert(ClientID != -1, "SendPackMsgOne called with -1");
 		CMsgPacker Packer(pMsg->MsgID(), false, protocol7::is_sixup<T>::value);

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -835,9 +835,6 @@ static inline bool RepackMsg(const CMsgPacker *pMsg, CPacker &Packer, bool Sixup
 int CServer::SendMsg(CMsgPacker *pMsg, int Flags, int ClientID)
 {
 	CNetChunk Packet;
-	if(!pMsg)
-		return -1;
-
 	mem_zero(&Packet, sizeof(CNetChunk));
 	if(Flags & MSGFLAG_VITAL)
 		Packet.m_Flags |= NETSENDFLAG_VITAL;


### PR DESCRIPTION
Fix clang warning: Address of stack memory associated with local variable 'aBuf' is still referred to by the stack variable 'tmp' upon returning to the caller.  This will be a dangling reference [clang-analyzer-core.StackAddressEscape]

Mark the input parameters as const pointers and mark the protocol message `Pack` methods as const.

And remove a null check that only serves to hide programmer errors.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
