### PR TITLE
Add OnSnapPlayerScore() controller hook

### DIFF
--- a/src/game/server/gamecontroller.h
+++ b/src/game/server/gamecontroller.h
@@ -115,6 +115,7 @@ public:
 
 	virtual void OnPlayerConnect(class CPlayer *pPlayer);
 	virtual void OnPlayerDisconnect(class CPlayer *pPlayer, const char *pReason);
+	virtual int OnSnapPlayerScore(class CPlayer *pPlayer, int SnappingClient) { return 0; };
 
 	virtual void OnReset();
 

--- a/src/game/server/gamemodes/DDRace.cpp
+++ b/src/game/server/gamemodes/DDRace.cpp
@@ -148,6 +148,34 @@ void CGameControllerDDRace::OnPlayerDisconnect(CPlayer *pPlayer, const char *pRe
 		Teams().SetForceCharacterTeam(ClientID, TEAM_FLOCK);
 }
 
+int CGameControllerDDRace::OnSnapPlayerScore(CPlayer *pPlayer, int SnappingClient)
+{
+	int Score;
+	// This is the time sent to the player while ingame (do not confuse to the one reported to the master server).
+	// Due to clients expecting this as a negative value, we have to make sure it's negative.
+	// Special numbers:
+	// -9999: means no time and isn't displayed in the scoreboard.
+	if(pPlayer->m_Score.has_value())
+	{
+		// shift the time by a second if the player actually took 9999
+		// seconds to finish the map.
+		if(pPlayer->m_Score.value() == 9999)
+			Score = -10000;
+		else
+			Score = -pPlayer->m_Score.value();
+	}
+	else
+	{
+		Score = -9999;
+	}
+
+	// send 0 if times of others are not shown
+	if(SnappingClient != pPlayer->GetCID() && g_Config.m_SvHideScore)
+		Score = -9999;
+
+	return Score;
+}
+
 void CGameControllerDDRace::OnReset()
 {
 	IGameController::OnReset();

--- a/src/game/server/gamemodes/DDRace.h
+++ b/src/game/server/gamemodes/DDRace.h
@@ -16,6 +16,7 @@ public:
 
 	void OnPlayerConnect(class CPlayer *pPlayer) override;
 	void OnPlayerDisconnect(class CPlayer *pPlayer, const char *pReason) override;
+	int OnSnapPlayerScore(class CPlayer *pPlayer, int SnappingClient) override;
 
 	void OnReset() override;
 

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -325,29 +325,7 @@ void CPlayer::Snap(int SnappingClient)
 
 	int SnappingClientVersion = GameServer()->GetClientVersion(SnappingClient);
 	int Latency = SnappingClient == SERVER_DEMO_CLIENT ? m_Latency.m_Min : GameServer()->m_apPlayers[SnappingClient]->m_aCurLatency[m_ClientID];
-
-	int Score;
-	// This is the time sent to the player while ingame (do not confuse to the one reported to the master server).
-	// Due to clients expecting this as a negative value, we have to make sure it's negative.
-	// Special numbers:
-	// -9999: means no time and isn't displayed in the scoreboard.
-	if(m_Score.has_value())
-	{
-		// shift the time by a second if the player actually took 9999
-		// seconds to finish the map.
-		if(m_Score.value() == 9999)
-			Score = -10000;
-		else
-			Score = -m_Score.value();
-	}
-	else
-	{
-		Score = -9999;
-	}
-
-	// send 0 if times of others are not shown
-	if(SnappingClient != m_ClientID && g_Config.m_SvHideScore)
-		Score = -9999;
+	int Score = GameServer()->m_pController->OnSnapPlayerScore(this, SnappingClient);
 
 	if(!Server()->IsSixup(SnappingClient))
 	{


### PR DESCRIPTION
Allow game controllers to implement their own scoring snap. This comes in handy for forks that are not using race times as scores. And want to send their own values.

``sv_gametype ddnet`` still loads scores just fine.

``sv_gametype mod`` shows score 0 at all times.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
