### PR TITLE
Support bezier envelope curves in maps and editor, forward compatiblity for upstream map item changes

### DIFF
--- a/src/base/math.h
+++ b/src/base/math.h
@@ -27,6 +27,20 @@ constexpr inline T mix(const T a, const T b, TB amount)
 	return a + (b - a) * amount;
 }
 
+template<typename T, typename TB>
+inline T bezier(const T p0, const T p1, const T p2, const T p3, TB amount)
+{
+	// De-Casteljau Algorithm
+	const T c10 = mix(p0, p1, amount);
+	const T c11 = mix(p1, p2, amount);
+	const T c12 = mix(p2, p3, amount);
+
+	const T c20 = mix(c10, c11, amount);
+	const T c21 = mix(c11, c12, amount);
+
+	return mix(c20, c21, amount); // c30
+}
+
 inline float random_float()
 {
 	return rand() / (float)(RAND_MAX);

--- a/src/engine/shared/datafile.cpp
+++ b/src/engine/shared/datafile.cpp
@@ -346,6 +346,15 @@ void *CDataFileReader::GetDataSwapped(int Index)
 	return GetDataImpl(Index, 1);
 }
 
+void CDataFileReader::ReplaceData(int Index, char *pData)
+{
+	// make sure the data has been loaded
+	GetDataImpl(Index, 0);
+
+	UnloadData(Index);
+	m_pDataFile->m_ppDataPtrs[Index] = pData;
+}
+
 void CDataFileReader::UnloadData(int Index)
 {
 	if(Index < 0 || Index >= m_pDataFile->m_Header.m_NumRawData)

--- a/src/engine/shared/datafile.h
+++ b/src/engine/shared/datafile.h
@@ -38,7 +38,7 @@ public:
 	void *GetData(int Index);
 	void *GetDataSwapped(int Index); // makes sure that the data is 32bit LE ints when saved
 	int GetDataSize(int Index) const;
-	void ReplaceData(int Index, char *pData);
+	void ReplaceData(int Index, char *pData, size_t Size);
 	void UnloadData(int Index);
 	int NumData() const;
 

--- a/src/engine/shared/datafile.h
+++ b/src/engine/shared/datafile.h
@@ -38,6 +38,7 @@ public:
 	void *GetData(int Index);
 	void *GetDataSwapped(int Index); // makes sure that the data is 32bit LE ints when saved
 	int GetDataSize(int Index) const;
+	void ReplaceData(int Index, char *pData);
 	void UnloadData(int Index);
 	int NumData() const;
 

--- a/src/engine/shared/map.cpp
+++ b/src/engine/shared/map.cpp
@@ -85,9 +85,10 @@ bool CMap::Load(const char *pMapName)
 				CMapItemLayerTilemap *pTilemap = reinterpret_cast<CMapItemLayerTilemap *>(pLayer);
 				if(pTilemap->m_Version >= CMapItemLayerTilemap::TILE_SKIP_MIN_VERSION)
 				{
-					CTile *pTiles = static_cast<CTile *>(malloc((size_t)pTilemap->m_Width * pTilemap->m_Height * sizeof(CTile)));
+					const size_t TilemapSize = (size_t)pTilemap->m_Width * pTilemap->m_Height * sizeof(CTile);
+					CTile *pTiles = static_cast<CTile *>(malloc(TilemapSize));
 					ExtractTiles(pTiles, (size_t)pTilemap->m_Width * pTilemap->m_Height, static_cast<CTile *>(m_DataFile.GetData(pTilemap->m_Data)), m_DataFile.GetDataSize(pTilemap->m_Data) / sizeof(CTile));
-					m_DataFile.ReplaceData(pTilemap->m_Data, reinterpret_cast<char *>(pTiles));
+					m_DataFile.ReplaceData(pTilemap->m_Data, reinterpret_cast<char *>(pTiles), TilemapSize);
 				}
 			}
 		}

--- a/src/engine/shared/map.cpp
+++ b/src/engine/shared/map.cpp
@@ -1,7 +1,10 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include "map.h"
+
 #include <engine/storage.h>
+
+#include <game/mapitems.h>
 
 CMap::CMap() = default;
 
@@ -60,7 +63,14 @@ bool CMap::Load(const char *pMapName)
 	IStorage *pStorage = Kernel()->RequestInterface<IStorage>();
 	if(!pStorage)
 		return false;
-	return m_DataFile.Open(pStorage, pMapName, IStorage::TYPE_ALL);
+	if(!m_DataFile.Open(pStorage, pMapName, IStorage::TYPE_ALL))
+		return false;
+	// check version
+	const CMapItemVersion *pItem = (CMapItemVersion *)m_DataFile.FindItem(MAPITEMTYPE_VERSION, 0);
+	if(!pItem || pItem->m_Version != CMapItemVersion::CURRENT_VERSION)
+		return false;
+
+	return true;
 }
 
 void CMap::Unload()

--- a/src/engine/shared/map.cpp
+++ b/src/engine/shared/map.cpp
@@ -70,6 +70,43 @@ bool CMap::Load(const char *pMapName)
 	if(!pItem || pItem->m_Version != CMapItemVersion::CURRENT_VERSION)
 		return false;
 
+	// replace compressed tile layers with uncompressed ones
+	int GroupsStart, GroupsNum, LayersStart, LayersNum;
+	m_DataFile.GetType(MAPITEMTYPE_GROUP, &GroupsStart, &GroupsNum);
+	m_DataFile.GetType(MAPITEMTYPE_LAYER, &LayersStart, &LayersNum);
+	for(int g = 0; g < GroupsNum; g++)
+	{
+		const CMapItemGroup *pGroup = static_cast<CMapItemGroup *>(m_DataFile.GetItem(GroupsStart + g));
+		for(int l = 0; l < pGroup->m_NumLayers; l++)
+		{
+			CMapItemLayer *pLayer = static_cast<CMapItemLayer *>(m_DataFile.GetItem(LayersStart + pGroup->m_StartLayer + l));
+			if(pLayer->m_Type == LAYERTYPE_TILES)
+			{
+				CMapItemLayerTilemap *pTilemap = reinterpret_cast<CMapItemLayerTilemap *>(pLayer);
+				if(pTilemap->m_Version > 3)
+				{
+					CTile *pTiles = static_cast<CTile *>(malloc(pTilemap->m_Width * pTilemap->m_Height * sizeof(CTile)));
+
+					// extract original tile data
+					int i = 0;
+					CTile *pSavedTiles = static_cast<CTile *>(m_DataFile.GetData(pTilemap->m_Data));
+					while(i < pTilemap->m_Width * pTilemap->m_Height)
+					{
+						for(unsigned Counter = 0; Counter <= pSavedTiles->m_Skip && i < pTilemap->m_Width * pTilemap->m_Height; Counter++)
+						{
+							pTiles[i] = *pSavedTiles;
+							pTiles[i++].m_Skip = 0;
+						}
+
+						pSavedTiles++;
+					}
+
+					m_DataFile.ReplaceData(pTilemap->m_Data, reinterpret_cast<char *>(pTiles));
+				}
+			}
+		}
+	}
+
 	return true;
 }
 

