### PR TITLE
Move home button to very right so it is consistent with close button ingame (fixes #5881)

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -675,49 +675,6 @@ int CMenus::RenderMenubar(CUIRect r)
 
 	if(Client()->State() == IClient::STATE_OFFLINE)
 	{
-		Box.VSplitLeft(33.0f, &Button, &Box);
-		static CButtonContainer s_StartButton;
-
-		TextRender()->SetCurFont(TextRender()->GetFont(TEXT_FONT_ICON_FONT));
-		TextRender()->SetRenderFlags(ETextRenderFlags::TEXT_RENDER_FLAG_ONLY_ADVANCE_WIDTH | ETextRenderFlags::TEXT_RENDER_FLAG_NO_X_BEARING | ETextRenderFlags::TEXT_RENDER_FLAG_NO_Y_BEARING | ETextRenderFlags::TEXT_RENDER_FLAG_NO_PIXEL_ALIGMENT | ETextRenderFlags::TEXT_RENDER_FLAG_NO_OVERSIZE);
-
-		bool GotNewsOrUpdate = false;
-
-#if defined(CONF_AUTOUPDATE)
-		int State = Updater()->GetCurrentState();
-		bool NeedUpdate = str_comp(Client()->LatestVersion(), "0");
-		if(State == IUpdater::CLEAN && NeedUpdate)
-		{
-			GotNewsOrUpdate = true;
-		}
-#endif
-
-		GotNewsOrUpdate |= (bool)g_Config.m_UiUnreadNews;
-
-		ColorRGBA HomeButtonColorAlert(0, 1, 0, 0.25f);
-		ColorRGBA HomeButtonColorAlertHover(0, 1, 0, 0.5f);
-		ColorRGBA *pHomeButtonColor = NULL;
-		ColorRGBA *pHomeButtonColorHover = NULL;
-
-		const char *pHomeScreenButtonLabel = "\xEF\x80\x95";
-		if(GotNewsOrUpdate)
-		{
-			pHomeScreenButtonLabel = "\xEF\x87\xAA";
-			pHomeButtonColor = &HomeButtonColorAlert;
-			pHomeButtonColorHover = &HomeButtonColorAlertHover;
-		}
-
-		if(DoButton_MenuTab(&s_StartButton, pHomeScreenButtonLabel, false, &Button, IGraphics::CORNER_T, &m_aAnimatorsSmallPage[SMALL_TAB_HOME], pHomeButtonColor, pHomeButtonColor, pHomeButtonColorHover, 10.0f, 0))
-		{
-			m_ShowStart = true;
-			m_DoubleClickIndex = -1;
-		}
-
-		TextRender()->SetRenderFlags(0);
-		TextRender()->SetCurFont(NULL);
-
-		Box.VSplitLeft(10.0f, 0, &Box);
-
 		// offline menus
 		if(m_ActivePage == PAGE_NEWS)
 		{
@@ -841,6 +798,46 @@ int CMenus::RenderMenubar(CUIRect r)
 			m_ControlPageOpening = true;
 		}
 	}
+
+	Box.VSplitRight(33.0f, &Box, &Button);
+	static CButtonContainer s_StartButton;
+
+	TextRender()->SetCurFont(TextRender()->GetFont(TEXT_FONT_ICON_FONT));
+	TextRender()->SetRenderFlags(ETextRenderFlags::TEXT_RENDER_FLAG_ONLY_ADVANCE_WIDTH | ETextRenderFlags::TEXT_RENDER_FLAG_NO_X_BEARING | ETextRenderFlags::TEXT_RENDER_FLAG_NO_Y_BEARING | ETextRenderFlags::TEXT_RENDER_FLAG_NO_PIXEL_ALIGMENT | ETextRenderFlags::TEXT_RENDER_FLAG_NO_OVERSIZE);
+
+	bool GotNewsOrUpdate = false;
+
+#if defined(CONF_AUTOUPDATE)
+	int State = Updater()->GetCurrentState();
+	bool NeedUpdate = str_comp(Client()->LatestVersion(), "0");
+	if(State == IUpdater::CLEAN && NeedUpdate)
+	{
+		GotNewsOrUpdate = true;
+	}
+#endif
+
+	GotNewsOrUpdate |= (bool)g_Config.m_UiUnreadNews;
+
+	ColorRGBA HomeButtonColorAlert(0, 1, 0, 0.25f);
+	ColorRGBA HomeButtonColorAlertHover(0, 1, 0, 0.5f);
+	ColorRGBA *pHomeButtonColor = NULL;
+	ColorRGBA *pHomeButtonColorHover = NULL;
+
+	const char *pHomeScreenButtonLabel = "\xEF\x80\x95";
+	if(GotNewsOrUpdate)
+	{
+		pHomeScreenButtonLabel = "\xEF\x87\xAA";
+		pHomeButtonColor = &HomeButtonColorAlert;
+		pHomeButtonColorHover = &HomeButtonColorAlertHover;
+	}
+
+	if(DoButton_MenuTab(&s_StartButton, pHomeScreenButtonLabel, false, &Button, IGraphics::CORNER_T, &m_aAnimatorsSmallPage[SMALL_TAB_HOME], pHomeButtonColor, pHomeButtonColor, pHomeButtonColorHover, 10.0f, 0))
+	{
+		m_ShowStart = true;
+		m_DoubleClickIndex = -1;
+	}
+
+	Box.VSplitRight(5.0f, &Box, &Button);
 
 	TextRender()->SetCurFont(TextRender()->GetFont(TEXT_FONT_ICON_FONT));
 	TextRender()->SetRenderFlags(ETextRenderFlags::TEXT_RENDER_FLAG_ONLY_ADVANCE_WIDTH | ETextRenderFlags::TEXT_RENDER_FLAG_NO_X_BEARING | ETextRenderFlags::TEXT_RENDER_FLAG_NO_Y_BEARING | ETextRenderFlags::TEXT_RENDER_FLAG_NO_PIXEL_ALIGMENT | ETextRenderFlags::TEXT_RENDER_FLAG_NO_OVERSIZE);


### PR DESCRIPTION
![screenshot-20220926@011155](https://user-images.githubusercontent.com/2335377/192169798-4b9b846f-1ab5-459c-98ab-c6f835404121.png)

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
