### PR TITLE
move some editor buttons into menus

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -886,6 +886,37 @@ void CEditor::DoToolbar(CUIRect ToolBar)
 	const bool ModPressed = Input()->ModifierIsPressed();
 	const bool ShiftPressed = Input()->ShiftIsPressed();
 
+	// handle shortcut for info button
+	if(m_Dialog == DIALOG_NONE && m_EditBoxActive == 0 && Input()->KeyPress(KEY_I) && ModPressed && !ShiftPressed)
+	{
+		if(m_ShowTileInfo && m_ShowTileHexInfo)
+			m_ShowTileHexInfo = false;
+		else if(m_ShowTileInfo)
+			m_ShowTileInfo = false;
+		else
+			m_ShowTileInfo = true;
+		m_ShowEnvelopePreview = SHOWENV_NONE;
+	}
+
+	// handle shortcut for hex button
+	if(m_Dialog == DIALOG_NONE && m_EditBoxActive == 0 && Input()->KeyPress(KEY_I) && ModPressed && ShiftPressed)
+	{
+		if(m_ShowTileInfo && m_ShowTileHexInfo)
+			m_ShowTileInfo = false;
+		else if(m_ShowTileInfo)
+			m_ShowTileHexInfo = true;
+		else
+		{
+			m_ShowTileInfo = true;
+			m_ShowTileHexInfo = true;
+		}
+		m_ShowEnvelopePreview = SHOWENV_NONE;
+	}
+
+	// handle shortcut for unused button
+	if(m_Dialog == DIALOG_NONE && m_EditBoxActive == 0 && Input()->KeyPress(KEY_U) && ModPressed)
+		m_AllowPlaceUnusedTiles = !m_AllowPlaceUnusedTiles;
+
 	CUIRect TB_Top, TB_Bottom;
 	CUIRect Button;
 
@@ -954,31 +985,6 @@ void CEditor::DoToolbar(CUIRect ToolBar)
 			(m_Dialog == DIALOG_NONE && m_EditBoxActive == 0 && Input()->KeyPress(KEY_G) && ModPressed && !ShiftPressed))
 		{
 			m_GridActive = !m_GridActive;
-		}
-
-		TB_Top.VSplitLeft(5.0f, nullptr, &TB_Top);
-
-		// tile info button
-		TB_Top.VSplitLeft(40.0f, &Button, &TB_Top);
-		static int s_TileInfoButton = 0;
-		if(DoButton_Editor(&s_TileInfoButton, "Info", m_ShowTileInfo, &Button, 0, "[ctrl+i] Show tile information") ||
-			(m_Dialog == DIALOG_NONE && m_EditBoxActive == 0 && Input()->KeyPress(KEY_I) && ModPressed && !ShiftPressed))
-		{
-			m_ShowTileInfo = !m_ShowTileInfo;
-			m_ShowEnvelopePreview = SHOWENV_NONE;
-		}
-
-		// handle shortcut for unused button
-		if(m_Dialog == DIALOG_NONE && m_EditBoxActive == 0 && Input()->KeyPress(KEY_U) && ModPressed)
-			m_AllowPlaceUnusedTiles = !m_AllowPlaceUnusedTiles;
-
-		TB_Top.VSplitLeft(5.0f, nullptr, &TB_Top);
-
-		TB_Top.VSplitLeft(40.0f, &Button, &TB_Top);
-		static int s_ColorBrushButton = 0;
-		if(DoButton_Editor(&s_ColorBrushButton, "Color", m_BrushColorEnabled, &Button, 0, "Toggle brush coloring"))
-		{
-			m_BrushColorEnabled = !m_BrushColorEnabled;
 		}
 
 		TB_Top.VSplitLeft(5.0f, nullptr, &TB_Top);
@@ -1274,16 +1280,6 @@ void CEditor::DoToolbar(CUIRect ToolBar)
 				(m_Dialog == DIALOG_NONE && m_EditBoxActive == 0 && Input()->KeyPress(KEY_D) && ModPressed && !ShiftPressed))
 				m_BrushDrawDestructive = !m_BrushDrawDestructive;
 			TB_Bottom.VSplitLeft(5.0f, &Button, &TB_Bottom);
