### PR TITLE
Make less headers depend on `<base/system.h>`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2157,6 +2157,7 @@ if(CLIENT)
     updater.h
     video.cpp
     video.h
+    warning.cpp
   )
   set_src(GAME_CLIENT GLOB_RECURSE src/game/client
     animstate.cpp

--- a/datasrc/network.py
+++ b/datasrc/network.py
@@ -51,6 +51,7 @@ Authed = ["NO", "HELPER", "MOD", "ADMIN"]
 EntityClasses = ["PROJECTILE", "DOOR", "DRAGGER_WEAK", "DRAGGER_NORMAL", "DRAGGER_STRONG", "GUN_NORMAL", "GUN_EXPLOSIVE", "GUN_FREEZE", "GUN_UNFREEZE", "LIGHT", "PICKUP"]
 
 RawHeader = '''
+#include <base/system.h>
 #include <engine/shared/teehistorian_ex.h>
 
 enum

--- a/src/antibot/antibot_data.h
+++ b/src/antibot/antibot_data.h
@@ -1,7 +1,6 @@
 #ifndef ANTIBOT_ANTIBOT_DATA_H
 #define ANTIBOT_ANTIBOT_DATA_H
 
-#include <base/system.h>
 #include <base/vmath.h>
 
 enum

--- a/src/base/hash_ctxt.h
+++ b/src/base/hash_ctxt.h
@@ -2,7 +2,6 @@
 #define BASE_HASH_CTXT_H
 
 #include "hash.h"
-#include "system.h"
 #include <cstdint>
 
 #if defined(CONF_OPENSSL)

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -9,6 +9,7 @@
 #define BASE_SYSTEM_H
 
 #include "detect.h"
+#include "types.h"
 
 #ifndef __USE_GNU
 #define __USE_GNU
@@ -226,11 +227,7 @@ enum
 	IOSEEK_START = 0,
 	IOSEEK_CUR = 1,
 	IOSEEK_END = 2,
-
-	IO_MAX_PATH_LENGTH = 512,
 };
-
-typedef void *IOHANDLE;
 
 /**
  * Opens a file.
@@ -741,43 +738,11 @@ ETimeSeason time_season();
  * @defgroup Network-General
  */
 
-/**
- * @ingroup Network-General
- */
-typedef struct NETSOCKET_INTERNAL *NETSOCKET;
-
-/**
- * @ingroup Network-General
- */
-enum
-{
-	NETADDR_MAXSTRSIZE = 1 + (8 * 4 + 7) + 1 + 1 + 5 + 1, // [XXXX:XXXX:XXXX:XXXX:XXXX:XXXX:XXXX:XXXX]:XXXXX
-
-	NETTYPE_LINK_BROADCAST = 4,
-
-	NETTYPE_INVALID = 0,
-	NETTYPE_IPV4 = 1,
-	NETTYPE_IPV6 = 2,
-	NETTYPE_WEBSOCKET_IPV4 = 8,
-
-	NETTYPE_ALL = NETTYPE_IPV4 | NETTYPE_IPV6 | NETTYPE_WEBSOCKET_IPV4,
-	NETTYPE_MASK = NETTYPE_ALL | NETTYPE_LINK_BROADCAST,
-};
-
-/**
- * @ingroup Network-General
- */
-typedef struct NETADDR
-{
-	unsigned int type;
-	unsigned char ip[16];
-	unsigned short port;
-
-	bool operator==(const NETADDR &other) const;
-	bool operator!=(const NETADDR &other) const { return !(*this == other); }
-} NETADDR;
-
 extern const NETADDR NETADDR_ZEROED;
+
+/**
+ * @ingroup Network-General
+ */
 
 #ifdef CONF_FAMILY_UNIX
 /**
@@ -1810,15 +1775,7 @@ void str_escape(char **dst, const char *src, const char *end);
  *
  * @remark The strings are treated as zero-terminated strings.
  */
-typedef int (*FS_LISTDIR_CALLBACK)(const char *name, int is_dir, int dir_type, void *user);
 void fs_listdir(const char *dir, FS_LISTDIR_CALLBACK cb, int type, void *user);
-
-typedef struct
-{
-	const char *m_pName;
-	time_t m_TimeCreated; // seconds since UNIX Epoch
-	time_t m_TimeModified; // seconds since UNIX Epoch
-} CFsFileInfo;
 
 /**
  * Lists the files and folders in a directory and gets additional file information.
@@ -1832,7 +1789,6 @@ typedef struct
  *
  * @remark The strings are treated as zero-terminated strings.
  */
-typedef int (*FS_LISTDIR_CALLBACK_FILEINFO)(const CFsFileInfo *info, int is_dir, int dir_type, void *user);
 void fs_listdir_fileinfo(const char *dir, FS_LISTDIR_CALLBACK_FILEINFO cb, int type, void *user);
 
 /**
@@ -2182,14 +2138,6 @@ int str_isallnum(const char *str);
 int str_isallnum_hex(const char *str);
 
 unsigned str_quickhash(const char *str);
-
-enum
-{
-	/**
-	 * The maximum bytes necessary to encode one Unicode codepoint with UTF-8.
-	 */
-	UTF8_BYTE_LENGTH = 4,
-};
 
 int str_utf8_to_skeleton(const char *str, int *buf, int buf_len);
 

--- a/src/base/types.h
+++ b/src/base/types.h
@@ -1,6 +1,8 @@
 #ifndef BASE_TYPES_H
 #define BASE_TYPES_H
 
+#include <ctime>
+
 enum class TRISTATE
 {
 	NONE,
@@ -8,4 +10,56 @@ enum class TRISTATE
 	ALL,
 };
 
+typedef void *IOHANDLE;
+
+typedef int (*FS_LISTDIR_CALLBACK)(const char *name, int is_dir, int dir_type, void *user);
+
+typedef struct
+{
+	const char *m_pName;
+	time_t m_TimeCreated; // seconds since UNIX Epoch
+	time_t m_TimeModified; // seconds since UNIX Epoch
+} CFsFileInfo;
+
+typedef int (*FS_LISTDIR_CALLBACK_FILEINFO)(const CFsFileInfo *info, int is_dir, int dir_type, void *user);
+
+/**
+ * @ingroup Network-General
+ */
+typedef struct NETSOCKET_INTERNAL *NETSOCKET;
+
+enum
+{
+	/**
+	 * The maximum bytes necessary to encode one Unicode codepoint with UTF-8.
+	 */
+	UTF8_BYTE_LENGTH = 4,
+
+	IO_MAX_PATH_LENGTH = 512,
+
+	NETADDR_MAXSTRSIZE = 1 + (8 * 4 + 7) + 1 + 1 + 5 + 1, // [XXXX:XXXX:XXXX:XXXX:XXXX:XXXX:XXXX:XXXX]:XXXXX
+
+	NETTYPE_LINK_BROADCAST = 4,
+
+	NETTYPE_INVALID = 0,
+	NETTYPE_IPV4 = 1,
+	NETTYPE_IPV6 = 2,
+	NETTYPE_WEBSOCKET_IPV4 = 8,
+
+	NETTYPE_ALL = NETTYPE_IPV4 | NETTYPE_IPV6 | NETTYPE_WEBSOCKET_IPV4,
+	NETTYPE_MASK = NETTYPE_ALL | NETTYPE_LINK_BROADCAST,
+};
+
+/**
+ * @ingroup Network-General
+ */
+typedef struct NETADDR
+{
+	unsigned int type;
+	unsigned char ip[16];
+	unsigned short port;
+
+	bool operator==(const NETADDR &other) const;
+	bool operator!=(const NETADDR &other) const { return !(*this == other); }
+} NETADDR;
 #endif // BASE_TYPES_H

--- a/src/engine/client/backend/backend_base.cpp
+++ b/src/engine/client/backend/backend_base.cpp
@@ -1,4 +1,5 @@
 #include "backend_base.h"
+#include <base/system.h>
 #include <engine/gfx/image_manipulation.h>
 
 void *CCommandProcessorFragment_GLBase::Resize(const unsigned char *pData, int Width, int Height, int NewWidth, int NewHeight, int BPP)

--- a/src/engine/client/favorites.cpp
+++ b/src/engine/client/favorites.cpp
@@ -1,3 +1,4 @@
+#include <base/system.h>
 #include <engine/favorites.h>
 #include <engine/shared/config.h>
 #include <engine/shared/protocol.h>

--- a/src/engine/client/ghost.h
+++ b/src/engine/client/ghost.h
@@ -3,6 +3,8 @@
 
 #include <engine/ghost.h>
 
+#include <base/system.h>
+
 enum
 {
 	MAX_ITEM_SIZE = 128,

--- a/src/engine/client/graphics_threaded.h
+++ b/src/engine/client/graphics_threaded.h
@@ -1,6 +1,7 @@
 #ifndef ENGINE_CLIENT_GRAPHICS_THREADED_H
 #define ENGINE_CLIENT_GRAPHICS_THREADED_H
 
+#include <base/system.h>
 #include <engine/graphics.h>
 #include <engine/shared/config.h>
 

--- a/src/engine/client/serverbrowser_http.h
+++ b/src/engine/client/serverbrowser_http.h
@@ -1,6 +1,6 @@
 #ifndef ENGINE_CLIENT_SERVERBROWSER_HTTP_H
 #define ENGINE_CLIENT_SERVERBROWSER_HTTP_H
-#include <base/system.h>
+#include <base/types.h>
 
 class CServerInfo;
 class IConsole;

--- a/src/engine/client/serverbrowser_ping_cache.cpp
+++ b/src/engine/client/serverbrowser_ping_cache.cpp
@@ -1,5 +1,6 @@
 #include "serverbrowser_ping_cache.h"
 
+#include <base/system.h>
 #include <engine/console.h>
 #include <engine/sqlite.h>
 

--- a/src/engine/client/serverbrowser_ping_cache.h
+++ b/src/engine/client/serverbrowser_ping_cache.h
@@ -1,6 +1,6 @@
 #ifndef ENGINE_CLIENT_SERVERBROWSER_PING_CACHE_H
 #define ENGINE_CLIENT_SERVERBROWSER_PING_CACHE_H
-#include <base/system.h>
+#include <base/types.h>
 
 class IConsole;
 class IStorage;

--- a/src/engine/client/steam.cpp
+++ b/src/engine/client/steam.cpp
@@ -1,5 +1,6 @@
 #include <engine/steam.h>
 
+#include <base/system.h>
 #include <engine/shared/config.h>
 
 #include <steam/steam_api_flat.h>

--- a/src/engine/client/video.h
+++ b/src/engine/client/video.h
@@ -2,7 +2,6 @@
 #define ENGINE_CLIENT_VIDEO_H
 
 #include <base/lock.h>
-#include <base/system.h>
 
 extern "C" {
 #include <libavcodec/avcodec.h>

--- a/src/engine/client/warning.cpp
+++ b/src/engine/client/warning.cpp
@@ -1,0 +1,14 @@
+#include <engine/warning.h>
+
+#include <base/system.h>
+
+SWarning::SWarning(const char *pMsg)
+{
+	str_copy(m_aWarningTitle, "");
+	str_copy(m_aWarningMsg, pMsg);
+}
+SWarning::SWarning(const char *pTitle, const char *pMsg)
+{
+	str_copy(m_aWarningTitle, pTitle);
+	str_copy(m_aWarningMsg, pMsg);
+}

--- a/src/engine/demo.h
+++ b/src/engine/demo.h
@@ -8,6 +8,8 @@
 #include <engine/map.h>
 #include <engine/shared/uuid_manager.h>
 
+#include <cstdint>
+
 enum
 {
 	MAX_TIMELINE_MARKERS = 64
@@ -37,15 +39,7 @@ struct CDemoHeader
 	unsigned char m_aLength[sizeof(int32_t)];
 	char m_aTimestamp[20];
 
-	bool Valid() const
-	{
-		// Check marker and ensure that strings are zero-terminated and valid UTF-8.
-		return mem_comp(m_aMarker, gs_aHeaderMarker, sizeof(gs_aHeaderMarker)) == 0 &&
-		       mem_has_null(m_aNetversion, sizeof(m_aNetversion)) && str_utf8_check(m_aNetversion) &&
-		       mem_has_null(m_aMapName, sizeof(m_aMapName)) && str_utf8_check(m_aMapName) &&
-		       mem_has_null(m_aType, sizeof(m_aType)) && str_utf8_check(m_aType) &&
-		       mem_has_null(m_aTimestamp, sizeof(m_aTimestamp)) && str_utf8_check(m_aTimestamp);
-	}
+	bool Valid() const;
 };
 
 struct CTimelineMarkers

--- a/src/engine/discord.h
+++ b/src/engine/discord.h
@@ -2,6 +2,7 @@
 #define ENGINE_DISCORD_H
 
 #include "kernel.h"
+#include <base/types.h>
 
 class IDiscord : public IInterface
 {

--- a/src/engine/graphics.h
+++ b/src/engine/graphics.h
@@ -7,6 +7,7 @@
 #include "warning.h"
 
 #include <base/color.h>
+#include <base/system.h>
 
 #include <cstddef>
 #include <cstdint>

--- a/src/engine/input.h
+++ b/src/engine/input.h
@@ -4,6 +4,7 @@
 #define ENGINE_INPUT_H
 
 #include "kernel.h"
+#include <base/system.h>
 
 const int g_MaxKeys = 512;
 extern const char g_aaKeyStrings[g_MaxKeys][20];

--- a/src/engine/kernel.h
+++ b/src/engine/kernel.h
@@ -3,8 +3,6 @@
 #ifndef ENGINE_KERNEL_H
 #define ENGINE_KERNEL_H
 
-#include <base/system.h>
-
 class IKernel;
 class IInterface;
 

--- a/src/engine/map.h
+++ b/src/engine/map.h
@@ -5,6 +5,7 @@
 
 #include "kernel.h"
 #include <base/hash.h>
+#include <base/types.h>
 
 enum
 {

--- a/src/engine/server/databases/connection.cpp
+++ b/src/engine/server/databases/connection.cpp
@@ -2,6 +2,11 @@
 
 #include <engine/shared/protocol.h>
 
+IDbConnection::IDbConnection(const char *pPrefix)
+{
+	str_copy(m_aPrefix, pPrefix);
+}
+
 void IDbConnection::FormatCreateRace(char *aBuf, unsigned int BufferSize, bool Backup)
 {
 	str_format(aBuf, BufferSize,

--- a/src/engine/server/databases/connection.h
+++ b/src/engine/server/databases/connection.h
@@ -2,7 +2,6 @@
 #define ENGINE_SERVER_DATABASES_CONNECTION_H
 
 #include "connection_pool.h"
-#include <base/system.h>
 
 #include <memory>
 
@@ -12,10 +11,7 @@ class IConsole;
 class IDbConnection
 {
 public:
-	IDbConnection(const char *pPrefix)
-	{
-		str_copy(m_aPrefix, pPrefix);
-	}
+	IDbConnection(const char *pPrefix);
 	virtual ~IDbConnection() {}
 	IDbConnection &operator=(const IDbConnection &) = delete;
 	virtual void Print(IConsole *pConsole, const char *pMode) = 0;

--- a/src/engine/server/upnp.h
+++ b/src/engine/server/upnp.h
@@ -1,7 +1,7 @@
 #ifndef ENGINE_SERVER_UPNP_H
 #define ENGINE_SERVER_UPNP_H
 
-#include <base/system.h>
+#include <base/types.h>
 class CUPnP
 {
 	NETADDR m_Addr;

--- a/src/engine/serverbrowser.h
+++ b/src/engine/serverbrowser.h
@@ -4,7 +4,7 @@
 #define ENGINE_SERVERBROWSER_H
 
 #include <base/hash.h>
-#include <base/types.h>
+#include <base/system.h>
 
 #include <engine/map.h>
 #include <engine/shared/protocol.h>

--- a/src/engine/shared/console.h
+++ b/src/engine/shared/console.h
@@ -5,6 +5,7 @@
 
 #include "memheap.h"
 #include <base/math.h>
+#include <base/system.h>
 #include <engine/console.h>
 #include <engine/storage.h>
 

--- a/src/engine/shared/csv.cpp
+++ b/src/engine/shared/csv.cpp
@@ -1,5 +1,7 @@
 #include "csv.h"
 
+#include <base/system.h>
+
 void CsvWrite(IOHANDLE File, int NumColumns, const char *const *ppColumns)
 {
 	for(int i = 0; i < NumColumns; i++)

--- a/src/engine/shared/csv.h
+++ b/src/engine/shared/csv.h
@@ -1,7 +1,7 @@
 #ifndef ENGINE_SHARED_CSV_H
 #define ENGINE_SHARED_CSV_H
 
-#include <base/system.h>
+#include <base/types.h>
 
 void CsvWrite(IOHANDLE File, int NumColumns, const char *const *ppColumns);
 

--- a/src/engine/shared/datafile.h
+++ b/src/engine/shared/datafile.h
@@ -6,7 +6,7 @@
 #include <engine/storage.h>
 
 #include <base/hash.h>
-#include <base/system.h>
+#include <base/types.h>
 
 #include <array>
 #include <vector>

--- a/src/engine/shared/demo.cpp
+++ b/src/engine/shared/demo.cpp
@@ -31,6 +31,16 @@ static const int gs_NumMarkersOffset = 176;
 
 static const ColorRGBA gs_DemoPrintColor{0.75f, 0.7f, 0.7f, 1.0f};
 
+bool CDemoHeader::Valid() const
+{
+	// Check marker and ensure that strings are zero-terminated and valid UTF-8.
+	return mem_comp(m_aMarker, gs_aHeaderMarker, sizeof(gs_aHeaderMarker)) == 0 &&
+	       mem_has_null(m_aNetversion, sizeof(m_aNetversion)) && str_utf8_check(m_aNetversion) &&
+	       mem_has_null(m_aMapName, sizeof(m_aMapName)) && str_utf8_check(m_aMapName) &&
+	       mem_has_null(m_aType, sizeof(m_aType)) && str_utf8_check(m_aType) &&
+	       mem_has_null(m_aTimestamp, sizeof(m_aTimestamp)) && str_utf8_check(m_aTimestamp);
+}
+
 CDemoRecorder::CDemoRecorder(class CSnapshotDelta *pSnapshotDelta, bool NoMapData)
 {
 	m_File = 0;

--- a/src/engine/shared/fifo.h
+++ b/src/engine/shared/fifo.h
@@ -1,6 +1,7 @@
 #ifndef ENGINE_SHARED_FIFO_H
 #define ENGINE_SHARED_FIFO_H
 
+#include <base/detect.h>
 #include <engine/console.h>
 
 class CFifo

--- a/src/engine/shared/filecollection.cpp
+++ b/src/engine/shared/filecollection.cpp
@@ -2,6 +2,7 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 
 #include <base/math.h>
+#include <base/system.h>
 
 #include <engine/storage.h>
 

--- a/src/engine/shared/filecollection.h
+++ b/src/engine/shared/filecollection.h
@@ -3,7 +3,7 @@
 #ifndef ENGINE_SHARED_FILECOLLECTION_H
 #define ENGINE_SHARED_FILECOLLECTION_H
 
-#include <base/system.h>
+#include <base/types.h>
 
 #include <cstdint>
 

--- a/src/engine/shared/jsonwriter.cpp
+++ b/src/engine/shared/jsonwriter.cpp
@@ -3,6 +3,8 @@
 
 #include "jsonwriter.h"
 
+#include <base/system.h>
+
 static char EscapeJsonChar(char c)
 {
 	switch(c)

--- a/src/engine/shared/jsonwriter.h
+++ b/src/engine/shared/jsonwriter.h
@@ -3,9 +3,10 @@
 #ifndef ENGINE_SHARED_JSONWRITER_H
 #define ENGINE_SHARED_JSONWRITER_H
 
-#include <base/system.h>
+#include <base/types.h>
 
 #include <stack>
+#include <string>
 
 /**
  * JSON writer with abstract writing function.

--- a/src/engine/shared/linereader.cpp
+++ b/src/engine/shared/linereader.cpp
@@ -2,6 +2,8 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include "linereader.h"
 
+#include <base/system.h>
+
 void CLineReader::Init(IOHANDLE File)
 {
 	m_BufferMaxSize = sizeof(m_aBuffer) - 1;

--- a/src/engine/shared/linereader.h
+++ b/src/engine/shared/linereader.h
@@ -2,7 +2,7 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #ifndef ENGINE_SHARED_LINEREADER_H
 #define ENGINE_SHARED_LINEREADER_H
-#include <base/system.h>
+#include <base/types.h>
 
 // buffered stream for reading lines, should perhaps be something smaller
 class CLineReader

--- a/src/engine/shared/map.h
+++ b/src/engine/shared/map.h
@@ -3,7 +3,7 @@
 #ifndef ENGINE_SHARED_MAP_H
 #define ENGINE_SHARED_MAP_H
 
-#include <base/system.h>
+#include <base/types.h>
 
 #include "datafile.h"
 #include <engine/map.h>

--- a/src/engine/shared/netban.h
+++ b/src/engine/shared/netban.h
@@ -1,9 +1,8 @@
 #ifndef ENGINE_SHARED_NETBAN_H
 #define ENGINE_SHARED_NETBAN_H
 
-#include <engine/console.h>
-
 #include <base/system.h>
+#include <engine/console.h>
 
 inline int NetComp(const NETADDR *pAddr1, const NETADDR *pAddr2)
 {

--- a/src/engine/shared/protocol_ex.cpp
+++ b/src/engine/shared/protocol_ex.cpp
@@ -3,6 +3,7 @@
 #include "config.h"
 #include "uuid_manager.h"
 
+#include <base/system.h>
 #include <engine/message.h>
 
 #include <new>

--- a/src/engine/shared/serverinfo.cpp
+++ b/src/engine/shared/serverinfo.cpp
@@ -2,6 +2,7 @@
 
 #include "json.h"
 #include <base/math.h>
+#include <base/system.h>
 #include <engine/external/json-parser/json.h>
 
 #include <cstdio>

--- a/src/engine/shared/uuid_manager.cpp
+++ b/src/engine/shared/uuid_manager.cpp
@@ -1,6 +1,7 @@
 #include "uuid_manager.h"
 
 #include <base/hash_ctxt.h>
+#include <base/system.h>
 #include <engine/shared/packer.h>
 
 #include <algorithm>
@@ -98,6 +99,11 @@ bool CUuid::operator==(const CUuid &Other) const
 bool CUuid::operator!=(const CUuid &Other) const
 {
 	return !(*this == Other);
+}
+
+bool CUuid::operator<(const CUuid &Other) const
+{
+	return mem_comp(this, &Other, sizeof(*this)) < 0;
 }
 
 static int GetIndex(int ID)

--- a/src/engine/shared/uuid_manager.h
+++ b/src/engine/shared/uuid_manager.h
@@ -3,8 +3,6 @@
 
 #include <vector>
 
-#include <base/system.h>
-
 enum
 {
 	UUID_MAXSTRSIZE = 37, // 12345678-0123-5678-0123-567890123456
@@ -21,7 +19,7 @@ struct CUuid
 
 	bool operator==(const CUuid &Other) const;
 	bool operator!=(const CUuid &Other) const;
-	bool operator<(const CUuid &Other) const { return mem_comp(m_aData, Other.m_aData, sizeof(m_aData)) < 0; }
+	bool operator<(const CUuid &Other) const;
 };
 
 extern const CUuid UUID_ZEROED;

--- a/src/engine/steam.h
+++ b/src/engine/steam.h
@@ -1,6 +1,8 @@
 #ifndef ENGINE_STEAM_H
 #define ENGINE_STEAM_H
 
+#include <base/types.h>
+
 #include "kernel.h"
 
 class ISteam : public IInterface

--- a/src/engine/storage.h
+++ b/src/engine/storage.h
@@ -4,6 +4,7 @@
 #define ENGINE_STORAGE_H
 
 #include <base/hash.h>
+#include <base/types.h>
 
 #include "kernel.h"
 

--- a/src/engine/warning.h
+++ b/src/engine/warning.h
@@ -3,17 +3,10 @@
 
 struct SWarning
 {
-	SWarning() {}
-	SWarning(const char *pMsg)
-	{
-		str_copy(m_aWarningTitle, "");
-		str_copy(m_aWarningMsg, pMsg);
-	}
-	SWarning(const char *pTitle, const char *pMsg)
-	{
-		str_copy(m_aWarningTitle, pTitle);
-		str_copy(m_aWarningMsg, pMsg);
-	}
+	SWarning() = default;
+	SWarning(const char *pMsg);
+	SWarning(const char *pTitle, const char *pMsg);
+
 	char m_aWarningTitle[128];
 	char m_aWarningMsg[256];
 	bool m_WasShown = false;

--- a/src/game/client/components/voting.h
+++ b/src/game/client/components/voting.h
@@ -3,8 +3,6 @@
 #ifndef GAME_CLIENT_COMPONENTS_VOTING_H
 #define GAME_CLIENT_COMPONENTS_VOTING_H
 
-#include <base/system.h>
-
 #include <engine/console.h>
 #include <engine/shared/memheap.h>
 

--- a/src/game/editor/mapitems/sound.h
+++ b/src/game/editor/mapitems/sound.h
@@ -1,8 +1,7 @@
 #ifndef GAME_EDITOR_MAPITEMS_SOUND_H
 #define GAME_EDITOR_MAPITEMS_SOUND_H
 
-#include <base/system.h>
-
+#include <base/types.h>
 #include <game/editor/component.h>
 
 class CEditorSound : public CEditorComponent

--- a/src/game/gamecore.h
+++ b/src/game/gamecore.h
@@ -3,7 +3,6 @@
 #ifndef GAME_GAMECORE_H
 #define GAME_GAMECORE_H
 
-#include <base/system.h>
 #include <base/vmath.h>
 
 #include <map>
@@ -191,7 +190,10 @@ class CWorldCore
 public:
 	CWorldCore()
 	{
-		mem_zero(m_apCharacters, sizeof(m_apCharacters));
+		for(auto &pCharacter : m_apCharacters)
+		{
+			pCharacter = nullptr;
+		}
 		m_pPrng = nullptr;
 	}
 

--- a/src/game/teamscore.cpp
+++ b/src/game/teamscore.cpp
@@ -1,5 +1,6 @@
 /* (c) Shereef Marzouk. See "licence DDRace.txt" and the readme.txt in the root of the distribution for more information. */
 #include "teamscore.h"
+#include <base/system.h>
 #include <engine/shared/config.h>
 
 CTeamsCore::CTeamsCore()

--- a/src/test/csv.cpp
+++ b/src/test/csv.cpp
@@ -1,6 +1,7 @@
 #include "test.h"
 #include <gtest/gtest.h>
 
+#include <base/system.h>
 #include <engine/shared/csv.h>
 
 static void Expect(int NumColumns, const char *const *ppColumns, const char *pExpected)

--- a/src/test/jsonwriter.cpp
+++ b/src/test/jsonwriter.cpp
@@ -3,6 +3,7 @@
 #include "test.h"
 #include <gtest/gtest.h>
 
+#include <base/system.h>
 #include <engine/shared/jsonwriter.h>
 
 #include <climits>

--- a/src/test/linereader.cpp
+++ b/src/test/linereader.cpp
@@ -1,6 +1,7 @@
 #include "test.h"
 #include <gtest/gtest.h>
 
+#include <base/system.h>
 #include <engine/shared/linereader.h>
 
 void TestFileLineReader(const char *pWritten, bool SkipBom, std::initializer_list<const char *> pReads)

--- a/src/tools/uuid.cpp
+++ b/src/tools/uuid.cpp
@@ -1,4 +1,5 @@
 #include <base/logger.h>
+#include <base/system.h>
 #include <engine/shared/uuid_manager.h>
 int main(int argc, const char **argv)
 {


### PR DESCRIPTION
Move a couple of trivial type definitions to `<base/types.h>` instead.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
