### PR TITLE
Improve positioning of IME candidate window for multi-line text

### DIFF
--- a/src/game/client/lineinput.cpp
+++ b/src/game/client/lineinput.cpp
@@ -494,9 +494,13 @@ STextBoundingBox CLineInput::Render(const CUIRect *pRect, float FontSize, int Al
 
 		m_CaretPosition = Cursor.m_CursorRenderedPosition;
 
-		STextBoundingBox CaretBoundingBox = TextRender()->TextBoundingBox(FontSize, pDisplayStr, DisplayCursorOffset, LineWidth);
-		CaretBoundingBox.MoveBy(CursorPos);
-		SetCompositionWindowPosition(vec2(CaretBoundingBox.Right(), CaretBoundingBox.Bottom()), CaretBoundingBox.m_H);
+		CTextCursor CaretCursor;
+		TextRender()->SetCursor(&CaretCursor, CursorPos.x, CursorPos.y, FontSize, 0);
+		CaretCursor.m_LineWidth = LineWidth;
+		CaretCursor.m_CursorMode = TEXT_CURSOR_CURSOR_MODE_SET;
+		CaretCursor.m_CursorCharacter = str_utf8_offset_bytes_to_chars(pDisplayStr, DisplayCursorOffset);
+		TextRender()->TextEx(&CaretCursor, pDisplayStr);
+		SetCompositionWindowPosition(CaretCursor.m_CursorRenderedPosition + vec2(0.0f, CaretCursor.m_AlignedFontSize / 2.0f), CaretCursor.m_AlignedFontSize);
 	}
 	else
 	{
@@ -609,7 +613,7 @@ void CLineInput::SetCompositionWindowPosition(vec2 Anchor, float LineHeight)
 	const vec2 ScreenScale = vec2(ScreenWidth / (ScreenX1 - ScreenX0), ScreenHeight / (ScreenY1 - ScreenY0));
 	ms_CompositionWindowPosition = Anchor * ScreenScale;
 	ms_CompositionLineHeight = LineHeight * ScreenScale.y;
-	Input()->SetCompositionWindowPosition(ms_CompositionWindowPosition.x, ms_CompositionWindowPosition.y - ms_CompositionLineHeight, ms_CompositionLineHeight);
+	Input()->SetCompositionWindowPosition(ms_CompositionWindowPosition.x, ms_CompositionWindowPosition.y, ms_CompositionLineHeight);
 }
 
 void CLineInput::Activate(EInputPriority Priority)


### PR DESCRIPTION
Previously, the IME candidate window was aligned with the top-right corner of the text bounding box (when rendering the text until the caret offset). This does not work correctly for text spanning multiple lines, causing the IME candidate window to be displayed at the X position of the longest line instead. Additionally, text clipping in the chat was not considered, as `CLineInput` is not aware of the clipping implemented in `CChat`, causing the IME candidate window to be moved up too far.

This is fixed by getting the correct rendered position of the caret offset using `m_CursorRenderedPosition`. Vertical alignment is also changed so only one line of text is considered, which makes the behavior more consistent with Windows' native IME candidate window and avoids larger changes in `CLineInput` to make it aware of clipping.

Screenshots:
- Before: 
![old](https://github.com/ddnet/ddnet/assets/23437060/f6a9bc3b-aa6b-4998-803d-dcda98473bab)
- After:
![new](https://github.com/ddnet/ddnet/assets/23437060/69645902-09da-4fa4-8332-0fdad17867d9)


## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
