### PR TITLE
Editor: stop/pause sound previews

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -3182,7 +3182,11 @@ void CClient::Run()
 			g_Config.m_DbgGraphs ^= 1;
 
 		if(CtrlShiftKey(KEY_E, LastE))
+		{
+			if(g_Config.m_ClEditor)
+				m_pEditor->OnClose();
 			g_Config.m_ClEditor = g_Config.m_ClEditor ^ 1;
+		}
 
 		// render
 		{

--- a/src/engine/editor.h
+++ b/src/engine/editor.h
@@ -14,6 +14,7 @@ public:
 	virtual void OnRender() = 0;
 	virtual void OnActivate() = 0;
 	virtual void OnWindowResize() = 0;
+	virtual void OnClose() = 0;
 	virtual bool HasUnsavedData() const = 0;
 	virtual bool HandleMapDrop(const char *pFilename, int StorageType) = 0;
 	virtual bool Load(const char *pFilename, int StorageType) = 0;

--- a/src/engine/editor.h
+++ b/src/engine/editor.h
@@ -15,6 +15,7 @@ public:
 	virtual void OnActivate() = 0;
 	virtual void OnWindowResize() = 0;
 	virtual void OnClose() = 0;
+	virtual void OnDialogClose() = 0;
 	virtual bool HasUnsavedData() const = 0;
 	virtual bool HandleMapDrop(const char *pFilename, int StorageType) = 0;
 	virtual bool Load(const char *pFilename, int StorageType) = 0;

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -884,6 +884,11 @@ bool CEditor::CallbackSaveSound(const char *pFileName, int StorageType, void *pU
 	{
 		io_write(File, pSound->m_pData, pSound->m_DataSize);
 		io_close(File);
+		if(pEditor->m_FilePreviewSound)
+		{
+			pEditor->Sound()->UnloadSample(pEditor->m_FilePreviewSound);
+			pEditor->m_FilePreviewSound = -1;
+		}
 		pEditor->m_Dialog = DIALOG_NONE;
 		return true;
 	}
@@ -1347,15 +1352,18 @@ void CEditor::DoToolbarSounds(CUIRect ToolBar)
 	CUIRect ToolBarTop, ToolBarBottom;
 	ToolBar.HSplitMid(&ToolBarTop, &ToolBarBottom, 5.0f);
 
-	m_ToolbarPreviewSound = -1;
 	if(m_SelectedSound >= 0 && (size_t)m_SelectedSound < m_Map.m_vpSounds.size())
 	{
 		const std::shared_ptr<CEditorSound> pSelectedSound = m_Map.m_vpSounds[m_SelectedSound];
+		if(pSelectedSound->m_SoundID != m_ToolbarPreviewSound && m_ToolbarPreviewSound && Sound()->IsPlaying(m_ToolbarPreviewSound))
+			Sound()->Stop(m_ToolbarPreviewSound);
 		m_ToolbarPreviewSound = pSelectedSound->m_SoundID;
 
 		static int s_PlayPauseButton, s_StopButton, s_SeekBar = 0;
 		DoAudioPreview(ToolBarBottom, &s_PlayPauseButton, &s_StopButton, &s_SeekBar, m_ToolbarPreviewSound);
 	}
+	else
+		m_ToolbarPreviewSound = -1;
 }
 
 static void Rotate(const CPoint *pCenter, CPoint *pPoint, float Rotation)

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -901,9 +901,16 @@ void CEditor::DoAudioPreview(CUIRect View, const void *pPlayPauseButtonID, const
 			(m_Dialog == DIALOG_NONE && CLineInput::GetActiveInput() == nullptr && Input()->KeyPress(KEY_SPACE)))
 		{
 			if(Sound()->IsPlaying(SampleID))
+			{
 				Sound()->Pause(SampleID);
+			}
 			else
+			{
+				if(SampleID != m_ToolbarPreviewSound && m_ToolbarPreviewSound && Sound()->IsPlaying(m_ToolbarPreviewSound))
+					Sound()->Pause(m_ToolbarPreviewSound);
+
 				Sound()->Play(CSounds::CHN_GUI, SampleID, ISound::FLAG_PREVIEW);
+			}
 		}
 	}
 	// stop button
@@ -1340,12 +1347,14 @@ void CEditor::DoToolbarSounds(CUIRect ToolBar)
 	CUIRect ToolBarTop, ToolBarBottom;
 	ToolBar.HSplitMid(&ToolBarTop, &ToolBarBottom, 5.0f);
 
