### PR TITLE
Fix /load from backup database

### DIFF
--- a/src/game/server/scoreworker.cpp
+++ b/src/game/server/scoreworker.cpp
@@ -1641,7 +1641,7 @@ bool CScoreWorker::SaveTeam(IDbConnection *pSqlServer, const ISqlData *pGameData
 
 bool CScoreWorker::LoadTeam(IDbConnection *pSqlServer, const ISqlData *pGameData, Write w, char *pError, int ErrorSize)
 {
-	if(w == Write::NORMAL_SUCCEEDED || Write::BACKUP_FIRST)
+	if(w == Write::NORMAL_SUCCEEDED || w == Write::BACKUP_FIRST)
 		return false;
 	const auto *pData = dynamic_cast<const CSqlTeamLoad *>(pGameData);
 	auto *pResult = dynamic_cast<CScoreSaveResult *>(pGameData->m_pResult.get());


### PR DESCRIPTION
Saves were deleted without the team getting its state when /load and /save both happened during mysql server not reachable.

Before this fix, the saves were only in the DDNet log output for recovery, not in any database anymore.

`Write::BACKUP_FIRST` is 0 so always false, so the previous code didn't harm other code paths (especially `Write::NORMAL`). The saves were tried to retrieve two times from the database, therefore at the second time it didn't exist anymore. One time erroneously in `Write::BACKUP_FIRST` and the second time in `Write::NORMAL_FAILED`.

Fixes #6924

<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
