### PR TITLE
Add prediction flag and custom starttick to ddnetlaser

### DIFF
--- a/datasrc/network.py
+++ b/datasrc/network.py
@@ -36,6 +36,9 @@ LegacyProjectileFlags = [f"CLIENTID_BIT{i}" for i in range(8)] + [
 ProjectileFlags = [
 	"BOUNCE_HORIZONTAL", "BOUNCE_VERTICAL", "EXPLOSIVE", "FREEZE", "NORMALIZE_VEL",
 ]
+LaserFlags = [
+	"NO_PREDICT",
+]
 
 LaserTypes = ["RIFLE", "SHOTGUN", "DOOR", "FREEZE", "DRAGGER", "GUN", "PLASMA"]
 DraggerTypes = ["WEAK", "WEAK_NW", "NORMAL", "NORMAL_NW", "STRONG", "STRONG_NW"]
@@ -100,6 +103,7 @@ Flags = [
 	Flags("EXPLAYERFLAG", ExPlayerFlags),
 	Flags("LEGACYPROJECTILEFLAG", LegacyProjectileFlags),
 	Flags("PROJECTILEFLAG", ProjectileFlags),
+	Flags("LASERFLAG", LaserFlags),
 ]
 
 Objects = [
@@ -294,6 +298,7 @@ Objects = [
 		NetIntAny("m_Type"),
 		NetIntAny("m_SwitchNumber", -1),
 		NetIntAny("m_Subtype", -1),
+		NetIntAny("m_Flags", 0),
 	]),
 
 	NetObjectEx("DDNetProjectile", "ddnet-projectile@netobj.ddnet.tw", [

--- a/src/game/client/components/items.cpp
+++ b/src/game/client/components/items.cpp
@@ -472,38 +472,46 @@ void CItems::OnRender()
 			CLaserData Data = ExtractLaserInfo(Item.m_Type, pData, &GameClient()->m_GameWorld, pEntEx);
 			bool Inactive = !IsSuper && Data.m_SwitchNumber > 0 && Data.m_SwitchNumber < (int)aSwitchers.size() && !aSwitchers[Data.m_SwitchNumber].m_aStatus[SwitcherTeam];
 
+			bool IsEntBlink = false;
+			int EntStartTick = -1;
 			if(Data.m_Type == LASERTYPE_FREEZE)
 			{
-				if(Inactive && BlinkingLight)
-					continue;
-				Data.m_StartTick = DraggerStartTick;
+				IsEntBlink = BlinkingLight;
+				EntStartTick = DraggerStartTick;
 			}
 			else if(Data.m_Type == LASERTYPE_GUN)
 			{
-				if(Inactive && BlinkingGun)
-					continue;
-				Data.m_StartTick = GunStartTick;
+				IsEntBlink = BlinkingGun;
+				EntStartTick = GunStartTick;
 			}
 			else if(Data.m_Type == LASERTYPE_DRAGGER)
 			{
-				if(Inactive && BlinkingDragger)
-					continue;
-				Data.m_StartTick = DraggerStartTick;
+				IsEntBlink = BlinkingDragger;
+				EntStartTick = DraggerStartTick;
 			}
 			else if(Data.m_Type == LASERTYPE_DOOR)
 			{
-				if(Inactive || IsSuper)
+				if(Data.m_Predict && (Inactive || IsSuper))
 				{
 					Data.m_From.x = Data.m_To.x;
 					Data.m_From.y = Data.m_To.y;
 				}
-				Data.m_StartTick = Client()->GameTick(g_Config.m_ClDummy);
+				EntStartTick = Client()->GameTick(g_Config.m_ClDummy);
 			}
-			else if(Data.m_Type >= NUM_LASERTYPES)
+			else
 			{
-				if(Inactive && BlinkingDragger)
-					continue;
-				Data.m_StartTick = Client()->GameTick(g_Config.m_ClDummy);
+				IsEntBlink = BlinkingDragger;
+				EntStartTick = Client()->GameTick(g_Config.m_ClDummy);
+			}
+
+			if(Data.m_Predict && Inactive && IsEntBlink)
+			{
+				continue;
+			}
+
+			if(Data.m_StartTick <= 0 && EntStartTick != -1)
+			{
+				Data.m_StartTick = EntStartTick;
 			}
 
 			RenderLaser(&Data);

--- a/src/game/client/laser_data.cpp
+++ b/src/game/client/laser_data.cpp
@@ -32,6 +32,7 @@ CLaserData ExtractLaserInfo(int NetObjType, const void *pData, CGameWorld *pGame
 		Result.m_SwitchNumber = 0;
 		Result.m_Subtype = -1;
 		Result.m_TuneZone = pGameWorld && pGameWorld->m_WorldConfig.m_UseTuneZones ? pGameWorld->Collision()->IsTune(pGameWorld->Collision()->GetMapIndex(Result.m_From)) : 0;
+		Result.m_Predict = true;
 	}
 
 	if(pEntEx && !(NetObjType == NETOBJTYPE_DDNETLASER && Result.m_SwitchNumber >= 0))
@@ -72,5 +73,6 @@ CLaserData ExtractLaserInfoDDNet(const CNetObj_DDNetLaser *pLaser, CGameWorld *p
 	Result.m_SwitchNumber = pLaser->m_SwitchNumber;
 	Result.m_Subtype = pLaser->m_Subtype;
 	Result.m_TuneZone = pGameWorld && pGameWorld->m_WorldConfig.m_UseTuneZones ? pGameWorld->Collision()->IsTune(pGameWorld->Collision()->GetMapIndex(Result.m_From)) : 0;
+	Result.m_Predict = !(pLaser->m_Flags & LASERFLAG_NO_PREDICT);
 	return Result;
 }

--- a/src/game/client/laser_data.h
+++ b/src/game/client/laser_data.h
@@ -21,6 +21,7 @@ public:
 	int m_Type;
 	int m_SwitchNumber;
 	int m_Subtype;
+	bool m_Predict;
 	// TuneZone is introduced locally
 	int m_TuneZone;
 };

--- a/src/game/client/prediction/gameworld.cpp
+++ b/src/game/client/prediction/gameworld.cpp
@@ -492,8 +492,10 @@ void CGameWorld::NetObjAdd(int ObjID, int ObjType, const void *pObjData, const C
 	else if((ObjType == NETOBJTYPE_LASER || ObjType == NETOBJTYPE_DDNETLASER) && m_WorldConfig.m_PredictWeapons)
 	{
 		CLaserData Data = ExtractLaserInfo(ObjType, pObjData, this, pDataEx);
-		if(!IsLocalTeam(Data.m_Owner))
+		if(!IsLocalTeam(Data.m_Owner) || !Data.m_Predict)
+		{
 			return;
+		}
 
 		if(Data.m_Type == LASERTYPE_RIFLE || Data.m_Type == LASERTYPE_SHOTGUN || Data.m_Type < 0)
 		{

--- a/src/game/server/entities/door.cpp
+++ b/src/game/server/entities/door.cpp
@@ -58,7 +58,7 @@ void CDoor::Snap(int SnappingClient)
 	if(SnappingClientVersion >= VERSION_DDNET_ENTITY_NETOBJS)
 	{
 		From = m_To;
-		StartTick = 0;
+		StartTick = -1;
 	}
 	else
 	{

--- a/src/game/server/entities/dragger.cpp
+++ b/src/game/server/entities/dragger.cpp
@@ -212,7 +212,7 @@ void CDragger::Snap(int SnappingClient)
 	int StartTick;
 	if(SnappingClientVersion >= VERSION_DDNET_ENTITY_NETOBJS)
 	{
-		StartTick = 0;
+		StartTick = -1;
 	}
 	else
 	{

--- a/src/game/server/entities/dragger_beam.cpp
+++ b/src/game/server/entities/dragger_beam.cpp
@@ -121,13 +121,18 @@ void CDraggerBeam::Snap(int SnappingClient)
 		StartTick = Server()->Tick();
 	}
 
+	int SnappingClientVersion = GameServer()->GetClientVersion(SnappingClient);
+	if(SnappingClientVersion >= VERSION_DDNET_ENTITY_NETOBJS)
+	{
+		StartTick = -1;
+	}
+
 	int SnapObjID = GetID();
 	if(m_pDragger->WillDraggerBeamUseDraggerID(m_ForClientID, SnappingClient))
 	{
 		SnapObjID = m_pDragger->GetID();
 	}
 
-	int SnappingClientVersion = GameServer()->GetClientVersion(SnappingClient);
 	GameServer()->SnapLaserObject(CSnapContext(SnappingClientVersion), SnapObjID,
 		TargetPos, m_Pos, StartTick, m_ForClientID, LASERTYPE_DRAGGER, Subtype, m_Number);
 }

--- a/src/game/server/entities/gun.cpp
+++ b/src/game/server/entities/gun.cpp
@@ -154,7 +154,7 @@ void CGun::Snap(int SnappingClient)
 	int StartTick;
 	if(SnappingClientVersion >= VERSION_DDNET_ENTITY_NETOBJS)
 	{
-		StartTick = 0;
+		StartTick = -1;
 	}
 	else
 	{

--- a/src/game/server/entities/light.cpp
+++ b/src/game/server/entities/light.cpp
@@ -112,7 +112,7 @@ void CLight::Snap(int SnappingClient)
 		pChr = GameServer()->GetPlayerChar(GameServer()->m_apPlayers[SnappingClient]->m_SpectatorID);
 
 	vec2 From = m_Pos;
-	int StartTick = 0;
+	int StartTick = -1;
 
 	if(pChr && pChr->Team() == TEAM_SUPER)
 	{

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -396,6 +396,7 @@ bool CGameContext::SnapLaserObject(const CSnapContext &Context, int SnapID, cons
 		pObj->m_Type = LaserType;
 		pObj->m_Subtype = Subtype;
 		pObj->m_SwitchNumber = SwitchNumber;
+		pObj->m_Flags = 0;
 	}
 	else
 	{


### PR DESCRIPTION
Fixes #7155.

Is based on #7200, but adds a flag NO_PREDICT to `DDNetLaser` that can be used by mods to tell the client not to predict it (this also disables the client-side blinking effect in switch layer), while `StartTick` is handled independently (-1 is sent to let the client decide it for non-player lasers).

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
