### PR TITLE
Refactor `GetClientVersion`, remove many `version.h` includes, fix potential use of undefined value

### DIFF
--- a/src/engine/server.h
+++ b/src/engine/server.h
@@ -56,7 +56,7 @@ public:
 	virtual int ClientCountry(int ClientID) const = 0;
 	virtual bool ClientIngame(int ClientID) const = 0;
 	virtual bool ClientAuthed(int ClientID) const = 0;
-	virtual int GetClientInfo(int ClientID, CClientInfo *pInfo) const = 0;
+	virtual bool GetClientInfo(int ClientID, CClientInfo *pInfo) const = 0;
 	virtual void SetClientDDNetVersion(int ClientID, int DDNetVersion) = 0;
 	virtual void GetClientAddr(int ClientID, char *pAddrStr, int Size) const = 0;
 

--- a/src/engine/server.h
+++ b/src/engine/server.h
@@ -14,7 +14,6 @@
 #include <game/generated/protocol.h>
 #include <game/generated/protocol7.h>
 #include <game/generated/protocolglue.h>
-#include <game/version.h>
 
 struct CAntibotRoundData;
 
@@ -61,6 +60,7 @@ public:
 	virtual void SetClientDDNetVersion(int ClientID, int DDNetVersion) = 0;
 	virtual void GetClientAddr(int ClientID, char *pAddrStr, int Size) const = 0;
 
+	virtual int GetClientVersion(int ClientID) const = 0;
 	virtual int SendMsg(CMsgPacker *pMsg, int Flags, int ClientID) = 0;
 
 	template<class T, typename std::enable_if<!protocol7::is_sixup<T>::value, int>::type = 0>
@@ -157,19 +157,11 @@ public:
 		return SendMsg(&Packer, Flags, ClientID);
 	}
 
-	int GetClientVersion(int ClientID) const
-	{
-		CClientInfo Info;
-		GetClientInfo(ClientID, &Info);
-		return Info.m_DDNetVersion;
-	}
-
 	bool Translate(int &Target, int Client)
 	{
 		if(IsSixup(Client))
 			return true;
-		int ClientVersion = Client != SERVER_DEMO_CLIENT ? GetClientVersion(Client) : CLIENT_VERSIONNR;
-		if(ClientVersion >= VERSION_DDNET_OLD)
+		if(GetClientVersion(Client) >= VERSION_DDNET_OLD)
 			return true;
 		int *pMap = GetIdMap(Client);
 		bool Found = false;
@@ -189,8 +181,7 @@ public:
 	{
 		if(IsSixup(Client))
 			return true;
-		int ClientVersion = Client != SERVER_DEMO_CLIENT ? GetClientVersion(Client) : CLIENT_VERSIONNR;
-		if(ClientVersion >= VERSION_DDNET_OLD)
+		if(GetClientVersion(Client) >= VERSION_DDNET_OLD)
 			return true;
 		Target = clamp(Target, 0, VANILLA_MAX_CLIENTS - 1);
 		int *pMap = GetIdMap(Client);

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -779,6 +779,17 @@ int CServer::DistinctClientCount() const
 	return ClientCount;
 }
 
+int CServer::GetClientVersion(int ClientID) const
+{
+	// Assume latest client version for server demos
+	if(ClientID == SERVER_DEMO_CLIENT)
+		return CLIENT_VERSIONNR;
+
+	CClientInfo Info;
+	GetClientInfo(ClientID, &Info);
+	return Info.m_DDNetVersion;
+}
+
 static inline bool RepackMsg(const CMsgPacker *pMsg, CPacker &Packer, bool Sixup)
 {
 	int MsgId = pMsg->m_MsgID;

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -641,7 +641,7 @@ const char *CServer::GetAuthName(int ClientID) const
 	return m_AuthManager.KeyIdent(Key);
 }
 
-int CServer::GetClientInfo(int ClientID, CClientInfo *pInfo) const
+bool CServer::GetClientInfo(int ClientID, CClientInfo *pInfo) const
 {
 	dbg_assert(ClientID >= 0 && ClientID < MAX_CLIENTS, "client_id is not valid");
 	dbg_assert(pInfo != 0, "info can not be null");
@@ -662,9 +662,9 @@ int CServer::GetClientInfo(int ClientID, CClientInfo *pInfo) const
 			pInfo->m_pConnectionID = 0;
 			pInfo->m_pDDNetVersionStr = 0;
 		}
-		return 1;
+		return true;
 	}
-	return 0;
+	return false;
 }
 
 void CServer::SetClientDDNetVersion(int ClientID, int DDNetVersion)
@@ -786,8 +786,9 @@ int CServer::GetClientVersion(int ClientID) const
 		return CLIENT_VERSIONNR;
 
 	CClientInfo Info;
