### PR TITLE
Limit effects of `dbg_stress` to features useful for debugging, remove remains of `dbg_stress` from server 

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -293,8 +293,6 @@ CClient::CClient() :
 		DemoRecorder = CDemoRecorder(&m_SnapshotDelta);
 
 	m_RenderFrameTime = 0.0001f;
-	m_RenderFrameTimeLow = 1.0f;
-	m_RenderFrameTimeHigh = 0.0f;
 	m_RenderFrames = 0;
 	m_LastRenderTime = time_get();
 
@@ -3238,10 +3236,6 @@ void CClient::Run()
 
 				// update frametime
 				m_RenderFrameTime = (Now - m_LastRenderTime) / (float)time_freq();
-				if(m_RenderFrameTime < m_RenderFrameTimeLow)
-					m_RenderFrameTimeLow = m_RenderFrameTime;
-				if(m_RenderFrameTime > m_RenderFrameTimeHigh)
-					m_RenderFrameTimeHigh = m_RenderFrameTime;
 				m_FpsGraph.Add(1.0f / m_RenderFrameTime, 1, 1, 1);
 
 				if(m_BenchmarkFile)

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -293,7 +293,6 @@ CClient::CClient() :
 		DemoRecorder = CDemoRecorder(&m_SnapshotDelta);
 
 	m_RenderFrameTime = 0.0001f;
-	m_RenderFrames = 0;
 	m_LastRenderTime = time_get();
 
 	m_GameTickSpeed = SERVER_TICK_SPEED;
