### PR TITLE
Add progress spinner to UI, show progress spinner while saving map in editor

### DIFF
--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -1279,6 +1279,55 @@ void CUI::DoScrollbarOption(const void *pID, int *pOption, const CUIRect *pRect,
 	*pOption = Value;
 }
 
+void CUI::RenderProgressSpinner(vec2 Center, float OuterRadius, const SProgressSpinnerProperties &Props)
+{
+	static float s_SpinnerOffset = 0.0f;
+	static float s_LastRender = Client()->LocalTime();
+	s_SpinnerOffset += (Client()->LocalTime() - s_LastRender) * 1.5f;
+	s_SpinnerOffset = std::fmod(s_SpinnerOffset, 1.0f);
+
+	Graphics()->TextureClear();
+	Graphics()->QuadsBegin();
+
+	// The filled and unfilled segments need to begin at the same angle offset
+	// or the differences in pixel alignment will make the filled segments flicker.
+	const float SegmentsAngle = 2.0f * pi / Props.m_Segments;
+	const float InnerRadius = OuterRadius * 0.75f;
+	const float AngleOffset = -0.5f * pi;
+	Graphics()->SetColor(Props.m_Color.WithMultipliedAlpha(0.5f));
+	for(int i = 0; i < Props.m_Segments; ++i)
+	{
+		const float Angle1 = AngleOffset + i * SegmentsAngle;
+		const float Angle2 = AngleOffset + (i + 1) * SegmentsAngle;
+		IGraphics::CFreeformItem Item = IGraphics::CFreeformItem(
+			Center.x + std::cos(Angle1) * InnerRadius, Center.y + std::sin(Angle1) * InnerRadius,
+			Center.x + std::cos(Angle2) * InnerRadius, Center.y + std::sin(Angle2) * InnerRadius,
+			Center.x + std::cos(Angle1) * OuterRadius, Center.y + std::sin(Angle1) * OuterRadius,
+			Center.x + std::cos(Angle2) * OuterRadius, Center.y + std::sin(Angle2) * OuterRadius);
+		Graphics()->QuadsDrawFreeform(&Item, 1);
+	}
+
+	const float FilledRatio = Props.m_Progress < 0.0f ? 0.333f : Props.m_Progress;
+	const int FilledSegmentOffset = Props.m_Progress < 0.0f ? round_to_int(s_SpinnerOffset * Props.m_Segments) : 0;
+	const int FilledNumSegments = minimum<int>(Props.m_Segments * FilledRatio + (Props.m_Progress < 0.0f ? 0 : 1), Props.m_Segments);
+	Graphics()->SetColor(Props.m_Color);
+	for(int i = 0; i < FilledNumSegments; ++i)
+	{
+		const float Angle1 = AngleOffset + (i + FilledSegmentOffset) * SegmentsAngle;
+		const float Angle2 = AngleOffset + ((i + 1 == FilledNumSegments && Props.m_Progress >= 0.0f) ? (2.0f * pi * Props.m_Progress) : ((i + FilledSegmentOffset + 1) * SegmentsAngle));
+		IGraphics::CFreeformItem Item = IGraphics::CFreeformItem(
+			Center.x + std::cos(Angle1) * InnerRadius, Center.y + std::sin(Angle1) * InnerRadius,
+			Center.x + std::cos(Angle2) * InnerRadius, Center.y + std::sin(Angle2) * InnerRadius,
+			Center.x + std::cos(Angle1) * OuterRadius, Center.y + std::sin(Angle1) * OuterRadius,
+			Center.x + std::cos(Angle2) * OuterRadius, Center.y + std::sin(Angle2) * OuterRadius);
+		Graphics()->QuadsDrawFreeform(&Item, 1);
+	}
+
+	Graphics()->QuadsEnd();
+
+	s_LastRender = Client()->LocalTime();
+}
+
 void CUI::DoPopupMenu(const SPopupMenuId *pID, int X, int Y, int Width, int Height, void *pContext, FPopupMenuFunction pfnFunc, const SPopupMenuProperties &Props)
 {
 	constexpr float Margin = SPopupMenu::POPUP_BORDER + SPopupMenu::POPUP_MARGIN;

--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -238,6 +238,13 @@ struct SValueSelectorProperties
 	ColorRGBA m_Color = ColorRGBA(0.0f, 0.0f, 0.0f, 0.4f);
 };
 
