### PR TITLE
Render editor pressed keys and saving message behind file dialog

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -6387,6 +6387,9 @@ void CEditor::Render()
 		}
 	}
 
+	RenderPressedKeys(View);
+	RenderSavingIndicator(View);
+
 	if(m_Dialog == DIALOG_FILE)
 	{
 		static int s_NullUiTarget = 0;
@@ -6421,8 +6424,6 @@ void CEditor::Render()
 	if(m_GuiActive)
 		RenderStatusbar(StatusBar);
 
-	RenderPressedKeys(View);
-	RenderSavingIndicator(View);
 	RenderMousePointer();
 }
 


### PR DESCRIPTION
The messages were previously rendered on top of the file dialog and popup menus.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
