### PR TITLE
Add "No server selected" message to server details

### DIFF
--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1136,6 +1136,10 @@ void CMenus::RenderServerbrowserServerDetail(CUIRect View)
 		Cursor.m_LineWidth = Row.w;
 		TextRender()->TextEx(&Cursor, aTemp, -1);
 	}
+	else
+	{
+		UI()->DoLabel(&ServerDetails, Localize("No server selected"), FontSize, TEXTALIGN_MC);
+	}
 
 	// server scoreboard
 	ServerScoreBoard.HSplitBottom(23.0f, &ServerScoreBoard, 0x0);


### PR DESCRIPTION
Otherwise the tab is completely empty when no server is selected.

![screenshot_2023-06-01_22-27-29](https://github.com/ddnet/ddnet/assets/23437060/b7d652cd-73de-45b7-a8fb-f16fa7f916e0)

## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
