### PR TITLE
Fix multiple editor undo/redo issues

### DIFF
--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -876,14 +876,14 @@ public:
 
 	void DoQuadEnvelopes(const std::vector<CQuad> &vQuads, IGraphics::CTextureHandle Texture = IGraphics::CTextureHandle());
 	void DoQuadEnvPoint(const CQuad *pQuad, int QIndex, int pIndex);
-	void DoQuadPoint(const std::shared_ptr<CLayerQuads> &pLayer, CQuad *pQuad, int QuadIndex, int v);
+	void DoQuadPoint(int LayerIndex, const std::shared_ptr<CLayerQuads> &pLayer, CQuad *pQuad, int QuadIndex, int v);
 	void SetHotQuadPoint(const std::shared_ptr<CLayerQuads> &pLayer);
 
 	float TriangleArea(vec2 A, vec2 B, vec2 C);
 	bool IsInTriangle(vec2 Point, vec2 A, vec2 B, vec2 C);
 	void DoQuadKnife(int QuadIndex);
 
-	void DoSoundSource(CSoundSource *pSource, int Index);
+	void DoSoundSource(int LayerIndex, CSoundSource *pSource, int Index);
 
 	enum class EAxis
 	{
@@ -907,7 +907,7 @@ public:
 	void DoMapEditor(CUIRect View);
 	void DoToolbarLayers(CUIRect Toolbar);
 	void DoToolbarSounds(CUIRect Toolbar);
-	void DoQuad(const std::shared_ptr<CLayerQuads> &pLayer, CQuad *pQuad, int Index);
+	void DoQuad(int LayerIndex, const std::shared_ptr<CLayerQuads> &pLayer, CQuad *pQuad, int Index);
 	void PreparePointDrag(const std::shared_ptr<CLayerQuads> &pLayer, CQuad *pQuad, int QuadIndex, int PointIndex);
 	void DoPointDrag(const std::shared_ptr<CLayerQuads> &pLayer, CQuad *pQuad, int QuadIndex, int PointIndex, int OffsetX, int OffsetY);
 	EAxis GetDragAxis(int OffsetX, int OffsetY);

--- a/src/game/editor/editor_actions.h
+++ b/src/game/editor/editor_actions.h
@@ -645,4 +645,18 @@ private:
 	CQuad m_Quad;
 };
 
+class CEditorActionMoveSoundSource : public CEditorActionLayerBase
+{
+public:
+	CEditorActionMoveSoundSource(CEditor *pEditor, int GroupIndex, int LayerIndex, int SourceIndex, CPoint OriginalPosition, CPoint CurrentPosition);
+
+	void Undo() override;
+	void Redo() override;
+
+private:
+	int m_SourceIndex;
+	CPoint m_OriginalPosition;
+	CPoint m_CurrentPosition;
+};
+
 #endif

--- a/src/game/editor/editor_history.cpp
+++ b/src/game/editor/editor_history.cpp
@@ -17,6 +17,12 @@ void CEditorHistory::Execute(const std::shared_ptr<IEditorAction> &pAction, cons
 
 void CEditorHistory::RecordAction(const std::shared_ptr<IEditorAction> &pAction, const char *pDisplay)
 {
+	if(m_IsBulk)
+	{
+		m_vpBulkActions.push_back(pAction);
+		return;
+	}
+
 	m_vpRedoActions.clear();
 
 	if((int)m_vpUndoActions.size() >= g_Config.m_ClEditorMaxHistory)
@@ -62,4 +68,23 @@ void CEditorHistory::Clear()
 {
 	m_vpUndoActions.clear();
 	m_vpRedoActions.clear();
+}
+
+void CEditorHistory::BeginBulk()
+{
+	m_IsBulk = true;
+	m_vpBulkActions.clear();
+}
+
+void CEditorHistory::EndBulk(const char *pDisplay)
+{
+	if(!m_IsBulk)
+		return;
+	m_IsBulk = false;
+
+	// Record bulk action
+	if(!m_vpBulkActions.empty())
+		RecordAction(std::make_shared<CEditorActionBulk>(m_pEditor, m_vpBulkActions, pDisplay, true));
+
+	m_vpBulkActions.clear();
 }

--- a/src/game/editor/editor_history.h
+++ b/src/game/editor/editor_history.h
@@ -11,6 +11,7 @@ public:
 	CEditorHistory()
 	{
 		m_pEditor = nullptr;
+		m_IsBulk = false;
 	}
 
 	~CEditorHistory()
@@ -29,9 +30,16 @@ public:
 	bool CanUndo() const { return !m_vpUndoActions.empty(); }
 	bool CanRedo() const { return !m_vpRedoActions.empty(); }
 
+	void BeginBulk();
+	void EndBulk(const char *pDisplay = nullptr);
+
 	CEditor *m_pEditor;
 	std::deque<std::shared_ptr<IEditorAction>> m_vpUndoActions;
 	std::deque<std::shared_ptr<IEditorAction>> m_vpRedoActions;
+
+private:
+	std::vector<std::shared_ptr<IEditorAction>> m_vpBulkActions;
+	bool m_IsBulk;
 };
 
 #endif

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -782,7 +782,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupLayer(void *pContext, CUIRect View, 
 	}
 	else if(Prop == ELayerProp::PROP_GROUP)
 	{
-		if(NewVal >= 0 && (size_t)NewVal < pEditor->m_Map.m_vpGroups.size())
+		if(NewVal >= 0 && (size_t)NewVal < pEditor->m_Map.m_vpGroups.size() && NewVal != pEditor->m_SelectedGroup)
 		{
 			auto Position = std::find(pCurrentGroup->m_vpLayers.begin(), pCurrentGroup->m_vpLayers.end(), pCurrentLayer);
 			if(Position != pCurrentGroup->m_vpLayers.end())


### PR DESCRIPTION
Fixed crash when runing tool 'Remove unused envelopes' and trying to undo the addition of an envelope (fixes #7738).
Fixed issues where undo/redo would not work properly when changing a layer's order or group property.
Added missing action for changing the position of a sound source.

I don't know if there are any more problems, so feel free to open an issue when you encounter a crash/unexpected behavior while using the feature.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
