### PR TITLE
Draft: start working on editor undo/redo feature

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2111,6 +2111,8 @@ if(CLIENT)
     auto_map.h
     editor.cpp
     editor.h
+	editor_actions.cpp
+    editor_actions.h
     explanations.cpp
     io.cpp
     layer_game.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2111,7 +2111,7 @@ if(CLIENT)
     auto_map.h
     editor.cpp
     editor.h
-	editor_actions.cpp
+    editor_actions.cpp
     editor_actions.h
     explanations.cpp
     io.cpp

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -23,6 +23,7 @@ MACRO_CONFIG_INT(ClRefreshRate, cl_refresh_rate, 0, 0, 10000, CFGFLAG_SAVE | CFG
 MACRO_CONFIG_INT(ClRefreshRateInactive, cl_refresh_rate_inactive, 120, 0, 10000, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Refresh rate for updating the game when the window is inactive (in Hz)")
 MACRO_CONFIG_INT(ClEditor, cl_editor, 0, 0, 1, CFGFLAG_CLIENT, "")
 MACRO_CONFIG_INT(ClEditorDilate, cl_editor_dilate, 1, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Automatically dilates embedded images")
+MACRO_CONFIG_INT(ClEditorMaxHistory, cl_editor_max_history, 50, 1, 100, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Maximum number of undo actions to have in the editor history")
 MACRO_CONFIG_STR(ClSkinFilterString, cl_skin_filter_string, 25, "", CFGFLAG_SAVE | CFGFLAG_CLIENT, "Skin filtering string")
 
 MACRO_CONFIG_INT(ClAutoDemoRecord, cl_auto_demo_record, 1, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Automatically record demos")

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -6524,3 +6524,56 @@ bool CEditorAddLayerAction::Undo()
 	Group->DeleteLayer(m_LayerIndex);
 	return true;
 }
+
+bool CEditorDeleteLayerAction::Undo()
+{
+	CLayerGroup *Group = (CLayerGroup *)m_pObject;
+
+	CLayer *pLayer = m_ValueFrom->Duplicate();
+	if(pLayer->m_Type == LAYERTYPE_TILES)
+	{
+		CLayerTiles *pTilesLayer = (CLayerTiles *)pLayer;
+		if(pTilesLayer->m_Tele)
+			m_pEditor->m_Map.m_pTeleLayer = (CLayerTele *)pLayer;
+		else if(pTilesLayer->m_Tune)
+			m_pEditor->m_Map.m_pTuneLayer = (CLayerTune *)pLayer;
+		else if(pTilesLayer->m_Speedup)
+			m_pEditor->m_Map.m_pSpeedupLayer = (CLayerSpeedup *)pLayer;
+		else if(pTilesLayer->m_Switch)
+			m_pEditor->m_Map.m_pSwitchLayer = (CLayerSwitch *)pLayer;
+		else if(pTilesLayer->m_Front)
+			m_pEditor->m_Map.m_pFrontLayer = (CLayerFront *)pLayer;
+	}
+
+	Group->AddLayer(pLayer);
+	m_pEditor->SelectLayer(Group->m_vpLayers.size() - 1);
+	return true;
+}
+
+bool CEditorDeleteLayerAction::Redo()
+{
+	CLayerGroup *Group = (CLayerGroup *)m_pObject;
+	CLayer *pLayer = m_ValueFrom;
+
+	if(pLayer->m_Type == LAYERTYPE_TILES)
+	{
+		CLayerTiles *pTilesLayer = (CLayerTiles *)pLayer;
+		if(pTilesLayer->m_Tele)
+			m_pEditor->m_Map.m_pTeleLayer = nullptr;
+		else if(pTilesLayer->m_Tune)
+			m_pEditor->m_Map.m_pTuneLayer = nullptr;
+		else if(pTilesLayer->m_Speedup)
+			m_pEditor->m_Map.m_pSpeedupLayer = nullptr;
+		else if(pTilesLayer->m_Switch)
+			m_pEditor->m_Map.m_pSwitchLayer = nullptr;
+		else if(pTilesLayer->m_Front)
+			m_pEditor->m_Map.m_pFrontLayer = nullptr;
+	}
+
+	Group->DeleteLayer(m_LayerIndex);
+
+	if(m_LayerIndex > 0)
+		m_pEditor->SelectLayer(m_LayerIndex - 1);
+
+	return true;
+}

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -1035,7 +1035,7 @@ void CEditor::DoToolbar(CUIRect ToolBar)
 			TB_Top.VSplitLeft(30.0f, &Button, &TB_Top);
 			static int s_UndoButton = 0;
 			int UndoEnabled = m_vpUndoActions.size() > 0;
-			if(DoButton_Ex(&s_UndoButton, "Undo", UndoEnabled-1, &Button, 0, "[Ctrl+Z] Undo", IGraphics::CORNER_L) || (UndoEnabled && ModPressed && Input()->KeyPress(KEY_Z) && m_Dialog == DIALOG_NONE && m_EditBoxActive == 0))
+			if(DoButton_Ex(&s_UndoButton, "Undo", UndoEnabled - 1, &Button, 0, "[Ctrl+Z] Undo", IGraphics::CORNER_L) || (UndoEnabled && ModPressed && m_ShowEnvelopeEditor == 0 && m_ShowServerSettingsEditor == 0 && Input()->KeyPress(KEY_Z) && m_Dialog == DIALOG_NONE && m_EditBoxActive == 0))
 			{
 				//for(auto &pLayer : m_Brush.m_vpLayers)
 				//	pLayer->BrushFlipX();
@@ -1046,7 +1046,7 @@ void CEditor::DoToolbar(CUIRect ToolBar)
 			TB_Top.VSplitLeft(30.0f, &Button, &TB_Top);
 			static int s_RedoButton = 0;
 			int RedoEnabled = m_vpRedoActions.size() > 0;
-			if(DoButton_Ex(&s_RedoButton, "Redo", RedoEnabled-1, &Button, 0, "[Ctrl+Y] Redo", IGraphics::CORNER_R) || (RedoEnabled && ModPressed && Input()->KeyPress(KEY_Y) && m_Dialog == DIALOG_NONE && m_EditBoxActive == 0))
+			if(DoButton_Ex(&s_RedoButton, "Redo", RedoEnabled - 1, &Button, 0, "[Ctrl+Y] Redo", IGraphics::CORNER_R) || (RedoEnabled && ModPressed && m_ShowEnvelopeEditor == 0 && m_ShowServerSettingsEditor == 0 && Input()->KeyPress(KEY_Y) && m_Dialog == DIALOG_NONE && m_EditBoxActive == 0))
 			{
 				dbg_msg("editor", "REEEDOOOO");
 				Redo();

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -1292,7 +1292,7 @@ void CEditor::DoToolbar(CUIRect ToolBar)
 					}
 
 					CQuad *NewQuad = pLayerQuads->NewQuad(x, y, Width, Height);
-					m_EditorHistory.RecordUndoAction(new CEditorAddQuadAction(m_SelectedGroup, m_vSelectedLayers[0], {x, y, Width, Height}));
+					m_EditorHistory.RecordUndoAction(new CEditorAddQuadAction(m_SelectedGroup, m_vSelectedLayers[0], new RECTi({x, y, Width, Height})));
 				}
 				else if(pLayer->m_Type == LAYERTYPE_SOUNDS)
 				{
@@ -5546,7 +5546,7 @@ void CEditor::RenderServerSettingsEditor(CUIRect View, bool ShowServerSettingsEd
 					m_Map.m_vSettings.push_back(Setting);
 					s_CommandSelectedIndex = m_Map.m_vSettings.size() - 1;
 
-					m_ServerSettingsEditorHistory.RecordUndoAction(new CEditorCommandAction(CEditorAction<std::string>::EType::ADD_COMMAND, &s_CommandSelectedIndex, m_Map.m_vSettings.size() - 1, std::string(), Setting.m_aCommand));
+					m_ServerSettingsEditorHistory.RecordUndoAction(new CEditorCommandAction(IEditorAction::EType::ADD_COMMAND, &s_CommandSelectedIndex, m_Map.m_vSettings.size() - 1, std::string(), Setting.m_aCommand));
 				}
 			}
 			UI()->SetActiveItem(&m_CommandBox);
@@ -5571,14 +5571,14 @@ void CEditor::RenderServerSettingsEditor(CUIRect View, bool ShowServerSettingsEd
 						}
 					if(Found)
 					{
-						m_ServerSettingsEditorHistory.RecordUndoAction(new CEditorCommandAction(CEditorAction<std::string>::EType::DELETE_COMMAND, &s_CommandSelectedIndex, s_CommandSelectedIndex, m_Map.m_vSettings[s_CommandSelectedIndex].m_aCommand, std::string()));
+						m_ServerSettingsEditorHistory.RecordUndoAction(new CEditorCommandAction(IEditorAction::EType::DELETE_COMMAND, &s_CommandSelectedIndex, s_CommandSelectedIndex, m_Map.m_vSettings[s_CommandSelectedIndex].m_aCommand, std::string()));
 
 						m_Map.m_vSettings.erase(m_Map.m_vSettings.begin() + s_CommandSelectedIndex);
 						s_CommandSelectedIndex = i > s_CommandSelectedIndex ? i - 1 : i;
 					}
 					else
 					{
-						m_ServerSettingsEditorHistory.RecordUndoAction(new CEditorCommandAction(CEditorAction<std::string>::EType::EDIT_COMMAND, &s_CommandSelectedIndex, s_CommandSelectedIndex, m_Map.m_vSettings[s_CommandSelectedIndex].m_aCommand, m_aSettingsCommand));
+						m_ServerSettingsEditorHistory.RecordUndoAction(new CEditorCommandAction(IEditorAction::EType::EDIT_COMMAND, &s_CommandSelectedIndex, s_CommandSelectedIndex, m_Map.m_vSettings[s_CommandSelectedIndex].m_aCommand, m_aSettingsCommand));
 						str_copy(m_Map.m_vSettings[s_CommandSelectedIndex].m_aCommand, m_aSettingsCommand, sizeof(m_Map.m_vSettings[s_CommandSelectedIndex].m_aCommand));
 					}
 				}
@@ -5590,7 +5590,7 @@ void CEditor::RenderServerSettingsEditor(CUIRect View, bool ShowServerSettingsEd
 			static int s_DelButton = 0;
 			if(DoButton_Editor(&s_DelButton, "Del", 0, &Button, 0, "Delete a command from the command list.") || (Input()->KeyPress(KEY_DELETE) && UI()->LastActiveItem() != &m_CommandBox && m_Dialog == DIALOG_NONE))
 			{
-				m_ServerSettingsEditorHistory.RecordUndoAction(new CEditorCommandAction(CEditorAction<std::string>::EType::DELETE_COMMAND, &s_CommandSelectedIndex, s_CommandSelectedIndex, m_Map.m_vSettings[s_CommandSelectedIndex].m_aCommand, std::string()));
+				m_ServerSettingsEditorHistory.RecordUndoAction(new CEditorCommandAction(IEditorAction::EType::DELETE_COMMAND, &s_CommandSelectedIndex, s_CommandSelectedIndex, m_Map.m_vSettings[s_CommandSelectedIndex].m_aCommand, std::string()));
 
 				m_Map.m_vSettings.erase(m_Map.m_vSettings.begin() + s_CommandSelectedIndex);
 				if(s_CommandSelectedIndex >= (int)m_Map.m_vSettings.size())
@@ -5605,7 +5605,7 @@ void CEditor::RenderServerSettingsEditor(CUIRect View, bool ShowServerSettingsEd
 			static int s_DownButton = 0;
 			if(s_CommandSelectedIndex < (int)m_Map.m_vSettings.size() - 1 && DoButton_Editor(&s_DownButton, "▼", 0, &Button, 0, "Move command down"))
 			{
-				m_ServerSettingsEditorHistory.RecordUndoAction(new CEditorCommandAction(CEditorAction<std::string>::EType::MOVE_COMMAND_DOWN, &s_CommandSelectedIndex, s_CommandSelectedIndex, std::string(), std::string()));
+				m_ServerSettingsEditorHistory.RecordUndoAction(new CEditorCommandAction(IEditorAction::EType::MOVE_COMMAND_DOWN, &s_CommandSelectedIndex, s_CommandSelectedIndex, std::string(), std::string()));
 
 				std::swap(m_Map.m_vSettings[s_CommandSelectedIndex], m_Map.m_vSettings[s_CommandSelectedIndex + 1]);
 				s_CommandSelectedIndex++;
@@ -5616,7 +5616,7 @@ void CEditor::RenderServerSettingsEditor(CUIRect View, bool ShowServerSettingsEd
 			static int s_UpButton = 0;
 			if(s_CommandSelectedIndex > 0 && DoButton_Editor(&s_UpButton, "▲", 0, &Button, 0, "Move command up"))
 			{
-				m_ServerSettingsEditorHistory.RecordUndoAction(new CEditorCommandAction(CEditorAction<std::string>::EType::MOVE_COMMAND_UP, &s_CommandSelectedIndex, s_CommandSelectedIndex, std::string(), std::string()));
+				m_ServerSettingsEditorHistory.RecordUndoAction(new CEditorCommandAction(IEditorAction::EType::MOVE_COMMAND_UP, &s_CommandSelectedIndex, s_CommandSelectedIndex, std::string(), std::string()));
 
 				std::swap(m_Map.m_vSettings[s_CommandSelectedIndex], m_Map.m_vSettings[s_CommandSelectedIndex - 1]);
 				s_CommandSelectedIndex--;
@@ -6715,433 +6715,4 @@ void CEditorHistory::Clear()
 	for(auto *pAction : m_vpUndoActions)
 		delete pAction;
 	m_vpUndoActions.clear();
-}
-
-bool CEditorChangeColorTileAction::Undo()
-{
-	//CLayerTiles *pTileLayer = (CLayerTiles *)m_pObject;
-	CLayerTiles *pTileLayer = (CLayerTiles *)m_pEditor->m_Map.m_vpGroups[m_GroupIndex]->m_vpLayers[m_LayerIndex];
-	pTileLayer->m_Color = m_ValueFrom;
-	return true;
-}
-
-bool CEditorChangeColorTileAction::Redo()
-{
-	//CLayerTiles *pTileLayer = (CLayerTiles *)m_pObject;
-	CLayerTiles *pTileLayer = (CLayerTiles *)m_pEditor->m_Map.m_vpGroups[m_GroupIndex]->m_vpLayers[m_LayerIndex];
-	pTileLayer->m_Color = m_ValueTo;
-	return true;
-}
-
-bool CEditorAddLayerAction::Undo()
-{
-	CLayerGroup *Group = m_pEditor->m_Map.m_vpGroups[m_GroupIndex];
-	CLayer *Layer = Group->m_vpLayers[m_LayerIndex];
-
-	if(Layer == m_pEditor->m_Map.m_pFrontLayer)
-		m_pEditor->m_Map.m_pFrontLayer = nullptr;
-	if(Layer == m_pEditor->m_Map.m_pTeleLayer)
-		m_pEditor->m_Map.m_pTeleLayer = nullptr;
-	if(Layer == m_pEditor->m_Map.m_pSpeedupLayer)
-		m_pEditor->m_Map.m_pSpeedupLayer = nullptr;
-	if(Layer == m_pEditor->m_Map.m_pSwitchLayer)
-		m_pEditor->m_Map.m_pSwitchLayer = nullptr;
-	if(Layer == m_pEditor->m_Map.m_pTuneLayer)
-		m_pEditor->m_Map.m_pTuneLayer = nullptr;
-
-	Group->DeleteLayer(m_LayerIndex);
-	return true;
-}
-
-CEditorDeleteLayerAction::CEditorDeleteLayerAction(CEditor *pEditor, int GroupIndex, int LayerIndex) :
-	CEditorAction(CEditorAction::EType::DELETE_LAYER, nullptr, pEditor->m_Map.m_vpGroups[GroupIndex]->m_vpLayers[LayerIndex]->Duplicate(), nullptr)
-{
-	m_GroupIndex = GroupIndex;
-	m_LayerIndex = LayerIndex;
-}
-
-bool CEditorDeleteLayerAction::Undo()
-{
-	CLayerGroup *Group = m_pEditor->m_Map.m_vpGroups[m_GroupIndex];
-
-	CLayer *pLayer = m_ValueFrom->Duplicate();
-	if(pLayer->m_Type == LAYERTYPE_TILES)
-	{
-		CLayerTiles *pTilesLayer = (CLayerTiles *)pLayer;
-		if(pTilesLayer->m_Tele)
-			m_pEditor->m_Map.m_pTeleLayer = (CLayerTele *)pLayer;
-		else if(pTilesLayer->m_Tune)
-			m_pEditor->m_Map.m_pTuneLayer = (CLayerTune *)pLayer;
-		else if(pTilesLayer->m_Speedup)
-			m_pEditor->m_Map.m_pSpeedupLayer = (CLayerSpeedup *)pLayer;
-		else if(pTilesLayer->m_Switch)
-			m_pEditor->m_Map.m_pSwitchLayer = (CLayerSwitch *)pLayer;
-		else if(pTilesLayer->m_Front)
-			m_pEditor->m_Map.m_pFrontLayer = (CLayerFront *)pLayer;
-	}
-
-	Group->m_vpLayers.insert(Group->m_vpLayers.begin() + m_LayerIndex, pLayer);
-	m_pEditor->m_Map.m_Modified = true;
-
-	m_pEditor->SelectLayer(m_LayerIndex);
-
-	return true;
-}
-
-bool CEditorDeleteLayerAction::Redo()
-{
-	CLayerGroup *Group = m_pEditor->m_Map.m_vpGroups[m_GroupIndex];
-	CLayer *pLayer = m_ValueFrom;
-
-	if(pLayer->m_Type == LAYERTYPE_TILES)
-	{
-		CLayerTiles *pTilesLayer = (CLayerTiles *)pLayer;
-		if(pTilesLayer->m_Tele)
-			m_pEditor->m_Map.m_pTeleLayer = nullptr;
-		else if(pTilesLayer->m_Tune)
-			m_pEditor->m_Map.m_pTuneLayer = nullptr;
-		else if(pTilesLayer->m_Speedup)
-			m_pEditor->m_Map.m_pSpeedupLayer = nullptr;
-		else if(pTilesLayer->m_Switch)
-			m_pEditor->m_Map.m_pSwitchLayer = nullptr;
-		else if(pTilesLayer->m_Front)
-			m_pEditor->m_Map.m_pFrontLayer = nullptr;
-	}
-
-	Group->DeleteLayer(m_LayerIndex);
-	m_pEditor->SelectLayer(maximum(0, m_LayerIndex - 1));
-
-	return true;
-}
-
-bool CEditorEditMultipleLayersAction::Undo()
-{
-	if(m_vLayers.size() != m_ValueFrom.size())
-		return false;
-
-	for(size_t k = 0; k < m_vLayers.size(); k++)
-	{
-		int LayerIndex = m_vLayers[k];
-		CLayerTiles *pLayer = (CLayerTiles *)m_pEditor->m_Map.m_vpGroups[m_GroupIndex]->m_vpLayers[LayerIndex];
-		CLayerTiles::SCommonPropState Original = m_ValueFrom[k];
-
-		pLayer->Resize(Original.m_Width, Original.m_Height);
-
-		pLayer->m_Color.r = (Original.m_Color >> 24) & 0xff;
-		pLayer->m_Color.g = (Original.m_Color >> 16) & 0xff;
-		pLayer->m_Color.b = (Original.m_Color >> 8) & 0xff;
-		pLayer->m_Color.a = Original.m_Color & 0xff;
-
-		pLayer->FlagModified(0, 0, pLayer->m_Width, pLayer->m_Height);
-	}
-
-	return true;
-}
-
-bool CEditorEditMultipleLayersAction::Redo()
-{
-	CLayerTiles::SCommonPropState State = m_ValueTo[0];
-	for(auto LayerIndex : m_vLayers)
-	{
-		CLayerTiles *pLayer = (CLayerTiles *)m_pEditor->m_Map.m_vpGroups[m_GroupIndex]->m_vpLayers[LayerIndex];
-
-		if((State.m_Modified & CLayerTiles::SCommonPropState::MODIFIED_SIZE) != 0)
-			pLayer->Resize(State.m_Width, State.m_Height);
-
-		if((State.m_Modified & CLayerTiles::SCommonPropState::MODIFIED_COLOR) != 0)
-		{
-			pLayer->m_Color.r = (State.m_Color >> 24) & 0xff;
-			pLayer->m_Color.g = (State.m_Color >> 16) & 0xff;
-			pLayer->m_Color.b = (State.m_Color >> 8) & 0xff;
-			pLayer->m_Color.a = State.m_Color & 0xff;
-		}
-
-		pLayer->FlagModified(0, 0, pLayer->m_Width, pLayer->m_Height);
-	}
-
-	return true;
-}
-
-bool CEditorAddGroupAction::Undo()
-{
-	CEditorMap *pMap = (CEditorMap *)m_pObject;
-	pMap->DeleteGroup(m_ValueTo);
-
-	m_pEditor->m_SelectedGroup = maximum(0, m_ValueTo - 1);
-
-	return true;
-}
-
-bool CEditorAddGroupAction::Redo()
-{
-	CEditorMap *pMap = (CEditorMap *)m_pObject;
-	pMap->NewGroup();
-
-	m_pEditor->m_SelectedGroup = m_ValueTo;
-
-	return true;
-}
-
-bool CEditorDeleteGroupAction::Undo()
-{
-	// undo is re-adding back the group
-	CEditorMap *pMap = (CEditorMap *)m_pObject;
-	pMap->m_vpGroups.insert(pMap->m_vpGroups.begin() + m_GroupIndex, new CLayerGroup(*m_ValueFrom));
-	pMap->m_Modified = true;
-
-	m_pEditor->m_SelectedGroup = m_GroupIndex;
-
-	return true;
-}
-
-bool CEditorDeleteGroupAction::Redo()
-{
-	// redo is deleting the group, that's easy
-	CEditorMap *pMap = (CEditorMap *)m_pObject;
-	pMap->DeleteGroup(m_GroupIndex);
-
-	m_pEditor->m_SelectedGroup = maximum(0, m_GroupIndex);
-
-	return true;
-}
-
-bool CEditorFillSelectionAction::Undo()
-{
-	bool OldDestructiveMode = m_pEditor->m_BrushDrawDestructive;
-	m_pEditor->m_BrushDrawDestructive = true;
-
-	// undo is filling back the original tiles
-	CLayerGroup *Brush = m_ValueFrom;
-	CLayerGroup *Group = m_pEditor->m_Map.m_vpGroups[m_GroupIndex];
-
-	size_t NumLayers = m_vLayers.size();
-	for(size_t k = 0; k < NumLayers; k++)
-	{
-		int LayerIndex = m_vLayers[k];
-		CLayer *pLayer = Group->m_vpLayers[LayerIndex];
-
-		size_t BrushIndex = k;
-		if(Brush->m_vpLayers.size() != NumLayers)
-			BrushIndex = 0;
-		CLayer *pBrush = Brush->IsEmpty() ? nullptr : Brush->m_vpLayers[BrushIndex];
-		//dbg_msg("editor", "undoing layer %d, brush index=%d, brush=%p", k, BrushIndex, pBrush);
-
-		pLayer->FillSelection(Brush->IsEmpty(), pBrush, m_Rect);
-	}
-
-	m_pEditor->m_BrushDrawDestructive = OldDestructiveMode;
-	return true;
-}
-
-bool CEditorFillSelectionAction::Redo()
-{
-	bool OldDestructiveMode = m_pEditor->m_BrushDrawDestructive;
-	m_pEditor->m_BrushDrawDestructive = true;
-
-	// redo is redoing the filling with the new tiles
-	CLayerGroup *Brush = m_ValueTo;
-	CLayerGroup *Group = m_pEditor->m_Map.m_vpGroups[m_GroupIndex];
-
-	size_t NumLayers = m_vLayers.size();
-	for(size_t k = 0; k < NumLayers; k++)
-	{
-		int LayerIndex = m_vLayers[k];
-		CLayer *pLayer = Group->m_vpLayers[LayerIndex];
-
-		size_t BrushIndex = k;
-		if(Brush->m_vpLayers.size() != NumLayers)
-			BrushIndex = 0;
-		CLayer *pBrush = Brush->IsEmpty() ? nullptr : Brush->m_vpLayers[BrushIndex];
-
-		pLayer->FillSelection(Brush->IsEmpty(), pBrush, m_Rect);
-	}
-
-	m_pEditor->m_BrushDrawDestructive = OldDestructiveMode;
-	return true;
-}
-
-void CEditorFillSelectionAction::Print()
-{
-	dbg_msg("editor", "editor fill action, num layers=%d, original brush num layers=%d, modified brush num layers=%d", m_vLayers.size(), m_ValueFrom->m_vpLayers.size(), m_ValueTo->m_vpLayers.size());
-	dbg_msg("editor", "rect: w=%f h=%f", m_Rect.w, m_Rect.h);
-}
-
-bool CEditorBrushDrawAction::Undo()
-{
-	// undo is drawing with brush with original data
-	return BrushDraw(m_ValueFrom);
-}
-
-bool CEditorBrushDrawAction::Redo()
-{
-	// redo is drawing with brush with modified data
-	return BrushDraw(m_ValueTo);
-}
-
-bool CEditorBrushDrawAction::BrushDraw(CLayerGroup *Brush)
-{
-	bool OldDestructiveMode = m_pEditor->m_BrushDrawDestructive;
-	m_pEditor->m_BrushDrawDestructive = true;
-
-	CLayerGroup *Group = m_pEditor->m_Map.m_vpGroups[m_GroupIndex];
-
-	int NumLayers = m_vLayers.size();
-
-	if(NumLayers != Brush->m_vpLayers.size())
-		return false;
-
-	for(size_t k = 0; k < NumLayers; k++)
-	{
-		int LayerIndex = m_vLayers[k];
-		CLayer *pLayer = Group->m_vpLayers[LayerIndex];
-		size_t BrushIndex = k;
-
-		if(pLayer->m_Type == Brush->m_vpLayers[BrushIndex]->m_Type)
-		{
-			if(pLayer->m_Type == LAYERTYPE_TILES)
-			{
-				CLayerTiles *pLayerTiles = (CLayerTiles *)pLayer;
-				CLayerTiles *pBrushLayer = (CLayerTiles *)Brush->m_vpLayers[BrushIndex];
-
-				pLayerTiles->BrushDraw(pBrushLayer, 0, 0);
-			}
-			else if(pLayer->m_Type == LAYERTYPE_QUADS)
-			{
-				CLayerQuads *pLayerQuads = (CLayerQuads *)pLayer;
-				CLayerQuads *pBrushLayer = (CLayerQuads *)Brush->m_vpLayers[BrushIndex];
-
-				pLayerQuads->m_vQuads.clear();
-				pLayerQuads->m_vQuads = pBrushLayer->m_vQuads;
-			}
-			else if(pLayer->m_Type == LAYERTYPE_SOUNDS)
-			{
-				CLayerSounds *pLayerSounds = (CLayerSounds *)pLayer;
-				CLayerSounds *pBrushLayer = (CLayerSounds *)Brush->m_vpLayers[BrushIndex];
-
-				pLayerSounds->m_Sound = pBrushLayer->m_Sound;
-
-				pLayerSounds->m_vSources.clear();
-				pLayerSounds->m_vSources = pBrushLayer->m_vSources;
-			}
-		}
-	}
-
-	m_pEditor->m_BrushDrawDestructive = OldDestructiveMode;
-	return true;
-}
-
-void CEditorBrushDrawAction::Print()
-{
-	CLayerGroup *Group = m_pEditor->m_Map.m_vpGroups[m_GroupIndex];
-	dbg_msg("editor", "Undo action: brush draw.");
-	//for(size_t k = 0; k < m_vLayers.size(); k++)
-	//{
-	//	dbg_msg("editor", "   k=%d, layer index=%d (%s)", k, m_vLayers[k], Group->m_vpLayers[m_vLayers[k]]->m_aName);
-	//	dbg_msg("editor", "   brush layer (original) -> %s", m_ValueFrom->m_vpLayers[k]->m_aName);
-	//	dbg_msg("editor", "   brush layer (modified) -> %s", m_ValueTo->m_vpLayers[k]->m_aName);
-	//}
-}
-
-bool CEditorCommandAction::Undo()
-{
-	switch(m_Type)
-	{
-	case CEditorAction::EType::ADD_COMMAND:
-	{
-		m_pEditor->m_Map.m_vSettings.pop_back();
-		*m_pSelectedCommand = m_pEditor->m_Map.m_vSettings.size() - 1;
-		break;
-	}
-	case CEditorAction::EType::EDIT_COMMAND:
-	{
-		str_copy(m_pEditor->m_Map.m_vSettings[m_CommandIndex].m_aCommand, m_ValueFrom.c_str(), sizeof(m_pEditor->m_Map.m_vSettings[m_CommandIndex].m_aCommand));
-		break;
-	}
-	case CEditorAction::EType::DELETE_COMMAND:
-	{
-		CEditorMap::CSetting Setting;
-		str_copy(Setting.m_aCommand, m_ValueFrom.c_str(), sizeof(Setting.m_aCommand));
-		m_pEditor->m_Map.m_vSettings.insert(m_pEditor->m_Map.m_vSettings.begin() + m_CommandIndex, Setting);
-		*m_pSelectedCommand = m_CommandIndex;
-		break;
-	}
-	case CEditorAction::EType::MOVE_COMMAND_UP:
-	{
-		std::swap(m_pEditor->m_Map.m_vSettings[m_CommandIndex], m_pEditor->m_Map.m_vSettings[m_CommandIndex - 1]);
-		*m_pSelectedCommand = m_CommandIndex;
-		break;
-	}
-	case CEditorAction::EType::MOVE_COMMAND_DOWN:
-	{
-		std::swap(m_pEditor->m_Map.m_vSettings[m_CommandIndex], m_pEditor->m_Map.m_vSettings[m_CommandIndex + 1]);
-		*m_pSelectedCommand = m_CommandIndex;
-		break;
-	}
-	default:
-		return false;
-	}
-	return true;
-}
-
-bool CEditorCommandAction::Redo()
-{
-	switch(m_Type)
-	{
-	case CEditorAction::EType::ADD_COMMAND:
-	{
-		CEditorMap::CSetting Setting;
-		str_copy(Setting.m_aCommand, m_ValueTo.c_str(), sizeof(Setting.m_aCommand));
-		m_pEditor->m_Map.m_vSettings.push_back(Setting);
-		*m_pSelectedCommand = m_pEditor->m_Map.m_vSettings.size() - 1;
-		break;
-	}
-	case CEditorAction::EType::EDIT_COMMAND:
-		str_copy(m_pEditor->m_Map.m_vSettings[m_CommandIndex].m_aCommand, m_ValueTo.c_str(), sizeof(m_pEditor->m_Map.m_vSettings[m_CommandIndex].m_aCommand));
-		break;
-	case CEditorAction::EType::DELETE_COMMAND:
-	{
-		m_pEditor->m_Map.m_vSettings.erase(m_pEditor->m_Map.m_vSettings.begin() + m_CommandIndex);
-
-		if(*m_pSelectedCommand >= (int)m_pEditor->m_Map.m_vSettings.size())
-			*m_pSelectedCommand = m_pEditor->m_Map.m_vSettings.size() - 1;
-
-		break;
-	}
-	case CEditorAction::EType::MOVE_COMMAND_UP:
-	{
-		std::swap(m_pEditor->m_Map.m_vSettings[m_CommandIndex], m_pEditor->m_Map.m_vSettings[m_CommandIndex - 1]);
-		*m_pSelectedCommand = m_CommandIndex;
-		break;
-	}
-	case CEditorAction::EType::MOVE_COMMAND_DOWN:
-	{
-		std::swap(m_pEditor->m_Map.m_vSettings[m_CommandIndex], m_pEditor->m_Map.m_vSettings[m_CommandIndex + 1]);
-		*m_pSelectedCommand = m_CommandIndex;
-		break;
-	}
-	default:
-		return false;
-	}
-	return true;
-}
-
-bool CEditorAddQuadAction::Undo()
-{
-	CLayerQuads *pLayer = GetLayer<CLayerQuads>();
-	pLayer->m_vQuads.pop_back();
-
-	m_pEditor->m_Map.m_Modified = true;
-
-	return true;
-}
-
-bool CEditorAddQuadAction::Redo()
-{
-	CLayerQuads *pLayer = GetLayer<CLayerQuads>();
-	RECTi Quad = m_ValueTo;
-	pLayer->NewQuad(Quad.x, Quad.y, Quad.w, Quad.h);
-
-	m_pEditor->m_Map.m_Modified = true;
-
-	return true;
 }

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -3047,13 +3047,12 @@ void CEditor::DoMapEditor(CUIRect View)
 	int i = 0;
 	TextRender()->TextColor(ColorRGBA(1.0, 0.0, 0.0, 1.0));
 	for(auto it = m_vpRedoActions.rbegin(); it != m_vpRedoActions.rend(); ++it)
-		
 	{
 		UI()->DoTextLabel(110, 80 + i * 14, 400, 12, (*it)->Name(), 12, TEXTALIGN_LEFT);
 		i++;
 	}
 	TextRender()->TextColor(ColorRGBA(1.0, 1.0, 1.0, 1.0));
-	for (const auto& Action : m_vpUndoActions)
+	for(const auto &Action : m_vpUndoActions)
 	{
 		UI()->DoTextLabel(110, 80 + i * 14, 400, 12, Action->Name(), 12, TEXTALIGN_LEFT);
 		i++;
@@ -6487,14 +6486,17 @@ void CEditor::RecordUndoAction(IEditorAction *pAction, bool Clear)
 {
 	pAction->m_pEditor = this;
 
-	if (Clear && m_vpRedoActions.size() > 0) {
-		for (auto Action : m_vpRedoActions) {
+	if(Clear && m_vpRedoActions.size() > 0)
+	{
+		for(auto Action : m_vpRedoActions)
+		{
 			delete Action;
 		}
 		m_vpRedoActions.clear();
 	}
 
-	if(m_vpUndoActions.size() >= s_MaxActions) {
+	if(m_vpUndoActions.size() >= s_MaxActions)
+	{
 		m_vpUndoActions.pop_back();
 	}
 
@@ -6502,7 +6504,7 @@ void CEditor::RecordUndoAction(IEditorAction *pAction, bool Clear)
 	pAction->Print();
 }
 
-void CEditor::RecordRedoAction(IEditorAction* pAction)
+void CEditor::RecordRedoAction(IEditorAction *pAction)
 {
 	if(m_vpRedoActions.size() >= s_MaxActions)
 	{
@@ -6533,7 +6535,6 @@ bool CEditor::Redo()
 	m_vpRedoActions.pop_front();
 	return FrontAction->Redo();
 }
-
 
 bool CEditorAddLayerAction::Undo()
 {

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -6665,7 +6665,7 @@ void CEditorHistory::RecordUndoAction(IEditorAction *pAction, bool Clear)
 		m_vpRedoActions.clear();
 	}
 
-	if(m_vpUndoActions.size() >= s_MaxActions)
+	if(m_vpUndoActions.size() >= g_Config.m_ClEditorMaxHistory)
 	{
 		m_vpUndoActions.pop_back();
 	}
@@ -6676,7 +6676,7 @@ void CEditorHistory::RecordUndoAction(IEditorAction *pAction, bool Clear)
 
 void CEditorHistory::RecordRedoAction(IEditorAction *pAction)
 {
-	if(m_vpRedoActions.size() >= s_MaxActions)
+	if(m_vpRedoActions.size() >= g_Config.m_ClEditorMaxHistory)
 	{
 		m_vpRedoActions.pop_back();
 	}

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -6455,6 +6455,8 @@ void CEditorMap::MakeTuneLayer(CLayer *pLayer)
 
 void CEditor::RecordUndoAction(IEditorAction *pAction, bool Clear)
 {
+	pAction->m_pEditor = this;
+
 	if (Clear && m_vpRedoActions.size() > 0) {
 		for (auto Action : m_vpRedoActions) {
 			delete Action;
@@ -6500,4 +6502,25 @@ bool CEditor::Redo()
 	RecordUndoAction(FrontAction, false);
 	m_vpRedoActions.pop_front();
 	return FrontAction->Redo();
+}
+
+
+bool CEditorAddLayerAction::Undo()
+{
+	CLayerGroup *Group = (CLayerGroup *)m_pObject;
+	CLayer *Layer = Group->m_vpLayers[m_LayerIndex];
+
+	if(Layer == m_pEditor->m_Map.m_pFrontLayer)
+		m_pEditor->m_Map.m_pFrontLayer = nullptr;
+	if(Layer == m_pEditor->m_Map.m_pTeleLayer)
+		m_pEditor->m_Map.m_pTeleLayer = nullptr;
+	if(Layer == m_pEditor->m_Map.m_pSpeedupLayer)
+		m_pEditor->m_Map.m_pSpeedupLayer = nullptr;
+	if(Layer == m_pEditor->m_Map.m_pSwitchLayer)
+		m_pEditor->m_Map.m_pSwitchLayer = nullptr;
+	if(Layer == m_pEditor->m_Map.m_pTuneLayer)
+		m_pEditor->m_Map.m_pTuneLayer = nullptr;
+
+	Group->DeleteLayer(m_LayerIndex);
+	return true;
 }

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -2717,14 +2717,24 @@ void CEditor::DoMapEditor(CUIRect View)
 				{
 					if(!UI()->MouseButton(0))
 					{
+						CLayerGroup Original;
+						Original.m_pMap = &m_Map;
+						std::vector<CLayer *> apLayers;
+
 						for(size_t k = 0; k < NumEditLayers; k++)
 						{
 							size_t BrushIndex = k;
 							if(m_Brush.m_vpLayers.size() != NumEditLayers)
 								BrushIndex = 0;
 							CLayer *pBrush = m_Brush.IsEmpty() ? nullptr : m_Brush.m_vpLayers[BrushIndex];
+
+							apEditLayers[k]->BrushGrab(&Original, r);
 							apEditLayers[k]->FillSelection(m_Brush.IsEmpty(), pBrush, r);
+							apLayers.push_back(apEditLayers[k]);
 						}
+
+
+						RecordUndoAction(new CEditorFillSelectionAction(nullptr, &Original, &m_Brush, apLayers, NumEditLayers, r));
 					}
 					else
 					{

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -729,7 +729,6 @@ public:
 	bool CanRedo() const { return m_vpRedoActions.size() > 0; }
 
 	CEditor *m_pEditor;
-	static const int s_MaxActions = 50;
 	std::deque<IEditorAction *> m_vpUndoActions;
 	std::deque<IEditorAction *> m_vpRedoActions;
 

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -1123,6 +1123,35 @@ private:
 	bool BrushDraw(CLayerGroup *Brush);
 };
 
+class CEditorHistory
+{
+public:
+	CEditorHistory()
+	{
+		m_pEditor = nullptr;
+	}
+
+	~CEditorHistory()
+	{
+		Clear();
+	}
+
+	void RecordUndoAction(IEditorAction *pAction, bool Clear = true);
+	bool Undo();
+	bool Redo();
+
+	void Clear();
+
+	CEditor *m_pEditor;
+	static const int s_MaxActions = 50;
+	std::deque<IEditorAction *> m_vpUndoActions;
+	std::deque<IEditorAction *> m_vpRedoActions;
+
+private:
+	void RecordRedoAction(IEditorAction *Action);
+
+};
+
 class CEditor : public IEditor
 {
 	class IInput *m_pInput;
@@ -1260,6 +1289,10 @@ public:
 		m_BrushDrawDestructive = true;
 
 		m_Mentions = 0;
+
+		m_EditorHistory.m_pEditor = this;
+		m_EnvelopeEditorHistory.m_pEditor = this;
+		m_ServerSettingsEditorHistory.m_pEditor = this;
 
 		m_ShouldAddFrontDrawLayer = false;
 	}
@@ -1653,10 +1686,6 @@ public:
 	static int ms_HuePicker;
 
 	// DDRace
-	void RecordUndoAction(IEditorAction *pAction, bool Clear = true);
-	bool Undo();
-	bool Redo();
-
 	IGraphics::CTextureHandle GetFrontTexture();
 	IGraphics::CTextureHandle GetTeleTexture();
 	IGraphics::CTextureHandle GetSpeedupTexture();
@@ -1678,15 +1707,13 @@ public:
 	unsigned char m_SwitchNum;
 	unsigned char m_SwitchDelay;
 
-	static const int s_MaxActions = 50;
-	std::deque<IEditorAction *> m_vpUndoActions;
-	std::deque<IEditorAction *> m_vpRedoActions;
+	CEditorHistory m_EditorHistory;
+	CEditorHistory m_EnvelopeEditorHistory;
+	CEditorHistory m_ServerSettingsEditorHistory;
 
 	bool m_ShouldAddFrontDrawLayer;
 
 private:
-	void RecordRedoAction(IEditorAction *Action);
-
 	CLayerGroup m_DrawLayerGroup;
 	CLayerGroup m_DrawOriginalGroup;
 	bool m_Drawing = false;

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -721,7 +721,7 @@ public:
 	CEditor *m_pEditor;
 };
 
-template <typename T>
+template<typename T>
 class CEditorAction : public IEditorAction
 {
 public:
@@ -854,19 +854,22 @@ public:
 	{
 	}
 
-	bool Undo() override {
+	bool Undo() override
+	{
 		CLayerTiles *pTileLayer = (CLayerTiles *)m_pObject;
 		pTileLayer->m_Color = m_ValueFrom;
 		return true;
 	}
 
-	bool Redo() override {
+	bool Redo() override
+	{
 		CLayerTiles *pTileLayer = (CLayerTiles *)m_pObject;
 		pTileLayer->m_Color = m_ValueTo;
 		return true;
 	}
 
-	void Print() override {
+	void Print() override
+	{
 		dbg_msg("editor", "Editor action: Change tile color, prev=%d %d %d %d, new=%d %d %d %d", m_ValueFrom.r, m_ValueFrom.g, m_ValueFrom.b, m_ValueFrom.a, m_ValueTo.r, m_ValueTo.g, m_ValueTo.b, m_ValueTo.a);
 	}
 };
@@ -903,7 +906,7 @@ private:
 	int m_Index;
 };
 
-class CEditorAddLayerAction : public CEditorAction<CLayer*>
+class CEditorAddLayerAction : public CEditorAction<CLayer *>
 {
 public:
 	CEditorAddLayerAction(CLayerGroup *pObject, int LayerIndex, std::function<void()> fnAddLayer) :
@@ -915,7 +918,6 @@ public:
 
 	~CEditorAddLayerAction()
 	{
-
 	}
 
 	bool Undo() override;
@@ -937,7 +939,7 @@ private:
 	std::function<void()> m_fnAddLayer;
 };
 
-class CEditorDeleteLayerAction : public CEditorAction<CLayer*>
+class CEditorDeleteLayerAction : public CEditorAction<CLayer *>
 {
 public:
 	CEditorDeleteLayerAction(CLayerGroup *pObject, int LayerIndex) :
@@ -984,7 +986,7 @@ public:
 			CLayerTiles::SCommonPropState Original = m_ValueFrom[i];
 
 			pLayer->Resize(Original.m_Width, Original.m_Height);
-			
+
 			pLayer->m_Color.r = (Original.m_Color >> 24) & 0xff;
 			pLayer->m_Color.g = (Original.m_Color >> 16) & 0xff;
 			pLayer->m_Color.b = (Original.m_Color >> 8) & 0xff;

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -3,17 +3,17 @@
 #ifndef GAME_EDITOR_EDITOR_H
 #define GAME_EDITOR_EDITOR_H
 
+#include <deque>
 #include <string>
 #include <vector>
-#include <deque>
 
 #include <base/system.h>
 
 #include <game/client/render.h>
 #include <game/client/ui.h>
+#include <game/editor/editor_actions.h>
 #include <game/mapitems.h>
 #include <game/mapitems_ex.h>
-#include <game/editor/editor_actions.h>
 
 #include <engine/editor.h>
 #include <engine/graphics.h>
@@ -734,7 +734,6 @@ public:
 
 private:
 	void RecordRedoAction(class IEditorAction *Action);
-
 };
 
 class CEditor : public IEditor
@@ -918,6 +917,15 @@ public:
 
 	float ScaleFontSize(char *pText, int TextSize, float FontSize, int Width);
 	int DoProperties(CUIRect *pToolbox, CProperty *pProps, int *pIDs, int *pNewVal, ColorRGBA Color = ColorRGBA(1, 1, 1, 0.5f));
+
+	enum class PropState
+	{
+		START,
+		EDITING,
+		END
+	};
+	// this allows to track when a prop starts to be edited, is being edited and when it has finished being edited
+	int DoProperties(CUIRect *pToolbox, CProperty *pProps, int *pIDs, int *pNewVal, PropState *pState, ColorRGBA Color = ColorRGBA(1, 1, 1, 0.5f));
 
 	int m_Mode;
 	int m_Dialog;
@@ -1265,6 +1273,7 @@ public:
 
 	int GetLineDistance() const;
 	void ZoomMouseTarget(float ZoomFactor);
+	static void Rotate(const CPoint *pCenter, CPoint *pPoint, float Rotation);
 
 	static ColorHSVA ms_PickerColor;
 	static int ms_SVPicker;

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -916,9 +916,10 @@ private:
 class CEditorAddLayerAction : public CEditorAction<CLayer *>
 {
 public:
-	CEditorAddLayerAction(CLayerGroup *pObject, int LayerIndex, std::function<void()> fnAddLayer) :
-		CEditorAction(CEditorAction::EType::ADD_LAYER, pObject, nullptr, pObject->m_vpLayers[LayerIndex])
+	CEditorAddLayerAction(int GroupIndex, int LayerIndex, std::function<void()> fnAddLayer) :
+		CEditorAction(CEditorAction::EType::ADD_LAYER, nullptr, nullptr, nullptr)
 	{
+		m_GroupIndex = GroupIndex;
 		m_LayerIndex = LayerIndex;
 		m_fnAddLayer = fnAddLayer;
 	}
@@ -938,22 +939,19 @@ public:
 
 	void Print() override
 	{
-		dbg_msg("editor", "Editor action: Add layer, type=%d name=%s", m_ValueTo->m_Type, m_ValueTo->m_aName);
+		//dbg_msg("editor", "Editor action: Add layer, type=%d name=%s", m_ValueTo->m_Type, m_ValueTo->m_aName);
 	}
 
 private:
 	int m_LayerIndex;
+	int m_GroupIndex;
 	std::function<void()> m_fnAddLayer;
 };
 
 class CEditorDeleteLayerAction : public CEditorAction<CLayer *>
 {
 public:
-	CEditorDeleteLayerAction(CLayerGroup *pObject, int LayerIndex) :
-		CEditorAction(CEditorAction::EType::DELETE_LAYER, pObject, pObject->m_vpLayers[LayerIndex]->Duplicate(), nullptr)
-	{
-		m_LayerIndex = LayerIndex;
-	}
+	CEditorDeleteLayerAction(CEditor *pEditor, int GroupIndex, int LayerIndex);
 
 	~CEditorDeleteLayerAction()
 	{
@@ -961,7 +959,6 @@ public:
 	}
 
 	bool Undo() override;
-
 	bool Redo() override;
 
 	void Print() override
@@ -971,6 +968,7 @@ public:
 
 private:
 	int m_LayerIndex;
+	int m_GroupIndex;
 };
 
 class CEditorEditMultipleLayersAction : public CEditorAction<std::vector<CLayerTiles::SCommonPropState>>

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -712,7 +712,7 @@ public:
 	virtual bool Redo() = 0;
 
 	virtual void Print() = 0;
-	virtual char *Name() const = 0;
+	virtual const char *Name() const = 0;
 
 	CEditor *m_pEditor;
 };
@@ -724,7 +724,52 @@ public:
 	enum class EType
 	{
 		CHANGE_COLOR_TILE,
-		CHANGE_COLOR_QUAD
+		CHANGE_COLOR_QUAD,
+
+		ADD_LAYER,
+		DELETE_LAYER,
+
+		ADD_GROUP,
+		DELETE_GROUP,
+
+		EDIT_LAYER_GROUP,
+		EDIT_LAYER_ORDER,
+		EDIT_LAYER_WIDTH,
+		EDIT_LAYER_HEIGHT,
+		EDIT_LAYER_IMAGE,
+		EDIT_LAYER_COLOR_ENV,
+		EDIT_LAYER_COLOR_TO,
+
+		EDIT_QUAD_POSITION,
+		EDIT_QUAD_CENTER,
+
+		SET_TILE,
+
+		EDIT_GROUP_ORDER,
+		EDIT_GROUP_POS_X,
+		EDIT_GROUP_POS_Y,
+		EDIT_GROUP_PARA_X,
+		EDIT_GROUP_PARA_Y,
+		EDIT_GROUP_CLIP_X,
+		EDIT_GROUP_CLIP_Y,
+		EDIT_GROUP_CLIP_W,
+		EDIT_GROUP_CLIP_H,
+
+		ADD_ENVELOPPE,
+		EDIT_ENV_NAME,
+		EDIT_ENV_POINT_VALUE,
+		EDIT_ENV_POINT_TIME,
+		EDIT_ENV_SYNC_CHECKBOX,
+		DELETE_ENVELOPPE,
+
+		ADD_COMMAND,
+		EDIT_COMMAND,
+		DELETE_COMMAND,
+
+		ADD_IMAGE,
+		ADD_SOUND,
+
+		CHANGE_ORIENTATION_VALUE
 	};
 
 public:
@@ -741,12 +786,47 @@ public:
 	{
 	}
 
-	char *Name() const
+	const char *Name() const override
 	{
 		switch(m_Type)
 		{
 		case EType::CHANGE_COLOR_TILE: return "CHANGE_COLOR_TILE";
 		case EType::CHANGE_COLOR_QUAD: return "CHANGE_COLOR_QUAD";
+		case EType::ADD_LAYER: return "ADD_LAYER";
+		case EType::DELETE_LAYER: return "DELETE_LAYER";
+		case EType::ADD_GROUP: return "ADD_GROUP";
+		case EType::DELETE_GROUP: return "DELETE_GROUP";
+		case EType::EDIT_LAYER_GROUP: return "EDIT_LAYER_GROUP";
+		case EType::EDIT_LAYER_ORDER: return "EDIT_LAYER_ORDER";
+		case EType::EDIT_LAYER_WIDTH: return "EDIT_LAYER_WIDTH";
+		case EType::EDIT_LAYER_HEIGHT: return "EDIT_LAYER_HEIGHT";
+		case EType::EDIT_LAYER_IMAGE: return "EDIT_LAYER_IMAGE";
+		case EType::EDIT_LAYER_COLOR_ENV: return "EDIT_LAYER_COLOR_ENV";
+		case EType::EDIT_LAYER_COLOR_TO: return "EDIT_LAYER_COLOR_TO";
+		case EType::EDIT_QUAD_POSITION: return "EDIT_QUAD_POSITION";
+		case EType::EDIT_QUAD_CENTER: return "EDIT_QUAD_CENTER";
+		case EType::SET_TILE: return "SET_TILE";
+		case EType::EDIT_GROUP_ORDER: return "EDIT_GROUP_ORDER";
+		case EType::EDIT_GROUP_POS_X: return "EDIT_GROUP_POS_X";
+		case EType::EDIT_GROUP_POS_Y: return "EDIT_GROUP_POS_Y";
+		case EType::EDIT_GROUP_PARA_X: return "EDIT_GROUP_PARA_X";
+		case EType::EDIT_GROUP_PARA_Y: return "EDIT_GROUP_PARA_Y";
+		case EType::EDIT_GROUP_CLIP_X: return "EDIT_GROUP_CLIP_X";
+		case EType::EDIT_GROUP_CLIP_Y: return "EDIT_GROUP_CLIP_Y";
+		case EType::EDIT_GROUP_CLIP_W: return "EDIT_GROUP_CLIP_W";
+		case EType::EDIT_GROUP_CLIP_H: return "EDIT_GROUP_CLIP_H";
+		case EType::ADD_ENVELOPPE: return "ADD_ENVELOPPE";
+		case EType::EDIT_ENV_NAME: return "EDIT_ENV_NAME";
+		case EType::EDIT_ENV_POINT_VALUE: return "EDIT_ENV_POINT_VALUE";
+		case EType::EDIT_ENV_POINT_TIME: return "EDIT_ENV_POINT_TIME";
+		case EType::EDIT_ENV_SYNC_CHECKBOX: return "EDIT_ENV_SYNC_CHECKBOX";
+		case EType::DELETE_ENVELOPPE: return "DELETE_ENVELOPPE";
+		case EType::ADD_COMMAND: return "ADD_COMMAND";
+		case EType::EDIT_COMMAND: return "EDIT_COMMAND";
+		case EType::DELETE_COMMAND: return "DELETE_COMMAND";
+		case EType::ADD_IMAGE: return "ADD_IMAGE";
+		case EType::ADD_SOUND: return "ADD_SOUND";
+		case EType::CHANGE_ORIENTATION_VALUE: return "CHANGE_ORIENTATION_VALUE";
 		default: return "UNKNOWN";
 		}
 	}
@@ -814,6 +894,40 @@ public:
 
 private:
 	int m_Index;
+};
+
+class CEditorAddLayerAction : public CEditorAction<CLayer*>
+{
+public:
+	CEditorAddLayerAction(CLayerGroup *pObject, int LayerIndex, std::function<void()> fnAddLayer) :
+		CEditorAction(CEditorAction::EType::ADD_LAYER, pObject, nullptr, pObject->m_vpLayers[pObject->m_vpLayers.size() - 1])
+	{
+		m_LayerIndex = LayerIndex;
+		m_fnAddLayer = fnAddLayer;
+	}
+
+	~CEditorAddLayerAction()
+	{
+
+	}
+
+	bool Undo() override;
+
+	bool Redo() override
+	{
+		// call the add layer function, needed for special layers
+		m_fnAddLayer();
+		return true;
+	}
+
+	void Print() override
+	{
+		dbg_msg("editor", "Editor action: Add layer, type=%d name=%s", m_ValueTo->m_Type, m_ValueTo->m_aName);
+	}
+
+private:
+	int m_LayerIndex;
+	std::function<void()> m_fnAddLayer;
 };
 
 class CEditor : public IEditor

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -752,7 +752,7 @@ public:
 		EDIT_QUAD_POSITION,
 		EDIT_QUAD_CENTER,
 
-		SET_TILE,
+		//SET_TILE,
 		FILL_SELECTION,
 		BRUSH_DRAW,
 
@@ -776,9 +776,11 @@ public:
 		ADD_COMMAND,
 		EDIT_COMMAND,
 		DELETE_COMMAND,
+		MOVE_COMMAND_UP,
+		MOVE_COMMAND_DOWN,
 
-		ADD_IMAGE,
-		ADD_SOUND,
+		//ADD_IMAGE,
+		//ADD_SOUND,
 
 		CHANGE_ORIENTATION_VALUE
 	};
@@ -817,7 +819,6 @@ public:
 		case EType::EDIT_LAYER_COLOR_TO: return "EDIT_LAYER_COLOR_TO";
 		case EType::EDIT_QUAD_POSITION: return "EDIT_QUAD_POSITION";
 		case EType::EDIT_QUAD_CENTER: return "EDIT_QUAD_CENTER";
-		case EType::SET_TILE: return "SET_TILE";
 		case EType::FILL_SELECTION: return "FILL_SELECTION";
 		case EType::BRUSH_DRAW: return "BRUSH_DRAW";
 		case EType::EDIT_GROUP_ORDER: return "EDIT_GROUP_ORDER";
@@ -838,8 +839,10 @@ public:
 		case EType::ADD_COMMAND: return "ADD_COMMAND";
 		case EType::EDIT_COMMAND: return "EDIT_COMMAND";
 		case EType::DELETE_COMMAND: return "DELETE_COMMAND";
-		case EType::ADD_IMAGE: return "ADD_IMAGE";
-		case EType::ADD_SOUND: return "ADD_SOUND";
+		case EType::MOVE_COMMAND_UP: return "MOVE_COMMAND_UP";
+		case EType::MOVE_COMMAND_DOWN: return "MOVE_COMMAND_DOWN";
+		//case EType::ADD_IMAGE: return "ADD_IMAGE";
+		//case EType::ADD_SOUND: return "ADD_SOUND";
 		case EType::CHANGE_ORIENTATION_VALUE: return "CHANGE_ORIENTATION_VALUE";
 		default: return "UNKNOWN";
 		}
@@ -1123,6 +1126,24 @@ private:
 	bool BrushDraw(CLayerGroup *Brush);
 };
 
+class CEditorCommandAction : public CEditorAction<std::string>
+{
+public:
+	CEditorCommandAction(CEditorAction::EType Action, int* pSelectedCommand, int CommandIndex, std::string Old, std::string New) :
+		CEditorAction(Action, nullptr, Old, New)
+	{
+		m_pSelectedCommand = pSelectedCommand;
+		m_CommandIndex = CommandIndex;
+	}
+
+	bool Undo() override;
+	bool Redo() override;
+
+private:
+	int m_CommandIndex;
+	int *m_pSelectedCommand;
+};
+
 class CEditorHistory
 {
 public:
@@ -1141,6 +1162,8 @@ public:
 	bool Redo();
 
 	void Clear();
+	bool CanUndo() const { return m_vpUndoActions.size() > 0; }
+	bool CanRedo() const { return m_vpRedoActions.size() > 0; }
 
 	CEditor *m_pEditor;
 	static const int s_MaxActions = 50;

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -204,6 +204,7 @@ public:
 	bool m_Collapse;
 
 	CLayerGroup();
+	CLayerGroup(const CLayerGroup &Other);
 	~CLayerGroup();
 
 	void Convert(CUIRect *pRect);
@@ -1024,6 +1025,39 @@ public:
 
 private:
 	std::vector<CLayerTiles *> m_vpLayers;
+};
+
+class CEditorAddGroupAction : public CEditorAction<int>
+{
+public:
+	CEditorAddGroupAction(CEditorMap *pObject, int GroupIndex) :
+		CEditorAction(CEditorAction::EType::ADD_GROUP, pObject, -1, GroupIndex)
+	{
+	}
+
+	bool Undo() override;
+	bool Redo() override;
+};
+
+class CEditorDeleteGroupAction : public CEditorAction<CLayerGroup *>
+{
+public:
+	CEditorDeleteGroupAction(CEditorMap *pObject, int GroupIndex) :
+		CEditorAction(CEditorAction::EType::DELETE_GROUP, pObject, new CLayerGroup(*pObject->m_vpGroups[GroupIndex]), nullptr)
+	{
+		m_GroupIndex = GroupIndex;
+	}
+
+	~CEditorDeleteGroupAction()
+	{
+		delete m_ValueFrom;
+	}
+
+	bool Undo() override;
+	bool Redo() override;
+
+private:
+	int m_GroupIndex;
 };
 
 class CEditor : public IEditor

--- a/src/game/editor/editor_actions.cpp
+++ b/src/game/editor/editor_actions.cpp
@@ -755,3 +755,67 @@ bool CEditorQuadOperationAction::Redo()
 
 	return true;
 }
+
+CEditorEditGroupProperty::CEditorEditGroupProperty(int GroupIndex, const SEditGroupInfo &OldInfo, const SEditGroupInfo &NewInfo) :
+	CEditorAction(IEditorAction::EType::EDIT_GROUP_PROPERTY, nullptr, OldInfo, NewInfo)
+{
+	m_GroupIndex = GroupIndex;
+}
+
+bool CEditorEditGroupProperty::Undo()
+{
+	if(m_ValueFrom.m_Modified & SEditGroupInfo::ORDER)
+	{
+		int CurrentOrder = m_ValueTo.m_Order;
+		bool Dir = m_ValueTo.m_Order > m_ValueFrom.m_Order;
+		while(CurrentOrder != m_ValueFrom.m_Order)
+		{
+			CurrentOrder = m_pEditor->m_Map.SwapGroups(CurrentOrder, Dir ? CurrentOrder - 1 : CurrentOrder + 1);
+		}
+		m_pEditor->m_SelectedGroup = m_ValueFrom.m_Order;
+	}
+	else
+		ApplyInfo(m_ValueFrom);
+
+	return true;
+}
+
+bool CEditorEditGroupProperty::Redo()
+{
+	if(m_ValueTo.m_Modified & SEditGroupInfo::ORDER)
+		m_pEditor->m_Map.SwapGroups(m_ValueTo.m_Order, m_ValueFrom.m_Order);
+	else
+		ApplyInfo(m_ValueTo);
+
+	return true;
+}
+
+void CEditorEditGroupProperty::ApplyInfo(const SEditGroupInfo &Info)
+{
+	CLayerGroup *pGroup = m_pEditor->m_Map.m_vpGroups[m_GroupIndex];
+
+	if(Info.m_Modified & SEditGroupInfo::OFFSET_X)
+		pGroup->m_OffsetX = Info.m_OffsetX;
+	if(Info.m_Modified & SEditGroupInfo::OFFSET_Y)
+		pGroup->m_OffsetY = Info.m_OffsetY;
+	if(Info.m_Modified & SEditGroupInfo::PARA_X)
+		pGroup->m_ParallaxX = Info.m_ParallaxX;
+	if(Info.m_Modified & SEditGroupInfo::PARA_Y)
+		pGroup->m_ParallaxY = Info.m_ParallaxY;
+	if(Info.m_Modified & SEditGroupInfo::CUSTOM_PARA_ZOOM)
+		pGroup->m_CustomParallaxZoom = Info.m_CustomParallaxZoom;
+	if(Info.m_Modified & SEditGroupInfo::PARA_ZOOM)
+		pGroup->m_ParallaxZoom = Info.m_ParallaxZoom;
+	if(Info.m_Modified & SEditGroupInfo::USE_CLIPPING)
+		pGroup->m_UseClipping = Info.m_UseClipping;
+	if(Info.m_Modified & SEditGroupInfo::CLIP_X)
+		pGroup->m_ClipX = Info.m_ClipX;
+	if(Info.m_Modified & SEditGroupInfo::CLIP_Y)
+		pGroup->m_ClipY = Info.m_ClipY;
+	if(Info.m_Modified & SEditGroupInfo::CLIP_W)
+		pGroup->m_ClipW = Info.m_ClipW;
+	if(Info.m_Modified & SEditGroupInfo::CLIP_H)
+		pGroup->m_ClipH = Info.m_ClipH;
+
+	pGroup->OnEdited();
+}

--- a/src/game/editor/editor_actions.cpp
+++ b/src/game/editor/editor_actions.cpp
@@ -1,0 +1,523 @@
+#include <game/editor/editor_actions.h>
+
+bool CEditorChangeColorTileAction::Undo()
+{
+	//CLayerTiles *pTileLayer = (CLayerTiles *)m_pObject;
+	CLayerTiles *pTileLayer = (CLayerTiles *)m_pEditor->m_Map.m_vpGroups[m_GroupIndex]->m_vpLayers[m_LayerIndex];
+	pTileLayer->m_Color = m_ValueFrom;
+	return true;
+}
+
+bool CEditorChangeColorTileAction::Redo()
+{
+	//CLayerTiles *pTileLayer = (CLayerTiles *)m_pObject;
+	CLayerTiles *pTileLayer = (CLayerTiles *)m_pEditor->m_Map.m_vpGroups[m_GroupIndex]->m_vpLayers[m_LayerIndex];
+	pTileLayer->m_Color = m_ValueTo;
+	return true;
+}
+
+bool CEditorChangeColorQuadAction::Undo()
+{
+	CQuad *pQuad = (CQuad *)m_pObject;
+	pQuad->m_aColors[m_Index] = m_ValueFrom;
+	return true;
+}
+
+bool CEditorChangeColorQuadAction::Redo()
+{
+	CQuad *pQuad = (CQuad *)m_pObject;
+	pQuad->m_aColors[m_Index] = m_ValueTo;
+	return true;
+}
+
+bool CEditorAddLayerAction::Undo()
+{
+	CLayerGroup *Group = m_pEditor->m_Map.m_vpGroups[m_GroupIndex];
+	CLayer *Layer = Group->m_vpLayers[m_LayerIndex];
+
+	if(Layer == m_pEditor->m_Map.m_pFrontLayer)
+		m_pEditor->m_Map.m_pFrontLayer = nullptr;
+	if(Layer == m_pEditor->m_Map.m_pTeleLayer)
+		m_pEditor->m_Map.m_pTeleLayer = nullptr;
+	if(Layer == m_pEditor->m_Map.m_pSpeedupLayer)
+		m_pEditor->m_Map.m_pSpeedupLayer = nullptr;
+	if(Layer == m_pEditor->m_Map.m_pSwitchLayer)
+		m_pEditor->m_Map.m_pSwitchLayer = nullptr;
+	if(Layer == m_pEditor->m_Map.m_pTuneLayer)
+		m_pEditor->m_Map.m_pTuneLayer = nullptr;
+
+	Group->DeleteLayer(m_LayerIndex);
+	return true;
+}
+
+CEditorDeleteLayerAction::CEditorDeleteLayerAction(CEditor *pEditor, int GroupIndex, int LayerIndex) :
+	CEditorAction(CEditorAction::EType::DELETE_LAYER, nullptr, pEditor->m_Map.m_vpGroups[GroupIndex]->m_vpLayers[LayerIndex]->Duplicate(), nullptr)
+{
+	m_GroupIndex = GroupIndex;
+	m_LayerIndex = LayerIndex;
+}
+
+bool CEditorDeleteLayerAction::Undo()
+{
+	CLayerGroup *Group = m_pEditor->m_Map.m_vpGroups[m_GroupIndex];
+
+	CLayer *pLayer = m_ValueFrom->Duplicate();
+	if(pLayer->m_Type == LAYERTYPE_TILES)
+	{
+		CLayerTiles *pTilesLayer = (CLayerTiles *)pLayer;
+		if(pTilesLayer->m_Tele)
+			m_pEditor->m_Map.m_pTeleLayer = (CLayerTele *)pLayer;
+		else if(pTilesLayer->m_Tune)
+			m_pEditor->m_Map.m_pTuneLayer = (CLayerTune *)pLayer;
+		else if(pTilesLayer->m_Speedup)
+			m_pEditor->m_Map.m_pSpeedupLayer = (CLayerSpeedup *)pLayer;
+		else if(pTilesLayer->m_Switch)
+			m_pEditor->m_Map.m_pSwitchLayer = (CLayerSwitch *)pLayer;
+		else if(pTilesLayer->m_Front)
+			m_pEditor->m_Map.m_pFrontLayer = (CLayerFront *)pLayer;
+	}
+
+	Group->m_vpLayers.insert(Group->m_vpLayers.begin() + m_LayerIndex, pLayer);
+	m_pEditor->m_Map.m_Modified = true;
+
+	m_pEditor->SelectLayer(m_LayerIndex);
+
+	return true;
+}
+
+bool CEditorDeleteLayerAction::Redo()
+{
+	CLayerGroup *Group = m_pEditor->m_Map.m_vpGroups[m_GroupIndex];
+	CLayer *pLayer = m_ValueFrom;
+
+	if(pLayer->m_Type == LAYERTYPE_TILES)
+	{
+		CLayerTiles *pTilesLayer = (CLayerTiles *)pLayer;
+		if(pTilesLayer->m_Tele)
+			m_pEditor->m_Map.m_pTeleLayer = nullptr;
+		else if(pTilesLayer->m_Tune)
+			m_pEditor->m_Map.m_pTuneLayer = nullptr;
+		else if(pTilesLayer->m_Speedup)
+			m_pEditor->m_Map.m_pSpeedupLayer = nullptr;
+		else if(pTilesLayer->m_Switch)
+			m_pEditor->m_Map.m_pSwitchLayer = nullptr;
+		else if(pTilesLayer->m_Front)
+			m_pEditor->m_Map.m_pFrontLayer = nullptr;
+	}
+
+	Group->DeleteLayer(m_LayerIndex);
+	m_pEditor->SelectLayer(maximum(0, m_LayerIndex - 1));
+
+	return true;
+}
+
+CEditorEditMultipleLayersAction::CEditorEditMultipleLayersAction(void *pObject, std::vector<CLayerTiles_SCommonPropState> vOriginals, CLayerTiles_SCommonPropState State, int GroupIndex, std::vector<int> vLayers) :
+	CEditorAction(CEditorAction::EType::EDIT_MULTIPLE_LAYERS, pObject, vOriginals, {State})
+{
+	m_GroupIndex = GroupIndex;
+	m_vLayers = vLayers;
+}
+
+bool CEditorEditMultipleLayersAction::Undo()
+{
+	if(m_vLayers.size() != m_ValueFrom.size())
+		return false;
+
+	for(size_t k = 0; k < m_vLayers.size(); k++)
+	{
+		int LayerIndex = m_vLayers[k];
+		CLayerTiles *pLayer = (CLayerTiles *)m_pEditor->m_Map.m_vpGroups[m_GroupIndex]->m_vpLayers[LayerIndex];
+		CLayerTiles_SCommonPropState Original = m_ValueFrom[k];
+
+		pLayer->Resize(Original.m_Width, Original.m_Height);
+
+		pLayer->m_Color.r = (Original.m_Color >> 24) & 0xff;
+		pLayer->m_Color.g = (Original.m_Color >> 16) & 0xff;
+		pLayer->m_Color.b = (Original.m_Color >> 8) & 0xff;
+		pLayer->m_Color.a = Original.m_Color & 0xff;
+
+		pLayer->FlagModified(0, 0, pLayer->m_Width, pLayer->m_Height);
+	}
+
+	return true;
+}
+
+bool CEditorEditMultipleLayersAction::Redo()
+{
+	CLayerTiles_SCommonPropState State = m_ValueTo[0];
+	for(auto LayerIndex : m_vLayers)
+	{
+		CLayerTiles *pLayer = (CLayerTiles *)m_pEditor->m_Map.m_vpGroups[m_GroupIndex]->m_vpLayers[LayerIndex];
+
+		if((State.m_Modified & CLayerTiles_SCommonPropState::MODIFIED_SIZE) != 0)
+			pLayer->Resize(State.m_Width, State.m_Height);
+
+		if((State.m_Modified & CLayerTiles_SCommonPropState::MODIFIED_COLOR) != 0)
+		{
+			pLayer->m_Color.r = (State.m_Color >> 24) & 0xff;
+			pLayer->m_Color.g = (State.m_Color >> 16) & 0xff;
+			pLayer->m_Color.b = (State.m_Color >> 8) & 0xff;
+			pLayer->m_Color.a = State.m_Color & 0xff;
+		}
+
+		pLayer->FlagModified(0, 0, pLayer->m_Width, pLayer->m_Height);
+	}
+
+	return true;
+}
+
+CEditorAddGroupAction::CEditorAddGroupAction(CEditorMap *pObject, int GroupIndex) :
+	CEditorAction(EType::ADD_GROUP, pObject, -1, GroupIndex)
+{
+}
+
+bool CEditorAddGroupAction::Undo()
+{
+	CEditorMap *pMap = (CEditorMap *)m_pObject;
+	pMap->DeleteGroup(m_ValueTo);
+
+	m_pEditor->m_SelectedGroup = maximum(0, m_ValueTo - 1);
+
+	return true;
+}
+
+bool CEditorAddGroupAction::Redo()
+{
+	CEditorMap *pMap = (CEditorMap *)m_pObject;
+	pMap->NewGroup();
+
+	m_pEditor->m_SelectedGroup = m_ValueTo;
+
+	return true;
+}
+
+CEditorDeleteGroupAction::CEditorDeleteGroupAction(CEditorMap *pObject, int GroupIndex) :
+	CEditorAction(CEditorAction::EType::DELETE_GROUP, pObject, new CLayerGroup(*pObject->m_vpGroups[GroupIndex]), nullptr)
+{
+	m_GroupIndex = GroupIndex;
+}
+
+bool CEditorDeleteGroupAction::Undo()
+{
+	// undo is re-adding back the group
+	CEditorMap *pMap = (CEditorMap *)m_pObject;
+	pMap->m_vpGroups.insert(pMap->m_vpGroups.begin() + m_GroupIndex, new CLayerGroup(*m_ValueFrom));
+	pMap->m_Modified = true;
+
+	m_pEditor->m_SelectedGroup = m_GroupIndex;
+
+	return true;
+}
+
+bool CEditorDeleteGroupAction::Redo()
+{
+	// redo is deleting the group, that's easy
+	CEditorMap *pMap = (CEditorMap *)m_pObject;
+	pMap->DeleteGroup(m_GroupIndex);
+
+	m_pEditor->m_SelectedGroup = maximum(0, m_GroupIndex);
+
+	return true;
+}
+
+CEditorFillSelectionAction::CEditorFillSelectionAction(void *pObject, CLayerGroup *Original, CLayerGroup *Brush, int GroupIndex, std::vector<int> vLayers, CUIRect Rect) :
+	CEditorAction(CEditorAction::EType::FILL_SELECTION, pObject, new CLayerGroup(*Original), new CLayerGroup(*Brush))
+{
+	m_Rect = Rect;
+	m_vLayers = vLayers;
+	m_GroupIndex = GroupIndex;
+}
+
+bool CEditorFillSelectionAction::Undo()
+{
+	bool OldDestructiveMode = m_pEditor->m_BrushDrawDestructive;
+	m_pEditor->m_BrushDrawDestructive = true;
+
+	// undo is filling back the original tiles
+	CLayerGroup *Brush = m_ValueFrom;
+	CLayerGroup *Group = m_pEditor->m_Map.m_vpGroups[m_GroupIndex];
+
+	size_t NumLayers = m_vLayers.size();
+	for(size_t k = 0; k < NumLayers; k++)
+	{
+		int LayerIndex = m_vLayers[k];
+		CLayer *pLayer = Group->m_vpLayers[LayerIndex];
+
+		size_t BrushIndex = k;
+		if(Brush->m_vpLayers.size() != NumLayers)
+			BrushIndex = 0;
+		CLayer *pBrush = Brush->IsEmpty() ? nullptr : Brush->m_vpLayers[BrushIndex];
+		//dbg_msg("editor", "undoing layer %d, brush index=%d, brush=%p", k, BrushIndex, pBrush);
+
+		pLayer->FillSelection(Brush->IsEmpty(), pBrush, m_Rect);
+	}
+
+	m_pEditor->m_BrushDrawDestructive = OldDestructiveMode;
+	return true;
+}
+
+bool CEditorFillSelectionAction::Redo()
+{
+	bool OldDestructiveMode = m_pEditor->m_BrushDrawDestructive;
+	m_pEditor->m_BrushDrawDestructive = true;
+
+	// redo is redoing the filling with the new tiles
+	CLayerGroup *Brush = m_ValueTo;
+	CLayerGroup *Group = m_pEditor->m_Map.m_vpGroups[m_GroupIndex];
+
+	size_t NumLayers = m_vLayers.size();
+	for(size_t k = 0; k < NumLayers; k++)
+	{
+		int LayerIndex = m_vLayers[k];
+		CLayer *pLayer = Group->m_vpLayers[LayerIndex];
+
+		size_t BrushIndex = k;
+		if(Brush->m_vpLayers.size() != NumLayers)
+			BrushIndex = 0;
+		CLayer *pBrush = Brush->IsEmpty() ? nullptr : Brush->m_vpLayers[BrushIndex];
+
+		pLayer->FillSelection(Brush->IsEmpty(), pBrush, m_Rect);
+	}
+
+	m_pEditor->m_BrushDrawDestructive = OldDestructiveMode;
+	return true;
+}
+
+void CEditorFillSelectionAction::Print()
+{
+	dbg_msg("editor", "editor fill action, num layers=%d, original brush num layers=%d, modified brush num layers=%d", m_vLayers.size(), m_ValueFrom->m_vpLayers.size(), m_ValueTo->m_vpLayers.size());
+	dbg_msg("editor", "rect: w=%f h=%f", m_Rect.w, m_Rect.h);
+}
+
+CEditorBrushDrawAction::CEditorBrushDrawAction(void *pObject, CLayerGroup *Original, CLayerGroup *Brush, int GroupIndex, std::vector<int> vLayers) :
+	CEditorAction(EType::BRUSH_DRAW, pObject, new CLayerGroup(*Original), new CLayerGroup(*Brush))
+{
+	m_vLayers = vLayers;
+	m_GroupIndex = GroupIndex;
+}
+
+bool CEditorBrushDrawAction::Undo()
+{
+	// undo is drawing with brush with original data
+	return BrushDraw(m_ValueFrom);
+}
+
+bool CEditorBrushDrawAction::Redo()
+{
+	// redo is drawing with brush with modified data
+	return BrushDraw(m_ValueTo);
+}
+
+bool CEditorBrushDrawAction::BrushDraw(CLayerGroup *Brush)
+{
+	bool OldDestructiveMode = m_pEditor->m_BrushDrawDestructive;
+	m_pEditor->m_BrushDrawDestructive = true;
+
+	CLayerGroup *Group = m_pEditor->m_Map.m_vpGroups[m_GroupIndex];
+
+	int NumLayers = m_vLayers.size();
+
+	if(NumLayers != Brush->m_vpLayers.size())
+		return false;
+
+	for(size_t k = 0; k < NumLayers; k++)
+	{
+		int LayerIndex = m_vLayers[k];
+		CLayer *pLayer = Group->m_vpLayers[LayerIndex];
+		size_t BrushIndex = k;
+
+		if(pLayer->m_Type == Brush->m_vpLayers[BrushIndex]->m_Type)
+		{
+			if(pLayer->m_Type == LAYERTYPE_TILES)
+			{
+				CLayerTiles *pLayerTiles = (CLayerTiles *)pLayer;
+				CLayerTiles *pBrushLayer = (CLayerTiles *)Brush->m_vpLayers[BrushIndex];
+
+				pLayerTiles->BrushDraw(pBrushLayer, 0, 0);
+			}
+			else if(pLayer->m_Type == LAYERTYPE_QUADS)
+			{
+				CLayerQuads *pLayerQuads = (CLayerQuads *)pLayer;
+				CLayerQuads *pBrushLayer = (CLayerQuads *)Brush->m_vpLayers[BrushIndex];
+
+				pLayerQuads->m_vQuads.clear();
+				pLayerQuads->m_vQuads = pBrushLayer->m_vQuads;
+			}
+			else if(pLayer->m_Type == LAYERTYPE_SOUNDS)
+			{
+				CLayerSounds *pLayerSounds = (CLayerSounds *)pLayer;
+				CLayerSounds *pBrushLayer = (CLayerSounds *)Brush->m_vpLayers[BrushIndex];
+
+				pLayerSounds->m_Sound = pBrushLayer->m_Sound;
+
+				pLayerSounds->m_vSources.clear();
+				pLayerSounds->m_vSources = pBrushLayer->m_vSources;
+			}
+		}
+	}
+
+	m_pEditor->m_BrushDrawDestructive = OldDestructiveMode;
+	return true;
+}
+
+void CEditorBrushDrawAction::Print()
+{
+	CLayerGroup *Group = m_pEditor->m_Map.m_vpGroups[m_GroupIndex];
+	dbg_msg("editor", "Undo action: brush draw.");
+	//for(size_t k = 0; k < m_vLayers.size(); k++)
+	//{
+	//	dbg_msg("editor", "   k=%d, layer index=%d (%s)", k, m_vLayers[k], Group->m_vpLayers[m_vLayers[k]]->m_aName);
+	//	dbg_msg("editor", "   brush layer (original) -> %s", m_ValueFrom->m_vpLayers[k]->m_aName);
+	//	dbg_msg("editor", "   brush layer (modified) -> %s", m_ValueTo->m_vpLayers[k]->m_aName);
+	//}
+}
+
+bool CEditorCommandAction::Undo()
+{
+	switch(m_Type)
+	{
+	case CEditorAction::EType::ADD_COMMAND:
+	{
+		m_pEditor->m_Map.m_vSettings.pop_back();
+		*m_pSelectedCommand = m_pEditor->m_Map.m_vSettings.size() - 1;
+		break;
+	}
+	case CEditorAction::EType::EDIT_COMMAND:
+	{
+		str_copy(m_pEditor->m_Map.m_vSettings[m_CommandIndex].m_aCommand, m_ValueFrom.c_str(), sizeof(m_pEditor->m_Map.m_vSettings[m_CommandIndex].m_aCommand));
+		break;
+	}
+	case CEditorAction::EType::DELETE_COMMAND:
+	{
+		CEditorMap::CSetting Setting;
+		str_copy(Setting.m_aCommand, m_ValueFrom.c_str(), sizeof(Setting.m_aCommand));
+		m_pEditor->m_Map.m_vSettings.insert(m_pEditor->m_Map.m_vSettings.begin() + m_CommandIndex, Setting);
+		*m_pSelectedCommand = m_CommandIndex;
+		break;
+	}
+	case CEditorAction::EType::MOVE_COMMAND_UP:
+	{
+		std::swap(m_pEditor->m_Map.m_vSettings[m_CommandIndex], m_pEditor->m_Map.m_vSettings[m_CommandIndex - 1]);
+		*m_pSelectedCommand = m_CommandIndex;
+		break;
+	}
+	case CEditorAction::EType::MOVE_COMMAND_DOWN:
+	{
+		std::swap(m_pEditor->m_Map.m_vSettings[m_CommandIndex], m_pEditor->m_Map.m_vSettings[m_CommandIndex + 1]);
+		*m_pSelectedCommand = m_CommandIndex;
+		break;
+	}
+	default:
+		return false;
+	}
+	return true;
+}
+
+bool CEditorCommandAction::Redo()
+{
+	switch(m_Type)
+	{
+	case CEditorAction::EType::ADD_COMMAND:
+	{
+		CEditorMap::CSetting Setting;
+		str_copy(Setting.m_aCommand, m_ValueTo.c_str(), sizeof(Setting.m_aCommand));
+		m_pEditor->m_Map.m_vSettings.push_back(Setting);
+		*m_pSelectedCommand = m_pEditor->m_Map.m_vSettings.size() - 1;
+		break;
+	}
+	case CEditorAction::EType::EDIT_COMMAND:
+		str_copy(m_pEditor->m_Map.m_vSettings[m_CommandIndex].m_aCommand, m_ValueTo.c_str(), sizeof(m_pEditor->m_Map.m_vSettings[m_CommandIndex].m_aCommand));
+		break;
+	case CEditorAction::EType::DELETE_COMMAND:
+	{
+		m_pEditor->m_Map.m_vSettings.erase(m_pEditor->m_Map.m_vSettings.begin() + m_CommandIndex);
+
+		if(*m_pSelectedCommand >= (int)m_pEditor->m_Map.m_vSettings.size())
+			*m_pSelectedCommand = m_pEditor->m_Map.m_vSettings.size() - 1;
+
+		break;
+	}
+	case CEditorAction::EType::MOVE_COMMAND_UP:
+	{
+		std::swap(m_pEditor->m_Map.m_vSettings[m_CommandIndex], m_pEditor->m_Map.m_vSettings[m_CommandIndex - 1]);
+		*m_pSelectedCommand = m_CommandIndex;
+		break;
+	}
+	case CEditorAction::EType::MOVE_COMMAND_DOWN:
+	{
+		std::swap(m_pEditor->m_Map.m_vSettings[m_CommandIndex], m_pEditor->m_Map.m_vSettings[m_CommandIndex + 1]);
+		*m_pSelectedCommand = m_CommandIndex;
+		break;
+	}
+	default:
+		return false;
+	}
+	return true;
+}
+
+CEditorAddQuadAction::CEditorAddQuadAction(int GroupIndex, int LayerIndex, RECTi *Quad) :
+	CEditorLayerAction(EType::ADD_QUAD, nullptr, GroupIndex, LayerIndex, nullptr, Quad)
+{
+}
+
+CEditorAddQuadAction::~CEditorAddQuadAction()
+{
+	delete m_ValueTo;
+}
+
+bool CEditorAddQuadAction::Undo()
+{
+	CLayerQuads *pLayer = GetLayer<CLayerQuads>();
+	pLayer->m_vQuads.pop_back();
+
+	m_pEditor->m_Map.m_Modified = true;
+
+	return true;
+}
+
+bool CEditorAddQuadAction::Redo()
+{
+	CLayerQuads *pLayer = GetLayer<CLayerQuads>();
+	RECTi *Quad = m_ValueTo;
+	pLayer->NewQuad(Quad->x, Quad->y, Quad->w, Quad->h);
+
+	m_pEditor->m_Map.m_Modified = true;
+
+	return true;
+}
+
+bool CEditorDeleteQuadsAction::Undo()
+{
+	CLayerQuads *pLayer = GetLayer<CLayerQuads>();
+
+	size_t k = 0;
+
+	pLayer->m_vQuads.resize(pLayer->m_vQuads.size() + m_vQuads.size());
+
+	for(auto &Index : m_vQuadIndexes)
+	{
+		pLayer->m_vQuads.insert(pLayer->m_vQuads.begin() + Index, m_vQuads[k]);
+		k++;
+	}
+
+	return true;
+}
+
+bool CEditorDeleteQuadsAction::Redo()
+{
+	CLayerQuads *pLayer = GetLayer<CLayerQuads>();
+	std::vector vSelectedQuads = m_vQuadIndexes;
+
+	for(int i = 0; i < (int)vSelectedQuads.size(); ++i)
+	{
+		pLayer->m_vQuads.erase(pLayer->m_vQuads.begin() + vSelectedQuads[i]);
+		for(int j = i + 1; j < (int)vSelectedQuads.size(); ++j)
+			if(vSelectedQuads[j] > vSelectedQuads[i])
+				vSelectedQuads[j]--;
+
+		vSelectedQuads.erase(vSelectedQuads.begin() + i);
+		i--;
+	}
+
+	return true;
+}

--- a/src/game/editor/editor_actions.h
+++ b/src/game/editor/editor_actions.h
@@ -7,6 +7,7 @@ class CLayerTiles;
 class CEditorMap;
 struct CLayerTiles_SCommonPropState;
 struct RECTi;
+class CLayerQuads;
 
 class IEditorAction
 {
@@ -54,6 +55,10 @@ public:
 		EDIT_QUAD_POSITION,
 		EDIT_QUAD_CENTER,
 		EDIT_QUAD_VERTEX,
+		ROTATE_QUAD,
+		QUAD_OPERATION_SQUARE,
+		QUAD_OPERATION_ALIGN,
+		QUAD_OPERATION_ASPECT_RATIO,
 
 		//SET_TILE,
 		FILL_SELECTION,
@@ -88,7 +93,6 @@ public:
 		CHANGE_ORIENTATION_VALUE
 	};
 };
-
 
 template<typename T>
 class CEditorAction : public IEditorAction
@@ -155,6 +159,10 @@ public:
 		case EType::ADD_QUAD: return "ADD_QUAD";
 		case EType::DELETE_QUAD: return "DELETE_QUAD";
 		case EType::EDIT_QUAD_VERTEX: return "EDIT_QUAD_VERTEX";
+		case EType::ROTATE_QUAD: return "ROTATE_QUAD";
+		case EType::QUAD_OPERATION_ALIGN: return "QUAD_OPERATION_ALIGN";
+		case EType::QUAD_OPERATION_ASPECT_RATIO: return "QUAD_OPERATION_ASPECT_RATIO";
+		case EType::QUAD_OPERATION_SQUARE: return "QUAD_OPERATION_SQUARE";
 		default: return "UNKNOWN";
 		}
 	}
@@ -193,6 +201,22 @@ K *CEditorLayerAction<T>::GetLayer()
 	return (K *)(m_pEditor->m_Map.m_vpGroups[m_GroupIndex]->m_vpLayers[m_LayerIndex]);
 }
 
+template<typename T>
+class CEditorLayerQuadsAction : public CEditorLayerAction<T>
+{
+public:
+	CEditorLayerQuadsAction(EType Type, int GroupIndex, int LayerIndex, std::vector<int> vQuads, const T &Old, const T &New) :
+		CEditorLayerAction<T>(Type, nullptr, GroupIndex, LayerIndex, Old, New)
+	{
+		m_vQuads = vQuads;
+	}
+
+	CLayerQuads *GetLayer() { return CEditorLayerAction::GetLayer<CLayerQuads>(); }
+
+protected:
+	std::vector<int> m_vQuads;
+};
+
 class CEditorChangeColorTileAction : public CEditorLayerAction<CColor>
 {
 public:
@@ -208,27 +232,6 @@ public:
 	{
 		dbg_msg("editor", "Editor action: Change tile color, prev=%d %d %d %d, new=%d %d %d %d", m_ValueFrom.r, m_ValueFrom.g, m_ValueFrom.b, m_ValueFrom.a, m_ValueTo.r, m_ValueTo.g, m_ValueTo.b, m_ValueTo.a);
 	}
-};
-
-class CEditorChangeColorQuadAction : public CEditorAction<CColor>
-{
-public:
-	CEditorChangeColorQuadAction(void *pObject, int Index, const CColor &OldColor, const CColor &NewColor) :
-		CEditorAction(EType::CHANGE_COLOR_QUAD, pObject, OldColor, NewColor)
-	{
-		m_Index = Index;
-	}
-
-	bool Undo() override;
-	bool Redo() override;
-
-	void Print() override
-	{
-		dbg_msg("editor", "Editor action: Change quad color, vertex %d, prev=%d %d %d %d, new=%d %d %d %d", m_Index, m_ValueFrom.r, m_ValueFrom.g, m_ValueFrom.b, m_ValueFrom.a, m_ValueTo.r, m_ValueTo.g, m_ValueTo.b, m_ValueTo.a);
-	}
-
-private:
-	int m_Index;
 };
 
 class CEditorAddLayerAction : public CEditorAction<class CLayer *>
@@ -393,10 +396,10 @@ private:
 	int *m_pSelectedCommand;
 };
 
-class CEditorAddQuadAction : public CEditorLayerAction<RECTi *>
+class CEditorAddQuadAction : public CEditorLayerAction<CQuad *>
 {
 public:
-	CEditorAddQuadAction(int GroupIndex, int LayerIndex, RECTi *Quad);
+	CEditorAddQuadAction(int GroupIndex, int LayerIndex, CQuad *pQuad);
 	~CEditorAddQuadAction();
 
 	bool Undo() override;
@@ -421,5 +424,129 @@ private:
 	std::vector<CQuad> m_vQuads;
 };
 
+class CEditorEditQuadPositionAction : public CEditorLayerQuadsAction<std::vector<CPoint>>
+{
+public:
+	CEditorEditQuadPositionAction(int GroupIndex, int LayerIndex, std::vector<int> vQuads, const std::vector<CPoint> &OldPos, const std::vector<CPoint> &NewPos);
+
+	bool Undo() override;
+	bool Redo() override;
+
+private:
+	void Move(int Direction);
+};
+
+struct SEditQuadPoint
+{
+	enum
+	{
+		MODIFIED_COLOR = 1 << 0,
+		MODIFIED_POS_X = 1 << 1,
+		MODIFIED_POS_Y = 1 << 2,
+		MODIFIED_TEX_U = 1 << 3,
+		MODIFIED_TEX_V = 1 << 4,
+
+		MODIFIED_OFFSET = 1 << 5,
+		MODIFIED_TEX_OFFSET = 1 << 5
+	};
+
+	CQuad m_Quad;
+	int m_Modified = 0;
+};
+
+class CEditorEditQuadsPointsAction : public CEditorLayerQuadsAction<std::vector<SEditQuadPoint>>
+{
+public:
+	CEditorEditQuadsPointsAction(int GroupIndex, int LayerIndex, std::vector<int> vQuads, int Points, const std::vector<SEditQuadPoint> &Old, const SEditQuadPoint &New) :
+		CEditorLayerQuadsAction(EType::EDIT_QUAD_VERTEX, GroupIndex, LayerIndex, vQuads, Old, {New})
+	{
+		m_Points = Points;
+	}
+
+	bool Undo() override;
+	bool Redo() override;
+
+private:
+	int m_Points;
+};
+
+template<typename T>
+class CEditorMultipleActions : public CEditorLayerAction<void *>
+{
+public:
+	CEditorMultipleActions(std::vector<T *> vpActions) :
+		CEditorLayerAction(EType::EDIT_QUAD_POSITION, nullptr, -1, -1, nullptr, nullptr)
+	{
+		m_vpActions = vpActions;
+	}
+	~CEditorMultipleActions()
+	{
+		for(auto pAction : m_vpActions)
+		{
+			delete pAction;
+		}
+		m_vpActions.clear();
+	}
+
+	bool Undo() override
+	{
+		bool Undid = true;
+		for(auto pAction : m_vpActions)
+		{
+			pAction->m_pEditor = m_pEditor;
+			Undid = Undid && pAction->Undo();
+		}
+		return Undid;
+	}
+
+	bool Redo() override
+	{
+		bool Redid = true;
+		for(auto pAction : m_vpActions)
+		{
+			pAction->m_pEditor = m_pEditor;
+			Redid = Redid && pAction->Redo();
+		}
+		return Redid;
+	}
+
+private:
+	std::vector<T *> m_vpActions;
+};
+
+class CEditorRotateQuadsAction : public CEditorLayerQuadsAction<float>
+{
+public:
+	CEditorRotateQuadsAction(int GroupIndex, int LayerIndex, std::vector<int> vQuads, const float &PrevRotation, const float &NewRotation);
+
+	bool Undo() override;
+	bool Redo() override;
+
+private:
+	void RotateInternal(int Direction);
+};
+
+class CEditorMoveQuadPivotAction : public CEditorLayerQuadsAction<CPoint>
+{
+public:
+	CEditorMoveQuadPivotAction(int GroupIndex, int LayerIndex, int Quad, const CPoint &OldPos, const CPoint &NewPos);
+
+	bool Undo() override;
+	bool Redo() override;
+};
+
+struct SQuadOperationInfo
+{
+	CPoint m_aPoints[4];
+};
+
+class CEditorQuadOperationAction : public CEditorLayerQuadsAction<std::vector<SQuadOperationInfo>>
+{
+public:
+	CEditorQuadOperationAction(EType Type, int GroupIndex, int LayerIndex, std::vector<int> vQuads, const std::vector<SQuadOperationInfo> &OldInfos, const std::vector<SQuadOperationInfo> &NewInfos);
+
+	bool Undo() override;
+	bool Redo() override;
+};
 
 #endif

--- a/src/game/editor/editor_actions.h
+++ b/src/game/editor/editor_actions.h
@@ -1,0 +1,425 @@
+#ifndef GAME_EDITOR_EDITOR_ACTIONS_H
+#define GAME_EDITOR_EDITOR_ACTIONS_H
+
+#include <game/editor/editor.h>
+
+class CLayerTiles;
+class CEditorMap;
+struct CLayerTiles_SCommonPropState;
+struct RECTi;
+
+class IEditorAction
+{
+public:
+	IEditorAction()
+	{
+		m_pEditor = nullptr;
+	}
+
+	virtual bool Undo() = 0;
+	virtual bool Redo() = 0;
+
+	virtual void Print()
+	{
+	}
+
+	virtual const char *Name() const = 0;
+
+	class CEditor *m_pEditor;
+
+public:
+	enum class EType
+	{
+		CHANGE_COLOR_TILE,
+		CHANGE_COLOR_QUAD,
+
+		EDIT_MULTIPLE_LAYERS,
+
+		ADD_LAYER,
+		DELETE_LAYER,
+
+		ADD_GROUP,
+		DELETE_GROUP,
+
+		EDIT_LAYER_GROUP,
+		EDIT_LAYER_ORDER,
+		EDIT_LAYER_WIDTH,
+		EDIT_LAYER_HEIGHT,
+		EDIT_LAYER_IMAGE,
+		EDIT_LAYER_COLOR_ENV,
+		EDIT_LAYER_COLOR_TO,
+
+		ADD_QUAD,
+		DELETE_QUAD,
+		EDIT_QUAD_POSITION,
+		EDIT_QUAD_CENTER,
+		EDIT_QUAD_VERTEX,
+
+		//SET_TILE,
+		FILL_SELECTION,
+		BRUSH_DRAW,
+
+		EDIT_GROUP_ORDER,
+		EDIT_GROUP_POS_X,
+		EDIT_GROUP_POS_Y,
+		EDIT_GROUP_PARA_X,
+		EDIT_GROUP_PARA_Y,
+		EDIT_GROUP_CLIP_X,
+		EDIT_GROUP_CLIP_Y,
+		EDIT_GROUP_CLIP_W,
+		EDIT_GROUP_CLIP_H,
+
+		ADD_ENVELOPPE,
+		EDIT_ENV_NAME,
+		EDIT_ENV_POINT_VALUE,
+		EDIT_ENV_POINT_TIME,
+		EDIT_ENV_SYNC_CHECKBOX,
+		DELETE_ENVELOPPE,
+
+		ADD_COMMAND,
+		EDIT_COMMAND,
+		DELETE_COMMAND,
+		MOVE_COMMAND_UP,
+		MOVE_COMMAND_DOWN,
+
+		//ADD_IMAGE,
+		//ADD_SOUND,
+
+		CHANGE_ORIENTATION_VALUE
+	};
+};
+
+
+template<typename T>
+class CEditorAction : public IEditorAction
+{
+public:
+	CEditorAction(EType Type, void *pObject, const T &From, const T &To) :
+		IEditorAction()
+	{
+		m_ValueFrom = From;
+		m_ValueTo = To;
+		m_pObject = pObject;
+		m_Type = Type;
+	}
+
+	virtual ~CEditorAction()
+	{
+	}
+
+	const char *Name() const override
+	{
+		switch(m_Type)
+		{
+		case EType::CHANGE_COLOR_TILE: return "CHANGE_COLOR_TILE";
+		case EType::CHANGE_COLOR_QUAD: return "CHANGE_COLOR_QUAD";
+		case EType::EDIT_MULTIPLE_LAYERS: return "EDIT_MULTIPLE_LAYERS";
+		case EType::ADD_LAYER: return "ADD_LAYER";
+		case EType::DELETE_LAYER: return "DELETE_LAYER";
+		case EType::ADD_GROUP: return "ADD_GROUP";
+		case EType::DELETE_GROUP: return "DELETE_GROUP";
+		case EType::EDIT_LAYER_GROUP: return "EDIT_LAYER_GROUP";
+		case EType::EDIT_LAYER_ORDER: return "EDIT_LAYER_ORDER";
+		case EType::EDIT_LAYER_WIDTH: return "EDIT_LAYER_WIDTH";
+		case EType::EDIT_LAYER_HEIGHT: return "EDIT_LAYER_HEIGHT";
+		case EType::EDIT_LAYER_IMAGE: return "EDIT_LAYER_IMAGE";
+		case EType::EDIT_LAYER_COLOR_ENV: return "EDIT_LAYER_COLOR_ENV";
+		case EType::EDIT_LAYER_COLOR_TO: return "EDIT_LAYER_COLOR_TO";
+		case EType::EDIT_QUAD_POSITION: return "EDIT_QUAD_POSITION";
+		case EType::EDIT_QUAD_CENTER: return "EDIT_QUAD_CENTER";
+		case EType::FILL_SELECTION: return "FILL_SELECTION";
+		case EType::BRUSH_DRAW: return "BRUSH_DRAW";
+		case EType::EDIT_GROUP_ORDER: return "EDIT_GROUP_ORDER";
+		case EType::EDIT_GROUP_POS_X: return "EDIT_GROUP_POS_X";
+		case EType::EDIT_GROUP_POS_Y: return "EDIT_GROUP_POS_Y";
+		case EType::EDIT_GROUP_PARA_X: return "EDIT_GROUP_PARA_X";
+		case EType::EDIT_GROUP_PARA_Y: return "EDIT_GROUP_PARA_Y";
+		case EType::EDIT_GROUP_CLIP_X: return "EDIT_GROUP_CLIP_X";
+		case EType::EDIT_GROUP_CLIP_Y: return "EDIT_GROUP_CLIP_Y";
+		case EType::EDIT_GROUP_CLIP_W: return "EDIT_GROUP_CLIP_W";
+		case EType::EDIT_GROUP_CLIP_H: return "EDIT_GROUP_CLIP_H";
+		case EType::ADD_ENVELOPPE: return "ADD_ENVELOPPE";
+		case EType::EDIT_ENV_NAME: return "EDIT_ENV_NAME";
+		case EType::EDIT_ENV_POINT_VALUE: return "EDIT_ENV_POINT_VALUE";
+		case EType::EDIT_ENV_POINT_TIME: return "EDIT_ENV_POINT_TIME";
+		case EType::EDIT_ENV_SYNC_CHECKBOX: return "EDIT_ENV_SYNC_CHECKBOX";
+		case EType::DELETE_ENVELOPPE: return "DELETE_ENVELOPPE";
+		case EType::ADD_COMMAND: return "ADD_COMMAND";
+		case EType::EDIT_COMMAND: return "EDIT_COMMAND";
+		case EType::DELETE_COMMAND: return "DELETE_COMMAND";
+		case EType::MOVE_COMMAND_UP: return "MOVE_COMMAND_UP";
+		case EType::MOVE_COMMAND_DOWN: return "MOVE_COMMAND_DOWN";
+		//case EType::ADD_IMAGE: return "ADD_IMAGE";
+		//case EType::ADD_SOUND: return "ADD_SOUND";
+		case EType::CHANGE_ORIENTATION_VALUE: return "CHANGE_ORIENTATION_VALUE";
+		case EType::ADD_QUAD: return "ADD_QUAD";
+		case EType::DELETE_QUAD: return "DELETE_QUAD";
+		case EType::EDIT_QUAD_VERTEX: return "EDIT_QUAD_VERTEX";
+		default: return "UNKNOWN";
+		}
+	}
+
+	EType m_Type;
+
+protected:
+	T m_ValueFrom;
+	T m_ValueTo;
+	void *m_pObject;
+};
+
+template<typename T>
+class CEditorLayerAction : public CEditorAction<T>
+{
+public:
+	CEditorLayerAction(EType Type, void *pObject, int GroupIndex, int LayerIndex, const T &From, const T &To) :
+		CEditorAction<T>(Type, pObject, From, To)
+	{
+		m_GroupIndex = GroupIndex;
+		m_LayerIndex = LayerIndex;
+	}
+
+	template<typename K>
+	K *GetLayer();
+
+protected:
+	int m_GroupIndex;
+	int m_LayerIndex;
+};
+
+template<typename T>
+template<typename K>
+K *CEditorLayerAction<T>::GetLayer()
+{
+	return (K *)(m_pEditor->m_Map.m_vpGroups[m_GroupIndex]->m_vpLayers[m_LayerIndex]);
+}
+
+class CEditorChangeColorTileAction : public CEditorLayerAction<CColor>
+{
+public:
+	CEditorChangeColorTileAction(int GroupIndex, int LayerIndex, const CColor &OldColor, const CColor &NewColor) :
+		CEditorLayerAction(EType::CHANGE_COLOR_TILE, nullptr, GroupIndex, LayerIndex, OldColor, NewColor)
+	{
+	}
+
+	bool Undo() override;
+	bool Redo() override;
+
+	void Print() override
+	{
+		dbg_msg("editor", "Editor action: Change tile color, prev=%d %d %d %d, new=%d %d %d %d", m_ValueFrom.r, m_ValueFrom.g, m_ValueFrom.b, m_ValueFrom.a, m_ValueTo.r, m_ValueTo.g, m_ValueTo.b, m_ValueTo.a);
+	}
+};
+
+class CEditorChangeColorQuadAction : public CEditorAction<CColor>
+{
+public:
+	CEditorChangeColorQuadAction(void *pObject, int Index, const CColor &OldColor, const CColor &NewColor) :
+		CEditorAction(EType::CHANGE_COLOR_QUAD, pObject, OldColor, NewColor)
+	{
+		m_Index = Index;
+	}
+
+	bool Undo() override;
+	bool Redo() override;
+
+	void Print() override
+	{
+		dbg_msg("editor", "Editor action: Change quad color, vertex %d, prev=%d %d %d %d, new=%d %d %d %d", m_Index, m_ValueFrom.r, m_ValueFrom.g, m_ValueFrom.b, m_ValueFrom.a, m_ValueTo.r, m_ValueTo.g, m_ValueTo.b, m_ValueTo.a);
+	}
+
+private:
+	int m_Index;
+};
+
+class CEditorAddLayerAction : public CEditorAction<class CLayer *>
+{
+public:
+	CEditorAddLayerAction(int GroupIndex, int LayerIndex, std::function<void()> fnAddLayer) :
+		CEditorAction(EType::ADD_LAYER, nullptr, nullptr, nullptr)
+	{
+		m_GroupIndex = GroupIndex;
+		m_LayerIndex = LayerIndex;
+		m_fnAddLayer = fnAddLayer;
+	}
+
+	~CEditorAddLayerAction()
+	{
+	}
+
+	bool Undo() override;
+
+	bool Redo() override
+	{
+		// call the add layer function, needed for special layers
+		m_fnAddLayer();
+		return true;
+	}
+
+	void Print() override
+	{
+		//dbg_msg("editor", "Editor action: Add layer, type=%d name=%s", m_ValueTo->m_Type, m_ValueTo->m_aName);
+	}
+
+private:
+	int m_LayerIndex;
+	int m_GroupIndex;
+	std::function<void()> m_fnAddLayer;
+};
+
+class CEditorDeleteLayerAction : public CEditorAction<class CLayer *>
+{
+public:
+	CEditorDeleteLayerAction(CEditor *pEditor, int GroupIndex, int LayerIndex);
+
+	~CEditorDeleteLayerAction()
+	{
+		delete m_ValueFrom;
+	}
+
+	bool Undo() override;
+	bool Redo() override;
+
+private:
+	int m_LayerIndex;
+	int m_GroupIndex;
+};
+
+class CEditorEditMultipleLayersAction : public CEditorAction<std::vector<CLayerTiles_SCommonPropState>>
+{
+public:
+	CEditorEditMultipleLayersAction(void *pObject, std::vector<CLayerTiles_SCommonPropState> vOriginals, CLayerTiles_SCommonPropState State, int GroupIndex, std::vector<int> vLayers);
+
+	bool Undo() override;
+	bool Redo() override;
+
+	void Print() override
+	{
+		dbg_msg("editor", "Editor action: Edit multiple layers");
+	}
+
+private:
+	std::vector<int> m_vLayers;
+	int m_GroupIndex;
+};
+
+class CEditorAddGroupAction : public CEditorAction<int>
+{
+public:
+	CEditorAddGroupAction(CEditorMap *pObject, int GroupIndex);
+
+	bool Undo() override;
+	bool Redo() override;
+};
+
+class CLayerGroup;
+
+class CEditorDeleteGroupAction : public CEditorAction<class CLayerGroup *>
+{
+public:
+	CEditorDeleteGroupAction(CEditorMap *pObject, int GroupIndex);
+
+	~CEditorDeleteGroupAction()
+	{
+		delete m_ValueFrom;
+	}
+
+	bool Undo() override;
+	bool Redo() override;
+
+private:
+	int m_GroupIndex;
+};
+
+class CEditorFillSelectionAction : public CEditorAction<class CLayerGroup *>
+{
+public:
+	CEditorFillSelectionAction(void *pObject, CLayerGroup *Original, CLayerGroup *Brush, int GroupIndex, std::vector<int> vLayers, CUIRect Rect);
+
+	~CEditorFillSelectionAction()
+	{
+		delete m_ValueFrom;
+		delete m_ValueTo;
+	}
+
+	bool Undo() override;
+	bool Redo() override;
+
+	void Print() override;
+
+private:
+	CUIRect m_Rect;
+	int m_GroupIndex;
+	std::vector<int> m_vLayers;
+};
+
+class CEditorBrushDrawAction : public CEditorAction<class CLayerGroup *>
+{
+public:
+	CEditorBrushDrawAction(void *pObject, CLayerGroup *Original, CLayerGroup *Brush, int GroupIndex, std::vector<int> vLayers);
+
+	~CEditorBrushDrawAction()
+	{
+		delete m_ValueFrom;
+		delete m_ValueTo;
+	}
+
+	bool Undo() override;
+	bool Redo() override;
+
+	void Print() override;
+
+private:
+	std::vector<int> m_vLayers;
+	int m_GroupIndex;
+
+	bool BrushDraw(CLayerGroup *Brush);
+};
+
+class CEditorCommandAction : public CEditorAction<std::string>
+{
+public:
+	CEditorCommandAction(EType Action, int *pSelectedCommand, int CommandIndex, std::string Old, std::string New) :
+		CEditorAction(Action, nullptr, Old, New)
+	{
+		m_pSelectedCommand = pSelectedCommand;
+		m_CommandIndex = CommandIndex;
+	}
+
+	bool Undo() override;
+	bool Redo() override;
+
+private:
+	int m_CommandIndex;
+	int *m_pSelectedCommand;
+};
+
+class CEditorAddQuadAction : public CEditorLayerAction<RECTi *>
+{
+public:
+	CEditorAddQuadAction(int GroupIndex, int LayerIndex, RECTi *Quad);
+	~CEditorAddQuadAction();
+
+	bool Undo() override;
+	bool Redo() override;
+};
+
+class CEditorDeleteQuadsAction : public CEditorLayerAction<void *>
+{
+public:
+	CEditorDeleteQuadsAction(int GroupIndex, int LayerIndex, std::vector<int> vQuadIndexes, std::vector<CQuad> vQuads) :
+		CEditorLayerAction(EType::DELETE_QUAD, nullptr, GroupIndex, LayerIndex, nullptr, nullptr)
+	{
+		m_vQuadIndexes = vQuadIndexes;
+		m_vQuads = vQuads;
+	}
+
+	bool Undo() override;
+	bool Redo() override;
+
+private:
+	std::vector<int> m_vQuadIndexes;
+	std::vector<CQuad> m_vQuads;
+};
+
+
+#endif

--- a/src/game/editor/editor_actions.h
+++ b/src/game/editor/editor_actions.h
@@ -68,14 +68,15 @@ public:
 		BRUSH_DRAW,
 
 		EDIT_GROUP_ORDER,
-		EDIT_GROUP_POS_X,
-		EDIT_GROUP_POS_Y,
-		EDIT_GROUP_PARA_X,
-		EDIT_GROUP_PARA_Y,
-		EDIT_GROUP_CLIP_X,
-		EDIT_GROUP_CLIP_Y,
-		EDIT_GROUP_CLIP_W,
-		EDIT_GROUP_CLIP_H,
+		EDIT_GROUP_PROPERTY,
+		//EDIT_GROUP_POS_X,
+		//EDIT_GROUP_POS_Y,
+		//EDIT_GROUP_PARA_X,
+		//EDIT_GROUP_PARA_Y,
+		//EDIT_GROUP_CLIP_X,
+		//EDIT_GROUP_CLIP_Y,
+		//EDIT_GROUP_CLIP_W,
+		//EDIT_GROUP_CLIP_H,
 
 		ADD_ENVELOPPE,
 		EDIT_ENV_NAME,
@@ -135,14 +136,15 @@ public:
 		case EType::FILL_SELECTION: return "FILL_SELECTION";
 		case EType::BRUSH_DRAW: return "BRUSH_DRAW";
 		case EType::EDIT_GROUP_ORDER: return "EDIT_GROUP_ORDER";
-		case EType::EDIT_GROUP_POS_X: return "EDIT_GROUP_POS_X";
-		case EType::EDIT_GROUP_POS_Y: return "EDIT_GROUP_POS_Y";
-		case EType::EDIT_GROUP_PARA_X: return "EDIT_GROUP_PARA_X";
-		case EType::EDIT_GROUP_PARA_Y: return "EDIT_GROUP_PARA_Y";
-		case EType::EDIT_GROUP_CLIP_X: return "EDIT_GROUP_CLIP_X";
-		case EType::EDIT_GROUP_CLIP_Y: return "EDIT_GROUP_CLIP_Y";
-		case EType::EDIT_GROUP_CLIP_W: return "EDIT_GROUP_CLIP_W";
-		case EType::EDIT_GROUP_CLIP_H: return "EDIT_GROUP_CLIP_H";
+		case EType::EDIT_GROUP_PROPERTY: return "EDIT_GROUP_PROPERTY";
+		//case EType::EDIT_GROUP_POS_X: return "EDIT_GROUP_POS_X";
+		//case EType::EDIT_GROUP_POS_Y: return "EDIT_GROUP_POS_Y";
+		//case EType::EDIT_GROUP_PARA_X: return "EDIT_GROUP_PARA_X";
+		//case EType::EDIT_GROUP_PARA_Y: return "EDIT_GROUP_PARA_Y";
+		//case EType::EDIT_GROUP_CLIP_X: return "EDIT_GROUP_CLIP_X";
+		//case EType::EDIT_GROUP_CLIP_Y: return "EDIT_GROUP_CLIP_Y";
+		//case EType::EDIT_GROUP_CLIP_W: return "EDIT_GROUP_CLIP_W";
+		//case EType::EDIT_GROUP_CLIP_H: return "EDIT_GROUP_CLIP_H";
 		case EType::ADD_ENVELOPPE: return "ADD_ENVELOPPE";
 		case EType::EDIT_ENV_NAME: return "EDIT_ENV_NAME";
 		case EType::EDIT_ENV_POINT_VALUE: return "EDIT_ENV_POINT_VALUE";
@@ -534,5 +536,55 @@ public:
 	bool Undo() override;
 	bool Redo() override;
 };
+
+struct SEditGroupInfo
+{
+	int m_OffsetX;
+	int m_OffsetY;
+
+	int m_ParallaxX;
+	int m_ParallaxY;
+	int m_CustomParallaxZoom;
+	int m_ParallaxZoom;
+
+	int m_UseClipping;
+	int m_ClipX;
+	int m_ClipY;
+	int m_ClipW;
+	int m_ClipH;
+
+	int m_Order;
+
+	enum
+	{
+		ORDER = 1 << 0,
+		OFFSET_X = 1 << 1,
+		OFFSET_Y = 1 << 2,
+		PARA_X = 1 << 3,
+		PARA_Y = 1 << 4,
+		CUSTOM_PARA_ZOOM = 1 << 5,
+		PARA_ZOOM = 1 << 6,
+		USE_CLIPPING = 1 << 7,
+		CLIP_X = 1 << 8,
+		CLIP_Y = 1 << 9,
+		CLIP_W = 1 << 10,
+		CLIP_H = 1 << 11
+	};
+	int m_Modified;
+};
+class CEditorEditGroupProperty : public CEditorAction<SEditGroupInfo>
+{
+public:
+	CEditorEditGroupProperty(int GroupIndex, const SEditGroupInfo &OldInfo, const SEditGroupInfo &NewInfo);
+
+	bool Undo() override;
+	bool Redo() override;
+
+private:
+	int m_GroupIndex;
+
+	void ApplyInfo(const SEditGroupInfo &Info);
+};
+
 
 #endif

--- a/src/game/editor/layer_tiles.cpp
+++ b/src/game/editor/layer_tiles.cpp
@@ -917,7 +917,7 @@ int CLayerTiles::RenderProperties(CUIRect *pToolBox)
 		m_Color.g = (NewVal >> 16) & 0xff;
 		m_Color.b = (NewVal >> 8) & 0xff;
 		m_Color.a = NewVal & 0xff;
-		
+
 		if(!(PrevColor == m_Color))
 			m_pEditor->RecordUndoAction(new CEditorChangeColorTileAction(this, PrevColor, m_Color));
 	}

--- a/src/game/editor/layer_tiles.cpp
+++ b/src/game/editor/layer_tiles.cpp
@@ -975,6 +975,8 @@ int CLayerTiles::RenderCommonProperties(SCommonPropState &State, CEditor *pEdito
 					pLayer->m_Color.g = (State.m_Color >> 16) & 0xff;
 					pLayer->m_Color.b = (State.m_Color >> 8) & 0xff;
 					pLayer->m_Color.a = State.m_Color & 0xff;
+
+					// TODO -- EDIT_LAYERS_BATCH_COLOR
 				}
 
 				pLayer->FlagModified(0, 0, pLayer->m_Width, pLayer->m_Height);
@@ -1102,9 +1104,25 @@ CLayerTele::CLayerTele(int w, int h) :
 	mem_zero(m_pTeleTile, (size_t)w * h * sizeof(CTeleTile));
 }
 
+CLayerTele::CLayerTele(const CLayerTele &Other) :
+	CLayerTiles(Other)
+{
+	str_copy(m_aName, "Tele", sizeof(m_aName));
+	m_Tele = 1;
+	m_TeleNum = Other.m_TeleNum;
+
+	m_pTeleTile = new CTeleTile[(size_t)m_Width * m_Height];
+	mem_copy(m_pTeleTile, Other.m_pTeleTile, (size_t)m_Width * m_Height * sizeof(CTeleTile));
+}
+
 CLayerTele::~CLayerTele()
 {
 	delete[] m_pTeleTile;
+}
+
+CLayer *CLayerTele::Duplicate() const
+{
+	return new CLayerTele(*this);
 }
 
 void CLayerTele::Resize(int NewW, int NewH)
@@ -1329,6 +1347,19 @@ CLayerSpeedup::CLayerSpeedup(int w, int h) :
 
 	m_pSpeedupTile = new CSpeedupTile[w * h];
 	mem_zero(m_pSpeedupTile, (size_t)w * h * sizeof(CSpeedupTile));
+}
+
+CLayerSpeedup::CLayerSpeedup(const CLayerSpeedup &Other) :
+	CLayerTiles(Other)
+{
+	str_copy(m_aName, "Speedup", sizeof(m_aName));
+	m_Speedup = 1;
+	m_SpeedupAngle = Other.m_SpeedupAngle;
+	m_SpeedupForce = Other.m_SpeedupForce;
+	m_SpeedupMaxSpeed = Other.m_SpeedupMaxSpeed;
+
+	m_pSpeedupTile = new CSpeedupTile[(size_t)m_Width * m_Height];
+	mem_copy(m_pSpeedupTile, Other.m_pSpeedupTile, (size_t)m_Width * m_Height * sizeof(CSpeedupTile));
 }
 
 CLayerSpeedup::~CLayerSpeedup()
@@ -1566,6 +1597,13 @@ CLayerFront::CLayerFront(int w, int h) :
 	m_Front = 1;
 }
 
+CLayerFront::CLayerFront(const CLayerFront &Other) :
+	CLayerTiles(Other)
+{
+	str_copy(m_aName, "Front", sizeof(m_aName));
+	m_Front = 1;
+}
+
 void CLayerFront::SetTile(int x, int y, CTile tile)
 {
 	if(tile.m_Index == TILE_THROUGH_CUT)
@@ -1614,6 +1652,18 @@ CLayerSwitch::CLayerSwitch(int w, int h) :
 
 	m_pSwitchTile = new CSwitchTile[w * h];
 	mem_zero(m_pSwitchTile, (size_t)w * h * sizeof(CSwitchTile));
+}
+
+CLayerSwitch::CLayerSwitch(const CLayerSwitch &Other) :
+	CLayerTiles(Other)
+{
+	str_copy(m_aName, "Switch", sizeof(m_aName));
+	m_Switch = 1;
+	m_SwitchNumber = Other.m_SwitchNumber;
+	m_SwitchDelay = Other.m_SwitchDelay;
+
+	m_pSwitchTile = new CSwitchTile[(size_t)m_Width * m_Height];
+	mem_copy(m_pSwitchTile, Other.m_pSwitchTile, (size_t)m_Width * m_Height * sizeof(CSwitchTile));
 }
 
 CLayerSwitch::~CLayerSwitch()
@@ -1871,6 +1921,17 @@ CLayerTune::CLayerTune(int w, int h) :
 
 	m_pTuneTile = new CTuneTile[w * h];
 	mem_zero(m_pTuneTile, (size_t)w * h * sizeof(CTuneTile));
+}
+
+CLayerTune::CLayerTune(const CLayerTune &Other) :
+	CLayerTiles(Other)
+{
+	str_copy(m_aName, "Tune", sizeof(m_aName));
+	m_Tune = 1;
+	m_TuningNumber = Other.m_TuningNumber;
+
+	m_pTuneTile = new CTuneTile[(size_t)m_Width * m_Height];
+	mem_copy(m_pTuneTile, Other.m_pTuneTile, (size_t)m_Width * m_Height * sizeof(CTuneTile));
 }
 
 CLayerTune::~CLayerTune()

--- a/src/game/editor/layer_tiles.cpp
+++ b/src/game/editor/layer_tiles.cpp
@@ -919,7 +919,15 @@ int CLayerTiles::RenderProperties(CUIRect *pToolBox)
 		m_Color.a = NewVal & 0xff;
 
 		if(!(PrevColor == m_Color))
-			m_pEditor->m_EditorHistory.RecordUndoAction(new CEditorChangeColorTileAction(this, PrevColor, m_Color));
+		{
+			int LayerIndex = -1;
+			for(size_t k = 0; k < m_pEditor->m_Map.m_vpGroups[m_pEditor->m_SelectedGroup]->m_vpLayers.size(); k++)
+				if(m_pEditor->m_Map.m_vpGroups[m_pEditor->m_SelectedGroup]->m_vpLayers[k] == this)
+					LayerIndex = k;
+
+			if(LayerIndex != -1)
+				m_pEditor->m_EditorHistory.RecordUndoAction(new CEditorChangeColorTileAction(m_pEditor->m_SelectedGroup, LayerIndex, PrevColor, m_Color));
+		}
 	}
 	if(Prop == PROP_COLOR_ENV)
 	{
@@ -988,7 +996,7 @@ int CLayerTiles::RenderCommonProperties(SCommonPropState &State, CEditor *pEdito
 				OriginalStates.push_back(Original);
 			}
 
-			pEditor->m_EditorHistory.RecordUndoAction(new CEditorEditMultipleLayersAction(nullptr, OriginalStates, State, vpLayers));
+			pEditor->m_EditorHistory.RecordUndoAction(new CEditorEditMultipleLayersAction(nullptr, OriginalStates, State, pEditor->m_SelectedGroup, pEditor->m_vSelectedLayers));
 			State.m_Modified = 0;
 		}
 	}

