### PR TITLE
Use icons for refresh and connect buttons, refactor `DoButtonMenu`

### DIFF
--- a/src/engine/textrender.h
+++ b/src/engine/textrender.h
@@ -101,6 +101,7 @@ MAYBE_UNUSED static const char *FONT_ICON_ARROW_UP_RIGHT_FROM_SQUARE = "\xEF\x82
 MAYBE_UNUSED static const char *FONT_ICON_BACKWARD_STEP = "\xEF\x81\x88";
 MAYBE_UNUSED static const char *FONT_ICON_FORWARD_STEP = "\xEF\x81\x91";
 MAYBE_UNUSED static const char *FONT_ICON_KEYBOARD = "\xE2\x8C\xA8";
+MAYBE_UNUSED static const char *FONT_ICON_ELLIPSIS = "\xEF\x85\x81";
 
 MAYBE_UNUSED static const char *FONT_ICON_FOLDER = "\xEF\x81\xBB";
 MAYBE_UNUSED static const char *FONT_ICON_FOLDER_TREE = "\xEF\xA0\x82";

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -74,8 +74,6 @@ class CMenus : public CComponent
 	static SColorPicker ms_ColorPicker;
 	static bool ms_ValueSelectorTextMode;
 
-	char m_aLocalStringHelper[1024];
-
 	int DoButton_DemoPlayer(const void *pID, const char *pText, int Checked, const CUIRect *pRect);
 	int DoButton_FontIcon(CButtonContainer *pButtonContainer, const char *pText, int Checked, const CUIRect *pRect, int Corners, bool Enabled = true);
 	int DoButton_Toggle(const void *pID, int Checked, const CUIRect *pRect, bool Active);
@@ -106,92 +104,6 @@ class CMenus : public CComponent
 	void RefreshSkins();
 
 	void RandomSkin();
-
-	// new gui with gui elements
-	template<typename T>
-	int DoButtonMenu(CUIElement &UIElement, const CButtonContainer *pID, T &&GetTextLambda, int Checked, const CUIRect *pRect, bool HintRequiresStringCheck, bool HintCanChangePositionOrSize = false, int Corners = IGraphics::CORNER_ALL, float r = 5.0f, float FontFactor = 0.0f, vec4 ColorHot = vec4(1.0f, 1.0f, 1.0f, 0.75f), vec4 Color = vec4(1, 1, 1, 0.5f))
-	{
-		CUIRect Text = *pRect;
-		Text.HMargin(pRect->h >= 20.0f ? 2.0f : 1.0f, &Text);
-		Text.HMargin((Text.h * FontFactor) / 2.0f, &Text);
-
-		if(!UIElement.AreRectsInit() || HintRequiresStringCheck || HintCanChangePositionOrSize || !UIElement.Rect(0)->m_UITextContainer.Valid())
-		{
-			bool NeedsRecalc = !UIElement.AreRectsInit() || !UIElement.Rect(0)->m_UITextContainer.Valid();
-			if(HintCanChangePositionOrSize)
-			{
-				if(UIElement.AreRectsInit())
-				{
-					if(UIElement.Rect(0)->m_X != pRect->x || UIElement.Rect(0)->m_Y != pRect->y || UIElement.Rect(0)->m_Width != pRect->w || UIElement.Rect(0)->m_Y != pRect->h)
-					{
-						NeedsRecalc = true;
-					}
-				}
-			}
-			const char *pText = nullptr;
-			if(HintRequiresStringCheck)
-			{
-				if(UIElement.AreRectsInit())
-				{
-					pText = GetTextLambda();
-					if(str_comp(UIElement.Rect(0)->m_Text.c_str(), pText) != 0)
-					{
-						NeedsRecalc = true;
-					}
-				}
-			}
-			if(NeedsRecalc)
-			{
-				if(!UIElement.AreRectsInit())
-				{
-					UIElement.InitRects(3);
-				}
-				UI()->ResetUIElement(UIElement);
-
-				vec4 RealColor = Color;
-				for(int i = 0; i < 3; ++i)
-				{
-					Color.a = RealColor.a;
-					if(i == 0)
-						Color.a *= UI()->ButtonColorMulActive();
-					else if(i == 1)
-						Color.a *= UI()->ButtonColorMulHot();
-					else if(i == 2)
-						Color.a *= UI()->ButtonColorMulDefault();
-					Graphics()->SetColor(Color);
-
-					CUIElement::SUIElementRect &NewRect = *UIElement.Rect(i);
-					NewRect.m_UIRectQuadContainer = Graphics()->CreateRectQuadContainer(pRect->x, pRect->y, pRect->w, pRect->h, r, Corners);
-
-					NewRect.m_X = pRect->x;
-					NewRect.m_Y = pRect->y;
-					NewRect.m_Width = pRect->w;
-					NewRect.m_Height = pRect->h;
-					if(i == 0)
-					{
-						if(pText == nullptr)
-							pText = GetTextLambda();
-						NewRect.m_Text = pText;
-						UI()->DoLabel(NewRect, &Text, pText, Text.h * CUI::ms_FontmodHeight, TEXTALIGN_MC);
-					}
-				}
-				Graphics()->SetColor(1, 1, 1, 1);
-			}
-		}
-		// render
-		size_t Index = 2;
-		if(UI()->CheckActiveItem(pID))
-			Index = 0;
-		else if(UI()->HotItem() == pID)
-			Index = 1;
-		Graphics()->TextureClear();
-		Graphics()->RenderQuadContainer(UIElement.Rect(Index)->m_UIRectQuadContainer, -1);
-		ColorRGBA ColorText(TextRender()->DefaultTextColor());
-		ColorRGBA ColorTextOutline(TextRender()->DefaultTextOutlineColor());
-		if(UIElement.Rect(0)->m_UITextContainer.Valid())
-			TextRender()->RenderTextContainer(UIElement.Rect(0)->m_UITextContainer, ColorText, ColorTextOutline);
-		return UI()->DoButtonLogic(pID, Checked, pRect);
-	}
 
 	// menus_settings_assets.cpp
 public:

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -828,6 +828,93 @@ bool CUI::DoClearableEditBox(CLineInput *pLineInput, const CUIRect *pRect, float
 	return ReturnValue;
 }
 
