### PR TITLE
Don't broadcast error if `CanJoinTeam` returned true

### DIFF
--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -2397,7 +2397,7 @@ void CGameContext::OnSetTeamNetMessage(const CNetMsg_Cl_SetTeam *pMsg, int Clien
 		m_pController->DoTeamChange(pPlayer, pMsg->m_Team);
 		pPlayer->m_TeamChangeTick = Server()->Tick();
 	}
-	if(aTeamJoinError[0])
+	else if(aTeamJoinError[0])
 		SendBroadcast(aTeamJoinError, ClientID);
 }
 


### PR DESCRIPTION
Fixes printing of invalid strings when joining a team.

![image](https://github.com/ddnet/ddnet/assets/141338449/e7ebaa7d-79ab-4332-a924-a75d9babe3fe)


## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
