### PR TITLE
Fix editor save dialog filename showing file extension

### DIFF
--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -2396,6 +2396,16 @@ char *fs_getcwd(char *buffer, int buffer_size)
 #endif
 }
 
+const char *fs_filename(const char *path)
+{
+	for(const char *filename = path + str_length(path); filename >= path; --filename)
+	{
+		if(filename[0] == '/' || filename[0] == '\\')
+			return filename + 1;
+	}
+	return path;
+}
+
 int fs_parent_dir(char *path)
 {
 	char *parent = 0;

--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -2406,6 +2406,29 @@ const char *fs_filename(const char *path)
 	return path;
 }
 
+void fs_split_file_extension(const char *filename, char *name, size_t name_size, char *extension, size_t extension_size)
+{
+	dbg_assert(name != nullptr || extension != nullptr, "name or extension parameter required");
+	dbg_assert(name == nullptr || name_size > 0, "name_size invalid");
+	dbg_assert(extension == nullptr || extension_size > 0, "extension_size invalid");
+
+	const char *last_dot = str_rchr(filename, '.');
+	if(last_dot == nullptr || last_dot == filename)
+	{
+		if(extension != nullptr)
+			extension[0] = '\0';
+		if(name != nullptr)
+			str_copy(name, filename, name_size);
+	}
+	else
+	{
+		if(extension != nullptr)
+			str_copy(extension, last_dot + 1, extension_size);
+		if(name != nullptr)
+			str_truncate(name, name_size, filename, last_dot - filename);
+	}
+}
+
 int fs_parent_dir(char *path)
 {
 	char *parent = 0;

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -2027,6 +2027,22 @@ int fs_chdir(const char *path);
 char *fs_getcwd(char *buffer, int buffer_size);
 
 /**
+ * Gets the name of a file or folder specified by a path,
+ * i.e. the last segment of the path.
+ *
+ * @ingroup Filesystem
+ *
+ * @param path Path from which to retrieve the filename.
+ *
+ * @return Filename of the path.
+ *
+ * @remark Supports forward and backward slashes as path segment separator.
+ * @remark No distinction between files and folders is being made.
+ * @remark The strings are treated as zero-terminated strings.
+ */
+const char *fs_filename(const char *path);
+
+/**
  * Get the parent directory of a directory.
  *
  * @ingroup Filesystem

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -2043,6 +2043,23 @@ char *fs_getcwd(char *buffer, int buffer_size);
 const char *fs_filename(const char *path);
 
 /**
+ * Splits a filename into name (without extension) and file extension.
+ *
+ * @ingroup Filesystem
+ *
+ * @param filename The filename to split.
+ * @param name Buffer that will receive the name without extension, may be nullptr.
+ * @param name_size Size of the name buffer (ignored if name is nullptr).
+ * @param extension Buffer that will receive the extension, may be nullptr.
+ * @param extension_size Size of the extension buffer (ignored if extension is nullptr).
+ *
+ * @remark Does NOT handle forward and backward slashes.
+ * @remark No distinction between files and folders is being made.
+ * @remark The strings are treated as zero-terminated strings.
+ */
+void fs_split_file_extension(const char *filename, char *name, size_t name_size, char *extension = nullptr, size_t extension_size = 0);
+
+/**
  * Get the parent directory of a directory.
  *
  * @ingroup Filesystem

--- a/src/test/fs.cpp
+++ b/src/test/fs.cpp
@@ -16,6 +16,38 @@ TEST(Filesystem, Filename)
 	EXPECT_STREQ(fs_filename("aaaaa\\bbbb/ccc"), "ccc");
 }
 
+TEST(Filesystem, SplitFileExtension)
+{
+	char aName[IO_MAX_PATH_LENGTH];
+	char aExt[IO_MAX_PATH_LENGTH];
+
+	fs_split_file_extension("", aName, sizeof(aName), aExt, sizeof(aExt));
+	EXPECT_STREQ(aName, "");
+	EXPECT_STREQ(aExt, "");
+
+	fs_split_file_extension("name.ext", aName, sizeof(aName), aExt, sizeof(aExt));
+	EXPECT_STREQ(aName, "name");
+	EXPECT_STREQ(aExt, "ext");
+
+	fs_split_file_extension("name.ext", aName, sizeof(aName)); // extension parameter is optional
+	EXPECT_STREQ(aName, "name");
+
+	fs_split_file_extension("name.ext", nullptr, 0, aExt, sizeof(aExt)); // name parameter is optional
+	EXPECT_STREQ(aExt, "ext");
+
+	fs_split_file_extension("archive.tar.gz", aName, sizeof(aName), aExt, sizeof(aExt));
+	EXPECT_STREQ(aName, "archive.tar");
+	EXPECT_STREQ(aExt, "gz");
+
+	fs_split_file_extension("no_dot", aName, sizeof(aName), aExt, sizeof(aExt));
+	EXPECT_STREQ(aName, "no_dot");
+	EXPECT_STREQ(aExt, "");
+
+	fs_split_file_extension(".dot_first", aName, sizeof(aName), aExt, sizeof(aExt));
+	EXPECT_STREQ(aName, ".dot_first");
+	EXPECT_STREQ(aExt, "");
+}
+
 TEST(Filesystem, CreateCloseDelete)
 {
 	CTestInfo Info;

--- a/src/test/fs.cpp
+++ b/src/test/fs.cpp
@@ -3,6 +3,19 @@
 
 #include <base/system.h>
 
+TEST(Filesystem, Filename)
+{
+	EXPECT_STREQ(fs_filename(""), "");
+	EXPECT_STREQ(fs_filename("a"), "a");
+	EXPECT_STREQ(fs_filename("abc"), "abc");
+	EXPECT_STREQ(fs_filename("a/b"), "b");
+	EXPECT_STREQ(fs_filename("a/b/c"), "c");
+	EXPECT_STREQ(fs_filename("aaaaa/bbbb/ccc"), "ccc");
+	EXPECT_STREQ(fs_filename("aaaaa\\bbbb\\ccc"), "ccc");
+	EXPECT_STREQ(fs_filename("aaaaa/bbbb\\ccc"), "ccc");
+	EXPECT_STREQ(fs_filename("aaaaa\\bbbb/ccc"), "ccc");
+}
+
 TEST(Filesystem, CreateCloseDelete)
 {
 	CTestInfo Info;


### PR DESCRIPTION
Which was causing the listbox selection to be cleared when activating the filename editbox, as the filename search expects names without the file extension.

Add `fs_split_file_extension` to separate filename and extension.

Add `fs_filename` to extract file/folder name from path. This commit is not required for this PR, but including it reduces conflicts with #6752 and #6763, which need this commit.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [X] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
