### PR TITLE
Fix textrender variables being uninitialized

### DIFF
--- a/src/engine/client/text.cpp
+++ b/src/engine/client/text.cpp
@@ -325,10 +325,10 @@ private:
 	uint8_t m_aaGlyphData[NUM_FONT_TEXTURES][64 * 1024];
 
 	// Font faces
-	FT_Face m_DefaultFace;
-	FT_Face m_IconFace;
-	FT_Face m_VariantFace;
-	FT_Face m_SelectedFace;
+	FT_Face m_DefaultFace = nullptr;
+	FT_Face m_IconFace = nullptr;
+	FT_Face m_VariantFace = nullptr;
+	FT_Face m_SelectedFace = nullptr;
 	std::vector<FT_Face> m_vFallbackFaces;
 	std::vector<FT_Face> m_vFtFaces;
 


### PR DESCRIPTION
Regression from #6952.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
