### PR TITLE
Fix cl_show_others_alpha not used in places where it can be

### DIFF
--- a/src/game/client/components/damageind.cpp
+++ b/src/game/client/components/damageind.cpp
@@ -1,14 +1,14 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#include <base/color.h>
 #include <engine/demo.h>
 #include <engine/graphics.h>
+#include <game/client/gameclient.h>
+#include <game/client/render.h>
 #include <game/generated/client_data.h>
 #include <game/generated/protocol.h>
 
 #include "damageind.h"
-#include <game/client/render.h>
-
-#include <game/client/gameclient.h>
 
 CDamageInd::CDamageInd()
 {
@@ -33,7 +33,7 @@ void CDamageInd::DestroyI(CDamageInd::CItem *pItem)
 	*pItem = m_aItems[m_NumItems];
 }
 
-void CDamageInd::Create(vec2 Pos, vec2 Dir)
+void CDamageInd::Create(vec2 Pos, vec2 Dir, float Alpha)
 {
 	CItem *pItem = CreateI();
 	if(pItem)
@@ -42,6 +42,8 @@ void CDamageInd::Create(vec2 Pos, vec2 Dir)
 		pItem->m_StartTime = LocalTime();
 		pItem->m_Dir = Dir * -1;
 		pItem->m_StartAngle = -random_angle();
+		pItem->m_Color = ColorRGBA(1.0f, 1.0f, 1.0f, Alpha);
+		pItem->m_StartAlpha = Alpha;
 	}
 }
 
@@ -71,7 +73,11 @@ void CDamageInd::OnRender()
 		else
 		{
 			vec2 Pos = mix(m_aItems[i].m_Pos + m_aItems[i].m_Dir * 75.0f, m_aItems[i].m_Pos, clamp((Life - 0.60f) / 0.15f, 0.0f, 1.0f));
-			Graphics()->SetColor(1.0f, 1.0f, 1.0f, Life / 0.1f);
+			ColorRGBA Color = m_aItems[i].m_Color;
+
+			float LifeAlpha = Life / 0.1f;
+			Color.a = m_aItems[i].m_StartAlpha * LifeAlpha;
+			Graphics()->SetColor(Color);
 			Graphics()->QuadsSetRotation(m_aItems[i].m_StartAngle + Life * 2.0f);
 			Graphics()->RenderQuadContainerAsSprite(m_DmgIndQuadContainerIndex, 0, Pos.x, Pos.y);
 			i++;

--- a/src/game/client/components/damageind.h
+++ b/src/game/client/components/damageind.h
@@ -2,6 +2,7 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #ifndef GAME_CLIENT_COMPONENTS_DAMAGEIND_H
 #define GAME_CLIENT_COMPONENTS_DAMAGEIND_H
+#include <base/color.h>
 #include <base/vmath.h>
 #include <game/client/component.h>
 
@@ -14,6 +15,8 @@ class CDamageInd : public CComponent
 		vec2 m_Dir;
 		float m_StartTime;
 		float m_StartAngle;
+		ColorRGBA m_Color;
+		float m_StartAlpha;
 	};
 
 	enum
@@ -33,7 +36,7 @@ public:
 	CDamageInd();
 	virtual int Sizeof() const override { return sizeof(*this); }
 
-	void Create(vec2 Pos, vec2 Dir);
+	void Create(vec2 Pos, vec2 Dir, float Alpha);
 	void Reset();
 	virtual void OnRender() override;
 	virtual void OnInit() override;

--- a/src/game/client/components/effects.cpp
+++ b/src/game/client/components/effects.cpp
@@ -22,7 +22,7 @@ CEffects::CEffects()
 	m_Add100hz = false;
 }
 
-void CEffects::AirJump(vec2 Pos)
+void CEffects::AirJump(vec2 Pos, float Alpha)
 {
 	CParticle p;
 	p.SetDefault();
@@ -37,6 +37,8 @@ void CEffects::AirJump(vec2 Pos)
 	p.m_Gravity = 500;
 	p.m_Friction = 0.7f;
 	p.m_FlowAffected = 0.0f;
+	p.m_Color.a = Alpha;
+	p.m_StartAlpha = Alpha;
 	m_pClient->m_Particles.Add(CParticles::GROUP_GENERAL, &p);
 
 	p.m_Pos = Pos + vec2(6.0f, 16.0f);
@@ -46,9 +48,9 @@ void CEffects::AirJump(vec2 Pos)
 		m_pClient->m_Sounds.PlayAt(CSounds::CHN_WORLD, SOUND_PLAYER_AIRJUMP, 1.0f, Pos);
 }
 
