### PR TITLE
Allow `username:password` for reserved slots

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -1377,13 +1377,17 @@ bool CServer::CheckReservedSlotAuth(int ClientID, const char *pPassword)
 		return true;
 	}
 
-	// "^#(.*?)#(.*)$"
-	if(Config()->m_SvReservedSlotsAuthLevel != 4 && pPassword[0] == '#')
+	// "^([^:]*):(.*)$"
+	if(Config()->m_SvReservedSlotsAuthLevel != 4)
 	{
 		char aName[sizeof(Config()->m_Password)];
-		const char *pPass = str_next_token(pPassword + 1, "#", aName, sizeof(aName));
+		const char *pInnerPassword = str_next_token(pPassword, ":", aName, sizeof(aName));
+		if(!pInnerPassword)
+		{
+			return false;
+		}
 		int Slot = m_AuthManager.FindKey(aName);
-		if(pPass && m_AuthManager.CheckKey(Slot, pPass + 1) && m_AuthManager.KeyLevel(Slot) >= Config()->m_SvReservedSlotsAuthLevel)
+		if(m_AuthManager.CheckKey(Slot, pInnerPassword + 1) && m_AuthManager.KeyLevel(Slot) >= Config()->m_SvReservedSlotsAuthLevel)
 		{
 			str_format(aBuf, sizeof(aBuf), "cid=%d joining reserved slot with key=%s", ClientID, m_AuthManager.KeyIdent(Slot));
 			Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "server", aBuf);


### PR DESCRIPTION
This is a more common syntax.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
