### PR TITLE
Readd cargo to Arch Linux dependencies in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Or on Fedora like this:
 
 Or on Arch Linux like this:
 
-    sudo pacman -S --needed base-devel cmake curl ffmpeg freetype2 git glew glslang gmock libnotify libpng opusfile python rust sdl2 spirv-tools sqlite vulkan-headers vulkan-icd-loader wavpack x264
+    sudo pacman -S --needed base-devel cargo cmake curl ffmpeg freetype2 git glew glslang gmock libnotify libpng opusfile python sdl2 spirv-tools sqlite vulkan-headers vulkan-icd-loader wavpack x264
 
 Or on Gentoo like this:
 


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

Previously I replaced "cargo" with "rust" in the Arch Linux's list of dependencies in the README (d10c4480) in order to use [rust](https://archlinux.org/packages/extra/x86_64/rust/) package directly, instead of the 'provides=cargo' flag feature.

This turned out to not be beneficial, because [rustup](https://archlinux.org/packages/community/x86_64/rustup/) package also has 'provides=cargo' flag, which means that both rust and rustup packages are satisfied when installing 'cargo'; however, explicitly installing rust conflicts and replaces rustup, which is no good for rustup users.

Hence, adding 'cargo' back to dependency list, and removing unnecessary 'rust' (installing cargo will install rust or rustup already).
