### PR TITLE
RFC: Make it possible to subclass CPlayer and CCharacter in a mod

### DIFF
--- a/src/game/server/entities/character.h
+++ b/src/game/server/entities/character.h
@@ -62,10 +62,10 @@ public:
 	void OnDirectInput(CNetObj_PlayerInput *pNewInput);
 	void ResetHook();
 	void ResetInput();
-	void FireWeapon();
+	virtual void FireWeapon();
 
-	void Die(int Killer, int Weapon, bool SendKillMsg = true);
-	bool TakeDamage(vec2 Force, int Dmg, int From, int Weapon);
+	virtual void Die(int Killer, int Weapon, bool SendKillMsg = true);
+	virtual bool TakeDamage(vec2 Force, int Dmg, int From, int Weapon);
 
 	bool Spawn(class CPlayer *pPlayer, vec2 Pos);
 	bool Remove();
@@ -88,7 +88,7 @@ public:
 	class CPlayer *GetPlayer() { return m_pPlayer; }
 	CClientMask TeamMask();
 
-private:
+protected:
 	// player controlling this character
 	class CPlayer *m_pPlayer;
 

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -1662,7 +1662,7 @@ void CGameContext::OnClientConnected(int ClientID, void *pData)
 
 	if(m_apPlayers[ClientID])
 		delete m_apPlayers[ClientID];
-	m_apPlayers[ClientID] = new(ClientID) CPlayer(this, GetNextUniqueClientID(), ClientID, StartTeam);
+	m_apPlayers[ClientID] = m_pController->CreatePlayer(ClientID, StartTeam);
 	m_apPlayers[ClientID]->SetInitialAfk(Afk);
 
 	SendMotd(ClientID);

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -1662,9 +1662,8 @@ void CGameContext::OnClientConnected(int ClientID, void *pData)
 
 	if(m_apPlayers[ClientID])
 		delete m_apPlayers[ClientID];
-	m_apPlayers[ClientID] = new(ClientID) CPlayer(this, NextUniqueClientID, ClientID, StartTeam);
+	m_apPlayers[ClientID] = new(ClientID) CPlayer(this, GetNextUniqueClientID(), ClientID, StartTeam);
 	m_apPlayers[ClientID]->SetInitialAfk(Afk);
-	NextUniqueClientID += 1;
 
 	SendMotd(ClientID);
 	SendSettings(ClientID);
@@ -4558,6 +4557,12 @@ void CGameContext::ForceVote(int EnforcerID, bool Success)
 	SendChatTarget(-1, aBuf);
 	str_format(aBuf, sizeof(aBuf), "forcing vote %s", pOption);
 	Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "server", aBuf);
+}
+
+uint32_t CGameContext::GetNextUniqueClientID()
+{
+	// starting 1 to make 0 the special value "no client id"
+	return ++m_LastUniqueClientID;
 }
 
 bool CGameContext::RateLimitPlayerVote(int ClientID)

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -350,6 +350,8 @@ public:
 	bool PlayerModerating() const;
 	void ForceVote(int EnforcerID, bool Success);
 
+	uint32_t GetNextUniqueClientID();
+
 	// Checks if player can vote and notify them about the reason
 	bool RateLimitPlayerVote(int ClientID);
 	bool RateLimitPlayerMapVote(int ClientID) const;
@@ -359,8 +361,7 @@ public:
 	std::shared_ptr<CScoreRandomMapResult> m_SqlRandomMapResult;
 
 private:
-	// starting 1 to make 0 the special value "no client id"
-	uint32_t NextUniqueClientID = 1;
+	uint32_t m_LastUniqueClientID = 0;
 	bool m_VoteWillPass;
 	CScore *m_pScore;
 

--- a/src/game/server/gamecontroller.cpp
+++ b/src/game/server/gamecontroller.cpp
@@ -388,6 +388,11 @@ bool IGameController::OnEntity(int Index, int x, int y, int Layer, int Flags, bo
 	return false;
 }
 
+CPlayer *IGameController::CreatePlayer(int ClientID, int StartTeam)
+{
+	return new(ClientID) CPlayer(m_pGameServer, m_pGameServer->GetNextUniqueClientID(), ClientID, StartTeam);
+}
+
 void IGameController::OnPlayerConnect(CPlayer *pPlayer)
 {
 	int ClientID = pPlayer->GetCID();

--- a/src/game/server/gamecontroller.h
+++ b/src/game/server/gamecontroller.h
@@ -113,6 +113,8 @@ public:
 	*/
 	virtual bool OnEntity(int Index, int x, int y, int Layer, int Flags, bool Initial, int Number = 0);
 
+	virtual CPlayer *CreatePlayer(int ClientID, int StartTeam);
+
 	virtual void OnPlayerConnect(class CPlayer *pPlayer);
 	virtual void OnPlayerDisconnect(class CPlayer *pPlayer, const char *pReason);
 

--- a/src/game/server/gamemodes/mod.cpp
+++ b/src/game/server/gamemodes/mod.cpp
@@ -15,6 +15,8 @@ class CCharacterMod : public CCharacter
 public:
 	CCharacterMod(CGameControllerMod *pGameController, CNetObj_PlayerInput LastInput);
 
+	bool TakeDamage(vec2 Force, int Dmg, int From, int Weapon) override;
+
 protected:
 	CGameControllerMod *m_pGameController = nullptr;
 };
