### PR TITLE
Fix image/sound readding broken by error messages

### DIFF
--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -1302,8 +1302,10 @@ public:
 	void DoQuad(CQuad *pQuad, int Index);
 	ColorRGBA GetButtonColor(const void *pID, int Checked);
 
-	static bool ReplaceImage(const char *pFilename, int StorageType, void *pUser);
-	static bool ReplaceSound(const char *pFileName, int StorageType, void *pUser);
+	bool ReplaceImage(const char *pFilename, int StorageType, bool CheckDuplicate);
+	static bool ReplaceImageCallback(const char *pFilename, int StorageType, void *pUser);
+	bool ReplaceSound(const char *pFileName, int StorageType, bool CheckDuplicate);
+	static bool ReplaceSoundCallback(const char *pFileName, int StorageType, void *pUser);
 	static bool AddImage(const char *pFilename, int StorageType, void *pUser);
 	static bool AddSound(const char *pFileName, int StorageType, void *pUser);
 

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -1283,17 +1283,17 @@ int CEditor::PopupImage(CEditor *pEditor, CUIRect View, void *pContext)
 	if(s_SelectionPopupContext.m_pSelection != nullptr)
 	{
 		const bool WasExternal = pImg->m_External;
-		ReplaceImage(s_SelectionPopupContext.m_pSelection->c_str(), IStorage::TYPE_ALL, pEditor);
+		const bool Result = pEditor->ReplaceImage(s_SelectionPopupContext.m_pSelection->c_str(), IStorage::TYPE_ALL, false);
 		pImg->m_External = WasExternal;
 		s_SelectionPopupContext.Reset();
-		return 1;
+		return Result ? 1 : 0;
 	}
 
 	View.HSplitTop(5.0f, nullptr, &View);
 	View.HSplitTop(12.0f, &Slot, &View);
 	if(pEditor->DoButton_MenuItem(&s_ReplaceButton, "Replace", 0, &Slot, 0, "Replaces the image with a new one"))
 	{
-		pEditor->InvokeFileDialog(IStorage::TYPE_ALL, FILETYPE_IMG, "Replace Image", "Replace", "mapres", "", ReplaceImage, pEditor);
+		pEditor->InvokeFileDialog(IStorage::TYPE_ALL, FILETYPE_IMG, "Replace Image", "Replace", "mapres", "", ReplaceImageCallback, pEditor);
 		return 1;
 	}
 
@@ -1344,16 +1344,16 @@ int CEditor::PopupSound(CEditor *pEditor, CUIRect View, void *pContext)
 	}
 	if(s_SelectionPopupContext.m_pSelection != nullptr)
 	{
-		ReplaceSound(s_SelectionPopupContext.m_pSelection->c_str(), IStorage::TYPE_ALL, pEditor);
+		const bool Result = pEditor->ReplaceSound(s_SelectionPopupContext.m_pSelection->c_str(), IStorage::TYPE_ALL, false);
 		s_SelectionPopupContext.Reset();
-		return 1;
+		return Result ? 1 : 0;
 	}
 
 	View.HSplitTop(5.0f, nullptr, &View);
 	View.HSplitTop(12.0f, &Slot, &View);
 	if(pEditor->DoButton_MenuItem(&s_ReplaceButton, "Replace", 0, &Slot, 0, "Replaces the sound with a new one"))
 	{
-		pEditor->InvokeFileDialog(IStorage::TYPE_ALL, FILETYPE_SOUND, "Replace sound", "Replace", "mapres", "", ReplaceSound, pEditor);
+		pEditor->InvokeFileDialog(IStorage::TYPE_ALL, FILETYPE_SOUND, "Replace sound", "Replace", "mapres", "", ReplaceSoundCallback, pEditor);
 		return 1;
 	}
 


### PR DESCRIPTION
When an image/sound is readded, this reuses the `ReplaceImage/Sound` callback functions. The added error handling to prevent duplicate images/sounds was causing this to not work, as the image/sound being readded was already present. The implementation is separated from the callback functions and an additional parameter is added to toggle the duplicate name check.

Previously this was hard to notice, as the error message popup was not shown due to the top-most popup being closed immediately. This will be fixed separately by a larger refactoring, so a popup can close itself immediately after opening another popup without closing the child popup instead.

Closes #6500.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
