### PR TITLE
ResetServerGameSettings → ResetGameSettings, remove flag argument

### DIFF
--- a/src/engine/console.h
+++ b/src/engine/console.h
@@ -119,7 +119,7 @@ public:
 
 	virtual void SetAccessLevel(int AccessLevel) = 0;
 
-	virtual void ResetServerGameSettings(int FlagMask) = 0;
+	virtual void ResetGameSettings() = 0;
 
 	static LEVEL ToLogLevel(int ConsoleLevel);
 

--- a/src/engine/shared/console.cpp
+++ b/src/engine/shared/console.cpp
@@ -1263,13 +1263,13 @@ const IConsole::CCommandInfo *CConsole::GetCommandInfo(const char *pName, int Fl
 
 std::unique_ptr<IConsole> CreateConsole(int FlagMask) { return std::make_unique<CConsole>(FlagMask); }
 
-void CConsole::ResetServerGameSettings(int FlagMask)
+void CConsole::ResetGameSettings()
 {
 #define MACRO_CONFIG_INT(Name, ScriptName, Def, Min, Max, Flags, Desc) \
 	{ \
-		if(((Flags) & (CFGFLAG_SERVER | CFGFLAG_GAME)) == (CFGFLAG_SERVER | CFGFLAG_GAME)) \
+		if(((Flags)&CFGFLAG_GAME) == CFGFLAG_GAME) \
 		{ \
-			CCommand *pCommand = FindCommand(#ScriptName, FlagMask); \
+			CCommand *pCommand = FindCommand(#ScriptName, CFGFLAG_GAME); \
 			void *pUserData = pCommand->m_pUserData; \
 			FCommandCallback pfnCallback = pCommand->m_pfnCallback; \
 			TraverseChain(&pfnCallback, &pUserData); \
@@ -1282,9 +1282,9 @@ void CConsole::ResetServerGameSettings(int FlagMask)
 
 #define MACRO_CONFIG_STR(Name, ScriptName, Len, Def, Flags, Desc) \
 	{ \
-		if(((Flags) & (CFGFLAG_SERVER | CFGFLAG_GAME)) == (CFGFLAG_SERVER | CFGFLAG_GAME)) \
+		if(((Flags)&CFGFLAG_GAME) == CFGFLAG_GAME) \
 		{ \
-			CCommand *pCommand = FindCommand(#ScriptName, FlagMask); \
+			CCommand *pCommand = FindCommand(#ScriptName, CFGFLAG_GAME); \
 			void *pUserData = pCommand->m_pUserData; \
 			FCommandCallback pfnCallback = pCommand->m_pfnCallback; \
 			TraverseChain(&pfnCallback, &pUserData); \

--- a/src/engine/shared/console.h
+++ b/src/engine/shared/console.h
@@ -223,7 +223,7 @@ public:
 	void InitChecksum(CChecksumData *pData) const override;
 
 	void SetAccessLevel(int AccessLevel) override { m_AccessLevel = clamp(AccessLevel, (int)(ACCESS_LEVEL_ADMIN), (int)(ACCESS_LEVEL_USER)); }
-	void ResetServerGameSettings(int FlagMask) override;
+	void ResetGameSettings() override;
 	// DDRace
 
 	static void ConUserCommandStatus(IConsole::IResult *pResult, void *pUser);

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -522,7 +522,7 @@ void CGameClient::OnConnected()
 	m_GameWorld.m_WorldConfig.m_InfiniteAmmo = true;
 	mem_zero(&m_GameInfo, sizeof(m_GameInfo));
 	m_PredictedDummyID = -1;
-	Console()->ResetServerGameSettings(CFGFLAG_GAME);
+	Console()->ResetGameSettings();
 	LoadMapSettings();
 
 	if(Client()->State() != IClient::STATE_DEMOPLAYBACK && g_Config.m_ClAutoDemoOnConnect)

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -3813,7 +3813,7 @@ void CGameContext::OnShutdown()
 	}
 
 	DeleteTempfile();
-	Console()->ResetServerGameSettings(CFGFLAG_SERVER);
+	Console()->ResetGameSettings();
 	Collision()->Dest();
 	delete m_pController;
 	m_pController = 0;


### PR DESCRIPTION
The old code looked pretty weird. It checked for `CFGFLAG_SERVER | CFGFLAG_GAME` being set above, and then used the passed-in parameter to find the command. I think it'd be better to just look for `CFGFLAG_GAME` and then find the command using `CFGFLAG_GAME`.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
