### PR TITLE
Fix afk timer not working.

### DIFF
--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -1612,7 +1612,7 @@ void CGameContext::OnClientConnected(int ClientID, void *pData)
 	if(m_apPlayers[ClientID])
 		delete m_apPlayers[ClientID];
 	m_apPlayers[ClientID] = new(ClientID) CPlayer(this, NextUniqueClientID, ClientID, StartTeam);
-	m_apPlayers[ClientID]->SetAfk(Afk);
+	m_apPlayers[ClientID]->SetInitialAfk(Afk);
 	NextUniqueClientID += 1;
 
 #ifdef CONF_DEBUG

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -714,15 +714,21 @@ void CPlayer::AfkTimer()
 void CPlayer::SetAfk(bool Afk)
 {
 	if(m_Afk != Afk)
+	{
 		Server()->ExpireServerInfo();
+		m_Afk = Afk;
+	}
+}
 
+void CPlayer::SetInitialAfk(bool Afk)
+{
 	if(g_Config.m_SvMaxAfkTime == 0)
 	{
-		m_Afk = false;
+		SetAfk(false);
 		return;
 	}
 
-	m_Afk = Afk;
+	SetAfk(Afk);
 
 	// Ensure that the AFK state is not reset again automatically
 	if(Afk)

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -193,6 +193,7 @@ public:
 	void UpdatePlaytime();
 	void AfkTimer();
 	void SetAfk(bool Afk);
+	void SetInitialAfk(bool Afk);
 	bool IsAfk() const { return m_Afk; }
 
 	int64_t m_LastPlaytime;


### PR DESCRIPTION
I broke it in #7262, because I thought `SetAfk` would just set `m_Afk`. The original function is now renamed to `SetInitialAfk` which is more representative of what it does. As reported by @0xfaulty in the original PR. 

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
