### PR TITLE
Fix shotgunfly hitting tee below

### DIFF
--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -428,6 +428,7 @@ void CCharacter::FireWeapon()
 		return;
 
 	vec2 ProjStartPos = m_Pos + Direction * GetProximityRadius() * 0.75f;
+	float ProjStartOffset = distance(m_Pos, ProjStartPos);
 
 	switch(m_Core.m_ActiveWeapon)
 	{
@@ -537,7 +538,7 @@ void CCharacter::FireWeapon()
 		else
 			LaserReach = GameServer()->TuningList()[m_TuneZone].m_LaserReach;
 
-		new CLaser(&GameServer()->m_World, m_Pos, Direction, LaserReach, m_pPlayer->GetCID(), WEAPON_SHOTGUN);
+		new CLaser(&GameServer()->m_World, ProjStartPos, Direction, LaserReach - ProjStartOffset, m_pPlayer->GetCID(), WEAPON_SHOTGUN);
 		GameServer()->CreateSound(m_Pos, SOUND_SHOTGUN_FIRE, TeamMask());
 	}
 	break;
@@ -575,7 +576,7 @@ void CCharacter::FireWeapon()
 		else
 			LaserReach = GameServer()->TuningList()[m_TuneZone].m_LaserReach;
 
-		new CLaser(GameWorld(), m_Pos, Direction, LaserReach, m_pPlayer->GetCID(), WEAPON_LASER);
+		new CLaser(GameWorld(), ProjStartPos, Direction, LaserReach - ProjStartOffset, m_pPlayer->GetCID(), WEAPON_LASER);
 		GameServer()->CreateSound(m_Pos, SOUND_LASER_FIRE, TeamMask());
 	}
 	break;


### PR DESCRIPTION
Sometimes while shotgunflying the shotgun doesnt seem to appear, that is because it hit's the tee below.
That can happen when both tees are extremely close to each other, so that the intersection radius is perfectly reached.
If we move the start position of the shotgun's laser a little bit up, then this is not possible.
It's probably possible to use a lower value than what `ProjStartPos` offers, I just took it as a PoC for now.

Physics changes are always unwanted in DDNet, so I am not sure if this is wanted. I didnt test any side effects this might cause, but I dont think there are any.

Edit: Yes, it should be possible to use a very low number. Something like 8 subtiles should probably be enough already.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
