### PR TITLE
Allow /times and /top5team without quotation marks

### DIFF
--- a/src/game/ddracechat.h
+++ b/src/game/ddracechat.h
@@ -40,7 +40,7 @@ CHAT_COMMAND("top5team", "?r[player name] ?i[rank to start with]", CFGFLAG_CHAT 
 CHAT_COMMAND("teamtop5", "?r[player name] ?i[rank to start with]", CFGFLAG_CHAT | CFGFLAG_SERVER, ConTeamTop5, this, "Shows five team ranks of the ladder or of a player beginning with rank i (1 by default, -1 for worst)")
 CHAT_COMMAND("top", "?i[rank to start with]", CFGFLAG_CHAT | CFGFLAG_SERVER, ConTop, this, "Shows the top ranks of the global and regional ladder beginning with rank i (1 by default, -1 for worst)")
 CHAT_COMMAND("top5", "?i[rank to start with]", CFGFLAG_CHAT | CFGFLAG_SERVER, ConTop, this, "Shows the top ranks of the global and regional ladder beginning with rank i (1 by default, -1 for worst)")
-CHAT_COMMAND("times", "?s[player name] ?i[number of times to skip]", CFGFLAG_CHAT | CFGFLAG_SERVER, ConTimes, this, "/times ?s?i shows last 5 times of the server or of a player beginning with name s starting with time i (i = 1 by default, -1 for first)")
+CHAT_COMMAND("times", "?r[player name] ?i[number of times to skip]", CFGFLAG_CHAT | CFGFLAG_SERVER, ConTimes, this, "/times ?r?i shows last 5 times of the server or of a player beginning with name s starting with time i (i = 1 by default, -1 for first)")
 CHAT_COMMAND("points", "?r[player name]", CFGFLAG_CHAT | CFGFLAG_SERVER, ConPoints, this, "Shows the global points of a player beginning with name r (your rank by default)")
 CHAT_COMMAND("top5points", "?i[number]", CFGFLAG_CHAT | CFGFLAG_SERVER, ConTopPoints, this, "Shows five points of the global point ladder beginning with rank i (1 by default)")
 CHAT_COMMAND("timecp", "?r[player name]", CFGFLAG_CHAT | CFGFLAG_SERVER, ConTimeCP, this, "Set your checkpoints based on another player")

--- a/src/game/ddracechat.h
+++ b/src/game/ddracechat.h
@@ -36,8 +36,8 @@ CHAT_COMMAND("rankteam", "?r[player name]", CFGFLAG_CHAT | CFGFLAG_SERVER, ConTe
 CHAT_COMMAND("teamrank", "?r[player name]", CFGFLAG_CHAT | CFGFLAG_SERVER, ConTeamRank, this, "Shows the team rank of player with name r (your team rank by default)")
 
 CHAT_COMMAND("rank", "?r[player name]", CFGFLAG_CHAT | CFGFLAG_SERVER, ConRank, this, "Shows the rank of player with name r (your rank by default)")
-CHAT_COMMAND("top5team", "?s[player name] ?i[rank to start with]", CFGFLAG_CHAT | CFGFLAG_SERVER, ConTeamTop5, this, "Shows five team ranks of the ladder or of a player beginning with rank i (1 by default, -1 for worst)")
-CHAT_COMMAND("teamtop5", "?s[player name] ?i[rank to start with]", CFGFLAG_CHAT | CFGFLAG_SERVER, ConTeamTop5, this, "Shows five team ranks of the ladder or of a player beginning with rank i (1 by default, -1 for worst)")
+CHAT_COMMAND("top5team", "?r[player name] ?i[rank to start with]", CFGFLAG_CHAT | CFGFLAG_SERVER, ConTeamTop5, this, "Shows five team ranks of the ladder or of a player beginning with rank i (1 by default, -1 for worst)")
+CHAT_COMMAND("teamtop5", "?r[player name] ?i[rank to start with]", CFGFLAG_CHAT | CFGFLAG_SERVER, ConTeamTop5, this, "Shows five team ranks of the ladder or of a player beginning with rank i (1 by default, -1 for worst)")
 CHAT_COMMAND("top", "?i[rank to start with]", CFGFLAG_CHAT | CFGFLAG_SERVER, ConTop, this, "Shows the top ranks of the global and regional ladder beginning with rank i (1 by default, -1 for worst)")
 CHAT_COMMAND("top5", "?i[rank to start with]", CFGFLAG_CHAT | CFGFLAG_SERVER, ConTop, this, "Shows the top ranks of the global and regional ladder beginning with rank i (1 by default, -1 for worst)")
 CHAT_COMMAND("times", "?s[player name] ?i[number of times to skip]", CFGFLAG_CHAT | CFGFLAG_SERVER, ConTimes, this, "/times ?s?i shows last 5 times of the server or of a player beginning with name s starting with time i (i = 1 by default, -1 for first)")

--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -394,7 +394,6 @@ void CGameContext::ConTeamTop5(IConsole::IResult *pResult, void *pUserData)
 	CGameContext *pSelf = (CGameContext *)pUserData;
 	if(!CheckClientID(pResult->m_ClientID))
 		return;
-
 	if(g_Config.m_SvHideScore)
 	{
 		pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "chatresp",
@@ -405,33 +404,41 @@ void CGameContext::ConTeamTop5(IConsole::IResult *pResult, void *pUserData)
 	if(pResult->NumArguments() == 0)
 	{
 		pSelf->Score()->ShowTeamTop5(pResult->m_ClientID, 1);
+		return;
 	}
-	else if(pResult->NumArguments() == 1)
+	
+	if (pResult->NumArguments() == 1 && pResult->GetInteger(0) != 0) {
+		pSelf->Score()->ShowTeamTop5(pResult->m_ClientID, pResult->GetInteger(0));
+		return;
+	}
+	char *pStr = (char *)pResult->GetString(0);
+	char *pName;
+	int index;
+	if (pResult->NumArguments() == 1) {
+
+		pSelf->ParseNameAndIndex(pStr, pName, index);
+	}
+
+	if(pResult->NumArguments() == 1 && index == 0)
 	{
-		if(pResult->GetInteger(0) != 0)
-		{
-			pSelf->Score()->ShowTeamTop5(pResult->m_ClientID, pResult->GetInteger(0));
-		}
-		else
-		{
-			const char *pRequestedName = (str_comp(pResult->GetString(0), "me") == 0) ?
-							     pSelf->Server()->ClientName(pResult->m_ClientID) :
-							     pResult->GetString(0);
-			pSelf->Score()->ShowPlayerTeamTop5(pResult->m_ClientID, pRequestedName, 0);
-		}
+		const char *pRequestedName = (str_comp(pName, "me") == 0) ?
+								pSelf->Server()->ClientName(pResult->m_ClientID) :
+								pName;
+		pSelf->Score()->ShowPlayerTeamTop5(pResult->m_ClientID, pRequestedName, 0);
 	}
-	else if(pResult->NumArguments() == 2 && pResult->GetInteger(1) != 0)
+	else if(pResult->NumArguments() == 1 && index != 0)
+	{
+		const char *pRequestedName = (str_comp(pName, "me") == 0) ?
+						     pSelf->Server()->ClientName(pResult->m_ClientID) :
+						     pName;
+		pSelf->Score()->ShowPlayerTeamTop5(pResult->m_ClientID, pRequestedName, index);
+	}
+	else if(pResult->NumArguments() == 2)
 	{
 		const char *pRequestedName = (str_comp(pResult->GetString(0), "me") == 0) ?
 						     pSelf->Server()->ClientName(pResult->m_ClientID) :
 						     pResult->GetString(0);
 		pSelf->Score()->ShowPlayerTeamTop5(pResult->m_ClientID, pRequestedName, pResult->GetInteger(1));
-	}
-	else
-	{
-		pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "chatresp", "/top5team needs 0, 1 or 2 parameter. 1. = name, 2. = start number");
-		pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "chatresp", "Example: /top5team, /top5team me, /top5team Hans, /top5team \"Papa Smurf\" 5");
-		pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "chatresp", "Bad: /top5team Papa Smurf 5 # Good: /top5team \"Papa Smurf\" 5 ");
 	}
 }
 

