### PR TITLE
Add config for gold angle teams color

### DIFF
--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -767,10 +767,18 @@ bool CGameClient::Predict() const
 
 ColorRGBA CGameClient::GetDDTeamColor(int DDTeam, float Lightness) const
 {
-	// Use golden angle to generate unique colors with distinct adjacent colors.
-	// The first DDTeam (team 1) gets angle 0°, i.e. red hue.
-	const float Hue = std::fmod((DDTeam - 1) * (137.50776f / 360.0f), 1.0f);
-	return color_cast<ColorRGBA>(ColorHSLA(Hue, 1.0f, Lightness));
+	if(g_Config.m_ClTeamsGoldAngle)
+	{
+		// Use golden angle to generate unique colors with distinct adjacent colors.
+		// The first DDTeam (team 1) gets angle 0°, i.e. red hue.
+		const float Hue = std::fmod((DDTeam - 1) * (137.50776f / 360.0f), 1.0f);
+		return color_cast<ColorRGBA>(ColorHSLA(Hue, 1.0f, Lightness));
+	}
+	else
+	{
+		// Old rainbow teams color
+		return color_cast<ColorRGBA>(ColorHSLA(DDTeam / 64.f, 1.f, Lightness));
+	}
 }
 
 void CGameClient::OnRelease()

--- a/src/game/variables.h
+++ b/src/game/variables.h
@@ -129,6 +129,7 @@ MACRO_CONFIG_STR(ClPlayerSkin, player_skin, 24, "default", CFGFLAG_CLIENT | CFGF
 MACRO_CONFIG_INT(ClPlayerDefaultEyes, player_default_eyes, 0, 0, 5, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Player eyes when joining server. 0 = normal, 1 = pain, 2 = happy, 3 = surprise, 4 = angry, 5 = blink")
 MACRO_CONFIG_STR(ClSkinPrefix, cl_skin_prefix, 12, "", CFGFLAG_CLIENT | CFGFLAG_SAVE, "Replace the skins by skins with this prefix (e.g. kitty, santa)")
 MACRO_CONFIG_INT(ClFatSkins, cl_fat_skins, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Enable fat skins")
+MACRO_CONFIG_INT(ClTeamsGoldAngle, cl_teams_gold_angle, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Use gold angle colors for teams")
 
 MACRO_CONFIG_INT(UiPage, ui_page, 9, 6, 10, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Interface page")
 MACRO_CONFIG_INT(UiSettingsPage, ui_settings_page, 0, 0, 9, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Interface settings page")


### PR DESCRIPTION
I think many players will be unhappy with the new colors for teams as it will change the colors of their favorite teams, so I suggest adding this variable to the config.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
