### PR TITLE
Initially keep server list scrolled to the top

### DIFF
--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -449,6 +449,7 @@ protected:
 
 	// found in menus_browser.cpp
 	int m_SelectedIndex;
+	bool m_ServerBrowserShouldRevealSelection;
 	void RenderServerbrowserServerList(CUIRect View);
 	void Connect(const char *pAddress);
 	void PopupConfirmSwitchServer();

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -188,12 +188,10 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 	s_ListBox.SetActive(!UI()->IsPopupOpen());
 	s_ListBox.DoStart(ms_ListheaderHeight, NumServers, 1, 3, -1, &View, false);
 
-	int NumPlayers = 0;
-	static int s_PrevSelectedIndex = -1;
-	if(s_PrevSelectedIndex != m_SelectedIndex)
+	if(m_ServerBrowserShouldRevealSelection)
 	{
 		s_ListBox.ScrollToSelected();
-		s_PrevSelectedIndex = m_SelectedIndex;
+		m_ServerBrowserShouldRevealSelection = false;
 	}
 	m_SelectedIndex = -1;
 
@@ -212,6 +210,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 		TextRender()->SetCurFont(nullptr);
 	};
 
+	int NumPlayers = 0;
 	for(int i = 0; i < NumServers; i++)
 	{
 		const CServerInfo *pItem = ServerBrowser()->SortedGet(i);
@@ -430,6 +429,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 			if(pItem)
 			{
 				str_copy(g_Config.m_UiServerAddress, pItem->m_aAddress);
+				m_ServerBrowserShouldRevealSelection = true;
 			}
 		}
 	}
@@ -553,7 +553,8 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 		UI()->DoLabel(&ServerAddr, Localize("Server address:"), 14.0f, TEXTALIGN_ML);
 		ServerAddr.VSplitLeft(SearchExcludeAddrStrMax + 5.0f + ExcludeSearchIconMax + 5.0f, NULL, &ServerAddr);
 		static CLineInput s_ServerAddressInput(g_Config.m_UiServerAddress, sizeof(g_Config.m_UiServerAddress));
-		UI()->DoClearableEditBox(&s_ServerAddressInput, &ServerAddr, 12.0f);
+		if(UI()->DoClearableEditBox(&s_ServerAddressInput, &ServerAddr, 12.0f))
+			m_ServerBrowserShouldRevealSelection = true;
 
 		// button area
 		CUIRect ButtonRefresh, ButtonConnect;
@@ -1575,6 +1576,7 @@ void CMenus::RenderServerbrowserFriends(CUIRect View)
 				if(ButtonResult && Friend.ServerInfo())
 				{
 					str_copy(g_Config.m_UiServerAddress, Friend.ServerInfo()->m_aAddress);
+					m_ServerBrowserShouldRevealSelection = true;
 					if(Input()->MouseDoubleClick())
 					{
 						Connect(g_Config.m_UiServerAddress);


### PR DESCRIPTION
When first launching the client, keep the server list scrolled to the top instead of scrolling to the selected server.

Closes #6845.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
