### PR TITLE
Move tele vector init from gamecontroller to collision

### DIFF
--- a/src/game/collision.cpp
+++ b/src/game/collision.cpp
@@ -135,12 +135,9 @@ void CCollision::Init(class CLayers *pLayers)
 	m_TeleIns.clear();
 	m_TeleOuts.clear();
 	m_TeleCheckOuts.clear();
-	if(m_pLayers->TeleLayer())
+	if(m_pTele)
 	{
-		int Width = m_pLayers->TeleLayer()->m_Width;
-		int Height = m_pLayers->TeleLayer()->m_Height;
-
-		for(int i = 0; i < Width * Height; i++)
+		for(int i = 0; i < m_Width * m_Height; i++)
 		{
 			int Number = TeleLayer()[i].m_Number;
 			int Type = TeleLayer()[i].m_Type;
@@ -148,15 +145,15 @@ void CCollision::Init(class CLayers *pLayers)
 			{
 				if(Type == TILE_TELEIN)
 				{
-					m_TeleIns[Number - 1].emplace_back(i % Width * 32.0f + 16.0f, i / Width * 32.0f + 16.0f);
+					m_TeleIns[Number - 1].emplace_back(i % m_Width * 32.0f + 16.0f, i / m_Width * 32.0f + 16.0f);
 				}
 				else if(Type == TILE_TELEOUT)
 				{
-					m_TeleOuts[Number - 1].emplace_back(i % Width * 32.0f + 16.0f, i / Width * 32.0f + 16.0f);
+					m_TeleOuts[Number - 1].emplace_back(i % m_Width * 32.0f + 16.0f, i / m_Width * 32.0f + 16.0f);
 				}
 				else if(Type == TILE_TELECHECKOUT)
 				{
-					m_TeleCheckOuts[Number - 1].emplace_back(i % Width * 32.0f + 16.0f, i / Width * 32.0f + 16.0f);
+					m_TeleCheckOuts[Number - 1].emplace_back(i % m_Width * 32.0f + 16.0f, i / m_Width * 32.0f + 16.0f);
 				}
 			}
 		}

--- a/src/game/collision.cpp
+++ b/src/game/collision.cpp
@@ -131,6 +131,36 @@ void CCollision::Init(class CLayers *pLayers)
 			}
 		}
 	}
+
+	m_TeleIns.clear();
+	m_TeleOuts.clear();
+	m_TeleCheckOuts.clear();
+	if(m_pLayers->TeleLayer())
+	{
+		int Width = m_pLayers->TeleLayer()->m_Width;
+		int Height = m_pLayers->TeleLayer()->m_Height;
+
+		for(int i = 0; i < Width * Height; i++)
+		{
+			int Number = TeleLayer()[i].m_Number;
+			int Type = TeleLayer()[i].m_Type;
+			if(Number > 0)
+			{
+				if(Type == TILE_TELEIN)
+				{
+					m_TeleIns[Number - 1].emplace_back(i % Width * 32.0f + 16.0f, i / Width * 32.0f + 16.0f);
+				}
+				else if(Type == TILE_TELEOUT)
+				{
+					m_TeleOuts[Number - 1].emplace_back(i % Width * 32.0f + 16.0f, i / Width * 32.0f + 16.0f);
+				}
+				else if(Type == TILE_TELECHECKOUT)
+				{
+					m_TeleCheckOuts[Number - 1].emplace_back(i % Width * 32.0f + 16.0f, i / Width * 32.0f + 16.0f);
+				}
+			}
+		}
+	}
 }
 
 void CCollision::FillAntibot(CAntibotMapData *pMapData)

--- a/src/game/collision.h
+++ b/src/game/collision.h
@@ -6,6 +6,7 @@
 #include <base/vmath.h>
 #include <engine/shared/protocol.h>
 
+#include <map>
 #include <vector>
 
 enum
@@ -116,7 +117,15 @@ public:
 	class CLayers *Layers() { return m_pLayers; }
 	int m_HighestSwitchNumber;
 
+	std::map<int, std::vector<vec2>> &TeleIns() { return m_TeleIns; }
+	std::map<int, std::vector<vec2>> &TeleOuts() { return m_TeleOuts; }
+	std::map<int, std::vector<vec2>> &TeleCheckOuts() { return m_TeleCheckOuts; }
+
 private:
