### PR TITLE
Autosave copy of current editor map periodically to `auto` folder, use separate thread to finish saving maps, add saving indicator

### DIFF
--- a/src/engine/shared/datafile.h
+++ b/src/engine/shared/datafile.h
@@ -58,9 +58,11 @@ class CDataFileWriter
 {
 	struct CDataInfo
 	{
+		void *m_pUncompressedData;
 		int m_UncompressedSize;
-		int m_CompressedSize;
 		void *m_pCompressedData;
+		int m_CompressedSize;
+		int m_CompressionLevel;
 	};
 
 	struct CItemInfo
@@ -103,14 +105,31 @@ class CDataFileWriter
 
 public:
 	CDataFileWriter();
+	CDataFileWriter(CDataFileWriter &&Other) :
+		m_NumItems(Other.m_NumItems),
+		m_NumDatas(Other.m_NumDatas),
+		m_NumItemTypes(Other.m_NumItemTypes),
+		m_NumExtendedItemTypes(Other.m_NumExtendedItemTypes)
+	{
+		m_File = Other.m_File;
+		Other.m_File = 0;
+		m_pItemTypes = Other.m_pItemTypes;
+		Other.m_pItemTypes = nullptr;
+		m_pItems = Other.m_pItems;
+		Other.m_pItems = nullptr;
+		m_pDatas = Other.m_pDatas;
+		Other.m_pDatas = nullptr;
+		mem_copy(m_aExtendedItemTypes, Other.m_aExtendedItemTypes, sizeof(m_aExtendedItemTypes));
+	}
 	~CDataFileWriter();
+
 	void Init();
 	bool OpenFile(class IStorage *pStorage, const char *pFilename, int StorageType = IStorage::TYPE_SAVE);
 	bool Open(class IStorage *pStorage, const char *pFilename, int StorageType = IStorage::TYPE_SAVE);
 	int AddData(int Size, void *pData, int CompressionLevel = Z_DEFAULT_COMPRESSION);
 	int AddDataSwapped(int Size, void *pData);
 	int AddItem(int Type, int ID, int Size, void *pData);
-	int Finish();
+	void Finish();
 };
 
 #endif

--- a/src/engine/shared/storage.cpp
+++ b/src/engine/shared/storage.cpp
@@ -68,6 +68,7 @@ public:
 				CreateFolder("screenshots/auto", TYPE_SAVE);
 				CreateFolder("screenshots/auto/stats", TYPE_SAVE);
 				CreateFolder("maps", TYPE_SAVE);
+				CreateFolder("maps/auto", TYPE_SAVE);
 				CreateFolder("mapres", TYPE_SAVE);
 				CreateFolder("downloadedmaps", TYPE_SAVE);
 				CreateFolder("skins", TYPE_SAVE);

