### PR TITLE
Add tests for too small/large `sha256_str` and `md5_str` buffers, minor refactoring

### DIFF
--- a/src/android/android_main.cpp
+++ b/src/android/android_main.cpp
@@ -149,8 +149,8 @@ void InitAndroid()
 		if(pIOR != NULL)
 		{
 			char aFileSHA[SHA256_MAXSTRSIZE];
-			sha256_str(ShaAllFile, aFileSHA, SHA256_MAXSTRSIZE);
-			io_write(pIOR, aFileSHA, SHA256_MAXSTRSIZE - 1);
+			sha256_str(ShaAllFile, aFileSHA, sizeof(aFileSHA));
+			io_write(pIOR, aFileSHA, str_length(aFileSHA));
 			io_close(pIOR);
 		}
 	}

--- a/src/base/hash.cpp
+++ b/src/base/hash.cpp
@@ -7,17 +7,16 @@ const SHA256_DIGEST SHA256_ZEROED = {{0}};
 
 static void digest_str(const unsigned char *digest, size_t digest_len, char *str, size_t max_len)
 {
-	unsigned i;
 	if(max_len > digest_len * 2 + 1)
 	{
 		max_len = digest_len * 2 + 1;
 	}
 	str[max_len - 1] = 0;
 	max_len -= 1;
-	for(i = 0; i < max_len; i++)
+	for(size_t i = 0; i < max_len; i++)
 	{
 		static const char HEX[] = "0123456789abcdef";
-		int index = i / 2;
+		size_t index = i / 2;
 		if(i % 2 == 0)
 		{
 			str[i] = HEX[digest[index] >> 4];

--- a/src/test/hash.cpp
+++ b/src/test/hash.cpp
@@ -3,9 +3,10 @@
 #include <base/hash_ctxt.h>
 #include <base/system.h>
 
-static void Expect(SHA256_DIGEST Actual, const char *pWanted)
+template<size_t BufferSize = SHA256_MAXSTRSIZE>
+static void ExpectSha256(SHA256_DIGEST Actual, const char *pWanted)
 {
-	char aActual[SHA256_MAXSTRSIZE];
+	char aActual[BufferSize];
 	sha256_str(Actual, aActual, sizeof(aActual));
 	EXPECT_STREQ(aActual, pWanted);
 }
@@ -13,15 +14,15 @@ static void Expect(SHA256_DIGEST Actual, const char *pWanted)
 TEST(Hash, Sha256)
 {
 	// https://en.wikipedia.org/w/index.php?title=SHA-2&oldid=840187620#Test_vectors
-	Expect(sha256("", 0), "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+	ExpectSha256(sha256("", 0), "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
 	SHA256_CTX ctxt;
 
 	sha256_init(&ctxt);
-	Expect(sha256_finish(&ctxt), "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+	ExpectSha256(sha256_finish(&ctxt), "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
 
 	// printf 'The quick brown fox jumps over the lazy dog.' | sha256sum
 	char QUICK_BROWN_FOX[] = "The quick brown fox jumps over the lazy dog.";
-	Expect(sha256(QUICK_BROWN_FOX, str_length(QUICK_BROWN_FOX)), "ef537f25c895bfa782526529a9b63d97aa631564d5d789c2b765448c8635fb6c");
+	ExpectSha256(sha256(QUICK_BROWN_FOX, str_length(QUICK_BROWN_FOX)), "ef537f25c895bfa782526529a9b63d97aa631564d5d789c2b765448c8635fb6c");
 
 	sha256_init(&ctxt);
 	sha256_update(&ctxt, "The ", 4);
@@ -33,7 +34,20 @@ TEST(Hash, Sha256)
 	sha256_update(&ctxt, "the ", 4);
 	sha256_update(&ctxt, "lazy ", 5);
 	sha256_update(&ctxt, "dog.", 4);
-	Expect(sha256_finish(&ctxt), "ef537f25c895bfa782526529a9b63d97aa631564d5d789c2b765448c8635fb6c");
+	ExpectSha256(sha256_finish(&ctxt), "ef537f25c895bfa782526529a9b63d97aa631564d5d789c2b765448c8635fb6c");
+}
+
+TEST(Hash, Sha256ToStringSmallBuffer)
+{
+	char QUICK_BROWN_FOX[] = "The quick brown fox jumps over the lazy dog.";
+	ExpectSha256<1>(sha256(QUICK_BROWN_FOX, str_length(QUICK_BROWN_FOX)), "");
+	ExpectSha256<16 + 1>(sha256(QUICK_BROWN_FOX, str_length(QUICK_BROWN_FOX)), "ef537f25c895bfa7");
+}
+
+TEST(Hash, Sha256ToStringLargeBuffer)
+{
+	char QUICK_BROWN_FOX[] = "The quick brown fox jumps over the lazy dog.";
+	ExpectSha256<SHA256_MAXSTRSIZE + 64>(sha256(QUICK_BROWN_FOX, str_length(QUICK_BROWN_FOX)), "ef537f25c895bfa782526529a9b63d97aa631564d5d789c2b765448c8635fb6c");
 }
 
 TEST(Hash, Sha256Eq)
@@ -87,9 +101,10 @@ TEST(Hash, Sha256FromStr)
 	EXPECT_TRUE(sha256_from_str(&Sha256, "x123456789012345678901234567890123456789012345678901234567890123"));
 }
 
-static void Expect2(MD5_DIGEST Actual, const char *pWanted)
+template<size_t BufferSize = MD5_MAXSTRSIZE>
+static void ExpectMd5(MD5_DIGEST Actual, const char *pWanted)
 {
-	char aActual[MD5_MAXSTRSIZE];
+	char aActual[BufferSize];
 	md5_str(Actual, aActual, sizeof(aActual));
 	EXPECT_STREQ(aActual, pWanted);
 }
@@ -97,14 +112,14 @@ static void Expect2(MD5_DIGEST Actual, const char *pWanted)
 TEST(Hash, Md5)
 {
 	// https://en.wikipedia.org/w/index.php?title=MD5&oldid=889664074#MD5_hashes
-	Expect2(md5("", 0), "d41d8cd98f00b204e9800998ecf8427e");
+	ExpectMd5(md5("", 0), "d41d8cd98f00b204e9800998ecf8427e");
 	MD5_CTX ctxt;
 
 	md5_init(&ctxt);
-	Expect2(md5_finish(&ctxt), "d41d8cd98f00b204e9800998ecf8427e");
+	ExpectMd5(md5_finish(&ctxt), "d41d8cd98f00b204e9800998ecf8427e");
 
 	char QUICK_BROWN_FOX[] = "The quick brown fox jumps over the lazy dog.";
-	Expect2(md5(QUICK_BROWN_FOX, str_length(QUICK_BROWN_FOX)), "e4d909c290d0fb1ca068ffaddf22cbd0");
+	ExpectMd5(md5(QUICK_BROWN_FOX, str_length(QUICK_BROWN_FOX)), "e4d909c290d0fb1ca068ffaddf22cbd0");
 
 	md5_init(&ctxt);
 	md5_update(&ctxt, "The ", 4);
@@ -116,7 +131,20 @@ TEST(Hash, Md5)
 	md5_update(&ctxt, "the ", 4);
 	md5_update(&ctxt, "lazy ", 5);
 	md5_update(&ctxt, "dog.", 4);
-	Expect2(md5_finish(&ctxt), "e4d909c290d0fb1ca068ffaddf22cbd0");
+	ExpectMd5(md5_finish(&ctxt), "e4d909c290d0fb1ca068ffaddf22cbd0");
+}
+
+TEST(Hash, Md5ToStringSmallBuffer)
+{
+	char QUICK_BROWN_FOX[] = "The quick brown fox jumps over the lazy dog.";
+	ExpectMd5<1>(md5(QUICK_BROWN_FOX, str_length(QUICK_BROWN_FOX)), "");
+	ExpectMd5<16 + 1>(md5(QUICK_BROWN_FOX, str_length(QUICK_BROWN_FOX)), "e4d909c290d0fb1c");
+}
+
+TEST(Hash, Md5ToStringLargeBuffer)
+{
+	char QUICK_BROWN_FOX[] = "The quick brown fox jumps over the lazy dog.";
+	ExpectMd5<MD5_MAXSTRSIZE + 64>(md5(QUICK_BROWN_FOX, str_length(QUICK_BROWN_FOX)), "e4d909c290d0fb1ca068ffaddf22cbd0");
 }
 
 TEST(Hash, Md5Eq)

--- a/src/tools/map_optimize.cpp
+++ b/src/tools/map_optimize.cpp
@@ -60,7 +60,7 @@ void ClearPixelsTile(uint8_t *pImg, int Width, int Height, int TileIndex)
 	}
 }
 
-void GetImageSHA256(uint8_t *pImgBuff, int ImgSize, int Width, int Height, char *pSHA256Str)
+void GetImageSHA256(uint8_t *pImgBuff, int ImgSize, int Width, int Height, char *pSHA256Str, size_t SHA256StrSize)
 {
 	uint8_t *pNewImgBuff = (uint8_t *)malloc(ImgSize);
 
@@ -68,7 +68,7 @@ void GetImageSHA256(uint8_t *pImgBuff, int ImgSize, int Width, int Height, char 
 	CopyOpaquePixels(pNewImgBuff, pImgBuff, Width, Height);
 	SHA256_DIGEST SHAStr = sha256(pNewImgBuff, (size_t)ImgSize);
 
-	sha256_str(SHAStr, pSHA256Str, SHA256_MAXSTRSIZE * sizeof(char));
+	sha256_str(SHAStr, pSHA256Str, SHA256StrSize);
 
 	free(pNewImgBuff);
 }
@@ -292,7 +292,7 @@ int main(int argc, const char **argv)
 				char aSHA256Str[SHA256_MAXSTRSIZE];
 				// This is the important function, that calculates the SHA256 in a special way
 				// Please read the comments inside the functions to understand it
-				GetImageSHA256(pImgBuff, ImgSize, Width, Height, aSHA256Str);
+				GetImageSHA256(pImgBuff, ImgSize, Width, Height, aSHA256Str, sizeof(aSHA256Str));
 
 				char aNewName[IO_MAX_PATH_LENGTH];
 				int StrLen = str_format(aNewName, std::size(aNewName), "%s_cut_%s", pImgName, aSHA256Str);


### PR DESCRIPTION


## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [X] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