--- a/src/game/editor/layer_tiles.cpp
+++ b/src/game/editor/layer_tiles.cpp
@@ -919,7 +919,7 @@ int CLayerTiles::RenderProperties(CUIRect *pToolBox)
 		m_Color.a = NewVal & 0xff;
 
 		if(!(PrevColor == m_Color))
-			m_pEditor->RecordUndoAction(new CEditorChangeColorTileAction(this, PrevColor, m_Color));
+			m_pEditor->m_EditorHistory.RecordUndoAction(new CEditorChangeColorTileAction(this, PrevColor, m_Color));
 	}
 	if(Prop == PROP_COLOR_ENV)
 	{
@@ -988,7 +988,7 @@ int CLayerTiles::RenderCommonProperties(SCommonPropState &State, CEditor *pEdito
 				OriginalStates.push_back(Original);
 			}
 
-			pEditor->RecordUndoAction(new CEditorEditMultipleLayersAction(nullptr, OriginalStates, State, vpLayers));
+			pEditor->m_EditorHistory.RecordUndoAction(new CEditorEditMultipleLayersAction(nullptr, OriginalStates, State, vpLayers));
 			State.m_Modified = 0;
 		}
 	}

--- a/src/game/editor/layer_tiles.cpp
+++ b/src/game/editor/layer_tiles.cpp
@@ -912,10 +912,14 @@ int CLayerTiles::RenderProperties(CUIRect *pToolBox)
 	}
 	else if(Prop == PROP_COLOR)
 	{
+		CColor PrevColor = m_Color;
 		m_Color.r = (NewVal >> 24) & 0xff;
 		m_Color.g = (NewVal >> 16) & 0xff;
 		m_Color.b = (NewVal >> 8) & 0xff;
 		m_Color.a = NewVal & 0xff;
+		
+		if(!(PrevColor == m_Color))
+			m_pEditor->RecordUndoAction(new CEditorChangeColorTileAction(this, PrevColor, m_Color));
 	}
 	if(Prop == PROP_COLOR_ENV)
 	{

--- a/src/game/editor/layer_tiles.cpp
+++ b/src/game/editor/layer_tiles.cpp
@@ -64,7 +64,7 @@ CLayerTiles::CLayerTiles(const CLayerTiles &Other) :
 	m_Switch = Other.m_Switch;
 	m_Tune = Other.m_Tune;
 
-	mem_copy(m_aFileName, Other.m_aFileName, IO_MAX_PATH_LENGTH);
+	str_copy(m_aFileName, Other.m_aFileName, sizeof(m_aFileName));
 }
 
 CLayerTiles::~CLayerTiles()
