### PR TITLE
Streamline `parse_drmingw.sh`

### DIFF
--- a/scripts/parse_drmingw.sh
+++ b/scripts/parse_drmingw.sh
@@ -14,24 +14,37 @@ if [ -z ${2+x} ]; then
 	exit 1
 fi
 
-TMP_OFFSET=$(grep -E -o "\(with offset [0-9A-F]+\)" "$2" | grep -E -o "[A-F0-9]*")
+TMP_OFFSET=$(grep -E -o "\(with offset [0-9A-Fa-f]+\)" "$2" | grep -E -o "[0-9A-Fa-f]*")
 if [ -z "$TMP_OFFSET" ]; then
-	TMP_OFFSET=$(grep -E -o "^[0-9A-F]+-[0-9A-F]+ .+\.exe" "$2" | grep -E -o "^[A-F0-9]+")
+	TMP_OFFSET=$(grep -E -o "^[0-9A-Fa-f]+-[0-9A-Fa-f]+ \S+\.exe" "$2" | grep -E -o "^[0-9A-Fa-f]+")
 	if [ -z "$TMP_OFFSET" ]; then
-		printf "\e[31m%s\e[30m\n" "Module offset not found; addresses will be absolute"
-		echo -en "\e[0m"
+		TMP_OFFSET="0"
+		if ! grep -q -E -o "\s\S+\.exe!" "$2"; then
+			printf "\e[31m%s\e[30m\n" "Module offset not found; addresses will be absolute"
+			echo -en "\e[0m"
+		fi
 	fi
 fi
 
-ADDR_PC_REGEX='[0-9A-F]+ [0-9A-F]+ [0-9A-F]+ [0-9A-F]+'
+if [ "$TMP_OFFSET" != "0" ]; then
+	echo "Module offset: 0x$TMP_OFFSET"
+fi
+
+ADDR_BASE=$(winedump -f "$1" | grep -E -o "image base[ ]*0x[0-9A-Fa-f]*" | grep -E -o "0x[0-9A-Fa-f]+" | tail -1)
+echo "Image base: $ADDR_BASE"
+
+ADDR_PC_REGEX='[0-9A-Fa-f]+ [0-9A-Fa-f]+ [0-9A-Fa-f]+ [0-9A-Fa-f]+'
 while read -r line
 do
 	if [[ $line =~ $ADDR_PC_REGEX ]]
 	then
-		TMP_ADDR=$(echo "$line" | grep -E -o -m 1 "[A-F0-9]+ " | head -1)
-		ADDR_BASE=$(winedump -f "$1" | grep -E -o "image base[ ]*0x[0-9A-Fa-f]*" | grep -E -o "[0-9A-Fa-f]+" | tail -1)
-		REAL_ADDR=$(printf '%X\n' "$(((0x$TMP_ADDR-0x$TMP_OFFSET)+0x$ADDR_BASE))")
-		echo "Parsing address: $REAL_ADDR (img base: $ADDR_BASE)"
-		addr2line -e "$1" "$REAL_ADDR"
+		RELATIVE_ADDR=$(echo "$line" | grep -E -o -m 1 "\s\S+\.exe!.*0x([0-9A-Fa-f]+)" | grep -E -o "0x[0-9A-Fa-f]+" | head -1)
+		if [ -z "$RELATIVE_ADDR" ]; then
+			TMP_ADDR=$(echo "$line" | grep -E -o -m 1 "[0-9A-Fa-f]+ " | head -1)
+			REAL_ADDR=$(printf '0x%X\n' "$(((0x$TMP_ADDR-0x$TMP_OFFSET)+ADDR_BASE))")
+		else
+			REAL_ADDR=$(printf '0x%X\n' "$((RELATIVE_ADDR+ADDR_BASE))")
+		fi
+		addr2line -e "$1" -a -p -f -C -i "$REAL_ADDR" | sed 's/ [^ ]*\/src\// src\//g'
 	fi
 done < "$2"


### PR DESCRIPTION
- Also handle newer Dr.Mingw trace format where relative addresses are already resolved, as some crash logs may not contain the list of module addresses and versions.
- Add more parameters to `addr2line` invocation to print addresses, pretty-print, print function names, demangle, and resolve inlined functions.
- Strip absolute prefix of source paths, so the paths all starts at `src/`, to improve readability.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
