### PR TITLE
Make file link absolute, add `fs_is_relative_path`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -721,7 +721,7 @@ endif()
 if(TARGET_OS STREQUAL "windows")
   set(PLATFORM_CLIENT)
   set(PLATFORM_CLIENT_LIBS opengl32 winmm)
-  set(PLATFORM_LIBS version ws2_32) # Windows sockets
+  set(PLATFORM_LIBS shlwapi version ws2_32) # Windows sockets
 elseif(TARGET_OS STREQUAL "mac")
   find_library(CARBON Carbon)
   find_library(COCOA Cocoa)

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -1822,6 +1822,15 @@ int fs_storage_path(const char *appname, char *path, int max);
 int fs_is_dir(const char *path);
 
 /*
+    Function: fs_is_relative_path
+        Checks whether a given path is relative or absolute.
+
+    Returns:
+        Returns 1 if relative, 0 if absolute.
+*/
+int fs_is_relative_path(const char *path);
+
+/*
 	Function: fs_chdir
 		Changes current working directory
 


### PR DESCRIPTION
This fixes links not opening for relative paths, as links like `file://temp/skins` cannot be resolved by the shell.

Closes #5746.

## Checklist

- [X] Tested the change ingame (only on Windows)
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
