### PR TITLE
Fix `nullptr` access on `dbg_assert` with no global logger

### DIFF
--- a/src/base/log.cpp
+++ b/src/base/log.cpp
@@ -36,7 +36,9 @@ void log_set_global_logger(ILogger *logger)
 
 void log_global_logger_finish()
 {
-	global_logger.load(std::memory_order_acquire)->GlobalFinish();
+	ILogger *logger = global_logger.load(std::memory_order_acquire);
+	if(logger)
+		logger->GlobalFinish();
 }
 
 void log_set_global_logger_default()


### PR DESCRIPTION
Now it's also possible to use `dbg_assert` without/before having set a global logger.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
