### PR TITLE
Inline `Is(GameType)` functions and remove support for legacy 64 player info protocol

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -1561,15 +1561,6 @@ void CClient::ProcessServerInfo(int RawType, NETADDR *pFrom, const void *pData, 
 #undef GET_INT
 }
 
-bool CClient::ShouldSendChatTimeoutCodeHeuristic()
-{
-	if(m_ServerSentCapabilities)
-	{
-		return false;
-	}
-	return str_find_nocase(m_CurrentServerInfo.m_aGameType, "ddracenet") || str_find_nocase(m_CurrentServerInfo.m_aGameType, "ddnet");
-}
-
 static CServerCapabilities GetServerCapabilities(int Version, int Flags)
 {
 	CServerCapabilities Result;
@@ -2156,7 +2147,7 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket, int Conn, bool Dummy)
 
 					if(m_aReceivedSnapshots[Conn] > 50 && !m_aCodeRunAfterJoin[Conn])
 					{
-						if(m_ServerCapabilities.m_ChatTimeoutCode || ShouldSendChatTimeoutCodeHeuristic())
+						if(m_ServerCapabilities.m_ChatTimeoutCode)
 						{
 							CNetMsg_Cl_Say MsgP;
 							MsgP.m_Team = 0;

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -1578,7 +1578,7 @@ bool CClient::ShouldSendChatTimeoutCodeHeuristic()
 	{
 		return false;
 	}
-	return IsDDNet(&m_CurrentServerInfo);
+	return str_find_nocase(m_CurrentServerInfo.m_aGameType, "ddracenet") || str_find_nocase(m_CurrentServerInfo.m_aGameType, "ddnet");
 }
 
 static CServerCapabilities GetServerCapabilities(int Version, int Flags)

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -1345,8 +1345,6 @@ void CClient::ProcessConnlessPacket(CNetChunk *pPacket)
 		int Type = -1;
 		if(mem_comp(pPacket->m_pData, SERVERBROWSE_INFO, sizeof(SERVERBROWSE_INFO)) == 0)
 			Type = SERVERINFO_VANILLA;
-		else if(mem_comp(pPacket->m_pData, SERVERBROWSE_INFO_64_LEGACY, sizeof(SERVERBROWSE_INFO_64_LEGACY)) == 0)
-			Type = SERVERINFO_64_LEGACY;
 		else if(mem_comp(pPacket->m_pData, SERVERBROWSE_INFO_EXTENDED, sizeof(SERVERBROWSE_INFO_EXTENDED)) == 0)
 			Type = SERVERINFO_EXTENDED;
 		else if(mem_comp(pPacket->m_pData, SERVERBROWSE_INFO_EXTENDED_MORE, sizeof(SERVERBROWSE_INFO_EXTENDED_MORE)) == 0)
@@ -1375,8 +1373,7 @@ void CClient::ProcessServerInfo(int RawType, NETADDR *pFrom, const void *pData, 
 
 	CServerInfo Info = {0};
 	int SavedType = SavedServerInfoType(RawType);
-	if((SavedType == SERVERINFO_64_LEGACY || SavedType == SERVERINFO_EXTENDED) &&
-		pEntry && pEntry->m_GotInfo && SavedType == pEntry->m_Info.m_Type)
+	if(SavedType == SERVERINFO_EXTENDED && pEntry && pEntry->m_GotInfo && SavedType == pEntry->m_Info.m_Type)
 	{
 		Info = pEntry->m_Info;
 	}
@@ -1391,7 +1388,6 @@ void CClient::ProcessServerInfo(int RawType, NETADDR *pFrom, const void *pData, 
 #define GET_STRING(array) str_copy(array, Up.GetString(CUnpacker::SANITIZE_CC | CUnpacker::SKIP_START_WHITESPACES), sizeof(array))
 #define GET_INT(integer) (integer) = str_toint(Up.GetString())
 
-	int Offset = 0; // Only used for SavedType == SERVERINFO_64_LEGACY
 	int Token;
 	int PacketNo = 0; // Only used if SavedType == SERVERINFO_EXTENDED
 
@@ -1449,13 +1445,6 @@ void CClient::ProcessServerInfo(int RawType, NETADDR *pFrom, const void *pData, 
 			dbg_assert(false, "unknown serverinfo type");
 		}
 
-		if(SavedType == SERVERINFO_64_LEGACY)
-			Offset = Up.GetInt();
-
-		// Check for valid offset.
-		if(Offset < 0)
-			return;
-
 		if(SavedType == SERVERINFO_EXTENDED)
 			PacketNo = 0;
 	}
@@ -1478,7 +1467,7 @@ void CClient::ProcessServerInfo(int RawType, NETADDR *pFrom, const void *pData, 
 	}
 
 	bool IgnoreError = false;
-	for(int i = Offset; i < MAX_CLIENTS && Info.m_NumReceivedClients < MAX_CLIENTS && !Up.Error(); i++)
+	for(int i = 0; i < MAX_CLIENTS && Info.m_NumReceivedClients < MAX_CLIENTS && !Up.Error(); i++)
 	{
 		CServerInfo::CClient *pClient = &Info.m_aClients[Info.m_NumReceivedClients];
 		GET_STRING(pClient->m_aName);

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -251,8 +251,6 @@ class CClient : public IClient, public CDemoPlayer::IListener
 	bool m_ServerSentCapabilities;
 	CServerCapabilities m_ServerCapabilities;
 
-	bool ShouldSendChatTimeoutCodeHeuristic();
-
 	CServerInfo m_CurrentServerInfo;
 	int64_t m_CurrentServerInfoRequestTime; // >= 0 should request, == -1 got info
 

--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -1564,70 +1564,7 @@ bool CServerInfo::ParseLocation(int *pResult, const char *pString)
 	return true;
 }
 
-bool IsVanilla(const CServerInfo *pInfo)
-{
-	return !str_comp(pInfo->m_aGameType, "DM") || !str_comp(pInfo->m_aGameType, "TDM") || !str_comp(pInfo->m_aGameType, "CTF");
-}
-
-bool IsCatch(const CServerInfo *pInfo)
-{
-	return str_find_nocase(pInfo->m_aGameType, "catch");
-}
-
-bool IsInsta(const CServerInfo *pInfo)
-{
-	return str_find_nocase(pInfo->m_aGameType, "idm") || str_find_nocase(pInfo->m_aGameType, "itdm") || str_find_nocase(pInfo->m_aGameType, "ictf");
-}
-
-bool IsFNG(const CServerInfo *pInfo)
-{
-	return str_find_nocase(pInfo->m_aGameType, "fng");
-}
-
-bool IsRace(const CServerInfo *pInfo)
-{
-	return str_find_nocase(pInfo->m_aGameType, "race") || str_find_nocase(pInfo->m_aGameType, "fastcap");
-}
-
-bool IsFastCap(const CServerInfo *pInfo)
-{
-	return str_find_nocase(pInfo->m_aGameType, "fastcap");
-}
-
-bool IsBlockInfectionZ(const CServerInfo *pInfo)
-{
-	return str_find_nocase(pInfo->m_aGameType, "blockz") ||
-	       str_find_nocase(pInfo->m_aGameType, "infectionz");
-}
-
-bool IsBlockWorlds(const CServerInfo *pInfo)
-{
-	return (str_startswith(pInfo->m_aGameType, "bw  ")) || (str_comp_nocase(pInfo->m_aGameType, "bw") == 0);
-}
-
-bool IsCity(const CServerInfo *pInfo)
-{
-	return str_find_nocase(pInfo->m_aGameType, "city");
-}
-
-bool IsDDRace(const CServerInfo *pInfo)
-{
-	return str_find_nocase(pInfo->m_aGameType, "ddrace") || str_find_nocase(pInfo->m_aGameType, "mkrace");
-}
-
-bool IsDDNet(const CServerInfo *pInfo)
-{
-	return str_find_nocase(pInfo->m_aGameType, "ddracenet") || str_find_nocase(pInfo->m_aGameType, "ddnet");
-}
-
-// other
-
 bool Is64Player(const CServerInfo *pInfo)
 {
-	return str_find(pInfo->m_aGameType, "64") || str_find(pInfo->m_aName, "64") || IsDDNet(pInfo);
-}
-
-bool IsPlus(const CServerInfo *pInfo)
-{
-	return str_find(pInfo->m_aGameType, "+");
+	return str_find(pInfo->m_aGameType, "64") || str_find(pInfo->m_aName, "64") || str_find_nocase(pInfo->m_aGameType, "ddracenet") || str_find_nocase(pInfo->m_aGameType, "ddnet");
 }

--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -720,12 +720,6 @@ void CServerBrowser::OnServerInfoUpdate(const NETADDR &Addr, int Token, const CS
 	{
 		SetInfo(pEntry, *pInfo);
 		pEntry->m_Info.m_Latency = minimum(static_cast<int>((time_get() - m_BroadcastTime) * 1000 / time_freq()), 999);
-		if(pInfo->m_Type == SERVERINFO_VANILLA && Is64Player(pInfo))
-		{
-			pEntry->m_Request64Legacy = true;
-			// Force a quick update.
-			RequestImpl64(Addr, pEntry);
-		}
 	}
 	else if(pEntry->m_RequestTime > 0)
 	{
@@ -747,16 +741,6 @@ void CServerBrowser::OnServerInfoUpdate(const NETADDR &Addr, int Token, const CS
 			SetLatency(Addr, Latency);
 		}
 		pEntry->m_RequestTime = -1; // Request has been answered
-
-		if(!pEntry->m_RequestIgnoreInfo)
-		{
-			if(pInfo->m_Type == SERVERINFO_VANILLA && Is64Player(pInfo))
-			{
-				pEntry->m_Request64Legacy = true;
-				// Force a quick update.
-				RequestImpl64(Addr, pEntry);
-			}
-		}
 	}
 	RemoveRequest(pEntry);
 
@@ -865,35 +849,6 @@ void CServerBrowser::RequestImpl(const NETADDR &Addr, CServerEntry *pEntry, int 
 	mem_zero(&Packet.m_aExtraData, sizeof(Packet.m_aExtraData));
 	Packet.m_aExtraData[0] = GetExtraToken(Token) >> 8;
 	Packet.m_aExtraData[1] = GetExtraToken(Token) & 0xff;
-
-	m_pNetClient->Send(&Packet);
-
-	if(pEntry)
-		pEntry->m_RequestTime = time_get();
-}
-
-void CServerBrowser::RequestImpl64(const NETADDR &Addr, CServerEntry *pEntry) const
-{
-	unsigned char aBuffer[sizeof(SERVERBROWSE_GETINFO_64_LEGACY) + 1];
-	CNetChunk Packet;
-
-	if(g_Config.m_Debug)
-	{
-		char aAddrStr[NETADDR_MAXSTRSIZE];
-		net_addr_str(&Addr, aAddrStr, sizeof(aAddrStr), true);
-		char aBuf[256];
-		str_format(aBuf, sizeof(aBuf), "requesting server info 64 from %s", aAddrStr);
-		m_pConsole->Print(IConsole::OUTPUT_LEVEL_DEBUG, "client_srvbrowse", aBuf);
-	}
-
-	mem_copy(aBuffer, SERVERBROWSE_GETINFO_64_LEGACY, sizeof(SERVERBROWSE_GETINFO_64_LEGACY));
-	aBuffer[sizeof(SERVERBROWSE_GETINFO_64_LEGACY)] = GetBasicToken(GenerateToken(Addr));
-
-	Packet.m_ClientID = -1;
-	Packet.m_Address = Addr;
-	Packet.m_Flags = NETSENDFLAG_CONNLESS;
-	Packet.m_DataSize = sizeof(aBuffer);
-	Packet.m_pData = aBuffer;
 
 	m_pNetClient->Send(&Packet);
 
@@ -1123,10 +1078,7 @@ void CServerBrowser::Update(bool ForceResort)
 
 		if(pEntry->m_RequestTime == 0)
 		{
-			if(pEntry->m_Request64Legacy)
-				RequestImpl64(pEntry->m_Info.m_aAddresses[0], pEntry);
-			else
-				RequestImpl(pEntry->m_Info.m_aAddresses[0], pEntry, nullptr, nullptr, false);
+			RequestImpl(pEntry->m_Info.m_aAddresses[0], pEntry, nullptr, nullptr, false);
 		}
 
 		Count++;
@@ -1562,9 +1514,4 @@ bool CServerInfo::ParseLocation(int *pResult, const char *pString)
 		}
 	}
 	return true;
-}
-
-bool Is64Player(const CServerInfo *pInfo)
-{
-	return str_find(pInfo->m_aGameType, "64") || str_find(pInfo->m_aName, "64") || str_find_nocase(pInfo->m_aGameType, "ddracenet") || str_find_nocase(pInfo->m_aGameType, "ddnet");
 }

--- a/src/engine/client/serverbrowser.h
+++ b/src/engine/client/serverbrowser.h
@@ -32,7 +32,6 @@ public:
 		int64_t m_RequestTime;
 		bool m_RequestIgnoreInfo;
 		int m_GotInfo;
-		bool m_Request64Legacy;
 		CServerInfo m_Info;
 
 		CServerEntry *m_pPrevReq; // request list
@@ -131,7 +130,6 @@ public:
 	void SetBaseInfo(class CNetClient *pClient, const char *pNetVersion);
 	void OnInit();
 
-	void RequestImpl64(const NETADDR &Addr, CServerEntry *pEntry) const;
 	void QueueRequest(CServerEntry *pEntry);
 	CServerEntry *Find(const NETADDR &Addr);
 	int GetCurrentType() override { return m_ServerlistType; }

--- a/src/engine/serverbrowser.h
+++ b/src/engine/serverbrowser.h
@@ -85,19 +85,7 @@ public:
 	static bool ParseLocation(int *pResult, const char *pString);
 };
 
