### PR TITLE
Quit client and server when starting with elevated privileges

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,7 +114,7 @@ jobs:
     - name: Run debug server
       run: |
         cd debug
-        ./DDNet-Server shutdown
+        ./DDNet-Server --allow-elevated shutdown
 
     - name: Build in release mode
       run: |
@@ -131,7 +131,7 @@ jobs:
     - name: Run release server
       run: |
         cd release
-        ./DDNet-Server shutdown
+        ./DDNet-Server --allow-elevated shutdown
 
     - name: Build headless client
       if: contains(matrix.os, 'ubuntu-latest')
@@ -165,8 +165,8 @@ jobs:
         cd headless
         # Remove old coverage data:
         find . -name '*.gcno' -o -name '*.gcda' -delete
-        ./DDNet-Server &
-        ./DDNet "cl_download_skins 0;connect localhost:8303;quit"
+        ./DDNet-Server --allow-elevated &
+        ./DDNet --allow-elevated "cl_download_skins 0;connect localhost:8303;quit"
 
     - name: Upload Codecov report (start & connect)
       if: contains(matrix.os, 'ubuntu-latest')
@@ -194,7 +194,7 @@ jobs:
       if: matrix.fancy
       run: |
         cd fancy
-        ./DDNet-Server shutdown
+        ./DDNet-Server --allow-elevated shutdown
 
     - name: Run integration tests with Valgrind's Memcheck
       if: contains(matrix.os, 'ubuntu-latest')

--- a/.github/workflows/clang-sanitizer.yml
+++ b/.github/workflows/clang-sanitizer.yml
@@ -38,8 +38,8 @@ jobs:
         export UBSAN_OPTIONS=suppressions=./ubsan.supp:log_path=./SAN:print_stacktrace=1:halt_on_errors=0
         export ASAN_OPTIONS=log_path=./SAN:print_stacktrace=1:check_initialization_order=1:detect_leaks=1:halt_on_errors=0
         export LSAN_OPTIONS=suppressions=./lsan.supp
-        ./DDNet "cl_download_skins 0;quit" || true
-        ./DDNet-Server shutdown || true
+        ./DDNet --allow-elevated "cl_download_skins 0;quit" || true
+        ./DDNet-Server --allow-elevated shutdown || true
         if test -n "$(find . -maxdepth 1 -name 'SAN.*' -print -quit)"
         then
           cat ./SAN.*

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -2749,6 +2749,19 @@ bool os_version_str(char *version, size_t length);
  */
 void os_locale_str(char *locale, size_t length);
 
+/**
+ * Returns whether the current process was launched with elevated privileges.
+ * On Unix, this mean the process was launched either by the "root" user itself
+ * or by using the "sudo" command on a regular user.
+ * On Windows, this means the process was launched by giving it administrative
+ * access using User Account Control (UAC). This does not include the user itself
+ * having the administrator role, as this is very common on Windows and in itself
+ * does not cause issues with permissions, as long as the user stays administrator.
+ *
+ * @return true if process was launched with elevated privileges, false otherwise
+ */
+bool os_has_elevated_privileges();
+
 #if defined(CONF_EXCEPTION_HANDLING)
 void init_exception_handler();
 void set_exception_handler_log_file(const char *log_file_path);

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -4532,12 +4532,17 @@ int main(int argc, const char **argv)
 	CCmdlineFix CmdlineFix(&argc, &argv);
 
 	bool Silent = false;
+	bool AllowElevated = false;
 
 	for(int i = 1; i < argc; i++)
 	{
 		if(str_comp("-s", argv[i]) == 0 || str_comp("--silent", argv[i]) == 0)
 		{
 			Silent = true;
+		}
+		else if(str_comp("--allow-elevated", argv[i]) == 0)
+		{
+			AllowElevated = true;
 		}
 	}
 
@@ -4570,6 +4575,13 @@ int main(int argc, const char **argv)
 	std::shared_ptr<CFutureLogger> pFutureAssertionLogger = std::make_shared<CFutureLogger>();
 	vpLoggers.push_back(pFutureAssertionLogger);
 	log_set_global_logger(log_logger_collection(std::move(vpLoggers)).release());
+
+	if(!AllowElevated && os_has_elevated_privileges())
+	{
+		const char *pMessage = "You are trying to launch the game with elevated privileges (admin/root).\nThis can cause issues and is not necessary. Please launch the game without elevated privileges.\nTo launch the game anyway, specify \"--allow-elevated\" as a command line argument.";
+		SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "Elevated privileges (admin/root) detected", pMessage, nullptr);
+		return -1;
+	}
 
 	std::stack<std::function<void()>> CleanerFunctions;
 	std::function<void()> PerformCleanup = [&CleanerFunctions]() mutable {

--- a/src/engine/shared/console.cpp
+++ b/src/engine/shared/console.cpp
@@ -1062,9 +1062,9 @@ void CConsole::ParseArguments(int NumArgs, const char **ppArguments)
 				ExecuteFile(ppArguments[i + 1], -1, true, IStorage::TYPE_ABSOLUTE);
 			i++;
 		}
-		else if(!str_comp("-s", ppArguments[i]) || !str_comp("--silent", ppArguments[i]))
+		else if(!str_comp("-s", ppArguments[i]) || !str_comp("--silent", ppArguments[i]) || !str_comp("--allow-elevated", ppArguments[i]))
 		{
-			// skip silent param
+			// ignore command line flags that are handled separately
 			continue;
 		}
 		else

--- a/src/test/os.cpp
+++ b/src/test/os.cpp
@@ -16,3 +16,11 @@ TEST(Os, LocaleStr)
 	os_locale_str(aLocale, sizeof(aLocale));
 	EXPECT_STRNE(aLocale, "");
 }
+
+TEST(Os, HasElevatedPrivileges)
+{
+	// Only check that the function returns. This currently returns false in Unix runners but
+	// true in Windows runners and it could also change in the future without warning.
+	// https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#administrative-privileges
+	(void)os_has_elevated_privileges();
+}


### PR DESCRIPTION
Launching client and server with elevated privileges can cause files and folders to have inconsistent permissions and should never be necessary. Therefore, immediately quit client and server if elevated privileges are detected.

On Unix, this mean the process was launched either by the "root" user itself or by using the "sudo" command on a regular user.

On Windows, this means the process was launched by giving it administrative access using User Account Control (UAC). This does not include the user itself having the administrator role, as this is very common on Windows and in itself does not cause issues with permissions, as long as the user stays administrator.

Add `os_has_elevated_privileges` to check for elevated privileges of the current process.

Add a test case that checks that the function returns, as it currently returns false in Unix runners but true in Windows runners and it could also change in the future without warning (https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#administrative-privileges).

Closes #7131.

Add a command line flag `--allow-elevated` to client and server to ignore this check, which is necessary because the Windows-based GitHub CI runners run everything with elevated privileges at the moment.

![client-error-message](https://github.com/ddnet/ddnet/assets/23437060/86f5d046-2913-4e09-8fa6-3f525eb4d523)

## Checklist

- [X] Tested the change ingame (on Windows and Ubuntu)
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
