### PR TITLE
Fix inaccurate envelope point value rounding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2744,6 +2744,7 @@ if(GTEST_FOUND OR DOWNLOAD_GTEST)
     jsonwriter.cpp
     linereader.cpp
     mapbugs.cpp
+    math.cpp
     name_ban.cpp
     net.cpp
     netaddr.cpp

--- a/src/base/math.h
+++ b/src/base/math.h
@@ -66,7 +66,7 @@ constexpr int fxpscale = 1 << 10;
 // float to fixed
 constexpr inline int f2fx(float v)
 {
-	return (int)(v * fxpscale);
+	return round_to_int(v * fxpscale);
 }
 constexpr inline float fx2f(int v)
 {

--- a/src/test/math.cpp
+++ b/src/test/math.cpp
@@ -1,0 +1,14 @@
+#include "test.h"
+#include <gtest/gtest.h>
+
+#include <base/math.h>
+
+TEST(Math, FixedPointRoundtrip)
+{
+	for(int i = 0; i < 100000; ++i)
+	{
+		const float Number = i / 1000.0f;
+		EXPECT_NEAR(Number, fx2f(f2fx(Number)), 0.0005f);
+		EXPECT_EQ(i, f2fx(fx2f(i)));
+	}
+}


### PR DESCRIPTION
Round to nearest integer instead of truncating in `f2fx` to ensure correct round-trip with `fx2f`.

Add test to ensure correct round-trip with maximum `0.0005f` absolute error.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [X] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
