### PR TITLE
Revert "Allow multiple connect addresses" (fixes #5792)

### DIFF
--- a/src/engine/client.h
+++ b/src/engine/client.h
@@ -187,8 +187,7 @@ public:
 	virtual void EnterGame(int Conn) = 0;
 
 	//
-	virtual const NETADDR &ServerAddress() const = 0;
-	virtual int ConnectNetTypes() const = 0;
+	virtual NETADDR ServerAddress() const = 0;
 	virtual const char *ConnectAddressString() const = 0;
 	virtual const char *MapDownloadName() const = 0;
 	virtual int MapDownloadAmount() const = 0;

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -645,8 +645,8 @@ void CClient::SetState(EClientState s)
 
 		if(s == IClient::STATE_ONLINE)
 		{
-			Discord()->SetGameInfo(ServerAddress(), m_aCurrentMap);
-			Steam()->SetGameInfo(ServerAddress(), m_aCurrentMap);
+			Discord()->SetGameInfo(m_ServerAddress, m_aCurrentMap);
+			Steam()->SetGameInfo(m_ServerAddress, m_aCurrentMap);
 		}
 		else if(Old == IClient::STATE_ONLINE)
 		{
@@ -704,17 +704,14 @@ void CClient::EnterGame(int Conn)
 	m_CurrentServerNextPingTime = time_get() + time_freq() / 2;
 }
 
-void GenerateTimeoutCode(char *pBuffer, unsigned Size, char *pSeed, const NETADDR *pAddrs, int NumAddrs, bool Dummy)
+void GenerateTimeoutCode(char *pBuffer, unsigned Size, char *pSeed, const NETADDR &Addr, bool Dummy)
 {
 	MD5_CTX Md5;
 	md5_init(&Md5);
 	const char *pDummy = Dummy ? "dummy" : "normal";
 	md5_update(&Md5, (unsigned char *)pDummy, str_length(pDummy) + 1);
 	md5_update(&Md5, (unsigned char *)pSeed, str_length(pSeed) + 1);
-	for(int i = 0; i < NumAddrs; i++)
-	{
-		md5_update(&Md5, (unsigned char *)&pAddrs[i], sizeof(pAddrs[i]));
-	}
+	md5_update(&Md5, (unsigned char *)&Addr, sizeof(Addr));
 	MD5_DIGEST Digest = md5_finish(&Md5);
 
 	unsigned short aRandom[8];
@@ -727,13 +724,13 @@ void CClient::GenerateTimeoutSeed()
 	secure_random_password(g_Config.m_ClTimeoutSeed, sizeof(g_Config.m_ClTimeoutSeed), 16);
 }
 
-void CClient::GenerateTimeoutCodes(const NETADDR *pAddrs, int NumAddrs)
+void CClient::GenerateTimeoutCodes()
 {
 	if(g_Config.m_ClTimeoutSeed[0])
 	{
 		for(int i = 0; i < 2; i++)
 		{
-			GenerateTimeoutCode(m_aTimeoutCodes[i], sizeof(m_aTimeoutCodes[i]), g_Config.m_ClTimeoutSeed, pAddrs, NumAddrs, i);
+			GenerateTimeoutCode(m_aTimeoutCodes[i], sizeof(m_aTimeoutCodes[i]), g_Config.m_ClTimeoutSeed, m_ServerAddress, i);
 
 			char aBuf[64];
 			str_format(aBuf, sizeof(aBuf), "timeout code '%s' (%s)", m_aTimeoutCodes[i], i == 0 ? "normal" : "dummy");
@@ -749,52 +746,25 @@ void CClient::GenerateTimeoutCodes(const NETADDR *pAddrs, int NumAddrs)
 
 void CClient::Connect(const char *pAddress, const char *pPassword)
 {
+	char aBuf[512];
+	int Port = 8303;
+
 	Disconnect();
 
 	m_ConnectionID = RandomUuid();
 	if(pAddress != m_aConnectAddressStr)
 		str_copy(m_aConnectAddressStr, pAddress);
 
-	char aMsg[512];
-	str_format(aMsg, sizeof(aMsg), "connecting to '%s'", m_aConnectAddressStr);
-	m_pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "client", aMsg, gs_ClientNetworkPrintColor);
+	str_format(aBuf, sizeof(aBuf), "connecting to '%s'", m_aConnectAddressStr);
+	m_pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "client", aBuf, gs_ClientNetworkPrintColor);
 
 	ServerInfoRequest();
-
-	int NumConnectAddrs = 0;
-	NETADDR aConnectAddrs[MAX_SERVER_ADDRESSES];
-	mem_zero(aConnectAddrs, sizeof(aConnectAddrs));
-	const char *pNextAddr = pAddress;
-	char aBuffer[128];
-	while((pNextAddr = str_next_token(pNextAddr, ",", aBuffer, sizeof(aBuffer))))
+	if(net_host_lookup(m_aConnectAddressStr, &m_ServerAddress, m_aNetClient[CONN_MAIN].NetType()) != 0)
 	{
-		NETADDR NextAddr;
-		if(net_host_lookup(aBuffer, &NextAddr, m_aNetClient[CONN_MAIN].NetType()) != 0)
-		{
-			log_error("client", "could not find address of %s", aBuffer);
-			continue;
-		}
-		if(NumConnectAddrs == (int)std::size(aConnectAddrs))
-		{
-			log_warn("client", "too many connect addresses, ignoring %s", aBuffer);
-			continue;
-		}
-		if(NextAddr.port == 0)
-		{
-			NextAddr.port = 8303;
-		}
-		char aNextAddr[NETADDR_MAXSTRSIZE];
-		net_addr_str(&NextAddr, aNextAddr, sizeof(aNextAddr), true);
-		log_debug("client", "resolved connect address '%s' to %s", aBuffer, aNextAddr);
-		aConnectAddrs[NumConnectAddrs] = NextAddr;
-		NumConnectAddrs += 1;
-	}
-
-	if(NumConnectAddrs == 0)
-	{
-		log_error("client", "could not find any connect address, defaulting to localhost for whatever reason...");
-		net_host_lookup("localhost", &aConnectAddrs[0], m_aNetClient[CONN_MAIN].NetType());
-		NumConnectAddrs = 1;
+		char aBufMsg[256];
+		str_format(aBufMsg, sizeof(aBufMsg), "could not find the address of %s, connecting to localhost", aBuf);
+		m_pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "client", aBufMsg);
+		net_host_lookup("localhost", &m_ServerAddress, m_aNetClient[CONN_MAIN].NetType());
 	}
 
 	if(m_SendPassword)
@@ -813,8 +783,9 @@ void CClient::Connect(const char *pAddress, const char *pPassword)
 	m_aRconAuthed[0] = 0;
 	m_UseTempRconCommands = 0;
 	m_pConsole->DeregisterTempAll();
-
-	m_aNetClient[CONN_MAIN].Connect(aConnectAddrs, NumConnectAddrs);
+	if(m_ServerAddress.port == 0)
+		m_ServerAddress.port = Port;
+	m_aNetClient[CONN_MAIN].Connect(&m_ServerAddress);
 	m_aNetClient[CONN_MAIN].RefreshStun();
 	SetState(IClient::STATE_CONNECTING);
 
@@ -825,7 +796,7 @@ void CClient::Connect(const char *pAddress, const char *pPassword)
 	m_InputtimeMarginGraph.Init(-150.0f, 150.0f);
 	m_GametimeMarginGraph.Init(-150.0f, 150.0f);
 
-	GenerateTimeoutCodes(aConnectAddrs, NumConnectAddrs);
+	GenerateTimeoutCodes();
 }
 
 void CClient::DisconnectWithReason(const char *pReason)
@@ -873,6 +844,7 @@ void CClient::DisconnectWithReason(const char *pReason)
 
 	// clear the current server info
 	mem_zero(&m_CurrentServerInfo, sizeof(m_CurrentServerInfo));
+	mem_zero(&m_ServerAddress, sizeof(m_ServerAddress));
 
 	// clear snapshots
 	m_aapSnapshots[g_Config.m_ClDummy][SNAP_CURRENT] = 0;
@@ -925,8 +897,8 @@ void CClient::DummyConnect()
 	g_Config.m_ClDummyCopyMoves = 0;
 	g_Config.m_ClDummyHammer = 0;
 
-	// connect to the server
-	m_aNetClient[CONN_DUMMY].Connect(m_aNetClient[CONN_MAIN].ServerAddress(), 1);
+	//connecting to the server
+	m_aNetClient[CONN_DUMMY].Connect(&m_ServerAddress);
 }
 
 void CClient::DummyDisconnect(const char *pReason)
