### PR TITLE
Don't scale TargetXY by zoom when in spectator.

### DIFF
--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -267,8 +267,11 @@ int CControls::SnapInput(int *pData)
 			m_aInputData[g_Config.m_ClDummy].m_Direction = 1;
 
 		// scale TargetX, TargetY by zoom.
-		m_aInputData[g_Config.m_ClDummy].m_TargetX *= m_pClient->m_Camera.m_Zoom;
-		m_aInputData[g_Config.m_ClDummy].m_TargetY *= m_pClient->m_Camera.m_Zoom;
+		if(!m_pClient->m_Snap.m_SpecInfo.m_Active)
+		{
+			m_aInputData[g_Config.m_ClDummy].m_TargetX *= m_pClient->m_Camera.m_Zoom;
+			m_aInputData[g_Config.m_ClDummy].m_TargetY *= m_pClient->m_Camera.m_Zoom;
+		}
 
 		// dummy copy moves
 		if(g_Config.m_ClDummyCopyMoves)


### PR DESCRIPTION
Don't scale TargetX and TargetY by zoom when in spectator, as it completely breaks ShowDistance and `/tp`. Closes #7569.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
