### PR TITLE
Close editor popups and prevent popups from opening when GUI hidden

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -1331,7 +1331,7 @@ void CEditor::DoSoundSource(CSoundSource *pSource, int Index)
 		{
 			if(!UI()->MouseButton(1))
 			{
-				if(m_vSelectedLayers.size() == 1)
+				if(m_vSelectedLayers.size() == 1 && m_GuiActive)
 				{
 					static int s_SourcePopupID = 0;
 					UiInvokePopupMenu(&s_SourcePopupID, 0, UI()->MouseX(), UI()->MouseY(), 120, 200, PopupSource);
@@ -1480,7 +1480,7 @@ void CEditor::DoQuad(CQuad *pQuad, int Index)
 		{
 			if(!UI()->MouseButton(1))
 			{
-				if(m_vSelectedLayers.size() == 1)
+				if(m_vSelectedLayers.size() == 1 && m_GuiActive)
 				{
 					m_SelectedQuadIndex = FindSelectedQuadIndex(Index);
 
@@ -1692,7 +1692,7 @@ void CEditor::DoQuadPoint(CQuad *pQuad, int QuadIndex, int V)
 		{
 			if(!UI()->MouseButton(1))
 			{
-				if(m_vSelectedLayers.size() == 1)
+				if(m_vSelectedLayers.size() == 1 && m_GuiActive)
 				{
 					m_SelectedQuadPoint = V;
 					m_SelectedQuadIndex = FindSelectedQuadIndex(QuadIndex);
@@ -6496,7 +6496,10 @@ void CEditor::OnRender()
 	{
 		m_GuiActive = !m_GuiActive;
 		if(!m_GuiActive)
+		{
 			m_LockMouse = false;
+			UiClosePopupMenus();
+		}
 	}
 
 	if(Input()->KeyPress(KEY_F10))


### PR DESCRIPTION
Prevent editor popups (quad point, quad pivot, sound source) from being opened while the editor GUI is hidden. The opened popups would not be visible, which results in multiple identical popups being opened at the same time. This cannot happen while the GUI is shown, as the already opened popup takes focus so no second identical popup can be opened at the same time.

Additionally, all opened popups are now closed when the GUI is hidden. Otherwise this results in crashes, as the already opened popups reference the current layer and quad selection, which can change or become invalidated while the GUI is hidden.

Closes #6383.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
