### PR TITLE
Improve editor toolbar anim and grid buttons, add dropdowns

### DIFF
--- a/src/engine/textrender.h
+++ b/src/engine/textrender.h
@@ -66,6 +66,7 @@ enum class EFontPreset
 namespace FontIcons {
 // Each font icon is named according to its official name in Font Awesome
 MAYBE_UNUSED static const char *FONT_ICON_PLUS = "+";
+MAYBE_UNUSED static const char *FONT_ICON_MINUS = "-";
 MAYBE_UNUSED static const char *FONT_ICON_LOCK = "\xEF\x80\xA3";
 MAYBE_UNUSED static const char *FONT_ICON_MAGNIFYING_GLASS = "\xEF\x80\x82";
 MAYBE_UNUSED static const char *FONT_ICON_HEART = "\xEF\x80\x84";

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -1084,13 +1084,23 @@ void CEditor::DoToolbarLayers(CUIRect ToolBar)
 		TB_Top.VSplitLeft(5.0f, nullptr, &TB_Top);
 
 		// animation button
-		TB_Top.VSplitLeft(40.0f, &Button, &TB_Top);
-		static int s_AnimateButton = 0;
-		if(DoButton_Editor(&s_AnimateButton, "Anim", m_Animate, &Button, 0, "[ctrl+m] Toggle animation") ||
+		TB_Top.VSplitLeft(25.0f, &Button, &TB_Top);
+		static char s_AnimateButton;
+		if(DoButton_FontIcon(&s_AnimateButton, FONT_ICON_CIRCLE_PLAY, m_Animate, &Button, 0, "[ctrl+m] Toggle animation", IGraphics::CORNER_L) ||
 			(m_Dialog == DIALOG_NONE && CLineInput::GetActiveInput() == nullptr && Input()->KeyPress(KEY_M) && ModPressed))
 		{
 			m_AnimateStart = time_get();
 			m_Animate = !m_Animate;
+		}
+
+		// animation settings button
+		TB_Top.VSplitLeft(14.0f, &Button, &TB_Top);
+		static char s_AnimateSettingsButton;
+		if(DoButton_FontIcon(&s_AnimateSettingsButton, FONT_ICON_CIRCLE_CHEVRON_DOWN, 0, &Button, 0, "Change animation settings.", IGraphics::CORNER_R, 8.0f))
+		{
+			m_AnimateUpdatePopup = true;
+			static SPopupMenuId s_PopupAnimateSettingsId;
+			UI()->DoPopupMenu(&s_PopupAnimateSettingsId, Button.x, Button.y + Button.h, 150.0f, 37.0f, this, PopupAnimateSettings);
 		}
 
 		TB_Top.VSplitLeft(5.0f, nullptr, &TB_Top);
@@ -1125,12 +1135,20 @@ void CEditor::DoToolbarLayers(CUIRect ToolBar)
 		TB_Top.VSplitLeft(5.0f, nullptr, &TB_Top);
 
 		// grid button
-		TB_Top.VSplitLeft(40.0f, &Button, &TB_Top);
+		TB_Top.VSplitLeft(25.0f, &Button, &TB_Top);
 		static int s_GridButton = 0;
-		if(DoButton_Editor(&s_GridButton, "Grid", MapView()->MapGrid()->IsEnabled(), &Button, 0, "[ctrl+g] Toggle Grid") ||
+		if(DoButton_FontIcon(&s_GridButton, FONT_ICON_BORDER_ALL, MapView()->MapGrid()->IsEnabled(), &Button, 0, "[ctrl+g] Toggle Grid", IGraphics::CORNER_L) ||
 			(m_Dialog == DIALOG_NONE && CLineInput::GetActiveInput() == nullptr && Input()->KeyPress(KEY_G) && ModPressed && !ShiftPressed))
 		{
 			MapView()->MapGrid()->Toggle();
+		}
+
+		// grid settings button
+		TB_Top.VSplitLeft(14.0f, &Button, &TB_Top);
+		static char s_GridSettingsButton;
+		if(DoButton_FontIcon(&s_GridSettingsButton, FONT_ICON_CIRCLE_CHEVRON_DOWN, 0, &Button, 0, "Change grid settings.", IGraphics::CORNER_R, 8.0f))
+		{
+			MapView()->MapGrid()->DoSettingsPopup(vec2(Button.x, Button.y + Button.h));
 		}
 
 		TB_Top.VSplitLeft(5.0f, nullptr, &TB_Top);
@@ -1138,7 +1156,7 @@ void CEditor::DoToolbarLayers(CUIRect ToolBar)
 		// zoom group
 		TB_Top.VSplitLeft(20.0f, &Button, &TB_Top);
 		static int s_ZoomOutButton = 0;
-		if(DoButton_FontIcon(&s_ZoomOutButton, "-", 0, &Button, 0, "[NumPad-] Zoom out", IGraphics::CORNER_L))
+		if(DoButton_FontIcon(&s_ZoomOutButton, FONT_ICON_MINUS, 0, &Button, 0, "[NumPad-] Zoom out", IGraphics::CORNER_L))
 		{
 			MapView()->Zoom()->ChangeValue(50.0f);
 		}
@@ -1152,7 +1170,7 @@ void CEditor::DoToolbarLayers(CUIRect ToolBar)
 
 		TB_Top.VSplitLeft(20.0f, &Button, &TB_Top);
 		static int s_ZoomInButton = 0;
-		if(DoButton_FontIcon(&s_ZoomInButton, "+", 0, &Button, 0, "[NumPad+] Zoom in", IGraphics::CORNER_R))
+		if(DoButton_FontIcon(&s_ZoomInButton, FONT_ICON_PLUS, 0, &Button, 0, "[NumPad+] Zoom in", IGraphics::CORNER_R))
 		{
 			MapView()->Zoom()->ChangeValue(-50.0f);
 		}
@@ -1229,56 +1247,6 @@ void CEditor::DoToolbarLayers(CUIRect ToolBar)
 				for(auto &pLayer : m_pBrush->m_vpLayers)
 					pLayer->BrushRotate(s_RotationAmount / 360.0f * pi * 2);
 			}
-
-			TB_Top.VSplitLeft(5.0f, &Button, &TB_Top);
-		}
-
-		// animation speed
-		if(m_Animate)
-		{
-			TB_Top.VSplitLeft(20.0f, &Button, &TB_Top);
-			static int s_AnimSlowerButton = 0;
-			if(DoButton_FontIcon(&s_AnimSlowerButton, "-", 0, &Button, 0, "Decrease animation speed", IGraphics::CORNER_L))
-			{
-				if(m_AnimateSpeed > 0.5f)
-					m_AnimateSpeed -= 0.5f;
-			}
-
-			TB_Top.VSplitLeft(25.0f, &Button, &TB_Top);
-			static int s_AnimNormalButton = 0;
-			if(DoButton_FontIcon(&s_AnimNormalButton, FONT_ICON_CIRCLE_PLAY, 0, &Button, 0, "Normal animation speed", 0))
-				m_AnimateSpeed = 1.0f;
-
-			TB_Top.VSplitLeft(20.0f, &Button, &TB_Top);
-			static int s_AnimFasterButton = 0;
-			if(DoButton_FontIcon(&s_AnimFasterButton, "+", 0, &Button, 0, "Increase animation speed", IGraphics::CORNER_R))
-				m_AnimateSpeed += 0.5f;
-
-			TB_Top.VSplitLeft(5.0f, &Button, &TB_Top);
-		}
-
-		// grid zoom
-		if(MapView()->MapGrid()->IsEnabled())
-		{
-			TB_Top.VSplitLeft(20.0f, &Button, &TB_Top);
-			static int s_GridIncreaseButton = 0;
-			if(DoButton_FontIcon(&s_GridIncreaseButton, "-", 0, &Button, 0, "Decrease grid", IGraphics::CORNER_L))
-			{
-				MapView()->MapGrid()->DecreaseFactor();
-			}
-
-			TB_Top.VSplitLeft(25.0f, &Button, &TB_Top);
-			static int s_GridNormalButton = 0;
-			if(DoButton_FontIcon(&s_GridNormalButton, FONT_ICON_BORDER_ALL, 0, &Button, 0, "Normal grid", IGraphics::CORNER_NONE))
-				MapView()->MapGrid()->ResetFactor();
-
-			TB_Top.VSplitLeft(20.0f, &Button, &TB_Top);
-			static int s_GridDecreaseButton = 0;
-			if(DoButton_FontIcon(&s_GridDecreaseButton, "+", 0, &Button, 0, "Increase grid", IGraphics::CORNER_R))
-			{
-				MapView()->MapGrid()->IncreaseFactor();
-			}
-			TB_Top.VSplitLeft(5.0f, &Button, &TB_Top);
 		}
 	}
 

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -381,6 +381,7 @@ public:
 		m_AnimateStart = 0;
 		m_AnimateTime = 0;
 		m_AnimateSpeed = 1;
