### PR TITLE
Add option to show skin names in nameplates

### DIFF
--- a/src/game/client/components/nameplates.cpp
+++ b/src/game/client/components/nameplates.cpp
@@ -142,6 +142,30 @@ void CNamePlates::RenderNameplatePos(vec2 Position, const CNetObj_PlayerInfo *pP
 			}
 		}
 
+		if(g_Config.m_Debug || g_Config.m_ClNameplatesSkin)
+		{
+			const char *pSkin = m_pClient->m_aClients[ClientID].m_aSkinName;
+			if(str_comp(pSkin, m_aNamePlates[ClientID].m_aSkinName) != 0 || FontSizeClan != m_aNamePlates[ClientID].m_SkinNameTextFontSize)
+			{
+				mem_copy(m_aNamePlates[ClientID].m_aSkinName, pSkin, sizeof(m_aNamePlates[ClientID].m_aSkinName));
+				m_aNamePlates[ClientID].m_SkinNameTextFontSize = FontSizeClan;
+
+				CTextCursor Cursor;
+				TextRender()->SetCursor(&Cursor, 0, 0, FontSizeClan, TEXTFLAG_RENDER);
+				Cursor.m_LineWidth = -1;
+
+				// create nameplates at standard zoom
+				float ScreenX0, ScreenY0, ScreenX1, ScreenY1;
+				Graphics()->GetScreen(&ScreenX0, &ScreenY0, &ScreenX1, &ScreenY1);
+				RenderTools()->MapScreenToInterface(m_pClient->m_Camera.m_Center.x, m_pClient->m_Camera.m_Center.y);
+
+				m_aNamePlates[ClientID].m_SkinNameTextWidth = TextRender()->TextWidth(FontSizeClan, pSkin, -1, -1.0f);
+
+				TextRender()->RecreateTextContainer(m_aNamePlates[ClientID].m_SkinNameTextContainerIndex, &Cursor, pSkin);
+				Graphics()->MapScreen(ScreenX0, ScreenY0, ScreenX1, ScreenY1);
+			}
+		}
+
 		float tw = m_aNamePlates[ClientID].m_NameTextWidth;
 		if(g_Config.m_ClNameplatesTeamcolors && m_pClient->m_Teams.Team(ClientID))
 			rgb = color_cast<ColorRGBA>(ColorHSLA(m_pClient->m_Teams.Team(ClientID) / 64.0f, 1.0f, 0.75f));
@@ -210,6 +234,13 @@ void CNamePlates::RenderNameplatePos(vec2 Position, const CNetObj_PlayerInfo *pP
 			float XOffset = TextRender()->TextWidth(FontSize, aBuf, -1, -1.0f) / 2.0f;
 			TextRender()->TextColor(rgb);
 			TextRender()->Text(Position.x - XOffset, YOffset, FontSize, aBuf, -1.0f);
+		}
+
+		if(g_Config.m_Debug || g_Config.m_ClNameplatesSkin)
+		{
+			YOffset -= FontSizeClan;
+			if(m_aNamePlates[ClientID].m_SkinNameTextContainerIndex.Valid())
+				TextRender()->RenderTextContainer(m_aNamePlates[ClientID].m_SkinNameTextContainerIndex, TColor, TOutlineColor, Position.x - m_aNamePlates[ClientID].m_SkinNameTextWidth / 2.0f, YOffset);
 		}
 	}
 
@@ -348,6 +379,7 @@ void CNamePlates::ResetNamePlates()
 	{
 		TextRender()->DeleteTextContainer(NamePlate.m_NameTextContainerIndex);
 		TextRender()->DeleteTextContainer(NamePlate.m_ClanNameTextContainerIndex);
+		TextRender()->DeleteTextContainer(NamePlate.m_SkinNameTextContainerIndex);
 
 		NamePlate.Reset();
 	}

--- a/src/game/client/components/nameplates.h
+++ b/src/game/client/components/nameplates.h
@@ -22,10 +22,12 @@ struct SPlayerNamePlate
 	{
 		m_NameTextContainerIndex.Reset();
 		m_ClanNameTextContainerIndex.Reset();
+		m_SkinNameTextContainerIndex.Reset();
 		m_aName[0] = 0;
 		m_aClanName[0] = 0;
-		m_NameTextWidth = m_ClanNameTextWidth = 0.f;
-		m_NameTextFontSize = m_ClanNameTextFontSize = 0;
+		m_aSkinName[0] = 0;
+		m_NameTextWidth = m_ClanNameTextWidth = m_SkinNameTextWidth = 0.f;
+		m_NameTextFontSize = m_ClanNameTextFontSize = m_SkinNameTextFontSize = 0;
 	}
 
 	char m_aName[MAX_NAME_LENGTH];
@@ -37,6 +39,11 @@ struct SPlayerNamePlate
 	float m_ClanNameTextWidth;
 	STextContainerIndex m_ClanNameTextContainerIndex;
 	float m_ClanNameTextFontSize;
+
+	char m_aSkinName[64];
+	float m_SkinNameTextWidth;
+	STextContainerIndex m_SkinNameTextContainerIndex;
+	float m_SkinNameTextFontSize;
 };
 
 class CNamePlates : public CComponent

--- a/src/game/variables.h
+++ b/src/game/variables.h
@@ -34,6 +34,7 @@ MACRO_CONFIG_INT(ClNameplatesIDs, cl_nameplates_ids, 0, 0, 1, CFGFLAG_CLIENT | C
 MACRO_CONFIG_INT(ClNameplatesOwn, cl_nameplates_own, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show own name plate (useful for demo recording)")
 MACRO_CONFIG_INT(ClNameplatesFriendMark, cl_nameplates_friendmark, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show friend mark (♥) in name plates")
 MACRO_CONFIG_INT(ClNameplatesStrong, cl_nameplates_strong, 0, 0, 2, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show strong/weak in name plates (0 - off, 1 - icons, 2 - icons + numbers)")
+MACRO_CONFIG_INT(ClNameplatesSkin, cl_nameplates_skin, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show skin name in name plates")
 MACRO_CONFIG_INT(ClTextEntities, cl_text_entities, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Render textual entity data")
 MACRO_CONFIG_INT(ClTextEntitiesSize, cl_text_entities_size, 100, 1, 100, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Size of textual entity data from 1 to 100%")
 


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->
Sometimes players will show up as the default skin, but it's not easy to know whether this is because you don't have their skin installed or because they simply chose the default skin.
This can also be useful if you see a player using a cool skin and want to use it yourself but don't know what it's called.

![nameplates with skin names](https://github.com/ddnet/ddnet/assets/19620451/e251c76a-15c8-42fe-9ec0-9c77868a09a5)

A screenshot with debug mode enabled, and `cl_nameplates_clan` enabled
![nameplates with EVERYTHING](https://github.com/ddnet/ddnet/assets/19620451/33439792-1e40-4338-b9b0-6d6b84af3bb0)

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
