### PR TITLE
Use curl-multi. Supersedes #5842

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1883,6 +1883,7 @@ set_src(ENGINE_INTERFACE GLOB src/engine
   friends.h
   ghost.h
   graphics.h
+  http.h
   input.h
   kernel.h
   keys.h

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -2524,9 +2524,9 @@ int kill_process(PROCESS process);
 
 /**
  * Checks if a process is alive.
- * 
+ *
  * @param process Handle/PID of the process.
- * 
+ *
  * @return bool Returns true if the process is currently running, false if the process is not running (dead).
  */
 bool is_process_alive(PROCESS process);

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -4568,6 +4568,9 @@ bool CClient::RaceRecord_IsRecording()
 
 void CClient::RequestDDNetInfo()
 {
+	if(m_pDDNetInfoTask && !m_pDDNetInfoTask->Done())
+		return;
+
 	char aUrl[256];
 	str_copy(aUrl, DDNET_INFO_URL);
 

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -76,6 +76,7 @@ class CClient : public IClient, public CDemoPlayer::IListener
 	IStorage *m_pStorage = nullptr;
 	IEngineTextRender *m_pTextRender = nullptr;
 	IUpdater *m_pUpdater = nullptr;
+	CHttp m_Http;
 
 	CNetClient m_aNetClient[NUM_CONNS];
 	CDemoPlayer m_DemoPlayer;
@@ -266,6 +267,7 @@ public:
 	IStorage *Storage() { return m_pStorage; }
 	IEngineTextRender *TextRender() { return m_pTextRender; }
 	IUpdater *Updater() { return m_pUpdater; }
+	IHttp *Http() { return &m_Http; }
 
 	CClient();
 

--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -97,7 +97,6 @@ void CServerBrowser::SetBaseInfo(class CNetClient *pClient, const char *pNetVers
 	m_pFriends = Kernel()->RequestInterface<IFriends>();
 	m_pStorage = Kernel()->RequestInterface<IStorage>();
 	m_pHttpClient = Kernel()->RequestInterface<IHttp>();
-	dbg_msg("cserverbrowser", "%p", m_pHttpClient);
 	m_pPingCache = CreateServerBrowserPingCache(m_pConsole, m_pStorage);
 
 	RegisterCommands();

--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -25,6 +25,7 @@
 #include <engine/engine.h>
 #include <engine/favorites.h>
 #include <engine/friends.h>
+#include <engine/http.h>
 #include <engine/storage.h>
 
 class CSortWrap
@@ -95,6 +96,8 @@ void CServerBrowser::SetBaseInfo(class CNetClient *pClient, const char *pNetVers
 	m_pFavorites = Kernel()->RequestInterface<IFavorites>();
 	m_pFriends = Kernel()->RequestInterface<IFriends>();
 	m_pStorage = Kernel()->RequestInterface<IStorage>();
+	m_pHttpClient = Kernel()->RequestInterface<IHttp>();
+	dbg_msg("cserverbrowser", "%p", m_pHttpClient);
 	m_pPingCache = CreateServerBrowserPingCache(m_pConsole, m_pStorage);
 
 	RegisterCommands();
@@ -102,7 +105,7 @@ void CServerBrowser::SetBaseInfo(class CNetClient *pClient, const char *pNetVers
 
 void CServerBrowser::OnInit()
 {
-	m_pHttp = CreateServerBrowserHttp(m_pEngine, m_pConsole, m_pStorage, g_Config.m_BrCachedBestServerinfoUrl);
+	m_pHttp = CreateServerBrowserHttp(m_pEngine, m_pConsole, m_pStorage, m_pHttpClient, g_Config.m_BrCachedBestServerinfoUrl);
 }
 
 void CServerBrowser::RegisterCommands()

--- a/src/engine/client/serverbrowser.h
+++ b/src/engine/client/serverbrowser.h
@@ -21,6 +21,7 @@ class IFriends;
 class IServerBrowserHttp;
 class IServerBrowserPingCache;
 class IStorage;
+class IHttp;
 
 class CCommunityServer
 {
@@ -143,6 +144,7 @@ private:
 	IFriends *m_pFriends = nullptr;
 	IFavorites *m_pFavorites = nullptr;
 	IStorage *m_pStorage = nullptr;
+	IHttp *m_pHttpClient = nullptr;
 	char m_aNetVersion[128];
 
 	bool m_RefreshingHttp = false;

--- a/src/engine/client/serverbrowser_http.cpp
+++ b/src/engine/client/serverbrowser_http.cpp
@@ -29,7 +29,7 @@ public:
 	{
 		MAX_URLS = 16,
 	};
-	CChooseMaster(IEngine *pEngine, VALIDATOR pfnValidator, const char **ppUrls, int NumUrls, int PreviousBestIndex);
+	CChooseMaster(IEngine *pEngine, IHttp *pHttp, VALIDATOR pfnValidator, const char **ppUrls, int NumUrls, int PreviousBestIndex);
 	virtual ~CChooseMaster();
 
 	bool GetBestUrl(const char **pBestUrl) const;
@@ -51,26 +51,29 @@ private:
 	};
 	class CJob : public IJob
 	{
+		CChooseMaster *m_pParent;
 		CLock m_Lock;
 		std::shared_ptr<CData> m_pData;
-		std::unique_ptr<CHttpRequest> m_pHead PT_GUARDED_BY(m_Lock);
-		std::unique_ptr<CHttpRequest> m_pGet PT_GUARDED_BY(m_Lock);
+		std::shared_ptr<CHttpRequest> m_pHead PT_GUARDED_BY(m_Lock);
+		std::shared_ptr<CHttpRequest> m_pGet PT_GUARDED_BY(m_Lock);
 		void Run() override REQUIRES(!m_Lock);
 
 	public:
-		CJob(std::shared_ptr<CData> pData) :
-			m_pData(std::move(pData)) {}
+		CJob(CChooseMaster *pParent, std::shared_ptr<CData> pData) :
+			m_pParent(pParent), m_pData(std::move(pData)) {}
 		void Abort() REQUIRES(!m_Lock);
 	};
 
 	IEngine *m_pEngine;
+	IHttp *m_pHttp;
 	int m_PreviousBestIndex;
 	std::shared_ptr<CData> m_pData;
 	std::shared_ptr<CJob> m_pJob;
 };
 
-CChooseMaster::CChooseMaster(IEngine *pEngine, VALIDATOR pfnValidator, const char **ppUrls, int NumUrls, int PreviousBestIndex) :
+CChooseMaster::CChooseMaster(IEngine *pEngine, IHttp *pHttp, VALIDATOR pfnValidator, const char **ppUrls, int NumUrls, int PreviousBestIndex) :
 	m_pEngine(pEngine),
+	m_pHttp(pHttp),
 	m_PreviousBestIndex(PreviousBestIndex)
 {
 	dbg_assert(NumUrls >= 0, "no master URLs");
@@ -128,7 +131,7 @@ void CChooseMaster::Reset()
 void CChooseMaster::Refresh()
 {
 	if(m_pJob == nullptr || m_pJob->Status() == IJob::STATE_DONE)
-		m_pEngine->AddJob(m_pJob = std::make_shared<CJob>(m_pData));
+		m_pEngine->AddJob(m_pJob = std::make_shared<CJob>(this, m_pData));
 }
 
 void CChooseMaster::CJob::Abort()
@@ -171,14 +174,16 @@ void CChooseMaster::CJob::Run()
 	{
 		aTimeMs[i] = -1;
 		const char *pUrl = m_pData->m_aaUrls[aRandomized[i]];
-		CHttpRequest *pHead = HttpHead(pUrl).release();
+		std::shared_ptr<CHttpRequest> pHead = std::move(HttpHead(pUrl));
 		pHead->Timeout(Timeout);
 		pHead->LogProgress(HTTPLOG::FAILURE);
 		{
 			CLockScope ls(m_Lock);
-			m_pHead = std::unique_ptr<CHttpRequest>(pHead);
+			m_pHead = pHead;
 		}
-		IEngine::RunJobBlocking(pHead);
+
+		m_pParent->m_pHttp->Run(pHead);
+		pHead->Wait();
 		if(pHead->State() == HTTP_ABORTED)
 		{
 			dbg_msg("serverbrowse_http", "master chooser aborted");
@@ -188,15 +193,19 @@ void CChooseMaster::CJob::Run()
 		{
 			continue;
 		}
+
 		auto StartTime = time_get_nanoseconds();
-		CHttpRequest *pGet = HttpGet(pUrl).release();
+		std::shared_ptr<CHttpRequest> pGet = std::move(HttpGet(pUrl));
 		pGet->Timeout(Timeout);
 		pGet->LogProgress(HTTPLOG::FAILURE);
 		{
 			CLockScope ls(m_Lock);
-			m_pGet = std::unique_ptr<CHttpRequest>(pGet);
+			m_pGet = pGet;
 		}
-		IEngine::RunJobBlocking(pGet);
+
+		m_pParent->m_pHttp->Run(pGet);
+		pGet->Wait();
+
 		auto Time = std::chrono::duration_cast<std::chrono::milliseconds>(time_get_nanoseconds() - StartTime);
 		if(pHead->State() == HTTP_ABORTED)
 		{
@@ -212,6 +221,7 @@ void CChooseMaster::CJob::Run()
 		{
 			continue;
 		}
+
 		bool ParseFailure = m_pData->m_pfnValidator(pJson);
 		json_value_free(pJson);
 		if(ParseFailure)
@@ -221,6 +231,7 @@ void CChooseMaster::CJob::Run()
 		dbg_msg("serverbrowse_http", "found master, url='%s' time=%dms", pUrl, (int)Time.count());
 		aTimeMs[i] = Time.count();
 	}
+
 	// Determine index of the minimum time.
 	int BestIndex = -1;
 	int BestTime = 0;
@@ -241,6 +252,7 @@ void CChooseMaster::CJob::Run()
 		dbg_msg("serverbrowse_http", "WARNING: no usable masters found");
 		return;
 	}
+
 	dbg_msg("serverbrowse_http", "determined best master, url='%s' time=%dms", m_pData->m_aaUrls[BestIndex], BestTime);
 	m_pData->m_BestIndex.store(BestIndex);
 }
@@ -248,7 +260,7 @@ void CChooseMaster::CJob::Run()
 class CServerBrowserHttp : public IServerBrowserHttp
 {
 public:
-	CServerBrowserHttp(IEngine *pEngine, IConsole *pConsole, const char **ppUrls, int NumUrls, int PreviousBestIndex);
+	CServerBrowserHttp(IEngine *pEngine, IConsole *pConsole, IHttp *pHttp, const char **ppUrls, int NumUrls, int PreviousBestIndex);
 	~CServerBrowserHttp() override;
 	void Update() override;
 	bool IsRefreshing() override { return m_State != STATE_DONE; }
@@ -286,6 +298,7 @@ private:
 
 	IEngine *m_pEngine;
 	IConsole *m_pConsole;
+	IHttp *m_pHttp;
 
 	int m_State = STATE_DONE;
 	std::shared_ptr<CHttpRequest> m_pGetServers;
@@ -295,10 +308,11 @@ private:
 	std::vector<NETADDR> m_vLegacyServers;
 };
 
-CServerBrowserHttp::CServerBrowserHttp(IEngine *pEngine, IConsole *pConsole, const char **ppUrls, int NumUrls, int PreviousBestIndex) :
+CServerBrowserHttp::CServerBrowserHttp(IEngine *pEngine, IConsole *pConsole, IHttp *pHttp, const char **ppUrls, int NumUrls, int PreviousBestIndex) :
 	m_pEngine(pEngine),
 	m_pConsole(pConsole),
-	m_pChooseMaster(new CChooseMaster(pEngine, Validate, ppUrls, NumUrls, PreviousBestIndex))
+	m_pHttp(pHttp),
+	m_pChooseMaster(new CChooseMaster(pEngine, pHttp, Validate, ppUrls, NumUrls, PreviousBestIndex))
 {
 	m_pChooseMaster->Refresh();
 }
@@ -328,7 +342,7 @@ void CServerBrowserHttp::Update()
 		m_pGetServers = HttpGet(pBestUrl);
 		// 10 seconds connection timeout, lower than 8KB/s for 10 seconds to fail.
 		m_pGetServers->Timeout(CTimeout{10000, 0, 8000, 10});
-		m_pEngine->AddJob(m_pGetServers);
+		m_pHttp->Run(m_pGetServers);
 		m_State = STATE_REFRESHING;
 	}
 	else if(m_State == STATE_REFRESHING)
@@ -469,7 +483,7 @@ static const char *DEFAULT_SERVERLIST_URLS[] = {
 	"https://master4.ddnet.org/ddnet/15/servers.json",
 };
 
-IServerBrowserHttp *CreateServerBrowserHttp(IEngine *pEngine, IConsole *pConsole, IStorage *pStorage, const char *pPreviousBestUrl)
+IServerBrowserHttp *CreateServerBrowserHttp(IEngine *pEngine, IConsole *pConsole, IStorage *pStorage, IHttp *pHttp, const char *pPreviousBestUrl)
 {
 	char aaUrls[CChooseMaster::MAX_URLS][256];
 	const char *apUrls[CChooseMaster::MAX_URLS] = {0};
@@ -506,5 +520,5 @@ IServerBrowserHttp *CreateServerBrowserHttp(IEngine *pEngine, IConsole *pConsole
 			break;
 		}
 	}
-	return new CServerBrowserHttp(pEngine, pConsole, ppUrls, NumUrls, PreviousBestIndex);
+	return new CServerBrowserHttp(pEngine, pConsole, pHttp, ppUrls, NumUrls, PreviousBestIndex);
 }

--- a/src/engine/client/serverbrowser_http.cpp
+++ b/src/engine/client/serverbrowser_http.cpp
@@ -54,8 +54,8 @@ private:
 		CChooseMaster *m_pParent;
 		CLock m_Lock;
 		std::shared_ptr<CData> m_pData;
-		std::shared_ptr<CHttpRequest> m_pHead PT_GUARDED_BY(m_Lock);
-		std::shared_ptr<CHttpRequest> m_pGet PT_GUARDED_BY(m_Lock);
+		std::shared_ptr<CHttpRequest> m_pHead;
+		std::shared_ptr<CHttpRequest> m_pGet;
 		void Run() override REQUIRES(!m_Lock);
 
 	public:
@@ -174,7 +174,7 @@ void CChooseMaster::CJob::Run()
 	{
 		aTimeMs[i] = -1;
 		const char *pUrl = m_pData->m_aaUrls[aRandomized[i]];
-		std::shared_ptr<CHttpRequest> pHead = std::move(HttpHead(pUrl));
+		std::shared_ptr<CHttpRequest> pHead = HttpHead(pUrl);
 		pHead->Timeout(Timeout);
 		pHead->LogProgress(HTTPLOG::FAILURE);
 		{
@@ -195,7 +195,7 @@ void CChooseMaster::CJob::Run()
 		}
 
 		auto StartTime = time_get_nanoseconds();
-		std::shared_ptr<CHttpRequest> pGet = std::move(HttpGet(pUrl));
+		std::shared_ptr<CHttpRequest> pGet = HttpGet(pUrl);
 		pGet->Timeout(Timeout);
 		pGet->LogProgress(HTTPLOG::FAILURE);
 		{
@@ -296,7 +296,6 @@ private:
 	static bool Validate(json_value *pJson);
 	static bool Parse(json_value *pJson, std::vector<CServerInfo> *pvServers, std::vector<NETADDR> *pvLegacyServers);
 
-	IEngine *m_pEngine;
 	IConsole *m_pConsole;
 	IHttp *m_pHttp;
 
@@ -309,7 +308,6 @@ private:
 };
 
 CServerBrowserHttp::CServerBrowserHttp(IEngine *pEngine, IConsole *pConsole, IHttp *pHttp, const char **ppUrls, int NumUrls, int PreviousBestIndex) :
-	m_pEngine(pEngine),
 	m_pConsole(pConsole),
 	m_pHttp(pHttp),
 	m_pChooseMaster(new CChooseMaster(pEngine, pHttp, Validate, ppUrls, NumUrls, PreviousBestIndex))

--- a/src/engine/client/serverbrowser_http.h
+++ b/src/engine/client/serverbrowser_http.h
@@ -6,6 +6,7 @@ class CServerInfo;
 class IConsole;
 class IEngine;
 class IStorage;
+class IHttp;
 
 class IServerBrowserHttp
 {
@@ -25,5 +26,5 @@ public:
 	virtual const NETADDR &LegacyServer(int Index) const = 0;
 };
 
-IServerBrowserHttp *CreateServerBrowserHttp(IEngine *pEngine, IConsole *pConsole, IStorage *pStorage, const char *pPreviousBestUrl);
+IServerBrowserHttp *CreateServerBrowserHttp(IEngine *pEngine, IConsole *pConsole, IStorage *pStorage, IHttp *pHttp, const char *pPreviousBestUrl);
 #endif // ENGINE_CLIENT_SERVERBROWSER_HTTP_H

--- a/src/engine/client/updater.cpp
+++ b/src/engine/client/updater.cpp
@@ -163,7 +163,8 @@ bool CUpdater::MoveFile(const char *pFile)
 
 void CUpdater::Update()
 {
-	switch(m_State)
+	auto State = GetCurrentState();
+	switch(State)
 	{
 	case IUpdater::GOT_MANIFEST:
 		PerformUpdate();
@@ -270,6 +271,7 @@ void CUpdater::ParseUpdate()
 				break;
 		}
 	}
+	json_value_free(pVersions);
 }
 
 void CUpdater::InitiateUpdate()
@@ -375,9 +377,9 @@ void CUpdater::CommitUpdate()
 	if(m_ServerUpdate)
 		Success &= ReplaceServer();
 	if(!Success)
-		m_State = FAIL;
+		SetCurrentState(IUpdater::FAIL);
 	else if(m_pClient->State() == IClient::STATE_ONLINE || m_pClient->EditorHasUnsavedData())
-		m_State = NEED_RESTART;
+		SetCurrentState(IUpdater::NEED_RESTART);
 	else
 	{
 		m_pClient->Restart();

--- a/src/engine/client/updater.h
+++ b/src/engine/client/updater.h
@@ -5,7 +5,8 @@
 
 #include <engine/updater.h>
 
-#include <map>
+#include <forward_list>
+#include <memory>
 #include <string>
 
 #define CLIENT_EXEC "DDNet"
@@ -34,6 +35,8 @@
 #define PLAT_CLIENT_EXEC CLIENT_EXEC PLAT_EXT
 #define PLAT_SERVER_EXEC SERVER_EXEC PLAT_EXT
 
+class CUpdaterFetchTask;
+
 class CUpdater : public IUpdater
 {
 	friend class CUpdaterFetchTask;
@@ -48,14 +51,15 @@ class CUpdater : public IUpdater
 	int m_State;
 	char m_aStatus[256] GUARDED_BY(m_Lock);
 	int m_Percent GUARDED_BY(m_Lock);
-	char m_aLastFile[256];
 	char m_aClientExecTmp[64];
 	char m_aServerExecTmp[64];
 
+	std::forward_list<std::pair<std::string, bool>> m_FileJobs;
+	std::shared_ptr<CUpdaterFetchTask> m_pCurrentTask;
+	decltype(m_FileJobs)::iterator m_CurrentJob;
+
 	bool m_ClientUpdate;
 	bool m_ServerUpdate;
-
-	std::map<std::string, bool> m_FileJobs;
 
 	void AddFileJob(const char *pFile, bool Job);
 	void FetchFile(const char *pFile, const char *pDestPath = nullptr);
@@ -63,6 +67,7 @@ class CUpdater : public IUpdater
 
 	void ParseUpdate();
 	void PerformUpdate();
+	void RunningUpdate();
 	void CommitUpdate();
 
 	bool ReplaceClient();

--- a/src/engine/client/updater.h
+++ b/src/engine/client/updater.h
@@ -48,7 +48,7 @@ class CUpdater : public IUpdater
 
 	CLock m_Lock;
 
-	int m_State;
+	int m_State GUARDED_BY(m_Lock);
 	char m_aStatus[256] GUARDED_BY(m_Lock);
 	int m_Percent GUARDED_BY(m_Lock);
 	char m_aClientExecTmp[64];
@@ -62,13 +62,13 @@ class CUpdater : public IUpdater
 	bool m_ServerUpdate;
 
 	void AddFileJob(const char *pFile, bool Job);
-	void FetchFile(const char *pFile, const char *pDestPath = nullptr);
+	void FetchFile(const char *pFile, const char *pDestPath = nullptr) REQUIRES(!m_Lock);
 	bool MoveFile(const char *pFile);
 
-	void ParseUpdate();
-	void PerformUpdate();
-	void RunningUpdate();
-	void CommitUpdate();
+	void ParseUpdate() REQUIRES(!m_Lock);
+	void PerformUpdate() REQUIRES(!m_Lock);
+	void RunningUpdate() REQUIRES(!m_Lock);
+	void CommitUpdate() REQUIRES(!m_Lock);
 
 	bool ReplaceClient();
 	bool ReplaceServer();
@@ -82,9 +82,9 @@ public:
 	void GetCurrentFile(char *pBuf, int BufSize) override REQUIRES(!m_Lock);
 	int GetCurrentPercent() override REQUIRES(!m_Lock);
 
-	void InitiateUpdate() override;
+	void InitiateUpdate() REQUIRES(!m_Lock) override;
 	void Init(CHttp *pHttp);
-	void Update() override;
+	void Update() REQUIRES(!m_Lock) override;
 };
 
 #endif

--- a/src/engine/client/updater.h
+++ b/src/engine/client/updater.h
@@ -41,6 +41,7 @@ class CUpdater : public IUpdater
 	class IClient *m_pClient;
 	class IStorage *m_pStorage;
 	class IEngine *m_pEngine;
+	class CHttp *m_pHttp;
 
 	CLock m_Lock;
 
@@ -77,7 +78,7 @@ public:
 	int GetCurrentPercent() override REQUIRES(!m_Lock);
 
 	void InitiateUpdate() override;
-	void Init();
+	void Init(CHttp *pHttp);
 	void Update() override;
 };
 

--- a/src/engine/http.h
+++ b/src/engine/http.h
@@ -1,0 +1,16 @@
+#ifndef HTTP_H
+#define HTTP_H
+
+#include "kernel.h"
+
+class IHttpRequest {};
+
+class IHttp : public IInterface
+{
+    MACRO_INTERFACE("http", 0)
+
+public:
+    virtual void Run(std::shared_ptr<IHttpRequest> pRequest) = 0;
+};
+
+#endif

--- a/src/engine/http.h
+++ b/src/engine/http.h
@@ -1,5 +1,5 @@
-#ifndef HTTP_H
-#define HTTP_H
+#ifndef ENGINE_HTTP_H
+#define ENGINE_HTTP_H
 
 #include "kernel.h"
 

--- a/src/engine/http.h
+++ b/src/engine/http.h
@@ -3,14 +3,16 @@
 
 #include "kernel.h"
 
-class IHttpRequest {};
+class IHttpRequest
+{
+};
 
 class IHttp : public IInterface
 {
-    MACRO_INTERFACE("http")
+	MACRO_INTERFACE("http")
 
 public:
-    virtual void Run(std::shared_ptr<IHttpRequest> pRequest) = 0;
+	virtual void Run(std::shared_ptr<IHttpRequest> pRequest) = 0;
 };
 
 #endif

--- a/src/engine/http.h
+++ b/src/engine/http.h
@@ -7,7 +7,7 @@ class IHttpRequest {};
 
 class IHttp : public IInterface
 {
-    MACRO_INTERFACE("http", 0)
+    MACRO_INTERFACE("http")
 
 public:
     virtual void Run(std::shared_ptr<IHttpRequest> pRequest) = 0;

--- a/src/engine/server/register.h
+++ b/src/engine/server/register.h
@@ -4,6 +4,7 @@
 class CConfig;
 class IConsole;
 class IEngine;
+class IHttp;
 struct CNetChunk;
 
 class IRegister
@@ -23,6 +24,6 @@ public:
 	virtual void OnShutdown() = 0;
 };
 
-IRegister *CreateRegister(CConfig *pConfig, IConsole *pConsole, IEngine *pEngine, int ServerPort, unsigned SixupSecurityToken);
+IRegister *CreateRegister(CConfig *pConfig, IConsole *pConsole, IEngine *pEngine, IHttp *pHttp, int ServerPort, unsigned SixupSecurityToken);
 
 #endif

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -2774,7 +2774,8 @@ int CServer::Run()
 #endif
 
 	IEngine *pEngine = Kernel()->RequestInterface<IEngine>();
-	m_pRegister = CreateRegister(&g_Config, m_pConsole, pEngine, this->Port(), m_NetServer.GetGlobalToken());
+	IHttp *pHttp = Kernel()->RequestInterface<IHttp>();
+	m_pRegister = CreateRegister(&g_Config, m_pConsole, pEngine, pHttp, this->Port(), m_NetServer.GetGlobalToken());
 
 	m_NetServer.SetCallbacks(NewClientCallback, NewClientNoAuthCallback, ClientRejoinCallback, DelClientCallback, this);
 
@@ -3822,7 +3823,8 @@ void CServer::RegisterCommands()
 	m_pStorage = Kernel()->RequestInterface<IStorage>();
 	m_pAntibot = Kernel()->RequestInterface<IEngineAntibot>();
 
-	HttpInit(m_pStorage);
+	m_Http.Init(std::chrono::seconds{2});
+	Kernel()->RegisterInterface(static_cast<IHttp *>(&m_Http), false);
 
 	// register console commands
 	Console()->Register("kick", "i[id] ?r[reason]", CFGFLAG_SERVER, ConKick, this, "Kick player with specified id for any reason");

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -11,6 +11,7 @@
 #include <engine/shared/demo.h>
 #include <engine/shared/econ.h>
 #include <engine/shared/fifo.h>
+#include <engine/shared/http.h>
 #include <engine/shared/netban.h>
 #include <engine/shared/network.h>
 #include <engine/shared/protocol.h>
@@ -238,6 +239,7 @@ public:
 	CEcon m_Econ;
 	CFifo m_Fifo;
 	CServerBan m_ServerBan;
+	CHttp m_Http;
 
 	IEngineMap *m_pMap;
 

--- a/src/engine/shared/http.cpp
+++ b/src/engine/shared/http.cpp
@@ -571,7 +571,7 @@ void CHttp::Run(std::shared_ptr<IHttpRequest> pRequest)
 {
 	std::unique_lock Lock(m_Lock);
 	m_Cv.wait(Lock, [this]() { return m_State != UNINITIALIZED; });
-	m_PendingRequests.emplace_back(std::move(std::static_pointer_cast<CHttpRequest>(pRequest)));
+	m_PendingRequests.emplace_back(std::static_pointer_cast<CHttpRequest>(pRequest));
 	curl_multi_wakeup(m_pMultiH);
 }
 
@@ -583,4 +583,13 @@ void CHttp::Shutdown()
 
 	m_Shutdown = true;
 	curl_multi_wakeup(m_pMultiH);
+}
+
+CHttp::~CHttp()
+{
+	if(!m_pThread)
+		return;
+
+	Shutdown();
+	thread_wait(m_pThread);
 }

--- a/src/engine/shared/http.cpp
+++ b/src/engine/shared/http.cpp
@@ -104,9 +104,9 @@ bool CHttpRequest::BeforeInit()
 	return true;
 }
 
-bool CHttpRequest::ConfigureHandle(void *pUser)
+bool CHttpRequest::ConfigureHandle(void *pHandle)
 {
-	CURL *pHandle = (CURL *)pUser;
+	CURL *pH = (CURL *)pHandle;
 	if(!BeforeInit())
 	{
 		return false;
@@ -114,8 +114,8 @@ bool CHttpRequest::ConfigureHandle(void *pUser)
 
 	if(g_Config.m_DbgCurl)
 	{
-		curl_easy_setopt(pHandle, CURLOPT_VERBOSE, 1L);
-		curl_easy_setopt(pHandle, CURLOPT_DEBUGFUNCTION, CurlDebug);
+		curl_easy_setopt(pH, CURLOPT_VERBOSE, 1L);
+		curl_easy_setopt(pH, CURLOPT_DEBUGFUNCTION, CurlDebug);
 	}
 	long Protocols = CURLPROTO_HTTPS;
 	if(g_Config.m_HttpAllowInsecure)
@@ -123,15 +123,15 @@ bool CHttpRequest::ConfigureHandle(void *pUser)
 		Protocols |= CURLPROTO_HTTP;
 	}
 
-	curl_easy_setopt(pHandle, CURLOPT_ERRORBUFFER, m_aErr);
+	curl_easy_setopt(pH, CURLOPT_ERRORBUFFER, m_aErr);
 
-	curl_easy_setopt(pHandle, CURLOPT_CONNECTTIMEOUT_MS, m_Timeout.ConnectTimeoutMs);
-	curl_easy_setopt(pHandle, CURLOPT_TIMEOUT_MS, m_Timeout.TimeoutMs);
-	curl_easy_setopt(pHandle, CURLOPT_LOW_SPEED_LIMIT, m_Timeout.LowSpeedLimit);
-	curl_easy_setopt(pHandle, CURLOPT_LOW_SPEED_TIME, m_Timeout.LowSpeedTime);
+	curl_easy_setopt(pH, CURLOPT_CONNECTTIMEOUT_MS, m_Timeout.ConnectTimeoutMs);
+	curl_easy_setopt(pH, CURLOPT_TIMEOUT_MS, m_Timeout.TimeoutMs);
+	curl_easy_setopt(pH, CURLOPT_LOW_SPEED_LIMIT, m_Timeout.LowSpeedLimit);
+	curl_easy_setopt(pH, CURLOPT_LOW_SPEED_TIME, m_Timeout.LowSpeedTime);
 	if(m_MaxResponseSize >= 0)
 	{
-		curl_easy_setopt(pHandle, CURLOPT_MAXFILESIZE_LARGE, (curl_off_t)m_MaxResponseSize);
+		curl_easy_setopt(pH, CURLOPT_MAXFILESIZE_LARGE, (curl_off_t)m_MaxResponseSize);
 	}
 
 	// ‘CURLOPT_PROTOCOLS’ is deprecated: since 7.85.0. Use CURLOPT_PROTOCOLS_STR
@@ -140,43 +140,43 @@ bool CHttpRequest::ConfigureHandle(void *pUser)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
-	curl_easy_setopt(pHandle, CURLOPT_PROTOCOLS, Protocols);
+	curl_easy_setopt(pH, CURLOPT_PROTOCOLS, Protocols);
 #ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif
-	curl_easy_setopt(pHandle, CURLOPT_FOLLOWLOCATION, 1L);
-	curl_easy_setopt(pHandle, CURLOPT_MAXREDIRS, 4L);
-	curl_easy_setopt(pHandle, CURLOPT_FAILONERROR, 1L);
-	curl_easy_setopt(pHandle, CURLOPT_URL, m_aUrl);
-	curl_easy_setopt(pHandle, CURLOPT_NOSIGNAL, 1L);
-	curl_easy_setopt(pHandle, CURLOPT_USERAGENT, GAME_NAME " " GAME_RELEASE_VERSION " (" CONF_PLATFORM_STRING "; " CONF_ARCH_STRING ")");
-	curl_easy_setopt(pHandle, CURLOPT_ACCEPT_ENCODING, ""); // Use any compression algorithm supported by libcurl.
+	curl_easy_setopt(pH, CURLOPT_FOLLOWLOCATION, 1L);
+	curl_easy_setopt(pH, CURLOPT_MAXREDIRS, 4L);
+	curl_easy_setopt(pH, CURLOPT_FAILONERROR, 1L);
+	curl_easy_setopt(pH, CURLOPT_URL, m_aUrl);
+	curl_easy_setopt(pH, CURLOPT_NOSIGNAL, 1L);
+	curl_easy_setopt(pH, CURLOPT_USERAGENT, GAME_NAME " " GAME_RELEASE_VERSION " (" CONF_PLATFORM_STRING "; " CONF_ARCH_STRING ")");
+	curl_easy_setopt(pH, CURLOPT_ACCEPT_ENCODING, ""); // Use any compression algorithm supported by libcurl.
 
-	curl_easy_setopt(pHandle, CURLOPT_WRITEDATA, this);
-	curl_easy_setopt(pHandle, CURLOPT_WRITEFUNCTION, WriteCallback);
-	curl_easy_setopt(pHandle, CURLOPT_NOPROGRESS, 0L);
-	curl_easy_setopt(pHandle, CURLOPT_PROGRESSDATA, this);
+	curl_easy_setopt(pH, CURLOPT_WRITEDATA, this);
+	curl_easy_setopt(pH, CURLOPT_WRITEFUNCTION, WriteCallback);
+	curl_easy_setopt(pH, CURLOPT_NOPROGRESS, 0L);
+	curl_easy_setopt(pH, CURLOPT_PROGRESSDATA, this);
 	// ‘CURLOPT_PROGRESSFUNCTION’ is deprecated: since 7.32.0. Use CURLOPT_XFERINFOFUNCTION
 	// See problems with curl_off_t type in header file in https://github.com/ddnet/ddnet/pull/6185/
 #ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
-	curl_easy_setopt(pHandle, CURLOPT_PROGRESSFUNCTION, ProgressCallback);
+	curl_easy_setopt(pH, CURLOPT_PROGRESSFUNCTION, ProgressCallback);
 #ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif
-	curl_easy_setopt(pHandle, CURLOPT_IPRESOLVE, m_IpResolve == IPRESOLVE::V4 ? CURL_IPRESOLVE_V4 : m_IpResolve == IPRESOLVE::V6 ? CURL_IPRESOLVE_V6 : CURL_IPRESOLVE_WHATEVER);
+	curl_easy_setopt(pH, CURLOPT_IPRESOLVE, m_IpResolve == IPRESOLVE::V4 ? CURL_IPRESOLVE_V4 : m_IpResolve == IPRESOLVE::V6 ? CURL_IPRESOLVE_V6 : CURL_IPRESOLVE_WHATEVER);
 	if(g_Config.m_Bindaddr[0] != '\0')
 	{
-		curl_easy_setopt(pHandle, CURLOPT_INTERFACE, g_Config.m_Bindaddr);
+		curl_easy_setopt(pH, CURLOPT_INTERFACE, g_Config.m_Bindaddr);
 	}
 
 	if(curl_version_info(CURLVERSION_NOW)->version_num < 0x074400)
 	{
 		// Causes crashes, see https://github.com/ddnet/ddnet/issues/4342.
 		// No longer a problem in curl 7.68 and above, and 0x44 = 68.
-		curl_easy_setopt(pHandle, CURLOPT_FORBID_REUSE, 1L);
+		curl_easy_setopt(pH, CURLOPT_FORBID_REUSE, 1L);
 	}
 
 #ifdef CONF_PLATFORM_ANDROID
@@ -188,7 +188,7 @@ bool CHttpRequest::ConfigureHandle(void *pUser)
 	case REQUEST::GET:
 		break;
 	case REQUEST::HEAD:
-		curl_easy_setopt(pHandle, CURLOPT_NOBODY, 1L);
+		curl_easy_setopt(pH, CURLOPT_NOBODY, 1L);
 		break;
 	case REQUEST::POST:
 	case REQUEST::POST_JSON:
@@ -200,12 +200,12 @@ bool CHttpRequest::ConfigureHandle(void *pUser)
 		{
 			Header("Content-Type:");
 		}
-		curl_easy_setopt(pHandle, CURLOPT_POSTFIELDS, m_pBody);
-		curl_easy_setopt(pHandle, CURLOPT_POSTFIELDSIZE, m_BodyLength);
+		curl_easy_setopt(pH, CURLOPT_POSTFIELDS, m_pBody);
+		curl_easy_setopt(pH, CURLOPT_POSTFIELDSIZE, m_BodyLength);
 		break;
 	}
 
-	curl_easy_setopt(pHandle, CURLOPT_HTTPHEADER, m_pHeaders);
+	curl_easy_setopt(pH, CURLOPT_HTTPHEADER, m_pHeaders);
 
 	return true;
 }

