### PR TITLE
Improve client/server launch log messages

### DIFF
--- a/src/engine/server/main.cpp
+++ b/src/engine/server/main.cpp
@@ -47,6 +47,8 @@ void HandleSigIntTerm(int Param)
 
 int main(int argc, const char **argv)
 {
+	const int64_t MainStart = time_get();
+
 	CCmdlineFix CmdlineFix(&argc, &argv);
 	bool Silent = false;
 
@@ -90,12 +92,12 @@ int main(int argc, const char **argv)
 
 	if(secure_random_init() != 0)
 	{
-		dbg_msg("secure", "could not initialize secure RNG");
+		log_error("secure", "could not initialize secure RNG");
 		return -1;
 	}
 	if(MysqlInit() != 0)
 	{
-		dbg_msg("mysql", "failed to initialize MySQL library");
+		log_error("mysql", "failed to initialize MySQL library");
 		return -1;
 	}
 
@@ -182,14 +184,14 @@ int main(int argc, const char **argv)
 		}
 		else
 		{
-			dbg_msg("server", "failed to open '%s' for logging", g_Config.m_Logfile);
+			log_error("server", "failed to open '%s' for logging", g_Config.m_Logfile);
 		}
 	}
 	auto pServerLogger = std::make_shared<CServerLogger>(pServer);
 	pEngine->SetAdditionalLogger(pServerLogger);
 
 	// run the server
-	dbg_msg("server", "starting...");
+	log_trace("server", "initialization finished after %.2fms, starting...", (time_get() - MainStart) * 1000.0f / (float)time_freq());
 	int Ret = pServer->Run();
 
 	pServerLogger->OnServerDeletion();

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -2741,7 +2741,7 @@ int CServer::Run()
 	// load map
 	if(!LoadMap(Config()->m_SvMap))
 	{
-		dbg_msg("server", "failed to load map. mapname='%s'", Config()->m_SvMap);
+		log_error("server", "failed to load map. mapname='%s'", Config()->m_SvMap);
 		return -1;
 	}
 
@@ -2769,7 +2769,7 @@ int CServer::Run()
 	}
 	else if(net_host_lookup(g_Config.m_Bindaddr, &BindAddr, NETTYPE_ALL) != 0)
 	{
-		dbg_msg("server", "The configured bindaddr '%s' cannot be resolved", g_Config.m_Bindaddr);
+		log_error("server", "The configured bindaddr '%s' cannot be resolved", g_Config.m_Bindaddr);
 		return -1;
 	}
 	BindAddr.type = Config()->m_SvIpv4Only ? NETTYPE_IPV4 : NETTYPE_ALL;
@@ -2779,13 +2779,13 @@ int CServer::Run()
 	{
 		if(Port != 0 || BindAddr.port >= 8310)
 		{
-			dbg_msg("server", "couldn't open socket. port %d might already be in use", BindAddr.port);
+			log_error("server", "couldn't open socket. port %d might already be in use", BindAddr.port);
 			return -1;
 		}
 	}
 
 	if(Port == 0)
-		dbg_msg("server", "using port %d", BindAddr.port);
+		log_info("server", "using port %d", BindAddr.port);
 
 #if defined(CONF_UPNP)
 	m_UPnP.Open(BindAddr);
@@ -2824,9 +2824,9 @@ int CServer::Run()
 
 	if(m_AuthManager.IsGenerated())
 	{
-		dbg_msg("server", "+-------------------------+");
-		dbg_msg("server", "| rcon password: '%s' |", Config()->m_SvRconPassword);
-		dbg_msg("server", "+-------------------------+");
+		log_info("server", "+-------------------------+");
+		log_info("server", "| rcon password: '%s' |", Config()->m_SvRconPassword);
+		log_info("server", "+-------------------------+");
 	}
 
 	// start game
@@ -3084,7 +3084,7 @@ int CServer::Run()
 
 	if(ErrorShutdown())
 	{
-		dbg_msg("server", "shutdown from game server (%s)", m_aErrorShutdownReason);
+		log_info("server", "shutdown from game server (%s)", m_aErrorShutdownReason);
 		pDisconnectReason = m_aErrorShutdownReason;
 	}
 	// disconnect all clients on shutdown


### PR DESCRIPTION
Use error log level for error messages. Use info log level explicitly instead of using `dbg_msg`.

Log time taken for initialization in trace level message.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
