### PR TITLE
Fix assertion failure when SQLite connection fails, Remove unused `IDbConnection::Copy`

### DIFF
--- a/src/engine/server/databases/connection.h
+++ b/src/engine/server/databases/connection.h
@@ -20,9 +20,6 @@ public:
 	IDbConnection &operator=(const IDbConnection &) = delete;
 	virtual void Print(IConsole *pConsole, const char *pMode) = 0;
 
-	// copies the credentials, not the active connection
-	virtual IDbConnection *Copy() = 0;
-
 	// returns the database prefix
 	const char *GetPrefix() const { return m_aPrefix; }
 	virtual const char *BinaryCollate() const = 0;

--- a/src/engine/server/databases/mysql.cpp
+++ b/src/engine/server/databases/mysql.cpp
@@ -69,8 +69,6 @@ public:
 	~CMysqlConnection();
 	void Print(IConsole *pConsole, const char *pMode) override;
 
-	CMysqlConnection *Copy() override;
-
 	const char *BinaryCollate() const override { return "utf8mb4_bin"; }
 	void ToUnixTimestamp(const char *pTimestamp, char *aBuf, unsigned int BufferSize) override;
 	const char *InsertTimestampAsUtc() const override { return "?"; }
@@ -195,11 +193,6 @@ void CMysqlConnection::Print(IConsole *pConsole, const char *pMode)
 		"MySQL-%s: DB: '%s' Prefix: '%s' User: '%s' IP: <{'%s'}> Port: %d",
 		pMode, m_Config.m_aDatabase, GetPrefix(), m_Config.m_aUser, m_Config.m_aIp, m_Config.m_Port);
 	pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "server", aBuf);
-}
-
-CMysqlConnection *CMysqlConnection::Copy()
-{
-	return new CMysqlConnection(m_Config);
 }
 
 void CMysqlConnection::ToUnixTimestamp(const char *pTimestamp, char *aBuf, unsigned int BufferSize)

--- a/src/engine/server/databases/sqlite.cpp
+++ b/src/engine/server/databases/sqlite.cpp
@@ -14,8 +14,6 @@ public:
 	virtual ~CSqliteConnection();
 	void Print(IConsole *pConsole, const char *pMode) override;
 
-	CSqliteConnection *Copy() override;
-
 	const char *BinaryCollate() const override { return "BINARY"; }
 	void ToUnixTimestamp(const char *pTimestamp, char *aBuf, unsigned int BufferSize) override;
 	const char *InsertTimestampAsUtc() const override { return "DATETIME(?, 'utc')"; }
@@ -106,11 +104,6 @@ void CSqliteConnection::Print(IConsole *pConsole, const char *pMode)
 void CSqliteConnection::ToUnixTimestamp(const char *pTimestamp, char *aBuf, unsigned int BufferSize)
 {
 	str_format(aBuf, BufferSize, "strftime('%%s', %s)", pTimestamp);
-}
-
-CSqliteConnection *CSqliteConnection::Copy()
-{
-	return new CSqliteConnection(m_aFilename, m_Setup);
 }
 
 bool CSqliteConnection::Connect(char *pError, int ErrorSize)

--- a/src/engine/server/databases/sqlite.cpp
+++ b/src/engine/server/databases/sqlite.cpp
@@ -65,6 +65,8 @@ private:
 	bool m_Done; // no more rows available for Step
 	// returns false, if the query succeeded
 	bool Execute(const char *pQuery, char *pError, int ErrorSize);
+	// returns true on failure
+	bool ConnectImpl(char *pError, int ErrorSize);
 
 	// returns true if an error was formatted
 	bool FormatError(int Result, char *pError, int ErrorSize);
@@ -110,9 +112,18 @@ bool CSqliteConnection::Connect(char *pError, int ErrorSize)
 {
 	if(m_InUse.exchange(true))
 	{
-		dbg_assert(0, "Tried connecting while the connection is in use");
+		dbg_assert(false, "Tried connecting while the connection is in use");
 	}
+	if(ConnectImpl(pError, ErrorSize))
+	{
+		m_InUse.store(false);
+		return true;
+	}
+	return false;
+}
 
+bool CSqliteConnection::ConnectImpl(char *pError, int ErrorSize)
+{
 	if(m_pDb != nullptr)
 	{
 		return false;


### PR DESCRIPTION
When connecting to the SQLite database fails, e.g. because the `.sqlite` file is corrupted, the server would crash with the assertion "Tried connecting while the connection is in use" when a player joins and performs any action.

This is fixed by resetting the use-flag when connecting to the SQLite database fails, which is the same behavior as for the MySQL database connection.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
