### PR TITLE
Fix multi-line text selection not rendered correctly anymore

### DIFF
--- a/src/engine/client/text.cpp
+++ b/src/engine/client/text.cpp
@@ -1867,7 +1867,7 @@ public:
 
 					if(SelectionStarted && IsRendered)
 					{
-						if(!vSelectionQuads.empty() && SelectionQuadLine == pCursor->m_LineCount)
+						if(!vSelectionQuads.empty() && SelectionQuadLine == LineCount)
 						{
 							vSelectionQuads.back().m_Width += SelWidth;
 						}
@@ -1877,7 +1877,7 @@ public:
 							const float SelectionY = DrawY + (1.0f - pCursor->m_SelectionHeightFactor) * SelectionHeight;
 							const float ScaledSelectionHeight = pCursor->m_SelectionHeightFactor * SelectionHeight;
 							vSelectionQuads.emplace_back(SelX, SelectionY, SelWidth, ScaledSelectionHeight);
-							SelectionQuadLine = pCursor->m_LineCount;
+							SelectionQuadLine = LineCount;
 						}
 					}
 


### PR DESCRIPTION
The `CTextCursor::m_LineCount` variable is only updated after the cursor is rendered. For calculating the selection quads we need to check `LineCount` instead, which is updated while the cursor is being rendered. Regression from #7733.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
