### PR TITLE
Add `Sv_CommandInfo` netmsg for autocompletion of chat commands.

### DIFF
--- a/datasrc/network.py
+++ b/datasrc/network.py
@@ -562,4 +562,14 @@ Messages = [
 		NetBool("m_RecordPersonal"),
 		NetBool("m_RecordServer", default=False),
 	]),
+
+	NetMessageEx("Sv_CommandInfo", "commandinfo@netmsg.ddnet.org", [
+			NetStringStrict("m_pName"),
+			NetStringStrict("m_pArgsFormat"),
+			NetStringStrict("m_pHelpText")
+	]),
+
+	NetMessageEx("Sv_CommandInfoRemove", "commandinfo-remove@netmsg.ddnet.org", [
+			NetStringStrict("m_pName")
+	]),
 ]

--- a/src/game/client/components/chat.h
+++ b/src/game/client/components/chat.h
@@ -96,21 +96,26 @@ class CChat : public CComponent
 
 	struct CCommand
 	{
-		const char *m_pName;
-		const char *m_pParams;
+		char m_aName[IConsole::TEMPCMD_NAME_LENGTH];
+		char m_aParams[IConsole::TEMPCMD_PARAMS_LENGTH];
+		char m_aHelpText[IConsole::TEMPCMD_HELP_LENGTH];
 
 		CCommand() = default;
-		CCommand(const char *pName, const char *pParams) :
-			m_pName(pName), m_pParams(pParams)
+		CCommand(const char *pName, const char *pParams, const char *pHelpText)
 		{
+			str_copy(m_aName, pName);
+			str_copy(m_aParams, pParams);
+			str_copy(m_aHelpText, pHelpText);
 		}
 
-		bool operator<(const CCommand &Other) const { return str_comp(m_pName, Other.m_pName) < 0; }
-		bool operator<=(const CCommand &Other) const { return str_comp(m_pName, Other.m_pName) <= 0; }
-		bool operator==(const CCommand &Other) const { return str_comp(m_pName, Other.m_pName) == 0; }
+		bool operator<(const CCommand &Other) const { return str_comp(m_aName, Other.m_aName) < 0; }
+		bool operator<=(const CCommand &Other) const { return str_comp(m_aName, Other.m_aName) <= 0; }
+		bool operator==(const CCommand &Other) const { return str_comp(m_aName, Other.m_aName) == 0; }
 	};
 
 	std::vector<CCommand> m_vCommands;
+	std::vector<CCommand> m_vDefaultCommands;
+	bool m_CommandsNeedSorting;
 
 	struct CHistoryEntry
 	{
@@ -125,6 +130,8 @@ class CChat : public CComponent
 	bool m_IsInputCensored;
 	char m_aCurrentInputText[MAX_LINE_LENGTH];
 	bool m_EditingNewLine;
+
+	bool m_ServerSupportsCommandInfo;
 
 	static void ConSay(IConsole::IResult *pResult, void *pUserData);
 	static void ConSayTeam(IConsole::IResult *pResult, void *pUserData);
@@ -151,7 +158,8 @@ public:
 	void DisableMode();
 	void Say(int Team, const char *pLine);
 	void SayChat(const char *pLine);
-	void RegisterCommand(const char *pName, const char *pParams, int flags, const char *pHelp);
+	void RegisterCommand(const char *pName, const char *pParams, const char *pHelpText);
+	void UnregisterCommand(const char *pName);
 	void Echo(const char *pString);
 
 	void OnWindowResize() override;
@@ -165,6 +173,7 @@ public:
 	void OnMessage(int MsgType, void *pRawMsg) override;
 	bool OnInput(const IInput::CEvent &Event) override;
 	void OnInit() override;
+	void OnMapLoad() override;
 
 	void RebuildChat();
 

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -1410,18 +1410,30 @@ void CGameContext::OnClientEnter(int ClientID)
 			Msg.m_pName = "team";
 			Server()->SendPackMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_NORECORD, ClientID);
 		}
+	}
 
-		for(const IConsole::CCommandInfo *pCmd = Console()->FirstCommandInfo(IConsole::ACCESS_LEVEL_USER, CFGFLAG_CHAT);
-			pCmd; pCmd = pCmd->NextCommandInfo(IConsole::ACCESS_LEVEL_USER, CFGFLAG_CHAT))
+	for(const IConsole::CCommandInfo *pCmd = Console()->FirstCommandInfo(IConsole::ACCESS_LEVEL_USER, CFGFLAG_CHAT);
+		pCmd; pCmd = pCmd->NextCommandInfo(IConsole::ACCESS_LEVEL_USER, CFGFLAG_CHAT))
+	{
+		const char *pName = pCmd->m_pName;
+
+		if(Server()->IsSixup(ClientID))
 		{
-			if(!str_comp_nocase(pCmd->m_pName, "w") || !str_comp_nocase(pCmd->m_pName, "whisper"))
+			if(!str_comp_nocase(pName, "w") || !str_comp_nocase(pName, "whisper"))
 				continue;
 
-			const char *pName = pCmd->m_pName;
-			if(!str_comp_nocase(pCmd->m_pName, "r"))
+			if(!str_comp_nocase(pName, "r"))
 				pName = "rescue";
 
 			protocol7::CNetMsg_Sv_CommandInfo Msg;
+			Msg.m_pName = pName;
+			Msg.m_pArgsFormat = pCmd->m_pParams;
+			Msg.m_pHelpText = pCmd->m_pHelp;
+			Server()->SendPackMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_NORECORD, ClientID);
+		}
+		else
+		{
+			CNetMsg_Sv_CommandInfo Msg;
 			Msg.m_pName = pName;
 			Msg.m_pArgsFormat = pCmd->m_pParams;
 			Msg.m_pHelpText = pCmd->m_pHelp;


### PR DESCRIPTION
This adds `Sv_CommandInfo` and `Sv_CommandInfoRemove` from 0.7, which can be used to send all the available chat commands. These commands are then used for the tab completion in chat instead of using the hard-coded DDRace commands (it will still use them, if the server doesn't send any `Sv_CommandInfo` netmsgs).

Closes #7524

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
