### PR TITLE
Fix `parse_drmingw.sh` not finding module offset on Linux systems

### DIFF
--- a/scripts/parse_drmingw.sh
+++ b/scripts/parse_drmingw.sh
@@ -16,7 +16,7 @@ fi
 
 TMP_OFFSET=$(grep -E -o "\(with offset [0-9A-F]+\)" "$2" | grep -E -o "[A-F0-9]*")
 if [ -z "$TMP_OFFSET" ]; then
-	TMP_OFFSET=$(grep -E -o "^[0-9A-F]+-[0-9A-F]+ .+\.exe$" "$2" | grep -E -o "^[A-F0-9]+")
+	TMP_OFFSET=$(grep -E -o "^[0-9A-F]+-[0-9A-F]+ .+\.exe" "$2" | grep -E -o "^[A-F0-9]+")
 	if [ -z "$TMP_OFFSET" ]; then
 		printf "\e[31m%s\e[30m\n" "Module offset not found; addresses will be absolute"
 		echo -en "\e[0m"


### PR DESCRIPTION
The end anchor is removed from the grep RegEx, as it's not necessary and as it doesn't work on Linux systems when the crash log uses Windows line endings.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