@@ -1101,6 +1101,15 @@ void CLayerTiles::ModifyEnvelopeIndex(INDEX_MODIFY_FUNC Func)
 	Func(&m_ColorEnv);
 }
 
+bool CLayerTiles::Contains(int Tile)
+{
+	for(int x = 0; x < m_Width; x++)
+		for(int y = 0; y < m_Height; y++)
+			if(GetTile(x, y).m_Index == Tile)
+				return true;
+	return false;
+}
+
 CLayerTele::CLayerTele(int w, int h) :
 	CLayerTiles(w, h)
 {
@@ -1117,7 +1126,7 @@ CLayerTele::CLayerTele(const CLayerTele &Other) :
 {
 	str_copy(m_aName, "Tele", sizeof(m_aName));
 	m_Tele = 1;
-	m_TeleNum = Other.m_TeleNum;
+	m_TeleNum = m_pEditor->m_TeleNumber;
 
 	m_pTeleTile = new CTeleTile[(size_t)m_Width * m_Height];
 	mem_copy(m_pTeleTile, Other.m_pTeleTile, (size_t)m_Width * m_Height * sizeof(CTeleTile));
@@ -1362,9 +1371,9 @@ CLayerSpeedup::CLayerSpeedup(const CLayerSpeedup &Other) :
 {
 	str_copy(m_aName, "Speedup", sizeof(m_aName));
 	m_Speedup = 1;
-	m_SpeedupAngle = Other.m_SpeedupAngle;
-	m_SpeedupForce = Other.m_SpeedupForce;
-	m_SpeedupMaxSpeed = Other.m_SpeedupMaxSpeed;
+	m_SpeedupAngle = m_pEditor->m_SpeedupAngle;
+	m_SpeedupForce = m_pEditor->m_SpeedupForce;
+	m_SpeedupMaxSpeed = m_pEditor->m_SpeedupMaxSpeed;
 
 	m_pSpeedupTile = new CSpeedupTile[(size_t)m_Width * m_Height];
 	mem_copy(m_pSpeedupTile, Other.m_pSpeedupTile, (size_t)m_Width * m_Height * sizeof(CSpeedupTile));
@@ -1667,8 +1676,8 @@ CLayerSwitch::CLayerSwitch(const CLayerSwitch &Other) :
 {
 	str_copy(m_aName, "Switch", sizeof(m_aName));
 	m_Switch = 1;
-	m_SwitchNumber = Other.m_SwitchNumber;
-	m_SwitchDelay = Other.m_SwitchDelay;
+	m_SwitchNumber = m_pEditor->m_SwitchNum;
+	m_SwitchDelay = m_pEditor->m_SwitchDelay;
 
 	m_pSwitchTile = new CSwitchTile[(size_t)m_Width * m_Height];
 	mem_copy(m_pSwitchTile, Other.m_pSwitchTile, (size_t)m_Width * m_Height * sizeof(CSwitchTile));
@@ -1936,7 +1945,7 @@ CLayerTune::CLayerTune(const CLayerTune &Other) :
 {
 	str_copy(m_aName, "Tune", sizeof(m_aName));
 	m_Tune = 1;
-	m_TuningNumber = Other.m_TuningNumber;
+	m_TuningNumber = m_pEditor->m_TuningNum;
 
 	m_pTuneTile = new CTuneTile[(size_t)m_Width * m_Height];
 	mem_copy(m_pTuneTile, Other.m_pTuneTile, (size_t)m_Width * m_Height * sizeof(CTuneTile));

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -130,7 +130,7 @@ int CEditor::PopupGroup(CEditor *pEditor, CUIRect View, void *pContext)
 	{
 		if(pEditor->DoButton_Editor(&s_DeleteButton, "Delete group", 0, &Button, 0, "Delete group"))
 		{
-			pEditor->RecordUndoAction(new CEditorDeleteGroupAction(&pEditor->m_Map, pEditor->m_SelectedGroup));
+			pEditor->m_EditorHistory.RecordUndoAction(new CEditorDeleteGroupAction(&pEditor->m_Map, pEditor->m_SelectedGroup));
 
 			pEditor->m_Map.DeleteGroup(pEditor->m_SelectedGroup);
 			pEditor->m_SelectedGroup = maximum(0, pEditor->m_SelectedGroup - 1);
@@ -197,7 +197,7 @@ int CEditor::PopupGroup(CEditor *pEditor, CUIRect View, void *pContext)
 			};
 
 			fnAddTeleLayer();
-			pEditor->RecordUndoAction(new CEditorAddLayerAction(SelectedGroup, pEditor->m_Map.m_vpGroups[SelectedGroup]->m_vpLayers.size() - 1, fnAddTeleLayer));
+			pEditor->m_EditorHistory.RecordUndoAction(new CEditorAddLayerAction(SelectedGroup, pEditor->m_Map.m_vpGroups[SelectedGroup]->m_vpLayers.size() - 1, fnAddTeleLayer));
 
 			return 1;
 		}
@@ -222,7 +222,7 @@ int CEditor::PopupGroup(CEditor *pEditor, CUIRect View, void *pContext)
 			};
 
 			fnAddSpeedupLayer();
-			pEditor->RecordUndoAction(new CEditorAddLayerAction(SelectedGroup, pEditor->m_Map.m_vpGroups[SelectedGroup]->m_vpLayers.size() - 1, fnAddSpeedupLayer));
+			pEditor->m_EditorHistory.RecordUndoAction(new CEditorAddLayerAction(SelectedGroup, pEditor->m_Map.m_vpGroups[SelectedGroup]->m_vpLayers.size() - 1, fnAddSpeedupLayer));
 
 			return 1;
 		}
@@ -247,7 +247,7 @@ int CEditor::PopupGroup(CEditor *pEditor, CUIRect View, void *pContext)
 			};
 
 			fnAddTuneLayer();
-			pEditor->RecordUndoAction(new CEditorAddLayerAction(SelectedGroup, pEditor->m_Map.m_vpGroups[SelectedGroup]->m_vpLayers.size() - 1, fnAddTuneLayer));
+			pEditor->m_EditorHistory.RecordUndoAction(new CEditorAddLayerAction(SelectedGroup, pEditor->m_Map.m_vpGroups[SelectedGroup]->m_vpLayers.size() - 1, fnAddTuneLayer));
 
 			return 1;
 		}
@@ -272,7 +272,7 @@ int CEditor::PopupGroup(CEditor *pEditor, CUIRect View, void *pContext)
 			};
 
 			fnAddFrontLayer();
