### PR TITLE
Validate ticks when reading demo chunk headers, check for all file errors in demo player, show demo error popup

### DIFF
--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -389,7 +389,7 @@ char *io_read_all_str(IOHANDLE io)
 	return (char *)buffer;
 }
 
-unsigned io_skip(IOHANDLE io, int size)
+int io_skip(IOHANDLE io, int size)
 {
 	return io_seek(io, size, IOSEEK_CUR);
 }

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -292,9 +292,9 @@ char *io_read_all_str(IOHANDLE io);
  * @param io Handle to the file.
  * @param size Number of bytes to skip.
  *
- * @return Number of bytes skipped.
+ * @return 0 on success.
  */
-unsigned io_skip(IOHANDLE io, int size);
+int io_skip(IOHANDLE io, int size);
 
 /**
  * Writes data from a buffer to file.

--- a/src/engine/demo.h
+++ b/src/engine/demo.h
@@ -58,8 +58,8 @@ struct CMapInfo
 {
 	char m_aName[MAX_MAP_LENGTH];
 	SHA256_DIGEST m_Sha256;
-	int m_Crc;
-	int m_Size;
+	unsigned m_Crc;
+	unsigned m_Size;
 };
 
 class IDemoPlayer : public IInterface
@@ -100,7 +100,7 @@ public:
 	virtual bool IsPlaying() const = 0;
 	virtual const CInfo *BaseInfo() const = 0;
 	virtual void GetDemoName(char *pBuffer, size_t BufferSize) const = 0;
-	virtual bool GetDemoInfo(class IStorage *pStorage, const char *pFilename, int StorageType, CDemoHeader *pDemoHeader, CTimelineMarkers *pTimelineMarkers, CMapInfo *pMapInfo) const = 0;
+	virtual bool GetDemoInfo(class IStorage *pStorage, class IConsole *pConsole, const char *pFilename, int StorageType, CDemoHeader *pDemoHeader, CTimelineMarkers *pTimelineMarkers, CMapInfo *pMapInfo, IOHANDLE *pFile = nullptr, char *pErrorMessage = nullptr, size_t ErrorMessageSize = 0) const = 0;
 };
 
 class IDemoRecorder : public IInterface

--- a/src/engine/shared/demo.h
+++ b/src/engine/shared/demo.h
@@ -107,6 +107,7 @@ private:
 	IOHANDLE m_File;
 	long m_MapOffset;
 	char m_aFilename[IO_MAX_PATH_LENGTH];
+	char m_aErrorMessage[256];
 	std::vector<SKeyFrame> m_vKeyFrames;
 	CMapInfo m_MapInfo;
 	int m_SpeedIndex;
@@ -150,7 +151,7 @@ public:
 	int Play();
 	void Pause() override;
 	void Unpause() override;
-	int Stop();
+	void Stop(const char *pErrorMessage = "");
 	void SetSpeed(float Speed) override;
 	void SetSpeedIndex(int SpeedIndex) override;
 	void AdjustSpeedIndex(int Offset) override;
@@ -160,8 +161,9 @@ public:
 	int SetPos(int WantedTick) override;
 	const CInfo *BaseInfo() const override { return &m_Info.m_Info; }
 	void GetDemoName(char *pBuffer, size_t BufferSize) const override;
-	bool GetDemoInfo(class IStorage *pStorage, const char *pFilename, int StorageType, CDemoHeader *pDemoHeader, CTimelineMarkers *pTimelineMarkers, CMapInfo *pMapInfo) const override;
-	const char *GetDemoFileName() { return m_aFilename; }
+	bool GetDemoInfo(class IStorage *pStorage, class IConsole *pConsole, const char *pFilename, int StorageType, CDemoHeader *pDemoHeader, CTimelineMarkers *pTimelineMarkers, CMapInfo *pMapInfo, IOHANDLE *pFile = nullptr, char *pErrorMessage = nullptr, size_t ErrorMessageSize = 0) const override;
+	const char *Filename() { return m_aFilename; }
+	const char *ErrorMessage() { return m_aErrorMessage; }
 
 	int Update(bool RealTime = true);
 

--- a/src/engine/shared/demo.h
+++ b/src/engine/shared/demo.h
@@ -123,9 +123,15 @@ private:
 	bool m_UseVideo;
 	bool m_WasRecording = false;
 
-	int ReadChunkHeader(int *pType, int *pSize, int *pTick);
+	enum EReadChunkHeaderResult
+	{
+		CHUNKHEADER_SUCCESS,
+		CHUNKHEADER_ERROR,
+		CHUNKHEADER_EOF,
+	};
+	EReadChunkHeaderResult ReadChunkHeader(int *pType, int *pSize, int *pTick);
 	void DoTick();
-	void ScanFile();
+	bool ScanFile();
 
 	int64_t Time();
 

--- a/src/engine/warning.h
+++ b/src/engine/warning.h
@@ -3,15 +3,21 @@
 
 struct SWarning
 {
-	SWarning() :
-		m_WasShown(false) {}
-	SWarning(const char *pMsg) :
-		m_WasShown(false)
+	SWarning() {}
+	SWarning(const char *pMsg)
 	{
-		str_copy(m_aWarningMsg, pMsg, sizeof(m_aWarningMsg));
+		str_copy(m_aWarningTitle, "");
+		str_copy(m_aWarningMsg, pMsg);
 	}
+	SWarning(const char *pTitle, const char *pMsg)
+	{
+		str_copy(m_aWarningTitle, pTitle);
+		str_copy(m_aWarningMsg, pMsg);
+	}
+	char m_aWarningTitle[128];
 	char m_aWarningMsg[256];
-	bool m_WasShown;
+	bool m_WasShown = false;
+	bool m_AutoHide = true;
 };
 
 #endif

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -1839,7 +1839,7 @@ void CMenus::PopupConfirmDemoReplaceVideo()
 	if(pError)
 	{
 		m_DemoRenderInput.Clear();
-		PopupMessage(Localize("Error"), str_comp(pError, "error loading demo") ? pError : Localize("Error loading demo"), Localize("Ok"));
+		PopupMessage(Localize("Error loading demo"), pError, Localize("Ok"));
 	}
 }
 #endif

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -1786,7 +1786,7 @@ int CMenus::Render()
 			Part.VMargin(120.0f, &Part);
 
 			static CButtonContainer s_Button;
-			if(DoButton_Menu(&s_Button, pButtonText, 0, &Part) || UI()->ConsumeHotkey(CUI::HOTKEY_ESCAPE) || UI()->ConsumeHotkey(CUI::HOTKEY_ENTER) || (time_get_nanoseconds() - m_PopupWarningLastTime >= m_PopupWarningDuration))
+			if(DoButton_Menu(&s_Button, pButtonText, 0, &Part) || UI()->ConsumeHotkey(CUI::HOTKEY_ESCAPE) || UI()->ConsumeHotkey(CUI::HOTKEY_ENTER) || (m_PopupWarningDuration > 0s && time_get_nanoseconds() - m_PopupWarningLastTime >= m_PopupWarningDuration))
 			{
 				m_Popup = POPUP_NONE;
 				SetActive(false);

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -1041,7 +1041,7 @@ bool CMenus::FetchHeader(CDemoItem &Item)
 	{
 		char aBuffer[IO_MAX_PATH_LENGTH];
 		str_format(aBuffer, sizeof(aBuffer), "%s/%s", m_aCurrentDemoFolder, Item.m_aFilename);
-		Item.m_Valid = DemoPlayer()->GetDemoInfo(Storage(), aBuffer, Item.m_StorageType, &Item.m_Info, &Item.m_TimelineMarkers, &Item.m_MapInfo);
+		Item.m_Valid = DemoPlayer()->GetDemoInfo(Storage(), nullptr, aBuffer, Item.m_StorageType, &Item.m_Info, &Item.m_TimelineMarkers, &Item.m_MapInfo);
 		Item.m_InfosLoaded = true;
 	}
 	return Item.m_Valid;
@@ -1505,7 +1505,9 @@ void CMenus::RenderDemoBrowserButtons(CUIRect ButtonsView, bool WasListboxItemAc
 				m_LastPauseChange = -1.0f;
 				m_LastSpeedChange = -1.0f;
 				if(pError)
-					PopupMessage(Localize("Error"), str_comp(pError, "error loading demo") ? pError : Localize("Error loading demo"), Localize("Ok"));
+				{
+					PopupMessage(Localize("Error loading demo"), pError, Localize("Ok"));
+				}
 				else
 				{
 					UI()->SetActiveItem(nullptr);

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -673,9 +673,9 @@ void CGameClient::OnRender()
 	// display gfx & client warnings
 	for(SWarning *pWarning : {Graphics()->GetCurWarning(), Client()->GetCurWarning()})
 	{
-		if(pWarning != NULL && m_Menus.CanDisplayWarning())
+		if(pWarning != nullptr && m_Menus.CanDisplayWarning())
 		{
-			m_Menus.PopupWarning(Localize("Warning"), pWarning->m_aWarningMsg, "Ok", 10s);
+			m_Menus.PopupWarning(pWarning->m_aWarningTitle[0] == '\0' ? Localize("Warning") : pWarning->m_aWarningTitle, pWarning->m_aWarningMsg, "Ok", pWarning->m_AutoHide ? 10s : 0s);
 			pWarning->m_WasShown = true;
 		}
 	}


### PR DESCRIPTION
See commit messages.

The demo linked in #7349 is now considered invalid and fails to load.

Demos which were simply truncated due to the client crashing during the recording can usually still be opened but the playback will be stopped entirely when an error is encountered reading the demo until the end.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
