### PR TITLE
Bundle libpng16.16.dylib for macOS

### DIFF
--- a/cmake/FindPNG.cmake
+++ b/cmake/FindPNG.cmake
@@ -11,7 +11,7 @@ endif()
 if(NOT PNG_FOUND)
   set_extra_dirs_lib(PNG png)
   find_library(PNG_LIBRARY
-    NAMES png16 libpng16 libpng16-16 png16-16
+    NAMES libpng16.16 png16.16 libpng16-16 png16-16 libpng16 png16
     HINTS ${HINTS_PNG_LIBDIR} ${PC_PNG_LIBDIR} ${PC_PNG_LIBRARY_DIRS}
     PATHS ${PATHS_PNG_LIBDIR}
     ${CROSSCOMPILING_NO_CMAKE_SYSTEM_PATH}
@@ -36,11 +36,14 @@ if(NOT PNG_FOUND)
   endif()
 endif()
 
+set(PNG_COPY_FILES)
 if(PNG_FOUND)
   is_bundled(PNG_BUNDLED "${PNG_LIBRARY}")
-  if(PNG_BUNDLED AND TARGET_OS STREQUAL "windows")
-    set(PNG_COPY_FILES "${EXTRA_PNG_LIBDIR}/libpng16-16.dll")
-  else()
-    set(PNG_COPY_FILES)
+  if(PNG_BUNDLED)
+    if(TARGET_OS STREQUAL "windows")
+      set(PNG_COPY_FILES "${EXTRA_PNG_LIBDIR}/libpng16-16.dll")
+    elseif(TARGET_OS STREQUAL "mac")
+      set(PNG_COPY_FILES "${EXTRA_PNG_LIBDIR}/libpng16.16.dylib")
+    endif()
   endif()
 endif()


### PR DESCRIPTION
```
dyld[41859]: Library not loaded: @rpath/libpng16.16.dylib
  Referenced from: /Users/deen/Library/Application Support/Steam/steamapps/common/DDraceNetwork/ddnet/DDNet
  Reason: tried: '/Users/deen/Library/Application Support/Steam/steamapps/common/DDraceNetwork/ddnet/../Frameworks/libpng16.16.dylib' (no such file), '/Users/deen/Library/Application Support/Steam/steamapps/common/DDraceNetwork/ddnet/../Frameworks/libpng16.16.dylib' (no such file), '/usr/local/lib/libpng16.16.dylib' (mach-o file, but is an incompatible architecture (have 'arm64', need 'x86_64')), '/usr/lib/libpng16.16.dylib' (no such file)
```
Fixes the nightly build on macOS so it starts again.
<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
