### PR TITLE
Fix and simplify check for maximum number of favorite communities

### DIFF
--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -1701,13 +1701,14 @@ void CFavoriteCommunityFilterList::Add(const char *pCommunityId)
 	// the end of the list, to allow setting the entire list easier with binds.
 	Remove(pCommunityId);
 
-	// Ensure maximum number of favorite communities, by removing least-recently
-	// added communities from the beginning. One more than the maximum is removed
-	// to make room for the new community.
+	// Ensure maximum number of favorite communities, by removing the least-recently
+	// added community from the beginning, when the maximum number of favorite
+	// communities has been reached.
 	constexpr size_t MaxFavoriteCommunities = 3;
 	if(m_vEntries.size() >= MaxFavoriteCommunities)
 	{
-		m_vEntries.erase(m_vEntries.begin(), m_vEntries.begin() + (MaxFavoriteCommunities - 1));
+		dbg_assert(m_vEntries.size() == MaxFavoriteCommunities, "Maximum number of communities can never be exceeded");
+		m_vEntries.erase(m_vEntries.begin());
 	}
 	m_vEntries.emplace_back(pCommunityId);
 }


### PR DESCRIPTION
Because of incorrect index/size math, two favorite communities were removed when exceeding the maximum number of three favorite communities instead of only one. The check can be simplified because the maximum number of favorite communities can never be exceeded, so at most the first element needs to be removed from the vector.

Closes #7935.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
