### PR TITLE
Fix warning title being uninitialized in some cases

### DIFF
--- a/src/engine/client/warning.cpp
+++ b/src/engine/client/warning.cpp
@@ -4,7 +4,6 @@
 
 SWarning::SWarning(const char *pMsg)
 {
-	str_copy(m_aWarningTitle, "");
 	str_copy(m_aWarningMsg, pMsg);
 }
 SWarning::SWarning(const char *pTitle, const char *pMsg)

--- a/src/engine/warning.h
+++ b/src/engine/warning.h
@@ -7,8 +7,8 @@ struct SWarning
 	SWarning(const char *pMsg);
 	SWarning(const char *pTitle, const char *pMsg);
 
-	char m_aWarningTitle[128];
-	char m_aWarningMsg[256];
+	char m_aWarningTitle[128] = "";
+	char m_aWarningMsg[256] = "";
 	bool m_WasShown = false;
 	bool m_AutoHide = true;
 };


### PR DESCRIPTION
For some warnings a random title instead of the default title was shown because it was not initialized.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
