### PR TITLE
Add ingame and browser buttons to copy server info to clipboard

### DIFF
--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -1505,6 +1505,7 @@ int CServerInfo::EstimateLatency(int Loc1, int Loc2)
 	}
 	return 99;
 }
+
 bool CServerInfo::ParseLocation(int *pResult, const char *pString)
 {
 	*pResult = LOC_UNKNOWN;
@@ -1533,4 +1534,17 @@ bool CServerInfo::ParseLocation(int *pResult, const char *pString)
 		}
 	}
 	return true;
+}
+
+void CServerInfo::InfoToString(char *pBuffer, int BufferSize) const
+{
+	str_format(
+		pBuffer,
+		BufferSize,
+		"%s\n"
+		"Address: ddnet://%s\n"
+		"My IGN: %s\n",
+		m_aName,
+		m_aAddress,
+		g_Config.m_PlayerName);
 }

--- a/src/engine/serverbrowser.h
+++ b/src/engine/serverbrowser.h
@@ -83,6 +83,7 @@ public:
 
 	static int EstimateLatency(int Loc1, int Loc2);
 	static bool ParseLocation(int *pResult, const char *pString);
+	void InfoToString(char *pBuffer, int BufferSize) const;
 };
 
 class IServerBrowser : public IInterface

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1030,8 +1030,7 @@ void CMenus::RenderServerbrowserServerDetail(CUIRect View)
 	const CServerInfo *pSelectedServer = ServerBrowser()->SortedGet(m_SelectedIndex);
 
 	// split off a piece to use for scoreboard
-	ServerDetails.HSplitTop(90.0f, &ServerDetails, &ServerScoreBoard);
-	ServerDetails.HSplitBottom(2.5f, &ServerDetails, 0x0);
+	ServerDetails.HSplitTop(110.0f, &ServerDetails, &ServerScoreBoard);
 
 	// server details
 	CTextCursor Cursor;
@@ -1043,8 +1042,7 @@ void CMenus::RenderServerbrowserServerDetail(CUIRect View)
 
 	if(pSelectedServer)
 	{
-		ServerDetails.VSplitLeft(5.0f, 0, &ServerDetails);
-		ServerDetails.Margin(3.0f, &ServerDetails);
+		ServerDetails.Margin(5.0f, &ServerDetails);
 
 		CUIRect Row;
 		static CLocConstString s_aLabels[] = {
@@ -1052,17 +1050,28 @@ void CMenus::RenderServerbrowserServerDetail(CUIRect View)
 			"Game type",
 			"Ping"};
 
-		CUIRect LeftColumn;
-		CUIRect RightColumn;
+		// copy info button
+		{
+			CUIRect Button;
+			ServerDetails.HSplitBottom(15.0f, &ServerDetails, &Button);
+			static CButtonContainer s_CopyButton;
+			if(DoButton_Menu(&s_CopyButton, Localize("Copy info"), 0, &Button))
+			{
+				char aInfo[256];
+				pSelectedServer->InfoToString(aInfo, sizeof(aInfo));
+				Input()->SetClipboardText(aInfo);
+			}
+		}
 
-		//
+		ServerDetails.HSplitBottom(2.5f, &ServerDetails, nullptr);
+
+		// favorite checkbox
 		{
 			CUIRect Button;
 			ServerDetails.HSplitBottom(20.0f, &ServerDetails, &Button);
 			CUIRect ButtonAddFav;
 			CUIRect ButtonLeakIp;
 			Button.VSplitMid(&ButtonAddFav, &ButtonLeakIp);
-			ButtonAddFav.VSplitLeft(5.0f, 0, &ButtonAddFav);
 			static int s_AddFavButton = 0;
 			static int s_LeakIpButton = 0;
 			if(DoButton_CheckBox_Tristate(&s_AddFavButton, Localize("Favorite"), pSelectedServer->m_Favorite, &ButtonAddFav))
@@ -1091,7 +1100,7 @@ void CMenus::RenderServerbrowserServerDetail(CUIRect View)
 			}
 		}
 
-		ServerDetails.VSplitLeft(5.0f, 0x0, &ServerDetails);
+		CUIRect LeftColumn, RightColumn;
 		ServerDetails.VSplitLeft(80.0f, &LeftColumn, &RightColumn);
 
 		for(auto &Label : s_aLabels)

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -415,6 +415,21 @@ void CMenus::RenderServerInfo(CUIRect MainView)
 
 	TextRender()->Text(0, ServerInfo.x + x, ServerInfo.y + y, 20, aBuf, 250.0f);
 
+	// copy info button
+	{
+		CUIRect Button;
+		ServerInfo.HSplitBottom(20.0f, &ServerInfo, &Button);
+		Button.VSplitRight(200.0f, &ServerInfo, &Button);
+		static CButtonContainer s_CopyButton;
+		if(DoButton_Menu(&s_CopyButton, Localize("Copy info"), 0, &Button))
+		{
+			char aInfo[256];
+			CurrentServerInfo.InfoToString(aInfo, sizeof(aInfo));
+			Input()->SetClipboardText(aInfo);
+		}
+	}
+
+	// favorite checkbox
 	{
 		CUIRect Button;
 		NETADDR ServerAddr = Client()->ServerAddress();


### PR DESCRIPTION
Add "Copy info" buttons to server browser and ingame menu to copy the server info of the selected/current server to the clipboard.

The margins around the server browser details are improved.

Closes #5440.

Screenshots:
- browser (old):
![browser old](https://user-images.githubusercontent.com/23437060/211093742-b877f1e2-6be0-4827-b1c8-0fd209f697aa.png)
- browser (new):
![browser new](https://user-images.githubusercontent.com/23437060/211093750-f0b3e2c2-8f95-42e1-94bf-ec8b9da4132f.png)
- ingame: 
![ingame](https://user-images.githubusercontent.com/23437060/211093736-04569b8e-96d6-40ab-a37e-8c581f2d8aea.png)


## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
