### PR TITLE
Refactor editor server settings and automapper config lists using `CScrollRegion`

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -5422,60 +5422,34 @@ void CEditor::RenderServerSettingsEditor(CUIRect View, bool ShowServerSettingsEd
 	CUIRect ListBox;
 	View.Margin(1.0f, &ListBox);
 
-	float ListHeight = 17.0f * m_Map.m_vSettings.size();
-	static float s_ScrollValue = 0;
+	const float ButtonHeight = 15.0f;
+	const float ButtonMargin = 2.0f;
 
-	float ScrollDifference = ListHeight - ListBox.h;
+	static CScrollRegion s_ScrollRegion;
+	vec2 ScrollOffset(0.0f, 0.0f);
+	CScrollRegionParams ScrollParams;
+	ScrollParams.m_ScrollUnit = (ButtonHeight + ButtonMargin) * 5.0f;
+	s_ScrollRegion.Begin(&ListBox, &ScrollOffset, &ScrollParams);
+	ListBox.y += ScrollOffset.y;
 
-	if(ListHeight > ListBox.h) // Do we even need a scrollbar?
-	{
-		CUIRect Scroll;
-		ListBox.VSplitRight(20.0f, &ListBox, &Scroll);
-		s_ScrollValue = UI()->DoScrollbarV(&s_ScrollValue, &Scroll, s_ScrollValue);
-
-		if(UI()->MouseInside(&Scroll) || UI()->MouseInside(&ListBox))
-		{
-			int ScrollNum = (int)((ListHeight - ListBox.h) / 17.0f) + 1;
-			if(ScrollNum > 0)
-			{
-				if(Input()->KeyPress(KEY_MOUSE_WHEEL_UP))
-					s_ScrollValue = clamp(s_ScrollValue - 1.0f / ScrollNum, 0.0f, 1.0f);
-				if(Input()->KeyPress(KEY_MOUSE_WHEEL_DOWN))
-					s_ScrollValue = clamp(s_ScrollValue + 1.0f / ScrollNum, 0.0f, 1.0f);
-			}
-		}
-	}
-
-	float ListStartAt = ScrollDifference * s_ScrollValue;
-	if(ListStartAt < 0.0f)
-		ListStartAt = 0.0f;
-
-	float ListStopAt = ListHeight - ScrollDifference * (1 - s_ScrollValue);
-	float ListCur = 0;
-
-	UI()->ClipEnable(&ListBox);
 	for(size_t i = 0; i < m_Map.m_vSettings.size(); i++)
 	{
-		if(ListCur > ListStopAt)
-			break;
-
-		if(ListCur >= ListStartAt)
+		CUIRect Button;
+		ListBox.HSplitTop(ButtonHeight, &Button, &ListBox);
+		ListBox.HSplitTop(ButtonMargin, nullptr, &ListBox);
+		Button.VSplitLeft(5.0f, nullptr, &Button);
+		if(s_ScrollRegion.AddRect(Button))
 		{
-			CUIRect Button;
-			ListBox.HSplitTop(15.0f, &Button, &ListBox);
-			ListBox.HSplitTop(2.0f, nullptr, &ListBox);
-			Button.VSplitLeft(5.0f, nullptr, &Button);
-
 			if(DoButton_MenuItem(&m_Map.m_vSettings[i], m_Map.m_vSettings[i].m_aCommand, s_CommandSelectedIndex >= 0 && (size_t)s_CommandSelectedIndex == i, &Button, 0, nullptr))
 			{
 				s_CommandSelectedIndex = i;
-				str_copy(m_aSettingsCommand, m_Map.m_vSettings[i].m_aCommand, sizeof(m_aSettingsCommand));
+				str_copy(m_aSettingsCommand, m_Map.m_vSettings[i].m_aCommand);
 				UI()->SetActiveItem(&m_CommandBox);
 			}
 		}
-		ListCur += 17.0f;
 	}
-	UI()->ClipDisable();
+
+	s_ScrollRegion.End();
 }
 
 int CEditor::PopupMenuFile(CEditor *pEditor, CUIRect View, void *pContext)


### PR DESCRIPTION
- Refactor editor automapper config list using `CScrollRegion`. Also fix some other minor issues with this list.
  - Fix the currently selected item not being highlighted after opening the dialog.
  - Remove static limit of 255 automapper rules, after which the editor previously caused out-of-bounds accesses, by using the address of the automapper config name as button ID.
  - Before:  ![automapper old](https://user-images.githubusercontent.com/23437060/188277300-bd634c13-fb66-4348-abf4-9481e8fcaa3a.png)
  - After: ![automapper new](https://user-images.githubusercontent.com/23437060/188277303-0cb94442-f35d-4c1e-bd81-7f56052cede6.png)
- Refactor editor server settings list using `CScrollRegion`.
  - Before:  ![server_settings old](https://user-images.githubusercontent.com/23437060/188277264-8a0d16b5-838c-4bd1-b94c-f11091c68ccf.png)
  - After: ![server_settings new](https://user-images.githubusercontent.com/23437060/188277269-1fabf5a5-9daf-4ffe-893d-1f1690ba597f.png)



## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
