### PR TITLE
Add client_score_kind field to serverinfo

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -2218,6 +2218,7 @@ void CServer::UpdateRegisterServerInfo()
 		"\"size\":%d"
 		"},"
 		"\"version\":\"%s\","
+		"\"client_score_kind\":\"time\","
 		"\"clients\":[",
 		MaxClients,
 		MaxPlayers,
@@ -2250,7 +2251,7 @@ void CServer::UpdateRegisterServerInfo()
 				EscapeJson(aCName, sizeof(aCName), ClientName(i)),
 				EscapeJson(aCClan, sizeof(aCClan), ClientClan(i)),
 				m_aClients[i].m_Country,
-				m_aClients[i].m_Score == -1 ? -9999 : m_aClients[i].m_Score == 9999 ? -10000 : -m_aClients[i].m_Score,
+				m_aClients[i].m_Score == -1 ? -9999 : m_aClients[i].m_Score,
 				JsonBool(GameServer()->IsClientPlayer(i)));
 			str_append(aInfo, aClientInfo, sizeof(aInfo));
 			FirstPlayer = false;

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -296,7 +296,7 @@ void CServer::CClient::Reset()
 	m_LastAckedSnapshot = -1;
 	m_LastInputTick = -1;
 	m_SnapRate = CClient::SNAPRATE_INIT;
-	m_Score = 0;
+	m_Score = -1;
 	m_NextMapChunk = 0;
 	m_Flags = 0;
 }
@@ -2014,7 +2014,7 @@ void CServer::CacheServerInfo(CCache *pCache, int Type, bool SendClients)
 			q.AddString(ClientClan(i), MAX_CLAN_LENGTH); // client clan
 
 			ADD_INT(q, m_aClients[i].m_Country); // client country
-			ADD_INT(q, m_aClients[i].m_Score); // client score
+			ADD_INT(q, m_aClients[i].m_Score == -1 ? -9999 : m_aClients[i].m_Score == 9999 ? -10000 : -m_aClients[i].m_Score); // client score
 			ADD_INT(q, GameServer()->IsClientPlayer(i) ? 1 : 0); // is player?
 			if(Type == SERVERINFO_EXTENDED)
 				q.AddString("", 0); // extra info, reserved
@@ -2096,7 +2096,7 @@ void CServer::CacheServerInfoSixup(CCache *pCache, bool SendClients)
 				Packer.AddString(ClientName(i), MAX_NAME_LENGTH); // client name
 				Packer.AddString(ClientClan(i), MAX_CLAN_LENGTH); // client clan
 				Packer.AddInt(m_aClients[i].m_Country); // client country
-				Packer.AddInt(m_aClients[i].m_Score == -9999 ? -1 : -m_aClients[i].m_Score); // client score
+				Packer.AddInt(m_aClients[i].m_Score); // client score
 				Packer.AddInt(GameServer()->IsClientPlayer(i) ? 0 : 1); // flag spectator=1, bot=2 (player=0)
 			}
 		}
@@ -2250,7 +2250,7 @@ void CServer::UpdateRegisterServerInfo()
 				EscapeJson(aCName, sizeof(aCName), ClientName(i)),
 				EscapeJson(aCClan, sizeof(aCClan), ClientClan(i)),
 				m_aClients[i].m_Country,
-				m_aClients[i].m_Score,
+				m_aClients[i].m_Score == -1 ? -9999 : m_aClients[i].m_Score == 9999 ? -10000 : -m_aClients[i].m_Score,
 				JsonBool(GameServer()->IsClientPlayer(i)));
 			str_append(aInfo, aClientInfo, sizeof(aInfo));
 			FirstPlayer = false;

--- a/src/engine/serverbrowser.h
+++ b/src/engine/serverbrowser.h
@@ -33,6 +33,14 @@ public:
 		NUM_LOCS,
 	};
 
