### PR TITLE
Fix crashes when rendering tees after skins are updated

### DIFF
--- a/src/game/client/components/ghost.cpp
+++ b/src/game/client/components/ghost.cpp
@@ -667,40 +667,32 @@ int CGhost::GetLastRaceTick()
 	return m_LastRaceTick;
 }
 
-void CGhost::RefindSkin()
+void CGhost::RefindSkins()
 {
-	char aSkinName[64];
-	for(auto &Ghost : m_aActiveGhosts)
-	{
-		if(!Ghost.Empty())
-		{
-			IntsToStr(&Ghost.m_Skin.m_Skin0, 6, aSkinName);
-			CTeeRenderInfo *pRenderInfo = &Ghost.m_RenderInfo;
-			if(aSkinName[0] != '\0')
-			{
-				const CSkin *pSkin = m_pClient->m_Skins.Find(aSkinName);
-				pRenderInfo->m_OriginalRenderSkin = pSkin->m_OriginalSkin;
-				pRenderInfo->m_ColorableRenderSkin = pSkin->m_ColorableSkin;
-				pRenderInfo->m_SkinMetrics = pSkin->m_Metrics;
-			}
-			else
-			{
-				pRenderInfo->m_OriginalRenderSkin.Reset();
-				pRenderInfo->m_ColorableRenderSkin.Reset();
-			}
-		}
-	}
-	if(!m_CurGhost.Empty())
-	{
-		IntsToStr(&m_CurGhost.m_Skin.m_Skin0, 6, aSkinName);
+	const auto &&RefindSkin = [&](auto &Ghost) {
+		if(Ghost.Empty())
+			return;
+		char aSkinName[64];
+		IntsToStr(&Ghost.m_Skin.m_Skin0, 6, aSkinName);
+		CTeeRenderInfo *pRenderInfo = &Ghost.m_RenderInfo;
 		if(aSkinName[0] != '\0')
 		{
-			CTeeRenderInfo *pRenderInfo = &m_CurGhost.m_RenderInfo;
-
 			const CSkin *pSkin = m_pClient->m_Skins.Find(aSkinName);
 			pRenderInfo->m_OriginalRenderSkin = pSkin->m_OriginalSkin;
 			pRenderInfo->m_ColorableRenderSkin = pSkin->m_ColorableSkin;
+			pRenderInfo->m_BloodColor = pSkin->m_BloodColor;
 			pRenderInfo->m_SkinMetrics = pSkin->m_Metrics;
 		}
+		else
+		{
+			pRenderInfo->m_OriginalRenderSkin.Reset();
+			pRenderInfo->m_ColorableRenderSkin.Reset();
+		}
+	};
+
+	for(auto &Ghost : m_aActiveGhosts)
+	{
+		RefindSkin(Ghost);
 	}
+	RefindSkin(m_CurGhost);
 }

--- a/src/game/client/components/ghost.h
+++ b/src/game/client/components/ghost.h
@@ -176,7 +176,7 @@ public:
 
 	int GetLastRaceTick();
 
-	void RefindSkin();
+	void RefindSkins();
 };
 
 #endif

