### PR TITLE
Port `CListBox` from upstream, smooth scrolling for all lists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2277,6 +2277,8 @@ if(CLIENT)
     skin.h
     ui.cpp
     ui.h
+    ui_listbox.cpp
+    ui_listbox.h
     ui_rect.cpp
     ui_rect.h
     ui_scrollregion.cpp

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -195,22 +195,6 @@ class CMenus : public CComponent
 		return UI()->DoButtonLogic(pID, Checked, pRect);
 	}
 
-	struct CListboxItem
-	{
-		int m_Visible;
-		int m_Selected;
-		CUIRect m_Rect;
-		CUIRect m_HitRect;
-	};
-
-	void UiDoListboxStart(const void *pID, const CUIRect *pRect, float RowHeight, const char *pTitle, const char *pBottomText, int NumItems,
-		int ItemsPerRow, int SelectedIndex, float ScrollValue, bool LogicOnly = false);
-	CListboxItem UiDoListboxNextItem(const void *pID, bool Selected = false, bool KeyEvents = true, bool NoHoverEffects = false);
-	CListboxItem UiDoListboxNextRow();
-	int UiDoListboxEnd(float *pScrollValue, bool *pItemActivated, bool *pListBoxActive = nullptr);
-
-	int UiLogicGetCurrentClickedItem();
-
 	/**
 	 * Places and renders a tooltip near pNearRect.
 	 * For now only works correctly with single line tooltips, since Text width calculation gets broken when there are multiple lines.
@@ -541,8 +525,6 @@ protected:
 
 	// found in menus_browser.cpp
 	int m_SelectedIndex;
-	int m_DoubleClickIndex;
-	int m_ScrollOffset;
 	void RenderServerbrowserServerList(CUIRect View);
 	void Connect(const char *pAddress);
 	void PopupConfirmSwitchServer();
@@ -565,8 +547,8 @@ protected:
 	void OnConfigSave(IConfigManager *pConfigManager);
 
 	// found in menus_settings.cpp
-	void RenderLanguageSelection(CUIRect MainView);
-	void RenderThemeSelection(CUIRect MainView, bool Header = true);
+	bool RenderLanguageSelection(CUIRect MainView);
+	void RenderThemeSelection(CUIRect MainView);
 	void RenderSettingsGeneral(CUIRect MainView);
 	void RenderSettingsPlayer(CUIRect MainView);
 	void RenderSettingsDummyPlayer(CUIRect MainView);
@@ -746,7 +728,6 @@ private:
 	static int GhostlistFetchCallback(const char *pName, int IsDir, int StorageType, void *pUser);
 	void SetMenuPage(int NewPage);
 	void RefreshBrowserTab(int UiPage);
-	bool HandleListInputs(const CUIRect &View, float &ScrollValue, float ScrollAmount, int *pScrollOffset, float ElemHeight, int &SelectedIndex, int NumElems);
 
 	// found in menus_ingame.cpp
 	void RenderInGameNetwork(CUIRect MainView);

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -14,11 +14,10 @@
 #include <game/client/components/console.h>
 #include <game/client/gameclient.h>
 #include <game/client/render.h>
-#include <game/localization.h>
-
 #include <game/client/ui.h>
-
+#include <game/client/ui_listbox.h>
 #include <game/generated/client_data.h>
+#include <game/localization.h>
 
 #include "maplayers.h"
 #include "menus.h"
@@ -636,246 +635,6 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 	HandleDemoSeeking(PositionToSeek, TimeToSeek);
 }
 
-static CUIRect gs_ListBoxOriginalView;
-static CUIRect gs_ListBoxView;
-static float gs_ListBoxRowHeight;
-static int gs_ListBoxItemIndex;
-static int gs_ListBoxSelectedIndex;
-static int gs_ListBoxNewSelected;
-static int gs_ListBoxDoneEvents;
-static int gs_ListBoxNumItems;
-static int gs_ListBoxItemsPerRow;
-static float gs_ListBoxScrollValue;
-static bool gs_ListBoxItemActivated;
-static bool gs_ListBoxClicked;
-
-void CMenus::UiDoListboxStart(const void *pID, const CUIRect *pRect, float RowHeight, const char *pTitle, const char *pBottomText, int NumItems,
-	int ItemsPerRow, int SelectedIndex, float ScrollValue, bool LogicOnly)
-{
-	CUIRect Scroll, Row;
-	CUIRect View = *pRect;
-
-	if(!LogicOnly)
-	{
-		// background
-		View.Draw(ColorRGBA(0, 0, 0, 0.15f), IGraphics::CORNER_ALL, 5.0f);
-	}
-
-	View.VSplitRight(20.0f, &View, &Scroll);
-
-	// setup the variables
-	gs_ListBoxOriginalView = View;
-	gs_ListBoxSelectedIndex = SelectedIndex;
-	gs_ListBoxNewSelected = SelectedIndex;
-	gs_ListBoxItemIndex = 0;
-	gs_ListBoxRowHeight = RowHeight;
-	gs_ListBoxNumItems = NumItems;
-	gs_ListBoxItemsPerRow = ItemsPerRow;
-	gs_ListBoxDoneEvents = 0;
-	gs_ListBoxScrollValue = ScrollValue;
-	gs_ListBoxItemActivated = false;
-	gs_ListBoxClicked = false;
-
-	// do the scrollbar
-	View.HSplitTop(gs_ListBoxRowHeight, &Row, 0);
-
-	int NumViewable = (int)(gs_ListBoxOriginalView.h / Row.h) * gs_ListBoxItemsPerRow;
-	//int Num = (NumItems + gs_ListBoxItemsPerRow - 1) / gs_ListBoxItemsPerRow - NumViewable + 1;
-	int Num = ceil((NumItems - NumViewable) / (float)gs_ListBoxItemsPerRow);
-	if(Num <= 0)
-	{
-		Num = 0;
-	}
-	else
-	{
-		if(Input()->KeyPress(KEY_MOUSE_WHEEL_UP) && UI()->MouseInside(&View))
-			gs_ListBoxScrollValue -= Num == 1 ? 0.1f : 3.0f / Num;
-		if(Input()->KeyPress(KEY_MOUSE_WHEEL_DOWN) && UI()->MouseInside(&View))
-			gs_ListBoxScrollValue += Num == 1 ? 0.1f : 3.0f / Num;
-	}
-
-	if(Num == 0)
-		gs_ListBoxScrollValue = 0;
-	else
-		gs_ListBoxScrollValue = UI()->DoScrollbarV(pID, &Scroll, gs_ListBoxScrollValue);
-
-	// the list
-	gs_ListBoxView = gs_ListBoxOriginalView;
-	gs_ListBoxView.VMargin(5.0f, &gs_ListBoxView);
-	UI()->ClipEnable(&gs_ListBoxView);
-	gs_ListBoxView.y -= gs_ListBoxScrollValue * Num * Row.h;
-}
-
-CMenus::CListboxItem CMenus::UiDoListboxNextRow()
-{
-	static CUIRect s_RowView;
-	CListboxItem Item = {0};
-	if(gs_ListBoxItemIndex % gs_ListBoxItemsPerRow == 0)
-		gs_ListBoxView.HSplitTop(gs_ListBoxRowHeight /*-2.0f*/, &s_RowView, &gs_ListBoxView);
-
-	s_RowView.VSplitLeft(s_RowView.w / (gs_ListBoxItemsPerRow - gs_ListBoxItemIndex % gs_ListBoxItemsPerRow), &Item.m_Rect, &s_RowView);
-
-	Item.m_Visible = 1;
-	//item.rect = row;
-
-	Item.m_HitRect = Item.m_Rect;
-
-	//CUIRect select_hit_box = item.rect;
-
-	if(gs_ListBoxSelectedIndex == gs_ListBoxItemIndex)
-		Item.m_Selected = 1;
-
-	// make sure that only those in view can be selected
-	if(Item.m_Rect.y + Item.m_Rect.h > gs_ListBoxOriginalView.y)
-	{
-		if(Item.m_HitRect.y < Item.m_HitRect.y) // clip the selection
-		{
-			Item.m_HitRect.h -= gs_ListBoxOriginalView.y - Item.m_HitRect.y;
-			Item.m_HitRect.y = gs_ListBoxOriginalView.y;
-		}
-	}
-	else
-		Item.m_Visible = 0;
-
-	// check if we need to do more
-	if(Item.m_Rect.y > gs_ListBoxOriginalView.y + gs_ListBoxOriginalView.h)
-		Item.m_Visible = 0;
-
-	gs_ListBoxItemIndex++;
-	return Item;
-}
-
-CMenus::CListboxItem CMenus::UiDoListboxNextItem(const void *pId, bool Selected, bool KeyEvents, bool NoHoverEffects)
-{
-	int ThisItemIndex = gs_ListBoxItemIndex;
-	if(Selected)
-	{
-		if(gs_ListBoxSelectedIndex == gs_ListBoxNewSelected)
-			gs_ListBoxNewSelected = ThisItemIndex;
-		gs_ListBoxSelectedIndex = ThisItemIndex;
-	}
-
-	CListboxItem Item = UiDoListboxNextRow();
-
-	CUIRect HitRect = Item.m_HitRect;
-
-	if(HitRect.y < gs_ListBoxOriginalView.y)
-	{
-		float TmpDiff = gs_ListBoxOriginalView.y - HitRect.y;
-		HitRect.y = gs_ListBoxOriginalView.y;
-		HitRect.h -= TmpDiff;
-	}
-
-	HitRect.h = minimum(HitRect.h, (gs_ListBoxOriginalView.y + gs_ListBoxOriginalView.h) - HitRect.y);
-
-	bool DoubleClickable = false;
-	if(Item.m_Visible && UI()->DoButtonLogic(pId, gs_ListBoxSelectedIndex == gs_ListBoxItemIndex, &HitRect))
-	{
-		DoubleClickable |= gs_ListBoxNewSelected == ThisItemIndex;
-		gs_ListBoxClicked = true;
-		gs_ListBoxNewSelected = ThisItemIndex;
-	}
-
-	// process input, regard selected index
-	if(gs_ListBoxSelectedIndex == ThisItemIndex)
-	{
-		if(!gs_ListBoxDoneEvents)
-		{
-			gs_ListBoxDoneEvents = 1;
-
-			if(UI()->ConsumeHotkey(CUI::HOTKEY_ENTER) || (DoubleClickable && Input()->MouseDoubleClick()))
-			{
-				gs_ListBoxItemActivated = true;
-				UI()->SetActiveItem(nullptr);
-			}
-			else if(KeyEvents)
-			{
-				for(int i = 0; i < m_NumInputEvents; i++)
-				{
-					int NewIndex = -1;
-					if(m_aInputEvents[i].m_Flags & IInput::FLAG_PRESS)
-					{
-						if(m_aInputEvents[i].m_Key == KEY_DOWN)
-							NewIndex = gs_ListBoxNewSelected + 1;
-						else if(m_aInputEvents[i].m_Key == KEY_UP)
-							NewIndex = gs_ListBoxNewSelected - 1;
-						else if(m_aInputEvents[i].m_Key == KEY_PAGEUP)
-							NewIndex = maximum(gs_ListBoxNewSelected - 20, 0);
-						else if(m_aInputEvents[i].m_Key == KEY_PAGEDOWN)
-							NewIndex = minimum(gs_ListBoxNewSelected + 20, gs_ListBoxNumItems - 1);
-						else if(m_aInputEvents[i].m_Key == KEY_HOME)
-							NewIndex = 0;
-						else if(m_aInputEvents[i].m_Key == KEY_END)
-							NewIndex = gs_ListBoxNumItems - 1;
-					}
-					if(NewIndex > -1 && NewIndex < gs_ListBoxNumItems)
-					{
-						// scroll
-						float Offset = (NewIndex / gs_ListBoxItemsPerRow - gs_ListBoxNewSelected / gs_ListBoxItemsPerRow) * gs_ListBoxRowHeight;
-						int Scroll = gs_ListBoxOriginalView.y > Item.m_Rect.y + Offset ? -1 :
-														 gs_ListBoxOriginalView.y + gs_ListBoxOriginalView.h < Item.m_Rect.y + Item.m_Rect.h + Offset ? 1 : 0;
-						if(Scroll)
-						{
-							int NumViewable = (int)(gs_ListBoxOriginalView.h / gs_ListBoxRowHeight) + 1;
-							int ScrollNum = (gs_ListBoxNumItems + gs_ListBoxItemsPerRow - 1) / gs_ListBoxItemsPerRow - NumViewable + 1;
-							if(Scroll < 0)
-							{
-								int Num = (gs_ListBoxOriginalView.y - Item.m_Rect.y - Offset + gs_ListBoxRowHeight - 1.0f) / gs_ListBoxRowHeight;
-								gs_ListBoxScrollValue -= (1.0f / ScrollNum) * Num;
-							}
-							else
-							{
-								int Num = (Item.m_Rect.y + Item.m_Rect.h + Offset - (gs_ListBoxOriginalView.y + gs_ListBoxOriginalView.h) + gs_ListBoxRowHeight - 1.0f) /
-									  gs_ListBoxRowHeight;
-								gs_ListBoxScrollValue += (1.0f / ScrollNum) * Num;
-							}
-							if(gs_ListBoxScrollValue < 0.0f)
-								gs_ListBoxScrollValue = 0.0f;
-							if(gs_ListBoxScrollValue > 1.0f)
-								gs_ListBoxScrollValue = 1.0f;
-						}
-
-						gs_ListBoxNewSelected = NewIndex;
-					}
-				}
-			}
-		}
-
-		//selected_index = i;
-		CUIRect r = Item.m_Rect;
-		r.Margin(1.5f, &r);
-		r.Draw(ColorRGBA(1, 1, 1, 0.5f), IGraphics::CORNER_ALL, 4.0f);
-	}
-	else if(UI()->MouseInside(&HitRect) && !NoHoverEffects)
-	{
-		CUIRect r = Item.m_Rect;
-		r.Margin(1.5f, &r);
-		r.Draw(ColorRGBA(1, 1, 1, 0.25f), IGraphics::CORNER_ALL, 4.0f);
-	}
-
-	return Item;
-}
-
-int CMenus::UiDoListboxEnd(float *pScrollValue, bool *pItemActivated, bool *pListBoxActive)
-{
-	UI()->ClipDisable();
-	if(pScrollValue)
-		*pScrollValue = gs_ListBoxScrollValue;
-	if(pItemActivated)
-		*pItemActivated = gs_ListBoxItemActivated;
-	if(pListBoxActive)
-		*pListBoxActive = gs_ListBoxClicked;
-	return gs_ListBoxNewSelected;
-}
-
-int CMenus::UiLogicGetCurrentClickedItem()
-{
-	if(gs_ListBoxClicked)
-		return gs_ListBoxNewSelected;
-	else
-		return -1;
-}
-
 int CMenus::DemolistFetchCallback(const CFsFileInfo *pInfo, int IsDir, int StorageType, void *pUser)
 {
 	CMenus *pSelf = (CMenus *)pUser;
@@ -1206,78 +965,26 @@ void CMenus::RenderDemoList(CUIRect MainView)
 		}
 	}
 
