### PR TITLE
Fix various issues reported by cppcheck static analyser

### DIFF
--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -4057,7 +4057,7 @@ int secure_random_uninit()
 #endif
 }
 
-void generate_password(char *buffer, unsigned length, unsigned short *random, unsigned random_length)
+void generate_password(char *buffer, unsigned length, const unsigned short *random, unsigned random_length)
 {
 	static const char VALUES[] = "ABCDEFGHKLMNPRSTUVWXYZabcdefghjkmnopqt23456789";
 	static const size_t NUM_VALUES = sizeof(VALUES) - 1; // Disregard the '\0'.

--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -1773,7 +1773,7 @@ int net_udp_recv(NETSOCKET sock, NETADDR *addr, unsigned char **data)
 		return bytes;
 	}
 #else
-	if(bytes == 0 && sock->ipv4sock >= 0)
+	if(sock->ipv4sock >= 0)
 	{
 		socklen_t fromlen = sizeof(struct sockaddr_in);
 		bytes = recvfrom(sock->ipv4sock, sock->buffer.buf, sizeof(sock->buffer.buf), 0, (struct sockaddr *)&sockaddrbuf, &fromlen);

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -2430,7 +2430,7 @@ int kill_process(PROCESS process);
 		random - Pointer to a randomly-initialized array of shorts.
 		random_length - Length of the short array.
 */
-void generate_password(char *buffer, unsigned length, unsigned short *random, unsigned random_length);
+void generate_password(char *buffer, unsigned length, const unsigned short *random, unsigned random_length);
 
 /*
 	Function: secure_random_init

--- a/src/engine/client/backend/glsl_shader_compiler.cpp
+++ b/src/engine/client/backend/glsl_shader_compiler.cpp
@@ -67,7 +67,7 @@ void CGLSLCompiler::ParseLine(std::string &Line, const char *pReadLine, EGLSLSha
 						++pBuff;
 					}
 
-					if(*pBuff == ' ' && *(pBuff + 1) && *(pBuff + 1) == 'i' && *(pBuff + 2) == 'n')
+					if(*pBuff == ' ' && *(pBuff + 1) == 'i' && *(pBuff + 2) == 'n')
 					{
 						pBuff += 3;
 						Line.append("attribute");
@@ -95,7 +95,7 @@ void CGLSLCompiler::ParseLine(std::string &Line, const char *pReadLine, EGLSLSha
 							pBuff += 2;
 							Found = true;
 						}
-						else if(*pBuff == 'o' && *(pBuff + 1) && *(pBuff + 1) == 'u' && *(pBuff + 2) == 't')
+						else if(*pBuff == 'o' && *(pBuff + 1) == 'u' && *(pBuff + 2) == 't')
 						{
 							pBuff += 3;
 							Found = true;

--- a/src/engine/client/backend/opengl/backend_opengl.cpp
+++ b/src/engine/client/backend/opengl/backend_opengl.cpp
@@ -206,12 +206,10 @@ static void ParseVersionString(EBackendType BackendType, const char *pStr, int &
 			}
 			else if(LastWasNumber && (*pStr == '.' || *pStr == ' ' || *pStr == '\0'))
 			{
-				int CurNumber = 0;
 				if(CurNumberStrLen > 0)
 				{
 					aCurNumberStr[CurNumberStrLen] = 0;
-					CurNumber = str_toint(aCurNumberStr);
-					aNumbers[TotalNumbersPassed++] = CurNumber;
+					aNumbers[TotalNumbersPassed++] = str_toint(aCurNumberStr);
 					CurNumberStrLen = 0;
 				}
 

--- a/src/engine/client/backend/opengl/backend_opengl.cpp
+++ b/src/engine/client/backend/opengl/backend_opengl.cpp
@@ -204,7 +204,7 @@ static void ParseVersionString(EBackendType BackendType, const char *pStr, int &
 				aCurNumberStr[CurNumberStrLen++] = (char)*pStr;
 				LastWasNumber = true;
 			}
-			else if(LastWasNumber && (*pStr == '.' || *pStr == ' ' || *pStr == '\0'))
+			else if(LastWasNumber && (*pStr == '.' || *pStr == ' '))
 			{
 				if(CurNumberStrLen > 0)
 				{

--- a/src/engine/client/backend/opengl/opengl_sl.cpp
+++ b/src/engine/client/backend/opengl/opengl_sl.cpp
@@ -71,7 +71,7 @@ bool CGLSL::LoadShader(CGLSLCompiler *pCompiler, IStorage *pStorage, const char 
 			}
 		}
 
-		for(CGLSLCompiler::SGLSLCompilerDefine &Define : pCompiler->m_vDefines)
+		for(const CGLSLCompiler::SGLSLCompilerDefine &Define : pCompiler->m_vDefines)
 		{
 			vLines.push_back(std::string("#define ") + Define.m_DefineName + std::string(" ") + Define.m_DefineValue + std::string("\r\n"));
 		}

--- a/src/engine/client/backend/vulkan/backend_vulkan.cpp
+++ b/src/engine/client/backend/vulkan/backend_vulkan.cpp
@@ -260,7 +260,7 @@ class CCommandProcessorFragment_Vulkan : public CCommandProcessorFragment_GLBase
 			}
 		}
 
-		void Free(SMemoryHeapQueueElement &AllocatedMemory)
+		void Free(const SMemoryHeapQueueElement &AllocatedMemory)
 		{
 			bool ContinueFree = true;
 			SMemoryHeapQueueElement ThisEl = AllocatedMemory;
@@ -1705,7 +1705,7 @@ protected:
 		return floor(log2(maximum(Width, maximum(Height, Depth)))) + 1;
 	}
 
-	static size_t ImageMipLevelCount(VkExtent3D &ImgExtent)
+	static size_t ImageMipLevelCount(const VkExtent3D &ImgExtent)
 	{
 		return ImageMipLevelCount(ImgExtent.width, ImgExtent.height, ImgExtent.depth);
 	}
@@ -2798,7 +2798,7 @@ protected:
 		vkBindImageMemory(m_VKDevice, Image, ImageMem.m_BufferMem.m_Mem, ImageMem.m_HeapData.m_OffsetToAlign);
 	}
 
-	void ImageBarrier(VkImage &Image, size_t MipMapBase, size_t MipMapCount, size_t LayerBase, size_t LayerCount, VkFormat Format, VkImageLayout OldLayout, VkImageLayout NewLayout)
+	void ImageBarrier(const VkImage &Image, size_t MipMapBase, size_t MipMapCount, size_t LayerBase, size_t LayerCount, VkFormat Format, VkImageLayout OldLayout, VkImageLayout NewLayout)
 	{
 		VkCommandBuffer MemCommandBuffer = GetMemoryCommandBuffer();
 
@@ -6492,7 +6492,7 @@ public:
 		ExecBuffer.m_EstimatedRenderCallCount = 0;
 	}
 
-	void Cmd_Clear(SRenderCommandExecuteBuffer &ExecBuffer, const CCommandBuffer::SCommand_Clear *pCommand)
+	void Cmd_Clear(const SRenderCommandExecuteBuffer &ExecBuffer, const CCommandBuffer::SCommand_Clear *pCommand)
 	{
 		if(ExecBuffer.m_ClearColorInRenderThread)
 		{

--- a/src/engine/client/backend/vulkan/backend_vulkan.cpp
+++ b/src/engine/client/backend/vulkan/backend_vulkan.cpp
@@ -6585,7 +6585,7 @@ public:
 			m_CanvasHeight = (uint32_t)pCommand->m_Height;
 			m_RecreateSwapChain = true;
 		}
-		else if(!pCommand->m_ByResize)
+		else
 		{
 			auto Viewport = m_VKSwapImgAndViewportExtent.GetPresentedImageViewport();
 			if(pCommand->m_X != 0 || pCommand->m_Y != 0 || (uint32_t)pCommand->m_Width != Viewport.width || (uint32_t)pCommand->m_Height != Viewport.height)

--- a/src/engine/client/backend/vulkan/backend_vulkan.cpp
+++ b/src/engine/client/backend/vulkan/backend_vulkan.cpp
@@ -2146,7 +2146,7 @@ protected:
 			{
 				if(m_vvUsedThreadDrawCommandBuffer[i + 1][m_CurImageIndex])
 				{
-					auto &GraphicThreadCommandBuffer = m_vvThreadDrawCommandBuffers[i + 1][m_CurImageIndex];
+					const auto &GraphicThreadCommandBuffer = m_vvThreadDrawCommandBuffers[i + 1][m_CurImageIndex];
 					m_vHelperThreadDrawCommandBuffers[ThreadedCommandsUsedCount++] = GraphicThreadCommandBuffer;
 
 					m_vvUsedThreadDrawCommandBuffer[i + 1][m_CurImageIndex] = false;
@@ -3189,7 +3189,7 @@ protected:
 	void RenderTileLayer_FillExecuteBuffer(SRenderCommandExecuteBuffer &ExecBuffer, size_t DrawCalls, const CCommandBuffer::SState &State, size_t BufferContainerIndex)
 	{
 		size_t BufferObjectIndex = (size_t)m_vBufferContainers[BufferContainerIndex].m_BufferObjectIndex;
-		auto &BufferObject = m_vBufferObjects[BufferObjectIndex];
+		const auto &BufferObject = m_vBufferObjects[BufferObjectIndex];
 
 		ExecBuffer.m_Buffer = BufferObject.m_CurBuffer;
 		ExecBuffer.m_BufferOff = BufferObject.m_CurBufferOffset;
@@ -3197,8 +3197,7 @@ protected:
 		bool IsTextured = GetIsTextured(State);
 		if(IsTextured)
 		{
-			auto &DescrSet = m_vTextures[State.m_Texture].m_VKStandard3DTexturedDescrSet;
-			ExecBuffer.m_aDescriptors[0] = DescrSet;
+			ExecBuffer.m_aDescriptors[0] = m_vTextures[State.m_Texture].m_VKStandard3DTexturedDescrSet;
 		}
 
 		ExecBuffer.m_IndexBuffer = m_RenderIndexBuffer;
@@ -3807,7 +3806,7 @@ public:
 		}
 
 		VKIOMode = g_Config.m_GfxVsync ? VK_PRESENT_MODE_FIFO_KHR : VK_PRESENT_MODE_IMMEDIATE_KHR;
-		for(auto &Mode : vPresentModeList)
+		for(const auto &Mode : vPresentModeList)
 		{
 			if(Mode == VKIOMode)
 				return true;
@@ -3815,7 +3814,7 @@ public:
 
 		dbg_msg("vulkan", "warning: requested presentation mode was not available. falling back to mailbox / fifo relaxed.");
 		VKIOMode = g_Config.m_GfxVsync ? VK_PRESENT_MODE_FIFO_RELAXED_KHR : VK_PRESENT_MODE_MAILBOX_KHR;
-		for(auto &Mode : vPresentModeList)
+		for(const auto &Mode : vPresentModeList)
 		{
 			if(Mode == VKIOMode)
 				return true;
@@ -6508,8 +6507,7 @@ public:
 		if(IsTextured)
 		{
 			size_t AddressModeIndex = GetAddressModeIndex(pCommand->m_State);
-			auto &DescrSet = m_vTextures[pCommand->m_State.m_Texture].m_aVKStandardTexturedDescrSets[AddressModeIndex];
-			ExecBuffer.m_aDescriptors[0] = DescrSet;
+			ExecBuffer.m_aDescriptors[0] = m_vTextures[pCommand->m_State.m_Texture].m_aVKStandardTexturedDescrSets[AddressModeIndex];
 		}
 
 		ExecBuffer.m_IndexBuffer = m_IndexBuffer;
@@ -6552,8 +6550,7 @@ public:
 		bool IsTextured = GetIsTextured(pCommand->m_State);
 		if(IsTextured)
 		{
-			auto &DescrSet = m_vTextures[pCommand->m_State.m_Texture].m_VKStandard3DTexturedDescrSet;
-			ExecBuffer.m_aDescriptors[0] = DescrSet;
+			ExecBuffer.m_aDescriptors[0] = m_vTextures[pCommand->m_State.m_Texture].m_VKStandard3DTexturedDescrSet;
 		}
 
 		ExecBuffer.m_IndexBuffer = m_IndexBuffer;
@@ -6657,7 +6654,7 @@ public:
 
 		auto StagingBuffer = GetStagingBuffer(pUploadData, DataSize);
 
-		auto &MemBlock = m_vBufferObjects[BufferIndex].m_BufferObject.m_Mem;
+		const auto &MemBlock = m_vBufferObjects[BufferIndex].m_BufferObject.m_Mem;
 		VkBuffer VertexBuffer = MemBlock.m_Buffer;
 		MemoryBarrier(VertexBuffer, Offset + MemBlock.m_HeapData.m_OffsetToAlign, DataSize, VK_ACCESS_VERTEX_ATTRIBUTE_READ_BIT, true);
 		CopyBuffer(StagingBuffer.m_Buffer, VertexBuffer, StagingBuffer.m_HeapData.m_OffsetToAlign, Offset + MemBlock.m_HeapData.m_OffsetToAlign, DataSize);
@@ -6796,7 +6793,7 @@ public:
 	{
 		size_t BufferContainerIndex = (size_t)pCommand->m_BufferContainerIndex;
 		size_t BufferObjectIndex = (size_t)m_vBufferContainers[BufferContainerIndex].m_BufferObjectIndex;
-		auto &BufferObject = m_vBufferObjects[BufferObjectIndex];
+		const auto &BufferObject = m_vBufferObjects[BufferObjectIndex];
 
 		ExecBuffer.m_Buffer = BufferObject.m_CurBuffer;
 		ExecBuffer.m_BufferOff = BufferObject.m_CurBufferOffset;
@@ -6805,8 +6802,7 @@ public:
 		if(IsTextured)
 		{
 			size_t AddressModeIndex = GetAddressModeIndex(pCommand->m_State);
-			auto &DescrSet = m_vTextures[pCommand->m_State.m_Texture].m_aVKStandardTexturedDescrSets[AddressModeIndex];
-			ExecBuffer.m_aDescriptors[0] = DescrSet;
+			ExecBuffer.m_aDescriptors[0] = m_vTextures[pCommand->m_State.m_Texture].m_aVKStandardTexturedDescrSets[AddressModeIndex];
 		}
 
 		ExecBuffer.m_IndexBuffer = m_RenderIndexBuffer;
@@ -6899,13 +6895,12 @@ public:
 	{
 		size_t BufferContainerIndex = (size_t)pCommand->m_BufferContainerIndex;
 		size_t BufferObjectIndex = (size_t)m_vBufferContainers[BufferContainerIndex].m_BufferObjectIndex;
-		auto &BufferObject = m_vBufferObjects[BufferObjectIndex];
+		const auto &BufferObject = m_vBufferObjects[BufferObjectIndex];
 
 		ExecBuffer.m_Buffer = BufferObject.m_CurBuffer;
 		ExecBuffer.m_BufferOff = BufferObject.m_CurBufferOffset;
 
-		auto &TextTextureDescr = m_vTextures[pCommand->m_TextTextureIndex].m_VKTextDescrSet;
-		ExecBuffer.m_aDescriptors[0] = TextTextureDescr;
+		ExecBuffer.m_aDescriptors[0] = m_vTextures[pCommand->m_TextTextureIndex].m_VKTextDescrSet;
 
 		ExecBuffer.m_IndexBuffer = m_RenderIndexBuffer;
 
@@ -6958,7 +6953,7 @@ public:
 	void BufferContainer_FillExecuteBuffer(SRenderCommandExecuteBuffer &ExecBuffer, const CCommandBuffer::SState &State, size_t BufferContainerIndex, size_t DrawCalls)
 	{
 		size_t BufferObjectIndex = (size_t)m_vBufferContainers[BufferContainerIndex].m_BufferObjectIndex;
-		auto &BufferObject = m_vBufferObjects[BufferObjectIndex];
+		const auto &BufferObject = m_vBufferObjects[BufferObjectIndex];
 
 		ExecBuffer.m_Buffer = BufferObject.m_CurBuffer;
 		ExecBuffer.m_BufferOff = BufferObject.m_CurBufferOffset;
@@ -6967,8 +6962,7 @@ public:
 		if(IsTextured)
 		{
 			size_t AddressModeIndex = GetAddressModeIndex(State);
-			auto &DescrSet = m_vTextures[State.m_Texture].m_aVKStandardTexturedDescrSets[AddressModeIndex];
-			ExecBuffer.m_aDescriptors[0] = DescrSet;
+			ExecBuffer.m_aDescriptors[0] = m_vTextures[State.m_Texture].m_aVKStandardTexturedDescrSets[AddressModeIndex];
 		}
 
 		ExecBuffer.m_IndexBuffer = m_RenderIndexBuffer;

--- a/src/engine/client/backend/vulkan/backend_vulkan.cpp
+++ b/src/engine/client/backend/vulkan/backend_vulkan.cpp
@@ -5745,7 +5745,6 @@ public:
 		auto &TextureText = m_vTextures[Texture];
 		auto &TextureTextOutline = m_vTextures[TextureOutline];
 		auto &DescrSetText = TextureText.m_VKTextDescrSet;
-		auto &DescrSetTextOutline = TextureText.m_VKTextDescrSet;
 
 		VkDescriptorSetAllocateInfo DesAllocInfo{};
 		DesAllocInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
@@ -5780,8 +5779,6 @@ public:
 		aDescriptorWrites[1].pImageInfo = &aImageInfo[1];
 
 		vkUpdateDescriptorSets(m_VKDevice, static_cast<uint32_t>(aDescriptorWrites.size()), aDescriptorWrites.data(), 0, nullptr);
-
-		DescrSetTextOutline = DescrSetText;
 
 		return true;
 	}

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -420,7 +420,7 @@ static inline bool RepackMsg(const CMsgPacker *pMsg, CPacker &Packer)
 	}
 	else
 	{
-		Packer.AddInt((0 << 1) | (pMsg->m_System ? 1 : 0)); // NETMSG_EX, NETMSGTYPE_EX
+		Packer.AddInt(pMsg->m_System ? 1 : 0); // NETMSG_EX, NETMSGTYPE_EX
 		g_UuidManager.PackUuid(pMsg->m_MsgID, &Packer);
 	}
 	Packer.AddRaw(pMsg->Data(), pMsg->Size());

--- a/src/engine/client/text.cpp
+++ b/src/engine/client/text.cpp
@@ -42,7 +42,6 @@ struct SFontSizeChar
 	float m_AdvanceX;
 
 	float m_aUVs[4];
-	int64_t m_TouchTime;
 	FT_UInt m_GlyphIndex;
 };
 

--- a/src/engine/gfx/image_manipulation.cpp
+++ b/src/engine/gfx/image_manipulation.cpp
@@ -4,7 +4,7 @@
 
 #define TW_DILATE_ALPHA_THRESHOLD 10
 
-static void Dilate(int w, int h, int BPP, unsigned char *pSrc, unsigned char *pDest, unsigned char AlphaThreshold = TW_DILATE_ALPHA_THRESHOLD)
+static void Dilate(int w, int h, int BPP, const unsigned char *pSrc, unsigned char *pDest, unsigned char AlphaThreshold = TW_DILATE_ALPHA_THRESHOLD)
 {
 	int ix, iy;
 	const int aDirX[] = {0, -1, 1, 0};
@@ -55,7 +55,7 @@ static void Dilate(int w, int h, int BPP, unsigned char *pSrc, unsigned char *pD
 	}
 }
 
-static void CopyColorValues(int w, int h, int BPP, unsigned char *pSrc, unsigned char *pDest)
+static void CopyColorValues(int w, int h, int BPP, const unsigned char *pSrc, unsigned char *pDest)
 {
 	int m = 0;
 	for(int y = 0; y < h; y++)

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -775,7 +775,7 @@ static inline bool RepackMsg(const CMsgPacker *pMsg, CPacker &Packer, bool Sixup
 	}
 	else
 	{
-		Packer.AddInt((0 << 1) | (pMsg->m_System ? 1 : 0)); // NETMSG_EX, NETMSGTYPE_EX
+		Packer.AddInt(pMsg->m_System ? 1 : 0); // NETMSG_EX, NETMSGTYPE_EX
 		g_UuidManager.PackUuid(MsgId, &Packer);
 	}
 	Packer.AddRaw(pMsg->Data(), pMsg->Size());

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -2809,7 +2809,7 @@ int CServer::Run()
 
 			NonActive = true;
 
-			for(auto &Client : m_aClients)
+			for(const auto &Client : m_aClients)
 			{
 				if(Client.m_State != CClient::STATE_EMPTY)
 				{

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -115,6 +115,7 @@ void CSnapIDPool::FreeID(int ID)
 {
 	if(ID < 0)
 		return;
+	dbg_assert((size_t)ID < std::size(m_aIDs), "id is out of range");
 	dbg_assert(m_aIDs[ID].m_State == ID_ALLOCATED, "id is not allocated");
 
 	m_InUsage--;

--- a/src/engine/server/server_logger.cpp
+++ b/src/engine/server/server_logger.cpp
@@ -26,7 +26,8 @@ void CServerLogger::Log(const CLogMessage *pMessage)
 			m_vPending.clear();
 		}
 		m_PendingLock.unlock();
-		m_pServer->SendLogLine(pMessage);
+		if(m_pServer)
+			m_pServer->SendLogLine(pMessage);
 	}
 	else
 	{

--- a/src/engine/server/sql_string_helpers.cpp
+++ b/src/engine/server/sql_string_helpers.cpp
@@ -48,7 +48,7 @@ void sqlstr::AgoTimeToString(int AgoTime, char *pAgoString, int Size)
 	}
 
 	char aBuf[20];
-	int aTimes[7] =
+	const int aTimes[7] =
 		{
 			60 * 60 * 24 * 365,
 			60 * 60 * 24 * 30,
@@ -57,7 +57,7 @@ void sqlstr::AgoTimeToString(int AgoTime, char *pAgoString, int Size)
 			60 * 60,
 			60,
 			1};
-	char aaNames[7][6] =
+	const char aaNames[7][6] =
 		{
 			"year",
 			"month",

--- a/src/engine/shared/compression.cpp
+++ b/src/engine/shared/compression.cpp
@@ -46,8 +46,8 @@ const unsigned char *CVariableInt::Unpack(const unsigned char *pSrc, int *pInOut
 	*pInOut = *pSrc & 0x3F;
 	SrcSize--;
 
-	const static int s_aMasks[] = {0x7F, 0x7F, 0x7F, 0x0F};
-	const static int s_aShifts[] = {6, 6 + 7, 6 + 7 + 7, 6 + 7 + 7 + 7};
+	static const int s_aMasks[] = {0x7F, 0x7F, 0x7F, 0x0F};
+	static const int s_aShifts[] = {6, 6 + 7, 6 + 7 + 7, 6 + 7 + 7 + 7};
 
 	for(unsigned i = 0; i < std::size(s_aMasks); i++)
 	{

--- a/src/engine/shared/datafile.cpp
+++ b/src/engine/shared/datafile.cpp
@@ -66,16 +66,6 @@ struct CDatafileHeader
 	int m_DataSize;
 };
 
-struct CDatafileData
-{
-	int m_NumItemTypes;
-	int m_NumItems;
-	int m_NumRawData;
-	int m_ItemSize;
-	int m_DataSize;
-	char m_aStart[4];
-};
-
 struct CDatafileInfo
 {
 	CDatafileItemType *m_pItemTypes;

--- a/src/engine/shared/datafile.cpp
+++ b/src/engine/shared/datafile.cpp
@@ -181,7 +181,6 @@ bool CDataFileReader::Open(class IStorage *pStorage, const char *pFilename, int 
 	{
 		io_close(pTmpDataFile->m_File);
 		free(pTmpDataFile);
-		pTmpDataFile = 0;
 		dbg_msg("datafile", "couldn't load the whole thing, wanted=%d got=%d", Size, ReadSize);
 		return false;
 	}

--- a/src/engine/shared/datafile.cpp
+++ b/src/engine/shared/datafile.cpp
@@ -116,7 +116,7 @@ bool CDataFileReader::Open(class IStorage *pStorage, const char *pFilename, int 
 		while(true)
 		{
 			unsigned Bytes = io_read(File, aBuffer, BUFFER_SIZE);
-			if(Bytes <= 0)
+			if(Bytes == 0)
 				break;
 			Crc = crc32(Crc, aBuffer, Bytes);
 			sha256_update(&Sha256Ctxt, aBuffer, Bytes);

--- a/src/engine/shared/huffman.cpp
+++ b/src/engine/shared/huffman.cpp
@@ -213,12 +213,11 @@ int CHuffman::Decompress(const void *pInput, int InputSize, void *pOutput, int O
 	unsigned Bitcount = 0;
 
 	const CNode *pEof = &m_aNodes[HUFFMAN_EOF_SYMBOL];
-	const CNode *pNode = 0;
 
 	while(true)
 	{
 		// {A} try to load a node now, this will reduce dependency at location {D}
-		pNode = 0;
+		const CNode *pNode = 0;
 		if(Bitcount >= HUFFMAN_LUTBITS)
 			pNode = m_apDecodeLut[Bits & HUFFMAN_LUTMASK];
 

--- a/src/engine/shared/network.h
+++ b/src/engine/shared/network.h
@@ -288,7 +288,7 @@ public:
 	void SetTimedOut(const NETADDR *pAddr, int Sequence, int Ack, SECURITY_TOKEN SecurityToken, CStaticRingBuffer<CNetChunkResend, NET_CONN_BUFFERSIZE> *pResendBuffer, bool Sixup);
 
 	// anti spoof
-	void DirectInit(NETADDR &Addr, SECURITY_TOKEN SecurityToken, SECURITY_TOKEN Token, bool Sixup);
+	void DirectInit(const NETADDR &Addr, SECURITY_TOKEN SecurityToken, SECURITY_TOKEN Token, bool Sixup);
 	void SetUnknownSeq() { m_UnknownSeq = true; }
 	void SetSequence(int Sequence) { m_Sequence = Sequence; }
 

--- a/src/engine/shared/network_conn.cpp
+++ b/src/engine/shared/network_conn.cpp
@@ -238,7 +238,7 @@ void CNetConnection::Disconnect(const char *pReason)
 	Reset();
 }
 
-void CNetConnection::DirectInit(NETADDR &Addr, SECURITY_TOKEN SecurityToken, SECURITY_TOKEN Token, bool Sixup)
+void CNetConnection::DirectInit(const NETADDR &Addr, SECURITY_TOKEN SecurityToken, SECURITY_TOKEN Token, bool Sixup)
 {
 	Reset();
 

--- a/src/engine/shared/snapshot.cpp
+++ b/src/engine/shared/snapshot.cpp
@@ -37,7 +37,7 @@ int CSnapshot::GetExternalItemType(int InternalType) const
 		return InternalType;
 	}
 
-	int TypeItemIndex = GetItemIndex((0 << 16) | InternalType); // NETOBJTYPE_EX
+	int TypeItemIndex = GetItemIndex(InternalType); // NETOBJTYPE_EX
 	if(TypeItemIndex == -1 || GetItemSize(TypeItemIndex) < (int)sizeof(CUuid))
 	{
 		return InternalType;

--- a/src/game/client/components/ghost.cpp
+++ b/src/game/client/components/ghost.cpp
@@ -106,7 +106,7 @@ void CGhost::CGhostPath::SetSize(int Items)
 	m_NumItems = Items;
 }
 
-void CGhost::CGhostPath::Add(CGhostCharacter Char)
+void CGhost::CGhostPath::Add(const CGhostCharacter &Char)
 {
 	SetSize(m_NumItems + 1);
 	*Get(m_NumItems - 1) = Char;

--- a/src/game/client/components/ghost.h
+++ b/src/game/client/components/ghost.h
@@ -80,7 +80,7 @@ private:
 		void SetSize(int Items);
 		int Size() const { return m_NumItems; }
 
-		void Add(CGhostCharacter Char);
+		void Add(const CGhostCharacter &Char);
 		CGhostCharacter *Get(int Index);
 	};
 

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -193,7 +193,7 @@ void CHud::RenderScoreHud()
 			static float s_TextWidth100 = TextRender()->TextWidth(0, 14.0f, "100", -1, -1.0f);
 			float ScoreWidthMax = maximum(maximum(m_aScoreInfo[0].m_ScoreTextWidth, m_aScoreInfo[1].m_ScoreTextWidth), s_TextWidth100);
 			float Split = 3.0f;
-			float ImageSize = GameFlags & GAMEFLAG_FLAGS ? 16.0f : Split;
+			float ImageSize = (GameFlags & GAMEFLAG_FLAGS) ? 16.0f : Split;
 			for(int t = 0; t < 2; t++)
 			{
 				// draw box

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -813,9 +813,10 @@ void CHud::RenderPlayerState(const int ClientID)
 	// pCharacter contains the predicted character for local players or the last snap for players who are spectated
 	CCharacterCore *pCharacter = &m_pClient->m_aClients[ClientID].m_Predicted;
 	CNetObj_Character *pPlayer = &m_pClient->m_aClients[ClientID].m_RenderCur;
-	int TotalJumpsToDisplay = 0, AvailableJumpsToDisplay = 0;
+	int TotalJumpsToDisplay = 0;
 	if(g_Config.m_ClShowhudJumpsIndicator)
 	{
+		int AvailableJumpsToDisplay;
 		if(m_pClient->m_Snap.m_aCharacters[ClientID].m_HasExtendedDisplayInfo)
 		{
 			bool Grounded = false;
@@ -1409,7 +1410,7 @@ void CHud::RenderMovementInformation(const int ClientID)
 	float y = StartY + LineSpacer * 2;
 	float xl = StartX + 2;
 	float xr = m_Width - 2;
-	int DigitsIndex = 0;
+	int DigitsIndex;
 
 	static float s_TextWidth0 = TextRender()->TextWidth(0, Fontsize, "0.00", -1, -1.0f);
 	static float s_TextWidth00 = TextRender()->TextWidth(0, Fontsize, "00.00", -1, -1.0f);

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -175,7 +175,7 @@ void CHud::RenderScoreHud()
 
 			bool aRecreateTeamScore[2] = {str_comp(aScoreTeam[0], m_aScoreInfo[0].m_aScoreText) != 0, str_comp(aScoreTeam[1], m_aScoreInfo[1].m_aScoreText) != 0};
 
-			int aFlagCarrier[2] = {
+			const int aFlagCarrier[2] = {
 				m_pClient->m_Snap.m_pGameDataObj->m_FlagCarrierRed,
 				m_pClient->m_Snap.m_pGameDataObj->m_FlagCarrierBlue};
 
@@ -516,7 +516,7 @@ void CHud::RenderTextInfo()
 		static float s_TextWidth000 = TextRender()->TextWidth(0, 12.f, "000", -1, -1.0f);
 		static float s_TextWidth0000 = TextRender()->TextWidth(0, 12.f, "0000", -1, -1.0f);
 		static float s_TextWidth00000 = TextRender()->TextWidth(0, 12.f, "00000", -1, -1.0f);
-		static float s_aTextWidth[5] = {s_TextWidth0, s_TextWidth00, s_TextWidth000, s_TextWidth0000, s_TextWidth00000};
+		static const float s_aTextWidth[5] = {s_TextWidth0, s_TextWidth00, s_TextWidth000, s_TextWidth0000, s_TextWidth00000};
 
 		int DigitIndex = GetDigitsIndex(FrameTime, 4);
 		//TextRender()->Text(0, m_Width-10-TextRender()->TextWidth(0,12,Buf,-1,-1.0f), 5, 12, Buf, -1.0f);

--- a/src/game/client/components/killmessages.cpp
+++ b/src/game/client/components/killmessages.cpp
@@ -302,7 +302,7 @@ void CKillMessages::RefindSkins()
 
 		if(m_aKillmsgs[r].m_KillerID >= 0)
 		{
-			CGameClient::CClientData &Client = GameClient()->m_aClients[m_aKillmsgs[r].m_KillerID];
+			const CGameClient::CClientData &Client = GameClient()->m_aClients[m_aKillmsgs[r].m_KillerID];
 			if(Client.m_aSkinName[0] != '\0')
 				m_aKillmsgs[r].m_KillerRenderInfo = Client.m_RenderInfo;
 			else
@@ -311,7 +311,7 @@ void CKillMessages::RefindSkins()
 
 		if(m_aKillmsgs[r].m_VictimID >= 0)
 		{
-			CGameClient::CClientData &Client = GameClient()->m_aClients[m_aKillmsgs[r].m_VictimID];
+			const CGameClient::CClientData &Client = GameClient()->m_aClients[m_aKillmsgs[r].m_VictimID];
 			if(Client.m_aSkinName[0] != '\0')
 				m_aKillmsgs[r].m_VictimRenderInfo = Client.m_RenderInfo;
 			else

--- a/src/game/client/components/maplayers.cpp
+++ b/src/game/client/components/maplayers.cpp
@@ -848,7 +848,7 @@ void CMapLayers::OnMapLoad()
 							mem_copy_special(pUploadData, pTmpTiles, sizeof(vec2), vtmpTiles.size() * 4, (DoTextureCoords ? sizeof(vec3) : 0));
 							if(DoTextureCoords)
 							{
-								mem_copy_special(pUploadData + sizeof(vec2), pTmpTileTexCoords, sizeof(vec3), vtmpTiles.size() * 4, (DoTextureCoords ? (sizeof(vec2)) : 0));
+								mem_copy_special(pUploadData + sizeof(vec2), pTmpTileTexCoords, sizeof(vec3), vtmpTiles.size() * 4, sizeof(vec2));
 							}
 
 							// first create the buffer object

--- a/src/game/client/components/menu_background.cpp
+++ b/src/game/client/components/menu_background.cpp
@@ -193,8 +193,6 @@ void CMenuBackground::LoadMenuBackground(bool HasDayHint, bool HasNightHint)
 
 	ResetPositions();
 
-	bool NeedImageLoading = false;
-
 	str_copy(m_aMapName, g_Config.m_ClMenuMap);
 
 	if(g_Config.m_ClMenuMap[0] != '\0')
@@ -265,11 +263,9 @@ void CMenuBackground::LoadMenuBackground(bool HasDayHint, bool HasNightHint)
 		if(m_Loaded)
 		{
 			m_pLayers->InitBackground(m_pMap);
-			NeedImageLoading = true;
 
 			CMapLayers::OnMapLoad();
-			if(NeedImageLoading)
-				m_pImages->LoadBackground(m_pLayers, m_pMap);
+			m_pImages->LoadBackground(m_pLayers, m_pMap);
 
 			// look for custom positions
 			CMapItemLayerTilemap *pTLayer = m_pLayers->GameLayer();

--- a/src/game/client/components/menu_background.cpp
+++ b/src/game/client/components/menu_background.cpp
@@ -282,11 +282,9 @@ void CMenuBackground::LoadMenuBackground(bool HasDayHint, bool HasNightHint)
 
 				if(Size >= pTLayer->m_Width * pTLayer->m_Height * TileSize)
 				{
-					int x = 0;
-					int y = 0;
-					for(y = 0; y < pTLayer->m_Height; ++y)
+					for(int y = 0; y < pTLayer->m_Height; ++y)
 					{
-						for(x = 0; x < pTLayer->m_Width; ++x)
+						for(int x = 0; x < pTLayer->m_Width; ++x)
 						{
 							unsigned char Index = ((CTile *)pTiles)[y * pTLayer->m_Width + x].m_Index;
 							if(Index >= TILE_TIME_CHECKPOINT_FIRST && Index <= TILE_TIME_CHECKPOINT_LAST)

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -69,16 +69,12 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 		CLocConstString m_Caption;
 		int m_Direction;
 		float m_Width;
-		int m_Flags;
 		CUIRect m_Rect;
 		CUIRect m_Spacer;
 	};
 
 	enum
 	{
-		FIXED = 1,
-		SPACER = 2,
-
 		COL_FLAG_LOCK = 0,
 		COL_FLAG_FAV,
 		COL_FLAG_OFFICIAL,
@@ -91,16 +87,16 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 	};
 
 	CColumn s_aCols[] = {
-		{-1, -1, " ", -1, 2.0f, 0, {0}, {0}},
-		{COL_FLAG_LOCK, -1, " ", -1, 14.0f, 0, {0}, {0}},
-		{COL_FLAG_FAV, -1, " ", -1, 14.0f, 0, {0}, {0}},
-		{COL_FLAG_OFFICIAL, -1, " ", -1, 14.0f, 0, {0}, {0}},
-		{COL_NAME, IServerBrowser::SORT_NAME, "Name", 0, 50.0f, 0, {0}, {0}}, // Localize - these strings are localized within CLocConstString
-		{COL_GAMETYPE, IServerBrowser::SORT_GAMETYPE, "Type", 1, 50.0f, 0, {0}, {0}},
-		{COL_MAP, IServerBrowser::SORT_MAP, "Map", 1, 120.0f + (Headers.w - 480) / 8, 0, {0}, {0}},
-		{COL_PLAYERS, IServerBrowser::SORT_NUMPLAYERS, "Players", 1, 85.0f, 0, {0}, {0}},
-		{-1, -1, " ", 1, 10.0f, 0, {0}, {0}},
-		{COL_PING, IServerBrowser::SORT_PING, "Ping", 1, 40.0f, FIXED, {0}, {0}},
+		{-1, -1, " ", -1, 2.0f, {0}, {0}},
+		{COL_FLAG_LOCK, -1, " ", -1, 14.0f, {0}, {0}},
+		{COL_FLAG_FAV, -1, " ", -1, 14.0f, {0}, {0}},
+		{COL_FLAG_OFFICIAL, -1, " ", -1, 14.0f, {0}, {0}},
+		{COL_NAME, IServerBrowser::SORT_NAME, "Name", 0, 50.0f, {0}, {0}}, // Localize - these strings are localized within CLocConstString
+		{COL_GAMETYPE, IServerBrowser::SORT_GAMETYPE, "Type", 1, 50.0f, {0}, {0}},
+		{COL_MAP, IServerBrowser::SORT_MAP, "Map", 1, 120.0f + (Headers.w - 480) / 8, {0}, {0}},
+		{COL_PLAYERS, IServerBrowser::SORT_NUMPLAYERS, "Players", 1, 85.0f, {0}, {0}},
+		{-1, -1, " ", 1, 10.0f, {0}, {0}},
+		{COL_PING, IServerBrowser::SORT_PING, "Ping", 1, 40.0f, {0}, {0}},
 	};
 	// This is just for scripts/update_localization.py to work correctly (all other strings are already Localize()'d somewhere else). Don't remove!
 	// Localize("Type");
@@ -116,7 +112,6 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 
 			if(i + 1 < NumCols)
 			{
-				//Cols[i].flags |= SPACER;
 				Headers.VSplitLeft(2, &s_aCols[i].m_Spacer, &Headers);
 			}
 		}

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -1081,7 +1081,6 @@ void CMenus::RenderDemoList(CUIRect MainView)
 		CLocConstString m_Caption;
 		int m_Direction;
 		float m_Width;
-		int m_Flags;
 		CUIRect m_Rect;
 		CUIRect m_Spacer;
 	};
@@ -1095,10 +1094,10 @@ void CMenus::RenderDemoList(CUIRect MainView)
 	};
 
 	static CColumn s_aCols[] = {
-		{COL_DEMONAME, SORT_DEMONAME, "Demo", 0, 0.0f, 0, {0}, {0}},
-		{COL_MARKERS, SORT_MARKERS, "Markers", 1, 75.0f, 0, {0}, {0}},
-		{COL_LENGTH, SORT_LENGTH, "Length", 1, 75.0f, 0, {0}, {0}},
-		{COL_DATE, SORT_DATE, "Date", 1, 160.0f, 1, {0}, {0}},
+		{COL_DEMONAME, SORT_DEMONAME, "Demo", 0, 0.0f, {0}, {0}},
+		{COL_MARKERS, SORT_MARKERS, "Markers", 1, 75.0f, {0}, {0}},
+		{COL_LENGTH, SORT_LENGTH, "Length", 1, 75.0f, {0}, {0}},
+		{COL_DATE, SORT_DATE, "Date", 1, 160.0f, {0}, {0}},
 	};
 	/* This is just for scripts/update_localization.py to work correctly. Don't remove!
 		Localize("Demo");Localize("Markers");Localize("Length");Localize("Date");

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -240,7 +240,7 @@ void CMenus::RenderPlayers(CUIRect MainView)
 
 	int TotalPlayers = 0;
 
-	for(auto &pInfoByName : m_pClient->m_Snap.m_apInfoByName)
+	for(const auto &pInfoByName : m_pClient->m_Snap.m_apInfoByName)
 	{
 		if(!pInfoByName)
 			continue;
@@ -527,7 +527,7 @@ bool CMenus::RenderServerControlKick(CUIRect MainView, bool FilterSpectators)
 	int NumOptions = 0;
 	int Selected = 0;
 	static int aPlayerIDs[MAX_CLIENTS];
-	for(auto &pInfoByName : m_pClient->m_Snap.m_apInfoByName)
+	for(const auto &pInfoByName : m_pClient->m_Snap.m_apInfoByName)
 	{
 		if(!pInfoByName)
 			continue;

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -618,7 +618,6 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 	EyesLabel.VSplitLeft(20.0f, 0, &EyesLabel);
 	EyesLabel.HSplitTop(50.0f, &EyesLabel, &Eyes);
 
-	float Highlight = 0.0f;
 	static CButtonContainer s_aEyeButtons[6];
 	static int s_aEyesToolTip[6];
 	for(int CurrentEyeEmote = 0; CurrentEyeEmote < 6; CurrentEyeEmote++)
@@ -631,7 +630,7 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 			Eyes.HSplitTop(60.0f, &EyesLabel, 0);
 			EyesLabel.HSplitTop(10.0f, 0, &EyesLabel);
 		}
-		Highlight = (m_Dummy) ? g_Config.m_ClDummyDefaultEyes == CurrentEyeEmote : g_Config.m_ClPlayerDefaultEyes == CurrentEyeEmote;
+		float Highlight = (m_Dummy ? g_Config.m_ClDummyDefaultEyes == CurrentEyeEmote : g_Config.m_ClPlayerDefaultEyes == CurrentEyeEmote) ? 1.0f : 0.0f;
 		if(DoButton_Menu(&s_aEyeButtons[CurrentEyeEmote], "", 0, &EyesTee, 0, IGraphics::CORNER_ALL, 10.0f, 0.0f, vec4(1, 1, 1, 0.5f + Highlight * 0.25f), vec4(1, 1, 1, 0.25f + Highlight * 0.25f)))
 		{
 			if(m_Dummy)

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -729,9 +729,6 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 			if((pSkinToBeSelected->GetName()[0] == 'x' && pSkinToBeSelected->GetName()[1] == '_'))
 				return false;
 
-			if(pSkinToBeSelected == 0)
-				return false;
-
 			return true;
 		};
 

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -193,7 +193,6 @@ void CPlayers::RenderHookCollLine(
 			vec2 NewPos = OldPos;
 
 			bool DoBreak = false;
-			int Hit = 0;
 
 			do
 			{
@@ -207,7 +206,7 @@ void CPlayers::RenderHookCollLine(
 				}
 
 				int TeleNr = 0;
-				Hit = Collision()->IntersectLineTeleHook(OldPos, NewPos, &FinishPos, 0x0, &TeleNr);
+				int Hit = Collision()->IntersectLineTeleHook(OldPos, NewPos, &FinishPos, 0x0, &TeleNr);
 
 				if(!DoBreak && Hit)
 				{

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -764,7 +764,7 @@ void CPlayers::OnRender()
 		if(m_pClient->m_aClients[i].m_LiveFrozen)
 			m_aRenderInfo[i].m_TeeRenderFlags |= TEE_EFFECT_FROZEN;
 
-		CGameClient::CSnapState::CCharacterInfo &CharacterInfo = m_pClient->m_Snap.m_aCharacters[i];
+		const CGameClient::CSnapState::CCharacterInfo &CharacterInfo = m_pClient->m_Snap.m_aCharacters[i];
 		if((CharacterInfo.m_Cur.m_Weapon == WEAPON_NINJA || (CharacterInfo.m_HasExtendedData && CharacterInfo.m_ExtendedData.m_FreezeEnd != 0)) && g_Config.m_ClShowNinja)
 		{
 			// change the skin for the player to the ninja

--- a/src/game/client/components/skins.cpp
+++ b/src/game/client/components/skins.cpp
@@ -80,7 +80,7 @@ int CSkins::SkinScan(const char *pName, int IsDir, int DirType, void *pUser)
 	return 0;
 }
 
-static void CheckMetrics(CSkin::SSkinMetricVariable &Metrics, uint8_t *pImg, int ImgWidth, int ImgX, int ImgY, int CheckWidth, int CheckHeight)
+static void CheckMetrics(CSkin::SSkinMetricVariable &Metrics, const uint8_t *pImg, int ImgWidth, int ImgX, int ImgY, int CheckWidth, int CheckHeight)
 {
 	int MaxY = -1;
 	int MinY = CheckHeight + 1;

--- a/src/game/client/components/spectator.cpp
+++ b/src/game/client/components/spectator.cpp
@@ -119,7 +119,7 @@ void CSpectator::ConSpectateClosest(IConsole::IResult *pResult, void *pUserData)
 	if(!pSelf->CanChangeSpectator())
 		return;
 
-	CGameClient::CSnapState &Snap = pSelf->m_pClient->m_Snap;
+	const CGameClient::CSnapState &Snap = pSelf->m_pClient->m_Snap;
 	int SpectatorID = Snap.m_SpecInfo.m_SpectatorID;
 
 	int NewSpectatorID = -1;
@@ -218,7 +218,7 @@ void CSpectator::OnRender()
 	float BoxMove = -10.0f;
 	float BoxOffset = 0.0f;
 
-	for(auto &pInfo : m_pClient->m_Snap.m_apInfoByDDTeamName)
+	for(const auto &pInfo : m_pClient->m_Snap.m_apInfoByDDTeamName)
 	{
 		if(!pInfo || pInfo->m_Team == TEAM_SPECTATORS)
 			continue;

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -2217,14 +2217,14 @@ int CGameClient::IntersectCharacter(vec2 HookPos, vec2 NewPos, vec2 &NewPos2, in
 	float Distance = 0.0f;
 	int ClosestID = -1;
 
-	CClientData &OwnClientData = m_aClients[ownID];
+	const CClientData &OwnClientData = m_aClients[ownID];
 
 	for(int i = 0; i < MAX_CLIENTS; i++)
 	{
 		if(i == ownID)
 			continue;
 
-		CClientData &cData = m_aClients[i];
+		const CClientData &cData = m_aClients[i];
 
 		if(!cData.m_Active)
 			continue;

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -2295,10 +2295,9 @@ void CGameClient::UpdatePrediction()
 	vec2 LocalCharPos = vec2(m_Snap.m_pLocalCharacter->m_X, m_Snap.m_pLocalCharacter->m_Y);
 	m_GameWorld.m_Core.m_aTuning[g_Config.m_ClDummy] = m_aTuning[g_Config.m_ClDummy];
 
-	int TuneZone = 0;
 	if(m_GameWorld.m_WorldConfig.m_UseTuneZones)
 	{
-		TuneZone = Collision()->IsTune(Collision()->GetMapIndex(LocalCharPos));
+		int TuneZone = Collision()->IsTune(Collision()->GetMapIndex(LocalCharPos));
 
 		if(TuneZone != m_aLocalTuneZone[g_Config.m_ClDummy])
 		{

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1662,7 +1662,7 @@ void CGameClient::OnNewSnapshot()
 		m_aDDRaceMsgSent[i] = true;
 	}
 
-	if(m_aShowOthers[g_Config.m_ClDummy] == SHOW_OTHERS_NOT_SET || (m_aShowOthers[g_Config.m_ClDummy] != SHOW_OTHERS_NOT_SET && m_aShowOthers[g_Config.m_ClDummy] != g_Config.m_ClShowOthers))
+	if(m_aShowOthers[g_Config.m_ClDummy] == SHOW_OTHERS_NOT_SET || m_aShowOthers[g_Config.m_ClDummy] != g_Config.m_ClShowOthers)
 	{
 		{
 			CNetMsg_Cl_ShowOthers Msg;

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1436,14 +1436,14 @@ void CGameClient::OnNewSnapshot()
 					if(m_aFlagDropTick[TEAM_RED] == 0)
 						m_aFlagDropTick[TEAM_RED] = Client()->GameTick(g_Config.m_ClDummy);
 				}
-				else if(m_aFlagDropTick[TEAM_RED] != 0)
+				else
 					m_aFlagDropTick[TEAM_RED] = 0;
 				if(m_Snap.m_pGameDataObj->m_FlagCarrierBlue == FLAG_TAKEN)
 				{
 					if(m_aFlagDropTick[TEAM_BLUE] == 0)
 						m_aFlagDropTick[TEAM_BLUE] = Client()->GameTick(g_Config.m_ClDummy);
 				}
-				else if(m_aFlagDropTick[TEAM_BLUE] != 0)
+				else
 					m_aFlagDropTick[TEAM_BLUE] = 0;
 				if(m_LastFlagCarrierRed == FLAG_ATSTAND && m_Snap.m_pGameDataObj->m_FlagCarrierRed >= 0)
 					OnFlagGrab(TEAM_RED);

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -725,7 +725,7 @@ private:
 
 	float m_LastZoom;
 	float m_LastScreenAspect;
-	float m_LastDummyConnected;
+	bool m_LastDummyConnected;
 };
 
 ColorRGBA CalculateNameColor(ColorHSLA TextColorHSL);

--- a/src/game/client/prediction/entities/character.cpp
+++ b/src/game/client/prediction/entities/character.cpp
@@ -1131,8 +1131,6 @@ CCharacter::CCharacter(CGameWorld *pGameWorld, int ID, CNetObj_Character *pChar,
 	m_Core.Init(&GameWorld()->m_Core, GameWorld()->Collision(), GameWorld()->Teams());
 	m_Core.m_Id = ID;
 	mem_zero(&m_Core.m_Ninja, sizeof(m_Core.m_Ninja));
-	mem_zero(&m_SavedInput, sizeof(m_SavedInput));
-	m_LatestInput = m_LatestPrevInput = m_PrevInput = m_Input = m_SavedInput;
 	m_Core.m_LeftWall = true;
 	m_ReloadTimer = 0;
 	m_NumObjectsHit = 0;
@@ -1142,6 +1140,7 @@ CCharacter::CCharacter(CGameWorld *pGameWorld, int ID, CNetObj_Character *pChar,
 	m_TeleCheckpoint = 0;
 	m_StrongWeakID = 0;
 
+	mem_zero(&m_Input, sizeof(m_Input));
 	// never initialize both to zero
 	m_Input.m_TargetX = 0;
 	m_Input.m_TargetY = -1;

--- a/src/game/client/prediction/entities/character.cpp
+++ b/src/game/client/prediction/entities/character.cpp
@@ -394,7 +394,7 @@ void CCharacter::FireWeapon()
 			int ShotSpread = 2;
 			for(int i = -ShotSpread; i <= ShotSpread; ++i)
 			{
-				float aSpreading[] = {-0.185f, -0.070f, 0, 0.070f, 0.185f};
+				const float aSpreading[] = {-0.185f, -0.070f, 0, 0.070f, 0.185f};
 				float a = angle(Direction);
 				a += aSpreading[i + 2];
 				float v = 1 - (absolute(i) / (float)ShotSpread);

--- a/src/game/client/prediction/entities/character.h
+++ b/src/game/client/prediction/entities/character.h
@@ -103,7 +103,7 @@ public:
 	void SetNinjaActivationTick(int ActivationTick) { m_Core.m_Ninja.m_ActivationTick = ActivationTick; }
 	void SetNinjaCurrentMoveTime(int CurrentMoveTime) { m_Core.m_Ninja.m_CurrentMoveTime = CurrentMoveTime; }
 	int GetCID() { return m_ID; }
-	void SetInput(CNetObj_PlayerInput *pNewInput)
+	void SetInput(const CNetObj_PlayerInput *pNewInput)
 	{
 		m_LatestInput = m_Input = *pNewInput;
 		// it is not allowed to aim in the center

--- a/src/game/client/prediction/entities/laser.cpp
+++ b/src/game/client/prediction/entities/laser.cpp
@@ -50,7 +50,7 @@ bool CLaser::HitCharacter(vec2 From, vec2 To)
 	{
 		vec2 Temp;
 		float Strength = GetTuning(m_TuneZone)->m_ShotgunStrength;
-		vec2 &HitPos = pHit->Core()->m_Pos;
+		const vec2 &HitPos = pHit->Core()->m_Pos;
 		if(!g_Config.m_SvOldLaser)
 		{
 			if(m_PrevPos != HitPos)

--- a/src/game/client/prediction/entities/projectile.cpp
+++ b/src/game/client/prediction/entities/projectile.cpp
@@ -101,7 +101,7 @@ void CProjectile::Tick()
 
 	if(((pTargetChr && (pOwnerChar ? !pOwnerChar->GrenadeHitDisabled() : g_Config.m_SvHit || m_Owner == -1 || pTargetChr == pOwnerChar)) || Collide || GameLayerClipped(CurPos)) && !isWeaponCollide)
 	{
-		if(m_Explosive && (!pTargetChr || (pTargetChr && (!m_Freeze || (m_Type == WEAPON_SHOTGUN && Collide)))))
+		if(m_Explosive && (!pTargetChr || (!m_Freeze || (m_Type == WEAPON_SHOTGUN && Collide))))
 		{
 			GameWorld()->CreateExplosion(ColPos, m_Owner, m_Type, m_Owner == -1, (!pTargetChr ? -1 : pTargetChr->Team()), -1LL);
 		}

--- a/src/game/client/prediction/gameworld.cpp
+++ b/src/game/client/prediction/gameworld.cpp
@@ -242,7 +242,7 @@ void CGameWorld::Tick()
 }
 
 // TODO: should be more general
-CCharacter *CGameWorld::IntersectCharacter(vec2 Pos0, vec2 Pos1, float Radius, vec2 &NewPos, CCharacter *pNotThis, int CollideWith, class CCharacter *pThisOnly)
+CCharacter *CGameWorld::IntersectCharacter(vec2 Pos0, vec2 Pos1, float Radius, vec2 &NewPos, const CCharacter *pNotThis, int CollideWith, const CCharacter *pThisOnly)
 {
 	// Find other players
 	float ClosestLen = distance(Pos0, Pos1) * 100.0f;
@@ -280,7 +280,7 @@ CCharacter *CGameWorld::IntersectCharacter(vec2 Pos0, vec2 Pos1, float Radius, v
 	return pClosest;
 }
 
-std::list<class CCharacter *> CGameWorld::IntersectedCharacters(vec2 Pos0, vec2 Pos1, float Radius, class CEntity *pNotThis)
+std::list<class CCharacter *> CGameWorld::IntersectedCharacters(vec2 Pos0, vec2 Pos1, float Radius, const CEntity *pNotThis)
 {
 	std::list<CCharacter *> listOfChars;
 

--- a/src/game/client/prediction/gameworld.cpp
+++ b/src/game/client/prediction/gameworld.cpp
@@ -564,7 +564,7 @@ void CGameWorld::CopyWorld(CGameWorld *pFrom)
 		return;
 	m_IsValidCopy = false;
 	m_pParent = pFrom;
-	if(m_pParent && m_pParent->m_pChild && m_pParent->m_pChild != this)
+	if(m_pParent->m_pChild && m_pParent->m_pChild != this)
 		m_pParent->m_pChild->m_IsValidCopy = false;
 	pFrom->m_pChild = this;
 

--- a/src/game/client/prediction/gameworld.h
+++ b/src/game/client/prediction/gameworld.h
@@ -36,7 +36,7 @@ public:
 	CEntity *FindFirst(int Type);
 	CEntity *FindLast(int Type);
 	int FindEntities(vec2 Pos, float Radius, CEntity **ppEnts, int Max, int Type);
-	CCharacter *IntersectCharacter(vec2 Pos0, vec2 Pos1, float Radius, vec2 &NewPos, CCharacter *pNotThis = nullptr, int CollideWith = -1, CCharacter *pThisOnly = nullptr);
+	CCharacter *IntersectCharacter(vec2 Pos0, vec2 Pos1, float Radius, vec2 &NewPos, const CCharacter *pNotThis = nullptr, int CollideWith = -1, const CCharacter *pThisOnly = nullptr);
 	void InsertEntity(CEntity *pEntity, bool Last = false);
 	void RemoveEntity(CEntity *pEntity);
 	void RemoveCharacter(CCharacter *pChar);
@@ -44,7 +44,7 @@ public:
 
 	// DDRace
 	void ReleaseHooked(int ClientID);
-	std::list<CCharacter *> IntersectedCharacters(vec2 Pos0, vec2 Pos1, float Radius, CEntity *pNotThis = nullptr);
+	std::list<CCharacter *> IntersectedCharacters(vec2 Pos0, vec2 Pos1, float Radius, const CEntity *pNotThis = nullptr);
 
 	int m_GameTick;
 	int m_GameTickSpeed;

--- a/src/game/client/race.cpp
+++ b/src/game/client/race.cpp
@@ -21,7 +21,7 @@ int CRaceHelper::TimeFromSecondsStr(const char *pStr)
 	{
 		pStr++;
 		static const int s_aMult[3] = {100, 10, 1};
-		for(int i = 0; isdigit(pStr[i]) && i < 3; i++)
+		for(size_t i = 0; i < std::size(s_aMult) && isdigit(pStr[i]); i++)
 			Time += (pStr[i] - '0') * s_aMult[i];
 	}
 	return Time;

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -519,7 +519,7 @@ void CUI::DoLabel(const CUIRect *pRect, const char *pText, float Size, int Align
 	DoTextLabel(pRect->x, pRect->y, pRect->w, pRect->h, pText, Size, Align, LabelProps);
 }
 
-void CUI::DoLabel(CUIElement::SUIElementRect &RectEl, const CUIRect *pRect, const char *pText, float Size, int Align, const SLabelProperties &LabelProps, int StrLen, CTextCursor *pReadCursor)
+void CUI::DoLabel(CUIElement::SUIElementRect &RectEl, const CUIRect *pRect, const char *pText, float Size, int Align, const SLabelProperties &LabelProps, int StrLen, const CTextCursor *pReadCursor)
 {
 	float AlignedSize = 0;
 	float MaxCharacterHeightInLine = 0;
@@ -581,7 +581,7 @@ void CUI::DoLabel(CUIElement::SUIElementRect &RectEl, const CUIRect *pRect, cons
 	RectEl.m_Cursor = Cursor;
 }
 
-void CUI::DoLabelStreamed(CUIElement::SUIElementRect &RectEl, float x, float y, float w, float h, const char *pText, float Size, int Align, float MaxWidth, int AlignVertically, bool StopAtEnd, int StrLen, CTextCursor *pReadCursor)
+void CUI::DoLabelStreamed(CUIElement::SUIElementRect &RectEl, float x, float y, float w, float h, const char *pText, float Size, int Align, float MaxWidth, int AlignVertically, bool StopAtEnd, int StrLen, const CTextCursor *pReadCursor)
 {
 	bool NeedsRecreate = false;
 	bool ColorChanged = RectEl.m_TextColor != TextRender()->GetTextColor() || RectEl.m_TextOutlineColor != TextRender()->GetTextOutlineColor();
@@ -637,7 +637,7 @@ void CUI::DoLabelStreamed(CUIElement::SUIElementRect &RectEl, float x, float y, 
 		TextRender()->RenderTextContainer(RectEl.m_UITextContainer, ColorText, ColorTextOutline);
 }
 
-void CUI::DoLabelStreamed(CUIElement::SUIElementRect &RectEl, const CUIRect *pRect, const char *pText, float Size, int Align, float MaxWidth, int AlignVertically, bool StopAtEnd, int StrLen, CTextCursor *pReadCursor)
+void CUI::DoLabelStreamed(CUIElement::SUIElementRect &RectEl, const CUIRect *pRect, const char *pText, float Size, int Align, float MaxWidth, int AlignVertically, bool StopAtEnd, int StrLen, const CTextCursor *pReadCursor)
 {
 	DoLabelStreamed(RectEl, pRect->x, pRect->y, pRect->w, pRect->h, pText, Size, Align, MaxWidth, AlignVertically, StopAtEnd, StrLen, pReadCursor);
 }

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -451,9 +451,8 @@ float CUI::DoTextLabel(float x, float y, float w, float h, const char *pText, fl
 {
 	float AlignedSize = 0;
 	float MaxCharacterHeightInLine = 0;
-	float tw = std::numeric_limits<float>::max();
 	float MaxTextWidth = LabelProps.m_MaxWidth != -1 ? LabelProps.m_MaxWidth : w;
-	tw = TextRender()->TextWidth(0, Size, pText, -1, LabelProps.m_MaxWidth, &AlignedSize, &MaxCharacterHeightInLine);
+	float tw = TextRender()->TextWidth(0, Size, pText, -1, LabelProps.m_MaxWidth, &AlignedSize, &MaxCharacterHeightInLine);
 	while(tw > MaxTextWidth + 0.001f)
 	{
 		if(!LabelProps.m_EnableWidthCheck)
@@ -524,9 +523,8 @@ void CUI::DoLabel(CUIElement::SUIElementRect &RectEl, const CUIRect *pRect, cons
 {
 	float AlignedSize = 0;
 	float MaxCharacterHeightInLine = 0;
-	float tw = std::numeric_limits<float>::max();
 	float MaxTextWidth = LabelProps.m_MaxWidth != -1 ? LabelProps.m_MaxWidth : pRect->w;
-	tw = TextRender()->TextWidth(0, Size, pText, -1, LabelProps.m_MaxWidth, &AlignedSize, &MaxCharacterHeightInLine);
+	float tw = TextRender()->TextWidth(0, Size, pText, -1, LabelProps.m_MaxWidth, &AlignedSize, &MaxCharacterHeightInLine);
 	while(tw > MaxTextWidth + 0.001f)
 	{
 		if(!LabelProps.m_EnableWidthCheck)

--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -343,9 +343,9 @@ public:
 	float DoTextLabel(float x, float y, float w, float h, const char *pText, float Size, int Align, const SLabelProperties &LabelProps = {});
 	void DoLabel(const CUIRect *pRect, const char *pText, float Size, int Align, const SLabelProperties &LabelProps = {});
 
-	void DoLabel(CUIElement::SUIElementRect &RectEl, const CUIRect *pRect, const char *pText, float Size, int Align, const SLabelProperties &LabelProps, int StrLen = -1, class CTextCursor *pReadCursor = nullptr);
-	void DoLabelStreamed(CUIElement::SUIElementRect &RectEl, float x, float y, float w, float h, const char *pText, float Size, int Align, float MaxWidth = -1, int AlignVertically = 1, bool StopAtEnd = false, int StrLen = -1, class CTextCursor *pReadCursor = nullptr);
-	void DoLabelStreamed(CUIElement::SUIElementRect &RectEl, const CUIRect *pRect, const char *pText, float Size, int Align, float MaxWidth = -1, int AlignVertically = 1, bool StopAtEnd = false, int StrLen = -1, class CTextCursor *pReadCursor = nullptr);
+	void DoLabel(CUIElement::SUIElementRect &RectEl, const CUIRect *pRect, const char *pText, float Size, int Align, const SLabelProperties &LabelProps, int StrLen = -1, const CTextCursor *pReadCursor = nullptr);
+	void DoLabelStreamed(CUIElement::SUIElementRect &RectEl, float x, float y, float w, float h, const char *pText, float Size, int Align, float MaxWidth = -1, int AlignVertically = 1, bool StopAtEnd = false, int StrLen = -1, const CTextCursor *pReadCursor = nullptr);
+	void DoLabelStreamed(CUIElement::SUIElementRect &RectEl, const CUIRect *pRect, const char *pText, float Size, int Align, float MaxWidth = -1, int AlignVertically = 1, bool StopAtEnd = false, int StrLen = -1, const CTextCursor *pReadCursor = nullptr);
 
 	bool DoEditBox(const void *pID, const CUIRect *pRect, char *pStr, unsigned StrSize, float FontSize, float *pOffset, bool Hidden = false, int Corners = IGraphics::CORNER_ALL, const SUIExEditBoxProperties &Properties = {});
 	bool DoClearableEditBox(const void *pID, const void *pClearID, const CUIRect *pRect, char *pStr, unsigned StrSize, float FontSize, float *pOffset, bool Hidden = false, int Corners = IGraphics::CORNER_ALL, const SUIExEditBoxProperties &Properties = {});

--- a/src/game/client/ui_scrollregion.cpp
+++ b/src/game/client/ui_scrollregion.cpp
@@ -20,7 +20,7 @@ CScrollRegion::CScrollRegion()
 	m_Params = CScrollRegionParams();
 }
 
-void CScrollRegion::Begin(CUIRect *pClipRect, vec2 *pOutOffset, CScrollRegionParams *pParams)
+void CScrollRegion::Begin(CUIRect *pClipRect, vec2 *pOutOffset, const CScrollRegionParams *pParams)
 {
 	if(pParams)
 		m_Params = *pParams;

--- a/src/game/client/ui_scrollregion.h
+++ b/src/game/client/ui_scrollregion.h
@@ -111,7 +111,7 @@ public:
 	};
 
 	CScrollRegion();
-	void Begin(CUIRect *pClipRect, vec2 *pOutOffset, CScrollRegionParams *pParams = nullptr);
+	void Begin(CUIRect *pClipRect, vec2 *pOutOffset, const CScrollRegionParams *pParams = nullptr);
 	void End();
 	bool AddRect(const CUIRect &Rect, bool ShouldScrollHere = false); // returns true if the added rect is visible (not clipped)
 	void ScrollHere(EScrollOption Option = SCROLLHERE_KEEP_IN_VIEW);

--- a/src/game/collision.cpp
+++ b/src/game/collision.cpp
@@ -294,13 +294,13 @@ int CCollision::IntersectLine(vec2 Pos0, vec2 Pos1, vec2 *pOutCollision, vec2 *p
 	float Distance = distance(Pos0, Pos1);
 	int End(Distance + 1);
 	vec2 Last = Pos0;
-	int ix = 0, iy = 0; // Temporary position for checking collision
 	for(int i = 0; i <= End; i++)
 	{
 		float a = i / (float)End;
 		vec2 Pos = mix(Pos0, Pos1, a);
-		ix = round_to_int(Pos.x);
-		iy = round_to_int(Pos.y);
+		// Temporary position for checking collision
+		int ix = round_to_int(Pos.x);
+		int iy = round_to_int(Pos.y);
 
 		if(CheckPoint(ix, iy))
 		{
@@ -325,15 +325,15 @@ int CCollision::IntersectLineTeleHook(vec2 Pos0, vec2 Pos1, vec2 *pOutCollision,
 	float Distance = distance(Pos0, Pos1);
 	int End(Distance + 1);
 	vec2 Last = Pos0;
-	int ix = 0, iy = 0; // Temporary position for checking collision
 	int dx = 0, dy = 0; // Offset for checking the "through" tile
 	ThroughOffset(Pos0, Pos1, &dx, &dy);
 	for(int i = 0; i <= End; i++)
 	{
 		float a = i / (float)End;
 		vec2 Pos = mix(Pos0, Pos1, a);
-		ix = round_to_int(Pos.x);
-		iy = round_to_int(Pos.y);
+		// Temporary position for checking collision
+		int ix = round_to_int(Pos.x);
+		int iy = round_to_int(Pos.y);
 
 		int Index = GetPureMapIndex(Pos);
 		if(g_Config.m_SvOldTeleportHook)
@@ -382,13 +382,13 @@ int CCollision::IntersectLineTeleWeapon(vec2 Pos0, vec2 Pos1, vec2 *pOutCollisio
 	float Distance = distance(Pos0, Pos1);
 	int End(Distance + 1);
 	vec2 Last = Pos0;
-	int ix = 0, iy = 0; // Temporary position for checking collision
 	for(int i = 0; i <= End; i++)
 	{
 		float a = i / (float)End;
 		vec2 Pos = mix(Pos0, Pos1, a);
-		ix = round_to_int(Pos.x);
-		iy = round_to_int(Pos.y);
+		// Temporary position for checking collision
+		int ix = round_to_int(Pos.x);
+		int iy = round_to_int(Pos.y);
 
 		int Index = GetPureMapIndex(Pos);
 		if(g_Config.m_SvOldTeleportWeapons)
@@ -913,18 +913,14 @@ std::list<int> CCollision::GetMapIndices(vec2 PrevPos, vec2 Pos, unsigned MaxInd
 	}
 	else
 	{
-		float a = 0.0f;
-		vec2 Tmp = vec2(0, 0);
-		int Nx = 0;
-		int Ny = 0;
-		int Index, LastIndex = 0;
+		int LastIndex = 0;
 		for(int i = 0; i < End; i++)
 		{
-			a = i / d;
-			Tmp = mix(PrevPos, Pos, a);
-			Nx = clamp((int)Tmp.x / 32, 0, m_Width - 1);
-			Ny = clamp((int)Tmp.y / 32, 0, m_Height - 1);
-			Index = Ny * m_Width + Nx;
+			float a = i / d;
+			vec2 Tmp = mix(PrevPos, Pos, a);
+			int Nx = clamp((int)Tmp.x / 32, 0, m_Width - 1);
+			int Ny = clamp((int)Tmp.y / 32, 0, m_Height - 1);
+			int Index = Ny * m_Width + Nx;
 			if(TileExists(Index) && LastIndex != Index)
 			{
 				if(MaxIndices && Indices.size() > MaxIndices)
@@ -997,17 +993,12 @@ int CCollision::GetIndex(vec2 PrevPos, vec2 Pos) const
 		}
 	}
 
-	float a = 0.0f;
-	vec2 Tmp = vec2(0, 0);
-	int Nx = 0;
-	int Ny = 0;
-
 	for(int i = 0, id = (int)ceilf(Distance); i < id; i++)
 	{
-		a = (float)i / Distance;
-		Tmp = mix(PrevPos, Pos, a);
-		Nx = clamp((int)Tmp.x / 32, 0, m_Width - 1);
-		Ny = clamp((int)Tmp.y / 32, 0, m_Height - 1);
+		float a = (float)i / Distance;
+		vec2 Tmp = mix(PrevPos, Pos, a);
+		int Nx = clamp((int)Tmp.x / 32, 0, m_Width - 1);
+		int Ny = clamp((int)Tmp.y / 32, 0, m_Height - 1);
 		if((m_pTele) ||
 			(m_pSpeedup && m_pSpeedup[Ny * m_Width + Nx].m_Force > 0))
 		{

--- a/src/game/editor/auto_map.cpp
+++ b/src/game/editor/auto_map.cpp
@@ -504,7 +504,7 @@ void CAutoMapper::Proceed(CLayerTiles *pLayer, int ConfigID, int Seed, int SeedO
 						if(pRule->m_Value == CPosRule::INDEX)
 						{
 							RespectRules = false;
-							for(auto &Index : pRule->m_vIndexList)
+							for(const auto &Index : pRule->m_vIndexList)
 							{
 								if(CheckIndex == Index.m_ID && (!Index.m_TestFlag || CheckFlags == Index.m_Flag))
 								{
@@ -515,7 +515,7 @@ void CAutoMapper::Proceed(CLayerTiles *pLayer, int ConfigID, int Seed, int SeedO
 						}
 						else if(pRule->m_Value == CPosRule::NOTINDEX)
 						{
-							for(auto &Index : pRule->m_vIndexList)
+							for(const auto &Index : pRule->m_vIndexList)
 							{
 								if(CheckIndex == Index.m_ID && (!Index.m_TestFlag || CheckFlags == Index.m_Flag))
 								{

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -6105,8 +6105,6 @@ void CEditor::Reset(bool CreateDefault)
 
 	m_ShowEnvelopePreview = SHOWENV_NONE;
 	m_ShiftBy = 1;
-
-	m_Map.m_Modified = false;
 }
 
 int CEditor::GetLineDistance() const

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -115,8 +115,8 @@ CLayerGroup::CLayerGroup()
 template<typename T>
 static void DeleteAll(std::vector<T> &vList)
 {
-	for(auto &Item : vList)
-		delete Item;
+	for(const auto &pItem : vList)
+		delete pItem;
 	vList.clear();
 }
 
@@ -2986,7 +2986,7 @@ void CEditor::DoMapEditor(CUIRect View)
 			for(int i = 0; i < 2; i++)
 			{
 				float aPoints[4];
-				float aAspects[] = {4.0f / 3.0f, 16.0f / 10.0f, 5.0f / 4.0f, 16.0f / 9.0f};
+				const float aAspects[] = {4.0f / 3.0f, 16.0f / 10.0f, 5.0f / 4.0f, 16.0f / 9.0f};
 				float Aspect = aAspects[i];
 
 				RenderTools()->MapScreenToWorld(
@@ -3143,7 +3143,7 @@ int CEditor::DoProperties(CUIRect *pToolBox, CProperty *pProps, int *pIDs, int *
 		else if(pProps[i].m_Type == PROPTYPE_COLOR)
 		{
 			static const char *s_apTexts[4] = {"R", "G", "B", "A"};
-			static int s_aShift[] = {24, 16, 8, 0};
+			static const int s_aShift[] = {24, 16, 8, 0};
 			int NewColor = 0;
 
 			// extra space

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -5119,24 +5119,21 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 		if(UI()->HotItem() == &s_EnvelopeEditorID)
 		{
 			// do stuff
-			if(pEnvelope)
+			if(UI()->MouseButtonClicked(1))
 			{
-				if(UI()->MouseButtonClicked(1))
-				{
-					// add point
-					int Time = (int)(((UI()->MouseX() - View.x) * TimeScale) * 1000.0f);
-					//float env_y = (UI()->MouseY()-view.y)/TimeScale;
-					ColorRGBA Channels;
-					pEnvelope->Eval(Time / 1000.0f, Channels);
-					pEnvelope->AddPoint(Time,
-						f2fx(Channels.r), f2fx(Channels.g),
-						f2fx(Channels.b), f2fx(Channels.a));
-					m_Map.m_Modified = true;
-				}
-
-				m_ShowEnvelopePreview = SHOWENV_SELECTED;
-				m_pTooltip = "Press right mouse button to create a new point";
+				// add point
+				int Time = (int)(((UI()->MouseX() - View.x) * TimeScale) * 1000.0f);
+				//float env_y = (UI()->MouseY()-view.y)/TimeScale;
+				ColorRGBA Channels;
+				pEnvelope->Eval(Time / 1000.0f, Channels);
+				pEnvelope->AddPoint(Time,
+					f2fx(Channels.r), f2fx(Channels.g),
+					f2fx(Channels.b), f2fx(Channels.a));
+				m_Map.m_Modified = true;
 			}
+
+			m_ShowEnvelopePreview = SHOWENV_SELECTED;
+			m_pTooltip = "Press right mouse button to create a new point";
 		}
 
 		// render lines

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -5057,48 +5057,45 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 
 		ColorRGBA aColors[] = {ColorRGBA(1, 0.2f, 0.2f), ColorRGBA(0.2f, 1, 0.2f), ColorRGBA(0.2f, 0.2f, 1), ColorRGBA(1, 1, 0.2f)};
 
-		if(pEnvelope)
+		CUIRect Button;
+
+		ToolBar.VSplitLeft(15.0f, &Button, &ToolBar);
+
+		static const char *s_aapNames[4][4] = {
+			{"V", "", "", ""},
+			{"", "", "", ""},
+			{"X", "Y", "R", ""},
+			{"R", "G", "B", "A"},
+		};
+
+		static const char *s_aapDescriptions[4][4] = {
+			{"Volume of the envelope", "", "", ""},
+			{"", "", "", ""},
+			{"X-axis of the envelope", "Y-axis of the envelope", "Rotation of the envelope", ""},
+			{"Red value of the envelope", "Green value of the envelope", "Blue value of the envelope", "Alpha value of the envelope"},
+		};
+
+		static int s_aChannelButtons[4] = {0};
+		int Bit = 1;
+
+		for(int i = 0; i < pEnvelope->m_Channels; i++, Bit <<= 1)
 		{
-			CUIRect Button;
-
 			ToolBar.VSplitLeft(15.0f, &Button, &ToolBar);
 
-			static const char *s_aapNames[4][4] = {
-				{"V", "", "", ""},
-				{"", "", "", ""},
-				{"X", "Y", "R", ""},
-				{"R", "G", "B", "A"},
-			};
-
-			static const char *s_aapDescriptions[4][4] = {
-				{"Volume of the envelope", "", "", ""},
-				{"", "", "", ""},
-				{"X-axis of the envelope", "Y-axis of the envelope", "Rotation of the envelope", ""},
-				{"Red value of the envelope", "Green value of the envelope", "Blue value of the envelope", "Alpha value of the envelope"},
-			};
-
-			static int s_aChannelButtons[4] = {0};
-			int Bit = 1;
-
-			for(int i = 0; i < pEnvelope->m_Channels; i++, Bit <<= 1)
-			{
-				ToolBar.VSplitLeft(15.0f, &Button, &ToolBar);
-
-				if(DoButton_Env(&s_aChannelButtons[i], s_aapNames[pEnvelope->m_Channels - 1][i], s_ActiveChannels & Bit, &Button, s_aapDescriptions[pEnvelope->m_Channels - 1][i], aColors[i]))
-					s_ActiveChannels ^= Bit;
-			}
-
-			// sync checkbox
-			ToolBar.VSplitLeft(15.0f, &Button, &ToolBar);
-			ToolBar.VSplitLeft(12.0f, &Button, &ToolBar);
-			static int s_SyncButton;
-			if(DoButton_Editor(&s_SyncButton, pEnvelope->m_Synchronized ? "X" : "", 0, &Button, 0, "Synchronize envelope animation to game time (restarts when you touch the start line)"))
-				pEnvelope->m_Synchronized = !pEnvelope->m_Synchronized;
-
-			ToolBar.VSplitLeft(4.0f, &Button, &ToolBar);
-			ToolBar.VSplitLeft(80.0f, &Button, &ToolBar);
-			UI()->DoLabel(&Button, "Synchronized", 10.0f, TEXTALIGN_LEFT);
+			if(DoButton_Env(&s_aChannelButtons[i], s_aapNames[pEnvelope->m_Channels - 1][i], s_ActiveChannels & Bit, &Button, s_aapDescriptions[pEnvelope->m_Channels - 1][i], aColors[i]))
+				s_ActiveChannels ^= Bit;
 		}
+
+		// sync checkbox
+		ToolBar.VSplitLeft(15.0f, &Button, &ToolBar);
+		ToolBar.VSplitLeft(12.0f, &Button, &ToolBar);
+		static int s_SyncButton;
+		if(DoButton_Editor(&s_SyncButton, pEnvelope->m_Synchronized ? "X" : "", 0, &Button, 0, "Synchronize envelope animation to game time (restarts when you touch the start line)"))
+			pEnvelope->m_Synchronized = !pEnvelope->m_Synchronized;
+
+		ToolBar.VSplitLeft(4.0f, &Button, &ToolBar);
+		ToolBar.VSplitLeft(80.0f, &Button, &ToolBar);
+		UI()->DoLabel(&Button, "Synchronized", 10.0f, TEXTALIGN_LEFT);
 
 		float EndTime = pEnvelope->EndTime();
 		if(EndTime < 1)

--- a/src/game/editor/io.cpp
+++ b/src/game/editor/io.cpp
@@ -884,8 +884,7 @@ bool CEditorMap::Load(class IStorage *pStorage, const char *pFileName, int Stora
 							pSounds->m_Sound = -1;
 
 						// load layer name
-						if(pSoundsItem->m_Version >= 1)
-							IntsToStr(pSoundsItem->m_aName, sizeof(pSounds->m_aName) / sizeof(int), pSounds->m_aName);
+						IntsToStr(pSoundsItem->m_aName, sizeof(pSounds->m_aName) / sizeof(int), pSounds->m_aName);
 
 						// load data
 						void *pData = DataFile.GetDataSwapped(pSoundsItem->m_Data);
@@ -911,8 +910,7 @@ bool CEditorMap::Load(class IStorage *pStorage, const char *pFileName, int Stora
 							pSounds->m_Sound = -1;
 
 						// load layer name
-						if(pSoundsItem->m_Version >= 1)
-							IntsToStr(pSoundsItem->m_aName, sizeof(pSounds->m_aName) / sizeof(int), pSounds->m_aName);
+						IntsToStr(pSoundsItem->m_aName, sizeof(pSounds->m_aName) / sizeof(int), pSounds->m_aName);
 
 						// load data
 						CSoundSource_DEPRECATED *pData = (CSoundSource_DEPRECATED *)DataFile.GetDataSwapped(pSoundsItem->m_Data);

--- a/src/game/editor/layer_tiles.cpp
+++ b/src/game/editor/layer_tiles.cpp
@@ -541,7 +541,7 @@ void CLayerTiles::BrushFlipX()
 			if(!Rotate && !IsRotatableTile(m_pTiles[y * m_Width + x].m_Index))
 				m_pTiles[y * m_Width + x].m_Flags = 0;
 			else
-				m_pTiles[y * m_Width + x].m_Flags ^= m_pTiles[y * m_Width + x].m_Flags & TILEFLAG_ROTATE ? TILEFLAG_HFLIP : TILEFLAG_VFLIP;
+				m_pTiles[y * m_Width + x].m_Flags ^= (m_pTiles[y * m_Width + x].m_Flags & TILEFLAG_ROTATE) ? TILEFLAG_HFLIP : TILEFLAG_VFLIP;
 }
 
 void CLayerTiles::BrushFlipY()
@@ -557,7 +557,7 @@ void CLayerTiles::BrushFlipY()
 			if(!Rotate && !IsRotatableTile(m_pTiles[y * m_Width + x].m_Index))
 				m_pTiles[y * m_Width + x].m_Flags = 0;
 			else
-				m_pTiles[y * m_Width + x].m_Flags ^= m_pTiles[y * m_Width + x].m_Flags & TILEFLAG_ROTATE ? TILEFLAG_VFLIP : TILEFLAG_HFLIP;
+				m_pTiles[y * m_Width + x].m_Flags ^= (m_pTiles[y * m_Width + x].m_Flags & TILEFLAG_ROTATE) ? TILEFLAG_VFLIP : TILEFLAG_HFLIP;
 }
 
 void CLayerTiles::BrushRotate(float Amount)

--- a/src/game/server/gameworld.cpp
+++ b/src/game/server/gameworld.cpp
@@ -339,8 +339,7 @@ void CGameWorld::SwapClients(int Client1, int Client2)
 }
 
 // TODO: should be more general
-//CCharacter *CGameWorld::IntersectCharacter(vec2 Pos0, vec2 Pos1, float Radius, vec2& NewPos, CEntity *pNotThis)
-CCharacter *CGameWorld::IntersectCharacter(vec2 Pos0, vec2 Pos1, float Radius, vec2 &NewPos, CCharacter *pNotThis, int CollideWith, class CCharacter *pThisOnly)
+CCharacter *CGameWorld::IntersectCharacter(vec2 Pos0, vec2 Pos1, float Radius, vec2 &NewPos, const CCharacter *pNotThis, int CollideWith, const CCharacter *pThisOnly)
 {
 	// Find other players
 	float ClosestLen = distance(Pos0, Pos1) * 100.0f;
@@ -378,7 +377,7 @@ CCharacter *CGameWorld::IntersectCharacter(vec2 Pos0, vec2 Pos1, float Radius, v
 	return pClosest;
 }
 
-CCharacter *CGameWorld::ClosestCharacter(vec2 Pos, float Radius, CEntity *pNotThis)
+CCharacter *CGameWorld::ClosestCharacter(vec2 Pos, float Radius, const CEntity *pNotThis)
 {
 	// Find other players
 	float ClosestRange = Radius * 2;
@@ -404,7 +403,7 @@ CCharacter *CGameWorld::ClosestCharacter(vec2 Pos, float Radius, CEntity *pNotTh
 	return pClosest;
 }
 
-std::list<class CCharacter *> CGameWorld::IntersectedCharacters(vec2 Pos0, vec2 Pos1, float Radius, class CEntity *pNotThis)
+std::list<class CCharacter *> CGameWorld::IntersectedCharacters(vec2 Pos0, vec2 Pos1, float Radius, const CEntity *pNotThis)
 {
 	std::list<CCharacter *> listOfChars;
 

--- a/src/game/server/gameworld.h
+++ b/src/game/server/gameworld.h
@@ -88,8 +88,7 @@ public:
 		Returns:
 			Returns a pointer to the closest hit or NULL of there is no intersection.
 	*/
-	//CCharacter *IntersectCharacter(vec2 Pos0, vec2 Pos1, float Radius, vec2 &NewPos, class CEntity *pNotThis = 0);
-	CCharacter *IntersectCharacter(vec2 Pos0, vec2 Pos1, float Radius, vec2 &NewPos, CCharacter *pNotThis = 0, int CollideWith = -1, CCharacter *pThisOnly = 0);
+	CCharacter *IntersectCharacter(vec2 Pos0, vec2 Pos1, float Radius, vec2 &NewPos, const CCharacter *pNotThis = nullptr, int CollideWith = -1, const CCharacter *pThisOnly = nullptr);
 	/*
 		Function: ClosestCharacter
 			Finds the closest CCharacter to a specific point.
@@ -97,12 +96,12 @@ public:
 		Arguments:
 			Pos - The center position.
 			Radius - How far off the CCharacter is allowed to be
-			ppNotThis - Entity to ignore
+			pNotThis - Entity to ignore
 
 		Returns:
 			Returns a pointer to the closest CCharacter or NULL if no CCharacter is close enough.
 	*/
-	CCharacter *ClosestCharacter(vec2 Pos, float Radius, CEntity *ppNotThis);
+	CCharacter *ClosestCharacter(vec2 Pos, float Radius, const CEntity *pNotThis);
 
 	/*
 		Function: InsertEntity
@@ -163,7 +162,7 @@ public:
 		Returns:
 			Returns list with all Characters on line.
 	*/
-	std::list<CCharacter *> IntersectedCharacters(vec2 Pos0, vec2 Pos1, float Radius, class CEntity *pNotThis = 0);
+	std::list<CCharacter *> IntersectedCharacters(vec2 Pos0, vec2 Pos1, float Radius, const CEntity *pNotThis = nullptr);
 };
 
 #endif

