### PR TITLE
Make team kills condensed in killfeed

### DIFF
--- a/datasrc/network.py
+++ b/datasrc/network.py
@@ -515,7 +515,8 @@ Messages = [
 	]),
     
 	NetMessageEx("Sv_KillMsgPlus", "killmsgplus@netmsg.ddnet.tw", [
-		NetBool("m_Sendable"),
-        NetIntRange("m_TeamSize", 0, 'MAX_CLIENTS'),
+		NetIntRange("m_Victim", 0, 'MAX_CLIENTS-1'),
+		NetIntRange("m_Weapon", -3, 'NUM_WEAPONS-1'),
+		NetIntRange("m_Size", 0, 'MAX_CLIENTS-1'),
 	]),
 ]

--- a/datasrc/network.py
+++ b/datasrc/network.py
@@ -514,9 +514,8 @@ Messages = [
 		NetIntAny("m_PlayerTimeBest"),
 	]),
     
-	NetMessageEx("Sv_KillMsgPlus", "killmsgplus@netmsg.ddnet.tw", [
-		NetIntRange("m_Victim", 0, 'MAX_CLIENTS-1'),
-		NetIntRange("m_Weapon", -3, 'NUM_WEAPONS-1'),
-		NetIntRange("m_Size", 0, 'MAX_CLIENTS-1'),
+	NetMessageEx("Sv_KillMsgTeam", "killmsgteam@netmsg.ddnet.tw", [
+		NetIntRange("m_Team", 0, 'MAX_CLIENTS-1'),
+		NetIntRange("m_First", -1, 'MAX_CLIENTS-1'),
 	]),
 ]

--- a/datasrc/network.py
+++ b/datasrc/network.py
@@ -513,4 +513,9 @@ Messages = [
 		NetIntAny("m_ServerTimeBest"),
 		NetIntAny("m_PlayerTimeBest"),
 	]),
+    
+	NetMessageEx("Sv_KillMsgPlus", "killmsgplus@netmsg.ddnet.tw", [
+		NetBool("m_Sendable"),
+        NetIntRange("m_TeamSize", 0, 'MAX_CLIENTS'),
+	]),
 ]

--- a/src/game/client/components/killmessages.cpp
+++ b/src/game/client/components/killmessages.cpp
@@ -6,6 +6,7 @@
 #include <engine/textrender.h>
 #include <game/generated/client_data.h>
 #include <game/generated/protocol.h>
+#include <game/localization.h>
 
 #include "killmessages.h"
 #include <game/client/animstate.h>
@@ -135,9 +136,7 @@ void CKillMessages::OnMessage(int MsgType, void *pRawMsg)
 				}
 			}
 
-			char aBuf[8];
-			str_format(aBuf, sizeof(aBuf), "Team %d", Kill.m_VictimDDTeam);
-			str_copy(Kill.m_aVictimName, aBuf);
+			str_format(Kill.m_aVictimName, sizeof(Kill.m_aVictimName), Localize("Team %d"), Kill.m_VictimDDTeam);
 		}
 
 		Kill.m_KillerID = Kill.m_VictimID;

--- a/src/game/client/components/killmessages.h
+++ b/src/game/client/components/killmessages.h
@@ -6,6 +6,11 @@
 
 #include <game/client/render.h>
 
+enum
+{
+	MAX_KILLMSGS = 5,
+	MAX_KILLMSGTEAM = 4,
+};
 class CKillMessages : public CComponent
 {
 	int m_SpriteQuadContainerIndex;
@@ -27,8 +32,7 @@ public:
 		char m_aVictimName[64];
 		int m_VictimTextContainerIndex;
 		float m_VitctimTextWidth;
-		CTeeRenderInfo m_VictimRenderInfo;
-
+		CTeeRenderInfo m_VictimRenderInfo[MAX_KILLMSGTEAM];
 		int m_KillerID;
 		int m_KillerTeam;
 		char m_aKillerName[64];
@@ -39,11 +43,7 @@ public:
 		int m_ModeSpecial; // for CTF, if the guy is carrying a flag for example
 		int m_Tick;
 		int m_FlagCarrierBlue;
-	};
-
-	enum
-	{
-		MAX_KILLMSGS = 5,
+		int m_TeamSize;
 	};
 
 private:
