### PR TITLE
Remove "Detail" from sound layers.

### DIFF
--- a/src/game/client/components/mapsounds.cpp
+++ b/src/game/client/components/mapsounds.cpp
@@ -118,7 +118,7 @@ void CMapSounds::OnRender()
 				Client()->IntraGameTick(g_Config.m_ClDummy));
 		}
 		float Offset = s_Time - Source.m_pSource->m_TimeDelay;
-		if(!DemoPlayerPaused && Offset >= 0.0f && g_Config.m_SndEnable && (g_Config.m_GfxHighDetail || !Source.m_HighDetail))
+		if(!DemoPlayerPaused && Offset >= 0.0f && g_Config.m_SndEnable)
 		{
 			if(Source.m_Voice.IsValid())
 			{

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -721,6 +721,12 @@ CUI::EPopupMenuFunctionResult CEditor::PopupLayer(void *pContext, CUIRect View, 
 		aProps[2].m_Type = PROPTYPE_NULL;
 	}
 
+	// don't use Detail from the selection if this is a sound layer
+	if(pCurrentLayer->m_Type == LAYERTYPE_SOUNDS)
+	{
+		aProps[2].m_Type = PROPTYPE_NULL;
+	}
+
 	static int s_aIds[NUM_PROPS] = {0};
 	int NewVal = 0;
 	int Prop = pEditor->DoProperties(&View, aProps, s_aIds, &NewVal);


### PR DESCRIPTION
The sound layer previously had the "Detail" property, and if enabled would make the sound not play if `gfx_high_detail` was disabled. Which makes no sense, as GFX has nothing to do with sounds.

![image](https://github.com/ddnet/ddnet/assets/141338449/8d22968d-833e-4495-9237-842392d45955)

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
