### PR TITLE
Fix inconsistent size and corners of connect button

### DIFF
--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -456,6 +456,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 	CUIRect SearchAndInfo, ServerAddr, ConnectButtons;
 	SearchInfoAndAddr.HSplitTop(40.0f, &SearchAndInfo, &ServerAddr);
 	ServersAndConnect.HSplitTop(35.0f, &Status3, &ConnectButtons);
+	ConnectButtons.HSplitTop(5.0f, nullptr, &ConnectButtons);
 	CUIRect QuickSearch, QuickExclude;
 
 	SearchAndInfo.HSplitTop(20.f, &QuickSearch, &QuickExclude);
@@ -553,10 +554,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 
 		// button area
 		CUIRect ButtonRefresh, ButtonConnect;
-		ConnectButtons.VSplitMid(&ButtonRefresh, &ButtonConnect);
-		ButtonRefresh.HSplitTop(5.0f, NULL, &ButtonRefresh);
-		ButtonConnect.HSplitTop(5.0f, NULL, &ButtonConnect);
-		ButtonConnect.VSplitLeft(5.0f, NULL, &ButtonConnect);
+		ConnectButtons.VSplitMid(&ButtonRefresh, &ButtonConnect, 5.0f);
 
 		// refresh button
 		{


### PR DESCRIPTION
The connect button had `5.0f` units less width, which was causing the corners of the refresh and connect buttons to look differently.

Screenshots:
- Before: 
![connect-button old](https://github.com/ddnet/ddnet/assets/23437060/1ed567b9-d108-4a7a-9141-c43fab89d4aa)
- After:
![connect-button new](https://github.com/ddnet/ddnet/assets/23437060/e054018d-cd2d-4257-96c4-e1d57e111c68)

## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
