### PR TITLE
Explicitly set all 0.7 dmg event fields

### DIFF
--- a/src/game/server/eventhandler.cpp
+++ b/src/game/server/eventhandler.cpp
@@ -81,10 +81,16 @@ void CEventHandler::EventToSixup(int *pType, int *pSize, const char **ppData)
 		pEvent7->m_X = pEvent->m_X;
 		pEvent7->m_Y = pEvent->m_Y;
 
+		pEvent7->m_ClientID = 0;
+		pEvent7->m_Angle = 0;
+
 		// This will need some work, perhaps an event wrapper for damageind,
 		// a scan of the event array to merge multiple damageinds
 		// or a separate array of "damage ind" events that's added in while snapping
 		pEvent7->m_HealthAmount = 1;
+
+		pEvent7->m_ArmorAmount = 0;
+		pEvent7->m_Self = 0;
 
 		*ppData = s_aEventStore;
 	}


### PR DESCRIPTION
Does not fix any bug as far as I know. Just gets rid of the weirdness that uninitialized static memory is cast to a struct where only half of the fields are set. I tested it and my 0.7 client receives 0 for all values either way.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
