### PR TITLE
Fix bug when using favourites in combination with prefixes.

### DIFF
--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -745,7 +745,7 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 
 		for(const auto &it : m_SkinFavorites)
 		{
-			const CSkin *pSkinToBeSelected = m_pClient->m_Skins.FindOrNullptr(it.c_str());
+			const CSkin *pSkinToBeSelected = m_pClient->m_Skins.FindOrNullptr(it.c_str(), true);
 
 			if(pSkinToBeSelected == nullptr || !SkinNotFiltered(pSkinToBeSelected))
 				continue;

--- a/src/game/client/components/skins.cpp
+++ b/src/game/client/components/skins.cpp
@@ -373,14 +373,14 @@ const CSkin *CSkins::Find(const char *pName)
 	}
 }
 
-const CSkin *CSkins::FindOrNullptr(const char *pName)
+const CSkin *CSkins::FindOrNullptr(const char *pName, bool IgnorePrefix)
 {
 	const char *pSkinPrefix = m_aEventSkinPrefix[0] ? m_aEventSkinPrefix : g_Config.m_ClSkinPrefix;
 	if(g_Config.m_ClVanillaSkinsOnly && !IsVanillaSkin(pName))
 	{
 		return nullptr;
 	}
-	else if(pSkinPrefix && pSkinPrefix[0])
+	else if(pSkinPrefix && pSkinPrefix[0] && !IgnorePrefix)
 	{
 		char aBuf[24];
 		str_format(aBuf, sizeof(aBuf), "%s_%s", pSkinPrefix, pName);

--- a/src/game/client/components/skins.h
+++ b/src/game/client/components/skins.h
@@ -64,7 +64,7 @@ public:
 	void Refresh(TSkinLoadedCBFunc &&SkinLoadedFunc);
 	int Num();
 	std::unordered_map<std::string_view, std::unique_ptr<CSkin>> &GetSkinsUnsafe() { return m_Skins; }
-	const CSkin *FindOrNullptr(const char *pName);
+	const CSkin *FindOrNullptr(const char *pName, bool IgnorePrefix = false);
 	const CSkin *Find(const char *pName);
 
 	bool IsDownloadingSkins() { return m_DownloadingSkins; }


### PR DESCRIPTION
Let's say you have `twinbop` as a favourite. and then use one of the prefixes. It will then bug out and select both of them when hovered.


https://github.com/ddnet/ddnet/assets/141338449/7bbf0242-abb2-4f4a-8e5b-b2c17eb1ac3c



## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
