### PR TITLE
Fix HUD PlayerState weapons rendering

### DIFF
--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -750,20 +750,16 @@ void CHud::PreparePlayerStateQuads()
 	m_AirjumpEmptyOffset = Graphics()->QuadContainerAddQuads(m_HudQuadContainerIndex, Array, 10);
 
 	// Quads for displaying weapons
-	float ScaleX, ScaleY;
-	const float HudWeaponScale = 0.25f;
-	RenderTools()->GetSpriteScale(g_pData->m_Weapons.m_aId[WEAPON_HAMMER].m_pSpriteBody, ScaleX, ScaleY);
-	m_WeaponHammerOffset = RenderTools()->QuadContainerAddSprite(m_HudQuadContainerIndex, g_pData->m_Weapons.m_aId[WEAPON_HAMMER].m_VisualSize * ScaleX * HudWeaponScale, g_pData->m_Weapons.m_aId[WEAPON_HAMMER].m_VisualSize * ScaleY * HudWeaponScale);
-	RenderTools()->GetSpriteScale(g_pData->m_Weapons.m_aId[WEAPON_GUN].m_pSpriteBody, ScaleX, ScaleY);
-	m_WeaponGunOffset = RenderTools()->QuadContainerAddSprite(m_HudQuadContainerIndex, g_pData->m_Weapons.m_aId[WEAPON_GUN].m_VisualSize * ScaleX * HudWeaponScale, g_pData->m_Weapons.m_aId[WEAPON_GUN].m_VisualSize * ScaleY * HudWeaponScale);
-	RenderTools()->GetSpriteScale(g_pData->m_Weapons.m_aId[WEAPON_SHOTGUN].m_pSpriteBody, ScaleX, ScaleY);
-	m_WeaponShotgunOffset = RenderTools()->QuadContainerAddSprite(m_HudQuadContainerIndex, g_pData->m_Weapons.m_aId[WEAPON_SHOTGUN].m_VisualSize * ScaleX * HudWeaponScale, g_pData->m_Weapons.m_aId[WEAPON_SHOTGUN].m_VisualSize * ScaleY * HudWeaponScale);
-	RenderTools()->GetSpriteScale(g_pData->m_Weapons.m_aId[WEAPON_GRENADE].m_pSpriteBody, ScaleX, ScaleY);
-	m_WeaponGrenadeOffset = RenderTools()->QuadContainerAddSprite(m_HudQuadContainerIndex, g_pData->m_Weapons.m_aId[WEAPON_GRENADE].m_VisualSize * ScaleX * HudWeaponScale, g_pData->m_Weapons.m_aId[WEAPON_GRENADE].m_VisualSize * ScaleY * HudWeaponScale);
-	RenderTools()->GetSpriteScale(g_pData->m_Weapons.m_aId[WEAPON_LASER].m_pSpriteBody, ScaleX, ScaleY);
-	m_WeaponLaserOffset = RenderTools()->QuadContainerAddSprite(m_HudQuadContainerIndex, g_pData->m_Weapons.m_aId[WEAPON_LASER].m_VisualSize * ScaleX * HudWeaponScale, g_pData->m_Weapons.m_aId[WEAPON_LASER].m_VisualSize * ScaleY * HudWeaponScale);
-	RenderTools()->GetSpriteScale(g_pData->m_Weapons.m_aId[WEAPON_NINJA].m_pSpriteBody, ScaleX, ScaleY);
-	m_WeaponNinjaOffset = RenderTools()->QuadContainerAddSprite(m_HudQuadContainerIndex, g_pData->m_Weapons.m_aId[WEAPON_NINJA].m_VisualSize * ScaleX * HudWeaponScale, g_pData->m_Weapons.m_aId[WEAPON_NINJA].m_VisualSize * ScaleY * HudWeaponScale);
+	for(int Weapon = 0; Weapon < NUM_WEAPONS; ++Weapon)
+	{
+		const CDataWeaponspec &WeaponSpec = g_pData->m_Weapons.m_aId[Weapon];
+		float ScaleX, ScaleY;
+		RenderTools()->GetSpriteScale(WeaponSpec.m_pSpriteBody, ScaleX, ScaleY);
+		constexpr float HudWeaponScale = 0.25f;
+		float Width = WeaponSpec.m_VisualSize * ScaleX * HudWeaponScale;
+		float Height = WeaponSpec.m_VisualSize * ScaleY * HudWeaponScale;
+		m_aWeaponOffset[Weapon] = RenderTools()->QuadContainerAddSprite(m_HudQuadContainerIndex, Width, Height);
+	}
 
 	// Quads for displaying capabilities
 	m_EndlessJumpOffset = RenderTools()->QuadContainerAddSprite(m_HudQuadContainerIndex, 0.f, 0.f, 12.f, 12.f);
