### PR TITLE
Ensure integer wrapping instead of preventing overflow/underflow

### DIFF
--- a/src/engine/shared/snapshot.cpp
+++ b/src/engine/shared/snapshot.cpp
@@ -214,14 +214,12 @@ int CSnapshotDelta::DiffItem(const int *pPast, const int *pCurrent, int *pOut, i
 	return Needed;
 }
 
-bool CSnapshotDelta::UndiffItem(const int *pPast, int *pDiff, int *pOut, int Size, int *pDataRate)
+void CSnapshotDelta::UndiffItem(const int *pPast, int *pDiff, int *pOut, int Size, int *pDataRate)
 {
 	while(Size)
 	{
-		const long OutValue = (long)*pPast + *pDiff;
-		//if(!in_range<long>(OutValue, std::numeric_limits<int>::min(), std::numeric_limits<int>::max()))
-		//	return false;
-		*pOut = (int)OutValue;
+		// addition with wrapping by casting to unsigned
+		*pOut = (unsigned)*pPast + (unsigned)*pDiff;
 
 		if(*pDiff == 0)
 			*pDataRate += 1;
@@ -237,8 +235,6 @@ bool CSnapshotDelta::UndiffItem(const int *pPast, int *pDiff, int *pOut, int Siz
 		pDiff++;
 		Size--;
 	}
-
-	return true;
 }
 
 CSnapshotDelta::CSnapshotDelta()
@@ -446,11 +442,7 @@ int CSnapshotDelta::UnpackDelta(CSnapshot *pFrom, CSnapshot *pTo, const void *pS
 		if(FromIndex != -1)
 		{
 			// we got an update so we need to apply the diff
-			if(!UndiffItem(pFrom->GetItem(FromIndex)->Data(), pData, pNewData, ItemSize / 4, &m_aSnapshotDataRate[Type]))
-			{
-				// TODO: Breaks old client on new server
-				//return -206;
-			}
+			UndiffItem(pFrom->GetItem(FromIndex)->Data(), pData, pNewData, ItemSize / 4, &m_aSnapshotDataRate[Type]);
 		}
 		else // no previous, just copy the pData
 		{

--- a/src/engine/shared/snapshot.h
+++ b/src/engine/shared/snapshot.h
@@ -88,7 +88,7 @@ private:
 	int m_aSnapshotDataUpdates[CSnapshot::MAX_TYPE + 1];
 	CData m_Empty;
 
-	static bool UndiffItem(const int *pPast, int *pDiff, int *pOut, int Size, int *pDataRate);
+	static void UndiffItem(const int *pPast, int *pDiff, int *pOut, int Size, int *pDataRate);
 
 public:
 	static int DiffItem(const int *pPast, const int *pCurrent, int *pOut, int Size);


### PR DESCRIPTION
As the integer overflow/underflow in `UndiffItem` can happen during normal gameplay, we should in this case neither ignore the snapshot delta nor show an error message.

Instead of depending on the particular compiler doing integer wrapping, when integer overflows or underflows occur, we make it part of the design, by casting to `unsigned`, which ensures that integer wrapping is being used.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
