### PR TITLE
Fix console selection being moved when keeping scroll offset

### DIFF
--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -1111,7 +1111,8 @@ void CGameConsole::OnRender()
 			float LocalOffsetY = OffsetY + pEntry->m_YOffset / (float)pEntry->m_LineCount;
 			OffsetY += pEntry->m_YOffset;
 
-			if((pConsole->m_HasSelection || pConsole->m_MouseIsPress) && pConsole->m_NewLineCounter > 0)
+			// Only apply offset if we do not keep scroll position (m_BacklogCurLine == 0)
+			if((pConsole->m_HasSelection || pConsole->m_MouseIsPress) && pConsole->m_NewLineCounter > 0 && pConsole->m_BacklogCurLine == 0)
 			{
 				float MouseExtraOff = pEntry->m_YOffset;
 				pConsole->m_MousePress.y -= MouseExtraOff;
@@ -1176,14 +1177,13 @@ void CGameConsole::OnRender()
 				pConsole->m_HasSelection = true;
 			}
 
+			if(pConsole->m_NewLineCounter > 0) // Decrease by the entry line count since we can have multiline entries
+				pConsole->m_NewLineCounter -= pEntry->m_LineCount;
+
 			pEntry = pConsole->m_Backlog.Prev(pEntry);
 
 			// reset color
 			TextRender()->TextColor(TextRender()->DefaultTextColor());
-			if(pConsole->m_NewLineCounter > 0)
-			{
-				--pConsole->m_NewLineCounter;
-			}
 			First = false;
 
 			if(!pEntry)


### PR DESCRIPTION
The selection in console should not change position when new entries are printed while keeping scroll position (when console is scrolled up by at least 1 line).
Also decrease `m_NewLineCounter` by the entry line count.

Before:

https://github.com/ddnet/ddnet/assets/13364635/96cf638c-e864-429f-af92-cd3ab35f5600


After:

https://github.com/ddnet/ddnet/assets/13364635/90b9a8c8-686c-4826-8911-3fb7413e3b39


## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
