### PR TITLE
Increase relative joystick movement based on input update time, disable relative joystick when console is open or window not focused

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -3313,13 +3313,6 @@ void CClient::Run()
 				// if the client does not render, it should reset its render time to a time where it would render the first frame, when it wakes up again
 				LastRenderTime = g_Config.m_GfxRefreshRate ? (Now - (time_freq() / (int64_t)g_Config.m_GfxRefreshRate)) : Now;
 			}
-
-			if(Input()->VideoRestartNeeded())
-			{
-				m_pGraphics->Init();
-				LoadData();
-				GameClient()->OnInit();
-			}
 		}
 
 		AutoScreenshot_Cleanup();

--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -47,7 +47,7 @@ CInput::CInput()
 	mem_zero(m_aInputState, sizeof(m_aInputState));
 
 	m_InputCounter = 1;
-	m_InputGrabbed = 0;
+	m_InputGrabbed = false;
 
 	m_MouseDoubleClick = false;
 
@@ -272,14 +272,14 @@ bool CInput::MouseRelative(float *pX, float *pY)
 
 void CInput::MouseModeAbsolute()
 {
-	m_InputGrabbed = 0;
+	m_InputGrabbed = false;
 	SDL_SetRelativeMouseMode(SDL_FALSE);
 	Graphics()->SetWindowGrab(false);
 }
 
 void CInput::MouseModeRelative()
 {
-	m_InputGrabbed = 1;
+	m_InputGrabbed = true;
 #if !defined(CONF_PLATFORM_ANDROID) // No relative mouse on Android
 	SDL_SetRelativeMouseMode(SDL_TRUE);
 #endif

--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -148,7 +148,7 @@ void CInput::ConchainJoystickGuidChanged(IConsole::IResult *pResult, void *pUser
 
 float CInput::GetJoystickDeadzone()
 {
-	return g_Config.m_InpControllerTolerance / 50.0f;
+	return minimum(g_Config.m_InpControllerTolerance / 50.0f, 0.995f);
 }
 
 CInput::CJoystick::CJoystick(CInput *pInput, int Index, SDL_Joystick *pDelegate)

--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -46,6 +46,9 @@ CInput::CInput()
 	mem_zero(m_aInputCount, sizeof(m_aInputCount));
 	mem_zero(m_aInputState, sizeof(m_aInputState));
 
+	m_LastUpdate = 0;
+	m_UpdateTime = 0.0f;
+
 	m_InputCounter = 1;
 	m_InputGrabbed = false;
 
@@ -220,7 +223,7 @@ bool CInput::CJoystick::Relative(float *pX, float *pY)
 	const float DeadZone = Input()->GetJoystickDeadzone();
 	if(Len > DeadZone)
 	{
-		const float Factor = 0.1f * maximum((Len - DeadZone) / (1 - DeadZone), 0.001f) / Len;
+		const float Factor = 2500.0f * Input()->GetUpdateTime() * maximum((Len - DeadZone) / (1.0f - DeadZone), 0.001f) / Len;
 		*pX = RawJoystickPos.x * Factor;
 		*pY = RawJoystickPos.y * Factor;
 		return true;
@@ -562,6 +565,14 @@ void CInput::SetEditingPosition(float X, float Y)
 
 int CInput::Update()
 {
+	const int64_t Now = time_get();
+	if(m_LastUpdate != 0)
+	{
+		const float Diff = (Now - m_LastUpdate) / (float)time_freq();
+		m_UpdateTime = m_UpdateTime == 0.0f ? Diff : (m_UpdateTime * 0.8f + Diff * 0.2f);
+	}
+	m_LastUpdate = Now;
+
 	// keep the counter between 1..0xFFFF, 0 means not pressed
 	m_InputCounter = (m_InputCounter % 0xFFFF) + 1;
 

--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -212,7 +212,7 @@ void CInput::CJoystick::GetHatValue(int Hat, int (&HatKeys)[2])
 
 bool CInput::CJoystick::Relative(float *pX, float *pY)
 {
-	if(!g_Config.m_InpControllerEnable)
+	if(!Input()->m_MouseFocus || !Input()->m_InputGrabbed || !g_Config.m_InpControllerEnable)
 		return false;
 
 	const vec2 RawJoystickPos = vec2(GetAxisValue(g_Config.m_InpControllerX), GetAxisValue(g_Config.m_InpControllerY));

--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -54,7 +54,6 @@ CInput::CInput()
 	m_NumEvents = 0;
 	m_MouseFocus = true;
 
-	m_VideoRestartNeeded = 0;
 	m_pClipboardText = NULL;
 
 	m_NumTextInputInstances = 0;
@@ -771,16 +770,6 @@ int CInput::Update()
 		}
 	}
 
-	return 0;
-}
-
-int CInput::VideoRestartNeeded()
-{
-	if(m_VideoRestartNeeded)
-	{
-		m_VideoRestartNeeded = 0;
-		return 1;
-	}
 	return 0;
 }
 

--- a/src/engine/client/input.h
+++ b/src/engine/client/input.h
@@ -75,8 +75,6 @@ private:
 	bool m_MouseFocus;
 	bool m_MouseDoubleClick;
 
-	int m_VideoRestartNeeded;
-
 	void AddEvent(char *pText, int Key, int Flags);
 	void Clear() override;
 	bool IsEventValid(CEvent *pEvent) const override { return pEvent->m_InputCount == m_InputCounter; }
@@ -131,8 +129,6 @@ public:
 	void SetClipboardText(const char *pText) override;
 
 	int Update() override;
-
-	int VideoRestartNeeded() override;
 
 	bool GetIMEState() override;
 	void SetIMEState(bool Activate) override;

--- a/src/engine/client/input.h
+++ b/src/engine/client/input.h
@@ -69,7 +69,7 @@ private:
 	static void ConchainJoystickGuidChanged(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 	float GetJoystickDeadzone();
 
-	int m_InputGrabbed;
+	bool m_InputGrabbed;
 	char *m_pClipboardText;
 
 	bool m_MouseFocus;

--- a/src/engine/input.h
+++ b/src/engine/input.h
@@ -134,7 +134,6 @@ public:
 	virtual void Init() = 0;
 	virtual void Shutdown() override = 0;
 	virtual int Update() = 0;
-	virtual int VideoRestartNeeded() = 0;
 };
 
 extern IEngineInput *CreateEngineInput();

--- a/src/engine/input.h
+++ b/src/engine/input.h
@@ -35,6 +35,8 @@ protected:
 	// quick access to events
 	int m_NumEvents;
 	IInput::CEvent m_aInputEvents[INPUT_BUFFER_SIZE];
+	int64_t m_LastUpdate;
+	float m_UpdateTime;
 
 public:
 	enum
@@ -65,6 +67,12 @@ public:
 	}
 	CEvent *GetEventsRaw() { return m_aInputEvents; }
 	int *GetEventCountRaw() { return &m_NumEvents; }
+
+	/**
+	 * @return Rolling average of the time in seconds between
+	 * calls of the Update function.
+	 */
+	float GetUpdateTime() const { return m_UpdateTime; }
 
 	// keys
 	virtual bool ModifierIsPressed() const = 0;


### PR DESCRIPTION


## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
