### PR TITLE
Keep console scrolling position during text selection

### DIFF
--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -1126,7 +1126,7 @@ void CGameConsole::OnRender()
 			pConsole->UpdateSearch();
 
 			// keep scroll position when new entries are printed.
-			if(pConsole->m_BacklogCurLine != 0)
+			if(pConsole->m_BacklogCurLine != 0 || pConsole->m_HasSelection)
 			{
 				pConsole->m_BacklogCurLine += pConsole->m_NewLineCounter;
 				pConsole->m_BacklogLastActiveLine += pConsole->m_NewLineCounter;


### PR DESCRIPTION
The console while now keep your scrolling position during text selection. Previously your selection would jump all over the place if people were typing.

Before

https://github.com/ddnet/ddnet/assets/141338449/3af742de-8cd1-48da-9a2d-56319045d3ca

After

https://github.com/ddnet/ddnet/assets/141338449/919ba33a-04dd-47b8-93ca-b02ea5238f40




## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