@@ -1541,7 +1513,7 @@ void CClient::ProcessServerInfo(int RawType, NETADDR *pFrom, const void *pData, 
 		//
 		// SERVERINFO_EXTENDED_MORE doesn't carry any server
 		// information, so just skip it.
-		if(net_addr_comp(&ServerAddress(), pFrom) == 0 && RawType != SERVERINFO_EXTENDED_MORE)
+		if(net_addr_comp(&m_ServerAddress, pFrom) == 0 && RawType != SERVERINFO_EXTENDED_MORE)
 		{
 			// Only accept server info that has a type that is
 			// newer or equal to something the server already sent
@@ -1550,7 +1522,7 @@ void CClient::ProcessServerInfo(int RawType, NETADDR *pFrom, const void *pData, 
 			{
 				mem_copy(&m_CurrentServerInfo, &Info, sizeof(m_CurrentServerInfo));
 				m_CurrentServerInfo.m_NumAddresses = 1;
-				m_CurrentServerInfo.m_aAddresses[0] = ServerAddress();
+				m_CurrentServerInfo.m_aAddresses[0] = m_ServerAddress;
 				m_CurrentServerInfoRequestTime = -1;
 			}
 
@@ -1569,7 +1541,7 @@ void CClient::ProcessServerInfo(int RawType, NETADDR *pFrom, const void *pData, 
 			if(ValidPong)
 			{
 				int LatencyMs = (time_get() - m_CurrentServerCurrentPingTime) * 1000 / time_freq();
-				m_ServerBrowser.SetCurrentServerPing(ServerAddress(), LatencyMs);
+				m_ServerBrowser.SetCurrentServerPing(m_ServerAddress, LatencyMs);
 				m_CurrentServerPingInfoType = SavedType;
 				m_CurrentServerCurrentPingTime = -1;
 
@@ -1856,7 +1828,7 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket, int Conn, bool Dummy)
 			if(m_ServerCapabilities.m_PingEx && m_CurrentServerCurrentPingTime >= 0 && *pID == m_CurrentServerPingUuid)
 			{
 				int LatencyMs = (time_get() - m_CurrentServerCurrentPingTime) * 1000 / time_freq();
-				m_ServerBrowser.SetCurrentServerPing(ServerAddress(), LatencyMs);
+				m_ServerBrowser.SetCurrentServerPing(m_ServerAddress, LatencyMs);
 				m_CurrentServerCurrentPingTime = -1;
 
 				char aBuf[64];
@@ -1948,7 +1920,7 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket, int Conn, bool Dummy)
 			int DeltaTick = GameTick - Unpacker.GetInt();
 
 			// only allow packets from the server we actually want
-			if(net_addr_comp(&pPacket->m_Address, &ServerAddress()))
+			if(net_addr_comp(&pPacket->m_Address, &m_ServerAddress))
 				return;
 
 			// we are not allowed to process snapshot yet
@@ -2506,19 +2478,6 @@ void CClient::LoadDDNetInfo()
 	Graphics()->WarnPngliteIncompatibleImages(WarnPngliteIncompatibleImages.type == json_boolean && (bool)WarnPngliteIncompatibleImages);
 }
 
-int CClient::ConnectNetTypes() const
-{
-	const NETADDR *pConnectAddrs;
-	int NumConnectAddrs;
-	m_aNetClient[CONN_MAIN].ConnectAddresses(&pConnectAddrs, &NumConnectAddrs);
-	int NetType = 0;
-	for(int i = 0; i < NumConnectAddrs; i++)
-	{
-		NetType |= pConnectAddrs[i].type;
-	}
-	return NetType;
-}
-
 void CClient::PumpNetwork()
 {
 	for(auto &NetClient : m_aNetClient)
@@ -2822,7 +2781,7 @@ void CClient::Update()
 				m_CurrentServerInfoRequestTime >= 0 &&
 				time_get() > m_CurrentServerInfoRequestTime)
 			{
-				m_ServerBrowser.RequestCurrentServer(ServerAddress());
+				m_ServerBrowser.RequestCurrentServer(m_ServerAddress);
 				m_CurrentServerInfoRequestTime = time_get() + time_freq() * 2;
 			}
 
@@ -2841,7 +2800,7 @@ void CClient::Update()
 				m_CurrentServerPingUuid = RandomUuid();
 				if(!m_ServerCapabilities.m_PingEx)
 				{
-					m_ServerBrowser.RequestCurrentServerWithRandomToken(ServerAddress(), &m_CurrentServerPingBasicToken, &m_CurrentServerPingToken);
+					m_ServerBrowser.RequestCurrentServerWithRandomToken(m_ServerAddress, &m_CurrentServerPingBasicToken, &m_CurrentServerPingToken);
 				}
 				else
 				{
@@ -4916,44 +4875,27 @@ int CClient::PredictionMargin() const
 
 int CClient::UdpConnectivity(int NetType)
 {
-	static const int NETTYPES[2] = {NETTYPE_IPV6, NETTYPE_IPV4};
-	int Connectivity = CONNECTIVITY_UNKNOWN;
-	for(int PossibleNetType : NETTYPES)
+	NETADDR GlobalUdpAddr;
+	CONNECTIVITY Connectivity = m_aNetClient->GetConnectivity(NetType, &GlobalUdpAddr);
+	GlobalUdpAddr.port = 0;
+	switch(Connectivity)
 	{
-		if((NetType & PossibleNetType) == 0)
+	case CONNECTIVITY::UNKNOWN:
+		return CONNECTIVITY_UNKNOWN;
+	case CONNECTIVITY::CHECKING:
+		return CONNECTIVITY_CHECKING;
+	case CONNECTIVITY::UNREACHABLE:
+		return CONNECTIVITY_UNREACHABLE;
+	case CONNECTIVITY::REACHABLE:
+		return CONNECTIVITY_REACHABLE;
+	case CONNECTIVITY::ADDRESS_KNOWN:
+		if(m_HaveGlobalTcpAddr && NetType == (int)m_GlobalTcpAddr.type && net_addr_comp(&m_GlobalTcpAddr, &GlobalUdpAddr) != 0)
 		{
-			continue;
+			return CONNECTIVITY_DIFFERING_UDP_TCP_IP_ADDRESSES;
 		}
-		NETADDR GlobalUdpAddr;
-		int NewConnectivity;
-		switch(m_aNetClient[CONN_MAIN].GetConnectivity(PossibleNetType, &GlobalUdpAddr))
-		{
-		case CONNECTIVITY::UNKNOWN:
-			NewConnectivity = CONNECTIVITY_UNKNOWN;
-			break;
-		case CONNECTIVITY::CHECKING:
-			NewConnectivity = CONNECTIVITY_CHECKING;
-			break;
-		case CONNECTIVITY::UNREACHABLE:
-			NewConnectivity = CONNECTIVITY_UNREACHABLE;
-			break;
-		case CONNECTIVITY::REACHABLE:
-			NewConnectivity = CONNECTIVITY_REACHABLE;
-			break;
-		case CONNECTIVITY::ADDRESS_KNOWN:
-			GlobalUdpAddr.port = 0;
-			if(m_HaveGlobalTcpAddr && NetType == (int)m_GlobalTcpAddr.type && net_addr_comp(&m_GlobalTcpAddr, &GlobalUdpAddr) != 0)
-			{
-				NewConnectivity = CONNECTIVITY_DIFFERING_UDP_TCP_IP_ADDRESSES;
-				break;
-			}
-			NewConnectivity = CONNECTIVITY_REACHABLE;
-			break;
-		default:
-			dbg_assert(0, "invalid connectivity value");
-			return CONNECTIVITY_UNKNOWN;
-		}
-		Connectivity = std::max(Connectivity, NewConnectivity);
+		return CONNECTIVITY_REACHABLE;
+	default:
+		dbg_assert(0, "invalid connectivity value");
+		return CONNECTIVITY_UNKNOWN;
 	}
-	return Connectivity;
 }

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -133,7 +133,7 @@ class CClient : public IClient, public CDemoPlayer::IListener
 	CFriends m_Friends;
 	CFriends m_Foes;
 
-	char m_aConnectAddressStr[MAX_SERVER_ADDRESSES * NETADDR_MAXSTRSIZE];
+	char m_aConnectAddressStr[256];
 
 	CUuid m_ConnectionID;
 
@@ -151,6 +151,7 @@ class CClient : public IClient, public CDemoPlayer::IListener
 	float m_RenderFrameTimeHigh;
 	int m_RenderFrames;
 
+	NETADDR m_ServerAddress;
 	int m_SnapCrcErrors;
 	bool m_AutoScreenshotRecycle;
 	bool m_AutoStatScreenshotRecycle;
@@ -408,8 +409,7 @@ public:
 	void FinishDDNetInfo();
 	void LoadDDNetInfo();
 
-	const NETADDR &ServerAddress() const override { return *m_aNetClient[CONN_MAIN].ServerAddress(); }
-	int ConnectNetTypes() const override;
+	NETADDR ServerAddress() const override { return m_ServerAddress; }
 	const char *ConnectAddressString() const override { return m_aConnectAddressStr; }
 	const char *MapDownloadName() const override { return m_aMapdownloadName; }
 	int MapDownloadAmount() const override { return !m_pMapdownloadTask ? m_MapdownloadAmount : (int)m_pMapdownloadTask->Current(); }
@@ -519,7 +519,7 @@ public:
 	// DDRace
 
 	void GenerateTimeoutSeed() override;
-	void GenerateTimeoutCodes(const NETADDR *pAddrs, int NumAddrs);
+	void GenerateTimeoutCodes();
 
 	int GetCurrentRaceTime() override;
 

--- a/src/engine/shared/network.h
+++ b/src/engine/shared/network.h
@@ -231,8 +231,6 @@ private:
 
 	CNetPacketConstruct m_Construct;
 
-	NETADDR m_aConnectAddrs[16];
-	int m_NumConnectAddrs;
 	NETADDR m_PeerAddr;
 	NETSOCKET m_Socket;
 	NETSTATS m_Stats;
@@ -243,7 +241,6 @@ private:
 	void AckChunks(int Ack);
 
 	int QueueChunkEx(int Flags, int DataSize, const void *pData, int Sequence);
-	void SendConnect();
 	void SendControl(int ControlMsg, const void *pExtra, int ExtraSize);
 	void ResendChunk(CNetChunkResend *pResend);
 	void Resend();
@@ -254,7 +251,7 @@ public:
 
 	void Reset(bool Rejoin = false);
 	void Init(NETSOCKET Socket, bool BlockCloseMsg);
-	int Connect(const NETADDR *pAddr, int NumAddrs);
+	int Connect(NETADDR *pAddr);
 	void Disconnect(const char *pReason);
 
 	int Update();
@@ -267,11 +264,6 @@ public:
 	void SignalResend();
 	int State() const { return m_State; }
 	const NETADDR *PeerAddress() const { return &m_PeerAddr; }
-	void ConnectAddresses(const NETADDR **ppAddrs, int *pNumAddrs) const
-	{
-		*ppAddrs = m_aConnectAddrs;
-		*pNumAddrs = m_NumConnectAddrs;
-	}
 
 	void ResetErrorString() { m_aErrorString[0] = 0; }
 	const char *ErrorString() const { return m_aErrorString; }
@@ -495,7 +487,7 @@ public:
 
 	// connection state
 	int Disconnect(const char *pReason);
-	int Connect(const NETADDR *pAddr, int NumAddrs);
+	int Connect(NETADDR *pAddr);
 
 	// communication
 	int Recv(CNetChunk *pChunk);
@@ -510,8 +502,6 @@ public:
 	// error and state
 	int NetType() const { return net_socket_type(m_Socket); }
 	int State();
-	const NETADDR *ServerAddress() const { return m_Connection.PeerAddress(); }
-	void ConnectAddresses(const NETADDR **ppAddrs, int *pNumAddrs) const { m_Connection.ConnectAddresses(ppAddrs, pNumAddrs); }
 	int GotProblems(int64_t MaxLatency) const;
 	const char *ErrorString() const;
 

--- a/src/engine/shared/network_client.cpp
+++ b/src/engine/shared/network_client.cpp
@@ -50,9 +50,9 @@ int CNetClient::Update()
 	return 0;
 }
 
-int CNetClient::Connect(const NETADDR *pAddr, int NumAddrs)
+int CNetClient::Connect(NETADDR *pAddr)
 {
-	m_Connection.Connect(pAddr, NumAddrs);
+	m_Connection.Connect(pAddr);
 	return 0;
 }
 
@@ -103,7 +103,7 @@ int CNetClient::Recv(CNetChunk *pChunk)
 			}
 			else
 			{
-				if(m_Connection.State() != NET_CONNSTATE_OFFLINE && m_Connection.State() != NET_CONNSTATE_ERROR && m_Connection.Feed(&m_RecvUnpacker.m_Data, &Addr))
+				if(m_Connection.State() != NET_CONNSTATE_OFFLINE && m_Connection.State() != NET_CONNSTATE_ERROR && net_addr_comp(m_Connection.PeerAddress(), &Addr) == 0 && m_Connection.Feed(&m_RecvUnpacker.m_Data, &Addr))
 					m_RecvUnpacker.Start(&Addr, &m_Connection, 0);
 			}
 		}

--- a/src/engine/shared/network_conn.cpp
+++ b/src/engine/shared/network_conn.cpp
@@ -38,8 +38,6 @@ void CNetConnection::Reset(bool Rejoin)
 	m_LastRecvTime = 0;
 	//m_LastUpdateTime = 0;
 
-	mem_zero(&m_aConnectAddrs, sizeof(m_aConnectAddrs));
-	m_NumConnectAddrs = 0;
 	//mem_zero(&m_PeerAddr, sizeof(m_PeerAddr));
 	m_UnknownSeq = false;
 
@@ -164,16 +162,6 @@ int CNetConnection::QueueChunk(int Flags, int DataSize, const void *pData)
 	return QueueChunkEx(Flags, DataSize, pData, m_Sequence);
 }
 
