### PR TITLE
Improve Multi-View UX

### DIFF
--- a/src/game/client/components/spectator.h
+++ b/src/game/client/components/spectator.h
@@ -16,12 +16,15 @@ class CSpectator : public CComponent
 
 	bool m_Active;
 	bool m_WasActive;
+	bool m_Clicked;
 
 	int m_SelectedSpectatorID;
 	vec2 m_SelectorMouse;
 
 	float m_OldMouseX;
 	float m_OldMouseY;
+
+	float m_MultiViewActivateDelay;
 
 	bool CanChangeSpectator();
 	void SpectateNext(bool Reverse);
@@ -42,8 +45,10 @@ public:
 	virtual void OnRender() override;
 	virtual void OnRelease() override;
 	virtual void OnReset() override;
+	virtual bool OnInput(const IInput::CEvent &Event) override;
 
 	void Spectate(int SpectatorID);
+	void SpectateClosest();
 };
 
 #endif

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -642,10 +642,13 @@ void CGameClient::OnRender()
 		if(m_Snap.m_SpecInfo.m_SpectatorID >= 0)
 			TeamId = m_Teams.Team(m_Snap.m_SpecInfo.m_SpectatorID);
 
-		if(!InitMultiViewFromFreeview(TeamId))
+		if(TeamId > MAX_CLIENTS || TeamId < 0)
+			TeamId = 0;
+
+		if(!InitMultiView(TeamId))
 		{
 			dbg_msg("MultiView", "No players found to spectate");
-			m_MultiViewActivated = false;
+			ResetMultiView();
 		}
 	}
 
@@ -868,13 +871,29 @@ void CGameClient::OnMessage(int MsgId, CUnpacker *pUnpacker, int Conn, bool Dumm
 		// if we are spectating a static id set (team 0) and somebody killed, we remove him from the list
 		if(IsMultiViewIdSet() && m_aMultiViewId[pMsg->m_Victim] && !m_aClients[pMsg->m_Victim].m_Spec)
 		{
-			// is multi view even activated and we are not spectating a solo guy
-			if(m_MultiViewActivated && !m_MultiView.m_Solo && m_MultiView.m_Team == 0)
+			// is multi-view even activated and we are not spectating a solo guy
+			if(m_MultiViewActivated && !m_MultiView.m_Solo)
+			{
 				m_aMultiViewId[pMsg->m_Victim] = false;
 
-			// if everyone of a team killed, we have no ids to spectate anymore, so we disable multi view
-			if(!IsMultiViewIdSet())
-				m_MultiViewActivated = false;
+				// if everyone of a team killed, we have no ids to spectate anymore, so we disable multi-view
+				if(!IsMultiViewIdSet())
+					m_MultiViewActivated = false;
+				else
+				{
+					// the "main" tee killed, search a new one
+					if(m_Snap.m_SpecInfo.m_SpectatorID == pMsg->m_Victim)
+					{
+						int NewClientID = FindFirstMultiViewId();
+						if(NewClientID < MAX_CLIENTS && NewClientID >= 0)
+						{
+							CleanMultiViewId(NewClientID);
+							m_aMultiViewId[NewClientID] = true;
+							m_Spectator.Spectate(NewClientID);
+						}
+					}
+				}
+			}
 		}
 	}
 }
@@ -1701,7 +1720,7 @@ void CGameClient::OnNewSnapshot()
 		m_aDDRaceMsgSent[i] = true;
 	}
 
-	if(m_MultiViewActivated)
+	if(m_Snap.m_SpecInfo.m_Active && m_MultiViewActivated)
 	{
 		// dont show other teams while spectating in multi view
 		CNetMsg_Cl_ShowOthers Msg;
@@ -3425,7 +3444,7 @@ void CGameClient::HandleMultiView()
 			continue;
 
 		// the player is not in the team we are spectating
-		if(m_Teams.Team(i) != m_MultiView.m_Team)
+		if(m_Teams.Team(i) != m_MultiViewTeam)
 			continue;
 
 		vec2 PlayerPos;
@@ -3443,7 +3462,12 @@ void CGameClient::HandleMultiView()
 			if(m_MultiView.m_aLastFreeze[i] == 0.0f)
 				m_MultiView.m_aLastFreeze[i] = Client()->LocalTime();
 			else if(m_MultiView.m_aLastFreeze[i] + 3.0f <= Client()->LocalTime())
+			{
 				m_MultiView.m_aVanish[i] = true;
+				// player we want to be vanished is our "main" tee, so lets switch the tee
+				if(i == m_Snap.m_SpecInfo.m_SpectatorID)
+					m_Spectator.Spectate(FindFirstMultiViewId());
+			}
 		}
 		else if(m_MultiView.m_aLastFreeze[i] != 0)
 			m_MultiView.m_aLastFreeze[i] = 0;
