### PR TITLE
Fix being run from rust-analyzer with a clean environment

### DIFF
--- a/src/rust-bridge/test/build.rs
+++ b/src/rust-bridge/test/build.rs
@@ -19,7 +19,8 @@ fn main() {
 
     println!("cargo:rerun-if-env-changed=DDNET_TEST_LIBRARIES");
     println!("cargo:rerun-if-env-changed=DDNET_TEST_NO_LINK");
-    if env::var_os("DDNET_TEST_NO_LINK").is_some() {
+    println!("cargo:rerun-if-env-changed=RA_RUSTC_WRAPPER");
+    if env::var_os("DDNET_TEST_NO_LINK").is_some() || env::var_os("RA_RUSTC_WRAPPER").is_some() {
         return;
     }
     if env::var_os("CARGO_FEATURE_LINK_TEST_LIBRARIES").is_some() {


### PR DESCRIPTION
Detect that we're being run from rust-analyzer and don't link to C++ libraries in that case.

Fixes #6019.

## Checklist

- [x] Tested the change ~~ingame~~
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