--- a/src/engine/shared/map.h
+++ b/src/engine/shared/map.h
@@ -15,6 +15,8 @@ class CMap : public IEngineMap
 public:
 	CMap();
 
+	CDataFileReader *GetReader() { return &m_DataFile; }
+
 	void *GetData(int Index) override;
 	int GetDataSize(int Index) const override;
 	void *GetDataSwapped(int Index) override;

--- a/src/engine/shared/map.h
+++ b/src/engine/shared/map.h
@@ -35,6 +35,8 @@ public:
 	SHA256_DIGEST Sha256() const override;
 	unsigned Crc() const override;
 	int MapSize() const override;
+
+	static void ExtractTiles(class CTile *pDest, size_t DestSize, const class CTile *pSrc, size_t SrcSize);
 };
 
 #endif

--- a/src/game/client/components/mapimages.cpp
+++ b/src/game/client/components/mapimages.cpp
@@ -105,13 +105,15 @@ void CMapImages::OnMapLoadImpl(class CLayers *pLayers, IMap *pMap)
 	for(int i = 0; i < m_Count; i++)
 	{
 		int LoadFlag = (((m_aTextureUsedByTileOrQuadLayerFlag[i] & 1) != 0) ? TextureLoadFlag : 0) | (((m_aTextureUsedByTileOrQuadLayerFlag[i] & 2) != 0) ? 0 : (Graphics()->IsTileBufferingEnabled() ? IGraphics::TEXLOAD_NO_2D_TEXTURE : 0));
-		CMapItemImage *pImg = (CMapItemImage *)pMap->GetItem(Start + i);
-		if(pImg->m_External)
+		const CMapItemImage_v2 *pImg = (CMapItemImage_v2 *)pMap->GetItem(Start + i);
+		const int Format = pImg->m_Version < CMapItemImage_v2::CURRENT_VERSION ? CImageInfo::FORMAT_RGBA : pImg->m_Format;
+		if(pImg->m_External || (Format != CImageInfo::FORMAT_RGB && Format != CImageInfo::FORMAT_RGBA))
 		{
 			char aPath[IO_MAX_PATH_LENGTH];
 			char *pName = (char *)pMap->GetData(pImg->m_ImageName);
 			str_format(aPath, sizeof(aPath), "mapres/%s.png", pName);
 			m_aTextures[i] = Graphics()->LoadTexture(aPath, IStorage::TYPE_ALL, CImageInfo::FORMAT_AUTO, LoadFlag);
+			pMap->UnloadData(pImg->m_ImageName);
 		}
 		else
 		{
@@ -119,7 +121,8 @@ void CMapImages::OnMapLoadImpl(class CLayers *pLayers, IMap *pMap)
 			char *pName = (char *)pMap->GetData(pImg->m_ImageName);
 			char aTexName[128];
 			str_format(aTexName, sizeof(aTexName), "%s %s", "embedded:", pName);
-			m_aTextures[i] = Graphics()->LoadTextureRaw(pImg->m_Width, pImg->m_Height, CImageInfo::FORMAT_RGBA, pData, CImageInfo::FORMAT_RGBA, LoadFlag, aTexName);
+			m_aTextures[i] = Graphics()->LoadTextureRaw(pImg->m_Width, pImg->m_Height, Format, pData, CImageInfo::FORMAT_RGBA, LoadFlag, aTexName);
+			pMap->UnloadData(pImg->m_ImageName);
 			pMap->UnloadData(pImg->m_ImageData);
 		}
 	}

--- a/src/game/client/components/maplayers.cpp
+++ b/src/game/client/components/maplayers.cpp
@@ -12,6 +12,7 @@
 
 #include <game/layers.h>
 #include <game/mapitems.h>
+#include <game/mapitems_ex.h>
 
 #include <game/client/components/camera.h>
 #include <game/client/components/mapimages.h>
@@ -60,22 +61,15 @@ void CMapLayers::EnvelopeEval(int TimeOffsetMillis, int Env, ColorRGBA &Channels
 	CMapLayers *pThis = (CMapLayers *)pUser;
 	Channels = ColorRGBA();
 
-	CEnvPoint *pPoints = 0;
+	const CMapBasedEnvelopePointAccess EnvelopePoints(pThis->m_pLayers->Map());
 
-	{
-		int Start, Num;
-		pThis->m_pLayers->Map()->GetType(MAPITEMTYPE_ENVPOINTS, &Start, &Num);
-		if(Num)
-			pPoints = (CEnvPoint *)pThis->m_pLayers->Map()->GetItem(Start);
-	}
+	int EnvStart, EnvNum;
+	pThis->m_pLayers->Map()->GetType(MAPITEMTYPE_ENVELOPE, &EnvStart, &EnvNum);
 
-	int Start, Num;
-	pThis->m_pLayers->Map()->GetType(MAPITEMTYPE_ENVELOPE, &Start, &Num);
-
-	if(Env >= Num)
+	if(EnvelopePoints.NumPoints() == 0 || Env < 0 || Env >= EnvNum)
 		return;
 
-	CMapItemEnvelope *pItem = (CMapItemEnvelope *)pThis->m_pLayers->Map()->GetItem(Start + Env);
+	const CMapItemEnvelope *pItem = (CMapItemEnvelope *)pThis->m_pLayers->Map()->GetItem(EnvStart + Env);
 
 	const auto TickToNanoSeconds = std::chrono::nanoseconds(1s) / (int64_t)pThis->Client()->GameTickSpeed();
 
@@ -117,7 +111,7 @@ void CMapLayers::EnvelopeEval(int TimeOffsetMillis, int Env, ColorRGBA &Channels
 					 MinTick * TickToNanoSeconds;
 			}
 		}
-		CRenderTools::RenderEvalEnvelope(pPoints + pItem->m_StartPoint, pItem->m_NumPoints, 4, s_Time + (int64_t)TimeOffsetMillis * std::chrono::nanoseconds(1ms), Channels);
+		CRenderTools::RenderEvalEnvelope(&EnvelopePoints, 4, s_Time + (int64_t)TimeOffsetMillis * std::chrono::nanoseconds(1ms), Channels);
 	}
 	else
 	{
@@ -142,7 +136,7 @@ void CMapLayers::EnvelopeEval(int TimeOffsetMillis, int Env, ColorRGBA &Channels
 			s_Time += CurTime - s_LastLocalTime;
 			s_LastLocalTime = CurTime;
 		}
-		CRenderTools::RenderEvalEnvelope(pPoints + pItem->m_StartPoint, pItem->m_NumPoints, 4, s_Time + std::chrono::nanoseconds(std::chrono::milliseconds(TimeOffsetMillis)), Channels);
+		CRenderTools::RenderEvalEnvelope(&EnvelopePoints, 4, s_Time + std::chrono::nanoseconds(std::chrono::milliseconds(TimeOffsetMillis)), Channels);
 	}
 }
 

