### PR TITLE
Fix ddnet.org change in UUIDs

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -4065,7 +4065,7 @@ void CClient::InitChecksum()
 }
 
 #ifndef DDNET_CHECKSUM_SALT
-// salt@checksum.ddnet.org: db877f2b-2ddb-3ba6-9f67-a6d169ec671d
+// salt@checksum.ddnet.tw: db877f2b-2ddb-3ba6-9f67-a6d169ec671d
 #define DDNET_CHECKSUM_SALT \
 	{ \
 		{ \

--- a/src/engine/shared/protocol_ex_msgs.h
+++ b/src/engine/shared/protocol_ex_msgs.h
@@ -8,7 +8,7 @@
 //
 // Example:
 //
-// 1) `i-unfreeze-you@ddnet.tw`
+// 1) `i-unfreeze-you@ddnet.org`
 // 2) `creeper@minetee`
 //
 // The first example applies if you own the `ddnet.org` domain, that is, if you


### PR DESCRIPTION
One case was a ddnet.tw UUID's string being changed (but the UUID was not), and the other case is a ddnet.tw UUID's string being changed in one place but not in another in documentation.

Fixes the commit c479230d714725754c93e516e3cde7fb96aac0c8.

CC #5312

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
