### PR TITLE
Render tees for online friends in friends list, change friend info text to `Map | Mode | Country/Ping`, show official server icon, show confirmation popup

### DIFF
--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -13,16 +13,16 @@
 #include <engine/console.h>
 #include <engine/demo.h>
 #include <engine/friends.h>
+#include <engine/serverbrowser.h>
 #include <engine/shared/config.h>
 #include <engine/shared/linereader.h>
 #include <engine/textrender.h>
-#include <game/client/components/mapimages.h>
 
 #include <game/client/component.h>
+#include <game/client/components/mapimages.h>
+#include <game/client/render.h>
 #include <game/client/ui.h>
 #include <game/voting.h>
-
-#include <game/client/render.h>
 
 struct CServerProcess
 {
@@ -459,21 +459,37 @@ protected:
 		const CServerInfo *m_pServerInfo;
 		int m_FriendState;
 		bool m_IsPlayer;
+		// skin
+		char m_aSkin[24 + 1];
+		bool m_CustomSkinColors;
+		int m_CustomSkinColorBody;
+		int m_CustomSkinColorFeet;
 
 	public:
 		CFriendItem() {}
 		CFriendItem(const CFriendInfo *pFriendInfo) :
-			m_pServerInfo(nullptr), m_IsPlayer(false)
+			m_pServerInfo(nullptr),
+			m_IsPlayer(false),
+			m_CustomSkinColors(false),
+			m_CustomSkinColorBody(0),
+			m_CustomSkinColorFeet(0)
 		{
 			str_copy(m_aName, pFriendInfo->m_aName);
 			str_copy(m_aClan, pFriendInfo->m_aClan);
 			m_FriendState = m_aName[0] == '\0' ? IFriends::FRIEND_CLAN : IFriends::FRIEND_PLAYER;
+			m_aSkin[0] = '\0';
 		}
-		CFriendItem(const char *pName, const char *pClan, const CServerInfo *pServerInfo, int FriendState, bool IsPlayer) :
-			m_pServerInfo(pServerInfo), m_FriendState(FriendState), m_IsPlayer(IsPlayer)
+		CFriendItem(const CServerInfo::CClient &CurrentClient, const CServerInfo *pServerInfo) :
+			m_pServerInfo(pServerInfo),
+			m_FriendState(CurrentClient.m_FriendState),
+			m_IsPlayer(CurrentClient.m_Player),
+			m_CustomSkinColors(CurrentClient.m_CustomSkinColors),
+			m_CustomSkinColorBody(CurrentClient.m_CustomSkinColorBody),
+			m_CustomSkinColorFeet(CurrentClient.m_CustomSkinColorFeet)
 		{
-			str_copy(m_aName, pName);
-			str_copy(m_aClan, pClan);
+			str_copy(m_aName, CurrentClient.m_aName);
+			str_copy(m_aClan, CurrentClient.m_aClan);
+			str_copy(m_aSkin, CurrentClient.m_aSkin);
 		}
 
 		const char *Name() const { return m_aName; }
@@ -481,6 +497,10 @@ protected:
 		const CServerInfo *ServerInfo() const { return m_pServerInfo; }
 		int FriendState() const { return m_FriendState; }
 		bool IsPlayer() const { return m_IsPlayer; }
+		const char *Skin() const { return m_aSkin; }
+		bool CustomSkinColors() const { return m_CustomSkinColors; }
+		int CustomSkinColorBody() const { return m_CustomSkinColorBody; }
+		int CustomSkinColorFeet() const { return m_CustomSkinColorFeet; }
 
 		const void *ListItemId() const { return &m_aName; }
 		const void *RemoveButtonId() const { return &m_FriendState; }

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -7,6 +7,7 @@
 #include <base/vmath.h>
 
 #include <chrono>
+#include <optional>
 #include <unordered_set>
 #include <vector>
 
@@ -562,7 +563,7 @@ protected:
 	// found in menus_browser.cpp
 	int m_SelectedIndex;
 	void RenderServerbrowserServerList(CUIRect View);
-	void Connect(const char *pAddress);
+	void Connect(const char *pAddress, std::optional<bool> Official = {});
 	void PopupConfirmSwitchServer();
 	void RenderServerbrowserServerDetail(CUIRect View);
 	void RenderServerbrowserFilters(CUIRect View);

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -585,9 +585,14 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 	}
 }
 
