### PR TITLE
Smooth console completion scrolling

### DIFF
--- a/src/game/client/components/console.h
+++ b/src/game/client/components/console.h
@@ -50,6 +50,7 @@ class CGameConsole : public CComponent
 		int m_CompletionChosenArgument;
 		int m_CompletionFlagmask;
 		float m_CompletionRenderOffset;
+		float m_CompletionRenderOffsetChange;
 
 		char m_aUser[32];
 		bool m_UserGot;

--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -12,6 +12,7 @@
 #include <string>
 #include <vector>
 
+class IClient;
 class IGraphics;
 class IKernel;
 
@@ -203,6 +204,7 @@ class CUI
 	std::vector<CUIRect> m_vClips;
 	void UpdateClipping();
 
+	IClient *m_pClient;
 	IGraphics *m_pGraphics;
 	IInput *m_pInput;
 	ITextRender *m_pTextRender;
@@ -218,6 +220,7 @@ public:
 
 	void Init(IKernel *pKernel);
 	void InitInputs(IInput::CEvent *pInputEventsArray, int *pInputEventCount);
+	IClient *Client() const { return m_pClient; }
 	IGraphics *Graphics() const { return m_pGraphics; }
 	IInput *Input() const { return m_pInput; }
 	ITextRender *TextRender() const { return m_pTextRender; }
@@ -306,6 +309,7 @@ public:
 
 	int DoButtonLogic(const void *pID, int Checked, const CUIRect *pRect);
 	int DoPickerLogic(const void *pID, const CUIRect *pRect, float *pX, float *pY);
+	void DoSmoothScrollLogic(float *pScrollOffset, float *pScrollOffsetChange, float ViewPortSize, float TotalSize, float ScrollSpeed = 10.0f);
 
 	float DoTextLabel(float x, float y, float w, float h, const char *pText, float Size, int Align, const SLabelProperties &LabelProps = {});
 	void DoLabel(const CUIRect *pRect, const char *pText, float Size, int Align, const SLabelProperties &LabelProps = {});


### PR DESCRIPTION
More smoothly scroll selected console completion option into view.

See videos at https://github.com/teeworlds/teeworlds/pull/3054.

The smooth scrolling logic is extracted in `CUI::DoSmoothScrollLogic` so it can eventually be reused for smooth input scrolling (see https://github.com/teeworlds/teeworlds/pull/3150).

## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
