### PR TITLE
Fix leak of map data when extracting map from demo fails

### DIFF
--- a/src/engine/shared/demo.cpp
+++ b/src/engine/shared/demo.cpp
@@ -882,7 +882,10 @@ bool CDemoPlayer::ExtractMap(class IStorage *pStorage)
 	// save map
 	IOHANDLE MapFile = pStorage->OpenFile(aMapFilename, IOFLAG_WRITE, IStorage::TYPE_SAVE);
 	if(!MapFile)
+	{
+		free(pMapData);
 		return false;
+	}
 
 	io_write(MapFile, pMapData, m_MapInfo.m_Size);
 	io_close(MapFile);


### PR DESCRIPTION

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