--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -406,24 +406,25 @@ void CGameContext::ConTeamTop5(IConsole::IResult *pResult, void *pUserData)
 		pSelf->Score()->ShowTeamTop5(pResult->m_ClientID, 1);
 		return;
 	}
-	
-	if (pResult->NumArguments() == 1 && pResult->GetInteger(0) != 0) {
+
+	if(pResult->NumArguments() == 1 && pResult->GetInteger(0) != 0)
+	{
 		pSelf->Score()->ShowTeamTop5(pResult->m_ClientID, pResult->GetInteger(0));
 		return;
 	}
 	char *pStr = (char *)pResult->GetString(0);
 	char *pName;
 	int index;
-	if (pResult->NumArguments() == 1) {
-
+	if(pResult->NumArguments() == 1)
+	{
 		pSelf->ParseNameAndIndex(pStr, pName, index);
 	}
 
 	if(pResult->NumArguments() == 1 && index == 0)
 	{
 		const char *pRequestedName = (str_comp(pName, "me") == 0) ?
-								pSelf->Server()->ClientName(pResult->m_ClientID) :
-								pName;
+						     pSelf->Server()->ClientName(pResult->m_ClientID) :
+						     pName;
 		pSelf->Score()->ShowPlayerTeamTop5(pResult->m_ClientID, pRequestedName, 0);
 	}
 	else if(pResult->NumArguments() == 1 && index != 0)
@@ -487,8 +488,8 @@ void CGameContext::ConTimes(IConsole::IResult *pResult, void *pUserData)
 		pSelf->ParseNameAndIndex(pStr, pName, index);
 
 		const char *pRequestedName = (str_comp(pName, "me") == 0) ?
-								pSelf->Server()->ClientName(pResult->m_ClientID) :
-								pName;
+						     pSelf->Server()->ClientName(pResult->m_ClientID) :
+						     pName;
 		pSelf->Score()->ShowTimes(pResult->m_ClientID, pRequestedName, index);
 	}
 	else if(pResult->NumArguments() == 2 && pResult->GetInteger(1) != 0)

--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -470,20 +470,26 @@ void CGameContext::ConTimes(IConsole::IResult *pResult, void *pUserData)
 	if(pResult->NumArguments() == 0)
 	{
 		pSelf->Score()->ShowTimes(pResult->m_ClientID, 1);
+		return;
 	}
-	else if(pResult->NumArguments() == 1)
+
+	if(pResult->NumArguments() == 1)
 	{
 		if(pResult->GetInteger(0) != 0)
 		{
 			pSelf->Score()->ShowTimes(pResult->m_ClientID, pResult->GetInteger(0));
+			return;
 		}
-		else
-		{
-			const char *pRequestedName = (str_comp(pResult->GetString(0), "me") == 0) ?
-							     pSelf->Server()->ClientName(pResult->m_ClientID) :
-							     pResult->GetString(0);
-			pSelf->Score()->ShowTimes(pResult->m_ClientID, pRequestedName, pResult->GetInteger(1));
-		}
+
+		char *pStr = (char *)pResult->GetString(0);
+		char *pName;
+		int index;
+		pSelf->ParseNameAndIndex(pStr, pName, index);
+
+		const char *pRequestedName = (str_comp(pName, "me") == 0) ?
+								pSelf->Server()->ClientName(pResult->m_ClientID) :
+								pName;
+		pSelf->Score()->ShowTimes(pResult->m_ClientID, pRequestedName, index);
 	}
 	else if(pResult->NumArguments() == 2 && pResult->GetInteger(1) != 0)
 	{
@@ -496,7 +502,6 @@ void CGameContext::ConTimes(IConsole::IResult *pResult, void *pUserData)
 	{
 		pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "chatresp", "/times needs 0, 1 or 2 parameter. 1. = name, 2. = start number");
 		pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "chatresp", "Example: /times, /times me, /times Hans, /times \"Papa Smurf\" 5");
-		pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "chatresp", "Bad: /times Papa Smurf 5 # Good: /times \"Papa Smurf\" 5 ");
 	}
 }
 

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -4303,35 +4303,32 @@ bool CheckClientID2(int ClientID)
 
 bool CGameContext::ParseNameAndIndex(char *&pStr, char *&pName, int &index)
 {
-    pStr = str_skip_whitespaces(pStr);
-    bool NumFound = true;
+	pStr = str_skip_whitespaces(pStr);
+	bool NumFound = true;
 	index = 0;
-    // Check if the text ends with a number
-    size_t len = str_length(pStr);
-    size_t lastDigitIndex = len;
-    while (lastDigitIndex > 0 
-		&& ((pStr[lastDigitIndex - 1] >= '0' 
-		&& pStr[lastDigitIndex - 1] <= '9')
-		|| pStr[lastDigitIndex - 1] == '-'))
-    {
-        lastDigitIndex--;
-    }
+	// Check if the text ends with a number
+	size_t len = str_length(pStr);
+	size_t lastDigitIndex = len;
+	while(lastDigitIndex > 0 && ((pStr[lastDigitIndex - 1] >= '0' && pStr[lastDigitIndex - 1] <= '9') || pStr[lastDigitIndex - 1] == '-'))
+	{
+		lastDigitIndex--;
+	}
 
-    // Extract player name
+	// Extract player name
 	pName = pStr;
-    if (lastDigitIndex < len)
-    {
+	if(lastDigitIndex < len)
+	{
 		pStr[lastDigitIndex - 1] = 0;
-        // Parse the index
-        index = str_toint(&pStr[lastDigitIndex]);
-    }
-    else
-    {
-        // No number found at the end, set error
-        NumFound = false;
-    }
+		// Parse the index
+		index = str_toint(&pStr[lastDigitIndex]);
+	}
+	else
+	{
+		// No number found at the end, set error
+		NumFound = false;
+	}
 
-    return NumFound;
+	return NumFound;
 }
 
 void CGameContext::Whisper(int ClientID, char *pStr)

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -4310,8 +4310,9 @@ bool CGameContext::ParseNameAndIndex(char *&pStr, char *&pName, int &index)
     size_t len = str_length(pStr);
     size_t lastDigitIndex = len;
     while (lastDigitIndex > 0 
-		&& pStr[lastDigitIndex - 1] >= '0' 
+		&& ((pStr[lastDigitIndex - 1] >= '0' 
 		&& pStr[lastDigitIndex - 1] <= '9')
+		|| pStr[lastDigitIndex - 1] == '-'))
     {
         lastDigitIndex--;
     }

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -4301,6 +4301,38 @@ bool CheckClientID2(int ClientID)
 	return ClientID >= 0 && ClientID < MAX_CLIENTS;
 }
 
