### PR TITLE
Support deleting/renaming demo folders, improve demo popups

### DIFF
--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -322,9 +322,10 @@ protected:
 	char m_aCurrentDemoSelectionName[IO_MAX_PATH_LENGTH];
 	CLineInputBuffered<IO_MAX_PATH_LENGTH> m_DemoRenameInput;
 	CLineInputBuffered<IO_MAX_PATH_LENGTH> m_DemoSliceInput;
+#if defined(CONF_VIDEORECORDER)
 	CLineInputBuffered<IO_MAX_PATH_LENGTH> m_DemoRenderInput;
+#endif
 	int m_DemolistSelectedIndex;
-	bool m_DemolistSelectedIsDir;
 	bool m_DemolistSelectedReveal = false;
 	int m_DemolistStorageType;
 	bool m_DemolistMultipleStorages = false;
@@ -428,6 +429,7 @@ protected:
 	void RenderDemoPlayerSliceSavePopup(CUIRect MainView);
 	void RenderDemoList(CUIRect MainView);
 	void PopupConfirmDeleteDemo();
+	void PopupConfirmDeleteFolder();
 
 	// found in menus_start.cpp
 	void RenderStartMenu(CUIRect MainView);


### PR DESCRIPTION
Support deleting and renaming folders in the demo browser. Only empty folders can be deleted.

Ensure only files and folders in the save directory can be deleted and renamed.

Also check if a folder with a demo rename/render filename already exists.

Fix broken `m_DemolistSelectedIsDir` checks by using `m_vDemos[m_DemolistSelectedIndex].m_IsDir` instead.

Append `.mp4` file extension only internally instead of appending it to the render filename lineinput, as this causes the file extension to appear when rendering doesn't start due an error message.

Use more efficient `FileExists` instead of `FindFile` to check if rendered demo video file already exists.

Change popup preconditions to assertions.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
