### PR TITLE
Add buttons+increased length on demo viewbar

### DIFF
--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -541,6 +541,9 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 	}
 	GameClient()->m_Tooltips.DoToolTip(&s_SliceSaveButton, &Button, Localize("Export cut as a separate demo"));
 
+	// threshold value, accounts for slight inaccuracy when setting demo position
+	const int Threshold = 10;
+
 	// one marker back
 	ButtonBar.VSplitLeft(Margins + 20.0f, 0, &ButtonBar);
 	ButtonBar.VSplitLeft(ButtonbarHeight, &Button, &ButtonBar);
@@ -548,11 +551,12 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 	if(DoButton_FontIcon(&s_OneMarkerBackButton, "\xEF\x81\x88", 0, &Button, IGraphics::CORNER_ALL))
 		for(int i = pInfo->m_NumTimelineMarkers - 1; i >= 0; i--)
 		{
-			if((pInfo->m_aTimelineMarkers[i] - pInfo->m_FirstTick) < CurrentTick)
+			if((pInfo->m_aTimelineMarkers[i] - pInfo->m_FirstTick) < CurrentTick && absolute(((pInfo->m_aTimelineMarkers[i] - pInfo->m_FirstTick) - CurrentTick)) > Threshold)
 			{
 				DemoPlayer()->SeekPercent((float)(pInfo->m_aTimelineMarkers[i] - pInfo->m_FirstTick) / TotalTicks);
 				break;
 			}
+			DemoPlayer()->SeekPercent(0.0f);
 		}
 	GameClient()->m_Tooltips.DoToolTip(&s_OneMarkerBackButton, &Button, Localize("Go back one marker"));
 
@@ -563,11 +567,12 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 	if(DoButton_FontIcon(&s_OneMarkerForwardButton, "\xEF\x81\x91", 0, &Button, IGraphics::CORNER_ALL))
 		for(int i = 0; i < pInfo->m_NumTimelineMarkers; i++)
 		{
-			if((pInfo->m_aTimelineMarkers[i] - pInfo->m_FirstTick) - 2 > CurrentTick)
+			if((pInfo->m_aTimelineMarkers[i] - pInfo->m_FirstTick) > CurrentTick && absolute(((pInfo->m_aTimelineMarkers[i] - pInfo->m_FirstTick) - CurrentTick)) > Threshold)
 			{
 				DemoPlayer()->SeekPercent((float)(pInfo->m_aTimelineMarkers[i] - pInfo->m_FirstTick) / TotalTicks);
 				break;
 			}
+			DemoPlayer()->SeekPercent(1.0f);
 		}
 	GameClient()->m_Tooltips.DoToolTip(&s_OneMarkerForwardButton, &Button, Localize("Go forward one marker"));
 

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -546,7 +546,7 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 	ButtonBar.VSplitLeft(ButtonbarHeight, &Button, &ButtonBar);
 	static CButtonContainer s_OneMarkerBackButton;
 	if(DoButton_FontIcon(&s_OneMarkerBackButton, "\xEF\x81\x88", 0, &Button, IGraphics::CORNER_ALL))
-		for(int i = pInfo->m_NumTimelineMarkers-1; i >= 0; i--)
+		for(int i = pInfo->m_NumTimelineMarkers - 1; i >= 0; i--)
 		{
 			if((pInfo->m_aTimelineMarkers[i] - pInfo->m_FirstTick) < CurrentTick)
 			{
@@ -563,7 +563,7 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 	if(DoButton_FontIcon(&s_OneMarkerForwardButton, "\xEF\x81\x91", 0, &Button, IGraphics::CORNER_ALL))
 		for(int i = 0; i < pInfo->m_NumTimelineMarkers; i++)
 		{
-			if((pInfo->m_aTimelineMarkers[i] - pInfo->m_FirstTick)-2 > CurrentTick)
+			if((pInfo->m_aTimelineMarkers[i] - pInfo->m_FirstTick) - 2 > CurrentTick)
 			{
 				DemoPlayer()->SeekPercent(static_cast<float>(pInfo->m_aTimelineMarkers[i] - pInfo->m_FirstTick) / static_cast<float>(TotalTicks));
 				break;

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -364,7 +364,7 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 			Graphics()->TextureClear();
 			Graphics()->QuadsBegin();
 			Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
-			IGraphics::CQuadItem QuadItem(SeekBar.x + (SeekBar.w - 10.0f) * Ratio, SeekBar.y, UI()->PixelSize(), SeekBar.h);
+			IGraphics::CQuadItem QuadItem(8.0f + SeekBar.x + (SeekBar.w - 10.0f) * Ratio, SeekBar.y, UI()->PixelSize(), SeekBar.h);
 			Graphics()->QuadsDrawTL(&QuadItem, 1);
 			Graphics()->QuadsEnd();
 		}

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -331,7 +331,7 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 
 	MainView.Margin(5.0f, &MainView);
 
-	CUIRect SeekBar, ButtonBar, NameBar, SpeedBar{};
+	CUIRect SeekBar, ButtonBar, NameBar, SpeedBar;
 
 	MainView.HSplitTop(SeekBarHeight, &SeekBar, &ButtonBar);
 	ButtonBar.HSplitTop(Margins, 0, &ButtonBar);
@@ -550,7 +550,7 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 		{
 			if((pInfo->m_aTimelineMarkers[i] - pInfo->m_FirstTick) < CurrentTick)
 			{
-				DemoPlayer()->SeekPercent(static_cast<float>(pInfo->m_aTimelineMarkers[i] - pInfo->m_FirstTick) / static_cast<float>(TotalTicks));
+				DemoPlayer()->SeekPercent((float)(pInfo->m_aTimelineMarkers[i] - pInfo->m_FirstTick) / TotalTicks);
 				break;
 			}
 		}
@@ -565,7 +565,7 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 		{
 			if((pInfo->m_aTimelineMarkers[i] - pInfo->m_FirstTick) - 2 > CurrentTick)
 			{
-				DemoPlayer()->SeekPercent(static_cast<float>(pInfo->m_aTimelineMarkers[i] - pInfo->m_FirstTick) / static_cast<float>(TotalTicks));
+				DemoPlayer()->SeekPercent((float)(pInfo->m_aTimelineMarkers[i] - pInfo->m_FirstTick) / TotalTicks);
 				break;
 			}
 		}


### PR DESCRIPTION
Aimed to add some more controls on the demo view bar:

Added tick step buttons and jump to next/prev marker buttons
Increased width of demo controls panel so it wasn't as cluttered
changed export cut icon to a common export icon instead of the camcorder icon
Centered the time multiplier between the buttons it was between

![image](https://user-images.githubusercontent.com/69405348/202874985-9d983959-9188-4d96-9a2d-633621e6f489.png)


## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
