### PR TITLE
Fix quadpoint selection

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -1674,6 +1674,7 @@ void CEditor::DoQuadPoint(CQuad *pQuad, int QuadIndex, int V)
 	enum
 	{
 		OP_NONE = 0,
+		OP_SELECT,
 		OP_MOVEPOINT,
 		OP_MOVEUV,
 		OP_CONTEXT_MENU
@@ -1681,6 +1682,8 @@ void CEditor::DoQuadPoint(CQuad *pQuad, int QuadIndex, int V)
 
 	static bool s_Moved;
 	static int s_Operation = OP_NONE;
+	static float s_MouseXStart = 0.0f;
+	static float s_MouseYStart = 0.0f;
 
 	const bool IgnoreGrid = Input()->AltIsPressed();
 
@@ -1694,6 +1697,15 @@ void CEditor::DoQuadPoint(CQuad *pQuad, int QuadIndex, int V)
 
 		if(s_Moved)
 		{
+			if(s_Operation == OP_SELECT)
+			{
+				float x = s_MouseXStart - UI()->MouseX();
+				float y = s_MouseYStart - UI()->MouseY();
+
+				if(x * x + y * y > 20.0f)
+					s_Operation = OP_MOVEPOINT;
+			}
+
 			if(s_Operation == OP_MOVEPOINT)
 			{
 				float x = wx;
@@ -1791,7 +1803,12 @@ void CEditor::DoQuadPoint(CQuad *pQuad, int QuadIndex, int V)
 				UI()->EnableMouseLock(pID);
 			}
 			else
-				s_Operation = OP_MOVEPOINT;
+			{
+				s_MouseXStart = UI()->MouseX();
+				s_MouseYStart = UI()->MouseY();
+
+				s_Operation = OP_SELECT;
+			}
 
 			if(!(m_SelectedPoints & (1 << V)))
 			{


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

Avoids quadpoints being moved when selected.

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
