### PR TITLE
Remove fatal space from vim syntax

### DIFF
--- a/other/vim/syntax/ddnet-cfg.vim
+++ b/other/vim/syntax/ddnet-cfg.vim
@@ -8,7 +8,7 @@ endif
 syntax match settingName "^\w*"
 
 syntax match value "\s\w*"
-syntax match escapeQuote  "\\\"" 
+syntax match escapeQuote  "\\\""
 syntax match number  "\s[0-9]\+"
 syntax match ip  "\s\d\+\.\d\+\.\d\+\.\d\+\(:\d\+\)\="
 


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
