### PR TITLE
refresh serverbrowser when disconnecting / abort

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -2732,23 +2732,23 @@ void CMenus::SetMenuPage(int NewPage)
 void CMenus::RefreshBrowserTab(int UiPage)
 {
 	if(UiPage == PAGE_INTERNET)
-				ServerBrowser()->Refresh(IServerBrowser::TYPE_INTERNET);
-			else if(UiPage == PAGE_LAN)
-				ServerBrowser()->Refresh(IServerBrowser::TYPE_LAN);
-			else if(UiPage == PAGE_FAVORITES)
-				ServerBrowser()->Refresh(IServerBrowser::TYPE_FAVORITES);
-			else if(UiPage == PAGE_DDNET)
-			{
-				// start a new server list request
-				Client()->RequestDDNetInfo();
-				ServerBrowser()->Refresh(IServerBrowser::TYPE_DDNET);
-			}
-			else if(UiPage == PAGE_KOG)
-			{
-				// start a new server list request
-				Client()->RequestDDNetInfo();
-				ServerBrowser()->Refresh(IServerBrowser::TYPE_KOG);
-			}
+		ServerBrowser()->Refresh(IServerBrowser::TYPE_INTERNET);
+	else if(UiPage == PAGE_LAN)
+		ServerBrowser()->Refresh(IServerBrowser::TYPE_LAN);
+	else if(UiPage == PAGE_FAVORITES)
+		ServerBrowser()->Refresh(IServerBrowser::TYPE_FAVORITES);
+	else if(UiPage == PAGE_DDNET)
+	{
+		// start a new server list request
+		Client()->RequestDDNetInfo();
+		ServerBrowser()->Refresh(IServerBrowser::TYPE_DDNET);
+	}
+	else if(UiPage == PAGE_KOG)
+	{
+		// start a new server list request
+		Client()->RequestDDNetInfo();
+		ServerBrowser()->Refresh(IServerBrowser::TYPE_KOG);
+	}
 }
 
 bool CMenus::HandleListInputs(const CUIRect &View, float &ScrollValue, const float ScrollAmount, int *pScrollOffset, const float ElemHeight, int &SelectedIndex, const int NumElems)

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -1783,6 +1783,24 @@ int CMenus::Render()
 			{
 				Client()->Disconnect();
 				m_Popup = POPUP_NONE;
+				if(g_Config.m_UiPage == PAGE_INTERNET)
+					ServerBrowser()->Refresh(IServerBrowser::TYPE_INTERNET);
+				else if(g_Config.m_UiPage == PAGE_LAN)
+					ServerBrowser()->Refresh(IServerBrowser::TYPE_LAN);
+				else if(g_Config.m_UiPage == PAGE_FAVORITES)
+					ServerBrowser()->Refresh(IServerBrowser::TYPE_FAVORITES);
+				else if(g_Config.m_UiPage == PAGE_DDNET)
+				{
+					// start a new server list request
+					Client()->RequestDDNetInfo();
+					ServerBrowser()->Refresh(IServerBrowser::TYPE_DDNET);
+				}
+				else if(g_Config.m_UiPage == PAGE_KOG)
+				{
+					// start a new server list request
+					Client()->RequestDDNetInfo();
+					ServerBrowser()->Refresh(IServerBrowser::TYPE_KOG);
+				}
 			}
 
 			if(Client()->MapDownloadTotalsize() > 0)

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -1298,6 +1298,7 @@ int CMenus::Render()
 		s_Frame++;
 		m_DoubleClickIndex = -1;
 
+		RefreshBrowserTab(g_Config.m_UiPage);
 		if(g_Config.m_UiPage == PAGE_INTERNET)
 			ServerBrowser()->Refresh(IServerBrowser::TYPE_INTERNET);
 		else if(g_Config.m_UiPage == PAGE_LAN)
@@ -1783,24 +1784,7 @@ int CMenus::Render()
 			{
 				Client()->Disconnect();
 				m_Popup = POPUP_NONE;
-				if(g_Config.m_UiPage == PAGE_INTERNET)
-					ServerBrowser()->Refresh(IServerBrowser::TYPE_INTERNET);
-				else if(g_Config.m_UiPage == PAGE_LAN)
-					ServerBrowser()->Refresh(IServerBrowser::TYPE_LAN);
-				else if(g_Config.m_UiPage == PAGE_FAVORITES)
-					ServerBrowser()->Refresh(IServerBrowser::TYPE_FAVORITES);
-				else if(g_Config.m_UiPage == PAGE_DDNET)
-				{
-					// start a new server list request
-					Client()->RequestDDNetInfo();
-					ServerBrowser()->Refresh(IServerBrowser::TYPE_DDNET);
-				}
-				else if(g_Config.m_UiPage == PAGE_KOG)
-				{
-					// start a new server list request
-					Client()->RequestDDNetInfo();
-					ServerBrowser()->Refresh(IServerBrowser::TYPE_KOG);
-				}
+				RefreshBrowserTab(g_Config.m_UiPage);
 			}
 
 			if(Client()->MapDownloadTotalsize() > 0)
@@ -2743,6 +2727,28 @@ void CMenus::SetMenuPage(int NewPage)
 	m_MenuPage = NewPage;
 	if(NewPage >= PAGE_INTERNET && NewPage <= PAGE_KOG)
 		g_Config.m_UiPage = NewPage;
