### PR TITLE
Broadcast: fade out in last second, wrap long text instead of stopping, fix horizontal centering

### DIFF
--- a/src/game/client/components/broadcast.cpp
+++ b/src/game/client/components/broadcast.cpp
@@ -50,8 +50,8 @@ void CBroadcast::RenderServerBroadcast()
 	if(!m_TextContainerIndex.Valid())
 	{
 		CTextCursor Cursor;
-		TextRender()->SetCursor(&Cursor, m_BroadcastRenderOffset, 40.0f, 12.0f, TEXTFLAG_RENDER | TEXTFLAG_STOP_AT_END);
-		Cursor.m_LineWidth = Width - m_BroadcastRenderOffset;
+		TextRender()->SetCursor(&Cursor, m_BroadcastRenderOffset, 40.0f, 12.0f, TEXTFLAG_RENDER);
+		Cursor.m_LineWidth = Width;
 		TextRender()->CreateTextContainer(m_TextContainerIndex, &Cursor, m_aBroadcastText);
 	}
 	if(m_TextContainerIndex.Valid())
@@ -80,7 +80,7 @@ void CBroadcast::OnBroadcastMessage(const CNetMsg_Sv_Broadcast *pMsg)
 	Graphics()->MapScreen(0.0f, 0.0f, Width, Height);
 
 	str_copy(m_aBroadcastText, pMsg->m_pMessage);
-	m_BroadcastRenderOffset = Width / 2.0f - TextRender()->TextWidth(12.0f, m_aBroadcastText, -1, Width, TEXTFLAG_STOP_AT_END) / 2.0f;
+	m_BroadcastRenderOffset = Width / 2.0f - TextRender()->TextWidth(12.0f, m_aBroadcastText, -1, Width) / 2.0f;
 	m_BroadcastTick = Client()->GameTick(g_Config.m_ClDummy) + Client()->GameTickSpeed() * 10;
 	TextRender()->DeleteTextContainer(m_TextContainerIndex);
 

--- a/src/game/client/components/broadcast.cpp
+++ b/src/game/client/components/broadcast.cpp
@@ -38,36 +38,40 @@ void CBroadcast::OnMessage(int MsgType, void *pRawMsg)
 {
 	if(MsgType == NETMSGTYPE_SV_BROADCAST)
 	{
-		CNetMsg_Sv_Broadcast *pMsg = (CNetMsg_Sv_Broadcast *)pRawMsg;
-		str_copy(m_aBroadcastText, pMsg->m_pMessage);
-		CTextCursor Cursor;
-		TextRender()->SetCursor(&Cursor, 0, 0, 12.0f, TEXTFLAG_STOP_AT_END);
-		Cursor.m_LineWidth = 300 * Graphics()->ScreenAspect();
-		TextRender()->TextEx(&Cursor, m_aBroadcastText, -1);
-		m_BroadcastRenderOffset = 150 * Graphics()->ScreenAspect() - Cursor.m_X / 2;
-		m_BroadcastTick = Client()->GameTick(g_Config.m_ClDummy) + Client()->GameTickSpeed() * 10;
-		if(g_Config.m_ClPrintBroadcasts)
+		OnBroadcastMessage((CNetMsg_Sv_Broadcast *)pRawMsg);
+	}
+}
+
+void CBroadcast::OnBroadcastMessage(const CNetMsg_Sv_Broadcast *pMsg)
+{
+	str_copy(m_aBroadcastText, pMsg->m_pMessage);
+	CTextCursor Cursor;
+	TextRender()->SetCursor(&Cursor, 0, 0, 12.0f, TEXTFLAG_STOP_AT_END);
+	Cursor.m_LineWidth = 300 * Graphics()->ScreenAspect();
+	TextRender()->TextEx(&Cursor, m_aBroadcastText, -1);
+	m_BroadcastRenderOffset = 150 * Graphics()->ScreenAspect() - Cursor.m_X / 2;
+	m_BroadcastTick = Client()->GameTick(g_Config.m_ClDummy) + Client()->GameTickSpeed() * 10;
+	if(g_Config.m_ClPrintBroadcasts)
+	{
+		char aBuf[1024];
+		int i, ii;
+		for(i = 0, ii = 0; i < str_length(m_aBroadcastText); i++)
 		{
-			char aBuf[1024];
-			int i, ii;
-			for(i = 0, ii = 0; i < str_length(m_aBroadcastText); i++)
+			if(m_aBroadcastText[i] == '\n')
 			{
-				if(m_aBroadcastText[i] == '\n')
-				{
-					aBuf[ii] = '\0';
-					ii = 0;
-					if(aBuf[0])
-						m_pClient->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "broadcast", aBuf, color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClMessageHighlightColor)));
-				}
-				else
-				{
-					aBuf[ii] = m_aBroadcastText[i];
-					ii++;
-				}
+				aBuf[ii] = '\0';
+				ii = 0;
+				if(aBuf[0])
+					m_pClient->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "broadcast", aBuf, color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClMessageHighlightColor)));
 			}
