### PR TITLE
Add compile time errors for unsupported endianness

### DIFF
--- a/src/base/detect.h
+++ b/src/base/detect.h
@@ -195,4 +195,12 @@
 #define CONF_ARCH_STRING "unknown"
 #endif
 
+#if defined(CONF_ARCH_ENDIAN_LITTLE)
+#define CONF_ARCH_ENDIAN_STRING "little endian"
+#elif defined(CONF_ARCH_ENDIAN_BIG)
+#define CONF_ARCH_ENDIAN_STRING "big endian"
+#else
+#error "Unsupported endianness"
+#endif
+
 #endif

--- a/src/engine/shared/engine.cpp
+++ b/src/engine/shared/engine.cpp
@@ -49,15 +49,8 @@ public:
 		str_copy(m_aAppName, pAppname);
 		if(!Test)
 		{
-			//
 			dbg_msg("engine", "running on %s-%s-%s", CONF_FAMILY_STRING, CONF_PLATFORM_STRING, CONF_ARCH_STRING);
-#ifdef CONF_ARCH_ENDIAN_LITTLE
-			dbg_msg("engine", "arch is little endian");
-#elif defined(CONF_ARCH_ENDIAN_BIG)
-			dbg_msg("engine", "arch is big endian");
-#else
-			dbg_msg("engine", "unknown endian");
-#endif
+			dbg_msg("engine", "arch is %s", CONF_ARCH_ENDIAN_STRING);
 
 			char aVersionStr[128];
 			if(os_version_str(aVersionStr, sizeof(aVersionStr)))


### PR DESCRIPTION
We support little and big endian but not PDP endian (Middle-endian).

Define endianness as string `CONF_ARCH_ENDIAN_STRING` to avoid conditional compilation when printing endianness.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
