### PR TITLE
Fix config_directory.bat (whitespaces in the path)

### DIFF
--- a/other/config_directory.bat
+++ b/other/config_directory.bat
@@ -1,5 +1,14 @@
+@echo off
+
 if exist "%APPDATA%\DDNet\" (
-	@start explorer "%APPDATA%\DDNet\"
-) else (
-	@start explorer "%APPDATA%\Teeworlds\"
+	start explorer "%APPDATA%\DDNet\"
+	exit /b
 )
+
+if exist "%APPDATA%\Teeworlds\" (
+	start explorer "%APPDATA%\Teeworlds\"
+	exit /b
+)
+
+echo No configuration directory was found.
+pause

--- a/other/config_directory.bat
+++ b/other/config_directory.bat
@@ -1,5 +1,5 @@
-if exist %APPDATA%\DDNet\ (
-	@start explorer %APPDATA%\DDNet\
+if exist "%APPDATA%\DDNet\" (
+	@start explorer "%APPDATA%\DDNet\"
 ) else (
-	@start explorer %APPDATA%\Teeworlds\
+	@start explorer "%APPDATA%\Teeworlds\"
 )


### PR DESCRIPTION
fixes #5936

Tested scenarioses when either DDnet directory present or Teeworlds directory present, and nor of them.
