### PR TITLE
Port line input and IME support from 0.7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -730,7 +730,7 @@ endif()
 
 if(TARGET_OS STREQUAL "windows")
   set(PLATFORM_CLIENT)
-  set(PLATFORM_CLIENT_LIBS opengl32 winmm)
+  set(PLATFORM_CLIENT_LIBS opengl32 winmm imm32)
   set(PLATFORM_LIBS)
   list(APPEND PLATFORM_LIBS shlwapi) # PathIsRelativeW
   list(APPEND PLATFORM_LIBS version ws2_32) # Windows sockets

--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -3750,7 +3750,7 @@ int str_utf8_check(const char *str)
 	return 1;
 }
 
-void str_utf8_stats(const char *str, int max_size, int max_count, int *size, int *count)
+void str_utf8_stats(const char *str, size_t max_size, size_t max_count, size_t *size, size_t *count)
 {
 	const char *cursor = str;
 	*size = 0;
@@ -3761,7 +3761,7 @@ void str_utf8_stats(const char *str, int max_size, int max_count, int *size, int
 		{
 			break;
 		}
-		if(cursor - str >= max_size)
+		if((size_t)(cursor - str) >= max_size)
 		{
 			break;
 		}

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -2386,7 +2386,7 @@ int str_utf8_check(const char *str);
 		- The string is treated as zero-terminated utf8 string.
 		- It's the user's responsibility to make sure the bounds are aligned.
 */
-void str_utf8_stats(const char *str, int max_size, int max_count, int *size, int *count);
+void str_utf8_stats(const char *str, size_t max_size, size_t max_count, size_t *size, size_t *count);
 
 /*
 	Function: str_next_token

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -3231,7 +3231,6 @@ void CClient::Run()
 				if(!m_EditorActive)
 				{
 					Input()->MouseModeRelative();
-					Input()->SetIMEState(true);
 					GameClient()->OnActivateEditor();
 					m_pEditor->ResetMentions();
 					m_EditorActive = true;
@@ -3239,7 +3238,6 @@ void CClient::Run()
 			}
 			else if(m_EditorActive)
 			{
-				Input()->SetIMEState(false);
 				m_EditorActive = false;
 			}
 

--- a/src/engine/client/input.h
+++ b/src/engine/client/input.h
@@ -9,6 +9,9 @@
 #include <engine/input.h>
 #include <engine/keys.h>
 
+#include <string>
+#include <vector>
+
 class IEngineGraphics;
 
 class CInput : public IEngineInput
@@ -75,6 +78,13 @@ private:
 	bool m_MouseFocus;
 	bool m_MouseDoubleClick;
 
+	// IME support
+	char m_aComposition[MAX_COMPOSITION_ARRAY_SIZE];
+	int m_CompositionCursor;
+	int m_CompositionLength;
+	std::vector<std::string> m_vCandidates;
+	int m_CandidateSelectedIndex;
+
 	void AddEvent(char *pText, int Key, int Flags);
 	void Clear() override;
 	bool IsEventValid(const CEvent &Event) const override { return Event.m_InputCount == m_InputCounter; }
@@ -94,18 +104,15 @@ private:
 
 	char m_aDropFile[IO_MAX_PATH_LENGTH];
 
-	// IME support
-	int m_NumTextInputInstances;
-	char m_aEditingText[INPUT_TEXT_SIZE];
-	int m_EditingTextLen;
-	int m_EditingCursor;
-
 	bool KeyState(int Key) const;
+
+	void ProcessSystemMessage(SDL_SysWMmsg *pMsg);
 
 public:
 	CInput();
 
 	void Init() override;
+	int Update() override;
 	void Shutdown() override;
 
 	bool ModifierIsPressed() const override { return KeyState(KEY_LCTRL) || KeyState(KEY_RCTRL) || KeyState(KEY_LGUI) || KeyState(KEY_RGUI); }
@@ -128,14 +135,16 @@ public:
 	const char *GetClipboardText() override;
 	void SetClipboardText(const char *pText) override;
 
-	int Update() override;
-
-	bool GetIMEState() override;
-	void SetIMEState(bool Activate) override;
-	int GetIMEEditingTextLength() const override { return m_EditingTextLen; }
-	const char *GetIMEEditingText() override;
-	int GetEditingCursor() override;
-	void SetEditingPosition(float X, float Y) override;
+	void StartTextInput() override;
+	void StopTextInput() override;
+	const char *GetComposition() const override { return m_aComposition; }
+	bool HasComposition() const override { return m_CompositionLength != COMP_LENGTH_INACTIVE; }
+	int GetCompositionCursor() const override { return m_CompositionCursor; }
+	int GetCompositionLength() const override { return m_CompositionLength; }
+	const char *GetCandidate(int Index) const override { return m_vCandidates[Index].c_str(); }
+	int GetCandidateCount() const override { return m_vCandidates.size(); }
+	int GetCandidateSelectedIndex() const override { return m_CandidateSelectedIndex; }
+	void SetCompositionWindowPosition(float X, float Y, float H) override;
 
 	bool GetDropFile(char *aBuf, int Len) override;
 };

--- a/src/engine/client/text.cpp
+++ b/src/engine/client/text.cpp
@@ -167,6 +167,7 @@ struct STextContainer
 	unsigned m_RenderFlags;
 
 	bool m_HasCursor;
+	bool m_ForceCursorRendering;
 	bool m_HasSelection;
 
 	bool m_SingleTimeUse;
@@ -193,6 +194,7 @@ struct STextContainer
 
 		m_HasCursor = false;
 		m_HasSelection = false;
+		m_ForceCursorRendering = false;
 
 		m_SingleTimeUse = false;
 
@@ -809,6 +811,7 @@ public:
 		pCursor->m_SelectionEnd = 0;
 
 		pCursor->m_CursorMode = TEXT_CURSOR_CURSOR_MODE_NONE;
+		pCursor->m_ForceCursorRendering = false;
 		pCursor->m_CursorCharacter = -1;
 	}
 
@@ -1505,6 +1508,7 @@ public:
 
 			TextContainer.m_HasCursor = HasCursor;
 			TextContainer.m_HasSelection = HasSelection;
+			TextContainer.m_ForceCursorRendering = pCursor->m_ForceCursorRendering;
 
 			if(HasSelection)
 			{
@@ -1660,14 +1664,16 @@ public:
 				const auto CurTime = time_get_nanoseconds();
 
 				Graphics()->TextureClear();
-				if((CurTime - m_CursorRenderTime) > 500ms)
+				if(TextContainer.m_ForceCursorRendering || (CurTime - m_CursorRenderTime) > 500ms)
 				{
 					Graphics()->SetColor(TextOutlineColor);
 					Graphics()->RenderQuadContainerEx(TextContainer.m_StringInfo.m_SelectionQuadContainerIndex, 0, 1, 0, 0);
 					Graphics()->SetColor(TextColor);
 					Graphics()->RenderQuadContainerEx(TextContainer.m_StringInfo.m_SelectionQuadContainerIndex, 1, 1, 0, 0);
 				}
-				if((CurTime - m_CursorRenderTime) > 1s)
+				if(TextContainer.m_ForceCursorRendering)
+					m_CursorRenderTime = CurTime - 501ms;
+				else if((CurTime - m_CursorRenderTime) > 1s)
 					m_CursorRenderTime = time_get_nanoseconds();
 				Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
 			}

--- a/src/engine/client/text.cpp
+++ b/src/engine/client/text.cpp
@@ -800,6 +800,7 @@ public:
 		pCursor->m_LongestLineWidth = 0;
 
 		pCursor->m_CalculateSelectionMode = TEXT_CURSOR_SELECTION_MODE_NONE;
+		pCursor->m_SelectionHeightFactor = 1.0f;
 		pCursor->m_PressMouseX = 0;
 		pCursor->m_PressMouseY = 0;
 		pCursor->m_ReleaseMouseX = 0;
@@ -1409,7 +1410,7 @@ public:
 
 					if(SelectionStarted && IsRendered)
 					{
-						vSelectionQuads.emplace_back(SelX, DrawY, SelWidth, Size);
+						vSelectionQuads.emplace_back(SelX, DrawY + (1.0f - pCursor->m_SelectionHeightFactor) * Size, SelWidth, pCursor->m_SelectionHeightFactor * Size);
 					}
 
 					LastSelX = SelX;

--- a/src/engine/client/text.cpp
+++ b/src/engine/client/text.cpp
@@ -1590,14 +1590,6 @@ public:
 		const STextContainer &TextContainer = GetTextContainer(TextContainerIndex);
 		const CFont *pFont = TextContainer.m_pFont;
 
-		if(TextContainer.m_StringInfo.m_SelectionQuadContainerIndex != -1 && TextContainer.m_HasSelection)
-		{
-			Graphics()->TextureClear();
-			Graphics()->SetColor(m_SelectionColor);
-			Graphics()->RenderQuadContainerEx(TextContainer.m_StringInfo.m_SelectionQuadContainerIndex, TextContainer.m_HasCursor ? 2 : 0, -1, 0, 0);
-			Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
-		}
-
 		if(TextContainer.m_StringInfo.m_QuadNum > 0)
 		{
 			if(Graphics()->IsTextBufferingEnabled())
@@ -1653,21 +1645,32 @@ public:
 			}
 		}
 
-		if(TextContainer.m_StringInfo.m_SelectionQuadContainerIndex != -1 && TextContainer.m_HasCursor)
+		if(TextContainer.m_StringInfo.m_SelectionQuadContainerIndex != -1)
 		{
-			const auto CurTime = time_get_nanoseconds();
-
-			Graphics()->TextureClear();
-			if((CurTime - m_CursorRenderTime) > 500ms)
+			if(TextContainer.m_HasSelection)
 			{
-				Graphics()->SetColor(TextOutlineColor);
-				Graphics()->RenderQuadContainerEx(TextContainer.m_StringInfo.m_SelectionQuadContainerIndex, 0, 1, 0, 0);
-				Graphics()->SetColor(TextColor);
-				Graphics()->RenderQuadContainerEx(TextContainer.m_StringInfo.m_SelectionQuadContainerIndex, 1, 1, 0, 0);
+				Graphics()->TextureClear();
+				Graphics()->SetColor(m_SelectionColor);
+				Graphics()->RenderQuadContainerEx(TextContainer.m_StringInfo.m_SelectionQuadContainerIndex, TextContainer.m_HasCursor ? 2 : 0, -1, 0, 0);
+				Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
 			}
-			if((CurTime - m_CursorRenderTime) > 1s)
-				m_CursorRenderTime = time_get_nanoseconds();
-			Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
+
+			if(TextContainer.m_HasCursor)
+			{
+				const auto CurTime = time_get_nanoseconds();
+
+				Graphics()->TextureClear();
+				if((CurTime - m_CursorRenderTime) > 500ms)
+				{
+					Graphics()->SetColor(TextOutlineColor);
+					Graphics()->RenderQuadContainerEx(TextContainer.m_StringInfo.m_SelectionQuadContainerIndex, 0, 1, 0, 0);
+					Graphics()->SetColor(TextColor);
+					Graphics()->RenderQuadContainerEx(TextContainer.m_StringInfo.m_SelectionQuadContainerIndex, 1, 1, 0, 0);
+				}
+				if((CurTime - m_CursorRenderTime) > 1s)
+					m_CursorRenderTime = time_get_nanoseconds();
+				Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
+			}
 		}
 	}
 

--- a/src/engine/input.h
+++ b/src/engine/input.h
@@ -14,7 +14,7 @@ class IInput : public IInterface
 public:
 	enum
 	{
-		INPUT_TEXT_SIZE = 128
+		INPUT_TEXT_SIZE = 32 * UTF8_BYTE_LENGTH + 1,
 	};
 
 	class CEvent
@@ -34,7 +34,7 @@ protected:
 
 	// quick access to events
 	size_t m_NumEvents;
-	IInput::CEvent m_aInputEvents[INPUT_BUFFER_SIZE];
+	CEvent m_aInputEvents[INPUT_BUFFER_SIZE];
 	int64_t m_LastUpdate;
 	float m_UpdateTime;
 
@@ -51,6 +51,12 @@ public:
 		CURSOR_MOUSE,
 		CURSOR_JOYSTICK,
 	};
+	enum
+	{
+		MAX_COMPOSITION_ARRAY_SIZE = 32, // SDL2 limitation
+
+		COMP_LENGTH_INACTIVE = -1,
+	};
 
 	// events
 	size_t NumEvents() const { return m_NumEvents; }
@@ -60,8 +66,6 @@ public:
 		dbg_assert(Index < m_NumEvents, "Index invalid");
 		return m_aInputEvents[Index];
 	}
-	CEvent *GetEventsRaw() { return m_aInputEvents; }
-	size_t *GetEventCountRaw() { return &m_NumEvents; }
 
 	/**
 	 * @return Rolling average of the time in seconds between
@@ -110,12 +114,16 @@ public:
 	virtual void SetClipboardText(const char *pText) = 0;
 
 	// text editing
-	virtual bool GetIMEState() = 0;
-	virtual void SetIMEState(bool Activate) = 0;
-	virtual int GetIMEEditingTextLength() const = 0;
-	virtual const char *GetIMEEditingText() = 0;
-	virtual int GetEditingCursor() = 0;
-	virtual void SetEditingPosition(float X, float Y) = 0;
+	virtual void StartTextInput() = 0;
+	virtual void StopTextInput() = 0;
+	virtual const char *GetComposition() const = 0;
+	virtual bool HasComposition() const = 0;
+	virtual int GetCompositionCursor() const = 0;
+	virtual int GetCompositionLength() const = 0;
+	virtual const char *GetCandidate(int Index) const = 0;
+	virtual int GetCandidateCount() const = 0;
+	virtual int GetCandidateSelectedIndex() const = 0;
+	virtual void SetCompositionWindowPosition(float X, float Y, float H) = 0;
 
 	virtual bool GetDropFile(char *aBuf, int Len) = 0;
 

--- a/src/engine/textrender.h
+++ b/src/engine/textrender.h
@@ -198,6 +198,7 @@ public:
 	int m_SelectionEnd;
 
 	ETextCursorCursorMode m_CursorMode;
+	bool m_ForceCursorRendering;
 	// note this is the decoded character offset
 	int m_CursorCharacter;
 

--- a/src/engine/textrender.h
+++ b/src/engine/textrender.h
@@ -183,6 +183,7 @@ public:
 	float m_AlignedFontSize;
 
 	ETextCursorSelectionMode m_CalculateSelectionMode;
+	float m_SelectionHeightFactor;
 
 	// these coordinates are repsected if selection mode is set to calculate @see ETextCursorSelectionMode
 	int m_PressMouseX;

--- a/src/engine/textrender.h
+++ b/src/engine/textrender.h
@@ -233,7 +233,7 @@ public:
 
 	ColorRGBA DefaultTextColor() const { return ColorRGBA(1, 1, 1, 1); }
 	ColorRGBA DefaultTextOutlineColor() const { return ColorRGBA(0, 0, 0, 0.3f); }
-	ColorRGBA DefaultTextSelectionColor() const { return ColorRGBA(0, 0, 1.0f, 1.0f); }
+	ColorRGBA DefaultTextSelectionColor() const { return ColorRGBA(1.0f, 1.0f, 1.0f, 0.5f); }
 
 	//
 	virtual void TextEx(CTextCursor *pCursor, const char *pText, int Length = -1) = 0;

--- a/src/engine/textrender.h
+++ b/src/engine/textrender.h
@@ -185,12 +185,10 @@ public:
 	ETextCursorSelectionMode m_CalculateSelectionMode;
 	float m_SelectionHeightFactor;
 
-	// these coordinates are repsected if selection mode is set to calculate @see ETextCursorSelectionMode
-	int m_PressMouseX;
-	int m_PressMouseY;
-	// these coordinates are repsected if selection/cursor mode is set to calculate @see ETextCursorSelectionMode / @see ETextCursorCursorMode
-	int m_ReleaseMouseX;
-	int m_ReleaseMouseY;
+	// these coordinates are respected if selection mode is set to calculate @see ETextCursorSelectionMode
+	vec2 m_PressMouse;
+	// these coordinates are respected if selection/cursor mode is set to calculate @see ETextCursorSelectionMode / @see ETextCursorCursorMode
+	vec2 m_ReleaseMouse;
 
 	// note m_SelectionStart can be bigger than m_SelectionEnd, depending on how the mouse cursor was dragged
 	// also note, that these are the character offsets decoded
@@ -201,6 +199,7 @@ public:
 	bool m_ForceCursorRendering;
 	// note this is the decoded character offset
 	int m_CursorCharacter;
+	vec2 m_CursorRenderedPosition;
 
 	float Height() const
 	{
@@ -273,7 +272,6 @@ public:
 	virtual void Text(float x, float y, float Size, const char *pText, float LineWidth = -1.0f) = 0;
 	virtual float TextWidth(float Size, const char *pText, int StrLength = -1, float LineWidth = -1.0f, int Flags = 0, float *pHeight = nullptr, float *pAlignedFontSize = nullptr, float *pMaxCharacterHeightInLine = nullptr) = 0;
 	virtual STextBoundingBox TextBoundingBox(float Size, const char *pText, int StrLength = -1, float LineWidth = -1.0f, int Flags = 0) = 0;
-	virtual vec2 CaretPosition(float Size, const char *pText, int StrLength = -1, float LineWidth = -1.0f, int Flags = 0) = 0;
 
 	virtual ColorRGBA GetTextColor() const = 0;
 	virtual ColorRGBA GetTextOutlineColor() const = 0;

--- a/src/game/client/components/chat.h
+++ b/src/game/client/components/chat.h
@@ -15,7 +15,7 @@
 
 class CChat : public CComponent
 {
-	CLineInput m_Input;
+	CLineInputBuffered<512> m_Input;
 
 	static constexpr float CHAT_WIDTH = 200.0f;
 	static constexpr float CHAT_HEIGHT_FULL = 200.0f;
@@ -80,9 +80,6 @@ class CChat : public CComponent
 
 	int m_Mode;
 	bool m_Show;
-	bool m_InputUpdate;
-	int m_ChatStringOffset;
-	int m_OldChatStringLength;
 	bool m_CompletionUsed;
 	int m_CompletionChosen;
 	char m_aCompletionBuffer[256];

--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -2,14 +2,10 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 
 #include <base/logger.h>
-
-#include <climits>
-#include <cmath>
-#include <limits>
+#include <base/math.h>
+#include <base/system.h>
 
 #include <game/generated/client_data.h>
-
-#include <base/system.h>
 
 #include <engine/console.h>
 #include <engine/graphics.h>
@@ -19,17 +15,12 @@
 #include <engine/storage.h>
 #include <engine/textrender.h>
 
-#include <game/client/ui.h>
-
 #include <game/localization.h>
 #include <game/version.h>
 
-#include <game/client/lineinput.h>
-#include <game/client/render.h>
-
 #include <game/client/gameclient.h>
-
-#include <base/math.h>
+#include <game/client/render.h>
+#include <game/client/ui.h>
 
 #include "console.h"
 
@@ -111,6 +102,8 @@ CGameConsole::CInstance::CInstance(int Type)
 	m_UsernameReq = false;
 
 	m_IsCommand = false;
+
+	m_Input.SetClipboardLineCallback([this](const char *pStr) { ExecuteLine(pStr); });
 }
 
 void CGameConsole::CInstance::Init(CGameConsole *pGameConsole)
@@ -203,124 +196,15 @@ void CGameConsole::CInstance::PossibleArgumentsCompleteCallback(int Index, const
 	}
 }
 
-void CGameConsole::CInstance::OnInput(const IInput::CEvent &Event)
+bool CGameConsole::CInstance::OnInput(const IInput::CEvent &Event)
 {
 	bool Handled = false;
-
-	if(m_pGameConsole->Input()->ModifierIsPressed()) // jump to spaces and special ASCII characters
-	{
-		int SearchDirection = 0;
-		if(m_pGameConsole->Input()->KeyPress(KEY_LEFT) || m_pGameConsole->Input()->KeyPress(KEY_BACKSPACE))
-			SearchDirection = -1;
-		else if(m_pGameConsole->Input()->KeyPress(KEY_RIGHT) || m_pGameConsole->Input()->KeyPress(KEY_DELETE))
-			SearchDirection = 1;
-
-		if(SearchDirection != 0)
-		{
-			int OldOffset = m_Input.GetCursorOffset();
-
-			int FoundAt = SearchDirection > 0 ? m_Input.GetLength() - 1 : 0;
-			for(int i = m_Input.GetCursorOffset() + SearchDirection; SearchDirection > 0 ? i < m_Input.GetLength() - 1 : i > 0; i += SearchDirection)
-			{
-				int Next = i + SearchDirection;
-				if((m_Input.GetString()[Next] == ' ') ||
-					(m_Input.GetString()[Next] >= 32 && m_Input.GetString()[Next] <= 47) ||
-					(m_Input.GetString()[Next] >= 58 && m_Input.GetString()[Next] <= 64) ||
-					(m_Input.GetString()[Next] >= 91 && m_Input.GetString()[Next] <= 96))
-				{
-					FoundAt = i;
-					if(SearchDirection < 0)
-						FoundAt++;
-					break;
-				}
-			}
-
-			if(m_pGameConsole->Input()->KeyPress(KEY_BACKSPACE))
-			{
-				if(m_Input.GetCursorOffset() != 0)
-				{
-					char aText[512];
-					str_copy(aText, m_Input.GetString(), FoundAt + 1);
-
-					if(m_Input.GetCursorOffset() != str_length(m_Input.GetString()))
-						str_append(aText, m_Input.GetString() + m_Input.GetCursorOffset(), str_length(m_Input.GetString()));
-
-					m_Input.Set(aText);
-				}
-			}
-
-			if(m_pGameConsole->Input()->KeyPress(KEY_DELETE))
-			{
-				if(m_Input.GetCursorOffset() != m_Input.GetLength())
-				{
-					char aText[512];
-					aText[0] = '\0';
-
-					str_copy(aText, m_Input.GetString(), m_Input.GetCursorOffset() + 1);
-
-					if(FoundAt != m_Input.GetLength())
-						str_append(aText, m_Input.GetString() + FoundAt, sizeof(aText));
-
-					m_Input.Set(aText);
-					FoundAt = OldOffset;
-				}
-			}
-			m_Input.SetCursorOffset(FoundAt);
-		}
-	}
-	if(m_pGameConsole->Input()->ModifierIsPressed() && m_pGameConsole->Input()->KeyPress(KEY_V))
-	{
-		const char *pText = m_pGameConsole->Input()->GetClipboardText();
-		if(pText)
-		{
-			char aLine[256];
-			int i, Begin = 0;
-			for(i = 0; i < str_length(pText); i++)
-			{
-				if(pText[i] == '\n')
-				{
-					if(i == Begin)
-					{
-						Begin++;
-						continue;
-					}
-					int max = minimum(i - Begin + 1, (int)sizeof(aLine));
-					str_copy(aLine, pText + Begin, max);
-					Begin = i + 1;
-					ExecuteLine(aLine);
-				}
-			}
-			int max = minimum(i - Begin + 1, (int)sizeof(aLine));
-			str_copy(aLine, pText + Begin, max);
-			m_Input.Append(aLine);
-		}
-	}
-	else if(m_pGameConsole->Input()->ModifierIsPressed() && m_pGameConsole->Input()->KeyPress(KEY_C))
-	{
-		m_pGameConsole->Input()->SetClipboardText(m_Input.GetString());
-	}
-	else if(m_pGameConsole->Input()->ModifierIsPressed() && m_pGameConsole->Input()->KeyPress(KEY_A))
-	{
-		m_Input.SetCursorOffset(0);
-	}
-	else if(m_pGameConsole->Input()->ModifierIsPressed() && m_pGameConsole->Input()->KeyPress(KEY_E))
-	{
-		m_Input.SetCursorOffset(m_Input.GetLength());
-	}
-	else if(m_pGameConsole->Input()->ModifierIsPressed() && m_pGameConsole->Input()->KeyPress(KEY_U))
-	{
-		m_Input.SetRange("", 0, m_Input.GetCursorOffset());
-	}
-	else if(m_pGameConsole->Input()->ModifierIsPressed() && m_pGameConsole->Input()->KeyPress(KEY_K))
-	{
-		m_Input.SetRange("", m_Input.GetCursorOffset(), m_Input.GetLength());
-	}
 
 	if(Event.m_Flags & IInput::FLAG_PRESS)
 	{
 		if(Event.m_Key == KEY_RETURN || Event.m_Key == KEY_KP_ENTER)
 		{
-			if(m_Input.GetString()[0] || (m_UsernameReq && !m_pGameConsole->Client()->RconAuthed() && !m_UserGot))
+			if(!m_Input.IsEmpty() || (m_UsernameReq && !m_pGameConsole->Client()->RconAuthed() && !m_UserGot))
 			{
 				if(m_Type == CONSOLETYPE_LOCAL || m_pGameConsole->Client()->RconAuthed())
 				{
@@ -424,12 +308,12 @@ void CGameConsole::CInstance::OnInput(const IInput::CEvent &Event)
 		}
 		// in order not to conflict with CLineInput's handling of Home/End only
 		// react to it when the input is empty
-		else if(Event.m_Key == KEY_HOME && m_Input.GetString()[0] == '\0')
+		else if(Event.m_Key == KEY_HOME && m_Input.IsEmpty())
 		{
 			m_BacklogCurPage = INT_MAX;
 			m_pGameConsole->m_HasSelection = false;
 		}
-		else if(Event.m_Key == KEY_END && m_Input.GetString()[0] == '\0')
+		else if(Event.m_Key == KEY_END && m_Input.IsEmpty())
 		{
 			m_BacklogCurPage = 0;
 			m_pGameConsole->m_HasSelection = false;
@@ -437,7 +321,7 @@ void CGameConsole::CInstance::OnInput(const IInput::CEvent &Event)
 	}
 
 	if(!Handled)
-		m_Input.ProcessInput(Event);
+		Handled = m_Input.ProcessInput(Event);
 
 	if(Event.m_Flags & (IInput::FLAG_PRESS | IInput::FLAG_TEXT))
 	{
@@ -475,6 +359,8 @@ void CGameConsole::CInstance::OnInput(const IInput::CEvent &Event)
 				m_IsCommand = false;
 		}
 	}
+
+	return Handled;
 }
 
 void CGameConsole::CInstance::PrintLine(const char *pLine, int Len, ColorRGBA PrintColor)
@@ -591,6 +477,8 @@ void CGameConsole::PossibleCommandsRenderCallback(int Index, const char *pStr, v
 void CGameConsole::OnRender()
 {
 	CUIRect Screen = *UI()->Screen();
+	CInstance *pConsole = CurrentConsole();
+
 	float ConsoleMaxHeight = Screen.h * 3 / 5.0f;
 	float ConsoleHeight;
 
@@ -599,9 +487,15 @@ void CGameConsole::OnRender()
 	if(Progress >= 1.0f)
 	{
 		if(m_ConsoleState == CONSOLE_CLOSING)
+		{
 			m_ConsoleState = CONSOLE_CLOSED;
+			pConsole->m_Input.Deactivate();
+		}
 		else if(m_ConsoleState == CONSOLE_OPENING)
+		{
 			m_ConsoleState = CONSOLE_OPEN;
+			pConsole->m_Input.Activate(EInputPriority::CONSOLE);
+		}
 
 		Progress = 1.0f;
 	}
@@ -675,8 +569,6 @@ void CGameConsole::OnRender()
 
 	ConsoleHeight -= 22.0f;
 
-	CInstance *pConsole = CurrentConsole();
-
 	{
 		float FontSize = 10.0f;
 		float RowHeight = FontSize * 1.25f;
@@ -714,57 +606,67 @@ void CGameConsole::OnRender()
 		}
 		TextRender()->TextEx(&Cursor, pPrompt, -1);
 
+		// check if mouse is pressed
+		if(!m_MouseIsPress && Input()->NativeMousePressed(1))
+		{
+			m_MouseIsPress = true;
+			ivec2 MousePress;
+			Input()->NativeMousePos(&MousePress.x, &MousePress.y);
+			m_MousePress.x = (MousePress.x / (float)Graphics()->WindowWidth()) * Screen.w;
+			m_MousePress.y = (MousePress.y / (float)Graphics()->WindowHeight()) * Screen.h;
+		}
+		if(m_MouseIsPress)
+		{
+			ivec2 MouseRelease;
+			Input()->NativeMousePos(&MouseRelease.x, &MouseRelease.y);
+			m_MouseRelease.x = (MouseRelease.x / (float)Graphics()->WindowWidth()) * Screen.w;
+			m_MouseRelease.y = (MouseRelease.y / (float)Graphics()->WindowHeight()) * Screen.h;
+		}
+		if(m_MouseIsPress && !Input()->NativeMousePressed(1))
+		{
+			m_MouseIsPress = false;
+		}
+
 		x = Cursor.m_X;
 
-		//console text editing
-		bool Editing = false;
-		int EditingCursor = Input()->GetEditingCursor();
-		if(Input()->GetIMEState())
+		static STextBoundingBox s_BoundingBox = {0.0f, 0.0f, 0.0f, 0.0f};
+
+		if(m_ConsoleState == CONSOLE_OPEN)
 		{
-			if(str_length(Input()->GetIMEEditingText()))
+			if(m_MousePress.y >= s_BoundingBox.m_Y && m_MousePress.y < s_BoundingBox.m_Y + s_BoundingBox.m_H)
 			{
-				pConsole->m_Input.Editing(Input()->GetIMEEditingText(), EditingCursor);
-				Editing = true;
+				CLineInput::SMouseSelection *pMouseSelection = pConsole->m_Input.GetMouseSelection();
+				pMouseSelection->m_Selecting = m_MouseIsPress;
+				pMouseSelection->m_PressMouse = m_MousePress;
+				pMouseSelection->m_ReleaseMouse = m_MouseRelease;
+			}
+			else if(m_MouseIsPress)
+			{
+				pConsole->m_Input.SelectNothing();
 			}
 		}
 
-		//hide rcon password
-		char aInputString[512];
-		str_copy(aInputString, pConsole->m_Input.GetString(Editing));
-		if(m_ConsoleType == CONSOLETYPE_REMOTE && Client()->State() == IClient::STATE_ONLINE && !Client()->RconAuthed() && (pConsole->m_UserGot || !pConsole->m_UsernameReq))
-		{
-			for(int i = 0; i < pConsole->m_Input.GetLength(Editing); ++i)
-				aInputString[i] = '*';
-		}
-
 		// render console input (wrap line)
-		TextRender()->SetCursor(&Cursor, x, y, FontSize, 0);
-		Cursor.m_LineWidth = Screen.w - 10.0f - x;
-		TextRender()->TextEx(&Cursor, aInputString, pConsole->m_Input.GetCursorOffset(Editing));
-		TextRender()->TextEx(&Cursor, aInputString + pConsole->m_Input.GetCursorOffset(Editing), -1);
-		int Lines = Cursor.m_LineCount;
+		pConsole->m_Input.SetHidden(m_ConsoleType == CONSOLETYPE_REMOTE && Client()->State() == IClient::STATE_ONLINE && !Client()->RconAuthed() && (pConsole->m_UserGot || !pConsole->m_UsernameReq));
+		pConsole->m_Input.Activate(EInputPriority::CONSOLE); // Ensure that the input is active
+		const CUIRect InputCursorRect = {x, y + FontSize, 0.0f, 0.0f};
+		s_BoundingBox = pConsole->m_Input.Render(&InputCursorRect, FontSize, TEXTALIGN_BL, pConsole->m_Input.WasChanged(), Screen.w - 10.0f - x);
+		if(pConsole->m_Input.HasSelection())
+			m_HasSelection = false; // Clear console selection if we have a line input selection
 
-		int InputExtraLineCount = Lines - 1;
-		y -= InputExtraLineCount * FontSize;
+		y -= s_BoundingBox.m_H - FontSize;
 		TextRender()->SetCursor(&Cursor, x, y, FontSize, TEXTFLAG_RENDER);
 		Cursor.m_LineWidth = Screen.w - 10.0f - x;
 
-		if(m_LastInputLineCount != InputExtraLineCount)
+		if(m_LastInputHeight != s_BoundingBox.m_H)
 		{
 			m_HasSelection = false;
 			m_MouseIsPress = false;
-			m_LastInputLineCount = InputExtraLineCount;
+			m_LastInputHeight = s_BoundingBox.m_H;
 		}
 
-		TextRender()->TextEx(&Cursor, aInputString, pConsole->m_Input.GetCursorOffset(Editing));
-		CTextCursor Marker = Cursor;
-		Marker.m_LineWidth = -1;
-		TextRender()->TextEx(&Marker, "|", -1);
-		TextRender()->TextEx(&Cursor, aInputString + pConsole->m_Input.GetCursorOffset(Editing), -1);
-		Input()->SetEditingPosition(Marker.m_X, Marker.m_Y + Marker.m_FontSize);
-
 		// render possible commands
-		if((m_ConsoleType == CONSOLETYPE_LOCAL || Client()->RconAuthed()) && pConsole->m_Input.GetString()[0])
+		if((m_ConsoleType == CONSOLETYPE_LOCAL || Client()->RconAuthed()) && !pConsole->m_Input.IsEmpty())
 		{
 			CCompletionOptionRenderInfo Info;
 			Info.m_pSelf = this;
@@ -813,29 +715,7 @@ void CGameConsole::OnRender()
 		float OffsetY = 0.0f;
 		float LineOffset = 1.0f;
 
-		bool WantsSelectionCopy = false;
-		if(Input()->ModifierIsPressed() && Input()->KeyPress(KEY_C))
-			WantsSelectionCopy = true;
 		std::string SelectionString;
-
-		// check if mouse is pressed
-		if(!m_MouseIsPress && Input()->NativeMousePressed(1))
-		{
-			m_MouseIsPress = true;
-			Input()->NativeMousePos(&m_MousePressX, &m_MousePressY);
-			m_MousePressX = (m_MousePressX / (float)Graphics()->WindowWidth()) * Screen.w;
-			m_MousePressY = (m_MousePressY / (float)Graphics()->WindowHeight()) * Screen.h;
-		}
-		if(m_MouseIsPress)
-		{
-			Input()->NativeMousePos(&m_MouseCurX, &m_MouseCurY);
-			m_MouseCurX = (m_MouseCurX / (float)Graphics()->WindowWidth()) * Screen.w;
-			m_MouseCurY = (m_MouseCurY / (float)Graphics()->WindowHeight()) * Screen.h;
-		}
-		if(m_MouseIsPress && !Input()->NativeMousePressed(1))
-		{
-			m_MouseIsPress = false;
-		}
 
 		static int s_LastActivePage = pConsole->m_BacklogCurPage;
 		int TotalPages = 1;
@@ -858,9 +738,9 @@ void CGameConsole::OnRender()
 				if((m_HasSelection || m_MouseIsPress) && m_NewLineCounter > 0)
 				{
 					float MouseExtraOff = pEntry->m_YOffset;
-					m_MousePressY -= MouseExtraOff;
+					m_MousePress.y -= MouseExtraOff;
 					if(!m_MouseIsPress)
-						m_MouseCurY -= MouseExtraOff;
+						m_MouseRelease.y -= MouseExtraOff;
 				}
 
 				// next page when lines reach the top
@@ -872,11 +752,9 @@ void CGameConsole::OnRender()
 				{
 					TextRender()->SetCursor(&Cursor, 0.0f, y - OffsetY, FontSize, TEXTFLAG_RENDER);
 					Cursor.m_LineWidth = Screen.w - 10.0f;
-					Cursor.m_CalculateSelectionMode = (m_MouseIsPress || (m_CurSelStart != m_CurSelEnd) || m_HasSelection) ? TEXT_CURSOR_SELECTION_MODE_CALCULATE : TEXT_CURSOR_SELECTION_MODE_NONE;
-					Cursor.m_PressMouseX = m_MousePressX;
-					Cursor.m_PressMouseY = m_MousePressY;
-					Cursor.m_ReleaseMouseX = m_MouseCurX;
-					Cursor.m_ReleaseMouseY = m_MouseCurY;
+					Cursor.m_CalculateSelectionMode = (m_ConsoleState == CONSOLE_OPEN && m_MousePress.y < s_BoundingBox.m_Y && (m_MouseIsPress || (m_CurSelStart != m_CurSelEnd) || m_HasSelection)) ? TEXT_CURSOR_SELECTION_MODE_CALCULATE : TEXT_CURSOR_SELECTION_MODE_NONE;
+					Cursor.m_PressMouse = m_MousePress;
+					Cursor.m_ReleaseMouse = m_MouseRelease;
 					TextRender()->TextEx(&Cursor, pEntry->m_aText, -1);
 					if(Cursor.m_CalculateSelectionMode == TEXT_CURSOR_SELECTION_MODE_CALCULATE)
 					{
@@ -885,11 +763,9 @@ void CGameConsole::OnRender()
 					}
 					if(m_CurSelStart != m_CurSelEnd)
 					{
-						if(WantsSelectionCopy)
+						if(m_WantsSelectionCopy)
 						{
-							bool HasNewLine = false;
-							if(!SelectionString.empty())
-								HasNewLine = true;
+							const bool HasNewLine = !SelectionString.empty();
 							int OffUTF8Start = 0;
 							int OffUTF8End = 0;
 							if(TextRender()->SelectionToUTF8OffSets(pEntry->m_aText, m_CurSelStart, m_CurSelEnd, OffUTF8Start, OffUTF8End))
@@ -908,11 +784,6 @@ void CGameConsole::OnRender()
 					--m_NewLineCounter;
 			}
 
-			if(WantsSelectionCopy && !SelectionString.empty())
-			{
-				Input()->SetClipboardText(SelectionString.c_str());
-			}
-
 			if(!pEntry)
 				break;
 			TotalPages++;
@@ -921,6 +792,15 @@ void CGameConsole::OnRender()
 		s_LastActivePage = pConsole->m_BacklogCurPage;
 
 		pConsole->m_BacklogLock.unlock();
+
+		if(m_WantsSelectionCopy && !SelectionString.empty())
+		{
+			m_HasSelection = false;
+			m_CurSelStart = -1;
+			m_CurSelEnd = -1;
+			Input()->SetClipboardText(SelectionString.c_str());
+			m_WantsSelectionCopy = false;
+		}
 
 		// render page
 		char aBuf[128];
@@ -949,8 +829,11 @@ bool CGameConsole::OnInput(const IInput::CEvent &Event)
 
 	if(Event.m_Key == KEY_ESCAPE && (Event.m_Flags & IInput::FLAG_PRESS))
 		Toggle(m_ConsoleType);
-	else
-		CurrentConsole()->OnInput(Event);
+	else if(!CurrentConsole()->OnInput(Event))
+	{
+		if(m_pClient->Input()->ModifierIsPressed() && Event.m_Flags & IInput::FLAG_PRESS && Event.m_Key == KEY_C)
+			m_WantsSelectionCopy = true;
+	}
 
 	return true;
 }
@@ -979,8 +862,6 @@ void CGameConsole::Toggle(int Type)
 		{
 			UI()->SetEnabled(false);
 			m_ConsoleState = CONSOLE_OPENING;
-
-			Input()->SetIMEState(true);
 		}
 		else
 		{
@@ -988,8 +869,6 @@ void CGameConsole::Toggle(int Type)
 			UI()->SetEnabled(true);
 			m_pClient->OnRelease();
 			m_ConsoleState = CONSOLE_CLOSING;
-
-			Input()->SetIMEState(false);
 		}
 	}
 	if(m_ConsoleType != Type)

--- a/src/game/client/components/console.h
+++ b/src/game/client/components/console.h
@@ -37,7 +37,7 @@ class CGameConsole : public CComponent
 		CStaticRingBuffer<char, 64 * 1024, CRingBufferBase::FLAG_RECYCLE> m_History;
 		char *m_pHistoryEntry;
 
-		CLineInput m_Input;
+		CLineInputBuffered<512> m_Input;
 		const char *m_pName;
 		int m_Type;
 		int m_BacklogCurPage;
@@ -71,7 +71,7 @@ class CGameConsole : public CComponent
 
 		void ExecuteLine(const char *pLine);
 
-		void OnInput(const IInput::CEvent &Event);
+		bool OnInput(const IInput::CEvent &Event);
 		void PrintLine(const char *pLine, int Len, ColorRGBA PrintColor);
 
 		const char *GetString() const { return m_Input.GetString(); }
@@ -94,16 +94,15 @@ class CGameConsole : public CComponent
 	float m_StateChangeDuration;
 
 	bool m_MouseIsPress = false;
-	int m_MousePressX = 0;
-	int m_MousePressY = 0;
-	int m_MouseCurX = 0;
-	int m_MouseCurY = 0;
+	vec2 m_MousePress = vec2(0.0f, 0.0f);
+	vec2 m_MouseRelease = vec2(0.0f, 0.0f);
 	int m_CurSelStart = 0;
 	int m_CurSelEnd = 0;
 	bool m_HasSelection = false;
 	int m_NewLineCounter = 0;
+	bool m_WantsSelectionCopy = false;
 
-	int m_LastInputLineCount = 0;
+	float m_LastInputHeight = 0.0f;
 
 	void Toggle(int Type);
 	void Dump(int Type);

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -334,14 +334,6 @@ protected:
 		FPopupButtonCallback pfnConfirmButtonCallback = &CMenus::DefaultButtonCallback, int ConfirmNextPopup = POPUP_NONE,
 		FPopupButtonCallback pfnCancelButtonCallback = &CMenus::DefaultButtonCallback, int CancelNextPopup = POPUP_NONE);
 
-	// TODO: this is a bit ugly but.. well.. yeah
-	enum
-	{
-		MAX_INPUTEVENTS = 32
-	};
-	static IInput::CEvent m_aInputEvents[MAX_INPUTEVENTS];
-	static size_t m_NumInputEvents;
-
 	// some settings
 	static float ms_ButtonHeight;
 	static float ms_ListheaderHeight;
@@ -366,8 +358,8 @@ protected:
 	// for call vote
 	int m_CallvoteSelectedOption;
 	int m_CallvoteSelectedPlayer;
-	char m_aCallvoteReason[VOTE_REASON_LENGTH];
-	char m_aFilterString[25];
+	CLineInputBuffered<VOTE_REASON_LENGTH> m_CallvoteReasonInput;
+	CLineInputBuffered<64> m_FilterInput;
 	bool m_ControlPageOpening;
 
 	// demo
@@ -443,7 +435,9 @@ protected:
 	};
 
 	char m_aCurrentDemoFolder[IO_MAX_PATH_LENGTH];
-	char m_aCurrentDemoFile[IO_MAX_PATH_LENGTH];
+	CLineInputBuffered<IO_MAX_PATH_LENGTH> m_DemoRenameInput;
+	CLineInputBuffered<IO_MAX_PATH_LENGTH> m_DemoSliceInput;
+	CLineInputBuffered<IO_MAX_PATH_LENGTH> m_DemoRenderInput;
 	int m_DemolistSelectedIndex;
 	bool m_DemolistSelectedIsDir;
 	int m_DemolistStorageType;

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -503,16 +503,13 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 		QuickSearch.VSplitLeft(SearchExcludeAddrStrMax, 0, &QuickSearch);
 		QuickSearch.VSplitLeft(5.0f, 0, &QuickSearch);
 
-		SUIExEditBoxProperties EditProps;
+		static CLineInput s_FilterInput(g_Config.m_BrFilterString, sizeof(g_Config.m_BrFilterString));
 		if(Input()->KeyPress(KEY_F) && Input()->ModifierIsPressed())
 		{
 			UI()->SetActiveItem(&g_Config.m_BrFilterString);
-
-			EditProps.m_SelectText = true;
+			s_FilterInput.SelectAll();
 		}
-		static int s_ClearButton = 0;
-		static float s_Offset = 0.0f;
-		if(UI()->DoClearableEditBox(&g_Config.m_BrFilterString, &s_ClearButton, &QuickSearch, g_Config.m_BrFilterString, sizeof(g_Config.m_BrFilterString), 12.0f, &s_Offset, false, IGraphics::CORNER_ALL, EditProps))
+		if(UI()->DoClearableEditBox(&s_FilterInput, &QuickSearch, 12.0f))
 			Client()->ServerBrowserUpdate();
 	}
 
@@ -533,11 +530,10 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 		QuickExclude.VSplitLeft(SearchExcludeAddrStrMax, 0, &QuickExclude);
 		QuickExclude.VSplitLeft(5.0f, 0, &QuickExclude);
 
-		static int s_ClearButton = 0;
-		static float s_Offset = 0.0f;
+		static CLineInput s_ExcludeInput(g_Config.m_BrExcludeString, sizeof(g_Config.m_BrExcludeString));
 		if(Input()->KeyPress(KEY_X) && Input()->ShiftIsPressed() && Input()->ModifierIsPressed())
-			UI()->SetActiveItem(&g_Config.m_BrExcludeString);
-		if(UI()->DoClearableEditBox(&g_Config.m_BrExcludeString, &s_ClearButton, &QuickExclude, g_Config.m_BrExcludeString, sizeof(g_Config.m_BrExcludeString), 12.0f, &s_Offset, false, IGraphics::CORNER_ALL))
+			UI()->SetActiveItem(&s_ExcludeInput);
+		if(UI()->DoClearableEditBox(&s_ExcludeInput, &QuickExclude, 12.0f))
 			Client()->ServerBrowserUpdate();
 	}
 
@@ -569,9 +565,8 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 		// address info
 		UI()->DoLabel(&ServerAddr, Localize("Server address:"), 14.0f, TEXTALIGN_ML);
 		ServerAddr.VSplitLeft(SearchExcludeAddrStrMax + 5.0f + ExcludeSearchIconMax + 5.0f, NULL, &ServerAddr);
-		static int s_ClearButton = 0;
-		static float s_Offset = 0.0f;
-		UI()->DoClearableEditBox(&g_Config.m_UiServerAddress, &s_ClearButton, &ServerAddr, g_Config.m_UiServerAddress, sizeof(g_Config.m_UiServerAddress), 12.0f, &s_Offset);
+		static CLineInput s_ServerAddressInput(g_Config.m_UiServerAddress, sizeof(g_Config.m_UiServerAddress));
+		UI()->DoClearableEditBox(&s_ServerAddressInput, &ServerAddr, 12.0f);
 
 		// button area
 		ButtonArea = ConnectButtons;
@@ -670,8 +665,8 @@ void CMenus::RenderServerbrowserFilters(CUIRect View)
 	UI()->DoLabel(&Button, Localize("Game types:"), FontSize, TEXTALIGN_ML);
 	Button.VSplitRight(60.0f, 0, &Button);
 	ServerFilter.HSplitTop(3.0f, 0, &ServerFilter);
-	static float s_OffsetGametype = 0.0f;
-	if(UI()->DoEditBox(&g_Config.m_BrFilterGametype, &Button, g_Config.m_BrFilterGametype, sizeof(g_Config.m_BrFilterGametype), FontSize, &s_OffsetGametype))
+	static CLineInput s_GametypeInput(g_Config.m_BrFilterGametype, sizeof(g_Config.m_BrFilterGametype));
+	if(UI()->DoEditBox(&s_GametypeInput, &Button, FontSize))
 		Client()->ServerBrowserUpdate();
 
 	// server address
@@ -679,8 +674,8 @@ void CMenus::RenderServerbrowserFilters(CUIRect View)
 	ServerFilter.HSplitTop(19.0f, &Button, &ServerFilter);
 	UI()->DoLabel(&Button, Localize("Server address:"), FontSize, TEXTALIGN_ML);
 	Button.VSplitRight(60.0f, 0, &Button);
-	static float s_OffsetAddr = 0.0f;
-	if(UI()->DoEditBox(&g_Config.m_BrFilterServerAddress, &Button, g_Config.m_BrFilterServerAddress, sizeof(g_Config.m_BrFilterServerAddress), FontSize, &s_OffsetAddr))
+	static CLineInput s_FilterServerAddressInput(g_Config.m_BrFilterServerAddress, sizeof(g_Config.m_BrFilterServerAddress));
+	if(UI()->DoEditBox(&s_FilterServerAddressInput, &Button, FontSize))
 		Client()->ServerBrowserUpdate();
 
 	// player country
@@ -1375,25 +1370,25 @@ void CMenus::RenderServerbrowserFriends(CUIRect View)
 		str_format(aBuf, sizeof(aBuf), "%s:", Localize("Name"));
 		UI()->DoLabel(&Button, aBuf, FontSize + 2, TEXTALIGN_ML);
 		Button.VSplitLeft(80.0f, 0, &Button);
-		static char s_aName[MAX_NAME_LENGTH] = {0};
-		static float s_OffsetName = 0.0f;
-		UI()->DoEditBox(&s_aName, &Button, s_aName, sizeof(s_aName), FontSize + 2, &s_OffsetName);
+		static CLineInputBuffered<MAX_NAME_LENGTH> s_NameInput;
+		UI()->DoEditBox(&s_NameInput, &Button, FontSize + 2.0f);
 
 		ServerFriends.HSplitTop(3.0f, 0, &ServerFriends);
 		ServerFriends.HSplitTop(19.0f, &Button, &ServerFriends);
 		str_format(aBuf, sizeof(aBuf), "%s:", Localize("Clan"));
 		UI()->DoLabel(&Button, aBuf, FontSize + 2, TEXTALIGN_ML);
 		Button.VSplitLeft(80.0f, 0, &Button);
-		static char s_aClan[MAX_CLAN_LENGTH] = {0};
-		static float s_OffsetClan = 0.0f;
-		UI()->DoEditBox(&s_aClan, &Button, s_aClan, sizeof(s_aClan), FontSize + 2, &s_OffsetClan);
+		static CLineInputBuffered<MAX_CLAN_LENGTH> s_ClanInput;
+		UI()->DoEditBox(&s_ClanInput, &Button, FontSize + 2.0f);
 
 		ServerFriends.HSplitTop(3.0f, 0, &ServerFriends);
 		ServerFriends.HSplitTop(20.0f, &Button, &ServerFriends);
 		static CButtonContainer s_AddButton;
 		if(DoButton_Menu(&s_AddButton, Localize("Add Friend"), 0, &Button))
 		{
-			m_pClient->Friends()->AddFriend(s_aName, s_aClan);
+			m_pClient->Friends()->AddFriend(s_NameInput.GetString(), s_ClanInput.GetString());
+			s_NameInput.Clear();
+			s_ClanInput.Clear();
 			FriendlistOnUpdate();
 			Client()->ServerBrowserUpdate();
 		}

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -163,15 +163,15 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 			DemoPlayer()->GetDemoName(aDemoName, sizeof(aDemoName));
 			str_append(aDemoName, ".demo", sizeof(aDemoName));
 
-			if(!str_endswith(m_aCurrentDemoFile, ".demo"))
-				str_append(m_aCurrentDemoFile, ".demo", sizeof(m_aCurrentDemoFile));
+			if(!str_endswith(m_DemoSliceInput.GetString(), ".demo"))
+				m_DemoSliceInput.Append(".demo");
 
-			if(str_comp(aDemoName, m_aCurrentDemoFile) == 0)
+			if(str_comp(aDemoName, m_DemoSliceInput.GetString()) == 0)
 				str_copy(m_aDemoPlayerPopupHint, Localize("Please use a different name"));
 			else
 			{
 				char aPath[IO_MAX_PATH_LENGTH];
-				str_format(aPath, sizeof(aPath), "%s/%s", m_aCurrentDemoFolder, m_aCurrentDemoFile);
+				str_format(aPath, sizeof(aPath), "%s/%s", m_aCurrentDemoFolder, m_DemoSliceInput.GetString());
 
 				IOHANDLE DemoFile = Storage()->OpenFile(aPath, IOFLAG_READ, IStorage::TYPE_SAVE);
 				const char *pStr = Localize("File already exists, do you want to overwrite it?");
@@ -207,8 +207,7 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 		TextBox.VSplitLeft(20.0f, 0, &TextBox);
 		TextBox.VSplitRight(60.0f, &TextBox, 0);
 		UI()->DoLabel(&Label, Localize("New name:"), 18.0f, TEXTALIGN_ML);
-		static float s_Offset = 0.0f;
-		if(UI()->DoEditBox(&s_Offset, &TextBox, m_aCurrentDemoFile, sizeof(m_aCurrentDemoFile), 12.0f, &s_Offset))
+		if(UI()->DoEditBox(&m_DemoSliceInput, &TextBox, 12.0f))
 		{
 			m_aDemoPlayerPopupHint[0] = '\0';
 		}
@@ -561,8 +560,11 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 	static CButtonContainer s_SliceSaveButton;
 	if(DoButton_FontIcon(&s_SliceSaveButton, FONT_ICON_ARROW_UP_RIGHT_FROM_SQUARE, 0, &Button, IGraphics::CORNER_ALL))
 	{
-		DemoPlayer()->GetDemoName(m_aCurrentDemoFile, sizeof(m_aCurrentDemoFile));
-		str_append(m_aCurrentDemoFile, ".demo", sizeof(m_aCurrentDemoFile));
+		char aDemoName[IO_MAX_PATH_LENGTH];
+		DemoPlayer()->GetDemoName(aDemoName, sizeof(aDemoName));
+		m_DemoSliceInput.Set(aDemoName);
+		m_DemoSliceInput.Append(".demo");
+		UI()->SetActiveItem(&m_DemoSliceInput);
 		m_aDemoPlayerPopupHint[0] = '\0';
 		m_DemoPlayerState = DEMOPLAYER_SLICE_SAVE;
 	}
@@ -1142,9 +1144,9 @@ void CMenus::RenderDemoList(CUIRect MainView)
 		{
 			if(m_DemolistSelectedIndex >= 0)
 			{
-				UI()->SetActiveItem(nullptr);
 				m_Popup = POPUP_RENAME_DEMO;
-				str_copy(m_aCurrentDemoFile, m_vDemos[m_DemolistSelectedIndex].m_aFilename);
+				m_DemoRenameInput.Set(m_vDemos[m_DemolistSelectedIndex].m_aFilename);
+				UI()->SetActiveItem(&m_DemoRenameInput);
 				return;
 			}
 		}
@@ -1155,9 +1157,9 @@ void CMenus::RenderDemoList(CUIRect MainView)
 		{
 			if(m_DemolistSelectedIndex >= 0)
 			{
-				UI()->SetActiveItem(nullptr);
 				m_Popup = POPUP_RENDER_DEMO;
-				str_copy(m_aCurrentDemoFile, m_vDemos[m_DemolistSelectedIndex].m_aFilename);
+				m_DemoRenderInput.Set(m_vDemos[m_DemolistSelectedIndex].m_aFilename);
+				UI()->SetActiveItem(&m_DemoRenderInput);
 				return;
 			}
 		}

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -535,7 +535,7 @@ bool CMenus::RenderServerControlServer(CUIRect MainView)
 
 	for(CVoteOptionClient *pOption = m_pClient->m_Voting.m_pFirst; pOption; pOption = pOption->m_pNext)
 	{
-		if(m_aFilterString[0] != '\0' && !str_utf8_find_nocase(pOption->m_aDescription, m_aFilterString))
+		if(!m_FilterInput.IsEmpty() && !str_utf8_find_nocase(pOption->m_aDescription, m_FilterInput.GetString()))
 			continue;
 		TotalShown++;
 	}
@@ -547,7 +547,7 @@ bool CMenus::RenderServerControlServer(CUIRect MainView)
 	for(CVoteOptionClient *pOption = m_pClient->m_Voting.m_pFirst; pOption; pOption = pOption->m_pNext)
 	{
 		i++;
-		if(m_aFilterString[0] != '\0' && !str_utf8_find_nocase(pOption->m_aDescription, m_aFilterString))
+		if(!m_FilterInput.IsEmpty() && !str_utf8_find_nocase(pOption->m_aDescription, m_FilterInput.GetString()))
 			continue;
 
 		if(NumVoteOptions < Total)
@@ -581,7 +581,7 @@ bool CMenus::RenderServerControlKick(CUIRect MainView, bool FilterSpectators)
 		if(Index == m_pClient->m_Snap.m_LocalClientID || (FilterSpectators && pInfoByName->m_Team == TEAM_SPECTATORS))
 			continue;
 
-		if(!str_utf8_find_nocase(m_pClient->m_aClients[Index].m_aName, m_aFilterString))
+		if(!str_utf8_find_nocase(m_pClient->m_aClients[Index].m_aName, m_FilterInput.GetString()))
 			continue;
 
 		if(m_CallvoteSelectedPlayer == Index)
@@ -680,18 +680,15 @@ void CMenus::RenderServerControl(CUIRect MainView)
 			TextRender()->SetCurFont(NULL);
 			QuickSearch.VSplitLeft(wSearch, 0, &QuickSearch);
 			QuickSearch.VSplitLeft(5.0f, 0, &QuickSearch);
-			static int s_ClearButton = 0;
-			static float s_Offset = 0.0f;
 
-			SUIExEditBoxProperties EditProps;
 			if(m_ControlPageOpening || (Input()->KeyPress(KEY_F) && Input()->ModifierIsPressed()))
 			{
-				UI()->SetActiveItem(&m_aFilterString);
+				UI()->SetActiveItem(&m_FilterInput);
 				m_ControlPageOpening = false;
-				EditProps.m_SelectText = true;
+				m_FilterInput.SelectAll();
 			}
-			EditProps.m_pEmptyText = Localize("Search");
-			UI()->DoClearableEditBox(&m_aFilterString, &s_ClearButton, &QuickSearch, m_aFilterString, sizeof(m_aFilterString), 14.0f, &s_Offset, false, IGraphics::CORNER_ALL, EditProps);
+			m_FilterInput.SetEmptyText(Localize("Search"));
+			UI()->DoClearableEditBox(&m_FilterInput, &QuickSearch, 14.0f);
 		}
 
 		Bottom.VSplitRight(120.0f, &Bottom, &Button);
@@ -701,7 +698,7 @@ void CMenus::RenderServerControl(CUIRect MainView)
 		{
 			if(s_ControlPage == 0)
 			{
-				m_pClient->m_Voting.CallvoteOption(m_CallvoteSelectedOption, m_aCallvoteReason);
+				m_pClient->m_Voting.CallvoteOption(m_CallvoteSelectedOption, m_CallvoteReasonInput.GetString());
 				if(g_Config.m_UiCloseWindowAfterChangingSetting)
 					SetActive(false);
 			}
@@ -710,7 +707,7 @@ void CMenus::RenderServerControl(CUIRect MainView)
 				if(m_CallvoteSelectedPlayer >= 0 && m_CallvoteSelectedPlayer < MAX_CLIENTS &&
 					m_pClient->m_Snap.m_apPlayerInfos[m_CallvoteSelectedPlayer])
 				{
-					m_pClient->m_Voting.CallvoteKick(m_CallvoteSelectedPlayer, m_aCallvoteReason);
+					m_pClient->m_Voting.CallvoteKick(m_CallvoteSelectedPlayer, m_CallvoteReasonInput.GetString());
 					SetActive(false);
 				}
 			}
@@ -719,11 +716,11 @@ void CMenus::RenderServerControl(CUIRect MainView)
 				if(m_CallvoteSelectedPlayer >= 0 && m_CallvoteSelectedPlayer < MAX_CLIENTS &&
 					m_pClient->m_Snap.m_apPlayerInfos[m_CallvoteSelectedPlayer])
 				{
-					m_pClient->m_Voting.CallvoteSpectate(m_CallvoteSelectedPlayer, m_aCallvoteReason);
+					m_pClient->m_Voting.CallvoteSpectate(m_CallvoteSelectedPlayer, m_CallvoteReasonInput.GetString());
 					SetActive(false);
 				}
 			}
-			m_aCallvoteReason[0] = 0;
+			m_CallvoteReasonInput.Clear();
 		}
 
 		// render kick reason
@@ -735,10 +732,12 @@ void CMenus::RenderServerControl(CUIRect MainView)
 		UI()->DoLabel(&Reason, pLabel, 14.0f, TEXTALIGN_ML);
 		float w = TextRender()->TextWidth(14.0f, pLabel, -1, -1.0f);
 		Reason.VSplitLeft(w + 10.0f, 0, &Reason);
-		static float s_Offset = 0.0f;
 		if(Input()->KeyPress(KEY_R) && Input()->ModifierIsPressed())
-			UI()->SetActiveItem(&m_aCallvoteReason);
-		UI()->DoEditBox(&m_aCallvoteReason, &Reason, m_aCallvoteReason, sizeof(m_aCallvoteReason), 14.0f, &s_Offset, false, IGraphics::CORNER_ALL);
+		{
+			UI()->SetActiveItem(&m_CallvoteReasonInput);
+			m_CallvoteReasonInput.SelectAll();
+		}
+		UI()->DoEditBox(&m_CallvoteReasonInput, &Reason, 14.0f);
 
 		// extended features (only available when authed in rcon)
 		if(Client()->RconAuthed())
@@ -756,13 +755,13 @@ void CMenus::RenderServerControl(CUIRect MainView)
 			if(DoButton_Menu(&s_ForceVoteButton, Localize("Force vote"), 0, &Button))
 			{
 				if(s_ControlPage == 0)
-					m_pClient->m_Voting.CallvoteOption(m_CallvoteSelectedOption, m_aCallvoteReason, true);
+					m_pClient->m_Voting.CallvoteOption(m_CallvoteSelectedOption, m_CallvoteReasonInput.GetString(), true);
 				else if(s_ControlPage == 1)
 				{
 					if(m_CallvoteSelectedPlayer >= 0 && m_CallvoteSelectedPlayer < MAX_CLIENTS &&
 						m_pClient->m_Snap.m_apPlayerInfos[m_CallvoteSelectedPlayer])
 					{
-						m_pClient->m_Voting.CallvoteKick(m_CallvoteSelectedPlayer, m_aCallvoteReason, true);
+						m_pClient->m_Voting.CallvoteKick(m_CallvoteSelectedPlayer, m_CallvoteReasonInput.GetString(), true);
 						SetActive(false);
 					}
 				}
@@ -771,11 +770,11 @@ void CMenus::RenderServerControl(CUIRect MainView)
 					if(m_CallvoteSelectedPlayer >= 0 && m_CallvoteSelectedPlayer < MAX_CLIENTS &&
 						m_pClient->m_Snap.m_apPlayerInfos[m_CallvoteSelectedPlayer])
 					{
-						m_pClient->m_Voting.CallvoteSpectate(m_CallvoteSelectedPlayer, m_aCallvoteReason, true);
+						m_pClient->m_Voting.CallvoteSpectate(m_CallvoteSelectedPlayer, m_CallvoteReasonInput.GetString(), true);
 						SetActive(false);
 					}
 				}
-				m_aCallvoteReason[0] = 0;
+				m_CallvoteReasonInput.Clear();
 			}
 
 			if(s_ControlPage == 0)
@@ -796,24 +795,22 @@ void CMenus::RenderServerControl(CUIRect MainView)
 				Bottom.VSplitLeft(20.0f, 0, &Button);
 				UI()->DoLabel(&Button, Localize("Vote command:"), 14.0f, TEXTALIGN_ML);
 
-				static char s_aVoteDescription[64] = {0};
-				static char s_aVoteCommand[512] = {0};
+				static CLineInputBuffered<64> s_VoteDescriptionInput;
+				static CLineInputBuffered<512> s_VoteCommandInput;
 				RconExtension.HSplitTop(20.0f, &Bottom, &RconExtension);
 				Bottom.VSplitRight(10.0f, &Bottom, 0);
 				Bottom.VSplitRight(120.0f, &Bottom, &Button);
 				static CButtonContainer s_AddVoteButton;
 				if(DoButton_Menu(&s_AddVoteButton, Localize("Add"), 0, &Button))
-					if(s_aVoteDescription[0] != 0 && s_aVoteCommand[0] != 0)
-						m_pClient->m_Voting.AddvoteOption(s_aVoteDescription, s_aVoteCommand);
+					if(!s_VoteDescriptionInput.IsEmpty() && !s_VoteCommandInput.IsEmpty())
+						m_pClient->m_Voting.AddvoteOption(s_VoteDescriptionInput.GetString(), s_VoteCommandInput.GetString());
 
 				Bottom.VSplitLeft(5.0f, 0, &Bottom);
 				Bottom.VSplitLeft(250.0f, &Button, &Bottom);
-				static float s_OffsetDesc = 0.0f;
-				UI()->DoEditBox(&s_aVoteDescription, &Button, s_aVoteDescription, sizeof(s_aVoteDescription), 14.0f, &s_OffsetDesc, false, IGraphics::CORNER_ALL);
+				UI()->DoEditBox(&s_VoteDescriptionInput, &Button, 14.0f);
 
 				Bottom.VMargin(20.0f, &Button);
-				static float s_OffsetCmd = 0.0f;
-				UI()->DoEditBox(&s_aVoteCommand, &Button, s_aVoteCommand, sizeof(s_aVoteCommand), 14.0f, &s_OffsetCmd, false, IGraphics::CORNER_ALL);
+				UI()->DoEditBox(&s_VoteCommandInput, &Button, 14.0f);
 			}
 		}
 	}

--- a/src/game/client/components/menus_settings_assets.cpp
+++ b/src/game/client/components/menus_settings_assets.cpp
@@ -259,7 +259,7 @@ static size_t gs_aCustomListSize[NUMBER_OF_ASSETS_TABS] = {
 	0,
 };
 
-static char s_aFilterString[NUMBER_OF_ASSETS_TABS][50];
+static CLineInputBuffered<64> s_aFilterInputs[NUMBER_OF_ASSETS_TABS];
 
 static int s_CurCustomTab = ASSETS_TAB_ENTITIES;
 
@@ -377,7 +377,7 @@ int InitSearchList(std::vector<const TName *> &vpSearchList, std::vector<TName> 
 		const TName *pAsset = &vAssetList[i];
 
 		// filter quick search
-		if(s_aFilterString[s_CurCustomTab][0] != '\0' && !str_utf8_find_nocase(pAsset->m_aName, s_aFilterString[s_CurCustomTab]))
+		if(!s_aFilterInputs[s_CurCustomTab].IsEmpty() && !str_utf8_find_nocase(pAsset->m_aName, s_aFilterInputs[s_CurCustomTab].GetString()))
 			continue;
 
 		vpSearchList.push_back(pAsset);
@@ -472,7 +472,7 @@ void CMenus::RenderSettingsCustom(CUIRect MainView)
 				const SCustomEntities *pEntity = &m_vEntitiesList[i];
 
 				// filter quick search
-				if(s_aFilterString[s_CurCustomTab][0] != '\0' && !str_utf8_find_nocase(pEntity->m_aName, s_aFilterString[s_CurCustomTab]))
+				if(!s_aFilterInputs[s_CurCustomTab].IsEmpty() && !str_utf8_find_nocase(pEntity->m_aName, s_aFilterInputs[s_CurCustomTab].GetString()))
 					continue;
 
 				gs_vpSearchEntitiesList.push_back(pEntity);
@@ -650,16 +650,13 @@ void CMenus::RenderSettingsCustom(CUIRect MainView)
 		QuickSearch.VSplitLeft(wSearch, 0, &QuickSearch);
 		QuickSearch.VSplitLeft(5.0f, 0, &QuickSearch);
 		QuickSearch.VSplitLeft(QuickSearch.w - 15.0f, &QuickSearch, &QuickSearchClearButton);
-		static int s_ClearButton = 0;
-		static float s_Offset = 0.0f;
-		SUIExEditBoxProperties EditProps;
 		if(Input()->KeyPress(KEY_F) && Input()->ModifierIsPressed())
 		{
-			UI()->SetActiveItem(&s_aFilterString[s_CurCustomTab]);
-			EditProps.m_SelectText = true;
+			UI()->SetActiveItem(&s_aFilterInputs[s_CurCustomTab]);
+			s_aFilterInputs[s_CurCustomTab].SelectAll();
 		}
-		EditProps.m_pEmptyText = Localize("Search");
-		if(UI()->DoClearableEditBox(&s_aFilterString[s_CurCustomTab], &s_ClearButton, &QuickSearch, s_aFilterString[s_CurCustomTab], sizeof(s_aFilterString[0]), 14.0f, &s_Offset, false, IGraphics::CORNER_ALL, EditProps))
+		s_aFilterInputs[s_CurCustomTab].SetEmptyText(Localize("Search"));
+		if(UI()->DoClearableEditBox(&s_aFilterInputs[s_CurCustomTab], &QuickSearch, 14.0f))
 			gs_aInitCustomList[s_CurCustomTab] = true;
 	}
 

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -28,6 +28,7 @@
 #include <base/vmath.h>
 
 #include "gameclient.h"
+#include "lineinput.h"
 #include "race.h"
 #include "render.h"
 
@@ -646,6 +647,8 @@ void CGameClient::OnRender()
 
 	// clear all events/input for this frame
 	Input()->Clear();
+
+	CLineInput::RenderCandidates();
 
 	// clear new tick flags
 	m_NewTick = false;

--- a/src/game/client/lineinput.cpp
+++ b/src/game/client/lineinput.cpp
@@ -1,80 +1,94 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
-#include <base/math.h>
-#include <base/system.h>
-
-#include "lineinput.h"
 #include <engine/keys.h>
 
-CLineInput::CLineInput()
+#include "lineinput.h"
+#include "ui.h"
+
+IInput *CLineInput::ms_pInput = nullptr;
+ITextRender *CLineInput::ms_pTextRender = nullptr;
+IGraphics *CLineInput::ms_pGraphics = nullptr;
+IClient *CLineInput::ms_pClient = nullptr;
+
+CLineInput *CLineInput::ms_pActiveInput = nullptr;
+EInputPriority CLineInput::ms_ActiveInputPriority = EInputPriority::NONE;
+
+vec2 CLineInput::ms_CompositionWindowPosition = vec2(0.0f, 0.0f);
+float CLineInput::ms_CompositionLineHeight = 0.0f;
+
+char CLineInput::ms_aStars[128] = {'\0'};
+
+void CLineInput::SetBuffer(char *pStr, size_t MaxSize, size_t MaxChars)
 {
-	Clear();
+	if(m_pStr && m_pStr == pStr)
+		return;
+	const char *pLastStr = m_pStr;
+	m_pStr = pStr;
+	m_MaxSize = MaxSize;
+	m_MaxChars = MaxChars;
+	m_WasChanged = m_pStr && pLastStr && m_WasChanged;
+	if(!pLastStr)
+	{
+		m_ScrollOffset = m_ScrollOffsetChange = 0.0f;
+		m_CaretPosition = vec2(0.0f, 0.0f);
+		m_Hidden = false;
+		m_pEmptyText = nullptr;
+		m_MouseSelection.m_Selecting = false;
+	}
+	if(m_pStr && m_pStr != pLastStr)
+		UpdateStrData();
 }
 
 void CLineInput::Clear()
 {
-	Set("");
+	mem_zero(m_pStr, m_MaxSize);
+	UpdateStrData();
 }
 
 void CLineInput::Set(const char *pString)
 {
-	str_copy(m_aStr, pString);
-	str_utf8_stats(m_aStr, MAX_SIZE, MAX_CHARS, &m_Len, &m_NumChars);
-	m_CursorPos = m_Len;
+	str_copy(m_pStr, pString, m_MaxSize);
+	UpdateStrData();
+	SetCursorOffset(m_Len);
 }
 
-void CLineInput::SetRange(const char *pString, int Begin, int End)
+void CLineInput::SetRange(const char *pString, size_t Begin, size_t End)
 {
 	if(Begin > End)
 		std::swap(Begin, End);
-	Begin = clamp(Begin, 0, m_Len);
-	End = clamp(End, 0, m_Len);
+	Begin = clamp<size_t>(Begin, 0, m_Len);
+	End = clamp<size_t>(End, 0, m_Len);
 
-	int RemovedCharSize, RemovedCharCount;
-	str_utf8_stats(m_aStr + Begin, End - Begin + 1, MAX_CHARS, &RemovedCharSize, &RemovedCharCount);
+	size_t RemovedCharSize, RemovedCharCount;
+	str_utf8_stats(m_pStr + Begin, End - Begin + 1, m_MaxChars, &RemovedCharSize, &RemovedCharCount);
 
-	int AddedCharSize, AddedCharCount;
-	str_utf8_stats(pString, MAX_SIZE - m_Len + RemovedCharSize, MAX_CHARS - m_NumChars + RemovedCharCount, &AddedCharSize, &AddedCharCount);
+	size_t AddedCharSize, AddedCharCount;
+	str_utf8_stats(pString, m_MaxSize - m_Len + RemovedCharSize, m_MaxChars - m_NumChars + RemovedCharCount, &AddedCharSize, &AddedCharCount);
 
 	if(RemovedCharSize || AddedCharSize)
 	{
 		if(AddedCharSize < RemovedCharSize)
 		{
 			if(AddedCharSize)
-				mem_copy(m_aStr + Begin, pString, AddedCharSize);
-			mem_move(m_aStr + Begin + AddedCharSize, m_aStr + Begin + RemovedCharSize, m_Len - Begin - AddedCharSize);
+				mem_copy(m_pStr + Begin, pString, AddedCharSize);
+			mem_move(m_pStr + Begin + AddedCharSize, m_pStr + Begin + RemovedCharSize, m_Len - Begin - AddedCharSize);
 		}
 		else if(AddedCharSize > RemovedCharSize)
-			mem_move(m_aStr + End + AddedCharSize - RemovedCharSize, m_aStr + End, m_Len - End);
+			mem_move(m_pStr + End + AddedCharSize - RemovedCharSize, m_pStr + End, m_Len - End);
 
 		if(AddedCharSize >= RemovedCharSize)
-			mem_copy(m_aStr + Begin, pString, AddedCharSize);
+			mem_copy(m_pStr + Begin, pString, AddedCharSize);
 
 		m_CursorPos = End - RemovedCharSize + AddedCharSize;
 		m_Len += AddedCharSize - RemovedCharSize;
 		m_NumChars += AddedCharCount - RemovedCharCount;
-		m_aStr[m_Len] = '\0';
+		m_WasChanged = true;
+		m_pStr[m_Len] = '\0';
+		m_SelectionStart = m_SelectionEnd = m_CursorPos;
 	}
 }
 
-void CLineInput::Editing(const char *pString, int Cursor)
-{
-	str_copy(m_aDisplayStr, m_aStr);
-	char aEditingText[IInput::INPUT_TEXT_SIZE + 2];
-	str_format(aEditingText, sizeof(aEditingText), "[%s]", pString);
-	int NewTextLen = str_length(aEditingText);
-	int CharsLeft = (int)sizeof(m_aDisplayStr) - str_length(m_aDisplayStr) - 1;
-	int FillCharLen = NewTextLen < CharsLeft ? NewTextLen : CharsLeft;
-	for(int i = str_length(m_aDisplayStr) - 1; i >= m_CursorPos; i--)
-		m_aDisplayStr[i + FillCharLen] = m_aDisplayStr[i];
-	for(int i = 0; i < FillCharLen; i++)
-		m_aDisplayStr[m_CursorPos + i] = aEditingText[i];
-	m_aDisplayStr[m_CursorPos + FillCharLen] = '\0';
-	m_FakeLen = str_length(m_aDisplayStr);
-	m_FakeCursorPos = m_CursorPos + Cursor + 1;
-}
-
-void CLineInput::Insert(const char *pString, int Begin)
+void CLineInput::Insert(const char *pString, size_t Begin)
 {
 	SetRange(pString, Begin, Begin);
 }
@@ -84,141 +98,583 @@ void CLineInput::Append(const char *pString)
 	Insert(pString, m_Len);
 }
 
-static bool IsNotAWordChar(signed char c)
+void CLineInput::UpdateStrData()
 {
-	return (c > 0 && c < '0') || (c > '9' && c < 'A') || (c > 'Z' && c < 'a') || (c > 'z'); // all non chars in ascii -- random
+	str_utf8_stats(m_pStr, m_MaxSize, m_MaxChars, &m_Len, &m_NumChars);
+	if(!in_range<size_t>(m_CursorPos, 0, m_Len))
+		SetCursorOffset(m_CursorPos);
+	if(!in_range<size_t>(m_SelectionStart, 0, m_Len) || !in_range<size_t>(m_SelectionEnd, 0, m_Len))
+		SetSelection(m_SelectionStart, m_SelectionEnd);
 }
 
-int32_t CLineInput::Manipulate(IInput::CEvent Event, char *pStr, int StrMaxSize, int StrMaxChars, int *pStrLenPtr, int *pCursorPosPtr, int *pNumCharsPtr, int32_t ModifyFlags, int ModifierKey)
+const char *CLineInput::GetDisplayedString()
 {
-	int NumChars = *pNumCharsPtr;
-	int CursorPos = *pCursorPosPtr;
-	int Len = *pStrLenPtr;
-	int32_t Changes = 0;
+	if(!IsHidden())
+		return m_pStr;
 
-	if(CursorPos > Len)
-		CursorPos = Len;
+	const size_t NumStars = minimum(GetNumChars(), sizeof(ms_aStars) - 1);
+	for(size_t i = 0; i < NumStars; ++i)
+		ms_aStars[i] = '*';
+	ms_aStars[NumStars] = '\0';
+	return ms_aStars;
+}
 
-	if(Event.m_Flags & IInput::FLAG_TEXT)
+void CLineInput::MoveCursor(EMoveDirection Direction, bool MoveWord, const char *pStr, size_t MaxSize, size_t *pCursorPos)
+{
+	// Check whether cursor position is initially on space or non-space character.
+	// When forwarding, check character to the right of the cursor position.
+	// When rewinding, check character to the left of the cursor position (rewind first).
+	size_t PeekCursorPos = Direction == FORWARD ? *pCursorPos : str_utf8_rewind(pStr, *pCursorPos);
+	const char *pTemp = pStr + PeekCursorPos;
+	bool AnySpace = str_utf8_isspace(str_utf8_decode(&pTemp));
+	bool AnyWord = !AnySpace;
+	while(true)
 	{
-		// gather string stats
-		int CharCount = 0;
-		int CharSize = 0;
-		str_utf8_stats(Event.m_aText, MAX_SIZE, MAX_CHARS, &CharSize, &CharCount);
+		if(Direction == FORWARD)
+			*pCursorPos = str_utf8_forward(pStr, *pCursorPos);
+		else
+			*pCursorPos = str_utf8_rewind(pStr, *pCursorPos);
+		if(!MoveWord || *pCursorPos <= 0 || *pCursorPos >= MaxSize)
+			break;
+		PeekCursorPos = Direction == FORWARD ? *pCursorPos : str_utf8_rewind(pStr, *pCursorPos);
+		pTemp = pStr + PeekCursorPos;
+		const bool CurrentSpace = str_utf8_isspace(str_utf8_decode(&pTemp));
+		const bool CurrentWord = !CurrentSpace;
+		if(Direction == FORWARD && AnySpace && !CurrentSpace)
+			break; // Forward: Stop when next (right) character is non-space after seeing at least one space character.
+		else if(Direction == REWIND && AnyWord && !CurrentWord)
+			break; // Rewind: Stop when next (left) character is space after seeing at least one non-space character.
+		AnySpace |= CurrentSpace;
+		AnyWord |= CurrentWord;
+	}
+}
 
-		// add new string
-		if(CharCount)
-		{
-			if(Len + CharSize < StrMaxSize && CursorPos + CharSize < StrMaxSize && NumChars + CharCount < StrMaxChars)
-			{
-				mem_move(pStr + CursorPos + CharSize, pStr + CursorPos, Len - CursorPos + 1); // +1 == null term
-				for(int i = 0; i < CharSize; i++)
-					pStr[CursorPos + i] = Event.m_aText[i];
-				CursorPos += CharSize;
-				Len += CharSize;
-				NumChars += CharCount;
-				Changes |= ELineInputChanges::LINE_INPUT_CHANGE_STRING;
-			}
-		}
+void CLineInput::SetCursorOffset(size_t Offset)
+{
+	m_SelectionStart = m_SelectionEnd = m_LastCompositionCursorPos = m_CursorPos = clamp<size_t>(Offset, 0, m_Len);
+	m_WasChanged = true;
+}
+
+void CLineInput::SetSelection(size_t Start, size_t End)
+{
+	if(Start > End)
+		std::swap(Start, End);
+	m_SelectionStart = clamp<size_t>(Start, 0, m_Len);
+	m_SelectionEnd = clamp<size_t>(End, 0, m_Len);
+	m_WasChanged = true;
+}
+
+size_t CLineInput::OffsetFromActualToDisplay(size_t ActualOffset) const
+{
+	if(!IsHidden())
+		return ActualOffset;
+	size_t DisplayOffset = 0;
+	size_t CurrentOffset = 0;
+	while(CurrentOffset < ActualOffset)
+	{
+		const size_t PrevOffset = CurrentOffset;
+		CurrentOffset = str_utf8_forward(m_pStr, CurrentOffset);
+		if(CurrentOffset == PrevOffset)
+			break;
+		DisplayOffset++;
+	}
+	return DisplayOffset;
+}
+
+size_t CLineInput::OffsetFromDisplayToActual(size_t DisplayOffset) const
+{
+	if(!IsHidden())
+		return DisplayOffset;
+	size_t ActualOffset = 0;
+	for(size_t i = 0; i < DisplayOffset; i++)
+	{
+		const size_t PrevOffset = ActualOffset;
+		ActualOffset = str_utf8_forward(m_pStr, ActualOffset);
+		if(ActualOffset == PrevOffset)
+			break;
+	}
+	return ActualOffset;
+}
+
+bool CLineInput::ProcessInput(const IInput::CEvent &Event)
+{
+	// update derived attributes to handle external changes to the buffer
+	UpdateStrData();
+
+	const size_t OldCursorPos = m_CursorPos;
+	const bool Selecting = Input()->ShiftIsPressed();
+	const size_t SelectionLength = GetSelectionLength();
+	bool KeyHandled = false;
+
+	if((Event.m_Flags & IInput::FLAG_TEXT) && !(KEY_LCTRL <= Event.m_Key && Event.m_Key <= KEY_RGUI))
+	{
+		SetRange(Event.m_aText, m_SelectionStart, m_SelectionEnd);
 	}
 
 	if(Event.m_Flags & IInput::FLAG_PRESS)
 	{
-		int Key = Event.m_Key;
-		if(Key == KEY_BACKSPACE)
+		const bool ModPressed = Input()->ModifierIsPressed();
+		const bool AltPressed = Input()->AltIsPressed();
+
+#ifdef CONF_PLATFORM_MACOSX
+		const bool MoveWord = AltPressed && !ModPressed;
+#else
+		const bool MoveWord = ModPressed && !AltPressed;
+#endif
+
+		if(Event.m_Key == KEY_BACKSPACE)
 		{
-			if((ModifyFlags & LINE_INPUT_MODIFY_DONT_DELETE) == 0 && CursorPos > 0)
+			if(SelectionLength && !MoveWord)
 			{
-				int NewCursorPos = str_utf8_rewind(pStr, CursorPos);
-				int CharSize = CursorPos - NewCursorPos;
-				mem_move(pStr + NewCursorPos, pStr + CursorPos, Len - NewCursorPos - CharSize + 1); // +1 == null term
-				CursorPos = NewCursorPos;
-				Len -= CharSize;
-				if(CharSize > 0)
-					--NumChars;
-			}
-			Changes |= ELineInputChanges::LINE_INPUT_CHANGE_CHARACTERS_DELETE;
-		}
-		else if(Key == KEY_DELETE)
-		{
-			if((ModifyFlags & LINE_INPUT_MODIFY_DONT_DELETE) == 0 && CursorPos < Len)
-			{
-				int p = str_utf8_forward(pStr, CursorPos);
-				int CharSize = p - CursorPos;
-				mem_move(pStr + CursorPos, pStr + CursorPos + CharSize, Len - CursorPos - CharSize + 1); // +1 == null term
-				Len -= CharSize;
-				if(CharSize > 0)
-					--NumChars;
-			}
-			Changes |= ELineInputChanges::LINE_INPUT_CHANGE_CHARACTERS_DELETE;
-		}
-		else if(Key == KEY_LEFT)
-		{
-			if(ModifierKey == KEY_LCTRL || ModifierKey == KEY_RCTRL || ModifierKey == KEY_LGUI || ModifierKey == KEY_RGUI)
-			{
-				bool MovedCursor = false;
-				int OldCursorPos = CursorPos;
-				CursorPos = str_utf8_rewind(pStr, CursorPos);
-				if(OldCursorPos != CursorPos)
-					MovedCursor = true;
-				bool WasNonWordChar = IsNotAWordChar(pStr[CursorPos]);
-				while((!WasNonWordChar && !IsNotAWordChar(pStr[CursorPos])) || (WasNonWordChar && IsNotAWordChar(pStr[CursorPos])))
-				{
-					CursorPos = str_utf8_rewind(pStr, CursorPos);
-					if(CursorPos == 0)
-						break;
-				}
-				if(MovedCursor && ((!WasNonWordChar && IsNotAWordChar(pStr[CursorPos])) || (WasNonWordChar && !IsNotAWordChar(pStr[CursorPos]))))
-					CursorPos = str_utf8_forward(pStr, CursorPos);
-				Changes |= ELineInputChanges::LINE_INPUT_CHANGE_WARP_CURSOR;
+				SetRange("", m_SelectionStart, m_SelectionEnd);
 			}
 			else
 			{
-				if(CursorPos > 0)
-					CursorPos = str_utf8_rewind(pStr, CursorPos);
-				Changes |= ELineInputChanges::LINE_INPUT_CHANGE_CURSOR;
+				// If in MoveWord-mode, backspace will delete the word before the selection
+				if(SelectionLength)
+					m_SelectionEnd = m_CursorPos = m_SelectionStart;
+				if(m_CursorPos > 0)
+				{
+					size_t NewCursorPos = m_CursorPos;
+					MoveCursor(REWIND, MoveWord, m_pStr, m_Len, &NewCursorPos);
+					SetRange("", NewCursorPos, m_CursorPos);
+				}
+				m_SelectionStart = m_SelectionEnd = m_CursorPos;
 			}
 		}
-		else if(Key == KEY_RIGHT)
+		else if(Event.m_Key == KEY_DELETE)
 		{
-			if(ModifierKey == KEY_LCTRL || ModifierKey == KEY_RCTRL || ModifierKey == KEY_LGUI || ModifierKey == KEY_RGUI)
+			if(SelectionLength && !MoveWord)
 			{
-				bool WasNonWordChar = IsNotAWordChar(pStr[CursorPos]);
-				while((!WasNonWordChar && !IsNotAWordChar(pStr[CursorPos])) || (WasNonWordChar && IsNotAWordChar(pStr[CursorPos])))
-				{
-					CursorPos = str_utf8_forward(pStr, CursorPos);
-					if(CursorPos >= Len)
-						break;
-				}
-				Changes |= ELineInputChanges::LINE_INPUT_CHANGE_WARP_CURSOR;
+				SetRange("", m_SelectionStart, m_SelectionEnd);
 			}
 			else
 			{
-				if(CursorPos < Len)
-					CursorPos = str_utf8_forward(pStr, CursorPos);
-				Changes |= ELineInputChanges::LINE_INPUT_CHANGE_CURSOR;
+				// If in MoveWord-mode, delete will delete the word after the selection
+				if(SelectionLength)
+					m_SelectionStart = m_CursorPos = m_SelectionEnd;
+				if(m_CursorPos < m_Len)
+				{
+					size_t EndCursorPos = m_CursorPos;
+					MoveCursor(FORWARD, MoveWord, m_pStr, m_Len, &EndCursorPos);
+					SetRange("", m_CursorPos, EndCursorPos);
+				}
+				m_SelectionStart = m_SelectionEnd = m_CursorPos;
 			}
 		}
-		else if(Key == KEY_HOME)
+		else if(Event.m_Key == KEY_LEFT)
 		{
-			CursorPos = 0;
-			Changes |= ELineInputChanges::LINE_INPUT_CHANGE_WARP_CURSOR;
+			if(SelectionLength && !Selecting)
+			{
+				m_CursorPos = m_SelectionStart;
+			}
+			else if(m_CursorPos > 0)
+			{
+				MoveCursor(REWIND, MoveWord, m_pStr, m_Len, &m_CursorPos);
+				if(Selecting)
+				{
+					if(m_SelectionStart == OldCursorPos) // expand start first
+						m_SelectionStart = m_CursorPos;
+					else if(m_SelectionEnd == OldCursorPos)
+						m_SelectionEnd = m_CursorPos;
+				}
+			}
+
+			if(!Selecting)
+				m_SelectionStart = m_SelectionEnd = m_CursorPos;
 		}
-		else if(Key == KEY_END)
+		else if(Event.m_Key == KEY_RIGHT)
 		{
-			CursorPos = Len;
-			Changes |= ELineInputChanges::LINE_INPUT_CHANGE_WARP_CURSOR;
+			if(SelectionLength && !Selecting)
+			{
+				m_CursorPos = m_SelectionEnd;
+			}
+			else if(m_CursorPos < m_Len)
+			{
+				MoveCursor(FORWARD, MoveWord, m_pStr, m_Len, &m_CursorPos);
+				if(Selecting)
+				{
+					if(m_SelectionEnd == OldCursorPos) // expand end first
+						m_SelectionEnd = m_CursorPos;
+					else if(m_SelectionStart == OldCursorPos)
+						m_SelectionStart = m_CursorPos;
+				}
+			}
+
+			if(!Selecting)
+				m_SelectionStart = m_SelectionEnd = m_CursorPos;
+		}
+		else if(Event.m_Key == KEY_HOME)
+		{
+			if(Selecting)
+			{
+				if(SelectionLength && m_CursorPos == m_SelectionEnd)
+					m_SelectionEnd = m_SelectionStart;
+			}
+			else
+				m_SelectionEnd = 0;
+			m_CursorPos = 0;
+			m_SelectionStart = 0;
+		}
+		else if(Event.m_Key == KEY_END)
+		{
+			if(Selecting)
+			{
+				if(SelectionLength && m_CursorPos == m_SelectionStart)
+					m_SelectionStart = m_SelectionEnd;
+			}
+			else
+				m_SelectionStart = m_Len;
+			m_CursorPos = m_Len;
+			m_SelectionEnd = m_Len;
+		}
+		else if(ModPressed && !AltPressed && Event.m_Key == KEY_V)
+		{
+			const char *pClipboardText = Input()->GetClipboardText();
+			if(pClipboardText)
+			{
+				std::string ClipboardText = Input()->GetClipboardText();
+				if(m_pfnClipboardLineCallback)
+				{
+					// Split clipboard text into multiple lines. Send all complete lines to callback.
+					// The lineinput is set to the last clipboard line.
+					bool FirstLine = true;
+					size_t i, Begin = 0;
+					for(i = 0; i < ClipboardText.length(); i++)
+					{
+						if(ClipboardText[i] == '\n')
+						{
+							if(i == Begin)
+							{
+								Begin++;
+								continue;
+							}
+							std::string Line = ClipboardText.substr(Begin, i - Begin + 1);
+							if(FirstLine)
+							{
+								str_sanitize_cc(Line.data());
+								SetRange(Line.c_str(), m_SelectionStart, m_SelectionEnd);
+								FirstLine = false;
+								Line = GetString();
+							}
+							Begin = i + 1;
+							m_pfnClipboardLineCallback(Line.c_str());
+						}
+					}
+					std::string Line = ClipboardText.substr(Begin, i - Begin + 1);
+					str_sanitize_cc(Line.data());
+					if(FirstLine)
+						SetRange(Line.c_str(), m_SelectionStart, m_SelectionEnd);
+					else
+						Set(Line.c_str());
+				}
+				else
+				{
+					str_sanitize_cc(ClipboardText.data());
+					SetRange(ClipboardText.c_str(), m_SelectionStart, m_SelectionEnd);
+				}
+			}
+			KeyHandled = true;
+		}
+		else if(ModPressed && !AltPressed && (Event.m_Key == KEY_C || Event.m_Key == KEY_X) && SelectionLength)
+		{
+			char *pSelection = m_pStr + m_SelectionStart;
+			const char TempChar = pSelection[SelectionLength];
+			pSelection[SelectionLength] = '\0';
+			Input()->SetClipboardText(pSelection);
+			pSelection[SelectionLength] = TempChar;
+			if(Event.m_Key == KEY_X)
+				SetRange("", m_SelectionStart, m_SelectionEnd);
+			KeyHandled = true;
+		}
+		else if(ModPressed && !AltPressed && Event.m_Key == KEY_A)
+		{
+			m_SelectionStart = 0;
+			m_SelectionEnd = m_CursorPos = m_Len;
 		}
 	}
 
-	*pNumCharsPtr = NumChars;
-	*pCursorPosPtr = CursorPos;
-	*pStrLenPtr = Len;
-
-	return Changes;
+	m_WasChanged |= OldCursorPos != m_CursorPos;
+	m_WasChanged |= SelectionLength != GetSelectionLength();
+	return m_WasChanged || KeyHandled;
 }
 
-void CLineInput::ProcessInput(IInput::CEvent e)
+STextBoundingBox CLineInput::Render(const CUIRect *pRect, float FontSize, int Align, bool Changed, float LineWidth)
 {
-	Manipulate(e, m_aStr, MAX_SIZE, MAX_CHARS, &m_Len, &m_CursorPos, &m_NumChars, 0, 0);
+	const char *pDisplayStr = GetDisplayedString();
+	const bool HasComposition = Input()->HasComposition();
+
+	if(pDisplayStr[0] == '\0' && !HasComposition && m_pEmptyText != nullptr)
+	{
+		pDisplayStr = m_pEmptyText;
+		m_MouseSelection.m_Selecting = false;
+		TextRender()->TextColor(1.0f, 1.0f, 1.0f, 0.75f);
+	}
+
+	CTextCursor Cursor;
+	if(IsActive())
+	{
+		const size_t CursorOffset = GetCursorOffset();
+		const size_t DisplayCursorOffset = OffsetFromActualToDisplay(CursorOffset);
+		const size_t CompositionStart = CursorOffset + Input()->GetCompositionCursor();
+		const size_t DisplayCompositionStart = OffsetFromActualToDisplay(CompositionStart);
+		const size_t CaretOffset = HasComposition ? DisplayCompositionStart : DisplayCursorOffset;
+
+		std::string DisplayStrBuffer;
+		if(HasComposition)
+		{
+			const std::string DisplayStr = std::string(pDisplayStr);
+			DisplayStrBuffer = DisplayStr.substr(0, DisplayCursorOffset) + Input()->GetComposition() + DisplayStr.substr(DisplayCursorOffset);
+			pDisplayStr = DisplayStrBuffer.c_str();
+		}
+
+		const STextBoundingBox BoundingBox = TextRender()->TextBoundingBox(FontSize, pDisplayStr, -1, LineWidth);
+		const vec2 CursorPos = CUI::CalcAlignedCursorPos(pRect, BoundingBox.Size(), Align);
+
+		TextRender()->SetCursor(&Cursor, CursorPos.x, CursorPos.y, FontSize, TEXTFLAG_RENDER);
+		Cursor.m_LineWidth = LineWidth;
+		Cursor.m_ForceCursorRendering = Changed;
+		Cursor.m_PressMouse.x = m_MouseSelection.m_PressMouse.x;
+		Cursor.m_ReleaseMouse.x = m_MouseSelection.m_ReleaseMouse.x;
+		if(LineWidth < 0.0f)
+		{
+			// Using a Y position that's always inside the line input makes it so the selection does not reset when
+			// the mouse is moved outside the line input while selecting, which would otherwise be very inconvenient.
+			// This is a single line cursor, so we don't need the Y position to support selection over multiple lines.
+			Cursor.m_PressMouse.y = CursorPos.y + BoundingBox.m_H / 2.0f;
+			Cursor.m_ReleaseMouse.y = CursorPos.y + BoundingBox.m_H / 2.0f;
+		}
+		else
+		{
+			Cursor.m_PressMouse.y = m_MouseSelection.m_PressMouse.y;
+			Cursor.m_ReleaseMouse.y = m_MouseSelection.m_ReleaseMouse.y;
+		}
+
+		if(HasComposition)
+		{
+			// We need to track the last composition cursor position separately, because the composition
+			// cursor movement does not cause an input event that would set the Changed variable.
+			Cursor.m_ForceCursorRendering |= m_LastCompositionCursorPos != CaretOffset;
+			m_LastCompositionCursorPos = CaretOffset;
+			const size_t DisplayCompositionEnd = DisplayCursorOffset + Input()->GetCompositionLength();
+			Cursor.m_CursorMode = TEXT_CURSOR_CURSOR_MODE_SET;
+			TextRender()->UTF8OffToDecodedOff(pDisplayStr, CaretOffset, Cursor.m_CursorCharacter);
+			Cursor.m_CalculateSelectionMode = TEXT_CURSOR_SELECTION_MODE_SET;
+			Cursor.m_SelectionHeightFactor = 0.1f;
+			TextRender()->UTF8OffToDecodedOff(pDisplayStr, DisplayCursorOffset, Cursor.m_SelectionStart);
+			TextRender()->UTF8OffToDecodedOff(pDisplayStr, DisplayCompositionEnd, Cursor.m_SelectionEnd);
+			TextRender()->TextSelectionColor(1.0f, 1.0f, 1.0f, 0.8f);
+			TextRender()->TextEx(&Cursor, pDisplayStr);
+			TextRender()->TextSelectionColor(TextRender()->DefaultTextSelectionColor());
+		}
+		else if(GetSelectionLength())
+		{
+			const size_t Start = OffsetFromActualToDisplay(GetSelectionStart());
+			const size_t End = OffsetFromActualToDisplay(GetSelectionEnd());
+			Cursor.m_CursorMode = m_MouseSelection.m_Selecting ? TEXT_CURSOR_CURSOR_MODE_CALCULATE : TEXT_CURSOR_CURSOR_MODE_SET;
+			TextRender()->UTF8OffToDecodedOff(pDisplayStr, CaretOffset, Cursor.m_CursorCharacter);
+			Cursor.m_CalculateSelectionMode = m_MouseSelection.m_Selecting ? TEXT_CURSOR_SELECTION_MODE_CALCULATE : TEXT_CURSOR_SELECTION_MODE_SET;
+			TextRender()->UTF8OffToDecodedOff(pDisplayStr, Start, Cursor.m_SelectionStart);
+			TextRender()->UTF8OffToDecodedOff(pDisplayStr, End, Cursor.m_SelectionEnd);
+			TextRender()->TextEx(&Cursor, pDisplayStr);
+		}
+		else
+		{
+			Cursor.m_CursorMode = m_MouseSelection.m_Selecting ? TEXT_CURSOR_CURSOR_MODE_CALCULATE : TEXT_CURSOR_CURSOR_MODE_SET;
+			TextRender()->UTF8OffToDecodedOff(pDisplayStr, CaretOffset, Cursor.m_CursorCharacter);
+			Cursor.m_CalculateSelectionMode = m_MouseSelection.m_Selecting ? TEXT_CURSOR_SELECTION_MODE_CALCULATE : TEXT_CURSOR_SELECTION_MODE_NONE;
+			TextRender()->TextEx(&Cursor, pDisplayStr);
+		}
+
+		if(Cursor.m_CursorMode == TEXT_CURSOR_CURSOR_MODE_CALCULATE)
+		{
+			int NewCursorOffset;
+			TextRender()->DecodedOffToUTF8Off(pDisplayStr, Cursor.m_CursorCharacter, NewCursorOffset);
+			if(NewCursorOffset >= 0)
+			{
+				SetCursorOffset(OffsetFromDisplayToActual(NewCursorOffset));
+			}
+		}
+		if(Cursor.m_CalculateSelectionMode == TEXT_CURSOR_SELECTION_MODE_CALCULATE)
+		{
+			int NewSelectionStart, NewSelectionEnd;
+			TextRender()->DecodedOffToUTF8Off(pDisplayStr, Cursor.m_SelectionStart, NewSelectionStart);
+			TextRender()->DecodedOffToUTF8Off(pDisplayStr, Cursor.m_SelectionEnd, NewSelectionEnd);
+			if(NewSelectionStart >= 0 && NewSelectionEnd >= 0)
+			{
+				SetSelection(OffsetFromDisplayToActual(NewSelectionStart), OffsetFromDisplayToActual(NewSelectionEnd));
+			}
+		}
+
+		m_CaretPosition = Cursor.m_CursorRenderedPosition;
+
+		STextBoundingBox CaretBoundingBox = TextRender()->TextBoundingBox(FontSize, pDisplayStr, DisplayCursorOffset, LineWidth);
+		CaretBoundingBox.MoveBy(CursorPos);
+		SetCompositionWindowPosition(vec2(CaretBoundingBox.Right(), CaretBoundingBox.Bottom()), CaretBoundingBox.m_H);
+	}
+	else
+	{
+		const STextBoundingBox BoundingBox = TextRender()->TextBoundingBox(FontSize, pDisplayStr, -1, LineWidth);
+		const vec2 CursorPos = CUI::CalcAlignedCursorPos(pRect, BoundingBox.Size(), Align);
+		TextRender()->SetCursor(&Cursor, CursorPos.x, CursorPos.y, FontSize, TEXTFLAG_RENDER);
+		Cursor.m_LineWidth = LineWidth;
+		TextRender()->TextEx(&Cursor, pDisplayStr);
+	}
+
+	TextRender()->TextColor(TextRender()->DefaultTextColor());
+
+	return Cursor.BoundingBox();
+}
+
+void CLineInput::RenderCandidates()
+{
+	if(!Input()->HasComposition() || !Input()->GetCandidateCount())
+		return;
+
+	const float FontSize = 7.0f;
+	const float Padding = 1.0f;
+	const float Margin = 4.0f;
+	const float Height = 300.0f;
+	const float Width = Height * Graphics()->ScreenAspect();
+	const int ScreenWidth = Graphics()->ScreenWidth();
+	const int ScreenHeight = Graphics()->ScreenHeight();
+
+	Graphics()->MapScreen(0.0f, 0.0f, Width, Height);
+
+	// Determine longest candidate width
+	float LongestCandidateWidth = 0.0f;
+	for(int i = 0; i < Input()->GetCandidateCount(); ++i)
+		LongestCandidateWidth = maximum(LongestCandidateWidth, TextRender()->TextWidth(FontSize, Input()->GetCandidate(i)));
+
+	const float NumOffset = 8.0f;
+	const float RectWidth = LongestCandidateWidth + Margin + NumOffset + 2.0f * Padding;
+	const float RectHeight = Input()->GetCandidateCount() * (FontSize + 2.0f * Padding) + Margin;
+
+	vec2 Position = ms_CompositionWindowPosition / vec2(ScreenWidth, ScreenHeight) * vec2(Width, Height);
+	Position.y += Margin;
+
+	// Move candidate window left if needed
+	if(Position.x + RectWidth + Margin > Width)
+		Position.x -= Position.x + RectWidth + Margin - Width;
+
+	// Move candidate window up if needed
+	if(Position.y + RectHeight + Margin > Height)
+		Position.y -= RectHeight + ms_CompositionLineHeight / ScreenHeight * Height + 2.0f * Margin;
+
+	Graphics()->TextureClear();
+	Graphics()->QuadsBegin();
+	Graphics()->BlendNormal();
+
+	// Draw window shadow
+	Graphics()->SetColor(0.0f, 0.0f, 0.0f, 0.8f);
+	IGraphics::CQuadItem Quad = IGraphics::CQuadItem(Position.x + 0.75f, Position.y + 0.75f, RectWidth, RectHeight);
+	Graphics()->QuadsDrawTL(&Quad, 1);
+
+	// Draw window background
+	Graphics()->SetColor(0.15f, 0.15f, 0.15f, 1.0f);
+	Quad = IGraphics::CQuadItem(Position.x, Position.y, RectWidth, RectHeight);
+	Graphics()->QuadsDrawTL(&Quad, 1);
+
+	// Draw selected entry highlight
+	Graphics()->SetColor(0.1f, 0.4f, 0.8f, 1.0f);
+	Quad = IGraphics::CQuadItem(Position.x + Margin / 4.0f, Position.y + Margin / 2.0f + Input()->GetCandidateSelectedIndex() * (FontSize + 2.0f * Padding), RectWidth - Margin / 2.0f, FontSize + 2.0f * Padding);
+	Graphics()->QuadsDrawTL(&Quad, 1);
+	Graphics()->QuadsEnd();
+
+	// Draw candidates
+	for(int i = 0; i < Input()->GetCandidateCount(); ++i)
+	{
+		char aBuf[3];
+		str_format(aBuf, sizeof(aBuf), "%d.", (i + 1) % 10);
+
+		const float PosX = Position.x + Margin / 2.0f + Padding;
+		const float PosY = Position.y + Margin / 2.0f + i * (FontSize + 2.0f * Padding) + Padding;
+		TextRender()->TextColor(0.6f, 0.6f, 0.6f, 1.0f);
+		TextRender()->Text(PosX, PosY, FontSize, aBuf);
+		TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
+		TextRender()->Text(PosX + NumOffset, PosY, FontSize, Input()->GetCandidate(i));
+	}
+}
+
+void CLineInput::SetCompositionWindowPosition(vec2 Anchor, float LineHeight)
+{
+	float ScreenX0, ScreenY0, ScreenX1, ScreenY1;
+	const int ScreenWidth = Graphics()->ScreenWidth();
+	const int ScreenHeight = Graphics()->ScreenHeight();
+	Graphics()->GetScreen(&ScreenX0, &ScreenY0, &ScreenX1, &ScreenY1);
+
+	const vec2 ScreenScale = vec2(ScreenWidth / (ScreenX1 - ScreenX0), ScreenHeight / (ScreenY1 - ScreenY0));
+	ms_CompositionWindowPosition = Anchor * ScreenScale;
+	ms_CompositionLineHeight = LineHeight * ScreenScale.y;
+	Input()->SetCompositionWindowPosition(ms_CompositionWindowPosition.x, ms_CompositionWindowPosition.y - ms_CompositionLineHeight, ms_CompositionLineHeight);
+}
+
+void CLineInput::Activate(EInputPriority Priority)
+{
+	if(IsActive())
+		return;
+	if(ms_ActiveInputPriority != EInputPriority::NONE && Priority < ms_ActiveInputPriority)
+		return; // do not replace a higher priority input
+	if(ms_pActiveInput)
+		ms_pActiveInput->OnDeactivate();
+	ms_pActiveInput = this;
+	ms_pActiveInput->OnActivate();
+	ms_ActiveInputPriority = Priority;
+}
+
+void CLineInput::Deactivate()
+{
+	if(!IsActive())
+		return;
+	ms_pActiveInput->OnDeactivate();
+	ms_pActiveInput = nullptr;
+	ms_ActiveInputPriority = EInputPriority::NONE;
+}
+
+void CLineInput::OnActivate()
+{
+	Input()->StartTextInput();
+}
+
+void CLineInput::OnDeactivate()
+{
+	Input()->StopTextInput();
+	m_MouseSelection.m_Selecting = false;
+}
+
+void CLineInputNumber::SetInteger(int Number, int Base)
+{
+	char aBuf[32];
+	switch(Base)
+	{
+	case 10:
+		str_format(aBuf, sizeof(aBuf), "%d", Number);
+		break;
+	case 16:
+		str_format(aBuf, sizeof(aBuf), "%06X", Number);
+		break;
+	default:
+		dbg_assert(false, "Base unsupported");
+		return;
+	}
+	if(str_comp(aBuf, GetDisplayedString()) != 0)
+		Set(aBuf);
+}
+
+int CLineInputNumber::GetInteger(int Base) const
+{
+	return str_toint_base(GetString(), Base);
+}
+
+void CLineInputNumber::SetFloat(float Number)
+{
+	char aBuf[32];
+	str_format(aBuf, sizeof(aBuf), "%.3f", Number);
+	if(str_comp(aBuf, GetDisplayedString()) != 0)
+		Set(aBuf);
+}
+
+float CLineInputNumber::GetFloat() const
+{
+	return str_tofloat(GetString());
 }

--- a/src/game/client/lineinput.h
+++ b/src/game/client/lineinput.h
@@ -3,55 +3,221 @@
 #ifndef GAME_CLIENT_LINEINPUT_H
 #define GAME_CLIENT_LINEINPUT_H
 
+#include <base/vmath.h>
+
+#include <engine/client.h>
+#include <engine/graphics.h>
 #include <engine/input.h>
+#include <engine/textrender.h>
+
+#include <game/client/ui_rect.h>
+
+enum class EInputPriority
+{
+	NONE = 0,
+	UI,
+	CHAT,
+	CONSOLE,
+};
 
 // line input helper
 class CLineInput
 {
-	enum
+public:
+	struct SMouseSelection
 	{
-		MAX_SIZE = 512,
-		MAX_CHARS = MAX_SIZE / 2,
+		bool m_Selecting = false;
+		vec2 m_PressMouse = vec2(0.0f, 0.0f);
+		vec2 m_ReleaseMouse = vec2(0.0f, 0.0f);
+		vec2 m_Offset = vec2(0.0f, 0.0f);
 	};
-	char m_aStr[MAX_SIZE];
-	int m_Len;
-	int m_CursorPos;
-	int m_NumChars;
 
-	char m_aDisplayStr[MAX_SIZE + IInput::INPUT_TEXT_SIZE + 2];
-	int m_FakeLen;
-	int m_FakeCursorPos;
+	typedef std::function<void(const char *pLine)> FClipboardLineCallback;
+
+private:
+	static IClient *ms_pClient;
+	static IGraphics *ms_pGraphics;
+	static IInput *ms_pInput;
+	static ITextRender *ms_pTextRender;
+
+	static IClient *Client() { return ms_pClient; }
+	static IGraphics *Graphics() { return ms_pGraphics; }
+	static IInput *Input() { return ms_pInput; }
+	static ITextRender *TextRender() { return ms_pTextRender; }
+
+	static CLineInput *ms_pActiveInput;
+	static EInputPriority ms_ActiveInputPriority;
+
+	static vec2 ms_CompositionWindowPosition;
+	static float ms_CompositionLineHeight;
+
+	static char ms_aStars[128];
+
+	char *m_pStr = nullptr; // explicitly set to nullptr outside of contructor, so SetBuffer works in this case
+	size_t m_MaxSize;
+	size_t m_MaxChars;
+	size_t m_Len;
+	size_t m_NumChars;
+
+	size_t m_CursorPos;
+	size_t m_SelectionStart;
+	size_t m_SelectionEnd;
+
+	float m_ScrollOffset;
+	float m_ScrollOffsetChange;
+	vec2 m_CaretPosition;
+	SMouseSelection m_MouseSelection;
+	size_t m_LastCompositionCursorPos;
+
+	bool m_Hidden;
+	const char *m_pEmptyText;
+	FClipboardLineCallback m_pfnClipboardLineCallback;
+	bool m_WasChanged;
+
+	char m_ClearButtonId;
+
+	void UpdateStrData();
+	enum EMoveDirection
+	{
+		FORWARD,
+		REWIND
+	};
+	static void MoveCursor(EMoveDirection Direction, bool MoveWord, const char *pStr, size_t MaxSize, size_t *pCursorPos);
+	static void SetCompositionWindowPosition(vec2 Anchor, float LineHeight);
+
+	void OnActivate();
+	void OnDeactivate();
 
 public:
-	enum ELineInputChanges
+	static void Init(IClient *pClient, IGraphics *pGraphics, IInput *pInput, ITextRender *pTextRender)
 	{
-		// string was changed
-		LINE_INPUT_CHANGE_STRING = 1 << 0,
-		// characters were removed from the string
-		LINE_INPUT_CHANGE_CHARACTERS_DELETE = 1 << 1,
-		// cursor was changed or tried to change(e.g. pressing right at the last char in the string)
-		LINE_INPUT_CHANGE_CURSOR = 1 << 2,
-		LINE_INPUT_CHANGE_WARP_CURSOR = 1 << 3,
-	};
-	enum ELineInputModifyFlags
-	{
-		// don't delete characters
-		LINE_INPUT_MODIFY_DONT_DELETE = 1 << 0,
-	};
-	static int32_t Manipulate(IInput::CEvent e, char *pStr, int StrMaxSize, int StrMaxChars, int *pStrLenPtr, int *pCursorPosPtr, int *pNumCharsPtr, int32_t ModifyFlags, int ModifierKey);
+		ms_pClient = pClient;
+		ms_pGraphics = pGraphics;
+		ms_pInput = pInput;
+		ms_pTextRender = pTextRender;
+	}
+	static void RenderCandidates();
 
-	CLineInput();
+	static CLineInput *GetActiveInput() { return ms_pActiveInput; }
+
+	CLineInput()
+	{
+		SetBuffer(nullptr, 0, 0);
+	}
+
+	CLineInput(char *pStr, size_t MaxSize)
+	{
+		SetBuffer(pStr, MaxSize);
+	}
+
+	CLineInput(char *pStr, size_t MaxSize, size_t MaxChars)
+	{
+		SetBuffer(pStr, MaxSize, MaxChars);
+	}
+
+	void SetBuffer(char *pStr, size_t MaxSize) { SetBuffer(pStr, MaxSize, MaxSize); }
+	void SetBuffer(char *pStr, size_t MaxSize, size_t MaxChars);
+
 	void Clear();
-	void ProcessInput(IInput::CEvent e);
-	void Editing(const char *pString, int Cursor);
 	void Set(const char *pString);
-	void SetRange(const char *pString, int Begin, int End);
-	void Insert(const char *pString, int Begin);
+	void SetRange(const char *pString, size_t Begin, size_t End);
+	void Insert(const char *pString, size_t Begin);
 	void Append(const char *pString);
-	const char *GetString(bool Editing = false) const { return Editing ? m_aDisplayStr : m_aStr; }
-	int GetLength(bool Editing = false) const { return Editing ? m_FakeLen : m_Len; }
-	int GetCursorOffset(bool Editing = false) const { return Editing ? m_FakeCursorPos : m_CursorPos; }
-	void SetCursorOffset(int Offset) { m_CursorPos = Offset > m_Len ? m_Len : Offset < 0 ? 0 : Offset; }
+
+	const char *GetString() const { return m_pStr; }
+	const char *GetDisplayedString();
+	size_t GetMaxSize() const { return m_MaxSize; }
+	size_t GetMaxChars() const { return m_MaxChars; }
+	size_t GetLength() const { return m_Len; }
+	size_t GetNumChars() const { return m_NumChars; }
+	bool IsEmpty() const { return GetLength() == 0; }
+
+	size_t GetCursorOffset() const { return m_CursorPos; }
+	void SetCursorOffset(size_t Offset);
+	size_t GetSelectionStart() const { return m_SelectionStart; }
+	size_t GetSelectionEnd() const { return m_SelectionEnd; }
+	size_t GetSelectionLength() const { return m_SelectionEnd - m_SelectionStart; }
+	bool HasSelection() const { return GetSelectionLength() > 0; }
+	void SetSelection(size_t Start, size_t End);
+	void SelectNothing() { SetSelection(GetCursorOffset(), GetCursorOffset()); }
+	void SelectAll() { SetSelection(0, GetLength()); }
+
+	size_t OffsetFromActualToDisplay(size_t ActualOffset) const;
+	size_t OffsetFromDisplayToActual(size_t DisplayOffset) const;
+
+	// used either for vertical or horizontal scrolling
+	float GetScrollOffset() const { return m_ScrollOffset; }
+	void SetScrollOffset(float ScrollOffset) { m_ScrollOffset = ScrollOffset; }
+	float GetScrollOffsetChange() const { return m_ScrollOffsetChange; }
+	void SetScrollOffsetChange(float ScrollOffsetChange) { m_ScrollOffsetChange = ScrollOffsetChange; }
+
+	vec2 GetCaretPosition() const { return m_CaretPosition; } // only updated while the input is active
+
+	bool IsHidden() const { return m_Hidden; }
+	void SetHidden(bool Hidden) { m_Hidden = Hidden; }
+
+	const char *GetEmptyText() const { return m_pEmptyText; }
+	void SetEmptyText(const char *pText) { m_pEmptyText = pText; }
+
+	void SetClipboardLineCallback(FClipboardLineCallback pfnClipboardLineCallback) { m_pfnClipboardLineCallback = pfnClipboardLineCallback; }
+
+	bool ProcessInput(const IInput::CEvent &Event);
+	bool WasChanged()
+	{
+		const bool Changed = m_WasChanged;
+		m_WasChanged = false;
+		return Changed;
+	}
+
+	STextBoundingBox Render(const CUIRect *pRect, float FontSize, int Align, bool Changed, float LineWidth);
+	SMouseSelection *GetMouseSelection() { return &m_MouseSelection; }
+
+	const void *GetClearButtonId() const { return &m_ClearButtonId; }
+
+	bool IsActive() const { return GetActiveInput() == this; }
+	void Activate(EInputPriority Priority);
+	void Deactivate();
+};
+
+template<size_t MaxSize, size_t MaxChars = MaxSize>
+class CLineInputBuffered : public CLineInput
+{
+	char m_aBuffer[MaxSize];
+
+public:
+	CLineInputBuffered() :
+		CLineInput()
+	{
+		m_aBuffer[0] = '\0';
+		SetBuffer(m_aBuffer, MaxSize, MaxChars);
+	}
+};
+
+class CLineInputNumber : public CLineInputBuffered<32>
+{
+public:
+	CLineInputNumber() :
+		CLineInputBuffered()
+	{
+	}
+
+	CLineInputNumber(int Number) :
+		CLineInputBuffered()
+	{
+		SetInteger(Number);
+	}
+
+	CLineInputNumber(float Number) :
+		CLineInputBuffered()
+	{
+		SetFloat(Number);
+	}
+
+	void SetInteger(int Number, int Base = 10);
+	int GetInteger(int Base = 10) const;
+
+	void SetFloat(float Number);
+	float GetFloat() const;
 };
 
 #endif

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -802,11 +802,9 @@ public:
 		m_pFileDialogTitle = nullptr;
 		m_pFileDialogButtonText = nullptr;
 		m_pFileDialogUser = nullptr;
-		m_aFileDialogFileName[0] = '\0';
 		m_aFileDialogCurrentFolder[0] = '\0';
 		m_aFileDialogCurrentLink[0] = '\0';
 		m_aFilesSelectedName[0] = '\0';
-		m_aFileDialogFilterString[0] = '\0';
 		m_pFileDialogPath = m_aFileDialogCurrentFolder;
 		m_FileDialogOpening = false;
 		m_FilesSelectedIndex = -1;
@@ -858,9 +856,6 @@ public:
 		m_CheckerTexture.Invalidate();
 		m_BackgroundTexture.Invalidate();
 		m_CursorTexture.Invalidate();
-
-		m_CommandBox = 0.0f;
-		m_aSettingsCommand[0] = 0;
 
 		ms_pUiGotContext = nullptr;
 
@@ -975,15 +970,15 @@ public:
 	const char *m_pFileDialogButtonText;
 	bool (*m_pfnFileDialogFunc)(const char *pFileName, int StorageType, void *pUser);
 	void *m_pFileDialogUser;
-	char m_aFileDialogFileName[IO_MAX_PATH_LENGTH];
+	CLineInputBuffered<IO_MAX_PATH_LENGTH> m_FileDialogFileNameInput;
 	char m_aFileDialogCurrentFolder[IO_MAX_PATH_LENGTH];
 	char m_aFileDialogCurrentLink[IO_MAX_PATH_LENGTH];
 	char m_aFilesSelectedName[IO_MAX_PATH_LENGTH];
-	char m_aFileDialogFilterString[IO_MAX_PATH_LENGTH];
+	CLineInputBuffered<IO_MAX_PATH_LENGTH> m_FileDialogFilterInput;
 	char *m_pFileDialogPath;
 	int m_FileDialogFileType;
 	int m_FilesSelectedIndex;
-	char m_aFileDialogNewFolderName[IO_MAX_PATH_LENGTH];
+	CLineInputBuffered<IO_MAX_PATH_LENGTH> m_FileDialogNewFolderNameInput;
 	IGraphics::CTextureHandle m_FilePreviewImage;
 	EPreviewImageState m_PreviewImageState;
 	CImageInfo m_FilePreviewImageInfo;
@@ -1146,8 +1141,7 @@ public:
 
 	static void EnvelopeEval(int TimeOffsetMillis, int Env, ColorRGBA &Channels, void *pUser);
 
-	float m_CommandBox;
-	char m_aSettingsCommand[256];
+	CLineInputBuffered<256> m_SettingsCommandInput;
 
 	void PlaceBorderTiles();
 
@@ -1171,8 +1165,8 @@ public:
 
 	int DoButton_DraggableEx(const void *pID, const char *pText, int Checked, const CUIRect *pRect, bool *pClicked, bool *pAbrupted, int Flags, const char *pToolTip = nullptr, int Corners = IGraphics::CORNER_ALL, float FontSize = 10.0f);
 
-	bool DoEditBox(void *pID, const CUIRect *pRect, char *pStr, unsigned StrSize, float FontSize, float *pOffset, bool Hidden = false, int Corners = IGraphics::CORNER_ALL, const char *pToolTip = nullptr);
-	bool DoClearableEditBox(void *pID, void *pClearID, const CUIRect *pRect, char *pStr, unsigned StrSize, float FontSize, float *pOffset, bool Hidden = false, int Corners = IGraphics::CORNER_ALL, const char *pToolTip = nullptr);
+	bool DoEditBox(CLineInput *pLineInput, const CUIRect *pRect, float FontSize, int Corners = IGraphics::CORNER_ALL, const char *pToolTip = nullptr);
+	bool DoClearableEditBox(CLineInput *pLineInput, const CUIRect *pRect, float FontSize, int Corners = IGraphics::CORNER_ALL, const char *pToolTip = nullptr);
 
 	void RenderBackground(CUIRect View, IGraphics::CTextureHandle Texture, float Size, float Brightness);
 

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -368,8 +368,9 @@ CUI::EPopupMenuFunctionResult CEditor::PopupGroup(void *pContext, CUIRect View, 
 		View.HSplitBottom(12.0f, &View, &Button);
 		pEditor->UI()->DoLabel(&Button, "Name:", 10.0f, TEXTALIGN_ML);
 		Button.VSplitLeft(40.0f, nullptr, &Button);
-		static float s_Name = 0;
-		if(pEditor->DoEditBox(&s_Name, &Button, pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_aName, sizeof(pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_aName), 10.0f, &s_Name))
+		static CLineInput s_NameInput;
+		s_NameInput.SetBuffer(pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_aName, sizeof(pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_aName));
+		if(pEditor->DoEditBox(&s_NameInput, &Button, 10.0f))
 			pEditor->m_Map.m_Modified = true;
 	}
 
@@ -538,8 +539,9 @@ CUI::EPopupMenuFunctionResult CEditor::PopupLayer(void *pContext, CUIRect View, 
 		View.HSplitBottom(12.0f, &View, &Label);
 		Label.VSplitLeft(40.0f, &Label, &EditBox);
 		pEditor->UI()->DoLabel(&Label, "Name:", 10.0f, TEXTALIGN_ML);
-		static float s_Name = 0;
-		if(pEditor->DoEditBox(&s_Name, &EditBox, pCurrentLayer->m_aName, sizeof(pCurrentLayer->m_aName), 10.0f, &s_Name))
+		static CLineInput s_NameInput;
+		s_NameInput.SetBuffer(pCurrentLayer->m_aName, sizeof(pCurrentLayer->m_aName));
+		if(pEditor->DoEditBox(&s_NameInput, &EditBox, 10.0f))
 			pEditor->m_Map.m_Modified = true;
 	}
 
@@ -1316,8 +1318,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupNewFolder(void *pContext, CUIRect Vi
 	pEditor->UI()->DoLabel(&Label, "Name:", 10.0f, TEXTALIGN_ML);
 	Label.VSplitLeft(50.0f, nullptr, &Button);
 	Button.HMargin(2.0f, &Button);
-	static float s_FolderBox = 0;
-	pEditor->DoEditBox(&s_FolderBox, &Button, pEditor->m_aFileDialogNewFolderName, sizeof(pEditor->m_aFileDialogNewFolderName), 12.0f, &s_FolderBox);
+	pEditor->DoEditBox(&pEditor->m_FileDialogNewFolderNameInput, &Button, 12.0f);
 
 	// button bar
 	ButtonBar.VSplitLeft(110.0f, &Button, &ButtonBar);
@@ -1330,10 +1331,10 @@ CUI::EPopupMenuFunctionResult CEditor::PopupNewFolder(void *pContext, CUIRect Vi
 	if(pEditor->DoButton_Editor(&s_CreateButton, "Create", 0, &Button, 0, nullptr) || (Active && pEditor->UI()->ConsumeHotkey(CUI::HOTKEY_ENTER)))
 	{
 		// create the folder
-		if(pEditor->m_aFileDialogNewFolderName[0])
+		if(!pEditor->m_FileDialogNewFolderNameInput.IsEmpty())
 		{
 			char aBuf[IO_MAX_PATH_LENGTH];
-			str_format(aBuf, sizeof(aBuf), "%s/%s", pEditor->m_pFileDialogPath, pEditor->m_aFileDialogNewFolderName);
+			str_format(aBuf, sizeof(aBuf), "%s/%s", pEditor->m_pFileDialogPath, pEditor->m_FileDialogNewFolderNameInput.GetString());
 			if(pEditor->Storage()->CreateFolder(aBuf, IStorage::TYPE_SAVE))
 			{
 				pEditor->FilelistPopulate(IStorage::TYPE_SAVE);
@@ -1368,32 +1369,36 @@ CUI::EPopupMenuFunctionResult CEditor::PopupMapInfo(void *pContext, CUIRect View
 	pEditor->UI()->DoLabel(&Label, "Author:", 10.0f, TEXTALIGN_ML);
 	Label.VSplitLeft(60.0f, nullptr, &Button);
 	Button.HMargin(3.0f, &Button);
-	static float s_AuthorBox = 0;
-	pEditor->DoEditBox(&s_AuthorBox, &Button, pEditor->m_Map.m_MapInfoTmp.m_aAuthor, sizeof(pEditor->m_Map.m_MapInfoTmp.m_aAuthor), 10.0f, &s_AuthorBox);
+	static CLineInput s_AuthorInput;
+	s_AuthorInput.SetBuffer(pEditor->m_Map.m_MapInfoTmp.m_aAuthor, sizeof(pEditor->m_Map.m_MapInfoTmp.m_aAuthor));
+	pEditor->DoEditBox(&s_AuthorInput, &Button, 10.0f);
 
 	// version box
 	View.HSplitTop(20.0f, &Label, &View);
 	pEditor->UI()->DoLabel(&Label, "Version:", 10.0f, TEXTALIGN_ML);
 	Label.VSplitLeft(60.0f, nullptr, &Button);
 	Button.HMargin(3.0f, &Button);
-	static float s_VersionBox = 0;
-	pEditor->DoEditBox(&s_VersionBox, &Button, pEditor->m_Map.m_MapInfoTmp.m_aVersion, sizeof(pEditor->m_Map.m_MapInfoTmp.m_aVersion), 10.0f, &s_VersionBox);
+	static CLineInput s_VersionInput;
+	s_VersionInput.SetBuffer(pEditor->m_Map.m_MapInfoTmp.m_aVersion, sizeof(pEditor->m_Map.m_MapInfoTmp.m_aVersion));
+	pEditor->DoEditBox(&s_VersionInput, &Button, 10.0f);
 
 	// credits box
 	View.HSplitTop(20.0f, &Label, &View);
 	pEditor->UI()->DoLabel(&Label, "Credits:", 10.0f, TEXTALIGN_ML);
 	Label.VSplitLeft(60.0f, nullptr, &Button);
 	Button.HMargin(3.0f, &Button);
-	static float s_CreditsBox = 0;
-	pEditor->DoEditBox(&s_CreditsBox, &Button, pEditor->m_Map.m_MapInfoTmp.m_aCredits, sizeof(pEditor->m_Map.m_MapInfoTmp.m_aCredits), 10.0f, &s_CreditsBox);
+	static CLineInput s_CreditsInput;
+	s_CreditsInput.SetBuffer(pEditor->m_Map.m_MapInfoTmp.m_aCredits, sizeof(pEditor->m_Map.m_MapInfoTmp.m_aCredits));
+	pEditor->DoEditBox(&s_CreditsInput, &Button, 10.0f);
 
 	// license box
 	View.HSplitTop(20.0f, &Label, &View);
 	pEditor->UI()->DoLabel(&Label, "License:", 10.0f, TEXTALIGN_ML);
 	Label.VSplitLeft(60.0f, nullptr, &Button);
 	Button.HMargin(3.0f, &Button);
-	static float s_LicenseBox = 0;
-	pEditor->DoEditBox(&s_LicenseBox, &Button, pEditor->m_Map.m_MapInfoTmp.m_aLicense, sizeof(pEditor->m_Map.m_MapInfoTmp.m_aLicense), 10.0f, &s_LicenseBox);
+	static CLineInput s_LicenseInput;
+	s_LicenseInput.SetBuffer(pEditor->m_Map.m_MapInfoTmp.m_aLicense, sizeof(pEditor->m_Map.m_MapInfoTmp.m_aLicense));
+	pEditor->DoEditBox(&s_LicenseInput, &Button, 10.0f);
 
 	// button bar
 	ButtonBar.VSplitLeft(110.0f, &Label, &ButtonBar);

--- a/src/test/str.cpp
+++ b/src/test/str.cpp
@@ -590,7 +590,7 @@ TEST(Str, Copy)
 
 TEST(Str, Utf8Stats)
 {
-	int Size, Count;
+	size_t Size, Count;
 
 	str_utf8_stats("abc", 4, 3, &Size, &Count);
 	EXPECT_EQ(Size, 3);


### PR DESCRIPTION
Port the line input (UI edit boxes, chat, console) and Input Method Editor (IME) support from upstream. Closes #4397.

General
------------------------------

Fix issues with the text input. Closes #4346. Closes #4524.

Word skipping (when holding Ctrl) is overhauled to be consistent with the Windows / Firefox experience that I took as reference.

Improve usability by not blinking (i.e. always rendering) the caret shortly after is has been moved.

UI text input
------------------------------

https://user-images.githubusercontent.com/23437060/233841419-6648ea97-3ccd-464b-a4c5-e6e5b8dde01c.mp4

Fix inconsistent mouse-based left and right scrolling (closes #4347).

Support smooth left and right scrolling.

Chat
------------------------------

https://user-images.githubusercontent.com/23437060/233841409-3f230b33-f1ad-4172-ade2-e8e5300c9220.mp4

Support keyboard-based text selection of the chat input.

Mouse-based selection could be support in the future when we decide to add something like an ingame UI cursor.

Support smooth up and down scrolling of the chat input, removing the old hack that offsets the input string to simulate scrolling.

Console
------------------------------

https://user-images.githubusercontent.com/23437060/233841427-d3aee499-254d-4bf9-83dd-3a0459ed6bf0.mp4

Also support mouse-based text selection of the command input.

Only text from either the command input or the console log can be selected at the same time. This ensures that Ctrl+C will always copy the text that is currently visually selected in the console.

Check for Ctrl+C input event in event handler instead of in render function, to hopefully fix the issue that copying does not work sometimes (closes #5974 until further notice).

When Ctrl+C is used to copy text from the console log, the selection is cleared. This should make it more clear when text was copied from the log.

Fix an issue that was preventing the console log selection from being cleared, when all log lines are selected.

Remove Ctrl+A/E hotkeys that move cursor to beginning/end respectively. Ctrl+A now selectes all text like for all other inputs. Home and End keys can still be used to go the beginning and end.

Remove Ctrl+U/K hotkeys that clear everything before/after the cursor respectively. Hold shift and use Home/End to select everything instead.

IME support
------------------------------

https://user-images.githubusercontent.com/23437060/233841395-635b6172-7582-4dce-a54f-cccf5e027dc5.mp4

Render list of IME candidates in the client on Windows, so the candidate list can also be viewed in fullscreen mode. There is no API available to retrieve a candidate list on the other operating systems.

**Note that this does not work with SDL 2.0.16, which we are currently using on Windows. See below for details on IME support in different SDL versions.**

Improve composition rendering by underlining the composition text instead of putting it in square brackets.

Track active input globally to properly activate and deactivate IME through the SDL functions.

Closes #1030. Closes #1008.

Password rendering
------------------------------

Fix rendering of passwords containing unicode. Instead of rendering one star character for each UTF-8 `char`, render on star for every unicode codepoint.

Show the composition text also for passwords. Without seeing the composition text it's hard to type a password containing those characters. The candidate window exposes the composition anyway. If you don't want to expose your password this way, e.g. while streaming, you could:

1. Use a latin password and switch off the IME for the password input with the IME hotkey.
2. Blank your screen with an external program while you are streaming and entering passwords.
3. Use binds to authenticate in rcon or to set the server browser password.

Refactoring
------------------------------

Move all text input logic and general rendering to `CLineInput`.

A `CLineInput` is associated with a particular `char` buffer given as a pointer either in the constructor or with `SetBuffer`. The maximum byte size of the buffer must also be specified. The maximum length in unicode codepoints can also be specified separately (e.g. on upstream, name are limited by the number of unicode codepoints instead).

Add `CLineInputBuffered`, which is a `CLineInput` that own a `char` buffer of a fixed size, which is specified as a template argument. As `CLineInput` does not own a buffer anymore, this reduces duplicate code for line inputs that need their own buffer.

Add `CLineInputNumber` which has additional convenience functions to consider the text as an `int` or `float`, to reduce duplicate code in those cases. In the future we could also add an input filter function so that only numbers can be entered in the number input.

Add `CLineInput::SetClipboardLineCallback` to handle the case that multiple lines of text are pasted into a lineinput. This reduces duplicate code, as this behavior was previously implemented separately for chat and console. The behavior is also fixed to be consistent with the console on Windows, so the first line being pasted edits the current input text and then sends it instead of being sent on its own without the existing input text.

Add `CalcFontSizeAndBoundingBox` to UI to reduce duplicate code. Expose `CalcAlignedCursorPos` as static member function to reuse it for line input.

Dispatch input events to UI inputs through the event handler instead of storing them in a duplicate buffer.

Use `size_t` for line input cursor position, length etc. and for `str_utf8_stats`.

Add `IButtonColorFunction` to UI to describe a functions that defines colors for the Default, Active and Hovered states of UI elements. Add some default button color functions. Use button color function to reduce duplicate code in scrollbar rendering.

Use `vec2` instead of two `floats` to represent the mouse positions in the text renderer.

Remove `CaretPosition` again, as it does not calculate the correct Y position near line breaks due to the wrapping being different when not rendering the entire string. Instead, calculate the exact caret position when rending a text container and store the caret position in the text cursor for later use.

IME usage guide (Windows)
------------------------------

1. Install the respective language and the Microsoft-IME keyboard (e.g. for Chinese, Japanese or Korean).
2. Launch the game (or a text editor to first try out the IME). Note that Windows may track the input language separately for every application. You can change this in the Windows input settings so the input language is changed globally.
2. Switch the input language using the hotkey Windows+Space or another hotkey that you configured in the Windows input settings (Alt+Shift is the default, but you should consider disabling it, to avoid accidentally changing the input language while playing).
3. Switch from Latin/English input mode to the respective asian input mode.
   - Chinese: Use Ctrl+Space to switch between English and Chinese input mode. You can change this hotkey in the IME's settings.
   - Japanese: Use Ctrl+Space to switch between Alphanumeric and Hiragana/Katakana input mode. You can change this hotkey in the IME's settings.
   - Korean: Use Right Alt to switch between English and Hangul input mode. You cannot change this hotkey as of yet.
   - Note that the input mode is also tracked per application, but there is no setting to change this behavior as far as I know, so you'll need to switch for every application separately.
4. Start typing. The underlined text is the current composition text. While a composition is active, you can only edit the composition text. Confirm the composition with Space or by selecting a candidate from the candidate list with the arrow keys. Cancel the composition with Escape or by using Backspace to delete the composition text. Note that not all languages offer a candidate list.

SDL version-specific issues
------------------------------

- 2.26.5, 2.24.2, 2.0.22: IME candidates work. But there are minor bugs when moving the composition cursor.
- 2.0.18, 2.0.20: IME candidates work.
- 2.0.16 (our current version): IME candidates cannot be determined with Windows API. Windows tries to draw the composition window like before, so this does not work in fullscreen mode.
- 2.0.8 (upstream 0.7): IME candidates work. But this SDL version is too old for us.

## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
