### PR TITLE
Fix map version checks in map_diff and map_extract tools

### DIFF
--- a/src/tools/map_diff.cpp
+++ b/src/tools/map_diff.cpp
@@ -17,10 +17,12 @@ bool Process(IStorage *pStorage, const char **pMapNames)
 			return false;
 		}
 
-		// check version
-		CMapItemVersion *pVersion = (CMapItemVersion *)aMaps[i].FindItem(MAPITEMTYPE_VERSION, 0);
-		if(pVersion && pVersion->m_Version != 1)
+		const CMapItemVersion *pVersion = static_cast<CMapItemVersion *>(aMaps[i].FindItem(MAPITEMTYPE_VERSION, 0));
+		if(pVersion == nullptr || pVersion->m_Version != CMapItemVersion::CURRENT_VERSION)
+		{
+			dbg_msg("map_compare", "unsupported map version '%s'", pMapNames[i]);
 			return false;
+		}
 	}
 
 	int aStart[2], aNum[2];

--- a/src/tools/map_extract.cpp
+++ b/src/tools/map_extract.cpp
@@ -16,10 +16,12 @@ bool Process(IStorage *pStorage, const char *pMapName, const char *pPathSave)
 		return false;
 	}
 
-	// check version
-	CMapItemVersion *pVersion = (CMapItemVersion *)Reader.FindItem(MAPITEMTYPE_VERSION, 0);
-	if(pVersion && pVersion->m_Version != 1)
+	const CMapItemVersion *pVersion = static_cast<CMapItemVersion *>(Reader.FindItem(MAPITEMTYPE_VERSION, 0));
+	if(pVersion == nullptr || pVersion->m_Version != CMapItemVersion::CURRENT_VERSION)
+	{
+		dbg_msg("map_extract", "unsupported map version '%s'", pMapName);
 		return false;
+	}
 
 	dbg_msg("map_extract", "Make sure you have the permission to use these images and sounds in your own maps");
 


### PR DESCRIPTION
The map version was only checked if the version item is present, which is different from how client and editor load maps. Now a missing version item is considered an unsupported version. Additional log messages are also added to the tools.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
