### PR TITLE
Fix server crash on DDTeam message with lower `sv_max_clients`

### DIFF
--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -522,7 +522,7 @@ void CGameContext::SendChatTarget(int To, const char *pText, int Flags)
 void CGameContext::SendChatTeam(int Team, const char *pText)
 {
 	for(int i = 0; i < MAX_CLIENTS; i++)
-		if(((CGameControllerDDRace *)m_pController)->m_Teams.m_Core.Team(i) == Team)
+		if(m_apPlayers[i] != nullptr && ((CGameControllerDDRace *)m_pController)->m_Teams.m_Core.Team(i) == Team)
 			SendChatTarget(i, pText);
 }
 


### PR DESCRIPTION
When the `CGameContext::SendChatTeam` function is used to send a chat message to all members of a DDTeam (e.g. on completed /swap chat command), it was not checked whether the target players are online but only whether they belong to the specified team according to the teams core. However, the default team for unconnected/cleared players is 0 in the teams core, which is the same for players in team 0, so chat messages were being sent to client IDs not corresponding to connected clients when chat messages where supposed to be sent to players in team 0. This was causing the server to crash with the assertion error "erroneous client id" specifically when the server is started with `sv_max_clients` being less than the default, maximum 64.

Closes #7450.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
