### PR TITLE
Vanilla tunings should be used for reckoning

### DIFF
--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -83,10 +83,8 @@ bool CCharacter::Spawn(CPlayer *pPlayer, vec2 Pos)
 
 	m_ReckoningTick = 0;
 	m_SendCore = CCharacterCore();
-	m_ReckoningCore = CCharacterCore();
-
-	m_ReckoningCore.Init(nullptr, Collision());
-	m_ReckoningCore.m_Tuning = *Tuning();
+	m_ReckoningCore = m_Core;
+	m_ReckoningCore.SetCoreWorld(nullptr, Collision(), nullptr);
 
 	GameServer()->m_World.InsertEntity(this);
 	m_Alive = true;
@@ -877,7 +875,7 @@ void CCharacter::TickDeferred()
 			m_SendCore = m_Core;
 			m_ReckoningCore = m_Core;
 			m_ReckoningCore.SetCoreWorld(nullptr, Collision(), nullptr);
-			m_ReckoningCore.m_Tuning = *GameWorld()->Tuning();
+			m_ReckoningCore.m_Tuning = CTuningParams();
 			m_Core.m_Reset = false;
 		}
 	}


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->
I really hope this is the final version of this. I made 5 test maps with different combinations of tunezones and tunes, played through 2 maps, didn't notice any oddity. Prediction is just so confusing, don't think I'll ever be touching it again :cold_sweat: 

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [x] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
