### PR TITLE
More efficient text selection rendering

### DIFF
--- a/src/engine/client/text.cpp
+++ b/src/engine/client/text.cpp
@@ -1532,6 +1532,7 @@ public:
 		const float CursorOuterInnerDiff = (CursorOuterWidth - CursorInnerWidth) / 2;
 
 		std::vector<IGraphics::CQuadItem> vSelectionQuads;
+		int SelectionQuadLine = -1;
 		bool SelectionStarted = false;
 		bool SelectionUsedPress = false;
 		bool SelectionUsedRelease = false;
@@ -1866,8 +1867,18 @@ public:
 
 					if(SelectionStarted && IsRendered)
 					{
-						const float SelectionHeight = pCursor->m_AlignedFontSize + pCursor->m_AlignedLineSpacing;
-						vSelectionQuads.emplace_back(SelX, DrawY + (1.0f - pCursor->m_SelectionHeightFactor) * SelectionHeight, SelWidth, pCursor->m_SelectionHeightFactor * SelectionHeight);
+						if(!vSelectionQuads.empty() && SelectionQuadLine == pCursor->m_LineCount)
+						{
+							vSelectionQuads.back().m_Width += SelWidth;
+						}
+						else
+						{
+							const float SelectionHeight = pCursor->m_AlignedFontSize + pCursor->m_AlignedLineSpacing;
+							const float SelectionY = DrawY + (1.0f - pCursor->m_SelectionHeightFactor) * SelectionHeight;
+							const float ScaledSelectionHeight = pCursor->m_SelectionHeightFactor * SelectionHeight;
+							vSelectionQuads.emplace_back(SelX, SelectionY, SelWidth, ScaledSelectionHeight);
+							SelectionQuadLine = pCursor->m_LineCount;
+						}
 					}
 
 					LastSelX = SelX;


### PR DESCRIPTION
Render one quad for each line of the text selection instead of rendering one quad per selected character.

This increases the average FPS when the console is open and all text is selected by around 10% (from around 849 to around 943 FPS) (on my machine, in release mode).

![text-selection-benchmark](https://github.com/ddnet/ddnet/assets/23437060/3b55229f-4d92-413f-96dd-3b829659d605)

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
