### PR TITLE
Fix incorrect ghost being loaded with `cl_race_ghost_save_best`

### DIFF
--- a/src/game/client/components/ghost.cpp
+++ b/src/game/client/components/ghost.cpp
@@ -432,13 +432,13 @@ void CGhost::StopRecord(int Time)
 	CMenus::CGhostItem *pOwnGhost = m_pClient->m_Menus.GetOwnGhost();
 	if(Time > 0 && (!pOwnGhost || Time < pOwnGhost->m_Time || !g_Config.m_ClRaceGhostSaveBest))
 	{
-		if(pOwnGhost && pOwnGhost->Active())
-			Unload(pOwnGhost->m_Slot);
-
 		// add to active ghosts
 		int Slot = GetSlot();
-		if(Slot != -1)
+		if(Slot != -1 && (!pOwnGhost || Time < pOwnGhost->m_Time))
 			m_aActiveGhosts[Slot] = std::move(m_CurGhost);
+
+		if(pOwnGhost && pOwnGhost->Active() && Time < pOwnGhost->m_Time)
+			Unload(pOwnGhost->m_Slot);
 
 		// create ghost item
 		CMenus::CGhostItem Item;

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -956,7 +956,7 @@ void CMenus::UpdateOwnGhost(CGhostItem Item)
 			if(Item.HasFile() || !m_vGhosts[Own].HasFile())
 				DeleteGhostItem(Own);
 		}
-		if(m_vGhosts[Own].m_Time >= Item.m_Time)
+		if(m_vGhosts[Own].m_Time > Item.m_Time)
 		{
 			Item.m_Own = true;
 			m_vGhosts[Own].m_Own = false;


### PR DESCRIPTION
Previously the wrong ghost would be shown/loaded when finishing a run that's worse than your best time. Closes #7387

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
