### PR TITLE
Allow loading embedded images without valid image name, show warning popup when map image/sound cannot be loaded

### DIFF
--- a/src/game/client/components/mapimages.cpp
+++ b/src/game/client/components/mapimages.cpp
@@ -112,8 +112,12 @@ void CMapImages::OnMapLoadImpl(class CLayers *pLayers, IMap *pMap)
 		const char *pName = pMap->GetDataString(pImg->m_ImageName);
 		if(pName == nullptr || pName[0] == '\0')
 		{
-			log_error("mapimages", "Failed to load map image %d: failed to load name.", i);
-			continue;
+			if(pImg->m_External)
+			{
+				log_error("mapimages", "Failed to load map image %d: failed to load name.", i);
+				continue;
+			}
+			pName = "(error)";
 		}
 
 		if(pImg->m_External)

--- a/src/game/client/components/mapimages.cpp
+++ b/src/game/client/components/mapimages.cpp
@@ -1,5 +1,7 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
+#include "mapimages.h"
+
 #include <base/log.h>
 
 #include <engine/graphics.h>
@@ -10,9 +12,12 @@
 #include <game/client/gameclient.h>
 #include <game/generated/client_data.h>
 #include <game/layers.h>
+#include <game/localization.h>
 #include <game/mapitems.h>
 
-#include "mapimages.h"
+#include <chrono>
+
+using namespace std::chrono_literals;
 
 const char *const gs_apModEntitiesNames[] = {
 	"ddnet",
@@ -103,6 +108,7 @@ void CMapImages::OnMapLoadImpl(class CLayers *pLayers, IMap *pMap)
 	const int TextureLoadFlag = Graphics()->HasTextureArrays() ? IGraphics::TEXLOAD_TO_2D_ARRAY_TEXTURE : IGraphics::TEXLOAD_TO_3D_TEXTURE;
 
 	// load new textures
+	bool ShowWarning = false;
 	for(int i = 0; i < m_Count; i++)
 	{
 		const int LoadFlag = (((m_aTextureUsedByTileOrQuadLayerFlag[i] & 1) != 0) ? TextureLoadFlag : 0) | (((m_aTextureUsedByTileOrQuadLayerFlag[i] & 2) != 0) ? 0 : (Graphics()->IsTileBufferingEnabled() ? IGraphics::TEXLOAD_NO_2D_TEXTURE : 0));
@@ -115,6 +121,7 @@ void CMapImages::OnMapLoadImpl(class CLayers *pLayers, IMap *pMap)
 			if(pImg->m_External)
 			{
 				log_error("mapimages", "Failed to load map image %d: failed to load name.", i);
+				ShowWarning = true;
 				continue;
 			}
 			pName = "(error)";
@@ -135,6 +142,11 @@ void CMapImages::OnMapLoadImpl(class CLayers *pLayers, IMap *pMap)
 			pMap->UnloadData(pImg->m_ImageData);
 		}
 		pMap->UnloadData(pImg->m_ImageName);
+		ShowWarning = ShowWarning || m_aTextures[i].Id() == Graphics()->InvalidTexture().Id();
+	}
+	if(ShowWarning)
+	{
+		m_pClient->m_Menus.PopupWarning(Localize("Warning"), Localize("Some map images could not be loaded. Check the local console for details."), Localize("Ok"), 10s);
 	}
 }
 


### PR DESCRIPTION
The image name is only required for external images. For embedded images it was only used in log messages. This fixes rendering with various maps that have embedded images with invalid names.

Show a warning popup when a map image or sound cannot be loaded for any reason. Only one generic warning popup is shown for images and sounds individually.

![screenshot_2023-10-31_21-09-16](https://github.com/ddnet/ddnet/assets/23437060/769b0cbb-b5fc-4e0a-9ac7-56f8d38ae668)

See #7397.

## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