+		m_AnimateUpdatePopup = false;
 
 		m_ShowEnvelopePreview = SHOWENV_NONE;
 		m_SelectedQuadEnvelope = -1;
@@ -692,10 +693,12 @@ public:
 	};
 	EShowTile m_ShowTileInfo;
 	bool m_ShowDetail;
+
 	bool m_Animate;
 	int64_t m_AnimateStart;
 	float m_AnimateTime;
 	float m_AnimateSpeed;
+	bool m_AnimateUpdatePopup;
 
 	enum EExtraEditor
 	{
@@ -824,6 +827,7 @@ public:
 	static CUI::EPopupMenuFunctionResult PopupGoto(void *pContext, CUIRect View, bool Active);
 	static CUI::EPopupMenuFunctionResult PopupEntities(void *pContext, CUIRect View, bool Active);
 	static CUI::EPopupMenuFunctionResult PopupProofMode(void *pContext, CUIRect View, bool Active);
+	static CUI::EPopupMenuFunctionResult PopupAnimateSettings(void *pContext, CUIRect View, bool Active);
 
 	static bool CallbackOpenMap(const char *pFileName, int StorageType, void *pUser);
 	static bool CallbackAppendMap(const char *pFileName, int StorageType, void *pUser);

--- a/src/game/editor/map_grid.cpp
+++ b/src/game/editor/map_grid.cpp
@@ -4,6 +4,9 @@
 
 #include "editor.h"
 
+static constexpr int MIN_GRID_FACTOR = 1;
+static constexpr int MAX_GRID_FACTOR = 15;
+
 void CMapGrid::OnReset()
 {
 	m_GridActive = false;
@@ -96,19 +99,47 @@ int CMapGrid::Factor() const
 	return m_GridFactor;
 }
 
-void CMapGrid::ResetFactor()
+void CMapGrid::SetFactor(int Factor)
 {
-	m_GridFactor = 1;
+	m_GridFactor = clamp(Factor, MIN_GRID_FACTOR, MAX_GRID_FACTOR);
 }
 
-void CMapGrid::IncreaseFactor()
+void CMapGrid::DoSettingsPopup(vec2 Position)
 {
-	if(m_GridFactor < 15)
-		m_GridFactor++;
+	UI()->DoPopupMenu(&m_PopupGridSettingsId, Position.x, Position.y, 120.0f, 37.0f, this, PopupGridSettings);
 }
 
-void CMapGrid::DecreaseFactor()
+CUI::EPopupMenuFunctionResult CMapGrid::PopupGridSettings(void *pContext, CUIRect View, bool Active)
 {
-	if(m_GridFactor > 1)
-		m_GridFactor--;
+	CMapGrid *pMapGrid = static_cast<CMapGrid *>(pContext);
+
+	enum
+	{
+		PROP_SIZE = 0,
+		NUM_PROPS,
+	};
+	CProperty aProps[] = {
+		{"Size", pMapGrid->Factor(), PROPTYPE_INT_STEP, MIN_GRID_FACTOR, MAX_GRID_FACTOR},
+		{nullptr},
+	};
+
+	static int s_aIds[NUM_PROPS];
+	int NewVal;
+	int Prop = pMapGrid->Editor()->DoProperties(&View, aProps, s_aIds, &NewVal);
+
+	if(Prop == PROP_SIZE)
+	{
+		pMapGrid->SetFactor(NewVal);
+	}
+
+	CUIRect Button;
+	View.HSplitBottom(12.0f, &View, &Button);
+
+	static char s_DefaultButton;
+	if(pMapGrid->Editor()->DoButton_Ex(&s_DefaultButton, "Default", 0, &Button, 0, "Normal grid size", IGraphics::CORNER_ALL))
+	{
+		pMapGrid->SetFactor(1);
+	}
+
+	return CUI::POPUP_KEEP_OPEN;
 }

--- a/src/game/editor/map_grid.h
+++ b/src/game/editor/map_grid.h
@@ -3,6 +3,8 @@
 
 #include "component.h"
 
+#include <game/client/ui.h>
+
 class CMapGrid : public CEditorComponent
 {
 public:
@@ -20,13 +22,16 @@ public:
 	void Toggle();
 
 	int Factor() const;
-	void ResetFactor();
-	void IncreaseFactor();
-	void DecreaseFactor();
+	void SetFactor(int Factor);
+
+	void DoSettingsPopup(vec2 Position);
 
 private:
 	bool m_GridActive;
 	int m_GridFactor;
+
+	SPopupMenuId m_PopupGridSettingsId;
+	static CUI::EPopupMenuFunctionResult PopupGridSettings(void *pContext, CUIRect View, bool Active);
 };
 
 #endif

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -2725,3 +2725,60 @@ CUI::EPopupMenuFunctionResult CEditor::PopupProofMode(void *pContext, CUIRect Vi
 
 	return CUI::POPUP_KEEP_OPEN;
 }
+
+CUI::EPopupMenuFunctionResult CEditor::PopupAnimateSettings(void *pContext, CUIRect View, bool Active)
+{
+	CEditor *pEditor = static_cast<CEditor *>(pContext);
+
+	constexpr float MIN_ANIM_SPEED = 0.001f;
+	constexpr float MAX_ANIM_SPEED = 1000000.0f;
+
+	CUIRect Row, Label, ButtonDecrease, EditBox, ButtonIncrease, ButtonReset;
+	View.HSplitTop(13.0f, &Row, &View);
+	Row.VSplitMid(&Label, &Row);
+	Row.HMargin(1.0f, &Row);
+	Row.VSplitLeft(10.0f, &ButtonDecrease, &Row);
+	Row.VSplitRight(10.0f, &EditBox, &ButtonIncrease);
+	View.HSplitBottom(12.0f, &View, &ButtonReset);
+	pEditor->UI()->DoLabel(&Label, "Speed", 10.0f, TEXTALIGN_ML);
+
+	static char s_DecreaseButton;
+	if(pEditor->DoButton_Ex(&s_DecreaseButton, "-", 0, &ButtonDecrease, 0, "Decrease animation speed", IGraphics::CORNER_L))
+	{
+		pEditor->m_AnimateSpeed -= pEditor->m_AnimateSpeed <= 1.0f ? 0.1f : 0.5f;
+		pEditor->m_AnimateSpeed = maximum(pEditor->m_AnimateSpeed, MIN_ANIM_SPEED);
+		pEditor->m_AnimateUpdatePopup = true;
+	}
+
+	static char s_IncreaseButton;
+	if(pEditor->DoButton_Ex(&s_IncreaseButton, "+", 0, &ButtonIncrease, 0, "Increase animation speed", IGraphics::CORNER_R))
+	{
+		if(pEditor->m_AnimateSpeed < 0.1f)
+			pEditor->m_AnimateSpeed = 0.1f;
+		else
+			pEditor->m_AnimateSpeed += pEditor->m_AnimateSpeed < 1.0f ? 0.1f : 0.5f;
+		pEditor->m_AnimateSpeed = minimum(pEditor->m_AnimateSpeed, MAX_ANIM_SPEED);
+		pEditor->m_AnimateUpdatePopup = true;
+	}
+
+	static char s_DefaultButton;
+	if(pEditor->DoButton_Ex(&s_DefaultButton, "Default", 0, &ButtonReset, 0, "Normal animation speed", IGraphics::CORNER_ALL))
+	{
+		pEditor->m_AnimateSpeed = 1.0f;
+		pEditor->m_AnimateUpdatePopup = true;
+	}
+
+	static CLineInputNumber s_SpeedInput;
+	if(pEditor->m_AnimateUpdatePopup)
+	{
+		s_SpeedInput.SetFloat(pEditor->m_AnimateSpeed);
+		pEditor->m_AnimateUpdatePopup = false;
+	}
+
+	if(pEditor->DoEditBox(&s_SpeedInput, &EditBox, 10.0f, IGraphics::CORNER_NONE, "The animation speed"))
+	{
+		pEditor->m_AnimateSpeed = clamp(s_SpeedInput.GetFloat(), MIN_ANIM_SPEED, MAX_ANIM_SPEED);
+	}
+
+	return CUI::POPUP_KEEP_OPEN;
+}


### PR DESCRIPTION
Add dropdown menus for changing animation and grid settings (i.e. animation speed and grid size) instead of conditionally showing more buttons for this directly in the menu bar. This frees up space in the menu bar, which is currently full on 5:4 resolutions.

The icons previously used for the default animation/grid buttons are now used for the main buttons that toggle animation/grid instead of using text.

Support setting lower animation speeds with the plus and minus buttons by adjusting the step size when the animation speed is low.

Support setting arbitrary animation speed by text input.

Screenshots:
- Anim/grid disabled:
   - Before:
![disabled old crop](https://github.com/ddnet/ddnet/assets/23437060/2bbeb9dc-0691-4b4a-afb1-92afc001f653)
   - After:
![disabled new crop](https://github.com/ddnet/ddnet/assets/23437060/b4061921-e763-4090-a8eb-5870aebdab95)
- Anim/grid enabled:
   - Before:
![enabled old crop](https://github.com/ddnet/ddnet/assets/23437060/64e12fb6-d4ea-4e77-ae0b-2866e3d28793)
   - After (anim popup):
![enabled_anim new crop](https://github.com/ddnet/ddnet/assets/23437060/2ad0dc6c-4211-4b66-9993-014f2258316a)
   - After (grid popup):
![enabled_grid new crop](https://github.com/ddnet/ddnet/assets/23437060/7fc3e00e-9189-4382-b7bd-bab5c1de5e32)


## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
