### PR TITLE
Add `INotifications` kernel interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1888,6 +1888,7 @@ set_src(ENGINE_INTERFACE GLOB src/engine
   keys.h
   map.h
   message.h
+  notifications.h
   rust.h
   server.h
   serverbrowser.h

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -2683,6 +2683,7 @@ void CClient::InitInterfaces()
 #endif
 	m_pDiscord = Kernel()->RequestInterface<IDiscord>();
 	m_pSteam = Kernel()->RequestInterface<ISteam>();
+	m_pNotifications = Kernel()->RequestInterface<INotifications>();
 	m_pStorage = Kernel()->RequestInterface<IStorage>();
 
 	m_DemoEditor.Init(m_pGameClient->NetVersion(), &m_SnapshotDelta, m_pConsole, m_pStorage);
@@ -3959,7 +3960,7 @@ void CClient::Notify(const char *pTitle, const char *pMessage)
 	if(m_pGraphics->WindowActive() || !g_Config.m_ClShowNotifications)
 		return;
 
-	NotificationsNotify(pTitle, pMessage);
+	Notifications()->Notify(pTitle, pMessage);
 	Graphics()->NotifyWindow();
 }
 
@@ -4290,9 +4291,6 @@ int main(int argc, const char **argv)
 	if(!RandInitFailed)
 		CleanerFunctions.emplace([]() { secure_random_uninit(); });
 
-	NotificationsInit();
-	CleanerFunctions.emplace([]() { NotificationsUninit(); });
-
 	// Register SDL for cleanup before creating the kernel and client,
 	// so SDL is shutdown after kernel and client. Otherwise the client
 	// may crash when shutting down after SDL is already shutdown.
@@ -4394,6 +4392,9 @@ int main(int argc, const char **argv)
 	ISteam *pSteam = CreateSteam();
 	pKernel->RegisterInterface(pSteam);
 
+	INotifications *pNotifications = CreateNotifications();
+	pKernel->RegisterInterface(pNotifications);
+
 	pKernel->RegisterInterface(CreateEditor(), false);
 	pKernel->RegisterInterface(CreateFavorites().release());
 	pKernel->RegisterInterface(CreateGameClient());
@@ -4401,6 +4402,7 @@ int main(int argc, const char **argv)
 	pEngine->Init();
 	pConsole->Init();
 	pConfigManager->Init();
+	pNotifications->Init(GAME_NAME " Client");
 
 	// register all console commands
 	pClient->RegisterCommands();

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -39,6 +39,7 @@ class IEngineSound;
 class IFriends;
 class ILogger;
 class ISteam;
+class INotifications;
 class IStorage;
 class IUpdater;
 
@@ -71,6 +72,7 @@ class CClient : public IClient, public CDemoPlayer::IListener
 	IEngineMap *m_pMap = nullptr;
 	IEngineSound *m_pSound = nullptr;
 	ISteam *m_pSteam = nullptr;
+	INotifications *m_pNotifications = nullptr;
 	IStorage *m_pStorage = nullptr;
 	IEngineTextRender *m_pTextRender = nullptr;
 	IUpdater *m_pUpdater = nullptr;
@@ -260,6 +262,7 @@ public:
 	IEngineInput *Input() { return m_pInput; }
 	IEngineSound *Sound() { return m_pSound; }
 	ISteam *Steam() { return m_pSteam; }
+	INotifications *Notifications() { return m_pNotifications; }
 	IStorage *Storage() { return m_pStorage; }
 	IEngineTextRender *TextRender() { return m_pTextRender; }
 	IUpdater *Updater() { return m_pUpdater; }

--- a/src/engine/client/notifications.cpp
+++ b/src/engine/client/notifications.cpp
@@ -4,35 +4,41 @@
 
 #if defined(CONF_PLATFORM_MACOS)
 // Code is in src/macos/notification.mm.
+void NotificationsNotifyMacOsInternal(const char *pTitle, const char *pMessage);
 #elif defined(CONF_FAMILY_UNIX) && !defined(CONF_PLATFORM_ANDROID) && !defined(CONF_PLATFORM_HAIKU) && !defined(CONF_WEBASM)
 #include <libnotify/notify.h>
