### PR TITLE
Add console chain for refreshing skins

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -814,6 +814,12 @@ void CMenus::OnInit()
 	Console()->Chain("cl_asset_hud", ConchainAssetHud, this);
 	Console()->Chain("cl_asset_extras", ConchainAssetExtras, this);
 
+	Console()->Chain("cl_skin_download_url", ConchainReloadSkins, this);
+	Console()->Chain("cl_skin_community_download_url", ConchainReloadSkins, this);
+	Console()->Chain("cl_download_skins", ConchainReloadSkins, this);
+	Console()->Chain("cl_download_community_skins", ConchainReloadSkins, this);
+	Console()->Chain("cl_vanilla_skins_only", ConchainReloadSkins, this);
+
 	m_TextureBlob = Graphics()->LoadTexture("blob.png", IStorage::TYPE_ALL);
 
 	// setup load amount

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -595,6 +595,8 @@ protected:
 
 	class CMenuBackground *m_pBackground;
 
+	static void ConchainReloadSkins(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
+
 public:
 	void RenderBackground();
 

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -3441,3 +3441,13 @@ void CMenus::RenderSettingsDDNet(CUIRect MainView)
 	}
 #endif
 }
+
+void CMenus::ConchainReloadSkins(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData)
+{
+	CMenus *pThis = (CMenus *)pUserData;
+	pfnCallback(pResult, pCallbackUserData);
+	if(pResult->NumArguments() && (pThis->Client()->State() == IClient::STATE_ONLINE || pThis->Client()->State() == IClient::STATE_DEMOPLAYBACK))
+	{
+		pThis->RefreshSkins();
+	}
+}


### PR DESCRIPTION
The client will now refresh the skins when changing `cl_skin_download_url`, `cl_skin_community_download_url`, `cl_download_skins`, `cl_download_community_skins` and `cl_vanilla_skins_only` just like it does when doing it from settings.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