-void CMenus::Connect(const char *pAddress)
+void CMenus::Connect(const char *pAddress, std::optional<bool> Official)
 {
-	if(Client()->State() == IClient::STATE_ONLINE && Client()->GetCurrentRaceTime() / 60 >= g_Config.m_ClConfirmDisconnectTime && g_Config.m_ClConfirmDisconnectTime >= 0)
+	if(Official.has_value() && !Official.value())
+	{
+		str_copy(m_aNextServer, pAddress);
+		PopupConfirm(Localize("Non-official server"), Localize("Are you sure that you want to connect to a non-official server?"), Localize("Yes"), Localize("No"), &CMenus::PopupConfirmSwitchServer);
+	}
+	else if(Client()->State() == IClient::STATE_ONLINE && Client()->GetCurrentRaceTime() / 60 >= g_Config.m_ClConfirmDisconnectTime && g_Config.m_ClConfirmDisconnectTime >= 0)
 	{
 		str_copy(m_aNextServer, pAddress);
 		PopupConfirm(Localize("Disconnect"), Localize("Are you sure that you want to disconnect and switch to a different server?"), Localize("Yes"), Localize("No"), &CMenus::PopupConfirmSwitchServer);
@@ -1509,7 +1514,7 @@ void CMenus::RenderServerbrowserFriends(CUIRect View)
 					str_copy(g_Config.m_UiServerAddress, Friend.ServerInfo()->m_aAddress);
 					if(Input()->MouseDoubleClick())
 					{
-						Connect(g_Config.m_UiServerAddress);
+						Connect(g_Config.m_UiServerAddress, Friend.ServerInfo()->m_Official);
 					}
 				}
 			}

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1509,7 +1509,7 @@ void CMenus::RenderServerbrowserFriends(CUIRect View)
 					str_copy(g_Config.m_UiServerAddress, Friend.ServerInfo()->m_aAddress);
 					if(Input()->MouseDoubleClick())
 					{
-						Client()->Connect(g_Config.m_UiServerAddress);
+						Connect(g_Config.m_UiServerAddress);
 					}
 				}
 			}

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1453,9 +1453,34 @@ void CMenus::RenderServerbrowserFriends(CUIRect View)
 				// clan
 				UI()->DoLabel(&ClanLabel, Friend.Clan(), FontSize - 2.0f, TEXTALIGN_ML);
 