--- a/src/game/server/score.cpp
+++ b/src/game/server/score.cpp
@@ -132,7 +132,7 @@ void CScore::MapInfo(int ClientID, const char *pMapName)
 	ExecPlayerThread(CScoreWorker::MapInfo, "map info", ClientID, pMapName, 0);
 }
 
-void CScore::SaveScore(int ClientID, float Time, const char *pTimestamp, float aTimeCp[NUM_CHECKPOINTS], bool NotEligible)
+void CScore::SaveScore(int ClientID, float Time, const char *pTimestamp, const float aTimeCp[NUM_CHECKPOINTS], bool NotEligible)
 {
 	CConsole *pCon = (CConsole *)GameServer()->Console();
 	if(pCon->m_Cheated || NotEligible)

--- a/src/game/server/score.h
+++ b/src/game/server/score.h
@@ -47,7 +47,7 @@ public:
 	void MapInfo(int ClientID, const char *pMapName);
 	void MapVote(int ClientID, const char *pMapName);
 	void LoadPlayerData(int ClientID, const char *pName = "");
-	void SaveScore(int ClientID, float Time, const char *pTimestamp, float aTimeCp[NUM_CHECKPOINTS], bool NotEligible);
+	void SaveScore(int ClientID, float Time, const char *pTimestamp, const float aTimeCp[NUM_CHECKPOINTS], bool NotEligible);
 
 	void SaveTeamScore(int *pClientIDs, unsigned int Size, float Time, const char *pTimestamp);
 

--- a/src/game/server/scoreworker.h
+++ b/src/game/server/scoreworker.h
@@ -236,7 +236,7 @@ public:
 			BestTimeCp = 0;
 	}
 
