### PR TITLE
Remove warning popup for pnglite-incompatible images

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -2498,8 +2498,6 @@ void CClient::LoadDDNetInfo()
 			log_debug("info", "got global tcp ip address: %s", (const char *)ConnectingIp);
 		}
 	}
-	const json_value &WarnPngliteIncompatibleImages = DDNetInfo["warn-pnglite-incompatible-images"];
-	Graphics()->WarnPngliteIncompatibleImages(WarnPngliteIncompatibleImages.type == json_boolean && (bool)WarnPngliteIncompatibleImages);
 }
 
 int CClient::ConnectNetTypes() const

--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -589,8 +589,7 @@ int CGraphics_Threaded::LoadPNG(CImageInfo *pImg, const char *pFilename, int Sto
 
 		uint8_t *pImgBuffer = NULL;
 		EImageFormat ImageFormat;
-		int PngliteIncompatible;
-		if(::LoadPNG(ImageByteBuffer, pFilename, PngliteIncompatible, pImg->m_Width, pImg->m_Height, pImgBuffer, ImageFormat))
+		if(::LoadPNG(ImageByteBuffer, pFilename, pImg->m_Width, pImg->m_Height, pImgBuffer, ImageFormat))
 		{
 			pImg->m_pData = pImgBuffer;
 
@@ -602,30 +601,6 @@ int CGraphics_Threaded::LoadPNG(CImageInfo *pImg, const char *pFilename, int Sto
 			{
 				free(pImgBuffer);
 				return 0;
-			}
-
-			if(m_WarnPngliteIncompatibleImages && PngliteIncompatible != 0)
-			{
-				SWarning Warning;
-				str_format(Warning.m_aWarningMsg, sizeof(Warning.m_aWarningMsg), Localize("\"%s\" is not compatible with pnglite and cannot be loaded by old DDNet versions: "), pFilename);
-				static const int FLAGS[] = {PNGLITE_COLOR_TYPE, PNGLITE_BIT_DEPTH, PNGLITE_INTERLACE_TYPE, PNGLITE_COMPRESSION_TYPE, PNGLITE_FILTER_TYPE};
-				static const char *EXPLANATION[] = {"color type", "bit depth", "interlace type", "compression type", "filter type"};
-
-				bool First = true;
-				for(size_t i = 0; i < std::size(FLAGS); ++i)
-				{
-					if((PngliteIncompatible & FLAGS[i]) != 0)
-					{
-						if(!First)
-						{
-							str_append(Warning.m_aWarningMsg, ", ");
-						}
-						str_append(Warning.m_aWarningMsg, EXPLANATION[i]);
-						First = false;
-					}
-				}
-				str_append(Warning.m_aWarningMsg, " unsupported");
-				m_vWarnings.emplace_back(Warning);
 			}
 		}
 		else
@@ -2703,11 +2678,6 @@ void CGraphics_Threaded::Maximize()
 
 	for(auto &PropChangedListener : m_vPropChangeListeners)
 		PropChangedListener();
-}
-
-void CGraphics_Threaded::WarnPngliteIncompatibleImages(bool Warn)
-{
-	m_WarnPngliteIncompatibleImages = Warn;
 }
 
 void CGraphics_Threaded::SetWindowParams(int FullscreenMode, bool IsBorderless, bool AllowResizing)

--- a/src/engine/client/graphics_threaded.h
+++ b/src/engine/client/graphics_threaded.h
@@ -824,8 +824,6 @@ class CGraphics_Threaded : public IEngineGraphics
 
 	std::vector<uint8_t> m_vSpriteHelper;
 
-	bool m_WarnPngliteIncompatibleImages = false;
-
 	std::vector<SWarning> m_vWarnings;
 
 	// is a non full windowed (in a sense that the viewport won't include the whole window),
@@ -1238,7 +1236,6 @@ public:
 
 	void Minimize() override;
 	void Maximize() override;
-	void WarnPngliteIncompatibleImages(bool Warn) override;
 	void SetWindowParams(int FullscreenMode, bool IsBorderless, bool AllowResizing) override;
 	bool SetWindowScreen(int Index) override;
 	void Move(int x, int y) override;

--- a/src/engine/gfx/image_loader.cpp
+++ b/src/engine/gfx/image_loader.cpp
@@ -83,53 +83,7 @@ static void LibPNGDeleteReadStruct(png_structp pPNGStruct, png_infop pPNGInfo)
 	png_destroy_read_struct(&pPNGStruct, nullptr, nullptr);
 }
 
