### PR TITLE
Shut down db connection pool (fixes #7036)

### DIFF
--- a/src/engine/server/databases/connection_pool.cpp
+++ b/src/engine/server/databases/connection_pool.cpp
@@ -160,6 +160,9 @@ void CDbConnectionPool::ExecuteWrite(
 
 void CDbConnectionPool::OnShutdown()
 {
+	if(m_Shutdown)
+		return;
+	m_Shutdown = true;
 	m_pShared->m_Shutdown.store(true);
 	m_pShared->m_NumBackup.Signal();
 	int i = 0;
@@ -470,6 +473,7 @@ CDbConnectionPool::CDbConnectionPool()
 
 CDbConnectionPool::~CDbConnectionPool()
 {
+	OnShutdown();
 	if(m_pWorkerThread)
 		thread_wait(m_pWorkerThread);
 	if(m_pBackupThread)

--- a/src/engine/server/databases/connection_pool.h
+++ b/src/engine/server/databases/connection_pool.h
@@ -104,6 +104,8 @@ private:
 	// where the next query is added to the queue.
 	int m_InsertIdx = 0;
 
+	bool m_Shutdown = false;
+
 	struct CSharedData
 	{
 		// Used as signal that shutdown is in progress from main thread to


### PR DESCRIPTION
This now calls OnShutdown twice in the successful case and once in the error cases. Easier than explicitly calling OnShutdown in each potential error location.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
