### PR TITLE
Add streamer mode to avoid leaks

### DIFF
--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -19,6 +19,8 @@
 
 #include "chat.h"
 
+char CChat::ms_aDisplayText[512] = {'\0'};
+
 CChat::CChat()
 {
 	for(auto &Line : m_aLines)
@@ -36,6 +38,37 @@ CChat::CChat()
 	m_Mode = MODE_NONE;
 
 	m_Input.SetClipboardLineCallback([this](const char *pStr) { SayChat(pStr); });
+	m_Input.SetCalculateOffsetCallback([this]() { return m_IsInputCensored; });
+	m_Input.SetDisplayTextCallback([this](char *pStr, size_t NumChars) {
+		m_IsInputCensored = false;
+		if(
+			g_Config.m_ClStreamerMode &&
+			(str_startswith(pStr, "/login ") ||
+				str_startswith(pStr, "/register ") ||
+				str_startswith(pStr, "/code ") ||
+				str_startswith(pStr, "/timeout ") ||
+				str_startswith(pStr, "/save ") ||
+				str_startswith(pStr, "/load ")))
+		{
+			bool Censor = false;
+			const size_t NumLetters = minimum(NumChars, sizeof(ms_aDisplayText) - 1);
+			for(size_t i = 0; i < NumLetters; ++i)
+			{
+				if(Censor)
+					ms_aDisplayText[i] = '*';
+				else
+					ms_aDisplayText[i] = pStr[i];
+				if(pStr[i] == ' ')
+				{
+					Censor = true;
+					m_IsInputCensored = true;
+				}
+			}
+			ms_aDisplayText[NumLetters] = '\0';
+			return ms_aDisplayText;
+		}
+		return pStr;
+	});
 }
 
 void CChat::RegisterCommand(const char *pName, const char *pParams, int flags, const char *pHelp)
@@ -86,6 +119,7 @@ void CChat::Reset()
 	m_PendingChatCounter = 0;
 	m_LastChatSend = 0;
 	m_CurrentLine = 0;
+	m_IsInputCensored = false;
 	DisableMode();
 
 	for(int64_t &LastSoundPlayed : m_aLastSoundPlayed)
@@ -1017,7 +1051,15 @@ void CChat::OnPrepareLines()
 			OriginalWidth = Cursor.m_LongestLineWidth;
 		}
 
-		TextRender()->CreateOrAppendTextContainer(m_aLines[r].m_TextContainerIndex, &AppendCursor, m_aLines[r].m_aText);
+		const char *pText = m_aLines[r].m_aText;
+		if(Config()->m_ClStreamerMode && m_aLines[r].m_ClientID == SERVER_MSG)
+		{
+			if(str_startswith(m_aLines[r].m_aText, "Team save in progress. You'll be able to load with '/load") && str_endswith(m_aLines[r].m_aText, "if it fails"))
+				pText = "Team save in progress. You'll be able to load with '/load ***' if save is successful or with '/load *** *** ***' if it fails";
+			else if(str_startswith(m_aLines[r].m_aText, "Team successfully saved by ") && str_endswith(m_aLines[r].m_aText, " to continue"))
+				pText = "Team successfully saved by ***. Use '/load ***' to continue";
+		}
+		TextRender()->CreateOrAppendTextContainer(m_aLines[r].m_TextContainerIndex, &AppendCursor, pText);
 
 		if(!g_Config.m_ClChatOld && (m_aLines[r].m_aText[0] != '\0' || m_aLines[r].m_aName[0] != '\0'))
 		{

--- a/src/game/client/components/chat.h
+++ b/src/game/client/components/chat.h
@@ -85,6 +85,7 @@ class CChat : public CComponent
 	char m_aCompletionBuffer[256];
 	int m_PlaceholderOffset;
 	int m_PlaceholderLength;
+	static char ms_aDisplayText[512];
 	struct CRateablePlayer
 	{
 		int ClientID;
@@ -121,6 +122,7 @@ class CChat : public CComponent
 	int m_PendingChatCounter;
 	int64_t m_LastChatSend;
 	int64_t m_aLastSoundPlayed[CHAT_NUM];
+	bool m_IsInputCensored;
 
 	static void ConSay(IConsole::IResult *pResult, void *pUserData);
 	static void ConSayTeam(IConsole::IResult *pResult, void *pUserData);

--- a/src/game/client/lineinput.cpp
+++ b/src/game/client/lineinput.cpp
@@ -1,6 +1,7 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include <engine/keys.h>
+#include <engine/shared/config.h>
 
 #include "lineinput.h"
 #include "ui.h"
@@ -111,6 +112,9 @@ void CLineInput::UpdateStrData()
 
 const char *CLineInput::GetDisplayedString()
 {
+	if(m_pfnDisplayTextCallback)
+		return m_pfnDisplayTextCallback(m_pStr, GetNumChars());
+
 	if(!IsHidden())
 		return m_pStr;
 
@@ -167,18 +171,18 @@ void CLineInput::SetSelection(size_t Start, size_t End)
 	m_WasChanged = true;
 }
 
-size_t CLineInput::OffsetFromActualToDisplay(size_t ActualOffset) const
+size_t CLineInput::OffsetFromActualToDisplay(size_t ActualOffset)
 {
-	if(!IsHidden())
-		return ActualOffset;
-	return str_utf8_offset_bytes_to_chars(m_pStr, ActualOffset);
+	if(IsHidden() || (m_pfnCalculateOffsetCallback && m_pfnCalculateOffsetCallback()))
+		return str_utf8_offset_bytes_to_chars(m_pStr, ActualOffset);
+	return ActualOffset;
 }
 
-size_t CLineInput::OffsetFromDisplayToActual(size_t DisplayOffset) const
+size_t CLineInput::OffsetFromDisplayToActual(size_t DisplayOffset)
 {
-	if(!IsHidden())
-		return DisplayOffset;
-	return str_utf8_offset_chars_to_bytes(m_pStr, DisplayOffset);
+	if(IsHidden() || (m_pfnCalculateOffsetCallback && m_pfnCalculateOffsetCallback()))
+		return str_utf8_offset_bytes_to_chars(m_pStr, DisplayOffset);
+	return DisplayOffset;
 }
 
 bool CLineInput::ProcessInput(const IInput::CEvent &Event)

--- a/src/game/client/lineinput.h
+++ b/src/game/client/lineinput.h
@@ -33,6 +33,8 @@ public:
 	};
 
 	typedef std::function<void(const char *pLine)> FClipboardLineCallback;
+	typedef std::function<const char *(char *pCurrentText, size_t NumChars)> FDisplayTextCallback;
+	typedef std::function<bool()> FCalculateOffsetCallback;
 
 private:
 	static IClient *ms_pClient;
@@ -72,6 +74,8 @@ private:
 	bool m_Hidden;
 	const char *m_pEmptyText;
 	FClipboardLineCallback m_pfnClipboardLineCallback;
+	FDisplayTextCallback m_pfnDisplayTextCallback;
+	FCalculateOffsetCallback m_pfnCalculateOffsetCallback;
 	bool m_WasChanged;
 	bool m_WasRendered;
 
@@ -147,8 +151,8 @@ public:
 		SetSelection(0, GetLength());
 	}
 
