### PR TITLE
Ensure client window is maximized and active after restarting, refactoring

### DIFF
--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -4106,7 +4106,7 @@ void cmdline_free(int argc, const char **argv)
 #endif
 }
 
-PROCESS shell_execute(const char *file)
+PROCESS shell_execute(const char *file, EShellExecuteWindowState window_state)
 {
 #if defined(CONF_FAMILY_WINDOWS)
 	const std::wstring wide_file = windows_utf8_to_wide(file);
@@ -4116,7 +4116,18 @@ PROCESS shell_execute(const char *file)
 	info.cbSize = sizeof(SHELLEXECUTEINFOW);
 	info.lpVerb = L"open";
 	info.lpFile = wide_file.c_str();
-	info.nShow = SW_SHOWMINNOACTIVE;
+	switch(window_state)
+	{
+	case EShellExecuteWindowState::FOREGROUND:
+		info.nShow = SW_SHOW;
+		break;
+	case EShellExecuteWindowState::BACKGROUND:
+		info.nShow = SW_SHOWMINNOACTIVE;
+		break;
+	default:
+		dbg_assert(false, "window_state invalid");
+		dbg_break();
+	}
 	info.fMask = SEE_MASK_NOCLOSEPROCESS;
 	// Save and restore the FPU control word because ShellExecute might change it
 	fenv_t floating_point_environment;

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -2517,26 +2517,23 @@ typedef pid_t PROCESS;
 constexpr PROCESS INVALID_PROCESS = 0;
 #endif
 
-/*
-	Function: shell_execute
-		Executes a given file.
 
-	Returns:
-		handle/pid of the new process
-*/
+/**
+ * Executes a given file.
+ *
+ * @param file The file to execute.
+ *
+ * @return Handle of the new process, or `INVALID_PROCESS` on error.
+ */
 PROCESS shell_execute(const char *file);
 
-/*
-	Function: kill_process
-		Sends kill signal to a process.
-
-	Parameters:
-		process - handle/pid of the process
-
-	Returns:
-		0 - Error
-		1 - Success
-*/
+/**
+ * Sends kill signal to a process.
+ *
+ * @param process Handle of the process to kill.
+ *
+ * @return 1 on success, 0 on error.
+ */
 int kill_process(PROCESS process);
 
 /**

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -2517,15 +2517,21 @@ typedef pid_t PROCESS;
 constexpr PROCESS INVALID_PROCESS = 0;
 #endif
 
+enum class EShellExecuteWindowState
+{
+	FOREGROUND,
+	BACKGROUND,
+};
 
 /**
  * Executes a given file.
  *
  * @param file The file to execute.
+ * @param window_state The window state how the process window should be shown.
  *
  * @return Handle of the new process, or `INVALID_PROCESS` on error.
  */
-PROCESS shell_execute(const char *file);
+PROCESS shell_execute(const char *file, EShellExecuteWindowState window_state);
 
 /**
  * Sends kill signal to a process.

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -4508,7 +4508,7 @@ int main(int argc, const char **argv)
 
 	if(Restarting)
 	{
-		shell_execute(aRestartBinaryPath);
+		shell_execute(aRestartBinaryPath, EShellExecuteWindowState::FOREGROUND);
 	}
 
 	PerformFinalCleanup();

--- a/src/game/client/components/menus_start.cpp
+++ b/src/game/client/components/menus_start.cpp
@@ -148,7 +148,7 @@ void CMenus::RenderStartMenu(CUIRect MainView)
 			// No / in binary path means to search in $PATH, so it is expected that the file can't be opened. Just try executing anyway.
 			if(str_find(aBuf, "/") == 0 || fs_is_file(aBuf))
 			{
-				m_ServerProcess.m_Process = shell_execute(aBuf);
+				m_ServerProcess.m_Process = shell_execute(aBuf, EShellExecuteWindowState::BACKGROUND);
 			}
 			else
 			{

--- a/src/game/client/components/menus_start.cpp
+++ b/src/game/client/components/menus_start.cpp
@@ -146,11 +146,7 @@ void CMenus::RenderStartMenu(CUIRect MainView)
 			char aBuf[IO_MAX_PATH_LENGTH];
 			Storage()->GetBinaryPath(PLAT_SERVER_EXEC, aBuf, sizeof(aBuf));
 			// No / in binary path means to search in $PATH, so it is expected that the file can't be opened. Just try executing anyway.
-			if(str_find(aBuf, "/") == 0)
-			{
-				m_ServerProcess.m_Process = shell_execute(aBuf);
-			}
-			else if(fs_is_file(aBuf))
+			if(str_find(aBuf, "/") == 0 || fs_is_file(aBuf))
 			{
 				m_ServerProcess.m_Process = shell_execute(aBuf);
 			}


### PR DESCRIPTION
Add parameter to `shell_execute` to either start the process in the foreground or background on Windows. Previously, all processes were started in the background, because this is desired when starting the server from the client. However, this causes the graphics initialization to fail when restarting the client after updating or with the `restart` command when using Vulkan with windowed and windowed fullscreen mode.

Closes #6578.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
