### PR TITLE
Count deaths in statboard from `KILLMSGTEAM`

### DIFF
--- a/src/game/client/components/statboard.cpp
+++ b/src/game/client/components/statboard.cpp
@@ -73,6 +73,20 @@ void CStatboard::OnMessage(int MsgType, void *pRawMsg)
 		else
 			pStats[pMsg->m_Victim].m_Suicides++;
 	}
+	else if(MsgType == NETMSGTYPE_SV_KILLMSGTEAM)
+	{
+		CNetMsg_Sv_KillMsgTeam *pMsg = (CNetMsg_Sv_KillMsgTeam *)pRawMsg;
+		CGameClient::CClientStats *pStats = m_pClient->m_aStats;
+
+		for(int i = 0; i < MAX_CLIENTS; i++)
+		{
+			if(m_pClient->m_Teams.Team(i) == pMsg->m_Team)
+			{
+				pStats[i].m_Deaths++;
+				pStats[i].m_Suicides++;
+			}
+		}
+	}
 	else if(MsgType == NETMSGTYPE_SV_CHAT)
 	{
 		CNetMsg_Sv_Chat *pMsg = (CNetMsg_Sv_Chat *)pRawMsg;


### PR DESCRIPTION
It will now increase deaths/suicides when a team dies in the `+statboard`.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
