### PR TITLE
Null-terminate string returned by mysql

### DIFF
--- a/src/engine/server/databases/mysql.cpp
+++ b/src/engine/server/databases/mysql.cpp
@@ -618,7 +618,7 @@ void CMysqlConnection::GetString(int Col, char *pBuffer, int BufferSize)
 
 	for(int i = 0; i < BufferSize; i++)
 	{
-		pBuffer[i] = 'a';
+		pBuffer[i] = '\0';
 	}
 
 	MYSQL_BIND Bind;
@@ -628,7 +628,8 @@ void CMysqlConnection::GetString(int Col, char *pBuffer, int BufferSize)
 	mem_zero(&Bind, sizeof(Bind));
 	Bind.buffer_type = MYSQL_TYPE_STRING;
 	Bind.buffer = pBuffer;
-	Bind.buffer_length = BufferSize;
+	// leave one character for null-termination
+	Bind.buffer_length = BufferSize - 1;
 	Bind.length = &Length;
 	Bind.is_null = &IsNull;
 	Bind.is_unsigned = false;


### PR DESCRIPTION
Found in #6050 that a 16 byte long name would be written, filling up the string entirely, no terminating '\0'

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
