### PR TITLE
Minor improvements to Multi-View

### DIFF
--- a/src/game/client/components/spectator.cpp
+++ b/src/game/client/components/spectator.cpp
@@ -217,7 +217,7 @@ void CSpectator::OnRender()
 				if(!GameClient()->m_MultiViewActivated)
 					Spectate(m_SelectedSpectatorID);
 
-				if(GameClient()->m_MultiViewActivated && m_pClient->m_Teams.Team(m_SelectedSpectatorID) != GameClient()->m_MultiViewTeam)
+				if(GameClient()->m_MultiViewActivated && m_SelectedSpectatorID != MULTI_VIEW && m_pClient->m_Teams.Team(m_SelectedSpectatorID) != GameClient()->m_MultiViewTeam)
 				{
 					GameClient()->ResetMultiView();
 					Spectate(m_SelectedSpectatorID);

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -629,6 +629,8 @@ void CGameClient::UpdatePositions()
 
 	if(!m_MultiViewActivated && m_MultiView.m_IsInit)
 		ResetMultiView();
+	else if(!m_Snap.m_SpecInfo.m_Active)
+		m_MultiViewPersonalZoom = 0;
 
 	UpdateRenderedCharacters();
 }
@@ -868,29 +870,25 @@ void CGameClient::OnMessage(int MsgId, CUnpacker *pUnpacker, int Conn, bool Dumm
 			m_GameWorld.ReleaseHooked(pMsg->m_Victim);
 		}
 
-		// if we are spectating a static id set (team 0) and somebody killed, we remove him from the list
-		if(IsMultiViewIdSet() && m_aMultiViewId[pMsg->m_Victim] && !m_aClients[pMsg->m_Victim].m_Spec)
+		// if we are spectating a static id set (team 0) and somebody killed, and its not a guy in solo, we remove him from the list
+		if(IsMultiViewIdSet() && m_MultiViewTeam == 0 && m_aMultiViewId[pMsg->m_Victim] && !m_aClients[pMsg->m_Victim].m_Spec && !m_MultiView.m_Solo)
 		{
-			// is multi-view even activated and we are not spectating a solo guy
-			if(m_MultiViewActivated && !m_MultiView.m_Solo)
-			{
-				m_aMultiViewId[pMsg->m_Victim] = false;
+			m_aMultiViewId[pMsg->m_Victim] = false;
 
-				// if everyone of a team killed, we have no ids to spectate anymore, so we disable multi-view
-				if(!IsMultiViewIdSet())
-					m_MultiViewActivated = false;
-				else
+			// if everyone of a team killed, we have no ids to spectate anymore, so we disable multi view
+			if(!IsMultiViewIdSet())
+				m_MultiViewActivated = false;
+			else
+			{
+				// the "main" tee killed, search a new one
+				if(m_Snap.m_SpecInfo.m_SpectatorID == pMsg->m_Victim)
 				{
-					// the "main" tee killed, search a new one
-					if(m_Snap.m_SpecInfo.m_SpectatorID == pMsg->m_Victim)
+					int NewClientID = FindFirstMultiViewId();
+					if(NewClientID < MAX_CLIENTS && NewClientID >= 0)
 					{
-						int NewClientID = FindFirstMultiViewId();
-						if(NewClientID < MAX_CLIENTS && NewClientID >= 0)
-						{
-							CleanMultiViewId(NewClientID);
-							m_aMultiViewId[NewClientID] = true;
-							m_Spectator.Spectate(NewClientID);
-						}
+						CleanMultiViewId(NewClientID);
+						m_aMultiViewId[NewClientID] = true;
+						m_Spectator.Spectate(NewClientID);
 					}
 				}
 			}
@@ -3507,6 +3505,9 @@ void CGameClient::HandleMultiView()
 	}
 	else if(m_MultiView.m_SecondChance != 0.0f)
 		m_MultiView.m_SecondChance = 0.0f;
+
+	// if we only have one tee thats in the list, we activate solo-mode
+	m_MultiView.m_Solo = std::count(std::begin(m_aMultiViewId), std::end(m_aMultiViewId), true) == 1;
 
 	vec2 TargetPos = vec2((Minpos.x + Maxpos.x) / 2.0f, (Minpos.y + Maxpos.y) / 2.0f);
 	// dont hide the position hud if its only one player

--- a/src/game/variables.h
+++ b/src/game/variables.h
@@ -90,9 +90,9 @@ MACRO_CONFIG_INT(ClDyncamFollowFactor, cl_dyncam_follow_factor, 60, 0, 200, CFGF
 MACRO_CONFIG_INT(ClDyncamSmoothness, cl_dyncam_smoothness, 0, 0, 100, CFGFLAG_CLIENT | CFGFLAG_SAVE | CFGFLAG_INSENSITIVE, "Transition amount of the camera movement, 0=instant, 100=slow and smooth")
 MACRO_CONFIG_INT(ClDyncamStabilizing, cl_dyncam_stabilizing, 0, 0, 100, CFGFLAG_CLIENT | CFGFLAG_SAVE | CFGFLAG_INSENSITIVE, "Amount of camera slowdown during fast cursor movement. High value can cause delay in camera movement")
 
-MACRO_CONFIG_INT(ClMultiViewSensitivity, cl_multiview_sensitivity, 100, 0, 200, CFGFLAG_CLIENT | CFGFLAG_SAVE | CFGFLAG_INSENSITIVE, "Set how fast the camera will move to the desired location (higher = faster)")
-MACRO_CONFIG_INT(ClMultiViewUseFreeView, cl_multiview_use_freeview, 0, 1, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE | CFGFLAG_INSENSITIVE, "Use the free-view mode when using multi-view from free-view (/showall 1 has to be activated)")
-MACRO_CONFIG_INT(ClMultiViewZoomSmoothness, cl_multiview_zoom_smoothness, 1300, 0, 5000, CFGFLAG_CLIENT | CFGFLAG_SAVE | CFGFLAG_INSENSITIVE, "Set the smoothness of the multi-view zoom (in ms, higher = slower)")
+MACRO_CONFIG_INT(ClMultiViewSensitivity, cl_multiview_sensitivity, 100, 0, 200, CFGFLAG_CLIENT | CFGFLAG_INSENSITIVE, "Set how fast the camera will move to the desired location (higher = faster)")
+MACRO_CONFIG_INT(ClMultiViewUseFreeView, cl_multiview_use_freeview, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_INSENSITIVE, "Use the free-view mode when using multi-view from free-view (/showall 1 has to be activated)")
+MACRO_CONFIG_INT(ClMultiViewZoomSmoothness, cl_multiview_zoom_smoothness, 1300, 0, 5000, CFGFLAG_CLIENT | CFGFLAG_INSENSITIVE, "Set the smoothness of the multi-view zoom (in ms, higher = slower)")
 
 MACRO_CONFIG_INT(EdAutosaveInterval, ed_autosave_interval, 10, 0, 240, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Interval in minutes at which a copy of the current editor map is automatically saved to the 'auto' folder (0 for off)")
 MACRO_CONFIG_INT(EdAutosaveMax, ed_autosave_max, 10, 0, 1000, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Maximum number of autosaves that are kept per map name (0 = no limit)")


### PR DESCRIPTION
Fixed / added some things according to feedback from discord.

- Multi-View can not longer be activated again after already active
- Fix cl_multiview_use_freeview variable config
- Players who killed will be removed now from Multi-View even if the spec mode is not active
- Multi-View personal zoom will be reseted when enabling Multi-View
- Fix bug where a kill in a team will be taken into account
- Improve the solo player experience in Multi-View

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
