### PR TITLE
Fix ingame animations not using correct envelope points anymore

### DIFF
--- a/src/game/client/components/maplayers.cpp
+++ b/src/game/client/components/maplayers.cpp
@@ -61,15 +61,18 @@ void CMapLayers::EnvelopeEval(int TimeOffsetMillis, int Env, ColorRGBA &Channels
 	CMapLayers *pThis = (CMapLayers *)pUser;
 	Channels = ColorRGBA();
 
-	const CMapBasedEnvelopePointAccess EnvelopePoints(pThis->m_pLayers->Map());
-
 	int EnvStart, EnvNum;
 	pThis->m_pLayers->Map()->GetType(MAPITEMTYPE_ENVELOPE, &EnvStart, &EnvNum);
 
-	if(EnvelopePoints.NumPoints() == 0 || Env < 0 || Env >= EnvNum)
+	if(Env < 0 || Env >= EnvNum)
 		return;
 
 	const CMapItemEnvelope *pItem = (CMapItemEnvelope *)pThis->m_pLayers->Map()->GetItem(EnvStart + Env);
+
+	CMapBasedEnvelopePointAccess EnvelopePoints(pThis->m_pLayers->Map());
+	EnvelopePoints.SetPointsRange(pItem->m_StartPoint, pItem->m_NumPoints);
+	if(EnvelopePoints.NumPoints() == 0)
+		return;
 
 	const auto TickToNanoSeconds = std::chrono::nanoseconds(1s) / (int64_t)pThis->Client()->GameTickSpeed();
 

--- a/src/game/client/render.h
+++ b/src/game/client/render.h
@@ -83,7 +83,9 @@ public:
 
 class CMapBasedEnvelopePointAccess : public IEnvelopePointAccess
 {
+	int m_StartPoint;
 	int m_NumPoints;
+	int m_NumPointsMax;
 	CEnvPoint *m_pPoints;
 	CEnvPointBezier *m_pPointsBezier;
 	CEnvPointBezier_upstream *m_pPointsBezierUpstream;
@@ -91,7 +93,10 @@ class CMapBasedEnvelopePointAccess : public IEnvelopePointAccess
 public:
 	CMapBasedEnvelopePointAccess(class CDataFileReader *pReader);
 	CMapBasedEnvelopePointAccess(class IMap *pMap);
+	void SetPointsRange(int StartPoint, int NumPoints);
+	int StartPoint() const;
 	int NumPoints() const override;
+	int NumPointsMax() const;
 	const CEnvPoint *GetPoint(int Index) const override;
 	const CEnvPointBezier *GetBezier(int Index) const override;
 };


### PR DESCRIPTION
Add `CMapBasedEnvelopePointAccess::SetPointsRange` function so the start point and number of points that should be considered when using this envelope point storage can be configured. In the editor, this range always includes all points, as each envelope directly stores only its own points, so animations were rendered correctly there. However, all points are stored in one array when loading them from the map file (i.e. when rendering the map ingame), so the start point and number of points specified for the envelopes have to be considered when accessing their envelope points.

Closes #6886.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
