### PR TITLE
When quitting/restarting client clear screen and render message

### DIFF
--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -915,6 +915,8 @@ void CGameClient::OnStateChange(int NewState, int OldState)
 
 void CGameClient::OnShutdown()
 {
+	RenderShutdownMessage();
+
 	for(auto &pComponent : m_vpAll)
 		pComponent->OnShutdown();
 }
@@ -970,6 +972,25 @@ void CGameClient::OnWindowResize()
 void CGameClient::OnLanguageChange()
 {
 	UI()->OnLanguageChange();
+}
+
+void CGameClient::RenderShutdownMessage()
+{
+	const char *pMessage = nullptr;
+	if(Client()->State() == IClient::STATE_QUITTING)
+		pMessage = Localize("Quitting. Please wait…");
+	else if(Client()->State() == IClient::STATE_RESTARTING)
+		pMessage = Localize("Restarting. Please wait…");
+	else
+		dbg_assert(false, "Invalid client state for quitting message");
+
+	// This function only gets called after the render loop has already terminated, so we have to call Swap manually.
+	Graphics()->Clear(0.0f, 0.0f, 0.0f);
+	UI()->MapScreen();
+	TextRender()->TextColor(TextRender()->DefaultTextColor());
+	UI()->DoLabel(UI()->Screen(), pMessage, 16.0f, TEXTALIGN_MC);
+	Graphics()->Swap();
+	Graphics()->Clear(0.0f, 0.0f, 0.0f);
 }
 
 void CGameClient::OnRconType(bool UsernameReq)

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -489,6 +489,8 @@ public:
 
 	void OnLanguageChange();
 
+	void RenderShutdownMessage();
+
 	const char *GetItemName(int Type) const override;
 	const char *Version() const override;
 	const char *NetVersion() const override;


### PR DESCRIPTION
When quitting or restarting the client, clear the screen and render a message "Quitting. Please wait…" or "Restarting. Please wait…" respectively.

Previously the last frame would keep getting shown while the client is busy with cleanup tasks. Rendering a final message before the client window stops being updated provides a cleaner user experience.

Screenshots:
- ![quitting](https://github.com/ddnet/ddnet/assets/23437060/190faceb-a5b9-4d66-89b4-d8710a4ad22d)
- ![restarting](https://github.com/ddnet/ddnet/assets/23437060/20ac90c0-e123-444c-a356-72405b2e56d1)

## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
