### PR TITLE
Add `CEditorObject` class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2271,6 +2271,8 @@ if(CLIENT)
     component.h
     editor.cpp
     editor.h
+    editor_object.cpp
+    editor_object.h
     explanations.cpp
     map_grid.cpp
     map_grid.h

--- a/src/game/editor/component.cpp
+++ b/src/game/editor/component.cpp
@@ -1,22 +1,5 @@
 #include "component.h"
 
-#include "editor.h"
-
-void CEditorComponent::Init(CEditor *pEditor)
-{
-	m_pEditor = pEditor;
-	OnReset();
-}
-
-void CEditorComponent::OnUpdate(CUIRect View)
-{
-	OnRender(View);
-	if(IsActive())
-		OnActive();
-	else if(IsHot())
-		OnHot();
-}
-
 bool CEditorComponent::OnInput(const IInput::CEvent &Event)
 {
 	for(CEditorComponent &Component : m_vSubComponents)
@@ -26,48 +9,6 @@ bool CEditorComponent::OnInput(const IInput::CEvent &Event)
 	}
 	return false;
 }
-
-void CEditorComponent::OnRender(CUIRect View) {}
-
-void CEditorComponent::OnReset() {}
-void CEditorComponent::OnMapLoad() {}
-
-bool CEditorComponent::IsHot()
-{
-	return UI()->HotItem() == this;
-}
-
-void CEditorComponent::SetHot()
-{
-	UI()->SetHotItem(this);
-}
-
-void CEditorComponent::UnsetHot()
-{
-	if(IsHot())
-		UI()->SetHotItem(nullptr);
-}
-
-void CEditorComponent::OnHot() {}
-
-bool CEditorComponent::IsActive()
-{
-	return UI()->CheckActiveItem(this);
-}
-
-void CEditorComponent::SetActive()
-{
-	SetHot();
-	UI()->SetActiveItem(this);
-}
-
-void CEditorComponent::SetInactive()
-{
-	if(IsActive())
-		UI()->SetActiveItem(nullptr);
-}
-
-void CEditorComponent::OnActive() {}
 
 void CEditorComponent::InitSubComponents()
 {
@@ -81,17 +22,3 @@ void CEditorComponent::RegisterSubComponent(CEditorComponent &Component)
 {
 	m_vSubComponents.emplace_back(Component);
 }
-
-CEditor *CEditorComponent::Editor() { return m_pEditor; }
-const CEditor *CEditorComponent::Editor() const { return m_pEditor; }
-IInput *CEditorComponent::Input() { return m_pEditor->Input(); }
-IClient *CEditorComponent::Client() { return m_pEditor->Client(); }
-CConfig *CEditorComponent::Config() { return m_pEditor->Config(); }
-IConsole *CEditorComponent::Console() { return m_pEditor->Console(); }
-IEngine *CEditorComponent::Engine() { return m_pEditor->Engine(); }
-IGraphics *CEditorComponent::Graphics() { return m_pEditor->Graphics(); }
-ISound *CEditorComponent::Sound() { return m_pEditor->Sound(); }
-ITextRender *CEditorComponent::TextRender() { return m_pEditor->TextRender(); }
-IStorage *CEditorComponent::Storage() { return m_pEditor->Storage(); }
-CUI *CEditorComponent::UI() { return m_pEditor->UI(); }
-CRenderTools *CEditorComponent::RenderTools() { return m_pEditor->RenderTools(); }

--- a/src/game/editor/component.h
+++ b/src/game/editor/component.h
@@ -1,91 +1,30 @@
 #ifndef GAME_EDITOR_COMPONENT_H
 #define GAME_EDITOR_COMPONENT_H
 
-#include <functional>
-#include <game/client/ui.h>
+#include "editor_object.h"
 
-class CEditor;
-class IInput;
-class IClient;
-class CConfig;
-class IConsole;
-class IEngine;
-class IGraphics;
-class ISound;
-class ITextRender;
-class IStorage;
-class CRenderTools;
+#include <vector>
 
-class CEditorComponent
+class CEditorComponent : public CEditorObject
 {
 public:
-	virtual ~CEditorComponent() = default;
-
-	/**
-	 * Initialise the component and interface pointers.
-	 * Needs to be the first function that is called.
-	 */
-	virtual void Init(CEditor *pEditor);
-
-	/**
-	 * Calls `OnRender` and then maybe `OnHot` or `OnActive`.
-	 */
-	void OnUpdate(CUIRect View);
-
 	/**
 	 * Gets called before `OnRender`. Should return true
-	 * if the event was consumed.
+	 * if the event was consumed. By default the events
+	 * are forwarded to the subcomponents.
 	 */
-	virtual bool OnInput(const IInput::CEvent &Event);
-
-	virtual void OnRender(CUIRect View);
-
-	/**
-	 * Gets called after `OnRender` when the component is hot but not active.
-	 * I
-	 */
-	virtual void OnHot();
-
-	/**
-	 * Gets called after `OnRender` when the component is active.
-	 */
-	virtual void OnActive();
-
-	virtual void OnReset();
-	virtual void OnMapLoad();
-
-	bool IsHot();
-	void SetHot();
-	void UnsetHot();
-
-	bool IsActive();
-	void SetActive();
-	void SetInactive();
+	virtual bool OnInput(const IInput::CEvent &Event) override;
 
 	/**
 	 * Initialise all registered subcomponents.
 	 * Needs to be called after the interfaces have been initialised.
 	 */
 	void InitSubComponents();
+
+	// Register a new subcomponent.
 	void RegisterSubComponent(CEditorComponent &Component);
 
-	CEditor *Editor();
-	const CEditor *Editor() const;
-	IInput *Input();
-	IClient *Client();
-	CConfig *Config();
-	IConsole *Console();
-	IEngine *Engine();
-	IGraphics *Graphics();
-	ISound *Sound();
-	ITextRender *TextRender();
-	IStorage *Storage();
-	CUI *UI();
-	CRenderTools *RenderTools();
-
 private:
-	CEditor *m_pEditor;
-
 	std::vector<std::reference_wrapper<CEditorComponent>> m_vSubComponents = {};
 };
 

--- a/src/game/editor/editor_object.cpp
+++ b/src/game/editor/editor_object.cpp
@@ -1,0 +1,79 @@
+#include "editor_object.h"
+
+#include "editor.h"
+
+void CEditorObject::Init(CEditor *pEditor)
+{
+	m_pEditor = pEditor;
+	OnReset();
+}
+
+void CEditorObject::OnUpdate(CUIRect View)
+{
+	OnRender(View);
+	if(IsActive())
+		OnActive();
+	else if(IsHot())
+		OnHot();
+}
+
+bool CEditorObject::OnInput(const IInput::CEvent &Event)
+{
+	return false;
+}
+
+void CEditorObject::OnRender(CUIRect View) {}
+
+void CEditorObject::OnReset() {}
+void CEditorObject::OnMapLoad() {}
+
+bool CEditorObject::IsHot()
+{
+	return UI()->HotItem() == this;
+}
+
+void CEditorObject::SetHot()
+{
+	UI()->SetHotItem(this);
+}
+
+void CEditorObject::UnsetHot()
+{
+	if(IsHot())
+		UI()->SetHotItem(nullptr);
+}
+
+void CEditorObject::OnHot() {}
+
+bool CEditorObject::IsActive()
+{
+	return UI()->CheckActiveItem(this);
+}
+
+void CEditorObject::SetActive()
+{
+	SetHot();
+	UI()->SetActiveItem(this);
+}
+
+void CEditorObject::SetInactive()
+{
+	if(IsActive())
+		UI()->SetActiveItem(nullptr);
+}
+
+void CEditorObject::OnActive() {}
+
+CEditor *CEditorObject::Editor() { return m_pEditor; }
+const CEditor *CEditorObject::Editor() const { return m_pEditor; }
+IInput *CEditorObject::Input() { return m_pEditor->Input(); }
+IClient *CEditorObject::Client() { return m_pEditor->Client(); }
+CConfig *CEditorObject::Config() { return m_pEditor->Config(); }
+IConsole *CEditorObject::Console() { return m_pEditor->Console(); }
+IEngine *CEditorObject::Engine() { return m_pEditor->Engine(); }
+IGraphics *CEditorObject::Graphics() { return m_pEditor->Graphics(); }
+ISound *CEditorObject::Sound() { return m_pEditor->Sound(); }
+ITextRender *CEditorObject::TextRender() { return m_pEditor->TextRender(); }
+IStorage *CEditorObject::Storage() { return m_pEditor->Storage(); }
+CUI *CEditorObject::UI() { return m_pEditor->UI(); }
+CRenderTools *CEditorObject::RenderTools() { return m_pEditor->RenderTools(); }

--- a/src/game/editor/editor_object.h
+++ b/src/game/editor/editor_object.h
@@ -1,0 +1,86 @@
+#ifndef GAME_EDITOR_EDITOR_OBJECT_H
+#define GAME_EDITOR_EDITOR_OBJECT_H
+
+#include <functional>
+
+#include <engine/input.h>
+#include <game/client/ui_rect.h>
+
+class CUI;
+class CEditor;
+class IClient;
+class CConfig;
+class IConsole;
+class IEngine;
+class IGraphics;
+class ISound;
+class ITextRender;
+class IStorage;
+class CRenderTools;
+
+class CEditorObject
+{
+public:
+	virtual ~CEditorObject() = default;
+
+	/**
+	 * Initialise the component and interface pointers.
+	 * Needs to be the first function that is called.
+     * The default implentation also resets the component.
+	 */
+	virtual void Init(CEditor *pEditor);
+
+	/**
+	 * Calls `OnRender` and then maybe `OnHot` or `OnActive`.
+	 */
+	void OnUpdate(CUIRect View);
+
+	/**
+	 * Gets called before `OnRender`. Should return true
+	 * if the event was consumed.
+	 */
+	virtual bool OnInput(const IInput::CEvent &Event);
+
+	virtual void OnRender(CUIRect View);
+
+	/**
+	 * Gets called after `OnRender` when the component is hot but not active.
+	 * I
+	 */
+	virtual void OnHot();
+
+	/**
+	 * Gets called after `OnRender` when the component is active.
+	 */
+	virtual void OnActive();
+
+	virtual void OnReset();
+	virtual void OnMapLoad();
+
+	bool IsHot();
+	void SetHot();
+	void UnsetHot();
+
+	bool IsActive();
+	void SetActive();
+	void SetInactive();
+
+	CEditor *Editor();
+	const CEditor *Editor() const;
+	IInput *Input();
+	IClient *Client();
+	CConfig *Config();
+	IConsole *Console();
+	IEngine *Engine();
+	IGraphics *Graphics();
+	ISound *Sound();
+	ITextRender *TextRender();
+	IStorage *Storage();
+	CUI *UI();
+	CRenderTools *RenderTools();
+
+private:
+	CEditor *m_pEditor;
+};
+
+#endif


### PR DESCRIPTION
This class is slightly more light-weight than a `CEditorComponent` and its naming makes it more natural to inherit for envelope points, proof-mode positions etc.

<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
