### PR TITLE
Editor: Added "Order" button in quads popup

### DIFF
--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -667,6 +667,7 @@ public:
 
 	void Render(bool QuadPicker = false) override;
 	CQuad *NewQuad(int x, int y, int Width, int Height);
+	int SwapQuads(int Index0, int Index1);
 
 	void BrushSelecting(CUIRect Rect) override;
 	int BrushGrab(CLayerGroup *pBrush, CUIRect Rect) override;

--- a/src/game/editor/layer_quads.cpp
+++ b/src/game/editor/layer_quads.cpp
@@ -267,3 +267,16 @@ CLayer *CLayerQuads::Duplicate() const
 {
 	return new CLayerQuads(*this);
 }
+
+int CLayerQuads::SwapQuads(int Index0, int Index1)
+{
+	if(Index0 < 0 || Index0 >= (int)m_vQuads.size())
+		return Index0;
+	if(Index1 < 0 || Index1 >= (int)m_vQuads.size())
+		return Index0;
+	if(Index0 == Index1)
+		return Index0;
+	m_pEditor->m_Map.m_Modified = true;
+	std::swap(m_vQuads[Index0], m_vQuads[Index1]);
+	return Index1;
+}

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -648,7 +648,8 @@ int CEditor::PopupQuad(CEditor *pEditor, CUIRect View, void *pContext)
 
 	enum
 	{
-		PROP_POS_X = 0,
+		PROP_ORDER = 0,
+		PROP_POS_X,
 		PROP_POS_Y,
 		PROP_POS_ENV,
 		PROP_POS_ENV_OFFSET,
@@ -657,7 +658,9 @@ int CEditor::PopupQuad(CEditor *pEditor, CUIRect View, void *pContext)
 		NUM_PROPS,
 	};
 
+	int NumQuads = pLayer ? (int)pLayer->m_vQuads.size() : 0;
 	CProperty aProps[] = {
+		{"Order", pEditor->m_vSelectedQuads[pEditor->m_SelectedQuadIndex], PROPTYPE_INT_STEP, 0, NumQuads},
 		{"Pos X", fx2i(pCurrentQuad->m_aPoints[4].x), PROPTYPE_INT_SCROLL, -1000000, 1000000},
 		{"Pos Y", fx2i(pCurrentQuad->m_aPoints[4].y), PROPTYPE_INT_SCROLL, -1000000, 1000000},
 		{"Pos. Env", pCurrentQuad->m_PosEnv + 1, PROPTYPE_ENVELOPE, 0, 0},
@@ -676,6 +679,12 @@ int CEditor::PopupQuad(CEditor *pEditor, CUIRect View, void *pContext)
 
 	float OffsetX = i2fx(NewVal) - pCurrentQuad->m_aPoints[4].x;
 	float OffsetY = i2fx(NewVal) - pCurrentQuad->m_aPoints[4].y;
+
+	if(Prop == PROP_ORDER && pLayer)
+	{
+		int QuadIndex = pLayer->SwapQuads(pEditor->m_vSelectedQuads[pEditor->m_SelectedQuadIndex], NewVal);
+		pEditor->m_vSelectedQuads[pEditor->m_SelectedQuadIndex] = QuadIndex;
+	}
 
 	for(auto &pQuad : vpQuads)
 	{


### PR DESCRIPTION
Main purpose is to control quads z index, but i like how this can be used to reveal how many quads a layer has just by placing a new one.
Furthermore, it provides a way to reference quads, that's needed to make custom cli tools work on user selected quads.

![Screenshot from 2022-09-09 19-04-21](https://user-images.githubusercontent.com/3328841/189411505-558ca601-e753-48b2-a6c3-d9f293795951.png)

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [x] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
