### PR TITLE
Fix server logfile error message

### DIFF
--- a/src/engine/server/main.cpp
+++ b/src/engine/server/main.cpp
@@ -181,7 +181,7 @@ int main(int argc, const char **argv)
 		}
 		else
 		{
-			dbg_msg("client", "failed to open '%s' for logging", g_Config.m_Logfile);
+			dbg_msg("server", "failed to open '%s' for logging", g_Config.m_Logfile);
 		}
 	}
 	pEngine->SetAdditionalLogger(std::make_unique<CServerLogger>(pServer));


### PR DESCRIPTION
before:
```
$ ./DDNet-Server 'logfile "invalid/path.txt"' | grep failed
2023-03-02 09:43:37 I client: failed to open 'invalid/path.txt' for logging
```

after:
```
$ ./DDNet-Server 'logfile "invalid/path.txt"' | grep failed
2023-03-02 09:43:55 I server: failed to open 'invalid/path.txt' for logging
```

:exploding_head: 