### PR TITLE
Load datafile into memory instead of keeping file open, check for errors when reading and decompressing datafile data

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -3967,7 +3967,7 @@ void CClient::DemoRecorder_Start(const char *pFilename, bool WithTimestamp, int 
 			str_format(aFilename, sizeof(aFilename), "demos/%s.demo", pFilename);
 
 		SHA256_DIGEST Sha256 = m_pMap->Sha256();
-		m_aDemoRecorder[Recorder].Start(Storage(), m_pConsole, aFilename, GameClient()->NetVersion(), m_aCurrentMap, &Sha256, m_pMap->Crc(), "client", m_pMap->MapSize(), 0, m_pMap->File());
+		m_aDemoRecorder[Recorder].Start(Storage(), m_pConsole, aFilename, GameClient()->NetVersion(), m_aCurrentMap, &Sha256, m_pMap->Crc(), "client", m_pMap->FileSize(), m_pMap->FileData());
 	}
 }
 
@@ -4885,7 +4885,7 @@ void CClient::RaceRecord_Start(const char *pFilename)
 	else
 	{
 		SHA256_DIGEST Sha256 = m_pMap->Sha256();
-		m_aDemoRecorder[RECORDER_RACE].Start(Storage(), m_pConsole, pFilename, GameClient()->NetVersion(), m_aCurrentMap, &Sha256, m_pMap->Crc(), "client", m_pMap->MapSize(), 0, m_pMap->File());
+		m_aDemoRecorder[RECORDER_RACE].Start(Storage(), m_pConsole, pFilename, GameClient()->NetVersion(), m_aCurrentMap, &Sha256, m_pMap->Crc(), "client", m_pMap->FileSize(), m_pMap->FileData());
 	}
 }
 

--- a/src/engine/map.h
+++ b/src/engine/map.h
@@ -35,11 +35,11 @@ public:
 	virtual bool Load(const char *pMapName) = 0;
 	virtual void Unload() = 0;
 	virtual bool IsLoaded() const = 0;
-	virtual IOHANDLE File() const = 0;
 
 	virtual SHA256_DIGEST Sha256() const = 0;
 	virtual unsigned Crc() const = 0;
-	virtual int MapSize() const = 0;
+	virtual const unsigned char *FileData() const = 0;
+	virtual unsigned FileSize() const = 0;
 };
 
 extern IEngineMap *CreateEngineMap();

--- a/src/engine/shared/datafile.h
+++ b/src/engine/shared/datafile.h
@@ -10,6 +10,8 @@
 
 #include <zlib.h>
 
