### PR TITLE
Allow using rescue (/r) on health pickup

### DIFF
--- a/src/game/client/prediction/entities/character.h
+++ b/src/game/client/prediction/entities/character.h
@@ -33,9 +33,6 @@ class CCharacter : public CEntity
 public:
 	~CCharacter();
 
-	//character's size
-	static const int ms_PhysSize = 28;
-
 	void PreTick() override;
 	void Tick() override;
 	void TickDeferred() override;

--- a/src/game/client/prediction/entities/pickup.cpp
+++ b/src/game/client/prediction/entities/pickup.cpp
@@ -11,13 +11,13 @@ void CPickup::Tick()
 	Move();
 	// Check if a player intersected us
 	CEntity *apEnts[MAX_CLIENTS];
-	int Num = GameWorld()->FindEntities(m_Pos, 20.0f, apEnts, MAX_CLIENTS, CGameWorld::ENTTYPE_CHARACTER);
+	int Num = GameWorld()->FindEntities(m_Pos, GetProximityRadius() + ms_CollisionExtraSize, apEnts, MAX_CLIENTS, CGameWorld::ENTTYPE_CHARACTER);
 	for(int i = 0; i < Num; ++i)
 	{
 		auto *pChr = static_cast<CCharacter *>(apEnts[i]);
 		if(pChr)
 		{
-			if(GameWorld()->m_WorldConfig.m_IsVanilla && distance(m_Pos, pChr->m_Pos) >= 20.0f * 2) // pickup distance is shorter on vanilla due to using ClosestEntity
+			if(GameWorld()->m_WorldConfig.m_IsVanilla && distance(m_Pos, pChr->m_Pos) >= (GetProximityRadius() + ms_CollisionExtraSize) * 2) // pickup distance is shorter on vanilla due to using ClosestEntity
 				continue;
 			if(m_Layer == LAYER_SWITCH && m_Number > 0 && m_Number < (int)Switchers().size() && !Switchers()[m_Number].m_aStatus[pChr->Team()])
 				continue;

--- a/src/game/client/prediction/entities/pickup.h
+++ b/src/game/client/prediction/entities/pickup.h
@@ -15,6 +15,9 @@ public:
 	bool Match(CPickup *pPickup);
 	bool InDDNetTile() { return m_IsCoreActive; }
 
+	int Type() const { return m_Type; }
+	int Subtype() const { return m_Subtype; }
+
 private:
 	int m_Type;
 	int m_Subtype;

--- a/src/game/client/prediction/entities/pickup.h
+++ b/src/game/client/prediction/entities/pickup.h
@@ -8,6 +8,8 @@
 class CPickup : public CEntity
 {
 public:
+	static const int ms_CollisionExtraSize = 6;
+
 	void Tick() override;
 
 	CPickup(CGameWorld *pGameWorld, int ID, CNetObj_Pickup *pPickup, const CNetObj_EntityEx *pEntEx = 0);

--- a/src/game/server/entities/pickup.cpp
+++ b/src/game/server/entities/pickup.cpp
@@ -35,7 +35,7 @@ void CPickup::Tick()
 
 	// Check if a player intersected us
 	CEntity *apEnts[MAX_CLIENTS];
-	int Num = GameWorld()->FindEntities(m_Pos, 20.0f, apEnts, MAX_CLIENTS, CGameWorld::ENTTYPE_CHARACTER);
+	int Num = GameWorld()->FindEntities(m_Pos, GetProximityRadius() + ms_CollisionExtraSize, apEnts, MAX_CLIENTS, CGameWorld::ENTTYPE_CHARACTER);
 	for(int i = 0; i < Num; ++i)
 	{
 		auto *pChr = static_cast<CCharacter *>(apEnts[i]);

--- a/src/game/server/entities/pickup.h
+++ b/src/game/server/entities/pickup.h
@@ -8,6 +8,8 @@
 class CPickup : public CEntity
 {
 public:
+	static const int ms_CollisionExtraSize = 6;
+
 	CPickup(CGameWorld *pGameWorld, int Type, int SubType = 0, int Layer = 0, int Number = 0);
 
 	void Reset() override;

--- a/src/game/server/entities/pickup.h
+++ b/src/game/server/entities/pickup.h
@@ -18,7 +18,6 @@ public:
 private:
 	int m_Type;
 	int m_Subtype;
-	//int m_SpawnTick;
 
 	// DDRace
 

--- a/src/game/server/entities/pickup.h
+++ b/src/game/server/entities/pickup.h
@@ -15,6 +15,9 @@ public:
 	void TickPaused() override;
 	void Snap(int SnappingClient) override;
 
+	int Type() const { return m_Type; }
+	int Subtype() const { return m_Subtype; }
+
 private:
 	int m_Type;
 	int m_Subtype;


### PR DESCRIPTION
Check if character is in range of health pickup and don't set rescue position if that's the case, so rescue can be used to get out of the health pickup's freeze effect.

The existing `m_Core.m_IsInFreeze` is not set so this should not have any side-effects.

Closes #3330.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
