### PR TITLE
Revert editor changes to popup menus, so popup menus are shown also when GUI is hidden

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -5965,8 +5965,7 @@ void CEditor::Render()
 		m_PopupEventWasActivated = true;
 	}
 
-	if(m_GuiActive)
-		UiDoPopupMenu();
+	UiDoPopupMenu();
 
 	if(m_Dialog == DIALOG_NONE && !m_MouseInsidePopup && UI()->MouseInside(&View))
 	{
@@ -6493,11 +6492,7 @@ void CEditor::OnRender()
 {
 	// toggle gui
 	if(m_Dialog == DIALOG_NONE && m_EditBoxActive == 0 && Input()->KeyPress(KEY_TAB))
-	{
 		m_GuiActive = !m_GuiActive;
-		if(!m_GuiActive)
-			m_LockMouse = false;
-	}
 
 	if(Input()->KeyPress(KEY_F10))
 		m_ShowMousePointer = false;

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -1331,7 +1331,7 @@ void CEditor::DoSoundSource(CSoundSource *pSource, int Index)
 		{
 			if(!UI()->MouseButton(1))
 			{
-				if(m_vSelectedLayers.size() == 1 && m_GuiActive)
+				if(m_vSelectedLayers.size() == 1)
 				{
 					static int s_SourcePopupID = 0;
 					UiInvokePopupMenu(&s_SourcePopupID, 0, UI()->MouseX(), UI()->MouseY(), 120, 200, PopupSource);
@@ -1480,7 +1480,7 @@ void CEditor::DoQuad(CQuad *pQuad, int Index)
 		{
 			if(!UI()->MouseButton(1))
 			{
-				if(m_vSelectedLayers.size() == 1 && m_GuiActive)
+				if(m_vSelectedLayers.size() == 1)
 				{
 					m_SelectedQuadIndex = FindSelectedQuadIndex(Index);
 
@@ -1692,7 +1692,7 @@ void CEditor::DoQuadPoint(CQuad *pQuad, int QuadIndex, int V)
 		{
 			if(!UI()->MouseButton(1))
 			{
-				if(m_vSelectedLayers.size() == 1 && m_GuiActive)
+				if(m_vSelectedLayers.size() == 1)
 				{
 					m_SelectedQuadPoint = V;
 					m_SelectedQuadIndex = FindSelectedQuadIndex(QuadIndex);
@@ -6496,10 +6496,7 @@ void CEditor::OnRender()
 	{
 		m_GuiActive = !m_GuiActive;
 		if(!m_GuiActive)
-		{
 			m_LockMouse = false;
-			UiClosePopupMenus();
-		}
 	}
 
 	if(Input()->KeyPress(KEY_F10))


### PR DESCRIPTION
Closes #6385.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