@@ -888,7 +884,7 @@ void CHud::RenderPlayerState(const int ClientID)
 		x -= 3;
 		Graphics()->QuadsSetRotation(pi * 7 / 4);
 		Graphics()->TextureSet(m_pClient->m_GameSkin.m_SpritePickupHammer);
-		Graphics()->RenderQuadContainerAsSprite(m_HudQuadContainerIndex, m_WeaponHammerOffset, x, y);
+		Graphics()->RenderQuadContainerAsSprite(m_HudQuadContainerIndex, m_aWeaponOffset[WEAPON_HAMMER], x, y);
 		Graphics()->QuadsSetRotation(0);
 		Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
 		x += 16;
@@ -901,7 +897,7 @@ void CHud::RenderPlayerState(const int ClientID)
 		}
 		Graphics()->QuadsSetRotation(pi * 7 / 4);
 		Graphics()->TextureSet(m_pClient->m_GameSkin.m_SpritePickupGun);
-		Graphics()->RenderQuadContainerAsSprite(m_HudQuadContainerIndex, m_WeaponGunOffset, x, y);
+		Graphics()->RenderQuadContainerAsSprite(m_HudQuadContainerIndex, m_aWeaponOffset[WEAPON_GUN], x, y);
 		Graphics()->QuadsSetRotation(0);
 		Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
 		x += 12;
@@ -914,7 +910,7 @@ void CHud::RenderPlayerState(const int ClientID)
 		}
 		Graphics()->QuadsSetRotation(pi * 7 / 4);
 		Graphics()->TextureSet(m_pClient->m_GameSkin.m_SpritePickupShotgun);
-		Graphics()->RenderQuadContainerAsSprite(m_HudQuadContainerIndex, m_WeaponShotgunOffset, x, y);
+		Graphics()->RenderQuadContainerAsSprite(m_HudQuadContainerIndex, m_aWeaponOffset[WEAPON_SHOTGUN], x, y);
 		Graphics()->QuadsSetRotation(0);
 		Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
 		x += 12;
@@ -927,7 +923,7 @@ void CHud::RenderPlayerState(const int ClientID)
 		}
 		Graphics()->QuadsSetRotation(pi * 7 / 4);
 		Graphics()->TextureSet(m_pClient->m_GameSkin.m_SpritePickupGrenade);
-		Graphics()->RenderQuadContainerAsSprite(m_HudQuadContainerIndex, m_WeaponGrenadeOffset, x, y);
+		Graphics()->RenderQuadContainerAsSprite(m_HudQuadContainerIndex, m_aWeaponOffset[WEAPON_GRENADE], x, y);
 		Graphics()->QuadsSetRotation(0);
 		Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
 		x += 12;
@@ -940,7 +936,7 @@ void CHud::RenderPlayerState(const int ClientID)
 		}
 		Graphics()->QuadsSetRotation(pi * 7 / 4);
 		Graphics()->TextureSet(m_pClient->m_GameSkin.m_SpritePickupLaser);
-		Graphics()->RenderQuadContainerAsSprite(m_HudQuadContainerIndex, m_WeaponLaserOffset, x, y);
+		Graphics()->RenderQuadContainerAsSprite(m_HudQuadContainerIndex, m_aWeaponOffset[WEAPON_LASER], x, y);
 		Graphics()->QuadsSetRotation(0);
 		Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
 		x += 12;
