### PR TITLE
Add parallax to layer selector (closed #7612)

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -4391,8 +4391,16 @@ bool CEditor::SelectLayerByTile()
 					continue;
 
 				std::shared_ptr<CLayerTiles> pTiles = std::static_pointer_cast<CLayerTiles>(m_Map.m_vpGroups[g]->m_vpLayers[l]);
-				int x = (int)UI()->MouseWorldX() / 32 + m_Map.m_vpGroups[g]->m_OffsetX;
-				int y = (int)UI()->MouseWorldY() / 32 + m_Map.m_vpGroups[g]->m_OffsetY;
+
+				float aMapping[4];
+				m_Map.m_vpGroups[g]->Mapping(aMapping);
+				int x = aMapping[0] + (aMapping[2] - aMapping[0]) / 2;
+				int y = aMapping[1] + (aMapping[3] - aMapping[1]) / 2;
+				x += UI()->MouseWorldX() - (MapView()->GetWorldOffset().x * m_Map.m_vpGroups[g]->m_ParallaxX / 100) - m_Map.m_vpGroups[g]->m_OffsetX;
+				y += UI()->MouseWorldY() - (MapView()->GetWorldOffset().y * m_Map.m_vpGroups[g]->m_ParallaxY / 100) - m_Map.m_vpGroups[g]->m_OffsetY;
+				x /= 32;
+				y /= 32;
+
 				if(x < 0 || x >= pTiles->m_Width)
 					continue;
 				if(y < 0 || y >= pTiles->m_Height)


### PR DESCRIPTION
Offset was already supported but parallax was ignored. Now it looks at offset and parallax when ctrl+right clicking a tile.

While extensively testing it I found another limitation. Partial tiles are not always selected correctly when there is some offsetting and parallaxing happening. It only checks one tile at a time and that after doing ``/ 32``. So it selects by tile and not by pixel and the casting might lose the correct offset. This is not too bad because it only happens when the user clicks on the edge of a tile and offset or para is used. As long as the user clicks somewhat in the center it should all work smoothly. Especially since tiles are usually grouped together this should work in most cases. But supporting pixel based selection would still be a nice improvement for another time (I am not opening an issue because it does not seem worth to pollute the backlog with that. If nobody ever runs into this literal edge (lol) case it is not worth to spend dev time on it and potentially add more bugs while trying to fix it).

![partial_tile_limitation](https://github.com/ddnet/ddnet/assets/20344300/330b9fe5-762b-452d-9f9c-3da940912cd4)


While looking through the code to understand parallax I found this quad insertion that seems to do exactly what I want.

https://github.com/ddnet/ddnet/blob/c09f1e133f0303fbe99bd67d1a2097a91b93e843/src/game/editor/editor.cpp#L1379-L1387

I did just copy that into my code and it worked. I did not bother to fully understand it.

![image](https://github.com/ddnet/ddnet/assets/20344300/b338b527-b196-4869-8054-bf12069a8c57)


## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
