### PR TITLE
Fix editor modified state not being updated properly

### DIFF
--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -1178,7 +1178,7 @@ void CChat::OnRender()
 
 		m_Input.Activate(EInputPriority::CHAT); // Ensure that the input is active
 		const CUIRect InputCursorRect = {Cursor.m_X, Cursor.m_Y - ScrollOffset, 0.0f, 0.0f};
-		const STextBoundingBox BoundingBox = m_Input.Render(&InputCursorRect, Cursor.m_FontSize, TEXTALIGN_TL, m_Input.WasChanged(), MessageMaxWidth, 0.0f);
+		const STextBoundingBox BoundingBox = m_Input.Render(&InputCursorRect, Cursor.m_FontSize, TEXTALIGN_TL, m_Input.WasCursorChanged(), MessageMaxWidth, 0.0f);
 
 		Graphics()->ClipDisable();
 

--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -767,7 +767,7 @@ void CGameConsole::OnRender()
 		pConsole->m_Input.SetHidden(m_ConsoleType == CONSOLETYPE_REMOTE && Client()->State() == IClient::STATE_ONLINE && !Client()->RconAuthed() && (pConsole->m_UserGot || !pConsole->m_UsernameReq));
 		pConsole->m_Input.Activate(EInputPriority::CONSOLE); // Ensure that the input is active
 		const CUIRect InputCursorRect = {x, y + FONT_SIZE, 0.0f, 0.0f};
-		pConsole->m_BoundingBox = pConsole->m_Input.Render(&InputCursorRect, FONT_SIZE, TEXTALIGN_BL, pConsole->m_Input.WasChanged(), Screen.w - 10.0f - x, LINE_SPACING);
+		pConsole->m_BoundingBox = pConsole->m_Input.Render(&InputCursorRect, FONT_SIZE, TEXTALIGN_BL, pConsole->m_Input.WasCursorChanged(), Screen.w - 10.0f - x, LINE_SPACING);
 		if(pConsole->m_LastInputHeight == 0.0f && pConsole->m_BoundingBox.m_H != 0.0f)
 			pConsole->m_LastInputHeight = pConsole->m_BoundingBox.m_H;
 		if(pConsole->m_Input.HasSelection())

--- a/src/game/client/lineinput.cpp
+++ b/src/game/client/lineinput.cpp
@@ -86,6 +86,7 @@ void CLineInput::SetRange(const char *pString, size_t Begin, size_t End)
 		m_Len += AddedCharSize - RemovedCharSize;
 		m_NumChars += AddedCharCount - RemovedCharCount;
 		m_WasChanged = true;
+		m_WasCursorChanged = true;
 		m_pStr[m_Len] = '\0';
 		m_SelectionStart = m_SelectionEnd = m_CursorPos;
 	}
@@ -158,7 +159,7 @@ void CLineInput::MoveCursor(EMoveDirection Direction, bool MoveWord, const char 
 void CLineInput::SetCursorOffset(size_t Offset)
 {
 	m_SelectionStart = m_SelectionEnd = m_LastCompositionCursorPos = m_CursorPos = clamp<size_t>(Offset, 0, m_Len);
-	m_WasChanged = true;
+	m_WasCursorChanged = true;
 }
 
 void CLineInput::SetSelection(size_t Start, size_t End)
@@ -168,7 +169,7 @@ void CLineInput::SetSelection(size_t Start, size_t End)
 		std::swap(Start, End);
 	m_SelectionStart = clamp<size_t>(Start, 0, m_Len);
 	m_SelectionEnd = clamp<size_t>(End, 0, m_Len);
-	m_WasChanged = true;
+	m_WasCursorChanged = true;
 }
 
 size_t CLineInput::OffsetFromActualToDisplay(size_t ActualOffset)
@@ -383,9 +384,9 @@ bool CLineInput::ProcessInput(const IInput::CEvent &Event)
 		}
 	}
 
-	m_WasChanged |= OldCursorPos != m_CursorPos;
+	m_WasCursorChanged |= OldCursorPos != m_CursorPos;
 	m_WasChanged |= SelectionLength != GetSelectionLength();
-	return m_WasChanged || KeyHandled;
+	return m_WasChanged || m_WasCursorChanged || KeyHandled;
 }
 
 STextBoundingBox CLineInput::Render(const CUIRect *pRect, float FontSize, int Align, bool Changed, float LineWidth, float LineSpacing)

--- a/src/game/client/lineinput.h
+++ b/src/game/client/lineinput.h
@@ -77,6 +77,7 @@ private:
 	FDisplayTextCallback m_pfnDisplayTextCallback;
 	FCalculateOffsetCallback m_pfnCalculateOffsetCallback;
 	bool m_WasChanged;
+	bool m_WasCursorChanged;
 	bool m_WasRendered;
 
 	char m_ClearButtonId;
@@ -177,6 +178,12 @@ public:
 	{
 		const bool Changed = m_WasChanged;
 		m_WasChanged = false;
+		return Changed;
+	}
+	bool WasCursorChanged()
+	{
+		const bool Changed = m_WasCursorChanged;
+		m_WasCursorChanged = false;
 		return Changed;
 	}
 

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -5674,6 +5674,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 				if(m_SelectedEnvelope >= (int)m_Map.m_vpEnvelopes.size())
 					m_SelectedEnvelope = m_Map.m_vpEnvelopes.size() - 1;
 				pEnvelope = m_SelectedEnvelope >= 0 ? m_Map.m_vpEnvelopes[m_SelectedEnvelope] : nullptr;
