### PR TITLE
Type safe mem_zero function (fixes #5228)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -347,6 +347,8 @@ if(NOT MSVC AND NOT HAIKU)
   add_cxx_compiler_flag_if_supported(OUR_FLAGS_OWN -Wthread-safety)
   add_cxx_compiler_flag_if_supported(OUR_FLAGS_OWN -Wthread-safety-negative)
   add_cxx_compiler_flag_if_supported(OUR_FLAGS_OWN -Wsuggest-override)
+  add_cxx_compiler_flag_if_supported(OUR_FLAGS_OWN -Wdynamic-class-memaccess) # clang
+  add_cxx_compiler_flag_if_supported(OUR_FLAGS_OWN -Wclass-memaccess) # gcc
   add_linker_flag_if_supported(OUR_FLAGS_LINK -Wno-alloc-size-larger-than) # save.cpp with LTO
   # add_cxx_compiler_flag_if_supported(OUR_FLAGS_OWN -Wdouble-promotion) # Many occurrences
   # add_cxx_compiler_flag_if_supported(OUR_FLAGS_OWN -Wnull-dereference) # Many occurrences
@@ -2693,6 +2695,7 @@ if(GTEST_FOUND OR DOWNLOAD_GTEST)
     jobs.cpp
     json.cpp
     mapbugs.cpp
+    memory.cpp
     name_ban.cpp
     net.cpp
     netaddr.cpp

--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -216,11 +216,6 @@ void mem_move(void *dest, const void *source, unsigned size)
 	memmove(dest, source, size);
 }
 
-void mem_zero(void *block, unsigned size)
-{
-	memset(block, 0, size);
-}
-
 IOHANDLE io_open_impl(const char *filename, int flags)
 {
 	dbg_assert(flags == (IOFLAG_READ | IOFLAG_SKIP_BOM) || flags == IOFLAG_READ || flags == IOFLAG_WRITE || flags == IOFLAG_APPEND, "flags must be read, read+skipbom, write or append");

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -4438,9 +4438,8 @@ void CClient::RegisterCommands()
 
 static CClient *CreateClient()
 {
-	CClient *pClient = static_cast<CClient *>(malloc(sizeof(*pClient)));
-	mem_zero(pClient, sizeof(CClient));
-	return new(pClient) CClient;
+	CClient *pClient = new CClient();
+	return pClient;
 }
 
 void CClient::HandleConnectAddress(const NETADDR *pAddr)
@@ -4630,8 +4629,7 @@ int main(int argc, const char **argv)
 		if(RegisterFail)
 		{
 			delete pKernel;
-			pClient->~CClient();
-			free(pClient);
+			delete pClient;
 			return -1;
 		}
 	}
@@ -4726,8 +4724,7 @@ int main(int argc, const char **argv)
 
 	bool Restarting = pClient->State() == CClient::STATE_RESTARTING;
 
-	pClient->~CClient();
-	free(pClient);
+	delete pClient;
 
 	NotificationsUninit();
 	secure_random_uninit();

--- a/src/engine/client/text.cpp
+++ b/src/engine/client/text.cpp
@@ -539,7 +539,7 @@ class CTextRender : public IEngineTextRender
 		if(Width > 0 && Height > 0)
 		{
 			// prepare glyph data
-			mem_zero(ms_aGlyphData, Width * Height);
+			mem_zero(ms_aGlyphData, (size_t)Width * Height);
 
 			for(py = 0; py < pBitmap->rows; py++)
 				for(px = 0; px < pBitmap->width; px++)

--- a/src/game/client/prediction/entities/character.cpp
+++ b/src/game/client/prediction/entities/character.cpp
@@ -457,7 +457,7 @@ void CCharacter::FireWeapon()
 	break;
 	}
 
-	m_AttackTick = GameWorld()->GameTick();
+	m_AttackTick = GameWorld()->GameTick(); // NOLINT(clang-analyzer-unix.Malloc)
 
 	if(!m_ReloadTimer)
 	{

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -522,7 +522,7 @@ void CCharacter::FireWeapon()
 				-1 //SoundImpact
 			);
 
-			GameServer()->CreateSound(m_Pos, SOUND_GUN_FIRE, TeamMask());
+			GameServer()->CreateSound(m_Pos, SOUND_GUN_FIRE, TeamMask()); // NOLINT(clang-analyzer-unix.Malloc)
 		}
 	}
 	break;
