### PR TITLE
Add ability to scroll in console. Remove pages.

### DIFF
--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -718,7 +718,7 @@ void CGameConsole::OnRender()
 
 		pConsole->m_BacklogLock.lock();
 
-		// render console log (current status, wrap lines)
+		// render console log (current entry, status, wrap lines)
 		CInstance::CBacklogEntry *pEntry = pConsole->m_Backlog.Last();
 		float OffsetY = 0.0f;
 		float LineOffset = 1.0f;
@@ -824,17 +824,15 @@ void CGameConsole::OnRender()
 
 		TextRender()->TextColor(TextRender()->DefaultTextColor());
 
-		// render current status (locked, following)
-		if(pConsole->m_BacklogCurLine != 0)
-			TextRender()->Text(10.0f, FontSize / 2.f, FontSize, "Locked", -1.0f);
-		else
-			TextRender()->Text(10.0f, FontSize / 2.f, FontSize, "Following", -1.0f);
+		// render current entry and status (locked, following)
+		char aBuf[128];
+		str_format(aBuf, sizeof(aBuf), "Entry %d (%s)", pConsole->m_BacklogCurLine + 1, pConsole->m_BacklogCurLine != 0 ? "Locked" : "Following");
+		TextRender()->Text(10.0f, FontSize / 2.f, FontSize, aBuf);
 
 		// render version
-		char aBuf[128];
 		str_copy(aBuf, "v" GAME_VERSION " on " CONF_PLATFORM_STRING " " CONF_ARCH_STRING);
 		float Width = TextRender()->TextWidth(FontSize, aBuf, -1, -1.0f);
-		TextRender()->Text(Screen.w - Width - 10.0f, FontSize / 2.f, FontSize, aBuf, -1.0f);
+		TextRender()->Text(Screen.w - Width - 10.0f, FontSize / 2.f, FontSize, aBuf);
 	}
 }
 
@@ -990,9 +988,9 @@ void CGameConsole::RequireUsername(bool UsernameReq)
 void CGameConsole::PrintLine(int Type, const char *pLine)
 {
 	if(Type == CONSOLETYPE_LOCAL)
-		m_LocalConsole.PrintLine(pLine, str_length(pLine), ColorRGBA{TextRender()->DefaultTextColor()});
+		m_LocalConsole.PrintLine(pLine, str_length(pLine), TextRender()->DefaultTextColor());
 	else if(Type == CONSOLETYPE_REMOTE)
-		m_RemoteConsole.PrintLine(pLine, str_length(pLine), ColorRGBA{TextRender()->DefaultTextColor()});
+		m_RemoteConsole.PrintLine(pLine, str_length(pLine), TextRender()->DefaultTextColor());
 }
 
 void CGameConsole::OnConsoleInit()

--- a/src/game/client/components/console.h
+++ b/src/game/client/components/console.h
@@ -40,8 +40,9 @@ class CGameConsole : public CComponent
 		CLineInputBuffered<512> m_Input;
 		const char *m_pName;
 		int m_Type;
-		int m_BacklogCurPage;
-		int m_BacklogLastActivePage = -1;
+		int m_BacklogCurLine;
+		int m_BacklogLastActiveLine = -1;
+		int m_LinesRendered;
 
 		STextBoundingBox m_BoundingBox = {0.0f, 0.0f, 0.0f, 0.0f};
 		float m_LastInputHeight = 0.0f;


### PR DESCRIPTION
This PR removes the idea of "pages" from the console and instead replaces it with "lines". This makes it now possible to navigate the consoles content by using the scroll wheel. It's still possible to use `PageUp` and `PageDown`, which would go down/up the amount of entries rendered.

Other bugs fixed
- The console now properly keeps the scroll position when new entries are added.
- Active page getting reset sometimes when opening/closing console (closes #6902)

One thing I wanted to fix, but couldn't was that the console should always try to render as many entries as possible. Currently if you scroll to the top it will only display the last entry, when instead it should show that entry + as many previous entries that would fit below it.

https://github.com/ddnet/ddnet/assets/141338449/d8e737cf-6689-42ed-b037-56343037df42

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
