### PR TITLE
Disable cycling through command history when logging in to rcon.

### DIFF
--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -313,7 +313,11 @@ bool CGameConsole::CInstance::OnInput(const IInput::CEvent &Event)
 		}
 		else if(Event.m_Key == KEY_UP)
 		{
-			if(!m_Searching)
+			if(m_Searching)
+			{
+				SelectNextSearchMatch(-1);
+			}
+			else if(m_Type == CONSOLETYPE_LOCAL || m_pGameConsole->Client()->RconAuthed())
 			{
 				if(m_pHistoryEntry)
 				{
@@ -328,15 +332,15 @@ bool CGameConsole::CInstance::OnInput(const IInput::CEvent &Event)
 				if(m_pHistoryEntry)
 					m_Input.Set(m_pHistoryEntry);
 			}
-			else
-			{
-				SelectNextSearchMatch(-1);
-			}
 			Handled = true;
 		}
 		else if(Event.m_Key == KEY_DOWN)
 		{
-			if(!m_Searching)
+			if(m_Searching)
+			{
+				SelectNextSearchMatch(1);
+			}
+			else if(m_Type == CONSOLETYPE_LOCAL || m_pGameConsole->Client()->RconAuthed())
 			{
 				if(m_pHistoryEntry)
 					m_pHistoryEntry = m_History.Next(m_pHistoryEntry);
@@ -345,10 +349,6 @@ bool CGameConsole::CInstance::OnInput(const IInput::CEvent &Event)
 					m_Input.Set(m_pHistoryEntry);
 				else
 					m_Input.Clear();
-			}
-			else
-			{
-				SelectNextSearchMatch(1);
 			}
 			Handled = true;
 		}


### PR DESCRIPTION
As it makes no sense to allow the user to cycle through the command history while in the rcon login prompt.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
