### PR TITLE
fix skin click ptr

### DIFF
--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -836,7 +836,7 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 						RenderFavIcon(FavIcon, IsFav);
 					}
 				}
-				if(UI()->DoButtonLogic(pSkinToBeDraw->GetName(), 0, &FavIcon))
+				if(UI()->DoButtonLogic(&pSkinToBeDraw->m_Metrics.m_Body, 0, &FavIcon))
 				{
 					if(IsFav)
 					{


### PR DESCRIPTION
Just noticed that the menu button didnt work anymore, bcs we often use the pointer of the config vars or other variables for the pID ptr

and since i moved the m_aName up in the CSkin: pSkin(the ptr) and pSkin->GetName()(ptr to m_aName) returned the same ptr ( another UI element already use pSkin, our UI breaks bcs of that)

such a mess xDD
## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
