### PR TITLE
Use `str_copy` instead of `str_format` with format `"%s"`

### DIFF
--- a/src/engine/client/backend/vulkan/backend_vulkan.cpp
+++ b/src/engine/client/backend/vulkan/backend_vulkan.cpp
@@ -1106,7 +1106,7 @@ protected:
 	{
 		char aError[1024];
 		if(pErrStrExtra == nullptr)
-			str_format(aError, std::size(aError), "%s", pErr);
+			str_copy(aError, pErr);
 		else
 			str_format(aError, std::size(aError), "%s: %s", pErr, pErrStrExtra);
 		dbg_msg("vulkan", "vulkan error: %s", aError);

--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -2681,7 +2681,7 @@ void CGraphics_Threaded::AddBackEndWarningIfExists()
 	if(pErrStr != NULL)
 	{
 		SWarning NewWarning;
-		str_format(NewWarning.m_aWarningMsg, sizeof(NewWarning.m_aWarningMsg), "%s", Localize(pErrStr));
+		str_copy(NewWarning.m_aWarningMsg, Localize(pErrStr));
 		m_vWarnings.emplace_back(NewWarning);
 	}
 }

--- a/src/game/client/components/binds.cpp
+++ b/src/game/client/components/binds.cpp
@@ -175,9 +175,9 @@ const char *CBinds::Get(int KeyID, int ModifierCombination)
 	return "";
 }
 
-void CBinds::GetKey(const char *pBindStr, char *aBuf, unsigned BufSize)
+void CBinds::GetKey(const char *pBindStr, char *pBuf, size_t BufSize)
 {
-	aBuf[0] = 0;
+	pBuf[0] = 0;
 	for(int Mod = 0; Mod < MODIFIER_COMBINATION_COUNT; Mod++)
 	{
 		for(int KeyId = 0; KeyId < KEY_LAST; KeyId++)
@@ -189,9 +189,9 @@ void CBinds::GetKey(const char *pBindStr, char *aBuf, unsigned BufSize)
 			if(str_comp(pBind, pBindStr) == 0)
 			{
 				if(Mod)
-					str_format(aBuf, BufSize, "%s+%s", GetModifierName(Mod), Input()->KeyName(KeyId));
+					str_format(pBuf, BufSize, "%s+%s", GetModifierName(Mod), Input()->KeyName(KeyId));
 				else
-					str_copy(aBuf, Input()->KeyName(KeyId), BufSize);
+					str_copy(pBuf, Input()->KeyName(KeyId), BufSize);
 				return;
 			}
 		}

--- a/src/game/client/components/binds.cpp
+++ b/src/game/client/components/binds.cpp
@@ -191,7 +191,7 @@ void CBinds::GetKey(const char *pBindStr, char *aBuf, unsigned BufSize)
 				if(Mod)
 					str_format(aBuf, BufSize, "%s+%s", GetModifierName(Mod), Input()->KeyName(KeyId));
 				else
-					str_format(aBuf, BufSize, "%s", Input()->KeyName(KeyId));
+					str_copy(aBuf, Input()->KeyName(KeyId), BufSize);
 				return;
 			}
 		}

--- a/src/game/client/components/binds.h
+++ b/src/game/client/components/binds.h
@@ -52,7 +52,7 @@ public:
 	void SetDefaults();
 	void UnbindAll();
 	const char *Get(int KeyID, int ModifierCombination);
-	void GetKey(const char *pBindStr, char *aBuf, unsigned BufSize);
+	void GetKey(const char *pBindStr, char *pBuf, size_t BufSize);
 	int GetBindSlot(const char *pBindString, int *pModifierCombination);
 	static int GetModifierMask(IInput *pInput);
 	static int GetModifierMaskOfKey(int Key);

--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -804,7 +804,7 @@ void CChat::AddLine(int ClientID, int Team, const char *pLine)
 		if(pCurrentLine->m_ClientID < 0) // server or client message
 		{
 			str_copy(pCurrentLine->m_aName, "*** ");
-			str_format(pCurrentLine->m_aText, sizeof(pCurrentLine->m_aText), "%s", pLine);
+			str_copy(pCurrentLine->m_aText, pLine);
 		}
 		else
 		{
@@ -834,9 +834,9 @@ void CChat::AddLine(int ClientID, int Team, const char *pLine)
 				Highlighted = true;
 			}
 			else
