### PR TITLE
Search for images/sounds in subfolders when readding in editor, show selection dialog if multiple files with the same are found, show error popup when file cannot be found

### DIFF
--- a/src/engine/shared/storage.cpp
+++ b/src/engine/shared/storage.cpp
@@ -520,6 +520,69 @@ public:
 		return pBuffer[0] != 0;
 	}
 
+	struct SFindFilesCallbackData
+	{
+		CStorage *m_pStorage;
+		const char *m_pFilename;
+		const char *m_pPath;
+		std::set<std::string> *m_pEntries;
+	};
+
+	static int FindFilesCallback(const char *pName, int IsDir, int Type, void *pUser)
+	{
+		SFindFilesCallbackData Data = *static_cast<SFindFilesCallbackData *>(pUser);
+		if(IsDir)
+		{
+			if(pName[0] == '.')
+				return 0;
+
+			// search within the folder
+			char aBuf[IO_MAX_PATH_LENGTH];
+			char aPath[IO_MAX_PATH_LENGTH];
+			str_format(aPath, sizeof(aPath), "%s/%s", Data.m_pPath, pName);
+			Data.m_pPath = aPath;
+			fs_listdir(Data.m_pStorage->GetPath(Type, aPath, aBuf, sizeof(aBuf)), FindFilesCallback, Type, &Data);
+		}
+		else if(!str_comp(pName, Data.m_pFilename))
+		{
+			char aBuffer[IO_MAX_PATH_LENGTH];
+			str_format(aBuffer, sizeof(aBuffer), "%s/%s", Data.m_pPath, Data.m_pFilename);
+			Data.m_pEntries->emplace(aBuffer);
+		}
+
+		return 0;
+	}
+
+	size_t FindFiles(const char *pFilename, const char *pPath, int Type, std::set<std::string> *pEntries) override
+	{
+		SFindFilesCallbackData Data;
+		Data.m_pStorage = this;
+		Data.m_pFilename = pFilename;
+		Data.m_pPath = pPath;
+		Data.m_pEntries = pEntries;
+
+		char aBuf[IO_MAX_PATH_LENGTH];
+		if(Type == TYPE_ALL)
+		{
+			// search within all available directories
+			for(int i = TYPE_SAVE; i < m_NumPaths; ++i)
+			{
+				fs_listdir(GetPath(i, pPath, aBuf, sizeof(aBuf)), FindFilesCallback, i, &Data);
+			}
+		}
+		else if(Type >= TYPE_SAVE && Type < m_NumPaths)
+		{
+			// search within wanted directory
+			fs_listdir(GetPath(Type, pPath, aBuf, sizeof(aBuf)), FindFilesCallback, Type, &Data);
+		}
+		else
+		{
+			dbg_assert(false, "Type invalid");
+		}
+
+		return pEntries->size();
+	}
+
 	bool RemoveFile(const char *pFilename, int Type) override
 	{
 		dbg_assert(Type == TYPE_ABSOLUTE || (Type >= TYPE_SAVE && Type < m_NumPaths), "Type invalid");

--- a/src/engine/storage.h
+++ b/src/engine/storage.h
@@ -5,6 +5,9 @@
 
 #include "kernel.h"
 
+#include <set>
+#include <string>
+
 enum
 {
 	MAX_PATHS = 16
@@ -31,6 +34,7 @@ public:
 	virtual bool ReadFile(const char *pFilename, int Type, void **ppResult, unsigned *pResultLen) = 0;
 	virtual char *ReadFileStr(const char *pFilename, int Type) = 0;
 	virtual bool FindFile(const char *pFilename, const char *pPath, int Type, char *pBuffer, int BufferSize) = 0;
+	virtual size_t FindFiles(const char *pFilename, const char *pPath, int Type, std::set<std::string> *pEntries) = 0;
 	virtual bool RemoveFile(const char *pFilename, int Type) = 0;
 	virtual bool RenameFile(const char *pOldFilename, const char *pNewFilename, int Type) = 0;
 	virtual bool CreateFolder(const char *pFoldername, int Type) = 0;

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -3839,14 +3839,25 @@ int CEditor::PopupImage(CEditor *pEditor, CUIRect View, void *pContext)
 		View.HSplitTop(12.0f, &Slot, &View);
 	}
 
-	if(pEditor->DoButton_MenuItem(&s_ReaddButton, "Readd", 0, &Slot, 0, "Reloads the image from mapres folder"))
+	if(pEditor->DoButton_MenuItem(&s_ReaddButton, "Readd", 0, &Slot, 0, "Reloads the image from the mapres folder"))
 	{
-		bool bIsExternal = pImg->m_External;
-		char aBuffer[1024];
-		str_format(aBuffer, sizeof(aBuffer), "mapres/%s.png", pImg->m_aName);
-		ReplaceImage(aBuffer, IStorage::TYPE_ALL, pEditor);
-		pImg->m_External = bIsExternal;
-		return 1;
+		char aFilename[IO_MAX_PATH_LENGTH];
+		str_format(aFilename, sizeof(aFilename), "%s.png", pImg->m_aName);
+		char aPath[IO_MAX_PATH_LENGTH];
+		if(pEditor->Storage()->FindFile(aFilename, "mapres", IStorage::TYPE_ALL, aPath, sizeof(aPath)))
+		{
+			bool WasExternal = pImg->m_External;
+			ReplaceImage(aPath, IStorage::TYPE_ALL, pEditor);
+			pImg->m_External = WasExternal;
+			return 1;
+		}
+		else
+		{
+			static SMessagePopupContext s_MessagePopupContext;
+			s_MessagePopupContext.ErrorColor();
+			str_format(s_MessagePopupContext.m_aMessage, sizeof(s_MessagePopupContext.m_aMessage), "Error: could not find image '%s' in the mapres folder.", aFilename);
+			pEditor->ShowPopupMessage(pEditor->UI()->MouseX(), pEditor->UI()->MouseY(), &s_MessagePopupContext);
+		}
 	}
 
 	View.HSplitTop(5.0f, nullptr, &View);
@@ -3881,12 +3892,23 @@ int CEditor::PopupSound(CEditor *pEditor, CUIRect View, void *pContext)
 	View.HSplitTop(12.0f, &Slot, &View);
 	CEditorSound *pSound = pEditor->m_Map.m_vpSounds[pEditor->m_SelectedSound];
 
-	if(pEditor->DoButton_MenuItem(&s_ReaddButton, "Readd", 0, &Slot, 0, "Reloads the sound from mapres folder"))
+	if(pEditor->DoButton_MenuItem(&s_ReaddButton, "Readd", 0, &Slot, 0, "Reloads the sound from the mapres folder"))
 	{
-		char aBuffer[1024];
-		str_format(aBuffer, sizeof(aBuffer), "mapres/%s.opus", pSound->m_aName);
-		ReplaceSound(aBuffer, IStorage::TYPE_ALL, pEditor);
-		return 1;
+		char aFilename[IO_MAX_PATH_LENGTH];
+		str_format(aFilename, sizeof(aFilename), "%s.opus", pSound->m_aName);
+		char aPath[IO_MAX_PATH_LENGTH];
+		if(pEditor->Storage()->FindFile(aFilename, "mapres", IStorage::TYPE_ALL, aPath, sizeof(aPath)))
+		{
+			ReplaceSound(aPath, IStorage::TYPE_ALL, pEditor);
+			return 1;
+		}
+		else
+		{
+			static SMessagePopupContext s_MessagePopupContext;
+			s_MessagePopupContext.ErrorColor();
+			str_format(s_MessagePopupContext.m_aMessage, sizeof(s_MessagePopupContext.m_aMessage), "Error: could not find sound '%s' in the mapres folder.", aFilename);
+			pEditor->ShowPopupMessage(pEditor->UI()->MouseX(), pEditor->UI()->MouseY(), &s_MessagePopupContext);
+		}
 	}
 
 	View.HSplitTop(5.0f, nullptr, &View);

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -3839,25 +3839,39 @@ int CEditor::PopupImage(CEditor *pEditor, CUIRect View, void *pContext)
 		View.HSplitTop(12.0f, &Slot, &View);
 	}
 
