### PR TITLE
Show correct max length in help text for `MACRO_CONFIG_STR`

### DIFF
--- a/src/engine/shared/console.cpp
+++ b/src/engine/shared/console.cpp
@@ -1041,7 +1041,9 @@ void CConsole::Init()
 	{ \
 		static char s_aOldValue[Len] = Def; \
 		static CStrVariableData Data = {this, g_Config.m_##Name, Len, s_aOldValue}; \
-		Register(#ScriptName, "?r", Flags, StrVariableCommand, &Data, Desc " (default: " #Def ", max length: " #Len ")"); \
+		static char s_aHelp[256]; \
+		str_format(s_aHelp, sizeof(s_aHelp), "%s (default: \"%s\", max length: %d)", Desc, Def, Len - 1); \
+		Register(#ScriptName, "?r", Flags, StrVariableCommand, &Data, s_aHelp); \
 	}
 
 #include "config_variables.h"


### PR DESCRIPTION
Previously it would show the max length with the '\0' included, which makes the help text kinda misleading. I wasn't able to find a way to do this with the previous macro method of doing it.

I guess #5523 would also be pretty easy to fix if we start using `str_format` to build the help string.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
