### PR TITLE
Reset graphics container indices after deletion

### DIFF
--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -1947,23 +1947,27 @@ int CGraphics_Threaded::QuadContainerAddQuads(int ContainerIndex, CFreeformItem 
 
 void CGraphics_Threaded::QuadContainerReset(int ContainerIndex)
 {
+	if(ContainerIndex == -1)
+		return;
+
 	SQuadContainer &Container = m_vQuadContainers[ContainerIndex];
 	if(IsQuadContainerBufferingEnabled())
-	{
-		if(Container.m_QuadBufferContainerIndex != -1)
-			DeleteBufferContainer(Container.m_QuadBufferContainerIndex, true);
-	}
+		DeleteBufferContainer(Container.m_QuadBufferContainerIndex, true);
 	Container.m_vQuads.clear();
-	Container.m_QuadBufferContainerIndex = Container.m_QuadBufferObjectIndex = -1;
+	Container.m_QuadBufferObjectIndex = -1;
 }
 
-void CGraphics_Threaded::DeleteQuadContainer(int ContainerIndex)
+void CGraphics_Threaded::DeleteQuadContainer(int &ContainerIndex)
 {
+	if(ContainerIndex == -1)
+		return;
+
 	QuadContainerReset(ContainerIndex);
 
 	// also clear the container index
 	m_vQuadContainers[ContainerIndex].m_FreeIndex = m_FirstFreeQuadContainer;
 	m_FirstFreeQuadContainer = ContainerIndex;
+	ContainerIndex = -1;
 }
 
 void CGraphics_Threaded::RenderQuadContainer(int ContainerIndex, int QuadDrawNum)
@@ -2534,10 +2538,11 @@ int CGraphics_Threaded::CreateBufferContainer(SBufferContainerInfo *pContainerIn
 	return Index;
 }
 
-void CGraphics_Threaded::DeleteBufferContainer(int ContainerIndex, bool DestroyAllBO)
+void CGraphics_Threaded::DeleteBufferContainer(int &ContainerIndex, bool DestroyAllBO)
 {
 	if(ContainerIndex == -1)
 		return;
+
 	CCommandBuffer::SCommand_DeleteBufferContainer Cmd;
 	Cmd.m_BufferContainerIndex = ContainerIndex;
 	Cmd.m_DestroyAllBO = DestroyAllBO;
@@ -2564,6 +2569,7 @@ void CGraphics_Threaded::DeleteBufferContainer(int ContainerIndex, bool DestroyA
 	// also clear the buffer object index
 	m_vVertexArrayInfo[ContainerIndex].m_FreeIndex = m_FirstFreeVertexArrayInfo;
 	m_FirstFreeVertexArrayInfo = ContainerIndex;
+	ContainerIndex = -1;
 }
 
 void CGraphics_Threaded::UpdateBufferContainerInternal(int ContainerIndex, SBufferContainerInfo *pContainerInfo)

--- a/src/engine/client/graphics_threaded.h
+++ b/src/engine/client/graphics_threaded.h
@@ -1153,7 +1153,7 @@ public:
 	int QuadContainerAddQuads(int ContainerIndex, CQuadItem *pArray, int Num) override;
 	int QuadContainerAddQuads(int ContainerIndex, CFreeformItem *pArray, int Num) override;
 	void QuadContainerReset(int ContainerIndex) override;
-	void DeleteQuadContainer(int ContainerIndex) override;
+	void DeleteQuadContainer(int &ContainerIndex) override;
 	void RenderQuadContainer(int ContainerIndex, int QuadDrawNum) override;
 	void RenderQuadContainer(int ContainerIndex, int QuadOffset, int QuadDrawNum, bool ChangeWrapMode = true) override;
 	void RenderQuadContainerEx(int ContainerIndex, int QuadOffset, int QuadDrawNum, float X, float Y, float ScaleX = 1.f, float ScaleY = 1.f) override;
@@ -1254,7 +1254,7 @@ public:
 
 	int CreateBufferContainer(SBufferContainerInfo *pContainerInfo) override;
 	// destroying all buffer objects means, that all referenced VBOs are destroyed automatically, so the user does not need to save references to them
-	void DeleteBufferContainer(int ContainerIndex, bool DestroyAllBO = true) override;
+	void DeleteBufferContainer(int &ContainerIndex, bool DestroyAllBO = true) override;
 	void UpdateBufferContainerInternal(int ContainerIndex, SBufferContainerInfo *pContainerInfo);
 	void IndicesNumRequiredNotify(unsigned int RequiredIndicesCount) override;
 

--- a/src/engine/client/text.cpp
+++ b/src/engine/client/text.cpp
@@ -240,13 +240,14 @@ class CTextRender : public IEngineTextRender
 		}
 	}
 
