### PR TITLE
Remove absolute includes from the rust bridge

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Check dilated images
       run: scripts/check_dilate.sh release data
     - name: Check absolute includes
-      run: "! grep --exclude-dir rust-bridge -rE '^#include \"(antibot|base|engine|game|steam|test)/' src/"
+      run: "! grep -rE '^#include \"(antibot|base|engine|game|steam|test)/' src/"
     - name: Check standard header includes
       run: scripts/check_standard_headers.sh
     # TODO: Enable on release branches

--- a/src/rust-bridge/cpp/console.cpp
+++ b/src/rust-bridge/cpp/console.cpp
@@ -1,6 +1,6 @@
-#include "base/rust.h"
-#include "engine/console.h"
-#include "engine/rust.h"
+#include <base/rust.h>
+#include <engine/console.h>
+#include <engine/rust.h>
 #include <cstddef>
 #include <cstdint>
 #include <memory>

--- a/src/rust-bridge/cpp/console.h
+++ b/src/rust-bridge/cpp/console.h
@@ -1,7 +1,7 @@
 #pragma once
-#include "base/rust.h"
-#include "engine/console.h"
-#include "engine/rust.h"
+#include <base/rust.h>
+#include <engine/console.h>
+#include <engine/rust.h>
 #include <cstdint>
 #include <memory>
 

--- a/src/rust-bridge/engine/shared/rust_version.cpp
+++ b/src/rust-bridge/engine/shared/rust_version.cpp
@@ -1,5 +1,5 @@
-#include "base/rust.h"
-#include "engine/console.h"
+#include <base/rust.h>
+#include <engine/console.h>
 
 extern "C" {
 void cxxbridge1$RustVersionPrint(const ::IConsole &console) noexcept;

--- a/src/rust-bridge/engine/shared/rust_version.h
+++ b/src/rust-bridge/engine/shared/rust_version.h
@@ -1,6 +1,6 @@
 #pragma once
-#include "base/rust.h"
-#include "engine/console.h"
+#include <base/rust.h>
+#include <engine/console.h>
 
 void RustVersionPrint(const ::IConsole &console) noexcept;
 


### PR DESCRIPTION
Any reason this was not done? @heinrich5991 