-	// scrollbar
-	CUIRect Scroll;
-	ListBox.VSplitRight(20.0f, &ListBox, &Scroll);
-
-	static float s_ScrollValue = 0;
-	s_ScrollValue = UI()->DoScrollbarV(&s_ScrollValue, &Scroll, s_ScrollValue);
-
-	int PreviousIndex = m_DemolistSelectedIndex;
-	HandleListInputs(ListBox, s_ScrollValue, 3.0f, &m_ScrollOffset, s_aCols[0].m_Rect.h, m_DemolistSelectedIndex, m_vDemos.size());
-	if(PreviousIndex != m_DemolistSelectedIndex)
-	{
-		str_copy(g_Config.m_UiDemoSelected, m_vDemos[m_DemolistSelectedIndex].m_aName);
-		DemolistOnUpdate(false);
-	}
-
-	// set clipping
-	UI()->ClipEnable(&ListBox);
-
-	CUIRect OriginalView = ListBox;
-	int Num = (int)(ListBox.h / s_aCols[0].m_Rect.h) + 1;
-	int ScrollNum = maximum<int>(m_vDemos.size() - Num + 1, 0);
-	ListBox.y -= s_ScrollValue * ScrollNum * s_aCols[0].m_Rect.h;
+	static CListBox s_ListBox;
+	s_ListBox.DoStart(ms_ListheaderHeight, m_vDemos.size(), 1, 3, m_DemolistSelectedIndex, &ListBox, false);
 
 	int ItemIndex = -1;
-	bool DoubleClicked = false;
-
 	for(auto &Item : m_vDemos)
 	{
 		ItemIndex++;
 
-		CUIRect Row;
-		ListBox.HSplitTop(ms_ListheaderHeight, &Row, &ListBox);
-
-		int Selected = ItemIndex == m_DemolistSelectedIndex;
-
-		// make sure that only those in view can be selected
-		if(Row.y + Row.h > OriginalView.y && Row.y < OriginalView.y + OriginalView.h)
-		{
-			if(Selected)
-			{
-				CUIRect Rect = Row;
-				Rect.Margin(0.5f, &Rect);
-				Rect.Draw(ColorRGBA(1, 1, 1, 0.5f), IGraphics::CORNER_ALL, 4.0f);
-			}
-			else if(UI()->MouseHovered(&Row))
-			{
-				CUIRect Rect = Row;
-				Rect.Margin(0.5f, &Rect);
-				Rect.Draw(ColorRGBA(1, 1, 1, 0.25f), IGraphics::CORNER_ALL, 4.0f);
-			}
-
-			if(UI()->DoButtonLogic(Item.m_aName, Selected, &Row))
-			{
-				DoubleClicked |= ItemIndex == m_DoubleClickIndex;
-				str_copy(g_Config.m_UiDemoSelected, Item.m_aName);
-				DemolistOnUpdate(false);
-				m_DoubleClickIndex = ItemIndex;
-			}
-		}
-		else
-		{
-			// don't render invisible items
+		const CListboxItem ListItem = s_ListBox.DoNextItem(&Item, ItemIndex == m_DemolistSelectedIndex);
+		if(!ListItem.m_Visible)
 			continue;
-		}
 
+		CUIRect Row = ListItem.m_Rect;
 		CUIRect FileIcon;
 		Row.VSplitLeft(Row.h, &FileIcon, &Row);
 		Row.VSplitLeft(5.0f, 0, &Row);
 		FileIcon.Margin(1.0f, &FileIcon);
 		FileIcon.x += 2.0f;
-		const char *pIconType;
 
+		const char *pIconType;
 		if(str_comp(Item.m_aFilename, "..") == 0)
 			pIconType = "\xEF\xA0\x82";
 		else if(Item.m_IsDir)
@@ -1338,13 +1045,13 @@ void CMenus::RenderDemoList(CUIRect MainView)
 		}
 	}
 
