### PR TITLE
Switch to Vulkan 1.1

### DIFF
--- a/src/engine/client/backend/vulkan/backend_vulkan.cpp
+++ b/src/engine/client/backend/vulkan/backend_vulkan.cpp
@@ -3450,7 +3450,7 @@ public:
 		VKAppInfo.applicationVersion = 1;
 		VKAppInfo.pEngineName = "DDNet-Vulkan";
 		VKAppInfo.engineVersion = 1;
-		VKAppInfo.apiVersion = VK_API_VERSION_1_0;
+		VKAppInfo.apiVersion = VK_API_VERSION_1_1;
 
 		void *pExt = nullptr;
 #if defined(VK_EXT_validation_features) && VK_EXT_VALIDATION_FEATURES_SPEC_VERSION >= 5

--- a/src/engine/client/backend/vulkan/backend_vulkan.h
+++ b/src/engine/client/backend/vulkan/backend_vulkan.h
@@ -4,7 +4,7 @@
 class CCommandProcessorFragment_GLBase;
 
 static constexpr int gs_BackendVulkanMajor = 1;
-static constexpr int gs_BackendVulkanMinor = 0;
+static constexpr int gs_BackendVulkanMinor = 1;
 
 CCommandProcessorFragment_GLBase *CreateVulkanCommandProcessorFragment();
 


### PR DESCRIPTION
Since the vulkan loader drops support for useful extensions (or the extension loading process changed between 1.0 & 1.1, not sure) Which causes OBS not to work

lets wait for a response in 
`https://github.com/KhronosGroup/Vulkan-Loader/issues/1048`
tho

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
