### PR TITLE
Fix various lineinput issues/regressions

### DIFF
--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -1217,7 +1217,9 @@ void CChat::OnRender()
 
 		m_Input.Activate(EInputPriority::CHAT); // Ensure that the input is active
 		const CUIRect InputCursorRect = {Cursor.m_X, Cursor.m_Y - ScrollOffset, 0.0f, 0.0f};
-		const STextBoundingBox BoundingBox = m_Input.Render(&InputCursorRect, Cursor.m_FontSize, TEXTALIGN_TL, m_Input.WasCursorChanged(), MessageMaxWidth, 0.0f);
+		// Arithmetic or to ensure that both functions are called so both flags are purged
+		const bool Changed = m_Input.WasChanged() | m_Input.WasCursorChanged();
+		const STextBoundingBox BoundingBox = m_Input.Render(&InputCursorRect, Cursor.m_FontSize, TEXTALIGN_TL, Changed, MessageMaxWidth, 0.0f);
 
 		Graphics()->ClipDisable();
 

--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -970,7 +970,9 @@ void CGameConsole::OnRender()
 		pConsole->m_Input.SetHidden(m_ConsoleType == CONSOLETYPE_REMOTE && Client()->State() == IClient::STATE_ONLINE && !Client()->RconAuthed() && (pConsole->m_UserGot || !pConsole->m_UsernameReq));
 		pConsole->m_Input.Activate(EInputPriority::CONSOLE); // Ensure that the input is active
 		const CUIRect InputCursorRect = {x, y + FONT_SIZE, 0.0f, 0.0f};
-		pConsole->m_BoundingBox = pConsole->m_Input.Render(&InputCursorRect, FONT_SIZE, TEXTALIGN_BL, pConsole->m_Input.WasCursorChanged(), Screen.w - 10.0f - x, LINE_SPACING);
+		// Arithmetic or to ensure that both functions are called so both flags are purged
+		const bool Changed = pConsole->m_Input.WasChanged() | pConsole->m_Input.WasCursorChanged();
+		pConsole->m_BoundingBox = pConsole->m_Input.Render(&InputCursorRect, FONT_SIZE, TEXTALIGN_BL, Changed, Screen.w - 10.0f - x, LINE_SPACING);
 		if(pConsole->m_LastInputHeight == 0.0f && pConsole->m_BoundingBox.m_H != 0.0f)
 			pConsole->m_LastInputHeight = pConsole->m_BoundingBox.m_H;
 		if(pConsole->m_Input.HasSelection())

--- a/src/game/client/lineinput.cpp
+++ b/src/game/client/lineinput.cpp
@@ -385,7 +385,7 @@ bool CLineInput::ProcessInput(const IInput::CEvent &Event)
 	}
 
 	m_WasCursorChanged |= OldCursorPos != m_CursorPos;
-	m_WasChanged |= SelectionLength != GetSelectionLength();
+	m_WasCursorChanged |= SelectionLength != GetSelectionLength();
 	return m_WasChanged || m_WasCursorChanged || KeyHandled;
 }
 

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -766,6 +766,7 @@ bool CUI::DoEditBox(CLineInput *pLineInput, const CUIRect *pRect, float FontSize
 	const bool Inside = MouseHovered(pRect);
 	const bool Active = m_pLastActiveItem == pLineInput;
 	const bool Changed = pLineInput->WasChanged();
+	const bool CursorChanged = pLineInput->WasCursorChanged();
 
 	const float VSpacing = 2.0f;
 	CUIRect Textbox;
@@ -842,11 +843,11 @@ bool CUI::DoEditBox(CLineInput *pLineInput, const CUIRect *pRect, float FontSize
 	pRect->Draw(ms_LightButtonColorFunction.GetColor(Active, HotItem() == pLineInput), Corners, 3.0f);
 	ClipEnable(pRect);
 	Textbox.x -= ScrollOffset;
-	const STextBoundingBox BoundingBox = pLineInput->Render(&Textbox, FontSize, TEXTALIGN_ML, pLineInput->WasCursorChanged(), -1.0f, 0.0f);
+	const STextBoundingBox BoundingBox = pLineInput->Render(&Textbox, FontSize, TEXTALIGN_ML, Changed || CursorChanged, -1.0f, 0.0f);
 	ClipDisable();
 
 	// Scroll left or right if necessary
-	if(Active && !JustGotActive && (Changed || Input()->HasComposition()))
+	if(Active && !JustGotActive && (Changed || CursorChanged || Input()->HasComposition()))
 	{
 		const float CaretPositionX = pLineInput->GetCaretPosition().x - Textbox.x - ScrollOffset - ScrollOffsetChange;
 		if(CaretPositionX > Textbox.w)


### PR DESCRIPTION
Fix Ctrl+C not working to copy text in console when the command input already contains text, as the changed flag was never reset properly.

Fix scroll position of UI editboxes not being updated when moving cursor without changing text.

Fix lineinput selection change being detected as content change, causing the editor modified state to be set incorrectly.

Fix cursor blinking not being disabled correctly after changing text without changing cursor position.

Regressions from #7626. And an additional fix for #6906.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
