### PR TITLE
Fix demo sorting

### DIFF
--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -913,6 +913,8 @@ void CMenus::DemolistOnUpdate(bool Reset)
 	{
 		bool Found = false;
 		int SelectedIndex = -1;
+		RefreshFilteredDemos();
+
 		// search for selected index
 		for(auto &Item : m_vpFilteredDemos)
 		{
@@ -924,7 +926,6 @@ void CMenus::DemolistOnUpdate(bool Reset)
 				break;
 			}
 		}
-		RefreshFilteredDemos();
 
 		if(Found)
 			m_DemolistSelectedIndex = SelectedIndex;

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -1182,7 +1182,7 @@ void CMenus::RenderDemoList(CUIRect MainView)
 			}
 
 			// Don't rescan in order to keep fetched headers, just resort
-			std::stable_sort(m_vpFilteredDemos.begin(), m_vpFilteredDemos.end());
+			std::stable_sort(m_vDemos.begin(), m_vDemos.end());
 			DemolistOnUpdate(false);
 		}
 	}


### PR DESCRIPTION
This fixes the sorting of demos which I accidentally broke after implementing demo searching (#7069).

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
