### PR TITLE
Refactor some core classes (step 1/xxx to shared CGameWorld)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1968,6 +1968,7 @@ set_src(ENGINE_GFX GLOB src/engine/gfx
   image_manipulation.h
 )
 set_src(GAME_SHARED GLOB src/game
+  alloc.h
   collision.cpp
   collision.h
   ddracechat.h
@@ -2470,7 +2471,6 @@ if(SERVER)
     upnp.h
   )
   set_src(GAME_SERVER GLOB_RECURSE src/game/server
-    alloc.h
     ddracechat.cpp
     ddracecommands.cpp
     entities/character.cpp

--- a/src/game/alloc.h
+++ b/src/game/alloc.h
@@ -1,7 +1,7 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
-#ifndef GAME_SERVER_ALLOC_H
-#define GAME_SERVER_ALLOC_H
+#ifndef GAME_ALLOC_H
+#define GAME_ALLOC_H
 
 #include <new>
 

--- a/src/game/client/prediction/entities/character.cpp
+++ b/src/game/client/prediction/entities/character.cpp
@@ -939,7 +939,7 @@ void CCharacter::HandleTuneLayer()
 	SetTuneZone(GameWorld()->m_WorldConfig.m_UseTuneZones ? Collision()->IsTune(CurrentIndex) : 0);
 
 	if(m_IsLocal)
-		m_Core.m_pWorld->m_aTuning[g_Config.m_ClDummy] = *GetTuning(m_TuneZone); // throw tunings (from specific zone if in a tunezone) into gamecore if the character is local
+		GameWorld()->m_Core.m_aTuning[g_Config.m_ClDummy] = *GetTuning(m_TuneZone); // throw tunings (from specific zone if in a tunezone) into gamecore if the character is local
 	m_Core.m_Tuning = *GetTuning(m_TuneZone);
 }
 

--- a/src/game/client/prediction/entities/character.cpp
+++ b/src/game/client/prediction/entities/character.cpp
@@ -1107,7 +1107,7 @@ void CCharacter::GiveAllWeapons()
 
 CTeamsCore *CCharacter::TeamsCore()
 {
-	return m_Core.m_pTeams;
+	return GameWorld()->Teams();
 }
 
 CCharacter::CCharacter(CGameWorld *pGameWorld, int ID, CNetObj_Character *pChar, CNetObj_DDNetCharacter *pExtended) :
@@ -1355,9 +1355,7 @@ void CCharacter::Read(CNetObj_Character *pChar, CNetObj_DDNetCharacter *pExtende
 
 void CCharacter::SetCoreWorld(CGameWorld *pGameWorld)
 {
-	m_Core.m_pWorld = &pGameWorld->m_Core;
-	m_Core.m_pCollision = pGameWorld->Collision();
-	m_Core.m_pTeams = pGameWorld->Teams();
+	m_Core.SetCoreWorld(&pGameWorld->m_Core, pGameWorld->Collision(), pGameWorld->Teams());
 }
 
 bool CCharacter::Match(CCharacter *pChar)

--- a/src/game/client/prediction/entities/character.cpp
+++ b/src/game/client/prediction/entities/character.cpp
@@ -1171,7 +1171,7 @@ void CCharacter::ResetPrediction()
 		SetWeaponGot(w, false);
 		SetWeaponAmmo(w, -1);
 	}
