### PR TITLE
Remove `snd_rate` and `cl_threadsoundloading` from settings menu, enable threaded sound loading per default again, set minimum/maximum values for `snd_rate`

### DIFF
--- a/data/languages/arabic.txt
+++ b/data/languages/arabic.txt
@@ -780,9 +780,6 @@ Show tiles layers from BG map
 Remove chat
 == ﺕﺎﺸﻟﺍ ﻑﺬﺣ
 
-Threaded sound loading
-== ﺔﻳﺍﺪﺒﻟﺍ ﺕﻮﺼ
-
 Frags
 == ﻞﺑﺎﻨﻗ
 

--- a/data/languages/arabic.txt
+++ b/data/languages/arabic.txt
@@ -1533,9 +1533,6 @@ Graphics cards
 auto
 == 
 
-Sample rate
-== 
-
 Appearance
 == 
 

--- a/data/languages/belarusian.txt
+++ b/data/languages/belarusian.txt
@@ -348,9 +348,6 @@ Rename demo
 Reset filter
 == Скінуць фільтр
 
-Sample rate
-== Чашчыня сэмпла
-
 Score
 == Ачкі
 

--- a/data/languages/belarusian.txt
+++ b/data/languages/belarusian.txt
@@ -1252,9 +1252,6 @@ Enable team chat sound
 Enable highlighted chat sound
 == Уключыць гук падсвечаных паведамленняў
 
-Threaded sound loading
-== Шматструменная загрузка гукаў
-
 Game sound volume
 == Гучнасць гульні
 

--- a/data/languages/bosnian.txt
+++ b/data/languages/bosnian.txt
@@ -350,9 +350,6 @@ Rename demo
 Reset filter
 == Poništi filter
 
-Sample rate
-== Frekvencija
-
 Score
 == Rezultat
 

--- a/data/languages/bosnian.txt
+++ b/data/languages/bosnian.txt
@@ -865,9 +865,6 @@ Enable team chat sound
 Enable highlighted chat sound
 == Omogući zvuk označavanja u čatu
 
-Threaded sound loading
-== Učitavanje tredovanog zvuka
-
 Map sound volume
 == Glasnoća zvuka mape
 

--- a/data/languages/brazilian_portuguese.txt
+++ b/data/languages/brazilian_portuguese.txt
@@ -373,9 +373,6 @@ Rename demo
 Reset filter
 == Redefinir filtro
 
-Sample rate
-== Frequência do som
-
 Score
 == Pontos
 

--- a/data/languages/brazilian_portuguese.txt
+++ b/data/languages/brazilian_portuguese.txt
@@ -688,9 +688,6 @@ Ghost
 Remove chat
 == Remover chat
 
-Threaded sound loading
-== Carregamento de som em fluxos
-
 Check now
 == Verificar agora
 

--- a/data/languages/bulgarian.txt
+++ b/data/languages/bulgarian.txt
@@ -1281,9 +1281,6 @@ Enable team chat sound
 Enable highlighted chat sound
 == 
 
-Threaded sound loading
-== 
-
 Game sound volume
 == 
 

--- a/data/languages/bulgarian.txt
+++ b/data/languages/bulgarian.txt
@@ -347,9 +347,6 @@ Rename demo
 Reset filter
 == Рестартирай филтрите
 
-Sample rate
-== Честота
-
 Score
 == Точки
 

--- a/data/languages/catalan.txt
+++ b/data/languages/catalan.txt
@@ -345,9 +345,6 @@ Rename demo
 Reset filter
 == Reiniciar el filtre
 
-Sample rate
-== Freqüència de la imatge
-
 Score
 == Punts
 

--- a/data/languages/catalan.txt
+++ b/data/languages/catalan.txt
@@ -705,9 +705,6 @@ Ghost
 Remove chat
 == Eliminar el xat
 
-Threaded sound loading
-== Càrrega de so en fils
-
 Check now
 == Comprova ara
 

