### PR TITLE
Fix rcon login when disconnecting dummy and when username used

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -323,6 +323,7 @@ CClient::CClient() :
 	m_aCurrentRecvTick[1] = 0;
 	m_aRconAuthed[0] = 0;
 	m_aRconAuthed[1] = 0;
+	m_aRconUsername[0] = '\0';
 	m_aRconPassword[0] = '\0';
 	m_aPassword[0] = '\0';
 
@@ -508,6 +509,8 @@ void CClient::RconAuth(const char *pName, const char *pPassword)
 	if(RconAuthed())
 		return;
 
+	if(pName != m_aRconUsername)
+		str_copy(m_aRconUsername, pName);
 	if(pPassword != m_aRconPassword)
 		str_copy(m_aRconPassword, pPassword);
 
@@ -838,6 +841,8 @@ void CClient::DisconnectWithReason(const char *pReason)
 
 	//
 	m_aRconAuthed[0] = 0;
+	mem_zero(m_aRconUsername, sizeof(m_aRconUsername));
+	mem_zero(m_aRconPassword, sizeof(m_aRconPassword));
 	m_ServerSentCapabilities = false;
 	m_UseTempRconCommands = 0;
 	m_pConsole->DeregisterTempAll();
@@ -933,7 +938,13 @@ void CClient::DummyDisconnect(const char *pReason)
 
 	m_aNetClient[CONN_DUMMY].Disconnect(pReason);
 	g_Config.m_ClDummy = 0;
+
+	if(!m_aRconAuthed[0] && m_aRconAuthed[1])
+	{
+		RconAuth(m_aRconUsername, m_aRconPassword);
+	}
 	m_aRconAuthed[1] = 0;
+
 	m_aapSnapshots[1][SNAP_CURRENT] = 0;
 	m_aapSnapshots[1][SNAP_PREV] = 0;
 	m_aReceivedSnapshots[1] = 0;
@@ -1803,7 +1814,7 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket, int Conn, bool Dummy)
 			g_Config.m_ClDummy = 1;
 			Rcon("crashmeplx");
 			if(m_aRconAuthed[0])
-				RconAuth("", m_aRconPassword);
+				RconAuth(m_aRconUsername, m_aRconPassword);
 		}
 		else if(Msg == NETMSG_PING)
 		{

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -163,6 +163,7 @@ class CClient : public IClient, public CDemoPlayer::IListener
 	int m_aAckGameTick[NUM_DUMMIES];
 	int m_aCurrentRecvTick[NUM_DUMMIES];
 	int m_aRconAuthed[NUM_DUMMIES];
+	char m_aRconUsername[32];
 	char m_aRconPassword[32];
 	int m_UseTempRconCommands;
 	char m_aPassword[32];


### PR DESCRIPTION
When connecting a dummy and then logging into rcon only the dummy is logged in. When disconnecting the dummy, the main client was not automatically logged in. When logging in with the main client and then connecting the dummy, the dummy was already authenticated automatically. Now the main client is also authenticated automatically when disconnecting an authenticated dummy.

This automatic authentication was also not working correctly if the login used a username, as only the password was stored. Now both username and password are stored to correctly authenticate the main or dummy client.

The stored username and password are completely cleared when disconnecting, so they are not stored in memory longer than necessary.

Closes #5586.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
