### PR TITLE
Prevent community filters excluding all elements, fix server browser update on community filter change via console

### DIFF
--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -1233,11 +1233,17 @@ void CServerBrowser::LoadDDNetServers()
 	m_CommunityServersByAddr.clear();
 
 	if(!m_pDDNetInfo)
+	{
+		CleanFilters();
 		return;
+	}
 
 	const json_value &Communities = (*m_pDDNetInfo)["communities"];
 	if(Communities.type != json_array)
+	{
+		CleanFilters();
 		return;
+	}
 
 	for(unsigned CommunityIndex = 0; CommunityIndex < Communities.u.array.length; ++CommunityIndex)
 	{
@@ -1524,6 +1530,7 @@ bool CFilterList::Empty() const
 
 void CFilterList::Clean(const std::vector<const char *> &vpAllowedElements)
 {
+	size_t NumFiltered = 0;
 	char aNewList[512];
 	aNewList[0] = '\0';
 
@@ -1534,10 +1541,15 @@ void CFilterList::Clean(const std::vector<const char *> &vpAllowedElements)
 			if(aNewList[0] != '\0')
 				str_append(aNewList, ",");
 			str_append(aNewList, pElement);
+			++NumFiltered;
 		}
 	}
 
-	str_copy(m_pFilter, aNewList, m_FilterSize);
+	// Prevent filter that would exclude all allowed elements
+	if(NumFiltered == vpAllowedElements.size())
+		m_pFilter[0] = '\0';
+	else
+		str_copy(m_pFilter, aNewList, m_FilterSize);
 }
 
 void CServerBrowser::CleanFilters()

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -688,8 +688,6 @@ void CMenus::RenderServerbrowserFilters(CUIRect View)
 	// community filter
 	if((g_Config.m_UiPage == PAGE_INTERNET || g_Config.m_UiPage == PAGE_FAVORITES) && !ServerBrowser()->Communities().empty())
 	{
-		ServerBrowser()->CleanFilters();
-
 		CUIRect Row;
 		View.HSplitTop(6.0f, nullptr, &View);
 		View.HSplitTop(19.0f, &Row, &View);
@@ -1742,8 +1740,13 @@ void CMenus::ConchainFavoritesUpdate(IConsole::IResult *pResult, void *pUserData
 void CMenus::ConchainCommunitiesUpdate(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData)
 {
 	pfnCallback(pResult, pCallbackUserData);
+	CMenus *pThis = static_cast<CMenus *>(pUserData);
 	if(pResult->NumArguments() >= 1 && (g_Config.m_UiPage == PAGE_INTERNET || g_Config.m_UiPage == PAGE_FAVORITES))
-		((CMenus *)pUserData)->UpdateCommunityCache(true);
+	{
+		pThis->ServerBrowser()->CleanFilters();
+		pThis->UpdateCommunityCache(true);
+		pThis->Client()->ServerBrowserUpdate();
+	}
 }
 
 void CMenus::UpdateCommunityCache(bool Force)


### PR DESCRIPTION
Ensure that community/country/type filters do not exclude all allowed elements, which can happen when a previously selected community is not available anymore or when arbitrary community filter values are set with the console.

Also update server browser filtering/sorting when changing the community/country/type filter config variables with the console.

Clean the filter config variables when they are changed instead of only when the community filter is rendered.

Closes #7494.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
