### PR TITLE
Fix automatic hammer on release when cl_dummy_control is set to 1

### DIFF
--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -284,10 +284,10 @@ int CControls::SnapInput(int *pData)
 			pDummyInput->m_TargetX = m_aInputData[g_Config.m_ClDummy].m_TargetX;
 			pDummyInput->m_TargetY = m_aInputData[g_Config.m_ClDummy].m_TargetY;
 			pDummyInput->m_WantedWeapon = m_aInputData[g_Config.m_ClDummy].m_WantedWeapon;
-			
+
 			if(!g_Config.m_ClDummyControl)
 				pDummyInput->m_Fire += m_aInputData[g_Config.m_ClDummy].m_Fire - m_aLastData[g_Config.m_ClDummy].m_Fire;
-	
+
 			pDummyInput->m_NextWeapon += m_aInputData[g_Config.m_ClDummy].m_NextWeapon - m_aLastData[g_Config.m_ClDummy].m_NextWeapon;
 			pDummyInput->m_PrevWeapon += m_aInputData[g_Config.m_ClDummy].m_PrevWeapon - m_aLastData[g_Config.m_ClDummy].m_PrevWeapon;
 
@@ -298,12 +298,12 @@ int CControls::SnapInput(int *pData)
 		{
 			CNetObj_PlayerInput *pDummyInput = &m_pClient->m_DummyInput;
 			pDummyInput->m_Jump = g_Config.m_ClDummyJump;
-		
+
 			if(g_Config.m_ClDummyFire)
 				pDummyInput->m_Fire = g_Config.m_ClDummyFire;
 			else if((pDummyInput->m_Fire & 1) != 0)
 				pDummyInput->m_Fire++;
-		
+
 			pDummyInput->m_Hook = g_Config.m_ClDummyHook;
 		}
 

--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -284,8 +284,10 @@ int CControls::SnapInput(int *pData)
 			pDummyInput->m_TargetX = m_aInputData[g_Config.m_ClDummy].m_TargetX;
 			pDummyInput->m_TargetY = m_aInputData[g_Config.m_ClDummy].m_TargetY;
 			pDummyInput->m_WantedWeapon = m_aInputData[g_Config.m_ClDummy].m_WantedWeapon;
-
-			pDummyInput->m_Fire += m_aInputData[g_Config.m_ClDummy].m_Fire - m_aLastData[g_Config.m_ClDummy].m_Fire;
+			
+			if(!g_Config.m_ClDummyControl)
+				pDummyInput->m_Fire += m_aInputData[g_Config.m_ClDummy].m_Fire - m_aLastData[g_Config.m_ClDummy].m_Fire;
+	
 			pDummyInput->m_NextWeapon += m_aInputData[g_Config.m_ClDummy].m_NextWeapon - m_aLastData[g_Config.m_ClDummy].m_NextWeapon;
 			pDummyInput->m_PrevWeapon += m_aInputData[g_Config.m_ClDummy].m_PrevWeapon - m_aLastData[g_Config.m_ClDummy].m_PrevWeapon;
 
@@ -296,7 +298,12 @@ int CControls::SnapInput(int *pData)
 		{
 			CNetObj_PlayerInput *pDummyInput = &m_pClient->m_DummyInput;
 			pDummyInput->m_Jump = g_Config.m_ClDummyJump;
-			pDummyInput->m_Fire = g_Config.m_ClDummyFire;
+		
+			if(g_Config.m_ClDummyFire)
+				pDummyInput->m_Fire = g_Config.m_ClDummyFire;
+			else if((pDummyInput->m_Fire & 1) != 0)
+				pDummyInput->m_Fire++;
+		
 			pDummyInput->m_Hook = g_Config.m_ClDummyHook;
 		}
 


### PR DESCRIPTION
Fixes #5077 

Let's say you have this bind:

```bind x +toggle cl_dummy_hammer 1 0```

and you set ```cl_dummy_control``` to ```1```.

When you press the bind i mentioned above, and then release, the dummy will hammer where he is looking (not at you). So, in total, there will be two hammers. One hammer when you press down the button and the dummy hammers towards you, and then another hammer when you release the button and the dummy hammers where he is looking.

This fixes it, and also makes sure it does not conflict with ```cl_dummy_copy_moves``` (as if it is enabled and ```cl_dummy_control``` is enabled, the dummy will not copy fire, hook, or jump) so I made sure it keeps this functionality as it's pretty cool.

This does not fix any other bugs yet, maybe I will fix those in the future but we'll see. Any bug you may encounter with this change is also probably present in the main branch, such as ```cl_dummy_resetonswitch``` not working perfectly with ```cl_dummy_control```, but if you do find something different then let me know.

<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
