### PR TITLE
Allow switching teams after finish

### DIFF
--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -388,9 +388,9 @@ const char *CGameTeams::SetCharacterTeam(int ClientID, int Team)
 	// you can not join a team which is currently in the process of saving,
 	// because the save-process can fail and then the team is reset into the game
 	if(Team != TEAM_SUPER && GetSaving(Team))
-		return "Your team is currently saving";
-	if(CurrentTeam != TEAM_SUPER && GetSaving(CurrentTeam))
 		return "This team is currently saving";
+	if(CurrentTeam != TEAM_SUPER && GetSaving(CurrentTeam))
+		return "Your team is currently saving";
 
 	SetForceCharacterTeam(ClientID, Team);
 	return nullptr;

--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -365,29 +365,31 @@ void CGameTeams::CheckTeamFinished(int Team)
 
 const char *CGameTeams::SetCharacterTeam(int ClientID, int Team)
 {
+	int CurrentTeam = m_Core.Team(ClientID);
+
 	if(ClientID < 0 || ClientID >= MAX_CLIENTS)
 		return "Invalid client ID";
 	if(Team < 0 || Team >= MAX_CLIENTS + 1)
 		return "Invalid team number";
 	if(Team != TEAM_SUPER && m_aTeamState[Team] > TEAMSTATE_OPEN)
 		return "This team started already";
-	if(m_Core.Team(ClientID) == Team)
+	if(CurrentTeam == Team)
 		return "You are in this team already";
 	if(!Character(ClientID))
 		return "Your character is not valid";
 	if(Team == TEAM_SUPER && !Character(ClientID)->IsSuper())
 		return "You can't join super team if you don't have super rights";
-	if(Team != TEAM_SUPER && Character(ClientID)->m_DDRaceState != DDRACE_NONE && m_aTeamState[m_Core.Team(ClientID)] < TEAMSTATE_FINISHED)
+	if(Team != TEAM_SUPER && Character(ClientID)->m_DDRaceState != DDRACE_NONE && m_aTeamState[CurrentTeam] < TEAMSTATE_FINISHED)
 		return "You have started racing already";
 	// No cheating through noob filter with practice and then leaving team
-	if(m_aPractice[m_Core.Team(ClientID)])
+	if(m_aPractice[CurrentTeam])
 		return "You have used practice mode already";
 
 	// you can not join a team which is currently in the process of saving,
 	// because the save-process can fail and then the team is reset into the game
 	if(Team != TEAM_SUPER && GetSaving(Team))
 		return "Your team is currently saving";
-	if(m_Core.Team(ClientID) != TEAM_SUPER && GetSaving(m_Core.Team(ClientID)))
+	if(CurrentTeam != TEAM_SUPER && GetSaving(CurrentTeam))
 		return "This team is currently saving";
 
 	SetForceCharacterTeam(ClientID, Team);

--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -377,7 +377,7 @@ const char *CGameTeams::SetCharacterTeam(int ClientID, int Team)
 		return "Your character is not valid";
 	if(Team == TEAM_SUPER && !Character(ClientID)->IsSuper())
 		return "You can't join super team if you don't have super rights";
-	if(Team != TEAM_SUPER && Character(ClientID)->m_DDRaceState != DDRACE_NONE)
+	if(Team != TEAM_SUPER && Character(ClientID)->m_DDRaceState != DDRACE_NONE && m_aTeamState[m_Core.Team(ClientID)] < TEAMSTATE_FINISHED)
 		return "You have started racing already";
 	// No cheating through noob filter with practice and then leaving team
 	if(m_aPractice[m_Core.Team(ClientID)])


### PR DESCRIPTION
I often play in locked teams out of convenience. Yet I often find myself stuck in the team after I have already finished, while unlocked teams automatically get moved to team 0.
These changes allow you to switch to any other team after your team has finished.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
