### PR TITLE
Add warning for unsaved editor changes when dragging a map file into the game

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -3120,8 +3120,11 @@ void CClient::Run()
 		// handle pending map edits
 		if(m_aCmdEditMap[0])
 		{
-			g_Config.m_ClEditor = true;
-			m_pEditor->HandleMapDrop(m_aCmdEditMap, IStorage::TYPE_ALL_OR_ABSOLUTE);
+			int Result = m_pEditor->HandleMapDrop(m_aCmdEditMap, IStorage::TYPE_ALL_OR_ABSOLUTE);
+			if(Result)
+				g_Config.m_ClEditor = true;
+			else
+				dbg_msg("editor", "editing passed map file '%s' failed", m_aCmdEditMap);
 			m_aCmdEditMap[0] = 0;
 		}
 

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -3120,11 +3120,8 @@ void CClient::Run()
 		// handle pending map edits
 		if(m_aCmdEditMap[0])
 		{
-			int Result = m_pEditor->Load(m_aCmdEditMap, IStorage::TYPE_ALL_OR_ABSOLUTE);
-			if(Result)
-				g_Config.m_ClEditor = true;
-			else
-				dbg_msg("editor", "editing passed map file '%s' failed", m_aCmdEditMap);
+			g_Config.m_ClEditor = true;
+			m_pEditor->HandleMapDrop(m_aCmdEditMap, IStorage::TYPE_ALL_OR_ABSOLUTE);
 			m_aCmdEditMap[0] = 0;
 		}
 

--- a/src/engine/editor.h
+++ b/src/engine/editor.h
@@ -15,7 +15,7 @@ public:
 	virtual void OnActivate() = 0;
 	virtual void OnWindowResize() = 0;
 	virtual bool HasUnsavedData() const = 0;
-	virtual void HandleMapDrop(const char *pFilename, int StorageType) = 0;
+	virtual bool HandleMapDrop(const char *pFilename, int StorageType) = 0;
 	virtual bool Load(const char *pFilename, int StorageType) = 0;
 	virtual bool Save(const char *pFilename) = 0;
 	virtual void UpdateMentions() = 0;

--- a/src/engine/editor.h
+++ b/src/engine/editor.h
@@ -15,6 +15,7 @@ public:
 	virtual void OnActivate() = 0;
 	virtual void OnWindowResize() = 0;
 	virtual bool HasUnsavedData() const = 0;
+	virtual void HandleMapDrop(const char *pFilename, int StorageType) = 0;
 	virtual bool Load(const char *pFilename, int StorageType) = 0;
 	virtual bool Save(const char *pFilename) = 0;
 	virtual void UpdateMentions() = 0;

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -523,7 +523,7 @@ public:
 	// io
 	bool Save(const char *pFilename);
 	bool Load(const char *pFilename, int StorageType, const std::function<void(const char *pErrorMessage)> &ErrorHandler);
-	void HandleMapDrop(const char *pFilename, int StorageType);
+	bool HandleMapDrop(const char *pFilename, int StorageType);
 	void PerformSanityChecks(const std::function<void(const char *pErrorMessage)> &ErrorHandler);
 
 	// DDRace
@@ -984,7 +984,7 @@ public:
 	void Reset(bool CreateDefault = true);
 	bool Save(const char *pFilename) override;
 	bool Load(const char *pFilename, int StorageType) override;
-	void HandleMapDrop(const char *pFilename, int StorageType) override;
+	bool HandleMapDrop(const char *pFilename, int StorageType) override;
 	bool Append(const char *pFilename, int StorageType);
 	void LoadCurrentMap();
 	void Render();

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -523,6 +523,7 @@ public:
 	// io
 	bool Save(const char *pFilename);
 	bool Load(const char *pFilename, int StorageType, const std::function<void(const char *pErrorMessage)> &ErrorHandler);
+	void HandleMapDrop(const char *pFilename, int StorageType);
 	void PerformSanityChecks(const std::function<void(const char *pErrorMessage)> &ErrorHandler);
 
 	// DDRace
@@ -867,6 +868,7 @@ public:
 		m_BrushColorEnabled = true;
 
 		m_aFileName[0] = '\0';
+		m_aFileNamePending[0] = '\0';
 		m_aFileSaveName[0] = '\0';
 		m_ValidSaveFilename = false;
 
@@ -982,6 +984,7 @@ public:
 	void Reset(bool CreateDefault = true);
 	bool Save(const char *pFilename) override;
 	bool Load(const char *pFilename, int StorageType) override;
+	void HandleMapDrop(const char *pFilename, int StorageType) override;
 	bool Append(const char *pFilename, int StorageType);
 	void LoadCurrentMap();
 	void Render();
@@ -1040,6 +1043,7 @@ public:
 	bool m_BrushColorEnabled;
 
 	char m_aFileName[IO_MAX_PATH_LENGTH];
+	char m_aFileNamePending[IO_MAX_PATH_LENGTH];
 	char m_aFileSaveName[IO_MAX_PATH_LENGTH];
 	bool m_ValidSaveFilename;
 
@@ -1048,6 +1052,7 @@ public:
 		POPEVENT_EXIT = 0,
 		POPEVENT_LOAD,
 		POPEVENT_LOADCURRENT,
+		POPEVENT_LOADDROP,
 		POPEVENT_NEW,
 		POPEVENT_SAVE,
 		POPEVENT_SAVE_COPY,

--- a/src/game/editor/io.cpp
+++ b/src/game/editor/io.cpp
@@ -426,24 +426,23 @@ bool CEditorMap::Save(const char *pFileName)
 	return true;
 }
 
