### PR TITLE
Fix game freezing up on duplicate snapshot

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -681,6 +681,7 @@ void CClient::OnEnterGame(bool Dummy)
 	m_aReceivedSnapshots[Dummy] = 0;
 	m_aSnapshotParts[Dummy] = 0;
 	m_aPredTick[Dummy] = 0;
+	m_aAckGameTick[Dummy] = -1;
 	m_aCurrentRecvTick[Dummy] = 0;
 	m_aCurGameTick[Dummy] = 0;
 	m_aPrevGameTick[Dummy] = 0;
@@ -1979,7 +1980,8 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket, int Conn, bool Dummy)
 			if(Unpacker.Error() || NumParts < 1 || NumParts > CSnapshot::MAX_PARTS || Part < 0 || Part >= NumParts || PartSize < 0 || PartSize > MAX_SNAPSHOT_PACKSIZE)
 				return;
 
-			if(GameTick >= m_aCurrentRecvTick[Conn])
+			// Check m_aAckGameTick to see if we already got a snapshot for that tick
+			if(GameTick >= m_aCurrentRecvTick[Conn] && GameTick > m_aAckGameTick[Conn])
 			{
 				if(GameTick != m_aCurrentRecvTick[Conn])
 				{
@@ -2124,8 +2126,6 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket, int Conn, bool Dummy)
 
 					// apply snapshot, cycle pointers
 					m_aReceivedSnapshots[Conn]++;
-
-					m_aCurrentRecvTick[Conn] = GameTick;
 
 					// we got two snapshots until we see us self as connected
 					if(m_aReceivedSnapshots[Conn] == 2)


### PR DESCRIPTION
If a duplicate snapshot is received (for the same tick), we add both to the SnapshotStorage and end up with the same snapshot as both Cur and Prev. This results in GameInfraTick returning "inf" and results in "NaN" downstream in a few places, getting the CollLine logic stuck.

Some debug info (tcpdump, gdb, perf): https://gist.github.com/Fireball-Teeworlds/ad0016d2551a2e4d4cb5691023493856

Apparently this doesn't really happen in the wild, unless you have a buggy network stack. In which case it happens frequently enough to pinpoint the issue :D

 (fixes #5657)

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [X] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