-	UI()->ClipDisable();
-
-	bool Activated = false;
-	if(UI()->ConsumeHotkey(CUI::HOTKEY_ENTER) || (DoubleClicked && Input()->MouseDoubleClick()))
+	const int NewSelected = s_ListBox.DoEnd();
+	if(NewSelected != m_DemolistSelectedIndex)
 	{
-		UI()->SetActiveItem(nullptr);
-		Activated = true;
+		m_DemolistSelectedIndex = NewSelected;
+		if(m_DemolistSelectedIndex >= 0)
+			str_copy(g_Config.m_UiDemoSelected, m_vDemos[m_DemolistSelectedIndex].m_aName);
+		DemolistOnUpdate(false);
 	}
 
 	static CButtonContainer s_RefreshButton;
@@ -1362,7 +1069,7 @@ void CMenus::RenderDemoList(CUIRect MainView)
 	}
 
 	static CButtonContainer s_PlayButton;
-	if(DoButton_Menu(&s_PlayButton, m_DemolistSelectedIsDir ? Localize("Open") : Localize("Play", "Demo browser"), 0, &PlayRect) || Activated || (Input()->KeyPress(KEY_P) && m_pClient->m_GameConsole.IsClosed() && m_DemoPlayerState == DEMOPLAYER_NONE))
+	if(DoButton_Menu(&s_PlayButton, m_DemolistSelectedIsDir ? Localize("Open") : Localize("Play", "Demo browser"), 0, &PlayRect) || s_ListBox.WasItemActivated() || UI()->ConsumeHotkey(CUI::HOTKEY_ENTER) || (Input()->KeyPress(KEY_P) && m_pClient->m_GameConsole.IsClosed() && m_DemoPlayerState == DEMOPLAYER_NONE))
 	{
 		if(m_DemolistSelectedIndex >= 0)
 		{

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -21,6 +21,7 @@
 #include <game/client/gameclient.h>
 #include <game/client/render.h>
 #include <game/client/ui.h>
+#include <game/client/ui_listbox.h>
 #include <game/client/ui_scrollregion.h>
 #include <game/localization.h>
 
@@ -242,16 +243,15 @@ void CMenus::RenderPlayers(CUIRect MainView)
 	ButtonBar.VSplitLeft(Width, &Button, &ButtonBar);
 	RenderTools()->RenderIcon(IMAGE_GUIICONS, SPRITE_GUIICON_MUTE, &Button);
 
-	ButtonBar.VSplitLeft(20.0f, 0, &ButtonBar);
+	ButtonBar.VSplitLeft(20.0f, nullptr, &ButtonBar);
 	ButtonBar.VSplitLeft(Width, &Button, &ButtonBar);
 	RenderTools()->RenderIcon(IMAGE_GUIICONS, SPRITE_GUIICON_EMOTICON_MUTE, &Button);
 
-	ButtonBar.VSplitLeft(20.0f, 0, &ButtonBar);
+	ButtonBar.VSplitLeft(20.0f, nullptr, &ButtonBar);
 	ButtonBar.VSplitLeft(Width, &Button, &ButtonBar);
 	RenderTools()->RenderIcon(IMAGE_GUIICONS, SPRITE_GUIICON_FRIEND, &Button);
 
 	int TotalPlayers = 0;
-
 	for(const auto &pInfoByName : m_pClient->m_Snap.m_apInfoByName)
 	{
 		if(!pInfoByName)
@@ -265,14 +265,11 @@ void CMenus::RenderPlayers(CUIRect MainView)
 		TotalPlayers++;
 	}
 
-	static int s_VoteList = 0;
-	static float s_ScrollValue = 0;
-	CUIRect List = Options;
-	// List.HSplitTop(28.0f, 0, &List);
-	UiDoListboxStart(&s_VoteList, &List, 24.0f, "", "", TotalPlayers, 1, -1, s_ScrollValue);
+	static CListBox s_ListBox;
+	s_ListBox.DoStart(24.0f, TotalPlayers, 1, 3, -1, &Options);
 
 	// options
-	static int s_aPlayerIDs[MAX_CLIENTS][3] = {{0}};
+	static char s_aPlayerIDs[MAX_CLIENTS][3] = {{0}};
 
 	for(int i = 0, Count = 0; i < MAX_CLIENTS; ++i)
 	{
@@ -280,25 +277,27 @@ void CMenus::RenderPlayers(CUIRect MainView)
 			continue;
 
 		int Index = m_pClient->m_Snap.m_apInfoByName[i]->m_ClientID;
-
 		if(Index == m_pClient->m_Snap.m_LocalClientID)
 			continue;
 
-		CListboxItem Item = UiDoListboxNextItem(&m_pClient->m_aClients[Index]);
+		CGameClient::CClientData &CurrentClient = m_pClient->m_aClients[Index];
+		const CListboxItem Item = s_ListBox.DoNextItem(&CurrentClient);
 
 		Count++;
 
 		if(!Item.m_Visible)
 			continue;
 
+		CUIRect Row = Item.m_Rect;
 		if(Count % 2 == 1)
-			Item.m_Rect.Draw(ColorRGBA(1.0f, 1.0f, 1.0f, 0.25f), IGraphics::CORNER_ALL, 10.0f);
-		Item.m_Rect.VSplitRight(300.0f, &Player, &Item.m_Rect);
+			Row.Draw(ColorRGBA(1.0f, 1.0f, 1.0f, 0.25f), IGraphics::CORNER_ALL, 5.0f);
+		Row.VSplitRight(s_ListBox.ScrollbarWidthMax() - s_ListBox.ScrollbarWidth(), &Row, nullptr);
+		Row.VSplitRight(300.0f, &Player, &Row);
 
 		// player info
 		Player.VSplitLeft(28.0f, &Button, &Player);
 
-		CTeeRenderInfo TeeInfo = m_pClient->m_aClients[Index].m_RenderInfo;
+		CTeeRenderInfo TeeInfo = CurrentClient.m_RenderInfo;
 		TeeInfo.m_Size = Button.h;
 
 		CAnimState *pIdleState = CAnimState::GetIdle();
@@ -308,59 +307,57 @@ void CMenus::RenderPlayers(CUIRect MainView)
 
 		RenderTools()->RenderTee(pIdleState, &TeeInfo, EMOTE_NORMAL, vec2(1.0f, 0.0f), TeeRenderPos);
 
-		Player.HSplitTop(1.5f, 0, &Player);
+		Player.HSplitTop(1.5f, nullptr, &Player);
 		Player.VSplitMid(&Player, &Button);
-		Item.m_Rect.VSplitRight(200.0f, &Button2, &Item.m_Rect);
+		Row.VSplitRight(210.0f, &Button2, &Row);
 		CTextCursor Cursor;
 		TextRender()->SetCursor(&Cursor, Player.x, Player.y + (Player.h - 14.f) / 2.f, 14.0f, TEXTFLAG_RENDER | TEXTFLAG_STOP_AT_END);
 		Cursor.m_LineWidth = Player.w;
-		TextRender()->TextEx(&Cursor, m_pClient->m_aClients[Index].m_aName, -1);
+		TextRender()->TextEx(&Cursor, CurrentClient.m_aName, -1);
 
 		TextRender()->SetCursor(&Cursor, Button.x, Button.y + (Button.h - 14.f) / 2.f, 14.0f, TEXTFLAG_RENDER | TEXTFLAG_STOP_AT_END);
 		Cursor.m_LineWidth = Button.w;
-		TextRender()->TextEx(&Cursor, m_pClient->m_aClients[Index].m_aClan, -1);
+		TextRender()->TextEx(&Cursor, CurrentClient.m_aClan, -1);
 
-		// TextRender()->SetCursor(&Cursor, Button2.x,Button2.y, 14.0f, TEXTFLAG_RENDER|TEXTFLAG_STOP_AT_END);
-		// Cursor.m_LineWidth = Button.w;
 		ColorRGBA Color(1.0f, 1.0f, 1.0f, 0.5f);
-		m_pClient->m_CountryFlags.Render(m_pClient->m_aClients[Index].m_Country, &Color,
+		m_pClient->m_CountryFlags.Render(CurrentClient.m_Country, &Color,
 			Button2.x, Button2.y + Button2.h / 2.0f - 0.75f * Button2.h / 2.0f, 1.5f * Button2.h, 0.75f * Button2.h);
 
 		// ignore chat button
-		Item.m_Rect.HMargin(2.0f, &Item.m_Rect);
-		Item.m_Rect.VSplitLeft(Width, &Button, &Item.m_Rect);
-		Button.VSplitLeft((Width - Button.h) / 4.0f, 0, &Button);
-		Button.VSplitLeft(Button.h, &Button, 0);
-		if(g_Config.m_ClShowChatFriends && !m_pClient->m_aClients[Index].m_Friend)
+		Row.HMargin(2.0f, &Row);
+		Row.VSplitLeft(Width, &Button, &Row);
+		Button.VSplitLeft((Width - Button.h) / 4.0f, nullptr, &Button);
+		Button.VSplitLeft(Button.h, &Button, nullptr);
+		if(g_Config.m_ClShowChatFriends && !CurrentClient.m_Friend)
 			DoButton_Toggle(&s_aPlayerIDs[Index][0], 1, &Button, false);
-		else if(DoButton_Toggle(&s_aPlayerIDs[Index][0], m_pClient->m_aClients[Index].m_ChatIgnore, &Button, true))
-			m_pClient->m_aClients[Index].m_ChatIgnore ^= 1;
+		else if(DoButton_Toggle(&s_aPlayerIDs[Index][0], CurrentClient.m_ChatIgnore, &Button, true))
+			CurrentClient.m_ChatIgnore ^= 1;
 
 		// ignore emoticon button
-		Item.m_Rect.VSplitLeft(20.0f, &Button, &Item.m_Rect);
-		Item.m_Rect.VSplitLeft(Width, &Button, &Item.m_Rect);
-		Button.VSplitLeft((Width - Button.h) / 4.0f, 0, &Button);
-		Button.VSplitLeft(Button.h, &Button, 0);
-		if(g_Config.m_ClShowChatFriends && !m_pClient->m_aClients[Index].m_Friend)
+		Row.VSplitLeft(30.0f, nullptr, &Row);
+		Row.VSplitLeft(Width, &Button, &Row);
+		Button.VSplitLeft((Width - Button.h) / 4.0f, nullptr, &Button);
+		Button.VSplitLeft(Button.h, &Button, nullptr);
+		if(g_Config.m_ClShowChatFriends && !CurrentClient.m_Friend)
 			DoButton_Toggle(&s_aPlayerIDs[Index][1], 1, &Button, false);
-		else if(DoButton_Toggle(&s_aPlayerIDs[Index][1], m_pClient->m_aClients[Index].m_EmoticonIgnore, &Button, true))
-			m_pClient->m_aClients[Index].m_EmoticonIgnore ^= 1;
+		else if(DoButton_Toggle(&s_aPlayerIDs[Index][1], CurrentClient.m_EmoticonIgnore, &Button, true))
+			CurrentClient.m_EmoticonIgnore ^= 1;
 
 		// friend button
-		Item.m_Rect.VSplitLeft(20.0f, &Button, &Item.m_Rect);
-		Item.m_Rect.VSplitLeft(Width, &Button, &Item.m_Rect);
-		Button.VSplitLeft((Width - Button.h) / 4.0f, 0, &Button);
-		Button.VSplitLeft(Button.h, &Button, 0);
-		if(DoButton_Toggle(&s_aPlayerIDs[Index][2], m_pClient->m_aClients[Index].m_Friend, &Button, true))
+		Row.VSplitLeft(10.0f, nullptr, &Row);
+		Row.VSplitLeft(Width, &Button, &Row);
+		Button.VSplitLeft((Width - Button.h) / 4.0f, nullptr, &Button);
+		Button.VSplitLeft(Button.h, &Button, nullptr);
+		if(DoButton_Toggle(&s_aPlayerIDs[Index][2], CurrentClient.m_Friend, &Button, true))
 		{
-			if(m_pClient->m_aClients[Index].m_Friend)
-				m_pClient->Friends()->RemoveFriend(m_pClient->m_aClients[Index].m_aName, m_pClient->m_aClients[Index].m_aClan);
+			if(CurrentClient.m_Friend)
+				m_pClient->Friends()->RemoveFriend(CurrentClient.m_aName, CurrentClient.m_aClan);
 			else
-				m_pClient->Friends()->AddFriend(m_pClient->m_aClients[Index].m_aName, m_pClient->m_aClients[Index].m_aClan);
+				m_pClient->Friends()->AddFriend(CurrentClient.m_aName, CurrentClient.m_aClan);
 		}
 	}
 
-	UiDoListboxEnd(&s_ScrollValue, 0);
+	s_ListBox.DoEnd();
 }
 
 void CMenus::RenderServerInfo(CUIRect MainView)
@@ -492,8 +489,6 @@ void CMenus::RenderServerInfo(CUIRect MainView)
 
 bool CMenus::RenderServerControlServer(CUIRect MainView)
 {
-	static int s_VoteList = 0;
-	static float s_ScrollValue = 0;
 	CUIRect List = MainView;
 	int Total = m_pClient->m_Voting.m_NumVoteOptions;
 	int NumVoteOptions = 0;
@@ -508,7 +503,8 @@ bool CMenus::RenderServerControlServer(CUIRect MainView)
 		TotalShown++;
 	}
 
-	UiDoListboxStart(&s_VoteList, &List, 19.0f, "", "", TotalShown, 1, s_CurVoteOption, s_ScrollValue);
+	static CListBox s_ListBox;
+	s_ListBox.DoStart(19.0f, TotalShown, 1, 3, s_CurVoteOption, &List);
 
 	int i = -1;
 	for(CVoteOptionClient *pOption = m_pClient->m_Voting.m_pFirst; pOption; pOption = pOption->m_pNext)
@@ -517,21 +513,23 @@ bool CMenus::RenderServerControlServer(CUIRect MainView)
 		if(m_aFilterString[0] != '\0' && !str_utf8_find_nocase(pOption->m_aDescription, m_aFilterString))
 			continue;
 
-		CListboxItem Item = UiDoListboxNextItem(pOption);
-
-		if(Item.m_Visible)
-			UI()->DoLabel(&Item.m_Rect, pOption->m_aDescription, 13.0f, TEXTALIGN_LEFT);
-
 		if(NumVoteOptions < Total)
 			aIndices[NumVoteOptions] = i;
 		NumVoteOptions++;
+
+		const CListboxItem Item = s_ListBox.DoNextItem(pOption);
+		if(!Item.m_Visible)
+			continue;
+
+		SLabelProperties Props;
+		Props.m_AlignVertically = 0;
+		UI()->DoLabel(&Item.m_Rect, pOption->m_aDescription, 13.0f, TEXTALIGN_LEFT, Props);
 	}
 
-	bool Call;
-	s_CurVoteOption = UiDoListboxEnd(&s_ScrollValue, &Call);
+	s_CurVoteOption = s_ListBox.DoEnd();
 	if(s_CurVoteOption < Total)
 		m_CallvoteSelectedOption = aIndices[s_CurVoteOption];
-	return Call;
+	return s_ListBox.WasItemActivated();
 }
 
 bool CMenus::RenderServerControlKick(CUIRect MainView, bool FilterSpectators)
