### PR TITLE
Remove remaining extern "C" from codebase

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -257,7 +257,7 @@ if(CMAKE_GENERATOR STREQUAL "Ninja")
 endif()
 
 if(NOT MSVC AND NOT HAIKU)
-  IF(NOT TARGET_OS STREQUAL "mac")
+  if(NOT TARGET_OS STREQUAL "mac")
     if(NOT FUSE_LD STREQUAL OFF)
       add_linker_flag_if_supported(OUR_FLAGS_LINK -fuse-ld=${FUSE_LD})
       if(FLAG_SUPPORTED_fuse_ld_${FUSE_LD})

--- a/src/base/log.cpp
+++ b/src/base/log.cpp
@@ -19,8 +19,6 @@
 #include <android/log.h>
 #endif
 
-extern "C" {
-
 std::atomic<LEVEL> loglevel = LEVEL_INFO;
 std::atomic<ILogger *> global_logger = nullptr;
 thread_local ILogger *scope_logger = nullptr;
@@ -152,7 +150,6 @@ void log_log_color(LEVEL level, LOG_COLOR color, const char *sys, const char *fm
 	va_start(args, fmt);
 	log_log_impl(level, true, color, sys, fmt, args);
 	va_end(args);
-}
 }
 
 #if defined(CONF_PLATFORM_ANDROID)

--- a/src/base/log.h
+++ b/src/base/log.h
@@ -4,10 +4,6 @@
 #include <stdarg.h>
 #include <stdint.h>
 
-#if defined(__cplusplus)
-extern "C" {
-#endif
-
 #ifdef __GNUC__
 #define GNUC_ATTRIBUTE(x) __attribute__(x)
 #else
@@ -93,8 +89,4 @@ void log_log_v(LEVEL level, const char *sys, const char *fmt, va_list args)
  */
 void log_log_color_v(LEVEL level, LOG_COLOR color, const char *sys, const char *fmt, va_list args)
 	GNUC_ATTRIBUTE((format(printf, 4, 0)));
-
-#if defined(__cplusplus)
-}
-#endif
 #endif // BASE_LOG_H

--- a/src/base/logger.h
+++ b/src/base/logger.h
@@ -7,8 +7,6 @@
 #include <mutex>
 #include <vector>
 
-extern "C" {
-
 typedef struct IOINTERNAL *IOHANDLE;
 
 /**
@@ -150,7 +148,6 @@ ILogger *log_get_scope_logger();
  * @see CLogScope
  */
 void log_set_scope_logger(ILogger *logger);
-}
 
 /**
  * @ingroup Log

--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -83,8 +83,6 @@
 #include <sys/filio.h>
 #endif
 
-extern "C" {
-
 IOHANDLE io_stdin()
 {
 	return (IOHANDLE)stdin;
@@ -4282,7 +4280,6 @@ void set_exception_handler_log_file(const char *log_file_path)
 #endif
 }
 #endif
-}
 
 std::chrono::nanoseconds time_get_nanoseconds()
 {

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -40,8 +40,6 @@
 #include <chrono>
 #include <functional>
 
-extern "C" {
-
 /**
  * @defgroup Debug
  *
@@ -2523,7 +2521,6 @@ int os_version_str(char *version, int length);
 void init_exception_handler();
 void set_exception_handler_log_file(const char *log_file_path);
 #endif
-}
 
 /**
  * Fetches a sample from a high resolution timer and converts it in nanoseconds.

--- a/src/base/unicode/tolower.cpp
+++ b/src/base/unicode/tolower.cpp
@@ -9,7 +9,6 @@ static int compul(const void *a, const void *b)
 	return ul_a->upper - ul_b->upper;
 }
 
-extern "C" {
 int str_utf8_tolower(int code)
 {
 	struct UPPER_LOWER key;
@@ -20,7 +19,6 @@ int str_utf8_tolower(int code)
 	if(res == NULL)
 		return code;
 	return res->lower;
-}
 }
 
 #define TOLOWER_DATA


### PR DESCRIPTION
`IF()` → `if()` in CMakeLists.txt

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
