### PR TITLE
Fix killmessages might drop text container indices, if a killmsg was invalid

### DIFF
--- a/src/engine/client/text.cpp
+++ b/src/engine/client/text.cpp
@@ -132,9 +132,7 @@ public:
 struct STextString
 {
 	int m_QuadBufferObjectIndex;
-	uint32_t m_DbgShadowBytes = 0x12345678;
 	int m_QuadBufferContainerIndex;
-	uint32_t m_DbgShadowBytes2 = 0x87654321;
 	size_t m_QuadNum;
 	int m_SelectionQuadContainerIndex;
 
@@ -1993,7 +1991,6 @@ public:
 				dbg_msg("textrender", "The text container index was in use by %d ", (int)pTextContainer->m_ContainerIndex.m_UseCount.use_count());
 				HasNonEmptyTextContainer = true; // NOLINT(clang-analyzer-deadcode.DeadStores)
 			}
-			dbg_assert(pTextContainer->m_StringInfo.m_DbgShadowBytes == STextString{}.m_DbgShadowBytes && pTextContainer->m_StringInfo.m_DbgShadowBytes2 == STextString{}.m_DbgShadowBytes2, "shadow bytes were modified in text container.");
 		}
 
 		dbg_assert(!HasNonEmptyTextContainer, "text container was not empty");

--- a/src/game/client/components/killmessages.cpp
+++ b/src/game/client/components/killmessages.cpp
@@ -179,6 +179,11 @@ void CKillMessages::OnMessage(int MsgType, void *pRawMsg)
 
 			m_aKillmsgs[m_KillmsgCurrent] = Kill;
 		}
+		else
+		{
+			TextRender()->DeleteTextContainer(Kill.m_VictimTextContainerIndex);
+			TextRender()->DeleteTextContainer(Kill.m_KillerTextContainerIndex);
+		}
 
 		Graphics()->MapScreen(ScreenX0, ScreenY0, ScreenX1, ScreenY1);
 	}
@@ -240,6 +245,11 @@ void CKillMessages::OnMessage(int MsgType, void *pRawMsg)
 			TextRender()->DeleteTextContainer(m_aKillmsgs[m_KillmsgCurrent].m_KillerTextContainerIndex);
 
 			m_aKillmsgs[m_KillmsgCurrent] = Kill;
+		}
+		else
+		{
+			TextRender()->DeleteTextContainer(Kill.m_VictimTextContainerIndex);
+			TextRender()->DeleteTextContainer(Kill.m_KillerTextContainerIndex);
 		}
 
 		Graphics()->MapScreen(ScreenX0, ScreenY0, ScreenX1, ScreenY1);


### PR DESCRIPTION
Kill is a temporary variable, that's why the indices were dropped without notice

fixes #5143

also reverted the hacks.
i guess we can keep 493f47515c556472f3d009e18b47655e2f8ba9fb for now, it at least gives a hint to find such stuff

_**we should also release a new patch version with this**_

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
