### PR TITLE
Fix additional clang-tidy 16 errors, remove some obsolete suppressions

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -16,6 +16,8 @@
 #   Crashes: https://github.com/llvm/llvm-project/issues/53359
 # misc-use-anonymous-namespace
 #   We don't want to use anonymous namespaces instead of static functions.
+# bugprone-suspicious-realloc-usage
+#   We generally don't handle memory allocation failures.
 
 Checks: >
   -*,
@@ -32,6 +34,7 @@ Checks: >
   -bugprone-reserved-identifier,
   -bugprone-suspicious-include,
   -bugprone-unhandled-self-assignment,
+  -bugprone-suspicious-realloc-usage,
   clang-analyzer-*,
   -clang-analyzer-optin.cplusplus.UninitializedObject,
   -clang-analyzer-optin.cplusplus.VirtualCall,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -10,8 +10,6 @@
 #   TODO: Requires C11 to fix
 # misc-unused-parameters
 #   TODO: Many changes
-# readability-static-accessed-through-instance,
-#   Crashes: https://github.com/llvm/llvm-project/issues/53359
 # misc-use-anonymous-namespace
 #   We don't want to use anonymous namespaces instead of static functions.
 # bugprone-suspicious-realloc-usage
@@ -87,7 +85,6 @@ Checks: >
   -readability-named-parameter,
   -readability-non-const-parameter,
   -readability-simplify-boolean-expr,
-  -readability-static-accessed-through-instance,
   -readability-suspicious-call-argument,
   -readability-uppercase-literal-suffix,
   performance-*,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -14,6 +14,8 @@
 #   TODO: Many changes
 # readability-static-accessed-through-instance,
 #   Crashes: https://github.com/llvm/llvm-project/issues/53359
+# misc-use-anonymous-namespace
+#   We don't want to use anonymous namespaces instead of static functions.
 
 Checks: >
   -*,
@@ -48,6 +50,7 @@ Checks: >
   -misc-non-private-member-variables-in-classes,
   -misc-static-assert,
   -misc-unused-parameters,
+  -misc-use-anonymous-namespace,
   modernize-avoid-bind,
   modernize-concat-nested-namespaces,
   modernize-deprecated-headers,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -8,8 +8,6 @@
 #   Too annoying to always align for perfect padding
 # clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling,
 #   TODO: Requires C11 to fix
-# modernize-use-override,
-#   TODO: modernize-use-override.IgnoreDestructors not supported on ubuntu-latest yet for CI
 # misc-unused-parameters
 #   TODO: Many changes
 # readability-static-accessed-through-instance,
@@ -71,6 +69,7 @@ Checks: >
   modernize-use-emplace,
   modernize-use-equals-default,
   modernize-use-equals-delete,
+  modernize-use-override,
   modernize-use-transparent-functors,
   modernize-use-uncaught-exceptions,
   readability-*,

--- a/src/base/log.cpp
+++ b/src/base/log.cpp
@@ -254,7 +254,7 @@ public:
 		aio_write_newline_unlocked(m_pAio);
 		aio_unlock(m_pAio);
 	}
