### PR TITLE
Recreate all entities when restarting round, fix server crash on maps with more than 64 spawn points of same type

### DIFF
--- a/src/game/server/entities/door.cpp
+++ b/src/game/server/entities/door.cpp
@@ -40,6 +40,11 @@ void CDoor::ResetCollision()
 	}
 }
 
+void CDoor::Reset()
+{
+	m_MarkedForDestroy = true;
+}
+
 void CDoor::Snap(int SnappingClient)
 {
 	if(NetworkClipped(SnappingClient, m_Pos) && NetworkClipped(SnappingClient, m_To))

--- a/src/game/server/entities/door.h
+++ b/src/game/server/entities/door.h
@@ -17,6 +17,7 @@ public:
 	CDoor(CGameWorld *pGameWorld, vec2 Pos, float Rotation, int Length,
 		int Number);
 
+	void Reset() override;
 	void Snap(int SnappingClient) override;
 };
 

--- a/src/game/server/entities/pickup.cpp
+++ b/src/game/server/entities/pickup.cpp
@@ -21,13 +21,12 @@ CPickup::CPickup(CGameWorld *pGameWorld, int Type, int SubType, int Layer, int N
 	m_Layer = Layer;
 	m_Number = Number;
 
-	Reset();
-
 	GameWorld()->InsertEntity(this);
 }
 
 void CPickup::Reset()
 {
+	m_MarkedForDestroy = true;
 }
 
 void CPickup::Tick()

--- a/src/game/server/entities/projectile.cpp
+++ b/src/game/server/entities/projectile.cpp
@@ -51,8 +51,7 @@ CProjectile::CProjectile(
 
 void CProjectile::Reset()
 {
-	if(m_LifeSpan > -2)
-		m_MarkedForDestroy = true;
+	m_MarkedForDestroy = true;
 }
 
 vec2 CProjectile::GetPos(float Time)

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -3494,8 +3494,7 @@ void CGameContext::CreateAllEntities(bool Initial)
 
 			if(Index >= ENTITY_OFFSET)
 			{
-				vec2 Pos(x * 32.0f + 16.0f, y * 32.0f + 16.0f);
-				m_pController->OnEntity(Index - ENTITY_OFFSET, Pos, LAYER_GAME, pTiles[y * pTileMap->m_Width + x].m_Flags, Initial);
+				m_pController->OnEntity(Index - ENTITY_OFFSET, x, y, LAYER_GAME, pTiles[y * pTileMap->m_Width + x].m_Flags, Initial);
 			}
 
 			if(pFront)
@@ -3528,8 +3527,7 @@ void CGameContext::CreateAllEntities(bool Initial)
 				}
 				if(Index >= ENTITY_OFFSET)
 				{
-					vec2 Pos(x * 32.0f + 16.0f, y * 32.0f + 16.0f);
-					m_pController->OnEntity(Index - ENTITY_OFFSET, Pos, LAYER_FRONT, pFront[y * pTileMap->m_Width + x].m_Flags, Initial);
+					m_pController->OnEntity(Index - ENTITY_OFFSET, x, y, LAYER_FRONT, pFront[y * pTileMap->m_Width + x].m_Flags, Initial);
 				}
 			}
 			if(pSwitch)
