### PR TITLE
Fix edge cases where demo tick seeking did not work

### DIFF
--- a/src/engine/demo.h
+++ b/src/engine/demo.h
@@ -77,9 +77,9 @@ public:
 
 	enum ETickOffset
 	{
-		TICK_CURRENT = 1, // update the current tick again
-		TICK_PREVIOUS = 0, // go to the previous tick
-		TICK_NEXT = 3, // go to the next tick
+		TICK_CURRENT, // update the current tick again
+		TICK_PREVIOUS, // go to the previous tick
+		TICK_NEXT, // go to the next tick
 	};
 
 	~IDemoPlayer() {}

--- a/src/engine/shared/demo.cpp
+++ b/src/engine/shared/demo.cpp
@@ -944,7 +944,27 @@ int CDemoPlayer::SeekTime(float Seconds)
 
 int CDemoPlayer::SeekTick(ETickOffset TickOffset)
 {
-	return SetPos(m_Info.m_Info.m_CurrentTick + (int)TickOffset);
+	int WantedTick;
+	switch(TickOffset)
+	{
+	case TICK_CURRENT:
+		WantedTick = m_Info.m_Info.m_CurrentTick;
+		break;
+	case TICK_PREVIOUS:
+		WantedTick = m_Info.m_PreviousTick;
+		break;
+	case TICK_NEXT:
+		WantedTick = m_Info.m_NextTick;
+		break;
+	default:
+		dbg_assert(false, "Invalid TickOffset");
+		WantedTick = -1;
+		break;
+	}
+
+	// +1 because SetPos will seek until the given tick is the next tick that
+	// will be played back, whereas we want the wanted tick to be played now.
+	return SetPos(WantedTick + 1);
 }
 
 int CDemoPlayer::SetPos(int WantedTick)


### PR DESCRIPTION
Instead of using hardcoded tick offsets, use the current/previous/next tick values from the demo info.

This fixes seeking the next tick not working for demos where the difference between the current and the next tick was greater than 3.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
