### PR TITLE
Use `CEditorComponent` methods instead of only `CMapView`

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -8164,6 +8164,9 @@ void CEditor::Render()
 			MapView()->Zoom()->ChangeValue(-20.0f);
 	}
 
+	for(CEditorComponent &Component : m_vComponents)
+		Component.OnRender(View);
+
 	MapView()->UpdateZoom();
 
 	UI()->RenderPopupMenus();
@@ -8259,7 +8262,9 @@ void CEditor::Reset(bool CreateDefault)
 	UI()->ClosePopupMenus();
 	m_Map.Clean();
 
-	m_MapView.OnReset();
+	for(CEditorComponent &Component : m_vComponents)
+		Component.OnReset();
+
 	// create default layers
 	if(CreateDefault)
 	{
@@ -8633,6 +8638,9 @@ void CEditor::OnUpdate()
 	DispatchInputEvents();
 	HandleAutosave();
 	HandleWriterFinishJobs();
+
+	for(CEditorComponent &Component : m_vComponents)
+		Component.OnUpdate();
 }
 
 void CEditor::OnRender()
@@ -8760,7 +8768,9 @@ bool CEditor::Load(const char *pFileName, int StorageType)
 		str_copy(m_aFileName, pFileName);
 		SortImages();
 		SelectGameLayer();
-		MapView()->OnMapLoad();
+
+		for(CEditorComponent &Component : m_vComponents)
+			Component.OnMapLoad();
 	}
 	else
 	{

--- a/src/game/editor/editor_object.cpp
+++ b/src/game/editor/editor_object.cpp
@@ -8,9 +8,8 @@ void CEditorObject::Init(CEditor *pEditor)
 	OnReset();
 }
 
-void CEditorObject::OnUpdate(CUIRect View)
+void CEditorObject::OnUpdate()
 {
-	OnRender(View);
 	if(IsActive())
 		OnActive();
 	else if(IsHot())

--- a/src/game/editor/editor_object.h
+++ b/src/game/editor/editor_object.h
@@ -31,9 +31,9 @@ public:
 	virtual void Init(CEditor *pEditor);
 
 	/**
-	 * Calls `OnRender` and then maybe `OnHot` or `OnActive`.
+	 * Maybe calls `OnHot` or `OnActive`.
 	 */
-	void OnUpdate(CUIRect View);
+	virtual void OnUpdate();
 
 	/**
 	 * Gets called before `OnRender`. Should return true


### PR DESCRIPTION
Also, small changes to `CEditorObject`.
Previously only `CMapView` methods were used, but we should instead use the components methods by iterating over them in case we add more in the future.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
