### PR TITLE
Add a hint for leaving /pause

### DIFF
--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -1428,6 +1428,22 @@ void CHud::RenderSpectatorHud()
 	TextRender()->Text(m_Width - 174.0f, m_Height - 15.0f + (15.f - 8.f) / 2.f, 8.0f, aBuf, -1.0f);
 }
 
+void CHud::RenderSpectateHint()
+{
+	if(m_pClient->m_Menus.IsActive() || g_Config.m_Debug)
+		return;
+
+	const float Height = 300.0f;
+	const float Width = Height * Graphics()->ScreenAspect();
+	Graphics()->MapScreen(0.0f, 0.0f, Width, Height);
+
+	const float FontSize = 5.0f;
+	const float Spacing = 5.0f;
+
+	TextRender()->TextColor(TextRender()->DefaultTextColor());
+	TextRender()->Text(Spacing, Height - FontSize - Spacing, FontSize, Localize("Spectating. Press Q or P again to stop spectating."));
+}
+
 void CHud::RenderLocalTime(float x)
 {
 	if(!g_Config.m_ClShowLocalTimeAlways && !m_pClient->m_Scoreboard.Active())
@@ -1488,6 +1504,10 @@ void CHud::OnRender()
 			if(SpectatorID != SPEC_FREEVIEW)
 			{
 				RenderMovementInformation(SpectatorID);
+			}
+			if(m_pClient->m_Snap.m_apInfoByName[m_pClient->m_Snap.m_LocalClientID] && m_pClient->m_Snap.m_apInfoByName[m_pClient->m_Snap.m_LocalClientID]->m_Team != TEAM_SPECTATORS)
+			{
+				RenderSpectateHint();
 			}
 			RenderSpectatorHud();
 		}

--- a/src/game/client/components/hud.h
+++ b/src/game/client/components/hud.h
@@ -66,6 +66,7 @@ class CHud : public CComponent
 	void RenderSuddenDeath();
 	void RenderScoreHud();
 	void RenderSpectatorHud();
+	void RenderSpectateHint();
 	void RenderWarmupTimer();
 	void RenderLocalTime(float x);
 


### PR DESCRIPTION
Adds a hint to tell the user how to leave `/pause`. Closes #3121 
![image](https://github.com/ddnet/ddnet/assets/141338449/73f3c98c-04b1-426e-aaca-5c9689428820)

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
