### PR TITLE
Allow selecting switch number 0 in editor again

### DIFF
--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -1646,7 +1646,7 @@ int CEditor::PopupSwitch(CEditor *pEditor, CUIRect View, void *pContext)
 		};
 
 		CProperty aProps[] = {
-			{"Number", pEditor->m_SwitchNum, PROPTYPE_INT_STEP, 1, 255},
+			{"Number", pEditor->m_SwitchNum, PROPTYPE_INT_STEP, 0, 255},
 			{"Delay", pEditor->m_SwitchDelay, PROPTYPE_INT_STEP, 0, 255},
 			{nullptr},
 		};
@@ -1657,7 +1657,7 @@ int CEditor::PopupSwitch(CEditor *pEditor, CUIRect View, void *pContext)
 
 		if(Prop == PROP_SwitchNumber)
 		{
-			pEditor->m_SwitchNum = (NewVal - 1 + 255) % 255 + 1;
+			pEditor->m_SwitchNum = (NewVal + 256) % 256;
 		}
 		else if(Prop == PROP_SwitchDelay)
 		{


### PR DESCRIPTION
This reverts part of #5993 to allow switch number 0 to be selected again. Switch number 0 is permanently enabled, so it useful for tiles that should always be switched on. Eventually tiles that don't work with switch 0 (e.g. switch open/close tiles) should be made unplaceable and the switch number should be hidden for tiles where it doesn't have any effect (e.g. jump tiles). See #5995.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
