### PR TITLE
Fix console selection not adjusted anymore when entries added

### DIFF
--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -1054,7 +1054,16 @@ void CGameConsole::OnRender()
 
 		pConsole->PumpBacklogPending();
 		if(pConsole->m_NewLineCounter > 0)
+		{
 			pConsole->UpdateSearch();
+
+			// keep scroll position when new entries are printed.
+			if(pConsole->m_BacklogCurLine != 0)
+			{
+				pConsole->m_BacklogCurLine += pConsole->m_NewLineCounter;
+				pConsole->m_BacklogLastActiveLine += pConsole->m_NewLineCounter;
+			}
+		}
 
 		// render console log (current entry, status, wrap lines)
 		CInstance::CBacklogEntry *pEntry = pConsole->m_Backlog.Last();
@@ -1085,17 +1094,6 @@ void CGameConsole::OnRender()
 				pConsole->UpdateEntryTextAttributes(pEntry);
 
 			LineNum += pEntry->m_LineCount;
-			while(pConsole->m_NewLineCounter > 0)
-			{
-				--pConsole->m_NewLineCounter;
-
-				// keep scroll position when new entries are printed.
-				if(pConsole->m_BacklogCurLine != 0)
-				{
-					pConsole->m_BacklogCurLine++;
-					pConsole->m_BacklogLastActiveLine++;
-				}
-			}
 			if(LineNum < pConsole->m_BacklogLastActiveLine)
 			{
 				SkippedLines += pEntry->m_LineCount;
@@ -1182,6 +1180,10 @@ void CGameConsole::OnRender()
 
 			// reset color
 			TextRender()->TextColor(TextRender()->DefaultTextColor());
+			if(pConsole->m_NewLineCounter > 0)
+			{
+				--pConsole->m_NewLineCounter;
+			}
 			First = false;
 
 			if(!pEntry)


### PR DESCRIPTION
The current mouse-based console selection was not being adjusted anymore when new lines are added to the console, as the `m_NewLineCounter` variable was decremented to `0` before the relevant check for `m_NewLineCounter > 0`.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
