### PR TITLE
Fix names of external images not being loaded in editor

### DIFF
--- a/src/game/editor/mapitems/map_io.cpp
+++ b/src/game/editor/mapitems/map_io.cpp
@@ -503,10 +503,13 @@ bool CEditorMap::Load(const char *pFileName, int StorageType, const std::functio
 				str_format(aBuf, sizeof(aBuf), "mapres/%s.png", pImg->m_aName);
 
 				// load external
-				CEditorImage ImgInfo(m_pEditor);
+				CImageInfo ImgInfo;
 				if(m_pEditor->Graphics()->LoadPNG(&ImgInfo, aBuf, IStorage::TYPE_ALL))
 				{
-					*pImg = ImgInfo;
+					pImg->m_Width = ImgInfo.m_Width;
+					pImg->m_Height = ImgInfo.m_Height;
+					pImg->m_Format = ImgInfo.m_Format;
+					pImg->m_pData = ImgInfo.m_pData;
 					int TextureLoadFlag = m_pEditor->Graphics()->HasTextureArrays() ? IGraphics::TEXLOAD_TO_2D_ARRAY_TEXTURE : IGraphics::TEXLOAD_TO_3D_TEXTURE;
 					if(ImgInfo.m_Width % 16 != 0 || ImgInfo.m_Height % 16 != 0)
 						TextureLoadFlag = 0;


### PR DESCRIPTION
The entire `CEditorImage` was being overwritten when loading external images, which was causing the already loaded image name to be cleared, due to the changed order of operations (regression from #7008). This is fixed by using `CImageInfo` to load the image and only copying the relevant members to the `CEditorImage`.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
