### PR TITLE
Fix more clang-tidy errors: mark functions as `const` when possible

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -81,7 +81,6 @@ Checks: >
   -readability-implicit-bool-conversion,
   -readability-isolate-declaration,
   -readability-magic-numbers,
-  -readability-make-member-function-const,
   -readability-named-parameter,
   -readability-non-const-parameter,
   -readability-simplify-boolean-expr,

--- a/src/engine/client.h
+++ b/src/engine/client.h
@@ -324,7 +324,7 @@ public:
 	virtual int OnSnapInput(int *pData, bool Dummy, bool Force) = 0;
 	virtual void OnDummySwap() = 0;
 	virtual void SendDummyInfo(bool Start) = 0;
-	virtual int GetLastRaceTick() = 0;
+	virtual int GetLastRaceTick() const = 0;
 
 	virtual const char *GetItemName(int Type) const = 0;
 	virtual const char *Version() const = 0;
@@ -335,8 +335,8 @@ public:
 	virtual void OnDummyDisconnect() = 0;
 	virtual void DummyResetInput() = 0;
 	virtual void Echo(const char *pString) = 0;
-	virtual bool CanDisplayWarning() = 0;
-	virtual bool IsDisplayingWarning() = 0;
+	virtual bool CanDisplayWarning() const = 0;
+	virtual bool IsDisplayingWarning() const = 0;
 
 	virtual CNetObjHandler *GetNetObjHandler() = 0;
 };

--- a/src/engine/client/backend/opengl/opengl_sl.cpp
+++ b/src/engine/client/backend/opengl/opengl_sl.cpp
@@ -142,12 +142,12 @@ void CGLSL::DeleteShader()
 	glDeleteShader(m_ShaderID);
 }
 
-bool CGLSL::IsLoaded()
+bool CGLSL::IsLoaded() const
 {
 	return m_IsLoaded;
 }
 
-TWGLuint CGLSL::GetShaderID()
+TWGLuint CGLSL::GetShaderID() const
 {
 	return m_ShaderID;
 }

--- a/src/engine/client/backend/opengl/opengl_sl.h
+++ b/src/engine/client/backend/opengl/opengl_sl.h
@@ -20,8 +20,8 @@ public:
 	bool LoadShader(CGLSLCompiler *pCompiler, class IStorage *pStorage, const char *pFile, int Type);
 	void DeleteShader();
 
-	bool IsLoaded();
-	TWGLuint GetShaderID();
+	bool IsLoaded() const;
+	TWGLuint GetShaderID() const;
 
 	CGLSL();
 	virtual ~CGLSL();

--- a/src/engine/client/backend/opengl/opengl_sl_program.cpp
+++ b/src/engine/client/backend/opengl/opengl_sl_program.cpp
@@ -25,7 +25,7 @@ void CGLSLProgram::DeleteProgram()
 	glDeleteProgram(m_ProgramID);
 }
 
-bool CGLSLProgram::AddShader(CGLSL *pShader)
+bool CGLSLProgram::AddShader(CGLSL *pShader) const
 {
 	if(pShader->IsLoaded())
 	{
@@ -35,7 +35,7 @@ bool CGLSLProgram::AddShader(CGLSL *pShader)
 	return false;
 }
 
-void CGLSLProgram::DetachShader(CGLSL *pShader)
+void CGLSLProgram::DetachShader(CGLSL *pShader) const
 {
 	if(pShader->IsLoaded())
 	{
@@ -43,7 +43,7 @@ void CGLSLProgram::DetachShader(CGLSL *pShader)
 	}
 }
 
-void CGLSLProgram::DetachShaderByID(TWGLuint ShaderID)
+void CGLSLProgram::DetachShaderByID(TWGLuint ShaderID) const
 {
 	glDetachShader(m_ProgramID, ShaderID);
 }
@@ -68,7 +68,7 @@ void CGLSLProgram::LinkProgram()
 	DetachAllShaders();
 }
 
-void CGLSLProgram::DetachAllShaders()
+void CGLSLProgram::DetachAllShaders() const
 {
 	TWGLuint aShaders[100];
 	GLsizei ReturnedCount = 0;
@@ -119,18 +119,18 @@ void CGLSLProgram::SetUniform(int Loc, const bool Value)
 	glUniform1i(Loc, (int)Value);
 }
 
-int CGLSLProgram::GetUniformLoc(const char *pName)
+int CGLSLProgram::GetUniformLoc(const char *pName) const
 {
 	return glGetUniformLocation(m_ProgramID, pName);
 }
 
-void CGLSLProgram::UseProgram()
+void CGLSLProgram::UseProgram() const
 {
 	if(m_IsLinked)
 		glUseProgram(m_ProgramID);
 }
 
-TWGLuint CGLSLProgram::GetProgramID()
+TWGLuint CGLSLProgram::GetProgramID() const
 {
 	return m_ProgramID;
 }

--- a/src/engine/client/backend/opengl/opengl_sl_program.h
+++ b/src/engine/client/backend/opengl/opengl_sl_program.h
@@ -22,15 +22,15 @@ public:
 	void CreateProgram();
 	void DeleteProgram();
 
-	bool AddShader(CGLSL *pShader);
+	bool AddShader(CGLSL *pShader) const;
 
 	void LinkProgram();
-	void UseProgram();
-	TWGLuint GetProgramID();
+	void UseProgram() const;
+	TWGLuint GetProgramID() const;
 
-	void DetachShader(CGLSL *pShader);
-	void DetachShaderByID(TWGLuint ShaderID);
-	void DetachAllShaders();
+	void DetachShader(CGLSL *pShader) const;
+	void DetachShaderByID(TWGLuint ShaderID) const;
+	void DetachAllShaders() const;
 
 	//Support various types
 	void SetUniformVec2(int Loc, int Count, const float *pValue);
@@ -41,7 +41,7 @@ public:
 	void SetUniform(int Loc, int Count, const float *pValues);
 
 	//for performance reason we do not use SetUniform with using strings... save the Locations of the variables instead
-	int GetUniformLoc(const char *pName);
+	int GetUniformLoc(const char *pName) const;
 
 	CGLSLProgram();
 	virtual ~CGLSLProgram();

--- a/src/engine/client/backend/vulkan/backend_vulkan.cpp
+++ b/src/engine/client/backend/vulkan/backend_vulkan.cpp
@@ -68,7 +68,7 @@ class CCommandProcessorFragment_Vulkan : public CCommandProcessorFragment_GLBase
 		return g_Config.m_DbgGfx == DEBUG_GFX_MODE_VERBOSE || g_Config.m_DbgGfx == DEBUG_GFX_MODE_ALL;
 	}
 
-	void VerboseAllocatedMemory(VkDeviceSize Size, size_t FrameImageIndex, EMemoryBlockUsage MemUsage)
+	void VerboseAllocatedMemory(VkDeviceSize Size, size_t FrameImageIndex, EMemoryBlockUsage MemUsage) const
 	{
 		const char *pUsage = "unknown";
 		switch(MemUsage)
@@ -90,7 +90,7 @@ class CCommandProcessorFragment_Vulkan : public CCommandProcessorFragment_GLBase
 		dbg_msg("vulkan", "allocated chunk of memory with size: %" PRIzu " for frame %" PRIzu " (%s)", (size_t)Size, (size_t)m_CurImageIndex, pUsage);
 	}
 
-	void VerboseDeallocatedMemory(VkDeviceSize Size, size_t FrameImageIndex, EMemoryBlockUsage MemUsage)
+	void VerboseDeallocatedMemory(VkDeviceSize Size, size_t FrameImageIndex, EMemoryBlockUsage MemUsage) const
 	{
 		const char *pUsage = "unknown";
 		switch(MemUsage)
@@ -300,7 +300,7 @@ class CCommandProcessorFragment_Vulkan : public CCommandProcessorFragment_GLBase
 			}
 		}
 
-		[[nodiscard]] bool IsUnused()
+		[[nodiscard]] bool IsUnused() const
 		{
 			return !m_Root.m_InUse;
 		}
@@ -829,7 +829,7 @@ class CCommandProcessorFragment_Vulkan : public CCommandProcessorFragment_GLBase
 		// the viewport of the resulting presented image on the screen
 		// if there is a forced viewport the resulting image is smaller
 		// than the full swap image size
-		VkExtent2D GetPresentedImageViewport()
+		VkExtent2D GetPresentedImageViewport() const
 		{
 			uint32_t ViewportWidth = m_SwapImageViewport.width;
 			uint32_t ViewportHeight = m_SwapImageViewport.height;
@@ -3168,7 +3168,7 @@ protected:
 		return State.m_BlendMode == CCommandBuffer::BLEND_ADDITIVE ? VULKAN_BACKEND_BLEND_MODE_ADDITATIVE : (State.m_BlendMode == CCommandBuffer::BLEND_NONE ? VULKAN_BACKEND_BLEND_MODE_NONE : VULKAN_BACKEND_BLEND_MODE_ALPHA);
 	}
 
-	size_t GetDynamicModeIndexFromState(const CCommandBuffer::SState &State)
+	size_t GetDynamicModeIndexFromState(const CCommandBuffer::SState &State) const
 	{
 		return (State.m_ClipEnable || m_HasDynamicViewport || m_VKSwapImgAndViewportExtent.m_HasForcedViewport) ? VULKAN_BACKEND_CLIP_MODE_DYNAMIC_SCISSOR_AND_VIEWPORT : VULKAN_BACKEND_CLIP_MODE_NONE;
 	}
@@ -4598,7 +4598,7 @@ public:
 		VkPipelineRasterizationStateCreateInfo &Rasterizer,
 		VkPipelineMultisampleStateCreateInfo &Multisampling,
 		VkPipelineColorBlendAttachmentState &ColorBlendAttachment,
-		VkPipelineColorBlendStateCreateInfo &ColorBlending)
+		VkPipelineColorBlendStateCreateInfo &ColorBlending) const
 	{
 		InputAssembly.sType = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
 		InputAssembly.topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
@@ -5967,12 +5967,12 @@ public:
 		FreeDescriptorSetFromPool(DescrSet);
 	}
 
-	[[nodiscard]] bool HasMultiSampling()
+	[[nodiscard]] bool HasMultiSampling() const
 	{
 		return GetSampleCount() != VK_SAMPLE_COUNT_1_BIT;
 	}
 
-	VkSampleCountFlagBits GetMaxSampleCount()
+	VkSampleCountFlagBits GetMaxSampleCount() const
 	{
 		if(m_MaxMultiSample & VK_SAMPLE_COUNT_64_BIT)
 			return VK_SAMPLE_COUNT_64_BIT;
@@ -5990,7 +5990,7 @@ public:
 		return VK_SAMPLE_COUNT_1_BIT;
 	}
 
