### PR TITLE
Set correct size of name column in SQL table

### DIFF
--- a/src/engine/server/databases/connection.cpp
+++ b/src/engine/server/databases/connection.cpp
@@ -1,7 +1,5 @@
 #include "connection.h"
 
-#include <engine/shared/protocol.h>
-
 IDbConnection::IDbConnection(const char *pPrefix)
 {
 	str_copy(m_aPrefix, pPrefix);
@@ -30,7 +28,7 @@ void IDbConnection::FormatCreateRace(char *aBuf, unsigned int BufferSize, bool B
 		"  PRIMARY KEY (Map, Name, Time, Timestamp, Server)"
 		")",
 		GetPrefix(), Backup ? "_backup" : "",
-		BinaryCollate(), MAX_NAME_LENGTH, BinaryCollate());
+		BinaryCollate(), MAX_NAME_LENGTH_SQL, BinaryCollate());
 }
 
 void IDbConnection::FormatCreateTeamrace(char *aBuf, unsigned int BufferSize, const char *pIdType, bool Backup) const
@@ -47,7 +45,7 @@ void IDbConnection::FormatCreateTeamrace(char *aBuf, unsigned int BufferSize, co
 		"  PRIMARY KEY (ID, Name)"
 		")",
 		GetPrefix(), Backup ? "_backup" : "",
-		BinaryCollate(), MAX_NAME_LENGTH, BinaryCollate(), pIdType);
+		BinaryCollate(), MAX_NAME_LENGTH_SQL, BinaryCollate(), pIdType);
 }
 
 void IDbConnection::FormatCreateMaps(char *aBuf, unsigned int BufferSize) const
@@ -90,5 +88,5 @@ void IDbConnection::FormatCreatePoints(char *aBuf, unsigned int BufferSize) cons
 		"  Points INT DEFAULT 0, "
 		"  PRIMARY KEY (Name)"
 		")",
-		GetPrefix(), MAX_NAME_LENGTH, BinaryCollate());
+		GetPrefix(), MAX_NAME_LENGTH_SQL, BinaryCollate());
 }

--- a/src/engine/server/databases/connection.h
+++ b/src/engine/server/databases/connection.h
@@ -3,7 +3,14 @@
 
 #include "connection_pool.h"
 
+#include <engine/shared/protocol.h>
 #include <memory>
+
+enum
+{
+	// MAX_NAME_LENGTH includes the size with \0, which is not necessary in SQL
+	MAX_NAME_LENGTH_SQL = MAX_NAME_LENGTH - 1,
+};
 
 class IConsole;
 


### PR DESCRIPTION
`MAX_NAME_LENGTH` includes space for `\0`, which doesn't need to be accounted for in SQL. So, the correct size would be 15 instead of 16. I also checked if there is any names in the official database that is more than 15 characters, but there is not.

```
sqlite> SELECT MAX(LENGTH(name)) FROM race;
MAX(LENGTH(name))
-----------------
15
```

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
