### PR TITLE
Fix string and color game settings not being reset correctly

### DIFF
--- a/src/engine/shared/console.cpp
+++ b/src/engine/shared/console.cpp
@@ -1289,7 +1289,18 @@ void CConsole::ResetGameSettings()
 		} \
 	}
 
-#define MACRO_CONFIG_COL(Name, ScriptName, Def, Save, Desc) MACRO_CONFIG_INT(Name, ScriptName, Def, 0, 0, Save, Desc)
+#define MACRO_CONFIG_COL(Name, ScriptName, Def, Flags, Desc) \
+	{ \
+		if(((Flags)&CFGFLAG_GAME) == CFGFLAG_GAME) \
+		{ \
+			CCommand *pCommand = FindCommand(#ScriptName, CFGFLAG_GAME); \
+			void *pUserData = pCommand->m_pUserData; \
+			FCommandCallback pfnCallback = pCommand->m_pfnCallback; \
+			TraverseChain(&pfnCallback, &pUserData); \
+			CColVariableData *pData = (CColVariableData *)pUserData; \
+			*pData->m_pVariable = pData->m_OldValue; \
+		} \
+	}
 
 #define MACRO_CONFIG_STR(Name, ScriptName, Len, Def, Flags, Desc) \
 	{ \

--- a/src/engine/shared/console.cpp
+++ b/src/engine/shared/console.cpp
@@ -1311,7 +1311,7 @@ void CConsole::ResetGameSettings()
 			FCommandCallback pfnCallback = pCommand->m_pfnCallback; \
 			TraverseChain(&pfnCallback, &pUserData); \
 			CStrVariableData *pData = (CStrVariableData *)pUserData; \
-			str_copy(pData->m_pOldValue, pData->m_pStr, pData->m_MaxSize); \
+			str_copy(pData->m_pStr, pData->m_pOldValue, pData->m_MaxSize); \
 		} \
 	}
 


### PR DESCRIPTION
We are only using int game settings at the moment so these bugs/fixes shouldn't have any effect on existing maps.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