-void CEditor::HandleMapDrop(const char *pFileName, int StorageType)
+bool CEditor::HandleMapDrop(const char *pFileName, int StorageType)
 {
-	m_Map.HandleMapDrop(pFileName, IStorage::TYPE_ALL_OR_ABSOLUTE);
+	return m_Map.HandleMapDrop(pFileName, IStorage::TYPE_ALL_OR_ABSOLUTE);
 }
 
-void CEditorMap::HandleMapDrop(const char *pFileName, int StorageType)
+bool CEditorMap::HandleMapDrop(const char *pFileName, int StorageType)
 {
 	if(m_pEditor->HasUnsavedData())
 	{
 		str_copy(m_pEditor->m_aFileNamePending, pFileName);
 		m_pEditor->m_PopupEventType = CEditor::POPEVENT_LOADDROP;
 		m_pEditor->m_PopupEventActivated = true;
+		return true;
 	}
 	else
 	{
-		int Result = m_pEditor->Load(pFileName, IStorage::TYPE_ALL_OR_ABSOLUTE);
-		if(!Result)
-			dbg_msg("editor", "editing passed map file '%s' failed", pFileName);
+		return m_pEditor->Load(pFileName, IStorage::TYPE_ALL_OR_ABSOLUTE);
 	}
 }
 

--- a/src/game/editor/io.cpp
+++ b/src/game/editor/io.cpp
@@ -432,7 +432,7 @@ void CEditor::HandleMapDrop(const char *pFileName, int StorageType)
 }
 
 void CEditorMap::HandleMapDrop(const char *pFileName, int StorageType)
-{	
+{
 	if(m_pEditor->HasUnsavedData())
 	{
 		str_copy(m_pEditor->m_aFileNamePending, pFileName);

--- a/src/game/editor/io.cpp
+++ b/src/game/editor/io.cpp
@@ -426,6 +426,27 @@ bool CEditorMap::Save(const char *pFileName)
 	return true;
 }
 
+void CEditor::HandleMapDrop(const char *pFileName, int StorageType)
+{
+	m_Map.HandleMapDrop(pFileName, IStorage::TYPE_ALL_OR_ABSOLUTE);
+}
+
+void CEditorMap::HandleMapDrop(const char *pFileName, int StorageType)
+{	
+	if(m_pEditor->HasUnsavedData())
+	{
+		str_copy(m_pEditor->m_aFileNamePending, pFileName);
+		m_pEditor->m_PopupEventType = CEditor::POPEVENT_LOADDROP;
+		m_pEditor->m_PopupEventActivated = true;
+	}
+	else
+	{
+		int Result = m_pEditor->Load(pFileName, IStorage::TYPE_ALL_OR_ABSOLUTE);
+		if(!Result)
+			dbg_msg("editor", "editing passed map file '%s' failed", pFileName);
+	}
+}
+
 bool CEditor::Load(const char *pFileName, int StorageType)
 {
 	const auto &&ErrorHandler = [this](const char *pErrorMessage) {

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -1786,22 +1786,12 @@ CUI::EPopupMenuFunctionResult CEditor::PopupEvent(void *pContext, CUIRect View, 
 	if(pEditor->m_PopupEventType != POPEVENT_LARGELAYER && pEditor->m_PopupEventType != POPEVENT_PREVENTUNUSEDTILES && pEditor->m_PopupEventType != POPEVENT_IMAGEDIV16 && pEditor->m_PopupEventType != POPEVENT_IMAGE_MAX)
 	{
 		static int s_CancelButton = 0;
-		if(pEditor->m_PopupEventType == POPEVENT_LOADDROP)
+		if(pEditor->DoButton_Editor(&s_CancelButton, "Cancel", 0, &Button, 0, nullptr))
 		{
-			if(pEditor->DoButton_Editor(&s_CancelButton, "Cancel", 0, &Button, 0, nullptr))
-			{
+			if(pEditor->m_PopupEventType == POPEVENT_LOADDROP)
 				pEditor->m_aFileNamePending[0] = 0;
-				pEditor->m_PopupEventWasActivated = false;
-				return CUI::POPUP_CLOSE_CURRENT;
-			}
-		}
-		else
-		{
-			if(pEditor->DoButton_Editor(&s_CancelButton, "Cancel", 0, &Button, 0, nullptr))
-			{
-				pEditor->m_PopupEventWasActivated = false;
-				return CUI::POPUP_CLOSE_CURRENT;
-			}
+			pEditor->m_PopupEventWasActivated = false;
+			return CUI::POPUP_CLOSE_CURRENT;
 		}
 	}
 

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -1822,12 +1822,12 @@ CUI::EPopupMenuFunctionResult CEditor::PopupEvent(void *pContext, CUIRect View, 
 			pEditor->LoadCurrentMap();
 		}
 		else if(pEditor->m_PopupEventType == POPEVENT_LOADDROP)
-		{	
+		{
 			int Result = pEditor->Load(pEditor->m_aFileNamePending, IStorage::TYPE_ALL_OR_ABSOLUTE);
 			if(!Result)
 				dbg_msg("editor", "editing passed map file '%s' failed", pEditor->m_aFileNamePending);
 			pEditor->m_aFileNamePending[0] = 0;
-		}	
+		}
 		else if(pEditor->m_PopupEventType == POPEVENT_NEW)
 		{
 			pEditor->Reset();


### PR DESCRIPTION
Closes #7011 

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
