### PR TITLE
Server: Split the huge CGameContext::OnMessage()

### DIFF
--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -1928,30 +1928,47 @@ void CGameContext::OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID)
 
 	if(Server()->ClientIngame(ClientID))
 	{
-		if(MsgID == NETMSGTYPE_CL_SAY)
+		switch(MsgID)
+		{
+		case NETMSGTYPE_CL_SAY:
 			OnSayNetMessage(static_cast<CNetMsg_Cl_Say *>(pRawMsg), ClientID, pUnpacker);
-		else if(MsgID == NETMSGTYPE_CL_CALLVOTE)
+			break;
+		case NETMSGTYPE_CL_CALLVOTE:
 			OnCallVoteNetMessage(static_cast<CNetMsg_Cl_CallVote *>(pRawMsg), ClientID);
-		else if(MsgID == NETMSGTYPE_CL_VOTE)
+			break;
+		case NETMSGTYPE_CL_VOTE:
 			OnVoteNetMessage(static_cast<CNetMsg_Cl_Vote *>(pRawMsg), ClientID);
-		else if(MsgID == NETMSGTYPE_CL_SETTEAM)
+			break;
+		case NETMSGTYPE_CL_SETTEAM:
 			OnSetTeamNetMessage(static_cast<CNetMsg_Cl_SetTeam *>(pRawMsg), ClientID);
-		else if(MsgID == NETMSGTYPE_CL_ISDDNETLEGACY)
+			break;
+		case NETMSGTYPE_CL_ISDDNETLEGACY:
 			OnIsDDNetLegacyNetMessage(static_cast<CNetMsg_Cl_IsDDNetLegacy *>(pRawMsg), ClientID, pUnpacker);
-		else if(MsgID == NETMSGTYPE_CL_SHOWOTHERSLEGACY)
+			break;
+		case NETMSGTYPE_CL_SHOWOTHERSLEGACY:
 			OnShowOthersLegacyNetMessage(static_cast<CNetMsg_Cl_ShowOthersLegacy *>(pRawMsg), ClientID);
-		else if(MsgID == NETMSGTYPE_CL_SHOWOTHERS)
+			break;
+		case NETMSGTYPE_CL_SHOWOTHERS:
 			OnShowOthersNetMessage(static_cast<CNetMsg_Cl_ShowOthers *>(pRawMsg), ClientID);
-		else if(MsgID == NETMSGTYPE_CL_SHOWDISTANCE)
+			break;
+		case NETMSGTYPE_CL_SHOWDISTANCE:
 			OnShowDistanceNetMessage(static_cast<CNetMsg_Cl_ShowDistance *>(pRawMsg), ClientID);
-		else if(MsgID == NETMSGTYPE_CL_SETSPECTATORMODE)
+			break;
+		case NETMSGTYPE_CL_SETSPECTATORMODE:
 			OnSetSpectatorModeNetMessage(static_cast<CNetMsg_Cl_SetSpectatorMode *>(pRawMsg), ClientID);
-		else if(MsgID == NETMSGTYPE_CL_CHANGEINFO)
+			break;
+		case NETMSGTYPE_CL_CHANGEINFO:
 			OnChangeInfoNetMessage(static_cast<CNetMsg_Cl_ChangeInfo *>(pRawMsg), ClientID);
-		else if(MsgID == NETMSGTYPE_CL_EMOTICON)
+			break;
+		case NETMSGTYPE_CL_EMOTICON:
 			OnEmoticonNetMessage(static_cast<CNetMsg_Cl_Emoticon *>(pRawMsg), ClientID);
-		else if(MsgID == NETMSGTYPE_CL_KILL)
+			break;
+		case NETMSGTYPE_CL_KILL:
 			OnKillNetMessage(static_cast<CNetMsg_Cl_Kill *>(pRawMsg), ClientID);
+			break;
+		default:
+			break;
+		}
 	}
 	if(MsgID == NETMSGTYPE_CL_STARTINFO)
 	{

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -1995,105 +1995,7 @@ void CGameContext::OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID)
 				pPlayer->m_SpectatorID = pMsg->m_SpectatorID;
 		}
 		else if(MsgID == NETMSGTYPE_CL_CHANGEINFO)
