### PR TITLE
Split emoticon sending into nearby and global players

### DIFF
--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -222,7 +222,8 @@ MACRO_CONFIG_INT(SvInviteFrequency, sv_invite_frequency, 1, 0, 9999, CFGFLAG_SER
 MACRO_CONFIG_INT(SvTeleOthersAuthLevel, sv_tele_others_auth_level, 1, 1, 3, CFGFLAG_SERVER, "The auth level you need to tele others")
 
 MACRO_CONFIG_INT(SvEmotionalTees, sv_emotional_tees, 1, -1, 1, CFGFLAG_SERVER, "Whether eye change of tees is enabled with emoticons = 1, not = 0, -1 not at all")
-MACRO_CONFIG_INT(SvEmoticonDelay, sv_emoticon_delay, 3, 0, 9999, CFGFLAG_SERVER, "The time in seconds between over-head emoticons")
+MACRO_CONFIG_INT(SvEmoticonMsDelay, sv_emoticon_ms_delay, 3000, 20, 999999999, CFGFLAG_SERVER, "The time in ms a player has to wait before allowing the next over-head emoticons")
+MACRO_CONFIG_INT(SvGlobalEmoticonMsDelay, sv_global_emoticon_ms_delay, 3000, 20, 999999999, CFGFLAG_SERVER, "The time in ms a player has to wait before allowing the next over-head emoticons that is send to all clients (this config must be higher or equal to sv_emoticon_ms_delay to have an effect)")
 MACRO_CONFIG_INT(SvEyeEmoteChangeDelay, sv_eye_emote_change_delay, 1, 0, 9999, CFGFLAG_SERVER, "The time in seconds between eye emoticons change")
 
 MACRO_CONFIG_INT(SvChatDelay, sv_chat_delay, 1, 0, 9999, CFGFLAG_SERVER, "The time in seconds between chat messages")

--- a/src/game/server/entities/character.h
+++ b/src/game/server/entities/character.h
@@ -41,6 +41,7 @@ public:
 	void SwapClients(int Client1, int Client2) override;
 
 	bool CanSnapCharacter(int SnappingClient);
+	bool IsSnappingCharacterInView(int SnappingClientID);
 
 	bool IsGrounded();
 

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -250,7 +250,7 @@ public:
 	void SendChatTeam(int Team, const char *pText);
 	void SendChat(int ClientID, int Team, const char *pText, int SpamProtectionClientID = -1, int Flags = CHAT_SIX | CHAT_SIXUP);
 	void SendStartWarning(int ClientID, const char *pMessage);
-	void SendEmoticon(int ClientID, int Emoticon);
+	void SendEmoticon(int ClientID, int Emoticon, int TargetClientID);
 	void SendWeaponPickup(int ClientID, int Weapon);
 	void SendMotd(int ClientID);
 	void SendSettings(int ClientID);

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -278,7 +278,7 @@ void CPlayer::Tick()
 	{
 		if(1200 - ((Server()->Tick() - m_pCharacter->GetLastAction()) % (1200)) < 5)
 		{
-			GameServer()->SendEmoticon(GetCID(), EMOTICON_GHOST);
+			GameServer()->SendEmoticon(GetCID(), EMOTICON_GHOST, -1);
 		}
 	}
 }

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -93,6 +93,7 @@ public:
 	int m_LastSetSpectatorMode;
 	int m_LastChangeInfo;
 	int m_LastEmote;
+	int m_LastEmoteGlobal;
 	int m_LastKill;
 	int m_aLastCommands[4];
 	int m_LastCommandPos;


### PR DESCRIPTION
The reason for this rather overcomplicated solution is, that emotes are send to other players all the time. But just sending it to nearby players only would not work as the emoticon does not track animation time.
So sending the emoticon later would restart the emote client side.

A different fix, which we obviously don't want, is breaking compability with all older clients and move the emoticon into the snapshot.

I also changed the config vars to use milliseconds instead of seconds. I did not use ticks, since ticks are not a clear enough time unit.

**It is not clear if this will fix all network lags, as there might be other packets that also are sent to all players globally**

global means:
send them less often than nearby, but still send them. this makes players that are close to you but not in your view range still see your emote if they run into your view range with reasonably enough speed. We could also think about disabling global emoticons completely, if this fix is not good enough. the main idea was really that it doesn't look weird: e.g. if you start to spec a player and he has no emoticon

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
