### PR TITLE
Ignore useless pylint options (fixes #5950)

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -22,3 +22,4 @@ disable=
   R0915, # too-many-statements
   W0511, # fixme
   W0603, # global-statement
+  R0022, # useless-option-value


### PR DESCRIPTION
I think we should disable this warning for unknown warnings so that old pylint versions keep working ok

<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
