### PR TITLE
Minor refactoring of `CAnimState` and tee rendering functions

### DIFF
--- a/src/game/client/animstate.h
+++ b/src/game/client/animstate.h
@@ -12,15 +12,17 @@ class CAnimState
 	CAnimKeyframe m_FrontFoot;
 	CAnimKeyframe m_Attach;
 
+	void AnimAdd(CAnimState *pState, const CAnimState *pAdded, float Amount);
+
 public:
-	CAnimKeyframe *GetBody() { return &m_Body; }
-	CAnimKeyframe *GetBackFoot() { return &m_BackFoot; }
-	CAnimKeyframe *GetFrontFoot() { return &m_FrontFoot; }
-	CAnimKeyframe *GetAttach() { return &m_Attach; }
+	const CAnimKeyframe *GetBody() const { return &m_Body; }
+	const CAnimKeyframe *GetBackFoot() const { return &m_BackFoot; }
+	const CAnimKeyframe *GetFrontFoot() const { return &m_FrontFoot; }
+	const CAnimKeyframe *GetAttach() const { return &m_Attach; }
 	void Set(CAnimation *pAnim, float Time);
 	void Add(CAnimation *pAnim, float Time, float Amount);
 
-	static CAnimState *GetIdle();
+	const static CAnimState *GetIdle();
 };
 
 #endif

--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -1179,7 +1179,7 @@ void CChat::OnRender()
 				float OffsetTeeY = MESSAGE_TEE_SIZE / 2.0f;
 				float FullHeightMinusTee = RowHeight - MESSAGE_TEE_SIZE;
 
-				CAnimState *pIdleState = CAnimState::GetIdle();
+				const CAnimState *pIdleState = CAnimState::GetIdle();
 				vec2 OffsetToMid;
 				RenderTools()->GetRenderTeeOffsetToRenderedTee(pIdleState, &RenderInfo, OffsetToMid);
 				vec2 TeeRenderPos(x + (RealMsgPaddingX + MESSAGE_TEE_SIZE) / 2.0f, y + OffsetTeeY + FullHeightMinusTee / 2.0f + OffsetToMid.y);

--- a/src/game/client/components/emoticon.cpp
+++ b/src/game/client/components/emoticon.cpp
@@ -135,7 +135,7 @@ void CEmoticon::OnRender()
 		Graphics()->DrawCircle(Screen.w / 2, Screen.h / 2, 100.0f, 64);
 		Graphics()->QuadsEnd();
 
-		CTeeRenderInfo *pTeeInfo = &m_pClient->m_aClients[m_pClient->m_aLocalIDs[g_Config.m_ClDummy]].m_RenderInfo;
+		CTeeRenderInfo TeeInfo = m_pClient->m_aClients[m_pClient->m_aLocalIDs[g_Config.m_ClDummy]].m_RenderInfo;
 
 		for(int i = 0; i < NUM_EMOTES; i++)
 		{
@@ -143,12 +143,11 @@ void CEmoticon::OnRender()
 			if(Angle > pi)
 				Angle -= 2 * pi;
 
-			bool Selected = m_SelectedEyeEmote == i;
+			const bool Selected = m_SelectedEyeEmote == i;
 
 			const vec2 Nudge = direction(Angle) * 70.0f;
-			pTeeInfo->m_Size = Selected ? 64.0f : 48.0f;
-			RenderTools()->RenderTee(CAnimState::GetIdle(), pTeeInfo, i, vec2(-1, 0), vec2(Screen.w / 2 + Nudge.x, Screen.h / 2 + Nudge.y));
-			pTeeInfo->m_Size = 64.0f;
+			TeeInfo.m_Size = Selected ? 64.0f : 48.0f;
+			RenderTools()->RenderTee(CAnimState::GetIdle(), &TeeInfo, i, vec2(-1, 0), vec2(Screen.w / 2 + Nudge.x, Screen.h / 2 + Nudge.y));
 		}
 
 		Graphics()->TextureClear();

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -269,7 +269,7 @@ void CHud::RenderScoreHud()
 						CTeeRenderInfo TeeInfo = m_pClient->m_aClients[ID].m_RenderInfo;
 						TeeInfo.m_Size = ScoreSingleBoxHeight;
 
