### PR TITLE
Fix incorrect sixup detection when snapping pickups

### DIFF
--- a/src/game/server/entities/pickup.cpp
+++ b/src/game/server/entities/pickup.cpp
@@ -173,7 +173,7 @@ void CPickup::Snap(int SnappingClient)
 		pChar = GameServer()->GetPlayerChar(GameServer()->m_apPlayers[SnappingClient]->m_SpectatorID);
 
 	int SnappingClientVersion = GameServer()->GetClientVersion(SnappingClient);
-	bool Sixup = SnappingClientVersion == VERSION_NONE ? Server()->IsSixup(SnappingClient) : false;
+	bool Sixup = Server()->IsSixup(SnappingClient);
 
 	CNetObj_EntityEx *pEntData = 0;
 	if(SnappingClientVersion >= VERSION_DDNET_SWITCH && (m_Layer == LAYER_SWITCH || length(m_Core) > 0))


### PR DESCRIPTION
For 0.7 clients the client version is not `VERSION_NONE`, so `IsSixup` was never called for them, which leads to version 0.6 pickups being snapped for 0.7 clients. This causes snapshot CRC errors for the 0.7 clients, as the 0.6 and 0.7 pickup structs have different sizes.

Now the version is no longer checked before calling `IsSixup`, which is the case in all other locations where the function is called and was also the case before this bug was introduced by #6330.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
