### PR TITLE
Send the player's latency if a menu is open

### DIFF
--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -286,6 +286,9 @@ void CPlayer::Tick()
 void CPlayer::PostTick()
 {
 	// update latency value
+	if(m_PlayerFlags & PLAYERFLAG_IN_MENU)
+		m_aCurLatency[m_ClientID] = GameServer()->m_apPlayers[m_ClientID]->m_Latency.m_Min;
+
 	if(m_PlayerFlags & PLAYERFLAG_SCOREBOARD)
 	{
 		for(int i = 0; i < MAX_CLIENTS; ++i)


### PR DESCRIPTION
Currently it's only sent if the scoreboard is open. This will cause the ping shown in the "Server info" tab not to be updated. So, if you have never opened the scoreboard before. It would just show 0

![image](https://github.com/ddnet/ddnet/assets/141338449/d3d7ecb6-4d1c-4720-bc94-60eee6dc32d7)


## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