--- a/data/languages/chuvash.txt
+++ b/data/languages/chuvash.txt
@@ -1281,9 +1281,6 @@ Enable team chat sound
 Enable highlighted chat sound
 == 
 
-Threaded sound loading
-== 
-
 Game sound volume
 == 
 

--- a/data/languages/chuvash.txt
+++ b/data/languages/chuvash.txt
@@ -347,9 +347,6 @@ Rename demo
 Reset filter
 == Фильтрсене тасат
 
-Sample rate
-== Тăтăшлăх
-
 Score
 == Паллă
 

--- a/data/languages/czech.txt
+++ b/data/languages/czech.txt
@@ -858,9 +858,6 @@ Enable team chat sound
 Enable highlighted chat sound
 == Povolit zvuk zvýrazněné zprávy
 
-Threaded sound loading
-== Načítání Threaded zvuku
-
 Map sound volume
 == Hlasitost zvuků mapy
 

--- a/data/languages/czech.txt
+++ b/data/languages/czech.txt
@@ -346,9 +346,6 @@ Rename demo
 Reset filter
 == Vymazat filtr
 
-Sample rate
-== Vzorkování:
-
 Score
 == Skóre
 

--- a/data/languages/danish.txt
+++ b/data/languages/danish.txt
@@ -348,9 +348,6 @@ Rename demo
 Reset filter
 == Nulstil filter
 
-Sample rate
-== Sample frekvens
-
 Score
 == Score
 

--- a/data/languages/danish.txt
+++ b/data/languages/danish.txt
@@ -908,9 +908,6 @@ Enable team chat sound
 Enable highlighted chat sound
 == Aktivér fremhævet chatlyd
 
-Threaded sound loading
-== Trådet lydindlæsning
-
 Game sound volume
 == Spillydstyrke
 

--- a/data/languages/dutch.txt
+++ b/data/languages/dutch.txt
@@ -360,9 +360,6 @@ Rename demo
 Reset filter
 == Herstel filter
 
-Sample rate
-== Voorbeeldssnelheid
-
 Score
 == Score
 

--- a/data/languages/dutch.txt
+++ b/data/languages/dutch.txt
@@ -880,9 +880,6 @@ Enable team chat sound
 Enable highlighted chat sound
 == Schakel gemarkeerde chat geluiden in
 
-Threaded sound loading
-== Threaded geluid laden
-
 Map sound volume
 == Map geluid volume
 

--- a/data/languages/esperanto.txt
+++ b/data/languages/esperanto.txt
@@ -1324,9 +1324,6 @@ Enable highlighted chat sound
 Threaded sound loading
 == 
 
-Sample rate
-== 
-
 Sound volume
 == 
 

--- a/data/languages/esperanto.txt
+++ b/data/languages/esperanto.txt
@@ -1321,9 +1321,6 @@ Enable team chat sound
 Enable highlighted chat sound
 == 
 
-Threaded sound loading
-== 
-
 Sound volume
 == 
 

--- a/data/languages/finnish.txt
+++ b/data/languages/finnish.txt
@@ -925,9 +925,6 @@ Enable team chat sound
 Enable highlighted chat sound
 == Ota korostetun chatin äänet käyttöön
 
-Threaded sound loading
-== Säikeistetty äänilataus
-
 Game sound volume
 == Pelin äänenvoimakkuus
 

--- a/data/languages/finnish.txt
+++ b/data/languages/finnish.txt
@@ -349,9 +349,6 @@ Rename demo
 Reset filter
 == Nollaa suotimet
 
-Sample rate
-== Näytteenottotaajuus
-
 Score
 == Pisteet
 

--- a/data/languages/french.txt
+++ b/data/languages/french.txt
@@ -371,9 +371,6 @@ Rename demo
 Reset filter
 == Filtres par défaut
 
-Sample rate
-== Taux d'échantillonnage
-
 Score
 == Score
 

