### PR TITLE
Clear pixels that are considered transparent

### DIFF
--- a/src/engine/gfx/image_manipulation.cpp
+++ b/src/engine/gfx/image_manipulation.cpp
@@ -22,6 +22,12 @@ static void Dilate(int w, int h, int BPP, const unsigned char *pSrc, unsigned ch
 			if(pSrc[m + AlphaCompIndex] > AlphaThreshold)
 				continue;
 
+			// clear pixels that are considered transparent
+			// this allows the image to always be black where no dilate is needed
+			pDest[m + 0] = 0;
+			pDest[m + 1] = 0;
+			pDest[m + 2] = 0;
+
 			int aSumOfOpaque[] = {0, 0, 0};
 			int Counter = 0;
 			for(int c = 0; c < 4; c++)


### PR DESCRIPTION
helps making 
#7167 

smaller in size, bcs lot of transparent pixels were white

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
