### PR TITLE
When all DDNet filter entries selected, deselect with right click

### DIFF
--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -808,11 +808,19 @@ void CMenus::RenderServerbrowserFilters(CUIRect View)
 						// left/right click to toggle filter
 						if(pFilterExcludeTypes[0] == '\0')
 						{
-							// when all are active, only activate one
-							for(int j = 0; j < MaxTypes; ++j)
+							if(Click == 1)
 							{
-								if(j != TypeIndex)
-									ServerBrowser()->DDNetFilterAdd(pFilterExcludeTypes, FilterExcludeTypesSize, ServerBrowser()->GetType(Network, j));
+								// Left click: when all are active, only activate one
+								for(int j = 0; j < MaxTypes; ++j)
+								{
+									if(j != TypeIndex)
+										ServerBrowser()->DDNetFilterAdd(pFilterExcludeTypes, FilterExcludeTypesSize, ServerBrowser()->GetType(Network, j));
+								}
+							}
+							else if(Click == 2)
+							{
+								// Right click: when all are active, only deactivate one
+								ServerBrowser()->DDNetFilterAdd(pFilterExcludeTypes, FilterExcludeTypesSize, ServerBrowser()->GetType(Network, TypeIndex));
 							}
 						}
 						else
@@ -905,11 +913,19 @@ void CMenus::RenderServerbrowserFilters(CUIRect View)
 						// left/right click to toggle filter
 						if(pFilterExcludeCountries[0] == '\0')
 						{
-							// when all are active, only activate one
-							for(int j = 0; j < MaxFlags; ++j)
+							if(Click == 1)
 							{
-								if(j != CountryIndex)
-									ServerBrowser()->DDNetFilterAdd(pFilterExcludeCountries, FilterExcludeCountriesSize, ServerBrowser()->GetCountryName(Network, j));
+								// Left click: when all are active, only activate one
+								for(int j = 0; j < MaxFlags; ++j)
+								{
+									if(j != CountryIndex)
+										ServerBrowser()->DDNetFilterAdd(pFilterExcludeCountries, FilterExcludeCountriesSize, ServerBrowser()->GetCountryName(Network, j));
+								}
+							}
+							else if(Click == 2)
+							{
+								// Right click: when all are active, only deactivate one
+								ServerBrowser()->DDNetFilterAdd(pFilterExcludeCountries, FilterExcludeCountriesSize, ServerBrowser()->GetCountryName(Network, CountryIndex));
 							}
 						}
 						else


### PR DESCRIPTION
Allow deselecting just one filter entry by right clicking the entry (country or game type) when all entries are currently selected (i.e. none are excluded). Previously the first right click always deselected all filters except the clicked one (same as the left click).

Closes #6746.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
