### PR TITLE
Fix server password input not being activated automatically, always move cursor to end when selecting all text

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -100,6 +100,9 @@ CMenus::CMenus()
 		animator.m_YOffset = -2.5f;
 		animator.m_HOffset = 2.5f;
 	}
+
+	m_PasswordInput.SetBuffer(g_Config.m_Password, sizeof(g_Config.m_Password));
+	m_PasswordInput.SetHidden(true);
 }
 
 int CMenus::DoButton_Toggle(const void *pID, int Checked, const CUIRect *pRect, bool Active)
@@ -1722,9 +1725,7 @@ int CMenus::Render()
 			TextBox.VSplitLeft(20.0f, 0, &TextBox);
 			TextBox.VSplitRight(60.0f, &TextBox, 0);
 			UI()->DoLabel(&Label, Localize("Password"), 18.0f, TEXTALIGN_ML);
-			static CLineInput s_PasswordInput(g_Config.m_Password, sizeof(g_Config.m_Password));
-			s_PasswordInput.SetHidden(true);
-			UI()->DoClearableEditBox(&s_PasswordInput, &TextBox, 12.0f);
+			UI()->DoClearableEditBox(&m_PasswordInput, &TextBox, 12.0f);
 		}
 		else if(m_Popup == POPUP_CONNECTING)
 		{
@@ -2318,8 +2319,8 @@ void CMenus::OnStateChange(int NewState, int OldState)
 			if(str_find(Client()->ErrorString(), "password"))
 			{
 				m_Popup = POPUP_PASSWORD;
-				UI()->SetHotItem(&g_Config.m_Password);
-				UI()->SetActiveItem(&g_Config.m_Password);
+				m_PasswordInput.SelectAll();
+				UI()->SetActiveItem(&m_PasswordInput);
 			}
 			else
 				m_Popup = POPUP_DISCONNECTED;

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -685,7 +685,6 @@ public:
 	void UpdateOwnGhost(CGhostItem Item);
 	void DeleteGhostItem(int Index);
 
-	void setPopup(int Popup) { m_Popup = Popup; }
 	int GetCurPopup() { return m_Popup; }
 	bool CanDisplayWarning();
 

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -355,6 +355,9 @@ protected:
 	int m_DownloadLastCheckSize;
 	float m_DownloadSpeed;
 
+	// for password popup
+	CLineInput m_PasswordInput;
+
 	// for call vote
 	int m_CallvoteSelectedOption;
 	int m_CallvoteSelectedPlayer;

--- a/src/game/client/lineinput.h
+++ b/src/game/client/lineinput.h
@@ -140,7 +140,11 @@ public:
 	bool HasSelection() const { return GetSelectionLength() > 0; }
 	void SetSelection(size_t Start, size_t End);
 	void SelectNothing() { SetSelection(GetCursorOffset(), GetCursorOffset()); }
-	void SelectAll() { SetSelection(0, GetLength()); }
+	void SelectAll()
+	{
+		SetCursorOffset(GetLength());
+		SetSelection(0, GetLength());
+	}
 
 	size_t OffsetFromActualToDisplay(size_t ActualOffset) const;
 	size_t OffsetFromDisplayToActual(size_t DisplayOffset) const;


### PR DESCRIPTION

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
