### PR TITLE
Editor: allow panning outside initial container

### DIFF
--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -680,6 +680,7 @@ public:
 	float m_MouseDeltaY;
 	float m_MouseDeltaWx;
 	float m_MouseDeltaWy;
+	void *m_pContainerPanned;
 
 	enum EShowTile
 	{


### PR DESCRIPTION
Closes #7029.
Allows paning outside initial containers for both envelope editor and map view.
This also adds infinite panning where you are no longer constrained to the bounds of your screen.

https://github.com/ddnet/ddnet/assets/13364635/1eb4d8d4-3f3c-4b86-8c0f-9c0a98520110

Works by using a variable to keep track of the current panned container and doing the panning logic outside of the initial `IsInside` check.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
