### PR TITLE
ignore tiles that dont use ids in ContainsElementWithId

### DIFF
--- a/src/game/editor/layer_tiles.cpp
+++ b/src/game/editor/layer_tiles.cpp
@@ -1311,6 +1311,10 @@ bool CLayerTele::ContainsElementWithId(int Id)
 	{
 		for(int x = 0; x < m_Width; ++x)
 		{
+			if(m_pTeleTile[y * m_Width + x].m_Type == TILE_TELECHECKIN)
+				continue;
+			if(m_pTeleTile[y * m_Width + x].m_Type == TILE_TELECHECKINEVIL)
+				continue;
 			if(m_pTeleTile[y * m_Width + x].m_Number == Id)
 			{
 				return true;


### PR DESCRIPTION
See #5908. As far as I can tell this function is only used in the popup, so this should not break anything.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