-static int PngliteIncompatibility(png_structp pPNGStruct, png_infop pPNGInfo)
-{
-	int ColorType = png_get_color_type(pPNGStruct, pPNGInfo);
-	int BitDepth = png_get_bit_depth(pPNGStruct, pPNGInfo);
-	int InterlaceType = png_get_interlace_type(pPNGStruct, pPNGInfo);
-	int Result = 0;
-	switch(ColorType)
-	{
-	case PNG_COLOR_TYPE_GRAY:
-	case PNG_COLOR_TYPE_RGB:
-	case PNG_COLOR_TYPE_RGB_ALPHA:
-	case PNG_COLOR_TYPE_GRAY_ALPHA:
-		break;
-	default:
-		log_debug("png", "color type %d unsupported by pnglite", ColorType);
-		Result |= PNGLITE_COLOR_TYPE;
-	}
-
-	switch(BitDepth)
-	{
-	case 8:
-	case 16:
-		break;
-	default:
-		log_debug("png", "bit depth %d unsupported by pnglite", BitDepth);
-		Result |= PNGLITE_BIT_DEPTH;
-	}
-
-	if(InterlaceType != PNG_INTERLACE_NONE)
-	{
-		log_debug("png", "interlace type %d unsupported by pnglite", InterlaceType);
-		Result |= PNGLITE_INTERLACE_TYPE;
-	}
-	if(png_get_compression_type(pPNGStruct, pPNGInfo) != PNG_COMPRESSION_TYPE_BASE)
-	{
-		log_debug("png", "non-default compression type unsupported by pnglite");
-		Result |= PNGLITE_COMPRESSION_TYPE;
-	}
-	if(png_get_filter_type(pPNGStruct, pPNGInfo) != PNG_FILTER_TYPE_BASE)
-	{
-		log_debug("png", "non-default filter type unsupported by pnglite");
-		Result |= PNGLITE_FILTER_TYPE;
-	}
-	return Result;
-}
-
-bool LoadPNG(SImageByteBuffer &ByteLoader, const char *pFileName, int &PngliteIncompatible, int &Width, int &Height, uint8_t *&pImageBuff, EImageFormat &ImageFormat)
+bool LoadPNG(SImageByteBuffer &ByteLoader, const char *pFileName, int &Width, int &Height, uint8_t *&pImageBuff, EImageFormat &ImageFormat)
 {
 	SLibPNGWarningItem UserErrorStruct = {&ByteLoader, pFileName, {}};
 
@@ -194,7 +148,6 @@ bool LoadPNG(SImageByteBuffer &ByteLoader, const char *pFileName, int &PngliteIn
 	Height = png_get_image_height(pPNGStruct, pPNGInfo);
 	const int ColorType = png_get_color_type(pPNGStruct, pPNGInfo);
 	const png_byte BitDepth = png_get_bit_depth(pPNGStruct, pPNGInfo);
-	PngliteIncompatible = PngliteIncompatibility(pPNGStruct, pPNGInfo);
 
 	if(BitDepth == 16)
 	{

--- a/src/engine/gfx/image_loader.h
+++ b/src/engine/gfx/image_loader.h
@@ -22,16 +22,7 @@ struct SImageByteBuffer
 	int m_Err;
 };
 
-enum
-{
-	PNGLITE_COLOR_TYPE = 1 << 0,
-	PNGLITE_BIT_DEPTH = 1 << 1,
-	PNGLITE_INTERLACE_TYPE = 1 << 2,
-	PNGLITE_COMPRESSION_TYPE = 1 << 3,
-	PNGLITE_FILTER_TYPE = 1 << 4,
-};
-
-bool LoadPNG(SImageByteBuffer &ByteLoader, const char *pFileName, int &PngliteIncompatible, int &Width, int &Height, uint8_t *&pImageBuff, EImageFormat &ImageFormat);
+bool LoadPNG(SImageByteBuffer &ByteLoader, const char *pFileName, int &Width, int &Height, uint8_t *&pImageBuff, EImageFormat &ImageFormat);
 bool SavePNG(EImageFormat ImageFormat, const uint8_t *pRawBuffer, SImageByteBuffer &WrittenBytes, int Width, int Height);
 
 #endif // ENGINE_GFX_IMAGE_LOADER_H

--- a/src/engine/graphics.h
+++ b/src/engine/graphics.h
@@ -278,7 +278,6 @@ public:
 	int WindowWidth() const { return m_ScreenWidth / m_ScreenHiDPIScale; }
 	int WindowHeight() const { return m_ScreenHeight / m_ScreenHiDPIScale; }
 
-	virtual void WarnPngliteIncompatibleImages(bool Warn) = 0;
 	virtual void SetWindowParams(int FullscreenMode, bool IsBorderless, bool AllowResizing) = 0;
 	virtual bool SetWindowScreen(int Index) = 0;
 	virtual bool SetVSync(bool State) = 0;

--- a/src/tools/dilate.cpp
+++ b/src/tools/dilate.cpp
@@ -26,8 +26,7 @@ int DilateFile(const char *pFilename)
 
 		uint8_t *pImgBuffer = NULL;
 		EImageFormat ImageFormat;
-		int PngliteIncompatible;
-		if(LoadPNG(ImageByteBuffer, pFilename, PngliteIncompatible, Img.m_Width, Img.m_Height, pImgBuffer, ImageFormat))
+		if(LoadPNG(ImageByteBuffer, pFilename, Img.m_Width, Img.m_Height, pImgBuffer, ImageFormat))
 		{
 			if(ImageFormat != IMAGE_FORMAT_RGBA)
 			{

--- a/src/tools/map_convert_07.cpp
+++ b/src/tools/map_convert_07.cpp
@@ -43,8 +43,7 @@ int LoadPNG(CImageInfo *pImg, const char *pFilename)
 
 		uint8_t *pImgBuffer = NULL;
 		EImageFormat ImageFormat;
-		int PngliteIncompatible;
-		if(LoadPNG(ImageByteBuffer, pFilename, PngliteIncompatible, pImg->m_Width, pImg->m_Height, pImgBuffer, ImageFormat))
+		if(LoadPNG(ImageByteBuffer, pFilename, pImg->m_Width, pImg->m_Height, pImgBuffer, ImageFormat))
 		{
 			pImg->m_pData = pImgBuffer;
 

--- a/src/tools/map_create_pixelart.cpp
+++ b/src/tools/map_create_pixelart.cpp
@@ -330,9 +330,7 @@ bool LoadPNG(CImageInfo *pImg, const char *pFilename)
 
 	uint8_t *pImgBuffer = NULL;
 	EImageFormat ImageFormat;
-	int PngliteIncompatible;
-
-	if(!LoadPNG(ImageByteBuffer, pFilename, PngliteIncompatible, pImg->m_Width, pImg->m_Height, pImgBuffer, ImageFormat))
+	if(!LoadPNG(ImageByteBuffer, pFilename, pImg->m_Width, pImg->m_Height, pImgBuffer, ImageFormat))
 	{
 		dbg_msg("map_create_pixelart", "ERROR: Unable to load a valid PNG from file %s", pFilename);
 		return false;

--- a/src/tools/map_replace_image.cpp
+++ b/src/tools/map_replace_image.cpp
@@ -41,8 +41,7 @@ int LoadPNG(CImageInfo *pImg, const char *pFilename)
 
 		uint8_t *pImgBuffer = NULL;
 		EImageFormat ImageFormat;
-		int PngliteIncompatible;
-		if(LoadPNG(ImageByteBuffer, pFilename, PngliteIncompatible, pImg->m_Width, pImg->m_Height, pImgBuffer, ImageFormat))
+		if(LoadPNG(ImageByteBuffer, pFilename, pImg->m_Width, pImg->m_Height, pImgBuffer, ImageFormat))
 		{
 			if((ImageFormat == IMAGE_FORMAT_RGBA || ImageFormat == IMAGE_FORMAT_RGB) && pImg->m_Width <= (2 << 13) && pImg->m_Height <= (2 << 13))
 			{


### PR DESCRIPTION
Remove warning popup when loading images which are not compatible with pnglite.

The number of users of client versions older than 16.3, which is the version in which pnglite was replace with libpng, appears to be less than 2%.

Clients older than version 16.3 fail gracefully when pnglite cannot load an image.

At the same time, we should set the https://info.ddnet.org/info attribute `warn-pnglite-incompatible-images` to `false`, so the warning popup is retroactively disabled for clients with version 16.3 and newer.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
