### PR TITLE
Remove all references to memset

### DIFF
--- a/src/engine/client/keynames.h
+++ b/src/engine/client/keynames.h
@@ -4,8 +4,6 @@
 #error do not include this header!
 #endif
 
-#include <string.h>
-
 const char g_aaKeyStrings[512][20] = // NOLINT(misc-definitions-in-headers)
 {
 	"unknown",

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -542,7 +542,7 @@ int CServer::Init()
 	m_CurrentGameTick = 0;
 
 	m_AnnouncementLastLine = 0;
-	memset(m_aPrevStates, CClient::STATE_EMPTY, MAX_CLIENTS * sizeof(int));
+	mem_zero(m_aPrevStates, sizeof(m_aPrevStates));
 
 	return 0;
 }

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -8,7 +8,6 @@
 #include <antibot/antibot_data.h>
 #include <base/logger.h>
 #include <base/math.h>
-#include <cstring>
 #include <engine/console.h>
 #include <engine/engine.h>
 #include <engine/map.h>
@@ -1782,7 +1781,10 @@ void CGameContext::CensorMessage(char *pCensoredMessage, const char *pMessage, i
 			pCurLoc = (char *)str_utf8_find_nocase(pCurLoc, Item.c_str());
 			if(pCurLoc)
 			{
-				memset(pCurLoc, '*', Item.length());
+				for(int i = 0; i < (int)Item.length(); i++)
+				{
+					pCurLoc[i] = '*';
+				}
 				pCurLoc++;
 			}
 		} while(pCurLoc);

--- a/src/tools/map_create_pixelart.cpp
+++ b/src/tools/map_create_pixelart.cpp
@@ -6,8 +6,6 @@
 #include <engine/storage.h>
 #include <game/mapitems.h>
 
-#include <cstring>
-
 bool CreatePixelArt(const char[][64], const int[], const int[], int[], const bool[]);
 void InsertCurrentQuads(CDataFileReader &, CMapItemLayerQuads *, CQuad *);
 int InsertPixelArtQuads(CQuad *, int &, const CImageInfo &, const int[], const int[], const bool[]);
@@ -217,7 +215,10 @@ bool GetPixelClamped(const CImageInfo &Img, int x, int y, uint8_t aPixel[4])
 {
 	x = clamp<int>(x, 0, (int)Img.m_Width - 1);
 	y = clamp<int>(y, 0, (int)Img.m_Height - 1);
-	memset(aPixel, 255, sizeof(uint8_t[4]));
+	aPixel[0] = 255;
+	aPixel[1] = 255;
+	aPixel[2] = 255;
+	aPixel[3] = 255;
 
 	int BPP = Img.m_Format == CImageInfo::FORMAT_RGB ? 3 : 4;
 	for(int i = 0; i < BPP; i++)


### PR DESCRIPTION
`memset` only worked with `CServer::CClient::STATE_EMPTY` by chance
because it is defined as 0.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
