### PR TITLE
Remove Android-specific layout code for demo render popup

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -1570,11 +1570,7 @@ int CMenus::Render()
 			CUIRect Label, TextBox, Ok, Abort, Button;
 
 			Box.HSplitBottom(20.f, &Box, &Part);
-#if defined(__ANDROID__)
-			Box.HSplitBottom(60.f, &Box, &Part);
-#else
 			Box.HSplitBottom(24.f, &Box, &Part);
-#endif
 			Part.VMargin(80.0f, &Part);
 
 			Part.VSplitMid(&Abort, &Ok);
@@ -1669,11 +1665,7 @@ int CMenus::Render()
 				g_Config.m_ClVideoShowhud ^= 1;
 
 			Box.HSplitBottom(20.f, &Box, &Part);
-#if defined(__ANDROID__)
-			Box.HSplitBottom(60.f, &Box, &Part);
-#else
 			Box.HSplitBottom(24.f, &Box, &Part);
-#endif
 
 			Part.VSplitLeft(60.0f, 0, &Label);
 			Label.VSplitLeft(120.0f, 0, &TextBox);


### PR DESCRIPTION
The filename editbox and buttons of the demo render popup were rendered excessively large on Android. While too small buttons could be an issue with smaller screens, this should not be implemented solely this popup, if Android support is revived in the future, as it makes the UI layout code harder to maintain.

Screenshots: 
- Before (assuming Android-specific layout was used):
![screenshot_2023-10-11_18-25-05](https://github.com/ddnet/ddnet/assets/23437060/9b6a0d31-ff61-4361-9b70-9525f23d58a0)
- After (same as on other systems):
![screenshot_2023-10-11_18-23-49](https://github.com/ddnet/ddnet/assets/23437060/dea10c98-11c1-4538-a014-be17f7cf991b)


## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
