### PR TITLE
Add flags for compatibility with Windows 8 - 11

### DIFF
--- a/other/manifest/client.manifest.in
+++ b/other/manifest/client.manifest.in
@@ -11,10 +11,16 @@
 
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>
-        <!-- Windows Vista -->
-        <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
-        <!-- Windows 7 -->
-        <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+      <!-- Windows 10 and Windows 11 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+      <!-- Windows 8.1 -->
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+      <!-- Windows 8 -->
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+      <!-- Windows 7 -->
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+      <!-- Windows Vista -->
+      <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
     </application>
   </compatibility>
 


### PR DESCRIPTION
We previously only defined compatibility with Windows Vista and 7. Now we define compatibility with Windows Vista - 11, which is what we currently support.

This means that Windows 8 - 11 will no longer try to run the client in a compatibility mode for Windows 7 applications. This should effectively not change anything, as we don't directly use any of the [components that function differently depending on the compatibility information](https://learn.microsoft.com/en-us/windows/compatibility/application-executable-manifest#manifestation).

## Checklist

- [X] Tested the change ingame (Windows 10)
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