-	VkSampleCountFlagBits GetSampleCount()
+	VkSampleCountFlagBits GetSampleCount() const
 	{
 		auto MaxSampleCount = GetMaxSampleCount();
 		if(m_MultiSamplingCount >= 64 && MaxSampleCount >= VK_SAMPLE_COUNT_64_BIT)

--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -122,7 +122,7 @@ void CServerBrowser::Con_LeakIpAddress(IConsole::IResult *pResult, void *pUserDa
 	{
 	public:
 		CServerBrowser *m_pThis;
-		bool operator()(int i, int j)
+		bool operator()(int i, int j) const
 		{
 			NETADDR Addr1 = m_pThis->m_ppServerlist[i]->m_Info.m_aAddresses[0];
 			NETADDR Addr2 = m_pThis->m_ppServerlist[j]->m_Info.m_aAddresses[0];
@@ -541,7 +541,7 @@ void ServerBrowserFormatAddresses(char *pBuffer, int BufferSize, NETADDR *pAddrs
 	}
 }
 
-void CServerBrowser::SetInfo(CServerEntry *pEntry, const CServerInfo &Info)
+void CServerBrowser::SetInfo(CServerEntry *pEntry, const CServerInfo &Info) const
 {
 	const CServerInfo TmpInfo = pEntry->m_Info;
 	pEntry->m_Info = Info;
@@ -575,7 +575,7 @@ void CServerBrowser::SetInfo(CServerEntry *pEntry, const CServerInfo &Info)
 		{
 		}
 
-		bool operator()(const CServerInfo::CClient &p0, const CServerInfo::CClient &p1)
+		bool operator()(const CServerInfo::CClient &p0, const CServerInfo::CClient &p1) const
 		{
 			// Sort players before non players
 			if(p0.m_Player && !p1.m_Player)

--- a/src/engine/client/serverbrowser.h
+++ b/src/engine/client/serverbrowser.h
@@ -217,7 +217,7 @@ private:
 	void RegisterCommands();
 	static void Con_LeakIpAddress(IConsole::IResult *pResult, void *pUserData);
 
-	void SetInfo(CServerEntry *pEntry, const CServerInfo &Info);
+	void SetInfo(CServerEntry *pEntry, const CServerInfo &Info) const;
 	void SetLatency(NETADDR Addr, int Latency);
 
 	static bool ParseCommunityFinishes(CCommunity *pCommunity, const json_value &Finishes);

--- a/src/engine/client/sound.cpp
+++ b/src/engine/client/sound.cpp
@@ -286,7 +286,7 @@ int CSound::AllocID()
 	return -1;
 }
 
-void CSound::RateConvert(CSample &Sample)
+void CSound::RateConvert(CSample &Sample) const
 {
 	// make sure that we need to convert this sound
 	if(!Sample.m_pData || Sample.m_Rate == m_MixingRate)
@@ -321,7 +321,7 @@ void CSound::RateConvert(CSample &Sample)
 	Sample.m_Rate = m_MixingRate;
 }
 
-bool CSound::DecodeOpus(CSample &Sample, const void *pData, unsigned DataSize)
+bool CSound::DecodeOpus(CSample &Sample, const void *pData, unsigned DataSize) const
 {
 	OggOpusFile *pOpusFile = op_open_memory((const unsigned char *)pData, DataSize, nullptr);
 	if(pOpusFile)
@@ -414,7 +414,7 @@ static int PushBackByte(void *pId, int Char)
 }
 #endif
 
-bool CSound::DecodeWV(CSample &Sample, const void *pData, unsigned DataSize)
+bool CSound::DecodeWV(CSample &Sample, const void *pData, unsigned DataSize) const
 {
 	char aError[100];
 

--- a/src/engine/client/sound.h
+++ b/src/engine/client/sound.h
@@ -77,10 +77,10 @@ class CSound : public IEngineSound
 	int *m_pMixBuffer = nullptr;
 
 	int AllocID();
-	void RateConvert(CSample &Sample);
+	void RateConvert(CSample &Sample) const;
 
-	bool DecodeOpus(CSample &Sample, const void *pData, unsigned DataSize);
-	bool DecodeWV(CSample &Sample, const void *pData, unsigned DataSize);
+	bool DecodeOpus(CSample &Sample, const void *pData, unsigned DataSize) const;
+	bool DecodeWV(CSample &Sample, const void *pData, unsigned DataSize) const;
 
 	void UpdateVolume();
 

--- a/src/engine/client/video.cpp
+++ b/src/engine/client/video.cpp
@@ -809,7 +809,7 @@ bool CVideo::OpenAudio()
 }
 
 /* Add an output stream. */
-bool CVideo::AddStream(OutputStream *pStream, AVFormatContext *pOC, const AVCodec **ppCodec, enum AVCodecID CodecId)
+bool CVideo::AddStream(OutputStream *pStream, AVFormatContext *pOC, const AVCodec **ppCodec, enum AVCodecID CodecId) const
 {
 	AVCodecContext *pContext;
 

--- a/src/engine/client/video.h
+++ b/src/engine/client/video.h
@@ -79,7 +79,7 @@ private:
 	void FinishFrames(OutputStream *pStream);
 	void CloseStream(OutputStream *pStream);
 
-	bool AddStream(OutputStream *pStream, AVFormatContext *pOC, const AVCodec **ppCodec, enum AVCodecID CodecId);
+	bool AddStream(OutputStream *pStream, AVFormatContext *pOC, const AVCodec **ppCodec, enum AVCodecID CodecId) const;
 
 	CGraphics_Threaded *m_pGraphics;
 	IStorage *m_pStorage;

--- a/src/engine/server/databases/connection.cpp
+++ b/src/engine/server/databases/connection.cpp
@@ -7,7 +7,7 @@ IDbConnection::IDbConnection(const char *pPrefix)
 	str_copy(m_aPrefix, pPrefix);
 }
 
-void IDbConnection::FormatCreateRace(char *aBuf, unsigned int BufferSize, bool Backup)
+void IDbConnection::FormatCreateRace(char *aBuf, unsigned int BufferSize, bool Backup) const
 {
 	str_format(aBuf, BufferSize,
 		"CREATE TABLE IF NOT EXISTS %s_race%s ("
@@ -33,7 +33,7 @@ void IDbConnection::FormatCreateRace(char *aBuf, unsigned int BufferSize, bool B
 		BinaryCollate(), MAX_NAME_LENGTH, BinaryCollate());
 }
 
-void IDbConnection::FormatCreateTeamrace(char *aBuf, unsigned int BufferSize, const char *pIdType, bool Backup)
+void IDbConnection::FormatCreateTeamrace(char *aBuf, unsigned int BufferSize, const char *pIdType, bool Backup) const
 {
 	str_format(aBuf, BufferSize,
 		"CREATE TABLE IF NOT EXISTS %s_teamrace%s ("
@@ -50,7 +50,7 @@ void IDbConnection::FormatCreateTeamrace(char *aBuf, unsigned int BufferSize, co
 		BinaryCollate(), MAX_NAME_LENGTH, BinaryCollate(), pIdType);
 }
 
-void IDbConnection::FormatCreateMaps(char *aBuf, unsigned int BufferSize)
+void IDbConnection::FormatCreateMaps(char *aBuf, unsigned int BufferSize) const
 {
 	str_format(aBuf, BufferSize,
 		"CREATE TABLE IF NOT EXISTS %s_maps ("
@@ -65,7 +65,7 @@ void IDbConnection::FormatCreateMaps(char *aBuf, unsigned int BufferSize)
 		GetPrefix(), BinaryCollate(), BinaryCollate(), BinaryCollate());
 }
 
-void IDbConnection::FormatCreateSaves(char *aBuf, unsigned int BufferSize, bool Backup)
+void IDbConnection::FormatCreateSaves(char *aBuf, unsigned int BufferSize, bool Backup) const
 {
 	str_format(aBuf, BufferSize,
 		"CREATE TABLE IF NOT EXISTS %s_saves%s ("
@@ -82,7 +82,7 @@ void IDbConnection::FormatCreateSaves(char *aBuf, unsigned int BufferSize, bool 
 		BinaryCollate(), BinaryCollate(), BinaryCollate());
 }
 
-void IDbConnection::FormatCreatePoints(char *aBuf, unsigned int BufferSize)
+void IDbConnection::FormatCreatePoints(char *aBuf, unsigned int BufferSize) const
 {
 	str_format(aBuf, BufferSize,
 		"CREATE TABLE IF NOT EXISTS %s_points ("

--- a/src/engine/server/databases/connection.h
+++ b/src/engine/server/databases/connection.h
@@ -84,11 +84,11 @@ private:
 	char m_aPrefix[64];
 
 protected:
-	void FormatCreateRace(char *aBuf, unsigned int BufferSize, bool Backup);
-	void FormatCreateTeamrace(char *aBuf, unsigned int BufferSize, const char *pIdType, bool Backup);
-	void FormatCreateMaps(char *aBuf, unsigned int BufferSize);
-	void FormatCreateSaves(char *aBuf, unsigned int BufferSize, bool Backup);
-	void FormatCreatePoints(char *aBuf, unsigned int BufferSize);
+	void FormatCreateRace(char *aBuf, unsigned int BufferSize, bool Backup) const;
+	void FormatCreateTeamrace(char *aBuf, unsigned int BufferSize, const char *pIdType, bool Backup) const;
+	void FormatCreateMaps(char *aBuf, unsigned int BufferSize) const;
+	void FormatCreateSaves(char *aBuf, unsigned int BufferSize, bool Backup) const;
+	void FormatCreatePoints(char *aBuf, unsigned int BufferSize) const;
 };
 
 bool MysqlAvailable();

--- a/src/engine/shared/config.cpp
+++ b/src/engine/shared/config.cpp
@@ -51,12 +51,12 @@ struct SConfigVariable
 	virtual void ResetToOld() = 0;
 
 protected:
-	void ExecuteLine(const char *pLine)
+	void ExecuteLine(const char *pLine) const
 	{
 		m_pConsole->ExecuteLine(pLine, (m_Flags & CFGFLAG_GAME) != 0 ? IConsole::CLIENT_ID_GAME : -1);
 	}
 
-	bool CheckReadOnly()
+	bool CheckReadOnly() const
 	{
 		if(!m_ReadOnly)
 			return false;

--- a/src/engine/shared/console.cpp
+++ b/src/engine/shared/console.cpp
@@ -1034,7 +1034,7 @@ void CConsole::CResult::ResetVictim()
 	m_Victim = VICTIM_NONE;
 }
 
-bool CConsole::CResult::HasVictim()
+bool CConsole::CResult::HasVictim() const
 {
 	return m_Victim != VICTIM_NONE;
 }

--- a/src/engine/shared/console.h
+++ b/src/engine/shared/console.h
@@ -137,7 +137,7 @@ class CConsole : public IConsole
 
 		int m_Victim;
 		void ResetVictim();
-		bool HasVictim();
+		bool HasVictim() const;
 		void SetVictim(int Victim);
 		void SetVictim(const char *pVictim);
 		int GetVictim() const override;

--- a/src/engine/shared/network.cpp
+++ b/src/engine/shared/network.cpp
@@ -317,7 +317,7 @@ void CNetBase::SendControlMsg(NETSOCKET Socket, NETADDR *pAddr, int Ack, int Con
 	CNetBase::SendPacket(Socket, pAddr, &Construct, SecurityToken, Sixup, true);
 }
 
-unsigned char *CNetChunkHeader::Pack(unsigned char *pData, int Split)
+unsigned char *CNetChunkHeader::Pack(unsigned char *pData, int Split) const
 {
 	pData[0] = ((m_Flags & 3) << 6) | ((m_Size >> Split) & 0x3f);
 	pData[1] = (m_Size & ((1 << Split) - 1));

--- a/src/engine/shared/network.h
+++ b/src/engine/shared/network.h
@@ -133,7 +133,7 @@ public:
 	int m_Size;
 	int m_Sequence;
 
-	unsigned char *Pack(unsigned char *pData, int Split = 4);
+	unsigned char *Pack(unsigned char *pData, int Split = 4) const;
 	unsigned char *Unpack(unsigned char *pData, int Split = 4);
 };
 

--- a/src/engine/shared/snapshot.cpp
+++ b/src/engine/shared/snapshot.cpp
@@ -98,7 +98,7 @@ const void *CSnapshot::FindItem(int Type, int ID) const
 	return Index < 0 ? nullptr : GetItem(Index)->Data();
 }
 
-unsigned CSnapshot::Crc()
+unsigned CSnapshot::Crc() const
 {
 	unsigned int Crc = 0;
 
@@ -113,7 +113,7 @@ unsigned CSnapshot::Crc()
 	return Crc;
 }
 
-void CSnapshot::DebugDump()
+void CSnapshot::DebugDump() const
 {
 	dbg_msg("snapshot", "data_size=%d num_items=%d", m_DataSize, m_NumItems);
 	for(int i = 0; i < m_NumItems; i++)
@@ -537,7 +537,7 @@ void CSnapshotStorage::Add(int Tick, int64_t Tagtime, size_t DataSize, const voi
 	m_pLast = pHolder;
 }
 
-int CSnapshotStorage::Get(int Tick, int64_t *pTagtime, const CSnapshot **ppData, const CSnapshot **ppAltData)
+int CSnapshotStorage::Get(int Tick, int64_t *pTagtime, const CSnapshot **ppData, const CSnapshot **ppAltData) const
 {
 	CHolder *pHolder = m_pFirst;
 

--- a/src/engine/shared/snapshot.h
+++ b/src/engine/shared/snapshot.h
@@ -56,8 +56,8 @@ public:
 	int GetExternalItemType(int InternalType) const;
 	const void *FindItem(int Type, int ID) const;
 
-	unsigned Crc();
-	void DebugDump();
+	unsigned Crc() const;
+	void DebugDump() const;
 	bool IsValid(size_t ActualSize) const;
 
 	static const CSnapshot *EmptySnapshot() { return &ms_EmptySnapshot; }
@@ -131,7 +131,7 @@ public:
 	void PurgeAll();
 	void PurgeUntil(int Tick);
 	void Add(int Tick, int64_t Tagtime, size_t DataSize, const void *pData, size_t AltDataSize, const void *pAltData);
-	int Get(int Tick, int64_t *pTagtime, const CSnapshot **ppData, const CSnapshot **ppAltData);
+	int Get(int Tick, int64_t *pTagtime, const CSnapshot **ppData, const CSnapshot **ppAltData) const;
 };
 
 class CSnapshotBuilder

--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -569,7 +569,7 @@ void CGameConsole::CInstance::ScrollToCenter(int StartLine, int EndLine)
 		m_BacklogCurLine -= ComputedLines;
 }
 
-void CGameConsole::CInstance::UpdateEntryTextAttributes(CBacklogEntry *pEntry)
+void CGameConsole::CInstance::UpdateEntryTextAttributes(CBacklogEntry *pEntry) const
 {
 	CTextCursor Cursor;
 	m_pGameConsole->TextRender()->SetCursor(&Cursor, 0.0f, 0.0f, FONT_SIZE, 0);

--- a/src/game/client/components/console.h
+++ b/src/game/client/components/console.h
@@ -114,7 +114,7 @@ class CGameConsole : public CComponent
 		static void PossibleCommandsCompleteCallback(int Index, const char *pStr, void *pUser);
 		static void PossibleArgumentsCompleteCallback(int Index, const char *pStr, void *pUser);
 
-		void UpdateEntryTextAttributes(CBacklogEntry *pEntry);
+		void UpdateEntryTextAttributes(CBacklogEntry *pEntry) const;
 
 	private:
 		void UpdateSearch();

--- a/src/game/client/components/ghost.cpp
+++ b/src/game/client/components/ghost.cpp
@@ -679,7 +679,7 @@ void CGhost::OnMapLoad()
 	m_AllowRestart = false;
 }
 
-int CGhost::GetLastRaceTick()
+int CGhost::GetLastRaceTick() const
 {
 	return m_LastRaceTick;
 }

--- a/src/game/client/components/ghost.h
+++ b/src/game/client/components/ghost.h
@@ -174,7 +174,7 @@ public:
 	class IGhostLoader *GhostLoader() const { return m_pGhostLoader; }
 	class IGhostRecorder *GhostRecorder() const { return m_pGhostRecorder; }
 
-	int GetLastRaceTick();
+	int GetLastRaceTick() const;
 
 	void RefindSkins();
 };

--- a/src/game/client/components/mapimages.cpp
+++ b/src/game/client/components/mapimages.cpp
@@ -427,7 +427,7 @@ void CMapImages::SetTextureScale(int Scale)
 	}
 }
 
-int CMapImages::GetTextureScale()
+int CMapImages::GetTextureScale() const
 {
 	return m_TextureScale;
 }

--- a/src/game/client/components/mapimages.h
+++ b/src/game/client/components/mapimages.h
@@ -70,7 +70,7 @@ public:
 	IGraphics::CTextureHandle GetOverlayCenter();
 
 	void SetTextureScale(int Scale);
-	int GetTextureScale();
+	int GetTextureScale() const;
 
 	void ChangeEntitiesPath(const char *pPath);
 

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -1634,7 +1634,7 @@ int CMenus::Render()
 
 			char aFilePath[IO_MAX_PATH_LENGTH];
 			char aSaveFolder[IO_MAX_PATH_LENGTH];
-			Storage()->GetCompletePath(Storage()->TYPE_SAVE, "videos", aSaveFolder, sizeof(aSaveFolder));
+			Storage()->GetCompletePath(IStorage::TYPE_SAVE, "videos", aSaveFolder, sizeof(aSaveFolder));
 			str_format(aFilePath, sizeof(aFilePath), "%s/%s.mp4", aSaveFolder, m_DemoRenderInput.GetString());
 
 			Box.HSplitBottom(20.f, &Box, &Part);
@@ -2008,7 +2008,7 @@ void CMenus::OnRender()
 		RenderDemoPlayer(*UI()->Screen());
 	}
 
-	if(Client()->State() == IClient::STATE_ONLINE && m_pClient->m_ServerMode == m_pClient->SERVERMODE_PUREMOD)
+	if(Client()->State() == IClient::STATE_ONLINE && m_pClient->m_ServerMode == CGameClient::SERVERMODE_PUREMOD)
 	{
 		Client()->Disconnect();
 		SetActive(true);

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -942,7 +942,7 @@ void CMenus::PopupWarning(const char *pTopic, const char *pBody, const char *pBu
 	m_PopupWarningLastTime = time_get_nanoseconds();
 }
 
-bool CMenus::CanDisplayWarning()
+bool CMenus::CanDisplayWarning() const
 {
 	return m_Popup == POPUP_NONE;
 }

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -720,8 +720,8 @@ public:
 	void UpdateOwnGhost(CGhostItem Item);
 	void DeleteGhostItem(int Index);
 
-	int GetCurPopup() { return m_Popup; }
-	bool CanDisplayWarning();
+	int GetCurPopup() const { return m_Popup; }
+	bool CanDisplayWarning() const;
 
 	void PopupWarning(const char *pTopic, const char *pBody, const char *pButton, std::chrono::nanoseconds Duration);
 

--- a/src/game/client/components/statboard.cpp
+++ b/src/game/client/components/statboard.cpp
@@ -41,7 +41,7 @@ void CStatboard::OnConsoleInit()
 	Console()->Register("+statboard", "", CFGFLAG_CLIENT, ConKeyStats, this, "Show stats");
 }
 
-bool CStatboard::IsActive()
+bool CStatboard::IsActive() const
 {
 	return m_Active;
 }

--- a/src/game/client/components/statboard.h
+++ b/src/game/client/components/statboard.h
@@ -28,7 +28,7 @@ public:
 	virtual void OnRender() override;
 	virtual void OnRelease() override;
 	virtual void OnMessage(int MsgType, void *pRawMsg) override;
-	bool IsActive();
+	bool IsActive() const;
 };
 
 #endif // GAME_CLIENT_COMPONENTS_STATBOARD_H

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -747,7 +747,7 @@ void CGameClient::OnDummyDisconnect()
 	m_PredictedDummyID = -1;
 }
 
-int CGameClient::GetLastRaceTick()
+int CGameClient::GetLastRaceTick() const
 {
 	return m_Ghost.GetLastRaceTick();
 }
@@ -2339,7 +2339,7 @@ void CGameClient::SendDummyInfo(bool Start)
 	}
 }
 