@@ -3539,8 +3537,7 @@ void CGameContext::CreateAllEntities(bool Initial)
 				// if (Index == TILE_DOOR_OFF)
 				if(Index >= ENTITY_OFFSET)
 				{
-					vec2 Pos(x * 32.0f + 16.0f, y * 32.0f + 16.0f);
-					m_pController->OnEntity(Index - ENTITY_OFFSET, Pos, LAYER_SWITCH, pSwitch[y * pTileMap->m_Width + x].m_Flags, Initial, pSwitch[y * pTileMap->m_Width + x].m_Number);
+					m_pController->OnEntity(Index - ENTITY_OFFSET, x, y, LAYER_SWITCH, pSwitch[y * pTileMap->m_Width + x].m_Flags, Initial, pSwitch[y * pTileMap->m_Width + x].m_Number);
 				}
 			}
 		}

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -3919,16 +3919,14 @@ bool CheckClientID2(int ClientID)
 
 void CGameContext::Whisper(int ClientID, char *pStr)
 {
-	char *pName;
-	char *pMessage;
-	int Error = 0;
-
 	if(ProcessSpamProtection(ClientID))
 		return;
 
 	pStr = str_skip_whitespaces(pStr);
 
+	char *pName;
 	int Victim;
+	int Error = 0;
 
 	// add token
 	if(*pStr == '"')
@@ -4007,8 +4005,7 @@ void CGameContext::Whisper(int ClientID, char *pStr)
 	*pStr = 0;
 	pStr++;
 
-	pMessage = pStr;
-
+	char *pMessage = pStr;
 	char aBuf[256];
 
 	if(Error)

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -3465,80 +3465,84 @@ void CGameContext::CreateAllEntities(bool Initial)
 	{
 		for(int x = 0; x < pTileMap->m_Width; x++)
 		{
-			int Index = pTiles[y * pTileMap->m_Width + x].m_Index;
+			const int Index = y * pTileMap->m_Width + x;
 
-			if(Index == TILE_OLDLASER)
+			// Game layer
 			{
-				g_Config.m_SvOldLaser = 1;
-				dbg_msg("game_layer", "found old laser tile");
-			}
-			else if(Index == TILE_NPC)
-			{
-				m_Tuning.Set("player_collision", 0);
-				dbg_msg("game_layer", "found no collision tile");
-			}
-			else if(Index == TILE_EHOOK)
-			{
-				g_Config.m_SvEndlessDrag = 1;
-				dbg_msg("game_layer", "found unlimited hook time tile");
-			}
-			else if(Index == TILE_NOHIT)
-			{
-				g_Config.m_SvHit = 0;
-				dbg_msg("game_layer", "found no weapons hitting others tile");
-			}
-			else if(Index == TILE_NPH)
-			{
-				m_Tuning.Set("player_hooking", 0);
-				dbg_msg("game_layer", "found no player hooking tile");
-			}
-
-			if(Index >= ENTITY_OFFSET)
-			{
-				m_pController->OnEntity(Index - ENTITY_OFFSET, x, y, LAYER_GAME, pTiles[y * pTileMap->m_Width + x].m_Flags, Initial);
+				const int GameIndex = pTiles[Index].m_Index;
+				if(GameIndex == TILE_OLDLASER)
+				{
+					g_Config.m_SvOldLaser = 1;
+					dbg_msg("game_layer", "found old laser tile");
+				}
+				else if(GameIndex == TILE_NPC)
+				{
+					m_Tuning.Set("player_collision", 0);
+					dbg_msg("game_layer", "found no collision tile");
+				}
+				else if(GameIndex == TILE_EHOOK)
+				{
+					g_Config.m_SvEndlessDrag = 1;
+					dbg_msg("game_layer", "found unlimited hook time tile");
+				}
+				else if(GameIndex == TILE_NOHIT)
+				{
+					g_Config.m_SvHit = 0;
+					dbg_msg("game_layer", "found no weapons hitting others tile");
+				}
+				else if(GameIndex == TILE_NPH)
+				{
+					m_Tuning.Set("player_hooking", 0);
+					dbg_msg("game_layer", "found no player hooking tile");
+				}
+				else if(GameIndex >= ENTITY_OFFSET)
+				{
+					m_pController->OnEntity(GameIndex - ENTITY_OFFSET, x, y, LAYER_GAME, pTiles[Index].m_Flags, Initial);
+				}
 			}
 
 			if(pFront)
 			{
-				Index = pFront[y * pTileMap->m_Width + x].m_Index;
-				if(Index == TILE_OLDLASER)
+				const int FrontIndex = pFront[Index].m_Index;
+				if(FrontIndex == TILE_OLDLASER)
 				{
 					g_Config.m_SvOldLaser = 1;
 					dbg_msg("front_layer", "found old laser tile");
 				}
-				else if(Index == TILE_NPC)
+				else if(FrontIndex == TILE_NPC)
 				{
 					m_Tuning.Set("player_collision", 0);
 					dbg_msg("front_layer", "found no collision tile");
 				}
-				else if(Index == TILE_EHOOK)
+				else if(FrontIndex == TILE_EHOOK)
 				{
 					g_Config.m_SvEndlessDrag = 1;
 					dbg_msg("front_layer", "found unlimited hook time tile");
 				}
-				else if(Index == TILE_NOHIT)
+				else if(FrontIndex == TILE_NOHIT)
 				{
 					g_Config.m_SvHit = 0;
 					dbg_msg("front_layer", "found no weapons hitting others tile");
 				}
-				else if(Index == TILE_NPH)
+				else if(FrontIndex == TILE_NPH)
 				{
 					m_Tuning.Set("player_hooking", 0);
 					dbg_msg("front_layer", "found no player hooking tile");
 				}
-				if(Index >= ENTITY_OFFSET)
+				else if(FrontIndex >= ENTITY_OFFSET)
 				{
-					m_pController->OnEntity(Index - ENTITY_OFFSET, x, y, LAYER_FRONT, pFront[y * pTileMap->m_Width + x].m_Flags, Initial);
+					m_pController->OnEntity(FrontIndex - ENTITY_OFFSET, x, y, LAYER_FRONT, pFront[Index].m_Flags, Initial);
 				}
 			}
+
 			if(pSwitch)
 			{
-				Index = pSwitch[y * pTileMap->m_Width + x].m_Type;
+				const int SwitchType = pSwitch[Index].m_Type;
 				// TODO: Add off by default door here
-				// if (Index == TILE_DOOR_OFF)
-				if(Index >= ENTITY_OFFSET)
+				// if(SwitchType == TILE_DOOR_OFF)
+				if(SwitchType >= ENTITY_OFFSET)
 				{
-					m_pController->OnEntity(Index - ENTITY_OFFSET, x, y, LAYER_SWITCH, pSwitch[y * pTileMap->m_Width + x].m_Flags, Initial, pSwitch[y * pTileMap->m_Width + x].m_Number);
+					m_pController->OnEntity(SwitchType - ENTITY_OFFSET, x, y, LAYER_SWITCH, pSwitch[Index].m_Flags, Initial, pSwitch[Index].m_Number);
 				}
 			}
 		}

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -1547,7 +1547,6 @@ void CGameContext::OnClientDrop(int ClientID, const char *pReason)
 	delete m_apPlayers[ClientID];
 	m_apPlayers[ClientID] = 0;
 
-	//(void)m_pController->CheckTeamBalance();
 	m_VoteUpdate = true;
 
 	// update spectator modes
@@ -2046,7 +2045,6 @@ void CGameContext::OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID)
 					m_apPlayers[ClientID]->m_Last_KickVote = time_get();
 					return;
 				}
