### PR TITLE
change cast of pointer to uintptr_t

### DIFF
--- a/src/engine/external/json-parser/json.c
+++ b/src/engine/external/json-parser/json.c
@@ -132,7 +132,7 @@ static int new_value (json_state * state,
             values_size = sizeof (*value->u.object.values) * value->u.object.length;
 
             if (! ((*(void **) &value->u.object.values) = json_alloc
-                  (state, values_size + ((unsigned long) value->u.object.values), 0)) )
+                  (state, values_size + ((uintptr_t) value->u.object.values), 0)) )
             {
                return 0;
             }


### PR DESCRIPTION
~~1 liner~~
Warning:

cast from pointer to integer of different size

fixed by pulling latest upstream of json-parser : https://github.com/json-parser/json-parser
## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
