### PR TITLE
Fix selected demo index being desynced with selected demo name

### DIFF
--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -899,16 +899,15 @@ int CMenus::DemolistFetchCallback(const CFsFileInfo *pInfo, int IsDir, int Stora
 	if(IsDir)
 	{
 		str_format(Item.m_aName, sizeof(Item.m_aName), "%s/", pInfo->m_pName);
-		Item.m_InfosLoaded = false;
-		Item.m_Valid = false;
 		Item.m_Date = 0;
 	}
 	else
 	{
 		str_truncate(Item.m_aName, sizeof(Item.m_aName), pInfo->m_pName, str_length(pInfo->m_pName) - str_length(".demo"));
-		Item.m_InfosLoaded = false;
 		Item.m_Date = pInfo->m_TimeModified;
 	}
+	Item.m_InfosLoaded = false;
+	Item.m_Valid = false;
 	Item.m_IsDir = IsDir != 0;
 	Item.m_IsLink = false;
 	Item.m_StorageType = StorageType;

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -996,32 +996,38 @@ void CMenus::RefreshFilteredDemos()
 void CMenus::DemolistOnUpdate(bool Reset)
 {
 	if(Reset)
-		m_aCurrentDemoSelectionName[0] = '\0';
+	{
+		if(m_vpFilteredDemos.empty())
+		{
+			m_DemolistSelectedIndex = -1;
+			m_aCurrentDemoSelectionName[0] = '\0';
+		}
+		else
+		{
+			m_DemolistSelectedIndex = 0;
+			str_copy(m_aCurrentDemoSelectionName, m_vpFilteredDemos[m_DemolistSelectedIndex]->m_aName);
+		}
+	}
 	else
 	{
-		bool Found = false;
-		int SelectedIndex = -1;
 		RefreshFilteredDemos();
 
 		// search for selected index
-		for(auto &Item : m_vpFilteredDemos)
+		m_DemolistSelectedIndex = -1;
+		int SelectedIndex = -1;
+		for(const auto &pItem : m_vpFilteredDemos)
 		{
 			SelectedIndex++;
-
-			if(str_comp(m_aCurrentDemoSelectionName, Item->m_aName) == 0)
+			if(str_comp(m_aCurrentDemoSelectionName, pItem->m_aName) == 0)
 			{
-				Found = true;
+				m_DemolistSelectedIndex = SelectedIndex;
 				break;
 			}
 		}
-
-		if(Found)
-			m_DemolistSelectedIndex = SelectedIndex;
 	}
 
-	m_DemolistSelectedIndex = Reset ? !m_vpFilteredDemos.empty() ? 0 : -1 :
-					  m_DemolistSelectedIndex >= (int)m_vpFilteredDemos.size() ? m_vpFilteredDemos.size() - 1 : m_DemolistSelectedIndex;
-	m_DemolistSelectedReveal = true;
+	if(m_DemolistSelectedIndex >= 0)
+		m_DemolistSelectedReveal = true;
 }
 
 bool CMenus::FetchHeader(CDemoItem &Item)


### PR DESCRIPTION
When using the demo filter and the selected demo name does not match any visible demo item, temporarily reset the selected demo index instead of keeping an incorrect demo index. This makes the behavior consistent with the server browser.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
