### PR TITLE
Use `Localizable` instead of `Localize` inside comment

### DIFF
--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -6,6 +6,7 @@
 #include <engine/graphics.h>
 #include <engine/shared/config.h>
 #include <engine/shared/linereader.h>
+#include <engine/shared/localization.h>
 #include <engine/storage.h>
 #include <engine/textrender.h>
 #include <engine/updater.h>
@@ -947,69 +948,56 @@ typedef struct
 
 static CKeyInfo gs_aKeys[] =
 	{
-		{"Move left", "+left", 0, 0}, // Localize - these strings are localized within CLocConstString
-		{"Move right", "+right", 0, 0},
-		{"Jump", "+jump", 0, 0},
-		{"Fire", "+fire", 0, 0},
-		{"Hook", "+hook", 0, 0},
-		{"Hook collisions", "+showhookcoll", 0, 0},
-		{"Pause", "say /pause", 0, 0},
-		{"Kill", "kill", 0, 0},
-		{"Zoom in", "zoom+", 0, 0},
-		{"Zoom out", "zoom-", 0, 0},
-		{"Default zoom", "zoom", 0, 0},
-		{"Show others", "say /showothers", 0, 0},
-		{"Show all", "say /showall", 0, 0},
-		{"Toggle dyncam", "toggle cl_dyncam 0 1", 0, 0},
-		{"Toggle ghost", "toggle cl_race_show_ghost 0 1", 0, 0},
+		{Localizable("Move left"), "+left", 0, 0}, // Localize - these strings are localized within CLocConstString
+		{Localizable("Move right"), "+right", 0, 0},
+		{Localizable("Jump"), "+jump", 0, 0},
+		{Localizable("Fire"), "+fire", 0, 0},
+		{Localizable("Hook"), "+hook", 0, 0},
+		{Localizable("Hook collisions"), "+showhookcoll", 0, 0},
+		{Localizable("Pause"), "say /pause", 0, 0},
+		{Localizable("Kill"), "kill", 0, 0},
+		{Localizable("Zoom in"), "zoom+", 0, 0},
+		{Localizable("Zoom out"), "zoom-", 0, 0},
+		{Localizable("Default zoom"), "zoom", 0, 0},
+		{Localizable("Show others"), "say /showothers", 0, 0},
+		{Localizable("Show all"), "say /showall", 0, 0},
+		{Localizable("Toggle dyncam"), "toggle cl_dyncam 0 1", 0, 0},
+		{Localizable("Toggle ghost"), "toggle cl_race_show_ghost 0 1", 0, 0},
 
-		{"Hammer", "+weapon1", 0, 0},
-		{"Pistol", "+weapon2", 0, 0},
-		{"Shotgun", "+weapon3", 0, 0},
-		{"Grenade", "+weapon4", 0, 0},
-		{"Laser", "+weapon5", 0, 0},
-		{"Next weapon", "+nextweapon", 0, 0},
-		{"Prev. weapon", "+prevweapon", 0, 0},
+		{Localizable("Hammer"), "+weapon1", 0, 0},
+		{Localizable("Pistol"), "+weapon2", 0, 0},
+		{Localizable("Shotgun"), "+weapon3", 0, 0},
+		{Localizable("Grenade"), "+weapon4", 0, 0},
+		{Localizable("Laser"), "+weapon5", 0, 0},
+		{Localizable("Next weapon"), "+nextweapon", 0, 0},
+		{Localizable("Prev. weapon"), "+prevweapon", 0, 0},
 
-		{"Vote yes", "vote yes", 0, 0},
-		{"Vote no", "vote no", 0, 0},
+		{Localizable("Vote yes"), "vote yes", 0, 0},
+		{Localizable("Vote no"), "vote no", 0, 0},
 
-		{"Chat", "+show_chat; chat all", 0, 0},
-		{"Team chat", "+show_chat; chat team", 0, 0},
-		{"Converse", "+show_chat; chat all /c ", 0, 0},
-		{"Chat command", "+show_chat; chat all /", 0, 0},
-		{"Show chat", "+show_chat", 0, 0},
+		{Localizable("Chat"), "+show_chat; chat all", 0, 0},
+		{Localizable("Team chat"), "+show_chat; chat team", 0, 0},
+		{Localizable("Converse"), "+show_chat; chat all /c ", 0, 0},
+		{Localizable("Chat command"), "+show_chat; chat all /", 0, 0},
+		{Localizable("Show chat"), "+show_chat", 0, 0},
 
-		{"Toggle dummy", "toggle cl_dummy 0 1", 0, 0},
-		{"Dummy copy", "toggle cl_dummy_copy_moves 0 1", 0, 0},
-		{"Hammerfly dummy", "toggle cl_dummy_hammer 0 1", 0, 0},
+		{Localizable("Toggle dummy"), "toggle cl_dummy 0 1", 0, 0},
+		{Localizable("Dummy copy"), "toggle cl_dummy_copy_moves 0 1", 0, 0},
+		{Localizable("Hammerfly dummy"), "toggle cl_dummy_hammer 0 1", 0, 0},
 
-		{"Emoticon", "+emote", 0, 0},
-		{"Spectator mode", "+spectate", 0, 0},
-		{"Spectate next", "spectate_next", 0, 0},
-		{"Spectate previous", "spectate_previous", 0, 0},
-		{"Console", "toggle_local_console", 0, 0},
-		{"Remote console", "toggle_remote_console", 0, 0},
-		{"Screenshot", "screenshot", 0, 0},
-		{"Scoreboard", "+scoreboard", 0, 0},
-		{"Statboard", "+statboard", 0, 0},
-		{"Lock team", "say /lock", 0, 0},
-		{"Show entities", "toggle cl_overlay_entities 0 100", 0, 0},
-		{"Show HUD", "toggle cl_showhud 0 1", 0, 0},
+		{Localizable("Emoticon"), "+emote", 0, 0},
+		{Localizable("Spectator mode"), "+spectate", 0, 0},
+		{Localizable("Spectate next"), "spectate_next", 0, 0},
+		{Localizable("Spectate previous"), "spectate_previous", 0, 0},
+		{Localizable("Console"), "toggle_local_console", 0, 0},
+		{Localizable("Remote console"), "toggle_remote_console", 0, 0},
+		{Localizable("Screenshot"), "screenshot", 0, 0},
+		{Localizable("Scoreboard"), "+scoreboard", 0, 0},
+		{Localizable("Statboard"), "+statboard", 0, 0},
+		{Localizable("Lock team"), "say /lock", 0, 0},
+		{Localizable("Show entities"), "toggle cl_overlay_entities 0 100", 0, 0},
+		{Localizable("Show HUD"), "toggle cl_showhud 0 1", 0, 0},
 };
