### PR TITLE
Fix console chain of `inp_controller_guid`

### DIFF
--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -101,7 +101,7 @@ void CInput::InitJoysticks()
 		OpenJoystick(i);
 	UpdateActiveJoystick();
 
-	Console()->Chain("joystick_guid", ConchainJoystickGuidChanged, this);
+	Console()->Chain("inp_controller_guid", ConchainJoystickGuidChanged, this);
 }
 
 bool CInput::OpenJoystick(int JoystickIndex)
@@ -145,7 +145,10 @@ void CInput::UpdateActiveJoystick()
 void CInput::ConchainJoystickGuidChanged(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData)
 {
 	pfnCallback(pResult, pCallbackUserData);
-	static_cast<CInput *>(pUserData)->UpdateActiveJoystick();
+	if(pResult->NumArguments() == 1)
+	{
+		static_cast<CInput *>(pUserData)->UpdateActiveJoystick();
+	}
 }
 
 float CInput::GetJoystickDeadzone()


### PR DESCRIPTION
The console chain was broken due to `joystick_guid` being renamed to `inp_controller_guid`, so the active controller was not being updated when the GUID is changed via the console.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
