### PR TITLE
Add "render cut to video"

### DIFF
--- a/data/languages/arabic.txt
+++ b/data/languages/arabic.txt
@@ -1397,6 +1397,9 @@ Cut interval
 Cut length
 == 
 
+Render cut to video
+== 
+
 Loading demo files
 == 
 
@@ -1448,10 +1451,10 @@ Open the directory that contains the configuration and user files
 Open the directory to add custom themes
 == 
 
-Loading skin files
+Toggle to edit your dummy settings
 == 
 
-Toggle to edit your dummy settings
+Loading skin files
 == 
 
 Download community skins

--- a/data/languages/belarusian.txt
+++ b/data/languages/belarusian.txt
@@ -1727,6 +1727,9 @@ Unable to rename the folder
 (paused)
 == 
 
+Render cut to video
+== 
+
 All combined
 == 
 

--- a/data/languages/bosnian.txt
+++ b/data/languages/bosnian.txt
@@ -1289,6 +1289,9 @@ Cut interval
 Cut length
 == 
 
+Render cut to video
+== 
+
 Loading demo files
 == 
 
@@ -1361,10 +1364,10 @@ Open the directory to add custom themes
 Max CSVs
 == 
 
-Loading skin files
+Toggle to edit your dummy settings
 == 
 
-Toggle to edit your dummy settings
+Loading skin files
 == 
 
 Download skins

--- a/data/languages/brazilian_portuguese.txt
+++ b/data/languages/brazilian_portuguese.txt
@@ -1767,3 +1767,6 @@ Unable to delete the folder '%s'. Make sure it's empty first.
 
 Moved ingame
 == Movido no jogo
+
+Render cut to video
+== 

--- a/data/languages/bulgarian.txt
+++ b/data/languages/bulgarian.txt
@@ -953,6 +953,9 @@ Cut length
 Remove chat
 == 
 
+Render cut to video
+== 
+
 Please use a different name
 == 
 
@@ -1103,10 +1106,10 @@ Max CSVs
 Dummy settings
 == 
 
-Loading skin files
+Toggle to edit your dummy settings
 == 
 
-Toggle to edit your dummy settings
+Loading skin files
 == 
 
 Download skins
@@ -1160,19 +1163,22 @@ Show all
 Toggle dyncam
 == 
 
-Toggle dummy
+Toggle ghost
 == 
 
-Toggle ghost
+Converse
+== 
+
+Chat command
+== 
+
+Toggle dummy
 == 
 
 Dummy copy
 == 
 
 Hammerfly dummy
-== 
-
-Converse
 == 
 
 Spectate previous
@@ -1188,9 +1194,6 @@ Show entities
 == 
 
 Show HUD
-== 
-
-Chat command
 == 
 
 Enable controller

--- a/data/languages/catalan.txt
+++ b/data/languages/catalan.txt
@@ -1469,6 +1469,9 @@ Cut interval
 Cut length
 == 
 
+Render cut to video
+== 
+
 Loading demo files
 == 
 
@@ -1514,10 +1517,10 @@ Open the directory that contains the configuration and user files
 Open the directory to add custom themes
 == 
 
-Loading skin files
+Toggle to edit your dummy settings
 == 
 
-Toggle to edit your dummy settings
+Loading skin files
 == 
 
 Download community skins

--- a/data/languages/chuvash.txt
+++ b/data/languages/chuvash.txt
@@ -956,6 +956,9 @@ Cut length
 Remove chat
 == 
 
+Render cut to video
+== 
+
 Please use a different name
 == 
 
@@ -1106,10 +1109,10 @@ Max CSVs
 Dummy settings
 == 
 
-Loading skin files
+Toggle to edit your dummy settings
 == 
 
-Toggle to edit your dummy settings
+Loading skin files
 == 
 
 Download skins
@@ -1163,19 +1166,22 @@ Show all
 Toggle dyncam
 == 
 
-Toggle dummy
+Toggle ghost
 == 
 
-Toggle ghost
+Converse
+== 
+
+Chat command
+== 
+
+Toggle dummy
 == 
 
 Dummy copy
 == 
 
 Hammerfly dummy
-== 
-
-Converse
 == 
 
 Statboard
@@ -1188,9 +1194,6 @@ Show entities
 == 
 
 Show HUD
-== 
-
-Chat command
 == 
 
 Enable controller

