### PR TITLE
Consistently name `CScrollRegion` and `CListBox` getters

### DIFF
--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1394,7 +1394,7 @@ void CMenus::RenderServerbrowserFriends(CUIRect View)
 
 	// friends list
 	static CScrollRegion s_ScrollRegion;
-	if(!s_ScrollRegion.IsScrollbarShown())
+	if(!s_ScrollRegion.ScrollbarShown())
 		List.VSplitRight(3.0f, &List, nullptr);
 	vec2 ScrollOffset(0.0f, 0.0f);
 	CScrollRegionParams ScrollParams;
@@ -1455,7 +1455,7 @@ void CMenus::RenderServerbrowserFriends(CUIRect View)
 				const auto &Friend = m_avFriends[FriendType][FriendIndex];
 				List.HSplitTop(11.0f + 10.0f + 2 * 2.0f + 1.0f + (Friend.ServerInfo() == nullptr ? 0.0f : 10.0f), &Rect, &List);
 				s_ScrollRegion.AddRect(Rect);
-				if(s_ScrollRegion.IsRectClipped(Rect))
+				if(s_ScrollRegion.RectClipped(Rect))
 					continue;
 
 				const bool Inside = UI()->MouseHovered(&Rect);

--- a/src/game/client/ui_listbox.cpp
+++ b/src/game/client/ui_listbox.cpp
@@ -17,7 +17,7 @@ CListBox::CListBox()
 	m_FilterOffset = 0.0f;
 	m_HasHeader = false;
 	m_AutoSpacing = 0.0f;
-	m_ScrollbarIsShown = false;
+	m_ScrollbarShown = false;
 	m_Active = true;
 }
 
@@ -140,7 +140,7 @@ CListboxItem CListBox::DoNextRow()
 	m_RowView.VSplitLeft(m_RowView.w / (m_ListBoxItemsPerRow - m_ListBoxItemIndex % m_ListBoxItemsPerRow), &Item.m_Rect, &m_RowView);
 
 	Item.m_Selected = m_ListBoxSelectedIndex == m_ListBoxItemIndex;
-	Item.m_Visible = !m_ScrollRegion.IsRectClipped(Item.m_Rect);
+	Item.m_Visible = !m_ScrollRegion.RectClipped(Item.m_Rect);
 
 	m_ListBoxItemIndex++;
 	return Item;
@@ -188,7 +188,7 @@ CListboxItem CListBox::DoNextItem(const void *pId, bool Selected)
 
 		Item.m_Rect.Draw(ColorRGBA(1.0f, 1.0f, 1.0f, m_Active ? 0.5f : 0.33f), IGraphics::CORNER_ALL, 5.0f);
 	}
-	if(UI()->HotItem() == pId && !m_ScrollRegion.IsAnimating())
+	if(UI()->HotItem() == pId && !m_ScrollRegion.Animating())
 	{
 		Item.m_Rect.Draw(ColorRGBA(1.0f, 1.0f, 1.0f, 0.33f), IGraphics::CORNER_ALL, 5.0f);
 	}
@@ -208,7 +208,7 @@ int CListBox::DoEnd()
 	m_ScrollRegion.End();
 	m_Active |= m_ScrollRegion.Params().m_Active;
 
-	m_ScrollbarIsShown = m_ScrollRegion.IsScrollbarShown();
+	m_ScrollbarShown = m_ScrollRegion.ScrollbarShown();
 	if(m_ListBoxNewSelOffset != 0 && m_ListBoxNumItems > 0 && m_ListBoxSelectedIndex == m_ListBoxNewSelected)
 	{
 		m_ListBoxNewSelected = clamp((m_ListBoxNewSelected == -1 ? 0 : m_ListBoxNewSelected) + m_ListBoxNewSelOffset, 0, m_ListBoxNumItems - 1);

--- a/src/game/client/ui_listbox.h
+++ b/src/game/client/ui_listbox.h
@@ -29,7 +29,7 @@ private:
 	int m_ListBoxItemsPerRow;
 	bool m_ListBoxItemSelected;
 	bool m_ListBoxItemActivated;
-	bool m_ScrollbarIsShown;
+	bool m_ScrollbarShown;
 	const char *m_pBottomText;
 	float m_FooterHeight;
 	float m_AutoSpacing;
@@ -64,8 +64,8 @@ public:
 	bool WasItemSelected() const { return m_ListBoxItemSelected; }
 	bool WasItemActivated() const { return m_ListBoxItemActivated; }
 
-	bool ScrollbarIsShown() const { return m_ScrollbarIsShown; }
-	float ScrollbarWidth() const { return ScrollbarIsShown() ? ScrollbarWidthMax() : 0.0f; }
+	bool ScrollbarShown() const { return m_ScrollbarShown; }
+	float ScrollbarWidth() const { return ScrollbarShown() ? ScrollbarWidthMax() : 0.0f; }
 	float ScrollbarWidthMax() const { return 20.0f; }
 };
 

