### PR TITLE
update scoreboard server info

### DIFF
--- a/src/game/client/components/scoreboard.cpp
+++ b/src/game/client/components/scoreboard.cpp
@@ -292,8 +292,9 @@ void CScoreboard::RenderScoreboard(float x, float y, float w, int Team, const ch
 			{
 				if(m_ServerRecord > 0)
 				{
-					str_time_float(m_ServerRecord, TIME_HOURS, aBuf, sizeof(aBuf));
-					str_format(aBuf, sizeof(aBuf), "%s: %s", Localize("Time"), aBuf);
+					char Time[128] = {0};
+					str_time_float(m_ServerRecord, TIME_HOURS, Time, sizeof(Time));
+					str_format(aBuf, sizeof(aBuf), "%s: %s", Localize("Time"), Time);
 				}
 				else
 					str_copy(aBuf, " ");

--- a/src/game/client/components/scoreboard.cpp
+++ b/src/game/client/components/scoreboard.cpp
@@ -76,9 +76,10 @@ void CScoreboard::RenderGoals(float x, float y, float w)
 		}
 		if(m_pClient->m_Snap.m_pGameInfoObj->m_RoundNum && m_pClient->m_Snap.m_pGameInfoObj->m_RoundCurrent)
 		{
+			float tw;
 			char aBuf[64];
 			str_format(aBuf, sizeof(aBuf), "%s %d/%d", Localize("Round"), m_pClient->m_Snap.m_pGameInfoObj->m_RoundCurrent, m_pClient->m_Snap.m_pGameInfoObj->m_RoundNum);
-			float tw = TextRender()->TextWidth(0, 20.0f, aBuf, -1, -1.0f);
+			tw = TextRender()->TextWidth(0, 20.0f, aBuf, -1, -1.0f);
 			TextRender()->Text(0, x + w - tw - 10.0f, y + (h - 20.f) / 2.f, 20.0f, aBuf, -1.0f);
 		}
 	}

--- a/src/game/client/components/scoreboard.h
+++ b/src/game/client/components/scoreboard.h
@@ -10,6 +10,7 @@
 class CScoreboard : public CComponent
 {
 	void RenderGoals(float x, float y, float w);
+	void RenderServerInfo(float x, float y, float w);
 	void RenderSpectators(float x, float y, float w, float h);
 	void RenderScoreboard(float x, float y, float w, int Team, const char *pTitle, int NumPlayers = -1);
 	void RenderRecordingNotification(float x);


### PR DESCRIPTION
Enables you to view server info in the scoreboard
If you want to check this server's address, now you can check it in scoreboard.
Instead of opening the menu like before.

Now it likes this.
![screen-fix](https://user-images.githubusercontent.com/65482653/212468987-ccbea86a-f91f-4ddc-8a9e-7d8f6bf9c564.png)

# Checklist
- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)