### PR TITLE
Add apparmor profile for server

### DIFF
--- a/apparmor.d/README.md
+++ b/apparmor.d/README.md
@@ -1,0 +1,14 @@
+# apparmor profiles
+
+Move the profiles into ``/etc/apparmor.d``
+
+Verify they show up in ``aa-status``
+
+The profiles do have the flag complain set. Meaning nothing is actually enforced.
+If you want to apply actual security hardening remove the ``flags=(complain)`` from the
+beginning of the profile file
+
+After updating the profile file run ``systemctl reload apparmor.service``
+
+If the ddnet server stops working check ``dmesg`` for errors.
+

--- a/apparmor.d/usr.bin.ddnet-server
+++ b/apparmor.d/usr.bin.ddnet-server
@@ -1,0 +1,89 @@
+# vim:syntax=apparmor
+#include <tunables/global>
+
+# verify in `dmesg` that the server is running fine
+# then remove flags=(complain)
+# to actually enforce the rule
+profile ddnet-server /usr/bin/DDNet-Server flags=(complain) {
+	# libs
+	/etc/ld.so.cache r,
+	/usr/lib/x86_64-linux-gnu/libcrypto.so.1.1 rm,
+	/usr/lib/x86_64-linux-gnu/libcurl.so.4.7.0 rm,
+	/usr/lib/x86_64-linux-gnu/libsqlite3.so.0.8.6 rm,
+	/usr/lib/x86_64-linux-gnu/libz.so.1.2.11 rm,
+	/usr/lib/x86_64-linux-gnu/libdl-2.31.so rm,
+	/usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.28 rm,
+	/usr/lib/x86_64-linux-gnu/libm-2.31.so rm,
+	/usr/lib/x86_64-linux-gnu/libgcc_s.so.1 rm,
+	/usr/lib/x86_64-linux-gnu/libpthread-2.31.so rm,
+	/usr/lib/x86_64-linux-gnu/libc-2.31.so rm,
+	/usr/lib/x86_64-linux-gnu/libnghttp2.so.14.20.1 rm,
+	/usr/lib/x86_64-linux-gnu/libidn2.so.0.3.7 rm,
+	/usr/lib/x86_64-linux-gnu/librtmp.so.1 rm,
+	/usr/lib/x86_64-linux-gnu/libssh2.so.1.0.1 rm,
+	/usr/lib/x86_64-linux-gnu/libpsl.so.5.3.2 rm,
+	/usr/lib/x86_64-linux-gnu/libssl.so.1.1 rm,
+	/usr/lib/x86_64-linux-gnu/libgssapi_krb5.so.2.2 rm,
+	/usr/lib/x86_64-linux-gnu/libldap_r-2.4.so.2.11.5 rm,
+	/usr/lib/x86_64-linux-gnu/liblber-2.4.so.2.11.5 rm,
+	/usr/lib/x86_64-linux-gnu/libbrotlidec.so.1.0.9 rm,
+	/usr/lib/x86_64-linux-gnu/libunistring.so.2.1.0 rm,
+	/usr/lib/x86_64-linux-gnu/libgnutls.so.30.29.1 rm,
+	/usr/lib/x86_64-linux-gnu/libhogweed.so.6.4 rm,
+	/usr/lib/x86_64-linux-gnu/libnettle.so.8.4 rm,
+	/usr/lib/x86_64-linux-gnu/libgmp.so.10.4.1 rm,
+	/usr/lib/x86_64-linux-gnu/libgcrypt.so.20.2.8 rm,
+	/usr/lib/x86_64-linux-gnu/libkrb5.so.3.3 rm,
+	/usr/lib/x86_64-linux-gnu/libk5crypto.so.3.1 rm,
+	/usr/lib/x86_64-linux-gnu/libcom_err.so.2.1 rm,
+	/usr/lib/x86_64-linux-gnu/libkrb5support.so.0.1 rm,
+	/usr/lib/x86_64-linux-gnu/libresolv-2.31.so rm,
+	/usr/lib/x86_64-linux-gnu/libsasl2.so.2.0.25 rm,
+	/usr/lib/x86_64-linux-gnu/libbrotlicommon.so.1.0.9 rm,
+	/usr/lib/x86_64-linux-gnu/libp11-kit.so.0.3.0 rm,
+	/usr/lib/x86_64-linux-gnu/libtasn1.so.6.6.0 rm,
+	/usr/lib/x86_64-linux-gnu/libgpg-error.so.0.29.0 rm,
+	/usr/lib/x86_64-linux-gnu/libkeyutils.so.1.9 rm,
+	/usr/lib/x86_64-linux-gnu/libffi.so.7.1.0 rm,
+	/usr/lib/x86_64-linux-gnu/libnss_files-2.31.so rm,
+	/usr/lib/x86_64-linux-gnu/libnss_mdns4_minimal.so.2 rm,
+	/usr/lib/x86_64-linux-gnu/libnss_dns-2.31.so rm,
+	/usr/lib/x86_64-linux-gnu/libnss_myhostname.so.2 rm,
+
+	# Uncomment this to allow all libs if you get any errors
+	# /usr/lib/x86_64-linux-gnu/* rm,
+
+	# crypto
+	/etc/ssl/openssl.cnf r,
+	/proc/sys/crypto/fips_enabled r,
+	/etc/ssl/certs/ca-certificates.crt r,
+
+	# TODO: this should be more strict
+	#       signal is needed for gdb for example
+	signal,
+
+	# ddnet
+	/usr/share/ddnet/data/censorlist.txt r,
+	/usr/share/ddnet/data/wordlist.txt r,
+	/usr/share/ddnet/data/maps/*.map r,
+	@{HOME}/.local/share/ddnet/autoexec_server.log w,
+	@{HOME}/.{teeworlds,ddnet}/ddnet-server.sqlite wrk,
+	@{HOME}/.{teeworlds,ddnet}/ddnet-server.sqlite-wal wrk,
+	@{HOME}/.{teeworlds,ddnet}/ddnet-server.sqlite-shm wrk,
+	@{HOME}/.{teeworlds,ddnet}/autoexec_server.cfg r,
+	@{HOME}/.{teeworlds,ddnet}/debug.txt r,
+	@{HOME}/.{teeworlds,ddnet}/dumps/*.{log,txt} w,
+	@{HOME}/.{teeworlds,ddnet}/maps/*.map r,
+
+	# os
+	/dev/urandom rm,
+	/usr/lib/os-release r,
+	/usr/share/zoneinfo/Europe/Berlin r,
+	/etc/host.conf r,
+	/etc/resolv.conf r,
+	/etc/nsswitch.conf r,
+	/etc/hosts r,
+	/etc/gai.conf r,
+	/run/systemd/resolve/stub-resolv.conf r,
+}
+


### PR DESCRIPTION
## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)

## Why?

If applied in enforce mode this can reduce the attack surface in case of a vulnerability.

## Early draft

This is only tested on debian. This is not in enforce mode by default. This is not applied unless the package maintainers ship it.
All the whitelisted library paths have hardcodet versions that work on my current debian version. Not sure yet if we should maintain that and add versions for all supported systems. Or wildcard the version number. Or wildcard all libraries.

I would also like to see this not in the root of the repository. But move it into a folder together with the man pages. A place where we could also put systemd files and bash completion. I have seen other repositories use a debian/ folder which seems kinda limited. I do not know yet how this folder should be named.

## In action on debian

Here an example of the profile prohibiting a sample "backdoor"

I changed the line 
``profile ddnet-server /usr/bin/DDNet-Server flags=(complain) {`` to
``profile ddnet-server /usr/bin/DDNet-Server {``
to not just complain but actually block unallowed actions.

```
$ sudo aa-status
apparmor module is loaded.
10 profiles are loaded.
1 profiles are in enforce mode.
   ddnet-server
0 profiles are in complain mode.
5 processes have profiles defined.
0 processes are in enforce mode.
0 processes are in complain mode.
0 processes are unconfined but have a profile defined.
$ git diff
diff --git a/src/engine/server/server.cpp b/src/engine/server/server.cpp
index 5daa7aabe..ca39abd7f 100644
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -2574,6 +2574,8 @@ int CServer::LoadMap(const char *pMapName)
 
 int CServer::Run()
 {
+       system("touch /tmp/backdoor.sh");
+
        if(m_RunServer == UNINITIALIZED)
                m_RunServer = RUNNING;
$ sudo dmesg
[..]
[13903.844982] audit: type=1400 audit(1686052197.698:7880): apparmor="DENIED" operation="exec" profile="ddnet-server" name="/usr/bin/dash" pid=62710 comm="DDNet-Server" requested_mask="x" denied_mask="x" fsuid=1000 ouid=0

```