+bool CGameContext::ParseNameAndIndex(char *&pStr, char *&pName, int &index)
+{
+    pStr = str_skip_whitespaces(pStr);
+    bool NumFound = true;
+	index = 0;
+    // Check if the text ends with a number
+    size_t len = str_length(pStr);
+    size_t lastDigitIndex = len;
+    while (lastDigitIndex > 0 
+		&& pStr[lastDigitIndex - 1] >= '0' 
+		&& pStr[lastDigitIndex - 1] <= '9')
+    {
+        lastDigitIndex--;
+    }
+
+    // Extract player name
+	pName = pStr;
+    if (lastDigitIndex < len)
+    {
+		pStr[lastDigitIndex - 1] = 0;
+        // Parse the index
+        index = str_toint(&pStr[lastDigitIndex]);
+    }
+    else
+    {
+        // No number found at the end, set error
+        NumFound = false;
+    }
+
+    return NumFound;
+}
+
 void CGameContext::Whisper(int ClientID, char *pStr)
 {
 	if(ProcessSpamProtection(ClientID))

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -498,6 +498,8 @@ private:
 	int m_NumMutes;
 	CMute m_aVoteMutes[MAX_VOTE_MUTES];
 	int m_NumVoteMutes;
+	bool ParseNameAndIndex(char *&pStr, char *&pName, int &index);
+	
 	bool TryMute(const NETADDR *pAddr, int Secs, const char *pReason, bool InitialChatDelay);
 	void Mute(const NETADDR *pAddr, int Secs, const char *pDisplayName, const char *pReason = "", bool InitialChatDelay = false);
 	bool TryVoteMute(const NETADDR *pAddr, int Secs, const char *pReason);

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -499,7 +499,7 @@ private:
 	CMute m_aVoteMutes[MAX_VOTE_MUTES];
 	int m_NumVoteMutes;
 	bool ParseNameAndIndex(char *&pStr, char *&pName, int &index);
-	
+
 	bool TryMute(const NETADDR *pAddr, int Secs, const char *pReason, bool InitialChatDelay);
 	void Mute(const NETADDR *pAddr, int Secs, const char *pDisplayName, const char *pReason = "", bool InitialChatDelay = false);
 	bool TryVoteMute(const NETADDR *pAddr, int Secs, const char *pReason);


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->
It always annoyed me to type /times "Nudelsaft c:" manually when checking times.
<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->
This PR allows using '/times Nudelsaft c: 5' while also allowing '/times "Nudelsaft c:" 5' (same for /top5team)
## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
