### PR TITLE
update selected group correctly after dragging

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -3750,7 +3750,7 @@ void CEditor::RenderLayers(CUIRect LayersBox)
 		auto InsertPosition = std::find(m_Map.m_vpGroups.begin(), m_Map.m_vpGroups.end(), pNextGroup);
 		m_Map.m_vpGroups.insert(InsertPosition, pSelectedGroup);
 
-		m_SelectedGroup = GroupAfterDraggedLayer == 0 ? 0 : GroupAfterDraggedLayer - 1;
+		m_SelectedGroup = InsertPosition - m_Map.m_vpGroups.begin();
 		m_Map.m_Modified = true;
 	}
 


### PR DESCRIPTION
When dragging a layer up, the wrong layer is selected after. Should be merged before #6467.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
