### PR TITLE
Save screenshot in separate thread to avoid lags

### DIFF
--- a/src/engine/client/graphics_threaded.h
+++ b/src/engine/client/graphics_threaded.h
@@ -802,6 +802,7 @@ class CGraphics_Threaded : public IEngineGraphics
 	//
 	class IStorage *m_pStorage;
 	class IConsole *m_pConsole;
+	class IEngine *m_pEngine;
 
 	int m_CurIndex;
 
@@ -817,7 +818,7 @@ class CGraphics_Threaded : public IEngineGraphics
 	float m_Rotation;
 	int m_Drawing;
 	bool m_DoScreenshot;
-	char m_aScreenshotName[128];
+	char m_aScreenshotName[IO_MAX_PATH_LENGTH];
 
 	CTextureHandle m_InvalidTexture;
 


### PR DESCRIPTION
Encoding the image as PNG and saving it to a file comprises the majority of the time when taking a screenshot.

To avoid the client freezing while a screenshot is being saved, this task is moved to a separate background thread.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
