### PR TITLE
Fix crash on editor autosave, add system method `timestamp_from_str`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2784,6 +2784,7 @@ if(GTEST_FOUND OR DOWNLOAD_GTEST)
     test.cpp
     test.h
     thread.cpp
+    timestamp.cpp
     unix.cpp
     uuid.cpp
   )

--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -9,7 +9,9 @@
 #include <cstdarg>
 #include <cstdio>
 #include <cstring>
+#include <iomanip> // std::get_time
 #include <iterator> // std::size
+#include <sstream> // std::istringstream
 #include <string_view>
 
 #include "lock.h"
@@ -3445,6 +3447,22 @@ void str_timestamp_format(char *buffer, int buffer_size, const char *format)
 void str_timestamp(char *buffer, int buffer_size)
 {
 	str_timestamp_format(buffer, buffer_size, FORMAT_NOSPACE);
+}
+
+bool timestamp_from_str(const char *string, const char *format, time_t *timestamp)
+{
+	std::tm tm{};
+	std::istringstream ss(string);
+	ss >> std::get_time(&tm, format);
+	if(ss.fail() || !ss.eof())
+		return false;
+
+	time_t result = mktime(&tm);
+	if(result < 0)
+		return false;
+
+	*timestamp = result;
+	return true;
 }
 #ifdef __GNUC__
 #pragma GCC diagnostic pop

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -1711,6 +1711,21 @@ void str_timestamp_format(char *buffer, int buffer_size, const char *format)
 void str_timestamp_ex(time_t time, char *buffer, int buffer_size, const char *format)
 	GNUC_ATTRIBUTE((format(strftime, 4, 0)));
 
+/**
+ * Parses a string into a timestamp following a specified format.
+ *
+ * @ingroup Timestamp
+ *
+ * @param string Pointer to the string to parse
+ * @param format The time format to use (for example FORMAT_NOSPACE below)
+ * @param timestamp Pointer to the timestamp result
+ *
+ * @return true on success, false if the string could not be parsed with the specified format
+ *
+ */
+bool timestamp_from_str(const char *string, const char *format, time_t *timestamp)
+	GNUC_ATTRIBUTE((format(strftime, 2, 0)));
+
 #define FORMAT_TIME "%H:%M:%S"
 #define FORMAT_SPACE "%Y-%m-%d %H:%M:%S"
 #define FORMAT_NOSPACE "%Y-%m-%d_%H-%M-%S"

--- a/src/engine/shared/filecollection.h
+++ b/src/engine/shared/filecollection.h
@@ -20,7 +20,7 @@ class CFileCollection
 
 	struct CFileEntry
 	{
-		int64_t m_Timestamp;
+		time_t m_Timestamp;
 		char m_aFilename[IO_MAX_PATH_LENGTH];
 		CFileEntry(int64_t Timestamp, const char *pFilename)
 		{
@@ -29,7 +29,7 @@ class CFileCollection
 		}
 	};
 
-	std::vector<CFileEntry> m_vTimestamps;
+	std::vector<CFileEntry> m_vFileEntries;
 	char m_aFileDesc[128];
 	int m_FileDescLength;
 	char m_aFileExt[32];
@@ -37,9 +37,8 @@ class CFileCollection
 	char m_aPath[IO_MAX_PATH_LENGTH];
 	IStorage *m_pStorage;
 
-	bool IsFilenameValid(const char *pFilename);
-	int64_t ExtractTimestamp(const char *pTimestring);
-	int64_t GetTimestamp(const char *pFilename);
+	bool ExtractTimestamp(const char *pTimestring, time_t *pTimestamp);
+	bool ParseFilename(const char *pFilename, time_t *pTimestamp);
 
 public:
 	void Init(IStorage *pStorage, const char *pPath, const char *pFileDesc, const char *pFileExt, int MaxEntries);

--- a/src/test/timestamp.cpp
+++ b/src/test/timestamp.cpp
@@ -1,0 +1,61 @@
+#include <gtest/gtest.h>
+
+#include <base/system.h>
+#include <cstdlib>
+
+class TimestampTest : public testing::Test
+{
+protected:
+	void SetUp() override
+	{
+#if defined(CONF_FAMILY_WINDOWS)
+		_putenv_s("TZ", "UTC");
+		_tzset();
+#else
+		setenv("TZ", "UTC", 1);
+		tzset();
+#endif
+	}
+};
+
+TEST_F(TimestampTest, FromStr)
+{
+	time_t Timestamp;
+	EXPECT_TRUE(timestamp_from_str("2023-12-31_12-58-55", FORMAT_NOSPACE, &Timestamp));
+	EXPECT_EQ(Timestamp, 1704027535);
+
+	EXPECT_TRUE(timestamp_from_str("2012-02-29_13-00-00", FORMAT_NOSPACE, &Timestamp));
+	EXPECT_EQ(Timestamp, 1330520400);
+
+	EXPECT_TRUE(timestamp_from_str("2004-05-15 18:13:53", FORMAT_SPACE, &Timestamp));
+	EXPECT_EQ(Timestamp, 1084644833);
+}
+
+TEST_F(TimestampTest, FromStrFailing)
+{
+	time_t Timestamp;
+	// Invalid time string
+	EXPECT_FALSE(timestamp_from_str("123 2023-12-31_12-58-55", FORMAT_NOSPACE, &Timestamp));
+
+	// Invalid time string
+	EXPECT_FALSE(timestamp_from_str("555-02-29_13-12-7", FORMAT_NOSPACE, &Timestamp));
+
+	// Time string does not fit the format
+	EXPECT_FALSE(timestamp_from_str("2004-05-15 18-13-53", FORMAT_SPACE, &Timestamp));
+
+	// Invalid time string
+	EXPECT_FALSE(timestamp_from_str("2000-01-01 00:00:00:00", FORMAT_SPACE, &Timestamp));
+}
+
+TEST_F(TimestampTest, WithSpecifiedFormatAndTimestamp)
+{
+	char aTimestamp[20];
+	str_timestamp_ex(1704027535, aTimestamp, sizeof(aTimestamp), FORMAT_NOSPACE);
+	EXPECT_STREQ(aTimestamp, "2023-12-31_12-58-55");
+
+	str_timestamp_ex(1330520400, aTimestamp, sizeof(aTimestamp), FORMAT_NOSPACE);
+	EXPECT_STREQ(aTimestamp, "2012-02-29_13-00-00");
+
+	str_timestamp_ex(1084644833, aTimestamp, sizeof(aTimestamp), FORMAT_SPACE);
+	EXPECT_STREQ(aTimestamp, "2004-05-15 18:13:53");
+}


### PR DESCRIPTION
When working on editor related features and having a debugger attached, I often got an exception after a few minutes of having it open. I then found out that this happened consistantly when the editor tried to autosave a new map.

This is likely due to #7712 which changed how timestamps work. The issue is the computed timestamp in `CFileCollection` which is not a UNIX timestamp, so using it with a method that takes a UNIX timestamp throws an error.

In this PR I fixed this issue by introducing a new system method `timestamp_from_str` to parse a time string into a valid UNIX timestamp that can then be used with the method `str_timestamp_ex` (that previously caused the exception). I have also added a few tests for that specific method.

One issue is that I had to use C++ specific methods such as `std::get_time` and `std::istringstream` because there is no easy C-like way to parse a string into a timestamp following different formats, but since the project is using C++, why not use its features.


## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [x] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
