### PR TITLE
Update string when cutting demo to indicate file name

### DIFF
--- a/data/languages/arabic.txt
+++ b/data/languages/arabic.txt
@@ -689,8 +689,8 @@ Grabs
 Automatically take game over screenshot
 == ﺔﺷﺎﺸﻟﺍ ﺔﻄﻘﻟ ﻰﻠﻋ ﺍًﻴﺋﺎﻘﻠﺗ ﺔﺒﻌﻠﻟﺍ ﺬﺧﺃ
 
-Please use a different name
-== ﺮﺧﺃ ﻢﺳﺍ ﺭﺎﻴﺘﺧﺎﺑ ﻢﻗ ﺀﺎﺟﺭ
+Please use a different filename
+== 
 
 Gameplay
 == ﺐﻌﻠﻟﺍ

--- a/data/languages/belarusian.txt
+++ b/data/languages/belarusian.txt
@@ -795,8 +795,8 @@ Are you sure that you want to remove the player '%s' from your friends list?
 Are you sure that you want to remove the clan '%s' from your friends list?
 == Вы ўпэўненыя што хочаце выдаліць клан '%s' са спіса вашых сяброў?
 
-Please use a different name
-== Калі ласка, выкарыстайце іншае імя
+Please use a different filename
+== 
 
 File already exists, do you want to overwrite it?
 == Файл ужо існуе, ці вы хочаце перазапісаць яго?

--- a/data/languages/bosnian.txt
+++ b/data/languages/bosnian.txt
@@ -639,8 +639,8 @@ Update now
 Restart
 == Restart
 
-Please use a different name
-== Molimo izaberite drugo ime
+Please use a different filename
+== 
 
 Remove chat
 == Ukloni čat

--- a/data/languages/brazilian_portuguese.txt
+++ b/data/languages/brazilian_portuguese.txt
@@ -591,8 +591,8 @@ Sound volume
 Hue
 == Matiz
 
-Please use a different name
-== Por favor, use um nome diferente
+Please use a different filename
+== 
 
 Show others
 == Mostrar outros

--- a/data/languages/bulgarian.txt
+++ b/data/languages/bulgarian.txt
@@ -939,7 +939,7 @@ Remove chat
 Render cut to video
 == 
 
-Please use a different name
+Please use a different filename
 == 
 
 File already exists, do you want to overwrite it?

--- a/data/languages/catalan.txt
+++ b/data/languages/catalan.txt
@@ -593,8 +593,8 @@ Enable game sounds
 DDNet Client needs to be restarted to complete update!
 == El client DDNet necessita reiniciar-se per completar l'actualització!
 
-Please use a different name
-== Si us plau, fes servir un nom diferent
+Please use a different filename
+== 
 
 Show others
 == Mostrar altres

--- a/data/languages/chuvash.txt
+++ b/data/languages/chuvash.txt
@@ -942,7 +942,7 @@ Remove chat
 Render cut to video
 == 
 
-Please use a different name
+Please use a different filename
 == 
 
 File already exists, do you want to overwrite it?

--- a/data/languages/czech.txt
+++ b/data/languages/czech.txt
@@ -627,8 +627,8 @@ Update now
 Restart
 == Restartovat
 
-Please use a different name
-== Použijte jiné jméno
+Please use a different filename
+== 
 
 Remove chat
 == Odebrat chat

--- a/data/languages/danish.txt
+++ b/data/languages/danish.txt
@@ -652,8 +652,8 @@ Countries
 Types
 == Typer
 
-Please use a different name
-== Brug et andet navn
+Please use a different filename
+== 
 
 Remove chat
 == Fjern chat

--- a/data/languages/dutch.txt
+++ b/data/languages/dutch.txt
@@ -646,8 +646,8 @@ Update now
 Restart
 == Herstarten
 
-Please use a different name
-== Gebruik a.u.b. een andere naam
+Please use a different filename
+== 
 
 Remove chat
 == Verwijder chat

--- a/data/languages/esperanto.txt
+++ b/data/languages/esperanto.txt
@@ -279,8 +279,8 @@ Clan
 Add Friend
 == Aldoni amikon
 
-Please use a different name
-== Bonvolu uzi malsaman nomon
+Please use a different filename
+== 
 
 Remove chat
 == Malmontri la diskutejon

--- a/data/languages/finnish.txt
+++ b/data/languages/finnish.txt
@@ -684,8 +684,8 @@ Types
 Leak IP
 == Vuoda IP
 
