### PR TITLE
Fix parent folder not being shown in editor file browser, fix typo

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -5144,15 +5144,15 @@ void CEditor::InvokeFileDialog(int StorageType, int FileType, const char *pTitle
 	m_FileDialogStorageType = StorageType;
 	if(m_FileDialogStorageType == IStorage::TYPE_ALL)
 	{
-		int NumStoragedWithFolder = 0;
+		int NumStoragesWithFolder = 0;
 		for(int CheckStorageType = IStorage::TYPE_SAVE; CheckStorageType < Storage()->NumPaths(); ++CheckStorageType)
 		{
-			if(Storage()->FolderExists(m_pFileDialogPath, CheckStorageType))
+			if(Storage()->FolderExists(pBasePath, CheckStorageType))
 			{
-				NumStoragedWithFolder++;
+				NumStoragesWithFolder++;
 			}
 		}
-		m_FileDialogMultipleStorages = NumStoragedWithFolder > 1;
+		m_FileDialogMultipleStorages = NumStoragesWithFolder > 1;
 	}
 	else
 	{


### PR DESCRIPTION
The check for multiple storage locations was using the base path from the previous invocation of the file dialog instead of using the new base path.

Closes #7463.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