--- a/src/game/client/render.h
+++ b/src/game/client/render.h
@@ -20,6 +20,8 @@ struct CDataSprite;
 }
 struct CDataSprite;
 struct CEnvPoint;
+struct CEnvPointBezier;
+struct CEnvPointBezier_upstream;
 struct CMapItemGroup;
 struct CMapItemGroupEx;
 struct CQuad;
@@ -71,6 +73,29 @@ enum
 	TILERENDERFLAG_EXTEND = 4,
 };
 
+class IEnvelopePointAccess
+{
+public:
+	virtual int NumPoints() const = 0;
+	virtual const CEnvPoint *GetPoint(int Index) const = 0;
+	virtual const CEnvPointBezier *GetBezier(int Index) const = 0;
+};
+
+class CMapBasedEnvelopePointAccess : public IEnvelopePointAccess
+{
+	int m_NumPoints;
+	CEnvPoint *m_pPoints;
+	CEnvPointBezier *m_pPointsBezier;
+	CEnvPointBezier_upstream *m_pPointsBezierUpstream;
+
+public:
+	CMapBasedEnvelopePointAccess(class CDataFileReader *pReader);
+	CMapBasedEnvelopePointAccess(class IMap *pMap);
+	int NumPoints() const override;
+	const CEnvPoint *GetPoint(int Index) const override;
+	const CEnvPointBezier *GetBezier(int Index) const override;
+};
+
 typedef void (*ENVELOPE_EVAL)(int TimeOffsetMillis, int Env, ColorRGBA &Channels, void *pUser);
 
 class CRenderTools
@@ -117,7 +142,7 @@ public:
 	void RenderTee(const CAnimState *pAnim, const CTeeRenderInfo *pInfo, int Emote, vec2 Dir, vec2 Pos, float Alpha = 1.0f);
 
 	// map render methods (render_map.cpp)
-	static void RenderEvalEnvelope(CEnvPoint *pPoints, int NumPoints, int Channels, std::chrono::nanoseconds TimeNanos, ColorRGBA &Result);
+	static void RenderEvalEnvelope(const IEnvelopePointAccess *pPoints, int Channels, std::chrono::nanoseconds TimeNanos, ColorRGBA &Result);
 	void RenderQuads(CQuad *pQuads, int NumQuads, int Flags, ENVELOPE_EVAL pfnEval, void *pUser);
 	void ForceRenderQuads(CQuad *pQuads, int NumQuads, int Flags, ENVELOPE_EVAL pfnEval, void *pUser, float Alpha = 1.0f);
 	void RenderTilemap(CTile *pTiles, int w, int h, float Scale, ColorRGBA Color, int RenderFlags, ENVELOPE_EVAL pfnEval, void *pUser, int ColorEnv, int ColorEnvOffset);

--- a/src/game/client/render_map.cpp
+++ b/src/game/client/render_map.cpp
@@ -3,23 +3,225 @@
 #include <base/math.h>
 
 #include <engine/graphics.h>
+#include <engine/map.h>
 #include <engine/textrender.h>
 
 #include <engine/shared/config.h>
+#include <engine/shared/datafile.h>
+#include <engine/shared/map.h>
 
 #include "render.h"
 
 #include <game/generated/client_data.h>
 
 #include <game/mapitems.h>
+#include <game/mapitems_ex.h>
 
 #include <chrono>
 #include <cmath>
 
 using namespace std::chrono_literals;
 
