### PR TITLE
Refactor skin refreshing in gameclient, fix crash in skin settings

### DIFF
--- a/src/game/client/component.h
+++ b/src/game/client/component.h
@@ -183,6 +183,10 @@ public:
 	 */
 	virtual void OnWindowResize() {}
 	/**
+	 * Called when skins have been invalidated and must be updated.
+	 */
+	virtual void OnRefreshSkins() {}
+	/**
 	 * Called when the component should get rendered.
 	 *
 	 * The render order depends on the component insertion order.

--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -923,7 +923,7 @@ void CChat::AddLine(int ClientID, int Team, const char *pLine)
 	}
 }
 
-void CChat::RefindSkins()
+void CChat::OnRefreshSkins()
 {
 	for(auto &Line : m_aLines)
 	{

--- a/src/game/client/components/chat.h
+++ b/src/game/client/components/chat.h
@@ -165,8 +165,8 @@ public:
 	void OnWindowResize() override;
 	void OnConsoleInit() override;
 	void OnStateChange(int NewState, int OldState) override;
+	void OnRefreshSkins() override;
 	void OnRender() override;
-	void RefindSkins();
 	void OnPrepareLines(float y);
 	void Reset();
 	void OnRelease() override;

--- a/src/game/client/components/ghost.cpp
+++ b/src/game/client/components/ghost.cpp
@@ -684,7 +684,7 @@ int CGhost::GetLastRaceTick() const
 	return m_LastRaceTick;
 }
 
-void CGhost::RefindSkins()
+void CGhost::OnRefreshSkins()
 {
 	const auto &&RefindSkin = [&](auto &Ghost) {
 		if(Ghost.Empty())

--- a/src/game/client/components/ghost.h
+++ b/src/game/client/components/ghost.h
@@ -155,6 +155,7 @@ public:
 	virtual void OnRender() override;
 	virtual void OnConsoleInit() override;
 	virtual void OnReset() override;
+	virtual void OnRefreshSkins() override;
 	virtual void OnMessage(int MsgType, void *pRawMsg) override;
 	virtual void OnMapLoad() override;
 	virtual void OnShutdown() override;
@@ -175,8 +176,6 @@ public:
 	class IGhostRecorder *GhostRecorder() const { return m_pGhostRecorder; }
 
 	int GetLastRaceTick() const;
-
-	void RefindSkins();
 };
 
 #endif

--- a/src/game/client/components/infomessages.cpp
+++ b/src/game/client/components/infomessages.cpp
@@ -536,7 +536,7 @@ void CInfoMessages::OnRender()
 	}
 }
 
-void CInfoMessages::RefindSkins()
+void CInfoMessages::OnRefreshSkins()
 {
 	for(auto &InfoMsg : m_aInfoMsgs)
 	{

--- a/src/game/client/components/infomessages.h
+++ b/src/game/client/components/infomessages.h
@@ -72,12 +72,11 @@ public:
 
 	virtual int Sizeof() const override { return sizeof(*this); }
 	virtual void OnWindowResize() override;
+	virtual void OnRefreshSkins() override;
 	virtual void OnReset() override;
 	virtual void OnRender() override;
 	virtual void OnMessage(int MsgType, void *pRawMsg) override;
 	virtual void OnInit() override;
-
-	void RefindSkins();
 };
 
 #endif

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -814,12 +814,6 @@ void CMenus::OnInit()
 	Console()->Chain("cl_asset_hud", ConchainAssetHud, this);
 	Console()->Chain("cl_asset_extras", ConchainAssetExtras, this);
 
-	Console()->Chain("cl_skin_download_url", ConchainReloadSkins, this);
-	Console()->Chain("cl_skin_community_download_url", ConchainReloadSkins, this);
-	Console()->Chain("cl_download_skins", ConchainReloadSkins, this);
-	Console()->Chain("cl_download_community_skins", ConchainReloadSkins, this);
-	Console()->Chain("cl_vanilla_skins_only", ConchainReloadSkins, this);
-
 	m_TextureBlob = Graphics()->LoadTexture("blob.png", IStorage::TYPE_ALL);
 
 	// setup load amount

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -81,8 +81,7 @@ class CMenus : public CComponent
 	void DoJoystickAxisPicker(CUIRect View);
 	void DoJoystickBar(const CUIRect *pRect, float Current, float Tolerance, bool Active);
 
-	void RefreshSkins();
-
+	bool m_SkinListNeedsUpdate = false;
 	void RandomSkin();
 
 	// menus_settings_assets.cpp
@@ -595,8 +594,6 @@ protected:
 
 	class CMenuBackground *m_pBackground;
 
-	static void ConchainReloadSkins(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
-
 public:
 	void RenderBackground();
 
@@ -619,6 +616,7 @@ public:
 
 	virtual void OnStateChange(int NewState, int OldState) override;
 	virtual void OnWindowResize() override;
+	virtual void OnRefreshSkins() override;
 	virtual void OnReset() override;
 	virtual void OnRender() override;
 	virtual bool OnInput(const IInput::CEvent &Event) override;

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -207,6 +207,7 @@ private:
 	static void ConchainLanguageUpdate(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 	static void ConchainSpecialInfoupdate(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 	static void ConchainSpecialDummyInfoupdate(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
+	static void ConchainRefreshSkins(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 	static void ConchainSpecialDummy(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 	static void ConchainClTextEntitiesSize(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 
@@ -499,6 +500,8 @@ public:
 	void OnLanguageChange();
 	void HandleLanguageChanged();
 
+	void RefreshSkins();
+
 	void RenderShutdownMessage();
 
 	const char *GetItemName(int Type) const override;
@@ -560,8 +563,6 @@ public:
 	void LoadParticlesSkin(const char *pPath, bool AsDir = false);
 	void LoadHudSkin(const char *pPath, bool AsDir = false);
 	void LoadExtrasSkin(const char *pPath, bool AsDir = false);
-
-	void RefindSkins();
 
 	struct SClientGameSkin
 	{


### PR DESCRIPTION
Add `CGameClient::RefreshSkins` function to refresh skins. This function reloads all skins by calling `CSkins::Refresh` and then notifies all gameclient components about the skins being refreshed by calling the new `CComponent::OnRefreshSkins` function, so the components can properly invalidate their current skin texture handles. The existing `RefindSkins` functions are changed to `OnRefreshSkins`.

Additionally, `OnRefreshSkins` is overridden in `CMenus` to set the flag so the skin list will be updated before it is rendered the next time, to fix the client crashing when changing skin related config variables via the console. Closes #7891.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
