### PR TITLE
Perform sanity check and show errors when loading map in editor

### DIFF
--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -448,7 +448,8 @@ public:
 
 	// io
 	bool Save(const char *pFilename);
-	bool Load(const char *pFilename, int StorageType);
+	bool Load(const char *pFilename, int StorageType, const std::function<void(const char *pErrorMessage)> &ErrorHandler);
+	void PerformSanityChecks(const std::function<void(const char *pErrorMessage)> &ErrorHandler);
 
 	// DDRace
 


### PR DESCRIPTION
Add `CEditorMap::PerformSanityChecks` to perform additional sanity checks when loading a map in the editor.

In particular, the following is added: Check if there are any images with a width or height that is not divisible by 16 which are used in tile layers. Reset the image for these layers, to prevent crashes with some drivers.

Closes #6519.

Error message popup when loading the map linked in the issue (loading goes through, but this popup message is shown):

![screenshot_2023-07-10_23-11-38](https://github.com/ddnet/ddnet/assets/23437060/21fbd1b3-88dc-4b59-a20c-113d5613efde)

## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