--- a/data/languages/french.txt
+++ b/data/languages/french.txt
@@ -784,9 +784,6 @@ Update failed! Check log...
 Reset
 == Défaut
 
-Threaded sound loading
-== Chargement des sons dans un thread spécifique
-
 File already exists, do you want to overwrite it?
 == Ce fichier existe déjà, voulez-vous l'écraser ?
 

--- a/data/languages/german.txt
+++ b/data/languages/german.txt
@@ -368,9 +368,6 @@ Rename demo
 Reset filter
 == Standardfilter
 
-Sample rate
-== Abtastrate
-
 Score
 == Punkte
 

--- a/data/languages/german.txt
+++ b/data/languages/german.txt
@@ -824,9 +824,6 @@ Show tiles layers from BG map
 Remove chat
 == Chat entfernen
 
-Threaded sound loading
-== Sounds in Threads laden
-
 Frags
 == Abschüsse
 

--- a/data/languages/greek.txt
+++ b/data/languages/greek.txt
@@ -350,9 +350,6 @@ Rename demo
 Reset filter
 == Αφαίρεση φίλτρου
 
-Sample rate
-== Δειγματοληψία
-
 Score
 == Βαθμ.
 

--- a/data/languages/greek.txt
+++ b/data/languages/greek.txt
@@ -1284,9 +1284,6 @@ Enable team chat sound
 Enable highlighted chat sound
 == 
 
-Threaded sound loading
-== 
-
 Game sound volume
 == 
 

--- a/data/languages/hungarian.txt
+++ b/data/languages/hungarian.txt
@@ -853,9 +853,6 @@ Deactivate
 Welcome to DDNet
 == Üdvözlet a DDNet-en
 
-Threaded sound loading
-== Csavarmenetes hang betöltése
-
 Activate
 == Aktiválás
 

--- a/data/languages/hungarian.txt
+++ b/data/languages/hungarian.txt
@@ -340,9 +340,6 @@ Rename demo
 Reset filter
 == Szűrő visszaállítása
 
-Sample rate
-== Mintavételi frekvencia
-
 Score
 == Pontszám
 

--- a/data/languages/italian.txt
+++ b/data/languages/italian.txt
@@ -940,9 +940,6 @@ Enable team chat sound
 Enable highlighted chat sound
 == Abilita suono della chat evidenziata
 
-Threaded sound loading
-== Suono filettato
-
 Game sound volume
 == Volume del gioco
 

--- a/data/languages/italian.txt
+++ b/data/languages/italian.txt
@@ -352,9 +352,6 @@ Rename demo
 Reset filter
 == Azzera filtri
 
-Sample rate
-== Frequenza
-
 Score
 == Punti
 

--- a/data/languages/japanese.txt
+++ b/data/languages/japanese.txt
@@ -934,9 +934,6 @@ Enable team chat sound
 Enable highlighted chat sound
 == メンション・メッセージ受信音
 
-Threaded sound loading
-== マルチスレッド音声読み込み
-
 Game sound volume
 == ゲーム SFX 音量
 

--- a/data/languages/japanese.txt
+++ b/data/languages/japanese.txt
@@ -344,9 +344,6 @@ Rename demo
 Reset filter
 == フィルタをリセット
 
-Sample rate
-== サンプルレート
-
 Score
 == スコア
 

--- a/data/languages/korean.txt
+++ b/data/languages/korean.txt
@@ -958,9 +958,6 @@ Enable team chat sound
 Enable highlighted chat sound
 == 언급된 채팅 소리 활성화
 
-Threaded sound loading
-== 다중 스레드 소리 로딩
-
 Game sound volume
 == 게임 음량
 

--- a/data/languages/korean.txt
+++ b/data/languages/korean.txt
@@ -350,9 +350,6 @@ Rename demo
 Reset filter
 == 필터 초기화
 
