### PR TITLE
Only start registering once the server is fully started

### DIFF
--- a/src/engine/server/register.cpp
+++ b/src/engine/server/register.cpp
@@ -508,7 +508,16 @@ CRegister::CRegister(CConfig *pConfig, IConsole *pConsole, IEngine *pEngine, int
 
 void CRegister::Update()
 {
-	m_GotFirstUpdateCall = true;
+	if(!m_GotFirstUpdateCall)
+	{
+		bool Ipv6 = m_aProtocolEnabled[PROTOCOL_TW6_IPV6] || m_aProtocolEnabled[PROTOCOL_TW7_IPV6];
+		bool Ipv4 = m_aProtocolEnabled[PROTOCOL_TW6_IPV4] || m_aProtocolEnabled[PROTOCOL_TW7_IPV4];
+		if(Ipv6 && Ipv4)
+		{
+			dbg_assert(!HttpHasIpresolveBug(), "curl version < 7.77.0 does not support registering via both IPv4 and IPv6, set `sv_register ipv6` or `sv_register ipv4`");
+		}
+		m_GotFirstUpdateCall = true;
+	}
 	if(!m_GotServerInfo)
 	{
 		return;

--- a/src/engine/shared/http.cpp
+++ b/src/engine/shared/http.cpp
@@ -116,6 +116,13 @@ void EscapeUrl(char *pBuf, int Size, const char *pStr)
 	curl_free(pEsc);
 }
 
+bool HttpHasIpresolveBug()
+{
+	// curl < 7.77.0 doesn't use CURLOPT_IPRESOLVE correctly wrt.
+	// connection caches.
+	return curl_version_info(CURLVERSION_NOW)->version_num < 0x074d00;
+}
+
 CHttpRequest::CHttpRequest(const char *pUrl)
 {
 	str_copy(m_aUrl, pUrl);

--- a/src/engine/shared/http.h
+++ b/src/engine/shared/http.h
@@ -194,4 +194,5 @@ inline std::unique_ptr<CHttpRequest> HttpPostJson(const char *pUrl, const char *
 
 bool HttpInit(IStorage *pStorage);
 void EscapeUrl(char *pBuf, int Size, const char *pStr);
+bool HttpHasIpresolveBug();
 #endif // ENGINE_SHARED_HTTP_H


### PR DESCRIPTION
This works around, i.e. fixes #5858 for curl versions < 7.77.0, as long
as the servers are only registered via IPv4 **OR** IPv6.

The bug that's being worked around is this:
https://github.com/curl/curl/commit/84d2839740ca78041ac7419d9aaeac55c1e1c729.

The bug makes curl reuse IPv6 connections when it is being requested to
connect via IPv4, making the registering fail. This commit works around
that by letting the server only register after having completely read
the config, so any `sv_register ipv4` should already be in effect.

Also stop server if started with old curl and incompatible `sv_register`.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
