### PR TITLE
Add separate `ed_limit_max_zoom_level` for editor, fix editor smooth zooming when joining/reloading game 

### DIFF
--- a/src/engine/client.h
+++ b/src/engine/client.h
@@ -84,6 +84,7 @@ protected:
 	float m_aPredIntraTick[NUM_DUMMIES];
 
 	float m_LocalTime;
+	float m_GlobalTime;
 	float m_RenderFrameTime;
 
 	int m_GameTickSpeed;
@@ -146,6 +147,7 @@ public:
 	// other time access
 	inline float RenderFrameTime() const { return m_RenderFrameTime; }
 	inline float LocalTime() const { return m_LocalTime; }
+	inline float GlobalTime() const { return m_GlobalTime; }
 	inline float FrameTimeAvg() const { return m_FrameTimeAvg; }
 
 	// actions

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -2964,7 +2964,7 @@ void CClient::InitInterfaces()
 
 void CClient::Run()
 {
-	m_LocalStartTime = time_get();
+	m_LocalStartTime = m_GlobalStartTime = time_get();
 #if defined(CONF_VIDEORECORDER)
 	IVideo::SetLocalStartTime(m_LocalStartTime);
 #endif
@@ -3383,8 +3383,9 @@ void CClient::Run()
 			g_Config.m_DbgHitch = 0;
 		}
 
-		// update local time
+		// update local and global time
 		m_LocalTime = (time_get() - m_LocalStartTime) / (float)time_freq();
+		m_GlobalTime = (time_get() - m_GlobalStartTime) / (float)time_freq();
 	}
 
 #if defined(CONF_FAMILY_UNIX)

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -143,6 +143,7 @@ class CClient : public IClient, public CDemoPlayer::IListener
 
 	uint64_t m_aSnapshotParts[NUM_DUMMIES];
 	int64_t m_LocalStartTime;
+	int64_t m_GlobalStartTime;
 
 	IGraphics::CTextureHandle m_DebugFont;
 	int m_DebugSoundIndex = 0;

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -6080,7 +6080,7 @@ void CEditor::SetZoom(float Target)
 {
 	Target = clamp(Target, MinZoomLevel(), MaxZoomLevel());
 
-	const float Now = Client()->LocalTime();
+	const float Now = Client()->GlobalTime();
 	float Current = m_Zoom;
 	float Derivative = 0.0f;
 	if(m_Zooming)
@@ -6128,7 +6128,7 @@ void CEditor::UpdateZoom()
 {
 	if(m_Zooming)
 	{
-		const float Time = Client()->LocalTime();
+		const float Time = Client()->GlobalTime();
 		const float OldLevel = m_Zoom;
 		if(Time >= m_ZoomSmoothingEnd)
 		{

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -6154,7 +6154,7 @@ float CEditor::MinZoomLevel() const
 
 float CEditor::MaxZoomLevel() const
 {
-	return g_Config.m_ClLimitMaxZoomLevel ? 2000.0f : std::numeric_limits<float>::max();
+	return g_Config.m_EdLimitMaxZoomLevel ? 2000.0f : std::numeric_limits<float>::max();
 }
 
 float CEditor::ZoomProgress(float CurrentTime) const

--- a/src/game/variables.h
+++ b/src/game/variables.h
@@ -91,6 +91,7 @@ MACRO_CONFIG_INT(ClDyncamSmoothness, cl_dyncam_smoothness, 0, 0, 100, CFGFLAG_CL
 MACRO_CONFIG_INT(ClDyncamStabilizing, cl_dyncam_stabilizing, 0, 0, 100, CFGFLAG_CLIENT | CFGFLAG_SAVE | CFGFLAG_INSENSITIVE, "Amount of camera slowdown during fast cursor movement. High value can cause delay in camera movement")
 
 MACRO_CONFIG_INT(EdSmoothZoomTime, ed_smooth_zoom_time, 250, 0, 5000, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Time of smooth zoom animation in the editor in ms (0 for off)")
+MACRO_CONFIG_INT(EdLimitMaxZoomLevel, ed_limit_max_zoom_level, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Specifies, if zooming in the editor should be limited or not (0 = no limit)")
 MACRO_CONFIG_INT(EdZoomTarget, ed_zoom_target, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Zoom to the current mouse target")
 MACRO_CONFIG_INT(EdShowkeys, ed_showkeys, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "")
 
@@ -114,7 +115,7 @@ MACRO_CONFIG_INT(ClAutoStatboardScreenshotMax, cl_auto_statboard_screenshot_max,
 
 MACRO_CONFIG_INT(ClDefaultZoom, cl_default_zoom, 10, 0, 20, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Default zoom level")
 MACRO_CONFIG_INT(ClSmoothZoomTime, cl_smooth_zoom_time, 250, 0, 5000, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Time of smooth zoom animation ingame in ms (0 for off)")
-MACRO_CONFIG_INT(ClLimitMaxZoomLevel, cl_limit_max_zoom_level, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Specifies, if zooming should be limited or not (0 = no limit)")
+MACRO_CONFIG_INT(ClLimitMaxZoomLevel, cl_limit_max_zoom_level, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Specifies, if zooming ingame should be limited or not (0 = no limit)")
 
 MACRO_CONFIG_INT(ClPlayerUseCustomColor, player_use_custom_color, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE | CFGFLAG_INSENSITIVE, "Toggles usage of custom colors")
 MACRO_CONFIG_COL(ClPlayerColorBody, player_color_body, 65408, CFGFLAG_CLIENT | CFGFLAG_SAVE | CFGFLAG_COLLIGHT | CFGFLAG_INSENSITIVE, "Player body color")


### PR DESCRIPTION


## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
