### PR TITLE
Editor: add shortcut to adjust special tiles numbers

### DIFF
--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -1061,7 +1061,8 @@ public:
 	unsigned char m_SwitchNum;
 	unsigned char m_SwitchDelay;
 
-	void AdjustBrushSpecialTiles(int Adjust);
+	void AdjustBrushSpecialTiles(bool UseNextFree, int Adjust = 0);
+	int FindNextFreeTileNumber(int Type);
 
 public:
 	// Undo/Redo

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -1061,6 +1061,8 @@ public:
 	unsigned char m_SwitchNum;
 	unsigned char m_SwitchDelay;
 
+	void AdjustBrushSpecialTiles(int Adjust);
+
 public:
 	// Undo/Redo
 	CEditorHistory m_EditorHistory;

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -2434,20 +2434,10 @@ CUI::EPopupMenuFunctionResult CEditor::PopupTele(void *pContext, CUIRect View, b
 		static int s_EmptySlotPid = 0;
 		if(pEditor->DoButton_Editor(&s_EmptySlotPid, "F", 0, &FindEmptySlot, 0, "[ctrl+f] Find empty slot") || (Active && pEditor->Input()->ModifierIsPressed() && pEditor->Input()->KeyPress(KEY_F)))
 		{
-			int number = -1;
-			for(int i = 1; i <= 255; i++)
-			{
-				if(!pEditor->m_Map.m_pTeleLayer->ContainsElementWithId(i))
-				{
-					number = i;
-					break;
-				}
-			}
+			int Number = pEditor->FindNextFreeTileNumber(LAYERTYPE_TELE);
 
-			if(number != -1)
-			{
-				pEditor->m_TeleNumber = number;
-			}
+			if(Number != -1)
+				pEditor->m_TeleNumber = Number;
 		}
 	}
 
@@ -2540,20 +2530,10 @@ CUI::EPopupMenuFunctionResult CEditor::PopupSwitch(void *pContext, CUIRect View,
 		static int s_EmptySlotPid = 0;
 		if(pEditor->DoButton_Editor(&s_EmptySlotPid, "F", 0, &FindEmptySlot, 0, "[ctrl+f] Find empty slot") || (Active && pEditor->Input()->ModifierIsPressed() && pEditor->Input()->KeyPress(KEY_F)))
 		{
-			int Number = -1;
-			for(int i = 1; i <= 255; i++)
-			{
-				if(!pEditor->m_Map.m_pSwitchLayer->ContainsElementWithId(i))
-				{
-					Number = i;
-					break;
-				}
-			}
+			int Number = pEditor->FindNextFreeTileNumber(LAYERTYPE_SWITCH);
 
 			if(Number != -1)
-			{
 				pEditor->m_SwitchNum = Number;
-			}
 		}
 	}
 


### PR DESCRIPTION
Closes #5400.
This PR adds two things:
- A way to easily change tele, switch and tune numbers of the current brush by using shift+scroll up/down to adjust the numbers by `1`/`-1`:

https://github.com/ddnet/ddnet/assets/13364635/8c7ddf0d-d4ef-4be3-9aa6-0e1c5825d01c

- A way to set tele and switch numbers to the next free number of the respective layer by using `ctrl+f` while having a brush selected:

https://github.com/ddnet/ddnet/assets/13364635/985491c4-0980-4c82-86af-98adc04c80c5

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
