### PR TITLE
Fix /tpxy parameter bug

### DIFF
--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -1638,11 +1638,11 @@ void CGameContext::ConTeleXY(IConsole::IResult *pResult, void *pUserData)
 			// Relative?
 			const char *pStrDelta = str_startswith(pInString, "~");
 
-			if(!str_isallnum(pStrDelta ? pStrDelta : pInString))
+			float d;
+			if(!str_tofloat(pStrDelta ? pStrDelta : pInString,&d))
 				return false;
 
 			// Is the number valid?
-			float d = str_tofloat(pStrDelta ? pStrDelta : pInString);
 			if(std::isnan(d) || std::isinf(d))
 				return false;
 

--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -1639,7 +1639,7 @@ void CGameContext::ConTeleXY(IConsole::IResult *pResult, void *pUserData)
 			const char *pStrDelta = str_startswith(pInString, "~");
 
 			float d;
-			if(!str_tofloat(pStrDelta ? pStrDelta : pInString,&d))
+			if(!str_tofloat(pStrDelta ? pStrDelta : pInString, &d))
 				return false;
 
 			// Is the number valid?

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -3647,7 +3647,7 @@ void CGameContext::RegisterChatCommands()
 	Console()->Register("rescue", "", CFGFLAG_CHAT | CFGFLAG_SERVER, ConRescue, this, "Teleport yourself out of freeze (use sv_rescue 1 to enable this feature)");
 	Console()->Register("tp", "?r[player name]", CFGFLAG_CHAT | CFGFLAG_SERVER, ConTeleTo, this, "Depending on the number of supplied arguments, teleport yourself to; (0.) where you are spectating or aiming; (1.) the specified player name");
 	Console()->Register("teleport", "?r[player name]", CFGFLAG_CHAT | CFGFLAG_SERVER, ConTeleTo, this, "Depending on the number of supplied arguments, teleport yourself to; (0.) where you are spectating or aiming; (1.) the specified player name");
-	Console()->Register("tpxy", "i[x] i[y]", CFGFLAG_CHAT | CFGFLAG_SERVER, ConTeleXY, this, "Teleport yourself to the specified coordinates");
+	Console()->Register("tpxy", "f[x] f[y]", CFGFLAG_CHAT | CFGFLAG_SERVER, ConTeleXY, this, "Teleport yourself to the specified coordinates");
 	Console()->Register("lasttp", "", CFGFLAG_CHAT | CFGFLAG_SERVER, ConLastTele, this, "Teleport yourself to the last location you teleported to");
 	Console()->Register("tc", "?r[player name]", CFGFLAG_CHAT | CFGFLAG_SERVER, ConTeleCursor, this, "Teleport yourself to player or to where you are spectating/or looking if no player name is given");
 	Console()->Register("telecursor", "?r[player name]", CFGFLAG_CHAT | CFGFLAG_SERVER, ConTeleCursor, this, "Teleport yourself to player or to where you are spectating/or looking if no player name is given");


### PR DESCRIPTION
Previously, /tpxy only worked with ints, as well as negative numbers not working. With this change, you can teleport to any float coordinate, as well as negative coordinate, including being able to tp relatively in the negative direction which was previously broken as well, only being able to teleport down or right.



## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
