### PR TITLE
Configs used in Register OnConfigChange should have Conchain

### DIFF
--- a/src/engine/server/register.cpp
+++ b/src/engine/server/register.cpp
@@ -503,7 +503,10 @@ CRegister::CRegister(CConfig *pConfig, IConsole *pConsole, IEngine *pEngine, int
 	str_format(m_aConnlessTokenHex, sizeof(m_aConnlessTokenHex), "%08x", bytes_be_to_uint(aTokenBytes));
 
 	m_pConsole->Chain("sv_register", ConchainOnConfigChange, this);
+	m_pConsole->Chain("sv_register_extra", ConchainOnConfigChange, this);
+	m_pConsole->Chain("sv_register_url", ConchainOnConfigChange, this);
 	m_pConsole->Chain("sv_sixup", ConchainOnConfigChange, this);
+	m_pConsole->Chain("sv_ipv4only", ConchainOnConfigChange, this);
 }
 
 void CRegister::Update()


### PR DESCRIPTION
Fixed so that `sv_register_extra`, `sv_register_url` and `sv_ipv4only` all call `OnConfigChange` when changed.
## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
