### PR TITLE
Fix server browser selection not being updated based an address input

### DIFF
--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -183,7 +183,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 	}
 
 	static CListBox s_ListBox;
-	s_ListBox.DoStart(ms_ListheaderHeight, NumServers, 1, 3, m_SelectedIndex, &View, false);
+	s_ListBox.DoStart(ms_ListheaderHeight, NumServers, 1, 3, -1, &View, false);
 
 	int NumPlayers = 0;
 	static int s_PrevSelectedIndex = -1;


### PR DESCRIPTION
The selected server browser entry was not being updated anymore when the server address input is changed manually by the user or when selecting an entry in the LAN server list and then switching back to the Internet list.

Regression from #6240.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
