### PR TITLE
Delay server race demo ending by 1 second.

### DIFF
--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -918,7 +918,16 @@ bool CCharacter::IncreaseArmor(int Amount)
 void CCharacter::Die(int Killer, int Weapon, bool SendKillMsg)
 {
 	if(Server()->IsRecording(m_pPlayer->GetCID()))
-		Server()->StopRecord(m_pPlayer->GetCID());
+	{
+		CPlayerData *pData = GameServer()->Score()->PlayerData(m_pPlayer->GetCID());
+
+		if(pData->m_RecordStopTick - Server()->Tick() <= Server()->TickSpeed() && pData->m_RecordStopTick != -1)
+			Server()->SaveDemo(m_pPlayer->GetCID(), pData->m_RecordFinishTime);
+		else
+			Server()->StopRecord(m_pPlayer->GetCID());
+
+		pData->m_RecordStopTick = -1;
+	}
 
 	int ModeSpecial = GameServer()->m_pController->OnCharacterDeath(this, GameServer()->m_apPlayers[Killer], Weapon);
 

--- a/src/game/server/scoreworker.h
+++ b/src/game/server/scoreworker.h
@@ -233,6 +233,8 @@ public:
 		m_BestTime = 0;
 		for(float &BestTimeCp : m_aBestTimeCp)
 			BestTimeCp = 0;
+
+		m_RecordStopTick = -1;
 	}
 
 	void Set(float Time, const float aTimeCp[NUM_CHECKPOINTS])
@@ -244,6 +246,9 @@ public:
 
 	float m_BestTime;
 	float m_aBestTimeCp[NUM_CHECKPOINTS];
+
+	int m_RecordStopTick;
+	float m_RecordFinishTime;
 };
 
 struct CTeamrank


### PR DESCRIPTION
Previously demos recorded with `sv_player_demo_record 1` would abruptly end as soonest the player hit the finish line. It now delays the end by 1 second. Closes #5775

https://github.com/ddnet/ddnet/assets/141338449/9e14a5a8-546a-41f9-8bad-209a83beed5b

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
