### PR TITLE
Add `CWindowsComLifecycle` RAII wrapper for Windows COM library

### DIFF
--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -65,6 +65,7 @@
 
 #include <cerrno>
 #include <io.h>
+#include <objbase.h>
 #include <process.h>
 #include <share.h>
 #include <shellapi.h>
@@ -4198,6 +4199,17 @@ int net_socket_read_wait(NETSOCKET sock, std::chrono::nanoseconds nanoseconds)
 	using namespace std::chrono_literals;
 	return ::net_socket_read_wait(sock, (nanoseconds / std::chrono::nanoseconds(1us).count()).count());
 }
+
+#if defined(CONF_FAMILY_WINDOWS)
+CWindowsComLifecycle::CWindowsComLifecycle()
+{
+	CoInitializeEx(NULL, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);
+}
+CWindowsComLifecycle::~CWindowsComLifecycle()
+{
+	CoUninitialize();
+}
+#endif
 
 size_t std::hash<NETADDR>::operator()(const NETADDR &Addr) const noexcept
 {

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -2515,6 +2515,19 @@ public:
 	}
 };
 
+#if defined(CONF_FAMILY_WINDOWS)
+/**
+ * This is a RAII wrapper to initialize/uninitialize the Windows COM library,
+ * which may be necessary for using the open_file and open_link functions.
+ */
+class CWindowsComLifecycle
+{
+public:
+	CWindowsComLifecycle();
+	~CWindowsComLifecycle();
+};
+#endif
+
 /**
  * Copies a string to a fixed-size array of chars.
  *

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -4561,6 +4561,8 @@ int main(int argc, const char **argv)
 {
 #if defined(CONF_PLATFORM_ANDROID)
 	const char **argv = const_cast<const char **>(argv2);
+#elif defined(CONF_FAMILY_WINDOWS)
+	CWindowsComLifecycle WindowsComLifecycle;
 #endif
 	CCmdlineFix CmdlineFix(&argc, &argv);
 	bool Silent = false;


### PR DESCRIPTION
I can't reproduce the crash/hang from #5744, so I don't know if this fixes the issue.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
