### PR TITLE
Fix emotes sometimes being shown for others tees

### DIFF
--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -2541,8 +2541,7 @@ void CGameContext::OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID)
 				{
 					for(int i = 0; i < MAX_CLIENTS; ++i)
 					{
-						if(Server()->Translate(ClientID, i) &&
-							m_apPlayers[i] && pChr->CanSnapCharacter(i) && pChr->IsSnappingCharacterInView(i))
+						if(m_apPlayers[i] && pChr->CanSnapCharacter(i) && pChr->IsSnappingCharacterInView(i))
 						{
 							SendEmoticon(ClientID, pMsg->m_Emoticon, i);
 						}


### PR DESCRIPTION
The `Translate` function modifies the first argument, so the client ID keeps changing when the function is being used in a loop. Additionally, calling `Translate` manually is not necessary for messages, as client IDs in messages are already automatically translated when using `SendPackMsg`. Both faults can cause emoticons to appear on the wrong players when the emote spamprotection limits emotes to nearby players.

## Checklist

- [ ] Tested the change ingame (couldn't easily reproduce it locally)
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