-Please use a different name
-== Ole hyvä ja käytä toista nimeä
+Please use a different filename
+== 
 
 Remove chat
 == Poista chatti

--- a/data/languages/french.txt
+++ b/data/languages/french.txt
@@ -819,8 +819,8 @@ Show HUD
 DDNet %s is available:
 == DDNet %s est disponible:
 
-Please use a different name
-== Veuillez changer de pseudonyme
+Please use a different filename
+== 
 
 Search
 == Chercher

--- a/data/languages/galician.txt
+++ b/data/languages/galician.txt
@@ -634,8 +634,8 @@ Update now
 Restart
 == Reiniciar
 
-Please use a different name
-== Por favor usa un nome diferente
+Please use a different filename
+== 
 
 Remove chat
 == Eliminar chat

--- a/data/languages/german.txt
+++ b/data/languages/german.txt
@@ -733,8 +733,8 @@ Grabs
 Automatically take game over screenshot
 == Automatisches Bildschirmfoto am Spielende
 
-Please use a different name
-== Bitte anderen Namen wählen
+Please use a different filename
+== 
 
 Gameplay
 == Gameplay

--- a/data/languages/greek.txt
+++ b/data/languages/greek.txt
@@ -945,7 +945,7 @@ Remove chat
 Render cut to video
 == 
 
-Please use a different name
+Please use a different filename
 == 
 
 File already exists, do you want to overwrite it?

--- a/data/languages/hungarian.txt
+++ b/data/languages/hungarian.txt
@@ -576,8 +576,8 @@ Enable game sounds
 DDNet Client needs to be restarted to complete update!
 == Újra kell indítani a DDNet Klienst a frissítés befejezéséhez!
 
-Please use a different name
-== Kérlek, válassz másik nevet
+Please use a different filename
+== 
 
 Show others
 == Játékosok mutatása

--- a/data/languages/italian.txt
+++ b/data/languages/italian.txt
@@ -700,8 +700,8 @@ Countries
 Types
 == Tipi
 
-Please use a different name
-== Per favore usa un nome differente
+Please use a different filename
+== 
 
 Remove chat
 == Rimuovi chat

--- a/data/languages/japanese.txt
+++ b/data/languages/japanese.txt
@@ -660,8 +660,8 @@ Types
 Leak IP
 == IP を漏洩する
 
-Please use a different name
-== 別の名前をつけてください
+Please use a different filename
+== 
 
 Remove chat
 == チャット履歴を削除

--- a/data/languages/korean.txt
+++ b/data/languages/korean.txt
@@ -678,8 +678,8 @@ Types
 Leak IP
 == IP 노출하기
 
-Please use a different name
-== 다른 이름을 사용해 주십시오
+Please use a different filename
+== 
 
 Remove chat
 == 채팅 제거

--- a/data/languages/kyrgyz.txt
+++ b/data/languages/kyrgyz.txt
@@ -936,7 +936,7 @@ Remove chat
 Render cut to video
 == 
 
-Please use a different name
+Please use a different filename
 == 
 
 File already exists, do you want to overwrite it?

--- a/data/languages/norwegian.txt
+++ b/data/languages/norwegian.txt
@@ -635,8 +635,8 @@ Update now
 Restart
 == Restart
 
-Please use a different name
-== Vennligst velg et annet navn
+Please use a different filename
+== 
 
 Remove chat
 == Fjern chat

--- a/data/languages/persian.txt
+++ b/data/languages/persian.txt
@@ -489,8 +489,8 @@ Scoreboard
 Remove
 == ﻥﺩﺮﮐ کﺎﭘ
 
-Please use a different name
-== ﻦﮐ ﻩﺩﺎﻔﺘﺳﺍ ﺕﻭﺎﻔﺘﻣ ﻡﺎﻧ ﮏﯾ ﺯﺍ ﺎﻔﻄﻟ
+Please use a different filename
+== 
 
 Remove chat
 == ﺖﭼ ﻥﺩﺮﮐ کﺎﭘ

--- a/data/languages/polish.txt
+++ b/data/languages/polish.txt
@@ -763,8 +763,8 @@ Show clan above name plates
 Loading DDNet Client
 == Ładowanie klienta DDNet
 
-Please use a different name
-== Użyj innej nazwy
+Please use a different filename
+== 
 
 HUD
 == HUD

--- a/data/languages/portuguese.txt
+++ b/data/languages/portuguese.txt
@@ -590,8 +590,8 @@ Enable game sounds
 DDNet Client needs to be restarted to complete update!
 == O cliente DDNet precisa de ser reiniciado para completar a atualização!
 
