### PR TITLE
Consistent rounding of editor value/color picker buttons

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -442,7 +442,7 @@ SEditResult<int> CEditor::UiDoValueSelector(void *pID, CUIRect *pRect, const cha
 			str_format(aBuf, sizeof(aBuf), "#%06X", Current);
 		else
 			str_from_int(Current, aBuf);
-		pRect->Draw(pColor ? *pColor : GetButtonColor(pID, 0), Corners, 5.0f);
+		pRect->Draw(pColor ? *pColor : GetButtonColor(pID, 0), Corners, 3.0f);
 		UI()->DoLabel(pRect, aBuf, 10, TEXTALIGN_MC);
 	}
 
@@ -3106,9 +3106,9 @@ void CEditor::SetHotQuadPoint(const std::shared_ptr<CLayerQuads> &pLayer)
 void CEditor::DoColorPickerButton(const void *pID, const CUIRect *pRect, ColorRGBA Color, const std::function<void(ColorRGBA Color)> &SetColor)
 {
 	CUIRect ColorRect;
-	pRect->Draw(ColorRGBA(1.0f, 1.0f, 1.0f, 0.5f * UI()->ButtonColorMul(pID)), IGraphics::CORNER_ALL, 5.0f);
+	pRect->Draw(ColorRGBA(1.0f, 1.0f, 1.0f, 0.5f * UI()->ButtonColorMul(pID)), IGraphics::CORNER_ALL, 3.0f);
 	pRect->Margin(1.0f, &ColorRect);
-	ColorRect.Draw(Color, IGraphics::CORNER_ALL, 5.0f);
+	ColorRect.Draw(Color, IGraphics::CORNER_ALL, 3.0f);
 
 	const int ButtonResult = DoButton_Editor_Common(pID, nullptr, 0, pRect, 0, "Click to show the color picker. Shift+rightclick to copy color to clipboard. Shift+leftclick to paste color from clipboard.");
 	if(Input()->ShiftIsPressed())


### PR DESCRIPTION
Fix too large rounding for some editor color picker buttons.

Screenshots (the color has alpha=100, so the incorrect border is visible in the before screenshot):
- Before:
![screenshot_2023-12-10_11-43-00](https://github.com/ddnet/ddnet/assets/23437060/6f2116cd-da3c-42df-9313-3d7c2aad6cdd)
- After:
![screenshot_2023-12-10_11-43-53](https://github.com/ddnet/ddnet/assets/23437060/10d79ba0-bef4-4b5a-8b41-79e28fcc0eb9)

## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
