### PR TITLE
Replace usages of `atan2f` and `atan2` with `std::atan2`

### DIFF
--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -1381,7 +1381,7 @@ void CHud::RenderMovementInformation(const int ClientID)
 	{
 		// On DDNet servers the more accurate angle is displayed, calculated from the target coordinates
 		CNetObj_DDNetCharacter *pExtendedData = &m_pClient->m_Snap.m_aCharacters[ClientID].m_ExtendedData;
-		Angle = atan2f(pExtendedData->m_TargetY, pExtendedData->m_TargetX);
+		Angle = std::atan2(pExtendedData->m_TargetY, pExtendedData->m_TargetX);
 	}
 	else
 	{

--- a/src/game/gamecore.cpp
+++ b/src/game/gamecore.cpp
@@ -160,7 +160,7 @@ void CCharacterCore::Tick(bool UseInput, bool DoDeferredTick)
 		m_Direction = m_Input.m_Direction;
 
 		// setup angle
-		float TmpAngle = atan2f(m_Input.m_TargetY, m_Input.m_TargetX);
+		float TmpAngle = std::atan2(m_Input.m_TargetY, m_Input.m_TargetX);
 		if(TmpAngle < -(pi / 2.0f))
 		{
 			m_Angle = (int)((TmpAngle + (2.0f * pi)) * 256.0f);

--- a/src/game/server/entities/projectile.cpp
+++ b/src/game/server/entities/projectile.cpp
@@ -233,7 +233,7 @@ void CProjectile::Tick()
 		}
 		else if(m_Type == WEAPON_GUN)
 		{
-			GameServer()->CreateDamageInd(CurPos, -atan2(m_Direction.x, m_Direction.y), 10, (m_Owner != -1) ? TeamMask : CClientMask().set());
+			GameServer()->CreateDamageInd(CurPos, -std::atan2(m_Direction.x, m_Direction.y), 10, (m_Owner != -1) ? TeamMask : CClientMask().set());
 			m_MarkedForDestroy = true;
 			return;
 		}
@@ -380,7 +380,7 @@ bool CProjectile::FillExtraInfo(CNetObj_DDNetProjectile *pProj)
 		return false;
 	}
 	//Send additional/modified info, by modifying the fields of the netobj
-	float Angle = -atan2f(m_Direction.x, m_Direction.y);
+	float Angle = -std::atan2(m_Direction.x, m_Direction.y);
 
 	int Data = 0;
 	Data |= (absolute(m_Owner) & 255) << 0;


### PR DESCRIPTION
Another leftover from #6372.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
