### PR TITLE
Init vec2 members to 0 and small cleanup

### DIFF
--- a/src/game/client/components/camera.cpp
+++ b/src/game/client/components/camera.cpp
@@ -24,6 +24,10 @@ CCamera::CCamera()
 	m_GotoTeleOffset = 0;
 	m_GotoSwitchLastPos = ivec2(-1, -1);
 	m_GotoTeleLastPos = ivec2(-1, -1);
+
+	mem_zero(m_aLastPos, sizeof(m_aLastPos));
+	m_PrevCenter = vec2(0, 0);
+	m_Center = vec2(0, 0);
 }
 
 float CCamera::ZoomProgress(float CurrentTime) const

--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -20,6 +20,10 @@ CControls::CControls()
 	mem_zero(&m_aLastData, sizeof(m_aLastData));
 	m_LastDummy = 0;
 	m_OtherFire = 0;
+
+	mem_zero(m_aMousePos, sizeof(m_aMousePos));
+	mem_zero(m_aMousePosOnAction, sizeof(m_aMousePosOnAction));
+	mem_zero(m_aTargetPos, sizeof(m_aTargetPos));
 }
 
 void CControls::OnReset()

--- a/src/game/client/components/damageind.cpp
+++ b/src/game/client/components/damageind.cpp
@@ -40,7 +40,7 @@ void CDamageInd::Create(vec2 Pos, vec2 Dir, float Alpha)
 	{
 		pItem->m_Pos = Pos;
 		pItem->m_StartTime = LocalTime();
-		pItem->m_Dir = Dir * -1;
+		pItem->m_Dir = -Dir;
 		pItem->m_StartAngle = -random_angle();
 		pItem->m_Color = ColorRGBA(1.0f, 1.0f, 1.0f, Alpha);
 		pItem->m_StartAlpha = Alpha;

--- a/src/game/client/components/menu_background.cpp
+++ b/src/game/client/components/menu_background.cpp
@@ -54,6 +54,10 @@ std::array<vec2, CMenuBackground::NUM_POS> GenerateMenuBackgroundPositions()
 CMenuBackground::CMenuBackground() :
 	CBackground(CMapLayers::TYPE_FULL_DESIGN, false)
 {
+	m_RotationCenter = vec2(0.0f, 0.0f);
+	m_AnimationStartPos = vec2(0.0f, 0.0f);
+	m_Camera.m_Center = vec2(0.0f, 0.0f);
+	m_Camera.m_PrevCenter = vec2(0.0f, 0.0f); // unused in this class
 	m_ChangedPosition = false;
 
 	ResetPositions();

--- a/src/game/client/components/menu_background.h
+++ b/src/game/client/components/menu_background.h
@@ -81,7 +81,6 @@ public:
 
 	CBackgroundEngineMap *CreateBGMap() override;
 
-	vec2 m_MenuCenter;
 	vec2 m_RotationCenter;
 	std::array<vec2, NUM_POS> m_aPositions;
 	int m_CurrentPosition;

--- a/src/game/client/components/particles.h
+++ b/src/game/client/components/particles.h
@@ -10,6 +10,7 @@ struct CParticle
 {
 	void SetDefault()
 	{
+		m_Pos = vec2(0, 0);
 		m_Vel = vec2(0, 0);
 		m_LifeSpan = 0;
 		m_StartSize = 32;

--- a/src/game/client/components/spectator.cpp
+++ b/src/game/client/components/spectator.cpp
@@ -162,6 +162,7 @@ void CSpectator::ConMultiView(IConsole::IResult *pResult, void *pUserData)
 
 CSpectator::CSpectator()
 {
+	m_SelectorMouse = vec2(0.0f, 0.0f);
 	OnReset();
 	m_OldMouseX = m_OldMouseY = 0.0f;
 }

--- a/src/game/client/prediction/entities/laser.cpp
+++ b/src/game/client/prediction/entities/laser.cpp
@@ -20,7 +20,6 @@ CLaser::CLaser(CGameWorld *pGameWorld, vec2 Pos, vec2 Direction, float StartEner
 	m_Dir = Direction;
 	m_Bounces = 0;
 	m_EvalTick = 0;
-	m_WasTele = false;
 	m_Type = Type;
 	m_ZeroEnergyBounceInLastTick = false;
 	m_TuneZone = GameWorld()->m_WorldConfig.m_UseTuneZones ? Collision()->IsTune(Collision()->GetMapIndex(m_Pos)) : 0;
@@ -34,7 +33,7 @@ bool CLaser::HitCharacter(vec2 From, vec2 To)
 	vec2 At;
 	CCharacter *pOwnerChar = GameWorld()->GetCharacterByID(m_Owner);
 	CCharacter *pHit;
-	bool DontHitSelf = (g_Config.m_SvOldLaser || !GameWorld()->m_WorldConfig.m_IsDDRace) || (m_Bounces == 0 && !m_WasTele);
+	bool DontHitSelf = (g_Config.m_SvOldLaser || !GameWorld()->m_WorldConfig.m_IsDDRace) || (m_Bounces == 0);
 
 	if(pOwnerChar ? (!pOwnerChar->LaserHitDisabled() && m_Type == WEAPON_LASER) || (!pOwnerChar->ShotgunHitDisabled() && m_Type == WEAPON_SHOTGUN) : g_Config.m_SvHit)
 		pHit = GameWorld()->IntersectCharacter(m_Pos, To, 0.f, At, DontHitSelf ? pOwnerChar : 0, m_Owner);
@@ -102,13 +101,6 @@ void CLaser::DoBounce()
 	int Res;
 	int z;
 
-	if(m_WasTele)
-	{
-		m_PrevPos = m_TelePos;
-		m_Pos = m_TelePos;
-		m_TelePos = vec2(0, 0);
-	}
-
 	vec2 To = m_Pos + m_Dir * m_Energy;
 
 	Res = Collision()->IntersectLineTeleWeapon(m_Pos, To, &Coltile, &To, &z);
@@ -151,7 +143,6 @@ void CLaser::DoBounce()
 			m_ZeroEnergyBounceInLastTick = Distance == 0.0f;
 
 			m_Bounces++;
-			m_WasTele = false;
 
 			int BounceNum = GetTuning(m_TuneZone)->m_LaserBounceNum;
 

--- a/src/game/client/prediction/entities/laser.h
+++ b/src/game/client/prediction/entities/laser.h
@@ -30,8 +30,6 @@ protected:
 private:
 	vec2 m_From;
 	vec2 m_Dir;
-	vec2 m_TelePos;
-	bool m_WasTele;
 	float m_Energy;
 	int m_Bounces;
 	int m_EvalTick;

--- a/src/game/client/ui_scrollregion.cpp
+++ b/src/game/client/ui_scrollregion.cpp
@@ -22,6 +22,7 @@ CScrollRegion::CScrollRegion()
 	m_AnimInitScrollY = 0.0f;
 	m_AnimTargetScrollY = 0.0f;
 
+	m_SliderGrabPos = 0.0f;
 	m_ContentScrollOff = vec2(0.0f, 0.0f);
 	m_Params = CScrollRegionParams();
 }
@@ -146,8 +147,8 @@ void CScrollRegion::End()
 	if(UI()->CheckActiveItem(pID) && UI()->MouseButton(0))
 	{
 		float MouseY = UI()->MouseY();
-		m_ScrollY += (MouseY - (Slider.y + m_SliderGrabPos.y)) / MaxSlider * MaxScroll;
-		m_SliderGrabPos.y = clamp(m_SliderGrabPos.y, 0.0f, SliderHeight);
+		m_ScrollY += (MouseY - (Slider.y + m_SliderGrabPos)) / MaxSlider * MaxScroll;
+		m_SliderGrabPos = clamp(m_SliderGrabPos, 0.0f, SliderHeight);
 		m_AnimTargetScrollY = m_ScrollY;
 		m_AnimTime = 0.0f;
 		Grabbed = true;
@@ -159,7 +160,7 @@ void CScrollRegion::End()
 		if(!UI()->CheckActiveItem(pID) && UI()->MouseButtonClicked(0))
 		{
 			UI()->SetActiveItem(pID);
-			m_SliderGrabPos.y = UI()->MouseY() - Slider.y;
+			m_SliderGrabPos = UI()->MouseY() - Slider.y;
 			m_AnimTargetScrollY = m_ScrollY;
 			m_AnimTime = 0.0f;
 			m_Params.m_Active = true;
@@ -170,7 +171,7 @@ void CScrollRegion::End()
 		m_ScrollY += (UI()->MouseY() - (Slider.y + Slider.h / 2.0f)) / MaxSlider * MaxScroll;
 		UI()->SetHotItem(pID);
 		UI()->SetActiveItem(pID);
-		m_SliderGrabPos.y = Slider.h / 2.0f;
+		m_SliderGrabPos = Slider.h / 2.0f;
 		m_AnimTargetScrollY = m_ScrollY;
 		m_AnimTime = 0.0f;
 		m_Params.m_Active = true;

--- a/src/game/client/ui_scrollregion.h
+++ b/src/game/client/ui_scrollregion.h
@@ -117,7 +117,7 @@ private:
 	CUIRect m_ClipRect;
 	CUIRect m_RailRect;
 	CUIRect m_LastAddedRect; // saved for ScrollHere()
-	vec2 m_SliderGrabPos; // where did user grab the slider
+	float m_SliderGrabPos; // where did user grab the slider
 	vec2 m_ContentScrollOff;
 	CScrollRegionParams m_Params;
 

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -390,6 +390,7 @@ public:
 
 		m_QuadKnifeActive = false;
 		m_QuadKnifeCount = 0;
+		mem_zero(m_aQuadKnifePoints, sizeof(m_aQuadKnifePoints));
 
 		m_CheckerTexture.Invalidate();
 		m_BackgroundTexture.Invalidate();

--- a/src/game/gamecore.cpp
+++ b/src/game/gamecore.cpp
@@ -99,6 +99,7 @@ void CCharacterCore::Reset()
 	m_NewHook = false;
 	m_HookPos = vec2(0, 0);
 	m_HookDir = vec2(0, 0);
+	m_HookTeleBase = vec2(0, 0);
 	m_HookTick = 0;
 	m_HookState = HOOK_IDLE;
 	SetHookedPlayer(-1);

--- a/src/game/gamecore.h
+++ b/src/game/gamecore.h
@@ -284,7 +284,6 @@ public:
 	bool m_Reset;
 	CCollision *Collision() { return m_pCollision; }
 
-	vec2 m_LastVel;
 	int m_Colliding;
 	bool m_LeftWall;
 

--- a/src/game/server/entities/character.h
+++ b/src/game/server/entities/character.h
@@ -203,7 +203,6 @@ public:
 
 	int m_MoveRestrictions;
 
-	vec2 m_Intersection;
 	int64_t m_LastStartWarning;
 	int64_t m_LastRescue;
 	bool m_LastRefillJumps;

--- a/src/game/server/entities/dragger.cpp
+++ b/src/game/server/entities/dragger.cpp
@@ -16,6 +16,7 @@
 CDragger::CDragger(CGameWorld *pGameWorld, vec2 Pos, float Strength, bool IgnoreWalls, int Layer, int Number) :
 	CEntity(pGameWorld, CGameWorld::ENTTYPE_LASER)
 {
+	m_Core = vec2(0.0f, 0.0f);
 	m_Pos = Pos;
 	m_Strength = Strength;
 	m_IgnoreWalls = IgnoreWalls;

--- a/src/game/server/entities/gun.cpp
+++ b/src/game/server/entities/gun.cpp
@@ -16,6 +16,7 @@
 CGun::CGun(CGameWorld *pGameWorld, vec2 Pos, bool Freeze, bool Explosive, int Layer, int Number) :
 	CEntity(pGameWorld, CGameWorld::ENTTYPE_LASER)
 {
+	m_Core = vec2(0.0f, 0.0f);
 	m_Pos = Pos;
 	m_Freeze = Freeze;
 	m_Explosive = Explosive;

--- a/src/game/server/entities/laser.cpp
+++ b/src/game/server/entities/laser.cpp
@@ -20,6 +20,7 @@ CLaser::CLaser(CGameWorld *pGameWorld, vec2 Pos, vec2 Direction, float StartEner
 	m_Dir = Direction;
 	m_Bounces = 0;
 	m_EvalTick = 0;
+	m_TelePos = vec2(0, 0);
 	m_WasTele = false;
 	m_Type = Type;
 	m_TeleportCancelled = false;

--- a/src/game/server/entities/light.cpp
+++ b/src/game/server/entities/light.cpp
@@ -15,6 +15,8 @@ CLight::CLight(CGameWorld *pGameWorld, vec2 Pos, float Rotation, int Length,
 	int Layer, int Number) :
 	CEntity(pGameWorld, CGameWorld::ENTTYPE_LASER)
 {
+	m_To = vec2(0.0f, 0.0f);
+	m_Core = vec2(0.0f, 0.0f);
 	m_Layer = Layer;
 	m_Number = Number;
 	m_Tick = (Server()->TickSpeed() * 0.15f);

--- a/src/game/server/entities/pickup.cpp
+++ b/src/game/server/entities/pickup.cpp
@@ -15,6 +15,7 @@ static constexpr int gs_PickupPhysSize = 14;
 CPickup::CPickup(CGameWorld *pGameWorld, int Type, int SubType, int Layer, int Number) :
 	CEntity(pGameWorld, CGameWorld::ENTTYPE_PICKUP, vec2(0, 0), gs_PickupPhysSize)
 {
+	m_Core = vec2(0.0f, 0.0f);
 	m_Type = Type;
 	m_Subtype = SubType;
 

--- a/src/game/server/gameworld.cpp
+++ b/src/game/server/gameworld.cpp
@@ -349,7 +349,6 @@ std::vector<CCharacter *> CGameWorld::IntersectedCharacters(vec2 Pos0, vec2 Pos1
 			float Len = distance(pChr->m_Pos, IntersectPos);
 			if(Len < pChr->m_ProximityRadius + Radius)
 			{
-				pChr->m_Intersection = IntersectPos;
 				vpCharacters.push_back(pChr);
 			}
 		}


### PR DESCRIPTION
Due to #6256, vec2 members used in physics calculation are no longer initialized to 0. This PR fixes that.
Small cleanup to remove unused members (write only)

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
