### PR TITLE
Add includes for ddnet mod configs

### DIFF
--- a/src/game/ddracechat.h
+++ b/src/game/ddracechat.h
@@ -6,6 +6,10 @@
 #define CHAT_COMMAND(name, params, flags, callback, userdata, help)
 #endif
 
+#if __has_include("ddracechat_mod.h")
+#include "ddracechat_mod.h"
+#endif
+
 CHAT_COMMAND("credits", "", CFGFLAG_CHAT | CFGFLAG_SERVER, ConCredits, this, "Shows the credits of the DDNet mod")
 CHAT_COMMAND("rules", "", CFGFLAG_CHAT | CFGFLAG_SERVER, ConRules, this, "Shows the server rules")
 CHAT_COMMAND("emote", "?s[emote name] i[duration in seconds]", CFGFLAG_CHAT | CFGFLAG_SERVER, ConEyeEmote, this, "Sets your tee's eye emote")

--- a/src/game/ddracecommands.h
+++ b/src/game/ddracecommands.h
@@ -6,6 +6,10 @@
 #define CONSOLE_COMMAND(name, params, flags, callback, userdata, help)
 #endif
 
+#if __has_include("ddracecommands_mod.h")
+#include "ddracecommands_mod.h"
+#endif
+
 CONSOLE_COMMAND("kill_pl", "v[id]", CFGFLAG_SERVER, ConKillPlayer, this, "Kills player v and announces the kill")
 CONSOLE_COMMAND("totele", "i[number]", CFGFLAG_SERVER | CMDFLAG_TEST, ConToTeleporter, this, "Teleports you to teleporter v")
 CONSOLE_COMMAND("totelecp", "i[number]", CFGFLAG_SERVER | CMDFLAG_TEST, ConToCheckTeleporter, this, "Teleports you to checkpoint teleporter v")

--- a/src/game/variables.h
+++ b/src/game/variables.h
@@ -11,6 +11,10 @@
 #define MACRO_CONFIG_STR(Name, ScriptName, Len, Def, Save, Desc) ;
 #endif
 
+#if __has_include("variables_mod.h")
+#include "variables_mod.h"
+#endif
+
 // client
 MACRO_CONFIG_INT(ClPredict, cl_predict, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Predict client movements")
 MACRO_CONFIG_INT(ClPredictDummy, cl_predict_dummy, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Predict dummy movements")


### PR DESCRIPTION
This allows ddnet forks to create the following files

src/game/ddracechat_mod.h
src/game/ddracecommands_mod.h
src/game/variables_mod.h

They will be loaded automatically and no git conflict surface is created.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
