### PR TITLE
TeeInfo: Fix blue and limekitty eyes and feet 0.6 -> 0.7 mapping

### DIFF
--- a/src/game/server/teeinfo.cpp
+++ b/src/game/server/teeinfo.cpp
@@ -14,13 +14,13 @@ struct StdSkin
 
 static StdSkin g_aStdSkins[] = {
 	{"default", {"standard", "", "", "standard", "standard", "standard"}, {true, false, false, true, true, false}, {1798004, 0, 0, 1799582, 1869630, 0}},
-	{"bluekitty", {"kitty", "whisker", "", "standard", "standard", "standard"}, {true, true, false, true, true, false}, {8681144, -8229413, 0, 7885547, 7885547, 0}},
+	{"bluekitty", {"kitty", "whisker", "", "standard", "standard", "negative"}, {true, true, false, true, true, true}, {8681144, -8229413, 0, 7885547, 8868585, 9043712}},
 	{"bluestripe", {"standard", "stripes", "", "standard", "standard", "standard"}, {true, false, false, true, true, false}, {10187898, 0, 0, 750848, 1944919, 0}},
 	{"brownbear", {"bear", "bear", "hair", "standard", "standard", "standard"}, {true, true, false, true, true, false}, {1082745, -15634776, 0, 1082745, 1147174, 0}},
 	{"cammo", {"standard", "cammo2", "", "standard", "standard", "standard"}, {true, true, false, true, true, false}, {5334342, -11771603, 0, 750848, 1944919, 0}},
 	{"cammostripes", {"standard", "cammostripes", "", "standard", "standard", "standard"}, {true, true, false, true, true, false}, {5334342, -14840320, 0, 750848, 1944919, 0}},
 	{"coala", {"koala", "twinbelly", "", "standard", "standard", "standard"}, {true, true, false, true, true, false}, {184, -15397662, 0, 184, 9765959, 0}},
-	{"limekitty", {"kitty", "whisker", "", "standard", "standard", "standard"}, {true, true, false, true, true, false}, {4612803, -12229920, 0, 3827951, 3827951, 0}},
+	{"limekitty", {"kitty", "whisker", "", "standard", "standard", "negative"}, {true, true, false, true, true, true}, {4612803, -12229920, 0, 3827951, 3827951, 8256000}},
 	{"pinky", {"standard", "whisker", "", "standard", "standard", "standard"}, {true, true, false, true, true, false}, {15911355, -801066, 0, 15043034, 15043034, 0}},
 	{"redbopp", {"standard", "donny", "unibop", "standard", "standard", "standard"}, {true, true, true, true, true, false}, {16177260, -16590390, 16177260, 16177260, 7624169, 0}},
 	{"redstripe", {"standard", "stripe", "", "standard", "standard", "standard"}, {true, false, false, true, true, false}, {16307835, 0, 0, 184, 9765959, 0}},


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->
It seems that the original mapping based on datasrc before https://github.com/teeworlds/teeworlds/pull/2692. Also bluekitty had wrong feet color (check [bluekitty.json](https://github.com/teeworlds/teeworlds/blob/master/datasrc/skins/bluekitty.json): `feet` hue in the json is different from that of `hands` but in TeeInfo mapping we had identical colors).

The idea is to later use those mapping to leverage 0.7 skins for DDNet protocol.
Note: maybe we'd want to use the same `.json` files instead of hardcoded skins info but `CSkins` is a part of the game/client and I'd postpone such refactoring (not to say that [0.7 skins](https://github.com/ddnet/ddnet/pull/5949) are not finished yet).

The immediate effect is fixed kitty skins for 0.7 vanilla client, though for me it is rather a side effect.

![image](https://github.com/ddnet/ddnet/assets/374839/8211aa24-5a14-49cd-bc80-1b0923da1674)

Note: 0.7 skins are visually different from 0.6 and there are both upsides (e.g. consistent outlining) and downsides (e.g. grey instead of colored shadow). :thinking: 

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