+	m_ToolbarPreviewSound = -1;
 	if(m_SelectedSound >= 0 && (size_t)m_SelectedSound < m_Map.m_vpSounds.size())
 	{
 		const std::shared_ptr<CEditorSound> pSelectedSound = m_Map.m_vpSounds[m_SelectedSound];
+		m_ToolbarPreviewSound = pSelectedSound->m_SoundID;
 
 		static int s_PlayPauseButton, s_StopButton, s_SeekBar = 0;
-		DoAudioPreview(ToolBarBottom, &s_PlayPauseButton, &s_StopButton, &s_SeekBar, pSelectedSound->m_SoundID);
+		DoAudioPreview(ToolBarBottom, &s_PlayPauseButton, &s_StopButton, &s_SeekBar, m_ToolbarPreviewSound);
 	}
 }
 
@@ -4062,6 +4071,11 @@ bool CEditor::AddSound(const char *pFileName, int StorageType, void *pUser)
 			}
 	}
 
+	if(pEditor->m_FilePreviewSound)
+	{
+		pEditor->Sound()->UnloadSample(pEditor->m_FilePreviewSound);
+		pEditor->m_FilePreviewSound = -1;
+	}
 	pEditor->m_Dialog = DIALOG_NONE;
 	return true;
 }
@@ -4913,7 +4927,14 @@ void CEditor::RenderFileDialog()
 	ButtonBar.VSplitRight(ButtonSpacing, &ButtonBar, nullptr);
 	ButtonBar.VSplitRight(50.0f, &ButtonBar, &Button);
 	if(DoButton_Editor(&s_CancelButton, "Cancel", 0, &Button, 0, nullptr) || (s_ListBox.Active() && UI()->ConsumeHotkey(CUI::HOTKEY_ESCAPE)))
+	{
+		if(m_FilePreviewSound)
+		{
+			Sound()->UnloadSample(m_FilePreviewSound);
+			m_FilePreviewSound = -1;
+		}
 		m_Dialog = DIALOG_NONE;
+	}
 
 	ButtonBar.VSplitRight(ButtonSpacing, &ButtonBar, nullptr);
 	ButtonBar.VSplitRight(50.0f, &ButtonBar, &Button);
@@ -7157,7 +7178,10 @@ void CEditor::RenderMenubar(CUIRect MenuBar)
 
 	static int s_CloseButton = 0;
 	if(DoButton_Editor(&s_CloseButton, "×", 0, &Close, 0, "Exits from the editor") || (m_Dialog == DIALOG_NONE && !UI()->IsPopupOpen() && !m_PopupEventActivated && Input()->KeyPress(KEY_ESCAPE)))
+	{
+		OnClose();
 		g_Config.m_ClEditor = 0;
+	}
 }
 
 void CEditor::Render()
@@ -7909,6 +7933,14 @@ void CEditor::OnActivate()
 void CEditor::OnWindowResize()
 {
 	UI()->OnWindowResize();
+}
+
+void CEditor::OnClose()
+{
+	if(m_ToolbarPreviewSound && Sound()->IsPlaying(m_ToolbarPreviewSound))
+		Sound()->Pause(m_ToolbarPreviewSound);
+	if(m_FilePreviewSound && Sound()->IsPlaying(m_FilePreviewSound))
+		Sound()->Pause(m_FilePreviewSound);
 }
 
 void CEditor::LoadCurrentMap()

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -884,11 +884,7 @@ bool CEditor::CallbackSaveSound(const char *pFileName, int StorageType, void *pU
 	{
 		io_write(File, pSound->m_pData, pSound->m_DataSize);
 		io_close(File);
-		if(pEditor->m_FilePreviewSound)
-		{
-			pEditor->Sound()->UnloadSample(pEditor->m_FilePreviewSound);
-			pEditor->m_FilePreviewSound = -1;
-		}
+		pEditor->OnDialogClose();
 		pEditor->m_Dialog = DIALOG_NONE;
 		return true;
 	}
@@ -4079,11 +4075,7 @@ bool CEditor::AddSound(const char *pFileName, int StorageType, void *pUser)
 			}
 	}
 