--- a/data/languages/czech.txt
+++ b/data/languages/czech.txt
@@ -1407,6 +1407,9 @@ Cut interval
 Cut length
 == 
 
+Render cut to video
+== 
+
 Loading demo files
 == 
 
@@ -1458,10 +1461,10 @@ Open the directory that contains the configuration and user files
 Open the directory to add custom themes
 == 
 
-Loading skin files
+Toggle to edit your dummy settings
 == 
 
-Toggle to edit your dummy settings
+Loading skin files
 == 
 
 Download community skins

--- a/data/languages/danish.txt
+++ b/data/languages/danish.txt
@@ -1405,6 +1405,9 @@ Cut interval
 Cut length
 == 
 
+Render cut to video
+== 
+
 Loading demo files
 == 
 
@@ -1456,10 +1459,10 @@ Open the directory that contains the configuration and user files
 Open the directory to add custom themes
 == 
 
-Loading skin files
+Toggle to edit your dummy settings
 == 
 
-Toggle to edit your dummy settings
+Loading skin files
 == 
 
 Download community skins

--- a/data/languages/dutch.txt
+++ b/data/languages/dutch.txt
@@ -1515,6 +1515,9 @@ Cut interval
 Cut length
 == 
 
+Render cut to video
+== 
+
 Loading demo files
 == 
 

--- a/data/languages/esperanto.txt
+++ b/data/languages/esperanto.txt
@@ -900,6 +900,9 @@ Cut interval
 Cut length
 == 
 
+Render cut to video
+== 
+
 File already exists, do you want to overwrite it?
 == 
 
@@ -1086,13 +1089,13 @@ Automatically create statboard csv
 Max CSVs
 == 
 
+Toggle to edit your dummy settings
+== 
+
 Loading skin files
 == 
 
 Your skin
-== 
-
-Toggle to edit your dummy settings
 == 
 
 Download skins
@@ -1143,16 +1146,7 @@ Default zoom
 Toggle dyncam
 == 
 
-Toggle dummy
-== 
-
 Toggle ghost
-== 
-
-Dummy copy
-== 
-
-Hammerfly dummy
 == 
 
 Shotgun
@@ -1171,6 +1165,18 @@ Team chat
 == 
 
 Converse
+== 
+
+Chat command
+== 
+
+Toggle dummy
+== 
+
+Dummy copy
+== 
+
+Hammerfly dummy
 == 
 
 Emoticon
@@ -1207,9 +1213,6 @@ Show entities
 == 
 
 Show HUD
-== 
-
-Chat command
 == 
 
 Enable controller

--- a/data/languages/finnish.txt
+++ b/data/languages/finnish.txt
@@ -1362,6 +1362,9 @@ Cut interval
 Cut length
 == 
 
+Render cut to video
+== 
+
 Loading demo files
 == 
 
@@ -1422,10 +1425,10 @@ Automatically create statboard csv
 Max CSVs
 == 
 
-Loading skin files
+Toggle to edit your dummy settings
 == 
 
-Toggle to edit your dummy settings
+Loading skin files
 == 
 
 Download community skins
@@ -1443,13 +1446,13 @@ Create a random skin
 Open the directory to add custom skins
 == 
 
+Converse
+== 
+
 Dummy copy
 == 
 
 Hammerfly dummy
-== 
-
-Converse
 == 
 
 Statboard

--- a/data/languages/french.txt
+++ b/data/languages/french.txt
@@ -1745,6 +1745,9 @@ Cut interval
 Cut length
 == 
 
+Render cut to video
+== 
+
 All combined
 == 
 

--- a/data/languages/galician.txt
+++ b/data/languages/galician.txt
@@ -1716,6 +1716,9 @@ Cut interval
 Cut length
 == 
 
+Render cut to video
+== 
+
 All combined
 == 
 

--- a/data/languages/german.txt
+++ b/data/languages/german.txt
@@ -1760,3 +1760,6 @@ Unable to delete the folder '%s'. Make sure it's empty first.
 
 Moved ingame
 == Im Spiel bewegt
+
+Render cut to video
+== 

--- a/data/languages/greek.txt
+++ b/data/languages/greek.txt
@@ -959,6 +959,9 @@ Cut length
 Remove chat
 == 
 
+Render cut to video
+== 
+
 Please use a different name
 == 
 
@@ -1109,10 +1112,10 @@ Max CSVs
 Dummy settings
 == 
 
