### PR TITLE
Avoid including `zlib.h` in header file

### DIFF
--- a/src/engine/shared/datafile.h
+++ b/src/engine/shared/datafile.h
@@ -13,8 +13,6 @@
 #include <array>
 #include <vector>
 
-#include <zlib.h>
-
 enum
 {
 	ITEMTYPE_EX = 0xffff,
@@ -70,13 +68,21 @@ public:
 // write access
 class CDataFileWriter
 {
+public:
+	enum ECompressionLevel
+	{
+		COMPRESSION_DEFAULT,
+		COMPRESSION_BEST,
+	};
+
+private:
 	struct CDataInfo
 	{
 		void *m_pUncompressedData;
 		int m_UncompressedSize;
 		void *m_pCompressedData;
 		int m_CompressedSize;
-		int m_CompressionLevel;
+		ECompressionLevel m_CompressionLevel;
 	};
 
 	struct CItemInfo
@@ -131,7 +137,7 @@ public:
 
 	bool Open(class IStorage *pStorage, const char *pFilename, int StorageType = IStorage::TYPE_SAVE);
 	int AddItem(int Type, int ID, size_t Size, const void *pData, const CUuid *pUuid = nullptr);
-	int AddData(size_t Size, const void *pData, int CompressionLevel = Z_DEFAULT_COMPRESSION);
+	int AddData(size_t Size, const void *pData, ECompressionLevel CompressionLevel = COMPRESSION_DEFAULT);
 	int AddDataSwapped(size_t Size, const void *pData);
 	int AddDataString(const char *pStr);
 	void Finish();

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -3741,7 +3741,7 @@ bool CGameClient::InitMultiView(int Team)
 			CurPosition.y = CurCharacter.m_Y;
 		}
 
-		int ClosestDistance = INT_MAX;
+		int ClosestDistance = std::numeric_limits<int>::max();
 		for(int i = 0; i < MAX_CLIENTS; i++)
 		{
 			if(!m_Snap.m_apPlayerInfos[i] || m_Snap.m_apPlayerInfos[i]->m_Team == TEAM_SPECTATORS || m_Teams.Team(i) != m_MultiViewTeam)

--- a/src/tools/dummy_map.cpp
+++ b/src/tools/dummy_map.cpp
@@ -7,6 +7,8 @@
 
 #include <game/mapitems.h>
 
+#include <zlib.h>
+
 void CreateEmptyMap(IStorage *pStorage)
 {
 	const char *pMapName = "maps/dummy3.map";

--- a/src/tools/map_optimize.cpp
+++ b/src/tools/map_optimize.cpp
@@ -308,7 +308,7 @@ int main(int argc, const char **argv)
 			}
 		}
 
-		Writer.AddData(Size, pPtr, Z_BEST_COMPRESSION);
+		Writer.AddData(Size, pPtr, CDataFileWriter::COMPRESSION_BEST);
 
 		if(DeletePtr)
 			free(pPtr);


### PR DESCRIPTION
By adding `CDataFileWriter::ECompressionLevel` to replace usage of zlib internal compression levels in the `CDataFileWriter` API.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