-		}
-
-		// Hex values button
-		if(m_ShowTileInfo)
-		{
-			TB_Bottom.VSplitLeft(65.0f, &Button, &TB_Bottom);
-			static int s_TileInfoHexButton = 0;
-			if(DoButton_Editor(&s_TileInfoHexButton, "Hex Values", m_ShowTileHexInfo, &Button, 0, "[ctrl+shift+i] Show a tile's hex value") ||
-				(m_Dialog == DIALOG_NONE && m_EditBoxActive == 0 && Input()->KeyPress(KEY_I) && ModPressed && ShiftPressed))
-				m_ShowTileHexInfo = !m_ShowTileHexInfo;
 		}
 	}
 }
@@ -6010,7 +6006,7 @@ void CEditor::RenderMenubar(CUIRect MenuBar)
 	if(DoButton_Menu(&s_SettingsButton, "Settings", 0, &SettingsButton, 0, nullptr))
 	{
 		static SPopupMenuId s_PopupMenuEntitiesId;
-		UI()->DoPopupMenu(&s_PopupMenuEntitiesId, SettingsButton.x, SettingsButton.y + SettingsButton.h - 1.0f, 200.0f, 36.0f, this, PopupMenuSettings, IGraphics::CORNER_R | IGraphics::CORNER_B);
+		UI()->DoPopupMenu(&s_PopupMenuEntitiesId, SettingsButton.x, SettingsButton.y + SettingsButton.h - 1.0f, 200.0f, 64.0f, this, PopupMenuSettings, IGraphics::CORNER_R | IGraphics::CORNER_B);
 	}
 
 	CUIRect Info, Close;

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -950,20 +950,18 @@ void CEditor::DoToolbar(CUIRect ToolBar)
 		// proof button
 		TB_Top.VSplitLeft(40.0f, &Button, &TB_Top);
 		static int s_ProofButton = 0;
