### PR TITLE
Fix height of layer popup when automapper properties shown, fix incorrect popup being closed when gametile popup used

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -3744,7 +3744,7 @@ void CEditor::RenderLayers(CUIRect LayersBox)
 						else
 							s_LayerPopupContext.m_vpLayers.clear();
 
-						UI()->DoPopupMenu(&s_LayerPopupContext, UI()->MouseX(), UI()->MouseY(), 120, 230, &s_LayerPopupContext, PopupLayer);
+						UI()->DoPopupMenu(&s_LayerPopupContext, UI()->MouseX(), UI()->MouseY(), 120, 270, &s_LayerPopupContext, PopupLayer);
 					}
 
 					s_Operation = OP_NONE;

--- a/src/game/editor/layer_tiles.cpp
+++ b/src/game/editor/layer_tiles.cpp
@@ -775,8 +775,6 @@ CUI::EPopupMenuFunctionResult CLayerTiles::RenderProperties(CUIRect *pToolBox)
 					}
 				}
 			}
-
-			return CUI::POPUP_CLOSE_CURRENT;
 		}
 	}
 

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -1853,6 +1853,8 @@ CUI::EPopupMenuFunctionResult CEditor::PopupSelectGametileOp(void *pContext, CUI
 {
 	CEditor *pEditor = static_cast<CEditor *>(pContext);
 
+	const int PreviousSelected = s_GametileOpSelected;
+
 	CUIRect Button;
 	for(size_t i = 0; i < std::size(s_apGametileOpButtonNames); ++i)
 	{
@@ -1862,7 +1864,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupSelectGametileOp(void *pContext, CUI
 			s_GametileOpSelected = i;
 	}
 
-	return CUI::POPUP_KEEP_OPEN;
+	return s_GametileOpSelected == PreviousSelected ? CUI::POPUP_KEEP_OPEN : CUI::POPUP_CLOSE_CURRENT;
 }
 
 void CEditor::PopupSelectGametileOpInvoke(float x, float y)


### PR DESCRIPTION
Both are regressions in 17.1 and should be added to the release.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
