### PR TITLE
Update darwin_strip_rpath.py

### DIFF
--- a/scripts/darwin_strip_rpath.py
+++ b/scripts/darwin_strip_rpath.py
@@ -12,7 +12,7 @@ def split_cmds(lines):
 			current = []
 			continue
 
- 		current.append(line.strip())
+		current.append(line.strip())
 
 	return cmds[1:]
 


### PR DESCRIPTION
Handling the `subprocess.CalledProcessError` exception when executing `otool`, to display the error output if it occurs. Outputting information about which specific `rpath` was removed from the executable file. Handling the `subprocess.CalledProcessError` exception when executing `install_name_tool`, to display the error output if it occurs.

<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