-			aBuf[ii] = '\0';
-			if(aBuf[0])
-				m_pClient->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "broadcast", aBuf, color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClMessageHighlightColor)));
+			else
+			{
+				aBuf[ii] = m_aBroadcastText[i];
+				ii++;
+			}
 		}
+		aBuf[ii] = '\0';
+		if(aBuf[0])
+			m_pClient->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "broadcast", aBuf, color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClMessageHighlightColor)));
 	}
 }

--- a/src/game/client/components/broadcast.cpp
+++ b/src/game/client/components/broadcast.cpp
@@ -20,6 +20,9 @@ void CBroadcast::OnReset()
 
 void CBroadcast::OnRender()
 {
+	if(Client()->State() != IClient::STATE_ONLINE && Client()->State() != IClient::STATE_DEMOPLAYBACK)
+		return;
+
 	RenderServerBroadcast();
 }
 

--- a/src/game/client/components/broadcast.cpp
+++ b/src/game/client/components/broadcast.cpp
@@ -16,11 +16,13 @@
 void CBroadcast::OnReset()
 {
 	m_BroadcastTick = 0;
+	m_BroadcastRenderOffset = -1.0f;
 	TextRender()->DeleteTextContainer(m_TextContainerIndex);
 }
 
 void CBroadcast::OnWindowResize()
 {
+	m_BroadcastRenderOffset = -1.0f;
 	TextRender()->DeleteTextContainer(m_TextContainerIndex);
 }
 
@@ -46,6 +48,9 @@ void CBroadcast::RenderServerBroadcast()
 	const float Height = 300.0f;
 	const float Width = Height * Graphics()->ScreenAspect();
 	Graphics()->MapScreen(0.0f, 0.0f, Width, Height);
