### PR TITLE
Add an optional vscode workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,8 @@ cscope.files
 cscope.out
 out
 tags
+# don't ignore this, it's used for the vscode workspace that ddnet provides
+!ddnet-cmake-tools-kits.json
 
 # bam ignores
 /.bam

--- a/other/vscode/README.md
+++ b/other/vscode/README.md
@@ -1,0 +1,14 @@
+Requirements:
+- clang
+- clangd
+- clang-format-10, needs to be in PATH (linux: https://aur.archlinux.org/packages/clang-format-static-bin)
+- clang-tidy
+- lldb
+- cmake
+- rustup (for the rust extension)
+Optional:
+- mold (linker), needs to be in PATH
+- ninja
+
+Inside vscode press `Ctrl+Shift+P` and type `Scan for kits`, press enter.
+Now press press `Ctrl+Shift+P` and type `Select a kit`, choose one with `[DDNet]` as prefix for best defaults.

--- a/other/vscode/ddnet-cmake-tools-kits.json
+++ b/other/vscode/ddnet-cmake-tools-kits.json
@@ -1,0 +1,20 @@
+[
+	{
+		"name": "[DDNet] (recommended) Clang + mold + ninja for fastest compiling (and dev modus)",
+		"compilers": {
+			"C": "clang",
+			"CXX": "clang++"
+		},
+		"preferredGenerator": {
+			"name": "Ninja"
+		},
+		"cmakeSettings": {
+			"DEV": "ON",
+			"CMAKE_CXX_LINK_FLAGS": "-fuse-ld=mold"
+		}
+	},
+	{
+		"name": "[DDNet] Crosscompile for Windows using MinGW",
+		"toolchainFile": "${workspaceFolder}/cmake/toolchains/mingw64.toolchain"
+	}
+]

--- a/other/vscode/ddnet.code-workspace
+++ b/other/vscode/ddnet.code-workspace
@@ -1,0 +1,242 @@
+{
+	"folders": [
+		{
+			"path": "../.."
+		}
+	],
+	"settings": {
+		"files.associations": {
+			"*.tcc": "cpp",
+			"array": "cpp",
+			"atomic": "cpp",
+			"cctype": "cpp",
+			"chrono": "cpp",
+			"clocale": "cpp",
+			"cmath": "cpp",
+			"condition_variable": "cpp",
+			"cstdarg": "cpp",
+			"cstddef": "cpp",
+			"cstdint": "cpp",
+			"cstdio": "cpp",
+			"cstdlib": "cpp",
+			"cstring": "cpp",
+			"ctime": "cpp",
+			"cwchar": "cpp",
+			"cwctype": "cpp",
+			"deque": "cpp",
+			"list": "cpp",
+			"unordered_map": "cpp",
+			"vector": "cpp",
+			"exception": "cpp",
+			"algorithm": "cpp",
+			"functional": "cpp",
+			"iterator": "cpp",
+			"map": "cpp",
+			"memory": "cpp",
+			"memory_resource": "cpp",
+			"numeric": "cpp",
+			"optional": "cpp",
+			"random": "cpp",
+			"ratio": "cpp",
+			"string": "cpp",
+			"string_view": "cpp",
+			"system_error": "cpp",
+			"tuple": "cpp",
+			"type_traits": "cpp",
+			"utility": "cpp",
+			"fstream": "cpp",
+			"initializer_list": "cpp",
+			"iosfwd": "cpp",
+			"istream": "cpp",
+			"limits": "cpp",
+			"mutex": "cpp",
+			"new": "cpp",
+			"ostream": "cpp",
+			"sstream": "cpp",
+			"stdexcept": "cpp",
+			"streambuf": "cpp",
+			"thread": "cpp",
+			"cinttypes": "cpp",
+			"typeinfo": "cpp",
+			"valarray": "cpp",
+			"bit": "cpp",
+			"compare": "cpp",
+			"concepts": "cpp",
+			"ranges": "cpp",
+			"stop_token": "cpp",
+			"hash_map": "cpp",
+			"hash_set": "cpp",
+			"forward_list": "cpp",
+			"set": "cpp",
+			"iomanip": "cpp",
+			"iostream": "cpp",
+			"any": "cpp",
+			"unordered_set": "cpp",
+			"variant": "cpp"
+		},
+		// clang-format-10 has to be in your PATH
+		// for linux simply grep a static built clang-format-10 from here:
+		// https://aur.archlinux.org/packages/clang-format-static-bin
+		"clang-format.executable": "clang-format-10",
+		"lldb.launch.expressions": "native",
+		"editor.defaultFormatter": "xaver.clang-format",
+		"editor.formatOnSave": true,
+		"cmake.additionalKits": [
+			"${workspaceFolder}/other/vscode/ddnet-cmake-tools-kits.json"
+		],
+		"cmake.defaultVariants": {
+			"buildType": {
+				"default": "debug",
+				"description": "build types",
+				"choices": {
+					"debug": {
+						"short": "Debug",
+						"long": "Disable optimizations",
+						"buildType": "Debug",
+						"settings": {
+							"CMAKE_CXX_FLAGS_DEBUG": "",
+							"CMAKE_C_FLAGS_DEBUG": "",
+						}
+					},
+					"release": {
+						"short": "Release",
+						"long": "Enable optimizations",
+						"buildType": "Release",
+						"settings": {
+							"CMAKE_CXX_FLAGS_RELEASE": "",
+							"CMAKE_C_FLAGS_RELEASE": "",
+						}
+					},
+					"minsize": {
+						"short": "MinSizeRel",
+						"long": "Enable optimizations, optimized for size",
+						"buildType": "MinSizeRel",
+						"settings": {
+							"CMAKE_CXX_FLAGS_MINSIZEREL": "",
+							"CMAKE_C_FLAGS_MINSIZEREL": "",
+						}
+					},
+					"reldeb": {
+						"short": "RelWithDebInfo",
+						"long": "Enable optimizations, provide debug symbols",
+						"buildType": "RelWithDebInfo",
+						"settings": {
+							"CMAKE_CXX_FLAGS_RELWITHDEBINFO": "",
+							"CMAKE_C_FLAGS_RELWITHDEBINFO": "",
+						}
+					},
+					"debAndASAN": {
+						"short": "Debug + ASAN (only for clang)",
+						"long": "Disable optimizations, enable ASAN & UBSAN",
+						"buildType": "Debug",
+						"settings": {
+							"CMAKE_CXX_FLAGS_DEBUG": "-fsanitize=address,undefined -fsanitize-recover=address,undefined -fno-omit-frame-pointer",
+							"CMAKE_C_FLAGS_DEBUG": "-fsanitize=address,undefined -fsanitize-recover=address,undefined -fno-omit-frame-pointer",
+						}
+					},
+					"relAndASAN": {
+						"short": "RelWithDebInfo + ASAN (only for clang)",
+						"long": "Enable optimizations, enable ASAN & UBSAN",
+						"buildType": "RelWithDebInfo",
+						"settings": {
+							"CMAKE_CXX_FLAGS_RELWITHDEBINFO": "-fsanitize=address,undefined -fsanitize-recover=address,undefined -fno-omit-frame-pointer",
+							"CMAKE_C_FLAGS_RELWITHDEBINFO": "-fsanitize=address,undefined -fsanitize-recover=address,undefined -fno-omit-frame-pointer",
+						}
+					},
+					"debAndTSAN": {
+						"short": "Debug + TSAN (only for clang)",
+						"long": "Disable optimizations, enable TSAN & UBSAN",
+						"buildType": "Debug",
+						"settings": {
+							"CMAKE_CXX_FLAGS_DEBUG": "-fsanitize=thread,undefined -fsanitize-recover=thread,undefined -fno-omit-frame-pointer",
+							"CMAKE_C_FLAGS_DEBUG": "-fsanitize=thread,undefined -fsanitize-recover=thread,undefined -fno-omit-frame-pointer",
+						}
+					},
+					"relAndTSAN": {
+						"short": "RelWithDebInfo + TSAN (only for clang)",
+						"long": "Enable optimizations, enable TSAN & UBSAN",
+						"buildType": "RelWithDebInfo",
+						"settings": {
+							"CMAKE_CXX_FLAGS_RELWITHDEBINFO": "-fsanitize=thread,undefined -fsanitize-recover=thread,undefined -fno-omit-frame-pointer",
+							"CMAKE_C_FLAGS_RELWITHDEBINFO": "-fsanitize=thread,undefined -fsanitize-recover=thread,undefined -fno-omit-frame-pointer",
+						}
+					}
+				}
+			}
+		},
+	},
+	"extensions": {
+		"recommendations": [
+			"xaver.clang-format",
+			"llvm-vs-code-extensions.vscode-clangd",
+			"twxs.cmake",
+			"ms-vscode.cmake-tools",
+			"vadimcn.vscode-lldb",
+			"rust-lang.rust"
+		]
+	},
+	"tasks": {
+		"version": "2.0.0",
+		"tasks": [
+			{
+				"type": "cmake",
+				"label": "CMake: build",
+				"command": "build",
+				"targets": [
+					"all"
+				],
+				"group": {
+					"kind": "build",
+					"isDefault": true
+				},
+				"problemMatcher": [],
+				"detail": "Build all targets"
+			}
+		]
+	},
+	"launch": {
+		"version": "0.2.0",
+		"configurations": [
+			{
+				"type": "lldb",
+				"request": "launch",
+				"name": "Launch client",
+				"program": "${workspaceFolder}/build/DDNet",
+				"preLaunchTask": "CMake: build",
+				// use dbg configs like this
+				// "args": [ "dbg_gfx 0" ],
+				// enable this to start the debugger with TSAN
+				// "environment": [ { "name":"TSAN_OPTIONS","value":"ignore_noninstrumented_modules=1" }],
+				"cwd": "${workspaceFolder}/build",
+			},
+			{
+				"type": "lldb",
+				"request": "launch",
+				"name": "Launch server",
+				"program": "${workspaceFolder}/build/DDNet-Server",
+				"preLaunchTask": "CMake: build",
+				"cwd": "${workspaceFolder}/build"
+			},
+			// useful for cross debugging the windows (wine) client
+			// for these you need the microsoft cpp extension
+			// start the wine executable like this:
+			// winedbg --gdb --no-start --port 55555 DDNet.exe
+			{
+				"type": "cppdbg",
+				"request": "launch",
+				"name": "Attach to wine gdbserver",
+				"program": "${workspaceFolder}/build_win/DDNet.exe",
+				"miDebuggerServerAddress": "localhost:55555",
+				"cwd": "${workspaceFolder}/build_win/",
+				"MIMode": "gdb",
+				"setupCommands": [
+					{
+						"description": "Auto styling for \"gdb\"",
+						"text": "-enable-pretty-printing",
+						"ignoreFailures": true
+					}
+				]
+			}
+		]
+	}
+}


### PR DESCRIPTION
The workspace is completly optional and doesn't need to be used

It suggests fitting extensions, comes with preconfigured launch tasks (+ prebuild task). some settings useful for using clang-format, -DDEV=ON, mold as linker etc.

if windows is ok leaving out `.exe`, it should also work there i guess, but not tested.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
