### PR TITLE
Improve color picker popup in settings (use new popup system, add alpha support, support mouse locking)

### DIFF
--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -3430,10 +3430,30 @@ int str_isallnum(const char *str)
 	return 1;
 }
 
-int str_toint(const char *str) { return str_toint_base(str, 10); }
-int str_toint_base(const char *str, int base) { return strtol(str, NULL, base); }
-unsigned long str_toulong_base(const char *str, int base) { return strtoul(str, NULL, base); }
-float str_tofloat(const char *str) { return strtod(str, NULL); }
+int str_toint(const char *str)
+{
+	return str_toint_base(str, 10);
+}
+
+int str_toint_base(const char *str, int base)
+{
+	return strtol(str, nullptr, base);
+}
+
+unsigned long str_toulong_base(const char *str, int base)
+{
+	return strtoul(str, nullptr, base);
+}
+
+int64_t str_toint64_base(const char *str, int base)
+{
+	return strtoll(str, nullptr, base);
+}
+
+float str_tofloat(const char *str)
+{
+	return strtod(str, nullptr);
+}
 
 int str_utf8_comp_nocase(const char *a, const char *b)
 {

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -2133,6 +2133,7 @@ void net_stats(NETSTATS *stats);
 int str_toint(const char *str);
 int str_toint_base(const char *str, int base);
 unsigned long str_toulong_base(const char *str, int base);
+int64_t str_toint64_base(const char *str, int base = 10);
 float str_tofloat(const char *str);
 
 /**

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -23,8 +23,10 @@
 #ifdef __MINGW32__
 #undef PRId64
 #undef PRIu64
+#undef PRIX64
 #define PRId64 "I64d"
 #define PRIu64 "I64u"
+#define PRIX64 "I64X"
 #define PRIzu "Iu"
 #else
 #define PRIzu "zu"

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -51,8 +51,6 @@ ColorRGBA CMenus::ms_ColorTabbarInactiveIngame;
 ColorRGBA CMenus::ms_ColorTabbarActiveIngame;
 ColorRGBA CMenus::ms_ColorTabbarHoverIngame;
 
-SColorPicker CMenus::ms_ColorPicker;
-
 float CMenus::ms_ButtonHeight = 25.0f;
 float CMenus::ms_ListheaderHeight = 17.0f;
 
@@ -122,28 +120,11 @@ int CMenus::DoButton_Toggle(const void *pID, int Checked, const CUIRect *pRect, 
 	return Active ? UI()->DoButtonLogic(pID, Checked, pRect) : 0;
 }
 
-int CMenus::DoButton_Menu(CButtonContainer *pButtonContainer, const char *pText, int Checked, const CUIRect *pRect, const char *pImageName, int Corners, float r, float FontFactor, vec4 ColorHot, vec4 Color, bool CheckForActiveColorPicker)
+int CMenus::DoButton_Menu(CButtonContainer *pButtonContainer, const char *pText, int Checked, const CUIRect *pRect, const char *pImageName, int Corners, float r, float FontFactor, vec4 ColorHot, vec4 Color)
 {
 	CUIRect Text = *pRect;
 
-	bool MouseInsideColorPicker = false;
-
-	if(CheckForActiveColorPicker)
-	{
-		if(ms_ColorPicker.m_Active)
-		{
-			CUIRect PickerRect;
-			PickerRect.x = ms_ColorPicker.m_X;
-			PickerRect.y = ms_ColorPicker.m_Y;
-			PickerRect.w = ms_ColorPicker.ms_Width;
-			PickerRect.h = ms_ColorPicker.ms_Height;
-
-			MouseInsideColorPicker = UI()->MouseInside(&PickerRect);
-		}
-	}
-
-	if(!MouseInsideColorPicker)
-		Color.a *= UI()->ButtonColorMul(pButtonContainer);
+	Color.a *= UI()->ButtonColorMul(pButtonContainer);
 	pRect->Draw(Color, Corners, r);
 
 	if(pImageName)
@@ -169,9 +150,6 @@ int CMenus::DoButton_Menu(CButtonContainer *pButtonContainer, const char *pText,
 	Text.HMargin(pRect->h >= 20.0f ? 2.0f : 1.0f, &Text);
 	Text.HMargin((Text.h * FontFactor) / 2.0f, &Text);
 	UI()->DoLabel(&Text, pText, Text.h * CUI::ms_FontmodHeight, TEXTALIGN_MC);
-
-	if(MouseInsideColorPicker)
-		return 0;
 
 	return UI()->DoButtonLogic(pButtonContainer, Checked, pRect);
 }
@@ -374,7 +352,7 @@ void CMenus::DoLaserPreview(const CUIRect *pRect, const ColorHSLA LaserOutlineCo
 	}
 }
 
-ColorHSLA CMenus::DoLine_ColorPicker(CButtonContainer *pResetID, const float LineSize, const float LabelSize, const float BottomMargin, CUIRect *pMainRect, const char *pText, unsigned int *pColorValue, const ColorRGBA DefaultColor, bool CheckBoxSpacing, int *pCheckBoxValue)
+ColorHSLA CMenus::DoLine_ColorPicker(CButtonContainer *pResetID, const float LineSize, const float LabelSize, const float BottomMargin, CUIRect *pMainRect, const char *pText, unsigned int *pColorValue, const ColorRGBA DefaultColor, bool CheckBoxSpacing, int *pCheckBoxValue, bool Alpha)
 {
 	CUIRect Section, ColorPickerButton, ResetButton, Label;
 
@@ -391,9 +369,9 @@ ColorHSLA CMenus::DoLine_ColorPicker(CButtonContainer *pResetID, const float Lin
 			if(DoButton_CheckBox(pCheckBoxValue, "", *pCheckBoxValue, &CheckBox))
 				*pCheckBoxValue ^= 1;
 		}
+		Section.VSplitLeft(5.0f, nullptr, &Section);
 	}
 
-	Section.VSplitLeft(5.0f, nullptr, &Section);
 	Section.VSplitMid(&Label, &Section, Section.h);
 	Section.VSplitRight(60.0f, &Section, &ResetButton);
 	Section.VSplitRight(8.0f, &Section, nullptr);
@@ -401,15 +379,44 @@ ColorHSLA CMenus::DoLine_ColorPicker(CButtonContainer *pResetID, const float Lin
 
 	UI()->DoLabel(&Label, pText, LabelSize, TEXTALIGN_ML);
 
-	ColorHSLA PickedColor = RenderHSLColorPicker(&ColorPickerButton, pColorValue, false);
+	ColorHSLA PickedColor = DoButton_ColorPicker(&ColorPickerButton, pColorValue, Alpha);
 
 	ResetButton.HMargin(2.0f, &ResetButton);
-	if(DoButton_Menu(pResetID, Localize("Reset"), 0, &ResetButton, nullptr, IGraphics::CORNER_ALL, 8.0f, 0.0f, vec4(1, 1, 1, 0.5f), vec4(1, 1, 1, 0.25f), true))
+	if(DoButton_Menu(pResetID, Localize("Reset"), 0, &ResetButton, nullptr, IGraphics::CORNER_ALL, 8.0f, 0.0f, vec4(1, 1, 1, 0.5f), vec4(1, 1, 1, 0.25f)))
 	{
-		*pColorValue = color_cast<ColorHSLA>(DefaultColor).Pack(false);
+		*pColorValue = color_cast<ColorHSLA>(DefaultColor).Pack(Alpha);
 	}
 
 	return PickedColor;
+}
+
+ColorHSLA CMenus::DoButton_ColorPicker(const CUIRect *pRect, unsigned int *pColor, bool Alpha)
+{
+	ColorHSLA HSLColor = ColorHSLA(*pColor, Alpha);
+
+	ColorRGBA Outline = ColorRGBA(1.0f, 1.0f, 1.0f, 0.25f);
+	Outline.a *= UI()->ButtonColorMul(pColor);
+
+	CUIRect Rect;
+	pRect->Margin(3.0f, &Rect);
+
+	pRect->Draw(Outline, IGraphics::CORNER_ALL, 4.0f);
+	Rect.Draw(color_cast<ColorRGBA>(HSLColor), IGraphics::CORNER_ALL, 4.0f);
+
+	static CUI::SColorPickerPopupContext s_ColorPickerPopupContext;
+	if(UI()->DoButtonLogic(pColor, 0, pRect))
+	{
+		s_ColorPickerPopupContext.m_pColor = pColor;
+		s_ColorPickerPopupContext.m_HSVColor = color_cast<ColorHSVA>(HSLColor).Pack(Alpha);
+		s_ColorPickerPopupContext.m_Alpha = Alpha;
+		UI()->ShowPopupColorPicker(UI()->MouseX(), UI()->MouseY(), &s_ColorPickerPopupContext);
+	}
+	else if(UI()->IsPopupOpen(&s_ColorPickerPopupContext) && s_ColorPickerPopupContext.m_pColor == pColor)
+	{
+		HSLColor = color_cast<ColorHSLA>(ColorHSVA(s_ColorPickerPopupContext.m_HSVColor, Alpha));
+	}
+
+	return HSLColor;
 }
 
 int CMenus::DoButton_CheckBoxAutoVMarginAndSet(const void *pID, const char *pText, int *pValue, CUIRect *pRect, float VMargin)
@@ -949,196 +956,6 @@ void CMenus::PopupWarning(const char *pTopic, const char *pBody, const char *pBu
 bool CMenus::CanDisplayWarning()
 {
 	return m_Popup == POPUP_NONE;
-}
-
-void CMenus::RenderColorPicker()
-{
-	if(!ms_ColorPicker.m_Active)
-		return;
-
-	if(UI()->ConsumeHotkey(CUI::HOTKEY_ESCAPE))
-	{
-		ms_ColorPicker.m_Active = false;
-		UI()->SetValueSelectorTextMode(false);
-		UI()->SetActiveItem(nullptr);
-		return;
-	}
-
-	// First check if we should disable color picker
-	CUIRect PickerRect;
-	PickerRect.x = ms_ColorPicker.m_X;
-	PickerRect.y = ms_ColorPicker.m_Y;
-	PickerRect.w = ms_ColorPicker.ms_Width;
-	PickerRect.h = ms_ColorPicker.ms_Height;
-
-	if(UI()->MouseButtonClicked(0) && !UI()->MouseInside(&PickerRect) && !UI()->MouseInside(&ms_ColorPicker.m_AttachedRect))
-	{
-		ms_ColorPicker.m_Active = false;
-		UI()->SetValueSelectorTextMode(false);
-		UI()->SetActiveItem(nullptr);
-		return;
-	}
-
-	// Prevent activation of UI elements outside of active color picker
-	if(UI()->MouseInside(&PickerRect))
-		UI()->SetHotItem(&ms_ColorPicker);
-
-	// Render
-	ColorRGBA BackgroundColor(0.1f, 0.1f, 0.1f, 1.0f);
-	PickerRect.Draw(BackgroundColor, 0, 0);
-
-	CUIRect ColorsArea, HueArea, ValuesHitbox, BottomArea, HueRect, SatRect, ValueRect, HexRect, AlphaRect;
-	PickerRect.Margin(3, &ColorsArea);
-
-	ColorsArea.HSplitBottom(ms_ColorPicker.ms_Height - 140.0f, &ColorsArea, &ValuesHitbox);
-	ColorsArea.VSplitRight(20, &ColorsArea, &HueArea);
-
-	BottomArea = ValuesHitbox;
-	BottomArea.HSplitTop(3, 0x0, &BottomArea);
-	HueArea.VSplitLeft(3, 0x0, &HueArea);
-
-	BottomArea.HSplitTop(20, &HueRect, &BottomArea);
-	BottomArea.HSplitTop(3, 0x0, &BottomArea);
-
-	constexpr float ValuePadding = 5.0f;
-	const float HsvValueWidth = (HueRect.w - ValuePadding * 2) / 3.0f;
-	const float HexValueWidth = HsvValueWidth * 2 + ValuePadding;
-
-	HueRect.VSplitLeft(HsvValueWidth, &HueRect, &SatRect);
-	SatRect.VSplitLeft(ValuePadding, 0x0, &SatRect);
-	SatRect.VSplitLeft(HsvValueWidth, &SatRect, &ValueRect);
-	ValueRect.VSplitLeft(ValuePadding, 0x0, &ValueRect);
-
-	BottomArea.HSplitTop(20, &HexRect, &BottomArea);
-	HexRect.VSplitLeft(HexValueWidth, &HexRect, &AlphaRect);
-	AlphaRect.VSplitLeft(ValuePadding, 0x0, &AlphaRect);
-
-	if(UI()->MouseButtonReleased(1) && !UI()->MouseInside(&ValuesHitbox))
-	{
-		ms_ColorPicker.m_Active = false;
-		UI()->SetValueSelectorTextMode(false);
-		UI()->SetActiveItem(nullptr);
-		return;
-	}
-
-	ColorRGBA BlackColor(0, 0, 0, 0.5f);
-
-	HueArea.Draw(BlackColor, 0, 0);
-	HueArea.Margin(1, &HueArea);
-
-	ColorsArea.Draw(BlackColor, 0, 0);
-	ColorsArea.Margin(1, &ColorsArea);
-
-	ColorHSVA PickerColorHSV(ms_ColorPicker.m_HSVColor);
-	unsigned H = (unsigned)(PickerColorHSV.x * 255.0f);
-	unsigned S = (unsigned)(PickerColorHSV.y * 255.0f);
-	unsigned V = (unsigned)(PickerColorHSV.z * 255.0f);
-
-	// Color Area
-	vec4 TL = color_cast<ColorRGBA>(ColorHSVA(PickerColorHSV.x, 0.0f, 1.0f));
-	vec4 TR = color_cast<ColorRGBA>(ColorHSVA(PickerColorHSV.x, 1.0f, 1.0f));
-	vec4 BL = color_cast<ColorRGBA>(ColorHSVA(PickerColorHSV.x, 0.0f, 1.0f));
-	vec4 BR = color_cast<ColorRGBA>(ColorHSVA(PickerColorHSV.x, 1.0f, 1.0f));
-
-	ColorsArea.Draw4(TL, TR, BL, BR, IGraphics::CORNER_NONE, 0.0f);
-
-	TL = vec4(0.0f, 0.0f, 0.0f, 0.0f);
-	TR = vec4(0.0f, 0.0f, 0.0f, 0.0f);
-	BL = vec4(0.0f, 0.0f, 0.0f, 1.0f);
-	BR = vec4(0.0f, 0.0f, 0.0f, 1.0f);
-
-	ColorsArea.Draw4(TL, TR, BL, BR, IGraphics::CORNER_NONE, 0.0f);
-
-	// Hue Area
-	static const float s_aColorIndices[7][3] = {
-		{1.0f, 0.0f, 0.0f}, // red
-		{1.0f, 0.0f, 1.0f}, // magenta
-		{0.0f, 0.0f, 1.0f}, // blue
-		{0.0f, 1.0f, 1.0f}, // cyan
-		{0.0f, 1.0f, 0.0f}, // green
-		{1.0f, 1.0f, 0.0f}, // yellow
-		{1.0f, 0.0f, 0.0f} // red
-	};
-
-	float HuePickerOffset = HueArea.h / 6.0f;
-	CUIRect HuePartialArea = HueArea;
-	HuePartialArea.h = HuePickerOffset;
-
-	for(int j = 0; j < 6; j++)
-	{
-		TL = vec4(s_aColorIndices[j][0], s_aColorIndices[j][1], s_aColorIndices[j][2], 1.0f);
-		BL = vec4(s_aColorIndices[j + 1][0], s_aColorIndices[j + 1][1], s_aColorIndices[j + 1][2], 1.0f);
-
-		HuePartialArea.y = HueArea.y + HuePickerOffset * j;
-		HuePartialArea.Draw4(TL, TL, BL, BL, IGraphics::CORNER_NONE, 0.0f);
-	}
-
-	// Editboxes Area
-	static char s_aValueSelectorIds[4];
-
-	H = UI()->DoValueSelector(&s_aValueSelectorIds[0], &HueRect, "H:", H, 0, 255);
-	S = UI()->DoValueSelector(&s_aValueSelectorIds[1], &SatRect, "S:", S, 0, 255);
-	V = UI()->DoValueSelector(&s_aValueSelectorIds[2], &ValueRect, "V:", V, 0, 255);
-
-	PickerColorHSV = ColorHSVA(H / 255.0f, S / 255.0f, V / 255.0f);
-
-	SValueSelectorProperties Props;
-	Props.m_UseScroll = false;
-	Props.m_IsHex = true;
-	unsigned int Hex = color_cast<ColorRGBA>(PickerColorHSV).Pack(false);
-	unsigned int NewHex = UI()->DoValueSelector(&s_aValueSelectorIds[3], &HexRect, "Hex:", Hex, 0, 0xFFFFFF, Props);
-
-	if(Hex != NewHex)
-		PickerColorHSV = color_cast<ColorHSVA>(ColorRGBA(NewHex));
-
-	// TODO : ALPHA SUPPORT
-	UI()->DoLabel(&AlphaRect, "A: 255", 10, TEXTALIGN_MC);
-	AlphaRect.Draw(ColorRGBA(0, 0, 0, 0.65f), IGraphics::CORNER_ALL, 5.0f);
-
-	// Logic
-	float PickerX, PickerY;
-	static int s_ColorPickerId = 0;
-	if(UI()->DoPickerLogic(&s_ColorPickerId, &ColorsArea, &PickerX, &PickerY))
-	{
-		PickerColorHSV.y = PickerX / ColorsArea.w;
-		PickerColorHSV.z = 1.0f - PickerY / ColorsArea.h;
-	}
-
-	static int s_HuePickerId = 0;
-	if(UI()->DoPickerLogic(&s_HuePickerId, &HueArea, &PickerX, &PickerY))
-		PickerColorHSV.x = 1.0f - PickerY / HueArea.h;
-
-	// Marker Color Area
-	const float MarkerX = ColorsArea.x + ColorsArea.w * PickerColorHSV.y;
-	const float MarkerY = ColorsArea.y + ColorsArea.h * (1.0f - PickerColorHSV.z);
-
-	const float MarkerOutlineInd = PickerColorHSV.z > 0.5f ? 0.0f : 1.0f;
-	const ColorRGBA MarkerOutline = ColorRGBA(MarkerOutlineInd, MarkerOutlineInd, MarkerOutlineInd, 1.0f);
-
-	Graphics()->TextureClear();
-	Graphics()->QuadsBegin();
-	Graphics()->SetColor(MarkerOutline);
-	Graphics()->DrawCircle(MarkerX, MarkerY, 4.5f, 32);
-	Graphics()->SetColor(color_cast<ColorRGBA>(PickerColorHSV));
-	Graphics()->DrawCircle(MarkerX, MarkerY, 3.5f, 32);
-	Graphics()->QuadsEnd();
-
-	// Marker Hue Area
-	CUIRect HueMarker;
-	HueArea.Margin(-2.5f, &HueMarker);
-	HueMarker.h = 6.5f;
-	HueMarker.y = (HueArea.y + HueArea.h * (1.0f - PickerColorHSV.x)) - HueMarker.h / 2.0f;
-
-	const ColorRGBA HueMarkerColor = color_cast<ColorRGBA>(ColorHSVA(PickerColorHSV.x, 1, 1, 1));
-	const float HueMarkerOutlineColor = PickerColorHSV.x > 0.75f ? 1.0f : 0.0f;
-	const ColorRGBA HueMarkerOutline = ColorRGBA(HueMarkerOutlineColor, HueMarkerOutlineColor, HueMarkerOutlineColor, 1);
-
-	HueMarker.Draw(HueMarkerOutline, IGraphics::CORNER_ALL, 1.2f);
-	HueMarker.Margin(1.2f, &HueMarker);
-	HueMarker.Draw(HueMarkerColor, IGraphics::CORNER_ALL, 1.2f);
-
-	ms_ColorPicker.m_HSVColor = PickerColorHSV.Pack(false);
-	*ms_ColorPicker.m_pColor = color_cast<ColorHSLA>(PickerColorHSV).Pack(false);
 }
 
 int CMenus::Render()
@@ -2048,7 +1865,6 @@ void CMenus::SetActive(bool Active)
 {
 	if(Active != m_MenuActive)
 	{
-		ms_ColorPicker.m_Active = false;
 		UI()->SetHotItem(nullptr);
 		UI()->SetActiveItem(nullptr);
 	}

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -2093,9 +2093,7 @@ bool CMenus::OnCursorMove(float x, float y, IInput::ECursorType CursorType)
 		return false;
 
 	UI()->ConvertMouseMove(&x, &y, CursorType);
-
-	m_MousePos.x = clamp(m_MousePos.x + x, 0.f, (float)Graphics()->WindowWidth());
-	m_MousePos.y = clamp(m_MousePos.y + y, 0.f, (float)Graphics()->WindowHeight());
+	UI()->OnCursorMove(x, y);
 
 	return true;
 }
@@ -2193,15 +2191,10 @@ void CMenus::OnRender()
 
 	UpdateColors();
 
-	// update the ui
-	const CUIRect *pScreen = UI()->Screen();
-	float mx = (m_MousePos.x / (float)Graphics()->WindowWidth()) * pScreen->w;
-	float my = (m_MousePos.y / (float)Graphics()->WindowHeight()) * pScreen->h;
-
-	UI()->Update(mx, my, mx * 3.0f, my * 3.0f);
+	UI()->Update();
 
 	Render();
-	RenderTools()->RenderCursor(vec2(mx, my), 24.0f);
+	RenderTools()->RenderCursor(UI()->MousePos(), 24.0f);
 
 	// render debug information
 	if(g_Config.m_Debug)

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -176,7 +176,6 @@ protected:
 	int m_ActivePage;
 	bool m_ShowStart;
 	bool m_MenuActive;
-	vec2 m_MousePos;
 	bool m_JoinTutorial;
 
 	char m_aNextServer[256];

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -29,22 +29,6 @@ struct CServerProcess
 	PROCESS m_Process;
 };
 
-struct SColorPicker
-{
-public:
-	const float ms_Width = 160.0f;
-	const float ms_Height = 186.0f;
-
-	float m_X;
-	float m_Y;
-
-	bool m_Active;
-
-	CUIRect m_AttachedRect;
-	unsigned int *m_pColor;
-	unsigned int m_HSVColor;
-};
-
 // component to fetch keypresses, override all other input
 class CMenusKeyBinder : public CComponent
 {
@@ -71,11 +55,9 @@ class CMenus : public CComponent
 	static ColorRGBA ms_ColorTabbarActive;
 	static ColorRGBA ms_ColorTabbarHover;
 
-	static SColorPicker ms_ColorPicker;
-
 	int DoButton_FontIcon(CButtonContainer *pButtonContainer, const char *pText, int Checked, const CUIRect *pRect, int Corners = IGraphics::CORNER_ALL, bool Enabled = true);
 	int DoButton_Toggle(const void *pID, int Checked, const CUIRect *pRect, bool Active);
-	int DoButton_Menu(CButtonContainer *pButtonContainer, const char *pText, int Checked, const CUIRect *pRect, const char *pImageName = nullptr, int Corners = IGraphics::CORNER_ALL, float r = 5.0f, float FontFactor = 0.0f, vec4 ColorHot = vec4(1.0f, 1.0f, 1.0f, 0.75f), vec4 Color = vec4(1, 1, 1, 0.5f), bool CheckForActiveColorPicker = false);
+	int DoButton_Menu(CButtonContainer *pButtonContainer, const char *pText, int Checked, const CUIRect *pRect, const char *pImageName = nullptr, int Corners = IGraphics::CORNER_ALL, float r = 5.0f, float FontFactor = 0.0f, vec4 ColorHot = vec4(1.0f, 1.0f, 1.0f, 0.75f), vec4 Color = vec4(1, 1, 1, 0.5f));
 	int DoButton_MenuTab(CButtonContainer *pButtonContainer, const char *pText, int Checked, const CUIRect *pRect, int Corners, SUIAnimator *pAnimator = nullptr, const ColorRGBA *pDefaultColor = nullptr, const ColorRGBA *pActiveColor = nullptr, const ColorRGBA *pHoverColor = nullptr, float EdgeRounding = 10);
 
 	int DoButton_CheckBox_Common(const void *pID, const char *pText, const char *pBoxText, const CUIRect *pRect);
@@ -83,7 +65,8 @@ class CMenus : public CComponent
 	int DoButton_CheckBoxAutoVMarginAndSet(const void *pID, const char *pText, int *pValue, CUIRect *pRect, float VMargin);
 	int DoButton_CheckBox_Number(const void *pID, const char *pText, int Checked, const CUIRect *pRect);
 
-	ColorHSLA DoLine_ColorPicker(CButtonContainer *pResetID, float LineSize, float LabelSize, float BottomMargin, CUIRect *pMainRect, const char *pText, unsigned int *pColorValue, ColorRGBA DefaultColor, bool CheckBoxSpacing = true, int *pCheckBoxValue = nullptr);
+	ColorHSLA DoLine_ColorPicker(CButtonContainer *pResetID, float LineSize, float LabelSize, float BottomMargin, CUIRect *pMainRect, const char *pText, unsigned int *pColorValue, ColorRGBA DefaultColor, bool CheckBoxSpacing = true, int *pCheckBoxValue = nullptr, bool Alpha = false);
+	ColorHSLA DoButton_ColorPicker(const CUIRect *pRect, unsigned int *pColor, bool Alpha);
 	void DoLaserPreview(const CUIRect *pRect, ColorHSLA OutlineColor, ColorHSLA InnerColor, const int LaserType);
 	int DoButton_GridHeader(const void *pID, const char *pText, int Checked, const CUIRect *pRect);
 
@@ -95,8 +78,6 @@ class CMenus : public CComponent
 	float RenderSettingsControlsJoystick(CUIRect View);
 	void DoJoystickAxisPicker(CUIRect View);
 	void DoJoystickBar(const CUIRect *pRect, float Current, float Tolerance, bool Active);
-
-	void RenderColorPicker();
 
 	void RefreshSkins();
 
@@ -679,7 +660,6 @@ private:
 	// found in menus_settings.cpp
 	void RenderSettingsDDNet(CUIRect MainView);
 	void RenderSettingsAppearance(CUIRect MainView);
-	ColorHSLA RenderHSLColorPicker(const CUIRect *pRect, unsigned int *pColor, bool Alpha);
 	ColorHSLA RenderHSLScrollbars(CUIRect *pRect, unsigned int *pColor, bool Alpha = false, bool ClampedLight = false);
 
 	int RenderDropDown(int &CurDropDownState, CUIRect *pRect, int CurSelection, const void **pIDs, const char **pStr, int PickNum, CButtonContainer *pButtonContainer, float &ScrollVal);

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -72,7 +72,6 @@ class CMenus : public CComponent
 	static ColorRGBA ms_ColorTabbarHover;
 
 	static SColorPicker ms_ColorPicker;
-	static bool ms_ValueSelectorTextMode;
 
 	int DoButton_FontIcon(CButtonContainer *pButtonContainer, const char *pText, int Checked, const CUIRect *pRect, int Corners = IGraphics::CORNER_ALL, bool Enabled = true);
 	int DoButton_Toggle(const void *pID, int Checked, const CUIRect *pRect, bool Active);
@@ -86,7 +85,6 @@ class CMenus : public CComponent
 
 	ColorHSLA DoLine_ColorPicker(CButtonContainer *pResetID, float LineSize, float LabelSize, float BottomMargin, CUIRect *pMainRect, const char *pText, unsigned int *pColorValue, ColorRGBA DefaultColor, bool CheckBoxSpacing = true, int *pCheckBoxValue = nullptr);
 	void DoLaserPreview(const CUIRect *pRect, ColorHSLA OutlineColor, ColorHSLA InnerColor, const int LaserType);
-	int DoValueSelector(void *pID, CUIRect *pRect, const char *pLabel, bool UseScroll, int Current, int Min, int Max, int Step, float Scale, bool IsHex, float Round, ColorRGBA *pColor);
 	int DoButton_GridHeader(const void *pID, const char *pText, int Checked, const CUIRect *pRect);
 
 	void DoButton_KeySelect(const void *pID, const char *pText, const CUIRect *pRect);

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -2122,7 +2122,6 @@ void CMenus::RenderSettings(CUIRect MainView)
 	static CButtonContainer s_aTabButtons[sizeof(apTabs)];
 
 	int NumTabs = (int)std::size(apTabs);
-	int PreviousPage = g_Config.m_UiSettingsPage;
 
 	for(int i = 0; i < NumTabs; i++)
 	{
@@ -2131,9 +2130,6 @@ void CMenus::RenderSettings(CUIRect MainView)
 		if(DoButton_MenuTab(&s_aTabButtons[i], apTabs[i], g_Config.m_UiSettingsPage == i, &Button, IGraphics::CORNER_R, &m_aAnimatorsSettingsTab[i]))
 			g_Config.m_UiSettingsPage = i;
 	}
-
-	if(PreviousPage != g_Config.m_UiSettingsPage)
-		ms_ColorPicker.m_Active = false;
 
 	MainView.Margin(10.0f, &MainView);
 
@@ -2196,49 +2192,6 @@ void CMenus::RenderSettings(CUIRect MainView)
 	}
 	else if(m_NeedRestartGeneral || m_NeedRestartSkins || m_NeedRestartGraphics || m_NeedRestartSound || m_NeedRestartDDNet)
 		UI()->DoLabel(&RestartWarning, Localize("You must restart the game for all settings to take effect."), 14.0f, TEXTALIGN_ML);
-
-	RenderColorPicker();
-}
-
-ColorHSLA CMenus::RenderHSLColorPicker(const CUIRect *pRect, unsigned int *pColor, bool Alpha)
-{
-	ColorHSLA HSLColor(*pColor, false);
-	ColorRGBA RGBColor = color_cast<ColorRGBA>(HSLColor);
-
-	ColorRGBA Outline(1, 1, 1, 0.25f);
-	const float OutlineSize = 3.0f;
-	Outline.a *= UI()->ButtonColorMul(pColor);
-
-	CUIRect Rect;
-	pRect->Margin(OutlineSize, &Rect);
-
-	pRect->Draw(Outline, IGraphics::CORNER_ALL, 4.0f);
-	Rect.Draw(RGBColor, IGraphics::CORNER_ALL, 4.0f);
-
-	if(UI()->DoButtonLogic(pColor, 0, pRect))
-	{
-		if(ms_ColorPicker.m_Active)
-		{
-			CUIRect PickerRect;
-			PickerRect.x = ms_ColorPicker.m_X;
-			PickerRect.y = ms_ColorPicker.m_Y;
-			PickerRect.w = ms_ColorPicker.ms_Width;
-			PickerRect.h = ms_ColorPicker.ms_Height;
-
-			if(ms_ColorPicker.m_pColor == pColor || UI()->MouseInside(&PickerRect))
-				return HSLColor;
-		}
-
-		const CUIRect *pScreen = UI()->Screen();
-		ms_ColorPicker.m_X = minimum(UI()->MouseX(), pScreen->w - ms_ColorPicker.ms_Width);
-		ms_ColorPicker.m_Y = minimum(UI()->MouseY(), pScreen->h - ms_ColorPicker.ms_Height);
-		ms_ColorPicker.m_pColor = pColor;
-		ms_ColorPicker.m_Active = true;
-		ms_ColorPicker.m_AttachedRect = *pRect;
-		ms_ColorPicker.m_HSVColor = color_cast<ColorHSVA, ColorHSLA>(HSLColor).Pack(false);
-	}
-
-	return HSLColor;
 }
 
 ColorHSLA CMenus::RenderHSLScrollbars(CUIRect *pRect, unsigned int *pColor, bool Alpha, bool ClampedLight)

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -1724,15 +1724,9 @@ void CMenus::RenderSettingsGraphics(CUIRect MainView)
 	if(g_Config.m_GfxRefreshRate <= 1000 || NewRefreshRate < 1000)
 		g_Config.m_GfxRefreshRate = NewRefreshRate;
 
-	CUIRect Text;
-	MainView.HSplitTop(20.0f, 0, &MainView);
-	MainView.HSplitTop(20.0f, &Text, &MainView);
-	// text.VSplitLeft(15.0f, 0, &text);
-	UI()->DoLabel(&Text, Localize("UI Color"), 14.0f, TEXTALIGN_ML);
-	CUIRect HSLBar = MainView;
-	RenderHSLScrollbars(&HSLBar, &g_Config.m_UiColor, true);
-	MainView.y = HSLBar.y;
-	MainView.h = MainView.h - MainView.y;
+	MainView.HSplitTop(2.0f, nullptr, &MainView);
+	static CButtonContainer s_UiColorResetId;
+	DoLine_ColorPicker(&s_UiColorResetId, 25.0f, 13.0f, 2.0f, &MainView, Localize("UI Color"), &g_Config.m_UiColor, color_cast<ColorRGBA>(ColorHSLA(0xE4A046AFU, true)), false, nullptr, true);
 
 	// Backend list
 	struct SMenuBackendInfo
@@ -1766,6 +1760,7 @@ void CMenus::RenderSettingsGraphics(CUIRect MainView)
 
 	if(FoundBackendCount > 1)
 	{
+		CUIRect Text;
 		MainView.HSplitTop(10.0f, nullptr, &MainView);
 		MainView.HSplitTop(20.0f, &Text, &MainView);
 		UI()->DoLabel(&Text, Localize("Renderer"), 16.0f, TEXTALIGN_MC);
@@ -1869,6 +1864,7 @@ void CMenus::RenderSettingsGraphics(CUIRect MainView)
 	const auto &GPUList = Graphics()->GetGPUs();
 	if(GPUList.m_vGPUs.size() > 1)
 	{
+		CUIRect Text;
 		MainView.HSplitTop(10.0f, nullptr, &MainView);
 		MainView.HSplitTop(20.0f, &Text, &MainView);
 		UI()->DoLabel(&Text, Localize("Graphics cards"), 16.0f, TEXTALIGN_MC);

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -1565,6 +1565,7 @@ void CMenus::RenderSettingsGraphics(CUIRect MainView)
 	static const float sc_RowHeightResList = 22.0f;
 	static const float sc_FontSizeResListHeader = 12.0f;
 	static const float sc_FontSizeResList = 10.0f;
+	bool ListBoxUsed = !UI()->IsPopupOpen();
 	int OldSelected = -1;
 	{
 		int G = std::gcd(g_Config.m_GfxScreenWidth, g_Config.m_GfxScreenHeight);
@@ -1572,7 +1573,7 @@ void CMenus::RenderSettingsGraphics(CUIRect MainView)
 	}
 
 	UI()->DoLabel(&ModeLabel, aBuf, sc_FontSizeResListHeader, TEXTALIGN_MC);
-	s_ListBox.DoStart(sc_RowHeightResList, s_NumNodes, 1, 3, OldSelected, &ModeList);
+	s_ListBox.DoStart(sc_RowHeightResList, s_NumNodes, 1, 3, OldSelected, &ModeList, true, &ListBoxUsed);
 
 	for(int i = 0; i < s_NumNodes; ++i)
 	{
@@ -1585,7 +1586,7 @@ void CMenus::RenderSettingsGraphics(CUIRect MainView)
 			OldSelected = i;
 		}
 
-		const CListboxItem Item = s_ListBox.DoNextItem(&s_aModes[i], OldSelected == i);
+		const CListboxItem Item = s_ListBox.DoNextItem(&s_aModes[i], OldSelected == i, &ListBoxUsed);
 		if(!Item.m_Visible)
 			continue;
 

--- a/src/game/client/lineinput.cpp
+++ b/src/game/client/lineinput.cpp
@@ -662,7 +662,7 @@ void CLineInput::OnDeactivate()
 	m_MouseSelection.m_Selecting = false;
 }
 
-void CLineInputNumber::SetInteger(int Number, int Base)
+void CLineInputNumber::SetInteger(int Number, int Base, int HexPrefix)
 {
 	char aBuf[32];
 	switch(Base)
@@ -671,7 +671,7 @@ void CLineInputNumber::SetInteger(int Number, int Base)
 		str_format(aBuf, sizeof(aBuf), "%d", Number);
 		break;
 	case 16:
-		str_format(aBuf, sizeof(aBuf), "%06X", Number);
+		str_format(aBuf, sizeof(aBuf), "%0*X", HexPrefix, Number);
 		break;
 	default:
 		dbg_assert(false, "Base unsupported");
@@ -684,6 +684,30 @@ void CLineInputNumber::SetInteger(int Number, int Base)
 int CLineInputNumber::GetInteger(int Base) const
 {
 	return str_toint_base(GetString(), Base);
+}
+
+void CLineInputNumber::SetInteger64(int64_t Number, int Base, int HexPrefix)
+{
+	char aBuf[64];
+	switch(Base)
+	{
+	case 10:
+		str_format(aBuf, sizeof(aBuf), "%" PRId64, Number);
+		break;
+	case 16:
+		str_format(aBuf, sizeof(aBuf), "%0*" PRIX64, HexPrefix, Number);
+		break;
+	default:
+		dbg_assert(false, "Base unsupported");
+		return;
+	}
+	if(str_comp(aBuf, GetString()) != 0)
+		Set(aBuf);
+}
+
+int64_t CLineInputNumber::GetInteger64(int Base) const
+{
+	return str_toint64_base(GetString(), Base);
 }
 
 void CLineInputNumber::SetFloat(float Number)

--- a/src/game/client/lineinput.h
+++ b/src/game/client/lineinput.h
@@ -218,8 +218,11 @@ public:
 		SetFloat(Number);
 	}
 
-	void SetInteger(int Number, int Base = 10);
+	void SetInteger(int Number, int Base = 10, int HexPrefix = 6);
 	int GetInteger(int Base = 10) const;
+
+	void SetInteger64(int64_t Number, int Base = 10, int HexPrefix = 6);
+	int64_t GetInteger64(int Base = 10) const;
 
 	void SetFloat(float Number);
 	float GetFloat() const;

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -181,8 +181,12 @@ void CUI::OnLanguageChange()
 
 void CUI::OnCursorMove(float X, float Y)
 {
-	m_UpdatedMousePos.x = clamp(m_UpdatedMousePos.x + X, 0.0f, (float)Graphics()->WindowWidth());
-	m_UpdatedMousePos.y = clamp(m_UpdatedMousePos.y + Y, 0.0f, (float)Graphics()->WindowHeight());
+	if(!CheckMouseLock())
+	{
+		m_UpdatedMousePos.x = clamp(m_UpdatedMousePos.x + X, 0.0f, (float)Graphics()->WindowWidth());
+		m_UpdatedMousePos.y = clamp(m_UpdatedMousePos.y + Y, 0.0f, (float)Graphics()->WindowHeight());
+	}
+
 	m_UpdatedMouseDelta += vec2(X, Y);
 }
 
@@ -957,8 +961,6 @@ int CUI::DoButton_PopupMenu(CButtonContainer *pButtonContainer, const char *pTex
 
 int64_t CUI::DoValueSelector(const void *pID, const CUIRect *pRect, const char *pLabel, int64_t Current, int64_t Min, int64_t Max, const SValueSelectorProperties &Props)
 {
-	// TODO: reimplement m_LockMouse
-
 	// logic
 	static float s_Value;
 	static CLineInputNumber s_NumberInput;
@@ -982,7 +984,7 @@ int64_t CUI::DoValueSelector(const void *pID, const CUIRect *pRect, const char *
 	{
 		if(!MouseButton(0))
 		{
-			//m_LockMouse = false;
+			DisableMouseLock();
 			SetActiveItem(nullptr);
 			m_ValueSelectorTextMode = false;
 		}
@@ -996,14 +998,14 @@ int64_t CUI::DoValueSelector(const void *pID, const CUIRect *pRect, const char *
 		if(ConsumeHotkey(HOTKEY_ENTER) || ((MouseButtonClicked(1) || MouseButtonClicked(0)) && !Inside))
 		{
 			Current = clamp(s_NumberInput.GetInteger64(Base), Min, Max);
-			//m_LockMouse = false;
+			DisableMouseLock();
 			SetActiveItem(nullptr);
 			m_ValueSelectorTextMode = false;
 		}
 
 		if(ConsumeHotkey(HOTKEY_ESCAPE))
 		{
-			//m_LockMouse = false;
+			DisableMouseLock();
 			SetActiveItem(nullptr);
 			m_ValueSelectorTextMode = false;
 		}
@@ -1038,9 +1040,10 @@ int64_t CUI::DoValueSelector(const void *pID, const CUIRect *pRect, const char *
 		{
 			if(MouseButtonClicked(0))
 			{
-				//m_LockMouse = true;
 				s_Value = 0;
 				SetActiveItem(pID);
+				if(Props.m_UseScroll)
+					EnableMouseLock(pID);
 			}
 		}
 

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -1539,3 +1539,180 @@ void CUI::ShowPopupSelection(float X, float Y, SSelectionPopupContext *pContext)
 	pContext->m_pSelection = nullptr;
 	DoPopupMenu(pContext, X, Y, SSelectionPopupContext::POPUP_MAX_WIDTH + 10.0f, PopupHeight, pContext, PopupSelection);
 }
+
+CUI::EPopupMenuFunctionResult CUI::PopupColorPicker(void *pContext, CUIRect View, bool Active)
+{
+	SColorPickerPopupContext *pColorPicker = static_cast<SColorPickerPopupContext *>(pContext);
+	CUI *pUI = pColorPicker->m_pUI;
+
+	CUIRect ColorsArea = View, HueArea, BottomArea, HueRect, SatRect, ValueRect, HexRect, AlphaRect;
+
+	ColorsArea.HSplitBottom(View.h - 140.0f, &ColorsArea, &BottomArea);
+	ColorsArea.VSplitRight(20.0f, &ColorsArea, &HueArea);
+
+	BottomArea.HSplitTop(3.0f, nullptr, &BottomArea);
+	HueArea.VSplitLeft(3.0f, nullptr, &HueArea);
+
+	BottomArea.HSplitTop(20.0f, &HueRect, &BottomArea);
+	BottomArea.HSplitTop(3.0f, nullptr, &BottomArea);
+
+	constexpr float ValuePadding = 5.0f;
+	const float HsvValueWidth = (HueRect.w - ValuePadding * 2) / 3.0f;
+	const float HexValueWidth = HsvValueWidth * 2 + ValuePadding;
+
+	HueRect.VSplitLeft(HsvValueWidth, &HueRect, &SatRect);
+	SatRect.VSplitLeft(ValuePadding, nullptr, &SatRect);
+	SatRect.VSplitLeft(HsvValueWidth, &SatRect, &ValueRect);
+	ValueRect.VSplitLeft(ValuePadding, nullptr, &ValueRect);
+
+	BottomArea.HSplitTop(20.0f, &HexRect, &BottomArea);
+	HexRect.VSplitLeft(HexValueWidth, &HexRect, &AlphaRect);
+	AlphaRect.VSplitLeft(ValuePadding, nullptr, &AlphaRect);
+
+	const ColorRGBA BlackColor = ColorRGBA(0.0f, 0.0f, 0.0f, 0.5f);
+
+	HueArea.Draw(BlackColor, IGraphics::CORNER_NONE, 0.0f);
+	HueArea.Margin(1.0f, &HueArea);
+
+	ColorsArea.Draw(BlackColor, IGraphics::CORNER_NONE, 0.0f);
+	ColorsArea.Margin(1.0f, &ColorsArea);
+
+	ColorHSVA PickerColorHSV = ColorHSVA(pColorPicker->m_HSVColor, pColorPicker->m_Alpha);
+	unsigned H = (unsigned)(PickerColorHSV.x * 255.0f);
+	unsigned S = (unsigned)(PickerColorHSV.y * 255.0f);
+	unsigned V = (unsigned)(PickerColorHSV.z * 255.0f);
+	unsigned A = (unsigned)(PickerColorHSV.a * 255.0f);
+
+	// Color Area
+	ColorRGBA TL, TR, BL, BR;
+	TL = BL = color_cast<ColorRGBA>(ColorHSVA(PickerColorHSV.x, 0.0f, 1.0f));
+	TR = BR = color_cast<ColorRGBA>(ColorHSVA(PickerColorHSV.x, 1.0f, 1.0f));
+	ColorsArea.Draw4(TL, TR, BL, BR, IGraphics::CORNER_NONE, 0.0f);
+
+	TL = TR = ColorRGBA(0.0f, 0.0f, 0.0f, 0.0f);
+	BL = BR = ColorRGBA(0.0f, 0.0f, 0.0f, 1.0f);
+	ColorsArea.Draw4(TL, TR, BL, BR, IGraphics::CORNER_NONE, 0.0f);
+
+	// Hue Area
+	static const float s_aaColorIndices[7][3] = {
+		{1.0f, 0.0f, 0.0f}, // red
+		{1.0f, 0.0f, 1.0f}, // magenta
+		{0.0f, 0.0f, 1.0f}, // blue
+		{0.0f, 1.0f, 1.0f}, // cyan
+		{0.0f, 1.0f, 0.0f}, // green
+		{1.0f, 1.0f, 0.0f}, // yellow
+		{1.0f, 0.0f, 0.0f}, // red
+	};
+
+	const float HuePickerOffset = HueArea.h / 6.0f;
+	CUIRect HuePartialArea = HueArea;
+	HuePartialArea.h = HuePickerOffset;
+
+	for(size_t j = 0; j < std::size(s_aaColorIndices) - 1; j++)
+	{
+		TL = ColorRGBA(s_aaColorIndices[j][0], s_aaColorIndices[j][1], s_aaColorIndices[j][2], 1.0f);
+		BL = ColorRGBA(s_aaColorIndices[j + 1][0], s_aaColorIndices[j + 1][1], s_aaColorIndices[j + 1][2], 1.0f);
+
+		HuePartialArea.y = HueArea.y + HuePickerOffset * j;
+		HuePartialArea.Draw4(TL, TL, BL, BL, IGraphics::CORNER_NONE, 0.0f);
+	}
+
+	// Editboxes Area
+	H = pUI->DoValueSelector(&pColorPicker->m_aValueSelectorIds[0], &HueRect, "H:", H, 0, 255);
+	S = pUI->DoValueSelector(&pColorPicker->m_aValueSelectorIds[1], &SatRect, "S:", S, 0, 255);
+	V = pUI->DoValueSelector(&pColorPicker->m_aValueSelectorIds[2], &ValueRect, "V:", V, 0, 255);
+	if(pColorPicker->m_Alpha)
+	{
+		A = pUI->DoValueSelector(&pColorPicker->m_aValueSelectorIds[3], &AlphaRect, "A:", A, 0, 255);
+	}
+	else
+	{
+		char aBuf[8];
+		str_format(aBuf, sizeof(aBuf), "A: %d", A);
+		pUI->DoLabel(&AlphaRect, aBuf, 10.0f, TEXTALIGN_MC);
+		AlphaRect.Draw(ColorRGBA(0.0f, 0.0f, 0.0f, 0.65f), IGraphics::CORNER_ALL, 3.0f);
+	}
+
+	PickerColorHSV = ColorHSVA(H / 255.0f, S / 255.0f, V / 255.0f, A / 255.0f);
+
+	const auto RotateByteLeft = [pColorPicker](unsigned Num) {
+		if(pColorPicker->m_Alpha)
+		{
+			// ARGB -> RGBA (internal -> displayed)
+			return ((Num & 0xFF000000u) >> 24) | (Num << 8);
+		}
+		return Num;
+	};
+	const auto RotateByteRight = [pColorPicker](unsigned Num) {
+		if(pColorPicker->m_Alpha)
+		{
+			// RGBA -> ARGB (displayed -> internal)
+			return ((Num & 0xFFu) << 24) | (Num >> 8);
+		}
+		return Num;
+	};
+
+	SValueSelectorProperties Props;
+	Props.m_UseScroll = false;
+	Props.m_IsHex = true;
+	Props.m_HexPrefix = pColorPicker->m_Alpha ? 8 : 6;
+	const unsigned Hex = RotateByteLeft(color_cast<ColorRGBA>(PickerColorHSV).Pack(pColorPicker->m_Alpha));
+	const unsigned NewHex = pUI->DoValueSelector(&pColorPicker->m_aValueSelectorIds[4], &HexRect, "Hex:", Hex, 0, pColorPicker->m_Alpha ? 0xFFFFFFFFll : 0xFFFFFFll, Props);
+	if(Hex != NewHex)
+	{
+		PickerColorHSV = color_cast<ColorHSVA>(ColorRGBA(RotateByteRight(NewHex), pColorPicker->m_Alpha));
+		if(!pColorPicker->m_Alpha)
+			PickerColorHSV.a = A / 255.0f;
+	}
+
+	// Logic
+	float PickerX, PickerY;
+	if(pUI->DoPickerLogic(&pColorPicker->m_ColorPickerId, &ColorsArea, &PickerX, &PickerY))
+	{
+		PickerColorHSV.y = PickerX / ColorsArea.w;
+		PickerColorHSV.z = 1.0f - PickerY / ColorsArea.h;
+	}
+
+	if(pUI->DoPickerLogic(&pColorPicker->m_HuePickerId, &HueArea, &PickerX, &PickerY))
+		PickerColorHSV.x = 1.0f - PickerY / HueArea.h;
+
+	// Marker Color Area
+	const float MarkerX = ColorsArea.x + ColorsArea.w * PickerColorHSV.y;
+	const float MarkerY = ColorsArea.y + ColorsArea.h * (1.0f - PickerColorHSV.z);
+
+	const float MarkerOutlineInd = PickerColorHSV.z > 0.5f ? 0.0f : 1.0f;
+	const ColorRGBA MarkerOutline = ColorRGBA(MarkerOutlineInd, MarkerOutlineInd, MarkerOutlineInd, 1.0f);
+
+	pUI->Graphics()->TextureClear();
+	pUI->Graphics()->QuadsBegin();
+	pUI->Graphics()->SetColor(MarkerOutline);
+	pUI->Graphics()->DrawCircle(MarkerX, MarkerY, 4.5f, 32);
+	pUI->Graphics()->SetColor(color_cast<ColorRGBA>(PickerColorHSV));
+	pUI->Graphics()->DrawCircle(MarkerX, MarkerY, 3.5f, 32);
+	pUI->Graphics()->QuadsEnd();
+
+	// Marker Hue Area
+	CUIRect HueMarker;
+	HueArea.Margin(-2.5f, &HueMarker);
+	HueMarker.h = 6.5f;
+	HueMarker.y = (HueArea.y + HueArea.h * (1.0f - PickerColorHSV.x)) - HueMarker.h / 2.0f;
+
+	const ColorRGBA HueMarkerColor = color_cast<ColorRGBA>(ColorHSVA(PickerColorHSV.x, 1.0f, 1.0f, 1.0f));
+	const float HueMarkerOutlineColor = PickerColorHSV.x > 0.75f ? 1.0f : 0.0f;
+	const ColorRGBA HueMarkerOutline = ColorRGBA(HueMarkerOutlineColor, HueMarkerOutlineColor, HueMarkerOutlineColor, 1.0f);
+
+	HueMarker.Draw(HueMarkerOutline, IGraphics::CORNER_ALL, 1.2f);
+	HueMarker.Margin(1.2f, &HueMarker);
+	HueMarker.Draw(HueMarkerColor, IGraphics::CORNER_ALL, 1.2f);
+
+	pColorPicker->m_HSVColor = PickerColorHSV.Pack(pColorPicker->m_Alpha);
+	*pColorPicker->m_pColor = color_cast<ColorHSLA>(PickerColorHSV).Pack(pColorPicker->m_Alpha);
+
+	return CUI::POPUP_KEEP_OPEN;
+}
+
+void CUI::ShowPopupColorPicker(float X, float Y, SColorPickerPopupContext *pContext)
+{
+	pContext->m_pUI = this;
+	DoPopupMenu(pContext, X, Y, 160.0f + 10.0f, 186.0f + 10.0f, pContext, PopupColorPicker);
+}

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -179,7 +179,23 @@ void CUI::OnLanguageChange()
 	OnElementsReset();
 }
 
-void CUI::Update(float MouseX, float MouseY, float MouseWorldX, float MouseWorldY)
+void CUI::OnCursorMove(float X, float Y)
+{
+	m_UpdatedMousePos.x = clamp(m_UpdatedMousePos.x + X, 0.0f, (float)Graphics()->WindowWidth());
+	m_UpdatedMousePos.y = clamp(m_UpdatedMousePos.y + Y, 0.0f, (float)Graphics()->WindowHeight());
+	m_UpdatedMouseDelta += vec2(X, Y);
+}
+
+void CUI::Update()
+{
+	const CUIRect *pScreen = Screen();
+	const float MouseX = (m_UpdatedMousePos.x / (float)Graphics()->WindowWidth()) * pScreen->w;
+	const float MouseY = (m_UpdatedMousePos.y / (float)Graphics()->WindowHeight()) * pScreen->h;
+	Update(MouseX, MouseY, m_UpdatedMouseDelta.x, m_UpdatedMouseDelta.y, MouseX * 3.0f, MouseY * 3.0f);
+	m_UpdatedMouseDelta = vec2(0.0f, 0.0f);
+}
+
+void CUI::Update(float MouseX, float MouseY, float MouseDeltaX, float MouseDeltaY, float MouseWorldX, float MouseWorldY)
 {
 	unsigned MouseButtons = 0;
 	if(Enabled())
@@ -192,8 +208,8 @@ void CUI::Update(float MouseX, float MouseY, float MouseWorldX, float MouseWorld
 			MouseButtons |= 4;
 	}
 
-	m_MouseDeltaX = MouseX - m_MouseX;
-	m_MouseDeltaY = MouseY - m_MouseY;
+	m_MouseDeltaX = MouseDeltaX;
+	m_MouseDeltaY = MouseDeltaY;
 	m_MouseX = MouseX;
 	m_MouseY = MouseY;
 	m_MouseWorldX = MouseWorldX;

--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -295,6 +295,8 @@ private:
 	const void *m_pActiveTooltipItem;
 	bool m_ActiveItemValid = false;
 
+	vec2 m_UpdatedMousePos = vec2(0.0f, 0.0f);
+	vec2 m_UpdatedMouseDelta = vec2(0.0f, 0.0f);
 	float m_MouseX, m_MouseY; // in gui space
 	float m_MouseDeltaX, m_MouseDeltaY; // in gui space
 	float m_MouseWorldX, m_MouseWorldY; // in world space
@@ -379,10 +381,12 @@ public:
 	void OnElementsReset();
 	void OnWindowResize();
 	void OnLanguageChange();
+	void OnCursorMove(float X, float Y);
 
 	void SetEnabled(bool Enabled) { m_Enabled = Enabled; }
 	bool Enabled() const { return m_Enabled; }
-	void Update(float MouseX, float MouseY, float MouseWorldX, float MouseWorldY);
+	void Update();
+	void Update(float MouseX, float MouseY, float MouseDeltaX, float MouseDeltaY, float MouseWorldX, float MouseWorldY);
 	void DebugRender();
 
 	float MouseDeltaX() const { return m_MouseDeltaX; }

--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -332,6 +332,7 @@ private:
 	static CUI::EPopupMenuFunctionResult PopupMessage(void *pContext, CUIRect View, bool Active);
 	static CUI::EPopupMenuFunctionResult PopupConfirm(void *pContext, CUIRect View, bool Active);
 	static CUI::EPopupMenuFunctionResult PopupSelection(void *pContext, CUIRect View, bool Active);
+	static CUI::EPopupMenuFunctionResult PopupColorPicker(void *pContext, CUIRect View, bool Active);
 
 	IClient *m_pClient;
 	IGraphics *m_pGraphics;
@@ -574,6 +575,18 @@ public:
 		void Reset();
 	};
 	void ShowPopupSelection(float X, float Y, SSelectionPopupContext *pContext);
+
+	struct SColorPickerPopupContext : public SPopupMenuId
+	{
+		CUI *m_pUI; // set by CUI when popup is shown
+		bool m_Alpha = false;
+		unsigned int *m_pColor;
+		unsigned int m_HSVColor;
+		const char m_HuePickerId = 0;
+		const char m_ColorPickerId = 0;
+		const char m_aValueSelectorIds[5] = {0};
+	};
+	void ShowPopupColorPicker(float X, float Y, SColorPickerPopupContext *pContext);
 };
 
 #endif

--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -227,6 +227,16 @@ class CButtonContainer
 {
 };
 
+struct SValueSelectorProperties
+{
+	bool m_UseScroll = true;
+	int64_t m_Step = 1;
+	float m_Scale = 1.0f;
+	bool m_IsHex = false;
+	int m_HexPrefix = 6;
+	ColorRGBA m_Color = ColorRGBA(0.0f, 0.0f, 0.0f, 0.4f);
+};
+
 /**
  * Type safe UI ID for popup menus.
  */
@@ -298,6 +308,8 @@ private:
 
 	std::vector<CUIRect> m_vClips;
 	void UpdateClipping();
+
+	bool m_ValueSelectorTextMode = false;
 
 	struct SPopupMenu
 	{
@@ -462,6 +474,12 @@ public:
 	// only used for popup menus
 	int DoButton_PopupMenu(CButtonContainer *pButtonContainer, const char *pText, const CUIRect *pRect, int Align);
 
+	// value selector
+	int64_t DoValueSelector(const void *pID, const CUIRect *pRect, const char *pLabel, int64_t Current, int64_t Min, int64_t Max, const SValueSelectorProperties &Props = {});
+	bool IsValueSelectorTextMode() const { return m_ValueSelectorTextMode; }
+	void SetValueSelectorTextMode(bool TextMode) { m_ValueSelectorTextMode = TextMode; }
+
+	// scrollbars
 	enum
 	{
 		SCROLLBAR_OPTION_INFINITE = 1,

--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -303,6 +303,8 @@ private:
 	unsigned m_MouseButtons;
 	unsigned m_LastMouseButtons;
 	bool m_MouseSlow = false;
+	bool m_MouseLock = false;
+	const void *m_pMouseLockID = nullptr;
 
 	unsigned m_HotkeysPressed = 0;
 
@@ -399,6 +401,18 @@ public:
 	int MouseButton(int Index) const { return (m_MouseButtons >> Index) & 1; }
 	int MouseButtonClicked(int Index) const { return MouseButton(Index) && !((m_LastMouseButtons >> Index) & 1); }
 	int MouseButtonReleased(int Index) const { return ((m_LastMouseButtons >> Index) & 1) && !MouseButton(Index); }
+	bool CheckMouseLock()
+	{
+		if(m_MouseLock && ActiveItem() != m_pMouseLockID)
+			DisableMouseLock();
+		return m_MouseLock;
+	}
+	void EnableMouseLock(const void *pID)
+	{
+		m_MouseLock = true;
+		m_pMouseLockID = pID;
+	}
+	void DisableMouseLock() { m_MouseLock = false; }
 
 	void SetHotItem(const void *pID) { m_pBecomingHotItem = pID; }
 	void SetActiveItem(const void *pID)

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -586,7 +586,7 @@ int CEditor::UiDoValueSelector(void *pID, CUIRect *pRect, const char *pLabel, in
 	{
 		s_pLastTextID = pID;
 		s_TextMode = true;
-		m_LockMouse = false;
+		UI()->DisableMouseLock();
 		s_NumberInput.SetInteger(Current, Base);
 	}
 
@@ -594,7 +594,7 @@ int CEditor::UiDoValueSelector(void *pID, CUIRect *pRect, const char *pLabel, in
 	{
 		if(!UI()->MouseButton(0))
 		{
-			m_LockMouse = false;
+			UI()->DisableMouseLock();
 			UI()->SetActiveItem(nullptr);
 			s_TextMode = false;
 		}
@@ -612,14 +612,14 @@ int CEditor::UiDoValueSelector(void *pID, CUIRect *pRect, const char *pLabel, in
 			((UI()->MouseButton(1) || UI()->MouseButton(0)) && !Inside))
 		{
 			Current = clamp(s_NumberInput.GetInteger(Base), Min, Max);
-			m_LockMouse = false;
+			UI()->DisableMouseLock();
 			UI()->SetActiveItem(nullptr);
 			s_TextMode = false;
 		}
 
 		if(Input()->KeyIsPressed(KEY_ESCAPE))
 		{
-			m_LockMouse = false;
+			UI()->DisableMouseLock();
 			UI()->SetActiveItem(nullptr);
 			s_TextMode = false;
 		}
@@ -656,9 +656,9 @@ int CEditor::UiDoValueSelector(void *pID, CUIRect *pRect, const char *pLabel, in
 		{
 			if(UI()->MouseButton(0))
 			{
-				m_LockMouse = true;
-				s_Value = 0;
 				UI()->SetActiveItem(pID);
+				UI()->EnableMouseLock(pID);
+				s_Value = 0;
 			}
 			if(pToolTip && !s_TextMode)
 				m_pTooltip = pToolTip;
@@ -1331,7 +1331,7 @@ void CEditor::DoSoundSource(CSoundSource *pSource, int Index)
 				{
 					static SPopupMenuId s_PopupSourceId;
 					UI()->DoPopupMenu(&s_PopupSourceId, UI()->MouseX(), UI()->MouseY(), 120, 200, this, PopupSource);
-					m_LockMouse = false;
+					UI()->DisableMouseLock();
 				}
 				s_Operation = OP_NONE;
 				UI()->SetActiveItem(nullptr);
@@ -1341,7 +1341,7 @@ void CEditor::DoSoundSource(CSoundSource *pSource, int Index)
 		{
 			if(!UI()->MouseButton(0))
 			{
-				m_LockMouse = false;
+				UI()->DisableMouseLock();
 				s_Operation = OP_NONE;
 				UI()->SetActiveItem(nullptr);
 			}
@@ -1482,7 +1482,7 @@ void CEditor::DoQuad(CQuad *pQuad, int Index)
 
 					static SPopupMenuId s_PopupQuadId;
 					UI()->DoPopupMenu(&s_PopupQuadId, UI()->MouseX(), UI()->MouseY(), 120, 198, this, PopupQuad);
-					m_LockMouse = false;
+					UI()->DisableMouseLock();
 				}
 				s_Operation = OP_NONE;
 				UI()->SetActiveItem(nullptr);
@@ -1494,7 +1494,7 @@ void CEditor::DoQuad(CQuad *pQuad, int Index)
 			{
 				if(m_vSelectedLayers.size() == 1)
 				{
-					m_LockMouse = false;
+					UI()->DisableMouseLock();
 					m_Map.m_Modified = true;
 					DeleteSelectedQuads();
 				}
@@ -1506,7 +1506,7 @@ void CEditor::DoQuad(CQuad *pQuad, int Index)
 		{
 			if(!UI()->MouseButton(0))
 			{
-				m_LockMouse = false;
+				UI()->DisableMouseLock();
 				s_Operation = OP_NONE;
 				UI()->SetActiveItem(nullptr);
 			}
@@ -1531,7 +1531,7 @@ void CEditor::DoQuad(CQuad *pQuad, int Index)
 			}
 			else if(Input()->ModifierIsPressed())
 			{
-				m_LockMouse = true;
+				UI()->EnableMouseLock(pID);
 				s_Operation = OP_ROTATE;
 				s_RotateAngle = 0;
 
@@ -1711,7 +1711,7 @@ void CEditor::DoQuadPoint(CQuad *pQuad, int QuadIndex, int V)
 						m_SelectedPoints = 1 << V;
 				}
 
-				m_LockMouse = false;
+				UI()->DisableMouseLock();
 				UI()->SetActiveItem(nullptr);
 			}
 		}
@@ -1732,7 +1732,7 @@ void CEditor::DoQuadPoint(CQuad *pQuad, int QuadIndex, int V)
 			if(Input()->ShiftIsPressed())
 			{
 				s_Operation = OP_MOVEUV;
-				m_LockMouse = true;
+				UI()->EnableMouseLock(pID);
 			}
 			else
 				s_Operation = OP_MOVEPOINT;
@@ -2197,7 +2197,7 @@ void CEditor::DoQuadEnvPoint(const CQuad *pQuad, int QIndex, int PIndex)
 
 		if(!UI()->MouseButton(0))
 		{
-			m_LockMouse = false;
+			UI()->DisableMouseLock();
 			s_Operation = OP_NONE;
 			UI()->SetActiveItem(nullptr);
 		}
@@ -2215,7 +2215,7 @@ void CEditor::DoQuadEnvPoint(const CQuad *pQuad, int QIndex, int PIndex)
 		{
 			if(Input()->ModifierIsPressed())
 			{
-				m_LockMouse = true;
+				UI()->EnableMouseLock(pID);
 				s_Operation = OP_ROTATE;
 
 				SelectQuad(QIndex);
@@ -6728,7 +6728,6 @@ void CEditor::Init()
 	m_pSound = Kernel()->RequestInterface<ISound>();
 	m_UI.Init(Kernel());
 	m_UI.SetPopupMenuClosedCallback([this]() {
-		m_LockMouse = false;
 		m_PopupEventWasActivated = false;
 	});
 	m_RenderTools.Init(m_pGraphics, m_pTextRender);
@@ -6822,7 +6821,7 @@ void CEditor::OnUpdate()
 		m_MouseDeltaX += MouseRelX;
 		m_MouseDeltaY += MouseRelY;
 
-		if(!m_LockMouse)
+		if(!UI()->CheckMouseLock())
 		{
 			s_MouseX = clamp<float>(s_MouseX + MouseRelX, 0.0f, Graphics()->WindowWidth());
 			s_MouseY = clamp<float>(s_MouseY + MouseRelY, 0.0f, Graphics()->WindowHeight());

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -6894,7 +6894,7 @@ void CEditor::OnRender()
 	for(size_t i = 0; i < Input()->NumEvents(); i++)
 		UI()->OnInput(Input()->GetEvent(i));
 
-	UI()->Update(m_MouseX, m_MouseY, m_MouseWorldX, m_MouseWorldY);
+	UI()->Update(m_MouseX, m_MouseY, m_MouseDeltaX, m_MouseDeltaY, m_MouseWorldX, m_MouseWorldY);
 
 	Render();
 

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -788,7 +788,6 @@ public:
 		m_Zooming = false;
 		m_WorldZoom = 1.0f;
 
-		m_LockMouse = false;
 		m_ShowMousePointer = true;
 		m_MouseDeltaX = 0;
 		m_MouseDeltaY = 0;
@@ -1029,7 +1028,6 @@ public:
 	float m_ZoomSmoothingTarget;
 	float m_WorldZoom;
 
-	bool m_LockMouse;
 	bool m_ShowMousePointer;
 	bool m_GuiActive;
 


### PR DESCRIPTION
Use the popup system ported from the editor to reimplement the color picker popup.

- Before: 
![screenshot_2023-06-05_21-57-46](https://github.com/ddnet/ddnet/assets/23437060/52d6adfa-7d62-4323-b6df-8d18a26b6cc6)
- After:
![screenshot_2023-06-05_21-57-26](https://github.com/ddnet/ddnet/assets/23437060/773115db-178c-48ab-a750-35b136a4fb30)

Remove special handling necessary for the hard-coded color picker.

Add alpha support to the color picker popup.

Support locking mouse position when dragging value selectors also in menus (color pickers), which improves usability of value selectors. Previously this was only supported in the editor.

Replace large HSLA scrollbar color picker for UI color setting with inline color picker popup:
- Before:
![screenshot_2023-06-05_21-57-57](https://github.com/ddnet/ddnet/assets/23437060/bb6cee4d-5438-40a3-b602-90abccc959ee)
- After:
![screenshot_2023-06-05_21-57-01](https://github.com/ddnet/ddnet/assets/23437060/e0a565a6-2956-403f-9fc0-4ab11a764400)


## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