-Please use a different name
-== Por favor usa um nome diferente
+Please use a different filename
+== 
 
 Show others
 == Mostrar os outros

--- a/data/languages/romanian.txt
+++ b/data/languages/romanian.txt
@@ -951,7 +951,7 @@ Remove chat
 Render cut to video
 == 
 
-Please use a different name
+Please use a different filename
 == 
 
 File already exists, do you want to overwrite it?

--- a/data/languages/russian.txt
+++ b/data/languages/russian.txt
@@ -613,8 +613,8 @@ Show other players' hook collision lines
 DDNet Client needs to be restarted to complete update!
 == Перезапустите DDNet Client для завершения обновления!
 
-Please use a different name
-== Пожалуйста, используйте другое имя
+Please use a different filename
+== 
 
 Show others
 == Показывать остальных

--- a/data/languages/serbian.txt
+++ b/data/languages/serbian.txt
@@ -664,8 +664,8 @@ Countries
 Types
 == Tipovi
 
-Please use a different name
-== Izaberite drugo ime
+Please use a different filename
+== 
 
 Remove chat
 == Ukloni dopisivanje

--- a/data/languages/serbian_cyrillic.txt
+++ b/data/languages/serbian_cyrillic.txt
@@ -663,8 +663,8 @@ Countries
 Types
 == Типови
 
-Please use a different name
-== Изаберите друго име
+Please use a different filename
+== 
 
 Remove chat
 == Уклони дописивање

--- a/data/languages/simplified_chinese.txt
+++ b/data/languages/simplified_chinese.txt
@@ -749,8 +749,8 @@ DDNet
 Deaths
 == 死亡数
 
-Please use a different name
-== 请换一个不同的文件名
+Please use a different filename
+== 
 
 Restart
 == 重新开始

--- a/data/languages/slovak.txt
+++ b/data/languages/slovak.txt
@@ -942,7 +942,7 @@ Remove chat
 Render cut to video
 == 
 
-Please use a different name
+Please use a different filename
 == 
 
 File already exists, do you want to overwrite it?

--- a/data/languages/spanish.txt
+++ b/data/languages/spanish.txt
@@ -655,8 +655,8 @@ Update now
 Restart
 == Reiniciar
 
-Please use a different name
-== Por favor usa un nombre diferente
+Please use a different filename
+== 
 
 Remove chat
 == Eliminar chat

--- a/data/languages/swedish.txt
+++ b/data/languages/swedish.txt
@@ -888,8 +888,8 @@ Length
 Skin prefix
 == Skin prefix
 
-Please use a different name
-== Använd ett annat namn
+Please use a different filename
+== 
 
 Game paused
 == Spel pausad

--- a/data/languages/traditional_chinese.txt
+++ b/data/languages/traditional_chinese.txt
@@ -738,8 +738,8 @@ DDNet
 Deaths
 == 死亡數
 
-Please use a different name
-== 請換一個不同的檔名
+Please use a different filename
+== 
 
 Restart
 == 重新開始

--- a/data/languages/turkish.txt
+++ b/data/languages/turkish.txt
@@ -642,8 +642,8 @@ Update now
 Restart
 == Yeniden başlat
 
-Please use a different name
-== Lütfen farklı takma ad kullanın
+Please use a different filename
+== 
 
 Remove chat
 == Sohbeti kaldır

--- a/data/languages/ukrainian.txt
+++ b/data/languages/ukrainian.txt
@@ -570,8 +570,8 @@ Update now
 Restart
 == Перезавантажити
 
-Please use a different name
-== Будь ласка, використовуйте інше ім’я
+Please use a different filename
+== 
 
 Remove chat
 == Видалити чат

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -842,7 +842,7 @@ void CMenus::RenderDemoPlayerSliceSavePopup(CUIRect MainView)
 		{
 			static CUI::SMessagePopupContext s_MessagePopupContext;
 			s_MessagePopupContext.ErrorColor();
-			str_copy(s_MessagePopupContext.m_aMessage, Localize("Please use a different name"));
+			str_copy(s_MessagePopupContext.m_aMessage, Localize("Please use a different filename"));
 			UI()->ShowPopupMessage(UI()->MouseX(), OkButton.y + OkButton.h + 5.0f, &s_MessagePopupContext);
 		}
 		else


### PR DESCRIPTION
Default string when exporting cut demo is the original demo name, but the string only indicates "name" instead of filename which is misleading and is badly translated (at least in french version).

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
