### PR TITLE
[callbacks] Move select layer to editor component

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2304,6 +2304,8 @@ if(CLIENT)
     editor_trackers.h
     editor_ui.h
     explanations.cpp
+    layer_selector.cpp
+    layer_selector.h
     map_grid.cpp
     map_grid.h
     map_view.cpp

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -3830,7 +3830,7 @@ void CEditor::RenderLayers(CUIRect LayersBox)
 	}
 
 	static bool s_ScrollToSelectionNext = false;
-	const bool ScrollToSelection = SelectLayerByTile() || s_ScrollToSelectionNext;
+	const bool ScrollToSelection = LayerSelector()->SelectByTile() || s_ScrollToSelectionNext;
 	s_ScrollToSelectionNext = false;
 
 	// render layers
@@ -4365,75 +4365,6 @@ void CEditor::RenderLayers(CUIRect LayersBox)
 			s_PreviousOperation = OP_NONE;
 		}
 	}
-}
-
-bool CEditor::SelectLayerByTile()
-{
-	// ctrl+rightclick a map index to select the layer that has a tile there
-	static bool s_CtrlClick = false;
-	static int s_Selected = 0;
-	int MatchedGroup = -1;
-	int MatchedLayer = -1;
-	int Matches = 0;
-	bool IsFound = false;
-	if(UI()->MouseButton(1) && Input()->ModifierIsPressed())
-	{
-		if(s_CtrlClick)
-			return false;
-		s_CtrlClick = true;
-		for(size_t g = 0; g < m_Map.m_vpGroups.size(); g++)
-		{
-			for(size_t l = 0; l < m_Map.m_vpGroups[g]->m_vpLayers.size(); l++)
-			{
-				if(IsFound)
-					continue;
-				if(m_Map.m_vpGroups[g]->m_vpLayers[l]->m_Type != LAYERTYPE_TILES)
-					continue;
-
-				std::shared_ptr<CLayerTiles> pTiles = std::static_pointer_cast<CLayerTiles>(m_Map.m_vpGroups[g]->m_vpLayers[l]);
-
-				float aMapping[4];
-				m_Map.m_vpGroups[g]->Mapping(aMapping);
-				int x = aMapping[0] + (aMapping[2] - aMapping[0]) / 2;
-				int y = aMapping[1] + (aMapping[3] - aMapping[1]) / 2;
-				x += UI()->MouseWorldX() - (MapView()->GetWorldOffset().x * m_Map.m_vpGroups[g]->m_ParallaxX / 100) - m_Map.m_vpGroups[g]->m_OffsetX;
-				y += UI()->MouseWorldY() - (MapView()->GetWorldOffset().y * m_Map.m_vpGroups[g]->m_ParallaxY / 100) - m_Map.m_vpGroups[g]->m_OffsetY;
-				x /= 32;
-				y /= 32;
-
-				if(x < 0 || x >= pTiles->m_Width)
-					continue;
-				if(y < 0 || y >= pTiles->m_Height)
-					continue;
-				CTile Tile = pTiles->GetTile(x, y);
-				if(Tile.m_Index)
-				{
-					if(MatchedGroup == -1)
-					{
-						MatchedGroup = g;
-						MatchedLayer = l;
-					}
-					if(++Matches > s_Selected)
-					{
-						s_Selected++;
-						MatchedGroup = g;
-						MatchedLayer = l;
-						IsFound = true;
-					}
-				}
-			}
-		}
-		if(MatchedGroup != -1 && MatchedLayer != -1)
-		{
-			if(!IsFound)
-				s_Selected = 1;
-			SelectLayer(MatchedLayer, MatchedGroup);
-			return true;
-		}
-	}
-	else
-		s_CtrlClick = false;
-	return false;
 }
 
 bool CEditor::ReplaceImage(const char *pFileName, int StorageType, bool CheckDuplicate)
@@ -8411,6 +8342,7 @@ void CEditor::Init()
 
 	m_vComponents.emplace_back(m_MapView);
 	m_vComponents.emplace_back(m_MapSettingsBackend);
+	m_vComponents.emplace_back(m_LayerSelector);
 	for(CEditorComponent &Component : m_vComponents)
 		Component.Init(this);
 
