### PR TITLE
Add doc comment for CUIRect::Draw()

### DIFF
--- a/src/game/client/ui_rect.h
+++ b/src/game/client/ui_rect.h
@@ -120,6 +120,19 @@ public:
 	 */
 	bool Inside(float PointX, float PointY) const;
 
+	/**
+	 * Fill background of *this* CUIRect.
+	 *
+	 * @note Example of filling a black half transparent background with 5px rounded edges on all sides
+	 * @note ```MyCuiRect.Draw(ColorRGBA(0.0f, 0.0f, 0.0f, 0.5f), IGraphics::CORNER_ALL, 5.0f);```
+	 *
+	 * @note Example of filling a red background with sharp edges
+	 * @note ```MyCuiRect.Draw(ColorRGBA(1.0f, 0.0f, 0.0f), IGraphics::CORNER_NONE, 0.0f);```
+	 *
+	 * @param Color
+	 * @param Corners
+	 * @param Rounding
+	 */
 	void Draw(ColorRGBA Color, int Corners, float Rounding) const;
 	void Draw4(ColorRGBA ColorTopLeft, ColorRGBA ColorTopRight, ColorRGBA ColorBottomLeft, ColorRGBA ColorBottomRight, int Corners, float Rounding) const;
 


### PR DESCRIPTION
I know the @note ``` reads cursed. But I really needed that example in there to ensure someone who never used or saw a call to Draw() can start using it just by looking at the doc hint. I also wanted it to display properly new lined and highlighted as code in both doxyygen and vscode. I played with markdown. \code{.cpp} and multi line code snippets.
This is the only way I found to achieve full syntax highlight including clickable links to ColorRGBA in doxygen. While also having it split on multiple lines and properly shown as a code snippet in vscode.

![image](https://github.com/ddnet/ddnet/assets/20344300/c6b4433a-1917-44d4-ba33-7c40d843d49d)
![image](https://github.com/ddnet/ddnet/assets/20344300/32e4dd4b-3e47-4b61-bd8b-170ac362c19c)


## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
