### PR TITLE
Always enable editor panning and zooming when GUI is hidden

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -2325,7 +2325,7 @@ void CEditor::DoMapEditor(CUIRect View)
 	}
 
 	static void *s_pEditorID = (void *)&s_pEditorID;
-	const bool Inside = UI()->MouseInside(&View);
+	const bool Inside = !m_GuiActive || UI()->MouseInside(&View);
 
 	// fetch mouse position
 	float wx = UI()->MouseWorldX();
@@ -6071,7 +6071,7 @@ void CEditor::Render()
 
 	UiDoPopupMenu();
 
-	if(m_Dialog == DIALOG_NONE && !m_MouseInsidePopup && UI()->MouseInside(&View))
+	if(m_Dialog == DIALOG_NONE && !m_MouseInsidePopup && (!m_GuiActive || UI()->MouseInside(&View)))
 	{
 		if(Input()->KeyPress(KEY_MOUSE_WHEEL_DOWN))
 			ChangeZoom(20.0f);


### PR DESCRIPTION
The `UI()->MouseInside(&View)` check does work when the mouse is all the way at the right or bottom side. Changing the `MouseInside` functions introduces other problems due to UI element and mouse positions being floating point numbers and not corresponding to exact pixels.

As a workaround to enable unlimited editor panning in all direction when the GUI is hidden the check is omitted, as the map editor encompasses the entire view and so the check is not necessary in this case.

Closes #4553.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
