### PR TITLE
Only embed map file in manual client demos

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -295,8 +295,10 @@ void CSmoothTime::UpdateMargin(int64_t TargetMargin)
 CClient::CClient() :
 	m_DemoPlayer(&m_SnapshotDelta, [&]() { UpdateDemoIntraTimers(); })
 {
-	for(auto &DemoRecorder : m_aDemoRecorder)
-		DemoRecorder = CDemoRecorder(&m_SnapshotDelta);
+	m_aDemoRecorder[RECORDER_MANUAL] = CDemoRecorder(&m_SnapshotDelta, false);
+	m_aDemoRecorder[RECORDER_AUTO] = CDemoRecorder(&m_SnapshotDelta, true);
+	m_aDemoRecorder[RECORDER_RACE] = CDemoRecorder(&m_SnapshotDelta, true);
+	m_aDemoRecorder[RECORDER_REPLAYS] = CDemoRecorder(&m_SnapshotDelta, true);
 
 	m_pEditor = 0;
 	m_pInput = 0;


### PR DESCRIPTION
Do not embed the map file in auto, race and replay demos, to keep them smaller. See #5868.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
