### PR TITLE
Fix input as the comments suggest for the next SDL version

### DIFF
--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -720,8 +720,7 @@ int CInput::Update()
 			case SDL_WINDOWEVENT_FOCUS_GAINED:
 				if(m_InputGrabbed)
 				{
-					// Enable this in case SDL 2.0.16 has major bugs or 2.0.18 still doesn't fix tabbing out with relative mouse
-					// MouseModeRelative();
+					MouseModeRelative();
 					// Clear pending relative mouse motion
 					SDL_GetRelativeMouseState(nullptr, nullptr);
 				}
@@ -733,8 +732,7 @@ int CInput::Update()
 				IgnoreKeys = true;
 				if(m_InputGrabbed)
 				{
-					// Enable this in case SDL 2.0.16 has major bugs or 2.0.18 still doesn't fix tabbing out with relative mouse
-					// MouseModeAbsolute();
+					MouseModeAbsolute();
 					// Remember that we had relative mouse
 					m_InputGrabbed = true;
 				}


### PR DESCRIPTION
Since we want to upgrade SDL version.

SDL fixed the bug on Windows that releasing the mouse while tabbing out directly refocuses the window, which broke desktop fullscreen (and maybe windowed fullscreen)

<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