-	~CLoggerAsync()
+	~CLoggerAsync() override
 	{
 		if(m_Close)
 		{

--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -1565,7 +1565,7 @@ std::string windows_format_system_message(unsigned long error)
 	if(FormatMessageW(flags, NULL, error, 0, (LPWSTR)&wide_message, 0, NULL) == 0)
 		return "unknown error";
 
-	const std::string message = windows_wide_to_utf8(wide_message);
+	std::string message = windows_wide_to_utf8(wide_message);
 	LocalFree(wide_message);
 	return message;
 }

--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -2464,7 +2464,7 @@ char *fs_getcwd(char *buffer, int buffer_size)
 #if defined(CONF_FAMILY_WINDOWS)
 	const DWORD size_needed = GetCurrentDirectoryW(0, nullptr);
 	std::wstring wide_current_dir(size_needed, L'0');
-	DWORD result = GetCurrentDirectoryW(size_needed, &wide_current_dir[0]);
+	DWORD result = GetCurrentDirectoryW(size_needed, wide_current_dir.data());
 	if(result == 0)
 	{
 		const DWORD LastError = GetLastError();
@@ -4566,7 +4566,7 @@ std::wstring windows_utf8_to_wide(const char *str)
 		return L"";
 	const int size_needed = MultiByteToWideChar(CP_UTF8, 0, str, orig_length, nullptr, 0);
 	std::wstring wide_string(size_needed, L'\0');
-	dbg_assert(MultiByteToWideChar(CP_UTF8, 0, str, orig_length, &wide_string[0], size_needed) == size_needed, "MultiByteToWideChar failure");
+	dbg_assert(MultiByteToWideChar(CP_UTF8, 0, str, orig_length, wide_string.data(), size_needed) == size_needed, "MultiByteToWideChar failure");
 	return wide_string;
 }
 
@@ -4577,7 +4577,7 @@ std::string windows_wide_to_utf8(const wchar_t *wide_str)
 		return "";
 	const int size_needed = WideCharToMultiByte(CP_UTF8, 0, wide_str, orig_length, nullptr, 0, nullptr, nullptr);
 	std::string string(size_needed, '\0');
-	dbg_assert(WideCharToMultiByte(CP_UTF8, 0, wide_str, orig_length, &string[0], size_needed, nullptr, nullptr) == size_needed, "WideCharToMultiByte failure");
+	dbg_assert(WideCharToMultiByte(CP_UTF8, 0, wide_str, orig_length, string.data(), size_needed, nullptr, nullptr) == size_needed, "WideCharToMultiByte failure");
 	return string;
 }
 

--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -4015,6 +4015,7 @@ void cmdline_fix(int *argc, const char ***argv)
 	int wide_argc = 0;
 	WCHAR **wide_argv = CommandLineToArgvW(GetCommandLineW(), &wide_argc);
 	dbg_assert(wide_argv != NULL, "CommandLineToArgvW failure");
+	dbg_assert(wide_argc > 0, "Invalid argc value");
 
 	int total_size = 0;
 

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -4564,15 +4564,15 @@ int main(int argc, const char **argv)
 
 	const bool RandInitFailed = secure_random_init() != 0;
 	if(!RandInitFailed)
-		CleanerFunctions.push([]() { secure_random_uninit(); });
+		CleanerFunctions.emplace([]() { secure_random_uninit(); });
 
 	NotificationsInit();
-	CleanerFunctions.push([]() { NotificationsUninit(); });
+	CleanerFunctions.emplace([]() { NotificationsUninit(); });
 
 	// Register SDL for cleanup before creating the kernel and client,
 	// so SDL is shutdown after kernel and client. Otherwise the client
 	// may crash when shutting down after SDL is already shutdown.
-	CleanerFunctions.push([]() { SDL_Quit(); });
+	CleanerFunctions.emplace([]() { SDL_Quit(); });
 
 	CClient *pClient = CreateClient();
 	pClient->SetLoggers(pFutureFileLogger, std::move(pStdoutLogger));
@@ -4580,7 +4580,7 @@ int main(int argc, const char **argv)
 	IKernel *pKernel = IKernel::Create();
 	pKernel->RegisterInterface(pClient, false);
 	pClient->RegisterInterfaces();
