### PR TITLE
Fix logging (fixes #6611)

### DIFF
--- a/src/base/logger.h
+++ b/src/base/logger.h
@@ -202,7 +202,7 @@ std::unique_ptr<ILogger> log_logger_windows_debugger();
 class CFutureLogger : public ILogger
 {
 private:
-	std::atomic<ILogger *> m_pLogger;
+	std::shared_ptr<ILogger> m_pLogger;
 	std::vector<CLogMessage> m_vPending;
 	std::mutex m_PendingLock;
 
@@ -211,7 +211,7 @@ public:
 	 * Replace the `CFutureLogger` instance with the given logger. It'll
 	 * receive all log messages sent to the `CFutureLogger` so far.
 	 */
-	void Set(std::unique_ptr<ILogger> &&pLogger);
+	void Set(std::shared_ptr<ILogger> pLogger);
 	void Log(const CLogMessage *pMessage) override;
 	void GlobalFinish() override;
 };

--- a/src/engine/shared/engine.cpp
+++ b/src/engine/shared/engine.cpp
@@ -30,7 +30,7 @@ public:
 	IStorage *m_pStorage;
 	bool m_Logging;
 
-	std::shared_ptr<ILogger> m_pFutureLogger;
+	std::shared_ptr<CFutureLogger> m_pFutureLogger;
 
 	char m_aAppName[256];
 
@@ -115,7 +115,7 @@ public:
 
 	void SetAdditionalLogger(std::shared_ptr<ILogger> &&pLogger) override
 	{
-		m_pFutureLogger = pLogger;
+		m_pFutureLogger->Set(pLogger);
 	}
 };
 


### PR DESCRIPTION
@heinrich5991 Was the atomic important? Could we have a lock instead if so?

Seems a bit annoying since atomic can't have a shared_ptr inside

![Screenshot 2023-05-18 at 18 02 32](https://github.com/ddnet/ddnet/assets/2335377/2f8bcc57-2301-4a65-ada2-0e51f2b8c200)

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