--- a/src/engine/shared/http.h
+++ b/src/engine/shared/http.h
@@ -11,6 +11,7 @@
 #include <deque>
 #include <mutex>
 #include <optional>
+#include <unordered_map>
 
 #include <engine/http.h>
 

--- a/src/engine/shared/http.h
+++ b/src/engine/shared/http.h
@@ -7,9 +7,9 @@
 
 #include <algorithm>
 #include <atomic>
-#include <mutex>
 #include <condition_variable>
 #include <deque>
+#include <mutex>
 #include <optional>
 
 #include <engine/http.h>
@@ -127,8 +127,8 @@ class CHttpRequest : public IHttpRequest
 
 protected:
 	// These run on the curl thread now, DO NOT STALL THE THREAD
-	virtual void OnProgress() {};
-	virtual void OnCompletion() {};
+	virtual void OnProgress(){};
+	virtual void OnCompletion(){};
 
 public:
 	CHttpRequest(const char *pUrl);
@@ -185,7 +185,11 @@ public:
 	double Size() const { return m_Size.load(std::memory_order_relaxed); }
 	int Progress() const { return m_Progress.load(std::memory_order_relaxed); }
 	int State() const { return m_State; }
-	bool Done() const { int State = m_State; return State != HTTP_QUEUED && State != HTTP_DONE; }
+	bool Done() const
+	{
+		int State = m_State;
+		return State != HTTP_QUEUED && State != HTTP_DONE;
+	}
 	void Abort() { m_Abort = true; }
 
 	void Wait();
