### PR TITLE
Fix variable shadow warnings with MinGW

### DIFF
--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -3040,11 +3040,10 @@ static int hexval(char x)
 	}
 }
 
-static int byteval(const char *byte, unsigned char *dst)
+static int byteval(const char *hex, unsigned char *dst)
 {
-	int v1 = -1, v2 = -1;
-	v1 = hexval(byte[0]);
-	v2 = hexval(byte[1]);
+	int v1 = hexval(hex[0]);
+	int v2 = hexval(hex[1]);
 
 	if(v1 < 0 || v2 < 0)
 		return 1;
@@ -3553,9 +3552,9 @@ int str_utf8_encode(char *ptr, int chr)
 
 static unsigned char str_byte_next(const char **ptr)
 {
-	unsigned char byte = **ptr;
+	unsigned char byte_value = **ptr;
 	(*ptr)++;
-	return byte;
+	return byte_value;
 }
 
 static void str_byte_rewind(const char **ptr)
@@ -3573,35 +3572,35 @@ int str_utf8_decode(const char **ptr)
 	int utf8_bytes_needed = 0;
 	while(true)
 	{
-		unsigned char byte = str_byte_next(ptr);
+		unsigned char byte_value = str_byte_next(ptr);
 		if(utf8_bytes_needed == 0)
 		{
-			if(byte <= 0x7F)
+			if(byte_value <= 0x7F)
 			{
-				return byte;
+				return byte_value;
 			}
-			else if(0xC2 <= byte && byte <= 0xDF)
+			else if(0xC2 <= byte_value && byte_value <= 0xDF)
 			{
 				utf8_bytes_needed = 1;
-				utf8_code_point = byte - 0xC0;
+				utf8_code_point = byte_value - 0xC0;
 			}
-			else if(0xE0 <= byte && byte <= 0xEF)
+			else if(0xE0 <= byte_value && byte_value <= 0xEF)
 			{
-				if(byte == 0xE0)
+				if(byte_value == 0xE0)
 					utf8_lower_boundary = 0xA0;
-				if(byte == 0xED)
+				if(byte_value == 0xED)
 					utf8_upper_boundary = 0x9F;
 				utf8_bytes_needed = 2;
-				utf8_code_point = byte - 0xE0;
+				utf8_code_point = byte_value - 0xE0;
 			}
-			else if(0xF0 <= byte && byte <= 0xF4)
+			else if(0xF0 <= byte_value && byte_value <= 0xF4)
 			{
-				if(byte == 0xF0)
+				if(byte_value == 0xF0)
 					utf8_lower_boundary = 0x90;
-				if(byte == 0xF4)
+				if(byte_value == 0xF4)
 					utf8_upper_boundary = 0x8F;
 				utf8_bytes_needed = 3;
-				utf8_code_point = byte - 0xF0;
+				utf8_code_point = byte_value - 0xF0;
 			}
 			else
 			{
@@ -3610,7 +3609,7 @@ int str_utf8_decode(const char **ptr)
 			utf8_code_point = utf8_code_point << (6 * utf8_bytes_needed);
 			continue;
 		}
-		if(!(utf8_lower_boundary <= byte && byte <= utf8_upper_boundary))
+		if(!(utf8_lower_boundary <= byte_value && byte_value <= utf8_upper_boundary))
 		{
 			// Resetting variables not necessary, will be done when
 			// the function is called again.
@@ -3620,7 +3619,7 @@ int str_utf8_decode(const char **ptr)
 		utf8_lower_boundary = 0x80;
 		utf8_upper_boundary = 0xBF;
 		utf8_bytes_seen += 1;
-		utf8_code_point = utf8_code_point + ((byte - 0x80) << (6 * (utf8_bytes_needed - utf8_bytes_seen)));
+		utf8_code_point = utf8_code_point + ((byte_value - 0x80) << (6 * (utf8_bytes_needed - utf8_bytes_seen)));
 		if(utf8_bytes_seen != utf8_bytes_needed)
 		{
 			continue;


### PR DESCRIPTION
```
ddnet/src/base/system.cpp: In function 'int byteval(const char*, unsigned char*)':
ddnet/src/base/system.cpp:3044:32: warning: declaration of 'byte' shadows a global declaration [-Wshadow]
 3044 | static int byteval(const char *byte, unsigned char *dst)
      |                    ~~~~~~~~~~~~^~~~
In file included from msys64/mingw64/include/objbase.h:8,
                 from ddnet/src/base/system.cpp:68:
msys64/mingw64/include/rpcndr.h:63:25: note: shadowed declaration is here
   63 |   typedef unsigned char byte;
      |                         ^~~~
ddnet/src/base/system.cpp: In function 'unsigned char str_byte_next(const char**)':
ddnet/src/base/system.cpp:3557:23: warning: declaration of 'byte' shadows a global declaration [-Wshadow]
 3557 |         unsigned char byte = **ptr;
      |                       ^~~~
msys64/mingw64/include/rpcndr.h:63:25: note: shadowed declaration is here
   63 |   typedef unsigned char byte;
      |                         ^~~~
ddnet/src/base/system.cpp: In function 'int str_utf8_decode(const char**)':
ddnet/src/base/system.cpp:3577:31: warning: declaration of 'byte' shadows a global declaration [-Wshadow]
 3577 |                 unsigned char byte = str_byte_next(ptr);
      |                               ^~~~
msys64/mingw64/include/rpcndr.h:63:25: note: shadowed declaration is here
   63 |   typedef unsigned char byte;
      |                         ^~~~
```

<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
