### PR TITLE
Adding one more msg ex exceeds `PACKER_BUFFER_SIZE`

### DIFF
--- a/src/engine/shared/protocol_ex_msgs.h
+++ b/src/engine/shared/protocol_ex_msgs.h
@@ -32,3 +32,5 @@ UUID(NETMSG_PONGEX, "pong@ddnet.tw")
 UUID(NETMSG_CHECKSUM_REQUEST, "checksum-request@ddnet.tw")
 UUID(NETMSG_CHECKSUM_RESPONSE, "checksum-response@ddnet.tw")
 UUID(NETMSG_CHECKSUM_ERROR, "checksum-error@ddnet.tw")
+
+UUID(NETMSG_OUT_OF_SPACE, "out-of-space@ddnet.tw")


### PR DESCRIPTION
This is not a pullrequest. I just wanted to show that the pipeline will fail if another msg is added.

I noticed this in downstream. After merging in voxels new kill msg. I added some [error codes](https://github.com/ddnet/ddnet/issues/6525) to the packer. And tracked it back to here

https://github.com/ddnet/ddnet/blob/15620354b99755c76ffe9880fb54a6c109a5751f/src/engine/shared/packer.cpp#L69-L73

Which I understand as it being bigger than `PACKER_BUFFER_SIZE (1024 * 2)`

So when the teehistorian test tries to pack them all it runs out of space.

https://github.com/ddnet/ddnet/blob/15620354b99755c76ffe9880fb54a6c109a5751f/src/test/teehistorian.cpp#L105-L117