+	static SSelectionPopupContext s_SelectionPopupContext;
 	if(pEditor->DoButton_MenuItem(&s_ReaddButton, "Readd", 0, &Slot, 0, "Reloads the image from the mapres folder"))
 	{
 		char aFilename[IO_MAX_PATH_LENGTH];
 		str_format(aFilename, sizeof(aFilename), "%s.png", pImg->m_aName);
-		char aPath[IO_MAX_PATH_LENGTH];
-		if(pEditor->Storage()->FindFile(aFilename, "mapres", IStorage::TYPE_ALL, aPath, sizeof(aPath)))
-		{
-			bool WasExternal = pImg->m_External;
-			ReplaceImage(aPath, IStorage::TYPE_ALL, pEditor);
-			pImg->m_External = WasExternal;
-			return 1;
-		}
-		else
+		s_SelectionPopupContext.m_pSelection = nullptr;
+		s_SelectionPopupContext.m_Entries.clear();
+		pEditor->Storage()->FindFiles(aFilename, "mapres", IStorage::TYPE_ALL, &s_SelectionPopupContext.m_Entries);
+		if(s_SelectionPopupContext.m_Entries.empty())
 		{
 			static SMessagePopupContext s_MessagePopupContext;
 			s_MessagePopupContext.ErrorColor();
 			str_format(s_MessagePopupContext.m_aMessage, sizeof(s_MessagePopupContext.m_aMessage), "Error: could not find image '%s' in the mapres folder.", aFilename);
 			pEditor->ShowPopupMessage(pEditor->UI()->MouseX(), pEditor->UI()->MouseY(), &s_MessagePopupContext);
 		}
+		else if(s_SelectionPopupContext.m_Entries.size() == 1)
+		{
+			s_SelectionPopupContext.m_pSelection = &*s_SelectionPopupContext.m_Entries.begin();
+		}
+		else
+		{
+			str_copy(s_SelectionPopupContext.m_aMessage, "Select the wanted image:");
+			pEditor->ShowPopupSelection(pEditor->UI()->MouseX(), pEditor->UI()->MouseY(), &s_SelectionPopupContext);
+		}
+	}
+	if(s_SelectionPopupContext.m_pSelection != nullptr)
+	{
+		bool WasExternal = pImg->m_External;
+		ReplaceImage(s_SelectionPopupContext.m_pSelection->c_str(), IStorage::TYPE_ALL, pEditor);
+		pImg->m_External = WasExternal;
+		s_SelectionPopupContext.m_pSelection = nullptr;
+		s_SelectionPopupContext.m_Entries.clear();
+		return 1;
 	}
 
 	View.HSplitTop(5.0f, nullptr, &View);
