### PR TITLE
server info: show clanmates in different color

### DIFF
--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1086,17 +1086,21 @@ void CMenus::RenderServerbrowserInfoScoreboard(CUIRect View, const CServerInfo *
 		Name = Item.m_Rect;
 
 		ColorRGBA Color;
-		const float alpha = (i % 2 + 1) * 0.05f;
+		const float Alpha = (i % 2 + 1) * 0.05f;
 		switch(CurrentClient.m_FriendState)
 		{
 		case IFriends::FRIEND_NO:
-			Color = ColorRGBA(1.0f, 1.0f, 1.0f, alpha);
+			Color = ColorRGBA(1.0f, 1.0f, 1.0f, Alpha);
 			break;
 		case IFriends::FRIEND_PLAYER:
-			Color = ColorRGBA(0.5f, 1.0f, 0.5f, 0.15f + alpha);
+			Color = ColorRGBA(0.5f, 1.0f, 0.5f, 0.15f + Alpha);
 			break;
 		case IFriends::FRIEND_CLAN:
-			Color = ColorRGBA(0.4f, 0.4f, 1.0f, 0.15f + alpha);
+			Color = ColorRGBA(0.4f, 0.4f, 1.0f, 0.15f + Alpha);
+			break;
+		default:
+			dbg_assert(false, "Invalid friend state");
+			dbg_break();
 			break;
 		}
 

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1085,9 +1085,21 @@ void CMenus::RenderServerbrowserInfoScoreboard(CUIRect View, const CServerInfo *
 		CUIRect Skin, Name, Clan, Score, Flag;
 		Name = Item.m_Rect;
 
-		ColorRGBA Color = CurrentClient.m_FriendState == IFriends::FRIEND_NO ?
-					  ColorRGBA(1.0f, 1.0f, 1.0f, (i % 2 + 1) * 0.05f) :
-					  ColorRGBA(0.5f, 1.0f, 0.5f, 0.15f + (i % 2 + 1) * 0.05f);
+		ColorRGBA Color;
+		const float alpha = (i % 2 + 1) * 0.05f;
+		switch(CurrentClient.m_FriendState)
+		{
+		case IFriends::FRIEND_NO:
+			Color = ColorRGBA(1.0f, 1.0f, 1.0f, alpha);
+			break;
+		case IFriends::FRIEND_PLAYER:
+			Color = ColorRGBA(0.5f, 1.0f, 0.5f, 0.15f + alpha);
+			break;
+		case IFriends::FRIEND_CLAN:
+			Color = ColorRGBA(0.4f, 0.4f, 1.0f, 0.15f + alpha);
+			break;
+		}
+
 		Name.Draw(Color, IGraphics::CORNER_ALL, 4.0f);
 		Name.VSplitLeft(1.0f, nullptr, &Name);
 		Name.VSplitLeft(34.0f, &Score, &Name);


### PR DESCRIPTION
closes #7315

![serverinfo](https://github.com/ddnet/ddnet/assets/121701317/b97ddba2-a2c8-4aac-b7b7-4c828a8f2ad8)

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
