### PR TITLE
Fix inaccurate envelope calculation

### DIFF
--- a/src/game/client/render_map.cpp
+++ b/src/game/client/render_map.cpp
@@ -263,7 +263,7 @@ void CRenderTools::RenderEvalEnvelope(const IEnvelopePointAccess *pPoints, int C
 	else
 		TimeNanos = decltype(TimeNanos)::zero();
 
-	int TimeMillis = (int)(TimeNanos / std::chrono::nanoseconds(1ms).count()).count();
+	const double TimeMillis = TimeNanos.count() / (double)std::chrono::nanoseconds(1ms).count();
 	for(int i = 0; i < NumPoints - 1; i++)
 	{
 		const CEnvPoint *pCurrentPoint = pPoints->GetPoint(i);
@@ -271,7 +271,7 @@ void CRenderTools::RenderEvalEnvelope(const IEnvelopePointAccess *pPoints, int C
 		if(TimeMillis >= pCurrentPoint->m_Time && TimeMillis <= pNextPoint->m_Time)
 		{
 			const float Delta = pNextPoint->m_Time - pCurrentPoint->m_Time;
-			float a = (float)(((double)TimeNanos.count() / (double)std::chrono::nanoseconds(1ms).count()) - pCurrentPoint->m_Time) / Delta;
+			float a = (float)(TimeMillis - pCurrentPoint->m_Time) / Delta;
 
 			switch(pCurrentPoint->m_Curvetype)
 			{


### PR DESCRIPTION
Use `double` instead of `int` to represent the time in milliseconds in envelope calculation.

This fixes step-ladder patterns appearing with bezier curves and artifacts appearing when two points are very close together in time.

Screenshots:
- Artifacts:
    - Before:
![screenshot_2023-07-21_17-50-42](https://github.com/ddnet/ddnet/assets/23437060/20b2a4c5-37a5-4628-968f-faed5d362d58)
    - After:
![screenshot_2023-07-21_17-51-09](https://github.com/ddnet/ddnet/assets/23437060/1882fcc2-8c27-4d9a-bd83-a1263ff03877)
- Bezier curves (minor difference already visible currently, will become more apparent with #6885):
    - Before:
![screenshot_2023-07-21_17-50-55](https://github.com/ddnet/ddnet/assets/23437060/9744ab59-10d1-45d0-8fee-e3c14388044a)
    - After:
![screenshot_2023-07-21_17-51-19](https://github.com/ddnet/ddnet/assets/23437060/70ac0ac8-539f-4fd9-bab6-db16943218e7)

## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
