### PR TITLE
rewrite int64_t to CMask

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1907,6 +1907,7 @@ set_src(ENGINE_INTERFACE GLOB src/engine
   kernel.h
   keys.h
   map.h
+  mask.h
   message.h
   rust.h
   server.h

--- a/src/engine/mask.h
+++ b/src/engine/mask.h
@@ -1,7 +1,7 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
-#ifndef ENGINE_MASK
-#define ENGINE_MASK
+#ifndef ENGINE_MASK_H
+#define ENGINE_MASK_H
 
 #include <cstdint>
 

--- a/src/engine/mask.h
+++ b/src/engine/mask.h
@@ -1,4 +1,4 @@
-/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* (c) DDNet Team. See licence.txt in the root of the distribution for more information.     */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #ifndef ENGINE_MASK_H
 #define ENGINE_MASK_H
@@ -7,69 +7,77 @@
 
 struct CMask
 {
-	int64_t m_aMask;
+	int64_t m_Mask;
 
 	CMask()
 	{
-		m_aMask = -1LL; // all by default
+		m_Mask = -1LL; // all by default
 	}
 
 	CMask(const CMask &) = default;
 
-	CMask(int ClientID)
+	CMask(int ID)
 	{
-		m_aMask = 1LL << ClientID;
+		m_Mask = 1LL << ID;
 	}
 
 	CMask(int64_t Mask)
 	{
-		m_aMask = Mask;
+		m_Mask = Mask;
 	}
 
 	CMask operator~() const
 	{
-		return CMask(~m_aMask);
+		return CMask(~m_Mask);
 	}
 
 	CMask operator^(CMask Mask)
 	{
-		return CMask(m_aMask ^ Mask.m_aMask);
+		return CMask(m_Mask ^ Mask.m_Mask);
 	}
 
 	CMask &operator=(CMask Mask)
 	{
-		m_aMask = Mask.m_aMask;
+		m_Mask = Mask.m_Mask;
 		return *this;
 	}
 
 	CMask operator|(CMask Mask)
 	{
-		return CMask(m_aMask | Mask.m_aMask);
+		return CMask(m_Mask | Mask.m_Mask);
 	}
 
 	void operator|=(CMask Mask)
 	{
-		m_aMask |= Mask.m_aMask;
+		m_Mask |= Mask.m_Mask;
 	}
 
 	CMask operator&(CMask Mask)
 	{
-		return CMask(m_aMask & Mask.m_aMask);
+		return CMask(m_Mask & Mask.m_Mask);
 	}
 
 	void operator&=(CMask Mask)
 	{
-		m_aMask &= Mask.m_aMask;
+		m_Mask &= Mask.m_Mask;
 	}
 
 	bool operator==(CMask Mask)
 	{
-		return m_aMask == Mask.m_aMask;
+		return m_Mask == Mask.m_Mask;
 	}
 
 	bool operator!=(CMask Mask)
 	{
-		return m_aMask != Mask.m_aMask;
+		return m_Mask != Mask.m_Mask;
 	}
 };
+
+inline CMask CMaskAll() { return CMask(); }
+inline CMask CMaskNone() { return ~CMask(); }
+inline CMask CMaskOne(int ID) { return CMask(ID); }
+inline CMask CMaskUnset(CMask Mask, int ID) { return Mask ^ CMaskOne(ID); }
+inline CMask CMaskAllExceptOne(int ID) { return CMaskUnset(CMaskAll(), ID); }
+inline bool CMaskIsSet(CMask Mask, int ID) { return (Mask & CMaskOne(ID)) != CMaskNone(); }
+
 #endif

--- a/src/engine/mask.h
+++ b/src/engine/mask.h
@@ -1,0 +1,75 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#ifndef ENGINE_MASK
+#define ENGINE_MASK
+
+#include <cstdint>
+
+struct CMask
+{
+	int64_t m_aMask;
+
+	CMask()
+	{
+		m_aMask = -1LL; // all by default
+	}
+
+	CMask(const CMask &) = default;
+
+	CMask(int ClientID)
+	{
+		m_aMask = 1LL << ClientID;
+	}
+
+	CMask(int64_t Mask)
+	{
+		m_aMask = Mask;
+	}
+
+	CMask operator~() const
+	{
+		return CMask(~m_aMask);
+	}
+
+	CMask operator^(CMask Mask)
+	{
+		return CMask(m_aMask ^ Mask.m_aMask);
+	}
+
+	CMask &operator=(CMask Mask)
+	{
+		m_aMask = Mask.m_aMask;
+		return *this;
+	}
+
+	CMask operator|(CMask Mask)
+	{
+		return CMask(m_aMask | Mask.m_aMask);
+	}
+
+	void operator|=(CMask Mask)
+	{
+		m_aMask |= Mask.m_aMask;
+	}
+
+	CMask operator&(CMask Mask)
+	{
+		return CMask(m_aMask & Mask.m_aMask);
+	}
+
+	void operator&=(CMask Mask)
+	{
+		m_aMask &= Mask.m_aMask;
+	}
+
+	bool operator==(CMask Mask)
+	{
+		return m_aMask == Mask.m_aMask;
+	}
+
+	bool operator!=(CMask Mask)
+	{
+		return m_aMask != Mask.m_aMask;
+	}
+};
+#endif

--- a/src/game/client/prediction/entities/projectile.cpp
+++ b/src/game/client/prediction/entities/projectile.cpp
@@ -101,7 +101,7 @@ void CProjectile::Tick()
 	{
 		if(m_Explosive && (!pTargetChr || (!m_Freeze || (m_Type == WEAPON_SHOTGUN && Collide))))
 		{
-			GameWorld()->CreateExplosion(ColPos, m_Owner, m_Type, m_Owner == -1, (!pTargetChr ? -1 : pTargetChr->Team()), CMask());
+			GameWorld()->CreateExplosion(ColPos, m_Owner, m_Type, m_Owner == -1, (!pTargetChr ? -1 : pTargetChr->Team()), CMaskAll());
 		}
 		else if(m_Freeze)
 		{
@@ -142,7 +142,7 @@ void CProjectile::Tick()
 			if(m_Owner >= 0)
 				pOwnerChar = GameWorld()->GetCharacterByID(m_Owner);
 
-			GameWorld()->CreateExplosion(ColPos, m_Owner, m_Type, m_Owner == -1, (!pOwnerChar ? -1 : pOwnerChar->Team()), CMask());
+			GameWorld()->CreateExplosion(ColPos, m_Owner, m_Type, m_Owner == -1, (!pOwnerChar ? -1 : pOwnerChar->Team()), CMaskAll());
 		}
 		m_MarkedForDestroy = true;
 	}

--- a/src/game/client/prediction/entities/projectile.cpp
+++ b/src/game/client/prediction/entities/projectile.cpp
@@ -101,7 +101,7 @@ void CProjectile::Tick()
 	{
 		if(m_Explosive && (!pTargetChr || (!m_Freeze || (m_Type == WEAPON_SHOTGUN && Collide))))
 		{
-			GameWorld()->CreateExplosion(ColPos, m_Owner, m_Type, m_Owner == -1, (!pTargetChr ? -1 : pTargetChr->Team()), -1LL);
+			GameWorld()->CreateExplosion(ColPos, m_Owner, m_Type, m_Owner == -1, (!pTargetChr ? -1 : pTargetChr->Team()), CMask());
 		}
 		else if(m_Freeze)
 		{
@@ -142,7 +142,7 @@ void CProjectile::Tick()
 			if(m_Owner >= 0)
 				pOwnerChar = GameWorld()->GetCharacterByID(m_Owner);
 
-			GameWorld()->CreateExplosion(ColPos, m_Owner, m_Type, m_Owner == -1, (!pOwnerChar ? -1 : pOwnerChar->Team()), -1LL);
+			GameWorld()->CreateExplosion(ColPos, m_Owner, m_Type, m_Owner == -1, (!pOwnerChar ? -1 : pOwnerChar->Team()), CMask());
 		}
 		m_MarkedForDestroy = true;
 	}

--- a/src/game/client/prediction/gameworld.cpp
+++ b/src/game/client/prediction/gameworld.cpp
@@ -336,7 +336,7 @@ CEntity *CGameWorld::GetEntity(int ID, int EntityType)
 	return 0;
 }
 
