### PR TITLE
Allow client to start without network, show network error popup

### DIFF
--- a/src/engine/client.h
+++ b/src/engine/client.h
@@ -246,6 +246,7 @@ public:
 	virtual const char *LatestVersion() const = 0;
 	virtual bool ConnectionProblems() const = 0;
 
+	virtual bool NetworkInitFailed() const = 0;
 	virtual bool SoundInitFailed() const = 0;
 
 	virtual IGraphics::CTextureHandle GetDebugFont() const = 0; // TODO: remove this function

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -3024,47 +3024,10 @@ void CClient::Run()
 	CVideo::Init();
 #endif
 
-#ifndef CONF_WEBASM
-	// open socket
-	{
-		NETADDR BindAddr;
-		if(g_Config.m_Bindaddr[0] == '\0')
-		{
-			mem_zero(&BindAddr, sizeof(BindAddr));
-		}
-		else if(net_host_lookup(g_Config.m_Bindaddr, &BindAddr, NETTYPE_ALL) != 0)
-		{
-			dbg_msg("client", "The configured bindaddr '%s' cannot be resolved", g_Config.m_Bindaddr);
-			return;
-		}
-		BindAddr.type = NETTYPE_ALL;
-		for(unsigned int i = 0; i < std::size(m_aNetClient); i++)
-		{
-			int &PortRef = i == CONN_MAIN ? g_Config.m_ClPort : i == CONN_DUMMY ? g_Config.m_ClDummyPort : g_Config.m_ClContactPort;
-			if(PortRef < 1024) // Reject users setting ports that we don't want to use
-			{
-				PortRef = 0;
-			}
-			BindAddr.port = PortRef;
-			unsigned RemainingAttempts = 25;
-			while(BindAddr.port == 0 || !m_aNetClient[i].Open(BindAddr))
-			{
-				if(BindAddr.port != 0)
-				{
-					--RemainingAttempts;
-					if(RemainingAttempts == 0)
-					{
-						if(g_Config.m_Bindaddr[0])
-							dbg_msg("client", "Could not open network client, try changing or unsetting the bindaddr '%s'", g_Config.m_Bindaddr);
-						else
-							dbg_msg("client", "Could not open network client");
-						return;
-					}
-				}
-				BindAddr.port = (secure_rand() % 64511) + 1024;
-			}
-		}
-	}
+#if defined(CONF_WEBASM)
+	m_NetworkInitFailed = false;
+#else
+	m_NetworkInitFailed = !InitNetworkClient();
 #endif
 
 	// init font rendering
@@ -3420,6 +3383,48 @@ void CClient::Run()
 		m_aNetClient[i].Close();
 
 	delete m_pEditor;
+}
+
+bool CClient::InitNetworkClient()
+{
+	NETADDR BindAddr;
+	if(g_Config.m_Bindaddr[0] == '\0')
+	{
+		mem_zero(&BindAddr, sizeof(BindAddr));
+	}
+	else if(net_host_lookup(g_Config.m_Bindaddr, &BindAddr, NETTYPE_ALL) != 0)
+	{
+		dbg_msg("client", "The configured bindaddr '%s' cannot be resolved", g_Config.m_Bindaddr);
+		return false;
+	}
+	BindAddr.type = NETTYPE_ALL;
+	for(unsigned int i = 0; i < std::size(m_aNetClient); i++)
+	{
+		int &PortRef = i == CONN_MAIN ? g_Config.m_ClPort : i == CONN_DUMMY ? g_Config.m_ClDummyPort : g_Config.m_ClContactPort;
+		if(PortRef < 1024) // Reject users setting ports that we don't want to use
+		{
+			PortRef = 0;
+		}
+		BindAddr.port = PortRef;
+		unsigned RemainingAttempts = 25;
+		while(BindAddr.port == 0 || !m_aNetClient[i].Open(BindAddr))
+		{
+			if(BindAddr.port != 0)
+			{
+				--RemainingAttempts;
+				if(RemainingAttempts == 0)
+				{
+					if(g_Config.m_Bindaddr[0])
+						dbg_msg("client", "Could not open network client, try changing or unsetting the bindaddr '%s'", g_Config.m_Bindaddr);
+					else
+						dbg_msg("client", "Could not open network client");
+					return false;
+				}
+			}
+			BindAddr.port = (secure_rand() % 64511) + 1024;
+		}
+	}
+	return true;
 }
 
 bool CClient::CtrlShiftKey(int Key, bool &Last)

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -158,6 +158,7 @@ class CClient : public IClient, public CDemoPlayer::IListener
 	bool m_AutoStatScreenshotRecycle;
 	bool m_AutoCSVRecycle;
 	bool m_EditorActive;