+	std::map<int, std::vector<vec2>> m_TeleIns;
+	std::map<int, std::vector<vec2>> m_TeleOuts;
+	std::map<int, std::vector<vec2>> m_TeleCheckOuts;
+
 	class CTeleTile *m_pTele;
 	class CSpeedupTile *m_pSpeedup;
 	class CTile *m_pFront;

--- a/src/game/collision.h
+++ b/src/game/collision.h
@@ -117,9 +117,9 @@ public:
 	class CLayers *Layers() { return m_pLayers; }
 	int m_HighestSwitchNumber;
 
-	std::map<int, std::vector<vec2>> &TeleIns() { return m_TeleIns; }
-	std::map<int, std::vector<vec2>> &TeleOuts() { return m_TeleOuts; }
-	std::map<int, std::vector<vec2>> &TeleCheckOuts() { return m_TeleCheckOuts; }
+	const std::vector<vec2> &TeleIns(int Number) { return m_TeleIns[Number]; }
+	const std::vector<vec2> &TeleOuts(int Number) { return m_TeleOuts[Number]; }
+	const std::vector<vec2> &TeleCheckOuts(int Number) { return m_TeleCheckOuts[Number]; }
 
 private:
 	std::map<int, std::vector<vec2>> m_TeleIns;

--- a/src/game/gamecore.cpp
+++ b/src/game/gamecore.cpp
@@ -70,11 +70,10 @@ float VelocityRamp(float Value, float Start, float Range, float Curvature)
 	return 1.0f / std::pow(Curvature, (Value - Start) / Range);
 }
 
-void CCharacterCore::Init(CWorldCore *pWorld, CCollision *pCollision, CTeamsCore *pTeams, std::map<int, std::vector<vec2>> *pTeleOuts)
+void CCharacterCore::Init(CWorldCore *pWorld, CCollision *pCollision, CTeamsCore *pTeams)
 {
 	m_pWorld = pWorld;
 	m_pCollision = pCollision;
-	m_pTeleOuts = pTeleOuts;
 
 	m_pTeams = pTeams;
 	m_Id = -1;
@@ -327,14 +326,14 @@ void CCharacterCore::Tick(bool UseInput, bool DoDeferredTick)
 				m_HookState = HOOK_RETRACT_START;
 			}
 
-			if(GoingThroughTele && m_pWorld && m_pTeleOuts && !m_pTeleOuts->empty() && !(*m_pTeleOuts)[teleNr - 1].empty())
+			if(GoingThroughTele && m_pWorld && !m_pCollision->TeleOuts(teleNr - 1).empty())
 			{
 				m_TriggeredEvents = 0;
 				SetHookedPlayer(-1);
 
 				m_NewHook = true;
-				int RandomOut = m_pWorld->RandomOr0((*m_pTeleOuts)[teleNr - 1].size());
-				m_HookPos = (*m_pTeleOuts)[teleNr - 1][RandomOut] + TargetDirection * PhysicalSize() * 1.5f;
+				int RandomOut = m_pWorld->RandomOr0(m_pCollision->TeleOuts(teleNr - 1).size());
+				m_HookPos = m_pCollision->TeleOuts(teleNr - 1)[RandomOut] + TargetDirection * PhysicalSize() * 1.5f;
 				m_HookDir = TargetDirection;
 				m_HookTeleBase = m_HookPos;
 			}
@@ -675,11 +674,6 @@ void CCharacterCore::SetHookedPlayer(int HookedPlayer)
 void CCharacterCore::SetTeamsCore(CTeamsCore *pTeams)
 {
 	m_pTeams = pTeams;
-}
-
-void CCharacterCore::SetTeleOuts(std::map<int, std::vector<vec2>> *pTeleOuts)
-{
-	m_pTeleOuts = pTeleOuts;
 }
 
 bool CCharacterCore::IsSwitchActiveCb(int Number, void *pUser)

