### PR TITLE
Rewrite unused header style check shell script in Python

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -73,9 +73,8 @@ jobs:
       run: |
         pylint --version
         find . -type f -name "*.py" -not -path './ddnet-libs/*' -not -path './googletest-src/*' -print0 | xargs -0 pylint
-    - name: Unused headers
-      run: |
-        find src -name '*.h' | while read -r i; do grep -r -q "$(basename "$i")" || (echo "Header file $i is unused" && exit 1); done
+    - name: Unused header files
+      run: scripts/check_unused_header_files.py
     - name: Check maps
       run: |
         findings=$(find data -type f -name '*.map' -print0 | xargs -0 ~/.cargo/bin/twmap-check-ddnet 2>&1 | \

--- a/scripts/check_unused_header_files.py
+++ b/scripts/check_unused_header_files.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+import os
+import sys
+
+def find_unused_header_files(directory):
+	header_files = set()
+	used_files = set()
+
+	for root, _, files in os.walk(directory):
+		for file in files:
+			if file.endswith('.h'):
+				header_files.add(file)
+
+	for root, _, files in os.walk(directory):
+		for file in files:
+			with open(os.path.join(root, file), 'r', encoding="utf-8") as f:
+				content = f.read()
+				for header in header_files:
+					if header in content:
+						used_files.add(header)
+
+	return header_files - used_files
+
+def main():
+	directory = 'src'
+	unused_header_files = find_unused_header_files(directory)
+
+	if unused_header_files:
+		for file in unused_header_files:
+			print(f"Error: Header file '{file}' is unused.")
+		return 1
+	print("Success: No header files are unused.")
+	return 0
+
+if __name__ == "__main__":
+	sys.exit(main())


### PR DESCRIPTION
As the shell script is pretty slow, taking roughly 84 seconds in the CI, whereas the equivalent Python script takes only 1 second.

## Checklist

- [X] Tested the change (by adding unused header files)
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
