### PR TITLE
Fix color rendering being inconsistent with displayed color values, fix slightly incorrect color components shown in color pickers 

### DIFF
--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -893,7 +893,7 @@ void CGraphics_Threaded::QuadsSetRotation(float Angle)
 
 static unsigned char NormalizeColorComponent(float ColorComponent)
 {
-	return (unsigned char)(clamp(ColorComponent, 0.0f, 1.0f) * 255.0f);
+	return (unsigned char)(clamp(ColorComponent, 0.0f, 1.0f) * 255.0f + 0.5f); // +0.5f to round to nearest
 }
 
 void CGraphics_Threaded::SetColorVertex(const CColorVertex *pArray, size_t Num)

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -1825,10 +1825,10 @@ CUI::EPopupMenuFunctionResult CUI::PopupColorPicker(void *pContext, CUIRect View
 	// Editboxes Area
 	if(pColorPicker->m_ColorMode == SColorPickerPopupContext::MODE_HSVA)
 	{
-		const unsigned OldH = (unsigned)(PickerColorHSV.h * 255.0f);
-		const unsigned OldS = (unsigned)(PickerColorHSV.s * 255.0f);
-		const unsigned OldV = (unsigned)(PickerColorHSV.v * 255.0f);
-		const unsigned OldA = (unsigned)(PickerColorHSV.a * 255.0f);
+		const unsigned OldH = round_to_int(PickerColorHSV.h * 255.0f);
+		const unsigned OldS = round_to_int(PickerColorHSV.s * 255.0f);
+		const unsigned OldV = round_to_int(PickerColorHSV.v * 255.0f);
+		const unsigned OldA = round_to_int(PickerColorHSV.a * 255.0f);
 
 		const auto [StateH, H] = pUI->DoValueSelectorWithState(&pColorPicker->m_aValueSelectorIds[0], &HueRect, "H:", OldH, 0, 255);
 		const auto [StateS, S] = pUI->DoValueSelectorWithState(&pColorPicker->m_aValueSelectorIds[1], &SatRect, "S:", OldS, 0, 255);
@@ -1853,10 +1853,10 @@ CUI::EPopupMenuFunctionResult CUI::PopupColorPicker(void *pContext, CUIRect View
 	}
 	else if(pColorPicker->m_ColorMode == SColorPickerPopupContext::MODE_RGBA)
 	{
-		const unsigned OldR = (unsigned)(PickerColorRGB.r * 255.0f);
-		const unsigned OldG = (unsigned)(PickerColorRGB.g * 255.0f);
-		const unsigned OldB = (unsigned)(PickerColorRGB.b * 255.0f);
-		const unsigned OldA = (unsigned)(PickerColorRGB.a * 255.0f);
+		const unsigned OldR = round_to_int(PickerColorRGB.r * 255.0f);
+		const unsigned OldG = round_to_int(PickerColorRGB.g * 255.0f);
+		const unsigned OldB = round_to_int(PickerColorRGB.b * 255.0f);
+		const unsigned OldA = round_to_int(PickerColorRGB.a * 255.0f);
 
 		const auto [StateR, R] = pUI->DoValueSelectorWithState(&pColorPicker->m_aValueSelectorIds[0], &HueRect, "R:", OldR, 0, 255);
 		const auto [StateG, G] = pUI->DoValueSelectorWithState(&pColorPicker->m_aValueSelectorIds[1], &SatRect, "G:", OldG, 0, 255);
@@ -1881,10 +1881,10 @@ CUI::EPopupMenuFunctionResult CUI::PopupColorPicker(void *pContext, CUIRect View
 	}
 	else if(pColorPicker->m_ColorMode == SColorPickerPopupContext::MODE_HSLA)
 	{
-		const unsigned OldH = (unsigned)(PickerColorHSL.h * 255.0f);
-		const unsigned OldS = (unsigned)(PickerColorHSL.s * 255.0f);
-		const unsigned OldL = (unsigned)(PickerColorHSL.l * 255.0f);
-		const unsigned OldA = (unsigned)(PickerColorHSL.a * 255.0f);
+		const unsigned OldH = round_to_int(PickerColorHSL.h * 255.0f);
+		const unsigned OldS = round_to_int(PickerColorHSL.s * 255.0f);
+		const unsigned OldL = round_to_int(PickerColorHSL.l * 255.0f);
+		const unsigned OldA = round_to_int(PickerColorHSL.a * 255.0f);
 
 		const auto [StateH, H] = pUI->DoValueSelectorWithState(&pColorPicker->m_aValueSelectorIds[0], &HueRect, "H:", OldH, 0, 255);
 		const auto [StateS, S] = pUI->DoValueSelectorWithState(&pColorPicker->m_aValueSelectorIds[1], &SatRect, "S:", OldS, 0, 255);


### PR DESCRIPTION
When normalizing color components in the engine graphics, round the components to the nearest integer instead of rounding down. Otherwise the color that is rendered in color pickers may be off by 1 in any of its RGB components from the color that the color picker displays as text (hex string and individual components). The slightly incorrect color can be confirmed by creating a screenshot or otherwise reading the backbuffer (planned editor pipette feature).

This should not change map rendering, since maps already store quantized RGBA values on which the rounding mode should have no effect. It may however slightly change appearance of colors in all other places (at most +1 in every RGB component).

The individual color components were rounded down when being displayed on their own in color pickers, whereas the components are rounded to the nearest integer when packing the colors into the hex string. This was causing minor discrepancies between the color being displayed/saved as hex and the individual components. Rounding the components when packing is necessary to reduce the error when converting between color spaces.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
