### PR TITLE
Remove successful queries from write backup

### DIFF
--- a/src/engine/server/databases/connection_pool.cpp
+++ b/src/engine/server/databases/connection_pool.cpp
@@ -329,27 +329,23 @@ void CWorker::ProcessQueries()
 			if(m_pShared->m_Shutdown && m_pWriteBackup != nullptr)
 			{
 				dbg_msg("sql", "[%i] %s skipped to backup database during shutdown", JobNum, pThreadData->m_pName);
-				break;
 			}
 			else if(FailMode && m_pWriteBackup != nullptr)
 			{
 				dbg_msg("sql", "[%i] %s skipped to backup database during FailMode", JobNum, pThreadData->m_pName);
-				break;
 			}
 			else if(CDbConnectionPool::ExecSqlFunc(m_pWriteConnection.get(), pThreadData.get(), Write::NORMAL))
 			{
 				dbg_msg("sql", "[%i] %s done on write database", JobNum, pThreadData->m_pName);
 				Success = true;
-				break;
 			}
 			// enter fail mode if not successful
 			FailMode = FailMode || !Success;
 			const Write w = Success ? Write::NORMAL_SUCCEEDED : Write::NORMAL_FAILED;
-			if(CDbConnectionPool::ExecSqlFunc(m_pWriteBackup.get(), pThreadData.get(), w))
+			if(m_pWriteBackup && CDbConnectionPool::ExecSqlFunc(m_pWriteBackup.get(), pThreadData.get(), w))
 			{
 				dbg_msg("sql", "[%i] %s done move write on backup database to non-backup table", JobNum, pThreadData->m_pName);
 				Success = true;
-				break;
 			}
 		}
 		break;


### PR DESCRIPTION
Fixes #6106

Seems like I didn't tested before whether the rank got removed in the successful path.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