@@ -556,36 +554,36 @@ bool CMenus::RenderServerControlKick(CUIRect MainView, bool FilterSpectators)
 		aPlayerIDs[NumOptions++] = Index;
 	}
 
-	static int s_VoteList = 0;
-	static float s_ScrollValue = 0;
-	CUIRect List = MainView;
-	UiDoListboxStart(&s_VoteList, &List, 24.0f, "", "", NumOptions, 1, Selected, s_ScrollValue);
+	static CListBox s_ListBox;
+	s_ListBox.DoStart(24.0f, NumOptions, 1, 3, Selected, &MainView);
 
 	for(int i = 0; i < NumOptions; i++)
 	{
-		CListboxItem Item = UiDoListboxNextItem(&aPlayerIDs[i]);
+		const CListboxItem Item = s_ListBox.DoNextItem(&aPlayerIDs[i]);
+		if(!Item.m_Visible)
+			continue;
 
-		if(Item.m_Visible)
-		{
-			CTeeRenderInfo TeeInfo = m_pClient->m_aClients[aPlayerIDs[i]].m_RenderInfo;
-			TeeInfo.m_Size = Item.m_Rect.h;
+		CUIRect TeeRect, Label;
+		Item.m_Rect.VSplitLeft(Item.m_Rect.h, &TeeRect, &Label);
 
-			CAnimState *pIdleState = CAnimState::GetIdle();
-			vec2 OffsetToMid;
-			RenderTools()->GetRenderTeeOffsetToRenderedTee(pIdleState, &TeeInfo, OffsetToMid);
-			vec2 TeeRenderPos(Item.m_Rect.x + Item.m_Rect.h / 2, Item.m_Rect.y + Item.m_Rect.h / 2 + OffsetToMid.y);
+		CTeeRenderInfo TeeInfo = m_pClient->m_aClients[aPlayerIDs[i]].m_RenderInfo;
+		TeeInfo.m_Size = TeeRect.h;
 
-			RenderTools()->RenderTee(pIdleState, &TeeInfo, EMOTE_NORMAL, vec2(1.0f, 0.0f), TeeRenderPos);
+		CAnimState *pIdleState = CAnimState::GetIdle();
+		vec2 OffsetToMid;
+		RenderTools()->GetRenderTeeOffsetToRenderedTee(pIdleState, &TeeInfo, OffsetToMid);
+		vec2 TeeRenderPos(TeeRect.x + TeeInfo.m_Size / 2, TeeRect.y + TeeInfo.m_Size / 2 + OffsetToMid.y);
 
-			Item.m_Rect.x += TeeInfo.m_Size;
-			UI()->DoLabel(&Item.m_Rect, m_pClient->m_aClients[aPlayerIDs[i]].m_aName, 16.0f, TEXTALIGN_LEFT);
-		}
+		RenderTools()->RenderTee(pIdleState, &TeeInfo, EMOTE_NORMAL, vec2(1.0f, 0.0f), TeeRenderPos);
+
+		SLabelProperties Props;
+		Props.m_AlignVertically = 0;
+		UI()->DoLabel(&Item.m_Rect, m_pClient->m_aClients[aPlayerIDs[i]].m_aName, 16.0f, TEXTALIGN_LEFT, Props);
 	}
 
