### PR TITLE
Improve performance of headless client

### DIFF
--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -1138,6 +1138,9 @@ void CChat::OnPrepareLines()
 
 void CChat::OnRender()
 {
+#if defined(CONF_HEADLESS_CLIENT)
+	return;
+#endif
 	// send pending chat messages
 	if(m_PendingChatCounter > 0 && m_LastChatSend + time_freq() < time())
 	{

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -1492,6 +1492,9 @@ void CHud::RenderLocalTime(float x)
 
 void CHud::OnRender()
 {
+#if defined(CONF_HEADLESS_CLIENT)
+	return;
+#endif
 	if(!m_pClient->m_Snap.m_pGameInfoObj)
 		return;
 

--- a/src/game/client/render_map.cpp
+++ b/src/game/client/render_map.cpp
@@ -255,6 +255,9 @@ void CRenderTools::RenderTileRectangle(int RectX, int RectY, int RectW, int Rect
 void CRenderTools::RenderTilemap(CTile *pTiles, int w, int h, float Scale, ColorRGBA Color, int RenderFlags,
 	ENVELOPE_EVAL pfnEval, void *pUser, int ColorEnv, int ColorEnvOffset)
 {
+#if defined(CONF_HEADLESS_CLIENT)
+	return;
+#endif
 	float ScreenX0, ScreenY0, ScreenX1, ScreenY1;
 	Graphics()->GetScreen(&ScreenX0, &ScreenY0, &ScreenX1, &ScreenY1);
 


### PR DESCRIPTION
When zooming out with headless client. This can easily cause 100% cpu usage on strong machines.
I am trying to track player movement with the headless client in a downstream project and would very much appreciate dropping it back to 40% cpu usage with this patch.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