-bool IsVanilla(const CServerInfo *pInfo);
-bool IsCatch(const CServerInfo *pInfo);
-bool IsInsta(const CServerInfo *pInfo);
-bool IsFNG(const CServerInfo *pInfo);
-bool IsRace(const CServerInfo *pInfo);
-bool IsFastCap(const CServerInfo *pInfo);
-bool IsDDRace(const CServerInfo *pInfo);
-bool IsDDNet(const CServerInfo *pInfo);
-bool IsBlockWorlds(const CServerInfo *pInfo);
-bool IsCity(const CServerInfo *pInfo);
-
 bool Is64Player(const CServerInfo *pInfo);
-bool IsPlus(const CServerInfo *pInfo);
 
 class IServerBrowser : public IInterface
 {

--- a/src/engine/serverbrowser.h
+++ b/src/engine/serverbrowser.h
@@ -85,8 +85,6 @@ public:
 	static bool ParseLocation(int *pResult, const char *pString);
 };
 
-bool Is64Player(const CServerInfo *pInfo);
-
 class IServerBrowser : public IInterface
 {
 	MACRO_INTERFACE("serverbrowser", 0)

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -464,19 +464,19 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 				{
 					ColorHSLA hsl = ColorHSLA(1.0f, 1.0f, 1.0f);
 
-					if(IsVanilla(pItem))
+					if(str_comp(pItem->m_aGameType, "DM") == 0 || str_comp(pItem->m_aGameType, "TDM") == 0 || str_comp(pItem->m_aGameType, "CTF") == 0)
 						hsl = ColorHSLA(0.33f, 1.0f, 0.75f);
-					else if(IsCatch(pItem))
+					else if(str_find_nocase(pItem->m_aGameType, "catch"))
 						hsl = ColorHSLA(0.17f, 1.0f, 0.75f);
-					else if(IsInsta(pItem))
+					else if(str_find_nocase(pItem->m_aGameType, "idm") || str_find_nocase(pItem->m_aGameType, "itdm") || str_find_nocase(pItem->m_aGameType, "ictf"))
 						hsl = ColorHSLA(0.00f, 1.0f, 0.75f);
-					else if(IsFNG(pItem))
+					else if(str_find_nocase(pItem->m_aGameType, "fng"))
 						hsl = ColorHSLA(0.83f, 1.0f, 0.75f);
-					else if(IsDDNet(pItem))
+					else if(str_find_nocase(pItem->m_aGameType, "ddracenet") || str_find_nocase(pItem->m_aGameType, "ddnet"))
 						hsl = ColorHSLA(0.58f, 1.0f, 0.75f);
-					else if(IsDDRace(pItem))
+					else if(str_find_nocase(pItem->m_aGameType, "ddrace") || str_find_nocase(pItem->m_aGameType, "mkrace"))
 						hsl = ColorHSLA(0.75f, 1.0f, 0.75f);
-					else if(IsRace(pItem))
+					else if(str_find_nocase(pItem->m_aGameType, "race") || str_find_nocase(pItem->m_aGameType, "fastcap"))
 						hsl = ColorHSLA(0.46f, 1.0f, 0.75f);
 
 					ColorRGBA rgb = color_cast<ColorRGBA>(hsl);
@@ -1167,7 +1167,7 @@ void CMenus::RenderServerbrowserServerDetail(CUIRect View)
 
 			if(!pSelectedServer->m_aClients[i].m_Player)
 				str_copy(aTemp, "SPEC");
-			else if(IsRace(pSelectedServer) && g_Config.m_ClDDRaceScoreBoard)
+			else if((str_find_nocase(pSelectedServer->m_aGameType, "race") || str_find_nocase(pSelectedServer->m_aGameType, "fastcap")) && g_Config.m_ClDDRaceScoreBoard)
 			{
 				if(pSelectedServer->m_aClients[i].m_Score == -9999 || pSelectedServer->m_aClients[i].m_Score == 0)
 					aTemp[0] = 0;

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1009,15 +1009,16 @@ static CGameInfo GetGameInfo(const CNetObj_GameInfoEx *pInfoEx, int InfoExSize, 
 	bool FDDrace;
 	if(Version < 1)
 	{
-		Race = IsRace(pFallbackServerInfo);
-		FastCap = IsFastCap(pFallbackServerInfo);
-		FNG = IsFNG(pFallbackServerInfo);
-		DDRace = IsDDRace(pFallbackServerInfo);
-		DDNet = IsDDNet(pFallbackServerInfo);
-		BlockWorlds = IsBlockWorlds(pFallbackServerInfo);
-		City = IsCity(pFallbackServerInfo);
-		Vanilla = IsVanilla(pFallbackServerInfo);
-		Plus = IsPlus(pFallbackServerInfo);
+		const char *pGameType = pFallbackServerInfo->m_aGameType;
+		Race = str_find_nocase(pGameType, "race") || str_find_nocase(pGameType, "fastcap");
+		FastCap = str_find_nocase(pGameType, "fastcap");
+		FNG = str_find_nocase(pGameType, "fng");
+		DDRace = str_find_nocase(pGameType, "ddrace") || str_find_nocase(pGameType, "mkrace");
+		DDNet = str_find_nocase(pGameType, "ddracenet") || str_find_nocase(pGameType, "ddnet");
+		BlockWorlds = str_startswith(pGameType, "bw  ") || str_comp_nocase(pGameType, "bw") == 0;
+		City = str_find_nocase(pGameType, "city");
+		Vanilla = str_comp(pGameType, "DM") == 0 || str_comp(pGameType, "TDM") == 0 || str_comp(pGameType, "CTF") == 0;
+		Plus = str_find(pGameType, "+");
 		FDDrace = false;
 	}
 	else


### PR DESCRIPTION
## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
