### PR TITLE
Rework base IO functions on Windows using `HANDLE`

### DIFF
--- a/src/base/logger.h
+++ b/src/base/logger.h
@@ -7,7 +7,7 @@
 #include <mutex>
 #include <vector>
 
-typedef struct IOINTERNAL *IOHANDLE;
+typedef void *IOHANDLE;
 
 /**
  * @ingroup Log

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -223,7 +223,7 @@ enum
 	IO_MAX_PATH_LENGTH = 512,
 };
 
-typedef struct IOINTERNAL *IOHANDLE;
+typedef void *IOHANDLE;
 
 /**
  * Opens a file.


### PR DESCRIPTION
Switch to using the Windows-specific `HANDLE` and Windows API functions instead of `FILE *` and standard library functions in all Windows IO function implementations.

Using `CreateFileW` instead of `_wfsopen` to open files is necessary, as only `CreateFileW` allows specifying all necessary sharing flags. The sharing flags `FILE_SHARE_READ` and `FILE_SHARE_WRITE` were previously already specified by using `_SH_DENYNO` with `_wfsopen`, but `FILE_SHARE_DELETE` can only be set when using `CreateFileW`. The flags are necessary so files which are in use by the game can still be opened by other processes. In particular, `FILE_SHARE_DELETE` allows deleting/renaming of open files, which was previously not possible. This was causing the smart editor saving process that renames files to fail if a map file is currently in use.

Because `CreateFileW` returns a `HANDLE` instead of a `FILE *` we have to use the `HANDLE`-based Windows IO functions everywhere.

See: https://devblogs.microsoft.com/oldnewthing/20211022-00/?p=105822

Closes #6922.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