-			pEditor->RecordUndoAction(new CEditorAddLayerAction(SelectedGroup, pEditor->m_Map.m_vpGroups[SelectedGroup]->m_vpLayers.size() - 1, fnAddFrontLayer));
+			pEditor->m_EditorHistory.RecordUndoAction(new CEditorAddLayerAction(SelectedGroup, pEditor->m_Map.m_vpGroups[SelectedGroup]->m_vpLayers.size() - 1, fnAddFrontLayer));
 
 			return 1;
 		}
@@ -297,7 +297,7 @@ int CEditor::PopupGroup(CEditor *pEditor, CUIRect View, void *pContext)
 			};
 
 			fnAddSwitchLayer();
-			pEditor->RecordUndoAction(new CEditorAddLayerAction(SelectedGroup, pEditor->m_Map.m_vpGroups[SelectedGroup]->m_vpLayers.size() - 1, fnAddSwitchLayer));
+			pEditor->m_EditorHistory.RecordUndoAction(new CEditorAddLayerAction(SelectedGroup, pEditor->m_Map.m_vpGroups[SelectedGroup]->m_vpLayers.size() - 1, fnAddSwitchLayer));
 
 			return 1;
 		}
@@ -320,7 +320,7 @@ int CEditor::PopupGroup(CEditor *pEditor, CUIRect View, void *pContext)
 		};
 
 		fnAddQuadLayer();
