### PR TITLE
add sorting by name and time modified to filedialog

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -1,6 +1,7 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 
+#include "game/client/ui_rect.h"
 #include <algorithm>
 
 #include <base/color.h>
@@ -4219,31 +4220,53 @@ void CEditor::RenderSounds(CUIRect ToolBox)
 	s_ScrollRegion.End();
 }
 
-static int EditorListdirCallback(const char *pName, int IsDir, int StorageType, void *pUser)
+static int EditorListdirCallback(const CFsFileInfo *info, int IsDir, int StorageType, void *pUser)
 {
 	CEditor *pEditor = (CEditor *)pUser;
-	if((pName[0] == '.' && (pName[1] == 0 ||
-				       (pName[1] == '.' && pName[2] == 0 && (!str_comp(pEditor->m_pFileDialogPath, "maps") || !str_comp(pEditor->m_pFileDialogPath, "mapres"))))) ||
-		(!IsDir && ((pEditor->m_FileDialogFileType == CEditor::FILETYPE_MAP && !str_endswith(pName, ".map")) ||
-				   (pEditor->m_FileDialogFileType == CEditor::FILETYPE_IMG && !str_endswith(pName, ".png")) ||
-				   (pEditor->m_FileDialogFileType == CEditor::FILETYPE_SOUND && !str_endswith(pName, ".opus")))))
+	if((info->m_pName[0] == '.' && (info->m_pName[1] == 0 ||
+					       (info->m_pName[1] == '.' && info->m_pName[2] == 0 && (!str_comp(pEditor->m_pFileDialogPath, "maps") || !str_comp(pEditor->m_pFileDialogPath, "mapres"))))) ||
+		(!IsDir && ((pEditor->m_FileDialogFileType == CEditor::FILETYPE_MAP && !str_endswith(info->m_pName, ".map")) ||
+				   (pEditor->m_FileDialogFileType == CEditor::FILETYPE_IMG && !str_endswith(info->m_pName, ".png")) ||
+				   (pEditor->m_FileDialogFileType == CEditor::FILETYPE_SOUND && !str_endswith(info->m_pName, ".opus")))))
 		return 0;
 
 	CEditor::CFilelistItem Item;
-	str_copy(Item.m_aFilename, pName, sizeof(Item.m_aFilename));
+	str_copy(Item.m_aFilename, info->m_pName, sizeof(Item.m_aFilename));
 	if(IsDir)
-		str_format(Item.m_aName, sizeof(Item.m_aName), "%s/", pName);
+		str_format(Item.m_aName, sizeof(Item.m_aName), "%s/", info->m_pName);
 	else
 	{
 		int LenEnding = pEditor->m_FileDialogFileType == CEditor::FILETYPE_SOUND ? 5 : 4;
-		str_truncate(Item.m_aName, sizeof(Item.m_aName), pName, str_length(pName) - LenEnding);
+		str_truncate(Item.m_aName, sizeof(Item.m_aName), info->m_pName, str_length(info->m_pName) - LenEnding);
 	}
 	Item.m_IsDir = IsDir != 0;
 	Item.m_IsLink = false;
 	Item.m_StorageType = StorageType;
+	Item.m_TimeModified = info->m_TimeModified;
 	pEditor->m_vCompleteFileList.push_back(Item);
 
 	return 0;
+}
+
+void CEditor::SortFilteredFileList()
+{
+	if(m_SortByFilename == 1)
+	{
+		std::sort(m_vpFilteredFileList.begin(), m_vpFilteredFileList.end(), CEditor::cmp_filename_less);
+	}
+	else
+	{
+		std::sort(m_vpFilteredFileList.begin(), m_vpFilteredFileList.end(), CEditor::cmp_filename_greater);
+	}
+
+	if(m_SortByTimeModified == 1)
+	{
+		std::stable_sort(m_vpFilteredFileList.begin(), m_vpFilteredFileList.end(), CEditor::cmp_timemodified_less);
+	}
+	else if(m_SortByTimeModified == -1)
+	{
+		std::stable_sort(m_vpFilteredFileList.begin(), m_vpFilteredFileList.end(), CEditor::cmp_timemodified_greater);
+	}
 }
 
 void CEditor::RenderFileDialog()
@@ -4274,6 +4297,53 @@ void CEditor::RenderFileDialog()
 		View.VSplitMid(&View, &Preview);
 
 	// title
