### PR TITLE
Add `/mode` allowing teams to behave like team 0

### DIFF
--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -635,6 +635,15 @@ void CGameContext::ConPractice(IConsole::IResult *pResult, void *pUserData)
 		return;
 	}
 
+	if(Teams.TeamMode(Team))
+	{
+		pSelf->Console()->Print(
+			IConsole::OUTPUT_LEVEL_STANDARD,
+			"chatresp",
+			"Practice mode can't be enabled in team 0 mode.");
+		return;
+	}
+
 	if(Teams.IsPractice(Team))
 	{
 		pSelf->Console()->Print(
@@ -772,7 +781,7 @@ void CGameContext::ConSwap(IConsole::IResult *pResult, void *pUserData)
 	}
 
 	CPlayer *pSwapPlayer = pSelf->m_apPlayers[TargetClientId];
-	if(Team == TEAM_FLOCK && g_Config.m_SvTeam != 3)
+	if((Team == TEAM_FLOCK || Teams.TeamMode(Team)) && g_Config.m_SvTeam != 3)
 	{
 		CCharacter *pChr = pPlayer->GetCharacter();
 		CCharacter *pSwapChr = pSwapPlayer->GetCharacter();
@@ -782,7 +791,7 @@ void CGameContext::ConSwap(IConsole::IResult *pResult, void *pUserData)
 			return;
 		}
 	}
-	else if(!Teams.IsStarted(Team))
+	else if(!Teams.IsStarted(Team) && !Teams.TeamMode(Team))
 	{
 		pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "chatresp", "Need to have started the map to swap with a player.");
 		return;
@@ -926,7 +935,10 @@ void CGameContext::ConLock(IConsole::IResult *pResult, void *pUserData)
 	{
 		pSelf->m_pController->Teams().SetTeamLock(Team, true);
 
-		str_format(aBuf, sizeof(aBuf), "'%s' locked your team. After the race starts, killing will kill everyone in your team.", pSelf->Server()->ClientName(pResult->m_ClientId));
+		if(pSelf->m_pController->Teams().TeamMode(Team))
+			str_format(aBuf, sizeof(aBuf), "'%s' locked your team.", pSelf->Server()->ClientName(pResult->m_ClientId));
+		else
+			str_format(aBuf, sizeof(aBuf), "'%s' locked your team. After the race starts, killing will kill everyone in your team.", pSelf->Server()->ClientName(pResult->m_ClientId));
 		pSelf->SendChatTeam(Team, aBuf);
 	}
 }
@@ -1015,7 +1027,7 @@ void CGameContext::AttemptJoinTeam(int ClientId, int Team)
 					"This team is locked using /lock. Only members of the team can unlock it using /lock." :
 					"This team is locked using /lock. Only members of the team can invite you or unlock it using /lock.");
 		}
-		else if(Team > 0 && Team < MAX_CLIENTS && m_pController->Teams().Count(Team) >= g_Config.m_SvMaxTeamSize)
+		else if(Team > 0 && Team < MAX_CLIENTS && m_pController->Teams().Count(Team) >= g_Config.m_SvMaxTeamSize && !m_pController->Teams().TeamMode(Team))
 		{
 			char aBuf[512];
 			str_format(aBuf, sizeof(aBuf), "This team already has the maximum allowed size of %d players", g_Config.m_SvMaxTeamSize);
@@ -1036,6 +1048,9 @@ void CGameContext::AttemptJoinTeam(int ClientId, int Team)
 
 			if(m_pController->Teams().IsPractice(Team))
 				SendChatTarget(pPlayer->GetCid(), "Practice mode enabled for your team, happy practicing!");
+
+			if(m_pController->Teams().TeamMode(Team))
+				SendChatTarget(pPlayer->GetCid(), "Team 0 mode enabled for your team, happy team 0-ing!");
 		}
 	}
 }
@@ -1102,6 +1117,70 @@ void CGameContext::ConInvite(IConsole::IResult *pResult, void *pUserData)
 	}
 	else
 		pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "chatresp", "Can't invite players to this team");
+}
+
+void CGameContext::ConMode(IConsole::IResult *pResult, void *pUserData)
+{
+	CGameContext *pSelf = (CGameContext *)pUserData;
+	auto *pController = pSelf->m_pController;
+
+	if(!CheckClientId(pResult->m_ClientId))
+		return;
+
+	if(g_Config.m_SvTeam == SV_TEAM_FORBIDDEN || g_Config.m_SvTeam == SV_TEAM_FORCED_SOLO || g_Config.m_SvTeam == SV_TEAM_MANDATORY)
+	{
+		pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "chatresp",
+			"Team mode change disabled");
+		return;
+	}
+
+	int Team = pController->Teams().m_Core.Team(pResult->m_ClientId);
+	bool Mode = pController->Teams().TeamMode(Team);
+
+	if(Team <= TEAM_FLOCK || Team >= TEAM_SUPER)
+	{
+		pSelf->Console()->Print(
+			IConsole::OUTPUT_LEVEL_STANDARD,
+			"chatresp",
+			"This team can't have the mode changed");
+		return;
+	}
+
+	if(pController->Teams().GetTeamState(Team) != CGameTeams::TEAMSTATE_OPEN)
+	{
+		pSelf->SendChatTarget(pResult->m_ClientId, "Team mode can't be changed while racing");
+		return;
+	}
+
+	if(pResult->NumArguments() > 0)
+		Mode = !pResult->GetInteger(0);
+
+	if(pSelf->ProcessSpamProtection(pResult->m_ClientId, false))
+		return;
+
+	char aBuf[512];
+	if(Mode)
+	{
+		if(pController->Teams().Count(Team) > g_Config.m_SvMaxTeamSize)
+		{
+			str_format(aBuf, sizeof(aBuf), "Can't disable team 0 mode. This team exceeds the maximum allowed size of %d players for regular team", g_Config.m_SvMaxTeamSize);
+			pSelf->SendChatTarget(pResult->m_ClientId, aBuf);
+		}
+		else
+		{
+			pController->Teams().SetTeamMode(Team, false);
+
+			str_format(aBuf, sizeof(aBuf), "'%s' disabled team 0 mode.", pSelf->Server()->ClientName(pResult->m_ClientId));
+			pSelf->SendChatTeam(Team, aBuf);
+		}
+	}
+	else
+	{
+		pController->Teams().SetTeamMode(Team, true);
+
+		str_format(aBuf, sizeof(aBuf), "'%s' enabled team 0 mode.", pSelf->Server()->ClientName(pResult->m_ClientId));
+		pSelf->SendChatTeam(Team, aBuf);
+	}
 }
 
 void CGameContext::ConTeam(IConsole::IResult *pResult, void *pUserData)

