### PR TITLE
Editor: fix input corners when editing value selector

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -364,7 +364,7 @@ SEditResult<int> CEditor::UiDoValueSelector(void *pID, CUIRect *pRect, const cha
 	{
 		str_copy(m_aTooltip, "Type your number");
 
-		DoEditBox(&s_NumberInput, pRect, 10.0f);
+		DoEditBox(&s_NumberInput, pRect, 10.0f, Corners);
 
 		UI()->SetActiveItem(&s_NumberInput);
 


### PR DESCRIPTION
It is a rather small change but I think this looks way better.

Before:

https://github.com/ddnet/ddnet/assets/13364635/680555db-1fcc-4d3c-88ec-a84afae269fc


After:

https://github.com/ddnet/ddnet/assets/13364635/d73d3aea-dbb7-4006-8335-4506b5d3f3d0


## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
