### PR TITLE
Document `DoEditBox()`

### DIFF
--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -514,7 +514,36 @@ public:
 	void DoLabel(CUIElement::SUIElementRect &RectEl, const CUIRect *pRect, const char *pText, float Size, int Align, const SLabelProperties &LabelProps = {}, int StrLen = -1, const CTextCursor *pReadCursor = nullptr) const;
 	void DoLabelStreamed(CUIElement::SUIElementRect &RectEl, const CUIRect *pRect, const char *pText, float Size, int Align, const SLabelProperties &LabelProps = {}, int StrLen = -1, const CTextCursor *pReadCursor = nullptr) const;
 
+	/**
+	 * Creates an input field.
+	 *
+	 * @see DoClearableEditBox
+	 *
+	 * @param pLineInput This pointer will be stored and written to on next user input.
+	 *                   So you can not pass in a pointer that goes out of scope such as a local variable.
+	 *                   Pass in either a member variable of the current class or a static variable.
+	 *                   For example ```static CLineInputBuffered<IO_MAX_PATH_LENGTH> s_MyInput;```
+	 * @param pRect the UI rect it will attach to with a 2.0f margin
+	 * @param FontSize Size of the font (`10.0f`, `12.0f` and `14.0f` are commonly used here)
+	 * @param Corners Number of corners (default: `IGraphics::CORNER_ALL`)
+	 * @param vColorSplits Sets color splits of the `CTextCursor` to allow multicolored text
+	 */
 	bool DoEditBox(CLineInput *pLineInput, const CUIRect *pRect, float FontSize, int Corners = IGraphics::CORNER_ALL, const std::vector<STextColorSplit> &vColorSplits = {});
+
+	/**
+	 * Creates an input field with a clear [x] button attached to it.
+	 *
+	 * @see DoEditBox
+	 *
+	 * @param pLineInput This pointer will be stored and written to on next user input.
+	 *                   So you can not pass in a pointer that goes out of scope such as a local variable.
+	 *                   Pass in either a member variable of the current class or a static variable.
+	 *                   For example ```static CLineInputBuffered<IO_MAX_PATH_LENGTH> s_MyInput;```
+	 * @param pRect the UI rect it will attach to
+	 * @param FontSize Size of the font (`10.0f`, `12.0f` and `14.0f` are commonly used here)
+	 * @param Corners Number of corners (default: `IGraphics::CORNER_ALL`)
+	 * @param vColorSplits Sets color splits of the `CTextCursor` to allow multicolored text
+	 */
 	bool DoClearableEditBox(CLineInput *pLineInput, const CUIRect *pRect, float FontSize, int Corners = IGraphics::CORNER_ALL, const std::vector<STextColorSplit> &vColorSplits = {});
 
 	int DoButton_Menu(CUIElement &UIElement, const CButtonContainer *pID, const std::function<const char *()> &GetTextLambda, const CUIRect *pRect, const SMenuButtonProperties &Props = {});


### PR DESCRIPTION
Henlo :wave: I am learning the ui code a bit and got so used to passing local variable CUIRect references as argument to the .Draw() and split calls. So I did the same with ``DoEditBox()`` and it segfaulted into my face :panda_face:.

```
Thread 1 "DDNet" received signal SIGSEGV, Segmentation fault.
str_byte_next (ptr=0x7fffffffac90) at /home/chiller/Desktop/git/ddnet/src/base/system.cpp:3847
3847            unsigned char byte_value = **ptr;
(gdb) bt
#0  str_byte_next(char const**) (ptr=0x7fffffffac90) at /home/chiller/Desktop/git/ddnet/src/base/system.cpp:3847
#1  0x000055555625550a in str_utf8_decode(char const**) (ptr=0x7fffffffac90) at /home/chiller/Desktop/git/ddnet/src/base/system.cpp:3867
#2  0x00005555562556c5 in str_utf8_stats(char const*, unsigned long, unsigned long, unsigned long*, unsigned long*)
    (str=0x0, max_size=5685534928871565824, max_count=512, size=0x7fffffffb0e8, count=0x7fffffffb0f0) at /home/chiller/Desktop/git/ddnet/src/base/system.cpp:3944
#3  0x000055555603c3c4 in CLineInput::UpdateStrData() (this=0x7fffffffb0d0) at /home/chiller/Desktop/git/ddnet/src/game/client/lineinput.cpp:107
#4  0x000055555603c9fe in CLineInput::ProcessInput(IInput::CEvent const&) (this=0x7fffffffb0d0, Event=...) at /home/chiller/Desktop/git/ddnet/src/game/client/lineinput.cpp:192
#5  0x000055555605a938 in CUI::OnInput(IInput::CEvent const&) (this=0x5555564ab088, Event=...) at /home/chiller/Desktop/git/ddnet/src/game/client/ui.cpp:288
#6  0x00005555560aa1bb in CEditor::DispatchInputEvents() (this=0x5555564ab010) at /home/chiller/Desktop/git/ddnet/src/game/editor/editor.cpp:8538
#7  0x00005555560aacdc in CEditor::OnUpdate() (this=0x5555564ab010) at /home/chiller/Desktop/git/ddnet/src/game/editor/editor.cpp:8687
#8  0x0000555555e54b21 in CClient::Update() (this=0x7fffeb226010) at /home/chiller/Desktop/git/ddnet/src/engine/client/client.cpp:2618
#9  0x0000555555e55fdf in CClient::Run() (this=0x7fffeb226010) at /home/chiller/Desktop/git/ddnet/src/engine/client/client.cpp:2922
#10 0x0000555555e5e4ad in main(int, char const**) (argc=2, argv=0x7fffffffc4f8) at /home/chiller/Desktop/git/ddnet/src/engine/client/client.cpp:4509
```

So this note is here to warn others of this trap.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
