### PR TITLE
Fix escape not working in settings menu anymore

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -1072,15 +1072,16 @@ bool CMenus::CanDisplayWarning()
 
 void CMenus::RenderColorPicker()
 {
+	if(!ms_ColorPicker.m_Active)
+		return;
+
 	if(UI()->ConsumeHotkey(CUI::HOTKEY_ESCAPE))
 	{
 		ms_ColorPicker.m_Active = false;
 		ms_ValueSelectorTextMode = false;
 		UI()->SetActiveItem(nullptr);
-	}
-
-	if(!ms_ColorPicker.m_Active)
 		return;
+	}
 
 	// First check if we should disable color picker
 	CUIRect PickerRect;


### PR DESCRIPTION
The color picker was always consuming the escape hotkey even when already disabled. Regression from #6705 due to changed order of hotkey consumption.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