+	CUIRect ButtonTimeModified, ButtonFileName;
+	Title.VSplitRight(10.0f, &Title, nullptr);
+	Title.VSplitRight(90.0f, &Title, &ButtonTimeModified);
+	Title.VSplitRight(10.0f, &Title, nullptr);
+	Title.VSplitRight(90.0f, &Title, &ButtonFileName);
+	Title.VSplitRight(10.0f, &Title, nullptr);
+
+	static int s_ButtonTimeModified = 0;
+	char aBufLabelButtonTimeModified[64];
+	str_format(aBufLabelButtonTimeModified, sizeof(aBufLabelButtonTimeModified), "Time modified %s", m_SortByTimeModified == 1 ? "▲" : m_SortByTimeModified == -1 ? "▼" :
+																					"");
+	if(DoButton_Editor(&s_ButtonTimeModified, aBufLabelButtonTimeModified, 0, &ButtonTimeModified, 0, "Sort by time modified"))
+	{
+		if(m_SortByTimeModified == 1)
+		{
+			m_SortByTimeModified = -1;
+		}
+		else if(m_SortByTimeModified == -1)
+		{
+			m_SortByTimeModified = 0;
+		}
+		else
+		{
+			m_SortByTimeModified = 1;
+		}
+
+		SortFilteredFileList();
+	}
+
+	static int s_ButtonFileName = 0;
+	char aBufLabelButtonFilename[64];
+	str_format(aBufLabelButtonFilename, sizeof(aBufLabelButtonFilename), "Filename %s", m_SortByFilename == 1 ? "▲" : m_SortByFilename == -1 ? "▼" :
+																		   "");
+	if(DoButton_Editor(&s_ButtonFileName, aBufLabelButtonFilename, 0, &ButtonFileName, 0, "Sort by file name"))
+	{
+		if(m_SortByFilename == 1)
+		{
+			m_SortByFilename = -1;
+		}
+		else
+		{
+			m_SortByFilename = 1;
+		}
+
+		SortFilteredFileList();
+	}
+
 	Title.Draw(ColorRGBA(1, 1, 1, 0.25f), IGraphics::CORNER_ALL, 4.0f);
 	Title.VMargin(10.0f, &Title);
 	UI()->DoLabel(&Title, m_pFileDialogTitle, 12.0f, TEXTALIGN_LEFT);
@@ -4435,9 +4505,10 @@ void CEditor::RenderFileDialog()
 		if(!Item.m_Visible)
 			continue;
 
-		CUIRect Button, FileIcon;
+		CUIRect Button, FileIcon, TimeModified;
 		Item.m_Rect.VSplitLeft(Item.m_Rect.h, &FileIcon, &Button);
 		Button.VSplitLeft(5.0f, nullptr, &Button);
+		Button.VSplitRight(100.0f, &Button, &TimeModified);
 
 		const char *pIconType;
 		if(!m_vpFilteredFileList[i]->m_IsDir)
@@ -4469,9 +4540,14 @@ void CEditor::RenderFileDialog()
 		UI()->DoLabel(&FileIcon, pIconType, 12.0f, TEXTALIGN_LEFT);
 		TextRender()->SetCurFont(nullptr);
 
+		char aBufTimeModified[64];
+		tm *time_modified = localtime(&m_vpFilteredFileList[i]->m_TimeModified);
+		strftime(aBufTimeModified, sizeof(aBufTimeModified), "%d.%m.%y %H:%M", time_modified);
+
 		SLabelProperties Props;
 		Props.m_AlignVertically = 0;
 		UI()->DoLabel(&Button, m_vpFilteredFileList[i]->m_aName, 10.0f, TEXTALIGN_LEFT, Props);
+		UI()->DoLabel(&TimeModified, aBufTimeModified, 10.0f, TEXTALIGN_RIGHT, Props);
 	}
 
 	const int NewSelection = s_ListBox.DoEnd();
@@ -4634,9 +4710,9 @@ void CEditor::FilelistPopulate(int StorageType, bool KeepSelection)
 		Item.m_StorageType = IStorage::TYPE_SAVE;
 		m_vCompleteFileList.push_back(Item);
 	}
