### PR TITLE
Show extra "Reset filter" button when no servers match filter

### DIFF
--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -461,6 +461,7 @@ protected:
 	void Connect(const char *pAddress);
 	void PopupConfirmSwitchServer();
 	void RenderServerbrowserFilters(CUIRect View);
+	void ResetServerbrowserFilters();
 	void RenderServerbrowserDDNetFilter(CUIRect View,
 		IFilterList &Filter,
 		float ItemHeight, int MaxItems, int ItemsPerRow,

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -199,11 +199,27 @@ void CMenus::RenderServerbrowserServerList(CUIRect View, bool &WasListboxItemAct
 	// users misses it
 	{
 		if(!ServerBrowser()->NumServers() && ServerBrowser()->IsGettingServerlist())
+		{
 			UI()->DoLabel(&View, Localize("Getting server list from master server"), 16.0f, TEXTALIGN_MC);
+		}
 		else if(!ServerBrowser()->NumServers())
+		{
 			UI()->DoLabel(&View, Localize("No servers found"), 16.0f, TEXTALIGN_MC);
+		}
 		else if(ServerBrowser()->NumServers() && !NumServers)
-			UI()->DoLabel(&View, Localize("No servers match your filter criteria"), 16.0f, TEXTALIGN_MC);
+		{
+			CUIRect Label, ResetButton;
+			View.HMargin((View.h - (16.0f + 18.0f + 8.0f)) / 2.0f, &Label);
+			Label.HSplitTop(16.0f, &Label, &ResetButton);
+			ResetButton.HSplitTop(8.0f, nullptr, &ResetButton);
+			ResetButton.VMargin((ResetButton.w - 200.0f) / 2.0f, &ResetButton);
+			UI()->DoLabel(&Label, Localize("No servers match your filter criteria"), 16.0f, TEXTALIGN_MC);
+			static CButtonContainer s_ResetButton;
+			if(DoButton_Menu(&s_ResetButton, Localize("Reset filter"), 0, &ResetButton))
+			{
+				ResetServerbrowserFilters();
+			}
+		}
 	}
 
 	s_ListBox.SetActive(!UI()->IsPopupOpen());
@@ -767,26 +783,31 @@ void CMenus::RenderServerbrowserFilters(CUIRect View)
 	static CButtonContainer s_ResetButton;
 	if(DoButton_Menu(&s_ResetButton, Localize("Reset filter"), 0, &ResetButton))
 	{
-		g_Config.m_BrFilterString[0] = '\0';
-		g_Config.m_BrExcludeString[0] = '\0';
-		g_Config.m_BrFilterFull = 0;
-		g_Config.m_BrFilterEmpty = 0;
-		g_Config.m_BrFilterSpectators = 0;
-		g_Config.m_BrFilterFriends = 0;
-		g_Config.m_BrFilterCountry = 0;
-		g_Config.m_BrFilterCountryIndex = -1;
-		g_Config.m_BrFilterPw = 0;
-		g_Config.m_BrFilterGametype[0] = '\0';
-		g_Config.m_BrFilterGametypeStrict = 0;
-		g_Config.m_BrFilterConnectingPlayers = 1;
-		g_Config.m_BrFilterUnfinishedMap = 0;
-		g_Config.m_BrFilterServerAddress[0] = '\0';
-		ConfigManager()->Reset("br_filter_exclude_communities");
-		ConfigManager()->Reset("br_filter_exclude_countries");
-		ConfigManager()->Reset("br_filter_exclude_types");
-		Client()->ServerBrowserUpdate();
-		UpdateCommunityCache(true);
+		ResetServerbrowserFilters();
 	}
+}
+
+void CMenus::ResetServerbrowserFilters()
+{
+	g_Config.m_BrFilterString[0] = '\0';
+	g_Config.m_BrExcludeString[0] = '\0';
+	g_Config.m_BrFilterFull = 0;
+	g_Config.m_BrFilterEmpty = 0;
+	g_Config.m_BrFilterSpectators = 0;
+	g_Config.m_BrFilterFriends = 0;
+	g_Config.m_BrFilterCountry = 0;
+	g_Config.m_BrFilterCountryIndex = -1;
+	g_Config.m_BrFilterPw = 0;
+	g_Config.m_BrFilterGametype[0] = '\0';
+	g_Config.m_BrFilterGametypeStrict = 0;
+	g_Config.m_BrFilterConnectingPlayers = 1;
+	g_Config.m_BrFilterUnfinishedMap = 0;
+	g_Config.m_BrFilterServerAddress[0] = '\0';
+	ConfigManager()->Reset("br_filter_exclude_communities");
+	ConfigManager()->Reset("br_filter_exclude_countries");
+	ConfigManager()->Reset("br_filter_exclude_types");
+	Client()->ServerBrowserUpdate();
+	UpdateCommunityCache(true);
 }
 
 void CMenus::RenderServerbrowserDDNetFilter(CUIRect View,


### PR DESCRIPTION
Render an additional "Reset filter" button below the "No servers match your filter criteria" message to make it more obvious for new players how to restore the original view of servers, especially when the filter tab is not currently selected.

Screenshots:
- Before: 
![screenshot_2024-01-23_20-59-20](https://github.com/ddnet/ddnet/assets/23437060/0ff4f48c-596c-4b40-8dd9-c79391710ac6)

- After: 
![screenshot_2024-01-23_20-57-53](https://github.com/ddnet/ddnet/assets/23437060/ef7bb0fa-7360-4b0e-b9c0-fe1358300976)


## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
