### PR TITLE
Add game controller hooks for gamecontext net msgs

### DIFF
--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -1914,40 +1914,40 @@ void CGameContext::OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID)
 		switch(MsgID)
 		{
 		case NETMSGTYPE_CL_SAY:
-			OnSayNetMessage(static_cast<CNetMsg_Cl_Say *>(pRawMsg), ClientID, pUnpacker);
+			m_pController->OnSayNetMessage(static_cast<CNetMsg_Cl_Say *>(pRawMsg), ClientID, pUnpacker);
 			break;
 		case NETMSGTYPE_CL_CALLVOTE:
-			OnCallVoteNetMessage(static_cast<CNetMsg_Cl_CallVote *>(pRawMsg), ClientID);
+			m_pController->OnCallVoteNetMessage(static_cast<CNetMsg_Cl_CallVote *>(pRawMsg), ClientID);
 			break;
 		case NETMSGTYPE_CL_VOTE:
-			OnVoteNetMessage(static_cast<CNetMsg_Cl_Vote *>(pRawMsg), ClientID);
+			m_pController->OnVoteNetMessage(static_cast<CNetMsg_Cl_Vote *>(pRawMsg), ClientID);
 			break;
 		case NETMSGTYPE_CL_SETTEAM:
-			OnSetTeamNetMessage(static_cast<CNetMsg_Cl_SetTeam *>(pRawMsg), ClientID);
+			m_pController->OnSetTeamNetMessage(static_cast<CNetMsg_Cl_SetTeam *>(pRawMsg), ClientID);
 			break;
 		case NETMSGTYPE_CL_ISDDNETLEGACY:
-			OnIsDDNetLegacyNetMessage(static_cast<CNetMsg_Cl_IsDDNetLegacy *>(pRawMsg), ClientID, pUnpacker);
+			m_pController->OnIsDDNetLegacyNetMessage(static_cast<CNetMsg_Cl_IsDDNetLegacy *>(pRawMsg), ClientID, pUnpacker);
 			break;
 		case NETMSGTYPE_CL_SHOWOTHERSLEGACY:
-			OnShowOthersLegacyNetMessage(static_cast<CNetMsg_Cl_ShowOthersLegacy *>(pRawMsg), ClientID);
+			m_pController->OnShowOthersLegacyNetMessage(static_cast<CNetMsg_Cl_ShowOthersLegacy *>(pRawMsg), ClientID);
 			break;
 		case NETMSGTYPE_CL_SHOWOTHERS:
-			OnShowOthersNetMessage(static_cast<CNetMsg_Cl_ShowOthers *>(pRawMsg), ClientID);
+			m_pController->OnShowOthersNetMessage(static_cast<CNetMsg_Cl_ShowOthers *>(pRawMsg), ClientID);
 			break;
 		case NETMSGTYPE_CL_SHOWDISTANCE:
-			OnShowDistanceNetMessage(static_cast<CNetMsg_Cl_ShowDistance *>(pRawMsg), ClientID);
+			m_pController->OnShowDistanceNetMessage(static_cast<CNetMsg_Cl_ShowDistance *>(pRawMsg), ClientID);
 			break;
 		case NETMSGTYPE_CL_SETSPECTATORMODE:
-			OnSetSpectatorModeNetMessage(static_cast<CNetMsg_Cl_SetSpectatorMode *>(pRawMsg), ClientID);
+			m_pController->OnSetSpectatorModeNetMessage(static_cast<CNetMsg_Cl_SetSpectatorMode *>(pRawMsg), ClientID);
 			break;
 		case NETMSGTYPE_CL_CHANGEINFO:
-			OnChangeInfoNetMessage(static_cast<CNetMsg_Cl_ChangeInfo *>(pRawMsg), ClientID);
+			m_pController->OnChangeInfoNetMessage(static_cast<CNetMsg_Cl_ChangeInfo *>(pRawMsg), ClientID);
 			break;
 		case NETMSGTYPE_CL_EMOTICON:
-			OnEmoticonNetMessage(static_cast<CNetMsg_Cl_Emoticon *>(pRawMsg), ClientID);
+			m_pController->OnEmoticonNetMessage(static_cast<CNetMsg_Cl_Emoticon *>(pRawMsg), ClientID);
 			break;
 		case NETMSGTYPE_CL_KILL:
-			OnKillNetMessage(static_cast<CNetMsg_Cl_Kill *>(pRawMsg), ClientID);
+			m_pController->OnKillNetMessage(static_cast<CNetMsg_Cl_Kill *>(pRawMsg), ClientID);
 			break;
 		default:
 			break;

--- a/src/game/server/gamecontroller.cpp
+++ b/src/game/server/gamecontroller.cpp
@@ -468,6 +468,71 @@ void IGameController::OnReset()
 			pPlayer->Respawn();
 }
 
