### PR TITLE
Make server settings editor height adjustable by dragging

### DIFF
--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -810,6 +810,7 @@ public:
 		m_ShowEnvelopeEditor = false;
 		m_EnvelopeEditorSplit = 250.0f;
 		m_ShowServerSettingsEditor = false;
+		m_ServerSettingsEditorSplit = 250.0f;
 
 		m_ShowEnvelopePreview = SHOWENV_NONE;
 		m_SelectedQuadEnvelope = -1;
@@ -1073,6 +1074,8 @@ public:
 
 	bool m_ShowEnvelopeEditor;
 	float m_EnvelopeEditorSplit;
+	bool m_ShowServerSettingsEditor;
+	float m_ServerSettingsEditorSplit;
 
 	enum EShowEnvelope
 	{
@@ -1081,7 +1084,6 @@ public:
 		SHOWENV_ALL
 	};
 	EShowEnvelope m_ShowEnvelopePreview;
-	bool m_ShowServerSettingsEditor;
 	bool m_ShowPicker;
 
 	std::vector<int> m_vSelectedLayers;
@@ -1234,8 +1236,10 @@ public:
 	void RenderSounds(CUIRect Toolbox);
 	void RenderModebar(CUIRect View);
 	void RenderStatusbar(CUIRect View);
+
 	void RenderEnvelopeEditor(CUIRect View);
 	void RenderServerSettingsEditor(CUIRect View, bool ShowServerSettingsEditorLast);
+	void RenderExtraEditorDragBar(CUIRect View, float *pSplit);
 
 	void RenderMenubar(CUIRect Menubar);
 	void RenderFileDialog();


### PR DESCRIPTION
Same as for the envelope editor. Extract `RenderExtraEditorDragBar` function to reduce duplicate code.

Fix height being changed by repeated clicking on the draggable element by also resetting `s_Operation` when `Clicked` is `true`.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