-	bool Call;
-	Selected = UiDoListboxEnd(&s_ScrollValue, &Call);
+	Selected = s_ListBox.DoEnd();
 	m_CallvoteSelectedPlayer = Selected != -1 ? aPlayerIDs[Selected] : -1;
-	return Call;
+	return s_ListBox.WasItemActivated();
 }
 
 void CMenus::RenderServerControl(CUIRect MainView)
@@ -1007,70 +1005,37 @@ void CMenus::RenderGhost(CUIRect MainView)
 
 	View.Draw(ColorRGBA(0, 0, 0, 0.15f), 0, 0);
 
-	CUIRect Scroll;
-	View.VSplitRight(20.0f, &View, &Scroll);
-
-	static float s_ScrollValue = 0;
-	s_ScrollValue = UI()->DoScrollbarV(&s_ScrollValue, &Scroll, s_ScrollValue);
-
-	int NumGhosts = m_vGhosts.size();
+	const int NumGhosts = m_vGhosts.size();
 	static int s_SelectedIndex = 0;
-	HandleListInputs(View, s_ScrollValue, 1.0f, nullptr, s_aCols[0].m_Rect.h, s_SelectedIndex, NumGhosts);
-
-	// set clipping
-	UI()->ClipEnable(&View);
-
-	CUIRect OriginalView = View;
-	int Num = (int)(View.h / s_aCols[0].m_Rect.h) + 1;
-	int ScrollNum = maximum(NumGhosts - Num + 1, 0);
-	View.y -= s_ScrollValue * ScrollNum * s_aCols[0].m_Rect.h;
-
-	int NewSelected = -1;
-	bool DoubleClicked = false;
+	static CListBox s_ListBox;
+	s_ListBox.DoStart(17.0f, NumGhosts, 1, 3, s_SelectedIndex, &View, false);
 
 	for(int i = 0; i < NumGhosts; i++)
 	{
-		const CGhostItem *pItem = &m_vGhosts[i];
-		CUIRect Row;
-		View.HSplitTop(17.0f, &Row, &View);
-
-		// make sure that only those in view can be selected
-		if(Row.y + Row.h > OriginalView.y && Row.y < OriginalView.y + OriginalView.h)
-		{
-			if(i == s_SelectedIndex)
-			{
-				CUIRect r = Row;
-				r.Margin(1.5f, &r);
-				r.Draw(ColorRGBA(1, 1, 1, 0.5f), IGraphics::CORNER_ALL, 4.0f);
-			}
-
-			if(UI()->DoButtonLogic(pItem, 0, &Row))
-			{
-				NewSelected = i;
-				DoubleClicked |= NewSelected == m_DoubleClickIndex;
-				m_DoubleClickIndex = NewSelected;
-			}
-		}
+		const CGhostItem *pGhost = &m_vGhosts[i];
+		const CListboxItem Item = s_ListBox.DoNextItem(pGhost);
+		if(!Item.m_Visible)
+			continue;
 
 		ColorRGBA rgb = ColorRGBA(1.0f, 1.0f, 1.0f);
-		if(pItem->m_Own)
+		if(pGhost->m_Own)
 			rgb = color_cast<ColorRGBA>(ColorHSLA(0.33f, 1.0f, 0.75f));
 
-		TextRender()->TextColor(rgb.WithAlpha(pItem->HasFile() ? 1.0f : 0.5f));
+		TextRender()->TextColor(rgb.WithAlpha(pGhost->HasFile() ? 1.0f : 0.5f));
 
 		for(int c = 0; c < NumCols; c++)
 		{
 			CUIRect Button;
 			Button.x = s_aCols[c].m_Rect.x;
-			Button.y = Row.y;
-			Button.h = Row.h;
+			Button.y = Item.m_Rect.y;
+			Button.h = Item.m_Rect.h;
 			Button.w = s_aCols[c].m_Rect.w;
 
 			int Id = s_aCols[c].m_Id;
 
 			if(Id == COL_ACTIVE)
 			{
-				if(pItem->Active())
+				if(pGhost->Active())
 				{
 					Graphics()->WrapClamp();
 					Graphics()->TextureSet(GameClient()->m_EmoticonsSkin.m_aSpriteEmoticons[(SPRITE_OOP + 7) - SPRITE_OOP]);
@@ -1088,7 +1053,7 @@ void CMenus::RenderGhost(CUIRect MainView)
 				TextRender()->SetCursor(&Cursor, Button.x, Button.y + (Button.h - 12.0f) / 2.f, 12.0f, TEXTFLAG_RENDER | TEXTFLAG_STOP_AT_END);
 				Cursor.m_LineWidth = Button.w;
 
-				TextRender()->TextEx(&Cursor, pItem->m_aPlayer, -1);
+				TextRender()->TextEx(&Cursor, pGhost->m_aPlayer, -1);
 			}
 			else if(Id == COL_TIME)
 			{
@@ -1097,7 +1062,7 @@ void CMenus::RenderGhost(CUIRect MainView)
 				Cursor.m_LineWidth = Button.w;
 
 				char aBuf[64];
-				str_time(pItem->m_Time / 10, TIME_HOURS_CENTISECS, aBuf, sizeof(aBuf));
+				str_time(pGhost->m_Time / 10, TIME_HOURS_CENTISECS, aBuf, sizeof(aBuf));
 				TextRender()->TextEx(&Cursor, aBuf, -1);
 			}
 		}
@@ -1105,10 +1070,7 @@ void CMenus::RenderGhost(CUIRect MainView)
 		TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
 	}
 
-	UI()->ClipDisable();
-
-	if(NewSelected != -1)
-		s_SelectedIndex = NewSelected;
+	s_SelectedIndex = s_ListBox.DoEnd();
 
 	Status.Draw(ColorRGBA(1, 1, 1, 0.25f), IGraphics::CORNER_B, 5.0f);
 	Status.Margin(5.0f, &Status);
@@ -1136,7 +1098,7 @@ void CMenus::RenderGhost(CUIRect MainView)
 
 		static CButtonContainer s_GhostButton;
 		const char *pText = pGhost->Active() ? Localize("Deactivate") : Localize("Activate");
-		if(DoButton_Menu(&s_GhostButton, pText, 0, &Button) || (DoubleClicked && Input()->MouseDoubleClick()))
+		if(DoButton_Menu(&s_GhostButton, pText, 0, &Button) || s_ListBox.WasItemActivated())
 		{
 			if(pGhost->Active())
 			{

--- a/src/game/client/components/menus_start.cpp
+++ b/src/game/client/components/menus_start.cpp
@@ -49,7 +49,6 @@ void CMenus::RenderStartMenu(CUIRect MainView)
 		{
 			dbg_msg("menus", "couldn't open link '%s'", pLink);
 		}
-		m_DoubleClickIndex = -1;
 	}
 
 	ExtMenu.HSplitBottom(5.0f, &ExtMenu, 0); // little space
@@ -62,7 +61,6 @@ void CMenus::RenderStartMenu(CUIRect MainView)
 		{
 			dbg_msg("menus", "couldn't open link '%s'", pLink);
 		}
-		m_DoubleClickIndex = -1;
 	}
 
 	ExtMenu.HSplitBottom(5.0f, &ExtMenu, 0); // little space
@@ -88,7 +86,6 @@ void CMenus::RenderStartMenu(CUIRect MainView)
 			PopupWarning(Localize("Warning"), Localize("Can't find a Tutorial server"), Localize("Ok"), 10s);
 			s_JoinTutorialTime = 0.0f;
 		}
