### PR TITLE
Use real instead of display string for number line inputs

### DIFF
--- a/src/game/client/lineinput.cpp
+++ b/src/game/client/lineinput.cpp
@@ -677,7 +677,7 @@ void CLineInputNumber::SetInteger(int Number, int Base)
 		dbg_assert(false, "Base unsupported");
 		return;
 	}
-	if(str_comp(aBuf, GetDisplayedString()) != 0)
+	if(str_comp(aBuf, GetString()) != 0)
 		Set(aBuf);
 }
 
@@ -690,7 +690,7 @@ void CLineInputNumber::SetFloat(float Number)
 {
 	char aBuf[32];
 	str_format(aBuf, sizeof(aBuf), "%.3f", Number);
-	if(str_comp(aBuf, GetDisplayedString()) != 0)
+	if(str_comp(aBuf, GetString()) != 0)
 		Set(aBuf);
 }
 


### PR DESCRIPTION
Set input string if it's not identical to the real input string instead of comparing to the display string, which would be incorrect for hidden number inputs.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