--- a/src/game/gamecore.h
+++ b/src/game/gamecore.h
@@ -221,7 +221,6 @@ class CCharacterCore
 {
 	CWorldCore *m_pWorld = nullptr;
 	CCollision *m_pCollision;
-	std::map<int, std::vector<vec2>> *m_pTeleOuts;
 
 public:
 	static constexpr float PhysicalSize() { return 28.0f; };
@@ -269,7 +268,7 @@ public:
 
 	int m_TriggeredEvents;
 
-	void Init(CWorldCore *pWorld, CCollision *pCollision, CTeamsCore *pTeams = nullptr, std::map<int, std::vector<vec2>> *pTeleOuts = nullptr);
+	void Init(CWorldCore *pWorld, CCollision *pCollision, CTeamsCore *pTeams = nullptr);
 	void SetCoreWorld(CWorldCore *pWorld, CCollision *pCollision, CTeamsCore *pTeams);
 	void Reset();
 	void TickDeferred();
@@ -290,7 +289,6 @@ public:
 
 	// DDNet Character
 	void SetTeamsCore(CTeamsCore *pTeams);
-	void SetTeleOuts(std::map<int, std::vector<vec2>> *pTeleOuts);
 	void ReadDDNet(const CNetObj_DDNetCharacter *pObjDDNet);
 	bool m_Solo;
 	bool m_Jetpack;

--- a/src/game/server/ddracecommands.cpp
+++ b/src/game/server/ddracecommands.cpp
@@ -361,13 +361,13 @@ void CGameContext::ConToTeleporter(IConsole::IResult *pResult, void *pUserData)
 	CGameContext *pSelf = (CGameContext *)pUserData;
 	unsigned int TeleTo = pResult->GetInteger(0);
 
-	if(!pSelf->Collision()->TeleOuts()[TeleTo - 1].empty())
+	if(!pSelf->Collision()->TeleOuts(TeleTo - 1).empty())
 	{
 		CCharacter *pChr = pSelf->GetPlayerChar(pResult->m_ClientId);
 		if(pChr)
 		{
-			int TeleOut = pSelf->m_World.m_Core.RandomOr0(pSelf->Collision()->TeleOuts()[TeleTo - 1].size());
-			pSelf->Teleport(pChr, pSelf->Collision()->TeleOuts()[TeleTo - 1][TeleOut]);
+			int TeleOut = pSelf->m_World.m_Core.RandomOr0(pSelf->Collision()->TeleOuts(TeleTo - 1).size());
+			pSelf->Teleport(pChr, pSelf->Collision()->TeleOuts(TeleTo - 1)[TeleOut]);
 		}
 	}
 }
@@ -377,13 +377,13 @@ void CGameContext::ConToCheckTeleporter(IConsole::IResult *pResult, void *pUserD
 	CGameContext *pSelf = (CGameContext *)pUserData;
 	unsigned int TeleTo = pResult->GetInteger(0);
 
-	if(!pSelf->Collision()->TeleCheckOuts()[TeleTo - 1].empty())
+	if(!pSelf->Collision()->TeleCheckOuts(TeleTo - 1).empty())
 	{
 		CCharacter *pChr = pSelf->GetPlayerChar(pResult->m_ClientId);
 		if(pChr)
 		{
-			int TeleOut = pSelf->m_World.m_Core.RandomOr0(pSelf->Collision()->TeleCheckOuts()[TeleTo - 1].size());
-			pSelf->Teleport(pChr, pSelf->Collision()->TeleCheckOuts()[TeleTo - 1][TeleOut]);
+			int TeleOut = pSelf->m_World.m_Core.RandomOr0(pSelf->Collision()->TeleCheckOuts(TeleTo - 1).size());
+			pSelf->Teleport(pChr, pSelf->Collision()->TeleCheckOuts(TeleTo - 1)[TeleOut]);
 			pChr->m_TeleCheckpoint = TeleTo;
 		}
 	}

--- a/src/game/server/ddracecommands.cpp
+++ b/src/game/server/ddracecommands.cpp
@@ -361,13 +361,13 @@ void CGameContext::ConToTeleporter(IConsole::IResult *pResult, void *pUserData)
 	CGameContext *pSelf = (CGameContext *)pUserData;
 	unsigned int TeleTo = pResult->GetInteger(0);
 
-	if(!pSelf->m_pController->m_TeleOuts[TeleTo - 1].empty())
+	if(!pSelf->Collision()->TeleOuts()[TeleTo - 1].empty())
 	{
 		CCharacter *pChr = pSelf->GetPlayerChar(pResult->m_ClientId);
 		if(pChr)
 		{
-			int TeleOut = pSelf->m_World.m_Core.RandomOr0(pSelf->m_pController->m_TeleOuts[TeleTo - 1].size());
-			pSelf->Teleport(pChr, pSelf->m_pController->m_TeleOuts[TeleTo - 1][TeleOut]);
+			int TeleOut = pSelf->m_World.m_Core.RandomOr0(pSelf->Collision()->TeleOuts()[TeleTo - 1].size());
+			pSelf->Teleport(pChr, pSelf->Collision()->TeleOuts()[TeleTo - 1][TeleOut]);
 		}
 	}
 }
