### PR TITLE
add proof mode for menu backgrounds closes #3009

### DIFF
--- a/src/game/client/components/menu_background.cpp
+++ b/src/game/client/components/menu_background.cpp
@@ -19,6 +19,36 @@
 
 using namespace std::chrono_literals;
 
+std::vector<vec2> GenerateMenuBackgroundPositions()
+{
+	std::vector<vec2> Positions(CMenuBackground::NUM_POS);
+
+	Positions[CMenuBackground::POS_START] = vec2(500.0f, 500.0f);
+	Positions[CMenuBackground::POS_BROWSER_INTERNET] = vec2(1000.0f, 1000.0f);
+	Positions[CMenuBackground::POS_BROWSER_LAN] = vec2(1100.0f, 1000.0f);
+	Positions[CMenuBackground::POS_DEMOS] = vec2(900.0f, 100.0f);
+	Positions[CMenuBackground::POS_NEWS] = vec2(500.0f, 750.0f);
+	Positions[CMenuBackground::POS_BROWSER_FAVORITES] = vec2(1250.0f, 500.0f);
+	Positions[CMenuBackground::POS_SETTINGS_LANGUAGE] = vec2(500.0f, 1200.0f);
+	Positions[CMenuBackground::POS_SETTINGS_GENERAL] = vec2(500.0f, 1000.0f);
+	Positions[CMenuBackground::POS_SETTINGS_PLAYER] = vec2(600.0f, 1000.0f);
+	Positions[CMenuBackground::POS_SETTINGS_TEE] = vec2(700.0f, 1000.0f);
+	Positions[CMenuBackground::POS_SETTINGS_APPEARANCE] = vec2(200.0f, 1000.0f);
+	Positions[CMenuBackground::POS_SETTINGS_CONTROLS] = vec2(800.0f, 1000.0f);
+	Positions[CMenuBackground::POS_SETTINGS_GRAPHICS] = vec2(900.0f, 1000.0f);
+	Positions[CMenuBackground::POS_SETTINGS_SOUND] = vec2(1000.0f, 1000.0f);
+	Positions[CMenuBackground::POS_SETTINGS_DDNET] = vec2(1200.0f, 200.0f);
+	Positions[CMenuBackground::POS_SETTINGS_ASSETS] = vec2(500.0f, 500.0f);
+	for(int i = 0; i < CMenuBackground::POS_BROWSER_CUSTOM_NUM; ++i)
+		Positions[CMenuBackground::POS_BROWSER_CUSTOM0 + i] = vec2(500.0f + (75.0f * (float)i), 650.0f - (75.0f * (float)i));
+	for(int i = 0; i < CMenuBackground::POS_SETTINGS_RESERVED_NUM; ++i)
+		Positions[CMenuBackground::POS_SETTINGS_RESERVED0 + i] = vec2(0, 0);
+	for(int i = 0; i < CMenuBackground::POS_RESERVED_NUM; ++i)
+		Positions[CMenuBackground::POS_RESERVED0 + i] = vec2(0, 0);
+	
+	return Positions;
+}
+
 CMenuBackground::CMenuBackground() :
 	CBackground(CMapLayers::TYPE_FULL_DESIGN, false)
 {
@@ -56,28 +86,7 @@ void CMenuBackground::OnInit()
 
 void CMenuBackground::ResetPositions()
 {
-	m_aPositions[POS_START] = vec2(500.0f, 500.0f);
-	m_aPositions[POS_BROWSER_INTERNET] = vec2(1000.0f, 1000.0f);
-	m_aPositions[POS_BROWSER_LAN] = vec2(1100.0f, 1000.0f);
-	m_aPositions[POS_DEMOS] = vec2(900.0f, 100.0f);
-	m_aPositions[POS_NEWS] = vec2(500.0f, 750.0f);
-	m_aPositions[POS_BROWSER_FAVORITES] = vec2(1250.0f, 500.0f);
-	m_aPositions[POS_SETTINGS_LANGUAGE] = vec2(500.0f, 1200.0f);
-	m_aPositions[POS_SETTINGS_GENERAL] = vec2(500.0f, 1000.0f);
-	m_aPositions[POS_SETTINGS_PLAYER] = vec2(600.0f, 1000.0f);
-	m_aPositions[POS_SETTINGS_TEE] = vec2(700.0f, 1000.0f);
-	m_aPositions[POS_SETTINGS_APPEARANCE] = vec2(200.0f, 1000.0f);
-	m_aPositions[POS_SETTINGS_CONTROLS] = vec2(800.0f, 1000.0f);
-	m_aPositions[POS_SETTINGS_GRAPHICS] = vec2(900.0f, 1000.0f);
-	m_aPositions[POS_SETTINGS_SOUND] = vec2(1000.0f, 1000.0f);
-	m_aPositions[POS_SETTINGS_DDNET] = vec2(1200.0f, 200.0f);
-	m_aPositions[POS_SETTINGS_ASSETS] = vec2(500.0f, 500.0f);
-	for(int i = 0; i < POS_BROWSER_CUSTOM_NUM; ++i)
-		m_aPositions[POS_BROWSER_CUSTOM0 + i] = vec2(500.0f + (75.0f * (float)i), 650.0f - (75.0f * (float)i));
-	for(int i = 0; i < POS_SETTINGS_RESERVED_NUM; ++i)
-		m_aPositions[POS_SETTINGS_RESERVED0 + i] = vec2(0, 0);
-	for(int i = 0; i < POS_RESERVED_NUM; ++i)
-		m_aPositions[POS_RESERVED0 + i] = vec2(0, 0);
+	m_aPositions = GenerateMenuBackgroundPositions();
 }
 
 int CMenuBackground::ThemeScan(const char *pName, int IsDir, int DirType, void *pUser)

--- a/src/game/client/components/menu_background.h
+++ b/src/game/client/components/menu_background.h
@@ -28,6 +28,8 @@ public:
 	bool operator<(const CTheme &Other) const { return m_Name < Other.m_Name; }
 };
 
