### PR TITLE
Fix multi sampling accuracy

### DIFF
--- a/data/shader/tile_border.frag
+++ b/data/shader/tile_border.frag
@@ -9,7 +9,7 @@ uniform sampler2DArray gTextureSampler;
 uniform vec4 gVertColor;
 
 #ifdef TW_TILE_TEXTURED
-noperspective in vec3 TexCoord;
+noperspective centroid in vec3 TexCoord;
 #endif
 
 out vec4 FragClr;

--- a/data/shader/vulkan/tile_border.frag
+++ b/data/shader/vulkan/tile_border.frag
@@ -10,7 +10,7 @@ layout(push_constant) uniform SVertexColorBO {
 } gColorBO;
 
 #ifdef TW_TILE_TEXTURED
-layout (location = 0) noperspective in vec3 TexCoord;
+layout (location = 0) noperspective centroid in vec3 TexCoord;
 #endif
 
 layout (location = 0) out vec4 FragClr;

--- a/src/engine/client/backend/glsl_shader_compiler.cpp
+++ b/src/engine/client/backend/glsl_shader_compiler.cpp
@@ -84,6 +84,8 @@ void CGLSLCompiler::ParseLine(std::string &Line, const char *pReadLine, EGLSLSha
 					//search for 'in' or 'out'
 					while(*pBuff && ((*pBuff != 'i' || *(pBuff + 1) != 'n') && (*pBuff != 'o' || (*(pBuff + 1) && *(pBuff + 1) != 'u') || *(pBuff + 2) != 't')))
 					{
+						// append anything that is inbetween noperspective & in/out vars
+						Line.push_back(*pBuff);
 						++pBuff;
 					}
 


### PR DESCRIPTION
fixes #7670

- for vulkan, which supports the `sample` qualifier this means it's basically using super sampling. which is more accurate, but more expensive. it allows multiple samples to pass and each sample will get the exact fragment input variables interpolated.
- for opengl it uses `centroid` which will cause basically cause the pixel to shift it's center if the center is outside but a sample is inside a fragment. This shifted center is the same for all samples tho, so at least a tiny bit less accurate than `sample`

I'll ready this pr tomorrow, so i still have a day to think about it 

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
