### PR TITLE
Allow navigating listboxes when no item is currently selected

### DIFF
--- a/src/game/client/ui_listbox.cpp
+++ b/src/game/client/ui_listbox.cpp
@@ -240,9 +240,9 @@ int CListBox::DoEnd()
 {
 	m_ScrollRegion.End();
 	m_ScrollbarIsShown = m_ScrollRegion.IsScrollbarShown();
-	if(m_ListBoxNewSelOffset != 0 && m_ListBoxSelectedIndex != -1 && m_ListBoxSelectedIndex == m_ListBoxNewSelected)
+	if(m_ListBoxNewSelOffset != 0 && m_ListBoxNumItems > 0 && m_ListBoxSelectedIndex == m_ListBoxNewSelected)
 	{
-		m_ListBoxNewSelected = clamp(m_ListBoxNewSelected + m_ListBoxNewSelOffset, 0, m_ListBoxNumItems - 1);
+		m_ListBoxNewSelected = clamp((m_ListBoxNewSelected == -1 ? 0 : m_ListBoxNewSelected) + m_ListBoxNewSelOffset, 0, m_ListBoxNumItems - 1);
 		ScrollToSelected();
 	}
 	return m_ListBoxNewSelected;


### PR DESCRIPTION
It was no longer possible to navigate listboxes (e.g. the server browser) by using keyboard hotkeys when no item is currently selected due to a regression from #6240.

Additionally, it was not possible even before #6240 to start navigating the server browser with the keyboard afer manually clearing the server address input, which is now possible as well.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
