### PR TITLE
Ensure correct HTTP request state when getting result

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -2064,7 +2064,7 @@ void CClient::ResetDDNetInfoTask()
 
 void CClient::FinishDDNetInfo()
 {
-	if(m_ServerBrowser.DDNetInfoSha256() == m_pDDNetInfoTask->Sha256())
+	if(m_ServerBrowser.DDNetInfoSha256() == m_pDDNetInfoTask->ResultSha256())
 	{
 		log_debug("client/info", "DDNet info already up-to-date");
 		return;
@@ -2082,7 +2082,6 @@ void CClient::FinishDDNetInfo()
 	unsigned char *pResult;
 	size_t ResultLength;
 	m_pDDNetInfoTask->Result(&pResult, &ResultLength);
-	dbg_assert(pResult != nullptr, "Invalid info task state");
 	bool Error = io_write(File, pResult, ResultLength) != ResultLength;
 	Error |= io_close(File) != 0;
 	if(Error)

--- a/src/engine/shared/http.cpp
+++ b/src/engine/shared/http.cpp
@@ -362,12 +362,8 @@ void CHttpRequest::Wait()
 
 void CHttpRequest::Result(unsigned char **ppResult, size_t *pResultLength) const
 {
-	if(m_WriteToFile || State() != EHttpState::DONE)
-	{
-		*ppResult = nullptr;
-		*pResultLength = 0;
-		return;
-	}
+	dbg_assert(State() == EHttpState::DONE, "Request not done");
+	dbg_assert(!m_WriteToFile, "Result not usable together with WriteToFile");
 	*ppResult = m_pBuffer;
 	*pResultLength = m_ResponseLength;
 }
@@ -377,11 +373,13 @@ json_value *CHttpRequest::ResultJson() const
 	unsigned char *pResult;
 	size_t ResultLength;
 	Result(&pResult, &ResultLength);
-	if(!pResult)
-	{
-		return nullptr;
-	}
 	return json_parse((char *)pResult, ResultLength);
+}
+
+const SHA256_DIGEST &CHttpRequest::ResultSha256() const
+{
+	dbg_assert(State() == EHttpState::DONE, "Request not done");
+	return m_ActualSha256;
 }
 
 bool CHttp::Init(std::chrono::milliseconds ShutdownDelay)

--- a/src/engine/shared/http.h
+++ b/src/engine/shared/http.h
@@ -199,7 +199,7 @@ public:
 	void Result(unsigned char **ppResult, size_t *pResultLength) const;
 	json_value *ResultJson() const;
 
-	const SHA256_DIGEST &Sha256() const { return m_ActualSha256; }
+	const SHA256_DIGEST &ResultSha256() const;
 };
 
 inline std::unique_ptr<CHttpRequest> HttpHead(const char *pUrl)


### PR DESCRIPTION
Add assertions to ensure that the HTTP request result data and SHA256 are available when getting them instead of returning `nullptr` and `SHA256_ZEROED` when they are not.

Rename `CHttpRequest::Sha256` function to `ResultSha256`.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