-Loading skin files
+Toggle to edit your dummy settings
 == 
 
-Toggle to edit your dummy settings
+Loading skin files
 == 
 
 Download skins
@@ -1166,19 +1169,22 @@ Show all
 Toggle dyncam
 == 
 
-Toggle dummy
+Toggle ghost
 == 
 
-Toggle ghost
+Converse
+== 
+
+Chat command
+== 
+
+Toggle dummy
 == 
 
 Dummy copy
 == 
 
 Hammerfly dummy
-== 
-
-Converse
 == 
 
 Statboard
@@ -1191,9 +1197,6 @@ Show entities
 == 
 
 Show HUD
-== 
-
-Chat command
 == 
 
 Enable controller

--- a/data/languages/hungarian.txt
+++ b/data/languages/hungarian.txt
@@ -1721,6 +1721,9 @@ Cut interval
 Cut length
 == 
 
+Render cut to video
+== 
+
 All combined
 == 
 

--- a/data/languages/italian.txt
+++ b/data/languages/italian.txt
@@ -1167,51 +1167,6 @@ Grabs
 9+ new mentions
 == +9 nuove menzioni
 
-[Graphics error]
-Failed during initialization. Try to change gfx_backend to OpenGL or Vulkan in settings_ddnet.cfg in the config directory and try again.
-== 
-
-[Graphics error]
-Out of VRAM. Try removing custom assets (skins, entities, etc.), especially those with high resolution.
-== 
-
-[Graphics error]
-An error during command recording occurred. Try to update your GPU drivers.
-== 
-
-[Graphics error]
-A render command failed. Try to update your GPU drivers.
-== 
-
-[Graphics error]
-Submitting the render commands failed. Try to update your GPU drivers.
-== 
-
-[Graphics error]
-Failed to swap framebuffers. Try to update your GPU drivers.
-== 
-
-[Graphics error]
-Unknown error. Try to change gfx_backend to OpenGL or Vulkan in settings_ddnet.cfg in the config directory and try again.
-== 
-
-[Graphics error]
-Could not initialize the given graphics backend, reverting to the default backend now.
-== 
-
-[Graphics error]
-Could not initialize the given graphics backend, this is probably because you didn't install the driver of the integrated graphics card.
-== 
-
-Could not save downloaded map. Try manually deleting this file: %s
-== 
-
-The width of texture %s is not divisible by %d, or the height is not divisible by %d, which might cause visual bugs.
-== 
-
-The format of texture %s is not RGBA which will cause visual bugs.
-== 
-
 Preparing demo playback
 == Preparando la riproduzione della demo
 
@@ -1220,9 +1175,6 @@ Connected
 
 Loading map file from storage
 == Caricando il file mappa dalla memoria
-
-Why are you slowmo replaying to read this?
-== 
 
 Initializing components
 == Inizializzando i componenti
@@ -1302,54 +1254,17 @@ Join Tutorial Server
 Skip Tutorial
 == Salta Tutorial
 
-Loading menu images
-== 
-
-AFR
-== 
-
-ASI
-== 
-
-AUS
-== 
-
-EUR
-== 
-
-NA
-== 
-
-SA
-== 
-
-CHN
-== 
-
 Getting server list from master server
 == Ottenere l'elenco dei server dal server principale
 
 Are you sure that you want to disconnect and switch to a different server?
 == Sei sicuro di voler disconnetterti e passare a un altro server?
 
-Copy info
-== 
-
-Leak IP
-== 
-
 No server selected
 == Nessun server selezionato
 
-Online players (%d)
-== 
-
 Online clanmates (%d)
 == Compagni di clan online
-
-[friends (server browser)]
-Offline (%d)
-== 
 
 Click to select server. Double click to join your friend.
 == Fare click per selezionare il server. Fai doppio click per unirti al tuo amico.
@@ -1372,122 +1287,8 @@ Are you sure that you want to remove the clan '%s' from your friends list?
 Add Clan
 == Aggiungi Clan
 