-				//else if(!g_Config.m_SvVoteKick)
 				else if(!g_Config.m_SvVoteKick && !Authed) // allow admins to call kick votes even if they are forbidden
 				{
 					SendChatTarget(ClientID, "Server does not allow voting to kick players");
@@ -3242,7 +3240,7 @@ void CGameContext::OnConsoleInit()
 #include <game/ddracechat.h>
 }
 
-void CGameContext::OnInit(/*class IKernel *pKernel*/)
+void CGameContext::OnInit()
 {
 	m_pServer = Kernel()->RequestInterface<IServer>();
 	m_pConfig = Kernel()->RequestInterface<IConfigManager>()->Values();
@@ -3264,9 +3262,6 @@ void CGameContext::OnInit(/*class IKernel *pKernel*/)
 
 	DeleteTempfile();
 
-	//if(!data) // only load once
-	//data = load_data_from_memory(internal_data);
-
 	for(int i = 0; i < NUM_NETOBJTYPES; i++)
 		Server()->SnapSetStaticsize(i, m_NetObjHandler.GetObjSize(i));
 
@@ -3280,10 +3275,6 @@ void CGameContext::OnInit(/*class IKernel *pKernel*/)
 	int MapCrc;
 	Server()->GetMapInfo(aMapName, sizeof(aMapName), &MapSize, &MapSha256, &MapCrc);
 	m_MapBugs = GetMapBugs(aMapName, MapSize, MapSha256);
-
-	// reset everything here
-	//world = new GAMEWORLD;
-	//players = new CPlayer[MAX_CLIENTS];
 
 	// Reset Tunezones
 	CTuningParams TuningParams;
@@ -3440,10 +3431,6 @@ void CGameContext::OnInit(/*class IKernel *pKernel*/)
 		m_pScore = new CScore(this, ((CServer *)Server())->DbPool());
 	}
 