-void CGameWorld::CreateExplosion(vec2 Pos, int Owner, int Weapon, bool NoDamage, int ActivatedTeam, int64_t Mask)
+void CGameWorld::CreateExplosion(vec2 Pos, int Owner, int Weapon, bool NoDamage, int ActivatedTeam, CMask Mask)
 {
 	if(Owner < 0 && m_WorldConfig.m_IsSolo && !(Weapon == WEAPON_SHOTGUN && m_WorldConfig.m_IsDDRace))
 		return;

--- a/src/game/client/prediction/gameworld.h
+++ b/src/game/client/prediction/gameworld.h
@@ -3,6 +3,7 @@
 #ifndef GAME_CLIENT_PREDICTION_GAMEWORLD_H
 #define GAME_CLIENT_PREDICTION_GAMEWORLD_H
 
+#include <engine/mask.h>
 #include <game/gamecore.h>
 #include <game/teamscore.h>
 
@@ -61,7 +62,7 @@ public:
 	CCharacter *GetCharacterByID(int ID) { return (ID >= 0 && ID < MAX_CLIENTS) ? m_apCharacters[ID] : nullptr; }
 
 	// from gamecontext
-	void CreateExplosion(vec2 Pos, int Owner, int Weapon, bool NoDamage, int ActivatedTeam, int64_t Mask);
+	void CreateExplosion(vec2 Pos, int Owner, int Weapon, bool NoDamage, int ActivatedTeam, CMask Mask);
 
 	// for client side prediction
 	struct

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -830,12 +830,12 @@ void CCharacter::TickDeferred()
 		int Events = m_Core.m_TriggeredEvents;
 		int CID = m_pPlayer->GetCID();
 
-		int64_t TeamMask = Teams()->TeamMask(Team(), -1, CID);
+		CMask TeamMask = Teams()->TeamMask(Team(), -1, CID);
 		// Some sounds are triggered client-side for the acting player
 		// so we need to avoid duplicating them
-		int64_t TeamMaskExceptSelf = Teams()->TeamMask(Team(), CID, CID);
+		CMask TeamMaskExceptSelf = Teams()->TeamMask(Team(), CID, CID);
 		// Some are triggered client-side but only on Sixup
-		int64_t TeamMaskExceptSelfIfSixup = Server()->IsSixup(CID) ? TeamMaskExceptSelf : TeamMask;
+		CMask TeamMaskExceptSelfIfSixup = Server()->IsSixup(CID) ? TeamMaskExceptSelf : TeamMask;
 
 		if(Events & COREEVENT_GROUND_JUMP)
 			GameServer()->CreateSound(m_Pos, SOUND_PLAYER_JUMP, TeamMaskExceptSelf);
@@ -2322,7 +2322,7 @@ void CCharacter::Rescue()
 	}
 }
 
