### PR TITLE
Save current chat input when pressing UP. Prevent input clearing when pressing DOWN

### DIFF
--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -120,6 +120,8 @@ void CChat::Reset()
 	m_LastChatSend = 0;
 	m_CurrentLine = 0;
 	m_IsInputCensored = false;
+	m_EditingNewLine = true;
+	mem_zero(m_aCurrentInputText, sizeof(m_aCurrentInputText));
 	DisableMode();
 
 	for(int64_t &LastSoundPlayed : m_aLastSoundPlayed)
@@ -426,6 +428,12 @@ bool CChat::OnInput(const IInput::CEvent &Event)
 
 	if(Event.m_Flags & IInput::FLAG_PRESS && Event.m_Key == KEY_UP)
 	{
+		if(m_EditingNewLine)
+		{
+			str_copy(m_aCurrentInputText, m_Input.GetString());
+			m_EditingNewLine = false;
+		}
+
 		if(m_pHistoryEntry)
 		{
 			CHistoryEntry *pTest = m_History.Prev(m_pHistoryEntry);
@@ -445,9 +453,14 @@ bool CChat::OnInput(const IInput::CEvent &Event)
 			m_pHistoryEntry = m_History.Next(m_pHistoryEntry);
 
 		if(m_pHistoryEntry)
+		{
 			m_Input.Set(m_pHistoryEntry->m_aText);
-		else
-			m_Input.Clear();
+		}
+		else if(!m_EditingNewLine)
+		{
+			m_Input.Set(m_aCurrentInputText);
+			m_EditingNewLine = true;
+		}
 	}
 
 	return true;

--- a/src/game/client/components/chat.h
+++ b/src/game/client/components/chat.h
@@ -123,6 +123,8 @@ class CChat : public CComponent
 	int64_t m_LastChatSend;
 	int64_t m_aLastSoundPlayed[CHAT_NUM];
 	bool m_IsInputCensored;
+	char m_aCurrentInputText[MAX_LINE_LENGTH];
+	bool m_EditingNewLine;
 
 	static void ConSay(IConsole::IResult *pResult, void *pUserData);
 	static void ConSayTeam(IConsole::IResult *pResult, void *pUserData);


### PR DESCRIPTION
Sometimes you can write a long message and accidentally press either UP or DOWN arrow and loose all the text you were writing. This PR fixes that issue by preventing the input to be cleared when pressing DOWN arrow and saving the current input when pressing the UP arrow.

<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