@@ -3472,9 +3496,17 @@ void CGameClient::HandleMultiView()
 	// if we have found no players, we disable multi view
 	if(AmountPlayers == 0)
 	{
-		m_MultiViewActivated = false;
+		if(m_MultiView.m_SecondChance == 0.0f)
+			m_MultiView.m_SecondChance = Client()->LocalTime() + 0.3f;
+		else if(m_MultiView.m_SecondChance < Client()->LocalTime())
+		{
+			m_MultiViewActivated = false;
+			return;
+		}
 		return;
 	}
+	else if(m_MultiView.m_SecondChance != 0.0f)
+		m_MultiView.m_SecondChance = 0.0f;
 
 	vec2 TargetPos = vec2((Minpos.x + Maxpos.x) / 2.0f, (Minpos.y + Maxpos.y) / 2.0f);
 	// dont hide the position hud if its only one player
@@ -3492,7 +3524,7 @@ void CGameClient::HandleMultiView()
 	m_Snap.m_SpecInfo.m_UsePosition = true;
 }
 
-bool CGameClient::InitMultiViewFromFreeview(int Team)
+bool CGameClient::InitMultiView(int Team)
 {
 	float Width, Height;
 	CleanMultiViewIds();
@@ -3503,10 +3535,13 @@ bool CGameClient::InitMultiViewFromFreeview(int Team)
 	vec2 AxisX = vec2(m_Camera.m_Center.x - (Width / 2), m_Camera.m_Center.x + (Width / 2));
 	vec2 AxisY = vec2(m_Camera.m_Center.y - (Height / 2), m_Camera.m_Center.y + (Height / 2));
 
-	m_MultiView.m_Team = Team;
+	m_MultiViewTeam = Team;
 
 	if(Team > 0)
-		return true; // spectating a team, not necessary to search the players in view
+	{
+		for(int i = 0; i < MAX_CLIENTS; i++)
+			m_aMultiViewId[i] = m_Teams.Team(i) == Team;
+	}
 	else
 	{
 		int Count = 0;
@@ -3539,22 +3574,71 @@ bool CGameClient::InitMultiViewFromFreeview(int Team)
 
 		// we are spectating only one player
 		m_MultiView.m_Solo = Count == 1;
-
-		// found players to spectate
-		return Count > 0;
 	}
+
+	if(!g_Config.m_ClMultiViewUseFreeView && IsMultiViewIdSet())
+	{
+		int SpectatorID = m_Snap.m_SpecInfo.m_SpectatorID;
+		int NewSpectatorID = -1;
+
+		vec2 CurPosition(m_Camera.m_Center);
+		if(SpectatorID != SPEC_FREEVIEW)
+		{
+			const CNetObj_Character &CurCharacter = m_Snap.m_aCharacters[SpectatorID].m_Cur;
+			CurPosition.x = CurCharacter.m_X;
+			CurPosition.y = CurCharacter.m_Y;
+		}
+
+		int ClosestDistance = INT_MAX;
+		for(int i = 0; i < MAX_CLIENTS; i++)
+		{
+			if(!m_Snap.m_apPlayerInfos[i] || m_Snap.m_apPlayerInfos[i]->m_Team == TEAM_SPECTATORS || m_Teams.Team(i) != Team)
+				continue;
+
+			vec2 PlayerPos;
+			if(m_Snap.m_aCharacters[i].m_Active)
+				PlayerPos = vec2(m_aClients[i].m_RenderPos.x, m_aClients[i].m_RenderPos.y);
+			else if(m_aClients[i].m_Spec) // tee is in spec
+				PlayerPos = m_aClients[i].m_SpecChar;
+			else
+				continue;
+
+			int Distance = distance(CurPosition, PlayerPos);
+			if(NewSpectatorID == -1 || Distance < ClosestDistance)
+			{
+				NewSpectatorID = i;
+				ClosestDistance = Distance;
+			}
+		}
+
+		if(NewSpectatorID > -1)
+			m_Spectator.Spectate(NewSpectatorID);
+	}
+
+	return IsMultiViewIdSet();
 }
 
