### PR TITLE
Stop all recording of server demos on shutdown.

### DIFF
--- a/src/engine/server.h
+++ b/src/engine/server.h
@@ -245,6 +245,7 @@ public:
 	virtual void StartRecord(int ClientID) = 0;
 	virtual void StopRecord(int ClientID) = 0;
 	virtual bool IsRecording(int ClientID) = 0;
+	virtual void StopDemos() = 0;
 
 	virtual void GetClientAddr(int ClientID, NETADDR *pAddr) const = 0;
 

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -2581,23 +2581,6 @@ int CServer::LoadMap(const char *pMapName)
 	if(!m_pMap->Load(aBuf))
 		return 0;
 
-	// stop recording when we change map
-	for(int i = 0; i < MAX_CLIENTS + 1; i++)
-	{
-		if(!m_aDemoRecorder[i].IsRecording())
-			continue;
-
-		m_aDemoRecorder[i].Stop();
-
-		// remove tmp demos
-		if(i < MAX_CLIENTS)
-		{
-			char aPath[256];
-			str_format(aPath, sizeof(aPath), "demos/%s_%d_%d_tmp.demo", m_aCurrentMap, m_NetServer.Address().port, i);
-			Storage()->RemoveFile(aPath, IStorage::TYPE_SAVE);
-		}
-	}
-
 	// reinit snapshot ids
 	m_IDPool.TimeoutIDs();
 
@@ -3449,6 +3432,25 @@ void CServer::StopRecord(int ClientID)
 bool CServer::IsRecording(int ClientID)
 {
 	return m_aDemoRecorder[ClientID].IsRecording();
+}
+
+void CServer::StopDemos()
+{
+	for(int i = 0; i < MAX_CLIENTS + 1; i++)
+	{
+		if(!m_aDemoRecorder[i].IsRecording())
+			continue;
+
+		m_aDemoRecorder[i].Stop();
+
+		// remove tmp demos
+		if(i < MAX_CLIENTS)
+		{
+			char aPath[256];
+			str_format(aPath, sizeof(aPath), "demos/%s_%d_%d_tmp.demo", m_aCurrentMap, m_NetServer.Address().port, i);
+			Storage()->RemoveFile(aPath, IStorage::TYPE_SAVE);
+		}
+	}
 }
 
 void CServer::ConRecord(IConsole::IResult *pResult, void *pUser)

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -410,6 +410,7 @@ public:
 	void StartRecord(int ClientID) override;
 	void StopRecord(int ClientID) override;
 	bool IsRecording(int ClientID) override;
+	void StopDemos() override;
 
 	int Run();
 

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -3950,6 +3950,9 @@ void CGameContext::OnShutdown(void *pPersistentData)
 		aio_free(m_pTeeHistorianFile);
 	}
 
+	// Stop any demos being recorded.
+	Server()->StopDemos();
+
 	DeleteTempfile();
 	ConfigManager()->ResetGameSettings();
 	Collision()->Dest();


### PR DESCRIPTION
Previously if you did `DDNet-Server "record a; shutdown"`. You would get the following assert `src/engine/shared/demo.cpp(47): Demo recorder was not stopped`. 

It now stops any recording demos on shutdown.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