-void CGameClient::SendKill(int ClientID)
+void CGameClient::SendKill(int ClientID) const
 {
 	CNetMsg_Cl_Kill Msg;
 	Client()->SendPackMsgActive(&Msg, MSGFLAG_VITAL);
@@ -2812,7 +2812,7 @@ void CGameClient::Echo(const char *pString)
 	m_Chat.Echo(pString);
 }
 
-bool CGameClient::IsOtherTeam(int ClientID)
+bool CGameClient::IsOtherTeam(int ClientID) const
 {
 	bool Local = m_Snap.m_LocalClientID == ClientID;
 
@@ -2835,7 +2835,7 @@ bool CGameClient::IsOtherTeam(int ClientID)
 	return m_Teams.Team(ClientID) != m_Teams.Team(m_Snap.m_LocalClientID);
 }
 
-int CGameClient::SwitchStateTeam()
+int CGameClient::SwitchStateTeam() const
 {
 	if(m_aSwitchStateTeam[g_Config.m_ClDummy] >= 0)
 		return m_aSwitchStateTeam[g_Config.m_ClDummy];
@@ -2846,7 +2846,7 @@ int CGameClient::SwitchStateTeam()
 	return m_Teams.Team(m_Snap.m_LocalClientID);
 }
 
-bool CGameClient::IsLocalCharSuper()
+bool CGameClient::IsLocalCharSuper() const
 {
 	if(m_Snap.m_LocalClientID < 0)
 		return false;
@@ -3485,12 +3485,12 @@ void CGameClient::DummyResetInput()
 	m_DummyInput = m_Controls.m_aInputData[!g_Config.m_ClDummy];
 }
 
-bool CGameClient::CanDisplayWarning()
+bool CGameClient::CanDisplayWarning() const
 {
 	return m_Menus.CanDisplayWarning();
 }
 
-bool CGameClient::IsDisplayingWarning()
+bool CGameClient::IsDisplayingWarning() const
 {
 	return m_Menus.GetCurPopup() == CMenus::POPUP_WARNING;
 }

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -507,7 +507,7 @@ public:
 	void SendSwitchTeam(int Team);
 	void SendInfo(bool Start);
 	void SendDummyInfo(bool Start) override;
-	void SendKill(int ClientID);
+	void SendKill(int ClientID) const;
 
 	// DDRace
 
@@ -521,7 +521,7 @@ public:
 
 	int IntersectCharacter(vec2 HookPos, vec2 NewPos, vec2 &NewPos2, int ownID);
 
-	int GetLastRaceTick() override;
+	int GetLastRaceTick() const override;
 
 	bool IsTeamPlay() { return m_Snap.m_pGameInfoObj && m_Snap.m_pGameInfoObj->m_GameFlags & GAMEFLAG_TEAMS; }
 
@@ -543,11 +543,11 @@ public:
 
 	void DummyResetInput() override;
 	void Echo(const char *pString) override;
-	bool IsOtherTeam(int ClientID);
-	int SwitchStateTeam();
-	bool IsLocalCharSuper();
-	bool CanDisplayWarning() override;
-	bool IsDisplayingWarning() override;
+	bool IsOtherTeam(int ClientID) const;
+	int SwitchStateTeam() const;
+	bool IsLocalCharSuper() const;
+	bool CanDisplayWarning() const override;
+	bool IsDisplayingWarning() const override;
 	CNetObjHandler *GetNetObjHandler() override;
 
 	void LoadGameSkin(const char *pPath, bool AsDir = false);

--- a/src/game/client/lineinput.cpp
+++ b/src/game/client/lineinput.cpp
@@ -633,7 +633,7 @@ void CLineInput::Activate(EInputPriority Priority)
 	ms_ActiveInputPriority = Priority;
 }
 
-void CLineInput::Deactivate()
+void CLineInput::Deactivate() const
 {
 	if(!IsActive())
 		return;

--- a/src/game/client/lineinput.h
+++ b/src/game/client/lineinput.h
@@ -194,7 +194,7 @@ public:
 
 	bool IsActive() const { return GetActiveInput() == this; }
 	void Activate(EInputPriority Priority);
-	void Deactivate();
+	void Deactivate() const;
 };
 
 template<size_t MaxSize, size_t MaxChars = MaxSize>

--- a/src/game/client/prediction/entities/character.cpp
+++ b/src/game/client/prediction/entities/character.cpp
@@ -1358,7 +1358,7 @@ void CCharacter::SetCoreWorld(CGameWorld *pGameWorld)
 	m_Core.SetCoreWorld(&pGameWorld->m_Core, pGameWorld->Collision(), pGameWorld->Teams());
 }
 
-bool CCharacter::Match(CCharacter *pChar)
+bool CCharacter::Match(CCharacter *pChar) const
 {
 	return distance(pChar->m_Core.m_Pos, m_Core.m_Pos) <= 32.f;
 }

--- a/src/game/client/prediction/entities/character.h
+++ b/src/game/client/prediction/entities/character.h
@@ -123,7 +123,7 @@ public:
 	int m_GameTeam;
 	bool m_CanMoveInFreeze;
 
-	bool Match(CCharacter *pChar);
+	bool Match(CCharacter *pChar) const;
 	void ResetPrediction();
 	void SetTuneZone(int Zone);
 

--- a/src/game/client/prediction/gameworld.cpp
+++ b/src/game/client/prediction/gameworld.cpp
@@ -372,7 +372,7 @@ void CGameWorld::CreateExplosion(vec2 Pos, int Owner, int Weapon, bool NoDamage,
 	}
 }
 