+int CUI::DoButton_Menu(CUIElement &UIElement, const CButtonContainer *pID, const std::function<const char *()> &GetTextLambda, const CUIRect *pRect, const SMenuButtonProperties &Props)
+{
+	CUIRect Text = *pRect;
+	Text.HMargin(pRect->h >= 20.0f ? 2.0f : 1.0f, &Text);
+	Text.HMargin((Text.h * Props.m_FontFactor) / 2.0f, &Text);
+
+	if(!UIElement.AreRectsInit() || Props.m_HintRequiresStringCheck || Props.m_HintCanChangePositionOrSize || !UIElement.Rect(0)->m_UITextContainer.Valid())
+	{
+		bool NeedsRecalc = !UIElement.AreRectsInit() || !UIElement.Rect(0)->m_UITextContainer.Valid();
+		if(Props.m_HintCanChangePositionOrSize)
+		{
+			if(UIElement.AreRectsInit())
+			{
+				if(UIElement.Rect(0)->m_X != pRect->x || UIElement.Rect(0)->m_Y != pRect->y || UIElement.Rect(0)->m_Width != pRect->w || UIElement.Rect(0)->m_Y != pRect->h)
+				{
+					NeedsRecalc = true;
+				}
+			}
+		}
+		const char *pText = nullptr;
+		if(Props.m_HintRequiresStringCheck)
+		{
+			if(UIElement.AreRectsInit())
+			{
+				pText = GetTextLambda();
+				if(str_comp(UIElement.Rect(0)->m_Text.c_str(), pText) != 0)
+				{
+					NeedsRecalc = true;
+				}
+			}
+		}
+		if(NeedsRecalc)
+		{
+			if(!UIElement.AreRectsInit())
+			{
+				UIElement.InitRects(3);
+			}
+			ResetUIElement(UIElement);
+
+			for(int i = 0; i < 3; ++i)
+			{
+				ColorRGBA Color = Props.m_Color;
+				if(i == 0)
+					Color.a *= ButtonColorMulActive();
+				else if(i == 1)
+					Color.a *= ButtonColorMulHot();
+				else if(i == 2)
+					Color.a *= ButtonColorMulDefault();
+				Graphics()->SetColor(Color);
+
+				CUIElement::SUIElementRect &NewRect = *UIElement.Rect(i);
+				NewRect.m_UIRectQuadContainer = Graphics()->CreateRectQuadContainer(pRect->x, pRect->y, pRect->w, pRect->h, Props.m_Rounding, Props.m_Corners);
+
+				NewRect.m_X = pRect->x;
+				NewRect.m_Y = pRect->y;
+				NewRect.m_Width = pRect->w;
+				NewRect.m_Height = pRect->h;
+				if(i == 0)
+				{
+					if(pText == nullptr)
+						pText = GetTextLambda();
+					NewRect.m_Text = pText;
+					if(Props.m_UseIconFont)
+						TextRender()->SetCurFont(TextRender()->GetFont(TEXT_FONT_ICON_FONT));
+					DoLabel(NewRect, &Text, pText, Text.h * CUI::ms_FontmodHeight, TEXTALIGN_MC);
+					if(Props.m_UseIconFont)
+						TextRender()->SetCurFont(nullptr);
+				}
+			}
+			Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
+		}
+	}
+	// render
+	size_t Index = 2;
+	if(CheckActiveItem(pID))
+		Index = 0;
+	else if(HotItem() == pID)
+		Index = 1;
+	Graphics()->TextureClear();
+	Graphics()->RenderQuadContainer(UIElement.Rect(Index)->m_UIRectQuadContainer, -1);
+	ColorRGBA ColorText(TextRender()->DefaultTextColor());
+	ColorRGBA ColorTextOutline(TextRender()->DefaultTextOutlineColor());
+	if(UIElement.Rect(0)->m_UITextContainer.Valid())
+		TextRender()->RenderTextContainer(UIElement.Rect(0)->m_UITextContainer, ColorText, ColorTextOutline);
+	return DoButtonLogic(pID, Props.m_Checked, pRect);
+}
+
 int CUI::DoButton_PopupMenu(CButtonContainer *pButtonContainer, const char *pText, const CUIRect *pRect, int Align)
 {
 	pRect->Draw(ColorRGBA(1.0f, 1.0f, 1.0f, 0.5f * ButtonColorMul(pButtonContainer)), IGraphics::CORNER_ALL, 3.0f);

--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -194,6 +194,18 @@ struct SLabelProperties
 	bool m_EnableWidthCheck = true;
 };
 