-						CAnimState *pIdleState = CAnimState::GetIdle();
+						const CAnimState *pIdleState = CAnimState::GetIdle();
 						vec2 OffsetToMid;
 						RenderTools()->GetRenderTeeOffsetToRenderedTee(pIdleState, &TeeInfo, OffsetToMid);
 						vec2 TeeRenderPos(m_Width - ScoreWidthMax - TeeInfo.m_Size / 2 - Split, StartY + (t * 20) + ScoreSingleBoxHeight / 2.0f + OffsetToMid.y);
@@ -432,7 +432,7 @@ void CHud::RenderScoreHud()
 						CTeeRenderInfo TeeInfo = m_pClient->m_aClients[ID].m_RenderInfo;
 						TeeInfo.m_Size = ScoreSingleBoxHeight;
 
-						CAnimState *pIdleState = CAnimState::GetIdle();
+						const CAnimState *pIdleState = CAnimState::GetIdle();
 						vec2 OffsetToMid;
 						RenderTools()->GetRenderTeeOffsetToRenderedTee(pIdleState, &TeeInfo, OffsetToMid);
 						vec2 TeeRenderPos(m_Width - ScoreWidthMax - TeeInfo.m_Size / 2 - Split, StartY + (t * 20) + ScoreSingleBoxHeight / 2.0f + OffsetToMid.y);

--- a/src/game/client/components/killmessages.cpp
+++ b/src/game/client/components/killmessages.cpp
@@ -320,7 +320,7 @@ void CKillMessages::OnRender()
 			{
 				CTeeRenderInfo TeeInfo = m_aKillmsgs[r].m_VictimRenderInfo[j];
 
-				CAnimState *pIdleState = CAnimState::GetIdle();
+				const CAnimState *pIdleState = CAnimState::GetIdle();
 				vec2 OffsetToMid;
 				RenderTools()->GetRenderTeeOffsetToRenderedTee(pIdleState, &TeeInfo, OffsetToMid);
 				vec2 TeeRenderPos(x, y + 46.0f / 2.0f + OffsetToMid.y);
@@ -366,7 +366,7 @@ void CKillMessages::OnRender()
 			{
 				CTeeRenderInfo TeeInfo = m_aKillmsgs[r].m_KillerRenderInfo;
 
-				CAnimState *pIdleState = CAnimState::GetIdle();
+				const CAnimState *pIdleState = CAnimState::GetIdle();
 				vec2 OffsetToMid;
 				RenderTools()->GetRenderTeeOffsetToRenderedTee(pIdleState, &TeeInfo, OffsetToMid);
 				vec2 TeeRenderPos(x, y + 46.0f / 2.0f + OffsetToMid.y);

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1237,7 +1237,7 @@ void CMenus::RenderServerbrowserServerDetail(CUIRect View)
 				}
 				TeeInfo.m_Size = minimum(Skin.w, Skin.h);
 
-				CAnimState *pIdleState = CAnimState::GetIdle();
+				const CAnimState *pIdleState = CAnimState::GetIdle();
 				vec2 OffsetToMid;
 				RenderTools()->GetRenderTeeOffsetToRenderedTee(pIdleState, &TeeInfo, OffsetToMid);
 				vec2 TeeRenderPos(Skin.x + TeeInfo.m_Size / 2, Skin.y + Skin.h / 2 + OffsetToMid.y);
@@ -1497,7 +1497,7 @@ void CMenus::RenderServerbrowserFriends(CUIRect View)
 					}
 					TeeInfo.m_Size = minimum(Skin.w, Skin.h);
 
-					CAnimState *pIdleState = CAnimState::GetIdle();
+					const CAnimState *pIdleState = CAnimState::GetIdle();
 					vec2 OffsetToMid;
 					RenderTools()->GetRenderTeeOffsetToRenderedTee(pIdleState, &TeeInfo, OffsetToMid);
 					vec2 TeeRenderPos(Skin.x + Skin.w / 2.0f, Skin.y + Skin.h * 0.55f + OffsetToMid.y);

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -301,7 +301,7 @@ void CMenus::RenderPlayers(CUIRect MainView)
 		CTeeRenderInfo TeeInfo = CurrentClient.m_RenderInfo;
 		TeeInfo.m_Size = Button.h;
 
-		CAnimState *pIdleState = CAnimState::GetIdle();
+		const CAnimState *pIdleState = CAnimState::GetIdle();
 		vec2 OffsetToMid;
 		RenderTools()->GetRenderTeeOffsetToRenderedTee(pIdleState, &TeeInfo, OffsetToMid);
 		vec2 TeeRenderPos(Button.x + Button.h / 2, Button.y + Button.h / 2 + OffsetToMid.y);
