### PR TITLE
Add a fading effect for buttons

### DIFF
--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -59,7 +59,7 @@ class CMenus : public CComponent
 
 	int DoButton_FontIcon(CButtonContainer *pButtonContainer, const char *pText, int Checked, const CUIRect *pRect, int Corners = IGraphics::CORNER_ALL, bool Enabled = true);
 	int DoButton_Toggle(const void *pID, int Checked, const CUIRect *pRect, bool Active);
-	int DoButton_Menu(CButtonContainer *pButtonContainer, const char *pText, int Checked, const CUIRect *pRect, const char *pImageName = nullptr, int Corners = IGraphics::CORNER_ALL, float r = 5.0f, float FontFactor = 0.0f, vec4 ColorHot = vec4(1.0f, 1.0f, 1.0f, 0.75f), vec4 Color = vec4(1, 1, 1, 0.5f));
+	int DoButton_Menu(CButtonContainer *pButtonContainer, const char *pText, int Checked, const CUIRect *pRect, const char *pImageName = nullptr, int Corners = IGraphics::CORNER_ALL, float r = 5.0f, float FontFactor = 0.0f, ColorRGBA ColorHot = vec4(1.0f, 1.0f, 1.0f, 0.75f), ColorRGBA Color = vec4(1, 1, 1, 0.5f));
 	int DoButton_MenuTab(CButtonContainer *pButtonContainer, const char *pText, int Checked, const CUIRect *pRect, int Corners, SUIAnimator *pAnimator = nullptr, const ColorRGBA *pDefaultColor = nullptr, const ColorRGBA *pActiveColor = nullptr, const ColorRGBA *pHoverColor = nullptr, float EdgeRounding = 10);
 
 	int DoButton_CheckBox_Common(const void *pID, const char *pText, const char *pBoxText, const CUIRect *pRect);
@@ -72,8 +72,8 @@ class CMenus : public CComponent
 	void DoLaserPreview(const CUIRect *pRect, ColorHSLA OutlineColor, ColorHSLA InnerColor, const int LaserType);
 	int DoButton_GridHeader(const void *pID, const char *pText, int Checked, const CUIRect *pRect);
 
-	void DoButton_KeySelect(const void *pID, const char *pText, const CUIRect *pRect);
-	int DoKeyReader(const void *pID, const CUIRect *pRect, int Key, int ModifierCombination, int *pNewModifierCombination);
+	void DoButton_KeySelect(CButtonContainer *pButtonContainer, const char *pText, const CUIRect *pRect);
+	int DoKeyReader(CButtonContainer *pButtonContainer, const CUIRect *pRect, int Key, int ModifierCombination, int *pNewModifierCombination);
 
 	void DoSettingsControlsButtons(int Start, int Stop, CUIRect View);
 

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -942,6 +942,7 @@ typedef struct
 	const char *m_pCommand;
 	int m_KeyId;
 	int m_ModifierCombination;
+	CButtonContainer m_ButtonContainer;
 } CKeyInfo;
 
 static CKeyInfo gs_aKeys[] =
@@ -1001,7 +1002,7 @@ void CMenus::DoSettingsControlsButtons(int Start, int Stop, CUIRect View)
 {
 	for(int i = Start; i < Stop; i++)
 	{
-		const CKeyInfo &Key = gs_aKeys[i];
+		CKeyInfo &Key = gs_aKeys[i];
 
 		CUIRect Button, Label;
 		View.HSplitTop(20.0f, &Button, &View);
@@ -1012,7 +1013,7 @@ void CMenus::DoSettingsControlsButtons(int Start, int Stop, CUIRect View)
 
 		UI()->DoLabel(&Label, aBuf, 13.0f, TEXTALIGN_ML);
 		int OldId = Key.m_KeyId, OldModifierCombination = Key.m_ModifierCombination, NewModifierCombination;
-		int NewId = DoKeyReader(&Key.m_KeyId, &Button, OldId, OldModifierCombination, &NewModifierCombination);
+		int NewId = DoKeyReader(&Key.m_ButtonContainer, &Button, OldId, OldModifierCombination, &NewModifierCombination);
 		if(NewId != OldId || NewModifierCombination != OldModifierCombination)
 		{
 			if(OldId != 0 || NewId == 0)

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -1928,3 +1928,14 @@ void CUI::ShowPopupColorPicker(float X, float Y, SColorPickerPopupContext *pCont
 		pContext->m_ColorMode = SColorPickerPopupContext::MODE_HSVA;
 	DoPopupMenu(pContext, X, Y, 160.0f + 10.0f, 209.0f + 10.0f, pContext, PopupColorPicker);
 }
+
+float CButtonContainer::GetFade(bool Checked, float Seconds)
+{
+	if(UI()->HotItem() == this || UI()->CheckActiveItem(this) || Checked)
+	{
+		m_FadeStartTime = Client()->GlobalTime();
+		return 1.0f;
+	}
+
+	return maximum(0.0f, m_FadeStartTime - Client()->GlobalTime() + Seconds) / Seconds;
+}

--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -226,8 +226,12 @@ public:
 	CUI *UI() const { return s_pUI; }
 };
 
-class CButtonContainer
+class CButtonContainer : public CUIElementBase
 {
+	float m_FadeStartTime;
+
+public:
+	float GetFade(bool Checked = false, float Seconds = 0.2f);
 };
 
 struct SValueSelectorProperties


### PR DESCRIPTION
Adds a small fading effect when switching from the hover colour for buttons. Ported from 0.7.


https://github.com/ddnet/ddnet/assets/141338449/55d8d3a1-ca24-4be1-b4f3-0e4014195549



## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
