### PR TITLE
Only include `layer_tiles.h` in `auto_map.cpp`

### DIFF
--- a/src/game/editor/auto_map.cpp
+++ b/src/game/editor/auto_map.cpp
@@ -5,10 +5,10 @@
 #include <engine/shared/linereader.h>
 #include <engine/storage.h>
 
+#include <game/editor/mapitems/layer_tiles.h>
 #include <game/mapitems.h>
 
 #include "auto_map.h"
-#include "editor.h" // TODO: only needs CLayerTiles
 #include "editor_actions.h"
 
 // Based on triple32inc from https://github.com/skeeto/hash-prospector/tree/79a6074062a84907df6e45b756134b74e2956760


### PR DESCRIPTION
`CAutoMapper` only needs `CLayerTiles` which has been moved to `layer_tiles.h`.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
