### PR TITLE
Fix cmake args in workspace

### DIFF
--- a/other/vscode/ddnet-cmake-tools-kits.json
+++ b/other/vscode/ddnet-cmake-tools-kits.json
@@ -10,7 +10,7 @@
 		},
 		"cmakeSettings": {
 			"DEV": "ON",
-			"CMAKE_CXX_LINK_FLAGS": "-fuse-ld=mold"
+			"CMAKE_CXX_LINK_FLAGS_INIT": "-fuse-ld=mold"
 		}
 	},
 	{

--- a/other/vscode/ddnet.code-workspace
+++ b/other/vscode/ddnet.code-workspace
@@ -97,8 +97,8 @@
 						"long": "Disable optimizations",
 						"buildType": "Debug",
 						"settings": {
-							"CMAKE_CXX_FLAGS_DEBUG": "",
-							"CMAKE_C_FLAGS_DEBUG": "",
+							"CMAKE_CXX_FLAGS": "",
+							"CMAKE_C_FLAGS": "",
 						}
 					},
 					"release": {
@@ -106,8 +106,8 @@
 						"long": "Enable optimizations",
 						"buildType": "Release",
 						"settings": {
-							"CMAKE_CXX_FLAGS_RELEASE": "",
-							"CMAKE_C_FLAGS_RELEASE": "",
+							"CMAKE_CXX_FLAGS": "",
+							"CMAKE_C_FLAGS": "",
 						}
 					},
 					"minsize": {
@@ -115,8 +115,8 @@
 						"long": "Enable optimizations, optimized for size",
 						"buildType": "MinSizeRel",
 						"settings": {
-							"CMAKE_CXX_FLAGS_MINSIZEREL": "",
-							"CMAKE_C_FLAGS_MINSIZEREL": "",
+							"CMAKE_CXX_FLAGS": "",
+							"CMAKE_C_FLAGS": "",
 						}
 					},
 					"reldeb": {
@@ -124,8 +124,8 @@
 						"long": "Enable optimizations, provide debug symbols",
 						"buildType": "RelWithDebInfo",
 						"settings": {
-							"CMAKE_CXX_FLAGS_RELWITHDEBINFO": "",
-							"CMAKE_C_FLAGS_RELWITHDEBINFO": "",
+							"CMAKE_CXX_FLAGS": "",
+							"CMAKE_C_FLAGS": "",
 						}
 					},
 					"debAndASAN": {
@@ -133,8 +133,8 @@
 						"long": "Disable optimizations, enable ASAN & UBSAN",
 						"buildType": "Debug",
 						"settings": {
-							"CMAKE_CXX_FLAGS_DEBUG": "-fsanitize=address,undefined -fsanitize-recover=address,undefined -fno-omit-frame-pointer",
-							"CMAKE_C_FLAGS_DEBUG": "-fsanitize=address,undefined -fsanitize-recover=address,undefined -fno-omit-frame-pointer",
+							"CMAKE_CXX_FLAGS": "-fsanitize=address,undefined -fsanitize-recover=address,undefined -fno-omit-frame-pointer",
+							"CMAKE_C_FLAGS": "-fsanitize=address,undefined -fsanitize-recover=address,undefined -fno-omit-frame-pointer",
 						}
 					},
 					"relAndASAN": {
@@ -142,8 +142,8 @@
 						"long": "Enable optimizations, enable ASAN & UBSAN",
 						"buildType": "RelWithDebInfo",
 						"settings": {
-							"CMAKE_CXX_FLAGS_RELWITHDEBINFO": "-fsanitize=address,undefined -fsanitize-recover=address,undefined -fno-omit-frame-pointer",
-							"CMAKE_C_FLAGS_RELWITHDEBINFO": "-fsanitize=address,undefined -fsanitize-recover=address,undefined -fno-omit-frame-pointer",
+							"CMAKE_CXX_FLAGS": "-fsanitize=address,undefined -fsanitize-recover=address,undefined -fno-omit-frame-pointer",
+							"CMAKE_C_FLAGS": "-fsanitize=address,undefined -fsanitize-recover=address,undefined -fno-omit-frame-pointer",
 						}
 					},
 					"debAndTSAN": {
@@ -151,8 +151,8 @@
 						"long": "Disable optimizations, enable TSAN & UBSAN",
 						"buildType": "Debug",
 						"settings": {
-							"CMAKE_CXX_FLAGS_DEBUG": "-fsanitize=thread,undefined -fsanitize-recover=thread,undefined -fno-omit-frame-pointer",
-							"CMAKE_C_FLAGS_DEBUG": "-fsanitize=thread,undefined -fsanitize-recover=thread,undefined -fno-omit-frame-pointer",
+							"CMAKE_CXX_FLAGS": "-fsanitize=thread,undefined -fsanitize-recover=thread,undefined -fno-omit-frame-pointer",
+							"CMAKE_C_FLAGS": "-fsanitize=thread,undefined -fsanitize-recover=thread,undefined -fno-omit-frame-pointer",
 						}
 					},
 					"relAndTSAN": {
@@ -160,8 +160,8 @@
 						"long": "Enable optimizations, enable TSAN & UBSAN",
 						"buildType": "RelWithDebInfo",
 						"settings": {
-							"CMAKE_CXX_FLAGS_RELWITHDEBINFO": "-fsanitize=thread,undefined -fsanitize-recover=thread,undefined -fno-omit-frame-pointer",
-							"CMAKE_C_FLAGS_RELWITHDEBINFO": "-fsanitize=thread,undefined -fsanitize-recover=thread,undefined -fno-omit-frame-pointer",
+							"CMAKE_CXX_FLAGS": "-fsanitize=thread,undefined -fsanitize-recover=thread,undefined -fno-omit-frame-pointer",
+							"CMAKE_C_FLAGS": "-fsanitize=thread,undefined -fsanitize-recover=thread,undefined -fno-omit-frame-pointer",
 						}
 					}
 				}


### PR DESCRIPTION
current is completely wrong, since it overwrites the cmake internal settings. and e.g. prevent `-g`
Now it should in worst case only overwrite custom settings by the user. but dunno how often u actually do that anyway inside a IDE

but if someone knows better I'm glad to hear it

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
