### PR TITLE
Make prediction margin take effect instantanously

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -348,7 +348,7 @@ void CClient::SendInput()
 
 			m_aInputs[i][m_aCurrentInput[i]].m_Tick = m_aPredTick[g_Config.m_ClDummy];
 			m_aInputs[i][m_aCurrentInput[i]].m_PredictedTime = m_PredictedTime.Get(Now);
-			m_aInputs[i][m_aCurrentInput[i]].m_PredictionMargin = m_PredictedTime.GetMargin(Now);
+			m_aInputs[i][m_aCurrentInput[i]].m_PredictionMargin = PredictionMargin() * time_freq() / 1000;
 			m_aInputs[i][m_aCurrentInput[i]].m_Time = Now;
 
 			// pack it
@@ -1710,7 +1710,7 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket, int Conn, bool Dummy)
 				if(m_aInputs[Conn][k].m_Tick == InputPredTick)
 				{
 					Target = m_aInputs[Conn][k].m_PredictedTime + (Now - m_aInputs[Conn][k].m_Time);
-					Target = Target - (int64_t)((TimeLeft / 1000.0f) * time_freq()) + m_aInputs[Conn][k].m_PredictionMargin;
+					Target = Target - (int64_t)((TimeLeft / 1000.0f) * time_freq());
 					break;
 				}
 			}

--- a/src/engine/client/smooth_time.cpp
+++ b/src/engine/client/smooth_time.cpp
@@ -12,9 +12,7 @@ void CSmoothTime::Init(int64_t Target)
 	m_Snap = time_get();
 	m_Current = Target;
 	m_Target = Target;
-	m_SnapMargin = m_Snap;
-	m_CurrentMargin = 0;
-	m_TargetMargin = 0;
+	m_Margin = 0;
 	m_aAdjustSpeed[ADJUSTDIRECTION_DOWN] = 0.3f;
 	m_aAdjustSpeed[ADJUSTDIRECTION_UP] = 0.3f;
 }
@@ -41,15 +39,15 @@ int64_t CSmoothTime::Get(int64_t Now) const
 		a = 1.0f;
 
 	int64_t r = c + (int64_t)((t - c) * a);
-	return r + GetMargin(Now);
+	return r + m_Margin;
 }
 
 void CSmoothTime::UpdateInt(int64_t Target)
 {
 	int64_t Now = time_get();
-	m_Current = Get(Now) - GetMargin(Now);
+	m_Current = Get(Now) - m_Margin;
 	m_Snap = Now;
-	m_Target = Target - GetMargin(Now);
+	m_Target = Target;
 }
 
 void CSmoothTime::Update(CGraph *pGraph, int64_t Target, int TimeLeft, EAdjustDirection AdjustDirection)
@@ -97,20 +95,7 @@ void CSmoothTime::Update(CGraph *pGraph, int64_t Target, int TimeLeft, EAdjustDi
 		UpdateInt(Target);
 }
 
-int64_t CSmoothTime::GetMargin(int64_t Now) const
+void CSmoothTime::UpdateMargin(int64_t Margin)
 {
-	int64_t TimePassed = Now - m_SnapMargin;
-	int64_t Diff = m_TargetMargin - m_CurrentMargin;
-
-	float a = clamp(TimePassed / (float)time_freq(), -1.f, 1.f);
-	int64_t Lim = maximum((int64_t)(a * absolute(Diff)), 1 + TimePassed / 100);
-	return m_CurrentMargin + (int64_t)clamp(Diff, -Lim, Lim);
-}
-
-void CSmoothTime::UpdateMargin(int64_t TargetMargin)
-{
-	int64_t Now = time_get();
-	m_CurrentMargin = GetMargin(Now);
-	m_SnapMargin = Now;
-	m_TargetMargin = TargetMargin;
+	m_Margin = Margin;
 }

--- a/src/engine/client/smooth_time.h
+++ b/src/engine/client/smooth_time.h
@@ -22,10 +22,7 @@ private:
 	int64_t m_Snap;
 	int64_t m_Current;
 	int64_t m_Target;
-
-	int64_t m_SnapMargin;
-	int64_t m_CurrentMargin;
-	int64_t m_TargetMargin;
+	int64_t m_Margin;
 
 	int m_SpikeCounter;
 	float m_aAdjustSpeed[NUM_ADJUSTDIRECTIONS];
@@ -39,8 +36,7 @@ public:
 	void UpdateInt(int64_t Target);
 	void Update(CGraph *pGraph, int64_t Target, int TimeLeft, EAdjustDirection AdjustDirection);
 
-	int64_t GetMargin(int64_t Now) const;
-	void UpdateMargin(int64_t TargetMargin);
+	void UpdateMargin(int64_t Margin);
 };
 
 #endif


### PR DESCRIPTION
This also simplifies the code a bit, and further separates ping calculations from the the margin (e.g. so it does not count towards ping spikes calculated in CSmoothTime).

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
