### PR TITLE
Make gamecore.h not depend on console

### DIFF
--- a/src/game/gamecore.cpp
+++ b/src/game/gamecore.cpp
@@ -48,20 +48,6 @@ bool CTuningParams::Get(const char *pName, float *pValue) const
 	return false;
 }
 
-int CTuningParams::PossibleTunings(const char *pStr, IConsole::FPossibleCallback pfnCallback, void *pUser)
-{
-	int Index = 0;
-	for(int i = 0; i < Num(); i++)
-	{
-		if(str_find_nocase(Name(i), pStr))
-		{
-			pfnCallback(Index, Name(i), pUser);
-			Index++;
-		}
-	}
-	return Index;
-}
-
 float CTuningParams::GetWeaponFireDelay(int Weapon) const
 {
 	switch(Weapon)

--- a/src/game/gamecore.h
+++ b/src/game/gamecore.h
@@ -10,7 +10,6 @@
 #include <set>
 #include <vector>
 
-#include <engine/console.h>
 #include <engine/shared/protocol.h>
 #include <game/generated/protocol.h>
 
@@ -65,7 +64,6 @@ public:
 	bool Get(int Index, float *pValue) const;
 	bool Get(const char *pName, float *pValue) const;
 	static const char *Name(int Index) { return ms_apNames[Index]; }
-	int PossibleTunings(const char *pStr, IConsole::FPossibleCallback pfnCallback = IConsole::EmptyPossibleCommandCallback, void *pUser = nullptr);
 	float GetWeaponFireDelay(int Weapon) const;
 };
 


### PR DESCRIPTION
## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
