### PR TITLE
Save entire character with `/lasttp`.

### DIFF
--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -1543,10 +1543,10 @@ void CGameContext::ConTele(IConsole::IResult *pResult, void *pUserData)
 			return;
 		Pos = pChrTo->m_Pos;
 	}
-	pPlayer->LastTelePos = Pos;
 	pSelf->Teleport(pChr, Pos);
 	pChr->UnFreeze();
 	pChr->Core()->m_Vel = vec2(0, 0);
+	pPlayer->m_LastTeleTee.Save(pChr);
 }
 
 void CGameContext::ConLastTele(IConsole::IResult *pResult, void *pUserData)
@@ -1568,14 +1568,13 @@ void CGameContext::ConLastTele(IConsole::IResult *pResult, void *pUserData)
 		pSelf->SendChatTarget(pPlayer->GetCID(), "You're not in a team with /practice turned on. Note that you can't earn a rank with practice enabled.");
 		return;
 	}
-	if(!pPlayer->LastTelePos.x)
+	if(!pPlayer->m_LastTeleTee.GetPos().x)
 	{
 		pSelf->SendChatTarget(pPlayer->GetCID(), "You haven't previously teleported. Use /tp before using this command.");
 		return;
 	}
-	pSelf->Teleport(pChr, pPlayer->LastTelePos);
-	pChr->UnFreeze();
-	pChr->Core()->m_Vel = vec2(0, 0);
+	pPlayer->m_LastTeleTee.Load(pChr, pChr->Team(), true);
+	pPlayer->Pause(CPlayer::PAUSE_NONE, true);
 }
 
 void CGameContext::ConPracticeUnSolo(IConsole::IResult *pResult, void *pUserData)

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -8,6 +8,7 @@
 #include <engine/shared/protocol.h>
 
 #include <game/alloc.h>
+#include <game/server/save.h>
 
 #include "teeinfo.h"
 
@@ -221,7 +222,7 @@ public:
 	int m_SwapTargetsClientID; //Client ID of the swap target for the given player
 	bool m_BirthdayAnnounced;
 
-	vec2 LastTelePos;
+	CSaveTee m_LastTeleTee;
 };
 
 #endif


### PR DESCRIPTION
Previously it only saved the position, it now saves the entire character and behaves more like `/rescue`. Closes #7441, Closes #7339.


https://github.com/ddnet/ddnet/assets/141338449/821cbe33-634b-43a3-9a21-e6fca0f9adc1



## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
