### PR TITLE
Add "Delete" button to editor file browser

### DIFF
--- a/src/engine/shared/storage.cpp
+++ b/src/engine/shared/storage.cpp
@@ -644,6 +644,19 @@ public:
 		return Success;
 	}
 
+	bool RemoveFolder(const char *pFilename, int Type) override
+	{
+		dbg_assert(Type == TYPE_ABSOLUTE || (Type >= TYPE_SAVE && Type < m_NumPaths), "Type invalid");
+
+		char aBuffer[IO_MAX_PATH_LENGTH];
+		GetPath(Type, pFilename, aBuffer, sizeof(aBuffer));
+
+		bool Success = !fs_removedir(aBuffer);
+		if(!Success)
+			dbg_msg("storage", "failed to remove: %s", aBuffer);
+		return Success;
+	}
+
 	bool RemoveBinaryFile(const char *pFilename) override
 	{
 		char aBuffer[IO_MAX_PATH_LENGTH];

--- a/src/engine/storage.h
+++ b/src/engine/storage.h
@@ -52,6 +52,7 @@ public:
 	virtual bool FindFile(const char *pFilename, const char *pPath, int Type, char *pBuffer, int BufferSize) = 0;
 	virtual size_t FindFiles(const char *pFilename, const char *pPath, int Type, std::set<std::string> *pEntries) = 0;
 	virtual bool RemoveFile(const char *pFilename, int Type) = 0;
+	virtual bool RemoveFolder(const char *pFilename, int Type) = 0;
 	virtual bool RenameFile(const char *pOldFilename, const char *pNewFilename, int Type) = 0;
 	virtual bool CreateFolder(const char *pFoldername, int Type) = 0;
 	virtual void GetCompletePath(int Type, const char *pDir, char *pBuffer, unsigned BufferSize) = 0;

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -5043,18 +5043,6 @@ void CEditor::RenderFileDialog()
 	if(DoButton_Editor(&s_CancelButton, "Cancel", 0, &Button, 0, nullptr) || (s_ListBoxUsed && UI()->ConsumeHotkey(CUI::HOTKEY_ESCAPE)))
 		m_Dialog = DIALOG_NONE;
 
-	if(m_FileDialogStorageType == IStorage::TYPE_SAVE)
-	{
-		ButtonBar.VSplitLeft(70.0f, &Button, &ButtonBar);
-		if(DoButton_Editor(&s_NewFolderButton, "New folder", 0, &Button, 0, nullptr))
-		{
-			m_aFileDialogNewFolderName[0] = 0;
-			static int s_NewFolderPopupID = 0;
-			UiInvokePopupMenu(&s_NewFolderPopupID, 0, Width / 2.0f - 200.0f, Height / 2.0f - 100.0f, 400.0f, 200.0f, PopupNewFolder);
-			UI()->SetActiveItem(nullptr);
-		}
-	}
-
 	ButtonBar.VSplitRight(40.0f, &ButtonBar, &Button);
 	ButtonBar.VSplitRight(50.0f, &ButtonBar, &Button);
 	if(DoButton_Editor(&s_RefreshButton, "Refresh", 0, &Button, 0, nullptr) || (s_ListBoxUsed && (Input()->KeyIsPressed(KEY_F5) || (Input()->ModifierIsPressed() && Input()->KeyIsPressed(KEY_R)))))
@@ -5072,6 +5060,15 @@ void CEditor::RenderFileDialog()
 
 	if(m_FileDialogStorageType == IStorage::TYPE_SAVE)
 	{
+		ButtonBar.VSplitLeft(70.0f, &Button, &ButtonBar);
+		if(DoButton_Editor(&s_NewFolderButton, "New folder", 0, &Button, 0, nullptr))
+		{
+			m_aFileDialogNewFolderName[0] = 0;
+			static int s_NewFolderPopupID = 0;
+			UiInvokePopupMenu(&s_NewFolderPopupID, 0, Width / 2.0f - 200.0f, Height / 2.0f - 100.0f, 400.0f, 200.0f, PopupNewFolder);
+			UI()->SetActiveItem(nullptr);
+		}
+
 		ButtonBar.VSplitLeft(40.0f, nullptr, &ButtonBar);
 		ButtonBar.VSplitLeft(70.0f, &Button, &ButtonBar);
 		if(DoButton_Editor(&s_MapInfoButton, "Map details", 0, &Button, 0, nullptr))


### PR DESCRIPTION
To delete files and empty folders from the user's save directory.

Only files and folders from the user's save directory can be deleted. Only empty folders can be deleted.

Error message popups are shown when the deletion fails.

Closes #6272.

Screenshots:

- ![screenshot_2023-03-25_16-54-58](https://user-images.githubusercontent.com/23437060/227728748-c13e7283-289f-47ee-a34b-c42407b5bd2b.png)
- ![screenshot_2023-03-25_16-55-05](https://user-images.githubusercontent.com/23437060/227728750-fb5246f1-35c2-4834-b71f-4e3b5782664f.png)
- ![screenshot_2023-03-25_16-55-26](https://user-images.githubusercontent.com/23437060/227728749-842a00d0-0dec-4671-aa1f-9d110defb0d4.png)


## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
