### PR TITLE
Clear console selection only when scroll position is changed

### DIFF
--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -278,6 +278,7 @@ bool CGameConsole::CInstance::OnInput(const IInput::CEvent &Event)
 		}
 	};
 
+	const int BacklogPrevLine = m_BacklogCurLine;
 	if(Event.m_Flags & IInput::FLAG_PRESS)
 	{
 		if(Event.m_Key == KEY_RETURN || Event.m_Key == KEY_KP_ENTER)
@@ -410,24 +411,19 @@ bool CGameConsole::CInstance::OnInput(const IInput::CEvent &Event)
 		else if(Event.m_Key == KEY_PAGEUP)
 		{
 			m_BacklogCurLine += GetLinesToScroll(-1, m_LinesRendered);
-			m_HasSelection = false;
 		}
 		else if(Event.m_Key == KEY_PAGEDOWN)
 		{
-			m_HasSelection = false;
 			m_BacklogCurLine -= GetLinesToScroll(1, m_LinesRendered);
-
 			if(m_BacklogCurLine < 0)
 				m_BacklogCurLine = 0;
 		}
 		else if(Event.m_Key == KEY_MOUSE_WHEEL_UP)
 		{
 			m_BacklogCurLine += GetLinesToScroll(-1, 1);
-			m_HasSelection = false;
 		}
 		else if(Event.m_Key == KEY_MOUSE_WHEEL_DOWN)
 		{
-			m_HasSelection = false;
 			--m_BacklogCurLine;
 			if(m_BacklogCurLine < 0)
 				m_BacklogCurLine = 0;
@@ -436,15 +432,12 @@ bool CGameConsole::CInstance::OnInput(const IInput::CEvent &Event)
 		// react to it when the input is empty
 		else if(Event.m_Key == KEY_HOME && m_Input.IsEmpty())
 		{
-			int Lines = GetLinesToScroll(-1, -1);
-			m_BacklogCurLine += Lines;
+			m_BacklogCurLine += GetLinesToScroll(-1, -1);
 			m_BacklogLastActiveLine = m_BacklogCurLine;
-			m_HasSelection = false;
 		}
 		else if(Event.m_Key == KEY_END && m_Input.IsEmpty())
 		{
 			m_BacklogCurLine = 0;
-			m_HasSelection = false;
 		}
 		else if(Event.m_Key == KEY_F && m_pGameConsole->Input()->ModifierIsPressed() && Event.m_Flags & IInput::FLAG_PRESS)
 		{
@@ -453,6 +446,11 @@ bool CGameConsole::CInstance::OnInput(const IInput::CEvent &Event)
 
 			Handled = true;
 		}
+	}
+
+	if(m_BacklogCurLine != BacklogPrevLine)
+	{
+		m_HasSelection = false;
 	}
 
 	if(!Handled)


### PR DESCRIPTION
The selection is only cleared because it would be incorrect after scrolling, but it doesn't need to be cleared if the scroll position does not change, e.g. when pressing Home while already at the top of the backlog.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
