### PR TITLE
Wait for graphics thread's current execution to end before triggering…

### DIFF
--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -777,7 +777,9 @@ void CGraphicsBackend_SDL_GL::ClampDriverVersion(EBackendType BackendType)
 bool CGraphicsBackend_SDL_GL::ShowMessageBox(unsigned Type, const char *pTitle, const char *pMsg)
 {
 	if(m_pProcessor != nullptr)
+	{
 		m_pProcessor->ErroneousCleanup();
+	}
 	// TODO: Remove this workaround when https://github.com/libsdl-org/SDL/issues/3750 is
 	// fixed and pass the window to SDL_ShowSimpleMessageBox to make the popup modal instead
 	// of destroying the window before opening the popup.

--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -3283,6 +3283,7 @@ bool CGraphics_Threaded::ShowMessageBox(unsigned Type, const char *pTitle, const
 {
 	if(m_pBackend == nullptr)
 		return false;
+	m_pBackend->WaitForIdle();
 	return m_pBackend->ShowMessageBox(Type, pTitle, pMsg);
 }
 


### PR DESCRIPTION
… the assert dialog

fixes #6674

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