@@ -603,7 +603,7 @@ bool CMenus::RenderServerControlKick(CUIRect MainView, bool FilterSpectators)
 		CTeeRenderInfo TeeInfo = m_pClient->m_aClients[aPlayerIDs[i]].m_RenderInfo;
 		TeeInfo.m_Size = TeeRect.h;
 
-		CAnimState *pIdleState = CAnimState::GetIdle();
+		const CAnimState *pIdleState = CAnimState::GetIdle();
 		vec2 OffsetToMid;
 		RenderTools()->GetRenderTeeOffsetToRenderedTee(pIdleState, &TeeInfo, OffsetToMid);
 		vec2 TeeRenderPos(TeeRect.x + TeeInfo.m_Size / 2, TeeRect.y + TeeInfo.m_Size / 2 + OffsetToMid.y);

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -586,7 +586,7 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 
 	MainView.HSplitTop(50.0f, &Label, &MainView);
 	Label.VSplitLeft(260.0f, &Label, 0);
-	CAnimState *pIdleState = CAnimState::GetIdle();
+	const CAnimState *pIdleState = CAnimState::GetIdle();
 	vec2 OffsetToMid;
 	RenderTools()->GetRenderTeeOffsetToRenderedTee(pIdleState, &OwnSkinInfo, OffsetToMid);
 	vec2 TeeRenderPos(Label.x + 30.0f, Label.y + Label.h / 2.0f + OffsetToMid.y);
@@ -2688,7 +2688,7 @@ void CMenus::RenderSettingsAppearance(CUIRect MainView)
 
 		str_copy(aBuf, Client()->PlayerName());
 
-		CAnimState *pIdleState = CAnimState::GetIdle();
+		const CAnimState *pIdleState = CAnimState::GetIdle();
 		constexpr int PreviewTeeCount = 4;
 		constexpr float RealTeeSize = CChat::MESSAGE_TEE_SIZE * 2;
 		constexpr float RealTeeSizeHalved = CChat::MESSAGE_TEE_SIZE;

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -25,7 +25,7 @@
 #include <base/color.h>
 #include <base/math.h>
 
