### PR TITLE
Fix incorrect minimum values for tele, speedup and switch layers

### DIFF
--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -1551,7 +1551,7 @@ int CEditor::PopupTele(CEditor *pEditor, CUIRect View, void *pContext)
 		int Prop = pEditor->DoProperties(&NumberPicker, aProps, s_aIds, &NewVal, s_Color);
 		if(Prop == PROP_TELE)
 		{
-			pEditor->m_TeleNumber = (NewVal + 256) % 256;
+			pEditor->m_TeleNumber = (NewVal - 1 + 255) % 255 + 1;
 		}
 
 		if(s_PreviousNumber == 1 || s_PreviousNumber != pEditor->m_TeleNumber)
@@ -1579,7 +1579,7 @@ int CEditor::PopupSpeedup(CEditor *pEditor, CUIRect View, void *pContext)
 	};
 
 	CProperty aProps[] = {
-		{"Force", pEditor->m_SpeedupForce, PROPTYPE_INT_STEP, 0, 255},
+		{"Force", pEditor->m_SpeedupForce, PROPTYPE_INT_STEP, 1, 255},
 		{"Max Speed", pEditor->m_SpeedupMaxSpeed, PROPTYPE_INT_STEP, 0, 255},
 		{"Angle", pEditor->m_SpeedupAngle, PROPTYPE_ANGLE_SCROLL, 0, 359},
 		{nullptr},
@@ -1590,7 +1590,7 @@ int CEditor::PopupSpeedup(CEditor *pEditor, CUIRect View, void *pContext)
 	int Prop = pEditor->DoProperties(&View, aProps, s_aIds, &NewVal);
 
 	if(Prop == PROP_FORCE)
-		pEditor->m_SpeedupForce = clamp(NewVal, 0, 255);
+		pEditor->m_SpeedupForce = clamp(NewVal, 1, 255);
 	if(Prop == PROP_MAXSPEED)
 		pEditor->m_SpeedupMaxSpeed = clamp(NewVal, 0, 255);
 	if(Prop == PROP_ANGLE)
@@ -1657,7 +1657,7 @@ int CEditor::PopupSwitch(CEditor *pEditor, CUIRect View, void *pContext)
 
 		if(Prop == PROP_SwitchNumber)
 		{
-			pEditor->m_SwitchNum = (NewVal + 256) % 256;
+			pEditor->m_SwitchNum = (NewVal - 1 + 255) % 255 + 1;
 		}
 		else if(Prop == PROP_SwitchDelay)
 		{


### PR DESCRIPTION
It was possible to select tele number 0, speedup force 0 and switch number 0 in the layer details in the editor, because some of the bounds checks or calculations were not excluding the value 0. As placing those tiles with the value 0 in the editor is not possible and the tiles with this value are ignored by server and client, it also shouldn't be possible to select those values in the first place.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
