### PR TITLE
Add 0.7 client broadcast feature

### DIFF
--- a/src/game/client/components/broadcast.h
+++ b/src/game/client/components/broadcast.h
@@ -10,13 +10,20 @@
 class CBroadcast : public CComponent
 {
 	// broadcasts
+	char m_aClientBroadcastText[1024];
 	char m_aBroadcastText[1024];
 	int m_BroadcastTick;
 	float m_BroadcastRenderOffset;
+	float m_ClientBroadcastRenderOffset;
+	float m_ClientBroadcastTime;
 	STextContainerIndex m_TextContainerIndex;
+	STextContainerIndex m_ClientTextContainerIndex;
 
 	void RenderServerBroadcast();
+	void RenderClientBroadcast();
 	void OnBroadcastMessage(const CNetMsg_Sv_Broadcast *pMsg);
+
+	static void ConClientBroadcast(IConsole::IResult *pResult, void *pUserData);
 
 public:
 	virtual int Sizeof() const override { return sizeof(*this); }
@@ -24,6 +31,9 @@ public:
 	virtual void OnWindowResize() override;
 	virtual void OnRender() override;
 	virtual void OnMessage(int MsgType, void *pRawMsg) override;
+	virtual void OnConsoleInit() override;
+
+	void DoClientBroadcast(const char *pText);
 };
 
 #endif


### PR DESCRIPTION
# Where is this coming from?

Robsti [suggested](https://github.com/ddnet/ddnet/pull/5949#discussion_r1398367155) this could be a separate pr. And I welcome every chance of getting pieces of https://github.com/ddnet/ddnet/pull/5949 merged and discussed separately. So this used to be part of the 0.7 client support pr and now is extracted into this one.

# What is a client broadcast?

0.7 moved the broadcast to the bottom of the screen. And at the 0.6 location there now sometimes are messages rendered by the client. Those are reactions to net messages from the server. The client rendering then unlocks the option to do translation. The messages in the 0.7 protocol are for example "All players were moved to the game" as you can see [here](https://github.com/teeworlds/teeworlds/blob/a1911c8f7d8458fb4076ef8e7651e8ef5e91ab3e/src/game/client/gameclient.cpp#L708-L715).

# Why 0.7 client broadcast in ddnet?

This comes in handy for the planned [0.7 client support](https://github.com/ddnet/ddnet/pull/5949) in ddnet to cover all new 0.7 features.

# How does this differ from the original teeworlds client broadcast?

In teeworlds 0.7 the broadcast is at the bottom so the client broadcast could take the server broadcasts place.

![07broadcast](https://github.com/ddnet/ddnet/assets/20344300/e98dd096-6e24-4539-954a-c5701599cb92)


This would not work for ddnet since I assume we do not want to move the server broadcast to the bottom. So I lifted the client broadcast above the server broadcast and colored it differently so no troll admins can imposter client broadcasts with the server broadcast.

![screenshot_2023-11-19_13-27-46](https://github.com/ddnet/ddnet/assets/20344300/7c6135db-ce69-40e5-bfc6-0d39c6e3308f)

It is high enough to display perfectly when the scoreboard is active (at least on my 16:9 resolution)


![screenshot_2023-11-19_13-27-55](https://github.com/ddnet/ddnet/assets/20344300/fe25b949-99dd-4269-9f35-970b33b857dc)

## Open questions and doubts from my side

- I can not believe I am saying this. But I do not think adding a local console command is a good idea. The client command ``client_broadcast`` was useful for testing the pr since otherwise this feature is not used. But in my opinion it should only be triggered by the server. The upstream also does not allow triggering it from the client side with a custom message. Just seems useless/misleading and confusing to me.
- Coloring and positioning. I am not an artist or good with colors. There might be a better way to display it.
- What about newlines? As of right now \n is rendered as literal \n. The upstream does not use a single message with linbreaks so it has no use case. Should be fine tho I think. If new lines are ever wanted they can be added. Since it is all client side only anyways there has to be no forward compatibility.
- Can this be merged without https://github.com/ddnet/ddnet/pull/5949 ? heinrich once expressed he does not want unused features on the master branch. So maybe in the meantime we can find a 0.6 use case for this like for example translation of server broadcasts that could help with https://github.com/ddnet/ddnet/issues/3091


## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