--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -635,7 +635,7 @@ void CGameContext::ConPractice(IConsole::IResult *pResult, void *pUserData)
 		return;
 	}
 
-	if(Teams.TeamMode(Team))
+	if(Teams.TeamFlock(Team))
 	{
 		pSelf->Console()->Print(
 			IConsole::OUTPUT_LEVEL_STANDARD,
@@ -781,7 +781,7 @@ void CGameContext::ConSwap(IConsole::IResult *pResult, void *pUserData)
 	}
 
 	CPlayer *pSwapPlayer = pSelf->m_apPlayers[TargetClientId];
-	if((Team == TEAM_FLOCK || Teams.TeamMode(Team)) && g_Config.m_SvTeam != 3)
+	if((Team == TEAM_FLOCK || Teams.TeamFlock(Team)) && g_Config.m_SvTeam != 3)
 	{
 		CCharacter *pChr = pPlayer->GetCharacter();
 		CCharacter *pSwapChr = pSwapPlayer->GetCharacter();
@@ -791,7 +791,7 @@ void CGameContext::ConSwap(IConsole::IResult *pResult, void *pUserData)
 			return;
 		}
 	}
-	else if(!Teams.IsStarted(Team) && !Teams.TeamMode(Team))
+	else if(!Teams.IsStarted(Team) && !Teams.TeamFlock(Team))
 	{
 		pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "chatresp", "Need to have started the map to swap with a player.");
 		return;
@@ -935,7 +935,7 @@ void CGameContext::ConLock(IConsole::IResult *pResult, void *pUserData)
 	{
 		pSelf->m_pController->Teams().SetTeamLock(Team, true);
 
-		if(pSelf->m_pController->Teams().TeamMode(Team))
+		if(pSelf->m_pController->Teams().TeamFlock(Team))
 			str_format(aBuf, sizeof(aBuf), "'%s' locked your team.", pSelf->Server()->ClientName(pResult->m_ClientId));
 		else
 			str_format(aBuf, sizeof(aBuf), "'%s' locked your team. After the race starts, killing will kill everyone in your team.", pSelf->Server()->ClientName(pResult->m_ClientId));
@@ -1027,7 +1027,7 @@ void CGameContext::AttemptJoinTeam(int ClientId, int Team)
 					"This team is locked using /lock. Only members of the team can unlock it using /lock." :
 					"This team is locked using /lock. Only members of the team can invite you or unlock it using /lock.");
 		}
-		else if(Team > 0 && Team < MAX_CLIENTS && m_pController->Teams().Count(Team) >= g_Config.m_SvMaxTeamSize && !m_pController->Teams().TeamMode(Team))
+		else if(Team > 0 && Team < MAX_CLIENTS && m_pController->Teams().Count(Team) >= g_Config.m_SvMaxTeamSize && !m_pController->Teams().TeamFlock(Team))
 		{
 			char aBuf[512];
 			str_format(aBuf, sizeof(aBuf), "This team already has the maximum allowed size of %d players", g_Config.m_SvMaxTeamSize);
@@ -1049,7 +1049,7 @@ void CGameContext::AttemptJoinTeam(int ClientId, int Team)
 			if(m_pController->Teams().IsPractice(Team))
 				SendChatTarget(pPlayer->GetCid(), "Practice mode enabled for your team, happy practicing!");
 
-			if(m_pController->Teams().TeamMode(Team))
+			if(m_pController->Teams().TeamFlock(Team))
 				SendChatTarget(pPlayer->GetCid(), "Team 0 mode enabled for your team, happy team 0-ing!");
 		}
 	}
@@ -1119,7 +1119,7 @@ void CGameContext::ConInvite(IConsole::IResult *pResult, void *pUserData)
 		pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "chatresp", "Can't invite players to this team");
 }
 
-void CGameContext::ConMode(IConsole::IResult *pResult, void *pUserData)
+void CGameContext::ConFlock(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
 	auto *pController = pSelf->m_pController;
@@ -1135,7 +1135,7 @@ void CGameContext::ConMode(IConsole::IResult *pResult, void *pUserData)
 	}
 
 	int Team = pController->Teams().m_Core.Team(pResult->m_ClientId);