-		pEditor->RecordUndoAction(new CEditorAddLayerAction(SelectedGroup, pEditor->m_Map.m_vpGroups[SelectedGroup]->m_vpLayers.size() - 1, fnAddQuadLayer));
+		pEditor->m_EditorHistory.RecordUndoAction(new CEditorAddLayerAction(SelectedGroup, pEditor->m_Map.m_vpGroups[SelectedGroup]->m_vpLayers.size() - 1, fnAddQuadLayer));
 
 		return 1;
 	}
@@ -342,7 +342,7 @@ int CEditor::PopupGroup(CEditor *pEditor, CUIRect View, void *pContext)
 		};
 
 		fnAddTileLayer();
-		pEditor->RecordUndoAction(new CEditorAddLayerAction(SelectedGroup, pEditor->m_Map.m_vpGroups[SelectedGroup]->m_vpLayers.size() - 1, fnAddTileLayer));
+		pEditor->m_EditorHistory.RecordUndoAction(new CEditorAddLayerAction(SelectedGroup, pEditor->m_Map.m_vpGroups[SelectedGroup]->m_vpLayers.size() - 1, fnAddTileLayer));
 
 		return 1;
 	}
@@ -364,7 +364,7 @@ int CEditor::PopupGroup(CEditor *pEditor, CUIRect View, void *pContext)
 		};
 
 		fnAddSoundLayer();
