### PR TITLE
Delay disconnecting until after render call

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -326,6 +326,7 @@ CClient::CClient() :
 	m_aRconUsername[0] = '\0';
 	m_aRconPassword[0] = '\0';
 	m_aPassword[0] = '\0';
+	m_aDisconnectReason[0] = '\0';
 
 	// version-checking
 	m_aVersionStr[0] = '0';
@@ -830,8 +831,13 @@ void CClient::Connect(const char *pAddress, const char *pPassword)
 
 void CClient::DisconnectWithReason(const char *pReason)
 {
+	str_copy(m_aDisconnectReason, pReason == nullptr || pReason[0] == '\0' ? "unknown" : pReason);
+}
+
+void CClient::DisconnectWithReasonImpl(const char *pReason)
+{
 	char aBuf[512];
-	str_format(aBuf, sizeof(aBuf), "disconnecting. reason='%s'", pReason ? pReason : "unknown");
+	str_format(aBuf, sizeof(aBuf), "disconnecting. reason='%s'", pReason);
 	m_pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "client", aBuf, gs_ClientNetworkPrintColor);
 
 	// stop demo playback and recorder
@@ -846,7 +852,7 @@ void CClient::DisconnectWithReason(const char *pReason)
 	m_ServerSentCapabilities = false;
 	m_UseTempRconCommands = 0;
 	m_pConsole->DeregisterTempAll();
-	m_aNetClient[CONN_MAIN].Disconnect(pReason);
+	m_aNetClient[CONN_MAIN].Disconnect(str_comp(pReason, "unknown") == 0 ? nullptr : pReason);
 	SetState(IClient::STATE_OFFLINE);
 	m_pMap->Unload();
 	m_CurrentServerPingInfoType = -1;
@@ -888,7 +894,7 @@ void CClient::Disconnect()
 	if(m_DummyConnected)
 		DummyDisconnect(0);
 	if(m_State != IClient::STATE_OFFLINE)
-		DisconnectWithReason(0);
+		DisconnectWithReason();
 
 	// make sure to remove replay tmp demo
 	if(g_Config.m_ClReplays)
@@ -2524,10 +2530,10 @@ void CClient::PumpNetwork()
 		// check for errors
 		if(State() != IClient::STATE_OFFLINE && State() < IClient::STATE_QUITTING && m_aNetClient[CONN_MAIN].State() == NETSTATE_OFFLINE)
 		{
-			Disconnect();
 			char aBuf[256];
 			str_format(aBuf, sizeof(aBuf), "offline error='%s'", m_aNetClient[CONN_MAIN].ErrorString());
 			m_pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "client", aBuf, gs_ClientNetworkErrPrintColor);
+			DisconnectWithReason(m_aNetClient[CONN_MAIN].ErrorString());
 		}
 
 		if(State() != IClient::STATE_OFFLINE && State() < IClient::STATE_QUITTING && m_DummyConnected &&
@@ -3296,6 +3302,14 @@ void CClient::Run()
 				// if the client does not render, it should reset its render time to a time where it would render the first frame, when it wakes up again
 				LastRenderTime = g_Config.m_GfxRefreshRate ? (Now - (time_freq() / (int64_t)g_Config.m_GfxRefreshRate)) : Now;
 			}
+		}
+
+		// Diconnecting is delayed until after the render call, to ensure
+		// that the map is not unloaded during the render call.
+		if(m_aDisconnectReason[0] != '\0')
+		{
+			DisconnectWithReasonImpl(m_aDisconnectReason);
+			m_aDisconnectReason[0] = '\0';
 		}
 
 		AutoScreenshot_Cleanup();

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -167,6 +167,7 @@ class CClient : public IClient, public CDemoPlayer::IListener
 	char m_aRconPassword[32];
 	int m_UseTempRconCommands;
 	char m_aPassword[32];
+	char m_aDisconnectReason[256];
 	bool m_SendPassword;
 	bool m_ButtonRender = false;
 
@@ -353,7 +354,8 @@ public:
 	void EnterGame(int Conn) override;
 
 	void Connect(const char *pAddress, const char *pPassword = nullptr) override;
-	void DisconnectWithReason(const char *pReason);
+	void DisconnectWithReason(const char *pReason = nullptr);
+	void DisconnectWithReasonImpl(const char *pReason);
 	void Disconnect() override;
 
 	void DummyDisconnect(const char *pReason) override;


### PR DESCRIPTION
When a client component (e.g. the menu or the console) disconnects the client, this immediately unloads the map data but the render call continues as normal. This causes all components rendered after this component to access invalid memory in place of the map, layers and collision data.

This is fixed by delaying the actual disconnecting until after the render call, to ensure that the map data can be safely unloaded.

Closes #6387. Closes #3179.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
