### PR TITLE
Make cl_default_zoom a float

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -4167,6 +4167,11 @@ int CClient::HandleChecksum(int Conn, CUuid Uuid, CUnpacker *pUnpacker)
 	{ \
 		m_Checksum.m_Data.m_Config.m_##Name = g_Config.m_##Name; \
 	}
+#define MACRO_CONFIG_FLOAT(Name, ScriptName, Def, Min, Max, Flags, Desc) \
+	if(CHECKSUM_RECORD(Flags)) \
+	{ \
+		m_Checksum.m_Data.m_Config.m_##Name = g_Config.m_##Name; \
+	}
 #define MACRO_CONFIG_COL(Name, ScriptName, Def, Flags, Desc) \
 	if(CHECKSUM_RECORD(Flags)) \
 	{ \
@@ -4180,6 +4185,7 @@ int CClient::HandleChecksum(int Conn, CUuid Uuid, CUnpacker *pUnpacker)
 #include <engine/shared/config_variables.h>
 #undef CHECKSUM_RECORD
 #undef MACRO_CONFIG_INT
+#undef MACRO_CONFIG_FLOAT
 #undef MACRO_CONFIG_COL
 #undef MACRO_CONFIG_STR
 	}

--- a/src/engine/shared/config.cpp
+++ b/src/engine/shared/config.cpp
@@ -29,12 +29,14 @@ void CConfigManager::Init()
 void CConfigManager::Reset()
 {
 #define MACRO_CONFIG_INT(Name, ScriptName, def, min, max, flags, desc) g_Config.m_##Name = def;
+#define MACRO_CONFIG_FLOAT(Name, ScriptName, def, min, max, flags, desc) MACRO_CONFIG_INT(Name, ScriptName, def, min, max, flags, desc)
 #define MACRO_CONFIG_COL(Name, ScriptName, def, flags, desc) MACRO_CONFIG_INT(Name, ScriptName, def, 0, 0, flags, desc)
 #define MACRO_CONFIG_STR(Name, ScriptName, len, def, flags, desc) str_copy(g_Config.m_##Name, def, len);
 
 #include "config_variables.h"
 
 #undef MACRO_CONFIG_INT
+#undef MACRO_CONFIG_FLOAT
 #undef MACRO_CONFIG_COL
 #undef MACRO_CONFIG_STR
 }
@@ -47,6 +49,7 @@ void CConfigManager::Reset(const char *pScriptName)
 		g_Config.m_##Name = def; \
 		return; \
 	};