-		pEditor->RecordUndoAction(new CEditorAddLayerAction(SelectedGroup, pEditor->m_Map.m_vpGroups[SelectedGroup]->m_vpLayers.size() - 1, fnAddSoundLayer));
+		pEditor->m_EditorHistory.RecordUndoAction(new CEditorAddLayerAction(SelectedGroup, pEditor->m_Map.m_vpGroups[SelectedGroup]->m_vpLayers.size() - 1, fnAddSoundLayer));
 
 		return 1;
 	}
@@ -496,7 +496,7 @@ int CEditor::PopupLayer(CEditor *pEditor, CUIRect View, void *pContext)
 			};
 
 			fnDupLayer();
-			pEditor->RecordUndoAction(new CEditorAddLayerAction(pEditor->m_SelectedGroup, SelectedLayer + 1, fnDupLayer));
+			pEditor->m_EditorHistory.RecordUndoAction(new CEditorAddLayerAction(pEditor->m_SelectedGroup, SelectedLayer + 1, fnDupLayer));
 
 			return 1;
 		}
@@ -506,7 +506,7 @@ int CEditor::PopupLayer(CEditor *pEditor, CUIRect View, void *pContext)
 	if(pEditor->m_Map.m_pGameLayer != pEditor->GetSelectedLayer(0) &&
 		pEditor->DoButton_Editor(&s_DeleteButton, "Delete layer", 0, &Button, 0, "Deletes the layer"))
 	{
-		pEditor->RecordUndoAction(new CEditorDeleteLayerAction(pEditor, pEditor->m_SelectedGroup, pEditor->m_vSelectedLayers[0]));
+		pEditor->m_EditorHistory.RecordUndoAction(new CEditorDeleteLayerAction(pEditor, pEditor->m_SelectedGroup, pEditor->m_vSelectedLayers[0]));
 
 		if(pEditor->GetSelectedLayer(0) == pEditor->m_Map.m_pFrontLayer)
 			pEditor->m_Map.m_pFrontLayer = nullptr;
@@ -1071,7 +1071,7 @@ int CEditor::PopupPoint(CEditor *pEditor, CUIRect View, void *pContext)
 					pQuad->m_aColors[v].a = NewVal & 0xff;
 
 					if(!(PrevColor == pQuad->m_aColors[v]))
-						pEditor->RecordUndoAction(new CEditorChangeColorQuadAction(pQuad, v, PrevColor, pQuad->m_aColors[v]));
+						pEditor->m_EditorHistory.RecordUndoAction(new CEditorChangeColorQuadAction(pQuad, v, PrevColor, pQuad->m_aColors[v]));
 				}
 			}
 		}

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -130,6 +130,8 @@ int CEditor::PopupGroup(CEditor *pEditor, CUIRect View, void *pContext)
 	{
 		if(pEditor->DoButton_Editor(&s_DeleteButton, "Delete group", 0, &Button, 0, "Delete group"))
 		{
+			pEditor->RecordUndoAction(new CEditorDeleteGroupAction(&pEditor->m_Map, pEditor->m_SelectedGroup));
+
 			pEditor->m_Map.DeleteGroup(pEditor->m_SelectedGroup);
 			pEditor->m_SelectedGroup = maximum(0, pEditor->m_SelectedGroup - 1);
 			return 1;

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -186,8 +186,9 @@ int CEditor::PopupGroup(CEditor *pEditor, CUIRect View, void *pContext)
 		static int s_NewTeleLayerButton = 0;
 		if(pEditor->DoButton_Editor(&s_NewTeleLayerButton, "Add tele layer", 0, &Button, 0, "Creates a new tele layer"))
 		{
-			CLayerGroup *Group = pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup];
-			auto fnAddTeleLayer = [pEditor, Group]() {
+			int SelectedGroup = pEditor->m_SelectedGroup;
+			auto fnAddTeleLayer = [pEditor, SelectedGroup]() {
+				CLayerGroup *Group = pEditor->m_Map.m_vpGroups[SelectedGroup];
 				CLayer *pTeleLayer = new CLayerTele(pEditor->m_Map.m_pGameLayer->m_Width, pEditor->m_Map.m_pGameLayer->m_Height);
 				pEditor->m_Map.MakeTeleLayer(pTeleLayer);
 				Group->AddLayer(pTeleLayer);
@@ -196,7 +197,7 @@ int CEditor::PopupGroup(CEditor *pEditor, CUIRect View, void *pContext)
 			};
 
 			fnAddTeleLayer();
-			pEditor->RecordUndoAction(new CEditorAddLayerAction(Group, Group->m_vpLayers.size() - 1, fnAddTeleLayer));
+			pEditor->RecordUndoAction(new CEditorAddLayerAction(SelectedGroup, pEditor->m_Map.m_vpGroups[SelectedGroup]->m_vpLayers.size() - 1, fnAddTeleLayer));
 
 			return 1;
 		}
@@ -210,8 +211,9 @@ int CEditor::PopupGroup(CEditor *pEditor, CUIRect View, void *pContext)
 		static int s_NewSpeedupLayerButton = 0;
 		if(pEditor->DoButton_Editor(&s_NewSpeedupLayerButton, "Add speedup layer", 0, &Button, 0, "Creates a new speedup layer"))
 		{
-			CLayerGroup *Group = pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup];
-			auto fnAddSpeedupLayer = [pEditor, Group]() {
+			int SelectedGroup = pEditor->m_SelectedGroup;
+			auto fnAddSpeedupLayer = [pEditor, SelectedGroup]() {
+				CLayerGroup *Group = pEditor->m_Map.m_vpGroups[SelectedGroup];
 				CLayer *pSpeedupLayer = new CLayerSpeedup(pEditor->m_Map.m_pGameLayer->m_Width, pEditor->m_Map.m_pGameLayer->m_Height);
 				pEditor->m_Map.MakeSpeedupLayer(pSpeedupLayer);
 				Group->AddLayer(pSpeedupLayer);
@@ -220,7 +222,7 @@ int CEditor::PopupGroup(CEditor *pEditor, CUIRect View, void *pContext)
 			};
 
 			fnAddSpeedupLayer();
-			pEditor->RecordUndoAction(new CEditorAddLayerAction(Group, Group->m_vpLayers.size() - 1, fnAddSpeedupLayer));
+			pEditor->RecordUndoAction(new CEditorAddLayerAction(SelectedGroup, pEditor->m_Map.m_vpGroups[SelectedGroup]->m_vpLayers.size() - 1, fnAddSpeedupLayer));
 
 			return 1;
 		}
@@ -234,8 +236,9 @@ int CEditor::PopupGroup(CEditor *pEditor, CUIRect View, void *pContext)
 		static int s_NewTuneLayerButton = 0;
 		if(pEditor->DoButton_Editor(&s_NewTuneLayerButton, "Add tune layer", 0, &Button, 0, "Creates a new tuning layer"))
 		{
-			CLayerGroup *Group = pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup];
-			auto fnAddTuneLayer = [pEditor, Group]() {
+			int SelectedGroup = pEditor->m_SelectedGroup;
+			auto fnAddTuneLayer = [pEditor, SelectedGroup]() {
+				CLayerGroup *Group = pEditor->m_Map.m_vpGroups[SelectedGroup];
 				CLayer *pTuneLayer = new CLayerTune(pEditor->m_Map.m_pGameLayer->m_Width, pEditor->m_Map.m_pGameLayer->m_Height);
 				pEditor->m_Map.MakeTuneLayer(pTuneLayer);
 				Group->AddLayer(pTuneLayer);
@@ -244,7 +247,7 @@ int CEditor::PopupGroup(CEditor *pEditor, CUIRect View, void *pContext)
 			};
 
 			fnAddTuneLayer();
-			pEditor->RecordUndoAction(new CEditorAddLayerAction(Group, Group->m_vpLayers.size() - 1, fnAddTuneLayer));
+			pEditor->RecordUndoAction(new CEditorAddLayerAction(SelectedGroup, pEditor->m_Map.m_vpGroups[SelectedGroup]->m_vpLayers.size() - 1, fnAddTuneLayer));
 
 			return 1;
 		}
@@ -258,8 +261,9 @@ int CEditor::PopupGroup(CEditor *pEditor, CUIRect View, void *pContext)
 		static int s_NewFrontLayerButton = 0;
 		if(pEditor->DoButton_Editor(&s_NewFrontLayerButton, "Add front layer", 0, &Button, 0, "Creates a new item layer"))
 		{
-			CLayerGroup *Group = pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup];
-			auto fnAddFrontLayer = [pEditor, Group]() {
+			int SelectedGroup = pEditor->m_SelectedGroup;
+			auto fnAddFrontLayer = [pEditor, SelectedGroup]() {
+				CLayerGroup *Group = pEditor->m_Map.m_vpGroups[SelectedGroup];
 				CLayer *pFrontLayer = new CLayerFront(pEditor->m_Map.m_pGameLayer->m_Width, pEditor->m_Map.m_pGameLayer->m_Height);
 				pEditor->m_Map.MakeFrontLayer(pFrontLayer);
 				Group->AddLayer(pFrontLayer);
@@ -268,7 +272,7 @@ int CEditor::PopupGroup(CEditor *pEditor, CUIRect View, void *pContext)
 			};
 
 			fnAddFrontLayer();
-			pEditor->RecordUndoAction(new CEditorAddLayerAction(Group, Group->m_vpLayers.size() - 1, fnAddFrontLayer));
+			pEditor->RecordUndoAction(new CEditorAddLayerAction(SelectedGroup, pEditor->m_Map.m_vpGroups[SelectedGroup]->m_vpLayers.size() - 1, fnAddFrontLayer));
 
 			return 1;
 		}
@@ -282,8 +286,9 @@ int CEditor::PopupGroup(CEditor *pEditor, CUIRect View, void *pContext)
 		static int s_NewSwitchLayerButton = 0;
 		if(pEditor->DoButton_Editor(&s_NewSwitchLayerButton, "Add switch layer", 0, &Button, 0, "Creates a new switch layer"))
 		{
-			CLayerGroup *Group = pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup];
-			auto fnAddSwitchLayer = [pEditor, Group]() {
+			int SelectedGroup = pEditor->m_SelectedGroup;
+			auto fnAddSwitchLayer = [pEditor, SelectedGroup]() {
+				CLayerGroup *Group = pEditor->m_Map.m_vpGroups[SelectedGroup];
 				CLayer *pSwitchLayer = new CLayerSwitch(pEditor->m_Map.m_pGameLayer->m_Width, pEditor->m_Map.m_pGameLayer->m_Height);
 				pEditor->m_Map.MakeSwitchLayer(pSwitchLayer);
 				Group->AddLayer(pSwitchLayer);
@@ -292,7 +297,7 @@ int CEditor::PopupGroup(CEditor *pEditor, CUIRect View, void *pContext)
 			};
 
 			fnAddSwitchLayer();
-			pEditor->RecordUndoAction(new CEditorAddLayerAction(Group, Group->m_vpLayers.size() - 1, fnAddSwitchLayer));
+			pEditor->RecordUndoAction(new CEditorAddLayerAction(SelectedGroup, pEditor->m_Map.m_vpGroups[SelectedGroup]->m_vpLayers.size() - 1, fnAddSwitchLayer));
 
 			return 1;
 		}
@@ -304,8 +309,9 @@ int CEditor::PopupGroup(CEditor *pEditor, CUIRect View, void *pContext)
 	static int s_NewQuadLayerButton = 0;
 	if(pEditor->DoButton_Editor(&s_NewQuadLayerButton, "Add quads layer", 0, &Button, 0, "Creates a new quad layer"))
 	{
-		CLayerGroup *Group = pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup];
-		auto fnAddQuadLayer = [pEditor, Group]() {
+		int SelectedGroup = pEditor->m_SelectedGroup;
+		auto fnAddQuadLayer = [pEditor, SelectedGroup]() {
+			CLayerGroup *Group = pEditor->m_Map.m_vpGroups[SelectedGroup];
 			CLayer *pQuadLayer = new CLayerQuads;
 			pQuadLayer->m_pEditor = pEditor;
 			Group->AddLayer(pQuadLayer);
@@ -314,7 +320,7 @@ int CEditor::PopupGroup(CEditor *pEditor, CUIRect View, void *pContext)
 		};
 
 		fnAddQuadLayer();
-		pEditor->RecordUndoAction(new CEditorAddLayerAction(Group, Group->m_vpLayers.size() - 1, fnAddQuadLayer));
+		pEditor->RecordUndoAction(new CEditorAddLayerAction(SelectedGroup, pEditor->m_Map.m_vpGroups[SelectedGroup]->m_vpLayers.size() - 1, fnAddQuadLayer));
 
 		return 1;
 	}
@@ -325,8 +331,9 @@ int CEditor::PopupGroup(CEditor *pEditor, CUIRect View, void *pContext)
 	static int s_NewTileLayerButton = 0;
 	if(pEditor->DoButton_Editor(&s_NewTileLayerButton, "Add tile layer", 0, &Button, 0, "Creates a new tile layer"))
 	{
-		CLayerGroup *Group = pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup];
-		auto fnAddTileLayer = [pEditor, Group]() {
+		int SelectedGroup = pEditor->m_SelectedGroup;
+		auto fnAddTileLayer = [pEditor, SelectedGroup]() {
+			CLayerGroup *Group = pEditor->m_Map.m_vpGroups[SelectedGroup];
 			CLayer *pTileLayer = new CLayerTiles(pEditor->m_Map.m_pGameLayer->m_Width, pEditor->m_Map.m_pGameLayer->m_Height);
 			pTileLayer->m_pEditor = pEditor;
 			Group->AddLayer(pTileLayer);
@@ -335,7 +342,7 @@ int CEditor::PopupGroup(CEditor *pEditor, CUIRect View, void *pContext)
 		};
 
 		fnAddTileLayer();
-		pEditor->RecordUndoAction(new CEditorAddLayerAction(Group, Group->m_vpLayers.size() - 1, fnAddTileLayer));
+		pEditor->RecordUndoAction(new CEditorAddLayerAction(SelectedGroup, pEditor->m_Map.m_vpGroups[SelectedGroup]->m_vpLayers.size() - 1, fnAddTileLayer));
 
 		return 1;
 	}
@@ -346,8 +353,9 @@ int CEditor::PopupGroup(CEditor *pEditor, CUIRect View, void *pContext)
 	static int s_NewSoundLayerButton = 0;
 	if(pEditor->DoButton_Editor(&s_NewSoundLayerButton, "Add sound layer", 0, &Button, 0, "Creates a new sound layer"))
 	{
-		CLayerGroup *Group = pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup];
-		auto fnAddSoundLayer = [pEditor, Group]() {
+		int SelectedGroup = pEditor->m_SelectedGroup;
+		auto fnAddSoundLayer = [pEditor, SelectedGroup]() {
+			CLayerGroup *Group = pEditor->m_Map.m_vpGroups[SelectedGroup];
 			CLayer *pSoundLayer = new CLayerSounds;
 			pSoundLayer->m_pEditor = pEditor;
 			Group->AddLayer(pSoundLayer);
@@ -356,7 +364,7 @@ int CEditor::PopupGroup(CEditor *pEditor, CUIRect View, void *pContext)
 		};
 
 		fnAddSoundLayer();
-		pEditor->RecordUndoAction(new CEditorAddLayerAction(Group, Group->m_vpLayers.size() - 1, fnAddSoundLayer));
+		pEditor->RecordUndoAction(new CEditorAddLayerAction(SelectedGroup, pEditor->m_Map.m_vpGroups[SelectedGroup]->m_vpLayers.size() - 1, fnAddSoundLayer));
 
 		return 1;
 	}
@@ -481,13 +489,14 @@ int CEditor::PopupLayer(CEditor *pEditor, CUIRect View, void *pContext)
 		if(pEditor->DoButton_Editor(&s_DuplicationButton, "Duplicate layer", 0, &DupButton, 0, "Duplicates the layer"))
 		{
 			int SelectedLayer = pEditor->m_vSelectedLayers[0];
-			CLayerGroup *Group = pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup];
-			auto fnDupLayer = [pEditor, SelectedLayer, Group]() {
+			int SelectedGroup = pEditor->m_SelectedGroup;
+			auto fnDupLayer = [pEditor, SelectedLayer, SelectedGroup]() {
+				CLayerGroup *Group = pEditor->m_Map.m_vpGroups[SelectedGroup];
 				Group->DuplicateLayer(SelectedLayer);
 			};
 
 			fnDupLayer();
-			pEditor->RecordUndoAction(new CEditorAddLayerAction(Group, SelectedLayer + 1, fnDupLayer));
+			pEditor->RecordUndoAction(new CEditorAddLayerAction(pEditor->m_SelectedGroup, SelectedLayer + 1, fnDupLayer));
 
 			return 1;
 		}
@@ -497,7 +506,7 @@ int CEditor::PopupLayer(CEditor *pEditor, CUIRect View, void *pContext)
 	if(pEditor->m_Map.m_pGameLayer != pEditor->GetSelectedLayer(0) &&
 		pEditor->DoButton_Editor(&s_DeleteButton, "Delete layer", 0, &Button, 0, "Deletes the layer"))
 	{
-		pEditor->RecordUndoAction(new CEditorDeleteLayerAction(pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup], pEditor->m_vSelectedLayers[0]));
+		pEditor->RecordUndoAction(new CEditorDeleteLayerAction(pEditor, pEditor->m_SelectedGroup, pEditor->m_vSelectedLayers[0]));
 
 		if(pEditor->GetSelectedLayer(0) == pEditor->m_Map.m_pFrontLayer)
 			pEditor->m_Map.m_pFrontLayer = nullptr;

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -495,6 +495,8 @@ int CEditor::PopupLayer(CEditor *pEditor, CUIRect View, void *pContext)
 	if(pEditor->m_Map.m_pGameLayer != pEditor->GetSelectedLayer(0) &&
 		pEditor->DoButton_Editor(&s_DeleteButton, "Delete layer", 0, &Button, 0, "Deletes the layer"))
 	{
+		pEditor->RecordUndoAction(new CEditorDeleteLayerAction(pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup], pEditor->m_vSelectedLayers[0]));
+
 		if(pEditor->GetSelectedLayer(0) == pEditor->m_Map.m_pFrontLayer)
 			pEditor->m_Map.m_pFrontLayer = nullptr;
 		if(pEditor->GetSelectedLayer(0) == pEditor->m_Map.m_pTeleLayer)

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -184,11 +184,18 @@ int CEditor::PopupGroup(CEditor *pEditor, CUIRect View, void *pContext)
 		static int s_NewTeleLayerButton = 0;
 		if(pEditor->DoButton_Editor(&s_NewTeleLayerButton, "Add tele layer", 0, &Button, 0, "Creates a new tele layer"))
 		{
-			CLayer *pTeleLayer = new CLayerTele(pEditor->m_Map.m_pGameLayer->m_Width, pEditor->m_Map.m_pGameLayer->m_Height);
-			pEditor->m_Map.MakeTeleLayer(pTeleLayer);
-			pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->AddLayer(pTeleLayer);
-			pEditor->SelectLayer(pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_vpLayers.size() - 1);
-			pEditor->m_Brush.Clear();
+			CLayerGroup *Group = pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup];
+			auto fnAddTeleLayer = [pEditor, Group]() {
+				CLayer *pTeleLayer = new CLayerTele(pEditor->m_Map.m_pGameLayer->m_Width, pEditor->m_Map.m_pGameLayer->m_Height);
+				pEditor->m_Map.MakeTeleLayer(pTeleLayer);
+				Group->AddLayer(pTeleLayer);
+				pEditor->SelectLayer(Group->m_vpLayers.size() - 1);
+				pEditor->m_Brush.Clear();
+			};
+
+			fnAddTeleLayer();
+			pEditor->RecordUndoAction(new CEditorAddLayerAction(Group, Group->m_vpLayers.size() - 1, fnAddTeleLayer));
+
 			return 1;
 		}
 	}
