### PR TITLE
Get away from vector for skins

### DIFF
--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -928,7 +928,7 @@ void CChat::RefindSkins()
 	{
 		if(Line.m_HasRenderTee)
 		{
-			const CSkin *pSkin = m_pClient->m_Skins.Get(m_pClient->m_Skins.Find(Line.m_aSkinName));
+			const CSkin *pSkin = m_pClient->m_Skins.Find(Line.m_aSkinName);
 			if(Line.m_CustomColoredSkin)
 				Line.m_RenderSkin = pSkin->m_ColorableSkin;
 			else

--- a/src/game/client/components/ghost.cpp
+++ b/src/game/client/components/ghost.cpp
@@ -352,15 +352,14 @@ void CGhost::OnRender()
 		if(Player.m_Weapon == WEAPON_NINJA && g_Config.m_ClShowNinja)
 		{
 			// change the skin for the ghost to the ninja
-			int Skin = m_pClient->m_Skins.Find("x_ninja");
-			if(Skin != -1)
+			const auto *pSkin = m_pClient->m_Skins.FindOrNullptr("x_ninja");
+			if(pSkin != nullptr)
 			{
 				bool IsTeamplay = false;
 				if(m_pClient->m_Snap.m_pGameInfoObj)
 					IsTeamplay = (m_pClient->m_Snap.m_pGameInfoObj->m_GameFlags & GAMEFLAG_TEAMS) != 0;
 
 				GhostNinjaRenderInfo = Ghost.m_RenderInfo;
-				const CSkin *pSkin = m_pClient->m_Skins.Get(Skin);
 				GhostNinjaRenderInfo.m_OriginalRenderSkin = pSkin->m_OriginalSkin;
 				GhostNinjaRenderInfo.m_ColorableRenderSkin = pSkin->m_ColorableSkin;
 				GhostNinjaRenderInfo.m_BloodColor = pSkin->m_BloodColor;
@@ -387,8 +386,7 @@ void CGhost::InitRenderInfos(CGhostItem *pGhost)
 	IntsToStr(&pGhost->m_Skin.m_Skin0, 6, aSkinName);
 	CTeeRenderInfo *pRenderInfo = &pGhost->m_RenderInfo;
 
-	int SkinId = m_pClient->m_Skins.Find(aSkinName);
-	const CSkin *pSkin = m_pClient->m_Skins.Get(SkinId);
+	const CSkin *pSkin = m_pClient->m_Skins.Find(aSkinName);
 	pRenderInfo->m_OriginalRenderSkin = pSkin->m_OriginalSkin;
 	pRenderInfo->m_ColorableRenderSkin = pSkin->m_ColorableSkin;
 	pRenderInfo->m_BloodColor = pSkin->m_BloodColor;
@@ -679,8 +677,7 @@ void CGhost::RefindSkin()
 		{
 			CTeeRenderInfo *pRenderInfo = &Ghost.m_RenderInfo;
 
-			int SkinId = m_pClient->m_Skins.Find(aSkinName);
-			const CSkin *pSkin = m_pClient->m_Skins.Get(SkinId);
+			const CSkin *pSkin = m_pClient->m_Skins.Find(aSkinName);
 			pRenderInfo->m_OriginalRenderSkin = pSkin->m_OriginalSkin;
 			pRenderInfo->m_ColorableRenderSkin = pSkin->m_ColorableSkin;
 			pRenderInfo->m_SkinMetrics = pSkin->m_Metrics;
@@ -691,8 +688,7 @@ void CGhost::RefindSkin()
 	{
 		CTeeRenderInfo *pRenderInfo = &m_CurGhost.m_RenderInfo;
 
-		int SkinId = m_pClient->m_Skins.Find(aSkinName);
-		const CSkin *pSkin = m_pClient->m_Skins.Get(SkinId);
+		const CSkin *pSkin = m_pClient->m_Skins.Find(aSkinName);
 		pRenderInfo->m_OriginalRenderSkin = pSkin->m_OriginalSkin;
 		pRenderInfo->m_ColorableRenderSkin = pSkin->m_ColorableSkin;
 		pRenderInfo->m_SkinMetrics = pSkin->m_Metrics;

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -769,10 +769,9 @@ void CPlayers::OnRender()
 		if((CharacterInfo.m_Cur.m_Weapon == WEAPON_NINJA || (CharacterInfo.m_HasExtendedData && CharacterInfo.m_ExtendedData.m_FreezeEnd != 0)) && g_Config.m_ClShowNinja)
 		{
 			// change the skin for the player to the ninja
-			int Skin = m_pClient->m_Skins.Find("x_ninja");
-			if(Skin != -1)
+			const auto *pSkin = m_pClient->m_Skins.FindOrNullptr("x_ninja");
+			if(pSkin != nullptr)
 			{
-				const CSkin *pSkin = m_pClient->m_Skins.Get(Skin);
 				m_aRenderInfo[i].m_OriginalRenderSkin = pSkin->m_OriginalSkin;
 				m_aRenderInfo[i].m_ColorableRenderSkin = pSkin->m_ColorableSkin;
 				m_aRenderInfo[i].m_BloodColor = pSkin->m_BloodColor;
@@ -786,8 +785,7 @@ void CPlayers::OnRender()
 			}
 		}
 	}
-	int Skin = m_pClient->m_Skins.Find("x_spec");
-	const CSkin *pSkin = m_pClient->m_Skins.Get(Skin);
+	const CSkin *pSkin = m_pClient->m_Skins.Find("x_spec");
 	m_RenderInfoSpec.m_OriginalRenderSkin = pSkin->m_OriginalSkin;
 	m_RenderInfoSpec.m_ColorableRenderSkin = pSkin->m_ColorableSkin;
 	m_RenderInfoSpec.m_BloodColor = pSkin->m_BloodColor;

--- a/src/game/client/components/skins.cpp
+++ b/src/game/client/components/skins.cpp
@@ -70,18 +70,14 @@ int CSkins::SkinScan(const char *pName, int IsDir, int DirType, void *pUser)
 
 	// Don't add duplicate skins (one from user's config directory, other from
 	// client itself)
-	for(int i = 0; i < pSelf->Num(); i++)
-	{
-		const char *pExName = pSelf->Get(i)->m_aName;
-		if(str_comp(pExName, aNameWithoutPng) == 0)
-			return 0;
-	}
+	if(pSelf->m_Skins.find(aNameWithoutPng) != pSelf->m_Skins.end())
+		return 0;
 
 	char aBuf[IO_MAX_PATH_LENGTH];
 	str_format(aBuf, sizeof(aBuf), "skins/%s", pName);
-	auto SkinID = pSelf->LoadSkin(aNameWithoutPng, aBuf, DirType);
-	pUserReal->m_SkinLoadedFunc(SkinID);
-	return SkinID;
+	pSelf->LoadSkin(aNameWithoutPng, aBuf, DirType);
+	pUserReal->m_SkinLoadedFunc((int)pSelf->m_Skins.size());
+	return 0;
 }
 
 static void CheckMetrics(CSkin::SSkinMetricVariable &Metrics, uint8_t *pImg, int ImgWidth, int ImgX, int ImgY, int CheckWidth, int CheckHeight)
@@ -119,7 +115,7 @@ static void CheckMetrics(CSkin::SSkinMetricVariable &Metrics, uint8_t *pImg, int
 	Metrics.m_MaxHeight = CheckHeight;
 }
 
-int CSkins::LoadSkin(const char *pName, const char *pPath, int DirType)
+const CSkin *CSkins::LoadSkin(const char *pName, const char *pPath, int DirType)
 {
 	CImageInfo Info;
 	if(!LoadSkinPNG(Info, pName, pPath, DirType))
@@ -139,7 +135,7 @@ bool CSkins::LoadSkinPNG(CImageInfo &Info, const char *pName, const char *pPath,
 	return true;
 }
 
-int CSkins::LoadSkin(const char *pName, CImageInfo &Info)
+const CSkin *CSkins::LoadSkin(const char *pName, CImageInfo &Info)
 {
 	char aBuf[512];
 
@@ -147,16 +143,16 @@ int CSkins::LoadSkin(const char *pName, CImageInfo &Info)
 	{
 		str_format(aBuf, sizeof(aBuf), "skin failed image divisibility: %s", pName);
 		Console()->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "game", aBuf);
-		return 0;
+		return nullptr;
 	}
 	if(!Graphics()->IsImageFormatRGBA(pName, Info))
 	{
 		str_format(aBuf, sizeof(aBuf), "skin format is not RGBA: %s", pName);
 		Console()->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "game", aBuf);
-		return 0;
+		return nullptr;
 	}
 
-	CSkin Skin;
+	CSkin Skin{pName};
 	Skin.m_OriginalSkin.m_Body = Graphics()->LoadSpriteTexture(Info, &g_pData->m_aSprites[SPRITE_TEE_BODY]);
 	Skin.m_OriginalSkin.m_BodyOutline = Graphics()->LoadSpriteTexture(Info, &g_pData->m_aSprites[SPRITE_TEE_BODY_OUTLINE]);
 	Skin.m_OriginalSkin.m_Feet = Graphics()->LoadSpriteTexture(Info, &g_pData->m_aSprites[SPRITE_TEE_FOOT]);
@@ -194,7 +190,7 @@ int CSkins::LoadSkin(const char *pName, CImageInfo &Info)
 	int BodyWidth = g_pData->m_aSprites[SPRITE_TEE_BODY].m_W * (Info.m_Width / g_pData->m_aSprites[SPRITE_TEE_BODY].m_pSet->m_Gridx); // body width
 	int BodyHeight = g_pData->m_aSprites[SPRITE_TEE_BODY].m_H * (Info.m_Height / g_pData->m_aSprites[SPRITE_TEE_BODY].m_pSet->m_Gridy); // body height
 	if(BodyWidth > Info.m_Width || BodyHeight > Info.m_Height)
-		return 0;
+		return nullptr;
 	unsigned char *pData = (unsigned char *)Info.m_pData;
 	const int PixelStep = 4;
 	int Pitch = Info.m_Width * PixelStep;
@@ -290,16 +286,16 @@ int CSkins::LoadSkin(const char *pName, CImageInfo &Info)
 	Graphics()->FreePNG(&Info);
 
 	// set skin data
-	str_copy(Skin.m_aName, pName);
 	if(g_Config.m_Debug)
 	{
-		str_format(aBuf, sizeof(aBuf), "load skin %s", Skin.m_aName);
+		str_format(aBuf, sizeof(aBuf), "load skin %s", Skin.GetName());
 		Console()->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "game", aBuf);
 	}
 
-	m_vSkins.insert(std::lower_bound(m_vSkins.begin(), m_vSkins.end(), Skin), Skin);
+	auto &&pSkin = std::make_unique<CSkin>(std::move(Skin));
+	const auto SkinInsertIt = m_Skins.insert({pSkin->GetName(), std::move(pSkin)});
 
-	return 0;
+	return SkinInsertIt.first->second.get();
 }
 
 void CSkins::OnInit()
@@ -319,132 +315,132 @@ void CSkins::OnInit()
 	}
 
 	// load skins;
-	Refresh([this](int SkinID) {
+	Refresh([this](int SkinCounter) {
 		GameClient()->m_Menus.RenderLoading(Localize("Loading DDNet Client"), Localize("Loading skin files"), 0);
 	});
 }
 
 void CSkins::Refresh(TSkinLoadedCBFunc &&SkinLoadedFunc)
 {
-	for(auto &Skin : m_vSkins)
+	for(const auto &SkinIt : m_Skins)
 	{
-		Graphics()->UnloadTexture(&Skin.m_OriginalSkin.m_Body);
-		Graphics()->UnloadTexture(&Skin.m_OriginalSkin.m_BodyOutline);
-		Graphics()->UnloadTexture(&Skin.m_OriginalSkin.m_Feet);
-		Graphics()->UnloadTexture(&Skin.m_OriginalSkin.m_FeetOutline);
-		Graphics()->UnloadTexture(&Skin.m_OriginalSkin.m_Hands);
-		Graphics()->UnloadTexture(&Skin.m_OriginalSkin.m_HandsOutline);
-		for(auto &Eye : Skin.m_OriginalSkin.m_aEyes)
+		const auto &pSkin = SkinIt.second;
+		Graphics()->UnloadTexture(&pSkin->m_OriginalSkin.m_Body);
+		Graphics()->UnloadTexture(&pSkin->m_OriginalSkin.m_BodyOutline);
+		Graphics()->UnloadTexture(&pSkin->m_OriginalSkin.m_Feet);
+		Graphics()->UnloadTexture(&pSkin->m_OriginalSkin.m_FeetOutline);
+		Graphics()->UnloadTexture(&pSkin->m_OriginalSkin.m_Hands);
+		Graphics()->UnloadTexture(&pSkin->m_OriginalSkin.m_HandsOutline);
+		for(auto &Eye : pSkin->m_OriginalSkin.m_aEyes)
 			Graphics()->UnloadTexture(&Eye);
 
-		Graphics()->UnloadTexture(&Skin.m_ColorableSkin.m_Body);
-		Graphics()->UnloadTexture(&Skin.m_ColorableSkin.m_BodyOutline);
-		Graphics()->UnloadTexture(&Skin.m_ColorableSkin.m_Feet);
-		Graphics()->UnloadTexture(&Skin.m_ColorableSkin.m_FeetOutline);
-		Graphics()->UnloadTexture(&Skin.m_ColorableSkin.m_Hands);
-		Graphics()->UnloadTexture(&Skin.m_ColorableSkin.m_HandsOutline);
-		for(auto &Eye : Skin.m_ColorableSkin.m_aEyes)
+		Graphics()->UnloadTexture(&pSkin->m_ColorableSkin.m_Body);
+		Graphics()->UnloadTexture(&pSkin->m_ColorableSkin.m_BodyOutline);
+		Graphics()->UnloadTexture(&pSkin->m_ColorableSkin.m_Feet);
+		Graphics()->UnloadTexture(&pSkin->m_ColorableSkin.m_FeetOutline);
+		Graphics()->UnloadTexture(&pSkin->m_ColorableSkin.m_Hands);
+		Graphics()->UnloadTexture(&pSkin->m_ColorableSkin.m_HandsOutline);
+		for(auto &Eye : pSkin->m_ColorableSkin.m_aEyes)
 			Graphics()->UnloadTexture(&Eye);
 	}
 
-	m_vSkins.clear();
-	m_vDownloadSkins.clear();
+	m_Skins.clear();
+	m_DownloadSkins.clear();
 	m_DownloadingSkins = 0;
 	SSkinScanUser SkinScanUser;
 	SkinScanUser.m_pThis = this;
 	SkinScanUser.m_SkinLoadedFunc = SkinLoadedFunc;
 	Storage()->ListDirectory(IStorage::TYPE_ALL, "skins", SkinScan, &SkinScanUser);
-	if(m_vSkins.empty())
+	if(m_Skins.empty())
 	{
 		Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "gameclient", "failed to load skins. folder='skins/'");
-		CSkin DummySkin;
-		str_copy(DummySkin.m_aName, "dummy");
+		CSkin DummySkin{"dummy"};
 		DummySkin.m_BloodColor = ColorRGBA(1.0f, 1.0f, 1.0f);
-		m_vSkins.push_back(DummySkin);
+		auto &&pDummySkin = std::make_unique<CSkin>(std::move(DummySkin));
+		m_Skins.insert({pDummySkin->GetName(), std::move(pDummySkin)});
 	}
 }
 
 int CSkins::Num()
 {
-	return m_vSkins.size();
+	return m_Skins.size();
 }
 
-const CSkin *CSkins::Get(int Index)
+const CSkin *CSkins::Find(const char *pName)
 {
-	if(Index < 0)
+	const auto *pSkin = FindOrNullptr(pName);
+	if(pSkin == nullptr)
 	{
-		Index = Find("default");
-
-		if(Index < 0)
-			Index = 0;
+		pSkin = FindOrNullptr("default");
+		if(pSkin == nullptr)
+			return m_Skins.begin()->second.get();
+		else
+			return pSkin;
 	}
-	return &m_vSkins[Index % m_vSkins.size()];
+	else
+	{
+		return pSkin;
+	}
 }
 
-int CSkins::Find(const char *pName)
+const CSkin *CSkins::FindOrNullptr(const char *pName)
 {
 	const char *pSkinPrefix = m_aEventSkinPrefix[0] ? m_aEventSkinPrefix : g_Config.m_ClSkinPrefix;
 	if(g_Config.m_ClVanillaSkinsOnly && !IsVanillaSkin(pName))
 	{
-		return -1;
+		return nullptr;
 	}
 	else if(pSkinPrefix && pSkinPrefix[0])
 	{
 		char aBuf[24];
 		str_format(aBuf, sizeof(aBuf), "%s_%s", pSkinPrefix, pName);
 		// If we find something, use it, otherwise fall back to normal skins.
-		int Result = FindImpl(aBuf);
-		if(Result != -1)
+		const auto *pResult = FindImpl(aBuf);
+		if(pResult != nullptr)
 		{
-			return Result;
+			return pResult;
 		}
 	}
 	return FindImpl(pName);
 }
 
-int CSkins::FindImpl(const char *pName)
+const CSkin *CSkins::FindImpl(const char *pName)
 {
-	CSkin Needle;
-	mem_zero(&Needle, sizeof(Needle));
-	str_copy(Needle.m_aName, pName);
-	auto Range = std::equal_range(m_vSkins.begin(), m_vSkins.end(), Needle);
-	if(std::distance(Range.first, Range.second) == 1)
-		return Range.first - m_vSkins.begin();
+	auto SkinIt = m_Skins.find(pName);
+	if(SkinIt != m_Skins.end())
+		return SkinIt->second.get();
 
 	if(str_comp(pName, "default") == 0)
-		return -1;
+		return nullptr;
 
 	if(!g_Config.m_ClDownloadSkins)
-		return -1;
+		return nullptr;
 
 	if(str_find(pName, "/") != 0)
-		return -1;
+		return nullptr;
 
-	CDownloadSkin DownloadNeedle;
-	mem_zero(&DownloadNeedle, sizeof(DownloadNeedle));
-	str_copy(DownloadNeedle.m_aName, pName);
-	const auto &[RangeBegin, RangeEnd] = std::equal_range(m_vDownloadSkins.begin(), m_vDownloadSkins.end(), DownloadNeedle);
-	if(std::distance(RangeBegin, RangeEnd) == 1)
+	const auto SkinDownloadIt = m_DownloadSkins.find(pName);
+	if(SkinDownloadIt != m_DownloadSkins.end())
 	{
-		if(RangeBegin->m_pTask && RangeBegin->m_pTask->State() == HTTP_DONE)
+		if(SkinDownloadIt->second->m_pTask && SkinDownloadIt->second->m_pTask->State() == HTTP_DONE)
 		{
 			char aPath[IO_MAX_PATH_LENGTH];
-			str_format(aPath, sizeof(aPath), "downloadedskins/%s.png", RangeBegin->m_aName);
-			Storage()->RenameFile(RangeBegin->m_aPath, aPath, IStorage::TYPE_SAVE);
-			LoadSkin(RangeBegin->m_aName, RangeBegin->m_pTask->m_Info);
-			RangeBegin->m_pTask = nullptr;
+			str_format(aPath, sizeof(aPath), "downloadedskins/%s.png", SkinDownloadIt->second->GetName());
+			Storage()->RenameFile(SkinDownloadIt->second->m_aPath, aPath, IStorage::TYPE_SAVE);
+			const auto *pSkin = LoadSkin(SkinDownloadIt->second->GetName(), SkinDownloadIt->second->m_pTask->m_Info);
+			SkinDownloadIt->second->m_pTask = nullptr;
 			--m_DownloadingSkins;
+			return pSkin;
 		}
-		if(RangeBegin->m_pTask && (RangeBegin->m_pTask->State() == HTTP_ERROR || RangeBegin->m_pTask->State() == HTTP_ABORTED))
+		if(SkinDownloadIt->second->m_pTask && (SkinDownloadIt->second->m_pTask->State() == HTTP_ERROR || SkinDownloadIt->second->m_pTask->State() == HTTP_ABORTED))
 		{
-			RangeBegin->m_pTask = nullptr;
+			SkinDownloadIt->second->m_pTask = nullptr;
 			--m_DownloadingSkins;
 		}
-		return -1;
+		return nullptr;
 	}
 
-	CDownloadSkin Skin;
-	str_copy(Skin.m_aName, pName);
+	CDownloadSkin Skin{pName};
 
 	char aUrl[IO_MAX_PATH_LENGTH];
 	char aEscapedName[256];
@@ -454,7 +450,8 @@ int CSkins::FindImpl(const char *pName)
 	str_format(Skin.m_aPath, sizeof(Skin.m_aPath), "downloadedskins/%s", IStorage::FormatTmpPath(aBuf, sizeof(aBuf), pName));
 	Skin.m_pTask = std::make_shared<CGetPngFile>(this, aUrl, Storage(), Skin.m_aPath);
 	m_pClient->Engine()->AddJob(Skin.m_pTask);
-	m_vDownloadSkins.insert(std::lower_bound(m_vDownloadSkins.begin(), m_vDownloadSkins.end(), Skin), std::move(Skin));
+	auto &&pDownloadSkin = std::make_unique<CDownloadSkin>(std::move(Skin));
+	m_DownloadSkins.insert({pDownloadSkin->GetName(), std::move(pDownloadSkin)});
 	++m_DownloadingSkins;
-	return -1;
+	return nullptr;
 }

--- a/src/game/client/components/skins.h
+++ b/src/game/client/components/skins.h
@@ -3,14 +3,18 @@
 #ifndef GAME_CLIENT_COMPONENTS_SKINS_H
 #define GAME_CLIENT_COMPONENTS_SKINS_H
 
+#include <base/system.h>
 #include <engine/shared/http.h>
 #include <game/client/component.h>
 #include <game/client/skin.h>
-#include <vector>
+#include <string_view>
+#include <unordered_map>
 
 class CSkins : public CComponent
 {
 public:
+	CSkins() = default;
+
 	class CGetPngFile : public CHttpRequest
 	{
 		CSkins *m_pSkins;
@@ -25,12 +29,18 @@ public:
 
 	struct CDownloadSkin
 	{
-		std::shared_ptr<CSkins::CGetPngFile> m_pTask;
-		char m_aPath[IO_MAX_PATH_LENGTH];
+	private:
 		char m_aName[24];
 
+	public:
+		std::shared_ptr<CSkins::CGetPngFile> m_pTask;
+		char m_aPath[IO_MAX_PATH_LENGTH];
+
 		CDownloadSkin(CDownloadSkin &&Other) = default;
-		CDownloadSkin() = default;
+		CDownloadSkin(const char *pName)
+		{
+			str_copy(m_aName, pName);
+		}
 
 		~CDownloadSkin()
 		{
@@ -42,6 +52,8 @@ public:
 		bool operator==(const char *pOther) const { return !str_comp(m_aName, pOther); }
 
 		CDownloadSkin &operator=(CDownloadSkin &&Other) = default;
+
+		const char *GetName() const { return m_aName; }
 	};
 
 	typedef std::function<void(int)> TSkinLoadedCBFunc;
@@ -51,21 +63,22 @@ public:
 
 	void Refresh(TSkinLoadedCBFunc &&SkinLoadedFunc);
 	int Num();
-	const CSkin *Get(int Index);
-	int Find(const char *pName);
+	std::unordered_map<std::string_view, std::unique_ptr<CSkin>> &GetSkinsUnsafe() { return m_Skins; }
+	const CSkin *FindOrNullptr(const char *pName);
+	const CSkin *Find(const char *pName);
 
 	bool IsDownloadingSkins() { return m_DownloadingSkins; }
 
 private:
-	std::vector<CSkin> m_vSkins;
-	std::vector<CDownloadSkin> m_vDownloadSkins;
+	std::unordered_map<std::string_view, std::unique_ptr<CSkin>> m_Skins;
+	std::unordered_map<std::string_view, std::unique_ptr<CDownloadSkin>> m_DownloadSkins;
 	size_t m_DownloadingSkins = 0;
 	char m_aEventSkinPrefix[24];
 
 	bool LoadSkinPNG(CImageInfo &Info, const char *pName, const char *pPath, int DirType);
-	int LoadSkin(const char *pName, const char *pPath, int DirType);
-	int LoadSkin(const char *pName, CImageInfo &Info);
-	int FindImpl(const char *pName);
+	const CSkin *LoadSkin(const char *pName, const char *pPath, int DirType);
+	const CSkin *LoadSkin(const char *pName, CImageInfo &Info);
+	const CSkin *FindImpl(const char *pName);
 	static int SkinScan(const char *pName, int IsDir, int DirType, void *pUser);
 };
 #endif

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1227,7 +1227,7 @@ void CGameClient::OnNewSnapshot()
 					pClient->m_SkinInfo.m_Size = 64;
 
 					// find new skin
-					const CSkin *pSkin = m_Skins.Get(m_Skins.Find(pClient->m_aSkinName));
+					const CSkin *pSkin = m_Skins.Find(pClient->m_aSkinName);
 					pClient->m_SkinInfo.m_OriginalRenderSkin = pSkin->m_OriginalSkin;
 					pClient->m_SkinInfo.m_ColorableRenderSkin = pSkin->m_ColorableSkin;
 					pClient->m_SkinInfo.m_SkinMetrics = pSkin->m_Metrics;
@@ -3185,7 +3185,7 @@ void CGameClient::RefindSkins()
 		Client.m_SkinInfo.m_ColorableRenderSkin.Reset();
 		if(Client.m_aSkinName[0] != '\0')
 		{
-			const CSkin *pSkin = m_Skins.Get(m_Skins.Find(Client.m_aSkinName));
+			const CSkin *pSkin = m_Skins.Find(Client.m_aSkinName);
 			Client.m_SkinInfo.m_OriginalRenderSkin = pSkin->m_OriginalSkin;
 			Client.m_SkinInfo.m_ColorableRenderSkin = pSkin->m_ColorableSkin;
 			Client.UpdateRenderInfo(IsTeamPlay());

--- a/src/game/client/skin.h
+++ b/src/game/client/skin.h
@@ -1,6 +1,7 @@
 #ifndef GAME_CLIENT_SKIN_H
 #define GAME_CLIENT_SKIN_H
 #include <base/color.h>
+#include <base/system.h>
 #include <base/vmath.h>
 #include <engine/graphics.h>
 #include <limits>
@@ -8,6 +9,10 @@
 // do this better and nicer
 struct CSkin
 {
+private:
+	char m_aName[24];
+
+public:
 	struct SSkinTextures
 	{
 		IGraphics::CTextureHandle m_Body;
@@ -36,7 +41,6 @@ struct CSkin
 
 	SSkinTextures m_OriginalSkin;
 	SSkinTextures m_ColorableSkin;
-	char m_aName[24];
 	ColorRGBA m_BloodColor;
 
 	template<bool IsSizeType>
@@ -129,6 +133,15 @@ struct CSkin
 
 	bool operator<(const CSkin &Other) const { return str_comp(m_aName, Other.m_aName) < 0; }
 	bool operator==(const CSkin &Other) const { return !str_comp(m_aName, Other.m_aName); }
+
+	CSkin(const char *pName)
+	{
+		str_copy(m_aName, pName);
+	}
+	CSkin(CSkin &&) = default;
+	CSkin &operator=(CSkin &&) = default;
+
+	const char *GetName() const { return m_aName; }
 };
 
 #endif


### PR DESCRIPTION
most of the time it uses the index just to get the skin, downloaded skins change the index. Now its simply a heap object and downloaded skins load directly. Also the loading might be a bit faster bcs it had a loop lookup .Also O(1) lookup

not 100% tested. also fixes a bug with favorite skins hopefully
## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