+#define MACRO_CONFIG_FLOAT(Name, ScriptName, def, min, max, flags, desc) MACRO_CONFIG_INT(Name, ScriptName, def, min, max, flags, desc)
 #define MACRO_CONFIG_COL(Name, ScriptName, def, flags, desc) MACRO_CONFIG_INT(Name, ScriptName, def, 0, 0, flags, desc)
 #define MACRO_CONFIG_STR(Name, ScriptName, len, def, flags, desc) \
 	if(str_comp(pScriptName, #ScriptName) == 0) \
@@ -58,6 +61,7 @@ void CConfigManager::Reset(const char *pScriptName)
 #include "config_variables.h"
 
 #undef MACRO_CONFIG_INT
+#undef MACRO_CONFIG_FLOAT
 #undef MACRO_CONFIG_COL
 #undef MACRO_CONFIG_STR
 }
@@ -87,6 +91,12 @@ bool CConfigManager::Save()
 		str_format(aLineBuf, sizeof(aLineBuf), "%s %i", #ScriptName, g_Config.m_##Name); \
 		WriteLine(aLineBuf); \
 	}
+#define MACRO_CONFIG_FLOAT(Name, ScriptName, def, min, max, flags, desc) \
+	if((flags)&CFGFLAG_SAVE && g_Config.m_##Name != (def)) \
+	{ \
+		str_format(aLineBuf, sizeof(aLineBuf), "%s %f", #ScriptName, g_Config.m_##Name); \
+		WriteLine(aLineBuf); \
+	}
 #define MACRO_CONFIG_COL(Name, ScriptName, def, flags, desc) \
 	if((flags)&CFGFLAG_SAVE && g_Config.m_##Name != (def)) \
 	{ \
@@ -104,6 +114,7 @@ bool CConfigManager::Save()
 #include "config_variables.h"
 
 #undef MACRO_CONFIG_INT
+#undef MACRO_CONFIG_FLOAT
 #undef MACRO_CONFIG_COL
 #undef MACRO_CONFIG_STR
 

--- a/src/engine/shared/config.h
+++ b/src/engine/shared/config.h
@@ -15,10 +15,12 @@ class CConfig
 {
 public:
 #define MACRO_CONFIG_INT(Name, ScriptName, Def, Min, Max, Save, Desc) int m_##Name;
+#define MACRO_CONFIG_FLOAT(Name, ScriptName, Def, Min, Max, Save, Desc) float m_##Name;
 #define MACRO_CONFIG_COL(Name, ScriptName, Def, Save, Desc) unsigned m_##Name;
 #define MACRO_CONFIG_STR(Name, ScriptName, Len, Def, Save, Desc) char m_##Name[Len]; // Flawfinder: ignore
 #include "config_variables.h"
 #undef MACRO_CONFIG_INT
+#undef MACRO_CONFIG_FLOAT
 #undef MACRO_CONFIG_COL
 #undef MACRO_CONFIG_STR
 };

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -3184,7 +3184,7 @@ void CMenus::RenderSettingsDDNet(CUIRect MainView)
 	Right.HSplitTop(20.0f, &Label, &Right);
 	Label.VSplitLeft(130.0f, &Label, &Button);
 	char aBuf[256];
-	str_format(aBuf, sizeof(aBuf), "%s: %i", Localize("Default zoom"), g_Config.m_ClDefaultZoom);
+	str_format(aBuf, sizeof(aBuf), "%s: %.2f", Localize("Default zoom"), g_Config.m_ClDefaultZoom);
 	UI()->DoLabel(&Label, aBuf, 14.0f, TEXTALIGN_LEFT);
 	g_Config.m_ClDefaultZoom = static_cast<int>(UI()->DoScrollbarH(&g_Config.m_ClDefaultZoom, &Button, g_Config.m_ClDefaultZoom / 20.0f) * 20.0f + 0.1f);
 

--- a/src/game/server/teehistorian.cpp
+++ b/src/game/server/teehistorian.cpp
@@ -142,6 +142,17 @@ void CTeeHistorian::WriteHeader(const CGameInfo *pGameInfo)
 		First = false; \
 	}
 
+#define MACRO_CONFIG_FLOAT(Name, ScriptName, Def, Min, Max, Flags, Desc) \
+	if((Flags)&CFGFLAG_SERVER && !((Flags)&CFGFLAG_NONTEEHISTORIC) && pGameInfo->m_pConfig->m_##Name != (Def)) \
+	{ \
+		str_format(aJson, sizeof(aJson), "%s\"%s\":\"%f\"", \
+			First ? "" : ",", \
+			E(aBuffer1, #ScriptName), \
+			pGameInfo->m_pConfig->m_##Name); \
+		Write(aJson, str_length(aJson)); \
+		First = false; \
+	}
+
 #define MACRO_CONFIG_COL(Name, ScriptName, Def, Save, Desc) MACRO_CONFIG_INT(Name, ScriptName, Def, 0, 0, Save, Desc)
 
 #define MACRO_CONFIG_STR(Name, ScriptName, Len, Def, Flags, Desc) \
@@ -158,6 +169,7 @@ void CTeeHistorian::WriteHeader(const CGameInfo *pGameInfo)
 #include <engine/shared/config_variables.h>
 
 #undef MACRO_CONFIG_INT
+#undef MACRO_CONFIG_FLOAT
 #undef MACRO_CONFIG_COL
 #undef MACRO_CONFIG_STR
 

--- a/src/game/variables.h
+++ b/src/game/variables.h
@@ -7,6 +7,7 @@
 #ifndef MACRO_CONFIG_INT
 #error "The config macros must be defined"
 #define MACRO_CONFIG_INT(Name, ScriptName, Def, Min, Max, Save, Desc) ;
+#define MACRO_CONFIG_FLOAT(Name, ScriptName, Def, Min, Max, Save, Desc) ;
 #define MACRO_CONFIG_COL(Name, ScriptName, Def, Save, Desc) ;
 #define MACRO_CONFIG_STR(Name, ScriptName, Len, Def, Save, Desc) ;
 #endif
@@ -111,7 +112,7 @@ MACRO_CONFIG_INT(ClDownloadCommunitySkins, cl_download_community_skins, 0, 0, 1,
 MACRO_CONFIG_INT(ClAutoStatboardScreenshot, cl_auto_statboard_screenshot, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Automatically take game over statboard screenshot")
 MACRO_CONFIG_INT(ClAutoStatboardScreenshotMax, cl_auto_statboard_screenshot_max, 10, 0, 1000, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Maximum number of automatically created statboard screenshots (0 = no limit)")
 
-MACRO_CONFIG_INT(ClDefaultZoom, cl_default_zoom, 10, 0, 20, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Default zoom level (10 default, min 0, max 20)")
+MACRO_CONFIG_FLOAT(ClDefaultZoom, cl_default_zoom, 10, 0, 20, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Default zoom level")
 MACRO_CONFIG_INT(ClSmoothZoomTime, cl_smooth_zoom_time, 250, 0, 5000, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Time of smooth zoom animation in ms (0 for off)")
 MACRO_CONFIG_INT(ClLimitMaxZoomLevel, cl_limit_max_zoom_level, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Specifies, if zooming should be limited or not (0 = no limit)")
 

--- a/src/test/teehistorian.cpp
+++ b/src/test/teehistorian.cpp
@@ -33,12 +33,14 @@ protected:
 		mem_zero(&m_Config, sizeof(m_Config));
 #define MACRO_CONFIG_INT(Name, ScriptName, Def, Min, Max, Save, Desc) \
 	m_Config.m_##Name = (Def);
+#define MACRO_CONFIG_FLOAT(Name, ScriptName, Def, Min, Max, Save, Desc) MACRO_CONFIG_INT(Name, ScriptName, Def, Min, Max, Save, Desc)
 #define MACRO_CONFIG_COL(Name, ScriptName, Def, Save, Desc) MACRO_CONFIG_INT(Name, ScriptName, Def, 0, 0, Save, Desc)
 #define MACRO_CONFIG_STR(Name, ScriptName, Len, Def, Save, Desc) \
 	str_copy(m_Config.m_##Name, (Def), sizeof(m_Config.m_##Name));
 #include <engine/shared/config_variables.h>
 #undef MACRO_CONFIG_STR
 #undef MACRO_CONFIG_COL
+#undef MACRO_CONFIG_FLOAT
 #undef MACRO_CONFIG_INT
 
 		RegisterUuids(&m_UuidManager);


### PR DESCRIPTION
Uses new MACRO_CONFIG_FLOAT

As suggested by Ar1gin
![Screenshot 2022-09-28 at 19 05 09](https://user-images.githubusercontent.com/2335377/192845286-c5b6d7a7-8aa1-4e66-9028-4bc47af2e452.png)

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