@@ -8517,6 +8449,59 @@ void CEditor::HandleCursorMovement()
 		m_MouseWorldNoParaX = aPoints[0] + WorldWidth * (s_MouseX / Graphics()->WindowWidth());
 		m_MouseWorldNoParaY = aPoints[1] + WorldHeight * (s_MouseY / Graphics()->WindowHeight());
 	}
+
+	OnMouseMove(s_MouseX, s_MouseY);
+}
+
+void CEditor::OnMouseMove(float MouseX, float MouseY)
+{
+	for(CEditorComponent &Component : m_vComponents)
+		Component.BeforeHoverTile();
+	for(size_t g = 0; g < m_Map.m_vpGroups.size(); g++)
+	{
+		const std::shared_ptr<CLayerGroup> pGroup = m_Map.m_vpGroups[g];
+		for(size_t l = 0; l < pGroup->m_vpLayers.size(); l++)
+		{
+			const std::shared_ptr<CLayer> pLayer = pGroup->m_vpLayers[l];
+			int LayerType = pLayer->m_Type;
+			if(LayerType != LAYERTYPE_TILES &&
+				LayerType != LAYERTYPE_FRONT &&
+				LayerType != LAYERTYPE_TELE &&
+				LayerType != LAYERTYPE_SPEEDUP &&
+				LayerType != LAYERTYPE_SWITCH &&
+				LayerType != LAYERTYPE_TUNE)
+				continue;
+
+			std::shared_ptr<CLayerTiles> pTiles = std::static_pointer_cast<CLayerTiles>(pLayer);
+			pGroup->MapScreen();
+			float aPoints[4];
+			pGroup->Mapping(aPoints);
+			float WorldWidth = aPoints[2] - aPoints[0];
+			float WorldHeight = aPoints[3] - aPoints[1];
+			CUIRect Rect;
+			Rect.x = aPoints[0] + WorldWidth * (MouseX / Graphics()->WindowWidth());
+			Rect.y = aPoints[1] + WorldHeight * (MouseY / Graphics()->WindowHeight());
+			Rect.w = 0;
+			Rect.h = 0;
+			RECTi r;
+			pTiles->Convert(Rect, &r);
+			pTiles->Clamp(&r);
+			int x = r.x;
+			int y = r.y;
+			UI()->MapScreen();
+
+			if(x < 0 || x >= pTiles->m_Width)
+				continue;
+			if(y < 0 || y >= pTiles->m_Height)
+				continue;
+			CTile Tile = pTiles->GetTile(x, y);
+			if(Tile.m_Index)
+				for(CEditorComponent &Component : m_vComponents)
+					Component.OnHoverTile(g, l, Tile, x, y);
+		}
+	}
+	for(CEditorComponent &Component : m_vComponents)
+		Component.AfterHoverTile();
 }
 
 void CEditor::DispatchInputEvents()

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -36,6 +36,7 @@
 #include "editor_server_settings.h"
 #include "editor_trackers.h"
 #include "editor_ui.h"
+#include "layer_selector.h"
 #include "map_view.h"
 #include "smooth_value.h"
 
@@ -277,6 +278,7 @@ class CEditor : public IEditor
 
 	std::vector<std::reference_wrapper<CEditorComponent>> m_vComponents;
 	CMapView m_MapView;
+	CLayerSelector m_LayerSelector;
 
 	bool m_EditorWasUsedBefore = false;
 
@@ -316,6 +318,7 @@ public:
 
 	CMapView *MapView() { return &m_MapView; }
 	const CMapView *MapView() const { return &m_MapView; }
+	CLayerSelector *LayerSelector() { return &m_LayerSelector; }
 
 	CEditor() :
 		m_ZoomEnvelopeX(1.0f, 0.1f, 600.0f),
@@ -440,6 +443,7 @@ public:
 	void ResetIngameMoved() override { m_IngameMoved = false; }
 
 	void HandleCursorMovement();
+	void OnMouseMove(float MouseX, float MouseY);
 	void DispatchInputEvents();
 	void HandleAutosave();
 	bool PerformAutosave();
@@ -994,7 +998,6 @@ public:
 
 	void SelectGameLayer();
 	std::vector<int> SortImages();
