### PR TITLE
Use generic client warning for failed sound init

### DIFF
--- a/src/engine/client.h
+++ b/src/engine/client.h
@@ -242,8 +242,6 @@ public:
 	virtual const char *LatestVersion() const = 0;
 	virtual bool ConnectionProblems() const = 0;
 
-	virtual bool SoundInitFailed() const = 0;
-
 	virtual IGraphics::CTextureHandle GetDebugFont() const = 0; // TODO: remove this function
 
 	//DDRace

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -2727,7 +2727,7 @@ void CClient::Run()
 	Graphics()->Swap();
 
 	// init sound, allowed to fail
-	m_SoundInitFailed = Sound()->Init() != 0;
+	const bool SoundInitFailed = Sound()->Init() != 0;
 
 #if defined(CONF_VIDEORECORDER)
 	// init video recorder aka ffmpeg
@@ -2804,6 +2804,13 @@ void CClient::Run()
 		g_Config.m_ClShowWelcome = 0;
 	else
 		RequestDDNetInfo();
+
+	if(SoundInitFailed)
+	{
+		SWarning Warning(Localize("Sound error"), Localize("The audio device couldn't be initialised."));
+		Warning.m_AutoHide = false;
+		m_vWarnings.emplace_back(Warning);
+	}
 
 	bool LastD = false;
 	bool LastE = false;

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -109,7 +109,6 @@ class CClient : public IClient, public CDemoPlayer::IListener
 	bool m_AutoStatScreenshotRecycle = false;
 	bool m_AutoCSVRecycle = false;
 	bool m_EditorActive = false;
-	bool m_SoundInitFailed = false;
 
 	int m_aAckGameTick[NUM_DUMMIES] = {-1, -1};
 	int m_aCurrentRecvTick[NUM_DUMMIES] = {0, 0};
@@ -286,8 +285,6 @@ public:
 	void Rcon(const char *pCmd) override;
 
 	bool ConnectionProblems() const override;
-
-	bool SoundInitFailed() const override { return m_SoundInitFailed; }
 
 	IGraphics::CTextureHandle GetDebugFont() const override { return m_DebugFont; }
 

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -1045,14 +1045,6 @@ void CMenus::Render()
 		ms_ColorTabbarHover = ms_ColorTabbarHoverOutgame;
 	}
 
-	static bool s_SoundCheck = false;
-	if(!s_SoundCheck && m_Popup == POPUP_NONE)
-	{
-		if(Client()->SoundInitFailed())
-			PopupMessage(Localize("Sound error"), Localize("The audio device couldn't be initialised."), Localize("Ok"));
-		s_SoundCheck = true;
-	}
-
 	if(m_Popup == POPUP_NONE)
 	{
 		if(m_JoinTutorial && ServerBrowser()->DDNetInfoAvailable() && !ServerBrowser()->IsGettingServerlist())


### PR DESCRIPTION
Simplify code by using generic warning system instead of hard-coding the warning.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
