### PR TITLE
Increase freeview radius to kill tile border

### DIFF
--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -412,8 +412,8 @@ void CControls::ClampMousePos()
 {
 	if(m_pClient->m_Snap.m_SpecInfo.m_Active && m_pClient->m_Snap.m_SpecInfo.m_SpectatorID < 0)
 	{
-		m_aMousePos[g_Config.m_ClDummy].x = clamp(m_aMousePos[g_Config.m_ClDummy].x, 0.0f, Collision()->GetWidth() * 32.0f);
-		m_aMousePos[g_Config.m_ClDummy].y = clamp(m_aMousePos[g_Config.m_ClDummy].y, 0.0f, Collision()->GetHeight() * 32.0f);
+		m_aMousePos[g_Config.m_ClDummy].x = clamp(m_aMousePos[g_Config.m_ClDummy].x, -201.0f * 32, (Collision()->GetWidth() + 201.0f) * 32.0f);
+		m_aMousePos[g_Config.m_ClDummy].y = clamp(m_aMousePos[g_Config.m_ClDummy].y, -201.0f * 32, (Collision()->GetHeight() + 201.0f) * 32.0f);
 	}
 	else
 	{


### PR DESCRIPTION
Instead of limiting the radius to the size of the game layer, it now instead extends all the way to kill-tile border. Mainly because sometimes a player is outside the game layer or you need to teleport high up in the sky to practice a part.

Before:

https://github.com/ddnet/ddnet/assets/141338449/22b6feba-c007-4b6d-8207-a6a06fd03fac

After:

https://github.com/ddnet/ddnet/assets/141338449/f83d2e20-ed7d-4c15-911b-0a7e942b0baa



## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