-	// setup core world
-	//for(int i = 0; i < MAX_CLIENTS; i++)
-	//	game.players[i].core.world = &game.world.core;
-
 	// create all entities from the game layer
 	CMapItemLayerTilemap *pTileMap = m_Layers.GameLayer();
 	CTile *pTiles = (CTile *)Kernel()->RequestInterface<IMap>()->GetData(pTileMap->m_Data);
@@ -3540,8 +3527,6 @@ void CGameContext::OnInit(/*class IKernel *pKernel*/)
 			}
 		}
 	}
-
-	//game.world.insert_entity(game.Controller);
 
 	if(GIT_SHORTREV_HASH)
 		Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "git-revision", GIT_SHORTREV_HASH);

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -3849,16 +3849,16 @@ void CGameContext::SendRecord(int ClientID)
 	}
 }
 
-int CGameContext::ProcessSpamProtection(int ClientID, bool RespectChatInitialDelay)
+bool CGameContext::ProcessSpamProtection(int ClientID, bool RespectChatInitialDelay)
 {
 	if(!m_apPlayers[ClientID])
-		return 0;
+		return false;
 	if(g_Config.m_SvSpamprotection && m_apPlayers[ClientID]->m_LastChat && m_apPlayers[ClientID]->m_LastChat + Server()->TickSpeed() * g_Config.m_SvChatDelay > Server()->Tick())
-		return 1;
+		return true;
 	else if(g_Config.m_SvDnsblChat && Server()->DnsblBlack(ClientID))
 	{
 		SendChatTarget(ClientID, "Players are not allowed to chat from VPNs at this time");
-		return 1;
+		return true;
 	}
 	else
 		m_apPlayers[ClientID]->m_LastChat = Server()->Tick();
@@ -3881,17 +3881,17 @@ int CGameContext::ProcessSpamProtection(int ClientID, bool RespectChatInitialDel
 		char aBuf[128];
 		str_format(aBuf, sizeof aBuf, "You are not permitted to talk for the next %d seconds.", Muted);
 		SendChatTarget(ClientID, aBuf);
-		return 1;
+		return true;
 	}
 
 	if(g_Config.m_SvSpamMuteDuration && (m_apPlayers[ClientID]->m_ChatScore += g_Config.m_SvChatPenalty) > g_Config.m_SvChatThreshold)
 	{
 		Mute(&Addr, g_Config.m_SvSpamMuteDuration, Server()->ClientName(ClientID));
 		m_apPlayers[ClientID]->m_ChatScore = 0;
-		return 1;
+		return true;
 	}
 
-	return 0;
+	return false;
 }
 
 int CGameContext::GetDDRaceTeam(int ClientID)
@@ -3926,7 +3926,7 @@ void CGameContext::Whisper(int ClientID, char *pStr)
 
 	char *pName;
 	int Victim;
