### PR TITLE
Save/load ninja

### DIFF
--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -644,8 +644,12 @@ void CCharacter::GiveNinja()
 
 void CCharacter::RemoveNinja()
 {
+	m_Core.m_Ninja.m_ActivationDir = vec2(0, 0);
+	m_Core.m_Ninja.m_ActivationTick = 0;
 	m_Core.m_Ninja.m_CurrentMoveTime = 0;
+	m_Core.m_Ninja.m_OldVelAmount = 0;
 	m_Core.m_aWeapons[WEAPON_NINJA].m_Got = false;
+	m_Core.m_aWeapons[WEAPON_NINJA].m_Ammo = 0;
 	m_Core.m_ActiveWeapon = m_LastWeapon;
 
 	SetWeapon(m_Core.m_ActiveWeapon);

--- a/src/game/server/save.h
+++ b/src/game/server/save.h
@@ -60,6 +60,15 @@ private:
 		int m_Got;
 	} m_aWeapons[NUM_WEAPONS];
 
+	// ninja
+	struct
+	{
+		vec2 m_ActivationDir;
+		int m_ActivationTick;
+		int m_CurrentMoveTime;
+		int m_OldVelAmount;
+	} m_Ninja;
+
 	int m_LastWeapon;
 	int m_QueuedWeapon;
 


### PR DESCRIPTION
Add ninja state to save string. Previously ninja was lost during load.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
   - [x] Tested save/load on new version
   - [x] Tested old save string that had ninja and one that didn't have ninja
   - [x] Tested with practice mode
   - [x] I looked at the save string to make sure it looks sane
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps:
   - I additionally reset the ninja variables in ResetNinja, because they now get written into the save code.
- [x] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
