### PR TITLE
Set size of text when changing slider of `cl_text_entities_size`.

### DIFF
--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -3085,7 +3085,13 @@ void CMenus::RenderSettingsDDNet(CUIRect MainView)
 		g_Config.m_ClTextEntities ^= 1;
 
 	if(g_Config.m_ClTextEntities)
+	{
+		int PreviousSize = g_Config.m_ClTextEntitiesSize;
 		UI()->DoScrollbarOption(&g_Config.m_ClTextEntitiesSize, &g_Config.m_ClTextEntitiesSize, &Button, Localize("Size"), 0, 100);
+
+		if(PreviousSize != g_Config.m_ClTextEntitiesSize)
+			m_pClient->m_MapImages.SetTextureScale(g_Config.m_ClTextEntitiesSize);
+	}
 
 	Left.HSplitTop(20.0f, &Button, &Left);
 	Button.VSplitMid(&LeftLeft, &Button);


### PR DESCRIPTION
It now updates the scaling of "text entities" when changing the size from settings. Previously it didn't nothing, and would only update when you restarted your game.

https://github.com/ddnet/ddnet/assets/141338449/8d841a76-e183-40dc-8408-7946cc0b3c9f



## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
