### PR TITLE
Fix erratic smooth scrolling when scroll time is changed

### DIFF
--- a/src/game/client/ui_scrollregion.h
+++ b/src/game/client/ui_scrollregion.h
@@ -91,6 +91,7 @@ private:
 	float m_ContentH;
 	float m_RequestScrollY; // [0, ContentHeight]
 
+	float m_AnimTimeMax;
 	float m_AnimTime;
 	float m_AnimInitScrollY;
 	float m_AnimTargetScrollY;


### PR DESCRIPTION
Remember the maximum animation time when initiating a smooth scroll, so the smooth scrolling does not change erratically when `ui_smooth_scroll_time` is changed while smooth scrolling is in progress.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
