### PR TITLE
Replace mem family function with typesafe functions (fixes #5228)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -337,6 +337,7 @@ if(NOT MSVC AND NOT HAIKU)
   add_cxx_compiler_flag_if_supported(OUR_FLAGS_OWN -Wformat=2) # Warn about format strings.
   add_c_compiler_flag_if_supported(OUR_FLAGS_DEP -Wno-implicit-function-declaration)
   add_cxx_compiler_flag_if_supported(OUR_FLAGS_OWN -Wno-nullability-completeness) # Mac OS build on github
+  add_cxx_compiler_flag_if_supported(OUR_FLAGS_OWN -Wclass-memaccess)
   add_cxx_compiler_flag_if_supported(OUR_FLAGS_OWN -Wduplicated-cond)
   add_cxx_compiler_flag_if_supported(OUR_FLAGS_OWN -Wduplicated-branches)
   add_cxx_compiler_flag_if_supported(OUR_FLAGS_OWN -Wlogical-op)

--- a/datasrc/network.py
+++ b/datasrc/network.py
@@ -1,7 +1,10 @@
 # pylint: skip-file
 # See https://github.com/ddnet/ddnet/issues/3507
 
-from datatypes import Enum, Flags, NetArray, NetBool, NetEvent, NetIntAny, NetIntRange, NetMessage, NetMessageEx, NetObject, NetObjectEx, NetString, NetStringHalfStrict, NetStringStrict, NetTick
+from datatypes import Enum, Flags, NetArray, NetBool, NetEvent, NetIntAny, \
+	NetIntRange, NetMessage, NetMessageEx, NetObject, NetObjectEx, NetString, \
+	NetStringHalfStrict, NetStringStrict, NetTick, NetOperatorAssignment, \
+	NetOperatorEquality, NetOperatorInequality
 
 Emotes = ["NORMAL", "PAIN", "HAPPY", "SURPRISE", "ANGRY", "BLINK"]
 PlayerFlags = ["PLAYING", "IN_MENU", "CHATTING", "SCOREBOARD", "AIM"]
@@ -91,241 +94,276 @@ Flags = [
 	Flags("PROJECTILEFLAG", ProjectileFlags),
 ]
 
-Objects = [
+PlayerInput = NetObject("PlayerInput", [
+	NetIntAny("m_Direction"),
+	NetIntAny("m_TargetX"),
+	NetIntAny("m_TargetY"),
 
-	NetObject("PlayerInput", [
-		NetIntAny("m_Direction"),
-		NetIntAny("m_TargetX"),
-		NetIntAny("m_TargetY"),
+	NetIntAny("m_Jump"),
+	NetIntAny("m_Fire"),
+	NetIntAny("m_Hook"),
 
-		NetIntAny("m_Jump"),
-		NetIntAny("m_Fire"),
-		NetIntAny("m_Hook"),
+	NetIntRange("m_PlayerFlags", 0, 256),
 
-		NetIntRange("m_PlayerFlags", 0, 256),
+	NetIntAny("m_WantedWeapon"),
+	NetIntAny("m_NextWeapon"),
+	NetIntAny("m_PrevWeapon"),
+])
 
-		NetIntAny("m_WantedWeapon"),
-		NetIntAny("m_NextWeapon"),
-		NetIntAny("m_PrevWeapon"),
-	]),
+Projectile = NetObject("Projectile", [
+	NetIntAny("m_X"),
+	NetIntAny("m_Y"),
+	NetIntAny("m_VelX"),
+	NetIntAny("m_VelY"),
 
-	NetObject("Projectile", [
-		NetIntAny("m_X"),
-		NetIntAny("m_Y"),
-		NetIntAny("m_VelX"),
-		NetIntAny("m_VelY"),
+	NetIntRange("m_Type", 0, 'NUM_WEAPONS-1'),
+	NetTick("m_StartTick"),
+])
 
-		NetIntRange("m_Type", 0, 'NUM_WEAPONS-1'),
-		NetTick("m_StartTick"),
-	]),
+Laser = NetObject("Laser", [
+	NetIntAny("m_X"),
+	NetIntAny("m_Y"),
+	NetIntAny("m_FromX"),
+	NetIntAny("m_FromY"),
 
-	NetObject("Laser", [
-		NetIntAny("m_X"),
-		NetIntAny("m_Y"),
-		NetIntAny("m_FromX"),
-		NetIntAny("m_FromY"),
+	NetTick("m_StartTick"),
+])
 
-		NetTick("m_StartTick"),
-	]),
+Pickup = NetObject("Pickup", [
+	NetIntAny("m_X"),
+	NetIntAny("m_Y"),
 
-	NetObject("Pickup", [
-		NetIntAny("m_X"),
-		NetIntAny("m_Y"),
+	NetIntRange("m_Type", 0, 'max_int'),
+	NetIntRange("m_Subtype", 0, 'max_int'),
+])
 
-		NetIntRange("m_Type", 0, 'max_int'),
-		NetIntRange("m_Subtype", 0, 'max_int'),
-	]),
+Flag = NetObject("Flag", [
+	NetIntAny("m_X"),
+	NetIntAny("m_Y"),
 
-	NetObject("Flag", [
-		NetIntAny("m_X"),
-		NetIntAny("m_Y"),
+	NetIntRange("m_Team", 'TEAM_RED', 'TEAM_BLUE')
+])
 
-		NetIntRange("m_Team", 'TEAM_RED', 'TEAM_BLUE')
-	]),
+GameInfo = NetObject("GameInfo", [
+	NetIntRange("m_GameFlags", 0, 256),
+	NetIntRange("m_GameStateFlags", 0, 256),
+	NetTick("m_RoundStartTick"),
+	NetIntRange("m_WarmupTimer", 'min_int', 'max_int'),
 
-	NetObject("GameInfo", [
-		NetIntRange("m_GameFlags", 0, 256),
-		NetIntRange("m_GameStateFlags", 0, 256),
-		NetTick("m_RoundStartTick"),
-		NetIntRange("m_WarmupTimer", 'min_int', 'max_int'),
+	NetIntRange("m_ScoreLimit", 0, 'max_int'),
+	NetIntRange("m_TimeLimit", 0, 'max_int'),
 
-		NetIntRange("m_ScoreLimit", 0, 'max_int'),
-		NetIntRange("m_TimeLimit", 0, 'max_int'),
+	NetIntRange("m_RoundNum", 0, 'max_int'),
+	NetIntRange("m_RoundCurrent", 0, 'max_int'),
+])
 
-		NetIntRange("m_RoundNum", 0, 'max_int'),
-		NetIntRange("m_RoundCurrent", 0, 'max_int'),
-	]),
+GameData = NetObject("GameData", [
+	NetIntAny("m_TeamscoreRed"),
+	NetIntAny("m_TeamscoreBlue"),
 
-	NetObject("GameData", [
-		NetIntAny("m_TeamscoreRed"),
-		NetIntAny("m_TeamscoreBlue"),
+	NetIntRange("m_FlagCarrierRed", 'FLAG_MISSING', 'MAX_CLIENTS-1'),
+	NetIntRange("m_FlagCarrierBlue", 'FLAG_MISSING', 'MAX_CLIENTS-1'),
+])
 
-		NetIntRange("m_FlagCarrierRed", 'FLAG_MISSING', 'MAX_CLIENTS-1'),
-		NetIntRange("m_FlagCarrierBlue", 'FLAG_MISSING', 'MAX_CLIENTS-1'),
-	]),
+CharacterCore = NetObject("CharacterCore", [
+	NetIntAny("m_Tick"),
+	NetIntAny("m_X"),
+	NetIntAny("m_Y"),
+	NetIntAny("m_VelX"),
+	NetIntAny("m_VelY"),
 
-	NetObject("CharacterCore", [
-		NetIntAny("m_Tick"),
-		NetIntAny("m_X"),
-		NetIntAny("m_Y"),
-		NetIntAny("m_VelX"),
-		NetIntAny("m_VelY"),
+	NetIntAny("m_Angle"),
+	NetIntRange("m_Direction", -1, 1),
 
-		NetIntAny("m_Angle"),
-		NetIntRange("m_Direction", -1, 1),
+	NetIntRange("m_Jumped", 0, 3),
+	NetIntRange("m_HookedPlayer", -1, 'MAX_CLIENTS-1'),
+	NetIntRange("m_HookState", -1, 5),
+	NetTick("m_HookTick"),
 
-		NetIntRange("m_Jumped", 0, 3),
-		NetIntRange("m_HookedPlayer", -1, 'MAX_CLIENTS-1'),
-		NetIntRange("m_HookState", -1, 5),
-		NetTick("m_HookTick"),
+	NetIntAny("m_HookX"),
+	NetIntAny("m_HookY"),
+	NetIntAny("m_HookDx"),
+	NetIntAny("m_HookDy"),
+])
 
-		NetIntAny("m_HookX"),
-		NetIntAny("m_HookY"),
-		NetIntAny("m_HookDx"),
-		NetIntAny("m_HookDy"),
-	]),
+CharacterCharacterCore = NetObject("Character:CharacterCore", [
+	NetIntRange("m_PlayerFlags", 0, 256),
+	NetIntRange("m_Health", 0, 10),
+	NetIntRange("m_Armor", 0, 10),
+	NetIntRange("m_AmmoCount", 0, 10),
+	NetIntRange("m_Weapon", 0, 'NUM_WEAPONS-1'),
+	NetIntRange("m_Emote", 0, len(Emotes)),
+	NetIntRange("m_AttackTick", 0, 'max_int'),
 
-	NetObject("Character:CharacterCore", [
-		NetIntRange("m_PlayerFlags", 0, 256),
-		NetIntRange("m_Health", 0, 10),
-		NetIntRange("m_Armor", 0, 10),
-		NetIntRange("m_AmmoCount", 0, 10),
-		NetIntRange("m_Weapon", 0, 'NUM_WEAPONS-1'),
-		NetIntRange("m_Emote", 0, len(Emotes)),
-		NetIntRange("m_AttackTick", 0, 'max_int'),
-	]),
+	NetOperatorEquality(),
+	NetOperatorInequality(),
+])
 
-	NetObject("PlayerInfo", [
-		NetIntRange("m_Local", 0, 1),
-		NetIntRange("m_ClientID", 0, 'MAX_CLIENTS-1'),
-		NetIntRange("m_Team", 'TEAM_SPECTATORS', 'TEAM_BLUE'),
+PlayerInfo = NetObject("PlayerInfo", [
+	NetIntRange("m_Local", 0, 1),
+	NetIntRange("m_ClientID", 0, 'MAX_CLIENTS-1'),
+	NetIntRange("m_Team", 'TEAM_SPECTATORS', 'TEAM_BLUE'),
 
-		NetIntAny("m_Score"),
-		NetIntAny("m_Latency"),
-	]),
+	NetIntAny("m_Score"),
+	NetIntAny("m_Latency"),
+])
 
-	NetObject("ClientInfo", [
-		# 4*4 = 16 characters
-		NetIntAny("m_Name0"), NetIntAny("m_Name1"), NetIntAny("m_Name2"),
-		NetIntAny("m_Name3"),
+ClientInfo = NetObject("ClientInfo", [
+	# 4*4 = 16 characters
+	NetIntAny("m_Name0"), NetIntAny("m_Name1"), NetIntAny("m_Name2"),
+	NetIntAny("m_Name3"),
 
-		# 4*3 = 12 characters
-		NetIntAny("m_Clan0"), NetIntAny("m_Clan1"), NetIntAny("m_Clan2"),
+	# 4*3 = 12 characters
+	NetIntAny("m_Clan0"), NetIntAny("m_Clan1"), NetIntAny("m_Clan2"),
 
-		NetIntAny("m_Country"),
+	NetIntAny("m_Country"),
 
-		# 4*6 = 24 characters
-		NetIntAny("m_Skin0"), NetIntAny("m_Skin1"), NetIntAny("m_Skin2"),
-		NetIntAny("m_Skin3"), NetIntAny("m_Skin4"), NetIntAny("m_Skin5"),
+	# 4*6 = 24 characters
+	NetIntAny("m_Skin0"), NetIntAny("m_Skin1"), NetIntAny("m_Skin2"),
+	NetIntAny("m_Skin3"), NetIntAny("m_Skin4"), NetIntAny("m_Skin5"),
 
-		NetIntRange("m_UseCustomColor", 0, 1),
+	NetIntRange("m_UseCustomColor", 0, 1),
 
-		NetIntAny("m_ColorBody"),
-		NetIntAny("m_ColorFeet"),
-	]),
+	NetIntAny("m_ColorBody"),
+	NetIntAny("m_ColorFeet"),
+])
 
-	NetObject("SpectatorInfo", [
-		NetIntRange("m_SpectatorID", 'SPEC_FREEVIEW', 'MAX_CLIENTS-1'),
-		NetIntAny("m_X"),
-		NetIntAny("m_Y"),
-	]),
+SpectatorInfo = NetObject("SpectatorInfo", [
+	NetIntRange("m_SpectatorID", 'SPEC_FREEVIEW', 'MAX_CLIENTS-1'),
+	NetIntAny("m_X"),
+	NetIntAny("m_Y"),
+])
 
-	NetObjectEx("MyOwnObject", "my-own-object@heinrich5991.de", [
-		NetIntAny("m_Test"),
-	]),
+MyOwnObject = NetObjectEx("MyOwnObject", "my-own-object@heinrich5991.de", [
+	NetIntAny("m_Test"),
+])
 
-	NetObjectEx("DDNetCharacter", "character@netobj.ddnet.tw", [
-		NetIntAny("m_Flags", 0),
-		NetTick("m_FreezeEnd", 0),
-		NetIntRange("m_Jumps", -1, 255, 2),
-		NetIntAny("m_TeleCheckpoint", -1),
-		NetIntRange("m_StrongWeakID", 0, 'MAX_CLIENTS-1', 0),
+DDNetCharacter = NetObjectEx("DDNetCharacter", "character@netobj.ddnet.tw", [
+	NetIntAny("m_Flags", 0),
+	NetTick("m_FreezeEnd", 0),
+	NetIntRange("m_Jumps", -1, 255, 2),
+	NetIntAny("m_TeleCheckpoint", -1),
+	NetIntRange("m_StrongWeakID", 0, 'MAX_CLIENTS-1', 0),
 
-		# New data fields for jump display, freeze bar and ninja bar
-		# Default values indicate that these values should not be used
-		NetIntRange("m_JumpedTotal", -1, 255, -1),
-		NetTick("m_NinjaActivationTick", -1),
-		NetTick("m_FreezeStart", -1),
-		# New data fields for improved target accuracy
-		NetIntAny("m_TargetX", 0),
-		NetIntAny("m_TargetY", 0),
-	], validate_size=False),
+	# New data fields for jump display, freeze bar and ninja bar
+	# Default values indicate that these values should not be used
+	NetIntRange("m_JumpedTotal", -1, 255, -1),
+	NetTick("m_NinjaActivationTick", -1),
+	NetTick("m_FreezeStart", -1),
+	# New data fields for improved target accuracy
+	NetIntAny("m_TargetX", 0),
+	NetIntAny("m_TargetY", 0),
+], validate_size=False)
 
-	NetObjectEx("DDNetPlayer", "player@netobj.ddnet.tw", [
-		NetIntAny("m_Flags"),
-		NetIntRange("m_AuthLevel", "AUTHED_NO", "AUTHED_ADMIN"),
-	]),
+DDNetPlayer = NetObjectEx("DDNetPlayer", "player@netobj.ddnet.tw", [
+	NetIntAny("m_Flags"),
+	NetIntRange("m_AuthLevel", "AUTHED_NO", "AUTHED_ADMIN"),
+])
 
-	NetObjectEx("GameInfoEx", "gameinfo@netobj.ddnet.tw", [
-		NetIntAny("m_Flags", 0),
-		NetIntAny("m_Version", 0),
-		NetIntAny("m_Flags2", 0),
-	], validate_size=False),
+GameInfoEx = NetObjectEx("GameInfoEx", "gameinfo@netobj.ddnet.tw", [
+	NetIntAny("m_Flags", 0),
+	NetIntAny("m_Version", 0),
+	NetIntAny("m_Flags2", 0),
+], validate_size=False)
 
-	# The code assumes that this has the same in-memory representation as
-	# the Projectile net object.
-	NetObjectEx("DDNetProjectile", "projectile@netobj.ddnet.tw", [
-		NetIntAny("m_X"),
-		NetIntAny("m_Y"),
-		NetIntAny("m_Angle"),
-		NetIntAny("m_Data"),
-		NetIntRange("m_Type", 0, 'NUM_WEAPONS-1'),
-		NetTick("m_StartTick"),
-	]),
+# The code assumes that this has the same in-memory representation as
+# the Projectile net object.
+DDNetProjectile = NetObjectEx("DDNetProjectile", "projectile@netobj.ddnet.tw", [
+	NetIntAny("m_X"),
+	NetIntAny("m_Y"),
+	NetIntAny("m_Angle"),
+	NetIntAny("m_Data"),
+	NetIntRange("m_Type", 0, 'NUM_WEAPONS-1'),
+	NetTick("m_StartTick"),
 
-	## Events
+	NetOperatorAssignment(Projectile, True),
+])
 
-	NetEvent("Common", [
-		NetIntAny("m_X"),
-		NetIntAny("m_Y"),
-	]),
+## Events
 
+Common = NetEvent("Common", [
+	NetIntAny("m_X"),
+	NetIntAny("m_Y"),
+])
 
-	NetEvent("Explosion:Common", []),
-	NetEvent("Spawn:Common", []),
-	NetEvent("HammerHit:Common", []),
+ExplosionCommon = NetEvent("Explosion:Common", [])
+SpawnCommon = NetEvent("Spawn:Common", [])
+HammerHitCommon = NetEvent("HammerHit:Common", [])
 
-	NetEvent("Death:Common", [
-		NetIntRange("m_ClientID", 0, 'MAX_CLIENTS-1'),
-	]),
+DeathCommon = NetEvent("Death:Common", [
+	NetIntRange("m_ClientID", 0, 'MAX_CLIENTS-1'),
+])
 
-	NetEvent("SoundGlobal:Common", [ #TODO 0.7: remove me
-		NetIntRange("m_SoundID", 0, 'NUM_SOUNDS-1'),
-	]),
+SoundGlobalCommon = NetEvent("SoundGlobal:Common", [ #TODO 0.7: remove me
+	NetIntRange("m_SoundID", 0, 'NUM_SOUNDS-1'),
+])
 
-	NetEvent("SoundWorld:Common", [
-		NetIntRange("m_SoundID", 0, 'NUM_SOUNDS-1'),
-	]),
+SoundWorldCommon = NetEvent("SoundWorld:Common", [
+	NetIntRange("m_SoundID", 0, 'NUM_SOUNDS-1'),
+])
 
-	NetEvent("DamageInd:Common", [
-		NetIntAny("m_Angle"),
-	]),
+DamageIndCommon = NetEvent("DamageInd:Common", [
+	NetIntAny("m_Angle"),
+])
 
-	NetObjectEx("MyOwnEvent", "my-own-event@heinrich5991.de", [
-		NetIntAny("m_Test"),
-	]),
+MyOwnEvent = NetObjectEx("MyOwnEvent", "my-own-event@heinrich5991.de", [
+	NetIntAny("m_Test"),
+])
 
-	NetObjectEx("SpecChar", "spec-char@netobj.ddnet.tw", [
-		NetIntAny("m_X"),
-		NetIntAny("m_Y"),
-	]),
+SpecChar = NetObjectEx("SpecChar", "spec-char@netobj.ddnet.tw", [
+	NetIntAny("m_X"),
+	NetIntAny("m_Y"),
+])
 
-	# Switch state for a player team.
-	NetObjectEx("SwitchState", "switch-state@netobj.ddnet.tw", [
-		NetIntAny("m_HighestSwitchNumber", 0),
-		# 256 switches / 32 bits = 8 int32
-		NetArray(NetIntAny("m_aStatus", 0), 8),
-		# send the endtick of up to 4 timed switchers
-		NetArray(NetIntAny("m_aSwitchNumbers", 0), 4),
-		NetArray(NetIntAny("m_aEndTicks", 0), 4),
-	], validate_size=False),
+# Switch state for a player team.
+SwitchState = NetObjectEx("SwitchState", "switch-state@netobj.ddnet.tw", [
+	NetIntAny("m_HighestSwitchNumber", 0),
+	# 256 switches / 32 bits = 8 int32
+	NetArray(NetIntAny("m_aStatus", 0), 8),
+	# send the endtick of up to 4 timed switchers
+	NetArray(NetIntAny("m_aSwitchNumbers", 0), 4),
+	NetArray(NetIntAny("m_aEndTicks", 0), 4),
+], validate_size=False)
 
-	# Switch info for map items
-	NetObjectEx("EntityEx", "entity-ex@netobj.ddnet.tw", [
-		NetIntAny("m_SwitchNumber"),
-		NetIntAny("m_Layer"),
-		NetIntAny("m_EntityClass"),
-	]),
+# Switch info for map items
+EntityEx = NetObjectEx("EntityEx", "entity-ex@netobj.ddnet.tw", [
+	NetIntAny("m_SwitchNumber"),
+	NetIntAny("m_Layer"),
+	NetIntAny("m_EntityClass"),
+])
+
+Objects = [PlayerInput,
+		   Projectile,
+		   Laser,
+		   Pickup,
+		   Flag,
+		   GameInfo,
+		   GameData,
+		   CharacterCore,
+		   CharacterCharacterCore,
+		   PlayerInfo,
+		   ClientInfo,
+		   SpectatorInfo,
+		   MyOwnObject,
+		   DDNetCharacter,
+		   DDNetPlayer,
+		   GameInfoEx,
+		   DDNetProjectile,
+
+## Events
+
+		   Common,
+		   ExplosionCommon,
+		   SpawnCommon,
+		   HammerHitCommon,
+		   DeathCommon,
+		   SoundGlobalCommon,
+		   SoundWorldCommon,
+		   DamageIndCommon,
+		   MyOwnEvent,
+		   SpecChar,
+		   SwitchState,
+		   EntityEx,
 ]
 
 Messages = [

--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -198,21 +198,6 @@ void dbg_msg(const char *sys, const char *fmt, ...)
 
 /* */
 
-void mem_copy(void *dest, const void *source, unsigned size)
-{
-	memcpy(dest, source, size);
-}
-
-void mem_move(void *dest, const void *source, unsigned size)
-{
-	memmove(dest, source, size);
-}
-
-void mem_zero(void *block, unsigned size)
-{
-	memset(block, 0, size);
-}
-
 IOHANDLE io_open_impl(const char *filename, int flags)
 {
 	dbg_assert(flags == (IOFLAG_READ | IOFLAG_SKIP_BOM) || flags == IOFLAG_READ || flags == IOFLAG_WRITE || flags == IOFLAG_APPEND, "flags must be read, read+skipbom, write or append");
@@ -3295,25 +3280,6 @@ void str_escape(char **dst, const char *src, const char *end)
 	**dst = 0;
 }
 
-int mem_comp(const void *a, const void *b, int size)
-{
-	return memcmp(a, b, size);
-}
-
-int mem_has_null(const void *block, unsigned size)
-{
-	const unsigned char *bytes = (const unsigned char *)block;
-	unsigned i;
-	for(i = 0; i < size; i++)
-	{
-		if(bytes[i] == 0)
-		{
-			return 1;
-		}
-	}
-	return 0;
-}
-
 void net_stats(NETSTATS *stats_inout)
 {
 	*stats_inout = network_stats;
@@ -4164,6 +4130,20 @@ void set_exception_handler_log_file(const char *log_file_path)
 #endif
 }
 #endif
+}
+
+int mem_has_null(const void *block, unsigned size)
+{
+	const unsigned char *bytes = (const unsigned char *)block;
+	unsigned i;
+	for(i = 0; i < size; i++)
+	{
+		if(bytes[i] == 0)
+		{
+			return 1;
+		}
+	}
+	return 0;
 }
 
 std::chrono::nanoseconds time_get_nanoseconds()

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -27,7 +27,9 @@
 #endif
 
 #include <chrono>
+#include <cstring>
 #include <functional>
+#include <type_traits>
 
 extern "C" {
 
@@ -103,79 +105,6 @@ dbg_break();
  */
 void dbg_msg(const char *sys, const char *fmt, ...)
 	GNUC_ATTRIBUTE((format(printf, 2, 3)));
-
-/**
- * @defgroup Memory
- * Memory management utilities.
- */
-
-/**
- * Copies a a memory block.
- *
- * @ingroup Memory
- *
- * @param dest Destination.
- * @param source Source to copy.
- * @param size Size of the block to copy.
- *
- * @remark This functions DOES NOT handle cases where the source and destination is overlapping.
- *
- * @see mem_move
- */
-void mem_copy(void *dest, const void *source, unsigned size);
-
-/**
- * Copies a a memory block.
- *
- * @ingroup Memory
- *
- * @param dest Destination.
- * @param source Source to copy.
- * @param size Size of the block to copy.
- *
- * @remark This functions handles the cases where the source and destination is overlapping.
- *
- * @see mem_copy
- */
-void mem_move(void *dest, const void *source, unsigned size);
-
-/**
- * Sets a complete memory block to 0.
- *
- * @ingroup Memory
- *
- * @param block Pointer to the block to zero out.
- * @param size Size of the block.
- */
-void mem_zero(void *block, unsigned size);
-
-/**
- * Compares two blocks of memory
- *
- * @ingroup Memory
- *
- * @param a First block of data
- * @param b Second block of data
- * @param size Size of the data to compare
- *
- * @return < 0 - Block a is less than block b.
- * @return 0 - Block a is equal to block b.
- * @return > 0 - Block a is greater than block b.
- */
-int mem_comp(const void *a, const void *b, int size);
-
-/**
- * Checks whether a block of memory contains null bytes.
- *
- * @ingroup Memory
- *
- * @param block Pointer to the block to check for nulls.
- * @param size Size of the block.
- *
- * @return 1 - The block has a null byte.
- * @return 0 - The block does not have a null byte.
- */
-int mem_has_null(const void *block, unsigned size);
 
 /**
  * @defgroup File-IO
@@ -2518,10 +2447,114 @@ public:
  * @remark Guarantees that dst string will contain zero-termination.
  */
 template<int N>
-void str_copy(char (&dst)[N], const char *src)
+inline void str_copy(char (&dst)[N], const char *src)
 {
 	str_copy(dst, src, N);
 }
+
+/**
+ * @defgroup Memory
+ * Memory management utilities.
+ */
+
+#if defined(__GNUC__) || defined(__clang__)
+#define RESTRICT __restrict__
+#else
+#define RESTRICT // no-op
+#endif
+
+/**
+ * Copies a a memory block.
+ *
+ * @ingroup Memory
+ *
+ * @param dest Destination.
+ * @param source Source to copy.
+ * @param size Size of the block to copy.
+ *
+ * @remark This functions DOES NOT handle cases where the source and destination is overlapping.
+ *
+ * @see mem_move
+ */
+template<typename T1, typename T2>
+inline void mem_copy(T1 *RESTRICT dest, const T2 *RESTRICT source, unsigned size)
+{
+	static_assert(std::is_same<T1, void>::value || std::is_trivial<T1>::value || std::is_standard_layout<T1>::value);
+	static_assert(std::is_same<T2, void>::value || std::is_trivial<T2>::value || std::is_standard_layout<T2>::value);
+	memcpy(dest, source, size);
+}
+
+/**
+ * Copies a a memory block.
+ *
+ * @ingroup Memory
+ *
+ * @param dest Destination.
+ * @param source Source to copy.
+ * @param size Size of the block to copy.
+ *
+ * @remark This functions handles the cases where the source and destination is overlapping.
+ *
+ * @see mem_copy
+ */
+template<typename T1, typename T2>
+inline void mem_move(T1 *dest, const T2 *source, unsigned size)
+{
+	static_assert(std::is_same<T1, void>::value || std::is_trivial<T1>::value || std::is_standard_layout<T1>::value);
+	static_assert(std::is_same<T2, void>::value || std::is_trivial<T2>::value || std::is_standard_layout<T2>::value);
+	memmove(dest, source, size);
+}
+
+/**
+ * Sets a complete memory block to 0.
+ *
+ * @ingroup Memory
+ *
+ * @param block Pointer to the block to zero out.
+ * @param size Size of the block.
+ */
+template<typename T>
+inline void mem_zero(T *block, unsigned size)
+{
+	static_assert(std::is_same<T, void>::value || std::is_trivial<T>::value || std::is_standard_layout<T>::value);
+
+	memset(block, 0, size);
+}
+
+/**
+ * Compares two blocks of memory
+ *
+ * @ingroup Memory
+ *
+ * @param a First block of data
+ * @param b Second block of data
+ * @param size Size of the data to compare
+ *
+ * @return < 0 - Block a is less than block b.
+ * @return 0 - Block a is equal to block b.
+ * @return > 0 - Block a is greater than block b.
+ */
+template<typename T1, typename T2>
+inline int mem_comp(const T1 *a, const T2 *b, int size)
+{
+	static_assert(std::is_same<T1, void>::value || std::is_trivial<T1>::value || std::is_standard_layout<T1>::value);
+	static_assert(std::is_same<T2, void>::value || std::is_trivial<T2>::value || std::is_standard_layout<T2>::value);
+
+	return memcmp(a, b, size);
+}
+
+/**
+ * Checks whether a block of memory contains null bytes.
+ *
+ * @ingroup Memory
+ *
+ * @param block Pointer to the block to check for nulls.
+ * @param size Size of the block.
+ *
+ * @return 1 - The block has a null byte.
+ * @return 0 - The block does not have a null byte.
+ */
+int mem_has_null(const void *block, unsigned size);
 
 template<>
 struct std::hash<NETADDR>

--- a/src/engine/client/backend/vulkan/backend_vulkan.cpp
+++ b/src/engine/client/backend/vulkan/backend_vulkan.cpp
@@ -800,6 +800,17 @@ class CCommandProcessorFragment_Vulkan : public CCommandProcessorFragment_GLBase
 		vec2 m_Offset;
 		float m_Rotation;
 		float m_Padding;
+
+		SUniformQuadPushGBufferObject &operator=(const SQuadRenderInfo &QuadInfo)
+		{
+			static_assert(sizeof(SUniformQuadPushGBufferObject) == sizeof(SQuadRenderInfo));
+			m_VertColor = QuadInfo.m_Color;
+			m_Offset = QuadInfo.m_Offsets;
+			m_Rotation = QuadInfo.m_Rotation;
+			m_Padding = QuadInfo.m_Padding;
+
+			return *this;
+		}
 	};
 
 	struct SUniformQuadPushGPos
@@ -6853,7 +6864,7 @@ public:
 		{
 			SUniformQuadPushGPos PushConstantVertex;
 
-			mem_copy(&PushConstantVertex.m_BOPush, &pCommand->m_pQuadInfo[0], sizeof(PushConstantVertex.m_BOPush));
+			PushConstantVertex.m_BOPush = pCommand->m_pQuadInfo[0];
 
 			mem_copy(PushConstantVertex.m_aPos, m.data(), sizeof(PushConstantVertex.m_aPos));
 			PushConstantVertex.m_QuadOffset = pCommand->m_QuadOffset;

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -376,7 +376,7 @@ CClient::CClient() :
 	m_CurrentServerPingInfoType = -1;
 	m_CurrentServerPingBasicToken = -1;
 	m_CurrentServerPingToken = -1;
-	mem_zero(&m_CurrentServerPingUuid, sizeof(m_CurrentServerPingUuid));
+	m_CurrentServerPingUuid = CUuid();
 	m_CurrentServerCurrentPingTime = -1;
 	m_CurrentServerNextPingTime = -1;
 
@@ -384,7 +384,7 @@ CClient::CClient() :
 	m_aCurrentInput[1] = 0;
 	m_LastDummy = false;
 
-	mem_zero(&m_aInputs, sizeof(m_aInputs));
+	new(m_aInputs) std::remove_pointer<decltype(m_aInputs)>::type{};
 
 	m_State = IClient::STATE_OFFLINE;
 	m_StateStartTime = time_get();
@@ -411,7 +411,7 @@ CClient::CClient() :
 	m_BenchmarkFile = 0;
 	m_BenchmarkStopTime = 0;
 
-	mem_zero(&m_Checksum, sizeof(m_Checksum));
+	m_Checksum = CChecksum();
 }
 
 // ----- send functions -----
@@ -434,7 +434,7 @@ static inline bool RepackMsg(const CMsgPacker *pMsg, CPacker &Packer)
 
 int CClient::SendMsg(int Conn, CMsgPacker *pMsg, int Flags)
 {
-	CNetChunk Packet;
+	CNetChunk Packet{};
 
 	if(State() == IClient::STATE_OFFLINE)
 		return 0;
@@ -444,7 +444,6 @@ int CClient::SendMsg(int Conn, CMsgPacker *pMsg, int Flags)
 	if(RepackMsg(pMsg, Pack))
 		return 0;
 
-	mem_zero(&Packet, sizeof(CNetChunk));
 	Packet.m_ClientID = 0;
 	Packet.m_pData = Pack.Data();
 	Packet.m_DataSize = Pack.Size();
@@ -768,8 +767,7 @@ void CClient::Connect(const char *pAddress, const char *pPassword)
 	ServerInfoRequest();
 
 	int NumConnectAddrs = 0;
-	NETADDR aConnectAddrs[MAX_SERVER_ADDRESSES];
-	mem_zero(aConnectAddrs, sizeof(aConnectAddrs));
+	NETADDR aConnectAddrs[MAX_SERVER_ADDRESSES]{};
 	const char *pNextAddr = pAddress;
 	char aBuffer[128];
 	while((pNextAddr = str_next_token(pNextAddr, ",", aBuffer, sizeof(aBuffer))))
@@ -856,7 +854,7 @@ void CClient::DisconnectWithReason(const char *pReason)
 	m_CurrentServerPingInfoType = -1;
 	m_CurrentServerPingBasicToken = -1;
 	m_CurrentServerPingToken = -1;
-	mem_zero(&m_CurrentServerPingUuid, sizeof(m_CurrentServerPingUuid));
+	m_CurrentServerPingUuid = CUuid();
 	m_CurrentServerCurrentPingTime = -1;
 	m_CurrentServerNextPingTime = -1;
 
@@ -878,7 +876,7 @@ void CClient::DisconnectWithReason(const char *pReason)
 	m_MapDetailsPresent = false;
 
 	// clear the current server info
-	mem_zero(&m_CurrentServerInfo, sizeof(m_CurrentServerInfo));
+	m_CurrentServerInfo = CServerInfo();
 
 	// clear snapshots
 	m_aapSnapshots[g_Config.m_ClDummy][SNAP_CURRENT] = 0;
@@ -972,7 +970,7 @@ void CClient::GetServerInfo(CServerInfo *pServerInfo) const
 
 void CClient::ServerInfoRequest()
 {
-	mem_zero(&m_CurrentServerInfo, sizeof(m_CurrentServerInfo));
+	m_CurrentServerInfo = CServerInfo();
 	m_CurrentServerInfoRequestTime = 0;
 }
 
@@ -3095,7 +3093,7 @@ void CClient::Run()
 		}
 		else
 		{
-			mem_zero(&BindAddr, sizeof(BindAddr));
+			BindAddr = NETADDR();
 			BindAddr.type = NETTYPE_ALL;
 		}
 		for(unsigned int i = 0; i < std::size(m_aNetClient); i++)
@@ -4181,7 +4179,7 @@ int CClient::HandleChecksum(int Conn, CUuid Uuid, CUnpacker *pUnpacker)
 
 	if(Start <= (int)sizeof(m_Checksum.m_aBytes))
 	{
-		mem_zero(&m_Checksum.m_Data.m_Config, sizeof(m_Checksum.m_Data.m_Config));
+		m_Checksum.m_Data.m_Config = CConfig();
 #define CHECKSUM_RECORD(Flags) (((Flags)&CFGFLAG_CLIENT) == 0 || ((Flags)&CFGFLAG_INSENSITIVE) != 0)
 #define MACRO_CONFIG_INT(Name, ScriptName, Def, Min, Max, Flags, Desc) \
 	if(CHECKSUM_RECORD(Flags)) \
@@ -4520,9 +4518,8 @@ void CClient::RegisterCommands()
 
 static CClient *CreateClient()
 {
-	CClient *pClient = static_cast<CClient *>(malloc(sizeof(*pClient)));
-	mem_zero(pClient, sizeof(CClient));
-	return new(pClient) CClient;
+	CClient *pClient = new CClient();
+	return pClient;
 }
 
 void CClient::HandleConnectAddress(const NETADDR *pAddr)
@@ -4678,8 +4675,7 @@ int main(int argc, const char **argv)
 		if(RegisterFail)
 		{
 			delete pKernel;
-			pClient->~CClient();
-			free(pClient);
+			delete pClient;
 			return -1;
 		}
 	}
@@ -4763,8 +4759,7 @@ int main(int argc, const char **argv)
 
 	bool Restarting = pClient->State() == CClient::STATE_RESTARTING;
 
-	pClient->~CClient();
-	free(pClient);
+	delete pClient;
 
 	NotificationsUninit();
 	secure_random_uninit();

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -964,7 +964,7 @@ int CClient::GetCurrentRaceTime()
 
 void CClient::GetServerInfo(CServerInfo *pServerInfo) const
 {
-	mem_copy(pServerInfo, &m_CurrentServerInfo, sizeof(m_CurrentServerInfo));
+	*pServerInfo = m_CurrentServerInfo;
 
 	if(m_DemoPlayer.IsPlaying() && g_Config.m_ClDemoAssumeRace)
 		str_copy(pServerInfo->m_aGameType, "DDraceNetwork");
@@ -1552,7 +1552,7 @@ void CClient::ProcessServerInfo(int RawType, NETADDR *pFrom, const void *pData, 
 			// us.
 			if(SavedType >= m_CurrentServerInfo.m_Type)
 			{
-				mem_copy(&m_CurrentServerInfo, &Info, sizeof(m_CurrentServerInfo));
+				m_CurrentServerInfo = Info;
 				m_CurrentServerInfo.m_NumAddresses = 1;
 				m_CurrentServerInfo.m_aAddresses[0] = ServerAddress();
 				m_CurrentServerInfoRequestTime = -1;

--- a/src/engine/client/discord.cpp
+++ b/src/engine/client/discord.cpp
@@ -36,7 +36,7 @@ public:
 	bool Init(FDiscordCreate pfnDiscordCreate)
 	{
 		m_pCore = 0;
-		mem_zero(&m_ActivityEvents, sizeof(m_ActivityEvents));
+		m_ActivityEvents = IDiscordActivityEvents();
 		m_pActivityManager = 0;
 
 		DiscordCreateParams Params;
@@ -66,8 +66,7 @@ public:
 	}
 	void SetGameInfo(NETADDR ServerAddr, const char *pMapName) override
 	{
-		DiscordActivity Activity;
-		mem_zero(&Activity, sizeof(DiscordActivity));
+		DiscordActivity Activity{};
 		str_copy(Activity.assets.large_image, "ddnet_logo", sizeof(Activity.assets.large_image));
 		str_copy(Activity.assets.large_text, "DDNet logo", sizeof(Activity.assets.large_text));
 		Activity.timestamps.start = time_timestamp();

--- a/src/engine/client/favorites.cpp
+++ b/src/engine/client/favorites.cpp
@@ -155,8 +155,7 @@ void CFavorites::Add(const NETADDR *pAddrs, int NumAddrs)
 		}
 	}
 	// Add the new entry.
-	CEntry NewEntry;
-	mem_zero(&NewEntry, sizeof(NewEntry));
+	CEntry NewEntry{};
 	NewEntry.m_NumAddrs = std::min(NumAddrs, (int)std::size(NewEntry.m_aAddrs));
 	for(int i = 0; i < NewEntry.m_NumAddrs; i++)
 	{

--- a/src/engine/client/friends.cpp
+++ b/src/engine/client/friends.cpp
@@ -139,7 +139,7 @@ void CFriends::RemoveFriend(int Index)
 {
 	if(Index >= 0 && Index < m_NumFriends)
 	{
-		mem_move(&m_aFriends[Index], &m_aFriends[Index + 1], sizeof(CFriendInfo) * (m_NumFriends - (Index + 1)));
+		std::copy(&m_aFriends[Index + 1], &m_aFriends[m_NumFriends], &m_aFriends[Index]);
 		--m_NumFriends;
 	}
 }

--- a/src/engine/client/friends.cpp
+++ b/src/engine/client/friends.cpp
@@ -11,7 +11,7 @@
 
 CFriends::CFriends()
 {
-	mem_zero(m_aFriends, sizeof(m_aFriends));
+	new(m_aFriends) std::remove_pointer<decltype(m_aFriends)>::type{};
 	m_NumFriends = 0;
 	m_Foes = false;
 }

--- a/src/engine/client/ghost.cpp
+++ b/src/engine/client/ghost.cpp
@@ -38,8 +38,7 @@ int CGhostRecorder::Start(const char *pFilename, const char *pMap, SHA256_DIGEST
 	}
 
 	// write header
-	CGhostHeader Header;
-	mem_zero(&Header, sizeof(Header));
+	CGhostHeader Header{};
 	mem_copy(Header.m_aMarker, gs_aHeaderMarker, sizeof(Header.m_aMarker));
 	Header.m_Version = gs_CurVersion;
 	str_copy(Header.m_aOwner, pName);
@@ -189,7 +188,7 @@ int CGhostLoader::Load(const char *pFilename, const char *pMap, SHA256_DIGEST Ma
 	}
 
 	// read the header
-	mem_zero(&m_Header, sizeof(m_Header));
+	m_Header = CGhostHeader();
 	io_read(m_File, &m_Header, sizeof(CGhostHeader));
 	if(mem_comp(m_Header.m_aMarker, gs_aHeaderMarker, sizeof(gs_aHeaderMarker)) != 0)
 	{
@@ -363,8 +362,7 @@ void CGhostLoader::Close()
 
 bool CGhostLoader::GetGhostInfo(const char *pFilename, CGhostInfo *pGhostInfo, const char *pMap, SHA256_DIGEST MapSha256, unsigned MapCrc)
 {
-	CGhostHeader Header;
-	mem_zero(&Header, sizeof(Header));
+	CGhostHeader Header{};
 
 	IOHANDLE File = m_pStorage->OpenFile(pFilename, IOFLAG_READ, IStorage::TYPE_SAVE);
 	if(!File)

--- a/src/engine/client/ghost.h
+++ b/src/engine/client/ghost.h
@@ -33,8 +33,7 @@ struct CGhostHeader
 
 	CGhostInfo ToGhostInfo() const
 	{
-		CGhostInfo Result;
-		mem_zero(&Result, sizeof(Result));
+		CGhostInfo Result{};
 		str_copy(Result.m_aOwner, m_aOwner);
 		str_copy(Result.m_aMap, m_aMap);
 		Result.m_NumTicks = GetTicks();

--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -803,8 +803,7 @@ void CGraphics_Threaded::KickCommandBuffer()
 bool CGraphics_Threaded::ScreenshotDirect()
 {
 	// add swap command
-	CImageInfo Image;
-	mem_zero(&Image, sizeof(Image));
+	CImageInfo Image{};
 
 	bool DidSwap = false;
 
@@ -2881,9 +2880,6 @@ int CGraphics_Threaded::GetVideoModes(CVideoMode *pModes, int MaxModes, int Scre
 	}
 
 	// add videomodes command
-	CImageInfo Image;
-	mem_zero(&Image, sizeof(Image));
-
 	int NumModes = 0;
 	m_pBackend->GetVideoModes(pModes, MaxModes, &NumModes, m_ScreenHiDPIScale, g_Config.m_GfxDesktopWidth, g_Config.m_GfxDesktopHeight, Screen);
 

--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -517,7 +517,7 @@ void CServerBrowser::SetInfo(CServerEntry *pEntry, const CServerInfo &Info)
 	pEntry->m_Info.m_Favorite = TmpInfo.m_Favorite;
 	pEntry->m_Info.m_FavoriteAllowPing = TmpInfo.m_FavoriteAllowPing;
 	pEntry->m_Info.m_Official = TmpInfo.m_Official;
-	mem_copy(pEntry->m_Info.m_aAddresses, TmpInfo.m_aAddresses, sizeof(pEntry->m_Info.m_aAddresses));
+	std::copy_n(TmpInfo.m_aAddresses, MAX_SERVER_ADDRESSES, pEntry->m_Info.m_aAddresses);
 	pEntry->m_Info.m_NumAddresses = TmpInfo.m_NumAddresses;
 	ServerBrowserFormatAddresses(pEntry->m_Info.m_aAddress, sizeof(pEntry->m_Info.m_aAddress), pEntry->m_Info.m_aAddresses, pEntry->m_Info.m_NumAddresses);
 
@@ -596,7 +596,7 @@ CServerBrowser::CServerEntry *CServerBrowser::Add(const NETADDR *pAddrs, int Num
 	mem_zero(pEntry, sizeof(CServerEntry));
 
 	// set the info
-	mem_copy(pEntry->m_Info.m_aAddresses, pAddrs, NumAddrs * sizeof(pAddrs[0]));
+	std::copy_n(pAddrs, NumAddrs, pEntry->m_Info.m_aAddresses);
 	pEntry->m_Info.m_NumAddresses = NumAddrs;
 
 	pEntry->m_Info.m_Latency = 999;

--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -593,7 +593,7 @@ CServerBrowser::CServerEntry *CServerBrowser::Add(const NETADDR *pAddrs, int Num
 
 	// create new pEntry
 	pEntry = (CServerEntry *)m_ServerlistHeap.Allocate(sizeof(CServerEntry));
-	mem_zero(pEntry, sizeof(CServerEntry));
+	*pEntry = CServerEntry();
 
 	// set the info
 	std::copy_n(pAddrs, NumAddrs, pEntry->m_Info.m_aAddresses);
@@ -667,8 +667,7 @@ void CServerBrowser::OnServerInfoUpdate(const NETADDR &Addr, int Token, const CS
 
 	if(m_ServerlistType == IServerBrowser::TYPE_LAN)
 	{
-		NETADDR Broadcast;
-		mem_zero(&Broadcast, sizeof(Broadcast));
+		NETADDR Broadcast{};
 		Broadcast.type = m_pNetClient->NetType() | NETTYPE_LINK_BROADCAST;
 		int TokenBC = GenerateToken(Broadcast);
 		bool Drop = false;
@@ -758,12 +757,10 @@ void CServerBrowser::Refresh(int Type)
 	if(Type == IServerBrowser::TYPE_LAN)
 	{
 		unsigned char aBuffer[sizeof(SERVERBROWSE_GETINFO) + 1];
-		CNetChunk Packet;
+		CNetChunk Packet{};
 		int i;
 
 		/* do the broadcast version */
-		Packet.m_ClientID = -1;
-		mem_zero(&Packet, sizeof(Packet));
 		Packet.m_Address.type = m_pNetClient->NetType() | NETTYPE_LINK_BROADCAST;
 		Packet.m_Flags = NETSENDFLAG_CONNLESS | NETSENDFLAG_EXTENDED;
 		Packet.m_DataSize = sizeof(aBuffer);

--- a/src/engine/client/text.cpp
+++ b/src/engine/client/text.cpp
@@ -792,7 +792,7 @@ public:
 
 	void SetCursor(CTextCursor *pCursor, float x, float y, float FontSize, int Flags) override
 	{
-		mem_zero(pCursor, sizeof(*pCursor));
+		*pCursor = CTextCursor();
 		pCursor->m_FontSize = FontSize;
 		pCursor->m_StartX = x;
 		pCursor->m_StartY = y;

--- a/src/engine/server.h
+++ b/src/engine/server.h
@@ -104,15 +104,13 @@ public:
 
 	int SendPackMsgTranslate(const CNetMsg_Sv_Emoticon *pMsg, int Flags, int ClientID)
 	{
-		CNetMsg_Sv_Emoticon MsgCopy;
-		mem_copy(&MsgCopy, pMsg, sizeof(MsgCopy));
+		CNetMsg_Sv_Emoticon MsgCopy(*pMsg);
 		return Translate(MsgCopy.m_ClientID, ClientID) && SendPackMsgOne(&MsgCopy, Flags, ClientID);
 	}
 
 	int SendPackMsgTranslate(const CNetMsg_Sv_Chat *pMsg, int Flags, int ClientID)
 	{
-		CNetMsg_Sv_Chat MsgCopy;
-		mem_copy(&MsgCopy, pMsg, sizeof(MsgCopy));
+		CNetMsg_Sv_Chat MsgCopy(*pMsg);
 
 		char aBuf[1000];
 		if(MsgCopy.m_ClientID >= 0 && !Translate(MsgCopy.m_ClientID, ClientID))
@@ -137,8 +135,7 @@ public:
 
 	int SendPackMsgTranslate(const CNetMsg_Sv_KillMsg *pMsg, int Flags, int ClientID)
 	{
-		CNetMsg_Sv_KillMsg MsgCopy;
-		mem_copy(&MsgCopy, pMsg, sizeof(MsgCopy));
+		CNetMsg_Sv_KillMsg MsgCopy(*pMsg);
 		if(!Translate(MsgCopy.m_Victim, ClientID))
 			return 0;
 		if(!Translate(MsgCopy.m_Killer, ClientID))

--- a/src/engine/server/antibot.cpp
+++ b/src/engine/server/antibot.cpp
@@ -56,7 +56,7 @@ void CAntibot::Init()
 	dbg_assert(m_pServer && m_pConsole, "antibot requires server and console");
 	dbg_assert(AntibotAbiVersion() == ANTIBOT_ABI_VERSION, "antibot abi version mismatch");
 
-	mem_zero(&m_Data, sizeof(m_Data));
+	m_Data = CAntibotData();
 	CAntibotVersion Version = ANTIBOT_VERSION;
 	m_Data.m_Version = Version;
 
@@ -73,7 +73,7 @@ void CAntibot::Init()
 void CAntibot::RoundStart(IGameServer *pGameServer)
 {
 	m_pGameServer = pGameServer;
-	mem_zero(&m_RoundData, sizeof(m_RoundData));
+	m_RoundData = CAntibotRoundData();
 	m_RoundData.m_Map.m_pTiles = 0;
 	AntibotRoundStart(&m_RoundData);
 	Update();

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -352,7 +352,7 @@ void CServer::CClient::Reset()
 	for(auto &Input : m_aInputs)
 		Input.m_GameTick = -1;
 	m_CurrentInput = 0;
-	mem_zero(&m_LatestInput, sizeof(m_LatestInput));
+	m_LatestInput = CInput();
 
 	m_Snapshots.PurgeAll();
 	m_LastAckedSnapshot = -1;
@@ -834,8 +834,7 @@ static inline bool RepackMsg(const CMsgPacker *pMsg, CPacker &Packer, bool Sixup
 
 int CServer::SendMsg(CMsgPacker *pMsg, int Flags, int ClientID)
 {
-	CNetChunk Packet;
-	mem_zero(&Packet, sizeof(CNetChunk));
+	CNetChunk Packet{};
 	if(Flags & MSGFLAG_VITAL)
 		Packet.m_Flags |= NETSENDFLAG_VITAL;
 	if(Flags & MSGFLAG_FLUSH)
@@ -902,8 +901,7 @@ int CServer::SendMsg(CMsgPacker *pMsg, int Flags, int ClientID)
 
 void CServer::SendMsgRaw(int ClientID, const void *pData, int Size, int Flags)
 {
-	CNetChunk Packet;
-	mem_zero(&Packet, sizeof(CNetChunk));
+	CNetChunk Packet{};
 	Packet.m_ClientID = ClientID;
 	Packet.m_pData = pData;
 	Packet.m_DataSize = Size;
@@ -2417,7 +2415,7 @@ void CServer::PumpNetwork(bool PacketWaiting)
 	{
 		unsigned char aBuffer[NET_MAX_PAYLOAD];
 		int Flags;
-		mem_zero(&Packet, sizeof(Packet));
+		Packet = CNetChunk();
 		Packet.m_pData = aBuffer;
 		while(Antibot()->OnEngineSimulateClientMessage(&Packet.m_ClientID, aBuffer, sizeof(aBuffer), &Packet.m_DataSize, &Flags))
 		{
@@ -2591,7 +2589,7 @@ int CServer::Run()
 	int NetType = Config()->m_SvIpv4Only ? NETTYPE_IPV4 : NETTYPE_ALL;
 
 	if(!Config()->m_Bindaddr[0] || net_host_lookup(Config()->m_Bindaddr, &BindAddr, NetType) != 0)
-		mem_zero(&BindAddr, sizeof(BindAddr));
+		BindAddr = NETADDR();
 
 	BindAddr.type = NetType;
 

--- a/src/engine/shared/datafile.cpp
+++ b/src/engine/shared/datafile.cpp
@@ -561,7 +561,7 @@ void CDataFileWriter::Init()
 	m_NumDatas = 0;
 	m_NumItemTypes = 0;
 	m_NumExtendedItemTypes = 0;
-	mem_zero(m_pItemTypes, sizeof(CItemTypeInfo) * MAX_ITEM_TYPES);
+	new(m_pItemTypes) CItemTypeInfo[MAX_ITEM_TYPES]{};
 	mem_zero(m_aExtendedItemTypes, sizeof(m_aExtendedItemTypes));
 
 	for(int i = 0; i < MAX_ITEM_TYPES; i++)

--- a/src/engine/shared/demo.cpp
+++ b/src/engine/shared/demo.cpp
@@ -128,7 +128,7 @@ int CDemoRecorder::Start(class IStorage *pStorage, class IConsole *pConsole, con
 		MapSize = io_length(MapFile);
 
 	// write header
-	mem_zero(&Header, sizeof(Header));
+	Header = CDemoHeader();
 	mem_copy(Header.m_aMarker, gs_aHeaderMarker, sizeof(Header.m_aMarker));
 	Header.m_Version = gs_CurVersion;
 	str_copy(Header.m_aNetversion, pNetVersion);
@@ -728,7 +728,7 @@ int CDemoPlayer::Load(class IStorage *pStorage, class IConsole *pConsole, const 
 	str_copy(m_aFilename, pFilename);
 
 	// clear the playback info
-	mem_zero(&m_Info, sizeof(m_Info));
+	m_Info = CDemoPlayer::CPlaybackInfo();
 	m_Info.m_Info.m_FirstTick = -1;
 	m_Info.m_Info.m_LastTick = -1;
 	m_Info.m_NextTick = -1;
@@ -1087,8 +1087,8 @@ bool CDemoPlayer::GetDemoInfo(class IStorage *pStorage, const char *pFilename, i
 	if(!pDemoHeader || !pTimelineMarkers || !pMapInfo)
 		return false;
 
-	mem_zero(pDemoHeader, sizeof(CDemoHeader));
-	mem_zero(pTimelineMarkers, sizeof(CTimelineMarkers));
+	*pDemoHeader = CDemoHeader();
+	*pTimelineMarkers = CTimelineMarkers();
 
 	IOHANDLE File = pStorage->OpenFile(pFilename, IOFLAG_READ, StorageType);
 	if(!File)

--- a/src/engine/shared/econ.cpp
+++ b/src/engine/shared/econ.cpp
@@ -72,7 +72,7 @@ void CEcon::Init(CConfig *pConfig, IConsole *pConsole, CNetBan *pNetBan)
 	}
 	else
 	{
-		mem_zero(&BindAddr, sizeof(BindAddr));
+		BindAddr = NETADDR();
 		BindAddr.type = NETTYPE_ALL;
 		BindAddr.port = g_Config.m_EcPort;
 	}

--- a/src/engine/shared/huffman.cpp
+++ b/src/engine/shared/huffman.cpp
@@ -93,7 +93,7 @@ void CHuffman::ConstructTree(const unsigned *pFrequencies)
 void CHuffman::Init(const unsigned *pFrequencies)
 {
 	// make sure to cleanout every thing
-	mem_zero(m_aNodes, sizeof(m_aNodes));
+	new(m_aNodes) std::remove_pointer<decltype(m_aNodes)>::type{};
 	mem_zero(m_apDecodeLut, sizeof(m_apDecodeLut));
 	m_pStartNode = 0x0;
 	m_NumNodes = 0;

--- a/src/engine/shared/netban.cpp
+++ b/src/engine/shared/netban.cpp
@@ -398,7 +398,7 @@ bool CNetBan::IsBanned(const NETADDR *pOrigAddr, char *pBuf, unsigned BufferSize
 	const NETADDR *pAddr = pOrigAddr;
 	if(pOrigAddr->type == NETTYPE_WEBSOCKET_IPV4)
 	{
-		mem_copy(&Addr, pOrigAddr, sizeof(NETADDR));
+		Addr = *pOrigAddr;
 		pAddr = &Addr;
 		Addr.type = NETTYPE_IPV4;
 	}

--- a/src/engine/shared/netban.cpp
+++ b/src/engine/shared/netban.cpp
@@ -202,7 +202,7 @@ template<class T, int HashCount>
 void CNetBan::CBanPool<T, HashCount>::Reset()
 {
 	mem_zero(m_aapHashList, sizeof(m_aapHashList));
-	mem_zero(m_aBans, sizeof(m_aBans));
+	new(m_aBans) typename std::remove_pointer<decltype(m_aBans)>::type{};
 	m_pFirstUsed = 0;
 	m_CountUsed = 0;
 

--- a/src/engine/shared/network_client.cpp
+++ b/src/engine/shared/network_client.cpp
@@ -12,7 +12,7 @@ bool CNetClient::Open(NETADDR BindAddr)
 		return false;
 
 	// clean it
-	mem_zero(this, sizeof(*this));
+	*this = CNetClient();
 
 	// init
 	m_Socket = Socket;

--- a/src/engine/shared/network_conn.cpp
+++ b/src/engine/shared/network_conn.cpp
@@ -11,8 +11,8 @@ SECURITY_TOKEN ToSecurityToken(unsigned char *pData)
 
 void CNetConnection::ResetStats()
 {
-	mem_zero(&m_Stats, sizeof(m_Stats));
-	mem_zero(&m_PeerAddr, sizeof(m_PeerAddr));
+	m_Stats = NETSTATS();
+	m_PeerAddr = NETADDR();
 	m_LastUpdateTime = 0;
 }
 
@@ -45,7 +45,7 @@ void CNetConnection::Reset(bool Rejoin)
 
 	m_Buffer.Init();
 
-	mem_zero(&m_Construct, sizeof(m_Construct));
+	m_Construct = CNetPacketConstruct();
 }
 
 const char *CNetConnection::ErrorString()
@@ -102,7 +102,7 @@ int CNetConnection::Flush()
 	m_LastSendTime = time_get();
 
 	// clear construct so we can start building a new package
-	mem_zero(&m_Construct, sizeof(m_Construct));
+	m_Construct = CNetPacketConstruct();
 	return NumChunks;
 }
 
@@ -200,7 +200,7 @@ int CNetConnection::Connect(const NETADDR *pAddr, int NumAddrs)
 
 	// init connection
 	Reset();
-	mem_zero(&m_PeerAddr, sizeof(m_PeerAddr));
+	m_PeerAddr = NETADDR();
 	for(int i = 0; i < NumAddrs; i++)
 	{
 		m_aConnectAddrs[i] = pAddr[i];

--- a/src/engine/shared/network_conn.cpp
+++ b/src/engine/shared/network_conn.cpp
@@ -511,7 +511,7 @@ void CNetConnection::SetTimedOut(const NETADDR *pAddr, int Sequence, int Ack, SE
 		CNetChunkResend *pFirst = pResendBuffer->First();
 
 		CNetChunkResend *pResend = m_Buffer.Allocate(sizeof(CNetChunkResend) + pFirst->m_DataSize);
-		mem_copy(pResend, pFirst, sizeof(CNetChunkResend) + pFirst->m_DataSize);
+		mem_copy((void*)pResend, (void*)pFirst, sizeof(CNetChunkResend) + pFirst->m_DataSize);
 
 		pResendBuffer->PopFirst();
 	}

--- a/src/engine/shared/network_console.cpp
+++ b/src/engine/shared/network_console.cpp
@@ -8,7 +8,7 @@
 bool CNetConsole::Open(NETADDR BindAddr, CNetBan *pNetBan)
 {
 	// zero out the whole structure
-	mem_zero(this, sizeof(*this));
+	*this = CNetConsole();
 	m_pNetBan = pNetBan;
 
 	// open socket

--- a/src/engine/shared/network_console_conn.cpp
+++ b/src/engine/shared/network_console_conn.cpp
@@ -6,7 +6,7 @@
 void CConsoleNetConnection::Reset()
 {
 	m_State = NET_CONNSTATE_OFFLINE;
-	mem_zero(&m_PeerAddr, sizeof(m_PeerAddr));
+	m_PeerAddr = NETADDR();
 	m_aErrorString[0] = 0;
 
 	m_Socket = nullptr;

--- a/src/engine/shared/network_server.cpp
+++ b/src/engine/shared/network_server.cpp
@@ -46,7 +46,7 @@ static SECURITY_TOKEN ToSecurityToken(const unsigned char *pData)
 bool CNetServer::Open(NETADDR BindAddr, CNetBan *pNetBan, int MaxClients, int MaxClientsPerIP)
 {
 	// zero out the whole structure
-	*this = CNetServer();
+	new(this) CNetServer{};
 
 	// open socket
 	m_Socket = net_udp_create(BindAddr);

--- a/src/engine/shared/network_server.cpp
+++ b/src/engine/shared/network_server.cpp
@@ -46,7 +46,7 @@ static SECURITY_TOKEN ToSecurityToken(const unsigned char *pData)
 bool CNetServer::Open(NETADDR BindAddr, CNetBan *pNetBan, int MaxClients, int MaxClientsPerIP)
 {
 	// zero out the whole structure
-	mem_zero(this, sizeof(*this));
+	*this = CNetServer();
 
 	// open socket
 	m_Socket = net_udp_create(BindAddr);
@@ -275,8 +275,7 @@ int CNetServer::TryAcceptClient(NETADDR &Addr, SECURITY_TOKEN SecurityToken, boo
 
 void CNetServer::SendMsgs(NETADDR &Addr, const CMsgPacker *apMsgs[], int Num)
 {
-	CNetPacketConstruct Construct;
-	mem_zero(&Construct, sizeof(Construct));
+	CNetPacketConstruct Construct{};
 	unsigned char *pChunkData = &Construct.m_aChunkData[Construct.m_DataSize];
 
 	for(int i = 0; i < Num; i++)

--- a/src/engine/shared/network_server.cpp
+++ b/src/engine/shared/network_server.cpp
@@ -543,7 +543,7 @@ int CNetServer::OnSixupCtrlMsg(NETADDR &Addr, CNetChunk *pChunk, int ControlMsg,
 	if(m_RecvUnpacker.m_Data.m_DataSize < 5 || ClientExists(Addr))
 		return 0; // silently ignore
 
-	mem_copy(&ResponseToken, Packet.m_aChunkData + 1, 4);
+	mem_copy(&ResponseToken, Packet.m_aChunkData + 1, sizeof(ResponseToken));
 
 	if(ControlMsg == 5)
 	{
@@ -564,7 +564,7 @@ int CNetServer::OnSixupCtrlMsg(NETADDR &Addr, CNetChunk *pChunk, int ControlMsg,
 	{
 		SECURITY_TOKEN MyToken = GetToken(Addr);
 		unsigned char aToken[4];
-		mem_copy(aToken, &MyToken, 4);
+		mem_copy(aToken, &MyToken, sizeof(MyToken));
 
 		CNetBase::SendControlMsg(m_Socket, &Addr, 0, NET_CTRLMSG_CONNECTACCEPT, aToken, sizeof(aToken), ResponseToken, true);
 		if(Token == MyToken)
@@ -757,7 +757,7 @@ void CNetServer::SendTokenSixup(NETADDR &Addr, SECURITY_TOKEN Token)
 {
 	SECURITY_TOKEN MyToken = GetToken(Addr);
 	unsigned char aBuf[512] = {};
-	mem_copy(aBuf, &MyToken, 4);
+	mem_copy(aBuf, &MyToken, sizeof(MyToken));
 	int Size = (Token == NET_SECURITY_TOKEN_UNKNOWN) ? 512 : 4;
 	CNetBase::SendControlMsg(m_Socket, &Addr, 0, 5, aBuf, Size, Token, true);
 }
@@ -770,8 +770,8 @@ int CNetServer::SendConnlessSixup(CNetChunk *pChunk, SECURITY_TOKEN ResponseToke
 	unsigned char aBuffer[NET_MAX_PACKETSIZE];
 	aBuffer[0] = NET_PACKETFLAG_CONNLESS << 2 | 1;
 	SECURITY_TOKEN Token = GetToken(pChunk->m_Address);
-	mem_copy(aBuffer + 1, &ResponseToken, 4);
-	mem_copy(aBuffer + 5, &Token, 4);
+	mem_copy(aBuffer + 1, &ResponseToken, sizeof(ResponseToken));
+	mem_copy(aBuffer + 5, &Token, sizeof(Token));
 	mem_copy(aBuffer + 9, pChunk->m_pData, pChunk->m_DataSize);
 	net_udp_send(m_Socket, &pChunk->m_Address, aBuffer, pChunk->m_DataSize + 9);
 

--- a/src/engine/shared/network_stun.cpp
+++ b/src/engine/shared/network_stun.cpp
@@ -37,7 +37,7 @@ CStun::CProtocol::CProtocol(int Index, NETSOCKET Socket) :
 	m_Index(Index),
 	m_Socket(Socket)
 {
-	mem_zero(&m_StunServer, sizeof(NETADDR));
+	m_StunServer = NETADDR();
 	// Initialize `m_Stun` with random data.
 	unsigned char aBuf[32];
 	StunMessagePrepare(aBuf, sizeof(aBuf), &m_Stun);

--- a/src/engine/shared/protocol_ex.cpp
+++ b/src/engine/shared/protocol_ex.cpp
@@ -18,7 +18,7 @@ int UnpackMessageID(int *pID, bool *pSys, CUuid *pUuid, CUnpacker *pUnpacker, CM
 {
 	*pID = 0;
 	*pSys = false;
-	mem_zero(pUuid, sizeof(*pUuid));
+	*pUuid = CUuid();
 
 	int MsgID = pUnpacker->GetInt();
 

--- a/src/engine/shared/serverinfo.cpp
+++ b/src/engine/shared/serverinfo.cpp
@@ -58,7 +58,7 @@ bool CServerInfo2::Validate() const
 
 bool CServerInfo2::FromJsonRaw(CServerInfo2 *pOut, const json_value *pJson)
 {
-	mem_zero(pOut, sizeof(*pOut));
+	*pOut = CServerInfo2();
 	bool Error;
 
 	const json_value &ServerInfo = *pJson;

--- a/src/engine/shared/snapshot.cpp
+++ b/src/engine/shared/snapshot.cpp
@@ -229,7 +229,7 @@ CSnapshotDelta::CSnapshotDelta()
 	mem_zero(m_aItemSizes, sizeof(m_aItemSizes));
 	mem_zero(m_aSnapshotDataRate, sizeof(m_aSnapshotDataRate));
 	mem_zero(m_aSnapshotDataUpdates, sizeof(m_aSnapshotDataUpdates));
-	mem_zero(&m_Empty, sizeof(m_Empty));
+	m_Empty = CData();
 }
 
 CSnapshotDelta::CSnapshotDelta(const CSnapshotDelta &Old)
@@ -237,7 +237,7 @@ CSnapshotDelta::CSnapshotDelta(const CSnapshotDelta &Old)
 	mem_copy(m_aItemSizes, Old.m_aItemSizes, sizeof(m_aItemSizes));
 	mem_copy(m_aSnapshotDataRate, Old.m_aSnapshotDataRate, sizeof(m_aSnapshotDataRate));
 	mem_copy(m_aSnapshotDataUpdates, Old.m_aSnapshotDataUpdates, sizeof(m_aSnapshotDataUpdates));
-	mem_zero(&m_Empty, sizeof(m_Empty));
+	m_Empty = CData();
 }
 
 void CSnapshotDelta::SetStaticsize(int ItemType, int Size)
@@ -672,7 +672,8 @@ void *CSnapshotBuilder::NewItem(int Type, int ID, int Size)
 			return pObj;
 	}
 
-	mem_zero(pObj, sizeof(CSnapshotItem) + Size);
+	// FIXME: unsafe behavior in c++
+	mem_zero((void *)pObj, sizeof(CSnapshotItem) + Size);
 	pObj->m_TypeAndID = (Type << 16) | ID;
 	m_aOffsets[m_NumItems] = m_DataSize;
 	m_DataSize += sizeof(CSnapshotItem) + Size;

--- a/src/engine/shared/stun.cpp
+++ b/src/engine/shared/stun.cpp
@@ -35,7 +35,7 @@ size_t StunMessagePrepare(unsigned char *pBuffer, size_t BufferSize, CStunData *
 bool StunMessageParse(const unsigned char *pMessage, size_t MessageSize, const CStunData *pData, bool *pSuccess, NETADDR *pAddr)
 {
 	*pSuccess = false;
-	mem_zero(pAddr, sizeof(*pAddr));
+	*pAddr = NETADDR();
 	if(MessageSize < 20)
 	{
 		return true;

--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -17,7 +17,7 @@
 
 CControls::CControls()
 {
-	mem_zero(&m_aLastData, sizeof(m_aLastData));
+	new(m_aLastData) std::remove_pointer<decltype(m_aLastData)>::type{};
 	m_LastDummy = 0;
 	m_OtherFire = 0;
 }
@@ -284,7 +284,7 @@ int CControls::SnapInput(int *pData)
 		if(g_Config.m_DbgStress)
 		{
 			float t = Client()->LocalTime();
-			mem_zero(&m_aInputData[g_Config.m_ClDummy], sizeof(m_aInputData[0]));
+			m_aInputData[g_Config.m_ClDummy] = CNetObj_PlayerInput();
 
 			m_aInputData[g_Config.m_ClDummy].m_Direction = ((int)t / 2) & 1;
 			m_aInputData[g_Config.m_ClDummy].m_Jump = ((int)t);

--- a/src/game/client/components/ghost.cpp
+++ b/src/game/client/components/ghost.cpp
@@ -49,7 +49,7 @@ void CGhost::GetGhostCharacter(CGhostCharacter *pGhostChar, const CNetObj_Charac
 
 void CGhost::GetNetObjCharacter(CNetObj_Character *pChar, const CGhostCharacter *pGhostChar)
 {
-	mem_zero(pChar, sizeof(CNetObj_Character));
+	*pChar = CNetObj_Character();
 	pChar->m_X = pGhostChar->m_X;
 	pChar->m_Y = pGhostChar->m_Y;
 	pChar->m_VelX = pGhostChar->m_VelX;

--- a/src/game/client/components/skins.cpp
+++ b/src/game/client/components/skins.cpp
@@ -402,8 +402,7 @@ int CSkins::Find(const char *pName)
 
 int CSkins::FindImpl(const char *pName)
 {
-	CSkin Needle;
-	mem_zero(&Needle, sizeof(Needle));
+	CSkin Needle{};
 	str_copy(Needle.m_aName, pName);
 	auto Range = std::equal_range(m_vSkins.begin(), m_vSkins.end(), Needle);
 	if(std::distance(Range.first, Range.second) == 1)
@@ -418,8 +417,7 @@ int CSkins::FindImpl(const char *pName)
 	if(str_find(pName, "/") != 0)
 		return -1;
 
-	CDownloadSkin DownloadNeedle;
-	mem_zero(&DownloadNeedle, sizeof(DownloadNeedle));
+	CDownloadSkin DownloadNeedle{};
 	str_copy(DownloadNeedle.m_aName, pName);
 	const auto &[RangeBegin, RangeEnd] = std::equal_range(m_vDownloadSkins.begin(), m_vDownloadSkins.end(), DownloadNeedle);
 	if(std::distance(RangeBegin, RangeEnd) == 1)

--- a/src/game/client/components/sounds.cpp
+++ b/src/game/client/components/sounds.cpp
@@ -169,7 +169,7 @@ void CSounds::OnRender()
 
 void CSounds::ClearQueue()
 {
-	mem_zero(m_aQueue, sizeof(m_aQueue));
+	new(m_aQueue) std::remove_pointer<decltype(m_aQueue)>::type{};
 	m_QueuePos = 0;
 	m_QueueWaitTime = time();
 }

--- a/src/game/client/components/sounds.cpp
+++ b/src/game/client/components/sounds.cpp
@@ -162,7 +162,7 @@ void CSounds::OnRender()
 			Play(m_aQueue[0].m_Channel, m_aQueue[0].m_SetId, 1.0f);
 			m_QueueWaitTime = Now + time_freq() * 3 / 10; // wait 300ms before playing the next one
 			if(--m_QueuePos > 0)
-				mem_move(m_aQueue, m_aQueue + 1, m_QueuePos * sizeof(QueueEntry));
+				std::copy(m_aQueue + 1, m_aQueue + 1 + m_QueuePos, m_aQueue);
 		}
 	}
 }

--- a/src/game/client/components/statboard.cpp
+++ b/src/game/client/components/statboard.cpp
@@ -412,8 +412,7 @@ std::string CStatboard::ReplaceCommata(char *pStr)
 	if(!str_find(pStr, ","))
 		return pStr;
 
-	char aOutbuf[256];
-	mem_zero(aOutbuf, sizeof(aOutbuf));
+	char aOutbuf[256] = {0};
 
 	for(int i = 0, skip = 0; i < 64; i++)
 	{

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -512,7 +512,7 @@ void CGameClient::OnConnected()
 
 	m_GameWorld.Clear();
 	m_GameWorld.m_WorldConfig.m_InfiniteAmmo = true;
-	mem_zero(&m_GameInfo, sizeof(m_GameInfo));
+	m_GameInfo = CGameInfo();
 	m_PredictedDummyID = -1;
 	LoadMapSettings();
 
@@ -1124,7 +1124,7 @@ static CGameInfo GetGameInfo(const CNetObj_GameInfoEx *pInfoEx, int InfoExSize, 
 void CGameClient::InvalidateSnapshot()
 {
 	// clear all pointers
-	mem_zero(&m_Snap, sizeof(m_Snap));
+	m_Snap = CGameClient::CSnapState();
 	m_Snap.m_LocalClientID = -1;
 	SnapCollectEntities();
 }

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1304,9 +1304,9 @@ void CGameClient::OnNewSnapshot()
 						// reuse the result from the previous evolve if the snapped character didn't change since the previous snapshot
 						if(EvolveCur && m_aClients[Item.m_ID].m_Evolved.m_Tick == Client()->PrevGameTick(g_Config.m_ClDummy))
 						{
-							if(mem_comp(&m_Snap.m_aCharacters[Item.m_ID].m_Prev, &m_aClients[Item.m_ID].m_Snapped, sizeof(CNetObj_Character)) == 0)
+							if(m_Snap.m_aCharacters[Item.m_ID].m_Prev == m_aClients[Item.m_ID].m_Snapped)
 								m_Snap.m_aCharacters[Item.m_ID].m_Prev = m_aClients[Item.m_ID].m_Evolved;
-							if(mem_comp(&m_Snap.m_aCharacters[Item.m_ID].m_Cur, &m_aClients[Item.m_ID].m_Snapped, sizeof(CNetObj_Character)) == 0)
+							if(m_Snap.m_aCharacters[Item.m_ID].m_Cur == m_aClients[Item.m_ID].m_Snapped)
 								m_Snap.m_aCharacters[Item.m_ID].m_Cur = m_aClients[Item.m_ID].m_Evolved;
 						}
 

--- a/src/game/client/prediction/entities/character.cpp
+++ b/src/game/client/prediction/entities/character.cpp
@@ -505,19 +505,19 @@ void CCharacter::OnPredictedInput(CNetObj_PlayerInput *pNewInput)
 	if(!GameWorld()->m_WorldConfig.m_BugDDRaceInput && pNewInput->m_PlayerFlags & PLAYERFLAG_CHATTING)
 	{
 		// save reseted input
-		mem_copy(&m_SavedInput, &m_Input, sizeof(m_SavedInput));
+		m_SavedInput = m_Input;
 		return;
 	}
 
 	// copy new input
-	mem_copy(&m_Input, pNewInput, sizeof(m_Input));
+	m_Input = *pNewInput;
 	//m_NumInputs++;
 
 	// it is not allowed to aim in the center
 	if(m_Input.m_TargetX == 0 && m_Input.m_TargetY == 0)
 		m_Input.m_TargetY = -1;
 
-	mem_copy(&m_SavedInput, &m_Input, sizeof(m_SavedInput));
+	m_SavedInput = m_Input;
 }
 
 void CCharacter::OnDirectInput(CNetObj_PlayerInput *pNewInput)
@@ -533,8 +533,8 @@ void CCharacter::OnDirectInput(CNetObj_PlayerInput *pNewInput)
 	}
 
 	m_NumInputs++;
-	mem_copy(&m_LatestPrevInput, &m_LatestInput, sizeof(m_LatestInput));
-	mem_copy(&m_LatestInput, pNewInput, sizeof(m_LatestInput));
+	m_LatestPrevInput = m_LatestInput;
+	m_LatestInput = *pNewInput;
 
 	// it is not allowed to aim in the center
 	if(m_LatestInput.m_TargetX == 0 && m_LatestInput.m_TargetY == 0)
@@ -546,7 +546,7 @@ void CCharacter::OnDirectInput(CNetObj_PlayerInput *pNewInput)
 		FireWeapon();
 	}
 
-	mem_copy(&m_LatestPrevInput, &m_LatestInput, sizeof(m_LatestInput));
+	m_LatestPrevInput = m_LatestInput;
 }
 
 void CCharacter::ResetInput()
@@ -936,7 +936,7 @@ void CCharacter::HandleTuneLayer()
 
 void CCharacter::DDRaceTick()
 {
-	mem_copy(&m_Input, &m_SavedInput, sizeof(m_Input));
+	m_Input = m_SavedInput;
 	if(m_Core.m_LiveFrozen && !m_CanMoveInFreeze && !m_Core.m_Super)
 	{
 		m_Input.m_Direction = 0;

--- a/src/game/client/prediction/entities/character.cpp
+++ b/src/game/client/prediction/entities/character.cpp
@@ -1117,9 +1117,8 @@ CCharacter::CCharacter(CGameWorld *pGameWorld, int ID, CNetObj_Character *pChar,
 	m_Core.Reset();
 	m_Core.Init(&GameWorld()->m_Core, GameWorld()->Collision(), GameWorld()->Teams());
 	m_Core.m_Id = ID;
-	mem_zero(&m_Core.m_Ninja, sizeof(m_Core.m_Ninja));
-	mem_zero(&m_SavedInput, sizeof(m_SavedInput));
-	m_LatestInput = m_LatestPrevInput = m_PrevInput = m_Input = m_SavedInput;
+	m_Core.m_Ninja = CCharacterCore::SNinja();
+	m_LatestInput = m_LatestPrevInput = m_PrevInput = m_Input = m_SavedInput = CNetObj_PlayerInput();
 	m_Core.m_LeftWall = true;
 	m_ReloadTimer = 0;
 	m_NumObjectsHit = 0;
@@ -1317,8 +1316,7 @@ void CCharacter::Read(CNetObj_Character *pChar, CNetObj_DDNetCharacter *pExtende
 	// reset all input except direction and hook for non-local players (as in vanilla prediction)
 	if(!IsLocal)
 	{
-		mem_zero(&m_Input, sizeof(m_Input));
-		mem_zero(&m_SavedInput, sizeof(m_SavedInput));
+		m_Input = m_SavedInput = CNetObj_PlayerInput();
 		m_Input.m_Direction = m_SavedInput.m_Direction = m_Core.m_Direction;
 		m_Input.m_Hook = m_SavedInput.m_Hook = (m_Core.m_HookState != HOOK_IDLE);
 

--- a/src/game/client/prediction/gameworld.cpp
+++ b/src/game/client/prediction/gameworld.cpp
@@ -513,7 +513,7 @@ void CGameWorld::NetObjEnd(int LocalID)
 					{
 						pHookedChar->m_Pos = pHookedChar->m_Core.m_Pos = pChar->m_Core.m_HookPos;
 						pHookedChar->m_Core.m_Vel = vec2(0, 0);
-						mem_zero(&pHookedChar->m_SavedInput, sizeof(pHookedChar->m_SavedInput));
+						pHookedChar->m_SavedInput = CNetObj_PlayerInput();
 						pHookedChar->m_SavedInput.m_TargetY = -1;
 						pHookedChar->m_KeepHooked = true;
 						pHookedChar->m_MarkedForDestroy = false;

--- a/src/game/client/projectile_data.cpp
+++ b/src/game/client/projectile_data.cpp
@@ -18,8 +18,10 @@ CProjectileData ExtractProjectileInfo(const CNetObj_Projectile *pProj, CGameWorl
 {
 	if(UseProjectileExtraInfo(pProj))
 	{
+		static_assert(sizeof(CNetObj_DDNetProjectile) == sizeof(CNetObj_Projectile),
+			"CNetObj_DDNetProjectile must have same layout as CNetObj_Projectile");
 		CNetObj_DDNetProjectile Proj;
-		mem_copy(&Proj, pProj, sizeof(Proj));
+		Proj = *pProj;
 		return ExtractProjectileInfoDDNet(&Proj, pGameWorld);
 	}
 

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -34,7 +34,7 @@ void CUIElement::SUIElementRect::Reset()
 	m_Width = -1;
 	m_Height = -1;
 	m_Text.clear();
-	mem_zero(&m_Cursor, sizeof(m_Cursor));
+	m_Cursor = CTextCursor();
 	m_TextColor = ColorRGBA(-1, -1, -1, -1);
 	m_TextOutlineColor = ColorRGBA(-1, -1, -1, -1);
 	m_QuadColor = ColorRGBA(-1, -1, -1, -1);

--- a/src/game/collision.cpp
+++ b/src/game/collision.cpp
@@ -85,8 +85,7 @@ void CCollision::Init(class CLayers *pLayers)
 		if(Size >= (size_t)m_Width * m_Height * sizeof(CSwitchTile))
 			m_pSwitch = static_cast<CSwitchTile *>(m_pLayers->Map()->GetData(m_pLayers->SwitchLayer()->m_Switch));
 
-		m_pDoor = new CDoorTile[m_Width * m_Height];
-		mem_zero(m_pDoor, (size_t)m_Width * m_Height * sizeof(CDoorTile));
+		m_pDoor = new CDoorTile[m_Width * m_Height]{};
 	}
 	else
 	{

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -513,28 +513,28 @@ protected:
 			for(int y = 0; y < m_Height; ++y)
 			{
 				std::copy(&pTiles[y * m_Width + ShiftBy], &pTiles[(y + 1) * m_Width], &pTiles[y * m_Width]);
-				mem_zero(&pTiles[y * m_Width + (m_Width - ShiftBy)], ShiftBy * sizeof(T));
+				new(&pTiles[y * m_Width + (m_Width - ShiftBy)]) T[ShiftBy]{};
 			}
 			break;
 		case DIRECTION_RIGHT:
 			for(int y = 0; y < m_Height; ++y)
 			{
 				std::copy_backward(&pTiles[y * m_Width],  &pTiles[(y + 1) * m_Width - ShiftBy], &pTiles[(y + 1) * m_Width]);
-				mem_zero(&pTiles[y * m_Width], ShiftBy * sizeof(T));
+				new(&pTiles[y * m_Width]) T[ShiftBy]{};
 			}
 			break;
 		case DIRECTION_UP:
 			for(int y = 0; y < m_Height - ShiftBy; ++y)
 			{
 				std::copy_n(&pTiles[(y + ShiftBy) * m_Width], m_Width, &pTiles[y * m_Width]);
-				mem_zero(&pTiles[(y + ShiftBy) * m_Width], m_Width * sizeof(T));
+				new(&pTiles[(y + ShiftBy) * m_Width]) T[m_Width]{};
 			}
 			break;
 		case DIRECTION_DOWN:
 			for(int y = m_Height - 1; y >= ShiftBy; --y)
 			{
 				std::copy_n(&pTiles[(y - ShiftBy) * m_Width], m_Width, &pTiles[y * m_Width]);
-				mem_zero(&pTiles[(y - ShiftBy) * m_Width], m_Width * sizeof(T));
+				new(&pTiles[(y - ShiftBy) * m_Width]) T[m_Width]{};
 			}
 		}
 	}

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -512,14 +512,14 @@ protected:
 		case DIRECTION_LEFT:
 			for(int y = 0; y < m_Height; ++y)
 			{
-				mem_move(&pTiles[y * m_Width], &pTiles[y * m_Width + ShiftBy], (m_Width - ShiftBy) * sizeof(T));
+				std::copy(&pTiles[y * m_Width + ShiftBy], &pTiles[(y + 1) * m_Width], &pTiles[y * m_Width]);
 				mem_zero(&pTiles[y * m_Width + (m_Width - ShiftBy)], ShiftBy * sizeof(T));
 			}
 			break;
 		case DIRECTION_RIGHT:
 			for(int y = 0; y < m_Height; ++y)
 			{
-				mem_move(&pTiles[y * m_Width + ShiftBy], &pTiles[y * m_Width], (m_Width - ShiftBy) * sizeof(T));
+				std::copy_backward(&pTiles[y * m_Width],  &pTiles[(y + 1) * m_Width - ShiftBy], &pTiles[(y + 1) * m_Width]);
 				mem_zero(&pTiles[y * m_Width], ShiftBy * sizeof(T));
 			}
 			break;

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -526,14 +526,14 @@ protected:
 		case DIRECTION_UP:
 			for(int y = 0; y < m_Height - ShiftBy; ++y)
 			{
-				mem_copy(&pTiles[y * m_Width], &pTiles[(y + ShiftBy) * m_Width], m_Width * sizeof(T));
+				std::copy_n(&pTiles[(y + ShiftBy) * m_Width], m_Width, &pTiles[y * m_Width]);
 				mem_zero(&pTiles[(y + ShiftBy) * m_Width], m_Width * sizeof(T));
 			}
 			break;
 		case DIRECTION_DOWN:
 			for(int y = m_Height - 1; y >= ShiftBy; --y)
 			{
-				mem_copy(&pTiles[y * m_Width], &pTiles[(y - ShiftBy) * m_Width], m_Width * sizeof(T));
+				std::copy_n(&pTiles[(y - ShiftBy) * m_Width], m_Width, &pTiles[y * m_Width]);
 				mem_zero(&pTiles[(y - ShiftBy) * m_Width], m_Width * sizeof(T));
 			}
 		}

--- a/src/game/editor/io.cpp
+++ b/src/game/editor/io.cpp
@@ -357,9 +357,8 @@ int CEditorMap::Save(class IStorage *pStorage, const char *pFileName)
 
 	for(const auto &pEnvelope : m_vpEnvelopes)
 	{
-		int Count = pEnvelope->m_vPoints.size();
-		mem_copy(&pPoints[PointCount], pEnvelope->m_vPoints.data(), sizeof(CEnvPoint) * Count);
-		PointCount += Count;
+		std::copy(pEnvelope->m_vPoints.begin(), pEnvelope->m_vPoints.end(), pPoints);
+		PointCount += pEnvelope->m_vPoints.size();
 	}
 
 	df.AddItem(MAPITEMTYPE_ENVPOINTS, 0, TotalSize, pPoints);
@@ -950,7 +949,7 @@ int CEditorMap::Load(class IStorage *pStorage, const char *pFileName, int Storag
 				CMapItemEnvelope *pItem = (CMapItemEnvelope *)DataFile.GetItem(Start + e, nullptr, nullptr);
 				CEnvelope *pEnv = new CEnvelope(pItem->m_Channels);
 				pEnv->m_vPoints.resize(pItem->m_NumPoints);
-				mem_copy(pEnv->m_vPoints.data(), &pPoints[pItem->m_StartPoint], sizeof(CEnvPoint) * pItem->m_NumPoints);
+				std::copy_n(&pPoints[pItem->m_StartPoint], pItem->m_NumPoints, pEnv->m_vPoints.data());
 				if(pItem->m_aName[0] != -1) // compatibility with old maps
 					IntsToStr(pItem->m_aName, sizeof(pItem->m_aName) / sizeof(int), pEnv->m_aName);
 				m_vpEnvelopes.push_back(pEnv);

--- a/src/game/editor/io.cpp
+++ b/src/game/editor/io.cpp
@@ -232,7 +232,7 @@ int CEditorMap::Save(class IStorage *pStorage, const char *pFileName)
 				if(Item.m_Flags && !(pLayerTiles->m_Game))
 				{
 					CTile *pEmptyTiles = (CTile *)calloc((size_t)pLayerTiles->m_Width * pLayerTiles->m_Height, sizeof(CTile));
-					mem_zero(pEmptyTiles, (size_t)pLayerTiles->m_Width * pLayerTiles->m_Height * sizeof(CTile));
+					new(pEmptyTiles) CTile[(size_t)pLayerTiles->m_Width * pLayerTiles->m_Height]{};
 					Item.m_Data = df.AddData((size_t)pLayerTiles->m_Width * pLayerTiles->m_Height * sizeof(CTile), pEmptyTiles);
 					free(pEmptyTiles);
 

--- a/src/game/editor/layer_tiles.cpp
+++ b/src/game/editor/layer_tiles.cpp
@@ -543,7 +543,7 @@ void CLayerTiles::BrushRotate(float Amount)
 	{
 		// 90° rotation
 		CTile *pTempData = new CTile[m_Width * m_Height];
-		mem_copy(pTempData, m_pTiles, (size_t)m_Width * m_Height * sizeof(CTile));
+		std::copy_n(m_pTiles, m_Width * m_Height, pTempData);
 		CTile *pDst = m_pTiles;
 		bool Rotate = !(m_Game || m_Front) || m_pEditor->m_AllowPlaceUnusedTiles;
 		for(int x = 0; x < m_Width; ++x)
@@ -578,7 +578,7 @@ void CLayerTiles::Resize(int NewW, int NewH)
 
 	// copy old data
 	for(int y = 0; y < minimum(NewH, m_Height); y++)
-		mem_copy(&pNewData[y * NewW], &m_pTiles[y * m_Width], minimum(m_Width, NewW) * sizeof(CTile));
+		std::copy_n(&m_pTiles[y * m_Width], minimum(m_Width, NewW), &pNewData[y * NewW]);
 
 	// replace old
 	delete[] m_pTiles;
@@ -1079,7 +1079,7 @@ void CLayerTele::Resize(int NewW, int NewH)
 
 	// copy old data
 	for(int y = 0; y < minimum(NewH, m_Height); y++)
-		mem_copy(&pNewTeleData[y * NewW], &m_pTeleTile[y * m_Width], minimum(m_Width, NewW) * sizeof(CTeleTile));
+		std::copy_n(&m_pTeleTile[y * m_Width], minimum(m_Width, NewW), &pNewTeleData[y * NewW]);
 
 	// replace old
 	delete[] m_pTeleTile;
@@ -1191,8 +1191,8 @@ void CLayerTele::BrushRotate(float Amount)
 		// 90° rotation
 		CTeleTile *pTempData1 = new CTeleTile[m_Width * m_Height];
 		CTile *pTempData2 = new CTile[m_Width * m_Height];
-		mem_copy(pTempData1, m_pTeleTile, (size_t)m_Width * m_Height * sizeof(CTeleTile));
-		mem_copy(pTempData2, m_pTiles, (size_t)m_Width * m_Height * sizeof(CTile));
+		std::copy_n(m_pTeleTile, m_Width * m_Height, pTempData1);
+		std::copy_n(m_pTiles, m_Width * m_Height, pTempData2);
 		CTeleTile *pDst1 = m_pTeleTile;
 		CTile *pDst2 = m_pTiles;
 		for(int x = 0; x < m_Width; ++x)
@@ -1308,7 +1308,7 @@ void CLayerSpeedup::Resize(int NewW, int NewH)
 
 	// copy old data
 	for(int y = 0; y < minimum(NewH, m_Height); y++)
-		mem_copy(&pNewSpeedupData[y * NewW], &m_pSpeedupTile[y * m_Width], minimum(m_Width, NewW) * sizeof(CSpeedupTile));
+		std::copy_n(&m_pSpeedupTile[y * m_Width], minimum(m_Width, NewW), &pNewSpeedupData[y * NewW]);
 
 	// replace old
 	delete[] m_pSpeedupTile;
@@ -1437,8 +1437,8 @@ void CLayerSpeedup::BrushRotate(float Amount)
 		// 90° rotation
 		CSpeedupTile *pTempData1 = new CSpeedupTile[m_Width * m_Height];
 		CTile *pTempData2 = new CTile[m_Width * m_Height];
-		mem_copy(pTempData1, m_pSpeedupTile, (size_t)m_Width * m_Height * sizeof(CSpeedupTile));
-		mem_copy(pTempData2, m_pTiles, (size_t)m_Width * m_Height * sizeof(CTile));
+		std::copy_n(m_pSpeedupTile, m_Width * m_Height, pTempData1);
+		std::copy_n(m_pTiles, m_Width * m_Height, pTempData2);
 		CSpeedupTile *pDst1 = m_pSpeedupTile;
 		CTile *pDst2 = m_pTiles;
 		for(int x = 0; x < m_Width; ++x)
@@ -1593,7 +1593,7 @@ void CLayerSwitch::Resize(int NewW, int NewH)
 
 	// copy old data
 	for(int y = 0; y < minimum(NewH, m_Height); y++)
-		mem_copy(&pNewSwitchData[y * NewW], &m_pSwitchTile[y * m_Width], minimum(m_Width, NewW) * sizeof(CSwitchTile));
+		std::copy_n(&m_pSwitchTile[y * m_Width], minimum(m_Width, NewW), &pNewSwitchData[y * NewW]);
 
 	// replace old
 	delete[] m_pSwitchTile;
@@ -1719,8 +1719,8 @@ void CLayerSwitch::BrushRotate(float Amount)
 		// 90° rotation
 		CSwitchTile *pTempData1 = new CSwitchTile[m_Width * m_Height];
 		CTile *pTempData2 = new CTile[m_Width * m_Height];
-		mem_copy(pTempData1, m_pSwitchTile, (size_t)m_Width * m_Height * sizeof(CSwitchTile));
-		mem_copy(pTempData2, m_pTiles, (size_t)m_Width * m_Height * sizeof(CTile));
+		std::copy_n(m_pSwitchTile, m_Width * m_Height, pTempData1);
+		std::copy_n(m_pTiles, m_Width * m_Height, pTempData2);
 		CSwitchTile *pDst1 = m_pSwitchTile;
 		CTile *pDst2 = m_pTiles;
 		for(int x = 0; x < m_Width; ++x)
@@ -1850,7 +1850,7 @@ void CLayerTune::Resize(int NewW, int NewH)
 
 	// copy old data
 	for(int y = 0; y < minimum(NewH, m_Height); y++)
-		mem_copy(&pNewTuneData[y * NewW], &m_pTuneTile[y * m_Width], minimum(m_Width, NewW) * sizeof(CTuneTile));
+		std::copy_n(&m_pTuneTile[y * m_Width], minimum(m_Width, NewW), &pNewTuneData[y * NewW]);
 
 	// replace old
 	delete[] m_pTuneTile;
@@ -1964,8 +1964,8 @@ void CLayerTune::BrushRotate(float Amount)
 		// 90° rotation
 		CTuneTile *pTempData1 = new CTuneTile[m_Width * m_Height];
 		CTile *pTempData2 = new CTile[m_Width * m_Height];
-		mem_copy(pTempData1, m_pTuneTile, (size_t)m_Width * m_Height * sizeof(CTuneTile));
-		mem_copy(pTempData2, m_pTiles, (size_t)m_Width * m_Height * sizeof(CTile));
+		std::copy_n(m_pTuneTile, m_Width * m_Height, pTempData1);
+		std::copy_n(m_pTiles, m_Width * m_Height, pTempData2);
 		CTuneTile *pDst1 = m_pTuneTile;
 		CTile *pDst2 = m_pTiles;
 		for(int x = 0; x < m_Width; ++x)

--- a/src/game/editor/layer_tiles.cpp
+++ b/src/game/editor/layer_tiles.cpp
@@ -36,8 +36,7 @@ CLayerTiles::CLayerTiles(int w, int h)
 	m_Seed = 0;
 	m_AutoAutoMap = false;
 
-	m_pTiles = new CTile[m_Width * m_Height];
-	mem_zero(m_pTiles, (size_t)m_Width * m_Height * sizeof(CTile));
+	m_pTiles = new CTile[m_Width * m_Height]{};
 }
 
 CLayerTiles::~CLayerTiles()
@@ -573,8 +572,7 @@ void CLayerTiles::BrushRotate(float Amount)
 
 void CLayerTiles::Resize(int NewW, int NewH)
 {
-	CTile *pNewData = new CTile[NewW * NewH];
-	mem_zero(pNewData, (size_t)NewW * NewH * sizeof(CTile));
+	CTile *pNewData = new CTile[NewW * NewH]{};
 
 	// copy old data
 	for(int y = 0; y < minimum(NewH, m_Height); y++)
@@ -1062,8 +1060,7 @@ CLayerTele::CLayerTele(int w, int h) :
 	str_copy(m_aName, "Tele", sizeof(m_aName));
 	m_Tele = 1;
 
-	m_pTeleTile = new CTeleTile[w * h];
-	mem_zero(m_pTeleTile, (size_t)w * h * sizeof(CTeleTile));
+	m_pTeleTile = new CTeleTile[w * h]{};
 }
 
 CLayerTele::~CLayerTele()
@@ -1074,8 +1071,7 @@ CLayerTele::~CLayerTele()
 void CLayerTele::Resize(int NewW, int NewH)
 {
 	// resize tele data
-	CTeleTile *pNewTeleData = new CTeleTile[NewW * NewH];
-	mem_zero(pNewTeleData, (size_t)NewW * NewH * sizeof(CTeleTile));
+	CTeleTile *pNewTeleData = new CTeleTile[NewW * NewH]{};
 
 	// copy old data
 	for(int y = 0; y < minimum(NewH, m_Height); y++)
@@ -1189,8 +1185,8 @@ void CLayerTele::BrushRotate(float Amount)
 	if(Rotation == 1 || Rotation == 3)
 	{
 		// 90° rotation
-		CTeleTile *pTempData1 = new CTeleTile[m_Width * m_Height];
-		CTile *pTempData2 = new CTile[m_Width * m_Height];
+		CTeleTile *pTempData1 = new CTeleTile[m_Width * m_Height]{};
+		CTile *pTempData2 = new CTile[m_Width * m_Height]{};
 		std::copy_n(m_pTeleTile, m_Width * m_Height, pTempData1);
 		std::copy_n(m_pTiles, m_Width * m_Height, pTempData2);
 		CTeleTile *pDst1 = m_pTeleTile;
@@ -1291,8 +1287,7 @@ CLayerSpeedup::CLayerSpeedup(int w, int h) :
 	str_copy(m_aName, "Speedup", sizeof(m_aName));
 	m_Speedup = 1;
 
-	m_pSpeedupTile = new CSpeedupTile[w * h];
-	mem_zero(m_pSpeedupTile, (size_t)w * h * sizeof(CSpeedupTile));
+	m_pSpeedupTile = new CSpeedupTile[w * h]{};
 }
 
 CLayerSpeedup::~CLayerSpeedup()
@@ -1303,8 +1298,7 @@ CLayerSpeedup::~CLayerSpeedup()
 void CLayerSpeedup::Resize(int NewW, int NewH)
 {
 	// resize speedup data
-	CSpeedupTile *pNewSpeedupData = new CSpeedupTile[NewW * NewH];
-	mem_zero(pNewSpeedupData, (size_t)NewW * NewH * sizeof(CSpeedupTile));
+	CSpeedupTile *pNewSpeedupData = new CSpeedupTile[NewW * NewH]{};
 
 	// copy old data
 	for(int y = 0; y < minimum(NewH, m_Height); y++)
@@ -1576,8 +1570,7 @@ CLayerSwitch::CLayerSwitch(int w, int h) :
 	str_copy(m_aName, "Switch", sizeof(m_aName));
 	m_Switch = 1;
 
-	m_pSwitchTile = new CSwitchTile[w * h];
-	mem_zero(m_pSwitchTile, (size_t)w * h * sizeof(CSwitchTile));
+	m_pSwitchTile = new CSwitchTile[w * h]{};
 }
 
 CLayerSwitch::~CLayerSwitch()
@@ -1588,8 +1581,7 @@ CLayerSwitch::~CLayerSwitch()
 void CLayerSwitch::Resize(int NewW, int NewH)
 {
 	// resize switch data
-	CSwitchTile *pNewSwitchData = new CSwitchTile[NewW * NewH];
-	mem_zero(pNewSwitchData, (size_t)NewW * NewH * sizeof(CSwitchTile));
+	CSwitchTile *pNewSwitchData = new CSwitchTile[NewW * NewH]{};
 
 	// copy old data
 	for(int y = 0; y < minimum(NewH, m_Height); y++)
@@ -1833,8 +1825,7 @@ CLayerTune::CLayerTune(int w, int h) :
 	str_copy(m_aName, "Tune", sizeof(m_aName));
 	m_Tune = 1;
 
-	m_pTuneTile = new CTuneTile[w * h];
-	mem_zero(m_pTuneTile, (size_t)w * h * sizeof(CTuneTile));
+	m_pTuneTile = new CTuneTile[w * h]{};
 }
 
 CLayerTune::~CLayerTune()
@@ -1845,8 +1836,7 @@ CLayerTune::~CLayerTune()
 void CLayerTune::Resize(int NewW, int NewH)
 {
 	// resize Tune data
-	CTuneTile *pNewTuneData = new CTuneTile[NewW * NewH];
-	mem_zero(pNewTuneData, (size_t)NewW * NewH * sizeof(CTuneTile));
+	CTuneTile *pNewTuneData = new CTuneTile[NewW * NewH]{};
 
 	// copy old data
 	for(int y = 0; y < minimum(NewH, m_Height); y++)

--- a/src/game/gamecore.h
+++ b/src/game/gamecore.h
@@ -246,7 +246,7 @@ public:
 	} m_aWeapons[NUM_WEAPONS];
 
 	// ninja
-	struct
+	struct SNinja
 	{
 		vec2 m_ActivationDir;
 		int m_ActivationTick;

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -66,7 +66,7 @@ bool CCharacter::Spawn(CPlayer *pPlayer, vec2 Pos)
 	m_pPlayer = pPlayer;
 	m_Pos = Pos;
 
-	mem_zero(&m_LatestPrevPrevInput, sizeof(m_LatestPrevPrevInput));
+	m_LatestPrevPrevInput = CNetObj_PlayerInput();
 	m_LatestPrevPrevInput.m_TargetY = -1;
 	m_NumInputs = 0;
 	m_SpawnTick = Server()->Tick();
@@ -846,10 +846,8 @@ void CCharacter::TickDefered()
 
 	// update the m_SendCore if needed
 	{
-		CNetObj_Character Predicted;
-		CNetObj_Character Current;
-		mem_zero(&Predicted, sizeof(Predicted));
-		mem_zero(&Current, sizeof(Current));
+		CNetObj_Character Predicted{};
+		CNetObj_Character Current{};
 		m_ReckoningCore.Write(&Predicted);
 		m_Core.Write(&Current);
 

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -854,7 +854,7 @@ void CCharacter::TickDefered()
 		m_Core.Write(&Current);
 
 		// only allow dead reackoning for a top of 3 seconds
-		if(m_Core.m_Reset || m_ReckoningTick + Server()->TickSpeed() * 3 < Server()->Tick() || mem_comp(&Predicted, &Current, sizeof(CNetObj_Character)) != 0)
+		if(m_Core.m_Reset || m_ReckoningTick + Server()->TickSpeed() * 3 < Server()->Tick() || Predicted != Current)
 		{
 			m_ReckoningTick = Server()->Tick();
 			m_SendCore = m_Core;

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -662,19 +662,19 @@ void CCharacter::OnPredictedInput(CNetObj_PlayerInput *pNewInput)
 		m_LastAction = Server()->Tick();
 
 	// copy new input
-	mem_copy(&m_Input, pNewInput, sizeof(m_Input));
+	m_Input = *pNewInput;
 
 	// it is not allowed to aim in the center
 	if(m_Input.m_TargetX == 0 && m_Input.m_TargetY == 0)
 		m_Input.m_TargetY = -1;
 
-	mem_copy(&m_SavedInput, &m_Input, sizeof(m_SavedInput));
+	m_SavedInput = m_Input;
 }
 
 void CCharacter::OnDirectInput(CNetObj_PlayerInput *pNewInput)
 {
-	mem_copy(&m_LatestPrevInput, &m_LatestInput, sizeof(m_LatestInput));
-	mem_copy(&m_LatestInput, pNewInput, sizeof(m_LatestInput));
+	m_LatestPrevInput = m_LatestInput;
+	m_LatestInput = *pNewInput;
 	m_NumInputs++;
 
 	// it is not allowed to aim in the center
@@ -689,8 +689,8 @@ void CCharacter::OnDirectInput(CNetObj_PlayerInput *pNewInput)
 		FireWeapon();
 	}
 
-	mem_copy(&m_LatestPrevPrevInput, &m_LatestPrevInput, sizeof(m_LatestInput));
-	mem_copy(&m_LatestPrevInput, &m_LatestInput, sizeof(m_LatestInput));
+	m_LatestPrevPrevInput = m_LatestPrevInput;
+	m_LatestPrevInput = m_LatestInput;
 }
 
 void CCharacter::ResetHook()
@@ -1988,7 +1988,7 @@ void CCharacter::SetRescue()
 
 void CCharacter::DDRaceTick()
 {
-	mem_copy(&m_Input, &m_SavedInput, sizeof(m_Input));
+	m_Input = m_SavedInput;
 	m_Armor = (m_FreezeTime >= 0) ? clamp(10 - (m_FreezeTime / 15), 0, 10) : 0;
 	if(m_Input.m_Direction != 0 || m_Input.m_Jump != 0)
 		m_LastMove = Server()->Tick();

--- a/src/game/server/entities/dragger.cpp
+++ b/src/game/server/entities/dragger.cpp
@@ -61,8 +61,7 @@ void CDragger::Tick()
 void CDragger::LookForPlayersToDrag()
 {
 	// Create a list of players who are in the range of the dragger
-	CCharacter *apPlayersInRange[MAX_CLIENTS];
-	mem_zero(apPlayersInRange, sizeof(apPlayersInRange));
+	CCharacter *apPlayersInRange[MAX_CLIENTS] = {nullptr};
 
 	int NumPlayersInRange = GameServer()->m_World.FindEntities(m_Pos,
 		g_Config.m_SvDraggerRange - CCharacterCore::PhysicalSize(),
@@ -70,12 +69,9 @@ void CDragger::LookForPlayersToDrag()
 
 	// The closest player (within range) in a team is selected as the target
 	int aClosestTargetIdInTeam[MAX_CLIENTS];
-	bool aCanStillBeTeamTarget[MAX_CLIENTS];
-	bool aIsTarget[MAX_CLIENTS];
-	int aMinDistInTeam[MAX_CLIENTS];
-	mem_zero(aCanStillBeTeamTarget, sizeof(aCanStillBeTeamTarget));
-	mem_zero(aMinDistInTeam, sizeof(aMinDistInTeam));
-	mem_zero(aIsTarget, sizeof(aIsTarget));
+	bool aCanStillBeTeamTarget[MAX_CLIENTS] = {false};
+	bool aIsTarget[MAX_CLIENTS] = {false};
+	int aMinDistInTeam[MAX_CLIENTS] = {0};
 	for(int &TargetId : aClosestTargetIdInTeam)
 	{
 		TargetId = -1;

--- a/src/game/server/entities/gun.cpp
+++ b/src/game/server/entities/gun.cpp
@@ -59,10 +59,8 @@ void CGun::Fire()
 
 	// The closest player (within range) in a team is selected as the target
 	int aTargetIdInTeam[MAX_CLIENTS];
-	bool aIsTarget[MAX_CLIENTS];
-	int aMinDistInTeam[MAX_CLIENTS];
-	mem_zero(aMinDistInTeam, sizeof(aMinDistInTeam));
-	mem_zero(aIsTarget, sizeof(aIsTarget));
+	bool aIsTarget[MAX_CLIENTS] = {false};
+	int aMinDistInTeam[MAX_CLIENTS] = {0};
 	for(int &TargetId : aTargetIdInTeam)
 	{
 		TargetId = -1;

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -75,7 +75,7 @@ void CGameContext::Construct(int Resetting)
 	for(auto &pPlayer : m_apPlayers)
 		pPlayer = 0;
 
-	mem_zero(&m_aLastPlayerInput, sizeof(m_aLastPlayerInput));
+	new(m_aLastPlayerInput) std::remove_pointer<decltype(m_aLastPlayerInput)>::type{};
 	mem_zero(&m_aPlayerHasInput, sizeof(m_aPlayerHasInput));
 
 	m_pController = 0;
@@ -192,7 +192,7 @@ void CGameContext::FillAntibot(CAntibotRoundData *pData)
 		Collision()->FillAntibot(&pData->m_Map);
 	}
 	pData->m_Tick = Server()->Tick();
-	mem_zero(pData->m_aCharacters, sizeof(pData->m_aCharacters));
+	new(pData->m_aCharacters) std::remove_pointer<decltype(pData->m_aCharacters)>::type{};
 	for(int i = 0; i < MAX_CLIENTS; i++)
 	{
 		CAntibotCharacterData *pChar = &pData->m_aCharacters[i];
@@ -1394,7 +1394,7 @@ void CGameContext::OnClientEnter(int ClientID)
 	Server()->ExpireServerInfo();
 
 	CPlayer *pNewPlayer = m_apPlayers[ClientID];
-	mem_zero(&m_aLastPlayerInput[ClientID], sizeof(m_aLastPlayerInput[ClientID]));
+	m_aLastPlayerInput[ClientID] = CNetObj_PlayerInput();
 	m_aPlayerHasInput[ClientID] = false;
 
 	// new info for others

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -1201,7 +1201,7 @@ void CGameContext::OnClientPredictedEarlyInput(int ClientID, void *pInput)
 		// because this function is called on all inputs, while
 		// `OnClientPredictedInput` is only called on the first input of each
 		// tick.
-		mem_copy(&m_aLastPlayerInput[ClientID], pApplyInput, sizeof(m_aLastPlayerInput[ClientID]));
+		m_aLastPlayerInput[ClientID] = *pApplyInput;
 		m_aPlayerHasInput[ClientID] = true;
 	}
 

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -524,7 +524,7 @@ void CPlayer::OnDirectInput(CNetObj_PlayerInput *pNewInput)
 	// check for activity
 	if(mem_comp(pNewInput, m_pLastTarget, sizeof(CNetObj_PlayerInput)))
 	{
-		mem_copy(m_pLastTarget, pNewInput, sizeof(CNetObj_PlayerInput));
+		*m_pLastTarget = *pNewInput;
 		// Ignore the first direct input and keep the player afk as it is sent automatically
 		if(m_LastTargetInit)
 			UpdatePlaytime();

--- a/src/game/server/scoreworker.cpp
+++ b/src/game/server/scoreworker.cpp
@@ -51,7 +51,7 @@ CTeamrank::CTeamrank() :
 {
 	for(auto &aName : m_aaNames)
 		aName[0] = '\0';
-	mem_zero(&m_TeamID.m_aData, sizeof(m_TeamID));
+	m_TeamID = CUuid();
 }
 
 bool CTeamrank::NextSqlResult(IDbConnection *pSqlServer, bool *pEnd, char *pError, int ErrorSize)

--- a/src/test/teehistorian.cpp
+++ b/src/test/teehistorian.cpp
@@ -30,7 +30,7 @@ protected:
 
 	TeeHistorian()
 	{
-		mem_zero(&m_Config, sizeof(m_Config));
+		m_Config = CConfig();
 #define MACRO_CONFIG_INT(Name, ScriptName, Def, Min, Max, Save, Desc) \
 	m_Config.m_##Name = (Def);
 #define MACRO_CONFIG_COL(Name, ScriptName, Def, Save, Desc) MACRO_CONFIG_INT(Name, ScriptName, Def, 0, 0, Save, Desc)
@@ -50,7 +50,7 @@ protected:
 			0x01, 0x23, 0x45, 0x67, 0x89, 0x01, 0x23, 0x45, 0x67, 0x89,
 			0x01, 0x23}};
 
-		mem_zero(&m_GameInfo, sizeof(m_GameInfo));
+		m_GameInfo = CTeeHistorian::CGameInfo();
 
 		m_GameInfo.m_GameUuid = CalculateUuid("test@ddnet.tw");
 		m_GameInfo.m_pServerVersion = "DDNet test";
@@ -206,8 +206,7 @@ protected:
 	}
 	void Player(int ClientID, int x, int y)
 	{
-		CNetObj_CharacterCore Char;
-		mem_zero(&Char, sizeof(Char));
+		CNetObj_CharacterCore Char{};
 		Char.m_X = x;
 		Char.m_Y = y;
 		m_TH.RecordPlayer(ClientID, &Char);

--- a/src/tools/stun.cpp
+++ b/src/tools/stun.cpp
@@ -22,8 +22,7 @@ int main(int argc, const char **argv)
 	}
 
 	net_init();
-	NETADDR BindAddr;
-	mem_zero(&BindAddr, sizeof(BindAddr));
+	NETADDR BindAddr{};
 	BindAddr.type = NETTYPE_ALL;
 	NETSOCKET Socket = net_udp_create(BindAddr);
 	if(net_socket_type(Socket) == NETTYPE_INVALID)

--- a/src/tools/twping.cpp
+++ b/src/tools/twping.cpp
@@ -10,8 +10,7 @@ static CNetClient g_NetOp; // main
 int main(int argc, const char **argv)
 {
 	CCmdlineFix CmdlineFix(&argc, &argv);
-	NETADDR BindAddr;
-	mem_zero(&BindAddr, sizeof(BindAddr));
+	NETADDR BindAddr{};
 	BindAddr.type = NETTYPE_ALL;
 	g_NetOp.Open(BindAddr);
 


### PR DESCRIPTION
This adds more type safety into the code. Generated code should be similar with no performance impacts. Fixes https://github.com/ddnet/ddnet/issues/5228.

I kept mem_zero and mem_copy on default language type.

Reference:
https://en.cppreference.com/w/cpp/algorithm/copy (allow overlap if dest starts left of source)
https://en.cppreference.com/w/cpp/algorithm/copy_n (no overlap allowed)
https://en.cppreference.com/w/cpp/algorithm/copy_backward (allow overlap if dest ends right of source)

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
