### PR TITLE
Add restart button for when game needs to restart to apply settings

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -1196,6 +1196,11 @@ int CMenus::Render()
 			pTitle = Localize("Password incorrect");
 			pButtonText = Localize("Try again");
 		}
+		else if(m_Popup == POPUP_RESTART)
+		{
+			pTitle = Localize("Restart");
+			pExtraText = Localize("Are you sure that you want to restart?");
+		}
 		else if(m_Popup == POPUP_QUIT)
 		{
 			pTitle = Localize("Quit");
@@ -1319,7 +1324,7 @@ int CMenus::Render()
 				}
 			}
 		}
-		else if(m_Popup == POPUP_QUIT)
+		else if(m_Popup == POPUP_QUIT || m_Popup == POPUP_RESTART)
 		{
 			CUIRect Yes, No;
 			Box.HSplitBottom(20.f, &Box, &Part);
@@ -1329,7 +1334,7 @@ int CMenus::Render()
 			Box.VMargin(20.f, &Box);
 			if(m_pClient->Editor()->HasUnsavedData())
 			{
-				str_format(aBuf, sizeof(aBuf), "%s\n%s", Localize("There's an unsaved map in the editor, you might want to save it before you quit the game."), Localize("Quit anyway?"));
+				str_format(aBuf, sizeof(aBuf), "%s\n\n%s", Localize("There's an unsaved map in the editor, you might want to save it."), Localize("Continue anyway?"));
 				Props.m_MaxWidth = Part.w - 20.0f;
 				UI()->DoLabel(&Box, aBuf, 20.f, TEXTALIGN_ML, Props);
 			}
@@ -1347,8 +1352,16 @@ int CMenus::Render()
 			static CButtonContainer s_ButtonTryAgain;
 			if(DoButton_Menu(&s_ButtonTryAgain, Localize("Yes"), 0, &Yes) || UI()->ConsumeHotkey(CUI::HOTKEY_ENTER))
 			{
-				m_Popup = POPUP_NONE;
-				Client()->Quit();
+				if(m_Popup == POPUP_RESTART)
+				{
+					m_Popup = POPUP_NONE;
+					Client()->Restart();
+				}
+				else
+				{
+					m_Popup = POPUP_NONE;
+					Client()->Quit();
+				}
 			}
 		}
 		else if(m_Popup == POPUP_PASSWORD)

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -219,12 +219,9 @@ protected:
 	static float ms_ListitemAdditionalHeight;
 
 	// for settings
-	bool m_NeedRestartGeneral;
-	bool m_NeedRestartSkins;
 	bool m_NeedRestartGraphics;
 	bool m_NeedRestartSound;
 	bool m_NeedRestartUpdate;
-	bool m_NeedRestartDDNet;
 	bool m_NeedSendinfo;
 	bool m_NeedSendDummyinfo;
 	int m_SettingPlayerPage;
@@ -745,6 +742,7 @@ public:
 		POPUP_RENDER_DONE,
 		POPUP_PASSWORD,
 		POPUP_QUIT,
+		POPUP_RESTART,
 		POPUP_WARNING,
 
 		// demo player states

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -1988,11 +1988,12 @@ bool CMenus::RenderLanguageSelection(CUIRect MainView)
 void CMenus::RenderSettings(CUIRect MainView)
 {
 	// render background
-	CUIRect Button, TabBar, RestartWarning;
+	CUIRect Button, TabBar, RestartBar, RestartWarning, RestartButton;
 	MainView.VSplitRight(120.0f, &MainView, &TabBar);
 	MainView.Draw(ms_ColorTabbarActive, IGraphics::CORNER_B, 10.0f);
 	MainView.Margin(10.0f, &MainView);
-	MainView.HSplitBottom(15.0f, &MainView, &RestartWarning);
+	MainView.HSplitBottom(15.0f, &MainView, &RestartBar);
+	RestartBar.VSplitRight(125.0f, &RestartWarning, &RestartButton);
 	TabBar.HSplitTop(50.0f, &Button, &TabBar);
 	Button.Draw(ms_ColorTabbarActive, IGraphics::CORNER_BR, 10.0f);
 
@@ -2020,7 +2021,7 @@ void CMenus::RenderSettings(CUIRect MainView)
 	}
 
 	MainView.Margin(10.0f, &MainView);
-	RestartWarning.VMargin(10.0f, &RestartWarning);
+	RestartBar.VMargin(10.0f, &RestartBar);
 
 	if(g_Config.m_UiSettingsPage == SETTINGS_LANGUAGE)
 	{
@@ -2073,14 +2074,32 @@ void CMenus::RenderSettings(CUIRect MainView)
 		RenderSettingsCustom(MainView);
 	}
 
-	if(m_NeedRestartUpdate)
+	if(m_NeedRestartGraphics || m_NeedRestartSound || m_NeedRestartUpdate)
 	{
-		TextRender()->TextColor(1.0f, 0.4f, 0.4f, 1.0f);
-		UI()->DoLabel(&RestartWarning, Localize("DDNet Client needs to be restarted to complete update!"), 14.0f, TEXTALIGN_ML);
-		TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
+		if(m_NeedRestartUpdate)
+		{
+			TextRender()->TextColor(1.0f, 0.4f, 0.4f, 1.0f);
+			UI()->DoLabel(&RestartWarning, Localize("DDNet Client needs to be restarted to complete update!"), 14.0f, TEXTALIGN_ML);
+			TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
+		}
+		else
+		{
+			UI()->DoLabel(&RestartWarning, Localize("You must restart the game for all settings to take effect."), 14.0f, TEXTALIGN_ML);
+		}
+
+		static CButtonContainer s_RestartButton;
+		if(DoButton_Menu(&s_RestartButton, Localize("Restart"), 0, &RestartButton))
+		{
+			if(Client()->State() == IClient::STATE_ONLINE || m_pClient->Editor()->HasUnsavedData())
+			{
+				m_Popup = POPUP_RESTART;
+			}
+			else
+			{
+				Client()->Restart();
+			}
+		}
 	}
-	else if(m_NeedRestartGeneral || m_NeedRestartSkins || m_NeedRestartGraphics || m_NeedRestartSound || m_NeedRestartDDNet)
-		UI()->DoLabel(&RestartWarning, Localize("You must restart the game for all settings to take effect."), 14.0f, TEXTALIGN_ML);
 }
 
 ColorHSLA CMenus::RenderHSLScrollbars(CUIRect *pRect, unsigned int *pColor, bool Alpha, bool ClampedLight)


### PR DESCRIPTION
In addition to the warning message a button will be shown allowing for easy restart.

![restart-button-1](https://github.com/ddnet/ddnet/assets/121701317/4926e63d-4758-4d89-a7bf-2503a69c27a3)
![restart-button-2](https://github.com/ddnet/ddnet/assets/121701317/aecabf72-ae59-4fde-b9a4-dc3eb3fa74f5)

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
