### PR TITLE
Do not recalculate if the mouse did not move

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -8464,8 +8464,10 @@ void CEditor::HandleCursorMovement()
 
 	float MouseRelX = 0.0f, MouseRelY = 0.0f;
 	IInput::ECursorType CursorType = Input()->CursorRelative(&MouseRelX, &MouseRelY);
-	if(CursorType != IInput::CURSOR_NONE)
-		UI()->ConvertMouseMove(&MouseRelX, &MouseRelY, CursorType);
+	if(CursorType == IInput::CURSOR_NONE)
+		return;
+
+	UI()->ConvertMouseMove(&MouseRelX, &MouseRelY, CursorType);
 
 	m_MouseDeltaX += MouseRelX;
 	m_MouseDeltaY += MouseRelY;


### PR DESCRIPTION
I feel like this broke something. But before it was running a bunch of calculations based on the mouse position. And that every tick no matter if the mouse position changed or not. I added some dbg_msg() below. And it used to spam every tick and now is only spammed on mouse move. Does it work on touch screens and joysticks? Not sure I only tested 10 seconds on my laptop touch pad.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
