### PR TITLE
Fix build with clang on debian 11

### DIFF
--- a/src/base/vmath.h
+++ b/src/base/vmath.h
@@ -138,7 +138,7 @@ inline vector2_base<float> normalize(const vector2_base<float> &v)
 	return vector2_base<float>(v.x * l, v.y * l);
 }
 
-constexpr inline vector2_base<float> direction(float angle)
+inline vector2_base<float> direction(float angle)
 {
 	return vector2_base<float>(cosf(angle), sinf(angle));
 }


### PR DESCRIPTION
$ clang --version
Debian clang version 11.0.1-2
Target: x86_64-pc-linux-gnu
Thread model: posix
InstalledDir: /usr/bin

Fixes this error

```
In file included from
/home/chiller/Desktop/git/ddnet/src/base/color.h:6: /home/chiller/Desktop/git/ddnet/src/base/vmath.h:141:38: error: constexpr function never produces a constant expression [-Winvalid-constexpr]
constexpr inline vector2_base<float> direction(float angle)
                                     ^
/home/chiller/Desktop/git/ddnet/src/base/vmath.h:143:29: note: non-constexpr function 'cosf' cannot be used in a constant expression
        return vector2_base<float>(cosf(angle), sinf(angle));
                                   ^
/usr/include/x86_64-linux-gnu/bits/mathcalls.h:62:1: note: declared here __MATHCALL_VEC (cos,, (_Mdouble_ __x));
^
/usr/include/math.h:266:3: note: expanded from macro '__MATHCALL_VEC'
  __MATHCALL (function, suffix, args)
  ^
/usr/include/math.h:273:3: note: expanded from macro '__MATHCALL'
  __MATHDECL (_Mdouble_,function,suffix, args)
  ^
/usr/include/math.h:275:3: note: expanded from macro '__MATHDECL'
  __MATHDECL_1(type, function,suffix, args); \
  ^
/usr/include/math.h:283:15: note: expanded from macro '__MATHDECL_1'
  extern type __MATH_PRECNAME(function,suffix) args __THROW
              ^
/usr/include/math.h:303:34: note: expanded from macro '__MATH_PRECNAME'
                                 ^
<scratch space>:34:1: note: expanded from here
cosf
^
1 error generated.
make[2]: *** [CMakeFiles/engine-shared.dir/build.make:173: CMakeFiles/engine-shared.dir/src/engine/shared/console.cpp.o] Error 1 make[1]: *** [CMakeFiles/Makefile2:604:
CMakeFiles/engine-shared.dir/all] Error 2
make: *** [Makefile:171: all] Error 2
```