--- a/src/game/client/components/killmessages.h
+++ b/src/game/client/components/killmessages.h
@@ -20,15 +20,13 @@ public:
 	{
 		int m_Weapon;
 
-		int m_VictimID;
-		int m_VictimTeam;
+		int m_aVictimIds[MAX_KILLMSG_TEAM_MEMBERS];
 		int m_VictimDDTeam;
 		char m_aVictimName[64];
 		STextContainerIndex m_VictimTextContainerIndex;
 		float m_VictimTextWidth;
-		CTeeRenderInfo m_VictimRenderInfo[MAX_KILLMSG_TEAM_MEMBERS];
+		CTeeRenderInfo m_aVictimRenderInfo[MAX_KILLMSG_TEAM_MEMBERS];
 		int m_KillerID;
-		int m_KillerTeam;
 		char m_aKillerName[64];
 		STextContainerIndex m_KillerTextContainerIndex;
 		float m_KillerTextWidth;

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -404,7 +404,7 @@ void CPlayers::RenderPlayer(
 
 	m_pClient->m_Flow.Add(Position, Vel * 100.0f, 10.0f);
 
-	RenderInfo.m_GotAirJump = Player.m_Jumped & 2 ? 0 : 1;
+	RenderInfo.m_GotAirJump = Player.m_Jumped & 2 ? false : true;
 
 	RenderInfo.m_FeetFlipped = false;
 

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -749,18 +749,20 @@ inline bool CPlayers::IsPlayerInfoAvailable(int ClientID) const
 
 void CPlayers::OnRender()
 {
+	CTeeRenderInfo aRenderInfo[MAX_CLIENTS];
+
 	// update RenderInfo for ninja
 	bool IsTeamplay = false;
 	if(m_pClient->m_Snap.m_pGameInfoObj)
 		IsTeamplay = (m_pClient->m_Snap.m_pGameInfoObj->m_GameFlags & GAMEFLAG_TEAMS) != 0;
 	for(int i = 0; i < MAX_CLIENTS; ++i)
 	{
-		m_aRenderInfo[i] = m_pClient->m_aClients[i].m_RenderInfo;
-		m_aRenderInfo[i].m_TeeRenderFlags = 0;
+		aRenderInfo[i] = m_pClient->m_aClients[i].m_RenderInfo;
+		aRenderInfo[i].m_TeeRenderFlags = 0;
 		if(m_pClient->m_aClients[i].m_FreezeEnd != 0)
-			m_aRenderInfo[i].m_TeeRenderFlags |= TEE_EFFECT_FROZEN | TEE_NO_WEAPON;
+			aRenderInfo[i].m_TeeRenderFlags |= TEE_EFFECT_FROZEN | TEE_NO_WEAPON;
 		if(m_pClient->m_aClients[i].m_LiveFrozen)
-			m_aRenderInfo[i].m_TeeRenderFlags |= TEE_EFFECT_FROZEN;
+			aRenderInfo[i].m_TeeRenderFlags |= TEE_EFFECT_FROZEN;
 
 		const CGameClient::CSnapState::CCharacterInfo &CharacterInfo = m_pClient->m_Snap.m_aCharacters[i];
 		const bool Frozen = CharacterInfo.m_HasExtendedData && CharacterInfo.m_ExtendedData.m_FreezeEnd != 0;
@@ -770,27 +772,28 @@ void CPlayers::OnRender()
 			const auto *pSkin = m_pClient->m_Skins.FindOrNullptr("x_ninja");
 			if(pSkin != nullptr)
 			{
-				m_aRenderInfo[i].m_OriginalRenderSkin = pSkin->m_OriginalSkin;
-				m_aRenderInfo[i].m_ColorableRenderSkin = pSkin->m_ColorableSkin;
-				m_aRenderInfo[i].m_BloodColor = pSkin->m_BloodColor;
-				m_aRenderInfo[i].m_SkinMetrics = pSkin->m_Metrics;
-				m_aRenderInfo[i].m_CustomColoredSkin = IsTeamplay;
+				aRenderInfo[i].m_OriginalRenderSkin = pSkin->m_OriginalSkin;
+				aRenderInfo[i].m_ColorableRenderSkin = pSkin->m_ColorableSkin;
+				aRenderInfo[i].m_BloodColor = pSkin->m_BloodColor;
+				aRenderInfo[i].m_SkinMetrics = pSkin->m_Metrics;
+				aRenderInfo[i].m_CustomColoredSkin = IsTeamplay;
 				if(!IsTeamplay)
 				{
-					m_aRenderInfo[i].m_ColorBody = ColorRGBA(1, 1, 1);
-					m_aRenderInfo[i].m_ColorFeet = ColorRGBA(1, 1, 1);
+					aRenderInfo[i].m_ColorBody = ColorRGBA(1, 1, 1);
+					aRenderInfo[i].m_ColorFeet = ColorRGBA(1, 1, 1);
 				}
 			}
 		}
 	}
 	const CSkin *pSkin = m_pClient->m_Skins.Find("x_spec");
-	m_RenderInfoSpec.m_OriginalRenderSkin = pSkin->m_OriginalSkin;
-	m_RenderInfoSpec.m_ColorableRenderSkin = pSkin->m_ColorableSkin;
-	m_RenderInfoSpec.m_BloodColor = pSkin->m_BloodColor;
-	m_RenderInfoSpec.m_SkinMetrics = pSkin->m_Metrics;
-	m_RenderInfoSpec.m_CustomColoredSkin = false;
-	m_RenderInfoSpec.m_Size = 64.0f;
-	int LocalClientID = m_pClient->m_Snap.m_LocalClientID;
+	CTeeRenderInfo RenderInfoSpec;
+	RenderInfoSpec.m_OriginalRenderSkin = pSkin->m_OriginalSkin;
+	RenderInfoSpec.m_ColorableRenderSkin = pSkin->m_ColorableSkin;
+	RenderInfoSpec.m_BloodColor = pSkin->m_BloodColor;
+	RenderInfoSpec.m_SkinMetrics = pSkin->m_Metrics;
+	RenderInfoSpec.m_CustomColoredSkin = false;
+	RenderInfoSpec.m_Size = 64.0f;
+	const int LocalClientID = m_pClient->m_Snap.m_LocalClientID;
 
 	// get screen edges to avoid rendering offscreen
 	float ScreenX0, ScreenY0, ScreenX1, ScreenY1;
@@ -812,12 +815,12 @@ void CPlayers::OnRender()
 		{
 			continue;
 		}
-		RenderHook(&m_pClient->m_aClients[ClientID].m_RenderPrev, &m_pClient->m_aClients[ClientID].m_RenderCur, &m_aRenderInfo[ClientID], ClientID);
+		RenderHook(&m_pClient->m_aClients[ClientID].m_RenderPrev, &m_pClient->m_aClients[ClientID].m_RenderCur, &aRenderInfo[ClientID], ClientID);
 	}
 	if(LocalClientID != -1 && m_pClient->m_Snap.m_aCharacters[LocalClientID].m_Active && IsPlayerInfoAvailable(LocalClientID))
 	{
 		const CGameClient::CClientData *pLocalClientData = &m_pClient->m_aClients[LocalClientID];
-		RenderHook(&pLocalClientData->m_RenderPrev, &pLocalClientData->m_RenderCur, &m_aRenderInfo[LocalClientID], LocalClientID);
+		RenderHook(&pLocalClientData->m_RenderPrev, &pLocalClientData->m_RenderCur, &aRenderInfo[LocalClientID], LocalClientID);
 	}
 
 	// render spectating players
@@ -827,7 +830,7 @@ void CPlayers::OnRender()
 		{
 			continue;
 		}
-		RenderTools()->RenderTee(CAnimState::GetIdle(), &m_RenderInfoSpec, EMOTE_BLINK, vec2(1, 0), m_aClient.m_SpecChar);
+		RenderTools()->RenderTee(CAnimState::GetIdle(), &RenderInfoSpec, EMOTE_BLINK, vec2(1, 0), m_aClient.m_SpecChar);
 	}
 
 	// render everyone else's tee, then our own