-int64_t CCharacter::TeamMask()
+CMask CCharacter::TeamMask()
 {
 	return Teams()->TeamMask(Team(), -1, GetPlayer()->GetCID());
 }

--- a/src/game/server/entities/character.h
+++ b/src/game/server/entities/character.h
@@ -3,6 +3,7 @@
 #ifndef GAME_SERVER_ENTITIES_CHARACTER_H
 #define GAME_SERVER_ENTITIES_CHARACTER_H
 
+#include <engine/mask.h>
 #include <game/server/entity.h>
 #include <game/server/save.h>
 
@@ -85,7 +86,7 @@ public:
 	bool IsAlive() const { return m_Alive; }
 	bool IsPaused() const { return m_Paused; }
 	class CPlayer *GetPlayer() { return m_pPlayer; }
-	int64_t TeamMask();
+	CMask TeamMask();
 
 private:
 	// player controlling this character

--- a/src/game/server/entities/laser.cpp
+++ b/src/game/server/entities/laser.cpp
@@ -27,7 +27,7 @@ CLaser::CLaser(CGameWorld *pGameWorld, vec2 Pos, vec2 Direction, float StartEner
 	m_ZeroEnergyBounceInLastTick = false;
 	m_TuneZone = GameServer()->Collision()->IsTune(GameServer()->Collision()->GetMapIndex(m_Pos));
 	CCharacter *pOwnerChar = GameServer()->GetPlayerChar(m_Owner);
-	m_TeamMask = pOwnerChar ? pOwnerChar->TeamMask() : CmaskNone();
+	m_TeamMask = pOwnerChar ? pOwnerChar->TeamMask() : CMaskNone();
 	m_BelongsToPracticeTeam = pOwnerChar && pOwnerChar->Teams()->IsPractice(pOwnerChar->Team());
 
 	GameWorld()->InsertEntity(this);
@@ -311,7 +311,7 @@ void CLaser::Snap(int SnappingClient)
 	if(pOwnerChar && pOwnerChar->IsAlive())
 		TeamMask = pOwnerChar->TeamMask();
 
-	if(SnappingClient != SERVER_DEMO_CLIENT && !CmaskIsSet(TeamMask, SnappingClient))
+	if(SnappingClient != SERVER_DEMO_CLIENT && !CMaskIsSet(TeamMask, SnappingClient))
 		return;
 
 	if(GameServer()->GetClientVersion(SnappingClient) >= VERSION_DDNET_MULTI_LASER)

--- a/src/game/server/entities/laser.cpp
+++ b/src/game/server/entities/laser.cpp
@@ -27,7 +27,7 @@ CLaser::CLaser(CGameWorld *pGameWorld, vec2 Pos, vec2 Direction, float StartEner
 	m_ZeroEnergyBounceInLastTick = false;
 	m_TuneZone = GameServer()->Collision()->IsTune(GameServer()->Collision()->GetMapIndex(m_Pos));
 	CCharacter *pOwnerChar = GameServer()->GetPlayerChar(m_Owner);
-	m_TeamMask = pOwnerChar ? pOwnerChar->TeamMask() : 0;
+	m_TeamMask = pOwnerChar ? pOwnerChar->TeamMask() : CmaskNone();
 	m_BelongsToPracticeTeam = pOwnerChar && pOwnerChar->Teams()->IsPractice(pOwnerChar->Team());
 
 	GameWorld()->InsertEntity(this);
@@ -303,7 +303,7 @@ void CLaser::Snap(int SnappingClient)
 		return;
 
 	pOwnerChar = nullptr;
-	int64_t TeamMask = -1LL;
+	CMask TeamMask;
 
 	if(m_Owner >= 0)
 		pOwnerChar = GameServer()->GetPlayerChar(m_Owner);

--- a/src/game/server/entities/laser.h
+++ b/src/game/server/entities/laser.h
@@ -3,6 +3,7 @@
 #ifndef GAME_SERVER_ENTITIES_LASER_H
 #define GAME_SERVER_ENTITIES_LASER_H
 
+#include <engine/mask.h>
 #include <game/server/entity.h>
 
 class CLaser : public CEntity
@@ -31,7 +32,7 @@ private:
 	int m_Bounces;
 	int m_EvalTick;
 	int m_Owner;
-	int m_TeamMask;
+	CMask m_TeamMask;
 	bool m_ZeroEnergyBounceInLastTick;
 
 	// DDRace

--- a/src/game/server/entities/projectile.cpp
+++ b/src/game/server/entities/projectile.cpp
@@ -159,9 +159,9 @@ void CProjectile::Tick()
 			for(int i = 0; i < Number; i++)
 			{
 				GameServer()->CreateExplosion(ColPos, m_Owner, m_Type, m_Owner == -1, (!pTargetChr ? -1 : pTargetChr->Team()),
-					(m_Owner != -1) ? TeamMask : -1LL);
+					(m_Owner != -1) ? TeamMask : CmaskAll());
 				GameServer()->CreateSound(ColPos, m_SoundImpact,
-					(m_Owner != -1) ? TeamMask : -1LL);
+					(m_Owner != -1) ? TeamMask : CmaskAll());
 			}
 		}
 		else if(m_Freeze)
