### PR TITLE
ci: remove useless command in ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,8 +92,6 @@ jobs:
       run: |
         brew update || true
         brew install pkg-config sdl2 ffmpeg ninja molten-vk vulkan-headers glslang spirv-tools || true
-        # --overwrite for:  Target /usr/local/bin/2to3 already exists.
-        brew link --overwrite python@3.11
         brew upgrade freetype
         pip3 install dmgbuild
         echo /Library/Frameworks/Python.framework/Versions/3.11/bin >> $GITHUB_PATH


### PR DESCRIPTION
That command didn't set python version to 3.11 anyways, and it works just fine without it, why not remove it?
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
