### PR TITLE
Remove obsolete clang-tidy `NOLINT` comments

### DIFF
--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -1100,9 +1100,7 @@ static void netaddr_to_sockaddr_in6(const NETADDR *src, struct sockaddr_in6 *des
 
 static void sockaddr_to_netaddr(const struct sockaddr *src, NETADDR *dst)
 {
-	// Filled by accept, clang-analyzer probably can't tell because of the
-	// (struct sockaddr *) cast.
-	if(src->sa_family == AF_INET) // NOLINT(clang-analyzer-core.UndefinedBinaryOperatorResult)
+	if(src->sa_family == AF_INET)
 	{
 		mem_zero(dst, sizeof(NETADDR));
 		dst->type = NETTYPE_IPV4;
@@ -2616,7 +2614,7 @@ int net_socket_read_wait(NETSOCKET sock, int time)
 	tv.tv_usec = time % 1000000;
 	sockid = 0;
 
-	FD_ZERO(&readfds); // NOLINT(clang-analyzer-security.insecureAPI.bzero)
+	FD_ZERO(&readfds);
 	if(sock->ipv4sock >= 0)
 	{
 		FD_SET(sock->ipv4sock, &readfds);

--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -147,7 +147,7 @@ void CInput::UpdateActiveJoystick()
 	}
 	// Fall back to first joystick if no match was found
 	if(!m_pActiveJoystick)
-		m_pActiveJoystick = &m_vJoysticks[0]; // NOLINT(readability-container-data-pointer)
+		m_pActiveJoystick = &m_vJoysticks.front();
 }
 
 void CInput::ConchainJoystickGuidChanged(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData)

--- a/src/engine/client/text.cpp
+++ b/src/engine/client/text.cpp
@@ -391,8 +391,8 @@ private:
 	void UploadTextures()
 	{
 		const size_t NewTextureSize = m_TextureDimension * m_TextureDimension;
-		void *pTmpTextFillData = malloc(NewTextureSize); // NOLINT(clang-analyzer-optin.portability.UnixAPI)
-		void *pTmpTextOutlineData = malloc(NewTextureSize); // NOLINT(clang-analyzer-optin.portability.UnixAPI)
+		void *pTmpTextFillData = malloc(NewTextureSize);
+		void *pTmpTextOutlineData = malloc(NewTextureSize);
 		mem_copy(pTmpTextFillData, m_apTextureData[FONT_TEXTURE_FILL], NewTextureSize);
 		mem_copy(pTmpTextOutlineData, m_apTextureData[FONT_TEXTURE_OUTLINE], NewTextureSize);
 		Graphics()->LoadTextTextures(m_TextureDimension, m_TextureDimension, m_aTextures[FONT_TEXTURE_FILL], m_aTextures[FONT_TEXTURE_OUTLINE], pTmpTextFillData, pTmpTextOutlineData);
@@ -2244,7 +2244,7 @@ public:
 			{
 				log_error("textrender", "Found non empty text container with index %d with %" PRIzu " quads '%s'", pTextContainer->m_StringInfo.m_QuadBufferContainerIndex, pTextContainer->m_StringInfo.m_vCharacterQuads.size(), pTextContainer->m_aDebugText);
 				log_error("textrender", "The text container index was in use by %d ", (int)pTextContainer->m_ContainerIndex.m_UseCount.use_count());
-				HasNonEmptyTextContainer = true; // NOLINT(clang-analyzer-deadcode.DeadStores)
+				HasNonEmptyTextContainer = true;
 			}
 		}
 

--- a/src/engine/gfx/image_manipulation.cpp
+++ b/src/engine/gfx/image_manipulation.cpp
@@ -33,10 +33,7 @@ static void Dilate(int w, int h, const unsigned char *pSrc, unsigned char *pDest
 				if(pSrc[k + AlphaCompIndex] > AlphaThreshold)
 				{
 					for(int p = 0; p < BPP - 1; ++p)
-						// Seems safe for BPP = 3, 4 which we use. clang-analyzer seems to
-						// assume being called with larger value. TODO: Can make this
-						// safer anyway.
-						aSumOfOpaque[p] += pSrc[k + p]; // NOLINT(clang-analyzer-core.uninitialized.Assign)
+						aSumOfOpaque[p] += pSrc[k + p];
 					++Counter;
 					break;
 				}
@@ -230,12 +227,8 @@ static void ResizeImage(const uint8_t *pSourceImage, uint32_t SW, uint32_t SH, u
 
 uint8_t *ResizeImage(const uint8_t *pImageData, int Width, int Height, int NewWidth, int NewHeight, int BPP)
 {
-	// All calls to Resize() ensure width & height are > 0, BPP is always > 0,
-	// thus no allocation size 0 possible.
-	uint8_t *pTmpData = (uint8_t *)malloc((size_t)NewWidth * NewHeight * BPP); // NOLINT(clang-analyzer-optin.portability.UnixAPI)
-
+	uint8_t *pTmpData = (uint8_t *)malloc((size_t)NewWidth * NewHeight * BPP);
 	ResizeImage(pImageData, Width, Height, pTmpData, NewWidth, NewHeight, BPP);
-
 	return pTmpData;
 }
 

--- a/src/game/mapbugs.cpp
+++ b/src/game/mapbugs.cpp
@@ -76,7 +76,7 @@ int CMapBugs::Update(const char *pBug)
 {
 	CMapBugsInternal *pInternal = (CMapBugsInternal *)m_pData;
 	int Bug = -1;
-	if(false) {} // NOLINT(readability-simplify-boolean-expr)
+	if(false) {}
 #define MAPBUG(constname, string) \
 	else if(str_comp(pBug, string) == 0) { Bug = (constname); }
 #include "mapbugs_list.h"


### PR DESCRIPTION
The TODO in the `Dilate` function is removed, as the code already appears to be safe without additional checks. The variable `k` is at most `(w * h - 1) * BPP`, as `ix` and `iy` are clamped to maximum `w - 1` and `h - 1` respectively. Because `p < BPP - 1` the index `k + p` is therefore always valid for the buffers. (The caller must ensure that the source and destination buffers are of size `w * h * BPP`.)

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