-void CNetConnection::SendConnect()
-{
-	// send the connect message
-	m_LastSendTime = time_get();
-	for(int i = 0; i < m_NumConnectAddrs; i++)
-	{
-		CNetBase::SendControlMsg(m_Socket, &m_aConnectAddrs[i], m_Ack, NET_CTRLMSG_CONNECT, SECURITY_TOKEN_MAGIC, sizeof(SECURITY_TOKEN_MAGIC), m_SecurityToken, m_Sixup);
-	}
-}
-
 void CNetConnection::SendControl(int ControlMsg, const void *pExtra, int ExtraSize)
 {
 	// send the control message
@@ -193,22 +181,17 @@ void CNetConnection::Resend()
 		ResendChunk(pResend);
 }
 
-int CNetConnection::Connect(const NETADDR *pAddr, int NumAddrs)
+int CNetConnection::Connect(NETADDR *pAddr)
 {
 	if(State() != NET_CONNSTATE_OFFLINE)
 		return -1;
 
 	// init connection
 	Reset();
-	mem_zero(&m_PeerAddr, sizeof(m_PeerAddr));
-	for(int i = 0; i < NumAddrs; i++)
-	{
-		m_aConnectAddrs[i] = pAddr[i];
-	}
-	m_NumConnectAddrs = NumAddrs;
+	m_PeerAddr = *pAddr;
 	mem_zero(m_aErrorString, sizeof(m_aErrorString));
 	m_State = NET_CONNSTATE_CONNECT;
-	SendConnect();
+	SendControl(NET_CTRLMSG_CONNECT, SECURITY_TOKEN_MAGIC, sizeof(SECURITY_TOKEN_MAGIC));
 	return 0;
 }
 