-		if(DoButton_Editor(&s_ProofButton, "Proof", m_ProofBorders, &Button, 0, "[ctrl+p] Toggles proof borders. These borders represent what a player maximum can see.") ||
+		if(DoButton_Ex(&s_ProofButton, "Proof", m_ProofBorders, &Button, 0, "[ctrl+p] Toggles proof borders. These borders represent what a player maximum can see.", IGraphics::CORNER_L) ||
 			(m_Dialog == DIALOG_NONE && m_EditBoxActive == 0 && Input()->KeyPress(KEY_P) && ModPressed))
 		{
-			m_ProofBorders = !m_ProofBorders && !m_MenuProofBorders;
+			m_ProofBorders = !m_ProofBorders;
 		}
 
-		TB_Top.VSplitLeft(5.0f, nullptr, &TB_Top);
-
-		// menu proof button
-		TB_Top.VSplitLeft(60.0f, &Button, &TB_Top);
+		TB_Top.VSplitLeft(10.0f, &Button, &TB_Top);
 		static int s_MenuProofButton = 0;
-		if(DoButton_Editor(&s_MenuProofButton, "Proof Menu", m_MenuProofBorders, &Button, 0, "Toggles menu proof borders. These borders represent what will be shown in the menu."))
+		if(DoButton_Ex(&s_MenuProofButton, "▾", 0, &Button, 0, "Select proof mode.", IGraphics::CORNER_R))
 		{
-			m_MenuProofBorders = !m_MenuProofBorders && !m_ProofBorders;
+			static SPopupMenuId s_PopupProofModeId;
+			UI()->DoPopupMenu(&s_PopupProofModeId, Button.x, Button.y + Button.h, 60.0f, 36.0f, this, PopupProofMode);
 		}
 
 		TB_Top.VSplitLeft(5.0f, nullptr, &TB_Top);
@@ -1129,7 +1127,7 @@ void CEditor::DoToolbar(CUIRect ToolBar)
 			TB_Bottom.VSplitLeft(45.0f, &Button, &TB_Bottom);
 			static int s_RefocusButton = 0;
 			int FocusButtonChecked;
-			if(m_MenuProofBorders)
+			if(m_ProofBorders && m_MenuProofBorders)
 			{
 				if(distance(m_vMenuBackgroundPositions[m_CurrentMenuProofIndex], vec2(m_WorldOffsetX, m_WorldOffsetY)) < 0.0001f)
 					FocusButtonChecked = -1;
@@ -1145,7 +1143,7 @@ void CEditor::DoToolbar(CUIRect ToolBar)
 			}
 			if(DoButton_Editor(&s_RefocusButton, "Refocus", FocusButtonChecked, &Button, 0, "[HOME] Restore map focus") || (m_Dialog == DIALOG_NONE && m_EditBoxActive == 0 && Input()->KeyPress(KEY_HOME)))
 			{
-				if(m_MenuProofBorders)
+				if(m_ProofBorders && m_MenuProofBorders)
 				{
 					m_WorldOffsetX = m_vMenuBackgroundPositions[m_CurrentMenuProofIndex].x;
 					m_WorldOffsetY = m_vMenuBackgroundPositions[m_CurrentMenuProofIndex].y;
@@ -2915,7 +2913,7 @@ void CEditor::DoMapEditor(CUIRect View)
 	}
 
 	// render screen sizes
-	if((m_ProofBorders || m_MenuProofBorders) && !m_ShowPicker)
+	if(m_ProofBorders && !m_ShowPicker)
 	{
 		CLayerGroup *pGameGroup = m_Map.m_pGameGroup;
 		pGameGroup->MapScreen();
@@ -2933,7 +2931,7 @@ void CEditor::DoMapEditor(CUIRect View)
 			float aPoints[4];
 			float Aspect = Start + (End - Start) * (i / (float)NumSteps);
 
-			float Zoom = m_MenuProofBorders ? 0.7f : 1.0f;
+			float Zoom = (m_ProofBorders && m_MenuProofBorders) ? 0.7f : 1.0f;
 			RenderTools()->MapScreenToWorld(
 				m_WorldOffsetX, m_WorldOffsetY,
 				100.0f, 100.0f, 100.0f, 0.0f, 0.0f, Aspect, Zoom, aPoints);
@@ -2976,7 +2974,7 @@ void CEditor::DoMapEditor(CUIRect View)
 				const float aAspects[] = {4.0f / 3.0f, 16.0f / 10.0f, 5.0f / 4.0f, 16.0f / 9.0f};
 				float Aspect = aAspects[i];
 
-				float Zoom = m_MenuProofBorders ? 0.7f : 1.0f;
+				float Zoom = (m_ProofBorders && m_MenuProofBorders) ? 0.7f : 1.0f;
 				RenderTools()->MapScreenToWorld(
 					m_WorldOffsetX, m_WorldOffsetY,
 					100.0f, 100.0f, 100.0f, 0.0f, 0.0f, Aspect, Zoom, aPoints);
@@ -3005,7 +3003,7 @@ void CEditor::DoMapEditor(CUIRect View)
 			Graphics()->SetColor(0, 0, 1, 0.3f);
 			Graphics()->DrawCircle(m_WorldOffsetX, m_WorldOffsetY - 3.0f, 20.0f, 32);
 
-			if(m_MenuProofBorders)
+			if(m_ProofBorders && m_MenuProofBorders)
 			{
 				Graphics()->SetColor(0, 1, 0, 0.3f);
 

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -5999,7 +5999,7 @@ void CEditor::RenderMenubar(CUIRect MenuBar)
 	if(DoButton_Menu(&s_ToolsButton, "Tools", 0, &ToolsButton, 0, nullptr))
 	{
 		static SPopupMenuId s_PopupMenuToolsId;
-		UI()->DoPopupMenu(&s_PopupMenuToolsId, ToolsButton.x, ToolsButton.y + ToolsButton.h - 1.0f, 200.0f, 46.0f, this, PopupMenuTools, IGraphics::CORNER_R | IGraphics::CORNER_B);
+		UI()->DoPopupMenu(&s_PopupMenuToolsId, ToolsButton.x, ToolsButton.y + ToolsButton.h - 1.0f, 200.0f, 50.0f, this, PopupMenuTools, IGraphics::CORNER_R | IGraphics::CORNER_B);
 	}
 
 	MenuBar.VSplitLeft(5.0f, nullptr, &MenuBar);
@@ -6010,7 +6010,7 @@ void CEditor::RenderMenubar(CUIRect MenuBar)
 	if(DoButton_Menu(&s_SettingsButton, "Settings", 0, &SettingsButton, 0, nullptr))
 	{
 		static SPopupMenuId s_PopupMenuEntitiesId;
-		UI()->DoPopupMenu(&s_PopupMenuEntitiesId, SettingsButton.x, SettingsButton.y + SettingsButton.h - 1.0f, 200.0f, 34.0f, this, PopupMenuSettings, IGraphics::CORNER_R | IGraphics::CORNER_B);
+		UI()->DoPopupMenu(&s_PopupMenuEntitiesId, SettingsButton.x, SettingsButton.y + SettingsButton.h - 1.0f, 200.0f, 36.0f, this, PopupMenuSettings, IGraphics::CORNER_R | IGraphics::CORNER_B);
 	}
 
 	CUIRect Info, Close;

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -1144,6 +1144,7 @@ public:
 
 	static CUI::EPopupMenuFunctionResult PopupMenuFile(void *pContext, CUIRect View, bool Active);
 	static CUI::EPopupMenuFunctionResult PopupMenuTools(void *pContext, CUIRect View, bool Active);
+	static CUI::EPopupMenuFunctionResult PopupMenuSettings(void *pContext, CUIRect View, bool Active);
 	static CUI::EPopupMenuFunctionResult PopupGroup(void *pContext, CUIRect View, bool Active);
 	struct SLayerPopupContext : public SPopupMenuId
 	{

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -1172,6 +1172,7 @@ public:
 	static CUI::EPopupMenuFunctionResult PopupGoto(void *pContext, CUIRect View, bool Active);
 	static CUI::EPopupMenuFunctionResult PopupColorPicker(void *pContext, CUIRect View, bool Active);
 	static CUI::EPopupMenuFunctionResult PopupEntities(void *pContext, CUIRect View, bool Active);
+	static CUI::EPopupMenuFunctionResult PopupProofMode(void *pContext, CUIRect View, bool Active);
 
 	static bool CallbackOpenMap(const char *pFileName, int StorageType, void *pUser);
 	static bool CallbackAppendMap(const char *pFileName, int StorageType, void *pUser);

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -243,7 +243,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupMenuSettings(void *pContext, CUIRect
 		CUIRect No, Yes;
 		Selector.VSplitMid(&No, &Yes);
 
-		pEditor->UI()->DoLabel(&Label, "Enable brush coloring", 10.0f, TEXTALIGN_ML);
+		pEditor->UI()->DoLabel(&Label, "Brush coloring", 10.0f, TEXTALIGN_ML);
 		static int s_ButtonNo = 0;
 		static int s_ButtonYes = 0;
 		if(pEditor->DoButton_ButtonDec(&s_ButtonNo, "No", !pEditor->m_BrushColorEnabled, &No, 0, "Disable brush coloring"))

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -2322,3 +2322,28 @@ CUI::EPopupMenuFunctionResult CEditor::PopupEntities(void *pContext, CUIRect Vie
 
 	return CUI::POPUP_KEEP_OPEN;
 }
+
+CUI::EPopupMenuFunctionResult CEditor::PopupProofMode(void *pContext, CUIRect View, bool Active)
+{
+	CEditor *pEditor = static_cast<CEditor *>(pContext);
+
+	CUIRect Button;
+	View.HSplitTop(12.0f, &Button, &View);
+	static int s_ButtonIngame;
+	if(pEditor->DoButton_MenuItem(&s_ButtonIngame, "Ingame", !pEditor->m_MenuProofBorders, &Button, 0, "These borders represent what a player maximum can see."))
+	{
+		pEditor->m_MenuProofBorders = false;
+		return CUI::POPUP_CLOSE_CURRENT;
+	}
+
+	View.HSplitTop(2.0f, nullptr, &View);
+	View.HSplitTop(12.0f, &Button, &View);
+	static int s_ButtonMenu;
+	if(pEditor->DoButton_MenuItem(&s_ButtonMenu, "Menu", pEditor->m_MenuProofBorders, &Button, 0, "These borders represent what will be shown in the menu."))
+	{
+		pEditor->m_MenuProofBorders = true;
+		return CUI::POPUP_CLOSE_CURRENT;
+	}
+
+	return CUI::POPUP_KEEP_OPEN;
+}

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -172,7 +172,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupMenuTools(void *pContext, CUIRect Vi
 	static int s_BorderButton = 0;
 	View.HSplitTop(2.0f, nullptr, &View);
 	View.HSplitTop(12.0f, &Slot, &View);
-	if(pEditor->DoButton_MenuItem(&s_BorderButton, "Border", 0, &Slot, 0, "Place tiles in a 2-tile wide border at the edges of the layer"))
+	if(pEditor->DoButton_MenuItem(&s_BorderButton, "Place Border", 0, &Slot, 0, "Place tiles in a 2-tile wide border at the edges of the layer"))
 	{
 		CLayerTiles *pT = (CLayerTiles *)pEditor->GetSelectedLayerType(0, LAYERTYPE_TILES);
 		if(pT && !pT->m_Tele && !pT->m_Speedup && !pT->m_Switch && !pT->m_Front && !pT->m_Tune)
@@ -220,7 +220,9 @@ CUI::EPopupMenuFunctionResult CEditor::PopupMenuSettings(void *pContext, CUIRect
 	CUIRect Slot;
 	View.HSplitTop(12.0f, &Slot, &View);
 	static int s_EntitiesButtonID = 0;
-	if(pEditor->DoButton_MenuItem(&s_EntitiesButtonID, "Entities", 0, &Slot, 0, "Choose game layer entities image for different gametypes"))
+	char aButtonText[64];
+	str_format(aButtonText, sizeof(aButtonText), "Entities: %s", pEditor->m_SelectEntitiesImage.c_str());
+	if(pEditor->DoButton_MenuItem(&s_EntitiesButtonID, aButtonText, 0, &Slot, 0, "Choose game layer entities image for different gametypes"))
 	{
 		pEditor->m_vSelectEntitiesFiles.clear();
 		pEditor->Storage()->ListDirectory(IStorage::TYPE_ALL, "editor/entities", EntitiesListdirCallback, pEditor);

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -236,7 +236,6 @@ CUI::EPopupMenuFunctionResult CEditor::PopupMenuSettings(void *pContext, CUIRect
 	View.HSplitTop(12.0f, &Slot, &View);
 	{
 		Slot.VMargin(5.0f, &Slot);
-		Slot.VSplitRight(5.0f, &Slot, nullptr); // right margin
 
 		CUIRect Label, Selector;
 		Slot.VSplitMid(&Label, &Selector);
@@ -260,7 +259,6 @@ CUI::EPopupMenuFunctionResult CEditor::PopupMenuSettings(void *pContext, CUIRect
 	View.HSplitTop(12.0f, &Slot, &View);
 	{
 		Slot.VMargin(5.0f, &Slot);
-		Slot.VSplitRight(5.0f, &Slot, nullptr); // right margin
 
 		CUIRect Label, Selector;
 		Slot.VSplitMid(&Label, &Selector);
@@ -284,7 +282,6 @@ CUI::EPopupMenuFunctionResult CEditor::PopupMenuSettings(void *pContext, CUIRect
 	View.HSplitTop(12.0f, &Slot, &View);
 	{
 		Slot.VMargin(5.0f, &Slot);
-		Slot.VSplitRight(5.0f, &Slot, nullptr); // right margin
 
 		CUIRect Label, Selector;
 		Slot.VSplitMid(&Label, &Selector);

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -170,6 +170,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupMenuTools(void *pContext, CUIRect Vi
 	}
 
 	static int s_BorderButton = 0;
+	View.HSplitTop(2.0f, nullptr, &View);
 	View.HSplitTop(12.0f, &Slot, &View);
 	if(pEditor->DoButton_MenuItem(&s_BorderButton, "Border", 0, &Slot, 0, "Place tiles in a 2-tile wide border at the edges of the layer"))
 	{
@@ -189,6 +190,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupMenuTools(void *pContext, CUIRect Vi
 	}
 
 	static int s_GotoButton = 0;
+	View.HSplitTop(2.0f, nullptr, &View);
 	View.HSplitTop(12.0f, &Slot, &View);
 	if(pEditor->DoButton_MenuItem(&s_GotoButton, "Goto XY", 0, &Slot, 0, "Go to a specified coordinate point on the map"))
 	{
@@ -228,25 +230,28 @@ CUI::EPopupMenuFunctionResult CEditor::PopupMenuSettings(void *pContext, CUIRect
 		pEditor->UI()->DoPopupMenu(&s_PopupEntitiesId, Slot.x, Slot.y + Slot.h, 250, pEditor->m_vSelectEntitiesFiles.size() * 14.0f + 10.0f, pEditor, PopupEntities);
 	}
 
+	View.HSplitTop(2.0f, nullptr, &View);
 	View.HSplitTop(12.0f, &Slot, &View);
-	Slot.VMargin(5.0f, &Slot);
-	Slot.VSplitRight(5.0f, &Slot, nullptr); // right margin
-
-	CUIRect Label, Selector;
-	Slot.VSplitMid(&Label, &Selector);
-	CUIRect No, Yes;
-	Selector.VSplitMid(&No, &Yes);
-
-	pEditor->UI()->DoLabel(&Label, "Allow unused", 10.0f, TEXTALIGN_ML);
-	static int s_ButtonNo = 0;
-	static int s_ButtonYes = 0;
-	if(pEditor->DoButton_ButtonDec(&s_ButtonNo, "No", !pEditor->m_AllowPlaceUnusedTiles, &No, 0, "[ctrl+u] Disallow placing unused tiles"))
 	{
-		pEditor->m_AllowPlaceUnusedTiles = false;
-	}
-	if(pEditor->DoButton_ButtonInc(&s_ButtonYes, "Yes", pEditor->m_AllowPlaceUnusedTiles, &Yes, 0, "[ctrl+u] Allow placing unused tiles"))
-	{
-		pEditor->m_AllowPlaceUnusedTiles = true;
+		Slot.VMargin(5.0f, &Slot);
+		Slot.VSplitRight(5.0f, &Slot, nullptr); // right margin
+
+		CUIRect Label, Selector;
+		Slot.VSplitMid(&Label, &Selector);
+		CUIRect No, Yes;
+		Selector.VSplitMid(&No, &Yes);
+
+		pEditor->UI()->DoLabel(&Label, "Allow unused", 10.0f, TEXTALIGN_ML);
+		static int s_ButtonNo = 0;
+		static int s_ButtonYes = 0;
+		if(pEditor->DoButton_ButtonDec(&s_ButtonNo, "No", !pEditor->m_AllowPlaceUnusedTiles, &No, 0, "[ctrl+u] Disallow placing unused tiles"))
+		{
+			pEditor->m_AllowPlaceUnusedTiles = false;
+		}
+		if(pEditor->DoButton_ButtonInc(&s_ButtonYes, "Yes", pEditor->m_AllowPlaceUnusedTiles, &Yes, 0, "[ctrl+u] Allow placing unused tiles"))
+		{
+			pEditor->m_AllowPlaceUnusedTiles = true;
+		}
 	}
 
 	return CUI::POPUP_KEEP_OPEN;

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -243,6 +243,30 @@ CUI::EPopupMenuFunctionResult CEditor::PopupMenuSettings(void *pContext, CUIRect
 		CUIRect No, Yes;
 		Selector.VSplitMid(&No, &Yes);
 
+		pEditor->UI()->DoLabel(&Label, "Enable brush coloring", 10.0f, TEXTALIGN_ML);
+		static int s_ButtonNo = 0;
+		static int s_ButtonYes = 0;
+		if(pEditor->DoButton_ButtonDec(&s_ButtonNo, "No", !pEditor->m_BrushColorEnabled, &No, 0, "Disable brush coloring"))
+		{
+			pEditor->m_BrushColorEnabled = false;
+		}
+		if(pEditor->DoButton_ButtonInc(&s_ButtonYes, "Yes", pEditor->m_BrushColorEnabled, &Yes, 0, "Enable brush coloring"))
+		{
+			pEditor->m_BrushColorEnabled = true;
+		}
+	}
+
+	View.HSplitTop(2.0f, nullptr, &View);
+	View.HSplitTop(12.0f, &Slot, &View);
+	{
+		Slot.VMargin(5.0f, &Slot);
+		Slot.VSplitRight(5.0f, &Slot, nullptr); // right margin
+
+		CUIRect Label, Selector;
+		Slot.VSplitMid(&Label, &Selector);
+		CUIRect No, Yes;
+		Selector.VSplitMid(&No, &Yes);
+
 		pEditor->UI()->DoLabel(&Label, "Allow unused", 10.0f, TEXTALIGN_ML);
 		static int s_ButtonNo = 0;
 		static int s_ButtonYes = 0;
@@ -253,6 +277,41 @@ CUI::EPopupMenuFunctionResult CEditor::PopupMenuSettings(void *pContext, CUIRect
 		if(pEditor->DoButton_ButtonInc(&s_ButtonYes, "Yes", pEditor->m_AllowPlaceUnusedTiles, &Yes, 0, "[ctrl+u] Allow placing unused tiles"))
 		{
 			pEditor->m_AllowPlaceUnusedTiles = true;
+		}
+	}
+
+	View.HSplitTop(2.0f, nullptr, &View);
+	View.HSplitTop(12.0f, &Slot, &View);
+	{
+		Slot.VMargin(5.0f, &Slot);
+		Slot.VSplitRight(5.0f, &Slot, nullptr); // right margin
+
+		CUIRect Label, Selector;
+		Slot.VSplitMid(&Label, &Selector);
+		CUIRect Off, Dec, Hex;
+		Selector.VSplitLeft(Selector.w / 3.0f, &Off, &Selector);
+		Selector.VSplitMid(&Dec, &Hex);
+
+		pEditor->UI()->DoLabel(&Label, "Show Info", 10.0f, TEXTALIGN_ML);
+		static int s_ButtonOff = 0;
+		static int s_ButtonDec = 0;
+		static int s_ButtonHex = 0;
+		if(pEditor->DoButton_ButtonDec(&s_ButtonOff, "Off", !pEditor->m_ShowTileInfo, &Off, 0, "Do not show tile information"))
+		{
+			pEditor->m_ShowTileInfo = false;
+			pEditor->m_ShowEnvelopePreview = SHOWENV_NONE;
+		}
+		if(pEditor->DoButton_Ex(&s_ButtonDec, "Dec", pEditor->m_ShowTileInfo && !pEditor->m_ShowTileHexInfo, &Dec, 0, "[ctrl+i] Show tile information", IGraphics::CORNER_NONE))
+		{
+			pEditor->m_ShowTileInfo = true;
+			pEditor->m_ShowTileHexInfo = false;
+			pEditor->m_ShowEnvelopePreview = SHOWENV_NONE;
+		}
+		if(pEditor->DoButton_ButtonInc(&s_ButtonHex, "Hex", pEditor->m_ShowTileInfo && pEditor->m_ShowTileHexInfo, &Hex, 0, "[ctrl+shift+i] Show tile information in hexadecimal"))
+		{
+			pEditor->m_ShowTileInfo = true;
+			pEditor->m_ShowTileHexInfo = true;
+			pEditor->m_ShowEnvelopePreview = SHOWENV_NONE;
 		}
 	}
 
@@ -1538,7 +1597,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupEvent(void *pContext, CUIRect View, 
 	else if(pEditor->m_PopupEventType == POPEVENT_PREVENTUNUSEDTILES)
 	{
 		pTitle = "Unused tiles disabled";
-		pMessage = "Unused tiles can't be placed by default because they could get a use later and then destroy your map.\n\nActivate the 'Unused' switch to be able to place every tile.";
+		pMessage = "Unused tiles can't be placed by default because they could get a use later and then destroy your map.\n\nActivate the 'Allow Unused' setting to be able to place every tile.";
 	}
 	else if(pEditor->m_PopupEventType == POPEVENT_IMAGEDIV16)
 	{


### PR DESCRIPTION
The entities and unused buttons are now in a new "Settings" menu.
![menu_settings](https://user-images.githubusercontent.com/49279081/235301689-a1375024-9233-432b-9ab3-4545f982711f.png)

The border and goto buttons got moved to the "Tools" menu.
![tools_menu](https://user-images.githubusercontent.com/49279081/235301690-6883e6a7-0afe-4b2f-826c-3fb48694f7f4.png)


## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
