### PR TITLE
Overhaul server browser filter, details and friends tabs

### DIFF
--- a/src/engine/textrender.h
+++ b/src/engine/textrender.h
@@ -91,6 +91,8 @@ MAYBE_UNUSED static const char *FONT_ICON_GEAR = "\xEF\x80\x93";
 MAYBE_UNUSED static const char *FONT_ICON_PEN_TO_SQUARE = "\xEF\x81\x84";
 MAYBE_UNUSED static const char *FONT_ICON_CLAPPERBOARD = "\xEE\x84\xB1";
 MAYBE_UNUSED static const char *FONT_ICON_EARTH_AMERICAS = "\xEF\x95\xBD";
+MAYBE_UNUSED static const char *FONT_ICON_LIST_UL = "\xEF\x83\x8A";
+MAYBE_UNUSED static const char *FONT_ICON_INFO = "\xEF\x84\xA9";
 
 MAYBE_UNUSED static const char *FONT_ICON_SLASH = "\xEF\x9C\x95";
 MAYBE_UNUSED static const char *FONT_ICON_PLAY = "\xEF\x81\x8B";

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -409,8 +409,6 @@ protected:
 	std::vector<CFriendItem> m_avFriends[NUM_FRIEND_TYPES];
 	const CFriendItem *m_pRemoveFriend = nullptr;
 
-	void FriendlistOnUpdate();
-
 	// found in menus.cpp
 	int Render();
 #if defined(CONF_VIDEORECORDER)
@@ -454,11 +452,19 @@ protected:
 	// found in menus_browser.cpp
 	int m_SelectedIndex;
 	bool m_ServerBrowserShouldRevealSelection;
-	void RenderServerbrowserServerList(CUIRect View);
+	void RenderServerbrowserServerList(CUIRect View, bool &WasListboxItemActivated);
+	void RenderServerbrowserStatusBox(CUIRect StatusBox, bool WasListboxItemActivated);
 	void Connect(const char *pAddress);
 	void PopupConfirmSwitchServer();
-	void RenderServerbrowserServerDetail(CUIRect View);
 	void RenderServerbrowserFilters(CUIRect View);
+	void RenderServerbrowserDDNetFilter(CUIRect View,
+		char *pFilterExclude, int FilterExcludeSize,
+		float ItemHeight, int MaxItems, int ItemsPerRow,
+		CScrollRegion &ScrollRegion, std::vector<unsigned char> &vItemIds,
+		const std::function<const char *(int ItemIndex)> &GetItemName,
+		const std::function<void(int ItemIndex, CUIRect Item, const void *pItemId, bool Active)> &RenderItem);
+	void RenderServerbrowserCountriesFilter(CUIRect View, int Network);
+	void RenderServerbrowserTypesFilter(CUIRect View, int Network);
 	struct SPopupCountrySelectionContext
 	{
 		CMenus *m_pMenus;
@@ -466,11 +472,17 @@ protected:
 		bool m_New;
 	};
 	static CUI::EPopupMenuFunctionResult PopupCountrySelection(void *pContext, CUIRect View, bool Active);
+	void RenderServerbrowserInfo(CUIRect View);
+	void RenderServerbrowserInfoScoreboard(CUIRect View, const CServerInfo *pSelectedServer);
 	void RenderServerbrowserFriends(CUIRect View);
+	void FriendlistOnUpdate();
 	void PopupConfirmRemoveFriend();
+	void RenderServerbrowserTabBar(CUIRect TabBar);
+	void RenderServerbrowserToolBox(CUIRect ToolBox);
 	void RenderServerbrowser(CUIRect MainView);
 	template<typename F>
 	bool PrintHighlighted(const char *pName, F &&PrintFn);
