### PR TITLE
Fix text input not working when entering editor with bind, fix IME not being deactivated when editor is closed

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -3252,7 +3252,10 @@ void CClient::Run()
 				}
 			}
 			else if(m_EditorActive)
+			{
+				Input()->SetIMEState(false);
 				m_EditorActive = false;
+			}
 
 			Update();
 			int64_t Now = time_get();

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -3236,11 +3236,7 @@ void CClient::Run()
 			g_Config.m_DbgGraphs ^= 1;
 
 		if(CtrlShiftKey(KEY_E, LastE))
-		{
 			g_Config.m_ClEditor = g_Config.m_ClEditor ^ 1;
-			Input()->MouseModeRelative();
-			Input()->SetIMEState(true);
-		}
 
 		// render
 		{
@@ -3249,6 +3245,7 @@ void CClient::Run()
 				if(!m_EditorActive)
 				{
 					Input()->MouseModeRelative();
+					Input()->SetIMEState(true);
 					GameClient()->OnActivateEditor();
 					m_pEditor->ResetMentions();
 					m_EditorActive = true;


### PR DESCRIPTION
When entering the editor with a custom bind (e.g. `bind e "cl_editor 1"`) or when opening it from the console while also immediately closing the console (e.g. with `cl_editor 1; toggle_local_console`), the IME state was not properly set to active, so SDL did not report any `SDL_TEXTINPUT` events, leading to editboxes in the editor not receiving any text.

The is fixed by always enabling the IME state when entering the editor, which was previously only done when using the Ctrl+Shift+E hotkey or coincidentally when the editor is activated while the IME is already active, i.e. when the menu or console is open.

Closes #5095.

And fix another minor issue that became apparent due to added debug messages while debugging the previous issue:

Previously the IME was not deactivated when the editor is closed, so `SDL_TEXTINPUT` events where still being reported ingame after exiting the editor.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
