### PR TITLE
CMenus::RandomSkin() adjustments

### DIFF
--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -432,7 +432,7 @@ void CMenus::RandomSkin()
 	}
 
 	const size_t SkinNameSize = !m_Dummy ? sizeof(g_Config.m_ClPlayerSkin) : sizeof(g_Config.m_ClDummySkin);
-	char aRandomSkinName[SkinNameSize];
+	char aRandomSkinName[24];
 	str_copy(aRandomSkinName, "default", SkinNameSize);
 	if(!m_pClient->m_Skins.GetSkinsUnsafe().empty())
 	{

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -440,7 +440,7 @@ void CMenus::RandomSkin()
 		{
 			auto it = m_pClient->m_Skins.GetSkinsUnsafe().begin();
 			std::advance(it, rand() % m_pClient->m_Skins.GetSkinsUnsafe().size());
-			str_copy(aRandomSkinName, (*it).second.get()->GetName(), SkinNameSize);
+			str_copy(aRandomSkinName, (*it).second->GetName(), SkinNameSize);
 		} while(!str_comp(aRandomSkinName, "x_ninja") || !str_comp(aRandomSkinName, "x_spec"));
 	}
 	char *pSkinName = !m_Dummy ? g_Config.m_ClPlayerSkin : g_Config.m_ClDummySkin;


### PR DESCRIPTION
+ Don't randomize colors if UseCustomColor is false
+ Use all instead of only vanilla skins when randomizing

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