-Sample rate
-== 샘플링 속도
-
 Score
 == 점수
 

--- a/data/languages/kyrgyz.txt
+++ b/data/languages/kyrgyz.txt
@@ -1275,9 +1275,6 @@ Enable team chat sound
 Enable highlighted chat sound
 == 
 
-Threaded sound loading
-== 
-
 Game sound volume
 == 
 

--- a/data/languages/kyrgyz.txt
+++ b/data/languages/kyrgyz.txt
@@ -412,9 +412,6 @@ Laser
 Round
 == Раунду
 
-Sample rate
-== Жыштыгы
-
 Sat.
 == Канык.
 

--- a/data/languages/norwegian.txt
+++ b/data/languages/norwegian.txt
@@ -349,9 +349,6 @@ Rename demo
 Reset filter
 == Tilbakestill filter
 
-Sample rate
-== Samplingsrate
-
 Score
 == Poeng
 

--- a/data/languages/norwegian.txt
+++ b/data/languages/norwegian.txt
@@ -870,9 +870,6 @@ Enable team chat sound
 Enable highlighted chat sound
 == Lyd for uthevet samtale
 
-Threaded sound loading
-== Trådet lyd-innlasting
-
 Map sound volume
 == Lydvolum bane
 

--- a/data/languages/persian.txt
+++ b/data/languages/persian.txt
@@ -1288,9 +1288,6 @@ Enable regular chat sound
 Enable highlighted chat sound
 == ﻩﺪﺷ ﺖﯾﻼﯾﺎﻫ ﺖﭼ ﯼﺍﺪﺻ ﻥﺩﺮﮐ ﻦﺷﻭﺭ
 
-Threaded sound loading
-== ﯼﺍ ﻪﺘﺷﺭ ﯼﺍﺪﺻ ﯼﺭﺍﺬﮔﺭﺎﺑ
-
 Appearance
 == ﺮﻫﺎﻇ
 

--- a/data/languages/persian.txt
+++ b/data/languages/persian.txt
@@ -1291,9 +1291,6 @@ Enable highlighted chat sound
 Threaded sound loading
 == ﯼﺍ ﻪﺘﺷﺭ ﯼﺍﺪﺻ ﯼﺭﺍﺬﮔﺭﺎﺑ
 
-Sample rate
-== ﻪﻧﻮﻤﻧ ﺥﺮﻧ
-
 Appearance
 == ﺮﻫﺎﻇ
 

--- a/data/languages/polish.txt
+++ b/data/languages/polish.txt
@@ -716,9 +716,6 @@ Enable team chat sound
 Enable highlighted chat sound
 == Włącz dźwięk wyróżnionej wiadomości
 
-Threaded sound loading
-== Wątkowe ładowanie dźwięku
-
 Map sound volume
 == Glośność dźwięków z map
 

--- a/data/languages/polish.txt
+++ b/data/languages/polish.txt
@@ -351,9 +351,6 @@ Rename demo
 Reset filter
 == Przywróć domyślne
 
-Sample rate
-== Częstotliwość próbkowania
-
 Score
 == Wynik
 

--- a/data/languages/portuguese.txt
+++ b/data/languages/portuguese.txt
@@ -1447,9 +1447,6 @@ auto
 Enable long pain sound (used when shooting in freeze)
 == 
 
-Threaded sound loading
-== 
-
 Appearance
 == 
 

--- a/data/languages/portuguese.txt
+++ b/data/languages/portuguese.txt
@@ -363,9 +363,6 @@ Reset
 Reset filter
 == Reiniciar filtro
 
-Sample rate
-== Frequencia de rate
-
 Score
 == Pontos
 

--- a/data/languages/romanian.txt
+++ b/data/languages/romanian.txt
@@ -1290,9 +1290,6 @@ Enable team chat sound
 Enable highlighted chat sound
 == 
 
-Threaded sound loading
-== 
-
 Game sound volume
 == 
 

