### PR TITLE
Fix editor crash when showing explanation for custom entities

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -2549,7 +2549,7 @@ void CEditor::DoMapEditor(CUIRect View)
 				else
 					Layer = NUM_LAYERS;
 
-				EExplanation Explanation = EExplanation::DDNET;
+				EExplanation Explanation;
 				if(m_SelectEntitiesImage == "DDNet")
 					Explanation = EExplanation::DDNET;
 				else if(m_SelectEntitiesImage == "FNG")
@@ -2561,7 +2561,7 @@ void CEditor::DoMapEditor(CUIRect View)
 				else if(m_SelectEntitiesImage == "blockworlds")
 					Explanation = EExplanation::BLOCKWORLDS;
 				else
-					dbg_assert(false, "Unhandled entities image for explanations");
+					Explanation = EExplanation::NONE;
 
 				if(Layer != NUM_LAYERS)
 				{

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -951,6 +951,7 @@ public:
 	// Explanations
 	enum class EExplanation
 	{
+		NONE,
 		DDNET,
 		FNG,
 		RACE,

--- a/src/game/editor/explanations.cpp
+++ b/src/game/editor/explanations.cpp
@@ -670,6 +670,8 @@ const char *CEditor::Explain(EExplanation Explanation, int Tile, int Layer)
 {
 	switch(Explanation)
 	{
+	case EExplanation::NONE:
+		return nullptr;
 	case EExplanation::DDNET:
 		return ExplainDDNet(Tile, Layer);
 	case EExplanation::FNG:


### PR DESCRIPTION
The failing assertion is removed because users can add custom entities images besides the predefined ones.

Reported by Mr.Gh0s7 on Discord.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