-				str_format(pCurrentLine->m_aName, sizeof(pCurrentLine->m_aName), "%s", m_pClient->m_aClients[ClientID].m_aName);
+				str_copy(pCurrentLine->m_aName, m_pClient->m_aClients[ClientID].m_aName);
 
-			str_format(pCurrentLine->m_aText, sizeof(pCurrentLine->m_aText), "%s", pLine);
+			str_copy(pCurrentLine->m_aText, pLine);
 			pCurrentLine->m_Friend = m_pClient->m_aClients[ClientID].m_Friend;
 		}
 

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -653,7 +653,7 @@ int CMenus::DoKeyReader(void *pID, const CUIRect *pRect, int Key, int ModifierCo
 			if(*pNewModifierCombination)
 				str_format(aBuf, sizeof(aBuf), "%s%s", CBinds::GetKeyBindModifiersName(*pNewModifierCombination), Input()->KeyName(Key));
 			else
-				str_format(aBuf, sizeof(aBuf), "%s", Input()->KeyName(Key));
+				str_copy(aBuf, Input()->KeyName(Key));
 
 			DoButton_KeySelect(pID, aBuf, 0, pRect);
 		}
@@ -2381,13 +2381,13 @@ void CMenus::RenderThemeSelection(CUIRect MainView, bool Header)
 		else if(str_comp(Theme.m_Name.c_str(), "rand") == 0)
 			str_copy(aName, "(random)");
 		else if(Theme.m_HasDay && Theme.m_HasNight)
-			str_format(aName, sizeof(aName), "%s", Theme.m_Name.c_str());
+			str_copy(aName, Theme.m_Name.c_str());
 		else if(Theme.m_HasDay && !Theme.m_HasNight)
 			str_format(aName, sizeof(aName), "%s (day)", Theme.m_Name.c_str());
 		else if(!Theme.m_HasDay && Theme.m_HasNight)
 			str_format(aName, sizeof(aName), "%s (night)", Theme.m_Name.c_str());
 		else // generic
-			str_format(aName, sizeof(aName), "%s", Theme.m_Name.c_str());
+			str_copy(aName, Theme.m_Name.c_str());
 
 		UI()->DoLabel(&Item.m_Rect, aName, 16 * CUI::ms_FontmodHeight, TEXTALIGN_LEFT);
 	}
@@ -2397,7 +2397,7 @@ void CMenus::RenderThemeSelection(CUIRect MainView, bool Header)
 
 	if(ItemActive && NewSelected != SelectedTheme)
 	{
-		str_format(g_Config.m_ClMenuMap, sizeof(g_Config.m_ClMenuMap), "%s", vThemesRef[NewSelected].m_Name.c_str());
+		str_copy(g_Config.m_ClMenuMap, vThemesRef[NewSelected].m_Name.c_str());
 		m_pBackground->LoadMenuBackground(vThemesRef[NewSelected].m_HasDay, vThemesRef[NewSelected].m_HasNight);
 	}
 }

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -47,7 +47,7 @@ void FormatServerbrowserPing(char *pBuffer, int BufferLength, const CServerInfo 
 		"CHN", // LOC_CHINA // Localize("CHN")
 	};
 	dbg_assert(0 <= pInfo->m_Location && pInfo->m_Location < CServerInfo::NUM_LOCS, "location out of range");
-	str_format(pBuffer, BufferLength, "%s", Localize(LOCATION_NAMES[pInfo->m_Location]));
+	str_copy(pBuffer, Localize(LOCATION_NAMES[pInfo->m_Location]), BufferLength);
 }
 
 void CMenus::RenderServerbrowserServerList(CUIRect View)

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -1434,7 +1434,7 @@ int CMenus::RenderDropDown(int &CurDropDownState, CUIRect *pRect, int CurSelecti
 			CListboxItem Item = UiDoListboxNextItem(pIDs[i], CurSelection == i);
 			if(Item.m_Visible)
 			{
-				str_format(aBuf, sizeof(aBuf), "%s", pStr[i]);
+				str_copy(aBuf, pStr[i]);
 				UI()->DoLabel(&Item.m_Rect, aBuf, 16.0f, TEXTALIGN_CENTER);
 			}
 		}

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -2773,7 +2773,7 @@ void CGameClient::LoadGameSkin(const char *pPath, bool AsDir)
 	bool IsDefault = false;
 	if(str_comp(pPath, "default") == 0)
 	{
-		str_format(aPath, sizeof(aPath), "%s", g_pData->m_aImages[IMAGE_GAME].m_pFilename);
+		str_copy(aPath, g_pData->m_aImages[IMAGE_GAME].m_pFilename);
 		IsDefault = true;
 	}
 	else