+#include <memory>
+
 enum
 {
 	ITEMTYPE_EX = 0xffff,
@@ -18,22 +20,22 @@ enum
 // raw datafile access
 class CDataFileReader
 {
-	struct CDatafile *m_pDataFile;
-	void *GetDataImpl(int Index, int Swap);
+	std::shared_ptr<class CDataFileMemoryReader> m_pMemoryReader = nullptr;
+	struct CDatafile *m_pDataFile = nullptr;
+
+	void *GetDataImpl(int Index, bool Swap);
 	int GetFileDataSize(int Index) const;
 
 	int GetExternalItemType(int InternalType);
 	int GetInternalItemType(int ExternalType);
 
 public:
-	CDataFileReader() :
-		m_pDataFile(nullptr) {}
+	CDataFileReader() {}
 	~CDataFileReader() { Close(); }
 
 	bool Open(class IStorage *pStorage, const char *pFilename, int StorageType);
-	bool Close();
+	void Close();
 	bool IsOpen() const { return m_pDataFile != nullptr; }
-	IOHANDLE File() const;
 
 	void *GetData(int Index);
 	void *GetDataSwapped(int Index); // makes sure that the data is 32bit LE ints when saved
@@ -51,7 +53,8 @@ public:
 
 	SHA256_DIGEST Sha256() const;
 	unsigned Crc() const;
-	int MapSize() const;
+	const unsigned char *FileData() const;
+	unsigned FileSize() const;
 };
 
 // write access

--- a/src/engine/shared/demo.cpp
+++ b/src/engine/shared/demo.cpp
@@ -882,7 +882,10 @@ bool CDemoPlayer::ExtractMap(class IStorage *pStorage)
 	// save map
 	IOHANDLE MapFile = pStorage->OpenFile(aMapFilename, IOFLAG_WRITE, IStorage::TYPE_SAVE);
 	if(!MapFile)
+	{
+		free(pMapData);
 		return false;
+	}
 
 	io_write(MapFile, pMapData, m_MapInfo.m_Size);
 	io_close(MapFile);

--- a/src/engine/shared/demo.cpp
+++ b/src/engine/shared/demo.cpp
@@ -45,12 +45,11 @@ CDemoRecorder::CDemoRecorder(class CSnapshotDelta *pSnapshotDelta, bool NoMapDat
 }
 
 // Record
-int CDemoRecorder::Start(class IStorage *pStorage, class IConsole *pConsole, const char *pFilename, const char *pNetVersion, const char *pMap, SHA256_DIGEST *pSha256, unsigned Crc, const char *pType, unsigned MapSize, unsigned char *pMapData, IOHANDLE MapFile, DEMOFUNC_FILTER pfnFilter, void *pUser)
+int CDemoRecorder::Start(class IStorage *pStorage, class IConsole *pConsole, const char *pFilename, const char *pNetVersion, const char *pMap, SHA256_DIGEST *pSha256, unsigned Crc, const char *pType, unsigned MapSize, const unsigned char *pMapData, IOHANDLE MapFile, DEMOFUNC_FILTER pfnFilter, void *pUser)
 {
 	m_pfnFilter = pfnFilter;
 	m_pUser = pUser;
 
-	m_pMapData = pMapData;
 	m_pConsole = pConsole;
 
 	IOHANDLE DemoFile = pStorage->OpenFile(pFilename, IOFLAG_WRITE, IStorage::TYPE_SAVE);

--- a/src/engine/shared/demo.h
+++ b/src/engine/shared/demo.h
@@ -26,7 +26,6 @@ class CDemoRecorder : public IDemoRecorder
 	int m_NumTimelineMarkers;
 	int m_aTimelineMarkers[MAX_TIMELINE_MARKERS];
 	bool m_NoMapData;
-	unsigned char *m_pMapData;
 
 	DEMOFUNC_FILTER m_pfnFilter;
 	void *m_pUser;
@@ -38,7 +37,7 @@ public:
 	CDemoRecorder(class CSnapshotDelta *pSnapshotDelta, bool NoMapData = false);
 	CDemoRecorder() {}
 
-	int Start(class IStorage *pStorage, class IConsole *pConsole, const char *pFilename, const char *pNetversion, const char *pMap, SHA256_DIGEST *pSha256, unsigned MapCrc, const char *pType, unsigned MapSize, unsigned char *pMapData, IOHANDLE MapFile = nullptr, DEMOFUNC_FILTER pfnFilter = nullptr, void *pUser = nullptr);
+	int Start(class IStorage *pStorage, class IConsole *pConsole, const char *pFilename, const char *pNetversion, const char *pMap, SHA256_DIGEST *pSha256, unsigned MapCrc, const char *pType, unsigned MapSize, const unsigned char *pMapData, IOHANDLE MapFile = nullptr, DEMOFUNC_FILTER pfnFilter = nullptr, void *pUser = nullptr);
 	int Stop() override;
 
 	void AddDemoMarker();

--- a/src/engine/shared/map.cpp
+++ b/src/engine/shared/map.cpp
@@ -107,11 +107,6 @@ bool CMap::IsLoaded() const
 	return m_DataFile.IsOpen();
 }
 
-IOHANDLE CMap::File() const
-{
-	return m_DataFile.File();
-}
-
 SHA256_DIGEST CMap::Sha256() const
 {
 	return m_DataFile.Sha256();
@@ -122,9 +117,14 @@ unsigned CMap::Crc() const
 	return m_DataFile.Crc();
 }
 
-int CMap::MapSize() const
+const unsigned char *CMap::FileData() const
 {
-	return m_DataFile.MapSize();
+	return m_DataFile.FileData();
+}
+
+unsigned CMap::FileSize() const
+{
+	return m_DataFile.FileSize();
 }
 
 void CMap::ExtractTiles(CTile *pDest, size_t DestSize, const CTile *pSrc, size_t SrcSize)

--- a/src/engine/shared/map.h
+++ b/src/engine/shared/map.h
@@ -32,11 +32,11 @@ public:
 	bool Load(const char *pMapName) override;
 	void Unload() override;
 	bool IsLoaded() const override;
-	IOHANDLE File() const override;
 
 	SHA256_DIGEST Sha256() const override;
 	unsigned Crc() const override;
-	int MapSize() const override;
+	const unsigned char *FileData() const override;
+	unsigned FileSize() const override;
 
 	static void ExtractTiles(class CTile *pDest, size_t DestSize, const class CTile *pSrc, size_t SrcSize);
 };

--- a/src/tools/map_extract.cpp
+++ b/src/tools/map_extract.cpp
@@ -95,7 +95,8 @@ bool Process(IStorage *pStorage, const char *pMapName, const char *pPathSave)
 		io_close(Opus);
 	}
 
-	return Reader.Close();
+	Reader.Close();
+	return true;
 }
 
 int main(int argc, const char *argv[])


### PR DESCRIPTION
See commit messages.

Closes #6922.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