-	bool SelectLayerByTile();
 
 	void DoAudioPreview(CUIRect View, const void *pPlayPauseButtonID, const void *pStopButtonID, const void *pSeekBarID, const int SampleID);
 

--- a/src/game/editor/editor_object.h
+++ b/src/game/editor/editor_object.h
@@ -17,6 +17,9 @@ class ISound;
 class ITextRender;
 class IStorage;
 class CRenderTools;
+class CTile;
+class CLayer;
+class CLayerGroup;
 
 class CEditorObject
 {
@@ -53,6 +56,21 @@ public:
 	 * Gets called after `OnRender` when the component is active.
 	 */
 	virtual void OnActive();
+
+	/**
+	 * Gets called once before `OnHoverTile` is being called multiple times
+	 */
+	virtual void BeforeHoverTile(){};
+
+	/**
+	 * Gets called once after `OnHoverTile` is being called multiple times
+	 */
+	virtual void AfterHoverTile(){};
+
+	/**
+	 * Gets called once for every tile that is under the cursor
+	 */
+	virtual void OnHoverTile(int Group, int Layer, const CTile &Tile, int x, int y){};
 
 	virtual void OnReset();
 	virtual void OnMapLoad();

--- a/src/game/editor/layer_selector.cpp
+++ b/src/game/editor/layer_selector.cpp
@@ -1,0 +1,63 @@
+#include "editor.h"
+
+#include "layer_selector.h"
+
+void CLayerSelector::Init(CEditor *pEditor)
+{
+	CEditorComponent::Init(pEditor);
+
+	m_SelectionOffset = 1;
+}
+
+bool CLayerSelector::SelectByTile()
+{
+	// ctrl+rightclick a map index to select the layer that has a tile there
+	static bool s_CtrlClick = false;
+	if(!UI()->CheckActiveItem(nullptr))
+		return false;
+	if(!UI()->MouseButton(1) || !Input()->ModifierIsPressed())
+	{
+		s_CtrlClick = false;
+		return false;
+	}
+
+	if(s_CtrlClick)
+		return false;
+	s_CtrlClick = true;
+
+	if(m_MatchedGroup == -1 || m_MatchedLayer == -1)
+		return false;
+
+	m_SelectionOffset++;
+	if(!m_Found)
+		m_SelectionOffset = 2;
+	Editor()->SelectLayer(m_MatchedLayer, m_MatchedGroup);
+	return true;
+}
+
+void CLayerSelector::BeforeHoverTile()
+{
+	m_MatchedGroup = -1;
+	m_MatchedLayer = -1;
+	m_Matches = 0;
+	m_Found = false;
+}
+
+void CLayerSelector::OnHoverTile(int Group, int Layer, const CTile &Tile, int x, int y)
+{
+	if(m_Found)
+		return;
+
+	if(m_MatchedGroup == -1)
+	{
+		m_MatchedGroup = Group;
+		m_MatchedLayer = Layer;
+	}
+	m_Matches++;
+	if(m_Matches == m_SelectionOffset)
+	{
+		m_MatchedGroup = Group;
+		m_MatchedLayer = Layer;
+		m_Found = true;
+	}
+}

--- a/src/game/editor/layer_selector.h
+++ b/src/game/editor/layer_selector.h
@@ -1,0 +1,21 @@
+#ifndef GAME_EDITOR_LAYER_SELECTOR_H
+#define GAME_EDITOR_LAYER_SELECTOR_H
+
+#include "component.h"
+
+class CLayerSelector : public CEditorComponent
+{
+	int m_SelectionOffset;
+	int m_MatchedGroup;
+	int m_MatchedLayer;
+	int m_Matches;
+	bool m_Found;
+
+public:
+	void Init(CEditor *pEditor) override;
+	void BeforeHoverTile() override;
+	void OnHoverTile(int Group, int Layer, const CTile &Tile, int x, int y) override;
+	bool SelectByTile();
+};
+
+#endif


### PR DESCRIPTION
This pr is all about adding ``virtual void OnHoverTile(int Group, int Layer, const CTile &Tile, int x, int y){};`` to close #7943

It fixes no bugs (probably adds some). It also decreases performance and adds no functionality.
The advantage is that there is now some easy to use api for new editor components that want to make tiles clickable or hoverable.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