@@ -52,6 +52,12 @@ private:
 public:
 	CKillMsg m_aKillmsgs[MAX_KILLMSGS];
 	int m_KillmsgCurrent;
+
+	CTeeRenderInfo m_aVictimSkinBuffer[MAX_KILLMSGTEAM];
+	int m_VictimSkinCurrent;
+
+	bool m_Sendable;
+	int m_TeamSizeCarrier;
 
 	virtual int Sizeof() const override { return sizeof(*this); }
 	virtual void OnWindowResize() override;

--- a/src/game/client/components/killmessages.h
+++ b/src/game/client/components/killmessages.h
@@ -52,12 +52,7 @@ private:
 public:
 	CKillMsg m_aKillmsgs[MAX_KILLMSGS];
 	int m_KillmsgCurrent;
-
-	CTeeRenderInfo m_aVictimSkinBuffer[MAX_KILLMSGTEAM];
 	int m_VictimSkinCurrent;
-
-	bool m_Sendable;
-	int m_TeamSizeCarrier;
 
 	virtual int Sizeof() const override { return sizeof(*this); }
 	virtual void OnWindowResize() override;

--- a/src/game/client/components/killmessages.h
+++ b/src/game/client/components/killmessages.h
@@ -5,15 +5,14 @@
 #include <game/client/component.h>
 
 #include <game/client/render.h>
-
-enum
-{
-	MAX_KILLMSGS = 5,
-	MAX_KILLMSGTEAM = 4,
-};
 class CKillMessages : public CComponent
 {
 	int m_SpriteQuadContainerIndex;
+	enum
+	{
+		MAX_KILLMSGS = 5,
+		MAX_KILLMSG_TEAM_MEMBERS = 4,
+	};
 
 public:
 	// kill messages
@@ -32,7 +31,7 @@ public:
 		char m_aVictimName[64];
 		int m_VictimTextContainerIndex;
 		float m_VitctimTextWidth;
-		CTeeRenderInfo m_VictimRenderInfo[MAX_KILLMSGTEAM];
+		CTeeRenderInfo m_VictimRenderInfo[MAX_KILLMSG_TEAM_MEMBERS];
 		int m_KillerID;
 		int m_KillerTeam;
 		char m_aKillerName[64];
@@ -52,7 +51,6 @@ private:
 public:
 	CKillMsg m_aKillmsgs[MAX_KILLMSGS];
 	int m_KillmsgCurrent;
-	int m_VictimSkinCurrent;
 
 	virtual int Sizeof() const override { return sizeof(*this); }
 	virtual void OnWindowResize() override;

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -906,7 +906,7 @@ bool CCharacter::IncreaseArmor(int Amount)
 	return true;
 }
 
-void CCharacter::Die(int Killer, int Weapon, bool Single)
+void CCharacter::Die(int Killer, int Weapon, bool SendKillMsg)
 {
 	if(Server()->IsRecording(m_pPlayer->GetCID()))
 		Server()->StopRecord(m_pPlayer->GetCID());
@@ -919,26 +919,15 @@ void CCharacter::Die(int Killer, int Weapon, bool Single)
 		m_pPlayer->GetCID(), Server()->ClientName(m_pPlayer->GetCID()), Weapon, ModeSpecial);
 	GameServer()->Console()->Print(IConsole::OUTPUT_LEVEL_DEBUG, "game", aBuf);
 
