### PR TITLE
Fix entities textures not being built for non-DDNet/DDRace types, fix assertion due to double-free of transparent texture 

### DIFF
--- a/src/game/client/components/mapimages.cpp
+++ b/src/game/client/components/mapimages.cpp
@@ -158,31 +158,6 @@ void CMapImages::LoadBackground(class CLayers *pLayers, class IMap *pMap)
 	OnMapLoadImpl(pLayers, pMap);
 }
 
-bool CMapImages::HasFrontLayer(EMapImageModType ModType)
-{
-	return ModType == MAP_IMAGE_MOD_TYPE_DDNET || ModType == MAP_IMAGE_MOD_TYPE_DDRACE;
-}
-
-bool CMapImages::HasSpeedupLayer(EMapImageModType ModType)
-{
-	return ModType == MAP_IMAGE_MOD_TYPE_DDNET || ModType == MAP_IMAGE_MOD_TYPE_DDRACE;
-}
-
-bool CMapImages::HasSwitchLayer(EMapImageModType ModType)
-{
-	return ModType == MAP_IMAGE_MOD_TYPE_DDNET || ModType == MAP_IMAGE_MOD_TYPE_DDRACE;
-}
-
-bool CMapImages::HasTeleLayer(EMapImageModType ModType)
-{
-	return ModType == MAP_IMAGE_MOD_TYPE_DDNET || ModType == MAP_IMAGE_MOD_TYPE_DDRACE;
-}
-
-bool CMapImages::HasTuneLayer(EMapImageModType ModType)
-{
-	return ModType == MAP_IMAGE_MOD_TYPE_DDNET || ModType == MAP_IMAGE_MOD_TYPE_DDRACE;
-}
-
 IGraphics::CTextureHandle CMapImages::GetEntities(EMapImageEntityLayerType EntityLayerType)
 {
 	EMapImageModType EntitiesModType = MAP_IMAGE_MOD_TYPE_DDNET;
@@ -207,17 +182,8 @@ IGraphics::CTextureHandle CMapImages::GetEntities(EMapImageEntityLayerType Entit
 	{
 		m_aEntitiesIsLoaded[(EntitiesModType * 2) + (int)EntitiesAreMasked] = true;
 
-		// any mod that does not mask, will get all layers unmasked
-		bool WasUnknown = !EntitiesAreMasked;
-
 		char aPath[64];
 		str_format(aPath, sizeof(aPath), "%s/%s.png", m_aEntitiesPath, gs_apModEntitiesNames[EntitiesModType]);
-
-		bool GameTypeHasFrontLayer = HasFrontLayer(EntitiesModType) || WasUnknown;
-		bool GameTypeHasSpeedupLayer = HasSpeedupLayer(EntitiesModType) || WasUnknown;
-		bool GameTypeHasSwitchLayer = HasSwitchLayer(EntitiesModType) || WasUnknown;
-		bool GameTypeHasTeleLayer = HasTeleLayer(EntitiesModType) || WasUnknown;
-		bool GameTypeHasTuneLayer = HasTuneLayer(EntitiesModType) || WasUnknown;
 
 		int TextureLoadFlag = 0;
 		if(Graphics()->HasTextureArraysSupport())
@@ -264,10 +230,7 @@ IGraphics::CTextureHandle CMapImages::GetEntities(EMapImageEntityLayerType Entit
 			for(int n = 0; n < MAP_IMAGE_ENTITY_LAYER_TYPE_COUNT; ++n)
 			{
 				bool BuildThisLayer = true;
-				if(n == MAP_IMAGE_ENTITY_LAYER_TYPE_ALL_EXCEPT_SWITCH && !GameTypeHasFrontLayer &&
-					!GameTypeHasSpeedupLayer && !GameTypeHasTeleLayer && !GameTypeHasTuneLayer)
-					BuildThisLayer = false;
-				else if(n == MAP_IMAGE_ENTITY_LAYER_TYPE_SWITCH && !GameTypeHasSwitchLayer)
+				if(n == MAP_IMAGE_ENTITY_LAYER_TYPE_SWITCH && EntitiesModType != MAP_IMAGE_MOD_TYPE_DDNET && EntitiesModType != MAP_IMAGE_MOD_TYPE_DDRACE)
 					BuildThisLayer = false;
 
 				dbg_assert(!m_aaEntitiesTextures[(EntitiesModType * 2) + (int)EntitiesAreMasked][n].IsValid(), "entities texture already loaded when it should not be");

--- a/src/game/client/components/mapimages.cpp
+++ b/src/game/client/components/mapimages.cpp
@@ -395,8 +395,10 @@ void CMapImages::ChangeEntitiesPath(const char *pPath)
 		{
 			for(int n = 0; n < MAP_IMAGE_ENTITY_LAYER_TYPE_COUNT; ++n)
 			{
-				if(m_aaEntitiesTextures[i][n].IsValid())
+				if(m_aaEntitiesTextures[i][n].IsValid() && m_aaEntitiesTextures[i][n].Id() != m_TransparentTexture.Id())
+				{
 					Graphics()->UnloadTexture(&(m_aaEntitiesTextures[i][n]));
+				}
 				m_aaEntitiesTextures[i][n] = IGraphics::CTextureHandle();
 			}
 

--- a/src/game/client/components/mapimages.h
+++ b/src/game/client/components/mapimages.h
@@ -42,12 +42,6 @@ class CMapImages : public CComponent
 
 	char m_aEntitiesPath[IO_MAX_PATH_LENGTH];
 
-	bool HasFrontLayer(EMapImageModType ModType);
-	bool HasSpeedupLayer(EMapImageModType ModType);
-	bool HasSwitchLayer(EMapImageModType ModType);
-	bool HasTeleLayer(EMapImageModType ModType);
-	bool HasTuneLayer(EMapImageModType ModType);
-
 public:
 	CMapImages();
 	CMapImages(int TextureSize);


### PR DESCRIPTION
Closes #7965.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
