### PR TITLE
Replace static variables in `MouseRelative` with member variable

### DIFF
--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -259,23 +259,18 @@ bool CInput::MouseRelative(float *pX, float *pY)
 	if(!m_MouseFocus || !m_InputGrabbed)
 		return false;
 
-	int nx = 0, ny = 0;
+	ivec2 Relative;
 #if defined(CONF_PLATFORM_ANDROID) // No relative mouse on Android
-	static int s_LastX = 0;
-	static int s_LastY = 0;
-	SDL_GetMouseState(&nx, &ny);
-	int XTmp = nx - s_LastX;
-	int YTmp = ny - s_LastY;
-	s_LastX = nx;
-	s_LastY = ny;
-	nx = XTmp;
-	ny = YTmp;
+	ivec2 CurrentPos;
+	SDL_GetMouseState(&CurrentPos.x, &CurrentPos.y);
+	Relative = CurrentPos - m_LastMousePos;
+	m_LastMousePos = CurrentPos;
 #else
-	SDL_GetRelativeMouseState(&nx, &ny);
+	SDL_GetRelativeMouseState(&Relative.x, &Relative.y);
 #endif
 
-	*pX = nx;
-	*pY = ny;
+	*pX = Relative.x;
+	*pY = Relative.y;
 	return *pX != 0.0f || *pY != 0.0f;
 }
 

--- a/src/engine/client/input.h
+++ b/src/engine/client/input.h
@@ -77,6 +77,9 @@ private:
 
 	bool m_MouseFocus;
 	bool m_MouseDoubleClick;
+#if defined(CONF_PLATFORM_ANDROID) // No relative mouse on Android
+	ivec2 m_LastMousePos = ivec2(0, 0);
+#endif
 
 	// IME support
 	char m_aComposition[MAX_COMPOSITION_ARRAY_SIZE];


### PR DESCRIPTION
Avoid using a global variable for last mouse position on Android.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
