### PR TITLE
Revert "Delay disconnecting until after render call"

### DIFF
--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -167,7 +167,6 @@ class CClient : public IClient, public CDemoPlayer::IListener
 	char m_aRconPassword[32];
 	int m_UseTempRconCommands;
 	char m_aPassword[32];
-	char m_aDisconnectReason[256];
 	bool m_SendPassword;
 	bool m_ButtonRender = false;
 
@@ -354,8 +353,7 @@ public:
 	void EnterGame(int Conn) override;
 
 	void Connect(const char *pAddress, const char *pPassword = nullptr) override;
-	void DisconnectWithReason(const char *pReason = nullptr);
-	void DisconnectWithReasonImpl(const char *pReason);
+	void DisconnectWithReason(const char *pReason);
 	void Disconnect() override;
 
 	void DummyDisconnect(const char *pReason) override;


### PR DESCRIPTION
This reverts commit 5c90fd2b8324bdbe89331bf1c819bca4b16f391a.

Delaying the disconnecting causes issues when the client automatically disconnects immediately before connecting to another server or starting demo playback.

It's not necessary to delay the disconnecting to deal with #6387, as #6589 is already enough. It's easier to revert this instead of rewriting the client so connecting and starting demo playback are also delayed.

Closes #6595.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
