### PR TITLE
Simplify `io_write_newline` error handling

### DIFF
--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -364,12 +364,12 @@ unsigned io_write(IOHANDLE io, const void *buffer, unsigned size)
 	return fwrite(buffer, 1, size, (FILE *)io);
 }
 
-unsigned io_write_newline(IOHANDLE io)
+bool io_write_newline(IOHANDLE io)
 {
 #if defined(CONF_FAMILY_WINDOWS)
-	return fwrite("\r\n", 1, 2, (FILE *)io);
+	return io_write(io, "\r\n", 2) == 2;
 #else
-	return fwrite("\n", 1, 1, (FILE *)io);
+	return io_write(io, "\n", 1) == 1;
 #endif
 }
 

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -296,15 +296,15 @@ unsigned io_skip(IOHANDLE io, int size);
 unsigned io_write(IOHANDLE io, const void *buffer, unsigned size);
 
 /**
- * Writes newline to file.
+ * Writes a platform dependent newline to file.
  *
  * @ingroup File-IO
  *
  * @param io Handle to the file.
  *
- * @return Number of bytes written.
+ * @return true on success, false on failure.
  */
-unsigned io_write_newline(IOHANDLE io);
+bool io_write_newline(IOHANDLE io);
 
 /**
  * Seeks to a specified offset in the file.

--- a/src/engine/shared/config.cpp
+++ b/src/engine/shared/config.cpp
@@ -147,12 +147,10 @@ void CConfigManager::WriteLine(const char *pLine)
 {
 	if(!m_ConfigFile ||
 		io_write(m_ConfigFile, pLine, str_length(pLine)) != static_cast<unsigned>(str_length(pLine)) ||
-#if defined(CONF_FAMILY_WINDOWS)
-		io_write_newline(m_ConfigFile) != 2)
-#else
-		io_write_newline(m_ConfigFile) != 1)
-#endif
+		!io_write_newline(m_ConfigFile))
+	{
 		m_Failed = true;
+	}
 }
 
 IConfigManager *CreateConfigManager() { return new CConfigManager; }


### PR DESCRIPTION
Instead of returning the number of bytes written, which are platform specific, return `true` on success and `false` on failure, so no platform specific code is required when checking the result.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
