### PR TITLE
src/engine/shared/datafile.cpp: Re-add #include <base/math.h> for big endian

### DIFF
--- a/src/engine/shared/datafile.cpp
+++ b/src/engine/shared/datafile.cpp
@@ -5,6 +5,7 @@
 
 #include <base/hash_ctxt.h>
 #include <base/log.h>
+#include <base/math.h>
 #include <base/system.h>
 #include <engine/storage.h>
 


### PR DESCRIPTION
This was removed by @Robyt3 in commit 31533d5e2aaa3d071668285af72997d95d631e1c, but it is still used behind `#if defined(CONF_ARCH_ENDIAN_BIG)` at https://github.com/ddnet/ddnet/blob/master/src/engine/shared/datafile.cpp#L145-L147 resulting in:

https://buildd.debian.org/status/fetch.php?pkg=ddnet&arch=s390x&ver=16.4-1&stamp=1665528559&raw=0

```
/<<PKGBUILDDIR>>/src/engine/shared/datafile.cpp: In member function ‘bool CDataFileReader::Open(IStorage*, const char*, int)’:
/<<PKGBUILDDIR>>/src/engine/shared/datafile.cpp:202:56: error: ‘minimum’ was not declared in this scope
  202 |         swap_endian(m_pDataFile->m_pData, sizeof(int), minimum(static_cast<unsigned>(Header.m_Swaplen), Size) / sizeof(int));
      |                                                        ^~~~~~~
```