-	Storage()->ListDirectory(StorageType, m_pFileDialogPath, EditorListdirCallback, this);
-	std::sort(m_vCompleteFileList.begin(), m_vCompleteFileList.end());
+	Storage()->ListDirectoryInfo(StorageType, m_pFileDialogPath, EditorListdirCallback, this);
 	RefreshFilteredFileList();
+	SortFilteredFileList();
 	if(!KeepSelection)
 	{
 		m_FilesSelectedIndex = m_vpFilteredFileList.empty() ? -1 : 0;

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -4323,7 +4323,7 @@ void CEditor::RenderFileDialog()
 			m_SortByTimeModified = 1;
 		}
 
-		SortFilteredFileList();
+		RefreshFilteredFileList();
 	}
 
 	static int s_ButtonFileName = 0;
@@ -4334,13 +4334,15 @@ void CEditor::RenderFileDialog()
 		if(m_SortByFilename == 1)
 		{
 			m_SortByFilename = -1;
+			m_SortByTimeModified = 0;
 		}
 		else
 		{
 			m_SortByFilename = 1;
+			m_SortByTimeModified = 0;
 		}
 
-		SortFilteredFileList();
+		RefreshFilteredFileList();
 	}
 
 	Title.Draw(ColorRGBA(1, 1, 1, 0.25f), IGraphics::CORNER_ALL, 4.0f);
@@ -4672,6 +4674,7 @@ void CEditor::RefreshFilteredFileList()
 			m_vpFilteredFileList.push_back(&Item);
 		}
 	}
+	SortFilteredFileList();
 	if(!m_vpFilteredFileList.empty())
 	{
 		if(m_aFilesSelectedName[0])
@@ -4711,7 +4714,6 @@ void CEditor::FilelistPopulate(int StorageType, bool KeepSelection)
 	}
 	Storage()->ListDirectoryInfo(StorageType, m_pFileDialogPath, EditorListdirCallback, this);
 	RefreshFilteredFileList();
-	SortFilteredFileList();
 	if(!KeepSelection)
 	{
 		m_FilesSelectedIndex = m_vpFilteredFileList.empty() ? -1 : 0;

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -4303,7 +4303,7 @@ void CEditor::RenderFileDialog()
 	Title.VSplitRight(90.0f, &Title, &ButtonFileName);
 	Title.VSplitRight(10.0f, &Title, nullptr);
 
-	const char* aSortIndicator[3] = {"▼", "", "▲"};
+	const char *aSortIndicator[3] = {"▼", "", "▲"};
 
 	static int s_ButtonTimeModified = 0;
 	char aBufLabelButtonTimeModified[64];

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -4219,29 +4219,29 @@ void CEditor::RenderSounds(CUIRect ToolBox)
 	s_ScrollRegion.End();
 }
 