+
+	if(m_BroadcastRenderOffset < 0.0f)
+		m_BroadcastRenderOffset = Width / 2.0f - TextRender()->TextWidth(12.0f, m_aBroadcastText, -1, Width) / 2.0f;
 
 	if(!m_TextContainerIndex.Valid())
 	{
@@ -75,13 +80,9 @@ void CBroadcast::OnMessage(int MsgType, void *pRawMsg)
 
 void CBroadcast::OnBroadcastMessage(const CNetMsg_Sv_Broadcast *pMsg)
 {
-	const float Height = 300.0f;
-	const float Width = Height * Graphics()->ScreenAspect();
-	Graphics()->MapScreen(0.0f, 0.0f, Width, Height);
-
 	str_copy(m_aBroadcastText, pMsg->m_pMessage);
-	m_BroadcastRenderOffset = Width / 2.0f - TextRender()->TextWidth(12.0f, m_aBroadcastText, -1, Width) / 2.0f;
 	m_BroadcastTick = Client()->GameTick(g_Config.m_ClDummy) + Client()->GameTickSpeed() * 10;
+	m_BroadcastRenderOffset = -1.0f;
 	TextRender()->DeleteTextContainer(m_TextContainerIndex);
 
 	if(g_Config.m_ClPrintBroadcasts)

--- a/src/game/client/components/broadcast.cpp
+++ b/src/game/client/components/broadcast.cpp
@@ -20,6 +20,11 @@ void CBroadcast::OnReset()
 
 void CBroadcast::OnRender()
 {
+	RenderServerBroadcast();
+}
+
+void CBroadcast::RenderServerBroadcast()
+{
 	if(m_pClient->m_Scoreboard.Active() || m_pClient->m_Motd.IsActive() || !g_Config.m_ClShowBroadcasts)
 		return;
 

--- a/src/game/client/components/broadcast.cpp
+++ b/src/game/client/components/broadcast.cpp
@@ -61,27 +61,17 @@ void CBroadcast::OnBroadcastMessage(const CNetMsg_Sv_Broadcast *pMsg)
 	str_copy(m_aBroadcastText, pMsg->m_pMessage);
 	m_BroadcastRenderOffset = Width / 2.0f - TextRender()->TextWidth(12.0f, m_aBroadcastText, -1, Width, TEXTFLAG_STOP_AT_END) / 2.0f;
 	m_BroadcastTick = Client()->GameTick(g_Config.m_ClDummy) + Client()->GameTickSpeed() * 10;
+
 	if(g_Config.m_ClPrintBroadcasts)
 	{
-		char aBuf[1024];
-		int i, ii;
-		for(i = 0, ii = 0; i < str_length(m_aBroadcastText); i++)
+		const char *pText = m_aBroadcastText;
+		char aLine[sizeof(m_aBroadcastText)];
+		while((pText = str_next_token(pText, "\n", aLine, sizeof(aLine))))
 		{
-			if(m_aBroadcastText[i] == '\n')
+			if(aLine[0] != '\0')
 			{
-				aBuf[ii] = '\0';
-				ii = 0;
-				if(aBuf[0])
-					m_pClient->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "broadcast", aBuf, color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClMessageHighlightColor)));
-			}
-			else
-			{
-				aBuf[ii] = m_aBroadcastText[i];
-				ii++;
+				m_pClient->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "broadcast", aLine, color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClMessageHighlightColor)));
 			}
 		}
-		aBuf[ii] = '\0';
-		if(aBuf[0])
-			m_pClient->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "broadcast", aBuf, color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClMessageHighlightColor)));
 	}
 }

--- a/src/game/client/components/broadcast.cpp
+++ b/src/game/client/components/broadcast.cpp
@@ -31,13 +31,15 @@ void CBroadcast::RenderServerBroadcast()
 	if(m_pClient->m_Scoreboard.Active() || m_pClient->m_Motd.IsActive() || !g_Config.m_ClShowBroadcasts)
 		return;
 
-	Graphics()->MapScreen(0, 0, 300 * Graphics()->ScreenAspect(), 300);
+	const float Height = 300.0f;
+	const float Width = Height * Graphics()->ScreenAspect();
+	Graphics()->MapScreen(0.0f, 0.0f, Width, Height);
 
 	if(Client()->GameTick(g_Config.m_ClDummy) < m_BroadcastTick)
 	{
 		CTextCursor Cursor;
 		TextRender()->SetCursor(&Cursor, m_BroadcastRenderOffset, 40.0f, 12.0f, TEXTFLAG_RENDER | TEXTFLAG_STOP_AT_END);
-		Cursor.m_LineWidth = 300 * Graphics()->ScreenAspect() - m_BroadcastRenderOffset;
+		Cursor.m_LineWidth = Width - m_BroadcastRenderOffset;
 		TextRender()->TextEx(&Cursor, m_aBroadcastText, -1);
 	}
 }
