### PR TITLE
Don't announce team killed if it's a solo server.

### DIFF
--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -1111,7 +1111,14 @@ void CGameTeams::SetClientInvited(int Team, int ClientID, bool Invited)
 
 void CGameTeams::KillSavedTeam(int ClientID, int Team)
 {
-	KillTeam(Team, -1);
+	if(g_Config.m_SvSoloServer || !g_Config.m_SvTeam)
+	{
+		GameServer()->m_apPlayers[ClientID]->KillCharacter(WEAPON_SELF, true);
+	}
+	else
+	{
+		KillTeam(Team, -1);
+	}
 }
 
 void CGameTeams::ResetSavedTeam(int ClientID, int Team)


### PR DESCRIPTION
Previously if you did `/save` on a solo server or one with teams disabled. It would announce the team the ID is in. But if it was ID 0, it would announce that everyone died :D Now it will just send killmsg of the player name instead of a team.

![image](https://github.com/ddnet/ddnet/assets/141338449/50e5fef8-c1d7-4f4e-89c5-f1b0198e4c87)
 
![image](https://github.com/ddnet/ddnet/assets/141338449/f391db34-fe6a-4e0d-bcc8-10f22a3c316d)

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