-
-/*	This is for scripts/languages to work, don't remove!
-	Localize("Move left");Localize("Move right");Localize("Jump");Localize("Fire");Localize("Hook");
-	Localize("Hook collisions");Localize("Pause");Localize("Kill");Localize("Zoom in");Localize("Zoom out");
-	Localize("Default zoom");Localize("Show others");Localize("Show all");Localize("Toggle dyncam");
-	Localize("Toggle dummy");Localize("Toggle ghost");Localize("Dummy copy");Localize("Hammerfly dummy");
-	Localize("Hammer");Localize("Pistol");Localize("Shotgun");Localize("Grenade");Localize("Laser");
-	Localize("Next weapon");Localize("Prev. weapon");Localize("Vote yes");Localize("Vote no");
-	Localize("Chat");Localize("Team chat");Localize("Converse");Localize("Show chat");Localize("Emoticon");
-	Localize("Spectator mode");Localize("Spectate next");Localize("Spectate previous");Localize("Console");
-	Localize("Remote console");Localize("Screenshot");Localize("Scoreboard");Localize("Statboard");
-	Localize("Lock team");Localize("Show entities");Localize("Show HUD");Localize("Chat command");
-*/
 
 void CMenus::DoSettingsControlsButtons(int Start, int Stop, CUIRect View)
 {


### PR DESCRIPTION


## Checklist

- [X] Tested the change with `scripts/languages/update_all.py`: this does not change any translations except for reordering some untranslated strings
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
