### PR TITLE
Fix incorrect chat background rect width calculation

### DIFF
--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -1021,11 +1021,11 @@ void CChat::OnPrepareLines()
 			}
 
 			CTextCursor AppendCursor = Cursor;
-
+			AppendCursor.m_LongestLineWidth = 0.0f;
 			if(!IsScoreBoardOpen && !g_Config.m_ClChatOld)
 			{
 				AppendCursor.m_StartX = Cursor.m_X;
-				AppendCursor.m_LineWidth -= (Cursor.m_LongestLineWidth - Cursor.m_StartX);
+				AppendCursor.m_LineWidth -= Cursor.m_LongestLineWidth;
 			}
 
 			TextRender()->TextEx(&AppendCursor, m_aLines[r].m_aText, -1);
@@ -1113,10 +1113,13 @@ void CChat::OnPrepareLines()
 		TextRender()->TextColor(Color);
 
 		CTextCursor AppendCursor = Cursor;
+		AppendCursor.m_LongestLineWidth = 0.0f;
+		float OriginalWidth = 0.0f;
 		if(!IsScoreBoardOpen && !g_Config.m_ClChatOld)
 		{
-			AppendCursor.m_LineWidth -= (Cursor.m_LongestLineWidth - Cursor.m_StartX);
 			AppendCursor.m_StartX = Cursor.m_X;
+			AppendCursor.m_LineWidth -= Cursor.m_LongestLineWidth;
+			OriginalWidth = Cursor.m_LongestLineWidth;
 		}
 
 		TextRender()->CreateOrAppendTextContainer(m_aLines[r].m_TextContainerIndex, &AppendCursor, m_aLines[r].m_aText);
@@ -1125,7 +1128,7 @@ void CChat::OnPrepareLines()
 		{
 			float Height = m_aLines[r].m_aYOffset[OffsetType];
 			Graphics()->SetColor(1, 1, 1, 1);
-			m_aLines[r].m_QuadContainerIndex = Graphics()->CreateRectQuadContainer(Begin, y, (AppendCursor.m_LongestLineWidth - TextBegin) + RealMsgPaddingX * 1.5f, Height, MESSAGE_ROUNDING, IGraphics::CORNER_ALL);
+			m_aLines[r].m_QuadContainerIndex = Graphics()->CreateRectQuadContainer(Begin, y, OriginalWidth + AppendCursor.m_LongestLineWidth + RealMsgPaddingX * 1.5f, Height, MESSAGE_ROUNDING, IGraphics::CORNER_ALL);
 		}
 
 		TextRender()->SetRenderFlags(CurRenderFlags);


### PR DESCRIPTION
The calculation of `m_LongestLineWidth` was adjusted in bf1e757581e7b37c7de493ae48b074ccb6a9eff5 so it's really the width of the line and not the X position of the end of the line. This caused the background rects of chat messages to be rendered incorrectly.

Screenshots:
- Normal
   - Before: ![screenshot_2023-04-15_11-56-38](https://user-images.githubusercontent.com/23437060/232208095-cc2ace57-244e-4345-b489-36a4bb70b6a7.png)
   - After: ![screenshot_2023-04-15_12-18-07](https://user-images.githubusercontent.com/23437060/232208119-cff59371-ef05-400f-9d32-8f9f335d05c4.png)
- With scoreboard open:
   - Before: ![screenshot_2023-04-15_11-56-41](https://user-images.githubusercontent.com/23437060/232208257-6bb54471-d746-43f1-a248-98576183ae64.png)
   - After: ![screenshot_2023-04-15_12-18-11](https://user-images.githubusercontent.com/23437060/232208229-b193f16f-5a60-44d8-817b-fffe806ff913.png)

## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
