### PR TITLE
Make color pickers not change selected color as much

### DIFF
--- a/src/base/color.h
+++ b/src/base/color.h
@@ -111,7 +111,7 @@ public:
 
 	unsigned Pack(bool Alpha = true)
 	{
-		return (Alpha ? ((unsigned)(a * 255.0f) << 24) : 0) + ((unsigned)(x * 255.0f) << 16) + ((unsigned)(y * 255.0f) << 8) + (unsigned)(z * 255.0f);
+		return (Alpha ? ((unsigned)round_to_int(a * 255.0f) << 24) : 0) + ((unsigned)round_to_int(x * 255.0f) << 16) + ((unsigned)round_to_int(y * 255.0f) << 8) + (unsigned)round_to_int(z * 255.0f);
 	}
 
 	DerivedT WithAlpha(float alpha)


### PR DESCRIPTION
As described in #5844, sometimes the color kept changing when activating a color picker.

By rounding the color components before packing them into an unsigned, the color only changes very little and only at most once when activating a color picker.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
