### PR TITLE
Fix client not quitting after graphics assertion

### DIFF
--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -191,7 +191,7 @@ void dbg_assert_imp(const char *filename, int line, int test, const char *msg)
 	{
 		const bool already_failing = dbg_assert_has_failed();
 		dbg_assert_failing.store(true, std::memory_order_release);
-		char error[256];
+		char error[512];
 		str_format(error, sizeof(error), "%s(%d): %s", filename, line, msg);
 		dbg_msg("assert", "%s", error);
 		if(!already_failing)

--- a/src/engine/client/backend_sdl.h
+++ b/src/engine/client/backend_sdl.h
@@ -58,20 +58,10 @@ public:
 		virtual ~ICommandProcessor() = default;
 		virtual void RunBuffer(CCommandBuffer *pBuffer) = 0;
 
-		virtual SGFXErrorContainer &GetError() = 0;
+		virtual const SGFXErrorContainer &GetError() const = 0;
 		virtual void ErroneousCleanup() = 0;
 
-		virtual SGFXWarningContainer &GetWarning() = 0;
-
-		bool HasError()
-		{
-			return GetError().m_ErrorType != GFX_ERROR_TYPE_NONE;
-		}
-
-		bool HasWarning()
-		{
-			return GetWarning().m_WarningType != GFX_WARNING_TYPE_NONE;
-		}
+		virtual const SGFXWarningContainer &GetWarning() const = 0;
 	};
 
 	CGraphicsBackend_Threaded(TTranslateFunc &&TranslateFunc);
@@ -81,7 +71,7 @@ public:
 	bool IsIdle() const override;
 	void WaitForIdle() override;
 
-	void ProcessError();
+	void ProcessError(const SGFXErrorContainer &Error);
 
 protected:
 	void StartProcessor(ICommandProcessor *pProcessor);
@@ -199,10 +189,10 @@ public:
 	virtual ~CCommandProcessor_SDL_GL();
 	void RunBuffer(CCommandBuffer *pBuffer) override;
 
-	SGFXErrorContainer &GetError() override;
+	const SGFXErrorContainer &GetError() const override;
 	void ErroneousCleanup() override;
 
-	SGFXWarningContainer &GetWarning() override;
+	const SGFXWarningContainer &GetWarning() const override;
 
 	void HandleError();
 	void HandleWarning();


### PR DESCRIPTION
After the error message popup is shown for graphics assertions, the client window was destroyed but the process was not terminated properly. Now the graphics assertion error is handled like a normal assertion error, as those are also shown in an error message popup and correctly cause the client to break into the debugger or terminate.

However, calling `dbg_assert` while already owning the lock that `WaitForIdle` waits on will cause a deadlock, so error handling must be delayed until after the lock is released.

The buffer size for assertion messages is increased, as it was not sufficient for some graphics assertions.

The `ICommandProcessor::GetError` and `ICommandProcessor::GetWarning` functions are marked as `const`.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
