### PR TITLE
Editor: Added reload button for image and sound popups

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -3791,7 +3791,7 @@ static void ModifyIndexDeleted(int *pIndex)
 
 int CEditor::PopupImage(CEditor *pEditor, CUIRect View, void *pContext)
 {
-	static int s_ReloadButton = 0;
+	static int s_ReaddButton = 0;
 	static int s_ReplaceButton = 0;
 	static int s_RemoveButton = 0;
 
@@ -3822,7 +3822,7 @@ int CEditor::PopupImage(CEditor *pEditor, CUIRect View, void *pContext)
 		View.HSplitTop(12.0f, &Slot, &View);
 	}
 
-	if(pEditor->DoButton_MenuItem(&s_ReloadButton, "Reload", 0, &Slot, 0, "Reloads the image from mapres folder"))
+	if(pEditor->DoButton_MenuItem(&s_ReaddButton, "Readd", 0, &Slot, 0, "Reloads the image from mapres folder"))
 	{
 		bool bIsExternal = pImg->m_External;
 		char aBuffer[1024];
@@ -3856,7 +3856,7 @@ int CEditor::PopupImage(CEditor *pEditor, CUIRect View, void *pContext)
 
 int CEditor::PopupSound(CEditor *pEditor, CUIRect View, void *pContext)
 {
-	static int s_ReloadButton = 0;
+	static int s_ReaddButton = 0;
 	static int s_ReplaceButton = 0;
 	static int s_RemoveButton = 0;
 
@@ -3865,7 +3865,7 @@ int CEditor::PopupSound(CEditor *pEditor, CUIRect View, void *pContext)
 	View.HSplitTop(12.0f, &Slot, &View);
 	CEditorSound *pSound = pEditor->m_Map.m_vpSounds[pEditor->m_SelectedSound];
 
-	if(pEditor->DoButton_MenuItem(&s_ReloadButton, "Reload", 0, &Slot, 0, "Reloads the sound from mapres folder"))
+	if(pEditor->DoButton_MenuItem(&s_ReaddButton, "Readd", 0, &Slot, 0, "Reloads the sound from mapres folder"))
 	{
 		char aBuffer[1024];
 		str_format(aBuffer, sizeof(aBuffer), "mapres/%s.opus", pSound->m_aName);

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -3791,6 +3791,7 @@ static void ModifyIndexDeleted(int *pIndex)
 
 int CEditor::PopupImage(CEditor *pEditor, CUIRect View, void *pContext)
 {
+	static int s_ReloadButton = 0;
 	static int s_ReplaceButton = 0;
 	static int s_RemoveButton = 0;
 
@@ -3821,6 +3822,18 @@ int CEditor::PopupImage(CEditor *pEditor, CUIRect View, void *pContext)
 		View.HSplitTop(12.0f, &Slot, &View);
 	}
 
+	if(pEditor->DoButton_MenuItem(&s_ReloadButton, "Reload", 0, &Slot, 0, "Reloads the image from mapres folder"))
+	{
+		bool bIsExternal = pImg->m_External;
+		char aBuffer[1024];
+		str_format(aBuffer, sizeof(aBuffer), "mapres/%s.png", pImg->m_aName);
+		pEditor->ReplaceImage(aBuffer, IStorage::TYPE_ALL, pEditor);
+		pImg->m_External = bIsExternal;
+		return 1;
+	}
+
+	View.HSplitTop(5.0f, &Slot, &View);
+	View.HSplitTop(12.0f, &Slot, &View);
 	if(pEditor->DoButton_MenuItem(&s_ReplaceButton, "Replace", 0, &Slot, 0, "Replaces the image with a new one"))
 	{
 		pEditor->InvokeFileDialog(IStorage::TYPE_ALL, FILETYPE_IMG, "Replace Image", "Replace", "mapres", "", ReplaceImage, pEditor);
@@ -3843,11 +3856,24 @@ int CEditor::PopupImage(CEditor *pEditor, CUIRect View, void *pContext)
 
 int CEditor::PopupSound(CEditor *pEditor, CUIRect View, void *pContext)
 {
+	static int s_ReloadButton = 0;
 	static int s_ReplaceButton = 0;
 	static int s_RemoveButton = 0;
 
 	CUIRect Slot;
 	View.HSplitTop(2.0f, &Slot, &View);
+	View.HSplitTop(12.0f, &Slot, &View);
+	CEditorSound *pSound = pEditor->m_Map.m_vpSounds[pEditor->m_SelectedSound];
+
+	if(pEditor->DoButton_MenuItem(&s_ReloadButton, "Reload", 0, &Slot, 0, "Reloads the sound from mapres folder"))
+	{
+		char aBuffer[1024];
+		str_format(aBuffer, sizeof(aBuffer), "mapres/%s.opus", pSound->m_aName);
+		pEditor->ReplaceSound(aBuffer, IStorage::TYPE_ALL, pEditor);
+		return 1;
+	}
+
+	View.HSplitTop(5.0f, &Slot, &View);
 	View.HSplitTop(12.0f, &Slot, &View);
 	if(pEditor->DoButton_MenuItem(&s_ReplaceButton, "Replace", 0, &Slot, 0, "Replaces the sound with a new one"))
 	{
@@ -3857,7 +3883,6 @@ int CEditor::PopupSound(CEditor *pEditor, CUIRect View, void *pContext)
 
 	View.HSplitTop(5.0f, &Slot, &View);
 	View.HSplitTop(12.0f, &Slot, &View);
-	CEditorSound *pSound = pEditor->m_Map.m_vpSounds[pEditor->m_SelectedSound];
 	if(pEditor->DoButton_MenuItem(&s_RemoveButton, "Remove", 0, &Slot, 0, "Removes the sound from the map"))
 	{
 		delete pSound;
@@ -4045,9 +4070,9 @@ void CEditor::RenderImagesList(CUIRect ToolBox)
 					CEditorImage *pImg = m_Map.m_vpImages[m_SelectedImage];
 					int Height;
 					if(pImg->m_External || IsVanillaImage(pImg->m_aName))
-						Height = 60;
+						Height = 73;
 					else
-						Height = 43;
+						Height = 60;
 					UiInvokePopupMenu(&s_PopupImageID, 0, UI()->MouseX(), UI()->MouseY(), 120, Height, PopupImage);
 				}
 			}


### PR DESCRIPTION
Automatically reloads the image from mapres folder based on its current name, that's just a quicker "replace" which is convenient while experimenting on image contents, some mappers asked for this.

![Screenshot from 2022-09-10 11-57-58](https://user-images.githubusercontent.com/3328841/189479587-620c812c-0df2-4ba2-94a0-83eca8e42c81.png)

note: image lookup is currently limited to the mapres root folder, no directory recursion has been implemented, this is an improvement that might be added in the future (even though in my understanding, organizing mapres into subfolders is not a very common practice, not even the "search" feature considers that).

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [x] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
