### PR TITLE
Add argument completion for `reset`, `toggle`, `access_level`

### DIFF
--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -90,13 +90,11 @@ CGameConsole::CInstance::CInstance(int Type)
 	{
 		m_pName = "local_console";
 		m_CompletionFlagmask = CFGFLAG_CLIENT;
-		m_ArgumentCompletionFlagmask = CFGFLAG_SAVE;
 	}
 	else
 	{
 		m_pName = "remote_console";
 		m_CompletionFlagmask = CFGFLAG_SERVER;
-		m_ArgumentCompletionFlagmask = CFGFLAG_SERVER;
 	}
 
 	m_aCompletionBuffer[0] = 0;
@@ -289,7 +287,7 @@ bool CGameConsole::CInstance::OnInput(const IInput::CEvent &Event)
 			if(TuningCompletion)
 				CompletionEnumerationCount = m_pGameConsole->m_pClient->m_aTuning[g_Config.m_ClDummy].PossibleTunings(m_aCompletionBufferArgument);
 			else if(SettingCompletion)
-				CompletionEnumerationCount = m_pGameConsole->m_pConsole->PossibleCommands(m_aCompletionBufferArgument, m_ArgumentCompletionFlagmask, UseTempCommands);
+				CompletionEnumerationCount = m_pGameConsole->m_pConsole->PossibleCommands(m_aCompletionBufferArgument, m_CompletionFlagmask, UseTempCommands);
 
 			if(CompletionEnumerationCount)
 			{
@@ -299,7 +297,7 @@ bool CGameConsole::CInstance::OnInput(const IInput::CEvent &Event)
 				if(TuningCompletion && m_pGameConsole->Client()->RconAuthed() && m_Type == CGameConsole::CONSOLETYPE_REMOTE)
 					m_pGameConsole->m_pClient->m_aTuning[g_Config.m_ClDummy].PossibleTunings(m_aCompletionBufferArgument, PossibleArgumentsCompleteCallback, this);
 				else if(SettingCompletion)
-					m_pGameConsole->m_pConsole->PossibleCommands(m_aCompletionBufferArgument, m_ArgumentCompletionFlagmask, UseTempCommands, PossibleArgumentsCompleteCallback, this);
+					m_pGameConsole->m_pConsole->PossibleCommands(m_aCompletionBufferArgument, m_CompletionFlagmask, UseTempCommands, PossibleArgumentsCompleteCallback, this);
 			}
 			else if(m_CompletionChosenArgument != -1)
 			{
@@ -709,7 +707,7 @@ void CGameConsole::OnRender()
 					if(TuningCompletion)
 						NumArguments = m_pClient->m_aTuning[g_Config.m_ClDummy].PossibleTunings(Info.m_pCurrentCmd, PossibleCommandsRenderCallback, &Info);
 					else if(SettingCompletion)
-						NumArguments = m_pConsole->PossibleCommands(Info.m_pCurrentCmd, pConsole->m_ArgumentCompletionFlagmask, m_ConsoleType != CGameConsole::CONSOLETYPE_LOCAL && Client()->RconAuthed() && Client()->UseTempRconCommands(), PossibleCommandsRenderCallback, &Info);
+						NumArguments = m_pConsole->PossibleCommands(Info.m_pCurrentCmd, pConsole->m_CompletionFlagmask, m_ConsoleType != CGameConsole::CONSOLETYPE_LOCAL && Client()->RconAuthed() && Client()->UseTempRconCommands(), PossibleCommandsRenderCallback, &Info);
 					pConsole->m_CompletionRenderOffset = Info.m_Offset;
 				}
 

--- a/src/game/client/components/console.h
+++ b/src/game/client/components/console.h
@@ -61,7 +61,6 @@ class CGameConsole : public CComponent
 		char m_aCompletionBufferArgument[128];
 		int m_CompletionChosenArgument;
 		int m_CompletionFlagmask;
-		int m_ArgumentCompletionFlagmask;
 		float m_CompletionRenderOffset;
 		float m_CompletionRenderOffsetChange;
 

--- a/src/game/client/components/console.h
+++ b/src/game/client/components/console.h
@@ -61,6 +61,7 @@ class CGameConsole : public CComponent
 		char m_aCompletionBufferArgument[128];
 		int m_CompletionChosenArgument;
 		int m_CompletionFlagmask;
+		int m_ArgumentCompletionFlagmask;
 		float m_CompletionRenderOffset;
 		float m_CompletionRenderOffsetChange;
 


### PR DESCRIPTION
Add auto completions for commands that take a command/config as their first argument.

https://github.com/ddnet/ddnet/assets/141338449/6b025409-724e-49db-a568-f8886f14ed53

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
