### PR TITLE
Fix background color in ingame server browser filter tab

### DIFF
--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -729,7 +729,7 @@ void CMenus::RenderServerbrowserFilters(CUIRect View)
 		View.HSplitTop(19.0f, &Button, &View);
 		View.HSplitTop(minimum(120.0f + CScrollRegion::HEIGHT_MAGIC_FIX, View.h), &TabContents, &View);
 		Button.VSplitMid(&CountriesTab, &TypesTab);
-		TabContents.Draw(ms_ColorTabbarInactive, IGraphics::CORNER_B, 4.0f);
+		TabContents.Draw(ColorActive, IGraphics::CORNER_B, 4.0f);
 
 		enum EFilterTab
 		{


### PR DESCRIPTION
Make background color of the tab content consistent with the color of the tab bar.

Regression from #7190.

Screenshots:
- Before:
![screenshot_2023-09-20_17-56-23](https://github.com/ddnet/ddnet/assets/23437060/ad009f2a-27ba-4b3c-9820-28e708920a7a)
- After:
![screenshot_2023-09-20_17-55-32](https://github.com/ddnet/ddnet/assets/23437060/e87ed011-a6d2-4360-8ba2-3a2a5b634f3a)


## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