-float CGameClient::CalculateMultiViewMultiplier(vec2 CameraPos)
+float CGameClient::CalculateMultiViewMultiplier(vec2 TargetPos)
 {
 	float MaxCameraDist = 200.0f;
 	float MinCameraDist = 20.0f;
-	float MaxVel = 0.1f;
+	float MaxVel = g_Config.m_ClMultiViewSensitivity / 150.0f;
 	float MinVel = 0.007f;
+	float CurrentCameraDistance = distance(m_MultiView.m_OldPos, TargetPos);
+	float UpperLimit = 1.0f;
 
-	float CurrentCameraDistance = distance(m_MultiView.m_OldPos, CameraPos);
+	if(m_MultiView.m_Teleported && CurrentCameraDistance <= 100)
+		m_MultiView.m_Teleported = false;
 
-	return clamp(MapValue(MaxCameraDist, MinCameraDist, MaxVel, MinVel, CurrentCameraDistance), MinVel, 1.0f);
+	// somebody got teleported very likely
+	if((m_MultiView.m_Teleported || CurrentCameraDistance - m_MultiView.m_OldCameraDistance > 100) && m_MultiView.m_OldCameraDistance != 0.0f)
+	{
+		UpperLimit = 0.1f; // dont try to compensate it by flickering
+		m_MultiView.m_Teleported = true;
+	}
+	m_MultiView.m_OldCameraDistance = CurrentCameraDistance;
+
+	return clamp(MapValue(MaxCameraDist, MinCameraDist, MaxVel, MinVel, CurrentCameraDistance), MinVel, UpperLimit);
 }
 
 float CGameClient::CalculateMultiViewZoom(vec2 MinPos, vec2 MaxPos, float Vel)
@@ -3575,7 +3659,7 @@ float CGameClient::CalculateMultiViewZoom(vec2 MinPos, vec2 MaxPos, float Vel)
 	// zoom should stay inbetween 1.1 and 20.0
 	Zoom = clamp(Zoom + Diff, 1.1f, 20.0f);
 	// add the user preference
-	Zoom -= (Zoom * 0.075f) * m_MultiViewPersonalZoom;
+	Zoom -= (Zoom * 0.1f) * m_MultiViewPersonalZoom;
 	m_MultiView.m_OldPersonalZoom = m_MultiViewPersonalZoom;
 
 	return Zoom;
@@ -3588,10 +3672,12 @@ float CGameClient::MapValue(float MaxValue, float MinValue, float MaxRange, floa
 
 void CGameClient::ResetMultiView()
 {
+	m_MultiViewPersonalZoom = 0;
+	m_MultiViewActivated = false;
 	m_MultiView.m_Solo = false;
 	m_MultiView.m_IsInit = false;
-	m_MultiViewActivated = false;
-	m_MultiViewPersonalZoom = 0;
+	m_MultiView.m_Teleported = false;
+	m_MultiView.m_OldCameraDistance = 0.0f;
 }
 
 void CGameClient::CleanMultiViewIds()
@@ -3601,7 +3687,28 @@ void CGameClient::CleanMultiViewIds()
 	std::fill(std::begin(m_MultiView.m_aVanish), std::end(m_MultiView.m_aVanish), false);
 }
 
+void CGameClient::CleanMultiViewId(int ClientID)
+{
+	if(ClientID >= MAX_CLIENTS || ClientID < 0)
+		return;
+
+	m_aMultiViewId[ClientID] = false;
+	m_MultiView.m_aLastFreeze[ClientID] = 0.0f;
+	m_MultiView.m_aVanish[ClientID] = false;
+}
+
 bool CGameClient::IsMultiViewIdSet()
 {
 	return std::any_of(std::begin(m_aMultiViewId), std::end(m_aMultiViewId), [](bool IsSet) { return IsSet; });
+}
+
+int CGameClient::FindFirstMultiViewId()
+{
+	int ClientID = -1;
+	for(int i = 0; i < MAX_CLIENTS; i++)
+	{
+		if(m_aMultiViewId[i] && !m_MultiView.m_aVanish[i])
+			return i;
+	}
+	return ClientID;
 }

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -698,10 +698,15 @@ public:
 
 	const std::vector<CSnapEntities> &SnapEntities() { return m_vSnapEntities; }
 
+	int m_MultiViewTeam;
 	int m_MultiViewPersonalZoom;
 	bool m_MultiViewShowHud;
 	bool m_MultiViewActivated;
 	bool m_aMultiViewId[MAX_CLIENTS];
+
+	void ResetMultiView();
+	int FindFirstMultiViewId();
+	void CleanMultiViewId(int ClientID);
 
 private:
 	std::vector<CSnapEntities> m_vSnapEntities;
