### PR TITLE
Fix demo seeking and automatic demo rewind not working while the menu is not active

### DIFF
--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -497,6 +497,7 @@ protected:
 	static bool DemoFilterChat(const void *pData, int Size, void *pUser);
 	bool FetchHeader(CDemoItem &Item);
 	void FetchAllHeaders();
+	void HandleDemoSeeking(float PositionToSeek, float TimeToSeek);
 	void RenderDemoPlayer(CUIRect MainView);
 	void RenderDemoList(CUIRect MainView);
 

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -79,6 +79,21 @@ bool CMenus::DemoFilterChat(const void *pData, int Size, void *pUser)
 	return !Unpacker.Error() && !Sys && Msg == NETMSGTYPE_SV_CHAT;
 }
 
+void CMenus::HandleDemoSeeking(float PositionToSeek, float TimeToSeek)
+{
+	if((PositionToSeek >= 0.0f && PositionToSeek <= 1.0f) || TimeToSeek != 0.0f)
+	{
+		m_pClient->m_SuppressEvents = true;
+		if(TimeToSeek != 0.0f)
+			DemoPlayer()->SeekTime(TimeToSeek);
+		else
+			DemoPlayer()->SeekPercent(PositionToSeek);
+		m_pClient->m_SuppressEvents = false;
+		m_pClient->m_MapLayersBackGround.EnvelopeUpdate();
+		m_pClient->m_MapLayersForeGround.EnvelopeUpdate();
+	}
+}
+
 void CMenus::RenderDemoPlayer(CUIRect MainView)
 {
 	const IDemoPlayer::CInfo *pInfo = DemoPlayer()->BaseInfo();
@@ -277,7 +292,10 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 	}
 
 	if(!m_MenuActive)
+	{
+		HandleDemoSeeking(PositionToSeek, TimeToSeek);
 		return;
+	}
 
 	MainView.HSplitBottom(TotalHeight, 0, &MainView);
 	MainView.VSplitLeft(50.0f, 0, &MainView);
@@ -526,17 +544,7 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 		s_LastSpeedChange = time_get();
 	}
 
-	if((PositionToSeek >= 0.0f && PositionToSeek <= 1.0f) || TimeToSeek != 0.0f)
-	{
-		m_pClient->m_SuppressEvents = true;
-		if(TimeToSeek != 0.0f)
-			DemoPlayer()->SeekTime(TimeToSeek);
-		else
-			DemoPlayer()->SeekPercent(PositionToSeek);
-		m_pClient->m_SuppressEvents = false;
-		m_pClient->m_MapLayersBackGround.EnvelopeUpdate();
-		m_pClient->m_MapLayersForeGround.EnvelopeUpdate();
-	}
+	HandleDemoSeeking(PositionToSeek, TimeToSeek);
 }
 
 static CUIRect gs_ListBoxOriginalView;

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -291,6 +291,15 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 		TextRender()->Text(0, 120.0f, Screen.y + Screen.h - 120.0f - TotalHeight, 60.0f, aSpeedBuf, -1.0f);
 	}
 
+	const int CurrentTick = pInfo->m_CurrentTick - pInfo->m_FirstTick;
+	const int TotalTicks = pInfo->m_LastTick - pInfo->m_FirstTick;
+
+	if(CurrentTick == TotalTicks)
+	{
+		DemoPlayer()->Pause();
+		PositionToSeek = 0.0f;
+	}
+
 	if(!m_MenuActive)
 	{
 		HandleDemoSeeking(PositionToSeek, TimeToSeek);
@@ -306,9 +315,6 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 	MainView.Margin(5.0f, &MainView);
 
 	CUIRect SeekBar, ButtonBar, NameBar;
-
-	int CurrentTick = pInfo->m_CurrentTick - pInfo->m_FirstTick;
-	int TotalTicks = pInfo->m_LastTick - pInfo->m_FirstTick;
 
 	MainView.HSplitTop(SeekBarHeight, &SeekBar, &ButtonBar);
 	ButtonBar.HSplitTop(Margins, 0, &ButtonBar);
@@ -413,12 +419,6 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 
 		if(Inside)
 			UI()->SetHotItem(pId);
-	}
-
-	if(CurrentTick == TotalTicks)
-	{
-		DemoPlayer()->Pause();
-		PositionToSeek = 0.0f;
 	}
 
 	bool IncreaseDemoSpeed = false, DecreaseDemoSpeed = false;


### PR DESCRIPTION
Demo seeking was broken when the menu is not active due to a regression from #5777, as the ddnet demo is structured differently than upstream (early return when the menu is not active).

The automatic demo rewinding when a demo reaches its end was already broken before, due to this different structure.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
