### PR TITLE
Avoid using `atoi`, `atof` and `atol` functions, use `str_copy` instead of `snprintf` to copy strings

### DIFF
--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -3402,7 +3402,7 @@ int str_isallnum(const char *str)
 int str_toint(const char *str) { return str_toint_base(str, 10); }
 int str_toint_base(const char *str, int base) { return strtol(str, NULL, base); }
 unsigned long str_toulong_base(const char *str, int base) { return strtoul(str, NULL, base); }
-float str_tofloat(const char *str) { return atof(str); }
+float str_tofloat(const char *str) { return strtod(str, NULL); }
 
 int str_utf8_comp_nocase(const char *a, const char *b)
 {

--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -3399,7 +3399,7 @@ int str_isallnum(const char *str)
 	return 1;
 }
 
-int str_toint(const char *str) { return atoi(str); }
+int str_toint(const char *str) { return str_toint_base(str, 10); }
 int str_toint_base(const char *str, int base) { return strtol(str, NULL, base); }
 unsigned long str_toulong_base(const char *str, int base) { return strtoul(str, NULL, base); }
 float str_tofloat(const char *str) { return atof(str); }

--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -1176,7 +1176,7 @@ static int priv_net_extract(const char *hostname, char *host, int max_host, int 
 
 		i++;
 		if(hostname[i] == ':')
-			*port = atol(hostname + i + 1);
+			*port = str_toint(hostname + i + 1);
 	}
 	else
 	{
@@ -1186,7 +1186,7 @@ static int priv_net_extract(const char *hostname, char *host, int max_host, int 
 		host[i] = 0;
 
 		if(hostname[i] == ':')
-			*port = atol(hostname + i + 1);
+			*port = str_toint(hostname + i + 1);
 	}
 
 	return 0;

--- a/src/tools/map_create_pixelart.cpp
+++ b/src/tools/map_create_pixelart.cpp
@@ -46,9 +46,9 @@ int main(int argc, const char **argv)
 	}
 
 	char aFilenames[3][64];
-	snprintf(aFilenames[0], 64, "%s", argv[3]); //input_map
-	snprintf(aFilenames[1], 64, "%s", argv[9]); //output_map
-	snprintf(aFilenames[2], 64, "%s", argv[1]); //image_file
+	str_copy(aFilenames[0], argv[3]); //input_map
+	str_copy(aFilenames[1], argv[9]); //output_map
+	str_copy(aFilenames[2], argv[1]); //image_file
 
 	int aLayerID[2] = {str_toint(argv[4]), str_toint(argv[5])}; //layergroup_id, layer_id
 	int aStartingPos[2] = {str_toint(argv[6]) * 32, str_toint(argv[7]) * 32}; //pos_x, pos_y

--- a/src/tools/map_create_pixelart.cpp
+++ b/src/tools/map_create_pixelart.cpp
@@ -50,13 +50,13 @@ int main(int argc, const char **argv)
 	snprintf(aFilenames[1], 64, "%s", argv[9]); //output_map
 	snprintf(aFilenames[2], 64, "%s", argv[1]); //image_file
 
-	int aLayerID[2] = {atoi(argv[4]), atoi(argv[5])}; //layergroup_id, layer_id
-	int aStartingPos[2] = {atoi(argv[6]) * 32, atoi(argv[7]) * 32}; //pos_x, pos_y
-	int aPixelSizes[2] = {atoi(argv[2]), atoi(argv[8])}; //quad_pixelsize, img_pixelsize
+	int aLayerID[2] = {str_toint(argv[4]), str_toint(argv[5])}; //layergroup_id, layer_id
+	int aStartingPos[2] = {str_toint(argv[6]) * 32, str_toint(argv[7]) * 32}; //pos_x, pos_y
+	int aPixelSizes[2] = {str_toint(argv[2]), str_toint(argv[8])}; //quad_pixelsize, img_pixelsize
 
 	bool aArtOptions[3];
