### PR TITLE
Fix client attempting to delete user directory when stopping replay demo

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -894,7 +894,7 @@ void CClient::Disconnect()
 	// make sure to remove replay tmp demo
 	if(g_Config.m_ClReplays)
 	{
-		Storage()->RemoveFile(m_aDemoRecorder[RECORDER_REPLAYS].GetCurrentFilename(), IStorage::TYPE_SAVE);
+		DemoRecorder_Stop(RECORDER_REPLAYS, true);
 	}
 }
 


### PR DESCRIPTION
When the client stops a replay demo and tries to remove the temporary file when being disconnected, it's not checked whether a recording of a replay demo has ever been started. In this case the filename is empty, which leads to the client trying to delete the user's directory, which will fail with an error message, as it's a folder and cannot be deleted with the function designed for deleting files.

This is fixed by calling the function `DemoRecorder_Stop` to delete the temporary demo file, as this function already makes sure that the filename is not empty.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
