### PR TITLE
Add auto labeler for pull requests

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -44,7 +44,11 @@ tools:
 - any: ["src/tools/**/*]
 
 "UI/UX":
-- any: ["src/game/client/components/menu_*.{h,cpp}", "src/game/client/components/*board.{h,cpp}", "src/game/client/components/{hud,chat,freezebars,killmessages}.{h,cpp}"]
+- any:
+  - "src/game/client/components/menu_*.{h,cpp}"
+  - "src/game/client/components/*board.{h,cpp}"
+  - "src/game/client/components/{hud,chat,freezebars,killmessages}.{h,cpp}"
+  - "src/game/client/ui*.{h,cpp}"
 
 teehistorian:
 - any: ["src/game/server/teehistorian.{h,cpp}"]

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,50 @@
+network:
+- any: ["datasrc/*.py"]
+
+sixup:
+- any: ["datasrc/seven/*.py"]
+
+scripts: "scripts/**/*"
+
+android:
+- any: ["scripts/android/**/*", "src/android/**/*"]
+
+base: "src/base/**/*"
+
+building:
+- any: ["*.supp", "CMakeLists.txt", "Dockerfile"]
+
+CI:
+- any: ["bors.toml", ".github/workflows/**/*"]
+
+client:
+- any: ["src/engine/client/**/*", "src/engine/shared/**/*", "src/game/client/**/*", "src/game/*.{h,cpp,rs}"]
+
+server:
+- any: ["src/engine/server/**/*", "src/engine/shared/**/*", "src/game/server/**/*", "src/game/*.{h,cpp,rs}"]
+
+antibot: "src/antibot/**/*"
+
+editor:
+- any: ["src/game/editor/**/*"]
+
+prediction:
+- any: ["src/game/client/prediction/**/*"]
+
+sql:
+- any: ["src/engine/server/databases/**/*"]
+
+macOS:
+- any: ["src/macos/**/*", "./**/*.mm"]
+
+tests:
+- any: ["src/test/**/*"]
+
+tools:
+- any: ["src/tools/**/*]
+
+"UI/UX":
+- any: ["src/game/client/components/menu_*.{h,cpp}", "src/game/client/components/*board.{h,cpp}", "src/game/client/components/{hud,chat,freezebars,killmessages}.{h,cpp}"]
+
+teehistorian:
+- any: ["src/game/server/teehistorian.{h,cpp}"]

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -41,7 +41,7 @@ tests:
 - any: ["src/test/**/*"]
 
 tools:
-- any: ["src/tools/**/*]
+- any: ["src/tools/**/*"]
 
 "UI/UX":
 - any:

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,22 @@
+# This workflow will triage pull requests and apply a label based on the
+# paths that are modified in the pull request.
+#
+# To use this workflow, you will need to set up a .github/labeler.yml
+# file with configuration.  For more information, see:
+# https://github.com/actions/labeler
+
+name: Labeler
+on: [pull_request]
+
+jobs:
+  label:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+    - uses: actions/labeler@v4
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This PR adds a github action that automatically labels PRs based on files changed: https://github.com/actions/labeler

---

Someone in the ddnet team needs to add an actions secret with the name GITHUB_TOKEN to https://github.com/ddnet/ddnet/settings/secrets/actions , can generate one from: https://github.com/settings/tokens

I would do it, but i think @def- is the best fit for such things.