### PR TITLE
fix timescore

### DIFF
--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -11,6 +11,7 @@
 #include "teeinfo.h"
 
 #include <memory>
+#include <optional>
 
 class CCharacter;
 class CGameContext;
@@ -104,7 +105,7 @@ public:
 
 	int m_DieTick;
 	int m_PreviousDieTick;
-	int m_Score;
+	std::optional<int> m_Score;
 	int m_JoinTick;
 	bool m_ForceBalanced;
 	int m_LastActionTick;

--- a/src/game/server/scoreworker.cpp
+++ b/src/game/server/scoreworker.cpp
@@ -40,7 +40,7 @@ void CScorePlayerResult::SetVariant(Variant v)
 		break;
 	case PLAYER_INFO:
 		m_Data.m_Info.m_Birthday = 0;
-		m_Data.m_Info.m_Time = -1;
+		m_Data.m_Info.m_Time.reset();
 		for(float &TimeCp : m_Data.m_Info.m_aTimeCp)
 			TimeCp = 0;
 	}

--- a/src/game/server/scoreworker.h
+++ b/src/game/server/scoreworker.h
@@ -2,6 +2,7 @@
 #define GAME_SERVER_SCOREWORKER_H
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -45,10 +46,10 @@ struct CScorePlayerResult : ISqlResult
 		char m_aBroadcast[1024];
 		struct
 		{
-			float m_Time; // -1 for no time.
+			std::optional<float> m_Time;
 			float m_aTimeCp[NUM_CHECKPOINTS];
 			int m_Birthday; // 0 indicates no birthday
-		} m_Info;
+		} m_Info = {};
 		struct
 		{
 			char m_aReason[VOTE_REASON_LENGTH];

--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -818,7 +818,7 @@ void CGameTeams::OnFinish(CPlayer *Player, float Time, const char *pTimestamp)
 	}
 
 	int TTime = 0 - (int)Time;
-	if(Player->m_Score == -1 || Player->m_Score < TTime)
+	if(!Player->m_Score || -1 * absolute(*Player->m_Score) < TTime)
 	{
 		Player->m_Score = TTime;
 	}

--- a/src/test/score.cpp
+++ b/src/test/score.cpp
@@ -183,7 +183,7 @@ TEST_P(SingleScore, LoadPlayerData)
 	ASSERT_FALSE(CScoreWorker::LoadPlayerData(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
 
 	EXPECT_EQ(m_pPlayerResult->m_MessageKind, CScorePlayerResult::PLAYER_INFO);
-	ASSERT_EQ(m_pPlayerResult->m_Data.m_Info.m_Time, -1.0);
+	ASSERT_FALSE(m_pPlayerResult->m_Data.m_Info.m_Time.has_value());
 	for(auto &Time : m_pPlayerResult->m_Data.m_Info.m_aTimeCp)
 	{
 		ASSERT_EQ(Time, 0);
@@ -194,7 +194,8 @@ TEST_P(SingleScore, LoadPlayerData)
 	ASSERT_FALSE(CScoreWorker::LoadPlayerData(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
 
 	EXPECT_EQ(m_pPlayerResult->m_MessageKind, CScorePlayerResult::PLAYER_INFO);
-	ASSERT_EQ(m_pPlayerResult->m_Data.m_Info.m_Time, 100.0);
+	ASSERT_TRUE(m_pPlayerResult->m_Data.m_Info.m_Time.has_value());
+	ASSERT_EQ(*m_pPlayerResult->m_Data.m_Info.m_Time, 100.0);
 	for(int i = 0; i < NUM_CHECKPOINTS; i++)
 	{
 		ASSERT_EQ(m_pPlayerResult->m_Data.m_Info.m_aTimeCp[i], i);
@@ -205,7 +206,7 @@ TEST_P(SingleScore, LoadPlayerData)
 	ASSERT_FALSE(CScoreWorker::LoadPlayerData(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
 
 	EXPECT_EQ(m_pPlayerResult->m_MessageKind, CScorePlayerResult::PLAYER_INFO);
-	ASSERT_EQ(m_pPlayerResult->m_Data.m_Info.m_Time, -1.0);
+	ASSERT_FALSE(m_pPlayerResult->m_Data.m_Info.m_Time.has_value());
 	for(int i = 0; i < NUM_CHECKPOINTS; i++)
 	{
 		ASSERT_EQ(m_pPlayerResult->m_Data.m_Info.m_aTimeCp[i], i);


### PR DESCRIPTION
Fixes the time displayed, this time i tested it quite thoroughly, i could reproduce the wrong ordering in scoreboard and the time not updating before, and fixed it now.

The previous way also had a issue with times that ended up with a value of -1, which is fixed now too

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
