### PR TITLE
Show indicator when pausing/unpausing in demo player

### DIFF
--- a/src/base/color.h
+++ b/src/base/color.h
@@ -130,6 +130,13 @@ public:
 		return col;
 	}
 
+	DerivedT WithMultipliedAlpha(float alpha) const
+	{
+		DerivedT col(static_cast<const DerivedT &>(*this));
+		col.a *= alpha;
+		return col;
+	}
+
 	template<typename UnpackT>
 	static UnpackT UnpackAlphaLast(unsigned Color, bool Alpha = true)
 	{

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -417,6 +417,7 @@ MACRO_CONFIG_INT(ClConfigVersion, cl_config_version, 0, 0, 0, CFGFLAG_CLIENT | C
 MACRO_CONFIG_INT(ClDemoSliceBegin, cl_demo_slice_begin, -1, 0, 0, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Begin marker for demo slice")
 MACRO_CONFIG_INT(ClDemoSliceEnd, cl_demo_slice_end, -1, 0, 0, CFGFLAG_SAVE | CFGFLAG_CLIENT, "End marker for demo slice")
 MACRO_CONFIG_INT(ClDemoShowSpeed, cl_demo_show_speed, 0, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Show speed meter on change")
+MACRO_CONFIG_INT(ClDemoShowPause, cl_demo_show_pause, 1, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Show pause/play indicator on change")
 MACRO_CONFIG_INT(ClDemoKeyboardShortcuts, cl_demo_keyboard_shortcuts, 1, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Enable keyboard shortcuts in demo player")
 
 // graphic library

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -1801,6 +1801,8 @@ void CMenus::PopupConfirmDemoReplaceVideo()
 	const char *pError = Client()->DemoPlayer_Render(aBuf, m_vDemos[m_DemolistSelectedIndex].m_StorageType, aVideoName, m_Speed, m_StartPaused);
 	m_Speed = 4;
 	m_StartPaused = false;
+	m_LastPauseChange = -1.0f;
+	m_LastSpeedChange = -1.0f;
 	if(pError)
 		PopupMessage(Localize("Error"), str_comp(pError, "error loading demo") ? pError : Localize("Error loading demo"), Localize("Ok"));
 }

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -422,6 +422,8 @@ protected:
 
 	// found in menus_demo.cpp
 	vec2 m_DemoControlsPositionOffset = vec2(0.0f, 0.0f);
+	float m_LastPauseChange = -1.0f;
+	float m_LastSpeedChange = -1.0f;
 	static bool DemoFilterChat(const void *pData, int Size, void *pUser);
 	bool FetchHeader(CDemoItem &Item);
 	void FetchAllHeaders();

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -33,6 +33,7 @@ int CMenus::DoButton_FontIcon(CButtonContainer *pButtonContainer, const char *pT
 	pRect->Draw(ColorRGBA(1.0f, 1.0f, 1.0f, (Checked ? 0.10f : 0.5f) * UI()->ButtonColorMul(pButtonContainer)), Corners, 5.0f);
 
 	TextRender()->SetFontPreset(EFontPreset::ICON_FONT);
+	TextRender()->SetRenderFlags(ETextRenderFlags::TEXT_RENDER_FLAG_ONLY_ADVANCE_WIDTH | ETextRenderFlags::TEXT_RENDER_FLAG_NO_X_BEARING | ETextRenderFlags::TEXT_RENDER_FLAG_NO_Y_BEARING);
 	TextRender()->TextOutlineColor(TextRender()->DefaultTextOutlineColor());
 	TextRender()->TextColor(TextRender()->DefaultTextColor());
 	CUIRect Temp;
@@ -48,6 +49,7 @@ int CMenus::DoButton_FontIcon(CButtonContainer *pButtonContainer, const char *pT
 		TextRender()->TextColor(TextRender()->DefaultTextColor());
 	}
 
+	TextRender()->SetRenderFlags(0);
 	TextRender()->SetFontPreset(EFontPreset::DEFAULT_FONT);
 
 	return UI()->DoButtonLogic(pButtonContainer, Checked, pRect);


### PR DESCRIPTION
Render a pause/play icon in the center of the screen when pausing/unpausing while the menu is not active.

The icon fades in and out over 0.5 seconds and slightly increases in size over that time.

When starting demo rendering with initial pause, the pause indicator is rendered continuous until playback is first started, to ensure that the initial pause state is communicated clearly to the user. The initial pause indicator is not included in the rendered demo, but pausing and unpausing later during demo rendering will cause it to be included in the video, same as other UI elements. Closes #7044.

The config variable `cl_demo_show_pause` (`0/1`, default `1`) is added to hide the pause indicator entirely, for example to render a demo with multiple pauses without the indicator.

The pause indicator and also the existing speed indicator are not rendered (anymore) while the menu is active, as the menu already contains this information.

https://github.com/ddnet/ddnet/assets/23437060/df444fd3-951d-43ff-ac2c-a4a8c06f2473

## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
