### PR TITLE
FIX: Announce gametype "Gores" & parse them correctly in the client

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -1591,7 +1591,7 @@ bool CClient::ShouldSendChatTimeoutCodeHeuristic()
 	{
 		return false;
 	}
-	return IsDDNet(&m_CurrentServerInfo);
+	return (IsDDNet(&m_CurrentServerInfo) || IsGores(&m_CurrentServerInfo));
 }
 
 static CServerCapabilities GetServerCapabilities(int Version, int Flags)

--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -1541,7 +1541,7 @@ bool IsFNG(const CServerInfo *pInfo)
 
 bool IsRace(const CServerInfo *pInfo)
 {
-	return str_find_nocase(pInfo->m_aGameType, "race") || str_find_nocase(pInfo->m_aGameType, "fastcap");
+	return str_find_nocase(pInfo->m_aGameType, "race") || str_find_nocase(pInfo->m_aGameType, "fastcap") || IsGores(pInfo);
 }
 
 bool IsFastCap(const CServerInfo *pInfo)
@@ -1575,11 +1575,16 @@ bool IsDDNet(const CServerInfo *pInfo)
 	return str_find_nocase(pInfo->m_aGameType, "ddracenet") || str_find_nocase(pInfo->m_aGameType, "ddnet");
 }
 
+bool IsGores(const CServerInfo *pInfo)
+{
+	return str_find_nocase(pInfo->m_aGameType, "gores");
+}
+
 // other
 
 bool Is64Player(const CServerInfo *pInfo)
 {
-	return str_find(pInfo->m_aGameType, "64") || str_find(pInfo->m_aName, "64") || IsDDNet(pInfo);
+	return str_find(pInfo->m_aGameType, "64") || str_find(pInfo->m_aName, "64") || IsDDNet(pInfo) || IsGores(pInfo);
 }
 
 bool IsPlus(const CServerInfo *pInfo)

--- a/src/engine/serverbrowser.h
+++ b/src/engine/serverbrowser.h
@@ -95,6 +95,7 @@ bool IsDDRace(const CServerInfo *pInfo);
 bool IsDDNet(const CServerInfo *pInfo);
 bool IsBlockWorlds(const CServerInfo *pInfo);
 bool IsCity(const CServerInfo *pInfo);
+bool IsGores(const CServerInfo *pInfo);
 
 bool Is64Player(const CServerInfo *pInfo);
 bool IsPlus(const CServerInfo *pInfo);

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -459,6 +459,8 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 						hsl = ColorHSLA(0.58f, 1.0f, 0.75f);
 					else if(IsDDRace(pItem))
 						hsl = ColorHSLA(0.75f, 1.0f, 0.75f);
+					else if(IsGores(pItem))
+						hsl = ColorHSLA(0.525f, 1.0f, 0.75f);
 					else if(IsRace(pItem))
 						hsl = ColorHSLA(0.46f, 1.0f, 0.75f);
 


### PR DESCRIPTION
Adding new gamemode "Gores" to the client with its own color and parse scores correctly in the serverbrowser

![65b587ffe87f68cb98f86ee3a6e21166](https://user-images.githubusercontent.com/105295486/193410660-5e757fd4-449f-4d0a-a719-4a0cc1e5a01e.png)

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
