### PR TITLE
Fix incorrect cursor position after exiting pause/spec

### DIFF
--- a/src/game/client/components/camera.cpp
+++ b/src/game/client/components/camera.cpp
@@ -114,10 +114,7 @@ void CCamera::OnRender()
 	{
 		if(m_CamType != CAMTYPE_PLAYER)
 		{
-			if((m_aLastPos[g_Config.m_ClDummy].x < g_Config.m_ClMouseMinDistance) || (m_aLastPos[g_Config.m_ClDummy].x < g_Config.m_ClDyncamMinDistance))
-				m_pClient->m_Controls.m_aMousePos[g_Config.m_ClDummy].x = m_aLastPos[g_Config.m_ClDummy].x + g_Config.m_ClMouseMinDistance + g_Config.m_ClDyncamMinDistance;
-			else
-				m_pClient->m_Controls.m_aMousePos[g_Config.m_ClDummy] = m_aLastPos[g_Config.m_ClDummy];
+			m_pClient->m_Controls.m_aMousePos[g_Config.m_ClDummy] = m_aLastPos[g_Config.m_ClDummy];
 			m_pClient->m_Controls.ClampMousePos();
 			m_CamType = CAMTYPE_PLAYER;
 		}


### PR DESCRIPTION
The cursor position was not correctly restored when exiting pause or spec, when the mouse was on the left side of the tee (x being negative).

This is caused by a calculation introduced in #1637 and #1830 that tries to ensure that the mouse can still be moved if it ends up inside the minimum mouse distance (`cl_mouse_min_distance` and `cl_dyncam_min_distance`). However, this did not consider that the x position can become negative, so the x position was also incorrectly changed when exiting pause.

This is fixed by reverting the changes, as this code has become obsolete and has been superseded by #2009 and #3884. The `CControls::ClampMousePos` function, which is called directly after restoring the position, already ensures that mouse is not stuck within the minimum mouse distance.

Closes #2591.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [X] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
