### PR TITLE
Include `limits` instead of `climits`

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -63,7 +63,7 @@
 #endif
 
 #include <chrono>
-#include <climits>
+#include <limits>
 #include <new>
 #include <stack>
 #include <thread>
@@ -3798,7 +3798,7 @@ int CClient::HandleChecksum(int Conn, CUuid Uuid, CUnpacker *pUnpacker)
 	{
 		return 1;
 	}
-	if(Start < 0 || Length < 0 || Start > INT_MAX - Length)
+	if(Start < 0 || Length < 0 || Start > std::numeric_limits<int>::max() - Length)
 	{
 		return 2;
 	}

--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -6,7 +6,6 @@
 #include "serverbrowser_ping_cache.h"
 
 #include <algorithm>
-#include <climits>
 #include <unordered_set>
 #include <vector>
 

--- a/src/game/client/components/spectator.cpp
+++ b/src/game/client/components/spectator.cpp
@@ -1,7 +1,7 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 
-#include <climits>
+#include <limits>
 
 #include <engine/graphics.h>
 #include <engine/shared/config.h>
@@ -132,7 +132,7 @@ void CSpectator::ConSpectateClosest(IConsole::IResult *pResult, void *pUserData)
 		CurPosition.y = CurCharacter.m_Y;
 	}
 
-	int ClosestDistance = INT_MAX;
+	int ClosestDistance = std::numeric_limits<int>::max();
 	for(int i = 0; i < MAX_CLIENTS; i++)
 	{
 		if(i == SpectatorID || !Snap.m_apPlayerInfos[i] || Snap.m_apPlayerInfos[i]->m_Team == TEAM_SPECTATORS || (SpectatorID == SPEC_FREEVIEW && i == Snap.m_LocalClientID))

--- a/src/test/jsonwriter.cpp
+++ b/src/test/jsonwriter.cpp
@@ -6,7 +6,7 @@
 #include <base/system.h>
 #include <engine/shared/jsonwriter.h>
 
-#include <climits>
+#include <limits>
 
 class JsonFileWriter
 {
@@ -201,12 +201,12 @@ TYPED_TEST(JsonWriters, MinusOne)
 
 TYPED_TEST(JsonWriters, Large)
 {
-	this->Impl.m_pJson->WriteIntValue(INT_MAX);
+	this->Impl.m_pJson->WriteIntValue(std::numeric_limits<int>::max());
 	this->Impl.Expect("2147483647\n");
 }
 
 TYPED_TEST(JsonWriters, Small)
 {
-	this->Impl.m_pJson->WriteIntValue(INT_MIN);
+	this->Impl.m_pJson->WriteIntValue(std::numeric_limits<int>::min());
 	this->Impl.Expect("-2147483648\n");
 }


### PR DESCRIPTION
Consistently use `std::numeric_limits` instead of `INT_MIN` and `INT_MAX`.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
