### PR TITLE
Editor: fix duplicate layers in popup layer context

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -4072,6 +4072,9 @@ void CEditor::RenderLayers(CUIRect LayersBox)
 					}
 					else if(Result == 2)
 					{
+						s_LayerPopupContext.m_vpLayers.clear();
+						s_LayerPopupContext.m_vLayerIndices.clear();
+
 						if(!IsLayerSelected)
 						{
 							SelectLayer(i, g);
@@ -4098,11 +4101,6 @@ void CEditor::RenderLayers(CUIRect LayersBox)
 								s_LayerPopupContext.m_vpLayers.clear();
 								s_LayerPopupContext.m_vLayerIndices.clear();
 							}
-						}
-						else
-						{
-							s_LayerPopupContext.m_vpLayers.clear();
-							s_LayerPopupContext.m_vLayerIndices.clear();
 						}
 
 						UI()->DoPopupMenu(&s_LayerPopupContext, UI()->MouseX(), UI()->MouseY(), 120, 270, &s_LayerPopupContext, PopupLayer);


### PR DESCRIPTION
Clear layers from context before adding any layer, preventing layers from being kept in the vector until only a single layer is selected. Fixes #4978.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
