### PR TITLE
Properly uninitialize network on Windows, add RAII wrapper

### DIFF
--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -2062,8 +2062,25 @@ void net_init()
 {
 #if defined(CONF_FAMILY_WINDOWS)
 	WSADATA wsa_data;
-	dbg_assert(WSAStartup(MAKEWORD(1, 1), &wsa_data) == 0, "network initialization failed.");
+	dbg_assert(WSAStartup(MAKEWORD(1, 1), &wsa_data) == 0, "Network initialization failed");
 #endif
+}
+
+void net_uninit()
+{
+#if defined(CONF_FAMILY_WINDOWS)
+	dbg_assert(WSACleanup() == 0, "Network uninitialization failed");
+#endif
+}
+
+CNetworkBase::CNetworkBase()
+{
+	net_init();
+}
+
+CNetworkBase::~CNetworkBase()
+{
+	net_uninit();
 }
 
 #if defined(CONF_FAMILY_UNIX)

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -791,13 +791,37 @@ typedef struct sockaddr_un UNIXSOCKETADDR;
 #endif
 
 /**
- * Initiates network functionality.
+ * Initializes network functionality.
  *
  * @ingroup Network-General
  *
  * @remark You must call this function before using any other network functions.
+ * @remark Each call to this function must eventually be balanced by a call to
+ * `net_uninit` to uninitialize the network functionality.
  */
 void net_init();
+
+/**
+ * Uninitializes network functionality.
+ *
+ * @ingroup Network-General
+ *
+ * @remark You must call this function once for every previous call to `net_init`.
+ */
+void net_uninit();
+
+/**
+ * This is a RAII wrapper to initialize/uninitialize the network functionality,
+ * i.e. it wraps the `net_init` and `net_uninit` functions.
+ *
+ * @ingroup Network-General
+ */
+class CNetworkBase
+{
+public:
+	CNetworkBase();
+	~CNetworkBase();
+};
 
 /*
 	Function: net_host_lookup

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -4334,6 +4334,8 @@ int main(int argc, const char **argv)
 		// Client will crash due to assertion, don't call PerformAllCleanup in this inconsistent state
 	});
 
+	const CNetworkBase NetworkBase;
+
 	// create the components
 	IEngine *pEngine = CreateEngine(GAME_NAME, pFutureConsoleLogger, 2 * std::thread::hardware_concurrency() + 2);
 	pKernel->RegisterInterface(pEngine, false);

--- a/src/engine/server/main.cpp
+++ b/src/engine/server/main.cpp
@@ -106,6 +106,8 @@ int main(int argc, const char **argv)
 	init_exception_handler();
 #endif
 
+	const CNetworkBase NetworkBase;
+
 	CServer *pServer = CreateServer();
 	pServer->SetLoggers(pFutureFileLogger, std::move(pStdoutLogger));
 

--- a/src/engine/shared/engine.cpp
+++ b/src/engine/shared/engine.cpp
@@ -59,7 +59,6 @@ public:
 			}
 
 			// init the network
-			net_init();
 			CNetBase::Init();
 		}
 

--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -137,7 +137,7 @@ int main(int argc, const char **argv)
 	CCmdlineFix CmdlineFix(&argc, &argv);
 	log_set_global_logger_default();
 	::testing::InitGoogleTest(&argc, const_cast<char **>(argv));
-	net_init();
+	const CNetworkBase NetworkBase;
 	if(secure_random_init())
 	{
 		fprintf(stderr, "random init failed\n");

--- a/src/tools/stun.cpp
+++ b/src/tools/stun.cpp
@@ -21,7 +21,8 @@ int main(int argc, const char **argv)
 		return 2;
 	}
 
-	net_init();
+	const CNetworkBase NetworkBase;
+
 	NETADDR BindAddr;
 	mem_zero(&BindAddr, sizeof(BindAddr));
 	BindAddr.type = NETTYPE_ALL;

--- a/src/tools/twping.cpp
+++ b/src/tools/twping.cpp
@@ -13,8 +13,8 @@ int main(int argc, const char **argv)
 
 	secure_random_init();
 	log_set_global_logger_default();
+	const CNetworkBase NetworkBase;
 
-	net_init();
 	NETADDR BindAddr;
 	mem_zero(&BindAddr, sizeof(BindAddr));
 	BindAddr.type = NETTYPE_ALL;


### PR DESCRIPTION
On Windows, we call `WSAStartup` in `net_init`. According to the [documentation](https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-wsastartup) we should call `WSACleanup` once for every previous successful call to `WSAStartup`.

For this purpose, the function `net_uninit` is added to call `WSACleanup` on Windows. The usage of the `net_init` and `net_uninit` functions is simplified by adding a RAII wrapper for them. The network initialization in client/server is moved from the `CEngine` constructor to the respective client/server `main` functions.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
