### PR TITLE
firing/hooking takes aim when action happened not when tick

### DIFF
--- a/src/game/client/components/binds.cpp
+++ b/src/game/client/components/binds.cpp
@@ -1,9 +1,9 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include "binds.h"
+#include <cstring>
 #include <engine/config.h>
 #include <engine/shared/config.h>
-#include <cstring>
 
 #include <game/client/gameclient.h>
 

--- a/src/game/client/components/binds.cpp
+++ b/src/game/client/components/binds.cpp
@@ -1,7 +1,7 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include "binds.h"
-#include <cstring>
+#include <base/system.h>
 #include <engine/config.h>
 #include <engine/shared/config.h>
 
@@ -135,14 +135,14 @@ bool CBinds::OnInput(const IInput::CEvent &Event)
 	Mask &= ~KeyModifierMask;
 
 	bool ret = false;
-	char *key = 0;
+	const char *pKey = nullptr;
 
 	if(m_aapKeyBindings[Mask][Event.m_Key])
 	{
 		if(Event.m_Flags & IInput::FLAG_PRESS)
 		{
 			Console()->ExecuteLineStroked(1, m_aapKeyBindings[Mask][Event.m_Key]);
-			key = m_aapKeyBindings[Mask][Event.m_Key];
+			pKey = m_aapKeyBindings[Mask][Event.m_Key];
 		}
 		// Have to check for nullptr again because the previous execute can unbind itself
 		if(Event.m_Flags & IInput::FLAG_RELEASE && m_aapKeyBindings[Mask][Event.m_Key])
@@ -156,7 +156,7 @@ bool CBinds::OnInput(const IInput::CEvent &Event)
 		if(Event.m_Flags & IInput::FLAG_PRESS && Mask != ((1 << MODIFIER_CTRL) | (1 << MODIFIER_SHIFT)) && Mask != ((1 << MODIFIER_GUI) | (1 << MODIFIER_SHIFT)))
 		{
 			Console()->ExecuteLineStroked(1, m_aapKeyBindings[0][Event.m_Key]);
-			key = m_aapKeyBindings[Mask][Event.m_Key];
+			pKey = m_aapKeyBindings[Mask][Event.m_Key];
 		}
 		// Have to check for nullptr again because the previous execute can unbind itself
 		if(Event.m_Flags & IInput::FLAG_RELEASE && m_aapKeyBindings[0][Event.m_Key])
@@ -164,11 +164,11 @@ bool CBinds::OnInput(const IInput::CEvent &Event)
 		ret = true;
 	}
 
-	if(g_Config.m_ClSubTickAiming && key)
+	if(g_Config.m_ClSubTickAiming && pKey)
 	{
-		if(strcmp("+fire", key) == 0 || strcmp("+hook", key) == 0)
+		if(str_comp("+fire", pKey) == 0 || str_comp("+hook", pKey) == 0)
 		{
-			mouseOnAction = true;
+			m_MouseOnAction = true;
 		}
 	}
 

--- a/src/game/client/components/binds.cpp
+++ b/src/game/client/components/binds.cpp
@@ -129,7 +129,7 @@ bool CBinds::OnInput(const IInput::CEvent &Event)
 	// don't handle invalid events
 	if(Event.m_Key <= KEY_FIRST || Event.m_Key >= KEY_LAST)
 		return false;
-	
+
 	int Mask = GetModifierMask(Input());
 	int KeyModifierMask = GetModifierMaskOfKey(Event.m_Key);
 	Mask &= ~KeyModifierMask;
@@ -164,7 +164,7 @@ bool CBinds::OnInput(const IInput::CEvent &Event)
 		ret = true;
 	}
 
