### PR TITLE
Fix the fix to dead reckoning

### DIFF
--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -876,6 +876,7 @@ void CCharacter::TickDeferred()
 			m_ReckoningTick = Server()->Tick();
 			m_SendCore = m_Core;
 			m_ReckoningCore = m_Core;
+			m_ReckoningCore.SetCoreWorld(nullptr, Collision(), nullptr);
 			m_Core.m_Reset = false;
 		}
 	}


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->
I missed the fact that the world does not stay `nullptr` should have tested more thoroughly.

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
