### PR TITLE
Add `Shift+G` editor hotkey to toggle visibility of game layers

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -910,7 +910,7 @@ void CEditor::DoToolbar(CUIRect ToolBar)
 		TB_Top.VSplitLeft(40.0f, &Button, &TB_Top);
 		static int s_GridButton = 0;
 		if(DoButton_Editor(&s_GridButton, "Grid", m_GridActive, &Button, 0, "[ctrl+g] Toggle Grid") ||
-			(Input()->KeyPress(KEY_G) && ModPressed))
+			(Input()->KeyPress(KEY_G) && ModPressed && !ShiftPressed))
 		{
 			m_GridActive = !m_GridActive;
 		}
@@ -2354,6 +2354,28 @@ void CEditor::DoMapEditor(CUIRect View)
 	// render all good stuff
 	if(!m_ShowPicker)
 	{
+		if(Input()->ShiftIsPressed() && !Input()->ModifierIsPressed() && Input()->KeyPress(KEY_G))
+		{
+			const bool AnyHidden =
+				!m_Map.m_pGameLayer->m_Visible ||
+				(m_Map.m_pFrontLayer && !m_Map.m_pFrontLayer->m_Visible) ||
+				(m_Map.m_pTeleLayer && !m_Map.m_pTeleLayer->m_Visible) ||
+				(m_Map.m_pSpeedupLayer && !m_Map.m_pSpeedupLayer->m_Visible) ||
+				(m_Map.m_pTuneLayer && !m_Map.m_pTuneLayer->m_Visible) ||
+				(m_Map.m_pSwitchLayer && !m_Map.m_pSwitchLayer->m_Visible);
+			m_Map.m_pGameLayer->m_Visible = AnyHidden;
+			if(m_Map.m_pFrontLayer)
+				m_Map.m_pFrontLayer->m_Visible = AnyHidden;
+			if(m_Map.m_pTeleLayer)
+				m_Map.m_pTeleLayer->m_Visible = AnyHidden;
+			if(m_Map.m_pSpeedupLayer)
+				m_Map.m_pSpeedupLayer->m_Visible = AnyHidden;
+			if(m_Map.m_pTuneLayer)
+				m_Map.m_pTuneLayer->m_Visible = AnyHidden;
+			if(m_Map.m_pSwitchLayer)
+				m_Map.m_pSwitchLayer->m_Visible = AnyHidden;
+		}
+
 		for(auto &pGroup : m_Map.m_vpGroups)
 		{
 			if(pGroup->m_Visible)


### PR DESCRIPTION
If any game layers are hidden, the hotkey will make them visible. Else, if all game layers are visible, the hotkey will hide all of them.

Closes #4109.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