@@ -3892,23 +3906,37 @@ int CEditor::PopupSound(CEditor *pEditor, CUIRect View, void *pContext)
 	View.HSplitTop(12.0f, &Slot, &View);
 	CEditorSound *pSound = pEditor->m_Map.m_vpSounds[pEditor->m_SelectedSound];
 
+	static SSelectionPopupContext s_SelectionPopupContext;
 	if(pEditor->DoButton_MenuItem(&s_ReaddButton, "Readd", 0, &Slot, 0, "Reloads the sound from the mapres folder"))
 	{
 		char aFilename[IO_MAX_PATH_LENGTH];
 		str_format(aFilename, sizeof(aFilename), "%s.opus", pSound->m_aName);
-		char aPath[IO_MAX_PATH_LENGTH];
-		if(pEditor->Storage()->FindFile(aFilename, "mapres", IStorage::TYPE_ALL, aPath, sizeof(aPath)))
-		{
-			ReplaceSound(aPath, IStorage::TYPE_ALL, pEditor);
-			return 1;
-		}
-		else
+		s_SelectionPopupContext.m_pSelection = nullptr;
+		s_SelectionPopupContext.m_Entries.clear();
+		pEditor->Storage()->FindFiles(aFilename, "mapres", IStorage::TYPE_ALL, &s_SelectionPopupContext.m_Entries);
+		if(s_SelectionPopupContext.m_Entries.empty())
 		{
 			static SMessagePopupContext s_MessagePopupContext;
 			s_MessagePopupContext.ErrorColor();
 			str_format(s_MessagePopupContext.m_aMessage, sizeof(s_MessagePopupContext.m_aMessage), "Error: could not find sound '%s' in the mapres folder.", aFilename);
 			pEditor->ShowPopupMessage(pEditor->UI()->MouseX(), pEditor->UI()->MouseY(), &s_MessagePopupContext);
 		}
+		else if(s_SelectionPopupContext.m_Entries.size() == 1)
+		{
+			s_SelectionPopupContext.m_pSelection = &*s_SelectionPopupContext.m_Entries.begin();
+		}
+		else
+		{
+			str_copy(s_SelectionPopupContext.m_aMessage, "Select the wanted sound:");
+			pEditor->ShowPopupSelection(pEditor->UI()->MouseX(), pEditor->UI()->MouseY(), &s_SelectionPopupContext);
+		}
+	}
+	if(s_SelectionPopupContext.m_pSelection != nullptr)
+	{
+		ReplaceSound(s_SelectionPopupContext.m_pSelection->c_str(), IStorage::TYPE_ALL, pEditor);
+		s_SelectionPopupContext.m_pSelection = nullptr;
+		s_SelectionPopupContext.m_Entries.clear();
+		return 1;
 	}
 
 	View.HSplitTop(5.0f, nullptr, &View);

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -1099,6 +1099,19 @@ public:
 	static int PopupColorPicker(CEditor *pEditor, CUIRect View, void *pContext);
 	static int PopupEntities(CEditor *pEditor, CUIRect View, void *pContext);
 