+struct SProgressSpinnerProperties
+{
+	float m_Progress = -1.0f; // between 0.0f and 1.0f, or negative for indeterminate progress
+	ColorRGBA m_Color = ColorRGBA(1.0f, 1.0f, 1.0f, 1.0f);
+	int m_Segments = 64;
+};
+
 /**
  * Type safe UI ID for popup menus.
  */
@@ -510,6 +517,9 @@ public:
 	float DoScrollbarV(const void *pID, const CUIRect *pRect, float Current);
 	float DoScrollbarH(const void *pID, const CUIRect *pRect, float Current, const ColorRGBA *pColorInner = nullptr);
 	void DoScrollbarOption(const void *pID, int *pOption, const CUIRect *pRect, const char *pStr, int Min, int Max, const IScrollbarScale *pScale = &ms_LinearScrollbarScale, unsigned Flags = 0u, const char *pSuffix = "");
+
+	// progress spinner
+	void RenderProgressSpinner(vec2 Center, float OuterRadius, const SProgressSpinnerProperties &Props = {});
 
 	// popup menu
 	void DoPopupMenu(const SPopupMenuId *pID, int X, int Y, int Width, int Height, void *pContext, FPopupMenuFunction pfnFunc, const SPopupMenuProperties &Props = {});

--- a/src/game/client/ui_rect.h
+++ b/src/game/client/ui_rect.h
@@ -113,6 +113,8 @@ public:
 
 	void Draw(ColorRGBA Color, int Corners, float Rounding) const;
 	void Draw4(ColorRGBA ColorTopLeft, ColorRGBA ColorTopRight, ColorRGBA ColorBottomLeft, ColorRGBA ColorBottomRight, int Corners, float Rounding) const;
+
+	vec2 Center() const { return vec2(x + w / 2.0f, y + h / 2.0f); }
 };
 
 #endif

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -7348,10 +7348,17 @@ void CEditor::RenderSavingIndicator(CUIRect View)
 	if(m_WriterFinishJobs.empty())
 		return;
 
+	const char *pText = "Saving…";
+	const float FontSize = 24.0f;
+
 	UI()->MapScreen();
-	CUIRect Label;
-	View.Margin(20.0f, &Label);
-	UI()->DoLabel(&Label, "Saving…", 24.0f, TEXTALIGN_BR);
+	CUIRect Label, Spinner;
+	View.Margin(20.0f, &View);
+	View.HSplitBottom(FontSize, nullptr, &View);
+	View.VSplitRight(TextRender()->TextWidth(FontSize, pText) + 2.0f, &Spinner, &Label);
+	Spinner.VSplitRight(Spinner.h, nullptr, &Spinner);
+	UI()->DoLabel(&Label, pText, FontSize, TEXTALIGN_MR);
+	UI()->RenderProgressSpinner(Spinner.Center(), 8.0f);
 }
 
 void CEditor::FreeDynamicPopupMenus()


### PR DESCRIPTION
Saving indicator in the editor:

https://github.com/ddnet/ddnet/assets/23437060/a71197a0-cdaa-4fc1-a28b-94e195c337f6

Supports indeterminate progress (spinning) and determinate progress (showing a percentage):

https://github.com/ddnet/ddnet/assets/23437060/345469c7-a17a-4147-af8f-d3a6225918f9

Could eventually also be used when assets are being loaded in the background (#6727) or to visualize the remaining callvote time.

## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
