### PR TITLE
Improve editor file browser button layout when screen width is low

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -2431,7 +2431,7 @@ void CMenus::OnRender()
 	ms_ColorTabbarHoverIngame = ColorRGBA(1, 1, 1, 0.75f);
 
 	// update the ui
-	CUIRect *pScreen = UI()->Screen();
+	const CUIRect *pScreen = UI()->Screen();
 	float mx = (m_MousePos.x / (float)Graphics()->WindowWidth()) * pScreen->w;
 	float my = (m_MousePos.y / (float)Graphics()->WindowHeight()) * pScreen->h;
 

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -2263,7 +2263,7 @@ ColorHSLA CMenus::RenderHSLColorPicker(const CUIRect *pRect, unsigned int *pColo
 				return HSLColor;
 		}
 
-		CUIRect *pScreen = UI()->Screen();
+		const CUIRect *pScreen = UI()->Screen();
 		ms_ColorPicker.m_X = minimum(UI()->MouseX(), pScreen->w - ms_ColorPicker.ms_Width);
 		ms_ColorPicker.m_Y = minimum(UI()->MouseY(), pScreen->h - ms_ColorPicker.ms_Height);
 		ms_ColorPicker.m_pColor = pColor;

--- a/src/game/client/components/tooltips.cpp
+++ b/src/game/client/components/tooltips.cpp
@@ -80,7 +80,7 @@ void CTooltips::OnRender()
 			Rect.w = TextRender()->TextWidth(14.0f, Tooltip.m_pText, -1, -1.0f) + 4.0f;
 		Rect.h = 30.0f;
 
-		CUIRect *pScreen = UI()->Screen();
+		const CUIRect *pScreen = UI()->Screen();
 
 		// Try the top side.
 		if(Tooltip.m_Rect.y - Rect.h - MARGIN > pScreen->y)

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -294,7 +294,7 @@ float CUI::ButtonColorMul(const void *pID)
 	return ButtonColorMulDefault();
 }
 
-CUIRect *CUI::Screen()
+const CUIRect *CUI::Screen()
 {
 	float Aspect = Graphics()->ScreenAspect();
 	float w, h;

--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -331,7 +331,7 @@ public:
 	float ButtonColorMulDefault() { return 1.0f; }
 	float ButtonColorMul(const void *pID);
 
-	CUIRect *Screen();
+	const CUIRect *Screen();
 	void MapScreen();
 	float PixelSize();
 

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -4958,7 +4958,6 @@ void CEditor::RenderFileDialog()
 	static int s_ShowDirectoryButton = 0;
 	static int s_DeleteButton = 0;
 	static int s_NewFolderButton = 0;
-	static int s_MapInfoButton = 0;
 
 	CUIRect Button;
 	ButtonBar.VSplitRight(50.0f, &ButtonBar, &Button);
@@ -5080,21 +5079,6 @@ void CEditor::RenderFileDialog()
 			constexpr float PopupWidth = 400.0f;
 			constexpr float PopupHeight = 110.0f;
 			UiInvokePopupMenu(&s_PopupNewFolderId, 0, Width / 2.0f - PopupWidth / 2.0f, Height / 2.0f - PopupHeight / 2.0f, PopupWidth, PopupHeight, PopupNewFolder);
-			UI()->SetActiveItem(nullptr);
-		}
-
-		ButtonBar.VSplitLeft(40.0f, nullptr, &ButtonBar);
-		ButtonBar.VSplitLeft(70.0f, &Button, &ButtonBar);
-		if(DoButton_Editor(&s_MapInfoButton, "Map details", 0, &Button, 0, nullptr))
-		{
-			str_copy(m_Map.m_MapInfo.m_aAuthorTmp, m_Map.m_MapInfo.m_aAuthor);
-			str_copy(m_Map.m_MapInfo.m_aVersionTmp, m_Map.m_MapInfo.m_aVersion);
-			str_copy(m_Map.m_MapInfo.m_aCreditsTmp, m_Map.m_MapInfo.m_aCredits);
-			str_copy(m_Map.m_MapInfo.m_aLicenseTmp, m_Map.m_MapInfo.m_aLicense);
-			static int s_PopupMapInfoId;
-			constexpr float PopupWidth = 400.0f;
-			constexpr float PopupHeight = 170.0f;
-			UiInvokePopupMenu(&s_PopupMapInfoId, 0, Width / 2.0f - PopupWidth / 2.0f, Height / 2.0f - PopupHeight / 2.0f, PopupWidth, PopupHeight, PopupMapInfo);
 			UI()->SetActiveItem(nullptr);
 		}
 	}
