### PR TITLE
Unfreeze on rcon undeep

### DIFF
--- a/src/game/server/ddracecommands.cpp
+++ b/src/game/server/ddracecommands.cpp
@@ -217,7 +217,10 @@ void CGameContext::ConUnDeep(IConsole::IResult *pResult, void *pUserData)
 		return;
 	CCharacter *pChr = pSelf->GetPlayerChar(pResult->m_ClientID);
 	if(pChr)
+	{
 		pChr->SetDeepFrozen(false);
+		pChr->UnFreeze();
+	}
 }
 
 void CGameContext::ConLiveFreeze(IConsole::IResult *pResult, void *pUserData)


### PR DESCRIPTION
Just for convenience during testing, using rcon undeep should unfreeze you instead of making you wait 3 seconds to get unfrozen after getting undeeped.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
