### PR TITLE
Don't warn about unfinishable map for super team

### DIFF
--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -266,7 +266,6 @@ void CGameTeams::Tick()
 	}
 	for(int i = 0; i < MAX_CLIENTS; i++)
 	{
-		bool TeamHasSuperCharacter = false;
 		if(((TeamHasWantedStartTime >> i) & 1) == 0)
 		{
 			continue;
@@ -275,13 +274,14 @@ void CGameTeams::Tick()
 		{
 			continue;
 		}
+		bool TeamHasCheatCharacter = false;
 		int NumPlayersNotStarted = 0;
 		char aPlayerNames[256];
 		aPlayerNames[0] = 0;
 		for(int j = 0; j < MAX_CLIENTS; j++)
 		{
-			if(GameServer()->GetPlayerChar(j) && GameServer()->GetPlayerChar(j)->IsSuper())
-				TeamHasSuperCharacter = true;
+			if(Character(j) && Character(j)->m_DDRaceState == DDRACE_CHEAT)
+				TeamHasCheatCharacter = true;
 			if(m_Core.Team(j) == i && !m_aTeeStarted[j])
 			{
 				if(aPlayerNames[0])
@@ -292,7 +292,7 @@ void CGameTeams::Tick()
 				NumPlayersNotStarted += 1;
 			}
 		}
-		if(!aPlayerNames[0] || TeamHasSuperCharacter)
+		if(!aPlayerNames[0] || TeamHasCheatCharacter)
 		{
 			continue;
 		}

--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -266,6 +266,7 @@ void CGameTeams::Tick()
 	}
 	for(int i = 0; i < MAX_CLIENTS; i++)
 	{
+		bool TeamHasSuperCharacter = false;
 		if(((TeamHasWantedStartTime >> i) & 1) == 0)
 		{
 			continue;
@@ -279,6 +280,8 @@ void CGameTeams::Tick()
 		aPlayerNames[0] = 0;
 		for(int j = 0; j < MAX_CLIENTS; j++)
 		{
+			if(GameServer()->GetPlayerChar(j) && GameServer()->GetPlayerChar(j)->IsSuper())
+				TeamHasSuperCharacter = true;
 			if(m_Core.Team(j) == i && !m_aTeeStarted[j])
 			{
 				if(aPlayerNames[0])
@@ -289,7 +292,7 @@ void CGameTeams::Tick()
 				NumPlayersNotStarted += 1;
 			}
 		}
-		if(!aPlayerNames[0])
+		if(!aPlayerNames[0] || TeamHasSuperCharacter)
 		{
 			continue;
 		}


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

Solves #4205 (Is there a variable to check if team had cheated before? Player can disable super and continue to receive this annoying message)

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
