### PR TITLE
Fix missing editor explanation for kill tile in front layer

### DIFF
--- a/src/game/editor/explanations.cpp
+++ b/src/game/editor/explanations.cpp
@@ -14,7 +14,7 @@ const char *CEditor::ExplainDDNet(int Tile, int Layer)
 			return "HOOKABLE: It's possible to hook and collide with it.";
 		break;
 	case TILE_DEATH:
-		if(Layer == LAYER_GAME)
+		if(Layer == LAYER_GAME || Layer == LAYER_FRONT)
 			return "KILL: Kills the tee.";
 		break;
 	case TILE_NOHOOK:


### PR DESCRIPTION
The kill tile can also be used in the front layer and works as expected.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