+std::vector<vec2> GenerateMenuBackgroundPositions();
+
 class CMenuBackground : public CBackground
 {
 	std::chrono::nanoseconds m_ThemeScanStartTime{0};
@@ -83,7 +85,7 @@ public:
 
 	vec2 m_MenuCenter;
 	vec2 m_RotationCenter;
-	vec2 m_aPositions[NUM_POS];
+	std::vector<vec2> m_aPositions;
 	int m_CurrentPosition;
 	vec2 m_AnimationStartPos;
 	bool m_ChangedPosition;

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -830,6 +830,8 @@ public:
 
 		m_GuiActive = true;
 		m_ProofBorders = false;
+		m_MenuProofBorders = false;
+		m_CurrentMenuProofIndex = 0;
 		m_PreviewZoom = false;
 
 		m_ShowTileInfo = false;
@@ -1068,12 +1070,17 @@ public:
 	bool m_ShowMousePointer;
 	bool m_GuiActive;
 	bool m_ProofBorders;
+	bool m_MenuProofBorders;
+	int m_CurrentMenuProofIndex;
+	std::vector<vec2> m_vMenuBackgroundPositions;
 	bool m_PreviewZoom;
 	float m_MouseWScale = 1.0f; // Mouse (i.e. UI) scale relative to the World (selected Group)
 	float m_MouseX = 0.0f;
 	float m_MouseY = 0.0f;
 	float m_MouseWorldX = 0.0f;
 	float m_MouseWorldY = 0.0f;
+	float m_MouseWorldNoParaX = 0.0f;
+	float m_MouseWorldNoParaY = 0.0f;
 	float m_MouseDeltaX;
 	float m_MouseDeltaY;
 	float m_MouseDeltaWx;


### PR DESCRIPTION

![backgroundproof](https://user-images.githubusercontent.com/49279081/225979288-3fb43d41-79f7-477e-8479-6b3d106fbd5b.gif)

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
