### PR TITLE
Support longer lines being rendered in console, fix incorrect text height when maximum number of lines specified

### DIFF
--- a/src/engine/client/text.cpp
+++ b/src/engine/client/text.cpp
@@ -1574,7 +1574,11 @@ public:
 		float LastCharX = DrawX;
 		float LastCharWidth = 0;
 
+		// Returns true if line was started
 		const auto &&StartNewLine = [&]() {
+			if(pCursor->m_MaxLines > 0 && LineCount >= pCursor->m_MaxLines)
+				return false;
+
 			DrawX = pCursor->m_StartX;
 			DrawY += pCursor->m_AlignedFontSize;
 			if((RenderFlags & TEXT_RENDER_FLAG_NO_PIXEL_ALIGMENT) == 0)
@@ -1587,6 +1591,7 @@ public:
 			LastCharX = DrawX;
 			LastCharWidth = 0;
 			++LineCount;
+			return true;
 		};
 
 		if(pCursor->m_CalculateSelectionMode != TEXT_CURSOR_SELECTION_MODE_NONE || pCursor->m_CursorMode != TEXT_CURSOR_CURSOR_MODE_NONE)
@@ -1606,7 +1611,7 @@ public:
 		bool GotNewLine = false;
 		bool GotNewLineLast = false;
 
