### PR TITLE
Correctly update auth keys when using `auth_remove`

### DIFF
--- a/src/engine/server/authmanager.cpp
+++ b/src/engine/server/authmanager.cpp
@@ -65,21 +65,21 @@ int CAuthManager::AddKey(const char *pIdent, const char *pPw, int AuthLevel)
 	return AddKeyHash(pIdent, HashPassword(pPw, aSalt), aSalt, AuthLevel);
 }
 
-int CAuthManager::RemoveKey(int Slot)
+void CAuthManager::RemoveKey(int Slot)
 {
 	m_vKeys.erase(m_vKeys.begin() + Slot);
+	// Update indices of default keys
 	for(int &Default : m_aDefault)
 	{
 		if(Default == Slot)
 		{
 			Default = -1;
 		}
-		else if(Default == (int)m_vKeys.size())
+		else if(Default > Slot)
 		{
-			Default = Slot;
+			--Default;
 		}
 	}
-	return m_vKeys.size();
 }
 
 int CAuthManager::FindKey(const char *pIdent) const

--- a/src/engine/server/authmanager.h
+++ b/src/engine/server/authmanager.h
@@ -30,7 +30,7 @@ public:
 	void Init();
 	int AddKeyHash(const char *pIdent, MD5_DIGEST Hash, const unsigned char *pSalt, int AuthLevel);
 	int AddKey(const char *pIdent, const char *pPw, int AuthLevel);
-	int RemoveKey(int Slot); // Returns the old key slot that is now in the named one.
+	void RemoveKey(int Slot);
 	int FindKey(const char *pIdent) const;
 	bool CheckKey(int Slot, const char *pPw) const;
 	int DefaultKey(int AuthLevel) const;

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -3107,16 +3107,20 @@ static int GetAuthLevel(const char *pLevel)
 
 void CServer::AuthRemoveKey(int KeySlot)
 {
-	int NewKeySlot = KeySlot;
-	int OldKeySlot = m_AuthManager.RemoveKey(KeySlot);
+	m_AuthManager.RemoveKey(KeySlot);
 	LogoutKey(KeySlot, "key removal");
 
 	// Update indices.
-	if(OldKeySlot != NewKeySlot)
+	for(auto &Client : m_aClients)
 	{
-		for(auto &Client : m_aClients)
-			if(Client.m_AuthKey == OldKeySlot)
-				Client.m_AuthKey = NewKeySlot;
+		if(Client.m_AuthKey == KeySlot)
+		{
+			Client.m_AuthKey = -1;
+		}
+		else if(Client.m_AuthKey > KeySlot)
+		{
+			--Client.m_AuthKey;
+		}
 	}
 }
 


### PR DESCRIPTION
When using `auth_remove`, the key indices for the default helper, mod and admin passwords were not properly adjusted, causing the wrong passwords to be used for the username-less logins.

The key indices for connected clients were also not properly adjusted, causing the wrong identity to be shown for currently authenticated clients when using the `status` command.

Closes #6427.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