-bool CGameWorld::IsLocalTeam(int OwnerID)
+bool CGameWorld::IsLocalTeam(int OwnerID) const
 {
 	return OwnerID < 0 || m_Teams.CanCollide(m_LocalClientID, OwnerID);
 }
@@ -698,7 +698,7 @@ CEntity *CGameWorld::FindMatch(int ObjID, int ObjType, const void *pObjData)
 	return 0;
 }
 
-void CGameWorld::OnModified()
+void CGameWorld::OnModified() const
 {
 	if(m_pChild)
 		m_pChild->m_IsValidCopy = false;

--- a/src/game/client/prediction/gameworld.h
+++ b/src/game/client/prediction/gameworld.h
@@ -89,8 +89,8 @@ public:
 
 	int m_LocalClientID;
 
-	bool IsLocalTeam(int OwnerID);
-	void OnModified();
+	bool IsLocalTeam(int OwnerID) const;
+	void OnModified() const;
 	void NetObjBegin(CTeamsCore Teams, int LocalClientID);
 	void NetCharAdd(int ObjID, CNetObj_Character *pChar, CNetObj_DDNetCharacter *pExtended, int GameTeam, bool IsLocal);
 	void NetObjAdd(int ObjID, int ObjType, const void *pObjData, const CNetObj_EntityEx *pDataEx);

--- a/src/game/client/render.cpp
+++ b/src/game/client/render.cpp
@@ -57,7 +57,7 @@ void CRenderTools::Init(IGraphics *pGraphics, ITextRender *pTextRender)
 	Graphics()->QuadContainerUpload(m_TeeQuadContainerIndex);
 }
 
-void CRenderTools::SelectSprite(CDataSprite *pSpr, int Flags, int sx, int sy)
+void CRenderTools::SelectSprite(CDataSprite *pSpr, int Flags, int sx, int sy) const
 {
 	int x = pSpr->m_X + sx;
 	int y = pSpr->m_Y + sy;
@@ -82,45 +82,45 @@ void CRenderTools::SelectSprite(CDataSprite *pSpr, int Flags, int sx, int sy)
 	Graphics()->QuadsSetSubset(x1, y1, x2, y2);
 }
 
-void CRenderTools::SelectSprite(int Id, int Flags, int sx, int sy)
+void CRenderTools::SelectSprite(int Id, int Flags, int sx, int sy) const
 {
 	if(Id < 0 || Id >= g_pData->m_NumSprites)
 		return;
 	SelectSprite(&g_pData->m_aSprites[Id], Flags, sx, sy);
 }
 
-void CRenderTools::GetSpriteScale(struct CDataSprite *pSprite, float &ScaleX, float &ScaleY)
+void CRenderTools::GetSpriteScale(const CDataSprite *pSprite, float &ScaleX, float &ScaleY) const
 {
 	int w = pSprite->m_W;
 	int h = pSprite->m_H;
 	GetSpriteScaleImpl(w, h, ScaleX, ScaleY);
 }
 
-void CRenderTools::GetSpriteScale(int Id, float &ScaleX, float &ScaleY)
+void CRenderTools::GetSpriteScale(int Id, float &ScaleX, float &ScaleY) const
 {
 	GetSpriteScale(&g_pData->m_aSprites[Id], ScaleX, ScaleY);
 }
 
-void CRenderTools::GetSpriteScaleImpl(int Width, int Height, float &ScaleX, float &ScaleY)
+void CRenderTools::GetSpriteScaleImpl(int Width, int Height, float &ScaleX, float &ScaleY) const
 {
 	const float f = length(vec2(Width, Height));
 	ScaleX = Width / f;
 	ScaleY = Height / f;
 }
 
-void CRenderTools::DrawSprite(float x, float y, float Size)
+void CRenderTools::DrawSprite(float x, float y, float Size) const
 {
 	IGraphics::CQuadItem QuadItem(x, y, Size * gs_SpriteWScale, Size * gs_SpriteHScale);
 	Graphics()->QuadsDraw(&QuadItem, 1);
 }
 
-void CRenderTools::DrawSprite(float x, float y, float ScaledWidth, float ScaledHeight)
+void CRenderTools::DrawSprite(float x, float y, float ScaledWidth, float ScaledHeight) const
 {
 	IGraphics::CQuadItem QuadItem(x, y, ScaledWidth, ScaledHeight);
 	Graphics()->QuadsDraw(&QuadItem, 1);
 }
 
-void CRenderTools::RenderCursor(vec2 Center, float Size)
+void CRenderTools::RenderCursor(vec2 Center, float Size) const
 {
 	Graphics()->WrapClamp();
 	Graphics()->TextureSet(g_pData->m_aImages[IMAGE_CURSOR].m_Id);
@@ -132,7 +132,7 @@ void CRenderTools::RenderCursor(vec2 Center, float Size)
 	Graphics()->WrapNormal();
 }
 
-void CRenderTools::RenderIcon(int ImageId, int SpriteId, const CUIRect *pRect, const ColorRGBA *pColor)
+void CRenderTools::RenderIcon(int ImageId, int SpriteId, const CUIRect *pRect, const ColorRGBA *pColor) const
 {
 	Graphics()->TextureSet(g_pData->m_aImages[ImageId].m_Id);
 	Graphics()->QuadsBegin();
@@ -144,25 +144,25 @@ void CRenderTools::RenderIcon(int ImageId, int SpriteId, const CUIRect *pRect, c
 	Graphics()->QuadsEnd();
 }
 
-int CRenderTools::QuadContainerAddSprite(int QuadContainerIndex, float x, float y, float Size)
+int CRenderTools::QuadContainerAddSprite(int QuadContainerIndex, float x, float y, float Size) const
 {
 	IGraphics::CQuadItem QuadItem(x, y, Size, Size);
 	return Graphics()->QuadContainerAddQuads(QuadContainerIndex, &QuadItem, 1);
 }
 
-int CRenderTools::QuadContainerAddSprite(int QuadContainerIndex, float Size)
+int CRenderTools::QuadContainerAddSprite(int QuadContainerIndex, float Size) const
 {
 	IGraphics::CQuadItem QuadItem(-(Size) / 2.f, -(Size) / 2.f, (Size), (Size));
 	return Graphics()->QuadContainerAddQuads(QuadContainerIndex, &QuadItem, 1);
 }
 
-int CRenderTools::QuadContainerAddSprite(int QuadContainerIndex, float Width, float Height)
+int CRenderTools::QuadContainerAddSprite(int QuadContainerIndex, float Width, float Height) const
 {
 	IGraphics::CQuadItem QuadItem(-(Width) / 2.f, -(Height) / 2.f, (Width), (Height));
 	return Graphics()->QuadContainerAddQuads(QuadContainerIndex, &QuadItem, 1);
 }
 
-int CRenderTools::QuadContainerAddSprite(int QuadContainerIndex, float X, float Y, float Width, float Height)
+int CRenderTools::QuadContainerAddSprite(int QuadContainerIndex, float X, float Y, float Width, float Height) const
 {
 	IGraphics::CQuadItem QuadItem(X, Y, Width, Height);
 	return Graphics()->QuadContainerAddQuads(QuadContainerIndex, &QuadItem, 1);

--- a/src/game/client/render.h
+++ b/src/game/client/render.h
@@ -130,21 +130,21 @@ public:
 
 	void Init(class IGraphics *pGraphics, class ITextRender *pTextRender);
 
-	void SelectSprite(CDataSprite *pSprite, int Flags = 0, int sx = 0, int sy = 0);
-	void SelectSprite(int Id, int Flags = 0, int sx = 0, int sy = 0);
+	void SelectSprite(CDataSprite *pSprite, int Flags = 0, int sx = 0, int sy = 0) const;
+	void SelectSprite(int Id, int Flags = 0, int sx = 0, int sy = 0) const;
 
-	void GetSpriteScale(CDataSprite *pSprite, float &ScaleX, float &ScaleY);
-	void GetSpriteScale(int Id, float &ScaleX, float &ScaleY);
-	void GetSpriteScaleImpl(int Width, int Height, float &ScaleX, float &ScaleY);
+	void GetSpriteScale(const CDataSprite *pSprite, float &ScaleX, float &ScaleY) const;
+	void GetSpriteScale(int Id, float &ScaleX, float &ScaleY) const;
+	void GetSpriteScaleImpl(int Width, int Height, float &ScaleX, float &ScaleY) const;
 
-	void DrawSprite(float x, float y, float size);
-	void DrawSprite(float x, float y, float ScaledWidth, float ScaledHeight);
-	void RenderCursor(vec2 Center, float Size);
-	void RenderIcon(int ImageId, int SpriteId, const CUIRect *pRect, const ColorRGBA *pColor = nullptr);
-	int QuadContainerAddSprite(int QuadContainerIndex, float x, float y, float size);
-	int QuadContainerAddSprite(int QuadContainerIndex, float size);
-	int QuadContainerAddSprite(int QuadContainerIndex, float Width, float Height);
-	int QuadContainerAddSprite(int QuadContainerIndex, float X, float Y, float Width, float Height);
+	void DrawSprite(float x, float y, float Size) const;
+	void DrawSprite(float x, float y, float ScaledWidth, float ScaledHeight) const;
+	void RenderCursor(vec2 Center, float Size) const;
+	void RenderIcon(int ImageId, int SpriteId, const CUIRect *pRect, const ColorRGBA *pColor = nullptr) const;
+	int QuadContainerAddSprite(int QuadContainerIndex, float x, float y, float Size) const;
+	int QuadContainerAddSprite(int QuadContainerIndex, float Size) const;
+	int QuadContainerAddSprite(int QuadContainerIndex, float Width, float Height) const;
+	int QuadContainerAddSprite(int QuadContainerIndex, float X, float Y, float Width, float Height) const;
 
 	// larger rendering methods
 	void GetRenderTeeBodySize(const CAnimState *pAnim, const CTeeRenderInfo *pInfo, vec2 &BodyOffset, float &Width, float &Height);
@@ -158,13 +158,13 @@ public:
 
 	// map render methods (render_map.cpp)
 	static void RenderEvalEnvelope(const IEnvelopePointAccess *pPoints, int Channels, std::chrono::nanoseconds TimeNanos, ColorRGBA &Result);
-	void RenderQuads(CQuad *pQuads, int NumQuads, int Flags, ENVELOPE_EVAL pfnEval, void *pUser);
-	void ForceRenderQuads(CQuad *pQuads, int NumQuads, int Flags, ENVELOPE_EVAL pfnEval, void *pUser, float Alpha = 1.0f);
-	void RenderTilemap(CTile *pTiles, int w, int h, float Scale, ColorRGBA Color, int RenderFlags, ENVELOPE_EVAL pfnEval, void *pUser, int ColorEnv, int ColorEnvOffset);
+	void RenderQuads(CQuad *pQuads, int NumQuads, int Flags, ENVELOPE_EVAL pfnEval, void *pUser) const;
+	void ForceRenderQuads(CQuad *pQuads, int NumQuads, int Flags, ENVELOPE_EVAL pfnEval, void *pUser, float Alpha = 1.0f) const;
+	void RenderTilemap(CTile *pTiles, int w, int h, float Scale, ColorRGBA Color, int RenderFlags, ENVELOPE_EVAL pfnEval, void *pUser, int ColorEnv, int ColorEnvOffset) const;
 
 	// render a rectangle made of IndexIn tiles, over a background made of IndexOut tiles
 	// the rectangle include all tiles in [RectX, RectX+RectW-1] x [RectY, RectY+RectH-1]
-	void RenderTileRectangle(int RectX, int RectY, int RectW, int RectH, unsigned char IndexIn, unsigned char IndexOut, float Scale, ColorRGBA Color, int RenderFlags, ENVELOPE_EVAL pfnEval, void *pUser, int ColorEnv, int ColorEnvOffset);
+	void RenderTileRectangle(int RectX, int RectY, int RectW, int RectH, unsigned char IndexIn, unsigned char IndexOut, float Scale, ColorRGBA Color, int RenderFlags, ENVELOPE_EVAL pfnEval, void *pUser, int ColorEnv, int ColorEnvOffset) const;
 
 	// helpers
 	void CalcScreenParams(float Aspect, float Zoom, float *pWidth, float *pHeight);
@@ -175,14 +175,14 @@ public:
 
 	// DDRace
 
-	void RenderTeleOverlay(CTeleTile *pTele, int w, int h, float Scale, float Alpha = 1.0f);
-	void RenderSpeedupOverlay(CSpeedupTile *pSpeedup, int w, int h, float Scale, float Alpha = 1.0f);
-	void RenderSwitchOverlay(CSwitchTile *pSwitch, int w, int h, float Scale, float Alpha = 1.0f);
-	void RenderTuneOverlay(CTuneTile *pTune, int w, int h, float Scale, float Alpha = 1.0f);
-	void RenderTelemap(CTeleTile *pTele, int w, int h, float Scale, ColorRGBA Color, int RenderFlags);
-	void RenderSpeedupmap(CSpeedupTile *pSpeedup, int w, int h, float Scale, ColorRGBA Color, int RenderFlags);
-	void RenderSwitchmap(CSwitchTile *pSwitch, int w, int h, float Scale, ColorRGBA Color, int RenderFlags);
-	void RenderTunemap(CTuneTile *pTune, int w, int h, float Scale, ColorRGBA Color, int RenderFlags);
+	void RenderTeleOverlay(CTeleTile *pTele, int w, int h, float Scale, float Alpha = 1.0f) const;
+	void RenderSpeedupOverlay(CSpeedupTile *pSpeedup, int w, int h, float Scale, float Alpha = 1.0f) const;
+	void RenderSwitchOverlay(CSwitchTile *pSwitch, int w, int h, float Scale, float Alpha = 1.0f) const;
+	void RenderTuneOverlay(CTuneTile *pTune, int w, int h, float Scale, float Alpha = 1.0f) const;
+	void RenderTelemap(CTeleTile *pTele, int w, int h, float Scale, ColorRGBA Color, int RenderFlags) const;
+	void RenderSpeedupmap(CSpeedupTile *pSpeedup, int w, int h, float Scale, ColorRGBA Color, int RenderFlags) const;
+	void RenderSwitchmap(CSwitchTile *pSwitch, int w, int h, float Scale, ColorRGBA Color, int RenderFlags) const;
+	void RenderTunemap(CTuneTile *pTune, int w, int h, float Scale, ColorRGBA Color, int RenderFlags) const;
 };
 
 #endif

--- a/src/game/client/render_map.cpp
+++ b/src/game/client/render_map.cpp
@@ -351,7 +351,7 @@ static void Rotate(CPoint *pCenter, CPoint *pPoint, float Rotation)
 	pPoint->y = (int)(x * std::sin(Rotation) + y * std::cos(Rotation) + pCenter->y);
 }
 