@@ -233,7 +233,7 @@ void CProjectile::Tick()
 		}
 		else if(m_Type == WEAPON_GUN)
 		{
-			GameServer()->CreateDamageInd(CurPos, -atan2(m_Direction.x, m_Direction.y), 10, (m_Owner != -1) ? TeamMask : -1LL);
+			GameServer()->CreateDamageInd(CurPos, -atan2(m_Direction.x, m_Direction.y), 10, (m_Owner != -1) ? TeamMask : CMask());
 			m_MarkedForDestroy = true;
 			return;
 		}
@@ -253,16 +253,16 @@ void CProjectile::Tick()
 			if(m_Owner >= 0)
 				pOwnerChar = GameServer()->GetPlayerChar(m_Owner);
 
-			TeamMask = -1LL;
+			TeamMask = CmaskAll();
 			if(pOwnerChar && pOwnerChar->IsAlive())
 			{
 				TeamMask = pOwnerChar->TeamMask();
 			}
 
 			GameServer()->CreateExplosion(ColPos, m_Owner, m_Type, m_Owner == -1, (!pOwnerChar ? -1 : pOwnerChar->Team()),
-				(m_Owner != -1) ? TeamMask : -1LL);
+				(m_Owner != -1) ? TeamMask : CmaskAll());
 			GameServer()->CreateSound(ColPos, m_SoundImpact,
-				(m_Owner != -1) ? TeamMask : -1LL);
+				(m_Owner != -1) ? TeamMask : CmaskAll());
 		}
 		m_MarkedForDestroy = true;
 		return;

--- a/src/game/server/entities/projectile.cpp
+++ b/src/game/server/entities/projectile.cpp
@@ -126,7 +126,7 @@ void CProjectile::Tick()
 	if(m_LifeSpan > -1)
 		m_LifeSpan--;
 
-	int64_t TeamMask = -1LL;
+	CMask TeamMask;
 	bool IsWeaponCollide = false;
 	if(
 		pOwnerChar &&
@@ -326,7 +326,7 @@ void CProjectile::Snap(int SnappingClient)
 	}
 
 	CCharacter *pOwnerChar = 0;
-	int64_t TeamMask = -1LL;
+	CMask TeamMask;
 
 	if(m_Owner >= 0)
 		pOwnerChar = GameServer()->GetPlayerChar(m_Owner);

--- a/src/game/server/entities/projectile.cpp
+++ b/src/game/server/entities/projectile.cpp
@@ -159,9 +159,9 @@ void CProjectile::Tick()
 			for(int i = 0; i < Number; i++)
 			{
 				GameServer()->CreateExplosion(ColPos, m_Owner, m_Type, m_Owner == -1, (!pTargetChr ? -1 : pTargetChr->Team()),
-					(m_Owner != -1) ? TeamMask : CmaskAll());
+					(m_Owner != -1) ? TeamMask : CMaskAll());
 				GameServer()->CreateSound(ColPos, m_SoundImpact,
-					(m_Owner != -1) ? TeamMask : CmaskAll());
+					(m_Owner != -1) ? TeamMask : CMaskAll());
 			}
 		}
 		else if(m_Freeze)
@@ -233,7 +233,7 @@ void CProjectile::Tick()
 		}
 		else if(m_Type == WEAPON_GUN)
 		{
-			GameServer()->CreateDamageInd(CurPos, -atan2(m_Direction.x, m_Direction.y), 10, (m_Owner != -1) ? TeamMask : CMask());
+			GameServer()->CreateDamageInd(CurPos, -atan2(m_Direction.x, m_Direction.y), 10, (m_Owner != -1) ? TeamMask : CMaskAll());
 			m_MarkedForDestroy = true;
 			return;
 		}
@@ -253,16 +253,16 @@ void CProjectile::Tick()
 			if(m_Owner >= 0)
 				pOwnerChar = GameServer()->GetPlayerChar(m_Owner);
 
-			TeamMask = CmaskAll();
+			TeamMask = CMaskAll();
 			if(pOwnerChar && pOwnerChar->IsAlive())
 			{
 				TeamMask = pOwnerChar->TeamMask();
 			}
 
 			GameServer()->CreateExplosion(ColPos, m_Owner, m_Type, m_Owner == -1, (!pOwnerChar ? -1 : pOwnerChar->Team()),
-				(m_Owner != -1) ? TeamMask : CmaskAll());
+				(m_Owner != -1) ? TeamMask : CMaskAll());
 			GameServer()->CreateSound(ColPos, m_SoundImpact,
-				(m_Owner != -1) ? TeamMask : CmaskAll());
+				(m_Owner != -1) ? TeamMask : CMaskAll());
 		}
 		m_MarkedForDestroy = true;
 		return;
@@ -334,7 +334,7 @@ void CProjectile::Snap(int SnappingClient)
 	if(pOwnerChar && pOwnerChar->IsAlive())
 		TeamMask = pOwnerChar->TeamMask();
 
-	if(SnappingClient != SERVER_DEMO_CLIENT && m_Owner != -1 && !CmaskIsSet(TeamMask, SnappingClient))
+	if(SnappingClient != SERVER_DEMO_CLIENT && m_Owner != -1 && !CMaskIsSet(TeamMask, SnappingClient))
 		return;
 
 	CNetObj_DDNetProjectile DDNetProjectile;