-Play the current demo
-== 
-
-Pause the current demo
-== 
-
-Stop the current demo
-== 
-
-Go back one tick
-== 
-
-Go forward one tick
-== 
-
-Slow down the demo
-== 
-
-Speed up the demo
-== 
-
-Mark the beginning of a cut (right click to reset)
-== 
-
-Mark the end of a cut (right click to reset)
-== 
-
-Export cut as a separate demo
-== 
-
-Go back one marker
-== 
-
-Go forward one marker
-== 
-
-Close the demo player
-== 
-
-Toggle keyboard shortcuts
-== 
-
-Export demo cut
-== 
-
-Cut interval
-== 
-
-Cut length
-== 
-
-Loading demo files
-== 
-
-All combined
-== 
-
-Folder Link
-== 
-
-Markers:
-== 
-
-%.2f MiB
-== 
-
-%.2f KiB
-== 
-
-Open the directory that contains the demo files
-== 
-
-Are you sure that you want to delete the folder '%s'?
-== 
-
-Are you sure that you want to delete the demo '%s'?
-== 
-
 Delete folder
 == Cancella cartella
-
-Unable to delete the demo '%s'
-== 
-
-Unable to delete the folder '%s'. Make sure it's empty first.
-== 
-
-Loading ghost files
-== 
-
-Menu opened. Press Esc key again to close menu.
-== 
-
-Save power by lowering refresh rate (higher input latency)
-== 
-
-Settings file
-== 
-
-Open the settings file
-== 
-
-Config directory
-== 
-
-Open the directory that contains the configuration and user files
-== 
-
-Open the directory to add custom themes
-== 
-
-Loading skin files
-== 
-
-Toggle to edit your dummy settings
-== 
 
 Download community skins
 == Scarica skin comunitá 
@@ -1501,17 +1302,8 @@ Create a random skin
 Open the directory to add custom skins
 == Apri la cartella per aggiungere una skin custom
 
-Converse
-== 
-
-Chat command
-== 
-
 Enable controller
 == Abilitá controller
-
-Controller
-== 
 
 Ingame controller mode
 == Modalitá controller in gioco
@@ -1519,19 +1311,6 @@ Ingame controller mode
 [Ingame controller mode]
 Relative
 == Relativo
-
-[Ingame controller mode]
-Absolute
-== 
-
-Ingame controller sens.
-== 
-
-UI controller sens.
-== 
-
-Controller jitter tolerance
-== 
 
 No controller found. Plug in a controller.
 == Nessun controller trovato. Collega un controller.
@@ -1541,12 +1320,6 @@ Axis
 
 Status
 == Stato
-
-Aim bind
-== 
-
-Mouse
-== 
 
 Ingame mouse sens.
 == Sens. mouse in gioco
@@ -1563,9 +1336,6 @@ Are you sure that you want to reset the controls to their defaults?
 Cancel
 == Cancella
 
-Dummy
-== 
-
 Windowed
 == Finestra
 
@@ -1578,41 +1348,14 @@ Windowed fullscreen
 Desktop fullscreen
 == Desktop schermo intero
 
-Allows maps to render with more detail
-== 
-
-Renderer
-== 
-
-default
-== 
-
-custom
-== 
-
 Graphics card
 == Scheda grafica
-
-auto
-== 
-
-Appearance
-== 
-
-Name Plate
-== 
 
 Hook Collisions
 == Collisione Hook
 
-Kill Messages
-== 
-
 Show health, shields and ammo
 == Mostra vita, scudi e munizioni
-
-DDRace HUD
-== 
 
 Show client IDs in scoreboard
 == Mostra gli ID clienti nella scoreboard
@@ -1671,50 +1414,11 @@ Nothing hookable
 Something hookable
 == Qualcosa hookabile
 
-A Tee
-== 
-
-Normal Color
-== 
-
-Highlight Color
-== 
-
 Weapons
 == Armi
 
-Rifle Laser Outline Color
-== 
-
-Rifle Laser Inner Color
-== 
-
-Shotgun Laser Outline Color
-== 
-
-Shotgun Laser Inner Color
-== 
-
-Door Laser Outline Color
-== 
-
-Door Laser Inner Color
-== 
-
-Freeze Laser Outline Color
-== 
-
-Freeze Laser Inner Color
-== 
-
-Set all to Rifle
-== 
-
 When you cross the start line, show a ghost tee replicating the movements of your best time
 == Quando attraversi la linea di partenza, mostra una maglietta fantasma che riproduce i movimenti del tuo miglior tempo
-
-Overlay entities
-== 
 
 Opacity
 == Opacitá 
@@ -1746,14 +1450,325 @@ Chat command (e.g. showall 1)
 Unregister protocol and file extensions
 == Protocollo ed estensioni file non registrati
 
