### PR TITLE
Fix use of closed demo file when playback stopped due to error

### DIFF
--- a/src/engine/shared/demo.cpp
+++ b/src/engine/shared/demo.cpp
@@ -937,7 +937,7 @@ int CDemoPlayer::SetPos(int WantedTick)
 	m_Info.m_PreviousTick = -1;
 
 	// playback everything until we hit our tick
-	while(m_Info.m_NextTick < WantedTick)
+	while(m_Info.m_NextTick < WantedTick && IsPlaying())
 		DoTick();
 
 	Play();
@@ -976,7 +976,7 @@ int CDemoPlayer::Update(bool RealTime)
 	{
 		m_Info.m_CurrentTime += (int64_t)(Deltatime * (double)m_Info.m_Info.m_Speed);
 
-		while(!m_Info.m_Info.m_Paused)
+		while(!m_Info.m_Info.m_Paused && IsPlaying())
 		{
 			int64_t CurtickStart = m_Info.m_Info.m_CurrentTick * Freq / SERVER_TICK_SPEED;
 


### PR DESCRIPTION
Check whether the demo file has been closed due to a playback error when calling `DoTick` in loops, to prevent crashes on operating systems with assertions for correct C library usage. On Windows, `warning: Invalid parameter passed to C runtime function` was printed to the debug console in this case.

See https://github.com/ddnet/ddnet/pull/7369#issuecomment-1779766832.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