-		m_DoubleClickIndex = -1;
 	}
 
 	ExtMenu.HSplitBottom(5.0f, &ExtMenu, 0); // little space
@@ -101,7 +98,6 @@ void CMenus::RenderStartMenu(CUIRect MainView)
 		{
 			dbg_msg("menus", "couldn't open link '%s'", pLink);
 		}
-		m_DoubleClickIndex = -1;
 	}
 
 	ExtMenu.HSplitBottom(5.0f, &ExtMenu, 0); // little space

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -275,6 +275,14 @@ bool CUI::OnInput(const IInput::CEvent &Event)
 			m_HotkeysPressed |= HOTKEY_SCROLL_UP;
 		else if(Event.m_Key == KEY_MOUSE_WHEEL_DOWN)
 			m_HotkeysPressed |= HOTKEY_SCROLL_DOWN;
+		else if(Event.m_Key == KEY_PAGEUP)
+			m_HotkeysPressed |= HOTKEY_PAGE_UP;
+		else if(Event.m_Key == KEY_PAGEDOWN)
+			m_HotkeysPressed |= HOTKEY_PAGE_DOWN;
+		else if(Event.m_Key == KEY_HOME)
+			m_HotkeysPressed |= HOTKEY_HOME;
+		else if(Event.m_Key == KEY_END)
+			m_HotkeysPressed |= HOTKEY_END;
 		return LastHotkeysPressed != m_HotkeysPressed;
 	}
 	return false;

--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -251,6 +251,10 @@ public:
 		HOTKEY_TAB = 1 << 5,
 		HOTKEY_SCROLL_UP = 1 << 6,
 		HOTKEY_SCROLL_DOWN = 1 << 7,
+		HOTKEY_PAGE_UP = 1 << 8,
+		HOTKEY_PAGE_DOWN = 1 << 9,
+		HOTKEY_HOME = 1 << 10,
+		HOTKEY_END = 1 << 11,
 	};
 
 	void ResetUIElement(CUIElement &UIElement);

--- a/src/game/client/ui_listbox.cpp
+++ b/src/game/client/ui_listbox.cpp
@@ -1,0 +1,254 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#include <base/system.h>
+#include <base/vmath.h>
+
+#include <engine/config.h>
+#include <engine/shared/config.h>
+
+#include <game/localization.h>
+
+#include "ui_listbox.h"
+
+CListBox::CListBox()
+{
+	m_ScrollOffset = vec2(0.0f, 0.0f);
+	m_ListBoxUpdateScroll = false;
+	m_aFilterString[0] = '\0';
+	m_FilterOffset = 0.0f;
+	m_HasHeader = false;
+	m_AutoSpacing = 0.0f;
+	m_ScrollbarIsShown = false;
+}
+
+void CListBox::DoBegin(const CUIRect *pRect)
+{
+	// setup the variables
+	m_ListBoxView = *pRect;
+}
+
+void CListBox::DoHeader(const CUIRect *pRect, const char *pTitle, float HeaderHeight, float Spacing)
+{
+	CUIRect View = *pRect;
+	CUIRect Header;
+
+	// background
+	View.HSplitTop(HeaderHeight + Spacing, &Header, 0);
+	Header.Draw(ColorRGBA(0.0f, 0.0f, 0.0f, 0.15f), m_BackgroundCorners & IGraphics::CORNER_T, 5.0f);
+
+	// draw header
+	View.HSplitTop(HeaderHeight, &Header, &View);
+	SLabelProperties Props;
+	Props.m_AlignVertically = 0;
+	UI()->DoLabel(&Header, pTitle, Header.h * CUI::ms_FontmodHeight * 0.8f, TEXTALIGN_CENTER, Props);
+
+	View.HSplitTop(Spacing, &Header, &View);
+
+	// setup the variables
+	m_ListBoxView = View;
+	m_HasHeader = true;
+}
+
+void CListBox::DoSpacing(float Spacing)
+{
+	CUIRect View = m_ListBoxView;
+	View.HSplitTop(Spacing, 0, &View);
+	m_ListBoxView = View;
+}
+
+bool CListBox::DoFilter(float FilterHeight, float Spacing)
+{
+	CUIRect Filter;
+	CUIRect View = m_ListBoxView;
+
+	// background
+	View.HSplitTop(FilterHeight + Spacing, &Filter, 0);
+	Filter.Draw(ColorRGBA(0.0f, 0.0f, 0.0f, 0.15f), IGraphics::CORNER_NONE, 0.0f);
+
+	// draw filter
+	View.HSplitTop(FilterHeight, &Filter, &View);
+	Filter.Margin(Spacing, &Filter);
+
+	const float FontSize = Filter.h * CUI::ms_FontmodHeight * 0.8f;
+
+	CUIRect Label, EditBox;
+	Filter.VSplitLeft(Filter.w / 5.0f, &Label, &EditBox);
+	Label.y += Spacing;
+	UI()->DoLabel(&Label, Localize("Search:"), FontSize, TEXTALIGN_CENTER);
+	bool Changed = UI()->DoClearableEditBox(m_aFilterString, m_aFilterString + 1, &EditBox, m_aFilterString, sizeof(m_aFilterString), FontSize, &m_FilterOffset);
+
+	View.HSplitTop(Spacing, &Filter, &View);
+
+	m_ListBoxView = View;
+
+	return Changed;
+}
+
+void CListBox::DoFooter(const char *pBottomText, float FooterHeight)
+{
+	m_pBottomText = pBottomText;
+	m_FooterHeight = FooterHeight;
+}
+
+void CListBox::DoStart(float RowHeight, int NumItems, int ItemsPerRow, int RowsPerScroll, int SelectedIndex, const CUIRect *pRect, bool Background, bool *pActive, int BackgroundCorners)
+{
+	CUIRect View;
+	if(pRect)
+		View = *pRect;
+	else
+		View = m_ListBoxView;
+
+	// background
+	m_BackgroundCorners = BackgroundCorners;
+	if(Background)
+		View.Draw(ColorRGBA(0.0f, 0.0f, 0.0f, 0.15f), m_BackgroundCorners & (m_HasHeader ? IGraphics::CORNER_B : IGraphics::CORNER_ALL), 5.0f);
+
+	// draw footers
+	if(m_pBottomText)
+	{
+		CUIRect Footer;
+		View.HSplitBottom(m_FooterHeight, &View, &Footer);
+		Footer.VSplitLeft(10.0f, 0, &Footer);
+		SLabelProperties Props;
+		Props.m_AlignVertically = 0;
+		UI()->DoLabel(&Footer, m_pBottomText, Footer.h * CUI::ms_FontmodHeight * 0.8f, TEXTALIGN_CENTER, Props);
+	}
+
+	// setup the variables
+	m_ListBoxView = View;
+	m_RowView = {};
+	m_ListBoxSelectedIndex = SelectedIndex;
+	m_ListBoxNewSelected = SelectedIndex;
+	m_ListBoxNewSelOffset = 0;
+	m_ListBoxItemIndex = 0;
+	m_ListBoxRowHeight = RowHeight;
+	m_ListBoxNumItems = NumItems;
+	m_ListBoxItemsPerRow = ItemsPerRow;
+	m_ListBoxDoneEvents = false;
+	m_ListBoxItemActivated = false;
+	m_ListBoxItemSelected = false;
+
+	// handle input
+	if(!pActive || *pActive)
+	{
+		if(UI()->ConsumeHotkey(CUI::HOTKEY_DOWN))
+			m_ListBoxNewSelOffset += 1;
+		else if(UI()->ConsumeHotkey(CUI::HOTKEY_UP))
+			m_ListBoxNewSelOffset -= 1;
+		else if(UI()->ConsumeHotkey(CUI::HOTKEY_PAGE_UP))
+			m_ListBoxNewSelOffset = -ItemsPerRow * RowsPerScroll * 4;
+		else if(UI()->ConsumeHotkey(CUI::HOTKEY_PAGE_DOWN))
+			m_ListBoxNewSelOffset = ItemsPerRow * RowsPerScroll * 4;
+		else if(UI()->ConsumeHotkey(CUI::HOTKEY_HOME))
+			m_ListBoxNewSelOffset = 1 - m_ListBoxNumItems;
+		else if(UI()->ConsumeHotkey(CUI::HOTKEY_END))
+			m_ListBoxNewSelOffset = m_ListBoxNumItems - 1;
+	}
+
+	// setup the scrollbar
+	m_ScrollOffset = vec2(0.0f, 0.0f);
+	CScrollRegionParams ScrollParams;
+	ScrollParams.m_ScrollbarWidth = ScrollbarWidthMax();
+	ScrollParams.m_ScrollUnit = (m_ListBoxRowHeight + m_AutoSpacing) * RowsPerScroll;
+	m_ScrollRegion.Begin(&m_ListBoxView, &m_ScrollOffset, &ScrollParams);
+	m_ListBoxView.y += m_ScrollOffset.y;
+}
+
+CListboxItem CListBox::DoNextRow()
+{
+	CListboxItem Item = {};
+
+	if(m_ListBoxItemIndex % m_ListBoxItemsPerRow == 0)
+		m_ListBoxView.HSplitTop(m_ListBoxRowHeight, &m_RowView, &m_ListBoxView);
+	m_ScrollRegion.AddRect(m_RowView);
+	if(m_ListBoxUpdateScroll && m_ListBoxSelectedIndex == m_ListBoxItemIndex)
+	{
+		m_ScrollRegion.ScrollHere(CScrollRegion::SCROLLHERE_KEEP_IN_VIEW);
+		m_ListBoxUpdateScroll = false;
+	}
+
+	m_RowView.VSplitLeft(m_RowView.w / (m_ListBoxItemsPerRow - m_ListBoxItemIndex % m_ListBoxItemsPerRow), &Item.m_Rect, &m_RowView);
+
+	Item.m_Selected = m_ListBoxSelectedIndex == m_ListBoxItemIndex;
+	Item.m_Visible = !m_ScrollRegion.IsRectClipped(Item.m_Rect);
+
+	m_ListBoxItemIndex++;
+	return Item;
+}
+
+CListboxItem CListBox::DoNextItem(const void *pId, bool Selected, bool *pActive)
+{
+	if(m_AutoSpacing > 0.0f && m_ListBoxItemIndex > 0)
+		DoSpacing(m_AutoSpacing);
+
+	const int ThisItemIndex = m_ListBoxItemIndex;
+	if(Selected)
+	{
+		if(m_ListBoxSelectedIndex == m_ListBoxNewSelected)
+			m_ListBoxNewSelected = ThisItemIndex;
+		m_ListBoxSelectedIndex = ThisItemIndex;
+	}
+
+	CListboxItem Item = DoNextRow();
+	bool ItemClicked = false;
+
+	if(Item.m_Visible && UI()->DoButtonLogic(pId, 0, &Item.m_Rect))
+	{
+		ItemClicked = true;
+		m_ListBoxNewSelected = ThisItemIndex;
+		m_ListBoxItemSelected = true;
+		if(pActive)
+			*pActive = true;
+	}
+	else
+		ItemClicked = false;
+
+	const bool ProcessInput = !pActive || *pActive;
+
+	// process input, regard selected index
+	if(m_ListBoxSelectedIndex == ThisItemIndex)
+	{
+		if(ProcessInput && !m_ListBoxDoneEvents)
+		{
+			m_ListBoxDoneEvents = true;
+
+			if(UI()->ConsumeHotkey(CUI::HOTKEY_ENTER) || (ItemClicked && Input()->MouseDoubleClick()))
+			{
+				m_ListBoxItemActivated = true;
+				UI()->SetActiveItem(nullptr);
+			}
+		}
+
+		Item.m_Rect.Draw(ColorRGBA(1.0f, 1.0f, 1.0f, ProcessInput ? 0.5f : 0.33f), IGraphics::CORNER_ALL, 5.0f);
+	}
+	if(UI()->HotItem() == pId && !m_ScrollRegion.IsAnimating())
+	{
+		Item.m_Rect.Draw(ColorRGBA(1.0f, 1.0f, 1.0f, 0.33f), IGraphics::CORNER_ALL, 5.0f);
+	}
+
+	return Item;
+}
+
+CListboxItem CListBox::DoSubheader()
+{
+	CListboxItem Item = DoNextRow();
+	Item.m_Rect.Draw(ColorRGBA(1.0f, 1.0f, 1.0f, 0.2f), IGraphics::CORNER_NONE, 0.0f);
+	return Item;
+}
+
+int CListBox::DoEnd()
+{
+	m_ScrollRegion.End();
+	m_ScrollbarIsShown = m_ScrollRegion.IsScrollbarShown();
+	if(m_ListBoxNewSelOffset != 0 && m_ListBoxSelectedIndex != -1 && m_ListBoxSelectedIndex == m_ListBoxNewSelected)
+	{
+		m_ListBoxNewSelected = clamp(m_ListBoxNewSelected + m_ListBoxNewSelOffset, 0, m_ListBoxNumItems - 1);
+		ScrollToSelected();
+	}
+	return m_ListBoxNewSelected;
+}
+
+bool CListBox::FilterMatches(const char *pNeedle) const
+{
+	return !m_aFilterString[0] || str_find_nocase(pNeedle, m_aFilterString);
+}

