### PR TITLE
More minimal clang-tidy 15 run

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -18,6 +18,7 @@
 Checks: >
   -*,
   bugprone-*,
+  -bugprone-assignment-in-if-condition,
   -bugprone-branch-clone,
   -bugprone-easily-swappable-parameters,
   -bugprone-implicit-widening-of-multiplication-result,
@@ -42,6 +43,7 @@ Checks: >
   cppcoreguidelines-slicing,
   cppcoreguidelines-virtual-class-destructor,
   misc-*,
+  -misc-const-correctness,
   -misc-no-recursion,
   -misc-non-private-member-variables-in-classes,
   -misc-static-assert,
@@ -79,6 +81,7 @@ Checks: >
   -readability-make-member-function-const,
   -readability-named-parameter,
   -readability-non-const-parameter,
+  -readability-simplify-boolean-expr,
   -readability-static-accessed-through-instance,
   -readability-suspicious-call-argument,
   -readability-uppercase-literal-suffix,

--- a/src/engine/client/backend/glsl_shader_compiler.cpp
+++ b/src/engine/client/backend/glsl_shader_compiler.cpp
@@ -19,7 +19,7 @@ CGLSLCompiler::CGLSLCompiler(int OpenGLVersionMajor, int OpenGLVersionMinor, int
 
 void CGLSLCompiler::AddDefine(const std::string &DefineName, const std::string &DefineValue)
 {
-	m_vDefines.emplace_back(SGLSLCompilerDefine(DefineName, DefineValue));
+	m_vDefines.emplace_back(DefineName, DefineValue);
 }
 
 void CGLSLCompiler::AddDefine(const char *pDefineName, const char *pDefineValue)

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -3324,7 +3324,7 @@ void CClient::Run()
 			{
 				// write down the config and quit
 				if(!m_pConfigManager->Save())
-					m_vWarnings.emplace_back(SWarning(Localize("Saving ddnet-settings.cfg failed")));
+					m_vWarnings.emplace_back(Localize("Saving ddnet-settings.cfg failed"));
 				s_SavedConfig = true;
 			}
 

--- a/src/game/client/prediction/gameworld.cpp
+++ b/src/game/client/prediction/gameworld.cpp
@@ -682,5 +682,5 @@ void CGameWorld::Clear()
 	// delete all entities
 	for(auto &pFirstEntityType : m_apFirstEntityTypes)
 		while(pFirstEntityType)
-			delete pFirstEntityType;
+			delete pFirstEntityType; // NOLINT(clang-analyzer-cplusplus.NewDelete)
 }

--- a/src/game/server/gamecontroller.cpp
+++ b/src/game/server/gamecontroller.cpp
@@ -652,7 +652,7 @@ void IGameController::Snap(int SnappingClient)
 			if(EndTick > 0 && EndTick < Server()->Tick() + 3 * Server()->TickSpeed() && GameServer()->Switchers()[i].m_aLastUpdateTick[Team] < Server()->Tick())
 			{
 				// only keep track of EndTicks that have less than three second left and are not currently being updated by a player being present on a switch tile, to limit how often these are sent
-				vEndTicks.emplace_back(std::pair<int, int>(GameServer()->Switchers()[i].m_aEndTick[Team], i));
+				vEndTicks.emplace_back(GameServer()->Switchers()[i].m_aEndTick[Team], i);
 			}
 		}
 

--- a/src/game/server/gameworld.cpp
+++ b/src/game/server/gameworld.cpp
@@ -33,7 +33,7 @@ CGameWorld::~CGameWorld()
 	// delete all entities
 	for(auto &pFirstEntityType : m_apFirstEntityTypes)
 		while(pFirstEntityType)
-			delete pFirstEntityType;
+			delete pFirstEntityType; // NOLINT(clang-analyzer-cplusplus.NewDelete)
 }
 
 void CGameWorld::SetGameServer(CGameContext *pGameServer)


### PR DESCRIPTION
Alternative to #6294

The only remaining problems are:
```
/home/deen/git/ddnet/src/engine/client/backend/glsl_shader_compiler.cpp:22:26: warning: unnecessary temporary object created while calling emplace_back [modernize-use-emplace]
        m_vDefines.emplace_back(SGLSLCompilerDefine(DefineName, DefineValue));
                                ^~~~~~~~~~~~~~~~~~~~                       ~
```

<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