+	enum
+	{
+		CLIENT_SCORE_KIND_UNSPECIFIED,
+		CLIENT_SCORE_KIND_POINTS,
+		CLIENT_SCORE_KIND_TIME,
+		CLIENT_SCORE_KIND_TIME_BACKCOMPAT,
+	};
+
 	class CClient
 	{
 	public:
@@ -62,6 +70,7 @@ public:
 	int m_MaxPlayers;
 	int m_NumPlayers;
 	int m_Flags;
+	int m_ClientScoreKind;
 	TRISTATE m_Favorite;
 	TRISTATE m_FavoriteAllowPing;
 	bool m_Official;

--- a/src/engine/shared/serverinfo.cpp
+++ b/src/engine/shared/serverinfo.cpp
@@ -64,6 +64,7 @@ bool CServerInfo2::FromJsonRaw(CServerInfo2 *pOut, const json_value *pJson)
 	const json_value &ServerInfo = *pJson;
 	const json_value &MaxClients = ServerInfo["max_clients"];
 	const json_value &MaxPlayers = ServerInfo["max_players"];
+	const json_value &ClientScoreKind = ServerInfo["client_score_kind"];
 	const json_value &Passworded = ServerInfo["passworded"];
 	const json_value &GameType = ServerInfo["game_type"];
 	const json_value &Name = ServerInfo["name"];
@@ -74,6 +75,7 @@ bool CServerInfo2::FromJsonRaw(CServerInfo2 *pOut, const json_value *pJson)
 	Error = Error || MaxClients.type != json_integer;
 	Error = Error || MaxPlayers.type != json_integer;
 	Error = Error || Passworded.type != json_boolean;
+	Error = Error || (ClientScoreKind.type != json_none && ClientScoreKind.type != json_string);
 	Error = Error || GameType.type != json_string || str_has_cc(GameType);
 	Error = Error || Name.type != json_string || str_has_cc(Name);
 	Error = Error || MapName.type != json_string || str_has_cc(MapName);
@@ -85,6 +87,15 @@ bool CServerInfo2::FromJsonRaw(CServerInfo2 *pOut, const json_value *pJson)
 	}
 	pOut->m_MaxClients = json_int_get(&MaxClients);
 	pOut->m_MaxPlayers = json_int_get(&MaxPlayers);
+	pOut->m_ClientScoreKind = CServerInfo::CLIENT_SCORE_KIND_UNSPECIFIED;
+	if(ClientScoreKind.type == json_string && str_startswith(ClientScoreKind, "points"))
+	{
+		pOut->m_ClientScoreKind = CServerInfo::CLIENT_SCORE_KIND_POINTS;
+	}
+	else if(ClientScoreKind.type == json_string && str_startswith(ClientScoreKind, "time"))
+	{
+		pOut->m_ClientScoreKind = CServerInfo::CLIENT_SCORE_KIND_TIME;
+	}
 	pOut->m_Passworded = Passworded;
 	str_copy(pOut->m_aGameType, GameType);
 	str_copy(pOut->m_aName, Name);
@@ -138,6 +149,7 @@ bool CServerInfo2::operator==(const CServerInfo2 &Other) const
 	Unequal = Unequal || m_NumClients != Other.m_NumClients;
 	Unequal = Unequal || m_MaxPlayers != Other.m_MaxPlayers;
 	Unequal = Unequal || m_NumPlayers != Other.m_NumPlayers;
+	Unequal = Unequal || m_ClientScoreKind != Other.m_ClientScoreKind;
 	Unequal = Unequal || m_Passworded != Other.m_Passworded;
 	Unequal = Unequal || str_comp(m_aGameType, Other.m_aGameType) != 0;
 	Unequal = Unequal || str_comp(m_aName, Other.m_aName) != 0;
@@ -170,6 +182,7 @@ CServerInfo2::operator CServerInfo() const
 	Result.m_NumClients = m_NumClients;
 	Result.m_MaxPlayers = m_MaxPlayers;
 	Result.m_NumPlayers = m_NumPlayers;
+	Result.m_ClientScoreKind = m_ClientScoreKind;
 	Result.m_Flags = m_Passworded ? SERVER_FLAG_PASSWORD : 0;
 	str_copy(Result.m_aGameType, m_aGameType);
 	str_copy(Result.m_aName, m_aName);

--- a/src/engine/shared/serverinfo.h
+++ b/src/engine/shared/serverinfo.h
@@ -25,6 +25,7 @@ public:
 	int m_NumClients; // Indirectly serialized.
 	int m_MaxPlayers;
 	int m_NumPlayers; // Not serialized.
+	int m_ClientScoreKind;
 	bool m_Passworded;
 	char m_aGameType[16];
 	char m_aName[64];

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -119,8 +119,7 @@ void CPlayer::Reset()
 	m_DND = false;
 
 	m_LastPause = 0;
-	m_Score = -9999;
-	m_HasFinishScore = false;
+	m_Score = -1;
 
 	// Variable initialized:
 	m_Last_Team = 0;
@@ -337,11 +336,10 @@ void CPlayer::Snap(int SnappingClient)
 
 	int SnappingClientVersion = GameServer()->GetClientVersion(SnappingClient);
 	int Latency = SnappingClient == SERVER_DEMO_CLIENT ? m_Latency.m_Min : GameServer()->m_apPlayers[SnappingClient]->m_aCurLatency[m_ClientID];
-	int Score = abs(m_Score) * -1;
-
+	int Score = m_Score;
 	// send 0 if times of others are not shown
 	if(SnappingClient != m_ClientID && g_Config.m_SvHideScore)
