### PR TITLE
Register protocol and file extensions on client launch on Windows

### DIFF
--- a/src/base/system.h
+++ b/src/base/system.h
@@ -2570,6 +2570,18 @@ public:
 	CWindowsComLifecycle(bool HasWindow);
 	~CWindowsComLifecycle();
 };
+
+/**
+ * Registers a protocol handler.
+ *
+ * @ingroup Shell
+ *
+ * @param protocol_name The name of the protocol.
+ * @param executable The absolute path of the executable that will be associated with the protocol.
+ *
+ * @return true on success, false on failure.
+ */
+bool shell_register_protocol(const char *protocol_name, const char *executable);
 #endif
 
 /**

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -2578,10 +2578,13 @@ public:
  *
  * @param protocol_name The name of the protocol.
  * @param executable The absolute path of the executable that will be associated with the protocol.
+ * @param updated Pointer to a variable that will be set to true, iff the shell needs to be updated.
  *
  * @return true on success, false on failure.
+ *
+ * @remark The caller must later call shell_update, iff the shell needs to be updated.
  */
-bool shell_register_protocol(const char *protocol_name, const char *executable);
+bool shell_register_protocol(const char *protocol_name, const char *executable, bool *updated);
 
 /**
  * Registers a file extension.
@@ -2592,10 +2595,22 @@ bool shell_register_protocol(const char *protocol_name, const char *executable);
  * @param description A readable description for the file extension.
  * @param executable_name A unique name that will used to describe the application.
  * @param executable The absolute path of the executable that will be associated with the file extension.
+ * @param updated Pointer to a variable that will be set to true, iff the shell needs to be updated.
  *
  * @return true on success, false on failure.
+ *
+ * @remark The caller must later call shell_update, iff the shell needs to be updated.
  */
-bool shell_register_extension(const char *extension, const char *description, const char *executable_name, const char *executable);
+bool shell_register_extension(const char *extension, const char *description, const char *executable_name, const char *executable, bool *updated);
+
+/**
+ * Notifies the system that a protocol or file extension has been changed and the shell needs to be updated.
+ *
+ * @ingroup Shell
+ * 
+ * @remark This is a potentially expensive operation, so it should only be called when necessary.
+ */
+void shell_update();
 #endif
 
 /**

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -2604,6 +2604,22 @@ bool shell_register_protocol(const char *protocol_name, const char *executable, 
 bool shell_register_extension(const char *extension, const char *description, const char *executable_name, const char *executable, bool *updated);
 
 /**
+ * Unregisters a protocol or file extension handler.
+ *
+ * @ingroup Shell
+ *
+ * @param shell_class The shell class to delete.
+ * For protocols this is the name of the protocol.
+ * For file extensions this is the program ID associated with the file extension.
+ * @param updated Pointer to a variable that will be set to true, iff the shell needs to be updated.
+ *
+ * @return true on success, false on failure.
+ *
+ * @remark The caller must later call shell_update, iff the shell needs to be updated.
+ */
+bool shell_unregister(const char *shell_class, bool *updated);
+
+/**
  * Notifies the system that a protocol or file extension has been changed and the shell needs to be updated.
  *
  * @ingroup Shell

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -2582,6 +2582,20 @@ public:
  * @return true on success, false on failure.
  */
 bool shell_register_protocol(const char *protocol_name, const char *executable);
+
+/**
+ * Registers a file extension.
+ *
+ * @ingroup Shell
+ *
+ * @param extension The file extension, including the leading dot.
+ * @param description A readable description for the file extension.
+ * @param executable_name A unique name that will used to describe the application.
+ * @param executable The absolute path of the executable that will be associated with the file extension.
+ *
+ * @return true on success, false on failure.
+ */
+bool shell_register_extension(const char *extension, const char *description, const char *executable_name, const char *executable);
 #endif
 
 /**

--- a/src/engine/client.h
+++ b/src/engine/client.h
@@ -283,6 +283,7 @@ public:
 
 #if defined(CONF_FAMILY_WINDOWS)
 	virtual void ShellRegister() = 0;
+	virtual void ShellUnregister() = 0;
 #endif
 };
 

--- a/src/engine/client.h
+++ b/src/engine/client.h
@@ -280,6 +280,10 @@ public:
 	virtual CChecksumData *ChecksumData() = 0;
 	virtual bool InfoTaskRunning() = 0;
 	virtual int UdpConnectivity(int NetType) = 0;
+
+#if defined(CONF_FAMILY_WINDOWS)
+	virtual void ShellRegister() = 0;
+#endif
 };
 
 class IGameClient : public IInterface

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -4928,4 +4928,17 @@ void CClient::ShellRegister()
 	if(Updated)
 		shell_update();
 }
+
+void CClient::ShellUnregister()
+{
+	bool Updated = false;
+	if(!shell_unregister("ddnet", &Updated))
+		dbg_msg("client", "Failed to unregister ddnet protocol");
+	if(!shell_unregister(GAME_NAME ".map", &Updated))
+		dbg_msg("client", "Failed to unregister .map file extension");
+	if(!shell_unregister(GAME_NAME ".demo", &Updated))
+		dbg_msg("client", "Failed to unregister .demo file extension");
+	if(Updated)
+		shell_update();
+}
 #endif

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -546,6 +546,10 @@ public:
 	CChecksumData *ChecksumData() override { return &m_Checksum.m_Data; }
 	bool InfoTaskRunning() override { return m_pDDNetInfoTask != nullptr; }
 	int UdpConnectivity(int NetType) override;
+
+#if defined(CONF_FAMILY_WINDOWS)
+	void ShellRegister() override;
+#endif
 };
 
 #endif

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -549,6 +549,7 @@ public:
 
 #if defined(CONF_FAMILY_WINDOWS)
 	void ShellRegister() override;
+	void ShellUnregister() override;
 #endif
 };
 

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -3433,6 +3433,17 @@ void CMenus::RenderSettingsDDNet(CUIRect MainView)
 	SUIExEditBoxProperties EditProps;
 	EditProps.m_pEmptyText = Localize("Chat command (e.g. showall 1)");
 	UI()->DoEditBox(g_Config.m_ClRunOnJoin, &Button, g_Config.m_ClRunOnJoin, sizeof(g_Config.m_ClRunOnJoin), 14.0f, &s_RunOnJoin, false, IGraphics::CORNER_ALL, EditProps);
+
+#if defined(CONF_FAMILY_WINDOWS)
+	static CButtonContainer s_ButtonUnregisterShell;
+	Right.HSplitTop(10.0f, nullptr, &Right);
+	Right.HSplitTop(20.0f, &Button, &Right);
+	if(DoButton_Menu(&s_ButtonUnregisterShell, Localize("Unregister protocol and file extensions"), 0, &Button))
+	{
+		Client()->ShellUnregister();
+	}
+#endif
+
 	// Updater
 #if defined(CONF_AUTOUPDATE)
 	{


### PR DESCRIPTION
When launching the client on Windows, associate the protocol `ddnet` and the file extensions `.map` and `.demo` with the client executable.

See #6072.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
