### PR TITLE
Automatically release the mouse for x11, when breakpoint is hit

### DIFF
--- a/other/vscode/README.md
+++ b/other/vscode/README.md
@@ -10,5 +10,8 @@ Optional:
 - mold (linker), needs to be in PATH
 - ninja
 
+Linux (x11):
+- xdotool, for automatic mouse release
+
 Inside vscode press `Ctrl+Shift+P` and type `Scan for kits`, press enter.
 Now press press `Ctrl+Shift+P` and type `Select a kit`, choose one with `[DDNet]` as prefix for best defaults.

--- a/other/vscode/ddnet.code-workspace
+++ b/other/vscode/ddnet.code-workspace
@@ -79,6 +79,7 @@
 		// https://aur.archlinux.org/packages/clang-format-static-bin
 		"clang-format.executable": "clang-format-10",
 		"lldb.launch.expressions": "native",
+		"lldb.launch.initCommands": ["target stop-hook add --one-liner \"command script import ${workspaceFolder}/other/vscode/lldbinit.py\""],
 		"editor.defaultFormatter": "xaver.clang-format",
 		"[rust]": {
 			"editor.defaultFormatter": "rust-lang.rust-analyzer",

--- a/other/vscode/lldbinit.py
+++ b/other/vscode/lldbinit.py
@@ -1,0 +1,15 @@
+#!/usr/bin/python
+import os
+import shutil
+
+# make sure to have the x11 package xdotool installed on your system
+def check_global_executable_exists(executable_name):
+	return shutil.which(executable_name) is not None
+
+def is_x11_session():
+	return "DISPLAY" in os.environ and "WAYLAND_DISPLAY" not in os.environ
+
+if is_x11_session() and check_global_executable_exists("xdotool"):
+	print("Breakpoint hit, releasing mouse!")
+	os.system("setxkbmap -option grab:break_actions")
+	os.system("xdotool key XF86Ungrab")


### PR DESCRIPTION
This will automatically free your mouse when a breakpoint is hit under x11, using LLDB
I also added it to the workspace so it works out of the box there.

If you prefer to manually do it, or not use the workspace, here are the steps:
_Note:! this only works with LLDB rn.. theoretically it should be ez to add support for GDB similary like this, but i rarely use GDB so i dunno how it works there ;)_


<details> 
  <summary>Setup xdotool manually to free the mouse on breakpoint hit </summary>

  - install xdotool package
  - execute or let lldb execute this at the start of debugging:
  
    ```
    command source ${env:HOME}/.lldbinit
    ```

  - in `~/.lldbinit`:
  
    ```
    target stop-hook add --one-liner "command script import  ~/lldbinit.py"
    ```
  
  - in `~/lldbinit.py` (no dot!):
  
    ```py
    #!/usr/bin/python
    import os
    
    os.system("setxkbmap -option grab:break_actions")
    os.system("xdotool key XF86Ungrab")
    ```
</detail>


## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
