### PR TITLE
Use `GetDataSize` instead of `CMapItemSound::m_SoundDataSize`

### DIFF
--- a/src/game/client/components/mapsounds.cpp
+++ b/src/game/client/components/mapsounds.cpp
@@ -51,8 +51,9 @@ void CMapSounds::OnMapLoad()
 		}
 		else
 		{
-			void *pData = pMap->GetData(pSound->m_SoundData);
-			m_aSounds[i] = Sound()->LoadOpusFromMem(pData, pSound->m_SoundDataSize);
+			const int SoundDataSize = pMap->GetDataSize(pSound->m_SoundData);
+			const void *pData = pMap->GetData(pSound->m_SoundData);
+			m_aSounds[i] = Sound()->LoadOpusFromMem(pData, SoundDataSize);
 			pMap->UnloadData(pSound->m_SoundData);
 		}
 		ShowWarning = ShowWarning || m_aSounds[i] == -1;

--- a/src/game/editor/mapitems/map_io.cpp
+++ b/src/game/editor/mapitems/map_io.cpp
@@ -146,6 +146,7 @@ bool CEditorMap::Save(const char *pFileName)
 		Item.m_External = 0;
 		Item.m_SoundName = Writer.AddDataString(pSound->m_aName);
 		Item.m_SoundData = Writer.AddData(pSound->m_DataSize, pSound->m_pData);
+		// Value is not read in new versions, but we still need to write it for compatibility with old versions.
 		Item.m_SoundDataSize = pSound->m_DataSize;
 
 		Writer.AddItem(MAPITEMTYPE_SOUND, i, sizeof(Item), &Item);
@@ -575,9 +576,7 @@ bool CEditorMap::Load(const char *pFileName, int StorageType, const std::functio
 			}
 			else
 			{
-				pSound->m_DataSize = pItem->m_SoundDataSize;
-
-				// copy sample data
+				pSound->m_DataSize = DataFile.GetDataSize(pItem->m_SoundData);
 				void *pData = DataFile.GetData(pItem->m_SoundData);
 				pSound->m_pData = malloc(pSound->m_DataSize);
 				mem_copy(pSound->m_pData, pData, pSound->m_DataSize);

--- a/src/game/mapitems.h
+++ b/src/game/mapitems.h
@@ -520,6 +520,9 @@ struct CMapItemSound
 
 	int m_SoundName;
 	int m_SoundData;
+	// Deprecated. Do not read this value, it could be wrong.
+	// Use GetDataSize instead, which returns the de facto size.
+	// Value must still be written for compatibility.
 	int m_SoundDataSize;
 };
 

--- a/src/tools/map_extract.cpp
+++ b/src/tools/map_extract.cpp
@@ -102,12 +102,13 @@ bool Process(IStorage *pStorage, const char *pMapName, const char *pPathSave)
 			continue;
 		}
 
+		const int SoundDataSize = Reader.GetDataSize(pItem->m_SoundData);
 		char aBuf[IO_MAX_PATH_LENGTH];
 		str_format(aBuf, sizeof(aBuf), "%s/%s.opus", pPathSave, pName);
-		dbg_msg("map_extract", "writing sound: %s (%d B)", aBuf, pItem->m_SoundDataSize);
+		dbg_msg("map_extract", "writing sound: %s (%d B)", aBuf, SoundDataSize);
 
 		IOHANDLE Opus = io_open(aBuf, IOFLAG_WRITE);
-		io_write(Opus, (unsigned char *)Reader.GetData(pItem->m_SoundData), pItem->m_SoundDataSize);
+		io_write(Opus, Reader.GetData(pItem->m_SoundData), SoundDataSize);
 		io_close(Opus);
 	}
 


### PR DESCRIPTION
Do not use the `CMapItemSound::m_SoundDataSize` value as it is redundant. This value could also be incorrect because it can be freely set by the map creator (tool).

Instead, use the map/datafile function `GetDataSize` to get the true size of the sound data in the file.

The `m_SoundDataSize` value is still written to map files for compatibility with old versions.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
