### PR TITLE
Remove individual RGBA sliders from editor color picker, add shift+rightclick/leftclick to copy/paste color in editor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1864,6 +1864,7 @@ add_custom_command(OUTPUT "src/game/generated/wordlist.h"
 set_src(BASE GLOB_RECURSE src/base
   bezier.cpp
   bezier.h
+  color.cpp
   color.h
   detect.h
   dynamic.h

--- a/src/base/color.cpp
+++ b/src/base/color.cpp
@@ -1,0 +1,48 @@
+#include "color.h"
+#include "system.h"
+
+template<typename T>
+std::optional<T> color_parse(const char *pStr)
+{
+	if(!str_isallnum_hex(pStr))
+		return {};
+
+	const unsigned Num = str_toulong_base(pStr, 16);
+
+	T Color;
+	switch(str_length(pStr))
+	{
+	case 3:
+		Color.x = (((Num >> 8) & 0x0F) + ((Num >> 4) & 0xF0)) / 255.0f;
+		Color.y = (((Num >> 4) & 0x0F) + ((Num >> 0) & 0xF0)) / 255.0f;
+		Color.z = (((Num >> 0) & 0x0F) + ((Num << 4) & 0xF0)) / 255.0f;
+		Color.a = 1.0f;
+		return Color;
+
+	case 4:
+		Color.x = (((Num >> 12) & 0x0F) + ((Num >> 8) & 0xF0)) / 255.0f;
+		Color.y = (((Num >> 8) & 0x0F) + ((Num >> 4) & 0xF0)) / 255.0f;
+		Color.z = (((Num >> 4) & 0x0F) + ((Num >> 0) & 0xF0)) / 255.0f;
+		Color.a = (((Num >> 0) & 0x0F) + ((Num << 4) & 0xF0)) / 255.0f;
+		return Color;
+
+	case 6:
+		Color.x = ((Num >> 16) & 0xFF) / 255.0f;
+		Color.y = ((Num >> 8) & 0xFF) / 255.0f;
+		Color.z = ((Num >> 0) & 0xFF) / 255.0f;
+		Color.a = 1.0f;
+		return Color;
+
+	case 8:
+		Color.x = ((Num >> 24) & 0xFF) / 255.0f;
+		Color.y = ((Num >> 16) & 0xFF) / 255.0f;
+		Color.z = ((Num >> 8) & 0xFF) / 255.0f;
+		Color.a = ((Num >> 0) & 0xFF) / 255.0f;
+		return Color;
+
+	default:
+		return {};
+	}
+}
+
+template std::optional<ColorRGBA> color_parse<ColorRGBA>(const char *);

--- a/src/base/color.h
+++ b/src/base/color.h
@@ -5,6 +5,8 @@
 #include <base/math.h>
 #include <base/vmath.h>
 
+#include <optional>
+
 /*
 	Title: Color handling
 */
@@ -289,5 +291,8 @@ T color_invert(const T &col)
 {
 	return T(1.0f - col.x, 1.0f - col.y, 1.0f - col.z, 1.0f - col.a);
 }
+
+template<typename T>
+std::optional<T> color_parse(const char *pStr);
 
 #endif

--- a/src/base/color.h
+++ b/src/base/color.h
@@ -114,11 +114,39 @@ public:
 		return (Alpha ? ((unsigned)round_to_int(a * 255.0f) << 24) : 0) + ((unsigned)round_to_int(x * 255.0f) << 16) + ((unsigned)round_to_int(y * 255.0f) << 8) + (unsigned)round_to_int(z * 255.0f);
 	}
 
+	unsigned PackAlphaLast(bool Alpha = true) const
+	{
+		if(Alpha)
+			return ((unsigned)round_to_int(x * 255.0f) << 24) + ((unsigned)round_to_int(y * 255.0f) << 16) + ((unsigned)round_to_int(z * 255.0f) << 8) + (unsigned)round_to_int(a * 255.0f);
+		return ((unsigned)round_to_int(x * 255.0f) << 16) + ((unsigned)round_to_int(y * 255.0f) << 8) + (unsigned)round_to_int(z * 255.0f);
+	}
+
 	DerivedT WithAlpha(float alpha) const
 	{
 		DerivedT col(static_cast<const DerivedT &>(*this));
 		col.a = alpha;
 		return col;
+	}
+
+	template<typename UnpackT>
+	static UnpackT UnpackAlphaLast(unsigned Color, bool Alpha = true)
+	{
+		UnpackT Result;
+		if(Alpha)
+		{
+			Result.x = ((Color >> 24) & 0xFF) / 255.0f;
+			Result.y = ((Color >> 16) & 0xFF) / 255.0f;
+			Result.z = ((Color >> 8) & 0xFF) / 255.0f;
+			Result.a = ((Color >> 0) & 0xFF) / 255.0f;
+		}
+		else
+		{
+			Result.x = ((Color >> 16) & 0xFF) / 255.0f;
+			Result.y = ((Color >> 8) & 0xFF) / 255.0f;
+			Result.z = ((Color >> 0) & 0xFF) / 255.0f;
+			Result.a = 1.0f;
+		}
+		return Result;
 	}
 };
 

