### PR TITLE
Finish `CHttpRequest::OnCompletion` before updating `State()`

### DIFF
--- a/src/engine/client/updater.cpp
+++ b/src/engine/client/updater.cpp
@@ -24,7 +24,7 @@ class CUpdaterFetchTask : public CHttpRequest
 	void OnProgress() override;
 
 protected:
-	void OnCompletion() override;
+	void OnCompletion(int State) override;
 
 public:
 	CUpdaterFetchTask(CUpdater *pUpdater, const char *pFile, const char *pDestPath);
@@ -59,7 +59,7 @@ void CUpdaterFetchTask::OnProgress()
 	m_pUpdater->m_Percent = Progress();
 }
 
-void CUpdaterFetchTask::OnCompletion()
+void CUpdaterFetchTask::OnCompletion(int State)
 {
 	const char *pFileName = 0;
 	for(const char *pPath = Dest(); *pPath; pPath++)
@@ -68,9 +68,9 @@ void CUpdaterFetchTask::OnCompletion()
 	pFileName = pFileName ? pFileName : Dest();
 	if(!str_comp(pFileName, "update.json"))
 	{
-		if(State() == HTTP_DONE)
+		if(State == HTTP_DONE)
 			m_pUpdater->SetCurrentState(IUpdater::GOT_MANIFEST);
-		else if(State() == HTTP_ERROR)
+		else if(State == HTTP_ERROR)
 			m_pUpdater->SetCurrentState(IUpdater::FAIL);
 	}
 }

--- a/src/engine/shared/http.cpp
+++ b/src/engine/shared/http.cpp
@@ -324,8 +324,11 @@ void CHttpRequest::OnCompletionInternal(std::optional<unsigned int> Result)
 		}
 	}
 
+	// The globally visible state must be updated after OnCompletion has finished,
+	// or other threads may try to access the result of a completed HTTP request,
+	// before the result has been initialized/updated in OnCompletion.
+	OnCompletion(State);
 	m_State = State;
-	OnCompletion();
 }
 
 void CHttpRequest::WriteToFile(IStorage *pStorage, const char *pDest, int StorageType)

--- a/src/engine/shared/http.h
+++ b/src/engine/shared/http.h
@@ -128,8 +128,8 @@ class CHttpRequest : public IHttpRequest
 
 protected:
 	// These run on the curl thread now, DO NOT STALL THE THREAD
-	virtual void OnProgress(){};
-	virtual void OnCompletion(){};
+	virtual void OnProgress() {}
+	virtual void OnCompletion(int State) {}
 
 public:
 	CHttpRequest(const char *pUrl);

--- a/src/game/client/components/skins.cpp
+++ b/src/game/client/components/skins.cpp
@@ -21,10 +21,10 @@ bool CSkins::IsVanillaSkin(const char *pName)
 	return std::any_of(std::begin(VANILLA_SKINS), std::end(VANILLA_SKINS), [pName](const char *pVanillaSkin) { return str_comp(pName, pVanillaSkin) == 0; });
 }
 
-void CSkins::CGetPngFile::OnCompletion()
+void CSkins::CGetPngFile::OnCompletion(int State)
 {
 	// Maybe this should start another thread to load the png in instead of stalling the curl thread
-	if(State() != HTTP_ERROR && State() != HTTP_ABORTED)
+	if(State == HTTP_DONE)
 	{
 		m_pSkins->LoadSkinPNG(m_Info, Dest(), Dest(), IStorage::TYPE_SAVE);
 	}
@@ -410,7 +410,7 @@ const CSkin *CSkins::FindImpl(const char *pName)
 	const auto SkinDownloadIt = m_DownloadSkins.find(pName);
 	if(SkinDownloadIt != m_DownloadSkins.end())
 	{
-		if(SkinDownloadIt->second->m_pTask && SkinDownloadIt->second->m_pTask->State() == HTTP_DONE)
+		if(SkinDownloadIt->second->m_pTask && SkinDownloadIt->second->m_pTask->State() == HTTP_DONE && SkinDownloadIt->second->m_pTask->m_Info.m_pData)
 		{
 			char aPath[IO_MAX_PATH_LENGTH];
 			str_format(aPath, sizeof(aPath), "downloadedskins/%s.png", SkinDownloadIt->second->GetName());

--- a/src/game/client/components/skins.h
+++ b/src/game/client/components/skins.h
@@ -20,7 +20,7 @@ public:
 		CSkins *m_pSkins;
 
 	protected:
-		virtual void OnCompletion() override;
+		virtual void OnCompletion(int State) override;
 
 	public:
 		CGetPngFile(CSkins *pSkins, const char *pUrl, IStorage *pStorage, const char *pDest);


### PR DESCRIPTION
Ensure that the `CHttpRequest::OnCompletion` function has finished before updating the state which is visible to other threads. Otherwise, threads may try to access the result of a completed HTTP request, before the result has been initialized/updated in the `OnCompletion` function.

Fixes warning due to invalid texture width/height being shown for downloaded skins, because the texture was loaded before the image data was initialized. Closes #7818.

Regression from #7683. Before this, the `OnCompletion` function could also modify the HTTP request's state, which was used to check if loading the skin PNG failed. Instead of doing this, a separate check is added for the skin download task to check that the PNG was loaded successfully.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
