### PR TITLE
Use Escape to cancel OP_SCALE envelope

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -373,7 +373,7 @@ int CEditor::UiDoValueSelector(void *pID, CUIRect *pRect, const char *pLabel, in
 			s_TextMode = false;
 		}
 
-		if(Input()->KeyIsPressed(KEY_ESCAPE))
+		if(UI()->ConsumeHotkey(CUI::HOTKEY_ESCAPE))
 		{
 			UI()->DisableMouseLock();
 			UI()->SetActiveItem(nullptr);
@@ -6874,7 +6874,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 			{
 				s_Operation = OP_NONE;
 			}
-			else if(UI()->MouseButton(1))
+			else if(UI()->MouseButton(1) || UI()->ConsumeHotkey(CUI::HOTKEY_ESCAPE))
 			{
 				for(size_t k = 0; k < m_vSelectedEnvelopePoints.size(); k++)
 				{
@@ -7199,7 +7199,7 @@ void CEditor::RenderMenubar(CUIRect MenuBar)
 	UI()->DoLabel(&Info, aBuf, 10.0f, TEXTALIGN_MR);
 
 	static int s_CloseButton = 0;
-	if(DoButton_Editor(&s_CloseButton, "×", 0, &Close, 0, "Exits from the editor") || (m_Dialog == DIALOG_NONE && !UI()->IsPopupOpen() && !m_PopupEventActivated && Input()->KeyPress(KEY_ESCAPE)))
+	if(DoButton_Editor(&s_CloseButton, "×", 0, &Close, 0, "Exits from the editor"))
 	{
 		OnClose();
 		g_Config.m_ClEditor = 0;
@@ -7459,6 +7459,12 @@ void CEditor::Render()
 
 	UI()->RenderPopupMenus();
 	FreeDynamicPopupMenus();
+
+	if(m_Dialog == DIALOG_NONE && !m_PopupEventActivated && UI()->ConsumeHotkey(CUI::HOTKEY_ESCAPE))
+	{
+		OnClose();
+		g_Config.m_ClEditor = 0;
+	}
 
 	// The tooltip can be set in popup menus so we have to render the tooltip after the popup menus.
 	if(m_GuiActive)


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->
https://github.com/ddnet/ddnet/issues/7435

Now escape and right click should behave the same and fixes issue

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
