### PR TITLE
Use `const char *` instead of `char const *` consistently

### DIFF
--- a/src/engine/server.h
+++ b/src/engine/server.h
@@ -205,8 +205,8 @@ public:
 	virtual void GetMapInfo(char *pMapName, int MapNameSize, int *pMapSize, SHA256_DIGEST *pSha256, int *pMapCrc) = 0;
 
 	virtual bool WouldClientNameChange(int ClientID, const char *pNameRequest) = 0;
-	virtual void SetClientName(int ClientID, char const *pName) = 0;
-	virtual void SetClientClan(int ClientID, char const *pClan) = 0;
+	virtual void SetClientName(int ClientID, const char *pName) = 0;
+	virtual void SetClientClan(int ClientID, const char *pClan) = 0;
 	virtual void SetClientCountry(int ClientID, int Country) = 0;
 	virtual void SetClientScore(int ClientID, std::optional<int> Score) = 0;
 	virtual void SetClientFlags(int ClientID, int Flags) = 0;
@@ -253,7 +253,7 @@ public:
 	virtual bool DnsblWhite(int ClientID) = 0;
 	virtual bool DnsblPending(int ClientID) = 0;
 	virtual bool DnsblBlack(int ClientID) = 0;
-	virtual const char *GetAnnouncementLine(char const *pFileName) = 0;
+	virtual const char *GetAnnouncementLine(const char *pFileName) = 0;
 	virtual bool ClientPrevIngame(int ClientID) = 0;
 	virtual const char *GetNetErrorString(int ClientID) = 0;
 	virtual void ResetNetErrorString(int ClientID) = 0;

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -3868,7 +3868,7 @@ void CServer::GetClientAddr(int ClientID, NETADDR *pAddr) const
 	}
 }
 
-const char *CServer::GetAnnouncementLine(char const *pFileName)
+const char *CServer::GetAnnouncementLine(const char *pFileName)
 {
 	if(str_comp(pFileName, m_aAnnouncementFile) != 0)
 	{

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -288,7 +288,7 @@ public:
 
 	bool WouldClientNameChange(int ClientID, const char *pNameRequest) override;
 	void SetClientName(int ClientID, const char *pName) override;
-	void SetClientClan(int ClientID, char const *pClan) override;
+	void SetClientClan(int ClientID, const char *pClan) override;
 	void SetClientCountry(int ClientID, int Country) override;
 	void SetClientScore(int ClientID, std::optional<int> Score) override;
 	void SetClientFlags(int ClientID, int Flags) override;
@@ -457,7 +457,7 @@ public:
 
 	void GetClientAddr(int ClientID, NETADDR *pAddr) const override;
 	int m_aPrevStates[MAX_CLIENTS];
-	const char *GetAnnouncementLine(char const *pFileName) override;
+	const char *GetAnnouncementLine(const char *pFileName) override;
 
 	int *GetIdMap(int ClientID) override;
 

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -439,7 +439,7 @@ public:
 		bool (*pfnFunc)(const char *pFilename, int StorageType, void *pUser), void *pUser);
 	struct SStringKeyComparator
 	{
-		bool operator()(char const *pLhs, char const *pRhs) const
+		bool operator()(const char *pLhs, const char *pRhs) const
 		{
 			return str_comp(pLhs, pRhs) < 0;
 		}

--- a/src/test/score.cpp
+++ b/src/test/score.cpp
@@ -19,7 +19,7 @@ char *CSaveTeam::GetString()
 	return nullptr;
 }
 
-int CSaveTeam::FromString(char const *)
+int CSaveTeam::FromString(const char *)
 {
 	// Dummy implementation for testing
 	return 1;


### PR DESCRIPTION
Both are equivalent. Seems to already be used consistently for all other types.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
