### PR TITLE
Show ASan/UBSan logs in CI also for unit and integration tests

### DIFF
--- a/.github/workflows/clang-sanitizer.yml
+++ b/.github/workflows/clang-sanitizer.yml
@@ -43,9 +43,18 @@ jobs:
         fi
     - name: Run unit tests with ASan and UBSan
       run: |
-        export UBSAN_OPTIONS=suppressions=./ubsan.supp:log_path=./SAN:print_stacktrace=1:halt_on_errors=0
         cmake --build . --config Debug --target run_cxx_tests
         # Rust tests work locally, but still not in CI, even with the same directory
+        if test -n "$(find . -maxdepth 1 -name 'SAN.*' -print -quit)"
+        then
+          cat ./SAN.*
+          exit 1
+        fi
     - name: Run integration tests with ASan and UBSan
       run: |
         make run_integration_tests
+        if test -n "$(find . -maxdepth 1 -name 'SAN.*' -print -quit)"
+        then
+          cat ./SAN.*
+          exit 1
+        fi


### PR DESCRIPTION
The ASan/UBSan logs are currently only printed in the CI log when launching the client and server once.

Now the logs are also printed when the unit or integration tests fail due to a sanitizer crash.

A redundant definition of an environment variable is removed.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