@@ -2935,7 +2935,7 @@ void CGameClient::LoadEmoticonsSkin(const char *pPath, bool AsDir)
 	bool IsDefault = false;
 	if(str_comp(pPath, "default") == 0)
 	{
-		str_format(aPath, sizeof(aPath), "%s", g_pData->m_aImages[IMAGE_EMOTICONS].m_pFilename);
+		str_copy(aPath, g_pData->m_aImages[IMAGE_EMOTICONS].m_pFilename);
 		IsDefault = true;
 	}
 	else
@@ -2989,7 +2989,7 @@ void CGameClient::LoadParticlesSkin(const char *pPath, bool AsDir)
 	bool IsDefault = false;
 	if(str_comp(pPath, "default") == 0)
 	{
-		str_format(aPath, sizeof(aPath), "%s", g_pData->m_aImages[IMAGE_PARTICLES].m_pFilename);
+		str_copy(aPath, g_pData->m_aImages[IMAGE_PARTICLES].m_pFilename);
 		IsDefault = true;
 	}
 	else
@@ -3076,7 +3076,7 @@ void CGameClient::LoadHudSkin(const char *pPath, bool AsDir)
 	bool IsDefault = false;
 	if(str_comp(pPath, "default") == 0)
 	{
-		str_format(aPath, sizeof(aPath), "%s", g_pData->m_aImages[IMAGE_HUD].m_pFilename);
+		str_copy(aPath, g_pData->m_aImages[IMAGE_HUD].m_pFilename);
 		IsDefault = true;
 	}
 	else
@@ -3149,7 +3149,7 @@ void CGameClient::LoadExtrasSkin(const char *pPath, bool AsDir)
 	bool IsDefault = false;
 	if(str_comp(pPath, "default") == 0)
 	{
-		str_format(aPath, sizeof(aPath), "%s", g_pData->m_aImages[IMAGE_EXTRAS].m_pFilename);
+		str_copy(aPath, g_pData->m_aImages[IMAGE_EXTRAS].m_pFilename);
 		IsDefault = true;
 	}
 	else
