### PR TITLE
Don't add duplicate consecutive commands to console history

### DIFF
--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -324,8 +324,12 @@ void CGameConsole::CInstance::OnInput(IInput::CEvent Event)
 			{
 				if(m_Type == CONSOLETYPE_LOCAL || m_pGameConsole->Client()->RconAuthed())
 				{
-					char *pEntry = m_History.Allocate(m_Input.GetLength() + 1);
-					str_copy(pEntry, m_Input.GetString(), m_Input.GetLength() + 1);
+					const char *pPrevEntry = m_History.Last();
+					if(pPrevEntry == nullptr || str_comp(pPrevEntry, m_Input.GetString()) != 0)
+					{
+						char *pEntry = m_History.Allocate(m_Input.GetLength() + 1);
+						str_copy(pEntry, m_Input.GetString(), m_Input.GetLength() + 1);
+					}
 				}
 				ExecuteLine(m_Input.GetString());
 				m_Input.Clear();


### PR DESCRIPTION
Don't add entered command to console history, if the last console history entry is identical to this command. For example, entering the commands `1`, `2`, `3`, `3`, `2`, `1` adds 5 entries to the history, i.e. only one entry for the command `3`.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
