### PR TITLE
Remove redundant UTF-8 checks

### DIFF
--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -2047,10 +2047,6 @@ void CGameContext::OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID)
 
 void CGameContext::OnSayNetMessage(const CNetMsg_Cl_Say *pMsg, int ClientID, const CUnpacker *pUnpacker)
 {
-	if(!str_utf8_check(pMsg->m_pMessage))
-	{
-		return;
-	}
 	CPlayer *pPlayer = m_apPlayers[ClientID];
 	bool Check = !pPlayer->m_NotEligibleForFinish && pPlayer->m_EligibleForFinishCheck + 10 * time_freq() >= time_get();
 	if(Check && str_comp(pMsg->m_pMessage, "xd sure chillerbot.png is lyfe") == 0 && pMsg->m_Team == 0)
@@ -2181,10 +2177,6 @@ void CGameContext::OnCallVoteNetMessage(const CNetMsg_Cl_CallVote *pMsg, int Cli
 	char aSixupDesc[VOTE_DESC_LENGTH] = {0};
 	char aCmd[VOTE_CMD_LENGTH] = {0};
 	char aReason[VOTE_REASON_LENGTH] = "No reason given";
-	if(!str_utf8_check(pMsg->m_pType) || !str_utf8_check(pMsg->m_pReason) || !str_utf8_check(pMsg->m_pValue))
-	{
-		return;
-	}
 	if(pMsg->m_pReason[0])
 	{
 		str_copy(aReason, pMsg->m_pReason, sizeof(aReason));
@@ -2557,10 +2549,6 @@ void CGameContext::OnChangeInfoNetMessage(const CNetMsg_Cl_ChangeInfo *pMsg, int
 
 	bool SixupNeedsUpdate = false;
 
-	if(!str_utf8_check(pMsg->m_pName) || !str_utf8_check(pMsg->m_pClan) || !str_utf8_check(pMsg->m_pSkin))
-	{
-		return;
-	}
 	pPlayer->m_LastChangeInfo = Server()->Tick();
 	pPlayer->UpdatePlaytime();
 
@@ -2770,22 +2758,6 @@ void CGameContext::OnStartInfoNetMessage(const CNetMsg_Cl_StartInfo *pMsg, int C
 
 	if(pPlayer->m_IsReady)
 		return;
-
-	if(!str_utf8_check(pMsg->m_pName))
-	{
-		Server()->Kick(ClientID, "name is not valid utf8");
-		return;
-	}
-	if(!str_utf8_check(pMsg->m_pClan))
-	{
-		Server()->Kick(ClientID, "clan is not valid utf8");
-		return;
-	}
-	if(!str_utf8_check(pMsg->m_pSkin))
-	{
-		Server()->Kick(ClientID, "skin is not valid utf8");
-		return;
-	}
 
 	pPlayer->m_LastChangeInfo = Server()->Tick();
 


### PR DESCRIPTION
We already check for valid UTF-8 while unpacking strings.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