--- a/src/game/server/eventhandler.cpp
+++ b/src/game/server/eventhandler.cpp
@@ -49,7 +49,7 @@ void CEventHandler::Snap(int SnappingClient)
 {
 	for(int i = 0; i < m_NumEvents; i++)
 	{
-		if(SnappingClient == SERVER_DEMO_CLIENT || CmaskIsSet(m_aClientMasks[i], SnappingClient))
+		if(SnappingClient == SERVER_DEMO_CLIENT || CMaskIsSet(m_aClientMasks[i], SnappingClient))
 		{
 			CNetEvent_Common *pEvent = (CNetEvent_Common *)&m_aData[m_aOffsets[i]];
 			if(!NetworkClipped(GameServer(), SnappingClient, vec2(pEvent->m_X, pEvent->m_Y)))

--- a/src/game/server/eventhandler.cpp
+++ b/src/game/server/eventhandler.cpp
@@ -22,7 +22,7 @@ void CEventHandler::SetGameServer(CGameContext *pGameServer)
 	m_pGameServer = pGameServer;
 }
 
-void *CEventHandler::Create(int Type, int Size, int64_t Mask)
+void *CEventHandler::Create(int Type, int Size, CMask Mask)
 {
 	if(m_NumEvents == MAX_EVENTS)
 		return 0;

--- a/src/game/server/eventhandler.h
+++ b/src/game/server/eventhandler.h
@@ -5,6 +5,8 @@
 
 #include <stdint.h>
 
+#include <engine/mask.h>
+
 class CEventHandler
 {
 	enum
@@ -16,7 +18,7 @@ class CEventHandler
 	int m_aTypes[MAX_EVENTS]; // TODO: remove some of these arrays
 	int m_aOffsets[MAX_EVENTS];
 	int m_aSizes[MAX_EVENTS];
-	int64_t m_aClientMasks[MAX_EVENTS];
+	CMask m_aClientMasks[MAX_EVENTS];
 	char m_aData[MAX_DATASIZE];
 
 	class CGameContext *m_pGameServer;
@@ -29,7 +31,7 @@ public:
 	void SetGameServer(CGameContext *pGameServer);
 
 	CEventHandler();
-	void *Create(int Type, int Size, int64_t Mask = -1LL);
+	void *Create(int Type, int Size, CMask Mask = {});
 	void Clear();
 	void Snap(int SnappingClient);
 

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -306,9 +306,9 @@ void CGameContext::CreateExplosion(vec2 Pos, int Owner, int Weapon, bool NoDamag
 			int PlayerTeam = pChr->Team();
 			if((GetPlayerChar(Owner) ? GetPlayerChar(Owner)->GrenadeHitDisabled() : !g_Config.m_SvHit) || NoDamage)
 			{
-				if(!CmaskIsSet(TeamMask, PlayerTeam))
+				if(!CMaskIsSet(TeamMask, PlayerTeam))
 					continue;
-				TeamMask = CmaskUnset(TeamMask, PlayerTeam);
+				TeamMask = CMaskUnset(TeamMask, PlayerTeam);
 			}
 
 			pChr->TakeDamage(ForceDir * Dmg * 2, (int)Dmg, Owner, Weapon);
@@ -4180,12 +4180,12 @@ int CGameContext::GetClientVersion(int ClientID) const
 
 CMask CGameContext::ClientsMaskExcludeClientVersionAndHigher(int Version)
 {
-	CMask Mask = CmaskNone();
+	CMask Mask = CMaskNone();
 	for(int i = 0; i < MAX_CLIENTS; ++i)
 	{
 		if(GetClientVersion(i) >= Version)
 			continue;
-		Mask |= CmaskOne(i);
+		Mask |= CMaskOne(i);
 	}
 	return Mask;
 }

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -230,7 +230,7 @@ void CGameContext::FillAntibot(CAntibotRoundData *pData)
 	}
 }
 
-void CGameContext::CreateDamageInd(vec2 Pos, float Angle, int Amount, int64_t Mask)
+void CGameContext::CreateDamageInd(vec2 Pos, float Angle, int Amount, CMask Mask)
 {
 	float a = 3 * pi / 2 + Angle;
 	//float a = get_angle(dir);
@@ -249,7 +249,7 @@ void CGameContext::CreateDamageInd(vec2 Pos, float Angle, int Amount, int64_t Ma
 	}
 }
 
-void CGameContext::CreateHammerHit(vec2 Pos, int64_t Mask)
+void CGameContext::CreateHammerHit(vec2 Pos, CMask Mask)
 {
 	// create the event
 	CNetEvent_HammerHit *pEvent = (CNetEvent_HammerHit *)m_Events.Create(NETEVENTTYPE_HAMMERHIT, sizeof(CNetEvent_HammerHit), Mask);
@@ -260,7 +260,7 @@ void CGameContext::CreateHammerHit(vec2 Pos, int64_t Mask)
 	}
 }
 
-void CGameContext::CreateExplosion(vec2 Pos, int Owner, int Weapon, bool NoDamage, int ActivatedTeam, int64_t Mask)
+void CGameContext::CreateExplosion(vec2 Pos, int Owner, int Weapon, bool NoDamage, int ActivatedTeam, CMask Mask)
 {
 	// create the event
 	CNetEvent_Explosion *pEvent = (CNetEvent_Explosion *)m_Events.Create(NETEVENTTYPE_EXPLOSION, sizeof(CNetEvent_Explosion), Mask);
@@ -275,7 +275,7 @@ void CGameContext::CreateExplosion(vec2 Pos, int Owner, int Weapon, bool NoDamag
 	float Radius = 135.0f;
 	float InnerRadius = 48.0f;
 	int Num = m_World.FindEntities(Pos, Radius, apEnts, MAX_CLIENTS, CGameWorld::ENTTYPE_CHARACTER);
-	int64_t TeamMask = -1;
+	CMask TeamMask;
 	for(int i = 0; i < Num; i++)
 	{
 		auto *pChr = static_cast<CCharacter *>(apEnts[i]);
@@ -316,7 +316,7 @@ void CGameContext::CreateExplosion(vec2 Pos, int Owner, int Weapon, bool NoDamag
 	}
 }
 
-void CGameContext::CreatePlayerSpawn(vec2 Pos, int64_t Mask)
+void CGameContext::CreatePlayerSpawn(vec2 Pos, CMask Mask)
 {
 	// create the event
 	CNetEvent_Spawn *pEvent = (CNetEvent_Spawn *)m_Events.Create(NETEVENTTYPE_SPAWN, sizeof(CNetEvent_Spawn), Mask);
@@ -327,7 +327,7 @@ void CGameContext::CreatePlayerSpawn(vec2 Pos, int64_t Mask)
 	}
 }
 
-void CGameContext::CreateDeath(vec2 Pos, int ClientID, int64_t Mask)
+void CGameContext::CreateDeath(vec2 Pos, int ClientID, CMask Mask)
 {
 	// create the event
 	CNetEvent_Death *pEvent = (CNetEvent_Death *)m_Events.Create(NETEVENTTYPE_DEATH, sizeof(CNetEvent_Death), Mask);
@@ -339,7 +339,7 @@ void CGameContext::CreateDeath(vec2 Pos, int ClientID, int64_t Mask)
 	}
 }
 
-void CGameContext::CreateSound(vec2 Pos, int Sound, int64_t Mask)
+void CGameContext::CreateSound(vec2 Pos, int Sound, CMask Mask)
 {
 	if(Sound < 0)
 		return;
@@ -4178,14 +4178,14 @@ int CGameContext::GetClientVersion(int ClientID) const
 	return Server()->GetClientVersion(ClientID);
 }
 
-int64_t CGameContext::ClientsMaskExcludeClientVersionAndHigher(int Version)
+CMask CGameContext::ClientsMaskExcludeClientVersionAndHigher(int Version)
 {
-	int64_t Mask = 0;
+	CMask Mask = CmaskNone();
 	for(int i = 0; i < MAX_CLIENTS; ++i)
 	{
 		if(GetClientVersion(i) >= Version)
 			continue;
-		Mask |= 1LL << i;
+		Mask |= CmaskOne(i);
 	}
 	return Mask;
 }

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -4,6 +4,7 @@
 #define GAME_SERVER_GAMECONTEXT_H
 
 #include <engine/console.h>
+#include <engine/mask.h>
 #include <engine/server.h>
 
 #include <game/collision.h>
@@ -205,12 +206,12 @@ public:
 	CVoteOptionServer *m_pVoteOptionLast;
 
 	// helper functions
-	void CreateDamageInd(vec2 Pos, float AngleMod, int Amount, int64_t Mask = -1);
-	void CreateExplosion(vec2 Pos, int Owner, int Weapon, bool NoDamage, int ActivatedTeam, int64_t Mask);
-	void CreateHammerHit(vec2 Pos, int64_t Mask = -1);
-	void CreatePlayerSpawn(vec2 Pos, int64_t Mask = -1);
-	void CreateDeath(vec2 Pos, int ClientID, int64_t Mask = -1);
-	void CreateSound(vec2 Pos, int Sound, int64_t Mask = -1);
+	void CreateDamageInd(vec2 Pos, float AngleMod, int Amount, CMask Mask = {});
+	void CreateExplosion(vec2 Pos, int Owner, int Weapon, bool NoDamage, int ActivatedTeam, CMask Mask = {});
+	void CreateHammerHit(vec2 Pos, CMask Mask = {});
+	void CreatePlayerSpawn(vec2 Pos, CMask Mask = {});
+	void CreateDeath(vec2 Pos, int ClientID, CMask Mask = {});
+	void CreateSound(vec2 Pos, int Sound, CMask Mask = {});
 	void CreateSoundGlobal(int Sound, int Target = -1);
 
 	enum
@@ -296,7 +297,7 @@ public:
 	int64_t m_NonEmptySince;
 	int64_t m_LastMapVote;
 	int GetClientVersion(int ClientID) const;
-	int64_t ClientsMaskExcludeClientVersionAndHigher(int Version);
+	CMask ClientsMaskExcludeClientVersionAndHigher(int Version);
 	bool PlayerExists(int ClientID) const override { return m_apPlayers[ClientID]; }
 	// Returns true if someone is actively moderating.
 	bool PlayerModerating() const;
@@ -503,9 +504,10 @@ public:
 	void ResetTuning();
 };
 
-inline int64_t CmaskAll() { return -1LL; }
-inline int64_t CmaskOne(int ClientID) { return 1LL << ClientID; }
-inline int64_t CmaskUnset(int64_t Mask, int ClientID) { return Mask ^ CmaskOne(ClientID); }
-inline int64_t CmaskAllExceptOne(int ClientID) { return CmaskUnset(CmaskAll(), ClientID); }
-inline bool CmaskIsSet(int64_t Mask, int ClientID) { return (Mask & CmaskOne(ClientID)) != 0; }
+inline CMask CmaskAll() { return CMask(); }
+inline CMask CmaskNone() { return CMask(0LL); }
+inline CMask CmaskOne(int ClientID) { return CMask(ClientID); }
+inline CMask CmaskUnset(CMask Mask, int ClientID) { return Mask ^ CmaskOne(ClientID); }
+inline CMask CmaskAllExceptOne(int ClientID) { return CmaskUnset(CmaskAll(), ClientID); }
+inline bool CmaskIsSet(CMask Mask, int ClientID) { return (Mask & CmaskOne(ClientID)) != CmaskNone(); }
 #endif

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -505,7 +505,7 @@ public:
 };
 
 inline CMask CmaskAll() { return CMask(); }
