### PR TITLE
Don't register to ipv6 when sv_ipv4only is enabled. (fixes #7091)

### DIFF
--- a/src/engine/server/register.cpp
+++ b/src/engine/server/register.cpp
@@ -257,7 +257,7 @@ void CRegister::ConchainOnConfigChange(IConsole::IResult *pResult, void *pUserDa
 
 void CRegister::CProtocol::SendRegister()
 {
-	if(g_Config.m_SvIpv4Only && (m_Protocol == PROTOCOL_TW6_IPV6 || m_Protocol == PROTOCOL_TW7_IPV6) )
+	if(g_Config.m_SvIpv4Only && (m_Protocol == PROTOCOL_TW6_IPV6 || m_Protocol == PROTOCOL_TW7_IPV6))
 		return;
 
 	int64_t Now = time_get();

--- a/src/engine/server/register.cpp
+++ b/src/engine/server/register.cpp
@@ -257,9 +257,6 @@ void CRegister::ConchainOnConfigChange(IConsole::IResult *pResult, void *pUserDa
 
 void CRegister::CProtocol::SendRegister()
 {
-	if(g_Config.m_SvIpv4Only && (m_Protocol == PROTOCOL_TW6_IPV6 || m_Protocol == PROTOCOL_TW7_IPV6))
-		return;
-
 	int64_t Now = time_get();
 	int64_t Freq = time_freq();
 
@@ -602,6 +599,11 @@ void CRegister::OnConfigChange()
 	{
 		m_aProtocolEnabled[PROTOCOL_TW7_IPV6] = false;
 		m_aProtocolEnabled[PROTOCOL_TW7_IPV4] = false;
+	}
+	if(m_pConfig->m_SvIpv4Only)
+	{
+		m_aProtocolEnabled[PROTOCOL_TW6_IPV6] = false;
+		m_aProtocolEnabled[PROTOCOL_TW7_IPV6] = false;
 	}
 	m_NumExtraHeaders = 0;
 	const char *pRegisterExtra = m_pConfig->m_SvRegisterExtra;

--- a/src/engine/server/register.cpp
+++ b/src/engine/server/register.cpp
@@ -257,6 +257,9 @@ void CRegister::ConchainOnConfigChange(IConsole::IResult *pResult, void *pUserDa
 
 void CRegister::CProtocol::SendRegister()
 {
+	if(g_Config.m_SvIpv4Only && (m_Protocol == PROTOCOL_TW6_IPV6 || m_Protocol == PROTOCOL_TW7_IPV6) )
+		return;
+
 	int64_t Now = time_get();
 	int64_t Freq = time_freq();
 


### PR DESCRIPTION
It makes no sense to try to register server to IPv6, when it's not enabled.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