-void CEffects::DamageIndicator(vec2 Pos, vec2 Dir)
+void CEffects::DamageIndicator(vec2 Pos, vec2 Dir, float Alpha)
 {
-	m_pClient->m_DamageInd.Create(Pos, Dir);
+	m_pClient->m_DamageInd.Create(Pos, Dir, Alpha);
 }
 
 void CEffects::ResetDamageIndicator()
@@ -56,7 +58,7 @@ void CEffects::ResetDamageIndicator()
 	m_pClient->m_DamageInd.Reset();
 }
 
-void CEffects::PowerupShine(vec2 Pos, vec2 Size)
+void CEffects::PowerupShine(vec2 Pos, vec2 Size, float Alpha)
 {
 	if(!m_Add50hz)
 		return;
@@ -74,10 +76,12 @@ void CEffects::PowerupShine(vec2 Pos, vec2 Size)
 	p.m_Gravity = 500;
 	p.m_Friction = 0.9f;
 	p.m_FlowAffected = 0.0f;
+	p.m_Color.a = Alpha;
+	p.m_StartAlpha = Alpha;
 	m_pClient->m_Particles.Add(CParticles::GROUP_GENERAL, &p);
 }
 
-void CEffects::FreezingFlakes(vec2 Pos, vec2 Size)
+void CEffects::FreezingFlakes(vec2 Pos, vec2 Size, float Alpha)
 {
 	if(!m_Add5hz)
 		return;
@@ -99,6 +103,8 @@ void CEffects::FreezingFlakes(vec2 Pos, vec2 Size)
 	p.m_Friction = 0.9f;
 	p.m_FlowAffected = 0.0f;
 	p.m_Collides = false;
+	p.m_Color.a = Alpha;
+	p.m_StartAlpha = Alpha;
 	m_pClient->m_Particles.Add(CParticles::GROUP_EXTRA, &p);
 }
 
@@ -117,11 +123,12 @@ void CEffects::SmokeTrail(vec2 Pos, vec2 Vel, float Alpha, float TimePassed)
 	p.m_EndSize = 0;
 	p.m_Friction = 0.7f;
 	p.m_Gravity = random_float(-500.0f);
-	p.m_Color.a *= Alpha;
+	p.m_Color.a = Alpha;
+	p.m_StartAlpha = Alpha;
 	m_pClient->m_Particles.Add(CParticles::GROUP_PROJECTILE_TRAIL, &p, TimePassed);
 }
 
-void CEffects::SkidTrail(vec2 Pos, vec2 Vel)
+void CEffects::SkidTrail(vec2 Pos, vec2 Vel, float Alpha)
 {
 	if(!m_Add100hz)
 		return;
@@ -136,7 +143,8 @@ void CEffects::SkidTrail(vec2 Pos, vec2 Vel)
 	p.m_EndSize = 0;
 	p.m_Friction = 0.7f;
 	p.m_Gravity = random_float(-500.0f);
-	p.m_Color = ColorRGBA(0.75f, 0.75f, 0.75f, 1.0f);
+	p.m_Color = ColorRGBA(0.75f, 0.75f, 0.75f, Alpha);
+	p.m_StartAlpha = Alpha;
 	m_pClient->m_Particles.Add(CParticles::GROUP_GENERAL, &p);
 }
 
@@ -154,10 +162,11 @@ void CEffects::BulletTrail(vec2 Pos, float Alpha, float TimePassed)
 	p.m_EndSize = 0;
 	p.m_Friction = 0.7f;
 	p.m_Color.a *= Alpha;
+	p.m_StartAlpha = Alpha;
 	m_pClient->m_Particles.Add(CParticles::GROUP_PROJECTILE_TRAIL, &p, TimePassed);
 }
 
