### PR TITLE
Update darwin_strip_rpath.py

### DIFF
--- a/scripts/darwin_strip_rpath.py
+++ b/scripts/darwin_strip_rpath.py
@@ -3,41 +3,51 @@ import subprocess
 import re
 
 def split_cmds(lines):
-	cmds = []
-	current = []
-	load_cmd_regex = re.compile(r"^Load command \d+$")
-	for line in lines:
-		if load_cmd_regex.match(line):
-			cmds.append(current)
-			current = []
-			continue
+    cmds = []
+    current = []
+    load_cmd_regex = re.compile(r"^Load command \d+$")
+    for line in lines:
+        if load_cmd_regex.match(line):
+            cmds.append(current)
+            current = []
+            continue
 
-		current.append(line.strip())
+        current.append(line.strip())
 
-	return cmds[1:]
+    return cmds[1:]
 
 def main():
-	p = argparse.ArgumentParser(description="Strip LC_RPATH commands from executable")
+    p = argparse.ArgumentParser(description="Удаление команд LC_RPATH из исполняемого файла")
 
-	p.add_argument('otool', help="Path to otool")
-	p.add_argument('install_name_tool', help="Path to install_name_tool")
-	p.add_argument('executable', metavar="EXECUTABLE", help="The executable to strip")
-	args = p.parse_args()
+    p.add_argument('otool', help="Путь к утилите otool")
+    p.add_argument('install_name_tool', help="Путь к утилите install_name_tool")
+    p.add_argument('executable', metavar="ИСПОЛНЯЕМЫЙ_ФАЙЛ", help="Исполняемый файл для обработки")
+    args = p.parse_args()
 
-	otool = args.otool
-	install_name_tool = args.install_name_tool
-	executable = args.executable
+    otool = args.otool
+    install_name_tool = args.install_name_tool
+    executable = args.executable
 
-	cmds = split_cmds(subprocess.check_output([otool, "-l", executable]).decode().splitlines())
-	lc_rpath_cmds = [cmd for cmd in cmds if cmd[0] == "cmd LC_RPATH"]
+    try:
+        output = subprocess.check_output([otool, "-l", executable], stderr=subprocess.STDOUT)
+    except subprocess.CalledProcessError as e:
+        print("Ошибка при выполнении otool:", e.output.decode())
+        return
 
-	path_regex = re.compile(r"^path (.*) \(offset \d+\)$")
-	rpaths = {k[0] for k in [[path_regex.match(part).group(1) for part in cmd if path_regex.match(part)] for cmd in lc_rpath_cmds]}
-	print("Found paths:")
+    cmds = split_cmds(output.decode().splitlines())
+    lc_rpath_cmds = [cmd for cmd in cmds if cmd[0] == "cmd LC_RPATH"]
 
-	for path in rpaths:
-		print("\t" + path)
-		subprocess.check_call([install_name_tool, "-delete_rpath", path, executable])
+    path_regex = re.compile(r"^path (.*) \(offset \d+\)$")
+    rpaths = {path_regex.match(part).group(1) for cmd in lc_rpath_cmds for part in cmd if path_regex.match(part)}
+
+    print("Найденные пути:")
+    for path in rpaths:
+        print("\t" + path)
+        try:
+            subprocess.check_call([install_name_tool, "-delete_rpath", path, executable])
+            print(f"Удален путь {path} из {executable}")
+        except subprocess.CalledProcessError as e:
+            print("Ошибка при выполнении install_name_tool:", e)
 
 if __name__ == '__main__':
-	main()
+    main()


### PR DESCRIPTION
Handling the subprocess.CalledProcessError exception when executing otool, to display the error output if it occurs. Outputting information about which specific rpath was removed from the executable file. Handling the subprocess.CalledProcessError exception when executing install_name_tool, to display the error output if it occurs. & fix tabulation

<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
