### PR TITLE
Fix buffer-overflow in editor on shift-clicking brush

### DIFF
--- a/src/game/editor/layer_tiles.cpp
+++ b/src/game/editor/layer_tiles.cpp
@@ -434,7 +434,7 @@ void CLayerTiles::FillSelection(bool Empty, CLayer *pBrush, CUIRect Rect)
 				continue;
 
 			bool HasTile = GetTile(fx, fy).m_Index;
-			if(!Empty && pLt->GetTile(x, y).m_Index == TILE_THROUGH_CUT)
+			if(!Empty && pLt->GetTile(x % pLt->m_Width, y % pLt->m_Height).m_Index == TILE_THROUGH_CUT)
 			{
 				if(m_Game && m_pEditor->m_Map.m_pFrontLayer)
 				{


### PR DESCRIPTION
1. Open any map, including an empty one.
2. Select a brush, e.g. size 2x2.
3. Shift click to repeat the brush over a larger area, e.g. 10x10.
4. This causes a buffer-overflow / crash with ASAN:

```
=================================================================
==4826==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x6060000f5040 at pc 0x55db7d0aa743 bp 0x7fffe4e191f0 sp 0x7fffe4e191e0
READ of size 4 at 0x6060000f5040 thread T0
    0 0x55db7d0aa742 in CLayerTiles::GetTile(int, int) src/game/editor/layer_tiles.cpp:50
    1 0x55db7d0d23e1 in CLayerTiles::FillSelection(bool, CLayer*, CUIRect) src/game/editor/layer_tiles.cpp:437
    2 0x55db7cf196e9 in CEditor::DoMapEditor(CUIRect) src/game/editor/editor.cpp:2641
    3 0x55db7cfa7755 in CEditor::Render() src/game/editor/editor.cpp:5747
    4 0x55db7cfd2a56 in CEditor::OnRender() src/game/editor/editor.cpp:6437
    5 0x55db7c23e02d in CClient::Run() src/engine/client/client.cpp:3374
    6 0x55db7c2a9f7b in main src/engine/client/client.cpp:4762

0x6060000f5040 is located 0 bytes to the right of 64-byte region [0x6060000f5000,0x6060000f5040)
allocated by thread T0 here:
    0 0x7f9b21db5787 in operator new[](unsigned long) ../../../../src/libsanitizer/asan/asan_new_delete.cc:107
    1 0x55db7d0a9a86 in CLayerTiles::CLayerTiles(int, int) src/game/editor/layer_tiles.cpp:39
    2 0x55db7d0cf0ed in CLayerTiles::BrushGrab(CLayerGroup*, CUIRect) src/game/editor/layer_tiles.cpp:387
    3 0x55db7cf18191 in CEditor::DoMapEditor(CUIRect) src/game/editor/editor.cpp:2612
    4 0x55db7cfa7755 in CEditor::Render() src/game/editor/editor.cpp:5747
    5 0x55db7cfd2a56 in CEditor::OnRender() src/game/editor/editor.cpp:6437
    6 0x55db7c23e02d in CClient::Run() src/engine/client/client.cpp:3374

SUMMARY: AddressSanitizer: heap-buffer-overflow src/game/editor/layer_tiles.cpp:50 in CLayerTiles::GetTile(int, int)
Shadow bytes around the buggy address:
  0x0c0c800169b0: 00 00 00 fa fa fa fa fa 00 00 00 00 00 00 00 fa
  0x0c0c800169c0: fa fa fa fa fd fd fd fd fd fd fd fa fa fa fa fa
  0x0c0c800169d0: fd fd fd fd fd fd fd fa fa fa fa fa fd fd fd fd
  0x0c0c800169e0: fd fd fd fd fa fa fa fa fd fd fd fd fd fd fd fa
  0x0c0c800169f0: fa fa fa fa fd fd fd fd fd fd fd fa fa fa fa fa
=>0x0c0c80016a00: 00 00 00 00 00 00 00 00[fa]fa fa fa fd fd fd fd
  0x0c0c80016a10: fd fd fd fa fa fa fa fa fd fd fd fd fd fd fd fa
  0x0c0c80016a20: fa fa fa fa fd fd fd fd fd fd fd fa fa fa fa fa
  0x0c0c80016a30: fd fd fd fd fd fd fd fa fa fa fa fa fd fd fd fd
  0x0c0c80016a40: fd fd fd fa fa fa fa fa fd fd fd fd fd fd fd fa
  0x0c0c80016a50: fa fa fa fa fd fd fd fd fd fd fd fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==4826==ABORTING
```

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [X] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