-	if(key)
+	if(g_Config.m_ClSubTickAiming && key)
 	{
 		if(strcmp("+fire", key) == 0 || strcmp("+hook", key) == 0)
 		{

--- a/src/game/client/components/binds.cpp
+++ b/src/game/client/components/binds.cpp
@@ -135,7 +135,7 @@ bool CBinds::OnInput(const IInput::CEvent &Event)
 	Mask &= ~KeyModifierMask;
 
 	bool ret = false;
-	char * key = 0;
+	char *key = 0;
 
 	if(m_aapKeyBindings[Mask][Event.m_Key])
 	{

--- a/src/game/client/components/binds.h
+++ b/src/game/client/components/binds.h
@@ -35,6 +35,8 @@ public:
 		virtual bool OnInput(const IInput::CEvent &Event) override;
 	};
 
+	bool mouseOnAction;
+
 	enum
 	{
 		MODIFIER_NONE = 0,

--- a/src/game/client/components/binds.h
+++ b/src/game/client/components/binds.h
@@ -35,7 +35,7 @@ public:
 		virtual bool OnInput(const IInput::CEvent &Event) override;
 	};
 
-	bool mouseOnAction;
+	bool m_MouseOnAction;
 
 	enum
 	{

--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -239,6 +239,16 @@ int CControls::SnapInput(int *pData)
 	{
 		m_aInputData[g_Config.m_ClDummy].m_TargetX = (int)m_aMousePos[g_Config.m_ClDummy].x;
 		m_aInputData[g_Config.m_ClDummy].m_TargetY = (int)m_aMousePos[g_Config.m_ClDummy].y;
+
+		if(m_aMousePosOnAction[g_Config.m_ClDummy].x != 0 && m_aMousePosOnAction[g_Config.m_ClDummy].y != 0)
+		{
+			m_aInputData[g_Config.m_ClDummy].m_TargetX = (int)m_aMousePosOnAction[g_Config.m_ClDummy].x;
+			m_aInputData[g_Config.m_ClDummy].m_TargetY = (int)m_aMousePosOnAction[g_Config.m_ClDummy].y;
+
+			m_aMousePosOnAction[g_Config.m_ClDummy].x = 0;
+			m_aMousePosOnAction[g_Config.m_ClDummy].y = 0;
+		}
+
 		if(!m_aInputData[g_Config.m_ClDummy].m_TargetX && !m_aInputData[g_Config.m_ClDummy].m_TargetY)
 		{
 			m_aInputData[g_Config.m_ClDummy].m_TargetX = 1;
@@ -295,7 +305,6 @@ int CControls::SnapInput(int *pData)
 			m_aInputData[g_Config.m_ClDummy].m_TargetY = (int)(std::cos(t * 3) * 100.0f);
 		}
 #endif
-
 		// check if we need to send input
 		if(m_aInputData[g_Config.m_ClDummy].m_Direction != m_aLastData[g_Config.m_ClDummy].m_Direction)
 			Send = true;

--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -240,7 +240,7 @@ int CControls::SnapInput(int *pData)
 		m_aInputData[g_Config.m_ClDummy].m_TargetX = (int)m_aMousePos[g_Config.m_ClDummy].x;
 		m_aInputData[g_Config.m_ClDummy].m_TargetY = (int)m_aMousePos[g_Config.m_ClDummy].y;
 
-		if(m_aMousePosOnAction[g_Config.m_ClDummy].x != 0 && m_aMousePosOnAction[g_Config.m_ClDummy].y != 0)
+		if(g_Config.m_ClSubTickAiming && m_aMousePosOnAction[g_Config.m_ClDummy].x != 0 && m_aMousePosOnAction[g_Config.m_ClDummy].y != 0)
 		{
 			m_aInputData[g_Config.m_ClDummy].m_TargetX = (int)m_aMousePosOnAction[g_Config.m_ClDummy].x;
 			m_aInputData[g_Config.m_ClDummy].m_TargetY = (int)m_aMousePosOnAction[g_Config.m_ClDummy].y;

--- a/src/game/client/components/controls.h
+++ b/src/game/client/components/controls.h
@@ -16,6 +16,7 @@ class CControls : public CComponent
 
 public:
 	vec2 m_aMousePos[NUM_DUMMIES];
+	vec2 m_aMousePosOnAction[NUM_DUMMIES];
 	vec2 m_aTargetPos[NUM_DUMMIES];
 	float m_OldMouseX;
 	float m_OldMouseY;

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -410,6 +410,12 @@ void CGameClient::OnUpdate()
 				break;
 		}
 	}
+
+	if(m_Binds.mouseOnAction)
+	{
+		m_Controls.m_aMousePosOnAction[g_Config.m_ClDummy] = m_Controls.m_aMousePos[g_Config.m_ClDummy]; //idk what g_Config.m_ClDummy is
+		m_Binds.mouseOnAction = false;
+	}
 }
 
 void CGameClient::OnDummySwap()

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -411,7 +411,7 @@ void CGameClient::OnUpdate()
 		}
 	}
 
