### PR TITLE
Fix client crash on team kill message with invalid team

### DIFF
--- a/src/game/client/components/killmessages.cpp
+++ b/src/game/client/components/killmessages.cpp
@@ -112,7 +112,7 @@ void CKillMessages::OnMessage(int MsgType, void *pRawMsg)
 		CNetMsg_Sv_KillMsgTeam *pMsg = (CNetMsg_Sv_KillMsgTeam *)pRawMsg;
 
 		// unpack messages
-		CKillMsg Kill;
+		CKillMsg Kill{};
 		Kill.m_aVictimName[0] = '\0';
 		Kill.m_aKillerName[0] = '\0';
 
@@ -132,7 +132,7 @@ void CKillMessages::OnMessage(int MsgType, void *pRawMsg)
 		if(Kill.m_TeamSize > MAX_KILLMSG_TEAM_MEMBERS)
 			Kill.m_TeamSize = MAX_KILLMSG_TEAM_MEMBERS;
 
-		Kill.m_VictimID = vStrongWeakSorted[0].first;
+		Kill.m_VictimID = vStrongWeakSorted.empty() ? -1 : vStrongWeakSorted[0].first;
 		if(Kill.m_VictimID >= 0 && Kill.m_VictimID < MAX_CLIENTS)
 		{
 			Kill.m_VictimTeam = m_pClient->m_aClients[Kill.m_VictimID].m_Team;
@@ -141,9 +141,8 @@ void CKillMessages::OnMessage(int MsgType, void *pRawMsg)
 
 			for(int i = 1; i < Kill.m_TeamSize; i++)
 				Kill.m_VictimRenderInfo[i] = m_pClient->m_aClients[vStrongWeakSorted[i].first].m_RenderInfo;
-
-			str_format(Kill.m_aVictimName, sizeof(Kill.m_aVictimName), Localize("Team %d"), Kill.m_VictimDDTeam);
 		}
+		str_format(Kill.m_aVictimName, sizeof(Kill.m_aVictimName), Localize("Team %d"), pMsg->m_Team);
 
 		Kill.m_KillerID = Kill.m_VictimID;
 

--- a/src/game/client/components/killmessages.cpp
+++ b/src/game/client/components/killmessages.cpp
@@ -66,7 +66,7 @@ void CKillMessages::CreateKillmessageNamesIfNotCreated(CKillMsg &Kill)
 	const float FontSize = 36.0f;
 	if(Kill.m_VictimTextContainerIndex == -1 && Kill.m_aVictimName[0] != 0)
 	{
-		Kill.m_VitctimTextWidth = TextRender()->TextWidth(FontSize, Kill.m_aVictimName, -1, -1.0f);
+		Kill.m_VictimTextWidth = TextRender()->TextWidth(FontSize, Kill.m_aVictimName, -1, -1.0f);
 
 		CTextCursor Cursor;
 		TextRender()->SetCursor(&Cursor, 0, 0, FontSize, TEXTFLAG_RENDER);
@@ -150,7 +150,7 @@ void CKillMessages::OnMessage(int MsgType, void *pRawMsg)
 		Kill.m_ModeSpecial = 0;
 		Kill.m_Tick = Client()->GameTick(g_Config.m_ClDummy);
 
-		Kill.m_VitctimTextWidth = Kill.m_KillerTextWidth = 0.f;
+		Kill.m_VictimTextWidth = Kill.m_KillerTextWidth = 0.f;
 
 		float Width = 400 * 3.0f * Graphics()->ScreenAspect();
 		float Height = 400 * 3.0f;
@@ -217,7 +217,7 @@ void CKillMessages::OnMessage(int MsgType, void *pRawMsg)
 
 		Kill.m_FlagCarrierBlue = m_pClient->m_Snap.m_pGameDataObj ? m_pClient->m_Snap.m_pGameDataObj->m_FlagCarrierBlue : -1;
 
-		Kill.m_VitctimTextWidth = Kill.m_KillerTextWidth = 0.f;
+		Kill.m_VictimTextWidth = Kill.m_KillerTextWidth = 0.f;
 
 		float Width = 400 * 3.0f * Graphics()->ScreenAspect();
 		float Height = 400 * 3.0f;
@@ -272,7 +272,7 @@ void CKillMessages::OnRender()
 		ColorRGBA TOutlineColor(0.f, 0.f, 0.f, 0.3f);
 
 		// render victim name
-		x -= m_aKillmsgs[r].m_VitctimTextWidth;
+		x -= m_aKillmsgs[r].m_VictimTextWidth;
 		if(m_aKillmsgs[r].m_VictimID >= 0 && g_Config.m_ClChatTeamColors && m_aKillmsgs[r].m_VictimDDTeam)
 		{
 			TColor = color_cast<ColorRGBA>(ColorHSLA(m_aKillmsgs[r].m_VictimDDTeam / 64.0f, 1.0f, 0.75f));

--- a/src/game/client/components/killmessages.cpp
+++ b/src/game/client/components/killmessages.cpp
@@ -152,8 +152,8 @@ void CKillMessages::OnMessage(int MsgType, void *pRawMsg)
 
 		Kill.m_VictimTextWidth = Kill.m_KillerTextWidth = 0.f;
 
-		float Width = 400 * 3.0f * Graphics()->ScreenAspect();
 		float Height = 400 * 3.0f;
+		float Width = Height * Graphics()->ScreenAspect();
 
 		float ScreenX0, ScreenY0, ScreenX1, ScreenY1;
 		Graphics()->GetScreen(&ScreenX0, &ScreenY0, &ScreenX1, &ScreenY1);
@@ -219,8 +219,8 @@ void CKillMessages::OnMessage(int MsgType, void *pRawMsg)
 
 		Kill.m_VictimTextWidth = Kill.m_KillerTextWidth = 0.f;
 
-		float Width = 400 * 3.0f * Graphics()->ScreenAspect();
 		float Height = 400 * 3.0f;
+		float Width = Height * Graphics()->ScreenAspect();
 
 		float ScreenX0, ScreenY0, ScreenX1, ScreenY1;
 		Graphics()->GetScreen(&ScreenX0, &ScreenY0, &ScreenX1, &ScreenY1);
@@ -251,8 +251,8 @@ void CKillMessages::OnRender()
 	if(!g_Config.m_ClShowKillMessages)
 		return;
 
-	float Width = 400 * 3.0f * Graphics()->ScreenAspect();
 	float Height = 400 * 3.0f;
+	float Width = Height * Graphics()->ScreenAspect();
 
 	Graphics()->MapScreen(0, 0, Width * 1.5f, Height * 1.5f);
 	Graphics()->SetColor(1.f, 1.f, 1.f, 1.f);

--- a/src/game/client/components/killmessages.h
+++ b/src/game/client/components/killmessages.h
@@ -30,7 +30,7 @@ public:
 		int m_VictimDDTeam;
 		char m_aVictimName[64];
 		int m_VictimTextContainerIndex;
-		float m_VitctimTextWidth;
+		float m_VictimTextWidth;
 		CTeeRenderInfo m_VictimRenderInfo[MAX_KILLMSG_TEAM_MEMBERS];
 		int m_KillerID;
 		int m_KillerTeam;


### PR DESCRIPTION
The client crashes when a team kill message specifies a team for which no client can be found. This can easily happen when the server sends an unknown team on purpose. It may also happen sporadically during normal gameplay, assuming a team is dissolved or the last team member leaves at the same time as the kill message is received.

The crash is fixed by not rendering any tee for these kill messages. The kill message text is always set depending on the team number in the team kill message, regardless of whether the team exists.

Closes #6533.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
