### PR TITLE
Fix dead lock when printing log entry while rendering console line

### DIFF
--- a/src/engine/shared/ringbuffer.cpp
+++ b/src/engine/shared/ringbuffer.cpp
@@ -46,9 +46,10 @@ CRingBufferBase::CItem *CRingBufferBase::MergeBack(CItem *pItem)
 
 void CRingBufferBase::Init(void *pMemory, int Size, int Flags)
 {
-	mem_zero(pMemory, Size);
 	m_Size = (Size) / sizeof(CItem) * sizeof(CItem);
 	m_pFirst = (CItem *)pMemory;
+	m_pFirst->m_pPrev = nullptr;
+	m_pFirst->m_pNext = nullptr;
 	m_pFirst->m_Free = 1;
 	m_pFirst->m_Size = m_Size;
 	m_pLast = m_pFirst;


### PR DESCRIPTION
Previously, the client would hang due to recursive usage of the console backlog lock when a log line is printed via the logger functions while already owning the backlog lock. This could happen when the text render causes log messages to be printed while the console backlog is rendered.

This is fixed by introducing a separate pending backlog to which new log lines are initially added and which is protected by a lock. The pending backlog entries are pumped into the normal backlog before the normal backlog is used, so accesses to the normal backlog do not need to be locked anymore. This means the console backlog lock is not owned when calling any functions that could print log messages, which should prevent the dead lock.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