@@ -846,13 +849,13 @@ void CPlayers::OnRender()
 		{
 			continue;
 		}
-		RenderPlayer(&m_pClient->m_aClients[ClientID].m_RenderPrev, &m_pClient->m_aClients[ClientID].m_RenderCur, &m_aRenderInfo[ClientID], ClientID);
+		RenderPlayer(&m_pClient->m_aClients[ClientID].m_RenderPrev, &m_pClient->m_aClients[ClientID].m_RenderCur, &aRenderInfo[ClientID], ClientID);
 	}
 	if(LocalClientID != -1 && m_pClient->m_Snap.m_aCharacters[LocalClientID].m_Active && IsPlayerInfoAvailable(LocalClientID))
 	{
 		const CGameClient::CClientData *pLocalClientData = &m_pClient->m_aClients[LocalClientID];
 		RenderHookCollLine(&pLocalClientData->m_RenderPrev, &pLocalClientData->m_RenderCur, LocalClientID);
-		RenderPlayer(&pLocalClientData->m_RenderPrev, &pLocalClientData->m_RenderCur, &m_aRenderInfo[LocalClientID], LocalClientID);
+		RenderPlayer(&pLocalClientData->m_RenderPrev, &pLocalClientData->m_RenderCur, &aRenderInfo[LocalClientID], LocalClientID);
 	}
 }
 

