### PR TITLE
Remove unnecessary return value of `net_init`

### DIFF
--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -2209,16 +2209,12 @@ int net_would_block()
 #endif
 }
 
-int net_init()
+void net_init()
 {
 #if defined(CONF_FAMILY_WINDOWS)
-	WSADATA wsaData;
-	int err = WSAStartup(MAKEWORD(1, 1), &wsaData);
-	dbg_assert(err == 0, "network initialization failed.");
-	return err == 0 ? 0 : 1;
+	WSADATA wsa_data;
+	dbg_assert(WSAStartup(MAKEWORD(1, 1), &wsa_data) == 0, "network initialization failed.");
 #endif
-
-	return 0;
 }
 
 #if defined(CONF_FAMILY_UNIX)

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -879,11 +879,9 @@ typedef struct sockaddr_un UNIXSOCKETADDR;
  *
  * @ingroup Network-General
  *
- * @return 0 on success.
- *
  * @remark You must call this function before using any other network functions.
  */
-int net_init();
+void net_init();
 
 /*
 	Function: net_host_lookup


### PR DESCRIPTION
The return value is unused and always 0, as the function fails with an assertion instead of returning an error value.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