@@ -201,11 +208,18 @@ int CEditor::PopupGroup(CEditor *pEditor, CUIRect View, void *pContext)
 		static int s_NewSpeedupLayerButton = 0;
 		if(pEditor->DoButton_Editor(&s_NewSpeedupLayerButton, "Add speedup layer", 0, &Button, 0, "Creates a new speedup layer"))
 		{
-			CLayer *pSpeedupLayer = new CLayerSpeedup(pEditor->m_Map.m_pGameLayer->m_Width, pEditor->m_Map.m_pGameLayer->m_Height);
-			pEditor->m_Map.MakeSpeedupLayer(pSpeedupLayer);
-			pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->AddLayer(pSpeedupLayer);
-			pEditor->SelectLayer(pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_vpLayers.size() - 1);
-			pEditor->m_Brush.Clear();
+			CLayerGroup *Group = pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup];
+			auto fnAddSpeedupLayer = [pEditor, Group]() {
+				CLayer *pSpeedupLayer = new CLayerSpeedup(pEditor->m_Map.m_pGameLayer->m_Width, pEditor->m_Map.m_pGameLayer->m_Height);
+				pEditor->m_Map.MakeSpeedupLayer(pSpeedupLayer);
+				Group->AddLayer(pSpeedupLayer);
+				pEditor->SelectLayer(Group->m_vpLayers.size() - 1);
+				pEditor->m_Brush.Clear();
+			};
+
+			fnAddSpeedupLayer();
+			pEditor->RecordUndoAction(new CEditorAddLayerAction(Group, Group->m_vpLayers.size() - 1, fnAddSpeedupLayer));
+
 			return 1;
 		}
 	}
@@ -218,11 +232,18 @@ int CEditor::PopupGroup(CEditor *pEditor, CUIRect View, void *pContext)
 		static int s_NewTuneLayerButton = 0;
 		if(pEditor->DoButton_Editor(&s_NewTuneLayerButton, "Add tune layer", 0, &Button, 0, "Creates a new tuning layer"))
 		{
-			CLayer *pTuneLayer = new CLayerTune(pEditor->m_Map.m_pGameLayer->m_Width, pEditor->m_Map.m_pGameLayer->m_Height);
-			pEditor->m_Map.MakeTuneLayer(pTuneLayer);
-			pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->AddLayer(pTuneLayer);
-			pEditor->SelectLayer(pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_vpLayers.size() - 1);
-			pEditor->m_Brush.Clear();
+			CLayerGroup *Group = pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup];
+			auto fnAddTuneLayer = [pEditor, Group]() {
+				CLayer *pTuneLayer = new CLayerTune(pEditor->m_Map.m_pGameLayer->m_Width, pEditor->m_Map.m_pGameLayer->m_Height);
+				pEditor->m_Map.MakeTuneLayer(pTuneLayer);
+				Group->AddLayer(pTuneLayer);
+				pEditor->SelectLayer(Group->m_vpLayers.size() - 1);
+				pEditor->m_Brush.Clear();
+			};
+
+			fnAddTuneLayer();
+			pEditor->RecordUndoAction(new CEditorAddLayerAction(Group, Group->m_vpLayers.size() - 1, fnAddTuneLayer));
+
 			return 1;
 		}
 	}
@@ -235,11 +256,18 @@ int CEditor::PopupGroup(CEditor *pEditor, CUIRect View, void *pContext)
 		static int s_NewFrontLayerButton = 0;
 		if(pEditor->DoButton_Editor(&s_NewFrontLayerButton, "Add front layer", 0, &Button, 0, "Creates a new item layer"))
 		{
-			CLayer *pFrontLayer = new CLayerFront(pEditor->m_Map.m_pGameLayer->m_Width, pEditor->m_Map.m_pGameLayer->m_Height);
-			pEditor->m_Map.MakeFrontLayer(pFrontLayer);
-			pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->AddLayer(pFrontLayer);
-			pEditor->SelectLayer(pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_vpLayers.size() - 1);
-			pEditor->m_Brush.Clear();
+			CLayerGroup *Group = pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup];
+			auto fnAddFrontLayer = [pEditor, Group]() {
+				CLayer *pFrontLayer = new CLayerFront(pEditor->m_Map.m_pGameLayer->m_Width, pEditor->m_Map.m_pGameLayer->m_Height);
+				pEditor->m_Map.MakeFrontLayer(pFrontLayer);
+				Group->AddLayer(pFrontLayer);
+				pEditor->SelectLayer(Group->m_vpLayers.size() - 1);
+				pEditor->m_Brush.Clear();
+			};
+
+			fnAddFrontLayer();
+			pEditor->RecordUndoAction(new CEditorAddLayerAction(Group, Group->m_vpLayers.size() - 1, fnAddFrontLayer));
+
 			return 1;
 		}
 	}
