### PR TITLE
Fix undefined player vote/team change time

### DIFF
--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -109,6 +109,8 @@ void CPlayer::Reset()
 
 	GameServer()->Score()->PlayerData(m_ClientID)->Reset();
 
+	m_Last_KickVote = 0;
+	m_Last_Team = 0;
 	m_ShowOthers = g_Config.m_SvShowOthersDefault;
 	m_ShowAll = g_Config.m_SvShowAllDefault;
 	m_ShowDistance = vec2(1200, 800);


### PR DESCRIPTION
The time of the last kick vote and the time of the last team change are initially in an undefined state, which causes the kick vote and team change to fail due to the delay incorrectly being applied.

Closes #6723.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
