### PR TITLE
Fix crash when enabling `dbg_dummies` on running server

### DIFF
--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -1204,9 +1204,12 @@ void CGameContext::OnTick()
 	{
 		for(int i = 0; i < g_Config.m_DbgDummies; i++)
 		{
-			CNetObj_PlayerInput Input = {0};
-			Input.m_Direction = (i & 1) ? -1 : 1;
-			m_apPlayers[MAX_CLIENTS - i - 1]->OnPredictedInput(&Input);
+			if(m_apPlayers[MAX_CLIENTS - i - 1])
+			{
+				CNetObj_PlayerInput Input = {0};
+				Input.m_Direction = (i & 1) ? -1 : 1;
+				m_apPlayers[MAX_CLIENTS - i - 1]->OnPredictedInput(&Input);
+			}
 		}
 	}
 #endif

--- a/src/game/variables.h
+++ b/src/game/variables.h
@@ -215,7 +215,7 @@ MACRO_CONFIG_INT(ClVideoX264Preset, cl_video_preset, 5, 0, 9, CFGFLAG_CLIENT | C
 
 // debug
 #ifdef CONF_DEBUG // this one can crash the server if not used correctly
-MACRO_CONFIG_INT(DbgDummies, dbg_dummies, 0, 0, 15, CFGFLAG_SERVER, "(Debug build only)")
+MACRO_CONFIG_INT(DbgDummies, dbg_dummies, 0, 0, MAX_CLIENTS, CFGFLAG_SERVER, "(Debug build only)")
 #endif
 
 MACRO_CONFIG_INT(DbgTuning, dbg_tuning, 0, 0, 1, CFGFLAG_CLIENT, "Display information about the tuning parameters that affect the own player")


### PR DESCRIPTION
The server normally needs to be reloaded to spawn the debug dummies, so this code was not checking if a debug dummy player exists. Decreasing the number of debug dummies while the server is running also causes them to simply not be snapped instead of completely destroying them.

For debugging any number of dummies can be useful, so the maximum number of debug dummies is increased to the maximum number of clients.

See #6702.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
