### PR TITLE
Support 4 and 8 digit RGBA color values in console

### DIFF
--- a/src/base/color.h
+++ b/src/base/color.h
@@ -109,14 +109,14 @@ public:
 	bool operator==(const color4_base &col) const { return x == col.x && y == col.y && z == col.z && a == col.a; }
 	bool operator!=(const color4_base &col) const { return x != col.x || y != col.y || z != col.z || a != col.a; }
 
-	unsigned Pack(bool Alpha = true)
+	unsigned Pack(bool Alpha = true) const
 	{
 		return (Alpha ? ((unsigned)round_to_int(a * 255.0f) << 24) : 0) + ((unsigned)round_to_int(x * 255.0f) << 16) + ((unsigned)round_to_int(y * 255.0f) << 8) + (unsigned)round_to_int(z * 255.0f);
 	}
 
-	DerivedT WithAlpha(float alpha)
+	DerivedT WithAlpha(float alpha) const
 	{
-		DerivedT col(static_cast<DerivedT &>(*this));
+		DerivedT col(static_cast<const DerivedT &>(*this));
 		col.a = alpha;
 		return col;
 	}
@@ -130,19 +130,19 @@ public:
 
 	constexpr static const float DARKEST_LGT = 0.5f;
 
-	ColorHSLA UnclampLighting(float Darkest = DARKEST_LGT)
+	ColorHSLA UnclampLighting(float Darkest = DARKEST_LGT) const
 	{
 		ColorHSLA col = *this;
 		col.l = Darkest + col.l * (1.0f - Darkest);
 		return col;
 	}
 
-	unsigned Pack(bool Alpha = true)
+	unsigned Pack(bool Alpha = true) const
 	{
 		return color4_base::Pack(Alpha);
 	}
 
