### PR TITLE
Check if HTTP request task is aborted in completion callback

### DIFF
--- a/src/engine/shared/http.cpp
+++ b/src/engine/shared/http.cpp
@@ -359,6 +359,9 @@ int CHttpRequest::ProgressCallback(void *pUser, double DlTotal, double DlCurr, d
 
 int CHttpRequest::OnCompletion(int State)
 {
+	if(m_Abort)
+		State = HTTP_ABORTED;
+
 	if(m_WriteToFile)
 	{
 		if(m_File && io_close(m_File) != 0)


### PR DESCRIPTION
It's possible for the HTTP request task to be aborted after the curl request has finished, so the returned `State` will be `HTTP_DONE` but `m_Abort` is `true`. The `State` never changes to `HTTP_ABORTED`, because the progress callback is not called after the HTTP request has completed.

This causes the client to crash when a skin download is aborted after the HTTP request finished but before the completion callback is called.

This is fixed by checking if `m_Abort` is `true` and setting the `State` to `HTTP_ABORTED` at the beginning of the completion callback.

Closes #3567.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
