### PR TITLE
Make KEY argument case-insensitive

### DIFF
--- a/src/game/client/components/binds.cpp
+++ b/src/game/client/components/binds.cpp
@@ -389,7 +389,7 @@ int CBinds::GetKeyID(const char *pKeyName)
 	// search for key
 	for(int i = 0; i < KEY_LAST; i++)
 	{
-		if(str_comp(pKeyName, Input()->KeyName(i)) == 0)
+		if(str_comp_nocase(pKeyName, Input()->KeyName(i)) == 0)
 			return i;
 	}
 
@@ -404,13 +404,13 @@ int CBinds::GetBindSlot(const char *pBindString, int *pModifierCombination)
 	const char *pKey = str_next_token(pBindString, "+", aMod, sizeof(aMod));
 	while(aMod[0] && *(pKey))
 	{
-		if(!str_comp(aMod, "shift"))
+		if(!str_comp_nocase(aMod, "shift"))
 			*pModifierCombination |= (1 << MODIFIER_SHIFT);
-		else if(!str_comp(aMod, "ctrl"))
+		else if(!str_comp_nocase(aMod, "ctrl"))
 			*pModifierCombination |= (1 << MODIFIER_CTRL);
-		else if(!str_comp(aMod, "alt"))
+		else if(!str_comp_nocase(aMod, "alt"))
 			*pModifierCombination |= (1 << MODIFIER_ALT);
-		else if(!str_comp(aMod, "gui"))
+		else if(!str_comp_nocase(aMod, "gui"))
 			*pModifierCombination |= (1 << MODIFIER_GUI);
 		else
 			return 0;


### PR DESCRIPTION
Previously, if you tried to use `bind` or `binds` with a key written in captial  letters. e.g. `bind A +left`, it would give `key A not found`. It's now treated as case-insensitive instead.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
