### PR TITLE
Add 0.7 system message constants

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1975,6 +1975,7 @@ set_src(ENGINE_SHARED GLOB_RECURSE src/engine/shared
   packer.cpp
   packer.h
   protocol.h
+  protocol7.h
   protocol_ex.cpp
   protocol_ex.h
   protocol_ex_msgs.h

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -28,6 +28,7 @@
 #include <engine/shared/network.h>
 #include <engine/shared/packer.h>
 #include <engine/shared/protocol.h>
+#include <engine/shared/protocol7.h>
 #include <engine/shared/protocol_ex.h>
 #include <engine/shared/rust_version.h>
 #include <engine/shared/snapshot.h>
@@ -749,7 +750,7 @@ static inline bool RepackMsg(const CMsgPacker *pMsg, CPacker &Packer, bool Sixup
 			else if(MsgId >= NETMSG_CON_READY && MsgId <= NETMSG_INPUTTIMING)
 				MsgId += 1;
 			else if(MsgId == NETMSG_RCON_LINE)
-				MsgId = 13;
+				MsgId = protocol7::NETMSG_RCON_LINE;
 			else if(MsgId >= NETMSG_AUTH_CHALLENGE && MsgId <= NETMSG_AUTH_RESULT)
 				MsgId += 4;
 			else if(MsgId >= NETMSG_PING && MsgId <= NETMSG_ERROR)
@@ -1687,7 +1688,7 @@ void CServer::ProcessClientPacket(CNetChunk *pPacket)
 						}
 						else
 						{
-							CMsgPacker Msgp(11, true, true); //NETMSG_RCON_AUTH_ON
+							CMsgPacker Msgp(protocol7::NETMSG_RCON_AUTH_ON, true, true);
 							SendMsg(&Msgp, MSGFLAG_VITAL, ClientID);
 						}
 
@@ -3510,7 +3511,7 @@ void CServer::LogoutClient(int ClientID, const char *pReason)
 	}
 	else
 	{
-		CMsgPacker Msg(12, true, true); //NETMSG_RCON_AUTH_OFF
+		CMsgPacker Msg(protocol7::NETMSG_RCON_AUTH_OFF, true, true);
 		SendMsg(&Msg, MSGFLAG_VITAL, ClientID);
 	}
 

--- a/src/engine/shared/protocol7.h
+++ b/src/engine/shared/protocol7.h
@@ -1,0 +1,57 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#ifndef ENGINE_SHARED_PROTOCOL7_H
+#define ENGINE_SHARED_PROTOCOL7_H
+
+namespace protocol7 {
+
+enum
+{
+	NETMSG_NULL = 0,
+
+	// the first thing sent by the client
+	// contains the version info for the client
+	NETMSG_INFO = 1,
+
+	// sent by server
+	NETMSG_MAP_CHANGE, // sent when client should switch map
+	NETMSG_MAP_DATA, // map transfer, contains a chunk of the map file
+	NETMSG_SERVERINFO,
+	NETMSG_CON_READY, // connection is ready, client should send start info
+	NETMSG_SNAP, // normal snapshot, multiple parts
+	NETMSG_SNAPEMPTY, // empty snapshot
+	NETMSG_SNAPSINGLE, // ?
+	NETMSG_SNAPSMALL, //
+	NETMSG_INPUTTIMING, // reports how off the input was
+	NETMSG_RCON_AUTH_ON, // rcon authentication enabled
+	NETMSG_RCON_AUTH_OFF, // rcon authentication disabled
+	NETMSG_RCON_LINE, // line that should be printed to the remote console
+	NETMSG_RCON_CMD_ADD,
+	NETMSG_RCON_CMD_REM,
+
+	NETMSG_AUTH_CHALLANGE, //
+	NETMSG_AUTH_RESULT, //
+
+	// sent by client
+	NETMSG_READY, //
+	NETMSG_ENTERGAME,
+	NETMSG_INPUT, // contains the inputdata from the client
+	NETMSG_RCON_CMD, //
+	NETMSG_RCON_AUTH, //
+	NETMSG_REQUEST_MAP_DATA, //
+
+	NETMSG_AUTH_START, //
+	NETMSG_AUTH_RESPONSE, //
+
+	// sent by both
+	NETMSG_PING,
+	NETMSG_PING_REPLY,
+	NETMSG_ERROR,
+
+	NETMSG_MAPLIST_ENTRY_ADD, // todo 0.8: move up
+	NETMSG_MAPLIST_ENTRY_REM,
+};
+
+}
+
+#endif


### PR DESCRIPTION
The protocolglue allows using all network constants from 0.7 using the ``protocol7::`` prefix. Such as game messages snap objects etc. But system messages are still magic numbers.