### PR TITLE
Improve error messages when saving settings fails

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -2997,7 +2997,11 @@ void CClient::Run()
 			{
 				// write down the config and quit
 				if(!m_pConfigManager->Save())
-					m_vWarnings.emplace_back(Localize("Saving ddnet-settings.cfg failed"));
+				{
+					char aWarning[128];
+					str_format(aWarning, sizeof(aWarning), Localize("Saving settings to '%s' failed"), CONFIG_FILE);
+					m_vWarnings.emplace_back(aWarning);
+				}
 				s_SavedConfig = true;
 			}
 

--- a/src/engine/shared/config.cpp
+++ b/src/engine/shared/config.cpp
@@ -496,19 +496,27 @@ bool CConfigManager::Save()
 		WriteLine(pCommand);
 	}
 
+	if(m_Failed)
+	{
+		log_error("config", "ERROR: writing to %s failed", aConfigFileTmp);
+	}
+
 	if(io_sync(m_ConfigFile) != 0)
 	{
 		m_Failed = true;
+		log_error("config", "ERROR: synchronizing %s failed", aConfigFileTmp);
 	}
 
 	if(io_close(m_ConfigFile) != 0)
+	{
 		m_Failed = true;
+		log_error("config", "ERROR: closing %s failed", aConfigFileTmp);
+	}
 
 	m_ConfigFile = 0;
 
 	if(m_Failed)
 	{
-		log_error("config", "ERROR: writing to %s failed", aConfigFileTmp);
 		return false;
 	}
 


### PR DESCRIPTION
Screenshots:
- Before: 
![screenshot_2024-01-07_12-28-29](https://github.com/ddnet/ddnet/assets/23437060/920a3762-cdd6-44f0-ab1c-fe62c60dc94b)
- After: 
![screenshot_2024-01-07_12-28-42](https://github.com/ddnet/ddnet/assets/23437060/0de229f1-8f53-47c8-8db9-0f5c3bec85a3)


## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