--- a/data/languages/romanian.txt
+++ b/data/languages/romanian.txt
@@ -356,9 +356,6 @@ Rename demo
 Reset filter
 == Filtru implicit
 
-Sample rate
-== Frecvența
-
 Score
 == Scor
 

--- a/data/languages/russian.txt
+++ b/data/languages/russian.txt
@@ -360,9 +360,6 @@ Rename demo
 Reset filter
 == Сбросить фильтры
 
-Sample rate
-== Частота
-
 Score
 == Счёт
 

--- a/data/languages/russian.txt
+++ b/data/languages/russian.txt
@@ -537,9 +537,6 @@ Enable team chat sound
 Enable highlighted chat sound
 == Звуки подсвечиваемых сообщений
 
-Threaded sound loading
-== Фоновая загрузка музыки
-
 Use DDRace Scoreboard
 == Использовать DDRace таблицу счета
 

--- a/data/languages/serbian.txt
+++ b/data/languages/serbian.txt
@@ -347,9 +347,6 @@ Rename demo
 Reset filter
 == Povrati filter
 
-Sample rate
-== Frekfencija
-
 Score
 == Rezultat
 

--- a/data/languages/serbian.txt
+++ b/data/languages/serbian.txt
@@ -902,9 +902,6 @@ Enable team chat sound
 Enable highlighted chat sound
 == Omogući istaknuti zvuk dopisivanja
 
-Threaded sound loading
-== Učitavanje zvuka sa navojem
-
 Map sound volume
 == Jačina zvuka na mapi
 

--- a/data/languages/serbian_cyrillic.txt
+++ b/data/languages/serbian_cyrillic.txt
@@ -343,9 +343,6 @@ Rename demo
 Reset filter
 == Поврати филтер
 
-Sample rate
-== Фрекфенција
-
 Score
 == Резултат
 

--- a/data/languages/serbian_cyrillic.txt
+++ b/data/languages/serbian_cyrillic.txt
@@ -901,9 +901,6 @@ Enable team chat sound
 Enable highlighted chat sound
 == Омогући истакнути звук дописивања
 
-Threaded sound loading
-== Учитавање звука са навојем
-
 Map sound volume
 == Јачина звука на мапи
 

--- a/data/languages/simplified_chinese.txt
+++ b/data/languages/simplified_chinese.txt
@@ -301,9 +301,6 @@ Enable team chat sound
 Enable highlighted chat sound
 == 启用聊天被提及消息提示音
 
-Threaded sound loading
-== 启用多线程音频加载
-
 Name
 == 名称
 

--- a/data/languages/simplified_chinese.txt
+++ b/data/languages/simplified_chinese.txt
@@ -407,9 +407,6 @@ Rename demo
 Reset filter
 == 重置筛选
 
-Sample rate
-== 采样率
-
 Score
 == 分数
 

--- a/data/languages/slovak.txt
+++ b/data/languages/slovak.txt
@@ -1281,9 +1281,6 @@ Enable team chat sound
 Enable highlighted chat sound
 == 
 
-Threaded sound loading
-== 
-
 Game sound volume
 == 
 

--- a/data/languages/slovak.txt
+++ b/data/languages/slovak.txt
@@ -347,9 +347,6 @@ Rename demo
 Reset filter
 == Obnoviť filter
 
-Sample rate
-== Sample rate
-
 Score
 == Skóre
 

--- a/data/languages/spanish.txt
+++ b/data/languages/spanish.txt
@@ -886,9 +886,6 @@ Enable team chat sound
 Enable highlighted chat sound
 == Habilitar sonido de chat resaltado
 
-Threaded sound loading
-== Carga de sonido en un hilo
-
 Map sound volume
 == Vol. del sonido del mapa
 

--- a/data/languages/spanish.txt
+++ b/data/languages/spanish.txt
@@ -368,9 +368,6 @@ Rename demo
 Reset filter
 == Resetear filtro
 