-	int Error = 0;
+	bool Error = false;
 
 	// add token
 	if(*pStr == '"')
@@ -3950,7 +3950,7 @@ void CGameContext::Whisper(int ClientID, char *pStr)
 			}
 			else if(pStr[0] == 0)
 			{
-				Error = 1;
+				Error = true;
 				break;
 			}
 
@@ -3978,7 +3978,7 @@ void CGameContext::Whisper(int ClientID, char *pStr)
 		{
 			if(pStr[0] == 0)
 			{
-				Error = 1;
+				Error = true;
 				break;
 			}
 			if(pStr[0] == ' ')
@@ -3999,7 +3999,7 @@ void CGameContext::Whisper(int ClientID, char *pStr)
 
 	if(pStr[0] != ' ')
 	{
-		Error = 1;
+		Error = true;
 	}
 
 	*pStr = 0;

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -3450,15 +3450,16 @@ void CGameContext::OnInit()
 
 void CGameContext::CreateAllEntities(bool Initial)
 {
-	CMapItemLayerTilemap *pTileMap = m_Layers.GameLayer();
-	CTile *pTiles = (CTile *)Kernel()->RequestInterface<IMap>()->GetData(pTileMap->m_Data);
+	const CMapItemLayerTilemap *pTileMap = m_Layers.GameLayer();
+	const CTile *pTiles = static_cast<CTile *>(Kernel()->RequestInterface<IMap>()->GetData(pTileMap->m_Data));
 
-	CTile *pFront = nullptr;
-	CSwitchTile *pSwitch = nullptr;
+	const CTile *pFront = nullptr;
 	if(m_Layers.FrontLayer())
-		pFront = (CTile *)Kernel()->RequestInterface<IMap>()->GetData(m_Layers.FrontLayer()->m_Front);
+		pFront = static_cast<CTile *>(Kernel()->RequestInterface<IMap>()->GetData(m_Layers.FrontLayer()->m_Front));
+
+	const CSwitchTile *pSwitch = nullptr;
 	if(m_Layers.SwitchLayer())
-		pSwitch = (CSwitchTile *)Kernel()->RequestInterface<IMap>()->GetData(m_Layers.SwitchLayer()->m_Switch);
+		pSwitch = static_cast<CSwitchTile *>(Kernel()->RequestInterface<IMap>()->GetData(m_Layers.SwitchLayer()->m_Switch));
 
 	for(int y = 0; y < pTileMap->m_Height; y++)
 	{

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -3432,11 +3432,29 @@ void CGameContext::OnInit()
 	}
 
 	// create all entities from the game layer
+	CreateAllEntities(true);
+
+	if(GIT_SHORTREV_HASH)
+		Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "git-revision", GIT_SHORTREV_HASH);
+
+#ifdef CONF_DEBUG
+	if(g_Config.m_DbgDummies)
+	{
+		for(int i = 0; i < g_Config.m_DbgDummies; i++)
+		{
+			OnClientConnected(MAX_CLIENTS - i - 1, 0);
+		}
+	}
+#endif
+}
+
+void CGameContext::CreateAllEntities(bool Initial)
+{
 	CMapItemLayerTilemap *pTileMap = m_Layers.GameLayer();
 	CTile *pTiles = (CTile *)Kernel()->RequestInterface<IMap>()->GetData(pTileMap->m_Data);
 
-	CTile *pFront = 0;
-	CSwitchTile *pSwitch = 0;
+	CTile *pFront = nullptr;
+	CSwitchTile *pSwitch = nullptr;
 	if(m_Layers.FrontLayer())
 		pFront = (CTile *)Kernel()->RequestInterface<IMap>()->GetData(m_Layers.FrontLayer()->m_Front);
 	if(m_Layers.SwitchLayer())
@@ -3477,7 +3495,7 @@ void CGameContext::OnInit()
 			if(Index >= ENTITY_OFFSET)
 			{
 				vec2 Pos(x * 32.0f + 16.0f, y * 32.0f + 16.0f);
-				m_pController->OnEntity(Index - ENTITY_OFFSET, Pos, LAYER_GAME, pTiles[y * pTileMap->m_Width + x].m_Flags);
+				m_pController->OnEntity(Index - ENTITY_OFFSET, Pos, LAYER_GAME, pTiles[y * pTileMap->m_Width + x].m_Flags, Initial);
 			}
 
 			if(pFront)
@@ -3511,7 +3529,7 @@ void CGameContext::OnInit()
 				if(Index >= ENTITY_OFFSET)
 				{
 					vec2 Pos(x * 32.0f + 16.0f, y * 32.0f + 16.0f);
-					m_pController->OnEntity(Index - ENTITY_OFFSET, Pos, LAYER_FRONT, pFront[y * pTileMap->m_Width + x].m_Flags);
+					m_pController->OnEntity(Index - ENTITY_OFFSET, Pos, LAYER_FRONT, pFront[y * pTileMap->m_Width + x].m_Flags, Initial);
 				}
 			}
 			if(pSwitch)