@@ -377,13 +377,13 @@ void CGameContext::ConToCheckTeleporter(IConsole::IResult *pResult, void *pUserD
 	CGameContext *pSelf = (CGameContext *)pUserData;
 	unsigned int TeleTo = pResult->GetInteger(0);
 
-	if(!pSelf->m_pController->m_TeleCheckOuts[TeleTo - 1].empty())
+	if(!pSelf->Collision()->TeleCheckOuts()[TeleTo - 1].empty())
 	{
 		CCharacter *pChr = pSelf->GetPlayerChar(pResult->m_ClientId);
 		if(pChr)
 		{
-			int TeleOut = pSelf->m_World.m_Core.RandomOr0(pSelf->m_pController->m_TeleCheckOuts[TeleTo - 1].size());
-			pSelf->Teleport(pChr, pSelf->m_pController->m_TeleCheckOuts[TeleTo - 1][TeleOut]);
+			int TeleOut = pSelf->m_World.m_Core.RandomOr0(pSelf->Collision()->TeleCheckOuts()[TeleTo - 1].size());
+			pSelf->Teleport(pChr, pSelf->Collision()->TeleCheckOuts()[TeleTo - 1][TeleOut]);
 			pChr->m_TeleCheckpoint = TeleTo;
 		}
 	}

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -794,7 +794,7 @@ void CCharacter::TickDeferred()
 	// advance the dummy
 	{
 		CWorldCore TempWorld;
-		m_ReckoningCore.Init(&TempWorld, Collision(), &Teams()->m_Core, m_pTeleOuts);
+		m_ReckoningCore.Init(&TempWorld, Collision(), &Teams()->m_Core);
 		m_ReckoningCore.m_Id = m_pPlayer->GetCid();
 		m_ReckoningCore.Tick(false);
 		m_ReckoningCore.Move();
@@ -1291,13 +1291,6 @@ bool CCharacter::SameTeam(int ClientId)
 int CCharacter::Team()
 {
 	return Teams()->m_Core.Team(m_pPlayer->GetCid());
-}
-
-void CCharacter::SetTeleports(std::map<int, std::vector<vec2>> *pTeleOuts, std::map<int, std::vector<vec2>> *pTeleCheckOuts)
-{
-	m_pTeleOuts = pTeleOuts;
-	m_pTeleCheckOuts = pTeleCheckOuts;
-	m_Core.SetTeleOuts(pTeleOuts);
 }
 
 void CCharacter::FillAntibot(CAntibotCharacterData *pData)
@@ -1834,12 +1827,12 @@ void CCharacter::HandleTiles(int Index)
 	}
 
 	int z = Collision()->IsTeleport(MapIndex);
-	if(!g_Config.m_SvOldTeleportHook && !g_Config.m_SvOldTeleportWeapons && z && !(*m_pTeleOuts)[z - 1].empty())
+	if(!g_Config.m_SvOldTeleportHook && !g_Config.m_SvOldTeleportWeapons && z && !Collision()->TeleOuts(z - 1).empty())
 	{
 		if(m_Core.m_Super)
 			return;
-		int TeleOut = GameWorld()->m_Core.RandomOr0((*m_pTeleOuts)[z - 1].size());
-		m_Core.m_Pos = (*m_pTeleOuts)[z - 1][TeleOut];
+		int TeleOut = GameWorld()->m_Core.RandomOr0(Collision()->TeleOuts(z - 1).size());
+		m_Core.m_Pos = Collision()->TeleOuts(z - 1)[TeleOut];
 		if(!g_Config.m_SvTeleportHoldHook)
 		{
 			ResetHook();
@@ -1849,12 +1842,12 @@ void CCharacter::HandleTiles(int Index)
 		return;
 	}
 	int evilz = Collision()->IsEvilTeleport(MapIndex);
-	if(evilz && !(*m_pTeleOuts)[evilz - 1].empty())
+	if(evilz && !Collision()->TeleOuts(evilz - 1).empty())
 	{
 		if(m_Core.m_Super)
 			return;
-		int TeleOut = GameWorld()->m_Core.RandomOr0((*m_pTeleOuts)[evilz - 1].size());
-		m_Core.m_Pos = (*m_pTeleOuts)[evilz - 1][TeleOut];
+		int TeleOut = GameWorld()->m_Core.RandomOr0(Collision()->TeleOuts(evilz - 1).size());
+		m_Core.m_Pos = Collision()->TeleOuts(evilz - 1)[TeleOut];
 		if(!g_Config.m_SvOldTeleportHook && !g_Config.m_SvOldTeleportWeapons)
 		{
 			m_Core.m_Vel = vec2(0, 0);
@@ -1878,10 +1871,10 @@ void CCharacter::HandleTiles(int Index)
 		// first check if there is a TeleCheckOut for the current recorded checkpoint, if not check previous checkpoints
 		for(int k = m_TeleCheckpoint - 1; k >= 0; k--)
 		{
-			if(!(*m_pTeleCheckOuts)[k].empty())
+			if(!Collision()->TeleCheckOuts(k).empty())
 			{
-				int TeleOut = GameWorld()->m_Core.RandomOr0((*m_pTeleCheckOuts)[k].size());
-				m_Core.m_Pos = (*m_pTeleCheckOuts)[k][TeleOut];
+				int TeleOut = GameWorld()->m_Core.RandomOr0(Collision()->TeleCheckOuts(k).size());
+				m_Core.m_Pos = Collision()->TeleCheckOuts(k)[TeleOut];
 				m_Core.m_Vel = vec2(0, 0);
 
 				if(!g_Config.m_SvTeleportHoldHook)
@@ -1915,10 +1908,10 @@ void CCharacter::HandleTiles(int Index)
 		// first check if there is a TeleCheckOut for the current recorded checkpoint, if not check previous checkpoints
 		for(int k = m_TeleCheckpoint - 1; k >= 0; k--)
 		{
-			if(!(*m_pTeleCheckOuts)[k].empty())
+			if(!Collision()->TeleCheckOuts(k).empty())
 			{
-				int TeleOut = GameWorld()->m_Core.RandomOr0((*m_pTeleCheckOuts)[k].size());
-				m_Core.m_Pos = (*m_pTeleCheckOuts)[k][TeleOut];
+				int TeleOut = GameWorld()->m_Core.RandomOr0(Collision()->TeleCheckOuts(k).size());
+				m_Core.m_Pos = Collision()->TeleCheckOuts(k)[TeleOut];
 
 				if(!g_Config.m_SvTeleportHoldHook)
 				{

--- a/src/game/server/entities/character.h
+++ b/src/game/server/entities/character.h
@@ -147,9 +147,6 @@ private:
 	CCharacterCore m_Core;
 	CGameTeams *m_pTeams = nullptr;
 
-	std::map<int, std::vector<vec2>> *m_pTeleOuts = nullptr;
-	std::map<int, std::vector<vec2>> *m_pTeleCheckOuts = nullptr;
-
 	// info for dead reckoning
 	int m_ReckoningTick; // tick that we are performing dead reckoning From
 	CCharacterCore m_SendCore; // core that we should send
@@ -179,7 +176,6 @@ private:
 public:
 	CGameTeams *Teams() { return m_pTeams; }
 	void SetTeams(CGameTeams *pTeams);
-	void SetTeleports(std::map<int, std::vector<vec2>> *pTeleOuts, std::map<int, std::vector<vec2>> *pTeleCheckOuts);
 
 	void FillAntibot(CAntibotCharacterData *pData);
 	void Pause(bool Pause);

--- a/src/game/server/entities/laser.cpp
+++ b/src/game/server/entities/laser.cpp
@@ -164,10 +164,10 @@ void CLaser::DoBounce()
 			}
 			m_ZeroEnergyBounceInLastTick = Distance == 0.0f;
 
-			if(Res == TILE_TELEINWEAPON && !GameServer()->Collision()->TeleOuts()[z - 1].empty())
+			if(Res == TILE_TELEINWEAPON && !GameServer()->Collision()->TeleOuts(z - 1).empty())
 			{
-				int TeleOut = GameServer()->m_World.m_Core.RandomOr0(GameServer()->Collision()->TeleOuts()[z - 1].size());
-				m_TelePos = GameServer()->Collision()->TeleOuts()[z - 1][TeleOut];
+				int TeleOut = GameServer()->m_World.m_Core.RandomOr0(GameServer()->Collision()->TeleOuts(z - 1).size());
+				m_TelePos = GameServer()->Collision()->TeleOuts(z - 1)[TeleOut];
 				m_WasTele = true;
 			}
 			else

--- a/src/game/server/entities/laser.cpp
+++ b/src/game/server/entities/laser.cpp
@@ -164,10 +164,10 @@ void CLaser::DoBounce()
 			}
 			m_ZeroEnergyBounceInLastTick = Distance == 0.0f;
 
-			if(Res == TILE_TELEINWEAPON && !GameServer()->m_pController->m_TeleOuts[z - 1].empty())
+			if(Res == TILE_TELEINWEAPON && !GameServer()->Collision()->TeleOuts()[z - 1].empty())
 			{
-				int TeleOut = GameServer()->m_World.m_Core.RandomOr0(GameServer()->m_pController->m_TeleOuts[z - 1].size());
-				m_TelePos = GameServer()->m_pController->m_TeleOuts[z - 1][TeleOut];
+				int TeleOut = GameServer()->m_World.m_Core.RandomOr0(GameServer()->Collision()->TeleOuts()[z - 1].size());
+				m_TelePos = GameServer()->Collision()->TeleOuts()[z - 1][TeleOut];
 				m_WasTele = true;
 			}
 			else

--- a/src/game/server/entities/projectile.cpp
+++ b/src/game/server/entities/projectile.cpp
@@ -276,10 +276,10 @@ void CProjectile::Tick()
 		z = GameServer()->Collision()->IsTeleport(x);
 	else
 		z = GameServer()->Collision()->IsTeleportWeapon(x);
-	if(z && !GameServer()->Collision()->TeleOuts()[z - 1].empty())
+	if(z && !GameServer()->Collision()->TeleOuts(z - 1).empty())
 	{
-		int TeleOut = GameServer()->m_World.m_Core.RandomOr0(GameServer()->Collision()->TeleOuts()[z - 1].size());
-		m_Pos = GameServer()->Collision()->TeleOuts()[z - 1][TeleOut];
+		int TeleOut = GameServer()->m_World.m_Core.RandomOr0(GameServer()->Collision()->TeleOuts(z - 1).size());
+		m_Pos = GameServer()->Collision()->TeleOuts(z - 1)[TeleOut];
 		m_StartTick = Server()->Tick();
 	}
 }

--- a/src/game/server/entities/projectile.cpp
+++ b/src/game/server/entities/projectile.cpp
@@ -276,10 +276,10 @@ void CProjectile::Tick()
 		z = GameServer()->Collision()->IsTeleport(x);
 	else
 		z = GameServer()->Collision()->IsTeleportWeapon(x);
-	if(z && !GameServer()->m_pController->m_TeleOuts[z - 1].empty())
+	if(z && !GameServer()->Collision()->TeleOuts()[z - 1].empty())
 	{
-		int TeleOut = GameServer()->m_World.m_Core.RandomOr0(GameServer()->m_pController->m_TeleOuts[z - 1].size());
-		m_Pos = GameServer()->m_pController->m_TeleOuts[z - 1][TeleOut];
+		int TeleOut = GameServer()->m_World.m_Core.RandomOr0(GameServer()->Collision()->TeleOuts()[z - 1].size());
+		m_Pos = GameServer()->Collision()->TeleOuts()[z - 1][TeleOut];
 		m_StartTick = Server()->Tick();
 	}
 }

--- a/src/game/server/gamecontroller.cpp
+++ b/src/game/server/gamecontroller.cpp
@@ -40,8 +40,6 @@ IGameController::IGameController(class CGameContext *pGameServer) :
 	m_ForceBalanced = false;
 
 	m_CurrentRecord = 0;
-
-	InitTeleporter();
 }
 
 IGameController::~IGameController() = default;
@@ -485,7 +483,7 @@ void IGameController::OnCharacterSpawn(class CCharacter *pChr)
 	pChr->GiveWeapon(WEAPON_HAMMER);
 	pChr->GiveWeapon(WEAPON_GUN);
 
-	pChr->SetTeleports(&m_TeleOuts, &m_TeleCheckOuts);
+	pChr->SetTeleports(&GameServer()->Collision()->TeleOuts(), &GameServer()->Collision()->TeleCheckOuts());
 }
 
 void IGameController::HandleCharacterTiles(CCharacter *pChr, int MapIndex)
@@ -710,31 +708,6 @@ CClientMask IGameController::GetMaskForPlayerWorldEvent(int Asker, int ExceptId)
 		return CClientMask().set().reset(ExceptId);
 
 	return Teams().TeamMask(GameServer()->GetDDRaceTeam(Asker), ExceptId, Asker);
-}
-
-void IGameController::InitTeleporter()
-{
-	if(!GameServer()->Collision()->Layers()->TeleLayer())
-		return;
-	int Width = GameServer()->Collision()->Layers()->TeleLayer()->m_Width;
-	int Height = GameServer()->Collision()->Layers()->TeleLayer()->m_Height;
-
-	for(int i = 0; i < Width * Height; i++)
-	{
-		int Number = GameServer()->Collision()->TeleLayer()[i].m_Number;
-		int Type = GameServer()->Collision()->TeleLayer()[i].m_Type;
-		if(Number > 0)
-		{
-			if(Type == TILE_TELEOUT)
-			{
-				m_TeleOuts[Number - 1].emplace_back(i % Width * 32.0f + 16.0f, i / Width * 32.0f + 16.0f);
-			}
-			else if(Type == TILE_TELECHECKOUT)
-			{
-				m_TeleCheckOuts[Number - 1].emplace_back(i % Width * 32.0f + 16.0f, i / Width * 32.0f + 16.0f);
-			}
-		}
-	}
 }
 
 void IGameController::DoTeamChange(CPlayer *pPlayer, int Team, bool DoChatMsg)

--- a/src/game/server/gamecontroller.cpp
+++ b/src/game/server/gamecontroller.cpp
@@ -482,8 +482,6 @@ void IGameController::OnCharacterSpawn(class CCharacter *pChr)
 	// give default weapons
 	pChr->GiveWeapon(WEAPON_HAMMER);
 	pChr->GiveWeapon(WEAPON_GUN);
-
-	pChr->SetTeleports(&GameServer()->Collision()->TeleOuts(), &GameServer()->Collision()->TeleCheckOuts());
 }
 
 void IGameController::HandleCharacterTiles(CCharacter *pChr, int MapIndex)

--- a/src/game/server/gamecontroller.h
+++ b/src/game/server/gamecontroller.h
@@ -8,9 +8,6 @@
 #include <engine/shared/protocol.h>
 #include <game/server/teams.h>
 
-#include <map>
-#include <vector>
-
 struct CScoreLoadBestTimeResult;
 
 /*
@@ -148,15 +145,12 @@ public:
 	virtual bool CanJoinTeam(int Team, int NotThisId, char *pErrorReason, int ErrorReasonSize);
 	int ClampTeam(int Team);
 
-	CClientMask GetMaskForPlayerWorldEvent(int Asker, int ExceptId = -1);
-	virtual void InitTeleporter();
+	CClientMask GetMaskForPlayerWorldEvent(int Asker, int ExceptID = -1);
 
 	bool IsTeamPlay() { return m_GameFlags & GAMEFLAG_TEAMS; }
 	// DDRace
 
 	float m_CurrentRecord;
-	std::map<int, std::vector<vec2>> m_TeleOuts;
-	std::map<int, std::vector<vec2>> m_TeleCheckOuts;
 	CGameTeams &Teams() { return m_Teams; }
 	std::shared_ptr<CScoreLoadBestTimeResult> m_pLoadBestTimeResult;
 };


### PR DESCRIPTION
Woah there cowboy! I know how this looks like. Breaking physics? Adding crash bugs? Increasing client startup time??

While trying to implement shift+n to see the previous teleporter in the editor I noticed how broken my old code is.
This thing seems to skip some tele tiles it should find #6887. Also the code is looping through the entire map which is not performant enough for live tele tracing which is needed for #2415. Also the weird loop makes it super messy to step forward and backward which is needed for #7931.

Having an indexed map seems like something that belongs into collision anyway and not into the game controller.
This also gives the client access to it. It does not use it yet. So for now its useless memory and cpu usage on client boot. Which I do not like. I was thinking of lazy loading it. So it only starts to fill the std::map and the std::vector inside when this getter is called the first time ``std::map<int, std::vector<vec2>> &TeleIns() { return m_TeleIns; }`` this way the client would not have any cpu/memory impact on launch. And would only ever fill the heap if the user is using a feature that requires to lookup teleporters.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