-Extras
-== 
-
 Loading assets
 == Caricando assets
 
 Open the directory to add custom assets
 == Apri la cartella per aggiungere assets custom
+
+Can't find a Tutorial server
+== Impossibile trovare un Server Tutorial
+
+Loading race demo files
+== Caricando i file della demo della gara
+
+Loading sound files
+== Caricando file musica
+
+Moved ingame
+== Spostato in gioco
+
+[Graphics error]
+Failed during initialization. Try to change gfx_backend to OpenGL or Vulkan in settings_ddnet.cfg in the config directory and try again.
+== 
+
+[Graphics error]
+Out of VRAM. Try removing custom assets (skins, entities, etc.), especially those with high resolution.
+== 
+
+[Graphics error]
+An error during command recording occurred. Try to update your GPU drivers.
+== 
+
+[Graphics error]
+A render command failed. Try to update your GPU drivers.
+== 
+
+[Graphics error]
+Submitting the render commands failed. Try to update your GPU drivers.
+== 
+
+[Graphics error]
+Failed to swap framebuffers. Try to update your GPU drivers.
+== 
+
+[Graphics error]
+Unknown error. Try to change gfx_backend to OpenGL or Vulkan in settings_ddnet.cfg in the config directory and try again.
+== 
+
+[Graphics error]
+Could not initialize the given graphics backend, reverting to the default backend now.
+== 
+
+[Graphics error]
+Could not initialize the given graphics backend, this is probably because you didn't install the driver of the integrated graphics card.
+== 
+
+Could not save downloaded map. Try manually deleting this file: %s
+== 
+
+The width of texture %s is not divisible by %d, or the height is not divisible by %d, which might cause visual bugs.
+== 
+
+The format of texture %s is not RGBA which will cause visual bugs.
+== 
+
+Why are you slowmo replaying to read this?
+== 
+
+Loading menu images
+== 
+
+AFR
+== 
+
+ASI
+== 
+
+AUS
+== 
+
+EUR
+== 
+
+NA
+== 
+
+SA
+== 
+
+CHN
+== 
+
+Copy info
+== 
+
+Leak IP
+== 
+
+Online players (%d)
+== 
+
+[friends (server browser)]
+Offline (%d)
+== 
+
+Play the current demo
+== 
+
+Pause the current demo
+== 
+
+Stop the current demo
+== 
+
+Go back one tick
+== 
+
+Go forward one tick
+== 
+
+Slow down the demo
+== 
+
+Speed up the demo
+== 
+
+Mark the beginning of a cut (right click to reset)
+== 
+
+Mark the end of a cut (right click to reset)
+== 
+
+Export cut as a separate demo
+== 
+
+Go back one marker
+== 
+
+Go forward one marker
+== 
+
+Close the demo player
+== 
+
+Toggle keyboard shortcuts
+== 
+
+Export demo cut
+== 
+
+Cut interval
+== 
+
+Cut length
+== 
+
+Render cut to video
+== 
+
+Loading demo files
+== 
+
+All combined
+== 
+
+Folder Link
+== 
+
+Markers:
+== 
+
+%.2f MiB
+== 
+
+%.2f KiB
+== 
+
+Open the directory that contains the demo files
+== 
+
+Are you sure that you want to delete the folder '%s'?
+== 
+
+Are you sure that you want to delete the demo '%s'?
+== 
+
+Unable to delete the demo '%s'
+== 
+
+Unable to delete the folder '%s'. Make sure it's empty first.
+== 
+
+Loading ghost files
+== 
+
+Menu opened. Press Esc key again to close menu.
+== 
+
+Save power by lowering refresh rate (higher input latency)
+== 
+
+Settings file
+== 
+
+Open the settings file
+== 
+
+Config directory
+== 
+
+Open the directory that contains the configuration and user files
+== 
+
+Open the directory to add custom themes
+== 
+
+Toggle to edit your dummy settings
+== 
+
+Loading skin files
+== 
+
+Converse
+== 
+
+Chat command
+== 
+
+Controller
+== 
+
+[Ingame controller mode]
+Absolute
+== 
+
+Ingame controller sens.
+== 
+
+UI controller sens.
+== 
+
+Controller jitter tolerance
+== 
+
+Aim bind
+== 
+
+Mouse
+== 
+
+Dummy
+== 
+
+Allows maps to render with more detail
+== 
+
+Renderer
+== 
+
+default
+== 
+
+custom
+== 
+
+auto
+== 
+
+Appearance
+== 
+
+Name Plate
+== 
+
+Kill Messages
+== 
+
+DDRace HUD
+== 
+
+A Tee
+== 
+
+Normal Color
+== 
+
+Highlight Color
+== 
+
+Rifle Laser Outline Color
+== 
+
+Rifle Laser Inner Color
+== 
+
+Shotgun Laser Outline Color
+== 
+
+Shotgun Laser Inner Color
+== 
+
+Door Laser Outline Color
+== 
+
+Door Laser Inner Color
+== 
+
+Freeze Laser Outline Color
+== 
+
+Freeze Laser Inner Color
+== 
+
+Set all to Rifle
+== 
+
+Overlay entities
+== 
+
+Extras
+== 
 
 Discord
 == 
