### PR TITLE
Make /points private (fixes #6140)

### DIFF
--- a/src/game/server/scoreworker.cpp
+++ b/src/game/server/scoreworker.cpp
@@ -1322,10 +1322,9 @@ bool CScoreWorker::ShowPoints(IDbConnection *pSqlServer, const ISqlData *pGameDa
 		int Count = pSqlServer->GetInt(2);
 		char aName[MAX_NAME_LENGTH];
 		pSqlServer->GetString(3, aName, sizeof(aName));
-		pResult->m_MessageKind = CScorePlayerResult::ALL;
+		pResult->m_MessageKind = CScorePlayerResult::DIRECT;
 		str_format(paMessages[0], sizeof(paMessages[0]),
-			"%d. %s Points: %d, requested by %s",
-			Rank, aName, Count, pData->m_aRequestingPlayer);
+			"%d. %s Points: %d", Rank, aName, Count);
 	}
 	else
 	{

--- a/src/test/score.cpp
+++ b/src/test/score.cpp
@@ -401,7 +401,7 @@ TEST_P(Points, OnePoints)
 {
 	m_pConn->AddPoints("nameless tee", 2, m_aError, sizeof(m_aError));
 	ASSERT_FALSE(CScoreWorker::ShowPoints(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
-	ExpectLines(m_pPlayerResult, {"1. nameless tee Points: 2, requested by brainless tee"}, true);
+	ExpectLines(m_pPlayerResult, {"1. nameless tee Points: 2"});
 }
 
 TEST_P(Points, OnePointsTop)
@@ -419,7 +419,7 @@ TEST_P(Points, TwoPoints)
 	m_pConn->AddPoints("nameless tee", 2, m_aError, sizeof(m_aError));
 	m_pConn->AddPoints("brainless tee", 3, m_aError, sizeof(m_aError));
 	ASSERT_FALSE(CScoreWorker::ShowPoints(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
-	ExpectLines(m_pPlayerResult, {"2. nameless tee Points: 2, requested by brainless tee"}, true);
+	ExpectLines(m_pPlayerResult, {"2. nameless tee Points: 2"});
 }
 
 TEST_P(Points, TwoPointsTop)
@@ -440,7 +440,7 @@ TEST_P(Points, EqualPoints)
 	m_pConn->AddPoints("brainless tee", 3, m_aError, sizeof(m_aError));
 	m_pConn->AddPoints("nameless tee", 1, m_aError, sizeof(m_aError));
 	ASSERT_FALSE(CScoreWorker::ShowPoints(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
-	ExpectLines(m_pPlayerResult, {"1. nameless tee Points: 3, requested by brainless tee"}, true);
+	ExpectLines(m_pPlayerResult, {"1. nameless tee Points: 3"});
 }
 
 TEST_P(Points, EqualPointsTop)


### PR DESCRIPTION
Still requires a pretty way to show points in scoreboard as a replacement. 

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