@@ -6031,7 +6015,7 @@ void CEditor::RenderMenubar(CUIRect MenuBar)
 	static int s_FileButton = 0;
 	MenuBar.VSplitLeft(60.0f, &FileButton, &MenuBar);
 	if(DoButton_Menu(&s_FileButton, "File", 0, &FileButton, 0, nullptr))
-		UiInvokePopupMenu(&s_FileButton, 1, FileButton.x, FileButton.y + FileButton.h - 1.0f, 120.0f, 152.0f, PopupMenuFile, this);
+		UiInvokePopupMenu(&s_FileButton, 1, FileButton.x, FileButton.y + FileButton.h - 1.0f, 120.0f, 174.0f, PopupMenuFile, this);
 
 	MenuBar.VSplitLeft(5.0f, nullptr, &MenuBar);
 

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -4951,6 +4951,8 @@ void CEditor::RenderFileDialog()
 		m_PreviewImageState = PREVIEWIMAGE_UNLOADED;
 	}
 
+	const float ButtonSpacing = ButtonBar.w > 600.0f ? 40.0f : 10.0f;
+
 	// the buttons
 	static int s_OkButton = 0;
 	static int s_CancelButton = 0;
@@ -5013,17 +5015,17 @@ void CEditor::RenderFileDialog()
 		}
 	}
 
-	ButtonBar.VSplitRight(40.0f, &ButtonBar, &Button);
+	ButtonBar.VSplitRight(ButtonSpacing, &ButtonBar, nullptr);
 	ButtonBar.VSplitRight(50.0f, &ButtonBar, &Button);
 	if(DoButton_Editor(&s_CancelButton, "Cancel", 0, &Button, 0, nullptr) || (s_ListBoxUsed && UI()->ConsumeHotkey(CUI::HOTKEY_ESCAPE)))
 		m_Dialog = DIALOG_NONE;
 
-	ButtonBar.VSplitRight(40.0f, &ButtonBar, &Button);
+	ButtonBar.VSplitRight(ButtonSpacing, &ButtonBar, nullptr);
 	ButtonBar.VSplitRight(50.0f, &ButtonBar, &Button);
 	if(DoButton_Editor(&s_RefreshButton, "Refresh", 0, &Button, 0, nullptr) || (s_ListBoxUsed && (Input()->KeyIsPressed(KEY_F5) || (Input()->ModifierIsPressed() && Input()->KeyIsPressed(KEY_R)))))
 		FilelistPopulate(m_FileDialogLastPopulatedStorageType, true);
 
-	ButtonBar.VSplitRight(40.0f, &ButtonBar, nullptr);
+	ButtonBar.VSplitRight(ButtonSpacing, &ButtonBar, nullptr);
 	ButtonBar.VSplitRight(90.0f, &ButtonBar, &Button);
 	if(DoButton_Editor(&s_ShowDirectoryButton, "Show directory", 0, &Button, 0, "Open the current directory in the file browser"))
 	{
@@ -5033,7 +5035,7 @@ void CEditor::RenderFileDialog()
 		}
 	}
 
-	ButtonBar.VSplitRight(40.0f, &ButtonBar, &Button);
+	ButtonBar.VSplitRight(ButtonSpacing, &ButtonBar, nullptr);
 	ButtonBar.VSplitRight(50.0f, &ButtonBar, &Button);
 	static SConfirmPopupContext s_ConfirmDeletePopupContext;
 	if(m_FilesSelectedIndex >= 0 && m_vpFilteredFileList[m_FilesSelectedIndex]->m_StorageType == IStorage::TYPE_SAVE && !m_vpFilteredFileList[m_FilesSelectedIndex]->m_IsLink && str_comp(m_vpFilteredFileList[m_FilesSelectedIndex]->m_aFilename, "..") != 0)

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -128,6 +128,7 @@ int CEditor::PopupMenuFile(CEditor *pEditor, CUIRect View, void *pContext)
 	static int s_OpenButton = 0;
 	static int s_OpenCurrentMapButton = 0;
 	static int s_AppendButton = 0;
