### PR TITLE
Fix text alignment in large confirmation popups with long text, increase buffer size for generic popup message 

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -1140,6 +1140,7 @@ int CMenus::Render()
 		{
 			pTitle = m_aPopupTitle;
 			pExtraText = m_aPopupMessage;
+			TopAlign = true;
 		}
 		else if(m_Popup == POPUP_CONNECTING)
 		{

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -199,7 +199,7 @@ protected:
 		NUM_BUTTONS
 	};
 	char m_aPopupTitle[128];
-	char m_aPopupMessage[256];
+	char m_aPopupMessage[IO_MAX_PATH_LENGTH + 256];
 	struct
 	{
 		char m_aLabel[64];


### PR DESCRIPTION
Closes #6806.

The message can contain a filename, so it should be large enough to contain that and the message itself.

Screenshots:
- Before: 
![screenshot_2023-07-04_18-09-12](https://github.com/ddnet/ddnet/assets/23437060/39cd4761-8cd0-4ac1-a24a-5115c8eed8c9)
- After:
![screenshot_2023-07-04_21-43-45](https://github.com/ddnet/ddnet/assets/23437060/c8f05f83-3f32-445a-8451-3a8be14a6007)
- Before (filename is truncated): 
![screenshot_2023-07-04_21-49-49](https://github.com/ddnet/ddnet/assets/23437060/16dfade5-f330-45b8-ac2f-1bc0d9a3fda1)
- After (full filename is shown):
![screenshot_2023-07-04_21-49-33](https://github.com/ddnet/ddnet/assets/23437060/eae1d789-f8e4-45c4-853e-ba655ab98168)

There is a separate issue with the text wrapping not working correctly with this long Unicode filename, which is causing the font size to decrease instead. See #6810.

## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