-	CleanerFunctions.push([pKernel, pClient]() {
+	CleanerFunctions.emplace([pKernel, pClient]() {
 		pKernel->Shutdown();
 		delete pKernel;
 		pClient->~CClient();
@@ -4648,7 +4648,7 @@ int main(int argc, const char **argv)
 
 		RegisterFail = RegisterFail || !pKernel->RegisterInterface(pEngine, false);
 
-		CleanerFunctions.push([pEngine]() {
+		CleanerFunctions.emplace([pEngine]() {
 			// Has to be before destroying graphics so that skin download thread can finish
 			delete pEngine;
 		});

--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -789,7 +789,7 @@ public:
 		str_copy(m_aName, pName);
 	}
 
-	virtual ~CScreenshotSaveJob()
+	~CScreenshotSaveJob() override
 	{
 		free(m_pData);
 	}

--- a/src/engine/client/serverbrowser_http.cpp
+++ b/src/engine/client/serverbrowser_http.cpp
@@ -60,7 +60,7 @@ private:
 	public:
 		CJob(std::shared_ptr<CData> pData) :
 			m_pData(std::move(pData)) { m_Lock = lock_create(); }
-		virtual ~CJob() { lock_destroy(m_Lock); }
+		~CJob() override { lock_destroy(m_Lock); }
 		void Abort() REQUIRES(!m_Lock);
 	};
 
@@ -250,7 +250,7 @@ class CServerBrowserHttp : public IServerBrowserHttp
 {
 public:
 	CServerBrowserHttp(IEngine *pEngine, IConsole *pConsole, const char **ppUrls, int NumUrls, int PreviousBestIndex);
-	virtual ~CServerBrowserHttp();
+	~CServerBrowserHttp() override;
 	void Update() override;
 	bool IsRefreshing() override { return m_State != STATE_DONE; }
 	void Refresh() override;

--- a/src/engine/client/serverbrowser_ping_cache.cpp
+++ b/src/engine/client/serverbrowser_ping_cache.cpp
@@ -19,7 +19,7 @@ public:
 	};
 
 	CServerBrowserPingCache(IConsole *pConsole, IStorage *pStorage);
-	virtual ~CServerBrowserPingCache() = default;
+	~CServerBrowserPingCache() override = default;
 
 	void Load() override;
 

--- a/src/engine/client/steam.cpp
+++ b/src/engine/client/steam.cpp
@@ -24,7 +24,7 @@ public:
 		ReadLaunchCommandLine();
 		str_copy(m_aPlayerName, SteamAPI_ISteamFriends_GetPersonaName(m_pSteamFriends));
 	}
-	~CSteam()
+	~CSteam() override
 	{
 		SteamAPI_Shutdown();
 	}

--- a/src/engine/server/databases/sqlite.cpp
+++ b/src/engine/server/databases/sqlite.cpp
@@ -11,7 +11,7 @@ class CSqliteConnection : public IDbConnection
 {
 public:
 	CSqliteConnection(const char *pFilename, bool Setup);
-	virtual ~CSqliteConnection();
+	~CSqliteConnection() override;
 	void Print(IConsole *pConsole, const char *pMode) override;
 
 	const char *BinaryCollate() const override { return "BINARY"; }

--- a/src/engine/server/register.cpp
+++ b/src/engine/server/register.cpp
@@ -91,7 +91,7 @@ class CRegister : public IRegister
 				m_pRegister(std::move(pRegister))
 			{
 			}
-			virtual ~CJob() = default;
+			~CJob() override = default;
 		};
 
 		CRegister *m_pParent;

--- a/src/engine/shared/jsonwriter.cpp
+++ b/src/engine/shared/jsonwriter.cpp
@@ -167,7 +167,7 @@ void CJsonWriter::PushState(EJsonStateKind NewState)
 	{
 		m_States.top().m_Empty = false;
 	}
-	m_States.push(SState(NewState));
+	m_States.emplace(NewState);
 	if(NewState != STATE_ATTRIBUTE)
 	{
 		m_Indentation++;

--- a/src/engine/shared/kernel.cpp
+++ b/src/engine/shared/kernel.cpp
@@ -53,7 +53,7 @@ public:
 		}
 	}
 
-	virtual ~CKernel()
+	~CKernel() override
 	{
 		// delete interfaces in reverse order just the way it would happen to objects on the stack
 		for(int i = m_NumInterfaces - 1; i >= 0; i--)

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -1711,7 +1711,7 @@ void CMenus::RenderSettingsGraphics(CUIRect MainView)
 		char aTmpBackendName[256];
 
 		auto IsInfoDefault = [](const SMenuBackendInfo &CheckInfo) {
-			return str_comp_nocase(CheckInfo.m_pBackendName, g_Config.ms_pGfxBackend) == 0 && CheckInfo.m_Major == g_Config.ms_GfxGLMajor && CheckInfo.m_Minor == g_Config.ms_GfxGLMinor && CheckInfo.m_Patch == g_Config.ms_GfxGLPatch;
+			return str_comp_nocase(CheckInfo.m_pBackendName, CConfig::ms_pGfxBackend) == 0 && CheckInfo.m_Major == CConfig::ms_GfxGLMajor && CheckInfo.m_Minor == CConfig::ms_GfxGLMinor && CheckInfo.m_Patch == CConfig::ms_GfxGLPatch;
 		};
 
 		int OldSelectedBackend = -1;

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -5161,7 +5161,7 @@ void CEditor::RenderModebar(CUIRect View)
 
 	// mode button
 	{
-		const char *pModeLabel = "";
+		const char *pModeLabel;
 		if(m_Mode == MODE_LAYERS)
 			pModeLabel = "Layers";
 		else if(m_Mode == MODE_IMAGES)
@@ -5169,7 +5169,10 @@ void CEditor::RenderModebar(CUIRect View)
 		else if(m_Mode == MODE_SOUNDS)
 			pModeLabel = "Sounds";
 		else
+		{
 			dbg_assert(false, "m_Mode invalid");
+			dbg_break();
+		}
 
 		static int s_ModeButton = 0;
 		const int MouseButton = DoButton_Ex(&s_ModeButton, pModeLabel, 0, &ModeButton, 0, "Switch between images, sounds and layers management.", IGraphics::CORNER_T, 10.0f);

--- a/src/game/editor/mapitems/layer_quads.cpp
+++ b/src/game/editor/mapitems/layer_quads.cpp
@@ -30,9 +30,9 @@ void CLayerQuads::Render(bool QuadPicker)
 		Graphics()->TextureSet(m_pEditor->m_Map.m_vpImages[m_Image]->m_Texture);
 
 	Graphics()->BlendNone();
-	m_pEditor->RenderTools()->ForceRenderQuads(m_vQuads.data(), m_vQuads.size(), LAYERRENDERFLAG_OPAQUE, m_pEditor->EnvelopeEval, m_pEditor);
+	m_pEditor->RenderTools()->ForceRenderQuads(m_vQuads.data(), m_vQuads.size(), LAYERRENDERFLAG_OPAQUE, CEditor::EnvelopeEval, m_pEditor);
 	Graphics()->BlendNormal();
-	m_pEditor->RenderTools()->ForceRenderQuads(m_vQuads.data(), m_vQuads.size(), LAYERRENDERFLAG_TRANSPARENT, m_pEditor->EnvelopeEval, m_pEditor);
+	m_pEditor->RenderTools()->ForceRenderQuads(m_vQuads.data(), m_vQuads.size(), LAYERRENDERFLAG_TRANSPARENT, CEditor::EnvelopeEval, m_pEditor);
 }
 
 CQuad *CLayerQuads::NewQuad(int x, int y, int Width, int Height)

--- a/src/game/editor/mapitems/layer_sounds.cpp
+++ b/src/game/editor/mapitems/layer_sounds.cpp
@@ -40,7 +40,7 @@ void CLayerSounds::Render(bool Tileset)
 		if(Source.m_PosEnv >= 0)
 		{
 			ColorRGBA Channels;
-			m_pEditor->EnvelopeEval(Source.m_PosEnvOffset, Source.m_PosEnv, Channels, m_pEditor);
+			CEditor::EnvelopeEval(Source.m_PosEnvOffset, Source.m_PosEnv, Channels, m_pEditor);
 			OffsetX = Channels.r;
 			OffsetY = Channels.g;
 		}
@@ -90,7 +90,7 @@ void CLayerSounds::Render(bool Tileset)
 		if(Source.m_PosEnv >= 0)
 		{
 			ColorRGBA Channels;
-			m_pEditor->EnvelopeEval(Source.m_PosEnvOffset, Source.m_PosEnv, Channels, m_pEditor);
+			CEditor::EnvelopeEval(Source.m_PosEnvOffset, Source.m_PosEnv, Channels, m_pEditor);
 			OffsetX = Channels.r;
 			OffsetY = Channels.g;
 		}

--- a/src/game/editor/mapitems/layer_tiles.cpp
+++ b/src/game/editor/mapitems/layer_tiles.cpp
@@ -131,10 +131,10 @@ void CLayerTiles::Render(bool Tileset)
 	ColorRGBA Color = ColorRGBA(m_Color.r / 255.0f, m_Color.g / 255.0f, m_Color.b / 255.0f, m_Color.a / 255.0f);
 	Graphics()->BlendNone();
 	m_pEditor->RenderTools()->RenderTilemap(m_pTiles, m_Width, m_Height, 32.0f, Color, LAYERRENDERFLAG_OPAQUE,
-		m_pEditor->EnvelopeEval, m_pEditor, m_ColorEnv, m_ColorEnvOffset);
+		CEditor::EnvelopeEval, m_pEditor, m_ColorEnv, m_ColorEnvOffset);
 	Graphics()->BlendNormal();
 	m_pEditor->RenderTools()->RenderTilemap(m_pTiles, m_Width, m_Height, 32.0f, Color, LAYERRENDERFLAG_TRANSPARENT,
-		m_pEditor->EnvelopeEval, m_pEditor, m_ColorEnv, m_ColorEnvOffset);
+		CEditor::EnvelopeEval, m_pEditor, m_ColorEnv, m_ColorEnvOffset);
 
 	// Render DDRace Layers
 	if(!Tileset)

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -58,7 +58,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupMenuFile(void *pContext, CUIRect Vie
 			pEditor->m_PopupEventActivated = true;
 		}
 		else
-			pEditor->InvokeFileDialog(IStorage::TYPE_ALL, FILETYPE_MAP, "Load map", "Load", "maps", false, pEditor->CallbackOpenMap, pEditor);
+			pEditor->InvokeFileDialog(IStorage::TYPE_ALL, FILETYPE_MAP, "Load map", "Load", "maps", false, CEditor::CallbackOpenMap, pEditor);
 		return CUI::POPUP_CLOSE_CURRENT;
 	}
 
