### PR TITLE
Accept `charset=*` in `Content-Type` for masterserver

### DIFF
--- a/src/mastersrv/Cargo.lock
+++ b/src/mastersrv/Cargo.lock
@@ -443,6 +443,7 @@ dependencies = [
  "hex",
  "ipnet",
  "log",
+ "mime",
  "rand",
  "serde",
  "serde_json",

--- a/src/mastersrv/Cargo.toml
+++ b/src/mastersrv/Cargo.toml
@@ -22,6 +22,7 @@ headers = "0.3.7"
 hex = "0.4.3"
 ipnet = { version = "2.5.0", features = ["serde"] }
 log = "0.4.17"
+mime = "0.3.16"
 rand = "0.8.4"
 serde = { version = "1.0.126", features = ["derive"] }
 serde_json = { version = "1.0.64", features = [

--- a/src/mastersrv/src/main.rs
+++ b/src/mastersrv/src/main.rs
@@ -823,8 +823,9 @@ fn register_from_headers(
         challenge_token: parse_opt(headers, "Challenge-Token")?,
         info_serial: parse(headers, "Info-Serial")?,
         info: if !info.is_empty() {
-            if headers.typed_get() != Some(headers::ContentType::json()) {
-                return Err(RegisterError::unsupported_media_type());
+            match headers.typed_get::<headers::ContentType>().map(mime::Mime::from) {
+                Some(mime) if mime.essence_str() == mime::APPLICATION_JSON => {}
+                _ => return Err(RegisterError::unsupported_media_type()),
             }
             Some(json::from_slice(info).map_err(|e| {
                 RegisterError::new(format!("Request body deserialize error: {}", e))


### PR DESCRIPTION
You should generally not send a `charset=*` parameter for `Content-Type: application/json` because no parameters are defined for it: https://datatracker.ietf.org/doc/html/rfc7158#section-11.

Fixes #6955.

## Checklist

- [x] Tested the change ~ingame~
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
