### PR TITLE
Add friend counter + Change alignment of player count text

### DIFF
--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -98,7 +98,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 		{COL_NAME, IServerBrowser::SORT_NAME, "Name", 0, 50.0f, 0, {0}, {0}}, // Localize - these strings are localized within CLocConstString
 		{COL_GAMETYPE, IServerBrowser::SORT_GAMETYPE, "Type", 1, 50.0f, 0, {0}, {0}},
 		{COL_MAP, IServerBrowser::SORT_MAP, "Map", 1, 120.0f + (Headers.w - 480) / 8, 0, {0}, {0}},
-		{COL_PLAYERS, IServerBrowser::SORT_NUMPLAYERS, "Players", 1, 75.0f, 0, {0}, {0}},
+		{COL_PLAYERS, IServerBrowser::SORT_NUMPLAYERS, "Players", 1, 85.0f, 0, {0}, {0}},
 		{-1, -1, " ", 1, 10.0f, 0, {0}, {0}},
 		{COL_PING, IServerBrowser::SORT_PING, "Ping", 1, 40.0f, FIXED, {0}, {0}},
 	};
@@ -426,16 +426,16 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 				Button.VMargin(2.0f, &Button);
 				if(pItem->m_FriendState != IFriends::FRIEND_NO)
 				{
-					Button.VSplitLeft(38.0f, &Button, &Icon);
+					Button.VSplitRight(50.0f, &Icon, &Button);
 					Icon.Margin(2.0f, &Icon);
-					Icon.VSplitLeft(13.0f, &Icon, &IconText);
-					RenderBrowserIcons(*pItem->m_pUIElement->Rect(gs_OffsetColFav + 1), &Icon, {0.94f, 0.4f, 0.4f, 1}, TextRender()->DefaultTextOutlineColor(), "\xEF\x80\x84", TEXTALIGN_LEFT);
+					Icon.HSplitBottom(6.0f, 0, &IconText);
+					RenderBrowserIcons(*pItem->m_pUIElement->Rect(gs_OffsetColFav + 1), &Icon, {0.94f, 0.4f, 0.4f, 1}, TextRender()->DefaultTextOutlineColor(), "\xEF\x80\x84", TEXTALIGN_CENTER);
 					if(FriendsOnServer > 1)
 					{
 						char aBufFriendsOnServer[64];
-						str_format(aBufFriendsOnServer, sizeof(aBufFriendsOnServer), "%d", FriendsOnServer);
-						TextRender()->TextColor(0.94f, 0.4f, 0.4f, 1);
-						UI()->DoLabel(&IconText, aBufFriendsOnServer, 10.0f, TEXTALIGN_LEFT);
+						str_format(aBufFriendsOnServer, sizeof(aBufFriendsOnServer), "%i", FriendsOnServer);
+						TextRender()->TextColor(0.94f, 0.8f, 0.8f, 1);
+						UI()->DoLabel(&IconText, aBufFriendsOnServer, 10.0f, TEXTALIGN_CENTER);
 						TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1);
 					}
 				}
@@ -444,7 +444,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 				if(g_Config.m_BrFilterString[0] && (pItem->m_QuickSearchHit & IServerBrowser::QUICK_PLAYER))
 					TextRender()->TextColor(0.4f, 0.4f, 1.0f, 1);
 				float FontSize = 12.0f;
-				UI()->DoLabelStreamed(*pItem->m_pUIElement->Rect(gs_OffsetColPlayers), &Button, aTemp, FontSize, TEXTALIGN_LEFT, -1, 1, false);
+				UI()->DoLabelStreamed(*pItem->m_pUIElement->Rect(gs_OffsetColPlayers), &Button, aTemp, FontSize, TEXTALIGN_RIGHT, -1, 1, false);
 				TextRender()->TextColor(1, 1, 1, 1);
 			}
 			else if(ID == COL_PING)

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -437,7 +437,6 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 						TextRender()->TextColor(0.94f, 0.4f, 0.4f, 1);
 						UI()->DoLabel(&IconText, aBufFriendsOnServer, 10.0f, TEXTALIGN_LEFT);
 						TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1);
-					
 					}
 				}
 

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -255,12 +255,14 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 			m_SelectedIndex = i;
 
 		// update friend counter
+		int FriendsOnServer = 0;
 		if(pItem->m_FriendState != IFriends::FRIEND_NO)
 		{
 			for(int j = 0; j < pItem->m_NumReceivedClients; ++j)
 			{
 				if(pItem->m_aClients[j].m_FriendState != IFriends::FRIEND_NO)
 				{
+					FriendsOnServer++;
 					unsigned NameHash = str_quickhash(pItem->m_aClients[j].m_aName);
 					unsigned ClanHash = str_quickhash(pItem->m_aClients[j].m_aClan);
 					for(auto &Friend : m_vFriends)
@@ -420,20 +422,30 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 			}
 			else if(ID == COL_PLAYERS)
 			{
-				CUIRect Icon;
-				Button.VMargin(4.0f, &Button);
+				CUIRect Icon, IconText;
+				Button.VMargin(2.0f, &Button);
 				if(pItem->m_FriendState != IFriends::FRIEND_NO)
 				{
-					Button.VSplitLeft(Button.h, &Icon, &Button);
+					Button.VSplitLeft(38.0f, &Button, &Icon);
 					Icon.Margin(2.0f, &Icon);
+					Icon.VSplitLeft(13.0f, &Icon, &IconText);
 					RenderBrowserIcons(*pItem->m_pUIElement->Rect(gs_OffsetColFav + 1), &Icon, {0.94f, 0.4f, 0.4f, 1}, TextRender()->DefaultTextOutlineColor(), "\xEF\x80\x84", TEXTALIGN_LEFT);
+					if(FriendsOnServer > 1)
+					{
+						char aBufFriendsOnServer[64];
+						str_format(aBufFriendsOnServer, sizeof(aBufFriendsOnServer), "%d", FriendsOnServer);
+						TextRender()->TextColor(0.94f, 0.4f, 0.4f, 1);
+						UI()->DoLabel(&IconText, aBufFriendsOnServer, 10.0f, TEXTALIGN_LEFT);
+						TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1);
+					
+					}
 				}
 
 				str_format(aTemp, sizeof(aTemp), "%i/%i", pItem->m_NumFilteredPlayers, ServerBrowser()->Max(*pItem));
 				if(g_Config.m_BrFilterString[0] && (pItem->m_QuickSearchHit & IServerBrowser::QUICK_PLAYER))
 					TextRender()->TextColor(0.4f, 0.4f, 1.0f, 1);
 				float FontSize = 12.0f;
-				UI()->DoLabelStreamed(*pItem->m_pUIElement->Rect(gs_OffsetColPlayers), &Button, aTemp, FontSize, TEXTALIGN_RIGHT, -1, 1, false);
+				UI()->DoLabelStreamed(*pItem->m_pUIElement->Rect(gs_OffsetColPlayers), &Button, aTemp, FontSize, TEXTALIGN_LEFT, -1, 1, false);
 				TextRender()->TextColor(1, 1, 1, 1);
 			}
 			else if(ID == COL_PING)


### PR DESCRIPTION
Added friend counter, changed the alignment of player count indicator to better accommodate friend counter + line up with the "Players" text at the top of the tab

![image](https://user-images.githubusercontent.com/69405348/202891241-b76899cf-e65a-4085-804b-0a6877468fbc.png)

Fixes #5911


## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
