### PR TITLE
Only log http requests if ``dbg_curl 1``

### DIFF
--- a/src/engine/shared/http.cpp
+++ b/src/engine/shared/http.cpp
@@ -507,7 +507,8 @@ void CHttp::RunLoop()
 		while(!NewRequests.empty())
 		{
 			auto &pRequest = NewRequests.front();
-			dbg_msg("http", "task: %s %s", CHttpRequest::GetRequestType(pRequest->m_Type), pRequest->m_aUrl);
+			if(g_Config.m_DbgCurl)
+				dbg_msg("http", "task: %s %s", CHttpRequest::GetRequestType(pRequest->m_Type), pRequest->m_aUrl);
 
 			CURL *pEH = curl_easy_init();
 			if(!pEH)


### PR DESCRIPTION
closed #7823

```
$ DDNet-Server "sv_register 1"
```

behind nat with errors looks like this
https://logs.zillyhuhn.com/?url=https://paste.zillyhuhn.com/M9

and a successful register looks like this
https://logs.zillyhuhn.com/?url=https://paste.zillyhuhn.com/Hy


```
$ DDNet-Server "sv_register 1;dbg_curl 1"
```
successful register looks like this
https://logs.zillyhuhn.com/?url=https://paste.zillyhuhn.com/k8

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
