### PR TITLE
Add ui setting for cl_authed_player_color

### DIFF
--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -2976,6 +2976,11 @@ void CMenus::RenderSettingsAppearance(CUIRect MainView)
 				break;
 			}
 		}
+
+		Section.HSplitTop(LineSize, &Button, &Section);
+		ColorRGBA GreenDefault(0.7f, 1.0f, 0.7f, 1);
+		static CButtonContainer s_AuthedColor;
+		DoLine_ColorPicker(&s_AuthedColor, 25.0f, 13.0f, 5.0f, &Button, Localize("Authed name color in scoreboard"), &g_Config.m_ClAuthedPlayerColor, GreenDefault, false);
 	}
 	else if(s_CurTab == APPEARANCE_TAB_HOOK_COLLISION)
 	{


### PR DESCRIPTION
Not even terminal fans want to do colors in the console

![screenshot_2023-12-11_20-20-08](https://github.com/ddnet/ddnet/assets/20344300/b3510681-e25c-4d78-95b9-134d237b8015)
![screenshot_2023-12-11_20-20-29](https://github.com/ddnet/ddnet/assets/20344300/d9cd857d-cb84-44b8-b212-70783f3bbd0b)
![screenshot_2023-12-11_20-20-33](https://github.com/ddnet/ddnet/assets/20344300/e740f2a1-aa32-4668-b11d-3532c47e3839)


## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