+	struct SMessagePopupContext
+	{
+		static constexpr float POPUP_MAX_WIDTH = 200.0f;
+		static constexpr float POPUP_FONT_SIZE = 10.0f;
+		char m_aMessage[256];
+		ColorRGBA m_TextColor;
+
+		void DefaultColor(class ITextRender *pTextRender);
+		void ErrorColor();
+	};
+	static int PopupMessage(CEditor *pEditor, CUIRect View, void *pContext);
+	void ShowPopupMessage(float X, float Y, SMessagePopupContext *pContext);
+
 	static void CallbackOpenMap(const char *pFileName, int StorageType, void *pUser);
 	static void CallbackAppendMap(const char *pFileName, int StorageType, void *pUser);
 	static void CallbackSaveMap(const char *pFileName, int StorageType, void *pUser);

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -3,9 +3,6 @@
 #ifndef GAME_EDITOR_EDITOR_H
 #define GAME_EDITOR_EDITOR_H
 
-#include <string>
-#include <vector>
-
 #include <base/system.h>
 
 #include <game/client/render.h>
@@ -19,6 +16,9 @@
 #include "auto_map.h"
 
 #include <chrono>
+#include <set>
+#include <string>
+#include <vector>
 
 using namespace std::chrono_literals;
 
@@ -1111,6 +1111,21 @@ public:
 	};
 	static int PopupMessage(CEditor *pEditor, CUIRect View, void *pContext);
 	void ShowPopupMessage(float X, float Y, SMessagePopupContext *pContext);
+
+	struct SSelectionPopupContext
+	{
+		static constexpr float POPUP_MAX_WIDTH = 300.0f;
+		static constexpr float POPUP_FONT_SIZE = 10.0f;
+		static constexpr float POPUP_ENTRY_HEIGHT = 12.0f;
+		static constexpr float POPUP_ENTRY_SPACING = 5.0f;
+		char m_aMessage[256];
+		std::set<std::string> m_Entries;
+		const std::string *m_pSelection;
+
+		SSelectionPopupContext();
+	};
+	static int PopupSelection(CEditor *pEditor, CUIRect View, void *pContext);
+	void ShowPopupSelection(float X, float Y, SSelectionPopupContext *pContext);
 
 	static void CallbackOpenMap(const char *pFileName, int StorageType, void *pUser);
 	static void CallbackAppendMap(const char *pFileName, int StorageType, void *pUser);

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -1870,3 +1870,34 @@ int CEditor::PopupEntities(CEditor *pEditor, CUIRect View, void *pContext)
 
 	return 0;
 }
