### PR TITLE
Add `TYPE_ALL_OR_ABSOLUTE` and `TYPE_SAVE_OR_ABSOLUTE` storage types

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -3119,9 +3119,7 @@ void CClient::Run()
 		// handle pending demo play
 		if(m_aCmdPlayDemo[0])
 		{
-			const char *pError = DemoPlayer_Play(m_aCmdPlayDemo, IStorage::TYPE_ALL);
-			if(pError && !fs_is_relative_path(m_aCmdPlayDemo))
-				pError = DemoPlayer_Play(m_aCmdPlayDemo, IStorage::TYPE_ABSOLUTE);
+			const char *pError = DemoPlayer_Play(m_aCmdPlayDemo, IStorage::TYPE_ALL_OR_ABSOLUTE);
 			if(pError)
 				dbg_msg("demo_player", "playing passed demo file '%s' failed: %s", m_aCmdPlayDemo, pError);
 			m_aCmdPlayDemo[0] = 0;
@@ -3130,9 +3128,7 @@ void CClient::Run()
 		// handle pending map edits
 		if(m_aCmdEditMap[0])
 		{
-			int Result = m_pEditor->Load(m_aCmdEditMap, IStorage::TYPE_ALL);
-			if(!Result && !fs_is_relative_path(m_aCmdEditMap))
-				Result = m_pEditor->Load(m_aCmdEditMap, IStorage::TYPE_ABSOLUTE);
+			int Result = m_pEditor->Load(m_aCmdEditMap, IStorage::TYPE_ALL_OR_ABSOLUTE);
 			if(Result)
 				g_Config.m_ClEditor = true;
 			else
@@ -4679,7 +4675,7 @@ int main(int argc, const char **argv)
 	log_set_loglevel((LEVEL)g_Config.m_Loglevel);
 	if(g_Config.m_Logfile[0])
 	{
-		IOHANDLE Logfile = pStorage->OpenFile(g_Config.m_Logfile, IOFLAG_WRITE, fs_is_relative_path(g_Config.m_Logfile) ? IStorage::TYPE_SAVE : IStorage::TYPE_ABSOLUTE);
+		IOHANDLE Logfile = pStorage->OpenFile(g_Config.m_Logfile, IOFLAG_WRITE, IStorage::TYPE_SAVE_OR_ABSOLUTE);
 		if(Logfile)
 		{
 			pFutureFileLogger->Set(log_logger_file(Logfile));

--- a/src/engine/server/main.cpp
+++ b/src/engine/server/main.cpp
@@ -174,7 +174,7 @@ int main(int argc, const char **argv)
 	log_set_loglevel((LEVEL)g_Config.m_Loglevel);
 	if(g_Config.m_Logfile[0])
 	{
-		IOHANDLE Logfile = pStorage->OpenFile(g_Config.m_Logfile, IOFLAG_WRITE, fs_is_relative_path(g_Config.m_Logfile) ? IStorage::TYPE_SAVE : IStorage::TYPE_ABSOLUTE);
+		IOHANDLE Logfile = pStorage->OpenFile(g_Config.m_Logfile, IOFLAG_WRITE, IStorage::TYPE_SAVE_OR_ABSOLUTE);
 		if(Logfile)
 		{
 			pFutureFileLogger->Set(log_logger_file(Logfile));

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -2542,7 +2542,7 @@ int CServer::Run()
 	if(Config()->m_SvSqliteFile[0] != '\0')
 	{
 		char aFullPath[IO_MAX_PATH_LENGTH];
-		Storage()->GetCompletePath(fs_is_relative_path(Config()->m_SvSqliteFile) ? IStorage::TYPE_SAVE : IStorage::TYPE_ABSOLUTE, Config()->m_SvSqliteFile, aFullPath, sizeof(aFullPath));
+		Storage()->GetCompletePath(IStorage::TYPE_SAVE_OR_ABSOLUTE, Config()->m_SvSqliteFile, aFullPath, sizeof(aFullPath));
 		auto pSqliteConn = CreateSqliteConnection(aFullPath, true);
 
 		if(Config()->m_SvUseSQL)

--- a/src/engine/shared/demo.cpp
+++ b/src/engine/shared/demo.cpp
@@ -1143,7 +1143,7 @@ void CDemoEditor::Slice(const char *pDemo, const char *pDst, int StartTick, int 
 	m_SliceTo = EndTick;
 	m_Stop = false;
 
-	if(m_pDemoPlayer->Load(m_pStorage, m_pConsole, pDemo, fs_is_relative_path(pDemo) ? IStorage::TYPE_ALL : IStorage::TYPE_ABSOLUTE) == -1)
+	if(m_pDemoPlayer->Load(m_pStorage, m_pConsole, pDemo, IStorage::TYPE_ALL_OR_ABSOLUTE) == -1)
 		return;
 
 	const CMapInfo *pMapInfo = m_pDemoPlayer->GetMapInfo();

--- a/src/engine/shared/storage.cpp
+++ b/src/engine/shared/storage.cpp
@@ -365,8 +365,18 @@ public:
 		return pBuffer;
 	}
 
+	void TranslateType(int &Type, const char *pPath)
+	{
+		if(Type == TYPE_SAVE_OR_ABSOLUTE)
+			Type = fs_is_relative_path(pPath) ? TYPE_SAVE : TYPE_ABSOLUTE;
+		else if(Type == TYPE_ALL_OR_ABSOLUTE)
+			Type = fs_is_relative_path(pPath) ? TYPE_ALL : TYPE_ABSOLUTE;
+	}
+
 	IOHANDLE OpenFile(const char *pFilename, int Flags, int Type, char *pBuffer = 0, int BufferSize = 0) override
 	{
+		TranslateType(Type, pFilename);
+
 		char aBuffer[IO_MAX_PATH_LENGTH];
 		if(!pBuffer)
 		{
@@ -376,7 +386,7 @@ public:
 
 		if(Type == TYPE_ABSOLUTE)
 		{
-			return io_open(pFilename, Flags);
+			return io_open(GetPath(TYPE_ABSOLUTE, pFilename, pBuffer, BufferSize), Flags);
 		}
 		if(str_startswith(pFilename, "mapres/../skins/"))
 		{
@@ -396,7 +406,7 @@ public:
 		}
 		else
 		{
-			if(Type <= TYPE_ALL)
+			if(Type == TYPE_ALL)
 			{
 				// check all available directories
 				for(int i = TYPE_SAVE; i < m_NumPaths; ++i)
@@ -656,6 +666,7 @@ public:
 
 	void GetCompletePath(int Type, const char *pDir, char *pBuffer, unsigned BufferSize) override
 	{
+		TranslateType(Type, pDir);
 		dbg_assert(Type >= TYPE_SAVE && Type < m_NumPaths, "Type invalid");
 		GetPath(Type, pDir, pBuffer, BufferSize);
 	}

--- a/src/engine/storage.h
+++ b/src/engine/storage.h
@@ -22,6 +22,20 @@ public:
 		TYPE_SAVE = 0,
 		TYPE_ALL = -1,
 		TYPE_ABSOLUTE = -2,
+		/**
+		 * Translates to TYPE_SAVE if a path is relative
+		 * and to TYPE_ABSOLUTE if a path is absolute.
+		 * Only usable with OpenFile, ReadFile, ReadFileStr
+		 * and GetCompletePath.
+		 */
+		TYPE_SAVE_OR_ABSOLUTE = -3,
+		/**
+		 * Translates to TYPE_ALL if a path is relative
+		 * and to TYPE_ABSOLUTE if a path is absolute.
+		 * Only usable with OpenFile, ReadFile, ReadFileStr
+		 * and GetCompletePath.
+		 */
+		TYPE_ALL_OR_ABSOLUTE = -4,
 
 		STORAGETYPE_BASIC = 0,
 		STORAGETYPE_SERVER,


### PR DESCRIPTION
The types are translated to `TYPE_ALL`/`TYPE_SAVE` respectively if a given path is relative and to `TYPE_ABSOLUTE` if a path is absolute.

These types are only supported with the `OpenFile`, `ReadFile`, `ReadFileStr` and `GetCompletePath` methods.

This reduces duplicate code when calling the methods.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
