### PR TITLE
Use temporary files for recording demos

### DIFF
--- a/src/engine/client.h
+++ b/src/engine/client.h
@@ -165,6 +165,7 @@ public:
 #endif
 	virtual void DemoRecorder_Start(const char *pFilename, bool WithTimestamp, int Recorder, bool Verbose = false) = 0;
 	virtual void DemoRecorder_HandleAutoStart() = 0;
+	virtual void DemoRecorder_UpdateReplayRecorder() = 0;
 	virtual void DemoRecorder_Stop(int Recorder, bool RemoveFile = false) = 0;
 	virtual class IDemoRecorder *DemoRecorder(int Recorder) = 0;
 	virtual void AutoScreenshot_Start() = 0;

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -118,7 +118,6 @@ class CClient : public IClient, public CDemoPlayer::IListener
 	int m_UseTempRconCommands = 0;
 	char m_aPassword[sizeof(g_Config.m_Password)] = "";
 	bool m_SendPassword = false;
-	bool m_ButtonRender = false;
 
 	// version-checking
 	char m_aVersionStr[10] = "0";
@@ -435,7 +434,7 @@ public:
 	const char *DemoPlayer_Play(const char *pFilename, int StorageType) override;
 	void DemoRecorder_Start(const char *pFilename, bool WithTimestamp, int Recorder, bool Verbose = false) override;
 	void DemoRecorder_HandleAutoStart() override;
-	void DemoRecorder_StartReplayRecorder();
+	void DemoRecorder_UpdateReplayRecorder() override;
 	void DemoRecorder_Stop(int Recorder, bool RemoveFile = false) override;
 	void DemoRecorder_AddDemoMarker(int Recorder);
 	IDemoRecorder *DemoRecorder(int Recorder) override;

--- a/src/engine/demo.h
+++ b/src/engine/demo.h
@@ -103,9 +103,10 @@ class IDemoRecorder : public IInterface
 public:
 	virtual ~IDemoRecorder() {}
 	virtual bool IsRecording() const = 0;
-	virtual int Stop() = 0;
+	virtual int Stop(bool RemoveFile = false) = 0;
 	virtual int Length() const = 0;
-	virtual char *GetCurrentFilename() = 0;
+	virtual const char *CurrentFilename() const = 0;
+	virtual void SetCurrentFilename(const char *pFilename) = 0;
 };
 
 class IDemoEditor : public IInterface

--- a/src/engine/shared/demo.h
+++ b/src/engine/shared/demo.h
@@ -18,17 +18,23 @@ typedef std::function<void()> TUpdateIntraTimesFunc;
 class CDemoRecorder : public IDemoRecorder
 {
 	class IConsole *m_pConsole;
+	class IStorage *m_pStorage;
+
 	IOHANDLE m_File;
 	char m_aCurrentFilename[IO_MAX_PATH_LENGTH];
+	char m_aTempFilename[IO_MAX_PATH_LENGTH];
+
 	int m_LastTickMarker;
 	int m_LastKeyFrame;
 	int m_FirstTick;
+
 	unsigned char m_aLastSnapshotData[CSnapshot::MAX_SIZE];
 	class CSnapshotDelta *m_pSnapshotDelta;
+
 	int m_NumTimelineMarkers;
 	int m_aTimelineMarkers[MAX_TIMELINE_MARKERS];
+
 	bool m_NoMapData;
-	unsigned char *m_pMapData;
 
 	DEMOFUNC_FILTER m_pfnFilter;
 	void *m_pUser;
@@ -42,7 +48,7 @@ public:
 	~CDemoRecorder() override;
 
 	int Start(class IStorage *pStorage, class IConsole *pConsole, const char *pFilename, const char *pNetversion, const char *pMap, const SHA256_DIGEST &Sha256, unsigned MapCrc, const char *pType, unsigned MapSize, unsigned char *pMapData, IOHANDLE MapFile = nullptr, DEMOFUNC_FILTER pfnFilter = nullptr, void *pUser = nullptr);
-	int Stop() override;
+	int Stop(bool RemoveFile = false) override;
 
 	void AddDemoMarker();
 	void AddDemoMarker(int Tick);
@@ -51,8 +57,8 @@ public:
 	void RecordMessage(const void *pData, int Size);
 
 	bool IsRecording() const override { return m_File != nullptr; }
-	char *GetCurrentFilename() override { return m_aCurrentFilename; }
-	void ClearCurrentFilename() { m_aCurrentFilename[0] = '\0'; }
+	const char *CurrentFilename() const override { return m_aCurrentFilename; }
+	void SetCurrentFilename(const char *pFilename) override;
 
 	int Length() const override { return (m_LastTickMarker - m_FirstTick) / SERVER_TICK_SPEED; }
 };

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -3194,16 +3194,7 @@ void CMenus::RenderSettingsDDNet(CUIRect MainView)
 	if(DoButton_CheckBox(&g_Config.m_ClReplays, Localize("Enable replays"), g_Config.m_ClReplays, &Button))
 	{
 		g_Config.m_ClReplays ^= 1;
-		if(!g_Config.m_ClReplays)
-		{
-			// stop recording and remove the tmp demo file
-			Client()->DemoRecorder_Stop(RECORDER_REPLAYS, true);
-		}
-		else
-		{
-			// start recording
-			Client()->DemoRecorder_HandleAutoStart();
-		}
+		Client()->DemoRecorder_UpdateReplayRecorder();
 	}
 
 	Left.HSplitTop(20.0f, &Button, &Left);


### PR DESCRIPTION
Initially record demos to `.%pid%.tmp` files and rename them to the real filename when the recording is stopped. This ensures that `.demo` files are valid, assuming no `io_write` errors occur. If the client crashes or otherwise fails to stop the demo recording, then the invalid demos will stay `.tmp` files.

To simplify the usage, the handling of temporary files is added directly to the demo recorder. A parameter `bool RemoveFile` is added to the `IDemoRecorder::Stop` function to control whether the temporary file is removed or renamed to the real filename.

Ensure `.tmp` files of the replay recorder are always removed (except on crashes). The temporary replay demos were previously not removed when being disconnected from a server.

Ensure that replay filenames are unique by appending a random number. The replay demo is sliced in a background job, so we need to avoid recording to the same file when restarting the replay recorder.

Fix auto demos being stopped and restarted when enabling replays in the settings menu. Now only the replay recorder is stopped/started when necessary.

Fix replay recorder being restarted when setting `cl_replay` variable with console without changing the value.

Remove unnecessary `CClient::m_ButtonRender` variable. Demo rendering is already stopped correctly when reaching the end of the demo without this additional variable.

Remove unused `CDemoRecorder::m_pMapData` variable.

See #7349.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