@@ -82,7 +82,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupMenuFile(void *pContext, CUIRect Vie
 	View.HSplitTop(12.0f, &Slot, &View);
 	if(pEditor->DoButton_MenuItem(&s_AppendButton, "Append", 0, &Slot, 0, "Opens a map and adds everything from that map to the current one (ctrl+a)"))
 	{
-		pEditor->InvokeFileDialog(IStorage::TYPE_ALL, FILETYPE_MAP, "Append map", "Append", "maps", false, pEditor->CallbackAppendMap, pEditor);
+		pEditor->InvokeFileDialog(IStorage::TYPE_ALL, FILETYPE_MAP, "Append map", "Append", "maps", false, CEditor::CallbackAppendMap, pEditor);
 		return CUI::POPUP_CLOSE_CURRENT;
 	}
 
@@ -97,7 +97,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupMenuFile(void *pContext, CUIRect Vie
 			pEditor->m_PopupEventActivated = true;
 		}
 		else
-			pEditor->InvokeFileDialog(IStorage::TYPE_SAVE, FILETYPE_MAP, "Save map", "Save", "maps", false, pEditor->CallbackSaveMap, pEditor);
+			pEditor->InvokeFileDialog(IStorage::TYPE_SAVE, FILETYPE_MAP, "Save map", "Save", "maps", false, CEditor::CallbackSaveMap, pEditor);
 		return CUI::POPUP_CLOSE_CURRENT;
 	}
 
