### PR TITLE
Replace cargo with rust for Arch in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Or on Fedora like this:
 
 Or on Arch Linux like this:
 
-    sudo pacman -S --needed base-devel cargo cmake curl ffmpeg freetype2 git glew glslang gmock libnotify libpng opusfile python rust sdl2 spirv-tools sqlite vulkan-headers vulkan-icd-loader wavpack x264
+    sudo pacman -S --needed base-devel rust cmake curl ffmpeg freetype2 git glew glslang gmock libnotify libpng opusfile python rust sdl2 spirv-tools sqlite vulkan-headers vulkan-icd-loader wavpack x264
 
 Or on Gentoo like this:
 


### PR DESCRIPTION
'rust' is the name of the package that provides cargo tool. Installing 'cargo' with work because rust is set with provides=cargo, but one might get confused for not finding a 'cargo' package installed in their system

<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