-void CEffects::PlayerSpawn(vec2 Pos)
+void CEffects::PlayerSpawn(vec2 Pos, float Alpha)
 {
 	for(int i = 0; i < 32; i++)
 	{
@@ -173,14 +182,15 @@ void CEffects::PlayerSpawn(vec2 Pos)
 		p.m_Rotspeed = random_float();
 		p.m_Gravity = random_float(-400.0f);
 		p.m_Friction = 0.7f;
-		p.m_Color = ColorRGBA(0xb5 / 255.0f, 0x50 / 255.0f, 0xcb / 255.0f, 1.0f);
+		p.m_Color = ColorRGBA(0xb5 / 255.0f, 0x50 / 255.0f, 0xcb / 255.0f, Alpha);
+		p.m_StartAlpha = Alpha;
 		m_pClient->m_Particles.Add(CParticles::GROUP_GENERAL, &p);
 	}
 	if(g_Config.m_SndGame)
 		m_pClient->m_Sounds.PlayAt(CSounds::CHN_WORLD, SOUND_PLAYER_SPAWN, 1.0f, Pos);
 }
 
-void CEffects::PlayerDeath(vec2 Pos, int ClientID)
+void CEffects::PlayerDeath(vec2 Pos, int ClientID, float Alpha)
 {
 	ColorRGBA BloodColor(1.0f, 1.0f, 1.0f);
 
@@ -215,12 +225,13 @@ void CEffects::PlayerDeath(vec2 Pos, int ClientID)
 		p.m_Gravity = 800.0f;
 		p.m_Friction = 0.8f;
 		ColorRGBA c = BloodColor.v4() * random_float(0.75f, 1.0f);
-		p.m_Color = ColorRGBA(c.r, c.g, c.b, 0.75f);
+		p.m_Color = ColorRGBA(c.r, c.g, c.b, 0.75f * Alpha);
+		p.m_StartAlpha = Alpha;
 		m_pClient->m_Particles.Add(CParticles::GROUP_GENERAL, &p);
 	}
 }
 
-void CEffects::Explosion(vec2 Pos)
+void CEffects::Explosion(vec2 Pos, float Alpha)
 {
 	// add to flow
 	for(int y = -8; y <= 8; y++)
@@ -242,6 +253,8 @@ void CEffects::Explosion(vec2 Pos)
 	p.m_StartSize = 150.0f;
 	p.m_EndSize = 0;
 	p.m_Rot = random_angle();
+	p.m_Color.a = Alpha;
+	p.m_StartAlpha = Alpha;
 	m_pClient->m_Particles.Add(CParticles::GROUP_EXPLOSIONS, &p);
 
 	// add the smoke
@@ -257,11 +270,13 @@ void CEffects::Explosion(vec2 Pos)
 		p.m_Gravity = random_float(-800.0f);
 		p.m_Friction = 0.4f;
 		p.m_Color = mix(vec4(0.75f, 0.75f, 0.75f, 1.0f), vec4(0.5f, 0.5f, 0.5f, 1.0f), random_float());
+		p.m_Color.a *= Alpha;
+		p.m_StartAlpha = p.m_Color.a;
 		m_pClient->m_Particles.Add(CParticles::GROUP_GENERAL, &p);
 	}
 }
 