-	unsigned Pack(float Darkest, bool Alpha = false)
+	unsigned Pack(float Darkest, bool Alpha = false) const
 	{
 		ColorHSLA col = *this;
 		col.l = (l - Darkest) / (1 - Darkest);

--- a/src/engine/console.rs
+++ b/src/engine/console.rs
@@ -144,7 +144,9 @@ mod ffi {
         ///
         /// It supports the following formats:
         /// - `$XXX` (RGB, e.g. `$f00` for red)
+        /// - `$XXXX` (RGBA, e.g. `$f00f` for red with maximum opacity)
         /// - `$XXXXXX` (RGB, e.g. `$ffa500` for DDNet's logo color)
+        /// - `$XXXXXXXX` (RGBA, e.g. `$ffa500ff` for DDNet's logo color with maximum opacity)
         /// - base 10 integers (24/32 bit HSL in base 10, e.g. `0` for black)
         /// - the following color names: `red`, `yellow`, `green`, `cyan`,
         /// `blue`, `magenta`, `white`, `gray`, `black`.
@@ -169,11 +171,11 @@ mod ffi {
         /// #
         /// # let mut console = CreateConsole(CFGFLAG_SERVER);
         /// # let mut executed = false;
-        /// # console.pin_mut().Register(s!("command"), s!("ssssss"), CFGFLAG_SERVER, IConsole_FCommandCallback(callback), UserPtr::from(&mut executed), s!(""));
-        /// # console.pin_mut().ExecuteLine(s!(r#"command "$f00" $ffa500 $1234 shiny cyan -16777216"#), -1, true);
+        /// # console.pin_mut().Register(s!("command"), s!("ssssssss"), CFGFLAG_SERVER, IConsole_FCommandCallback(callback), UserPtr::from(&mut executed), s!(""));
+        /// # console.pin_mut().ExecuteLine(s!(r#"command "$f00" $ffa500 $12345 shiny cyan -16777216 $f008 $00ffff80"#), -1, true);
         /// # extern "C" fn callback(result_param: &IConsole_IResult, mut user: UserPtr) {
         /// # unsafe { *user.cast_mut::<bool>() = true; }
-        /// let result: &IConsole_IResult /* = `command "$f00" $ffa500 $1234 shiny cyan -16777216` */;
+        /// let result: &IConsole_IResult /* = `command "$f00" $ffa500 $12345 shiny cyan -16777216 $f008 $00ffff80` */;
         /// # result = result_param;
         /// assert_eq!(result.GetColor(0, false), ColorHSLA { h: 0.0, s: 1.0, l: 0.5, a: 1.0 }); // red
         /// assert_eq!(result.GetColor(1, false), ColorHSLA { h: 0.10784314, s: 1.0, l: 0.5, a: 1.0 }); // DDNet logo color
@@ -181,7 +183,9 @@ mod ffi {
         /// assert_eq!(result.GetColor(3, false), ColorHSLA { h: 0.0, s: 0.0, l: 0.0, a: 1.0 }); // unknown color name => black
         /// assert_eq!(result.GetColor(4, false), ColorHSLA { h: 0.5, s: 1.0, l: 0.5, a: 1.0 }); // cyan
         /// assert_eq!(result.GetColor(5, false), ColorHSLA { h: 0.0, s: 0.0, l: 0.0, a: 1.0 }); // black
-        /// assert_eq!(result.GetColor(6, false), ColorHSLA { h: 0.0, s: 0.0, l: 0.0, a: 1.0 }); // out of range => black
+        /// assert_eq!(result.GetColor(6, false), ColorHSLA { h: 0.0, s: 1.0, l: 0.5, a: 0.53333336 }); // red with alpha specified
+        /// assert_eq!(result.GetColor(7, false), ColorHSLA { h: 0.5, s: 1.0, l: 0.5, a: 0.5019608 }); // cyan with alpha specified
+        /// assert_eq!(result.GetColor(8, false), ColorHSLA { h: 0.0, s: 0.0, l: 0.0, a: 1.0 }); // out of range => black
         ///
         /// assert_eq!(result.GetColor(0, true), result.GetColor(0, false));
         /// assert_eq!(result.GetColor(1, true), result.GetColor(1, false));
@@ -190,6 +194,8 @@ mod ffi {
         /// assert_eq!(result.GetColor(4, true), result.GetColor(4, false));
         /// assert_eq!(result.GetColor(5, true), ColorHSLA { h: 0.0, s: 0.0, l: 0.5, a: 1.0 }); // black, but has the `Light` parameter set
         /// assert_eq!(result.GetColor(6, true), result.GetColor(6, false));
+        /// assert_eq!(result.GetColor(7, true), result.GetColor(7, false));
+        /// assert_eq!(result.GetColor(8, true), result.GetColor(8, false));
         /// # }
         /// # assert!(executed);
         /// ```

--- a/src/engine/shared/console.cpp
+++ b/src/engine/shared/console.cpp
@@ -42,16 +42,16 @@ float CConsole::CResult::GetFloat(unsigned Index) const
 
 ColorHSLA CConsole::CResult::GetColor(unsigned Index, bool Light) const
 {
-	ColorHSLA Hsla = ColorHSLA(0, 0, 0);
 	if(Index >= m_NumArgs)
-		return Hsla;
+		return ColorHSLA(0, 0, 0);
 
 	const char *pStr = m_apArgs[Index];
 	if(str_isallnum(pStr) || ((pStr[0] == '-' || pStr[0] == '+') && str_isallnum(pStr + 1))) // Teeworlds Color (Packed HSL)
 	{
-		Hsla = ColorHSLA(str_toulong_base(pStr, 10), true);
+		const ColorHSLA Hsla = ColorHSLA(str_toulong_base(pStr, 10), true);
 		if(Light)
-			Hsla = Hsla.UnclampLighting();
+			return Hsla.UnclampLighting();
+		return Hsla;
 	}
 	else if(*pStr == '$') // Hex RGB
 	{
@@ -73,31 +73,31 @@ ColorHSLA CConsole::CResult::GetColor(unsigned Index, bool Light) const
 		}
 		else
 		{
-			return Hsla;
+			return ColorHSLA(0, 0, 0);
 		}
 
-		Hsla = color_cast<ColorHSLA>(Rgba);
+		return color_cast<ColorHSLA>(Rgba);
 	}
 	else if(!str_comp_nocase(pStr, "red"))
-		Hsla = ColorHSLA(0.0f / 6.0f, 1, .5f);
+		return ColorHSLA(0.0f / 6.0f, 1, .5f);
 	else if(!str_comp_nocase(pStr, "yellow"))
-		Hsla = ColorHSLA(1.0f / 6.0f, 1, .5f);
+		return ColorHSLA(1.0f / 6.0f, 1, .5f);
 	else if(!str_comp_nocase(pStr, "green"))
-		Hsla = ColorHSLA(2.0f / 6.0f, 1, .5f);
+		return ColorHSLA(2.0f / 6.0f, 1, .5f);
 	else if(!str_comp_nocase(pStr, "cyan"))
-		Hsla = ColorHSLA(3.0f / 6.0f, 1, .5f);
+		return ColorHSLA(3.0f / 6.0f, 1, .5f);
 	else if(!str_comp_nocase(pStr, "blue"))
-		Hsla = ColorHSLA(4.0f / 6.0f, 1, .5f);
+		return ColorHSLA(4.0f / 6.0f, 1, .5f);
 	else if(!str_comp_nocase(pStr, "magenta"))
-		Hsla = ColorHSLA(5.0f / 6.0f, 1, .5f);
+		return ColorHSLA(5.0f / 6.0f, 1, .5f);
 	else if(!str_comp_nocase(pStr, "white"))
-		Hsla = ColorHSLA(0, 0, 1);
+		return ColorHSLA(0, 0, 1);
 	else if(!str_comp_nocase(pStr, "gray"))
-		Hsla = ColorHSLA(0, 0, .5f);
+		return ColorHSLA(0, 0, .5f);
 	else if(!str_comp_nocase(pStr, "black"))
-		Hsla = ColorHSLA(0, 0, 0);
+		return ColorHSLA(0, 0, 0);
 
-	return Hsla;
+	return ColorHSLA(0, 0, 0);
 }
 
 const IConsole::CCommandInfo *CConsole::CCommand::NextCommandInfo(int AccessLevel, int FlagMask) const

--- a/src/engine/shared/console.cpp
+++ b/src/engine/shared/console.cpp
@@ -53,23 +53,39 @@ ColorHSLA CConsole::CResult::GetColor(unsigned Index, bool Light) const
 			return Hsla.UnclampLighting();
 		return Hsla;
 	}
-	else if(*pStr == '$') // Hex RGB
+	else if(*pStr == '$') // Hex RGB/RGBA
 	{
 		ColorRGBA Rgba = ColorRGBA(0, 0, 0, 1);
-		int Len = str_length(pStr);
+		const int Len = str_length(pStr);
 		if(Len == 4)
 		{
-			unsigned Num = str_toulong_base(pStr + 1, 16);
+			const unsigned Num = str_toulong_base(pStr + 1, 16);
 			Rgba.r = (((Num >> 8) & 0x0F) + ((Num >> 4) & 0xF0)) / 255.0f;
 			Rgba.g = (((Num >> 4) & 0x0F) + ((Num >> 0) & 0xF0)) / 255.0f;
 			Rgba.b = (((Num >> 0) & 0x0F) + ((Num << 4) & 0xF0)) / 255.0f;
 		}
+		else if(Len == 5)
+		{
+			const unsigned Num = str_toulong_base(pStr + 1, 16);
+			Rgba.r = (((Num >> 12) & 0x0F) + ((Num >> 8) & 0xF0)) / 255.0f;
+			Rgba.g = (((Num >> 8) & 0x0F) + ((Num >> 4) & 0xF0)) / 255.0f;
+			Rgba.b = (((Num >> 4) & 0x0F) + ((Num >> 0) & 0xF0)) / 255.0f;
+			Rgba.a = (((Num >> 0) & 0x0F) + ((Num << 4) & 0xF0)) / 255.0f;
+		}
 		else if(Len == 7)
 		{
-			unsigned Num = str_toulong_base(pStr + 1, 16);
+			const unsigned Num = str_toulong_base(pStr + 1, 16);
 			Rgba.r = ((Num >> 16) & 0xFF) / 255.0f;
 			Rgba.g = ((Num >> 8) & 0xFF) / 255.0f;
 			Rgba.b = ((Num >> 0) & 0xFF) / 255.0f;
+		}
+		else if(Len == 9)
+		{
+			const unsigned Num = str_toulong_base(pStr + 1, 16);
+			Rgba.r = ((Num >> 24) & 0xFF) / 255.0f;
+			Rgba.g = ((Num >> 16) & 0xFF) / 255.0f;
+			Rgba.b = ((Num >> 8) & 0xFF) / 255.0f;
+			Rgba.a = ((Num >> 0) & 0xFF) / 255.0f;
 		}
 		else
 		{


### PR DESCRIPTION
In addition to values in `$RGB` and `$RRGGBB` format, also support the `$RGBA` and `$RRGGBBAA` formats for color variables.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
