### PR TITLE
Fix map grid factor always being shown as 1

### DIFF
--- a/src/game/editor/map_grid.cpp
+++ b/src/game/editor/map_grid.cpp
@@ -91,7 +91,7 @@ void CMapGrid::Toggle()
 	m_GridActive = !m_GridActive;
 }
 
-bool CMapGrid::Factor() const
+int CMapGrid::Factor() const
 {
 	return m_GridFactor;
 }

--- a/src/game/editor/map_grid.h
+++ b/src/game/editor/map_grid.h
@@ -19,7 +19,7 @@ public:
 
 	void Toggle();
 
-	bool Factor() const;
+	int Factor() const;
 	void ResetFactor();
 	void IncreaseFactor();
 	void DecreaseFactor();


### PR DESCRIPTION


## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
