### PR TITLE
fix cmake warning when building with -DMYSQL=ON

### DIFF
--- a/cmake/FindMySQL.cmake
+++ b/cmake/FindMySQL.cmake
@@ -4,7 +4,7 @@ if(NOT CMAKE_CROSSCOMPILING)
   )
 
   if(MYSQL_CONFIG)
-    exec_program(${MYSQL_CONFIG}
+    execute_process(COMMAND ${MYSQL_CONFIG}
       ARGS --include
       OUTPUT_VARIABLE MY_TMP
     )
@@ -13,7 +13,7 @@ if(NOT CMAKE_CROSSCOMPILING)
 
     set(MYSQL_CONFIG_INCLUDE_DIR ${MY_TMP} CACHE FILEPATH INTERNAL)
 
-    exec_program(${MYSQL_CONFIG}
+    execute_process(COMMAND ${MYSQL_CONFIG}
       ARGS --libs_r
       OUTPUT_VARIABLE MY_TMP
     )

--- a/cmake/FindMySQL.cmake
+++ b/cmake/FindMySQL.cmake
@@ -7,6 +7,7 @@ if(NOT CMAKE_CROSSCOMPILING)
     execute_process(COMMAND ${MYSQL_CONFIG}
       ARGS --include
       OUTPUT_VARIABLE MY_TMP
+      OUTPUT_STRIP_TRAILING_WHITESPACE
     )
 
     string(REGEX REPLACE "-I([^ ]*)( .*)?" "\\1" MY_TMP "${MY_TMP}")
@@ -16,6 +17,7 @@ if(NOT CMAKE_CROSSCOMPILING)
     execute_process(COMMAND ${MYSQL_CONFIG}
       ARGS --libs_r
       OUTPUT_VARIABLE MY_TMP
+      OUTPUT_STRIP_TRAILING_WHITESPACE
     )
 
     set(MYSQL_CONFIG_LIBRARIES "")


### PR DESCRIPTION
closes #7881 

edit:
the ubuntu 20.04 check is failing - i cant exactly tell why, i assume its because of:

CMake Error at CMakeLists.txt:642 (message):
  You must install MySQL to compile the DDNet server with MySQL support


## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