-Sample rate
-== Frecuencia de muestreo
-
 Score
 == Puntos
 

--- a/data/languages/swedish.txt
+++ b/data/languages/swedish.txt
@@ -351,9 +351,6 @@ Rename demo
 Reset filter
 == Återställ filter
 
-Sample rate
-== Samplingsfrekvens
-
 Score
 == Poäng
 

--- a/data/languages/swedish.txt
+++ b/data/languages/swedish.txt
@@ -741,9 +741,6 @@ Use high DPI
 may cause delay
 == kan orsaka fördröjning
 
-Threaded sound loading
-== Threaded ljud laddning
-
 AntiPing
 == AntiPing
 

--- a/data/languages/traditional_chinese.txt
+++ b/data/languages/traditional_chinese.txt
@@ -395,9 +395,6 @@ Rename demo
 Reset filter
 == 重置過濾器
 
-Sample rate
-== 取樣率
-
 Score
 == 分數
 

--- a/data/languages/traditional_chinese.txt
+++ b/data/languages/traditional_chinese.txt
@@ -289,9 +289,6 @@ Enable team chat sound
 Enable highlighted chat sound
 == 啟用被提及時的提示音
 
-Threaded sound loading
-== 啟用多執行緒音訊載入
-
 Name
 == 名稱
 

--- a/data/languages/turkish.txt
+++ b/data/languages/turkish.txt
@@ -349,9 +349,6 @@ Rename demo
 Reset filter
 == Filtreleri sıfırla
 
-Sample rate
-== Örnekleme hızı
-
 Score
 == Skor
 

--- a/data/languages/turkish.txt
+++ b/data/languages/turkish.txt
@@ -876,9 +876,6 @@ Enable team chat sound
 Enable highlighted chat sound
 == Vurgulanmış mesaj sesini etkinleştir
 
-Threaded sound loading
-== Threaded ses yükleme
-
 Map sound volume
 == Harita ses seviyesi
 

--- a/data/languages/ukrainian.txt
+++ b/data/languages/ukrainian.txt
@@ -862,9 +862,6 @@ Enable team chat sound
 Enable highlighted chat sound
 == Включити звуки виділених повідомлень
 
-Threaded sound loading
-== музика при завантаженні
-
 Map sound volume
 == Гучність звуку на карті
 

--- a/data/languages/ukrainian.txt
+++ b/data/languages/ukrainian.txt
@@ -260,9 +260,6 @@ Remote console
 Reset filter
 == Скинути фільтри
 
