### PR TITLE
Check for invalid unicode in filenames etc. on Windows

### DIFF
--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -111,8 +111,8 @@ IOHANDLE io_current_exe()
 	{
 		return 0;
 	}
-	const std::string path = windows_wide_to_utf8(wide_path);
-	return io_open(path.c_str(), IOFLAG_READ);
+	const std::optional<std::string> path = windows_wide_to_utf8(wide_path);
+	return path.has_value() ? io_open(path.value().c_str(), IOFLAG_READ) : 0;
 #elif defined(CONF_PLATFORM_MACOS)
 	char path[IO_MAX_PATH_LENGTH];
 	uint32_t path_size = sizeof(path);
@@ -1456,9 +1456,9 @@ std::string windows_format_system_message(unsigned long error)
 	if(FormatMessageW(flags, NULL, error, 0, (LPWSTR)&wide_message, 0, NULL) == 0)
 		return "unknown error";
 
-	std::string message = windows_wide_to_utf8(wide_message);
+	std::optional<std::string> message = windows_wide_to_utf8(wide_message);
 	LocalFree(wide_message);
-	return message;
+	return message.value_or("invalid error");
 }
 #endif
 
@@ -2108,8 +2108,13 @@ void fs_listdir(const char *dir, FS_LISTDIR_CALLBACK cb, int type, void *user)
 
 	do
 	{
-		const std::string current_entry = windows_wide_to_utf8(finddata.cFileName);
-		if(cb(current_entry.c_str(), (finddata.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0, type, user))
+		const std::optional<std::string> current_entry = windows_wide_to_utf8(finddata.cFileName);
+		if(!current_entry.has_value())
+		{
+			log_error("filesystem", "ERROR: file/folder name containing invalid UTF-16 found in folder '%s'", dir);
+			continue;
+		}
+		if(cb(current_entry.value().c_str(), (finddata.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0, type, user))
 			break;
 	} while(FindNextFileW(handle, &finddata));
 
@@ -2155,10 +2160,15 @@ void fs_listdir_fileinfo(const char *dir, FS_LISTDIR_CALLBACK_FILEINFO cb, int t
 
 	do
 	{
-		const std::string current_entry = windows_wide_to_utf8(finddata.cFileName);
+		const std::optional<std::string> current_entry = windows_wide_to_utf8(finddata.cFileName);
+		if(!current_entry.has_value())
+		{
+			log_error("filesystem", "ERROR: file/folder name containing invalid UTF-16 found in folder '%s'", dir);
+			continue;
+		}
 
 		CFsFileInfo info;
-		info.m_pName = current_entry.c_str();
+		info.m_pName = current_entry.value().c_str();
 		info.m_TimeCreated = filetime_to_unixtime(&finddata.ftCreationTime);
 		info.m_TimeModified = filetime_to_unixtime(&finddata.ftLastWriteTime);
 
@@ -2212,8 +2222,14 @@ int fs_storage_path(const char *appname, char *path, int max)
 		path[0] = '\0';
 		return -1;
 	}
-	const std::string home = windows_wide_to_utf8(wide_home);
-	str_format(path, max, "%s/%s", home.c_str(), appname);
+	const std::optional<std::string> home = windows_wide_to_utf8(wide_home);
+	if(!home.has_value())
+	{
+		log_error("filesystem", "ERROR: the APPDATA environment variable contains invalid UTF-16");
+		path[0] = '\0';
+		return -1;
+	}
+	str_format(path, max, "%s/%s", home.value().c_str(), appname);
 	return 0;
 #else
 	char *home = getenv("HOME");
@@ -2386,8 +2402,13 @@ char *fs_getcwd(char *buffer, int buffer_size)
 		buffer[0] = '\0';
 		return nullptr;
 	}
-	const std::string current_dir = windows_wide_to_utf8(wide_current_dir.c_str());
-	str_copy(buffer, current_dir.c_str(), buffer_size);
+	const std::optional<std::string> current_dir = windows_wide_to_utf8(wide_current_dir.c_str());
+	if(!current_dir.has_value())
+	{
+		buffer[0] = '\0';
+		return nullptr;
+	}
+	str_copy(buffer, current_dir.value().c_str(), buffer_size);
 	return buffer;
 #else
 	char *result = getcwd(buffer, buffer_size);
@@ -4405,8 +4426,8 @@ void os_locale_str(char *locale, size_t length)
 	wchar_t wide_buffer[LOCALE_NAME_MAX_LENGTH];
 	dbg_assert(GetUserDefaultLocaleName(wide_buffer, std::size(wide_buffer)) > 0, "GetUserDefaultLocaleName failure");
 
-	const std::string buffer = windows_wide_to_utf8(wide_buffer);
-	str_copy(locale, buffer.c_str(), length);
+	const std::optional<std::string> buffer = windows_wide_to_utf8(wide_buffer);
+	str_copy(locale, buffer.value_or("en-US").c_str(), length);
 #elif defined(CONF_PLATFORM_MACOS)
 	CFLocaleRef locale_ref = CFLocaleCopyCurrent();
 	CFStringRef locale_identifier_ref = static_cast<CFStringRef>(CFLocaleGetValue(locale_ref, kCFLocaleIdentifier));
@@ -4531,20 +4552,23 @@ std::wstring windows_utf8_to_wide(const char *str)
 	const int orig_length = str_length(str);
 	if(orig_length == 0)
 		return L"";
-	const int size_needed = MultiByteToWideChar(CP_UTF8, 0, str, orig_length, nullptr, 0);
+	const int size_needed = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, str, orig_length, nullptr, 0);
+	dbg_assert(size_needed > 0, "Invalid UTF-8 passed to windows_utf8_to_wide");
 	std::wstring wide_string(size_needed, L'\0');
-	dbg_assert(MultiByteToWideChar(CP_UTF8, 0, str, orig_length, wide_string.data(), size_needed) == size_needed, "MultiByteToWideChar failure");
+	dbg_assert(MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, str, orig_length, wide_string.data(), size_needed) == size_needed, "MultiByteToWideChar failure");
 	return wide_string;
 }
 
