### PR TITLE
Fix map check excluded warnings in CI

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -73,8 +73,8 @@ jobs:
         findings=$(find data -type f -name '*.map' -print0 | xargs -0 ~/.cargo/bin/twmap-check-ddnet 2>&1 | \
           grep -v -E "\"data/maps/(ctf|dm).*\.map\": Time cps are missing on the map" | \
           grep -v -E "\"data/themes/.*\.map\": Time cps are missing on the map" | \
-          grep -v -E "\"data/maps/ctf4\.map\": Map - Image error at index 3 : 'jungle_doodads_old' is not a valid external image in version DDNet06" | \
-          grep -v -E "\"data/themes/autumn_night\.map\": Map - Image error at index 3 : 'generic_lamps' is not a valid external image in version DDNet06" | \
+          grep -v -E "\"data/maps/ctf4\.map\": Map - In Image at index 3 -> Image 'jungle_doodads_old' is not a valid external image for DDNet06" | \
+          grep -v -E "\"data/themes/autumn_night\.map\": Map - In Image at index 3 -> Image 'generic_lamps' is not a valid external image for DDNet06" | \
           grep -v -E "\"data/maps7?/Tutorial\.map\": Map setting - Unusual: 'sv_show_others_default'" || true)
         if [ -n "$findings" ]; then
           echo "$findings"


### PR DESCRIPTION
Due to changes in wording of the error messages, some of the twmap-check-ddnet warnings were no longer suppressed.

Closes #6305.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