@@ -105,7 +105,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupMenuFile(void *pContext, CUIRect Vie
 	View.HSplitTop(12.0f, &Slot, &View);
 	if(pEditor->DoButton_MenuItem(&s_SaveAsButton, "Save As", 0, &Slot, 0, "Saves the current map under a new name (ctrl+shift+s)"))
 	{
-		pEditor->InvokeFileDialog(IStorage::TYPE_SAVE, FILETYPE_MAP, "Save map", "Save", "maps", true, pEditor->CallbackSaveMap, pEditor);
+		pEditor->InvokeFileDialog(IStorage::TYPE_SAVE, FILETYPE_MAP, "Save map", "Save", "maps", true, CEditor::CallbackSaveMap, pEditor);
 		return CUI::POPUP_CLOSE_CURRENT;
 	}
 
@@ -113,7 +113,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupMenuFile(void *pContext, CUIRect Vie
 	View.HSplitTop(12.0f, &Slot, &View);
 	if(pEditor->DoButton_MenuItem(&s_SaveCopyButton, "Save Copy", 0, &Slot, 0, "Saves a copy of the current map under a new name (ctrl+shift+alt+s)"))
 	{
-		pEditor->InvokeFileDialog(IStorage::TYPE_SAVE, FILETYPE_MAP, "Save map", "Save", "maps", true, pEditor->CallbackSaveCopyMap, pEditor);
+		pEditor->InvokeFileDialog(IStorage::TYPE_SAVE, FILETYPE_MAP, "Save map", "Save", "maps", true, CEditor::CallbackSaveCopyMap, pEditor);
 		return CUI::POPUP_CLOSE_CURRENT;
 	}
 
@@ -1578,7 +1578,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupImage(void *pContext, CUIRect View, 
 		View.HSplitTop(5.0f, nullptr, &View);
 		View.HSplitTop(12.0f, &Slot, &View);
 	}
-	else if(pEditor->IsVanillaImage(pImg->m_aName))
+	else if(CEditor::IsVanillaImage(pImg->m_aName))
 	{
 		if(pEditor->DoButton_MenuItem(&s_ExternalButton, "Make external", 0, &Slot, 0, "Removes the image from the map file."))
 		{

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -2860,7 +2860,7 @@ void CGameContext::ConTunes(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
 	char aBuf[256];
-	for(int i = 0; i < pSelf->Tuning()->Num(); i++)
+	for(int i = 0; i < CTuningParams::Num(); i++)
 	{
 		float Value;
 		pSelf->Tuning()->Get(i, &Value);
@@ -2899,7 +2899,7 @@ void CGameContext::ConTuneDumpZone(IConsole::IResult *pResult, void *pUserData)
 	char aBuf[256];
 	if(List >= 0 && List < NUM_TUNEZONES)
 	{
-		for(int i = 0; i < pSelf->TuningList()[List].Num(); i++)
+		for(int i = 0; i < CTuningParams::Num(); i++)
 		{
 			float Value;
 			pSelf->TuningList()[List].Get(i, &Value);

--- a/src/game/server/gamemodes/DDRace.cpp
+++ b/src/game/server/gamemodes/DDRace.cpp
@@ -234,13 +234,11 @@ void CGameControllerDDRace::InitTeleporter()
 		{
 			if(Type == TILE_TELEOUT)
 			{
-				m_TeleOuts[Number - 1].push_back(
-					vec2(i % Width * 32 + 16, i / Width * 32 + 16));
+				m_TeleOuts[Number - 1].emplace_back(i % Width * 32.0f + 16.0f, i / Width * 32.0f + 16.0f);
 			}
 			else if(Type == TILE_TELECHECKOUT)
 			{
-				m_TeleCheckOuts[Number - 1].push_back(
-					vec2(i % Width * 32 + 16, i / Width * 32 + 16));
+				m_TeleCheckOuts[Number - 1].emplace_back(i % Width * 32.0f + 16.0f, i / Width * 32.0f + 16.0f);
 			}
 		}
 	}

--- a/src/tools/map_replace_area.cpp
+++ b/src/tools/map_replace_area.cpp
@@ -479,8 +479,8 @@ MapObject CreateMapObject(const CMapItemGroup *pLayerGroup, const int PosX, cons
 
 	for(int i = 0; i < 2; i++)
 	{
-		Ob.m_aaScreenOffset[i][0] = -Ob.ms_aStandardScreen[i];
-		Ob.m_aaScreenOffset[i][1] = Ob.ms_aStandardScreen[i];
+		Ob.m_aaScreenOffset[i][0] = -MapObject::ms_aStandardScreen[i];
+		Ob.m_aaScreenOffset[i][1] = MapObject::ms_aStandardScreen[i];
 		if(Ob.m_aSpeed[i] < 0)
 			std::swap(Ob.m_aaScreenOffset[i][0], Ob.m_aaScreenOffset[i][1]);
 	}


### PR DESCRIPTION
Fix additional clang-tidy errors that are found when running the current checks with clang-tidy 16.

Remove some obsolete suppressions and fix the errors instead.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
