### PR TITLE
Use 0.7 translation layer for `Sv_RaceFinish` netmessage.

### DIFF
--- a/src/engine/server.h
+++ b/src/engine/server.h
@@ -157,6 +157,21 @@ public:
 		return SendPackMsgOne(&MsgCopy, Flags, ClientID);
 	}
 
+	int SendPackMsgTranslate(const CNetMsg_Sv_RaceFinish *pMsg, int Flags, int ClientID)
+	{
+		if(IsSixup(ClientID))
+		{
+			protocol7::CNetMsg_Sv_RaceFinish Msg7;
+			Msg7.m_ClientID = pMsg->m_ClientID;
+			Msg7.m_Diff = pMsg->m_Diff;
+			Msg7.m_Time = pMsg->m_Time;
+			Msg7.m_RecordPersonal = pMsg->m_RecordPersonal;
+			Msg7.m_RecordServer = pMsg->m_RecordServer;
+			return SendPackMsgOne(&Msg7, Flags, ClientID);
+		}
+		return SendPackMsgOne(pMsg, Flags, ClientID);
+	}
+
 	template<class T>
 	int SendPackMsgOne(const T *pMsg, int Flags, int ClientID)
 	{

--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -770,33 +770,19 @@ void CGameTeams::OnFinish(CPlayer *Player, float Time, const char *pTimestamp)
 				Server()->SendPackMsg(&MsgLegacy, MSGFLAG_VITAL, ClientID);
 			}
 		}
+	}
 
-		CNetMsg_Sv_RaceFinish RaceFinishMsg;
-		RaceFinishMsg.m_ClientID = ClientID;
-		RaceFinishMsg.m_Time = Time * 1000;
-		RaceFinishMsg.m_Diff = 0;
-		if(pData->m_BestTime)
-		{
-			RaceFinishMsg.m_Diff = Diff * 1000 * (Time < pData->m_BestTime ? -1 : 1);
-		}
-		RaceFinishMsg.m_RecordPersonal = (Time < pData->m_BestTime || !pData->m_BestTime);
-		RaceFinishMsg.m_RecordServer = Time < GameServer()->m_pController->m_CurrentRecord;
-		Server()->SendPackMsg(&RaceFinishMsg, MSGFLAG_VITAL | MSGFLAG_NORECORD, -1);
-	}
-	else
+	CNetMsg_Sv_RaceFinish RaceFinishMsg;
+	RaceFinishMsg.m_ClientID = ClientID;
+	RaceFinishMsg.m_Time = Time * 1000;
+	RaceFinishMsg.m_Diff = 0;
+	if(pData->m_BestTime)
 	{
-		protocol7::CNetMsg_Sv_RaceFinish Msg;
-		Msg.m_ClientID = ClientID;
-		Msg.m_Time = Time * 1000;
-		Msg.m_Diff = 0;
-		if(pData->m_BestTime)
-		{
-			Msg.m_Diff = Diff * 1000 * (Time < pData->m_BestTime ? -1 : 1);
-		}
-		Msg.m_RecordPersonal = (Time < pData->m_BestTime || !pData->m_BestTime);
-		Msg.m_RecordServer = Time < GameServer()->m_pController->m_CurrentRecord;
-		Server()->SendPackMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_NORECORD, -1);
+		RaceFinishMsg.m_Diff = Diff * 1000 * (Time < pData->m_BestTime ? -1 : 1);
 	}
+	RaceFinishMsg.m_RecordPersonal = (Time < pData->m_BestTime || !pData->m_BestTime);
+	RaceFinishMsg.m_RecordServer = Time < GameServer()->m_pController->m_CurrentRecord;
+	Server()->SendPackMsg(&RaceFinishMsg, MSGFLAG_VITAL | MSGFLAG_NORECORD, -1);
 
 	bool CallSaveScore = g_Config.m_SvSaveWorseScores;
 	bool NeedToSendNewPersonalRecord = false;


### PR DESCRIPTION
Fixes 0.7 players not being able to receive finishes done by players on 0.6 (and vice-versa).

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
