### PR TITLE
Hide "Allow unused" button when not using "DDNet" entities.

### DIFF
--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -280,15 +280,18 @@ CUI::EPopupMenuFunctionResult CEditor::PopupMenuSettings(void *pContext, CUIRect
 		Selector.VSplitMid(&No, &Yes);
 
 		pEditor->UI()->DoLabel(&Label, "Allow unused", 10.0f, TEXTALIGN_ML);
-		static int s_ButtonNo = 0;
-		static int s_ButtonYes = 0;
-		if(pEditor->DoButton_ButtonDec(&s_ButtonNo, "No", !pEditor->m_AllowPlaceUnusedTiles, &No, 0, "[ctrl+u] Disallow placing unused tiles"))
+		if(pEditor->m_AllowPlaceUnusedTiles != -1)
 		{
-			pEditor->m_AllowPlaceUnusedTiles = false;
-		}
-		if(pEditor->DoButton_ButtonInc(&s_ButtonYes, "Yes", pEditor->m_AllowPlaceUnusedTiles, &Yes, 0, "[ctrl+u] Allow placing unused tiles"))
-		{
-			pEditor->m_AllowPlaceUnusedTiles = true;
+			static int s_ButtonNo = 0;
+			static int s_ButtonYes = 0;
+			if(pEditor->DoButton_ButtonDec(&s_ButtonNo, "No", !pEditor->m_AllowPlaceUnusedTiles, &No, 0, "[ctrl+u] Disallow placing unused tiles"))
+			{
+				pEditor->m_AllowPlaceUnusedTiles = false;
+			}
+			if(pEditor->DoButton_ButtonInc(&s_ButtonYes, "Yes", pEditor->m_AllowPlaceUnusedTiles, &Yes, 0, "[ctrl+u] Allow placing unused tiles"))
+			{
+				pEditor->m_AllowPlaceUnusedTiles = true;
+			}
 		}
 	}
 


### PR DESCRIPTION
Previously it would just grey out the "Yes" button, but if you were to click "No". It was possible to enable it again. Which shouldn't be possible as "Allow unused" is only supported for "DDNet" entities

Before
![image](https://github.com/ddnet/ddnet/assets/141338449/a905b3a0-6912-45b9-9404-bced7ea97781)

After
![image](https://github.com/ddnet/ddnet/assets/141338449/d80b4e72-fa98-403f-b5fc-cd2c1d3efa97)



## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
