### PR TITLE
Minimal fix for macOS info.plist

### DIFF
--- a/other/bundle/client/Info.plist.in
+++ b/other/bundle/client/Info.plist.in
@@ -5,9 +5,9 @@
 		<key>CFBundleDevelopmentRegion</key>
 		<string>English</string>
 		<key>CFBundleExecutable</key>
-		<string>${TARGET_CLIENT}</string>
+		<string>${CLIENT_EXECUTABLE}</string>
 		<key>CFBundleIconFile</key>
-		<string>${TARGET_CLIENT}</string>
+		<string>${CLIENT_EXECUTABLE}</string>
 		<key>CFBundleInfoDictionaryVersion</key>
 		<string>6.0</string>
 		<key>CFBundlePackageType</key>

--- a/other/bundle/server/Info.plist.in
+++ b/other/bundle/server/Info.plist.in
@@ -5,9 +5,9 @@
 		<key>CFBundleDevelopmentRegion</key>
 		<string>English</string>
 		<key>CFBundleExecutable</key>
-		<string>${TARGET_SERVER_LAUNCHER}</string>
+		<string>${SERVER_EXECUTABLE}-Launcher</string>
 		<key>CFBundleIconFile</key>
-		<string>${TARGET_SERVER}</string>
+		<string>${SERVER_EXECUTABLE}</string>
 		<key>CFBundleInfoDictionaryVersion</key>
 		<string>6.0</string>
 		<key>CFBundlePackageType</key>


### PR DESCRIPTION
When building app, info.plist at the app bundle will have CFBundleExecutable key empty, this didnt cause major problems, but actually would cause "DDNet-Server" being run instead of "DDNet-Server-Launcher", and the server app will stay jumping on the dock forever.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
