### PR TITLE
Support dragging demo player controls to move them, fix minor related issues

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -2220,14 +2220,8 @@ bool CMenus::OnCursorMove(float x, float y, IInput::ECursorType CursorType)
 
 bool CMenus::OnInput(const IInput::CEvent &Event)
 {
-	// special handle esc and enter for popup purposes
-	if(Event.m_Flags & IInput::FLAG_PRESS && Event.m_Key == KEY_ESCAPE)
-	{
-		SetActive(!IsActive());
-		UI()->OnInput(Event);
-		return true;
-	}
-	if(IsActive())
+	// Escape key is always handled to activate/deactivate menu
+	if((Event.m_Flags & IInput::FLAG_PRESS && Event.m_Key == KEY_ESCAPE) || IsActive())
 	{
 		UI()->OnInput(Event);
 		return true;
@@ -2308,6 +2302,8 @@ void CMenus::OnRender()
 
 	if(!IsActive())
 	{
+		if(UI()->ConsumeHotkey(CUI::HOTKEY_ESCAPE))
+			SetActive(true);
 		UI()->FinishCheck();
 		UI()->ClearHotkeys();
 		return;
@@ -2358,6 +2354,9 @@ void CMenus::OnRender()
 		TextRender()->SetCursor(&Cursor, 10, 10, 10, TEXTFLAG_RENDER);
 		TextRender()->TextEx(&Cursor, aBuf, -1);
 	}
+
+	if(UI()->ConsumeHotkey(CUI::HOTKEY_ESCAPE))
+		SetActive(false);
 
 	UI()->FinishCheck();
 	UI()->ClearHotkeys();

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -437,6 +437,7 @@ protected:
 	void UpdateMusicState();
 
 	// found in menus_demo.cpp
+	vec2 m_DemoControlsPositionOffset = vec2(0.0f, 0.0f);
 	static bool DemoFilterChat(const void *pData, int Size, void *pUser);
 	bool FetchHeader(CDemoItem &Item);
 	void FetchAllHeaders();

--- a/src/game/client/components/tooltips.cpp
+++ b/src/game/client/components/tooltips.cpp
@@ -30,6 +30,7 @@ void CTooltips::DoToolTip(const void *pID, const CUIRect *pNearRect, const char 
 {
 	uintptr_t ID = reinterpret_cast<uintptr_t>(pID);
 	const auto result = m_Tooltips.emplace(ID, CTooltip{
+							   pID,
 							   *pNearRect,
 							   pText,
 							   WidthHint,
@@ -44,7 +45,7 @@ void CTooltips::DoToolTip(const void *pID, const CUIRect *pNearRect, const char 
 
 	Tooltip.m_OnScreen = true;
 
-	if(UI()->MouseInside(&Tooltip.m_Rect))
+	if(UI()->HotItem() == Tooltip.m_pID)
 	{
 		SetActiveTooltip(Tooltip);
 	}
@@ -56,7 +57,7 @@ void CTooltips::OnRender()
 	{
 		CTooltip &Tooltip = m_ActiveTooltip.value();
 
-		if(!UI()->MouseInside(&Tooltip.m_Rect))
+		if(UI()->HotItem() != Tooltip.m_pID)
 		{
 			Tooltip.m_OnScreen = false;
 			ClearActiveTooltip();

--- a/src/game/client/components/tooltips.h
+++ b/src/game/client/components/tooltips.h
@@ -11,6 +11,7 @@
 
 struct CTooltip
 {
+	const void *m_pID;
 	CUIRect m_Rect;
 	const char *m_pText;
 	float m_WidthHint;


### PR DESCRIPTION
Allow dragging the demo player controls anywhere on the screen. The controls can't be moved outside of the screen. Round corners are automatically disabled when the controls are on the edge of the screen.

https://github.com/ddnet/ddnet/assets/23437060/72510c1f-4fd2-426b-a631-3a78db5f7b8b

## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
