### PR TITLE
Add -DSECURITY_COMPILER_FLAGS=OFF option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,6 +132,7 @@ option(VULKAN "Enable the vulkan backend" ${AUTO_VULKAN_BACKEND})
 option(EXCEPTION_HANDLING "Enable exception handling (only works with Windows as of now)" OFF)
 option(IPO "Enable interprocedural optimizations" OFF)
 option(FUSE_LD "Linker to use" OFF)
+option(SECURITY_COMPILER_FLAGS "Whether to set security-relevant compiler flags like -D_FORTIFY_SOURCE=2 and -fstack-protector-all" ON)
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Emscripten")
   include(${PROJECT_SOURCE_DIR}/cmake/toolchains/Emscripten.toolchain)
@@ -293,9 +294,11 @@ if(NOT MSVC AND NOT HAIKU)
     add_cxx_compiler_flag_if_supported(OUR_FLAGS_OWN -std=gnu++17)
   endif()
 
-  # Protect the stack pointer.
-  # -fstack-protector-all doesn't work on MinGW.
-  add_cxx_compiler_flag_if_supported(OUR_FLAGS -fstack-protector-all)
+  if(NOT SECURITY_COMPILER_FLAGS STREQUAL OFF)
+    # Protect the stack pointer.
+    # -fstack-protector-all doesn't work on MinGW.
+    add_cxx_compiler_flag_if_supported(OUR_FLAGS -fstack-protector-all)
+  endif()
 
   # Disable exceptions as DDNet does not use them.
   add_cxx_compiler_flag_if_supported(OUR_FLAGS -fno-exceptions)
@@ -359,7 +362,7 @@ if(MSVC)
   endif()
 endif()
 
-if(NOT MSVC AND NOT HAIKU)
+if(NOT MSVC AND NOT HAIKU AND NOT SECURITY_COMPILER_FLAGS STREQUAL OFF)
   check_c_compiler_flag("-O2;-Wp,-Werror;-D_FORTIFY_SOURCE=2" DEFINE_FORTIFY_SOURCE) # Some distributions define _FORTIFY_SOURCE by themselves.
 endif()
 

--- a/README.md
+++ b/README.md
@@ -134,11 +134,19 @@ Default value is ON for Windows x86\_64 and Linux, and OFF for Windows x86 and m
 Use the Ninja build system instead of Make. This automatically parallelizes the build and is generally faster. Compile with `ninja` instead of `make`. Install Ninja with `sudo apt install ninja-build` on Debian, `sudo pacman -S --needed ninja` on Arch Linux.
 
 * **-DCMAKE_CXX_LINK_FLAGS=[FLAGS]** <br>
-Custom flags to set for compiler when linking. With clang++ as the compiler this can be [used to link](https://github.com/rui314/mold#how-to-use) with [mold](https://github.com/rui314/mold), speeds up linking by a factor of ~10:
+Custom flags to set for compiler when linking.
 
-```bash
-CC=clang CXX=clang++ cmake -DCMAKE_CXX_LINK_FLAGS="--ld-path=/usr/bin/mold" .
-```
+* **-DEXCEPTION_HANDLING=[ON|OFF]** <br>
+Enable exception handling (only works with Windows as of now, uses DrMingw there). Default value is OFF.
+
+* **-DIPO=[ON|OFF]** <br>
+Enable interprocedural optimizations, also known as Link Time Optimization (LTO). Default value is OFF.
+
+* **-DFUSE_LD=[OFF|LINKER]** <br>
+Linker to use. Default value is OFF to try mold, lld, gold.
+
+* **-DSECURITY_COMPILER_FLAGS=[ON|OFF]** <br>
+Whether to set security-relevant compiler flags like `-D_FORTIFY_SOURCE=2` and `-fstack-protector-all`. Default Value is ON.
 
 Running tests (Debian/Ubuntu)
 -----------------------------


### PR DESCRIPTION
To disable -D_FORTIFY_SOURCE=2 -fstack-protector-all, see https://bugs.gentoo.org/888875 for report. Default behavior is not changed.

<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
