### PR TITLE
Add tests for int packer

### DIFF
--- a/src/test/packer.cpp
+++ b/src/test/packer.cpp
@@ -27,6 +27,184 @@ static void ExpectAddString5(const char *pString, int Limit, const char *pExpect
 	}
 }
 
+static void ExpectAddInt(int Input, int Expected)
+{
+	CPacker Packer;
+	Packer.Reset();
+	Packer.AddInt(Input);
+	EXPECT_EQ(Packer.Error(), 0);
+	ASSERT_EQ(Packer.Size(), 1);
+	EXPECT_EQ(Packer.Data()[0], Expected);
+}
+
+static void ExpectAddExtendedInt(int Input, unsigned char *pExpected, int Size)
+{
+	CPacker Packer;
+	Packer.Reset();
+	Packer.AddInt(Input);
+	EXPECT_EQ(Packer.Error(), 0);
+	ASSERT_EQ(Packer.Size(), Size);
+	EXPECT_EQ(mem_comp(Packer.Data(), pExpected, Size), 0);
+}
+
+TEST(Packer, AddInt)
+{
+	ExpectAddInt(1, 0b0000'0001);
+	ExpectAddInt(2, 0b0000'0010);
+	//                ^^^     ^
+	//                ||\     /
+	//     Not extended| \   /
+	//                 |  \ /
+	//                 |00'0010 => 2
+	//                 |
+	//                 Positive
+
+	// there is no -0 so 00 0000
+	// plus the negative bit is -1
+	ExpectAddInt(-1, 0b0100'0000);
+	//                 ^^^     ^
+	//                 ||\     /
+	//      Not extended| \   /
+	//                  |  \ /
+	//                  |00'0000 => 0
+	//                  |
+	//                  Negative
+	ExpectAddInt(-2, 0b0100'0001);
+
+	// 0-63 packed ints
+	// are represented the same way
+	// C++ represents ints
+	// All other numbers differ due to packing shinanigans
+	for(int i = 0; i < 63; i++)
+		ExpectAddInt(i, i);
+}
+
+TEST(Packer, AddExtendedInt)
+{
+	unsigned char pExpected64[] = {
+		0b1000'0000, 0b0000'0001};
+	ExpectAddExtendedInt(64, pExpected64, 2);
+	unsigned char pExpected65[] = {
+		0b1000'0001, 0b0000'0001
+		/*^^^      ^   ^^      ^
+		  ||\     /    | \    /
+		  || \   /     |  \  /
+		  ||  \ /    Not   \/
+		  ||   \  Extended /
+		  ||    \         /
+		  ||     \       /
+		  ||      \     /
+		  ||       \   /
+		  ||        \ /
+		  ||         X
+		  ||        / \
+		  ||       /   \
+		  ||      /     \
+		  ||     /       \
+		  ||  000'0001  00'0001 => 1000001 => 65
+		  ||
+		  |0 Not negative
+		  |
+		  1 Extended (one more byte following)
+		*/
+	};
+	ExpectAddExtendedInt(65, pExpected65, 2);
+
+	unsigned char pExpected66[] = {
+		0b1000'0010, 0b0000'0001
+		/*^^^      ^   ^^      ^
+		  ||\     /    | \    /
+		  || \   /     |  \  /
+		  ||  \ /    Not   \/
+		  ||   \  Extended /
+		  ||    \         /
+		  ||     \       /
+		  ||      \     /
+		  ||       \   /
+		  ||        \ /
+		  ||         X
+		  ||        / \
+		  ||       /   \
+		  ||      /     \
+		  ||     /       \
+		  ||  000'0001  00'0010 => 1000010 => 66
+		  ||
+		  |0 Not negative
+		  |
+		  1 Extended (one more byte following)
+		*/
+	};
+	ExpectAddExtendedInt(66, pExpected66, 2);
+
+	// there is no -0 so all negative numbers
+	// are one smaller
+	// So 64 + negative bit is -65
+	unsigned char pExpectedNegative65[] = {
+		0b1100'0000, 0b0000'0001
+		/*^^^      ^   ^^      ^
+		  ||\     /    | \    /
+		  || \   /     |  \  /
+		  ||  \ /    Not   \/
+		  ||   \  Extended /
+		  ||    \         /
+		  ||     \       /
+		  ||      \     /
+		  ||       \   /
+		  ||        \ /
+		  ||         X
+		  ||        / \
+		  ||       /   \
+		  ||      /     \
+		  ||     /       \
+		  ||  000'0001  00'0000 => 1000000 => 64
+		  ||
+		  |1 Negative
+		  |
+		  1 Extended (one more byte following)
+		*/
+	};
+	ExpectAddExtendedInt(-65, pExpectedNegative65, 2);
+
+	unsigned char pExpectedNegative66[] = {
+		0b1100'0001, 0b0000'0001
+		/*^^^      ^   ^^      ^
+		  ||\     /    | \    /
+		  || \   /     |  \  /
+		  ||  \ /    Not   \/
+		  ||   \  Extended /
+		  ||    \         /
+		  ||     \       /
+		  ||      \     /
+		  ||       \   /
+		  ||        \ /
+		  ||         X
+		  ||        / \
+		  ||       /   \
+		  ||      /     \
+		  ||     /       \
+		  ||  000'0001  00'0001 => 1000001 => 65
+		  ||
+		  |1 Negative
+		  |
+		  1 Extended (one more byte following)
+		*/
+	};
+	ExpectAddExtendedInt(-66, pExpectedNegative66, 2);
+
+	unsigned char pExpectedNegative67[] = {
+		0b1100'0010, 0b0000'0001};
+	ExpectAddExtendedInt(-67, pExpectedNegative67, 2);
+	unsigned char pExpectedNegative68[] = {
+		0b1100'0011, 0b0000'0001};
+	ExpectAddExtendedInt(-68, pExpectedNegative68, 2);
+	unsigned char pExpectedNegative69[] = {
+		0b1100'0100, 0b0000'0001};
+	ExpectAddExtendedInt(-69, pExpectedNegative69, 2);
+	unsigned char pExpectedNegative70[] = {
+		0b1100'0101, 0b0000'0001};
+	ExpectAddExtendedInt(-70, pExpectedNegative70, 2);
+}
+
 TEST(Packer, AddString)
 {
 	ExpectAddString5("", 0, "");


### PR DESCRIPTION
This is an effort to test the Integer packer code. It should hopefully also be useful as some kind of documentation for everyone trying to understand how ints are packed.

BTW github in my browser uses a weird angle for the slashes so it looks like this:

![image](https://user-images.githubusercontent.com/20344300/200165832-b35bae5c-6681-4a43-8a7c-b51b374b3da9.png)

In my vscode it looks nice tho:

![image](https://user-images.githubusercontent.com/20344300/200165853-c7cedc06-a053-4c4c-aad1-711c403e9b84.png)

Or in vim. So I blame the github web preview font being broken:

![image](https://user-images.githubusercontent.com/20344300/200165893-e30754eb-5570-433d-805d-3b8308ddd65d.png)
