### PR TITLE
Teleport the player to their cursor if they aren't in pause

### DIFF
--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -1518,8 +1518,11 @@ void CGameContext::ConTele(IConsole::IResult *pResult, void *pUserData)
 	}
 
 	vec2 Pos = pPlayer->m_ViewPos;
-
-	if(pResult->NumArguments() > 0)
+	if(pResult->NumArguments() == 0 && !pPlayer->IsPaused())
+	{
+		Pos = Pos + vec2(pChr->Core()->m_Input.m_TargetX, pChr->Core()->m_Input.m_TargetY);
+	}
+	else if(pResult->NumArguments() > 0)
 	{
 		int ClientID;
 		for(ClientID = 0; ClientID < MAX_CLIENTS; ClientID++)

--- a/src/game/server/ddracecommands.cpp
+++ b/src/game/server/ddracecommands.cpp
@@ -383,9 +383,15 @@ void CGameContext::ConTeleport(IConsole::IResult *pResult, void *pUserData)
 	}
 
 	CCharacter *pChr = pSelf->GetPlayerChar(Tele);
-	if(pChr && pSelf->GetPlayerChar(TeleTo))
+	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientID];
+
+	if(pChr && pPlayer && pSelf->GetPlayerChar(TeleTo))
 	{
-		pSelf->Teleport(pChr, pSelf->m_apPlayers[TeleTo]->m_ViewPos);
+		vec2 Pos = pSelf->m_apPlayers[TeleTo]->m_ViewPos;
+		if(!pPlayer->IsPaused() && !pResult->NumArguments())
+			Pos = Pos + vec2(pChr->Core()->m_Input.m_TargetX, pChr->Core()->m_Input.m_TargetY);
+
+		pSelf->Teleport(pChr, Pos);
 		pChr->UnFreeze();
 		pChr->Core()->m_Vel = vec2(0, 0);
 	}


### PR DESCRIPTION
`tele` and `/tp` will now teleport the player to their cursor if they aren't paused or used one of the optional arguments.

https://github.com/ddnet/ddnet/assets/141338449/8a217199-c13d-47fc-a077-3b4360afe3f4



## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
