### PR TITLE
Quit when configured bindaddr cannot be resolved, quit client when failing to open network client for 25 times 

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -3017,16 +3017,16 @@ void CClient::Run()
 	// open socket
 	{
 		NETADDR BindAddr;
-		if(g_Config.m_Bindaddr[0] && net_host_lookup(g_Config.m_Bindaddr, &BindAddr, NETTYPE_ALL) == 0)
-		{
-			// got bindaddr
-			BindAddr.type = NETTYPE_ALL;
-		}
-		else
+		if(g_Config.m_Bindaddr[0] == '\0')
 		{
 			mem_zero(&BindAddr, sizeof(BindAddr));
-			BindAddr.type = NETTYPE_ALL;
 		}
+		else if(net_host_lookup(g_Config.m_Bindaddr, &BindAddr, NETTYPE_ALL) != 0)
+		{
+			dbg_msg("client", "The configured bindaddr '%s' cannot be resolved", g_Config.m_Bindaddr);
+			return;
+		}
+		BindAddr.type = NETTYPE_ALL;
 		for(unsigned int i = 0; i < std::size(m_aNetClient); i++)
 		{
 			int &PortRef = i == CONN_MAIN ? g_Config.m_ClPort : i == CONN_DUMMY ? g_Config.m_ClDummyPort : g_Config.m_ClContactPort;

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -3035,8 +3035,21 @@ void CClient::Run()
 				PortRef = 0;
 			}
 			BindAddr.port = PortRef;
+			unsigned RemainingAttempts = 25;
 			while(BindAddr.port == 0 || !m_aNetClient[i].Open(BindAddr))
 			{
+				if(BindAddr.port != 0)
+				{
+					--RemainingAttempts;
+					if(RemainingAttempts == 0)
+					{
+						if(g_Config.m_Bindaddr[0])
+							dbg_msg("client", "Could not open network client, try changing or unsetting the bindaddr '%s'", g_Config.m_Bindaddr);
+						else
+							dbg_msg("client", "Could not open network client");
+						return;
+					}
+				}
 				BindAddr.port = (secure_rand() % 64511) + 1024;
 			}
 		}

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -967,10 +967,9 @@ void CClient::ServerInfoRequest()
 	m_CurrentServerInfoRequestTime = 0;
 }
 
-int CClient::LoadData()
+void CClient::LoadDebugFont()
 {
 	m_DebugFont = Graphics()->LoadTexture("debug_font.png", IStorage::TYPE_ALL, CImageInfo::FORMAT_AUTO, 0);
-	return 1;
 }
 
 // ---
@@ -3057,9 +3056,7 @@ void CClient::Run()
 	// loads the existing ddnet info file if it exists
 	LoadDDNetInfo();
 
-	// load data
-	if(!LoadData())
-		return;
+	LoadDebugFont();
 
 	if(Steam()->GetPlayerName())
 	{

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -366,7 +366,7 @@ public:
 	void GetServerInfo(CServerInfo *pServerInfo) const override;
 	void ServerInfoRequest();
 
-	int LoadData();
+	void LoadDebugFont();
 
 	// ---
 

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -2568,12 +2568,16 @@ int CServer::Run()
 
 	// start server
 	NETADDR BindAddr;
-	int NetType = Config()->m_SvIpv4Only ? NETTYPE_IPV4 : NETTYPE_ALL;
-
-	if(!Config()->m_Bindaddr[0] || net_host_lookup(Config()->m_Bindaddr, &BindAddr, NetType) != 0)
+	if(g_Config.m_Bindaddr[0] == '\0')
+	{
 		mem_zero(&BindAddr, sizeof(BindAddr));
-
-	BindAddr.type = NetType;
+	}
+	else if(net_host_lookup(g_Config.m_Bindaddr, &BindAddr, NETTYPE_ALL) != 0)
+	{
+		dbg_msg("server", "The configured bindaddr '%s' cannot be resolved", g_Config.m_Bindaddr);
+		return -1;
+	}
+	BindAddr.type = Config()->m_SvIpv4Only ? NETTYPE_IPV4 : NETTYPE_ALL;
 
 	int Port = Config()->m_SvPort;
 	for(BindAddr.port = Port != 0 ? Port : 8303; !m_NetServer.Open(BindAddr, &m_ServerBan, Config()->m_SvMaxClients, Config()->m_SvMaxClientsPerIP); BindAddr.port++)

--- a/src/engine/shared/econ.cpp
+++ b/src/engine/shared/econ.cpp
@@ -64,18 +64,18 @@ void CEcon::Init(CConfig *pConfig, IConsole *pConsole, CNetBan *pNetBan)
 		return;
 
 	NETADDR BindAddr;
-	if(g_Config.m_EcBindaddr[0] && net_host_lookup(g_Config.m_EcBindaddr, &BindAddr, NETTYPE_ALL) == 0)
-	{
-		// got bindaddr
-		BindAddr.type = NETTYPE_ALL;
-		BindAddr.port = g_Config.m_EcPort;
-	}
-	else
+	if(g_Config.m_EcBindaddr[0] == '\0')
 	{
 		mem_zero(&BindAddr, sizeof(BindAddr));
-		BindAddr.type = NETTYPE_ALL;
-		BindAddr.port = g_Config.m_EcPort;
 	}
+	else if(net_host_lookup(g_Config.m_EcBindaddr, &BindAddr, NETTYPE_ALL) != 0)
+	{
+		char aBuf[256];
+		str_format(aBuf, sizeof(aBuf), "The configured bindaddr '%s' cannot be resolved.", g_Config.m_Bindaddr);
+		Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "econ", aBuf);
+	}
+	BindAddr.type = NETTYPE_ALL;
+	BindAddr.port = g_Config.m_EcPort;
 
 	if(m_NetConsole.Open(BindAddr, pNetBan))
 	{


### PR DESCRIPTION


## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
