### PR TITLE
Remove unused commands from `autoexec_server.cfg`

### DIFF
--- a/data/autoexec_server.cfg
+++ b/data/autoexec_server.cfg
@@ -55,9 +55,6 @@ logfile "autoexec_server.log"
 # Log level (-3 = None, -2 = Error, -1 = Warn, 0 = Info, 1 = Debug, 2 = Trace)
 loglevel 0
 
-# Folder where map records will be saved
-sv_score_folder "records"
-
 # Max players on server
 sv_max_clients 64
 
@@ -74,9 +71,6 @@ sv_pauseable 0
 sv_rescue 1
 # Number of seconds between two rescues
 sv_rescue_delay 5
-
-# Enable ranks after rcon cheats have been used
-sv_rank_cheats 1
 
 
 


### PR DESCRIPTION
Deleted `sv_score_folder` and `sv_rank_cheats` from `autoexec_server.cg`. As both of them don't exist.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
