### PR TITLE
Fix close messages not being shown when connecting

### DIFF
--- a/src/engine/shared/network_conn.cpp
+++ b/src/engine/shared/network_conn.cpp
@@ -308,7 +308,20 @@ int CNetConnection::Feed(CNetPacketConstruct *pPacket, NETADDR *pAddr, SECURITY_
 
 		if(CtrlMsg == NET_CTRLMSG_CLOSE)
 		{
-			if(net_addr_comp(&m_PeerAddr, pAddr) == 0)
+			bool IsPeer;
+			if(m_State != NET_CONNSTATE_CONNECT)
+			{
+				IsPeer = m_PeerAddr == *pAddr;
+			}
+			else
+			{
+				IsPeer = false;
+				for(int i = 0; i < m_NumConnectAddrs; i++)
+				{
+					IsPeer = IsPeer || m_aConnectAddrs[i] == *pAddr;
+				}
+			}
+			if(IsPeer)
 			{
 				m_State = NET_CONNSTATE_ERROR;
 				m_RemoteClosed = 1;


### PR DESCRIPTION
Previously, close messages were entirely ignored during the connection
process, this meant that ban messages weren't shown to players. Instead,
they'd see the standard "no answer from server yet" message.

Fixes #5792.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
