### PR TITLE
Clamp volume envelopes between 0.0f and 1.0f

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -6918,7 +6918,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 											s_vAccurateDragValuesY[k] -= DeltaY;
 											pEnvelope->m_vPoints[SelectedIndex].m_aValues[SelectedChannel] = std::round(s_vAccurateDragValuesY[k]);
 
-											if(pEnvelope->GetChannels() == 4)
+											if(pEnvelope->GetChannels() == 1 || pEnvelope->GetChannels() == 4)
 											{
 												pEnvelope->m_vPoints[i].m_aValues[c] = clamp(pEnvelope->m_vPoints[i].m_aValues[c], 0, 1024);
 												s_vAccurateDragValuesY[k] = clamp<float>(s_vAccurateDragValuesY[k], 0, 1024);
@@ -7383,7 +7383,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 					else
 						pEnvelope->m_vPoints[SelectedIndex].m_aValues[SelectedChannel] = std::round(s_vInitialPositionsY[k] * s_ScaleFactorY);
 
-					if(pEnvelope->GetChannels() == 4)
+					if(pEnvelope->GetChannels() == 1 || pEnvelope->GetChannels() == 4)
 						pEnvelope->m_vPoints[SelectedIndex].m_aValues[SelectedChannel] = clamp(pEnvelope->m_vPoints[SelectedIndex].m_aValues[SelectedChannel], 0, 1024);
 				}
 			}

--- a/src/game/editor/editor_actions.cpp
+++ b/src/game/editor/editor_actions.cpp
@@ -1534,7 +1534,7 @@ void CEditorActionEditEnvelopePointValue::Apply(bool Undo)
 	}
 	else
 	{
-		if(pEnvelope->GetChannels() == 4)
+		if(pEnvelope->GetChannels() == 1 || pEnvelope->GetChannels() == 4)
 			CurrentValue = clamp(CurrentValue, 0.0f, 1.0f);
 		pEnvelope->m_vPoints[m_PtIndex].m_aValues[m_Channel] = f2fx(CurrentValue);
 


### PR DESCRIPTION
Closes #7680

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
