### PR TITLE
`fix_style.py`: replace windows path separator with `/`

### DIFF
--- a/scripts/fix_style.py
+++ b/scripts/fix_style.py
@@ -17,11 +17,19 @@ IGNORE_FILES = [
 	"src/engine/client/keynames.h",
 	"src/engine/keys.h",
 ]
+IGNORE_DIRS = [
+	"src/game/generated",
+	"src/rust-bridge"
+]
 def filter_ignored(filenames):
-	return [filename for filename in filenames
-		if filename not in IGNORE_FILES
-		and not filename.startswith("src/game/generated/")
-        and not filename.startswith("src/rust-bridge")]
+	result = []
+	for filename in filenames:
+		real_filename = os.path.realpath(filename)
+		if real_filename not in [os.path.realpath(ignore_file) for ignore_file in IGNORE_FILES] \
+			and not any(real_filename.startswith(os.path.realpath(subdir) + os.path.sep) for subdir in IGNORE_DIRS):
+			result.append(filename)
+
+	return result
 
 def filter_cpp(filenames):
 	return [filename for filename in filenames


### PR DESCRIPTION
On Windows the paths contains `\` which is different from the used path separator in the script `/`, being used for files to ignore for example. It means that those ignore files wouldn't match any of the collected paths when running the script on Windows, which lead to having those files being clang formatted when they should be ignored.

This PR simply replaces the windows path separator `\` with `/` so that everything involving path comparison should work properly.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
