### PR TITLE
Add random skin button

### DIFF
--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -105,6 +105,8 @@ class CMenus : public CComponent
 
 	void RefreshSkins();
 
+	void RandomSkin();
+
 	// new gui with gui elements
 	template<typename T>
 	int DoButtonMenu(CUIElement &UIElement, const void *pID, T &&GetTextLambda, int Checked, const CUIRect *pRect, bool HintRequiresStringCheck, bool HintCanChangePositionOrSize = false, int Corners = IGraphics::CORNER_ALL, float r = 5.0f, float FontFactor = 0.0f, vec4 ColorHot = vec4(1.0f, 1.0f, 1.0f, 0.75f), vec4 Color = vec4(1, 1, 1, 0.5f), int AlignVertically = 1)

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -716,7 +716,7 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 	}
 	TextRender()->SetRenderFlags(0);
 	TextRender()->SetCurFont(nullptr);
-	GameClient()->m_Tooltips.DoToolTip(0, &Button, Localize("Create a random skin"));
+	GameClient()->m_Tooltips.DoToolTip(&s_RandomSkinButtonID, &Button, Localize("Create a random skin"));
 
 	// custom color selector
 	MainView.HSplitTop(20.0f + RenderEyesBelow * 25.0f, 0, &MainView);

--- a/src/game/client/components/skins.cpp
+++ b/src/game/client/components/skins.cpp
@@ -17,12 +17,7 @@
 
 #include "skins.h"
 
-static const char *VANILLA_SKINS[] = {"bluekitty", "bluestripe", "brownbear",
-	"cammo", "cammostripes", "coala", "default", "limekitty",
-	"pinky", "redbopp", "redstripe", "saddo", "toptri",
-	"twinbop", "twintri", "warpaint", "x_ninja", "x_spec"};
-
-static bool IsVanillaSkin(const char *pName)
+bool CSkins::IsVanillaSkin(const char *pName)
 {
 	return std::any_of(std::begin(VANILLA_SKINS), std::end(VANILLA_SKINS), [pName](const char *pVanillaSkin) { return str_comp(pName, pVanillaSkin) == 0; });
 }

--- a/src/game/client/components/skins.h
+++ b/src/game/client/components/skins.h
@@ -69,6 +69,13 @@ public:
 
 	bool IsDownloadingSkins() { return m_DownloadingSkins; }
 
+	static bool IsVanillaSkin(const char *pName);
+
+	constexpr static const char *VANILLA_SKINS[] = {"bluekitty", "bluestripe", "brownbear",
+		"cammo", "cammostripes", "coala", "default", "limekitty",
+		"pinky", "redbopp", "redstripe", "saddo", "toptri",
+		"twinbop", "twintri", "warpaint", "x_ninja", "x_spec"};
+
 private:
 	std::unordered_map<std::string_view, std::unique_ptr<CSkin>> m_Skins;
 	std::unordered_map<std::string_view, std::unique_ptr<CDownloadSkin>> m_DownloadSkins;


### PR DESCRIPTION
Adds a button for generating a random skin in tee settings. The logic generates handsome tees more often than not.
Intentionally didn't add a console command so it's not possible to make annoying skin change binds with this.
![random_skin](https://user-images.githubusercontent.com/65019210/227658839-5e8f3a4b-4e7c-4561-90c9-21a267d61a3a.png)

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
