### PR TITLE
Improve Windows pipe (FIFO) support

### DIFF
--- a/src/engine/shared/fifo.cpp
+++ b/src/engine/shared/fifo.cpp
@@ -154,7 +154,13 @@ void CFifo::Update()
 		if(!PeekNamedPipe(m_pPipe, NULL, 0, NULL, &BytesAvailable, NULL))
 		{
 			const DWORD LastError = GetLastError();
-			if(LastError != ERROR_BAD_PIPE) // pipe not connected, not an error
+			if(LastError == ERROR_BROKEN_PIPE)
+			{
+				// Pipe was disconnected from the other side, either immediately
+				// after connecting or after reading the previous message.
+				DisconnectNamedPipe(m_pPipe);
+			}
+			else
 			{
 				const std::string ErrorMsg = windows_format_system_message(LastError);
 				dbg_msg("fifo", "failed to peek at pipe '%s' (%ld %s)", m_aFilename, LastError, ErrorMsg.c_str());


### PR DESCRIPTION
Use `WaitForPipeDrain` to deterministically wait for the pipe to drain instead of using `Start-Sleep`.

Use `Dispose` instead of `Close` to properly flush and close the pipe stream.

Add error handling for connection timeout and I/O errors.

Handle `ERROR_BROKEN_PIPE` separately when peeking at pipe, as this happens when the pipe is disconnected immediately after connecting it or after reading the previous message.

Don't ignore `ERROR_BAD_PIPE` anymore, as the pipe should never be in a disconnected (i.e. bad) state at this point of the function.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
