### PR TITLE
Add support for custom score kinds in ddnet mods

### DIFF
--- a/src/engine/server.h
+++ b/src/engine/server.h
@@ -365,6 +365,12 @@ public:
 	 * @param i The client id.
 	 */
 	virtual void OnUpdatePlayerServerInfo(char *aBuf, int BufSize, int ID) = 0;
+	/**
+	 * Used to report custom server info to master servers.
+	 *
+	 * @param aBuf Should be the json key values to add, starting with a ',' beforehand, like: ',"client_score_kind": "points", "custom": 1'
+	 */
+	virtual void OnUpdateServerInfo(char *aBuf, int BufSize) const = 0;
 };
 
 extern IGameServer *CreateGameServer();

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -2383,6 +2383,9 @@ void CServer::UpdateRegisterServerInfo()
 
 	sha256_str(m_aCurrentMapSha256[MAP_TYPE_SIX], aMapSha256, sizeof(aMapSha256));
 
+	char aExtraServerInfo[512];
+	GameServer()->OnUpdateServerInfo(aExtraServerInfo, sizeof(aExtraServerInfo));
+
 	char aInfo[16384];
 	str_format(aInfo, sizeof(aInfo),
 		"{"
@@ -2397,7 +2400,7 @@ void CServer::UpdateRegisterServerInfo()
 		"\"size\":%d"
 		"},"
 		"\"version\":\"%s\","
-		"\"client_score_kind\":\"time\","
+		"%s"
 		"\"clients\":[",
 		MaxClients,
 		MaxPlayers,
@@ -2407,7 +2410,8 @@ void CServer::UpdateRegisterServerInfo()
 		EscapeJson(aMapName, sizeof(aMapName), m_aCurrentMap),
 		aMapSha256,
 		m_aCurrentMapSize[MAP_TYPE_SIX],
-		EscapeJson(aVersion, sizeof(aVersion), GameServer()->Version()));
+		EscapeJson(aVersion, sizeof(aVersion), GameServer()->Version()),
+		aExtraServerInfo);
 
 	bool FirstPlayer = true;
 	for(int i = 0; i < MAX_CLIENTS; i++)

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -4744,3 +4744,31 @@ void CGameContext::OnUpdatePlayerServerInfo(char *aBuf, int BufSize, int ID)
 		JsonBool(m_apPlayers[ID]->IsAfk()),
 		Team);
 }
+
+void CGameContext::OnUpdateServerInfo(char *aBuf, int BufSize) const
+{
+	if(BufSize <= 0)
+		return;
+
+	aBuf[0] = '\0';
+	const char *pScoreKind;
+
+	switch(m_pController->ScoreKind())
+	{
+	case CServerInfo::CLIENT_SCORE_KIND_TIME:
+		pScoreKind = "time";
+		break;
+	case CServerInfo::CLIENT_SCORE_KIND_POINTS:
+		pScoreKind = "points";
+		break;
+	case CServerInfo::CLIENT_SCORE_KIND_TIME_BACKCOMPAT:
+	case CServerInfo::CLIENT_SCORE_KIND_UNSPECIFIED:
+	default:
+		dbg_assert(false, "IGameController::ScoreKind returned invalid value");
+		dbg_break();
+	}
+
+	str_format(aBuf, BufSize,
+		"\"client_score_kind\":\"%s\",",
+		pScoreKind);
+}

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -355,6 +355,7 @@ public:
 	bool RateLimitPlayerMapVote(int ClientID) const;
 
 	void OnUpdatePlayerServerInfo(char *aBuf, int BufSize, int ID) override;
+	void OnUpdateServerInfo(char *aBuf, int BufSize) const override;
 
 	std::shared_ptr<CScoreRandomMapResult> m_SqlRandomMapResult;
 

--- a/src/game/server/gamecontroller.cpp
+++ b/src/game/server/gamecontroller.cpp
@@ -597,7 +597,6 @@ void IGameController::Snap(int SnappingClient)
 		return;
 
 	pGameInfoEx->m_Flags =
