### PR TITLE
Only show ingame hint in Game tab

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -1377,20 +1377,34 @@ int CMenus::Render()
 			if(Client()->State() != IClient::STATE_OFFLINE)
 			{
 				if(m_GamePage == PAGE_GAME)
+				{
 					RenderGame(MainView);
+					RenderIngameHint();
+				}
 				else if(m_GamePage == PAGE_PLAYERS)
+				{
 					RenderPlayers(MainView);
+				}
 				else if(m_GamePage == PAGE_SERVER_INFO)
+				{
 					RenderServerInfo(MainView);
+				}
 				else if(m_GamePage == PAGE_NETWORK)
+				{
 					RenderInGameNetwork(MainView);
+				}
 				else if(m_GamePage == PAGE_GHOST)
+				{
 					RenderGhost(MainView);
+				}
 				else if(m_GamePage == PAGE_CALLVOTE)
+				{
 					RenderServerControl(MainView);
+				}
 				else if(m_GamePage == PAGE_SETTINGS)
+				{
 					RenderSettings(MainView);
-				RenderIngameHint();
+				}
 			}
 			else if(m_MenuPage == PAGE_NEWS)
 			{


### PR DESCRIPTION
Since it looks ugly overlaid over the other tabs

<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
