### PR TITLE
Fix large editor popups being outside of screen, add margin

### DIFF
--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -32,10 +32,11 @@ void CEditor::UiInvokePopupMenu(void *pID, int Flags, float x, float y, float Wi
 	if(g_UiNumPopups > 7)
 		return;
 	Console()->Print(IConsole::OUTPUT_LEVEL_DEBUG, "editor", "invoked");
-	if(x + Width > UI()->Screen()->w)
-		x -= Width;
-	if(y + Height > UI()->Screen()->h)
-		y -= Height;
+	const float Margin = 5.0f;
+	if(x + Width > UI()->Screen()->w - Margin)
+		x = maximum<float>(x - Width, Margin);
+	if(y + Height > UI()->Screen()->h - Margin)
+		y = maximum<float>(y - Height, Margin);
 	s_UiPopups[g_UiNumPopups].m_pId = pID;
 	s_UiPopups[g_UiNumPopups].m_IsMenu = Flags;
 	s_UiPopups[g_UiNumPopups].m_Rect.x = x;


### PR DESCRIPTION
Large editor popups could be positioned outside of the screen area, when they could not be positioned below or to the right of the cursor without overflowing. This is fixed by making sure the popup does not overflow the top or left side of the screen after adjusting its position.

A small margin is also added so popups don't start or end immediately at the screen border.

Closes #5982.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
