### PR TITLE
Prevent temporary demo file from being deleted multiple times

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -3978,7 +3978,10 @@ void CClient::DemoRecorder_Stop(int Recorder, bool RemoveFile)
 	{
 		const char *pFilename = m_aDemoRecorder[Recorder].GetCurrentFilename();
 		if(pFilename[0] != '\0')
+		{
 			Storage()->RemoveFile(pFilename, IStorage::TYPE_SAVE);
+			m_aDemoRecorder[Recorder].ClearCurrentFilename();
+		}
 	}
 }
 

--- a/src/engine/shared/demo.h
+++ b/src/engine/shared/demo.h
@@ -49,6 +49,7 @@ public:
 
 	bool IsRecording() const override { return m_File != nullptr; }
 	char *GetCurrentFilename() override { return m_aCurrentFilename; }
+	void ClearCurrentFilename() { m_aCurrentFilename[0] = '\0'; }
 
 	int Length() const override { return (m_LastTickMarker - m_FirstTick) / SERVER_TICK_SPEED; }
 };


### PR DESCRIPTION
Each time the client disconnected or stopped a demo, it tried to delete the previous temporary replay file, which causes an error message "could not delete file" to be shown in the console.

This is prevented by clearing the current filename of the demo recorder after deleting the file.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
