### PR TITLE
Fix client crash with more than `MAX_VOTE_OPTIONS` vote options

### DIFF
--- a/src/game/client/components/voting.cpp
+++ b/src/game/client/components/voting.cpp
@@ -148,6 +148,9 @@ CVoting::CVoting()
 
 void CVoting::AddOption(const char *pDescription)
 {
+	if(m_NumVoteOptions == MAX_VOTE_OPTIONS)
+		return;
+
 	CVoteOptionClient *pOption;
 	if(m_pRecycleFirst)
 	{


### PR DESCRIPTION
The server does not allow adding more than `MAX_VOTE_OPTIONS` vote options, so the client will now also refuse to add more options than that.

Supersedes #6930.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
