### PR TITLE
Fix slow cl_dummy_fire

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -277,7 +277,7 @@ void CClient::SendInput()
 			// ugly workaround for dummy. we need to send input with dummy to prevent
 			// prediction time resets. but if we do it too often, then it's
 			// impossible to use grenade with frozen dummy that gets hammered...
-			if(g_Config.m_ClDummyCopyMoves || m_aCurrentInput[i] % 2)
+			if(g_Config.m_ClDummyCopyMoves || g_Config.m_ClDummyControl || m_aCurrentInput[i] % 2)
 				Force = true;
 		}
 	}


### PR DESCRIPTION
I was wondering why having a bind like this: ```bind x +toggle cl_dummy_fire 1 0``` wasn't very snappy - as in, simply wouldn't process the button press, but only sometimes.

I then wondered why this was seemingly fixed when ```cl_dummy_copy_moves``` was set to ```1```, even if all the code for it was empty. 

Like the comment says, it's supposedly an ugly workaround, so if you don't want to endorse this kind of change then I guess don't add it, but it probably doesn't break anything anyway. All the testing I did was with cl_dummy_copy_moves set to 0, as that is where the difference is.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