--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -3430,6 +3430,17 @@ int str_isallnum(const char *str)
 	return 1;
 }
 
+int str_isallnum_hex(const char *str)
+{
+	while(*str)
+	{
+		if(!(*str >= '0' && *str <= '9') && !(*str >= 'a' && *str <= 'f') && !(*str >= 'A' && *str <= 'F'))
+			return 0;
+		str++;
+	}
+	return 1;
+}
+
 int str_toint(const char *str)
 {
 	return str_toint_base(str, 10);

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -2186,7 +2186,11 @@ float str_tofloat(const char *str);
 int str_isspace(char c);
 
 char str_uppercase(char c);
+
 int str_isallnum(const char *str);
+
+int str_isallnum_hex(const char *str);
+
 unsigned str_quickhash(const char *str);
 
 enum

--- a/src/engine/shared/console.cpp
+++ b/src/engine/shared/console.cpp
@@ -55,44 +55,7 @@ ColorHSLA CConsole::CResult::GetColor(unsigned Index, bool Light) const
 	}
 	else if(*pStr == '$') // Hex RGB/RGBA
 	{
-		ColorRGBA Rgba = ColorRGBA(0, 0, 0, 1);
-		const int Len = str_length(pStr);
-		if(Len == 4)
-		{
-			const unsigned Num = str_toulong_base(pStr + 1, 16);
-			Rgba.r = (((Num >> 8) & 0x0F) + ((Num >> 4) & 0xF0)) / 255.0f;
-			Rgba.g = (((Num >> 4) & 0x0F) + ((Num >> 0) & 0xF0)) / 255.0f;
-			Rgba.b = (((Num >> 0) & 0x0F) + ((Num << 4) & 0xF0)) / 255.0f;
-		}
-		else if(Len == 5)
-		{
-			const unsigned Num = str_toulong_base(pStr + 1, 16);
-			Rgba.r = (((Num >> 12) & 0x0F) + ((Num >> 8) & 0xF0)) / 255.0f;
-			Rgba.g = (((Num >> 8) & 0x0F) + ((Num >> 4) & 0xF0)) / 255.0f;
-			Rgba.b = (((Num >> 4) & 0x0F) + ((Num >> 0) & 0xF0)) / 255.0f;
-			Rgba.a = (((Num >> 0) & 0x0F) + ((Num << 4) & 0xF0)) / 255.0f;
-		}
-		else if(Len == 7)
-		{
-			const unsigned Num = str_toulong_base(pStr + 1, 16);
-			Rgba.r = ((Num >> 16) & 0xFF) / 255.0f;
-			Rgba.g = ((Num >> 8) & 0xFF) / 255.0f;
-			Rgba.b = ((Num >> 0) & 0xFF) / 255.0f;
-		}
-		else if(Len == 9)
-		{
-			const unsigned Num = str_toulong_base(pStr + 1, 16);
-			Rgba.r = ((Num >> 24) & 0xFF) / 255.0f;
-			Rgba.g = ((Num >> 16) & 0xFF) / 255.0f;
-			Rgba.b = ((Num >> 8) & 0xFF) / 255.0f;
-			Rgba.a = ((Num >> 0) & 0xFF) / 255.0f;
-		}
-		else
-		{
-			return ColorHSLA(0, 0, 0);
-		}
-
-		return color_cast<ColorHSLA>(Rgba);
+		return color_cast<ColorHSLA>(color_parse<ColorRGBA>(pStr + 1).value_or(ColorRGBA(0.0f, 0.0f, 0.0f, 1.0f)));
 	}
 	else if(!str_comp_nocase(pStr, "red"))
 		return ColorHSLA(0.0f / 6.0f, 1, .5f);

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -1711,32 +1711,15 @@ CUI::EPopupMenuFunctionResult CUI::PopupColorPicker(void *pContext, CUIRect View
 
 	PickerColorHSV = ColorHSVA(H / 255.0f, S / 255.0f, V / 255.0f, A / 255.0f);
 
-	const auto RotateByteLeft = [pColorPicker](unsigned Num) {
-		if(pColorPicker->m_Alpha)
-		{
-			// ARGB -> RGBA (internal -> displayed)
-			return ((Num & 0xFF000000u) >> 24) | (Num << 8);
-		}
-		return Num;
-	};
-	const auto RotateByteRight = [pColorPicker](unsigned Num) {
-		if(pColorPicker->m_Alpha)
-		{
-			// RGBA -> ARGB (displayed -> internal)
-			return ((Num & 0xFFu) << 24) | (Num >> 8);
-		}
-		return Num;
-	};
-
 	SValueSelectorProperties Props;
 	Props.m_UseScroll = false;
 	Props.m_IsHex = true;
 	Props.m_HexPrefix = pColorPicker->m_Alpha ? 8 : 6;
-	const unsigned Hex = RotateByteLeft(color_cast<ColorRGBA>(PickerColorHSV).Pack(pColorPicker->m_Alpha));
+	const unsigned Hex = color_cast<ColorRGBA>(PickerColorHSV).PackAlphaLast(pColorPicker->m_Alpha);
 	const unsigned NewHex = pUI->DoValueSelector(&pColorPicker->m_aValueSelectorIds[4], &HexRect, "Hex:", Hex, 0, pColorPicker->m_Alpha ? 0xFFFFFFFFll : 0xFFFFFFll, Props);
 	if(Hex != NewHex)
 	{
-		PickerColorHSV = color_cast<ColorHSVA>(ColorRGBA(RotateByteRight(NewHex), pColorPicker->m_Alpha));
+		PickerColorHSV = color_cast<ColorHSVA>(ColorRGBA::UnpackAlphaLast<ColorRGBA>(NewHex, pColorPicker->m_Alpha));
 		if(!pColorPicker->m_Alpha)
 			PickerColorHSV.a = A / 255.0f;
 	}


### PR DESCRIPTION
Remove the individual RGBA sliders for editor color pickers and only show one button that opens the color picker popup instead.

Decrease size of layer and point popups that previously had color properties which need less space now.

Support shift-rightclicking color picker buttons to copy the color to the clipboard in RRGGBBAA hex format.

Support shift-leftclicking color picker buttons to paste a color from the clipboard in RGB, RGBA, RRGGBB or RRGGBBAA format with optional leading `#` or `$`.

Screenshots:
- Before:
![screenshot_2023-06-20_20-39-43](https://github.com/ddnet/ddnet/assets/23437060/4a8b230c-a66b-4e2a-9744-cb5f80f6a799)
- After:
![screenshot_2023-06-20_20-40-00](https://github.com/ddnet/ddnet/assets/23437060/517f90cf-06a5-4332-9eb8-6a87cbc91b32)
- After (color picker open):
![screenshot_2023-06-25_17-35-55](https://github.com/ddnet/ddnet/assets/23437060/30320b56-e4cb-4e93-bf7b-8cfc8d96620b)


Suggested by @HiRavie in https://github.com/ddnet/ddnet/pull/6743#issuecomment-1593886873, though it was easier and also looks better to me when the color picker button has exactly the same size as the other value selectors.

## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