+}
+
+void CMenus::RefreshBrowserTab(int UiPage)
+{
+	if(UiPage == PAGE_INTERNET)
+				ServerBrowser()->Refresh(IServerBrowser::TYPE_INTERNET);
+			else if(UiPage == PAGE_LAN)
+				ServerBrowser()->Refresh(IServerBrowser::TYPE_LAN);
+			else if(UiPage == PAGE_FAVORITES)
+				ServerBrowser()->Refresh(IServerBrowser::TYPE_FAVORITES);
+			else if(UiPage == PAGE_DDNET)
+			{
+				// start a new server list request
+				Client()->RequestDDNetInfo();
+				ServerBrowser()->Refresh(IServerBrowser::TYPE_DDNET);
+			}
+			else if(UiPage == PAGE_KOG)
+			{
+				// start a new server list request
+				Client()->RequestDDNetInfo();
+				ServerBrowser()->Refresh(IServerBrowser::TYPE_KOG);
+			}
 }
 
 bool CMenus::HandleListInputs(const CUIRect &View, float &ScrollValue, const float ScrollAmount, int *pScrollOffset, const float ElemHeight, int &SelectedIndex, const int NumElems)

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -705,6 +705,7 @@ public:
 private:
 	static int GhostlistFetchCallback(const char *pName, int IsDir, int StorageType, void *pUser);
 	void SetMenuPage(int NewPage);
+	void RefreshBrowserTab(int UiPage);
 	bool HandleListInputs(const CUIRect &View, float &ScrollValue, float ScrollAmount, int *pScrollOffset, float ElemHeight, int &SelectedIndex, int NumElems);
 
 	// found in menus_ingame.cpp

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -631,25 +631,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 
 		if(DoButtonMenu(m_RefreshButton, &s_RefreshButton, Func, 0, &ButtonRefresh, true, false, IGraphics::CORNER_ALL) || Input()->KeyPress(KEY_F5) || (Input()->KeyPress(KEY_R) && Input()->ModifierIsPressed()))
 		{
-			if(g_Config.m_UiPage == PAGE_INTERNET)
-				ServerBrowser()->Refresh(IServerBrowser::TYPE_INTERNET);
-			else if(g_Config.m_UiPage == PAGE_LAN)
-				ServerBrowser()->Refresh(IServerBrowser::TYPE_LAN);
-			else if(g_Config.m_UiPage == PAGE_FAVORITES)
-				ServerBrowser()->Refresh(IServerBrowser::TYPE_FAVORITES);
-			else if(g_Config.m_UiPage == PAGE_DDNET)
-			{
-				// start a new server list request
-				Client()->RequestDDNetInfo();
-				ServerBrowser()->Refresh(IServerBrowser::TYPE_DDNET);
-			}
-			else if(g_Config.m_UiPage == PAGE_KOG)
-			{
-				// start a new server list request
-				Client()->RequestDDNetInfo();
-				ServerBrowser()->Refresh(IServerBrowser::TYPE_KOG);
-			}
-			m_DoubleClickIndex = -1;
+			RefreshBrowserTab(g_Config.m_UiPage);
 		}
 
 		static int s_JoinButton = 0;

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -61,6 +61,24 @@ void CMenus::RenderGame(CUIRect MainView)
 		else
 		{
 			Client()->Disconnect();
+			if(g_Config.m_UiPage == PAGE_INTERNET)
+				ServerBrowser()->Refresh(IServerBrowser::TYPE_INTERNET);
+			else if(g_Config.m_UiPage == PAGE_LAN)
+				ServerBrowser()->Refresh(IServerBrowser::TYPE_LAN);
+			else if(g_Config.m_UiPage == PAGE_FAVORITES)
+				ServerBrowser()->Refresh(IServerBrowser::TYPE_FAVORITES);
+			else if(g_Config.m_UiPage == PAGE_DDNET)
+			{
+				// start a new server list request
+				Client()->RequestDDNetInfo();
+				ServerBrowser()->Refresh(IServerBrowser::TYPE_DDNET);
+			}
+			else if(g_Config.m_UiPage == PAGE_KOG)
+			{
+				// start a new server list request
+				Client()->RequestDDNetInfo();
+				ServerBrowser()->Refresh(IServerBrowser::TYPE_KOG);
+			}
 		}
 	}
 

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -61,24 +61,7 @@ void CMenus::RenderGame(CUIRect MainView)
 		else
 		{
 			Client()->Disconnect();
-			if(g_Config.m_UiPage == PAGE_INTERNET)
-				ServerBrowser()->Refresh(IServerBrowser::TYPE_INTERNET);
-			else if(g_Config.m_UiPage == PAGE_LAN)
-				ServerBrowser()->Refresh(IServerBrowser::TYPE_LAN);
-			else if(g_Config.m_UiPage == PAGE_FAVORITES)
-				ServerBrowser()->Refresh(IServerBrowser::TYPE_FAVORITES);
-			else if(g_Config.m_UiPage == PAGE_DDNET)
-			{
-				// start a new server list request
-				Client()->RequestDDNetInfo();
-				ServerBrowser()->Refresh(IServerBrowser::TYPE_DDNET);
-			}
-			else if(g_Config.m_UiPage == PAGE_KOG)
-			{
-				// start a new server list request
-				Client()->RequestDDNetInfo();
-				ServerBrowser()->Refresh(IServerBrowser::TYPE_KOG);
-			}
+			RefreshBrowserTab(g_Config.m_UiPage);
 		}
 	}
 


### PR DESCRIPTION
This might be not complete, but this adds the functionality to refresh the server browser list after disconnecting from a server, or after aborting joining a server.

This fixes issue #5863.


## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