@@ -1764,20 +1779,8 @@ https://ddnet.org/discord
 Tutorial
 == 
 
-Can't find a Tutorial server
-== Impossibile trovare un Server Tutorial
-
-Loading race demo files
-== Caricando i file della demo della gara
-
 Super
 == 
 
-Loading sound files
-== Caricando file musica
-
 FPM
 == 
-
-Moved ingame
-== Spostato in gioco

--- a/data/languages/japanese.txt
+++ b/data/languages/japanese.txt
@@ -1437,6 +1437,9 @@ Cut interval
 Cut length
 == 
 
+Render cut to video
+== 
+
 Loading demo files
 == 
 
@@ -1488,10 +1491,10 @@ Open the directory that contains the configuration and user files
 Open the directory to add custom themes
 == 
 
-Loading skin files
+Toggle to edit your dummy settings
 == 
 
-Toggle to edit your dummy settings
+Loading skin files
 == 
 
 Download community skins

--- a/data/languages/korean.txt
+++ b/data/languages/korean.txt
@@ -1733,6 +1733,9 @@ Cut interval
 Cut length
 == 
 
+Render cut to video
+== 
+
 All combined
 == 
 

--- a/data/languages/kyrgyz.txt
+++ b/data/languages/kyrgyz.txt
@@ -950,6 +950,9 @@ Cut length
 Remove chat
 == 
 
+Render cut to video
+== 
+
 Please use a different name
 == 
 
@@ -1100,10 +1103,10 @@ Max CSVs
 Dummy settings
 == 
 
-Loading skin files
+Toggle to edit your dummy settings
 == 
 
-Toggle to edit your dummy settings
+Loading skin files
 == 
 
 Download skins
@@ -1157,19 +1160,22 @@ Show all
 Toggle dyncam
 == 
 
-Toggle dummy
+Toggle ghost
 == 
 
-Toggle ghost
+Converse
+== 
+
+Chat command
+== 
+
+Toggle dummy
 == 
 
 Dummy copy
 == 
 
 Hammerfly dummy
-== 
-
-Converse
 == 
 
 Statboard
@@ -1182,9 +1188,6 @@ Show entities
 == 
 
 Show HUD
-== 
-
-Chat command
 == 
 
 Enable controller

--- a/data/languages/norwegian.txt
+++ b/data/languages/norwegian.txt
@@ -1406,6 +1406,9 @@ Cut interval
 Cut length
 == 
 
+Render cut to video
+== 
+
 Loading demo files
 == 
 
@@ -1457,10 +1460,10 @@ Open the directory that contains the configuration and user files
 Open the directory to add custom themes
 == 
 
-Loading skin files
+Toggle to edit your dummy settings
 == 
 
-Toggle to edit your dummy settings
+Loading skin files
 == 
 
 Download community skins

--- a/data/languages/persian.txt
+++ b/data/languages/persian.txt
@@ -1703,6 +1703,9 @@ Cut interval
 Cut length
 == 
 
+Render cut to video
+== 
+
 All combined
 == 
 

--- a/data/languages/polish.txt
+++ b/data/languages/polish.txt
@@ -1507,6 +1507,9 @@ Cut interval
 Cut length
 == 
 
+Render cut to video
+== 
+
 Loading demo files
 == 
 

--- a/data/languages/portuguese.txt
+++ b/data/languages/portuguese.txt
@@ -1225,6 +1225,9 @@ Cut interval
 Cut length
 == 
 
+Render cut to video
+== 
+
 Loading demo files
 == 
 
@@ -1309,10 +1312,10 @@ Open the directory that contains the configuration and user files
 Open the directory to add custom themes
 == 
 