-				// info
+				// server info
 				if(Friend.ServerInfo())
 				{
+					// official server icon
+					if(Friend.ServerInfo()->m_Official)
+					{
+						CUIRect OfficialIcon;
+						InfoLabel.VSplitLeft(InfoLabel.h, &OfficialIcon, &InfoLabel);
+						InfoLabel.VSplitLeft(1.0f, nullptr, &InfoLabel); // spacing
+						OfficialIcon.HSplitTop(1.0f, nullptr, &OfficialIcon); // alignment
+
+						SLabelProperties Props;
+						Props.m_EnableWidthCheck = false;
+						TextRender()->SetCurFont(TextRender()->GetFont(TEXT_FONT_ICON_FONT));
+						TextRender()->SetRenderFlags(ETextRenderFlags::TEXT_RENDER_FLAG_ONLY_ADVANCE_WIDTH | ETextRenderFlags::TEXT_RENDER_FLAG_NO_X_BEARING | ETextRenderFlags::TEXT_RENDER_FLAG_NO_Y_BEARING | ETextRenderFlags::TEXT_RENDER_FLAG_NO_PIXEL_ALIGMENT | ETextRenderFlags::TEXT_RENDER_FLAG_NO_OVERSIZE);
+						TextRender()->TextColor(0.4f, 0.7f, 0.94f, 1.0f);
+						TextRender()->TextOutlineColor(0.0f, 0.0f, 0.0f, 1.0f);
+						UI()->DoLabel(&OfficialIcon, FONT_ICON_CERTIFICATE, OfficialIcon.h, TEXTALIGN_MC, Props);
+						TextRender()->TextColor(0.0f, 0.0f, 0.0f, 1.0f);
+						TextRender()->TextOutlineColor(0.0f, 0.0f, 0.0f, 0.0f);
+						UI()->DoLabel(&OfficialIcon, FONT_ICON_CHECK, OfficialIcon.h * 0.5f, TEXTALIGN_MC, Props);
+						TextRender()->TextColor(TextRender()->DefaultTextColor());
+						TextRender()->TextOutlineColor(TextRender()->DefaultTextOutlineColor());
+						TextRender()->SetRenderFlags(0);
+						TextRender()->SetCurFont(nullptr);
+					}
+
+					// server info text
 					char aLatency[16];
 					FormatServerbrowserPing(aLatency, sizeof(aLatency), Friend.ServerInfo());
 					if(aLatency[0] != '\0')

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1377,25 +1377,19 @@ void CMenus::RenderServerbrowserFriends(CUIRect View)
 		// entries
 		if(s_aListExtended[FriendType])
 		{
-			// space
-			{
-				CUIRect Space;
-				List.HSplitTop(SpacingH, &Space, &List);
-				s_ScrollRegion.AddRect(Space);
-			}
-
 			for(size_t FriendIndex = 0; FriendIndex < m_avFriends[FriendType].size(); ++FriendIndex)
 			{
-				CUIRect Rect;
-				const auto &Friend = m_avFriends[FriendType][FriendIndex];
-				List.HSplitTop(10.0f + 10.0f + 2 * 2.0f + 1.0f + (Friend.ServerInfo() == nullptr ? 0.0f : 10.0f), &Rect, &List);
-				s_ScrollRegion.AddRect(Rect);
-				if(FriendIndex < m_avFriends[FriendType].size() - 1)
+				// space
 				{
 					CUIRect Space;
 					List.HSplitTop(SpacingH, &Space, &List);
 					s_ScrollRegion.AddRect(Space);
 				}
+
+				CUIRect Rect;
+				const auto &Friend = m_avFriends[FriendType][FriendIndex];
+				List.HSplitTop(10.0f + 10.0f + 2 * 2.0f + 1.0f + (Friend.ServerInfo() == nullptr ? 0.0f : 10.0f), &Rect, &List);
+				s_ScrollRegion.AddRect(Rect);
 				if(s_ScrollRegion.IsRectClipped(Rect))
 					continue;
 

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1462,10 +1462,12 @@ void CMenus::RenderServerbrowserFriends(CUIRect View)
 				// info
 				if(Friend.ServerInfo())
 				{
-					if(Friend.IsPlayer())
-						str_format(aBuf, sizeof(aBuf), Localize("Playing '%s' on '%s'", "Playing '(gametype)' on '(map)'"), Friend.ServerInfo()->m_aGameType, Friend.ServerInfo()->m_aMap);
+					char aLatency[16];
+					FormatServerbrowserPing(aLatency, sizeof(aLatency), Friend.ServerInfo());
+					if(aLatency[0] != '\0')
+						str_format(aBuf, sizeof(aBuf), "%s | %s | %s", Friend.ServerInfo()->m_aMap, Friend.ServerInfo()->m_aGameType, aLatency);
 					else
-						str_format(aBuf, sizeof(aBuf), Localize("Spectating '%s' on '%s'", "Spectating '(gametype)' on '(map)'"), Friend.ServerInfo()->m_aGameType, Friend.ServerInfo()->m_aMap);
+						str_format(aBuf, sizeof(aBuf), "%s | %s", Friend.ServerInfo()->m_aMap, Friend.ServerInfo()->m_aGameType);
 					UI()->DoLabel(&InfoLabel, aBuf, FontSize - 2.0f, TEXTALIGN_ML);
 				}
 


### PR DESCRIPTION
Closes #6614.

![friends](https://github.com/ddnet/ddnet/assets/23437060/946cd095-a1f3-420c-b158-2e66687e7806)

Show race disconnect confirmation when joining friend. Closes #6622.

Add popup to confirm connecting to friend on non-official server:

![popup](https://github.com/ddnet/ddnet/assets/23437060/cb702277-93a5-4d90-9369-0f3dbff7cca3)


## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
