### PR TITLE
Add `IJob::Done` callback called on main thread

### DIFF
--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -3,8 +3,8 @@
 #ifndef ENGINE_CLIENT_CLIENT_H
 #define ENGINE_CLIENT_CLIENT_H
 
-#include <deque>
 #include <memory>
+#include <vector>
 
 #include <base/hash.h>
 
@@ -21,6 +21,7 @@
 #include <engine/shared/fifo.h>
 #include <engine/shared/http.h>
 #include <engine/shared/network.h>
+#include <engine/textrender.h>
 #include <engine/warning.h>
 
 #include "graph.h"
@@ -195,7 +196,7 @@ class CClient : public IClient, public CDemoPlayer::IListener
 
 	CSnapshotDelta m_SnapshotDelta;
 
-	std::deque<std::shared_ptr<CDemoEdit>> m_EditJobs;
+	std::vector<std::shared_ptr<CDemoEdit>> m_vpEditJobs;
 
 	//
 	bool m_CanReceiveServerCapabilities;
@@ -252,6 +253,7 @@ class CClient : public IClient, public CDemoPlayer::IListener
 public:
 	IConfigManager *ConfigManager() { return m_pConfigManager; }
 	CConfig *Config() { return m_pConfig; }
+	IConsole *Console() { return m_pConsole; }
 	IDiscord *Discord() { return m_pDiscord; }
 	IEngine *Engine() { return m_pEngine; }
 	IGameClient *GameClient() { return m_pGameClient; }

--- a/src/engine/client/demoedit.cpp
+++ b/src/engine/client/demoedit.cpp
@@ -1,11 +1,15 @@
 #include "demoedit.h"
 
+#include <engine/client/client.h>
+#include <engine/console.h>
 #include <engine/shared/demo.h>
 #include <engine/storage.h>
 
-CDemoEdit::CDemoEdit(const char *pNetVersion, class CSnapshotDelta *pSnapshotDelta, IStorage *pStorage, const char *pDemo, const char *pDst, int StartTick, int EndTick) :
-	m_SnapshotDelta(*pSnapshotDelta),
-	m_pStorage(pStorage)
+#include <game/localization.h>
+
+CDemoEdit::CDemoEdit(CClient *pClient, const char *pNetVersion, class CSnapshotDelta *pSnapshotDelta, const char *pDemo, const char *pDst, int StartTick, int EndTick) :
+	m_pClient(pClient),
+	m_SnapshotDelta(*pSnapshotDelta)
 {
 	str_copy(m_aDemo, pDemo);
 	str_copy(m_aDst, pDst);
@@ -14,7 +18,7 @@ CDemoEdit::CDemoEdit(const char *pNetVersion, class CSnapshotDelta *pSnapshotDel
 	m_EndTick = EndTick;
 
 	// Init the demoeditor
-	m_DemoEditor.Init(pNetVersion, &m_SnapshotDelta, NULL, pStorage);
+	m_DemoEditor.Init(pNetVersion, &m_SnapshotDelta, NULL, pClient->Storage());
 }
 
 void CDemoEdit::Run()
@@ -22,5 +26,17 @@ void CDemoEdit::Run()
 	// Slice the current demo
 	m_DemoEditor.Slice(m_aDemo, m_aDst, m_StartTick, m_EndTick, NULL, 0);
 	// We remove the temporary demo file
-	m_pStorage->RemoveFile(m_aDemo, IStorage::TYPE_SAVE);
+	m_pClient->Storage()->RemoveFile(m_aDemo, IStorage::TYPE_SAVE);
+}
+
+void CDemoEdit::Done()
+{
+	if(m_pClient->State() != IClient::STATE_ONLINE)
+		return;
+
+	char aBuf[IO_MAX_PATH_LENGTH + 64];
+	str_format(aBuf, sizeof(aBuf), "Successfully saved the replay to '%s'!", Destination());
+	m_pClient->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "replay", aBuf);
+
+	m_pClient->GameClient()->Echo(Localize("Successfully saved the replay!"));
 }

--- a/src/engine/client/demoedit.h
+++ b/src/engine/client/demoedit.h
@@ -5,12 +5,12 @@
 #include <engine/shared/jobs.h>
 #include <engine/shared/snapshot.h>
 
