### PR TITLE
Only call onresize events if actual size changed

### DIFF
--- a/src/engine/client/graphics_threaded.h
+++ b/src/engine/client/graphics_threaded.h
@@ -878,14 +878,8 @@ class CGraphics_Threaded : public IEngineGraphics
 	std::vector<SQuadContainer> m_vQuadContainers;
 	int m_FirstFreeQuadContainer;
 
-	struct SWindowResizeListener
-	{
-		SWindowResizeListener(WINDOW_RESIZE_FUNC pFunc, void *pUser) :
-			m_pFunc(std::move(pFunc)), m_pUser(pUser) {}
-		WINDOW_RESIZE_FUNC m_pFunc;
-		void *m_pUser;
-	};
-	std::vector<SWindowResizeListener> m_vResizeListeners;
+	std::vector<WINDOW_RESIZE_FUNC> m_vResizeListeners;
+	std::vector<WINDOW_PROPS_CHANGED_FUNC> m_vPropChangeListeners;
 
 	void *AllocCommandBufferData(unsigned AllocSize);
 
@@ -1268,7 +1262,8 @@ public:
 	void Resize(int w, int h, int RefreshRate) override;
 	void GotResized(int w, int h, int RefreshRate) override;
 	void UpdateViewport(int X, int Y, int W, int H, bool ByResize) override;
-	void AddWindowResizeListener(WINDOW_RESIZE_FUNC pFunc, void *pUser) override;
+	void AddWindowResizeListener(WINDOW_RESIZE_FUNC pFunc) override;
+	void AddWindowPropChangeListener(WINDOW_PROPS_CHANGED_FUNC pFunc) override;
 	int GetWindowScreen() override;
 
 	void WindowDestroyNtf(uint32_t WindowID) override;

--- a/src/engine/graphics.h
+++ b/src/engine/graphics.h
@@ -199,7 +199,8 @@ struct STWGraphicGPU
 
 typedef STWGraphicGPU TTWGraphicsGPUList;
 
-typedef std::function<void(void *)> WINDOW_RESIZE_FUNC;
+typedef std::function<void()> WINDOW_RESIZE_FUNC;
+typedef std::function<void()> WINDOW_PROPS_CHANGED_FUNC;
 
 namespace client_data7 {
 struct CDataSprite; // NOLINT(bugprone-forward-declaration-namespace)
@@ -261,7 +262,16 @@ public:
 	virtual void Resize(int w, int h, int RefreshRate) = 0;
 	virtual void GotResized(int w, int h, int RefreshRate) = 0;
 	virtual void UpdateViewport(int X, int Y, int W, int H, bool ByResize) = 0;
-	virtual void AddWindowResizeListener(WINDOW_RESIZE_FUNC pFunc, void *pUser) = 0;
+
+	/**
+	* Listens to a resize event of the canvas, which is usually caused by a window resize.
+	* Will only be triggered if the actual size changed.
+	*/
+	virtual void AddWindowResizeListener(WINDOW_RESIZE_FUNC pFunc) = 0;
+	/**
+	* Listens to various window property changes, such as minimize, maximize, move, fullscreen mode
+	*/
+	virtual void AddWindowPropChangeListener(WINDOW_PROPS_CHANGED_FUNC pFunc) = 0;
 
 	virtual void WindowDestroyNtf(uint32_t WindowID) = 0;
 	virtual void WindowCreateNtf(uint32_t WindowID) = 0;

--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -1106,12 +1106,11 @@ void CGameConsole::OnInit()
 	m_pConsoleLogger = new CConsoleLogger(this);
 	Engine()->SetAdditionalLogger(std::unique_ptr<ILogger>(m_pConsoleLogger));
 	// add resize event
-	Graphics()->AddWindowResizeListener([this](void *) {
+	Graphics()->AddWindowResizeListener([this]() {
 		m_LocalConsole.ClearBacklogYOffsets();
 		m_RemoteConsole.ClearBacklogYOffsets();
 		m_HasSelection = false;
-	},
-		nullptr);
+	});
 }
 
 void CGameConsole::OnStateChange(int NewState, int OldState)

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -1508,10 +1508,9 @@ void CMenus::RenderSettingsGraphics(CUIRect MainView)
 	{
 		s_WasInit = true;
 
-		Graphics()->AddWindowResizeListener([&](void *pUser) {
+		Graphics()->AddWindowPropChangeListener([]() {
 			s_ModesReload = true;
-		},
-			this);
+		});
 	}
 
 	if(s_ModesReload || g_Config.m_GfxDisplayAllVideoModes != s_InitDisplayAllVideoModes)

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -225,7 +225,7 @@ void CGameClient::OnInit()
 
 	m_pGraphics = Kernel()->RequestInterface<IGraphics>();
 
-	m_pGraphics->AddWindowResizeListener(OnWindowResizeCB, this);
+	m_pGraphics->AddWindowResizeListener([this] { OnWindowResize(); });
 
 	// propagate pointers
 	m_UI.Init(Kernel());
@@ -901,12 +901,6 @@ void CGameClient::OnWindowResize()
 
 	UI()->OnWindowResize();
 	TextRender()->OnWindowResize();
-}
-
-void CGameClient::OnWindowResizeCB(void *pUser)
-{
-	CGameClient *pClient = (CGameClient *)pUser;
-	pClient->OnWindowResize();
 }
 
 void CGameClient::OnLanguageChange()

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -474,7 +474,6 @@ public:
 	virtual void OnFlagGrab(int TeamID);
 
 	void OnWindowResize();
-	static void OnWindowResizeCB(void *pUser);
 
 	void OnLanguageChange();
 


### PR DESCRIPTION
clearify difference between resize and window property change for resolution list

for: " Maybe we can at least fix this for 16.8 so the crash is no longer triggered by minimizing/maximizing and only by resizing." from https://github.com/ddnet/ddnet/pull/6358#issuecomment-1445046002

Only partially quickly tested.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