@@ -3522,24 +3540,11 @@ void CGameContext::OnInit()
 				if(Index >= ENTITY_OFFSET)
 				{
 					vec2 Pos(x * 32.0f + 16.0f, y * 32.0f + 16.0f);
-					m_pController->OnEntity(Index - ENTITY_OFFSET, Pos, LAYER_SWITCH, pSwitch[y * pTileMap->m_Width + x].m_Flags, pSwitch[y * pTileMap->m_Width + x].m_Number);
+					m_pController->OnEntity(Index - ENTITY_OFFSET, Pos, LAYER_SWITCH, pSwitch[y * pTileMap->m_Width + x].m_Flags, Initial, pSwitch[y * pTileMap->m_Width + x].m_Number);
 				}
 			}
 		}
 	}
-
-	if(GIT_SHORTREV_HASH)
-		Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "git-revision", GIT_SHORTREV_HASH);
-
-#ifdef CONF_DEBUG
-	if(g_Config.m_DbgDummies)
-	{
-		for(int i = 0; i < g_Config.m_DbgDummies; i++)
-		{
-			OnClientConnected(MAX_CLIENTS - i - 1, 0);
-		}
-	}
-#endif
 }
 
 void CGameContext::DeleteTempfile()

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -187,6 +187,8 @@ public:
 	char m_aaZoneEnterMsg[NUM_TUNEZONES][256]; // 0 is used for switching from or to area without tunings
 	char m_aaZoneLeaveMsg[NUM_TUNEZONES][256];
 
+	void CreateAllEntities(bool Initial);
+
 	char m_aDeleteTempfile[128];
 	void DeleteTempfile();
 

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -287,7 +287,7 @@ public:
 	void OnPreTickTeehistorian() override;
 	bool OnClientDDNetVersionKnown(int ClientID);
 	void FillAntibot(CAntibotRoundData *pData) override;
-	int ProcessSpamProtection(int ClientID, bool RespectChatInitialDelay = true);
+	bool ProcessSpamProtection(int ClientID, bool RespectChatInitialDelay = true);
 	int GetDDRaceTeam(int ClientID);
 	// Describes the time when the first player joined the server.
 	int64_t m_NonEmptySince;

