### PR TITLE
Teeworlds style name quoting for team joins

### DIFF
--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -1083,7 +1083,7 @@ void CGameContext::ConJoinTeam(IConsole::IResult *pResult, void *pUserData)
 			else
 			{
 				char aBuf[512];
-				str_format(aBuf, sizeof(aBuf), "%s joined team %d",
+				str_format(aBuf, sizeof(aBuf), "'%s' joined team %d",
 					pSelf->Server()->ClientName(pPlayer->GetCID()),
 					Team);
 				pSelf->SendChat(-1, CGameContext::CHAT_ALL, aBuf);

--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -657,7 +657,7 @@ void CGameTeams::OnTeamFinish(CPlayer **Players, unsigned int Size, float Time, 
 		{
 			SetForceCharacterTeam(Players[i]->GetCID(), TEAM_FLOCK);
 			char aBuf[512];
-			str_format(aBuf, sizeof(aBuf), "%s joined team 0",
+			str_format(aBuf, sizeof(aBuf), "'%s' joined team 0",
 				GameServer()->Server()->ClientName(Players[i]->GetCID()));
 			GameServer()->SendChat(-1, CGameContext::CHAT_ALL, aBuf);
 		}


### PR DESCRIPTION
Before:
![image](https://github.com/ddnet/ddnet/assets/20344300/ca0e1cd4-4f37-410d-9ce6-f2762eaf510b)

After:
![image](https://github.com/ddnet/ddnet/assets/20344300/1029019c-2382-436b-9800-f006b11d418c)


:warning:  **Breaks chat parsers.**

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