@@ -24,6 +26,12 @@ CCharacterMod::CCharacterMod(CGameControllerMod *pGameController, CNetObj_Player
 	m_pGameController(pGameController)
 
 {
+}
+
+bool CCharacterMod::TakeDamage(vec2 Force, int Dmg, int From, int Weapon)
+{
+	m_pGameController->OnCharacterTakeDamage(this, Dmg, From, Weapon);
+	return CCharacter::TakeDamage(Force, Dmg, From, Weapon);
 }
 
 MACRO_ALLOC_POOL_ID_IMPL(CCharacterMod, MAX_CLIENTS)
@@ -73,4 +81,11 @@ void CGameControllerMod::Tick()
 	// this is the main part of the gamemode, this function is run every tick
 
 	IGameController::Tick();
+}
+
+void CGameControllerMod::OnCharacterTakeDamage(CCharacterMod *pCharacter, int Damage, int From, int Weapon)
+{
+	char aBuf[128];
+	str_format(aBuf, sizeof(aBuf), "You've received %d damage points from player %d", Damage, From);
+	GameServer()->SendChatTarget(pCharacter->GetPlayer()->GetCID(), aBuf);
 }

--- a/src/game/server/gamemodes/mod.cpp
+++ b/src/game/server/gamemodes/mod.cpp
@@ -6,6 +6,26 @@
 #define GAME_TYPE_NAME "Mod"
 #define TEST_TYPE_NAME "TestMod"
 
+#include <game/server/player.h>
+
+class CPlayerMod : public CPlayer
+{
+	MACRO_ALLOC_POOL_ID()
+public:
+	CPlayerMod(CGameControllerMod *pGameController, uint32_t UniqueClientID, int ClientID, int Team);
+
+private:
+	CGameControllerMod *m_pGameController = nullptr;
+};
+
+MACRO_ALLOC_POOL_ID_IMPL(CPlayerMod, MAX_CLIENTS)
+
+CPlayerMod::CPlayerMod(CGameControllerMod *pGameController, uint32_t UniqueClientID, int ClientID, int Team) :
+	CPlayer(pGameController->GameServer(), UniqueClientID, ClientID, Team),
+	m_pGameController(pGameController)
+{
+}
+
 CGameControllerMod::CGameControllerMod(class CGameContext *pGameServer) :
 	IGameController(pGameServer)
 {
@@ -15,6 +35,11 @@ CGameControllerMod::CGameControllerMod(class CGameContext *pGameServer) :
 }
 
 CGameControllerMod::~CGameControllerMod() = default;
+
+CPlayer *CGameControllerMod::CreatePlayer(int ClientID, int StartTeam)
+{
+	return new(ClientID) CPlayerMod(this, GameServer()->GetNextUniqueClientID(), ClientID, StartTeam);
+}
 
 void CGameControllerMod::Tick()
 {

--- a/src/game/server/gamemodes/mod.cpp
+++ b/src/game/server/gamemodes/mod.cpp
@@ -6,7 +6,27 @@
 #define GAME_TYPE_NAME "Mod"
 #define TEST_TYPE_NAME "TestMod"
 
+#include <game/server/entities/character.h>
 #include <game/server/player.h>
+
+class CCharacterMod : public CCharacter
+{
+	MACRO_ALLOC_POOL_ID()
+public:
+	CCharacterMod(CGameControllerMod *pGameController, CNetObj_PlayerInput LastInput);
+
+protected:
+	CGameControllerMod *m_pGameController = nullptr;
+};
+
+CCharacterMod::CCharacterMod(CGameControllerMod *pGameController, CNetObj_PlayerInput LastInput) :
+	CCharacter(&pGameController->GameServer()->m_World, LastInput),
+	m_pGameController(pGameController)
+
+{
+}
+
+MACRO_ALLOC_POOL_ID_IMPL(CCharacterMod, MAX_CLIENTS)
 
 class CPlayerMod : public CPlayer
 {
@@ -14,7 +34,9 @@ class CPlayerMod : public CPlayer
 public:
 	CPlayerMod(CGameControllerMod *pGameController, uint32_t UniqueClientID, int ClientID, int Team);
 
-private:
+protected:
+	CCharacter *CreateCharacter() override;
+
 	CGameControllerMod *m_pGameController = nullptr;
 };
 
@@ -24,6 +46,11 @@ CPlayerMod::CPlayerMod(CGameControllerMod *pGameController, uint32_t UniqueClien
 	CPlayer(pGameController->GameServer(), UniqueClientID, ClientID, Team),
 	m_pGameController(pGameController)
 {
+}
+
+CCharacter *CPlayerMod::CreateCharacter()
+{
+	return new(m_ClientID) CCharacterMod(m_pGameController, GameServer()->GetLastPlayerInput(m_ClientID));
 }
 
 CGameControllerMod::CGameControllerMod(class CGameContext *pGameServer) :

--- a/src/game/server/gamemodes/mod.h
+++ b/src/game/server/gamemodes/mod.h
@@ -9,6 +9,10 @@ public:
 	CGameControllerMod(class CGameContext *pGameServer);
 	~CGameControllerMod();
 
+	CPlayer *CreatePlayer(int ClientID, int StartTeam) override;
+
 	void Tick() override;
+
+	using IGameController::GameServer;
 };
 #endif // GAME_SERVER_GAMEMODES_MOD_H

--- a/src/game/server/gamemodes/mod.h
+++ b/src/game/server/gamemodes/mod.h
@@ -13,6 +13,8 @@ public:
 
 	void Tick() override;
 
+	void OnCharacterTakeDamage(class CCharacterMod *pCharacter, int Damage, int From, int Weapon);
+
 	using IGameController::GameServer;
 };
 #endif // GAME_SERVER_GAMEMODES_MOD_H

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -595,7 +595,7 @@ void CPlayer::Respawn(bool WeakHook)
 CCharacter *CPlayer::ForceSpawn(vec2 Pos)
 {
 	m_Spawning = false;
-	m_pCharacter = new(m_ClientID) CCharacter(&GameServer()->m_World, GameServer()->GetLastPlayerInput(m_ClientID));
+	m_pCharacter = CreateCharacter();
 	m_pCharacter->Spawn(this, Pos);
 	m_Team = 0;
 	return m_pCharacter;
@@ -688,7 +688,7 @@ void CPlayer::TryRespawn()
 
 	m_WeakHookSpawn = false;
 	m_Spawning = false;
-	m_pCharacter = new(m_ClientID) CCharacter(&GameServer()->m_World, GameServer()->GetLastPlayerInput(m_ClientID));
+	m_pCharacter = CreateCharacter();
 	m_ViewPos = SpawnPos;
 	m_pCharacter->Spawn(this, SpawnPos);
 	GameServer()->CreatePlayerSpawn(SpawnPos, GameServer()->m_pController->GetMaskForPlayerWorldEvent(m_ClientID));
@@ -860,6 +860,11 @@ void CPlayer::SpectatePlayerName(const char *pName)
 			return;
 		}
 	}
