### PR TITLE
Reset teams when restarting round

### DIFF
--- a/src/game/server/gamecontroller.h
+++ b/src/game/server/gamecontroller.h
@@ -108,7 +108,7 @@ public:
 	virtual void OnPlayerConnect(class CPlayer *pPlayer);
 	virtual void OnPlayerDisconnect(class CPlayer *pPlayer, const char *pReason);
 
-	void OnReset();
+	virtual void OnReset();
 
 	// game
 	void DoWarmup(int Seconds);

--- a/src/game/server/gamemodes/DDRace.cpp
+++ b/src/game/server/gamemodes/DDRace.cpp
@@ -159,6 +159,12 @@ void CGameControllerDDRace::OnPlayerDisconnect(CPlayer *pPlayer, const char *pRe
 		m_Teams.SetForceCharacterTeam(ClientID, TEAM_FLOCK);
 }
 
+void CGameControllerDDRace::OnReset()
+{
+	IGameController::OnReset();
+	m_Teams.Reset();
+}
+
 void CGameControllerDDRace::Tick()
 {
 	IGameController::Tick();

--- a/src/game/server/gamemodes/DDRace.h
+++ b/src/game/server/gamemodes/DDRace.h
@@ -23,6 +23,8 @@ public:
 	void OnPlayerConnect(class CPlayer *pPlayer) override;
 	void OnPlayerDisconnect(class CPlayer *pPlayer, const char *pReason) override;
 
+	void OnReset() override;
+
 	void Tick() override;
 
 	void DoTeamChange(class CPlayer *pPlayer, int Team, bool DoChatMsg = true) override;

--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -31,19 +31,16 @@ void CGameTeams::Reset()
 		m_aTeamState[i] = TEAMSTATE_EMPTY;
 		m_aTeamLocked[i] = false;
 		m_apSaveTeamResult[i] = nullptr;
-
-		m_aInvited[i] = 0;
-		m_aPractice[i] = false;
-		m_aLastSwap[i] = 0;
 		m_aTeamSentStartWarning[i] = false;
-		m_aTeamUnfinishableKillTick[i] = -1;
+		ResetRoundState(i);
 	}
 }
 
 void CGameTeams::ResetRoundState(int Team)
 {
 	ResetInvited(Team);
-	ResetSwitchers(Team);
+	if(Team != TEAM_SUPER)
+		ResetSwitchers(Team);
 	m_aLastSwap[Team] = 0;
 
 	m_aPractice[Team] = false;


### PR DESCRIPTION
The state of teams was not reset when restarting a round with `restart`, which led to various issues (#5144):

- Switchers kept their previous state instead of being reset to the initial state after restarting.
- Teams that started racing sometimes could not be joined after restarting.
- Sometimes teams cannot finish a race after restarting. I cannot reproduce this issue, so I don't know if it's fixed by these changes.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
