### PR TITLE
Colorify BW gamemode

### DIFF
--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -480,6 +480,8 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 						hsl = ColorHSLA(0.83f, 1.0f, 0.75f);
 					else if(str_find_nocase(pItem->m_aGameType, "gores"))
 						hsl = ColorHSLA(0.525f, 1.0f, 0.75f);
+					else if(str_find_nocase(pItem->m_aGameType, "BW"))
+						hsl = ColorHSLA(0.050f, 1.0f, 0.75f);
 					else if(str_find_nocase(pItem->m_aGameType, "ddracenet") || str_find_nocase(pItem->m_aGameType, "ddnet"))
 						hsl = ColorHSLA(0.58f, 1.0f, 0.75f);
 					else if(str_find_nocase(pItem->m_aGameType, "ddrace") || str_find_nocase(pItem->m_aGameType, "mkrace"))


### PR DESCRIPTION
Hi,

according to #6090, this isn't a big deal, is it? BW mode is pretty important and well known, so it would be cool to give it its own color!

**this has already been discussed by the BW team.**

![Capture](https://user-images.githubusercontent.com/75568768/206277087-da7efe83-21b4-4b6f-abf5-f685d9ac7f00.PNG)
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)



