### PR TITLE
Remove inverted round rectangle corner drawing

### DIFF
--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -1377,50 +1377,6 @@ void CGraphics_Threaded::DrawRectExt4(float x, float y, float w, float h, ColorR
 				x + w - r + Ca2 * r, y + h - r + Sa2 * r);
 			QuadsDrawFreeform(&ItemF, 1);
 		}
-
-		if(Corners & CORNER_ITL)
-		{
-			SetColor(ColorTopLeft);
-			IGraphics::CFreeformItem ItemF = IGraphics::CFreeformItem(
-				x, y,
-				x + (1 - Ca1) * r, y - r + Sa1 * r,
-				x + (1 - Ca3) * r, y - r + Sa3 * r,
-				x + (1 - Ca2) * r, y - r + Sa2 * r);
-			QuadsDrawFreeform(&ItemF, 1);
-		}
-
-		if(Corners & CORNER_ITR)
-		{
-			SetColor(ColorTopRight);
-			IGraphics::CFreeformItem ItemF = IGraphics::CFreeformItem(
-				x + w, y,
-				x + w - r + Ca1 * r, y - r + Sa1 * r,
-				x + w - r + Ca3 * r, y - r + Sa3 * r,
-				x + w - r + Ca2 * r, y - r + Sa2 * r);
-			QuadsDrawFreeform(&ItemF, 1);
-		}
-
-		if(Corners & CORNER_IBL)
-		{
-			SetColor(ColorBottomLeft);
-			IGraphics::CFreeformItem ItemF = IGraphics::CFreeformItem(
-				x, y + h,
-				x + (1 - Ca1) * r, y + h + (1 - Sa1) * r,
-				x + (1 - Ca3) * r, y + h + (1 - Sa3) * r,
-				x + (1 - Ca2) * r, y + h + (1 - Sa2) * r);
-			QuadsDrawFreeform(&ItemF, 1);
-		}
-
-		if(Corners & CORNER_IBR)
-		{
-			SetColor(ColorBottomRight);
-			IGraphics::CFreeformItem ItemF = IGraphics::CFreeformItem(
-				x + w, y + h,
-				x + w - r + Ca1 * r, y + h + (1 - Sa1) * r,
-				x + w - r + Ca3 * r, y + h + (1 - Sa3) * r,
-				x + w - r + Ca2 * r, y + h + (1 - Sa2) * r);
-			QuadsDrawFreeform(&ItemF, 1);
-		}
 	}
 
 	SetColor4(ColorTopLeft, ColorTopRight, ColorBottomLeft, ColorBottomRight);

--- a/src/engine/graphics.h
+++ b/src/engine/graphics.h
@@ -461,23 +461,13 @@ public:
 		CORNER_TR = 2,
 		CORNER_BL = 4,
 		CORNER_BR = 8,
-		CORNER_ITL = 16,
-		CORNER_ITR = 32,
-		CORNER_IBL = 64,
-		CORNER_IBR = 128,
 
 		CORNER_T = CORNER_TL | CORNER_TR,
 		CORNER_B = CORNER_BL | CORNER_BR,
 		CORNER_R = CORNER_TR | CORNER_BR,
 		CORNER_L = CORNER_TL | CORNER_BL,
 
-		CORNER_IT = CORNER_ITL | CORNER_ITR,
-		CORNER_IB = CORNER_IBL | CORNER_IBR,
-		CORNER_IR = CORNER_ITR | CORNER_IBR,
-		CORNER_IL = CORNER_ITL | CORNER_IBL,
-
 		CORNER_ALL = CORNER_T | CORNER_B,
-		CORNER_INV_ALL = CORNER_IT | CORNER_IB
 	};
 	virtual void DrawRectExt(float x, float y, float w, float h, float r, int Corners) = 0;
 	virtual void DrawRectExt4(float x, float y, float w, float h, ColorRGBA ColorTopLeft, ColorRGBA ColorTopRight, ColorRGBA ColorBottomLeft, ColorRGBA ColorBottomRight, float r, int Corners) = 0;


### PR DESCRIPTION
Rectangles with inverted round corners (`IGraphics::CORNER_I*`) are currently not used anywhere and also only supported when using `Draw4`.

They also feel clunky to use due to the inverted corners being drawn outside of the specified rectangle area.

Here is how the inverted round corners would look like (on color pickers because it's the only place where we use `Draw4`):

![inverted corners](https://github.com/ddnet/ddnet/assets/23437060/36880fce-e90f-4bf4-bd2a-a0147d1977a4)

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
