### PR TITLE
Ensure debug dummies are not included in server info

### DIFF
--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -197,6 +197,7 @@ public:
 		int m_NextMapChunk;
 		int m_Flags;
 		bool m_ShowIps;
+		bool m_DebugDummy;
 
 		const IConsole::CCommandInfo *m_pRconCmdToSend;
 
@@ -220,6 +221,11 @@ public:
 		std::shared_ptr<CHostLookup> m_pDnsblLookup;
 
 		bool m_Sixup;
+
+		bool IncludedInServerInfo() const
+		{
+			return m_State != STATE_EMPTY && !m_DebugDummy;
+		}
 	};
 
 	CClient m_aClients[MAX_CLIENTS];


### PR DESCRIPTION
Also fix normal clients being disconnected/controlled like debug dummies.

Closes #7523.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
