### PR TITLE
Persist AFK state of players on map change, fix players always being considered AFK with `sv_max_afk_time 0 `

### DIFF
--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -1028,7 +1028,7 @@ void CCharacter::SnapCharacter(int SnappingClient, int ID)
 			AmmoCount = (!m_FreezeTime) ? m_Core.m_aWeapons[m_Core.m_ActiveWeapon].m_Ammo : 0;
 	}
 
-	if(GetPlayer()->m_Afk || GetPlayer()->IsPaused())
+	if(GetPlayer()->IsAfk() || GetPlayer()->IsPaused())
 	{
 		if(m_FreezeTime > 0 || m_FreezeTime == -1 || m_Core.m_DeepFrozen || m_Core.m_LiveFrozen)
 			Emote = EMOTE_NORMAL;

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -127,6 +127,7 @@ class CGameContext : public IGameServer
 	struct CPersistentClientData
 	{
 		bool m_IsSpectator;
+		bool m_IsAfk;
 	};
 
 public:

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -689,6 +689,23 @@ void CPlayer::AfkTimer()
 	m_Afk = g_Config.m_SvMaxAfkTime != 0 && m_LastPlaytime < time_get() - time_freq() * g_Config.m_SvMaxAfkTime;
 }
 
+void CPlayer::SetAfk(bool Afk)
+{
+	if(g_Config.m_SvMaxAfkTime == 0)
+	{
+		m_Afk = false;
+		return;
+	}
+
+	m_Afk = Afk;
+
+	// Ensure that the AFK state is not reset again automatically
+	if(Afk)
+		m_LastPlaytime = time_get() - time_freq() * g_Config.m_SvMaxAfkTime - 1;
+	else
+		m_LastPlaytime = time_get();
+}
+
 int CPlayer::GetDefaultEmote() const
 {
 	if(m_OverrideEmoteReset >= 0)

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -686,16 +686,7 @@ void CPlayer::UpdatePlaytime()
 
 void CPlayer::AfkTimer()
 {
-	if(g_Config.m_SvMaxAfkTime == 0)
-		return;
-
-	if(m_LastPlaytime < time_get() - time_freq() * g_Config.m_SvMaxAfkTime)
-	{
-		m_Afk = true;
-		return;
-	}
-
-	m_Afk = false;
+	m_Afk = g_Config.m_SvMaxAfkTime != 0 && m_LastPlaytime < time_get() - time_freq() * g_Config.m_SvMaxAfkTime;
 }
 
 int CPlayer::GetDefaultEmote() const

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -140,6 +140,7 @@ private:
 	int m_Paused;
 	int64_t m_ForcePauseTime;
 	int64_t m_LastPause;
+	bool m_Afk;
 
 	int m_DefEmote;
 	int m_OverrideEmote;
@@ -181,7 +182,6 @@ public:
 	vec2 m_ShowDistance;
 	bool m_SpecTeam;
 	bool m_NinjaJetpack;
-	bool m_Afk;
 	bool m_HasFinishScore;
 
 	int m_ChatScore;
@@ -190,6 +190,9 @@ public:
 
 	void UpdatePlaytime();
 	void AfkTimer();
+	void SetAfk(bool Afk);
+	bool IsAfk() const { return m_Afk; }
+
 	int64_t m_LastPlaytime;
 	int64_t m_LastEyeEmote;
 	int64_t m_LastBroadcast;


### PR DESCRIPTION


## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
