### PR TITLE
Add placeholder country/type for servers without community, fix filter excluding all items when right-clicking the only entry

### DIFF
--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -724,7 +724,9 @@ void CMenus::RenderServerbrowserFilters(CUIRect View)
 		}
 	}
 
-	if(!m_CommunityCache.m_vpSelectableCountries.empty() || !m_CommunityCache.m_vpSelectableTypes.empty())
+	// countries and types filters (not shown if there are no countries and types, or if only the none community is selected)
+	if((!m_CommunityCache.m_vpSelectableCountries.empty() || !m_CommunityCache.m_vpSelectableTypes.empty()) &&
+		(m_CommunityCache.m_vpSelectedCommunities.size() != 1 || str_comp(m_CommunityCache.m_vpSelectedCommunities[0]->Id(), IServerBrowser::COMMUNITY_NONE) != 0))
 	{
 		const ColorRGBA ColorActive = ColorRGBA(0.0f, 0.0f, 0.0f, 0.3f);
 		const ColorRGBA ColorInactive = ColorRGBA(0.0f, 0.0f, 0.0f, 0.15f);

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -858,7 +858,10 @@ void CMenus::RenderServerbrowserDDNetFilter(CUIRect View,
 				else if(Click == 2)
 				{
 					// Right click: when all are active, only deactivate one
-					Filter.Add(GetItemName(ItemIndex));
+					if(MaxItems >= 2)
+					{
+						Filter.Add(GetItemName(ItemIndex));
+					}
 				}
 			}
 			else


### PR DESCRIPTION
Add a country "none" with tee flag (code `-1`) and a type "None" for all servers without community.

Previously, the country and type for these servers was unset and their handling special-cased, so any non-empty country/type filter would exclude servers without country/type information. Now individual countries/types can be excluded without also excluding all servers without community.

Closes #7961.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