@@ -52,12 +54,12 @@ void CBroadcast::OnMessage(int MsgType, void *pRawMsg)
 
 void CBroadcast::OnBroadcastMessage(const CNetMsg_Sv_Broadcast *pMsg)
 {
+	const float Height = 300.0f;
+	const float Width = Height * Graphics()->ScreenAspect();
+	Graphics()->MapScreen(0.0f, 0.0f, Width, Height);
+
 	str_copy(m_aBroadcastText, pMsg->m_pMessage);
-	CTextCursor Cursor;
-	TextRender()->SetCursor(&Cursor, 0, 0, 12.0f, TEXTFLAG_STOP_AT_END);
-	Cursor.m_LineWidth = 300 * Graphics()->ScreenAspect();
-	TextRender()->TextEx(&Cursor, m_aBroadcastText, -1);
-	m_BroadcastRenderOffset = 150 * Graphics()->ScreenAspect() - Cursor.m_X / 2;
+	m_BroadcastRenderOffset = Width / 2.0f - TextRender()->TextWidth(12.0f, m_aBroadcastText, -1, Width, TEXTFLAG_STOP_AT_END) / 2.0f;
 	m_BroadcastTick = Client()->GameTick(g_Config.m_ClDummy) + Client()->GameTickSpeed() * 10;
 	if(g_Config.m_ClPrintBroadcasts)
 	{

--- a/src/game/client/components/broadcast.h
+++ b/src/game/client/components/broadcast.h
@@ -11,6 +11,8 @@ class CBroadcast : public CComponent
 	int m_BroadcastTick;
 	float m_BroadcastRenderOffset;
 
+	void OnBroadcastMessage(const CNetMsg_Sv_Broadcast *pMsg);
+
 public:
 	virtual int Sizeof() const override { return sizeof(*this); }
 	virtual void OnReset() override;

--- a/src/game/client/components/broadcast.h
+++ b/src/game/client/components/broadcast.h
@@ -2,6 +2,9 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #ifndef GAME_CLIENT_COMPONENTS_BROADCAST_H
 #define GAME_CLIENT_COMPONENTS_BROADCAST_H
+
+#include <engine/textrender.h>
+
 #include <game/client/component.h>
 
 class CBroadcast : public CComponent
@@ -10,6 +13,7 @@ class CBroadcast : public CComponent
 	char m_aBroadcastText[1024];
 	int m_BroadcastTick;
 	float m_BroadcastRenderOffset;
+	STextContainerIndex m_TextContainerIndex;
 
 	void RenderServerBroadcast();
 	void OnBroadcastMessage(const CNetMsg_Sv_Broadcast *pMsg);
@@ -17,6 +21,7 @@ class CBroadcast : public CComponent
 public:
 	virtual int Sizeof() const override { return sizeof(*this); }
 	virtual void OnReset() override;
+	virtual void OnWindowResize() override;
 	virtual void OnRender() override;
 	virtual void OnMessage(int MsgType, void *pRawMsg) override;
 };

--- a/src/game/client/components/broadcast.h
+++ b/src/game/client/components/broadcast.h
@@ -11,6 +11,7 @@ class CBroadcast : public CComponent
 	int m_BroadcastTick;
 	float m_BroadcastRenderOffset;
 
+	void RenderServerBroadcast();
 	void OnBroadcastMessage(const CNetMsg_Sv_Broadcast *pMsg);
 
 public:

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -520,9 +520,7 @@ void CHud::RenderTextInfo()
 		TextRender()->SetRenderFlags(OldFlags);
 		if(m_FPSTextContainerIndex.Valid())
 		{
-			ColorRGBA TColor(1, 1, 1, 1);
-			ColorRGBA TOutColor(0, 0, 0, 0.3f);
-			TextRender()->RenderTextContainer(m_FPSTextContainerIndex, TColor, TOutColor);
+			TextRender()->RenderTextContainer(m_FPSTextContainerIndex, TextRender()->DefaultTextColor(), TextRender()->DefaultTextOutlineColor());
 		}
 	}
 	if(g_Config.m_ClShowpred)
