### PR TITLE
 Don't reset `/lasttp` position on death

### DIFF
--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -1540,7 +1540,7 @@ void CGameContext::ConTele(IConsole::IResult *pResult, void *pUserData)
 			return;
 		Pos = pChrTo->m_Pos;
 	}
-	pChr->LastTelePos = Pos;
+	pPlayer->LastTelePos = Pos;
 	pSelf->Teleport(pChr, Pos);
 	pChr->UnFreeze();
 	pChr->Core()->m_Vel = vec2(0, 0);
@@ -1565,12 +1565,12 @@ void CGameContext::ConLastTele(IConsole::IResult *pResult, void *pUserData)
 		pSelf->SendChatTarget(pPlayer->GetCID(), "You're not in a team with /practice turned on. Note that you can't earn a rank with practice enabled.");
 		return;
 	}
-	if(!pChr->LastTelePos.x)
+	if(!pPlayer->LastTelePos.x)
 	{
 		pSelf->SendChatTarget(pPlayer->GetCID(), "You haven't previously teleported. Use /tp before using this command.");
 		return;
 	}
-	pSelf->Teleport(pChr, pChr->LastTelePos);
+	pSelf->Teleport(pChr, pPlayer->LastTelePos);
 	pChr->UnFreeze();
 	pChr->Core()->m_Vel = vec2(0, 0);
 }

--- a/src/game/server/entities/character.h
+++ b/src/game/server/entities/character.h
@@ -217,8 +217,6 @@ public:
 	int m_SpawnTick;
 	int m_WeaponChangeTick;
 
-	vec2 LastTelePos;
-
 	// Setters/Getters because i don't want to modify vanilla vars access modifiers
 	int GetLastWeapon() { return m_LastWeapon; }
 	void SetLastWeapon(int LastWeap) { m_LastWeapon = LastWeap; }

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -220,6 +220,8 @@ public:
 	bool m_VotedForPractice;
 	int m_SwapTargetsClientID; //Client ID of the swap target for the given player
 	bool m_BirthdayAnnounced;
+
+	vec2 LastTelePos;
 };
 
 #endif


### PR DESCRIPTION
It's now moved to `player.h` so it's persistent after death and only reset when the map changes. Which makes it way nicer to use.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
