### PR TITLE
Support showing multiple different error messages in editor

### DIFF
--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -21,6 +21,7 @@
 
 #include <chrono>
 #include <deque>
+#include <map>
 #include <string>
 #include <vector>
 
@@ -890,6 +891,14 @@ public:
 	void InvokeFileDialog(int StorageType, int FileType, const char *pTitle, const char *pButtonText,
 		const char *pBasepath, const char *pDefaultName,
 		bool (*pfnFunc)(const char *pFilename, int StorageType, void *pUser), void *pUser);
+	struct SStringKeyComparator
+	{
+		bool operator()(char const *pLhs, char const *pRhs) const
+		{
+			return str_comp(pLhs, pRhs) < 0;
+		}
+	};
+	std::map<const char *, CUI::SMessagePopupContext *, SStringKeyComparator> m_PopupMessageContexts;
 	void ShowFileDialogError(const char *pFormat, ...)
 		GNUC_ATTRIBUTE((format(printf, 2, 3)));
 
@@ -902,6 +911,7 @@ public:
 
 	void RenderPressedKeys(CUIRect View);
 	void RenderSavingIndicator(CUIRect View);
+	void FreeDynamicPopupMenus();
 	void RenderMousePointer();
 
 	void ResetMenuBackgroundPositions();


### PR DESCRIPTION
Previously the same message popup context was used for all error messages. While multiple message popups could be opened at the same time, the message would always be the same for all, as the same buffer was used for all popups.

This is fixed by creating and destroying the message popup contexts dynamically, so there can be any number of message popups with different messages. Additionally, if a popup with an identical message is already open, it will first be closed and then reopened at the new position, to prevent duplicate message popups.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
