### PR TITLE
Use toggle button instead of checkbox for "Sync envelope button".

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -6462,20 +6462,17 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 			}
 		}
 
-		// sync checkbox
+		// toggle sync button
 		ToolBar.VSplitLeft(15.0f, nullptr, &ToolBar);
-		ToolBar.VSplitLeft(12.0f, &Button, &ToolBar);
+		ToolBar.VSplitLeft(40.0f, &Button, &ToolBar);
+
 		static int s_SyncButton;
-		if(DoButton_Editor(&s_SyncButton, pEnvelope->m_Synchronized ? "X" : "", 0, &Button, 0, "Synchronize envelope animation to game time (restarts when you touch the start line)"))
+		if(DoButton_Editor(&s_SyncButton, "Sync", pEnvelope->m_Synchronized, &Button, 0, "Synchronize envelope animation to game time (restarts when you touch the start line)"))
 		{
 			m_EnvelopeEditorHistory.RecordAction(std::make_shared<CEditorActionEnvelopeEdit>(this, m_SelectedEnvelope, CEditorActionEnvelopeEdit::EEditType::SYNC, pEnvelope->m_Synchronized, !pEnvelope->m_Synchronized));
 			pEnvelope->m_Synchronized = !pEnvelope->m_Synchronized;
 			m_Map.OnModify();
 		}
-
-		ToolBar.VSplitLeft(4.0f, nullptr, &ToolBar);
-		ToolBar.VSplitLeft(40.0f, &Button, &ToolBar);
-		UI()->DoLabel(&Button, "Sync.", 10.0f, TEXTALIGN_ML);
 
 		const bool ShouldPan = s_Operation == EEnvelopeEditorOp::OP_NONE && (UI()->MouseButton(2) || (UI()->MouseButton(0) && Input()->ModifierIsPressed()));
 		if(m_pContainerPanned == &s_EnvelopeEditorID)


### PR DESCRIPTION
As suggested here, https://github.com/ddnet/ddnet/issues/7905#issuecomment-1924670295. I believe a toggle button makes more sense, as they are easier to hit and fits in more with the editor UI.

Before
![image](https://github.com/ddnet/ddnet/assets/141338449/069b9c23-4401-40f1-80d4-4206e75fb7b6)

After
![image](https://github.com/ddnet/ddnet/assets/141338449/2e21a365-0fa6-453b-b6c8-72e3e8696622)


## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