-		{
-			if(g_Config.m_SvSpamprotection && pPlayer->m_LastChangeInfo && pPlayer->m_LastChangeInfo + Server()->TickSpeed() * g_Config.m_SvInfoChangeDelay > Server()->Tick())
-				return;
-
-			bool SixupNeedsUpdate = false;
-
-			CNetMsg_Cl_ChangeInfo *pMsg = (CNetMsg_Cl_ChangeInfo *)pRawMsg;
-			if(!str_utf8_check(pMsg->m_pName) || !str_utf8_check(pMsg->m_pClan) || !str_utf8_check(pMsg->m_pSkin))
-			{
-				return;
-			}
-			pPlayer->m_LastChangeInfo = Server()->Tick();
-			pPlayer->UpdatePlaytime();
-
-			// set infos
-			if(Server()->WouldClientNameChange(ClientID, pMsg->m_pName) && !ProcessSpamProtection(ClientID))
-			{
-				char aOldName[MAX_NAME_LENGTH];
-				str_copy(aOldName, Server()->ClientName(ClientID), sizeof(aOldName));
-
-				Server()->SetClientName(ClientID, pMsg->m_pName);
-
-				char aChatText[256];
-				str_format(aChatText, sizeof(aChatText), "'%s' changed name to '%s'", aOldName, Server()->ClientName(ClientID));
-				SendChat(-1, CGameContext::CHAT_ALL, aChatText);
-
-				// reload scores
-				Score()->PlayerData(ClientID)->Reset();
-				m_apPlayers[ClientID]->m_Score.reset();
-				Score()->LoadPlayerData(ClientID);
-
-				SixupNeedsUpdate = true;
-
-				LogEvent("Name change", ClientID);
-			}
-
-			if(str_comp(Server()->ClientClan(ClientID), pMsg->m_pClan))
-				SixupNeedsUpdate = true;
-			Server()->SetClientClan(ClientID, pMsg->m_pClan);
-
-			if(Server()->ClientCountry(ClientID) != pMsg->m_Country)
-				SixupNeedsUpdate = true;
-			Server()->SetClientCountry(ClientID, pMsg->m_Country);
-
-			str_copy(pPlayer->m_TeeInfos.m_aSkinName, pMsg->m_pSkin, sizeof(pPlayer->m_TeeInfos.m_aSkinName));
-			pPlayer->m_TeeInfos.m_UseCustomColor = pMsg->m_UseCustomColor;
-			pPlayer->m_TeeInfos.m_ColorBody = pMsg->m_ColorBody;
-			pPlayer->m_TeeInfos.m_ColorFeet = pMsg->m_ColorFeet;
-			if(!Server()->IsSixup(ClientID))
-				pPlayer->m_TeeInfos.ToSixup();
-
-			if(SixupNeedsUpdate)
-			{
-				protocol7::CNetMsg_Sv_ClientDrop Drop;
-				Drop.m_ClientID = ClientID;
-				Drop.m_pReason = "";
-				Drop.m_Silent = true;
-
-				protocol7::CNetMsg_Sv_ClientInfo Info;
-				Info.m_ClientID = ClientID;
-				Info.m_pName = Server()->ClientName(ClientID);
-				Info.m_Country = pMsg->m_Country;
-				Info.m_pClan = pMsg->m_pClan;
-				Info.m_Local = 0;
-				Info.m_Silent = true;
-				Info.m_Team = pPlayer->GetTeam();
-
-				for(int p = 0; p < 6; p++)
-				{
-					Info.m_apSkinPartNames[p] = pPlayer->m_TeeInfos.m_apSkinPartNames[p];
-					Info.m_aSkinPartColors[p] = pPlayer->m_TeeInfos.m_aSkinPartColors[p];
-					Info.m_aUseCustomColors[p] = pPlayer->m_TeeInfos.m_aUseCustomColors[p];
-				}
-
-				for(int i = 0; i < Server()->MaxClients(); i++)
-				{
-					if(i != ClientID)
-					{
-						Server()->SendPackMsg(&Drop, MSGFLAG_VITAL | MSGFLAG_NORECORD, i);
-						Server()->SendPackMsg(&Info, MSGFLAG_VITAL | MSGFLAG_NORECORD, i);
-					}
-				}
-			}
-			else
-			{
-				protocol7::CNetMsg_Sv_SkinChange Msg;
-				Msg.m_ClientID = ClientID;
-				for(int p = 0; p < 6; p++)
-				{
-					Msg.m_apSkinPartNames[p] = pPlayer->m_TeeInfos.m_apSkinPartNames[p];
-					Msg.m_aSkinPartColors[p] = pPlayer->m_TeeInfos.m_aSkinPartColors[p];
-					Msg.m_aUseCustomColors[p] = pPlayer->m_TeeInfos.m_aUseCustomColors[p];
-				}
-
-				Server()->SendPackMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_NORECORD, -1);
-			}
-
-			Server()->ExpireServerInfo();
-		}
+			OnChangeInfoNetMessage(static_cast<CNetMsg_Cl_ChangeInfo *>(pRawMsg), ClientID);
 		else if(MsgID == NETMSGTYPE_CL_EMOTICON && !m_World.m_Paused)
 		{
 			CNetMsg_Cl_Emoticon *pMsg = (CNetMsg_Cl_Emoticon *)pRawMsg;
@@ -2707,6 +2609,107 @@ void CGameContext::OnSetTeamNetMessage(const CNetMsg_Cl_SetTeam *pMsg, int Clien
 		str_format(aBuf, sizeof(aBuf), "Only %d active players are allowed", Server()->MaxClients() - g_Config.m_SvSpectatorSlots);
 		SendBroadcast(aBuf, ClientID);
 	}
+}
+
+void CGameContext::OnChangeInfoNetMessage(const CNetMsg_Cl_ChangeInfo *pMsg, int ClientID)
+{
+	CPlayer *pPlayer = m_apPlayers[ClientID];
+	if(g_Config.m_SvSpamprotection && pPlayer->m_LastChangeInfo && pPlayer->m_LastChangeInfo + Server()->TickSpeed() * g_Config.m_SvInfoChangeDelay > Server()->Tick())
+		return;
+
+	bool SixupNeedsUpdate = false;
+
+	if(!str_utf8_check(pMsg->m_pName) || !str_utf8_check(pMsg->m_pClan) || !str_utf8_check(pMsg->m_pSkin))
+	{
+		return;
+	}
+	pPlayer->m_LastChangeInfo = Server()->Tick();
+	pPlayer->UpdatePlaytime();
+
+	// set infos
+	if(Server()->WouldClientNameChange(ClientID, pMsg->m_pName) && !ProcessSpamProtection(ClientID))
+	{
+		char aOldName[MAX_NAME_LENGTH];
+		str_copy(aOldName, Server()->ClientName(ClientID), sizeof(aOldName));
+
+		Server()->SetClientName(ClientID, pMsg->m_pName);
+
+		char aChatText[256];
+		str_format(aChatText, sizeof(aChatText), "'%s' changed name to '%s'", aOldName, Server()->ClientName(ClientID));
+		SendChat(-1, CGameContext::CHAT_ALL, aChatText);
+
+		// reload scores
+		Score()->PlayerData(ClientID)->Reset();
+		m_apPlayers[ClientID]->m_Score.reset();
+		Score()->LoadPlayerData(ClientID);
+
+		SixupNeedsUpdate = true;
+
+		LogEvent("Name change", ClientID);
+	}
+
+	if(str_comp(Server()->ClientClan(ClientID), pMsg->m_pClan))
+		SixupNeedsUpdate = true;
+	Server()->SetClientClan(ClientID, pMsg->m_pClan);
+
+	if(Server()->ClientCountry(ClientID) != pMsg->m_Country)
+		SixupNeedsUpdate = true;
+	Server()->SetClientCountry(ClientID, pMsg->m_Country);
+
+	str_copy(pPlayer->m_TeeInfos.m_aSkinName, pMsg->m_pSkin, sizeof(pPlayer->m_TeeInfos.m_aSkinName));
+	pPlayer->m_TeeInfos.m_UseCustomColor = pMsg->m_UseCustomColor;
+	pPlayer->m_TeeInfos.m_ColorBody = pMsg->m_ColorBody;
+	pPlayer->m_TeeInfos.m_ColorFeet = pMsg->m_ColorFeet;
+	if(!Server()->IsSixup(ClientID))
+		pPlayer->m_TeeInfos.ToSixup();
+
+	if(SixupNeedsUpdate)
+	{
+		protocol7::CNetMsg_Sv_ClientDrop Drop;
+		Drop.m_ClientID = ClientID;
+		Drop.m_pReason = "";
+		Drop.m_Silent = true;
+
+		protocol7::CNetMsg_Sv_ClientInfo Info;
+		Info.m_ClientID = ClientID;
+		Info.m_pName = Server()->ClientName(ClientID);
+		Info.m_Country = pMsg->m_Country;
+		Info.m_pClan = pMsg->m_pClan;
+		Info.m_Local = 0;
+		Info.m_Silent = true;
+		Info.m_Team = pPlayer->GetTeam();
+
+		for(int p = 0; p < 6; p++)
+		{
+			Info.m_apSkinPartNames[p] = pPlayer->m_TeeInfos.m_apSkinPartNames[p];
+			Info.m_aSkinPartColors[p] = pPlayer->m_TeeInfos.m_aSkinPartColors[p];
+			Info.m_aUseCustomColors[p] = pPlayer->m_TeeInfos.m_aUseCustomColors[p];
+		}
+
+		for(int i = 0; i < Server()->MaxClients(); i++)
+		{
+			if(i != ClientID)
+			{
+				Server()->SendPackMsg(&Drop, MSGFLAG_VITAL | MSGFLAG_NORECORD, i);
+				Server()->SendPackMsg(&Info, MSGFLAG_VITAL | MSGFLAG_NORECORD, i);
+			}
+		}
+	}
+	else
+	{
+		protocol7::CNetMsg_Sv_SkinChange Msg;
+		Msg.m_ClientID = ClientID;
+		for(int p = 0; p < 6; p++)
+		{
+			Msg.m_apSkinPartNames[p] = pPlayer->m_TeeInfos.m_apSkinPartNames[p];
+			Msg.m_aSkinPartColors[p] = pPlayer->m_TeeInfos.m_aSkinPartColors[p];
+			Msg.m_aUseCustomColors[p] = pPlayer->m_TeeInfos.m_aUseCustomColors[p];
+		}
+
+		Server()->SendPackMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_NORECORD, -1);
+	}
+
+	Server()->ExpireServerInfo();
 }
 
 void CGameContext::ConTuneParam(IConsole::IResult *pResult, void *pUserData)

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -1997,79 +1997,7 @@ void CGameContext::OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID)
 		else if(MsgID == NETMSGTYPE_CL_CHANGEINFO)
 			OnChangeInfoNetMessage(static_cast<CNetMsg_Cl_ChangeInfo *>(pRawMsg), ClientID);
 		else if(MsgID == NETMSGTYPE_CL_EMOTICON && !m_World.m_Paused)