--- a/src/game/server/gamecontroller.cpp
+++ b/src/game/server/gamecontroller.cpp
@@ -165,12 +165,11 @@ void IGameController::EvaluateSpawnType(CSpawnEval *pEval, int Type, int DDTeam)
 
 bool IGameController::CanSpawn(int Team, vec2 *pOutPos, int DDTeam)
 {
-	CSpawnEval Eval;
-
 	// spectators can't spawn
 	if(Team == TEAM_SPECTATORS)
 		return false;
 
+	CSpawnEval Eval;
 	EvaluateSpawnType(&Eval, 0, DDTeam);
 	EvaluateSpawnType(&Eval, 1, DDTeam);
 	EvaluateSpawnType(&Eval, 2, DDTeam);
@@ -184,9 +183,8 @@ bool IGameController::OnEntity(int Index, vec2 Pos, int Layer, int Flags, int Nu
 	if(Index < 0)
 		return false;
 
-	int x, y;
-	x = (Pos.x - 16.0f) / 32.0f;
-	y = (Pos.y - 16.0f) / 32.0f;
+	int x = (Pos.x - 16.0f) / 32.0f;
+	int y = (Pos.y - 16.0f) / 32.0f;
 	int aSides[8];
 	aSides[0] = GameServer()->Collision()->Entity(x, y + 1, Layer);
 	aSides[1] = GameServer()->Collision()->Entity(x + 1, y + 1, Layer);
@@ -203,7 +201,6 @@ bool IGameController::OnEntity(int Index, vec2 Pos, int Layer, int Flags, int Nu
 		m_aaSpawnPoints[Type][m_aNumSpawnPoints[Type]] = Pos;
 		m_aNumSpawnPoints[Type] = minimum(m_aNumSpawnPoints[Type] + 1, (int)std::size(m_aaSpawnPoints[0]));
 	}
-
 	else if(Index == ENTITY_DOOR)
 	{
 		for(int i = 0; i < 8; i++)
@@ -322,7 +319,6 @@ bool IGameController::OnEntity(int Index, vec2 Pos, int Layer, int Flags, int Nu
 		aSides2[6] = GameServer()->Collision()->Entity(x - 2, y, Layer);
 		aSides2[7] = GameServer()->Collision()->Entity(x - 2, y + 2, Layer);
 
-		float AngularSpeed = 0.0f;
 		int Ind = Index - ENTITY_LASER_STOP;
 		int M;
 		if(Ind < 0)
@@ -335,6 +331,7 @@ bool IGameController::OnEntity(int Index, vec2 Pos, int Layer, int Flags, int Nu
 		else
 			M = -1;
 
+		float AngularSpeed = 0.0f;
 		if(Ind == 0)
 			AngularSpeed = 0.0f;
 		else if(Ind == 1)

--- a/src/game/server/gamecontroller.cpp
+++ b/src/game/server/gamecontroller.cpp
@@ -173,7 +173,7 @@ bool IGameController::CanSpawn(int Team, vec2 *pOutPos, int DDTeam)
 	return Eval.m_Got;
 }
 
-bool IGameController::OnEntity(int Index, vec2 Pos, int Layer, int Flags, int Number)
+bool IGameController::OnEntity(int Index, vec2 Pos, int Layer, int Flags, bool Initial, int Number)
 {
 	if(Index < 0)
 		return false;
@@ -190,7 +190,7 @@ bool IGameController::OnEntity(int Index, vec2 Pos, int Layer, int Flags, int Nu
 	aSides[6] = GameServer()->Collision()->Entity(x - 1, y, Layer);
 	aSides[7] = GameServer()->Collision()->Entity(x - 1, y + 1, Layer);
 
-	if(Index >= ENTITY_SPAWN && Index <= ENTITY_SPAWN_BLUE)
+	if(Index >= ENTITY_SPAWN && Index <= ENTITY_SPAWN_BLUE && Initial)
 	{
 		const int Type = Index - ENTITY_SPAWN;
 		m_avSpawnPoints[Type].push_back(Pos);

--- a/src/game/server/gamecontroller.cpp
+++ b/src/game/server/gamecontroller.cpp
@@ -173,13 +173,12 @@ bool IGameController::CanSpawn(int Team, vec2 *pOutPos, int DDTeam)
 	return Eval.m_Got;
 }
 
-bool IGameController::OnEntity(int Index, vec2 Pos, int Layer, int Flags, bool Initial, int Number)
+bool IGameController::OnEntity(int Index, int x, int y, int Layer, int Flags, bool Initial, int Number)
 {
 	dbg_assert(Index >= 0, "Invalid entity index");
 
+	const vec2 Pos(x * 32.0f + 16.0f, y * 32.0f + 16.0f);
 
-	int x = (Pos.x - 16.0f) / 32.0f;
-	int y = (Pos.y - 16.0f) / 32.0f;
 	int aSides[8];
 	aSides[0] = GameServer()->Collision()->Entity(x, y + 1, Layer);
 	aSides[1] = GameServer()->Collision()->Entity(x + 1, y + 1, Layer);

--- a/src/game/server/gamecontroller.cpp
+++ b/src/game/server/gamecontroller.cpp
@@ -454,8 +454,6 @@ const char *IGameController::GetTeamName(int Team)
 	return "spectators";
 }
 
-//static bool IsSeparator(char c) { return c == ';' || c == ' ' || c == ',' || c == '\t'; }
-
 void IGameController::StartRound()
 {
 	ResetGame();

--- a/src/game/server/gamecontroller.cpp
+++ b/src/game/server/gamecontroller.cpp
@@ -175,8 +175,8 @@ bool IGameController::CanSpawn(int Team, vec2 *pOutPos, int DDTeam)
 
 bool IGameController::OnEntity(int Index, vec2 Pos, int Layer, int Flags, bool Initial, int Number)
 {
-	if(Index < 0)
-		return false;
+	dbg_assert(Index >= 0, "Invalid entity index");
+
 
 	int x = (Pos.x - 16.0f) / 32.0f;
 	int y = (Pos.y - 16.0f) / 32.0f;

--- a/src/game/server/gamecontroller.h
+++ b/src/game/server/gamecontroller.h
@@ -6,6 +6,8 @@
 #include <base/vmath.h>
 #include <engine/map.h>
 
+#include <vector>
+
 /*
 	Class: Game Controller
 		Controls the main game logic. Keeping track of team and player score,
@@ -15,8 +17,7 @@ class IGameController
 {
 	friend class CSaveTeam; // need access to GameServer() and Server()
 
-	vec2 m_aaSpawnPoints[3][64];
-	int m_aNumSpawnPoints[3];
+	std::vector<vec2> m_avSpawnPoints[3];
 
 	class CGameContext *m_pGameServer;
 	class CConfig *m_pConfig;

--- a/src/game/server/gamecontroller.h
+++ b/src/game/server/gamecontroller.h
@@ -104,7 +104,7 @@ public:
 		Returns:
 			bool?
 	*/
-	virtual bool OnEntity(int Index, vec2 Pos, int Layer, int Flags, bool Initial, int Number = 0);
+	virtual bool OnEntity(int Index, int x, int y, int Layer, int Flags, bool Initial, int Number = 0);
 
 	virtual void OnPlayerConnect(class CPlayer *pPlayer);
 	virtual void OnPlayerDisconnect(class CPlayer *pPlayer, const char *pReason);

--- a/src/game/server/gamecontroller.h
+++ b/src/game/server/gamecontroller.h
@@ -104,7 +104,7 @@ public:
 		Returns:
 			bool?
 	*/
-	virtual bool OnEntity(int Index, vec2 Pos, int Layer, int Flags, int Number = 0);
+	virtual bool OnEntity(int Index, vec2 Pos, int Layer, int Flags, bool Initial, int Number = 0);
 
 	virtual void OnPlayerConnect(class CPlayer *pPlayer);
 	virtual void OnPlayerDisconnect(class CPlayer *pPlayer, const char *pReason);

--- a/src/game/server/gameworld.cpp
+++ b/src/game/server/gameworld.cpp
@@ -146,6 +146,8 @@ void CGameWorld::Reset()
 	RemoveEntities();
 
 	m_ResetRequested = false;
+
+	GameServer()->CreateAllEntities(false);
 }
 
 void CGameWorld::RemoveEntities()


### PR DESCRIPTION


## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