-	aArtOptions[0] = argc >= 10 ? atoi(argv[10]) : true; //optimize
-	aArtOptions[1] = argc >= 11 ? atoi(argv[11]) : false; //centralize
+	aArtOptions[0] = argc >= 10 ? str_toint(argv[10]) : true; //optimize
+	aArtOptions[1] = argc >= 11 ? str_toint(argv[11]) : false; //centralize
 
 	dbg_msg("map_create_pixelart", "image_file='%s'; image_pixelsize='%dpx'; input_map='%s'; layergroup_id='#%d'; layer_id='#%d'; pos_x='#%dpx'; pos_y='%dpx'; quad_pixelsize='%dpx'; output_map='%s'; optimize='%d'; centralize='%d'",
 		aFilenames[2], aPixelSizes[0], aFilenames[1], aLayerID[0], aLayerID[1], aStartingPos[0], aStartingPos[1], aPixelSizes[1], aFilenames[2], aArtOptions[0], aArtOptions[1]);

--- a/src/tools/map_find_env.cpp
+++ b/src/tools/map_find_env.cpp
@@ -130,7 +130,7 @@ int main(int argc, const char **argv)
 	}
 
 	char aFilename[64];
-	snprintf(aFilename, 64, "%s", argv[1]);
+	str_copy(aFilename, argv[1]);
 	int EnvID = str_toint(argv[2]) - 1;
 	dbg_msg("map_find_env", "input_map='%s'; env_number='#%d';", aFilename, EnvID + 1);
 

--- a/src/tools/map_find_env.cpp
+++ b/src/tools/map_find_env.cpp
@@ -131,7 +131,7 @@ int main(int argc, const char **argv)
 
 	char aFilename[64];
 	snprintf(aFilename, 64, "%s", argv[1]);
-	int EnvID = atoi(argv[2]) - 1;
+	int EnvID = str_toint(argv[2]) - 1;
 	dbg_msg("map_find_env", "input_map='%s'; env_number='#%d';", aFilename, EnvID + 1);
 
 	return FindEnv(aFilename, EnvID);

--- a/src/tools/map_replace_area.cpp
+++ b/src/tools/map_replace_area.cpp
@@ -72,9 +72,9 @@ int main(int argc, const char *argv[])
 	}
 
 	char aaMapNames[3][64];
-	snprintf(aaMapNames[0], 64, "%s", argv[1]); //from_map
-	snprintf(aaMapNames[1], 64, "%s", argv[4]); //to_map
-	snprintf(aaMapNames[2], 64, "%s", argv[9]); //output_map
+	str_copy(aaMapNames[0], argv[1]); //from_map
+	str_copy(aaMapNames[1], argv[4]); //to_map
+	str_copy(aaMapNames[2], argv[9]); //output_map
 
 	float aaaGameAreas[2][2][2];
 

--- a/src/tools/map_replace_area.cpp
+++ b/src/tools/map_replace_area.cpp
@@ -80,10 +80,10 @@ int main(int argc, const char *argv[])
 
 	for(int i = 0; i < 2; i++)
 	{
-		aaaGameAreas[i][0][0] = atof(argv[2 + i * 3]) * 32; //x
-		aaaGameAreas[i][1][0] = atof(argv[3 + i * 3]) * 32; //y
-		aaaGameAreas[i][0][1] = aaaGameAreas[i][0][0] + atof(argv[7]) * 32; //x + width
-		aaaGameAreas[i][1][1] = aaaGameAreas[i][1][0] + atof(argv[8]) * 32; //y + height
+		aaaGameAreas[i][0][0] = str_tofloat(argv[2 + i * 3]) * 32; //x
+		aaaGameAreas[i][1][0] = str_tofloat(argv[3 + i * 3]) * 32; //y
+		aaaGameAreas[i][0][1] = aaaGameAreas[i][0][0] + str_tofloat(argv[7]) * 32; //x + width
+		aaaGameAreas[i][1][1] = aaaGameAreas[i][1][0] + str_tofloat(argv[8]) * 32; //y + height
 	}
 
 	cmdline_free(argc, argv);


### PR DESCRIPTION


## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
