### PR TITLE
Use PRIu64 (which is for uint64_t) since %zu (for size_t) doesn't work on Windows (fixes #6187)

### DIFF
--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -80,6 +80,11 @@
 #include <sys/filio.h>
 #endif
 
+// for msvc
+#ifndef PRId64
+#define PRId64 "I64d"
+#endif
+
 extern "C" {
 
 IOHANDLE io_stdin()

--- a/src/engine/client/backend/vulkan/backend_vulkan.cpp
+++ b/src/engine/client/backend/vulkan/backend_vulkan.cpp
@@ -48,6 +48,11 @@
 #define VK_API_VERSION_PATCH VK_VERSION_PATCH
 #endif
 
+// for msvc
+#ifndef PRIu64
+#define PRIu64 "I64u"
+#endif
+
 using namespace std::chrono_literals;
 
 class CCommandProcessorFragment_Vulkan : public CCommandProcessorFragment_GLBase
@@ -87,7 +92,7 @@ class CCommandProcessorFragment_Vulkan : public CCommandProcessorFragment_GLBase
 			break;
 		default: break;
 		}
-		dbg_msg("vulkan", "allocated chunk of memory with size: %zu for frame %zu (%s)", (size_t)Size, (size_t)m_CurImageIndex, pUsage);
+		dbg_msg("vulkan", "allocated chunk of memory with size: %" PRIu64 " for frame %" PRIu64 " (%s)", (uint64_t)Size, (uint64_t)m_CurImageIndex, pUsage);
 	}
 
 	void VerboseDeallocatedMemory(VkDeviceSize Size, size_t FrameImageIndex, EMemoryBlockUsage MemUsage)
@@ -109,7 +114,7 @@ class CCommandProcessorFragment_Vulkan : public CCommandProcessorFragment_GLBase
 			break;
 		default: break;
 		}
-		dbg_msg("vulkan", "deallocated chunk of memory with size: %zu for frame %zu (%s)", (size_t)Size, (size_t)m_CurImageIndex, pUsage);
+		dbg_msg("vulkan", "deallocated chunk of memory with size: %" PRIu64 " for frame %" PRIu64 " (%s)", (uint64_t)Size, (uint64_t)m_CurImageIndex, pUsage);
 	}
 
 	/************************
@@ -2057,7 +2062,7 @@ protected:
 			m_pStagingMemoryUsage->store(m_pStagingMemoryUsage->load(std::memory_order_relaxed) - FreeedMemory, std::memory_order_relaxed);
 			if(IsVerbose())
 			{
-				dbg_msg("vulkan", "deallocated chunks of memory with size: %zu from all frames (staging buffer)", (size_t)FreeedMemory);
+				dbg_msg("vulkan", "deallocated chunks of memory with size: %" PRIu64 " from all frames (staging buffer)", (uint64_t)FreeedMemory);
 			}
 		}
 		FreeedMemory = 0;
@@ -2067,7 +2072,7 @@ protected:
 			m_pBufferMemoryUsage->store(m_pBufferMemoryUsage->load(std::memory_order_relaxed) - FreeedMemory, std::memory_order_relaxed);
 			if(IsVerbose())
 			{
-				dbg_msg("vulkan", "deallocated chunks of memory with size: %zu from all frames (buffer)", (size_t)FreeedMemory);
+				dbg_msg("vulkan", "deallocated chunks of memory with size: %" PRIu64 " from all frames (buffer)", (uint64_t)FreeedMemory);
 			}
 		}
 		FreeedMemory = 0;
@@ -2078,7 +2083,7 @@ protected:
 			m_pTextureMemoryUsage->store(m_pTextureMemoryUsage->load(std::memory_order_relaxed) - FreeedMemory, std::memory_order_relaxed);
 			if(IsVerbose())
 			{
-				dbg_msg("vulkan", "deallocated chunks of memory with size: %zu from all frames (texture)", (size_t)FreeedMemory);
+				dbg_msg("vulkan", "deallocated chunks of memory with size: %" PRIu64 " from all frames (texture)", (uint64_t)FreeedMemory);
 			}
 		}
 	}
@@ -3817,7 +3822,7 @@ public:
 
 			if(IsVerbose())
 			{
-				dbg_msg("vulkan", "device prop: non-coherent align: %zu, optimal image copy align: %zu, max texture size: %u, max sampler anisotropy: %u", (size_t)m_NonCoherentMemAlignment, (size_t)m_OptimalImageCopyMemAlignment, m_MaxTextureSize, m_MaxSamplerAnisotropy);
+				dbg_msg("vulkan", "device prop: non-coherent align: %" PRIu64 ", optimal image copy align: %" PRIu64 ", max texture size: %u, max sampler anisotropy: %u", (uint64_t)m_NonCoherentMemAlignment, (uint64_t)m_OptimalImageCopyMemAlignment, m_MaxTextureSize, m_MaxSamplerAnisotropy);
 				dbg_msg("vulkan", "device prop: min uniform align: %u, multi sample: %u", m_MinUniformAlign, (uint32_t)m_MaxMultiSample);
 			}
 		}
@@ -7634,7 +7639,7 @@ public:
 
 			if(IsVerbose() && s_BenchmarkRenderThreads)
 			{
-				dbg_msg("vulkan", "render thread %zu took %d ns to finish", ThreadIndex, (int)(time_get_nanoseconds() - ThreadRenderTime).count());
+				dbg_msg("vulkan", "render thread %" PRIu64 " took %d ns to finish", (uint64_t)ThreadIndex, (int)(time_get_nanoseconds() - ThreadRenderTime).count());
 			}
 
 			pThread->m_IsRendering = false;


### PR DESCRIPTION
This reverts commit a59613e56fac0fc354c9ec8403a8130a16ef098a.

<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
