### PR TITLE
Handle all color channel counts in image loader, refactoring

### DIFF
--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -2,6 +2,7 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 
 #include <base/detect.h>
+#include <base/log.h>
 #include <base/math.h>
 
 #if defined(CONF_FAMILY_UNIX)
@@ -583,6 +584,7 @@ bool CGraphics_Threaded::LoadPNG(CImageInfo *pImg, const char *pFilename, int St
 			else
 			{
 				free(pImgBuffer);
+				log_error("game/png", "image had unsupported image format. filename='%s' format='%d'", pFilename, (int)ImageFormat);
 				return false;
 			}
 
@@ -612,13 +614,13 @@ bool CGraphics_Threaded::LoadPNG(CImageInfo *pImg, const char *pFilename, int St
 		}
 		else
 		{
-			dbg_msg("game/png", "image had unsupported image format. filename='%s'", pFilename);
+			log_error("game/png", "failed to load file. filename='%s'", pFilename);
 			return false;
 		}
 	}
 	else
 	{
-		dbg_msg("game/png", "failed to open file. filename='%s'", pFilename);
+		log_error("game/png", "failed to open file. filename='%s'", pFilename);
 		return false;
 	}
 

--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -551,7 +551,7 @@ bool CGraphics_Threaded::UpdateTextTexture(CTextureHandle TextureID, int x, int 
 	return true;
 }
 
