### PR TITLE
Remove unused `VkBufferImageCopy Region` variable

### DIFF
--- a/src/engine/client/backend/vulkan/backend_vulkan.cpp
+++ b/src/engine/client/backend/vulkan/backend_vulkan.cpp
@@ -1400,17 +1400,6 @@ protected:
 				return false;
 			VkCommandBuffer &CommandBuffer = *pCommandBuffer;
 
-			VkBufferImageCopy Region{};
-			Region.bufferOffset = 0;
-			Region.bufferRowLength = 0;
-			Region.bufferImageHeight = 0;
-			Region.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-			Region.imageSubresource.mipLevel = 0;
-			Region.imageSubresource.baseArrayLayer = 0;
-			Region.imageSubresource.layerCount = 1;
-			Region.imageOffset = {0, 0, 0};
-			Region.imageExtent = {Viewport.width, Viewport.height, 1};
-
 			auto &SwapImg = m_vSwapChainImages[m_LastPresentedSwapChainImageIndex];
 
 			if(!ImageBarrier(m_GetPresentedImgDataHelperImage, 0, 1, 0, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL))


### PR DESCRIPTION
According to the Vulkan specification, the struct `VkBufferImageCopy` is used only for `vkCmdCopyBufferToImage` and `vkCmdCopyImageToBuffer`. The variable `Region` is only initialized but not passed to either of those functions.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
