### PR TITLE
Fix more issues with the `restart` command

### DIFF
--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -810,18 +810,10 @@ void CGameClient::OnMessage(int MsgId, CUnpacker *pUnpacker, int Conn, bool Dumm
 
 		for(i = 0; i < MAX_CLIENTS; i++)
 		{
-			int Team = pUnpacker->GetInt();
-			bool WentWrong = false;
-
-			if(pUnpacker->Error())
-				WentWrong = true;
-
-			if(!WentWrong && Team >= TEAM_FLOCK && Team <= TEAM_SUPER)
+			const int Team = pUnpacker->GetInt();
+			if(!pUnpacker->Error() && Team >= TEAM_FLOCK && Team <= TEAM_SUPER)
 				m_Teams.Team(i, Team);
 			else
-				WentWrong = true;
-
-			if(WentWrong)
 			{
 				m_Teams.Team(i, 0);
 				break;

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -470,6 +470,7 @@ public:
 	void OnRconLine(const char *pLine) override;
 	virtual void OnGameOver();
 	virtual void OnStartGame();
+	virtual void OnStartRound();
 	virtual void OnFlagGrab(int TeamID);
 
 	void OnWindowResize();

--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -24,6 +24,7 @@ void CGameTeams::Reset()
 		m_aTeeStarted[i] = false;
 		m_aTeeFinished[i] = false;
 		m_aLastChat[i] = 0;
+		SendTeamsState(i);
 	}
 
 	for(int i = 0; i < NUM_TEAMS; ++i)


### PR DESCRIPTION
Closes #6168.

Not resetting the team when restarting requires too much effort for a feature that would only be active with the non-default `sv_rejoin_team_0 0` setting. If the `restart` command is used for testing a map or for tournaments, it would be easy enough as a workaround to create a bind to join a specific team after restarting, so I don't think this is necessary.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