-		{
-			CNetMsg_Cl_Emoticon *pMsg = (CNetMsg_Cl_Emoticon *)pRawMsg;
-
-			auto &&CheckPreventEmote = [&](int64_t LastEmote, int64_t DelayInMs) {
-				return (LastEmote * (int64_t)1000) + (int64_t)Server()->TickSpeed() * DelayInMs > ((int64_t)Server()->Tick() * (int64_t)1000);
-			};
-
-			if(g_Config.m_SvSpamprotection && CheckPreventEmote((int64_t)pPlayer->m_LastEmote, (int64_t)g_Config.m_SvEmoticonMsDelay))
-				return;
-
-			CCharacter *pChr = pPlayer->GetCharacter();
-			// player needs a character to send emotes
-			if(pChr != nullptr)
-			{
-				pPlayer->m_LastEmote = Server()->Tick();
-				pPlayer->UpdatePlaytime();
-
-				// check if the global emoticon is prevented and emotes are only send to nearby players
-				if(g_Config.m_SvSpamprotection && CheckPreventEmote((int64_t)pPlayer->m_LastEmoteGlobal, (int64_t)g_Config.m_SvGlobalEmoticonMsDelay))
-				{
-					for(int i = 0; i < MAX_CLIENTS; ++i)
-					{
-						if(m_apPlayers[i] && pChr->CanSnapCharacter(i) && pChr->IsSnappingCharacterInView(i))
-						{
-							SendEmoticon(ClientID, pMsg->m_Emoticon, i);
-						}
-					}
-				}
-				else
-				{
-					// else send emoticons to all players
-					pPlayer->m_LastEmoteGlobal = Server()->Tick();
-					SendEmoticon(ClientID, pMsg->m_Emoticon, -1);
-				}
-
-				if(g_Config.m_SvEmotionalTees && pPlayer->m_EyeEmoteEnabled)
-				{
-					int EmoteType = EMOTE_NORMAL;
-					switch(pMsg->m_Emoticon)
-					{
-					case EMOTICON_EXCLAMATION:
-					case EMOTICON_GHOST:
-					case EMOTICON_QUESTION:
-					case EMOTICON_WTF:
-						EmoteType = EMOTE_SURPRISE;
-						break;
-					case EMOTICON_DOTDOT:
-					case EMOTICON_DROP:
-					case EMOTICON_ZZZ:
-						EmoteType = EMOTE_BLINK;
-						break;
-					case EMOTICON_EYES:
-					case EMOTICON_HEARTS:
-					case EMOTICON_MUSIC:
-						EmoteType = EMOTE_HAPPY;
-						break;
-					case EMOTICON_OOP:
-					case EMOTICON_SORRY:
-					case EMOTICON_SUSHI:
-						EmoteType = EMOTE_PAIN;
-						break;
-					case EMOTICON_DEVILTEE:
-					case EMOTICON_SPLATTEE:
-					case EMOTICON_ZOMG:
-						EmoteType = EMOTE_ANGRY;
-						break;
-					default:
-						break;
-					}
-					pChr->SetEmote(EmoteType, Server()->Tick() + 2 * Server()->TickSpeed());
-				}
-			}
-		}
+			OnEmoticonNetMessage(static_cast<CNetMsg_Cl_Emoticon *>(pRawMsg), ClientID);
 		else if(MsgID == NETMSGTYPE_CL_KILL && !m_World.m_Paused)
 		{
 			if(m_VoteCloseTime && m_VoteCreator == ClientID && GetDDRaceTeam(ClientID) && (IsKickVote() || IsSpecVote()))
@@ -2710,6 +2638,82 @@ void CGameContext::OnChangeInfoNetMessage(const CNetMsg_Cl_ChangeInfo *pMsg, int
 	}
 
 	Server()->ExpireServerInfo();
+}
+
+void CGameContext::OnEmoticonNetMessage(const CNetMsg_Cl_Emoticon *pMsg, int ClientID)
+{
+	CPlayer *pPlayer = m_apPlayers[ClientID];
+
+	auto &&CheckPreventEmote = [&](int64_t LastEmote, int64_t DelayInMs) {
+		return (LastEmote * (int64_t)1000) + (int64_t)Server()->TickSpeed() * DelayInMs > ((int64_t)Server()->Tick() * (int64_t)1000);
+	};
+
+	if(g_Config.m_SvSpamprotection && CheckPreventEmote((int64_t)pPlayer->m_LastEmote, (int64_t)g_Config.m_SvEmoticonMsDelay))
+		return;
+
+	CCharacter *pChr = pPlayer->GetCharacter();
+
+	// player needs a character to send emotes
+	if(!pChr)
+		return;
+
+	pPlayer->m_LastEmote = Server()->Tick();
+	pPlayer->UpdatePlaytime();
+
+	// check if the global emoticon is prevented and emotes are only send to nearby players
+	if(g_Config.m_SvSpamprotection && CheckPreventEmote((int64_t)pPlayer->m_LastEmoteGlobal, (int64_t)g_Config.m_SvGlobalEmoticonMsDelay))
+	{
+		for(int i = 0; i < MAX_CLIENTS; ++i)
+		{
+			if(m_apPlayers[i] && pChr->CanSnapCharacter(i) && pChr->IsSnappingCharacterInView(i))
+			{
+				SendEmoticon(ClientID, pMsg->m_Emoticon, i);
+			}
+		}
+	}
+	else
+	{
+		// else send emoticons to all players
+		pPlayer->m_LastEmoteGlobal = Server()->Tick();
+		SendEmoticon(ClientID, pMsg->m_Emoticon, -1);
+	}
+
+	if(g_Config.m_SvEmotionalTees && pPlayer->m_EyeEmoteEnabled)
+	{
+		int EmoteType = EMOTE_NORMAL;
+		switch(pMsg->m_Emoticon)
+		{
+		case EMOTICON_EXCLAMATION:
+		case EMOTICON_GHOST:
+		case EMOTICON_QUESTION:
+		case EMOTICON_WTF:
+			EmoteType = EMOTE_SURPRISE;
+			break;
+		case EMOTICON_DOTDOT:
+		case EMOTICON_DROP:
+		case EMOTICON_ZZZ:
+			EmoteType = EMOTE_BLINK;
+			break;
+		case EMOTICON_EYES:
+		case EMOTICON_HEARTS:
+		case EMOTICON_MUSIC:
+			EmoteType = EMOTE_HAPPY;
+			break;
+		case EMOTICON_OOP:
+		case EMOTICON_SORRY:
+		case EMOTICON_SUSHI:
+			EmoteType = EMOTE_PAIN;
+			break;
+		case EMOTICON_DEVILTEE:
+		case EMOTICON_SPLATTEE:
+		case EMOTICON_ZOMG:
+			EmoteType = EMOTE_ANGRY;
+			break;
+		default:
+			break;
+		}
+		pChr->SetEmote(EmoteType, Server()->Tick() + 2 * Server()->TickSpeed());
+	}
 }
 
 void CGameContext::ConTuneParam(IConsole::IResult *pResult, void *pUserData)

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -1936,7 +1936,7 @@ void CGameContext::OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID)
 			OnCallVoteNetMessage(static_cast<CNetMsg_Cl_CallVote *>(pRawMsg), ClientID);
 		else if(MsgID == NETMSGTYPE_CL_VOTE)
 			OnVoteNetMessage(static_cast<CNetMsg_Cl_Vote *>(pRawMsg), ClientID);
