### PR TITLE
Fix map tools crashing on maps with unknown UUID-based map items

### DIFF
--- a/src/tools/map_convert_07.cpp
+++ b/src/tools/map_convert_07.cpp
@@ -219,14 +219,15 @@ int main(int argc, const char **argv)
 	{
 		int Type, ID;
 		void *pItem = g_DataReader.GetItem(Index, &Type, &ID);
-		int Size = g_DataReader.GetItemSize(Index);
 
-		// filter ITEMTYPE_EX items, they will be automatically added again
-		if(Type == ITEMTYPE_EX)
+		// Filter items with unknown type, as we can't write them back.
+		// Filter ITEMTYPE_EX items, they will be automatically added again.
+		if(Type < 0 || Type == ITEMTYPE_EX)
 		{
 			continue;
 		}
 
+		int Size = g_DataReader.GetItemSize(Index);
 		Success &= CheckImageDimensions(pItem, Type, pSourceFileName);
 
 		CMapItemImage NewImageItem;

--- a/src/tools/map_create_pixelart.cpp
+++ b/src/tools/map_create_pixelart.cpp
@@ -377,8 +377,13 @@ void SaveOutputMap(CDataFileReader &InputMap, CDataFileWriter &OutputMap, CMapIt
 		int ID, Type;
 		void *pItem = InputMap.GetItem(i, &Type, &ID);
 
-		if(Type == ITEMTYPE_EX)
+		// Filter items with unknown type, as we can't write them back.
+		// Filter ITEMTYPE_EX items, they will be automatically added again.
+		if(Type < 0 || Type == ITEMTYPE_EX)
+		{
 			continue;
+		}
+
 		if(i == NewItemNumber)
 			pItem = pNewItem;
 

--- a/src/tools/map_optimize.cpp
+++ b/src/tools/map_optimize.cpp
@@ -140,13 +140,14 @@ int main(int argc, const char **argv)
 	{
 		int Type, ID;
 		void *pPtr = Reader.GetItem(Index, &Type, &ID);
-		int Size = Reader.GetItemSize(Index);
 
-		// filter ITEMTYPE_EX items, they will be automatically added again
-		if(Type == ITEMTYPE_EX)
+		// Filter items with unknown type, as we can't write them back.
+		// Filter ITEMTYPE_EX items, they will be automatically added again.
+		if(Type < 0 || Type == ITEMTYPE_EX)
 		{
 			continue;
 		}
+
 		// for all layers, check if it uses a image and set the corresponding flag
 		if(Type == MAPITEMTYPE_LAYER)
 		{
@@ -203,6 +204,7 @@ int main(int argc, const char **argv)
 			++i;
 		}
 
+		int Size = Reader.GetItemSize(Index);
 		Writer.AddItem(Type, ID, Size, pPtr);
 	}
 

--- a/src/tools/map_replace_area.cpp
+++ b/src/tools/map_replace_area.cpp
@@ -168,8 +168,13 @@ void SaveOutputMap(CDataFileReader &InputMap, CDataFileWriter &OutputMap)
 		int ID, Type;
 		void *pItem = InputMap.GetItem(i, &Type, &ID);
 
-		if(Type == ITEMTYPE_EX)
+		// Filter items with unknown type, as we can't write them back.
+		// Filter ITEMTYPE_EX items, they will be automatically added again.
+		if(Type < 0 || Type == ITEMTYPE_EX)
+		{
 			continue;
+		}
+
 		if(g_apNewItem[i])
 			pItem = g_apNewItem[i];
 

--- a/src/tools/map_replace_image.cpp
+++ b/src/tools/map_replace_image.cpp
@@ -150,9 +150,12 @@ int main(int argc, const char **argv)
 		int Type, ID;
 		void *pItem = g_DataReader.GetItem(Index, &Type, &ID);
 
-		// filter ITEMTYPE_EX items, they will be automatically added again
-		if(Type == ITEMTYPE_EX)
+		// Filter items with unknown type, as we can't write them back.
+		// Filter ITEMTYPE_EX items, they will be automatically added again.
+		if(Type < 0 || Type == ITEMTYPE_EX)
+		{
 			continue;
+		}
 
 		int Size = g_DataReader.GetItemSize(Index);
 

--- a/src/tools/map_resave.cpp
+++ b/src/tools/map_resave.cpp
@@ -32,9 +32,12 @@ static int ResaveMap(const char *pSourceMap, const char *pDestinationMap, IStora
 		int Type, ID;
 		const void *pPtr = Reader.GetItem(Index, &Type, &ID);
 
-		// filter ITEMTYPE_EX items, they will be automatically added again
-		if(Type == ITEMTYPE_EX)
+		// Filter items with unknown type, as we can't write them back.
+		// Filter ITEMTYPE_EX items, they will be automatically added again.
+		if(Type < 0 || Type == ITEMTYPE_EX)
+		{
 			continue;
+		}
 
 		int Size = Reader.GetItemSize(Index);
 		Writer.AddItem(Type, ID, Size, pPtr);


### PR DESCRIPTION
All `map_*` tools were crashing with the assertion `Invalid type` when used on maps that contain unknown UUID-based map items. When the UUID cannot be resolved, the type `-1` is returned by the `GetItem` function. The assertion predates UUID map items, so this crash has likely existed since the introduction of UUID map items. The editor was not affected and has instead always discarded map items that it does not support. The tools will now also discard map items with unknown UUIDs.

See #7669.

## Checklist

- [X] Tested the change
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
