### PR TITLE
Move chat message into CanJoinTeam()

### DIFF
--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -2389,24 +2389,16 @@ void CGameContext::OnSetTeamNetMessage(const CNetMsg_Cl_SetTeam *pMsg, int Clien
 	}
 
 	// Switch team on given client and kill/respawn them
-	if(m_pController->CanJoinTeam(pMsg->m_Team, ClientID))
+	char aTeamJoinError[512];
+	if(m_pController->CanJoinTeam(pMsg->m_Team, ClientID, aTeamJoinError, sizeof(aTeamJoinError)))
 	{
-		if(pPlayer->IsPaused())
-			SendChatTarget(ClientID, "Use /pause first then you can kill");
-		else
-		{
-			if(pPlayer->GetTeam() == TEAM_SPECTATORS || pMsg->m_Team == TEAM_SPECTATORS)
-				m_VoteUpdate = true;
-			m_pController->DoTeamChange(pPlayer, pMsg->m_Team);
-			pPlayer->m_TeamChangeTick = Server()->Tick();
-		}
+		if(pPlayer->GetTeam() == TEAM_SPECTATORS || pMsg->m_Team == TEAM_SPECTATORS)
+			m_VoteUpdate = true;
+		m_pController->DoTeamChange(pPlayer, pMsg->m_Team);
+		pPlayer->m_TeamChangeTick = Server()->Tick();
 	}
-	else
-	{
-		char aBuf[128];
-		str_format(aBuf, sizeof(aBuf), "Only %d active players are allowed", Server()->MaxClients() - g_Config.m_SvSpectatorSlots);
-		SendBroadcast(aBuf, ClientID);
-	}
+	if(aTeamJoinError[0])
+		SendBroadcast(aTeamJoinError, ClientID);
 }
 
 void CGameContext::OnIsDDNetLegacyNetMessage(const CNetMsg_Cl_IsDDNetLegacy *pMsg, int ClientID, CUnpacker *pUnpacker)

--- a/src/game/server/gamecontroller.h
+++ b/src/game/server/gamecontroller.h
@@ -145,7 +145,7 @@ public:
 	*/
 	virtual const char *GetTeamName(int Team);
 	virtual int GetAutoTeam(int NotThisID);
-	virtual bool CanJoinTeam(int Team, int NotThisID);
+	virtual bool CanJoinTeam(int Team, int NotThisID, char *pErrorReason, int ErrorReasonSize);
 	int ClampTeam(int Team);
 
 	CClientMask GetMaskForPlayerWorldEvent(int Asker, int ExceptID = -1);

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -832,7 +832,7 @@ int CPlayer::ForcePause(int Time)
 	return Pause(PAUSE_SPEC, true);
 }
 
-int CPlayer::IsPaused()
+int CPlayer::IsPaused() const
 {
 	return m_ForcePauseTime ? m_ForcePauseTime : -1 * m_Paused;
 }

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -176,7 +176,7 @@ public:
 	void ProcessPause();
 	int Pause(int State, bool Force);
 	int ForcePause(int Time);
-	int IsPaused();
+	int IsPaused() const;
 
 	bool IsPlaying();
 	int64_t m_Last_KickVote;


### PR DESCRIPTION
Now `CGameContext` no longer assumes the `IGameController` declined the team join due to slots.

This enables custom gametypes to disallow joining the game if the player died, an active tournament is running or the player is not logged in yet. And then the controller can print the correct error message accordingly.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