-		else if(MsgID == NETMSGTYPE_CL_SETTEAM && !m_World.m_Paused)
+		else if(MsgID == NETMSGTYPE_CL_SETTEAM)
 			OnSetTeamNetMessage(static_cast<CNetMsg_Cl_SetTeam *>(pRawMsg), ClientID);
 		else if(MsgID == NETMSGTYPE_CL_ISDDNETLEGACY)
 		{
@@ -2656,6 +2656,9 @@ void CGameContext::OnVoteNetMessage(const CNetMsg_Cl_Vote *pMsg, int ClientID)
 
 void CGameContext::OnSetTeamNetMessage(const CNetMsg_Cl_SetTeam *pMsg, int ClientID)
 {
+	if(m_World.m_Paused)
+		return;
+
 	CPlayer *pPlayer = m_apPlayers[ClientID];
 
 	if(pPlayer->GetTeam() == pMsg->m_Team || (g_Config.m_SvSpamprotection && pPlayer->m_LastSetTeam && pPlayer->m_LastSetTeam + Server()->TickSpeed() * g_Config.m_SvTeamChangeDelay > Server()->Tick()))

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -292,8 +292,14 @@ public:
 	void OnCallVoteNetMessage(const CNetMsg_Cl_CallVote *pMsg, int ClientID);
 	void OnVoteNetMessage(const CNetMsg_Cl_Vote *pMsg, int ClientID);
 	void OnSetTeamNetMessage(const CNetMsg_Cl_SetTeam *pMsg, int ClientID);
+	void OnIsDDNetLegacyNetMessage(const CNetMsg_Cl_IsDDNetLegacy *pMsg, int ClientID, CUnpacker *pUnpacker);
+	void OnShowOthersLegacyNetMessage(const CNetMsg_Cl_ShowOthersLegacy *pMsg, int ClientID);
+	void OnShowOthersNetMessage(const CNetMsg_Cl_ShowOthers *pMsg, int ClientID);
+	void OnShowDistanceNetMessage(const CNetMsg_Cl_ShowDistance *pMsg, int ClientID);
+	void OnSetSpectatorModeNetMessage(const CNetMsg_Cl_SetSpectatorMode *pMsg, int ClientID);
 	void OnChangeInfoNetMessage(const CNetMsg_Cl_ChangeInfo *pMsg, int ClientID);
 	void OnEmoticonNetMessage(const CNetMsg_Cl_Emoticon *pMsg, int ClientID);
+	void OnKillNetMessage(const CNetMsg_Cl_Kill *pMsg, int ClientID);
 	void OnStartInfoNetMessage(const CNetMsg_Cl_StartInfo *pMsg, int ClientID);
 
 	bool OnClientDataPersist(int ClientID, void *pData) override;

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -288,6 +288,8 @@ public:
 	void *PreProcessMsg(int *pMsgID, CUnpacker *pUnpacker, int ClientID);
 	void CensorMessage(char *pCensoredMessage, const char *pMessage, int Size);
 	void OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID) override;
+	void OnCallVoteNetMessage(const CNetMsg_Cl_CallVote *pMsg, int ClientID);
+	void OnVoteNetMessage(const CNetMsg_Cl_Vote *pMsg, int ClientID);
 
 	bool OnClientDataPersist(int ClientID, void *pData) override;
 	void OnClientConnected(int ClientID, void *pData) override;

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -291,6 +291,7 @@ public:
 	void OnSayNetMessage(const CNetMsg_Cl_Say *pMsg, int ClientID, const CUnpacker *pUnpacker);
 	void OnCallVoteNetMessage(const CNetMsg_Cl_CallVote *pMsg, int ClientID);
 	void OnVoteNetMessage(const CNetMsg_Cl_Vote *pMsg, int ClientID);
+	void OnSetTeamNetMessage(const CNetMsg_Cl_SetTeam *pMsg, int ClientID);
 
 	bool OnClientDataPersist(int ClientID, void *pData) override;
 	void OnClientConnected(int ClientID, void *pData) override;

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -288,6 +288,7 @@ public:
 	void *PreProcessMsg(int *pMsgID, CUnpacker *pUnpacker, int ClientID);
 	void CensorMessage(char *pCensoredMessage, const char *pMessage, int Size);
 	void OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID) override;