+				m_Map.OnModify();
 			}
 
 			// Move right button
@@ -5686,6 +5687,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 				m_Map.SwapEnvelopes(m_SelectedEnvelope, m_SelectedEnvelope + 1);
 				m_SelectedEnvelope = clamp<int>(m_SelectedEnvelope + 1, 0, m_Map.m_vpEnvelopes.size() - 1);
 				pEnvelope = m_Map.m_vpEnvelopes[m_SelectedEnvelope];
+				m_Map.OnModify();
 			}
 
 			// Move left button
@@ -5697,6 +5699,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 				m_Map.SwapEnvelopes(m_SelectedEnvelope - 1, m_SelectedEnvelope);
 				m_SelectedEnvelope = clamp<int>(m_SelectedEnvelope - 1, 0, m_Map.m_vpEnvelopes.size() - 1);
 				pEnvelope = m_Map.m_vpEnvelopes[m_SelectedEnvelope];
+				m_Map.OnModify();
 			}
 
 			if(pEnvelope)
@@ -5875,6 +5878,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 		{
 			m_EnvelopeEditorHistory.RecordAction(std::make_shared<CEditorActionEnvelopeEdit>(this, m_SelectedEnvelope, CEditorActionEnvelopeEdit::EEditType::SYNC, pEnvelope->m_Synchronized, !pEnvelope->m_Synchronized));
 			pEnvelope->m_Synchronized = !pEnvelope->m_Synchronized;
+			m_Map.OnModify();
 		}
 
 		ToolBar.VSplitLeft(4.0f, nullptr, &ToolBar);
@@ -6172,6 +6176,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 
 						m_EnvelopeEditorHistory.RecordAction(std::make_shared<CEditorActionEnvelopeEditPoint>(this,
 							m_SelectedEnvelope, i, 0, CEditorActionEnvelopeEditPoint::EEditType::CURVE_TYPE, PrevCurve, pEnvelope->m_vPoints[i].m_Curvetype));
+						m_Map.OnModify();
 					}
 				}
 			}

--- a/src/game/editor/mapitems/layer_tiles.cpp
+++ b/src/game/editor/mapitems/layer_tiles.cpp
@@ -1058,7 +1058,7 @@ CUI::EPopupMenuFunctionResult CLayerTiles::RenderProperties(CUIRect *pToolBox)
 			m_AutoMapperConfig = -1;
 	}
 
-	if(Prop != ETilesProp::PROP_NONE)
+	if(Prop != ETilesProp::PROP_NONE && Prop != ETilesProp::PROP_SHIFT_BY)
 	{
 		FlagModified(0, 0, m_Width, m_Height);
 	}

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -1903,6 +1903,14 @@ CUI::EPopupMenuFunctionResult CEditor::PopupMapInfo(void *pContext, CUIRect View
 	static int s_ConfirmButton = 0;
 	if(pEditor->DoButton_Editor(&s_ConfirmButton, "Confirm", 0, &Label, 0, nullptr) || (Active && pEditor->UI()->ConsumeHotkey(CUI::HOTKEY_ENTER)))
 	{
+		bool AuthorDifferent = str_comp(pEditor->m_Map.m_MapInfoTmp.m_aAuthor, pEditor->m_Map.m_MapInfo.m_aAuthor) != 0;
+		bool VersionDifferent = str_comp(pEditor->m_Map.m_MapInfoTmp.m_aVersion, pEditor->m_Map.m_MapInfo.m_aVersion) != 0;
+		bool CreditsDifferent = str_comp(pEditor->m_Map.m_MapInfoTmp.m_aCredits, pEditor->m_Map.m_MapInfo.m_aCredits) != 0;
+		bool LicenseDifferent = str_comp(pEditor->m_Map.m_MapInfoTmp.m_aLicense, pEditor->m_Map.m_MapInfo.m_aLicense) != 0;
+
+		if(AuthorDifferent || VersionDifferent || CreditsDifferent || LicenseDifferent)
+			pEditor->m_Map.OnModify();
+
 		pEditor->m_Map.m_MapInfo.Copy(pEditor->m_Map.m_MapInfoTmp);
 		return CUI::POPUP_CLOSE_CURRENT;
 	}


### PR DESCRIPTION
Fixes #6906.
More details:
- [x] Fix "Clicking "Sync." checkbox does not set modified state."
- [x] Fix "Changing curve type of line segments does not set modified state."
- [x] Fix "Modified state is incorrectly set all the time while the envelope name lineinput is selected. This also applies to group names. In general the updated-state seems to be always set for lineinputs that use a dynamic buffer (SetBuffer)."
- [x] Fix "Modified state is incorrect set by changing the "Shift by" value of layers. This value is not saved in maps so it's shouldn't set the modified state."
- [x] Fix "Moving/deleting envelopes also does not update the modified state."
- [x] Fix "Confirming the "Map Details" popup also does not update the modified state."

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
