### PR TITLE
Update `Dockerfile`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,15 @@
-FROM debian:11
+# Docker image to build DDNet for Linux and Windows (32 bit, 64 bit)
+# Usage:
+# 1. Build image
+# docker build -t ddnet - < Dockerfile
+# 2. Run the DDNet build script
+# docker run -it -v PATH_TO_DDNET:/ddnet:ro -v PATH_TO_OUTPUT_DIRECTORY:/build ddnet ./build-all.sh
+FROM debian:12
 
-RUN apt-get update && apt-get install -y mingw-w64 \
+RUN apt-get update && apt-get install -y gcc-mingw-w64-x86-64-posix \
+        g++-mingw-w64-x86-64-posix \
+        gcc-mingw-w64-i686-posix \
+        g++-mingw-w64-i686-posix \
         wget \
         git \
         ca-certificates \
@@ -15,38 +24,45 @@ RUN apt-get update && apt-get install -y mingw-w64 \
         libwavpack-dev \
         libopusfile-dev \
         libsdl2-dev \
-        cmake
+        cmake \
+        glslang-tools \
+        libavcodec-extra \
+        libavdevice-dev \
+        libavfilter-dev \
+        libavformat-dev \
+        libavutil-dev \
+        libcurl4-openssl-dev \
+        libnotify-dev \
+        libsqlite3-dev \
+        libssl-dev \
+        libvulkan-dev \
+        libx264-dev \
+        spirv-tools \
+        curl
 
-RUN git clone --depth=1 https://github.com/tpoechtrager/osxcross.git /osxcross
-RUN /osxcross/tools/get_dependencies.sh
+RUN curl https://sh.rustup.rs -sSf | \
+    sh -s -- --default-toolchain stable -y
 
-ARG OSX_SDK_FILE
-COPY $OSX_SDK_FILE /osxcross/tarballs/
-RUN ls -la /osxcross/tarballs
-RUN UNATTENDED=1 /osxcross/build.sh
+RUN ~/.cargo/bin/rustup toolchain install stable
+RUN ~/.cargo/bin/rustup target add i686-pc-windows-gnu
+RUN ~/.cargo/bin/rustup target add x86_64-pc-windows-gnu
 
 RUN printf '#!/bin/bash\n \
+        export PATH=$PATH:$HOME/.cargo/bin\n \
         set -x\n \
-        export PATH=$PATH:/osxcross/target/bin\n \
-        o32-clang++ -v\n \
+        mkdir /build\n \
         mkdir /build/linux\n \
         cd /build/linux\n \
         pwd\n \
-        cmake /ddnet && make\n \
+        cmake /ddnet && make -j$(nproc) \n \
         mkdir /build/win64\n \
         cd /build/win64\n \
         pwd\n \
-        cmake -DCMAKE_TOOLCHAIN_FILE=/ddnet/cmake/toolchains/mingw64.toolchain /ddnet && make\n \
+        cmake -DCMAKE_TOOLCHAIN_FILE=/ddnet/cmake/toolchains/mingw64.toolchain /ddnet && make -j$(nproc) \n \
         mkdir /build/win32\n \
         cd /build/win32\n \
         pwd\n \
-        cmake -DCMAKE_TOOLCHAIN_FILE=/ddnet/cmake/toolchains/mingw32.toolchain /ddnet && make\n \
-        mkdir /build/macos\n \
-        cd /build/macos\n \
-        pwd\n \
-        cmake -DCMAKE_TOOLCHAIN_FILE=/ddnet/cmake/toolchains/darwin.toolchain -DCMAKE_OSX_SYSROOT=/osxcross/target/SDK/MacOSX10.11.sdk/ /ddnet && make' \
-        >> build-all.sh
+        cmake -DCMAKE_TOOLCHAIN_FILE=/ddnet/cmake/toolchains/mingw32.toolchain /ddnet && make -j$(nproc) \n' \
+        > build-all.sh
 RUN chmod +x build-all.sh
 RUN mkdir /build
-
-ADD . /ddnet


### PR DESCRIPTION
The `Dockerfile` has been broken ever since Rust got added, but this PR updates the dependencies and adds some improvements.
- Use the source code as a volume instead of adding a copy of it in the image itself.
- Use `nproc` to use all threads during compilation, instead of just using 1.
- Added a short usage guide inside of the file

One issue is that MacOS is no longer supported, as I can't figure out how to cross-compile to it using osxcross. If anyone knows how, some help would be great.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
