### PR TITLE
Use member variables for demo player snapshot data, enable use of video recording for each demo player individually

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -283,7 +283,7 @@ void CSmoothTime::UpdateMargin(int64_t TargetMargin)
 }
 
 CClient::CClient() :
-	m_DemoPlayer(&m_SnapshotDelta, [&]() { UpdateDemoIntraTimers(); })
+	m_DemoPlayer(&m_SnapshotDelta, true, [&]() { UpdateDemoIntraTimers(); })
 {
 	for(auto &DemoRecorder : m_aDemoRecorder)
 		DemoRecorder = CDemoRecorder(&m_SnapshotDelta);

--- a/src/engine/shared/demo.h
+++ b/src/engine/shared/demo.h
@@ -114,6 +114,10 @@ private:
 
 	CPlaybackInfo m_Info;
 	int m_DemoType;
+	unsigned char m_aCompressedSnapshotData[CSnapshot::MAX_SIZE];
+	unsigned char m_aDecompressedSnapshotData[CSnapshot::MAX_SIZE];
+	unsigned char m_aCurrentSnapshotData[CSnapshot::MAX_SIZE];
+	unsigned char m_aDeltaSnapshotData[CSnapshot::MAX_SIZE];
 	unsigned char m_aLastSnapshotData[CSnapshot::MAX_SIZE];
 	int m_LastSnapshotDataSize;
 	class CSnapshotDelta *m_pSnapshotDelta;

--- a/src/engine/shared/demo.h
+++ b/src/engine/shared/demo.h
@@ -122,6 +122,9 @@ private:
 	int m_LastSnapshotDataSize;
 	class CSnapshotDelta *m_pSnapshotDelta;
 
+	bool m_UseVideo;
+	bool m_WasRecording = false;
+
 	int ReadChunkHeader(int *pType, int *pSize, int *pTick);
 	void DoTick();
 	void ScanFile();
@@ -129,11 +132,11 @@ private:
 	int64_t Time();
 
 public:
-	CDemoPlayer(class CSnapshotDelta *pSnapshotDelta);
-	CDemoPlayer(class CSnapshotDelta *pSnapshotDelta, TUpdateIntraTimesFunc &&UpdateIntraTimesFunc);
+	CDemoPlayer(class CSnapshotDelta *pSnapshotDelta, bool UseVideo);
+	CDemoPlayer(class CSnapshotDelta *pSnapshotDelta, bool UseVideo, TUpdateIntraTimesFunc &&UpdateIntraTimesFunc);
 	~CDemoPlayer() override;
 
-	void Construct(class CSnapshotDelta *pSnapshotDelta);
+	void Construct(class CSnapshotDelta *pSnapshotDelta, bool UseVideo);
 
 	void SetListener(IListener *pListener);
 


### PR DESCRIPTION
Use member instead of static variables for demo player snapshot data. The static variables would otherwise cause issues when multiple demo players are playing at the same time, especially demo players used in background jobs for replay demo slicing. This hopefully closes #7068.

Previously all demo players checked `IVideo::Current` to render a video, which would cause issues when rendering a demo while a demo slicing background job is running. Now video rendering can be toggled for each demo player individually and is only enabled for the main demo player.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
