### PR TITLE
Make Gamemode get enabled when playing DDNet in macOS 14

### DIFF
--- a/other/bundle/client/Info.plist.in
+++ b/other/bundle/client/Info.plist.in
@@ -56,6 +56,8 @@
 		<true/>
 		<key>NSPrefersDisplaySafeAreaCompatibilityMode</key>
 		<true/>
+  		<key>LSApplicationCategoryType</key>
+		<string>public.app-category.games</string>
 		<key>NSQualityOfService</key>
 		<string>NSQualityOfServiceUserInteractive</string>
 	</dict>


### PR DESCRIPTION
This change allows the client to use the Gamemode feature from macOS 14 by specifying the app category at Info.plist.

<img width="353" alt="Captura de pantalla 2023-09-26 a la(s) 22 57 01" src="https://github.com/ddnet/ddnet/assets/60852359/3231b189-d1d0-4a8c-9862-bb37d13244b9">


## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
