### PR TITLE
Add assertion when double-freeing texture index, ensure OpenGL texture vectors are large enough

### DIFF
--- a/src/engine/client/backend/opengl/backend_opengl.cpp
+++ b/src/engine/client/backend/opengl/backend_opengl.cpp
@@ -729,7 +729,7 @@ void CCommandProcessorFragment_OpenGL::TextureCreate(int Slot, int Width, int He
 		glGetIntegerv(GL_MAX_TEXTURE_SIZE, &m_MaxTexSize);
 	}
 
-	if(Slot >= (int)m_vTextures.size())
+	while(Slot >= (int)m_vTextures.size())
 		m_vTextures.resize(m_vTextures.size() * 2);
 
 	m_vTextures[Slot].m_ResizeWidth = -1.f;

--- a/src/engine/client/backend/opengl/backend_opengl3.cpp
+++ b/src/engine/client/backend/opengl/backend_opengl3.cpp
@@ -579,7 +579,7 @@ void CCommandProcessorFragment_OpenGL3_3::Cmd_Texture_Destroy(const CCommandBuff
 
 void CCommandProcessorFragment_OpenGL3_3::TextureCreate(int Slot, int Width, int Height, int GLFormat, int GLStoreFormat, int Flags, void *pTexData)
 {
-	if(Slot >= (int)m_vTextures.size())
+	while(Slot >= (int)m_vTextures.size())
 		m_vTextures.resize(m_vTextures.size() * 2);
 
 	// resample if needed

--- a/src/engine/client/graphics_threaded.h
+++ b/src/engine/client/graphics_threaded.h
@@ -819,7 +819,7 @@ class CGraphics_Threaded : public IEngineGraphics
 	CTextureHandle m_InvalidTexture;
 
 	std::vector<int> m_vTextureIndices;
-	int m_FirstFreeTexture;
+	size_t m_FirstFreeTexture;
 	int m_TextureMemoryUsage;
 
 	std::vector<uint8_t> m_vSpriteHelper;


### PR DESCRIPTION
Simplify the handling of free texture indices by using `-1` only for indices which are currently in use, whereas the size of the vector is now used to indicate the last free index. Otherwise the assertions incorrectly detect the last texture index always being in use because `-1` was used for both states.

Ensure OpenGL texture index vectors are large enough, in the unlikely case that the wanted texture slot is larger than twice the size of the original texture vector.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