-Loading skin files
+Toggle to edit your dummy settings
 == 
 
-Toggle to edit your dummy settings
+Loading skin files
 == 
 
 Download skins
@@ -1357,19 +1360,22 @@ Show all
 Toggle dyncam
 == 
 
-Toggle dummy
+Toggle ghost
 == 
 
-Toggle ghost
+Converse
+== 
+
+Chat command
+== 
+
+Toggle dummy
 == 
 
 Dummy copy
 == 
 
 Hammerfly dummy
-== 
-
-Converse
 == 
 
 Statboard
@@ -1382,9 +1388,6 @@ Show entities
 == 
 
 Show HUD
-== 
-
-Chat command
 == 
 
 Enable controller

--- a/data/languages/romanian.txt
+++ b/data/languages/romanian.txt
@@ -965,6 +965,9 @@ Cut length
 Remove chat
 == 
 
+Render cut to video
+== 
+
 Please use a different name
 == 
 
@@ -1115,10 +1118,10 @@ Max CSVs
 Dummy settings
 == 
 
-Loading skin files
+Toggle to edit your dummy settings
 == 
 
-Toggle to edit your dummy settings
+Loading skin files
 == 
 
 Download skins
@@ -1172,19 +1175,22 @@ Show all
 Toggle dyncam
 == 
 
-Toggle dummy
+Toggle ghost
 == 
 
-Toggle ghost
+Converse
+== 
+
+Chat command
+== 
+
+Toggle dummy
 == 
 
 Dummy copy
 == 
 
 Hammerfly dummy
-== 
-
-Converse
 == 
 
 Statboard
@@ -1197,9 +1203,6 @@ Show entities
 == 
 
 Show HUD
-== 
-
-Chat command
 == 
 
 Enable controller

--- a/data/languages/russian.txt
+++ b/data/languages/russian.txt
@@ -1756,3 +1756,6 @@ Unable to delete the folder '%s'. Make sure it's empty first.
 
 Moved ingame
 == Перемещены в игре
+
+Render cut to video
+== 

--- a/data/languages/serbian.txt
+++ b/data/languages/serbian.txt
@@ -1507,11 +1507,6 @@ A render command failed. Try to update your GPU drivers.
 Submitting the render commands failed. Try to update your GPU drivers.
 == Неуспешно слање рендерних команди. Покушајте ажурирати драјвере за вашу графичку картицу.
 
-[Graphics error]
-Failed to swap framebuffers. Try to update your GPU drivers.
-== 
-
-[Graphics error]
 Unknown error. Try to change gfx_backend to OpenGL or Vulkan in settings_ddnet.cfg in the config directory and try again.
 == Неуспешно замена бафера фреймова. Покушајте ажурирати драјвере за вашу графичку картицу.
 
@@ -1748,3 +1743,10 @@ Open the directory to add custom assets
 
 Moved ingame
 == Померено у игри
+
+[Graphics error]
+Failed to swap framebuffers. Try to update your GPU drivers.
+== 
+
+Render cut to video
+== 

--- a/data/languages/serbian_cyrillic.txt
+++ b/data/languages/serbian_cyrillic.txt
@@ -1643,6 +1643,9 @@ Cut interval
 Cut length
 == 
 
+Render cut to video
+== 
+
 All combined
 == 
 

--- a/data/languages/simplified_chinese.txt
+++ b/data/languages/simplified_chinese.txt
@@ -1780,3 +1780,6 @@ Unable to delete the folder '%s'. Make sure it's empty first.
 
 Moved ingame
 == 游戏内移动
+
+Render cut to video
+== 

--- a/data/languages/slovak.txt
+++ b/data/languages/slovak.txt
@@ -956,6 +956,9 @@ Cut length
 Remove chat
 == 
 
+Render cut to video
+== 
+
 Please use a different name
 == 
 
@@ -1106,10 +1109,10 @@ Max CSVs
 Dummy settings
 == 
 
-Loading skin files
+Toggle to edit your dummy settings
 == 
 
-Toggle to edit your dummy settings
+Loading skin files
 == 
 
 Download skins
@@ -1163,19 +1166,22 @@ Show all
 Toggle dyncam
 == 
 
-Toggle dummy
+Toggle ghost
 == 
 
-Toggle ghost
+Converse
+== 
+
+Chat command
+== 
+
+Toggle dummy
 == 
 
 Dummy copy
 == 
 
 Hammerfly dummy
