### PR TITLE
Fix players on 0.7 becoming invisible when `m_HookTick` is negative.

### DIFF
--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -1099,6 +1099,10 @@ void CCharacter::SnapCharacter(int SnappingClient, int ID)
 			pCharacter->m_Angle -= (int)(2.0f * pi * 256.0f);
 		}
 
+		// m_HookTick can be negative when using the hook_duration tune, which 0.7 clients
+		// will consider invalid. https://github.com/ddnet/ddnet/issues/3915
+		pCharacter->m_HookTick = maximum(0, pCharacter->m_HookTick);
+
 		pCharacter->m_Tick = Tick;
 		pCharacter->m_Emote = Emote;
 		pCharacter->m_AttackTick = m_AttackTick;


### PR DESCRIPTION
If you were to enter a tune_zone that has `hammer_duration` with a value above `1.25f`, `m_HookTick` becomes negative. Which leads to 0.7 clients dropping the `CNetObj_CharacterCore` message, because it only accepts values between `0` and `int_max`. So, I just decided to clamp it at 0 if it's negative when sending it to 0.7 clients. Closes #3915

https://github.com/ddnet/ddnet/assets/141338449/2fa8986a-94aa-41ab-b65d-57110166627a

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