-	// send the kill messages
-	if(Single)
+	// send the kill message
+	if(SendKillMsg && (Team() == TEAM_FLOCK || Teams()->Count(Team()) == 1 || Teams()->GetTeamState(Team()) == CGameTeams::TEAMSTATE_OPEN))
 	{
-		if(Team() != TEAM_FLOCK && Teams()->TeamSize(Team()) > 1 && Teams()->GetTeamState(Team()) != 1)
-		{
-			CNetMsg_Sv_KillMsgPlus MsgPlus;
-			MsgPlus.m_Victim = m_pPlayer->GetCID();
-			MsgPlus.m_Weapon = Weapon;
-			MsgPlus.m_Size = Teams()->TeamSize(Team());
-			Server()->SendPackMsg(&MsgPlus, MSGFLAG_VITAL, -1);
-		}
-		else
-		{
-			CNetMsg_Sv_KillMsg Msg;
-			Msg.m_Killer = Killer;
-			Msg.m_Victim = m_pPlayer->GetCID();
-			Msg.m_Weapon = Weapon;
-			Msg.m_ModeSpecial = ModeSpecial;
-			Server()->SendPackMsg(&Msg, MSGFLAG_VITAL, -1);
-		}
+		CNetMsg_Sv_KillMsg Msg;
+		Msg.m_Killer = Killer;
+		Msg.m_Victim = m_pPlayer->GetCID();
+		Msg.m_Weapon = Weapon;
+		Msg.m_ModeSpecial = ModeSpecial;
+		Server()->SendPackMsg(&Msg, MSGFLAG_VITAL, -1);
 	}
 
 	// a nice sound

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -922,27 +922,24 @@ void CCharacter::Die(int Killer, int Weapon, bool Single)
 	// send the kill messages
 	if(Single)
 	{
-		CNetMsg_Sv_KillMsgPlus MsgPlus;
-
-		if(Team() != TEAM_FLOCK && Teams()->TeamSize(Team()) != 1 && Teams()->GetTeamState(Team()) != 1)
+		if(Team() != TEAM_FLOCK && Teams()->TeamSize(Team()) > 1 && Teams()->GetTeamState(Team()) != 1)
 		{
-			MsgPlus.m_Sendable = false;
-			MsgPlus.m_TeamSize = 0;
+			CNetMsg_Sv_KillMsgPlus MsgPlus;
+			MsgPlus.m_Victim = m_pPlayer->GetCID();
+			MsgPlus.m_Weapon = Weapon;
+			MsgPlus.m_Size = Teams()->TeamSize(Team());
+			Server()->SendPackMsg(&MsgPlus, MSGFLAG_VITAL, -1);
 		}
 		else
 		{
-			MsgPlus.m_Sendable = true;
-			MsgPlus.m_TeamSize = 1;
+			CNetMsg_Sv_KillMsg Msg;
+			Msg.m_Killer = Killer;
+			Msg.m_Victim = m_pPlayer->GetCID();
+			Msg.m_Weapon = Weapon;
+			Msg.m_ModeSpecial = ModeSpecial;
+			Server()->SendPackMsg(&Msg, MSGFLAG_VITAL, -1);
 		}
-		Server()->SendPackMsg(&MsgPlus, MSGFLAG_VITAL, -1);
 	}
-
-	CNetMsg_Sv_KillMsg Msg;
-	Msg.m_Killer = Killer;
-	Msg.m_Victim = m_pPlayer->GetCID();
-	Msg.m_Weapon = Weapon;
-	Msg.m_ModeSpecial = ModeSpecial;
-	Server()->SendPackMsg(&Msg, MSGFLAG_VITAL, -1);
 
 	// a nice sound
 	GameServer()->CreateSound(m_Pos, SOUND_PLAYER_DIE, TeamMask());

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -906,7 +906,7 @@ bool CCharacter::IncreaseArmor(int Amount)
 	return true;
 }
 
-void CCharacter::Die(int Killer, int Weapon)
+void CCharacter::Die(int Killer, int Weapon, bool Single)
 {
 	if(Server()->IsRecording(m_pPlayer->GetCID()))
 		Server()->StopRecord(m_pPlayer->GetCID());
@@ -919,7 +919,24 @@ void CCharacter::Die(int Killer, int Weapon)
 		m_pPlayer->GetCID(), Server()->ClientName(m_pPlayer->GetCID()), Weapon, ModeSpecial);
 	GameServer()->Console()->Print(IConsole::OUTPUT_LEVEL_DEBUG, "game", aBuf);
 
