### PR TITLE
Add period/comma hotkeys to skip one tick forward/backward, various other improvements to demo skipping

### DIFF
--- a/src/engine/shared/demo.cpp
+++ b/src/engine/shared/demo.cpp
@@ -885,7 +885,7 @@ bool CDemoPlayer::ExtractMap(class IStorage *pStorage)
 	return true;
 }
 
-int64_t CDemoPlayer::time()
+int64_t CDemoPlayer::Time()
 {
 #if defined(CONF_VIDEORECORDER)
 	static bool s_Recording = false;
@@ -921,7 +921,7 @@ int CDemoPlayer::Play()
 
 	// set start info
 	m_Info.m_CurrentTime = m_Info.m_PreviousTick * time_freq() / SERVER_TICK_SPEED;
-	m_Info.m_LastUpdate = time();
+	m_Info.m_LastUpdate = Time();
 	return 0;
 }
 
@@ -985,7 +985,7 @@ void CDemoPlayer::SetSpeedIndex(int Offset)
 
 int CDemoPlayer::Update(bool RealTime)
 {
-	int64_t Now = time();
+	int64_t Now = Time();
 	int64_t Deltatime = Now - m_Info.m_LastUpdate;
 	m_Info.m_LastUpdate = Now;
 

--- a/src/engine/shared/demo.cpp
+++ b/src/engine/shared/demo.cpp
@@ -989,15 +989,12 @@ int CDemoPlayer::Update(bool RealTime)
 	if(!IsPlaying())
 		return 0;
 
-	if(m_Info.m_Info.m_Paused)
+	const int64_t Freq = time_freq();
+	if(!m_Info.m_Info.m_Paused)
 	{
-	}
-	else
-	{
-		int64_t Freq = time_freq();
 		m_Info.m_CurrentTime += (int64_t)(Deltatime * (double)m_Info.m_Info.m_Speed);
 
-		while(true)
+		while(!m_Info.m_Info.m_Paused)
 		{
 			int64_t CurtickStart = (m_Info.m_Info.m_CurrentTick) * Freq / SERVER_TICK_SPEED;
 
@@ -1007,34 +1004,31 @@ int CDemoPlayer::Update(bool RealTime)
 
 			// do one more tick
 			DoTick();
-
-			if(m_Info.m_Info.m_Paused)
-				return 0;
-		}
-
-		// update intratick
-		{
-			int64_t CurtickStart = (m_Info.m_Info.m_CurrentTick) * Freq / SERVER_TICK_SPEED;
-			int64_t PrevtickStart = (m_Info.m_PreviousTick) * Freq / SERVER_TICK_SPEED;
-			m_Info.m_IntraTick = (m_Info.m_CurrentTime - PrevtickStart) / (float)(CurtickStart - PrevtickStart);
-			m_Info.m_IntraTickSincePrev = (m_Info.m_CurrentTime - PrevtickStart) / (float)(Freq / SERVER_TICK_SPEED);
-			m_Info.m_TickTime = (m_Info.m_CurrentTime - PrevtickStart) / (float)Freq;
-			if(m_UpdateIntraTimesFunc)
-				m_UpdateIntraTimesFunc();
-		}
-
-		if(m_Info.m_Info.m_CurrentTick == m_Info.m_PreviousTick ||
-			m_Info.m_Info.m_CurrentTick == m_Info.m_NextTick)
-		{
-			if(m_pConsole)
-			{
-				char aBuf[256];
-				str_format(aBuf, sizeof(aBuf), "tick error prev=%d cur=%d next=%d",
-					m_Info.m_PreviousTick, m_Info.m_Info.m_CurrentTick, m_Info.m_NextTick);
-				m_pConsole->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "demo_player", aBuf);
-			}
 		}
 	}
+
+	// update intratick
+	{
+		int64_t CurtickStart = (m_Info.m_Info.m_CurrentTick) * Freq / SERVER_TICK_SPEED;
+		int64_t PrevtickStart = (m_Info.m_PreviousTick) * Freq / SERVER_TICK_SPEED;
+		m_Info.m_IntraTick = (m_Info.m_CurrentTime - PrevtickStart) / (float)(CurtickStart - PrevtickStart);
+		m_Info.m_IntraTickSincePrev = (m_Info.m_CurrentTime - PrevtickStart) / (float)(Freq / SERVER_TICK_SPEED);
+		m_Info.m_TickTime = (m_Info.m_CurrentTime - PrevtickStart) / (float)Freq;
+		if(m_UpdateIntraTimesFunc)
+			m_UpdateIntraTimesFunc();
+	}
+
+	if(m_Info.m_Info.m_CurrentTick == m_Info.m_PreviousTick || m_Info.m_Info.m_CurrentTick == m_Info.m_NextTick)
+	{
+		if(m_pConsole)
+		{
+			char aBuf[256];
+			str_format(aBuf, sizeof(aBuf), "tick error prev=%d cur=%d next=%d",
+				m_Info.m_PreviousTick, m_Info.m_Info.m_CurrentTick, m_Info.m_NextTick);
+			m_pConsole->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "demo_player", aBuf);
+		}
+	}
+
 	return 0;
 }
 

--- a/src/engine/shared/demo.cpp
+++ b/src/engine/shared/demo.cpp
@@ -885,12 +885,6 @@ bool CDemoPlayer::ExtractMap(class IStorage *pStorage)
 	return true;
 }
 
