### PR TITLE
Add ``goto_switch`` and ``goto_tele``

### DIFF
--- a/src/base/vmath.h
+++ b/src/base/vmath.h
@@ -109,6 +109,11 @@ inline float length(const vector2_base<float> &a)
 	return std::sqrt(dot(a, a));
 }
 
+inline float length(const vector2_base<int> &a)
+{
+	return std::sqrt(dot(a, a));
+}
+
 inline float length_squared(const vector2_base<float> &a)
 {
 	return dot(a, a);

--- a/src/game/client/components/camera.h
+++ b/src/game/client/components/camera.h
@@ -53,14 +53,23 @@ public:
 	virtual void OnReset() override;
 
 	void SetZoom(float Target, int Smoothness);
+	void SetView(ivec2 Pos);
+	void GotoSwitch(int Number, int Offset = -1);
+	void GotoTele(int Number, int Offset = -1);
 
 private:
 	static void ConZoomPlus(IConsole::IResult *pResult, void *pUserData);
 	static void ConZoomMinus(IConsole::IResult *pResult, void *pUserData);
 	static void ConZoom(IConsole::IResult *pResult, void *pUserData);
 	static void ConSetView(IConsole::IResult *pResult, void *pUserData);
+	static void ConGotoSwitch(IConsole::IResult *pResult, void *pUserData);
+	static void ConGotoTele(IConsole::IResult *pResult, void *pUserData);
 
 	vec2 m_ForceFreeviewPos;
+	int m_GotoSwitchOffset;
+	int m_GotoTeleOffset;
+	ivec2 m_GotoSwitchLastPos;
+	ivec2 m_GotoTeleLastPos;
 };
 
 #endif


### PR DESCRIPTION
Set the clients view to a given teleporter or switch number

**TRIGGER WARNING**

~~The use of the keyword ``goto`` may offend some developers~~
UPDATE: This code is clean and can be red without caution.

# Wat it do

Allows users to find teleporters and switchers by the index. If one wonders how to open a door or where a teleporter leads the user can lookup the id using entities and then run the console command ``goto_switch [id]``. Which will set the clients view port to the first occurrence it finds of that switcher in the map. If the command is run again it jumps to the next it finds. It also takes a second optional parameter which is the index of the occurrence to check so if one runs ``goto_switch 1 2`` it will set the view to the 2nd switcher of type 1 in the map it finds.

The user has to manually set it self into the free view mode. Just running goto_switch while being in game or being in pause but not in free view will not update the camera position until the user manually enters free view (the same way the ``set_view`` command works)



https://github.com/ddnet/ddnet/assets/20344300/f1439562-ecc3-4a1e-8368-7145c4bccf97


https://github.com/ddnet/ddnet/assets/20344300/ad07a0cd-41fe-4ede-8699-66ad22151f81


https://github.com/ddnet/ddnet/assets/20344300/2dff4b1c-7e57-49ca-8353-0bc6a2c6c96c






## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
