### PR TITLE
Add play/stop button and duration label for editor sounds 

### DIFF
--- a/src/engine/client/sound.cpp
+++ b/src/engine/client/sound.cpp
@@ -576,7 +576,7 @@ int CSound::DecodeWV(int SampleID, const void *pData, unsigned DataSize)
 	return SampleID;
 }
 
-int CSound::LoadOpus(const char *pFilename)
+int CSound::LoadOpus(const char *pFilename, int StorageType)
 {
 	// don't waste memory on sound when we are stress testing
 #ifdef CONF_DEBUG
@@ -600,7 +600,7 @@ int CSound::LoadOpus(const char *pFilename)
 
 	void *pData;
 	unsigned DataSize;
-	if(!m_pStorage->ReadFile(pFilename, IStorage::TYPE_ALL, &pData, &DataSize))
+	if(!m_pStorage->ReadFile(pFilename, StorageType, &pData, &DataSize))
 	{
 		dbg_msg("sound/opus", "failed to open file. filename='%s'", pFilename);
 		return -1;
@@ -618,7 +618,7 @@ int CSound::LoadOpus(const char *pFilename)
 	return SampleID;
 }
 
-int CSound::LoadWV(const char *pFilename)
+int CSound::LoadWV(const char *pFilename, int StorageType)
 {
 	// don't waste memory on sound when we are stress testing
 #ifdef CONF_DEBUG
@@ -642,7 +642,7 @@ int CSound::LoadWV(const char *pFilename)
 
 	void *pData;
 	unsigned DataSize;
-	if(!m_pStorage->ReadFile(pFilename, IStorage::TYPE_ALL, &pData, &DataSize))
+	if(!m_pStorage->ReadFile(pFilename, StorageType, &pData, &DataSize))
 	{
 		dbg_msg("sound/wv", "failed to open file. filename='%s'", pFilename);
 		return -1;

--- a/src/engine/client/sound.h
+++ b/src/engine/client/sound.h
@@ -34,9 +34,9 @@ public:
 
 	bool IsSoundEnabled() override { return m_SoundEnabled; }
 
-	int LoadWV(const char *pFilename) override;
+	int LoadWV(const char *pFilename, int StorageType = IStorage::TYPE_ALL) override;
 	int LoadWVFromMem(const void *pData, unsigned DataSize, bool FromEditor) override;
-	int LoadOpus(const char *pFilename) override;
+	int LoadOpus(const char *pFilename, int StorageType = IStorage::TYPE_ALL) override;
 	int LoadOpusFromMem(const void *pData, unsigned DataSize, bool FromEditor) override;
 	void UnloadSample(int SampleID) override;
 

--- a/src/engine/sound.h
+++ b/src/engine/sound.h
@@ -6,6 +6,7 @@
 #include "kernel.h"
 
 #include <engine/shared/video.h>
+#include <engine/storage.h>
 
 class ISound : public IInterface
 {
@@ -63,8 +64,8 @@ public:
 
 	virtual bool IsSoundEnabled() = 0;
 
-	virtual int LoadWV(const char *pFilename) = 0;
-	virtual int LoadOpus(const char *pFilename) = 0;
+	virtual int LoadWV(const char *pFilename, int StorageType = IStorage::TYPE_ALL) = 0;
+	virtual int LoadOpus(const char *pFilename, int StorageType = IStorage::TYPE_ALL) = 0;
 	virtual int LoadWVFromMem(const void *pData, unsigned DataSize, bool FromEditor = false) = 0;
 	virtual int LoadOpusFromMem(const void *pData, unsigned DataSize, bool FromEditor = false) = 0;
 	virtual void UnloadSample(int SampleID) = 0;

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -710,11 +710,11 @@ class CEditor : public IEditor
 
 	int GetTextureUsageFlag();
 
-	enum EPreviewImageState
+	enum EPreviewState
 	{
-		PREVIEWIMAGE_UNLOADED,
-		PREVIEWIMAGE_LOADED,
-		PREVIEWIMAGE_ERROR,
+		PREVIEW_UNLOADED,
+		PREVIEW_LOADED,
+		PREVIEW_ERROR,
 	};
 
 public:
@@ -775,7 +775,8 @@ public:
 		m_FilesSelectedIndex = -1;
 
 		m_FilePreviewImage.Invalidate();
-		m_PreviewImageState = PREVIEWIMAGE_UNLOADED;
+		m_FilePreviewSound = -1;
+		m_FilePreviewState = PREVIEW_UNLOADED;
 
 		m_SelectEntitiesImage = "DDNet";
 
@@ -945,8 +946,10 @@ public:
 	int m_FileDialogFileType;
 	int m_FilesSelectedIndex;
 	CLineInputBuffered<IO_MAX_PATH_LENGTH> m_FileDialogNewFolderNameInput;
+
 	IGraphics::CTextureHandle m_FilePreviewImage;
-	EPreviewImageState m_PreviewImageState;
+	int m_FilePreviewSound;
+	EPreviewState m_FilePreviewState;
 	CImageInfo m_FilePreviewImageInfo;
 	bool m_FileDialogOpening;
 
@@ -1212,7 +1215,8 @@ public:
 	void DoSoundSource(CSoundSource *pSource, int Index);
 
 	void DoMapEditor(CUIRect View);
-	void DoToolbar(CUIRect Toolbar);
+	void DoToolbarLayers(CUIRect Toolbar);
+	void DoToolbarSounds(CUIRect Toolbar);
 	void DoQuad(CQuad *pQuad, int Index);
 	ColorRGBA GetButtonColor(const void *pID, int Checked);
 


### PR DESCRIPTION
Add button to play/stop audio preview and label showing selected sound duration in editor sound list and sound file browser.

Show error message instead of preview in editor image/sound file browser when selected file cannot be loaded.

Screenshots:
- ![screenshot_2023-06-25_21-53-14](https://github.com/ddnet/ddnet/assets/23437060/a2eb810c-e132-4fa8-9d0d-730b78088651)
- ![screenshot_2023-06-25_21-53-01](https://github.com/ddnet/ddnet/assets/23437060/1a742abc-51f9-4526-aada-d941d42e481d)
- ![screenshot_2023-06-25_21-53-05](https://github.com/ddnet/ddnet/assets/23437060/bf500772-ab6b-409f-8cc4-1bfbaeae55eb)


## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
