### PR TITLE
Improve demo (video) renderer UX

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -3912,7 +3912,7 @@ const char *CClient::DemoPlayer_Render(const char *pFilename, int StorageType, c
 
 	this->CClient::StartVideo(NULL, this, pVideoName);
 	m_DemoPlayer.Play();
-	m_DemoPlayer.SetSpeed(g_aSpeeds[SpeedIndex]);
+	m_DemoPlayer.SetSpeedIndex(SpeedIndex);
 	//m_pConsole->Print(IConsole::OUTPUT_LEVEL_DEBUG, "demo_recorder", "demo eof");
 	return 0;
 }

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -3913,6 +3913,10 @@ const char *CClient::DemoPlayer_Render(const char *pFilename, int StorageType, c
 	this->CClient::StartVideo(NULL, this, pVideoName);
 	m_DemoPlayer.Play();
 	m_DemoPlayer.SetSpeedIndex(SpeedIndex);
+	if(Config()->m_ClVideoPauseOnStart)
+	{
+		m_DemoPlayer.Pause();
+	}
 	//m_pConsole->Print(IConsole::OUTPUT_LEVEL_DEBUG, "demo_recorder", "demo eof");
 	return 0;
 }

--- a/src/engine/demo.h
+++ b/src/engine/demo.h
@@ -84,7 +84,8 @@ public:
 
 	~IDemoPlayer() {}
 	virtual void SetSpeed(float Speed) = 0;
-	virtual void SetSpeedIndex(int Offset) = 0;
+	virtual void SetSpeedIndex(int SpeedIndex) = 0;
+	virtual void AdjustSpeedIndex(int Offset) = 0;
 	virtual int SeekPercent(float Percent) = 0;
 	virtual int SeekTime(float Seconds) = 0;
 	virtual int SeekTick(ETickOffset TickOffset) = 0;

--- a/src/engine/shared/datafile.cpp
+++ b/src/engine/shared/datafile.cpp
@@ -611,7 +611,7 @@ int CDataFileWriter::GetExtendedItemTypeIndex(int Type)
 	return Index;
 }
 
-int CDataFileWriter::AddItem(int Type, int ID, int Size, void *pData)
+int CDataFileWriter::AddItem(int Type, int ID, int Size, const void *pData)
 {
 	dbg_assert((Type >= 0 && Type < MAX_ITEM_TYPES) || Type >= OFFSET_UUID, "incorrect type");
 	dbg_assert(m_NumItems < 1024, "too many items");
@@ -650,7 +650,7 @@ int CDataFileWriter::AddItem(int Type, int ID, int Size, void *pData)
 	return m_NumItems - 1;
 }
 
-int CDataFileWriter::AddData(int Size, void *pData, int CompressionLevel)
+int CDataFileWriter::AddData(int Size, const void *pData, int CompressionLevel)
 {
 	dbg_assert(m_NumDatas < 1024, "too much data");
 
@@ -666,7 +666,7 @@ int CDataFileWriter::AddData(int Size, void *pData, int CompressionLevel)
 	return m_NumDatas - 1;
 }
 
-int CDataFileWriter::AddDataSwapped(int Size, void *pData)
+int CDataFileWriter::AddDataSwapped(int Size, const void *pData)
 {
 	dbg_assert(Size % sizeof(int) == 0, "incorrect boundary");
 

--- a/src/engine/shared/datafile.h
+++ b/src/engine/shared/datafile.h
@@ -126,9 +126,9 @@ public:
 	void Init();
 	bool OpenFile(class IStorage *pStorage, const char *pFilename, int StorageType = IStorage::TYPE_SAVE);
 	bool Open(class IStorage *pStorage, const char *pFilename, int StorageType = IStorage::TYPE_SAVE);
-	int AddData(int Size, void *pData, int CompressionLevel = Z_DEFAULT_COMPRESSION);
-	int AddDataSwapped(int Size, void *pData);
-	int AddItem(int Type, int ID, int Size, void *pData);
+	int AddData(int Size, const void *pData, int CompressionLevel = Z_DEFAULT_COMPRESSION);
+	int AddDataSwapped(int Size, const void *pData);
+	int AddItem(int Type, int ID, int Size, const void *pData);
 	void Finish();
 };
 

--- a/src/engine/shared/demo.cpp
+++ b/src/engine/shared/demo.cpp
@@ -1006,10 +1006,16 @@ void CDemoPlayer::SetSpeed(float Speed)
 	m_Info.m_Info.m_Speed = clamp(Speed, 0.f, 256.f);
 }
 
-void CDemoPlayer::SetSpeedIndex(int Offset)
+void CDemoPlayer::SetSpeedIndex(int SpeedIndex)
 {
-	m_SpeedIndex = clamp(m_SpeedIndex + Offset, 0, (int)(std::size(g_aSpeeds) - 1));
+	dbg_assert(SpeedIndex >= 0 && SpeedIndex < g_DemoSpeeds, "invalid SpeedIndex");
+	m_SpeedIndex = SpeedIndex;
 	SetSpeed(g_aSpeeds[m_SpeedIndex]);
+}
+
+void CDemoPlayer::AdjustSpeedIndex(int Offset)
+{
+	SetSpeedIndex(clamp(m_SpeedIndex + Offset, 0, (int)(std::size(g_aSpeeds) - 1)));
 }
 
 int CDemoPlayer::Update(bool RealTime)

