### PR TITLE
Editor: Add QoL features for quads

### DIFF
--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -101,6 +101,8 @@ MACRO_CONFIG_INT(EdSmoothZoomTime, ed_smooth_zoom_time, 250, 0, 5000, CFGFLAG_CL
 MACRO_CONFIG_INT(EdLimitMaxZoomLevel, ed_limit_max_zoom_level, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Specifies, if zooming in the editor should be limited or not (0 = no limit)")
 MACRO_CONFIG_INT(EdZoomTarget, ed_zoom_target, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Zoom to the current mouse target")
 MACRO_CONFIG_INT(EdShowkeys, ed_showkeys, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show pressed keys")
+MACRO_CONFIG_INT(EdAlignQuads, ed_align_quads, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Enable/disable quad alignment. When enabled, red lines appear to show how quad/points are aligned and snapped to other quads/points when moving them")
+MACRO_CONFIG_INT(EdShowQuadsRect, ed_show_quads_rect, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show the bounds of the selected quad. In case of multiple quads, it shows the bounds of the englobing rect. Can be helpful when aligning a group of quads")
 
 MACRO_CONFIG_INT(ClShowWelcome, cl_show_welcome, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show welcome message indicating the first launch of the client")
 MACRO_CONFIG_INT(ClMotdTime, cl_motd_time, 10, 0, 100, CFGFLAG_CLIENT | CFGFLAG_SAVE, "How long to show the server message of the day")

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -853,10 +853,20 @@ public:
 
 	void DoSoundSource(CSoundSource *pSource, int Index);
 
+	enum class EAxis
+	{
+		AXIS_NONE = 0,
+		AXIS_X,
+		AXIS_Y
+	};
 	void DoMapEditor(CUIRect View);
 	void DoToolbarLayers(CUIRect Toolbar);
 	void DoToolbarSounds(CUIRect Toolbar);
 	void DoQuad(const std::shared_ptr<CLayerQuads> &pLayer, CQuad *pQuad, int Index);
+	void PreparePointDrag(const std::shared_ptr<CLayerQuads> &pLayer, CQuad *pQuad, int QuadIndex, int PointIndex);
+	void DoPointDrag(const std::shared_ptr<CLayerQuads> &pLayer, CQuad *pQuad, int QuadIndex, int PointIndex, int OffsetX, int OffsetY);
+	EAxis GetDragAxis(int OffsetX, int OffsetY);
+	void DrawAxis(EAxis Axis, CPoint &Point);
 	ColorRGBA GetButtonColor(const void *pID, int Checked);
 
 	bool ReplaceImage(const char *pFilename, int StorageType, bool CheckDuplicate);
@@ -1011,6 +1021,7 @@ public:
 	unsigned char m_SwitchNum;
 	unsigned char m_SwitchDelay;
 
+public:
 	// Undo/Redo
 	CEditorHistory m_EditorHistory;
 	CEditorHistory m_ServerSettingsHistory;
@@ -1021,6 +1032,9 @@ public:
 private:
 	void UndoLastAction();
 	void RedoLastAction();
+
+private:
+	std::map<int, std::map<int, CPoint>> m_QuadDragOriginalPoints;
 };
 
 // make sure to inline this function

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -328,6 +328,58 @@ CUI::EPopupMenuFunctionResult CEditor::PopupMenuSettings(void *pContext, CUIRect
 		}
 	}
 
+	View.HSplitTop(2.0f, nullptr, &View);
+	View.HSplitTop(12.0f, &Slot, &View);
+	{
+		Slot.VMargin(5.0f, &Slot);
+
+		CUIRect Label, Selector;
+		Slot.VSplitMid(&Label, &Selector);
+		CUIRect No, Yes;
+		Selector.VSplitMid(&No, &Yes);
+
+		pEditor->UI()->DoLabel(&Label, "Align quads", 10.0f, TEXTALIGN_ML);
+		if(pEditor->m_AllowPlaceUnusedTiles != -1)
+		{
+			static int s_ButtonNo = 0;
+			static int s_ButtonYes = 0;
+			if(pEditor->DoButton_ButtonDec(&s_ButtonNo, "No", !g_Config.m_EdAlignQuads, &No, 0, "Do not perform quad alignment to other quads/points when moving quads"))
+			{
+				g_Config.m_EdAlignQuads = false;
+			}
+			if(pEditor->DoButton_ButtonInc(&s_ButtonYes, "Yes", g_Config.m_EdAlignQuads, &Yes, 0, "Allow quad alignment to other quads/points when moving quads"))
+			{
+				g_Config.m_EdAlignQuads = true;
+			}
+		}
+	}
+
+	View.HSplitTop(2.0f, nullptr, &View);
+	View.HSplitTop(12.0f, &Slot, &View);
+	{
+		Slot.VMargin(5.0f, &Slot);
+
+		CUIRect Label, Selector;
+		Slot.VSplitMid(&Label, &Selector);
+		CUIRect No, Yes;
+		Selector.VSplitMid(&No, &Yes);
+
+		pEditor->UI()->DoLabel(&Label, "Show quads bounds", 10.0f, TEXTALIGN_ML);
+		if(pEditor->m_AllowPlaceUnusedTiles != -1)
+		{
+			static int s_ButtonNo = 0;
+			static int s_ButtonYes = 0;
+			if(pEditor->DoButton_ButtonDec(&s_ButtonNo, "No", !g_Config.m_EdShowQuadsRect, &No, 0, "Do not show quad bounds when moving quads"))
+			{
+				g_Config.m_EdShowQuadsRect = false;
+			}
+			if(pEditor->DoButton_ButtonInc(&s_ButtonYes, "Yes", g_Config.m_EdShowQuadsRect, &Yes, 0, "Show quad bounds when moving quads"))
+			{
+				g_Config.m_EdShowQuadsRect = true;
+			}
+		}
+	}
+
 	return CUI::POPUP_KEEP_OPEN;
 }
 


### PR DESCRIPTION
Closes #6062.
This PR adds two quality of life features to quad, one of which has been requested in that issue.

1. Add the ability to preserve drag axis while holding shift. Works with entire quads or individual points.

https://github.com/ddnet/ddnet/assets/13364635/2a50eba3-54b0-4a8f-9f09-b835db322de3

2. Add the ability to align/snap points/quads to other points/quads. While dragging there is also an option to display the bounding box of the quad to better see how it can be snapped/aligned.

https://github.com/ddnet/ddnet/assets/13364635/344504f9-5181-4015-a7ca-489b3c7a0a86

This aims to make working with quads better as it allows to easily snap and align quads to each other. If one does not want that feature, they can simply disable it from the settings popup.

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