-	void Set(float Time, float aTimeCp[NUM_CHECKPOINTS])
+	void Set(float Time, const float aTimeCp[NUM_CHECKPOINTS])
 	{
 		m_BestTime = Time;
 		for(int i = 0; i < NUM_CHECKPOINTS; i++)

--- a/src/game/server/teeinfo.cpp
+++ b/src/game/server/teeinfo.cpp
@@ -38,7 +38,7 @@ CTeeInfo::CTeeInfo(const char *pSkinName, int UseCustomColor, int ColorBody, int
 	m_ColorFeet = ColorFeet;
 }
 
-CTeeInfo::CTeeInfo(const char *apSkinPartNames[6], int *pUseCustomColors, int *pSkinPartColors)
+CTeeInfo::CTeeInfo(const char *apSkinPartNames[6], const int *pUseCustomColors, const int *pSkinPartColors)
 {
 	for(int i = 0; i < 6; i++)
 	{

--- a/src/game/server/teeinfo.h
+++ b/src/game/server/teeinfo.h
@@ -21,7 +21,7 @@ public:
 	CTeeInfo(const char *pSkinName, int UseCustomColor, int ColorBody, int ColorFeet);
 
 	// This constructor will assume all arrays are of length 6
-	CTeeInfo(const char *apSkinPartNames[6], int *pUseCustomColors, int *pSkinPartColors);
+	CTeeInfo(const char *apSkinPartNames[6], const int *pUseCustomColors, const int *pSkinPartColors);
 
 	void FromSixup();
 	void ToSixup();

--- a/src/test/secure_random.cpp
+++ b/src/test/secure_random.cpp
@@ -21,7 +21,7 @@ TEST(SecureRandom, Below1)
 
 TEST(SecureRandom, Below)
 {
-	int BOUNDS[] = {2, 3, 4, 5, 10, 100, 127, 128, 129};
+	const int BOUNDS[] = {2, 3, 4, 5, 10, 100, 127, 128, 129};
 	for(auto Below : BOUNDS)
 	{
 		for(int j = 0; j < 10; j++)

--- a/src/tools/crapnet.cpp
+++ b/src/tools/crapnet.cpp
@@ -138,11 +138,10 @@ void Run(unsigned short Port, NETADDR Dest)
 			}
 		}
 
-		SPacket *p = 0;
 		SPacket *pNext = g_pFirst;
 		while(true)
 		{
-			p = pNext;
+			SPacket *p = pNext;
 			if(!p)
 				break;
 			pNext = p->m_pNext;

--- a/src/tools/map_create_pixelart.cpp
+++ b/src/tools/map_create_pixelart.cpp
@@ -31,7 +31,7 @@ int main(int argc, const char **argv)
 	CCmdlineFix CmdlineFix(&argc, &argv);
 	log_set_global_logger_default();
 
-	if(argc < 11 || argc > 12)
+	if(argc < 9 || argc > 12)
 	{
 		dbg_msg("map_create_pixelart", "Invalid arguments");
 		dbg_msg("map_create_pixelart", "Usage: %s <image.png> <img_pixelsize> <input_map> <layergroup_id> <layer_id> <pos_x> <pos_y> <quad_pixelsize> <output_map> [optimize=0|1] [centralize=0|1]", argv[0]);

--- a/src/tools/map_create_pixelart.cpp
+++ b/src/tools/map_create_pixelart.cpp
@@ -224,7 +224,7 @@ bool GetPixelClamped(const CImageInfo &Img, int x, int y, uint8_t aPixel[4])
 	for(int i = 0; i < BPP; i++)
 		aPixel[i] = ((uint8_t *)Img.m_pData)[x * BPP + (Img.m_Width * BPP * y) + i];
 
-	return aPixel[3];
+	return aPixel[3] > 0;
 }
 
 bool ComparePixel(const uint8_t aPixel1[4], const uint8_t aPixel2[4])

--- a/src/tools/map_replace_area.cpp
+++ b/src/tools/map_replace_area.cpp
@@ -43,12 +43,12 @@ bool AdaptVisiblePoint(const float[2][2][2], const float[2][2], const MapObject[
 
 MapObject CreateMapObject(const CMapItemGroup *, int, int, int, int);
 void SetExtendedArea(MapObject &);
-bool GetVisibleArea(const float[2][2], MapObject, float[2][2] = 0x0);
-bool GetReplaceableArea(const float[2][2], MapObject, float[2][2]);
+bool GetVisibleArea(const float[2][2], const MapObject &, float[2][2] = 0x0);
+bool GetReplaceableArea(const float[2][2], const MapObject &, float[2][2]);
 
 void GetGameAreaDistance(const float[2][2][2], const MapObject[2], const float[2][2][2], float[2]);
 void GetGameAreaDistance(const float[2][2][2], const MapObject[2], const float[2][2], float[2]);
-void GetSignificantScreenPos(MapObject, const float[2][2], const float[2][2], float[2]);
+void GetSignificantScreenPos(const MapObject &, const float[2][2], const float[2][2], float[2]);
 void ConvertToTiles(const float[2][2], int[2][2]);
 
 bool GetLineIntersection(const float[2], const float[2], float[2] = 0x0);
@@ -511,7 +511,7 @@ void SetExtendedArea(MapObject &Ob)
 	}
 }
 
-bool GetVisibleArea(const float aaGameArea[2][2], const MapObject Ob, float aaVisibleArea[2][2])
+bool GetVisibleArea(const float aaGameArea[2][2], const MapObject &Ob, float aaVisibleArea[2][2])
 {
 	if(IsInexistent((float *)Ob.m_aaExtendedArea, 4))
 		return false;
@@ -543,7 +543,7 @@ bool GetVisibleArea(const float aaGameArea[2][2], const MapObject Ob, float aaVi
 	return true;
 }
 
-bool GetReplaceableArea(const float aaVisibleArea[2][2], const MapObject Ob, float aaReplaceableArea[2][2])
+bool GetReplaceableArea(const float aaVisibleArea[2][2], const MapObject &Ob, float aaReplaceableArea[2][2])
 {
 	SetInexistent((float *)aaReplaceableArea, 4);
 	if(IsInexistent((float *)aaVisibleArea, 4))
@@ -599,7 +599,7 @@ void GetGameAreaDistance(const float aaaGameAreas[2][2][2], const MapObject aObs
 	GetGameAreaDistance(aaaGameAreas, aObs, aaaVisibleAreas, aDistance);
 }
 
-void GetSignificantScreenPos(const MapObject Ob, const float aaVisibleArea[2][2], const float aaReplaceableArea[2][2], float aScreen[2])
+void GetSignificantScreenPos(const MapObject &Ob, const float aaVisibleArea[2][2], const float aaReplaceableArea[2][2], float aScreen[2])
 {
 	for(int i = 0; i < 2; i++)
 	{


### PR DESCRIPTION
After generating `compile_commands.json` with cmake, I ran [cppcheck](https://cppcheck.sourceforge.io/) like this:

```
cppcheck --project=compile_commands.json -DWIN64 --suppressions-list=cppcheck.supp --enable=all 2>cppcheck.log
```

With these suppressions in `cppcheck.supp`:

```
cstyleCast
useStlAlgorithm
unusedFunction
variableScope
noExplicitConstructor
useInitializationList
noConstructor
uninitMemberVar
uninitMemberVarPrivate
uninitDerivedMemberVar
uninitStructMember
uninitvar
shadowFunction
memleakOnRealloc
internalAstError
virtualCallInConstructor
unknownMacro
noOperatorEq
noCopyConstructor
```

Many of these occur too often or are false positives. 

Here is a list of all remaining non-suppressed issues reported by cppcheck: [cppcheck.log](https://github.com/ddnet/ddnet/files/9997663/cppcheck.log)

And here is a list of all remaining issues including the suppressed ones: [cppcheck_all.log](https://github.com/ddnet/ddnet/files/9997662/cppcheck_all.log)

I couldn't get cppcheck's command line argument to ignore the external folders to work correctly, so I manually removed those entries from the files.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
