### PR TITLE
Reset history entry along with chat input when using Escape

### DIFF
--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -227,7 +227,10 @@ bool CChat::OnInput(const IInput::CEvent &Event)
 		DisableMode();
 		m_pClient->OnRelease();
 		if(g_Config.m_ClChatReset)
+		{
 			m_Input.Clear();
+			m_pHistoryEntry = nullptr;
+		}
 	}
 	else if(Event.m_Flags & IInput::FLAG_PRESS && (Event.m_Key == KEY_RETURN || Event.m_Key == KEY_KP_ENTER))
 	{
@@ -253,7 +256,7 @@ bool CChat::OnInput(const IInput::CEvent &Event)
 				mem_copy(pEntry->m_aText, m_Input.GetString(), m_Input.GetLength() + 1);
 			}
 		}
-		m_pHistoryEntry = 0x0;
+		m_pHistoryEntry = nullptr;
 		DisableMode();
 		m_pClient->OnRelease();
 		m_Input.Clear();


### PR DESCRIPTION
Moved reseting chat input history entry to `DisableMode()`. Currently it is not being reset when pressing Escape, which I believe is not intended.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
