### PR TITLE
Fix the fix to the fix to dead reckoning

### DIFF
--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -877,6 +877,7 @@ void CCharacter::TickDeferred()
 			m_SendCore = m_Core;
 			m_ReckoningCore = m_Core;
 			m_ReckoningCore.SetCoreWorld(nullptr, Collision(), nullptr);
+			m_ReckoningCore.m_Tuning = *GameWorld()->Tuning();
 			m_Core.m_Reset = false;
 		}
 	}
@@ -1916,9 +1917,9 @@ void CCharacter::HandleTuneLayer()
 	m_TuneZone = Collision()->IsTune(CurrentIndex);
 
 	if(m_TuneZone)
-		m_Core.m_Tuning = m_ReckoningCore.m_Tuning = TuningList()[m_TuneZone]; // throw tunings from specific zone into gamecore
+		m_Core.m_Tuning = TuningList()[m_TuneZone]; // throw tunings from specific zone into gamecore
 	else
-		m_Core.m_Tuning = m_ReckoningCore.m_Tuning = *Tuning();
+		m_Core.m_Tuning = *Tuning();
 
 	if(m_TuneZone != m_TuneZoneOld) // don't send tunigs all the time
 	{


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->
I was fooled by the tuning line in the constructor of `CWorldCore`. The tunings are supposed to be what vanilla clients can know, not what ddnet clients can know.

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
