### PR TITLE
Show warnings after client close instead of preventing quitting

### DIFF
--- a/src/engine/client.h
+++ b/src/engine/client.h
@@ -335,7 +335,6 @@ public:
 	virtual void DummyResetInput() = 0;
 	virtual void Echo(const char *pString) = 0;
 	virtual bool CanDisplayWarning() const = 0;
-	virtual bool IsDisplayingWarning() const = 0;
 
 	virtual CNetObjHandler *GetNetObjHandler() = 0;
 };

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -228,6 +228,7 @@ class CClient : public IClient, public CDemoPlayer::IListener
 	} m_VersionInfo;
 
 	std::vector<SWarning> m_vWarnings;
+	std::vector<SWarning> m_vQuittingWarnings;
 
 	CFifo m_Fifo;
 
@@ -495,6 +496,7 @@ public:
 
 	void AddWarning(const SWarning &Warning) override;
 	SWarning *GetCurWarning() override;
+	std::vector<SWarning> &&QuittingWarnings() { return std::move(m_vQuittingWarnings); }
 
 	CChecksumData *ChecksumData() override { return &m_Checksum.m_Data; }
 	int UdpConnectivity(int NetType) override;

--- a/src/engine/shared/config.cpp
+++ b/src/engine/shared/config.cpp
@@ -445,6 +445,7 @@ bool CConfigManager::Save()
 		return false;
 	}
 
+	log_info("config", "saved to " CONFIG_FILE);
 	return true;
 }
 

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -731,7 +731,6 @@ public:
 	void UpdateOwnGhost(CGhostItem Item);
 	void DeleteGhostItem(int Index);
 
-	int GetCurPopup() const { return m_Popup; }
 	bool CanDisplayWarning() const;
 
 	void PopupWarning(const char *pTopic, const char *pBody, const char *pButton, std::chrono::nanoseconds Duration);

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -3520,11 +3520,6 @@ bool CGameClient::CanDisplayWarning() const
 	return m_Menus.CanDisplayWarning();
 }
 
-bool CGameClient::IsDisplayingWarning() const
-{
-	return m_Menus.GetCurPopup() == CMenus::POPUP_WARNING;
-}
-
 CNetObjHandler *CGameClient::GetNetObjHandler()
 {
 	return &m_NetObjHandler;

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -555,7 +555,6 @@ public:
 	int SwitchStateTeam() const;
 	bool IsLocalCharSuper() const;
 	bool CanDisplayWarning() const override;
-	bool IsDisplayingWarning() const override;
 	CNetObjHandler *GetNetObjHandler() override;
 
 	void LoadGameSkin(const char *pPath, bool AsDir = false);


### PR DESCRIPTION
Instead of preventing the client from quitting/restarting while a warning is shown in the menus, add warnings that should be shown after quitting/restarting (i.e. the warning when the config could not be saved) to a separate list and show these warnings using an OS message box after the client has been closed. Otherwise, the client is prevented from closing if a warning is shown without being automatically hidden, which causes the client to hang indefinitely in the CI.

The message boxes for warnings must be shown after the client has already been completely shutdown, otherwise the regular shutdown with the Vulkan backend crashes because showing the message box has already partially deinitialized the backend.

The quitting/restarting client state is now checked after updating the FIFO component, so quitting/restarting initiated via FIFO is effective immediately, although this should have little effect in practice.

For completeness, a log message is added also for the case that the config was saved successfully.

The GitHub CI seems to automatically confirm/disable OS message boxes, so they should not block workflows.

See #7942 for runs which were hanging due to warnings because of failed sound init in the Ubuntu workflows. 

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
