### PR TITLE
Added possibility to edit chat size and width

### DIFF
--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -621,6 +621,8 @@ MACRO_CONFIG_COL(ClHookCollColorTeeColl, cl_hook_coll_color_tee_coll, 2817919, C
 MACRO_CONFIG_INT(ClChatTeamColors, cl_chat_teamcolors, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show names in chat in team colors")
 MACRO_CONFIG_INT(ClChatReset, cl_chat_reset, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Reset chat when pressing escape")
 MACRO_CONFIG_INT(ClChatOld, cl_chat_old, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Old chat style: No tee, no background")
+MACRO_CONFIG_INT(ClChatFontSize, cl_chat_size, 60, 10, 100, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Chat font size")
+MACRO_CONFIG_INT(ClChatWidth, cl_chat_width, 200, 140, 400, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Chat width")
 
 MACRO_CONFIG_INT(ClShowDirection, cl_show_direction, 1, 0, 3, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Show key presses (1 = other players', 2 = also your own, 3 = only your own")
 MACRO_CONFIG_INT(ClOldGunPosition, cl_old_gun_position, 0, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Tees hold gun a bit higher like in TW 0.6.1 and older")

--- a/src/game/client/components/chat.h
+++ b/src/game/client/components/chat.h
@@ -15,13 +15,13 @@
 
 class CChat : public CComponent
 {
-	static constexpr float CHAT_WIDTH = 200.0f;
 	static constexpr float CHAT_HEIGHT_FULL = 200.0f;
 	static constexpr float CHAT_HEIGHT_MIN = 50.0f;
+	static constexpr float CHAT_FONTSIZE_WIDTH_RATIO = 2.5f;
 
 	enum
 	{
-		MAX_LINES = 25,
+		MAX_LINES = 64,
 		MAX_LINE_LENGTH = 256
 	};
 
@@ -133,6 +133,8 @@ class CChat : public CComponent
 	static void ConEcho(IConsole::IResult *pResult, void *pUserData);
 
 	static void ConchainChatOld(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
+	static void ConchainChatFontSize(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
+	static void ConchainChatWidth(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 
 	bool LineShouldHighlight(const char *pLine, const char *pName);
 	void StoreSave(const char *pText);
@@ -141,13 +143,7 @@ public:
 	CChat();
 	int Sizeof() const override { return sizeof(*this); }
 
-	static constexpr float MESSAGE_PADDING_X = 5.0f;
-	static constexpr float MESSAGE_TEE_SIZE = 7.0f;
 	static constexpr float MESSAGE_TEE_PADDING_RIGHT = 0.5f;
-	static constexpr float FONT_SIZE = 6.0f;
-	static constexpr float MESSAGE_PADDING_Y = 1.0f;
-	static constexpr float MESSAGE_ROUNDING = 3.0f;
-	static_assert(FONT_SIZE + MESSAGE_PADDING_Y >= MESSAGE_ROUNDING * 2.0f, "Corners for background chat are too huge for this combination of font size and message padding.");
 
 	bool IsActive() const { return m_Mode != MODE_NONE; }
 	void AddLine(int ClientID, int Team, const char *pLine);
@@ -163,7 +159,7 @@ public:
 	void OnStateChange(int NewState, int OldState) override;
 	void OnRender() override;
 	void RefindSkins();
-	void OnPrepareLines();
+	void OnPrepareLines(float y);
 	void Reset();
 	void OnRelease() override;
 	void OnMessage(int MsgType, void *pRawMsg) override;
@@ -171,5 +167,14 @@ public:
 	void OnInit() override;
 
 	void RebuildChat();
+
+	void EnsureCoherentFontSize() const;
+	void EnsureCoherentWidth() const;
+
+	float FontSize() const { return g_Config.m_ClChatFontSize / 10.0f; }
+	float MessagePaddingX() const { return FontSize() * (5 / 6.f); }
+	float MessagePaddingY() const { return FontSize() * (1 / 6.f); }
+	float MessageTeeSize() const { return FontSize() * (7 / 6.f); }
+	float MessageRounding() const { return FontSize() * (1 / 2.f); }
 };
 #endif


### PR DESCRIPTION
Closes #7531. To make this work, I had to refactor the code that does chat preview. I also made sure to always have some minimal ratio between chat font size and chat width so that we don't have a 5 character wide chat possible. This should also work when `cl_chat_old` is set to `1`.


https://github.com/ddnet/ddnet/assets/13364635/310d75ba-c38d-4773-96eb-c02debb00616



## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