@@ -252,11 +280,18 @@ int CEditor::PopupGroup(CEditor *pEditor, CUIRect View, void *pContext)
 		static int s_NewSwitchLayerButton = 0;
 		if(pEditor->DoButton_Editor(&s_NewSwitchLayerButton, "Add switch layer", 0, &Button, 0, "Creates a new switch layer"))
 		{
-			CLayer *pSwitchLayer = new CLayerSwitch(pEditor->m_Map.m_pGameLayer->m_Width, pEditor->m_Map.m_pGameLayer->m_Height);
-			pEditor->m_Map.MakeSwitchLayer(pSwitchLayer);
-			pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->AddLayer(pSwitchLayer);
-			pEditor->SelectLayer(pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_vpLayers.size() - 1);
-			pEditor->m_Brush.Clear();
+			CLayerGroup *Group = pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup];
+			auto fnAddSwitchLayer = [pEditor, Group]() {
+				CLayer *pSwitchLayer = new CLayerSwitch(pEditor->m_Map.m_pGameLayer->m_Width, pEditor->m_Map.m_pGameLayer->m_Height);
+				pEditor->m_Map.MakeSwitchLayer(pSwitchLayer);
+				Group->AddLayer(pSwitchLayer);
+				pEditor->SelectLayer(Group->m_vpLayers.size() - 1);
+				pEditor->m_Brush.Clear();
+			};
+
+			fnAddSwitchLayer();
+			pEditor->RecordUndoAction(new CEditorAddLayerAction(Group, Group->m_vpLayers.size() - 1, fnAddSwitchLayer));
+
 			return 1;
 		}
 	}
@@ -267,11 +302,18 @@ int CEditor::PopupGroup(CEditor *pEditor, CUIRect View, void *pContext)
 	static int s_NewQuadLayerButton = 0;
 	if(pEditor->DoButton_Editor(&s_NewQuadLayerButton, "Add quads layer", 0, &Button, 0, "Creates a new quad layer"))
 	{
-		CLayer *pQuadLayer = new CLayerQuads;
-		pQuadLayer->m_pEditor = pEditor;
-		pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->AddLayer(pQuadLayer);
-		pEditor->SelectLayer(pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_vpLayers.size() - 1);
-		pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_Collapse = false;
+		CLayerGroup *Group = pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup];
+		auto fnAddQuadLayer = [pEditor, Group]() {
+			CLayer *pQuadLayer = new CLayerQuads;
+			pQuadLayer->m_pEditor = pEditor;
+			Group->AddLayer(pQuadLayer);
+			pEditor->SelectLayer(Group->m_vpLayers.size() - 1);
+			Group->m_Collapse = false;
+		};
+
+		fnAddQuadLayer();
+		pEditor->RecordUndoAction(new CEditorAddLayerAction(Group, Group->m_vpLayers.size() - 1, fnAddQuadLayer));
+
 		return 1;
 	}
 
@@ -281,11 +323,18 @@ int CEditor::PopupGroup(CEditor *pEditor, CUIRect View, void *pContext)
 	static int s_NewTileLayerButton = 0;
 	if(pEditor->DoButton_Editor(&s_NewTileLayerButton, "Add tile layer", 0, &Button, 0, "Creates a new tile layer"))
 	{
-		CLayer *pTileLayer = new CLayerTiles(pEditor->m_Map.m_pGameLayer->m_Width, pEditor->m_Map.m_pGameLayer->m_Height);
-		pTileLayer->m_pEditor = pEditor;
-		pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->AddLayer(pTileLayer);
-		pEditor->SelectLayer(pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_vpLayers.size() - 1);
-		pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_Collapse = false;
+		CLayerGroup *Group = pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup];
+		auto fnAddTileLayer = [pEditor, Group]() {
+			CLayer *pTileLayer = new CLayerTiles(pEditor->m_Map.m_pGameLayer->m_Width, pEditor->m_Map.m_pGameLayer->m_Height);
+			pTileLayer->m_pEditor = pEditor;
+			Group->AddLayer(pTileLayer);
+			pEditor->SelectLayer(Group->m_vpLayers.size() - 1);
+			Group->m_Collapse = false;
+		};
+
+		fnAddTileLayer();
+		pEditor->RecordUndoAction(new CEditorAddLayerAction(Group, Group->m_vpLayers.size() - 1, fnAddTileLayer));
+
 		return 1;
 	}
 
@@ -295,11 +344,18 @@ int CEditor::PopupGroup(CEditor *pEditor, CUIRect View, void *pContext)
 	static int s_NewSoundLayerButton = 0;
 	if(pEditor->DoButton_Editor(&s_NewSoundLayerButton, "Add sound layer", 0, &Button, 0, "Creates a new sound layer"))
 	{
-		CLayer *pSoundLayer = new CLayerSounds;
-		pSoundLayer->m_pEditor = pEditor;
-		pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->AddLayer(pSoundLayer);
-		pEditor->SelectLayer(pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_vpLayers.size() - 1);
-		pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_Collapse = false;
+		CLayerGroup *Group = pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup];
+		auto fnAddSoundLayer = [pEditor, Group]() {
+			CLayer *pSoundLayer = new CLayerSounds;
+			pSoundLayer->m_pEditor = pEditor;
+			Group->AddLayer(pSoundLayer);
+			pEditor->SelectLayer(Group->m_vpLayers.size() - 1);
+			Group->m_Collapse = false;
+		};
+
+		fnAddSoundLayer();
+		pEditor->RecordUndoAction(new CEditorAddLayerAction(Group, Group->m_vpLayers.size() - 1, fnAddSoundLayer));
+
 		return 1;
 	}
 
@@ -422,7 +478,15 @@ int CEditor::PopupLayer(CEditor *pEditor, CUIRect View, void *pContext)
 	{
 		if(pEditor->DoButton_Editor(&s_DuplicationButton, "Duplicate layer", 0, &DupButton, 0, "Duplicates the layer"))
 		{
-			pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->DuplicateLayer(pEditor->m_vSelectedLayers[0]);
+			int SelectedLayer = pEditor->m_vSelectedLayers[0];
+			CLayerGroup *Group = pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup];
+			auto fnDupLayer = [pEditor, SelectedLayer, Group]() {
+				Group->DuplicateLayer(SelectedLayer);
+			};
+
+			fnDupLayer();
+			pEditor->RecordUndoAction(new CEditorAddLayerAction(Group, SelectedLayer+1, fnDupLayer));
+
 			return 1;
 		}
 	}

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -987,10 +987,14 @@ int CEditor::PopupPoint(CEditor *pEditor, CUIRect View, void *pContext)
 			{
 				if(pEditor->m_SelectedPoints & (1 << v))
 				{
+					CColor PrevColor = pQuad->m_aColors[v];
 					pQuad->m_aColors[v].r = (NewVal >> 24) & 0xff;
 					pQuad->m_aColors[v].g = (NewVal >> 16) & 0xff;
 					pQuad->m_aColors[v].b = (NewVal >> 8) & 0xff;
 					pQuad->m_aColors[v].a = NewVal & 0xff;
+
+					if(!(PrevColor == pQuad->m_aColors[v]))
+						pEditor->RecordUndoAction(new CEditorChangeColorQuadAction(pQuad, v, PrevColor, pQuad->m_aColors[v]));
 				}
 			}
 		}

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -124,9 +124,10 @@ int CEditor::PopupGroup(CEditor *pEditor, CUIRect View, void *pContext)
 	CUIRect Button;
 	View.HSplitBottom(12.0f, &View, &Button);
 	static int s_DeleteButton = 0;
+	CLayerGroup *pGroup = pEditor->GetSelectedGroup();
 
 	// don't allow deletion of game group
-	if(pEditor->m_Map.m_pGameGroup != pEditor->GetSelectedGroup())
+	if(pEditor->m_Map.m_pGameGroup != pGroup)
 	{
 		if(pEditor->DoButton_Editor(&s_DeleteButton, "Delete group", 0, &Button, 0, "Delete group"))
 		{
@@ -178,7 +179,7 @@ int CEditor::PopupGroup(CEditor *pEditor, CUIRect View, void *pContext)
 		}
 	}
 
-	if(pEditor->GetSelectedGroup()->m_GameGroup && !pEditor->m_Map.m_pTeleLayer)
+	if(pGroup->m_GameGroup && !pEditor->m_Map.m_pTeleLayer)
 	{
 		// new tele layer
 		View.HSplitBottom(5.0f, &View, &Button);
@@ -203,7 +204,7 @@ int CEditor::PopupGroup(CEditor *pEditor, CUIRect View, void *pContext)
 		}
 	}
 
-	if(pEditor->GetSelectedGroup()->m_GameGroup && !pEditor->m_Map.m_pSpeedupLayer)
+	if(pGroup->m_GameGroup && !pEditor->m_Map.m_pSpeedupLayer)
 	{
 		// new speedup layer
 		View.HSplitBottom(5.0f, &View, &Button);
@@ -228,7 +229,7 @@ int CEditor::PopupGroup(CEditor *pEditor, CUIRect View, void *pContext)
 		}
 	}
 
-	if(pEditor->GetSelectedGroup()->m_GameGroup && !pEditor->m_Map.m_pTuneLayer)
+	if(pGroup->m_GameGroup && !pEditor->m_Map.m_pTuneLayer)
 	{
 		// new tune layer
 		View.HSplitBottom(5.0f, &View, &Button);
@@ -253,7 +254,7 @@ int CEditor::PopupGroup(CEditor *pEditor, CUIRect View, void *pContext)
 		}
 	}
 
-	if(pEditor->GetSelectedGroup()->m_GameGroup && !pEditor->m_Map.m_pFrontLayer)
+	if(pGroup->m_GameGroup && !pEditor->m_Map.m_pFrontLayer)
 	{
 		// new front layer
 		View.HSplitBottom(5.0f, &View, &Button);
@@ -278,7 +279,7 @@ int CEditor::PopupGroup(CEditor *pEditor, CUIRect View, void *pContext)
 		}
 	}
 
-	if(pEditor->GetSelectedGroup()->m_GameGroup && !pEditor->m_Map.m_pSwitchLayer)
+	if(pGroup->m_GameGroup && !pEditor->m_Map.m_pSwitchLayer)
 	{
 		// new Switch layer
 		View.HSplitBottom(5.0f, &View, &Button);
@@ -370,7 +371,7 @@ int CEditor::PopupGroup(CEditor *pEditor, CUIRect View, void *pContext)
 	}
 
 	// group name
-	if(!pEditor->GetSelectedGroup()->m_GameGroup)
+	if(!pGroup->m_GameGroup)
 	{
 		View.HSplitBottom(5.0f, &View, &Button);
 		View.HSplitBottom(12.0f, &View, &Button);
@@ -400,18 +401,18 @@ int CEditor::PopupGroup(CEditor *pEditor, CUIRect View, void *pContext)
 
 	CProperty aProps[] = {
 		{"Order", pEditor->m_SelectedGroup, PROPTYPE_INT_STEP, 0, (int)pEditor->m_Map.m_vpGroups.size() - 1},
-		{"Pos X", -pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_OffsetX, PROPTYPE_INT_SCROLL, -1000000, 1000000},
-		{"Pos Y", -pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_OffsetY, PROPTYPE_INT_SCROLL, -1000000, 1000000},
-		{"Para X", pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_ParallaxX, PROPTYPE_INT_SCROLL, -1000000, 1000000},
-		{"Para Y", pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_ParallaxY, PROPTYPE_INT_SCROLL, -1000000, 1000000},
-		{"Custom Zoom", pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_CustomParallaxZoom, PROPTYPE_BOOL, 0, 1},
-		{"Para Zoom", pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_ParallaxZoom, PROPTYPE_INT_SCROLL, -1000000, 1000000},
+		{"Pos X", -pGroup->m_OffsetX, PROPTYPE_INT_SCROLL, -1000000, 1000000},
+		{"Pos Y", -pGroup->m_OffsetY, PROPTYPE_INT_SCROLL, -1000000, 1000000},
+		{"Para X", pGroup->m_ParallaxX, PROPTYPE_INT_SCROLL, -1000000, 1000000},
+		{"Para Y", pGroup->m_ParallaxY, PROPTYPE_INT_SCROLL, -1000000, 1000000},
+		{"Custom Zoom", pGroup->m_CustomParallaxZoom, PROPTYPE_BOOL, 0, 1},
+		{"Para Zoom", pGroup->m_ParallaxZoom, PROPTYPE_INT_SCROLL, -1000000, 1000000},
 
-		{"Use Clipping", pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_UseClipping, PROPTYPE_BOOL, 0, 1},
-		{"Clip X", pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_ClipX, PROPTYPE_INT_SCROLL, -1000000, 1000000},
-		{"Clip Y", pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_ClipY, PROPTYPE_INT_SCROLL, -1000000, 1000000},
-		{"Clip W", pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_ClipW, PROPTYPE_INT_SCROLL, 0, 1000000},
-		{"Clip H", pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_ClipH, PROPTYPE_INT_SCROLL, 0, 1000000},
+		{"Use Clipping", pGroup->m_UseClipping, PROPTYPE_BOOL, 0, 1},
+		{"Clip X", pGroup->m_ClipX, PROPTYPE_INT_SCROLL, -1000000, 1000000},
+		{"Clip Y", pGroup->m_ClipY, PROPTYPE_INT_SCROLL, -1000000, 1000000},
+		{"Clip W", pGroup->m_ClipW, PROPTYPE_INT_SCROLL, 0, 1000000},
+		{"Clip H", pGroup->m_ClipH, PROPTYPE_INT_SCROLL, 0, 1000000},
 		{nullptr},
 	};
 
@@ -419,47 +420,127 @@ int CEditor::PopupGroup(CEditor *pEditor, CUIRect View, void *pContext)
 	int NewVal = 0;
 
 	// cut the properties that isn't needed
-	if(pEditor->GetSelectedGroup()->m_GameGroup)
+	if(pGroup->m_GameGroup)
 		aProps[PROP_POS_X].m_pName = nullptr;
 
-	int Prop = pEditor->DoProperties(&View, aProps, s_aIds, &NewVal);
+	PropState State;
+	int Prop = pEditor->DoProperties(&View, aProps, s_aIds, &NewVal, &State);
 	if(Prop != -1)
 		pEditor->m_Map.m_Modified = true;
 
+	static SEditGroupInfo s_OriginalGroupInfo;
+	SEditGroupInfo ModifiedGroupInfo;
+
+	bool Save = State == PropState::START;
+	bool Record = State == PropState::END;
+
 	if(Prop == PROP_ORDER)
+	{
+		if(Save)
+			s_OriginalGroupInfo.m_Order = pEditor->m_SelectedGroup;
+
 		pEditor->m_SelectedGroup = pEditor->m_Map.SwapGroups(pEditor->m_SelectedGroup, NewVal);
+		ModifiedGroupInfo.m_Order = pEditor->m_SelectedGroup;
+
+	}
+
+	if(Save)
+		s_OriginalGroupInfo.m_Modified = 1 << Prop;
+	ModifiedGroupInfo.m_Modified = 1 << Prop;
 
 	// these can not be changed on the game group
-	if(!pEditor->GetSelectedGroup()->m_GameGroup)
+	if(!pGroup->m_GameGroup)
 	{
 		if(Prop == PROP_PARA_X)
-			pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_ParallaxX = NewVal;
+		{
+			if(Save)
+				s_OriginalGroupInfo.m_ParallaxX = pGroup->m_ParallaxX;
+			pGroup->m_ParallaxX = NewVal;
+			ModifiedGroupInfo.m_ParallaxX = pGroup->m_ParallaxX;
+		}
 		else if(Prop == PROP_PARA_Y)
-			pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_ParallaxY = NewVal;
+		{
+			if(Save)
+				s_OriginalGroupInfo.m_ParallaxY = pGroup->m_ParallaxY;
+			pGroup->m_ParallaxY = NewVal;
+			ModifiedGroupInfo.m_ParallaxY = pGroup->m_ParallaxY;
+		}
 		else if(Prop == PROP_CUSTOM_ZOOM)
-			pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_CustomParallaxZoom = NewVal;
+		{
+			if(Save)
+				s_OriginalGroupInfo.m_CustomParallaxZoom = pGroup->m_CustomParallaxZoom;
+			pGroup->m_CustomParallaxZoom = NewVal;
+			ModifiedGroupInfo.m_CustomParallaxZoom = pGroup->m_CustomParallaxZoom;
+		}
 		else if(Prop == PROP_PARA_ZOOM)
 		{
-			pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_CustomParallaxZoom = 1;
-			pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_ParallaxZoom = NewVal;
+			if(Save)
+			{
+				s_OriginalGroupInfo.m_CustomParallaxZoom = pGroup->m_CustomParallaxZoom;
+				s_OriginalGroupInfo.m_ParallaxZoom = pGroup->m_ParallaxZoom;
+			}
+			pGroup->m_CustomParallaxZoom = 1;
+			pGroup->m_ParallaxZoom = NewVal;
+
+			ModifiedGroupInfo.m_CustomParallaxZoom = pGroup->m_CustomParallaxZoom;
+			ModifiedGroupInfo.m_ParallaxZoom = pGroup->m_ParallaxZoom;
 		}
 		else if(Prop == PROP_POS_X)
-			pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_OffsetX = -NewVal;
+		{
+			if(Save)
+				s_OriginalGroupInfo.m_OffsetX = pGroup->m_OffsetX;
+			pGroup->m_OffsetX = -NewVal;
+			ModifiedGroupInfo.m_OffsetX = pGroup->m_OffsetX;
+		}
 		else if(Prop == PROP_POS_Y)
-			pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_OffsetY = -NewVal;
+		{
+			if(Save)
+				s_OriginalGroupInfo.m_OffsetY = pGroup->m_OffsetY;
+			pGroup->m_OffsetY = -NewVal;
+			ModifiedGroupInfo.m_OffsetY = pGroup->m_OffsetY;
+		}
 		else if(Prop == PROP_USE_CLIPPING)
-			pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_UseClipping = NewVal;
+		{
+			if(Save)
+				s_OriginalGroupInfo.m_UseClipping = pGroup->m_UseClipping;
+			pGroup->m_UseClipping = NewVal;
+			ModifiedGroupInfo.m_UseClipping = pGroup->m_UseClipping;
+		}
 		else if(Prop == PROP_CLIP_X)
-			pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_ClipX = NewVal;
+		{
+			if(Save)
+				s_OriginalGroupInfo.m_ClipX = pGroup->m_ClipX;
+			pGroup->m_ClipX = NewVal;
+			ModifiedGroupInfo.m_ClipX = pGroup->m_ClipX;
+		}
 		else if(Prop == PROP_CLIP_Y)
-			pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_ClipY = NewVal;
+		{
+			if(Save)
+				s_OriginalGroupInfo.m_ClipX = pGroup->m_ClipY;
+			pGroup->m_ClipY = NewVal;
+			ModifiedGroupInfo.m_ClipY = pGroup->m_ClipY;
+		}
 		else if(Prop == PROP_CLIP_W)
-			pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_ClipW = NewVal;
+		{
+			if(Save)
+				s_OriginalGroupInfo.m_ClipX = pGroup->m_ClipW;
+			pGroup->m_ClipW = NewVal;
+			ModifiedGroupInfo.m_ClipW = pGroup->m_ClipW;
+		}
 		else if(Prop == PROP_CLIP_H)
-			pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_ClipH = NewVal;
+		{
+			if(Save)
+				s_OriginalGroupInfo.m_ClipX = pGroup->m_ClipH;
+			pGroup->m_ClipH = NewVal;
+			ModifiedGroupInfo.m_ClipH = pGroup->m_ClipH;
+		}
 
-		pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->OnEdited();
+		pGroup->OnEdited();
+
 	}
+
+	if(Prop != -1 && Record)
+		pEditor->m_EditorHistory.RecordUndoAction(new CEditorEditGroupProperty(pEditor->m_SelectedGroup, s_OriginalGroupInfo, ModifiedGroupInfo));
 
 	return 0;
 }

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -487,7 +487,7 @@ int CEditor::PopupLayer(CEditor *pEditor, CUIRect View, void *pContext)
 			};
 
 			fnDupLayer();
-			pEditor->RecordUndoAction(new CEditorAddLayerAction(Group, SelectedLayer+1, fnDupLayer));
+			pEditor->RecordUndoAction(new CEditorAddLayerAction(Group, SelectedLayer + 1, fnDupLayer));
 
 			return 1;
 		}


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request -->

Suggested by Pulsar yet again, I think this feature could be highly useful for a lot of mappers, so I'm trying to implement a functional history system. I'm planing to make most of the actions that can be done inside the editor as reversible. This includes:
- add/remove layer
- add/remove group
- ~~rename layer/group~~
- change tile (placing, removing)
- edit quad (color, position, center, rotation)
- edit layer properties (group, color, position, ...)
- edit group properties (order, para x/y, ...)
- enveloppes
	- name
	- points (value, time)
	- checkbox "Synchronized"
	- all editboxes
	- undo delete (if possible)
- commands
	- adding
	- deleting
	- editing
- ~~add image (if possible)~~
- ~~add sound (if possible)~~
- change order of layer/group
- change orientation value (editbox)

Pulsar also suggested to make a popup to warn users about some actions that cannot be undone. For example if a user wants to automap a layer, there will first be a popup with a warning text "Warning, this action cannot be reversed.". There will be an "OK" button but also a checkbox to not show the popup next time. There will also be a client command to disable the popups.

Right now, two buttons, "Undo" and "Redo" have been added in the toolbar, with shortcuts (respectively ctrl+z and ctrl+y). I also started working on some actions to undo which are changing color of a tile layer and a quad vertex.

![image](https://user-images.githubusercontent.com/13364635/186896173-66bf5692-d3a9-4f7e-9a15-fa6e624d2165.png)

The current limit of the history is 50 actions. This will probably be configurable through a command.

There is still a lot to be done and this is still a work in progress. If you have some ideas to add to this or some suggestion on what else can be undone, or if you think some things don't have to be reversed, please let me know. Also, please keep in mind that the code might change a lot and that the first commits might not be the better ones.

## Todo

- [x] Add "Undo" and "Redo" buttons with shortcuts
- [x] Undo: "add/remove layer"
- [x] Undo: "add/remove group"
- [x] Undo: "change tile (placing, removing)"
- [x] Undo: "edit quad"
	- [x] color
	- [x] position
	- [x] pivot
	- [x] rotation
	- [x] square, align & aspect ratio operations
	- [x] points properties (uv, position, ...)
- [ ] Undo: "edit layer properties"
	- [ ] group
	- [ ] order
	- [x] color
	- [ ] width/height
	- [ ] image
	- [ ] color env
	- [ ] color to
- [x] Undo: "edit group properties"
	- [x] order
	- [x] pos X/pos Y
	- [x] para X/para Y
	- [x] clip X/clip Y/clip W/clip H
- [ ] Undo: "edit enveloppes"
	- [ ] name
	- [ ] points (value, time)
	- [ ] checkbox "Synchronized"
	- [ ] all editboxes
	- [ ] undo delete (if possible)
- [x] Undo: "edit commands"
	- [x] adding
	- [x] deleting
	- [x] editing
	- [x] moving
- [ ] Undo: "change orientation value (editbox)"

## Checklist
- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