-void CPlayers::RenderHand(CTeeRenderInfo *pInfo, vec2 CenterPos, vec2 Dir, float AngleOffset, vec2 PostRotOffset, float Alpha)
+void CPlayers::RenderHand(const CTeeRenderInfo *pInfo, vec2 CenterPos, vec2 Dir, float AngleOffset, vec2 PostRotOffset, float Alpha)
 {
 	vec2 HandPos = CenterPos + Dir;
 	float Angle = angle(Dir);
@@ -666,7 +666,7 @@ void CPlayers::RenderPlayer(
 	RenderTools()->RenderTee(&State, &RenderInfo, Player.m_Emote, Direction, Position, Alpha);
 
 	float TeeAnimScale, TeeBaseSize;
-	RenderTools()->GetRenderTeeAnimScaleAndBaseSize(&State, &RenderInfo, TeeAnimScale, TeeBaseSize);
+	RenderTools()->GetRenderTeeAnimScaleAndBaseSize(&RenderInfo, TeeAnimScale, TeeBaseSize);
 	vec2 BodyPos = Position + vec2(State.GetBody()->m_X, State.GetBody()->m_Y) * TeeAnimScale;
 	if(RenderInfo.m_TeeRenderFlags & TEE_EFFECT_FROZEN)
 	{

--- a/src/game/client/components/players.h
+++ b/src/game/client/components/players.h
@@ -13,7 +13,7 @@ class CPlayers : public CComponent
 
 	CTeeRenderInfo m_RenderInfoSpec;
 	CTeeRenderInfo m_aRenderInfo[MAX_CLIENTS];
-	void RenderHand(class CTeeRenderInfo *pInfo, vec2 CenterPos, vec2 Dir, float AngleOffset, vec2 PostRotOffset, float Alpha = 1.0f);
+	void RenderHand(const CTeeRenderInfo *pInfo, vec2 CenterPos, vec2 Dir, float AngleOffset, vec2 PostRotOffset, float Alpha = 1.0f);
 	void RenderPlayer(
 		const CNetObj_Character *pPrevChar,
 		const CNetObj_Character *pPlayerChar,

--- a/src/game/client/components/scoreboard.cpp
+++ b/src/game/client/components/scoreboard.cpp
@@ -432,7 +432,7 @@ void CScoreboard::RenderScoreboard(float x, float y, float w, int Team, const ch
 		// avatar
 		CTeeRenderInfo TeeInfo = m_pClient->m_aClients[pInfo->m_ClientID].m_RenderInfo;
 		TeeInfo.m_Size *= TeeSizeMod;
-		CAnimState *pIdleState = CAnimState::GetIdle();
+		const CAnimState *pIdleState = CAnimState::GetIdle();
 		vec2 OffsetToMid;
 		RenderTools()->GetRenderTeeOffsetToRenderedTee(pIdleState, &TeeInfo, OffsetToMid);
 		vec2 TeeRenderPos(TeeOffset + TeeLength / 2, y + LineHeight / 2.0f + OffsetToMid.y);

--- a/src/game/client/components/spectator.cpp
+++ b/src/game/client/components/spectator.cpp
@@ -390,7 +390,7 @@ void CSpectator::OnRender()
 		CTeeRenderInfo TeeInfo = m_pClient->m_aClients[m_pClient->m_Snap.m_apInfoByDDTeamName[i]->m_ClientID].m_RenderInfo;
 		TeeInfo.m_Size *= TeeSizeMod;
 
-		CAnimState *pIdleState = CAnimState::GetIdle();
+		const CAnimState *pIdleState = CAnimState::GetIdle();
 		vec2 OffsetToMid;
 		RenderTools()->GetRenderTeeOffsetToRenderedTee(pIdleState, &TeeInfo, OffsetToMid);
 		vec2 TeeRenderPos(Width / 2.0f + x + 20.0f, Height / 2.0f + y + BoxMove + LineHeight / 2.0f + OffsetToMid.y);

--- a/src/game/client/components/statboard.cpp
+++ b/src/game/client/components/statboard.cpp
@@ -276,7 +276,7 @@ void CStatboard::RenderGlobalStats()
 		CTeeRenderInfo Teeinfo = m_pClient->m_aClients[pInfo->m_ClientID].m_RenderInfo;
 		Teeinfo.m_Size *= TeeSizemod;
 
-		CAnimState *pIdleState = CAnimState::GetIdle();
+		const CAnimState *pIdleState = CAnimState::GetIdle();
 		vec2 OffsetToMid;
 		RenderTools()->GetRenderTeeOffsetToRenderedTee(pIdleState, &Teeinfo, OffsetToMid);
 		vec2 TeeRenderPos(x + Teeinfo.m_Size / 2, y + LineHeight / 2.0f + OffsetToMid.y);

--- a/src/game/client/render.cpp
+++ b/src/game/client/render.cpp
@@ -176,7 +176,7 @@ int CRenderTools::QuadContainerAddSprite(int QuadContainerIndex, float X, float 
 	return Graphics()->QuadContainerAddQuads(QuadContainerIndex, &QuadItem, 1);
 }
 
-void CRenderTools::GetRenderTeeAnimScaleAndBaseSize(CAnimState *pAnim, CTeeRenderInfo *pInfo, float &AnimScale, float &BaseSize)
+void CRenderTools::GetRenderTeeAnimScaleAndBaseSize(const CTeeRenderInfo *pInfo, float &AnimScale, float &BaseSize)
 {
 	AnimScale = pInfo->m_Size * 1.0f / 64.0f;
 	BaseSize = pInfo->m_Size;
@@ -194,10 +194,10 @@ void CRenderTools::GetRenderTeeFeetScale(float BaseSize, float &FeetScaleWidth, 
 	FeetScaleHeight = (BaseSize / 2) / 32.0f;
 }
 
-void CRenderTools::GetRenderTeeBodySize(CAnimState *pAnim, CTeeRenderInfo *pInfo, vec2 &BodyOffset, float &Width, float &Height)
+void CRenderTools::GetRenderTeeBodySize(const CAnimState *pAnim, const CTeeRenderInfo *pInfo, vec2 &BodyOffset, float &Width, float &Height)
 {
 	float AnimScale, BaseSize;
-	GetRenderTeeAnimScaleAndBaseSize(pAnim, pInfo, AnimScale, BaseSize);
+	GetRenderTeeAnimScaleAndBaseSize(pInfo, AnimScale, BaseSize);
 
 	float BodyScale;
 	GetRenderTeeBodyScale(BaseSize, BodyScale);
@@ -208,10 +208,10 @@ void CRenderTools::GetRenderTeeBodySize(CAnimState *pAnim, CTeeRenderInfo *pInfo
 	BodyOffset.y = pInfo->m_SkinMetrics.m_Body.OffsetYNormalized() * 64.0f * BodyScale;
 }
 
-void CRenderTools::GetRenderTeeFeetSize(CAnimState *pAnim, CTeeRenderInfo *pInfo, vec2 &FeetOffset, float &Width, float &Height)
+void CRenderTools::GetRenderTeeFeetSize(const CAnimState *pAnim, const CTeeRenderInfo *pInfo, vec2 &FeetOffset, float &Width, float &Height)
 {
 	float AnimScale, BaseSize;
-	GetRenderTeeAnimScaleAndBaseSize(pAnim, pInfo, AnimScale, BaseSize);
+	GetRenderTeeAnimScaleAndBaseSize(pInfo, AnimScale, BaseSize);
 
 	float FeetScaleWidth, FeetScaleHeight;
 	GetRenderTeeFeetScale(BaseSize, FeetScaleWidth, FeetScaleHeight);
@@ -222,17 +222,17 @@ void CRenderTools::GetRenderTeeFeetSize(CAnimState *pAnim, CTeeRenderInfo *pInfo
 	FeetOffset.y = pInfo->m_SkinMetrics.m_Feet.OffsetYNormalized() * 32.0f * FeetScaleHeight;
 }
 
-void CRenderTools::GetRenderTeeOffsetToRenderedTee(CAnimState *pAnim, CTeeRenderInfo *pInfo, vec2 &TeeOffsetToMid)
+void CRenderTools::GetRenderTeeOffsetToRenderedTee(const CAnimState *pAnim, const CTeeRenderInfo *pInfo, vec2 &TeeOffsetToMid)
 {
 	float AnimScale, BaseSize;
-	GetRenderTeeAnimScaleAndBaseSize(pAnim, pInfo, AnimScale, BaseSize);
+	GetRenderTeeAnimScaleAndBaseSize(pInfo, AnimScale, BaseSize);
 	vec2 BodyPos = vec2(pAnim->GetBody()->m_X, pAnim->GetBody()->m_Y) * AnimScale;
 
 	float AssumedScale = BaseSize / 64.0f;
 
 	// just use the lowest feet
 	vec2 FeetPos;
-	CAnimKeyframe *pFoot = pAnim->GetFrontFoot();
+	const CAnimKeyframe *pFoot = pAnim->GetFrontFoot();
 	FeetPos = vec2(pFoot->m_X * AnimScale, pFoot->m_Y * AnimScale);
 	pFoot = pAnim->GetBackFoot();
 	FeetPos = vec2(FeetPos.x, maximum(FeetPos.y, pFoot->m_Y * AnimScale));
@@ -270,7 +270,7 @@ void CRenderTools::GetRenderTeeOffsetToRenderedTee(CAnimState *pAnim, CTeeRender
 	TeeOffsetToMid.y = -MidOfRendered;
 }
 
-void CRenderTools::RenderTee(CAnimState *pAnim, CTeeRenderInfo *pInfo, int Emote, vec2 Dir, vec2 Pos, float Alpha)
+void CRenderTools::RenderTee(const CAnimState *pAnim, const CTeeRenderInfo *pInfo, int Emote, vec2 Dir, vec2 Pos, float Alpha)
 {
 	vec2 Direction = Dir;
 	vec2 Position = Pos;
@@ -286,7 +286,7 @@ void CRenderTools::RenderTee(CAnimState *pAnim, CTeeRenderInfo *pInfo, int Emote
 		for(int f = 0; f < 2; f++)
 		{
 			float AnimScale, BaseSize;
-			GetRenderTeeAnimScaleAndBaseSize(pAnim, pInfo, AnimScale, BaseSize);
+			GetRenderTeeAnimScaleAndBaseSize(pInfo, AnimScale, BaseSize);
 			if(f == 1)
 			{
 				Graphics()->QuadsSetRotation(pAnim->GetBody()->m_Angle * pi * 2);
@@ -341,7 +341,7 @@ void CRenderTools::RenderTee(CAnimState *pAnim, CTeeRenderInfo *pInfo, int Emote
 			}
 
 			// draw feet
-			CAnimKeyframe *pFoot = f ? pAnim->GetFrontFoot() : pAnim->GetBackFoot();
+			const CAnimKeyframe *pFoot = f ? pAnim->GetFrontFoot() : pAnim->GetBackFoot();
 
 			float w = BaseSize;
 			float h = BaseSize / 2;

--- a/src/game/client/render.h
+++ b/src/game/client/render.h
@@ -9,6 +9,7 @@
 #include <game/client/skin.h>
 #include <game/client/ui_rect.h>
 
+class CAnimState;
 class CSpeedupTile;
 class CSwitchTile;
 class CTeleTile;
@@ -106,14 +107,14 @@ public:
 	int QuadContainerAddSprite(int QuadContainerIndex, float X, float Y, float Width, float Height);
 
 	// larger rendering methods
-	void GetRenderTeeBodySize(class CAnimState *pAnim, CTeeRenderInfo *pInfo, vec2 &BodyOffset, float &Width, float &Height);
-	void GetRenderTeeFeetSize(class CAnimState *pAnim, CTeeRenderInfo *pInfo, vec2 &FeetOffset, float &Width, float &Height);
-	void GetRenderTeeAnimScaleAndBaseSize(class CAnimState *pAnim, CTeeRenderInfo *pInfo, float &AnimScale, float &BaseSize);
+	void GetRenderTeeBodySize(const CAnimState *pAnim, const CTeeRenderInfo *pInfo, vec2 &BodyOffset, float &Width, float &Height);
+	void GetRenderTeeFeetSize(const CAnimState *pAnim, const CTeeRenderInfo *pInfo, vec2 &FeetOffset, float &Width, float &Height);
+	void GetRenderTeeAnimScaleAndBaseSize(const CTeeRenderInfo *pInfo, float &AnimScale, float &BaseSize);
 
 	// returns the offset to use, to render the tee with @see RenderTee exactly in the mid
-	void GetRenderTeeOffsetToRenderedTee(class CAnimState *pAnim, CTeeRenderInfo *pInfo, vec2 &TeeOffsetToMid);
+	void GetRenderTeeOffsetToRenderedTee(const CAnimState *pAnim, const CTeeRenderInfo *pInfo, vec2 &TeeOffsetToMid);
 	// object render methods
-	void RenderTee(class CAnimState *pAnim, CTeeRenderInfo *pInfo, int Emote, vec2 Dir, vec2 Pos, float Alpha = 1.0f);
+	void RenderTee(const CAnimState *pAnim, const CTeeRenderInfo *pInfo, int Emote, vec2 Dir, vec2 Pos, float Alpha = 1.0f);
 
 	// map render methods (render_map.cpp)
 	static void RenderEvalEnvelope(CEnvPoint *pPoints, int NumPoints, int Channels, std::chrono::nanoseconds TimeNanos, ColorRGBA &Result);

--- a/src/game/client/skin.h
+++ b/src/game/client/skin.h
@@ -47,7 +47,7 @@ public:
 	struct SSkinMetricVariableInt
 	{
 		int m_Value;
-		operator int() { return m_Value; }
+		operator int() const { return m_Value; }
 		SSkinMetricVariableInt &operator=(int NewVal)
 		{
 			if(IsSizeType)
@@ -82,22 +82,22 @@ public:
 		SSkinMetricVariableInt<true> m_MaxWidth;
 		SSkinMetricVariableInt<true> m_MaxHeight;
 
-		float WidthNormalized()
+		float WidthNormalized() const
 		{
 			return (float)m_Width / (float)m_MaxWidth;
 		}
 
-		float HeightNormalized()
+		float HeightNormalized() const
 		{
 			return (float)m_Height / (float)m_MaxHeight;
 		}
 
-		float OffsetXNormalized()
+		float OffsetXNormalized() const
 		{
 			return (float)m_OffsetX / (float)m_MaxWidth;
 		}
 
-		float OffsetYNormalized()
+		float OffsetYNormalized() const
 		{
 			return (float)m_OffsetY / (float)m_MaxHeight;
 		}


### PR DESCRIPTION
- Use `nullptr` instead of `0`.
- Remove dead code.
- Mark functions and pointers as `const` when possible.
- Remove unused argument of `CRenderTools::GetRenderTeeAnimScaleAndBaseSize` function.
- Copy tee render info when rendering emote wheel instead of modifying global render info.
- Fix names of static variables.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