@@ -558,7 +556,7 @@ void CHud::RenderTeambalanceWarning()
 			else
 				TextRender()->TextColor(0.7f, 0.7f, 0.2f, 1.0f);
 			TextRender()->Text(5, 50, 6, pText, -1.0f);
-			TextRender()->TextColor(1, 1, 1, 1);
+			TextRender()->TextColor(TextRender()->DefaultTextColor());
 		}
 	}
 }
@@ -570,7 +568,7 @@ void CHud::RenderVoting()
 
 	Graphics()->DrawRect(-10, 60 - 2, 100 + 10 + 4 + 5, 46, ColorRGBA(0.0f, 0.0f, 0.0f, 0.4f), IGraphics::CORNER_ALL, 5.0f);
 
-	TextRender()->TextColor(1, 1, 1, 1);
+	TextRender()->TextColor(TextRender()->DefaultTextColor());
 
 	CTextCursor Cursor;
 	char aBuf[512];
@@ -1652,8 +1650,8 @@ void CHud::RenderDDRaceEffects()
 				auto OutlineColor = TextRender()->DefaultTextOutlineColor();
 				OutlineColor.a *= Alpha;
 				TextRender()->RenderTextContainer(m_DDRaceEffectsTextContainerIndex, TextRender()->DefaultTextColor(), OutlineColor);
-				TextRender()->TextColor(1, 1, 1, 1);
 			}
+			TextRender()->TextColor(TextRender()->DefaultTextColor());
 		}
 		else if(!m_ShowFinishTime && m_TimeCpLastReceivedTick + Client()->GameTickSpeed() * 6 > Client()->GameTick(g_Config.m_ClDummy))
 		{
@@ -1693,8 +1691,8 @@ void CHud::RenderDDRaceEffects()
 				auto OutlineColor = TextRender()->DefaultTextOutlineColor();
 				OutlineColor.a *= Alpha;
 				TextRender()->RenderTextContainer(m_DDRaceEffectsTextContainerIndex, TextRender()->DefaultTextColor(), OutlineColor);
-				TextRender()->TextColor(1, 1, 1, 1);
 			}
+			TextRender()->TextColor(TextRender()->DefaultTextColor());
 		}
 	}
 }

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -507,7 +507,6 @@ void CHud::RenderTextInfo()
 		static const float s_aTextWidth[5] = {s_TextWidth0, s_TextWidth00, s_TextWidth000, s_TextWidth0000, s_TextWidth00000};
 
 		int DigitIndex = GetDigitsIndex(FrameTime, 4);
-		//TextRender()->Text(m_Width-10-TextRender()->TextWidth(0,12,Buf,-1,-1.0f), 5, 12, Buf, -1.0f);
 
 		CTextCursor Cursor;
 		TextRender()->SetCursor(&Cursor, m_Width - 10 - s_aTextWidth[DigitIndex], 5, 12, TEXTFLAG_RENDER);


### PR DESCRIPTION
Before (centering):

![screenshot_2023-05-06_16-06-33](https://user-images.githubusercontent.com/23437060/236629074-d5387437-f770-4185-b389-313f170e9a09.png)

After (centering):

![screenshot_2023-05-06_16-06-56](https://user-images.githubusercontent.com/23437060/236629076-1baad8c3-13ee-493a-b716-cb233bf881f5.png)

Before (wrapping):

![screenshot_2023-05-06_16-05-50](https://user-images.githubusercontent.com/23437060/236629122-6a9aa70a-709c-482f-8730-0922506f18dd.png)

After (wrapping):

![screenshot_2023-05-06_16-05-09](https://user-images.githubusercontent.com/23437060/236629125-ba7666f1-b0a1-48fb-9d38-36292c97f1fe.png)


## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
