### PR TITLE
fix happy ddnet birthday broadcast (#7758)

### DIFF
--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -4078,8 +4078,10 @@ void CGameContext::OnSnap(int ClientID)
 			pPlayer->Snap(ClientID);
 	}
 
-	if(ClientID > -1)
+	if(ClientID > -1) {
 		m_apPlayers[ClientID]->FakeSnap();
+		m_apPlayers[ClientID]->m_SentSnaps++;
+	}
 
 	m_World.Snap(ClientID);
 	m_Events.Snap(ClientID);

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -4078,10 +4078,8 @@ void CGameContext::OnSnap(int ClientID)
 			pPlayer->Snap(ClientID);
 	}
 
-	if(ClientID > -1) {
+	if(ClientID > -1)
 		m_apPlayers[ClientID]->FakeSnap();
-		m_apPlayers[ClientID]->m_SentSnaps++;
-	}
 
 	m_World.Snap(ClientID);
 	m_Events.Snap(ClientID);

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -158,7 +158,7 @@ static int PlayerFlags_SixToSeven(int Flags)
 
 void CPlayer::Tick()
 {
-	if(m_ScoreQueryResult != nullptr && m_ScoreQueryResult->m_Completed)
+	if(m_ScoreQueryResult != nullptr && m_ScoreQueryResult->m_Completed && m_SentSnaps >= 3)
 	{
 		ProcessScoreResult(*m_ScoreQueryResult);
 		m_ScoreQueryResult = nullptr;

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -451,6 +451,7 @@ void CPlayer::Snap(int SnappingClient)
 
 void CPlayer::FakeSnap()
 {
+	m_SentSnaps++;
 	if(GetClientVersion() >= VERSION_DDNET_OLD)
 		return;
 

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -80,6 +80,8 @@ public:
 	// used for snapping to just update latency if the scoreboard is active
 	int m_aCurLatency[MAX_CLIENTS];
 
+	int m_SentSnaps = 0;
+
 	// used for spectator mode
 	int m_SpectatorID;
 


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->
The broadcast gets fixed by only running the method, which triggers the broadcast, only when the client has received (at least) 3 snapshots. 
![image](https://github.com/ddnet/ddnet/assets/135431730/a0838a7d-76ef-4605-b9ba-a7db942ed12e)
## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)