-	GetClientInfo(ClientID, &Info);
-	return Info.m_DDNetVersion;
+	if(GetClientInfo(ClientID, &Info))
+		return Info.m_DDNetVersion;
+	return VERSION_NONE;
 }
 
 static inline bool RepackMsg(const CMsgPacker *pMsg, CPacker &Packer, bool Sixup)

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -643,8 +643,8 @@ const char *CServer::GetAuthName(int ClientID) const
 
 bool CServer::GetClientInfo(int ClientID, CClientInfo *pInfo) const
 {
-	dbg_assert(ClientID >= 0 && ClientID < MAX_CLIENTS, "client_id is not valid");
-	dbg_assert(pInfo != 0, "info can not be null");
+	dbg_assert(ClientID >= 0 && ClientID < MAX_CLIENTS, "ClientID is not valid");
+	dbg_assert(pInfo != nullptr, "pInfo cannot be null");
 
 	if(m_aClients[ClientID].m_State == CClient::STATE_INGAME)
 	{
@@ -659,8 +659,8 @@ bool CServer::GetClientInfo(int ClientID, CClientInfo *pInfo) const
 		}
 		else
 		{
-			pInfo->m_pConnectionID = 0;
-			pInfo->m_pDDNetVersionStr = 0;
+			pInfo->m_pConnectionID = nullptr;
+			pInfo->m_pDDNetVersionStr = nullptr;
 		}
 		return true;
 	}
