### PR TITLE
Disallow adding overlapping envelope points

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -6299,11 +6299,21 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 						pEnvelope->Eval(Time, Channels);
 					else
 						Channels = {0, 0, 0, 0};
-					pEnvelope->AddPoint(f2fxt(Time),
-						f2fx(Channels.r), f2fx(Channels.g),
-						f2fx(Channels.b), f2fx(Channels.a));
 
-					if(Time < 0)
+					int FixedTime = std::round(Time * 1000.0f);
+					bool TimeFound = false;
+					for(CEnvPoint &Point : pEnvelope->m_vPoints)
+					{
+						if(Point.m_Time == FixedTime)
+							TimeFound = true;
+					}
+
+					if(!TimeFound)
+						pEnvelope->AddPoint(FixedTime,
+							f2fx(Channels.r), f2fx(Channels.g),
+							f2fx(Channels.b), f2fx(Channels.a));
+
+					if(FixedTime < 0)
 						RemoveTimeOffsetEnvelope(pEnvelope);
 					m_Map.OnModify();
 				}


### PR DESCRIPTION
Also now round is used to convert the mouse position to fixed precision time which places the added point closer to the mouse. Fixes #6986.

<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
