### PR TITLE
Fix compilation with VS2022 with exception handling enabled

### DIFF
--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -4239,7 +4239,7 @@ void set_exception_handler_log_file(const char *log_file_path)
 #pragma GCC diagnostic ignored "-Wcast-function-type"
 #endif
 		const char *function_name = "ExcHndlSetLogFileNameW";
-		auto exception_log_file_path_func = (BOOL APIENTRY(*)(const WCHAR *))(GetProcAddress(exception_handling_module, function_name));
+		auto exception_log_file_path_func = (BOOL(APIENTRY *)(const WCHAR *))(GetProcAddress(exception_handling_module, function_name));
 #ifdef __MINGW32__
 #pragma GCC diagnostic pop
 #endif


### PR DESCRIPTION
By moving the calling convention `APIENTRY`, which expands to `__stdcall`, inside the parenthesis.

```
Severity	Code	Description	Project	File	Line	Suppression State
Error	C2143	syntax error: missing ')' before '('	engine-shared	src\base\system.cpp	4242
Warning	C4229	anachronism used: modifiers on data are ignored	engine-shared	src\base\system.cpp	4242
Error	C2059	syntax error: ')'	engine-shared	src\base\system.cpp	4242
Error	C2059	syntax error: ')'	engine-shared	src\base\system.cpp	4242
Error	C3536	'exception_log_file_path_func': cannot be used before it is initialized	engine-shared	src\base\system.cpp	4246
Error	C2446	'==': no conversion from 'nullptr' to 'int'	engine-shared	src\base\system.cpp	4246
Error	C2064	term does not evaluate to a function taking 1 arguments	engine-shared	src\base\system.cpp	4249
```

<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