@@ -953,7 +949,7 @@ void CHud::RenderPlayerState(const int ClientID)
 		}
 		Graphics()->QuadsSetRotation(pi * 7 / 4);
 		Graphics()->TextureSet(m_pClient->m_GameSkin.m_SpritePickupNinja);
-		Graphics()->RenderQuadContainerAsSprite(m_HudQuadContainerIndex, m_WeaponNinjaOffset, x, y);
+		Graphics()->RenderQuadContainerAsSprite(m_HudQuadContainerIndex, m_aWeaponOffset[WEAPON_NINJA], x, y);
 		Graphics()->QuadsSetRotation(0);
 		Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
 

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -875,92 +875,36 @@ void CHud::RenderPlayerState(const int ClientID)
 		   (GameClient()->m_GameInfo.m_HudAmmo && g_Config.m_ClShowhudHealthAmmo ? 12 : 0));
 
 	// render weapons
-	if(pCharacter->m_aWeapons[WEAPON_HAMMER].m_Got)
 	{
-		if(pPlayer->m_Weapon != WEAPON_HAMMER)
+		constexpr float aWeaponWidth[NUM_WEAPONS] = {16, 12, 12, 12, 12, 12};
+		constexpr float aWeaponInitialOffset[NUM_WEAPONS] = {-3, -4, -1, -1, -2, -4};
+		bool InitialOffsetAdded = false;
+		for(int Weapon = 0; Weapon < NUM_WEAPONS; ++Weapon)
 		{
-			Graphics()->SetColor(1.0f, 1.0f, 1.0f, 0.4f);
+			if(!pCharacter->m_aWeapons[Weapon].m_Got)
+				continue;
+			if(!InitialOffsetAdded)
+			{
+				x += aWeaponInitialOffset[Weapon];
+				InitialOffsetAdded = true;
+			}
+			if(pPlayer->m_Weapon != Weapon)
+				Graphics()->SetColor(1.0f, 1.0f, 1.0f, 0.4f);
+			Graphics()->QuadsSetRotation(pi * 7 / 4);
+			Graphics()->TextureSet(m_pClient->m_GameSkin.m_aSpritePickupWeapons[Weapon]);
+			Graphics()->RenderQuadContainerAsSprite(m_HudQuadContainerIndex, m_aWeaponOffset[Weapon], x, y);
+			Graphics()->QuadsSetRotation(0);
+			Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
+			x += aWeaponWidth[Weapon];
 		}
-		x -= 3;
-		Graphics()->QuadsSetRotation(pi * 7 / 4);
-		Graphics()->TextureSet(m_pClient->m_GameSkin.m_SpritePickupHammer);
-		Graphics()->RenderQuadContainerAsSprite(m_HudQuadContainerIndex, m_aWeaponOffset[WEAPON_HAMMER], x, y);
-		Graphics()->QuadsSetRotation(0);
-		Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
-		x += 16;
-	}
-	if(pCharacter->m_aWeapons[WEAPON_GUN].m_Got)
-	{
-		if(pPlayer->m_Weapon != WEAPON_GUN)
+		if(pCharacter->m_aWeapons[WEAPON_NINJA].m_Got)
 		{
-			Graphics()->SetColor(1.0f, 1.0f, 1.0f, 0.4f);
-		}
-		Graphics()->QuadsSetRotation(pi * 7 / 4);
-		Graphics()->TextureSet(m_pClient->m_GameSkin.m_SpritePickupGun);
-		Graphics()->RenderQuadContainerAsSprite(m_HudQuadContainerIndex, m_aWeaponOffset[WEAPON_GUN], x, y);
-		Graphics()->QuadsSetRotation(0);
-		Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
-		x += 12;
-	}
-	if(pCharacter->m_aWeapons[WEAPON_SHOTGUN].m_Got)
-	{
-		if(pPlayer->m_Weapon != WEAPON_SHOTGUN)
-		{
-			Graphics()->SetColor(1.0f, 1.0f, 1.0f, 0.4f);
-		}
-		Graphics()->QuadsSetRotation(pi * 7 / 4);
-		Graphics()->TextureSet(m_pClient->m_GameSkin.m_SpritePickupShotgun);
-		Graphics()->RenderQuadContainerAsSprite(m_HudQuadContainerIndex, m_aWeaponOffset[WEAPON_SHOTGUN], x, y);
-		Graphics()->QuadsSetRotation(0);
-		Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
-		x += 12;
-	}
-	if(pCharacter->m_aWeapons[WEAPON_GRENADE].m_Got)
-	{
-		if(pPlayer->m_Weapon != WEAPON_GRENADE)
-		{
-			Graphics()->SetColor(1.0f, 1.0f, 1.0f, 0.4f);
-		}
-		Graphics()->QuadsSetRotation(pi * 7 / 4);
-		Graphics()->TextureSet(m_pClient->m_GameSkin.m_SpritePickupGrenade);
-		Graphics()->RenderQuadContainerAsSprite(m_HudQuadContainerIndex, m_aWeaponOffset[WEAPON_GRENADE], x, y);
-		Graphics()->QuadsSetRotation(0);
-		Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
-		x += 12;
-	}
-	if(pCharacter->m_aWeapons[WEAPON_LASER].m_Got)
-	{
-		if(pPlayer->m_Weapon != WEAPON_LASER)
-		{
-			Graphics()->SetColor(1.0f, 1.0f, 1.0f, 0.4f);
-		}
-		Graphics()->QuadsSetRotation(pi * 7 / 4);
-		Graphics()->TextureSet(m_pClient->m_GameSkin.m_SpritePickupLaser);
-		Graphics()->RenderQuadContainerAsSprite(m_HudQuadContainerIndex, m_aWeaponOffset[WEAPON_LASER], x, y);
-		Graphics()->QuadsSetRotation(0);
-		Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
-		x += 12;
-	}
-	if(pCharacter->m_aWeapons[WEAPON_NINJA].m_Got)
-	{
-		if(pPlayer->m_Weapon != WEAPON_NINJA)
-		{
-			Graphics()->SetColor(1.0f, 1.0f, 1.0f, 0.4f);
-		}
-		Graphics()->QuadsSetRotation(pi * 7 / 4);
-		Graphics()->TextureSet(m_pClient->m_GameSkin.m_SpritePickupNinja);
-		Graphics()->RenderQuadContainerAsSprite(m_HudQuadContainerIndex, m_aWeaponOffset[WEAPON_NINJA], x, y);
-		Graphics()->QuadsSetRotation(0);
-		Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
-		x += 12;
-	}
-	if(pCharacter->m_aWeapons[WEAPON_NINJA].m_Got)
-	{
-		const int Max = g_pData->m_Weapons.m_Ninja.m_Duration * Client()->GameTickSpeed() / 1000;
-		float NinjaProgress = clamp(pCharacter->m_Ninja.m_ActivationTick + g_pData->m_Weapons.m_Ninja.m_Duration * Client()->GameTickSpeed() / 1000 - Client()->GameTick(g_Config.m_ClDummy), 0, Max) / (float)Max;
-		if(NinjaProgress > 0.0f && m_pClient->m_Snap.m_aCharacters[ClientID].m_HasExtendedDisplayInfo)
-		{
-			RenderNinjaBarPos(x, y - 12, 6.f, 24.f, NinjaProgress);
+			const int Max = g_pData->m_Weapons.m_Ninja.m_Duration * Client()->GameTickSpeed() / 1000;
+			float NinjaProgress = clamp(pCharacter->m_Ninja.m_ActivationTick + g_pData->m_Weapons.m_Ninja.m_Duration * Client()->GameTickSpeed() / 1000 - Client()->GameTick(g_Config.m_ClDummy), 0, Max) / (float)Max;
+			if(NinjaProgress > 0.0f && m_pClient->m_Snap.m_aCharacters[ClientID].m_HasExtendedDisplayInfo)
+			{
+				RenderNinjaBarPos(x, y - 12, 6.f, 24.f, NinjaProgress);
+			}
 		}
 	}
 

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -952,12 +952,14 @@ void CHud::RenderPlayerState(const int ClientID)
 		Graphics()->RenderQuadContainerAsSprite(m_HudQuadContainerIndex, m_aWeaponOffset[WEAPON_NINJA], x, y);
 		Graphics()->QuadsSetRotation(0);
 		Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
