### PR TITLE
Fix symlink handling of `fs_listdir`

### DIFF
--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -2095,7 +2095,7 @@ void fs_listdir(const char *dir, FS_LISTDIR_CALLBACK cb, int type, void *user)
 	{
 		WideCharToMultiByte(CP_UTF8, 0, finddata.cFileName, -1, buffer2, sizeof(buffer2), NULL, NULL);
 		str_copy(buffer + length, buffer2, (int)sizeof(buffer) - length);
-		if(cb(buffer2, (finddata.dwFileAttributes & (FILE_ATTRIBUTE_DIRECTORY || FILE_ATTRIBUTE_REPARSE_POINT)) != 0, type, user))
+		if(cb(buffer2, (finddata.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0, type, user))
 			break;
 	} while(FindNextFileW(handle, &finddata));
 
@@ -2115,7 +2115,7 @@ void fs_listdir(const char *dir, FS_LISTDIR_CALLBACK cb, int type, void *user)
 	while((entry = readdir(d)) != NULL)
 	{
 		str_copy(buffer + length, entry->d_name, (int)sizeof(buffer) - length);
-		if(cb(entry->d_name, entry->d_type == DT_UNKNOWN ? fs_is_dir(buffer) : entry->d_type == DT_DIR || entry->d_type == DT_LNK, type, user))
+		if(cb(entry->d_name, fs_is_dir(buffer), type, user))
 			break;
 	}
 
@@ -2155,7 +2155,7 @@ void fs_listdir_fileinfo(const char *dir, FS_LISTDIR_CALLBACK_FILEINFO cb, int t
 		info.m_TimeCreated = filetime_to_unixtime(&finddata.ftCreationTime);
 		info.m_TimeModified = filetime_to_unixtime(&finddata.ftLastWriteTime);
 
-		if(cb(&info, (finddata.dwFileAttributes & (FILE_ATTRIBUTE_DIRECTORY || FILE_ATTRIBUTE_REPARSE_POINT)) != 0, type, user))
+		if(cb(&info, (finddata.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0, type, user))
 			break;
 	} while(FindNextFileW(handle, &finddata));
 
@@ -2184,7 +2184,7 @@ void fs_listdir_fileinfo(const char *dir, FS_LISTDIR_CALLBACK_FILEINFO cb, int t
 		info.m_TimeCreated = created;
 		info.m_TimeModified = modified;
 
-		if(cb(&info, entry->d_type == DT_UNKNOWN ? fs_is_dir(buffer) : entry->d_type == DT_DIR || entry->d_type == DT_LNK, type, user))
+		if(cb(&info, fs_is_dir(buffer), type, user))
 			break;
 	}
 


### PR DESCRIPTION
On Windows, the check was incorrectly using logical or instead of bitwise or. Checking for the flag `FILE_ATTRIBUTE_REPARSE_POINT` is not necessary, as the `FILE_ATTRIBUTE_DIRECTORY` will correctly be set when the target of a symbolic link is a directory. This otherwise causes symbolic links to files to be incorrectly handled as directories.

On Linux, the minor performance optimization of using `entry->d_type` is reverted and `fs_is_dir` is used instead. This internally uses `stat`, which correctly returns the attributes for the symbolic link targets.

Closes #5752. Closes #5753.

## Checklist

- [X] Tested the change ingame (only on Windows)
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
