### PR TITLE
Fix files not being truncated when opening for writing on Windows

### DIFF
--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -273,7 +273,7 @@ IOHANDLE io_open_impl(const char *filename, int flags)
 	else if(flags == IOFLAG_WRITE)
 	{
 		desired_access = FILE_WRITE_DATA;
-		creation_disposition = OPEN_ALWAYS;
+		creation_disposition = CREATE_ALWAYS;
 		open_mode = "wb";
 	}
 	else if(flags == IOFLAG_APPEND)

--- a/src/test/io.cpp
+++ b/src/test/io.cpp
@@ -78,3 +78,26 @@ TEST(Io, SyncWorks)
 	EXPECT_FALSE(io_close(File));
 	EXPECT_FALSE(fs_remove(Info.m_aFilename));
 }
+
+TEST(Io, WriteTruncatesFile)
+{
+	CTestInfo Info;
+
+	IOHANDLE File = io_open(Info.m_aFilename, IOFLAG_WRITE);
+	ASSERT_TRUE(File);
+	EXPECT_EQ(io_write(File, "0123456789", 10), 10);
+	EXPECT_FALSE(io_close(File));
+
+	File = io_open(Info.m_aFilename, IOFLAG_WRITE);
+	EXPECT_EQ(io_write(File, "ABCDE", 5), 5);
+	EXPECT_FALSE(io_close(File));
+
+	char aBuf[16];
+	File = io_open(Info.m_aFilename, IOFLAG_READ);
+	ASSERT_TRUE(File);
+	EXPECT_EQ(io_read(File, aBuf, sizeof(aBuf)), 5);
+	EXPECT_TRUE(mem_comp(aBuf, "ABCDE", 5) == 0);
+	EXPECT_FALSE(io_close(File));
+
+	EXPECT_FALSE(fs_remove(Info.m_aFilename));
+}


### PR DESCRIPTION
Files were not being truncated on Windows anymore when using `io_open` with `IOFLAG_WRITE` due to a regression from #7254. Instead, the existing file contents were kept and the file pointer was set to the beginning of the file.

This caused broken demo files to be created (#7349) when recording a shorter demo with the same filename as an existing longer demo. It also caused the map tools to produce maps with additional junk data at the end, if an existing map is overridden by a smaller map.

This is fixed by using the creation disposition `CREATE_ALWAYS` instead of `OPEN_EXISTING` with [`CreateFileW`](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilew), which ensures that a file is always created and truncated.

A regression test case is added, which fails without this change.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [X] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
