### PR TITLE
Fix swapping with dragger beams and plasmas

### DIFF
--- a/src/game/server/entities/dragger_beam.cpp
+++ b/src/game/server/entities/dragger_beam.cpp
@@ -123,3 +123,8 @@ void CDraggerBeam::Snap(int SnappingClient)
 	GameServer()->SnapLaserObject(CSnapContext(SnappingClientVersion), GetID(),
 		m_Pos, TargetPos, StartTick, -1, LASERTYPE_DOOR);
 }
+
+void CDraggerBeam::SwapClients(int Client1, int Client2)
+{
+	m_ForClientID = m_ForClientID == Client1 ? Client2 : m_ForClientID == Client2 ? Client1 : m_ForClientID;
+}

--- a/src/game/server/entities/dragger_beam.h
+++ b/src/game/server/entities/dragger_beam.h
@@ -38,6 +38,7 @@ public:
 	void Reset() override;
 	void Tick() override;
 	void Snap(int SnappingClient) override;
+	void SwapClients(int Client1, int Client2) override;
 };
 
 #endif // GAME_SERVER_ENTITIES_DRAGGER_BEAM_H

--- a/src/game/server/entities/plasma.cpp
+++ b/src/game/server/entities/plasma.cpp
@@ -122,3 +122,8 @@ void CPlasma::Snap(int SnappingClient)
 	GameServer()->SnapLaserObject(CSnapContext(SnappingClientVersion), GetID(),
 		m_Pos, m_Pos, m_EvalTick, -1, m_Freeze ? LASERTYPE_FREEZE : LASERTYPE_RIFLE);
 }
+
+void CPlasma::SwapClients(int Client1, int Client2)
+{
+	m_ForClientID = m_ForClientID == Client1 ? Client2 : m_ForClientID == Client2 ? Client1 : m_ForClientID;
+}

--- a/src/game/server/entities/plasma.h
+++ b/src/game/server/entities/plasma.h
@@ -40,6 +40,7 @@ public:
 	void Reset() override;
 	void Tick() override;
 	void Snap(int SnappingClient) override;
+	void SwapClients(int Client1, int Client2) override;
 };
 
 #endif // GAME_SERVER_ENTITIES_PLASMA_H


### PR DESCRIPTION
The client ID referenced by dragger beams and plasmas must also be swapped when two clients are swapped, as those entities should refer to the same character entity as before the swap.

For dragger beams, swapping previously caused the active beams to switch target to another character.

For plasmas, swapping previously caused already shot plasmas to not have an effect on their original target character.

Closes #5865.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