-	void FreeTextContainerIndex(int Index)
+	void FreeTextContainerIndex(int &Index)
 	{
 		m_vTextContainerIndices[Index] = m_FirstFreeTextContainerIndex;
 		m_FirstFreeTextContainerIndex = Index;
+		Index = -1;
 	}
 
-	void FreeTextContainer(int Index)
+	void FreeTextContainer(int &Index)
 	{
 		m_vpTextContainers[Index]->Reset();
 		FreeTextContainerIndex(Index);
@@ -987,7 +988,6 @@ public:
 		if(TextContainer.m_StringInfo.m_vCharacterQuads.empty() && TextContainer.m_StringInfo.m_SelectionQuadContainerIndex == -1 && IsRendered)
 		{
 			FreeTextContainer(TextContainerIndex);
-			TextContainerIndex = -1;
 			return false;
 		}
 		else
@@ -1170,10 +1170,7 @@ public:
 		if(pCursor->m_CalculateSelectionMode != TEXT_CURSOR_SELECTION_MODE_NONE || pCursor->m_CursorMode != TEXT_CURSOR_CURSOR_MODE_NONE)
 		{
 			if(IsRendered)
-			{
-				if(TextContainer.m_StringInfo.m_SelectionQuadContainerIndex != -1)
-					Graphics()->QuadContainerReset(TextContainer.m_StringInfo.m_SelectionQuadContainerIndex);
-			}
+				Graphics()->QuadContainerReset(TextContainer.m_StringInfo.m_SelectionQuadContainerIndex);
 
 			// if in calculate mode, also calculate the cursor
 			if(pCursor->m_CursorMode == TEXT_CURSOR_CURSOR_MODE_CALCULATE)
@@ -1560,19 +1557,14 @@ public:
 
 	void DeleteTextContainer(int &TextContainerIndex) override
 	{
-		if(TextContainerIndex != -1)
-		{
-			STextContainer &TextContainer = GetTextContainer(TextContainerIndex);
-			if(Graphics()->IsTextBufferingEnabled())
-			{
-				if(TextContainer.m_StringInfo.m_QuadBufferContainerIndex != -1)
-					Graphics()->DeleteBufferContainer(TextContainer.m_StringInfo.m_QuadBufferContainerIndex, true);
-			}
-			if(TextContainer.m_StringInfo.m_SelectionQuadContainerIndex != -1)
-				Graphics()->DeleteQuadContainer(TextContainer.m_StringInfo.m_SelectionQuadContainerIndex);
-			FreeTextContainer(TextContainerIndex);
-			TextContainerIndex = -1;
-		}
+		if(TextContainerIndex == -1)
+			return;
+
+		STextContainer &TextContainer = GetTextContainer(TextContainerIndex);
+		if(Graphics()->IsTextBufferingEnabled())
+			Graphics()->DeleteBufferContainer(TextContainer.m_StringInfo.m_QuadBufferContainerIndex, true);
+		Graphics()->DeleteQuadContainer(TextContainer.m_StringInfo.m_SelectionQuadContainerIndex);
+		FreeTextContainer(TextContainerIndex);
 	}
 
 	void UploadTextContainer(int TextContainerIndex) override

--- a/src/engine/graphics.h
+++ b/src/engine/graphics.h
@@ -344,7 +344,7 @@ public:
 
 	virtual int CreateBufferContainer(struct SBufferContainerInfo *pContainerInfo) = 0;
 	// destroying all buffer objects means, that all referenced VBOs are destroyed automatically, so the user does not need to save references to them
-	virtual void DeleteBufferContainer(int ContainerIndex, bool DestroyAllBO = true) = 0;
+	virtual void DeleteBufferContainer(int &ContainerIndex, bool DestroyAllBO = true) = 0;
 	virtual void IndicesNumRequiredNotify(unsigned int RequiredIndicesCount) = 0;
 
 	// returns true if the driver age type is supported, passing BACKEND_TYPE_AUTO for BackendType will query the values for the currently used backend
@@ -424,7 +424,7 @@ public:
 	virtual int QuadContainerAddQuads(int ContainerIndex, CQuadItem *pArray, int Num) = 0;
 	virtual int QuadContainerAddQuads(int ContainerIndex, CFreeformItem *pArray, int Num) = 0;
 	virtual void QuadContainerReset(int ContainerIndex) = 0;
-	virtual void DeleteQuadContainer(int ContainerIndex) = 0;
+	virtual void DeleteQuadContainer(int &ContainerIndex) = 0;
 	virtual void RenderQuadContainer(int ContainerIndex, int QuadDrawNum) = 0;
 	virtual void RenderQuadContainer(int ContainerIndex, int QuadOffset, int QuadDrawNum, bool ChangeWrapMode = true) = 0;
 	virtual void RenderQuadContainerEx(int ContainerIndex, int QuadOffset, int QuadDrawNum, float X, float Y, float ScaleX = 1.f, float ScaleY = 1.f) = 0;

--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -48,9 +48,7 @@ void CChat::RebuildChat()
 	for(auto &Line : m_aLines)
 	{
 		TextRender()->DeleteTextContainer(Line.m_TextContainerIndex);
-		if(Line.m_QuadContainerIndex != -1)
-			Graphics()->DeleteQuadContainer(Line.m_QuadContainerIndex);
-		Line.m_QuadContainerIndex = -1;
+		Graphics()->DeleteQuadContainer(Line.m_QuadContainerIndex);
 		// recalculate sizes
 		Line.m_aYOffset[0] = -1.f;
 		Line.m_aYOffset[1] = -1.f;
@@ -67,14 +65,11 @@ void CChat::Reset()
 	for(auto &Line : m_aLines)
 	{
 		TextRender()->DeleteTextContainer(Line.m_TextContainerIndex);
-		if(Line.m_QuadContainerIndex != -1)
-			Graphics()->DeleteQuadContainer(Line.m_QuadContainerIndex);
+		Graphics()->DeleteQuadContainer(Line.m_QuadContainerIndex);
 		Line.m_Time = 0;
 		Line.m_aText[0] = 0;
 		Line.m_aName[0] = 0;
 		Line.m_Friend = false;
-		Line.m_TextContainerIndex = -1;
-		Line.m_QuadContainerIndex = -1;
 		Line.m_TimesRepeated = 0;
 		Line.m_HasRenderTee = false;
 	}
@@ -738,10 +733,7 @@ void CChat::AddLine(int ClientID, int Team, const char *pLine)
 		{
 			pCurrentLine->m_TimesRepeated++;
 			TextRender()->DeleteTextContainer(pCurrentLine->m_TextContainerIndex);
-
-			if(pCurrentLine->m_QuadContainerIndex != -1)
-				Graphics()->DeleteQuadContainer(pCurrentLine->m_QuadContainerIndex);
-			pCurrentLine->m_QuadContainerIndex = -1;
+			Graphics()->DeleteQuadContainer(pCurrentLine->m_QuadContainerIndex);
 			pCurrentLine->m_Time = time();
 			pCurrentLine->m_aYOffset[0] = -1.f;
 			pCurrentLine->m_aYOffset[1] = -1.f;
@@ -764,10 +756,7 @@ void CChat::AddLine(int ClientID, int Team, const char *pLine)
 		pCurrentLine->m_NameColor = -2;
 
 		TextRender()->DeleteTextContainer(pCurrentLine->m_TextContainerIndex);
-
-		if(pCurrentLine->m_QuadContainerIndex != -1)
-			Graphics()->DeleteQuadContainer(pCurrentLine->m_QuadContainerIndex);
-		pCurrentLine->m_QuadContainerIndex = -1;
+		Graphics()->DeleteQuadContainer(pCurrentLine->m_QuadContainerIndex);
 
 		// check for highlighted name
 		if(Client()->State() != IClient::STATE_DEMOPLAYBACK)
@@ -979,11 +968,7 @@ void CChat::OnPrepareLines()
 			continue;
 
 		TextRender()->DeleteTextContainer(m_aLines[r].m_TextContainerIndex);
-
-		if(m_aLines[r].m_QuadContainerIndex != -1)
-			Graphics()->DeleteQuadContainer(m_aLines[r].m_QuadContainerIndex);
-
-		m_aLines[r].m_QuadContainerIndex = -1;
+		Graphics()->DeleteQuadContainer(m_aLines[r].m_QuadContainerIndex);
 
 		char aName[64 + 12] = "";
 

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -36,8 +36,7 @@ void CHud::ResetHudContainers()
 		TextRender()->DeleteTextContainer(ScoreInfo.m_OptionalNameTextContainerIndex);
 		TextRender()->DeleteTextContainer(ScoreInfo.m_TextRankContainerIndex);
 		TextRender()->DeleteTextContainer(ScoreInfo.m_TextScoreContainerIndex);
-		if(ScoreInfo.m_RoundRectQuadContainerIndex != -1)
-			Graphics()->DeleteQuadContainer(ScoreInfo.m_RoundRectQuadContainerIndex);
+		Graphics()->DeleteQuadContainer(ScoreInfo.m_RoundRectQuadContainerIndex);
 
 		ScoreInfo.Reset();
 	}
@@ -199,8 +198,7 @@ void CHud::RenderScoreHud()
 				// draw box
 				if(RecreateRect)
 				{
-					if(m_aScoreInfo[t].m_RoundRectQuadContainerIndex != -1)
-						Graphics()->DeleteQuadContainer(m_aScoreInfo[t].m_RoundRectQuadContainerIndex);
+					Graphics()->DeleteQuadContainer(m_aScoreInfo[t].m_RoundRectQuadContainerIndex);
 
 					if(t == 0)
 						Graphics()->SetColor(1.0f, 0.0f, 0.0f, 0.25f);
@@ -379,8 +377,7 @@ void CHud::RenderScoreHud()
 				// draw box
 				if(RecreateRect)
 				{
-					if(m_aScoreInfo[t].m_RoundRectQuadContainerIndex != -1)
-						Graphics()->DeleteQuadContainer(m_aScoreInfo[t].m_RoundRectQuadContainerIndex);
+					Graphics()->DeleteQuadContainer(m_aScoreInfo[t].m_RoundRectQuadContainerIndex);
 
 					if(t == Local)
 						Graphics()->SetColor(1.0f, 1.0f, 1.0f, 0.25f);

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -53,8 +53,7 @@ void CUIElement::SUIElementRect::Draw(const CUIRect *pRect, ColorRGBA Color, int
 	bool NeedsRecreate = false;
 	if(m_UIRectQuadContainer == -1 || m_Width != pRect->w || m_Height != pRect->h || mem_comp(&m_QuadColor, &Color, sizeof(Color)) != 0)
 	{
-		if(m_UIRectQuadContainer != -1)
-			m_pParent->UI()->Graphics()->DeleteQuadContainer(m_UIRectQuadContainer);
+		m_pParent->UI()->Graphics()->DeleteQuadContainer(m_UIRectQuadContainer);
 		NeedsRecreate = true;
 	}
 	m_X = pRect->x;
@@ -157,11 +156,8 @@ void CUI::ResetUIElement(CUIElement &UIElement)
 {
 	for(CUIElement::SUIElementRect &Rect : UIElement.m_vUIRects)
 	{
-		if(Rect.m_UIRectQuadContainer != -1)
-			Graphics()->DeleteQuadContainer(Rect.m_UIRectQuadContainer);
-		Rect.m_UIRectQuadContainer = -1;
+		Graphics()->DeleteQuadContainer(Rect.m_UIRectQuadContainer);
 		TextRender()->DeleteTextContainer(Rect.m_UITextContainer);
-
 		Rect.Reset();
 	}
 }


### PR DESCRIPTION
Reduce duplicate code and improve correctness by passing indices of quad, buffer and text containers by reference and always setting them to `-1` after they are deleted.

Also check if index is `-1` before trying to delete it to reduce duplicate code when calling the methods.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
