### PR TITLE
Reset text containers on language change

### DIFF
--- a/src/engine/client/text.cpp
+++ b/src/engine/client/text.cpp
@@ -2341,8 +2341,6 @@ public:
 		}
 
 		dbg_assert(!HasNonEmptyTextContainer, "text container was not empty");
-
-		m_pGlyphMap->Clear();
 	}
 };
 

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -990,7 +990,8 @@ void CGameClient::HandleLanguageChanged()
 	g_Localization.Load(g_Config.m_ClLanguagefile, Storage(), Console());
 	TextRender()->SetFontLanguageVariant(g_Config.m_ClLanguagefile);
 
-	UI()->OnLanguageChange();
+	// Clear all text containers
+	OnWindowResize();
 }
 
 void CGameClient::RenderShutdownMessage()

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -174,11 +174,6 @@ void CUI::OnWindowResize()
 	OnElementsReset();
 }
 
-void CUI::OnLanguageChange()
-{
-	OnElementsReset();
-}
-
 void CUI::OnCursorMove(float X, float Y)
 {
 	if(!CheckMouseLock())

--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -390,7 +390,6 @@ public:
 	void AddUIElement(CUIElement *pElement);
 	void OnElementsReset();
 	void OnWindowResize();
-	void OnLanguageChange();
 	void OnCursorMove(float X, float Y);
 
 	void SetEnabled(bool Enabled) { m_Enabled = Enabled; }


### PR DESCRIPTION
Fix text containers rendering broken text after the language is changed, as this cleared the glyph atlas without clearing the references to the glyph positions in the text containers. Now `OnWindowResize` is also called on language change to reset all text containers.

However, the glyph atlas is not cleared on normal window resize anymore, because this seems to be unnecessary.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