-	size_t OffsetFromActualToDisplay(size_t ActualOffset) const;
-	size_t OffsetFromDisplayToActual(size_t DisplayOffset) const;
+	size_t OffsetFromActualToDisplay(size_t ActualOffset);
+	size_t OffsetFromDisplayToActual(size_t DisplayOffset);
 
 	// used either for vertical or horizontal scrolling
 	float GetScrollOffset() const { return m_ScrollOffset; }
@@ -165,6 +169,8 @@ public:
 	void SetEmptyText(const char *pText) { m_pEmptyText = pText; }
 
 	void SetClipboardLineCallback(FClipboardLineCallback pfnClipboardLineCallback) { m_pfnClipboardLineCallback = pfnClipboardLineCallback; }
+	void SetDisplayTextCallback(FDisplayTextCallback pfnDisplayTextCallback) { m_pfnDisplayTextCallback = pfnDisplayTextCallback; }
+	void SetCalculateOffsetCallback(FCalculateOffsetCallback pfnCalculateOffsetCallback) { m_pfnCalculateOffsetCallback = pfnCalculateOffsetCallback; }
 
 	bool ProcessInput(const IInput::CEvent &Event);
 	bool WasChanged()

--- a/src/game/variables.h
+++ b/src/game/variables.h
@@ -36,6 +36,7 @@ MACRO_CONFIG_INT(ClNameplatesFriendMark, cl_nameplates_friendmark, 0, 0, 1, CFGF
 MACRO_CONFIG_INT(ClNameplatesStrong, cl_nameplates_strong, 0, 0, 2, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show strong/weak in name plates (0 - off, 1 - icons, 2 - icons + numbers)")
 MACRO_CONFIG_INT(ClTextEntities, cl_text_entities, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Render textual entity data")
 MACRO_CONFIG_INT(ClTextEntitiesSize, cl_text_entities_size, 100, 1, 100, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Size of textual entity data from 1 to 100%")
+MACRO_CONFIG_INT(ClStreamerMode, cl_streamer_mode, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Censor sensitive information such as /save password")
 
 MACRO_CONFIG_COL(ClAuthedPlayerColor, cl_authed_player_color, 5898211, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Color of name of authenticated player in scoreboard")
 MACRO_CONFIG_COL(ClSameClanColor, cl_same_clan_color, 5898211, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Clan color of players with the same clan as you in scoreboard.")


### PR DESCRIPTION
Made for the top1 teeworlds tiktoker [teeworldseasy](https://www.twitch.tv/teeworldseasy). Who is live 24/7 and occasionally leaking his save password.

![image](https://github.com/ddnet/ddnet/assets/20344300/3aef1299-b4ad-4e36-8fdf-144d328a4ff0)

![image](https://github.com/ddnet/ddnet/assets/20344300/2cd7ae08-8723-4600-a00a-fbcdaebbc8f5)


![image](https://github.com/ddnet/ddnet/assets/20344300/a3d671f7-640e-4253-ba4d-21980ea8d85e)
![image](https://github.com/ddnet/ddnet/assets/20344300/491f3cb1-f016-4e3d-ba3e-53a57c49ffa1)
![image](https://github.com/ddnet/ddnet/assets/20344300/14a888c1-420f-4051-8d3f-80c896b482dc)
![image](https://github.com/ddnet/ddnet/assets/20344300/d9390bf8-25db-452d-84bc-647f35eef136)
![image](https://github.com/ddnet/ddnet/assets/20344300/e139dfb4-6417-4a23-b916-4b7ed33b9f56)


https://github.com/ddnet/ddnet/assets/20344300/cd357d64-50f2-484b-9264-2a6f1c1b0c1b

https://www.youtube.com/shorts/mPZ_zhz1Pew

## Checklist

- [x] Tested the change ingame
- [x] :heavy_check_mark:  Provided screenshots if it is a visual change :heavy_check_mark: 
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
