### PR TITLE
Port `CScrollRegion` from upstream and refactor MOTD, controls settings, editor images popup, editor layers/images/sounds lists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2103,6 +2103,8 @@ if(CLIENT)
     ui.h
     ui_rect.cpp
     ui_rect.h
+    ui_scrollregion.cpp
+    ui_scrollregion.h
   )
   set_src(GAME_EDITOR GLOB src/game/editor
     auto_map.cpp

--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -2997,6 +2997,18 @@ const char *str_rchr(const char *haystack, char needle)
 	return strrchr(haystack, needle);
 }
 
+int str_countchr(const char *haystack, char needle)
+{
+	int count = 0;
+	while(*haystack)
+	{
+		if(*haystack == needle)
+			count++;
+		haystack++;
+	}
+	return count;
+}
+
 void str_hex(char *dst, int dst_size, const void *data, int data_size)
 {
 	static const char hex[] = "0123456789ABCDEF";

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -1589,6 +1589,23 @@ const char *str_find(const char *haystack, const char *needle);
 const char *str_rchr(const char *haystack, char needle);
 
 /*
+	Function: str_countchr
+		Counts the number of occurrences of a character in a string.
+
+	Parameters:
+		haystack - String to count in
+		needle - Character to count
+
+	Returns:
+		The number of characters in the haystack string matching
+		the needle character.
+
+	Remarks:
+		- The strings are treated as zero-terminated strings.
+*/
+int str_countchr(const char *haystack, char needle);
+
+/*
 	Function: str_hex
 		Takes a datablock and generates a hex string of it, with spaces
 		between bytes.

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -113,14 +113,14 @@ class CMenus : public CComponent
 		Text.HMargin(pRect->h >= 20.0f ? 2.0f : 1.0f, &Text);
 		Text.HMargin((Text.h * FontFactor) / 2.0f, &Text);
 
-		if(!UIElement.AreRectsInit() || HintRequiresStringCheck || HintCanChangePositionOrSize || UIElement.Get(0)->m_UITextContainer == -1)
+		if(!UIElement.AreRectsInit() || HintRequiresStringCheck || HintCanChangePositionOrSize || UIElement.Rect(0)->m_UITextContainer == -1)
 		{
-			bool NeedsRecalc = !UIElement.AreRectsInit() || UIElement.Get(0)->m_UITextContainer == -1;
+			bool NeedsRecalc = !UIElement.AreRectsInit() || UIElement.Rect(0)->m_UITextContainer == -1;
 			if(HintCanChangePositionOrSize)
 			{
 				if(UIElement.AreRectsInit())
 				{
-					if(UIElement.Get(0)->m_X != pRect->x || UIElement.Get(0)->m_Y != pRect->y || UIElement.Get(0)->m_Width != pRect->w || UIElement.Get(0)->m_Y != pRect->h)
+					if(UIElement.Rect(0)->m_X != pRect->x || UIElement.Rect(0)->m_Y != pRect->y || UIElement.Rect(0)->m_Width != pRect->w || UIElement.Rect(0)->m_Y != pRect->h)
 					{
 						NeedsRecalc = true;
 					}
@@ -132,7 +132,7 @@ class CMenus : public CComponent
 				if(UIElement.AreRectsInit())
 				{
 					pText = GetTextLambda();
-					if(str_comp(UIElement.Get(0)->m_Text.c_str(), pText) != 0)
+					if(str_comp(UIElement.Rect(0)->m_Text.c_str(), pText) != 0)
 					{
 						NeedsRecalc = true;
 					}
@@ -158,7 +158,7 @@ class CMenus : public CComponent
 						Color.a *= UI()->ButtonColorMulDefault();
 					Graphics()->SetColor(Color);
 
-					CUIElement::SUIElementRect &NewRect = *UIElement.Get(i);
+					CUIElement::SUIElementRect &NewRect = *UIElement.Rect(i);
 					NewRect.m_UIRectQuadContainer = Graphics()->CreateRectQuadContainer(pRect->x, pRect->y, pRect->w, pRect->h, r, Corners);
 
 					NewRect.m_X = pRect->x;
@@ -185,11 +185,11 @@ class CMenus : public CComponent
 		else if(UI()->HotItem() == pID)
 			Index = 1;
 		Graphics()->TextureClear();
-		Graphics()->RenderQuadContainer(UIElement.Get(Index)->m_UIRectQuadContainer, -1);
+		Graphics()->RenderQuadContainer(UIElement.Rect(Index)->m_UIRectQuadContainer, -1);
 		ColorRGBA ColorText(TextRender()->DefaultTextColor());
 		ColorRGBA ColorTextOutline(TextRender()->DefaultTextOutlineColor());
-		if(UIElement.Get(0)->m_UITextContainer != -1)
-			TextRender()->RenderTextContainer(UIElement.Get(0)->m_UITextContainer, ColorText, ColorTextOutline);
+		if(UIElement.Rect(0)->m_UITextContainer != -1)
+			TextRender()->RenderTextContainer(UIElement.Rect(0)->m_UITextContainer, ColorText, ColorTextOutline);
 		return UI()->DoButtonLogic(pID, Checked, pRect);
 	}
 

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -286,13 +286,13 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 			{
 				CUIRect r = Row;
 				r.Margin(0.5f, &r);
-				pItem->m_pUIElement->Get(0)->Draw(&r, ColorRGBA(1, 1, 1, 0.5f), IGraphics::CORNER_ALL, 4.0f);
+				pItem->m_pUIElement->Rect(0)->Draw(&r, ColorRGBA(1, 1, 1, 0.5f), IGraphics::CORNER_ALL, 4.0f);
 			}
 			else if(UI()->MouseHovered(&Row))
 			{
 				CUIRect r = Row;
 				r.Margin(0.5f, &r);
-				pItem->m_pUIElement->Get(0)->Draw(&r, ColorRGBA(1, 1, 1, 0.25f), IGraphics::CORNER_ALL, 4.0f);
+				pItem->m_pUIElement->Rect(0)->Draw(&r, ColorRGBA(1, 1, 1, 0.25f), IGraphics::CORNER_ALL, 4.0f);
 			}
 
 			if(UI()->DoButtonLogic(pItem, Selected, &Row))
@@ -328,22 +328,22 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 			{
 				if(pItem->m_Flags & SERVER_FLAG_PASSWORD)
 				{
-					RenderBrowserIcons(*pItem->m_pUIElement->Get(gs_OffsetColFlagLock + 0), &Button, {0.75f, 0.75f, 0.75f, 1}, TextRender()->DefaultTextOutlineColor(), "\xEF\x80\xA3", TEXTALIGN_CENTER);
+					RenderBrowserIcons(*pItem->m_pUIElement->Rect(gs_OffsetColFlagLock + 0), &Button, {0.75f, 0.75f, 0.75f, 1}, TextRender()->DefaultTextOutlineColor(), "\xEF\x80\xA3", TEXTALIGN_CENTER);
 				}
 			}
 			else if(ID == COL_FLAG_FAV)
 			{
 				if(pItem->m_Favorite != TRISTATE::NONE)
 				{
-					RenderBrowserIcons(*pItem->m_pUIElement->Get(gs_OffsetColFav + 0), &Button, {0.94f, 0.4f, 0.4f, 1}, TextRender()->DefaultTextOutlineColor(), "\xEF\x80\x84", TEXTALIGN_CENTER);
+					RenderBrowserIcons(*pItem->m_pUIElement->Rect(gs_OffsetColFav + 0), &Button, {0.94f, 0.4f, 0.4f, 1}, TextRender()->DefaultTextOutlineColor(), "\xEF\x80\x84", TEXTALIGN_CENTER);
 				}
 			}
 			else if(ID == COL_FLAG_OFFICIAL)
 			{
 				if(pItem->m_Official && g_Config.m_UiPage != PAGE_DDNET && g_Config.m_UiPage != PAGE_KOG)
 				{
-					RenderBrowserIcons(*pItem->m_pUIElement->Get(gs_OffsetColOff + 0), &Button, {0.4f, 0.7f, 0.94f, 1}, {0.0f, 0.0f, 0.0f, 1.0f}, "\xEF\x82\xA3", TEXTALIGN_CENTER);
-					RenderBrowserIcons(*pItem->m_pUIElement->Get(gs_OffsetColOff + 1), &Button, {0.0f, 0.0f, 0.0f, 1.0f}, {0.0f, 0.0f, 0.0f, 0.0f}, "\xEF\x80\x8C", TEXTALIGN_CENTER, true);
+					RenderBrowserIcons(*pItem->m_pUIElement->Rect(gs_OffsetColOff + 0), &Button, {0.4f, 0.7f, 0.94f, 1}, {0.0f, 0.0f, 0.0f, 1.0f}, "\xEF\x82\xA3", TEXTALIGN_CENTER);
+					RenderBrowserIcons(*pItem->m_pUIElement->Rect(gs_OffsetColOff + 1), &Button, {0.0f, 0.0f, 0.0f, 1.0f}, {0.0f, 0.0f, 0.0f, 0.0f}, "\xEF\x80\x8C", TEXTALIGN_CENTER, true);
 				}
 			}
 			else if(ID == COL_NAME)
@@ -356,17 +356,17 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 					const char *pStr = str_utf8_find_nocase(pItem->m_aName, g_Config.m_BrFilterString);
 					if(pStr)
 					{
-						UI()->DoLabelStreamed(*pItem->m_pUIElement->Get(gs_OffsetColName + 0), &Button, pItem->m_aName, FontSize, TEXTALIGN_LEFT, Button.w, 1, true, (int)(pStr - pItem->m_aName));
+						UI()->DoLabelStreamed(*pItem->m_pUIElement->Rect(gs_OffsetColName + 0), &Button, pItem->m_aName, FontSize, TEXTALIGN_LEFT, Button.w, 1, true, (int)(pStr - pItem->m_aName));
 						TextRender()->TextColor(0.4f, 0.4f, 1.0f, 1);
-						UI()->DoLabelStreamed(*pItem->m_pUIElement->Get(gs_OffsetColName + 1), &Button, pStr, FontSize, TEXTALIGN_LEFT, Button.w, 1, true, (int)str_length(g_Config.m_BrFilterString), &pItem->m_pUIElement->Get(gs_OffsetColName + 0)->m_Cursor);
+						UI()->DoLabelStreamed(*pItem->m_pUIElement->Rect(gs_OffsetColName + 1), &Button, pStr, FontSize, TEXTALIGN_LEFT, Button.w, 1, true, (int)str_length(g_Config.m_BrFilterString), &pItem->m_pUIElement->Rect(gs_OffsetColName + 0)->m_Cursor);
 						TextRender()->TextColor(1, 1, 1, 1);
-						UI()->DoLabelStreamed(*pItem->m_pUIElement->Get(gs_OffsetColName + 2), &Button, pStr + str_length(g_Config.m_BrFilterString), FontSize, TEXTALIGN_LEFT, Button.w, 1, true, -1, &pItem->m_pUIElement->Get(gs_OffsetColName + 1)->m_Cursor);
+						UI()->DoLabelStreamed(*pItem->m_pUIElement->Rect(gs_OffsetColName + 2), &Button, pStr + str_length(g_Config.m_BrFilterString), FontSize, TEXTALIGN_LEFT, Button.w, 1, true, -1, &pItem->m_pUIElement->Rect(gs_OffsetColName + 1)->m_Cursor);
 					}
 					else
-						UI()->DoLabelStreamed(*pItem->m_pUIElement->Get(gs_OffsetColName), &Button, pItem->m_aName, FontSize, TEXTALIGN_LEFT, Button.w, 1, true);
+						UI()->DoLabelStreamed(*pItem->m_pUIElement->Rect(gs_OffsetColName), &Button, pItem->m_aName, FontSize, TEXTALIGN_LEFT, Button.w, 1, true);
 				}
 				else
-					UI()->DoLabelStreamed(*pItem->m_pUIElement->Get(gs_OffsetColName), &Button, pItem->m_aName, FontSize, TEXTALIGN_LEFT, Button.w, 1, true);
+					UI()->DoLabelStreamed(*pItem->m_pUIElement->Rect(gs_OffsetColName), &Button, pItem->m_aName, FontSize, TEXTALIGN_LEFT, Button.w, 1, true);
 			}
 			else if(ID == COL_MAP)
 			{
@@ -379,7 +379,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 
 					if(g_Config.m_BrIndicateFinished && pItem->m_HasRank == 1)
 					{
-						RenderBrowserIcons(*pItem->m_pUIElement->Get(gs_OffsetColFlagLock + 1), &Icon, TextRender()->DefaultTextColor(), TextRender()->DefaultTextOutlineColor(), "\xEF\x84\x9E", TEXTALIGN_CENTER);
+						RenderBrowserIcons(*pItem->m_pUIElement->Rect(gs_OffsetColFlagLock + 1), &Icon, TextRender()->DefaultTextColor(), TextRender()->DefaultTextOutlineColor(), "\xEF\x84\x9E", TEXTALIGN_CENTER);
 					}
 				}
 
@@ -391,17 +391,17 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 					const char *pStr = str_utf8_find_nocase(pItem->m_aMap, g_Config.m_BrFilterString);
 					if(pStr)
 					{
-						UI()->DoLabelStreamed(*pItem->m_pUIElement->Get(gs_OffsetColMap + 0), &Button, pItem->m_aMap, FontSize, TEXTALIGN_LEFT, Button.w, 1, true, (int)(pStr - pItem->m_aMap));
+						UI()->DoLabelStreamed(*pItem->m_pUIElement->Rect(gs_OffsetColMap + 0), &Button, pItem->m_aMap, FontSize, TEXTALIGN_LEFT, Button.w, 1, true, (int)(pStr - pItem->m_aMap));
 						TextRender()->TextColor(0.4f, 0.4f, 1.0f, 1);
-						UI()->DoLabelStreamed(*pItem->m_pUIElement->Get(gs_OffsetColMap + 1), &Button, pStr, FontSize, TEXTALIGN_LEFT, Button.w, 1, true, (int)str_length(g_Config.m_BrFilterString), &pItem->m_pUIElement->Get(gs_OffsetColMap + 0)->m_Cursor);
+						UI()->DoLabelStreamed(*pItem->m_pUIElement->Rect(gs_OffsetColMap + 1), &Button, pStr, FontSize, TEXTALIGN_LEFT, Button.w, 1, true, (int)str_length(g_Config.m_BrFilterString), &pItem->m_pUIElement->Rect(gs_OffsetColMap + 0)->m_Cursor);
 						TextRender()->TextColor(1, 1, 1, 1);
-						UI()->DoLabelStreamed(*pItem->m_pUIElement->Get(gs_OffsetColMap + 2), &Button, pStr + str_length(g_Config.m_BrFilterString), FontSize, TEXTALIGN_LEFT, Button.w, 1, true, -1, &pItem->m_pUIElement->Get(gs_OffsetColMap + 1)->m_Cursor);
+						UI()->DoLabelStreamed(*pItem->m_pUIElement->Rect(gs_OffsetColMap + 2), &Button, pStr + str_length(g_Config.m_BrFilterString), FontSize, TEXTALIGN_LEFT, Button.w, 1, true, -1, &pItem->m_pUIElement->Rect(gs_OffsetColMap + 1)->m_Cursor);
 					}
 					else
-						UI()->DoLabelStreamed(*pItem->m_pUIElement->Get(gs_OffsetColMap), &Button, pItem->m_aMap, FontSize, TEXTALIGN_LEFT, Button.w, 1, true);
+						UI()->DoLabelStreamed(*pItem->m_pUIElement->Rect(gs_OffsetColMap), &Button, pItem->m_aMap, FontSize, TEXTALIGN_LEFT, Button.w, 1, true);
 				}
 				else
-					UI()->DoLabelStreamed(*pItem->m_pUIElement->Get(gs_OffsetColMap), &Button, pItem->m_aMap, FontSize, TEXTALIGN_LEFT, Button.w, 1, true);
+					UI()->DoLabelStreamed(*pItem->m_pUIElement->Rect(gs_OffsetColMap), &Button, pItem->m_aMap, FontSize, TEXTALIGN_LEFT, Button.w, 1, true);
 			}
 			else if(ID == COL_PLAYERS)
 			{
@@ -411,14 +411,14 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 				{
 					Button.VSplitLeft(Button.h, &Icon, &Button);
 					Icon.Margin(2.0f, &Icon);
-					RenderBrowserIcons(*pItem->m_pUIElement->Get(gs_OffsetColFav + 1), &Icon, {0.94f, 0.4f, 0.4f, 1}, TextRender()->DefaultTextOutlineColor(), "\xEF\x80\x84", TEXTALIGN_LEFT);
+					RenderBrowserIcons(*pItem->m_pUIElement->Rect(gs_OffsetColFav + 1), &Icon, {0.94f, 0.4f, 0.4f, 1}, TextRender()->DefaultTextOutlineColor(), "\xEF\x80\x84", TEXTALIGN_LEFT);
 				}
 
 				str_format(aTemp, sizeof(aTemp), "%i/%i", pItem->m_NumFilteredPlayers, ServerBrowser()->Max(*pItem));
 				if(g_Config.m_BrFilterString[0] && (pItem->m_QuickSearchHit & IServerBrowser::QUICK_PLAYER))
 					TextRender()->TextColor(0.4f, 0.4f, 1.0f, 1);
 				float FontSize = 12.0f;
-				UI()->DoLabelStreamed(*pItem->m_pUIElement->Get(gs_OffsetColPlayers), &Button, aTemp, FontSize, TEXTALIGN_RIGHT, -1, 1, false);
+				UI()->DoLabelStreamed(*pItem->m_pUIElement->Rect(gs_OffsetColPlayers), &Button, aTemp, FontSize, TEXTALIGN_RIGHT, -1, 1, false);
 				TextRender()->TextColor(1, 1, 1, 1);
 			}
 			else if(ID == COL_PING)
@@ -432,14 +432,14 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 				}
 
 				float FontSize = 12.0f;
-				UI()->DoLabelStreamed(*pItem->m_pUIElement->Get(gs_OffsetColPing), &Button, aTemp, FontSize, TEXTALIGN_RIGHT, -1, 1, false);
+				UI()->DoLabelStreamed(*pItem->m_pUIElement->Rect(gs_OffsetColPing), &Button, aTemp, FontSize, TEXTALIGN_RIGHT, -1, 1, false);
 				TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
 			}
 			else if(ID == COL_VERSION)
 			{
 				const char *pVersion = pItem->m_aVersion;
 				float FontSize = 12.0f;
-				UI()->DoLabelStreamed(*pItem->m_pUIElement->Get(gs_OffsetColVersion), &Button, pVersion, FontSize, TEXTALIGN_RIGHT, -1, 1, false);
+				UI()->DoLabelStreamed(*pItem->m_pUIElement->Rect(gs_OffsetColVersion), &Button, pVersion, FontSize, TEXTALIGN_RIGHT, -1, 1, false);
 			}
 			else if(ID == COL_GAMETYPE)
 			{
@@ -466,11 +466,11 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 
 					ColorRGBA rgb = color_cast<ColorRGBA>(hsl);
 					TextRender()->TextColor(rgb);
-					UI()->DoLabelStreamed(*pItem->m_pUIElement->Get(gs_OffsetColGameType), &Button, pItem->m_aGameType, FontSize, TEXTALIGN_LEFT, Button.w, 1, true);
+					UI()->DoLabelStreamed(*pItem->m_pUIElement->Rect(gs_OffsetColGameType), &Button, pItem->m_aGameType, FontSize, TEXTALIGN_LEFT, Button.w, 1, true);
 					TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
 				}
 				else
-					UI()->DoLabelStreamed(*pItem->m_pUIElement->Get(gs_OffsetColGameType), &Button, pItem->m_aGameType, FontSize, TEXTALIGN_LEFT, Button.w, 1, true);
+					UI()->DoLabelStreamed(*pItem->m_pUIElement->Rect(gs_OffsetColGameType), &Button, pItem->m_aGameType, FontSize, TEXTALIGN_LEFT, Button.w, 1, true);
 			}
 		}
 	}

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -20,6 +20,7 @@
 #include <game/client/gameclient.h>
 #include <game/client/render.h>
 #include <game/client/ui.h>
+#include <game/client/ui_scrollregion.h>
 #include <game/localization.h>
 
 #include "menus.h"
@@ -450,14 +451,30 @@ void CMenus::RenderServerInfo(CUIRect MainView)
 	}
 
 	// motd
-	Motd.HSplitTop(10.0f, 0, &Motd);
+	const float MotdFontSize = 16.0f;
+	Motd.HSplitTop(10.0f, nullptr, &Motd);
 	Motd.Draw(ColorRGBA(1, 1, 1, 0.25f), IGraphics::CORNER_ALL, 10.0f);
-	Motd.Margin(5.0f, &Motd);
-	y = 0.0f;
-	x = 5.0f;
-	TextRender()->Text(0, Motd.x + x, Motd.y + y, 32, Localize("MOTD"), -1.0f);
-	y += 32.0f + 5.0f;
-	TextRender()->Text(0, Motd.x + x, Motd.y + y, 16, m_pClient->m_Motd.m_aServerMotd, Motd.w);
+	Motd.HMargin(5.0f, &Motd);
+	Motd.VMargin(10.0f, &Motd);
+
+	CUIRect MotdHeader;
+	Motd.HSplitTop(2.0f * MotdFontSize, &MotdHeader, &Motd);
+	Motd.HSplitTop(5.0f, nullptr, &Motd);
+	TextRender()->Text(nullptr, MotdHeader.x, MotdHeader.y, 2.0f * MotdFontSize, Localize("MOTD"), -1.0f);
+
+	static CScrollRegion s_ScrollRegion;
+	vec2 ScrollOffset(0.0f, 0.0f);
+	CScrollRegionParams ScrollParams;
+	ScrollParams.m_ScrollUnit = 5 * MotdFontSize;
+	s_ScrollRegion.Begin(&Motd, &ScrollOffset, &ScrollParams);
+	Motd.y += ScrollOffset.y;
+
+	CUIRect MotdTextArea;
+	Motd.HSplitTop((str_countchr(m_pClient->m_Motd.m_aServerMotd, '\n') + 1) * MotdFontSize, &MotdTextArea, &Motd);
+	s_ScrollRegion.AddRect(MotdTextArea);
+	TextRender()->Text(nullptr, MotdTextArea.x, MotdTextArea.y, MotdFontSize, m_pClient->m_Motd.m_aServerMotd, MotdTextArea.w);
+
+	s_ScrollRegion.End();
 }
 
 bool CMenus::RenderServerControlServer(CUIRect MainView)

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -374,6 +374,8 @@ void CGameClient::OnInit()
 
 void CGameClient::OnUpdate()
 {
+	CUIElementBase::Init(UI()); // update static pointer because game and editor use separate UI
+
 	// handle mouse movement
 	float x = 0.0f, y = 0.0f;
 	IInput::ECursorType CursorType = Input()->CursorRelative(&x, &y);

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -82,6 +82,13 @@ const CLinearScrollbarScale CUI::ms_LinearScrollbarScale;
 const CLogarithmicScrollbarScale CUI::ms_LogarithmicScrollbarScale(25);
 float CUI::ms_FontmodHeight = 0.8f;
 
+CUI *CUIElementBase::s_pUI = nullptr;
+
+IClient *CUIElementBase::Client() const { return s_pUI->Client(); }
+IGraphics *CUIElementBase::Graphics() const { return s_pUI->Graphics(); }
+IInput *CUIElementBase::Input() const { return s_pUI->Input(); }
+ITextRender *CUIElementBase::TextRender() const { return s_pUI->TextRender(); }
+
 void CUI::Init(IKernel *pKernel)
 {
 	m_pClient = pKernel->RequestInterface<IClient>();
@@ -90,6 +97,7 @@ void CUI::Init(IKernel *pKernel)
 	m_pTextRender = pKernel->RequestInterface<ITextRender>();
 	InitInputs(m_pInput->GetEventsRaw(), m_pInput->GetEventCountRaw());
 	CUIRect::Init(m_pGraphics);
+	CUIElementBase::Init(this);
 }
 
 void CUI::InitInputs(IInput::CEvent *pInputEventsArray, int *pInputEventCount)

--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -158,6 +158,21 @@ struct SLabelProperties
 	bool m_EnableWidthCheck = true;
 };
 
+class CUIElementBase
+{
+private:
+	static CUI *s_pUI;
+
+public:
+	static void Init(CUI *pUI) { s_pUI = pUI; }
+
+	IClient *Client() const;
+	IGraphics *Graphics() const;
+	IInput *Input() const;
+	ITextRender *TextRender() const;
+	CUI *UI() const { return s_pUI; }
+};
+
 class CButtonContainer
 {
 };

--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -131,9 +131,6 @@ protected:
 	CUI *UI() const { return m_pUI; }
 	std::vector<SUIElementRect> m_vUIRects;
 
-	// used for marquees or other user implemented things
-	int64_t m_ElementTime;
-
 public:
 	CUIElement() = default;
 

--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -136,7 +136,7 @@ public:
 
 	void Init(CUI *pUI, int RequestedRectCount);
 
-	SUIElementRect *Get(size_t Index)
+	SUIElementRect *Rect(size_t Index)
 	{
 		return &m_vUIRects[Index];
 	}

--- a/src/game/client/ui_scrollregion.cpp
+++ b/src/game/client/ui_scrollregion.cpp
@@ -1,0 +1,220 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#include <base/system.h>
+#include <base/vmath.h>
+
+#include <engine/client.h>
+#include <engine/keys.h>
+
+#include "ui_scrollregion.h"
+
+CScrollRegion::CScrollRegion()
+{
+	m_ScrollY = 0.0f;
+	m_ContentH = 0.0f;
+	m_AnimTime = 0.0f;
+	m_AnimInitScrollY = 0.0f;
+	m_AnimTargetScrollY = 0.0f;
+	m_RequestScrollY = -1.0f;
+	m_ContentScrollOff = vec2(0.0f, 0.0f);
+	m_Params = CScrollRegionParams();
+}
+
+void CScrollRegion::Begin(CUIRect *pClipRect, vec2 *pOutOffset, CScrollRegionParams *pParams)
+{
+	if(pParams)
+		m_Params = *pParams;
+
+	const bool ContentOverflows = m_ContentH > pClipRect->h;
+	const bool ForceShowScrollbar = m_Params.m_Flags & CScrollRegionParams::FLAG_CONTENT_STATIC_WIDTH;
+
+	CUIRect ScrollBarBg;
+	bool HasScrollBar = ContentOverflows || ForceShowScrollbar;
+	CUIRect *pModifyRect = HasScrollBar ? pClipRect : nullptr;
+	pClipRect->VSplitRight(m_Params.m_ScrollbarWidth, pModifyRect, &ScrollBarBg);
+	ScrollBarBg.Margin(m_Params.m_ScrollbarMargin, &m_RailRect);
+
+	// only show scrollbar if required
+	if(HasScrollBar)
+	{
+		if(m_Params.m_ScrollbarBgColor.a > 0.0f)
+			ScrollBarBg.Draw(m_Params.m_ScrollbarBgColor, IGraphics::CORNER_R, 4.0f);
+		if(m_Params.m_RailBgColor.a > 0.0f)
+			m_RailRect.Draw(m_Params.m_RailBgColor, IGraphics::CORNER_ALL, m_RailRect.w / 2.0f);
+	}
+	if(!ContentOverflows)
+		m_ContentScrollOff.y = 0.0f;
+
+	if(m_Params.m_ClipBgColor.a > 0.0f)
+		pClipRect->Draw(m_Params.m_ClipBgColor, HasScrollBar ? IGraphics::CORNER_L : IGraphics::CORNER_ALL, 4.0f);
+
+	UI()->ClipEnable(pClipRect);
+
+	m_ClipRect = *pClipRect;
+	m_ContentH = 0.0f;
+	*pOutOffset = m_ContentScrollOff;
+}
+
+void CScrollRegion::End()
+{
+	UI()->ClipDisable();
+
+	// only show scrollbar if content overflows
+	if(m_ContentH <= m_ClipRect.h)
+		return;
+
+	// scroll wheel
+	CUIRect RegionRect = m_ClipRect;
+	RegionRect.w += m_Params.m_ScrollbarWidth;
+
+	const float AnimationDuration = 0.5f;
+
+	if(UI()->Enabled() && UI()->MouseHovered(&RegionRect))
+	{
+		const bool IsPageScroll = Input()->KeyIsPressed(KEY_LALT) || Input()->KeyIsPressed(KEY_RALT);
+		const float ScrollUnit = IsPageScroll ? m_ClipRect.h : m_Params.m_ScrollUnit;
+		if(Input()->KeyPress(KEY_MOUSE_WHEEL_UP))
+		{
+			m_AnimTime = AnimationDuration;
+			m_AnimInitScrollY = m_ScrollY;
+			m_AnimTargetScrollY -= ScrollUnit;
+		}
+		else if(Input()->KeyPress(KEY_MOUSE_WHEEL_DOWN))
+		{
+			m_AnimTime = AnimationDuration;
+			m_AnimInitScrollY = m_ScrollY;
+			m_AnimTargetScrollY += ScrollUnit;
+		}
+	}
+
+	const float SliderHeight = maximum(m_Params.m_SliderMinHeight, m_ClipRect.h / m_ContentH * m_RailRect.h);
+
+	CUIRect Slider = m_RailRect;
+	Slider.h = SliderHeight;
+
+	const float MaxSlider = m_RailRect.h - SliderHeight;
+	const float MaxScroll = m_ContentH - m_ClipRect.h;
+
+	if(m_RequestScrollY >= 0.0f)
+	{
+		m_AnimTargetScrollY = m_RequestScrollY;
+		m_AnimTime = 0.0f;
+		m_RequestScrollY = -1.0f;
+	}
+
+	m_AnimTargetScrollY = clamp(m_AnimTargetScrollY, 0.0f, MaxScroll);
+
+	if(absolute(m_AnimInitScrollY - m_AnimTargetScrollY) < 0.5f)
+		m_AnimTime = 0.0f;
+
+	if(m_AnimTime > 0.0f)
+	{
+		m_AnimTime -= Client()->RenderFrameTime();
+		float AnimProgress = (1.0f - powf(m_AnimTime / AnimationDuration, 3.0f)); // cubic ease out
+		m_ScrollY = m_AnimInitScrollY + (m_AnimTargetScrollY - m_AnimInitScrollY) * AnimProgress;
+	}
+	else
+	{
+		m_ScrollY = m_AnimTargetScrollY;
+	}
+
+	Slider.y += m_ScrollY / MaxScroll * MaxSlider;
+
+	bool Hovered = false;
+	bool Grabbed = false;
+	const void *pID = &m_ScrollY;
+	const bool InsideSlider = UI()->MouseHovered(&Slider);
+	const bool InsideRail = UI()->MouseHovered(&m_RailRect);
+
+	if(UI()->CheckActiveItem(pID) && UI()->MouseButton(0))
+	{
+		float MouseY = UI()->MouseY();
+		m_ScrollY += (MouseY - (Slider.y + m_SliderGrabPos.y)) / MaxSlider * MaxScroll;
+		m_SliderGrabPos.y = clamp(m_SliderGrabPos.y, 0.0f, SliderHeight);
+		m_AnimTargetScrollY = m_ScrollY;
+		m_AnimTime = 0.0f;
+		Grabbed = true;
+	}
+	else if(InsideSlider)
+	{
+		UI()->SetHotItem(pID);
+
+		if(!UI()->CheckActiveItem(pID) && UI()->MouseButtonClicked(0))
+		{
+			UI()->SetActiveItem(pID);
+			m_SliderGrabPos.y = UI()->MouseY() - Slider.y;
+			m_AnimTargetScrollY = m_ScrollY;
+			m_AnimTime = 0.0f;
+		}
+		Hovered = true;
+	}
+	else if(InsideRail && UI()->MouseButtonClicked(0))
+	{
+		m_ScrollY += (UI()->MouseY() - (Slider.y + Slider.h / 2.0f)) / MaxSlider * MaxScroll;
+		UI()->SetActiveItem(pID);
+		m_SliderGrabPos.y = Slider.h / 2.0f;
+		m_AnimTargetScrollY = m_ScrollY;
+		m_AnimTime = 0.0f;
+		Hovered = true;
+	}
+	else if(UI()->CheckActiveItem(pID) && !UI()->MouseButton(0))
+	{
+		UI()->SetActiveItem(nullptr);
+	}
+
+	m_ScrollY = clamp(m_ScrollY, 0.0f, MaxScroll);
+	m_ContentScrollOff.y = -m_ScrollY;
+
+	Slider.Draw(m_Params.SliderColor(Grabbed, Hovered), IGraphics::CORNER_ALL, Slider.w / 2.0f);
+}
+
+bool CScrollRegion::AddRect(const CUIRect &Rect, bool ShouldScrollHere)
+{
+	m_LastAddedRect = Rect;
+	// Round up and add 1 to fix pixel clipping at the end of the scrolling area
+	m_ContentH = maximum(ceilf(Rect.y + Rect.h - (m_ClipRect.y + m_ContentScrollOff.y)) + 1.0f, m_ContentH);
+	if(ShouldScrollHere)
+		ScrollHere();
+	return !IsRectClipped(Rect);
+}
+
+void CScrollRegion::ScrollHere(EScrollOption Option)
+{
+	const float MinHeight = minimum(m_ClipRect.h, m_LastAddedRect.h);
+	const float TopScroll = m_LastAddedRect.y - (m_ClipRect.y + m_ContentScrollOff.y);
+
+	switch(Option)
+	{
+	case SCROLLHERE_TOP:
+		m_RequestScrollY = TopScroll;
+		break;
+
+	case SCROLLHERE_BOTTOM:
+		m_RequestScrollY = TopScroll - (m_ClipRect.h - MinHeight);
+		break;
+
+	case SCROLLHERE_KEEP_IN_VIEW:
+	default:
+		const float DeltaY = m_LastAddedRect.y - m_ClipRect.y;
+		if(DeltaY < 0)
+			m_RequestScrollY = TopScroll;
+		else if(DeltaY > (m_ClipRect.h - MinHeight))
+			m_RequestScrollY = TopScroll - (m_ClipRect.h - MinHeight);
+		break;
+	}
+}
+
+bool CScrollRegion::IsRectClipped(const CUIRect &Rect) const
+{
+	return (m_ClipRect.x > (Rect.x + Rect.w) || (m_ClipRect.x + m_ClipRect.w) < Rect.x || m_ClipRect.y > (Rect.y + Rect.h) || (m_ClipRect.y + m_ClipRect.h) < Rect.y);
+}
+
+bool CScrollRegion::IsScrollbarShown() const
+{
+	return m_ContentH > m_ClipRect.h;
+}
+
+bool CScrollRegion::IsAnimating() const
+{
+	return m_AnimTime > 0.0f;
+}

--- a/src/game/client/ui_scrollregion.h
+++ b/src/game/client/ui_scrollregion.h
@@ -1,0 +1,123 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#ifndef GAME_CLIENT_UI_SCROLLREGION_H
+#define GAME_CLIENT_UI_SCROLLREGION_H
+
+#include "ui.h"
+
+struct CScrollRegionParams
+{
+	float m_ScrollbarWidth;
+	float m_ScrollbarMargin;
+	float m_SliderMinHeight;
+	float m_ScrollUnit;
+	ColorRGBA m_ClipBgColor;
+	ColorRGBA m_ScrollbarBgColor;
+	ColorRGBA m_RailBgColor;
+	ColorRGBA m_SliderColor;
+	ColorRGBA m_SliderColorHover;
+	ColorRGBA m_SliderColorGrabbed;
+	unsigned m_Flags;
+
+	enum
+	{
+		FLAG_CONTENT_STATIC_WIDTH = 1 << 0,
+	};
+
+	CScrollRegionParams()
+	{
+		m_ScrollbarWidth = 20.0f;
+		m_ScrollbarMargin = 5.0f;
+		m_SliderMinHeight = 25.0f;
+		m_ScrollUnit = 10.0f;
+		m_ClipBgColor = ColorRGBA(0.0f, 0.0f, 0.0f, 0.0f);
+		m_ScrollbarBgColor = ColorRGBA(0.0f, 0.0f, 0.0f, 0.0f);
+		m_RailBgColor = ColorRGBA(1.0f, 1.0f, 1.0f, 0.25f);
+		m_SliderColor = ColorRGBA(0.8f, 0.8f, 0.8f, 1.0f);
+		m_SliderColorHover = ColorRGBA(1.0f, 1.0f, 1.0f, 1.0f);
+		m_SliderColorGrabbed = ColorRGBA(0.9f, 0.9f, 0.9f, 1.0f);
+		m_Flags = 0;
+	}
+
+	ColorRGBA SliderColor(bool Active, bool Hovered) const
+	{
+		if(Active)
+			return m_SliderColorGrabbed;
+		else if(Hovered)
+			return m_SliderColorHover;
+		return m_SliderColor;
+	}
+};
+
+/*
+Usage:
+	-- Initialization --
+	static CScrollRegion s_ScrollRegion;
+	vec2 ScrollOffset(0, 0);
+	s_ScrollRegion.Begin(&ScrollRegionRect, &ScrollOffset);
+	Content = ScrollRegionRect;
+	Content.y += ScrollOffset.y;
+
+	-- "Register" your content rects --
+	CUIRect Rect;
+	Content.HSplitTop(SomeValue, &Rect, &Content);
+	s_ScrollRegion.AddRect(Rect);
+
+	-- [Optional] Knowing if a rect is clipped --
+	s_ScrollRegion.IsRectClipped(Rect);
+
+	-- [Optional] Scroll to a rect (to the last added rect)--
+	...
+	s_ScrollRegion.AddRect(Rect);
+	s_ScrollRegion.ScrollHere(Option);
+
+	-- [Convenience] Add rect and check for visibility at the same time
+	if(s_ScrollRegion.AddRect(Rect))
+		// The rect is visible (not clipped)
+
+	-- [Convenience] Add rect and scroll to it if it's selected
+	if(s_ScrollRegion.AddRect(Rect, ScrollToSelection && IsSelected))
+		// The rect is visible (not clipped)
+
+	-- End --
+	s_ScrollRegion.End();
+*/
+
+// Instances of CScrollRegion must be static, as member addresses are used as UI item IDs
+class CScrollRegion : private CUIElementBase
+{
+private:
+	float m_ScrollY;
+	float m_ContentH;
+	float m_RequestScrollY; // [0, ContentHeight]
+
+	float m_AnimTime;
+	float m_AnimInitScrollY;
+	float m_AnimTargetScrollY;
+
+	CUIRect m_ClipRect;
+	CUIRect m_RailRect;
+	CUIRect m_LastAddedRect; // saved for ScrollHere()
+	vec2 m_SliderGrabPos; // where did user grab the slider
+	vec2 m_ContentScrollOff;
+	CScrollRegionParams m_Params;
+
+public:
+	enum EScrollOption
+	{
+		SCROLLHERE_KEEP_IN_VIEW = 0,
+		SCROLLHERE_TOP,
+		SCROLLHERE_BOTTOM,
+	};
+
+	CScrollRegion();
+	void Begin(CUIRect *pClipRect, vec2 *pOutOffset, CScrollRegionParams *pParams = nullptr);
+	void End();
+	bool AddRect(const CUIRect &Rect, bool ShouldScrollHere = false); // returns true if the added rect is visible (not clipped)
+	void ScrollHere(EScrollOption Option = SCROLLHERE_KEEP_IN_VIEW);
+	bool IsRectClipped(const CUIRect &Rect) const;
+	bool IsScrollbarShown() const;
+	bool IsAnimating() const;
+};
+
+#endif

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -6392,6 +6392,8 @@ void CEditor::PlaceBorderTiles()
 
 void CEditor::OnUpdate()
 {
+	CUIElementBase::Init(UI()); // update static pointer because game and editor use separate UI
+
 	if(!m_EditorWasUsedBefore)
 	{
 		m_EditorWasUsedBefore = true;

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -3286,9 +3286,6 @@ int CEditor::DoProperties(CUIRect *pToolBox, CProperty *pProps, int *pIDs, int *
 
 void CEditor::RenderLayers(CUIRect ToolBox, CUIRect View)
 {
-	if(!m_GuiActive)
-		return;
-
 	CUIRect LayersBox = ToolBox;
 	CUIRect Slot, Button;
 	char aBuf[64];
@@ -3987,9 +3984,6 @@ void CEditor::SortImages()
 
 void CEditor::RenderImages(CUIRect ToolBox, CUIRect View)
 {
-	if(!m_GuiActive)
-		return;
-
 	static float s_ScrollValue = 0;
 	float ImagesHeight = 30.0f + 14.0f * m_Map.m_vpImages.size() + 27.0f;
 	float ScrollDifference = ImagesHeight - ToolBox.h;
@@ -4201,9 +4195,6 @@ void CEditor::RenderImages(CUIRect ToolBox, CUIRect View)
 
 void CEditor::RenderSounds(CUIRect ToolBox, CUIRect View)
 {
-	if(!m_GuiActive)
-		return;
-
 	static float s_ScrollValue = 0;
 	float SoundsHeight = 30.0f + 14.0f * m_Map.m_vpSounds.size() + 27.0f;
 	float ScrollDifference = SoundsHeight - ToolBox.h;

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -1127,7 +1127,8 @@ public:
 	bool IsEnvelopeUsed(int EnvelopeIndex) const;
 
 	void RenderLayers(CUIRect LayersBox);
-	void RenderImages(CUIRect Toolbox, CUIRect View);
+	void RenderImagesList(CUIRect Toolbox);
+	void RenderSelectedImage(CUIRect View);
 	void RenderSounds(CUIRect Toolbox, CUIRect View);
 	void RenderModebar(CUIRect View);
 	void RenderStatusbar(CUIRect View);

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -1129,7 +1129,7 @@ public:
 	void RenderLayers(CUIRect LayersBox);
 	void RenderImagesList(CUIRect Toolbox);
 	void RenderSelectedImage(CUIRect View);
-	void RenderSounds(CUIRect Toolbox, CUIRect View);
+	void RenderSounds(CUIRect Toolbox);
 	void RenderModebar(CUIRect View);
 	void RenderStatusbar(CUIRect View);
 	void RenderEnvelopeEditor(CUIRect View);

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -1126,8 +1126,8 @@ public:
 
 	bool IsEnvelopeUsed(int EnvelopeIndex) const;
 
+	void RenderLayers(CUIRect LayersBox);
 	void RenderImages(CUIRect Toolbox, CUIRect View);
-	void RenderLayers(CUIRect Toolbox, CUIRect View);
 	void RenderSounds(CUIRect Toolbox, CUIRect View);
 	void RenderModebar(CUIRect View);
 	void RenderStatusbar(CUIRect View);
@@ -1140,7 +1140,7 @@ public:
 	void AddFileDialogEntry(int Index, CUIRect *pView);
 	void SelectGameLayer();
 	void SortImages();
-	void SelectLayerByTile(float &Scroll);
+	bool SelectLayerByTile();
 
 	//Tile Numbers For Explanations - TODO: Add/Improve tiles and explanations
 	enum

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -10,6 +10,8 @@
 #include <engine/shared/config.h>
 #include <engine/storage.h>
 
+#include <game/client/ui_scrollregion.h>
+
 #include "editor.h"
 
 // popup menu handling
@@ -1247,54 +1249,29 @@ static int g_SelectImageCurrent = -100;
 int CEditor::PopupSelectImage(CEditor *pEditor, CUIRect View, void *pContext)
 {
 	CUIRect ButtonBar, ImageView;
-	View.VSplitLeft(80.0f, &ButtonBar, &View);
+	View.VSplitLeft(150.0f, &ButtonBar, &View);
 	View.Margin(10.0f, &ImageView);
 
 	int ShowImage = g_SelectImageCurrent;
 
-	static float s_ScrollValue = 0;
-	float ImagesHeight = pEditor->m_Map.m_vpImages.size() * 14;
-	float ScrollDifference = ImagesHeight - ButtonBar.h;
+	const float RowHeight = 14.0f;
+	static CScrollRegion s_ScrollRegion;
+	vec2 ScrollOffset(0.0f, 0.0f);
+	CScrollRegionParams ScrollParams;
+	ScrollParams.m_ScrollbarWidth = 10.0f;
+	ScrollParams.m_ScrollbarMargin = 3.0f;
+	ScrollParams.m_ScrollUnit = RowHeight * 5;
+	s_ScrollRegion.Begin(&ButtonBar, &ScrollOffset, &ScrollParams);
+	ButtonBar.y += ScrollOffset.y;
 
-	if(pEditor->m_Map.m_vpImages.size() > 20) // Do we need a scrollbar?
-	{
-		CUIRect Scroll;
-		ButtonBar.VSplitRight(20.0f, &ButtonBar, &Scroll);
-		s_ScrollValue = pEditor->UI()->DoScrollbarV(&s_ScrollValue, &Scroll, s_ScrollValue);
-
-		if(pEditor->UI()->MouseInside(&Scroll) || pEditor->UI()->MouseInside(&ButtonBar))
-		{
-			int ScrollNum = (int)((ImagesHeight - ButtonBar.h) / 14.0f) + 1;
-			if(ScrollNum > 0)
-			{
-				if(pEditor->Input()->KeyPress(KEY_MOUSE_WHEEL_UP))
-					s_ScrollValue = clamp(s_ScrollValue - 1.0f / ScrollNum, 0.0f, 1.0f);
-				if(pEditor->Input()->KeyPress(KEY_MOUSE_WHEEL_DOWN))
-					s_ScrollValue = clamp(s_ScrollValue + 1.0f / ScrollNum, 0.0f, 1.0f);
-			}
-		}
-	}
-
-	float ImageStartAt = ScrollDifference * s_ScrollValue;
-	if(ImageStartAt < 0.0f)
-		ImageStartAt = 0.0f;
-
-	float ImageStopAt = ImagesHeight - ScrollDifference * (1 - s_ScrollValue);
-	float ImageCur = 0.0f;
 	for(int i = -1; i < (int)pEditor->m_Map.m_vpImages.size(); i++)
 	{
-		if(ImageCur > ImageStopAt)
-			break;
-		if(ImageCur < ImageStartAt)
-		{
-			ImageCur += 14.0f;
-			continue;
-		}
-		ImageCur += 14.0f;
-
 		CUIRect Button;
-		ButtonBar.HSplitTop(14.0f, &Button, &ButtonBar);
+		ButtonBar.HSplitTop(RowHeight, &Button, &ButtonBar);
+		if(!s_ScrollRegion.AddRect(Button))
+			continue;
 
+		Button.HSplitTop(12.0f, &Button, 0);
 		if(pEditor->UI()->MouseInside(&Button))
 			ShowImage = i;
 
@@ -1310,6 +1287,8 @@ int CEditor::PopupSelectImage(CEditor *pEditor, CUIRect View, void *pContext)
 				g_SelectImageSelected = i;
 		}
 	}
+
+	s_ScrollRegion.End();
 
 	if(ShowImage >= 0 && (size_t)ShowImage < pEditor->m_Map.m_vpImages.size())
 	{
@@ -1338,7 +1317,7 @@ void CEditor::PopupSelectImageInvoke(int Current, float x, float y)
 	static int s_SelectImagePopupId = 0;
 	g_SelectImageSelected = -100;
 	g_SelectImageCurrent = Current;
-	UiInvokePopupMenu(&s_SelectImagePopupId, 0, x, y, 400, 300, PopupSelectImage);
+	UiInvokePopupMenu(&s_SelectImagePopupId, 0, x, y, 450, 300, PopupSelectImage);
 }
 
 int CEditor::PopupSelectImageResult()


### PR DESCRIPTION
This brings smooth scrolling from upstream to the following UI elements:
- ingame server info MOTD (supercedes #5704)
  - Before:  ![motd old](https://user-images.githubusercontent.com/23437060/185678277-801982e2-f403-441f-af67-0b62ad8841c7.png)
  - After:  ![motd new](https://user-images.githubusercontent.com/23437060/185678284-7e685a36-6a35-4cd2-8f9c-8f2b6e8acc61.png)
- controls settings
  - Before: ![controls old](https://user-images.githubusercontent.com/23437060/185678351-bac742f6-77dd-4f6a-972d-c1fcff8bacf3.png)
  - After:  ![controls new](https://user-images.githubusercontent.com/23437060/185678358-b59f538f-aa81-41ae-938f-bb8349ebf730.png)
- editor images popup
  - Before:  ![layers-and-image-popup old](https://user-images.githubusercontent.com/23437060/185678396-c2bb1db9-fb83-4663-b1f5-4d6ce7f0513a.png)
  - After: ![layers-and-image-popup new](https://user-images.githubusercontent.com/23437060/185678404-ade20158-3ee3-43f8-93e6-e27533b9064a.png)
- editor layers list (see above screenshots)
- editor images list
  - Before: ![images old](https://user-images.githubusercontent.com/23437060/185678425-b184798a-7e46-4bd4-9699-0430352192a2.png)
  - After:  ![images new](https://user-images.githubusercontent.com/23437060/185678432-09977bff-1a1d-4873-be3c-a9b96f518f28.png)
- editor sounds list
  - Before:  ![sounds old](https://user-images.githubusercontent.com/23437060/185678462-10381845-07f2-4ea3-bb38-67443bc2b833.png)
  - After: ![sounds new](https://user-images.githubusercontent.com/23437060/185678483-217cc13f-b1fd-4c55-8fc2-a80378048668.png)

## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
