### PR TITLE
Revert "Execute CFGFLAG_GAME configs from map load on the client"

### DIFF
--- a/src/engine/shared/console.cpp
+++ b/src/engine/shared/console.cpp
@@ -438,11 +438,7 @@ void CConsole::ExecuteLineStroked(int Stroke, const char *pStr, int ClientID, bo
 		if(!*Result.m_pCommand)
 			return;
 
-		CCommand *pCommand;
-		if(ClientID == IConsole::CLIENT_ID_GAME)
-			pCommand = FindCommand(Result.m_pCommand, m_FlagMask | CFGFLAG_GAME);
-		else
-			pCommand = FindCommand(Result.m_pCommand, m_FlagMask);
+		CCommand *pCommand = FindCommand(Result.m_pCommand, m_FlagMask);
 
 		if(pCommand)
 		{

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -522,7 +522,6 @@ void CGameClient::OnConnected()
 	m_GameWorld.m_WorldConfig.m_InfiniteAmmo = true;
 	mem_zero(&m_GameInfo, sizeof(m_GameInfo));
 	m_PredictedDummyID = -1;
-	Console()->ResetServerGameSettings();
 	LoadMapSettings();
 
 	if(Client()->State() != IClient::STATE_DEMOPLAYBACK && g_Config.m_ClAutoDemoOnConnect)


### PR DESCRIPTION
Reverts #6912.

Closes #6921.

Supersedes #6928.

Reopens #6774.