### PR TITLE
Add logs for moderators (fixes #5433)

### DIFF
--- a/src/game/ddracecommands.h
+++ b/src/game/ddracecommands.h
@@ -58,6 +58,7 @@ CONSOLE_COMMAND("mutes", "", CFGFLAG_SERVER, ConMutes, this, "")
 CONSOLE_COMMAND("moderate", "", CFGFLAG_SERVER, ConModerate, this, "Enables/disables active moderator mode for the player")
 CONSOLE_COMMAND("vote_no", "", CFGFLAG_SERVER, ConVoteNo, this, "Same as \"vote no\"")
 CONSOLE_COMMAND("save_dry", "", CFGFLAG_SERVER, ConDrySave, this, "Dump the current savestring")
+CONSOLE_COMMAND("dump_log", "?i[seconds]", CFGFLAG_SERVER, ConDumpLog, this, "Show logs of the last i seconds")
 
 CONSOLE_COMMAND("freezehammer", "v[id]", CFGFLAG_SERVER | CMDFLAG_TEST, ConFreezeHammer, this, "Gives a player Freeze Hammer")
 CONSOLE_COMMAND("unfreezehammer", "v[id]", CFGFLAG_SERVER | CMDFLAG_TEST, ConUnFreezeHammer, this, "Removes Freeze Hammer from a player")

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -117,6 +117,7 @@ class CGameContext : public IGameServer
 	static void ConDrySave(IConsole::IResult *pResult, void *pUserData);
 	static void ConDumpAntibot(IConsole::IResult *pResult, void *pUserData);
 	static void ConchainSpecialMotdupdate(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
+	static void ConDumpLog(IConsole::IResult *pResult, void *pUserData);
 
 	void Construct(int Resetting);
 	void Destruct(int Resetting);
@@ -448,6 +449,26 @@ private:
 	void Converse(int ClientID, char *pStr);
 	bool IsVersionBanned(int Version);
 	void UnlockTeam(int ClientID, int Team);
+
+	enum
+	{
+		MAX_LOG_SECONDS = 240,
+		MAX_LOGS = 256,
+	};
+	struct CLog
+	{
+		int64_t m_Timestamp;
+		bool m_FromServer;
+		char m_aDescription[128];
+		int m_ClientVersion;
+		char m_aClientName[MAX_NAME_LENGTH];
+		char m_aClientAddrStr[NETADDR_MAXSTRSIZE];
+	};
+	CLog m_aLogs[MAX_LOGS];
+	int m_FirstLog;
+	int m_LastLog;
+
+	void LogEvent(const char *Description, int ClientID);
 
 public:
 	CLayers *Layers() { return &m_Layers; }


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->
issue #5433 
Moderators can access the last x minutes of the chat activity.
Every entry beside server messages will show the player name, player ip and client who wrote the message / who disconnected so moderators can get the players ip after something happened in case he left already.

The current implementation has a 4 minute time slot, messages older than 4 minutes are not shown.
To limit the memory usage its limited atm to 256 log-entries. In case of more messages than 256 in 4 minutes (unlikely), the oldest messages are overwritten.

I keep this as a draft for a while, because its my first pr and I am sure there is some improvement i did not see (or to improve the wording)
<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