@@ -259,12 +242,6 @@ void CNetConnection::DirectInit(NETADDR &Addr, SECURITY_TOKEN SecurityToken, SEC
 
 int CNetConnection::Feed(CNetPacketConstruct *pPacket, NETADDR *pAddr, SECURITY_TOKEN SecurityToken)
 {
-	// Disregard packets from the wrong address, unless we don't know our peer yet.
-	if(State() != NET_CONNSTATE_OFFLINE && State() != NET_CONNSTATE_CONNECT && *pAddr != m_PeerAddr)
-	{
-		return 0;
-	}
-
 	if(!m_Sixup && State() != NET_CONNSTATE_OFFLINE && m_SecurityToken != NET_SECURITY_TOKEN_UNKNOWN && m_SecurityToken != NET_SECURITY_TOKEN_UNSUPPORTED)
 	{
 		// supposed to have a valid token in this packet, check it
@@ -371,7 +348,6 @@ int CNetConnection::Feed(CNetPacketConstruct *pPacket, NETADDR *pAddr, SECURITY_
 				// connection made
 				if(CtrlMsg == NET_CTRLMSG_CONNECTACCEPT)
 				{
-					m_PeerAddr = *pAddr;
 					if(m_SecurityToken == NET_SECURITY_TOKEN_UNKNOWN && pPacket->m_DataSize >= (int)(1 + sizeof(SECURITY_TOKEN_MAGIC) + sizeof(m_SecurityToken)) && !mem_comp(&pPacket->m_aChunkData[1], SECURITY_TOKEN_MAGIC, sizeof(SECURITY_TOKEN_MAGIC)))
 					{
 						m_SecurityToken = ToSecurityToken(&pPacket->m_aChunkData[1 + sizeof(SECURITY_TOKEN_MAGIC)]);
@@ -476,7 +452,7 @@ int CNetConnection::Update()
 	else if(State() == NET_CONNSTATE_CONNECT)
 	{
 		if(time_get() - m_LastSendTime > time_freq() / 2) // send a new connect every 500ms
-			SendConnect();
+			SendControl(NET_CTRLMSG_CONNECT, SECURITY_TOKEN_MAGIC, sizeof(SECURITY_TOKEN_MAGIC));
 	}
 	else if(State() == NET_CONNSTATE_PENDING)
 	{

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -1443,7 +1443,7 @@ int CMenus::Render()
 			pButtonText = Localize("Abort");
 			if(Client()->State() == IClient::STATE_CONNECTING && time_get() - Client()->StateStartTime() > time_freq())
 			{
-				int Connectivity = Client()->UdpConnectivity(Client()->ConnectNetTypes());
+				int Connectivity = Client()->UdpConnectivity(Client()->ServerAddress().type);
 				switch(Connectivity)
 				{
 				case IClient::CONNECTIVITY_UNKNOWN:


### PR DESCRIPTION
This reverts commit 8996d152abe1eef489e6457617ef7df5f64e0765.

Maybe only for 16.3.2?
New:
![screenshot-20220903@171243](https://user-images.githubusercontent.com/2335377/188276881-09fe132f-f87b-4b40-bf09-5391a46ad050.png)
Old:
![screenshot-20220903@171324](https://user-images.githubusercontent.com/2335377/188276903-bf8de779-3cbe-4d22-9292-d348c5e4d85d.png)

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
