### PR TITLE
Replace leftover `memcpy` with `mem_copy`

### DIFF
--- a/src/tools/map_replace_area.cpp
+++ b/src/tools/map_replace_area.cpp
@@ -499,7 +499,7 @@ void SetExtendedArea(MapObject &Ob)
 		{
 			float aInspectedArea[2];
 			if(GetLineIntersection(Ob.m_aaBaseArea[i], Ob.m_aaScreenOffset[i], aInspectedArea))
-				memcpy(Ob.m_aaExtendedArea[i], aInspectedArea, sizeof(float[2]));
+				mem_copy(Ob.m_aaExtendedArea[i], aInspectedArea, sizeof(float[2]));
 			continue;
 		}
 
@@ -520,13 +520,13 @@ bool GetVisibleArea(const float aaGameArea[2][2], const MapObject &Ob, float aaV
 		SetInexistent((float *)aaVisibleArea, 4);
 
 	float aaInspectedArea[2][2];
-	memcpy(aaInspectedArea, aaGameArea, sizeof(float[2][2]));
+	mem_copy(aaInspectedArea, aaGameArea, sizeof(float[2][2]));
 
 	for(int i = 0; i < 2; i++)
 	{
 		if(Ob.m_aSpeed[i] == 1)
 		{
-			memcpy(aaInspectedArea[i], Ob.m_aaExtendedArea[i], sizeof(float[2]));
+			mem_copy(aaInspectedArea[i], Ob.m_aaExtendedArea[i], sizeof(float[2]));
 			continue;
 		}
 
@@ -538,7 +538,7 @@ bool GetVisibleArea(const float aaGameArea[2][2], const MapObject &Ob, float aaV
 	}
 
 	if(aaVisibleArea)
-		memcpy(aaVisibleArea, aaInspectedArea, sizeof(float[2][2]));
+		mem_copy(aaVisibleArea, aaInspectedArea, sizeof(float[2][2]));
 
 	return true;
 }
@@ -594,8 +594,8 @@ void GetGameAreaDistance(const float aaaGameAreas[2][2][2], const MapObject aObs
 void GetGameAreaDistance(const float aaaGameAreas[2][2][2], const MapObject aObs[2], const float aaVisibleArea[2][2], float aDistance[2])
 {
 	float aaaVisibleAreas[2][2][2];
-	memcpy(aaaVisibleAreas[0], aaVisibleArea[0], sizeof(float[2][2]));
-	memcpy(aaaVisibleAreas[1], aaVisibleArea[0], sizeof(float[2][2]));
+	mem_copy(aaaVisibleAreas[0], aaVisibleArea[0], sizeof(float[2][2]));
+	mem_copy(aaaVisibleAreas[1], aaVisibleArea[0], sizeof(float[2][2]));
 	GetGameAreaDistance(aaaGameAreas, aObs, aaaVisibleAreas, aDistance);
 }
 
@@ -636,7 +636,7 @@ bool GetLineIntersection(const float aLine1[2], const float aLine2[2], float aIn
 		return false;
 
 	if(aIntersection)
-		memcpy(aIntersection, aBorders, sizeof(float[2]));
+		mem_copy(aIntersection, aBorders, sizeof(float[2]));
 
 	return true;
 }


### PR DESCRIPTION
Fixes the following error on Haiku:

```
~/ddnet/build> ninja
[5/8] Building CXX object CMakeFiles/m...a.dir/src/tools/map_replace_area.cpp.o
FAILED: CMakeFiles/map_replace_area.dir/src/tools/map_replace_area.cpp.o
/bin/c++ -DCONF_INFORM_UPDATE -DCONF_OPENSSL -DCONF_VIDEORECORDER -DGAME_RELEASE_VERSION=\"16.8\" -DGLEW_STATIC -I/boot/home/ddnet/build/src -I/boot/home/ddnet/src -I/boot/home/ddnet/src/ru>
/boot/home/ddnet/src/tools/map_replace_area.cpp: In function 'void SetExtendedArea(MapObject&)':
/boot/home/ddnet/src/tools/map_replace_area.cpp:502:33: error: 'memcpy' was not declared in this scope
  502 |                                 memcpy(Ob.m_aaExtendedArea[i], aInspectedArea, sizeof(float[2]));
      |                                 ^~~~~~
/boot/home/ddnet/src/tools/map_replace_area.cpp:7:1: note: 'memcpy' is defined in header '<cstring>'; did you forget to '#include <cstring>'?
    6 | #include <game/mapitems.h>
  +++ |+#include <cstring>
    7 |
/boot/home/ddnet/src/tools/map_replace_area.cpp: In function 'bool GetVisibleArea(const float (*)[2], const MapObject&, float (*)[2])':
/boot/home/ddnet/src/tools/map_replace_area.cpp:523:9: error: 'memcpy' was not declared in this scope
  523 |         memcpy(aaInspectedArea, aaGameArea, sizeof(float[2][2]));
      |         ^~~~~~
/boot/home/ddnet/src/tools/map_replace_area.cpp:523:9: note: 'memcpy' is defined in header '<cstring>'; did you forget to '#include <cstring>'?
/boot/home/ddnet/src/tools/map_replace_area.cpp: In function 'void GetGameAreaDistance(const float (*)[2][2], const MapObject*, const float (*)[2], float*)':
/boot/home/ddnet/src/tools/map_replace_area.cpp:597:9: error: 'memcpy' was not declared in this scope
  597 |         memcpy(aaaVisibleAreas[0], aaVisibleArea[0], sizeof(float[2][2]));
      |         ^~~~~~
/boot/home/ddnet/src/tools/map_replace_area.cpp:597:9: note: 'memcpy' is defined in header '<cstring>'; did you forget to '#include <cstring>'?
/boot/home/ddnet/src/tools/map_replace_area.cpp: In function 'bool GetLineIntersection(const float*, const float*, float*)':
/boot/home/ddnet/src/tools/map_replace_area.cpp:639:17: error: 'memcpy' was not declared in this scope
  639 |                 memcpy(aIntersection, aBorders, sizeof(float[2]));
      |                 ^~~~~~
/boot/home/ddnet/src/tools/map_replace_area.cpp:639:17: note: 'memcpy' is defined in header '<cstring>'; did you forget to '#include <cstring>'?
[6/8] Building CXX object CMakeFiles/g....dir/src/game/generated/checksum.cpp.o
ninja: build stopped: subcommand failed.
~/ddnet/build>
```

#### Regarding the Haiku port

After a two year hiatus (I temporarily stopped working on the Haiku port after being done with 80% of the work, as I was waiting for a Haiku-specific Mesa patch to land so that I could run it), I tried testing whether the port would work in a Haiku VM.

I was a bit afraid that it wouldn't work because of Rust being added as a dependency, but apparently, Haiku can support that just fine using OpenGL. Some additional stability/input-related patches may be required.

![image](https://user-images.githubusercontent.com/30193966/223889249-5ac8568f-23e4-418f-beae-7496e6afdbbb.png)

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