-
+		x += 12;
+	}
+	if(pCharacter->m_aWeapons[WEAPON_NINJA].m_Got)
+	{
 		const int Max = g_pData->m_Weapons.m_Ninja.m_Duration * Client()->GameTickSpeed() / 1000;
 		float NinjaProgress = clamp(pCharacter->m_Ninja.m_ActivationTick + g_pData->m_Weapons.m_Ninja.m_Duration * Client()->GameTickSpeed() / 1000 - Client()->GameTick(g_Config.m_ClDummy), 0, Max) / (float)Max;
 		if(NinjaProgress > 0.0f && m_pClient->m_Snap.m_aCharacters[ClientID].m_HasExtendedDisplayInfo)
 		{
-			x += 12;
 			RenderNinjaBarPos(x, y - 12, 6.f, 24.f, NinjaProgress);
 		}
 	}

--- a/src/game/client/components/hud.h
+++ b/src/game/client/components/hud.h
@@ -111,12 +111,7 @@ private:
 	int m_FlagOffset;
 	int m_AirjumpOffset;
 	int m_AirjumpEmptyOffset;
-	int m_WeaponHammerOffset;
-	int m_WeaponGunOffset;
-	int m_WeaponShotgunOffset;
-	int m_WeaponGrenadeOffset;
-	int m_WeaponLaserOffset;
-	int m_WeaponNinjaOffset;
+	int m_aWeaponOffset[NUM_WEAPONS];
 	int m_EndlessJumpOffset;
 	int m_EndlessHookOffset;
 	int m_JetpackOffset;


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->
The proper offset for the first available weapon is provided only for Hammer but sometimes (in some mods) the character has no hammer and the icons got a wrong left margin.

