### PR TITLE
Fix 0.7 validation range of m_HookedPlayer in character snap items

### DIFF
--- a/datasrc/seven/network.py
+++ b/datasrc/seven/network.py
@@ -152,7 +152,7 @@ Objects = [
 		NetIntRange("m_Direction", -1, 1),
 
 		NetIntRange("m_Jumped", 0, 3),
-		NetIntRange("m_HookedPlayer", 0, 'MAX_CLIENTS-1'),
+		NetIntRange("m_HookedPlayer", -1, 'MAX_CLIENTS-1'),
 		NetIntRange("m_HookState", -1, 5),
 		NetTick("m_HookTick"),
 


### PR DESCRIPTION
Missed in https://github.com/ddnet/ddnet/pull/7768
My bad I should have caught that. Got lost when [#7762](https://github.com/ddnet/ddnet/pull/7762/commits) got replaced.

In 0.7 the value -1 is used for m_HookedPlayer. So this too strict validation broke https://github.com/ddnet/ddnet/pull/5949

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
