### PR TITLE
Fix CheckAtomic.cmake

### DIFF
--- a/cmake/CheckAtomic.cmake
+++ b/cmake/CheckAtomic.cmake
@@ -10,11 +10,16 @@ function(check_working_cxx_atomics varname)
   check_cxx_source_compiles("
 #include <atomic>
 #include <cstdint>
+std::atomic<int> x1;
+std::atomic<short> x2;
+std::atomic<char> x3;
 std::atomic<uint64_t> x (0);
 int main() {
   uint64_t i = x.load(std::memory_order_relaxed);
   (void)i;
-  return 0;
+  ++x3;
+  ++x2;
+  return ++x1;
 }
 " ${varname})
   set(CMAKE_REQUIRED_FLAGS ${OLD_CMAKE_REQUIRED_FLAGS})


### PR DESCRIPTION
Fix build on RISC-V (and other platforms that the original CheckAtomic.cmake may give false positive), since there are no sub-word atomics but larger ones like 32-bit and 64-bit.

Debian buildd logs: https://buildd.debian.org/status/fetch.php?pkg=ddnet&arch=riscv64&ver=16.4-1&stamp=1671449589&raw=0

See https://github.com/llvm/llvm-project/commit/cef85193b2cc1817ca43199a0ae9c6f25723997d for more information.