+	CTeeRenderInfo GetTeeRenderInfo(vec2 Size, const char *pSkinName, bool CustomSkinColors, int CustomSkinColorBody, int CustomSkinColorFeet) const;
 	static void ConchainFriendlistUpdate(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 	static void ConchainServerbrowserUpdate(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 
@@ -583,6 +595,9 @@ public:
 		SMALL_TAB_EDITOR,
 		SMALL_TAB_DEMOBUTTON,
 		SMALL_TAB_SERVER,
+		SMALL_TAB_BROWSER_FILTER,
+		SMALL_TAB_BROWSER_INFO,
+		SMALL_TAB_BROWSER_FRIENDS,
 
 		SMALL_TAB_LENGTH,
 	};

--- a/src/game/client/ui_listbox.cpp
+++ b/src/game/client/ui_listbox.cpp
@@ -14,7 +14,8 @@ CListBox::CListBox()
 {
 	m_ScrollOffset = vec2(0.0f, 0.0f);
 	m_ListBoxUpdateScroll = false;
-	m_FilterOffset = 0.0f;
+	m_ScrollbarWidth = 20.0f;
+	m_ScrollbarMargin = 5.0f;
 	m_HasHeader = false;
 	m_AutoSpacing = 0.0f;
 	m_ScrollbarShown = false;
@@ -118,6 +119,7 @@ void CListBox::DoStart(float RowHeight, int NumItems, int ItemsPerRow, int RowsP
 	CScrollRegionParams ScrollParams;
 	ScrollParams.m_Active = m_Active;
 	ScrollParams.m_ScrollbarWidth = ScrollbarWidthMax();
+	ScrollParams.m_ScrollbarMargin = ScrollbarMargin();
 	ScrollParams.m_ScrollUnit = (m_ListBoxRowHeight + m_AutoSpacing) * RowsPerScroll;
 	ScrollParams.m_Flags = ForceShowScrollbar ? CScrollRegionParams::FLAG_CONTENT_STATIC_WIDTH : 0;
 	m_ScrollRegion.Begin(&m_ListBoxView, &m_ScrollOffset, &ScrollParams);

--- a/src/game/client/ui_listbox.h
+++ b/src/game/client/ui_listbox.h
@@ -35,8 +35,9 @@ private:
 	float m_AutoSpacing;
 	CScrollRegion m_ScrollRegion;
 	vec2 m_ScrollOffset;
-	float m_FilterOffset;
 	int m_BackgroundCorners;
+	float m_ScrollbarWidth;
+	float m_ScrollbarMargin;
 	bool m_HasHeader;
 	bool m_Active;
 
@@ -66,7 +67,10 @@ public:
 
 	bool ScrollbarShown() const { return m_ScrollbarShown; }
 	float ScrollbarWidth() const { return ScrollbarShown() ? ScrollbarWidthMax() : 0.0f; }
-	float ScrollbarWidthMax() const { return 20.0f; }
+	float ScrollbarWidthMax() const { return m_ScrollbarWidth; }
+	void SetScrollbarWidth(float Width) { m_ScrollbarWidth = Width; }
+	float ScrollbarMargin() const { return m_ScrollbarMargin; }
+	void SetScrollbarMargin(float Margin) { m_ScrollbarMargin = Margin; }
 };
 
 #endif


### PR DESCRIPTION
Move the "Filter", "Info" and "Friends" tabs to the top, above the tab content. Use icons instead of text for the tabs. Use animator to animate the tabs on mouse-over. Closes #6613.

Make spacings, corners and font sizes used in the filter, details and friends tabs more consistent.

Remove some unnecessary dark UI rect backgrounds.

Improve alignment of the number of friends with the heart icon for entries in the server list.

Improve layout of countries and types filters. Make the filters scrollable when there are many entries.

Refactor most of the server browser in preparation for replacing the DDNet and KoG tabs with a community filter, which will work like the countries and types filters. Split rendering of different server browser sections into multiple functions to improve readability. Reduce duplicate code for the countries and types filters.

Screenshots:
- Filter:
   - Before: 
![filter old](https://github.com/ddnet/ddnet/assets/23437060/8734196b-278a-4a02-8ae3-04650de46bc3)
   - After:
![filter new](https://github.com/ddnet/ddnet/assets/23437060/7e1a9cfb-91e5-4916-8bcd-0c5a288b504c)
- Info:
   - Before: 
![info old](https://github.com/ddnet/ddnet/assets/23437060/12238f6e-9ae6-4d80-b72d-83b3a10158d2)
   - After:
![info new](https://github.com/ddnet/ddnet/assets/23437060/b6db6aba-7b48-4e66-abd7-f94c896f97b2)
- Friends:
   - Before: 
![friends old](https://github.com/ddnet/ddnet/assets/23437060/d99acf8a-63c0-4a88-9dfb-91be0bb1183e)
   - After:
![friends new](https://github.com/ddnet/ddnet/assets/23437060/a0435e14-bc9c-45d2-b9ba-d0360e7ba08f)

## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
