### PR TITLE
Ensure strings in demo header are zero-terminated and valid UTF-8

### DIFF
--- a/src/engine/demo.h
+++ b/src/engine/demo.h
@@ -13,6 +13,8 @@ enum
 	MAX_TIMELINE_MARKERS = 64
 };
 
+static const unsigned char gs_aHeaderMarker[7] = {'T', 'W', 'D', 'E', 'M', 'O', 0};
+
 constexpr int g_DemoSpeeds = 22;
 extern const double g_aSpeeds[g_DemoSpeeds];
 
@@ -34,6 +36,16 @@ struct CDemoHeader
 	char m_aType[8];
 	unsigned char m_aLength[sizeof(int32_t)];
 	char m_aTimestamp[20];
+
+	bool Valid() const
+	{
+		// Check marker and ensure that strings are zero-terminated and valid UTF-8.
+		return mem_comp(m_aMarker, gs_aHeaderMarker, sizeof(gs_aHeaderMarker)) == 0 &&
+		       mem_has_null(m_aNetversion, sizeof(m_aNetversion)) && str_utf8_check(m_aNetversion) &&
+		       mem_has_null(m_aMapName, sizeof(m_aMapName)) && str_utf8_check(m_aMapName) &&
+		       mem_has_null(m_aType, sizeof(m_aType)) && str_utf8_check(m_aType) &&
+		       mem_has_null(m_aTimestamp, sizeof(m_aTimestamp)) && str_utf8_check(m_aTimestamp);
+	}
 };
 
 struct CTimelineMarkers


### PR DESCRIPTION
Previously, if the demo header strings did not contain zero-termination, the client would render the strings and any following non-zero memory from the demo header.

Now, demos will not be loaded, if any string in the header is not zero-terminated or not valid UTF-8.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
