### PR TITLE
Shellcheck Unused headers CI

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -52,4 +52,4 @@ jobs:
         find . -type f -name "*.py" -not -path './ddnet-libs/*' -not -path './googletest-src/*' -print0 | xargs -0 pylint
     - name: Unused headers
       run: |
-        find src -name '*.h' | while read i; do grep -r -q $(basename $i) || (echo "Header file $i is unused" && exit 1); done
+        find src -name '*.h' | while read -r i; do grep -r -q "$(basename "$i")" || (echo "Header file $i is unused" && exit 1); done


### PR DESCRIPTION
```
find src -name '*.h' | while read i; do grep -r -q $(basename $i) || (echo "Header file $i is unused" && exit 1); done                                                                                                                                                                                                        
                             ^--^ SC2162 (info): read without -r will mangle backslashes.                                                                                                                                                                                                                                     
                                                   ^------------^ SC2046 (warning): Quote this to prevent word splitting.                                                                                                                                                                                                     
                                                              ^-- SC2086 (info): Double quote to prevent globbing and word splitting.
```