### PR TITLE
Make point selection easier

### DIFF
--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -949,10 +949,12 @@ public:
 
 		m_ShowEnvelopePreview = SHOWENV_NONE;
 		m_SelectedQuadEnvelope = -1;
+
 		m_vSelectedEnvelopePoints = {};
 		m_UpdateEnvPointInfo = false;
 		m_SelectedTangentInPoint = std::pair(-1, -1);
 		m_SelectedTangentOutPoint = std::pair(-1, -1);
+		m_CurrentQuadIndex = -1;
 
 		m_QuadKnifeActive = false;
 		m_QuadKnifeCount = 0;
@@ -1292,6 +1294,7 @@ public:
 	int m_SelectedEnvelope;
 	std::vector<std::pair<int, int>> m_vSelectedEnvelopePoints;
 	int m_SelectedQuadEnvelope;
+	int m_CurrentQuadIndex;
 	int m_SelectedImage;
 	int m_SelectedSound;
 	int m_SelectedSource;
@@ -1407,6 +1410,7 @@ public:
 	void DoQuadEnvelopes(const std::vector<CQuad> &vQuads, IGraphics::CTextureHandle Texture = IGraphics::CTextureHandle());
 	void DoQuadEnvPoint(const CQuad *pQuad, int QIndex, int pIndex);
 	void DoQuadPoint(CQuad *pQuad, int QuadIndex, int v);
+	void SetHotQuadPoint(CLayerQuads *pLayer);
 
 	float TriangleArea(vec2 A, vec2 B, vec2 C);
 	bool IsInTriangle(vec2 Point, vec2 A, vec2 B, vec2 C);
@@ -1442,7 +1446,10 @@ public:
 
 	void RenderEnvelopeEditor(CUIRect View);
 	void RenderServerSettingsEditor(CUIRect View, bool ShowServerSettingsEditorLast);
+
 	void RenderExtraEditorDragBar(CUIRect View, CUIRect DragBar);
+
+	void SetHotEnvelopePoint(const CUIRect &View, CEnvelope *pEnvelope);
 
 	void RenderMenubar(CUIRect Menubar);
 	void RenderFileDialog();


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

Draft to make quad point selection easier. To work properly this will need #6844. Since this change was inspired by blender the hitbox is currently quite big. If two points are within range the nearest one is chosen. 

![pointselection](https://github.com/ddnet/ddnet/assets/49279081/f2a68173-7e61-4879-8a66-fcc97df9b009)

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
