### PR TITLE
Add "View" button to switch drop down in editor

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -1310,7 +1310,7 @@ void CEditor::DoToolbarLayers(CUIRect ToolBar)
 					{
 						pButtonName = "Switch";
 						pfnPopupFunc = PopupSwitch;
-						Rows = 2;
+						Rows = 3;
 					}
 					else if(pS == m_Map.m_pSpeedupLayer)
 					{

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -1114,6 +1114,7 @@ public:
 
 	unsigned char m_SwitchNum;
 	unsigned char m_SwitchDelay;
+	unsigned char m_ViewSwitch;
 
 	void AdjustBrushSpecialTiles(bool UseNextFree, int Adjust = 0);
 	int FindNextFreeSwitchNumber();

--- a/src/game/editor/mapitems/layer_switch.h
+++ b/src/game/editor/mapitems/layer_switch.h
@@ -36,6 +36,10 @@ public:
 	void BrushRotate(float Amount) override;
 	void FillSelection(bool Empty, std::shared_ptr<CLayer> pBrush, CUIRect Rect) override;
 	virtual bool ContainsElementWithId(int Id);
+	virtual void GetPos(int Number, int Offset, ivec2 &SwitchPos);
+
+	int m_GotoSwitchOffset;
+	ivec2 m_GotoSwitchLastPos;
 
 	EditorTileStateChangeHistory<SSwitchTileStateChange> m_History;
 	inline void ClearHistory() override


### PR DESCRIPTION
This allows mappers to find switchers by number.

#7931 is still not finished. Because it also demands shift+n functionality which is not yet implemented.

![image](https://github.com/ddnet/ddnet/assets/20344300/7d4e98d0-3613-4456-b4f1-fa76f571135c)

Works the same as #7929 just for switch instead of tele.

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
