### PR TITLE
Move `m_pLoadBestTimeResult` to `IGameController`

### DIFF
--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -953,7 +953,7 @@ void CGameContext::UnlockTeam(int ClientID, int Team)
 void CGameContext::ConInviteTeam(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	CGameControllerDDRace *pController = (CGameControllerDDRace *)pSelf->m_pController;
+	auto *pController = pSelf->m_pController;
 	const char *pName = pResult->GetString(0);
 
 	if(g_Config.m_SvTeam == SV_TEAM_FORBIDDEN || g_Config.m_SvTeam == SV_TEAM_FORCED_SOLO)
@@ -1017,7 +1017,7 @@ void CGameContext::ConInviteTeam(IConsole::IResult *pResult, void *pUserData)
 void CGameContext::ConJoinTeam(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	CGameControllerDDRace *pController = (CGameControllerDDRace *)pSelf->m_pController;
+	auto *pController = pSelf->m_pController;
 	if(!CheckClientID(pResult->m_ClientID))
 		return;
 

--- a/src/game/server/ddracecommands.cpp
+++ b/src/game/server/ddracecommands.cpp
@@ -774,7 +774,7 @@ void CGameContext::ConModerate(IConsole::IResult *pResult, void *pUserData)
 void CGameContext::ConSetDDRTeam(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	CGameControllerDDRace *pController = (CGameControllerDDRace *)pSelf->m_pController;
+	auto *pController = pSelf->m_pController;
 
 	if(g_Config.m_SvTeam == SV_TEAM_FORBIDDEN || g_Config.m_SvTeam == SV_TEAM_FORCED_SOLO)
 	{
@@ -800,7 +800,7 @@ void CGameContext::ConSetDDRTeam(IConsole::IResult *pResult, void *pUserData)
 void CGameContext::ConUninvite(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	CGameControllerDDRace *pController = (CGameControllerDDRace *)pSelf->m_pController;
+	auto *pController = pSelf->m_pController;
 
 	pController->Teams().SetClientInvited(pResult->GetInteger(1), pResult->GetVictim(), false);
 }

--- a/src/game/server/gamecontroller.cpp
+++ b/src/game/server/gamecontroller.cpp
@@ -4,6 +4,7 @@
 
 #include <game/generated/protocol.h>
 #include <game/mapitems.h>
+#include <game/server/score.h>
 #include <game/teamscore.h>
 
 #include "gamecontext.h"
@@ -19,7 +20,7 @@
 #include "entities/projectile.h"
 
 IGameController::IGameController(class CGameContext *pGameServer) :
-	m_Teams(pGameServer)
+	m_Teams(pGameServer), m_pLoadBestTimeResult(nullptr)
 {
 	m_pGameServer = pGameServer;
 	m_pConfig = m_pGameServer->Config();
@@ -535,6 +536,23 @@ void IGameController::Tick()
 			StartRound();
 			m_RoundCount++;
 		}
+	}
+
+	if(m_pLoadBestTimeResult != nullptr && m_pLoadBestTimeResult->m_Completed)
+	{
+		if(m_pLoadBestTimeResult->m_Success)
+		{
+			m_CurrentRecord = m_pLoadBestTimeResult->m_CurrentRecord;
+
+			for(int i = 0; i < MAX_CLIENTS; i++)
+			{
+				if(GameServer()->m_apPlayers[i] && GameServer()->m_apPlayers[i]->GetClientVersion() >= VERSION_DDRACE)
+				{
+					GameServer()->SendRecord(i);
+				}
+			}
+		}
+		m_pLoadBestTimeResult = nullptr;
 	}
 
 	DoActivityCheck();

--- a/src/game/server/gamecontroller.h
+++ b/src/game/server/gamecontroller.h
@@ -11,6 +11,8 @@
 #include <map>
 #include <vector>
 
+struct CScoreLoadBestTimeResult;
+
 /*
 	Class: Game Controller
 		Controls the main game logic. Keeping track of team and player score,
@@ -155,6 +157,7 @@ public:
 	std::map<int, std::vector<vec2>> m_TeleOuts;
 	std::map<int, std::vector<vec2>> m_TeleCheckOuts;
 	CGameTeams &Teams() { return m_Teams; }
+	std::shared_ptr<CScoreLoadBestTimeResult> m_pLoadBestTimeResult;
 };
 
 #endif

--- a/src/game/server/gamemodes/DDRace.cpp
+++ b/src/game/server/gamemodes/DDRace.cpp
@@ -15,7 +15,7 @@
 #define TEST_TYPE_NAME "TestDDraceNetwork"
 
 CGameControllerDDRace::CGameControllerDDRace(class CGameContext *pGameServer) :
-	IGameController(pGameServer), m_pLoadBestTimeResult(nullptr)
+	IGameController(pGameServer)
 {
 	m_pGameType = g_Config.m_SvTestingCommands ? TEST_TYPE_NAME : GAME_TYPE_NAME;
 }
@@ -159,23 +159,6 @@ void CGameControllerDDRace::Tick()
 	IGameController::Tick();
 	Teams().ProcessSaveTeam();
 	Teams().Tick();
-
-	if(m_pLoadBestTimeResult != nullptr && m_pLoadBestTimeResult->m_Completed)
-	{
-		if(m_pLoadBestTimeResult->m_Success)
-		{
-			m_CurrentRecord = m_pLoadBestTimeResult->m_CurrentRecord;
-
-			for(int i = 0; i < MAX_CLIENTS; i++)
-			{
-				if(GameServer()->m_apPlayers[i] && GameServer()->m_apPlayers[i]->GetClientVersion() >= VERSION_DDRACE)
-				{
-					GameServer()->SendRecord(i);
-				}
-			}
-		}
-		m_pLoadBestTimeResult = nullptr;
-	}
 }
 
 void CGameControllerDDRace::DoTeamChange(class CPlayer *pPlayer, int Team, bool DoChatMsg)

--- a/src/game/server/gamemodes/DDRace.h
+++ b/src/game/server/gamemodes/DDRace.h
@@ -4,7 +4,6 @@
 
 #include <game/server/gamecontroller.h>
 
-struct CScoreLoadBestTimeResult;
 class CGameControllerDDRace : public IGameController
 {
 public:
@@ -23,7 +22,5 @@ public:
 	void Tick() override;
 
 	void DoTeamChange(class CPlayer *pPlayer, int Team, bool DoChatMsg = true) override;
-
-	std::shared_ptr<CScoreLoadBestTimeResult> m_pLoadBestTimeResult;
 };
 #endif // GAME_SERVER_GAMEMODES_DDRACE_H

--- a/src/game/server/score.cpp
+++ b/src/game/server/score.cpp
@@ -110,11 +110,11 @@ CScore::CScore(CGameContext *pGameServer, CDbConnectionPool *pPool) :
 
 void CScore::LoadBestTime()
 {
-	if(((CGameControllerDDRace *)(m_pGameServer->m_pController))->m_pLoadBestTimeResult)
+	if(m_pGameServer->m_pController->m_pLoadBestTimeResult)
 		return; // already in progress
 
 	auto LoadBestTimeResult = std::make_shared<CScoreLoadBestTimeResult>();
-	((CGameControllerDDRace *)(m_pGameServer->m_pController))->m_pLoadBestTimeResult = LoadBestTimeResult;
+	m_pGameServer->m_pController->m_pLoadBestTimeResult = LoadBestTimeResult;
 
 	auto Tmp = std::make_unique<CSqlLoadBestTimeData>(LoadBestTimeResult);
 	str_copy(Tmp->m_aMap, g_Config.m_SvMap, sizeof(Tmp->m_aMap));
@@ -281,7 +281,7 @@ void CScore::SaveTeam(int ClientID, const char *pCode, const char *pServer)
 {
 	if(RateLimitPlayer(ClientID))
 		return;
-	auto *pController = ((CGameControllerDDRace *)(GameServer()->m_pController));
+	auto *pController = GameServer()->m_pController;
 	int Team = pController->Teams().m_Core.Team(ClientID);
 	if(pController->Teams().GetSaving(Team))
 		return;
@@ -326,7 +326,7 @@ void CScore::LoadTeam(const char *pCode, int ClientID)
 {
 	if(RateLimitPlayer(ClientID))
 		return;
-	auto *pController = ((CGameControllerDDRace *)(GameServer()->m_pController));
+	auto *pController = GameServer()->m_pController;
 	int Team = pController->Teams().m_Core.Team(ClientID);
 	if(pController->Teams().GetSaving(Team))
 		return;


### PR DESCRIPTION
Gets rid of more CGameControllerDDRace casts.
Those did not show up during compile time only during runtime of another active controller when asan is active.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