@@ -669,7 +669,7 @@ bool CServer::GetClientInfo(int ClientID, CClientInfo *pInfo) const
 
 void CServer::SetClientDDNetVersion(int ClientID, int DDNetVersion)
 {
-	dbg_assert(ClientID >= 0 && ClientID < MAX_CLIENTS, "client_id is not valid");
+	dbg_assert(ClientID >= 0 && ClientID < MAX_CLIENTS, "ClientID is not valid");
 
 	if(m_aClients[ClientID].m_State == CClient::STATE_INGAME)
 	{

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -300,7 +300,7 @@ public:
 	int GetAuthedState(int ClientID) const override;
 	const char *GetAuthName(int ClientID) const override;
 	void GetMapInfo(char *pMapName, int MapNameSize, int *pMapSize, SHA256_DIGEST *pMapSha256, int *pMapCrc) override;
-	int GetClientInfo(int ClientID, CClientInfo *pInfo) const override;
+	bool GetClientInfo(int ClientID, CClientInfo *pInfo) const override;
 	void SetClientDDNetVersion(int ClientID, int DDNetVersion) override;
 	void GetClientAddr(int ClientID, char *pAddrStr, int Size) const override;
 	const char *ClientName(int ClientID) const override;

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -313,6 +313,7 @@ public:
 	int ClientCount() const override;
 	int DistinctClientCount() const override;
 
+	int GetClientVersion(int ClientID) const override;
 	int SendMsg(CMsgPacker *pMsg, int Flags, int ClientID) override;
 
 	void DoSnapshot();

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -1,21 +1,21 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
-#include <antibot/antibot_data.h>
-
-#include <engine/antibot.h>
-
-#include <engine/shared/config.h>
-#include <game/generated/server_data.h>
-#include <game/mapitems.h>
-#include <game/server/gamecontext.h>
-#include <game/server/gamecontroller.h>
-#include <game/server/player.h>
-
 #include "character.h"
-#include "game/generated/protocol.h"
 #include "laser.h"
 #include "projectile.h"
 
+#include <antibot/antibot_data.h>
+
+#include <engine/antibot.h>
+#include <engine/shared/config.h>
+
+#include <game/generated/protocol.h>
+#include <game/generated/server_data.h>
+#include <game/mapitems.h>
+
+#include <game/server/gamecontext.h>
+#include <game/server/gamecontroller.h>
+#include <game/server/player.h>
 #include <game/server/score.h>
 #include <game/server/teams.h>
 
@@ -948,9 +948,7 @@ bool CCharacter::TakeDamage(vec2 Force, int Dmg, int From, int Weapon)
 //TODO: Move the emote stuff to a function
 void CCharacter::SnapCharacter(int SnappingClient, int ID)
 {
-	int SnappingClientVersion = SnappingClient != SERVER_DEMO_CLIENT ?
-					    GameServer()->GetClientVersion(SnappingClient) :
-					    CLIENT_VERSIONNR;
+	int SnappingClientVersion = GameServer()->GetClientVersion(SnappingClient);
 	CCharacterCore *pCore;
 	int Tick, Emote = m_EmoteType, Weapon = m_Core.m_ActiveWeapon, AmmoCount = 0,
 		  Health = 0, Armor = 0;

--- a/src/game/server/entities/door.cpp
+++ b/src/game/server/entities/door.cpp
@@ -5,7 +5,6 @@
 #include <game/generated/protocol.h>
 #include <game/mapitems.h>
 #include <game/teamscore.h>
-#include <game/version.h>
 
 #include <game/server/gamecontext.h>
 #include <game/server/player.h>
@@ -55,7 +54,7 @@ void CDoor::Snap(int SnappingClient)
 	pObj->m_X = (int)m_Pos.x;
 	pObj->m_Y = (int)m_Pos.y;
 
-	int SnappingClientVersion = SnappingClient != SERVER_DEMO_CLIENT ? GameServer()->GetClientVersion(SnappingClient) : CLIENT_VERSIONNR;
+	int SnappingClientVersion = GameServer()->GetClientVersion(SnappingClient);
 
 	CNetObj_EntityEx *pEntData = 0;
 	if(SnappingClientVersion >= VERSION_DDNET_SWITCH)

--- a/src/game/server/entities/dragger.cpp
+++ b/src/game/server/entities/dragger.cpp
@@ -8,7 +8,6 @@
 
 #include <game/generated/protocol.h>
 #include <game/mapitems.h>
-#include <game/version.h>
 
 #include <game/server/gamecontext.h>
 #include <game/server/player.h>
@@ -185,9 +184,7 @@ void CDragger::Snap(int SnappingClient)
 		}
 	}
 
-	int SnappingClientVersion = SnappingClient != SERVER_DEMO_CLIENT ?
-					    GameServer()->GetClientVersion(SnappingClient) :
-					    CLIENT_VERSIONNR;
+	int SnappingClientVersion = GameServer()->GetClientVersion(SnappingClient);
 
 	CNetObj_EntityEx *pEntData = 0;
 	if(SnappingClientVersion >= VERSION_DDNET_SWITCH)

--- a/src/game/server/entities/gun.cpp
+++ b/src/game/server/entities/gun.cpp
@@ -8,7 +8,6 @@
 
 #include <game/generated/protocol.h>
 #include <game/mapitems.h>
-#include <game/version.h>
 
 #include <game/server/gamecontext.h>
 #include <game/server/player.h>
@@ -148,9 +147,7 @@ void CGun::Snap(int SnappingClient)
 	if(NetworkClipped(SnappingClient))
 		return;
 
-	int SnappingClientVersion = SnappingClient != SERVER_DEMO_CLIENT ?
-					    GameServer()->GetClientVersion(SnappingClient) :
-					    CLIENT_VERSIONNR;
+	int SnappingClientVersion = GameServer()->GetClientVersion(SnappingClient);
 
 	CNetObj_EntityEx *pEntData = 0;
 	if(SnappingClientVersion >= VERSION_DDNET_SWITCH)

--- a/src/game/server/entities/light.cpp
+++ b/src/game/server/entities/light.cpp
@@ -7,7 +7,6 @@
 #include <game/generated/protocol.h>
 #include <game/mapitems.h>
 #include <game/teamscore.h>
-#include <game/version.h>
 
 #include <game/server/gamecontext.h>
 #include <game/server/player.h>
@@ -106,7 +105,7 @@ void CLight::Snap(int SnappingClient)
 	if(NetworkClipped(SnappingClient, m_Pos) && NetworkClipped(SnappingClient, m_To))
 		return;
 
-	int SnappingClientVersion = SnappingClient != SERVER_DEMO_CLIENT ? GameServer()->GetClientVersion(SnappingClient) : CLIENT_VERSIONNR;
+	int SnappingClientVersion = GameServer()->GetClientVersion(SnappingClient);
 
 	CNetObj_EntityEx *pEntData = 0;
 	if(SnappingClientVersion >= VERSION_DDNET_SWITCH && (m_Layer == LAYER_SWITCH || length(m_Core) > 0))

--- a/src/game/server/entities/pickup.cpp
+++ b/src/game/server/entities/pickup.cpp
@@ -6,7 +6,6 @@
 #include <game/generated/protocol.h>
 #include <game/mapitems.h>
 #include <game/teamscore.h>
-#include <game/version.h>
 
 #include <game/server/gamecontext.h>
 #include <game/server/player.h>
@@ -174,7 +173,7 @@ void CPickup::Snap(int SnappingClient)
 	if(SnappingClient != SERVER_DEMO_CLIENT && (GameServer()->m_apPlayers[SnappingClient]->GetTeam() == TEAM_SPECTATORS || GameServer()->m_apPlayers[SnappingClient]->IsPaused()) && GameServer()->m_apPlayers[SnappingClient]->m_SpectatorID != SPEC_FREEVIEW)
 		pChar = GameServer()->GetPlayerChar(GameServer()->m_apPlayers[SnappingClient]->m_SpectatorID);
 
-	int SnappingClientVersion = SnappingClient != SERVER_DEMO_CLIENT ? GameServer()->GetClientVersion(SnappingClient) : CLIENT_VERSIONNR;
+	int SnappingClientVersion = GameServer()->GetClientVersion(SnappingClient);
 
 	CNetObj_EntityEx *pEntData = 0;
 	if(SnappingClientVersion >= VERSION_DDNET_SWITCH && (m_Layer == LAYER_SWITCH || length(m_Core) > 0))

--- a/src/game/server/entities/projectile.cpp
+++ b/src/game/server/entities/projectile.cpp
@@ -7,7 +7,6 @@
 
 #include <game/generated/protocol.h>
 #include <game/mapitems.h>
-#include <game/version.h>
 
 #include <game/server/gamecontext.h>
 #include <game/server/gamemodes/DDRace.h>
@@ -317,7 +316,7 @@ void CProjectile::Snap(int SnappingClient)
 		pEntData->m_EntityClass = ENTITYCLASS_PROJECTILE;
 	}
 