-class IStorage;
+class CClient;
 
 class CDemoEdit : public IJob
 {
+	CClient *m_pClient;
 	CSnapshotDelta m_SnapshotDelta;
-	IStorage *m_pStorage;
 
 	CDemoEditor m_DemoEditor;
 
@@ -19,9 +19,11 @@ class CDemoEdit : public IJob
 	int m_StartTick;
 	int m_EndTick;
 
-public:
-	CDemoEdit(const char *pNetVersion, CSnapshotDelta *pSnapshotDelta, IStorage *pStorage, const char *pDemo, const char *pDst, int StartTick, int EndTick);
 	void Run() override;
-	char *Destination() { return m_aDst; }
+	void Done() override;
+
+public:
+	CDemoEdit(CClient *pClient, const char *pNetVersion, CSnapshotDelta *pSnapshotDelta, const char *pDemo, const char *pDst, int StartTick, int EndTick);
+	const char *Destination() const { return m_aDst; }
 };
 #endif

--- a/src/engine/engine.h
+++ b/src/engine/engine.h
@@ -21,6 +21,7 @@ public:
 
 	virtual void Init() = 0;
 	virtual void AddJob(std::shared_ptr<IJob> pJob) = 0;
+	virtual void UpdateJobs() = 0;
 	virtual void SetAdditionalLogger(std::shared_ptr<ILogger> &&pLogger) = 0;
 	static void RunJobBlocking(IJob *pJob);
 };

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -31,7 +31,6 @@
 #endif
 
 class CConfig;
-class CHostLookup;
 class CLogMessage;
 class CMsgPacker;
 class CPacker;
@@ -210,10 +209,7 @@ public:
 		CUuid m_ConnectionID;
 		int64_t m_RedirectDropTime;
 
-		// DNSBL
 		int m_DnsblState;
-		std::shared_ptr<CHostLookup> m_pDnsblLookup;
-
 		bool m_Sixup;
 	};
 
@@ -461,7 +457,7 @@ public:
 
 	int *GetIdMap(int ClientID) override;
 
-	void InitDnsbl(int ClientID);
+	void InitDnsblLookup(int ClientID);
 	bool DnsblWhite(int ClientID) override
 	{
 		return m_aClients[ClientID].m_DnsblState == CClient::DNSBL_STATE_NONE ||

--- a/src/engine/shared/engine.cpp
+++ b/src/engine/shared/engine.cpp
@@ -100,6 +100,11 @@ public:
 		m_JobPool.Add(std::move(pJob));
 	}
 
