### PR TITLE
Fix proximity radius of predicted pickups

### DIFF
--- a/src/game/client/prediction/entities/pickup.cpp
+++ b/src/game/client/prediction/entities/pickup.cpp
@@ -7,6 +7,8 @@
 #include <game/generated/protocol.h>
 #include <game/mapitems.h>
 
+static constexpr int gs_PickupPhysSize = 14;
+
 void CPickup::Tick()
 {
 	Move();
@@ -143,7 +145,7 @@ void CPickup::Move()
 }
 
 CPickup::CPickup(CGameWorld *pGameWorld, int ID, const CPickupData *pPickup) :
-	CEntity(pGameWorld, CGameWorld::ENTTYPE_PICKUP)
+	CEntity(pGameWorld, CGameWorld::ENTTYPE_PICKUP, vec2(0, 0), gs_PickupPhysSize)
 {
 	m_Pos = pPickup->m_Pos;
 	m_Type = pPickup->m_Type;


### PR DESCRIPTION
Radius was set to 0 before this, so pickups were sometimes not predicted.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
