### PR TITLE
Shutdown SDL after kernel and client

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -4608,6 +4608,11 @@ int main(int argc, const char **argv)
 	NotificationsInit();
 	CleanerFunctions.push([]() { NotificationsUninit(); });
 
+	// Register SDL for cleanup before creating the kernel and client,
+	// so SDL is shutdown after kernel and client. Otherwise the client
+	// may crash when shutting down after SDL is already shutdown.
+	CleanerFunctions.push([]() { SDL_Quit(); });
+
 	CClient *pClient = CreateClient();
 	IKernel *pKernel = IKernel::Create();
 	pKernel->RegisterInterface(pClient, false);
@@ -4792,7 +4797,6 @@ int main(int argc, const char **argv)
 		PerformAllCleanup();
 		return -1;
 	}
-	CleanerFunctions.push([]() { SDL_Quit(); });
 
 	// run the client
 	dbg_msg("client", "starting...");


### PR DESCRIPTION
Register SDL for cleanup before creating the kernel and client, so SDL is shutdown after kernel and client. Otherwise the client may crash when shutting down after SDL is already shutdown.

Closes #6581.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
