### PR TITLE
Remove Parallax Zoom from map file

### DIFF
--- a/src/game/client/components/maplayers.cpp
+++ b/src/game/client/components/maplayers.cpp
@@ -1559,7 +1559,6 @@ void CMapLayers::OnRender()
 	for(int g = 0; g < m_pLayers->NumGroups(); g++)
 	{
 		CMapItemGroup *pGroup = m_pLayers->GetGroup(g);
-		CMapItemGroupEx *pGroupEx = m_pLayers->GetGroupEx(g);
 
 		if(!pGroup)
 		{
@@ -1573,7 +1572,7 @@ void CMapLayers::OnRender()
 		{
 			// set clipping
 			float aPoints[4];
-			RenderTools()->MapScreenToGroup(Center.x, Center.y, m_pLayers->GameGroup(), m_pLayers->GameGroupEx(), GetCurCamera()->m_Zoom);
+			RenderTools()->MapScreenToGroup(Center.x, Center.y, m_pLayers->GameGroup(), GetCurCamera()->m_Zoom);
 			Graphics()->GetScreen(&aPoints[0], &aPoints[1], &aPoints[2], &aPoints[3]);
 			float x0 = (pGroup->m_ClipX - aPoints[0]) / (aPoints[2] - aPoints[0]);
 			float y0 = (pGroup->m_ClipY - aPoints[1]) / (aPoints[3] - aPoints[1]);
@@ -1591,7 +1590,7 @@ void CMapLayers::OnRender()
 				(int)((x1 - x0) * Graphics()->ScreenWidth()), (int)((y1 - y0) * Graphics()->ScreenHeight()));
 		}
 
-		RenderTools()->MapScreenToGroup(Center.x, Center.y, pGroup, pGroupEx, GetCurCamera()->m_Zoom);
+		RenderTools()->MapScreenToGroup(Center.x, Center.y, pGroup, GetCurCamera()->m_Zoom);
 
 		for(int l = 0; l < pGroup->m_NumLayers; l++)
 		{

--- a/src/game/client/render.cpp
+++ b/src/game/client/render.cpp
@@ -15,7 +15,6 @@
 #include <game/generated/protocol.h>
 
 #include <game/mapitems.h>
-#include <game/mapitems_ex.h>
 
 static float gs_SpriteWScale;
 static float gs_SpriteHScale;
@@ -413,9 +412,9 @@ void CRenderTools::MapScreenToWorld(float CenterX, float CenterY, float Parallax
 	pPoints[3] = pPoints[1] + Height;
 }
 
-void CRenderTools::MapScreenToGroup(float CenterX, float CenterY, CMapItemGroup *pGroup, CMapItemGroupEx *pGroupEx, float Zoom)
+void CRenderTools::MapScreenToGroup(float CenterX, float CenterY, CMapItemGroup *pGroup, float Zoom)
 {
-	float ParallaxZoom = GetParallaxZoom(pGroup, pGroupEx);
+	float ParallaxZoom = clamp((double)(maximum(pGroup->m_ParallaxX, pGroup->m_ParallaxY)), 0., 100.);
 	float aPoints[4];
 	MapScreenToWorld(CenterX, CenterY, pGroup->m_ParallaxX, pGroup->m_ParallaxY, ParallaxZoom,
 		pGroup->m_OffsetX, pGroup->m_OffsetY, Graphics()->ScreenAspect(), Zoom, aPoints);

--- a/src/game/client/render.h
+++ b/src/game/client/render.h
@@ -23,7 +23,6 @@ struct CEnvPoint;
 struct CEnvPointBezier;
 struct CEnvPointBezier_upstream;
 struct CMapItemGroup;
-struct CMapItemGroupEx;
 struct CQuad;
 
 class CTeeRenderInfo
@@ -171,7 +170,7 @@ public:
 	void CalcScreenParams(float Aspect, float Zoom, float *pWidth, float *pHeight);
 	void MapScreenToWorld(float CenterX, float CenterY, float ParallaxX, float ParallaxY,
 		float ParallaxZoom, float OffsetX, float OffsetY, float Aspect, float Zoom, float *pPoints);
-	void MapScreenToGroup(float CenterX, float CenterY, CMapItemGroup *pGroup, CMapItemGroupEx *pGroupEx, float Zoom);
+	void MapScreenToGroup(float CenterX, float CenterY, CMapItemGroup *pGroup, float Zoom);
 	void MapScreenToInterface(float CenterX, float CenterY);
 
 	// DDRace

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -2738,7 +2738,6 @@ void CEditor::DoMapEditor(CUIRect View)
 						m_pBrush->m_OffsetY += pGroup->m_OffsetY;
 						m_pBrush->m_ParallaxX = pGroup->m_ParallaxX;
 						m_pBrush->m_ParallaxY = pGroup->m_ParallaxY;
-						m_pBrush->m_ParallaxZoom = pGroup->m_ParallaxZoom;
 						m_pBrush->Render();
 						float w, h;
 						m_pBrush->GetSize(&w, &h);

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -9,7 +9,6 @@
 #include <game/client/render.h>
 #include <game/client/ui.h>
 #include <game/mapitems.h>
-#include <game/mapitems_ex.h>
 
 #include <game/editor/mapitems/envelope.h>
 #include <game/editor/mapitems/layer.h>

--- a/src/game/editor/mapitems/layer_group.cpp
+++ b/src/game/editor/mapitems/layer_group.cpp
@@ -1,5 +1,6 @@
 #include "layer_group.h"
 
+#include <base/math.h>
 #include <game/editor/editor.h>
 
 CLayerGroup::CLayerGroup()
@@ -13,8 +14,6 @@ CLayerGroup::CLayerGroup()
 	m_OffsetY = 0;
 	m_ParallaxX = 100;
 	m_ParallaxY = 100;
-	m_CustomParallaxZoom = 0;
-	m_ParallaxZoom = 100;
 
 	m_UseClipping = 0;
 	m_ClipX = 0;
@@ -36,7 +35,8 @@ void CLayerGroup::Convert(CUIRect *pRect)
 
 void CLayerGroup::Mapping(float *pPoints)
 {
-	float ParallaxZoom = m_pMap->m_pEditor->m_PreviewZoom ? m_ParallaxZoom : 100.0f;
+	float NormalParallaxZoom = clamp((double)(maximum(m_ParallaxX, m_ParallaxY)), 0., 100.);
+	float ParallaxZoom = m_pMap->m_pEditor->m_PreviewZoom ? NormalParallaxZoom : 100.0f;
 
 	m_pMap->m_pEditor->RenderTools()->MapScreenToWorld(
 		m_pMap->m_pEditor->MapView()->GetWorldOffset().x, m_pMap->m_pEditor->MapView()->GetWorldOffset().y,

--- a/src/game/editor/mapitems/layer_group.h
+++ b/src/game/editor/mapitems/layer_group.h
@@ -3,8 +3,6 @@
 
 #include "layer.h"
 
-#include <game/mapitems_ex.h>
-
 #include <memory>
 #include <vector>
 
@@ -20,8 +18,6 @@ public:
 
 	int m_ParallaxX;
 	int m_ParallaxY;
-	int m_CustomParallaxZoom;
-	int m_ParallaxZoom;
 
 	int m_UseClipping;
 	int m_ClipX;
@@ -51,12 +47,6 @@ public:
 	bool IsEmpty() const
 	{
 		return m_vpLayers.empty();
-	}
-
-	void OnEdited()
-	{
-		if(!m_CustomParallaxZoom)
-			m_ParallaxZoom = GetParallaxZoomDefault(m_ParallaxX, m_ParallaxY);
 	}
 
 	void Clear()

--- a/src/game/editor/mapitems/map.cpp
+++ b/src/game/editor/mapitems/map.cpp
@@ -125,8 +125,6 @@ void CEditorMap::CreateDefault(IGraphics::CTextureHandle EntitiesTexture)
 	std::shared_ptr<CLayerGroup> pGroup = NewGroup();
 	pGroup->m_ParallaxX = 0;
 	pGroup->m_ParallaxY = 0;
-	pGroup->m_CustomParallaxZoom = 0;
-	pGroup->m_ParallaxZoom = 0;
 	std::shared_ptr<CLayerQuads> pLayer = std::make_shared<CLayerQuads>(m_pEditor);
 	CQuad *pQuad = pLayer->NewQuad(0, 0, 1600, 1200);
 	pQuad->m_aColors[0].r = pQuad->m_aColors[1].r = 94;

--- a/src/game/editor/mapitems/map_io.cpp
+++ b/src/game/editor/mapitems/map_io.cpp
@@ -174,10 +174,6 @@ bool CEditorMap::Save(const char *pFileName)
 		// save group name
 		StrToInts(GItem.m_aName, sizeof(GItem.m_aName) / sizeof(int), pGroup->m_aName);
 
-		CMapItemGroupEx GItemEx;
-		GItemEx.m_Version = CMapItemGroupEx::CURRENT_VERSION;
-		GItemEx.m_ParallaxZoom = pGroup->m_ParallaxZoom;
-
 		for(const std::shared_ptr<CLayer> &pLayer : pGroup->m_vpLayers)
 		{
 			if(pLayer->m_Type == LAYERTYPE_TILES)
@@ -323,7 +319,6 @@ bool CEditorMap::Save(const char *pFileName)
 		}
 
 		Writer.AddItem(MAPITEMTYPE_GROUP, GroupCount, sizeof(GItem), &GItem);
-		Writer.AddItem(MAPITEMTYPE_GROUP_EX, GroupCount, sizeof(GItemEx), &GItemEx);
 		GroupCount++;
 	}
 
@@ -605,14 +600,9 @@ bool CEditorMap::Load(const char *pFileName, int StorageType, const std::functio
 		int Start, Num;
 		DataFile.GetType(MAPITEMTYPE_GROUP, &Start, &Num);
 
-		int StartEx, NumEx;
-		DataFile.GetType(MAPITEMTYPE_GROUP_EX, &StartEx, &NumEx);
 		for(int g = 0; g < Num; g++)
 		{
 			CMapItemGroup *pGItem = (CMapItemGroup *)DataFile.GetItem(Start + g);
-			CMapItemGroupEx *pGItemEx = nullptr;
-			if(NumEx)
-				pGItemEx = (CMapItemGroupEx *)DataFile.GetItem(StartEx + g);
 
 			if(pGItem->m_Version < 1 || pGItem->m_Version > CMapItemGroup::CURRENT_VERSION)
 				continue;
@@ -635,9 +625,6 @@ bool CEditorMap::Load(const char *pFileName, int StorageType, const std::functio
 			// load group name
 			if(pGItem->m_Version >= 3)
 				IntsToStr(pGItem->m_aName, sizeof(pGroup->m_aName) / sizeof(int), pGroup->m_aName);
-
-			pGroup->m_ParallaxZoom = GetParallaxZoom(pGItem, pGItemEx);
-			pGroup->m_CustomParallaxZoom = pGroup->m_ParallaxZoom != GetParallaxZoomDefault(pGroup->m_ParallaxX, pGroup->m_ParallaxY);
 
 			for(int l = 0; l < pGItem->m_NumLayers; l++)
 			{

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -534,8 +534,6 @@ CUI::EPopupMenuFunctionResult CEditor::PopupGroup(void *pContext, CUIRect View, 
 		PROP_POS_Y,
 		PROP_PARA_X,
 		PROP_PARA_Y,
-		PROP_CUSTOM_ZOOM,
-		PROP_PARA_ZOOM,
 		PROP_USE_CLIPPING,
 		PROP_CLIP_X,
 		PROP_CLIP_Y,
@@ -550,8 +548,6 @@ CUI::EPopupMenuFunctionResult CEditor::PopupGroup(void *pContext, CUIRect View, 
 		{"Pos Y", -pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_OffsetY, PROPTYPE_INT_SCROLL, -1000000, 1000000},
 		{"Para X", pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_ParallaxX, PROPTYPE_INT_SCROLL, -1000000, 1000000},
 		{"Para Y", pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_ParallaxY, PROPTYPE_INT_SCROLL, -1000000, 1000000},
-		{"Custom Zoom", pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_CustomParallaxZoom, PROPTYPE_BOOL, 0, 1},
-		{"Para Zoom", pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_ParallaxZoom, PROPTYPE_INT_SCROLL, -1000000, 1000000},
 		{"Use Clipping", pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_UseClipping, PROPTYPE_BOOL, 0, 1},
 		{"Clip X", pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_ClipX, PROPTYPE_INT_SCROLL, -1000000, 1000000},
 		{"Clip Y", pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_ClipY, PROPTYPE_INT_SCROLL, -1000000, 1000000},
@@ -588,15 +584,6 @@ CUI::EPopupMenuFunctionResult CEditor::PopupGroup(void *pContext, CUIRect View, 
 		{
 			pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_ParallaxY = NewVal;
 		}
-		else if(Prop == PROP_CUSTOM_ZOOM)
-		{
-			pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_CustomParallaxZoom = NewVal;
-		}
-		else if(Prop == PROP_PARA_ZOOM)
-		{
-			pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_CustomParallaxZoom = 1;
-			pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_ParallaxZoom = NewVal;
-		}
 		else if(Prop == PROP_POS_X)
 		{
 			pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_OffsetX = -NewVal;
@@ -625,8 +612,6 @@ CUI::EPopupMenuFunctionResult CEditor::PopupGroup(void *pContext, CUIRect View, 
 		{
 			pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_ClipH = NewVal;
 		}
-
-		pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->OnEdited();
 	}
 
 	return CUI::POPUP_KEEP_OPEN;

--- a/src/game/layers.cpp
+++ b/src/game/layers.cpp
@@ -3,7 +3,6 @@
 #include "layers.h"
 
 #include "mapitems.h"
-#include "mapitems_ex.h"
 
 #include <engine/map.h>
 
@@ -11,12 +10,9 @@ CLayers::CLayers()
 {
 	m_GroupsNum = 0;
 	m_GroupsStart = 0;
-	m_GroupsExNum = 0;
-	m_GroupsExStart = 0;
 	m_LayersNum = 0;
 	m_LayersStart = 0;
 	m_pGameGroup = 0;
-	m_pGameGroupEx = 0;
 	m_pGameLayer = 0;
 	m_pMap = 0;
 
@@ -31,7 +27,6 @@ void CLayers::Init(class IKernel *pKernel)
 {
 	m_pMap = pKernel->RequestInterface<IMap>();
 	m_pMap->GetType(MAPITEMTYPE_GROUP, &m_GroupsStart, &m_GroupsNum);
-	m_pMap->GetType(MAPITEMTYPE_GROUP_EX, &m_GroupsExStart, &m_GroupsExNum);
 	m_pMap->GetType(MAPITEMTYPE_LAYER, &m_LayersStart, &m_LayersNum);
 
 	m_pTeleLayer = 0;
@@ -43,7 +38,6 @@ void CLayers::Init(class IKernel *pKernel)
 	for(int g = 0; g < NumGroups(); g++)
 	{
 		CMapItemGroup *pGroup = GetGroup(g);
-		CMapItemGroupEx *pGroupEx = GetGroupEx(g);
 		for(int l = 0; l < pGroup->m_NumLayers; l++)
 		{
 			CMapItemLayer *pLayer = GetLayer(pGroup->m_StartLayer + l);
@@ -56,7 +50,6 @@ void CLayers::Init(class IKernel *pKernel)
 				{
 					m_pGameLayer = pTilemap;
 					m_pGameGroup = pGroup;
-					m_pGameGroupEx = pGroupEx;
 
 					// make sure the game group has standard settings
 					m_pGameGroup->m_OffsetX = 0;
@@ -72,9 +65,6 @@ void CLayers::Init(class IKernel *pKernel)
 						m_pGameGroup->m_ClipW = 0;
 						m_pGameGroup->m_ClipH = 0;
 					}
-
-					if(pGroupEx)
-						pGroupEx->m_ParallaxZoom = 100;
 
 					//break;
 				}
@@ -129,7 +119,6 @@ void CLayers::InitBackground(class IMap *pMap)
 {
 	m_pMap = pMap;
 	m_pMap->GetType(MAPITEMTYPE_GROUP, &m_GroupsStart, &m_GroupsNum);
-	m_pMap->GetType(MAPITEMTYPE_GROUP_EX, &m_GroupsExStart, &m_GroupsExNum);
 	m_pMap->GetType(MAPITEMTYPE_LAYER, &m_LayersStart, &m_LayersNum);
 
 	//following is here to prevent crash using standard map as background
@@ -142,7 +131,6 @@ void CLayers::InitBackground(class IMap *pMap)
 	for(int g = 0; g < NumGroups(); g++)
 	{
 		CMapItemGroup *pGroup = GetGroup(g);
-		CMapItemGroupEx *pGroupEx = GetGroupEx(g);
 		for(int l = 0; l < pGroup->m_NumLayers; l++)
 		{
 			CMapItemLayer *pLayer = GetLayer(pGroup->m_StartLayer + l);
@@ -155,7 +143,6 @@ void CLayers::InitBackground(class IMap *pMap)
 				{
 					m_pGameLayer = pTilemap;
 					m_pGameGroup = pGroup;
-					m_pGameGroupEx = pGroupEx;
 
 					// make sure the game group has standard settings
 					m_pGameGroup->m_OffsetX = 0;
@@ -171,10 +158,6 @@ void CLayers::InitBackground(class IMap *pMap)
 						m_pGameGroup->m_ClipW = 0;
 						m_pGameGroup->m_ClipH = 0;
 					}
-
-					if(pGroupEx)
-						pGroupEx->m_ParallaxZoom = 100;
-
 					//We don't care about tile layers.
 				}
 			}
@@ -221,15 +204,6 @@ void CLayers::InitTilemapSkip()
 CMapItemGroup *CLayers::GetGroup(int Index) const
 {
 	return static_cast<CMapItemGroup *>(m_pMap->GetItem(m_GroupsStart + Index));
-}
-
-CMapItemGroupEx *CLayers::GetGroupEx(int Index) const
-{
-	// Map doesn't have GroupEx items or GroupEx indexes don't match groups for some other reason. Lets turn them off completely to be safe.
-	if(m_GroupsExNum != m_GroupsNum)
-		return nullptr;
-
-	return static_cast<CMapItemGroupEx *>(m_pMap->GetItem(m_GroupsExStart + Index));
 }
 
 CMapItemLayer *CLayers::GetLayer(int Index) const

--- a/src/game/layers.h
+++ b/src/game/layers.h
@@ -7,7 +7,6 @@ class IKernel;
 class IMap;
 
 struct CMapItemGroup;
-struct CMapItemGroupEx;
 struct CMapItemLayer;
 struct CMapItemLayerTilemap;
 
@@ -15,12 +14,9 @@ class CLayers
 {
 	int m_GroupsNum;
 	int m_GroupsStart;
-	int m_GroupsExNum;
-	int m_GroupsExStart;
 	int m_LayersNum;
 	int m_LayersStart;
 	CMapItemGroup *m_pGameGroup;
-	CMapItemGroupEx *m_pGameGroupEx;
 	CMapItemLayerTilemap *m_pGameLayer;
 	IMap *m_pMap;
 
@@ -34,10 +30,8 @@ public:
 	int NumLayers() const { return m_LayersNum; }
 	IMap *Map() const { return m_pMap; }
 	CMapItemGroup *GameGroup() const { return m_pGameGroup; }
-	CMapItemGroupEx *GameGroupEx() const { return m_pGameGroupEx; }
 	CMapItemLayerTilemap *GameLayer() const { return m_pGameLayer; }
 	CMapItemGroup *GetGroup(int Index) const;
-	CMapItemGroupEx *GetGroupEx(int Index) const;
 	CMapItemLayer *GetLayer(int Index) const;
 
 	// DDRace

--- a/src/game/mapitems_ex.cpp
+++ b/src/game/mapitems_ex.cpp
@@ -1,20 +1,6 @@
 #include "mapitems_ex.h"
 
-#include <base/math.h>
 #include <engine/shared/uuid_manager.h>
-
-int GetParallaxZoom(const CMapItemGroup *pGroup, const CMapItemGroupEx *pGroupEx)
-{
-	if(pGroupEx)
-		return pGroupEx->m_ParallaxZoom;
-
-	return GetParallaxZoomDefault(pGroup->m_ParallaxX, pGroup->m_ParallaxY);
-}
-
-int GetParallaxZoomDefault(int ParallaxX, int ParallaxY)
-{
-	return clamp(maximum(ParallaxX, ParallaxY), 0, 100);
-}
 
 void RegisterMapItemTypeUuids(CUuidManager *pManager)
 {

--- a/src/game/mapitems_ex.h
+++ b/src/game/mapitems_ex.h
@@ -2,8 +2,6 @@
 #define GAME_MAPITEMS_EX_H
 #include <game/generated/protocol.h>
 
-#include "mapitems.h"
-
 enum
 {
 	__MAPITEMTYPE_UUID_HELPER = OFFSET_MAPITEMTYPE_UUID - 1,
@@ -44,24 +42,6 @@ struct CMapItemAutoMapperConfig
 	int m_AutomapperSeed;
 	int m_Flags;
 };
-
-struct CMapItemGroupEx
-{
-	enum
-	{
-		CURRENT_VERSION = 1
-	};
-
-	int m_Version;
-
-	// ItemGroup's perceived distance from camera when zooming. Similar to how
-	// Parallax{X,Y} works when camera is moving along the X and Y axes,
-	// this setting applies to camera moving closer or away (zooming in or out).
-	int m_ParallaxZoom;
-};
-
-int GetParallaxZoom(const CMapItemGroup *pGroup, const CMapItemGroupEx *pGroupEx);
-int GetParallaxZoomDefault(int ParallaxX, int ParallaxY);
 
 void RegisterMapItemTypeUuids(class CUuidManager *pManager);
 #endif // GAME_MAPITEMS_EX_H

--- a/src/game/mapitems_ex_types.h
+++ b/src/game/mapitems_ex_types.h
@@ -2,5 +2,4 @@
 
 UUID(MAPITEMTYPE_TEST, "mapitemtype-test@ddnet.tw")
 UUID(MAPITEMTYPE_AUTOMAPPER_CONFIG, "mapitemtype-automapper-config@ddnet.tw")
-UUID(MAPITEMTYPE_GROUP_EX, "mapitemtype-group@ddnet.tw")
 UUID(MAPITEMTYPE_ENVPOINTS_BEZIER, "mapitemtype-envpoints-bezier@ddnet.tw")


### PR DESCRIPTION
Parallax Zoom improves the appearance of maps visually when zooming. Contrary to initial tests, it does not interfere with certain map locations, such as the shop on the map Timeshop.
The default value appears to be correct for all existing maps.

The value in the map file is non-trivial to manage, and provides little benefit. See #6196 for further discussion.

Interesting could be if there are more maps nowadays, which set custom values. And then also if those maps use the value correctly.
The opinion of mappers would also be interesting.

I can see this customizability coming back in some shape or form, but as of now, I don't see a reason for this to be integrated into the map file.
On the other hand, it does have downsides like side effects on modification and nudging mappers into editing a value that shouldn't really be touched.

<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
