### PR TITLE
Don't remove the `.map` suffix in editor file dialog

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -4850,10 +4850,7 @@ void CEditor::RenderFileDialog()
 		str_copy(m_aFilesSelectedName, m_vpFilteredFileList[m_FilesSelectedIndex]->m_aName);
 		const bool WasChanged = m_FileDialogFileNameInput.WasChanged();
 		if(!m_vpFilteredFileList[m_FilesSelectedIndex]->m_IsDir)
-		{
 			m_FileDialogFileNameInput.Set(m_vpFilteredFileList[m_FilesSelectedIndex]->m_aFilename);
-			m_FileDialogFileNameInput.SetRange("", m_FileDialogFileNameInput.GetLength() - str_length(".map"), m_FileDialogFileNameInput.GetLength());
-		}
 		else
 			m_FileDialogFileNameInput.Clear();
 		if(!WasChanged) // ensure that changed flag is not set if it wasn't previously set, as this would reset the selection after DoEditBox is called


### PR DESCRIPTION
This otherwise breaks file loading because the file extension is expected in this input buffer even when the input is not rendered.

Regression from #6736.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
