### PR TITLE
FIX: parse & colorify gametype Gores correctly

### DIFF
--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -483,6 +483,8 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 						hsl = ColorHSLA(0.00f, 1.0f, 0.75f);
 					else if(str_find_nocase(pItem->m_aGameType, "fng"))
 						hsl = ColorHSLA(0.83f, 1.0f, 0.75f);
+					else if(str_find_nocase(pItem->m_aGameType, "gores"))
+						hsl = ColorHSLA(0.525f, 1.0f, 0.75f);
 					else if(str_find_nocase(pItem->m_aGameType, "ddracenet") || str_find_nocase(pItem->m_aGameType, "ddnet"))
 						hsl = ColorHSLA(0.58f, 1.0f, 0.75f);
 					else if(str_find_nocase(pItem->m_aGameType, "ddrace") || str_find_nocase(pItem->m_aGameType, "mkrace"))


### PR DESCRIPTION
@def- The correct PR now :) Correct coloring the gamemode "Gores"
![193410660-5e757fd4-449f-4d0a-a719-4a0cc1e5a01e](https://user-images.githubusercontent.com/105295486/205684472-36cc6daa-bda4-4af1-a838-b7fe25a55dec.png)

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