@@ -732,12 +737,11 @@ private:
 	float m_LastScreenAspect;
 	bool m_LastDummyConnected;
 
-	void ResetMultiView();
 	void HandleMultiView();
 	bool IsMultiViewIdSet();
 	void CleanMultiViewIds();
-	bool InitMultiViewFromFreeview(int Team);
-	float CalculateMultiViewMultiplier(vec2 CameraPos);
+	bool InitMultiView(int Team);
+	float CalculateMultiViewMultiplier(vec2 TargetPos);
 	float CalculateMultiViewZoom(vec2 MinPos, vec2 MaxPos, float Vel);
 	float MapValue(float MaxValue, float MinValue, float MaxRange, float MinRange, float Value);
 
@@ -745,10 +749,12 @@ private:
 	{
 		bool m_Solo;
 		bool m_IsInit;
+		bool m_Teleported;
 		bool m_aVanish[MAX_CLIENTS];
 		vec2 m_OldPos;
-		int m_Team;
 		int m_OldPersonalZoom;
+		float m_SecondChance;
+		float m_OldCameraDistance;
 		float m_aLastFreeze[MAX_CLIENTS];
 	};
 

--- a/src/game/variables.h
+++ b/src/game/variables.h
@@ -90,7 +90,9 @@ MACRO_CONFIG_INT(ClDyncamFollowFactor, cl_dyncam_follow_factor, 60, 0, 200, CFGF
 MACRO_CONFIG_INT(ClDyncamSmoothness, cl_dyncam_smoothness, 0, 0, 100, CFGFLAG_CLIENT | CFGFLAG_SAVE | CFGFLAG_INSENSITIVE, "Transition amount of the camera movement, 0=instant, 100=slow and smooth")
 MACRO_CONFIG_INT(ClDyncamStabilizing, cl_dyncam_stabilizing, 0, 0, 100, CFGFLAG_CLIENT | CFGFLAG_SAVE | CFGFLAG_INSENSITIVE, "Amount of camera slowdown during fast cursor movement. High value can cause delay in camera movement")
 
-MACRO_CONFIG_INT(ClMultiViewZoomSmoothness, cl_multi_view_zoom_smoothness, 1300, 0, 5000, CFGFLAG_CLIENT | CFGFLAG_SAVE | CFGFLAG_INSENSITIVE, "Set the smoothness of the multi view zoom (in ms, higher = slower)")
+MACRO_CONFIG_INT(ClMultiViewSensitivity, cl_multiview_sensitivity, 100, 0, 200, CFGFLAG_CLIENT | CFGFLAG_SAVE | CFGFLAG_INSENSITIVE, "Set how fast the camera will move to the desired location (higher = faster)")
+MACRO_CONFIG_INT(ClMultiViewUseFreeView, cl_multiview_use_freeview, 0, 1, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE | CFGFLAG_INSENSITIVE, "Use the free-view mode when using multi-view from free-view (/showall 1 has to be activated)")
+MACRO_CONFIG_INT(ClMultiViewZoomSmoothness, cl_multiview_zoom_smoothness, 1300, 0, 5000, CFGFLAG_CLIENT | CFGFLAG_SAVE | CFGFLAG_INSENSITIVE, "Set the smoothness of the multi-view zoom (in ms, higher = slower)")
 
 MACRO_CONFIG_INT(EdAutosaveInterval, ed_autosave_interval, 10, 0, 240, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Interval in minutes at which a copy of the current editor map is automatically saved to the 'auto' folder (0 for off)")
 MACRO_CONFIG_INT(EdAutosaveMax, ed_autosave_max, 10, 0, 1000, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Maximum number of autosaves that are kept per map name (0 = no limit)")


### PR DESCRIPTION
- [x] You can now see who you are spectating in the spectator menu and even add/remove people from it (left mouse button)
- [x] Teleports are now being processed slower (more smoothly)
- [x] Workaround for starting multi-view from free-view (chooses now the nearest player to be the focus)
- [x] Added two more important variables to be able to customize it for specific scenarios (youtubers)

before:
![screenshot_2023-07-09_18-34-29](https://github.com/ddnet/ddnet/assets/24738662/a2ff8b77-c626-4ac2-b200-1eea70f85213)
after:
![screenshot_2023-07-09_18-32-49](https://github.com/ddnet/ddnet/assets/24738662/a54f0b06-b228-43ac-a1fc-eab95e7d9c20)

Edit: Thats the feedback i got from people. Hope its okay.

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
