### PR TITLE
Editor: fix FPS drop when editing tiles layer properties

### DIFF
--- a/src/game/editor/editor_history.cpp
+++ b/src/game/editor/editor_history.cpp
@@ -88,3 +88,8 @@ void CEditorHistory::EndBulk(const char *pDisplay)
 
 	m_vpBulkActions.clear();
 }
+
+void CEditorHistory::EndBulk(int DisplayToUse)
+{
+	EndBulk((DisplayToUse < 0 || DisplayToUse >= (int)m_vpBulkActions.size()) ? nullptr : m_vpBulkActions[DisplayToUse]->DisplayText());
+}

--- a/src/game/editor/editor_history.h
+++ b/src/game/editor/editor_history.h
@@ -32,6 +32,7 @@ public:
 
 	void BeginBulk();
 	void EndBulk(const char *pDisplay = nullptr);
+	void EndBulk(int DisplayToUse);
 
 	CEditor *m_pEditor;
 	std::deque<std::shared_ptr<IEditorAction>> m_vpUndoActions;

--- a/src/game/editor/mapitems/layer_tiles.h
+++ b/src/game/editor/mapitems/layer_tiles.h
@@ -185,6 +185,8 @@ public:
 	EditorTileStateChangeHistory<STileStateChange> m_TilesHistory;
 	inline virtual void ClearHistory() { m_TilesHistory.clear(); }
 
+	static bool HasAutomapEffect(ETilesProp Prop);
+
 protected:
 	void RecordStateChange(int x, int y, CTile Previous, CTile Tile);
 


### PR DESCRIPTION
Fixes #7959.
This was caused by calls to `FlagModified` each frame, mainly when changing the color property. However, changing the color of a tiles layer does not affect the automapper, so it should not be ran when having the auto button enabled. This PR fixes those problems by only calling `FlagModified` when changing a property that may affect the automapper (width, height, shift, image and automapper config).

Also, I added more cases for undoing auto automap: changing any of the properties mentioned earlier now cause an action to be recorded, which was not the case before so you could change a property that would run the automapper and undoing was a bit broken.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
