### PR TITLE
Do not scale envelopes on ctrl+s

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -6749,7 +6749,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 		static float s_MidpointY = 0.0f;
 		static std::vector<float> s_vInitialPositionsX;
 		static std::vector<float> s_vInitialPositionsY;
-		if(s_Operation == OP_NONE && Input()->KeyIsPressed(KEY_S) && !m_vSelectedEnvelopePoints.empty())
+		if(s_Operation == OP_NONE && Input()->KeyIsPressed(KEY_S) && !Input()->ModifierIsPressed() && !m_vSelectedEnvelopePoints.empty())
 		{
 			s_Operation = OP_SCALE;
 			s_ScaleFactorX = 1.0f;


### PR DESCRIPTION
When using ctrl+s to test the current envelope it should not activate the scale mode. This causes unexpected envelope changes on ctrl+s based envelope fine tuning testing.



Here a video of me showcasing the issue. I pressed ctrl+s to save the map and it started moving the envelope.

https://github.com/ddnet/ddnet/assets/20344300/0623b0ff-ae3f-4e6f-afbd-48db57ab9235



## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
