### PR TITLE
Fix dead reckoning

### DIFF
--- a/src/game/gamecore.cpp
+++ b/src/game/gamecore.cpp
@@ -93,7 +93,9 @@ void CCharacterCore::Init(CWorldCore *pWorld, CCollision *pCollision, CTeamsCore
 	m_Id = -1;
 
 	// fail safe, if core's tuning didn't get updated at all, just fallback to world tuning.
-	m_Tuning = m_pWorld->m_aTuning[g_Config.m_ClDummy];
+	if(m_pWorld)
+		m_Tuning = m_pWorld->m_aTuning[g_Config.m_ClDummy];
+
 	Reset();
 }
 

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -85,6 +85,9 @@ bool CCharacter::Spawn(CPlayer *pPlayer, vec2 Pos)
 	m_SendCore = CCharacterCore();
 	m_ReckoningCore = CCharacterCore();
 
+	m_ReckoningCore.Init(nullptr, Collision());
+	m_ReckoningCore.m_Tuning = *Tuning();
+
 	GameServer()->m_World.InsertEntity(this);
 	m_Alive = true;
 
@@ -785,9 +788,6 @@ void CCharacter::TickDeferred()
 {
 	// advance the dummy
 	{
-		CWorldCore TempWorld;
-		m_ReckoningCore.Init(&TempWorld, Collision(), &Teams()->m_Core, m_pTeleOuts);
-		m_ReckoningCore.m_Id = m_pPlayer->GetCID();
 		m_ReckoningCore.Tick(false);
 		m_ReckoningCore.Move();
 		m_ReckoningCore.Quantize();
@@ -1915,9 +1915,9 @@ void CCharacter::HandleTuneLayer()
 	m_TuneZone = Collision()->IsTune(CurrentIndex);
 
 	if(m_TuneZone)
-		m_Core.m_Tuning = TuningList()[m_TuneZone]; // throw tunings from specific zone into gamecore
+		m_Core.m_Tuning = m_ReckoningCore.m_Tuning = TuningList()[m_TuneZone]; // throw tunings from specific zone into gamecore
 	else
-		m_Core.m_Tuning = *Tuning();
+		m_Core.m_Tuning = m_ReckoningCore.m_Tuning = *Tuning();
 
 	if(m_TuneZone != m_TuneZoneOld) // don't send tunigs all the time
 	{


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->
Dead reckoning has been broken for quite some time now due to a Reset call clearing out past state in an unintended way. (#7170) 

This is my proposed replacement for #7171 
<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