+
+void CEditor::SMessagePopupContext::DefaultColor(ITextRender *pTextRender)
+{
+	m_TextColor = pTextRender->DefaultTextColor();
+}
+
+void CEditor::SMessagePopupContext::ErrorColor()
+{
+	m_TextColor = ColorRGBA(1.0f, 0.0f, 0.0f, 1.0f);
+}
+
+int CEditor::PopupMessage(CEditor *pEditor, CUIRect View, void *pContext)
+{
+	SMessagePopupContext *pMessagePopup = static_cast<SMessagePopupContext *>(pContext);
+
+	CTextCursor Cursor;
+	pEditor->TextRender()->SetCursor(&Cursor, View.x, View.y, SMessagePopupContext::POPUP_FONT_SIZE, TEXTFLAG_RENDER);
+	Cursor.m_LineWidth = View.w;
+	pEditor->TextRender()->TextColor(pMessagePopup->m_TextColor);
+	pEditor->TextRender()->TextEx(&Cursor, pMessagePopup->m_aMessage, -1);
+	pEditor->TextRender()->TextColor(pEditor->TextRender()->DefaultTextColor());
+
+	return 0;
+}
+
+void CEditor::ShowPopupMessage(float X, float Y, SMessagePopupContext *pContext)
+{
+	const float TextWidth = minimum(TextRender()->TextWidth(nullptr, SMessagePopupContext::POPUP_FONT_SIZE, pContext->m_aMessage, -1, -1.0f), SMessagePopupContext::POPUP_MAX_WIDTH);
+	const int LineCount = TextRender()->TextLineCount(nullptr, SMessagePopupContext::POPUP_FONT_SIZE, pContext->m_aMessage, TextWidth);
+	UiInvokePopupMenu(pContext, 0, X, Y, TextWidth + 10.0f, LineCount * SMessagePopupContext::POPUP_FONT_SIZE + 10.0f, PopupMessage, pContext);
+}

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -1901,3 +1901,40 @@ void CEditor::ShowPopupMessage(float X, float Y, SMessagePopupContext *pContext)
 	const int LineCount = TextRender()->TextLineCount(nullptr, SMessagePopupContext::POPUP_FONT_SIZE, pContext->m_aMessage, TextWidth);
 	UiInvokePopupMenu(pContext, 0, X, Y, TextWidth + 10.0f, LineCount * SMessagePopupContext::POPUP_FONT_SIZE + 10.0f, PopupMessage, pContext);
 }
+
+CEditor::SSelectionPopupContext::SSelectionPopupContext()
+{
+	m_pSelection = nullptr;
+}
+
+int CEditor::PopupSelection(CEditor *pEditor, CUIRect View, void *pContext)
+{
+	SSelectionPopupContext *pSelectionPopup = static_cast<SSelectionPopupContext *>(pContext);
+
+	CUIRect Slot;
+	const int LineCount = pEditor->TextRender()->TextLineCount(nullptr, SSelectionPopupContext::POPUP_FONT_SIZE, pSelectionPopup->m_aMessage, SSelectionPopupContext::POPUP_MAX_WIDTH);
+	View.HSplitTop(LineCount * SSelectionPopupContext::POPUP_FONT_SIZE, &Slot, &View);
+
+	CTextCursor Cursor;
+	pEditor->TextRender()->SetCursor(&Cursor, Slot.x, Slot.y, SSelectionPopupContext::POPUP_FONT_SIZE, TEXTFLAG_RENDER);
+	Cursor.m_LineWidth = Slot.w;
+	pEditor->TextRender()->TextEx(&Cursor, pSelectionPopup->m_aMessage, -1);
+
+	for(const auto &Entry : pSelectionPopup->m_Entries)
+	{
+		View.HSplitTop(SSelectionPopupContext::POPUP_ENTRY_SPACING, nullptr, &View);
+		View.HSplitTop(SSelectionPopupContext::POPUP_ENTRY_HEIGHT, &Slot, &View);
+		if(pEditor->DoButton_MenuItem(&Entry, Entry.c_str(), 0, &Slot, 0, nullptr))
+			pSelectionPopup->m_pSelection = &Entry;
+	}
+
+	return pSelectionPopup->m_pSelection == nullptr ? 0 : 1;
+}
+
+void CEditor::ShowPopupSelection(float X, float Y, SSelectionPopupContext *pContext)
+{
+	const int LineCount = TextRender()->TextLineCount(nullptr, SSelectionPopupContext::POPUP_FONT_SIZE, pContext->m_aMessage, SSelectionPopupContext::POPUP_MAX_WIDTH);
+	const float PopupHeight = LineCount * SSelectionPopupContext::POPUP_FONT_SIZE + pContext->m_Entries.size() * (SSelectionPopupContext::POPUP_ENTRY_HEIGHT + SSelectionPopupContext::POPUP_ENTRY_SPACING) + 10.0f;
+	pContext->m_pSelection = nullptr;
+	UiInvokePopupMenu(pContext, 0, X, Y, SSelectionPopupContext::POPUP_MAX_WIDTH + 10.0f, PopupHeight, PopupSelection, pContext);
+}


### PR DESCRIPTION
Search for the image/sound file in all subfolders of the mapres folder when using the "Readd" button in the editor.

Show an error popup when readding fails:

![errorpopup](https://user-images.githubusercontent.com/23437060/200087069-bb735f14-b56f-458a-9571-c013fc19e59d.png)

Show a selection dialog if multiple files with the same name are found in different subfolders:

![selectiondialog](https://user-images.githubusercontent.com/23437060/200125448-dccf47ba-d643-4f41-b256-eb90656ba693.png)


## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
