### PR TITLE
Don't .gitignore directory called `build`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,7 +82,6 @@ versionsrv
 generated
 target
 
-/build*
 /integration_test/*
 
 # IDE project files


### PR DESCRIPTION
We don't limit support to build directories called `build`, files that are inside the build directory should be in .gitignore instead.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
