### PR TITLE
Remove `CLocConstString`

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -448,10 +448,10 @@ int CMenus::DoButton_CheckBox_Number(const void *pID, const char *pText, int Che
 	return DoButton_CheckBox_Common(pID, pText, aBuf, pRect);
 }
 
-int CMenus::DoKeyReader(void *pID, const CUIRect *pRect, int Key, int ModifierCombination, int *pNewModifierCombination)
+int CMenus::DoKeyReader(const void *pID, const CUIRect *pRect, int Key, int ModifierCombination, int *pNewModifierCombination)
 {
 	// process
-	static void *pGrabbedID = 0;
+	static const void *pGrabbedID = 0;
 	static bool MouseReleased = true;
 	static int s_ButtonUsed = 0;
 	const bool Inside = UI()->MouseHovered(pRect);

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -71,7 +71,7 @@ class CMenus : public CComponent
 	int DoButton_GridHeader(const void *pID, const char *pText, int Checked, const CUIRect *pRect);
 
 	void DoButton_KeySelect(const void *pID, const char *pText, const CUIRect *pRect);
-	int DoKeyReader(void *pID, const CUIRect *pRect, int Key, int ModifierCombination, int *pNewModifierCombination);
+	int DoKeyReader(const void *pID, const CUIRect *pRect, int Key, int ModifierCombination, int *pNewModifierCombination);
 
 	void DoSettingsControlsButtons(int Start, int Stop, CUIRect View);
 

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -70,7 +70,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 	{
 		int m_ID;
 		int m_Sort;
-		CLocConstString m_Caption;
+		const char *m_pCaption;
 		int m_Direction;
 		float m_Width;
 		CUIRect m_Rect;
@@ -90,17 +90,17 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 		COL_VERSION,
 	};
 
-	CColumn s_aCols[] = {
-		{-1, -1, " ", -1, 2.0f, {0}, {0}},
-		{COL_FLAG_LOCK, -1, " ", -1, 14.0f, {0}, {0}},
-		{COL_FLAG_FAV, -1, " ", -1, 14.0f, {0}, {0}},
-		{COL_FLAG_OFFICIAL, -1, " ", -1, 14.0f, {0}, {0}},
-		{COL_NAME, IServerBrowser::SORT_NAME, "Name", 0, 50.0f, {0}, {0}}, // Localize - these strings are localized within CLocConstString
+	static CColumn s_aCols[] = {
+		{-1, -1, "", -1, 2.0f, {0}, {0}},
+		{COL_FLAG_LOCK, -1, "", -1, 14.0f, {0}, {0}},
+		{COL_FLAG_FAV, -1, "", -1, 14.0f, {0}, {0}},
+		{COL_FLAG_OFFICIAL, -1, "", -1, 14.0f, {0}, {0}},
+		{COL_NAME, IServerBrowser::SORT_NAME, Localizable("Name"), 0, 50.0f, {0}, {0}},
 		{COL_GAMETYPE, IServerBrowser::SORT_GAMETYPE, Localizable("Type"), 1, 50.0f, {0}, {0}},
-		{COL_MAP, IServerBrowser::SORT_MAP, "Map", 1, 120.0f + (Headers.w - 480) / 8, {0}, {0}},
-		{COL_PLAYERS, IServerBrowser::SORT_NUMPLAYERS, "Players", 1, 85.0f, {0}, {0}},
-		{-1, -1, " ", 1, 10.0f, {0}, {0}},
-		{COL_PING, IServerBrowser::SORT_PING, "Ping", 1, 40.0f, {0}, {0}},
+		{COL_MAP, IServerBrowser::SORT_MAP, Localizable("Map"), 1, 120.0f + (Headers.w - 480) / 8, {0}, {0}},
+		{COL_PLAYERS, IServerBrowser::SORT_NUMPLAYERS, Localizable("Players"), 1, 85.0f, {0}, {0}},
+		{-1, -1, "", 1, 10.0f, {0}, {0}},
+		{COL_PING, IServerBrowser::SORT_PING, Localizable("Ping"), 1, 40.0f, {0}, {0}},
 	};
 
 	int NumCols = std::size(s_aCols);
@@ -143,7 +143,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View)
 		if(PlayersOrPing && g_Config.m_BrSortOrder == 2 && (s_aCols[i].m_Sort == IServerBrowser::SORT_NUMPLAYERS || s_aCols[i].m_Sort == IServerBrowser::SORT_PING))
 			Checked = 2;
 
-		if(DoButton_GridHeader(s_aCols[i].m_Caption, Localize(s_aCols[i].m_Caption), Checked, &s_aCols[i].m_Rect))
+		if(DoButton_GridHeader(&s_aCols[i].m_ID, Localize(s_aCols[i].m_pCaption), Checked, &s_aCols[i].m_Rect))
 		{
 			if(s_aCols[i].m_Sort != -1)
 			{
@@ -1066,12 +1066,6 @@ void CMenus::RenderServerbrowserServerDetail(CUIRect View)
 	{
 		ServerDetails.Margin(5.0f, &ServerDetails);
 
-		CUIRect Row;
-		static CLocConstString s_aLabels[] = {
-			"Version", // Localize - these strings are localized within CLocConstString
-			"Game type",
-			"Ping"};
-
 		// copy info button
 		{
 			CUIRect Button;
@@ -1122,20 +1116,23 @@ void CMenus::RenderServerbrowserServerDetail(CUIRect View)
 			}
 		}
 
-		CUIRect LeftColumn, RightColumn;
+		CUIRect LeftColumn, RightColumn, Row;
 		ServerDetails.VSplitLeft(80.0f, &LeftColumn, &RightColumn);
 
-		for(auto &Label : s_aLabels)
-		{
-			LeftColumn.HSplitTop(15.0f, &Row, &LeftColumn);
-			UI()->DoLabel(&Row, Label, FontSize, TEXTALIGN_ML);
-		}
+		LeftColumn.HSplitTop(15.0f, &Row, &LeftColumn);
+		UI()->DoLabel(&Row, Localize("Version"), FontSize, TEXTALIGN_ML);
 
 		RightColumn.HSplitTop(15.0f, &Row, &RightColumn);
 		UI()->DoLabel(&Row, pSelectedServer->m_aVersion, FontSize, TEXTALIGN_ML);
 
+		LeftColumn.HSplitTop(15.0f, &Row, &LeftColumn);
+		UI()->DoLabel(&Row, Localize("Game type"), FontSize, TEXTALIGN_ML);
+
 		RightColumn.HSplitTop(15.0f, &Row, &RightColumn);
 		UI()->DoLabel(&Row, pSelectedServer->m_aGameType, FontSize, TEXTALIGN_ML);
+
+		LeftColumn.HSplitTop(15.0f, &Row, &LeftColumn);
+		UI()->DoLabel(&Row, Localize("Ping"), FontSize, TEXTALIGN_ML);
 
 		char aTemp[16];
 		FormatServerbrowserPing(aTemp, sizeof(aTemp), pSelectedServer);

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -1113,7 +1113,7 @@ void CMenus::RenderDemoList(CUIRect MainView)
 	{
 		int m_ID;
 		int m_Sort;
-		CLocConstString m_Caption;
+		const char *m_pCaption;
 		int m_Direction;
 		float m_Width;
 		CUIRect m_Rect;
@@ -1171,7 +1171,7 @@ void CMenus::RenderDemoList(CUIRect MainView)
 	// do headers
 	for(auto &Col : s_aCols)
 	{
-		if(DoButton_GridHeader(&Col.m_ID, Col.m_Caption, g_Config.m_BrDemoSort == Col.m_Sort, &Col.m_Rect))
+		if(DoButton_GridHeader(&Col.m_ID, Localize(Col.m_pCaption), g_Config.m_BrDemoSort == Col.m_Sort, &Col.m_Rect))
 		{
 			if(Col.m_Sort != -1)
 			{

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -988,7 +988,7 @@ void CMenus::RenderGhost(CUIRect MainView)
 
 	struct CColumn
 	{
-		CLocConstString m_Caption;
+		const char *m_pCaption;
 		int m_Id;
 		float m_Width;
 		CUIRect m_Rect;
@@ -1003,8 +1003,8 @@ void CMenus::RenderGhost(CUIRect MainView)
 	};
 
 	static CColumn s_aCols[] = {
-		{" ", -1, 2.0f, {0}, {0}},
-		{" ", COL_ACTIVE, 30.0f, {0}, {0}},
+		{"", -1, 2.0f, {0}, {0}},
+		{"", COL_ACTIVE, 30.0f, {0}, {0}},
 		{Localizable("Name"), COL_NAME, 300.0f, {0}, {0}},
 		{Localizable("Time"), COL_TIME, 200.0f, {0}, {0}},
 	};
@@ -1022,7 +1022,7 @@ void CMenus::RenderGhost(CUIRect MainView)
 
 	// do headers
 	for(int i = 0; i < NumCols; i++)
-		DoButton_GridHeader(s_aCols[i].m_Caption, Localize(s_aCols[i].m_Caption), 0, &s_aCols[i].m_Rect);
+		DoButton_GridHeader(&s_aCols[i].m_Id, Localize(s_aCols[i].m_pCaption), 0, &s_aCols[i].m_Rect);
 
 	View.Draw(ColorRGBA(0, 0, 0, 0.15f), 0, 0);
 

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -940,7 +940,7 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 
 typedef struct
 {
-	CLocConstString m_Name;
+	const char *m_pName;
 	const char *m_pCommand;
 	int m_KeyId;
 	int m_ModifierCombination;
@@ -948,7 +948,7 @@ typedef struct
 
 static CKeyInfo gs_aKeys[] =
 	{
-		{Localizable("Move left"), "+left", 0, 0}, // Localize - these strings are localized within CLocConstString
+		{Localizable("Move left"), "+left", 0, 0},
 		{Localizable("Move right"), "+right", 0, 0},
 		{Localizable("Jump"), "+jump", 0, 0},
 		{Localizable("Fire"), "+fire", 0, 0},
@@ -1003,23 +1003,24 @@ void CMenus::DoSettingsControlsButtons(int Start, int Stop, CUIRect View)
 {
 	for(int i = Start; i < Stop; i++)
 	{
-		CKeyInfo &Key = gs_aKeys[i];
+		const CKeyInfo &Key = gs_aKeys[i];
+
 		CUIRect Button, Label;
 		View.HSplitTop(20.0f, &Button, &View);
 		Button.VSplitLeft(135.0f, &Label, &Button);
 
 		char aBuf[64];
-		str_format(aBuf, sizeof(aBuf), "%s:", Localize((const char *)Key.m_Name));
+		str_format(aBuf, sizeof(aBuf), "%s:", Localize(Key.m_pName));
 
 		UI()->DoLabel(&Label, aBuf, 13.0f, TEXTALIGN_ML);
 		int OldId = Key.m_KeyId, OldModifierCombination = Key.m_ModifierCombination, NewModifierCombination;
-		int NewId = DoKeyReader((void *)&Key.m_Name, &Button, OldId, OldModifierCombination, &NewModifierCombination);
+		int NewId = DoKeyReader(&Key.m_KeyId, &Button, OldId, OldModifierCombination, &NewModifierCombination);
 		if(NewId != OldId || NewModifierCombination != OldModifierCombination)
 		{
 			if(OldId != 0 || NewId == 0)
 				m_pClient->m_Binds.Bind(OldId, "", false, OldModifierCombination);
 			if(NewId != 0)
-				m_pClient->m_Binds.Bind(NewId, gs_aKeys[i].m_pCommand, false, NewModifierCombination);
+				m_pClient->m_Binds.Bind(NewId, Key.m_pCommand, false, NewModifierCombination);
 		}
 
 		View.HSplitTop(2.0f, 0, &View);

--- a/src/game/localization.cpp
+++ b/src/game/localization.cpp
@@ -13,28 +13,6 @@ const char *Localize(const char *pStr, const char *pContext)
 	return pNewStr ? pNewStr : pStr;
 }
 
-CLocConstString::CLocConstString(const char *pStr, const char *pContext)
-{
-	m_pDefaultStr = pStr;
-	m_Hash = str_quickhash(m_pDefaultStr);
-	m_Version = -1;
-}
-
-void CLocConstString::Reload()
-{
-	m_Version = g_Localization.Version();
-	const char *pNewStr = g_Localization.FindString(m_Hash, m_ContextHash);
-	m_pCurrentStr = pNewStr;
-	if(!m_pCurrentStr)
-		m_pCurrentStr = m_pDefaultStr;
-}
-
-CLocalizationDatabase::CLocalizationDatabase()
-{
-	m_VersionCounter = 0;
-	m_CurrentVersion = 0;
-}
-
 void CLocalizationDatabase::LoadIndexfile(IStorage *pStorage, IConsole *pConsole)
 {
 	m_vLanguages.clear();
@@ -214,7 +192,6 @@ bool CLocalizationDatabase::Load(const char *pFilename, IStorage *pStorage, ICon
 	{
 		m_vStrings.clear();
 		m_StringsHeap.Reset();
-		m_CurrentVersion = 0;
 		return true;
 	}
 
@@ -281,8 +258,6 @@ bool CLocalizationDatabase::Load(const char *pFilename, IStorage *pStorage, ICon
 	}
 	io_close(IoHandle);
 	std::sort(m_vStrings.begin(), m_vStrings.end());
-
-	m_CurrentVersion = ++m_VersionCounter;
 	return true;
 }
 

--- a/src/game/localization.h
+++ b/src/game/localization.h
@@ -48,45 +48,19 @@ class CLocalizationDatabase
 	std::vector<CLanguage> m_vLanguages;
 	std::vector<CString> m_vStrings;
 	CHeap m_StringsHeap;
-	int m_VersionCounter;
-	int m_CurrentVersion;
 
 public:
-	CLocalizationDatabase();
-
 	void LoadIndexfile(class IStorage *pStorage, class IConsole *pConsole);
 	const std::vector<CLanguage> &Languages() const { return m_vLanguages; }
 	void SelectDefaultLanguage(class IConsole *pConsole, char *pFilename, size_t Length) const;
 
 	bool Load(const char *pFilename, class IStorage *pStorage, class IConsole *pConsole);
 
-	int Version() const { return m_CurrentVersion; }
-
 	void AddString(const char *pOrgStr, const char *pNewStr, const char *pContext);
 	const char *FindString(unsigned Hash, unsigned ContextHash) const;
 };
 
 extern CLocalizationDatabase g_Localization;
-
-class CLocConstString
-{
-	const char *m_pDefaultStr;
-	const char *m_pCurrentStr;
-	unsigned m_Hash;
-	unsigned m_ContextHash;
-	int m_Version;
-
-public:
-	CLocConstString(const char *pStr, const char *pContext = "");
-	void Reload();
-
-	inline operator const char *()
-	{
-		if(m_Version != g_Localization.Version())
-			Reload();
-		return m_pCurrentStr;
-	}
-};
 
 extern const char *Localize(const char *pStr, const char *pContext = "")
 	GNUC_ATTRIBUTE((format_arg(1)));


### PR DESCRIPTION
This makes it more obvious where text is localized. This class was also broken for localized strings with context, since the member variable `m_ContextHash` was uninitialized.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
