### PR TITLE
Fix desynced lineinput cursor/selection on external buffer change

### DIFF
--- a/src/game/client/lineinput.cpp
+++ b/src/game/client/lineinput.cpp
@@ -386,6 +386,9 @@ bool CLineInput::ProcessInput(const IInput::CEvent &Event)
 
 STextBoundingBox CLineInput::Render(const CUIRect *pRect, float FontSize, int Align, bool Changed, float LineWidth)
 {
+	// update derived attributes to handle external changes to the buffer
+	UpdateStrData();
+
 	m_WasRendered = true;
 
 	const char *pDisplayStr = GetDisplayedString();


### PR DESCRIPTION
When the buffer of a lineinput is modified externally, the cursor offset and selection are not updated, which causes them to be rendered wrong and also causes the assertion error "Selection and cursor offset got desynchronized" when changing the selection of a lineinput.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
