### PR TITLE
Fix incorrect swapping with draggers

### DIFF
--- a/src/game/server/entities/dragger.cpp
+++ b/src/game/server/entities/dragger.cpp
@@ -222,4 +222,8 @@ void CDragger::Snap(int SnappingClient)
 void CDragger::SwapClients(int Client1, int Client2)
 {
 	std::swap(m_apDraggerBeam[Client1], m_apDraggerBeam[Client2]);
+	for(int &TargetId : m_aTargetIdInTeam)
+	{
+		TargetId = TargetId == Client1 ? Client2 : TargetId == Client2 ? Client1 : TargetId;
+	}
 }


### PR DESCRIPTION
There is another member variable `CDragger::m_aTargetIdInTeam` that contains for every team the client ID of the team member currently being dragged by this dragger.

The client IDs in this array also need to be swapped accordingly or the dragger will not switch target correctly when swapping.

Closes #5865.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