-== 
-
-Converse
 == 
 
 Statboard
@@ -1188,9 +1194,6 @@ Show entities
 == 
 
 Show HUD
-== 
-
-Chat command
 == 
 
 Enable controller

--- a/data/languages/spanish.txt
+++ b/data/languages/spanish.txt
@@ -1763,3 +1763,6 @@ Unable to delete the folder '%s'. Make sure it's empty first.
 
 Moved ingame
 == Movido dentro del juego
+
+Render cut to video
+== 

--- a/data/languages/swedish.txt
+++ b/data/languages/swedish.txt
@@ -1747,3 +1747,6 @@ Loading sound files
 
 Moved ingame
 == Förflyttades i spelet
+
+Render cut to video
+== Rendera snitt till video

--- a/data/languages/traditional_chinese.txt
+++ b/data/languages/traditional_chinese.txt
@@ -1769,3 +1769,6 @@ Unable to delete the folder '%s'. Make sure it's empty first.
 
 Moved ingame
 == 遊戲內移動
+
+Render cut to video
+== 

--- a/data/languages/turkish.txt
+++ b/data/languages/turkish.txt
@@ -1751,3 +1751,6 @@ Loading sound files
 
 Moved ingame
 == Hareket edildi
+
+Render cut to video
+== 

--- a/data/languages/ukrainian.txt
+++ b/data/languages/ukrainian.txt
@@ -1744,3 +1744,6 @@ Graphics card
 
 Moved ingame
 == Перемістився в грі
+
+Render cut to video
+== 

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -726,13 +726,22 @@ void CMenus::RenderDemoPlayerSliceSavePopup(CUIRect MainView)
 
 	// remove chat checkbox
 	static int s_RemoveChat = 0;
-	CUIRect RemoveChatCheckBox;
-	Box.HSplitTop(24.0f, &RemoveChatCheckBox, &Box);
+
+	CUIRect CheckBoxBar, RemoveChatCheckBox, RenderCutCheckBox;
+	Box.HSplitTop(24.0f, &CheckBoxBar, &Box);
 	Box.HSplitTop(20.0f, nullptr, &Box);
+	CheckBoxBar.VSplitMid(&RemoveChatCheckBox, &RenderCutCheckBox, 40.0f);
 	if(DoButton_CheckBox(&s_RemoveChat, Localize("Remove chat"), s_RemoveChat, &RemoveChatCheckBox))
 	{
 		s_RemoveChat ^= 1;
 	}
+#if defined(CONF_VIDEORECORDER)
+	static int s_RenderCut = 0;
+	if(DoButton_CheckBox(&s_RenderCut, Localize("Render cut to video"), s_RenderCut, &RenderCutCheckBox))
+	{
+		s_RenderCut ^= 1;
+	}
+#endif
 
 	// buttons
 	CUIRect ButtonBar, AbortButton, OkButton;
@@ -784,10 +793,20 @@ void CMenus::RenderDemoPlayerSliceSavePopup(CUIRect MainView)
 		str_copy(m_aCurrentDemoSelectionName, m_DemoSliceInput.GetString());
 		if(str_endswith(m_aCurrentDemoSelectionName, ".demo"))
 			m_aCurrentDemoSelectionName[str_length(m_aCurrentDemoSelectionName) - str_length(".demo")] = '\0';
-		m_DemoPlayerState = DEMOPLAYER_NONE;
+
 		Client()->DemoSlice(aPath, CMenus::DemoFilterChat, &s_RemoveChat);
 		DemolistPopulate();
 		DemolistOnUpdate(false);
+		m_DemoPlayerState = DEMOPLAYER_NONE;
+#if defined(CONF_VIDEORECORDER)
+		if(s_RenderCut)
+		{
+			m_Popup = POPUP_RENDER_DEMO;
+			m_StartPaused = false;
+			m_DemoRenderInput.Set(m_aCurrentDemoSelectionName);
+			UI()->SetActiveItem(&m_DemoRenderInput);
+		}
+#endif
 	}
 	if(s_ConfirmPopupContext.m_Result != CUI::SConfirmPopupContext::UNSET)
 	{


### PR DESCRIPTION
Adds a way of rendering the demo to a video straight from the "demo cut prompt". Closes #6131

https://github.com/ddnet/ddnet/assets/141338449/8feec1fc-076f-4448-8c28-d1c7b9c397f6

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