-	if(pEditor->m_FilePreviewSound)
-	{
-		pEditor->Sound()->UnloadSample(pEditor->m_FilePreviewSound);
-		pEditor->m_FilePreviewSound = -1;
-	}
+	pEditor->OnDialogClose();
 	pEditor->m_Dialog = DIALOG_NONE;
 	return true;
 }
@@ -4936,11 +4928,7 @@ void CEditor::RenderFileDialog()
 	ButtonBar.VSplitRight(50.0f, &ButtonBar, &Button);
 	if(DoButton_Editor(&s_CancelButton, "Cancel", 0, &Button, 0, nullptr) || (s_ListBox.Active() && UI()->ConsumeHotkey(CUI::HOTKEY_ESCAPE)))
 	{
-		if(m_FilePreviewSound)
-		{
-			Sound()->UnloadSample(m_FilePreviewSound);
-			m_FilePreviewSound = -1;
-		}
+		OnDialogClose();
 		m_Dialog = DIALOG_NONE;
 	}
 
@@ -7949,6 +7937,15 @@ void CEditor::OnClose()
 		Sound()->Pause(m_ToolbarPreviewSound);
 	if(m_FilePreviewSound && Sound()->IsPlaying(m_FilePreviewSound))
 		Sound()->Pause(m_FilePreviewSound);
+}
+
+void CEditor::OnDialogClose()
+{
+	if(m_FilePreviewSound)
+	{
+		Sound()->UnloadSample(m_FilePreviewSound);
+		m_FilePreviewSound = -1;
+	}
 }
 
 void CEditor::LoadCurrentMap()

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -4127,6 +4127,7 @@ bool CEditor::ReplaceSound(const char *pFileName, int StorageType, bool CheckDup
 	pSound->m_pData = pData;
 	pSound->m_DataSize = DataSize;
 
+	OnDialogClose();
 	m_Dialog = DIALOG_NONE;
 	return true;
 }

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -356,6 +356,8 @@ public:
 		m_FilePreviewSound = -1;
 		m_FilePreviewState = PREVIEW_UNLOADED;
 
+		m_ToolbarPreviewSound = -1;
+
 		m_SelectEntitiesImage = "DDNet";
 
 		m_ResetZoomEnvelope = true;
@@ -416,6 +418,7 @@ public:
 	void OnRender() override;
 	void OnActivate() override;
 	void OnWindowResize() override;
+	void OnClose() override;
 	bool HasUnsavedData() const override { return m_Map.m_Modified; }
 	void UpdateMentions() override { m_Mentions++; }
 	void ResetMentions() override { m_Mentions = 0; }
@@ -567,6 +570,8 @@ public:
 	EPreviewState m_FilePreviewState;
 	CImageInfo m_FilePreviewImageInfo;
 	bool m_FileDialogOpening;
+
+	int m_ToolbarPreviewSound;
 
 	struct CFilelistItem
 	{

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -419,6 +419,7 @@ public:
 	void OnActivate() override;
 	void OnWindowResize() override;
 	void OnClose() override;
+	void OnDialogClose() override;
 	bool HasUnsavedData() const override { return m_Map.m_Modified; }
 	void UpdateMentions() override { m_Mentions++; }
 	void ResetMentions() override { m_Mentions = 0; }

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -141,7 +141,10 @@ CUI::EPopupMenuFunctionResult CEditor::PopupMenuFile(void *pContext, CUIRect Vie
 			pEditor->m_PopupEventActivated = true;
 		}
 		else
+		{
+			pEditor->OnClose();
 			g_Config.m_ClEditor = 0;
+		}
 		return CUI::POPUP_CLOSE_CURRENT;
 	}
 
@@ -1972,6 +1975,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupEvent(void *pContext, CUIRect View, 
 	{
 		if(pEditor->m_PopupEventType == POPEVENT_EXIT)
 		{
+			pEditor->OnClose();
 			g_Config.m_ClEditor = 0;
 		}
 		else if(pEditor->m_PopupEventType == POPEVENT_LOAD)


### PR DESCRIPTION
When leaving the editor pause any sound preview that is playing.

When playing a file dialog sound preview pause the toolbar sound preview if it's playing.

When switching selected sound stop the previous sound preview if it's playing.

**File dialog**
Unload (stop) the sound of the preview when:
- closing file dialog using `Cancel`
- closing file dialog using `escape`
- adding selected sound using `Add`
- saving selected sound using `Save` (when exporting)
- replacing selected sound using `Replace` (when replacing)

closes #7256

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