+}
+
+CCharacter *CPlayer::CreateCharacter()
+{
+	return new(m_ClientID) CCharacter(&GameServer()->m_World, GameServer()->GetLastPlayerInput(m_ClientID));
 }
 
 void CPlayer::ProcessScoreResult(CScorePlayerResult &Result)

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -35,7 +35,7 @@ class CPlayer
 
 public:
 	CPlayer(CGameContext *pGameServer, uint32_t UniqueClientID, int ClientID, int Team);
-	~CPlayer();
+	virtual ~CPlayer();
 
 	void Reset();
 
@@ -49,12 +49,12 @@ public:
 	int GetClientVersion() const;
 	bool SetTimerType(int TimerType);
 
-	void Tick();
-	void PostTick();
+	virtual void Tick();
+	virtual void PostTick();
 
 	// will be called after all Tick and PostTick calls from other players
 	void PostPostTick();
-	void Snap(int SnappingClient);
+	virtual void Snap(int SnappingClient);
 	void FakeSnap();
 
 	void OnDirectInput(CNetObj_PlayerInput *pNewInput);
@@ -62,7 +62,7 @@ public:
 	void OnPredictedEarlyInput(CNetObj_PlayerInput *pNewInput);
 	void OnDisconnect();
 
-	void KillCharacter(int Weapon = WEAPON_GAME, bool SendKillMsg = true);
+	virtual void KillCharacter(int Weapon = WEAPON_GAME, bool SendKillMsg = true);
 	CCharacter *GetCharacter();
 	const CCharacter *GetCharacter() const;
 

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -39,7 +39,7 @@ public:
 
 	void Reset();
 
-	void TryRespawn();
+	virtual void TryRespawn();
 	void Respawn(bool WeakHook = false); // with WeakHook == true the character will be spawned after all calls of Tick from other Players
 	CCharacter *ForceSpawn(vec2 Pos); // required for loading savegames
 	void SetTeam(int Team, bool DoChatMsg = true);
@@ -126,7 +126,9 @@ public:
 		int m_Max;
 	} m_Latency;
 
-private:
+protected:
+	virtual CCharacter *CreateCharacter();
+
 	const uint32_t m_UniqueClientID;
 	CCharacter *m_pCharacter;
 	int m_NumInputs;


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->
This is an alternative approach to https://github.com/ddnet/ddnet/pull/7598

The issue with the linked approach is that it is not flexible enough (the snap is still tied to the race game type).

The approach suggested in this MR is tested in action — I base [infclass](https://github.com/infclass/teeworlds-infclassR/tree/staging/src/game/server/infclass) mod on CPlayer (and CCharacter) subclassing.

Later on we can move DDNet-specific stuff to some CPlayer subclass but right now it is hard to extract something because ddracechat commands access virtually all ddrace specific stuff in CPlayer, so it is blocked by missing commands registration support in GameController.

I marked `virtual` a few methods in CPlayer so a mod can override them (and I actually override those methods in infclass).
<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->


## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