@@ -3261,7 +3261,7 @@ void CGameClient::ConchainMenuMap(IConsole::IResult *pResult, void *pUserData, I
 	{
 		if(str_comp(g_Config.m_ClMenuMap, pResult->GetString(0)) != 0)
 		{
-			str_format(g_Config.m_ClMenuMap, sizeof(g_Config.m_ClMenuMap), "%s", pResult->GetString(0));
+			str_copy(g_Config.m_ClMenuMap, pResult->GetString(0));
 			pSelf->m_MenuBackground.LoadMenuBackground();
 		}
 	}

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -3191,7 +3191,7 @@ int CEditor::DoProperties(CUIRect *pToolBox, CProperty *pProps, int *pIDs, int *
 			if(pProps[i].m_Value < 0)
 				str_copy(aBuf, "None", sizeof(aBuf));
 			else
-				str_format(aBuf, sizeof(aBuf), "%s", m_Map.m_vpImages[pProps[i].m_Value]->m_aName);
+				str_copy(aBuf, m_Map.m_vpImages[pProps[i].m_Value]->m_aName);
 
 			float FontSize = ScaleFontSize(aBuf, sizeof(aBuf), 10.0f, Shifter.w);
 			if(DoButton_Ex(&pIDs[i], aBuf, 0, &Shifter, 0, nullptr, IGraphics::CORNER_ALL, FontSize))
@@ -3243,7 +3243,7 @@ int CEditor::DoProperties(CUIRect *pToolBox, CProperty *pProps, int *pIDs, int *
 			if(pProps[i].m_Value < 0)
 				str_copy(aBuf, "None", sizeof(aBuf));
 			else
-				str_format(aBuf, sizeof(aBuf), "%s", m_Map.m_vpSounds[pProps[i].m_Value]->m_aName);
+				str_copy(aBuf, m_Map.m_vpSounds[pProps[i].m_Value]->m_aName);
 
 			float FontSize = ScaleFontSize(aBuf, sizeof(aBuf), 10.0f, Shifter.w);
 			if(DoButton_Ex(&pIDs[i], aBuf, 0, &Shifter, 0, nullptr, IGraphics::CORNER_ALL, FontSize))
@@ -3262,7 +3262,7 @@ int CEditor::DoProperties(CUIRect *pToolBox, CProperty *pProps, int *pIDs, int *
 			if(pProps[i].m_Value < 0 || pProps[i].m_Min < 0 || pProps[i].m_Min >= (int)m_Map.m_vpImages.size())
 				str_copy(aBuf, "None", sizeof(aBuf));
 			else
-				str_format(aBuf, sizeof(aBuf), "%s", m_Map.m_vpImages[pProps[i].m_Min]->m_AutoMapper.GetConfigName(pProps[i].m_Value));
+				str_copy(aBuf, m_Map.m_vpImages[pProps[i].m_Min]->m_AutoMapper.GetConfigName(pProps[i].m_Value));
 
 			float FontSize = ScaleFontSize(aBuf, sizeof(aBuf), 10.0f, Shifter.w);
 			if(DoButton_Ex(&pIDs[i], aBuf, 0, &Shifter, 0, nullptr, IGraphics::CORNER_ALL, FontSize))

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -1975,7 +1975,7 @@ void CGameContext::OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID)
 
 						str_format(aChatmsg, sizeof(aChatmsg), "'%s' called vote to change server option '%s' (%s)", Server()->ClientName(ClientID),
 							pOption->m_aDescription, aReason);
-						str_format(aDesc, sizeof(aDesc), "%s", pOption->m_aDescription);
+						str_copy(aDesc, pOption->m_aDescription);
 
 						if((str_endswith(pOption->m_aCommand, "random_map") || str_endswith(pOption->m_aCommand, "random_unfinished_map")) && str_length(aReason) == 1 && aReason[0] >= '0' && aReason[0] <= '5')
 						{
@@ -1984,7 +1984,7 @@ void CGameContext::OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID)
 						}
 						else
 						{
-							str_format(aCmd, sizeof(aCmd), "%s", pOption->m_aCommand);
+							str_copy(aCmd, pOption->m_aCommand);
 						}
 
 						m_LastMapVote = time_get();
@@ -2005,8 +2005,8 @@ void CGameContext::OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID)
 					else
 					{
 						str_format(aChatmsg, sizeof(aChatmsg), "'%s' called vote to change server option '%s'", Server()->ClientName(ClientID), pMsg->m_pValue);
-						str_format(aDesc, sizeof(aDesc), "%s", pMsg->m_pValue);
-						str_format(aCmd, sizeof(aCmd), "%s", pMsg->m_pValue);
+						str_copy(aDesc, pMsg->m_pValue);
+						str_copy(aCmd, pMsg->m_pValue);
 					}
 				}
 
@@ -3380,7 +3380,7 @@ void CGameContext::OnInit(/*class IKernel *pKernel*/)
 		}
 		else
 		{
-			str_format(aVersion, sizeof(aVersion), "%s", GAME_VERSION);
+			str_copy(aVersion, GAME_VERSION);
 		}
 		CTeeHistorian::CGameInfo GameInfo;
 		GameInfo.m_GameUuid = m_GameUuid;
@@ -4147,7 +4147,7 @@ void CGameContext::List(int ClientID, const char *pFilter)
 			}
 			else
 			{
-				str_format(&aBuf[Bufcnt], sizeof(aBuf) - Bufcnt, "%s", pName);
+				str_copy(&aBuf[Bufcnt], pName, sizeof(aBuf) - Bufcnt);
 				Bufcnt += str_length(pName);
 			}
 		}


### PR DESCRIPTION
Using `str_format(aBuf, sizeof(aBuf), "%s", pStr)` is equivalent to `str_copy(aBuf, pStr, sizeof(aBuf))`. Using `str_copy` is more readable and also more efficient as there is no overhead from parsing the format string and from passing varargs.

<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