--- a/src/game/editor/auto_map.cpp
+++ b/src/game/editor/auto_map.cpp
@@ -470,7 +470,7 @@ void CAutoMapper::Proceed(CLayerTiles *pLayer, int ConfigID, int Seed, int SeedO
 			for(int x = 0; x < pLayer->m_Width; x++)
 			{
 				CTile *pTile = &(pLayer->m_pTiles[y * pLayer->m_Width + x]);
-				m_pEditor->m_Map.m_Modified = true;
+				m_pEditor->m_Map.OnModify();
 
 				for(size_t i = 0; i < pRun->m_vIndexRules.size(); ++i)
 				{

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -6440,25 +6440,7 @@ void CEditor::Render()
 	if(m_GuiActive)
 		RenderStatusbar(StatusBar);
 
-	//
-	if(g_Config.m_EdShowkeys)
-	{
-		UI()->MapScreen();
-		CTextCursor Cursor;
-		TextRender()->SetCursor(&Cursor, View.x + 10, View.y + View.h - 24 - 10, 24.0f, TEXTFLAG_RENDER);
-
-		int NKeys = 0;
-		for(int i = 0; i < KEY_LAST; i++)
-		{
-			if(Input()->KeyIsPressed(i))
-			{
-				if(NKeys)
-					TextRender()->TextEx(&Cursor, " + ", -1);
-				TextRender()->TextEx(&Cursor, Input()->KeyName(i), -1);
-				NKeys++;
-			}
-		}
-	}
+	RenderPressedKeys(View);
 
 	if(m_ShowMousePointer)
 	{
@@ -6474,6 +6456,28 @@ void CEditor::Render()
 		Graphics()->QuadsDrawTL(&QuadItem, 1);
 		Graphics()->QuadsEnd();
 		Graphics()->WrapNormal();
+	}
+}
+
+void CEditor::RenderPressedKeys(CUIRect View)
+{
+	if(!g_Config.m_EdShowkeys)
+		return;
+
+	UI()->MapScreen();
+	CTextCursor Cursor;
+	TextRender()->SetCursor(&Cursor, View.x + 10, View.y + View.h - 24 - 10, 24.0f, TEXTFLAG_RENDER);
+
+	int NKeys = 0;
+	for(int i = 0; i < KEY_LAST; i++)
+	{
+		if(Input()->KeyIsPressed(i))
+		{
+			if(NKeys)
+				TextRender()->TextEx(&Cursor, " + ", -1);
+			TextRender()->TextEx(&Cursor, Input()->KeyName(i), -1);
+			NKeys++;
+		}
 	}
 }
 

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -6441,22 +6441,7 @@ void CEditor::Render()
 		RenderStatusbar(StatusBar);
 
 	RenderPressedKeys(View);
-
-	if(m_ShowMousePointer)
-	{
-		// render butt ugly mouse cursor
-		float mx = UI()->MouseX();
-		float my = UI()->MouseY();
-		Graphics()->WrapClamp();
-		Graphics()->TextureSet(m_CursorTexture);
-		Graphics()->QuadsBegin();
-		if(ms_pUiGotContext == UI()->HotItem())
-			Graphics()->SetColor(1, 0, 0, 1);
-		IGraphics::CQuadItem QuadItem(mx, my, 16.0f, 16.0f);
-		Graphics()->QuadsDrawTL(&QuadItem, 1);
-		Graphics()->QuadsEnd();
-		Graphics()->WrapNormal();
-	}
+	RenderMousePointer();
 }
 
 void CEditor::RenderPressedKeys(CUIRect View)
@@ -6479,6 +6464,22 @@ void CEditor::RenderPressedKeys(CUIRect View)
 			NKeys++;
 		}
 	}
+}
+
+void CEditor::RenderMousePointer()
+{
+	if(!m_ShowMousePointer)
+		return;
+
+	Graphics()->WrapClamp();
+	Graphics()->TextureSet(m_CursorTexture);
+	Graphics()->QuadsBegin();
+	if(ms_pUiGotContext == UI()->HotItem())
+		Graphics()->SetColor(1, 0, 0, 1);
+	IGraphics::CQuadItem QuadItem(UI()->MouseX(), UI()->MouseY(), 16.0f, 16.0f);
+	Graphics()->QuadsDrawTL(&QuadItem, 1);
+	Graphics()->QuadsEnd();
+	Graphics()->WrapNormal();
 }
 
 void CEditor::Reset(bool CreateDefault)

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -877,6 +877,7 @@ public:
 	void Render();
 
 	void RenderPressedKeys(CUIRect View);
+	void RenderMousePointer();
 
 	void ResetMenuBackgroundPositions();
 

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -876,6 +876,8 @@ public:
 	void LoadCurrentMap();
 	void Render();
 
+	void RenderPressedKeys(CUIRect View);
+
 	void ResetMenuBackgroundPositions();
 
 	std::vector<CQuad *> GetSelectedQuads();

--- a/src/game/editor/io.cpp
+++ b/src/game/editor/io.cpp
@@ -976,6 +976,9 @@ bool CEditorMap::Load(const char *pFileName, int StorageType)
 		return false;
 
 	m_Modified = false;
+	m_ModifiedAuto = false;
+	m_LastModifiedTime = -1.0f;
+	m_LastSaveTime = m_pEditor->Client()->GlobalTime();
 	return true;
 }
 

--- a/src/game/editor/layer_quads.cpp
+++ b/src/game/editor/layer_quads.cpp
@@ -37,7 +37,7 @@ void CLayerQuads::Render(bool QuadPicker)
 
 CQuad *CLayerQuads::NewQuad(int x, int y, int Width, int Height)
 {
-	m_pEditor->m_Map.m_Modified = true;
+	m_pEditor->m_Map.OnModify();
 
 	m_vQuads.emplace_back();
 	CQuad *pQuad = &m_vQuads[m_vQuads.size() - 1];
@@ -153,7 +153,7 @@ void CLayerQuads::BrushPlace(CLayer *pBrush, float wx, float wy)
 
 		m_vQuads.push_back(n);
 	}
-	m_pEditor->m_Map.m_Modified = true;
+	m_pEditor->m_Map.OnModify();
 }
 
 void CLayerQuads::BrushFlipX()
@@ -163,7 +163,7 @@ void CLayerQuads::BrushFlipX()
 		std::swap(Quad.m_aPoints[0], Quad.m_aPoints[1]);
 		std::swap(Quad.m_aPoints[2], Quad.m_aPoints[3]);
 	}
