### PR TITLE
CGameClient::Predict: Disable prediction if the game is paused 

### DIFF
--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -757,7 +757,7 @@ bool CGameClient::Predict() const
 
 	if(m_Snap.m_pGameInfoObj)
 	{
-		if(m_Snap.m_pGameInfoObj->m_GameStateFlags & GAMESTATEFLAG_GAMEOVER)
+		if(m_Snap.m_pGameInfoObj->m_GameStateFlags & (GAMESTATEFLAG_GAMEOVER | GAMESTATEFLAG_PAUSED))
 		{
 			return false;
 		}

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -750,6 +750,25 @@ int CGameClient::GetLastRaceTick()
 	return m_Ghost.GetLastRaceTick();
 }
 
+bool CGameClient::Predict() const
+{
+	if(!g_Config.m_ClPredict)
+		return false;
+
+	if(m_Snap.m_pGameInfoObj)
+	{
+		if(m_Snap.m_pGameInfoObj->m_GameStateFlags & GAMESTATEFLAG_GAMEOVER)
+		{
+			return false;
+		}
+	}
+
+	if(Client()->State() == IClient::STATE_DEMOPLAYBACK)
+		return false;
+
+	return !m_Snap.m_SpecInfo.m_Active && m_Snap.m_pLocalCharacter;
+}
+
 void CGameClient::OnRelease()
 {
 	// release all systems

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -527,7 +527,7 @@ public:
 	bool AntiPingGrenade() { return g_Config.m_ClAntiPing && g_Config.m_ClAntiPingGrenade && !m_Snap.m_SpecInfo.m_Active && Client()->State() != IClient::STATE_DEMOPLAYBACK; }
 	bool AntiPingWeapons() { return g_Config.m_ClAntiPing && g_Config.m_ClAntiPingWeapons && !m_Snap.m_SpecInfo.m_Active && Client()->State() != IClient::STATE_DEMOPLAYBACK; }
 	bool AntiPingGunfire() { return AntiPingGrenade() && AntiPingWeapons() && g_Config.m_ClAntiPingGunfire; }
-	bool Predict() { return g_Config.m_ClPredict && !(m_Snap.m_pGameInfoObj && m_Snap.m_pGameInfoObj->m_GameStateFlags & GAMESTATEFLAG_GAMEOVER) && !m_Snap.m_SpecInfo.m_Active && Client()->State() != IClient::STATE_DEMOPLAYBACK && m_Snap.m_pLocalCharacter; }
+	bool Predict() const;
 	bool PredictDummy() { return g_Config.m_ClPredictDummy && Client()->DummyConnected() && m_Snap.m_LocalClientID >= 0 && m_PredictedDummyID >= 0 && !m_aClients[m_PredictedDummyID].m_Paused; }
 	const CTuningParams *GetTuning(int i) { return &m_aTuningList[i]; }
 

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -392,7 +392,6 @@ private:
 	static void ConTopPoints(IConsole::IResult *pResult, void *pUserData);
 	static void ConTimeCP(IConsole::IResult *pResult, void *pUserData);
 
-	static void ConUTF8(IConsole::IResult *pResult, void *pUserData);
 	static void ConDND(IConsole::IResult *pResult, void *pUserData);
 	static void ConMapInfo(IConsole::IResult *pResult, void *pUserData);
 	static void ConTimeout(IConsole::IResult *pResult, void *pUserData);
@@ -403,7 +402,6 @@ private:
 	static void ConMap(IConsole::IResult *pResult, void *pUserData);
 	static void ConTeamRank(IConsole::IResult *pResult, void *pUserData);
 	static void ConRank(IConsole::IResult *pResult, void *pUserData);
-	static void ConBroadTime(IConsole::IResult *pResult, void *pUserData);
 	static void ConJoinTeam(IConsole::IResult *pResult, void *pUserData);
 	static void ConLockTeam(IConsole::IResult *pResult, void *pUserData);
 	static void ConUnlockTeam(IConsole::IResult *pResult, void *pUserData);
@@ -412,7 +410,6 @@ private:
 	static void ConWhisper(IConsole::IResult *pResult, void *pUserData);
 	static void ConConverse(IConsole::IResult *pResult, void *pUserData);
 	static void ConSetEyeEmote(IConsole::IResult *pResult, void *pUserData);
-	static void ConToggleBroadcast(IConsole::IResult *pResult, void *pUserData);
 	static void ConEyeEmote(IConsole::IResult *pResult, void *pUserData);
 	static void ConShowOthers(IConsole::IResult *pResult, void *pUserData);
 	static void ConShowAll(IConsole::IResult *pResult, void *pUserData);

--- a/src/game/server/gamecontroller.h
+++ b/src/game/server/gamecontroller.h
@@ -119,8 +119,6 @@ public:
 	void EndRound();
 	void ChangeMap(const char *pToMap);
 
-	bool IsFriendlyFire(int ClientID1, int ClientID2);
-
 	bool IsForceBalanced();
 
 	/*


### PR DESCRIPTION
CGameClient::OnPredict() says "don't predict anything if we are paused" and yet we predict different stuff based on CGameClient::Predict() result which leads to flickering here and there (e.g. for projectiles and characters).

Steps to reproduce:
1. Check 'AntiPing' in the settings
2. Join a server
3. Pause the round (`rcon pause_game`)

Expected result: The game is paused and characters, projectiles and other entities do not move (until the server moves them)
Actual result: The game says it's paused but everything (except the player character) is shaking / jumping back and forth.

The actual fix is:
```diff
--- src/game/client/gameclient.cpp
+++ src/game/client/gameclient.cpp
@@ -757,7 +757,7 @@ bool CGameClient::Predict() const
 
        if(m_Snap.m_pGameInfoObj)
        {
-               if(m_Snap.m_pGameInfoObj->m_GameStateFlags & GAMESTATEFLAG_GAMEOVER)
+               if(m_Snap.m_pGameInfoObj->m_GameStateFlags & (GAMESTATEFLAG_GAMEOVER | GAMESTATEFLAG_PAUSED))
                {
                        return false;
                }
```

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
