### PR TITLE
Fix heap-use-after-free when popup opens another popup

### DIFF
--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -1368,27 +1368,30 @@ void CUI::RenderPopupMenus()
 	for(size_t i = 0; i < m_vPopupMenus.size(); ++i)
 	{
 		const SPopupMenu &PopupMenu = m_vPopupMenus[i];
+		const SPopupMenuId *pID = PopupMenu.m_pID;
 		const bool Inside = MouseInside(&PopupMenu.m_Rect);
 		const bool Active = i == m_vPopupMenus.size() - 1;
 
 		if(Active)
-			SetHotItem(PopupMenu.m_pID);
+			SetHotItem(pID);
 
-		if(CheckActiveItem(PopupMenu.m_pID))
+		if(CheckActiveItem(pID))
 		{
 			if(!MouseButton(0))
 			{
 				if(!Inside)
 				{
-					ClosePopupMenu(PopupMenu.m_pID);
+					ClosePopupMenu(pID);
+					--i;
+					continue;
 				}
 				SetActiveItem(nullptr);
 			}
 		}
-		else if(HotItem() == PopupMenu.m_pID)
+		else if(HotItem() == pID)
 		{
 			if(MouseButton(0))
-				SetActiveItem(PopupMenu.m_pID);
+				SetActiveItem(pID);
 		}
 
 		CUIRect PopupRect = PopupMenu.m_Rect;
@@ -1397,9 +1400,11 @@ void CUI::RenderPopupMenus()
 		PopupRect.Draw(PopupMenu.m_Props.m_BackgroundColor, PopupMenu.m_Props.m_Corners, 3.0f);
 		PopupRect.Margin(SPopupMenu::POPUP_MARGIN, &PopupRect);
 
+		// The popup render function can open/close popups, which may resize the vector and thus
+		// invalidate the variable PopupMenu. We therefore store pID in a separate variable.
 		EPopupMenuFunctionResult Result = PopupMenu.m_pfnFunc(PopupMenu.m_pContext, PopupRect, Active);
 		if(Result != POPUP_KEEP_OPEN || (Active && ConsumeHotkey(HOTKEY_ESCAPE)))
-			ClosePopupMenu(PopupMenu.m_pID, Result == POPUP_CLOSE_CURRENT_AND_DESCENDANTS);
+			ClosePopupMenu(pID, Result == POPUP_CLOSE_CURRENT_AND_DESCENDANTS);
 	}
 }
 


### PR DESCRIPTION
The popup menu render function can open/close other popups, which may resize the vector of popup menus and thus invalidate the current popup menu variable before the popup is closed. We therefore store the popup UI element ID in a separate variable to avoid the access to the potentially invalidated popup menu variable after the popup menu is rendered.

Also prevent invalidated popup menu from being rendered for one frame after it is closed by clicking outside.

Closes #7565.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [X] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
