### PR TITLE
Initialize the Windows COM library on all threads, ensure Windows DDE conversations are finished in `open_link`

### DIFF
--- a/src/base/system.h
+++ b/src/base/system.h
@@ -2563,11 +2563,14 @@ public:
 /**
  * This is a RAII wrapper to initialize/uninitialize the Windows COM library,
  * which may be necessary for using the open_file and open_link functions.
+ * Must be used on every thread. It's automatically used on threads created
+ * with thread_init. Pass true to the constructor on threads that own a
+ * window (i.e. pump a message queue).
  */
 class CWindowsComLifecycle
 {
 public:
-	CWindowsComLifecycle();
+	CWindowsComLifecycle(bool HasWindow);
 	~CWindowsComLifecycle();
 };
 #endif

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -4574,7 +4574,7 @@ int main(int argc, const char **argv)
 #if defined(CONF_PLATFORM_ANDROID)
 	const char **argv = const_cast<const char **>(argv2);
 #elif defined(CONF_FAMILY_WINDOWS)
-	CWindowsComLifecycle WindowsComLifecycle;
+	CWindowsComLifecycle WindowsComLifecycle(true);
 #endif
 	CCmdlineFix CmdlineFix(&argc, &argv);
 	bool Silent = false;

--- a/src/engine/server/main.cpp
+++ b/src/engine/server/main.cpp
@@ -62,6 +62,10 @@ int main(int argc, const char **argv)
 		}
 	}
 
+#if defined(CONF_FAMILY_WINDOWS)
+	CWindowsComLifecycle WindowsComLifecycle(false);
+#endif
+
 	std::vector<std::shared_ptr<ILogger>> vpLoggers;
 #if defined(CONF_PLATFORM_ANDROID)
 	vpLoggers.push_back(std::shared_ptr<ILogger>(log_logger_android()));


### PR DESCRIPTION


## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
