### PR TITLE
Fix memset compilation

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -1066,7 +1066,7 @@ int CServer::NewClientCallback(int ClientID, void *pUser, bool Sixup)
 	pThis->m_aClients[ClientID].m_DDNetVersion = VERSION_NONE;
 	pThis->m_aClients[ClientID].m_GotDDNetVersionPacket = false;
 	pThis->m_aClients[ClientID].m_DDNetVersionSettled = false;
-	memset(&pThis->m_aClients[ClientID].m_Addr, 0, sizeof(NETADDR));
+	mem_zero(&pThis->m_aClients[ClientID].m_Addr, sizeof(NETADDR));
 	pThis->m_aClients[ClientID].Reset();
 
 	pThis->GameServer()->OnClientEngineJoin(ClientID, Sixup);

--- a/src/engine/shared/websockets.cpp
+++ b/src/engine/shared/websockets.cpp
@@ -170,7 +170,7 @@ static context_data contexts[WS_CONTEXTS];
 int websocket_create(const char *addr, int port)
 {
 	struct lws_context_creation_info info;
-	memset(&info, 0, sizeof(info));
+	mem_zero(&info, sizeof(info));
 	info.port = port;
 	info.iface = addr;
 	info.protocols = protocols;

--- a/src/tools/map_create_pixelart.cpp
+++ b/src/tools/map_create_pixelart.cpp
@@ -6,6 +6,8 @@
 #include <engine/storage.h>
 #include <game/mapitems.h>
 
+#include <cstring>
+
 bool CreatePixelArt(const char[][64], const int[], const int[], int[], const bool[]);
 void InsertCurrentQuads(CDataFileReader &, CMapItemLayerQuads *, CQuad *);
 int InsertPixelArtQuads(CQuad *, int &, const CImageInfo &, const int[], const int[], const bool[]);
@@ -107,7 +109,7 @@ int InsertPixelArtQuads(CQuad *pQuads, int &NumQuads, const CImageInfo &Img, con
 	int ImgPixelSize = aPixelSizes[0], QuadPixelSize = aPixelSizes[1], OriginalNumQuads = NumQuads;
 	int aForcedPivot[2] = {std::numeric_limits<int>::max(), std::numeric_limits<int>::max()};
 	bool *aVisitedPixels = new bool[Img.m_Height * Img.m_Width];
-	memset(aVisitedPixels, 0, sizeof(bool) * Img.m_Height * Img.m_Width);
+	mem_zero(aVisitedPixels, sizeof(bool) * Img.m_Height * Img.m_Width);
 
 	for(int y = 0; y < Img.m_Height; y += ImgPixelSize)
 		for(int x = 0; x < Img.m_Width; x += ImgPixelSize)
@@ -162,7 +164,7 @@ int GetImagePixelSize(const CImageInfo &Img)
 {
 	int ImgPixelSize = std::numeric_limits<int>::max();
 	bool *aVisitedPixels = new bool[Img.m_Height * Img.m_Width];
-	memset(aVisitedPixels, 0, sizeof(bool) * Img.m_Height * Img.m_Width);
+	mem_zero(aVisitedPixels, sizeof(bool) * Img.m_Height * Img.m_Width);
 
 	for(int y = 0; y < Img.m_Height && ImgPixelSize > 1; y++)
 		for(int x = 0; x < Img.m_Width && ImgPixelSize > 1; x++)


### PR DESCRIPTION
```
/home/deen/isos/ddnet/ddnet-source/src/tools/map_create_pixelart.cpp: In function ‘int InsertPixelArtQuads(CQuad*, int&, const CImageInfo&, const int*, const int*, const bool*)’:
/home/deen/isos/ddnet/ddnet-source/src/tools/map_create_pixelart.cpp:110:9: error: ‘memset’ was not declared in this scope
  110 |         memset(aVisitedPixels, 0, sizeof(bool) * Img.m_Height * Img.m_Width);
      |         ^~~~~~
/home/deen/isos/ddnet/ddnet-source/src/tools/map_create_pixelart.cpp:8:1: note: ‘memset’ is defined in header ‘<cstring>’; did you forget to ‘#include <cstring>’?
    7 | #include <game/mapitems.h>
  +++ |+#include <cstring>
    8 |
```
<!-- What is the motivation for the changes of this pull request -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
