### PR TITLE
Fix warning in CI when cloning twmap from GitLab

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -21,7 +21,7 @@ jobs:
         sudo apt-get update -y
         sudo apt-get install clang-format imagemagick ddnet-tools shellcheck pkg-config cmake ninja-build libfreetype6-dev libnotify-dev libsdl2-dev libsqlite3-dev libavcodec-dev libavformat-dev libavutil-dev libswresample-dev libswscale-dev libx264-dev python3-clang libvulkan-dev glslang-tools spirv-tools rustc cargo -y
         pip3 install pylint
-        git clone https://gitlab.com/Patiga/twmap
+        git clone https://gitlab.com/Patiga/twmap.git/
         cd twmap/twmap-tools
         cargo install --path=.
         cd ../..


### PR DESCRIPTION
`warning: redirecting to https://gitlab.com/Patiga/twmap.git/`

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
