### PR TITLE
Allow finer editor grid

### DIFF
--- a/src/game/editor/map_grid.cpp
+++ b/src/game/editor/map_grid.cpp
@@ -63,7 +63,11 @@ void CMapGrid::OnRender(CUIRect View)
 
 int CMapGrid::GridLineDistance() const
 {
-	if(Editor()->MapView()->Zoom()->GetValue() <= 100.0f)
+	if(Editor()->MapView()->Zoom()->GetValue() <= 10.0f)
+		return 4;
+	else if(Editor()->MapView()->Zoom()->GetValue() <= 50.0f)
+		return 8;
+	else if(Editor()->MapView()->Zoom()->GetValue() <= 100.0f)
 		return 16;
 	else if(Editor()->MapView()->Zoom()->GetValue() <= 250.0f)
 		return 32;


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->
Sometimes a smaller grid is useful. Now it goes up to 1/8 tile on max zoom in.
<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
