### PR TITLE
Fix text wrapping with long Unicode strings

### DIFF
--- a/src/engine/client/text.cpp
+++ b/src/engine/client/text.cpp
@@ -1214,7 +1214,7 @@ public:
 					Cutter.m_Flags |= TEXTFLAG_STOP_AT_END | TEXTFLAG_DISALLOW_NEWLINE;
 
 					TextEx(&Cutter, pCurrent, Wlen);
-					Wlen = maximum(Cutter.m_CharCount - 1, 0);
+					Wlen = str_utf8_rewind(pCurrent, Cutter.m_CharCount); // rewind once to skip the last character that did not fit
 					NewLine = true;
 
 					if(Cutter.m_GlyphCount <= 3 && !GotNewLineLast) // if we can't place 3 chars of the word on this line, take the next


### PR DESCRIPTION
Rewind one unicode codepoint instead of rewinding only one character (byte) when text does not fit.

Closes #6810.

Screenshots:
- Before: 
![screenshot_2023-07-10_17-54-21](https://github.com/ddnet/ddnet/assets/23437060/d3700f2a-2702-480e-bedf-ce8724efffe1)
- After:
![screenshot_2023-07-10_17-51-37](https://github.com/ddnet/ddnet/assets/23437060/8e2550ab-33ed-40e1-acc5-d14a4b3137c6)

## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
