### PR TITLE
Fix clang warning and UB when there is no game layer

### DIFF
--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -405,7 +405,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupGroup(void *pContext, CUIRect View, 
 		{
 			// gather all tile layers
 			std::vector<std::shared_ptr<CLayerTiles>> vpLayers;
-			int GameLayerIndex;
+			int GameLayerIndex = -1;
 			for(int LayerIndex = 0; LayerIndex < (int)pEditor->m_Map.m_pGameGroup->m_vpLayers.size(); LayerIndex++)
 			{
 				auto &pLayer = pEditor->m_Map.m_pGameGroup->m_vpLayers.at(LayerIndex);
@@ -446,8 +446,15 @@ CUI::EPopupMenuFunctionResult CEditor::PopupGroup(void *pContext, CUIRect View, 
 
 			if(!pGameLayer->m_TilesHistory.empty())
 			{
-				// record undo
-				pEditor->m_EditorHistory.RecordAction(std::make_shared<CEditorActionTileChanges>(pEditor, pEditor->m_SelectedGroup, GameLayerIndex, "Clean up game tiles", pGameLayer->m_TilesHistory));
+				if(GameLayerIndex == -1)
+				{
+					dbg_msg("editor", "failed to record action (GameLayerIndex not found)");
+				}
+				else
+				{
+					// record undo
+					pEditor->m_EditorHistory.RecordAction(std::make_shared<CEditorActionTileChanges>(pEditor, pEditor->m_SelectedGroup, GameLayerIndex, "Clean up game tiles", pGameLayer->m_TilesHistory));
+				}
 				pGameLayer->ClearHistory();
 			}
 


### PR DESCRIPTION
clang 14.0.6 shows this:

```
[ 98%] Building CXX object CMakeFiles/game-client.dir/src/game/generated/client_data7.cpp.o
In file included from /usr/include/c++/12/bits/stl_tempbuf.h:60,
                 from /usr/include/c++/12/bits/stl_algo.h:61,
                 from /usr/include/c++/12/algorithm:61,
                 from /home/chiller/Desktop/git/ddnet/src/base/math.h:6,
                 from /home/chiller/Desktop/git/ddnet/src/base/color.h:5,
                 from /home/chiller/Desktop/git/ddnet/src/game/editor/popups.cpp:4:
In function ‘void std::_Construct(_Tp*, _Args&& ...) [with _Tp = CEditorActionTileChanges; _Args = {CEditor*&, int&, int&, const char (&)[20], map<int, map<int, STileStateChange, less<int>, allocator<pair<const int, STileStateChange> > >, less<int>, allocator<pair<const int, map<int, STileStateChange, less<int>, allocator<pair<const int, STileStateChange> > > > > >&}]’,
    inlined from ‘static void std::allocator_traits<std::allocator<void> >::construct(allocator_type&, _Up*, _Args&& ...) [with _Up = CEditorActionTileChanges; _Args = {CEditor*&, int&, int&, const char (&)[20], std::map<int, std::map<int, STileStateChange, std::less<int>, std::allocator<std::pair<const int, STileStateChange> > >, std::less<int>, std::allocator<std::pair<const int, std::map<int, STileStateChange, std::less<int>, std::allocator<std::pair<const int, STileStateChange> > > > > >&}]’ at /usr/include/c++/12/bits/alloc_traits.h:635:19,
    inlined from ‘std::_Sp_counted_ptr_inplace<_Tp, _Alloc, _Lp>::_Sp_counted_ptr_inplace(_Alloc, _Args&& ...) [with _Args = {CEditor*&, int&, int&, const char (&)[20], std::map<int, std::map<int, STileStateChange, std::less<int>, std::allocator<std::pair<const int, STileStateChange> > >, std::less<int>, std::allocator<std::pair<const int, std::map<int, STileStateChange, std::less<int>, std::allocator<std::pair<const int, STileStateChange> > > > > >&}; _Tp = CEditorActionTileChanges; _Alloc = std::allocator<void>; __gnu_cxx::_Lock_policy _Lp = __gnu_cxx::_S_atomic]’ at /usr/include/c++/12/bits/shared_ptr_base.h:604:39,
    inlined from ‘std::__shared_count<_Lp>::__shared_count(_Tp*&, std::_Sp_alloc_shared_tag<_Alloc>, _Args&& ...) [with _Tp = CEditorActionTileChanges; _Alloc = std::allocator<void>; _Args = {CEditor*&, int&, int&, const char (&)[20], std::map<int, std::map<int, STileStateChange, std::less<int>, std::allocator<std::pair<const int, STileStateChange> > >, std::less<int>, std::allocator<std::pair<const int, std::map<int, STileStateChange, std::less<int>, std::allocator<std::pair<const int, STileStateChange> > > > > >&}; __gnu_cxx::_Lock_policy _Lp = __gnu_cxx::_S_atomic]’ at /usr/include/c++/12/bits/shared_ptr_base.h:971:16,
    inlined from ‘std::__shared_ptr<_Tp, _Lp>::__shared_ptr(std::_Sp_alloc_shared_tag<_Tp>, _Args&& ...) [with _Alloc = std::allocator<void>; _Args = {CEditor*&, int&, int&, const char (&)[20], std::map<int, std::map<int, STileStateChange, std::less<int>, std::allocator<std::pair<const int, STileStateChange> > >, std::less<int>, std::allocator<std::pair<const int, std::map<int, STileStateChange, std::less<int>, std::allocator<std::pair<const int, STileStateChange> > > > > >&}; _Tp = CEditorActionTileChanges; __gnu_cxx::_Lock_policy _Lp = __gnu_cxx::_S_atomic]’ at /usr/include/c++/12/bits/shared_ptr_base.h:1712:14,
    inlined from ‘std::shared_ptr<_Tp>::shared_ptr(std::_Sp_alloc_shared_tag<_Tp>, _Args&& ...) [with _Alloc = std::allocator<void>; _Args = {CEditor*&, int&, int&, const char (&)[20], std::map<int, std::map<int, STileStateChange, std::less<int>, std::allocator<std::pair<const int, STileStateChange> > >, std::less<int>, std::allocator<std::pair<const int, std::map<int, STileStateChange, std::less<int>, std::allocator<std::pair<const int, STileStateChange> > > > > >&}; _Tp = CEditorActionTileChanges]’ at /usr/include/c++/12/bits/shared_ptr.h:464:59,
    inlined from ‘std::shared_ptr<typename std::enable_if<(! std::is_array< <template-parameter-1-1> >::value), _Tp>::type> std::make_shared(_Args&& ...) [with _Tp = CEditorActionTileChanges; _Args = {CEditor*&, int&, int&, const char (&)[20], map<int, map<int, STileStateChange, less<int>, allocator<pair<const int, STileStateChange> > >, less<int>, allocator<pair<const int, map<int, STileStateChange, less<int>, allocator<pair<const int, STileStateChange> > > > > >&}]’ at /usr/include/c++/12/bits/shared_ptr.h:1010:39,
    inlined from ‘static CUI::EPopupMenuFunctionResult CEditor::PopupGroup(void*, CUIRect, bool)’ at /home/chiller/Desktop/git/ddnet/src/game/editor/popups.cpp:450:85:
/usr/include/c++/12/bits/stl_construct.h:119:7: warning: ‘GameLayerIndex’ may be used uninitialized [-Wmaybe-uninitialized]
  119 |       ::new((void*)__p) _Tp(std::forward<_Args>(__args)...);
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/chiller/Desktop/git/ddnet/src/game/editor/popups.cpp: In static member function ‘static CUI::EPopupMenuFunctionResult CEditor::PopupGroup(void*, CUIRect, bool)’:
/home/chiller/Desktop/git/ddnet/src/game/editor/popups.cpp:408:29: note: ‘GameLayerIndex’ was declared here
  408 |                         int GameLayerIndex;
      |                             ^~~~~~~~~~~~~~
At global scope:
cc1plus: note: unrecognized command-line option ‘-Wno-nullability-completeness’ may have been intended to silence earlier diagnostics
```

Which makes sense. GameLayerIndex is only set in a loop if a condition is met. And then its value is recorded for the undo feature.

The condition should never be false. Because a game layer is a strict requirement for a functional map. But I still decided to avoid using an assert or silent ignore. If this breaks logs would be nice.
If this breaks the editor should not crash.
The editor should never crash or quit to not lose unsaved changes.

<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
