### PR TITLE
Mod Support: Add NINJA_SKIN_FOR_FROZEN game info flag

### DIFF
--- a/datasrc/network.py
+++ b/datasrc/network.py
@@ -26,7 +26,7 @@ GameInfoFlags = [
 ]
 GameInfoFlags2 = [
 	"ALLOW_X_SKINS", "GAMETYPE_CITY", "GAMETYPE_FDDRACE", "ENTITIES_FDDRACE", "HUD_HEALTH_ARMOR", "HUD_AMMO",
-	"HUD_DDRACE", "NO_WEAK_HOOK"
+	"HUD_DDRACE", "NO_WEAK_HOOK", "NO_SKIN_CHANGE_FOR_FROZEN"
 ]
 ExPlayerFlags = ["AFK", "PAUSED", "SPEC"]
 LegacyProjectileFlags = [f"CLIENTID_BIT{i}" for i in range(8)] + [
@@ -71,7 +71,7 @@ enum
 
 enum
 {
-	GAMEINFO_CURVERSION=8,
+	GAMEINFO_CURVERSION=9,
 };
 '''
 

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -763,7 +763,8 @@ void CPlayers::OnRender()
 			m_aRenderInfo[i].m_TeeRenderFlags |= TEE_EFFECT_FROZEN;
 
 		const CGameClient::CSnapState::CCharacterInfo &CharacterInfo = m_pClient->m_Snap.m_aCharacters[i];
-		if((CharacterInfo.m_Cur.m_Weapon == WEAPON_NINJA || (CharacterInfo.m_HasExtendedData && CharacterInfo.m_ExtendedData.m_FreezeEnd != 0)) && g_Config.m_ClShowNinja)
+		const bool Frozen = CharacterInfo.m_HasExtendedData && CharacterInfo.m_ExtendedData.m_FreezeEnd != 0;
+		if((CharacterInfo.m_Cur.m_Weapon == WEAPON_NINJA || (Frozen && !m_pClient->m_GameInfo.m_NoSkinChangeForFrozen)) && g_Config.m_ClShowNinja)
 		{
 			// change the skin for the player to the ninja
 			const auto *pSkin = m_pClient->m_Skins.FindOrNullptr("x_ninja");

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1188,6 +1188,7 @@ static CGameInfo GetGameInfo(const CNetObj_GameInfoEx *pInfoEx, int InfoExSize, 
 	Info.m_HudAmmo = true;
 	Info.m_HudDDRace = false;
 	Info.m_NoWeakHookAndBounce = false;
+	Info.m_NoSkinChangeForFrozen = false;
 
 	if(Version >= 0)
 	{
@@ -1243,6 +1244,11 @@ static CGameInfo GetGameInfo(const CNetObj_GameInfoEx *pInfoEx, int InfoExSize, 
 	{
 		Info.m_NoWeakHookAndBounce = Flags2 & GAMEINFOFLAG2_NO_WEAK_HOOK;
 	}
+	if(Version >= 9)
+	{
+		Info.m_NoSkinChangeForFrozen = Flags2 & GAMEINFOFLAG2_NO_SKIN_CHANGE_FOR_FROZEN;
+	}
+
 	return Info;
 }
 

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -96,6 +96,7 @@ public:
 	bool m_HudDDRace;
 
 	bool m_NoWeakHookAndBounce;
+	bool m_NoSkinChangeForFrozen;
 };
 
 class CSnapEntities


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->
The mod I maintain ([infclass](https://github.com/infclass/teeworlds-infclassR)) has different player classes, and (as in many other games) the classes have unique skins — it is critical to differentiate the classes.

One of the classes is `ninja` which has stun (freeze) grenades. I'd like to use the `CNetObj_DDNetCharacter::FreezeEnd` to show the freeze bars and enable better prediction but by default DDNet client shows ninja skin for frozen characters and it totally ruins infclass gameplay:

### Frozen characters in current DDNet client
![image](https://github.com/ddnet/ddnet/assets/374839/e0178719-b704-4cde-9382-b65874405104)

### Frozen characters with `NINJA_SKIN_FOR_FREEZED` disabled on the server side
![image](https://github.com/ddnet/ddnet/assets/374839/3e8aa0b8-ea8e-40d9-97d8-121f970d0123)


I already maintain a DDNet [client fork](https://github.com/infclass/infclass-client) with 100+ infclass-specific commits (fixes/features) but of course I'd prefer to have DDNet client be capable for all of this stuff so ultimately I can archive the fork and work on infclass server and on DDNet client directly.

I think this feature can be useful for other mods, e.g. maybe `fng` would decide to keep player skins for frozen characters.
<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks.

If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