--- a/src/engine/shared/demo.h
+++ b/src/engine/shared/demo.h
@@ -139,7 +139,8 @@ public:
 	void Unpause() override;
 	int Stop();
 	void SetSpeed(float Speed) override;
-	void SetSpeedIndex(int Offset) override;
+	void SetSpeedIndex(int SpeedIndex) override;
+	void AdjustSpeedIndex(int Offset) override;
 	int SeekPercent(float Percent) override;
 	int SeekTime(float Seconds) override;
 	int SeekTick(ETickOffset TickOffset) override;

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -1558,7 +1558,7 @@ int CMenus::Render()
 #if defined(CONF_VIDEORECORDER)
 		else if(m_Popup == POPUP_RENDER_DEMO)
 		{
-			CUIRect Label, TextBox, Ok, Abort, IncSpeed, DecSpeed, Button;
+			CUIRect Label, TextBox, Ok, Abort, Button;
 
 			Box.HSplitBottom(20.f, &Box, &Part);
 #if defined(__ANDROID__)
@@ -1614,14 +1614,9 @@ int CMenus::Render()
 				g_Config.m_ClVideoSndEnable ^= 1;
 
 			Box.HSplitBottom(20.f, &Box, &Part);
-			Part.VSplitLeft(60.0f, 0, &Part);
+			Part.VSplitLeft(55.0f, 0, &Part);
 			Part.VSplitLeft(60.0f, 0, &Label);
-			Part.VSplitMid(&IncSpeed, &DecSpeed);
 
-			IncSpeed.VMargin(20.0f, &IncSpeed);
-			DecSpeed.VMargin(20.0f, &DecSpeed);
-
-			Part.VSplitLeft(20.0f, &Button, &Part);
 			bool IncDemoSpeed = false, DecDemoSpeed = false;
 			// slowdown
 			Part.VSplitLeft(5.0f, 0, &Part);
@@ -1629,6 +1624,13 @@ int CMenus::Render()
 			static CButtonContainer s_SlowDownButton;
 			if(DoButton_FontIcon(&s_SlowDownButton, FONT_ICON_BACKWARD, 0, &Button, IGraphics::CORNER_ALL))
 				DecDemoSpeed = true;
+
+			// paused
+			Part.VSplitLeft(5.0f, 0, &Part);
+			Part.VSplitLeft(ButtonSize, &Button, &Part);
+			static CButtonContainer s_PausedButton;
+			if(DoButton_FontIcon(&s_PausedButton, FONT_ICON_PAUSE, 0, &Button, IGraphics::CORNER_ALL))
+				g_Config.m_ClVideoPauseOnStart ^= 1;
 
 			// fastforward
 			Part.VSplitLeft(5.0f, 0, &Part);
@@ -1639,8 +1641,9 @@ int CMenus::Render()
 
 			// speed meter
 			Part.VSplitLeft(8.0f, 0, &Part);
-			char aBuffer[64];
-			str_format(aBuffer, sizeof(aBuffer), "%s: ×%g", Localize("Speed"), g_aSpeeds[m_Speed]);
+			char aBuffer[128];
+			const char *pPaused = g_Config.m_ClVideoPauseOnStart ? Localize("(paused)") : "";
+			str_format(aBuffer, sizeof(aBuffer), "%s: ×%g %s", Localize("Speed"), g_aSpeeds[m_Speed], pPaused);
 			UI()->DoLabel(&Part, aBuffer, 12.8f, TEXTALIGN_ML);
 
 			if(IncDemoSpeed)

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -119,12 +119,12 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 		{
 			if(Input()->KeyPress(KEY_MOUSE_WHEEL_UP) || Input()->KeyPress(KEY_UP))
 			{
-				DemoPlayer()->SetSpeedIndex(+1);
+				DemoPlayer()->AdjustSpeedIndex(+1);
 				s_LastSpeedChange = time_get();
 			}
 			else if(Input()->KeyPress(KEY_MOUSE_WHEEL_DOWN) || Input()->KeyPress(KEY_DOWN))
 			{
-				DemoPlayer()->SetSpeedIndex(-1);
+				DemoPlayer()->AdjustSpeedIndex(-1);
 				s_LastSpeedChange = time_get();
 			}
 		}
@@ -597,12 +597,12 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 
 	if(IncreaseDemoSpeed)
 	{
-		DemoPlayer()->SetSpeedIndex(+1);
+		DemoPlayer()->AdjustSpeedIndex(+1);
 		s_LastSpeedChange = time_get();
 	}
 	else if(DecreaseDemoSpeed)
 	{
-		DemoPlayer()->SetSpeedIndex(-1);
+		DemoPlayer()->AdjustSpeedIndex(-1);
 		s_LastSpeedChange = time_get();
 	}
 

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -1314,7 +1314,9 @@ void CMenus::RenderDemoList(CUIRect MainView)
 		if(DoButton_Menu(&s_RenderButton, Localize("Render"), 0, &RenderRect) || (Input()->KeyPress(KEY_R) && m_pClient->m_GameConsole.IsClosed()))
 		{
 			m_Popup = POPUP_RENDER_DEMO;
-			m_DemoRenderInput.Set(m_vDemos[m_DemolistSelectedIndex].m_aFilename);
+			char aNameWithoutExt[IO_MAX_PATH_LENGTH];
+			fs_split_file_extension(m_vDemos[m_DemolistSelectedIndex].m_aFilename, aNameWithoutExt, sizeof(aNameWithoutExt));
+			m_DemoRenderInput.Set(aNameWithoutExt);
 			UI()->SetActiveItem(&m_DemoRenderInput);
 			return;
 		}

--- a/src/game/editor/io.cpp
+++ b/src/game/editor/io.cpp
@@ -192,7 +192,7 @@ bool CEditorMap::Save(const char *pFileName)
 		GItemEx.m_Version = CMapItemGroupEx::CURRENT_VERSION;
 		GItemEx.m_ParallaxZoom = pGroup->m_ParallaxZoom;
 
-		for(const auto &pLayer : pGroup->m_vpLayers)
+		for(CLayer *pLayer : pGroup->m_vpLayers)
 		{
 			if(pLayer->m_Type == LAYERTYPE_TILES)
 			{

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -3785,7 +3785,7 @@ void CGameContext::OnMapChange(char *pNewMapName, int MapNameSize)
 			Writer.AddData(TotalLength, pSettings);
 			continue;
 		}
-		unsigned char *pData = (unsigned char *)Reader.GetData(i);
+		const void *pData = Reader.GetData(i);
 		int Size = Reader.GetDataSize(i);
 		Writer.AddData(Size, pData);
 		Reader.UnloadData(i);

--- a/src/game/variables.h
+++ b/src/game/variables.h
@@ -211,6 +211,7 @@ MACRO_CONFIG_INT(ClVideoPauseWithDemo, cl_video_pausewithdemo, 1, 0, 1, CFGFLAG_
 MACRO_CONFIG_INT(ClVideoShowhud, cl_video_showhud, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show ingame HUD when rendering video")
 MACRO_CONFIG_INT(ClVideoShowChat, cl_video_showchat, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show chat when rendering video")
 MACRO_CONFIG_INT(ClVideoSndEnable, cl_video_sound_enable, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Use sound when rendering video")
+MACRO_CONFIG_INT(ClVideoPauseOnStart, cl_video_pause_on_start, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Pause video rendering on start")
 MACRO_CONFIG_INT(ClVideoShowHookCollOther, cl_video_show_hook_coll_other, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show other players' hook collision lines when rendering video")
 MACRO_CONFIG_INT(ClVideoShowDirection, cl_video_show_direction, 0, 0, 2, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show players' key presses when rendering video (1 = other players', 2 = also your own)")
 MACRO_CONFIG_INT(ClVideoX264Crf, cl_video_crf, 18, 0, 51, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Set crf when encode video with libx264 (0 for highest quality, 51 for lowest)")

--- a/src/tools/map_resave.cpp
+++ b/src/tools/map_resave.cpp
@@ -24,7 +24,7 @@ int main(int argc, const char **argv)
 	for(int Index = 0; Index < Reader.NumItems(); Index++)
 	{
 		int Type, ID;
-		void *pPtr = Reader.GetItem(Index, &Type, &ID);
+		const void *pPtr = Reader.GetItem(Index, &Type, &ID);
 
 		// filter ITEMTYPE_EX items, they will be automatically added again
 		if(Type == ITEMTYPE_EX)
@@ -37,7 +37,7 @@ int main(int argc, const char **argv)
 	// add all data
 	for(int Index = 0; Index < Reader.NumData(); Index++)
 	{
-		void *pPtr = Reader.GetData(Index);
+		const void *pPtr = Reader.GetData(Index);
 		int Size = Reader.GetDataSize(Index);
 		Writer.AddData(Size, pPtr);
 	}


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->
In this MR I want to address three issues with video recorder:
1. A bug: if I start a rendering with 0.25x speed and click on 'Increase the speed' during the rendering, I expect to get the next speed (0.5x) but as the speed index is not set (kept default `4`), the speed is boosted to 1.25x.
2. Usecase: I want to adjust the camera (change position, decrease zoom, etc) for the demos and I don't want to use extra video editor to cut the first frames with the unwanted camera moves/setups from the demo. I came to a simple solution: start the rendering pre-paused to do the needed adjustments before anything is added to the video.
3. NotABug: All recorded video files have double `.demo.mp4` extension which is ugly.

Probably I have to change something to fit DDNet codebase. E.g. I don't know if `Localize("(paused)")` is acceptable here.

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Before
![image](https://github.com/ddnet/ddnet/assets/374839/7273dd5b-e3d1-4f73-87bd-e09493d106a0)

## After
![image](https://github.com/ddnet/ddnet/assets/374839/7d62028d-04bc-45af-babf-5a2e8cb243dc)

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
