### PR TITLE
Fix crash in mod controller

### DIFF
--- a/src/game/server/gamecontroller.cpp
+++ b/src/game/server/gamecontroller.cpp
@@ -731,8 +731,10 @@ int IGameController::ClampTeam(int Team)
 
 CClientMask IGameController::GetMaskForPlayerWorldEvent(int Asker, int ExceptID)
 {
-	// Send all world events to everyone by default
-	return CClientMask().set().reset(ExceptID);
+	if(Asker == -1)
+		return CClientMask().set().reset(ExceptID);
+
+	return Teams().TeamMask(GameServer()->GetDDRaceTeam(Asker), ExceptID, Asker);
 }
 
 void IGameController::InitTeleporter()

--- a/src/game/server/gamecontroller.h
+++ b/src/game/server/gamecontroller.h
@@ -146,7 +146,7 @@ public:
 	virtual bool CanJoinTeam(int Team, int NotThisID);
 	int ClampTeam(int Team);
 
-	virtual CClientMask GetMaskForPlayerWorldEvent(int Asker, int ExceptID = -1);
+	CClientMask GetMaskForPlayerWorldEvent(int Asker, int ExceptID = -1);
 	virtual void InitTeleporter();
 
 	// DDRace

--- a/src/game/server/gamemodes/DDRace.cpp
+++ b/src/game/server/gamemodes/DDRace.cpp
@@ -200,11 +200,3 @@ void CGameControllerDDRace::DoTeamChange(class CPlayer *pPlayer, int Team, bool 
 
 	IGameController::DoTeamChange(pPlayer, Team, DoChatMsg);
 }
-
-CClientMask CGameControllerDDRace::GetMaskForPlayerWorldEvent(int Asker, int ExceptID)
-{
-	if(Asker == -1)
-		return CClientMask().set().reset(ExceptID);
-
-	return Teams().TeamMask(GameServer()->GetDDRaceTeam(Asker), ExceptID, Asker);
-}

--- a/src/game/server/gamemodes/DDRace.h
+++ b/src/game/server/gamemodes/DDRace.h
@@ -24,8 +24,6 @@ public:
 
 	void DoTeamChange(class CPlayer *pPlayer, int Team, bool DoChatMsg = true) override;
 
-	CClientMask GetMaskForPlayerWorldEvent(int Asker, int ExceptID = -1) override;
-
 	std::shared_ptr<CScoreLoadBestTimeResult> m_pLoadBestTimeResult;
 };
 #endif // GAME_SERVER_GAMEMODES_DDRACE_H


### PR DESCRIPTION
When creating a non ddrace controller and it uses `IGameController::GetMaskForPlayerWorldEvent` it will crash:

```
 #0  0x00007ffff72ac83c in ?? () from /usr/lib/libc.so.6
 #1  0x00007ffff725c668 in raise () from /usr/lib/libc.so.6
 #2  0x00007ffff72444b8 in abort () from /usr/lib/libc.so.6
 #3  0x00007ffff749ca6f in __gnu_cxx::__verbose_terminate_handler () at /usr/src/debug/gcc/gcc/libstdc++-v3/libsupc++/vterminate.cc:95
 #4  0x00007ffff74b011c in __cxxabiv1::__terminate (handler=<optimized out>) at /usr/src/debug/gcc/gcc/libstdc++-v3/libsupc++/eh_terminate.cc:48
 #5  0x00007ffff74b0189 in std::terminate () at /usr/src/debug/gcc/gcc/libstdc++-v3/libsupc++/eh_terminate.cc:58
 #6  0x00007ffff74b03ed in __cxxabiv1::__cxa_throw (obj=<optimized out>, tinfo=0x7ffff766c0e8 <typeinfo for std::out_of_range>, dest=0x7ffff74c85c0 <std::out_of_range::~out_of_range()>) at /usr/src/debug/gcc/gcc/libstdc++-v3/libsupc++/eh_throw.cc:98
 #7  0x00007ffff74a025f in std::__throw_out_of_range_fmt (__fmt=<optimized out>) at /usr/src/debug/gcc/gcc/libstdc++-v3/src/c++11/functexcept.cc:101
 #8  0x00005555555bd4a3 in std::bitset<64ul>::_M_check (this=0x7fffffffbb90, __position=0xffffffffffffffff, __s=0x5555557a9881 "bitset::reset") at /usr/include/c++/13.2.1/bitset:823
 #9  0x00005555555f83e0 in std::bitset<64ul>::reset (this=0x7fffffffbb90, __position=0xffffffffffffffff) at /usr/include/c++/13.2.1/bitset:1196
 #10 0x000055555560262a in IGameController::GetMaskForPlayerWorldEvent (this=0x555555b113d0, Asker=0x0, ExceptID=0xffffffff) at /home/chiller/Desktop/git/ddnet/src/game/server/gamecontroller.cpp:728
 #11 0x000055555560be0f in CPlayer::TryRespawn (this=0x55555592e500 <gs_PoolDataCPlayer>) at /home/chiller/Desktop/git/ddnet/src/game/server/player.cpp:695
 #12 0x000055555560a1a6 in CPlayer::Tick (this=0x55555592e500 <gs_PoolDataCPlayer>) at /home/chiller/Desktop/git/ddnet/src/game/server/player.cpp:249
 #13 0x00005555555e174b in CGameContext::OnTick (this=0x7ffff477d010) at /home/chiller/Desktop/git/ddnet/src/game/server/gamecontext.cpp:964
 #14 0x00005555555a7e34 in CServer::Run (this=0x7ffff57d5010) at /home/chiller/Desktop/git/ddnet/src/engine/server/server.cpp:2893
 #15 0x0000555555592a2b in main (argc=0x1, argv=0x7fffffffd178) at /home/chiller/Desktop/git/ddnet/src/engine/server/main.cpp:197
```

Won't compile before https://github.com/ddnet/ddnet/pull/7464 is merged

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
