### PR TITLE
Truncate IP with ellipsis in connecting popup

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -1299,7 +1299,10 @@ int CMenus::Render()
 
 		if(UseIpLabel)
 		{
-			UI()->DoLabel(&Part, Client()->ConnectAddressString(), FontSize, TEXTALIGN_MC);
+			SLabelProperties IpLabelProps;
+			IpLabelProps.m_MaxWidth = Part.w;
+			IpLabelProps.m_EllipsisAtEnd = true;
+			UI()->DoLabel(&Part, Client()->ConnectAddressString(), FontSize, TEXTALIGN_MC, IpLabelProps);
 			Box.HSplitTop(20.f, &Part, &Box);
 			Box.HSplitTop(24.f, &Part, &Box);
 		}


### PR DESCRIPTION
Reported by Jurai!.

Screenshots:
- Before:
![screenshot_2023-09-04_21-18-44](https://github.com/ddnet/ddnet/assets/23437060/9ce8a97a-5984-4ad9-a11c-5c79417ba57d)
- After:
![screenshot_2023-09-04_21-18-36](https://github.com/ddnet/ddnet/assets/23437060/1c4fbbd2-7889-49cb-b56a-47e819057b7c)

## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
