### PR TITLE
Minor refactoring and a fix for a typo

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -3904,22 +3904,28 @@ const char *CClient::DemoPlayer_Play(const char *pFilename, int StorageType)
 		return "error loading demo";
 
 	// load map
-	int Crc = m_DemoPlayer.GetMapInfo()->m_Crc;
-	SHA256_DIGEST Sha = m_DemoPlayer.GetMapInfo()->m_Sha256;
-	const char *pError = LoadMapSearch(m_DemoPlayer.Info()->m_Header.m_aMapName, Sha != SHA256_ZEROED ? &Sha : nullptr, Crc);
+	const CMapInfo *pMapInfo = m_DemoPlayer.GetMapInfo();
+	int Crc = pMapInfo->m_Crc;
+	SHA256_DIGEST Sha = pMapInfo->m_Sha256;
+	const char *pError = LoadMapSearch(pMapInfo->m_aName, Sha != SHA256_ZEROED ? &Sha : nullptr, Crc);
 	if(pError)
 	{
 		if(!m_DemoPlayer.ExtractMap(Storage()))
 			return pError;
 
 		Sha = m_DemoPlayer.GetMapInfo()->m_Sha256;
-		pError = LoadMapSearch(m_DemoPlayer.Info()->m_Header.m_aMapName, &Sha, Crc);
+		pError = LoadMapSearch(pMapInfo->m_aName, &Sha, Crc);
 		if(pError)
 		{
 			DisconnectWithReason(pError);
 			return pError;
 		}
 	}
+
+	// setup current info
+	str_copy(m_CurrentServerInfo.m_aMap, pMapInfo->m_aName);
+	m_CurrentServerInfo.m_MapCrc = pMapInfo->m_Crc;
+	m_CurrentServerInfo.m_MapSize = pMapInfo->m_Size;
 
 	GameClient()->OnConnected();
 

--- a/src/engine/shared/demo.h
+++ b/src/engine/shared/demo.h
@@ -151,7 +151,7 @@ public:
 
 	const CPlaybackInfo *Info() const { return &m_Info; }
 	bool IsPlaying() const override { return m_File != nullptr; }
-	const CMapInfo *GetMapInfo() { return &m_MapInfo; }
+	const CMapInfo *GetMapInfo() const { return &m_MapInfo; }
 };
 
 class CDemoEditor : public IDemoEditor, public CDemoPlayer::IListener

--- a/src/game/client/components/items.cpp
+++ b/src/game/client/components/items.cpp
@@ -334,7 +334,7 @@ void CItems::OnRender()
 				continue;
 
 			CProjectileData Data = pProj->GetData();
-			RenderProjectile(&Data, pProj->ID());
+			RenderProjectile(&Data, pProj->GetID());
 		}
 		for(CEntity *pEnt = GameClient()->m_PredictedWorld.FindFirst(CGameWorld::ENTTYPE_LASER); pEnt; pEnt = pEnt->NextEntity())
 		{
@@ -352,7 +352,7 @@ void CItems::OnRender()
 
 			if(pPickup->InDDNetTile())
 			{
-				if(auto *pPrev = (CPickup *)GameClient()->m_PrevPredictedWorld.GetEntity(pPickup->ID(), CGameWorld::ENTTYPE_PICKUP))
+				if(auto *pPrev = (CPickup *)GameClient()->m_PrevPredictedWorld.GetEntity(pPickup->GetID(), CGameWorld::ENTTYPE_PICKUP))
 				{
 					CNetObj_Pickup Data, Prev;
 					pPickup->FillInfo(&Data);

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -1492,7 +1492,7 @@ int CMenus::Render()
 				else if(Client()->LoadingStateDetail() == IClient::LOADING_STATE_DETAIL_GETTING_READY)
 				{
 					pTitle = Localize("Connected");
-					pExtraText = Localize("Sending intial client info");
+					pExtraText = Localize("Sending initial client info");
 				}
 			}
 		}

--- a/src/game/client/prediction/entity.h
+++ b/src/game/client/prediction/entity.h
@@ -48,6 +48,7 @@ public:
 	class CCollision *Collision() { return GameWorld()->Collision(); }
 	CEntity *TypeNext() { return m_pNextTypeEntity; }
 	CEntity *TypePrev() { return m_pPrevTypeEntity; }
+	const vec2 &GetPos() const { return m_Pos; }
 	float GetProximityRadius() const { return m_ProximityRadius; }
 
 	void Destroy() { delete this; }

--- a/src/game/client/prediction/entity.h
+++ b/src/game/client/prediction/entity.h
@@ -35,6 +35,8 @@ protected:
 	int m_ObjType;
 
 public:
+	int GetID() const { return m_ID; }
+
 	CEntity(CGameWorld *pGameWorld, int Objtype, vec2 Pos = vec2(0, 0), int ProximityRadius = 0);
 	virtual ~CEntity();
 
@@ -64,7 +66,6 @@ public:
 	CEntity *m_pParent;
 	CEntity *m_pChild;
 	CEntity *NextEntity() { return m_pNextTypeEntity; }
-	int ID() { return m_ID; }
 	void Keep()
 	{
 		m_SnapTicks = 0;


### PR DESCRIPTION
The minor refactoring:
- https://github.com/ddnet/ddnet/commit/1f264a042ded7585c26dabac04e4823ee5b51b52 After DDNet tuning [re-introduced](8ef1f35f89d538372a346f4fbc9bedd67ff73195) as the default tuning for all maps and gametypes, I had to find another solution to use vanilla tuning at least for the mod I work on.
The mod maps are started with a prefix so I check the map name on demo playback to disable DDNet tuning for the mod demos.
I found that the map info was not set on demo loaded but it was easy to fix.
I hope you'll agree that this is the correct behavior and this might be useful for some other client features too (maybe we'll need this to show the map name during playback).
- prediction/entity API changes — I needed those to reuse server-side code for client-side (mod specific) prediction. I think it'll be useful and I would like to push it now to have less conflicts later

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
