### PR TITLE
Don't print "tunes"/unknown commands from maps.

### DIFF
--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -3369,6 +3369,11 @@ void CGameClient::RefindSkins()
 	m_KillMessages.RefindSkins();
 }
 
+static bool UnknownMapSettingCallback(const char *pCommand, void *pUser)
+{
+	return true;
+}
+
 void CGameClient::LoadMapSettings()
 {
 	// Reset Tunezones
@@ -3403,13 +3408,14 @@ void CGameClient::LoadMapSettings()
 		int Size = pMap->GetDataSize(pItem->m_Settings);
 		char *pSettings = (char *)pMap->GetData(pItem->m_Settings);
 		char *pNext = pSettings;
-		dbg_msg("tune", "%s", pNext);
+		Console()->SetUnknownCommandCallback(UnknownMapSettingCallback, nullptr);
 		while(pNext < pSettings + Size)
 		{
 			int StrSize = str_length(pNext) + 1;
 			Console()->ExecuteLine(pNext, IConsole::CLIENT_ID_GAME);
 			pNext += StrSize;
 		}
+		Console()->SetUnknownCommandCallback(IConsole::EmptyUnknownCommandCallback, nullptr);
 		pMap->UnloadData(pItem->m_Settings);
 		break;
 	}


### PR DESCRIPTION
The client tries to execute all commands from maps, but this usually leads to tons of spam in the local console. Commands that aren't found are now no longer printed, as well as the "tune" message. Closes #4144 ?

![image](https://github.com/ddnet/ddnet/assets/141338449/a52e8c87-c3ff-494b-a4bd-863e1fcdb342)


## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
