### PR TITLE
Align kill messages properly in demos when using `cl_showpred`

### DIFF
--- a/src/game/client/components/killmessages.cpp
+++ b/src/game/client/components/killmessages.cpp
@@ -282,7 +282,7 @@ void CKillMessages::OnRender()
 	Graphics()->SetColor(1.f, 1.f, 1.f, 1.f);
 
 	float StartX = Width * 1.5f - 10.0f;
-	float y = 30.0f + 100.0f * ((g_Config.m_ClShowfps ? 1 : 0) + g_Config.m_ClShowpred);
+	float y = 30.0f + 100.0f * ((g_Config.m_ClShowfps ? 1 : 0) + (g_Config.m_ClShowpred && Client()->State() != IClient::STATE_DEMOPLAYBACK));
 
 	for(int i = 1; i <= MAX_KILLMSGS; i++)
 	{


### PR DESCRIPTION
As `cl_showpred` isn't shown in demos anymore after #7261.

Before
![image](https://github.com/ddnet/ddnet/assets/141338449/cd63de1b-dadf-4e77-ae5d-bc034d73ba81)

After
![image](https://github.com/ddnet/ddnet/assets/141338449/52dc2854-87b3-4f87-b9c9-ad3e81a74506)


## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