+	void OnSayNetMessage(const CNetMsg_Cl_Say *pMsg, int ClientID, const CUnpacker *pUnpacker);
 	void OnCallVoteNetMessage(const CNetMsg_Cl_CallVote *pMsg, int ClientID);
 	void OnVoteNetMessage(const CNetMsg_Cl_Vote *pMsg, int ClientID);
 

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -293,6 +293,7 @@ public:
 	void OnVoteNetMessage(const CNetMsg_Cl_Vote *pMsg, int ClientID);
 	void OnSetTeamNetMessage(const CNetMsg_Cl_SetTeam *pMsg, int ClientID);
 	void OnChangeInfoNetMessage(const CNetMsg_Cl_ChangeInfo *pMsg, int ClientID);
+	void OnEmoticonNetMessage(const CNetMsg_Cl_Emoticon *pMsg, int ClientID);
 
 	bool OnClientDataPersist(int ClientID, void *pData) override;
 	void OnClientConnected(int ClientID, void *pData) override;

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -294,6 +294,7 @@ public:
 	void OnSetTeamNetMessage(const CNetMsg_Cl_SetTeam *pMsg, int ClientID);
 	void OnChangeInfoNetMessage(const CNetMsg_Cl_ChangeInfo *pMsg, int ClientID);
 	void OnEmoticonNetMessage(const CNetMsg_Cl_Emoticon *pMsg, int ClientID);
