### PR TITLE
Delay "Ingame moved" warning in editor

### DIFF
--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1777,11 +1777,7 @@ void CGameClient::OnNewSnapshot()
 		pComponent->OnNewSnapshot();
 
 	// notify editor when local character moved
-	if(m_Snap.m_pLocalCharacter && m_Snap.m_pLocalPrevCharacter &&
-		(m_Snap.m_pLocalCharacter->m_X != m_Snap.m_pLocalPrevCharacter->m_X || m_Snap.m_pLocalCharacter->m_Y != m_Snap.m_pLocalPrevCharacter->m_Y))
-	{
-		Editor()->OnIngameMoved();
-	}
+	UpdateEditorIngameMoved();
 
 	// detect air jump for other players
 	for(int i = 0; i < MAX_CLIENTS; i++)
@@ -1809,6 +1805,24 @@ void CGameClient::OnNewSnapshot()
 	// update prediction data
 	if(Client()->State() != IClient::STATE_DEMOPLAYBACK)
 		UpdatePrediction();
+}
+
+void CGameClient::UpdateEditorIngameMoved()
+{
+	const bool LocalCharacterMoved = m_Snap.m_pLocalCharacter && m_Snap.m_pLocalPrevCharacter && (m_Snap.m_pLocalCharacter->m_X != m_Snap.m_pLocalPrevCharacter->m_X || m_Snap.m_pLocalCharacter->m_Y != m_Snap.m_pLocalPrevCharacter->m_Y);
+	static int s_EditorMovementDelay = 5;
+	if(!g_Config.m_ClEditor)
+	{
+		s_EditorMovementDelay = 5;
+	}
+	else if(s_EditorMovementDelay > 0 && !LocalCharacterMoved)
+	{
+		--s_EditorMovementDelay;
+	}
+	if(s_EditorMovementDelay == 0 && LocalCharacterMoved)
+	{
+		Editor()->OnIngameMoved();
+	}
 }
 
 void CGameClient::OnPredict()

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -182,6 +182,7 @@ private:
 
 	void ProcessEvents();
 	void UpdatePositions();
+	void UpdateEditorIngameMoved();
 
 	int m_PredictedTick;
 	int m_aLastNewPredictedTick[NUM_DUMMIES];


### PR DESCRIPTION
Delay showing the warning for ingame movement until the player has stopped moving while the editor is open, so the warning doesn't show immediately when the player performs an action (like jumping) and opens the editor shortly after.

Closes #6852.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
