### PR TITLE
Account for zoom when teleporting to cursor.

### DIFF
--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -1524,7 +1524,8 @@ void CGameContext::ConTele(IConsole::IResult *pResult, void *pUserData)
 	vec2 Pos = pPlayer->m_ViewPos;
 	if(pResult->NumArguments() == 0 && !pPlayer->IsPaused())
 	{
-		Pos = Pos + vec2(pChr->Core()->m_Input.m_TargetX, pChr->Core()->m_Input.m_TargetY);
+		vec2 ZoomScale = vec2(pPlayer->m_ShowDistance.x / 1400.0f, pPlayer->m_ShowDistance.y / 800.0f);
+		Pos = Pos + (vec2(pChr->Core()->m_Input.m_TargetX, pChr->Core()->m_Input.m_TargetY) * ZoomScale);
 	}
 	else if(pResult->NumArguments() > 0)
 	{

--- a/src/game/server/ddracecommands.cpp
+++ b/src/game/server/ddracecommands.cpp
@@ -409,8 +409,10 @@ void CGameContext::ConTeleport(IConsole::IResult *pResult, void *pUserData)
 	{
 		vec2 Pos = pSelf->m_apPlayers[TeleTo]->m_ViewPos;
 		if(!pPlayer->IsPaused() && !pResult->NumArguments())
-			Pos = Pos + vec2(pChr->Core()->m_Input.m_TargetX, pChr->Core()->m_Input.m_TargetY);
-
+		{
+			vec2 ZoomScale = vec2(pPlayer->m_ShowDistance.x / 1400.0f, pPlayer->m_ShowDistance.y / 800.0f);
+			Pos = Pos + (vec2(pChr->Core()->m_Input.m_TargetX, pChr->Core()->m_Input.m_TargetY) * ZoomScale);
+		}
 		pSelf->Teleport(pChr, Pos);
 		pChr->UnFreeze();
 		pChr->Core()->m_Vel = vec2(0, 0);


### PR DESCRIPTION
Previously teleporting to cursor wasn't accurate when not using zoom 10. Closes #7510.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