-void NotificationsInit()
+#define NOTIFICATIONS_USE_LIBNOTIFY
+#endif
+
+void CNotifications::Init(const char *pAppname)
 {
-	notify_init("DDNet Client");
+#if defined(NOTIFICATIONS_USE_LIBNOTIFY)
+	notify_init(pAppname);
+#endif
 }
-void NotificationsUninit()
+
+void CNotifications::Shutdown()
 {
+#if defined(NOTIFICATIONS_USE_LIBNOTIFY)
 	notify_uninit();
+#endif
 }
-void NotificationsNotify(const char *pTitle, const char *pMessage)
+
+void CNotifications::Notify(const char *pTitle, const char *pMessage)
 {
+#if defined(CONF_PLATFORM_MACOS)
+	NotificationsNotifyMacOsInternal(pTitle, pMessage);
+#elif defined(NOTIFICATIONS_USE_LIBNOTIFY)
 	NotifyNotification *pNotif = notify_notification_new(pTitle, pMessage, "ddnet");
 	if(pNotif)
 	{
 		notify_notification_show(pNotif, NULL);
 		g_object_unref(G_OBJECT(pNotif));
 	}
-}
-#else
-void NotificationsInit()
-{
-}
-void NotificationsUninit()
-{
-}
-void NotificationsNotify(const char *pTitle, const char *pMessage)
-{
-	(void)pTitle;
-	(void)pMessage;
-}
 #endif
+}
+
+INotifications *CreateNotifications()
+{
+	return new CNotifications();
+}

--- a/src/engine/client/notifications.h
+++ b/src/engine/client/notifications.h
@@ -1,6 +1,14 @@
 #ifndef ENGINE_CLIENT_NOTIFICATIONS_H
 #define ENGINE_CLIENT_NOTIFICATIONS_H
-void NotificationsInit();
-void NotificationsUninit();
-void NotificationsNotify(const char *pTitle, const char *pMessage);
+
+#include <engine/notifications.h>
+
+class CNotifications : public INotifications
+{
+public:
+	void Init(const char *pAppname) override;
+	void Shutdown() override;
+	void Notify(const char *pTitle, const char *pMessage) override;
+};
+
 #endif // ENGINE_CLIENT_NOTIFICATIONS_H

--- a/src/engine/notifications.h
+++ b/src/engine/notifications.h
@@ -1,0 +1,17 @@
+#ifndef ENGINE_NOTIFICATIONS_H
+#define ENGINE_NOTIFICATIONS_H
+
+#include "kernel.h"
+
+class INotifications : public IInterface
+{
+	MACRO_INTERFACE("notifications")
+public:
+	virtual void Init(const char *pAppname) = 0;
+	virtual void Shutdown() override = 0;
+	virtual void Notify(const char *pTitle, const char *pMessage) = 0;
+};
+
+INotifications *CreateNotifications();
+
+#endif // ENGINE_NOTIFICATIONS_H

--- a/src/macos/notifications.mm
+++ b/src/macos/notifications.mm
@@ -1,16 +1,9 @@
-#import <engine/client/notifications.h>
-
 #import <Foundation/Foundation.h>
 #import <Foundation/NSUserNotification.h>
 #import <Cocoa/Cocoa.h>
 
-void NotificationsInit()
-{
-}
-void NotificationsUninit()
-{
-}
-void NotificationsNotify(const char *pTitle, const char *pMessage)
+// TODO: NSUserNotification is deprecated. Use the User Notifications framework instead: https://developer.apple.com/documentation/usernotifications?language=objc
+void NotificationsNotifyMacOsInternal(const char *pTitle, const char *pMessage)
 {
 	NSString* pNsTitle = [NSString stringWithCString:pTitle encoding:NSUTF8StringEncoding];
 	NSString* pNsMsg = [NSString stringWithCString:pMessage encoding:NSUTF8StringEncoding];


### PR DESCRIPTION
Add a proper kernel interface `INotifications` for the notifications component instead of using a C style interface.

Add parameter for the application name when initializing notifications to avoid hardcoding the application name.

The implementation for macOS is kept in Objective-C and a TODO is added, as the API we are currently using appears to be deprecated.

## Checklist

- [X] Tested the change ingame (libnotify only)
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [X] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