-inline CMask CmaskNone() { return CMask(0LL); }
+inline CMask CmaskNone() { return ~CMask(); }
 inline CMask CmaskOne(int ClientID) { return CMask(ClientID); }
 inline CMask CmaskUnset(CMask Mask, int ClientID) { return Mask ^ CmaskOne(ClientID); }
 inline CMask CmaskAllExceptOne(int ClientID) { return CmaskUnset(CmaskAll(), ClientID); }

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -504,10 +504,4 @@ public:
 	void ResetTuning();
 };
 
-inline CMask CmaskAll() { return CMask(); }
-inline CMask CmaskNone() { return ~CMask(); }
-inline CMask CmaskOne(int ClientID) { return CMask(ClientID); }
-inline CMask CmaskUnset(CMask Mask, int ClientID) { return Mask ^ CmaskOne(ClientID); }
-inline CMask CmaskAllExceptOne(int ClientID) { return CmaskUnset(CmaskAll(), ClientID); }
-inline bool CmaskIsSet(CMask Mask, int ClientID) { return (Mask & CmaskOne(ClientID)) != CmaskNone(); }
 #endif

--- a/src/game/server/gamecontroller.cpp
+++ b/src/game/server/gamecontroller.cpp
@@ -724,7 +724,7 @@ int IGameController::ClampTeam(int Team)
 CMask IGameController::GetMaskForPlayerWorldEvent(int Asker, int ExceptID)
 {
 	// Send all world events to everyone by default
-	return CmaskAllExceptOne(ExceptID);
+	return CMaskAllExceptOne(ExceptID);
 }
 
 void IGameController::DoTeamChange(CPlayer *pPlayer, int Team, bool DoChatMsg)