-void CRenderTools::RenderEvalEnvelope(CEnvPoint *pPoints, int NumPoints, int Channels, std::chrono::nanoseconds TimeNanos, ColorRGBA &Result)
+CMapBasedEnvelopePointAccess::CMapBasedEnvelopePointAccess(CDataFileReader *pReader)
 {
+	bool FoundBezierEnvelope = false;
+	int EnvStart, EnvNum;
+	pReader->GetType(MAPITEMTYPE_ENVELOPE, &EnvStart, &EnvNum);
+	for(int EnvIndex = 0; EnvIndex < EnvNum; EnvIndex++)
+	{
+		CMapItemEnvelope *pEnvelope = static_cast<CMapItemEnvelope *>(pReader->GetItem(EnvStart + EnvIndex));
+		if(pEnvelope->m_Version >= CMapItemEnvelope_v3::CURRENT_VERSION)
+		{
+			FoundBezierEnvelope = true;
+			break;
+		}
+	}
+
+	if(FoundBezierEnvelope)
+	{
+		m_pPoints = nullptr;
+		m_pPointsBezier = nullptr;
+
+		int EnvPointStart, FakeEnvPointNum;
+		pReader->GetType(MAPITEMTYPE_ENVPOINTS, &EnvPointStart, &FakeEnvPointNum);
+		if(FakeEnvPointNum > 0)
+			m_pPointsBezierUpstream = static_cast<CEnvPointBezier_upstream *>(pReader->GetItem(EnvPointStart));
+		else
+			m_pPointsBezierUpstream = nullptr;
+
+		m_NumPoints = pReader->GetItemSize(EnvPointStart) / sizeof(CEnvPointBezier_upstream);
+	}
+	else
+	{
+		int EnvPointStart, FakeEnvPointNum;
+		pReader->GetType(MAPITEMTYPE_ENVPOINTS, &EnvPointStart, &FakeEnvPointNum);
+		if(FakeEnvPointNum > 0)
+			m_pPoints = static_cast<CEnvPoint *>(pReader->GetItem(EnvPointStart));
+		else
+			m_pPoints = nullptr;
+
+		m_NumPoints = pReader->GetItemSize(EnvPointStart) / sizeof(CEnvPoint);
+
+		int EnvPointBezierStart, FakeEnvPointBezierNum;
+		pReader->GetType(MAPITEMTYPE_ENVPOINTS_BEZIER, &EnvPointBezierStart, &FakeEnvPointBezierNum);
+		const int NumPointsBezier = pReader->GetItemSize(EnvPointBezierStart) / sizeof(CEnvPointBezier);
+		if(FakeEnvPointBezierNum > 0 && m_NumPoints == NumPointsBezier)
+			m_pPointsBezier = static_cast<CEnvPointBezier *>(pReader->GetItem(EnvPointBezierStart));
+		else
+			m_pPointsBezier = nullptr;
+
+		m_pPointsBezierUpstream = nullptr;
+	}
+}
+
+CMapBasedEnvelopePointAccess::CMapBasedEnvelopePointAccess(IMap *pMap) :
+	CMapBasedEnvelopePointAccess(static_cast<CMap *>(pMap)->GetReader())
+{
+}
+
+int CMapBasedEnvelopePointAccess::NumPoints() const
+{
+	return m_NumPoints;
+}
+
+const CEnvPoint *CMapBasedEnvelopePointAccess::GetPoint(int Index) const
+{
+	if(Index < 0 || Index >= m_NumPoints)
+		return nullptr;
+	if(m_pPoints != nullptr)
+		return &m_pPoints[Index];
+	if(m_pPointsBezierUpstream != nullptr)
+		return &m_pPointsBezierUpstream[Index];
+	return nullptr;
+}
+
+const CEnvPointBezier *CMapBasedEnvelopePointAccess::GetBezier(int Index) const
+{
+	if(Index < 0 || Index >= m_NumPoints)
+		return nullptr;
+	if(m_pPointsBezier != nullptr)
+		return &m_pPointsBezier[Index];
+	if(m_pPointsBezierUpstream != nullptr)
+		return &m_pPointsBezierUpstream[Index].m_Bezier;
+	return nullptr;
+}
+
+static void ValidateFCurve(const vec2 &p0, vec2 &p1, vec2 &p2, const vec2 &p3)
+{
+	// validate the bezier curve
+	p1.x = clamp(p1.x, p0.x, p3.x);
+	p2.x = clamp(p2.x, p0.x, p3.x);
+}
+
+static double CubicRoot(double x)
+{
+	if(x == 0.0)
+		return 0.0;
+	else if(x < 0.0)
+		return -std::exp(std::log(-x) / 3.0);
+	else
+		return std::exp(std::log(x) / 3.0);
+}
+
+static float SolveBezier(float x, float p0, float p1, float p2, float p3)
+{
+	// check for valid f-curve
+	// we only take care of monotonic bezier curves, so there has to be exactly 1 real solution
+	if(!(p0 <= x && x <= p3) || !(p0 <= p1 && p1 <= p3) || !(p0 <= p2 && p2 <= p3))
+		return 0.0f;
+
+	const double x3 = -p0 + 3.0 * p1 - 3.0 * p2 + p3;
+	const double x2 = 3.0 * p0 - 6.0 * p1 + 3.0 * p2;
+	const double x1 = -3.0 * p0 + 3.0 * p1;
+	const double x0 = p0 - x;
+
+	if(x3 == 0.0 && x2 == 0.0)
+	{
+		// linear
+		// a * t + b = 0
+		const double a = x1;
+		const double b = x0;
+
+		if(a == 0.0)
+			return 0.0f;
+		return -b / a;
+	}
+	else if(x3 == 0.0)
+	{
+		// quadratic
+		// t * t + b * t +c = 0
+		const double b = x1 / x2;
+		const double c = x0 / x2;
+
+		if(c == 0.0)
+			return 0.0f;
+
+		const double D = b * b - 4.0 * c;
+		const double SqrtD = std::sqrt(D);
+
+		const double t = (-b + SqrtD) / 2.0;
+
+		if(0.0 <= t && t <= 1.0001f)
+			return t;
+		return (-b - SqrtD) / 2.0;
+	}
+	else
+	{
+		// cubic
+		// t * t * t + a * t * t + b * t * t + c = 0
+		const double a = x2 / x3;
+		const double b = x1 / x3;
+		const double c = x0 / x3;
+
+		// substitute t = y - a / 3
+		const double sub = a / 3.0;
+
+		// depressed form x^3 + px + q = 0
+		// cardano's method
+		const double p = b / 3.0 - a * a / 9.0;
+		const double q = (2.0 * a * a * a / 27.0 - a * b / 3.0 + c) / 2.0;
+
+		const double D = q * q + p * p * p;
+
+		if(D > 0.0)
+		{
+			// only one 'real' solution
+			const double s = std::sqrt(D);
+			return CubicRoot(s - q) - CubicRoot(s + q) - sub;
+		}
+		else if(D == 0.0)
+		{
+			// one single, one double solution or triple solution
+			const double s = CubicRoot(-q);
+			const double t = 2.0 * s - sub;
+
+			if(0.0 <= t && t <= 1.0001f)
+				return t;
+			return (-s - sub);
+		}
+		else
+		{
+			// Casus irreductibilis ... ,_,
+			const double phi = std::acos(-q / std::sqrt(-(p * p * p))) / 3.0;
+			const double s = 2.0 * std::sqrt(-p);
+
+			const double t1 = s * std::cos(phi) - sub;
+
+			if(0.0 <= t1 && t1 <= 1.0001f)
+				return t1;
+
+			const double t2 = -s * std::cos(phi + pi / 3.0) - sub;
+
+			if(0.0 <= t2 && t2 <= 1.0001f)
+				return t2;
+			return -s * std::cos(phi - pi / 3.0) - sub;
+		}
+	}
+}
+
+void CRenderTools::RenderEvalEnvelope(const IEnvelopePointAccess *pPoints, int Channels, std::chrono::nanoseconds TimeNanos, ColorRGBA &Result)
+{
+	const int NumPoints = pPoints->NumPoints();
 	if(NumPoints == 0)
 	{
 		Result = ColorRGBA();
@@ -28,14 +230,16 @@ void CRenderTools::RenderEvalEnvelope(CEnvPoint *pPoints, int NumPoints, int Cha
 
 	if(NumPoints == 1)
 	{
-		Result.r = fx2f(pPoints[0].m_aValues[0]);
-		Result.g = fx2f(pPoints[0].m_aValues[1]);
-		Result.b = fx2f(pPoints[0].m_aValues[2]);
-		Result.a = fx2f(pPoints[0].m_aValues[3]);
+		const CEnvPoint *pFirstPoint = pPoints->GetPoint(0);
+		Result.r = fx2f(pFirstPoint->m_aValues[0]);
+		Result.g = fx2f(pFirstPoint->m_aValues[1]);
+		Result.b = fx2f(pFirstPoint->m_aValues[2]);
+		Result.a = fx2f(pFirstPoint->m_aValues[3]);
 		return;
 	}
 
-	int64_t MaxPointTime = (int64_t)pPoints[NumPoints - 1].m_Time * std::chrono::nanoseconds(1ms).count();
+	const CEnvPoint *pLastPoint = pPoints->GetPoint(NumPoints - 1);
+	const int64_t MaxPointTime = (int64_t)pLastPoint->m_Time * std::chrono::nanoseconds(1ms).count();
 	if(MaxPointTime > 0) // TODO: remove this check when implementing a IO check for maps(in this case broken envelopes)
 		TimeNanos = std::chrono::nanoseconds(TimeNanos.count() % MaxPointTime);
 	else
@@ -44,31 +248,70 @@ void CRenderTools::RenderEvalEnvelope(CEnvPoint *pPoints, int NumPoints, int Cha
 	int TimeMillis = (int)(TimeNanos / std::chrono::nanoseconds(1ms).count()).count();
 	for(int i = 0; i < NumPoints - 1; i++)
 	{
-		if(TimeMillis >= pPoints[i].m_Time && TimeMillis <= pPoints[i + 1].m_Time)
+		const CEnvPoint *pCurrentPoint = pPoints->GetPoint(i);
+		const CEnvPoint *pNextPoint = pPoints->GetPoint(i + 1);
+		if(TimeMillis >= pCurrentPoint->m_Time && TimeMillis <= pNextPoint->m_Time)
 		{
-			float Delta = pPoints[i + 1].m_Time - pPoints[i].m_Time;
-			float a = (float)(((double)TimeNanos.count() / (double)std::chrono::nanoseconds(1ms).count()) - pPoints[i].m_Time) / Delta;
+			const float Delta = pNextPoint->m_Time - pCurrentPoint->m_Time;
+			float a = (float)(((double)TimeNanos.count() / (double)std::chrono::nanoseconds(1ms).count()) - pCurrentPoint->m_Time) / Delta;
 
-			if(pPoints[i].m_Curvetype == CURVETYPE_SMOOTH)
-				a = -2 * a * a * a + 3 * a * a; // second hermite basis
-			else if(pPoints[i].m_Curvetype == CURVETYPE_SLOW)
+			switch(pCurrentPoint->m_Curvetype)
+			{
+			case CURVETYPE_STEP:
+				a = 0.0f;
+				break;
+
+			case CURVETYPE_SLOW:
 				a = a * a * a;
-			else if(pPoints[i].m_Curvetype == CURVETYPE_FAST)
+				break;
+
+			case CURVETYPE_FAST:
+				a = 1.0f - a;
+				a = 1.0f - a * a * a;
+				break;
+
+			case CURVETYPE_SMOOTH:
+				a = -2.0f * a * a * a + 3.0f * a * a; // second hermite basis
+				break;
+
+			case CURVETYPE_BEZIER:
 			{
-				a = 1 - a;
-				a = 1 - a * a * a;
+				const CEnvPointBezier *pCurrentPointBezier = pPoints->GetBezier(i);
+				const CEnvPointBezier *pNextPointBezier = pPoints->GetBezier(i + 1);
+				if(pCurrentPointBezier == nullptr || pNextPointBezier == nullptr)
+					break; // fallback to linear
+				for(int c = 0; c < Channels; c++)
+				{
+					// monotonic 2d cubic bezier curve
+					const vec2 p0 = vec2(pCurrentPoint->m_Time / 1000.0f, fx2f(pCurrentPoint->m_aValues[c]));
+					const vec2 p3 = vec2(pNextPoint->m_Time / 1000.0f, fx2f(pNextPoint->m_aValues[c]));
+
+					const vec2 OutTang = vec2(pCurrentPointBezier->m_aOutTangentDeltaX[c] / 1000.0f, fx2f(pCurrentPointBezier->m_aOutTangentDeltaY[c]));
+					const vec2 InTang = -vec2(pNextPointBezier->m_aInTangentDeltaX[c] / 1000.0f, fx2f(pNextPointBezier->m_aInTangentDeltaY[c]));
+					vec2 p1 = p0 + OutTang;
+					vec2 p2 = p3 - InTang;
+
+					// validate bezier curve
+					ValidateFCurve(p0, p1, p2, p3);
+
+					// solve x(a) = time for a
+					a = clamp(SolveBezier(TimeMillis / 1000.0f, p0.x, p1.x, p2.x, p3.x), 0.0f, 1.0f);
+
+					// value = y(t)
+					Result[c] = bezier(p0.y, p1.y, p2.y, p3.y, a);
+				}
+				return;
 			}
-			else if(pPoints[i].m_Curvetype == CURVETYPE_STEP)
-				a = 0;
-			else
-			{
-				// linear
+
+			case CURVETYPE_LINEAR: [[fallthrough]];
+			default:
+				break;
 			}
 
 			for(int c = 0; c < Channels; c++)
 			{
-				float v0 = fx2f(pPoints[i].m_aValues[c]);
-				float v1 = fx2f(pPoints[i + 1].m_aValues[c]);
+				const float v0 = fx2f(pCurrentPoint->m_aValues[c]);
+				const float v1 = fx2f(pNextPoint->m_aValues[c]);
 				Result[c] = v0 + (v1 - v0) * a;
 			}
 
@@ -76,10 +319,10 @@ void CRenderTools::RenderEvalEnvelope(CEnvPoint *pPoints, int NumPoints, int Cha
 		}
 	}
 
-	Result.r = fx2f(pPoints[NumPoints - 1].m_aValues[0]);
-	Result.g = fx2f(pPoints[NumPoints - 1].m_aValues[1]);
-	Result.b = fx2f(pPoints[NumPoints - 1].m_aValues[2]);
-	Result.a = fx2f(pPoints[NumPoints - 1].m_aValues[3]);
+	Result.r = fx2f(pLastPoint->m_aValues[0]);
+	Result.g = fx2f(pLastPoint->m_aValues[1]);
+	Result.b = fx2f(pLastPoint->m_aValues[2]);
+	Result.a = fx2f(pLastPoint->m_aValues[3]);
 }
 
 static void Rotate(CPoint *pCenter, CPoint *pPoint, float Rotation)

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -45,17 +45,50 @@ enum
 
 class CEnvelope
 {
-public:
+	class CEnvelopePointAccess : public IEnvelopePointAccess
+	{
+		std::vector<CEnvPoint_runtime> *m_pvPoints;
+
+	public:
+		CEnvelopePointAccess(std::vector<CEnvPoint_runtime> *pvPoints)
+		{
+			m_pvPoints = pvPoints;
+		}
+
+		int NumPoints() const override
+		{
+			return m_pvPoints->size();
+		}
+
+		const CEnvPoint *GetPoint(int Index) const override
+		{
+			if(Index < 0 || (size_t)Index >= m_pvPoints->size())
+				return nullptr;
+			return &m_pvPoints->at(Index);
+		}
+
+		const CEnvPointBezier *GetBezier(int Index) const override
+		{
+			if(Index < 0 || (size_t)Index >= m_pvPoints->size())
+				return nullptr;
+			return &m_pvPoints->at(Index).m_Bezier;
+		}
+	};
+
 	int m_Channels;
-	std::vector<CEnvPoint> m_vPoints;
+
+public:
+	std::vector<CEnvPoint_runtime> m_vPoints;
+	CEnvelopePointAccess m_PointsAccess;
 	char m_aName[32];
 	float m_Bottom, m_Top;
 	bool m_Synchronized;
 
-	CEnvelope(int Chan)
+	CEnvelope(int Channels) :
+		m_PointsAccess(&m_vPoints)
 	{
-		m_Channels = Chan;
-		m_aName[0] = 0;
+		SetChannels(Channels);
+		m_aName[0] = '\0';
 		m_Bottom = 0;
 		m_Top = 0;
 		m_Synchronized = false;
@@ -71,46 +104,82 @@ public:
 	{
 		m_Top = -1000000000.0f;
 		m_Bottom = 1000000000.0f;
+		CEnvPoint_runtime *pPrevPoint = nullptr;
 		for(auto &Point : m_vPoints)
 		{
 			for(int c = 0; c < m_Channels; c++)
 			{
 				if(ChannelMask & (1 << c))
 				{
-					float v = fx2f(Point.m_aValues[c]);
-					if(v > m_Top)
-						m_Top = v;
-					if(v < m_Bottom)
-						m_Bottom = v;
+					{
+						// value handle
+						const float v = fx2f(Point.m_aValues[c]);
+						m_Top = maximum(m_Top, v);
+						m_Bottom = minimum(m_Bottom, v);
+					}
+
+					if(Point.m_Curvetype == CURVETYPE_BEZIER)
+					{
+						// out-tangent handle
+						const float v = fx2f(Point.m_aValues[c] + Point.m_Bezier.m_aOutTangentDeltaY[c]);
+						m_Top = maximum(m_Top, v);
+						m_Bottom = minimum(m_Bottom, v);
+					}
+
+					if(pPrevPoint != nullptr && pPrevPoint->m_Curvetype == CURVETYPE_BEZIER)
+					{
+						// in-tangent handle
+						const float v = fx2f(Point.m_aValues[c] + Point.m_Bezier.m_aInTangentDeltaY[c]);
+						m_Top = maximum(m_Top, v);
+						m_Bottom = minimum(m_Bottom, v);
+					}
 				}
 			}
+			pPrevPoint = &Point;
 		}
 	}
 
 	int Eval(float Time, ColorRGBA &Color)
 	{
-		CRenderTools::RenderEvalEnvelope(&m_vPoints[0], m_vPoints.size(), m_Channels, std::chrono::nanoseconds((int64_t)((double)Time * (double)std::chrono::nanoseconds(1s).count())), Color);
+		CRenderTools::RenderEvalEnvelope(&m_PointsAccess, m_Channels, std::chrono::nanoseconds((int64_t)((double)Time * (double)std::chrono::nanoseconds(1s).count())), Color);
 		return m_Channels;
 	}
 
 	void AddPoint(int Time, int v0, int v1 = 0, int v2 = 0, int v3 = 0)
 	{
-		CEnvPoint p;
+		CEnvPoint_runtime p;
 		p.m_Time = Time;
 		p.m_aValues[0] = v0;
 		p.m_aValues[1] = v1;
 		p.m_aValues[2] = v2;
 		p.m_aValues[3] = v3;
 		p.m_Curvetype = CURVETYPE_LINEAR;
+		for(int c = 0; c < CEnvPoint::MAX_CHANNELS; c++)
+		{
+			p.m_Bezier.m_aInTangentDeltaX[c] = 0;
+			p.m_Bezier.m_aInTangentDeltaY[c] = 0;
+			p.m_Bezier.m_aOutTangentDeltaX[c] = 0;
+			p.m_Bezier.m_aOutTangentDeltaY[c] = 0;
+		}
 		m_vPoints.push_back(p);
 		Resort();
 	}
 
 	float EndTime() const
 	{
-		if(!m_vPoints.empty())
-			return m_vPoints[m_vPoints.size() - 1].m_Time * (1.0f / 1000.0f);
-		return 0;
+		if(m_vPoints.empty())
+			return 0.0f;
+		return m_vPoints.back().m_Time / 1000.0f;
+	}
+
+	int GetChannels() const
+	{
+		return m_Channels;
+	}
+
+	void SetChannels(int Channels)
+	{
+		m_Channels = clamp<int>(Channels, 1, CEnvPoint::MAX_CHANNELS);
 	}
 };
 

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -624,6 +624,7 @@ public:
 	void ModifyEnvelopeIndex(INDEX_MODIFY_FUNC pfnFunc) override;
 
 	void PrepareForSave();
+	void ExtractTiles(CTile *pSavedTiles);
 
 	void GetSize(float *pWidth, float *pHeight) override
 	{

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -624,7 +624,7 @@ public:
 	void ModifyEnvelopeIndex(INDEX_MODIFY_FUNC pfnFunc) override;
 
 	void PrepareForSave();
-	void ExtractTiles(CTile *pSavedTiles);
+	void ExtractTiles(int TilemapItemVersion, const CTile *pSavedTiles, size_t SavedTilesSize);
 
 	void GetSize(float *pWidth, float *pHeight) override
 	{

--- a/src/game/editor/io.cpp
+++ b/src/game/editor/io.cpp
@@ -56,7 +56,7 @@ bool CEditorMap::Save(const char *pFileName)
 	// save version
 	{
 		CMapItemVersion Item;
-		Item.m_Version = 1;
+		Item.m_Version = CMapItemVersion::CURRENT_VERSION;
 		df.AddItem(MAPITEMTYPE_VERSION, 0, sizeof(Item), &Item);
 	}
 
@@ -421,7 +421,7 @@ bool CEditorMap::Load(const char *pFileName, int StorageType, const std::functio
 	{
 		return false;
 	}
-	else if(pItemVersion->m_Version == 1)
+	else if(pItemVersion->m_Version == CMapItemVersion::CURRENT_VERSION)
 	{
 		// load map info
 		{

--- a/src/game/editor/io.cpp
+++ b/src/game/editor/io.cpp
@@ -793,17 +793,17 @@ bool CEditorMap::Load(const char *pFileName, int StorageType, const std::functio
 						{
 							void *pData = DataFile.GetData(pTilemapItem->m_Data);
 							unsigned int Size = DataFile.GetDataSize(pTilemapItem->m_Data);
-							if(Size >= (size_t)pTiles->m_Width * pTiles->m_Height * sizeof(CTile))
-							{
+							if(pTilemapItem->m_Version > 3)
+								pTiles->ExtractTiles((CTile *)pData);
+							else if(Size >= (size_t)pTiles->m_Width * pTiles->m_Height * sizeof(CTile))
 								mem_copy(pTiles->m_pTiles, pData, (size_t)pTiles->m_Width * pTiles->m_Height * sizeof(CTile));
 
-								if(pTiles->m_Game && pTilemapItem->m_Version == MakeVersion(1, *pTilemapItem))
+							if(pTiles->m_Game && pTilemapItem->m_Version == MakeVersion(1, *pTilemapItem))
+							{
+								for(int i = 0; i < pTiles->m_Width * pTiles->m_Height; i++)
 								{
-									for(int i = 0; i < pTiles->m_Width * pTiles->m_Height; i++)
-									{
-										if(pTiles->m_pTiles[i].m_Index)
-											pTiles->m_pTiles[i].m_Index += ENTITY_OFFSET;
-									}
+									if(pTiles->m_pTiles[i].m_Index)
+										pTiles->m_pTiles[i].m_Index += ENTITY_OFFSET;
 								}
 							}
 							DataFile.UnloadData(pTilemapItem->m_Data);

--- a/src/game/editor/io.cpp
+++ b/src/game/editor/io.cpp
@@ -736,8 +736,10 @@ bool CEditorMap::Load(const char *pFileName, int StorageType, const std::functio
 						{
 							void *pFrontData = DataFile.GetData(pTilemapItem->m_Front);
 							unsigned int Size = DataFile.GetDataSize(pTilemapItem->m_Front);
-							if(Size >= (size_t)pTiles->m_Width * pTiles->m_Height * sizeof(CTile))
-								mem_copy(((CLayerFront *)pTiles)->m_pTiles, pFrontData, (size_t)pTiles->m_Width * pTiles->m_Height * sizeof(CTile));
+							if(pTilemapItem->m_Version > 3)
+								pTiles->ExtractTiles((CTile *)pFrontData);
+							else if(Size >= (size_t)pTiles->m_Width * pTiles->m_Height * sizeof(CTile))
+								mem_copy(pTiles->m_pTiles, pFrontData, (size_t)pTiles->m_Width * pTiles->m_Height * sizeof(CTile));
 
 							DataFile.UnloadData(pTilemapItem->m_Front);
 						}

--- a/src/game/editor/io.cpp
+++ b/src/game/editor/io.cpp
@@ -201,7 +201,7 @@ bool CEditorMap::Save(const char *pFileName)
 				pLayerTiles->PrepareForSave();
 
 				CMapItemLayerTilemap Item;
-				Item.m_Version = 3;
+				Item.m_Version = CMapItemLayerTilemap::CURRENT_VERSION;
 
 				Item.m_Layer.m_Version = 0; // was previously uninitialized, do not rely on it being 0
 				Item.m_Layer.m_Flags = pLayerTiles->m_Flags;
@@ -736,11 +736,7 @@ bool CEditorMap::Load(const char *pFileName, int StorageType, const std::functio
 						{
 							void *pFrontData = DataFile.GetData(pTilemapItem->m_Front);
 							unsigned int Size = DataFile.GetDataSize(pTilemapItem->m_Front);
-							if(pTilemapItem->m_Version > 3)
-								pTiles->ExtractTiles((CTile *)pFrontData);
-							else if(Size >= (size_t)pTiles->m_Width * pTiles->m_Height * sizeof(CTile))
-								mem_copy(pTiles->m_pTiles, pFrontData, (size_t)pTiles->m_Width * pTiles->m_Height * sizeof(CTile));
-
+							pTiles->ExtractTiles(pTilemapItem->m_Version, (CTile *)pFrontData, Size);
 							DataFile.UnloadData(pTilemapItem->m_Front);
 						}
 						else if(pTiles->m_Switch)
@@ -795,10 +791,7 @@ bool CEditorMap::Load(const char *pFileName, int StorageType, const std::functio
 						{
 							void *pData = DataFile.GetData(pTilemapItem->m_Data);
 							unsigned int Size = DataFile.GetDataSize(pTilemapItem->m_Data);
-							if(pTilemapItem->m_Version > 3)
-								pTiles->ExtractTiles((CTile *)pData);
-							else if(Size >= (size_t)pTiles->m_Width * pTiles->m_Height * sizeof(CTile))
-								mem_copy(pTiles->m_pTiles, pData, (size_t)pTiles->m_Width * pTiles->m_Height * sizeof(CTile));
+							pTiles->ExtractTiles(pTilemapItem->m_Version, (CTile *)pData, Size);
 
 							if(pTiles->m_Game && pTilemapItem->m_Version == MakeVersion(1, *pTilemapItem))
 							{

--- a/src/game/editor/layer_tiles.cpp
+++ b/src/game/editor/layer_tiles.cpp
@@ -4,6 +4,7 @@
 
 #include <engine/client.h>
 #include <engine/graphics.h>
+#include <engine/shared/map.h>
 #include <engine/textrender.h>
 
 #include "editor.h"
@@ -97,19 +98,13 @@ void CLayerTiles::PrepareForSave()
 	}
 }
 
-void CLayerTiles::ExtractTiles(CTile *pSavedTiles)
+void CLayerTiles::ExtractTiles(int TilemapItemVersion, const CTile *pSavedTiles, size_t SavedTilesSize)
 {
-	int i = 0;
-	while(i < m_Width * m_Height)
-	{
-		for(unsigned Counter = 0; Counter <= pSavedTiles->m_Skip && i < m_Width * m_Height; Counter++)
-		{
-			m_pTiles[i] = *pSavedTiles;
-			m_pTiles[i++].m_Skip = 0;
-		}
-
-		pSavedTiles++;
-	}
+	const size_t DestSize = (size_t)m_Width * m_Height;
+	if(TilemapItemVersion >= CMapItemLayerTilemap::TILE_SKIP_MIN_VERSION)
+		CMap::ExtractTiles(m_pTiles, DestSize, pSavedTiles, SavedTilesSize);
+	else if(SavedTilesSize >= DestSize)
+		mem_copy(m_pTiles, pSavedTiles, DestSize * sizeof(CTile));
 }
 
 void CLayerTiles::MakePalette()

--- a/src/game/editor/layer_tiles.cpp
+++ b/src/game/editor/layer_tiles.cpp
@@ -930,7 +930,7 @@ CUI::EPopupMenuFunctionResult CLayerTiles::RenderProperties(CUIRect *pToolBox)
 		{
 			for(; Index >= -1 && Index < (int)m_pEditor->m_Map.m_vpEnvelopes.size(); Index += Step)
 			{
-				if(Index == -1 || m_pEditor->m_Map.m_vpEnvelopes[Index]->m_Channels == 4)
+				if(Index == -1 || m_pEditor->m_Map.m_vpEnvelopes[Index]->GetChannels() == 4)
 				{
 					m_ColorEnv = Index;
 					break;

--- a/src/game/editor/layer_tiles.cpp
+++ b/src/game/editor/layer_tiles.cpp
@@ -97,6 +97,21 @@ void CLayerTiles::PrepareForSave()
 	}
 }
 
+void CLayerTiles::ExtractTiles(CTile *pSavedTiles)
+{
+	int i = 0;
+	while(i < m_Width * m_Height)
+	{
+		for(unsigned Counter = 0; Counter <= pSavedTiles->m_Skip && i < m_Width * m_Height; Counter++)
+		{
+			m_pTiles[i] = *pSavedTiles;
+			m_pTiles[i++].m_Skip = 0;
+		}
+
+		pSavedTiles++;
+	}
+}
+
 void CLayerTiles::MakePalette()
 {
 	for(int y = 0; y < m_Height; y++)

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -936,7 +936,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupQuad(void *pContext, CUIRect View, b
 			{
 				for(; Index >= -1 && Index < (int)pEditor->m_Map.m_vpEnvelopes.size(); Index += StepDirection)
 				{
-					if(Index == -1 || pEditor->m_Map.m_vpEnvelopes[Index]->m_Channels == 3)
+					if(Index == -1 || pEditor->m_Map.m_vpEnvelopes[Index]->GetChannels() == 3)
 					{
 						pQuad->m_PosEnv = Index;
 						break;
@@ -956,7 +956,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupQuad(void *pContext, CUIRect View, b
 			{
 				for(; Index >= -1 && Index < (int)pEditor->m_Map.m_vpEnvelopes.size(); Index += StepDirection)
 				{
-					if(Index == -1 || pEditor->m_Map.m_vpEnvelopes[Index]->m_Channels == 4)
+					if(Index == -1 || pEditor->m_Map.m_vpEnvelopes[Index]->GetChannels() == 4)
 					{
 						pQuad->m_ColorEnv = Index;
 						break;
@@ -1095,7 +1095,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupSource(void *pContext, CUIRect View,
 		const int StepDirection = Index < pSource->m_PosEnv ? -1 : 1;
 		for(; Index >= -1 && Index < (int)pEditor->m_Map.m_vpEnvelopes.size(); Index += StepDirection)
 		{
-			if(Index == -1 || pEditor->m_Map.m_vpEnvelopes[Index]->m_Channels == 3)
+			if(Index == -1 || pEditor->m_Map.m_vpEnvelopes[Index]->GetChannels() == 3)
 			{
 				pSource->m_PosEnv = Index;
 				break;
@@ -1112,7 +1112,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupSource(void *pContext, CUIRect View,
 		const int StepDirection = Index < pSource->m_SoundEnv ? -1 : 1;
 		for(; Index >= -1 && Index < (int)pEditor->m_Map.m_vpEnvelopes.size(); Index += StepDirection)
 		{
-			if(Index == -1 || pEditor->m_Map.m_vpEnvelopes[Index]->m_Channels == 1)
+			if(Index == -1 || pEditor->m_Map.m_vpEnvelopes[Index]->GetChannels() == 1)
 			{
 				pSource->m_SoundEnv = Index;
 				break;

--- a/src/game/mapitems.h
+++ b/src/game/mapitems.h
@@ -298,6 +298,11 @@ struct CMapItemLayer
 
 struct CMapItemLayerTilemap
 {
+	enum
+	{
+		CURRENT_VERSION = 4
+	};
+
 	CMapItemLayer m_Layer;
 	int m_Version;
 

--- a/src/game/mapitems.h
+++ b/src/game/mapitems.h
@@ -252,8 +252,13 @@ struct CMapItemInfoSettings : CMapItemInfo
 	int m_Settings;
 };
 
-struct CMapItemImage
+struct CMapItemImage_v1
 {
+	enum
+	{
+		CURRENT_VERSION = 1,
+	};
+
 	int m_Version;
 	int m_Width;
 	int m_Height;
@@ -261,6 +266,18 @@ struct CMapItemImage
 	int m_ImageName;
 	int m_ImageData;
 };
+
+struct CMapItemImage_v2 : public CMapItemImage_v1
+{
+	enum
+	{
+		CURRENT_VERSION = 2,
+	};
+
+	int m_Format; // Default before this version is CImageInfo::FORMAT_RGBA
+};
+
+typedef CMapItemImage_v1 CMapItemImage;
 
 struct CMapItemGroup_v1
 {

--- a/src/game/mapitems.h
+++ b/src/game/mapitems.h
@@ -300,7 +300,8 @@ struct CMapItemLayerTilemap
 {
 	enum
 	{
-		CURRENT_VERSION = 4
+		CURRENT_VERSION = 3,
+		TILE_SKIP_MIN_VERSION = 4, // supported for loading but not saving
 	};
 
 	CMapItemLayer m_Layer;

--- a/src/game/mapitems.h
+++ b/src/game/mapitems.h
@@ -337,6 +337,11 @@ struct CMapItemLayerQuads
 
 struct CMapItemVersion
 {
+	enum
+	{
+		CURRENT_VERSION = 1
+	};
+
 	int m_Version;
 };
 

--- a/src/game/mapitems_ex_types.h
+++ b/src/game/mapitems_ex_types.h
@@ -3,3 +3,4 @@
 UUID(MAPITEMTYPE_TEST, "mapitemtype-test@ddnet.tw")
 UUID(MAPITEMTYPE_AUTOMAPPER_CONFIG, "mapitemtype-automapper-config@ddnet.tw")
 UUID(MAPITEMTYPE_GROUP_EX, "mapitemtype-group@ddnet.tw")
+UUID(MAPITEMTYPE_ENVPOINTS_BEZIER, "mapitemtype-envpoints-bezier@ddnet.tw")

--- a/src/tools/map_optimize.cpp
+++ b/src/tools/map_optimize.cpp
@@ -188,8 +188,8 @@ int main(int argc, const char **argv)
 		}
 		else if(Type == MAPITEMTYPE_IMAGE)
 		{
-			CMapItemImage *pImg = (CMapItemImage *)pPtr;
-			if(!pImg->m_External)
+			CMapItemImage_v2 *pImg = (CMapItemImage_v2 *)pPtr;
+			if(!pImg->m_External && pImg->m_Version < CMapItemImage_v2::CURRENT_VERSION)
 			{
 				SMapOptimizeItem Item;
 				Item.m_pImage = pImg;


### PR DESCRIPTION
![screenshot](https://user-images.githubusercontent.com/23437060/234628870-317d4d1e-478e-406f-b948-0bb493ebb181.png)

Port map and editor support for `CURVETYPE_BEZIER` from upstream, i.e. support bezier curves with configurable in- and out-tangents for every envelope point.

The in- and out-tangents are represented by triangles and can be dragged in the envelope editor like the envelope points.

Support reading and writing the bezier information as a separate UUID-based map item. If the bezier information is not found, bezier will default to linear behavior. Old clients will still be able to read the new maps and ignore the unknown map item. The unknown curvetype will also be handled as linear by old clients.

Allow reading upstream maps that use `CMapItemEnvelope` version 3. On upstream, a different struct is used to store all envelope points including bezier information, which broke compatibility to old clients.

Fix holding Ctrl for slow envelope point editing not working for vertical movement.

Highlight the currently selected element (envelope point or bezier tangent marker) which is being used with the value/time edit boxes.

Hide the value/time edit boxes when no element is selected.

Add a version item check in `CMap`.

Support loading maps with `CMapItemLayerTilemap` version 4, which makes use of the `CTile::m_Skip` member to compress tile layers.

Support loading CMapItemImage version 2. This map item version adds the `m_Format` field, which specifies the image format for embedded images. The default value is `CImageInfo::FORMAT_RGBA` for map items of the previous version.

## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
