### PR TITLE
improve envelope y offset on reset for small value ranges

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -5652,7 +5652,7 @@ void CEditor::ResetZoomEnvelope(CEnvelope *pEnvelope, int ActiveChannels)
 	if(ValueRange < 0.1f)
 	{
 		// Set view to some sane default if range is too small
-		m_OffsetEnvelopeY = 0.5f - Top / 0.1f;
+		m_OffsetEnvelopeY = 0.5f - ValueRange / 0.2f - Bottom / 0.1f;
 		m_ZoomEnvelopeY.SetZoomInstant(0.1f);
 	}
 	else


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

Before:

![image](https://github.com/ddnet/ddnet/assets/49279081/afcdaea6-aae1-49b9-a141-539ab43e7e98)


After:

![image](https://github.com/ddnet/ddnet/assets/49279081/fd197bbf-0179-4585-b8ba-296a32e6f79e)


<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
