### PR TITLE
Fix incorrect text wrapping in ingame server info

### DIFF
--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -392,7 +392,7 @@ void CMenus::RenderServerInfo(CUIRect MainView)
 	x = 5.0f;
 	y = 0.0f;
 
-	TextRender()->Text(ServerInfo.x + x, ServerInfo.y + y, 32, Localize("Server info"), 250.0f);
+	TextRender()->Text(ServerInfo.x + x, ServerInfo.y + y, 32, Localize("Server info"), -1.0f);
 	y += 32.0f + 5.0f;
 
 	mem_zero(aBuf, sizeof(aBuf));
@@ -410,7 +410,7 @@ void CMenus::RenderServerInfo(CUIRect MainView)
 		Localize("Version"), CurrentServerInfo.m_aVersion,
 		Localize("Password"), CurrentServerInfo.m_Flags & 1 ? Localize("Yes") : Localize("No"));
 
-	TextRender()->Text(ServerInfo.x + x, ServerInfo.y + y, 20, aBuf, 250.0f);
+	TextRender()->Text(ServerInfo.x + x, ServerInfo.y + y, 20, aBuf, ServerInfo.w - 10.0f);
 
 	// copy info button
 	{
@@ -451,7 +451,7 @@ void CMenus::RenderServerInfo(CUIRect MainView)
 	x = 5.0f;
 	y = 0.0f;
 
-	TextRender()->Text(GameInfo.x + x, GameInfo.y + y, 32, Localize("Game info"), 250.0f);
+	TextRender()->Text(GameInfo.x + x, GameInfo.y + y, 32, Localize("Game info"), -1.0f);
 	y += 32.0f + 5.0f;
 
 	if(m_pClient->m_Snap.m_pGameInfoObj)
@@ -472,7 +472,7 @@ void CMenus::RenderServerInfo(CUIRect MainView)
 			Localize("Score limit"), m_pClient->m_Snap.m_pGameInfoObj->m_ScoreLimit,
 			Localize("Time limit"), m_pClient->m_Snap.m_pGameInfoObj->m_TimeLimit,
 			Localize("Players"), m_pClient->m_Snap.m_NumPlayers, CurrentServerInfo.m_MaxClients);
-		TextRender()->Text(GameInfo.x + x, GameInfo.y + y, 20, aBuf, 250.0f);
+		TextRender()->Text(GameInfo.x + x, GameInfo.y + y, 20, aBuf, GameInfo.w - 10.0f);
 	}
 
 	// motd


### PR DESCRIPTION
The maximum width for the server info and game info text was too small, which previously didn't matter, because the manual newlines broke text wrapping in this case, but with the fix from #6353 this now causes the text to break after the colons already.

This is fixed by using the maximum available width for the text instead of a too small magic number (`250.0f`).

For completeness, the maximum width for the title texts is unset (`-1.0f`), because they should never wrap, which is consistent with the MOTD title text.

Before:

![screenshot_2023-02-26_11-46-26](https://user-images.githubusercontent.com/23437060/221405841-30c0a57a-d7ce-44c5-8c2e-958d67c801a4.png)

After:

![screenshot_2023-02-26_11-41-24](https://user-images.githubusercontent.com/23437060/221405844-faf9095f-07d9-4dde-bfd5-9e44197d1fce.png)


## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
