### PR TITLE
Add flag search

### DIFF
--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -273,7 +273,7 @@ void CMenus::SetNeedSendInfo()
 
 void CMenus::RenderSettingsPlayer(CUIRect MainView)
 {
-	CUIRect TabBar, PlayerTab, DummyTab, QuickSearch, SearchIcon, QuickSearchClearButton;
+	CUIRect TabBar, PlayerTab, DummyTab, QuickSearch, QuickSearchClearButton;
 	MainView.HSplitTop(20.0f, &TabBar, &MainView);
 	TabBar.VSplitMid(&TabBar, nullptr);
 	TabBar.VSplitMid(&PlayerTab, &DummyTab);
@@ -338,24 +338,24 @@ void CMenus::RenderSettingsPlayer(CUIRect MainView)
 	// country flag selector
 	static CLineInputBuffered<25> s_FlagFilterInput;
 
-	std::vector<size_t> vFilteredFlagsIndices;
+	std::vector<const CCountryFlags::CCountryFlag *> vpFilteredFlags;
 	for(size_t i = 0; i < m_pClient->m_CountryFlags.Num(); ++i)
 	{
 		const CCountryFlags::CCountryFlag *pEntry = m_pClient->m_CountryFlags.GetByIndex(i);
 		if(!str_find_nocase(pEntry->m_aCountryCodeString, s_FlagFilterInput.GetString()))
 			continue;
-		vFilteredFlagsIndices.push_back(i);
+		vpFilteredFlags.push_back(pEntry);
 	}
 
 	MainView.HSplitTop(10.0f, nullptr, &MainView);
 	MainView.HSplitBottom(25.0f, &MainView, &QuickSearch);
 	int OldSelected = -1;
 	static CListBox s_ListBox;
-	s_ListBox.DoStart(48.0f, vFilteredFlagsIndices.size(), 10, 3, OldSelected, &MainView);
+	s_ListBox.DoStart(48.0f, vpFilteredFlags.size(), 10, 3, OldSelected, &MainView);
 
-	for(size_t i = 0; i < vFilteredFlagsIndices.size(); i++)
+	for(size_t i = 0; i < vpFilteredFlags.size(); i++)
 	{
-		const CCountryFlags::CCountryFlag *pEntry = m_pClient->m_CountryFlags.GetByIndex(vFilteredFlagsIndices[i]);
+		const CCountryFlags::CCountryFlag *pEntry = vpFilteredFlags[i];
 
 		if(pEntry->m_CountryCode == *pCountry)
 			OldSelected = i;
@@ -382,7 +382,7 @@ void CMenus::RenderSettingsPlayer(CUIRect MainView)
 	const int NewSelected = s_ListBox.DoEnd();
 	if(OldSelected != NewSelected)
 	{
-		*pCountry = m_pClient->m_CountryFlags.GetByIndex(vFilteredFlagsIndices[NewSelected])->m_CountryCode;
+		*pCountry = vpFilteredFlags[NewSelected]->m_CountryCode;
 		SetNeedSendInfo();
 	}
 

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -273,7 +273,7 @@ void CMenus::SetNeedSendInfo()
 
 void CMenus::RenderSettingsPlayer(CUIRect MainView)
 {
-	CUIRect TabBar, PlayerTab, DummyTab;
+	CUIRect TabBar, PlayerTab, DummyTab, QuickSearch, SearchIcon, QuickSearchClearButton;
 	MainView.HSplitTop(20.0f, &TabBar, &MainView);
 	TabBar.VSplitMid(&TabBar, nullptr);
 	TabBar.VSplitMid(&PlayerTab, &DummyTab);
@@ -336,14 +336,27 @@ void CMenus::RenderSettingsPlayer(CUIRect MainView)
 	}
 
 	// country flag selector
-	MainView.HSplitTop(10.0f, nullptr, &MainView);
-	int OldSelected = -1;
-	static CListBox s_ListBox;
-	s_ListBox.DoStart(48.0f, m_pClient->m_CountryFlags.Num(), 10, 3, OldSelected, &MainView);
+	static CLineInputBuffered<25> s_FlagFilterInput;
 
+	std::vector<size_t> vFilteredFlagsIndices;
 	for(size_t i = 0; i < m_pClient->m_CountryFlags.Num(); ++i)
 	{
 		const CCountryFlags::CCountryFlag *pEntry = m_pClient->m_CountryFlags.GetByIndex(i);
+		if(!str_find_nocase(pEntry->m_aCountryCodeString, s_FlagFilterInput.GetString()))
+			continue;
+		vFilteredFlagsIndices.push_back(i);
+	}
+
+	MainView.HSplitTop(10.0f, nullptr, &MainView);
+	MainView.HSplitBottom(25.0f, &MainView, &QuickSearch);
+	int OldSelected = -1;
+	static CListBox s_ListBox;
+	s_ListBox.DoStart(48.0f, vFilteredFlagsIndices.size(), 10, 3, OldSelected, &MainView);
+
+	for(size_t i = 0; i < vFilteredFlagsIndices.size(); i++)
+	{
+		const CCountryFlags::CCountryFlag *pEntry = m_pClient->m_CountryFlags.GetByIndex(vFilteredFlagsIndices[i]);
+
 		if(pEntry->m_CountryCode == *pCountry)
 			OldSelected = i;
 
@@ -369,9 +382,34 @@ void CMenus::RenderSettingsPlayer(CUIRect MainView)
 	const int NewSelected = s_ListBox.DoEnd();
 	if(OldSelected != NewSelected)
 	{
-		*pCountry = m_pClient->m_CountryFlags.GetByIndex(NewSelected)->m_CountryCode;
+		*pCountry = m_pClient->m_CountryFlags.GetByIndex(vFilteredFlagsIndices[NewSelected])->m_CountryCode;
 		SetNeedSendInfo();
 	}
+
+	// render quick search
+	QuickSearch.VSplitLeft(240.0f, &QuickSearch, nullptr);
+	QuickSearch.HSplitTop(5.0f, nullptr, &QuickSearch);
+
+	TextRender()->SetFontPreset(EFontPreset::ICON_FONT);
+	TextRender()->SetRenderFlags(ETextRenderFlags::TEXT_RENDER_FLAG_ONLY_ADVANCE_WIDTH | ETextRenderFlags::TEXT_RENDER_FLAG_NO_X_BEARING | ETextRenderFlags::TEXT_RENDER_FLAG_NO_Y_BEARING | ETextRenderFlags::TEXT_RENDER_FLAG_NO_PIXEL_ALIGMENT | ETextRenderFlags::TEXT_RENDER_FLAG_NO_OVERSIZE);
+	UI()->DoLabel(&QuickSearch, FONT_ICON_MAGNIFYING_GLASS, 14.0f, TEXTALIGN_ML);
+	TextRender()->SetRenderFlags(0);
+	TextRender()->SetFontPreset(EFontPreset::DEFAULT_FONT);
+
+	float wSearch = TextRender()->TextWidth(14.0f, FONT_ICON_MAGNIFYING_GLASS, -1, -1.0f);
+	QuickSearch.VSplitLeft(wSearch - 1.5f, nullptr, &QuickSearch);
+	QuickSearch.VSplitLeft(5.0f, nullptr, &QuickSearch);
+	QuickSearch.VSplitLeft(QuickSearch.w - 10.0f, &QuickSearch, &QuickSearchClearButton);
+
+	TextRender()->SetRenderFlags(0);
+	TextRender()->SetFontPreset(EFontPreset::DEFAULT_FONT);
+	if(Input()->KeyPress(KEY_F) && Input()->ModifierIsPressed())
+	{
+		UI()->SetActiveItem(&s_FlagFilterInput);
+		s_FlagFilterInput.SelectAll();
+	}
+	s_FlagFilterInput.SetEmptyText(Localize("Search"));
+	UI()->DoClearableEditBox(&s_FlagFilterInput, &QuickSearch, 14.0f);
 }
 
 struct CUISkin

--- a/src/game/client/components/menus_settings_assets.cpp
+++ b/src/game/client/components/menus_settings_assets.cpp
@@ -613,7 +613,7 @@ void CMenus::RenderSettingsCustom(CUIRect MainView)
 		TextRender()->SetFontPreset(EFontPreset::DEFAULT_FONT);
 		QuickSearch.VSplitLeft(wSearch, 0, &QuickSearch);
 		QuickSearch.VSplitLeft(5.0f, 0, &QuickSearch);
-		QuickSearch.VSplitLeft(QuickSearch.w - 15.0f, &QuickSearch, &QuickSearchClearButton);
+		QuickSearch.VSplitLeft(QuickSearch.w - 10.0f, &QuickSearch, &QuickSearchClearButton);
 		if(Input()->KeyPress(KEY_F) && Input()->ModifierIsPressed())
 		{
 			UI()->SetActiveItem(&s_aFilterInputs[s_CurCustomTab]);


### PR DESCRIPTION
Adds a flag search bar to the Player tab, so you can filter flags. Also resized every search bar in the settings to be the same width, in the Player, Tee, Assets tabs.
![changes](https://github.com/ddnet/ddnet/assets/78111412/15d80feb-30c5-4cd0-84e8-1046e5346124)


## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
