### PR TITLE
Set correct colour for authed colour reset button

### DIFF
--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -2978,7 +2978,7 @@ void CMenus::RenderSettingsAppearance(CUIRect MainView)
 		}
 
 		Section.HSplitTop(LineSize, &Button, &Section);
-		ColorRGBA GreenDefault(0.7f, 1.0f, 0.7f, 1);
+		ColorRGBA GreenDefault(0.78f, 1.0f, 0.8f, 1.0f);
 		static CButtonContainer s_AuthedColor;
 		DoLine_ColorPicker(&s_AuthedColor, 25.0f, 13.0f, 5.0f, &Button, Localize("Authed name color in scoreboard"), &g_Config.m_ClAuthedPlayerColor, GreenDefault, false);
 	}


### PR DESCRIPTION
https://github.com/ddnet/ddnet/pull/7630#issuecomment-1850804027

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
