### PR TITLE
Fix crash when using `goto_tele` in map without tele layer

### DIFF
--- a/src/game/client/components/camera.cpp
+++ b/src/game/client/components/camera.cpp
@@ -256,6 +256,9 @@ void CCamera::SetView(ivec2 Pos)
 
 void CCamera::GotoSwitch(int Number, int Offset)
 {
+	if(Collision()->SwitchLayer() == nullptr)
+		return;
+
 	int Match = -1;
 	ivec2 MatchPos = ivec2(-1, -1);
 
@@ -297,6 +300,9 @@ void CCamera::GotoSwitch(int Number, int Offset)
 
 void CCamera::GotoTele(int Number, int Offset)
 {
+	if(Collision()->TeleLayer() == nullptr)
+		return;
+
 	int Match = -1;
 	ivec2 MatchPos = ivec2(-1, -1);
 


### PR DESCRIPTION
The check for `goto_switch` is added for completeness but not strictly necessary, as this is also checked in `GetSwitchNumber`.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
