### PR TITLE
Auto refresh skins when changing related settings

### DIFF
--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -103,6 +103,8 @@ class CMenus : public CComponent
 
 	void RenderColorPicker();
 
+	void RefreshSkins();
+
 	// new gui with gui elements
 	template<typename T>
 	int DoButtonMenu(CUIElement &UIElement, const void *pID, T &&GetTextLambda, int Checked, const CUIRect *pRect, bool HintRequiresStringCheck, bool HintCanChangePositionOrSize = false, int Corners = IGraphics::CORNER_ALL, float r = 5.0f, float FontFactor = 0.0f, vec4 ColorHot = vec4(1.0f, 1.0f, 1.0f, 0.75f), vec4 Color = vec4(1, 1, 1, 0.5f), int AlignVertically = 1)

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -668,10 +668,6 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 			if((pSkinToBeSelected->m_aName[0] == 'x' && pSkinToBeSelected->m_aName[1] == '_'))
 				continue;
 
-			// vanilla skins only
-			if(g_Config.m_ClVanillaSkinsOnly && !pSkinToBeSelected->m_IsVanilla)
-				continue;
-
 			if(pSkinToBeSelected == 0)
 				continue;
 

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -409,6 +409,18 @@ struct CUISkin
 	bool operator==(const char *pOther) const { return !str_comp_nocase(m_pSkin->m_aName, pOther); }
 };
 
+void CMenus::RefreshSkins()
+{
+	auto SkinStartLoadTime = time_get_nanoseconds();
+	m_pClient->m_Skins.Refresh([&](int) {
+		// if skin refreshing takes to long, swap to a loading screen
+		if(time_get_nanoseconds() - SkinStartLoadTime > 500ms)
+		{
+			RenderLoading(Localize("Loading skin files"), "", 0, false);
+		}
+	});
+}
+
 void CMenus::RenderSettingsTee(CUIRect MainView)
 {
 	CUIRect Button, Label, Dummy, DummyLabel, SkinList, QuickSearch, QuickSearchClearButton, SkinDB, SkinPrefix, SkinPrefixLabel, DirectoryButton, RefreshButton, Eyes, EyesLabel, EyesTee, EyesRight;
@@ -470,6 +482,8 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 	if(DoButton_CheckBox(&g_Config.m_ClDownloadSkins, Localize("Download skins"), g_Config.m_ClDownloadSkins, &DummyLabel))
 	{
 		g_Config.m_ClDownloadSkins ^= 1;
+		RefreshSkins();
+		s_InitSkinlist = true;
 	}
 
 	Dummy.HSplitTop(20.0f, &DummyLabel, &Dummy);
@@ -477,6 +491,8 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 	if(DoButton_CheckBox(&g_Config.m_ClDownloadCommunitySkins, Localize("Download community skins"), g_Config.m_ClDownloadCommunitySkins, &DummyLabel))
 	{
 		g_Config.m_ClDownloadCommunitySkins ^= 1;
+		RefreshSkins();
+		s_InitSkinlist = true;
 	}
 
 	Dummy.HSplitTop(20.0f, &DummyLabel, &Dummy);
@@ -484,6 +500,7 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 	if(DoButton_CheckBox(&g_Config.m_ClVanillaSkinsOnly, Localize("Vanilla skins only"), g_Config.m_ClVanillaSkinsOnly, &DummyLabel))
 	{
 		g_Config.m_ClVanillaSkinsOnly ^= 1;
+		RefreshSkins();
 		s_InitSkinlist = true;
 	}
 
@@ -779,14 +796,7 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 		// reset render flags for possible loading screen
 		TextRender()->SetRenderFlags(0);
 		TextRender()->SetCurFont(NULL);
-		auto SkinStartLoadTime = time_get_nanoseconds();
-		m_pClient->m_Skins.Refresh([&](int) {
-			// if skin refreshing takes to long, swap to a loading screen
-			if(time_get_nanoseconds() - SkinStartLoadTime > 500ms)
-			{
-				RenderLoading(Localize("Loading skin files"), "", 0, false);
-			}
-		});
+		RefreshSkins();
 		s_InitSkinlist = true;
 		if(Client()->State() >= IClient::STATE_ONLINE)
 		{

--- a/src/game/client/components/skins.cpp
+++ b/src/game/client/components/skins.cpp
@@ -65,6 +65,9 @@ int CSkins::SkinScan(const char *pName, int IsDir, int DirType, void *pUser)
 	str_copy(aNameWithoutPng, pName);
 	aNameWithoutPng[str_length(aNameWithoutPng) - 4] = 0;
 
+	if(g_Config.m_ClVanillaSkinsOnly && !IsVanillaSkin(aNameWithoutPng))
+		return 0;
+
 	// Don't add duplicate skins (one from user's config directory, other from
 	// client itself)
 	for(int i = 0; i < pSelf->Num(); i++)
@@ -154,7 +157,6 @@ int CSkins::LoadSkin(const char *pName, CImageInfo &Info)
 	}
 
 	CSkin Skin;
-	Skin.m_IsVanilla = IsVanillaSkin(pName);
 	Skin.m_OriginalSkin.m_Body = Graphics()->LoadSpriteTexture(Info, &g_pData->m_aSprites[SPRITE_TEE_BODY]);
 	Skin.m_OriginalSkin.m_BodyOutline = Graphics()->LoadSpriteTexture(Info, &g_pData->m_aSprites[SPRITE_TEE_BODY_OUTLINE]);
 	Skin.m_OriginalSkin.m_Feet = Graphics()->LoadSpriteTexture(Info, &g_pData->m_aSprites[SPRITE_TEE_FOOT]);
@@ -355,7 +357,6 @@ void CSkins::Refresh(TSkinLoadedCBFunc &&SkinLoadedFunc)
 	{
 		Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "gameclient", "failed to load skins. folder='skins/'");
 		CSkin DummySkin;
-		DummySkin.m_IsVanilla = true;
 		str_copy(DummySkin.m_aName, "dummy");
 		DummySkin.m_BloodColor = ColorRGBA(1.0f, 1.0f, 1.0f);
 		m_vSkins.push_back(DummySkin);

--- a/src/game/client/skin.h
+++ b/src/game/client/skin.h
@@ -8,8 +8,6 @@
 // do this better and nicer
 struct CSkin
 {
-	bool m_IsVanilla;
-
 	struct SSkinTextures
 	{
 		IGraphics::CTextureHandle m_Body;


### PR DESCRIPTION
motivation: downloaded skins aren't resettet, e.g. if they failed before. config change -> resets everything

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