--- a/src/game/server/gamecontroller.cpp
+++ b/src/game/server/gamecontroller.cpp
@@ -721,7 +721,7 @@ int IGameController::ClampTeam(int Team)
 	return 0;
 }
 
-int64_t IGameController::GetMaskForPlayerWorldEvent(int Asker, int ExceptID)
+CMask IGameController::GetMaskForPlayerWorldEvent(int Asker, int ExceptID)
 {
 	// Send all world events to everyone by default
 	return CmaskAllExceptOne(ExceptID);

--- a/src/game/server/gamecontroller.h
+++ b/src/game/server/gamecontroller.h
@@ -5,6 +5,7 @@
 
 #include <base/vmath.h>
 #include <engine/map.h>
+#include <engine/mask.h>
 
 #include <vector>
 
@@ -143,7 +144,7 @@ public:
 	virtual bool CanJoinTeam(int Team, int NotThisID);
 	int ClampTeam(int Team);
 
-	virtual int64_t GetMaskForPlayerWorldEvent(int Asker, int ExceptID = -1);
+	virtual CMask GetMaskForPlayerWorldEvent(int Asker, int ExceptID = -1);
 
 	// DDRace
 

--- a/src/game/server/gamemodes/DDRace.cpp
+++ b/src/game/server/gamemodes/DDRace.cpp
@@ -212,7 +212,7 @@ void CGameControllerDDRace::DoTeamChange(class CPlayer *pPlayer, int Team, bool 
 	IGameController::DoTeamChange(pPlayer, Team, DoChatMsg);
 }
 
-int64_t CGameControllerDDRace::GetMaskForPlayerWorldEvent(int Asker, int ExceptID)
+CMask CGameControllerDDRace::GetMaskForPlayerWorldEvent(int Asker, int ExceptID)
 {
 	if(Asker == -1)
 		return CmaskAllExceptOne(ExceptID);

--- a/src/game/server/gamemodes/DDRace.cpp
+++ b/src/game/server/gamemodes/DDRace.cpp
@@ -215,7 +215,7 @@ void CGameControllerDDRace::DoTeamChange(class CPlayer *pPlayer, int Team, bool 
 CMask CGameControllerDDRace::GetMaskForPlayerWorldEvent(int Asker, int ExceptID)
 {
 	if(Asker == -1)
-		return CmaskAllExceptOne(ExceptID);
+		return CMaskAllExceptOne(ExceptID);
 
 	return m_Teams.TeamMask(GetPlayerTeam(Asker), ExceptID, Asker);
 }

--- a/src/game/server/gamemodes/DDRace.h
+++ b/src/game/server/gamemodes/DDRace.h
@@ -29,7 +29,7 @@ public:
 
 	void DoTeamChange(class CPlayer *pPlayer, int Team, bool DoChatMsg = true) override;
 
-	int64_t GetMaskForPlayerWorldEvent(int Asker, int ExceptID = -1) override;
+	CMask GetMaskForPlayerWorldEvent(int Asker, int ExceptID = -1) override;
 
 	void InitTeleporter();
 

--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -480,11 +480,11 @@ CMask CGameTeams::TeamMask(int Team, int ExceptID, int Asker)
 	if(Team == TEAM_SUPER)
 	{
 		if(ExceptID == -1)
-			return CmaskAll();
-		return CmaskAllExceptOne(ExceptID);
+			return CMaskAll();
+		return CMaskAllExceptOne(ExceptID);
 	}
 
-	CMask Mask = CmaskNone();
+	CMask Mask = CMaskNone();
 	for(int i = 0; i < MAX_CLIENTS; ++i)
 	{
 		if(i == ExceptID)
@@ -545,7 +545,7 @@ CMask CGameTeams::TeamMask(int Team, int ExceptID, int Asker)
 			}
 		}
 
-		Mask |= CmaskOne(i);
+		Mask |= CMaskOne(i);
 	}
 	return Mask;
 }