-	// send the kill message
+	// send the kill messages
+	if(Single)
+	{
+		CNetMsg_Sv_KillMsgPlus MsgPlus;
+
+		if(Team() != TEAM_FLOCK && Teams()->TeamSize(Team()) != 1 && Teams()->GetTeamState(Team()) != 1)
+		{
+			MsgPlus.m_Sendable = false;
+			MsgPlus.m_TeamSize = 0;
+		}
+		else
+		{
+			MsgPlus.m_Sendable = true;
+			MsgPlus.m_TeamSize = 1;
+		}
+		Server()->SendPackMsg(&MsgPlus, MSGFLAG_VITAL, -1);
+	}
+
 	CNetMsg_Sv_KillMsg Msg;
 	Msg.m_Killer = Killer;
 	Msg.m_Victim = m_pPlayer->GetCID();

--- a/src/game/server/entities/character.h
+++ b/src/game/server/entities/character.h
@@ -63,7 +63,7 @@ public:
 	void ResetInput();
 	void FireWeapon();
 
-	void Die(int Killer, int Weapon, bool Single = true);
+	void Die(int Killer, int Weapon, bool SendKillMsg = true);
 	bool TakeDamage(vec2 Force, int Dmg, int From, int Weapon);
 
 	bool Spawn(class CPlayer *pPlayer, vec2 Pos);

--- a/src/game/server/entities/character.h
+++ b/src/game/server/entities/character.h
@@ -63,7 +63,7 @@ public:
 	void ResetInput();
 	void FireWeapon();
 
-	void Die(int Killer, int Weapon);
+	void Die(int Killer, int Weapon, bool Single = true);
 	bool TakeDamage(vec2 Force, int Dmg, int From, int Weapon);
 
 	bool Spawn(class CPlayer *pPlayer, vec2 Pos);

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -559,11 +559,11 @@ CCharacter *CPlayer::GetCharacter()
 	return 0;
 }
 
