### PR TITLE
Added back underline for `sv_regional_rankings 0`.

### DIFF
--- a/src/game/server/scoreworker.cpp
+++ b/src/game/server/scoreworker.cpp
@@ -970,7 +970,10 @@ bool CScoreWorker::ShowTop(IDbConnection *pSqlServer, const ISqlData *pGameData,
 	}
 
 	if(!g_Config.m_SvRegionalRankings)
+	{
+		str_copy(pResult->m_Data.m_aaMessages[Line], "----------------------------------------", sizeof(pResult->m_Data.m_aaMessages[Line]));
 		return !End;
+	}
 
 	char aServerLike[16];
 	str_format(aServerLike, sizeof(aServerLike), "%%%s%%", pData->m_aServer);

--- a/src/test/score.cpp
+++ b/src/test/score.cpp
@@ -159,7 +159,8 @@ TEST_P(SingleScore, Top)
 	ASSERT_FALSE(CScoreWorker::ShowTop(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
 	ExpectLines(m_pPlayerResult,
 		{"------------ Global Top ------------",
-			"1. nameless tee Time: 01:40.00"});
+			"1. nameless tee Time: 01:40.00",
+			"----------------------------------------"});
 }
 
 TEST_P(SingleScore, RankRegional)
@@ -195,7 +196,8 @@ TEST_P(SingleScore, TopServer)
 	ASSERT_FALSE(CScoreWorker::ShowTop(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
 	ExpectLines(m_pPlayerResult,
 		{"------------ Global Top ------------",
-			"1. nameless tee Time: 01:40.00"});
+			"1. nameless tee Time: 01:40.00",
+			"----------------------------------------"});
 }
 
 TEST_P(SingleScore, RankServerRegional)


### PR DESCRIPTION
This resurrects the underline under the top 5 list when using  `sv_regional_rankings 0`.

Fixes #7395.

Demonstaration:

![image](https://github.com/ddnet/ddnet/assets/37349525/c7bd7c31-f44f-40e1-86d7-230ab382fc1b)

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [x] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