-static int EditorListdirCallback(const CFsFileInfo *info, int IsDir, int StorageType, void *pUser)
+static int EditorListdirCallback(const CFsFileInfo *pInfo, int IsDir, int StorageType, void *pUser)
 {
 	CEditor *pEditor = (CEditor *)pUser;
-	if((info->m_pName[0] == '.' && (info->m_pName[1] == 0 ||
-					       (info->m_pName[1] == '.' && info->m_pName[2] == 0 && (!str_comp(pEditor->m_pFileDialogPath, "maps") || !str_comp(pEditor->m_pFileDialogPath, "mapres"))))) ||
-		(!IsDir && ((pEditor->m_FileDialogFileType == CEditor::FILETYPE_MAP && !str_endswith(info->m_pName, ".map")) ||
-				   (pEditor->m_FileDialogFileType == CEditor::FILETYPE_IMG && !str_endswith(info->m_pName, ".png")) ||
-				   (pEditor->m_FileDialogFileType == CEditor::FILETYPE_SOUND && !str_endswith(info->m_pName, ".opus")))))
+	if((pInfo->m_pName[0] == '.' && (pInfo->m_pName[1] == 0 ||
+						(pInfo->m_pName[1] == '.' && pInfo->m_pName[2] == 0 && (!str_comp(pEditor->m_pFileDialogPath, "maps") || !str_comp(pEditor->m_pFileDialogPath, "mapres"))))) ||
+		(!IsDir && ((pEditor->m_FileDialogFileType == CEditor::FILETYPE_MAP && !str_endswith(pInfo->m_pName, ".map")) ||
+				   (pEditor->m_FileDialogFileType == CEditor::FILETYPE_IMG && !str_endswith(pInfo->m_pName, ".png")) ||
+				   (pEditor->m_FileDialogFileType == CEditor::FILETYPE_SOUND && !str_endswith(pInfo->m_pName, ".opus")))))
 		return 0;
 
 	CEditor::CFilelistItem Item;
-	str_copy(Item.m_aFilename, info->m_pName, sizeof(Item.m_aFilename));
+	str_copy(Item.m_aFilename, pInfo->m_pName, sizeof(Item.m_aFilename));
 	if(IsDir)
-		str_format(Item.m_aName, sizeof(Item.m_aName), "%s/", info->m_pName);
+		str_format(Item.m_aName, sizeof(Item.m_aName), "%s/", pInfo->m_pName);
 	else
 	{
 		int LenEnding = pEditor->m_FileDialogFileType == CEditor::FILETYPE_SOUND ? 5 : 4;
-		str_truncate(Item.m_aName, sizeof(Item.m_aName), info->m_pName, str_length(info->m_pName) - LenEnding);
+		str_truncate(Item.m_aName, sizeof(Item.m_aName), pInfo->m_pName, str_length(pInfo->m_pName) - LenEnding);
 	}
 	Item.m_IsDir = IsDir != 0;
 	Item.m_IsLink = false;
 	Item.m_StorageType = StorageType;
-	Item.m_TimeModified = info->m_TimeModified;
+	Item.m_TimeModified = pInfo->m_TimeModified;
 	pEditor->m_vCompleteFileList.push_back(Item);
 
 	return 0;
@@ -4540,8 +4540,7 @@ void CEditor::RenderFileDialog()
 		TextRender()->SetCurFont(nullptr);
 
 		char aBufTimeModified[64];
-		tm *time_modified = localtime(&m_vpFilteredFileList[i]->m_TimeModified);
-		strftime(aBufTimeModified, sizeof(aBufTimeModified), "%d.%m.%y %H:%M", time_modified);
+		str_timestamp_ex(m_vpFilteredFileList[i]->m_TimeModified, aBufTimeModified, sizeof(aBufTimeModified), "%d.%m.%Y %H:%M");
 
 		SLabelProperties Props;
 		Props.m_AlignVertically = 0;

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -4251,20 +4251,20 @@ void CEditor::SortFilteredFileList()
 {
 	if(m_SortByFilename == 1)
 	{
-		std::sort(m_vpFilteredFileList.begin(), m_vpFilteredFileList.end(), CEditor::cmp_filename_less);
+		std::sort(m_vpFilteredFileList.begin(), m_vpFilteredFileList.end(), CEditor::CompareFilenameAscending);
 	}
 	else
 	{
-		std::sort(m_vpFilteredFileList.begin(), m_vpFilteredFileList.end(), CEditor::cmp_filename_greater);
+		std::sort(m_vpFilteredFileList.begin(), m_vpFilteredFileList.end(), CEditor::CompareFilenameDescending);
 	}
 
 	if(m_SortByTimeModified == 1)
 	{
-		std::stable_sort(m_vpFilteredFileList.begin(), m_vpFilteredFileList.end(), CEditor::cmp_timemodified_less);
+		std::stable_sort(m_vpFilteredFileList.begin(), m_vpFilteredFileList.end(), CEditor::CompareTimeModifiedAscending);
 	}
 	else if(m_SortByTimeModified == -1)
 	{
-		std::stable_sort(m_vpFilteredFileList.begin(), m_vpFilteredFileList.end(), CEditor::cmp_timemodified_greater);
+		std::stable_sort(m_vpFilteredFileList.begin(), m_vpFilteredFileList.end(), CEditor::CompareTimeModifiedDescending);
 	}
 }
 
@@ -4303,11 +4303,11 @@ void CEditor::RenderFileDialog()
 	Title.VSplitRight(90.0f, &Title, &ButtonFileName);
 	Title.VSplitRight(10.0f, &Title, nullptr);
 
-	std::string aSortIndicator[3] = {"▼", "", "▲"};
+	const char* aSortIndicator[3] = {"▼", "", "▲"};
 
 	static int s_ButtonTimeModified = 0;
 	char aBufLabelButtonTimeModified[64];
-	str_format(aBufLabelButtonTimeModified, sizeof(aBufLabelButtonTimeModified), "Time modified %s", aSortIndicator[m_SortByTimeModified + 1].c_str());
+	str_format(aBufLabelButtonTimeModified, sizeof(aBufLabelButtonTimeModified), "Time modified %s", aSortIndicator[m_SortByTimeModified + 1]);
 	if(DoButton_Editor(&s_ButtonTimeModified, aBufLabelButtonTimeModified, 0, &ButtonTimeModified, 0, "Sort by time modified"))
 	{
 		if(m_SortByTimeModified == 1)
@@ -4328,7 +4328,7 @@ void CEditor::RenderFileDialog()
 
 	static int s_ButtonFileName = 0;
 	char aBufLabelButtonFilename[64];
-	str_format(aBufLabelButtonFilename, sizeof(aBufLabelButtonFilename), "Filename %s", aSortIndicator[m_SortByFilename + 1].c_str());
+	str_format(aBufLabelButtonFilename, sizeof(aBufLabelButtonFilename), "Filename %s", aSortIndicator[m_SortByFilename + 1]);
 	if(DoButton_Editor(&s_ButtonFileName, aBufLabelButtonFilename, 0, &ButtonFileName, 0, "Sort by file name"))
 	{
 		if(m_SortByFilename == 1)
@@ -4545,7 +4545,8 @@ void CEditor::RenderFileDialog()
 		SLabelProperties Props;
 		Props.m_AlignVertically = 0;
 		UI()->DoLabel(&Button, m_vpFilteredFileList[i]->m_aName, 10.0f, TEXTALIGN_LEFT, Props);
-		UI()->DoLabel(&TimeModified, aBufTimeModified, 10.0f, TEXTALIGN_RIGHT, Props);
+		if(!m_vpFilteredFileList[i]->m_IsLink && str_comp(m_vpFilteredFileList[i]->m_aFilename, "..") != 0)
+			UI()->DoLabel(&TimeModified, aBufTimeModified, 10.0f, TEXTALIGN_RIGHT, Props);
 	}
 
 	const int NewSelection = s_ListBox.DoEnd();

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -1,7 +1,6 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 
-#include "game/client/ui_rect.h"
 #include <algorithm>
 
 #include <base/color.h>
@@ -4304,10 +4303,11 @@ void CEditor::RenderFileDialog()
 	Title.VSplitRight(90.0f, &Title, &ButtonFileName);
 	Title.VSplitRight(10.0f, &Title, nullptr);
 
+	std::string aSortIndicator[3] = {"▼", "", "▲"};
+
 	static int s_ButtonTimeModified = 0;
 	char aBufLabelButtonTimeModified[64];
-	str_format(aBufLabelButtonTimeModified, sizeof(aBufLabelButtonTimeModified), "Time modified %s", m_SortByTimeModified == 1 ? "▲" : m_SortByTimeModified == -1 ? "▼" :
-																					"");
+	str_format(aBufLabelButtonTimeModified, sizeof(aBufLabelButtonTimeModified), "Time modified %s", aSortIndicator[m_SortByTimeModified + 1].c_str());
 	if(DoButton_Editor(&s_ButtonTimeModified, aBufLabelButtonTimeModified, 0, &ButtonTimeModified, 0, "Sort by time modified"))
 	{
 		if(m_SortByTimeModified == 1)
@@ -4328,8 +4328,7 @@ void CEditor::RenderFileDialog()
 
 	static int s_ButtonFileName = 0;
 	char aBufLabelButtonFilename[64];
-	str_format(aBufLabelButtonFilename, sizeof(aBufLabelButtonFilename), "Filename %s", m_SortByFilename == 1 ? "▲" : m_SortByFilename == -1 ? "▼" :
-																		   "");
+	str_format(aBufLabelButtonFilename, sizeof(aBufLabelButtonFilename), "Filename %s", aSortIndicator[m_SortByFilename + 1].c_str());
 	if(DoButton_Editor(&s_ButtonFileName, aBufLabelButtonFilename, 0, &ButtonFileName, 0, "Sort by file name"))
 	{
 		if(m_SortByFilename == 1)

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -980,22 +980,22 @@ public:
 	std::vector<CFilelistItem> m_vCompleteFileList;
 	std::vector<const CFilelistItem *> m_vpFilteredFileList;
 
-	static bool cmp_filename_less(const CFilelistItem *a, const CFilelistItem *b) 
+	static bool cmp_filename_less(const CFilelistItem *a, const CFilelistItem *b)
 	{
-		if (str_comp(a->m_aFilename, "..") == 0)
+		if(str_comp(a->m_aFilename, "..") == 0)
 			return true;
-		if (str_comp(b->m_aFilename, "..") == 0)
+		if(str_comp(b->m_aFilename, "..") == 0)
 			return false;
 		if(a->m_IsDir != b->m_IsDir)
 			return a->m_IsDir;
 		return str_comp(a->m_aName, b->m_aName) < 0;
 	}
 
-	static bool cmp_filename_greater(const CFilelistItem *a, const CFilelistItem *b) 
+	static bool cmp_filename_greater(const CFilelistItem *a, const CFilelistItem *b)
 	{
-		if (str_comp(a->m_aFilename, "..") == 0)
+		if(str_comp(a->m_aFilename, "..") == 0)
 			return true;
-		if (str_comp(b->m_aFilename, "..") == 0)
+		if(str_comp(b->m_aFilename, "..") == 0)
 			return false;
 		if(a->m_IsDir != b->m_IsDir)
 			return a->m_IsDir;
@@ -1009,7 +1009,8 @@ public:
 		return a->m_TimeModified < b->m_TimeModified;
 	}
 
-	static bool cmp_timemodified_greater(const CFilelistItem *a, const CFilelistItem *b) {
+	static bool cmp_timemodified_greater(const CFilelistItem *a, const CFilelistItem *b)
+	{
 		if(a->m_IsDir != b->m_IsDir)
 			return a->m_IsDir;
 		return a->m_TimeModified > b->m_TimeModified;

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -980,40 +980,52 @@ public:
 	std::vector<CFilelistItem> m_vCompleteFileList;
 	std::vector<const CFilelistItem *> m_vpFilteredFileList;
 
-	static bool cmp_filename_less(const CFilelistItem *a, const CFilelistItem *b)
+	static bool CompareFilenameAscending(const CFilelistItem *pLhs, const CFilelistItem *pRhs)
 	{
-		if(str_comp(a->m_aFilename, "..") == 0)
+		if(str_comp(pLhs->m_aFilename, "..") == 0)
 			return true;
-		if(str_comp(b->m_aFilename, "..") == 0)
+		if(str_comp(pRhs->m_aFilename, "..") == 0)
 			return false;
-		if(a->m_IsDir != b->m_IsDir)
-			return a->m_IsDir;
-		return str_comp(a->m_aName, b->m_aName) < 0;
+		if(pLhs->m_IsDir != pRhs->m_IsDir)
+			return pLhs->m_IsDir;
+		return str_comp_filenames(pLhs->m_aName, pRhs->m_aName) < 0;
 	}
 
-	static bool cmp_filename_greater(const CFilelistItem *a, const CFilelistItem *b)
+	static bool CompareFilenameDescending(const CFilelistItem *pLhs, const CFilelistItem *pRhs)
 	{
-		if(str_comp(a->m_aFilename, "..") == 0)
+		if(str_comp(pLhs->m_aFilename, "..") == 0)
 			return true;
-		if(str_comp(b->m_aFilename, "..") == 0)
+		if(str_comp(pRhs->m_aFilename, "..") == 0)
 			return false;
-		if(a->m_IsDir != b->m_IsDir)
-			return a->m_IsDir;
-		return str_comp(a->m_aName, b->m_aName) > 0;
+		if(pLhs->m_IsDir != pRhs->m_IsDir)
+			return pLhs->m_IsDir;
+		return str_comp_filenames(pLhs->m_aName, pRhs->m_aName) > 0;
 	}
 
-	static bool cmp_timemodified_less(const CFilelistItem *a, const CFilelistItem *b) 
+	static bool CompareTimeModifiedAscending(const CFilelistItem *pLhs, const CFilelistItem *pRhs)
 	{
-		if(a->m_IsDir != b->m_IsDir)
-			return a->m_IsDir;
-		return a->m_TimeModified < b->m_TimeModified;
+		if(str_comp(pLhs->m_aFilename, "..") == 0)
+			return true;
+		if(str_comp(pRhs->m_aFilename, "..") == 0)
+			return false;
+		if(pLhs->m_IsLink || pRhs->m_IsLink)
+			return pLhs->m_IsLink;
+		if(pLhs->m_IsDir != pRhs->m_IsDir)
+			return pLhs->m_IsDir;
+		return pLhs->m_TimeModified < pRhs->m_TimeModified;
 	}
 
-	static bool cmp_timemodified_greater(const CFilelistItem *a, const CFilelistItem *b)
+	static bool CompareTimeModifiedDescending(const CFilelistItem *pLhs, const CFilelistItem *pRhs)
 	{
-		if(a->m_IsDir != b->m_IsDir)
-			return a->m_IsDir;
-		return a->m_TimeModified > b->m_TimeModified;
+		if(str_comp(pLhs->m_aFilename, "..") == 0)
+			return true;
+		if(str_comp(pRhs->m_aFilename, "..") == 0)
+			return false;
+		if(pLhs->m_IsLink || pRhs->m_IsLink)
+			return pLhs->m_IsLink;
+		if(pLhs->m_IsDir != pRhs->m_IsDir)
+			return pLhs->m_IsDir;
+		return pLhs->m_TimeModified > pRhs->m_TimeModified;
 	}
 
 	void SortFilteredFileList();

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -975,11 +975,49 @@ public:
 		bool m_IsDir;
 		bool m_IsLink;
 		int m_StorageType;
-
-		bool operator<(const CFilelistItem &Other) const { return !str_comp(m_aFilename, "..") ? true : !str_comp(Other.m_aFilename, "..") ? false : m_IsDir && !Other.m_IsDir ? true : !m_IsDir && Other.m_IsDir ? false : str_comp_filenames(m_aFilename, Other.m_aFilename) < 0; }
+		time_t m_TimeModified;
 	};
 	std::vector<CFilelistItem> m_vCompleteFileList;
 	std::vector<const CFilelistItem *> m_vpFilteredFileList;
+
+	static bool cmp_filename_less(const CFilelistItem *a, const CFilelistItem *b) 
+	{
+		if (str_comp(a->m_aFilename, "..") == 0)
+			return true;
+		if (str_comp(b->m_aFilename, "..") == 0)
+			return false;
+		if(a->m_IsDir != b->m_IsDir)
+			return a->m_IsDir;
+		return str_comp(a->m_aName, b->m_aName) < 0;
+	}
+
+	static bool cmp_filename_greater(const CFilelistItem *a, const CFilelistItem *b) 
+	{
+		if (str_comp(a->m_aFilename, "..") == 0)
+			return true;
+		if (str_comp(b->m_aFilename, "..") == 0)
+			return false;
+		if(a->m_IsDir != b->m_IsDir)
+			return a->m_IsDir;
+		return str_comp(a->m_aName, b->m_aName) > 0;
+	}
+
+	static bool cmp_timemodified_less(const CFilelistItem *a, const CFilelistItem *b) 
+	{
+		if(a->m_IsDir != b->m_IsDir)
+			return a->m_IsDir;
+		return a->m_TimeModified < b->m_TimeModified;
+	}
+
+	static bool cmp_timemodified_greater(const CFilelistItem *a, const CFilelistItem *b) {
+		if(a->m_IsDir != b->m_IsDir)
+			return a->m_IsDir;
+		return a->m_TimeModified > b->m_TimeModified;
+	}
+
+	void SortFilteredFileList();
+	int m_SortByFilename = 1;
+	int m_SortByTimeModified = 0;
 
 	std::vector<std::string> m_vSelectEntitiesFiles;
 	std::string m_SelectEntitiesImage;


### PR DESCRIPTION
As suggested in #4508 it would be nice to have at least some basic sorting ability in the filedialog. This PR implements at least the two most important sorting criteria: filename and time modified. Also the time modified is now displayed.
At the moment the characters ▲ and ▼ are used to indicate the sorting direction. Maybe there is a nicer way to display this.
![file_dialog_1](https://user-images.githubusercontent.com/49279081/224561567-d3335ca0-d9c9-4d44-ab97-31ce177d287e.png)
![dialog_2](https://user-images.githubusercontent.com/49279081/224561570-4182ba16-bfe0-42d7-b2ee-0f49895fec85.png)

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
