### PR TITLE
Add gameclient warnings to queue instead of overriding others

### DIFF
--- a/src/engine/client.h
+++ b/src/engine/client.h
@@ -279,7 +279,9 @@ public:
 
 	virtual void GetSmoothTick(int *pSmoothTick, float *pSmoothIntraTick, float MixAmount) = 0;
 
+	virtual void AddWarning(const SWarning &Warning) = 0;
 	virtual SWarning *GetCurWarning() = 0;
+
 	virtual CChecksumData *ChecksumData() = 0;
 	virtual bool InfoTaskRunning() = 0;
 	virtual int UdpConnectivity(int NetType) = 0;

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -4662,6 +4662,11 @@ void CClient::GetSmoothTick(int *pSmoothTick, float *pSmoothIntraTick, float Mix
 	*pSmoothIntraTick = (SmoothTime - (*pSmoothTick - 1) * time_freq() / 50) / (float)(time_freq() / 50);
 }
 
+void CClient::AddWarning(const SWarning &Warning)
+{
+	m_vWarnings.emplace_back(Warning);
+}
+
 SWarning *CClient::GetCurWarning()
 {
 	if(m_vWarnings.empty())

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -493,7 +493,9 @@ public:
 
 	void GetSmoothTick(int *pSmoothTick, float *pSmoothIntraTick, float MixAmount) override;
 
+	void AddWarning(const SWarning &Warning) override;
 	SWarning *GetCurWarning() override;
+
 	CChecksumData *ChecksumData() override { return &m_Checksum.m_Data; }
 	bool InfoTaskRunning() override { return m_pDDNetInfoTask != nullptr; }
 	int UdpConnectivity(int NetType) override;

--- a/src/game/client/components/mapimages.cpp
+++ b/src/game/client/components/mapimages.cpp
@@ -15,10 +15,6 @@
 #include <game/localization.h>
 #include <game/mapitems.h>
 
-#include <chrono>
-
-using namespace std::chrono_literals;
-
 const char *const gs_apModEntitiesNames[] = {
 	"ddnet",
 	"ddrace",
@@ -146,7 +142,7 @@ void CMapImages::OnMapLoadImpl(class CLayers *pLayers, IMap *pMap)
 	}
 	if(ShowWarning)
 	{
-		m_pClient->m_Menus.PopupWarning(Localize("Warning"), Localize("Some map images could not be loaded. Check the local console for details."), Localize("Ok"), 10s);
+		Client()->AddWarning(SWarning(Localize("Some map images could not be loaded. Check the local console for details.")));
 	}
 }
 

--- a/src/game/client/components/mapsounds.cpp
+++ b/src/game/client/components/mapsounds.cpp
@@ -12,10 +12,6 @@
 #include <game/localization.h>
 #include <game/mapitems.h>
 
-#include <chrono>
-
-using namespace std::chrono_literals;
-
 CMapSounds::CMapSounds()
 {
 	m_Count = 0;
@@ -63,7 +59,7 @@ void CMapSounds::OnMapLoad()
 	}
 	if(ShowWarning)
 	{
-		m_pClient->m_Menus.PopupWarning(Localize("Warning"), Localize("Some map sounds could not be loaded. Check the local console for details."), Localize("Ok"), 10s);
+		Client()->AddWarning(SWarning(Localize("Some map sounds could not be loaded. Check the local console for details.")));
 	}
 
 	// enqueue sound sources

--- a/src/game/client/components/menus_start.cpp
+++ b/src/game/client/components/menus_start.cpp
@@ -17,10 +17,6 @@
 
 #include "menus.h"
 
-#include <chrono>
-
-using namespace std::chrono_literals;
-
 void CMenus::RenderStartMenu(CUIRect MainView)
 {
 	// render logo
@@ -84,7 +80,7 @@ void CMenus::RenderStartMenu(CUIRect MainView)
 		}
 		else
 		{
-			PopupWarning(Localize("Warning"), Localize("Can't find a Tutorial server"), Localize("Ok"), 10s);
+			Client()->AddWarning(SWarning(Localize("Can't find a Tutorial server")));
 			s_JoinTutorialTime = 0.0f;
 		}
 	}
@@ -160,7 +156,7 @@ void CMenus::RenderStartMenu(CUIRect MainView)
 			}
 			else
 			{
-				PopupWarning(Localize("Warning"), Localize("Server executable not found, can't run server"), Localize("Ok"), 10s);
+				Client()->AddWarning(SWarning(Localize("Server executable not found, can't run server")));
 			}
 		}
 	}


### PR DESCRIPTION
Using `CMenus::PopupWarning` will immediately set the popup and override the current warning, which can hide warnings when multiple are shown at the same time. Now all warnings are added to the queue with `IClient::AddWarning`.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
