### PR TITLE
Allocate more space for `DoLine_ColorPicker` label

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -367,7 +367,7 @@ ColorHSLA CMenus::DoLine_ColorPicker(CButtonContainer *pResetID, const float Lin
 		Section.VSplitLeft(5.0f, nullptr, &Section);
 	}
 
-	Section.VSplitMid(&Label, &Section, 4.0f);
+	Section.VSplitRight(88.0f, &Label, &Section);
 	Section.VSplitRight(60.0f, &Section, &ResetButton);
 	Section.VSplitRight(8.0f, &Section, nullptr);
 	Section.VSplitRight(Section.h, &Section, &ColorPickerButton);


### PR DESCRIPTION
Previously the labels would get squished even though a lot of space was available.

Before:
![before](https://github.com/ddnet/ddnet/assets/121701317/f349052e-4402-4ebf-95de-57837dad7ab0)

After:
![after](https://github.com/ddnet/ddnet/assets/121701317/7fc61fff-d6b6-432c-afe3-8672e25ec240)

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
