### PR TITLE
Ensure texture is cleared when rendering MOTD background

### DIFF
--- a/src/game/client/components/motd.cpp
+++ b/src/game/client/components/motd.cpp
@@ -64,7 +64,10 @@ void CMotd::OnRender()
 	}
 
 	if(m_RectQuadContainer != -1)
+	{
+		Graphics()->TextureClear();
 		Graphics()->RenderQuadContainer(m_RectQuadContainer, -1);
+	}
 
 	const float TextWidth = RectWidth - 2.0f * FontSize;
 	const float TextX = RectX + FontSize;


### PR DESCRIPTION
Seems like there are cases where the texture is not cleared when the MOTD background is rendered, so part of the font texture is used for the round rect.

![screenshot](https://user-images.githubusercontent.com/23437060/227772184-65a7e463-4551-460f-814d-9ad70eaa3dc7.png)

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