@@ -1093,7 +1093,7 @@ void CGameTeams::SetTeamLock(int Team, bool Lock)
 
 void CGameTeams::ResetInvited(int Team)
 {
-	m_aInvited[Team] = CmaskNone();
+	m_aInvited[Team] = CMaskNone();
 }
 
 void CGameTeams::SetClientInvited(int Team, int ClientID, bool Invited)
@@ -1101,9 +1101,9 @@ void CGameTeams::SetClientInvited(int Team, int ClientID, bool Invited)
 	if(Team > TEAM_FLOCK && Team < TEAM_SUPER)
 	{
 		if(Invited)
-			m_aInvited[Team] |= CMask(ClientID);
+			m_aInvited[Team] |= CMaskOne(ClientID);
 		else
-			m_aInvited[Team] &= ~CMask(ClientID);
+			m_aInvited[Team] &= ~CMaskOne(ClientID);
 	}
 }
 

--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -475,16 +475,16 @@ bool CGameTeams::TeamFinished(int Team)
 	return true;
 }
 
-int64_t CGameTeams::TeamMask(int Team, int ExceptID, int Asker)
+CMask CGameTeams::TeamMask(int Team, int ExceptID, int Asker)
 {
 	if(Team == TEAM_SUPER)
 	{
 		if(ExceptID == -1)
-			return 0xffffffffffffffff;
-		return 0xffffffffffffffff & ~(1 << ExceptID);
+			return CmaskAll();
+		return CmaskAllExceptOne(ExceptID);
 	}
 
-	int64_t Mask = 0;
+	CMask Mask = CmaskNone();
 	for(int i = 0; i < MAX_CLIENTS; ++i)
 	{
 		if(i == ExceptID)
@@ -545,7 +545,7 @@ int64_t CGameTeams::TeamMask(int Team, int ExceptID, int Asker)
 			}
 		}
 
-		Mask |= 1LL << i;
+		Mask |= CmaskOne(i);
 	}
 	return Mask;
 }
@@ -1093,7 +1093,7 @@ void CGameTeams::SetTeamLock(int Team, bool Lock)
 
 void CGameTeams::ResetInvited(int Team)
 {
-	m_aInvited[Team] = 0;
+	m_aInvited[Team] = CmaskNone();
 }
 
 void CGameTeams::SetClientInvited(int Team, int ClientID, bool Invited)
@@ -1101,9 +1101,9 @@ void CGameTeams::SetClientInvited(int Team, int ClientID, bool Invited)
 	if(Team > TEAM_FLOCK && Team < TEAM_SUPER)
 	{
 		if(Invited)
-			m_aInvited[Team] |= 1ULL << ClientID;
+			m_aInvited[Team] |= CMask(ClientID);
 		else
-			m_aInvited[Team] &= ~(1ULL << ClientID);
+			m_aInvited[Team] &= ~CMask(ClientID);
 	}
 }
 

--- a/src/game/server/teams.h
+++ b/src/game/server/teams.h
@@ -151,7 +151,7 @@ public:
 
 	bool IsInvited(int Team, int ClientID)
 	{
-		return CmaskIsSet(m_aInvited[Team], ClientID);
+		return CMaskIsSet(m_aInvited[Team], ClientID);
 	}
 
 	bool IsStarted(int Team)

--- a/src/game/server/teams.h
+++ b/src/game/server/teams.h
@@ -25,7 +25,7 @@ class CGameTeams
 
 	int m_aTeamState[NUM_TEAMS];
 	bool m_aTeamLocked[NUM_TEAMS];
-	uint64_t m_aInvited[NUM_TEAMS];
+	CMask m_aInvited[NUM_TEAMS];
 	bool m_aPractice[NUM_TEAMS];
 	std::shared_ptr<CScoreSaveResult> m_apSaveTeamResult[NUM_TEAMS];
 	uint64_t m_aLastSwap[MAX_CLIENTS]; // index is id of player who initiated swap
@@ -96,7 +96,7 @@ public:
 
 	void ChangeTeamState(int Team, int State);
 
-	int64_t TeamMask(int Team, int ExceptID = -1, int Asker = -1);
+	CMask TeamMask(int Team, int ExceptID = -1, int Asker = -1);
 
 	int Count(int Team) const;
 
@@ -151,7 +151,7 @@ public:
 
 	bool IsInvited(int Team, int ClientID)
 	{
-		return m_aInvited[Team] & 1LL << ClientID;
+		return CmaskIsSet(m_aInvited[Team], ClientID);
 	}
 
 	bool IsStarted(int Team)


### PR DESCRIPTION
At this moment, one of the main parts of the refactoring aimed at increasing the number of supported clients is that it is necessary to edit all places where client masks are used.
In the case of accepting my pull request, when we deside to increase the number of supported clients to any, it will be necessary to change only one file - _mask.h_.
This pull request **does not** set the task of migrating to a larger number of clients and **does not** change any server logic, it will only simplify this process in the future. And I think that sooner or later we will come to this.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
