### PR TITLE
Improve demo browser layout

### DIFF
--- a/src/game/client/ui_listbox.cpp
+++ b/src/game/client/ui_listbox.cpp
@@ -60,7 +60,7 @@ void CListBox::DoFooter(const char *pBottomText, float FooterHeight)
 	m_FooterHeight = FooterHeight;
 }
 
-void CListBox::DoStart(float RowHeight, int NumItems, int ItemsPerRow, int RowsPerScroll, int SelectedIndex, const CUIRect *pRect, bool Background, int BackgroundCorners)
+void CListBox::DoStart(float RowHeight, int NumItems, int ItemsPerRow, int RowsPerScroll, int SelectedIndex, const CUIRect *pRect, bool Background, int BackgroundCorners, bool ForceShowScrollbar)
 {
 	CUIRect View;
 	if(pRect)
@@ -119,6 +119,7 @@ void CListBox::DoStart(float RowHeight, int NumItems, int ItemsPerRow, int RowsP
 	ScrollParams.m_Active = m_Active;
 	ScrollParams.m_ScrollbarWidth = ScrollbarWidthMax();
 	ScrollParams.m_ScrollUnit = (m_ListBoxRowHeight + m_AutoSpacing) * RowsPerScroll;
+	ScrollParams.m_Flags = ForceShowScrollbar ? CScrollRegionParams::FLAG_CONTENT_STATIC_WIDTH : 0;
 	m_ScrollRegion.Begin(&m_ListBoxView, &m_ScrollOffset, &ScrollParams);
 	m_ListBoxView.y += m_ScrollOffset.y;
 }

--- a/src/game/client/ui_listbox.h
+++ b/src/game/client/ui_listbox.h
@@ -51,7 +51,7 @@ public:
 	void DoAutoSpacing(float Spacing = 20.0f) { m_AutoSpacing = Spacing; }
 	void DoSpacing(float Spacing = 20.0f);
 	void DoFooter(const char *pBottomText, float FooterHeight = 20.0f); // call before DoStart to create a footer
-	void DoStart(float RowHeight, int NumItems, int ItemsPerRow, int RowsPerScroll, int SelectedIndex, const CUIRect *pRect = nullptr, bool Background = true, int BackgroundCorners = IGraphics::CORNER_ALL);
+	void DoStart(float RowHeight, int NumItems, int ItemsPerRow, int RowsPerScroll, int SelectedIndex, const CUIRect *pRect = nullptr, bool Background = true, int BackgroundCorners = IGraphics::CORNER_ALL, bool ForceShowScrollbar = false);
 	void ScrollToSelected() { m_ListBoxUpdateScroll = true; }
 	CListboxItem DoNextItem(const void *pID, bool Selected = false);
 	CListboxItem DoSubheader();


### PR DESCRIPTION
Use separate columns for icons and spacing like in the server browser.

Always show scrollbar for more consistent layout.

Show ellipsis if filename is too long, also for the filename shown in the demo player.

Hide number of markers and length if the demo is invalid.

Screenshots:
- Browser:
   - Before:
![Browser old](https://github.com/ddnet/ddnet/assets/23437060/55f4de41-e225-43eb-b07d-435cb4f9292d)
   - After:
![Browser new2](https://github.com/ddnet/ddnet/assets/23437060/56005b8c-a4e9-47eb-80a3-50013a856852)
- Player:
   - Before:
![Player old](https://github.com/ddnet/ddnet/assets/23437060/ef74c873-a62a-4184-8f90-08289ab2b829)
   - After:
![Player new2](https://github.com/ddnet/ddnet/assets/23437060/54f06bfa-28a8-480a-9125-f5ff9ffc81e0)

## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
