### PR TITLE
Avoid duplicate calculation in `QuadsTex3DDrawTL`

### DIFF
--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -1074,26 +1074,14 @@ void CGraphics_Threaded::QuadsDrawTL(const CQuadItem *pArray, int Num)
 
 void CGraphics_Threaded::QuadsTex3DDrawTL(const CQuadItem *pArray, int Num)
 {
-	int CurNumVert = m_NumVertices;
-
-	int VertNum = 0;
-	if(g_Config.m_GfxQuadAsTriangle && !m_GLUseTrianglesAsQuad)
-	{
-		VertNum = 6;
-	}
-	else
-	{
-		VertNum = 4;
-	}
+	const int VertNum = g_Config.m_GfxQuadAsTriangle && !m_GLUseTrianglesAsQuad ? 6 : 4;
+	const float CurIndex = Uses2DTextureArrays() ? m_CurIndex : (m_CurIndex + 0.5f) / 256.0f;
 
 	for(int i = 0; i < Num; ++i)
 	{
 		for(int n = 0; n < VertNum; ++n)
 		{
-			if(Uses2DTextureArrays())
-				m_aVerticesTex3D[CurNumVert + VertNum * i + n].m_Tex.w = (float)m_CurIndex;
-			else
-				m_aVerticesTex3D[CurNumVert + VertNum * i + n].m_Tex.w = ((float)m_CurIndex + 0.5f) / 256.f;
+			m_aVerticesTex3D[m_NumVertices + VertNum * i + n].m_Tex.w = CurIndex;
 		}
 	}
 


### PR DESCRIPTION
Only calculate `CurIndex` value once outside of loop instead of calculating it every iteration.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