-	if(m_Core.m_HookedPlayer >= 0)
+	if(m_Core.HookedPlayer() >= 0)
 	{
 		m_Core.SetHookedPlayer(-1);
 		m_Core.m_HookState = HOOK_IDLE;

--- a/src/game/client/prediction/entity.h
+++ b/src/game/client/prediction/entity.h
@@ -12,12 +12,14 @@
 class CEntity
 {
 	MACRO_ALLOC_HEAP()
-	friend class CGameWorld; // entity list handling
+
+private:
+	friend CGameWorld; // entity list handling
 	CEntity *m_pPrevTypeEntity;
 	CEntity *m_pNextTypeEntity;
 
 protected:
-	class CGameWorld *m_pGameWorld;
+	CGameWorld *m_pGameWorld;
 	bool m_MarkedForDestroy;
 	int m_ID;
 	int m_ObjType;
@@ -29,7 +31,7 @@ public:
 	virtual ~CEntity();
 
 	std::vector<SSwitchers> &Switchers() { return m_pGameWorld->Switchers(); }
-	class CGameWorld *GameWorld() { return m_pGameWorld; }
+	CGameWorld *GameWorld() { return m_pGameWorld; }
 	CTuningParams *Tuning() { return GameWorld()->Tuning(); }
 	CTuningParams *TuningList() { return GameWorld()->TuningList(); }
 	CTuningParams *GetTuning(int i) { return GameWorld()->GetTuning(i); }

--- a/src/game/client/prediction/entity.h
+++ b/src/game/client/prediction/entity.h
@@ -3,23 +3,11 @@
 #ifndef GAME_CLIENT_PREDICTION_ENTITY_H
 #define GAME_CLIENT_PREDICTION_ENTITY_H
 
-#include "gameworld.h"
 #include <base/vmath.h>
 
-#define MACRO_ALLOC_HEAP() \
-public: \
-	void *operator new(size_t Size) \
-	{ \
-		void *p = malloc(Size); \
-		mem_zero(p, Size); \
-		return p; \
-	} \
-	void operator delete(void *pPtr) \
-	{ \
-		free(pPtr); \
-	} \
-\
-private:
+#include <game/alloc.h>
+
+#include "gameworld.h"
 
 class CEntity
 {

--- a/src/game/client/prediction/gameworld.cpp
+++ b/src/game/client/prediction/gameworld.cpp
@@ -315,7 +315,7 @@ void CGameWorld::ReleaseHooked(int ClientID)
 	for(; pChr; pChr = (CCharacter *)pChr->TypeNext())
 	{
 		CCharacterCore *pCore = pChr->Core();
-		if(pCore->m_HookedPlayer == ClientID)
+		if(pCore->HookedPlayer() == ClientID)
 		{
 			pCore->SetHookedPlayer(-1);
 			pCore->m_HookState = HOOK_RETRACTED;
@@ -556,7 +556,7 @@ void CGameWorld::NetObjEnd()
 	for(int i = 0; i < MAX_CLIENTS; i++)
 		if(CCharacter *pChar = GetCharacterByID(i))
 			if(!pChar->m_MarkedForDestroy)
-				if(CCharacter *pHookedChar = GetCharacterByID(pChar->m_Core.m_HookedPlayer))
+				if(CCharacter *pHookedChar = GetCharacterByID(pChar->m_Core.HookedPlayer()))
 					if(pHookedChar->m_MarkedForDestroy)
 					{
 						pHookedChar->m_Pos = pHookedChar->m_Core.m_Pos = pChar->m_Core.m_HookPos;

--- a/src/game/client/prediction/gameworld.cpp
+++ b/src/game/client/prediction/gameworld.cpp
@@ -182,11 +182,6 @@ void CGameWorld::RemoveEntities()
 		}
 }
 
-bool distCompare(std::pair<float, int> a, std::pair<float, int> b)
-{
-	return (a.first < b.first);
-}
-
 void CGameWorld::Tick()
 {
 	// update all objects

--- a/src/game/client/prediction/gameworld.h
+++ b/src/game/client/prediction/gameworld.h
@@ -15,8 +15,6 @@ class CEntity;
 
 class CGameWorld
 {
-	friend CCharacter;
-
 public:
 	enum
 	{

--- a/src/game/gamecore.cpp
+++ b/src/game/gamecore.cpp
@@ -97,6 +97,13 @@ void CCharacterCore::Init(CWorldCore *pWorld, CCollision *pCollision, CTeamsCore
 	Reset();
 }
 
+void CCharacterCore::SetCoreWorld(CWorldCore *pWorld, CCollision *pCollision, CTeamsCore *pTeams)
+{
+	m_pWorld = pWorld;
+	m_pCollision = pCollision;
+	m_pTeams = pTeams;
+}
+
 void CCharacterCore::Reset()
 {
 	m_Pos = vec2(0, 0);

--- a/src/game/gamecore.h
+++ b/src/game/gamecore.h
@@ -220,7 +220,6 @@ public:
 
 class CCharacterCore
 {
-	friend class CCharacter;
 	CWorldCore *m_pWorld = nullptr;
 	CCollision *m_pCollision;
 	std::map<int, std::vector<vec2>> *m_pTeleOuts;
@@ -272,6 +271,7 @@ public:
 	int m_TriggeredEvents;
 
 	void Init(CWorldCore *pWorld, CCollision *pCollision, CTeamsCore *pTeams = nullptr, std::map<int, std::vector<vec2>> *pTeleOuts = nullptr);
+	void SetCoreWorld(CWorldCore *pWorld, CCollision *pCollision, CTeamsCore *pTeams);
 	void Reset();
 	void TickDeferred();
 	void Tick(bool UseInput, bool DoDeferredTick = true);

--- a/src/game/gamecore.h
+++ b/src/game/gamecore.h
@@ -236,8 +236,8 @@ public:
 	vec2 m_HookTeleBase;
 	int m_HookTick;
 	int m_HookState;
-	int m_HookedPlayer;
 	std::set<int> m_AttachedPlayers;
+	int HookedPlayer() const { return m_HookedPlayer; }
 	void SetHookedPlayer(int HookedPlayer);
 
 	int m_ActiveWeapon;
@@ -318,6 +318,7 @@ public:
 private:
 	CTeamsCore *m_pTeams;
 	int m_MoveRestrictions;
+	int m_HookedPlayer;
 	static bool IsSwitchActiveCb(int Number, void *pUser);
 };
 

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -206,9 +206,9 @@ void CCharacter::HandleJetpack()
 		{
 			float Strength;
 			if(!m_TuneZone)
-				Strength = GameServer()->Tuning()->m_JetpackStrength;
+				Strength = Tuning()->m_JetpackStrength;
 			else
-				Strength = GameServer()->TuningList()[m_TuneZone].m_JetpackStrength;
+				Strength = TuningList()[m_TuneZone].m_JetpackStrength;
 			TakeDamage(Direction * -1.0f * (Strength / 100.0f / 6.11f), 0, m_pPlayer->GetCID(), m_Core.m_ActiveWeapon);
 		}
 	}
@@ -255,9 +255,9 @@ void CCharacter::HandleNinja()
 		vec2 GroundElasticity;
 
 		if(!m_TuneZone)
-			GroundElasticity = vec2(GameServer()->Tuning()->m_GroundElasticityX, GameServer()->Tuning()->m_GroundElasticityY);
+			GroundElasticity = vec2(Tuning()->m_GroundElasticityX, Tuning()->m_GroundElasticityY);
 		else
-			GroundElasticity = vec2(GameServer()->TuningList()[m_TuneZone].m_GroundElasticityX, GameServer()->TuningList()[m_TuneZone].m_GroundElasticityY);
+			GroundElasticity = vec2(TuningList()[m_TuneZone].m_GroundElasticityX, TuningList()[m_TuneZone].m_GroundElasticityY);
 
 		Collision()->MoveBox(&m_Core.m_Pos, &m_Core.m_Vel, vec2(GetProximityRadius(), GetProximityRadius()), GroundElasticity);
 
@@ -470,9 +470,9 @@ void CCharacter::FireWeapon()
 
 			float Strength;
 			if(!m_TuneZone)
-				Strength = GameServer()->Tuning()->m_HammerStrength;
+				Strength = Tuning()->m_HammerStrength;
 			else
-				Strength = GameServer()->TuningList()[m_TuneZone].m_HammerStrength;
+				Strength = TuningList()[m_TuneZone].m_HammerStrength;
 
 			vec2 Temp = pTarget->m_Core.m_Vel + normalize(Dir + vec2(0.f, -1.1f)) * 10.0f;
 			Temp = ClampVel(pTarget->m_MoveRestrictions, Temp);
@@ -494,9 +494,9 @@ void CCharacter::FireWeapon()
 		{
 			float FireDelay;
 			if(!m_TuneZone)
-				FireDelay = GameServer()->Tuning()->m_HammerHitFireDelay;
+				FireDelay = Tuning()->m_HammerHitFireDelay;
 			else
-				FireDelay = GameServer()->TuningList()[m_TuneZone].m_HammerHitFireDelay;
+				FireDelay = TuningList()[m_TuneZone].m_HammerHitFireDelay;
 			m_ReloadTimer = FireDelay * Server()->TickSpeed() / 1000;
 		}
 	}
@@ -508,9 +508,9 @@ void CCharacter::FireWeapon()
 		{
 			int Lifetime;
 			if(!m_TuneZone)
-				Lifetime = (int)(Server()->TickSpeed() * GameServer()->Tuning()->m_GunLifetime);
+				Lifetime = (int)(Server()->TickSpeed() * Tuning()->m_GunLifetime);
 			else
-				Lifetime = (int)(Server()->TickSpeed() * GameServer()->TuningList()[m_TuneZone].m_GunLifetime);
+				Lifetime = (int)(Server()->TickSpeed() * TuningList()[m_TuneZone].m_GunLifetime);
 
 			new CProjectile(
 				GameWorld(),
@@ -534,9 +534,9 @@ void CCharacter::FireWeapon()
 	{
 		float LaserReach;
 		if(!m_TuneZone)
-			LaserReach = GameServer()->Tuning()->m_LaserReach;
+			LaserReach = Tuning()->m_LaserReach;
 		else
-			LaserReach = GameServer()->TuningList()[m_TuneZone].m_LaserReach;
+			LaserReach = TuningList()[m_TuneZone].m_LaserReach;
 
 		new CLaser(&GameServer()->m_World, m_Pos, Direction, LaserReach, m_pPlayer->GetCID(), WEAPON_SHOTGUN);
 		GameServer()->CreateSound(m_Pos, SOUND_SHOTGUN_FIRE, TeamMask());
@@ -547,9 +547,9 @@ void CCharacter::FireWeapon()
 	{
 		int Lifetime;
 		if(!m_TuneZone)
-			Lifetime = (int)(Server()->TickSpeed() * GameServer()->Tuning()->m_GrenadeLifetime);
+			Lifetime = (int)(Server()->TickSpeed() * Tuning()->m_GrenadeLifetime);
 		else
-			Lifetime = (int)(Server()->TickSpeed() * GameServer()->TuningList()[m_TuneZone].m_GrenadeLifetime);
+			Lifetime = (int)(Server()->TickSpeed() * TuningList()[m_TuneZone].m_GrenadeLifetime);
 
 		new CProjectile(
 			GameWorld(),
@@ -572,9 +572,9 @@ void CCharacter::FireWeapon()
 	{
 		float LaserReach;
 		if(!m_TuneZone)
-			LaserReach = GameServer()->Tuning()->m_LaserReach;
+			LaserReach = Tuning()->m_LaserReach;
 		else
-			LaserReach = GameServer()->TuningList()[m_TuneZone].m_LaserReach;
+			LaserReach = TuningList()[m_TuneZone].m_LaserReach;
 
 		new CLaser(GameWorld(), m_Pos, Direction, LaserReach, m_pPlayer->GetCID(), WEAPON_LASER);
 		GameServer()->CreateSound(m_Pos, SOUND_LASER_FIRE, TeamMask());
@@ -601,9 +601,9 @@ void CCharacter::FireWeapon()
 	{
 		float FireDelay;
 		if(!m_TuneZone)
-			GameServer()->Tuning()->Get(38 + m_Core.m_ActiveWeapon, &FireDelay);
+			Tuning()->Get(38 + m_Core.m_ActiveWeapon, &FireDelay);
 		else
-			GameServer()->TuningList()[m_TuneZone].Get(38 + m_Core.m_ActiveWeapon, &FireDelay);
+			TuningList()[m_TuneZone].Get(38 + m_Core.m_ActiveWeapon, &FireDelay);
 		m_ReloadTimer = FireDelay * Server()->TickSpeed() / 1000;
 	}
 }
@@ -1184,9 +1184,9 @@ void CCharacter::Snap(int SnappingClient)
 		pDDNetCharacter->m_Flags |= CHARACTERFLAG_SUPER;
 	if(m_Core.m_EndlessHook)
 		pDDNetCharacter->m_Flags |= CHARACTERFLAG_ENDLESS_HOOK;
-	if(m_Core.m_CollisionDisabled || !GameServer()->Tuning()->m_PlayerCollision)
+	if(m_Core.m_CollisionDisabled || !Tuning()->m_PlayerCollision)
 		pDDNetCharacter->m_Flags |= CHARACTERFLAG_COLLISION_DISABLED;
-	if(m_Core.m_HookHitDisabled || !GameServer()->Tuning()->m_PlayerHooking)
+	if(m_Core.m_HookHitDisabled || !Tuning()->m_PlayerHooking)
 		pDDNetCharacter->m_Flags |= CHARACTERFLAG_HOOK_HIT_DISABLED;
 	if(m_Core.m_EndlessJump)
 		pDDNetCharacter->m_Flags |= CHARACTERFLAG_ENDLESS_JUMP;
@@ -1915,9 +1915,9 @@ void CCharacter::HandleTuneLayer()
 	m_TuneZone = Collision()->IsTune(CurrentIndex);
 
 	if(m_TuneZone)
-		m_Core.m_Tuning = GameServer()->TuningList()[m_TuneZone]; // throw tunings from specific zone into gamecore
+		m_Core.m_Tuning = TuningList()[m_TuneZone]; // throw tunings from specific zone into gamecore
 	else
-		m_Core.m_Tuning = *GameServer()->Tuning();
+		m_Core.m_Tuning = *Tuning();
 
 	if(m_TuneZone != m_TuneZoneOld) // don't send tunigs all the time
 	{

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -1262,7 +1262,7 @@ void CCharacter::SetTeleports(std::map<int, std::vector<vec2>> *pTeleOuts, std::
 {
 	m_pTeleOuts = pTeleOuts;
 	m_pTeleCheckOuts = pTeleCheckOuts;
-	m_Core.m_pTeleOuts = pTeleOuts;
+	m_Core.SetTeleOuts(pTeleOuts);
 }
 
 void CCharacter::FillAntibot(CAntibotCharacterData *pData)

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -1803,7 +1803,7 @@ void CCharacter::HandleTiles(int Index)
 	{
 		if(m_Core.m_Super)
 			return;
-		int TeleOut = m_Core.m_pWorld->RandomOr0((*m_pTeleOuts)[z - 1].size());
+		int TeleOut = GameWorld()->m_Core.RandomOr0((*m_pTeleOuts)[z - 1].size());
 		m_Core.m_Pos = (*m_pTeleOuts)[z - 1][TeleOut];
 		if(!g_Config.m_SvTeleportHoldHook)
 		{
@@ -1818,7 +1818,7 @@ void CCharacter::HandleTiles(int Index)
 	{
 		if(m_Core.m_Super)
 			return;
-		int TeleOut = m_Core.m_pWorld->RandomOr0((*m_pTeleOuts)[evilz - 1].size());
+		int TeleOut = GameWorld()->m_Core.RandomOr0((*m_pTeleOuts)[evilz - 1].size());
 		m_Core.m_Pos = (*m_pTeleOuts)[evilz - 1][TeleOut];
 		if(!g_Config.m_SvOldTeleportHook && !g_Config.m_SvOldTeleportWeapons)
 		{
@@ -1845,7 +1845,7 @@ void CCharacter::HandleTiles(int Index)
 		{
 			if(!(*m_pTeleCheckOuts)[k].empty())
 			{
-				int TeleOut = m_Core.m_pWorld->RandomOr0((*m_pTeleCheckOuts)[k].size());
+				int TeleOut = GameWorld()->m_Core.RandomOr0((*m_pTeleCheckOuts)[k].size());
 				m_Core.m_Pos = (*m_pTeleCheckOuts)[k][TeleOut];
 				m_Core.m_Vel = vec2(0, 0);
 
@@ -1882,7 +1882,7 @@ void CCharacter::HandleTiles(int Index)
 		{
 			if(!(*m_pTeleCheckOuts)[k].empty())
 			{
-				int TeleOut = m_Core.m_pWorld->RandomOr0((*m_pTeleCheckOuts)[k].size());
+				int TeleOut = GameWorld()->m_Core.RandomOr0((*m_pTeleCheckOuts)[k].size());
 				m_Core.m_Pos = (*m_pTeleCheckOuts)[k][TeleOut];
 
 				if(!g_Config.m_SvTeleportHoldHook)

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -768,7 +768,8 @@ void CCharacter::Tick()
 
 	if(m_Core.m_TriggeredEvents & COREEVENT_HOOK_ATTACH_PLAYER)
 	{
-		if(m_Core.m_HookedPlayer != -1 && GameServer()->m_apPlayers[m_Core.m_HookedPlayer]->GetTeam() != TEAM_SPECTATORS)
+		const int HookedPlayer = m_Core.HookedPlayer();
+		if(HookedPlayer != -1 && GameServer()->m_apPlayers[HookedPlayer]->GetTeam() != TEAM_SPECTATORS)
 		{
 			Antibot()->OnHookAttach(m_pPlayer->GetCID(), true);
 		}
@@ -1138,7 +1139,7 @@ bool CCharacter::IsSnappingCharacterInView(int SnappingClientID)
 		for(const auto &AttachedPlayerID : m_Core.m_AttachedPlayers)
 		{
 			CCharacter *pOtherPlayer = GameServer()->GetPlayerChar(AttachedPlayerID);
-			if(pOtherPlayer && pOtherPlayer->m_Core.m_HookedPlayer == ID)
+			if(pOtherPlayer && pOtherPlayer->m_Core.HookedPlayer() == ID)
 			{
 				if(!NetworkClippedLine(SnappingClientID, m_Pos, pOtherPlayer->m_Pos))
 				{
@@ -1269,7 +1270,7 @@ void CCharacter::FillAntibot(CAntibotCharacterData *pData)
 	pData->m_Pos = m_Pos;
 	pData->m_Vel = m_Core.m_Vel;
 	pData->m_Angle = m_Core.m_Angle;
-	pData->m_HookedPlayer = m_Core.m_HookedPlayer;
+	pData->m_HookedPlayer = m_Core.HookedPlayer();
 	pData->m_SpawnTick = m_SpawnTick;
 	pData->m_WeaponChangeTick = m_WeaponChangeTick;
 	pData->m_aLatestInputs[0].m_TargetX = m_LatestInput.m_TargetX;
@@ -2229,7 +2230,7 @@ void CCharacter::Pause(bool Pause)
 		GameServer()->m_World.m_Core.m_apCharacters[m_pPlayer->GetCID()] = 0;
 		GameServer()->m_World.RemoveEntity(this);
 
-		if(m_Core.m_HookedPlayer != -1) // Keeping hook would allow cheats
+		if(m_Core.HookedPlayer() != -1) // Keeping hook would allow cheats
 		{
 			ResetHook();
 			GameWorld()->ReleaseHooked(GetPlayer()->GetCID());
@@ -2332,5 +2333,6 @@ CClientMask CCharacter::TeamMask()
 
 void CCharacter::SwapClients(int Client1, int Client2)
 {
-	m_Core.SetHookedPlayer(m_Core.m_HookedPlayer == Client1 ? Client2 : m_Core.m_HookedPlayer == Client2 ? Client1 : m_Core.m_HookedPlayer);
+	const int HookedPlayer = m_Core.HookedPlayer();
+	m_Core.SetHookedPlayer(HookedPlayer == Client1 ? Client2 : HookedPlayer == Client2 ? Client1 : HookedPlayer);
 }

--- a/src/game/server/entities/laser.cpp
+++ b/src/game/server/entities/laser.cpp
@@ -58,9 +58,9 @@ bool CLaser::HitCharacter(vec2 From, vec2 To)
 
 		float Strength;
 		if(!m_TuneZone)
-			Strength = GameServer()->Tuning()->m_ShotgunStrength;
+			Strength = Tuning()->m_ShotgunStrength;
 		else
-			Strength = GameServer()->TuningList()[m_TuneZone].m_ShotgunStrength;
+			Strength = TuningList()[m_TuneZone].m_ShotgunStrength;
 
 		vec2 &HitPos = pHit->Core()->m_Pos;
 		if(!g_Config.m_SvOldLaser)
@@ -158,7 +158,7 @@ void CLaser::DoBounce()
 			}
 			else if(!m_TuneZone)
 			{
-				m_Energy -= Distance + GameServer()->Tuning()->m_LaserBounceCost;
+				m_Energy -= Distance + Tuning()->m_LaserBounceCost;
 			}
 			else
 			{
@@ -179,9 +179,9 @@ void CLaser::DoBounce()
 				m_WasTele = false;
 			}
 
-			int BounceNum = GameServer()->Tuning()->m_LaserBounceNum;
+			int BounceNum = Tuning()->m_LaserBounceNum;
 			if(m_TuneZone)
-				BounceNum = GameServer()->TuningList()[m_TuneZone].m_LaserBounceNum;
+				BounceNum = TuningList()[m_TuneZone].m_LaserBounceNum;
 
 			if(m_Bounces > BounceNum)
 				m_Energy = -1;
@@ -279,9 +279,9 @@ void CLaser::Tick()
 
 	float Delay;
 	if(m_TuneZone)
-		Delay = GameServer()->TuningList()[m_TuneZone].m_LaserBounceDelay;
+		Delay = TuningList()[m_TuneZone].m_LaserBounceDelay;
 	else
-		Delay = GameServer()->Tuning()->m_LaserBounceDelay;
+		Delay = Tuning()->m_LaserBounceDelay;
 
 	if((Server()->Tick() - m_EvalTick) > (Server()->TickSpeed() * Delay / 1000.0f))
 		DoBounce();

--- a/src/game/server/entities/projectile.cpp
+++ b/src/game/server/entities/projectile.cpp
@@ -64,13 +64,13 @@ vec2 CProjectile::GetPos(float Time)
 	case WEAPON_GRENADE:
 		if(!m_TuneZone)
 		{
-			Curvature = GameServer()->Tuning()->m_GrenadeCurvature;
-			Speed = GameServer()->Tuning()->m_GrenadeSpeed;
+			Curvature = Tuning()->m_GrenadeCurvature;
+			Speed = Tuning()->m_GrenadeSpeed;
 		}
 		else
 		{
-			Curvature = GameServer()->TuningList()[m_TuneZone].m_GrenadeCurvature;
-			Speed = GameServer()->TuningList()[m_TuneZone].m_GrenadeSpeed;
+			Curvature = TuningList()[m_TuneZone].m_GrenadeCurvature;
+			Speed = TuningList()[m_TuneZone].m_GrenadeSpeed;
 		}
 
 		break;
@@ -78,13 +78,13 @@ vec2 CProjectile::GetPos(float Time)
 	case WEAPON_SHOTGUN:
 		if(!m_TuneZone)
 		{
-			Curvature = GameServer()->Tuning()->m_ShotgunCurvature;
-			Speed = GameServer()->Tuning()->m_ShotgunSpeed;
+			Curvature = Tuning()->m_ShotgunCurvature;
+			Speed = Tuning()->m_ShotgunSpeed;
 		}
 		else
 		{
-			Curvature = GameServer()->TuningList()[m_TuneZone].m_ShotgunCurvature;
-			Speed = GameServer()->TuningList()[m_TuneZone].m_ShotgunSpeed;
+			Curvature = TuningList()[m_TuneZone].m_ShotgunCurvature;
+			Speed = TuningList()[m_TuneZone].m_ShotgunSpeed;
 		}
 
 		break;
@@ -92,13 +92,13 @@ vec2 CProjectile::GetPos(float Time)
 	case WEAPON_GUN:
 		if(!m_TuneZone)
 		{
-			Curvature = GameServer()->Tuning()->m_GunCurvature;
-			Speed = GameServer()->Tuning()->m_GunSpeed;
+			Curvature = Tuning()->m_GunCurvature;
+			Speed = Tuning()->m_GunSpeed;
 		}
 		else
 		{
-			Curvature = GameServer()->TuningList()[m_TuneZone].m_GunCurvature;
-			Speed = GameServer()->TuningList()[m_TuneZone].m_GunSpeed;
+			Curvature = TuningList()[m_TuneZone].m_GunCurvature;
+			Speed = TuningList()[m_TuneZone].m_GunSpeed;
 		}
 		break;
 	}

--- a/src/game/server/entity.h
+++ b/src/game/server/entity.h
@@ -5,7 +5,8 @@
 
 #include <base/vmath.h>
 
-#include "alloc.h"
+#include <game/alloc.h>
+
 #include "gameworld.h"
 
 class CCollision;

--- a/src/game/server/entity.h
+++ b/src/game/server/entity.h
@@ -61,6 +61,9 @@ public: // TODO: Maybe make protected
 	/* Objects */
 	std::vector<SSwitchers> &Switchers() { return m_pGameWorld->m_Core.m_vSwitchers; }
 	CGameWorld *GameWorld() { return m_pGameWorld; }
+	CTuningParams *Tuning() { return GameWorld()->Tuning(); }
+	CTuningParams *TuningList() { return GameWorld()->TuningList(); }
+	CTuningParams *GetTuning(int i) { return GameWorld()->GetTuning(i); }
 	class CConfig *Config() { return m_pGameWorld->Config(); }
 	class CGameContext *GameServer() { return m_pGameWorld->GameServer(); }
 	class IServer *Server() { return m_pGameWorld->Server(); }

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -3480,6 +3480,7 @@ void CGameContext::OnInit(const void *pPersistentData)
 
 	m_Layers.Init(Kernel());
 	m_Collision.Init(&m_Layers);
+	m_World.m_pTuningList = m_aTuningList;
 	m_World.m_Core.InitSwitchers(m_Collision.m_HighestSwitchNumber);
 
 	char aMapName[IO_MAX_PATH_LENGTH];

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -285,6 +285,8 @@ public:
 	void OnSnap(int ClientID) override;
 	void OnPostSnap() override;
 
+	void UpdatePlayerMaps();
+
 	void *PreProcessMsg(int *pMsgID, CUnpacker *pUnpacker, int ClientID);
 	void CensorMessage(char *pCensoredMessage, const char *pMessage, int Size);
 	void OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID) override;

--- a/src/game/server/gameworld.cpp
+++ b/src/game/server/gameworld.cpp
@@ -428,7 +428,7 @@ void CGameWorld::ReleaseHooked(int ClientID)
 	for(; pChr; pChr = (CCharacter *)pChr->TypeNext())
 	{
 		CCharacterCore *pCore = pChr->Core();
-		if(pCore->m_HookedPlayer == ClientID && !pChr->IsSuper())
+		if(pCore->HookedPlayer() == ClientID && !pChr->IsSuper())
 		{
 			pCore->SetHookedPlayer(-1);
 			pCore->m_TriggeredEvents |= COREEVENT_HOOK_RETRACT;

--- a/src/game/server/gameworld.cpp
+++ b/src/game/server/gameworld.cpp
@@ -371,3 +371,8 @@ void CGameWorld::ReleaseHooked(int ClientID)
 		}
 	}
 }
+
+CTuningParams *CGameWorld::Tuning()
+{
+	return &m_Core.m_aTuning[0];
+}

--- a/src/game/server/gameworld.cpp
+++ b/src/game/server/gameworld.cpp
@@ -6,7 +6,6 @@
 #include "entity.h"
 #include "gamecontext.h"
 #include "gamecontroller.h"
-#include "player.h"
 
 #include <engine/shared/config.h>
 
@@ -192,68 +191,6 @@ void CGameWorld::RemoveEntities()
 		}
 }
 
-bool distCompare(std::pair<float, int> a, std::pair<float, int> b)
-{
-	return (a.first < b.first);
-}
-
-void CGameWorld::UpdatePlayerMaps()
-{
-	if(Server()->Tick() % g_Config.m_SvMapUpdateRate != 0)
-		return;
-
-	std::pair<float, int> Dist[MAX_CLIENTS];
-	for(int i = 0; i < MAX_CLIENTS; i++)
-	{
-		if(!Server()->ClientIngame(i))
-			continue;
-		if(Server()->GetClientVersion(i) >= VERSION_DDNET_OLD)
-			continue;
-		int *pMap = Server()->GetIdMap(i);
-
-		// compute distances
-		for(int j = 0; j < MAX_CLIENTS; j++)
-		{
-			Dist[j].second = j;
-			if(j == i)
-				continue;
-			if(!Server()->ClientIngame(j) || !GameServer()->m_apPlayers[j])
-			{
-				Dist[j].first = 1e10;
-				continue;
-			}
-			CCharacter *pChr = GameServer()->m_apPlayers[j]->GetCharacter();
-			if(!pChr)
-			{
-				Dist[j].first = 1e9;
-				continue;
-			}
-			if(!pChr->CanSnapCharacter(i))
-				Dist[j].first = 1e8;
-			else
-				Dist[j].first = length_squared(GameServer()->m_apPlayers[i]->m_ViewPos - pChr->m_Pos);
-		}
-
-		// always send the player themselves, even if all in same position
-		Dist[i].first = -1;
-
-		std::nth_element(&Dist[0], &Dist[VANILLA_MAX_CLIENTS - 1], &Dist[MAX_CLIENTS], distCompare);
-
-		int Index = 1; // exclude self client id
-		for(int j = 0; j < VANILLA_MAX_CLIENTS - 1; j++)
-		{
-			pMap[j + 1] = -1; // also fill player with empty name to say chat msgs
-			if(Dist[j].second == i || Dist[j].first > 5e9f)
-				continue;
-			pMap[Index++] = Dist[j].second;
-		}
-
-		// sort by real client ids, guarantee order on distance changes, O(Nlog(N)) worst case
-		// sort just clients in game always except first (self client id) and last (fake client id) indexes
-		std::sort(&pMap[1], &pMap[minimum(Index, VANILLA_MAX_CLIENTS - 1)]);
-	}
-}
-
 void CGameWorld::Tick()
 {
 	if(m_ResetRequested)
@@ -310,8 +247,6 @@ void CGameWorld::Tick()
 	}
 
 	RemoveEntities();
-
-	UpdatePlayerMaps();
 
 	// find the characters' strong/weak id
 	int StrongWeakID = 0;

--- a/src/game/server/gameworld.h
+++ b/src/game/server/gameworld.h
@@ -39,8 +39,6 @@ private:
 	class CConfig *m_pConfig;
 	class IServer *m_pServer;
 
-	void UpdatePlayerMaps();
-
 public:
 	class CGameContext *GameServer() { return m_pGameServer; }
 	class CConfig *Config() { return m_pConfig; }

--- a/src/game/server/gameworld.h
+++ b/src/game/server/gameworld.h
@@ -164,6 +164,12 @@ public:
 			Returns list with all Characters on line.
 	*/
 	std::vector<CCharacter *> IntersectedCharacters(vec2 Pos0, vec2 Pos1, float Radius, const CEntity *pNotThis = nullptr);
+
+	CTuningParams *Tuning();
+
+	CTuningParams *m_pTuningList;
+	CTuningParams *TuningList() { return m_pTuningList; }
+	CTuningParams *GetTuning(int i) { return &TuningList()[i]; }
 };
 
 #endif

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -7,7 +7,8 @@
 
 #include <engine/shared/protocol.h>
 
-#include "alloc.h"
+#include <game/alloc.h>
+
 #include "teeinfo.h"
 
 #include <memory>

--- a/src/game/server/save.cpp
+++ b/src/game/server/save.cpp
@@ -100,7 +100,7 @@ void CSaveTee::Save(CCharacter *pChr)
 	m_HookTick = pChr->m_Core.m_HookTick;
 
 	m_HookState = pChr->m_Core.m_HookState;
-	m_HookedPlayer = pChr->m_Core.m_HookedPlayer;
+	m_HookedPlayer = pChr->m_Core.HookedPlayer();
 	m_NewHook = pChr->m_Core.m_NewHook != 0;
 
 	m_InputDirection = pChr->m_SavedInput.m_Direction;


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->
- https://github.com/ddnet/ddnet/pull/7136/commits/90ae9e6f6268e5b621f7c23c88541cdf313766c5 is needed to make all references to `m_HookedPlayer` go via setter (or getter) and enforce `CCharacterCore::m_AttachedPlayers` update (I had a code which accessed `m_HookedPlayer` directly and it continued to compile even though now we must use the setter).
- https://github.com/ddnet/ddnet/pull/7136/commits/fc42d003e63b899e784b8762362c98141c743959 is needed to force CCharacter(s) use the setter (the classes still had direct access otherwise).
- https://github.com/ddnet/ddnet/pull/7136/commits/68f3beaa35bfb343dbe2e9bed40766f8575733cd is a server-side cleanup for shared CGameWorld. The players mapping has nothing to do with the GameWorld logic, and the move allows to drop GameWorld dependence on CPlayer.
 
<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
