### PR TITLE
Fix client crash if `cl_race_ghost_save_best 1` deletes last ghost

### DIFF
--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -985,28 +985,25 @@ void CMenus::UpdateOwnGhost(CGhostItem Item)
 		if(m_vGhosts[i].m_Own)
 			Own = i;
 
-	if(Own != -1)
+	if(Own == -1)
 	{
-		if(g_Config.m_ClRaceGhostSaveBest)
-		{
-			if(Item.HasFile() || !m_vGhosts[Own].HasFile())
-				DeleteGhostItem(Own);
-		}
-		if(m_vGhosts[Own].m_Time > Item.m_Time)
-		{
-			Item.m_Own = true;
-			m_vGhosts[Own].m_Own = false;
-			m_vGhosts[Own].m_Slot = -1;
-		}
-		else
-		{
-			Item.m_Own = false;
-			Item.m_Slot = -1;
-		}
+		Item.m_Own = true;
+	}
+	else if(g_Config.m_ClRaceGhostSaveBest && (Item.HasFile() || !m_vGhosts[Own].HasFile()))
+	{
+		Item.m_Own = true;
+		DeleteGhostItem(Own);
+	}
+	else if(m_vGhosts[Own].m_Time > Item.m_Time)
+	{
+		Item.m_Own = true;
+		m_vGhosts[Own].m_Own = false;
+		m_vGhosts[Own].m_Slot = -1;
 	}
 	else
 	{
-		Item.m_Own = true;
+		Item.m_Own = false;
+		Item.m_Slot = -1;
 	}
 
 	Item.m_Date = std::time(0);


### PR DESCRIPTION
If the own ghost is the last element in the vector and deleted due to using the `cl_race_ghost_save_best 1` setting then the following accesses with index `Own` were out-of-bounds. Closes #8003.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [X] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
