### PR TITLE
Fix scoreboard time being reset when using `/timecp`, fix SQL query buffer sizes being too small

### DIFF
--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -905,8 +905,10 @@ void CPlayer::ProcessScoreResult(CScorePlayerResult &Result)
 			break;
 		case CScorePlayerResult::PLAYER_INFO:
 			if(Result.m_Data.m_Info.m_Time.has_value())
+			{
 				GameServer()->Score()->PlayerData(m_ClientID)->Set(Result.m_Data.m_Info.m_Time.value(), Result.m_Data.m_Info.m_aTimeCp);
-			m_Score = Result.m_Data.m_Info.m_Time;
+				m_Score = Result.m_Data.m_Info.m_Time;
+			}
 			Server()->ExpireServerInfo();
 			int Birthday = Result.m_Data.m_Info.m_Birthday;
 			if(Birthday != 0 && !m_BirthdayAnnounced)

--- a/src/game/server/scoreworker.cpp
+++ b/src/game/server/scoreworker.cpp
@@ -128,7 +128,7 @@ bool CScoreWorker::LoadPlayerData(IDbConnection *pSqlServer, const ISqlData *pGa
 	auto *pResult = dynamic_cast<CScorePlayerResult *>(pGameData->m_pResult.get());
 	pResult->SetVariant(CScorePlayerResult::PLAYER_INFO);
 
-	char aBuf[512];
+	char aBuf[1024];
 	// get best race time
 	str_format(aBuf, sizeof(aBuf),
 		"SELECT"
@@ -1002,7 +1002,7 @@ bool CScoreWorker::ShowTeamTop5(IDbConnection *pSqlServer, const ISqlData *pGame
 	const char *pOrder = pData->m_Offset >= 0 ? "ASC" : "DESC";
 
 	// check sort method
-	char aBuf[512];
+	char aBuf[1024];
 
 	str_format(aBuf, sizeof(aBuf),
 		"SELECT Name, Time, Ranking, TeamSize "


### PR DESCRIPTION
Using `/timecp` with a player name that has no time on the current map incorrectly cleared the player score/time causing it to not be shown in the scoreboard anymore.

In `LoadPlayerData` exactly the `LIMIT 1` clause was getting truncated from the query due to the buffer size being insufficient. Depending on the length of the table name prefix the query could have been truncated at any other position resulting in syntax errors.

In `ShowTeamTop5` the buffer size is increased because it could cause truncation with a longer than default table name prefix.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