-Sample rate
-== Частота
-
 Score
 == бали
 

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -81,7 +81,6 @@ MACRO_CONFIG_INT(SndRate, snd_rate, 48000, 0, 0, CFGFLAG_SAVE | CFGFLAG_CLIENT, 
 MACRO_CONFIG_INT(SndEnable, snd_enable, 1, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Sound enable")
 MACRO_CONFIG_INT(SndMusic, snd_enable_music, 0, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Play background music")
 MACRO_CONFIG_INT(SndVolume, snd_volume, 30, 0, 100, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Sound volume")
-MACRO_CONFIG_INT(SndDevice, snd_device, -1, 0, 0, CFGFLAG_SAVE | CFGFLAG_CLIENT, "(deprecated) Sound device to use")
 MACRO_CONFIG_INT(SndChatSoundVolume, snd_chat_volume, 30, 0, 100, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Chat sound volume")
 MACRO_CONFIG_INT(SndGameSoundVolume, snd_game_volume, 30, 0, 100, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Game sound volume")
 MACRO_CONFIG_INT(SndMapSoundVolume, snd_ambient_volume, 30, 0, 100, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Map Sound sound volume")

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -77,7 +77,7 @@ MACRO_CONFIG_INT(BrDemoSortOrder, br_demo_sort_order, 0, 0, 1, CFGFLAG_SAVE | CF
 MACRO_CONFIG_INT(BrDemoFetchInfo, br_demo_fetch_info, 0, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Whether to auto fetch demo infos on refresh")
 
 MACRO_CONFIG_INT(SndBufferSize, snd_buffer_size, 512, 128, 32768, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Sound buffer size")
-MACRO_CONFIG_INT(SndRate, snd_rate, 48000, 0, 0, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Sound mixing rate")
+MACRO_CONFIG_INT(SndRate, snd_rate, 48000, 5512, 384000, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Sound mixing rate")
 MACRO_CONFIG_INT(SndEnable, snd_enable, 1, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Sound enable")
 MACRO_CONFIG_INT(SndMusic, snd_enable_music, 0, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Play background music")
 MACRO_CONFIG_INT(SndVolume, snd_volume, 30, 0, 100, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Sound volume")

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -1944,14 +1944,13 @@ void CMenus::RenderSettingsSound(CUIRect MainView)
 {
 	CUIRect Button, Label;
 	static int s_SndEnable = g_Config.m_SndEnable;
-	static int s_SndRate = g_Config.m_SndRate;
 
 	MainView.HSplitTop(20.0f, &Button, &MainView);
 	if(DoButton_CheckBox(&g_Config.m_SndEnable, Localize("Use sounds"), g_Config.m_SndEnable, &Button))
 	{
 		g_Config.m_SndEnable ^= 1;
 		UpdateMusicState();
-		m_NeedRestartSound = g_Config.m_SndEnable && (!s_SndEnable || s_SndRate != g_Config.m_SndRate);
+		m_NeedRestartSound = g_Config.m_SndEnable && !s_SndEnable;
 	}
 
 	if(!g_Config.m_SndEnable)
@@ -1999,20 +1998,6 @@ void CMenus::RenderSettingsSound(CUIRect MainView)
 	MainView.HSplitTop(20.0f, &Button, &MainView);
 	if(DoButton_CheckBox(&g_Config.m_ClThreadsoundloading, Localize("Threaded sound loading"), g_Config.m_ClThreadsoundloading, &Button))
 		g_Config.m_ClThreadsoundloading ^= 1;
-
-	// sample rate box
-	{
-		MainView.HSplitTop(20.0f, &Button, &MainView);
-		UI()->DoLabel(&Button, Localize("Sample rate"), 14.0f, TEXTALIGN_ML);
-		Button.VSplitLeft(190.0f, 0, &Button);
-		static CLineInputNumber s_SndRateInput(g_Config.m_SndRate);
-		if(UI()->DoEditBox(&s_SndRateInput, &Button, 14.0f))
-		{
-			g_Config.m_SndRate = maximum(1, s_SndRateInput.GetInteger());
-			m_NeedRestartSound = !s_SndEnable || s_SndRate != g_Config.m_SndRate;
-		}
-		s_SndRateInput.SetInteger(g_Config.m_SndRate);
-	}
 
 	// volume slider
 	{

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -1995,10 +1995,6 @@ void CMenus::RenderSettingsSound(CUIRect MainView)
 	if(DoButton_CheckBox(&g_Config.m_SndHighlight, Localize("Enable highlighted chat sound"), g_Config.m_SndHighlight, &Button))
 		g_Config.m_SndHighlight ^= 1;
 
-	MainView.HSplitTop(20.0f, &Button, &MainView);
-	if(DoButton_CheckBox(&g_Config.m_ClThreadsoundloading, Localize("Threaded sound loading"), g_Config.m_ClThreadsoundloading, &Button))
-		g_Config.m_ClThreadsoundloading ^= 1;
-
 	// volume slider
 	{
 		MainView.HSplitTop(5.0f, &Button, &MainView);

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -1997,7 +1997,7 @@ void CMenus::RenderSettingsSound(CUIRect MainView)
 
 	// volume slider
 	{
-		MainView.HSplitTop(5.0f, &Button, &MainView);
+		MainView.HSplitTop(5.0f, nullptr, &MainView);
 		MainView.HSplitTop(20.0f, &Button, &MainView);
 		Button.VSplitLeft(190.0f, &Label, &Button);
 		UI()->DoLabel(&Label, Localize("Sound volume"), 14.0f, TEXTALIGN_ML);
@@ -2006,7 +2006,7 @@ void CMenus::RenderSettingsSound(CUIRect MainView)
 
 	// volume slider game sounds
 	{
-		MainView.HSplitTop(5.0f, &Button, &MainView);
+		MainView.HSplitTop(5.0f, nullptr, &MainView);
 		MainView.HSplitTop(20.0f, &Button, &MainView);
 		Button.VSplitLeft(190.0f, &Label, &Button);
 		UI()->DoLabel(&Label, Localize("Game sound volume"), 14.0f, TEXTALIGN_ML);
@@ -2015,7 +2015,7 @@ void CMenus::RenderSettingsSound(CUIRect MainView)
 
 	// volume slider gui sounds
 	{
-		MainView.HSplitTop(5.0f, &Button, &MainView);
+		MainView.HSplitTop(5.0f, nullptr, &MainView);
 		MainView.HSplitTop(20.0f, &Button, &MainView);
 		Button.VSplitLeft(190.0f, &Label, &Button);
 		UI()->DoLabel(&Label, Localize("Chat sound volume"), 14.0f, TEXTALIGN_ML);
@@ -2024,7 +2024,7 @@ void CMenus::RenderSettingsSound(CUIRect MainView)
 
 	// volume slider map sounds
 	{
-		MainView.HSplitTop(5.0f, &Button, &MainView);
+		MainView.HSplitTop(5.0f, nullptr, &MainView);
 		MainView.HSplitTop(20.0f, &Button, &MainView);
 		Button.VSplitLeft(190.0f, &Label, &Button);
 		UI()->DoLabel(&Label, Localize("Map sound volume"), 14.0f, TEXTALIGN_ML);
@@ -2033,7 +2033,7 @@ void CMenus::RenderSettingsSound(CUIRect MainView)
 
 	// volume slider background music
 	{
-		MainView.HSplitTop(5.0f, &Button, &MainView);
+		MainView.HSplitTop(5.0f, nullptr, &MainView);
 		MainView.HSplitTop(20.0f, &Button, &MainView);
 		Button.VSplitLeft(190.0f, &Label, &Button);
 		UI()->DoLabel(&Label, Localize("Background music volume"), 14.0f, TEXTALIGN_ML);

--- a/src/game/variables.h
+++ b/src/game/variables.h
@@ -71,7 +71,7 @@ MACRO_CONFIG_INT(ClEyeWheel, cl_eye_wheel, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAV
 MACRO_CONFIG_INT(ClEyeDuration, cl_eye_duration, 999999, 1, 999999, CFGFLAG_CLIENT | CFGFLAG_SAVE, "How long the eyes emotes last")
 
 MACRO_CONFIG_INT(ClAirjumpindicator, cl_airjumpindicator, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "")
-MACRO_CONFIG_INT(ClThreadsoundloading, cl_threadsoundloading, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Load sound files threaded")
+MACRO_CONFIG_INT(ClThreadsoundloading, cl_threadsoundloading, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Load sound files threaded")
 
 MACRO_CONFIG_INT(ClWarningTeambalance, cl_warning_teambalance, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Warn about team balance")
 


### PR DESCRIPTION
Before:
![screenshot_2023-05-24_21-22-53](https://github.com/ddnet/ddnet/assets/23437060/32764f2d-6e77-4066-8e8d-df9361a75dad)

After:
![screenshot_2023-05-24_21-22-29](https://github.com/ddnet/ddnet/assets/23437060/b92be9c6-75dc-4cdc-8883-c993dcac1f42)

## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