@@ -536,7 +536,7 @@ void CCharacter::FireWeapon()
 			LaserReach = GameServer()->TuningList()[m_TuneZone].m_LaserReach;
 
 		new CLaser(&GameServer()->m_World, m_Pos, Direction, LaserReach, m_pPlayer->GetCID(), WEAPON_SHOTGUN);
-		GameServer()->CreateSound(m_Pos, SOUND_SHOTGUN_FIRE, TeamMask());
+		GameServer()->CreateSound(m_Pos, SOUND_SHOTGUN_FIRE, TeamMask()); // NOLINT(clang-analyzer-unix.Malloc)
 	}
 	break;
 
@@ -573,7 +573,7 @@ void CCharacter::FireWeapon()
 			LaserReach = GameServer()->TuningList()[m_TuneZone].m_LaserReach;
 
 		new CLaser(GameWorld(), m_Pos, Direction, LaserReach, m_pPlayer->GetCID(), WEAPON_LASER);
-		GameServer()->CreateSound(m_Pos, SOUND_LASER_FIRE, TeamMask());
+		GameServer()->CreateSound(m_Pos, SOUND_LASER_FIRE, TeamMask()); // NOLINT(clang-analyzer-unix.Malloc)
 	}
 	break;
 

--- a/src/game/server/gamecontroller.cpp
+++ b/src/game/server/gamecontroller.cpp
@@ -379,11 +379,11 @@ bool IGameController::OnEntity(int Index, int x, int y, int Layer, int Flags, bo
 		new CGun(&GameServer()->m_World, Pos, false, false, Layer, Number);
 	}
 
-	if(Type != -1)
+	if(Type != -1) // NOLINT(clang-analyzer-unix.Malloc)
 	{
 		CPickup *pPickup = new CPickup(&GameServer()->m_World, Type, SubType, Layer, Number);
 		pPickup->m_Pos = Pos;
-		return true;
+		return true; // NOLINT(clang-analyzer-unix.Malloc)
 	}
 
 	return false;

