### PR TITLE
Fix leak of command line arguments on Windows

### DIFF
--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -4039,6 +4039,7 @@ void cmdline_fix(int *argc, const char ***argv)
 		new_argv[i + 1] = new_argv[i] + size;
 	}
 
+	LocalFree(wide_argv);
 	new_argv[wide_argc] = 0;
 	*argc = wide_argc;
 	*argv = (const char **)new_argv;


### PR DESCRIPTION
See https://learn.microsoft.com/en-us/windows/win32/api/shellapi/nf-shellapi-commandlinetoargvw#remarks

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
