### PR TITLE
Avoid using console to reset game settings

### DIFF
--- a/src/engine/shared/config.cpp
+++ b/src/engine/shared/config.cpp
@@ -156,7 +156,7 @@ struct SIntConfigVariable : public SConfigVariable
 
 	void ResetToOld() override
 	{
-		SetValue(m_OldValue);
+		*m_pVariable = m_OldValue;
 	}
 };
 
@@ -257,7 +257,7 @@ struct SColorConfigVariable : public SConfigVariable
 
 	void ResetToOld() override
 	{
-		SetValue(m_OldValue);
+		*m_pVariable = m_OldValue;
 	}
 };
 
@@ -362,7 +362,7 @@ struct SStringConfigVariable : public SConfigVariable
 
 	void ResetToOld() override
 	{
-		SetValue(m_pOldValue);
+		str_copy(m_pStr, m_pOldValue, m_MaxSize);
 	}
 };
 


### PR DESCRIPTION
Prevent potential dead lock when using `/map` chat command in combination with Teehistorian. Closes #7619. I could not reproduce the issue on Windows though.

This also means resetting game settings should actually be efficient now, because it only involves iterating over all game settings and directly resetting their value.

## Checklist

- [X] Tested the change ingame (but could not reproduce the dead-lock on Windows)
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
