### PR TITLE
Delete fishy-looking assignment operator/copy constructor of `IJob`

### DIFF
--- a/src/engine/shared/jobs.cpp
+++ b/src/engine/shared/jobs.cpp
@@ -9,17 +9,6 @@ IJob::IJob() :
 {
 }
 
-IJob::IJob(const IJob &Other) :
-	m_Status(STATE_PENDING)
-{
-}
-
-IJob &IJob::operator=(const IJob &Other)
-{
-	m_Status = STATE_PENDING;
-	return *this;
-}
-
 IJob::~IJob() = default;
 
 int IJob::Status()

--- a/src/engine/shared/jobs.h
+++ b/src/engine/shared/jobs.h
@@ -22,8 +22,8 @@ private:
 
 public:
 	IJob();
-	IJob(const IJob &Other);
-	IJob &operator=(const IJob &Other);
+	IJob(const IJob &Other) = delete;
+	IJob &operator=(const IJob &Other) = delete;
 	virtual ~IJob();
 	int Status();
 


### PR DESCRIPTION
Since they're not called anyway, they can go away.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