+void IGameController::OnSayNetMessage(const CNetMsg_Cl_Say *pMsg, int ClientID, const CUnpacker *pUnpacker)
+{
+	GameServer()->OnSayNetMessage(pMsg, ClientID, pUnpacker);
+}
+
+void IGameController::OnCallVoteNetMessage(const CNetMsg_Cl_CallVote *pMsg, int ClientID)
+{
+	GameServer()->OnCallVoteNetMessage(pMsg, ClientID);
+}
+
+void IGameController::OnVoteNetMessage(const CNetMsg_Cl_Vote *pMsg, int ClientID)
+{
+	GameServer()->OnVoteNetMessage(pMsg, ClientID);
+}
+
+void IGameController::OnSetTeamNetMessage(const CNetMsg_Cl_SetTeam *pMsg, int ClientID)
+{
+	GameServer()->OnSetTeamNetMessage(pMsg, ClientID);
+}
+
+void IGameController::OnIsDDNetLegacyNetMessage(const CNetMsg_Cl_IsDDNetLegacy *pMsg, int ClientID, CUnpacker *pUnpacker)
+{
+	GameServer()->OnIsDDNetLegacyNetMessage(pMsg, ClientID, pUnpacker);
+}
+
+void IGameController::OnShowOthersLegacyNetMessage(const CNetMsg_Cl_ShowOthersLegacy *pMsg, int ClientID)
+{
+	GameServer()->OnShowOthersLegacyNetMessage(pMsg, ClientID);
+}
+
+void IGameController::OnShowOthersNetMessage(const CNetMsg_Cl_ShowOthers *pMsg, int ClientID)
+{
+	GameServer()->OnShowOthersNetMessage(pMsg, ClientID);
+}
+
+void IGameController::OnShowDistanceNetMessage(const CNetMsg_Cl_ShowDistance *pMsg, int ClientID)
+{
+	GameServer()->OnShowDistanceNetMessage(pMsg, ClientID);
+}
+
+void IGameController::OnSetSpectatorModeNetMessage(const CNetMsg_Cl_SetSpectatorMode *pMsg, int ClientID)
+{
+	GameServer()->OnSetSpectatorModeNetMessage(pMsg, ClientID);
+}
+
+void IGameController::OnChangeInfoNetMessage(const CNetMsg_Cl_ChangeInfo *pMsg, int ClientID)
+{
+	GameServer()->OnChangeInfoNetMessage(pMsg, ClientID);
+}
+
+void IGameController::OnEmoticonNetMessage(const CNetMsg_Cl_Emoticon *pMsg, int ClientID)
+{
+	GameServer()->OnEmoticonNetMessage(pMsg, ClientID);
+}
+
+void IGameController::OnKillNetMessage(const CNetMsg_Cl_Kill *pMsg, int ClientID)
+{
+	GameServer()->OnKillNetMessage(pMsg, ClientID);
+}
+
+void IGameController::OnStartInfoNetMessage(const CNetMsg_Cl_StartInfo *pMsg, int ClientID)
+{
+	GameServer()->OnStartInfoNetMessage(pMsg, ClientID);
+}
+
 int IGameController::OnCharacterDeath(class CCharacter *pVictim, class CPlayer *pKiller, int Weapon)
 {
 	return 0;

--- a/src/game/server/gamecontroller.h
+++ b/src/game/server/gamecontroller.h
@@ -118,6 +118,20 @@ public:
 
 	virtual void OnReset();
 
+	virtual void OnSayNetMessage(const CNetMsg_Cl_Say *pMsg, int ClientID, const CUnpacker *pUnpacker);
+	virtual void OnCallVoteNetMessage(const CNetMsg_Cl_CallVote *pMsg, int ClientID);
+	virtual void OnVoteNetMessage(const CNetMsg_Cl_Vote *pMsg, int ClientID);
+	virtual void OnSetTeamNetMessage(const CNetMsg_Cl_SetTeam *pMsg, int ClientID);
+	virtual void OnIsDDNetLegacyNetMessage(const CNetMsg_Cl_IsDDNetLegacy *pMsg, int ClientID, CUnpacker *pUnpacker);
+	virtual void OnShowOthersLegacyNetMessage(const CNetMsg_Cl_ShowOthersLegacy *pMsg, int ClientID);
+	virtual void OnShowOthersNetMessage(const CNetMsg_Cl_ShowOthers *pMsg, int ClientID);
+	virtual void OnShowDistanceNetMessage(const CNetMsg_Cl_ShowDistance *pMsg, int ClientID);
+	virtual void OnSetSpectatorModeNetMessage(const CNetMsg_Cl_SetSpectatorMode *pMsg, int ClientID);
+	virtual void OnChangeInfoNetMessage(const CNetMsg_Cl_ChangeInfo *pMsg, int ClientID);
+	virtual void OnEmoticonNetMessage(const CNetMsg_Cl_Emoticon *pMsg, int ClientID);
+	virtual void OnKillNetMessage(const CNetMsg_Cl_Kill *pMsg, int ClientID);
+	virtual void OnStartInfoNetMessage(const CNetMsg_Cl_StartInfo *pMsg, int ClientID);
+
 	// game
 	void DoWarmup(int Seconds);
 

--- a/src/game/server/gamemodes/mod.cpp
+++ b/src/game/server/gamemodes/mod.cpp
@@ -22,3 +22,16 @@ void CGameControllerMod::Tick()
 
 	IGameController::Tick();
 }
+
+void CGameControllerMod::OnSayNetMessage(const CNetMsg_Cl_Say *pMsg, int ClientID, const CUnpacker *pUnpacker)
+{
+	if(!str_utf8_check(pMsg->m_pMessage))
+		return;
+
+	char aBuf[512];
+	str_format(aBuf, sizeof(aBuf), "%s UwU", pMsg->m_pMessage);
+	CNetMsg_Cl_Say Msg;
+	Msg.m_Team = pMsg->m_Team;
+	Msg.m_pMessage = aBuf;
+	IGameController::OnSayNetMessage(&Msg, ClientID, pUnpacker);
+}

--- a/src/game/server/gamemodes/mod.h
+++ b/src/game/server/gamemodes/mod.h
@@ -10,5 +10,6 @@ public:
 	~CGameControllerMod();
 
 	void Tick() override;
+	void OnSayNetMessage(const CNetMsg_Cl_Say *pMsg, int ClientID, const CUnpacker *pUnpacker) override;
 };
 #endif // GAME_SERVER_GAMEMODES_MOD_H


### PR DESCRIPTION
Is appending UwU to every chat message the best sample usage of this feature? Who knows ...

Allows ddnet forks and the ddrace controller to hook into the net messages currently handled in CGameContext

@Kaffeine hi :)

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