--- a/src/game/client/ui_listbox.h
+++ b/src/game/client/ui_listbox.h
@@ -1,0 +1,68 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#ifndef GAME_CLIENT_UI_LISTBOX_H
+#define GAME_CLIENT_UI_LISTBOX_H
+
+#include "ui_scrollregion.h"
+
+struct CListboxItem
+{
+	bool m_Visible;
+	bool m_Selected;
+	CUIRect m_Rect;
+};
+
+// Instances of CListBox must be static, as member addresses are used as UI item IDs
+class CListBox : private CUIElementBase
+{
+private:
+	CUIRect m_ListBoxView;
+	CUIRect m_RowView;
+	float m_ListBoxRowHeight;
+	int m_ListBoxItemIndex;
+	int m_ListBoxSelectedIndex;
+	int m_ListBoxNewSelected;
+	int m_ListBoxNewSelOffset;
+	bool m_ListBoxUpdateScroll;
+	bool m_ListBoxDoneEvents;
+	int m_ListBoxNumItems;
+	int m_ListBoxItemsPerRow;
+	bool m_ListBoxItemSelected;
+	bool m_ListBoxItemActivated;
+	bool m_ScrollbarIsShown;
+	const char *m_pBottomText;
+	float m_FooterHeight;
+	float m_AutoSpacing;
+	CScrollRegion m_ScrollRegion;
+	vec2 m_ScrollOffset;
+	char m_aFilterString[128];
+	float m_FilterOffset;
+	int m_BackgroundCorners;
+	bool m_HasHeader;
+
+protected:
+	CListboxItem DoNextRow();
+
+public:
+	CListBox();
+
+	void DoBegin(const CUIRect *pRect);
+	void DoHeader(const CUIRect *pRect, const char *pTitle, float HeaderHeight = 20.0f, float Spacing = 2.0f);
+	void DoAutoSpacing(float Spacing = 20.0f) { m_AutoSpacing = Spacing; }
+	void DoSpacing(float Spacing = 20.0f);
+	bool DoFilter(float FilterHeight = 20.0f, float Spacing = 2.0f);
+	void DoFooter(const char *pBottomText, float FooterHeight = 20.0f); // call before DoStart to create a footer
+	void DoStart(float RowHeight, int NumItems, int ItemsPerRow, int RowsPerScroll, int SelectedIndex, const CUIRect *pRect = nullptr, bool Background = true, bool *pActive = nullptr, int BackgroundCorners = IGraphics::CORNER_ALL);
+	void ScrollToSelected() { m_ListBoxUpdateScroll = true; }
+	CListboxItem DoNextItem(const void *pID, bool Selected = false, bool *pActive = nullptr);
+	CListboxItem DoSubheader();
+	int DoEnd();
+	bool FilterMatches(const char *pNeedle) const;
+	bool WasItemSelected() const { return m_ListBoxItemSelected; }
+	bool WasItemActivated() const { return m_ListBoxItemActivated; }
+	bool ScrollbarIsShown() const { return m_ScrollbarIsShown; }
+	float ScrollbarWidth() const { return ScrollbarIsShown() ? ScrollbarWidthMax() : 0.0f; }
+	float ScrollbarWidthMax() const { return 20.0f; }
+};
+
+#endif

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -770,8 +770,8 @@ public:
 
 		m_BrushColorEnabled = true;
 
-		m_aFileName[0] = 0;
-		m_aFileSaveName[0] = 0;
+		m_aFileName[0] = '\0';
+		m_aFileSaveName[0] = '\0';
 		m_ValidSaveFilename = false;
 
 		m_PopupEventActivated = false;
@@ -782,17 +782,14 @@ public:
 		m_pFileDialogTitle = nullptr;
 		m_pFileDialogButtonText = nullptr;
 		m_pFileDialogUser = nullptr;
-		m_aFileDialogFileName[0] = 0;
-		m_aFileDialogCurrentFolder[0] = 0;
-		m_aFileDialogCurrentLink[0] = 0;
+		m_aFileDialogFileName[0] = '\0';
+		m_aFileDialogCurrentFolder[0] = '\0';
+		m_aFileDialogCurrentLink[0] = '\0';
+		m_aFilesSelectedName[0] = '\0';
+		m_aFileDialogFilterString[0] = '\0';
 		m_pFileDialogPath = m_aFileDialogCurrentFolder;
-		m_FileDialogActivate = false;
 		m_FileDialogOpening = false;
-		m_FileDialogScrollValue = 0.0f;
 		m_FilesSelectedIndex = -1;
-		m_FilesStartAt = 0;
-		m_FilesCur = 0;
-		m_FilesStopAt = 999;
 
 		m_SelectEntitiesImage = "DDNet";
 