-	m_pEditor->m_Map.m_Modified = true;
+	m_pEditor->m_Map.OnModify();
 }
 
 void CLayerQuads::BrushFlipY()
@@ -173,7 +173,7 @@ void CLayerQuads::BrushFlipY()
 		std::swap(Quad.m_aPoints[0], Quad.m_aPoints[2]);
 		std::swap(Quad.m_aPoints[1], Quad.m_aPoints[3]);
 	}
-	m_pEditor->m_Map.m_Modified = true;
+	m_pEditor->m_Map.OnModify();
 }
 
 void Rotate(vec2 *pCenter, vec2 *pPoint, float Rotation)
@@ -236,7 +236,7 @@ CUI::EPopupMenuFunctionResult CLayerQuads::RenderProperties(CUIRect *pToolBox)
 	int Prop = m_pEditor->DoProperties(pToolBox, aProps, s_aIds, &NewVal);
 	if(Prop != -1)
 	{
-		m_pEditor->m_Map.m_Modified = true;
+		m_pEditor->m_Map.OnModify();
 	}
 
 	if(Prop == PROP_IMAGE)
@@ -277,7 +277,7 @@ int CLayerQuads::SwapQuads(int Index0, int Index1)
 		return Index0;
 	if(Index0 == Index1)
 		return Index0;
-	m_pEditor->m_Map.m_Modified = true;
+	m_pEditor->m_Map.OnModify();
 	std::swap(m_vQuads[Index0], m_vQuads[Index1]);
 	return Index1;
 }

--- a/src/game/editor/layer_sounds.cpp
+++ b/src/game/editor/layer_sounds.cpp
@@ -101,7 +101,7 @@ void CLayerSounds::Render(bool Tileset)
 
 CSoundSource *CLayerSounds::NewSource(int x, int y)
 {
-	m_pEditor->m_Map.m_Modified = true;
+	m_pEditor->m_Map.OnModify();
 
 	m_vSources.emplace_back();
 	CSoundSource *pSource = &m_vSources[m_vSources.size() - 1];
@@ -179,7 +179,7 @@ void CLayerSounds::BrushPlace(CLayer *pBrush, float wx, float wy)
 
 		m_vSources.push_back(n);
 	}
-	m_pEditor->m_Map.m_Modified = true;
+	m_pEditor->m_Map.OnModify();
 }
 
 CUI::EPopupMenuFunctionResult CLayerSounds::RenderProperties(CUIRect *pToolBox)
@@ -200,7 +200,7 @@ CUI::EPopupMenuFunctionResult CLayerSounds::RenderProperties(CUIRect *pToolBox)
 	int Prop = m_pEditor->DoProperties(pToolBox, aProps, s_aIds, &NewVal);
 	if(Prop != -1)
 	{
-		m_pEditor->m_Map.m_Modified = true;
+		m_pEditor->m_Map.OnModify();
 	}
 
 	if(Prop == PROP_SOUND)

