### PR TITLE
Switch order in which envelope points are selected

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -5969,7 +5969,7 @@ void CEditor::SetHotEnvelopePoint(const CUIRect &View, const std::shared_ptr<CEn
 
 	for(size_t i = 0; i < pEnvelope->m_vPoints.size(); i++)
 	{
-		for(int c = 0; c < pEnvelope->GetChannels(); c++)
+		for(int c = pEnvelope->GetChannels() - 1; c >= 0; c--)
 		{
 			if(i > 0 && pEnvelope->m_vPoints[i - 1].m_Curvetype == CURVETYPE_BEZIER)
 			{


### PR DESCRIPTION
When multiple envelope points could be selected, switch the order such that the one that is visible is selected first.
The mouse is hovering the second point in both pictures.
Before:
![screenshot_2023-08-10_08-20-30](https://github.com/ddnet/ddnet/assets/49279081/306f927d-a72a-46c9-ba20-75013066eed0)
After:
![screenshot_2023-08-10_08-20-01](https://github.com/ddnet/ddnet/assets/49279081/f96b50fd-325e-4f3a-ad08-e99c262e8972)

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