-int CGraphics_Threaded::LoadPNG(CImageInfo *pImg, const char *pFilename, int StorageType)
+bool CGraphics_Threaded::LoadPNG(CImageInfo *pImg, const char *pFilename, int StorageType)
 {
 	char aCompleteFilename[IO_MAX_PATH_LENGTH];
 	IOHANDLE File = m_pStorage->OpenFile(pFilename, IOFLAG_READ, StorageType, aCompleteFilename, sizeof(aCompleteFilename));
@@ -583,7 +583,7 @@ int CGraphics_Threaded::LoadPNG(CImageInfo *pImg, const char *pFilename, int Sto
 			else
 			{
 				free(pImgBuffer);
-				return 0;
+				return false;
 			}
 
 			if(m_WarnPngliteIncompatibleImages && PngliteIncompatible != 0)
@@ -613,16 +613,16 @@ int CGraphics_Threaded::LoadPNG(CImageInfo *pImg, const char *pFilename, int Sto
 		else
 		{
 			dbg_msg("game/png", "image had unsupported image format. filename='%s'", pFilename);
-			return 0;
+			return false;
 		}
 	}
 	else
 	{
 		dbg_msg("game/png", "failed to open file. filename='%s'", pFilename);
-		return 0;
+		return false;
 	}
 
-	return 1;
+	return true;
 }
 
 void CGraphics_Threaded::FreePNG(CImageInfo *pImg)

--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -576,9 +576,9 @@ int CGraphics_Threaded::LoadPNG(CImageInfo *pImg, const char *pFilename, int Sto
 		{
 			pImg->m_pData = pImgBuffer;
 
-			if(ImageFormat == IMAGE_FORMAT_RGB) // ignore_convention
+			if(ImageFormat == IMAGE_FORMAT_RGB)
 				pImg->m_Format = CImageInfo::FORMAT_RGB;
-			else if(ImageFormat == IMAGE_FORMAT_RGBA) // ignore_convention
+			else if(ImageFormat == IMAGE_FORMAT_RGBA)
 				pImg->m_Format = CImageInfo::FORMAT_RGBA;
 			else
 			{

--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -575,8 +575,6 @@ bool CGraphics_Threaded::LoadPNG(CImageInfo *pImg, const char *pFilename, int St
 		int PngliteIncompatible;
 		if(::LoadPNG(ImageByteBuffer, pFilename, PngliteIncompatible, pImg->m_Width, pImg->m_Height, pImgBuffer, ImageFormat))
 		{
-			pImg->m_pData = pImgBuffer;
-
 			if(ImageFormat == IMAGE_FORMAT_RGB)
 				pImg->m_Format = CImageInfo::FORMAT_RGB;
 			else if(ImageFormat == IMAGE_FORMAT_RGBA)
@@ -587,6 +585,7 @@ bool CGraphics_Threaded::LoadPNG(CImageInfo *pImg, const char *pFilename, int St
 				log_error("game/png", "image had unsupported image format. filename='%s' format='%d'", pFilename, (int)ImageFormat);
 				return false;
 			}
+			pImg->m_pData = pImgBuffer;
 
 			if(m_WarnPngliteIncompatibleImages && PngliteIncompatible != 0)
 			{

--- a/src/engine/client/graphics_threaded.h
+++ b/src/engine/client/graphics_threaded.h
@@ -965,7 +965,7 @@ public:
 
 	// simple uncompressed RGBA loaders
 	IGraphics::CTextureHandle LoadTexture(const char *pFilename, int StorageType, int Flags = 0) override;
-	int LoadPNG(CImageInfo *pImg, const char *pFilename, int StorageType) override;
+	bool LoadPNG(CImageInfo *pImg, const char *pFilename, int StorageType) override;
 	void FreePNG(CImageInfo *pImg) override;
 
 	bool CheckImageDivisibility(const char *pFileName, CImageInfo &Img, int DivX, int DivY, bool AllowResize) override;

--- a/src/engine/gfx/image_loader.cpp
+++ b/src/engine/gfx/image_loader.cpp
@@ -59,12 +59,15 @@ static EImageFormat LibPNGGetImageFormat(int ColorChannelCount)
 	{
 	case 1:
 		return IMAGE_FORMAT_R;
+	case 2:
+		return IMAGE_FORMAT_RA;
 	case 3:
 		return IMAGE_FORMAT_RGB;
 	case 4:
 		return IMAGE_FORMAT_RGBA;
 	default:
-		return IMAGE_FORMAT_RGBA;
+		dbg_assert(false, "ColorChannelCount invalid");
+		dbg_break();
 	}
 }
 
@@ -276,14 +279,20 @@ static void FlushPNGWrite(png_structp png_ptr) {}
 
 static int ImageLoaderHelperFormatToColorChannel(EImageFormat Format)
 {
-	if(Format == IMAGE_FORMAT_R)
+	switch(Format)
+	{
+	case IMAGE_FORMAT_R:
 		return 1;
-	else if(Format == IMAGE_FORMAT_RGB)
+	case IMAGE_FORMAT_RA:
+		return 2;
+	case IMAGE_FORMAT_RGB:
 		return 3;
-	else if(Format == IMAGE_FORMAT_RGBA)
+	case IMAGE_FORMAT_RGBA:
 		return 4;
-
-	return 4;
+	default:
+		dbg_assert(false, "Format invalid");
+		dbg_break();
+	}
 }
 
 bool SavePNG(EImageFormat ImageFormat, const uint8_t *pRawBuffer, SImageByteBuffer &WrittenBytes, int Width, int Height)

--- a/src/engine/gfx/image_loader.h
+++ b/src/engine/gfx/image_loader.h
@@ -8,6 +8,7 @@
 enum EImageFormat
 {
 	IMAGE_FORMAT_R = 0,
+	IMAGE_FORMAT_RA,
 	IMAGE_FORMAT_RGB,
 	IMAGE_FORMAT_RGBA,
 };

--- a/src/engine/graphics.h
+++ b/src/engine/graphics.h
@@ -320,7 +320,7 @@ public:
 
 	virtual const TTWGraphicsGPUList &GetGPUs() const = 0;
 
-	virtual int LoadPNG(CImageInfo *pImg, const char *pFilename, int StorageType) = 0;
+	virtual bool LoadPNG(CImageInfo *pImg, const char *pFilename, int StorageType) = 0;
 	virtual void FreePNG(CImageInfo *pImg) = 0;
 
 	virtual bool CheckImageDivisibility(const char *pFileName, CImageInfo &Img, int DivX, int DivY, bool AllowResize) = 0;

--- a/src/tools/map_replace_image.cpp
+++ b/src/tools/map_replace_image.cpp
@@ -48,9 +48,9 @@ int LoadPNG(CImageInfo *pImg, const char *pFilename)
 			{
 				pImg->m_pData = pImgBuffer;
 
-				if(ImageFormat == IMAGE_FORMAT_RGB) // ignore_convention
+				if(ImageFormat == IMAGE_FORMAT_RGB)
 					pImg->m_Format = CImageInfo::FORMAT_RGB;
-				else if(ImageFormat == IMAGE_FORMAT_RGBA) // ignore_convention
+				else if(ImageFormat == IMAGE_FORMAT_RGBA)
 					pImg->m_Format = CImageInfo::FORMAT_RGBA;
 				else
 				{

--- a/src/tools/map_replace_image.cpp
+++ b/src/tools/map_replace_image.cpp
@@ -23,7 +23,7 @@ int g_NewDataID = -1;
 int g_NewDataSize = 0;
 void *g_pNewData = nullptr;
 
-int LoadPNG(CImageInfo *pImg, const char *pFilename)
+bool LoadPNG(CImageInfo *pImg, const char *pFilename)
 {
 	IOHANDLE File = io_open(pFilename, IOFLAG_READ);
 	if(File)
@@ -55,16 +55,16 @@ int LoadPNG(CImageInfo *pImg, const char *pFilename)
 				else
 				{
 					free(pImgBuffer);
-					return 0;
+					return false;
 				}
 			}
 		}
 		else
-			return 0;
+			return false;
 	}
 	else
-		return 0;
-	return 1;
+		return false;
+	return true;
 }
 
 void *ReplaceImageItem(int Index, CMapItemImage *pImgItem, const char *pImgName, const char *pImgFile, CMapItemImage *pNewImgItem)


### PR DESCRIPTION
Greyscale images with alpha channel (i.e. channel count = 2) were incorrectly handled as RGBA images, causing the client to crash when loading such images. Now the images can successfully be loaded with the image loader, but the client still only supports loading RGB and RGBA images like before.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
