### PR TITLE
Make it less likely that antibot message is sent from random tees

### DIFF
--- a/src/engine/server.h
+++ b/src/engine/server.h
@@ -55,6 +55,7 @@ public:
 	virtual const char *ClientName(int ClientID) const = 0;
 	virtual const char *ClientClan(int ClientID) const = 0;
 	virtual int ClientCountry(int ClientID) const = 0;
+	virtual bool ClientEmpty(int ClientID) const = 0;
 	virtual bool ClientIngame(int ClientID) const = 0;
 	virtual bool ClientAuthed(int ClientID) const = 0;
 	virtual bool GetClientInfo(int ClientID, CClientInfo *pInfo) const = 0;

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -646,6 +646,11 @@ int CServer::ClientCountry(int ClientID) const
 		return -1;
 }
 
+bool CServer::ClientEmpty(int ClientID) const
+{
+	return ClientID >= 0 && ClientID < MAX_CLIENTS && m_aClients[ClientID].m_State == CServer::CClient::STATE_EMPTY;
+}
+
 bool CServer::ClientIngame(int ClientID) const
 {
 	return ClientID >= 0 && ClientID < MAX_CLIENTS && m_aClients[ClientID].m_State == CServer::CClient::STATE_INGAME;

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -298,6 +298,7 @@ public:
 	const char *ClientName(int ClientID) const override;
 	const char *ClientClan(int ClientID) const override;
 	int ClientCountry(int ClientID) const override;
+	bool ClientEmpty(int ClientID) const override;
 	bool ClientIngame(int ClientID) const override;
 	bool ClientAuthed(int ClientID) const override;
 	int Port() const override;

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -1521,7 +1521,7 @@ void CGameContext::OnClientEnter(int ClientID)
 		int Empty = -1;
 		for(int i = 0; i < MAX_CLIENTS; i++)
 		{
-			if(!Server()->ClientIngame(i))
+			if(Server()->ClientEmpty(i))
 			{
 				Empty = i;
 				break;


### PR DESCRIPTION
Instead of sending the message from the first client which is not ingame, choose the first client which is fully empty, to make it less likely that the message is sent from a currently connecting client.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
