### PR TITLE
Detect if server started from client is no longer running

### DIFF
--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -4149,8 +4149,13 @@ int kill_process(PROCESS process)
 {
 #if defined(CONF_FAMILY_WINDOWS)
 	BOOL success = TerminateProcess(process, 0);
-	CloseHandle(process);
-	return success || GetLastError() == ERROR_INVALID_HANDLE;
+	BOOL is_alive = is_process_alive(process);
+	if(success || !is_alive)
+	{
+		CloseHandle(process);
+		return true;
+	}
+	return false;
 #elif defined(CONF_FAMILY_UNIX)
 	if(!is_process_alive(process))
 		return true;

--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -4149,12 +4149,11 @@ int kill_process(PROCESS process)
 {
 #if defined(CONF_FAMILY_WINDOWS)
 	BOOL success = TerminateProcess(process, 0);
-	if(success)
-	{
-		CloseHandle(process);
-	}
-	return success;
+	CloseHandle(process);
+	return success || GetLastError() == ERROR_INVALID_HANDLE;
 #elif defined(CONF_FAMILY_UNIX)
+	if(!is_process_alive(process))
+		return true;
 	int status;
 	kill(process, SIGTERM);
 	return waitpid(process, &status, 0) != -1;

--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -4161,6 +4161,19 @@ int kill_process(PROCESS process)
 #endif
 }
 
+bool is_process_alive(PROCESS process)
+{
+	if(process == INVALID_PROCESS)
+		return false;
+#if defined(CONF_FAMILY_WINDOWS)
+	DWORD exit_code;
+	GetExitCodeProcess(process, &exit_code);
+	return exit_code == STILL_ACTIVE;
+#else
+	return waitpid(process, nullptr, WNOHANG) == 0;
+#endif
+}
+
 int open_link(const char *link)
 {
 #if defined(CONF_FAMILY_WINDOWS)

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -2648,6 +2648,15 @@ PROCESS shell_execute(const char *file);
 */
 int kill_process(PROCESS process);
 
+/**
+ * Checks if a process is alive.
+ * 
+ * @param process Handle/PID of the process.
+ * 
+ * @return bool Returns true if the process is currently running, false if the process is not running (dead).
+ */
+bool is_process_alive(PROCESS process);
+
 /*
 	Function: generate_password
 		Generates a null-terminated password of length `2 *

--- a/src/game/client/components/menus_start.cpp
+++ b/src/game/client/components/menus_start.cpp
@@ -137,10 +137,7 @@ void CMenus::RenderStartMenu(CUIRect MainView)
 	static CButtonContainer s_LocalServerButton;
 
 	if(!is_process_alive(m_ServerProcess.m_Process))
-	{
 		KillServer();
-		m_ServerProcess.m_Process = INVALID_PROCESS;
-	}
 
 	if(DoButton_Menu(&s_LocalServerButton, m_ServerProcess.m_Process ? Localize("Stop server") : Localize("Run server"), 0, &Button, g_Config.m_ClShowStartMenuImages ? "local_server" : 0, IGraphics::CORNER_ALL, Rounding, 0.5f, vec4(0.0f, 0.0f, 0.0f, 0.5f), m_ServerProcess.m_Process ? vec4(0.0f, 1.0f, 0.0f, 0.25f) : vec4(0.0f, 0.0f, 0.0f, 0.25f)) || (CheckHotKey(KEY_R) && Input()->KeyPress(KEY_R)))
 	{

--- a/src/game/client/components/menus_start.cpp
+++ b/src/game/client/components/menus_start.cpp
@@ -135,6 +135,13 @@ void CMenus::RenderStartMenu(CUIRect MainView)
 	Menu.HSplitBottom(5.0f, &Menu, 0); // little space
 	Menu.HSplitBottom(40.0f, &Menu, &Button);
 	static CButtonContainer s_LocalServerButton;
+
+	if(!is_process_alive(m_ServerProcess.m_Process))
+	{
+		KillServer();
+		m_ServerProcess.m_Process = INVALID_PROCESS;
+	}
+
 	if(DoButton_Menu(&s_LocalServerButton, m_ServerProcess.m_Process ? Localize("Stop server") : Localize("Run server"), 0, &Button, g_Config.m_ClShowStartMenuImages ? "local_server" : 0, IGraphics::CORNER_ALL, Rounding, 0.5f, vec4(0.0f, 0.0f, 0.0f, 0.5f), m_ServerProcess.m_Process ? vec4(0.0f, 1.0f, 0.0f, 0.25f) : vec4(0.0f, 0.0f, 0.0f, 0.25f)) || (CheckHotKey(KEY_R) && Input()->KeyPress(KEY_R)))
 	{
 		if(m_ServerProcess.m_Process)


### PR DESCRIPTION
Fixes 1. of #6403
> The menu button should be updated to reflect whether the server is still running. For example the server may have been shut down manually with shutdown or it may have failed to start entirely due to the map missing or another issue.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
