### PR TITLE
Suppress more events while skipping in demos, reset specifics components before long skips in demo

### DIFF
--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -564,6 +564,9 @@ void CChat::DisableMode()
 
 void CChat::OnMessage(int MsgType, void *pRawMsg)
 {
+	if(m_pClient->m_SuppressEvents)
+		return;
+
 	if(MsgType == NETMSGTYPE_SV_CHAT)
 	{
 		CNetMsg_Sv_Chat *pMsg = (CNetMsg_Sv_Chat *)pRawMsg;

--- a/src/game/client/components/chat.h
+++ b/src/game/client/components/chat.h
@@ -133,7 +133,6 @@ class CChat : public CComponent
 
 	bool LineShouldHighlight(const char *pLine, const char *pName);
 	void StoreSave(const char *pText);
-	void Reset();
 
 public:
 	CChat();
@@ -162,6 +161,7 @@ public:
 	void OnRender() override;
 	void RefindSkins();
 	void OnPrepareLines();
+	void Reset();
 	void OnRelease() override;
 	void OnMessage(int MsgType, void *pRawMsg) override;
 	bool OnInput(IInput::CEvent Event) override;

--- a/src/game/client/components/killmessages.cpp
+++ b/src/game/client/components/killmessages.cpp
@@ -100,6 +100,9 @@ void CKillMessages::CreateKillmessageNamesIfNotCreated(CKillMsg &Kill)
 
 void CKillMessages::OnMessage(int MsgType, void *pRawMsg)
 {
+	if(m_pClient->m_SuppressEvents)
+		return;
+
 	if(MsgType == NETMSGTYPE_SV_KILLMSG)
 	{
 		CNetMsg_Sv_KillMsg *pMsg = (CNetMsg_Sv_KillMsg *)pRawMsg;

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -83,6 +83,12 @@ void CMenus::HandleDemoSeeking(float PositionToSeek, float TimeToSeek)
 {
 	if((PositionToSeek >= 0.0f && PositionToSeek <= 1.0f) || TimeToSeek != 0.0f)
 	{
+		m_pClient->m_Chat.Reset();
+		m_pClient->m_KillMessages.OnReset();
+		m_pClient->m_Particles.OnReset();
+		m_pClient->m_Sounds.OnReset();
+		m_pClient->m_Scoreboard.OnReset();
+		m_pClient->m_Statboard.OnReset();
 		m_pClient->m_SuppressEvents = true;
 		if(TimeToSeek != 0.0f)
 			DemoPlayer()->SeekTime(TimeToSeek);

--- a/src/game/client/components/sounds.cpp
+++ b/src/game/client/components/sounds.cpp
@@ -176,15 +176,15 @@ void CSounds::ClearQueue()
 
 void CSounds::Enqueue(int Channel, int SetId)
 {
-	// add sound to the queue
-	if(m_QueuePos < QUEUE_SIZE)
-	{
-		if(Channel == CHN_MUSIC || !g_Config.m_ClEditor)
-		{
-			m_aQueue[m_QueuePos].m_Channel = Channel;
-			m_aQueue[m_QueuePos++].m_SetId = SetId;
-		}
-	}
+	if(m_pClient->m_SuppressEvents)
+		return;
+	if(m_QueuePos >= QUEUE_SIZE)
+		return;
+	if(Channel != CHN_MUSIC && g_Config.m_ClEditor)
+		return;
+
+	m_aQueue[m_QueuePos].m_Channel = Channel;
+	m_aQueue[m_QueuePos++].m_SetId = SetId;
 }
 
 void CSounds::PlayAndRecord(int Channel, int SetId, float Vol, vec2 Pos)
@@ -198,6 +198,8 @@ void CSounds::PlayAndRecord(int Channel, int SetId, float Vol, vec2 Pos)
 
 void CSounds::Play(int Channel, int SetId, float Vol)
 {
+	if(m_pClient->m_SuppressEvents)
+		return;
 	if(Channel == CHN_MUSIC && !g_Config.m_SndMusic)
 		return;
 
@@ -214,6 +216,8 @@ void CSounds::Play(int Channel, int SetId, float Vol)
 
 void CSounds::PlayAt(int Channel, int SetId, float Vol, vec2 Pos)
 {
+	if(m_pClient->m_SuppressEvents)
+		return;
 	if(Channel == CHN_MUSIC && !g_Config.m_SndMusic)
 		return;
 

--- a/src/game/client/components/statboard.cpp
+++ b/src/game/client/components/statboard.cpp
@@ -48,6 +48,9 @@ bool CStatboard::IsActive()
 
 void CStatboard::OnMessage(int MsgType, void *pRawMsg)
 {
+	if(m_pClient->m_SuppressEvents)
+		return;
+
 	if(MsgType == NETMSGTYPE_SV_KILLMSG)
 	{
 		CNetMsg_Sv_KillMsg *pMsg = (CNetMsg_Sv_KillMsg *)pRawMsg;

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1843,10 +1843,10 @@ void CGameClient::OnPredict()
 			m_NewPredictedTick = true;
 			vec2 Pos = pLocalChar->Core()->m_Pos;
 			int Events = pLocalChar->Core()->m_TriggeredEvents;
-			if(g_Config.m_ClPredict)
+			if(g_Config.m_ClPredict && !m_SuppressEvents)
 				if(Events & COREEVENT_AIR_JUMP)
 					m_Effects.AirJump(Pos);
-			if(g_Config.m_SndGame)
+			if(g_Config.m_SndGame && !m_SuppressEvents)
 			{
 				if(Events & COREEVENT_GROUND_JUMP)
 					m_Sounds.PlayAndRecord(CSounds::CHN_WORLD, SOUND_PLAYER_JUMP, 1.0f, Pos);
@@ -1863,7 +1863,7 @@ void CGameClient::OnPredict()
 			m_aLastNewPredictedTick[!Dummy] = Tick;
 			vec2 Pos = pDummyChar->Core()->m_Pos;
 			int Events = pDummyChar->Core()->m_TriggeredEvents;
-			if(g_Config.m_ClPredict)
+			if(g_Config.m_ClPredict && !m_SuppressEvents)
 				if(Events & COREEVENT_AIR_JUMP)
 					m_Effects.AirJump(Pos);
 		}


### PR DESCRIPTION
Closes #5779.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
