### PR TITLE
Fix incorrect SHA256 logged in `dummy_map` tool

### DIFF
--- a/src/tools/dummy_map.cpp
+++ b/src/tools/dummy_map.cpp
@@ -90,7 +90,7 @@ void CreateEmptyMap(IStorage *pStorage)
 	unsigned char *pDataChar = static_cast<unsigned char *>(pData);
 
 	unsigned Crc = crc32(0, pDataChar, DataSize);
-	SHA256_DIGEST Sha256 = sha256(&pDataChar, DataSize);
+	SHA256_DIGEST Sha256 = sha256(pDataChar, DataSize);
 
 	char aMapSha[SHA256_MAXSTRSIZE];
 	sha256_str(Sha256, aMapSha, sizeof(aMapSha));


### PR DESCRIPTION
The SHA256 was being calculated over a pointer to the map data and random following memory instead of over the data itself.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
