### PR TITLE
Add "View" button to tele drop down in editor

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -1328,7 +1328,7 @@ void CEditor::DoToolbarLayers(CUIRect ToolBar)
 					{
 						pButtonName = "Tele";
 						pfnPopupFunc = PopupTele;
-						Rows = 2;
+						Rows = 3;
 					}
 
 					if(pButtonName != nullptr)

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -1105,6 +1105,7 @@ public:
 
 	unsigned char m_TeleNumber;
 	unsigned char m_TeleCheckpointNumber;
+	unsigned char m_ViewTeleNumber;
 
 	unsigned char m_TuningNum;
 

--- a/src/game/editor/mapitems/layer_tele.h
+++ b/src/game/editor/mapitems/layer_tele.h
@@ -34,6 +34,10 @@ public:
 	void BrushRotate(float Amount) override;
 	void FillSelection(bool Empty, std::shared_ptr<CLayer> pBrush, CUIRect Rect) override;
 	virtual bool ContainsElementWithId(int Id, bool Checkpoint);
+	virtual void GetPos(int Number, int Offset, int &TeleX, int &TeleY);
+
+	int m_GotoTeleOffset;
+	ivec2 m_GotoTeleLastPos;
 
 	EditorTileStateChangeHistory<STeleTileStateChange> m_History;
 	inline void ClearHistory() override


### PR DESCRIPTION
This allows mappers to find teles by number.

Partially fixed #2194


https://github.com/ddnet/ddnet/assets/20344300/f2f27b72-f7d4-40e3-8c48-034240f0856f

I copy pasted the code from camera.cpp

https://github.com/ddnet/ddnet/blob/c09f1e133f0303fbe99bd67d1a2097a91b93e843/src/game/client/components/camera.cpp#L303-L355

Would love to share it somehow. But did not find a good way. Also when this is merged I will probably follow up with the same thing for switchers to fully close #2194

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
