### PR TITLE
Run MysqlUninit later (fixes #6571)

### DIFF
--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -833,12 +833,12 @@ void thread_detach(void *thread)
 #endif
 }
 
-void *thread_init_and_detach(void (*threadfunc)(void *), void *u, const char *name)
+bool thread_init_and_detach(void (*threadfunc)(void *), void *u, const char *name)
 {
 	void *thread = thread_init(threadfunc, u, name);
 	if(thread)
 		thread_detach(thread);
-	return thread;
+	return thread != nullptr;
 }
 
 #if defined(CONF_FAMILY_UNIX)

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -603,9 +603,9 @@ void thread_detach(void *thread);
  * @param user Pointer to pass to the thread.
  * @param name Name describing the use of the thread
  *
- * @return The thread if no error occurred, 0 on error.
+ * @return true on success, false on failure.
  */
-void *thread_init_and_detach(void (*threadfunc)(void *), void *user, const char *name);
+bool thread_init_and_detach(void (*threadfunc)(void *), void *user, const char *name);
 
 // Enable thread safety attributes only with clang.
 // The attributes can be safely erased when compiling with other compilers.

--- a/src/engine/server/databases/connection_pool.h
+++ b/src/engine/server/databases/connection_pool.h
@@ -124,6 +124,8 @@ private:
 	};
 
 	std::shared_ptr<CSharedData> m_pShared;
+	void *m_pWorkerThread = nullptr;
+	void *m_pBackupThread = nullptr;
 };
 
 #endif // ENGINE_SERVER_DATABASES_CONNECTION_POOL_H

--- a/src/engine/server/main.cpp
+++ b/src/engine/server/main.cpp
@@ -190,12 +190,12 @@ int main(int argc, const char **argv)
 	dbg_msg("server", "starting...");
 	int Ret = pServer->Run();
 
-	MysqlUninit();
-	secure_random_uninit();
-
 	pServerLogger->OnServerDeletion();
 	// free
 	delete pKernel;
+
+	MysqlUninit();
+	secure_random_uninit();
 
 	return Ret;
 }


### PR DESCRIPTION
Otherwise the mysql thread can still be running in the background while we uninitialize it.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
