### PR TITLE
Clear Victim Team render info on skin changes

### DIFF
--- a/src/game/client/components/killmessages.cpp
+++ b/src/game/client/components/killmessages.cpp
@@ -396,6 +396,10 @@ void CKillMessages::RefindSkins()
 
 		if(m_aKillmsgs[r].m_VictimID >= 0)
 		{
+			for(auto &VictimRenderInfo : m_aKillmsgs[r].m_VictimRenderInfo)
+			{
+				VictimRenderInfo = {};
+			}
 			const CGameClient::CClientData &Client = GameClient()->m_aClients[m_aKillmsgs[r].m_VictimID];
 			if(Client.m_aSkinName[0] != '\0')
 				m_aKillmsgs[r].m_VictimRenderInfo[0] = Client.m_RenderInfo;


### PR DESCRIPTION
fixes #6662

This should fix the issue, I guess, by simply clearing the render info. I can't find an easy way to restore the original skins of the team members as we don't save their IDs.
I couldn't directly trigger the assert, but I could certainly see the skin getting invalid when killen the team and switch to "vanilla only skins". (Edit: When triggering it a few times I got the assert)

The code generally looks a bit hacky. Maybe the original author can refactor it a bit

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
