### PR TITLE
Remove redundant argument of `Dilate` function

### DIFF
--- a/src/engine/gfx/image_manipulation.cpp
+++ b/src/engine/gfx/image_manipulation.cpp
@@ -4,8 +4,9 @@
 
 #define TW_DILATE_ALPHA_THRESHOLD 10
 
-static void Dilate(int w, int h, int BPP, const unsigned char *pSrc, unsigned char *pDest, unsigned char AlphaThreshold = TW_DILATE_ALPHA_THRESHOLD)
+static void Dilate(int w, int h, const unsigned char *pSrc, unsigned char *pDest, unsigned char AlphaThreshold = TW_DILATE_ALPHA_THRESHOLD)
 {
+	const int BPP = 4; // RGBA assumed
 	int ix, iy;
 	const int aDirX[] = {0, -1, 1, 0};
 	const int aDirY[] = {-1, 0, 0, 1};
@@ -71,13 +72,14 @@ static void CopyColorValues(int w, int h, int BPP, const unsigned char *pSrc, un
 	}
 }
 
-void DilateImage(unsigned char *pImageBuff, int w, int h, int BPP)
+void DilateImage(unsigned char *pImageBuff, int w, int h)
 {
-	DilateImageSub(pImageBuff, w, h, BPP, 0, 0, w, h);
+	DilateImageSub(pImageBuff, w, h, 0, 0, w, h);
 }
 
-void DilateImageSub(unsigned char *pImageBuff, int w, int h, int BPP, int x, int y, int sw, int sh)
+void DilateImageSub(unsigned char *pImageBuff, int w, int h, int x, int y, int sw, int sh)
 {
+	const int BPP = 4; // RGBA assumed
 	unsigned char *apBuffer[2] = {NULL, NULL};
 
 	apBuffer[0] = (unsigned char *)malloc((size_t)sw * sh * sizeof(unsigned char) * BPP);
@@ -94,12 +96,12 @@ void DilateImageSub(unsigned char *pImageBuff, int w, int h, int BPP, int x, int
 		mem_copy(&pBufferOriginal[DstImgOffset], &pPixelBuff[SrcImgOffset], CopySize);
 	}
 
-	Dilate(sw, sh, BPP, pBufferOriginal, apBuffer[0]);
+	Dilate(sw, sh, pBufferOriginal, apBuffer[0]);
 
 	for(int i = 0; i < 5; i++)
 	{
-		Dilate(sw, sh, BPP, apBuffer[0], apBuffer[1]);
-		Dilate(sw, sh, BPP, apBuffer[1], apBuffer[0]);
+		Dilate(sw, sh, apBuffer[0], apBuffer[1]);
+		Dilate(sw, sh, apBuffer[1], apBuffer[0]);
 	}
 
 	CopyColorValues(sw, sh, BPP, apBuffer[0], pBufferOriginal);

--- a/src/engine/gfx/image_manipulation.h
+++ b/src/engine/gfx/image_manipulation.h
@@ -3,8 +3,9 @@
 
 #include <cstdint>
 
-void DilateImage(unsigned char *pImageBuff, int w, int h, int BPP);
-void DilateImageSub(unsigned char *pImageBuff, int w, int h, int BPP, int x, int y, int sw, int sh);
+// These functions assume that the image data is 4 bytes per pixel RGBA
+void DilateImage(unsigned char *pImageBuff, int w, int h);
+void DilateImageSub(unsigned char *pImageBuff, int w, int h, int x, int y, int sw, int sh);
 
 // returned pointer is allocated with malloc
 uint8_t *ResizeImage(const uint8_t *pImageData, int Width, int Height, int NewWidth, int NewHeight, int BPP);

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -3860,7 +3860,7 @@ bool CEditor::ReplaceImage(const char *pFileName, int StorageType, bool CheckDup
 
 	if(!pImg->m_External && g_Config.m_ClEditorDilate == 1 && pImg->m_Format == CImageInfo::FORMAT_RGBA)
 	{
-		DilateImage((unsigned char *)ImgInfo.m_pData, ImgInfo.m_Width, ImgInfo.m_Height, ImgInfo.PixelSize());
+		DilateImage((unsigned char *)ImgInfo.m_pData, ImgInfo.m_Width, ImgInfo.m_Height);
 	}
 
 	pImg->m_AutoMapper.Load(pImg->m_aName);
@@ -3920,7 +3920,7 @@ bool CEditor::AddImage(const char *pFileName, int StorageType, void *pUser)
 
 	if(!pImg->m_External && g_Config.m_ClEditorDilate == 1 && pImg->m_Format == CImageInfo::FORMAT_RGBA)
 	{
-		DilateImage((unsigned char *)ImgInfo.m_pData, ImgInfo.m_Width, ImgInfo.m_Height, ImgInfo.PixelSize());
+		DilateImage((unsigned char *)ImgInfo.m_pData, ImgInfo.m_Width, ImgInfo.m_Height);
 	}
 
 	int TextureLoadFlag = pEditor->Graphics()->HasTextureArrays() ? IGraphics::TEXLOAD_TO_2D_ARRAY_TEXTURE : IGraphics::TEXLOAD_TO_3D_TEXTURE;

--- a/src/tools/dilate.cpp
+++ b/src/tools/dilate.cpp
@@ -43,7 +43,7 @@ int DilateFile(const char *pFilename)
 			int w = Img.m_Width;
 			int h = Img.m_Height;
 
-			DilateImage(pBuffer, w, h, 4);
+			DilateImage(pBuffer, w, h);
 
 			// save here
 			IOHANDLE SaveFile = io_open(pFilename, IOFLAG_WRITE);

--- a/src/tools/map_optimize.cpp
+++ b/src/tools/map_optimize.cpp
@@ -274,12 +274,12 @@ int main(int argc, const char **argv)
 							int ImgTileH = Height / 16;
 							int x = (i % 16) * ImgTileW;
 							int y = (i / 16) * ImgTileH;
-							DilateImageSub(pImgBuff, Width, Height, 4, x, y, ImgTileW, ImgTileH);
+							DilateImageSub(pImgBuff, Width, Height, x, y, ImgTileW, ImgTileH);
 						}
 					}
 					else
 					{
-						DilateImage(pImgBuff, Width, Height, 4);
+						DilateImage(pImgBuff, Width, Height);
 					}
 				}
 			}


### PR DESCRIPTION
The pixel size (bytes per pixel) always has to be 4 for the `Dilate` function to work correctly. This is already checked before calling the function, so the redundant argument which is always `4` can be removed.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
