### PR TITLE
Fix bug, increase dump_log max seconds to 10min

### DIFF
--- a/src/game/server/ddracecommands.cpp
+++ b/src/game/server/ddracecommands.cpp
@@ -831,9 +831,11 @@ void CGameContext::ConDumpLog(IConsole::IResult *pResult, void *pUserData)
 	if(LimitSecs < 0)
 		return;
 
-	for(int i = pSelf->m_FirstLog; i != pSelf->m_LastLog; i = (i + 1) % pSelf->MAX_LOGS)
+	int Iterator = pSelf->m_LatestLog;
+	for(int i = 0; i < MAX_LOGS; i++)
 	{
-		CLog *pEntry = &pSelf->m_aLogs[i];
+		CLog *pEntry = &pSelf->m_aLogs[Iterator];
+		Iterator = (Iterator + 1) % MAX_LOGS;
 
 		if(!pEntry->m_Timestamp)
 			continue;
@@ -854,10 +856,8 @@ void CGameContext::ConDumpLog(IConsole::IResult *pResult, void *pUserData)
 
 void CGameContext::LogEvent(const char *Description, int ClientID)
 {
-	CLog *pNewEntry = &m_aLogs[m_LastLog];
-	m_LastLog = (m_LastLog + 1) % MAX_LOGS;
-	if(m_LastLog == m_FirstLog)
-		m_FirstLog++;
+	CLog *pNewEntry = &m_aLogs[m_LatestLog];
+	m_LatestLog = (m_LatestLog + 1) % MAX_LOGS;
 
 	pNewEntry->m_Timestamp = time_get();
 	str_copy(pNewEntry->m_aDescription, Description);

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -94,8 +94,8 @@ void CGameContext::Construct(int Resetting)
 	m_NumMutes = 0;
 	m_NumVoteMutes = 0;
 
-	m_LastLog = 0;
-	m_FirstLog = 0;
+	m_LatestLog = 0;
+	mem_zero(&m_aLogs, sizeof(m_aLogs));
 
 	if(Resetting == NO_RESET)
 	{
@@ -1148,14 +1148,6 @@ void CGameContext::OnTick()
 		{
 			m_NumVoteMutes--;
 			m_aVoteMutes[i] = m_aVoteMutes[m_NumVoteMutes];
-		}
-	}
-	for(int i = 0; i < m_LastLog; i++)
-	{
-		if(m_aLogs[i].m_Timestamp && (time_get() - m_aLogs[i].m_Timestamp) / time_freq() > MAX_LOG_SECONDS)
-		{
-			m_FirstLog = (m_FirstLog + 1) % MAX_LOGS;
-			m_aLogs[m_FirstLog].m_Timestamp = 0;
 		}
 	}
 

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -475,8 +475,8 @@ private:
 
 	enum
 	{
-		MAX_LOG_SECONDS = 240,
-		MAX_LOGS = 256,
+		MAX_LOG_SECONDS = 600,
+		MAX_LOGS = 512,
 	};
 	struct CLog
 	{
@@ -488,8 +488,7 @@ private:
 		char m_aClientAddrStr[NETADDR_MAXSTRSIZE];
 	};
 	CLog m_aLogs[MAX_LOGS];
-	int m_FirstLog;
-	int m_LastLog;
+	int m_LatestLog;
 
 	void LogEvent(const char *Description, int ClientID);
 


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

- Fixed a bug where the index was outside the bounds of the array
- Increased the log time to 10 minutes (600 seconds)

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