--- a/src/game/editor/layer_tiles.cpp
+++ b/src/game/editor/layer_tiles.cpp
@@ -1079,7 +1079,7 @@ CUI::EPopupMenuFunctionResult CLayerTiles::RenderCommonProperties(SCommonPropSta
 
 void CLayerTiles::FlagModified(int x, int y, int w, int h)
 {
-	m_pEditor->m_Map.m_Modified = true;
+	m_pEditor->m_Map.OnModify();
 	if(m_Seed != 0 && m_AutoMapperConfig != -1 && m_AutoAutoMap && m_Image >= 0)
 	{
 		m_pEditor->m_Map.m_vpImages[m_Image]->m_AutoMapper.ProceedLocalized(this, m_AutoMapperConfig, m_Seed, x, y, w, h);

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -366,7 +366,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupGroup(void *pContext, CUIRect View, 
 					if(!Found)
 					{
 						pGameLayer->m_pTiles[y * pGameLayer->m_Width + x].m_Index = TILE_AIR;
-						pEditor->m_Map.m_Modified = true;
+						pEditor->m_Map.OnModify();
 					}
 				}
 			}
@@ -512,7 +512,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupGroup(void *pContext, CUIRect View, 
 		static CLineInput s_NameInput;
 		s_NameInput.SetBuffer(pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_aName, sizeof(pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_aName));
 		if(pEditor->DoEditBox(&s_NameInput, &Button, 10.0f))
-			pEditor->m_Map.m_Modified = true;
+			pEditor->m_Map.OnModify();
 	}
 
 	enum
@@ -557,7 +557,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupGroup(void *pContext, CUIRect View, 
 	int Prop = pEditor->DoProperties(&View, aProps, s_aIds, &NewVal);
 	if(Prop != -1)
 	{
-		pEditor->m_Map.m_Modified = true;
+		pEditor->m_Map.OnModify();
 	}
 
 	if(Prop == PROP_ORDER)
@@ -683,7 +683,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupLayer(void *pContext, CUIRect View, 
 		static CLineInput s_NameInput;
 		s_NameInput.SetBuffer(pCurrentLayer->m_aName, sizeof(pCurrentLayer->m_aName));
 		if(pEditor->DoEditBox(&s_NameInput, &EditBox, 10.0f))
-			pEditor->m_Map.m_Modified = true;
+			pEditor->m_Map.OnModify();
 	}
 
 	// spacing if any button was rendered
@@ -717,7 +717,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupLayer(void *pContext, CUIRect View, 
 	int Prop = pEditor->DoProperties(&View, aProps, s_aIds, &NewVal);
 	if(Prop != -1)
 	{
-		pEditor->m_Map.m_Modified = true;
+		pEditor->m_Map.OnModify();
 	}
 
 	if(Prop == PROP_ORDER)
@@ -762,7 +762,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupQuad(void *pContext, CUIRect View, b
 	{
 		if(pLayer)
 		{
-			pEditor->m_Map.m_Modified = true;
+			pEditor->m_Map.OnModify();
 			pEditor->DeleteSelectedQuads();
 		}
 		return CUI::POPUP_CLOSE_CURRENT;
@@ -802,7 +802,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupQuad(void *pContext, CUIRect View, b
 				pQuad->m_aPoints[2].y = Top + Height;
 				pQuad->m_aPoints[3].x = Right;
 				pQuad->m_aPoints[3].y = Top + Height;
-				pEditor->m_Map.m_Modified = true;
+				pEditor->m_Map.OnModify();
 			}
 			return CUI::POPUP_CLOSE_CURRENT;
 		}
@@ -821,7 +821,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupQuad(void *pContext, CUIRect View, b
 				pQuad->m_aPoints[k].x = 1000.0f * (pQuad->m_aPoints[k].x / 1000);
 				pQuad->m_aPoints[k].y = 1000.0f * (pQuad->m_aPoints[k].y / 1000);
 			}
-			pEditor->m_Map.m_Modified = true;
+			pEditor->m_Map.OnModify();
 		}
 		return CUI::POPUP_CLOSE_CURRENT;
 	}
@@ -859,7 +859,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupQuad(void *pContext, CUIRect View, b
 			pQuad->m_aPoints[2].y = Bottom;
 			pQuad->m_aPoints[3].x = Right;
 			pQuad->m_aPoints[3].y = Bottom;
-			pEditor->m_Map.m_Modified = true;
+			pEditor->m_Map.OnModify();
 		}
 		return CUI::POPUP_CLOSE_CURRENT;
 	}
@@ -904,7 +904,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupQuad(void *pContext, CUIRect View, b
 	int Prop = pEditor->DoProperties(&View, aProps, s_aIds, &NewVal);
 	if(Prop != -1)
 	{
-		pEditor->m_Map.m_Modified = true;
+		pEditor->m_Map.OnModify();
 	}
 
 	const float OffsetX = i2fx(NewVal) - pCurrentQuad->m_aPoints[4].x;
@@ -988,7 +988,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupSource(void *pContext, CUIRect View,
 		CLayerSounds *pLayer = (CLayerSounds *)pEditor->GetSelectedLayerType(0, LAYERTYPE_SOUNDS);
 		if(pLayer)
 		{
-			pEditor->m_Map.m_Modified = true;
+			pEditor->m_Map.OnModify();
 			pLayer->m_vSources.erase(pLayer->m_vSources.begin() + pEditor->m_SelectedSource);
 			pEditor->m_SelectedSource--;
 		}
@@ -1062,7 +1062,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupSource(void *pContext, CUIRect View,
 	int Prop = pEditor->DoProperties(&View, aProps, s_aIds, &NewVal);
 	if(Prop != -1)
 	{
-		pEditor->m_Map.m_Modified = true;
+		pEditor->m_Map.OnModify();
 	}
 
 	if(Prop == PROP_POS_X)
@@ -1145,7 +1145,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupSource(void *pContext, CUIRect View,
 		Prop = pEditor->DoProperties(&View, aCircleProps, s_aCircleIds, &NewVal);
 		if(Prop != -1)
 		{
-			pEditor->m_Map.m_Modified = true;
+			pEditor->m_Map.OnModify();
 		}
 
 		if(Prop == PROP_CIRCLE_RADIUS)
@@ -1176,7 +1176,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupSource(void *pContext, CUIRect View,
 		Prop = pEditor->DoProperties(&View, aRectangleProps, s_aRectangleIds, &NewVal);
 		if(Prop != -1)
 		{
-			pEditor->m_Map.m_Modified = true;
+			pEditor->m_Map.OnModify();
 		}
 
 		if(Prop == PROP_RECTANGLE_WIDTH)
@@ -1236,7 +1236,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupPoint(void *pContext, CUIRect View, 
 	int Prop = pEditor->DoProperties(&View, aProps, s_aIds, &NewVal);
 	if(Prop != -1)
 	{
-		pEditor->m_Map.m_Modified = true;
+		pEditor->m_Map.OnModify();
 	}
 
 	for(auto &pQuad : vpQuads)

--- a/src/game/variables.h
+++ b/src/game/variables.h
@@ -90,6 +90,8 @@ MACRO_CONFIG_INT(ClDyncamFollowFactor, cl_dyncam_follow_factor, 60, 0, 200, CFGF
 MACRO_CONFIG_INT(ClDyncamSmoothness, cl_dyncam_smoothness, 0, 0, 100, CFGFLAG_CLIENT | CFGFLAG_SAVE | CFGFLAG_INSENSITIVE, "Transition amount of the camera movement, 0=instant, 100=slow and smooth")
 MACRO_CONFIG_INT(ClDyncamStabilizing, cl_dyncam_stabilizing, 0, 0, 100, CFGFLAG_CLIENT | CFGFLAG_SAVE | CFGFLAG_INSENSITIVE, "Amount of camera slowdown during fast cursor movement. High value can cause delay in camera movement")
 
+MACRO_CONFIG_INT(EdAutosaveInterval, ed_autosave_interval, 10, 0, 240, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Interval in minutes at which a copy of the current editor map is automatically saved to the 'auto' folder (0 for off)")
+MACRO_CONFIG_INT(EdAutosaveMax, ed_autosave_max, 10, 0, 1000, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Maximum number of autosaves that are kept per map name (0 = no limit)")
 MACRO_CONFIG_INT(EdSmoothZoomTime, ed_smooth_zoom_time, 250, 0, 5000, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Time of smooth zoom animation in the editor in ms (0 for off)")
 MACRO_CONFIG_INT(EdLimitMaxZoomLevel, ed_limit_max_zoom_level, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Specifies, if zooming in the editor should be limited or not (0 = no limit)")
 MACRO_CONFIG_INT(EdZoomTarget, ed_zoom_target, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Zoom to the current mouse target")


### PR DESCRIPTION
A copy of the map currently open in the editor is saved every 10 minutes to the `maps/auto` folder (interval configurable, see below). The automatically saved map uses the filename of the original map with an additional timestamp. Per map name 10 autosaves are kept in the `auto` folder before old autosaves will be deleted (number configurable, see below).

Add config variable `ed_autosave_interval` (0 - 240, default 10) to configure the interval in minutes at which a copy of the current editor map is automatically saved to the 'auto' folder.

Add config variable `ed_autosave_max` (0 - 1000, default 10) to configure the maximum number of autosaves that are kept per map name (0 = no limit).

Autosaving will not take place in the 5 seconds immediately after the map was last modified by the user, to avoid interrupting the user with the autosave.
This will only delay autosaving for up to 1 minute though, so autosaves are not prevented entirely, should the user continuously edit the map.

When the editor is reopened after being closed for more than 10 seconds, the autosave timer will be adjusted to compensate for the time that was not spent on editing in the editor.

When the map is saved manually by the user the autosave file is also updated, if it's outdated by at least half of the configured autosave interval. This ensures that autosaves are always available as a periodic backup of the map.

When a copy of the current map is saved, this does not update the autosave and will also no longer reset the modified state. The modified state should reflect whether changes have been made that are not saved to the current map file. As saving a copy does not update the current file, the modified state should not be reset in this case.

Closes #6693.

Compressing the data with zlib takes the majority of the time when saving a datafile. Therefore, compressing is now delayed until the `CDataFileWriter::Finish` function is called. This function is then off-loaded to another thread to make saving maps in the editor not block the rendering.

A message "Saving…" is shown in the bottom right of the editor view while a job to save a map is running in the background.

While a map is being finished in a background thread another save for the same filename cannot be initiated to prevent multiples accesses to the same file.

Closes #6762.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [X] Tested in combination with possibly related configuration options
- [X] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
