### PR TITLE
Remove `bytes_be_to_int` and `int_to_bytes_be`, static assert size of `int` and `unsigned`, refactoring

### DIFF
--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -3838,34 +3838,6 @@ const char *str_next_token(const char *str, const char *delim, char *buffer, int
 	return tok + len;
 }
 
-int bytes_be_to_int(const unsigned char *bytes)
-{
-	int Result;
-	unsigned char *pResult = (unsigned char *)&Result;
-	for(unsigned i = 0; i < sizeof(int); i++)
-	{
-#if defined(CONF_ARCH_ENDIAN_BIG)
-		pResult[i] = bytes[i];
-#else
-		pResult[i] = bytes[sizeof(int) - i - 1];
-#endif
-	}
-	return Result;
-}
-
-void int_to_bytes_be(unsigned char *bytes, int value)
-{
-	const unsigned char *pValue = (const unsigned char *)&value;
-	for(unsigned i = 0; i < sizeof(int); i++)
-	{
-#if defined(CONF_ARCH_ENDIAN_BIG)
-		bytes[i] = pValue[i];
-#else
-		bytes[sizeof(int) - i - 1] = pValue[i];
-#endif
-	}
-}
-
 unsigned bytes_be_to_uint(const unsigned char *bytes)
 {
 	return ((bytes[0] & 0xffu) << 24u) | ((bytes[1] & 0xffu) << 16u) | ((bytes[2] & 0xffu) << 8u) | (bytes[3] & 0xffu);

--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -3838,6 +3838,9 @@ const char *str_next_token(const char *str, const char *delim, char *buffer, int
 	return tok + len;
 }
 
+static_assert(sizeof(unsigned) == 4, "unsigned must be 4 bytes in size");
+static_assert(sizeof(unsigned) == sizeof(int), "unsigned and int must have the same size");
+
 unsigned bytes_be_to_uint(const unsigned char *bytes)
 {
 	return ((bytes[0] & 0xffu) << 24u) | ((bytes[1] & 0xffu) << 16u) | ((bytes[2] & 0xffu) << 8u) | (bytes[3] & 0xffu);

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -2387,29 +2387,6 @@ const char *str_next_token(const char *str, const char *delim, char *buffer, int
 int str_in_list(const char *list, const char *delim, const char *needle);
 
 /*
-	Function: bytes_be_to_int
-		Packs 4 big endian bytes into an int
-
-	Returns:
-		The packed int
-
-	Remarks:
-		- Assumes the passed array is 4 bytes
-		- Assumes int is 4 bytes
-*/
-int bytes_be_to_int(const unsigned char *bytes);
-
-/*
-	Function: int_to_bytes_be
-		Packs an int into 4 big endian bytes
-
-	Remarks:
-		- Assumes the passed array is 4 bytes
-		- Assumes int is 4 bytes
-*/
-void int_to_bytes_be(unsigned char *bytes, int value);
-
-/*
 	Function: bytes_be_to_uint
 		Packs 4 big endian bytes into an unsigned
 

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -2386,27 +2386,31 @@ const char *str_next_token(const char *str, const char *delim, char *buffer, int
 */
 int str_in_list(const char *list, const char *delim, const char *needle);
 
-/*
-	Function: bytes_be_to_uint
-		Packs 4 big endian bytes into an unsigned
-
-	Returns:
-		The packed unsigned
-
-	Remarks:
-		- Assumes the passed array is 4 bytes
-		- Assumes unsigned is 4 bytes
-*/
+/**
+ * Packs 4 big endian bytes into an unsigned.
+ *
+ * @param bytes Pointer to an array of bytes that will be packed.
+ *
+ * @return The packed unsigned.
+ *
+ * @remark Assumes the passed array is least 4 bytes in size.
+ * @remark Assumes unsigned is 4 bytes in size.
+ *
+ * @see uint_to_bytes_be
+ */
 unsigned bytes_be_to_uint(const unsigned char *bytes);
 
-/*
-	Function: uint_to_bytes_be
-		Packs an unsigned into 4 big endian bytes
-
-	Remarks:
-		- Assumes the passed array is 4 bytes
-		- Assumes unsigned is 4 bytes
-*/
+/**
+ * Packs an unsigned into 4 big endian bytes.
+ *
+ * @param bytes Pointer to an array where the bytes will be stored.
+ * @param value The values that will be packed into the array.
+ *
+ * @remark Assumes the passed array is least 4 bytes in size.
+ * @remark Assumes unsigned is 4 bytes in size.
+ *
+ * @see bytes_be_to_uint
+ */
 void uint_to_bytes_be(unsigned char *bytes, unsigned value);
 
 /*

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -4086,8 +4086,8 @@ int CClient::HandleChecksum(int Conn, CUuid Uuid, CUnpacker *pUnpacker)
 	int End = Start + Length;
 	int ChecksumBytesEnd = minimum(End, (int)sizeof(m_Checksum.m_aBytes));
 	int FileStart = maximum(Start, (int)sizeof(m_Checksum.m_aBytes));
-	unsigned char aStartBytes[4];
-	unsigned char aEndBytes[4];
+	unsigned char aStartBytes[sizeof(int32_t)];
+	unsigned char aEndBytes[sizeof(int32_t)];
 	uint_to_bytes_be(aStartBytes, Start);
 	uint_to_bytes_be(aEndBytes, End);
 

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -4088,8 +4088,8 @@ int CClient::HandleChecksum(int Conn, CUuid Uuid, CUnpacker *pUnpacker)
 	int FileStart = maximum(Start, (int)sizeof(m_Checksum.m_aBytes));
 	unsigned char aStartBytes[4];
 	unsigned char aEndBytes[4];
-	int_to_bytes_be(aStartBytes, Start);
-	int_to_bytes_be(aEndBytes, End);
+	uint_to_bytes_be(aStartBytes, Start);
+	uint_to_bytes_be(aEndBytes, End);
 
 	if(Start <= (int)sizeof(m_Checksum.m_aBytes))
 	{

--- a/src/engine/client/ghost.cpp
+++ b/src/engine/client/ghost.cpp
@@ -83,7 +83,7 @@ void CGhostRecorder::WriteData(int Type, const void *pData, int Size)
 	mem_copy(Data.m_aData, pData, Size);
 
 	if(m_LastItem.m_Type == Data.m_Type)
-		DiffItem((int *)m_LastItem.m_aData, (int *)Data.m_aData, (int *)m_pBufferPos, Size / 4);
+		DiffItem((int *)m_LastItem.m_aData, (int *)Data.m_aData, (int *)m_pBufferPos, Size / sizeof(int32_t));
 	else
 	{
 		FlushChunk();
@@ -144,11 +144,11 @@ int CGhostRecorder::Stop(int Ticks, int Time)
 	// write down num shots and time
 	io_seek(m_File, gs_NumTicksOffset, IOSEEK_START);
 
-	unsigned char aNumTicks[4];
+	unsigned char aNumTicks[sizeof(int32_t)];
 	uint_to_bytes_be(aNumTicks, Ticks);
 	io_write(m_File, aNumTicks, sizeof(aNumTicks));
 
-	unsigned char aTime[4];
+	unsigned char aTime[sizeof(int32_t)];
 	uint_to_bytes_be(aTime, Time);
 	io_write(m_File, aTime, sizeof(aTime));
 
@@ -341,7 +341,7 @@ bool CGhostLoader::ReadData(int Type, void *pData, int Size)
 	CGhostItem Data(Type);
 
 	if(m_LastItem.m_Type == Data.m_Type)
-		UndiffItem((int *)m_LastItem.m_aData, (int *)m_pBufferPos, (int *)Data.m_aData, Size / 4);
+		UndiffItem((int *)m_LastItem.m_aData, (int *)m_pBufferPos, (int *)Data.m_aData, Size / sizeof(int32_t));
 	else
 		mem_copy(Data.m_aData, m_pBufferPos, Size);
 

--- a/src/engine/client/ghost.cpp
+++ b/src/engine/client/ghost.cpp
@@ -145,11 +145,11 @@ int CGhostRecorder::Stop(int Ticks, int Time)
 	io_seek(m_File, gs_NumTicksOffset, IOSEEK_START);
 
 	unsigned char aNumTicks[4];
-	int_to_bytes_be(aNumTicks, Ticks);
+	uint_to_bytes_be(aNumTicks, Ticks);
 	io_write(m_File, aNumTicks, sizeof(aNumTicks));
 
 	unsigned char aTime[4];
-	int_to_bytes_be(aTime, Time);
+	uint_to_bytes_be(aTime, Time);
 	io_write(m_File, aTime, sizeof(aTime));
 
 	io_close(m_File);

--- a/src/engine/client/ghost.h
+++ b/src/engine/client/ghost.h
@@ -16,9 +16,9 @@ struct CGhostHeader
 	unsigned char m_Version;
 	char m_aOwner[MAX_NAME_LENGTH];
 	char m_aMap[64];
-	unsigned char m_aZeroes[4]; // Crc before version 6
-	unsigned char m_aNumTicks[4];
-	unsigned char m_aTime[4];
+	unsigned char m_aZeroes[sizeof(int32_t)]; // Crc before version 6
+	unsigned char m_aNumTicks[sizeof(int32_t)];
+	unsigned char m_aTime[sizeof(int32_t)];
 	SHA256_DIGEST m_MapSha256;
 
 	int GetTicks() const

--- a/src/engine/client/ghost.h
+++ b/src/engine/client/ghost.h
@@ -23,12 +23,12 @@ struct CGhostHeader
 
 	int GetTicks() const
 	{
-		return bytes_be_to_int(m_aNumTicks);
+		return bytes_be_to_uint(m_aNumTicks);
 	}
 
 	int GetTime() const
 	{
-		return bytes_be_to_int(m_aTime);
+		return bytes_be_to_uint(m_aTime);
 	}
 
 	CGhostInfo ToGhostInfo() const

--- a/src/engine/demo.h
+++ b/src/engine/demo.h
@@ -29,17 +29,17 @@ struct CDemoHeader
 	unsigned char m_Version;
 	char m_aNetversion[64];
 	char m_aMapName[64];
-	unsigned char m_aMapSize[4];
-	unsigned char m_aMapCrc[4];
+	unsigned char m_aMapSize[sizeof(int32_t)];
+	unsigned char m_aMapCrc[sizeof(int32_t)];
 	char m_aType[8];
-	unsigned char m_aLength[4];
+	unsigned char m_aLength[sizeof(int32_t)];
 	char m_aTimestamp[20];
 };
 
 struct CTimelineMarkers
 {
-	unsigned char m_aNumTimelineMarkers[4];
-	unsigned char m_aTimelineMarkers[MAX_TIMELINE_MARKERS][4];
+	unsigned char m_aNumTimelineMarkers[sizeof(int32_t)];
+	unsigned char m_aTimelineMarkers[MAX_TIMELINE_MARKERS][sizeof(int32_t)];
 };
 
 struct CMapInfo

--- a/src/engine/server/register.cpp
+++ b/src/engine/server/register.cpp
@@ -498,7 +498,7 @@ CRegister::CRegister(CConfig *pConfig, IConsole *pConsole, IEngine *pEngine, int
 	m_aVerifyPacketPrefix[HEADER_LEN + UUID_MAXSTRSIZE - 1] = ':';
 
 	// The DDNet code uses the `unsigned` security token in memory byte order.
-	unsigned char aTokenBytes[4];
+	unsigned char aTokenBytes[sizeof(int32_t)];
 	mem_copy(aTokenBytes, &SixupSecurityToken, sizeof(aTokenBytes));
 	str_format(m_aConnlessTokenHex, sizeof(m_aConnlessTokenHex), "%08x", bytes_be_to_uint(aTokenBytes));
 

--- a/src/engine/shared/datafile.cpp
+++ b/src/engine/shared/datafile.cpp
@@ -22,21 +22,21 @@ enum
 
 struct CItemEx
 {
-	int m_aUuid[sizeof(CUuid) / 4];
+	int m_aUuid[sizeof(CUuid) / sizeof(int32_t)];
 
 	static CItemEx FromUuid(CUuid Uuid)
 	{
 		CItemEx Result;
-		for(int i = 0; i < (int)sizeof(CUuid) / 4; i++)
-			Result.m_aUuid[i] = bytes_be_to_uint(&Uuid.m_aData[i * 4]);
+		for(size_t i = 0; i < sizeof(CUuid) / sizeof(int32_t); i++)
+			Result.m_aUuid[i] = bytes_be_to_uint(&Uuid.m_aData[i * sizeof(int32_t)]);
 		return Result;
 	}
 
 	CUuid ToUuid() const
 	{
 		CUuid Result;
-		for(int i = 0; i < (int)sizeof(CUuid) / 4; i++)
-			uint_to_bytes_be(&Result.m_aData[i * 4], m_aUuid[i]);
+		for(size_t i = 0; i < sizeof(CUuid) / sizeof(int32_t); i++)
+			uint_to_bytes_be(&Result.m_aData[i * sizeof(int32_t)], m_aUuid[i]);
 		return Result;
 	}
 };

--- a/src/engine/shared/datafile.cpp
+++ b/src/engine/shared/datafile.cpp
@@ -28,7 +28,7 @@ struct CItemEx
 	{
 		CItemEx Result;
 		for(int i = 0; i < (int)sizeof(CUuid) / 4; i++)
-			Result.m_aUuid[i] = bytes_be_to_int(&Uuid.m_aData[i * 4]);
+			Result.m_aUuid[i] = bytes_be_to_uint(&Uuid.m_aData[i * 4]);
 		return Result;
 	}
 
@@ -36,7 +36,7 @@ struct CItemEx
 	{
 		CUuid Result;
 		for(int i = 0; i < (int)sizeof(CUuid) / 4; i++)
-			int_to_bytes_be(&Result.m_aData[i * 4], m_aUuid[i]);
+			uint_to_bytes_be(&Result.m_aData[i * 4], m_aUuid[i]);
 		return Result;
 	}
 };

--- a/src/engine/shared/demo.cpp
+++ b/src/engine/shared/demo.cpp
@@ -348,18 +348,18 @@ int CDemoRecorder::Stop()
 	// add the demo length to the header
 	io_seek(m_File, gs_LengthOffset, IOSEEK_START);
 	unsigned char aLength[4];
-	int_to_bytes_be(aLength, Length());
+	uint_to_bytes_be(aLength, Length());
 	io_write(m_File, aLength, sizeof(aLength));
 
 	// add the timeline markers to the header
 	io_seek(m_File, gs_NumMarkersOffset, IOSEEK_START);
 	unsigned char aNumMarkers[4];
-	int_to_bytes_be(aNumMarkers, m_NumTimelineMarkers);
+	uint_to_bytes_be(aNumMarkers, m_NumTimelineMarkers);
 	io_write(m_File, aNumMarkers, sizeof(aNumMarkers));
 	for(int i = 0; i < m_NumTimelineMarkers; i++)
 	{
 		unsigned char aMarker[4];
-		int_to_bytes_be(aMarker, m_aTimelineMarkers[i]);
+		uint_to_bytes_be(aMarker, m_aTimelineMarkers[i]);
 		io_write(m_File, aMarker, sizeof(aMarker));
 	}
 
@@ -457,7 +457,7 @@ int CDemoPlayer::ReadChunkHeader(int *pType, int *pSize, int *pTick)
 			unsigned char aTickdata[4];
 			if(io_read(m_File, aTickdata, sizeof(aTickdata)) != sizeof(aTickdata))
 				return -1;
-			*pTick = bytes_be_to_int(aTickdata);
+			*pTick = bytes_be_to_uint(aTickdata);
 		}
 	}
 	else
@@ -824,11 +824,11 @@ int CDemoPlayer::Load(class IStorage *pStorage, class IConsole *pConsole, const 
 	if(m_Info.m_Header.m_Version > gs_OldVersion)
 	{
 		// get timeline markers
-		int Num = bytes_be_to_int(m_Info.m_TimelineMarkers.m_aNumTimelineMarkers);
+		int Num = bytes_be_to_uint(m_Info.m_TimelineMarkers.m_aNumTimelineMarkers);
 		m_Info.m_Info.m_NumTimelineMarkers = clamp<int>(Num, 0, MAX_TIMELINE_MARKERS);
 		for(int i = 0; i < m_Info.m_Info.m_NumTimelineMarkers; i++)
 		{
-			m_Info.m_Info.m_aTimelineMarkers[i] = bytes_be_to_int(m_Info.m_TimelineMarkers.m_aTimelineMarkers[i]);
+			m_Info.m_Info.m_aTimelineMarkers[i] = bytes_be_to_uint(m_Info.m_TimelineMarkers.m_aTimelineMarkers[i]);
 		}
 	}
 
@@ -1117,7 +1117,7 @@ bool CDemoPlayer::GetDemoInfo(class IStorage *pStorage, const char *pFilename, i
 	io_read(File, pTimelineMarkers, sizeof(CTimelineMarkers));
 
 	str_copy(pMapInfo->m_aName, pDemoHeader->m_aMapName);
-	pMapInfo->m_Crc = bytes_be_to_int(pDemoHeader->m_aMapCrc);
+	pMapInfo->m_Crc = bytes_be_to_uint(pDemoHeader->m_aMapCrc);
 
 	SHA256_DIGEST Sha256 = SHA256_ZEROED;
 	if(pDemoHeader->m_Version >= gs_Sha256Version)
@@ -1138,7 +1138,7 @@ bool CDemoPlayer::GetDemoInfo(class IStorage *pStorage, const char *pFilename, i
 	}
 	pMapInfo->m_Sha256 = Sha256;
 
-	pMapInfo->m_Size = bytes_be_to_int(pDemoHeader->m_aMapSize);
+	pMapInfo->m_Size = bytes_be_to_uint(pDemoHeader->m_aMapSize);
 
 	io_close(File);
 	return !(mem_comp(pDemoHeader->m_aMarker, gs_aHeaderMarker, sizeof(gs_aHeaderMarker)) || pDemoHeader->m_Version < gs_OldVersion);

--- a/src/engine/shared/demo.cpp
+++ b/src/engine/shared/demo.cpp
@@ -225,7 +225,7 @@ void CDemoRecorder::WriteTickMarker(int Tick, int Keyframe)
 {
 	if(m_LastTickMarker == -1 || Tick - m_LastTickMarker > CHUNKMASK_TICK || Keyframe)
 	{
-		unsigned char aChunk[5];
+		unsigned char aChunk[sizeof(int32_t) + 1];
 		aChunk[0] = CHUNKTYPEFLAG_TICKMARKER;
 		uint_to_bytes_be(aChunk + 1, Tick);
 
@@ -347,18 +347,18 @@ int CDemoRecorder::Stop()
 
 	// add the demo length to the header
 	io_seek(m_File, gs_LengthOffset, IOSEEK_START);
-	unsigned char aLength[4];
+	unsigned char aLength[sizeof(int32_t)];
 	uint_to_bytes_be(aLength, Length());
 	io_write(m_File, aLength, sizeof(aLength));
 
 	// add the timeline markers to the header
 	io_seek(m_File, gs_NumMarkersOffset, IOSEEK_START);
-	unsigned char aNumMarkers[4];
+	unsigned char aNumMarkers[sizeof(int32_t)];
 	uint_to_bytes_be(aNumMarkers, m_NumTimelineMarkers);
 	io_write(m_File, aNumMarkers, sizeof(aNumMarkers));
 	for(int i = 0; i < m_NumTimelineMarkers; i++)
 	{
-		unsigned char aMarker[4];
+		unsigned char aMarker[sizeof(int32_t)];
 		uint_to_bytes_be(aMarker, m_aTimelineMarkers[i]);
 		io_write(m_File, aMarker, sizeof(aMarker));
 	}
@@ -454,7 +454,7 @@ int CDemoPlayer::ReadChunkHeader(int *pType, int *pSize, int *pTick)
 		}
 		else
 		{
-			unsigned char aTickdata[4];
+			unsigned char aTickdata[sizeof(int32_t)];
 			if(io_read(m_File, aTickdata, sizeof(aTickdata)) != sizeof(aTickdata))
 				return -1;
 			*pTick = bytes_be_to_uint(aTickdata);

--- a/src/engine/shared/network_server.cpp
+++ b/src/engine/shared/network_server.cpp
@@ -564,8 +564,8 @@ int CNetServer::OnSixupCtrlMsg(NETADDR &Addr, CNetChunk *pChunk, int ControlMsg,
 	else if(ControlMsg == NET_CTRLMSG_CONNECT)
 	{
 		SECURITY_TOKEN MyToken = GetToken(Addr);
-		unsigned char aToken[4];
-		mem_copy(aToken, &MyToken, 4);
+		unsigned char aToken[sizeof(SECURITY_TOKEN)];
+		mem_copy(aToken, &MyToken, sizeof(aToken));
 
 		CNetBase::SendControlMsg(m_Socket, &Addr, 0, NET_CTRLMSG_CONNECTACCEPT, aToken, sizeof(aToken), ResponseToken, true);
 		if(Token == MyToken)

--- a/src/engine/shared/snapshot.cpp
+++ b/src/engine/shared/snapshot.cpp
@@ -47,7 +47,7 @@ int CSnapshot::GetExternalItemType(int InternalType) const
 	const CSnapshotItem *pTypeItem = GetItem(TypeItemIndex);
 	CUuid Uuid;
 	for(int i = 0; i < (int)sizeof(CUuid) / 4; i++)
-		int_to_bytes_be(&Uuid.m_aData[i * 4], pTypeItem->Data()[i]);
+		uint_to_bytes_be(&Uuid.m_aData[i * 4], pTypeItem->Data()[i]);
 
 	return g_UuidManager.LookupUuid(Uuid);
 }
@@ -71,7 +71,7 @@ const void *CSnapshot::FindItem(int Type, int ID) const
 		CUuid TypeUuid = g_UuidManager.GetUuid(Type);
 		int aTypeUuidItem[sizeof(CUuid) / 4];
 		for(int i = 0; i < (int)sizeof(CUuid) / 4; i++)
-			aTypeUuidItem[i] = bytes_be_to_int(&TypeUuid.m_aData[i * 4]);
+			aTypeUuidItem[i] = bytes_be_to_uint(&TypeUuid.m_aData[i * 4]);
 
 		bool Found = false;
 		for(int i = 0; i < m_NumItems; i++)
@@ -630,7 +630,7 @@ void CSnapshotBuilder::AddExtendedItemType(int Index)
 	if(pUuidItem)
 	{
 		for(int i = 0; i < (int)sizeof(CUuid) / 4; i++)
-			pUuidItem[i] = bytes_be_to_int(&Uuid.m_aData[i * 4]);
+			pUuidItem[i] = bytes_be_to_uint(&Uuid.m_aData[i * 4]);
 	}
 }
 

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -397,12 +397,12 @@ protected:
 
 		int NumMarkers() const
 		{
-			return clamp<int>(bytes_be_to_int(m_TimelineMarkers.m_aNumTimelineMarkers), 0, MAX_TIMELINE_MARKERS);
+			return clamp<int>(bytes_be_to_uint(m_TimelineMarkers.m_aNumTimelineMarkers), 0, MAX_TIMELINE_MARKERS);
 		}
 
 		int Length() const
 		{
-			return bytes_be_to_int(m_Info.m_aLength);
+			return bytes_be_to_uint(m_Info.m_aLength);
 		}
 
 		unsigned Size() const

--- a/src/game/server/teehistorian.cpp
+++ b/src/game/server/teehistorian.cpp
@@ -423,7 +423,7 @@ void CTeeHistorian::RecordPlayerInput(int ClientID, uint32_t UniqueClientID, con
 		Buffer.Reset();
 
 		Buffer.AddInt(-TEEHISTORIAN_INPUT_DIFF);
-		CSnapshotDelta::DiffItem((int *)&pPrev->m_Input, (int *)pInput, (int *)&DiffInput, sizeof(DiffInput) / sizeof(int));
+		CSnapshotDelta::DiffItem((int *)&pPrev->m_Input, (int *)pInput, (int *)&DiffInput, sizeof(DiffInput) / sizeof(int32_t));
 		if(m_Debug)
 		{
 			const int *pData = (const int *)&DiffInput;
@@ -444,7 +444,7 @@ void CTeeHistorian::RecordPlayerInput(int ClientID, uint32_t UniqueClientID, con
 		}
 	}
 	Buffer.AddInt(ClientID);
-	for(int i = 0; i < (int)(sizeof(DiffInput) / sizeof(int)); i++)
+	for(size_t i = 0; i < sizeof(DiffInput) / sizeof(int32_t); i++)
 	{
 		Buffer.AddInt(((int *)&DiffInput)[i]);
 	}

--- a/src/test/bytes_be.cpp
+++ b/src/test/bytes_be.cpp
@@ -4,14 +4,14 @@
 
 #include <base/system.h>
 
-static const int INT_DATA[] = {0, 1, -1, 32, 64, 256, -512, 12345, -123456, 1234567, 12345678, 123456789, 2147483647, (-2147483647 - 1)};
-static const unsigned UINT_DATA[] = {0u, 1u, 2u, 32u, 64u, 256u, 512u, 12345u, 123456u, 1234567u, 12345678u, 123456789u, 2147483647u, 2147483648u, 4294967295u};
+static const int32_t INT_DATA[] = {0, 1, -1, 32, 64, 256, -512, 12345, -123456, 1234567, 12345678, 123456789, 2147483647, (-2147483647 - 1)};
+static const uint32_t UINT_DATA[] = {0u, 1u, 2u, 32u, 64u, 256u, 512u, 12345u, 123456u, 1234567u, 12345678u, 123456789u, 2147483647u, 2147483648u, 4294967295u};
 
 TEST(BytePacking, RoundtripInt)
 {
 	for(auto i : INT_DATA)
 	{
-		unsigned char aPacked[4];
+		unsigned char aPacked[sizeof(int32_t)];
 		uint_to_bytes_be(aPacked, i);
 		EXPECT_EQ(bytes_be_to_uint(aPacked), i);
 	}
@@ -21,7 +21,7 @@ TEST(BytePacking, RoundtripUnsigned)
 {
 	for(auto u : UINT_DATA)
 	{
-		unsigned char aPacked[4];
+		unsigned char aPacked[sizeof(uint32_t)];
 		uint_to_bytes_be(aPacked, u);
 		EXPECT_EQ(bytes_be_to_uint(aPacked), u);
 	}

--- a/src/test/bytes_be.cpp
+++ b/src/test/bytes_be.cpp
@@ -12,8 +12,8 @@ TEST(BytePacking, RoundtripInt)
 	for(auto i : INT_DATA)
 	{
 		unsigned char aPacked[4];
-		int_to_bytes_be(aPacked, i);
-		EXPECT_EQ(bytes_be_to_int(aPacked), i);
+		uint_to_bytes_be(aPacked, i);
+		EXPECT_EQ(bytes_be_to_uint(aPacked), i);
 	}
 }
 


### PR DESCRIPTION
Supersedes #6263.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
