### PR TITLE
Change editor hotkey Ctrl+A to Ctrl+T for layer/tile details

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -1166,11 +1166,11 @@ void CEditor::DoToolbar(CUIRect ToolBar)
 					if(pButtonName != nullptr)
 					{
 						static char aBuf[64];
-						str_format(aBuf, sizeof(aBuf), "[ctrl+a] %s", pButtonName);
+						str_format(aBuf, sizeof(aBuf), "[ctrl+t] %s", pButtonName);
 
 						TB_Bottom.VSplitLeft(60.0f, &Button, &TB_Bottom);
 						static int s_ModifierButton = 0;
-						if(DoButton_Ex(&s_ModifierButton, pButtonName, 0, &Button, 0, aBuf, IGraphics::CORNER_ALL) || (ModPressed && Input()->KeyPress(KEY_A)))
+						if(DoButton_Ex(&s_ModifierButton, pButtonName, 0, &Button, 0, aBuf, IGraphics::CORNER_ALL) || (ModPressed && Input()->KeyPress(KEY_T)))
 						{
 							static int s_ModifierPopupID = 0;
 							if(!UiPopupExists(&s_ModifierPopupID))


### PR DESCRIPTION
The hotkey Ctrl+A is already active universally in the editor to open and append a map to the current one. This collides with the hotkeys for opening the layer/tile details popup for tune, tele, speedup and switch layers, which is only active when a layer of said type is select. Pressing the hotkey in this context opens the popup and the append dialog at the same time, which is undesirable. Therefore the hotkey to open the layer/tile details is changed to Ctrl+T instead. This combination is currently unused and seems approriate, as the T could stand for "Tile details".

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
