### PR TITLE
Allow multiple selection in filedialog

### DIFF
--- a/src/game/client/ui_listbox.cpp
+++ b/src/game/client/ui_listbox.cpp
@@ -124,7 +124,6 @@ void CListBox::DoStart(float RowHeight, int NumItems, int ItemsPerRow, int RowsP
 	m_ListBoxRowHeight = RowHeight;
 	m_ListBoxNumItems = NumItems;
 	m_ListBoxItemsPerRow = ItemsPerRow;
-	m_ListBoxDoneEvents = false;
 	m_ListBoxItemActivated = false;
 	m_ListBoxItemSelected = false;
 
@@ -182,7 +181,7 @@ CListboxItem CListBox::DoNextItem(const void *pId, bool Selected, bool *pActive)
 		DoSpacing(m_AutoSpacing);
 
 	const int ThisItemIndex = m_ListBoxItemIndex;
-	if(Selected)
+	if(Selected && !m_ListBoxItemSelected)
 	{
 		if(m_ListBoxSelectedIndex == m_ListBoxNewSelected)
 			m_ListBoxNewSelected = ThisItemIndex;
@@ -206,17 +205,12 @@ CListboxItem CListBox::DoNextItem(const void *pId, bool Selected, bool *pActive)
 	const bool ProcessInput = !pActive || *pActive;
 
 	// process input, regard selected index
-	if(m_ListBoxSelectedIndex == ThisItemIndex)
+	if(m_ListBoxSelectedIndex == ThisItemIndex && ProcessInput)
 	{
-		if(ProcessInput && !m_ListBoxDoneEvents)
+		if(UI()->ConsumeHotkey(CUI::HOTKEY_ENTER) || (ItemClicked && Input()->MouseDoubleClick()))
 		{
-			m_ListBoxDoneEvents = true;
-
-			if(UI()->ConsumeHotkey(CUI::HOTKEY_ENTER) || (ItemClicked && Input()->MouseDoubleClick()))
-			{
-				m_ListBoxItemActivated = true;
-				UI()->SetActiveItem(nullptr);
-			}
+			m_ListBoxItemActivated = true;
+			UI()->SetActiveItem(nullptr);
 		}
 
 		Item.m_Rect.Draw(ColorRGBA(1.0f, 1.0f, 1.0f, ProcessInput ? 0.5f : 0.33f), IGraphics::CORNER_ALL, 5.0f);

--- a/src/game/client/ui_listbox.cpp
+++ b/src/game/client/ui_listbox.cpp
@@ -205,7 +205,7 @@ CListboxItem CListBox::DoNextItem(const void *pId, bool Selected, bool *pActive)
 	const bool ProcessInput = !pActive || *pActive;
 
 	// process input, regard selected index
-	if(m_ListBoxSelectedIndex == ThisItemIndex && ProcessInput)
+	if(Selected && ProcessInput)
 	{
 		if(UI()->ConsumeHotkey(CUI::HOTKEY_ENTER) || (ItemClicked && Input()->MouseDoubleClick()))
 		{

--- a/src/game/client/ui_listbox.h
+++ b/src/game/client/ui_listbox.h
@@ -24,7 +24,6 @@ private:
 	int m_ListBoxNewSelected;
 	int m_ListBoxNewSelOffset;
 	bool m_ListBoxUpdateScroll;
-	bool m_ListBoxDoneEvents;
 	int m_ListBoxNumItems;
 	int m_ListBoxItemsPerRow;
 	bool m_ListBoxItemSelected;

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -4983,11 +4983,11 @@ void CEditor::RenderFileDialog()
 	{
 		if(m_PreviewImageState == PREVIEWIMAGE_UNLOADED)
 		{
-			int FirstIndex = *m_SelectedFileIndices.begin();
-			if(str_endswith(m_vpFilteredFileList[FirstIndex]->m_aFilename, ".png"))
+			int Index = m_FileDialogLastSelectedIndex >= 0 ? m_FileDialogLastSelectedIndex : *m_SelectedFileIndices.begin();
+			if(str_endswith(m_vpFilteredFileList[Index]->m_aFilename, ".png"))
 			{
 				char aBuffer[IO_MAX_PATH_LENGTH];
-				str_format(aBuffer, sizeof(aBuffer), "%s/%s", m_pFileDialogPath, m_vpFilteredFileList[FirstIndex]->m_aFilename);
+				str_format(aBuffer, sizeof(aBuffer), "%s/%s", m_pFileDialogPath, m_vpFilteredFileList[Index]->m_aFilename);
 				if(Graphics()->LoadPNG(&m_FilePreviewImageInfo, aBuffer, IStorage::TYPE_ALL))
 				{
 					Graphics()->UnloadTexture(&m_FilePreviewImage);

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -808,11 +808,11 @@ public:
 		m_aFileDialogFileName[0] = '\0';
 		m_aFileDialogCurrentFolder[0] = '\0';
 		m_aFileDialogCurrentLink[0] = '\0';
-		m_aFilesSelectedName[0] = '\0';
 		m_aFileDialogFilterString[0] = '\0';
 		m_pFileDialogPath = m_aFileDialogCurrentFolder;
 		m_FileDialogOpening = false;
-		m_FilesSelectedIndex = -1;
+		m_FileDialogAllowMultipleSelection = false;
+		m_FileDialogLastSelectedIndex = -1;
 
 		m_FilePreviewImage.Invalidate();
 		m_PreviewImageState = PREVIEWIMAGE_UNLOADED;
@@ -899,7 +899,7 @@ public:
 	void RefreshFilteredFileList();
 	void FilelistPopulate(int StorageType, bool KeepSelection = false);
 	void InvokeFileDialog(int StorageType, int FileType, const char *pTitle, const char *pButtonText,
-		const char *pBasepath, const char *pDefaultName,
+		const char *pBasepath, const char *pDefaultName, bool AllowMultipleSelection,
 		bool (*pfnFunc)(const char *pFilename, int StorageType, void *pUser), void *pUser);
 	void ShowFileDialogError(const char *pFormat, ...)
 		GNUC_ATTRIBUTE((format(printf, 2, 3)));
@@ -984,16 +984,17 @@ public:
 	char m_aFileDialogFileName[IO_MAX_PATH_LENGTH];
 	char m_aFileDialogCurrentFolder[IO_MAX_PATH_LENGTH];
 	char m_aFileDialogCurrentLink[IO_MAX_PATH_LENGTH];
-	char m_aFilesSelectedName[IO_MAX_PATH_LENGTH];
 	char m_aFileDialogFilterString[IO_MAX_PATH_LENGTH];
 	char *m_pFileDialogPath;
 	int m_FileDialogFileType;
-	int m_FilesSelectedIndex;
+	std::set<int> m_SelectedFileIndices;
+	int m_FileDialogLastSelectedIndex;
 	char m_aFileDialogNewFolderName[IO_MAX_PATH_LENGTH];
 	IGraphics::CTextureHandle m_FilePreviewImage;
 	EPreviewImageState m_PreviewImageState;
 	CImageInfo m_FilePreviewImageInfo;
 	bool m_FileDialogOpening;
+	bool m_FileDialogAllowMultipleSelection;
 
 	struct CFilelistItem
 	{

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -1205,7 +1205,7 @@ int CEditor::PopupEvent(CEditor *pEditor, CUIRect View, void *pContext)
 		if(pEditor->m_PopupEventType == POPEVENT_EXIT)
 			g_Config.m_ClEditor = 0;
 		else if(pEditor->m_PopupEventType == POPEVENT_LOAD)
-			pEditor->InvokeFileDialog(IStorage::TYPE_ALL, FILETYPE_MAP, "Load map", "Load", "maps", "", CEditor::CallbackOpenMap, pEditor);
+			pEditor->InvokeFileDialog(IStorage::TYPE_ALL, FILETYPE_MAP, "Load map", "Load", "maps", "", false, CEditor::CallbackOpenMap, pEditor);
 		else if(pEditor->m_PopupEventType == POPEVENT_LOADCURRENT)
 			pEditor->LoadCurrentMap();
 		else if(pEditor->m_PopupEventType == POPEVENT_NEW)


### PR DESCRIPTION

![multiple_selection](https://user-images.githubusercontent.com/49279081/228326568-afb42706-8ce5-41d2-9ed1-7e86c473b5f1.gif)

When loading a lot of already loaded pictures all warnings are shown and you have to click them away one by one. This is definitely not ideal. One option to solve this would be to only show one warning. The other would be to show a list of warnings, but I'm not sure how hard that is to implement.

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
