### PR TITLE
Move `OnWindowResize` listener to engine, handle editor

### DIFF
--- a/src/engine/client.h
+++ b/src/engine/client.h
@@ -181,6 +181,7 @@ public:
 	virtual void SetWindowParams(int FullscreenMode, bool IsBorderless, bool AllowResizing) = 0;
 	virtual void ToggleWindowVSync() = 0;
 	virtual void Notify(const char *pTitle, const char *pMessage) = 0;
+	virtual void OnWindowResize() = 0;
 
 	virtual void UpdateAndSwap() = 0;
 
@@ -316,6 +317,7 @@ public:
 	virtual void OnMessage(int MsgID, CUnpacker *pUnpacker, int Conn, bool Dummy) = 0;
 	virtual void OnPredict() = 0;
 	virtual void OnActivateEditor() = 0;
+	virtual void OnWindowResize() = 0;
 
 	virtual int OnSnapInput(int *pData, bool Dummy, bool Force) = 0;
 	virtual void OnDummySwap() = 0;

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -292,16 +292,6 @@ CClient::CClient() :
 	for(auto &DemoRecorder : m_aDemoRecorder)
 		DemoRecorder = CDemoRecorder(&m_SnapshotDelta);
 
-	m_pEditor = 0;
-	m_pInput = 0;
-	m_pGraphics = 0;
-	m_pSound = 0;
-	m_pGameClient = 0;
-	m_pMap = 0;
-	m_pConfigManager = 0;
-	m_pConfig = 0;
-	m_pConsole = 0;
-
 	m_RenderFrameTime = 0.0001f;
 	m_RenderFrameTimeLow = 1.0f;
 	m_RenderFrameTimeHigh = 0.0f;

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -1122,13 +1122,12 @@ void CClient::DebugRender()
 		float sp = Graphics()->ScreenWidth() / 100.0f;
 		float x = Graphics()->ScreenWidth() - w - sp;
 
-		ITextRender *pTextRender = Kernel()->RequestInterface<ITextRender>();
 		m_FpsGraph.Scale();
-		m_FpsGraph.Render(Graphics(), pTextRender, x, sp * 5, w, h, "FPS");
+		m_FpsGraph.Render(Graphics(), TextRender(), x, sp * 5, w, h, "FPS");
 		m_InputtimeMarginGraph.Scale();
-		m_InputtimeMarginGraph.Render(Graphics(), pTextRender, x, sp * 6 + h, w, h, "Prediction Margin");
+		m_InputtimeMarginGraph.Render(Graphics(), TextRender(), x, sp * 6 + h, w, h, "Prediction Margin");
 		m_GametimeMarginGraph.Scale();
-		m_GametimeMarginGraph.Render(Graphics(), pTextRender, x, sp * 7 + h * 2, w, h, "Gametime Margin");
+		m_GametimeMarginGraph.Render(Graphics(), TextRender(), x, sp * 7 + h * 2, w, h, "Gametime Margin");
 	}
 }
 
@@ -3038,8 +3037,8 @@ void CClient::Run()
 #endif
 
 	// init text render
-	IEngineTextRender *pTextRender = Kernel()->RequestInterface<IEngineTextRender>();
-	pTextRender->Init();
+	m_pTextRender = Kernel()->RequestInterface<IEngineTextRender>();
+	m_pTextRender->Init();
 
 	// init the input
 	Input()->Init();
@@ -3057,6 +3056,8 @@ void CClient::Run()
 	{
 		str_copy(g_Config.m_SteamName, Steam()->GetPlayerName());
 	}
+
+	Graphics()->AddWindowResizeListener([this] { OnWindowResize(); });
 
 	GameClient()->OnInit();
 
@@ -3398,7 +3399,7 @@ void CClient::Run()
 	delete m_pEditor;
 
 	// shutdown text render while graphics are still available
-	pTextRender->Shutdown();
+	m_pTextRender->Shutdown();
 }
 
 bool CClient::InitNetworkClient(char *pError, size_t ErrorSize)
