### PR TITLE
Remove check for `pResponseToken`, which isn't used on this code path

### DIFF
--- a/src/engine/shared/network.cpp
+++ b/src/engine/shared/network.cpp
@@ -243,7 +243,7 @@ int CNetBase::UnpackPacket(unsigned char *pBuffer, int Size, CNetPacketConstruct
 	{
 		if(pPacket->m_Flags & NET_PACKETFLAG_UNUSED)
 			Sixup = true;
-		if(Sixup && (pSecurityToken == nullptr || pResponseToken == nullptr))
+		if(Sixup && pSecurityToken == nullptr)
 			return -1;
 		int DataStart = Sixup ? 7 : NET_PACKETHEADERSIZE;
 		if(Size < DataStart)


### PR DESCRIPTION
Closes #6100.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
