### PR TITLE
Fix Crash in CSafeTeam::Safe/Load

### DIFF
--- a/src/game/server/gameworld.cpp
+++ b/src/game/server/gameworld.cpp
@@ -168,6 +168,7 @@ void CGameWorld::RemoveEntitiesFromPlayers(int PlayerIds[], int NumPlayers)
 				{
 					RemoveEntity(pEnt);
 					pEnt->Destroy();
+					break;
 				}
 			}
 			pEnt = m_pNextTraverseEntity;


### PR DESCRIPTION
Fixes #6304

`pEnt` is freed after removing, so must not be used in the next loop iteration.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