@@ -237,7 +241,8 @@ bool HttpHasIpresolveBug();
 // In an ideal world this would be a kernel interface
 class CHttp : public IHttp
 {
-	enum EState {
+	enum EState
+	{
 		UNINITIALIZED,
 		RUNNING,
 		STOPPING,

--- a/src/engine/shared/http.h
+++ b/src/engine/shared/http.h
@@ -188,7 +188,7 @@ public:
 	bool Done() const
 	{
 		int State = m_State;
-		return State != HTTP_QUEUED && State != HTTP_DONE;
+		return State != HTTP_QUEUED && State != HTTP_RUNNING;
 	}
 	void Abort() { m_Abort = true; }
 

--- a/src/engine/shared/http.h
+++ b/src/engine/shared/http.h
@@ -234,7 +234,6 @@ inline std::unique_ptr<CHttpRequest> HttpPostJson(const char *pUrl, const char *
 	return pResult;
 }
 
-bool HttpInit(IStorage *pStorage);
 void EscapeUrl(char *pBuf, int Size, const char *pStr);
 bool HttpHasIpresolveBug();
 

--- a/src/engine/shared/http.h
+++ b/src/engine/shared/http.h
@@ -132,7 +132,7 @@ protected:
 
 public:
 	CHttpRequest(const char *pUrl);
-	~CHttpRequest();
+	virtual ~CHttpRequest();
 
 	void Timeout(CTimeout Timeout) { m_Timeout = Timeout; }
 	void MaxResponseSize(int64_t MaxResponseSize) { m_MaxResponseSize = MaxResponseSize; }
@@ -273,6 +273,7 @@ public:
 	// User
 	virtual void Run(std::shared_ptr<IHttpRequest> pRequest) override;
 	void Shutdown() override;
+	~CHttp();
 };
 
 #endif // ENGINE_SHARED_HTTP_H

--- a/src/game/client/component.cpp
+++ b/src/game/client/component.cpp
@@ -40,3 +40,5 @@ class IClient *CComponent::Client() const
 {
 	return m_pClient->Client();
 }
+
+class IHttp *CComponent::Http() const { return m_pClient->Http(); }

--- a/src/game/client/component.h
+++ b/src/game/client/component.h
@@ -128,6 +128,11 @@ protected:
 	 */
 	float LocalTime() const;
 
+	/**
+	 * Get the http interface
+	 */
+	class IHttp *Http() const;
+
 public:
 	/**
 	 * The component virtual destructor.

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -17,6 +17,7 @@
 #include <engine/serverbrowser.h>
 #include <engine/shared/config.h>
 #include <engine/shared/http.h>
+#include <engine/shared/jobs.h>
 #include <engine/shared/linereader.h>
 #include <engine/textrender.h>
 
@@ -515,34 +516,35 @@ protected:
 		char m_aPath[IO_MAX_PATH_LENGTH];
 		int m_StorageType;
 		bool m_Success = false;
-		CImageInfo m_ImageInfo;
 		SHA256_DIGEST m_Sha256;
 
 		CAbstractCommunityIconJob(CMenus *pMenus, const char *pCommunityId, int StorageType);
-		virtual ~CAbstractCommunityIconJob();
+		virtual ~CAbstractCommunityIconJob() {};
 
 	public:
 		const char *CommunityId() const { return m_aCommunityId; }
 		bool Success() const { return m_Success; }
-		CImageInfo &&ImageInfo() { return std::move(m_ImageInfo); }
 		SHA256_DIGEST &&Sha256() { return std::move(m_Sha256); }
 	};
+
 	class CCommunityIconLoadJob : public IJob, public CAbstractCommunityIconJob
 	{
+		CImageInfo m_ImageInfo;
 	protected:
 		void Run() override;
 
 	public:
 		CCommunityIconLoadJob(CMenus *pMenus, const char *pCommunityId, int StorageType);
+
+		CImageInfo &&ImageInfo() { return std::move(m_ImageInfo); }
 	};
+
 	class CCommunityIconDownloadJob : public CHttpRequest, public CAbstractCommunityIconJob
 	{
-	protected:
-		int OnCompletion(int State) override;
-
 	public:
 		CCommunityIconDownloadJob(CMenus *pMenus, const char *pCommunityId, const char *pUrl, const SHA256_DIGEST &Sha256);
 	};
+
 	struct SCommunityIcon
 	{
 		char m_aCommunityId[CServerInfo::MAX_COMMUNITY_ID_LENGTH];

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -519,7 +519,7 @@ protected:
 		SHA256_DIGEST m_Sha256;
 
 		CAbstractCommunityIconJob(CMenus *pMenus, const char *pCommunityId, int StorageType);
-		virtual ~CAbstractCommunityIconJob() {};
+		virtual ~CAbstractCommunityIconJob(){};
 
 	public:
 		const char *CommunityId() const { return m_aCommunityId; }
@@ -530,6 +530,7 @@ protected:
 	class CCommunityIconLoadJob : public IJob, public CAbstractCommunityIconJob
 	{
 		CImageInfo m_ImageInfo;
+
 	protected:
 		void Run() override;
 

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -536,6 +536,7 @@ protected:
 
 	public:
 		CCommunityIconLoadJob(CMenus *pMenus, const char *pCommunityId, int StorageType);
+		~CCommunityIconLoadJob();
 
 		CImageInfo &&ImageInfo() { return std::move(m_ImageInfo); }
 	};

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1802,25 +1802,6 @@ CMenus::CAbstractCommunityIconJob::CAbstractCommunityIconJob(CMenus *pMenus, con
 	str_format(m_aPath, sizeof(m_aPath), "communityicons/%s.png", pCommunityId);
 }
 
-CMenus::CAbstractCommunityIconJob::~CAbstractCommunityIconJob()
-{
-	free(m_ImageInfo.m_pData);
-	m_ImageInfo.m_pData = nullptr;
-}
-
-int CMenus::CCommunityIconDownloadJob::OnCompletion(int State)
-{
-	State = CHttpRequest::OnCompletion(State);
-	if(State == HTTP_DONE)
-	{
-		if(m_pMenus->LoadCommunityIconFile(Dest(), IStorage::TYPE_SAVE, m_ImageInfo, m_Sha256))
-			m_Success = true;
-		else
-			State = HTTP_ERROR;
-	}
-	return State;
-}
-
 CMenus::CCommunityIconDownloadJob::CCommunityIconDownloadJob(CMenus *pMenus, const char *pCommunityId, const char *pUrl, const SHA256_DIGEST &Sha256) :
 	CHttpRequest(pUrl),
 	CAbstractCommunityIconJob(pMenus, pCommunityId, IStorage::TYPE_SAVE)
@@ -1964,10 +1945,14 @@ void CMenus::UpdateCommunityIcons()
 	if(!m_CommunityIconDownloadJobs.empty())
 	{
 		std::shared_ptr<CCommunityIconDownloadJob> pJob = m_CommunityIconDownloadJobs.front();
-		if(pJob->Status() == IJob::STATE_DONE)
+		if(pJob->Done())
 		{
-			if(pJob->Success())
-				LoadCommunityIconFinish(pJob->CommunityId(), pJob->ImageInfo(), pJob->Sha256());
+			if(pJob->State() == HTTP_DONE)
+			{
+				std::shared_ptr<CCommunityIconLoadJob> pLoadJob = std::make_shared<CCommunityIconLoadJob>(this, pJob->CommunityId(), IStorage::TYPE_SAVE);
+				Engine()->AddJob(pLoadJob);
+				m_CommunityIconLoadJobs.emplace_back(std::move(pLoadJob));
+			}
 			m_CommunityIconDownloadJobs.pop_front();
 		}
 	}
@@ -2007,7 +1992,7 @@ void CMenus::UpdateCommunityIcons()
 		if(pExistingDownload == m_CommunityIconDownloadJobs.end() && (ExistingIcon == m_vCommunityIcons.end() || ExistingIcon->m_Sha256 != Community.IconSha256()))
 		{
 			std::shared_ptr<CCommunityIconDownloadJob> pJob = std::make_shared<CCommunityIconDownloadJob>(this, Community.Id(), Community.IconUrl(), Community.IconSha256());
-			Engine()->AddJob(pJob);
+			Http()->Run(pJob);
 			m_CommunityIconDownloadJobs.push_back(pJob);
 		}
 	}

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1822,6 +1822,12 @@ CMenus::CCommunityIconLoadJob::CCommunityIconLoadJob(CMenus *pMenus, const char 
 {
 }
 
+CMenus::CCommunityIconLoadJob::~CCommunityIconLoadJob()
+{
+	free(m_ImageInfo.m_pData);
+	m_ImageInfo.m_pData = nullptr;
+}
+
 int CMenus::CommunityIconScan(const char *pName, int IsDir, int DirType, void *pUser)
 {
 	const char *pExtension = ".png";

--- a/src/game/client/components/skins.h
+++ b/src/game/client/components/skins.h
@@ -20,7 +20,7 @@ public:
 		CSkins *m_pSkins;
 
 	protected:
-		virtual int OnCompletion(int State) override;
+		virtual void OnCompletion() override;
 
 	public:
 		CGetPngFile(CSkins *pSkins, const char *pUrl, IStorage *pStorage, const char *pDest);

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -100,6 +100,7 @@ void CGameClient::OnConsoleInit()
 #if defined(CONF_AUTOUPDATE)
 	m_pUpdater = Kernel()->RequestInterface<IUpdater>();
 #endif
+	m_pHttp = Kernel()->RequestInterface<IHttp>();
 
 	m_Menus.SetMenuBackground(&m_MenuBackground);
 

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -177,6 +177,7 @@ private:
 #if defined(CONF_AUTOUPDATE)
 	class IUpdater *m_pUpdater;
 #endif
+	class IHttp *m_pHttp;
 
 	CLayers m_Layers;
 	CCollision m_Collision;
@@ -251,6 +252,7 @@ public:
 		return m_pUpdater;
 	}
 #endif
+	class IHttp *Http() { return m_pHttp; }
 
 	int NetobjNumCorrections()
 	{

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -252,7 +252,10 @@ public:
 		return m_pUpdater;
 	}
 #endif
-	class IHttp *Http() { return m_pHttp; }
+	class IHttp *Http()
+	{
+		return m_pHttp;
+	}
 
 	int NetobjNumCorrections()
 	{


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->
This rebases and partially rewrites #5842. Tested very roughly

I still am not the biggest fan but this is the best I can do without going far too deep into a jobs rewrite: 
- This iteration uses the approach in #5092 as we talked about on Discord so the `IJob` interface is lost.
- Another issue is that this isn't a real engine interface but just pretends to be one so I can easily get pointers to it around the code. This can be mitigated by either designing a proper interface for `IHttpRequest` or by passing `CHttp` around everywhere like in #5092
- Finally one might want to rework the concurrency aids from `std` with our own ones, I'm far too tired of messing around with this PR to care about that.

@heinrich5991 you specifically should take a look at `CHttpRequest::Wait()`, the way I implemented it is rather nasty. You might want to replace it with a condvar but then you also need a mutex and suddenly there is a lot to think about. This feature is currently only used in `CRegister`.

@Robyt3 you should probably take a look at my changes in `menus_browser.cpp`. Since we don't want to stall the curl thread I moved the loading of the icon to a thread of it's own.

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