-void CPlayer::KillCharacter(int Weapon, bool Single)
+void CPlayer::KillCharacter(int Weapon, bool SendKillMsg)
 {
 	if(m_pCharacter)
 	{
-		m_pCharacter->Die(m_ClientID, Weapon, Single);
+		m_pCharacter->Die(m_ClientID, Weapon, SendKillMsg);
 
 		delete m_pCharacter;
 		m_pCharacter = 0;

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -559,11 +559,11 @@ CCharacter *CPlayer::GetCharacter()
 	return 0;
 }
 
-void CPlayer::KillCharacter(int Weapon)
+void CPlayer::KillCharacter(int Weapon, bool Single)
 {
 	if(m_pCharacter)
 	{
-		m_pCharacter->Die(m_ClientID, Weapon);
+		m_pCharacter->Die(m_ClientID, Weapon, Single);
 
 		delete m_pCharacter;
 		m_pCharacter = 0;

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -59,7 +59,7 @@ public:
 	void OnPredictedEarlyInput(CNetObj_PlayerInput *pNewInput);
 	void OnDisconnect();
 
-	void KillCharacter(int Weapon = WEAPON_GAME, bool Single = true);
+	void KillCharacter(int Weapon = WEAPON_GAME, bool SendKillMsg = true);
 	CCharacter *GetCharacter();
 
 	void SpectatePlayerName(const char *pName);

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -59,7 +59,7 @@ public:
 	void OnPredictedEarlyInput(CNetObj_PlayerInput *pNewInput);
 	void OnDisconnect();
 
-	void KillCharacter(int Weapon = WEAPON_GAME);
+	void KillCharacter(int Weapon = WEAPON_GAME, bool Single = true);
 	CCharacter *GetCharacter();
 
 	void SpectatePlayerName(const char *pName);

--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -446,6 +446,12 @@ void CGameTeams::ChangeTeamState(int Team, int State)
 
 void CGameTeams::KillTeam(int Team, int NewStrongID, int ExceptID)
 {
+	int ShowcaseID = 0;
+	int First = 0;
+
+	if(NewStrongID != -1)
+		ShowcaseID = NewStrongID;
+
 	for(int i = 0; i < MAX_CLIENTS; i++)
 	{
 		if(m_Core.Team(i) == Team && GameServer()->m_apPlayers[i])
@@ -453,7 +459,12 @@ void CGameTeams::KillTeam(int Team, int NewStrongID, int ExceptID)
 			GameServer()->m_apPlayers[i]->m_VotedForPractice = false;
 			if(i != ExceptID)
 			{
-				GameServer()->m_apPlayers[i]->KillCharacter(WEAPON_SELF);
+				GameServer()->m_apPlayers[i]->KillCharacter(WEAPON_SELF, false);
+
+				First++;
+				if(First == 1 && NewStrongID == -1)
+					ShowcaseID = i;
+
 				if(NewStrongID != -1 && i != NewStrongID)
 				{
 					GameServer()->m_apPlayers[i]->Respawn(true); // spawn the rest of team with weak hook on the killer
@@ -461,6 +472,19 @@ void CGameTeams::KillTeam(int Team, int NewStrongID, int ExceptID)
 			}
 		}
 	}
+
+	CNetMsg_Sv_KillMsgPlus MsgPlus;
+
+	MsgPlus.m_Sendable = true;
+	MsgPlus.m_TeamSize = TeamSize(Team);
+	Server()->SendPackMsg(&MsgPlus, MSGFLAG_VITAL, -1);
+
+	CNetMsg_Sv_KillMsg Msg;
+	Msg.m_Killer = ShowcaseID;
+	Msg.m_Victim = ShowcaseID;
+	Msg.m_Weapon = WEAPON_SELF;
+	Msg.m_ModeSpecial = 0;
+	Server()->SendPackMsg(&Msg, MSGFLAG_VITAL, -1);
 }
 
 bool CGameTeams::TeamFinished(int Team)
@@ -1137,4 +1161,15 @@ int CGameTeams::GetFirstEmptyTeam() const
 		if(m_aTeamState[i] == TEAMSTATE_EMPTY)
 			return i;
 	return -1;
+}
+
+int CGameTeams::TeamSize(int Team)
+{
+	int TeamSize = 0;
+	for(int i = 0; i < MAX_CLIENTS; i++)
+	{
+		if(m_Core.Team(i) == Team && GameServer()->m_apPlayers[i])
+			TeamSize++;
+	}
+	return TeamSize;
 }

--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -446,12 +446,6 @@ void CGameTeams::ChangeTeamState(int Team, int State)
 
 void CGameTeams::KillTeam(int Team, int NewStrongID, int ExceptID)
 {
-	int ShowcaseID = 0;
-	int First = 0;
-
-	if(NewStrongID != -1)
-		ShowcaseID = NewStrongID;
-
 	for(int i = 0; i < MAX_CLIENTS; i++)
 	{
 		if(m_Core.Team(i) == Team && GameServer()->m_apPlayers[i])
@@ -460,11 +454,6 @@ void CGameTeams::KillTeam(int Team, int NewStrongID, int ExceptID)
 			if(i != ExceptID)
 			{
 				GameServer()->m_apPlayers[i]->KillCharacter(WEAPON_SELF, false);
-
-				First++;
-				if(First == 1 && NewStrongID == -1)
-					ShowcaseID = i;
-
 				if(NewStrongID != -1 && i != NewStrongID)
 				{
 					GameServer()->m_apPlayers[i]->Respawn(true); // spawn the rest of team with weak hook on the killer
@@ -474,10 +463,9 @@ void CGameTeams::KillTeam(int Team, int NewStrongID, int ExceptID)
 	}
 
 	// send the team kill message
-	CNetMsg_Sv_KillMsgPlus Msg;
-	Msg.m_Victim = ShowcaseID;
-	Msg.m_Weapon = WEAPON_SELF;
-	Msg.m_Size = Count(Team);
+	CNetMsg_Sv_KillMsgTeam Msg;
+	Msg.m_Team = Team;
+	Msg.m_First = NewStrongID;
 	Server()->SendPackMsg(&Msg, MSGFLAG_VITAL, -1);
 }
 

--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -446,12 +446,6 @@ void CGameTeams::ChangeTeamState(int Team, int State)
 
 void CGameTeams::KillTeam(int Team, int NewStrongID, int ExceptID)
 {
-	int ShowcaseID = 0;
-	int First = 0;
-
-	if(NewStrongID != -1)
-		ShowcaseID = NewStrongID;
-
 	for(int i = 0; i < MAX_CLIENTS; i++)
 	{
 		if(m_Core.Team(i) == Team && GameServer()->m_apPlayers[i])
@@ -461,10 +455,6 @@ void CGameTeams::KillTeam(int Team, int NewStrongID, int ExceptID)
 			{
 				GameServer()->m_apPlayers[i]->KillCharacter(WEAPON_SELF, false);
 
-				First++;
-				if(First == 1 && NewStrongID == -1)
-					ShowcaseID = i;
-
 				if(NewStrongID != -1 && i != NewStrongID)
 				{
 					GameServer()->m_apPlayers[i]->Respawn(true); // spawn the rest of team with weak hook on the killer
@@ -472,19 +462,6 @@ void CGameTeams::KillTeam(int Team, int NewStrongID, int ExceptID)
 			}
 		}
 	}
-
-	CNetMsg_Sv_KillMsgPlus MsgPlus;
-
-	MsgPlus.m_Sendable = true;
-	MsgPlus.m_TeamSize = TeamSize(Team);
-	Server()->SendPackMsg(&MsgPlus, MSGFLAG_VITAL, -1);
-
-	CNetMsg_Sv_KillMsg Msg;
-	Msg.m_Killer = ShowcaseID;
-	Msg.m_Victim = ShowcaseID;
-	Msg.m_Weapon = WEAPON_SELF;
-	Msg.m_ModeSpecial = 0;
-	Server()->SendPackMsg(&Msg, MSGFLAG_VITAL, -1);
 }
 
 bool CGameTeams::TeamFinished(int Team)
@@ -1165,11 +1142,9 @@ int CGameTeams::GetFirstEmptyTeam() const
 
 int CGameTeams::TeamSize(int Team)
 {
-	int TeamSize = 0;
+	int NumberOfTees = 0;
 	for(int i = 0; i < MAX_CLIENTS; i++)
-	{
 		if(m_Core.Team(i) == Team && GameServer()->m_apPlayers[i])
-			TeamSize++;
-	}
-	return TeamSize;
+			NumberOfTees++;
+	return NumberOfTees;
 }

--- a/src/game/server/teams.h
+++ b/src/game/server/teams.h
@@ -126,8 +126,6 @@ public:
 
 	int GetFirstEmptyTeam() const;
 
-	int TeamSize(int Team);
-
 	bool TeeStarted(int ClientID)
 	{
 		return m_aTeeStarted[ClientID];

--- a/src/game/server/teams.h
+++ b/src/game/server/teams.h
@@ -126,6 +126,8 @@ public:
 
 	int GetFirstEmptyTeam() const;
 
+	int TeamSize(int Team);
+
 	bool TeeStarted(int ClientID)
 	{
 		return m_aTeeStarted[ClientID];


### PR DESCRIPTION
For those who still have the killfeed on, I wanted to modernize it, by having team kills become one line instead of a bunch!

![image](https://user-images.githubusercontent.com/95713843/226060109-ed74c2f6-1289-4247-81dc-1725428ddf59.png)
## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
