### PR TITLE
Editor: improve text rendering inside tele tiles

### DIFF
--- a/src/game/client/render_map.cpp
+++ b/src/game/client/render_map.cpp
@@ -724,7 +724,6 @@ void CRenderTools::RenderTeleOverlay(CTeleTile *pTele, int w, int h, float Scale
 		return; // its useless to render text at this distance
 
 	float Size = g_Config.m_ClTextEntitiesSize / 100.f;
-	float ToCenterOffset = (1 - Size) / 2.f;
 
 	for(int y = StartY; y < EndY; y++)
 		for(int x = StartX; x < EndX; x++)
@@ -749,7 +748,14 @@ void CRenderTools::RenderTeleOverlay(CTeleTile *pTele, int w, int h, float Scale
 				char aBuf[16];
 				str_from_int(Index, aBuf);
 				TextRender()->TextColor(1.0f, 1.0f, 1.0f, Alpha);
-				TextRender()->Text(mx * Scale - 3.f, (my + ToCenterOffset) * Scale, Size * Scale, aBuf, -1.0f);
+
+				// Auto-resize text to fit inside the tile
+				float ScaledWidth = TextRender()->TextWidth(Size * Scale, aBuf, -1);
+				float Factor = clamp(Scale / ScaledWidth, 0.0f, 1.0f);
+				float LocalSize = Size * Factor;
+				float ToCenterOffset = (1 - LocalSize) / 2.f;
+				TextRender()->Text((mx + 0.5f) * Scale - (ScaledWidth * Factor) / 2.0f, (my + ToCenterOffset) * Scale, LocalSize * Scale, aBuf, -1.0f);
+
 				TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
 			}
 		}


### PR DESCRIPTION
When setting `cl_text_entities_size` to a value higher than `60`/`70`, the text could be very hard to read when many tele tiles are next to each other.
Now, the text is contained within each individual tele tile to improve readability while trying to match `cl_text_entities_size`. This means for large number (for example `255`), the text will be smaller than for small numbers (for example `8`). The text is also centered.

Before:
- `cl_text_entities_size`: `60`

![editor_tele_text_before_60](https://github.com/ddnet/ddnet/assets/13364635/571bc6ac-7e0a-455f-9376-01ef0ca85dc9)

- `cl_text_entities_size`: `100`

![editor_tele_text_before_100](https://github.com/ddnet/ddnet/assets/13364635/c199b09a-2e42-4f1f-a391-9b50ec971176)


After:
- `cl_text_entities_size`: `60`

![editor_tele_text_after_60](https://github.com/ddnet/ddnet/assets/13364635/aace975c-6ccf-4a3d-8ef1-03e915d32e7b)

- `cl_text_entities_size`: `100`

![editor_tele_text_after_100](https://github.com/ddnet/ddnet/assets/13364635/fb647f28-b6bb-4e56-ae09-dace39d5b4cd)

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