@@ -4285,6 +4286,14 @@ void CClient::Notify(const char *pTitle, const char *pMessage)
 
 	NotificationsNotify(pTitle, pMessage);
 	Graphics()->NotifyWindow();
+}
+
+void CClient::OnWindowResize()
+{
+	TextRender()->OnPreWindowResize();
+	GameClient()->OnWindowResize();
+	m_pEditor->OnWindowResize();
+	TextRender()->OnWindowResize();
 }
 
 void CClient::ConchainWindowVSync(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData)

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -107,21 +107,21 @@ public:
 class CClient : public IClient, public CDemoPlayer::IListener
 {
 	// needed interfaces
-	IEngine *m_pEngine;
-	IEditor *m_pEditor;
-	IEngineInput *m_pInput;
-	IEngineGraphics *m_pGraphics;
-	IEngineSound *m_pSound;
-	IFavorites *m_pFavorites;
-	IGameClient *m_pGameClient;
-	IEngineMap *m_pMap;
-	IConfigManager *m_pConfigManager;
-	CConfig *m_pConfig;
-	IConsole *m_pConsole;
-	IStorage *m_pStorage;
-	IUpdater *m_pUpdater;
-	IDiscord *m_pDiscord;
-	ISteam *m_pSteam;
+	IConfigManager *m_pConfigManager = nullptr;
+	CConfig *m_pConfig = nullptr;
+	IConsole *m_pConsole = nullptr;
+	IDiscord *m_pDiscord = nullptr;
+	IEditor *m_pEditor = nullptr;
+	IEngine *m_pEngine = nullptr;
+	IFavorites *m_pFavorites = nullptr;
+	IGameClient *m_pGameClient = nullptr;
+	IEngineGraphics *m_pGraphics = nullptr;
+	IEngineInput *m_pInput = nullptr;
+	IEngineMap *m_pMap = nullptr;
+	IEngineSound *m_pSound = nullptr;
+	ISteam *m_pSteam = nullptr;
+	IStorage *m_pStorage = nullptr;
+	IUpdater *m_pUpdater = nullptr;
 
 	CNetClient m_aNetClient[NUM_CONNS];
 	CDemoPlayer m_DemoPlayer;
@@ -301,17 +301,17 @@ class CClient : public IClient, public CDemoPlayer::IListener
 	std::shared_ptr<ILogger> m_pStdoutLogger = nullptr;
 
 public:
+	IConfigManager *ConfigManager() { return m_pConfigManager; }
+	CConfig *Config() { return m_pConfig; }
+	IDiscord *Discord() { return m_pDiscord; }
 	IEngine *Engine() { return m_pEngine; }
+	IGameClient *GameClient() { return m_pGameClient; }
 	IEngineGraphics *Graphics() { return m_pGraphics; }
 	IEngineInput *Input() { return m_pInput; }
 	IEngineSound *Sound() { return m_pSound; }
-	IGameClient *GameClient() { return m_pGameClient; }
-	IConfigManager *ConfigManager() { return m_pConfigManager; }
-	CConfig *Config() { return m_pConfig; }
+	ISteam *Steam() { return m_pSteam; }
 	IStorage *Storage() { return m_pStorage; }
 	IUpdater *Updater() { return m_pUpdater; }
-	IDiscord *Discord() { return m_pDiscord; }
-	ISteam *Steam() { return m_pSteam; }
 
 	CClient();
 

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -121,6 +121,7 @@ class CClient : public IClient, public CDemoPlayer::IListener
 	IEngineSound *m_pSound = nullptr;
 	ISteam *m_pSteam = nullptr;
 	IStorage *m_pStorage = nullptr;
+	IEngineTextRender *m_pTextRender = nullptr;
 	IUpdater *m_pUpdater = nullptr;
 
 	CNetClient m_aNetClient[NUM_CONNS];
@@ -311,6 +312,7 @@ public:
 	IEngineSound *Sound() { return m_pSound; }
 	ISteam *Steam() { return m_pSteam; }
 	IStorage *Storage() { return m_pStorage; }
+	IEngineTextRender *TextRender() { return m_pTextRender; }
 	IUpdater *Updater() { return m_pUpdater; }
 
 	CClient();
@@ -510,6 +512,7 @@ public:
 	void SetWindowParams(int FullscreenMode, bool IsBorderless, bool AllowResizing) override;
 	void ToggleWindowVSync() override;
 	void Notify(const char *pTitle, const char *pMessage) override;
+	void OnWindowResize() override;
 	void BenchmarkQuit(int Seconds, const char *pFilename);
 
 	void UpdateAndSwap() override;

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -146,7 +146,6 @@ class CClient : public IClient, public CDemoPlayer::IListener
 	int64_t m_GlobalStartTime;
 
 	IGraphics::CTextureHandle m_DebugFont;
-	int m_DebugSoundIndex = 0;
 
 	int64_t m_LastRenderTime;
 	float m_RenderFrameTimeLow;

--- a/src/engine/editor.h
+++ b/src/engine/editor.h
@@ -13,6 +13,7 @@ public:
 	virtual void OnUpdate() = 0;
 	virtual void OnRender() = 0;
 	virtual void OnActivate() = 0;
+	virtual void OnWindowResize() = 0;
 	virtual bool HasUnsavedData() const = 0;
 	virtual bool Load(const char *pFilename, int StorageType) = 0;
 	virtual bool Save(const char *pFilename) = 0;

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -227,8 +227,6 @@ void CGameClient::OnInit()
 
 	m_pGraphics = Kernel()->RequestInterface<IGraphics>();
 
-	m_pGraphics->AddWindowResizeListener([this] { OnWindowResize(); });
-
 	// propagate pointers
 	m_UI.Init(Kernel());
 	m_RenderTools.Init(Graphics(), TextRender());
@@ -964,13 +962,10 @@ void CGameClient::OnFlagGrab(int TeamID)
 
 void CGameClient::OnWindowResize()
 {
-	TextRender()->OnPreWindowResize();
-
 	for(auto &pComponent : m_vpAll)
 		pComponent->OnWindowResize();
 
 	UI()->OnWindowResize();
-	TextRender()->OnWindowResize();
 }
 
 void CGameClient::OnLanguageChange()
@@ -991,7 +986,7 @@ void CGameClient::HandleLanguageChanged()
 	TextRender()->SetFontLanguageVariant(g_Config.m_ClLanguagefile);
 
 	// Clear all text containers
-	OnWindowResize();
+	Client()->OnWindowResize();
 }
 
 void CGameClient::RenderShutdownMessage()

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -485,8 +485,7 @@ public:
 	virtual void OnStartGame();
 	virtual void OnStartRound();
 	virtual void OnFlagGrab(int TeamID);
-
-	void OnWindowResize();
+	void OnWindowResize() override;
 
 	bool m_LanguageChanged = false;
 	void OnLanguageChange();

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -8292,6 +8292,11 @@ void CEditor::OnActivate()
 	ResetIngameMoved();
 }
 
+void CEditor::OnWindowResize()
+{
+	UI()->OnWindowResize();
+}
+
 void CEditor::LoadCurrentMap()
 {
 	if(Load(m_pClient->GetCurrentMapPath(), IStorage::TYPE_SAVE))

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -950,6 +950,7 @@ public:
 	void OnUpdate() override;
 	void OnRender() override;
 	void OnActivate() override;
+	void OnWindowResize() override;
 	bool HasUnsavedData() const override { return m_Map.m_Modified; }
 	void UpdateMentions() override { m_Mentions++; }
 	void ResetMentions() override { m_Mentions = 0; }


### PR DESCRIPTION
Register the `OnWindowResize` listener in the engine client instead of the game client and properly dispatch the event also to the editor, so text containers in the editor are cleared when the window is resized.

Closes #7018.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