+	void UpdateJobs() override
+	{
+		m_JobPool.Update();
+	}
+
 	void SetAdditionalLogger(std::shared_ptr<ILogger> &&pLogger) override
 	{
 		m_pFutureLogger->Set(pLogger);

--- a/src/engine/shared/host_lookup.cpp
+++ b/src/engine/shared/host_lookup.cpp
@@ -17,3 +17,11 @@ void CHostLookup::Run()
 {
 	m_Result = net_host_lookup(m_aHostname, &m_Addr, m_Nettype);
 }
+
+void CHostLookup::Done()
+{
+	if(m_DoneHandler)
+	{
+		m_DoneHandler(this);
+	}
+}

--- a/src/engine/shared/host_lookup.h
+++ b/src/engine/shared/host_lookup.h
@@ -7,6 +7,10 @@
 
 #include <engine/shared/jobs.h>
 
+#include <functional>
+
+typedef std::function<void(class CHostLookup *pLookup)> TLookupDoneHandler;
+
 class CHostLookup : public IJob
 {
 private:
@@ -16,10 +20,15 @@ private:
 	NETADDR m_Addr;
 
 	void Run() override;
+	void Done() override;
+
+	TLookupDoneHandler m_DoneHandler = nullptr;
 
 public:
 	CHostLookup();
 	CHostLookup(const char *pHostname, int Nettype);
+
+	void DoneHandler(TLookupDoneHandler &&DoneHandler) { m_DoneHandler = std::move(DoneHandler); }
 
 	int Result() const { return m_Result; }
 	const char *Hostname() const { return m_aHostname; }

--- a/src/engine/shared/http.cpp
+++ b/src/engine/shared/http.cpp
@@ -165,6 +165,14 @@ void CHttpRequest::Run()
 	m_State = OnCompletion(FinalState);
 }
 
+void CHttpRequest::Done()
+{
+	if(m_DoneHandler)
+	{
+		m_DoneHandler(this);
+	}
+}
+
 bool CHttpRequest::BeforeInit()
 {
 	if(m_WriteToFile)

--- a/src/engine/shared/jobs.cpp
+++ b/src/engine/shared/jobs.cpp
@@ -11,7 +11,7 @@ IJob::IJob() :
 
 IJob::~IJob() = default;
 
-int IJob::Status()
+IJob::EJobState IJob::Status()
 {
 	return m_Status.load();
 }

--- a/src/engine/shared/jobs.h
+++ b/src/engine/shared/jobs.h
@@ -27,7 +27,17 @@ private:
 	std::shared_ptr<IJob> m_pNext;
 	std::atomic<EJobState> m_Status;
 
+	/**
+	 * Performs tasks in a worker thread.
+	 */
 	virtual void Run() = 0;
+
+	/**
+	 * Performs final tasks on the main thread after job is done.
+	 */
+	virtual void Done()
+	{
+	}
 
 public:
 	IJob();
@@ -47,15 +57,54 @@ class CJobPool
 	std::shared_ptr<IJob> m_pFirstJob GUARDED_BY(m_Lock);
 	std::shared_ptr<IJob> m_pLastJob GUARDED_BY(m_Lock);
 
+	LOCK m_LockDone;
+	std::shared_ptr<IJob> m_pFirstJobDone GUARDED_BY(m_LockDone);
+	std::shared_ptr<IJob> m_pLastJobDone GUARDED_BY(m_LockDone);
+
 	static void WorkerThread(void *pUser) NO_THREAD_SAFETY_ANALYSIS;
 
 public:
 	CJobPool();
 	~CJobPool();
 
+	/**
+	 * Initializes the job pool with the given number of worker threads.
+	 *
+	 * @param NumTheads The number of worker threads.
+	 *
+	 * @remark Must be called on the main thread.
+	 */
 	void Init(int NumThreads);
+
+	/**
+	 * Destroys the job pool. Waits for worker threads to complete their current jobs.
+	 *
+	 * @remark Must be called on the main thread.
+	 */
 	void Destroy();
+
+	/**
+	 * Updates the job pool, calling the `Done` function for completed jobs.
+	 *
+	 * @remark Must be called on the main thread.
+	 */
+	void Update() REQUIRES(!m_LockDone);
+
+	/**
+	 * Adds a job to the queue of the job pool.
+	 *
+	 * @param pJob The job to enqueue.
+	 */
 	void Add(std::shared_ptr<IJob> pJob) REQUIRES(!m_Lock);
+
+	/**
+	 * Runs a job's lifecycle functions in the current thread.
+	 *
+	 * @param pJob The job to run.
+	 *
+	 * @remark Must be called on the main thread, if the job has
+	 * a `Done` function must be called on the main thread.
+	 */
 	static void RunBlocking(IJob *pJob);
 };
 #endif

--- a/src/engine/shared/jobs.h
+++ b/src/engine/shared/jobs.h
@@ -15,10 +15,18 @@ class IJob
 {
 	friend CJobPool;
 
+public:
+	enum EJobState
+	{
+		STATE_PENDING = 0,
+		STATE_RUNNING,
+		STATE_DONE
+	};
+
 private:
 	std::shared_ptr<IJob> m_pNext;
+	std::atomic<EJobState> m_Status;
 
-	std::atomic<int> m_Status;
 	virtual void Run() = 0;
 
 public:
@@ -26,14 +34,7 @@ public:
 	IJob(const IJob &Other) = delete;
 	IJob &operator=(const IJob &Other) = delete;
 	virtual ~IJob();
-	int Status();
-
-	enum
-	{
-		STATE_PENDING = 0,
-		STATE_RUNNING,
-		STATE_DONE
-	};
+	EJobState Status();
 };
 
 class CJobPool

--- a/src/game/client/components/skins.h
+++ b/src/game/client/components/skins.h
@@ -15,17 +15,20 @@ class CSkins : public CComponent
 public:
 	CSkins() = default;
 
-	class CGetPngFile : public CHttpRequest
+	class CSkinDownloadJob : public CHttpRequest
 	{
 		CSkins *m_pSkins;
+		char m_aName[24];
 
 	protected:
 		virtual int OnCompletion(int State) override;
+		void Done() override;
 
 	public:
-		CGetPngFile(CSkins *pSkins, const char *pUrl, IStorage *pStorage, const char *pDest);
+		CSkinDownloadJob(CSkins *pSkins, const char *pName, const char *pUrl, const char *pDest);
 		CImageInfo m_Info;
 	};
+	friend CSkinDownloadJob;
 
 	struct CDownloadSkin
 	{
@@ -33,7 +36,7 @@ public:
 		char m_aName[24];
 
 	public:
-		std::shared_ptr<CSkins::CGetPngFile> m_pTask;
+		std::shared_ptr<CSkins::CSkinDownloadJob> m_pTask;
 		char m_aPath[IO_MAX_PATH_LENGTH];
 
 		CDownloadSkin(CDownloadSkin &&Other) = default;

--- a/src/game/client/components/sounds.h
+++ b/src/game/client/components/sounds.h
@@ -10,16 +10,19 @@
 
 class CSoundLoading : public IJob
 {
-	CGameClient *m_pGameClient;
+	class CSounds *m_pSounds;
 	bool m_Render;
 
 public:
-	CSoundLoading(CGameClient *pGameClient, bool Render);
+	CSoundLoading(class CSounds *pSounds, bool Render);
 	void Run() override;
+	void Done() override;
 };
 
 class CSounds : public CComponent
 {
+	friend CSoundLoading;
+
 	enum
 	{
 		QUEUE_SIZE = 32,
@@ -31,7 +34,6 @@ class CSounds : public CComponent
 	} m_aQueue[QUEUE_SIZE];
 	int m_QueuePos;
 	int64_t m_QueueWaitTime;
-	std::shared_ptr<CSoundLoading> m_pSoundJob;
 	bool m_WaitForSoundJob;
 
 	int GetSampleId(int SetId);

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -34,7 +34,6 @@
 #include "map_view.h"
 #include "smooth_value.h"
 
-#include <deque>
 #include <functional>
 #include <map>
 #include <memory>
@@ -241,17 +240,17 @@ enum
 
 class CDataFileWriterFinishJob : public IJob
 {
+	class CEditor *m_pEditor;
 	char m_aRealFileName[IO_MAX_PATH_LENGTH];
 	char m_aTempFileName[IO_MAX_PATH_LENGTH];
 	CDataFileWriter m_Writer;
 
-	void Run() override
-	{
-		m_Writer.Finish();
-	}
+	void Run() override;
+	void Done() override;
 
 public:
-	CDataFileWriterFinishJob(const char *pRealFileName, const char *pTempFileName, CDataFileWriter &&Writer) :
+	CDataFileWriterFinishJob(class CEditor *pEditor, const char *pRealFileName, const char *pTempFileName, CDataFileWriter &&Writer) :
+		m_pEditor(pEditor),
 		m_Writer(std::move(Writer))
 	{
 		str_copy(m_aRealFileName, pRealFileName);
@@ -430,7 +429,6 @@ public:
 	void DispatchInputEvents();
 	void HandleAutosave();
 	bool PerformAutosave();
-	void HandleWriterFinishJobs();
 
 	void RefreshFilteredFileList();
 	void FilelistPopulate(int StorageType, bool KeepSelection = false);
@@ -737,7 +735,7 @@ public:
 	static const void *ms_pUiGotContext;
 
 	CEditorMap m_Map;
-	std::deque<std::shared_ptr<CDataFileWriterFinishJob>> m_WriterFinishJobs;
+	std::vector<std::shared_ptr<CDataFileWriterFinishJob>> m_vpWriterFinishJobs;
 
 	int m_ShiftBy;
 


### PR DESCRIPTION
We currently poll if specific background jobs are done in various places to perform some final computations on the main thread.

To simplify job handling the virtual function `IJob::Done` is added to perform these final computations. This function will be called automatically on the main thread by the job pool, for all jobs that have finished their `Run` function. Hence, polling the current state of jobs is not necessary anymore for most use-cases.

The `CJobPool::Update` function is added, which must be called on the main thread periodically to call the `Done` callback for all finished jobs, which are stored in a separate queue.

For the generic `CHostLookup` and `CHttpRequest` jobs the `Done` function can be set to a lambda function, so overriding these classes is not necessary just to specify a custom `Done` function.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [X] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