+	bool m_NetworkInitFailed;
 	bool m_SoundInitFailed;
 
 	int m_aAckGameTick[NUM_DUMMIES];
@@ -333,6 +334,7 @@ public:
 
 	bool ConnectionProblems() const override;
 
+	bool NetworkInitFailed() const override { return m_NetworkInitFailed; }
 	bool SoundInitFailed() const override { return m_SoundInitFailed; }
 
 	IGraphics::CTextureHandle GetDebugFont() const override { return m_DebugFont; }
@@ -425,6 +427,7 @@ public:
 
 	void Run();
 
+	bool InitNetworkClient();
 	bool CtrlShiftKey(int Key, bool &Last);
 
 	static void Con_Connect(IConsole::IResult *pResult, void *pUserData);

--- a/src/engine/shared/network.h
+++ b/src/engine/shared/network.h
@@ -508,7 +508,7 @@ public:
 	int ResetErrorString();
 
 	// error and state
-	int NetType() const { return net_socket_type(m_Socket); }
+	int NetType() const { return m_Socket ? net_socket_type(m_Socket) : 0; }
 	int State();
 	const NETADDR *ServerAddress() const { return m_Connection.PeerAddress(); }
 	void ConnectAddresses(const NETADDR **ppAddrs, int *pNumAddrs) const { m_Connection.ConnectAddresses(ppAddrs, pNumAddrs); }

--- a/src/engine/shared/network_conn.cpp
+++ b/src/engine/shared/network_conn.cpp
@@ -90,6 +90,9 @@ void CNetConnection::SignalResend()
 
 int CNetConnection::Flush()
 {
+	if(!m_Socket)
+		return 0;
+
 	int NumChunks = m_Construct.m_NumChunks;
 	if(!NumChunks && !m_Construct.m_Flags)
 		return 0;
@@ -166,6 +169,9 @@ int CNetConnection::QueueChunk(int Flags, int DataSize, const void *pData)
 
 void CNetConnection::SendConnect()
 {
+	if(!m_Socket)
+		return;
+
 	// send the connect message
 	m_LastSendTime = time_get();
 	for(int i = 0; i < m_NumConnectAddrs; i++)
@@ -176,6 +182,9 @@ void CNetConnection::SendConnect()
 
 void CNetConnection::SendControl(int ControlMsg, const void *pExtra, int ExtraSize)
 {
+	if(!m_Socket)
+		return;
+
 	// send the control message
 	m_LastSendTime = time_get();
 	CNetBase::SendControlMsg(m_Socket, &m_PeerAddr, m_Ack, ControlMsg, pExtra, ExtraSize, m_SecurityToken, m_Sixup);

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -1322,11 +1322,19 @@ int CMenus::Render()
 	// some margin around the screen
 	Screen.Margin(10.0f, &Screen);
 
+	static bool s_NetworkCheck = false;
+	if(!s_NetworkCheck && m_Popup == POPUP_NONE)
+	{
+		if(Client()->NetworkInitFailed())
+			PopupMessage(Localize("Network error"), Localize("The network couldn't be initialised. Check the local console for details."), Localize("Ok"));
+		s_NetworkCheck = true;
+	}
+
 	static bool s_SoundCheck = false;
 	if(!s_SoundCheck && m_Popup == POPUP_NONE)
 	{
 		if(Client()->SoundInitFailed())
-			PopupMessage(Localize("Sound error"), Localize("The audio device couldn't be initialised."), Localize("Ok"));
+			PopupMessage(Localize("Sound error"), Localize("The audio device couldn't be initialised. Check the local console for details."), Localize("Ok"));
 		s_SoundCheck = true;
 	}
 


### PR DESCRIPTION
When the network cannot be initialized show error popup when client launches instead of closing client.

Add necessary checks to prevent crashes with uninitialized network client.

Closes #6482.

![screenshot_2023-04-02_17-07-02](https://user-images.githubusercontent.com/23437060/229361599-2abe5b5e-dd2c-44f6-8999-b21cc9106207.png)

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
