### PR TITLE
scripts/git_revision.py: Allow to pass in the git shortrev

### DIFF
--- a/scripts/git_revision.py
+++ b/scripts/git_revision.py
@@ -1,9 +1,12 @@
+import os
 import subprocess
+git_hash = os.environ.get("DDNET_GIT_SHORTREV_HASH")
 try:
-	git_hash = subprocess.check_output(["git", "rev-parse", "--short=16", "HEAD"], stderr=subprocess.DEVNULL).decode().strip()
+	git_hash = git_hash or subprocess.check_output(["git", "rev-parse", "--short=16", "HEAD"], stderr=subprocess.DEVNULL).decode().strip()
+except (FileNotFoundError, subprocess.CalledProcessError):
+	pass
+if git_hash is not None:
 	definition = f'"{git_hash}"'
-except FileNotFoundError:
-	definition = "0"
-except subprocess.CalledProcessError:
+else:
 	definition = "0"
 print(f"const char *GIT_SHORTREV_HASH = {definition};")

--- a/scripts/git_revision.py
+++ b/scripts/git_revision.py
@@ -1,11 +1,8 @@
-import errno
 import subprocess
 try:
 	git_hash = subprocess.check_output(["git", "rev-parse", "--short=16", "HEAD"], stderr=subprocess.DEVNULL).decode().strip()
 	definition = f'"{git_hash}"'
-except FileNotFoundError as e:
-	if e.errno != errno.ENOENT:
-		raise
+except FileNotFoundError:
 	definition = "0"
 except subprocess.CalledProcessError:
 	definition = "0"


### PR DESCRIPTION
Use the `DDNET_GIT_SHORTREV_HASH` variable for this. This allows builds that do not use `git` to still have this kind of version information.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