@@ -3232,8 +3231,6 @@ void CClient::Run()
 				(!AsyncRenderOld || m_pGraphics->IsIdle()) &&
 				(!GfxRefreshRate || (time_freq() / (int64_t)g_Config.m_GfxRefreshRate) <= Now - LastRenderTime))
 			{
-				m_RenderFrames++;
-
 				// update frametime
 				m_RenderFrameTime = (Now - m_LastRenderTime) / (float)time_freq();
 				m_FpsGraph.Add(1.0f / m_RenderFrameTime, 1, 1, 1);
@@ -3261,33 +3258,14 @@ void CClient::Run()
 				LastRenderTime = Now - AdditionalTime;
 				m_LastRenderTime = Now;
 
-#ifdef CONF_DEBUG
-				if(g_Config.m_DbgStress)
-				{
-					if((m_RenderFrames % 10) == 0)
-					{
-						if(!m_EditorActive)
-							Render();
-						else
-						{
-							m_pEditor->OnRender();
-							DebugRender();
-						}
-						m_pGraphics->Swap();
-					}
-				}
+				if(!m_EditorActive)
+					Render();
 				else
-#endif
 				{
-					if(!m_EditorActive)
-						Render();
-					else
-					{
-						m_pEditor->OnRender();
-						DebugRender();
-					}
-					m_pGraphics->Swap();
+					m_pEditor->OnRender();
+					DebugRender();
 				}
+				m_pGraphics->Swap();
 			}
 			else if(!IsRenderActive)
 			{
@@ -3327,11 +3305,7 @@ void CClient::Run()
 		auto Now = time_get_nanoseconds();
 		decltype(Now) SleepTimeInNanoSeconds{0};
 		bool Slept = false;
-		if(
-#ifdef CONF_DEBUG
-			g_Config.m_DbgStress ||
-#endif
-			(g_Config.m_ClRefreshRateInactive && !m_pGraphics->WindowActive()))
+		if(g_Config.m_ClRefreshRateInactive && !m_pGraphics->WindowActive())
 		{
 			SleepTimeInNanoSeconds = (std::chrono::nanoseconds(1s) / (int64_t)g_Config.m_ClRefreshRateInactive) - (Now - LastTime);
 			std::this_thread::sleep_for(SleepTimeInNanoSeconds);

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -149,7 +149,6 @@ class CClient : public IClient, public CDemoPlayer::IListener
 	IGraphics::CTextureHandle m_DebugFont;
 
 	int64_t m_LastRenderTime;
-	int m_RenderFrames;
 
 	int m_SnapCrcErrors;
 	bool m_AutoScreenshotRecycle;

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -149,8 +149,6 @@ class CClient : public IClient, public CDemoPlayer::IListener
 	IGraphics::CTextureHandle m_DebugFont;
 
 	int64_t m_LastRenderTime;
-	float m_RenderFrameTimeLow;
-	float m_RenderFrameTimeHigh;
 	int m_RenderFrames;
 
 	int m_SnapCrcErrors;

--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -428,12 +428,6 @@ bool CGraphics_Threaded::IsSpriteTextureFullyTransparent(CImageInfo &FromImageIn
 
 IGraphics::CTextureHandle CGraphics_Threaded::LoadTextureRaw(size_t Width, size_t Height, CImageInfo::EImageFormat Format, const void *pData, int Flags, const char *pTexName)
 {
-	// don't waste memory on texture if we are stress testing
-#ifdef CONF_DEBUG
-	if(g_Config.m_DbgStress && m_InvalidTexture.IsValid())
-		return m_InvalidTexture;
-#endif
-
 	if((Flags & IGraphics::TEXLOAD_TO_2D_ARRAY_TEXTURE) != 0 || (Flags & IGraphics::TEXLOAD_TO_3D_TEXTURE) != 0)
 	{
 		if(Width == 0 || (Width % 16) != 0 || Height == 0 || (Height % 16) != 0)

--- a/src/engine/client/sound.cpp
+++ b/src/engine/client/sound.cpp
@@ -498,12 +498,6 @@ bool CSound::DecodeWV(CSample &Sample, const void *pData, unsigned DataSize)
 
 int CSound::LoadOpus(const char *pFilename, int StorageType)
 {
-	// don't waste memory on sound when we are stress testing
-#ifdef CONF_DEBUG
-	if(g_Config.m_DbgStress)
-		return -1;
-#endif
-
 	// no need to load sound when we are running with no sound
 	if(!m_SoundEnabled)
 		return -1;
@@ -540,12 +534,6 @@ int CSound::LoadOpus(const char *pFilename, int StorageType)
 
 int CSound::LoadWV(const char *pFilename, int StorageType)
 {
-	// don't waste memory on sound when we are stress testing
-#ifdef CONF_DEBUG
-	if(g_Config.m_DbgStress)
-		return -1;
-#endif
-
 	// no need to load sound when we are running with no sound
 	if(!m_SoundEnabled)
 		return -1;
@@ -582,12 +570,6 @@ int CSound::LoadWV(const char *pFilename, int StorageType)
 
 int CSound::LoadOpusFromMem(const void *pData, unsigned DataSize, bool FromEditor = false)
 {
-	// don't waste memory on sound when we are stress testing
-#ifdef CONF_DEBUG
-	if(g_Config.m_DbgStress)
-		return -1;
-#endif
-
 	// no need to load sound when we are running with no sound
 	if(!m_SoundEnabled && !FromEditor)
 		return -1;
@@ -608,12 +590,6 @@ int CSound::LoadOpusFromMem(const void *pData, unsigned DataSize, bool FromEdito
 
 int CSound::LoadWVFromMem(const void *pData, unsigned DataSize, bool FromEditor = false)
 {
-	// don't waste memory on sound when we are stress testing
-#ifdef CONF_DEBUG
-	if(g_Config.m_DbgStress)
-		return -1;
-#endif
-
 	// no need to load sound when we are running with no sound
 	if(!m_SoundEnabled && !FromEditor)
 		return -1;

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -195,7 +195,7 @@ MACRO_CONFIG_INT(DbgCurl, dbg_curl, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SERVER, "D
 MACRO_CONFIG_INT(DbgGraphs, dbg_graphs, 0, 0, 1, CFGFLAG_CLIENT, "Performance graphs")
 MACRO_CONFIG_INT(DbgGfx, dbg_gfx, 0, 0, 4, CFGFLAG_CLIENT, "Show graphic library warnings and errors, if the GPU supports it (0: none, 1: minimal, 2: affects performance, 3: verbose, 4: all)")
 #ifdef CONF_DEBUG
-MACRO_CONFIG_INT(DbgStress, dbg_stress, 0, 0, 0, CFGFLAG_CLIENT | CFGFLAG_SERVER, "Stress systems (Debug build only)")
+MACRO_CONFIG_INT(DbgStress, dbg_stress, 0, 0, 1, CFGFLAG_CLIENT, "Stress systems (Debug build only)")
 MACRO_CONFIG_STR(DbgStressServer, dbg_stress_server, 32, "localhost", CFGFLAG_CLIENT, "Server to stress (Debug build only)")
 #endif
 

--- a/src/game/server/gamecontroller.cpp
+++ b/src/game/server/gamecontroller.cpp
@@ -679,12 +679,6 @@ void IGameController::Snap(int SnappingClient)
 
 int IGameController::GetAutoTeam(int NotThisID)
 {
-	// this will force the auto balancer to work overtime as well
-#ifdef CONF_DEBUG
-	if(g_Config.m_DbgStress)
-		return 0;
-#endif
-
 	int aNumplayers[2] = {0, 0};
 	for(int i = 0; i < MAX_CLIENTS; i++)
 	{


### PR DESCRIPTION
Using `dbg_stress 1` now only does the following (in debug build):

- Randomly send inputs.
- Randomly send chat messages.
- Randomly connect/disconnect to server configured with `dbg_stress_server` (`localhost` by default).

Previously it also did the following, which is not useful for this debugging feature and only complicates the code unnecessarily:

- Cause images and sounds not to be loaded.
- Render only every tenth frame.
- Always use inactive graphics refresh rate.

Using `dbg_stress 1` on a server made clients always auto-join team 0 and nothing else, which is not useful on its own for stress testing.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
