### PR TITLE
Move "Regular background color" setting to background

### DIFF
--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -3136,9 +3136,13 @@ void CMenus::RenderSettingsDDNet(CUIRect MainView)
 	Background.HSplitTop(5.0f, nullptr, &Background);
 	UI()->DoLabel(&Label, Localize("Background"), 20.0f, TEXTALIGN_ML);
 
-	static CButtonContainer s_ResetID2;
 	ColorRGBA GreyDefault(0.5f, 0.5f, 0.5f, 1);
-	DoLine_ColorPicker(&s_ResetID2, 25.0f, 13.0f, 5.0f, &Background, Localize("Entities Background color"), &g_Config.m_ClBackgroundEntitiesColor, GreyDefault, false);
+
+	static CButtonContainer s_ResetID1;
+	DoLine_ColorPicker(&s_ResetID1, 25.0f, 13.0f, 5.0f, &Background, Localize("Regular background color"), &g_Config.m_ClBackgroundColor, GreyDefault, false);
+
+	static CButtonContainer s_ResetID2;
+	DoLine_ColorPicker(&s_ResetID2, 25.0f, 13.0f, 5.0f, &Background, Localize("Entities background color"), &g_Config.m_ClBackgroundEntitiesColor, GreyDefault, false);
 
 	CUIRect EditBox;
 	Background.HSplitTop(20.0f, &Label, &Background);
@@ -3181,12 +3185,7 @@ void CMenus::RenderSettingsDDNet(CUIRect MainView)
 
 	UI()->DoLabel(&Label, Localize("Miscellaneous"), 20.0f, TEXTALIGN_ML);
 
-	static CButtonContainer s_ResetID1;
-	Miscellaneous.HSplitTop(25.0f, &Button, &Miscellaneous);
-	DoLine_ColorPicker(&s_ResetID1, 25.0f, 13.0f, 5.0f, &Button, Localize("Regular Background Color"), &g_Config.m_ClBackgroundColor, GreyDefault, false);
-
 	static CButtonContainer s_ButtonTimeout;
-	Miscellaneous.HSplitTop(10.0f, nullptr, &Miscellaneous);
 	Miscellaneous.HSplitTop(20.0f, &Button, &Miscellaneous);
 	if(DoButton_Menu(&s_ButtonTimeout, Localize("New random timeout code"), 0, &Button))
 	{


### PR DESCRIPTION
"Regular background color" setting is now moved to background instead of miscellaneous. Also made the capitalization correct.

"Entities Background color" -> "Entities background color"
"Regular Background Color" -> "Regular background color"

Before,

![image](https://github.com/ddnet/ddnet/assets/141338449/e93ff2dd-86c6-4e12-b917-fd1c48b0d4a3)

After,

![image](https://github.com/ddnet/ddnet/assets/141338449/e7523ae7-6723-4939-905d-e83d0a9b8df6)


## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
