### PR TITLE
Use `mem_copy` instead of `memcpy` for websockets

### DIFF
--- a/src/engine/shared/websockets.cpp
+++ b/src/engine/shared/websockets.cpp
@@ -60,8 +60,8 @@ static int receive_chunk(context_data *ctx_data, struct per_session_data *pss,
 		return 1;
 	chunk->size = len;
 	chunk->read = 0;
-	memcpy(&chunk->addr, &pss->addr, sizeof(sockaddr_in));
-	memcpy(&chunk->data[0], in, len);
+	mem_copy(&chunk->addr, &pss->addr, sizeof(sockaddr_in));
+	mem_copy(&chunk->data[0], in, len);
 	return 0;
 }
 
@@ -228,15 +228,15 @@ int websocket_recv(int socket, unsigned char *data, size_t maxsize,
 	if(maxsize >= chunk->size - chunk->read)
 	{
 		int len = chunk->size - chunk->read;
-		memcpy(data, &chunk->data[chunk->read], len);
-		memcpy(sockaddrbuf, &chunk->addr, fromLen);
+		mem_copy(data, &chunk->data[chunk->read], len);
+		mem_copy(sockaddrbuf, &chunk->addr, fromLen);
 		ctx_data->recv_buffer.PopFirst();
 		return len;
 	}
 	else
 	{
-		memcpy(data, &chunk->data[chunk->read], maxsize);
-		memcpy(sockaddrbuf, &chunk->addr, fromLen);
+		mem_copy(data, &chunk->data[chunk->read], maxsize);
+		mem_copy(sockaddrbuf, &chunk->addr, fromLen);
 		chunk->read += maxsize;
 		return maxsize;
 	}
@@ -281,8 +281,8 @@ int websocket_send(int socket, const unsigned char *data, size_t size,
 		return -1;
 	chunk->size = size;
 	chunk->read = 0;
-	memcpy(&chunk->addr, &pss->addr, sizeof(sockaddr_in));
-	memcpy(&chunk->data[LWS_SEND_BUFFER_PRE_PADDING], data, size);
+	mem_copy(&chunk->addr, &pss->addr, sizeof(sockaddr_in));
+	mem_copy(&chunk->data[LWS_SEND_BUFFER_PRE_PADDING], data, size);
 	lws_callback_on_writable(pss->wsi);
 	lws_service(context, -1);
 	return size;


### PR DESCRIPTION
Replace all remaining usages of `memcpy`.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
