### PR TITLE
Revert the mess-chain #7247. Apply #7171

### DIFF
--- a/src/game/gamecore.cpp
+++ b/src/game/gamecore.cpp
@@ -79,10 +79,7 @@ void CCharacterCore::Init(CWorldCore *pWorld, CCollision *pCollision, CTeamsCore
 	m_Id = -1;
 
 	// fail safe, if core's tuning didn't get updated at all, just fallback to world tuning.
-	if(m_pWorld)
-		m_Tuning = m_pWorld->m_aTuning[g_Config.m_ClDummy];
-
-	Reset();
+	m_Tuning = m_pWorld->m_aTuning[g_Config.m_ClDummy];
 }
 
 void CCharacterCore::SetCoreWorld(CWorldCore *pWorld, CCollision *pCollision, CTeamsCore *pTeams)

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -83,8 +83,7 @@ bool CCharacter::Spawn(CPlayer *pPlayer, vec2 Pos)
 
 	m_ReckoningTick = 0;
 	m_SendCore = CCharacterCore();
-	m_ReckoningCore = m_Core;
-	m_ReckoningCore.SetCoreWorld(nullptr, Collision(), nullptr);
+	m_ReckoningCore = CCharacterCore();
 
 	GameServer()->m_World.InsertEntity(this);
 	m_Alive = true;
@@ -790,6 +789,9 @@ void CCharacter::TickDeferred()
 {
 	// advance the dummy
 	{
+		CWorldCore TempWorld;
+		m_ReckoningCore.Init(&TempWorld, Collision(), &Teams()->m_Core, m_pTeleOuts);
+		m_ReckoningCore.m_Id = m_pPlayer->GetCID();
 		m_ReckoningCore.Tick(false);
 		m_ReckoningCore.Move();
 		m_ReckoningCore.Quantize();
@@ -878,8 +880,6 @@ void CCharacter::TickDeferred()
 			m_ReckoningTick = Server()->Tick();
 			m_SendCore = m_Core;
 			m_ReckoningCore = m_Core;
-			m_ReckoningCore.SetCoreWorld(nullptr, Collision(), nullptr);
-			m_ReckoningCore.m_Tuning = CTuningParams();
 			m_Core.m_Reset = false;
 		}
 	}


### PR DESCRIPTION
This fixes the hook going invisible issue reported on Discord, and potentially reintroduces the UB fixed in 6680ec388cb8b71f9fa73223d3af9d37148bd26a, however I could not reproduce the UB anymore using ubsan :/

Lesson learned, don't try to be smart :upside_down_face: 
## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [x] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