+	static int s_MapInfoButton = 0;
 	static int s_ExitButton = 0;
 
 	CUIRect Slot;
@@ -214,6 +215,22 @@ int CEditor::PopupMenuFile(CEditor *pEditor, CUIRect View, void *pContext)
 	{
 		pEditor->InvokeFileDialog(IStorage::TYPE_SAVE, FILETYPE_MAP, "Save map", "Save", "maps", "", pEditor->CallbackSaveCopyMap, pEditor);
 		return 1;
+	}
+
+	View.HSplitTop(10.0f, nullptr, &View);
+	View.HSplitTop(12.0f, &Slot, &View);
+	if(pEditor->DoButton_MenuItem(&s_MapInfoButton, "Map details", 0, &Slot, 0, "Adjust the map details of the current map"))
+	{
+		const CUIRect *pScreen = pEditor->UI()->Screen();
+		str_copy(pEditor->m_Map.m_MapInfo.m_aAuthorTmp, pEditor->m_Map.m_MapInfo.m_aAuthor);
+		str_copy(pEditor->m_Map.m_MapInfo.m_aVersionTmp, pEditor->m_Map.m_MapInfo.m_aVersion);
+		str_copy(pEditor->m_Map.m_MapInfo.m_aCreditsTmp, pEditor->m_Map.m_MapInfo.m_aCredits);
+		str_copy(pEditor->m_Map.m_MapInfo.m_aLicenseTmp, pEditor->m_Map.m_MapInfo.m_aLicense);
+		static int s_PopupMapInfoId;
+		constexpr float PopupWidth = 400.0f;
+		constexpr float PopupHeight = 170.0f;
+		pEditor->UiInvokePopupMenu(&s_PopupMapInfoId, 0, pScreen->w / 2.0f - PopupWidth / 2.0f, pScreen->h / 2.0f - PopupHeight / 2.0f, PopupWidth, PopupHeight, PopupMapInfo);
+		pEditor->UI()->SetActiveItem(nullptr);
 	}
 
 	View.HSplitTop(10.0f, nullptr, &View);


### PR DESCRIPTION
Move "Map details" button from editor file browser to file menu.

Decrease button spacing in editor file browser when screen width is low (4:3 and 5:4 resolutions).

Screenshots:
- File menu:
   - Before: 
![file-menu old](https://user-images.githubusercontent.com/23437060/230586902-079a042d-0223-4a97-b228-ec8a4fae43d1.png)
   - After:
![file-menu new](https://user-images.githubusercontent.com/23437060/230589757-ef18d6d8-f8f0-4a2b-bc35-219349d6a7e7.png)
- File browser (800x600):
   - Before:
![save 800x600 old](https://user-images.githubusercontent.com/23437060/230591373-11b3e0c8-ce3f-4e8e-9fd1-297f8276de28.png)
   - After:
![save 800x600 new](https://user-images.githubusercontent.com/23437060/230591387-162de3fc-95e9-41ea-94a8-9b7b46ac97cb.png)
- File browser (1280x1024):
   - Before:
![save 1280x1024 old](https://user-images.githubusercontent.com/23437060/230591411-5dddd9de-4773-4dc9-a77b-61d5d4de4dc6.png)
   - After:
![save 1280x1024 new](https://user-images.githubusercontent.com/23437060/230591422-1ee8c941-9eb2-4e13-9268-de591b5b72f5.png)
- File browser (1920x1080):
   - Before:
![save 1920x1080 old](https://user-images.githubusercontent.com/23437060/230591437-146e961a-3e55-463f-988e-0d7eef92b439.png)
   - After:
![save 1920x1080 new](https://user-images.githubusercontent.com/23437060/230591445-931718f4-81fb-4c87-a018-f377a5c473df.png)

## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