--- a/src/game/client/components/players.h
+++ b/src/game/client/components/players.h
@@ -11,8 +11,6 @@ class CPlayers : public CComponent
 {
 	friend class CGhost;
 
-	CTeeRenderInfo m_RenderInfoSpec;
-	CTeeRenderInfo m_aRenderInfo[MAX_CLIENTS];
 	void RenderHand(const CTeeRenderInfo *pInfo, vec2 CenterPos, vec2 Dir, float AngleOffset, vec2 PostRotOffset, float Alpha = 1.0f);
 	void RenderPlayer(
 		const CNetObj_Character *pPrevChar,

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -3350,13 +3350,13 @@ void CGameClient::RefindSkins()
 			const CSkin *pSkin = m_Skins.Find(Client.m_aSkinName);
 			Client.m_SkinInfo.m_OriginalRenderSkin = pSkin->m_OriginalSkin;
 			Client.m_SkinInfo.m_ColorableRenderSkin = pSkin->m_ColorableSkin;
-			Client.UpdateRenderInfo(IsTeamPlay());
 		}
 		else
 		{
 			Client.m_SkinInfo.m_OriginalRenderSkin.Reset();
 			Client.m_SkinInfo.m_ColorableRenderSkin.Reset();
 		}
+		Client.UpdateRenderInfo(IsTeamPlay());
 	}
 	m_Ghost.RefindSkins();
 	m_Chat.RefindSkins();

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -3358,7 +3358,7 @@ void CGameClient::RefindSkins()
 			Client.m_SkinInfo.m_ColorableRenderSkin.Reset();
 		}
 	}
-	m_Ghost.RefindSkin();
+	m_Ghost.RefindSkins();
 	m_Chat.RefindSkins();
 	m_KillMessages.RefindSkins();
 }

--- a/src/game/client/render.h
+++ b/src/game/client/render.h
@@ -34,7 +34,7 @@ public:
 		m_ColorBody = ColorRGBA(1, 1, 1);
 		m_ColorFeet = ColorRGBA(1, 1, 1);
 		m_Size = 1.0f;
-		m_GotAirJump = 1;
+		m_GotAirJump = true;
 		m_TeeRenderFlags = 0;
 	};
 
@@ -49,7 +49,7 @@ public:
 	ColorRGBA m_ColorBody;
 	ColorRGBA m_ColorFeet;
 	float m_Size;
-	int m_GotAirJump;
+	bool m_GotAirJump;
 	int m_TeeRenderFlags;
 	bool m_FeetFlipped;
 };

--- a/src/game/client/render.h
+++ b/src/game/client/render.h
@@ -31,12 +31,23 @@ class CTeeRenderInfo
 public:
 	CTeeRenderInfo()
 	{
-		m_ColorBody = ColorRGBA(1, 1, 1);
-		m_ColorFeet = ColorRGBA(1, 1, 1);
+		Reset();
+	}
+
+	void Reset()
+	{
+		m_OriginalRenderSkin.Reset();
+		m_ColorableRenderSkin.Reset();
+		m_SkinMetrics.Reset();
+		m_CustomColoredSkin = false;
+		m_BloodColor = ColorRGBA(1.0f, 1.0f, 1.0f, 1.0f);
+		m_ColorBody = ColorRGBA(1.0f, 1.0f, 1.0f, 1.0f);
+		m_ColorFeet = ColorRGBA(1.0f, 1.0f, 1.0f, 1.0f);
 		m_Size = 1.0f;
 		m_GotAirJump = true;
 		m_TeeRenderFlags = 0;
-	};
+		m_FeetFlipped = false;
+	}
 
 	CSkin::SSkinTextures m_OriginalRenderSkin;
 	CSkin::SSkinTextures m_ColorableRenderSkin;


### PR DESCRIPTION
At least with the method I described in https://github.com/ddnet/ddnet/issues/7205#issuecomment-1742842164, I cannot reproduce the assertion anymore. It previously happened in several components. In particular, this assertion also happened when rendering players and the HUD, for which the only explanation was that the gameclient render info was already wrong, which is fixed by 96ef1fbc88d21966c581176afab71ed5dca69004.

Closes #6882. Closes #7205.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