-int CDemoPlayer::NextFrame()
-{
-	DoTick();
-	return IsPlaying();
-}
-
 int64_t CDemoPlayer::time()
 {
 #if defined(CONF_VIDEORECORDER)

--- a/src/engine/shared/demo.h
+++ b/src/engine/shared/demo.h
@@ -118,7 +118,7 @@ private:
 	void DoTick();
 	void ScanFile();
 
-	int64_t time();
+	int64_t Time();
 
 public:
 	CDemoPlayer(class CSnapshotDelta *pSnapshotDelta);

--- a/src/engine/shared/demo.h
+++ b/src/engine/shared/demo.h
@@ -117,7 +117,6 @@ private:
 	int ReadChunkHeader(int *pType, int *pSize, int *pTick);
 	void DoTick();
 	void ScanFile();
-	int NextFrame();
 
 	int64_t time();
 

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -339,14 +339,14 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 				UI()->SetActiveItem(nullptr);
 			else
 			{
-				static float PrevAmount = 0.0f;
+				static float s_PrevAmount = 0.0f;
 				float AmountSeek = (UI()->MouseX() - SeekBar.x) / SeekBar.w;
 
 				if(Input()->KeyIsPressed(KEY_LSHIFT) || Input()->KeyIsPressed(KEY_RSHIFT))
 				{
-					AmountSeek = PrevAmount + (AmountSeek - PrevAmount) * 0.05f;
+					AmountSeek = s_PrevAmount + (AmountSeek - s_PrevAmount) * 0.05f;
 
-					if(AmountSeek > 0.0f && AmountSeek < 1.0f && absolute(PrevAmount - AmountSeek) >= 0.0001f)
+					if(AmountSeek > 0.0f && AmountSeek < 1.0f && absolute(s_PrevAmount - AmountSeek) >= 0.0001f)
 					{
 						m_pClient->m_SuppressEvents = true;
 						DemoPlayer()->SeekPercent(AmountSeek);
@@ -357,9 +357,9 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 				}
 				else
 				{
-					if(AmountSeek > 0.0f && AmountSeek < 1.0f && absolute(PrevAmount - AmountSeek) >= 0.001f)
+					if(AmountSeek > 0.0f && AmountSeek < 1.0f && absolute(s_PrevAmount - AmountSeek) >= 0.001f)
 					{
-						PrevAmount = AmountSeek;
+						s_PrevAmount = AmountSeek;
 						m_pClient->m_SuppressEvents = true;
 						DemoPlayer()->SeekPercent(AmountSeek);
 						m_pClient->m_SuppressEvents = false;

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -235,6 +235,17 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 		{
 			DemoPlayer()->SeekPercent(1.0f);
 		}
+
+		// Advance single frame forward/backward with period/comma key
+		const bool TickForwards = Input()->KeyPress(KEY_PERIOD);
+		const bool TickBackwards = Input()->KeyPress(KEY_COMMA);
+		if(TickForwards || TickBackwards)
+		{
+			m_pClient->m_SuppressEvents = true;
+			DemoPlayer()->SetPos(pInfo->m_CurrentTick + (TickForwards ? 3 : 0));
+			m_pClient->m_SuppressEvents = false;
+			DemoPlayer()->Pause();
+		}
 	}
 
 	float TotalHeight = SeekBarHeight + ButtonbarHeight + NameBarHeight + Margins * 3;

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -75,7 +75,7 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 	const float ButtonbarHeight = 20.0f;
 	const float NameBarHeight = 20.0f;
 	const float Margins = 5.0f;
-	static int64_t LastSpeedChange = 0;
+	static int64_t s_LastSpeedChange = 0;
 
 	// render popups
 	if(m_DemoPlayerState == DEMOPLAYER_SLICE_SAVE)
@@ -175,12 +175,12 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 			if(Input()->KeyPress(KEY_MOUSE_WHEEL_UP) || Input()->KeyPress(KEY_UP))
 			{
 				DemoPlayer()->SetSpeedIndex(+1);
-				LastSpeedChange = time_get();
+				s_LastSpeedChange = time_get();
 			}
 			else if(Input()->KeyPress(KEY_MOUSE_WHEEL_DOWN) || Input()->KeyPress(KEY_DOWN))
 			{
 				DemoPlayer()->SetSpeedIndex(-1);
-				LastSpeedChange = time_get();
+				s_LastSpeedChange = time_get();
 			}
 		}
 
@@ -240,7 +240,7 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 	float TotalHeight = SeekBarHeight + ButtonbarHeight + NameBarHeight + Margins * 3;
 
 	// render speed info
-	if(g_Config.m_ClDemoShowSpeed && time_get() - LastSpeedChange < time_freq() * 1)
+	if(g_Config.m_ClDemoShowSpeed && time_get() - s_LastSpeedChange < time_freq() * 1)
 	{
 		CUIRect Screen = *UI()->Screen();
 
@@ -493,12 +493,12 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 	if(IncreaseDemoSpeed)
 	{
 		DemoPlayer()->SetSpeedIndex(+1);
-		LastSpeedChange = time_get();
+		s_LastSpeedChange = time_get();
 	}
 	else if(DecreaseDemoSpeed)
 	{
 		DemoPlayer()->SetSpeedIndex(-1);
-		LastSpeedChange = time_get();
+		s_LastSpeedChange = time_get();
 	}
 }
 


### PR DESCRIPTION
Mostly from upstream https://github.com/teeworlds/teeworlds/pull/2904, with some more fixes and refactorings.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