-		Score = -9999;
+		Score = -1;
 
 	if(!Server()->IsSixup(SnappingClient))
 	{
@@ -350,7 +348,10 @@ void CPlayer::Snap(int SnappingClient)
 			return;
 
 		pPlayerInfo->m_Latency = Latency;
-		pPlayerInfo->m_Score = Score;
+		// -9999 stands for no time and isn't displayed in scoreboard, so
+		// shift the time by a second if the player actually took 9999
+		// seconds to finish the map.
+		pPlayerInfo->m_Score = Score == -1 ? -9999 : Score == 9999 ? -10000 : -Score;
 		pPlayerInfo->m_Local = (int)(m_ClientID == SnappingClient && (m_Paused != PAUSE_PAUSED || SnappingClientVersion >= VERSION_DDNET_OLD));
 		pPlayerInfo->m_ClientID = id;
 		pPlayerInfo->m_Team = m_Team;
@@ -373,7 +374,7 @@ void CPlayer::Snap(int SnappingClient)
 			pPlayerInfo->m_PlayerFlags |= protocol7::PLAYERFLAG_ADMIN;
 
 		// Times are in milliseconds for 0.7
-		pPlayerInfo->m_Score = Score == -9999 ? -1 : -Score * 1000;
+		pPlayerInfo->m_Score = Score == -1 ? -1 : Score * 1000;
 		pPlayerInfo->m_Latency = Latency;
 	}
 
@@ -878,13 +879,7 @@ void CPlayer::ProcessScoreResult(CScorePlayerResult &Result)
 			break;
 		case CScorePlayerResult::PLAYER_INFO:
 			GameServer()->Score()->PlayerData(m_ClientID)->Set(Result.m_Data.m_Info.m_Time, Result.m_Data.m_Info.m_aTimeCp);
-			m_Score = Result.m_Data.m_Info.m_Score;
-			m_HasFinishScore = Result.m_Data.m_Info.m_HasFinishScore;
-			// -9999 stands for no time and isn't displayed in scoreboard, so
-			// shift the time by a second if the player actually took 9999
-			// seconds to finish the map.
-			if(m_HasFinishScore && m_Score == -9999)
-				m_Score = -10000;
+			m_Score = Result.m_Data.m_Info.m_Time;
 			Server()->ExpireServerInfo();
 			int Birthday = Result.m_Data.m_Info.m_Birthday;
 			if(Birthday != 0 && !m_BirthdayAnnounced)

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -182,7 +182,6 @@ public:
 	bool m_SpecTeam;
 	bool m_NinjaJetpack;
 	bool m_Afk;
-	bool m_HasFinishScore;
 
 	int m_ChatScore;
 

--- a/src/game/server/scoreworker.cpp
+++ b/src/game/server/scoreworker.cpp
@@ -37,10 +37,8 @@ void CScorePlayerResult::SetVariant(Variant v)
 		m_Data.m_MapVote.m_aServer[0] = '\0';
 		break;
 	case PLAYER_INFO:
-		m_Data.m_Info.m_Score = -9999;
 		m_Data.m_Info.m_Birthday = 0;
-		m_Data.m_Info.m_HasFinishScore = false;
-		m_Data.m_Info.m_Time = 0;
+		m_Data.m_Info.m_Time = -1;
 		for(float &TimeCp : m_Data.m_Info.m_aTimeCp)
 			TimeCp = 0;
 	}
@@ -165,8 +163,6 @@ bool CScoreWorker::LoadPlayerData(IDbConnection *pSqlServer, const ISqlData *pGa
 			// get the best time
 			float Time = pSqlServer->GetFloat(1);
 			pResult->m_Data.m_Info.m_Time = Time;
-			pResult->m_Data.m_Info.m_Score = -Time;
-			pResult->m_Data.m_Info.m_HasFinishScore = true;
 		}
 
 		for(int i = 0; i < NUM_CHECKPOINTS; i++)

--- a/src/game/server/scoreworker.h
+++ b/src/game/server/scoreworker.h
@@ -45,10 +45,8 @@ struct CScorePlayerResult : ISqlResult
 		char m_aBroadcast[1024];
 		struct
 		{
-			float m_Time;
+			float m_Time; // -1 for no time.
 			float m_aTimeCp[NUM_CHECKPOINTS];
-			int m_Score;
-			int m_HasFinishScore;
 			int m_Birthday; // 0 indicates no birthday
 		} m_Info;
 		struct

--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -809,10 +809,9 @@ void CGameTeams::OnFinish(CPlayer *Player, float Time, const char *pTimestamp)
 	}
 
 	int TTime = 0 - (int)Time;
-	if(Player->m_Score < TTime || !Player->m_HasFinishScore)
+	if(Player->m_Score == -1 || Player->m_Score < TTime)
 	{
 		Player->m_Score = TTime;
-		Player->m_HasFinishScore = true;
 	}
 }
 


### PR DESCRIPTION
It specifies whether the scores are to be interpreted as times (string value starting with "time") or as points (string value starting with "points").

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
