### PR TITLE
Use real ClientID to lookup authed state

### DIFF
--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -379,7 +379,7 @@ void CPlayer::Snap(int SnappingClient)
 			pPlayerInfo->m_PlayerFlags |= protocol7::PLAYERFLAG_ADMIN;
 
 		// Times are in milliseconds for 0.7
-		pPlayerInfo->m_Score = m_Score.has_value() ? GameServer()->Score()->PlayerData(id)->m_BestTime * 1000 : -1;
+		pPlayerInfo->m_Score = m_Score.has_value() ? GameServer()->Score()->PlayerData(m_ClientID)->m_BestTime * 1000 : -1;
 		pPlayerInfo->m_Latency = Latency;
 	}
 
@@ -412,7 +412,7 @@ void CPlayer::Snap(int SnappingClient)
 	if(!pDDNetPlayer)
 		return;
 
-	pDDNetPlayer->m_AuthLevel = Server()->GetAuthedState(id);
+	pDDNetPlayer->m_AuthLevel = Server()->GetAuthedState(m_ClientID);
 	pDDNetPlayer->m_Flags = 0;
 	if(m_Afk)
 		pDDNetPlayer->m_Flags |= EXPLAYERFLAG_AFK;


### PR DESCRIPTION
The variable `Id` is translated for old clients and is not guranteed to be the real id. While `m_ClientID` is the real ID. That can also be used to index the CServer::m_aClients[] array to get the authed state.

closed #7599

Fixes

```
valgrind ./DDNet-Server "dbg_dummies 1"
[..]
2023-12-07 18:01:33 I chat: *** 'Debug dummy 1' entered and joined the
game
==75634== Conditional jump or move depends on uninitialised value(s)
==75634==    at 0x2DAA83: CVariableInt::Pack(unsigned char*, int, int)
(compression.cpp:17)
==75634==    by 0x2DAD79: CVariableInt::Compress(void const*, int,
void*, int) (compression.cpp:98)
==75634==    by 0x23EC50: CServer::DoSnapshot() (server.cpp:1046)
==75634==    by 0x247D2D: CServer::Run() (server.cpp:2994)
==75634==    by 0x230173: main (main.cpp:193)
==75634==
==75634== Conditional jump or move depends on uninitialised value(s)
==75634==    at 0x2DAAF7: CVariableInt::Pack(unsigned char*, int, int)
(compression.cpp:25)
==75634==    by 0x2DAD79: CVariableInt::Compress(void const*, int,
void*, int) (compression.cpp:98)
==75634==    by 0x23EC50: CServer::DoSnapshot() (server.cpp:1046)
==75634==    by 0x247D2D: CServer::Run() (server.cpp:2994)
==75634==    by 0x230173: main (main.cpp:193)
==75634==
==75634== Conditional jump or move depends on uninitialised value(s)
==75634==    at 0x2DAA83: CVariableInt::Pack(unsigned char*, int, int)
(compression.cpp:17)
==75634==    by 0x32E812: CPacker::AddInt(int) (packer.cpp:20)
==75634==    by 0x23ED51: CServer::DoSnapshot() (server.cpp:1059)
==75634==    by 0x247D2D: CServer::Run() (server.cpp:2994)
==75634==    by 0x230173: main (main.cpp:193)
==75634==
==75634== Conditional jump or move depends on uninitialised value(s)
==75634==    at 0x2DAAF7: CVariableInt::Pack(unsigned char*, int, int)
(compression.cpp:25)
==75634==    by 0x32E812: CPacker::AddInt(int) (packer.cpp:20)
==75634==    by 0x23ED51: CServer::DoSnapshot() (server.cpp:1059)
==75634==    by 0x247D2D: CServer::Run() (server.cpp:2994)
==75634==    by 0x230173: main (main.cpp:193)
==75634==
```

Which is using ID 0 as index in the m_aClients array but only ID 63 was ever initialized.

This should also fix wrong tees being marked as admin in the scoreboard.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [x] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
