### PR TITLE
Fix countries/types filters excluding all servers

### DIFF
--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -1569,8 +1569,8 @@ void CServerBrowser::CommunitiesFilterClean()
 void CServerBrowser::CountriesFilterClean()
 {
 	std::vector<const char *> vpCountryNames;
-	for(const auto &Community : Communities())
-		for(const auto &Country : Community.Countries())
+	for(const CCommunity *pCommunity : SelectedCommunities())
+		for(const auto &Country : pCommunity->Countries())
 			vpCountryNames.push_back(Country.Name());
 	m_CountriesFilter.Clean(vpCountryNames);
 }
@@ -1578,8 +1578,8 @@ void CServerBrowser::CountriesFilterClean()
 void CServerBrowser::TypesFilterClean()
 {
 	std::vector<const char *> vpTypeNames;
-	for(const auto &Community : Communities())
-		for(const auto &Type : Community.Types())
+	for(const CCommunity *pCommunity : SelectedCommunities())
+		for(const auto &Type : pCommunity->Types())
 			vpTypeNames.push_back(Type.Name());
 	m_TypesFilter.Clean(vpTypeNames);
 }

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1743,7 +1743,6 @@ void CMenus::ConchainCommunitiesUpdate(IConsole::IResult *pResult, void *pUserDa
 	CMenus *pThis = static_cast<CMenus *>(pUserData);
 	if(pResult->NumArguments() >= 1 && (g_Config.m_UiPage == PAGE_INTERNET || g_Config.m_UiPage == PAGE_FAVORITES))
 	{
-		pThis->ServerBrowser()->CleanFilters();
 		pThis->UpdateCommunityCache(true);
 		pThis->Client()->ServerBrowserUpdate();
 	}
@@ -1754,6 +1753,8 @@ void CMenus::UpdateCommunityCache(bool Force)
 	const bool PageWithCommunities = g_Config.m_UiPage == PAGE_INTERNET || g_Config.m_UiPage == PAGE_FAVORITES;
 	if(!Force && m_CommunityCache.m_UpdateTime != 0 && m_CommunityCache.m_UpdateTime == ServerBrowser()->DDNetInfoUpdateTime() && m_CommunityCache.m_PageWithCommunities == PageWithCommunities)
 		return;
+
+	ServerBrowser()->CleanFilters();
 
 	m_CommunityCache.m_UpdateTime = ServerBrowser()->DDNetInfoUpdateTime();
 	m_CommunityCache.m_PageWithCommunities = PageWithCommunities;


### PR DESCRIPTION
Instead of cleaning the countries/types filters based on all available communities' countries/types, only consider the countries/types of currently selected communities. Ensure countries/types are always cleaned when updating the server browser filter in the UI. This fixes that countries/types which are not available for the selected communities were still affecting the server filtering, causing no servers to be shown in some cases.

Closes #7847.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