-	int SnappingClientVersion = SnappingClient != SERVER_DEMO_CLIENT ? GameServer()->GetClientVersion(SnappingClient) : CLIENT_VERSIONNR;
+	int SnappingClientVersion = GameServer()->GetClientVersion(SnappingClient);
 	if(SnappingClientVersion < VERSION_DDNET_SWITCH)
 	{
 		CCharacter *pSnapChar = GameServer()->GetPlayerChar(SnappingClient);

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -1365,8 +1365,7 @@ void CGameContext::OnClientEnter(int ClientID)
 	}
 
 	IServer::CClientInfo Info;
-	Server()->GetClientInfo(ClientID, &Info);
-	if(Info.m_GotDDNetVersion)
+	if(Server()->GetClientInfo(ClientID, &Info) && Info.m_GotDDNetVersion)
 	{
 		if(OnClientDDNetVersionKnown(ClientID))
 			return; // kicked
@@ -1574,7 +1573,7 @@ void CGameContext::OnClientEngineDrop(int ClientID, const char *pReason)
 bool CGameContext::OnClientDDNetVersionKnown(int ClientID)
 {
 	IServer::CClientInfo Info;
-	Server()->GetClientInfo(ClientID, &Info);
+	dbg_assert(Server()->GetClientInfo(ClientID, &Info), "failed to get client info");
 	int ClientVersion = Info.m_DDNetVersion;
 	dbg_msg("ddnet", "cid=%d version=%d", ClientID, ClientVersion);
 
@@ -2258,8 +2257,7 @@ void CGameContext::OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID)
 		else if(MsgID == NETMSGTYPE_CL_ISDDNETLEGACY)
 		{
 			IServer::CClientInfo Info;
-			Server()->GetClientInfo(ClientID, &Info);
-			if(Info.m_GotDDNetVersion)
+			if(Server()->GetClientInfo(ClientID, &Info) && Info.m_GotDDNetVersion)
 			{
 				return;
 			}

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -4119,9 +4119,7 @@ void CGameContext::List(int ClientID, const char *pFilter)
 
 int CGameContext::GetClientVersion(int ClientID) const
 {
-	IServer::CClientInfo Info = {0};
-	Server()->GetClientInfo(ClientID, &Info);
-	return Info.m_DDNetVersion;
+	return Server()->GetClientVersion(ClientID);
 }
 
 int64_t CGameContext::ClientsMaskExcludeClientVersionAndHigher(int Version)

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -1,20 +1,19 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include "player.h"
-#include <engine/shared/config.h>
-
-#include <engine/antibot.h>
-#include <engine/server.h>
-
-#include "base/system.h"
 #include "entities/character.h"
 #include "gamecontext.h"
 #include "gamecontroller.h"
 #include "score.h"
 
+#include <base/system.h>
+
+#include <engine/antibot.h>
+#include <engine/server.h>
+#include <engine/shared/config.h>
+
 #include <game/gamecore.h>
 #include <game/teamscore.h>
-#include <game/version.h>
 
 MACRO_ALLOC_POOL_ID_IMPL(CPlayer, MAX_CLIENTS)
 
@@ -336,7 +335,7 @@ void CPlayer::Snap(int SnappingClient)
 	pClientInfo->m_ColorBody = m_TeeInfos.m_ColorBody;
 	pClientInfo->m_ColorFeet = m_TeeInfos.m_ColorFeet;
 
-	int SnappingClientVersion = SnappingClient != SERVER_DEMO_CLIENT ? GameServer()->GetClientVersion(SnappingClient) : CLIENT_VERSIONNR;
+	int SnappingClientVersion = GameServer()->GetClientVersion(SnappingClient);
 	int Latency = SnappingClient == SERVER_DEMO_CLIENT ? m_Latency.m_Min : GameServer()->m_apPlayers[SnappingClient]->m_aCurLatency[m_ClientID];
 	int Score = abs(m_Score) * -1;
 


### PR DESCRIPTION
Some refactoring to reduce duplicate code and to remove includes.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
