### PR TITLE
Add missing `<cstring>` include for `memset` to `system.h`

### DIFF
--- a/src/base/system.h
+++ b/src/base/system.h
@@ -18,6 +18,7 @@
 #include <cinttypes>
 #include <cstdarg>
 #include <cstdint>
+#include <cstring>
 #include <ctime>
 #include <functional>
 #include <mutex>


### PR DESCRIPTION
Fix compilation with MinGW due to `memset` call added to `system.h` in #6256.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
