### PR TITLE
Show AFK status in info tab

### DIFF
--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1093,10 +1093,16 @@ void CMenus::RenderServerbrowserInfoScoreboard(CUIRect View, const CServerInfo *
 			Color = ColorRGBA(1.0f, 1.0f, 1.0f, Alpha);
 			break;
 		case IFriends::FRIEND_PLAYER:
-			Color = ColorRGBA(0.5f, 1.0f, 0.5f, 0.15f + Alpha);
+			if(CurrentClient.m_Afk)
+				Color = ColorRGBA(1.0f, 1.0f, 0.5f, 0.15f + Alpha);
+			else
+				Color = ColorRGBA(0.5f, 1.0f, 0.5f, 0.15f + Alpha);
 			break;
 		case IFriends::FRIEND_CLAN:
-			Color = ColorRGBA(0.4f, 0.4f, 1.0f, 0.15f + Alpha);
+			if(CurrentClient.m_Afk)
+				Color = ColorRGBA(0.4f, 0.75f, 1.0f, 0.15f + Alpha);
+			else
+				Color = ColorRGBA(0.4f, 0.4f, 1.0f, 0.15f + Alpha);
 			break;
 		default:
 			dbg_assert(false, "Invalid friend state");
@@ -1159,7 +1165,7 @@ void CMenus::RenderServerbrowserInfoScoreboard(CUIRect View, const CServerInfo *
 			vec2 OffsetToMid;
 			RenderTools()->GetRenderTeeOffsetToRenderedTee(pIdleState, &TeeInfo, OffsetToMid);
 			const vec2 TeeRenderPos = vec2(Skin.x + TeeInfo.m_Size / 2.0f, Skin.y + Skin.h / 2.0f + OffsetToMid.y);
-			RenderTools()->RenderTee(pIdleState, &TeeInfo, EMOTE_NORMAL, vec2(1.0f, 0.0f), TeeRenderPos);
+			RenderTools()->RenderTee(pIdleState, &TeeInfo, CurrentClient.m_Afk ? EMOTE_BLINK : EMOTE_NORMAL, vec2(1.0f, 0.0f), TeeRenderPos);
 		}
 
 		// name


### PR DESCRIPTION
Friends/Clanmates in the info tab are now shown in their "afk" colours as well. While non-friends that are AFK are just shown with EMOTE_BLINK. Closes #7312

![image](https://github.com/ddnet/ddnet/assets/141338449/db7a552c-dcec-467f-a192-9205475f5871)

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