-	if(m_Binds.mouseOnAction)
+	if(g_Config.m_ClSubTickAiming && m_Binds.mouseOnAction)
 	{
 		m_Controls.m_aMousePosOnAction[g_Config.m_ClDummy] = m_Controls.m_aMousePos[g_Config.m_ClDummy]; //idk what g_Config.m_ClDummy is
 		m_Binds.mouseOnAction = false;

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -411,10 +411,10 @@ void CGameClient::OnUpdate()
 		}
 	}
 
-	if(g_Config.m_ClSubTickAiming && m_Binds.mouseOnAction)
+	if(g_Config.m_ClSubTickAiming && m_Binds.m_MouseOnAction)
 	{
-		m_Controls.m_aMousePosOnAction[g_Config.m_ClDummy] = m_Controls.m_aMousePos[g_Config.m_ClDummy]; //idk what g_Config.m_ClDummy is
-		m_Binds.mouseOnAction = false;
+		m_Controls.m_aMousePosOnAction[g_Config.m_ClDummy] = m_Controls.m_aMousePos[g_Config.m_ClDummy];
+		m_Binds.m_MouseOnAction = false;
 	}
 }
 

--- a/src/game/variables.h
+++ b/src/game/variables.h
@@ -22,7 +22,7 @@ MACRO_CONFIG_INT(ClAntiPingWeapons, cl_antiping_weapons, 1, 0, 1, CFGFLAG_CLIENT
 MACRO_CONFIG_INT(ClAntiPingSmooth, cl_antiping_smooth, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Make the prediction of other player's movement smoother")
 MACRO_CONFIG_INT(ClAntiPingGunfire, cl_antiping_gunfire, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Predict gunfire and show predicted weapon physics (with cl_antiping_grenade 1 and cl_antiping_weapons 1)")
 MACRO_CONFIG_INT(ClPredictionMargin, cl_prediction_margin, 10, 1, 2000, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Prediction margin in ms (adds latency, can reduce lag from ping jumps)")
-MACRO_CONFIG_INT(ClSubTickAiming, cl_sub_tick_aiming, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Send aiming data at sub-tick accuracy")
+MACRO_CONFIG_INT(ClSubTickAiming, cl_sub_tick_aiming, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Send aiming data at sub-tick accuracy")
 
 MACRO_CONFIG_INT(ClNameplates, cl_nameplates, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show name plates")
 MACRO_CONFIG_INT(ClAfkEmote, cl_afk_emote, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show zzz emote next to afk players")

--- a/src/game/variables.h
+++ b/src/game/variables.h
@@ -22,6 +22,7 @@ MACRO_CONFIG_INT(ClAntiPingWeapons, cl_antiping_weapons, 1, 0, 1, CFGFLAG_CLIENT
 MACRO_CONFIG_INT(ClAntiPingSmooth, cl_antiping_smooth, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Make the prediction of other player's movement smoother")
 MACRO_CONFIG_INT(ClAntiPingGunfire, cl_antiping_gunfire, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Predict gunfire and show predicted weapon physics (with cl_antiping_grenade 1 and cl_antiping_weapons 1)")
 MACRO_CONFIG_INT(ClPredictionMargin, cl_prediction_margin, 10, 1, 2000, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Prediction margin in ms (adds latency, can reduce lag from ping jumps)")
+MACRO_CONFIG_INT(ClSubTickAiming, cl_sub_tick_aiming, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Send aiming data at sub-tick accuracy")
 
 MACRO_CONFIG_INT(ClNameplates, cl_nameplates, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show name plates")
 MACRO_CONFIG_INT(ClAfkEmote, cl_afk_emote, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show zzz emote next to afk players")


### PR DESCRIPTION
When moving the mouse fast there can be a discrepancy between where I aimed and where my weapon or hook actually go's. This is because of the fact that the mouse can move after I've shot/hooked and the mouse position at the end of the tick gets send, not the one when shot/hooked.
This makes aiming these actions kind of random and tick dependent, if you did the action right before the tick ends its really accurate but if its all the way in the beginning the mouse can move up to 20 ms longer, that can be a big difference when moving fast.
Hopefully tying it to framerate will behave better, since most players play with higher framerates than 50.

That all being said, I have tested this but there isn't an extremely noticeable difference, some pro-players might want to test this out. That being said, I have printed the difference in values, the highest I saw was 100x 150y at 1920x1080. That probably is a pretty decent difference in aim, can be the difference between hitting a shot or hook and not.

Also sorry for shitty code I don't know the coding style that well and just wanted to quickly implement it, I don't mind changing the implementation.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