@@ -867,6 +864,7 @@ public:
 
 	CLayerGroup *m_apSavedBrushes[10];
 
+	void RefreshFilteredFileList();
 	void FilelistPopulate(int StorageType);
 	void InvokeFileDialog(int StorageType, int FileType, const char *pTitle, const char *pButtonText,
 		const char *pBasepath, const char *pDefaultName,
@@ -950,12 +948,10 @@ public:
 	char m_aFileDialogFileName[IO_MAX_PATH_LENGTH];
 	char m_aFileDialogCurrentFolder[IO_MAX_PATH_LENGTH];
 	char m_aFileDialogCurrentLink[IO_MAX_PATH_LENGTH];
-	char m_aFileDialogSearchText[64];
-	char m_aFileDialogPrevSearchText[64];
+	char m_aFilesSelectedName[IO_MAX_PATH_LENGTH];
+	char m_aFileDialogFilterString[64];
 	char *m_pFileDialogPath;
-	bool m_FileDialogActivate;
 	int m_FileDialogFileType;
-	float m_FileDialogScrollValue;
 	int m_FilesSelectedIndex;
 	char m_aFileDialogNewFolderName[64];
 	char m_aFileDialogErrString[64];
@@ -971,14 +967,11 @@ public:
 		bool m_IsDir;
 		bool m_IsLink;
 		int m_StorageType;
-		bool m_IsVisible;
 
 		bool operator<(const CFilelistItem &Other) const { return !str_comp(m_aFilename, "..") ? true : !str_comp(Other.m_aFilename, "..") ? false : m_IsDir && !Other.m_IsDir ? true : !m_IsDir && Other.m_IsDir ? false : str_comp_filenames(m_aFilename, Other.m_aFilename) < 0; }
 	};
-	std::vector<CFilelistItem> m_vFileList;
-	int m_FilesStartAt;
-	int m_FilesCur;
-	int m_FilesStopAt;
+	std::vector<CFilelistItem> m_vCompleteFileList;
+	std::vector<const CFilelistItem *> m_vpFilteredFileList;
 
 	std::vector<std::string> m_vSelectEntitiesFiles;
 	std::string m_SelectEntitiesImage;
@@ -1229,7 +1222,6 @@ public:
 	void RenderMenubar(CUIRect Menubar);
 	void RenderFileDialog();
 
-	void AddFileDialogEntry(int Index, CUIRect *pView);
 	void SelectGameLayer();
 	void SortImages();
 	bool SelectLayerByTile();


### PR DESCRIPTION
Replace existing listbox implementations (`CMenus::UiDoListbox*` and `HandleListInputs` functions) with `CListBox` from upstream.

Reimplement additional feature that was already present in ddnet: page up/down, home and end key handling.

Affects the following lists:

- server browser
  - see screenshots for scoreboard
- server browser scoreboard
  - before:
![server-browser-scoreboard old](https://user-images.githubusercontent.com/23437060/211005067-3a08f874-bcb5-40e1-84e8-3f3e8e3133c9.png)
  - after:
![server-browser-scoreboard new](https://user-images.githubusercontent.com/23437060/211005074-5d113fd3-e541-45e6-95d1-4d7f633b4d12.png)
- server browser friends
  - before:
![server-browser-friends old](https://user-images.githubusercontent.com/23437060/211005039-13ef4bda-5be4-4be4-8561-19cde9f487aa.png)
  - after:
![server-browser-friends new](https://user-images.githubusercontent.com/23437060/211005048-d9f74d13-e93d-4a35-b848-bee0c84ea047.png)
- country / region selection popup (server browser filter)
  - before:
![country-popup old](https://user-images.githubusercontent.com/23437060/211004344-04651e63-7931-4e82-8f6b-c0afa6f0ed33.png)
  - after:
![country-popup new](https://user-images.githubusercontent.com/23437060/211004353-866f081b-2444-4184-8194-9468c15460f0.png)
- player skin list
  - before:
![player-skins old](https://user-images.githubusercontent.com/23437060/211004903-88864d5d-17d8-4b23-836a-1ae24a9f36ac.png)
  - after:
![player-skins new](https://user-images.githubusercontent.com/23437060/211004909-a096b98e-e754-4e76-94ff-571a7462ba81.png)
- player country / region list
  - before:
![player-country old](https://user-images.githubusercontent.com/23437060/211004564-fbd7320b-95b5-4d0a-9629-9e511ff70f34.png)
  - after:
![player-country new](https://user-images.githubusercontent.com/23437060/211004571-4f3e1aed-b878-4b84-aa81-fe8edbee6ebd.png)
- theme list
  - before:
![themes new](https://user-images.githubusercontent.com/23437060/211005196-0692fcd1-770f-45a3-9290-2ac1af75e097.png)
  - after:
![themes old](https://user-images.githubusercontent.com/23437060/211005187-48a4436f-df54-43de-a15e-bf4920d99c85.png)
- assets list
  - before:
![assets old](https://user-images.githubusercontent.com/23437060/211004237-41b71b0d-c030-4ea6-9c6b-7be4aae0836b.png)
  - after:
![assets new](https://user-images.githubusercontent.com/23437060/211004251-9be08d8d-4b16-487f-82cc-a40c7e17bc48.png)
- graphics resolutions list
  - before:
![resolutions-dropdown old](https://user-images.githubusercontent.com/23437060/211004941-23105a96-815e-4ee9-b39a-de24dcd9e4e3.png)
  - after:
![resolutions-dropdown new](https://user-images.githubusercontent.com/23437060/211004947-e251ff3e-ece6-4c59-b62c-39ca277461b5.png)
- dropdown menus (e.g. graphics fullscreen mode)
  - see screenshots for graphics resolutions list
- ingame player list
  - before:
![players old](https://user-images.githubusercontent.com/23437060/211004612-f79e892c-2712-4904-9f5e-8ee7909c4a56.png)
  - after:
![players new](https://user-images.githubusercontent.com/23437060/211004632-b6b73c8e-3c14-4d72-8178-a1562bf968f9.png)
  - before (low number): 
![players-few old](https://user-images.githubusercontent.com/23437060/211004760-cd82b93f-b978-484b-a893-a9af2b881848.png)
  - after (low number):
![players-few new](https://user-images.githubusercontent.com/23437060/211004768-b844a98d-19d7-4519-883d-939ca9b4ef89.png)
- vote options list
  - before:
![vote-options old](https://user-images.githubusercontent.com/23437060/211005215-e9db81f2-24f2-48cd-9293-99a957fa372b.png)
  - after:
![vote-options new](https://user-images.githubusercontent.com/23437060/211005229-e9285a12-efb3-4236-9317-377ae0daf834.png)
- kick/specvote lists
  - before:
![kick-spec-vote old](https://user-images.githubusercontent.com/23437060/211004518-d6ed6869-6dda-46a4-a83f-b370c58a5727.png)
  - after:
![kick-spec-vote new](https://user-images.githubusercontent.com/23437060/211004527-5844caf8-6983-49e6-b309-c717a26de0c9.png)
- ghost list
  - before:
![ghosts old](https://user-images.githubusercontent.com/23437060/211004481-7be7d338-77fe-499d-9fba-3721e2d00215.png)
  - after:
![ghosts new](https://user-images.githubusercontent.com/23437060/211004490-d875eaf7-9fb0-4a29-9bbd-0226c7997434.png)
- language list (in settings and in popup on first launch)
  - settings:
    - before: 
![languages-setting old](https://user-images.githubusercontent.com/23437060/211007012-85d16464-6bd6-4444-bd32-57385afeb2c6.png)
    - after:
![languages-setting new](https://user-images.githubusercontent.com/23437060/211007018-faafdb88-9a0c-4e80-9955-0871c7cc4107.png)
  - popup:
    - before:
![languages-popup old](https://user-images.githubusercontent.com/23437060/211006181-2faa36be-3a4c-467b-91c2-2b0b9ea8eed2.png)
    - after:
![languages-popup new](https://user-images.githubusercontent.com/23437060/211006210-f91234f0-9d70-44a2-902d-0c049c63b2ba.png)
- demo browser
  - before:
![demos old](https://user-images.githubusercontent.com/23437060/211004399-c0f49652-cd0d-478c-8b2b-328512d6367b.png)
  - after:
![demos new](https://user-images.githubusercontent.com/23437060/211004406-ee1d2637-4d69-4aec-ba0b-26750bb5bf44.png)
- editor file browser (saving, loading, adding images / sounds)
  - before:
![editor old](https://user-images.githubusercontent.com/23437060/211004451-1d989358-f811-42ba-834f-0344e5e3f280.png)
  - after:
![editor new](https://user-images.githubusercontent.com/23437060/211004459-12c7abc7-4cc5-4610-b7e0-dfc546754c24.png)
  - The search / filename input is also improved so navigating a filtered list works correctly by porting the logic from upstream.

There are minor changes to the visual appearance of some lists, due to changed margins.

The vertical alignment of some list item texts is improved so the text is centered vertically.

Closes #5791.

## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
