### PR TITLE
Fix editor crashes with quad point and other popup menus

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -6577,6 +6577,7 @@ void CEditor::RenderMousePointer()
 
 void CEditor::Reset(bool CreateDefault)
 {
+	UI()->ClosePopupMenus();
 	m_Map.Clean();
 
 	mem_zero(m_apSavedBrushes, sizeof m_apSavedBrushes);

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -6579,10 +6579,6 @@ void CEditor::Reset(bool CreateDefault)
 {
 	m_Map.Clean();
 
-	//delete undo file
-	char aBuffer[1024];
-	m_pStorage->GetCompletePath(IStorage::TYPE_SAVE, "editor/", aBuffer, sizeof(aBuffer));
-
 	mem_zero(m_apSavedBrushes, sizeof m_apSavedBrushes);
 
 	// create default layers

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -1199,6 +1199,8 @@ CUI::EPopupMenuFunctionResult CEditor::PopupPoint(void *pContext, CUIRect View, 
 {
 	CEditor *pEditor = static_cast<CEditor *>(pContext);
 	std::vector<CQuad *> vpQuads = pEditor->GetSelectedQuads();
+	if(!in_range<int>(pEditor->m_SelectedQuadIndex, 0, vpQuads.size() - 1))
+		return CUI::POPUP_CLOSE_CURRENT;
 	CQuad *pCurrentQuad = vpQuads[pEditor->m_SelectedQuadIndex];
 
 	enum


### PR DESCRIPTION
Closes #6817.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