-	bool Mode = pController->Teams().TeamMode(Team);
+	bool Mode = pController->Teams().TeamFlock(Team);
 
 	if(Team <= TEAM_FLOCK || Team >= TEAM_SUPER)
 	{
@@ -1168,7 +1168,7 @@ void CGameContext::ConMode(IConsole::IResult *pResult, void *pUserData)
 		}
 		else
 		{
-			pController->Teams().SetTeamMode(Team, false);
+			pController->Teams().SetTeamFlock(Team, false);
 
 			str_format(aBuf, sizeof(aBuf), "'%s' disabled team 0 mode.", pSelf->Server()->ClientName(pResult->m_ClientId));
 			pSelf->SendChatTeam(Team, aBuf);
@@ -1176,7 +1176,7 @@ void CGameContext::ConMode(IConsole::IResult *pResult, void *pUserData)
 	}
 	else
 	{
-		pController->Teams().SetTeamMode(Team, true);
+		pController->Teams().SetTeamFlock(Team, true);
 
 		str_format(aBuf, sizeof(aBuf), "'%s' enabled team 0 mode.", pSelf->Server()->ClientName(pResult->m_ClientId));
 		pSelf->SendChatTeam(Team, aBuf);

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -942,7 +942,7 @@ void CCharacter::Die(int Killer, int Weapon, bool SendKillMsg)
 	GameServer()->Console()->Print(IConsole::OUTPUT_LEVEL_DEBUG, "game", aBuf);
 
 	// send the kill message
-	if(SendKillMsg && (Team() == TEAM_FLOCK || Teams()->TeamMode(Team()) || Teams()->Count(Team()) == 1 || Teams()->GetTeamState(Team()) == CGameTeams::TEAMSTATE_OPEN || Teams()->TeamLocked(Team()) == false))
+	if(SendKillMsg && (Team() == TEAM_FLOCK || Teams()->TeamFlock(Team()) || Teams()->Count(Team()) == 1 || Teams()->GetTeamState(Team()) == CGameTeams::TEAMSTATE_OPEN || Teams()->TeamLocked(Team()) == false))
 	{
 		CNetMsg_Sv_KillMsg Msg;
 		Msg.m_Killer = Killer;
@@ -1773,7 +1773,7 @@ void CCharacter::HandleTiles(int Index)
 
 		m_StartTime -= (min * 60 + sec) * Server()->TickSpeed();
 
-		if((g_Config.m_SvTeam == SV_TEAM_FORCED_SOLO || (Team != TEAM_FLOCK && !Teams()->TeamMode(Team))) && Team != TEAM_SUPER)
+		if((g_Config.m_SvTeam == SV_TEAM_FORCED_SOLO || (Team != TEAM_FLOCK && !Teams()->TeamFlock(Team))) && Team != TEAM_SUPER)
 		{
 			for(int i = 0; i < MAX_CLIENTS; i++)
 			{
@@ -1799,7 +1799,7 @@ void CCharacter::HandleTiles(int Index)
 		if(m_StartTime > Server()->Tick())
 			m_StartTime = Server()->Tick();
 
-		if((g_Config.m_SvTeam == SV_TEAM_FORCED_SOLO || (Team != TEAM_FLOCK && !Teams()->TeamMode(Team))) && Team != TEAM_SUPER)
+		if((g_Config.m_SvTeam == SV_TEAM_FORCED_SOLO || (Team != TEAM_FLOCK && !Teams()->TeamFlock(Team))) && Team != TEAM_SUPER)
 		{
 			for(int i = 0; i < MAX_CLIENTS; i++)
 			{

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -942,7 +942,7 @@ void CCharacter::Die(int Killer, int Weapon, bool SendKillMsg)
 	GameServer()->Console()->Print(IConsole::OUTPUT_LEVEL_DEBUG, "game", aBuf);
 
 	// send the kill message
-	if(SendKillMsg && (Team() == TEAM_FLOCK || Teams()->Count(Team()) == 1 || Teams()->GetTeamState(Team()) == CGameTeams::TEAMSTATE_OPEN || Teams()->TeamLocked(Team()) == false))
+	if(SendKillMsg && (Team() == TEAM_FLOCK || Teams()->TeamMode(Team()) || Teams()->Count(Team()) == 1 || Teams()->GetTeamState(Team()) == CGameTeams::TEAMSTATE_OPEN || Teams()->TeamLocked(Team()) == false))
 	{
 		CNetMsg_Sv_KillMsg Msg;
 		Msg.m_Killer = Killer;
@@ -1773,7 +1773,7 @@ void CCharacter::HandleTiles(int Index)
 
 		m_StartTime -= (min * 60 + sec) * Server()->TickSpeed();
 
-		if((g_Config.m_SvTeam == SV_TEAM_FORCED_SOLO || Team != TEAM_FLOCK) && Team != TEAM_SUPER)
+		if((g_Config.m_SvTeam == SV_TEAM_FORCED_SOLO || (Team != TEAM_FLOCK && !Teams()->TeamMode(Team))) && Team != TEAM_SUPER)
 		{
 			for(int i = 0; i < MAX_CLIENTS; i++)
 			{
@@ -1799,7 +1799,7 @@ void CCharacter::HandleTiles(int Index)
 		if(m_StartTime > Server()->Tick())
 			m_StartTime = Server()->Tick();
 
-		if((g_Config.m_SvTeam == SV_TEAM_FORCED_SOLO || Team != TEAM_FLOCK) && Team != TEAM_SUPER)
+		if((g_Config.m_SvTeam == SV_TEAM_FORCED_SOLO || (Team != TEAM_FLOCK && !Teams()->TeamMode(Team))) && Team != TEAM_SUPER)
 		{
 			for(int i = 0; i < MAX_CLIENTS; i++)
 			{

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -942,7 +942,7 @@ void CCharacter::Die(int Killer, int Weapon, bool SendKillMsg)
 	GameServer()->Console()->Print(IConsole::OUTPUT_LEVEL_DEBUG, "game", aBuf);
 
 	// send the kill message
-	if(SendKillMsg && (Team() == TEAM_FLOCK || Teams()->TeamFlock(Team()) || Teams()->Count(Team()) == 1 || Teams()->GetTeamState(Team()) == CGameTeams::TEAMSTATE_OPEN || Teams()->TeamLocked(Team()) == false))
+	if(SendKillMsg && (Team() == TEAM_FLOCK || Teams()->TeamFlock(Team()) || Teams()->Count(Team()) == 1 || Teams()->GetTeamState(Team()) == CGameTeams::TEAMSTATE_OPEN || !Teams()->TeamLocked(Team())))
 	{
 		CNetMsg_Sv_KillMsg Msg;
 		Msg.m_Killer = Killer;

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -444,6 +444,7 @@ private:
 	static void ConUnlock(IConsole::IResult *pResult, void *pUserData);
 	static void ConInvite(IConsole::IResult *pResult, void *pUserData);
 	static void ConJoin(IConsole::IResult *pResult, void *pUserData);
+	static void ConMode(IConsole::IResult *pResult, void *pUserData);
 	static void ConMe(IConsole::IResult *pResult, void *pUserData);
 	static void ConWhisper(IConsole::IResult *pResult, void *pUserData);
 	static void ConConverse(IConsole::IResult *pResult, void *pUserData);

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -445,6 +445,7 @@ private:
 	static void ConInvite(IConsole::IResult *pResult, void *pUserData);
 	static void ConJoin(IConsole::IResult *pResult, void *pUserData);
 	static void ConMode(IConsole::IResult *pResult, void *pUserData);
+	static void ConFlock(IConsole::IResult *pResult, void *pUserData);
 	static void ConMe(IConsole::IResult *pResult, void *pUserData);
 	static void ConWhisper(IConsole::IResult *pResult, void *pUserData);
 	static void ConConverse(IConsole::IResult *pResult, void *pUserData);

--- a/src/game/server/gamemodes/DDRace.cpp
+++ b/src/game/server/gamemodes/DDRace.cpp
@@ -67,7 +67,7 @@ void CGameControllerDDRace::HandleCharacterTiles(CCharacter *pChr, int MapIndex)
 			pChr->Die(ClientId, WEAPON_WORLD);
 			return;
 		}
-		if(g_Config.m_SvTeam != SV_TEAM_FORCED_SOLO && Team > TEAM_FLOCK && Team < TEAM_SUPER && Teams().Count(Team) < g_Config.m_SvMinTeamSize && !Teams().TeamMode(Team))
+		if(g_Config.m_SvTeam != SV_TEAM_FORCED_SOLO && Team > TEAM_FLOCK && Team < TEAM_SUPER && Teams().Count(Team) < g_Config.m_SvMinTeamSize && !Teams().TeamFlock(Team))
 		{
 			char aBuf[128];
 			str_format(aBuf, sizeof(aBuf), "Your team has fewer than %d players, so your team rank won't count", g_Config.m_SvMinTeamSize);

--- a/src/game/server/gamemodes/DDRace.cpp
+++ b/src/game/server/gamemodes/DDRace.cpp
@@ -67,7 +67,7 @@ void CGameControllerDDRace::HandleCharacterTiles(CCharacter *pChr, int MapIndex)
 			pChr->Die(ClientId, WEAPON_WORLD);
 			return;
 		}
-		if(g_Config.m_SvTeam != SV_TEAM_FORCED_SOLO && Team > TEAM_FLOCK && Team < TEAM_SUPER && Teams().Count(Team) < g_Config.m_SvMinTeamSize)
+		if(g_Config.m_SvTeam != SV_TEAM_FORCED_SOLO && Team > TEAM_FLOCK && Team < TEAM_SUPER && Teams().Count(Team) < g_Config.m_SvMinTeamSize && !Teams().TeamMode(Team))
 		{
 			char aBuf[128];
 			str_format(aBuf, sizeof(aBuf), "Your team has fewer than %d players, so your team rank won't count", g_Config.m_SvMinTeamSize);

--- a/src/game/server/save.cpp
+++ b/src/game/server/save.cpp
@@ -481,6 +481,11 @@ int CSaveTeam::Save(CGameContext *pGameServer, int Team, bool Dry)
 	IGameController *pController = pGameServer->m_pController;
 	CGameTeams *pTeams = &pController->Teams();
 
+	if(pTeams->TeamMode(Team))
+	{
+		return 5;
+	}
+
 	m_MembersCount = pTeams->Count(Team);
 	if(m_MembersCount <= 0)
 	{
@@ -553,6 +558,9 @@ bool CSaveTeam::HandleSaveError(int Result, int ClientId, CGameContext *pGameCon
 		break;
 	case 4:
 		pGameContext->SendChatTarget(ClientId, "Your team has not started yet");
+		break;
+	case 5:
+		pGameContext->SendChatTarget(ClientId, "Team can't be saved while in team 0 mode");
 		break;
 	default: // this state should never be reached
 		pGameContext->SendChatTarget(ClientId, "Unknown error while saving");

--- a/src/game/server/save.cpp
+++ b/src/game/server/save.cpp
@@ -481,7 +481,7 @@ int CSaveTeam::Save(CGameContext *pGameServer, int Team, bool Dry)
 	IGameController *pController = pGameServer->m_pController;
 	CGameTeams *pTeams = &pController->Teams();
 
-	if(pTeams->TeamMode(Team))
+	if(pTeams->TeamFlock(Team))
 	{
 		return 5;
 	}

--- a/src/game/server/score.cpp
+++ b/src/game/server/score.cpp
@@ -345,6 +345,11 @@ void CScore::LoadTeam(const char *pCode, int ClientId)
 		GameServer()->SendChatTarget(ClientId, "Team can't be loaded while racing");
 		return;
 	}
+	if(pController->Teams().TeamMode(Team))
+	{
+		GameServer()->SendChatTarget(ClientId, "Team can't be loaded while in team 0 mode");
+		return;
+	}
 	auto SaveResult = std::make_shared<CScoreSaveResult>(ClientId);
 	SaveResult->m_Status = CScoreSaveResult::LOAD_FAILED;
 	pController->Teams().SetSaving(Team, SaveResult);

--- a/src/game/server/score.cpp
+++ b/src/game/server/score.cpp
@@ -345,7 +345,7 @@ void CScore::LoadTeam(const char *pCode, int ClientId)
 		GameServer()->SendChatTarget(ClientId, "Team can't be loaded while racing");
 		return;
 	}
-	if(pController->Teams().TeamMode(Team))
+	if(pController->Teams().TeamFlock(Team))
 	{
 		GameServer()->SendChatTarget(ClientId, "Team can't be loaded while in team 0 mode");
 		return;

--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -32,7 +32,7 @@ void CGameTeams::Reset()
 	{
 		m_aTeamState[i] = TEAMSTATE_EMPTY;
 		m_aTeamLocked[i] = false;
-		m_aTeamMode[i] = false;
+		m_aTeamFlock[i] = false;
 		m_apSaveTeamResult[i] = nullptr;
 		m_aTeamSentStartWarning[i] = false;
 		ResetRoundState(i);
@@ -76,12 +76,12 @@ void CGameTeams::OnCharacterStart(int ClientId)
 		return;
 	if(g_Config.m_SvTeam == SV_TEAM_FORCED_SOLO && pStartingChar->m_DDRaceState == DDRACE_STARTED)
 		return;
-	if((g_Config.m_SvTeam == SV_TEAM_FORCED_SOLO || (m_Core.Team(ClientId) != TEAM_FLOCK && !m_aTeamMode[m_Core.Team(ClientId)])) && pStartingChar->m_DDRaceState == DDRACE_FINISHED)
+	if((g_Config.m_SvTeam == SV_TEAM_FORCED_SOLO || (m_Core.Team(ClientId) != TEAM_FLOCK && !m_aTeamFlock[m_Core.Team(ClientId)])) && pStartingChar->m_DDRaceState == DDRACE_FINISHED)
 		return;
 	if(g_Config.m_SvTeam != SV_TEAM_FORCED_SOLO &&
-		(m_Core.Team(ClientId) == TEAM_FLOCK || TeamMode(m_Core.Team(ClientId)) || m_Core.Team(ClientId) == TEAM_SUPER))
+		(m_Core.Team(ClientId) == TEAM_FLOCK || TeamFlock(m_Core.Team(ClientId)) || m_Core.Team(ClientId) == TEAM_SUPER))
 	{
-		if(TeamMode(m_Core.Team(ClientId)) && (m_aTeamState[m_Core.Team(ClientId)] < TEAMSTATE_STARTED))
+		if(TeamFlock(m_Core.Team(ClientId)) && (m_aTeamState[m_Core.Team(ClientId)] < TEAMSTATE_STARTED))
 			ChangeTeamState(m_Core.Team(ClientId), TEAMSTATE_STARTED);
 
 		m_aTeeStarted[ClientId] = true;
@@ -188,7 +188,7 @@ void CGameTeams::OnCharacterStart(int ClientId)
 
 void CGameTeams::OnCharacterFinish(int ClientId)
 {
-	if(((m_Core.Team(ClientId) == TEAM_FLOCK || m_aTeamMode[m_Core.Team(ClientId)]) && g_Config.m_SvTeam != SV_TEAM_FORCED_SOLO) || m_Core.Team(ClientId) == TEAM_SUPER)
+	if(((m_Core.Team(ClientId) == TEAM_FLOCK || m_aTeamFlock[m_Core.Team(ClientId)]) && g_Config.m_SvTeam != SV_TEAM_FORCED_SOLO) || m_Core.Team(ClientId) == TEAM_SUPER)
 	{
 		CPlayer *pPlayer = GetPlayer(ClientId);
 		if(pPlayer && pPlayer->IsPlaying())
@@ -254,7 +254,7 @@ void CGameTeams::Tick()
 	{
 		CCharacter *pChar = GameServer()->m_apPlayers[i] ? GameServer()->m_apPlayers[i]->GetCharacter() : nullptr;
 		int Team = m_Core.Team(i);
-		if(!pChar || m_aTeamState[Team] != TEAMSTATE_STARTED || m_aTeamMode[Team] || m_aTeeStarted[i] || m_aPractice[m_Core.Team(i)])
+		if(!pChar || m_aTeamState[Team] != TEAMSTATE_STARTED || m_aTeamFlock[Team] || m_aTeeStarted[i] || m_aPractice[m_Core.Team(i)])
 		{
 			continue;
 		}
@@ -376,7 +376,7 @@ const char *CGameTeams::SetCharacterTeam(int ClientId, int Team)
 		return "Invalid client ID";
 	if(Team < 0 || Team >= MAX_CLIENTS + 1)
 		return "Invalid team number";
-	if(Team != TEAM_SUPER && m_aTeamState[Team] > TEAMSTATE_OPEN && !m_aPractice[Team] && !m_aTeamMode[Team])
+	if(Team != TEAM_SUPER && m_aTeamState[Team] > TEAMSTATE_OPEN && !m_aPractice[Team] && !m_aTeamFlock[Team])
 		return "This team started already";
 	if(m_Core.Team(ClientId) == Team)
 		return "You are in this team already";
@@ -416,7 +416,7 @@ void CGameTeams::SetForceCharacterTeam(int ClientId, int Team)
 
 			// unlock team when last player leaves
 			SetTeamLock(OldTeam, false);
-			SetTeamMode(OldTeam, false);
+			SetTeamFlock(OldTeam, false);
 			ResetRoundState(OldTeam);
 			// do not reset SaveTeamResult, because it should be logged into teehistorian even if the team leaves
 		}
@@ -438,7 +438,7 @@ void CGameTeams::SetForceCharacterTeam(int ClientId, int Team)
 		m_pGameContext->m_World.RemoveEntitiesFromPlayer(ClientId);
 	}
 
-	if(Team != TEAM_SUPER && (m_aTeamState[Team] == TEAMSTATE_EMPTY || (m_aTeamLocked[Team] && !m_aTeamMode[Team])))
+	if(Team != TEAM_SUPER && (m_aTeamState[Team] == TEAMSTATE_EMPTY || (m_aTeamLocked[Team] && !m_aTeamFlock[Team])))
 	{
 		if(!m_aTeamLocked[Team])
 			ChangeTeamState(Team, TEAMSTATE_OPEN);
@@ -936,7 +936,7 @@ void CGameTeams::SwapTeamCharacters(CPlayer *pPrimaryPlayer, CPlayer *pTargetPla
 	PrimarySavedTee.Load(pTargetPlayer->GetCharacter(), Team, true);
 	SecondarySavedTee.Load(pPrimaryPlayer->GetCharacter(), Team, true);
 
-	if(Team >= 1 && !m_aTeamMode[Team])
+	if(Team >= 1 && !m_aTeamFlock[Team])
 	{
 		for(const auto &pPlayer : GameServer()->m_apPlayers)
 		{
@@ -1052,7 +1052,7 @@ void CGameTeams::OnCharacterSpawn(int ClientId)
 			SetForceCharacterTeam(ClientId, TEAM_FLOCK);
 		else
 			SetForceCharacterTeam(ClientId, ClientId); // initialize team
-		if(!m_aTeamMode[Team])
+		if(!m_aTeamFlock[Team])
 			CheckTeamFinished(Team);
 	}
 }
@@ -1089,7 +1089,7 @@ void CGameTeams::OnCharacterDeath(int ClientId, int Weapon)
 	{
 		SetForceCharacterTeam(ClientId, Team);
 
-		if(GetTeamState(Team) != TEAMSTATE_OPEN && !m_aTeamMode[m_Core.Team(ClientId)])
+		if(GetTeamState(Team) != TEAMSTATE_OPEN && !m_aTeamFlock[m_Core.Team(ClientId)])
 		{
 			ChangeTeamState(Team, CGameTeams::TEAMSTATE_OPEN);
 
@@ -1108,7 +1108,7 @@ void CGameTeams::OnCharacterDeath(int ClientId, int Weapon)
 	}
 	else
 	{
-		if(m_aTeamState[m_Core.Team(ClientId)] == CGameTeams::TEAMSTATE_STARTED && !m_aTeeStarted[ClientId] && !m_aTeamMode[m_Core.Team(ClientId)])
+		if(m_aTeamState[m_Core.Team(ClientId)] == CGameTeams::TEAMSTATE_STARTED && !m_aTeeStarted[ClientId] && !m_aTeamFlock[m_Core.Team(ClientId)])
 		{
 			char aBuf[128];
 			str_format(aBuf, sizeof(aBuf), "This team cannot finish anymore because '%s' left the team before hitting the start", Server()->ClientName(ClientId));
@@ -1119,7 +1119,7 @@ void CGameTeams::OnCharacterDeath(int ClientId, int Weapon)
 			ChangeTeamState(Team, CGameTeams::TEAMSTATE_STARTED_UNFINISHABLE);
 		}
 		SetForceCharacterTeam(ClientId, TEAM_FLOCK);
-		if(!m_aTeamMode[m_Core.Team(ClientId)])
+		if(!m_aTeamFlock[m_Core.Team(ClientId)])
 			CheckTeamFinished(Team);
 	}
 }
@@ -1130,10 +1130,10 @@ void CGameTeams::SetTeamLock(int Team, bool Lock)
 		m_aTeamLocked[Team] = Lock;
 }
 
-void CGameTeams::SetTeamMode(int Team, bool Mode)
+void CGameTeams::SetTeamFlock(int Team, bool Mode)
 {
 	if(Team > TEAM_FLOCK && Team < TEAM_SUPER)
-		m_aTeamMode[Team] = Mode;
+		m_aTeamFlock[Team] = Mode;
 }
 
 void CGameTeams::ResetInvited(int Team)

--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -32,6 +32,7 @@ void CGameTeams::Reset()
 	{
 		m_aTeamState[i] = TEAMSTATE_EMPTY;
 		m_aTeamLocked[i] = false;
+		m_aTeamMode[i] = false;
 		m_apSaveTeamResult[i] = nullptr;
 		m_aTeamSentStartWarning[i] = false;
 		ResetRoundState(i);
@@ -75,11 +76,14 @@ void CGameTeams::OnCharacterStart(int ClientId)
 		return;
 	if(g_Config.m_SvTeam == SV_TEAM_FORCED_SOLO && pStartingChar->m_DDRaceState == DDRACE_STARTED)
 		return;
-	if((g_Config.m_SvTeam == SV_TEAM_FORCED_SOLO || m_Core.Team(ClientId) != TEAM_FLOCK) && pStartingChar->m_DDRaceState == DDRACE_FINISHED)
+	if((g_Config.m_SvTeam == SV_TEAM_FORCED_SOLO || (m_Core.Team(ClientId) != TEAM_FLOCK && !m_aTeamMode[m_Core.Team(ClientId)])) && pStartingChar->m_DDRaceState == DDRACE_FINISHED)
 		return;
 	if(g_Config.m_SvTeam != SV_TEAM_FORCED_SOLO &&
-		(m_Core.Team(ClientId) == TEAM_FLOCK || m_Core.Team(ClientId) == TEAM_SUPER))
+		(m_Core.Team(ClientId) == TEAM_FLOCK || TeamMode(m_Core.Team(ClientId)) || m_Core.Team(ClientId) == TEAM_SUPER))
 	{
+		if(TeamMode(m_Core.Team(ClientId)) && (m_aTeamState[m_Core.Team(ClientId)] < TEAMSTATE_STARTED))
+			ChangeTeamState(m_Core.Team(ClientId), TEAMSTATE_STARTED);
+
 		m_aTeeStarted[ClientId] = true;
 		pStartingChar->m_DDRaceState = DDRACE_STARTED;
 		pStartingChar->m_StartTime = Tick;
@@ -184,7 +188,7 @@ void CGameTeams::OnCharacterStart(int ClientId)
 
 void CGameTeams::OnCharacterFinish(int ClientId)
 {
-	if((m_Core.Team(ClientId) == TEAM_FLOCK && g_Config.m_SvTeam != SV_TEAM_FORCED_SOLO) || m_Core.Team(ClientId) == TEAM_SUPER)
+	if(((m_Core.Team(ClientId) == TEAM_FLOCK || m_aTeamMode[m_Core.Team(ClientId)]) && g_Config.m_SvTeam != SV_TEAM_FORCED_SOLO) || m_Core.Team(ClientId) == TEAM_SUPER)
 	{
 		CPlayer *pPlayer = GetPlayer(ClientId);
 		if(pPlayer && pPlayer->IsPlaying())
@@ -250,7 +254,7 @@ void CGameTeams::Tick()
 	{
 		CCharacter *pChar = GameServer()->m_apPlayers[i] ? GameServer()->m_apPlayers[i]->GetCharacter() : nullptr;
 		int Team = m_Core.Team(i);
-		if(!pChar || m_aTeamState[Team] != TEAMSTATE_STARTED || m_aTeeStarted[i] || m_aPractice[m_Core.Team(i)])
+		if(!pChar || m_aTeamState[Team] != TEAMSTATE_STARTED || m_aTeamMode[Team] || m_aTeeStarted[i] || m_aPractice[m_Core.Team(i)])
 		{
 			continue;
 		}
@@ -372,7 +376,7 @@ const char *CGameTeams::SetCharacterTeam(int ClientId, int Team)
 		return "Invalid client ID";
 	if(Team < 0 || Team >= MAX_CLIENTS + 1)
 		return "Invalid team number";
-	if(Team != TEAM_SUPER && m_aTeamState[Team] > TEAMSTATE_OPEN && !m_aPractice[Team])
+	if(Team != TEAM_SUPER && m_aTeamState[Team] > TEAMSTATE_OPEN && !m_aPractice[Team] && !m_aTeamMode[Team])
 		return "This team started already";
 	if(m_Core.Team(ClientId) == Team)
 		return "You are in this team already";
@@ -412,6 +416,7 @@ void CGameTeams::SetForceCharacterTeam(int ClientId, int Team)
 
 			// unlock team when last player leaves
 			SetTeamLock(OldTeam, false);
+			SetTeamMode(OldTeam, false);
 			ResetRoundState(OldTeam);
 			// do not reset SaveTeamResult, because it should be logged into teehistorian even if the team leaves
 		}
@@ -433,7 +438,7 @@ void CGameTeams::SetForceCharacterTeam(int ClientId, int Team)
 		m_pGameContext->m_World.RemoveEntitiesFromPlayer(ClientId);
 	}
 
-	if(Team != TEAM_SUPER && (m_aTeamState[Team] == TEAMSTATE_EMPTY || m_aTeamLocked[Team]))
+	if(Team != TEAM_SUPER && (m_aTeamState[Team] == TEAMSTATE_EMPTY || (m_aTeamLocked[Team] && !m_aTeamMode[Team])))
 	{
 		if(!m_aTeamLocked[Team])
 			ChangeTeamState(Team, TEAMSTATE_OPEN);
@@ -931,7 +936,7 @@ void CGameTeams::SwapTeamCharacters(CPlayer *pPrimaryPlayer, CPlayer *pTargetPla
 	PrimarySavedTee.Load(pTargetPlayer->GetCharacter(), Team, true);
 	SecondarySavedTee.Load(pPrimaryPlayer->GetCharacter(), Team, true);
 
-	if(Team >= 1)
+	if(Team >= 1 && !m_aTeamMode[Team])
 	{
 		for(const auto &pPlayer : GameServer()->m_apPlayers)
 		{
@@ -1047,7 +1052,8 @@ void CGameTeams::OnCharacterSpawn(int ClientId)
 			SetForceCharacterTeam(ClientId, TEAM_FLOCK);
 		else
 			SetForceCharacterTeam(ClientId, ClientId); // initialize team
-		CheckTeamFinished(Team);
+		if(!m_aTeamMode[Team])
+			CheckTeamFinished(Team);
 	}
 }
 
@@ -1083,7 +1089,7 @@ void CGameTeams::OnCharacterDeath(int ClientId, int Weapon)
 	{
 		SetForceCharacterTeam(ClientId, Team);
 
-		if(GetTeamState(Team) != TEAMSTATE_OPEN)
+		if(GetTeamState(Team) != TEAMSTATE_OPEN && !m_aTeamMode[m_Core.Team(ClientId)])
 		{
 			ChangeTeamState(Team, CGameTeams::TEAMSTATE_OPEN);
 
@@ -1102,7 +1108,7 @@ void CGameTeams::OnCharacterDeath(int ClientId, int Weapon)
 	}
 	else
 	{
-		if(m_aTeamState[m_Core.Team(ClientId)] == CGameTeams::TEAMSTATE_STARTED && !m_aTeeStarted[ClientId] && !m_aPractice[Team])
+		if(m_aTeamState[m_Core.Team(ClientId)] == CGameTeams::TEAMSTATE_STARTED && !m_aTeeStarted[ClientId] && !m_aTeamMode[m_Core.Team(ClientId)])
 		{
 			char aBuf[128];
 			str_format(aBuf, sizeof(aBuf), "This team cannot finish anymore because '%s' left the team before hitting the start", Server()->ClientName(ClientId));
@@ -1113,7 +1119,8 @@ void CGameTeams::OnCharacterDeath(int ClientId, int Weapon)
 			ChangeTeamState(Team, CGameTeams::TEAMSTATE_STARTED_UNFINISHABLE);
 		}
 		SetForceCharacterTeam(ClientId, TEAM_FLOCK);
-		CheckTeamFinished(Team);
+		if(!m_aTeamMode[m_Core.Team(ClientId)])
+			CheckTeamFinished(Team);
 	}
 }
 
@@ -1121,6 +1128,12 @@ void CGameTeams::SetTeamLock(int Team, bool Lock)
 {
 	if(Team > TEAM_FLOCK && Team < TEAM_SUPER)
 		m_aTeamLocked[Team] = Lock;
+}
+
+void CGameTeams::SetTeamMode(int Team, bool Mode)
+{
+	if(Team > TEAM_FLOCK && Team < TEAM_SUPER)
+		m_aTeamMode[Team] = Mode;
 }
 
 void CGameTeams::ResetInvited(int Team)

--- a/src/game/server/teams.h
+++ b/src/game/server/teams.h
@@ -25,7 +25,7 @@ class CGameTeams
 
 	int m_aTeamState[NUM_TEAMS];
 	bool m_aTeamLocked[NUM_TEAMS];
-	bool m_aTeamMode[NUM_TEAMS];
+	bool m_aTeamFlock[NUM_TEAMS];
 	CClientMask m_aInvited[NUM_TEAMS];
 	bool m_aPractice[NUM_TEAMS];
 	std::shared_ptr<CScoreSaveResult> m_apSaveTeamResult[NUM_TEAMS];
@@ -110,7 +110,7 @@ public:
 
 	void SendTeamsState(int ClientId);
 	void SetTeamLock(int Team, bool Lock);
-	void SetTeamMode(int Team, bool Mode);
+	void SetTeamFlock(int Team, bool Mode);
 	void ResetInvited(int Team);
 	void SetClientInvited(int Team, int ClientId, bool Invited);
 
@@ -151,12 +151,12 @@ public:
 		return m_aTeamLocked[Team];
 	}
 
-	bool TeamMode(int Team)
+	bool TeamFlock(int Team)
 	{
 		if(Team <= TEAM_FLOCK || Team >= TEAM_SUPER)
 			return false;
 
-		return m_aTeamMode[Team];
+		return m_aTeamFlock[Team];
 	}
 
 	bool IsInvited(int Team, int ClientId)

--- a/src/game/server/teams.h
+++ b/src/game/server/teams.h
@@ -25,6 +25,7 @@ class CGameTeams
 
 	int m_aTeamState[NUM_TEAMS];
 	bool m_aTeamLocked[NUM_TEAMS];
+	bool m_aTeamMode[NUM_TEAMS];
 	CClientMask m_aInvited[NUM_TEAMS];
 	bool m_aPractice[NUM_TEAMS];
 	std::shared_ptr<CScoreSaveResult> m_apSaveTeamResult[NUM_TEAMS];
@@ -109,6 +110,7 @@ public:
 
 	void SendTeamsState(int ClientId);
 	void SetTeamLock(int Team, bool Lock);
+	void SetTeamMode(int Team, bool Mode);
 	void ResetInvited(int Team);
 	void SetClientInvited(int Team, int ClientId, bool Invited);
 
@@ -147,6 +149,14 @@ public:
 			return false;
 
 		return m_aTeamLocked[Team];
+	}
+
+	bool TeamMode(int Team)
+	{
+		if(Team <= TEAM_FLOCK || Team >= TEAM_SUPER)
+			return false;
+
+		return m_aTeamMode[Team];
 	}
 
 	bool IsInvited(int Team, int ClientId)


### PR DESCRIPTION
Maybe more of a concept?
Not sure if this is too hacky and can't guarantee this doesn't break things.

Adds `/mode` that can enable teams to behave like team 0 with the added benefit of being able to manage it with `/lock` and `/invite`.

Tested with possible configurations such as `sv_team`, `sv_max_team_size`, `sv_min_team_size`, `sv_solo_server`.
Teams in "team 0 mode" can't use `/save`,  `/load` or `/practice`.

Closes #7380 

Very little showcase:

https://github.com/ddnet/ddnet/assets/121701317/ea2b848a-0af4-4b97-a769-890901a9ef42

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
