### PR TITLE
Handle non-default Windows directory in `os_version_str`, print the operating system version on client/server launch

### DIFF
--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -4113,27 +4113,27 @@ int secure_rand_below(int below)
 int os_version_str(char *version, int length)
 {
 #if defined(CONF_FAMILY_WINDOWS)
-	const char *DLL = "C:\\Windows\\System32\\user32.dll";
+	const WCHAR *module_path = L"kernel32.dll";
 	DWORD handle;
-	DWORD size = GetFileVersionInfoSizeA(DLL, &handle);
+	DWORD size = GetFileVersionInfoSizeW(module_path, &handle);
 	if(!size)
 	{
 		return 1;
 	}
 	void *data = malloc(size);
-	if(!GetFileVersionInfoA(DLL, handle, size, data))
+	if(!GetFileVersionInfoW(module_path, handle, size, data))
 	{
 		free(data);
 		return 1;
 	}
 	VS_FIXEDFILEINFO *fileinfo;
 	UINT unused;
-	if(!VerQueryValueA(data, "\\", (void **)&fileinfo, &unused))
+	if(!VerQueryValueW(data, L"\\", (void **)&fileinfo, &unused))
 	{
 		free(data);
 		return 1;
 	}
-	str_format(version, length, "Windows %d.%d.%d.%d",
+	str_format(version, length, "Windows %hu.%hu.%hu.%hu",
 		HIWORD(fileinfo->dwProductVersionMS),
 		LOWORD(fileinfo->dwProductVersionMS),
 		HIWORD(fileinfo->dwProductVersionLS),

--- a/src/engine/shared/engine.cpp
+++ b/src/engine/shared/engine.cpp
@@ -72,6 +72,12 @@ public:
 			dbg_msg("engine", "unknown endian");
 #endif
 
+			char aVersionStr[128];
+			if(!os_version_str(aVersionStr, sizeof(aVersionStr)))
+			{
+				dbg_msg("engine", "operation system version: %s", aVersionStr);
+			}
+
 			// init the network
 			net_init();
 			CNetBase::Init();


### PR DESCRIPTION

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
