### PR TITLE
Fix leak of community icons when jobs not finished

### DIFF
--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -520,6 +520,7 @@ protected:
 		SHA256_DIGEST m_Sha256;
 
 		CAbstractCommunityIconJob(CMenus *pMenus, const char *pCommunityId, int StorageType);
+		virtual ~CAbstractCommunityIconJob();
 
 	public:
 		const char *CommunityId() const { return m_aCommunityId; }

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1799,6 +1799,12 @@ CMenus::CAbstractCommunityIconJob::CAbstractCommunityIconJob(CMenus *pMenus, con
 	str_format(m_aPath, sizeof(m_aPath), "communityicons/%s.png", pCommunityId);
 }
 
+CMenus::CAbstractCommunityIconJob::~CAbstractCommunityIconJob()
+{
+	free(m_ImageInfo.m_pData);
+	m_ImageInfo.m_pData = nullptr;
+}
+
 int CMenus::CCommunityIconDownloadJob::OnCompletion(int State)
 {
 	State = CHttpRequest::OnCompletion(State);


### PR DESCRIPTION
The community icon data loaded in background jobs was previously not freed when the client is quit before the community icon data is processed.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [X] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
