### PR TITLE
Overhaul demo player skipping UI and UX

### DIFF
--- a/src/engine/textrender.h
+++ b/src/engine/textrender.h
@@ -98,6 +98,8 @@ MAYBE_UNUSED static const char *FONT_ICON_PAUSE = "\xEF\x81\x8C";
 MAYBE_UNUSED static const char *FONT_ICON_STOP = "\xEF\x81\x8D";
 MAYBE_UNUSED static const char *FONT_ICON_CHEVRON_LEFT = "\xEF\x81\x93";
 MAYBE_UNUSED static const char *FONT_ICON_CHEVRON_RIGHT = "\xEF\x81\x94";
+MAYBE_UNUSED static const char *FONT_ICON_CHEVRON_UP = "\xEF\x81\xB7";
+MAYBE_UNUSED static const char *FONT_ICON_CHEVRON_DOWN = "\xEF\x81\xB8";
 MAYBE_UNUSED static const char *FONT_ICON_BACKWARD = "\xEF\x81\x8A";
 MAYBE_UNUSED static const char *FONT_ICON_FORWARD = "\xEF\x81\x8E";
 MAYBE_UNUSED static const char *FONT_ICON_RIGHT_FROM_BRACKET = "\xEF\x8B\xB5";
@@ -105,6 +107,8 @@ MAYBE_UNUSED static const char *FONT_ICON_RIGHT_TO_BRACKET = "\xEF\x8B\xB6";
 MAYBE_UNUSED static const char *FONT_ICON_ARROW_UP_RIGHT_FROM_SQUARE = "\xEF\x82\x8E";
 MAYBE_UNUSED static const char *FONT_ICON_BACKWARD_STEP = "\xEF\x81\x88";
 MAYBE_UNUSED static const char *FONT_ICON_FORWARD_STEP = "\xEF\x81\x91";
+MAYBE_UNUSED static const char *FONT_ICON_BACKWARD_FAST = "\xEF\x81\x89";
+MAYBE_UNUSED static const char *FONT_ICON_FORWARD_FAST = "\xEF\x81\x90";
 MAYBE_UNUSED static const char *FONT_ICON_KEYBOARD = "\xE2\x8C\xA8";
 MAYBE_UNUSED static const char *FONT_ICON_ELLIPSIS = "\xEF\x85\x81";
 


### PR DESCRIPTION
Make the skipping duration adjustable with a dropdown menu. The dropdown menu includes the durations 1s, 5s, 10s, 30s, 1m, 5m and 10m. The default duration is 5s. Skipping durations longer than the current demo are not shown. The dropdown menu is only shown if two or more durations would be shown.

Add buttons for skipping the duration, which was previously only possible with the hotkeys.

Add Ctrl+Left/Right hotkeys for skipping to chapters.

Add Shift+Left/Right hotkeys for adjusting the skipping time.

The Left/Right arrow keys and the J/L keys work identically for all hotkeys now.

Ignore ctrl, shift and alt keys for demo speed changes with the mouse wheel, to better support actions like zooming being bound to alt+mousewheel etc.

Also handle keypad enter key for play/pause like the normal return key.

Use arrow up/down icon for speed adjustment buttons, so that the "backward/forward" icons can be used for duration skipping instead.

Closes #7064.

Screenshots:
- Before: 
![screenshot_2023-09-13_21-07-23](https://github.com/ddnet/ddnet/assets/23437060/0dca183c-0ba0-4ede-b0a7-00eac282149a)
- After:
![screenshot_2023-09-13_21-08-26](https://github.com/ddnet/ddnet/assets/23437060/e125d354-63b9-4ea1-a339-70f389fe32e7)
- Changes:
![changes](https://github.com/ddnet/ddnet/assets/23437060/18c9d507-42f9-4b1e-83b4-b8c957fa6b76)

## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