-std::string windows_wide_to_utf8(const wchar_t *wide_str)
+std::optional<std::string> windows_wide_to_utf8(const wchar_t *wide_str)
 {
 	const int orig_length = wcslen(wide_str);
 	if(orig_length == 0)
 		return "";
-	const int size_needed = WideCharToMultiByte(CP_UTF8, 0, wide_str, orig_length, nullptr, 0, nullptr, nullptr);
+	const int size_needed = WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, wide_str, orig_length, nullptr, 0, nullptr, nullptr);
+	if(size_needed == 0)
+		return {};
 	std::string string(size_needed, '\0');
-	dbg_assert(WideCharToMultiByte(CP_UTF8, 0, wide_str, orig_length, string.data(), size_needed, nullptr, nullptr) == size_needed, "WideCharToMultiByte failure");
+	dbg_assert(WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, wide_str, orig_length, string.data(), size_needed, nullptr, nullptr) == size_needed, "WideCharToMultiByte failure");
 	return string;
 }
 

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -22,6 +22,7 @@
 #include <ctime>
 #include <functional>
 #include <mutex>
+#include <optional>
 #include <string>
 
 #ifdef __MINGW32__
@@ -2727,6 +2728,7 @@ public:
  * @return The argument as a wide character string.
  *
  * @remark The argument string must be zero-terminated.
+ * @remark Fails with assertion error if passed utf8 is invalid.
  */
 std::wstring windows_utf8_to_wide(const char *str);
 
@@ -2736,11 +2738,12 @@ std::wstring windows_utf8_to_wide(const char *str);
  *
  * @param wide_str The wide character string to convert.
  *
- * @return The argument as a utf8 encoded string.
+ * @return The argument as a utf8 encoded string, wrapped in an optional.
+ * The optional is empty, if the wide string contains invalid codepoints.
  *
  * @remark The argument string must be zero-terminated.
  */
-std::string windows_wide_to_utf8(const wchar_t *wide_str);
+std::optional<std::string> windows_wide_to_utf8(const wchar_t *wide_str);
 
 /**
  * This is a RAII wrapper to initialize/uninitialize the Windows COM library,

--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -800,7 +800,7 @@ void CInput::ProcessSystemMessage(SDL_SysWMmsg *pMsg)
 				for(DWORD i = pCandidateList->dwPageStart; i < pCandidateList->dwCount && (int)m_vCandidates.size() < (int)pCandidateList->dwPageSize; i++)
 				{
 					LPCWSTR pCandidate = (LPCWSTR)((DWORD_PTR)pCandidateList + pCandidateList->dwOffset[i]);
-					m_vCandidates.push_back(std::move(windows_wide_to_utf8(pCandidate)));
+					m_vCandidates.push_back(std::move(windows_wide_to_utf8(pCandidate).value_or("<invalid candidate>")));
 				}
 				m_CandidateSelectedIndex = pCandidateList->dwSelection - pCandidateList->dwPageStart;
 			}

--- a/src/test/str.cpp
+++ b/src/test/str.cpp
@@ -1107,9 +1107,10 @@ TEST(Str, WindowsUtf8WideConversion)
 	static_assert(std::size(apUtf8Strings) == std::size(apWideStrings));
 	for(size_t i = 0; i < std::size(apUtf8Strings); i++)
 	{
-		const std::string ConvertedUtf8 = windows_wide_to_utf8(apWideStrings[i]);
+		const std::optional<std::string> ConvertedUtf8 = windows_wide_to_utf8(apWideStrings[i]);
 		const std::wstring ConvertedWide = windows_utf8_to_wide(apUtf8Strings[i]);
-		EXPECT_STREQ(ConvertedUtf8.c_str(), apUtf8Strings[i]);
+		ASSERT_TRUE(ConvertedUtf8.has_value());
+		EXPECT_STREQ(ConvertedUtf8.value().c_str(), apUtf8Strings[i]);
 		EXPECT_STREQ(ConvertedWide.c_str(), apWideStrings[i]);
 	}
 }


### PR DESCRIPTION
Add stricter error handling when converting between UTF-16 (wide characters) and UTF-8 (multi-byte) on Windows.

The `windows_wide_to_utf8` function now returns an `std::optional`, which will be empty if the argument contains invalid UTF-16. Files/folders with names containing invalid UTF-16 are now ignored on Windows. It was previously not possible to use these files either, as converting their names to UTF-8 changed the invalid codepoints to unicode replacement characters.

The `windows_utf8_to_wide` function now fails with an assertion error if the argument contains invalid UTF-8, as this should never happen.

Closes #7486.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
