### PR TITLE
Editor: improve append (fixes #7625)

### DIFF
--- a/src/game/editor/mapitems/image.cpp
+++ b/src/game/editor/mapitems/image.cpp
@@ -54,3 +54,29 @@ void CEditorImage::AnalyseTileFlags()
 			}
 	}
 }
+
+bool CEditorImage::DataEquals(const CEditorImage &Other) const
+{
+	// If height, width or pixel size don't match, then data cannot be equal
+	const size_t ImgPixelSize = PixelSize();
+
+	if(Other.m_Height != m_Height || Other.m_Width != m_Width || Other.PixelSize() != ImgPixelSize)
+		return false;
+
+	const auto &&GetPixel = [&](void *pData, int x, int y, size_t p) -> uint8_t {
+		return ((uint8_t *)pData)[x * ImgPixelSize + (m_Width * ImgPixelSize * y) + p];
+	};
+
+	// Look through every pixel and check if there are any difference
+	for(int y = 0; y < m_Height; y += ImgPixelSize)
+	{
+		for(int x = 0; x < m_Width; x += ImgPixelSize)
+		{
+			for(size_t p = 0; p < ImgPixelSize; p++)
+				if(GetPixel(m_pData, x, y, p) != GetPixel(Other.m_pData, x, y, p))
+					return false;
+		}
+	}
+
+	return true;
+}

--- a/src/game/editor/mapitems/image.h
+++ b/src/game/editor/mapitems/image.h
@@ -14,6 +14,7 @@ public:
 
 	void Init(CEditor *pEditor) override;
 	void AnalyseTileFlags();
+	bool DataEquals(const CEditorImage &Other) const;
 
 	IGraphics::CTextureHandle m_Texture;
 	int m_External = 0;


### PR DESCRIPTION
Fix broken editor append (fixes #7625).
Check for image data when image names are identical. In such case, appended image is renamed until its name is unique.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
