### PR TITLE
Change editor UI, fix an overflow bug.

### DIFF
--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -1051,6 +1051,7 @@ public:
 
 	int DoButton_Tab(const void *pID, const char *pText, int Checked, const CUIRect *pRect, int Flags, const char *pToolTip);
 	int DoButton_Ex(const void *pID, const char *pText, int Checked, const CUIRect *pRect, int Flags, const char *pToolTip, int Corners, float FontSize = 10.0f, int AlignVert = 1);
+	int DoButton_FontIcon(const void *pID, const char *pText, int Checked, const CUIRect *pRect, int Flags, const char *pToolTip, int Corners, float FontSize = 10.0f, int AlignVert = 1);
 	int DoButton_ButtonDec(const void *pID, const char *pText, int Checked, const CUIRect *pRect, int Flags, const char *pToolTip);
 	int DoButton_ButtonInc(const void *pID, const char *pText, int Checked, const CUIRect *pRect, int Flags, const char *pToolTip);
 


### PR DESCRIPTION
I made this not as a completely final idea, but a step forward to an overall cleaner UI experience. New mappers would want to use the buttons more, and so we should it readable for those who do use them. I also fixed the zoom in/out buttons because a negative overflow is possible. If you zoom all the way in and hit the zoom in button, there wasn't a stopping point.

Old: 
![image](https://user-images.githubusercontent.com/95713843/201449957-006a1a39-1254-4586-8a92-fb4bb0fd87e8.png)
![image](https://user-images.githubusercontent.com/95713843/201449977-2887c99d-6b0d-4a3b-aded-99db460b152d.png)

New:
![image](https://user-images.githubusercontent.com/95713843/201449997-d8ada70a-06f3-4ee1-acd2-3085e3c3223f.png)
![image](https://user-images.githubusercontent.com/95713843/201450005-8853ca68-8d69-4a1e-8477-e390595bda93.png)


## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
