### PR TITLE
Ingame aspect ratio, a.k.a 5:4 ingame support while UI is normal resolution

### DIFF
--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -151,6 +151,7 @@ MACRO_CONFIG_INT(UiCloseWindowAfterChangingSetting, ui_close_window_after_changi
 MACRO_CONFIG_INT(UiUnreadNews, ui_unread_news, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Whether there is unread news")
 
 MACRO_CONFIG_INT(GfxNoclip, gfx_noclip, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Disable clipping")
+MACRO_CONFIG_INT(GfxIngameAspectRatio, gfx_ingame_aspect_ratio, 0, 0, 10000, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Ingame aspect ratio (normalized float by 1000)")
 
 // dummy
 MACRO_CONFIG_STR(ClDummyName, dummy_name, 16, "", CFGFLAG_SAVE | CFGFLAG_CLIENT | CFGFLAG_INSENSITIVE, "Name of the dummy")

--- a/src/game/client/render.cpp
+++ b/src/game/client/render.cpp
@@ -373,6 +373,9 @@ void CRenderTools::CalcScreenParams(float Aspect, float Zoom, float *pWidth, flo
 	const float WMax = 1500;
 	const float HMax = 1050;
 
+	if(g_Config.m_GfxIngameAspectRatio != 0)
+		Aspect = g_Config.m_GfxIngameAspectRatio / 1000.0f;
+
 	const float f = std::sqrt(Amount) / std::sqrt(Aspect);
 	*pWidth = f * Aspect;
 	*pHeight = f;

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -332,13 +332,15 @@ float CUI::ButtonColorMul(const void *pID)
 const CUIRect *CUI::Screen()
 {
 	m_Screen.h = 600.0f;
-	m_Screen.w = Graphics()->ScreenAspect() * m_Screen.h;
+	m_Screen.w = (16.0f / 9.0f) * m_Screen.h;
 	return &m_Screen;
 }
 
 void CUI::MapScreen()
 {
-	const CUIRect *pScreen = Screen();
+	CUIRect ScreenV = *Screen();
+	CUIRect* pScreen = &ScreenV;
+	pScreen->h = pScreen->w / Graphics()->ScreenAspect();
 	Graphics()->MapScreen(pScreen->x, pScreen->y, pScreen->w, pScreen->h);
 }
 


### PR DESCRIPTION
Not really a pr that i want to finish.

Just want to show how ez it would be to have 5:4 stretched aspect without changing UI aspect ratio.
That's what some players use to play.

so `gfx_ingame_aspect_ratio 1250` (`5 / 4 = 1.25 => 1.25 * 1000 (normalized float)`) would be 5:4 aspect ratio.

This could be interesting to discourage ppl from using native 5:4 resolutions, which means more 5:4 UI testings xd

Edit:

Menu map would be affected like this, so maybe would be cleaner to handle it outside or force disallow the config

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
