### PR TITLE
Handle escape to go to start menu after popup menus

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -1342,11 +1342,6 @@ int CMenus::Render()
 		{
 			Screen.HSplitTop(24.0f, &TabBar, &MainView);
 
-			if(Client()->State() == IClient::STATE_OFFLINE && UI()->ConsumeHotkey(CUI::HOTKEY_ESCAPE))
-			{
-				m_ShowStart = true;
-			}
-
 			// render news
 			if(m_MenuPage < PAGE_NEWS || m_MenuPage > PAGE_SETTINGS || (Client()->State() == IClient::STATE_OFFLINE && m_MenuPage >= PAGE_GAME && m_MenuPage <= PAGE_CALLVOTE))
 			{
@@ -2074,6 +2069,12 @@ int CMenus::Render()
 	}
 
 	UI()->RenderPopupMenus();
+
+	// Handle this escape hotkey after popup menus
+	if(m_MenuPage == PAGE_SETTINGS && !m_ShowStart && Client()->State() == IClient::STATE_OFFLINE && UI()->ConsumeHotkey(CUI::HOTKEY_ESCAPE))
+	{
+		m_ShowStart = true;
+	}
 
 	return 0;
 }


### PR DESCRIPTION
Popup menus should be closed before escape is used to navigate back to the start menu.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
