### PR TITLE
Fix uninitialized field causing assertion error with MSVC

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -4906,12 +4906,14 @@ void CEditor::RenderFileDialog()
 		UI()->DoLabel(&FileIcon, pIconType, 12.0f, TEXTALIGN_ML);
 		TextRender()->SetCurFont(nullptr);
 
-		char aBufTimeModified[64];
-		str_timestamp_ex(m_vpFilteredFileList[i]->m_TimeModified, aBufTimeModified, sizeof(aBufTimeModified), "%d.%m.%Y %H:%M");
-
 		UI()->DoLabel(&Button, m_vpFilteredFileList[i]->m_aName, 10.0f, TEXTALIGN_ML);
+
 		if(!m_vpFilteredFileList[i]->m_IsLink && str_comp(m_vpFilteredFileList[i]->m_aFilename, "..") != 0)
+		{
+			char aBufTimeModified[64];
+			str_timestamp_ex(m_vpFilteredFileList[i]->m_TimeModified, aBufTimeModified, sizeof(aBufTimeModified), "%d.%m.%Y %H:%M");
 			UI()->DoLabel(&TimeModified, aBufTimeModified, 10.0f, TEXTALIGN_MR);
+		}
 	}
 
 	const int NewSelection = s_ListBox.DoEnd();
@@ -5106,6 +5108,7 @@ void CEditor::FilelistPopulate(int StorageType, bool KeepSelection)
 		Item.m_IsDir = true;
 		Item.m_IsLink = true;
 		Item.m_StorageType = IStorage::TYPE_SAVE;
+		Item.m_TimeModified = 0;
 		m_vCompleteFileList.push_back(Item);
 	}
 	Storage()->ListDirectoryInfo(StorageType, m_pFileDialogPath, EditorListdirCallback, this);


### PR DESCRIPTION
The modified time was uninitialized for the editor file browser entry corresponding to the downloadedmaps-link. The time is never rendered for links, but the uninitialized time value was still passed to `str_timestamp_ex`, which results in an assertion error due to an incorrect time value being used when compiling with MSVC.

This is fixed by properly initializing the field and also by only calling `str_timestamp_ex` when the time value will be rendered.

Closes #6579.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
