### PR TITLE
Fix UI element check with `m_HintCanChangePositionOrSize`

### DIFF
--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -41,6 +41,8 @@ void CUIElement::SUIElementRect::Reset()
 	m_Y = -1;
 	m_Width = -1;
 	m_Height = -1;
+	m_Rounding = -1.0f;
+	m_Corners = -1;
 	m_Text.clear();
 	mem_zero(&m_Cursor, sizeof(m_Cursor));
 	m_TextColor = ColorRGBA(-1, -1, -1, -1);
@@ -850,7 +852,7 @@ int CUI::DoButton_Menu(CUIElement &UIElement, const CButtonContainer *pID, const
 		{
 			if(UIElement.AreRectsInit())
 			{
-				if(UIElement.Rect(0)->m_X != pRect->x || UIElement.Rect(0)->m_Y != pRect->y || UIElement.Rect(0)->m_Width != pRect->w || UIElement.Rect(0)->m_Y != pRect->h)
+				if(UIElement.Rect(0)->m_X != pRect->x || UIElement.Rect(0)->m_Y != pRect->y || UIElement.Rect(0)->m_Width != pRect->w || UIElement.Rect(0)->m_Height != pRect->h || UIElement.Rect(0)->m_Rounding != Props.m_Rounding || UIElement.Rect(0)->m_Corners != Props.m_Corners)
 				{
 					NeedsRecalc = true;
 				}
@@ -894,6 +896,8 @@ int CUI::DoButton_Menu(CUIElement &UIElement, const CButtonContainer *pID, const
 				NewRect.m_Y = pRect->y;
 				NewRect.m_Width = pRect->w;
 				NewRect.m_Height = pRect->h;
+				NewRect.m_Rounding = Props.m_Rounding;
+				NewRect.m_Corners = Props.m_Corners;
 				if(i == 0)
 				{
 					if(pText == nullptr)

--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -149,6 +149,8 @@ public:
 		float m_Y;
 		float m_Width;
 		float m_Height;
+		float m_Rounding;
+		int m_Corners;
 
 		std::string m_Text;
 


### PR DESCRIPTION
It was incorrectly checked for `UIElement.Rect(0)->m_Y != pRect->h`, so any UI rect using `m_HintCanChangePositionOrSize` would be updated every frame (although, no UI element currently uses this hint).

Additionally, checks for changed rounding size and corners are added so UI elements are updated when those are changed.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
