### PR TITLE
Fix server browser filter highlighting of non-ASCII text

### DIFF
--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -3539,7 +3539,7 @@ int str_utf8_comp_nocase_num(const char *a, const char *b, int num)
 	return (unsigned char)*a - (unsigned char)*b;
 }
 
-const char *str_utf8_find_nocase(const char *haystack, const char *needle)
+const char *str_utf8_find_nocase(const char *haystack, const char *needle, const char **end)
 {
 	while(*haystack) /* native implementation */
 	{
@@ -3553,11 +3553,17 @@ const char *str_utf8_find_nocase(const char *haystack, const char *needle)
 			b = b_next;
 		}
 		if(!(*b))
+		{
+			if(end != nullptr)
+				*end = a_next;
 			return haystack;
+		}
 		str_utf8_decode(&haystack);
 	}
 
-	return 0;
+	if(end != nullptr)
+		*end = nullptr;
+	return nullptr;
 }
 
 int str_utf8_isspace(int code)

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -2300,6 +2300,9 @@ int str_utf8_comp_nocase_num(const char *a, const char *b, int num);
 	Parameters:
 		haystack - String to search in
 		needle - String to search for
+        end - A pointer that will be set to a pointer into haystack directly behind the
+            last character where the needle was found. Will be set to nullptr if needle
+            could not be found. Optional parameter.
 
 	Returns:
 		A pointer into haystack where the needle was found.
@@ -2308,7 +2311,7 @@ int str_utf8_comp_nocase_num(const char *a, const char *b, int num);
 	Remarks:
 		- The strings are treated as zero-terminated strings.
 */
-const char *str_utf8_find_nocase(const char *haystack, const char *needle);
+const char *str_utf8_find_nocase(const char *haystack, const char *needle, const char **end = nullptr);
 
 /*
 	Function: str_utf8_isspace

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1320,7 +1320,10 @@ bool CMenus::PrintHighlighted(const char *pName, F &&PrintFn)
 		}
 		else
 		{
-			pFilteredStr = str_utf8_find_nocase(pName, aFilterStr);
+			const char *pFilteredStrEnd;
+			pFilteredStr = str_utf8_find_nocase(pName, aFilterStr, &pFilteredStrEnd);
+			if(pFilteredStr != nullptr && pFilteredStrEnd != nullptr)
+				FilterLen = pFilteredStrEnd - pFilteredStr;
 		}
 		if(pFilteredStr)
 		{

--- a/src/test/str.cpp
+++ b/src/test/str.cpp
@@ -124,12 +124,52 @@ TEST(Str, Utf8ToLower)
 	EXPECT_TRUE(str_utf8_comp_nocase_num("ÖlÜ", "ölüa", 6) != 0);
 	EXPECT_TRUE(str_utf8_comp_nocase_num("a", "z", 0) == 0);
 	EXPECT_TRUE(str_utf8_comp_nocase_num("a", "z", 1) != 0);
+}
 
-	const char str[] = "ÄÖÜ";
-	EXPECT_TRUE(str_utf8_find_nocase(str, "ä") == str);
-	EXPECT_TRUE(str_utf8_find_nocase(str, "ö") == str + 2);
-	EXPECT_TRUE(str_utf8_find_nocase(str, "ü") == str + 4);
-	EXPECT_TRUE(str_utf8_find_nocase(str, "z") == NULL);
+TEST(Str, Utf8FindNocase)
+{
+	const char *pStr = "abc";
+	const char *pEnd;
+	EXPECT_EQ(str_utf8_find_nocase(pStr, "a", &pEnd), pStr);
+	EXPECT_EQ(pEnd, pStr + str_length("a"));
+	EXPECT_EQ(str_utf8_find_nocase(pStr, "b", &pEnd), pStr + str_length("a"));
+	EXPECT_EQ(pEnd, pStr + str_length("ab"));
+	EXPECT_EQ(str_utf8_find_nocase(pStr, "c", &pEnd), pStr + str_length("ab"));
+	EXPECT_EQ(pEnd, pStr + str_length("abc"));
+	EXPECT_EQ(str_utf8_find_nocase(pStr, "d", &pEnd), nullptr);
+	EXPECT_EQ(pEnd, nullptr);
+
+	EXPECT_EQ(str_utf8_find_nocase(pStr, "A", &pEnd), pStr);
+	EXPECT_EQ(pEnd, pStr + str_length("a"));
+	EXPECT_EQ(str_utf8_find_nocase(pStr, "B", &pEnd), pStr + str_length("a"));
+	EXPECT_EQ(pEnd, pStr + str_length("ab"));
+	EXPECT_EQ(str_utf8_find_nocase(pStr, "C", &pEnd), pStr + str_length("ab"));
+	EXPECT_EQ(pEnd, pStr + str_length("abc"));
+	EXPECT_EQ(str_utf8_find_nocase(pStr, "D", &pEnd), nullptr);
+	EXPECT_EQ(pEnd, nullptr);
+
+	pStr = "ÄÖÜ";
+	EXPECT_EQ(str_utf8_find_nocase(pStr, "ä", &pEnd), pStr);
+	EXPECT_EQ(pEnd, pStr + str_length("Ä"));
+	EXPECT_EQ(str_utf8_find_nocase(pStr, "ö", &pEnd), pStr + str_length("Ä"));
+	EXPECT_EQ(pEnd, pStr + str_length("ÄÖ"));
+	EXPECT_EQ(str_utf8_find_nocase(pStr, "ü", &pEnd), pStr + str_length("ÄÖ"));
+	EXPECT_EQ(pEnd, pStr + str_length("ÄÖÜ"));
+	EXPECT_EQ(str_utf8_find_nocase(pStr, "z", &pEnd), nullptr);
+	EXPECT_EQ(pEnd, nullptr);
+
+	// Both 'I' and 'İ' map to 'i'
+	pStr = "antimatter";
+	EXPECT_EQ(str_utf8_find_nocase(pStr, "I", &pEnd), pStr + str_length("ant"));
+	EXPECT_EQ(pEnd, pStr + str_length("anti"));
+	EXPECT_EQ(str_utf8_find_nocase(pStr, "İ", &pEnd), pStr + str_length("ant"));
+	EXPECT_EQ(pEnd, pStr + str_length("anti"));
+	pStr = "ANTIMATTER";
+	EXPECT_EQ(str_utf8_find_nocase(pStr, "i", &pEnd), pStr + str_length("ANT"));
+	EXPECT_EQ(pEnd, pStr + str_length("ANTI"));
+	pStr = "ANTİMATTER";
+	EXPECT_EQ(str_utf8_find_nocase(pStr, "i", &pEnd), pStr + str_length("ANT"));
+	EXPECT_EQ(pEnd, pStr + str_length("ANTİ"));
 }
 
 TEST(Str, Utf8FixTruncation)


### PR DESCRIPTION
By calculating the correct length of the string matched in the haystack using the added `end` parameter of `str_utf8_find_nocase`.

Closes #6850.

Add optional `end` output parameter to `str_utf8_find_nocase` which is set to a pointer into the haystack after the matched string.

This is necessary because there are pairs of matching upper case and lower case Unicode characters with different byte length (e.g. both `I` and `İ` map to `i`), so the byte length of the string matched in the haystack may not be identical to the length of the needle string.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [X] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
