### PR TITLE
don't panic on missing DDNET_TEST_LIBRARIES env var, fixes #6019

### DIFF
--- a/src/rust-bridge/test/build.rs
+++ b/src/rust-bridge/test/build.rs
@@ -22,9 +22,8 @@ fn main() {
     if env::var_os("DDNET_TEST_NO_LINK").is_some() {
         return;
     }
-    if env::var_os("CARGO_FEATURE_LINK_TEST_LIBRARIES").is_some() {
-        let libraries = env::var("DDNET_TEST_LIBRARIES")
-            .expect("environment variable DDNET_TEST_LIBRARIES required but not found");
+
+    if let Ok(libraries) = env::var("DDNET_TEST_LIBRARIES") {
         let mut seen_library_dirs = HashSet::new();
         for library in libraries.split(';') {
             let library = Path::new(library);


### PR DESCRIPTION
I don't know why we panicked before, but maybe we shouldn't?

In the rust-analyzer context, looks like  `CARGO_FEATURE_LINK_TEST_LIBRARIES` is set but `DDNET_TEST_LIBRARIES` isn't. Maybe there is another solution that keeps the panic if its intended, but i don't know why yet, maybe the libraries aren't needed in the context of rust-analyzer since it only analyzes code, not run tests.

<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