-		while(pCurrent < pEnd && (pCursor->m_MaxLines < 1 || LineCount <= pCursor->m_MaxLines) && pCurrent != pEllipsis)
+		while(pCurrent < pEnd && pCurrent != pEllipsis)
 		{
 			bool NewLine = false;
 			const char *pBatchEnd = pEnd;
@@ -1667,8 +1672,7 @@ public:
 					if((pCursor->m_Flags & TEXTFLAG_DISALLOW_NEWLINE) == 0)
 					{
 						pLastGlyph = nullptr;
-						StartNewLine();
-						if(pCursor->m_MaxLines > 0 && LineCount > pCursor->m_MaxLines)
+						if(!StartNewLine())
 							break;
 						continue;
 					}
@@ -1859,7 +1863,8 @@ public:
 
 			if(NewLine)
 			{
-				StartNewLine();
+				if(!StartNewLine())
+					break;
 				GotNewLine = true;
 				GotNewLineLast = true;
 			}

--- a/src/engine/shared/console.cpp
+++ b/src/engine/shared/console.cpp
@@ -543,7 +543,7 @@ void CConsole::ExecuteLineStroked(int Stroke, const char *pStr, int ClientID, bo
 			// ends at the first whitespace, which breaks for unknown commands (filenames) containing spaces.
 			if(!m_pfnUnknownCommandCallback(pStr, m_pUnknownCommandUserdata))
 			{
-				char aBuf[256];
+				char aBuf[512 + 32];
 				str_format(aBuf, sizeof(aBuf), "No such command: %s.", Result.m_pCommand);
 				Print(OUTPUT_LEVEL_STANDARD, "chatresp", aBuf);
 			}
@@ -881,7 +881,7 @@ void CConsole::TraverseChain(FCommandCallback *ppfnCallback, void **ppUserData)
 void CConsole::ConToggle(IConsole::IResult *pResult, void *pUser)
 {
 	CConsole *pConsole = static_cast<CConsole *>(pUser);
-	char aBuf[128] = {0};
+	char aBuf[512 + 32] = {0};
 	CCommand *pCommand = pConsole->FindCommand(pResult->GetString(0), pConsole->m_FlagMask);
 	if(pCommand)
 	{
@@ -933,7 +933,7 @@ void CConsole::ConToggle(IConsole::IResult *pResult, void *pUser)
 void CConsole::ConToggleStroke(IConsole::IResult *pResult, void *pUser)
 {
 	CConsole *pConsole = static_cast<CConsole *>(pUser);
-	char aBuf[128] = {0};
+	char aBuf[512 + 32] = {0};
 	CCommand *pCommand = pConsole->FindCommand(pResult->GetString(1), pConsole->m_FlagMask);
 	if(pCommand)
 	{

--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -346,7 +346,7 @@ bool CGameConsole::CInstance::OnInput(const IInput::CEvent &Event)
 
 		// find the current command
 		{
-			char aBuf[128];
+			char aBuf[512];
 			StrCopyUntilSpace(aBuf, sizeof(aBuf), GetString());
 			const IConsole::CCommandInfo *pCommand = m_pGameConsole->m_pConsole->GetCommandInfo(aBuf, m_CompletionFlagmask,
 				m_Type != CGameConsole::CONSOLETYPE_LOCAL && m_pGameConsole->Client()->RconAuthed() && m_pGameConsole->Client()->UseTempRconCommands());
@@ -367,9 +367,6 @@ bool CGameConsole::CInstance::OnInput(const IInput::CEvent &Event)
 
 void CGameConsole::CInstance::PrintLine(const char *pLine, int Len, ColorRGBA PrintColor)
 {
-	if(Len > 255)
-		Len = 255;
-
 	m_BacklogLock.lock();
 	CBacklogEntry *pEntry = m_Backlog.Allocate(sizeof(CBacklogEntry) + Len);
 	pEntry->m_YOffset = -1.0f;
@@ -694,7 +691,7 @@ void CGameConsole::OnRender()
 
 				if(NumArguments <= 0 && pConsole->m_IsCommand)
 				{
-					char aBuf[512];
+					char aBuf[1024];
 					str_format(aBuf, sizeof(aBuf), "Help: %s ", pConsole->m_pCommandHelp);
 					TextRender()->TextEx(&Info.m_Cursor, aBuf, -1);
 					TextRender()->TextColor(0.75f, 0.75f, 0.75f, 1);
@@ -729,8 +726,9 @@ void CGameConsole::OnRender()
 				{
 					TextRender()->SetCursor(&Cursor, 0.0f, 0.0f, FontSize, 0);
 					Cursor.m_LineWidth = Screen.w - 10;
+					Cursor.m_MaxLines = 10;
 					TextRender()->TextEx(&Cursor, pEntry->m_aText, -1);
-					pEntry->m_YOffset = Cursor.m_Y + Cursor.m_AlignedFontSize + LineOffset;
+					pEntry->m_YOffset = Cursor.Height() + LineOffset;
 				}
 				OffsetY += pEntry->m_YOffset;
 
@@ -751,6 +749,7 @@ void CGameConsole::OnRender()
 				{
 					TextRender()->SetCursor(&Cursor, 0.0f, y - OffsetY, FontSize, TEXTFLAG_RENDER);
 					Cursor.m_LineWidth = Screen.w - 10.0f;
+					Cursor.m_MaxLines = 10;
 					Cursor.m_CalculateSelectionMode = (m_ConsoleState == CONSOLE_OPEN && pConsole->m_MousePress.y < pConsole->m_BoundingBox.m_Y && (pConsole->m_MouseIsPress || (pConsole->m_CurSelStart != pConsole->m_CurSelEnd) || pConsole->m_HasSelection)) ? TEXT_CURSOR_SELECTION_MODE_CALCULATE : TEXT_CURSOR_SELECTION_MODE_NONE;
 					Cursor.m_PressMouse = pConsole->m_MousePress;
 					Cursor.m_ReleaseMouse = pConsole->m_MouseRelease;


### PR DESCRIPTION
Don't truncate console lines at 255 bytes anymore. Especially lines containing many Unicode characters would be adversely affected by this limitation.

Instead, truncate console lines after 10 wrapped lines are rendered. Rendering too many lines at once currently breaks the console scrolling. Rendering an ellipsis is currently not possible when rendering text with a maximum line count.

Increase buffer sizes to handle long (esp. invalid) command inputs.

Closes #7132.

Check if maximum number of lines has been reached before starting a new line, to prevent the text cursor from reporting the wrong number of lines and text height in that case.

Screenshots (maximum number of character `m` was used as command):
- Before:
![screenshot_2023-09-06_19-19-35](https://github.com/ddnet/ddnet/assets/23437060/6c162c6d-4685-4466-94bc-9531d0589db1)
- After:
![screenshot_2023-09-06_19-18-00](https://github.com/ddnet/ddnet/assets/23437060/894a8707-c064-4164-b101-ddd9f25f5123)

## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