-void CEffects::HammerHit(vec2 Pos)
+void CEffects::HammerHit(vec2 Pos, float Alpha)
 {
 	// add the explosion
 	CParticle p;
@@ -272,6 +287,8 @@ void CEffects::HammerHit(vec2 Pos)
 	p.m_StartSize = 120.0f;
 	p.m_EndSize = 0;
 	p.m_Rot = random_angle();
+	p.m_Color.a = Alpha;
+	p.m_StartAlpha = Alpha;
 	m_pClient->m_Particles.Add(CParticles::GROUP_EXPLOSIONS, &p);
 	if(g_Config.m_SndGame)
 		m_pClient->m_Sounds.PlayAt(CSounds::CHN_WORLD, SOUND_HAMMER_HIT, 1.0f, Pos);

--- a/src/game/client/components/effects.h
+++ b/src/game/client/components/effects.h
@@ -18,16 +18,16 @@ public:
 
 	void BulletTrail(vec2 Pos, float Alpha = 1.f, float TimePassed = 0.f);
 	void SmokeTrail(vec2 Pos, vec2 Vel, float Alpha = 1.f, float TimePassed = 0.f);
-	void SkidTrail(vec2 Pos, vec2 Vel);
-	void Explosion(vec2 Pos);
-	void HammerHit(vec2 Pos);
-	void AirJump(vec2 Pos);
-	void DamageIndicator(vec2 Pos, vec2 Dir);
+	void SkidTrail(vec2 Pos, vec2 Vel, float Alpha = 1.0f);
+	void Explosion(vec2 Pos, float Alpha = 1.0f);
+	void HammerHit(vec2 Pos, float Alpha = 1.0f);
+	void AirJump(vec2 Pos, float Alpha = 1.0f);
+	void DamageIndicator(vec2 Pos, vec2 Dir, float Alpha = 1.0f);
 	void ResetDamageIndicator();
-	void PlayerSpawn(vec2 Pos);
-	void PlayerDeath(vec2 Pos, int ClientID);
-	void PowerupShine(vec2 Pos, vec2 Size);
-	void FreezingFlakes(vec2 Pos, vec2 Size);
+	void PlayerSpawn(vec2 Pos, float Alpha = 1.0f);
+	void PlayerDeath(vec2 Pos, int ClientID, float Alpha = 1.0f);
+	void PowerupShine(vec2 Pos, vec2 Size, float Alpha = 1.0f);
+	void FreezingFlakes(vec2 Pos, vec2 Size, float Alpha = 1.0f);
 
 	void Update();
 };