--- a/src/test/memory.cpp
+++ b/src/test/memory.cpp
@@ -1,0 +1,389 @@
+#include <gtest/gtest.h>
+
+#include <base/system.h>
+
+#include <random>
+#include <vector>
+
+static std::mt19937 gs_randomizer;
+
+void mem_fill(void *block, size_t size)
+{
+	unsigned char *bytes = (unsigned char *)block;
+	size_t i;
+	for(i = 0; i < size; i++)
+	{
+		bytes[i] = gs_randomizer();
+	}
+}
+
+bool mem_is_null(const void *block, size_t size)
+{
+	const unsigned char *bytes = (const unsigned char *)block;
+	size_t i;
+	for(i = 0; i < size; i++)
+	{
+		if(bytes[i] != 0)
+		{
+			return false;
+		}
+	}
+	return true;
+}
+
+TEST(Memory, BaseTypes)
+{
+	void *aVoid[123];
+	mem_fill(aVoid, sizeof(aVoid));
+	EXPECT_FALSE(mem_is_null(aVoid, sizeof(aVoid)));
+	mem_zero(&aVoid, sizeof(aVoid));
+	EXPECT_TRUE(mem_is_null(aVoid, sizeof(aVoid)));
+	mem_fill(aVoid, sizeof(aVoid));
+	EXPECT_FALSE(mem_is_null(aVoid, sizeof(aVoid)));
+	mem_zero(&aVoid[0], 123 * sizeof(void *));
+	EXPECT_TRUE(mem_is_null(aVoid, sizeof(aVoid)));
+
+	mem_fill(aVoid, sizeof(aVoid));
+	EXPECT_FALSE(mem_is_null(aVoid, sizeof(aVoid)));
+	mem_zero(aVoid, sizeof(aVoid));
+	EXPECT_TRUE(mem_is_null(aVoid, sizeof(aVoid)));
+
+	int aInt[512];
+	mem_fill(aInt, sizeof(aInt));
+	EXPECT_FALSE(mem_is_null(aInt, sizeof(aInt)));
+	mem_zero(&aInt, sizeof(aInt));
+	EXPECT_TRUE(mem_is_null(aInt, sizeof(aInt)));
+	mem_fill(aInt, sizeof(aInt));
+	EXPECT_FALSE(mem_is_null(aInt, sizeof(aInt)));
+	mem_zero(&aInt[0], sizeof(aInt));
+	EXPECT_TRUE(mem_is_null(aInt, sizeof(aInt)));
+
+	mem_fill(aInt, sizeof(aInt));
+	EXPECT_FALSE(mem_is_null(aInt, sizeof(aInt)));
+	mem_zero(aInt, sizeof(aInt));
+	EXPECT_TRUE(mem_is_null(aInt, sizeof(aInt)));
+
+	int *apInt[512];
+	mem_fill(apInt, sizeof(apInt));
+	EXPECT_FALSE(mem_is_null(apInt, sizeof(apInt)));
+	mem_zero(&apInt, sizeof(apInt));
+	EXPECT_TRUE(mem_is_null(apInt, sizeof(apInt)));
+
+	mem_fill(apInt, sizeof(apInt));
+	EXPECT_FALSE(mem_is_null(apInt, sizeof(apInt)));
+	mem_zero(apInt, sizeof(apInt));
+	EXPECT_TRUE(mem_is_null(apInt, sizeof(apInt)));
+
+	int aaInt[10][20];
+	mem_fill(aaInt, sizeof(aaInt));
+	EXPECT_FALSE(mem_is_null(aaInt, sizeof(aaInt)));
+	mem_zero(&aaInt, sizeof(aaInt));
+	EXPECT_TRUE(mem_is_null(aaInt, sizeof(aaInt)));
+	mem_fill(aaInt, sizeof(aaInt));
+	EXPECT_FALSE(mem_is_null(aaInt, sizeof(aaInt)));
+	mem_zero(&aaInt[0], sizeof(aaInt));
+	EXPECT_TRUE(mem_is_null(aaInt, sizeof(aaInt)));
+	mem_fill(aaInt, sizeof(aaInt));
+	EXPECT_FALSE(mem_is_null(aaInt, sizeof(aaInt)));
+	mem_zero(&aaInt[0][0], sizeof(aaInt));
+	EXPECT_TRUE(mem_is_null(aaInt, sizeof(aaInt)));
+
+	mem_fill(aaInt, sizeof(aaInt));
+	EXPECT_FALSE(mem_is_null(aaInt, sizeof(aaInt)));
+	mem_zero(aaInt, sizeof(aaInt));
+	EXPECT_TRUE(mem_is_null(aaInt, sizeof(aaInt)));
+	mem_fill(aaInt, sizeof(aaInt));
+	EXPECT_FALSE(mem_is_null(aaInt, sizeof(aaInt)));
+	mem_zero(aaInt[0], sizeof(aaInt));
+	EXPECT_TRUE(mem_is_null(aaInt, sizeof(aaInt)));
+
+	int *aapInt[10][20];
+	mem_fill(aapInt, sizeof(aapInt));
+	EXPECT_FALSE(mem_is_null(aapInt, sizeof(aapInt)));
+	mem_zero(&aapInt, sizeof(aapInt));
+	EXPECT_TRUE(mem_is_null(aapInt, sizeof(aapInt)));
+	mem_fill(aapInt, sizeof(aapInt));
+	EXPECT_FALSE(mem_is_null(aapInt, sizeof(aapInt)));
+	mem_zero(&aapInt[0], sizeof(aapInt));
+	EXPECT_TRUE(mem_is_null(aapInt, sizeof(aapInt)));
+
+	mem_fill(aapInt, sizeof(aapInt));
+	EXPECT_FALSE(mem_is_null(aapInt, sizeof(aapInt)));
+	mem_zero(aapInt, sizeof(aapInt));
+	EXPECT_TRUE(mem_is_null(aapInt, sizeof(aapInt)));
+	mem_fill(aapInt, sizeof(aapInt));
+	EXPECT_FALSE(mem_is_null(aapInt, sizeof(aapInt)));
+	mem_zero(aapInt[0], sizeof(aapInt));
+	EXPECT_TRUE(mem_is_null(aapInt, sizeof(aapInt)));
+}
+
+TEST(Memory, PODTypes)
+{
+	NETADDR aAddr[123];
+	mem_fill(aAddr, sizeof(aAddr));
+	EXPECT_FALSE(mem_is_null(aAddr, sizeof(aAddr)));
+	mem_zero(&aAddr, sizeof(aAddr));
+	EXPECT_TRUE(mem_is_null(aAddr, sizeof(aAddr)));
+	mem_fill(aAddr, sizeof(aAddr));
+	EXPECT_FALSE(mem_is_null(aAddr, sizeof(aAddr)));
+	mem_zero(&aAddr[0], sizeof(aAddr));
+	EXPECT_TRUE(mem_is_null(aAddr, sizeof(aAddr)));
+
+	mem_fill(aAddr, sizeof(aAddr));
+	EXPECT_FALSE(mem_is_null(aAddr, sizeof(aAddr)));
+	mem_zero(aAddr, sizeof(aAddr));
+	EXPECT_TRUE(mem_is_null(aAddr, sizeof(aAddr)));
+
+	NETADDR *apAddr[123];
+	mem_fill(apAddr, sizeof(apAddr));
+	EXPECT_FALSE(mem_is_null(apAddr, sizeof(apAddr)));
+	mem_zero((NETADDR **)apAddr, sizeof(apAddr));
+	EXPECT_TRUE(mem_is_null(apAddr, sizeof(apAddr)));
+	mem_fill(apAddr, sizeof(apAddr));
+	EXPECT_FALSE(mem_is_null(apAddr, sizeof(apAddr)));
+	mem_zero(&apAddr, sizeof(apAddr));
+	EXPECT_TRUE(mem_is_null(apAddr, sizeof(apAddr)));
+	mem_fill(apAddr, sizeof(apAddr));
+	EXPECT_FALSE(mem_is_null(apAddr, sizeof(apAddr)));
+	mem_zero(&apAddr[0], sizeof(apAddr));
+	EXPECT_TRUE(mem_is_null(apAddr, sizeof(apAddr)));
+	mem_fill(apAddr, sizeof(apAddr));
+	EXPECT_FALSE(mem_is_null(apAddr, sizeof(apAddr)));
+	mem_zero(apAddr, sizeof(apAddr));
+	EXPECT_TRUE(mem_is_null(apAddr, sizeof(apAddr)));
+
+	// 2D arrays
+	NETADDR aaAddr[10][20];
+	mem_fill(aaAddr, sizeof(aaAddr));
+	EXPECT_FALSE(mem_is_null((NETADDR *)aaAddr, sizeof(aaAddr)));
+	mem_zero(&aaAddr, sizeof(aaAddr));
+	EXPECT_TRUE(mem_is_null((NETADDR *)aaAddr, sizeof(aaAddr)));
+	mem_fill(aaAddr, sizeof(aaAddr));
+	EXPECT_FALSE(mem_is_null((NETADDR *)aaAddr, sizeof(aaAddr)));
+	mem_zero(&aaAddr[0], sizeof(aaAddr));
+	EXPECT_TRUE(mem_is_null((NETADDR *)aaAddr, sizeof(aaAddr)));
+	mem_fill(aaAddr, sizeof(aaAddr));
+	EXPECT_FALSE(mem_is_null((NETADDR *)aaAddr, sizeof(aaAddr)));
+	mem_zero(&aaAddr[0][0], sizeof(aaAddr));
+	EXPECT_TRUE(mem_is_null((NETADDR *)aaAddr, sizeof(aaAddr)));
+
+	mem_fill(aaAddr, sizeof(aaAddr));
+	EXPECT_FALSE(mem_is_null((NETADDR *)aaAddr, sizeof(aaAddr)));
+	mem_zero(aaAddr, sizeof(aaAddr));
+	EXPECT_TRUE(mem_is_null((NETADDR *)aaAddr, sizeof(aaAddr)));
+	mem_fill(aaAddr, sizeof(aaAddr));
+	EXPECT_FALSE(mem_is_null((NETADDR *)aaAddr, sizeof(aaAddr)));
+	mem_zero(aaAddr[0], sizeof(aaAddr));
+	EXPECT_TRUE(mem_is_null((NETADDR *)aaAddr, sizeof(aaAddr)));
+
+	// 2D pointer arrays
+	NETADDR *aapAddr[10][20];
+	mem_fill(aapAddr, sizeof(aapAddr));
+	EXPECT_FALSE(mem_is_null(aapAddr, sizeof(aapAddr)));
+	mem_zero(&aapAddr, sizeof(aapAddr));
+	EXPECT_TRUE(mem_is_null(aapAddr, sizeof(aapAddr)));
+	mem_fill(aapAddr, sizeof(aapAddr));
+	EXPECT_FALSE(mem_is_null(aapAddr, sizeof(aapAddr)));
+	mem_zero(&aapAddr[0], sizeof(aapAddr));
+	EXPECT_TRUE(mem_is_null(aapAddr, sizeof(aapAddr)));
+	mem_fill(aapAddr, sizeof(aapAddr));
+	EXPECT_FALSE(mem_is_null(aapAddr, sizeof(aapAddr)));
+	mem_zero(&aapAddr[0][0], sizeof(aapAddr));
+	EXPECT_TRUE(mem_is_null(aapAddr, sizeof(aapAddr)));
+
+	mem_fill(aapAddr, sizeof(aapAddr));
+	EXPECT_FALSE(mem_is_null(aapAddr, sizeof(aapAddr)));
+	mem_zero(aapAddr, sizeof(aapAddr));
+	EXPECT_TRUE(mem_is_null(aapAddr, sizeof(aapAddr)));
+	mem_fill(aapAddr, sizeof(aapAddr));
+	EXPECT_FALSE(mem_is_null(aapAddr, sizeof(aapAddr)));
+	mem_zero(aapAddr[0], sizeof(aapAddr));
+	EXPECT_TRUE(mem_is_null(aapAddr, sizeof(aapAddr)));
+}
+
+struct CDummyClass
+{
+	int x = 1234;
+	int y;
+};
+
+bool mem_is_null(CDummyClass *block, size_t size)
+{
+	const CDummyClass *data = block;
+	size_t i;
+	for(i = 0; i < size / sizeof(CDummyClass); i++)
+	{
+		if(data[i].x != 1234 || data[i].y != 0)
+		{
+			return false;
+		}
+	}
+	return true;
+}
+
+TEST(Memory, ConstructibleTypes)
+{
+	CDummyClass aTest[123];
+	mem_fill(aTest, sizeof(aTest));
+	EXPECT_FALSE(mem_is_null(aTest, sizeof(aTest)));
+	mem_zero(&aTest, sizeof(aTest));
+	EXPECT_TRUE(mem_is_null(aTest, sizeof(aTest)));
+	mem_fill(aTest, sizeof(aTest));
+	EXPECT_FALSE(mem_is_null(aTest, sizeof(aTest)));
+	mem_zero(&aTest[0], sizeof(aTest));
+	EXPECT_TRUE(mem_is_null(aTest, sizeof(aTest)));
+
+	mem_fill(aTest, sizeof(aTest));
+	EXPECT_FALSE(mem_is_null(aTest, sizeof(aTest)));
+	mem_zero(aTest, sizeof(aTest));
+	EXPECT_TRUE(mem_is_null(aTest, sizeof(aTest)));
+
+	CDummyClass aaTest[2][2];
+	mem_fill(aaTest, sizeof(aaTest));
+	EXPECT_FALSE(mem_is_null((CDummyClass *)aaTest, sizeof(aaTest)));
+	mem_zero(&aaTest, sizeof(aaTest));
+	EXPECT_TRUE(mem_is_null((CDummyClass *)aaTest, sizeof(aaTest)));
+	mem_fill(aaTest, sizeof(aaTest));
+	EXPECT_FALSE(mem_is_null((CDummyClass *)aaTest, sizeof(aaTest)));
+	mem_zero(&aaTest[0], sizeof(aaTest));
+	EXPECT_TRUE(mem_is_null((CDummyClass *)aaTest, sizeof(aaTest)));
+	mem_fill(aaTest, sizeof(aaTest));
+	EXPECT_FALSE(mem_is_null((CDummyClass *)aaTest, sizeof(aaTest)));
+	mem_zero(&aaTest[0][0], sizeof(aaTest));
+	EXPECT_TRUE(mem_is_null((CDummyClass *)aaTest, sizeof(aaTest)));
+
+	mem_fill(aaTest, sizeof(aaTest));
+	EXPECT_FALSE(mem_is_null((CDummyClass *)aaTest, sizeof(aaTest)));
+	mem_zero(aaTest, sizeof(aaTest));
+	EXPECT_TRUE(mem_is_null((CDummyClass *)aaTest, sizeof(aaTest)));
+	mem_fill(aaTest, sizeof(aaTest));
+	EXPECT_FALSE(mem_is_null((CDummyClass *)aaTest, sizeof(aaTest)));
+	mem_zero(aaTest[0], sizeof(aaTest));
+	EXPECT_TRUE(mem_is_null((CDummyClass *)aaTest, sizeof(aaTest)));
+}
+
+struct CDummyClass2
+{
+	int x;
+	int y;
+	~CDummyClass2()
+	{
+		if(x == 684684 && y == -12345678)
+			dbg_break();
+	}
+};
+
+TEST(Memory, DestructibleTypes)
+{
+	CDummyClass2 aTest2[123];
+	mem_fill(aTest2, sizeof(aTest2));
+	EXPECT_FALSE(mem_is_null(aTest2, sizeof(aTest2)));
+	mem_zero(&aTest2, sizeof(aTest2));
+	EXPECT_TRUE(mem_is_null(aTest2, sizeof(aTest2)));
+	mem_fill(aTest2, sizeof(aTest2));
+	EXPECT_FALSE(mem_is_null(aTest2, sizeof(aTest2)));
+	mem_zero(&aTest2[0], sizeof(aTest2));
+	EXPECT_TRUE(mem_is_null(aTest2, sizeof(aTest2)));
+
+	mem_fill(aTest2, sizeof(aTest2));
+	EXPECT_FALSE(mem_is_null(aTest2, sizeof(aTest2)));
+	mem_zero(aTest2, sizeof(aTest2));
+	EXPECT_TRUE(mem_is_null(aTest2, sizeof(aTest2)));
+
+	CDummyClass2 aaTest2[10][20];
+	mem_fill(aaTest2, sizeof(aaTest2));
+	EXPECT_FALSE(mem_is_null((CDummyClass2 *)aaTest2, sizeof(aaTest2)));
+	mem_zero(&aaTest2, sizeof(aaTest2));
+	EXPECT_TRUE(mem_is_null((CDummyClass2 *)aaTest2, sizeof(aaTest2)));
+	mem_fill(aaTest2, sizeof(aaTest2));
+	EXPECT_FALSE(mem_is_null((CDummyClass2 *)aaTest2, sizeof(aaTest2)));
+	mem_zero(&aaTest2[0], sizeof(aaTest2));
+	EXPECT_TRUE(mem_is_null((CDummyClass2 *)aaTest2, sizeof(aaTest2)));
+	mem_fill(aaTest2, sizeof(aaTest2));
+	EXPECT_FALSE(mem_is_null((CDummyClass2 *)aaTest2, sizeof(aaTest2)));
+	mem_zero(&aaTest2[0][0], sizeof(aaTest2));
+	EXPECT_TRUE(mem_is_null((CDummyClass2 *)aaTest2, sizeof(aaTest2)));
+
+	mem_fill(aaTest2, sizeof(aaTest2));
+	EXPECT_FALSE(mem_is_null((CDummyClass2 *)aaTest2, sizeof(aaTest2)));
+	mem_zero(aaTest2, sizeof(aaTest2));
+	EXPECT_TRUE(mem_is_null((CDummyClass2 *)aaTest2, sizeof(aaTest2)));
+
+	mem_fill(aaTest2, sizeof(aaTest2));
+	EXPECT_FALSE(mem_is_null((CDummyClass2 *)aaTest2, sizeof(aaTest2)));
+	mem_zero(aaTest2[0], sizeof(aaTest2));
+	EXPECT_TRUE(mem_is_null((CDummyClass2 *)aaTest2, sizeof(aaTest2)));
+}
+
+struct CDummyClass3
+{
+	int x;
+	int y;
+	std::vector<int> v;
+};
+
+void mem_fill(CDummyClass3 *block, size_t size)
+{
+	size_t i;
+	for(i = 0; i < size / sizeof(CDummyClass3); i++)
+	{
+		block[i].x = gs_randomizer();
+		block[i].y = gs_randomizer();
+		block[i].v.resize(gs_randomizer() & 127, gs_randomizer());
+	}
+}
+
+bool mem_is_null(CDummyClass3 *block, size_t size)
+{
+	const CDummyClass3 *data = block;
+	size_t i;
+	for(i = 0; i < size / sizeof(CDummyClass3); i++)
+	{
+		if(data[i].x != 0 || data[i].y != 0 || !data[i].v.empty())
+		{
+			return false;
+		}
+	}
+	return true;
+}
+
+TEST(Memory, ComplexTypes)
+{
+	CDummyClass3 aTest3[123];
+	mem_fill(aTest3, sizeof(aTest3));
+	EXPECT_FALSE(mem_is_null(aTest3, sizeof(aTest3)));
+	mem_zero(&aTest3, sizeof(aTest3));
+	EXPECT_TRUE(mem_is_null(aTest3, sizeof(aTest3)));
+	mem_fill(aTest3, sizeof(aTest3));
+	EXPECT_FALSE(mem_is_null(aTest3, sizeof(aTest3)));
+	mem_zero(&aTest3[0], sizeof(aTest3));
+	EXPECT_TRUE(mem_is_null(aTest3, sizeof(aTest3)));
+
+	mem_fill(aTest3, sizeof(aTest3));
+	EXPECT_FALSE(mem_is_null(aTest3, sizeof(aTest3)));
+	mem_zero(aTest3, sizeof(aTest3));
+	EXPECT_TRUE(mem_is_null(aTest3, sizeof(aTest3)));
+
+	CDummyClass3 aaTest3[10][20];
+	mem_fill((CDummyClass3 *)aaTest3, sizeof(aaTest3));
+	EXPECT_FALSE(mem_is_null((CDummyClass3 *)aaTest3, sizeof(aaTest3)));
+	mem_zero(&aaTest3, sizeof(aaTest3));
+	EXPECT_TRUE(mem_is_null((CDummyClass3 *)aaTest3, sizeof(aaTest3)));
+	mem_fill((CDummyClass3 *)aaTest3, sizeof(aaTest3));
+	EXPECT_FALSE(mem_is_null((CDummyClass3 *)aaTest3, sizeof(aaTest3)));
+	mem_zero(&aaTest3[0], sizeof(aaTest3));
+	EXPECT_TRUE(mem_is_null((CDummyClass3 *)aaTest3, sizeof(aaTest3)));
+	mem_fill((CDummyClass3 *)aaTest3, sizeof(aaTest3));
+	EXPECT_FALSE(mem_is_null((CDummyClass3 *)aaTest3, sizeof(aaTest3)));
+	mem_zero(&aaTest3[0][0], sizeof(aaTest3));
+	EXPECT_TRUE(mem_is_null((CDummyClass3 *)aaTest3, sizeof(aaTest3)));
+
+	mem_fill((CDummyClass3 *)aaTest3, sizeof(aaTest3));
+	EXPECT_FALSE(mem_is_null((CDummyClass3 *)aaTest3, sizeof(aaTest3)));
+	mem_zero(aaTest3, sizeof(aaTest3));
+	EXPECT_TRUE(mem_is_null((CDummyClass3 *)aaTest3, sizeof(aaTest3)));
+	mem_fill((CDummyClass3 *)aaTest3, sizeof(aaTest3));
+	EXPECT_FALSE(mem_is_null((CDummyClass3 *)aaTest3, sizeof(aaTest3)));
+	mem_zero(aaTest3[0], sizeof(aaTest3));
+	EXPECT_TRUE(mem_is_null((CDummyClass3 *)aaTest3, sizeof(aaTest3)));
+}

--- a/src/tools/map_optimize.cpp
+++ b/src/tools/map_optimize.cpp
@@ -250,7 +250,7 @@ int main(int argc, const char **argv)
 				}
 				else if(aImageFlags[ImageIndex] == 0)
 				{
-					mem_zero(pImgBuff, Width * Height * 4);
+					mem_zero(pImgBuff, (size_t)Width * Height * 4);
 				}
 				else
 				{


### PR DESCRIPTION
Partially replaces #5690.
POD types are just memset. Other types are either destructed if not trivial and/or constructed if not trivial. Types need to have a default constructor. Virtual classes can be mem_zeroed only if they already have been constructed, otherwise it is UB.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [x] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [x] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
