### PR TITLE
Fix twmap installation in CI

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -18,7 +18,8 @@ jobs:
     - name: Prepare
       run: |
         sudo apt-get update -y
-        sudo apt-get install clang-format imagemagick ddnet-tools shellcheck pkg-config cmake ninja-build libfreetype6-dev libnotify-dev libsdl2-dev libsqlite3-dev libavcodec-dev libavformat-dev libavutil-dev libswresample-dev libswscale-dev libx264-dev python3-clang libvulkan-dev glslang-tools spirv-tools rustc cargo -y
+        sudo apt-get install clang-format imagemagick ddnet-tools shellcheck pkg-config cmake ninja-build libfreetype6-dev libnotify-dev libsdl2-dev libsqlite3-dev libavcodec-dev libavformat-dev libavutil-dev libswresample-dev libswscale-dev libx264-dev python3-clang libvulkan-dev glslang-tools spirv-tools -y
+        rustup default stable
         pip3 install pylint
         git clone https://gitlab.com/Patiga/twmap.git/
         cd twmap/twmap-tools


### PR DESCRIPTION
```
error: failed to compile `twmap-tools v0.3.1 (/home/runner/work/ddnet/ddnet/twmap/twmap-tools)`, intermediate artifacts can be found at `/home/runner/work/ddnet/ddnet/twmap/target`

Caused by:
  package `half v2.3.1` cannot be built because it requires rustc 1.70 or newer, while the currently active rustc version is 1.69.0
  Either upgrade to rustc 1.70 or newer, or use
  cargo update -p half@2.3.1 --precise ver
  where `ver` is the latest version of `half` supporting rustc 1.69.0
```
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