-void CRenderTools::RenderQuads(CQuad *pQuads, int NumQuads, int RenderFlags, ENVELOPE_EVAL pfnEval, void *pUser)
+void CRenderTools::RenderQuads(CQuad *pQuads, int NumQuads, int RenderFlags, ENVELOPE_EVAL pfnEval, void *pUser) const
 {
 	if(!g_Config.m_ClShowQuads || g_Config.m_ClOverlayEntities == 100)
 		return;
@@ -359,7 +359,7 @@ void CRenderTools::RenderQuads(CQuad *pQuads, int NumQuads, int RenderFlags, ENV
 	ForceRenderQuads(pQuads, NumQuads, RenderFlags, pfnEval, pUser, (100 - g_Config.m_ClOverlayEntities) / 100.0f);
 }
 
-void CRenderTools::ForceRenderQuads(CQuad *pQuads, int NumQuads, int RenderFlags, ENVELOPE_EVAL pfnEval, void *pUser, float Alpha)
+void CRenderTools::ForceRenderQuads(CQuad *pQuads, int NumQuads, int RenderFlags, ENVELOPE_EVAL pfnEval, void *pUser, float Alpha) const
 {
 	Graphics()->TrianglesBegin();
 	float Conv = 1 / 255.0f;
@@ -443,7 +443,7 @@ void CRenderTools::ForceRenderQuads(CQuad *pQuads, int NumQuads, int RenderFlags
 void CRenderTools::RenderTileRectangle(int RectX, int RectY, int RectW, int RectH,
 	unsigned char IndexIn, unsigned char IndexOut,
 	float Scale, ColorRGBA Color, int RenderFlags,
-	ENVELOPE_EVAL pfnEval, void *pUser, int ColorEnv, int ColorEnvOffset)
+	ENVELOPE_EVAL pfnEval, void *pUser, int ColorEnv, int ColorEnvOffset) const
 {
 	float ScreenX0, ScreenY0, ScreenX1, ScreenY1;
 	Graphics()->GetScreen(&ScreenX0, &ScreenY0, &ScreenX1, &ScreenY1);
@@ -541,7 +541,7 @@ void CRenderTools::RenderTileRectangle(int RectX, int RectY, int RectW, int Rect
 }
 
 void CRenderTools::RenderTilemap(CTile *pTiles, int w, int h, float Scale, ColorRGBA Color, int RenderFlags,
-	ENVELOPE_EVAL pfnEval, void *pUser, int ColorEnv, int ColorEnvOffset)
+	ENVELOPE_EVAL pfnEval, void *pUser, int ColorEnv, int ColorEnvOffset) const
 {
 	float ScreenX0, ScreenY0, ScreenX1, ScreenY1;
 	Graphics()->GetScreen(&ScreenX0, &ScreenY0, &ScreenX1, &ScreenY1);
@@ -707,7 +707,7 @@ void CRenderTools::RenderTilemap(CTile *pTiles, int w, int h, float Scale, Color
 	Graphics()->MapScreen(ScreenX0, ScreenY0, ScreenX1, ScreenY1);
 }
 
-void CRenderTools::RenderTeleOverlay(CTeleTile *pTele, int w, int h, float Scale, float Alpha)
+void CRenderTools::RenderTeleOverlay(CTeleTile *pTele, int w, int h, float Scale, float Alpha) const
 {
 	if(!g_Config.m_ClTextEntities)
 		return;
@@ -757,7 +757,7 @@ void CRenderTools::RenderTeleOverlay(CTeleTile *pTele, int w, int h, float Scale
 	Graphics()->MapScreen(ScreenX0, ScreenY0, ScreenX1, ScreenY1);
 }
 
-void CRenderTools::RenderSpeedupOverlay(CSpeedupTile *pSpeedup, int w, int h, float Scale, float Alpha)
+void CRenderTools::RenderSpeedupOverlay(CSpeedupTile *pSpeedup, int w, int h, float Scale, float Alpha) const
 {
 	float ScreenX0, ScreenY0, ScreenX1, ScreenY1;
 	Graphics()->GetScreen(&ScreenX0, &ScreenY0, &ScreenX1, &ScreenY1);
@@ -826,7 +826,7 @@ void CRenderTools::RenderSpeedupOverlay(CSpeedupTile *pSpeedup, int w, int h, fl
 	Graphics()->MapScreen(ScreenX0, ScreenY0, ScreenX1, ScreenY1);
 }
 
-void CRenderTools::RenderSwitchOverlay(CSwitchTile *pSwitch, int w, int h, float Scale, float Alpha)
+void CRenderTools::RenderSwitchOverlay(CSwitchTile *pSwitch, int w, int h, float Scale, float Alpha) const
 {
 	if(!g_Config.m_ClTextEntities)
 		return;
@@ -886,7 +886,7 @@ void CRenderTools::RenderSwitchOverlay(CSwitchTile *pSwitch, int w, int h, float
 	Graphics()->MapScreen(ScreenX0, ScreenY0, ScreenX1, ScreenY1);
 }
 
-void CRenderTools::RenderTuneOverlay(CTuneTile *pTune, int w, int h, float Scale, float Alpha)
+void CRenderTools::RenderTuneOverlay(CTuneTile *pTune, int w, int h, float Scale, float Alpha) const
 {
 	if(!g_Config.m_ClTextEntities)
 		return;
@@ -935,7 +935,7 @@ void CRenderTools::RenderTuneOverlay(CTuneTile *pTune, int w, int h, float Scale
 	Graphics()->MapScreen(ScreenX0, ScreenY0, ScreenX1, ScreenY1);
 }
 
-void CRenderTools::RenderTelemap(CTeleTile *pTele, int w, int h, float Scale, ColorRGBA Color, int RenderFlags)
+void CRenderTools::RenderTelemap(CTeleTile *pTele, int w, int h, float Scale, ColorRGBA Color, int RenderFlags) const
 {
 	float ScreenX0, ScreenY0, ScreenX1, ScreenY1;
 	Graphics()->GetScreen(&ScreenX0, &ScreenY0, &ScreenX1, &ScreenY1);
@@ -1052,7 +1052,7 @@ void CRenderTools::RenderTelemap(CTeleTile *pTele, int w, int h, float Scale, Co
 	Graphics()->MapScreen(ScreenX0, ScreenY0, ScreenX1, ScreenY1);
 }
 
-void CRenderTools::RenderSpeedupmap(CSpeedupTile *pSpeedupTile, int w, int h, float Scale, ColorRGBA Color, int RenderFlags)
+void CRenderTools::RenderSpeedupmap(CSpeedupTile *pSpeedupTile, int w, int h, float Scale, ColorRGBA Color, int RenderFlags) const
 {
 	//Graphics()->TextureSet(img_get(tmap->image));
 	float ScreenX0, ScreenY0, ScreenX1, ScreenY1;
@@ -1171,7 +1171,7 @@ void CRenderTools::RenderSpeedupmap(CSpeedupTile *pSpeedupTile, int w, int h, fl
 	Graphics()->MapScreen(ScreenX0, ScreenY0, ScreenX1, ScreenY1);
 }
 
-void CRenderTools::RenderSwitchmap(CSwitchTile *pSwitchTile, int w, int h, float Scale, ColorRGBA Color, int RenderFlags)
+void CRenderTools::RenderSwitchmap(CSwitchTile *pSwitchTile, int w, int h, float Scale, ColorRGBA Color, int RenderFlags) const
 {
 	//Graphics()->TextureSet(img_get(tmap->image));
 	float ScreenX0, ScreenY0, ScreenX1, ScreenY1;
@@ -1333,7 +1333,7 @@ void CRenderTools::RenderSwitchmap(CSwitchTile *pSwitchTile, int w, int h, float
 	Graphics()->MapScreen(ScreenX0, ScreenY0, ScreenX1, ScreenY1);
 }
 
-void CRenderTools::RenderTunemap(CTuneTile *pTune, int w, int h, float Scale, ColorRGBA Color, int RenderFlags)
+void CRenderTools::RenderTunemap(CTuneTile *pTune, int w, int h, float Scale, ColorRGBA Color, int RenderFlags) const
 {
 	float ScreenX0, ScreenY0, ScreenX1, ScreenY1;
 	Graphics()->GetScreen(&ScreenX0, &ScreenY0, &ScreenX1, &ScreenY1);

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -152,7 +152,7 @@ void CUI::AddUIElement(CUIElement *pElement)
 	m_vpUIElements.push_back(pElement);
 }
 
-void CUI::ResetUIElement(CUIElement &UIElement)
+void CUI::ResetUIElement(CUIElement &UIElement) const
 {
 	for(CUIElement::SUIElementRect &Rect : UIElement.m_vUIRects)
 	{
@@ -533,7 +533,7 @@ EEditState CUI::DoPickerLogic(const void *pID, const CUIRect *pRect, float *pX, 
 	return Res;
 }
 
-void CUI::DoSmoothScrollLogic(float *pScrollOffset, float *pScrollOffsetChange, float ViewPortSize, float TotalSize, bool SmoothClamp, float ScrollSpeed)
+void CUI::DoSmoothScrollLogic(float *pScrollOffset, float *pScrollOffsetChange, float ViewPortSize, float TotalSize, bool SmoothClamp, float ScrollSpeed) const
 {
 	// reset scrolling if it's not necessary anymore
 	if(TotalSize < ViewPortSize)
@@ -666,7 +666,7 @@ vec2 CUI::CalcAlignedCursorPos(const CUIRect *pRect, vec2 TextSize, int Align, c
 	return Cursor;
 }
 
-void CUI::DoLabel(const CUIRect *pRect, const char *pText, float Size, int Align, const SLabelProperties &LabelProps)
+void CUI::DoLabel(const CUIRect *pRect, const char *pText, float Size, int Align, const SLabelProperties &LabelProps) const
 {
 	const int Flags = GetFlagsForLabelProperties(LabelProps, nullptr);
 	const SCursorAndBoundingBox TextBounds = CalcFontSizeCursorHeightAndBoundingBox(TextRender(), pText, Flags, Size, pRect->w, LabelProps);
@@ -678,7 +678,7 @@ void CUI::DoLabel(const CUIRect *pRect, const char *pText, float Size, int Align
 	TextRender()->TextEx(&Cursor, pText, -1);
 }
 
-void CUI::DoLabel(CUIElement::SUIElementRect &RectEl, const CUIRect *pRect, const char *pText, float Size, int Align, const SLabelProperties &LabelProps, int StrLen, const CTextCursor *pReadCursor)
+void CUI::DoLabel(CUIElement::SUIElementRect &RectEl, const CUIRect *pRect, const char *pText, float Size, int Align, const SLabelProperties &LabelProps, int StrLen, const CTextCursor *pReadCursor) const
 {
 	const int Flags = GetFlagsForLabelProperties(LabelProps, pReadCursor);
 	const SCursorAndBoundingBox TextBounds = CalcFontSizeCursorHeightAndBoundingBox(TextRender(), pText, Flags, Size, pRect->w, LabelProps);
@@ -705,7 +705,7 @@ void CUI::DoLabel(CUIElement::SUIElementRect &RectEl, const CUIRect *pRect, cons
 	RectEl.m_Cursor = Cursor;
 }
 
-void CUI::DoLabelStreamed(CUIElement::SUIElementRect &RectEl, const CUIRect *pRect, const char *pText, float Size, int Align, const SLabelProperties &LabelProps, int StrLen, const CTextCursor *pReadCursor)
+void CUI::DoLabelStreamed(CUIElement::SUIElementRect &RectEl, const CUIRect *pRect, const char *pText, float Size, int Align, const SLabelProperties &LabelProps, int StrLen, const CTextCursor *pReadCursor) const
 {
 	const int ReadCursorGlyphCount = pReadCursor == nullptr ? -1 : pReadCursor->m_GlyphCount;
 	bool NeedsRecreate = false;
@@ -1335,7 +1335,7 @@ void CUI::DoScrollbarOption(const void *pID, int *pOption, const CUIRect *pRect,
 	*pOption = Value;
 }
 
-void CUI::RenderProgressSpinner(vec2 Center, float OuterRadius, const SProgressSpinnerProperties &Props)
+void CUI::RenderProgressSpinner(vec2 Center, float OuterRadius, const SProgressSpinnerProperties &Props) const
 {
 	static float s_SpinnerOffset = 0.0f;
 	static float s_LastRender = Client()->LocalTime();

--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -408,7 +408,7 @@ public:
 		HOTKEY_END = 1 << 11,
 	};
 
-	void ResetUIElement(CUIElement &UIElement);
+	void ResetUIElement(CUIElement &UIElement) const;
 
 	CUIElement *GetNewUIElement(int RequestedRectCount);
 
@@ -505,13 +505,13 @@ public:
 	int DoButtonLogic(const void *pID, int Checked, const CUIRect *pRect);
 	int DoDraggableButtonLogic(const void *pID, int Checked, const CUIRect *pRect, bool *pClicked, bool *pAbrupted);
 	EEditState DoPickerLogic(const void *pID, const CUIRect *pRect, float *pX, float *pY);
-	void DoSmoothScrollLogic(float *pScrollOffset, float *pScrollOffsetChange, float ViewPortSize, float TotalSize, bool SmoothClamp = false, float ScrollSpeed = 10.0f);
+	void DoSmoothScrollLogic(float *pScrollOffset, float *pScrollOffsetChange, float ViewPortSize, float TotalSize, bool SmoothClamp = false, float ScrollSpeed = 10.0f) const;
 	static vec2 CalcAlignedCursorPos(const CUIRect *pRect, vec2 TextSize, int Align, const float *pBiggestCharHeight = nullptr);
 
-	void DoLabel(const CUIRect *pRect, const char *pText, float Size, int Align, const SLabelProperties &LabelProps = {});
+	void DoLabel(const CUIRect *pRect, const char *pText, float Size, int Align, const SLabelProperties &LabelProps = {}) const;
 
-	void DoLabel(CUIElement::SUIElementRect &RectEl, const CUIRect *pRect, const char *pText, float Size, int Align, const SLabelProperties &LabelProps = {}, int StrLen = -1, const CTextCursor *pReadCursor = nullptr);
-	void DoLabelStreamed(CUIElement::SUIElementRect &RectEl, const CUIRect *pRect, const char *pText, float Size, int Align, const SLabelProperties &LabelProps = {}, int StrLen = -1, const CTextCursor *pReadCursor = nullptr);
+	void DoLabel(CUIElement::SUIElementRect &RectEl, const CUIRect *pRect, const char *pText, float Size, int Align, const SLabelProperties &LabelProps = {}, int StrLen = -1, const CTextCursor *pReadCursor = nullptr) const;
+	void DoLabelStreamed(CUIElement::SUIElementRect &RectEl, const CUIRect *pRect, const char *pText, float Size, int Align, const SLabelProperties &LabelProps = {}, int StrLen = -1, const CTextCursor *pReadCursor = nullptr) const;
 
 	bool DoEditBox(CLineInput *pLineInput, const CUIRect *pRect, float FontSize, int Corners = IGraphics::CORNER_ALL);
 	bool DoClearableEditBox(CLineInput *pLineInput, const CUIRect *pRect, float FontSize, int Corners = IGraphics::CORNER_ALL);
@@ -538,7 +538,7 @@ public:
 	void DoScrollbarOption(const void *pID, int *pOption, const CUIRect *pRect, const char *pStr, int Min, int Max, const IScrollbarScale *pScale = &ms_LinearScrollbarScale, unsigned Flags = 0u, const char *pSuffix = "");
 
 	// progress spinner
-	void RenderProgressSpinner(vec2 Center, float OuterRadius, const SProgressSpinnerProperties &Props = {});
+	void RenderProgressSpinner(vec2 Center, float OuterRadius, const SProgressSpinnerProperties &Props = {}) const;
 
 	// popup menu
 	void DoPopupMenu(const SPopupMenuId *pID, int X, int Y, int Width, int Height, void *pContext, FPopupMenuFunction pfnFunc, const SPopupMenuProperties &Props = {});

--- a/src/game/collision.cpp
+++ b/src/game/collision.cpp
@@ -225,7 +225,7 @@ static int GetMoveRestrictions(int Direction, int Tile, int Flags)
 	return Result & GetMoveRestrictionsMask(Direction);
 }
 
-int CCollision::GetMoveRestrictions(CALLBACK_SWITCHACTIVE pfnSwitchActive, void *pUser, vec2 Pos, float Distance, int OverrideCenterTileIndex)
+int CCollision::GetMoveRestrictions(CALLBACK_SWITCHACTIVE pfnSwitchActive, void *pUser, vec2 Pos, float Distance, int OverrideCenterTileIndex) const
 {
 	static const vec2 DIRECTIONS[NUM_MR_DIRS] =
 		{

--- a/src/game/collision.h
+++ b/src/game/collision.h
@@ -62,7 +62,7 @@ public:
 	int GetIndex(vec2 PrevPos, vec2 Pos) const;
 	int GetFIndex(int x, int y) const;
 
-	int GetMoveRestrictions(CALLBACK_SWITCHACTIVE pfnSwitchActive, void *pUser, vec2 Pos, float Distance = 18.0f, int OverrideCenterTileIndex = -1);
+	int GetMoveRestrictions(CALLBACK_SWITCHACTIVE pfnSwitchActive, void *pUser, vec2 Pos, float Distance = 18.0f, int OverrideCenterTileIndex = -1) const;
 	int GetMoveRestrictions(vec2 Pos, float Distance = 18.0f)
 	{
 		return GetMoveRestrictions(nullptr, nullptr, Pos, Distance);

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -508,7 +508,7 @@ std::vector<CQuad *> CEditor::GetSelectedQuads()
 	return vpQuads;
 }
 
-CSoundSource *CEditor::GetSelectedSource()
+CSoundSource *CEditor::GetSelectedSource() const
 {
 	std::shared_ptr<CLayerSounds> pSounds = std::static_pointer_cast<CLayerSounds>(GetSelectedLayerType(0, LAYERTYPE_SOUNDS));
 	if(!pSounds)

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -467,7 +467,7 @@ public:
 	std::shared_ptr<CLayer> GetSelectedLayerType(int Index, int Type) const;
 	std::shared_ptr<CLayer> GetSelectedLayer(int Index) const;
 	std::shared_ptr<CLayerGroup> GetSelectedGroup() const;
-	CSoundSource *GetSelectedSource();
+	CSoundSource *GetSelectedSource() const;
 	void SelectLayer(int LayerIndex, int GroupIndex = -1);
 	void AddSelectedLayer(int LayerIndex);
 	void SelectQuad(int Index);

--- a/src/game/editor/editor_actions.cpp
+++ b/src/game/editor/editor_actions.cpp
@@ -1078,6 +1078,7 @@ void CEditorActionEditLayersGroupAndOrder::Undo()
 	auto &pCurrentGroup = Map.m_vpGroups[m_NewGroupIndex];
 	auto &pPreviousGroup = Map.m_vpGroups[m_GroupIndex];
 	std::vector<std::shared_ptr<CLayer>> vpLayers;
+	vpLayers.reserve(m_NewLayerIndices.size());
 	for(auto &LayerIndex : m_NewLayerIndices)
 		vpLayers.push_back(pCurrentGroup->m_vpLayers[LayerIndex]);
 
@@ -1099,6 +1100,7 @@ void CEditorActionEditLayersGroupAndOrder::Redo()
 	auto &pCurrentGroup = Map.m_vpGroups[m_GroupIndex];
 	auto &pPreviousGroup = Map.m_vpGroups[m_NewGroupIndex];
 	std::vector<std::shared_ptr<CLayer>> vpLayers;
+	vpLayers.reserve(m_LayerIndices.size());
 	for(auto &LayerIndex : m_LayerIndices)
 		vpLayers.push_back(pCurrentGroup->m_vpLayers[LayerIndex]);
 

--- a/src/game/editor/editor_actions.cpp
+++ b/src/game/editor/editor_actions.cpp
@@ -48,7 +48,7 @@ CEditorBrushDrawAction::CEditorBrushDrawAction(CEditor *pEditor, int Group) :
 
 			if(!pLayerTiles->m_TilesHistory.empty())
 			{
-				m_vTileChanges.emplace_back(std::make_pair(k, std::map(pLayerTiles->m_TilesHistory)));
+				m_vTileChanges.emplace_back(k, std::map(pLayerTiles->m_TilesHistory));
 				pLayerTiles->ClearHistory();
 			}
 		}

--- a/src/game/editor/map_grid.cpp
+++ b/src/game/editor/map_grid.cpp
@@ -74,7 +74,7 @@ int CMapGrid::GridLineDistance() const
 		return 512;
 }
 
-void CMapGrid::SnapToGrid(float &x, float &y)
+void CMapGrid::SnapToGrid(float &x, float &y) const
 {
 	const int GridDistance = GridLineDistance() * m_GridFactor;
 	x = (int)((x + (x >= 0 ? 1.0f : -1.0f) * GridDistance / 2) / GridDistance) * GridDistance;

--- a/src/game/editor/map_grid.h
+++ b/src/game/editor/map_grid.h
@@ -9,7 +9,7 @@ public:
 	void OnReset() override;
 	void OnRender(CUIRect View) override;
 
-	void SnapToGrid(float &x, float &y);
+	void SnapToGrid(float &x, float &y) const;
 	int GridLineDistance() const;
 
 	/**

--- a/src/game/editor/map_view.cpp
+++ b/src/game/editor/map_view.cpp
@@ -135,7 +135,7 @@ void CMapView::ResetZoom()
 	m_Zoom.SetValue(100.0f);
 }
 
-float CMapView::ScaleLength(float Value)
+float CMapView::ScaleLength(float Value) const
 {
 	return m_WorldZoom * Value;
 }

--- a/src/game/editor/map_view.h
+++ b/src/game/editor/map_view.h
@@ -34,7 +34,7 @@ public:
 	/**
 	 * Scale length according to zoom value.
 	 */
-	float ScaleLength(float Value);
+	float ScaleLength(float Value) const;
 
 	bool m_ShowPicker; // TODO: make private
 

--- a/src/game/editor/mapitems/layer_group.cpp
+++ b/src/game/editor/mapitems/layer_group.cpp
@@ -27,13 +27,13 @@ CLayerGroup::~CLayerGroup()
 	m_vpLayers.clear();
 }
 
-void CLayerGroup::Convert(CUIRect *pRect)
+void CLayerGroup::Convert(CUIRect *pRect) const
 {
 	pRect->x += m_OffsetX;
 	pRect->y += m_OffsetY;
 }
 
-void CLayerGroup::Mapping(float *pPoints)
+void CLayerGroup::Mapping(float *pPoints) const
 {
 	float NormalParallaxZoom = clamp((double)(maximum(m_ParallaxX, m_ParallaxY)), 0., 100.);
 	float ParallaxZoom = m_pMap->m_pEditor->m_PreviewZoom ? NormalParallaxZoom : 100.0f;
@@ -49,7 +49,7 @@ void CLayerGroup::Mapping(float *pPoints)
 	pPoints[3] += m_pMap->m_pEditor->MapView()->GetEditorOffset().y;
 }
 
-void CLayerGroup::MapScreen()
+void CLayerGroup::MapScreen() const
 {
 	float aPoints[4];
 	Mapping(aPoints);

--- a/src/game/editor/mapitems/layer_group.h
+++ b/src/game/editor/mapitems/layer_group.h
@@ -33,10 +33,10 @@ public:
 	CLayerGroup();
 	~CLayerGroup();
 
-	void Convert(CUIRect *pRect);
+	void Convert(CUIRect *pRect) const;
 	void Render();
-	void MapScreen();
-	void Mapping(float *pPoints);
+	void MapScreen() const;
+	void Mapping(float *pPoints) const;
 
 	void GetSize(float *pWidth, float *pHeight) const;
 

--- a/src/game/editor/mapitems/layer_tiles.cpp
+++ b/src/game/editor/mapitems/layer_tiles.cpp
@@ -1197,7 +1197,7 @@ CUI::EPopupMenuFunctionResult CLayerTiles::RenderCommonProperties(SCommonPropSta
 	{
 		if(NewVal > 1000 && !pEditor->m_LargeLayerWasWarned)
 		{
-			pEditor->m_PopupEventType = pEditor->POPEVENT_LARGELAYER;
+			pEditor->m_PopupEventType = CEditor::POPEVENT_LARGELAYER;
 			pEditor->m_PopupEventActivated = true;
 			pEditor->m_LargeLayerWasWarned = true;
 		}
@@ -1207,7 +1207,7 @@ CUI::EPopupMenuFunctionResult CLayerTiles::RenderCommonProperties(SCommonPropSta
 	{
 		if(NewVal > 1000 && !pEditor->m_LargeLayerWasWarned)
 		{
-			pEditor->m_PopupEventType = pEditor->POPEVENT_LARGELAYER;
+			pEditor->m_PopupEventType = CEditor::POPEVENT_LARGELAYER;
 			pEditor->m_PopupEventActivated = true;
 			pEditor->m_LargeLayerWasWarned = true;
 		}

--- a/src/game/editor/mapitems/layer_tiles.cpp
+++ b/src/game/editor/mapitems/layer_tiles.cpp
@@ -84,7 +84,7 @@ void CLayerTiles::SetTile(int x, int y, CTile Tile)
 	RecordStateChange(x, y, CurrentTile, Tile);
 }
 
-void CLayerTiles::SetTileIgnoreHistory(int x, int y, CTile Tile)
+void CLayerTiles::SetTileIgnoreHistory(int x, int y, CTile Tile) const
 {
 	m_pTiles[y * m_Width + x] = Tile;
 }
@@ -111,7 +111,7 @@ void CLayerTiles::PrepareForSave()
 	}
 }
 
-void CLayerTiles::ExtractTiles(int TilemapItemVersion, const CTile *pSavedTiles, size_t SavedTilesSize)
+void CLayerTiles::ExtractTiles(int TilemapItemVersion, const CTile *pSavedTiles, size_t SavedTilesSize) const
 {
 	const size_t DestSize = (size_t)m_Width * m_Height;
 	if(TilemapItemVersion >= CMapItemLayerTilemap::TILE_SKIP_MIN_VERSION)
@@ -120,7 +120,7 @@ void CLayerTiles::ExtractTiles(int TilemapItemVersion, const CTile *pSavedTiles,
 		mem_copy(m_pTiles, pSavedTiles, DestSize * sizeof(CTile));
 }
 
-void CLayerTiles::MakePalette()
+void CLayerTiles::MakePalette() const
 {
 	for(int y = 0; y < m_Height; y++)
 		for(int x = 0; x < m_Width; x++)
@@ -171,7 +171,7 @@ void CLayerTiles::Render(bool Tileset)
 int CLayerTiles::ConvertX(float x) const { return (int)(x / 32.0f); }
 int CLayerTiles::ConvertY(float y) const { return (int)(y / 32.0f); }
 
-void CLayerTiles::Convert(CUIRect Rect, RECTi *pOut)
+void CLayerTiles::Convert(CUIRect Rect, RECTi *pOut) const
 {
 	pOut->x = ConvertX(Rect.x);
 	pOut->y = ConvertY(Rect.y);
@@ -179,7 +179,7 @@ void CLayerTiles::Convert(CUIRect Rect, RECTi *pOut)
 	pOut->h = ConvertY(Rect.y + Rect.h + 31) - pOut->y;
 }
 
-void CLayerTiles::Snap(CUIRect *pRect)
+void CLayerTiles::Snap(CUIRect *pRect) const
 {
 	RECTi Out;
 	Convert(*pRect, &Out);
@@ -189,7 +189,7 @@ void CLayerTiles::Snap(CUIRect *pRect)
 	pRect->h = Out.h * 32.0f;
 }
 
-void CLayerTiles::Clamp(RECTi *pRect)
+void CLayerTiles::Clamp(RECTi *pRect) const
 {
 	if(pRect->x < 0)
 	{

--- a/src/game/editor/mapitems/layer_tiles.h
+++ b/src/game/editor/mapitems/layer_tiles.h
@@ -102,19 +102,19 @@ public:
 
 	virtual CTile GetTile(int x, int y);
 	virtual void SetTile(int x, int y, CTile Tile);
-	void SetTileIgnoreHistory(int x, int y, CTile Tile);
+	void SetTileIgnoreHistory(int x, int y, CTile Tile) const;
 
 	virtual void Resize(int NewW, int NewH);
 	virtual void Shift(int Direction);
 
-	void MakePalette();
+	void MakePalette() const;
 	void Render(bool Tileset = false) override;
 
 	int ConvertX(float x) const;
 	int ConvertY(float y) const;
-	void Convert(CUIRect Rect, RECTi *pOut);
-	void Snap(CUIRect *pRect);
-	void Clamp(RECTi *pRect);
+	void Convert(CUIRect Rect, RECTi *pOut) const;
+	void Snap(CUIRect *pRect) const;
+	void Clamp(RECTi *pRect) const;
 
 	virtual bool IsEntitiesLayer() const override;
 
@@ -151,7 +151,7 @@ public:
 	void ModifyEnvelopeIndex(FIndexModifyFunction pfnFunc) override;
 
 	void PrepareForSave();
-	void ExtractTiles(int TilemapItemVersion, const CTile *pSavedTiles, size_t SavedTilesSize);
+	void ExtractTiles(int TilemapItemVersion, const CTile *pSavedTiles, size_t SavedTilesSize) const;
 
 	void GetSize(float *pWidth, float *pHeight) override
 	{

--- a/src/game/gamecore.cpp
+++ b/src/game/gamecore.cpp
@@ -547,7 +547,7 @@ void CCharacterCore::Move()
 	m_Pos = NewPos;
 }
 
-void CCharacterCore::Write(CNetObj_CharacterCore *pObjCore)
+void CCharacterCore::Write(CNetObj_CharacterCore *pObjCore) const
 {
 	pObjCore->m_X = round_to_int(m_Pos.x);
 	pObjCore->m_Y = round_to_int(m_Pos.y);

--- a/src/game/gamecore.h
+++ b/src/game/gamecore.h
@@ -277,7 +277,7 @@ public:
 	void Move();
 
 	void Read(const CNetObj_CharacterCore *pObjCore);
-	void Write(CNetObj_CharacterCore *pObjCore);
+	void Write(CNetObj_CharacterCore *pObjCore) const;
 	void Quantize();
 
 	// DDRace

--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -941,7 +941,7 @@ void CGameContext::ConUnlockTeam(IConsole::IResult *pResult, void *pUserData)
 	pSelf->UnlockTeam(pResult->m_ClientID, Team);
 }
 
-void CGameContext::UnlockTeam(int ClientID, int Team)
+void CGameContext::UnlockTeam(int ClientID, int Team) const
 {
 	m_pController->Teams().SetTeamLock(Team, false);
 

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -362,7 +362,7 @@ void CGameContext::CreateSound(vec2 Pos, int Sound, CClientMask Mask)
 	}
 }
 
-void CGameContext::CreateSoundGlobal(int Sound, int Target)
+void CGameContext::CreateSoundGlobal(int Sound, int Target) const
 {
 	if(Sound < 0)
 		return;
@@ -434,7 +434,7 @@ void CGameContext::SnapSwitchers(int SnappingClient)
 	}
 }
 
-bool CGameContext::SnapLaserObject(const CSnapContext &Context, int SnapID, const vec2 &To, const vec2 &From, int StartTick, int Owner, int LaserType, int Subtype, int SwitchNumber)
+bool CGameContext::SnapLaserObject(const CSnapContext &Context, int SnapID, const vec2 &To, const vec2 &From, int StartTick, int Owner, int LaserType, int Subtype, int SwitchNumber) const
 {
 	if(Context.GetClientVersion() >= VERSION_DDNET_MULTI_LASER)
 	{
@@ -469,7 +469,7 @@ bool CGameContext::SnapLaserObject(const CSnapContext &Context, int SnapID, cons
 	return true;
 }
 
-bool CGameContext::SnapPickup(const CSnapContext &Context, int SnapID, const vec2 &Pos, int Type, int SubType, int SwitchNumber)
+bool CGameContext::SnapPickup(const CSnapContext &Context, int SnapID, const vec2 &Pos, int Type, int SubType, int SwitchNumber) const
 {
 	if(Context.IsSixup())
 	{
@@ -543,7 +543,7 @@ void CGameContext::CallVote(int ClientID, const char *pDesc, const char *pCmd, c
 	pPlayer->m_LastVoteCall = Now;
 }
 
-void CGameContext::SendChatTarget(int To, const char *pText, int Flags)
+void CGameContext::SendChatTarget(int To, const char *pText, int Flags) const
 {
 	CNetMsg_Sv_Chat Msg;
 	Msg.m_Team = 0;
@@ -574,7 +574,7 @@ void CGameContext::SendChatTarget(int To, const char *pText, int Flags)
 	}
 }
 
-void CGameContext::SendChatTeam(int Team, const char *pText)
+void CGameContext::SendChatTeam(int Team, const char *pText) const
 {
 	for(int i = 0; i < MAX_CLIENTS; i++)
 		if(m_apPlayers[i] != nullptr && GetDDRaceTeam(i) == Team)
@@ -673,7 +673,7 @@ void CGameContext::SendStartWarning(int ClientID, const char *pMessage)
 	}
 }
 
-void CGameContext::SendEmoticon(int ClientID, int Emoticon, int TargetClientID)
+void CGameContext::SendEmoticon(int ClientID, int Emoticon, int TargetClientID) const
 {
 	CNetMsg_Sv_Emoticon Msg;
 	Msg.m_ClientID = ClientID;
@@ -681,21 +681,21 @@ void CGameContext::SendEmoticon(int ClientID, int Emoticon, int TargetClientID)
 	Server()->SendPackMsg(&Msg, MSGFLAG_VITAL, TargetClientID);
 }
 
-void CGameContext::SendWeaponPickup(int ClientID, int Weapon)
+void CGameContext::SendWeaponPickup(int ClientID, int Weapon) const
 {
 	CNetMsg_Sv_WeaponPickup Msg;
 	Msg.m_Weapon = Weapon;
 	Server()->SendPackMsg(&Msg, MSGFLAG_VITAL, ClientID);
 }
 
-void CGameContext::SendMotd(int ClientID)
+void CGameContext::SendMotd(int ClientID) const
 {
 	CNetMsg_Sv_Motd Msg;
 	Msg.m_pMessage = g_Config.m_SvMotd;
 	Server()->SendPackMsg(&Msg, MSGFLAG_VITAL, ClientID);
 }
 
-void CGameContext::SendSettings(int ClientID)
+void CGameContext::SendSettings(int ClientID) const
 {
 	protocol7::CNetMsg_Sv_ServerSettings Msg;
 	Msg.m_KickVote = g_Config.m_SvVoteKick;
@@ -1351,9 +1351,9 @@ void CGameContext::OnClientPredictedEarlyInput(int ClientID, void *pInput)
 	}
 }
 
-struct CVoteOptionServer *CGameContext::GetVoteOption(int Index)
+const CVoteOptionServer *CGameContext::GetVoteOption(int Index) const
 {
-	CVoteOptionServer *pCurrent;
+	const CVoteOptionServer *pCurrent;
 	for(pCurrent = m_pVoteOptionFirst;
 		Index > 0 && pCurrent;
 		Index--, pCurrent = pCurrent->m_pNext)
@@ -1404,7 +1404,7 @@ void CGameContext::ProgressVoteOptions(int ClientID)
 	OptionMsg.m_pDescription14 = "";
 
 	// get current vote option by index
-	CVoteOptionServer *pCurrent = GetVoteOption(pPl->m_SendVoteIndex);
+	const CVoteOptionServer *pCurrent = GetVoteOption(pPl->m_SendVoteIndex);
 
 	while(CurIndex < NumVotesToSend && pCurrent != NULL)
 	{
@@ -4245,7 +4245,7 @@ bool CGameContext::ProcessSpamProtection(int ClientID, bool RespectChatInitialDe
 	return false;
 }
 
-int CGameContext::GetDDRaceTeam(int ClientID)
+int CGameContext::GetDDRaceTeam(int ClientID) const
 {
 	return m_pController->Teams().m_Core.Team(ClientID);
 }
@@ -4514,7 +4514,7 @@ int CGameContext::GetClientVersion(int ClientID) const
 	return Server()->GetClientVersion(ClientID);
 }
 
-CClientMask CGameContext::ClientsMaskExcludeClientVersionAndHigher(int Version)
+CClientMask CGameContext::ClientsMaskExcludeClientVersionAndHigher(int Version) const
 {
 	CClientMask Mask;
 	for(int i = 0; i < MAX_CLIENTS; ++i)
@@ -4622,7 +4622,7 @@ bool CGameContext::RateLimitPlayerVote(int ClientID)
 	return false;
 }
 
-bool CGameContext::RateLimitPlayerMapVote(int ClientID)
+bool CGameContext::RateLimitPlayerMapVote(int ClientID) const
 {
 	if(!Server()->GetAuthedState(ClientID) && time_get() < m_LastMapVote + (time_freq() * g_Config.m_SvVoteMapTimeDelay))
 	{

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -237,11 +237,11 @@ public:
 	void CreatePlayerSpawn(vec2 Pos, CClientMask Mask = CClientMask().set());
 	void CreateDeath(vec2 Pos, int ClientID, CClientMask Mask = CClientMask().set());
 	void CreateSound(vec2 Pos, int Sound, CClientMask Mask = CClientMask().set());
-	void CreateSoundGlobal(int Sound, int Target = -1);
+	void CreateSoundGlobal(int Sound, int Target = -1) const;
 
 	void SnapSwitchers(int SnappingClient);
-	bool SnapLaserObject(const CSnapContext &Context, int SnapID, const vec2 &To, const vec2 &From, int StartTick, int Owner = -1, int LaserType = -1, int Subtype = -1, int SwitchNumber = -1);
-	bool SnapPickup(const CSnapContext &Context, int SnapID, const vec2 &Pos, int Type, int SubType, int SwitchNumber);
+	bool SnapLaserObject(const CSnapContext &Context, int SnapID, const vec2 &To, const vec2 &From, int StartTick, int Owner = -1, int LaserType = -1, int Subtype = -1, int SwitchNumber = -1) const;
+	bool SnapPickup(const CSnapContext &Context, int SnapID, const vec2 &Pos, int Type, int SubType, int SwitchNumber) const;
 
 	enum
 	{
@@ -258,14 +258,14 @@ public:
 
 	// network
 	void CallVote(int ClientID, const char *pDesc, const char *pCmd, const char *pReason, const char *pChatmsg, const char *pSixupDesc = 0);
-	void SendChatTarget(int To, const char *pText, int Flags = CHAT_SIX | CHAT_SIXUP);
-	void SendChatTeam(int Team, const char *pText);
+	void SendChatTarget(int To, const char *pText, int Flags = CHAT_SIX | CHAT_SIXUP) const;
+	void SendChatTeam(int Team, const char *pText) const;
 	void SendChat(int ClientID, int Team, const char *pText, int SpamProtectionClientID = -1, int Flags = CHAT_SIX | CHAT_SIXUP);
 	void SendStartWarning(int ClientID, const char *pMessage);
-	void SendEmoticon(int ClientID, int Emoticon, int TargetClientID);
-	void SendWeaponPickup(int ClientID, int Weapon);
-	void SendMotd(int ClientID);
-	void SendSettings(int ClientID);
+	void SendEmoticon(int ClientID, int Emoticon, int TargetClientID) const;
+	void SendWeaponPickup(int ClientID, int Weapon) const;
+	void SendMotd(int ClientID) const;
+	void SendSettings(int ClientID) const;
 	void SendBroadcast(const char *pText, int ClientID, bool IsImportant = true);
 
 	void List(int ClientID, const char *pFilter);
@@ -274,7 +274,7 @@ public:
 	void CheckPureTuning();
 	void SendTuningParams(int ClientID, int Zone = 0);
 
-	struct CVoteOptionServer *GetVoteOption(int Index);
+	const CVoteOptionServer *GetVoteOption(int Index) const;
 	void ProgressVoteOptions(int ClientID);
 
 	//
@@ -339,12 +339,12 @@ public:
 	bool OnClientDDNetVersionKnown(int ClientID);
 	void FillAntibot(CAntibotRoundData *pData) override;
 	bool ProcessSpamProtection(int ClientID, bool RespectChatInitialDelay = true);
-	int GetDDRaceTeam(int ClientID);
+	int GetDDRaceTeam(int ClientID) const;
 	// Describes the time when the first player joined the server.
 	int64_t m_NonEmptySince;
 	int64_t m_LastMapVote;
 	int GetClientVersion(int ClientID) const;
-	CClientMask ClientsMaskExcludeClientVersionAndHigher(int Version);
+	CClientMask ClientsMaskExcludeClientVersionAndHigher(int Version) const;
 	bool PlayerExists(int ClientID) const override { return m_apPlayers[ClientID]; }
 	// Returns true if someone is actively moderating.
 	bool PlayerModerating() const;
@@ -352,7 +352,7 @@ public:
 
 	// Checks if player can vote and notify them about the reason
 	bool RateLimitPlayerVote(int ClientID);
-	bool RateLimitPlayerMapVote(int ClientID);
+	bool RateLimitPlayerMapVote(int ClientID) const;
 
 	void OnUpdatePlayerServerInfo(char *aBuf, int BufSize, int ID) override;
 
@@ -505,7 +505,7 @@ private:
 	void WhisperID(int ClientID, int VictimID, const char *pMessage);
 	void Converse(int ClientID, char *pStr);
 	bool IsVersionBanned(int Version);
-	void UnlockTeam(int ClientID, int Team);
+	void UnlockTeam(int ClientID, int Team) const;
 
 	enum
 	{

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -837,7 +837,7 @@ int CPlayer::IsPaused() const
 	return m_ForcePauseTime ? m_ForcePauseTime : -1 * m_Paused;
 }
 
-bool CPlayer::IsPlaying()
+bool CPlayer::IsPlaying() const
 {
 	return m_pCharacter && m_pCharacter->IsAlive();
 }

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -178,7 +178,7 @@ public:
 	int ForcePause(int Time);
 	int IsPaused() const;
 
-	bool IsPlaying();
+	bool IsPlaying() const;
 	int64_t m_Last_KickVote;
 	int64_t m_Last_Team;
 	int m_ShowOthers;

--- a/src/game/server/save.cpp
+++ b/src/game/server/save.cpp
@@ -596,7 +596,7 @@ void CSaveTeam::Load(CGameContext *pGameServer, int Team, bool KeepCurrentWeakSt
 	pGameServer->m_World.RemoveEntitiesFromPlayers(aPlayerCIDs, m_MembersCount);
 }
 
-CCharacter *CSaveTeam::MatchCharacter(CGameContext *pGameServer, int ClientID, int SaveID, bool KeepCurrentCharacter)
+CCharacter *CSaveTeam::MatchCharacter(CGameContext *pGameServer, int ClientID, int SaveID, bool KeepCurrentCharacter) const
 {
 	if(KeepCurrentCharacter && pGameServer->m_apPlayers[ClientID]->GetCharacter())
 	{
@@ -785,7 +785,7 @@ int CSaveTeam::FromString(const char *pString)
 	return 0;
 }
 
-bool CSaveTeam::MatchPlayers(const char (*paNames)[MAX_NAME_LENGTH], const int *pClientID, int NumPlayer, char *pMessage, int MessageLen)
+bool CSaveTeam::MatchPlayers(const char (*paNames)[MAX_NAME_LENGTH], const int *pClientID, int NumPlayer, char *pMessage, int MessageLen) const
 {
 	if(NumPlayer > m_MembersCount)
 	{

--- a/src/game/server/save.h
+++ b/src/game/server/save.h
@@ -140,7 +140,7 @@ public:
 	// MatchPlayers has to be called afterwards
 	int FromString(const char *pString);
 	// returns true if a team can load, otherwise writes a nice error Message in pMessage
-	bool MatchPlayers(const char (*paNames)[MAX_NAME_LENGTH], const int *pClientID, int NumPlayer, char *pMessage, int MessageLen);
+	bool MatchPlayers(const char (*paNames)[MAX_NAME_LENGTH], const int *pClientID, int NumPlayer, char *pMessage, int MessageLen) const;
 	int Save(CGameContext *pGameServer, int Team, bool Dry = false);
 	void Load(CGameContext *pGameServer, int Team, bool KeepCurrentWeakStrong);
 
@@ -150,7 +150,7 @@ public:
 	static bool HandleSaveError(int Result, int ClientID, CGameContext *pGameContext);
 
 private:
-	CCharacter *MatchCharacter(CGameContext *pGameServer, int ClientID, int SaveID, bool KeepCurrentCharacter);
+	CCharacter *MatchCharacter(CGameContext *pGameServer, int ClientID, int SaveID, bool KeepCurrentCharacter) const;
 
 	char m_aString[65536];
 

--- a/src/test/score.cpp
+++ b/src/test/score.cpp
@@ -25,7 +25,7 @@ int CSaveTeam::FromString(const char *)
 	return 1;
 }
 
-bool CSaveTeam::MatchPlayers(const char (*paNames)[MAX_NAME_LENGTH], const int *pClientID, int NumPlayer, char *pMessage, int MessageLen)
+bool CSaveTeam::MatchPlayers(const char (*paNames)[MAX_NAME_LENGTH], const int *pClientID, int NumPlayer, char *pMessage, int MessageLen) const
 {
 	// Dummy implementation for testing
 	return false;


### PR DESCRIPTION


## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