+struct SMenuButtonProperties
+{
+	int m_Checked = 0;
+	bool m_HintRequiresStringCheck = false;
+	bool m_HintCanChangePositionOrSize = false;
+	bool m_UseIconFont = false;
+	int m_Corners = IGraphics::CORNER_ALL;
+	float m_Rounding = 5.0f;
+	float m_FontFactor = 0.0f;
+	ColorRGBA m_Color = ColorRGBA(1.0f, 1.0f, 1.0f, 0.5f);
+};
+
 class CUIElementBase
 {
 private:
@@ -443,6 +455,8 @@ public:
 	bool DoEditBox(CLineInput *pLineInput, const CUIRect *pRect, float FontSize, int Corners = IGraphics::CORNER_ALL);
 	bool DoClearableEditBox(CLineInput *pLineInput, const CUIRect *pRect, float FontSize, int Corners = IGraphics::CORNER_ALL);
 
+	int DoButton_Menu(CUIElement &UIElement, const CButtonContainer *pID, const std::function<const char *()> &GetTextLambda, const CUIRect *pRect, const SMenuButtonProperties &Props = {});
+	// only used for popup menus
 	int DoButton_PopupMenu(CButtonContainer *pButtonContainer, const char *pText, const CUIRect *pRect, int Align);
 
 	enum


### PR DESCRIPTION
Use less space for refresh and connect buttons to improve layout with 5:4 and 4:3 resolutions. Closes #5605. Closes #5878.

The "Refreshing..." text is replaced with combined refresh and ellipsis icons.

Alpha and saturation of the green color of the connect button are increased.

Move `CMenus::DoButtonMenu` to `CUI::DoButton_Menu`. Simplify usage by adding `SMenuButtonProperties` parameter object for all optional arguments. Remove unused `ColorHot` parameter.

Screenshots:
- Before:
![screenshot_2023-05-27_19-52-37](https://github.com/ddnet/ddnet/assets/23437060/3bf27f53-b034-4147-97ee-5c24a5b68457)
- After:
![screenshot_2023-05-27_19-51-07](https://github.com/ddnet/ddnet/assets/23437060/702a9c1c-be07-4cd6-94b5-b4b0fd9b4fa1)
- After (when refreshing):
![screenshot_2023-05-27_19-56-15](https://github.com/ddnet/ddnet/assets/23437060/0a456467-6550-4ce7-b756-56e3bbbc4f43)


## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
