### PR TITLE
Don't use mouse position for angle if paused.

### DIFF
--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -384,7 +384,7 @@ void CPlayers::RenderPlayer(
 	float AttackTicksPassed = AttackTime * (float)SERVER_TICK_SPEED;
 
 	float Angle;
-	if(Local && Client()->State() != IClient::STATE_DEMOPLAYBACK)
+	if(Local && (!m_pClient->m_Snap.m_SpecInfo.m_Active || m_pClient->m_Snap.m_SpecInfo.m_SpectatorID != SPEC_FREEVIEW) && Client()->State() != IClient::STATE_DEMOPLAYBACK)
 	{
 		// just use the direct input if it's the local player we are rendering
 		Angle = angle(m_pClient->m_Controls.m_aMousePos[g_Config.m_ClDummy]);


### PR DESCRIPTION
Previously it would always show the same angle if you were paused but then it would snap back to the actual angle when you exited pause.

Before:

https://github.com/ddnet/ddnet/assets/141338449/57c910a5-9f17-42e2-8ed3-c948d2228561

After:

https://github.com/ddnet/ddnet/assets/141338449/88b02156-0330-40cc-b494-12dd02ea3de0



## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