--- a/src/game/client/components/items.cpp
+++ b/src/game/client/components/items.cpp
@@ -162,7 +162,7 @@ void CItems::RenderPickup(const CNetObj_Pickup *pPrev, const CNetObj_Pickup *pCu
 	else if(pCurrent->m_Type == POWERUP_NINJA)
 	{
 		QuadOffset = m_PickupNinjaOffset;
-		m_pClient->m_Effects.PowerupShine(Pos, vec2(96, 18));
+		m_pClient->m_Effects.PowerupShine(Pos, vec2(96, 18), 1.0f);
 		Pos.x -= 10.0f;
 		Graphics()->TextureSet(GameClient()->m_GameSkin.m_SpritePickupNinja);
 	}

--- a/src/game/client/components/nameplates.cpp
+++ b/src/game/client/components/nameplates.cpp
@@ -176,7 +176,17 @@ void CNamePlates::RenderNameplatePos(vec2 Position, const CNetObj_PlayerInfo *pP
 		{
 			YOffset -= FontSize;
 			char aFriendMark[] = "♥";
-			TextRender()->TextColor(ColorRGBA(1.0f, 0.0f, 0.0f));
+
+			ColorRGBA Color;
+
+			if(OtherTeam && !ForceAlpha)
+				Color = ColorRGBA(1.0f, 0.0f, 0.0f, g_Config.m_ClShowOthersAlpha / 100.0f);
+			else
+				Color = ColorRGBA(1.0f, 0.0f, 0.0f, a);
+
+			Color.a *= Alpha;
+
+			TextRender()->TextColor(Color);
 			float XOffSet = TextRender()->TextWidth(FontSize, aFriendMark, -1, -1.0f) / 2.0f;
 			TextRender()->Text(Position.x - XOffSet, YOffset, FontSize, aFriendMark, -1.0f);
 		}
@@ -221,6 +231,17 @@ void CNamePlates::RenderNameplatePos(vec2 Position, const CNetObj_PlayerInfo *pP
 						StrongWeakStatusColor = color_cast<ColorRGBA>(ColorHSLA(41131));
 						StrongWeakSpriteID = SPRITE_HOOK_WEAK;
 					}
+
+					float ClampedAlpha = 1;
+					if(g_Config.m_ClNameplatesAlways == 0)
+						ClampedAlpha = clamp(1 - std::pow(distance(m_pClient->m_Controls.m_aTargetPos[g_Config.m_ClDummy], Position) / 200.0f, 16.0f), 0.0f, 1.0f);
+
+					if(OtherTeam && !ForceAlpha)
+						StrongWeakStatusColor.a = g_Config.m_ClShowOthersAlpha / 100.0f;
+					else
+						StrongWeakStatusColor.a = ClampedAlpha;
+
+					StrongWeakStatusColor.a *= Alpha;
 					Graphics()->SetColor(StrongWeakStatusColor);
 					RenderTools()->SelectSprite(StrongWeakSpriteID);
 					RenderTools()->GetSpriteScale(StrongWeakSpriteID, ScaleX, ScaleY);

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -462,7 +462,8 @@ void CPlayers::RenderPlayer(
 
 		m_pClient->m_Effects.SkidTrail(
 			Position + vec2(-Player.m_Direction * 6, 12),
-			vec2(-Player.m_Direction * 100 * length(Vel), -50));
+			vec2(-Player.m_Direction * 100 * length(Vel), -50),
+			Alpha);
 	}
 
 	// draw gun
@@ -521,12 +522,12 @@ void CPlayers::RenderPlayer(
 				{
 					Graphics()->QuadsSetRotation(-pi / 2 - State.GetAttach()->m_Angle * pi * 2);
 					WeaponPosition.x -= g_pData->m_Weapons.m_aId[CurrentWeapon].m_Offsetx;
-					m_pClient->m_Effects.PowerupShine(WeaponPosition + vec2(32, 0), vec2(32, 12));
+					m_pClient->m_Effects.PowerupShine(WeaponPosition + vec2(32, 0), vec2(32, 12), Alpha);
 				}
 				else
 				{
 					Graphics()->QuadsSetRotation(-pi / 2 + State.GetAttach()->m_Angle * pi * 2);
-					m_pClient->m_Effects.PowerupShine(WeaponPosition - vec2(32, 0), vec2(32, 12));
+					m_pClient->m_Effects.PowerupShine(WeaponPosition - vec2(32, 0), vec2(32, 12), Alpha);
 				}
 				Graphics()->RenderQuadContainerAsSprite(m_WeaponEmoteQuadContainerIndex, QuadOffset, WeaponPosition.x, WeaponPosition.y);
 
@@ -669,7 +670,7 @@ void CPlayers::RenderPlayer(
 	vec2 BodyPos = Position + vec2(State.GetBody()->m_X, State.GetBody()->m_Y) * TeeAnimScale;
 	if(RenderInfo.m_TeeRenderFlags & TEE_EFFECT_FROZEN)
 	{
-		GameClient()->m_Effects.FreezingFlakes(BodyPos, vec2(32, 32));
+		GameClient()->m_Effects.FreezingFlakes(BodyPos, vec2(32, 32), Alpha);
 	}
 
 	int QuadOffsetToEmoticon = NUM_WEAPONS * 2 + 2 + 2;

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1707,8 +1707,6 @@ void CGameClient::OnNewSnapshot()
 	for(auto &pComponent : m_vpAll)
 		pComponent->OnNewSnapshot();
 
-	float Alpha = g_Config.m_ClShowOthersAlpha / 100.0f;
-
 	// detect air jump for other players
 	for(int i = 0; i < MAX_CLIENTS; i++)
 		if(m_Snap.m_aCharacters[i].m_Active && (m_Snap.m_aCharacters[i].m_Cur.m_Jumped & 2) && !(m_Snap.m_aCharacters[i].m_Prev.m_Jumped & 2))
@@ -1717,6 +1715,10 @@ void CGameClient::OnNewSnapshot()
 				vec2 Pos = mix(vec2(m_Snap.m_aCharacters[i].m_Prev.m_X, m_Snap.m_aCharacters[i].m_Prev.m_Y),
 					vec2(m_Snap.m_aCharacters[i].m_Cur.m_X, m_Snap.m_aCharacters[i].m_Cur.m_Y),
 					Client()->IntraGameTick(g_Config.m_ClDummy));
+				float Alpha = 1.0f;
+				bool SameTeam = m_Teams.SameTeam(m_Snap.m_LocalClientID, i);
+				if(!SameTeam || m_aClients[i].m_Solo || m_aClients[m_Snap.m_LocalClientID].m_Solo)
+					Alpha = g_Config.m_ClShowOthersAlpha / 100.0f;
 				m_Effects.AirJump(Pos, Alpha);
 			}
 


### PR DESCRIPTION
There are some things like damage indicator, spawn particles, etc which we have no way to properly set alpha based on team/solo knowledge because they don't have any info about that. (to my knowledge)

Fixes #6520

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
