### PR TITLE
CMake: Add targets to allow (previously available) build by exec name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2588,6 +2588,19 @@ if(SERVER)
   endif()
 endif()
 
+# Targets for compatibility with build commands previously available with Makefiles
+if(CMAKE_GENERATOR MATCHES ".*Makefiles.*")
+  if(TARGET game-client)
+    add_custom_target(${CLIENT_EXECUTABLE})
+    add_dependencies(${CLIENT_EXECUTABLE} game-client)
+  endif()
+
+  if(TARGET game-server)
+    add_custom_target(${SERVER_EXECUTABLE})
+    add_dependencies(${SERVER_EXECUTABLE} game-server)
+  endif()
+endif()
+
 ########################################################################
 # VARIOUS TARGETS
 ########################################################################


### PR DESCRIPTION
Seems to be needed only for MinGW/Unix Makefiles generator.

Note: ninja (and probably some other build systems) does not allow us to add extra `DDNet` target because it already builds a file with that name. At the same time, CMake alias targets are not propagated to Makefile.