### PR TITLE
Show if your friend is AFK through friends list

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -1479,6 +1479,7 @@ void CClient::ProcessServerInfo(int RawType, NETADDR *pFrom, const void *pData, 
 		GET_INT(pClient->m_Country);
 		GET_INT(pClient->m_Score);
 		GET_INT(pClient->m_Player);
+		GET_INT(pClient->m_Afk);
 		if(SavedType == SERVERINFO_EXTENDED)
 		{
 			Up.GetString(); // extra info, reserved

--- a/src/engine/serverbrowser.h
+++ b/src/engine/serverbrowser.h
@@ -51,6 +51,7 @@ public:
 		int m_Country;
 		int m_Score;
 		bool m_Player;
+		bool m_Afk;
 
 		// skin info
 		char m_aSkin[24 + 1];

--- a/src/engine/shared/serverinfo.cpp
+++ b/src/engine/shared/serverinfo.cpp
@@ -112,12 +112,14 @@ bool CServerInfo2::FromJsonRaw(CServerInfo2 *pOut, const json_value *pJson)
 		const json_value &Country = Client["country"];
 		const json_value &Score = Client["score"];
 		const json_value &IsPlayer = Client["is_player"];
+		const json_value &IsAfk = Client["afk"];
 		Error = false;
 		Error = Error || ClientName.type != json_string || str_has_cc(ClientName);
 		Error = Error || Clan.type != json_string || str_has_cc(ClientName);
 		Error = Error || Country.type != json_integer;
 		Error = Error || Score.type != json_integer;
 		Error = Error || IsPlayer.type != json_boolean;
+		Error = Error || IsAfk.type != json_boolean;
 		if(Error)
 		{
 			return true;
@@ -130,6 +132,7 @@ bool CServerInfo2::FromJsonRaw(CServerInfo2 *pOut, const json_value *pJson)
 			pClient->m_Country = json_int_get(&Country);
 			pClient->m_Score = json_int_get(&Score);
 			pClient->m_IsPlayer = IsPlayer;
+			pClient->m_IsAfk = IsAfk;
 
 			// check if a skin is also available
 			bool HasSkin = false;
@@ -203,6 +206,7 @@ bool CServerInfo2::operator==(const CServerInfo2 &Other) const
 		Unequal = Unequal || m_aClients[i].m_Country != Other.m_aClients[i].m_Country;
 		Unequal = Unequal || m_aClients[i].m_Score != Other.m_aClients[i].m_Score;
 		Unequal = Unequal || m_aClients[i].m_IsPlayer != Other.m_aClients[i].m_IsPlayer;
+		Unequal = Unequal || m_aClients[i].m_IsAfk != Other.m_aClients[i].m_IsAfk;
 		if(Unequal)
 		{
 			return false;
@@ -232,6 +236,7 @@ CServerInfo2::operator CServerInfo() const
 		Result.m_aClients[i].m_Country = m_aClients[i].m_Country;
 		Result.m_aClients[i].m_Score = m_aClients[i].m_Score;
 		Result.m_aClients[i].m_Player = m_aClients[i].m_IsPlayer;
+		Result.m_aClients[i].m_Afk = m_aClients[i].m_IsAfk;
 
 		str_copy(Result.m_aClients[i].m_aSkin, m_aClients[i].m_aSkin);
 		Result.m_aClients[i].m_CustomSkinColors = m_aClients[i].m_CustomSkinColors;

--- a/src/engine/shared/serverinfo.h
+++ b/src/engine/shared/serverinfo.h
@@ -18,6 +18,7 @@ public:
 		int m_Country;
 		int m_Score;
 		bool m_IsPlayer;
+		bool m_IsAfk;
 		char m_aSkin[24 + 1];
 		bool m_CustomSkinColors;
 		int m_CustomSkinColorBody;

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -346,6 +346,7 @@ protected:
 		const CServerInfo *m_pServerInfo;
 		int m_FriendState;
 		bool m_IsPlayer;
+		bool m_IsAfk;
 		// skin
 		char m_aSkin[24 + 1];
 		bool m_CustomSkinColors;
@@ -357,6 +358,7 @@ protected:
 		CFriendItem(const CFriendInfo *pFriendInfo) :
 			m_pServerInfo(nullptr),
 			m_IsPlayer(false),
+			m_IsAfk(false),
 			m_CustomSkinColors(false),
 			m_CustomSkinColorBody(0),
 			m_CustomSkinColorFeet(0)
@@ -370,6 +372,7 @@ protected:
 			m_pServerInfo(pServerInfo),
 			m_FriendState(CurrentClient.m_FriendState),
 			m_IsPlayer(CurrentClient.m_Player),
+			m_IsAfk(CurrentClient.m_Afk),
 			m_CustomSkinColors(CurrentClient.m_CustomSkinColors),
 			m_CustomSkinColorBody(CurrentClient.m_CustomSkinColorBody),
 			m_CustomSkinColorFeet(CurrentClient.m_CustomSkinColorFeet)
@@ -384,6 +387,7 @@ protected:
 		const CServerInfo *ServerInfo() const { return m_pServerInfo; }
 		int FriendState() const { return m_FriendState; }
 		bool IsPlayer() const { return m_IsPlayer; }
+		bool IsAfk() const { return m_IsAfk; }
 		const char *Skin() const { return m_aSkin; }
 		bool CustomSkinColors() const { return m_CustomSkinColors; }
 		int CustomSkinColorBody() const { return m_CustomSkinColorBody; }

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1218,7 +1218,8 @@ void CMenus::RenderServerbrowserFriends(CUIRect View)
 	const float FontSize = 10.0f;
 	static bool s_aListExtended[NUM_FRIEND_TYPES] = {true, true, false};
 	static const ColorRGBA s_aListColors[NUM_FRIEND_TYPES] = {ColorRGBA(0.5f, 1.0f, 0.5f, 1.0f), ColorRGBA(0.4f, 0.4f, 1.0f, 1.0f), ColorRGBA(1.0f, 0.5f, 0.5f, 1.0f)};
-	const ColorRGBA OfflineClanColor = ColorRGBA(0.7f, 0.45f, 0.75f, 1.0f);
+	// Alternates of s_aListColors include: AFK friend color, AFK clanmate color, Offline clan color.
+	static const ColorRGBA s_aListColorAlternates[NUM_FRIEND_TYPES] = {ColorRGBA(1.0f, 1.0f, 0.5f, 1.0f), ColorRGBA(0.4f, 0.75f, 1.0f, 1.0f), ColorRGBA(0.7f, 0.45f, 0.75f, 1.0f)};
 	const float SpacingH = 2.0f;
 
 	CUIRect List, ServerFriends;
@@ -1334,8 +1335,8 @@ void CMenus::RenderServerbrowserFriends(CUIRect View)
 				{
 					GameClient()->m_Tooltips.DoToolTip(Friend.ListItemId(), &Rect, Localize("Click to select server. Double click to join your friend."));
 				}
-				const bool OfflineClan = Friend.FriendState() == IFriends::FRIEND_CLAN && FriendType == FRIEND_OFF;
-				Rect.Draw((OfflineClan ? OfflineClanColor : s_aListColors[FriendType]).WithAlpha(Inside ? 0.5f : 0.3f), IGraphics::CORNER_ALL, 5.0f);
+				const bool AlternateColor = (FriendType != FRIEND_OFF && Friend.IsAfk()) || (Friend.FriendState() == IFriends::FRIEND_CLAN && FriendType == FRIEND_OFF);
+				Rect.Draw((AlternateColor ? s_aListColorAlternates[FriendType] : s_aListColors[FriendType]).WithAlpha(Inside ? 0.5f : 0.3f), IGraphics::CORNER_ALL, 5.0f);
 				Rect.Margin(2.0f, &Rect);
 
 				CUIRect RemoveButton, NameLabel, ClanLabel, InfoLabel;
@@ -1360,7 +1361,7 @@ void CMenus::RenderServerbrowserFriends(CUIRect View)
 					vec2 OffsetToMid;
 					RenderTools()->GetRenderTeeOffsetToRenderedTee(pIdleState, &TeeInfo, OffsetToMid);
 					const vec2 TeeRenderPos = vec2(Skin.x + Skin.w / 2.0f, Skin.y + Skin.h * 0.55f + OffsetToMid.y);
-					RenderTools()->RenderTee(pIdleState, &TeeInfo, EMOTE_NORMAL, vec2(1.0f, 0.0f), TeeRenderPos);
+					RenderTools()->RenderTee(pIdleState, &TeeInfo, Friend.IsAfk() ? EMOTE_BLINK : EMOTE_NORMAL, vec2(1.0f, 0.0f), TeeRenderPos);
 				}
 				Rect.HSplitTop(11.0f, &NameLabel, &ClanLabel);
 


### PR DESCRIPTION
This update shows if your friend is AFK in a server without you having to go in to find out. It will only show this inside the friends list. To make this work, I had to add a check for the "afk" key from server,json to the CServerInfo::CClient scripting.

Before:
![image](https://github.com/ddnet/ddnet/assets/95713843/4f52164f-791c-4331-bf39-b10264b3989d)

After:
![image](https://github.com/ddnet/ddnet/assets/95713843/89ea0f74-1219-4522-a3f3-432dad9cb5b9)

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
