### PR TITLE
Remove obsolete leak sanitizer suppression

### DIFF
--- a/lsan.supp
+++ b/lsan.supp
@@ -1,1 +1,0 @@
-leak:CCommandProcessorFragment_OpenGL2::Cmd_CreateBufferObject


### PR DESCRIPTION
The memory appears to be properly freed now, so this suppression is no longer necessary.

Keeping the empty suppressions file for the future is easier than removing it.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
