### PR TITLE
Make skin refind cleanup bit more aggressive

### DIFF
--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -817,6 +817,10 @@ void CChat::RefindSkins()
 
 			Line.m_RenderSkinMetrics = pSkin->m_Metrics;
 		}
+		else
+		{
+			Line.m_RenderSkin.Reset();
+		}
 	}
 }
 

--- a/src/game/client/components/ghost.cpp
+++ b/src/game/client/components/ghost.cpp
@@ -675,14 +675,18 @@ void CGhost::RefindSkin()
 		if(!Ghost.Empty())
 		{
 			IntsToStr(&Ghost.m_Skin.m_Skin0, 6, aSkinName);
+			CTeeRenderInfo *pRenderInfo = &Ghost.m_RenderInfo;
 			if(aSkinName[0] != '\0')
 			{
-				CTeeRenderInfo *pRenderInfo = &Ghost.m_RenderInfo;
-
 				const CSkin *pSkin = m_pClient->m_Skins.Find(aSkinName);
 				pRenderInfo->m_OriginalRenderSkin = pSkin->m_OriginalSkin;
 				pRenderInfo->m_ColorableRenderSkin = pSkin->m_ColorableSkin;
 				pRenderInfo->m_SkinMetrics = pSkin->m_Metrics;
+			}
+			else
+			{
+				pRenderInfo->m_OriginalRenderSkin.Reset();
+				pRenderInfo->m_ColorableRenderSkin.Reset();
 			}
 		}
 	}

--- a/src/game/client/components/killmessages.cpp
+++ b/src/game/client/components/killmessages.cpp
@@ -397,6 +397,7 @@ void CKillMessages::RefindSkins()
 
 		if(m_aKillmsgs[r].m_KillerID >= 0)
 		{
+			m_aKillmsgs[r].m_KillerRenderInfo = {};
 			const CGameClient::CClientData &Client = GameClient()->m_aClients[m_aKillmsgs[r].m_KillerID];
 			if(Client.m_aSkinName[0] != '\0')
 				m_aKillmsgs[r].m_KillerRenderInfo = Client.m_RenderInfo;

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -3343,6 +3343,11 @@ void CGameClient::RefindSkins()
 			Client.m_SkinInfo.m_ColorableRenderSkin = pSkin->m_ColorableSkin;
 			Client.UpdateRenderInfo(IsTeamPlay());
 		}
+		else
+		{
+			Client.m_SkinInfo.m_OriginalRenderSkin.Reset();
+			Client.m_SkinInfo.m_ColorableRenderSkin.Reset();
+		}
 	}
 	m_Ghost.RefindSkin();
 	m_Chat.RefindSkins();


### PR DESCRIPTION
tested ingame by trying to reproduce (so not 100% fix), but seems logical to me

fixes #7165

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
