### PR TITLE
Average FPS graph values to ensure constant graph scroll speed

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -3017,7 +3017,7 @@ void CClient::Run()
 			{
 				// update frametime
 				m_RenderFrameTime = (Now - m_LastRenderTime) / (float)time_freq();
-				m_FpsGraph.Add(1.0f / m_RenderFrameTime);
+				m_FpsGraph.AddAveraged(1.0f / m_RenderFrameTime, round_to_int(1.0f / m_FrameTimeAvg / 60.0f));
 
 				if(m_BenchmarkFile)
 				{

--- a/src/engine/client/graph.cpp
+++ b/src/engine/client/graph.cpp
@@ -13,6 +13,7 @@ void CGraph::Init(float Min, float Max)
 	m_Index = 0;
 	for(auto &Entry : m_aEntries)
 		Entry.m_Initialized = false;
+	m_StoredIndex = 0;
 }
 
 void CGraph::SetMin(float Min)
@@ -42,6 +43,23 @@ void CGraph::Add(float Value, ColorRGBA Color)
 {
 	InsertAt(m_Index, Value, Color);
 	m_Index = (m_Index + 1) % MAX_VALUES;
+}
+
+void CGraph::AddAveraged(float Value, size_t AveragedCount, ColorRGBA Color)
+{
+	AveragedCount = clamp<size_t>(AveragedCount, 1, std::size(m_aStoredValues));
+
+	m_aStoredValues[m_StoredIndex] = Value;
+	++m_StoredIndex;
+
+	if(m_StoredIndex >= AveragedCount)
+	{
+		float Average = 0.0f;
+		for(size_t i = 0; i < m_StoredIndex; ++i)
+			Average += m_aStoredValues[i];
+		Add(Average / m_StoredIndex, Color);
+		m_StoredIndex = 0;
+	}
 }
 
 void CGraph::InsertAt(size_t Index, float Value, ColorRGBA Color)

--- a/src/engine/client/graph.h
+++ b/src/engine/client/graph.h
@@ -31,6 +31,10 @@ private:
 	SEntry m_aEntries[MAX_VALUES];
 	size_t m_Index;
 
+	// For averaging
+	float m_aStoredValues[MAX_VALUES];
+	size_t m_StoredIndex;
+
 public:
 	void Init(float Min, float Max);
 	void SetMin(float Min);
@@ -38,6 +42,7 @@ public:
 
 	void Scale();
 	void Add(float Value, ColorRGBA Color = ColorRGBA(1.0f, 1.0f, 1.0f, 0.75f));
+	void AddAveraged(float Value, size_t AveragedCount, ColorRGBA Color = ColorRGBA(1.0f, 1.0f, 1.0f, 0.75f));
 	void InsertAt(size_t Index, float Value, ColorRGBA Color = ColorRGBA(1.0f, 1.0f, 1.0f, 0.75f));
 	void Render(IGraphics *pGraphics, ITextRender *pTextRender, float x, float y, float w, float h, const char *pDescription) const;
 };


### PR DESCRIPTION
Previously, the speed at which values in the FPS graph scrolled by was highly FPS dependent, as values get added every frame, causing the graph to scroll very fast with high FPS.

Now, the graph scroll speed at higher FPS is fixed so it always scrolls at roughly the speed that it would have at 60 FPS. For this purpose, the FPS values are accumulated and the average FPS values are added to the graph roughly 60 times per second.

Videos:
- Before:

https://github.com/ddnet/ddnet/assets/23437060/aa8b3a3e-811f-48fe-b15b-177eb2c7a179

- After:

https://github.com/ddnet/ddnet/assets/23437060/550293b1-94c1-4dd4-ac1f-0d0f59ceab20

## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
