### PR TITLE
Fix clang warning `-Wbitwise-instead-of-logical`

### DIFF
--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -1217,8 +1217,9 @@ void CChat::OnRender()
 
 		m_Input.Activate(EInputPriority::CHAT); // Ensure that the input is active
 		const CUIRect InputCursorRect = {Cursor.m_X, Cursor.m_Y - ScrollOffset, 0.0f, 0.0f};
-		// Arithmetic or to ensure that both functions are called so both flags are purged
-		const bool Changed = m_Input.WasChanged() | m_Input.WasCursorChanged();
+		const bool WasChanged = m_Input.WasChanged();
+		const bool WasCursorChanged = m_Input.WasCursorChanged();
+		const bool Changed = WasChanged || WasCursorChanged;
 		const STextBoundingBox BoundingBox = m_Input.Render(&InputCursorRect, Cursor.m_FontSize, TEXTALIGN_TL, Changed, MessageMaxWidth, 0.0f);
 
 		Graphics()->ClipDisable();

--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -970,8 +970,9 @@ void CGameConsole::OnRender()
 		pConsole->m_Input.SetHidden(m_ConsoleType == CONSOLETYPE_REMOTE && Client()->State() == IClient::STATE_ONLINE && !Client()->RconAuthed() && (pConsole->m_UserGot || !pConsole->m_UsernameReq));
 		pConsole->m_Input.Activate(EInputPriority::CONSOLE); // Ensure that the input is active
 		const CUIRect InputCursorRect = {x, y + FONT_SIZE, 0.0f, 0.0f};
-		// Arithmetic or to ensure that both functions are called so both flags are purged
-		const bool Changed = pConsole->m_Input.WasChanged() | pConsole->m_Input.WasCursorChanged();
+		const bool WasChanged = pConsole->m_Input.WasChanged();
+		const bool WasCursorChanged = pConsole->m_Input.WasCursorChanged();
+		const bool Changed = WasChanged || WasCursorChanged;
 		pConsole->m_BoundingBox = pConsole->m_Input.Render(&InputCursorRect, FONT_SIZE, TEXTALIGN_BL, Changed, Screen.w - 10.0f - x, LINE_SPACING);
 		if(pConsole->m_LastInputHeight == 0.0f && pConsole->m_BoundingBox.m_H != 0.0f)
 			pConsole->m_LastInputHeight = pConsole->m_BoundingBox.m_H;


### PR DESCRIPTION
```
/home/user/Development/ddnet/src/game/client/components/chat.cpp:1221:24: warning: use of bitwise '|' with boolean operands [-Wbitwise-instead-of-logical]
                const bool Changed = m_Input.WasChanged() | m_Input.WasCursorChanged();
                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                                          ||
/home/user/Development/ddnet/src/game/client/components/chat.cpp:1221:24: note: cast one or both operands to int to silence this warning

/home/user/Development/ddnet/src/game/client/components/console.cpp:974:24: warning: use of bitwise '|' with boolean operands [-Wbitwise-instead-of-logical]
                const bool Changed = pConsole->m_Input.WasChanged() | pConsole->m_Input.WasCursorChanged();
                                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                                                    ||
/home/user/Development/ddnet/src/game/client/components/console.cpp:974:24: note: cast one or both operands to int to silence this warning
```

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
