### PR TITLE
Don't clear saved brushes when loading another map

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -7838,10 +7838,6 @@ void CEditor::Reset(bool CreateDefault)
 	UI()->ClosePopupMenus();
 	m_Map.Clean();
 
-	m_pBrush->Clear();
-	for(std::shared_ptr<CLayerGroup> &pSavedBrush : m_apSavedBrushes)
-		pSavedBrush.reset();
-
 	// create default layers
 	if(CreateDefault)
 	{


### PR DESCRIPTION
It was not actually necessary to clear the brushes to prevent the crashes. The crashes were fixed by not storing the texture handles for the layers anymore.

Closes #7024.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