### Current code

https://github.com/ddnet/ddnet/blob/83a2ad0e2482d39ff26fcf08c148b4ffeec05277/src/game/client/components/hud.cpp#L882-L895

Notice the `x -= 3;` in the hammer rendering branch. It fixes the `x` offset for this and further weapons but it works only if the character has a hammer (other weapons has no such line).
`-3` is specific for the hammer, we need different "first item" offsets for other weapons.

## Before

![image](https://github.com/ddnet/ddnet/assets/374839/419f97be-d1e3-4eff-94a6-387e89d6ef64)
(the hammer offset is _correct_)

![image](https://github.com/ddnet/ddnet/assets/374839/400ab01f-02a2-4d2a-bd6f-97806e12cbef)
but if the character has no hammer then the things go _wrong_.

![image](https://github.com/ddnet/ddnet/assets/374839/262e45a5-cee8-45b9-bd8b-a982761a5dc5)
Shotgun/Grenade Launcher/Laser has just a small offset but the _wrong_ placement of katana indicator if very noticeable.

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## After
![image](https://github.com/ddnet/ddnet/assets/374839/af24c361-228e-4461-b7ea-0b4531ffedf0)
(no difference in the hammer icon rendering)

![image](https://github.com/ddnet/ddnet/assets/374839/04b30b2e-5560-431d-a949-b37b63e27b9e)
(fixed gun offset)

![image](https://github.com/ddnet/ddnet/assets/374839/5abb5be3-212c-48b1-9c78-169441d6442e)
(fixed shotgun offset)

![image](https://github.com/ddnet/ddnet/assets/374839/918ef960-162e-4942-916f-b8eb9802c2e4)
(fixed grenade launcher offset)

![image](https://github.com/ddnet/ddnet/assets/374839/7a8e1257-590b-4589-877a-51f90298d6f7)
(fixed laser offset)

![image](https://github.com/ddnet/ddnet/assets/374839/157258b6-f7de-4411-8b63-140083b883c3)
(fixed katana offset)

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
