### PR TITLE
revert change to quad selection (resolves #7025)

### DIFF
--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -940,7 +940,6 @@ public:
 	void RenderMousePointer();
 
 	std::vector<CQuad *> GetSelectedQuads();
-	std::vector<std::pair<CQuad *, int>> GetSelectedQuadPoints();
 	std::shared_ptr<CLayer> GetSelectedLayerType(int Index, int Type) const;
 	std::shared_ptr<CLayer> GetSelectedLayer(int Index) const;
 	std::shared_ptr<CLayerGroup> GetSelectedGroup() const;
@@ -951,13 +950,12 @@ public:
 	void ToggleSelectQuad(int Index);
 	void DeselectQuads();
 	void DeselectQuadPoints();
-	void SelectQuadPoint(int QuadIndex, int Index);
-	void ToggleSelectQuadPoint(int QuadIndex, int Index);
+	void SelectQuadPoint(int Index);
+	void ToggleSelectQuadPoint(int Index);
 	void DeleteSelectedQuads();
 	bool IsQuadSelected(int Index) const;
-	bool IsQuadPointSelected(int QuadIndex, int Index) const;
+	bool IsQuadPointSelected(int Index) const;
 	int FindSelectedQuadIndex(int Index) const;
-	int FindSelectedQuadPointIndex(int QuadIndex) const;
 
 	int FindEnvPointIndex(int Index, int Channel) const;
 	void SelectEnvPoint(int Index);
@@ -1183,7 +1181,7 @@ public:
 	int m_SelectedQuadPoint;
 	int m_SelectedQuadIndex;
 	int m_SelectedGroup;
-	std::vector<std::pair<int, int>> m_vSelectedQuadPoints;
+	int m_SelectedQuadPoints;
 	int m_SelectedEnvelope;
 	std::vector<std::pair<int, int>> m_vSelectedEnvelopePoints;
 	int m_SelectedQuadEnvelope;
@@ -1194,8 +1192,6 @@ public:
 	std::pair<int, int> m_SelectedTangentInPoint;
 	std::pair<int, int> m_SelectedTangentOutPoint;
 	bool m_UpdateEnvPointInfo;
-
-	std::vector<CQuad> m_vCopyBuffer;
 
 	bool m_QuadKnifeActive;
 	int m_QuadKnifeCount;

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -1209,10 +1209,10 @@ CUI::EPopupMenuFunctionResult CEditor::PopupSource(void *pContext, CUIRect View,
 CUI::EPopupMenuFunctionResult CEditor::PopupPoint(void *pContext, CUIRect View, bool Active)
 {
 	CEditor *pEditor = static_cast<CEditor *>(pContext);
-	std::vector<std::pair<CQuad *, int>> vpQuads = pEditor->GetSelectedQuadPoints();
+	std::vector<CQuad *> vpQuads = pEditor->GetSelectedQuads();
 	if(!in_range<int>(pEditor->m_SelectedQuadIndex, 0, vpQuads.size() - 1))
 		return CUI::POPUP_CLOSE_CURRENT;
-	CQuad *pCurrentQuad = vpQuads[pEditor->m_SelectedQuadIndex].first;
+	CQuad *pCurrentQuad = vpQuads[pEditor->m_SelectedQuadIndex];
 
 	enum
 	{
@@ -1252,25 +1252,25 @@ CUI::EPopupMenuFunctionResult CEditor::PopupPoint(void *pContext, CUIRect View, 
 		pEditor->m_Map.OnModify();
 	}
 
-	for(auto [pQuad, SelectedPoints] : vpQuads)
+	for(CQuad *pQuad : vpQuads)
 	{
 		if(Prop == PROP_POS_X)
 		{
 			for(int v = 0; v < 4; v++)
-				if(SelectedPoints & (1 << v))
+				if(pEditor->IsQuadSelected(v))
 					pQuad->m_aPoints[v].x = i2fx(fx2i(pQuad->m_aPoints[v].x) + NewVal - X);
 		}
 		else if(Prop == PROP_POS_Y)
 		{
 			for(int v = 0; v < 4; v++)
-				if(SelectedPoints & (1 << v))
+				if(pEditor->IsQuadSelected(v))
 					pQuad->m_aPoints[v].y = i2fx(fx2i(pQuad->m_aPoints[v].y) + NewVal - Y);
 		}
 		else if(Prop == PROP_COLOR)
 		{
 			for(int v = 0; v < 4; v++)
 			{
-				if(SelectedPoints & (1 << v))
+				if(pEditor->IsQuadSelected(v))
 				{
 					pQuad->m_aColors[v].r = (NewVal >> 24) & 0xff;
 					pQuad->m_aColors[v].g = (NewVal >> 16) & 0xff;
@@ -1282,13 +1282,13 @@ CUI::EPopupMenuFunctionResult CEditor::PopupPoint(void *pContext, CUIRect View, 
 		else if(Prop == PROP_TEX_U)
 		{
 			for(int v = 0; v < 4; v++)
-				if(SelectedPoints & (1 << v))
+				if(pEditor->IsQuadSelected(v))
 					pQuad->m_aTexcoords[v].x = f2fx(fx2f(pQuad->m_aTexcoords[v].x) + (NewVal - TextureU) / 1024.0f);
 		}
 		else if(Prop == PROP_TEX_V)
 		{
 			for(int v = 0; v < 4; v++)
-				if(SelectedPoints & (1 << v))
+				if(pEditor->IsQuadSelected(v))
 					pQuad->m_aTexcoords[v].y = f2fx(fx2f(pQuad->m_aTexcoords[v].y) + (NewVal - TextureV) / 1024.0f);
 		}
 	}


### PR DESCRIPTION
Some refactorings are kept and rotation being bound to `R` is also not reverted.

<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