-		GAMEINFOFLAG_TIMESCORE |
 		GAMEINFOFLAG_GAMETYPE_RACE |
 		GAMEINFOFLAG_GAMETYPE_DDRACE |
 		GAMEINFOFLAG_GAMETYPE_DDNET |
@@ -614,6 +613,8 @@ void IGameController::Snap(int SnappingClient)
 		GAMEINFOFLAG_ENTITIES_DDRACE |
 		GAMEINFOFLAG_ENTITIES_RACE |
 		GAMEINFOFLAG_RACE;
+	if(ScoreKind() == CServerInfo::CLIENT_SCORE_KIND_TIME)
+		pGameInfoEx->m_Flags |= GAMEINFOFLAG_TIMESCORE;
 	pGameInfoEx->m_Flags2 = GAMEINFOFLAG2_HUD_DDRACE;
 	if(g_Config.m_SvNoWeakHook)
 		pGameInfoEx->m_Flags2 |= GAMEINFOFLAG2_NO_WEAK_HOOK;

--- a/src/game/server/gamecontroller.h
+++ b/src/game/server/gamecontroller.h
@@ -5,6 +5,7 @@
 
 #include <base/vmath.h>
 #include <engine/map.h>
+#include <engine/serverbrowser.h>
 #include <engine/shared/protocol.h>
 #include <game/server/teams.h>
 
@@ -150,6 +151,7 @@ public:
 
 	CClientMask GetMaskForPlayerWorldEvent(int Asker, int ExceptID = -1);
 	virtual void InitTeleporter();
+	virtual CServerInfo::EClientScoreKind ScoreKind() const { return CServerInfo::CLIENT_SCORE_KIND_TIME; };
 
 	bool IsTeamPlay() { return m_GameFlags & GAMEFLAG_TEAMS; }
 	// DDRace

--- a/src/game/server/gamemodes/mod.h
+++ b/src/game/server/gamemodes/mod.h
@@ -10,5 +10,6 @@ public:
 	~CGameControllerMod();
 
 	void Tick() override;
+	CServerInfo::EClientScoreKind ScoreKind() const override { return CServerInfo::CLIENT_SCORE_KIND_POINTS; };
 };
 #endif // GAME_SERVER_GAMEMODES_MOD_H


### PR DESCRIPTION
Running ``./DDNet-Server "sv_gametype mod"`` now shows -9999 in scoreboard and reports the "points" score kind to master server. This gives ddnet based mods a clear api for using point based scores. Mods with minigames or similiar might also want to report different score types to different players that is why the api also includes the ClientID.

https://github.com/ZillyInsta/ddnet-insta/pull/83

```
$ ./DDNet-Server "stdout_output_level 3;sv_register 1;sv_gametype mod" | grep client_score_kind
2024-01-07 10:36:12 T register: info: {"max_clients":64,"max_players":64,"passworded":false,"game_type":"Mod","name":"unnamed server","map":{"name":"tmp/maps-07/ctf5_spikes","sha256":"8692f4f91239b298b6ecadb4700d1a7a7f166742e3864d8026a41c1d43e64a42","size":10250},"version":"0.6.4, 17.4.2","client_score_kind":"points","clients":[]}

$ ./DDNet-Server "stdout_output_level 3;sv_register 1;sv_gametype ddnet" | grep client_score_kind
2024-01-07 10:36:21 T register: info: {"max_clients":64,"max_players":64,"passworded":false,"game_type":"DDraceNetwork","name":"unnamed server","map":{"name":"tmp/maps-07/ctf5_spikes","sha256":"8692f4f91239b298b6ecadb4700d1a7a7f166742e3864d8026a41c1d43e64a42","size":10250},"version":"0.6.4, 17.4.2","client_score_kind":"time","clients":[]}

```

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
