### PR TITLE
Fix double-click handling with `gfx_asyncrender_old 0`

### DIFF
--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -557,6 +557,9 @@ int CInput::Update()
 	// keep the counter between 1..0xFFFF, 0 means not pressed
 	m_InputCounter = (m_InputCounter % 0xFFFF) + 1;
 
+	// Ensure that we have the latest keyboard, mouse and joystick state
+	SDL_PumpEvents();
+
 	int NumKeyStates;
 	const Uint8 *pState = SDL_GetKeyboardState(&NumKeyStates);
 	if(NumKeyStates >= KEY_MOUSE_1)


### PR DESCRIPTION
We need to call `SDL_PumpEvents()` to ensure that we have the latest keyboard, mouse and joystick state before we use it.

See:
- https://wiki.libsdl.org/SDL2/SDL_GetKeyboardState
- https://wiki.libsdl.org/SDL3/SDL_GetMouseState#code-examples

Closes #7052.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
