### PR TITLE
Ability to show local keypresses only

### DIFF
--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -399,10 +399,9 @@ MACRO_CONFIG_COL(ClHookCollColorTeeColl, cl_hook_coll_color_tee_coll, 2817919, C
 
 MACRO_CONFIG_INT(ClChatTeamColors, cl_chat_teamcolors, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show names in chat in team colors")
 MACRO_CONFIG_INT(ClChatReset, cl_chat_reset, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Reset chat when pressing escape")
-MACRO_CONFIG_INT(ClChatOld, cl_chat_old, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Old chat style: No tee, no background");
+MACRO_CONFIG_INT(ClChatOld, cl_chat_old, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Old chat style: No tee, no background")
 
-MACRO_CONFIG_INT(ClShowDirectionOther, cl_show_direction_other, 1, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Show other players' key presses")
-MACRO_CONFIG_INT(ClShowDirectionOwn, cl_show_direction_own, 0, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Show local player's key presses")
+MACRO_CONFIG_INT(ClShowDirection, cl_show_direction, 1, 0, 3, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Show key presses (1 = other players', 2 = also your own, 3 = only your own")
 MACRO_CONFIG_INT(ClOldGunPosition, cl_old_gun_position, 0, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Tees hold gun a bit higher like in TW 0.6.1 and older")
 MACRO_CONFIG_INT(ClConfirmDisconnectTime, cl_confirm_disconnect_time, 20, -1, 1440, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Confirmation popup before disconnecting after game time (in minutes, -1 to turn off, 0 to always turn on)")
 MACRO_CONFIG_INT(ClConfirmQuitTime, cl_confirm_quit_time, 20, -1, 1440, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Confirmation popup before quitting after game time (in minutes, -1 to turn off, 0 to always turn on)")

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -401,7 +401,8 @@ MACRO_CONFIG_INT(ClChatTeamColors, cl_chat_teamcolors, 0, 0, 1, CFGFLAG_CLIENT |
 MACRO_CONFIG_INT(ClChatReset, cl_chat_reset, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Reset chat when pressing escape")
 MACRO_CONFIG_INT(ClChatOld, cl_chat_old, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Old chat style: No tee, no background");
 
-MACRO_CONFIG_INT(ClShowDirection, cl_show_direction, 1, 0, 2, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Show key presses (1 = other players', 2 = also your own)")
+MACRO_CONFIG_INT(ClShowDirectionOther, cl_show_direction_other, 1, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Show other players' key presses")
+MACRO_CONFIG_INT(ClShowDirectionOwn, cl_show_direction_own, 0, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Show local player's key presses")
 MACRO_CONFIG_INT(ClOldGunPosition, cl_old_gun_position, 0, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Tees hold gun a bit higher like in TW 0.6.1 and older")
 MACRO_CONFIG_INT(ClConfirmDisconnectTime, cl_confirm_disconnect_time, 20, -1, 1440, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Confirmation popup before disconnecting after game time (in minutes, -1 to turn off, 0 to always turn on)")
 MACRO_CONFIG_INT(ClConfirmQuitTime, cl_confirm_quit_time, 20, -1, 1440, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Confirmation popup before quitting after game time (in minutes, -1 to turn off, 0 to always turn on)")

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -2798,8 +2798,47 @@ void CMenus::RenderSettingsAppearance(CUIRect MainView)
 
 		DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClNameplatesTeamcolors, Localize("Use team colors for name plates"), &g_Config.m_ClNameplatesTeamcolors, &Section, LineSize);
 		DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClNameplatesStrong, Localize("Show hook strength indicator"), &g_Config.m_ClNameplatesStrong, &Section, LineSize);
-		DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClShowDirectionOther, Localize("Show other players' key presses"), &g_Config.m_ClShowDirectionOther, &Section, LineSize);
-		DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClShowDirectionOwn, Localize("Show local player's key presses"), &g_Config.m_ClShowDirectionOwn, &Section, LineSize);
+
+		Section.HSplitTop(LineSize, &Button, &Section);
+		if(DoButton_CheckBox(&g_Config.m_ClShowDirection, Localize("Show other players' key presses"), g_Config.m_ClShowDirection >= 1 && g_Config.m_ClShowDirection != 3, &Button))
+		{
+			switch(g_Config.m_ClShowDirection)
+			{
+			case 0:
+				g_Config.m_ClShowDirection = 1;
+				break;
+			case 1:
+				g_Config.m_ClShowDirection = 0;
+				break;
+			case 2:
+				g_Config.m_ClShowDirection = 3;
+				break;
+			case 3:
+				g_Config.m_ClShowDirection = 2;
+				break;
+			}
+		}
+
+		Section.HSplitTop(LineSize, &Button, &Section);
+		static int s_ShowLocalPlayer = 0;
+		if(DoButton_CheckBox(&s_ShowLocalPlayer, Localize("Show local player's key presses"), g_Config.m_ClShowDirection >= 2, &Button))
+		{
+			switch(g_Config.m_ClShowDirection)
+			{
+			case 0:
+				g_Config.m_ClShowDirection = 3;
+				break;
+			case 1:
+				g_Config.m_ClShowDirection = 2;
+				break;
+			case 2:
+				g_Config.m_ClShowDirection = 1;
+				break;
+			case 3:
+				g_Config.m_ClShowDirection = 0;
+				break;
+			}
+		}
 	}
 	else if(s_CurTab == APPEARANCE_TAB_HOOK_COLLISION)
 	{

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -2798,19 +2798,8 @@ void CMenus::RenderSettingsAppearance(CUIRect MainView)
 
 		DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClNameplatesTeamcolors, Localize("Use team colors for name plates"), &g_Config.m_ClNameplatesTeamcolors, &Section, LineSize);
 		DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClNameplatesStrong, Localize("Show hook strength indicator"), &g_Config.m_ClNameplatesStrong, &Section, LineSize);
-
-		Section.HSplitTop(LineSize, &Button, &Section);
-		if(DoButton_CheckBox(&g_Config.m_ClShowDirection, Localize("Show other players' key presses"), g_Config.m_ClShowDirection >= 1, &Button))
-		{
-			g_Config.m_ClShowDirection = g_Config.m_ClShowDirection >= 1 ? 0 : 1;
-		}
-
-		Section.HSplitTop(LineSize, &Button, &Section);
-		static int s_ShowLocalPlayer = 0;
-		if(DoButton_CheckBox(&s_ShowLocalPlayer, Localize("Show local player's key presses"), g_Config.m_ClShowDirection == 2, &Button))
-		{
-			g_Config.m_ClShowDirection = g_Config.m_ClShowDirection != 2 ? 2 : 1;
-		}
+		DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClShowDirectionOther, Localize("Show other players' key presses"), &g_Config.m_ClShowDirectionOther, &Section, LineSize);
+		DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClShowDirectionOwn, Localize("Show local player's key presses"), &g_Config.m_ClShowDirectionOwn, &Section, LineSize);
 	}
 	else if(s_CurTab == APPEARANCE_TAB_HOOK_COLLISION)
 	{

--- a/src/game/client/components/nameplates.cpp
+++ b/src/game/client/components/nameplates.cpp
@@ -44,12 +44,16 @@ void CNamePlates::RenderNameplatePos(vec2 Position, const CNetObj_PlayerInfo *pP
 	ColorRGBA rgb = ColorRGBA(1.0f, 1.0f, 1.0f);
 
 	// render players' key presses
-	int ShowDirection = g_Config.m_ClShowDirection;
+	int ShowDirectionOther = g_Config.m_ClShowDirectionOther;
+	int ShowDirectionOwn = g_Config.m_ClShowDirectionOwn;
 #if defined(CONF_VIDEORECORDER)
 	if(IVideo::Current())
-		ShowDirection = g_Config.m_ClVideoShowDirection;
+	{
+		ShowDirectionOther = g_Config.m_ClVideoShowDirectionOther;
+		ShowDirectionOwn = g_Config.m_ClVideoShowDirectionOwn;
+	}
 #endif
-	if((pPlayerInfo->m_Local && ShowDirection == 2) || (!pPlayerInfo->m_Local && ShowDirection >= 1))
+	if((ShowDirectionOther && !pPlayerInfo->m_Local) || (ShowDirectionOwn && pPlayerInfo->m_Local) || (ShowDirectionOwn && Client()->DummyConnected() && Client()->State() != IClient::STATE_DEMOPLAYBACK && ClientID == m_pClient->m_aLocalIDs[!g_Config.m_ClDummy]))
 	{
 		Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
 		Graphics()->QuadsSetRotation(0);
@@ -282,10 +286,10 @@ void CNamePlates::RenderNameplatePos(vec2 Position, const CNetObj_PlayerInfo *pP
 
 void CNamePlates::OnRender()
 {
-	int ShowDirection = g_Config.m_ClShowDirection;
+	int ShowDirection = (g_Config.m_ClShowDirectionOther || g_Config.m_ClShowDirectionOwn);
 #if defined(CONF_VIDEORECORDER)
 	if(IVideo::Current())
-		ShowDirection = g_Config.m_ClVideoShowDirection;
+		ShowDirection = (g_Config.m_ClVideoShowDirectionOther || g_Config.m_ClVideoShowDirectionOwn);
 #endif
 	if(!g_Config.m_ClNameplates && ShowDirection == 0)
 		return;

--- a/src/game/client/components/nameplates.cpp
+++ b/src/game/client/components/nameplates.cpp
@@ -44,16 +44,12 @@ void CNamePlates::RenderNameplatePos(vec2 Position, const CNetObj_PlayerInfo *pP
 	ColorRGBA rgb = ColorRGBA(1.0f, 1.0f, 1.0f);
 
 	// render players' key presses
-	int ShowDirectionOther = g_Config.m_ClShowDirectionOther;
-	int ShowDirectionOwn = g_Config.m_ClShowDirectionOwn;
+	int ShowDirection = g_Config.m_ClShowDirection;
 #if defined(CONF_VIDEORECORDER)
 	if(IVideo::Current())
-	{
-		ShowDirectionOther = g_Config.m_ClVideoShowDirectionOther;
-		ShowDirectionOwn = g_Config.m_ClVideoShowDirectionOwn;
-	}
+		ShowDirection = g_Config.m_ClVideoShowDirection;
 #endif
-	if((ShowDirectionOther && !pPlayerInfo->m_Local) || (ShowDirectionOwn && pPlayerInfo->m_Local) || (ShowDirectionOwn && Client()->DummyConnected() && Client()->State() != IClient::STATE_DEMOPLAYBACK && ClientID == m_pClient->m_aLocalIDs[!g_Config.m_ClDummy]))
+	if((ShowDirection && ShowDirection != 3 && !pPlayerInfo->m_Local) || (ShowDirection >= 2 && pPlayerInfo->m_Local) || (ShowDirection == 3 && Client()->DummyConnected() && Client()->State() != IClient::STATE_DEMOPLAYBACK && ClientID == m_pClient->m_aLocalIDs[!g_Config.m_ClDummy]))
 	{
 		Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
 		Graphics()->QuadsSetRotation(0);
@@ -286,10 +282,10 @@ void CNamePlates::RenderNameplatePos(vec2 Position, const CNetObj_PlayerInfo *pP
 
 void CNamePlates::OnRender()
 {
-	int ShowDirection = (g_Config.m_ClShowDirectionOther || g_Config.m_ClShowDirectionOwn);
+	int ShowDirection = g_Config.m_ClShowDirection;
 #if defined(CONF_VIDEORECORDER)
 	if(IVideo::Current())
-		ShowDirection = (g_Config.m_ClVideoShowDirectionOther || g_Config.m_ClVideoShowDirectionOwn);
+		ShowDirection = g_Config.m_ClVideoShowDirection;
 #endif
 	if(!g_Config.m_ClNameplates && ShowDirection == 0)
 		return;

--- a/src/game/variables.h
+++ b/src/game/variables.h
@@ -213,8 +213,7 @@ MACRO_CONFIG_INT(ClVideoShowhud, cl_video_showhud, 0, 0, 1, CFGFLAG_CLIENT | CFG
 MACRO_CONFIG_INT(ClVideoShowChat, cl_video_showchat, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show chat when rendering video")
 MACRO_CONFIG_INT(ClVideoSndEnable, cl_video_sound_enable, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Use sound when rendering video")
 MACRO_CONFIG_INT(ClVideoShowHookCollOther, cl_video_show_hook_coll_other, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show other players' hook collision lines when rendering video")
-MACRO_CONFIG_INT(ClVideoShowDirectionOther, cl_video_show_direction_other, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show other players' key presses when rendering video")
-MACRO_CONFIG_INT(ClVideoShowDirectionOwn, cl_video_show_direction_own, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show local player's key presses when rendering video")
+MACRO_CONFIG_INT(ClVideoShowDirection, cl_video_show_direction, 0, 0, 3, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show players' key presses when rendering video (1 = other players', 2 = also your own, 3 = only your own)")
 MACRO_CONFIG_INT(ClVideoX264Crf, cl_video_crf, 18, 0, 51, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Set crf when encode video with libx264 (0 for highest quality, 51 for lowest)")
 MACRO_CONFIG_INT(ClVideoX264Preset, cl_video_preset, 5, 0, 9, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Set preset when encode video with libx264, default is 5 (medium), 0 is ultrafast, 9 is placebo (the slowest, not recommend)")
 

--- a/src/game/variables.h
+++ b/src/game/variables.h
@@ -213,7 +213,8 @@ MACRO_CONFIG_INT(ClVideoShowhud, cl_video_showhud, 0, 0, 1, CFGFLAG_CLIENT | CFG
 MACRO_CONFIG_INT(ClVideoShowChat, cl_video_showchat, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show chat when rendering video")
 MACRO_CONFIG_INT(ClVideoSndEnable, cl_video_sound_enable, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Use sound when rendering video")
 MACRO_CONFIG_INT(ClVideoShowHookCollOther, cl_video_show_hook_coll_other, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show other players' hook collision lines when rendering video")
-MACRO_CONFIG_INT(ClVideoShowDirection, cl_video_show_direction, 0, 0, 2, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show players' key presses when rendering video (1 = other players', 2 = also your own)")
+MACRO_CONFIG_INT(ClVideoShowDirectionOther, cl_video_show_direction_other, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show other players' key presses when rendering video")
+MACRO_CONFIG_INT(ClVideoShowDirectionOwn, cl_video_show_direction_own, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show local player's key presses when rendering video")
 MACRO_CONFIG_INT(ClVideoX264Crf, cl_video_crf, 18, 0, 51, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Set crf when encode video with libx264 (0 for highest quality, 51 for lowest)")
 MACRO_CONFIG_INT(ClVideoX264Preset, cl_video_preset, 5, 0, 9, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Set preset when encode video with libx264, default is 5 (medium), 0 is ultrafast, 9 is placebo (the slowest, not recommend)")
 


### PR DESCRIPTION
Splits `cl_show_direction` into `cl_show_direction_other` and `cl_show_direction_own` allowing players to toggle them independently. 
`cl_show_direction_own` shows dummy keypresses as well (doesnt work in playback)

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
