### PR TITLE
[vector] Move select layer to editor component

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2304,6 +2304,8 @@ if(CLIENT)
     editor_trackers.h
     editor_ui.h
     explanations.cpp
+    layer_selector.cpp
+    layer_selector.h
     map_grid.cpp
     map_grid.h
     map_view.cpp

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -36,6 +36,7 @@
 #include "editor_server_settings.h"
 #include "editor_trackers.h"
 #include "editor_ui.h"
+#include "layer_selector.h"
 #include "map_view.h"
 #include "smooth_value.h"
 
@@ -277,6 +278,7 @@ class CEditor : public IEditor
 
 	std::vector<std::reference_wrapper<CEditorComponent>> m_vComponents;
 	CMapView m_MapView;
+	CLayerSelector m_LayerSelector;
 
 	bool m_EditorWasUsedBefore = false;
 
@@ -316,6 +318,7 @@ public:
 
 	CMapView *MapView() { return &m_MapView; }
 	const CMapView *MapView() const { return &m_MapView; }
+	CLayerSelector *LayerSelector() { return &m_LayerSelector; }
 
 	CEditor() :
 		m_ZoomEnvelopeX(1.0f, 0.1f, 600.0f),
@@ -426,6 +429,27 @@ public:
 		m_BrushDrawDestructive = true;
 	}
 
+	class CHoverTile
+	{
+	public:
+		CHoverTile(int Group, int Layer, int x, int y, const CTile Tile) :
+			m_Group(Group),
+			m_Layer(Layer),
+			m_X(x),
+			m_Y(y),
+			m_Tile(Tile)
+		{
+		}
+
+		int m_Group;
+		int m_Layer;
+		int m_X;
+		int m_Y;
+		const CTile m_Tile;
+	};
+	std::vector<CHoverTile> m_vHoverTiles;
+	const std::vector<CHoverTile> &HoverTiles() const { return m_vHoverTiles; }
+
 	void Init() override;
 	void OnUpdate() override;
 	void OnRender() override;
@@ -440,6 +464,7 @@ public:
 	void ResetIngameMoved() override { m_IngameMoved = false; }
 
 	void HandleCursorMovement();
+	void OnMouseMove(float MouseX, float MouseY);
 	void DispatchInputEvents();
 	void HandleAutosave();
 	bool PerformAutosave();
@@ -995,7 +1020,6 @@ public:
 
 	void SelectGameLayer();
 	std::vector<int> SortImages();
-	bool SelectLayerByTile();
 
 	void DoAudioPreview(CUIRect View, const void *pPlayPauseButtonID, const void *pStopButtonID, const void *pSeekBarID, const int SampleID);
 

--- a/src/game/editor/layer_selector.cpp
+++ b/src/game/editor/layer_selector.cpp
@@ -1,0 +1,48 @@
+#include "editor.h"
+
+#include "layer_selector.h"
+
+void CLayerSelector::Init(CEditor *pEditor)
+{
+	CEditorComponent::Init(pEditor);
+
+	m_SelectionOffset = 0;
+}
+
+bool CLayerSelector::SelectByTile()
+{
+	// ctrl+rightclick a map index to select the layer that has a tile there
+	if(UI()->HotItem() != &Editor()->m_MapEditorId)
+		return false;
+	if(!Input()->ModifierIsPressed() || !UI()->MouseButtonClicked(1))
+		return false;
+
+	int MatchedGroup = -1;
+	int MatchedLayer = -1;
+	int Matches = 0;
+	bool IsFound = false;
+	for(auto HoverTile : Editor()->HoverTiles())
+	{
+		if(MatchedGroup == -1)
+		{
+			MatchedGroup = HoverTile.m_Group;
+			MatchedLayer = HoverTile.m_Layer;
+		}
+		if(++Matches > m_SelectionOffset)
+		{
+			m_SelectionOffset++;
+			MatchedGroup = HoverTile.m_Group;
+			MatchedLayer = HoverTile.m_Layer;
+			IsFound = true;
+			break;
+		}
+	}
+	if(MatchedGroup != -1 && MatchedLayer != -1)
+	{
+		if(!IsFound)
+			m_SelectionOffset = 1;
+		Editor()->SelectLayer(MatchedLayer, MatchedGroup);
+		return true;
+	}
+	return false;
+}

--- a/src/game/editor/layer_selector.h
+++ b/src/game/editor/layer_selector.h
@@ -1,0 +1,15 @@
+#ifndef GAME_EDITOR_LAYER_SELECTOR_H
+#define GAME_EDITOR_LAYER_SELECTOR_H
+
+#include "component.h"
+
+class CLayerSelector : public CEditorComponent
+{
+	int m_SelectionOffset;
+
+public:
+	void Init(CEditor *pEditor) override;
+	bool SelectByTile();
+};
+
+#endif


### PR DESCRIPTION
Alternative for https://github.com/ddnet/ddnet/pull/7954

I did not like the complexity of #7954 at all. It was 3 callbacks and one of them gets called for every tile. Working with that was not nice. So I decided to go with one vector that can just be red by everyone who needs it. I like it from a developer experience now. But I hate the performance. It is iterating over all tiles in all layers every tick and pushing the ones under the cursor in some vector. I still get similar cpu/ram usage stats than before on my laptop. But there has to be a more performant way of achieving the same thing. Maybe not using a vector and use a statically allocated fixed size array of size 64 instead. And just drop support for hovering more than 64 overlapping tiles. Or calling that code less often. Only when the underlying tiles actually changed (but that seems to be [tricky](https://github.com/ddnet/ddnet/pull/7949#pullrequestreview-1870921754)).

closed #7943
closed #7612

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
