### PR TITLE
Ignore hidden channels when selecting envelopes

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -5944,7 +5944,7 @@ private:
 	}
 };
 
-void CEditor::SetHotEnvelopePoint(const CUIRect &View, const std::shared_ptr<CEnvelope> &pEnvelope)
+void CEditor::SetHotEnvelopePoint(const CUIRect &View, const std::shared_ptr<CEnvelope> &pEnvelope, int ActiveChannels)
 {
 	if(!UI()->MouseInside(&View))
 		return;
@@ -5971,6 +5971,9 @@ void CEditor::SetHotEnvelopePoint(const CUIRect &View, const std::shared_ptr<CEn
 	{
 		for(int c = 0; c < pEnvelope->GetChannels(); c++)
 		{
+			if(!(ActiveChannels & (1 << c)))
+				continue;
+
 			if(i > 0 && pEnvelope->m_vPoints[i - 1].m_Curvetype == CURVETYPE_BEZIER)
 			{
 				float px = EnvelopeToScreenX(View, fxt2f(pEnvelope->m_vPoints[i].m_Time + pEnvelope->m_vPoints[i].m_Bezier.m_aInTangentDeltaX[c]));
@@ -6583,7 +6586,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 
 		{
 			if(s_Operation == OP_NONE)
-				SetHotEnvelopePoint(View, pEnvelope);
+				SetHotEnvelopePoint(View, pEnvelope, s_ActiveChannels);
 
 			UI()->ClipEnable(&View);
 			Graphics()->TextureClear();

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -1444,7 +1444,7 @@ public:
 
 	void RenderExtraEditorDragBar(CUIRect View, CUIRect DragBar);
 
-	void SetHotEnvelopePoint(const CUIRect &View, const std::shared_ptr<CEnvelope> &pEnvelope);
+	void SetHotEnvelopePoint(const CUIRect &View, const std::shared_ptr<CEnvelope> &pEnvelope, int ActiveChannels);
 
 	void RenderMenubar(CUIRect Menubar);
 	void RenderFileDialog();


### PR DESCRIPTION
When two envelope points overlap it can happen that the hidden one will be marked as hot. Then neither can be selected. Fixes #6989.

<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
