### PR TITLE
Fix dummy hammer when switching with copy moves turned on

### DIFF
--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -286,7 +286,8 @@ int CControls::SnapInput(int *pData)
 			pDummyInput->m_WantedWeapon = m_aInputData[g_Config.m_ClDummy].m_WantedWeapon;
 
 			if(!g_Config.m_ClDummyControl)
-				pDummyInput->m_Fire += m_aInputData[g_Config.m_ClDummy].m_Fire - m_aLastData[g_Config.m_ClDummy].m_Fire;
+				if ((m_aInputData[g_Config.m_ClDummy].m_Fire - m_aLastData[g_Config.m_ClDummy].m_Fire & 1) != 0)
+					pDummyInput->m_Fire++;
 
 			pDummyInput->m_NextWeapon += m_aInputData[g_Config.m_ClDummy].m_NextWeapon - m_aLastData[g_Config.m_ClDummy].m_NextWeapon;
 			pDummyInput->m_PrevWeapon += m_aInputData[g_Config.m_ClDummy].m_PrevWeapon - m_aLastData[g_Config.m_ClDummy].m_PrevWeapon;

--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -285,7 +285,7 @@ int CControls::SnapInput(int *pData)
 			pDummyInput->m_TargetY = m_aInputData[g_Config.m_ClDummy].m_TargetY;
 			pDummyInput->m_WantedWeapon = m_aInputData[g_Config.m_ClDummy].m_WantedWeapon;
 
-			if(!g_Config.m_ClDummyControl && (m_aInputData[g_Config.m_ClDummy].m_Fire - m_aLastData[g_Config.m_ClDummy].m_Fire & 1) != 0)
+			if(!g_Config.m_ClDummyControl && ((m_aInputData[g_Config.m_ClDummy].m_Fire - m_aLastData[g_Config.m_ClDummy].m_Fire) & 1) != 0)
 				pDummyInput->m_Fire++;
 
 			pDummyInput->m_NextWeapon += m_aInputData[g_Config.m_ClDummy].m_NextWeapon - m_aLastData[g_Config.m_ClDummy].m_NextWeapon;

--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -285,9 +285,8 @@ int CControls::SnapInput(int *pData)
 			pDummyInput->m_TargetY = m_aInputData[g_Config.m_ClDummy].m_TargetY;
 			pDummyInput->m_WantedWeapon = m_aInputData[g_Config.m_ClDummy].m_WantedWeapon;
 
-			if(!g_Config.m_ClDummyControl)
-				if ((m_aInputData[g_Config.m_ClDummy].m_Fire - m_aLastData[g_Config.m_ClDummy].m_Fire & 1) != 0)
-					pDummyInput->m_Fire++;
+			if(!g_Config.m_ClDummyControl && (m_aInputData[g_Config.m_ClDummy].m_Fire - m_aLastData[g_Config.m_ClDummy].m_Fire & 1) != 0)
+				pDummyInput->m_Fire++;
 
 			pDummyInput->m_NextWeapon += m_aInputData[g_Config.m_ClDummy].m_NextWeapon - m_aLastData[g_Config.m_ClDummy].m_NextWeapon;
 			pDummyInput->m_PrevWeapon += m_aInputData[g_Config.m_ClDummy].m_PrevWeapon - m_aLastData[g_Config.m_ClDummy].m_PrevWeapon;


### PR DESCRIPTION
With `cl_dummy_copy_moves` set to `1`, if you have hammered at all and then switch dummies, your new dummy will hammer automatically. This repeats each time you switch dummies.

The reason for this is that the code calculates the difference between the first and last input data; however, when switching, I guess the `m_aLastData[g_Config.m_ClDummy]` actually refers to the dummy, not the player (which _was_ the player right before switching) (this is just a guess, but in my testing, it checks out). So it takes the difference between the player's m_Fire and the dummy's m_Fire, resulting in some positive or negative even number.

This attempts to fix it; in my testing, nothing is different except this. This is a pretty minor change.

(Also I wasn't sure about braces with nested if statements, if this is not correct formatting then feel free to change it)

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
