### PR TITLE
Update `m_FileDialogFileNameInput` when deleting a file

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -5003,6 +5003,7 @@ void CEditor::RenderFileDialog()
 				else
 					ShowFileDialogError("Failed to delete file '%s'.", aDeleteFilePath);
 			}
+			UpdateFileNameInput();
 		}
 		if(s_ConfirmDeletePopupContext.m_Result != CUI::SConfirmPopupContext::UNSET)
 			s_ConfirmDeletePopupContext.Reset();


### PR DESCRIPTION
After deleting a file `m_FileDialogFileNameInput` wasnt getting updated making it impossible to open the newly selected file.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