--- a/src/game/client/ui_scrollregion.cpp
+++ b/src/game/client/ui_scrollregion.cpp
@@ -193,7 +193,7 @@ bool CScrollRegion::AddRect(const CUIRect &Rect, bool ShouldScrollHere)
 	m_ContentH = maximum(std::ceil(Rect.y + Rect.h - (m_ClipRect.y + m_ContentScrollOff.y)) + HEIGHT_MAGIC_FIX, m_ContentH);
 	if(ShouldScrollHere)
 		ScrollHere();
-	return !IsRectClipped(Rect);
+	return !RectClipped(Rect);
 }
 
 void CScrollRegion::ScrollHere(EScrollOption Option)
@@ -230,7 +230,7 @@ void CScrollRegion::ScrollRelative(EScrollRelative Direction, float SpeedMultipl
 
 void CScrollRegion::DoEdgeScrolling()
 {
-	if(!IsScrollbarShown())
+	if(!ScrollbarShown())
 		return;
 
 	const float ScrollBorderSize = 20.0f;
@@ -244,17 +244,17 @@ void CScrollRegion::DoEdgeScrolling()
 		ScrollRelative(SCROLLRELATIVE_DOWN, minimum(MaxScrollMultiplier, (UI()->MouseY() - BottomScrollPosition) * ScrollSpeedFactor));
 }
 
-bool CScrollRegion::IsRectClipped(const CUIRect &Rect) const
+bool CScrollRegion::RectClipped(const CUIRect &Rect) const
 {
 	return (m_ClipRect.x > (Rect.x + Rect.w) || (m_ClipRect.x + m_ClipRect.w) < Rect.x || m_ClipRect.y > (Rect.y + Rect.h) || (m_ClipRect.y + m_ClipRect.h) < Rect.y);
 }
 
-bool CScrollRegion::IsScrollbarShown() const
+bool CScrollRegion::ScrollbarShown() const
 {
 	return m_ContentH > m_ClipRect.h;
 }
 
-bool CScrollRegion::IsAnimating() const
+bool CScrollRegion::Animating() const
 {
 	return m_AnimTime > 0.0f;
 }

--- a/src/game/client/ui_scrollregion.h
+++ b/src/game/client/ui_scrollregion.h
@@ -68,7 +68,7 @@ Usage:
 	s_ScrollRegion.AddRect(Rect);
 
 	-- [Optional] Knowing if a rect is clipped --
-	s_ScrollRegion.IsRectClipped(Rect);
+	s_ScrollRegion.RectClipped(Rect);
 
 	-- [Optional] Scroll to a rect (to the last added rect)--
 	...
@@ -137,9 +137,9 @@ public:
 	void ScrollRelative(EScrollRelative Direction, float SpeedMultiplier = 1.0f);
 	const CUIRect *ClipRect() const { return &m_ClipRect; }
 	void DoEdgeScrolling();
-	bool IsRectClipped(const CUIRect &Rect) const;
-	bool IsScrollbarShown() const;
-	bool IsAnimating() const;
+	bool RectClipped(const CUIRect &Rect) const;
+	bool ScrollbarShown() const;
+	bool Animating() const;
 	const CScrollRegionParams &Params() const { return m_Params; }
 };
 


### PR DESCRIPTION
Remove `Is` from the getter names for the same reason that removing `Get` from the name is preferred. The word `Is` was inconsistently used as a prefix in `CScrollRegion` but as an infix in `CListBox`.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