+	void OnStartInfoNetMessage(const CNetMsg_Cl_StartInfo *pMsg, int ClientID);
 
 	bool OnClientDataPersist(int ClientID, void *pData) override;
 	void OnClientConnected(int ClientID, void *pData) override;

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -292,6 +292,7 @@ public:
 	void OnCallVoteNetMessage(const CNetMsg_Cl_CallVote *pMsg, int ClientID);
 	void OnVoteNetMessage(const CNetMsg_Cl_Vote *pMsg, int ClientID);
 	void OnSetTeamNetMessage(const CNetMsg_Cl_SetTeam *pMsg, int ClientID);
+	void OnChangeInfoNetMessage(const CNetMsg_Cl_ChangeInfo *pMsg, int ClientID);
 
 	bool OnClientDataPersist(int ClientID, void *pData) override;
 	void OnClientConnected(int ClientID, void *pData) override;


### PR DESCRIPTION
This is actually helpful for forks and modding: some mods customize votes, some customize the processing of `NETMSGTYPE_CL_SAY`, etc.

It is hard to track what is going on in this method, and sometimes it is even harder to merge changes here.

This MR is hard to rebase and I'd appreciate a quick (like: before other MRs touching this area) response. :eyes: 

<s>**Note: I can't fix the code style for this MR, this is why I asked for #7033 ("please update clang-format").**</s>

Edit: Oh, what!? It failed in my repo and I gave up. Now it goes :heavy_check_mark: here :exploding_head: 

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
