### PR TITLE
Save unknown commands from `settings_ddnet.cfg`

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -4251,6 +4251,13 @@ static bool UnknownArgumentCallback(const char *pCommand, void *pUser)
 	return false;
 }
 
+static bool SaveUnknownCommandCallback(const char *pCommand, void *pUser)
+{
+	CClient *pClient = static_cast<CClient *>(pUser);
+	pClient->ConfigManager()->StoreUnknownCommand(pCommand);
+	return true;
+}
+
 /*
 	Server Time
 	Client Mirror Time
@@ -4478,6 +4485,7 @@ int main(int argc, const char **argv)
 	// execute config file
 	if(pStorage->FileExists(CONFIG_FILE, IStorage::TYPE_ALL))
 	{
+		pConsole->SetUnknownCommandCallback(SaveUnknownCommandCallback, pClient);
 		if(!pConsole->ExecuteFile(CONFIG_FILE))
 		{
 			const char *pError = "Failed to load config from '" CONFIG_FILE "'.";
@@ -4486,6 +4494,7 @@ int main(int argc, const char **argv)
 			PerformAllCleanup();
 			return -1;
 		}
+		pConsole->SetUnknownCommandCallback(IConsole::EmptyUnknownCommandCallback, nullptr);
 	}
 
 	// execute autoexec file

--- a/src/engine/config.h
+++ b/src/engine/config.h
@@ -20,6 +20,8 @@ public:
 	virtual void RegisterCallback(SAVECALLBACKFUNC pfnFunc, void *pUserData) = 0;
 
 	virtual void WriteLine(const char *pLine) = 0;
+
+	virtual void StoreUnknownCommand(const char *pCommand) = 0;
 };
 
 extern IConfigManager *CreateConfigManager();

--- a/src/engine/shared/config.cpp
+++ b/src/engine/shared/config.cpp
@@ -110,6 +110,11 @@ bool CConfigManager::Save()
 	for(int i = 0; i < m_NumCallbacks; i++)
 		m_aCallbacks[i].m_pfnFunc(this, m_aCallbacks[i].m_pUserData);
 
+	for(const auto &Command : m_vUnknownCommands)
+	{
+		WriteLine(Command.c_str());
+	}
+
 	if(io_sync(m_ConfigFile) != 0)
 	{
 		m_Failed = true;
@@ -151,6 +156,11 @@ void CConfigManager::WriteLine(const char *pLine)
 	{
 		m_Failed = true;
 	}
+}
+
+void CConfigManager::StoreUnknownCommand(const char *pCommand)
+{
+	m_vUnknownCommands.emplace_back(pCommand);
 }
 
 IConfigManager *CreateConfigManager() { return new CConfigManager; }

--- a/src/engine/shared/config.h
+++ b/src/engine/shared/config.h
@@ -6,6 +6,9 @@
 #include <base/detect.h>
 #include <engine/config.h>
 
+#include <string>
+#include <vector>
+
 // include protocol for MAX_CLIENT used in config_variables
 #include <engine/shared/protocol.h>
 
@@ -72,6 +75,8 @@ class CConfigManager : public IConfigManager
 	CCallback m_aCallbacks[MAX_CALLBACKS];
 	int m_NumCallbacks;
 
+	std::vector<std::string> m_vUnknownCommands;
+
 public:
 	CConfigManager();
 
@@ -84,6 +89,8 @@ public:
 	void RegisterCallback(SAVECALLBACKFUNC pfnFunc, void *pUserData) override;
 
 	void WriteLine(const char *pLine) override;
+
+	void StoreUnknownCommand(const char *pCommand) override;
 };
 
 #endif


### PR DESCRIPTION
This fixes `Allow client to still save settings that it doesn't know about.` from #6660. Previously if you were to use a different client such as Tater-Client which shares the same config file as DDNet, the settings used from Tater-Client would be lost if you were to launch up DDNet again.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
