### PR TITLE
Correct usage of `demo_extract_chat` tool.

### DIFF
--- a/src/tools/demo_extract_chat.cpp
+++ b/src/tools/demo_extract_chat.cpp
@@ -237,7 +237,7 @@ int main(int argc, const char *argv[])
 
 	if(argc != 2)
 	{
-		dbg_msg(TOOL_NAME, "Usage: %s [demo_filename]", TOOL_NAME);
+		dbg_msg(TOOL_NAME, "Usage: %s <demo_filename>", TOOL_NAME);
 		return -1;
 	}
 


### PR DESCRIPTION
Changed `Usage: demo_extract_chat [demo_filename]` to `Usage: demo_extract_chat <demo_filename>`.

`[ ]` are used for optional arguments, but `demo_filename` is a required argument.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
