### PR TITLE
Fix stack overflow in destructor when dnsbl object is kept too long alive

### DIFF
--- a/src/engine/shared/jobs.cpp
+++ b/src/engine/shared/jobs.cpp
@@ -62,6 +62,8 @@ void CJobPool::WorkerThread(void *pUser)
 			{
 				pJob = pPool->m_pFirstJob;
 				pPool->m_pFirstJob = pPool->m_pFirstJob->m_pNext;
+				// allow remaining objects in list to destruct, even when current object stays alive
+				pJob->m_pNext = nullptr;
 				if(!pPool->m_pFirstJob)
 					pPool->m_pLastJob = 0;
 			}


### PR DESCRIPTION
`shared_ptr`s of `CServer::m_pDnsblLookup[ClientID]` are set, but not cleaned up when done. Therefore the Job is kept alive until the player disconnects and a new player joins on that slot. Currently this means that the full linked list of jobs is kept alive.

When the Job is overwritten with a new job, all the remaining objects in the list can be dropped. With enough jobs, that is causing a stack overflow in the destructor.

This patch fixes this overflow by making the lifetime independent of the previous Job. Jobs can get dropped after processing them, even when the previous job is still alive.

Fixes #6954

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
