### PR TITLE
add cargo for fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Or on CentOS, RedHat and AlmaLinux like this:
 
 Or on Fedora like this:
 
-    sudo dnf install cmake ffmpeg-devel freetype-devel gcc gcc-c++ git glew-devel glslang gmock-devel gtest-devel libcurl-devel libnotify-devel libogg-devel libpng-devel make openssl-devel opus-devel opusfile-devel python2 SDL2-devel spirv-tools sqlite-devel vulkan-devel wavpack-devel x264-devel
+    sudo dnf install cargo cmake ffmpeg-devel freetype-devel gcc gcc-c++ git glew-devel glslang gmock-devel gtest-devel libcurl-devel libnotify-devel libogg-devel libpng-devel make openssl-devel opus-devel opusfile-devel python2 SDL2-devel spirv-tools sqlite-devel vulkan-devel wavpack-devel x264-devel
 
 Or on Arch Linux like this:
 


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->
looks like in https://github.com/ddnet/ddnet/commit/07be2a7663f0fcc847d06c2ce649c35da9ce9970 cargo package for fedora wasn't added
<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->