### PR TITLE
Track UI elements separately for each server browser tab

### DIFF
--- a/src/engine/serverbrowser.h
+++ b/src/engine/serverbrowser.h
@@ -198,12 +198,12 @@ public:
 		QUICK_PLAYER = 2,
 		QUICK_MAPNAME = 4,
 
-		TYPE_NONE = 0,
-		TYPE_INTERNET = 1,
-		TYPE_LAN = 2,
-		TYPE_FAVORITES = 3,
-		TYPE_DDNET = 4,
-		TYPE_KOG = 5,
+		TYPE_INTERNET = 0,
+		TYPE_LAN,
+		TYPE_FAVORITES,
+		TYPE_DDNET,
+		TYPE_KOG,
+		NUM_TYPES,
 
 		// TODO: remove integer community index and used string IDs instead
 		NETWORK_DDNET = 0,

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -452,7 +452,7 @@ protected:
 	// found in menus_browser.cpp
 	int m_SelectedIndex;
 	bool m_ServerBrowserShouldRevealSelection;
-	std::vector<CUIElement *> m_vpServerBrowserUiElements;
+	std::vector<CUIElement *> m_avpServerBrowserUiElements[IServerBrowser::NUM_TYPES];
 	void RenderServerbrowserServerList(CUIRect View, bool &WasListboxItemActivated);
 	void RenderServerbrowserStatusBox(CUIRect StatusBox, bool WasListboxItemActivated);
 	void Connect(const char *pAddress);

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -230,18 +230,19 @@ void CMenus::RenderServerbrowserServerList(CUIRect View, bool &WasListboxItemAct
 		TextRender()->SetFontPreset(EFontPreset::DEFAULT_FONT);
 	};
 
-	if(m_vpServerBrowserUiElements.size() < (size_t)NumServers)
-		m_vpServerBrowserUiElements.resize(NumServers, nullptr);
+	std::vector<CUIElement *> &vpServerBrowserUiElements = m_avpServerBrowserUiElements[ServerBrowser()->GetCurrentType()];
+	if(vpServerBrowserUiElements.size() < (size_t)NumServers)
+		vpServerBrowserUiElements.resize(NumServers, nullptr);
 
 	for(int i = 0; i < NumServers; i++)
 	{
 		const CServerInfo *pItem = ServerBrowser()->SortedGet(i);
 
-		if(m_vpServerBrowserUiElements[i] == nullptr)
+		if(vpServerBrowserUiElements[i] == nullptr)
 		{
-			m_vpServerBrowserUiElements[i] = UI()->GetNewUIElement(NUM_UI_ELEMS);
+			vpServerBrowserUiElements[i] = UI()->GetNewUIElement(NUM_UI_ELEMS);
 		}
-		CUIElement *pUiElement = m_vpServerBrowserUiElements[i];
+		CUIElement *pUiElement = vpServerBrowserUiElements[i];
 
 		const CListboxItem ListItem = s_ListBox.DoNextItem(pItem, str_comp(pItem->m_aAddress, g_Config.m_UiServerAddress) == 0);
 		if(ListItem.m_Selected)

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -732,12 +732,10 @@ void CUI::DoLabelStreamed(CUIElement::SUIElementRect &RectEl, const CUIRect *pRe
 		DoLabel(RectEl, &TmpRect, pText, Size, TEXTALIGN_TL, LabelProps, StrLen, pReadCursor);
 	}
 
-	ColorRGBA ColorText(RectEl.m_TextColor);
-	ColorRGBA ColorTextOutline(RectEl.m_TextOutlineColor);
 	if(RectEl.m_UITextContainer.Valid())
 	{
 		const vec2 CursorPos = CalcAlignedCursorPos(pRect, vec2(RectEl.m_Cursor.m_LongestLineWidth, RectEl.m_Cursor.Height()), Align);
-		TextRender()->RenderTextContainer(RectEl.m_UITextContainer, ColorText, ColorTextOutline, CursorPos.x, CursorPos.y);
+		TextRender()->RenderTextContainer(RectEl.m_UITextContainer, RectEl.m_TextColor, RectEl.m_TextOutlineColor, CursorPos.x, CursorPos.y);
 	}
 }
 

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -690,7 +690,7 @@ void CUI::DoLabelStreamed(CUIElement::SUIElementRect &RectEl, const CUIRect *pRe
 {
 	bool NeedsRecreate = false;
 	bool ColorChanged = RectEl.m_TextColor != TextRender()->GetTextColor() || RectEl.m_TextOutlineColor != TextRender()->GetTextOutlineColor();
-	if(!RectEl.m_UITextContainer.Valid() || RectEl.m_Width != pRect->w || RectEl.m_Height != pRect->h || ColorChanged)
+	if((!RectEl.m_UITextContainer.Valid() && pText[0] != '\0' && StrLen != 0) || RectEl.m_Width != pRect->w || RectEl.m_Height != pRect->h || ColorChanged)
 	{
 		NeedsRecreate = true;
 	}


### PR DESCRIPTION
Fix highlighted text of server browser entries not being refresh correctly when switching tabs.

This also reduces lag when switching tabs, as the UI elements for all tabs are now cached and don't need to be recreated when switching.

Regression from #7203.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
