### PR TITLE
Rename all variables for strict camel-casing of abbreviations

### DIFF
--- a/datasrc/datatypes.py
+++ b/datasrc/datatypes.py
@@ -4,12 +4,12 @@ def only(x):
 	return list(x)[0]
 
 GlobalIdCounter = 0
-def GetID():
+def GetId():
 	global GlobalIdCounter
 	GlobalIdCounter += 1
 	return GlobalIdCounter
 def GetUID():
-	return f"x{int(GetID())}"
+	return f"x{int(GetId())}"
 
 def FixCasing(Str):
 	NewStr = ""
@@ -36,7 +36,7 @@ class BaseType:
 	def __init__(self, type_name):
 		self._type_name = type_name
 		self._target_name = "INVALID"
-		self._id = GetID() # this is used to remember what order the members have in structures etc
+		self._id = GetId() # this is used to remember what order the members have in structures etc
 
 	def Identifier(self):
 		return "x"+str(self._id)
@@ -44,7 +44,7 @@ class BaseType:
 		return self._target_name
 	def TypeName(self):
 		return self._type_name
-	def ID(self):
+	def Id(self):
 		return self._id
 
 	def EmitDeclaration(self, name):
@@ -65,7 +65,7 @@ class Struct(BaseType):
 		BaseType.__init__(self, type_name)
 	def Members(self):
 		def sorter(a):
-			return a.var.ID()
+			return a.var.Id()
 		m = []
 		for name, value in self.__dict__.items():
 			if name[0] == "_":
@@ -226,7 +226,7 @@ class NetObject:
 			lines += [f"struct {self.struct_name} : public {self.base_struct_name}", "{"]
 		else:
 			lines += [f"struct {self.struct_name}", "{"]
-		lines += [f"\tstatic constexpr int ms_MsgID = {self.enum_name};"]
+		lines += [f"\tstatic constexpr int ms_MsgId = {self.enum_name};"]
 		for v in self.variables:
 			lines += ["\t"+line for line in v.emit_declaration()]
 		lines += ["};"]

--- a/datasrc/network.py
+++ b/datasrc/network.py
@@ -208,7 +208,7 @@ Objects = [
 
 	NetObject("PlayerInfo", [
 		NetIntRange("m_Local", 0, 1),
-		NetIntRange("m_ClientID", 0, 'MAX_CLIENTS-1'),
+		NetIntRange("m_ClientId", 0, 'MAX_CLIENTS-1'),
 		NetIntRange("m_Team", 'TEAM_SPECTATORS', 'TEAM_BLUE'),
 
 		NetIntAny("m_Score"),
@@ -236,7 +236,7 @@ Objects = [
 	]),
 
 	NetObject("SpectatorInfo", [
-		NetIntRange("m_SpectatorID", 'SPEC_FREEVIEW', 'MAX_CLIENTS-1'),
+		NetIntRange("m_SpectatorId", 'SPEC_FREEVIEW', 'MAX_CLIENTS-1'),
 		NetIntAny("m_X"),
 		NetIntAny("m_Y"),
 	]),
@@ -250,7 +250,7 @@ Objects = [
 		NetTick("m_FreezeEnd", 0),
 		NetIntRange("m_Jumps", -1, 255, 2),
 		NetIntAny("m_TeleCheckpoint", -1),
-		NetIntRange("m_StrongWeakID", 0, 'MAX_CLIENTS-1', 0),
+		NetIntRange("m_StrongWeakId", 0, 'MAX_CLIENTS-1', 0),
 
 		# New data fields for jump display, freeze bar and ninja bar
 		# Default values indicate that these values should not be used
@@ -331,15 +331,15 @@ Objects = [
 	NetEvent("HammerHit:Common", []),
 
 	NetEvent("Death:Common", [
-		NetIntRange("m_ClientID", 0, 'MAX_CLIENTS-1'),
+		NetIntRange("m_ClientId", 0, 'MAX_CLIENTS-1'),
 	]),
 
 	NetEvent("SoundGlobal:Common", [ #TODO 0.7: remove me
-		NetIntRange("m_SoundID", 0, 'NUM_SOUNDS-1'),
+		NetIntRange("m_SoundId", 0, 'NUM_SOUNDS-1'),
 	]),
 
 	NetEvent("SoundWorld:Common", [
-		NetIntRange("m_SoundID", 0, 'NUM_SOUNDS-1'),
+		NetIntRange("m_SoundId", 0, 'NUM_SOUNDS-1'),
 	]),
 
 	NetEvent("DamageInd:Common", [
@@ -386,7 +386,7 @@ Messages = [
 
 	NetMessage("Sv_Chat", [
 		NetIntRange("m_Team", -2, 3),
-		NetIntRange("m_ClientID", -1, 'MAX_CLIENTS-1'),
+		NetIntRange("m_ClientId", -1, 'MAX_CLIENTS-1'),
 		NetStringHalfStrict("m_pMessage"),
 	]),
 
@@ -398,7 +398,7 @@ Messages = [
 	]),
 
 	NetMessage("Sv_SoundGlobal", [
-		NetIntRange("m_SoundID", 0, 'NUM_SOUNDS-1'),
+		NetIntRange("m_SoundId", 0, 'NUM_SOUNDS-1'),
 	]),
 
 	NetMessage("Sv_TuneParams", []),
@@ -410,7 +410,7 @@ Messages = [
 	]),
 
 	NetMessage("Sv_Emoticon", [
-		NetIntRange("m_ClientID", 0, 'MAX_CLIENTS-1'),
+		NetIntRange("m_ClientId", 0, 'MAX_CLIENTS-1'),
 		NetIntRange("m_Emoticon", 0, 'NUM_EMOTICONS-1'),
 	]),
 
@@ -458,7 +458,7 @@ Messages = [
 	]),
 
 	NetMessage("Cl_SetSpectatorMode", [
-		NetIntRange("m_SpectatorID", 'SPEC_FREEVIEW', 'MAX_CLIENTS-1'),
+		NetIntRange("m_SpectatorId", 'SPEC_FREEVIEW', 'MAX_CLIENTS-1'),
 	]),
 
 	NetMessage("Cl_StartInfo", [
@@ -556,7 +556,7 @@ Messages = [
 	]),
 
 	NetMessageEx("Sv_RaceFinish", "racefinish@netmsg.ddnet.org", [
-		NetIntRange("m_ClientID", 0, 'MAX_CLIENTS-1'),
+		NetIntRange("m_ClientId", 0, 'MAX_CLIENTS-1'),
 		NetIntAny("m_Time"),
 		NetIntAny("m_Diff"),
 		NetBool("m_RecordPersonal"),

--- a/datasrc/seven/datatypes.py
+++ b/datasrc/seven/datatypes.py
@@ -4,12 +4,12 @@ def only(x):
 	return list(x)[0]
 
 GlobalIdCounter = 0
-def GetID():
+def GetId():
 	global GlobalIdCounter
 	GlobalIdCounter += 1
 	return GlobalIdCounter
 def GetUID():
-	return f"x{int(GetID())}"
+	return f"x{int(GetId())}"
 
 def FixCasing(Str):
 	NewStr = ""
@@ -36,7 +36,7 @@ class BaseType:
 	def __init__(self, type_name):
 		self._type_name = type_name
 		self._target_name = "INVALID"
-		self._id = GetID() # this is used to remember what order the members have in structures etc
+		self._id = GetId() # this is used to remember what order the members have in structures etc
 
 	def Identifier(self):
 		return "x"+str(self._id)
@@ -44,7 +44,7 @@ class BaseType:
 		return self._target_name
 	def TypeName(self):
 		return self._type_name
-	def ID(self):
+	def Id(self):
 		return self._id
 
 	def EmitDeclaration(self, name):
@@ -65,7 +65,7 @@ class Struct(BaseType):
 		BaseType.__init__(self, type_name)
 	def Members(self):
 		def sorter(a):
-			return a.var.ID()
+			return a.var.Id()
 		m = []
 		for name, value in self.__dict__.items():
 			if name[0] == "_":
@@ -229,7 +229,7 @@ class NetObject:
 		else:
 			lines = [f"struct {self.struct_name}", "{"]
 		lines += ["\tusing is_sixup = char;"]
-		lines += [f"\tstatic constexpr int ms_MsgID = {self.enum_name};"]
+		lines += [f"\tstatic constexpr int ms_MsgId = {self.enum_name};"]
 		for v in self.variables:
 			lines += ["\t"+line for line in v.emit_declaration()]
 		lines += ["};"]

--- a/datasrc/seven/network.py
+++ b/datasrc/seven/network.py
@@ -12,7 +12,7 @@ GameStateFlags = Flags("GAMESTATEFLAG", ["WARMUP", "SUDDENDEATH", "ROUNDOVER", "
 CoreEventFlags = Flags("COREEVENTFLAG", ["GROUND_JUMP", "AIR_JUMP", "HOOK_ATTACH_PLAYER", "HOOK_ATTACH_GROUND", "HOOK_HIT_NOHOOK"])
 RaceFlags = Flags("RACEFLAG", ["HIDE_KILLMSG", "FINISHMSG_AS_CHAT", "KEEP_WANTED_WEAPON"])
 
-GameMsgIDs = Enum("GAMEMSG", ["TEAM_SWAP", "SPEC_INVALIDID", "TEAM_SHUFFLE", "TEAM_BALANCE", "CTF_DROP", "CTF_RETURN",
+GameMsgIds = Enum("GAMEMSG", ["TEAM_SWAP", "SPEC_INVALIDID", "TEAM_SHUFFLE", "TEAM_BALANCE", "CTF_DROP", "CTF_RETURN",
 
 							"TEAM_ALL", "TEAM_BALANCE_VICTIM", "CTF_GRAB",
 
@@ -61,7 +61,7 @@ Enums = [
 	Emoticons,
 	Votes,
 	ChatModes,
-	GameMsgIDs,
+	GameMsgIds,
 ]
 
 Flags = [
@@ -180,7 +180,7 @@ Objects = [
 
 	NetObject("SpectatorInfo", [
 		NetIntRange("m_SpecMode", 0, 'NUM_SPECMODES-1'),
-		NetIntRange("m_SpectatorID", -1, 'MAX_CLIENTS-1'),
+		NetIntRange("m_SpectatorId", -1, 'MAX_CLIENTS-1'),
 		NetIntAny("m_X"),
 		NetIntAny("m_Y"),
 	]),
@@ -229,15 +229,15 @@ Objects = [
 	NetEvent("HammerHit:Common", []),
 
 	NetEvent("Death:Common", [
-		NetIntRange("m_ClientID", 0, 'MAX_CLIENTS-1'),
+		NetIntRange("m_ClientId", 0, 'MAX_CLIENTS-1'),
 	]),
 
 	NetEvent("SoundWorld:Common", [
-		NetIntRange("m_SoundID", 0, 'NUM_SOUNDS-1'),
+		NetIntRange("m_SoundId", 0, 'NUM_SOUNDS-1'),
 	]),
 
 	NetEvent("Damage:Common", [ # Unused yet
-		NetIntRange("m_ClientID", 0, 'MAX_CLIENTS-1'),
+		NetIntRange("m_ClientId", 0, 'MAX_CLIENTS-1'),
 		NetIntAny("m_Angle"),
 		NetIntRange("m_HealthAmount", 0, 9),
 		NetIntRange("m_ArmorAmount", 0, 9),
@@ -270,13 +270,13 @@ Messages = [
 
 	NetMessage("Sv_Chat", [
 		NetIntRange("m_Mode", 0, 'NUM_CHATS-1'),
-		NetIntRange("m_ClientID", -1, 'MAX_CLIENTS-1'),
-		NetIntRange("m_TargetID", -1, 'MAX_CLIENTS-1'),
+		NetIntRange("m_ClientId", -1, 'MAX_CLIENTS-1'),
+		NetIntRange("m_TargetId", -1, 'MAX_CLIENTS-1'),
 		NetStringStrict("m_pMessage"),
 	]),
 
 	NetMessage("Sv_Team", [
-		NetIntRange("m_ClientID", -1, 'MAX_CLIENTS-1'),
+		NetIntRange("m_ClientId", -1, 'MAX_CLIENTS-1'),
 		NetIntRange("m_Team", 'TEAM_SPECTATORS', 'TEAM_BLUE'),
 		NetBool("m_Silent"),
 		NetTick("m_CooldownTick"),
@@ -298,7 +298,7 @@ Messages = [
 	]),
 
 	NetMessage("Sv_Emoticon", [
-		NetIntRange("m_ClientID", 0, 'MAX_CLIENTS-1'),
+		NetIntRange("m_ClientId", 0, 'MAX_CLIENTS-1'),
 		NetEnum("m_Emoticon", Emoticons),
 	]),
 
@@ -315,7 +315,7 @@ Messages = [
 	]),
 
 	NetMessage("Sv_VoteSet", [
-		NetIntRange("m_ClientID", -1, 'MAX_CLIENTS-1'),
+		NetIntRange("m_ClientId", -1, 'MAX_CLIENTS-1'),
 		NetEnum("m_Type", Votes),
 		NetIntRange("m_Timeout", 0, 60),
 		NetStringStrict("m_pDescription"),
@@ -339,7 +339,7 @@ Messages = [
 	]),
 
 	NetMessage("Sv_ClientInfo", [
-		NetIntRange("m_ClientID", 0, 'MAX_CLIENTS-1'),
+		NetIntRange("m_ClientId", 0, 'MAX_CLIENTS-1'),
 		NetBool("m_Local"),
 		NetIntRange("m_Team", 'TEAM_SPECTATORS', 'TEAM_BLUE'),
 		NetStringStrict("m_pName"),
@@ -362,7 +362,7 @@ Messages = [
 	]),
 
 	NetMessage("Sv_ClientDrop", [
-		NetIntRange("m_ClientID", 0, 'MAX_CLIENTS-1'),
+		NetIntRange("m_ClientId", 0, 'MAX_CLIENTS-1'),
 		NetStringStrict("m_pReason"),
 		NetBool("m_Silent"),
 	]),
@@ -372,13 +372,13 @@ Messages = [
 	## Demo messages
 	NetMessage("De_ClientEnter", [
 		NetStringStrict("m_pName"),
-		NetIntRange("m_ClientID", -1, 'MAX_CLIENTS-1'),
+		NetIntRange("m_ClientId", -1, 'MAX_CLIENTS-1'),
 		NetIntRange("m_Team", 'TEAM_SPECTATORS', 'TEAM_BLUE'),
 	]),
 
 	NetMessage("De_ClientLeave", [
 		NetStringStrict("m_pName"),
-		NetIntRange("m_ClientID", -1, 'MAX_CLIENTS-1'),
+		NetIntRange("m_ClientId", -1, 'MAX_CLIENTS-1'),
 		NetStringStrict("m_pReason"),
 	]),
 
@@ -395,7 +395,7 @@ Messages = [
 
 	NetMessage("Cl_SetSpectatorMode", [
 		NetIntRange("m_SpecMode", 0, 'NUM_SPECMODES-1'),
-		NetIntRange("m_SpectatorID", -1, 'MAX_CLIENTS-1'),
+		NetIntRange("m_SpectatorId", -1, 'MAX_CLIENTS-1'),
 	]),
 
 	NetMessage("Cl_StartInfo", [
@@ -428,7 +428,7 @@ Messages = [
 
 	# todo 0.8: move up
 	NetMessage("Sv_SkinChange", [
-		NetIntRange("m_ClientID", 0, 'MAX_CLIENTS-1'),
+		NetIntRange("m_ClientId", 0, 'MAX_CLIENTS-1'),
 		NetArray(NetStringStrict("m_apSkinPartNames"), 6),
 		NetArray(NetBool("m_aUseCustomColors"), 6),
 		NetArray(NetIntAny("m_aSkinPartColors"), 6),
@@ -442,7 +442,7 @@ Messages = [
 
 	## Race
 	NetMessage("Sv_RaceFinish", [
-		NetIntRange("m_ClientID", 0, 'MAX_CLIENTS-1'),
+		NetIntRange("m_ClientId", 0, 'MAX_CLIENTS-1'),
 		NetIntRange("m_Time", -1, 'max_int'),
 		NetIntAny("m_Diff"),
 		NetBool("m_RecordPersonal"),

--- a/scripts/import_file_score.py
+++ b/scripts/import_file_score.py
@@ -63,13 +63,13 @@ def main():
 			"Time FLOAT DEFAULT 0, "
 			"Server CHAR(4), " +
 			"".join(f"cp{i + 1} FLOAT DEFAULT 0, " for i in range(25)) +
-			"GameID VARCHAR(64), "
+			"GameId VARCHAR(64), "
 			"DDNet7 BOOL DEFAULT FALSE"
 		");")
 		c.executemany(
 			"INSERT INTO record_race (Map, Name, Time, Server, " +
 			"".join(f"cp{i + 1}, " for i in range(25)) +
-			"GameID, DDNet7) " +
+			"GameId, DDNet7) " +
 			f"VALUES ({','.join('?' * 31)})",
 			[(map, r.name, float(r.time), "TEXT", *[float(c) for c in r.checkpoints], None, False) for map, record in records.items() for r in record]
 		)

--- a/src/antibot/antibot_data.h
+++ b/src/antibot/antibot_data.h
@@ -87,10 +87,10 @@ struct CAntibotData
 
 	int64_t m_Now;
 	int64_t m_Freq;
-	void (*m_pfnKick)(int ClientID, const char *pMessage, void *pUser);
+	void (*m_pfnKick)(int ClientId, const char *pMessage, void *pUser);
 	void (*m_pfnLog)(const char *pMessage, void *pUser);
-	void (*m_pfnReport)(int ClientID, const char *pMessage, void *pUser);
-	void (*m_pfnSend)(int ClientID, const void *pData, int DataSize, int Flags, void *pUser);
+	void (*m_pfnReport)(int ClientId, const char *pMessage, void *pUser);
+	void (*m_pfnSend)(int ClientId, const void *pData, int DataSize, int Flags, void *pUser);
 	void (*m_pfnTeehistorian)(const void *pData, int DataSize, void *pUser);
 	void *m_pUser;
 };

--- a/src/antibot/antibot_interface.h
+++ b/src/antibot/antibot_interface.h
@@ -17,23 +17,23 @@ ANTIBOTAPI void AntibotRoundEnd(void);
 ANTIBOTAPI void AntibotUpdateData(void);
 ANTIBOTAPI void AntibotDestroy(void);
 ANTIBOTAPI void AntibotConsoleCommand(const char *pCommand);
-ANTIBOTAPI void AntibotOnPlayerInit(int ClientID);
-ANTIBOTAPI void AntibotOnPlayerDestroy(int ClientID);
-ANTIBOTAPI void AntibotOnSpawn(int ClientID);
-ANTIBOTAPI void AntibotOnHammerFireReloading(int ClientID);
-ANTIBOTAPI void AntibotOnHammerFire(int ClientID);
-ANTIBOTAPI void AntibotOnHammerHit(int ClientID, int TargetID);
-ANTIBOTAPI void AntibotOnDirectInput(int ClientID);
-ANTIBOTAPI void AntibotOnCharacterTick(int ClientID);
-ANTIBOTAPI void AntibotOnHookAttach(int ClientID, bool Player);
+ANTIBOTAPI void AntibotOnPlayerInit(int ClientId);
+ANTIBOTAPI void AntibotOnPlayerDestroy(int ClientId);
+ANTIBOTAPI void AntibotOnSpawn(int ClientId);
+ANTIBOTAPI void AntibotOnHammerFireReloading(int ClientId);
+ANTIBOTAPI void AntibotOnHammerFire(int ClientId);
+ANTIBOTAPI void AntibotOnHammerHit(int ClientId, int TargetId);
+ANTIBOTAPI void AntibotOnDirectInput(int ClientId);
+ANTIBOTAPI void AntibotOnCharacterTick(int ClientId);
+ANTIBOTAPI void AntibotOnHookAttach(int ClientId, bool Player);
 ANTIBOTAPI void AntibotOnEngineTick(void);
-ANTIBOTAPI void AntibotOnEngineClientJoin(int ClientID, bool Sixup);
-ANTIBOTAPI void AntibotOnEngineClientDrop(int ClientID, const char *pReason);
+ANTIBOTAPI void AntibotOnEngineClientJoin(int ClientId, bool Sixup);
+ANTIBOTAPI void AntibotOnEngineClientDrop(int ClientId, const char *pReason);
 // Returns true if the message shouldn't be processed by the server.
-ANTIBOTAPI bool AntibotOnEngineClientMessage(int ClientID, const void *pData, int Size, int Flags);
-ANTIBOTAPI bool AntibotOnEngineServerMessage(int ClientID, const void *pData, int Size, int Flags);
+ANTIBOTAPI bool AntibotOnEngineClientMessage(int ClientId, const void *pData, int Size, int Flags);
+ANTIBOTAPI bool AntibotOnEngineServerMessage(int ClientId, const void *pData, int Size, int Flags);
 // Returns true if the server should simulate receiving a client message.
-ANTIBOTAPI bool AntibotOnEngineSimulateClientMessage(int *pClientID, void *pBuffer, int BufferSize, int *pOutSize, int *pFlags);
+ANTIBOTAPI bool AntibotOnEngineSimulateClientMessage(int *pClientId, void *pBuffer, int BufferSize, int *pOutSize, int *pFlags);
 }
 
 #endif // ANTIBOT_ANTIBOT_INTERFACE_H

--- a/src/antibot/antibot_null.cpp
+++ b/src/antibot/antibot_null.cpp
@@ -32,19 +32,19 @@ void AntibotConsoleCommand(const char *pCommand)
 		g_pData->m_pfnLog("unknown command", g_pData->m_pUser);
 	}
 }
-void AntibotOnPlayerInit(int /*ClientID*/) {}
-void AntibotOnPlayerDestroy(int /*ClientID*/) {}
-void AntibotOnSpawn(int /*ClientID*/) {}
-void AntibotOnHammerFireReloading(int /*ClientID*/) {}
-void AntibotOnHammerFire(int /*ClientID*/) {}
-void AntibotOnHammerHit(int /*ClientID*/, int /*TargetID*/) {}
-void AntibotOnDirectInput(int /*ClientID*/) {}
-void AntibotOnCharacterTick(int /*ClientID*/) {}
-void AntibotOnHookAttach(int /*ClientID*/, bool /*Player*/) {}
+void AntibotOnPlayerInit(int /*ClientId*/) {}
+void AntibotOnPlayerDestroy(int /*ClientId*/) {}
+void AntibotOnSpawn(int /*ClientId*/) {}
+void AntibotOnHammerFireReloading(int /*ClientId*/) {}
+void AntibotOnHammerFire(int /*ClientId*/) {}
+void AntibotOnHammerHit(int /*ClientId*/, int /*TargetId*/) {}
+void AntibotOnDirectInput(int /*ClientId*/) {}
+void AntibotOnCharacterTick(int /*ClientId*/) {}
+void AntibotOnHookAttach(int /*ClientId*/, bool /*Player*/) {}
 void AntibotOnEngineTick(void) {}
-void AntibotOnEngineClientJoin(int /*ClientID*/, bool /*Sixup*/) {}
-void AntibotOnEngineClientDrop(int /*ClientID*/, const char * /*pReason*/) {}
-bool AntibotOnEngineClientMessage(int /*ClientID*/, const void * /*pData*/, int /*Size*/, int /*Flags*/) { return false; }
-bool AntibotOnEngineServerMessage(int /*ClientID*/, const void * /*pData*/, int /*Size*/, int /*Flags*/) { return false; }
-bool AntibotOnEngineSimulateClientMessage(int * /*pClientID*/, void * /*pBuffer*/, int /*BufferSize*/, int * /*pOutSize*/, int * /*pFlags*/) { return false; }
+void AntibotOnEngineClientJoin(int /*ClientId*/, bool /*Sixup*/) {}
+void AntibotOnEngineClientDrop(int /*ClientId*/, const char * /*pReason*/) {}
+bool AntibotOnEngineClientMessage(int /*ClientId*/, const void * /*pData*/, int /*Size*/, int /*Flags*/) { return false; }
+bool AntibotOnEngineServerMessage(int /*ClientId*/, const void * /*pData*/, int /*Size*/, int /*Flags*/) { return false; }
+bool AntibotOnEngineSimulateClientMessage(int * /*pClientId*/, void * /*pBuffer*/, int /*BufferSize*/, int * /*pOutSize*/, int * /*pFlags*/) { return false; }
 }

--- a/src/engine/antibot.h
+++ b/src/engine/antibot.h
@@ -11,15 +11,15 @@ public:
 	virtual void RoundEnd() = 0;
 
 	// Hooks
-	virtual void OnPlayerInit(int ClientID) = 0;
-	virtual void OnPlayerDestroy(int ClientID) = 0;
-	virtual void OnSpawn(int ClientID) = 0;
-	virtual void OnHammerFireReloading(int ClientID) = 0;
-	virtual void OnHammerFire(int ClientID) = 0;
-	virtual void OnHammerHit(int ClientID, int TargetID) = 0;
-	virtual void OnDirectInput(int ClientID) = 0;
-	virtual void OnCharacterTick(int ClientID) = 0;
-	virtual void OnHookAttach(int ClientID, bool Player) = 0;
+	virtual void OnPlayerInit(int ClientId) = 0;
+	virtual void OnPlayerDestroy(int ClientId) = 0;
+	virtual void OnSpawn(int ClientId) = 0;
+	virtual void OnHammerFireReloading(int ClientId) = 0;
+	virtual void OnHammerFire(int ClientId) = 0;
+	virtual void OnHammerHit(int ClientId, int TargetId) = 0;
+	virtual void OnDirectInput(int ClientId) = 0;
+	virtual void OnCharacterTick(int ClientId) = 0;
+	virtual void OnHookAttach(int ClientId, bool Player) = 0;
 
 	// Commands
 	virtual void ConsoleCommand(const char *pCommand) = 0;
@@ -35,11 +35,11 @@ public:
 
 	// Hooks
 	virtual void OnEngineTick() = 0;
-	virtual void OnEngineClientJoin(int ClientID, bool Sixup) = 0;
-	virtual void OnEngineClientDrop(int ClientID, const char *pReason) = 0;
-	virtual bool OnEngineClientMessage(int ClientID, const void *pData, int Size, int Flags) = 0;
-	virtual bool OnEngineServerMessage(int ClientID, const void *pData, int Size, int Flags) = 0;
-	virtual bool OnEngineSimulateClientMessage(int *pClientID, void *pBuffer, int BufferSize, int *pOutSize, int *pFlags) = 0;
+	virtual void OnEngineClientJoin(int ClientId, bool Sixup) = 0;
+	virtual void OnEngineClientDrop(int ClientId, const char *pReason) = 0;
+	virtual bool OnEngineClientMessage(int ClientId, const void *pData, int Size, int Flags) = 0;
+	virtual bool OnEngineServerMessage(int ClientId, const void *pData, int Size, int Flags) = 0;
+	virtual bool OnEngineSimulateClientMessage(int *pClientId, void *pBuffer, int BufferSize, int *pOutSize, int *pFlags) = 0;
 
 	virtual ~IEngineAntibot(){};
 };

--- a/src/engine/client.h
+++ b/src/engine/client.h
@@ -99,7 +99,7 @@ public:
 	{
 	public:
 		int m_Type;
-		int m_ID;
+		int m_Id;
 		int m_DataSize;
 	};
 
@@ -217,10 +217,10 @@ public:
 	};
 
 	// TODO: Refactor: should redo this a bit i think, too many virtual calls
-	virtual int SnapNumItems(int SnapID) const = 0;
-	virtual const void *SnapFindItem(int SnapID, int Type, int ID) const = 0;
-	virtual void *SnapGetItem(int SnapID, int Index, CSnapItem *pItem) const = 0;
-	virtual int SnapItemSize(int SnapID, int Index) const = 0;
+	virtual int SnapNumItems(int SnapId) const = 0;
+	virtual const void *SnapFindItem(int SnapId, int Type, int Id) const = 0;
+	virtual void *SnapGetItem(int SnapId, int Index, CSnapItem *pItem) const = 0;
+	virtual int SnapItemSize(int SnapId, int Index) const = 0;
 
 	virtual void SnapSetStaticsize(int ItemType, int Size) = 0;
 
@@ -230,7 +230,7 @@ public:
 	template<class T>
 	int SendPackMsgActive(T *pMsg, int Flags)
 	{
-		CMsgPacker Packer(T::ms_MsgID, false);
+		CMsgPacker Packer(T::ms_MsgId, false);
 		if(pMsg->Pack(&Packer))
 			return -1;
 		return SendMsgActive(&Packer, Flags);
@@ -293,7 +293,7 @@ public:
 		MESSAGE_BOX_TYPE_INFO,
 	};
 	virtual void ShowMessageBox(const char *pTitle, const char *pMessage, EMessageBoxType Type = MESSAGE_BOX_TYPE_ERROR) = 0;
-	virtual void GetGPUInfoString(char (&aGPUInfo)[256]) = 0;
+	virtual void GetGpuInfoString(char (&aGpuInfo)[256]) = 0;
 };
 
 class IGameClient : public IInterface
@@ -314,7 +314,7 @@ public:
 	virtual void OnUpdate() = 0;
 	virtual void OnStateChange(int NewState, int OldState) = 0;
 	virtual void OnConnected() = 0;
-	virtual void OnMessage(int MsgID, CUnpacker *pUnpacker, int Conn, bool Dummy) = 0;
+	virtual void OnMessage(int MsgId, CUnpacker *pUnpacker, int Conn, bool Dummy) = 0;
 	virtual void OnPredict() = 0;
 	virtual void OnActivateEditor() = 0;
 	virtual void OnWindowResize() = 0;

--- a/src/engine/client/backend/backend_base.h
+++ b/src/engine/client/backend/backend_base.h
@@ -123,7 +123,7 @@ public:
 		char *m_pVersionString;
 		char *m_pRendererString;
 
-		TTWGraphicsGPUList *m_pGPUList;
+		TTwGraphicsGpuList *m_pGpuList;
 	};
 
 	struct SCommand_Init : public CCommandBuffer::SCommand
@@ -141,7 +141,7 @@ public:
 		std::atomic<uint64_t> *m_pStreamMemoryUsage;
 		std::atomic<uint64_t> *m_pStagingMemoryUsage;
 
-		TTWGraphicsGPUList *m_pGPUList;
+		TTwGraphicsGpuList *m_pGpuList;
 
 		TGLBackendReadPresentedImageData *m_pReadPresentedImageDataFunc;
 

--- a/src/engine/client/backend/opengl/backend_opengl.cpp
+++ b/src/engine/client/backend/opengl/backend_opengl.cpp
@@ -326,9 +326,9 @@ bool CCommandProcessorFragment_OpenGL::InitOpenGL(const SCommand_Init *pCommand)
 
 	const char *pRendererString = (const char *)glGetString(GL_RENDERER);
 
-	str_copy(pCommand->m_pVendorString, pVendorString, gs_GPUInfoStringSize);
-	str_copy(pCommand->m_pVersionString, pVersionString, gs_GPUInfoStringSize);
-	str_copy(pCommand->m_pRendererString, pRendererString, gs_GPUInfoStringSize);
+	str_copy(pCommand->m_pVendorString, pVendorString, gs_GpuInfoStringSize);
+	str_copy(pCommand->m_pVersionString, pVersionString, gs_GpuInfoStringSize);
+	str_copy(pCommand->m_pRendererString, pRendererString, gs_GpuInfoStringSize);
 
 	// parse version string
 	ParseVersionString(pCommand->m_RequestedBackend, pVersionString, pCommand->m_pCapabilities->m_ContextMajor, pCommand->m_pCapabilities->m_ContextMinor, pCommand->m_pCapabilities->m_ContextPatch);
@@ -1664,7 +1664,7 @@ bool CCommandProcessorFragment_OpenGL2::Cmd_Init(const SCommand_Init *pCommand)
 				m_pTileProgram->AddShader(&VertexShader);
 				m_pTileProgram->AddShader(&FragmentShader);
 
-				glBindAttribLocation(m_pTileProgram->GetProgramID(), 0, "inVertex");
+				glBindAttribLocation(m_pTileProgram->GetProgramId(), 0, "inVertex");
 
 				m_pTileProgram->LinkProgram();
 
@@ -1691,8 +1691,8 @@ bool CCommandProcessorFragment_OpenGL2::Cmd_Init(const SCommand_Init *pCommand)
 				m_pTileProgramTextured->AddShader(&VertexShader);
 				m_pTileProgramTextured->AddShader(&FragmentShader);
 
-				glBindAttribLocation(m_pTileProgram->GetProgramID(), 0, "inVertex");
-				glBindAttribLocation(m_pTileProgram->GetProgramID(), 1, "inVertexTexCoord");
+				glBindAttribLocation(m_pTileProgram->GetProgramId(), 0, "inVertex");
+				glBindAttribLocation(m_pTileProgram->GetProgramId(), 1, "inVertexTexCoord");
 
 				m_pTileProgramTextured->LinkProgram();
 
@@ -1717,7 +1717,7 @@ bool CCommandProcessorFragment_OpenGL2::Cmd_Init(const SCommand_Init *pCommand)
 				m_pBorderTileProgram->AddShader(&VertexShader);
 				m_pBorderTileProgram->AddShader(&FragmentShader);
 
-				glBindAttribLocation(m_pBorderTileProgram->GetProgramID(), 0, "inVertex");
+				glBindAttribLocation(m_pBorderTileProgram->GetProgramId(), 0, "inVertex");
 
 				m_pBorderTileProgram->LinkProgram();
 
@@ -1746,8 +1746,8 @@ bool CCommandProcessorFragment_OpenGL2::Cmd_Init(const SCommand_Init *pCommand)
 				m_pBorderTileProgramTextured->AddShader(&VertexShader);
 				m_pBorderTileProgramTextured->AddShader(&FragmentShader);
 
-				glBindAttribLocation(m_pBorderTileProgramTextured->GetProgramID(), 0, "inVertex");
-				glBindAttribLocation(m_pBorderTileProgramTextured->GetProgramID(), 1, "inVertexTexCoord");
+				glBindAttribLocation(m_pBorderTileProgramTextured->GetProgramId(), 0, "inVertex");
+				glBindAttribLocation(m_pBorderTileProgramTextured->GetProgramId(), 1, "inVertexTexCoord");
 
 				m_pBorderTileProgramTextured->LinkProgram();
 
@@ -1864,15 +1864,15 @@ void CCommandProcessorFragment_OpenGL2::Cmd_CreateBufferObject(const CCommandBuf
 		}
 	}
 
-	GLuint VertBufferID = 0;
+	GLuint VertBufferId = 0;
 
-	glGenBuffers(1, &VertBufferID);
-	glBindBuffer(GL_ARRAY_BUFFER, VertBufferID);
+	glGenBuffers(1, &VertBufferId);
+	glBindBuffer(GL_ARRAY_BUFFER, VertBufferId);
 	glBufferData(GL_ARRAY_BUFFER, (GLsizeiptr)(pCommand->m_DataSize), pUploadData, GL_STATIC_DRAW);
 	glBindBuffer(GL_ARRAY_BUFFER, 0);
 
 	SBufferObject &BufferObject = m_vBufferObjectIndices[Index];
-	BufferObject.m_BufferObjectID = VertBufferID;
+	BufferObject.m_BufferObjectId = VertBufferId;
 	BufferObject.m_DataSize = pCommand->m_DataSize;
 	BufferObject.m_pData = malloc(pCommand->m_DataSize);
 	if(pUploadData)
@@ -1888,7 +1888,7 @@ void CCommandProcessorFragment_OpenGL2::Cmd_RecreateBufferObject(const CCommandB
 	int Index = pCommand->m_BufferIndex;
 	SBufferObject &BufferObject = m_vBufferObjectIndices[Index];
 
-	glBindBuffer(GL_ARRAY_BUFFER, BufferObject.m_BufferObjectID);
+	glBindBuffer(GL_ARRAY_BUFFER, BufferObject.m_BufferObjectId);
 	glBufferData(GL_ARRAY_BUFFER, (GLsizeiptr)(pCommand->m_DataSize), pUploadData, GL_STATIC_DRAW);
 	glBindBuffer(GL_ARRAY_BUFFER, 0);
 
@@ -1908,7 +1908,7 @@ void CCommandProcessorFragment_OpenGL2::Cmd_UpdateBufferObject(const CCommandBuf
 	int Index = pCommand->m_BufferIndex;
 	SBufferObject &BufferObject = m_vBufferObjectIndices[Index];
 
-	glBindBuffer(GL_ARRAY_BUFFER, BufferObject.m_BufferObjectID);
+	glBindBuffer(GL_ARRAY_BUFFER, BufferObject.m_BufferObjectId);
 	glBufferSubData(GL_ARRAY_BUFFER, (GLintptr)(pCommand->m_pOffset), (GLsizeiptr)(pCommand->m_DataSize), pUploadData);
 	glBindBuffer(GL_ARRAY_BUFFER, 0);
 
@@ -1929,7 +1929,7 @@ void CCommandProcessorFragment_OpenGL2::Cmd_CopyBufferObject(const CCommandBuffe
 
 	mem_copy(((uint8_t *)WriteBufferObject.m_pData) + (ptrdiff_t)pCommand->m_WriteOffset, ((uint8_t *)ReadBufferObject.m_pData) + (ptrdiff_t)pCommand->m_ReadOffset, pCommand->m_CopySize);
 
-	glBindBuffer(GL_ARRAY_BUFFER, WriteBufferObject.m_BufferObjectID);
+	glBindBuffer(GL_ARRAY_BUFFER, WriteBufferObject.m_BufferObjectId);
 	glBufferSubData(GL_ARRAY_BUFFER, (GLintptr)(pCommand->m_WriteOffset), (GLsizeiptr)(pCommand->m_CopySize), ((uint8_t *)WriteBufferObject.m_pData) + (ptrdiff_t)pCommand->m_WriteOffset);
 	glBindBuffer(GL_ARRAY_BUFFER, 0);
 }
@@ -1939,7 +1939,7 @@ void CCommandProcessorFragment_OpenGL2::Cmd_DeleteBufferObject(const CCommandBuf
 	int Index = pCommand->m_BufferIndex;
 	SBufferObject &BufferObject = m_vBufferObjectIndices[Index];
 
-	glDeleteBuffers(1, &BufferObject.m_BufferObjectID);
+	glDeleteBuffers(1, &BufferObject.m_BufferObjectId);
 
 	free(BufferObject.m_pData);
 	BufferObject.m_pData = NULL;
@@ -1992,13 +1992,13 @@ void CCommandProcessorFragment_OpenGL2::Cmd_DeleteBufferContainer(const CCommand
 
 	if(pCommand->m_DestroyAllBO)
 	{
-		int VertBufferID = BufferContainer.m_ContainerInfo.m_VertBufferBindingIndex;
-		if(VertBufferID != -1)
+		int VertBufferId = BufferContainer.m_ContainerInfo.m_VertBufferBindingIndex;
+		if(VertBufferId != -1)
 		{
-			glDeleteBuffers(1, &m_vBufferObjectIndices[VertBufferID].m_BufferObjectID);
+			glDeleteBuffers(1, &m_vBufferObjectIndices[VertBufferId].m_BufferObjectId);
 
-			free(m_vBufferObjectIndices[VertBufferID].m_pData);
-			m_vBufferObjectIndices[VertBufferID].m_pData = NULL;
+			free(m_vBufferObjectIndices[VertBufferId].m_pData);
+			m_vBufferObjectIndices[VertBufferId].m_pData = NULL;
 		}
 	}
 
@@ -2035,7 +2035,7 @@ void CCommandProcessorFragment_OpenGL2::Cmd_RenderBorderTile(const CCommandBuffe
 
 	SBufferObject &BufferObject = m_vBufferObjectIndices[(size_t)BufferContainer.m_ContainerInfo.m_VertBufferBindingIndex];
 
-	glBindBuffer(GL_ARRAY_BUFFER, BufferObject.m_BufferObjectID);
+	glBindBuffer(GL_ARRAY_BUFFER, BufferObject.m_BufferObjectId);
 
 	glEnableVertexAttribArray(0);
 	glVertexAttribPointer(0, 2, GL_FLOAT, false, BufferContainer.m_ContainerInfo.m_Stride, BufferContainer.m_ContainerInfo.m_vAttributes[0].m_pOffset);
@@ -2087,7 +2087,7 @@ void CCommandProcessorFragment_OpenGL2::Cmd_RenderTileLayer(const CCommandBuffer
 
 	SBufferObject &BufferObject = m_vBufferObjectIndices[(size_t)BufferContainer.m_ContainerInfo.m_VertBufferBindingIndex];
 
-	glBindBuffer(GL_ARRAY_BUFFER, BufferObject.m_BufferObjectID);
+	glBindBuffer(GL_ARRAY_BUFFER, BufferObject.m_BufferObjectId);
 
 	glEnableVertexAttribArray(0);
 	glVertexAttribPointer(0, 2, GL_FLOAT, false, BufferContainer.m_ContainerInfo.m_Stride, BufferContainer.m_ContainerInfo.m_vAttributes[0].m_pOffset);

--- a/src/engine/client/backend/opengl/backend_opengl.h
+++ b/src/engine/client/backend/opengl/backend_opengl.h
@@ -144,13 +144,13 @@ class CCommandProcessorFragment_OpenGL2 : public CCommandProcessorFragment_OpenG
 
 	struct SBufferObject
 	{
-		SBufferObject(TWGLuint BufferObjectID) :
-			m_BufferObjectID(BufferObjectID)
+		SBufferObject(TWGLuint BufferObjectId) :
+			m_BufferObjectId(BufferObjectId)
 		{
 			m_pData = NULL;
 			m_DataSize = 0;
 		}
-		TWGLuint m_BufferObjectID;
+		TWGLuint m_BufferObjectId;
 		void *m_pData;
 		size_t m_DataSize;
 	};

--- a/src/engine/client/backend/opengl/backend_opengl3.cpp
+++ b/src/engine/client/backend/opengl/backend_opengl3.cpp
@@ -39,10 +39,10 @@ int CCommandProcessorFragment_OpenGL3_3::TexFormatToNewOpenGLFormat(int TexForma
 
 void CCommandProcessorFragment_OpenGL3_3::UseProgram(CGLSLTWProgram *pProgram)
 {
-	if(m_LastProgramID != pProgram->GetProgramID())
+	if(m_LastProgramId != pProgram->GetProgramId())
 	{
 		pProgram->UseProgram();
-		m_LastProgramID = pProgram->GetProgramID();
+		m_LastProgramId = pProgram->GetProgramId();
 	}
 }
 
@@ -114,7 +114,7 @@ bool CCommandProcessorFragment_OpenGL3_3::Cmd_Init(const SCommand_Init *pCommand
 	m_pPrimitiveExProgramRotationless = new CGLSLPrimitiveExProgram;
 	m_pPrimitiveExProgramTexturedRotationless = new CGLSLPrimitiveExProgram;
 	m_pSpriteProgramMultiple = new CGLSLSpriteMultipleProgram;
-	m_LastProgramID = 0;
+	m_LastProgramId = 0;
 
 	CGLSLCompiler ShaderCompiler(g_Config.m_GfxGLMajor, g_Config.m_GfxGLMinor, g_Config.m_GfxGLPatch, m_IsOpenGLES, m_OpenGLTextureLodBIAS / 1000.0f);
 
@@ -366,15 +366,15 @@ bool CCommandProcessorFragment_OpenGL3_3::Cmd_Init(const SCommand_Init *pCommand
 
 	m_LastStreamBuffer = 0;
 
-	glGenBuffers(MAX_STREAM_BUFFER_COUNT, m_aPrimitiveDrawBufferID);
-	glGenVertexArrays(MAX_STREAM_BUFFER_COUNT, m_aPrimitiveDrawVertexID);
-	glGenBuffers(1, &m_PrimitiveDrawBufferIDTex3D);
-	glGenVertexArrays(1, &m_PrimitiveDrawVertexIDTex3D);
+	glGenBuffers(MAX_STREAM_BUFFER_COUNT, m_aPrimitiveDrawBufferId);
+	glGenVertexArrays(MAX_STREAM_BUFFER_COUNT, m_aPrimitiveDrawVertexId);
+	glGenBuffers(1, &m_PrimitiveDrawBufferIdTex3D);
+	glGenVertexArrays(1, &m_PrimitiveDrawVertexIdTex3D);
 
 	for(int i = 0; i < MAX_STREAM_BUFFER_COUNT; ++i)
 	{
-		glBindBuffer(GL_ARRAY_BUFFER, m_aPrimitiveDrawBufferID[i]);
-		glBindVertexArray(m_aPrimitiveDrawVertexID[i]);
+		glBindBuffer(GL_ARRAY_BUFFER, m_aPrimitiveDrawBufferId[i]);
+		glBindVertexArray(m_aPrimitiveDrawVertexId[i]);
 		glEnableVertexAttribArray(0);
 		glEnableVertexAttribArray(1);
 		glEnableVertexAttribArray(2);
@@ -386,8 +386,8 @@ bool CCommandProcessorFragment_OpenGL3_3::Cmd_Init(const SCommand_Init *pCommand
 		m_aLastIndexBufferBound[i] = 0;
 	}
 
-	glBindBuffer(GL_ARRAY_BUFFER, m_PrimitiveDrawBufferIDTex3D);
-	glBindVertexArray(m_PrimitiveDrawVertexIDTex3D);
+	glBindBuffer(GL_ARRAY_BUFFER, m_PrimitiveDrawBufferIdTex3D);
+	glBindVertexArray(m_PrimitiveDrawVertexIdTex3D);
 	glEnableVertexAttribArray(0);
 	glEnableVertexAttribArray(1);
 	glEnableVertexAttribArray(2);
@@ -400,8 +400,8 @@ bool CCommandProcessorFragment_OpenGL3_3::Cmd_Init(const SCommand_Init *pCommand
 	glGetIntegerv(GL_MAX_TEXTURE_SIZE, &m_MaxTexSize);
 
 	glBindVertexArray(0);
-	glGenBuffers(1, &m_QuadDrawIndexBufferID);
-	glBindBuffer(BUFFER_INIT_INDEX_TARGET, m_QuadDrawIndexBufferID);
+	glGenBuffers(1, &m_QuadDrawIndexBufferId);
+	glBindBuffer(BUFFER_INIT_INDEX_TARGET, m_QuadDrawIndexBufferId);
 
 	unsigned int aIndices[CCommandBuffer::MAX_VERTICES / 4 * 6];
 	int Primq = 0;
@@ -469,11 +469,11 @@ void CCommandProcessorFragment_OpenGL3_3::Cmd_Shutdown(const SCommand_Shutdown *
 	delete m_pSpriteProgramMultiple;
 
 	glBindVertexArray(0);
-	glDeleteBuffers(MAX_STREAM_BUFFER_COUNT, m_aPrimitiveDrawBufferID);
-	glDeleteBuffers(1, &m_QuadDrawIndexBufferID);
-	glDeleteVertexArrays(MAX_STREAM_BUFFER_COUNT, m_aPrimitiveDrawVertexID);
-	glDeleteBuffers(1, &m_PrimitiveDrawBufferIDTex3D);
-	glDeleteVertexArrays(1, &m_PrimitiveDrawVertexIDTex3D);
+	glDeleteBuffers(MAX_STREAM_BUFFER_COUNT, m_aPrimitiveDrawBufferId);
+	glDeleteBuffers(1, &m_QuadDrawIndexBufferId);
+	glDeleteVertexArrays(MAX_STREAM_BUFFER_COUNT, m_aPrimitiveDrawVertexId);
+	glDeleteBuffers(1, &m_PrimitiveDrawBufferIdTex3D);
+	glDeleteVertexArrays(1, &m_PrimitiveDrawVertexIdTex3D);
 
 	for(int i = 0; i < (int)m_vTextures.size(); ++i)
 	{
@@ -727,9 +727,9 @@ void CCommandProcessorFragment_OpenGL3_3::UploadStreamBufferData(unsigned int Pr
 	};
 
 	if(AsTex3D)
-		glBindBuffer(GL_ARRAY_BUFFER, m_PrimitiveDrawBufferIDTex3D);
+		glBindBuffer(GL_ARRAY_BUFFER, m_PrimitiveDrawBufferIdTex3D);
 	else
-		glBindBuffer(GL_ARRAY_BUFFER, m_aPrimitiveDrawBufferID[m_LastStreamBuffer]);
+		glBindBuffer(GL_ARRAY_BUFFER, m_aPrimitiveDrawBufferId[m_LastStreamBuffer]);
 
 	glBufferData(GL_ARRAY_BUFFER, VertSize * Count, pVertices, GL_STREAM_DRAW);
 }
@@ -744,7 +744,7 @@ void CCommandProcessorFragment_OpenGL3_3::Cmd_Render(const CCommandBuffer::SComm
 
 	UploadStreamBufferData(pCommand->m_PrimType, pCommand->m_pVertices, sizeof(CCommandBuffer::SVertex), pCommand->m_PrimCount);
 
-	glBindVertexArray(m_aPrimitiveDrawVertexID[m_LastStreamBuffer]);
+	glBindVertexArray(m_aPrimitiveDrawVertexId[m_LastStreamBuffer]);
 
 	switch(pCommand->m_PrimType)
 	{
@@ -756,10 +756,10 @@ void CCommandProcessorFragment_OpenGL3_3::Cmd_Render(const CCommandBuffer::SComm
 		glDrawArrays(GL_TRIANGLES, 0, pCommand->m_PrimCount * 3);
 		break;
 	case CCommandBuffer::PRIMTYPE_QUADS:
-		if(m_aLastIndexBufferBound[m_LastStreamBuffer] != m_QuadDrawIndexBufferID)
+		if(m_aLastIndexBufferBound[m_LastStreamBuffer] != m_QuadDrawIndexBufferId)
 		{
-			glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_QuadDrawIndexBufferID);
-			m_aLastIndexBufferBound[m_LastStreamBuffer] = m_QuadDrawIndexBufferID;
+			glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_QuadDrawIndexBufferId);
+			m_aLastIndexBufferBound[m_LastStreamBuffer] = m_QuadDrawIndexBufferId;
 		}
 		glDrawElements(GL_TRIANGLES, pCommand->m_PrimCount * 6, GL_UNSIGNED_INT, 0);
 		break;
@@ -780,7 +780,7 @@ void CCommandProcessorFragment_OpenGL3_3::Cmd_RenderTex3D(const CCommandBuffer::
 
 	UploadStreamBufferData(pCommand->m_PrimType, pCommand->m_pVertices, sizeof(CCommandBuffer::SVertexTex3DStream), pCommand->m_PrimCount, true);
 
-	glBindVertexArray(m_PrimitiveDrawVertexIDTex3D);
+	glBindVertexArray(m_PrimitiveDrawVertexIdTex3D);
 
 	switch(pCommand->m_PrimType)
 	{
@@ -789,7 +789,7 @@ void CCommandProcessorFragment_OpenGL3_3::Cmd_RenderTex3D(const CCommandBuffer::
 		glDrawArrays(GL_LINES, 0, pCommand->m_PrimCount * 2);
 		break;
 	case CCommandBuffer::PRIMTYPE_QUADS:
-		glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_QuadDrawIndexBufferID);
+		glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_QuadDrawIndexBufferId);
 		glDrawElements(GL_TRIANGLES, pCommand->m_PrimCount * 6, GL_UNSIGNED_INT, 0);
 		break;
 	default:
@@ -800,16 +800,16 @@ void CCommandProcessorFragment_OpenGL3_3::Cmd_RenderTex3D(const CCommandBuffer::
 void CCommandProcessorFragment_OpenGL3_3::DestroyBufferContainer(int Index, bool DeleteBOs)
 {
 	SBufferContainer &BufferContainer = m_vBufferContainers[Index];
-	if(BufferContainer.m_VertArrayID != 0)
-		glDeleteVertexArrays(1, &BufferContainer.m_VertArrayID);
+	if(BufferContainer.m_VertArrayId != 0)
+		glDeleteVertexArrays(1, &BufferContainer.m_VertArrayId);
 
 	// all buffer objects can deleted automatically, so the program doesn't need to deal with them (e.g. causing crashes because of driver bugs)
 	if(DeleteBOs)
 	{
-		int VertBufferID = BufferContainer.m_ContainerInfo.m_VertBufferBindingIndex;
-		if(VertBufferID != -1)
+		int VertBufferId = BufferContainer.m_ContainerInfo.m_VertBufferBindingIndex;
+		if(VertBufferId != -1)
 		{
-			glDeleteBuffers(1, &m_vBufferObjectIndices[VertBufferID]);
+			glDeleteBuffers(1, &m_vBufferObjectIndices[VertBufferId]);
 		}
 	}
 
@@ -835,10 +835,10 @@ void CCommandProcessorFragment_OpenGL3_3::AppendIndices(unsigned int NewIndicesC
 		Primq += 4;
 	}
 
-	glBindBuffer(GL_COPY_READ_BUFFER, m_QuadDrawIndexBufferID);
-	GLuint NewIndexBufferID;
-	glGenBuffers(1, &NewIndexBufferID);
-	glBindBuffer(BUFFER_INIT_INDEX_TARGET, NewIndexBufferID);
+	glBindBuffer(GL_COPY_READ_BUFFER, m_QuadDrawIndexBufferId);
+	GLuint NewIndexBufferId;
+	glGenBuffers(1, &NewIndexBufferId);
+	glBindBuffer(BUFFER_INIT_INDEX_TARGET, NewIndexBufferId);
 	GLsizeiptr size = sizeof(unsigned int);
 	glBufferData(BUFFER_INIT_INDEX_TARGET, (GLsizeiptr)NewIndicesCount * size, NULL, GL_STATIC_DRAW);
 	glCopyBufferSubData(GL_COPY_READ_BUFFER, BUFFER_INIT_INDEX_TARGET, 0, 0, (GLsizeiptr)m_CurrentIndicesInBuffer * size);
@@ -846,8 +846,8 @@ void CCommandProcessorFragment_OpenGL3_3::AppendIndices(unsigned int NewIndicesC
 	glBindBuffer(BUFFER_INIT_INDEX_TARGET, 0);
 	glBindBuffer(GL_COPY_READ_BUFFER, 0);
 
-	glDeleteBuffers(1, &m_QuadDrawIndexBufferID);
-	m_QuadDrawIndexBufferID = NewIndexBufferID;
+	glDeleteBuffers(1, &m_QuadDrawIndexBufferId);
+	m_QuadDrawIndexBufferId = NewIndexBufferId;
 
 	for(unsigned int &i : m_aLastIndexBufferBound)
 		i = 0;
@@ -873,13 +873,13 @@ void CCommandProcessorFragment_OpenGL3_3::Cmd_CreateBufferObject(const CCommandB
 		}
 	}
 
-	GLuint VertBufferID = 0;
+	GLuint VertBufferId = 0;
 
-	glGenBuffers(1, &VertBufferID);
-	glBindBuffer(BUFFER_INIT_VERTEX_TARGET, VertBufferID);
+	glGenBuffers(1, &VertBufferId);
+	glBindBuffer(BUFFER_INIT_VERTEX_TARGET, VertBufferId);
 	glBufferData(BUFFER_INIT_VERTEX_TARGET, (GLsizeiptr)(pCommand->m_DataSize), pUploadData, GL_STATIC_DRAW);
 
-	m_vBufferObjectIndices[Index] = VertBufferID;
+	m_vBufferObjectIndices[Index] = VertBufferId;
 
 	if(pCommand->m_DeletePointer)
 		free(pUploadData);
@@ -942,8 +942,8 @@ void CCommandProcessorFragment_OpenGL3_3::Cmd_CreateBufferContainer(const CComma
 	}
 
 	SBufferContainer &BufferContainer = m_vBufferContainers[Index];
-	glGenVertexArrays(1, &BufferContainer.m_VertArrayID);
-	glBindVertexArray(BufferContainer.m_VertArrayID);
+	glGenVertexArrays(1, &BufferContainer.m_VertArrayId);
+	glBindVertexArray(BufferContainer.m_VertArrayId);
 
 	BufferContainer.m_LastIndexBufferBound = 0;
 
@@ -971,7 +971,7 @@ void CCommandProcessorFragment_OpenGL3_3::Cmd_UpdateBufferContainer(const CComma
 {
 	SBufferContainer &BufferContainer = m_vBufferContainers[pCommand->m_BufferContainerIndex];
 
-	glBindVertexArray(BufferContainer.m_VertArrayID);
+	glBindVertexArray(BufferContainer.m_VertArrayId);
 
 	// disable all old attributes
 	for(size_t i = 0; i < BufferContainer.m_ContainerInfo.m_vAttributes.size(); ++i)
@@ -1017,7 +1017,7 @@ void CCommandProcessorFragment_OpenGL3_3::Cmd_RenderBorderTile(const CCommandBuf
 		return;
 
 	SBufferContainer &BufferContainer = m_vBufferContainers[Index];
-	if(BufferContainer.m_VertArrayID == 0)
+	if(BufferContainer.m_VertArrayId == 0)
 		return;
 
 	CGLSLTileProgram *pProgram = NULL;
@@ -1033,11 +1033,11 @@ void CCommandProcessorFragment_OpenGL3_3::Cmd_RenderBorderTile(const CCommandBuf
 	pProgram->SetUniformVec2(pProgram->m_LocOffset, 1, (float *)&pCommand->m_Offset);
 	pProgram->SetUniformVec2(pProgram->m_LocScale, 1, (float *)&pCommand->m_Scale);
 
-	glBindVertexArray(BufferContainer.m_VertArrayID);
-	if(BufferContainer.m_LastIndexBufferBound != m_QuadDrawIndexBufferID)
+	glBindVertexArray(BufferContainer.m_VertArrayId);
+	if(BufferContainer.m_LastIndexBufferBound != m_QuadDrawIndexBufferId)
 	{
-		glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_QuadDrawIndexBufferID);
-		BufferContainer.m_LastIndexBufferBound = m_QuadDrawIndexBufferID;
+		glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_QuadDrawIndexBufferId);
+		BufferContainer.m_LastIndexBufferBound = m_QuadDrawIndexBufferId;
 	}
 	glDrawElements(GL_TRIANGLES, pCommand->m_DrawNum * 6, GL_UNSIGNED_INT, pCommand->m_pIndicesOffset);
 }
@@ -1050,7 +1050,7 @@ void CCommandProcessorFragment_OpenGL3_3::Cmd_RenderTileLayer(const CCommandBuff
 		return;
 
 	SBufferContainer &BufferContainer = m_vBufferContainers[Index];
-	if(BufferContainer.m_VertArrayID == 0)
+	if(BufferContainer.m_VertArrayId == 0)
 		return;
 
 	if(pCommand->m_IndicesDrawNum == 0)
@@ -1071,11 +1071,11 @@ void CCommandProcessorFragment_OpenGL3_3::Cmd_RenderTileLayer(const CCommandBuff
 	SetState(pCommand->m_State, pProgram, true);
 	pProgram->SetUniformVec4(pProgram->m_LocColor, 1, (float *)&pCommand->m_Color);
 
-	glBindVertexArray(BufferContainer.m_VertArrayID);
-	if(BufferContainer.m_LastIndexBufferBound != m_QuadDrawIndexBufferID)
+	glBindVertexArray(BufferContainer.m_VertArrayId);
+	if(BufferContainer.m_LastIndexBufferBound != m_QuadDrawIndexBufferId)
 	{
-		glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_QuadDrawIndexBufferID);
-		BufferContainer.m_LastIndexBufferBound = m_QuadDrawIndexBufferID;
+		glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_QuadDrawIndexBufferId);
+		BufferContainer.m_LastIndexBufferBound = m_QuadDrawIndexBufferId;
 	}
 	for(int i = 0; i < pCommand->m_IndicesDrawNum; ++i)
 	{
@@ -1091,7 +1091,7 @@ void CCommandProcessorFragment_OpenGL3_3::Cmd_RenderQuadLayer(const CCommandBuff
 		return;
 
 	SBufferContainer &BufferContainer = m_vBufferContainers[Index];
-	if(BufferContainer.m_VertArrayID == 0)
+	if(BufferContainer.m_VertArrayId == 0)
 		return;
 
 	if(pCommand->m_QuadNum == 0)
@@ -1110,11 +1110,11 @@ void CCommandProcessorFragment_OpenGL3_3::Cmd_RenderQuadLayer(const CCommandBuff
 	UseProgram(pProgram);
 	SetState(pCommand->m_State, pProgram);
 
-	glBindVertexArray(BufferContainer.m_VertArrayID);
-	if(BufferContainer.m_LastIndexBufferBound != m_QuadDrawIndexBufferID)
+	glBindVertexArray(BufferContainer.m_VertArrayId);
+	if(BufferContainer.m_LastIndexBufferBound != m_QuadDrawIndexBufferId)
 	{
-		glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_QuadDrawIndexBufferID);
-		BufferContainer.m_LastIndexBufferBound = m_QuadDrawIndexBufferID;
+		glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_QuadDrawIndexBufferId);
+		BufferContainer.m_LastIndexBufferBound = m_QuadDrawIndexBufferId;
 	}
 
 	int QuadsLeft = pCommand->m_QuadNum;
@@ -1209,14 +1209,14 @@ void CCommandProcessorFragment_OpenGL3_3::Cmd_RenderText(const CCommandBuffer::S
 		return;
 
 	SBufferContainer &BufferContainer = m_vBufferContainers[Index];
-	if(BufferContainer.m_VertArrayID == 0)
+	if(BufferContainer.m_VertArrayId == 0)
 		return;
 
-	glBindVertexArray(BufferContainer.m_VertArrayID);
-	if(BufferContainer.m_LastIndexBufferBound != m_QuadDrawIndexBufferID)
+	glBindVertexArray(BufferContainer.m_VertArrayId);
+	if(BufferContainer.m_LastIndexBufferBound != m_QuadDrawIndexBufferId)
 	{
-		glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_QuadDrawIndexBufferID);
-		BufferContainer.m_LastIndexBufferBound = m_QuadDrawIndexBufferID;
+		glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_QuadDrawIndexBufferId);
+		BufferContainer.m_LastIndexBufferBound = m_QuadDrawIndexBufferId;
 	}
 
 	RenderText(pCommand->m_State, pCommand->m_DrawNum, pCommand->m_TextTextureIndex, pCommand->m_TextOutlineTextureIndex, pCommand->m_TextureSize, pCommand->m_TextColor, pCommand->m_TextOutlineColor);
@@ -1235,14 +1235,14 @@ void CCommandProcessorFragment_OpenGL3_3::Cmd_RenderQuadContainer(const CCommand
 		return;
 
 	SBufferContainer &BufferContainer = m_vBufferContainers[Index];
-	if(BufferContainer.m_VertArrayID == 0)
+	if(BufferContainer.m_VertArrayId == 0)
 		return;
 
-	glBindVertexArray(BufferContainer.m_VertArrayID);
-	if(BufferContainer.m_LastIndexBufferBound != m_QuadDrawIndexBufferID)
+	glBindVertexArray(BufferContainer.m_VertArrayId);
+	if(BufferContainer.m_LastIndexBufferBound != m_QuadDrawIndexBufferId)
 	{
-		glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_QuadDrawIndexBufferID);
-		BufferContainer.m_LastIndexBufferBound = m_QuadDrawIndexBufferID;
+		glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_QuadDrawIndexBufferId);
+		BufferContainer.m_LastIndexBufferBound = m_QuadDrawIndexBufferId;
 	}
 
 	CGLSLTWProgram *pProgram = m_pPrimitiveProgram;
@@ -1267,14 +1267,14 @@ void CCommandProcessorFragment_OpenGL3_3::Cmd_RenderQuadContainerEx(const CComma
 		return;
 
 	SBufferContainer &BufferContainer = m_vBufferContainers[Index];
-	if(BufferContainer.m_VertArrayID == 0)
+	if(BufferContainer.m_VertArrayId == 0)
 		return;
 
-	glBindVertexArray(BufferContainer.m_VertArrayID);
-	if(BufferContainer.m_LastIndexBufferBound != m_QuadDrawIndexBufferID)
+	glBindVertexArray(BufferContainer.m_VertArrayId);
+	if(BufferContainer.m_LastIndexBufferBound != m_QuadDrawIndexBufferId)
 	{
-		glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_QuadDrawIndexBufferID);
-		BufferContainer.m_LastIndexBufferBound = m_QuadDrawIndexBufferID;
+		glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_QuadDrawIndexBufferId);
+		BufferContainer.m_LastIndexBufferBound = m_QuadDrawIndexBufferId;
 	}
 
 	CGLSLPrimitiveExProgram *pProgram = m_pPrimitiveExProgramRotationless;
@@ -1328,14 +1328,14 @@ void CCommandProcessorFragment_OpenGL3_3::Cmd_RenderQuadContainerAsSpriteMultipl
 		return;
 
 	SBufferContainer &BufferContainer = m_vBufferContainers[Index];
-	if(BufferContainer.m_VertArrayID == 0)
+	if(BufferContainer.m_VertArrayId == 0)
 		return;
 
-	glBindVertexArray(BufferContainer.m_VertArrayID);
-	if(BufferContainer.m_LastIndexBufferBound != m_QuadDrawIndexBufferID)
+	glBindVertexArray(BufferContainer.m_VertArrayId);
+	if(BufferContainer.m_LastIndexBufferBound != m_QuadDrawIndexBufferId)
 	{
-		glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_QuadDrawIndexBufferID);
-		BufferContainer.m_LastIndexBufferBound = m_QuadDrawIndexBufferID;
+		glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_QuadDrawIndexBufferId);
+		BufferContainer.m_LastIndexBufferBound = m_QuadDrawIndexBufferId;
 	}
 
 	UseProgram(m_pSpriteProgramMultiple);

--- a/src/engine/client/backend/opengl/backend_opengl3.h
+++ b/src/engine/client/backend/opengl/backend_opengl3.h
@@ -37,18 +37,18 @@ protected:
 	CGLSLPrimitiveExProgram *m_pPrimitiveExProgramTexturedRotationless;
 	CGLSLSpriteMultipleProgram *m_pSpriteProgramMultiple;
 
-	TWGLuint m_LastProgramID;
+	TWGLuint m_LastProgramId;
 
-	TWGLuint m_aPrimitiveDrawVertexID[MAX_STREAM_BUFFER_COUNT];
-	TWGLuint m_PrimitiveDrawVertexIDTex3D;
-	TWGLuint m_aPrimitiveDrawBufferID[MAX_STREAM_BUFFER_COUNT];
-	TWGLuint m_PrimitiveDrawBufferIDTex3D;
+	TWGLuint m_aPrimitiveDrawVertexId[MAX_STREAM_BUFFER_COUNT];
+	TWGLuint m_PrimitiveDrawVertexIdTex3D;
+	TWGLuint m_aPrimitiveDrawBufferId[MAX_STREAM_BUFFER_COUNT];
+	TWGLuint m_PrimitiveDrawBufferIdTex3D;
 
 	TWGLuint m_aLastIndexBufferBound[MAX_STREAM_BUFFER_COUNT];
 
 	int m_LastStreamBuffer;
 
-	TWGLuint m_QuadDrawIndexBufferID;
+	TWGLuint m_QuadDrawIndexBufferId;
 	unsigned int m_CurrentIndicesInBuffer;
 
 	void DestroyBufferContainer(int Index, bool DeleteBOs = true);
@@ -58,8 +58,8 @@ protected:
 	struct SBufferContainer
 	{
 		SBufferContainer() :
-			m_VertArrayID(0), m_LastIndexBufferBound(0) {}
-		TWGLuint m_VertArrayID;
+			m_VertArrayId(0), m_LastIndexBufferBound(0) {}
+		TWGLuint m_VertArrayId;
 		TWGLuint m_LastIndexBufferBound;
 		SBufferContainerInfo m_ContainerInfo;
 	};

--- a/src/engine/client/backend/opengl/opengl_sl.cpp
+++ b/src/engine/client/backend/opengl/opengl_sl.cpp
@@ -126,7 +126,7 @@ bool CGLSL::LoadShader(CGLSLCompiler *pCompiler, IStorage *pStorage, const char 
 		m_Type = Type;
 		m_IsLoaded = true;
 
-		m_ShaderID = shader;
+		m_ShaderId = shader;
 
 		return true;
 	}
@@ -139,7 +139,7 @@ void CGLSL::DeleteShader()
 	if(!IsLoaded())
 		return;
 	m_IsLoaded = false;
-	glDeleteShader(m_ShaderID);
+	glDeleteShader(m_ShaderId);
 }
 
 bool CGLSL::IsLoaded() const
@@ -147,9 +147,9 @@ bool CGLSL::IsLoaded() const
 	return m_IsLoaded;
 }
 
-TWGLuint CGLSL::GetShaderID() const
+TWGLuint CGLSL::GetShaderId() const
 {
-	return m_ShaderID;
+	return m_ShaderId;
 }
 
 CGLSL::CGLSL()

--- a/src/engine/client/backend/opengl/opengl_sl.h
+++ b/src/engine/client/backend/opengl/opengl_sl.h
@@ -21,13 +21,13 @@ public:
 	void DeleteShader();
 
 	bool IsLoaded() const;
-	TWGLuint GetShaderID() const;
+	TWGLuint GetShaderId() const;
 
 	CGLSL();
 	virtual ~CGLSL();
 
 private:
-	TWGLuint m_ShaderID;
+	TWGLuint m_ShaderId;
 	int m_Type;
 	bool m_IsLoaded;
 };

--- a/src/engine/client/backend/opengl/opengl_sl_program.cpp
+++ b/src/engine/client/backend/opengl/opengl_sl_program.cpp
@@ -14,7 +14,7 @@
 
 void CGLSLProgram::CreateProgram()
 {
-	m_ProgramID = glCreateProgram();
+	m_ProgramId = glCreateProgram();
 }
 
 void CGLSLProgram::DeleteProgram()
@@ -22,14 +22,14 @@ void CGLSLProgram::DeleteProgram()
 	if(!m_IsLinked)
 		return;
 	m_IsLinked = false;
-	glDeleteProgram(m_ProgramID);
+	glDeleteProgram(m_ProgramId);
 }
 
 bool CGLSLProgram::AddShader(CGLSL *pShader) const
 {
 	if(pShader->IsLoaded())
 	{
-		glAttachShader(m_ProgramID, pShader->GetShaderID());
+		glAttachShader(m_ProgramId, pShader->GetShaderId());
 		return true;
 	}
 	return false;
@@ -39,27 +39,27 @@ void CGLSLProgram::DetachShader(CGLSL *pShader) const
 {
 	if(pShader->IsLoaded())
 	{
-		DetachShaderByID(pShader->GetShaderID());
+		DetachShaderById(pShader->GetShaderId());
 	}
 }
 
-void CGLSLProgram::DetachShaderByID(TWGLuint ShaderID) const
+void CGLSLProgram::DetachShaderById(TWGLuint ShaderId) const
 {
-	glDetachShader(m_ProgramID, ShaderID);
+	glDetachShader(m_ProgramId, ShaderId);
 }
 
 void CGLSLProgram::LinkProgram()
 {
-	glLinkProgram(m_ProgramID);
+	glLinkProgram(m_ProgramId);
 	int LinkStatus;
-	glGetProgramiv(m_ProgramID, GL_LINK_STATUS, &LinkStatus);
+	glGetProgramiv(m_ProgramId, GL_LINK_STATUS, &LinkStatus);
 	m_IsLinked = LinkStatus == GL_TRUE;
 	if(!m_IsLinked)
 	{
 		char aInfoLog[1024];
 		char aFinalMessage[1536];
 		int iLogLength;
-		glGetProgramInfoLog(m_ProgramID, 1024, &iLogLength, aInfoLog);
+		glGetProgramInfoLog(m_ProgramId, 1024, &iLogLength, aInfoLog);
 		str_format(aFinalMessage, sizeof(aFinalMessage), "Error! Shader program wasn't linked! The linker returned:\n\n%s", aInfoLog);
 		dbg_msg("glslprogram", "%s", aFinalMessage);
 	}
@@ -74,13 +74,13 @@ void CGLSLProgram::DetachAllShaders() const
 	GLsizei ReturnedCount = 0;
 	while(true)
 	{
-		glGetAttachedShaders(m_ProgramID, 100, &ReturnedCount, aShaders);
+		glGetAttachedShaders(m_ProgramId, 100, &ReturnedCount, aShaders);
 
 		if(ReturnedCount > 0)
 		{
 			for(GLsizei i = 0; i < ReturnedCount; ++i)
 			{
-				DetachShaderByID(aShaders[i]);
+				DetachShaderById(aShaders[i]);
 			}
 		}
 
@@ -121,18 +121,18 @@ void CGLSLProgram::SetUniform(int Loc, const bool Value)
 
 int CGLSLProgram::GetUniformLoc(const char *pName) const
 {
-	return glGetUniformLocation(m_ProgramID, pName);
+	return glGetUniformLocation(m_ProgramId, pName);
 }
 
 void CGLSLProgram::UseProgram() const
 {
 	if(m_IsLinked)
-		glUseProgram(m_ProgramID);
+		glUseProgram(m_ProgramId);
 }
 
-TWGLuint CGLSLProgram::GetProgramID() const
+TWGLuint CGLSLProgram::GetProgramId() const
 {
-	return m_ProgramID;
+	return m_ProgramId;
 }
 
 CGLSLProgram::CGLSLProgram()

--- a/src/engine/client/backend/opengl/opengl_sl_program.h
+++ b/src/engine/client/backend/opengl/opengl_sl_program.h
@@ -26,10 +26,10 @@ public:
 
 	void LinkProgram();
 	void UseProgram() const;
-	TWGLuint GetProgramID() const;
+	TWGLuint GetProgramId() const;
 
 	void DetachShader(CGLSL *pShader) const;
-	void DetachShaderByID(TWGLuint ShaderID) const;
+	void DetachShaderById(TWGLuint ShaderId) const;
 	void DetachAllShaders() const;
 
 	//Support various types
@@ -47,7 +47,7 @@ public:
 	virtual ~CGLSLProgram();
 
 protected:
-	TWGLuint m_ProgramID;
+	TWGLuint m_ProgramId;
 	bool m_IsLinked;
 };
 

--- a/src/engine/client/backend/vulkan/backend_vulkan.cpp
+++ b/src/engine/client/backend/vulkan/backend_vulkan.cpp
@@ -113,10 +113,10 @@ class CCommandProcessorFragment_Vulkan : public CCommandProcessorFragment_GLBase
 	* STRUCT DEFINITIONS
 	************************/
 
-	static constexpr size_t s_StagingBufferCacheID = 0;
-	static constexpr size_t s_StagingBufferImageCacheID = 1;
-	static constexpr size_t s_VertexBufferCacheID = 2;
-	static constexpr size_t s_ImageBufferCacheID = 3;
+	static constexpr size_t s_StagingBufferCacheId = 0;
+	static constexpr size_t s_StagingBufferImageCacheId = 1;
+	static constexpr size_t s_VertexBufferCacheId = 2;
+	static constexpr size_t s_ImageBufferCacheId = 3;
 
 	struct SDeviceMemoryBlock
 	{
@@ -325,7 +325,7 @@ class CCommandProcessorFragment_Vulkan : public CCommandProcessorFragment_GLBase
 		}
 	};
 
-	template<size_t ID>
+	template<size_t Id>
 	struct SMemoryBlock
 	{
 		SMemoryHeap::SMemoryHeapQueueElement m_HeapData;
@@ -342,13 +342,13 @@ class CCommandProcessorFragment_Vulkan : public CCommandProcessorFragment_GLBase
 		SMemoryHeap *m_pHeap;
 	};
 
-	template<size_t ID>
-	struct SMemoryImageBlock : public SMemoryBlock<ID>
+	template<size_t Id>
+	struct SMemoryImageBlock : public SMemoryBlock<Id>
 	{
 		uint32_t m_ImageMemoryBits;
 	};
 
-	template<size_t ID>
+	template<size_t Id>
 	struct SMemoryBlockCache
 	{
 		struct SMemoryCacheType
@@ -364,7 +364,7 @@ class CCommandProcessorFragment_Vulkan : public CCommandProcessorFragment_GLBase
 			std::vector<SMemoryCacheHeap *> m_vpMemoryHeaps;
 		};
 		SMemoryCacheType m_MemoryCaches;
-		std::vector<std::vector<SMemoryBlock<ID>>> m_vvFrameDelayedCachedBufferCleanup;
+		std::vector<std::vector<SMemoryBlock<Id>>> m_vvFrameDelayedCachedBufferCleanup;
 
 		bool m_CanShrink = false;
 
@@ -411,7 +411,7 @@ class CCommandProcessorFragment_Vulkan : public CCommandProcessorFragment_GLBase
 			m_vvFrameDelayedCachedBufferCleanup[ImgIndex].clear();
 		}
 
-		void FreeMemBlock(SMemoryBlock<ID> &Block, size_t ImgIndex)
+		void FreeMemBlock(SMemoryBlock<Id> &Block, size_t ImgIndex)
 		{
 			m_vvFrameDelayedCachedBufferCleanup[ImgIndex].push_back(Block);
 		}
@@ -455,12 +455,12 @@ class CCommandProcessorFragment_Vulkan : public CCommandProcessorFragment_GLBase
 	struct CTexture
 	{
 		VkImage m_Img = VK_NULL_HANDLE;
-		SMemoryImageBlock<s_ImageBufferCacheID> m_ImgMem;
+		SMemoryImageBlock<s_ImageBufferCacheId> m_ImgMem;
 		VkImageView m_ImgView = VK_NULL_HANDLE;
 		VkSampler m_aSamplers[2] = {VK_NULL_HANDLE, VK_NULL_HANDLE};
 
 		VkImage m_Img3D = VK_NULL_HANDLE;
-		SMemoryImageBlock<s_ImageBufferCacheID> m_Img3DMem;
+		SMemoryImageBlock<s_ImageBufferCacheId> m_Img3DMem;
 		VkImageView m_Img3DView = VK_NULL_HANDLE;
 		VkSampler m_Sampler3D = VK_NULL_HANDLE;
 
@@ -477,7 +477,7 @@ class CCommandProcessorFragment_Vulkan : public CCommandProcessorFragment_GLBase
 
 	struct SBufferObject
 	{
-		SMemoryBlock<s_VertexBufferCacheID> m_Mem;
+		SMemoryBlock<s_VertexBufferCacheId> m_Mem;
 	};
 
 	struct SBufferObjectFrame
@@ -865,7 +865,7 @@ class CCommandProcessorFragment_Vulkan : public CCommandProcessorFragment_GLBase
 	struct SSwapChainMultiSampleImage
 	{
 		VkImage m_Image = VK_NULL_HANDLE;
-		SMemoryImageBlock<s_ImageBufferCacheID> m_ImgMem;
+		SMemoryImageBlock<s_ImageBufferCacheId> m_ImgMem;
 		VkImageView m_ImgView = VK_NULL_HANDLE;
 	};
 
@@ -875,10 +875,10 @@ class CCommandProcessorFragment_Vulkan : public CCommandProcessorFragment_GLBase
 
 	std::unordered_map<std::string, SShaderFileCache> m_ShaderFiles;
 
-	SMemoryBlockCache<s_StagingBufferCacheID> m_StagingBufferCache;
-	SMemoryBlockCache<s_StagingBufferImageCacheID> m_StagingBufferCacheImage;
-	SMemoryBlockCache<s_VertexBufferCacheID> m_VertexBufferCache;
-	std::map<uint32_t, SMemoryBlockCache<s_ImageBufferCacheID>> m_ImageBufferCaches;
+	SMemoryBlockCache<s_StagingBufferCacheId> m_StagingBufferCache;
+	SMemoryBlockCache<s_StagingBufferImageCacheId> m_StagingBufferCacheImage;
+	SMemoryBlockCache<s_VertexBufferCacheId> m_VertexBufferCache;
+	std::map<uint32_t, SMemoryBlockCache<s_ImageBufferCacheId>> m_ImageBufferCaches;
 
 	std::vector<VkMappedMemoryRange> m_vNonFlushedStagingBufferRange;
 
@@ -889,7 +889,7 @@ class CCommandProcessorFragment_Vulkan : public CCommandProcessorFragment_GLBase
 	std::atomic<uint64_t> *m_pStreamMemoryUsage;
 	std::atomic<uint64_t> *m_pStagingMemoryUsage;
 
-	TTWGraphicsGPUList *m_pGPUList;
+	TTwGraphicsGpuList *m_pGpuList;
 
 	int m_GlobalTextureLodBIAS;
 	uint32_t m_MultiSamplingCount = 1;
@@ -1600,10 +1600,10 @@ protected:
 		return CreateBuffer(RequiredSize, MemUsage, BufferUsage, BufferProperties, Buffer, BufferMemory);
 	}
 
-	template<size_t ID,
+	template<size_t Id,
 		int64_t MemoryBlockSize, size_t BlockCount,
 		bool RequiresMapping>
-	[[nodiscard]] bool GetBufferBlockImpl(SMemoryBlock<ID> &RetBlock, SMemoryBlockCache<ID> &MemoryCache, VkBufferUsageFlags BufferUsage, VkMemoryPropertyFlags BufferProperties, const void *pBufferData, VkDeviceSize RequiredSize, VkDeviceSize TargetAlignment)
+	[[nodiscard]] bool GetBufferBlockImpl(SMemoryBlock<Id> &RetBlock, SMemoryBlockCache<Id> &MemoryCache, VkBufferUsageFlags BufferUsage, VkMemoryPropertyFlags BufferProperties, const void *pBufferData, VkDeviceSize RequiredSize, VkDeviceSize TargetAlignment)
 	{
 		bool Res = true;
 
@@ -1611,7 +1611,7 @@ protected:
 			bool FoundAllocation = false;
 			SMemoryHeap::SMemoryHeapQueueElement AllocatedMem;
 			SDeviceMemoryBlock TmpBufferMemory;
-			typename SMemoryBlockCache<ID>::SMemoryCacheType::SMemoryCacheHeap *pCacheHeap = nullptr;
+			typename SMemoryBlockCache<Id>::SMemoryCacheType::SMemoryCacheHeap *pCacheHeap = nullptr;
 			auto &Heaps = MemoryCache.m_MemoryCaches.m_vpMemoryHeaps;
 			for(size_t i = 0; i < Heaps.size(); ++i)
 			{
@@ -1626,7 +1626,7 @@ protected:
 			}
 			if(!FoundAllocation)
 			{
-				typename SMemoryBlockCache<ID>::SMemoryCacheType::SMemoryCacheHeap *pNewHeap = new typename SMemoryBlockCache<ID>::SMemoryCacheType::SMemoryCacheHeap();
+				typename SMemoryBlockCache<Id>::SMemoryCacheType::SMemoryCacheHeap *pNewHeap = new typename SMemoryBlockCache<Id>::SMemoryCacheType::SMemoryCacheHeap();
 
 				VkBuffer TmpBuffer;
 				if(!GetBufferImpl(MemoryBlockSize * BlockCount, RequiresMapping ? MEMORY_BLOCK_USAGE_STAGING : MEMORY_BLOCK_USAGE_BUFFER, TmpBuffer, TmpBufferMemory, BufferUsage, BufferProperties))
@@ -1712,18 +1712,18 @@ protected:
 		return Res;
 	}
 
-	[[nodiscard]] bool GetStagingBuffer(SMemoryBlock<s_StagingBufferCacheID> &ResBlock, const void *pBufferData, VkDeviceSize RequiredSize)
+	[[nodiscard]] bool GetStagingBuffer(SMemoryBlock<s_StagingBufferCacheId> &ResBlock, const void *pBufferData, VkDeviceSize RequiredSize)
 	{
-		return GetBufferBlockImpl<s_StagingBufferCacheID, 8 * 1024 * 1024, 3, true>(ResBlock, m_StagingBufferCache, VK_BUFFER_USAGE_TRANSFER_SRC_BIT, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_CACHED_BIT, pBufferData, RequiredSize, maximum<VkDeviceSize>(m_NonCoherentMemAlignment, 16));
+		return GetBufferBlockImpl<s_StagingBufferCacheId, 8 * 1024 * 1024, 3, true>(ResBlock, m_StagingBufferCache, VK_BUFFER_USAGE_TRANSFER_SRC_BIT, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_CACHED_BIT, pBufferData, RequiredSize, maximum<VkDeviceSize>(m_NonCoherentMemAlignment, 16));
 	}
 
-	[[nodiscard]] bool GetStagingBufferImage(SMemoryBlock<s_StagingBufferImageCacheID> &ResBlock, const void *pBufferData, VkDeviceSize RequiredSize)
+	[[nodiscard]] bool GetStagingBufferImage(SMemoryBlock<s_StagingBufferImageCacheId> &ResBlock, const void *pBufferData, VkDeviceSize RequiredSize)
 	{
-		return GetBufferBlockImpl<s_StagingBufferImageCacheID, 8 * 1024 * 1024, 3, true>(ResBlock, m_StagingBufferCacheImage, VK_BUFFER_USAGE_TRANSFER_SRC_BIT, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_CACHED_BIT, pBufferData, RequiredSize, maximum<VkDeviceSize>(m_OptimalImageCopyMemAlignment, maximum<VkDeviceSize>(m_NonCoherentMemAlignment, 16)));
+		return GetBufferBlockImpl<s_StagingBufferImageCacheId, 8 * 1024 * 1024, 3, true>(ResBlock, m_StagingBufferCacheImage, VK_BUFFER_USAGE_TRANSFER_SRC_BIT, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_CACHED_BIT, pBufferData, RequiredSize, maximum<VkDeviceSize>(m_OptimalImageCopyMemAlignment, maximum<VkDeviceSize>(m_NonCoherentMemAlignment, 16)));
 	}
 
-	template<size_t ID>
-	void PrepareStagingMemRange(SMemoryBlock<ID> &Block)
+	template<size_t Id>
+	void PrepareStagingMemRange(SMemoryBlock<Id> &Block)
 	{
 		VkMappedMemoryRange UploadRange{};
 		UploadRange.sType = VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE;
@@ -1742,7 +1742,7 @@ protected:
 		m_vNonFlushedStagingBufferRange.push_back(UploadRange);
 	}
 
-	void UploadAndFreeStagingMemBlock(SMemoryBlock<s_StagingBufferCacheID> &Block)
+	void UploadAndFreeStagingMemBlock(SMemoryBlock<s_StagingBufferCacheId> &Block)
 	{
 		PrepareStagingMemRange(Block);
 		if(!Block.m_IsCached)
@@ -1755,7 +1755,7 @@ protected:
 		}
 	}
 
-	void UploadAndFreeStagingImageMemBlock(SMemoryBlock<s_StagingBufferImageCacheID> &Block)
+	void UploadAndFreeStagingImageMemBlock(SMemoryBlock<s_StagingBufferImageCacheId> &Block)
 	{
 		PrepareStagingMemRange(Block);
 		if(!Block.m_IsCached)
@@ -1768,12 +1768,12 @@ protected:
 		}
 	}
 
-	[[nodiscard]] bool GetVertexBuffer(SMemoryBlock<s_VertexBufferCacheID> &ResBlock, VkDeviceSize RequiredSize)
+	[[nodiscard]] bool GetVertexBuffer(SMemoryBlock<s_VertexBufferCacheId> &ResBlock, VkDeviceSize RequiredSize)
 	{
-		return GetBufferBlockImpl<s_VertexBufferCacheID, 8 * 1024 * 1024, 3, false>(ResBlock, m_VertexBufferCache, VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, nullptr, RequiredSize, 16);
+		return GetBufferBlockImpl<s_VertexBufferCacheId, 8 * 1024 * 1024, 3, false>(ResBlock, m_VertexBufferCache, VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, nullptr, RequiredSize, 16);
 	}
 
-	void FreeVertexMemBlock(SMemoryBlock<s_VertexBufferCacheID> &Block)
+	void FreeVertexMemBlock(SMemoryBlock<s_VertexBufferCacheId> &Block)
 	{
 		if(!Block.m_IsCached)
 		{
@@ -1825,15 +1825,15 @@ protected:
 		return true;
 	}
 
-	template<size_t ID,
+	template<size_t Id,
 		int64_t MemoryBlockSize, size_t BlockCount>
-	[[nodiscard]] bool GetImageMemoryBlockImpl(SMemoryImageBlock<ID> &RetBlock, SMemoryBlockCache<ID> &MemoryCache, VkMemoryPropertyFlags BufferProperties, VkDeviceSize RequiredSize, VkDeviceSize RequiredAlignment, uint32_t RequiredMemoryTypeBits)
+	[[nodiscard]] bool GetImageMemoryBlockImpl(SMemoryImageBlock<Id> &RetBlock, SMemoryBlockCache<Id> &MemoryCache, VkMemoryPropertyFlags BufferProperties, VkDeviceSize RequiredSize, VkDeviceSize RequiredAlignment, uint32_t RequiredMemoryTypeBits)
 	{
 		auto &&CreateCacheBlock = [&]() -> bool {
 			bool FoundAllocation = false;
 			SMemoryHeap::SMemoryHeapQueueElement AllocatedMem;
 			SDeviceMemoryBlock TmpBufferMemory;
-			typename SMemoryBlockCache<ID>::SMemoryCacheType::SMemoryCacheHeap *pCacheHeap = nullptr;
+			typename SMemoryBlockCache<Id>::SMemoryCacheType::SMemoryCacheHeap *pCacheHeap = nullptr;
 			for(size_t i = 0; i < MemoryCache.m_MemoryCaches.m_vpMemoryHeaps.size(); ++i)
 			{
 				auto *pHeap = MemoryCache.m_MemoryCaches.m_vpMemoryHeaps[i];
@@ -1847,7 +1847,7 @@ protected:
 			}
 			if(!FoundAllocation)
 			{
-				typename SMemoryBlockCache<ID>::SMemoryCacheType::SMemoryCacheHeap *pNewHeap = new typename SMemoryBlockCache<ID>::SMemoryCacheType::SMemoryCacheHeap();
+				typename SMemoryBlockCache<Id>::SMemoryCacheType::SMemoryCacheHeap *pNewHeap = new typename SMemoryBlockCache<Id>::SMemoryCacheType::SMemoryCacheHeap();
 
 				if(!GetImageMemoryImpl(MemoryBlockSize * BlockCount, RequiredMemoryTypeBits, TmpBufferMemory, BufferProperties))
 				{
@@ -1907,7 +1907,7 @@ protected:
 		return true;
 	}
 
-	[[nodiscard]] bool GetImageMemory(SMemoryImageBlock<s_ImageBufferCacheID> &RetBlock, VkDeviceSize RequiredSize, VkDeviceSize RequiredAlignment, uint32_t RequiredMemoryTypeBits)
+	[[nodiscard]] bool GetImageMemory(SMemoryImageBlock<s_ImageBufferCacheId> &RetBlock, VkDeviceSize RequiredSize, VkDeviceSize RequiredAlignment, uint32_t RequiredMemoryTypeBits)
 	{
 		auto it = m_ImageBufferCaches.find(RequiredMemoryTypeBits);
 		if(it == m_ImageBufferCaches.end())
@@ -1916,10 +1916,10 @@ protected:
 
 			it->second.Init(m_SwapChainImageCount);
 		}
-		return GetImageMemoryBlockImpl<s_ImageBufferCacheID, s_1024x1024ImgSize, 2>(RetBlock, it->second, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, RequiredSize, RequiredAlignment, RequiredMemoryTypeBits);
+		return GetImageMemoryBlockImpl<s_ImageBufferCacheId, s_1024x1024ImgSize, 2>(RetBlock, it->second, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, RequiredSize, RequiredAlignment, RequiredMemoryTypeBits);
 	}
 
-	void FreeImageMemBlock(SMemoryImageBlock<s_ImageBufferCacheID> &Block)
+	void FreeImageMemBlock(SMemoryImageBlock<s_ImageBufferCacheId> &Block)
 	{
 		if(!Block.m_IsCached)
 		{
@@ -2531,7 +2531,7 @@ protected:
 	[[nodiscard]] bool UpdateTexture(size_t TextureSlot, VkFormat Format, void *&pData, int64_t XOff, int64_t YOff, size_t Width, size_t Height)
 	{
 		const size_t ImageSize = Width * Height * VulkanFormatToPixelSize(Format);
-		SMemoryBlock<s_StagingBufferImageCacheID> StagingBuffer;
+		SMemoryBlock<s_StagingBufferImageCacheId> StagingBuffer;
 		if(!GetStagingBufferImage(StagingBuffer, pData, ImageSize))
 			return false;
 
@@ -2793,11 +2793,11 @@ protected:
 		return true;
 	}
 
-	[[nodiscard]] bool CreateTextureImage(size_t ImageIndex, VkImage &NewImage, SMemoryImageBlock<s_ImageBufferCacheID> &NewImgMem, const void *pData, VkFormat Format, size_t Width, size_t Height, size_t Depth, size_t PixelSize, size_t MipMapLevelCount)
+	[[nodiscard]] bool CreateTextureImage(size_t ImageIndex, VkImage &NewImage, SMemoryImageBlock<s_ImageBufferCacheId> &NewImgMem, const void *pData, VkFormat Format, size_t Width, size_t Height, size_t Depth, size_t PixelSize, size_t MipMapLevelCount)
 	{
 		int ImageSize = Width * Height * Depth * PixelSize;
 
-		SMemoryBlock<s_StagingBufferImageCacheID> StagingBuffer;
+		SMemoryBlock<s_StagingBufferImageCacheId> StagingBuffer;
 		if(!GetStagingBufferImage(StagingBuffer, pData, ImageSize))
 			return false;
 
@@ -2903,7 +2903,7 @@ protected:
 		return ImageView;
 	}
 
-	[[nodiscard]] bool CreateImage(uint32_t Width, uint32_t Height, uint32_t Depth, size_t MipMapLevelCount, VkFormat Format, VkImageTiling Tiling, VkImage &Image, SMemoryImageBlock<s_ImageBufferCacheID> &ImageMemory, VkImageUsageFlags ImageUsage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT)
+	[[nodiscard]] bool CreateImage(uint32_t Width, uint32_t Height, uint32_t Depth, size_t MipMapLevelCount, VkFormat Format, VkImageTiling Tiling, VkImage &Image, SMemoryImageBlock<s_ImageBufferCacheId> &ImageMemory, VkImageUsageFlags ImageUsage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT)
 	{
 		VkImageCreateInfo ImageInfo{};
 		ImageInfo.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
@@ -3088,11 +3088,11 @@ protected:
 		size_t BufferOffset = 0;
 		if(!IsOneFrameBuffer)
 		{
-			SMemoryBlock<s_StagingBufferCacheID> StagingBuffer;
+			SMemoryBlock<s_StagingBufferCacheId> StagingBuffer;
 			if(!GetStagingBuffer(StagingBuffer, pUploadData, BufferDataSize))
 				return false;
 
-			SMemoryBlock<s_VertexBufferCacheID> Mem;
+			SMemoryBlock<s_VertexBufferCacheId> Mem;
 			if(!GetVertexBuffer(Mem, BufferDataSize))
 				return false;
 
@@ -3653,25 +3653,25 @@ public:
 		return true;
 	}
 
-	STWGraphicGPU::ETWGraphicsGPUType VKGPUTypeToGraphicsGPUType(VkPhysicalDeviceType VKGPUType)
+	STWGraphicGpu::ETWGraphicsGpuType VKGPUTypeToGraphicsGpuType(VkPhysicalDeviceType VKGPUType)
 	{
 		if(VKGPUType == VkPhysicalDeviceType::VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU)
-			return STWGraphicGPU::ETWGraphicsGPUType::GRAPHICS_GPU_TYPE_DISCRETE;
+			return STWGraphicGpu::ETWGraphicsGpuType::GRAPHICS_GPU_TYPE_DISCRETE;
 		else if(VKGPUType == VkPhysicalDeviceType::VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU)
-			return STWGraphicGPU::ETWGraphicsGPUType::GRAPHICS_GPU_TYPE_INTEGRATED;
+			return STWGraphicGpu::ETWGraphicsGpuType::GRAPHICS_GPU_TYPE_INTEGRATED;
 		else if(VKGPUType == VkPhysicalDeviceType::VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU)
-			return STWGraphicGPU::ETWGraphicsGPUType::GRAPHICS_GPU_TYPE_VIRTUAL;
+			return STWGraphicGpu::ETWGraphicsGpuType::GRAPHICS_GPU_TYPE_VIRTUAL;
 		else if(VKGPUType == VkPhysicalDeviceType::VK_PHYSICAL_DEVICE_TYPE_CPU)
-			return STWGraphicGPU::ETWGraphicsGPUType::GRAPHICS_GPU_TYPE_CPU;
+			return STWGraphicGpu::ETWGraphicsGpuType::GRAPHICS_GPU_TYPE_CPU;
 
-		return STWGraphicGPU::ETWGraphicsGPUType::GRAPHICS_GPU_TYPE_CPU;
+		return STWGraphicGpu::ETWGraphicsGpuType::GRAPHICS_GPU_TYPE_CPU;
 	}
 
 	// from: https://github.com/SaschaWillems/vulkan.gpuinfo.org/blob/5c3986798afc39d736b825bf8a5fbf92b8d9ed49/includes/functions.php#L364
-	const char *GetDriverVerson(char (&aBuff)[256], uint32_t DriverVersion, uint32_t VendorID)
+	const char *GetDriverVerson(char (&aBuff)[256], uint32_t DriverVersion, uint32_t VendorId)
 	{
 		// NVIDIA
-		if(VendorID == 4318)
+		if(VendorId == 4318)
 		{
 			str_format(aBuff, std::size(aBuff), "%d.%d.%d.%d",
 				(DriverVersion >> 22) & 0x3ff,
@@ -3681,7 +3681,7 @@ public:
 		}
 #ifdef CONF_FAMILY_WINDOWS
 		// windows only
-		else if(VendorID == 0x8086)
+		else if(VendorId == 0x8086)
 		{
 			str_format(aBuff, std::size(aBuff),
 				"%d.%d",
@@ -3702,7 +3702,7 @@ public:
 		return aBuff;
 	}
 
-	[[nodiscard]] bool SelectGPU(char *pRendererName, char *pVendorName, char *pVersionName)
+	[[nodiscard]] bool SelectGpu(char *pRendererName, char *pVendorName, char *pVersionName)
 	{
 		uint32_t DevicesCount = 0;
 		auto Res = vkEnumeratePhysicalDevices(m_VKInstance, &DevicesCount, nullptr);
@@ -3736,14 +3736,14 @@ public:
 
 		size_t Index = 0;
 		std::vector<VkPhysicalDeviceProperties> vDevicePropList(vDeviceList.size());
-		m_pGPUList->m_vGPUs.reserve(vDeviceList.size());
+		m_pGpuList->m_vGpus.reserve(vDeviceList.size());
 
 		size_t FoundDeviceIndex = 0;
-		size_t FoundGPUType = STWGraphicGPU::ETWGraphicsGPUType::GRAPHICS_GPU_TYPE_INVALID;
+		size_t FoundGpuType = STWGraphicGpu::ETWGraphicsGpuType::GRAPHICS_GPU_TYPE_INVALID;
 
-		STWGraphicGPU::ETWGraphicsGPUType AutoGPUType = STWGraphicGPU::ETWGraphicsGPUType::GRAPHICS_GPU_TYPE_INVALID;
+		STWGraphicGpu::ETWGraphicsGpuType AutoGpuType = STWGraphicGpu::ETWGraphicsGpuType::GRAPHICS_GPU_TYPE_INVALID;
 
-		bool IsAutoGPU = str_comp(g_Config.m_GfxGPUName, "auto") == 0;
+		bool IsAutoGpu = str_comp(g_Config.m_GfxGpuName, "auto") == 0;
 
 		for(auto &CurDevice : vDeviceList)
 		{
@@ -3751,30 +3751,30 @@ public:
 
 			auto &DeviceProp = vDevicePropList[Index];
 
-			STWGraphicGPU::ETWGraphicsGPUType GPUType = VKGPUTypeToGraphicsGPUType(DeviceProp.deviceType);
+			STWGraphicGpu::ETWGraphicsGpuType GPUType = VKGPUTypeToGraphicsGpuType(DeviceProp.deviceType);
 
-			STWGraphicGPU::STWGraphicGPUItem NewGPU;
-			str_copy(NewGPU.m_aName, DeviceProp.deviceName);
-			NewGPU.m_GPUType = GPUType;
-			m_pGPUList->m_vGPUs.push_back(NewGPU);
+			STWGraphicGpu::STWGraphicGpuItem NewGpu;
+			str_copy(NewGpu.m_aName, DeviceProp.deviceName);
+			NewGpu.m_GpuType = GPUType;
+			m_pGpuList->m_vGpus.push_back(NewGpu);
 
 			Index++;
 
 			int DevAPIMajor = (int)VK_API_VERSION_MAJOR(DeviceProp.apiVersion);
 			int DevAPIMinor = (int)VK_API_VERSION_MINOR(DeviceProp.apiVersion);
 
-			if(GPUType < AutoGPUType && (DevAPIMajor > gs_BackendVulkanMajor || (DevAPIMajor == gs_BackendVulkanMajor && DevAPIMinor >= gs_BackendVulkanMinor)))
+			if(GPUType < AutoGpuType && (DevAPIMajor > gs_BackendVulkanMajor || (DevAPIMajor == gs_BackendVulkanMajor && DevAPIMinor >= gs_BackendVulkanMinor)))
 			{
-				str_copy(m_pGPUList->m_AutoGPU.m_aName, DeviceProp.deviceName);
-				m_pGPUList->m_AutoGPU.m_GPUType = GPUType;
+				str_copy(m_pGpuList->m_AutoGpu.m_aName, DeviceProp.deviceName);
+				m_pGpuList->m_AutoGpu.m_GpuType = GPUType;
 
-				AutoGPUType = GPUType;
+				AutoGpuType = GPUType;
 			}
 
-			if(((IsAutoGPU && (FoundGPUType > STWGraphicGPU::ETWGraphicsGPUType::GRAPHICS_GPU_TYPE_INTEGRATED && GPUType < FoundGPUType)) || str_comp(DeviceProp.deviceName, g_Config.m_GfxGPUName) == 0) && (DevAPIMajor > gs_BackendVulkanMajor || (DevAPIMajor == gs_BackendVulkanMajor && DevAPIMinor >= gs_BackendVulkanMinor)))
+			if(((IsAutoGpu && (FoundGpuType > STWGraphicGpu::ETWGraphicsGpuType::GRAPHICS_GPU_TYPE_INTEGRATED && GPUType < FoundGpuType)) || str_comp(DeviceProp.deviceName, g_Config.m_GfxGpuName) == 0) && (DevAPIMajor > gs_BackendVulkanMajor || (DevAPIMajor == gs_BackendVulkanMajor && DevAPIMinor >= gs_BackendVulkanMinor)))
 			{
 				FoundDeviceIndex = Index;
-				FoundGPUType = GPUType;
+				FoundGpuType = GPUType;
 			}
 		}
 
@@ -3788,7 +3788,7 @@ public:
 			int DevAPIMinor = (int)VK_API_VERSION_MINOR(DeviceProp.apiVersion);
 			int DevAPIPatch = (int)VK_API_VERSION_PATCH(DeviceProp.apiVersion);
 
-			str_copy(pRendererName, DeviceProp.deviceName, gs_GPUInfoStringSize);
+			str_copy(pRendererName, DeviceProp.deviceName, gs_GpuInfoStringSize);
 			const char *pVendorNameStr = NULL;
 			switch(DeviceProp.vendorID)
 			{
@@ -3823,8 +3823,8 @@ public:
 			}
 
 			char aBuff[256];
-			str_copy(pVendorName, pVendorNameStr, gs_GPUInfoStringSize);
-			str_format(pVersionName, gs_GPUInfoStringSize, "Vulkan %d.%d.%d (driver: %s)", DevAPIMajor, DevAPIMinor, DevAPIPatch, GetDriverVerson(aBuff, DeviceProp.driverVersion, DeviceProp.vendorID));
+			str_copy(pVendorName, pVendorNameStr, gs_GpuInfoStringSize);
+			str_format(pVersionName, gs_GpuInfoStringSize, "Vulkan %d.%d.%d (driver: %s)", DevAPIMajor, DevAPIMinor, DevAPIPatch, GetDriverVerson(aBuff, DeviceProp.driverVersion, DeviceProp.vendorID));
 
 			// get important device limits
 			m_NonCoherentMemAlignment = DeviceProp.limits.nonCoherentAtomSize;
@@ -5606,7 +5606,7 @@ public:
 			}
 		}
 
-		if(!SelectGPU(pRendererString, pVendorString, pVersionString))
+		if(!SelectGpu(pRendererString, pVendorString, pVersionString))
 			return -1;
 
 		if(!CreateLogicalDevice(vVKLayers))
@@ -6393,7 +6393,7 @@ public:
 	{
 		VkDeviceSize BufferDataSize = DataSize;
 
-		SMemoryBlock<s_StagingBufferCacheID> StagingBuffer;
+		SMemoryBlock<s_StagingBufferCacheId> StagingBuffer;
 		if(!GetStagingBuffer(StagingBuffer, pData, DataSize))
 			return false;
 
@@ -6945,7 +6945,7 @@ public:
 		void *pUploadData = pCommand->m_pUploadData;
 		VkDeviceSize DataSize = (VkDeviceSize)pCommand->m_DataSize;
 
-		SMemoryBlock<s_StagingBufferCacheID> StagingBuffer;
+		SMemoryBlock<s_StagingBufferCacheId> StagingBuffer;
 		if(!GetStagingBuffer(StagingBuffer, pUploadData, DataSize))
 			return false;
 
@@ -7490,7 +7490,7 @@ public:
 	[[nodiscard]] bool Cmd_WindowCreateNtf(const CCommandBuffer::SCommand_WindowCreateNtf *pCommand)
 	{
 		log_debug("vulkan", "creating new surface.");
-		m_pWindow = SDL_GetWindowFromID(pCommand->m_WindowID);
+		m_pWindow = SDL_GetWindowFromID(pCommand->m_WindowId);
 		if(m_RenderingPaused)
 		{
 #ifdef CONF_PLATFORM_ANDROID
@@ -7527,7 +7527,7 @@ public:
 
 	[[nodiscard]] bool Cmd_PreInit(const CCommandProcessorFragment_GLBase::SCommand_PreInit *pCommand)
 	{
-		m_pGPUList = pCommand->m_pGPUList;
+		m_pGpuList = pCommand->m_pGpuList;
 		if(InitVulkanSDL(pCommand->m_pWindow, pCommand->m_Width, pCommand->m_Height, pCommand->m_pRendererString, pCommand->m_pVendorString, pCommand->m_pVersionString) != 0)
 		{
 			m_VKInstance = VK_NULL_HANDLE;

--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -226,7 +226,7 @@ void CCommandProcessorFragment_SDL::Cmd_VSync(const CCommandBuffer::SCommand_VSy
 
 void CCommandProcessorFragment_SDL::Cmd_WindowCreateNtf(const CCommandBuffer::SCommand_WindowCreateNtf *pCommand)
 {
-	m_pWindow = SDL_GetWindowFromID(pCommand->m_WindowID);
+	m_pWindow = SDL_GetWindowFromID(pCommand->m_WindowId);
 	// Android destroys windows when they are not visible, so we get the new one and work with that
 	// The graphic context does not need to be recreated, just unbound see @see SCommand_WindowDestroyNtf
 #ifdef CONF_PLATFORM_ANDROID
@@ -900,10 +900,10 @@ static void DisplayToVideoMode(CVideoMode *pVMode, SDL_DisplayMode *pMode, int H
 	pVMode->m_Format = pMode->format;
 }
 
-void CGraphicsBackend_SDL_GL::GetVideoModes(CVideoMode *pModes, int MaxModes, int *pNumModes, int HiDPIScale, int MaxWindowWidth, int MaxWindowHeight, int ScreenID)
+void CGraphicsBackend_SDL_GL::GetVideoModes(CVideoMode *pModes, int MaxModes, int *pNumModes, int HiDPIScale, int MaxWindowWidth, int MaxWindowHeight, int ScreenId)
 {
 	SDL_DisplayMode DesktopMode;
-	int maxModes = SDL_GetNumDisplayModes(ScreenID);
+	int maxModes = SDL_GetNumDisplayModes(ScreenId);
 	int numModes = 0;
 
 	// Only collect fullscreen modes when requested, that makes sure in windowed mode no refresh rates are shown that aren't supported without
@@ -911,7 +911,7 @@ void CGraphicsBackend_SDL_GL::GetVideoModes(CVideoMode *pModes, int MaxModes, in
 	bool IsFullscreenDestkop = m_pWindow != NULL && (((SDL_GetWindowFlags(m_pWindow) & SDL_WINDOW_FULLSCREEN_DESKTOP) == SDL_WINDOW_FULLSCREEN_DESKTOP) || g_Config.m_GfxFullscreen == 3);
 	bool CollectFullscreenModes = m_pWindow == NULL || ((SDL_GetWindowFlags(m_pWindow) & SDL_WINDOW_FULLSCREEN) != 0 && !IsFullscreenDestkop);
 
-	if(SDL_GetDesktopDisplayMode(ScreenID, &DesktopMode) < 0)
+	if(SDL_GetDesktopDisplayMode(ScreenId, &DesktopMode) < 0)
 	{
 		dbg_msg("gfx", "unable to get display mode: %s", SDL_GetError());
 	}
@@ -922,7 +922,7 @@ void CGraphicsBackend_SDL_GL::GetVideoModes(CVideoMode *pModes, int MaxModes, in
 	for(int i = 0; i < maxModes && NumModes < ModeCount; i++)
 	{
 		SDL_DisplayMode mode;
-		if(SDL_GetDisplayMode(ScreenID, i, &mode) < 0)
+		if(SDL_GetDisplayMode(ScreenId, i, &mode) < 0)
 		{
 			dbg_msg("gfx", "unable to get display mode: %s", SDL_GetError());
 			continue;
@@ -964,20 +964,20 @@ void CGraphicsBackend_SDL_GL::GetVideoModes(CVideoMode *pModes, int MaxModes, in
 	*pNumModes = numModes;
 }
 
-void CGraphicsBackend_SDL_GL::GetCurrentVideoMode(CVideoMode &CurMode, int HiDPIScale, int MaxWindowWidth, int MaxWindowHeight, int ScreenID)
+void CGraphicsBackend_SDL_GL::GetCurrentVideoMode(CVideoMode &CurMode, int HiDPIScale, int MaxWindowWidth, int MaxWindowHeight, int ScreenId)
 {
-	SDL_DisplayMode DPMode;
+	SDL_DisplayMode DpMode;
 	// if "real" fullscreen, obtain the video mode for that
 	if((SDL_GetWindowFlags(m_pWindow) & SDL_WINDOW_FULLSCREEN_DESKTOP) == SDL_WINDOW_FULLSCREEN)
 	{
-		if(SDL_GetCurrentDisplayMode(ScreenID, &DPMode))
+		if(SDL_GetCurrentDisplayMode(ScreenId, &DpMode))
 		{
 			dbg_msg("gfx", "unable to get display mode: %s", SDL_GetError());
 		}
 	}
 	else
 	{
-		if(SDL_GetDesktopDisplayMode(ScreenID, &DPMode) < 0)
+		if(SDL_GetDesktopDisplayMode(ScreenId, &DpMode) < 0)
 		{
 			dbg_msg("gfx", "unable to get display mode: %s", SDL_GetError());
 		}
@@ -986,11 +986,11 @@ void CGraphicsBackend_SDL_GL::GetCurrentVideoMode(CVideoMode &CurMode, int HiDPI
 			int Width = 0;
 			int Height = 0;
 			SDL_GL_GetDrawableSize(m_pWindow, &Width, &Height);
-			DPMode.w = Width;
-			DPMode.h = Height;
+			DpMode.w = Width;
+			DpMode.h = Height;
 		}
 	}
-	DisplayToVideoMode(&CurMode, &DPMode, HiDPIScale, DPMode.refresh_rate);
+	DisplayToVideoMode(&CurMode, &DpMode, HiDPIScale, DpMode.refresh_rate);
 }
 
 CGraphicsBackend_SDL_GL::CGraphicsBackend_SDL_GL(TTranslateFunc &&TranslateFunc) :
@@ -1275,7 +1275,7 @@ int CGraphicsBackend_SDL_GL::Init(const char *pName, int *pScreen, int *pWidth, 
 	CmdPre.m_pVendorString = m_aVendorString;
 	CmdPre.m_pVersionString = m_aVersionString;
 	CmdPre.m_pRendererString = m_aRendererString;
-	CmdPre.m_pGPUList = &m_GPUList;
+	CmdPre.m_pGpuList = &m_GpuList;
 	CmdBuffer.AddCommandUnsafe(CmdPre);
 	RunBufferSingleThreadedUnsafe(&CmdBuffer);
 	CmdBuffer.Reset();
@@ -1299,7 +1299,7 @@ int CGraphicsBackend_SDL_GL::Init(const char *pName, int *pScreen, int *pWidth, 
 		CmdGL.m_pBufferMemoryUsage = &m_BufferMemoryUsage;
 		CmdGL.m_pStreamMemoryUsage = &m_StreamMemoryUsage;
 		CmdGL.m_pStagingMemoryUsage = &m_StagingMemoryUsage;
-		CmdGL.m_pGPUList = &m_GPUList;
+		CmdGL.m_pGpuList = &m_GpuList;
 		CmdGL.m_pReadPresentedImageDataFunc = &m_ReadPresentedImageDataFunc;
 		CmdGL.m_pStorage = pStorage;
 		CmdGL.m_pCapabilities = &m_Capabilites;
@@ -1444,9 +1444,9 @@ uint64_t CGraphicsBackend_SDL_GL::StagingMemoryUsage() const
 	return m_StagingMemoryUsage;
 }
 
-const TTWGraphicsGPUList &CGraphicsBackend_SDL_GL::GetGPUs() const
+const TTwGraphicsGpuList &CGraphicsBackend_SDL_GL::GetGpus() const
 {
-	return m_GPUList;
+	return m_GpuList;
 }
 
 void CGraphicsBackend_SDL_GL::Minimize()
@@ -1488,14 +1488,14 @@ void CGraphicsBackend_SDL_GL::SetWindowParams(int FullscreenMode, bool IsBorderl
 			SDL_SetWindowFullscreen(m_pWindow, 0);
 			SDL_SetWindowBordered(m_pWindow, SDL_TRUE);
 			SDL_SetWindowResizable(m_pWindow, SDL_FALSE);
-			SDL_DisplayMode DPMode;
-			if(SDL_GetDesktopDisplayMode(g_Config.m_GfxScreen, &DPMode) < 0)
+			SDL_DisplayMode DpMode;
+			if(SDL_GetDesktopDisplayMode(g_Config.m_GfxScreen, &DpMode) < 0)
 			{
 				dbg_msg("gfx", "unable to get display mode: %s", SDL_GetError());
 			}
 			else
 			{
-				ResizeWindow(DPMode.w, DPMode.h, DPMode.refresh_rate);
+				ResizeWindow(DpMode.w, DpMode.h, DpMode.refresh_rate);
 				SDL_SetWindowPosition(m_pWindow, SDL_WINDOWPOS_CENTERED_DISPLAY(g_Config.m_GfxScreen), SDL_WINDOWPOS_CENTERED_DISPLAY(g_Config.m_GfxScreen));
 			}
 		}
@@ -1620,13 +1620,13 @@ void CGraphicsBackend_SDL_GL::NotifyWindow()
 #endif
 }
 
-void CGraphicsBackend_SDL_GL::WindowDestroyNtf(uint32_t WindowID)
+void CGraphicsBackend_SDL_GL::WindowDestroyNtf(uint32_t WindowId)
 {
 }
 
-void CGraphicsBackend_SDL_GL::WindowCreateNtf(uint32_t WindowID)
+void CGraphicsBackend_SDL_GL::WindowCreateNtf(uint32_t WindowId)
 {
-	m_pWindow = SDL_GetWindowFromID(WindowID);
+	m_pWindow = SDL_GetWindowFromID(WindowId);
 }
 
 TGLBackendReadPresentedImageData &CGraphicsBackend_SDL_GL::GetReadPresentedImageDataFuncUnsafe()

--- a/src/engine/client/backend_sdl.h
+++ b/src/engine/client/backend_sdl.h
@@ -198,7 +198,7 @@ public:
 	void HandleWarning();
 };
 
-static constexpr size_t gs_GPUInfoStringSize = 256;
+static constexpr size_t gs_GpuInfoStringSize = 256;
 
 // graphics backend implemented with SDL and the graphics library @see EBackendType
 class CGraphicsBackend_SDL_GL : public CGraphicsBackend_Threaded
@@ -211,7 +211,7 @@ class CGraphicsBackend_SDL_GL : public CGraphicsBackend_Threaded
 	std::atomic<uint64_t> m_StreamMemoryUsage{0};
 	std::atomic<uint64_t> m_StagingMemoryUsage{0};
 
-	TTWGraphicsGPUList m_GPUList;
+	TTwGraphicsGpuList m_GpuList;
 
 	TGLBackendReadPresentedImageData m_ReadPresentedImageDataFunc;
 
@@ -219,9 +219,9 @@ class CGraphicsBackend_SDL_GL : public CGraphicsBackend_Threaded
 
 	SBackendCapabilites m_Capabilites;
 
-	char m_aVendorString[gs_GPUInfoStringSize] = {};
-	char m_aVersionString[gs_GPUInfoStringSize] = {};
-	char m_aRendererString[gs_GPUInfoStringSize] = {};
+	char m_aVendorString[gs_GpuInfoStringSize] = {};
+	char m_aVersionString[gs_GpuInfoStringSize] = {};
+	char m_aRendererString[gs_GpuInfoStringSize] = {};
 
 	EBackendType m_BackendType = BACKEND_TYPE_AUTO;
 
@@ -240,13 +240,13 @@ public:
 	uint64_t StreamedMemoryUsage() const override;
 	uint64_t StagingMemoryUsage() const override;
 
-	const TTWGraphicsGPUList &GetGPUs() const override;
+	const TTwGraphicsGpuList &GetGpus() const override;
 
 	int GetNumScreens() const override { return m_NumScreens; }
 	const char *GetScreenName(int Screen) const override;
 
-	void GetVideoModes(CVideoMode *pModes, int MaxModes, int *pNumModes, int HiDPIScale, int MaxWindowWidth, int MaxWindowHeight, int ScreenID) override;
-	void GetCurrentVideoMode(CVideoMode &CurMode, int HiDPIScale, int MaxWindowWidth, int MaxWindowHeight, int ScreenID) override;
+	void GetVideoModes(CVideoMode *pModes, int MaxModes, int *pNumModes, int HiDPIScale, int MaxWindowWidth, int MaxWindowHeight, int ScreenId) override;
+	void GetCurrentVideoMode(CVideoMode &CurMode, int HiDPIScale, int MaxWindowWidth, int MaxWindowHeight, int ScreenId) override;
 
 	void Minimize() override;
 	void Maximize() override;
@@ -261,8 +261,8 @@ public:
 	void GetViewportSize(int &w, int &h) override;
 	void NotifyWindow() override;
 
-	void WindowDestroyNtf(uint32_t WindowID) override;
-	void WindowCreateNtf(uint32_t WindowID) override;
+	void WindowDestroyNtf(uint32_t WindowId) override;
+	void WindowCreateNtf(uint32_t WindowId) override;
 
 	bool GetDriverVersion(EGraphicsDriverAgeType DriverAgeType, int &Major, int &Minor, int &Patch, const char *&pName, EBackendType BackendType) override;
 	bool IsConfigModernAPI() override { return IsModernAPI(m_BackendType); }

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -98,14 +98,14 @@ CClient::CClient() :
 static inline bool RepackMsg(const CMsgPacker *pMsg, CPacker &Packer)
 {
 	Packer.Reset();
-	if(pMsg->m_MsgID < OFFSET_UUID)
+	if(pMsg->m_MsgId < OFFSET_UUID)
 	{
-		Packer.AddInt((pMsg->m_MsgID << 1) | (pMsg->m_System ? 1 : 0));
+		Packer.AddInt((pMsg->m_MsgId << 1) | (pMsg->m_System ? 1 : 0));
 	}
 	else
 	{
 		Packer.AddInt(pMsg->m_System ? 1 : 0); // NETMSG_EX, NETMSGTYPE_EX
-		g_UuidManager.PackUuid(pMsg->m_MsgID, &Packer);
+		g_UuidManager.PackUuid(pMsg->m_MsgId, &Packer);
 	}
 	Packer.AddRaw(pMsg->Data(), pMsg->Size());
 
@@ -125,7 +125,7 @@ int CClient::SendMsg(int Conn, CMsgPacker *pMsg, int Flags)
 		return 0;
 
 	mem_zero(&Packet, sizeof(CNetChunk));
-	Packet.m_ClientID = 0;
+	Packet.m_ClientId = 0;
 	Packet.m_pData = Pack.Data();
 	Packet.m_DataSize = Pack.Size();
 
@@ -157,7 +157,7 @@ int CClient::SendMsgActive(CMsgPacker *pMsg, int Flags)
 void CClient::SendInfo(int Conn)
 {
 	CMsgPacker MsgVer(NETMSG_CLIENTVER, true);
-	MsgVer.AddRaw(&m_ConnectionID, sizeof(m_ConnectionID));
+	MsgVer.AddRaw(&m_ConnectionId, sizeof(m_ConnectionId));
 	MsgVer.AddInt(GameClient()->DDNetVersion());
 	MsgVer.AddString(GameClient()->DDNetVersionStr());
 	SendMsg(Conn, &MsgVer, MSGFLAG_VITAL);
@@ -445,7 +445,7 @@ void CClient::Connect(const char *pAddress, const char *pPassword)
 	Disconnect();
 	dbg_assert(m_State == IClient::STATE_OFFLINE, "Disconnect must ensure that client is offline");
 
-	m_ConnectionID = RandomUuid();
+	m_ConnectionId = RandomUuid();
 	if(pAddress != m_aConnectAddressStr)
 		str_copy(m_aConnectAddressStr, pAddress);
 
@@ -676,37 +676,37 @@ void CClient::LoadDebugFont()
 
 // ---
 
-void *CClient::SnapGetItem(int SnapID, int Index, CSnapItem *pItem) const
+void *CClient::SnapGetItem(int SnapId, int Index, CSnapItem *pItem) const
 {
-	dbg_assert(SnapID >= 0 && SnapID < NUM_SNAPSHOT_TYPES, "invalid SnapID");
-	const CSnapshot *pSnapshot = m_aapSnapshots[g_Config.m_ClDummy][SnapID]->m_pAltSnap;
+	dbg_assert(SnapId >= 0 && SnapId < NUM_SNAPSHOT_TYPES, "invalid SnapId");
+	const CSnapshot *pSnapshot = m_aapSnapshots[g_Config.m_ClDummy][SnapId]->m_pAltSnap;
 	const CSnapshotItem *pSnapshotItem = pSnapshot->GetItem(Index);
 	pItem->m_DataSize = pSnapshot->GetItemSize(Index);
 	pItem->m_Type = pSnapshot->GetItemType(Index);
-	pItem->m_ID = pSnapshotItem->ID();
+	pItem->m_Id = pSnapshotItem->Id();
 	return (void *)pSnapshotItem->Data();
 }
 
-int CClient::SnapItemSize(int SnapID, int Index) const
+int CClient::SnapItemSize(int SnapId, int Index) const
 {
-	dbg_assert(SnapID >= 0 && SnapID < NUM_SNAPSHOT_TYPES, "invalid SnapID");
-	return m_aapSnapshots[g_Config.m_ClDummy][SnapID]->m_pAltSnap->GetItemSize(Index);
+	dbg_assert(SnapId >= 0 && SnapId < NUM_SNAPSHOT_TYPES, "invalid SnapId");
+	return m_aapSnapshots[g_Config.m_ClDummy][SnapId]->m_pAltSnap->GetItemSize(Index);
 }
 
-const void *CClient::SnapFindItem(int SnapID, int Type, int ID) const
+const void *CClient::SnapFindItem(int SnapId, int Type, int Id) const
 {
-	if(!m_aapSnapshots[g_Config.m_ClDummy][SnapID])
+	if(!m_aapSnapshots[g_Config.m_ClDummy][SnapId])
 		return nullptr;
 
-	return m_aapSnapshots[g_Config.m_ClDummy][SnapID]->m_pAltSnap->FindItem(Type, ID);
+	return m_aapSnapshots[g_Config.m_ClDummy][SnapId]->m_pAltSnap->FindItem(Type, Id);
 }
 
-int CClient::SnapNumItems(int SnapID) const
+int CClient::SnapNumItems(int SnapId) const
 {
-	dbg_assert(SnapID >= 0 && SnapID < NUM_SNAPSHOT_TYPES, "invalid SnapID");
-	if(!m_aapSnapshots[g_Config.m_ClDummy][SnapID])
+	dbg_assert(SnapId >= 0 && SnapId < NUM_SNAPSHOT_TYPES, "invalid SnapId");
+	if(!m_aapSnapshots[g_Config.m_ClDummy][SnapId])
 		return 0;
-	return m_aapSnapshots[g_Config.m_ClDummy][SnapID]->m_pAltSnap->NumItems();
+	return m_aapSnapshots[g_Config.m_ClDummy][SnapId]->m_pAltSnap->NumItems();
 }
 
 void CClient::SnapSetStaticsize(int ItemType, int Size)
@@ -1306,7 +1306,7 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket, int Conn, bool Dummy)
 	bool Sys;
 	CUuid Uuid;
 
-	int Result = UnpackMessageID(&Msg, &Sys, &Uuid, &Unpacker, &Packer);
+	int Result = UnpackMessageId(&Msg, &Sys, &Uuid, &Unpacker, &Packer);
 	if(Result == UNPACKMESSAGE_ERROR)
 	{
 		return;
@@ -1513,24 +1513,24 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket, int Conn, bool Dummy)
 		}
 		else if(Msg == NETMSG_PINGEX)
 		{
-			CUuid *pID = (CUuid *)Unpacker.GetRaw(sizeof(*pID));
+			CUuid *pId = (CUuid *)Unpacker.GetRaw(sizeof(*pId));
 			if(Unpacker.Error())
 			{
 				return;
 			}
 			CMsgPacker MsgP(NETMSG_PONGEX, true);
-			MsgP.AddRaw(pID, sizeof(*pID));
+			MsgP.AddRaw(pId, sizeof(*pId));
 			int Vital = (pPacket->m_Flags & NET_CHUNKFLAG_VITAL) != 0 ? MSGFLAG_VITAL : 0;
 			SendMsg(Conn, &MsgP, MSGFLAG_FLUSH | Vital);
 		}
 		else if(Conn == CONN_MAIN && Msg == NETMSG_PONGEX)
 		{
-			CUuid *pID = (CUuid *)Unpacker.GetRaw(sizeof(*pID));
+			CUuid *pId = (CUuid *)Unpacker.GetRaw(sizeof(*pId));
 			if(Unpacker.Error())
 			{
 				return;
 			}
-			if(m_ServerCapabilities.m_PingEx && m_CurrentServerCurrentPingTime >= 0 && *pID == m_CurrentServerPingUuid)
+			if(m_ServerCapabilities.m_PingEx && m_CurrentServerCurrentPingTime >= 0 && *pId == m_CurrentServerPingUuid)
 			{
 				int LatencyMs = (time_get() - m_CurrentServerCurrentPingTime) * 1000 / time_freq();
 				m_ServerBrowser.SetCurrentServerPing(ServerAddress(), LatencyMs);
@@ -1565,10 +1565,10 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket, int Conn, bool Dummy)
 				return;
 			}
 			char aAddr[128];
-			char aIP[64];
+			char aIp[64];
 			NETADDR ServerAddr = ServerAddress();
-			net_addr_str(&ServerAddr, aIP, sizeof(aIP), 0);
-			str_format(aAddr, sizeof(aAddr), "%s:%d", aIP, RedirectPort);
+			net_addr_str(&ServerAddr, aIp, sizeof(aIp), 0);
+			str_format(aAddr, sizeof(aAddr), "%s:%d", aIp, RedirectPort);
 			Connect(aAddr);
 		}
 		else if(Conn == CONN_MAIN && (pPacket->m_Flags & NET_CHUNKFLAG_VITAL) != 0 && Msg == NETMSG_RCON_CMD_ADD)
@@ -1995,7 +1995,7 @@ int CClient::UnpackAndValidateSnapshot(CSnapshot *pFrom, CSnapshot *pTo)
 		}
 		const int ItemSize = pNetObjHandler->GetUnpackedObjSize(ItemType);
 
-		void *pObj = Builder.NewItem(pFromItem->Type(), pFromItem->ID(), ItemSize);
+		void *pObj = Builder.NewItem(pFromItem->Type(), pFromItem->Id(), ItemSize);
 		if(!pObj)
 			return -4;
 
@@ -2279,7 +2279,7 @@ void CClient::PumpNetwork()
 	{
 		while(m_aNetClient[i].Recv(&Packet))
 		{
-			if(Packet.m_ClientID == -1)
+			if(Packet.m_ClientId == -1)
 			{
 				ProcessConnlessPacket(&Packet);
 				continue;
@@ -2329,7 +2329,7 @@ void CClient::OnDemoPlayerMessage(void *pData, int Size)
 	bool Sys;
 	CUuid Uuid;
 
-	int Result = UnpackMessageID(&Msg, &Sys, &Uuid, &Unpacker, &Packer);
+	int Result = UnpackMessageId(&Msg, &Sys, &Uuid, &Unpacker, &Packer);
 	if(Result == UNPACKMESSAGE_ERROR)
 	{
 		return;
@@ -4340,8 +4340,8 @@ int main(int argc, const char **argv)
 		char aVersionStr[128];
 		if(!os_version_str(aVersionStr, sizeof(aVersionStr)))
 			str_copy(aVersionStr, "unknown");
-		char aGPUInfo[256];
-		pClient->GetGPUInfoString(aGPUInfo);
+		char aGpuInfo[256];
+		pClient->GetGpuInfoString(aGpuInfo);
 		char aMessage[768];
 		str_format(aMessage, sizeof(aMessage),
 			"An assertion error occurred. Please write down or take a screenshot of the following information and report this error.\n"
@@ -4352,7 +4352,7 @@ int main(int argc, const char **argv)
 			"OS version: %s\n\n"
 			"%s", // GPU info
 			pMsg, CONF_PLATFORM_STRING, GAME_RELEASE_VERSION, GIT_SHORTREV_HASH != nullptr ? GIT_SHORTREV_HASH : "", aVersionStr,
-			aGPUInfo);
+			aGpuInfo);
 		pClient->ShowMessageBox("Assertion Error", aMessage);
 		// Client will crash due to assertion, don't call PerformAllCleanup in this inconsistent state
 	});
@@ -4768,15 +4768,15 @@ void CClient::ShowMessageBox(const char *pTitle, const char *pMessage, EMessageB
 		::ShowMessageBox(pTitle, pMessage, Type);
 }
 
-void CClient::GetGPUInfoString(char (&aGPUInfo)[256])
+void CClient::GetGpuInfoString(char (&aGpuInfo)[256])
 {
 	if(m_pGraphics != nullptr && m_pGraphics->IsBackendInitialized())
 	{
-		str_format(aGPUInfo, std::size(aGPUInfo), "GPU: %s - %s - %s", m_pGraphics->GetVendorString(), m_pGraphics->GetRendererString(), m_pGraphics->GetVersionString());
+		str_format(aGpuInfo, std::size(aGpuInfo), "GPU: %s - %s - %s", m_pGraphics->GetVendorString(), m_pGraphics->GetRendererString(), m_pGraphics->GetVersionString());
 	}
 	else
 	{
-		str_copy(aGPUInfo, "Graphics backend was not yet initialized.");
+		str_copy(aGpuInfo, "Graphics backend was not yet initialized.");
 	}
 }
 

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -91,7 +91,7 @@ class CClient : public IClient, public CDemoPlayer::IListener
 
 	char m_aConnectAddressStr[MAX_SERVER_ADDRESSES * NETADDR_MAXSTRSIZE] = "";
 
-	CUuid m_ConnectionID = UUID_ZEROED;
+	CUuid m_ConnectionId = UUID_ZEROED;
 
 	bool m_HaveGlobalTcpAddr = false;
 	NETADDR m_GlobalTcpAddr = NETADDR_ZEROED;
@@ -323,10 +323,10 @@ public:
 	// ---
 
 	int GetPredictionTime() override;
-	void *SnapGetItem(int SnapID, int Index, CSnapItem *pItem) const override;
-	int SnapItemSize(int SnapID, int Index) const override;
-	const void *SnapFindItem(int SnapID, int Type, int ID) const override;
-	int SnapNumItems(int SnapID) const override;
+	void *SnapGetItem(int SnapId, int Index, CSnapItem *pItem) const override;
+	int SnapItemSize(int SnapId, int Index) const override;
+	const void *SnapFindItem(int SnapId, int Type, int Id) const override;
+	int SnapNumItems(int SnapId) const override;
 	void SnapSetStaticsize(int ItemType, int Size) override;
 
 	void Render();
@@ -506,7 +506,7 @@ public:
 #endif
 
 	void ShowMessageBox(const char *pTitle, const char *pMessage, EMessageBoxType Type = MESSAGE_BOX_TYPE_ERROR) override;
-	void GetGPUInfoString(char (&aGPUInfo)[256]) override;
+	void GetGpuInfoString(char (&aGpuInfo)[256]) override;
 	void SetLoggers(std::shared_ptr<ILogger> &&pFileLogger, std::shared_ptr<ILogger> &&pStdoutLogger);
 };
 

--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -208,9 +208,9 @@ uint64_t CGraphics_Threaded::StagingMemoryUsage() const
 	return m_pBackend->StagingMemoryUsage();
 }
 
-const TTWGraphicsGPUList &CGraphics_Threaded::GetGPUs() const
+const TTwGraphicsGpuList &CGraphics_Threaded::GetGpus() const
 {
-	return m_pBackend->GetGPUs();
+	return m_pBackend->GetGpus();
 }
 
 void CGraphics_Threaded::MapScreen(float TopLeftX, float TopLeftY, float BottomRightX, float BottomRightY)
@@ -337,12 +337,12 @@ static bool ConvertToRGBA(uint8_t *pDest, const uint8_t *pSrc, size_t SrcWidth, 
 	}
 }
 
-int CGraphics_Threaded::LoadTextureRawSub(CTextureHandle TextureID, int x, int y, size_t Width, size_t Height, CImageInfo::EImageFormat Format, const void *pData)
+int CGraphics_Threaded::LoadTextureRawSub(CTextureHandle TextureId, int x, int y, size_t Width, size_t Height, CImageInfo::EImageFormat Format, const void *pData)
 {
-	dbg_assert(TextureID.IsValid(), "Invalid texture handle used with LoadTextureRawSub.");
+	dbg_assert(TextureId.IsValid(), "Invalid texture handle used with LoadTextureRawSub.");
 
 	CCommandBuffer::SCommand_Texture_Update Cmd;
-	Cmd.m_Slot = TextureID.Id();
+	Cmd.m_Slot = TextureId.Id();
 	Cmd.m_X = x;
 	Cmd.m_Y = y;
 	Cmd.m_Width = Width;
@@ -505,12 +505,12 @@ IGraphics::CTextureHandle CGraphics_Threaded::LoadTexture(const char *pFilename,
 	CImageInfo Img;
 	if(LoadPNG(&Img, pFilename, StorageType))
 	{
-		CTextureHandle ID = LoadTextureRawMove(Img.m_Width, Img.m_Height, Img.m_Format, Img.m_pData, Flags, pFilename);
-		if(ID.IsValid())
+		CTextureHandle Id = LoadTextureRawMove(Img.m_Width, Img.m_Height, Img.m_Format, Img.m_pData, Flags, pFilename);
+		if(Id.IsValid())
 		{
 			if(g_Config.m_Debug)
 				dbg_msg("graphics/texture", "loaded %s", pFilename);
-			return ID;
+			return Id;
 		}
 	}
 
@@ -556,10 +556,10 @@ bool CGraphics_Threaded::UnloadTextTextures(CTextureHandle &TextTexture, CTextur
 	return true;
 }
 
-bool CGraphics_Threaded::UpdateTextTexture(CTextureHandle TextureID, int x, int y, size_t Width, size_t Height, const void *pData)
+bool CGraphics_Threaded::UpdateTextTexture(CTextureHandle TextureId, int x, int y, size_t Width, size_t Height, const void *pData)
 {
 	CCommandBuffer::SCommand_TextTexture_Update Cmd;
-	Cmd.m_Slot = TextureID.Id();
+	Cmd.m_Slot = TextureId.Id();
 	Cmd.m_X = x;
 	Cmd.m_Y = y;
 	Cmd.m_Width = Width;
@@ -839,11 +839,11 @@ void CGraphics_Threaded::ScreenshotDirect(bool *pSwapped)
 	}
 }
 
-void CGraphics_Threaded::TextureSet(CTextureHandle TextureID)
+void CGraphics_Threaded::TextureSet(CTextureHandle TextureId)
 {
 	dbg_assert(m_Drawing == 0, "called Graphics()->TextureSet within begin");
-	dbg_assert(!TextureID.IsValid() || m_vTextureIndices[TextureID.Id()] == -1, "Texture handle was not invalid, but also did not correlate to an existing texture.");
-	m_State.m_Texture = TextureID.Id();
+	dbg_assert(!TextureId.IsValid() || m_vTextureIndices[TextureId.Id()] == -1, "Texture handle was not invalid, but also did not correlate to an existing texture.");
+	m_State.m_Texture = TextureId.Id();
 }
 
 void CGraphics_Threaded::Clear(float r, float g, float b, bool ForceClearNow)
@@ -2741,12 +2741,12 @@ int CGraphics_Threaded::GetWindowScreen()
 	return m_pBackend->GetWindowScreen();
 }
 
-void CGraphics_Threaded::WindowDestroyNtf(uint32_t WindowID)
+void CGraphics_Threaded::WindowDestroyNtf(uint32_t WindowId)
 {
-	m_pBackend->WindowDestroyNtf(WindowID);
+	m_pBackend->WindowDestroyNtf(WindowId);
 
 	CCommandBuffer::SCommand_WindowDestroyNtf Cmd;
-	Cmd.m_WindowID = WindowID;
+	Cmd.m_WindowId = WindowId;
 	AddCmd(Cmd);
 
 	// wait
@@ -2754,12 +2754,12 @@ void CGraphics_Threaded::WindowDestroyNtf(uint32_t WindowID)
 	WaitForIdle();
 }
 
-void CGraphics_Threaded::WindowCreateNtf(uint32_t WindowID)
+void CGraphics_Threaded::WindowCreateNtf(uint32_t WindowId)
 {
-	m_pBackend->WindowCreateNtf(WindowID);
+	m_pBackend->WindowCreateNtf(WindowId);
 
 	CCommandBuffer::SCommand_WindowCreateNtf Cmd;
-	Cmd.m_WindowID = WindowID;
+	Cmd.m_WindowId = WindowId;
 	AddCmd(Cmd);
 
 	// wait

--- a/src/engine/client/graphics_threaded.h
+++ b/src/engine/client/graphics_threaded.h
@@ -604,7 +604,7 @@ public:
 		SCommand_WindowCreateNtf() :
 			SCommand(CMD_WINDOW_CREATE_NTF) {}
 
-		uint32_t m_WindowID;
+		uint32_t m_WindowId;
 	};
 
 	struct SCommand_WindowDestroyNtf : public CCommandBuffer::SCommand
@@ -612,7 +612,7 @@ public:
 		SCommand_WindowDestroyNtf() :
 			SCommand(CMD_WINDOW_DESTROY_NTF) {}
 
-		uint32_t m_WindowID;
+		uint32_t m_WindowId;
 	};
 
 	//
@@ -709,7 +709,7 @@ public:
 	virtual uint64_t StreamedMemoryUsage() const = 0;
 	virtual uint64_t StagingMemoryUsage() const = 0;
 
-	virtual const TTWGraphicsGPUList &GetGPUs() const = 0;
+	virtual const TTwGraphicsGpuList &GetGpus() const = 0;
 
 	virtual void GetVideoModes(CVideoMode *pModes, int MaxModes, int *pNumModes, int HiDPIScale, int MaxWindowWidth, int MaxWindowHeight, int Screen) = 0;
 	virtual void GetCurrentVideoMode(CVideoMode &CurMode, int HiDPIScale, int MaxWindowWidth, int MaxWindowHeight, int Screen) = 0;
@@ -731,8 +731,8 @@ public:
 	virtual void GetViewportSize(int &w, int &h) = 0;
 	virtual void NotifyWindow() = 0;
 
-	virtual void WindowDestroyNtf(uint32_t WindowID) = 0;
-	virtual void WindowCreateNtf(uint32_t WindowID) = 0;
+	virtual void WindowDestroyNtf(uint32_t WindowId) = 0;
+	virtual void WindowCreateNtf(uint32_t WindowId) = 0;
 
 	virtual void RunBuffer(CCommandBuffer *pBuffer) = 0;
 	virtual void RunBufferSingleThreadedUnsafe(CCommandBuffer *pBuffer) = 0;
@@ -953,7 +953,7 @@ public:
 	uint64_t StreamedMemoryUsage() const override;
 	uint64_t StagingMemoryUsage() const override;
 
-	const TTWGraphicsGPUList &GetGPUs() const override;
+	const TTwGraphicsGpuList &GetGpus() const override;
 
 	void MapScreen(float TopLeftX, float TopLeftY, float BottomRightX, float BottomRightY) override;
 	void GetScreen(float *pTopLeftX, float *pTopLeftY, float *pBottomRightX, float *pBottomRightY) override;
@@ -967,12 +967,12 @@ public:
 	int UnloadTexture(IGraphics::CTextureHandle *pIndex) override;
 	IGraphics::CTextureHandle LoadTextureRaw(size_t Width, size_t Height, CImageInfo::EImageFormat Format, const void *pData, int Flags, const char *pTexName = nullptr) override;
 	IGraphics::CTextureHandle LoadTextureRawMove(size_t Width, size_t Height, CImageInfo::EImageFormat Format, void *pData, int Flags, const char *pTexName = nullptr) override;
-	int LoadTextureRawSub(IGraphics::CTextureHandle TextureID, int x, int y, size_t Width, size_t Height, CImageInfo::EImageFormat Format, const void *pData) override;
+	int LoadTextureRawSub(IGraphics::CTextureHandle TextureId, int x, int y, size_t Width, size_t Height, CImageInfo::EImageFormat Format, const void *pData) override;
 	IGraphics::CTextureHandle NullTexture() const override;
 
 	bool LoadTextTextures(size_t Width, size_t Height, CTextureHandle &TextTexture, CTextureHandle &TextOutlineTexture, void *pTextData, void *pTextOutlineData) override;
 	bool UnloadTextTextures(CTextureHandle &TextTexture, CTextureHandle &TextOutlineTexture) override;
-	bool UpdateTextTexture(CTextureHandle TextureID, int x, int y, size_t Width, size_t Height, const void *pData) override;
+	bool UpdateTextTexture(CTextureHandle TextureId, int x, int y, size_t Width, size_t Height, const void *pData) override;
 
 	CTextureHandle LoadSpriteTextureImpl(CImageInfo &FromImageInfo, int x, int y, size_t w, size_t h);
 	CTextureHandle LoadSpriteTexture(CImageInfo &FromImageInfo, struct CDataSprite *pSprite) override;
@@ -991,7 +991,7 @@ public:
 	void CopyTextureBufferSub(uint8_t *pDestBuffer, uint8_t *pSourceBuffer, size_t FullWidth, size_t FullHeight, size_t PixelSize, size_t SubOffsetX, size_t SubOffsetY, size_t SubCopyWidth, size_t SubCopyHeight) override;
 	void CopyTextureFromTextureBufferSub(uint8_t *pDestBuffer, size_t DestWidth, size_t DestHeight, uint8_t *pSourceBuffer, size_t SrcWidth, size_t SrcHeight, size_t PixelSize, size_t SrcSubOffsetX, size_t SrcSubOffsetY, size_t SrcSubCopyWidth, size_t SrcSubCopyHeight) override;
 
-	void TextureSet(CTextureHandle TextureID) override;
+	void TextureSet(CTextureHandle TextureId) override;
 
 	void Clear(float r, float g, float b, bool ForceClearNow = false) override;
 
@@ -1245,8 +1245,8 @@ public:
 	void AddWindowPropChangeListener(WINDOW_PROPS_CHANGED_FUNC pFunc) override;
 	int GetWindowScreen() override;
 
-	void WindowDestroyNtf(uint32_t WindowID) override;
-	void WindowCreateNtf(uint32_t WindowID) override;
+	void WindowDestroyNtf(uint32_t WindowId) override;
+	void WindowCreateNtf(uint32_t WindowId) override;
 
 	int WindowActive() override;
 	int WindowOpen() override;

--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -174,7 +174,7 @@ CInput::CJoystick::CJoystick(CInput *pInput, int Index, SDL_Joystick *pDelegate)
 	m_NumHats = SDL_JoystickNumHats(pDelegate);
 	str_copy(m_aName, SDL_JoystickName(pDelegate));
 	SDL_JoystickGetGUIDString(SDL_JoystickGetGUID(pDelegate), m_aGUID, sizeof(m_aGUID));
-	m_InstanceID = SDL_JoystickInstanceID(pDelegate);
+	m_InstanceId = SDL_JoystickInstanceID(pDelegate);
 }
 
 void CInput::CloseJoysticks()
@@ -411,7 +411,7 @@ void CInput::HandleJoystickAxisMotionEvent(const SDL_JoyAxisEvent &Event)
 	if(!g_Config.m_InpControllerEnable)
 		return;
 	CJoystick *pJoystick = GetActiveJoystick();
-	if(!pJoystick || pJoystick->GetInstanceID() != Event.which)
+	if(!pJoystick || pJoystick->GetInstanceId() != Event.which)
 		return;
 	if(Event.axis >= NUM_JOYSTICK_AXES)
 		return;
@@ -450,7 +450,7 @@ void CInput::HandleJoystickButtonEvent(const SDL_JoyButtonEvent &Event)
 	if(!g_Config.m_InpControllerEnable)
 		return;
 	CJoystick *pJoystick = GetActiveJoystick();
-	if(!pJoystick || pJoystick->GetInstanceID() != Event.which)
+	if(!pJoystick || pJoystick->GetInstanceId() != Event.which)
 		return;
 	if(Event.button >= NUM_JOYSTICK_BUTTONS)
 		return;
@@ -475,7 +475,7 @@ void CInput::HandleJoystickHatMotionEvent(const SDL_JoyHatEvent &Event)
 	if(!g_Config.m_InpControllerEnable)
 		return;
 	CJoystick *pJoystick = GetActiveJoystick();
-	if(!pJoystick || pJoystick->GetInstanceID() != Event.which)
+	if(!pJoystick || pJoystick->GetInstanceId() != Event.which)
 		return;
 	if(Event.hat >= NUM_JOYSTICK_HATS)
 		return;
@@ -513,7 +513,7 @@ void CInput::HandleJoystickAddedEvent(const SDL_JoyDeviceEvent &Event)
 
 void CInput::HandleJoystickRemovedEvent(const SDL_JoyDeviceEvent &Event)
 {
-	auto RemovedJoystick = std::find_if(m_vJoysticks.begin(), m_vJoysticks.end(), [Event](const CJoystick &Joystick) -> bool { return Joystick.GetInstanceID() == Event.which; });
+	auto RemovedJoystick = std::find_if(m_vJoysticks.begin(), m_vJoysticks.end(), [Event](const CJoystick &Joystick) -> bool { return Joystick.GetInstanceId() == Event.which; });
 	if(RemovedJoystick != m_vJoysticks.end())
 	{
 		dbg_msg("joystick", "Closed joystick %d '%s'", (*RemovedJoystick).GetIndex(), (*RemovedJoystick).GetName());

--- a/src/engine/client/input.h
+++ b/src/engine/client/input.h
@@ -25,7 +25,7 @@ public:
 		int m_Index;
 		char m_aName[64];
 		char m_aGUID[34];
-		SDL_JoystickID m_InstanceID;
+		SDL_JoystickID m_InstanceId;
 		int m_NumAxes;
 		int m_NumButtons;
 		int m_NumBalls;
@@ -42,7 +42,7 @@ public:
 		int GetIndex() const override { return m_Index; }
 		const char *GetName() const override { return m_aName; }
 		const char *GetGUID() const { return m_aGUID; }
-		SDL_JoystickID GetInstanceID() const { return m_InstanceID; }
+		SDL_JoystickID GetInstanceId() const { return m_InstanceId; }
 		int GetNumAxes() const override { return m_NumAxes; }
 		int GetNumButtons() const override { return m_NumButtons; }
 		int GetNumBalls() const override { return m_NumBalls; }

--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -944,7 +944,7 @@ void CServerBrowser::Refresh(int Type, bool Force)
 		CNetChunk Packet;
 
 		/* do the broadcast version */
-		Packet.m_ClientID = -1;
+		Packet.m_ClientId = -1;
 		mem_zero(&Packet, sizeof(Packet));
 		Packet.m_Address.type = m_pNetClient->NetType() | NETTYPE_LINK_BROADCAST;
 		Packet.m_Flags = NETSENDFLAG_CONNLESS | NETSENDFLAG_EXTENDED;
@@ -1020,7 +1020,7 @@ void CServerBrowser::RequestImpl(const NETADDR &Addr, CServerEntry *pEntry, int 
 	aBuffer[sizeof(SERVERBROWSE_GETINFO)] = GetBasicToken(Token);
 
 	CNetChunk Packet;
-	Packet.m_ClientID = -1;
+	Packet.m_ClientId = -1;
 	Packet.m_Address = Addr;
 	Packet.m_Flags = NETSENDFLAG_CONNLESS | NETSENDFLAG_EXTENDED;
 	Packet.m_DataSize = sizeof(aBuffer);

--- a/src/engine/client/sound.cpp
+++ b/src/engine/client/sound.cpp
@@ -275,9 +275,9 @@ void CSound::UpdateVolume()
 
 void CSound::Shutdown()
 {
-	for(unsigned SampleID = 0; SampleID < NUM_SAMPLES; SampleID++)
+	for(unsigned SampleId = 0; SampleId < NUM_SAMPLES; SampleId++)
 	{
-		UnloadSample(SampleID);
+		UnloadSample(SampleId);
 	}
 
 	SDL_CloseAudioDevice(m_Device);
@@ -640,15 +640,15 @@ int CSound::LoadWVFromMem(const void *pData, unsigned DataSize, bool FromEditor 
 	return pSample->m_Index;
 }
 
-void CSound::UnloadSample(int SampleID)
+void CSound::UnloadSample(int SampleId)
 {
-	if(SampleID == -1 || SampleID >= NUM_SAMPLES)
+	if(SampleId == -1 || SampleId >= NUM_SAMPLES)
 		return;
 
-	Stop(SampleID);
+	Stop(SampleId);
 
 	// Free data
-	CSample &Sample = m_aSamples[SampleID];
+	CSample &Sample = m_aSamples[SampleId];
 	free(Sample.m_pData);
 	Sample.m_pData = nullptr;
 
@@ -660,21 +660,21 @@ void CSound::UnloadSample(int SampleID)
 	}
 }
 
-float CSound::GetSampleTotalTime(int SampleID)
+float CSound::GetSampleTotalTime(int SampleId)
 {
-	if(SampleID == -1 || SampleID >= NUM_SAMPLES)
+	if(SampleId == -1 || SampleId >= NUM_SAMPLES)
 		return 0.0f;
 
-	return m_aSamples[SampleID].TotalTime();
+	return m_aSamples[SampleId].TotalTime();
 }
 
-float CSound::GetSampleCurrentTime(int SampleID)
+float CSound::GetSampleCurrentTime(int SampleId)
 {
-	if(SampleID == -1 || SampleID >= NUM_SAMPLES)
+	if(SampleId == -1 || SampleId >= NUM_SAMPLES)
 		return 0.0f;
 
 	const CLockScope LockScope(m_SoundLock);
-	CSample *pSample = &m_aSamples[SampleID];
+	CSample *pSample = &m_aSamples[SampleId];
 	for(auto &Voice : m_aVoices)
 	{
 		if(Voice.m_pSample == pSample)
@@ -686,13 +686,13 @@ float CSound::GetSampleCurrentTime(int SampleID)
 	return pSample->m_PausedAt / (float)pSample->m_Rate;
 }
 
-void CSound::SetSampleCurrentTime(int SampleID, float Time)
+void CSound::SetSampleCurrentTime(int SampleId, float Time)
 {
-	if(SampleID == -1 || SampleID >= NUM_SAMPLES)
+	if(SampleId == -1 || SampleId >= NUM_SAMPLES)
 		return;
 
 	const CLockScope LockScope(m_SoundLock);
-	CSample *pSample = &m_aSamples[SampleID];
+	CSample *pSample = &m_aSamples[SampleId];
 	for(auto &Voice : m_aVoices)
 	{
 		if(Voice.m_pSample == pSample)
@@ -705,10 +705,10 @@ void CSound::SetSampleCurrentTime(int SampleID, float Time)
 	pSample->m_PausedAt = pSample->m_NumFrames * Time;
 }
 
-void CSound::SetChannel(int ChannelID, float Vol, float Pan)
+void CSound::SetChannel(int ChannelId, float Vol, float Pan)
 {
-	m_aChannels[ChannelID].m_Vol = (int)(Vol * 255.0f);
-	m_aChannels[ChannelID].m_Pan = (int)(Pan * 255.0f); // TODO: this is only on and off right now
+	m_aChannels[ChannelId].m_Vol = (int)(Vol * 255.0f);
+	m_aChannels[ChannelId].m_Pan = (int)(Pan * 255.0f); // TODO: this is only on and off right now
 }
 
 void CSound::SetListenerPos(float x, float y)
@@ -722,14 +722,14 @@ void CSound::SetVoiceVolume(CVoiceHandle Voice, float Volume)
 	if(!Voice.IsValid())
 		return;
 
-	int VoiceID = Voice.Id();
+	int VoiceId = Voice.Id();
 
 	const CLockScope LockScope(m_SoundLock);
-	if(m_aVoices[VoiceID].m_Age != Voice.Age())
+	if(m_aVoices[VoiceId].m_Age != Voice.Age())
 		return;
 
 	Volume = clamp(Volume, 0.0f, 1.0f);
-	m_aVoices[VoiceID].m_Vol = (int)(Volume * 255.0f);
+	m_aVoices[VoiceId].m_Vol = (int)(Volume * 255.0f);
 }
 
 void CSound::SetVoiceFalloff(CVoiceHandle Voice, float Falloff)
@@ -737,14 +737,14 @@ void CSound::SetVoiceFalloff(CVoiceHandle Voice, float Falloff)
 	if(!Voice.IsValid())
 		return;
 
-	int VoiceID = Voice.Id();
+	int VoiceId = Voice.Id();
 
 	const CLockScope LockScope(m_SoundLock);
-	if(m_aVoices[VoiceID].m_Age != Voice.Age())
+	if(m_aVoices[VoiceId].m_Age != Voice.Age())
 		return;
 
 	Falloff = clamp(Falloff, 0.0f, 1.0f);
-	m_aVoices[VoiceID].m_Falloff = Falloff;
+	m_aVoices[VoiceId].m_Falloff = Falloff;
 }
 
 void CSound::SetVoiceLocation(CVoiceHandle Voice, float x, float y)
@@ -752,14 +752,14 @@ void CSound::SetVoiceLocation(CVoiceHandle Voice, float x, float y)
 	if(!Voice.IsValid())
 		return;
 
-	int VoiceID = Voice.Id();
+	int VoiceId = Voice.Id();
 
 	const CLockScope LockScope(m_SoundLock);
-	if(m_aVoices[VoiceID].m_Age != Voice.Age())
+	if(m_aVoices[VoiceId].m_Age != Voice.Age())
 		return;
 
-	m_aVoices[VoiceID].m_X = x;
-	m_aVoices[VoiceID].m_Y = y;
+	m_aVoices[VoiceId].m_X = x;
+	m_aVoices[VoiceId].m_Y = y;
 }
 
 void CSound::SetVoiceTimeOffset(CVoiceHandle Voice, float TimeOffset)
@@ -767,31 +767,31 @@ void CSound::SetVoiceTimeOffset(CVoiceHandle Voice, float TimeOffset)
 	if(!Voice.IsValid())
 		return;
 
-	int VoiceID = Voice.Id();
+	int VoiceId = Voice.Id();
 
 	const CLockScope LockScope(m_SoundLock);
-	if(m_aVoices[VoiceID].m_Age != Voice.Age())
+	if(m_aVoices[VoiceId].m_Age != Voice.Age())
 		return;
 
-	if(!m_aVoices[VoiceID].m_pSample)
+	if(!m_aVoices[VoiceId].m_pSample)
 		return;
 
 	int Tick = 0;
-	bool IsLooping = m_aVoices[VoiceID].m_Flags & ISound::FLAG_LOOP;
-	uint64_t TickOffset = m_aVoices[VoiceID].m_pSample->m_Rate * TimeOffset;
-	if(m_aVoices[VoiceID].m_pSample->m_NumFrames > 0 && IsLooping)
-		Tick = TickOffset % m_aVoices[VoiceID].m_pSample->m_NumFrames;
+	bool IsLooping = m_aVoices[VoiceId].m_Flags & ISound::FLAG_LOOP;
+	uint64_t TickOffset = m_aVoices[VoiceId].m_pSample->m_Rate * TimeOffset;
+	if(m_aVoices[VoiceId].m_pSample->m_NumFrames > 0 && IsLooping)
+		Tick = TickOffset % m_aVoices[VoiceId].m_pSample->m_NumFrames;
 	else
-		Tick = clamp(TickOffset, (uint64_t)0, (uint64_t)m_aVoices[VoiceID].m_pSample->m_NumFrames);
+		Tick = clamp(TickOffset, (uint64_t)0, (uint64_t)m_aVoices[VoiceId].m_pSample->m_NumFrames);
 
 	// at least 200msec off, else depend on buffer size
-	float Threshold = maximum(0.2f * m_aVoices[VoiceID].m_pSample->m_Rate, (float)m_MaxFrames);
-	if(absolute(m_aVoices[VoiceID].m_Tick - Tick) > Threshold)
+	float Threshold = maximum(0.2f * m_aVoices[VoiceId].m_pSample->m_Rate, (float)m_MaxFrames);
+	if(absolute(m_aVoices[VoiceId].m_Tick - Tick) > Threshold)
 	{
 		// take care of looping (modulo!)
-		if(!(IsLooping && (minimum(m_aVoices[VoiceID].m_Tick, Tick) + m_aVoices[VoiceID].m_pSample->m_NumFrames - maximum(m_aVoices[VoiceID].m_Tick, Tick)) <= Threshold))
+		if(!(IsLooping && (minimum(m_aVoices[VoiceId].m_Tick, Tick) + m_aVoices[VoiceId].m_pSample->m_NumFrames - maximum(m_aVoices[VoiceId].m_Tick, Tick)) <= Threshold))
 		{
-			m_aVoices[VoiceID].m_Tick = Tick;
+			m_aVoices[VoiceId].m_Tick = Tick;
 		}
 	}
 }
@@ -801,14 +801,14 @@ void CSound::SetVoiceCircle(CVoiceHandle Voice, float Radius)
 	if(!Voice.IsValid())
 		return;
 
-	int VoiceID = Voice.Id();
+	int VoiceId = Voice.Id();
 
 	const CLockScope LockScope(m_SoundLock);
-	if(m_aVoices[VoiceID].m_Age != Voice.Age())
+	if(m_aVoices[VoiceId].m_Age != Voice.Age())
 		return;
 
-	m_aVoices[VoiceID].m_Shape = ISound::SHAPE_CIRCLE;
-	m_aVoices[VoiceID].m_Circle.m_Radius = maximum(0.0f, Radius);
+	m_aVoices[VoiceId].m_Shape = ISound::SHAPE_CIRCLE;
+	m_aVoices[VoiceId].m_Circle.m_Radius = maximum(0.0f, Radius);
 }
 
 void CSound::SetVoiceRectangle(CVoiceHandle Voice, float Width, float Height)
@@ -816,81 +816,81 @@ void CSound::SetVoiceRectangle(CVoiceHandle Voice, float Width, float Height)
 	if(!Voice.IsValid())
 		return;
 
-	int VoiceID = Voice.Id();
+	int VoiceId = Voice.Id();
 
 	const CLockScope LockScope(m_SoundLock);
-	if(m_aVoices[VoiceID].m_Age != Voice.Age())
+	if(m_aVoices[VoiceId].m_Age != Voice.Age())
 		return;
 
-	m_aVoices[VoiceID].m_Shape = ISound::SHAPE_RECTANGLE;
-	m_aVoices[VoiceID].m_Rectangle.m_Width = maximum(0.0f, Width);
-	m_aVoices[VoiceID].m_Rectangle.m_Height = maximum(0.0f, Height);
+	m_aVoices[VoiceId].m_Shape = ISound::SHAPE_RECTANGLE;
+	m_aVoices[VoiceId].m_Rectangle.m_Width = maximum(0.0f, Width);
+	m_aVoices[VoiceId].m_Rectangle.m_Height = maximum(0.0f, Height);
 }
 
-ISound::CVoiceHandle CSound::Play(int ChannelID, int SampleID, int Flags, float x, float y)
+ISound::CVoiceHandle CSound::Play(int ChannelId, int SampleId, int Flags, float x, float y)
 {
 	const CLockScope LockScope(m_SoundLock);
 
 	// search for voice
-	int VoiceID = -1;
+	int VoiceId = -1;
 	for(int i = 0; i < NUM_VOICES; i++)
 	{
-		int NextID = (m_NextVoice + i) % NUM_VOICES;
-		if(!m_aVoices[NextID].m_pSample)
+		int NextId = (m_NextVoice + i) % NUM_VOICES;
+		if(!m_aVoices[NextId].m_pSample)
 		{
-			VoiceID = NextID;
-			m_NextVoice = NextID + 1;
+			VoiceId = NextId;
+			m_NextVoice = NextId + 1;
 			break;
 		}
 	}
 
 	// voice found, use it
 	int Age = -1;
-	if(VoiceID != -1)
+	if(VoiceId != -1)
 	{
-		m_aVoices[VoiceID].m_pSample = &m_aSamples[SampleID];
-		m_aVoices[VoiceID].m_pChannel = &m_aChannels[ChannelID];
+		m_aVoices[VoiceId].m_pSample = &m_aSamples[SampleId];
+		m_aVoices[VoiceId].m_pChannel = &m_aChannels[ChannelId];
 		if(Flags & FLAG_LOOP)
 		{
-			m_aVoices[VoiceID].m_Tick = m_aSamples[SampleID].m_PausedAt;
+			m_aVoices[VoiceId].m_Tick = m_aSamples[SampleId].m_PausedAt;
 		}
 		else if(Flags & FLAG_PREVIEW)
 		{
-			m_aVoices[VoiceID].m_Tick = m_aSamples[SampleID].m_PausedAt;
-			m_aSamples[SampleID].m_PausedAt = 0;
+			m_aVoices[VoiceId].m_Tick = m_aSamples[SampleId].m_PausedAt;
+			m_aSamples[SampleId].m_PausedAt = 0;
 		}
 		else
 		{
-			m_aVoices[VoiceID].m_Tick = 0;
+			m_aVoices[VoiceId].m_Tick = 0;
 		}
-		m_aVoices[VoiceID].m_Vol = 255;
-		m_aVoices[VoiceID].m_Flags = Flags;
-		m_aVoices[VoiceID].m_X = (int)x;
-		m_aVoices[VoiceID].m_Y = (int)y;
-		m_aVoices[VoiceID].m_Falloff = 0.0f;
-		m_aVoices[VoiceID].m_Shape = ISound::SHAPE_CIRCLE;
-		m_aVoices[VoiceID].m_Circle.m_Radius = 1500;
-		Age = m_aVoices[VoiceID].m_Age;
+		m_aVoices[VoiceId].m_Vol = 255;
+		m_aVoices[VoiceId].m_Flags = Flags;
+		m_aVoices[VoiceId].m_X = (int)x;
+		m_aVoices[VoiceId].m_Y = (int)y;
+		m_aVoices[VoiceId].m_Falloff = 0.0f;
+		m_aVoices[VoiceId].m_Shape = ISound::SHAPE_CIRCLE;
+		m_aVoices[VoiceId].m_Circle.m_Radius = 1500;
+		Age = m_aVoices[VoiceId].m_Age;
 	}
 
-	return CreateVoiceHandle(VoiceID, Age);
+	return CreateVoiceHandle(VoiceId, Age);
 }
 
-ISound::CVoiceHandle CSound::PlayAt(int ChannelID, int SampleID, int Flags, float x, float y)
+ISound::CVoiceHandle CSound::PlayAt(int ChannelId, int SampleId, int Flags, float x, float y)
 {
-	return Play(ChannelID, SampleID, Flags | ISound::FLAG_POS, x, y);
+	return Play(ChannelId, SampleId, Flags | ISound::FLAG_POS, x, y);
 }
 
-ISound::CVoiceHandle CSound::Play(int ChannelID, int SampleID, int Flags)
+ISound::CVoiceHandle CSound::Play(int ChannelId, int SampleId, int Flags)
 {
-	return Play(ChannelID, SampleID, Flags, 0, 0);
+	return Play(ChannelId, SampleId, Flags, 0, 0);
 }
 
-void CSound::Pause(int SampleID)
+void CSound::Pause(int SampleId)
 {
 	// TODO: a nice fade out
 	const CLockScope LockScope(m_SoundLock);
-	CSample *pSample = &m_aSamples[SampleID];
+	CSample *pSample = &m_aSamples[SampleId];
 	for(auto &Voice : m_aVoices)
 	{
 		if(Voice.m_pSample == pSample)
@@ -901,11 +901,11 @@ void CSound::Pause(int SampleID)
 	}
 }
 
-void CSound::Stop(int SampleID)
+void CSound::Stop(int SampleId)
 {
 	// TODO: a nice fade out
 	const CLockScope LockScope(m_SoundLock);
-	CSample *pSample = &m_aSamples[SampleID];
+	CSample *pSample = &m_aSamples[SampleId];
 	for(auto &Voice : m_aVoices)
 	{
 		if(Voice.m_pSample == pSample)
@@ -941,20 +941,20 @@ void CSound::StopVoice(CVoiceHandle Voice)
 	if(!Voice.IsValid())
 		return;
 
-	int VoiceID = Voice.Id();
+	int VoiceId = Voice.Id();
 
 	const CLockScope LockScope(m_SoundLock);
-	if(m_aVoices[VoiceID].m_Age != Voice.Age())
+	if(m_aVoices[VoiceId].m_Age != Voice.Age())
 		return;
 
-	m_aVoices[VoiceID].m_pSample = nullptr;
-	m_aVoices[VoiceID].m_Age++;
+	m_aVoices[VoiceId].m_pSample = nullptr;
+	m_aVoices[VoiceId].m_Age++;
 }
 
-bool CSound::IsPlaying(int SampleID)
+bool CSound::IsPlaying(int SampleId)
 {
 	const CLockScope LockScope(m_SoundLock);
-	const CSample *pSample = &m_aSamples[SampleID];
+	const CSample *pSample = &m_aSamples[SampleId];
 	return std::any_of(std::begin(m_aVoices), std::end(m_aVoices), [pSample](const auto &Voice) { return Voice.m_pSample == pSample; });
 }
 

--- a/src/engine/client/sound.h
+++ b/src/engine/client/sound.h
@@ -105,13 +105,13 @@ public:
 	int LoadWV(const char *pFilename, int StorageType = IStorage::TYPE_ALL) override REQUIRES(!m_SoundLock);
 	int LoadOpusFromMem(const void *pData, unsigned DataSize, bool FromEditor) override REQUIRES(!m_SoundLock);
 	int LoadWVFromMem(const void *pData, unsigned DataSize, bool FromEditor) override REQUIRES(!m_SoundLock);
-	void UnloadSample(int SampleID) override REQUIRES(!m_SoundLock);
+	void UnloadSample(int SampleId) override REQUIRES(!m_SoundLock);
 
-	float GetSampleTotalTime(int SampleID) override; // in s
-	float GetSampleCurrentTime(int SampleID) override REQUIRES(!m_SoundLock); // in s
-	void SetSampleCurrentTime(int SampleID, float Time) override REQUIRES(!m_SoundLock);
+	float GetSampleTotalTime(int SampleId) override; // in s
+	float GetSampleCurrentTime(int SampleId) override REQUIRES(!m_SoundLock); // in s
+	void SetSampleCurrentTime(int SampleId, float Time) override REQUIRES(!m_SoundLock);
 
-	void SetChannel(int ChannelID, float Vol, float Pan) override;
+	void SetChannel(int ChannelId, float Vol, float Pan) override;
 	void SetListenerPos(float x, float y) override;
 
 	void SetVoiceVolume(CVoiceHandle Voice, float Volume) override REQUIRES(!m_SoundLock);
@@ -122,14 +122,14 @@ public:
 	void SetVoiceCircle(CVoiceHandle Voice, float Radius) override REQUIRES(!m_SoundLock);
 	void SetVoiceRectangle(CVoiceHandle Voice, float Width, float Height) override REQUIRES(!m_SoundLock);
 
-	CVoiceHandle Play(int ChannelID, int SampleID, int Flags, float x, float y) REQUIRES(!m_SoundLock);
-	CVoiceHandle PlayAt(int ChannelID, int SampleID, int Flags, float x, float y) override REQUIRES(!m_SoundLock);
-	CVoiceHandle Play(int ChannelID, int SampleID, int Flags) override REQUIRES(!m_SoundLock);
-	void Pause(int SampleID) override REQUIRES(!m_SoundLock);
-	void Stop(int SampleID) override REQUIRES(!m_SoundLock);
+	CVoiceHandle Play(int ChannelId, int SampleId, int Flags, float x, float y) REQUIRES(!m_SoundLock);
+	CVoiceHandle PlayAt(int ChannelId, int SampleId, int Flags, float x, float y) override REQUIRES(!m_SoundLock);
+	CVoiceHandle Play(int ChannelId, int SampleId, int Flags) override REQUIRES(!m_SoundLock);
+	void Pause(int SampleId) override REQUIRES(!m_SoundLock);
+	void Stop(int SampleId) override REQUIRES(!m_SoundLock);
 	void StopAll() override REQUIRES(!m_SoundLock);
 	void StopVoice(CVoiceHandle Voice) override REQUIRES(!m_SoundLock);
-	bool IsPlaying(int SampleID) override REQUIRES(!m_SoundLock);
+	bool IsPlaying(int SampleId) override REQUIRES(!m_SoundLock);
 
 	void Mix(short *pFinalOut, unsigned Frames) override REQUIRES(!m_SoundLock);
 	void PauseAudioDevice() override;

--- a/src/engine/console.h
+++ b/src/engine/console.h
@@ -58,7 +58,7 @@ public:
 		virtual void RemoveArgument(unsigned Index) = 0;
 
 		int NumArguments() const { return m_NumArgs; }
-		int m_ClientID;
+		int m_ClientId;
 
 		// DDRace
 
@@ -82,7 +82,7 @@ public:
 		int GetAccessLevel() const { return m_AccessLevel; }
 	};
 
-	typedef void (*FTeeHistorianCommandCallback)(int ClientID, int FlagMask, const char *pCmd, IResult *pResult, void *pUser);
+	typedef void (*FTeeHistorianCommandCallback)(int ClientId, int FlagMask, const char *pCmd, IResult *pResult, void *pUser);
 	typedef void (*FPrintCallback)(const char *pStr, void *pUser, ColorRGBA PrintColor);
 	typedef void (*FPossibleCallback)(int Index, const char *pCmd, void *pUser);
 	typedef void (*FCommandCallback)(IResult *pResult, void *pUserData);
@@ -106,10 +106,10 @@ public:
 	virtual void StoreCommands(bool Store) = 0;
 
 	virtual bool LineIsValid(const char *pStr) = 0;
-	virtual void ExecuteLine(const char *pStr, int ClientID = -1, bool InterpretSemicolons = true) = 0;
-	virtual void ExecuteLineFlag(const char *pStr, int FlasgMask, int ClientID = -1, bool InterpretSemicolons = true) = 0;
-	virtual void ExecuteLineStroked(int Stroke, const char *pStr, int ClientID = -1, bool InterpretSemicolons = true) = 0;
-	virtual bool ExecuteFile(const char *pFilename, int ClientID = -1, bool LogFailure = false, int StorageType = IStorage::TYPE_ALL) = 0;
+	virtual void ExecuteLine(const char *pStr, int ClientId = -1, bool InterpretSemicolons = true) = 0;
+	virtual void ExecuteLineFlag(const char *pStr, int FlasgMask, int ClientId = -1, bool InterpretSemicolons = true) = 0;
+	virtual void ExecuteLineStroked(int Stroke, const char *pStr, int ClientId = -1, bool InterpretSemicolons = true) = 0;
+	virtual bool ExecuteFile(const char *pFilename, int ClientId = -1, bool LogFailure = false, int StorageType = IStorage::TYPE_ALL) = 0;
 
 	virtual char *Format(char *pBuf, int Size, const char *pFrom, const char *pStr) = 0;
 	virtual void Print(int Level, const char *pFrom, const char *pStr, ColorRGBA PrintColor = gs_ConsoleDefaultColor) const = 0;

--- a/src/engine/graphics.h
+++ b/src/engine/graphics.h
@@ -202,9 +202,9 @@ enum EBackendType
 	BACKEND_TYPE_COUNT,
 };
 
-struct STWGraphicGPU
+struct STWGraphicGpu
 {
-	enum ETWGraphicsGPUType
+	enum ETWGraphicsGpuType
 	{
 		GRAPHICS_GPU_TYPE_DISCRETE = 0,
 		GRAPHICS_GPU_TYPE_INTEGRATED,
@@ -215,16 +215,16 @@ struct STWGraphicGPU
 		GRAPHICS_GPU_TYPE_INVALID,
 	};
 
-	struct STWGraphicGPUItem
+	struct STWGraphicGpuItem
 	{
 		char m_aName[256];
-		ETWGraphicsGPUType m_GPUType;
+		ETWGraphicsGpuType m_GpuType;
 	};
-	std::vector<STWGraphicGPUItem> m_vGPUs;
-	STWGraphicGPUItem m_AutoGPU;
+	std::vector<STWGraphicGpuItem> m_vGpus;
+	STWGraphicGpuItem m_AutoGpu;
 };
 
-typedef STWGraphicGPU TTWGraphicsGPUList;
+typedef STWGraphicGpu TTwGraphicsGpuList;
 
 typedef std::function<void()> WINDOW_RESIZE_FUNC;
 typedef std::function<void()> WINDOW_PROPS_CHANGED_FUNC;
@@ -295,8 +295,8 @@ public:
 	*/
 	virtual void AddWindowPropChangeListener(WINDOW_PROPS_CHANGED_FUNC pFunc) = 0;
 
-	virtual void WindowDestroyNtf(uint32_t WindowID) = 0;
-	virtual void WindowCreateNtf(uint32_t WindowID) = 0;
+	virtual void WindowDestroyNtf(uint32_t WindowId) = 0;
+	virtual void WindowCreateNtf(uint32_t WindowId) = 0;
 
 	// ForceClearNow forces the backend to trigger a clear, even at performance cost, else it might be delayed by one frame
 	virtual void Clear(float r, float g, float b, bool ForceClearNow = false) = 0;
@@ -319,7 +319,7 @@ public:
 	virtual uint64_t StreamedMemoryUsage() const = 0;
 	virtual uint64_t StagingMemoryUsage() const = 0;
 
-	virtual const TTWGraphicsGPUList &GetGPUs() const = 0;
+	virtual const TTwGraphicsGpuList &GetGpus() const = 0;
 
 	virtual bool LoadPNG(CImageInfo *pImg, const char *pFilename, int StorageType) = 0;
 	virtual void FreePNG(CImageInfo *pImg) = 0;
@@ -336,7 +336,7 @@ public:
 	virtual int UnloadTexture(CTextureHandle *pIndex) = 0;
 	virtual CTextureHandle LoadTextureRaw(size_t Width, size_t Height, CImageInfo::EImageFormat Format, const void *pData, int Flags, const char *pTexName = nullptr) = 0;
 	virtual CTextureHandle LoadTextureRawMove(size_t Width, size_t Height, CImageInfo::EImageFormat Format, void *pData, int Flags, const char *pTexName = nullptr) = 0;
-	virtual int LoadTextureRawSub(CTextureHandle TextureID, int x, int y, size_t Width, size_t Height, CImageInfo::EImageFormat Format, const void *pData) = 0;
+	virtual int LoadTextureRawSub(CTextureHandle TextureId, int x, int y, size_t Width, size_t Height, CImageInfo::EImageFormat Format, const void *pData) = 0;
 	virtual CTextureHandle LoadTexture(const char *pFilename, int StorageType, int Flags = 0) = 0;
 	virtual CTextureHandle NullTexture() const = 0;
 	virtual void TextureSet(CTextureHandle Texture) = 0;
@@ -345,7 +345,7 @@ public:
 	// pTextData & pTextOutlineData are automatically free'd
 	virtual bool LoadTextTextures(size_t Width, size_t Height, CTextureHandle &TextTexture, CTextureHandle &TextOutlineTexture, void *pTextData, void *pTextOutlineData) = 0;
 	virtual bool UnloadTextTextures(CTextureHandle &TextTexture, CTextureHandle &TextOutlineTexture) = 0;
-	virtual bool UpdateTextTexture(CTextureHandle TextureID, int x, int y, size_t Width, size_t Height, const void *pData) = 0;
+	virtual bool UpdateTextTexture(CTextureHandle TextureId, int x, int y, size_t Width, size_t Height, const void *pData) = 0;
 
 	virtual CTextureHandle LoadSpriteTexture(CImageInfo &FromImageInfo, struct CDataSprite *pSprite) = 0;
 

--- a/src/engine/map.h
+++ b/src/engine/map.h
@@ -24,10 +24,10 @@ public:
 	virtual int NumData() const = 0;
 
 	virtual int GetItemSize(int Index) = 0;
-	virtual void *GetItem(int Index, int *pType = nullptr, int *pID = nullptr) = 0;
+	virtual void *GetItem(int Index, int *pType = nullptr, int *pId = nullptr) = 0;
 	virtual void GetType(int Type, int *pStart, int *pNum) = 0;
-	virtual int FindItemIndex(int Type, int ID) = 0;
-	virtual void *FindItem(int Type, int ID) = 0;
+	virtual int FindItemIndex(int Type, int Id) = 0;
+	virtual void *FindItem(int Type, int Id) = 0;
 	virtual int NumItems() const = 0;
 };
 

--- a/src/engine/message.h
+++ b/src/engine/message.h
@@ -9,18 +9,18 @@
 class CMsgPacker : public CPacker
 {
 public:
-	int m_MsgID;
+	int m_MsgId;
 	bool m_System;
 	bool m_NoTranslate;
 	CMsgPacker(int Type, bool System = false, bool NoTranslate = false) :
-		m_MsgID(Type), m_System(System), m_NoTranslate(NoTranslate)
+		m_MsgId(Type), m_System(System), m_NoTranslate(NoTranslate)
 	{
 		Reset();
 	}
 
 	template<typename T>
 	CMsgPacker(const T *, bool System = false, bool NoTranslate = false) :
-		CMsgPacker(T::ms_MsgID, System, NoTranslate)
+		CMsgPacker(T::ms_MsgId, System, NoTranslate)
 	{
 	}
 };

--- a/src/engine/server.h
+++ b/src/engine/server.h
@@ -19,7 +19,7 @@
 
 struct CAntibotRoundData;
 
-// When recording a demo on the server, the ClientID -1 is used
+// When recording a demo on the server, the ClientId -1 is used
 enum
 {
 	SERVER_DEMO_CLIENT = -1
@@ -42,7 +42,7 @@ public:
 		bool m_GotDDNetVersion;
 		int m_DDNetVersion;
 		const char *m_pDDNetVersionStr;
-		const CUuid *m_pConnectionID;
+		const CUuid *m_pConnectionId;
 	};
 
 	int Tick() const { return m_CurrentGameTick; }
@@ -52,34 +52,34 @@ public:
 	virtual int MaxClients() const = 0;
 	virtual int ClientCount() const = 0;
 	virtual int DistinctClientCount() const = 0;
-	virtual const char *ClientName(int ClientID) const = 0;
-	virtual const char *ClientClan(int ClientID) const = 0;
-	virtual int ClientCountry(int ClientID) const = 0;
-	virtual bool ClientSlotEmpty(int ClientID) const = 0;
-	virtual bool ClientIngame(int ClientID) const = 0;
-	virtual bool ClientAuthed(int ClientID) const = 0;
-	virtual bool GetClientInfo(int ClientID, CClientInfo *pInfo) const = 0;
-	virtual void SetClientDDNetVersion(int ClientID, int DDNetVersion) = 0;
-	virtual void GetClientAddr(int ClientID, char *pAddrStr, int Size) const = 0;
+	virtual const char *ClientName(int ClientId) const = 0;
+	virtual const char *ClientClan(int ClientId) const = 0;
+	virtual int ClientCountry(int ClientId) const = 0;
+	virtual bool ClientSlotEmpty(int ClientId) const = 0;
+	virtual bool ClientIngame(int ClientId) const = 0;
+	virtual bool ClientAuthed(int ClientId) const = 0;
+	virtual bool GetClientInfo(int ClientId, CClientInfo *pInfo) const = 0;
+	virtual void SetClientDDNetVersion(int ClientId, int DDNetVersion) = 0;
+	virtual void GetClientAddr(int ClientId, char *pAddrStr, int Size) const = 0;
 
 	/**
 	 * Returns the version of the client with the given client ID.
 	 *
-	 * @param ClientID the client ID, which must be between 0 and
+	 * @param ClientId the client Id, which must be between 0 and
 	 * MAX_CLIENTS - 1, or equal to SERVER_DEMO_CLIENT for server demos.
 	 *
 	 * @return The version of the client with the given client ID.
 	 * For server demos this is always the latest client version.
 	 * On errors, VERSION_NONE is returned.
 	 */
-	virtual int GetClientVersion(int ClientID) const = 0;
-	virtual int SendMsg(CMsgPacker *pMsg, int Flags, int ClientID) = 0;
+	virtual int GetClientVersion(int ClientId) const = 0;
+	virtual int SendMsg(CMsgPacker *pMsg, int Flags, int ClientId) = 0;
 
 	template<class T, typename std::enable_if<!protocol7::is_sixup<T>::value, int>::type = 0>
-	inline int SendPackMsg(const T *pMsg, int Flags, int ClientID)
+	inline int SendPackMsg(const T *pMsg, int Flags, int ClientId)
 	{
 		int Result = 0;
-		if(ClientID == -1)
+		if(ClientId == -1)
 		{
 			for(int i = 0; i < MaxClients(); i++)
 				if(ClientIngame(i))
@@ -87,101 +87,101 @@ public:
 		}
 		else
 		{
-			Result = SendPackMsgTranslate(pMsg, Flags, ClientID);
+			Result = SendPackMsgTranslate(pMsg, Flags, ClientId);
 		}
 		return Result;
 	}
 
 	template<class T, typename std::enable_if<protocol7::is_sixup<T>::value, int>::type = 1>
-	inline int SendPackMsg(const T *pMsg, int Flags, int ClientID)
+	inline int SendPackMsg(const T *pMsg, int Flags, int ClientId)
 	{
 		int Result = 0;
-		if(ClientID == -1)
+		if(ClientId == -1)
 		{
 			for(int i = 0; i < MaxClients(); i++)
 				if(ClientIngame(i) && IsSixup(i))
 					Result = SendPackMsgOne(pMsg, Flags, i);
 		}
-		else if(IsSixup(ClientID))
-			Result = SendPackMsgOne(pMsg, Flags, ClientID);
+		else if(IsSixup(ClientId))
+			Result = SendPackMsgOne(pMsg, Flags, ClientId);
 
 		return Result;
 	}
 
 	template<class T>
-	int SendPackMsgTranslate(const T *pMsg, int Flags, int ClientID)
+	int SendPackMsgTranslate(const T *pMsg, int Flags, int ClientId)
 	{
-		return SendPackMsgOne(pMsg, Flags, ClientID);
+		return SendPackMsgOne(pMsg, Flags, ClientId);
 	}
 
-	int SendPackMsgTranslate(const CNetMsg_Sv_Emoticon *pMsg, int Flags, int ClientID)
+	int SendPackMsgTranslate(const CNetMsg_Sv_Emoticon *pMsg, int Flags, int ClientId)
 	{
 		CNetMsg_Sv_Emoticon MsgCopy;
 		mem_copy(&MsgCopy, pMsg, sizeof(MsgCopy));
-		return Translate(MsgCopy.m_ClientID, ClientID) && SendPackMsgOne(&MsgCopy, Flags, ClientID);
+		return Translate(MsgCopy.m_ClientId, ClientId) && SendPackMsgOne(&MsgCopy, Flags, ClientId);
 	}
 
-	int SendPackMsgTranslate(const CNetMsg_Sv_Chat *pMsg, int Flags, int ClientID)
+	int SendPackMsgTranslate(const CNetMsg_Sv_Chat *pMsg, int Flags, int ClientId)
 	{
 		CNetMsg_Sv_Chat MsgCopy;
 		mem_copy(&MsgCopy, pMsg, sizeof(MsgCopy));
 
 		char aBuf[1000];
-		if(MsgCopy.m_ClientID >= 0 && !Translate(MsgCopy.m_ClientID, ClientID))
+		if(MsgCopy.m_ClientId >= 0 && !Translate(MsgCopy.m_ClientId, ClientId))
 		{
-			str_format(aBuf, sizeof(aBuf), "%s: %s", ClientName(MsgCopy.m_ClientID), MsgCopy.m_pMessage);
+			str_format(aBuf, sizeof(aBuf), "%s: %s", ClientName(MsgCopy.m_ClientId), MsgCopy.m_pMessage);
 			MsgCopy.m_pMessage = aBuf;
-			MsgCopy.m_ClientID = VANILLA_MAX_CLIENTS - 1;
+			MsgCopy.m_ClientId = VANILLA_MAX_CLIENTS - 1;
 		}
 
-		if(IsSixup(ClientID))
+		if(IsSixup(ClientId))
 		{
 			protocol7::CNetMsg_Sv_Chat Msg7;
-			Msg7.m_ClientID = MsgCopy.m_ClientID;
+			Msg7.m_ClientId = MsgCopy.m_ClientId;
 			Msg7.m_pMessage = MsgCopy.m_pMessage;
 			Msg7.m_Mode = MsgCopy.m_Team > 0 ? protocol7::CHAT_TEAM : protocol7::CHAT_ALL;
-			Msg7.m_TargetID = -1;
-			return SendPackMsgOne(&Msg7, Flags, ClientID);
+			Msg7.m_TargetId = -1;
+			return SendPackMsgOne(&Msg7, Flags, ClientId);
 		}
 
-		return SendPackMsgOne(&MsgCopy, Flags, ClientID);
+		return SendPackMsgOne(&MsgCopy, Flags, ClientId);
 	}
 
-	int SendPackMsgTranslate(const CNetMsg_Sv_KillMsg *pMsg, int Flags, int ClientID)
+	int SendPackMsgTranslate(const CNetMsg_Sv_KillMsg *pMsg, int Flags, int ClientId)
 	{
 		CNetMsg_Sv_KillMsg MsgCopy;
 		mem_copy(&MsgCopy, pMsg, sizeof(MsgCopy));
-		if(!Translate(MsgCopy.m_Victim, ClientID))
+		if(!Translate(MsgCopy.m_Victim, ClientId))
 			return 0;
-		if(!Translate(MsgCopy.m_Killer, ClientID))
+		if(!Translate(MsgCopy.m_Killer, ClientId))
 			MsgCopy.m_Killer = MsgCopy.m_Victim;
-		return SendPackMsgOne(&MsgCopy, Flags, ClientID);
+		return SendPackMsgOne(&MsgCopy, Flags, ClientId);
 	}
 
-	int SendPackMsgTranslate(const CNetMsg_Sv_RaceFinish *pMsg, int Flags, int ClientID)
+	int SendPackMsgTranslate(const CNetMsg_Sv_RaceFinish *pMsg, int Flags, int ClientId)
 	{
-		if(IsSixup(ClientID))
+		if(IsSixup(ClientId))
 		{
 			protocol7::CNetMsg_Sv_RaceFinish Msg7;
-			Msg7.m_ClientID = pMsg->m_ClientID;
+			Msg7.m_ClientId = pMsg->m_ClientId;
 			Msg7.m_Diff = pMsg->m_Diff;
 			Msg7.m_Time = pMsg->m_Time;
 			Msg7.m_RecordPersonal = pMsg->m_RecordPersonal;
 			Msg7.m_RecordServer = pMsg->m_RecordServer;
-			return SendPackMsgOne(&Msg7, Flags, ClientID);
+			return SendPackMsgOne(&Msg7, Flags, ClientId);
 		}
-		return SendPackMsgOne(pMsg, Flags, ClientID);
+		return SendPackMsgOne(pMsg, Flags, ClientId);
 	}
 
 	template<class T>
-	int SendPackMsgOne(const T *pMsg, int Flags, int ClientID)
+	int SendPackMsgOne(const T *pMsg, int Flags, int ClientId)
 	{
-		dbg_assert(ClientID != -1, "SendPackMsgOne called with -1");
-		CMsgPacker Packer(T::ms_MsgID, false, protocol7::is_sixup<T>::value);
+		dbg_assert(ClientId != -1, "SendPackMsgOne called with -1");
+		CMsgPacker Packer(T::ms_MsgId, false, protocol7::is_sixup<T>::value);
 
 		if(pMsg->Pack(&Packer))
 			return -1;
-		return SendMsg(&Packer, Flags, ClientID);
+		return SendMsg(&Packer, Flags, ClientId);
 	}
 
 	bool Translate(int &Target, int Client)
@@ -220,23 +220,23 @@ public:
 
 	virtual void GetMapInfo(char *pMapName, int MapNameSize, int *pMapSize, SHA256_DIGEST *pSha256, int *pMapCrc) = 0;
 
-	virtual bool WouldClientNameChange(int ClientID, const char *pNameRequest) = 0;
-	virtual bool WouldClientClanChange(int ClientID, const char *pClanRequest) = 0;
-	virtual void SetClientName(int ClientID, const char *pName) = 0;
-	virtual void SetClientClan(int ClientID, const char *pClan) = 0;
-	virtual void SetClientCountry(int ClientID, int Country) = 0;
-	virtual void SetClientScore(int ClientID, std::optional<int> Score) = 0;
-	virtual void SetClientFlags(int ClientID, int Flags) = 0;
+	virtual bool WouldClientNameChange(int ClientId, const char *pNameRequest) = 0;
+	virtual bool WouldClientClanChange(int ClientId, const char *pClanRequest) = 0;
+	virtual void SetClientName(int ClientId, const char *pName) = 0;
+	virtual void SetClientClan(int ClientId, const char *pClan) = 0;
+	virtual void SetClientCountry(int ClientId, int Country) = 0;
+	virtual void SetClientScore(int ClientId, std::optional<int> Score) = 0;
+	virtual void SetClientFlags(int ClientId, int Flags) = 0;
 
-	virtual int SnapNewID() = 0;
-	virtual void SnapFreeID(int ID) = 0;
-	virtual void *SnapNewItem(int Type, int ID, int Size) = 0;
+	virtual int SnapNewId() = 0;
+	virtual void SnapFreeId(int Id) = 0;
+	virtual void *SnapNewItem(int Type, int Id, int Size) = 0;
 
 	template<typename T>
-	T *SnapNewItem(int ID)
+	T *SnapNewItem(int Id)
 	{
-		const int Type = protocol7::is_sixup<T>::value ? -T::ms_MsgID : T::ms_MsgID;
-		return static_cast<T *>(SnapNewItem(Type, ID, sizeof(T)));
+		const int Type = protocol7::is_sixup<T>::value ? -T::ms_MsgId : T::ms_MsgId;
+		return static_cast<T *>(SnapNewItem(Type, Id, sizeof(T)));
 	}
 
 	virtual void SnapSetStaticsize(int ItemType, int Size) = 0;
@@ -246,48 +246,48 @@ public:
 		RCON_CID_SERV = -1,
 		RCON_CID_VOTE = -2,
 	};
-	virtual void SetRconCID(int ClientID) = 0;
-	virtual int GetAuthedState(int ClientID) const = 0;
-	virtual const char *GetAuthName(int ClientID) const = 0;
-	virtual void Kick(int ClientID, const char *pReason) = 0;
-	virtual void Ban(int ClientID, int Seconds, const char *pReason) = 0;
-	virtual void RedirectClient(int ClientID, int Port, bool Verbose = false) = 0;
+	virtual void SetRconCid(int ClientId) = 0;
+	virtual int GetAuthedState(int ClientId) const = 0;
+	virtual const char *GetAuthName(int ClientId) const = 0;
+	virtual void Kick(int ClientId, const char *pReason) = 0;
+	virtual void Ban(int ClientId, int Seconds, const char *pReason) = 0;
+	virtual void RedirectClient(int ClientId, int Port, bool Verbose = false) = 0;
 	virtual void ChangeMap(const char *pMap) = 0;
 
 	virtual void DemoRecorder_HandleAutoStart() = 0;
 
 	// DDRace
 
-	virtual void SaveDemo(int ClientID, float Time) = 0;
-	virtual void StartRecord(int ClientID) = 0;
-	virtual void StopRecord(int ClientID) = 0;
-	virtual bool IsRecording(int ClientID) = 0;
+	virtual void SaveDemo(int ClientId, float Time) = 0;
+	virtual void StartRecord(int ClientId) = 0;
+	virtual void StopRecord(int ClientId) = 0;
+	virtual bool IsRecording(int ClientId) = 0;
 	virtual void StopDemos() = 0;
 
-	virtual void GetClientAddr(int ClientID, NETADDR *pAddr) const = 0;
+	virtual void GetClientAddr(int ClientId, NETADDR *pAddr) const = 0;
 
-	virtual int *GetIdMap(int ClientID) = 0;
+	virtual int *GetIdMap(int ClientId) = 0;
 
-	virtual bool DnsblWhite(int ClientID) = 0;
-	virtual bool DnsblPending(int ClientID) = 0;
-	virtual bool DnsblBlack(int ClientID) = 0;
+	virtual bool DnsblWhite(int ClientId) = 0;
+	virtual bool DnsblPending(int ClientId) = 0;
+	virtual bool DnsblBlack(int ClientId) = 0;
 	virtual const char *GetAnnouncementLine(const char *pFileName) = 0;
-	virtual bool ClientPrevIngame(int ClientID) = 0;
-	virtual const char *GetNetErrorString(int ClientID) = 0;
-	virtual void ResetNetErrorString(int ClientID) = 0;
-	virtual bool SetTimedOut(int ClientID, int OrigID) = 0;
-	virtual void SetTimeoutProtected(int ClientID) = 0;
+	virtual bool ClientPrevIngame(int ClientId) = 0;
+	virtual const char *GetNetErrorString(int ClientId) = 0;
+	virtual void ResetNetErrorString(int ClientId) = 0;
+	virtual bool SetTimedOut(int ClientId, int OrigId) = 0;
+	virtual void SetTimeoutProtected(int ClientId) = 0;
 
 	virtual void SetErrorShutdown(const char *pReason) = 0;
 	virtual void ExpireServerInfo() = 0;
 
 	virtual void FillAntibot(CAntibotRoundData *pData) = 0;
 
-	virtual void SendMsgRaw(int ClientID, const void *pData, int Size, int Flags) = 0;
+	virtual void SendMsgRaw(int ClientId, const void *pData, int Size, int Flags) = 0;
 
 	virtual const char *GetMapName() const = 0;
 
-	virtual bool IsSixup(int ClientID) const = 0;
+	virtual bool IsSixup(int ClientId) const = 0;
 };
 
 class IGameServer : public IInterface
@@ -306,10 +306,10 @@ public:
 
 	virtual void OnTick() = 0;
 	virtual void OnPreSnap() = 0;
-	virtual void OnSnap(int ClientID) = 0;
+	virtual void OnSnap(int ClientId) = 0;
 	virtual void OnPostSnap() = 0;
 
-	virtual void OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID) = 0;
+	virtual void OnMessage(int MsgId, CUnpacker *pUnpacker, int ClientId) = 0;
 
 	// Called before map reload, for any data that the game wants to
 	// persist to the next map.
@@ -318,24 +318,24 @@ public:
 	//
 	// Returns whether the game should be supplied with the data when the
 	// client connects for the next map.
-	virtual bool OnClientDataPersist(int ClientID, void *pData) = 0;
+	virtual bool OnClientDataPersist(int ClientId, void *pData) = 0;
 
 	// Called when a client connects.
 	//
 	// If it is reconnecting to the game after a map change, the
 	// `pPersistentData` point is nonnull and contains the data the game
 	// previously stored.
-	virtual void OnClientConnected(int ClientID, void *pPersistentData) = 0;
+	virtual void OnClientConnected(int ClientId, void *pPersistentData) = 0;
 
-	virtual void OnClientEnter(int ClientID) = 0;
-	virtual void OnClientDrop(int ClientID, const char *pReason) = 0;
-	virtual void OnClientPrepareInput(int ClientID, void *pInput) = 0;
-	virtual void OnClientDirectInput(int ClientID, void *pInput) = 0;
-	virtual void OnClientPredictedInput(int ClientID, void *pInput) = 0;
-	virtual void OnClientPredictedEarlyInput(int ClientID, void *pInput) = 0;
+	virtual void OnClientEnter(int ClientId) = 0;
+	virtual void OnClientDrop(int ClientId, const char *pReason) = 0;
+	virtual void OnClientPrepareInput(int ClientId, void *pInput) = 0;
+	virtual void OnClientDirectInput(int ClientId, void *pInput) = 0;
+	virtual void OnClientPredictedInput(int ClientId, void *pInput) = 0;
+	virtual void OnClientPredictedEarlyInput(int ClientId, void *pInput) = 0;
 
-	virtual bool IsClientReady(int ClientID) const = 0;
-	virtual bool IsClientPlayer(int ClientID) const = 0;
+	virtual bool IsClientReady(int ClientId) const = 0;
+	virtual bool IsClientPlayer(int ClientId) const = 0;
 
 	virtual int PersistentDataSize() const = 0;
 	virtual int PersistentClientDataSize() const = 0;
@@ -349,13 +349,13 @@ public:
 
 	virtual void OnPreTickTeehistorian() = 0;
 
-	virtual void OnSetAuthed(int ClientID, int Level) = 0;
-	virtual bool PlayerExists(int ClientID) const = 0;
+	virtual void OnSetAuthed(int ClientId, int Level) = 0;
+	virtual bool PlayerExists(int ClientId) const = 0;
 
 	virtual void TeehistorianRecordAntibot(const void *pData, int DataSize) = 0;
-	virtual void TeehistorianRecordPlayerJoin(int ClientID, bool Sixup) = 0;
-	virtual void TeehistorianRecordPlayerDrop(int ClientID, const char *pReason) = 0;
-	virtual void TeehistorianRecordPlayerRejoin(int ClientID) = 0;
+	virtual void TeehistorianRecordPlayerJoin(int ClientId, bool Sixup) = 0;
+	virtual void TeehistorianRecordPlayerDrop(int ClientId, const char *pReason) = 0;
+	virtual void TeehistorianRecordPlayerRejoin(int ClientId) = 0;
 
 	virtual void FillAntibot(CAntibotRoundData *pData) = 0;
 
@@ -365,7 +365,7 @@ public:
 	 * @param aBuf Should be the json key values to add, starting with a ',' beforehand, like: ',"skin": "default", "team": 1'
 	 * @param i The client id.
 	 */
-	virtual void OnUpdatePlayerServerInfo(char *aBuf, int BufSize, int ID) = 0;
+	virtual void OnUpdatePlayerServerInfo(char *aBuf, int BufSize, int Id) = 0;
 };
 
 extern IGameServer *CreateGameServer();

--- a/src/engine/server/antibot.cpp
+++ b/src/engine/server/antibot.cpp
@@ -23,23 +23,23 @@ CAntibot::~CAntibot()
 	if(m_Initialized)
 		AntibotDestroy();
 }
-void CAntibot::Kick(int ClientID, const char *pMessage, void *pUser)
+void CAntibot::Kick(int ClientId, const char *pMessage, void *pUser)
 {
 	CAntibot *pAntibot = (CAntibot *)pUser;
-	pAntibot->Server()->Kick(ClientID, pMessage);
+	pAntibot->Server()->Kick(ClientId, pMessage);
 }
 void CAntibot::Log(const char *pMessage, void *pUser)
 {
 	CAntibot *pAntibot = (CAntibot *)pUser;
 	pAntibot->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "antibot", pMessage);
 }
-void CAntibot::Report(int ClientID, const char *pMessage, void *pUser)
+void CAntibot::Report(int ClientId, const char *pMessage, void *pUser)
 {
 	char aBuf[256];
-	str_format(aBuf, sizeof(aBuf), "%d: %s", ClientID, pMessage);
+	str_format(aBuf, sizeof(aBuf), "%d: %s", ClientId, pMessage);
 	Log(aBuf, pUser);
 }
-void CAntibot::Send(int ClientID, const void *pData, int Size, int Flags, void *pUser)
+void CAntibot::Send(int ClientId, const void *pData, int Size, int Flags, void *pUser)
 {
 	CAntibot *pAntibot = (CAntibot *)pUser;
 
@@ -52,7 +52,7 @@ void CAntibot::Send(int ClientID, const void *pData, int Size, int Flags, void *
 	{
 		RealFlags |= MSGFLAG_FLUSH;
 	}
-	pAntibot->Server()->SendMsgRaw(ClientID, pData, Size, RealFlags);
+	pAntibot->Server()->SendMsgRaw(ClientId, pData, Size, RealFlags);
 }
 void CAntibot::Teehistorian(const void *pData, int Size, void *pUser)
 {
@@ -115,50 +115,50 @@ void CAntibot::Update()
 	}
 }
 
-void CAntibot::OnPlayerInit(int ClientID)
+void CAntibot::OnPlayerInit(int ClientId)
 {
 	Update();
-	AntibotOnPlayerInit(ClientID);
+	AntibotOnPlayerInit(ClientId);
 }
-void CAntibot::OnPlayerDestroy(int ClientID)
+void CAntibot::OnPlayerDestroy(int ClientId)
 {
 	Update();
-	AntibotOnPlayerDestroy(ClientID);
+	AntibotOnPlayerDestroy(ClientId);
 }
-void CAntibot::OnSpawn(int ClientID)
+void CAntibot::OnSpawn(int ClientId)
 {
 	Update();
-	AntibotOnSpawn(ClientID);
+	AntibotOnSpawn(ClientId);
 }
-void CAntibot::OnHammerFireReloading(int ClientID)
+void CAntibot::OnHammerFireReloading(int ClientId)
 {
 	Update();
-	AntibotOnHammerFireReloading(ClientID);
+	AntibotOnHammerFireReloading(ClientId);
 }
-void CAntibot::OnHammerFire(int ClientID)
+void CAntibot::OnHammerFire(int ClientId)
 {
 	Update();
-	AntibotOnHammerFire(ClientID);
+	AntibotOnHammerFire(ClientId);
 }
-void CAntibot::OnHammerHit(int ClientID, int TargetID)
+void CAntibot::OnHammerHit(int ClientId, int TargetId)
 {
 	Update();
-	AntibotOnHammerHit(ClientID, TargetID);
+	AntibotOnHammerHit(ClientId, TargetId);
 }
-void CAntibot::OnDirectInput(int ClientID)
+void CAntibot::OnDirectInput(int ClientId)
 {
 	Update();
-	AntibotOnDirectInput(ClientID);
+	AntibotOnDirectInput(ClientId);
 }
-void CAntibot::OnCharacterTick(int ClientID)
+void CAntibot::OnCharacterTick(int ClientId)
 {
 	Update();
-	AntibotOnCharacterTick(ClientID);
+	AntibotOnCharacterTick(ClientId);
 }
-void CAntibot::OnHookAttach(int ClientID, bool Player)
+void CAntibot::OnHookAttach(int ClientId, bool Player)
 {
 	Update();
-	AntibotOnHookAttach(ClientID, Player);
+	AntibotOnHookAttach(ClientId, Player);
 }
 
 void CAntibot::OnEngineTick()
@@ -166,27 +166,17 @@ void CAntibot::OnEngineTick()
 	Update();
 	AntibotOnEngineTick();
 }
-void CAntibot::OnEngineClientJoin(int ClientID, bool Sixup)
+void CAntibot::OnEngineClientJoin(int ClientId, bool Sixup)
 {
 	Update();
-	AntibotOnEngineClientJoin(ClientID, Sixup);
+	AntibotOnEngineClientJoin(ClientId, Sixup);
 }
-void CAntibot::OnEngineClientDrop(int ClientID, const char *pReason)
+void CAntibot::OnEngineClientDrop(int ClientId, const char *pReason)
 {
 	Update();
-	AntibotOnEngineClientDrop(ClientID, pReason);
+	AntibotOnEngineClientDrop(ClientId, pReason);
 }
-bool CAntibot::OnEngineClientMessage(int ClientID, const void *pData, int Size, int Flags)
-{
-	Update();
-	int AntibotFlags = 0;
-	if((Flags & MSGFLAG_VITAL) == 0)
-	{
-		AntibotFlags |= ANTIBOT_MSGFLAG_NONVITAL;
-	}
-	return AntibotOnEngineClientMessage(ClientID, pData, Size, AntibotFlags);
-}
-bool CAntibot::OnEngineServerMessage(int ClientID, const void *pData, int Size, int Flags)
+bool CAntibot::OnEngineClientMessage(int ClientId, const void *pData, int Size, int Flags)
 {
 	Update();
 	int AntibotFlags = 0;
@@ -194,12 +184,22 @@ bool CAntibot::OnEngineServerMessage(int ClientID, const void *pData, int Size, 
 	{
 		AntibotFlags |= ANTIBOT_MSGFLAG_NONVITAL;
 	}
-	return AntibotOnEngineServerMessage(ClientID, pData, Size, AntibotFlags);
+	return AntibotOnEngineClientMessage(ClientId, pData, Size, AntibotFlags);
 }
-bool CAntibot::OnEngineSimulateClientMessage(int *pClientID, void *pBuffer, int BufferSize, int *pOutSize, int *pFlags)
+bool CAntibot::OnEngineServerMessage(int ClientId, const void *pData, int Size, int Flags)
+{
+	Update();
+	int AntibotFlags = 0;
+	if((Flags & MSGFLAG_VITAL) == 0)
+	{
+		AntibotFlags |= ANTIBOT_MSGFLAG_NONVITAL;
+	}
+	return AntibotOnEngineServerMessage(ClientId, pData, Size, AntibotFlags);
+}
+bool CAntibot::OnEngineSimulateClientMessage(int *pClientId, void *pBuffer, int BufferSize, int *pOutSize, int *pFlags)
 {
 	int AntibotFlags = 0;
-	bool Result = AntibotOnEngineSimulateClientMessage(pClientID, pBuffer, BufferSize, pOutSize, &AntibotFlags);
+	bool Result = AntibotOnEngineSimulateClientMessage(pClientId, pBuffer, BufferSize, pOutSize, &AntibotFlags);
 	if(Result)
 	{
 		*pFlags = 0;
@@ -245,22 +245,22 @@ void CAntibot::Update()
 {
 }
 
-void CAntibot::OnPlayerInit(int ClientID) {}
-void CAntibot::OnPlayerDestroy(int ClientID) {}
-void CAntibot::OnSpawn(int ClientID) {}
-void CAntibot::OnHammerFireReloading(int ClientID) {}
-void CAntibot::OnHammerFire(int ClientID) {}
-void CAntibot::OnHammerHit(int ClientID, int TargetID) {}
-void CAntibot::OnDirectInput(int ClientID) {}
-void CAntibot::OnCharacterTick(int ClientID) {}
-void CAntibot::OnHookAttach(int ClientID, bool Player) {}
+void CAntibot::OnPlayerInit(int ClientId) {}
+void CAntibot::OnPlayerDestroy(int ClientId) {}
+void CAntibot::OnSpawn(int ClientId) {}
+void CAntibot::OnHammerFireReloading(int ClientId) {}
+void CAntibot::OnHammerFire(int ClientId) {}
+void CAntibot::OnHammerHit(int ClientId, int TargetId) {}
+void CAntibot::OnDirectInput(int ClientId) {}
+void CAntibot::OnCharacterTick(int ClientId) {}
+void CAntibot::OnHookAttach(int ClientId, bool Player) {}
 
 void CAntibot::OnEngineTick() {}
-void CAntibot::OnEngineClientJoin(int ClientID, bool Sixup) {}
-void CAntibot::OnEngineClientDrop(int ClientID, const char *pReason) {}
-bool CAntibot::OnEngineClientMessage(int ClientID, const void *pData, int Size, int Flags) { return false; }
-bool CAntibot::OnEngineServerMessage(int ClientID, const void *pData, int Size, int Flags) { return false; }
-bool CAntibot::OnEngineSimulateClientMessage(int *pClientID, void *pBuffer, int BufferSize, int *pOutSize, int *pFlags) { return false; }
+void CAntibot::OnEngineClientJoin(int ClientId, bool Sixup) {}
+void CAntibot::OnEngineClientDrop(int ClientId, const char *pReason) {}
+bool CAntibot::OnEngineClientMessage(int ClientId, const void *pData, int Size, int Flags) { return false; }
+bool CAntibot::OnEngineServerMessage(int ClientId, const void *pData, int Size, int Flags) { return false; }
+bool CAntibot::OnEngineSimulateClientMessage(int *pClientId, void *pBuffer, int BufferSize, int *pOutSize, int *pFlags) { return false; }
 #endif
 
 IEngineAntibot *CreateEngineAntibot()

--- a/src/engine/server/antibot.h
+++ b/src/engine/server/antibot.h
@@ -19,10 +19,10 @@ class CAntibot : public IEngineAntibot
 	bool m_Initialized;
 
 	void Update();
-	static void Kick(int ClientID, const char *pMessage, void *pUser);
+	static void Kick(int ClientId, const char *pMessage, void *pUser);
 	static void Log(const char *pMessage, void *pUser);
-	static void Report(int ClientID, const char *pMessage, void *pUser);
-	static void Send(int ClientID, const void *pData, int Size, int Flags, void *pUser);
+	static void Report(int ClientId, const char *pMessage, void *pUser);
+	static void Send(int ClientId, const void *pData, int Size, int Flags, void *pUser);
 	static void Teehistorian(const void *pData, int Size, void *pUser);
 
 public:
@@ -33,25 +33,25 @@ public:
 	void Init() override;
 
 	void OnEngineTick() override;
-	void OnEngineClientJoin(int ClientID, bool Sixup) override;
-	void OnEngineClientDrop(int ClientID, const char *pReason) override;
-	bool OnEngineClientMessage(int ClientID, const void *pData, int Size, int Flags) override;
-	bool OnEngineServerMessage(int ClientID, const void *pData, int Size, int Flags) override;
-	bool OnEngineSimulateClientMessage(int *pClientID, void *pBuffer, int BufferSize, int *pOutSize, int *pFlags) override;
+	void OnEngineClientJoin(int ClientId, bool Sixup) override;
+	void OnEngineClientDrop(int ClientId, const char *pReason) override;
+	bool OnEngineClientMessage(int ClientId, const void *pData, int Size, int Flags) override;
+	bool OnEngineServerMessage(int ClientId, const void *pData, int Size, int Flags) override;
+	bool OnEngineSimulateClientMessage(int *pClientId, void *pBuffer, int BufferSize, int *pOutSize, int *pFlags) override;
 
 	// Game
 	void RoundStart(class IGameServer *pGameServer) override;
 	void RoundEnd() override;
 
-	void OnPlayerInit(int ClientID) override;
-	void OnPlayerDestroy(int ClientID) override;
-	void OnSpawn(int ClientID) override;
-	void OnHammerFireReloading(int ClientID) override;
-	void OnHammerFire(int ClientID) override;
-	void OnHammerHit(int ClientID, int TargetID) override;
-	void OnDirectInput(int ClientID) override;
-	void OnCharacterTick(int ClientID) override;
-	void OnHookAttach(int ClientID, bool Player) override;
+	void OnPlayerInit(int ClientId) override;
+	void OnPlayerDestroy(int ClientId) override;
+	void OnSpawn(int ClientId) override;
+	void OnHammerFireReloading(int ClientId) override;
+	void OnHammerFire(int ClientId) override;
+	void OnHammerHit(int ClientId, int TargetId) override;
+	void OnDirectInput(int ClientId) override;
+	void OnCharacterTick(int ClientId) override;
+	void OnHookAttach(int ClientId, bool Player) override;
 
 	void ConsoleCommand(const char *pCommand) override;
 };

--- a/src/engine/server/databases/connection.cpp
+++ b/src/engine/server/databases/connection.cpp
@@ -23,7 +23,7 @@ void IDbConnection::FormatCreateRace(char *aBuf, unsigned int BufferSize, bool B
 		"  cp19 FLOAT DEFAULT 0, cp20 FLOAT DEFAULT 0, cp21 FLOAT DEFAULT 0, "
 		"  cp22 FLOAT DEFAULT 0, cp23 FLOAT DEFAULT 0, cp24 FLOAT DEFAULT 0, "
 		"  cp25 FLOAT DEFAULT 0, "
-		"  GameID VARCHAR(64), "
+		"  GameId VARCHAR(64), "
 		"  DDNet7 BOOL DEFAULT FALSE, "
 		"  PRIMARY KEY (Map, Name, Time, Timestamp, Server)"
 		")",
@@ -40,9 +40,9 @@ void IDbConnection::FormatCreateTeamrace(char *aBuf, unsigned int BufferSize, co
 		"  Timestamp TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, "
 		"  Time FLOAT DEFAULT 0, "
 		"  ID %s NOT NULL, " // VARBINARY(16) for MySQL and BLOB for SQLite
-		"  GameID VARCHAR(64), "
+		"  GameId VARCHAR(64), "
 		"  DDNet7 BOOL DEFAULT FALSE, "
-		"  PRIMARY KEY (ID, Name)"
+		"  PRIMARY KEY (Id, Name)"
 		")",
 		GetPrefix(), Backup ? "_backup" : "",
 		BinaryCollate(), MAX_NAME_LENGTH_SQL, BinaryCollate(), pIdType);
@@ -73,7 +73,7 @@ void IDbConnection::FormatCreateSaves(char *aBuf, unsigned int BufferSize, bool 
 		"  Timestamp TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP, "
 		"  Server CHAR(4), "
 		"  DDNet7 BOOL DEFAULT FALSE, "
-		"  SaveID VARCHAR(36) DEFAULT NULL, "
+		"  SaveId VARCHAR(36) DEFAULT NULL, "
 		"  PRIMARY KEY (Map, Code)"
 		")",
 		GetPrefix(), Backup ? "_backup" : "",

--- a/src/engine/server/databases/connection_pool.cpp
+++ b/src/engine/server/databases/connection_pool.cpp
@@ -49,7 +49,7 @@ struct CSqlExecData
 		{
 			CDbConnectionPool::Mode m_Mode;
 			CMysqlConfig m_Config;
-		} m_MySql;
+		} m_Mysql;
 		struct
 		{
 			CDbConnectionPool::Mode m_Mode;
@@ -104,8 +104,8 @@ CSqlExecData::CSqlExecData(CDbConnectionPool::Mode m,
 	m_pThreadData(nullptr),
 	m_pName("add mysql server")
 {
-	m_Ptr.m_MySql.m_Mode = m;
-	mem_copy(&m_Ptr.m_MySql.m_Config, pMysqlConfig, sizeof(m_Ptr.m_MySql.m_Config));
+	m_Ptr.m_Mysql.m_Mode = m;
+	mem_copy(&m_Ptr.m_Mysql.m_Config, pMysqlConfig, sizeof(m_Ptr.m_Mysql.m_Config));
 }
 
 CSqlExecData::CSqlExecData(IConsole *pConsole, CDbConnectionPool::Mode m) :
@@ -352,8 +352,8 @@ void CWorker::ProcessQueries()
 		break;
 		case CSqlExecData::ADD_MYSQL:
 		{
-			auto pMysql = CreateMysqlConnection(pThreadData->m_Ptr.m_MySql.m_Config);
-			switch(pThreadData->m_Ptr.m_MySql.m_Mode)
+			auto pMysql = CreateMysqlConnection(pThreadData->m_Ptr.m_Mysql.m_Config);
+			switch(pThreadData->m_Ptr.m_Mysql.m_Mode)
 			{
 			case CDbConnectionPool::Mode::READ:
 				m_vpReadConnections.push_back(std::move(pMysql));

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -177,7 +177,7 @@ public:
 		bool m_DDNetVersionSettled;
 		int m_DDNetVersion;
 		char m_aDDNetVersionStr[64];
-		CUuid m_ConnectionID;
+		CUuid m_ConnectionId;
 		int64_t m_RedirectDropTime;
 
 		// DNSBL
@@ -197,7 +197,7 @@ public:
 
 	CSnapshotDelta m_SnapshotDelta;
 	CSnapshotBuilder m_SnapshotBuilder;
-	CSnapIDPool m_IDPool;
+	CSnapIdPool m_IdPool;
 	CNetServer m_NetServer;
 	CEcon m_Econ;
 	CFifo m_Fifo;
@@ -220,7 +220,7 @@ public:
 
 	bool m_MapReload;
 	bool m_ReloadedWhenEmpty;
-	int m_RconClientID;
+	int m_RconClientId;
 	int m_RconAuthLevel;
 	int m_PrintCBIndex;
 	char m_aShutdownReason[128];
@@ -266,21 +266,21 @@ public:
 	CServer();
 	~CServer();
 
-	bool IsClientNameAvailable(int ClientID, const char *pNameRequest);
-	bool SetClientNameImpl(int ClientID, const char *pNameRequest, bool Set);
-	bool SetClientClanImpl(int ClientID, const char *pClanRequest, bool Set);
+	bool IsClientNameAvailable(int ClientId, const char *pNameRequest);
+	bool SetClientNameImpl(int ClientId, const char *pNameRequest, bool Set);
+	bool SetClientClanImpl(int ClientId, const char *pClanRequest, bool Set);
 
-	bool WouldClientNameChange(int ClientID, const char *pNameRequest) override;
-	bool WouldClientClanChange(int ClientID, const char *pClanRequest) override;
-	void SetClientName(int ClientID, const char *pName) override;
-	void SetClientClan(int ClientID, const char *pClan) override;
-	void SetClientCountry(int ClientID, int Country) override;
-	void SetClientScore(int ClientID, std::optional<int> Score) override;
-	void SetClientFlags(int ClientID, int Flags) override;
+	bool WouldClientNameChange(int ClientId, const char *pNameRequest) override;
+	bool WouldClientClanChange(int ClientId, const char *pClanRequest) override;
+	void SetClientName(int ClientId, const char *pName) override;
+	void SetClientClan(int ClientId, const char *pClan) override;
+	void SetClientCountry(int ClientId, int Country) override;
+	void SetClientScore(int ClientId, std::optional<int> Score) override;
+	void SetClientFlags(int ClientId, int Flags) override;
 
-	void Kick(int ClientID, const char *pReason) override;
-	void Ban(int ClientID, int Seconds, const char *pReason) override;
-	void RedirectClient(int ClientID, int Port, bool Verbose = false) override;
+	void Kick(int ClientId, const char *pReason) override;
+	void Ban(int ClientId, int Seconds, const char *pReason) override;
+	void RedirectClient(int ClientId, int Port, bool Verbose = false) override;
 
 	void DemoRecorder_HandleAutoStart() override;
 
@@ -291,49 +291,49 @@ public:
 	int Init();
 
 	void SendLogLine(const CLogMessage *pMessage);
-	void SetRconCID(int ClientID) override;
-	int GetAuthedState(int ClientID) const override;
-	const char *GetAuthName(int ClientID) const override;
+	void SetRconCid(int ClientId) override;
+	int GetAuthedState(int ClientId) const override;
+	const char *GetAuthName(int ClientId) const override;
 	void GetMapInfo(char *pMapName, int MapNameSize, int *pMapSize, SHA256_DIGEST *pMapSha256, int *pMapCrc) override;
-	bool GetClientInfo(int ClientID, CClientInfo *pInfo) const override;
-	void SetClientDDNetVersion(int ClientID, int DDNetVersion) override;
-	void GetClientAddr(int ClientID, char *pAddrStr, int Size) const override;
-	const char *ClientName(int ClientID) const override;
-	const char *ClientClan(int ClientID) const override;
-	int ClientCountry(int ClientID) const override;
-	bool ClientSlotEmpty(int ClientID) const override;
-	bool ClientIngame(int ClientID) const override;
-	bool ClientAuthed(int ClientID) const override;
+	bool GetClientInfo(int ClientId, CClientInfo *pInfo) const override;
+	void SetClientDDNetVersion(int ClientId, int DDNetVersion) override;
+	void GetClientAddr(int ClientId, char *pAddrStr, int Size) const override;
+	const char *ClientName(int ClientId) const override;
+	const char *ClientClan(int ClientId) const override;
+	int ClientCountry(int ClientId) const override;
+	bool ClientSlotEmpty(int ClientId) const override;
+	bool ClientIngame(int ClientId) const override;
+	bool ClientAuthed(int ClientId) const override;
 	int Port() const override;
 	int MaxClients() const override;
 	int ClientCount() const override;
 	int DistinctClientCount() const override;
 
-	int GetClientVersion(int ClientID) const override;
-	int SendMsg(CMsgPacker *pMsg, int Flags, int ClientID) override;
+	int GetClientVersion(int ClientId) const override;
+	int SendMsg(CMsgPacker *pMsg, int Flags, int ClientId) override;
 
 	void DoSnapshot();
 
-	static int NewClientCallback(int ClientID, void *pUser, bool Sixup);
-	static int NewClientNoAuthCallback(int ClientID, void *pUser);
-	static int DelClientCallback(int ClientID, const char *pReason, void *pUser);
+	static int NewClientCallback(int ClientId, void *pUser, bool Sixup);
+	static int NewClientNoAuthCallback(int ClientId, void *pUser);
+	static int DelClientCallback(int ClientId, const char *pReason, void *pUser);
 
-	static int ClientRejoinCallback(int ClientID, void *pUser);
+	static int ClientRejoinCallback(int ClientId, void *pUser);
 
-	void SendRconType(int ClientID, bool UsernameReq);
-	void SendCapabilities(int ClientID);
-	void SendMap(int ClientID);
-	void SendMapData(int ClientID, int Chunk);
-	void SendConnectionReady(int ClientID);
-	void SendRconLine(int ClientID, const char *pLine);
-	// Accepts -1 as ClientID to mean "all clients with at least auth level admin"
-	void SendRconLogLine(int ClientID, const CLogMessage *pMessage);
+	void SendRconType(int ClientId, bool UsernameReq);
+	void SendCapabilities(int ClientId);
+	void SendMap(int ClientId);
+	void SendMapData(int ClientId, int Chunk);
+	void SendConnectionReady(int ClientId);
+	void SendRconLine(int ClientId, const char *pLine);
+	// Accepts -1 as ClientId to mean "all clients with at least auth level admin"
+	void SendRconLogLine(int ClientId, const CLogMessage *pMessage);
 
-	void SendRconCmdAdd(const IConsole::CCommandInfo *pCommandInfo, int ClientID);
-	void SendRconCmdRem(const IConsole::CCommandInfo *pCommandInfo, int ClientID);
+	void SendRconCmdAdd(const IConsole::CCommandInfo *pCommandInfo, int ClientId);
+	void SendRconCmdRem(const IConsole::CCommandInfo *pCommandInfo, int ClientId);
 	void UpdateClientRconCommands();
 
-	bool CheckReservedSlotAuth(int ClientID, const char *pPassword);
+	bool CheckReservedSlotAuth(int ClientId, const char *pPassword);
 	void ProcessClientPacket(CNetChunk *pPacket);
 
 	class CCache
@@ -379,10 +379,10 @@ public:
 	const char *GetMapName() const override;
 	int LoadMap(const char *pMapName);
 
-	void SaveDemo(int ClientID, float Time) override;
-	void StartRecord(int ClientID) override;
-	void StopRecord(int ClientID) override;
-	bool IsRecording(int ClientID) override;
+	void SaveDemo(int ClientId, float Time) override;
+	void StartRecord(int ClientId) override;
+	void StopRecord(int ClientId) override;
+	bool IsRecording(int ClientId) override;
 	void StopDemos() override;
 
 	int Run();
@@ -411,7 +411,7 @@ public:
 	static void ConchainMaxclientsperipUpdate(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 	static void ConchainCommandAccessUpdate(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 
-	void LogoutClient(int ClientID, const char *pReason);
+	void LogoutClient(int ClientId, const char *pReason);
 	void LogoutKey(int Key, const char *pReason);
 
 	void ConchainRconPasswordChangeGeneric(int Level, const char *pCurrent, IConsole::IResult *pResult);
@@ -429,47 +429,47 @@ public:
 
 	void RegisterCommands();
 
-	int SnapNewID() override;
-	void SnapFreeID(int ID) override;
-	void *SnapNewItem(int Type, int ID, int Size) override;
+	int SnapNewId() override;
+	void SnapFreeId(int Id) override;
+	void *SnapNewItem(int Type, int Id, int Size) override;
 	void SnapSetStaticsize(int ItemType, int Size) override;
 
 	// DDRace
 
-	void GetClientAddr(int ClientID, NETADDR *pAddr) const override;
+	void GetClientAddr(int ClientId, NETADDR *pAddr) const override;
 	int m_aPrevStates[MAX_CLIENTS];
 	const char *GetAnnouncementLine(const char *pFileName) override;
 
-	int *GetIdMap(int ClientID) override;
+	int *GetIdMap(int ClientId) override;
 
-	void InitDnsbl(int ClientID);
-	bool DnsblWhite(int ClientID) override
+	void InitDnsbl(int ClientId);
+	bool DnsblWhite(int ClientId) override
 	{
-		return m_aClients[ClientID].m_DnsblState == CClient::DNSBL_STATE_NONE ||
-		       m_aClients[ClientID].m_DnsblState == CClient::DNSBL_STATE_WHITELISTED;
+		return m_aClients[ClientId].m_DnsblState == CClient::DNSBL_STATE_NONE ||
+		       m_aClients[ClientId].m_DnsblState == CClient::DNSBL_STATE_WHITELISTED;
 	}
-	bool DnsblPending(int ClientID) override
+	bool DnsblPending(int ClientId) override
 	{
-		return m_aClients[ClientID].m_DnsblState == CClient::DNSBL_STATE_PENDING;
+		return m_aClients[ClientId].m_DnsblState == CClient::DNSBL_STATE_PENDING;
 	}
-	bool DnsblBlack(int ClientID) override
+	bool DnsblBlack(int ClientId) override
 	{
-		return m_aClients[ClientID].m_DnsblState == CClient::DNSBL_STATE_BLACKLISTED;
+		return m_aClients[ClientId].m_DnsblState == CClient::DNSBL_STATE_BLACKLISTED;
 	}
 
 	void AuthRemoveKey(int KeySlot);
-	bool ClientPrevIngame(int ClientID) override { return m_aPrevStates[ClientID] == CClient::STATE_INGAME; }
-	const char *GetNetErrorString(int ClientID) override { return m_NetServer.ErrorString(ClientID); }
-	void ResetNetErrorString(int ClientID) override { m_NetServer.ResetErrorString(ClientID); }
-	bool SetTimedOut(int ClientID, int OrigID) override;
-	void SetTimeoutProtected(int ClientID) override { m_NetServer.SetTimeoutProtected(ClientID); }
+	bool ClientPrevIngame(int ClientId) override { return m_aPrevStates[ClientId] == CClient::STATE_INGAME; }
+	const char *GetNetErrorString(int ClientId) override { return m_NetServer.ErrorString(ClientId); }
+	void ResetNetErrorString(int ClientId) override { m_NetServer.ResetErrorString(ClientId); }
+	bool SetTimedOut(int ClientId, int OrigId) override;
+	void SetTimeoutProtected(int ClientId) override { m_NetServer.SetTimeoutProtected(ClientId); }
 
-	void SendMsgRaw(int ClientID, const void *pData, int Size, int Flags) override;
+	void SendMsgRaw(int ClientId, const void *pData, int Size, int Flags) override;
 
 	bool ErrorShutdown() const { return m_aErrorShutdownReason[0] != 0; }
 	void SetErrorShutdown(const char *pReason) override;
 
-	bool IsSixup(int ClientID) const override { return ClientID != SERVER_DEMO_CLIENT && m_aClients[ClientID].m_Sixup; }
+	bool IsSixup(int ClientId) const override { return ClientId != SERVER_DEMO_CLIENT && m_aClients[ClientId].m_Sixup; }
 
 	void SetLoggers(std::shared_ptr<ILogger> &&pFileLogger, std::shared_ptr<ILogger> &&pStdoutLogger);
 

--- a/src/engine/server/snap_id_pool.cpp
+++ b/src/engine/server/snap_id_pool.cpp
@@ -5,20 +5,20 @@
 
 #include <base/system.h>
 
-CSnapIDPool::CSnapIDPool()
+CSnapIdPool::CSnapIdPool()
 {
 	Reset();
 }
 
-void CSnapIDPool::Reset()
+void CSnapIdPool::Reset()
 {
 	for(int i = 0; i < MAX_IDS; i++)
 	{
-		m_aIDs[i].m_Next = i + 1;
-		m_aIDs[i].m_State = ID_FREE;
+		m_aIds[i].m_Next = i + 1;
+		m_aIds[i].m_State = ID_FREE;
 	}
 
-	m_aIDs[MAX_IDS - 1].m_Next = -1;
+	m_aIds[MAX_IDS - 1].m_Next = -1;
 	m_FirstFree = 0;
 	m_FirstTimed = -1;
 	m_LastTimed = -1;
@@ -26,13 +26,13 @@ void CSnapIDPool::Reset()
 	m_InUsage = 0;
 }
 
-void CSnapIDPool::RemoveFirstTimeout()
+void CSnapIdPool::RemoveFirstTimeout()
 {
-	int NextTimed = m_aIDs[m_FirstTimed].m_Next;
+	int NextTimed = m_aIds[m_FirstTimed].m_Next;
 
 	// add it to the free list
-	m_aIDs[m_FirstTimed].m_Next = m_FirstFree;
-	m_aIDs[m_FirstTimed].m_State = ID_FREE;
+	m_aIds[m_FirstTimed].m_Next = m_FirstFree;
+	m_aIds[m_FirstTimed].m_State = ID_FREE;
 	m_FirstFree = m_FirstTimed;
 
 	// remove it from the timed list
@@ -43,54 +43,54 @@ void CSnapIDPool::RemoveFirstTimeout()
 	m_Usage--;
 }
 
-int CSnapIDPool::NewID()
+int CSnapIdPool::NewId()
 {
 	int64_t Now = time_get();
 
 	// process timed ids
-	while(m_FirstTimed != -1 && m_aIDs[m_FirstTimed].m_Timeout < Now)
+	while(m_FirstTimed != -1 && m_aIds[m_FirstTimed].m_Timeout < Now)
 		RemoveFirstTimeout();
 
-	int ID = m_FirstFree;
-	if(ID == -1)
+	int Id = m_FirstFree;
+	if(Id == -1)
 	{
 		dbg_msg("server", "invalid id");
-		return ID;
+		return Id;
 	}
-	m_FirstFree = m_aIDs[m_FirstFree].m_Next;
-	m_aIDs[ID].m_State = ID_ALLOCATED;
+	m_FirstFree = m_aIds[m_FirstFree].m_Next;
+	m_aIds[Id].m_State = ID_ALLOCATED;
 	m_Usage++;
 	m_InUsage++;
-	return ID;
+	return Id;
 }
 
-void CSnapIDPool::TimeoutIDs()
+void CSnapIdPool::TimeoutIds()
 {
 	// process timed ids
 	while(m_FirstTimed != -1)
 		RemoveFirstTimeout();
 }
 
-void CSnapIDPool::FreeID(int ID)
+void CSnapIdPool::FreeId(int Id)
 {
-	if(ID < 0)
+	if(Id < 0)
 		return;
-	dbg_assert((size_t)ID < std::size(m_aIDs), "id is out of range");
-	dbg_assert(m_aIDs[ID].m_State == ID_ALLOCATED, "id is not allocated");
+	dbg_assert((size_t)Id < std::size(m_aIds), "id is out of range");
+	dbg_assert(m_aIds[Id].m_State == ID_ALLOCATED, "id is not allocated");
 
 	m_InUsage--;
-	m_aIDs[ID].m_State = ID_TIMED;
-	m_aIDs[ID].m_Timeout = time_get() + time_freq() * 5;
-	m_aIDs[ID].m_Next = -1;
+	m_aIds[Id].m_State = ID_TIMED;
+	m_aIds[Id].m_Timeout = time_get() + time_freq() * 5;
+	m_aIds[Id].m_Next = -1;
 
 	if(m_LastTimed != -1)
 	{
-		m_aIDs[m_LastTimed].m_Next = ID;
-		m_LastTimed = ID;
+		m_aIds[m_LastTimed].m_Next = Id;
+		m_LastTimed = Id;
 	}
 	else
 	{
-		m_FirstTimed = ID;
-		m_LastTimed = ID;
+		m_FirstTimed = Id;
+		m_LastTimed = Id;
 	}
 }

--- a/src/engine/server/snap_id_pool.h
+++ b/src/engine/server/snap_id_pool.h
@@ -4,7 +4,7 @@
 #ifndef ENGINE_SERVER_SNAP_ID_POOL_H
 #define ENGINE_SERVER_SNAP_ID_POOL_H
 
-class CSnapIDPool
+class CSnapIdPool
 {
 	enum
 	{
@@ -27,7 +27,7 @@ class CSnapIDPool
 		int m_Timeout;
 	};
 
-	CID m_aIDs[MAX_IDS];
+	CID m_aIds[MAX_IDS];
 
 	int m_FirstFree;
 	int m_FirstTimed;
@@ -36,13 +36,13 @@ class CSnapIDPool
 	int m_InUsage;
 
 public:
-	CSnapIDPool();
+	CSnapIdPool();
 
 	void Reset();
 	void RemoveFirstTimeout();
-	int NewID();
-	void TimeoutIDs();
-	void FreeID(int ID);
+	int NewId();
+	void TimeoutIds();
+	void FreeId(int Id);
 };
 
 #endif

--- a/src/engine/shared/config.cpp
+++ b/src/engine/shared/config.cpp
@@ -56,7 +56,7 @@ void SIntConfigVariable::CommandCallback(IConsole::IResult *pResult, void *pUser
 		}
 
 		*pData->m_pVariable = Value;
-		if(pResult->m_ClientID != IConsole::CLIENT_ID_GAME)
+		if(pResult->m_ClientId != IConsole::CLIENT_ID_GAME)
 			pData->m_OldValue = Value;
 	}
 	else
@@ -121,7 +121,7 @@ void SColorConfigVariable::CommandCallback(IConsole::IResult *pResult, void *pUs
 		const unsigned Value = Color.Pack(pData->m_Light ? 0.5f : 0.0f, pData->m_Alpha);
 
 		*pData->m_pVariable = Value;
-		if(pResult->m_ClientID != IConsole::CLIENT_ID_GAME)
+		if(pResult->m_ClientId != IConsole::CLIENT_ID_GAME)
 			pData->m_OldValue = Value;
 	}
 	else
@@ -230,7 +230,7 @@ void SStringConfigVariable::CommandCallback(IConsole::IResult *pResult, void *pU
 		else
 			str_copy(pData->m_pStr, pString, pData->m_MaxSize);
 
-		if(pResult->m_ClientID != IConsole::CLIENT_ID_GAME)
+		if(pResult->m_ClientId != IConsole::CLIENT_ID_GAME)
 			str_copy(pData->m_pOldValue, pData->m_pStr, pData->m_MaxSize);
 	}
 	else

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -30,7 +30,7 @@ MACRO_CONFIG_INT(ClNameplatesTeamcolors, cl_nameplates_teamcolors, 1, 0, 1, CFGF
 MACRO_CONFIG_INT(ClNameplatesSize, cl_nameplates_size, 50, 0, 100, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Size of the name plates from 0 to 100%")
 MACRO_CONFIG_INT(ClNameplatesClan, cl_nameplates_clan, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show clan in name plates")
 MACRO_CONFIG_INT(ClNameplatesClanSize, cl_nameplates_clan_size, 30, 0, 100, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Size of the clan plates from 0 to 100%")
-MACRO_CONFIG_INT(ClNameplatesIDs, cl_nameplates_ids, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show IDs in name plates")
+MACRO_CONFIG_INT(ClNameplatesIds, cl_nameplates_ids, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show IDs in name plates")
 MACRO_CONFIG_INT(ClNameplatesOwn, cl_nameplates_own, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show own name plate (useful for demo recording)")
 MACRO_CONFIG_INT(ClNameplatesFriendMark, cl_nameplates_friendmark, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show friend mark (♥) in name plates")
 MACRO_CONFIG_INT(ClNameplatesStrong, cl_nameplates_strong, 0, 0, 2, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show strong/weak in name plates (0 - off, 1 - icons, 2 - icons + numbers)")
@@ -373,7 +373,7 @@ MACRO_CONFIG_INT(SvPort, sv_port, 0, 0, 65535, CFGFLAG_SERVER, "Port to use for 
 MACRO_CONFIG_STR(SvHostname, sv_hostname, 128, "", CFGFLAG_SERVER, "Server hostname (0.7 only)")
 MACRO_CONFIG_STR(SvMap, sv_map, 128, "Sunny Side Up", CFGFLAG_SERVER, "Map to use on the server")
 MACRO_CONFIG_INT(SvMaxClients, sv_max_clients, MAX_CLIENTS, 1, MAX_CLIENTS, CFGFLAG_SERVER, "Maximum number of clients that are allowed on a server")
-MACRO_CONFIG_INT(SvMaxClientsPerIP, sv_max_clients_per_ip, 4, 1, MAX_CLIENTS, CFGFLAG_SERVER, "Maximum number of clients with the same IP that can connect to the server")
+MACRO_CONFIG_INT(SvMaxClientsPerIp, sv_max_clients_per_ip, 4, 1, MAX_CLIENTS, CFGFLAG_SERVER, "Maximum number of clients with the same IP that can connect to the server")
 MACRO_CONFIG_INT(SvHighBandwidth, sv_high_bandwidth, 0, 0, 1, CFGFLAG_SERVER, "Use high bandwidth mode. Doubles the bandwidth required for the server. LAN use only")
 MACRO_CONFIG_STR(SvRegister, sv_register, 16, "1", CFGFLAG_SERVER, "Register server with master server for public listing, can also accept a comma-separated list of protocols to register on, like 'ipv4,ipv6'")
 MACRO_CONFIG_STR(SvRegisterExtra, sv_register_extra, 256, "", CFGFLAG_SERVER, "Extra headers to send to the register endpoint, comma separated 'Header: Value' pairs")
@@ -471,7 +471,7 @@ MACRO_CONFIG_INT(SvSaveSwapGamesDelay, sv_saveswapgames_delay, 30, 0, 10000, CFG
 MACRO_CONFIG_INT(SvSaveSwapGamesPenalty, sv_saveswapgames_penalty, 60, 0, 10000, CFGFLAG_SERVER, "Penalty in seconds for saving or swapping position")
 MACRO_CONFIG_INT(SvSwapTimeout, sv_swap_timeout, 180, 0, 10000, CFGFLAG_SERVER, "Timeout in seconds before option to swap expires")
 MACRO_CONFIG_INT(SvSwap, sv_swap, 1, 0, 1, CFGFLAG_SERVER, "Enable /swap")
-MACRO_CONFIG_INT(SvUseSQL, sv_use_sql, 0, 0, 1, CFGFLAG_SERVER, "Enables MySQL backend instead of SQLite backend (sv_sqlite_file is still used as fallback write server when no MySQL server is reachable)")
+MACRO_CONFIG_INT(SvUseSql, sv_use_sql, 0, 0, 1, CFGFLAG_SERVER, "Enables MySQL backend instead of SQLite backend (sv_sqlite_file is still used as fallback write server when no MySQL server is reachable)")
 MACRO_CONFIG_INT(SvSqlQueriesDelay, sv_sql_queries_delay, 1, 0, 20, CFGFLAG_SERVER, "Delay in seconds between SQL queries of a single player")
 MACRO_CONFIG_STR(SvSqliteFile, sv_sqlite_file, 64, "ddnet-server.sqlite", CFGFLAG_SERVER, "File to store ranks in case sv_use_sql is turned off or used as backup sql server")
 
@@ -530,7 +530,7 @@ MACRO_CONFIG_COL(ClMessageFriendColor, cl_message_friend_color, 65425, CFGFLAG_C
 
 MACRO_CONFIG_INT(ConnTimeout, conn_timeout, 100, 5, 1000, CFGFLAG_SAVE | CFGFLAG_CLIENT | CFGFLAG_SERVER, "Network timeout")
 MACRO_CONFIG_INT(ConnTimeoutProtection, conn_timeout_protection, 1000, 5, 10000, CFGFLAG_SERVER, "Network timeout protection")
-MACRO_CONFIG_INT(ClShowIDs, cl_show_ids, 0, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Whether to show client ids in scoreboard")
+MACRO_CONFIG_INT(ClShowIds, cl_show_ids, 0, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Whether to show client ids in scoreboard")
 MACRO_CONFIG_INT(ClScoreboardOnDeath, cl_scoreboard_on_death, 1, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Whether to show scoreboard after death or not")
 MACRO_CONFIG_INT(ClAutoRaceRecord, cl_auto_race_record, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Save the best demo of each race")
 MACRO_CONFIG_INT(ClReplays, cl_replays, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Enable/disable replays")
@@ -664,7 +664,7 @@ MACRO_CONFIG_INT(Gfx3DTextureAnalysisRan, gfx_3d_texture_analysis_ran, 0, 0, 1, 
 MACRO_CONFIG_STR(Gfx3DTextureAnalysisRenderer, gfx_3d_texture_analysis_renderer, 128, "", CFGFLAG_SAVE | CFGFLAG_CLIENT, "The renderer on which the analysis was performed")
 MACRO_CONFIG_STR(Gfx3DTextureAnalysisVersion, gfx_3d_texture_analysis_version, 128, "", CFGFLAG_SAVE | CFGFLAG_CLIENT, "The version on which the analysis was performed")
 
-MACRO_CONFIG_STR(GfxGPUName, gfx_gpu_name, 256, "auto", CFGFLAG_SAVE | CFGFLAG_CLIENT, "The GPU's name, which will be selected by the backend. (if supported by the backend)")
+MACRO_CONFIG_STR(GfxGpuName, gfx_gpu_name, 256, "auto", CFGFLAG_SAVE | CFGFLAG_CLIENT, "The GPU's name, which will be selected by the backend. (if supported by the backend)")
 #if !defined(CONF_ARCH_IA32) && !defined(CONF_PLATFORM_MACOS)
 MACRO_CONFIG_STR(GfxBackend, gfx_backend, 256, "Vulkan", CFGFLAG_SAVE | CFGFLAG_CLIENT, "The backend to use (e.g. OpenGL or Vulkan)")
 #else

--- a/src/engine/shared/console.cpp
+++ b/src/engine/shared/console.cpp
@@ -402,7 +402,7 @@ bool CConsole::LineIsValid(const char *pStr)
 	return true;
 }
 
-void CConsole::ExecuteLineStroked(int Stroke, const char *pStr, int ClientID, bool InterpretSemicolons)
+void CConsole::ExecuteLineStroked(int Stroke, const char *pStr, int ClientId, bool InterpretSemicolons)
 {
 	const char *pWithoutPrefix = str_startswith(pStr, "mc;");
 	if(pWithoutPrefix)
@@ -413,7 +413,7 @@ void CConsole::ExecuteLineStroked(int Stroke, const char *pStr, int ClientID, bo
 	while(pStr && *pStr)
 	{
 		CResult Result;
-		Result.m_ClientID = ClientID;
+		Result.m_ClientId = ClientId;
 		const char *pEnd = pStr;
 		const char *pNextPart = 0;
 		int InString = 0;
@@ -448,14 +448,14 @@ void CConsole::ExecuteLineStroked(int Stroke, const char *pStr, int ClientID, bo
 			return;
 
 		CCommand *pCommand;
-		if(ClientID == IConsole::CLIENT_ID_GAME)
+		if(ClientId == IConsole::CLIENT_ID_GAME)
 			pCommand = FindCommand(Result.m_pCommand, m_FlagMask | CFGFLAG_GAME);
 		else
 			pCommand = FindCommand(Result.m_pCommand, m_FlagMask);
 
 		if(pCommand)
 		{
-			if(ClientID == IConsole::CLIENT_ID_GAME && !(pCommand->m_Flags & CFGFLAG_GAME))
+			if(ClientId == IConsole::CLIENT_ID_GAME && !(pCommand->m_Flags & CFGFLAG_GAME))
 			{
 				if(Stroke)
 				{
@@ -464,7 +464,7 @@ void CConsole::ExecuteLineStroked(int Stroke, const char *pStr, int ClientID, bo
 					Print(OUTPUT_LEVEL_STANDARD, "console", aBuf);
 				}
 			}
-			else if(ClientID == IConsole::CLIENT_ID_NO_GAME && pCommand->m_Flags & CFGFLAG_GAME)
+			else if(ClientId == IConsole::CLIENT_ID_NO_GAME && pCommand->m_Flags & CFGFLAG_GAME)
 			{
 				if(Stroke)
 				{
@@ -509,11 +509,11 @@ void CConsole::ExecuteLineStroked(int Stroke, const char *pStr, int ClientID, bo
 
 						if(m_pfnTeeHistorianCommandCallback && !(pCommand->m_Flags & CFGFLAG_NONTEEHISTORIC))
 						{
-							m_pfnTeeHistorianCommandCallback(ClientID, m_FlagMask, pCommand->m_pName, &Result, m_pTeeHistorianCommandUserdata);
+							m_pfnTeeHistorianCommandCallback(ClientId, m_FlagMask, pCommand->m_pName, &Result, m_pTeeHistorianCommandUserdata);
 						}
 
 						if(Result.GetVictim() == CResult::VICTIM_ME)
-							Result.SetVictim(ClientID);
+							Result.SetVictim(ClientId);
 
 						if(Result.HasVictim() && Result.GetVictim() == CResult::VICTIM_ALL)
 						{
@@ -590,21 +590,21 @@ CConsole::CCommand *CConsole::FindCommand(const char *pName, int FlagMask)
 	return 0x0;
 }
 
-void CConsole::ExecuteLine(const char *pStr, int ClientID, bool InterpretSemicolons)
+void CConsole::ExecuteLine(const char *pStr, int ClientId, bool InterpretSemicolons)
 {
-	CConsole::ExecuteLineStroked(1, pStr, ClientID, InterpretSemicolons); // press it
-	CConsole::ExecuteLineStroked(0, pStr, ClientID, InterpretSemicolons); // then release it
+	CConsole::ExecuteLineStroked(1, pStr, ClientId, InterpretSemicolons); // press it
+	CConsole::ExecuteLineStroked(0, pStr, ClientId, InterpretSemicolons); // then release it
 }
 
-void CConsole::ExecuteLineFlag(const char *pStr, int FlagMask, int ClientID, bool InterpretSemicolons)
+void CConsole::ExecuteLineFlag(const char *pStr, int FlagMask, int ClientId, bool InterpretSemicolons)
 {
 	int Temp = m_FlagMask;
 	m_FlagMask = FlagMask;
-	ExecuteLine(pStr, ClientID, InterpretSemicolons);
+	ExecuteLine(pStr, ClientId, InterpretSemicolons);
 	m_FlagMask = Temp;
 }
 
-bool CConsole::ExecuteFile(const char *pFilename, int ClientID, bool LogFailure, int StorageType)
+bool CConsole::ExecuteFile(const char *pFilename, int ClientId, bool LogFailure, int StorageType)
 {
 	// make sure that this isn't being executed already
 	for(CExecFile *pCur = m_pFirstExec; pCur; pCur = pCur->m_pPrev)
@@ -636,7 +636,7 @@ bool CConsole::ExecuteFile(const char *pFilename, int ClientID, bool LogFailure,
 
 		char *pLine;
 		while((pLine = Reader.Get()))
-			ExecuteLine(pLine, ClientID);
+			ExecuteLine(pLine, ClientId);
 
 		io_close(File);
 		Success = true;

--- a/src/engine/shared/console.h
+++ b/src/engine/shared/console.h
@@ -61,7 +61,7 @@ class CConsole : public IConsole
 	static void ConCommandAccess(IResult *pResult, void *pUser);
 	static void ConCommandStatus(IConsole::IResult *pResult, void *pUser);
 
-	void ExecuteLineStroked(int Stroke, const char *pStr, int ClientID = -1, bool InterpretSemicolons = true) override;
+	void ExecuteLineStroked(int Stroke, const char *pStr, int ClientId = -1, bool InterpretSemicolons = true) override;
 
 	FTeeHistorianCommandCallback m_pfnTeeHistorianCommandCallback;
 	void *m_pTeeHistorianCommandUserdata;
@@ -207,9 +207,9 @@ public:
 	void StoreCommands(bool Store) override;
 
 	bool LineIsValid(const char *pStr) override;
-	void ExecuteLine(const char *pStr, int ClientID = -1, bool InterpretSemicolons = true) override;
-	void ExecuteLineFlag(const char *pStr, int FlagMask, int ClientID = -1, bool InterpretSemicolons = true) override;
-	bool ExecuteFile(const char *pFilename, int ClientID = -1, bool LogFailure = false, int StorageType = IStorage::TYPE_ALL) override;
+	void ExecuteLine(const char *pStr, int ClientId = -1, bool InterpretSemicolons = true) override;
+	void ExecuteLineFlag(const char *pStr, int FlagMask, int ClientId = -1, bool InterpretSemicolons = true) override;
+	bool ExecuteFile(const char *pFilename, int ClientId = -1, bool LogFailure = false, int StorageType = IStorage::TYPE_ALL) override;
 
 	char *Format(char *pBuf, int Size, const char *pFrom, const char *pStr) override;
 	void Print(int Level, const char *pFrom, const char *pStr, ColorRGBA PrintColor = gs_ConsoleDefaultColor) const override;

--- a/src/engine/shared/datafile.cpp
+++ b/src/engine/shared/datafile.cpp
@@ -53,13 +53,13 @@ struct CDatafileItemType
 
 struct CDatafileItem
 {
-	int m_TypeAndID;
+	int m_TypeAndId;
 	int m_Size;
 };
 
 struct CDatafileHeader
 {
-	char m_aID[4];
+	char m_aId[4];
 	int m_Version;
 	int m_Size;
 	int m_Swaplen;
@@ -72,7 +72,7 @@ struct CDatafileHeader
 	constexpr size_t SizeOffset()
 	{
 		// The size of these members is not included in m_Size and m_Swaplen
-		return sizeof(m_aID) + sizeof(m_Version) + sizeof(m_Size) + sizeof(m_Swaplen);
+		return sizeof(m_aId) + sizeof(m_Version) + sizeof(m_Size) + sizeof(m_Swaplen);
 	}
 };
 
@@ -144,11 +144,11 @@ bool CDataFileReader::Open(class IStorage *pStorage, const char *pFilename, int 
 		dbg_msg("datafile", "couldn't load header");
 		return false;
 	}
-	if(Header.m_aID[0] != 'A' || Header.m_aID[1] != 'T' || Header.m_aID[2] != 'A' || Header.m_aID[3] != 'D')
+	if(Header.m_aId[0] != 'A' || Header.m_aId[1] != 'T' || Header.m_aId[2] != 'A' || Header.m_aId[3] != 'D')
 	{
-		if(Header.m_aID[0] != 'D' || Header.m_aID[1] != 'A' || Header.m_aID[2] != 'T' || Header.m_aID[3] != 'A')
+		if(Header.m_aId[0] != 'D' || Header.m_aId[1] != 'A' || Header.m_aId[2] != 'T' || Header.m_aId[3] != 'A')
 		{
-			dbg_msg("datafile", "wrong signature. %x %x %x %x", Header.m_aID[0], Header.m_aID[1], Header.m_aID[2], Header.m_aID[3]);
+			dbg_msg("datafile", "wrong signature. %x %x %x %x", Header.m_aId[0], Header.m_aId[1], Header.m_aId[2], Header.m_aId[3]);
 			return false;
 		}
 	}
@@ -490,23 +490,23 @@ int CDataFileReader::GetInternalItemType(int ExternalType)
 		{
 			continue;
 		}
-		int ID;
-		if(Uuid == ((const CItemEx *)GetItem(i, nullptr, &ID))->ToUuid())
+		int Id;
+		if(Uuid == ((const CItemEx *)GetItem(i, nullptr, &Id))->ToUuid())
 		{
-			return ID;
+			return Id;
 		}
 	}
 	return -1;
 }
 
-void *CDataFileReader::GetItem(int Index, int *pType, int *pID, CUuid *pUuid)
+void *CDataFileReader::GetItem(int Index, int *pType, int *pId, CUuid *pUuid)
 {
 	if(!m_pDataFile)
 	{
 		if(pType)
 			*pType = 0;
-		if(pID)
-			*pID = 0;
+		if(pId)
+			*pId = 0;
 		if(pUuid)
 			*pUuid = UUID_ZEROED;
 		return nullptr;
@@ -515,14 +515,14 @@ void *CDataFileReader::GetItem(int Index, int *pType, int *pID, CUuid *pUuid)
 	CDatafileItem *pItem = (CDatafileItem *)(m_pDataFile->m_Info.m_pItemStart + m_pDataFile->m_Info.m_pItemOffsets[Index]);
 
 	// remove sign extension
-	const int Type = GetExternalItemType((pItem->m_TypeAndID >> 16) & 0xffff, pUuid);
+	const int Type = GetExternalItemType((pItem->m_TypeAndId >> 16) & 0xffff, pUuid);
 	if(pType)
 	{
 		*pType = Type;
 	}
-	if(pID)
+	if(pId)
 	{
-		*pID = pItem->m_TypeAndID & 0xffff;
+		*pId = pItem->m_TypeAndId & 0xffff;
 	}
 	return (void *)(pItem + 1);
 }
@@ -547,7 +547,7 @@ void CDataFileReader::GetType(int Type, int *pStart, int *pNum)
 	}
 }
 
-int CDataFileReader::FindItemIndex(int Type, int ID)
+int CDataFileReader::FindItemIndex(int Type, int Id)
 {
 	if(!m_pDataFile)
 	{
@@ -558,9 +558,9 @@ int CDataFileReader::FindItemIndex(int Type, int ID)
 	GetType(Type, &Start, &Num);
 	for(int i = 0; i < Num; i++)
 	{
-		int ItemID;
-		GetItem(Start + i, nullptr, &ItemID);
-		if(ID == ItemID)
+		int ItemId;
+		GetItem(Start + i, nullptr, &ItemId);
+		if(Id == ItemId)
 		{
 			return Start + i;
 		}
@@ -568,9 +568,9 @@ int CDataFileReader::FindItemIndex(int Type, int ID)
 	return -1;
 }
 
-void *CDataFileReader::FindItem(int Type, int ID)
+void *CDataFileReader::FindItem(int Type, int Id)
 {
-	int Index = FindItemIndex(Type, ID);
+	int Index = FindItemIndex(Type, Id);
 	if(Index < 0)
 	{
 		return nullptr;
@@ -690,10 +690,10 @@ int CDataFileWriter::GetExtendedItemTypeIndex(int Type, const CUuid *pUuid)
 	return Index;
 }
 
-int CDataFileWriter::AddItem(int Type, int ID, size_t Size, const void *pData, const CUuid *pUuid)
+int CDataFileWriter::AddItem(int Type, int Id, size_t Size, const void *pData, const CUuid *pUuid)
 {
 	dbg_assert((Type >= 0 && Type < MAX_ITEM_TYPES) || Type >= OFFSET_UUID || (Type == -1 && pUuid != nullptr), "Invalid type");
-	dbg_assert(ID >= 0 && ID <= ITEMTYPE_EX, "Invalid ID");
+	dbg_assert(Id >= 0 && Id <= ITEMTYPE_EX, "Invalid ID");
 	dbg_assert(Size == 0 || pData != nullptr, "Data missing"); // Items without data are allowed
 	dbg_assert(Size <= (size_t)std::numeric_limits<int>::max(), "Data too large");
 	dbg_assert(Size % sizeof(int) == 0, "Invalid data boundary");
@@ -707,7 +707,7 @@ int CDataFileWriter::AddItem(int Type, int ID, size_t Size, const void *pData, c
 	m_vItems.emplace_back();
 	CItemInfo &Info = m_vItems.back();
 	Info.m_Type = Type;
-	Info.m_ID = ID;
+	Info.m_Id = Id;
 	Info.m_Size = Size;
 
 	// copy data
@@ -851,10 +851,10 @@ void CDataFileWriter::Finish()
 	// Construct and write header
 	{
 		CDatafileHeader Header;
-		Header.m_aID[0] = 'D';
-		Header.m_aID[1] = 'A';
-		Header.m_aID[2] = 'T';
-		Header.m_aID[3] = 'A';
+		Header.m_aId[0] = 'D';
+		Header.m_aId[1] = 'A';
+		Header.m_aId[2] = 'T';
+		Header.m_aId[3] = 'A';
 		Header.m_Version = 4;
 		Header.m_Size = FileSize - Header.SizeOffset();
 		Header.m_Swaplen = SwapSize - Header.SizeOffset();
@@ -947,11 +947,11 @@ void CDataFileWriter::Finish()
 		for(int ItemIndex = m_aItemTypes[Type].m_First; ItemIndex != -1; ItemIndex = m_vItems[ItemIndex].m_Next)
 		{
 			CDatafileItem Item;
-			Item.m_TypeAndID = (Type << 16) | m_vItems[ItemIndex].m_ID;
+			Item.m_TypeAndId = (Type << 16) | m_vItems[ItemIndex].m_Id;
 			Item.m_Size = m_vItems[ItemIndex].m_Size;
 
 			if(DEBUG)
-				dbg_msg("datafile", "writing item. Type=%x ItemIndex=%d ID=%d Size=%d", Type, ItemIndex, m_vItems[ItemIndex].m_ID, m_vItems[ItemIndex].m_Size);
+				dbg_msg("datafile", "writing item. Type=%x ItemIndex=%d Id=%d Size=%d", Type, ItemIndex, m_vItems[ItemIndex].m_Id, m_vItems[ItemIndex].m_Size);
 
 #if defined(CONF_ARCH_ENDIAN_BIG)
 			swap_endian(&Item, sizeof(int), sizeof(Item) / sizeof(int));

--- a/src/engine/shared/datafile.h
+++ b/src/engine/shared/datafile.h
@@ -54,10 +54,10 @@ public:
 	int NumData() const;
 
 	int GetItemSize(int Index) const;
-	void *GetItem(int Index, int *pType = nullptr, int *pID = nullptr, CUuid *pUuid = nullptr);
+	void *GetItem(int Index, int *pType = nullptr, int *pId = nullptr, CUuid *pUuid = nullptr);
 	void GetType(int Type, int *pStart, int *pNum);
-	int FindItemIndex(int Type, int ID);
-	void *FindItem(int Type, int ID);
+	int FindItemIndex(int Type, int Id);
+	void *FindItem(int Type, int Id);
 	int NumItems() const;
 
 	SHA256_DIGEST Sha256() const;
@@ -88,7 +88,7 @@ private:
 	struct CItemInfo
 	{
 		int m_Type;
-		int m_ID;
+		int m_Id;
 		int m_Size;
 		int m_Next;
 		int m_Prev;
@@ -136,7 +136,7 @@ public:
 	~CDataFileWriter();
 
 	bool Open(class IStorage *pStorage, const char *pFilename, int StorageType = IStorage::TYPE_SAVE);
-	int AddItem(int Type, int ID, size_t Size, const void *pData, const CUuid *pUuid = nullptr);
+	int AddItem(int Type, int Id, size_t Size, const void *pData, const CUuid *pUuid = nullptr);
 	int AddData(size_t Size, const void *pData, ECompressionLevel CompressionLevel = COMPRESSION_DEFAULT);
 	int AddDataSwapped(size_t Size, const void *pData);
 	int AddDataString(const char *pStr);

--- a/src/engine/shared/econ.h
+++ b/src/engine/shared/econ.h
@@ -38,13 +38,13 @@ class CEcon
 
 	bool m_Ready;
 	int m_PrintCBIndex;
-	int m_UserClientID;
+	int m_UserClientId;
 
 	static void SendLineCB(const char *pLine, void *pUserData, ColorRGBA PrintColor = {1, 1, 1, 1});
 	static void ConLogout(IConsole::IResult *pResult, void *pUserData);
 
-	static int NewClientCallback(int ClientID, void *pUser);
-	static int DelClientCallback(int ClientID, const char *pReason, void *pUser);
+	static int NewClientCallback(int ClientId, void *pUser);
+	static int DelClientCallback(int ClientId, const char *pReason, void *pUser);
 
 public:
 	CEcon();
@@ -52,7 +52,7 @@ public:
 
 	void Init(CConfig *pConfig, IConsole *pConsole, CNetBan *pNetBan);
 	void Update();
-	void Send(int ClientID, const char *pLine);
+	void Send(int ClientId, const char *pLine);
 	void Shutdown();
 };
 

--- a/src/engine/shared/map.cpp
+++ b/src/engine/shared/map.cpp
@@ -45,9 +45,9 @@ int CMap::GetItemSize(int Index)
 	return m_DataFile.GetItemSize(Index);
 }
 
-void *CMap::GetItem(int Index, int *pType, int *pID)
+void *CMap::GetItem(int Index, int *pType, int *pId)
 {
-	return m_DataFile.GetItem(Index, pType, pID);
+	return m_DataFile.GetItem(Index, pType, pId);
 }
 
 void CMap::GetType(int Type, int *pStart, int *pNum)
@@ -55,14 +55,14 @@ void CMap::GetType(int Type, int *pStart, int *pNum)
 	m_DataFile.GetType(Type, pStart, pNum);
 }
 
-int CMap::FindItemIndex(int Type, int ID)
+int CMap::FindItemIndex(int Type, int Id)
 {
-	return m_DataFile.FindItemIndex(Type, ID);
+	return m_DataFile.FindItemIndex(Type, Id);
 }
 
-void *CMap::FindItem(int Type, int ID)
+void *CMap::FindItem(int Type, int Id)
 {
-	return m_DataFile.FindItem(Type, ID);
+	return m_DataFile.FindItem(Type, Id);
 }
 
 int CMap::NumItems() const

--- a/src/engine/shared/map.h
+++ b/src/engine/shared/map.h
@@ -25,10 +25,10 @@ public:
 	int NumData() const override;
 
 	int GetItemSize(int Index) override;
-	void *GetItem(int Index, int *pType = nullptr, int *pID = nullptr) override;
+	void *GetItem(int Index, int *pType = nullptr, int *pId = nullptr) override;
 	void GetType(int Type, int *pStart, int *pNum) override;
-	int FindItemIndex(int Type, int ID) override;
-	void *FindItem(int Type, int ID) override;
+	int FindItemIndex(int Type, int Id) override;
+	void *FindItem(int Type, int Id) override;
 	int NumItems() const override;
 
 	bool Load(const char *pMapName) override;

--- a/src/engine/shared/netban.cpp
+++ b/src/engine/shared/netban.cpp
@@ -211,7 +211,7 @@ template<class T>
 int CNetBan::Ban(T *pBanPool, const typename T::CDataType *pData, int Seconds, const char *pReason)
 {
 	// do not ban localhost
-	if(NetMatch(pData, &m_LocalhostIPV4) || NetMatch(pData, &m_LocalhostIPV6))
+	if(NetMatch(pData, &m_LocalhostIpV4) || NetMatch(pData, &m_LocalhostIpV6))
 	{
 		Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "net_ban", "ban failed (localhost)");
 		return -1;
@@ -276,8 +276,8 @@ void CNetBan::Init(IConsole *pConsole, IStorage *pStorage)
 	m_BanAddrPool.Reset();
 	m_BanRangePool.Reset();
 
-	net_host_lookup("localhost", &m_LocalhostIPV4, NETTYPE_IPV4);
-	net_host_lookup("localhost", &m_LocalhostIPV6, NETTYPE_IPV6);
+	net_host_lookup("localhost", &m_LocalhostIpV4, NETTYPE_IPV4);
+	net_host_lookup("localhost", &m_LocalhostIpV6, NETTYPE_IPV6);
 
 	Console()->Register("ban", "s[ip|id] ?i[minutes] r[reason]", CFGFLAG_SERVER | CFGFLAG_MASTER | CFGFLAG_STORE, ConBan, this, "Ban ip for x minutes for any reason");
 	Console()->Register("ban_range", "s[first ip] s[last ip] ?i[minutes] r[reason]", CFGFLAG_SERVER | CFGFLAG_MASTER | CFGFLAG_STORE, ConBanRange, this, "Ban ip range for x minutes for any reason");

--- a/src/engine/shared/netban.h
+++ b/src/engine/shared/netban.h
@@ -158,7 +158,7 @@ protected:
 	class IStorage *m_pStorage;
 	CBanAddrPool m_BanAddrPool;
 	CBanRangePool m_BanRangePool;
-	NETADDR m_LocalhostIPV4, m_LocalhostIPV6;
+	NETADDR m_LocalhostIpV4, m_LocalhostIpV6;
 
 public:
 	enum

--- a/src/engine/shared/network.cpp
+++ b/src/engine/shared/network.cpp
@@ -13,11 +13,11 @@ void CNetRecvUnpacker::Clear()
 	m_Valid = false;
 }
 
-void CNetRecvUnpacker::Start(const NETADDR *pAddr, CNetConnection *pConnection, int ClientID)
+void CNetRecvUnpacker::Start(const NETADDR *pAddr, CNetConnection *pConnection, int ClientId)
 {
 	m_Addr = *pAddr;
 	m_pConnection = pConnection;
-	m_ClientID = ClientID;
+	m_ClientId = ClientId;
 	m_CurrentChunk = 0;
 	m_Valid = true;
 }
@@ -82,7 +82,7 @@ int CNetRecvUnpacker::FetchChunk(CNetChunk *pChunk)
 		}
 
 		// fill in the info
-		pChunk->m_ClientID = m_ClientID;
+		pChunk->m_ClientId = m_ClientId;
 		pChunk->m_Address = m_Addr;
 		pChunk->m_Flags = Header.m_Flags;
 		pChunk->m_DataSize = Header.m_Size;

--- a/src/engine/shared/network.h
+++ b/src/engine/shared/network.h
@@ -107,17 +107,17 @@ enum
 	NET_SECURITY_TOKEN_UNSUPPORTED = 0,
 };
 
-typedef int (*NETFUNC_DELCLIENT)(int ClientID, const char *pReason, void *pUser);
-typedef int (*NETFUNC_NEWCLIENT_CON)(int ClientID, void *pUser);
-typedef int (*NETFUNC_NEWCLIENT)(int ClientID, void *pUser, bool Sixup);
-typedef int (*NETFUNC_NEWCLIENT_NOAUTH)(int ClientID, void *pUser);
-typedef int (*NETFUNC_CLIENTREJOIN)(int ClientID, void *pUser);
+typedef int (*NETFUNC_DELCLIENT)(int ClientId, const char *pReason, void *pUser);
+typedef int (*NETFUNC_NEWCLIENT_CON)(int ClientId, void *pUser);
+typedef int (*NETFUNC_NEWCLIENT)(int ClientId, void *pUser, bool Sixup);
+typedef int (*NETFUNC_NEWCLIENT_NOAUTH)(int ClientId, void *pUser);
+typedef int (*NETFUNC_CLIENTREJOIN)(int ClientId, void *pUser);
 
 struct CNetChunk
 {
 	// -1 means that it's a stateless packet
 	// 0 on the client means the server
-	int m_ClientID;
+	int m_ClientId;
 	NETADDR m_Address; // only used when client_id == -1
 	int m_Flags;
 	int m_DataSize;
@@ -334,13 +334,13 @@ public:
 	NETADDR m_Addr;
 	CNetConnection *m_pConnection;
 	int m_CurrentChunk;
-	int m_ClientID;
+	int m_ClientId;
 	CNetPacketConstruct m_Data;
 	unsigned char m_aBuffer[NET_MAX_PACKETSIZE];
 
 	CNetRecvUnpacker() { Clear(); }
 	void Clear();
-	void Start(const NETADDR *pAddr, CNetConnection *pConnection, int ClientID);
+	void Start(const NETADDR *pAddr, CNetConnection *pConnection, int ClientId);
 	int FetchChunk(CNetChunk *pChunk);
 };
 
@@ -365,7 +365,7 @@ class CNetServer
 	CNetBan *m_pNetBan;
 	CSlot m_aSlots[NET_MAX_CLIENTS];
 	int m_MaxClients;
-	int m_MaxClientsPerIP;
+	int m_MaxClientsPerIp;
 
 	NETFUNC_NEWCLIENT m_pfnNewClient;
 	NETFUNC_NEWCLIENT_NOAUTH m_pfnNewClientNoAuth;
@@ -388,7 +388,7 @@ class CNetServer
 	void OnTokenCtrlMsg(NETADDR &Addr, int ControlMsg, const CNetPacketConstruct &Packet);
 	int OnSixupCtrlMsg(NETADDR &Addr, CNetChunk *pChunk, int ControlMsg, const CNetPacketConstruct &Packet, SECURITY_TOKEN &ResponseToken, SECURITY_TOKEN Token);
 	void OnPreConnMsg(NETADDR &Addr, CNetPacketConstruct &Packet);
-	void OnConnCtrlMsg(NETADDR &Addr, int ClientID, int ControlMsg, const CNetPacketConstruct &Packet);
+	void OnConnCtrlMsg(NETADDR &Addr, int ClientId, int ControlMsg, const CNetPacketConstruct &Packet);
 	bool ClientExists(const NETADDR &Addr) { return GetClientSlot(Addr) != -1; }
 	int GetClientSlot(const NETADDR &Addr);
 	void SendControl(NETADDR &Addr, int ControlMsg, const void *pExtra, int ExtraSize, SECURITY_TOKEN SecurityToken);
@@ -403,7 +403,7 @@ public:
 	int SetCallbacks(NETFUNC_NEWCLIENT pfnNewClient, NETFUNC_NEWCLIENT_NOAUTH pfnNewClientNoAuth, NETFUNC_CLIENTREJOIN pfnClientRejoin, NETFUNC_DELCLIENT pfnDelClient, void *pUser);
 
 	//
-	bool Open(NETADDR BindAddr, CNetBan *pNetBan, int MaxClients, int MaxClientsPerIP);
+	bool Open(NETADDR BindAddr, CNetBan *pNetBan, int MaxClients, int MaxClientsPerIp);
 	int Close();
 
 	//
@@ -412,11 +412,11 @@ public:
 	int Update();
 
 	//
-	int Drop(int ClientID, const char *pReason);
+	int Drop(int ClientId, const char *pReason);
 
 	// status requests
-	const NETADDR *ClientAddr(int ClientID) const { return m_aSlots[ClientID].m_Connection.PeerAddress(); }
-	bool HasSecurityToken(int ClientID) const { return m_aSlots[ClientID].m_Connection.SecurityToken() != NET_SECURITY_TOKEN_UNSUPPORTED; }
+	const NETADDR *ClientAddr(int ClientId) const { return m_aSlots[ClientId].m_Connection.PeerAddress(); }
+	bool HasSecurityToken(int ClientId) const { return m_aSlots[ClientId].m_Connection.SecurityToken() != NET_SECURITY_TOKEN_UNSUPPORTED; }
 	NETADDR Address() const { return m_Address; }
 	NETSOCKET Socket() const { return m_Socket; }
 	CNetBan *NetBan() const { return m_pNetBan; }
@@ -427,12 +427,12 @@ public:
 	int SendConnlessSixup(CNetChunk *pChunk, SECURITY_TOKEN ResponseToken);
 
 	//
-	void SetMaxClientsPerIP(int Max);
-	bool SetTimedOut(int ClientID, int OrigID);
-	void SetTimeoutProtected(int ClientID);
+	void SetMaxClientsPerIp(int Max);
+	bool SetTimedOut(int ClientId, int OrigId);
+	void SetTimeoutProtected(int ClientId);
 
-	int ResetErrorString(int ClientID);
-	const char *ErrorString(int ClientID);
+	int ResetErrorString(int ClientId);
+	const char *ErrorString(int ClientId);
 
 	// anti spoof
 	SECURITY_TOKEN GetGlobalToken();
@@ -466,16 +466,16 @@ public:
 	int Close();
 
 	//
-	int Recv(char *pLine, int MaxLength, int *pClientID = nullptr);
-	int Send(int ClientID, const char *pLine);
+	int Recv(char *pLine, int MaxLength, int *pClientId = nullptr);
+	int Send(int ClientId, const char *pLine);
 	int Update();
 
 	//
 	int AcceptClient(NETSOCKET Socket, const NETADDR *pAddr);
-	int Drop(int ClientID, const char *pReason);
+	int Drop(int ClientId, const char *pReason);
 
 	// status requests
-	const NETADDR *ClientAddr(int ClientID) const { return m_aSlots[ClientID].m_Connection.PeerAddress(); }
+	const NETADDR *ClientAddr(int ClientId) const { return m_aSlots[ClientId].m_Connection.PeerAddress(); }
 	CNetBan *NetBan() const { return m_pNetBan; }
 };
 

--- a/src/engine/shared/network_client.cpp
+++ b/src/engine/shared/network_client.cpp
@@ -90,7 +90,7 @@ int CNetClient::Recv(CNetChunk *pChunk)
 			if(m_RecvUnpacker.m_Data.m_Flags & NET_PACKETFLAG_CONNLESS)
 			{
 				pChunk->m_Flags = NETSENDFLAG_CONNLESS;
-				pChunk->m_ClientID = -1;
+				pChunk->m_ClientId = -1;
 				pChunk->m_Address = Addr;
 				pChunk->m_DataSize = m_RecvUnpacker.m_Data.m_DataSize;
 				pChunk->m_pData = m_RecvUnpacker.m_Data.m_aChunkData;
@@ -128,7 +128,7 @@ int CNetClient::Send(CNetChunk *pChunk)
 	else
 	{
 		int Flags = 0;
-		dbg_assert(pChunk->m_ClientID == 0, "erroneous client id");
+		dbg_assert(pChunk->m_ClientId == 0, "erroneous client id");
 
 		if(pChunk->m_Flags & NETSENDFLAG_VITAL)
 			Flags = NET_CHUNKFLAG_VITAL;

--- a/src/engine/shared/network_console.cpp
+++ b/src/engine/shared/network_console.cpp
@@ -42,12 +42,12 @@ int CNetConsole::Close()
 	return 0;
 }
 
-int CNetConsole::Drop(int ClientID, const char *pReason)
+int CNetConsole::Drop(int ClientId, const char *pReason)
 {
 	if(m_pfnDelClient)
-		m_pfnDelClient(ClientID, pReason, m_pUser);
+		m_pfnDelClient(ClientId, pReason, m_pUser);
 
-	m_aSlots[ClientID].m_Connection.Disconnect(pReason);
+	m_aSlots[ClientId].m_Connection.Disconnect(pReason);
 
 	return 0;
 }
@@ -121,24 +121,24 @@ int CNetConsole::Update()
 	return 0;
 }
 
-int CNetConsole::Recv(char *pLine, int MaxLength, int *pClientID)
+int CNetConsole::Recv(char *pLine, int MaxLength, int *pClientId)
 {
 	for(int i = 0; i < NET_MAX_CONSOLE_CLIENTS; i++)
 	{
 		if(m_aSlots[i].m_Connection.State() == NET_CONNSTATE_ONLINE && m_aSlots[i].m_Connection.Recv(pLine, MaxLength))
 		{
-			if(pClientID)
-				*pClientID = i;
+			if(pClientId)
+				*pClientId = i;
 			return 1;
 		}
 	}
 	return 0;
 }
 
-int CNetConsole::Send(int ClientID, const char *pLine)
+int CNetConsole::Send(int ClientId, const char *pLine)
 {
-	if(m_aSlots[ClientID].m_Connection.State() == NET_CONNSTATE_ONLINE)
-		return m_aSlots[ClientID].m_Connection.Send(pLine);
+	if(m_aSlots[ClientId].m_Connection.State() == NET_CONNSTATE_ONLINE)
+		return m_aSlots[ClientId].m_Connection.Send(pLine);
 	else
 		return -1;
 }

--- a/src/engine/shared/network_server.cpp
+++ b/src/engine/shared/network_server.cpp
@@ -41,7 +41,7 @@ static SECURITY_TOKEN ToSecurityToken(const unsigned char *pData)
 	return (int)pData[0] | (pData[1] << 8) | (pData[2] << 16) | (pData[3] << 24);
 }
 
-bool CNetServer::Open(NETADDR BindAddr, CNetBan *pNetBan, int MaxClients, int MaxClientsPerIP)
+bool CNetServer::Open(NETADDR BindAddr, CNetBan *pNetBan, int MaxClients, int MaxClientsPerIp)
 {
 	// zero out the whole structure
 	this->~CNetServer();
@@ -56,7 +56,7 @@ bool CNetServer::Open(NETADDR BindAddr, CNetBan *pNetBan, int MaxClients, int Ma
 	m_pNetBan = pNetBan;
 
 	m_MaxClients = clamp(MaxClients, 1, (int)NET_MAX_CLIENTS);
-	m_MaxClientsPerIP = MaxClientsPerIP;
+	m_MaxClientsPerIp = MaxClientsPerIp;
 
 	m_NumConAttempts = 0;
 	m_TimeNumConAttempts = time_get();
@@ -97,14 +97,14 @@ int CNetServer::Close()
 	return net_udp_close(m_Socket);
 }
 
-int CNetServer::Drop(int ClientID, const char *pReason)
+int CNetServer::Drop(int ClientId, const char *pReason)
 {
 	// TODO: insert lots of checks here
 
 	if(m_pfnDelClient)
-		m_pfnDelClient(ClientID, pReason, m_pUser);
+		m_pfnDelClient(ClientId, pReason, m_pUser);
 
-	m_aSlots[ClientID].m_Connection.Disconnect(pReason);
+	m_aSlots[ClientId].m_Connection.Disconnect(pReason);
 
 	return 0;
 }
@@ -219,10 +219,10 @@ int CNetServer::TryAcceptClient(NETADDR &Addr, SECURITY_TOKEN SecurityToken, boo
 	}
 
 	// check for sv_max_clients_per_ip
-	if(NumClientsWithAddr(Addr) + 1 > m_MaxClientsPerIP)
+	if(NumClientsWithAddr(Addr) + 1 > m_MaxClientsPerIp)
 	{
 		char aBuf[128];
-		str_format(aBuf, sizeof(aBuf), "Only %d players with the same IP are allowed", m_MaxClientsPerIP);
+		str_format(aBuf, sizeof(aBuf), "Only %d players with the same IP are allowed", m_MaxClientsPerIp);
 		CNetBase::SendControlMsg(m_Socket, &Addr, 0, NET_CTRLMSG_CLOSE, aBuf, str_length(aBuf) + 1, SecurityToken, Sixup);
 		return -1; // failed to add client
 	}
@@ -465,7 +465,7 @@ void CNetServer::OnPreConnMsg(NETADDR &Addr, CNetPacketConstruct &Packet)
 	}
 }
 
-void CNetServer::OnConnCtrlMsg(NETADDR &Addr, int ClientID, int ControlMsg, const CNetPacketConstruct &Packet)
+void CNetServer::OnConnCtrlMsg(NETADDR &Addr, int ClientId, int ControlMsg, const CNetPacketConstruct &Packet)
 {
 	if(ControlMsg == NET_CTRLMSG_CONNECT)
 	{
@@ -483,7 +483,7 @@ void CNetServer::OnConnCtrlMsg(NETADDR &Addr, int ClientID, int ControlMsg, cons
 		}
 
 		if(g_Config.m_Debug)
-			dbg_msg("security", "client %d wants to reconnect", ClientID);
+			dbg_msg("security", "client %d wants to reconnect", ClientId);
 	}
 	else if(ControlMsg == NET_CTRLMSG_ACCEPT && Packet.m_DataSize == 1 + sizeof(SECURITY_TOKEN))
 	{
@@ -493,11 +493,11 @@ void CNetServer::OnConnCtrlMsg(NETADDR &Addr, int ClientID, int ControlMsg, cons
 			// correct token
 			// try to accept client
 			if(g_Config.m_Debug)
-				dbg_msg("security", "client %d reconnect", ClientID);
+				dbg_msg("security", "client %d reconnect", ClientId);
 
 			// reset netconn and process rejoin
-			m_aSlots[ClientID].m_Connection.Reset(true);
-			m_pfnClientRejoin(ClientID, m_pUser);
+			m_aSlots[ClientId].m_Connection.Reset(true);
+			m_pfnClientRejoin(ClientId, m_pUser);
 		}
 	}
 }
@@ -557,7 +557,7 @@ int CNetServer::OnSixupCtrlMsg(NETADDR &Addr, CNetChunk *pChunk, int ControlMsg,
 
 		// Is this behaviour safe to rely on?
 		pChunk->m_Flags = 0;
-		pChunk->m_ClientID = -1;
+		pChunk->m_ClientId = -1;
 		pChunk->m_Address = Addr;
 		pChunk->m_DataSize = 0;
 		return 1;
@@ -654,7 +654,7 @@ int CNetServer::Recv(CNetChunk *pChunk, SECURITY_TOKEN *pResponseToken)
 					continue;
 
 				pChunk->m_Flags = NETSENDFLAG_CONNLESS;
-				pChunk->m_ClientID = -1;
+				pChunk->m_ClientId = -1;
 				pChunk->m_Address = Addr;
 				pChunk->m_DataSize = m_RecvUnpacker.m_Data.m_DataSize;
 				pChunk->m_pData = m_RecvUnpacker.m_Data.m_aChunkData;
@@ -740,20 +740,20 @@ int CNetServer::Send(CNetChunk *pChunk)
 	else
 	{
 		int Flags = 0;
-		dbg_assert(pChunk->m_ClientID >= 0, "erroneous client id");
-		dbg_assert(pChunk->m_ClientID < MaxClients(), "erroneous client id");
+		dbg_assert(pChunk->m_ClientId >= 0, "erroneous client id");
+		dbg_assert(pChunk->m_ClientId < MaxClients(), "erroneous client id");
 
 		if(pChunk->m_Flags & NETSENDFLAG_VITAL)
 			Flags = NET_CHUNKFLAG_VITAL;
 
-		if(m_aSlots[pChunk->m_ClientID].m_Connection.QueueChunk(Flags, pChunk->m_DataSize, pChunk->m_pData) == 0)
+		if(m_aSlots[pChunk->m_ClientId].m_Connection.QueueChunk(Flags, pChunk->m_DataSize, pChunk->m_pData) == 0)
 		{
 			if(pChunk->m_Flags & NETSENDFLAG_FLUSH)
-				m_aSlots[pChunk->m_ClientID].m_Connection.Flush();
+				m_aSlots[pChunk->m_ClientId].m_Connection.Flush();
 		}
 		else
 		{
-			//Drop(pChunk->m_ClientID, "Error sending data");
+			//Drop(pChunk->m_ClientId, "Error sending data");
 		}
 	}
 	return 0;
@@ -784,7 +784,7 @@ int CNetServer::SendConnlessSixup(CNetChunk *pChunk, SECURITY_TOKEN ResponseToke
 	return 0;
 }
 
-void CNetServer::SetMaxClientsPerIP(int Max)
+void CNetServer::SetMaxClientsPerIp(int Max)
 {
 	// clamp
 	if(Max < 1)
@@ -792,31 +792,31 @@ void CNetServer::SetMaxClientsPerIP(int Max)
 	else if(Max > NET_MAX_CLIENTS)
 		Max = NET_MAX_CLIENTS;
 
-	m_MaxClientsPerIP = Max;
+	m_MaxClientsPerIp = Max;
 }
 
-bool CNetServer::SetTimedOut(int ClientID, int OrigID)
+bool CNetServer::SetTimedOut(int ClientId, int OrigId)
 {
-	if(m_aSlots[ClientID].m_Connection.State() != NET_CONNSTATE_ERROR)
+	if(m_aSlots[ClientId].m_Connection.State() != NET_CONNSTATE_ERROR)
 		return false;
 
-	m_aSlots[ClientID].m_Connection.SetTimedOut(ClientAddr(OrigID), m_aSlots[OrigID].m_Connection.SeqSequence(), m_aSlots[OrigID].m_Connection.AckSequence(), m_aSlots[OrigID].m_Connection.SecurityToken(), m_aSlots[OrigID].m_Connection.ResendBuffer(), m_aSlots[OrigID].m_Connection.m_Sixup);
-	m_aSlots[OrigID].m_Connection.Reset();
+	m_aSlots[ClientId].m_Connection.SetTimedOut(ClientAddr(OrigId), m_aSlots[OrigId].m_Connection.SeqSequence(), m_aSlots[OrigId].m_Connection.AckSequence(), m_aSlots[OrigId].m_Connection.SecurityToken(), m_aSlots[OrigId].m_Connection.ResendBuffer(), m_aSlots[OrigId].m_Connection.m_Sixup);
+	m_aSlots[OrigId].m_Connection.Reset();
 	return true;
 }
 
-void CNetServer::SetTimeoutProtected(int ClientID)
+void CNetServer::SetTimeoutProtected(int ClientId)
 {
-	m_aSlots[ClientID].m_Connection.m_TimeoutProtected = true;
+	m_aSlots[ClientId].m_Connection.m_TimeoutProtected = true;
 }
 
-int CNetServer::ResetErrorString(int ClientID)
+int CNetServer::ResetErrorString(int ClientId)
 {
-	m_aSlots[ClientID].m_Connection.ResetErrorString();
+	m_aSlots[ClientId].m_Connection.ResetErrorString();
 	return 0;
 }
 
-const char *CNetServer::ErrorString(int ClientID)
+const char *CNetServer::ErrorString(int ClientId)
 {
-	return m_aSlots[ClientID].m_Connection.ErrorString();
+	return m_aSlots[ClientId].m_Connection.ErrorString();
 }

--- a/src/engine/shared/protocol_ex.cpp
+++ b/src/engine/shared/protocol_ex.cpp
@@ -15,52 +15,52 @@ void RegisterUuids(CUuidManager *pManager)
 #undef UUID
 }
 
-int UnpackMessageID(int *pID, bool *pSys, CUuid *pUuid, CUnpacker *pUnpacker, CMsgPacker *pPacker)
+int UnpackMessageId(int *pId, bool *pSys, CUuid *pUuid, CUnpacker *pUnpacker, CMsgPacker *pPacker)
 {
-	*pID = 0;
+	*pId = 0;
 	*pSys = false;
 	mem_zero(pUuid, sizeof(*pUuid));
 
-	int MsgID = pUnpacker->GetInt();
+	int MsgId = pUnpacker->GetInt();
 
 	if(pUnpacker->Error())
 	{
 		return UNPACKMESSAGE_ERROR;
 	}
 
-	*pID = MsgID >> 1;
-	*pSys = MsgID & 1;
+	*pId = MsgId >> 1;
+	*pSys = MsgId & 1;
 
-	if(*pID < 0 || *pID >= OFFSET_UUID)
+	if(*pId < 0 || *pId >= OFFSET_UUID)
 	{
 		return UNPACKMESSAGE_ERROR;
 	}
 
-	if(*pID != 0) // NETMSG_EX, NETMSGTYPE_EX
+	if(*pId != 0) // NETMSG_EX, NETMSGTYPE_EX
 	{
 		return UNPACKMESSAGE_OK;
 	}
 
-	*pID = g_UuidManager.UnpackUuid(pUnpacker, pUuid);
+	*pId = g_UuidManager.UnpackUuid(pUnpacker, pUuid);
 
-	if(*pID == UUID_INVALID || *pID == UUID_UNKNOWN)
+	if(*pId == UUID_INVALID || *pId == UUID_UNKNOWN)
 	{
 		return UNPACKMESSAGE_ERROR;
 	}
 
 	if(*pSys)
 	{
-		switch(*pID)
+		switch(*pId)
 		{
 		case NETMSG_WHATIS:
 		{
 			CUuid Uuid2;
-			int ID2 = g_UuidManager.UnpackUuid(pUnpacker, &Uuid2);
-			if(ID2 == UUID_INVALID)
+			int Id2 = g_UuidManager.UnpackUuid(pUnpacker, &Uuid2);
+			if(Id2 == UUID_INVALID)
 			{
 				break;
 			}
-			if(ID2 == UUID_UNKNOWN)
+			if(Id2 == UUID_UNKNOWN)
 			{
 				new(pPacker) CMsgPacker(NETMSG_IDONTKNOW, true);
 				pPacker->AddRaw(&Uuid2, sizeof(Uuid2));
@@ -69,7 +69,7 @@ int UnpackMessageID(int *pID, bool *pSys, CUuid *pUuid, CUnpacker *pUnpacker, CM
 			{
 				new(pPacker) CMsgPacker(NETMSG_ITIS, true);
 				pPacker->AddRaw(&Uuid2, sizeof(Uuid2));
-				pPacker->AddString(g_UuidManager.GetName(ID2), 0);
+				pPacker->AddString(g_UuidManager.GetName(Id2), 0);
 			}
 			return UNPACKMESSAGE_ANSWER;
 		}

--- a/src/engine/shared/protocol_ex.h
+++ b/src/engine/shared/protocol_ex.h
@@ -33,8 +33,8 @@ enum
 };
 
 void RegisterUuids(CUuidManager *pManager);
-bool NetworkExDefaultHandler(int *pID, CUuid *pUuid, CUnpacker *pUnpacker, CMsgPacker *pPacker, int Type);
+bool NetworkExDefaultHandler(int *pId, CUuid *pUuid, CUnpacker *pUnpacker, CMsgPacker *pPacker, int Type);
 
-int UnpackMessageID(int *pID, bool *pSys, CUuid *pUuid, CUnpacker *pUnpacker, CMsgPacker *pPacker);
+int UnpackMessageId(int *pId, bool *pSys, CUuid *pUuid, CUnpacker *pUnpacker, CMsgPacker *pPacker);
 
 #endif // ENGINE_SHARED_PROTOCOL_EX_H

--- a/src/engine/shared/snapshot.h
+++ b/src/engine/shared/snapshot.h
@@ -15,12 +15,12 @@ class CSnapshotItem
 	int *Data() { return (int *)(this + 1); }
 
 public:
-	int m_TypeAndID;
+	int m_TypeAndId;
 
 	const int *Data() const { return (int *)(this + 1); }
-	int Type() const { return m_TypeAndID >> 16; }
-	int ID() const { return m_TypeAndID & 0xffff; }
-	int Key() const { return m_TypeAndID; }
+	int Type() const { return m_TypeAndId >> 16; }
+	int Id() const { return m_TypeAndId & 0xffff; }
+	int Key() const { return m_TypeAndId; }
 };
 
 class CSnapshot
@@ -54,7 +54,7 @@ public:
 	int GetItemIndex(int Key) const;
 	int GetItemType(int Index) const;
 	int GetExternalItemType(int InternalType) const;
-	const void *FindItem(int Type, int ID) const;
+	const void *FindItem(int Type, int Id) const;
 
 	unsigned Crc() const;
 	void DebugDump() const;
@@ -151,7 +151,7 @@ class CSnapshotBuilder
 	int m_NumExtendedItemTypes;
 
 	void AddExtendedItemType(int Index);
-	int GetExtendedItemTypeIndex(int TypeID);
+	int GetExtendedItemTypeIndex(int TypeId);
 	int GetTypeFromIndex(int Index) const;
 
 	bool m_Sixup;
@@ -161,7 +161,7 @@ public:
 
 	void Init(bool Sixup = false);
 
-	void *NewItem(int Type, int ID, int Size);
+	void *NewItem(int Type, int Id, int Size);
 
 	CSnapshotItem *GetItem(int Index);
 	int *GetItemData(int Key);

--- a/src/engine/shared/uuid_manager.cpp
+++ b/src/engine/shared/uuid_manager.cpp
@@ -106,19 +106,19 @@ bool CUuid::operator<(const CUuid &Other) const
 	return mem_comp(this, &Other, sizeof(*this)) < 0;
 }
 
-static int GetIndex(int ID)
+static int GetIndex(int Id)
 {
-	return ID - OFFSET_UUID;
+	return Id - OFFSET_UUID;
 }
 
-static int GetID(int Index)
+static int GetId(int Index)
 {
 	return Index + OFFSET_UUID;
 }
 
-void CUuidManager::RegisterName(int ID, const char *pName)
+void CUuidManager::RegisterName(int Id, const char *pName)
 {
-	dbg_assert(GetIndex(ID) == (int)m_vNames.size(), "names must be registered with increasing ID");
+	dbg_assert(GetIndex(Id) == (int)m_vNames.size(), "names must be registered with increasing ID");
 	CName Name;
 	Name.m_pName = pName;
 	Name.m_Uuid = CalculateUuid(pName);
@@ -128,29 +128,29 @@ void CUuidManager::RegisterName(int ID, const char *pName)
 
 	CNameIndexed NameIndexed;
 	NameIndexed.m_Uuid = Name.m_Uuid;
-	NameIndexed.m_ID = GetIndex(ID);
+	NameIndexed.m_Id = GetIndex(Id);
 	m_vNamesSorted.insert(std::lower_bound(m_vNamesSorted.begin(), m_vNamesSorted.end(), NameIndexed), NameIndexed);
 }
 
-CUuid CUuidManager::GetUuid(int ID) const
+CUuid CUuidManager::GetUuid(int Id) const
 {
-	return m_vNames[GetIndex(ID)].m_Uuid;
+	return m_vNames[GetIndex(Id)].m_Uuid;
 }
 
-const char *CUuidManager::GetName(int ID) const
+const char *CUuidManager::GetName(int Id) const
 {
-	return m_vNames[GetIndex(ID)].m_pName;
+	return m_vNames[GetIndex(Id)].m_pName;
 }
 
 int CUuidManager::LookupUuid(CUuid Uuid) const
 {
 	CNameIndexed Needle;
 	Needle.m_Uuid = Uuid;
-	Needle.m_ID = 0;
+	Needle.m_Id = 0;
 	auto Range = std::equal_range(m_vNamesSorted.begin(), m_vNamesSorted.end(), Needle);
 	if(std::distance(Range.first, Range.second) == 1)
 	{
-		return GetID(Range.first->m_ID);
+		return GetId(Range.first->m_Id);
 	}
 	return UUID_UNKNOWN;
 }
@@ -177,9 +177,9 @@ int CUuidManager::UnpackUuid(CUnpacker *pUnpacker, CUuid *pOut) const
 	return LookupUuid(*pUuid);
 }
 
-void CUuidManager::PackUuid(int ID, CPacker *pPacker) const
+void CUuidManager::PackUuid(int Id, CPacker *pPacker) const
 {
-	CUuid Uuid = GetUuid(ID);
+	CUuid Uuid = GetUuid(Id);
 	pPacker->AddRaw(&Uuid, sizeof(Uuid));
 }
 

--- a/src/engine/shared/uuid_manager.h
+++ b/src/engine/shared/uuid_manager.h
@@ -40,7 +40,7 @@ struct CName
 struct CNameIndexed
 {
 	CUuid m_Uuid;
-	int m_ID;
+	int m_Id;
 
 	bool operator<(const CNameIndexed &Other) const { return m_Uuid < Other.m_Uuid; }
 	bool operator==(const CNameIndexed &Other) const { return m_Uuid == Other.m_Uuid; }
@@ -55,15 +55,15 @@ class CUuidManager
 	std::vector<CNameIndexed> m_vNamesSorted;
 
 public:
-	void RegisterName(int ID, const char *pName);
-	CUuid GetUuid(int ID) const;
-	const char *GetName(int ID) const;
+	void RegisterName(int Id, const char *pName);
+	CUuid GetUuid(int Id) const;
+	const char *GetName(int Id) const;
 	int LookupUuid(CUuid Uuid) const;
 	int NumUuids() const;
 
 	int UnpackUuid(CUnpacker *pUnpacker) const;
 	int UnpackUuid(CUnpacker *pUnpacker, CUuid *pOut) const;
-	void PackUuid(int ID, CPacker *pPacker) const;
+	void PackUuid(int Id, CPacker *pPacker) const;
 
 	void DebugDump() const;
 };

--- a/src/engine/sound.h
+++ b/src/engine/sound.h
@@ -28,7 +28,7 @@ public:
 	// unused
 	struct CSampleHandle
 	{
-		int m_SampleID;
+		int m_SampleId;
 	};
 
 	struct CVoiceShapeCircle
@@ -67,13 +67,13 @@ public:
 	virtual int LoadWV(const char *pFilename, int StorageType = IStorage::TYPE_ALL) = 0;
 	virtual int LoadOpusFromMem(const void *pData, unsigned DataSize, bool FromEditor = false) = 0;
 	virtual int LoadWVFromMem(const void *pData, unsigned DataSize, bool FromEditor = false) = 0;
-	virtual void UnloadSample(int SampleID) = 0;
+	virtual void UnloadSample(int SampleId) = 0;
 
-	virtual float GetSampleTotalTime(int SampleID) = 0; // in s
-	virtual float GetSampleCurrentTime(int SampleID) = 0; // in s
-	virtual void SetSampleCurrentTime(int SampleID, float Time) = 0;
+	virtual float GetSampleTotalTime(int SampleId) = 0; // in s
+	virtual float GetSampleCurrentTime(int SampleId) = 0; // in s
+	virtual void SetSampleCurrentTime(int SampleId, float Time) = 0;
 
-	virtual void SetChannel(int ChannelID, float Volume, float Panning) = 0;
+	virtual void SetChannel(int ChannelId, float Volume, float Panning) = 0;
 	virtual void SetListenerPos(float x, float y) = 0;
 
 	virtual void SetVoiceVolume(CVoiceHandle Voice, float Volume) = 0;
@@ -84,13 +84,13 @@ public:
 	virtual void SetVoiceCircle(CVoiceHandle Voice, float Radius) = 0;
 	virtual void SetVoiceRectangle(CVoiceHandle Voice, float Width, float Height) = 0;
 
-	virtual CVoiceHandle PlayAt(int ChannelID, int SampleID, int Flags, float x, float y) = 0;
-	virtual CVoiceHandle Play(int ChannelID, int SampleID, int Flags) = 0;
-	virtual void Pause(int SampleID) = 0;
-	virtual void Stop(int SampleID) = 0;
+	virtual CVoiceHandle PlayAt(int ChannelId, int SampleId, int Flags, float x, float y) = 0;
+	virtual CVoiceHandle Play(int ChannelId, int SampleId, int Flags) = 0;
+	virtual void Pause(int SampleId) = 0;
+	virtual void Stop(int SampleId) = 0;
 	virtual void StopAll() = 0;
 	virtual void StopVoice(CVoiceHandle Voice) = 0;
-	virtual bool IsPlaying(int SampleID) = 0;
+	virtual bool IsPlaying(int SampleId) = 0;
 
 	virtual void Mix(short *pFinalOut, unsigned Frames) = 0;
 	// useful for thread synchronization

--- a/src/game/client/component.cpp
+++ b/src/game/client/component.cpp
@@ -8,7 +8,7 @@ class IGraphics *CComponent::Graphics() const { return m_pClient->Graphics(); }
 class ITextRender *CComponent::TextRender() const { return m_pClient->TextRender(); }
 class IInput *CComponent::Input() const { return m_pClient->Input(); }
 class IStorage *CComponent::Storage() const { return m_pClient->Storage(); }
-class CUI *CComponent::UI() const { return m_pClient->UI(); }
+class CUi *CComponent::Ui() const { return m_pClient->Ui(); }
 class ISound *CComponent::Sound() const { return m_pClient->Sound(); }
 class CRenderTools *CComponent::RenderTools() const { return m_pClient->RenderTools(); }
 class IConfigManager *CComponent::ConfigManager() const { return m_pClient->ConfigManager(); }

--- a/src/game/client/component.h
+++ b/src/game/client/component.h
@@ -49,7 +49,7 @@ protected:
 	/**
 	 * Get the ui interface.
 	 */
-	class CUI *UI() const;
+	class CUi *Ui() const;
 	/**
 	 * Get the sound interface.
 	 */

--- a/src/game/client/components/binds.cpp
+++ b/src/game/client/components/binds.cpp
@@ -49,16 +49,16 @@ CBinds::~CBinds()
 			free(apKeyBinding[i]);
 }
 
-void CBinds::Bind(int KeyID, const char *pStr, bool FreeOnly, int ModifierCombination)
+void CBinds::Bind(int KeyId, const char *pStr, bool FreeOnly, int ModifierCombination)
 {
-	if(KeyID < 0 || KeyID >= KEY_LAST)
+	if(KeyId < 0 || KeyId >= KEY_LAST)
 		return;
 
-	if(FreeOnly && Get(KeyID, ModifierCombination)[0])
+	if(FreeOnly && Get(KeyId, ModifierCombination)[0])
 		return;
 
-	free(m_aapKeyBindings[ModifierCombination][KeyID]);
-	m_aapKeyBindings[ModifierCombination][KeyID] = 0;
+	free(m_aapKeyBindings[ModifierCombination][KeyId]);
+	m_aapKeyBindings[ModifierCombination][KeyId] = 0;
 
 	// skip modifiers for +xxx binds
 	if(pStr[0] == '+')
@@ -67,14 +67,14 @@ void CBinds::Bind(int KeyID, const char *pStr, bool FreeOnly, int ModifierCombin
 	char aBuf[256];
 	if(!pStr[0])
 	{
-		str_format(aBuf, sizeof(aBuf), "unbound %s%s (%d)", GetKeyBindModifiersName(ModifierCombination), Input()->KeyName(KeyID), KeyID);
+		str_format(aBuf, sizeof(aBuf), "unbound %s%s (%d)", GetKeyBindModifiersName(ModifierCombination), Input()->KeyName(KeyId), KeyId);
 	}
 	else
 	{
 		int Size = str_length(pStr) + 1;
-		m_aapKeyBindings[ModifierCombination][KeyID] = (char *)malloc(Size);
-		str_copy(m_aapKeyBindings[ModifierCombination][KeyID], pStr, Size);
-		str_format(aBuf, sizeof(aBuf), "bound %s%s (%d) = %s", GetKeyBindModifiersName(ModifierCombination), Input()->KeyName(KeyID), KeyID, m_aapKeyBindings[ModifierCombination][KeyID]);
+		m_aapKeyBindings[ModifierCombination][KeyId] = (char *)malloc(Size);
+		str_copy(m_aapKeyBindings[ModifierCombination][KeyId], pStr, Size);
+		str_format(aBuf, sizeof(aBuf), "bound %s%s (%d) = %s", GetKeyBindModifiersName(ModifierCombination), Input()->KeyName(KeyId), KeyId, m_aapKeyBindings[ModifierCombination][KeyId]);
 	}
 	Console()->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "binds", aBuf, gs_BindPrintColor);
 }
@@ -187,10 +187,10 @@ void CBinds::UnbindAll()
 	}
 }
 
-const char *CBinds::Get(int KeyID, int ModifierCombination)
+const char *CBinds::Get(int KeyId, int ModifierCombination)
 {
-	if(KeyID > 0 && KeyID < KEY_LAST && m_aapKeyBindings[ModifierCombination][KeyID])
-		return m_aapKeyBindings[ModifierCombination][KeyID];
+	if(KeyId > 0 && KeyId < KEY_LAST && m_aapKeyBindings[ModifierCombination][KeyId])
+		return m_aapKeyBindings[ModifierCombination][KeyId];
 	return "";
 }
 
@@ -283,9 +283,9 @@ void CBinds::ConBind(IConsole::IResult *pResult, void *pUserData)
 	CBinds *pBinds = (CBinds *)pUserData;
 	const char *pBindStr = pResult->GetString(0);
 	int Modifier;
-	int KeyID = pBinds->GetBindSlot(pBindStr, &Modifier);
+	int KeyId = pBinds->GetBindSlot(pBindStr, &Modifier);
 
-	if(!KeyID)
+	if(!KeyId)
 	{
 		char aBuf[256];
 		str_format(aBuf, sizeof(aBuf), "key %s not found", pBindStr);
@@ -298,16 +298,16 @@ void CBinds::ConBind(IConsole::IResult *pResult, void *pUserData)
 		char aBuf[256];
 		const char *pKeyName = pResult->GetString(0);
 
-		if(!pBinds->m_aapKeyBindings[Modifier][KeyID])
-			str_format(aBuf, sizeof(aBuf), "%s (%d) is not bound", pKeyName, KeyID);
+		if(!pBinds->m_aapKeyBindings[Modifier][KeyId])
+			str_format(aBuf, sizeof(aBuf), "%s (%d) is not bound", pKeyName, KeyId);
 		else
-			str_format(aBuf, sizeof(aBuf), "%s (%d) = %s", pKeyName, KeyID, pBinds->m_aapKeyBindings[Modifier][KeyID]);
+			str_format(aBuf, sizeof(aBuf), "%s (%d) = %s", pKeyName, KeyId, pBinds->m_aapKeyBindings[Modifier][KeyId]);
 
 		pBinds->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "binds", aBuf, gs_BindPrintColor);
 		return;
 	}
 
-	pBinds->Bind(KeyID, pResult->GetString(1), false, Modifier);
+	pBinds->Bind(KeyId, pResult->GetString(1), false, Modifier);
 }
 
 void CBinds::ConBinds(IConsole::IResult *pResult, void *pUserData)
@@ -319,18 +319,18 @@ void CBinds::ConBinds(IConsole::IResult *pResult, void *pUserData)
 		const char *pKeyName = pResult->GetString(0);
 
 		int Modifier;
-		int KeyID = pBinds->GetBindSlot(pKeyName, &Modifier);
-		if(!KeyID)
+		int KeyId = pBinds->GetBindSlot(pKeyName, &Modifier);
+		if(!KeyId)
 		{
 			str_format(aBuf, sizeof(aBuf), "key '%s' not found", pKeyName);
 			pBinds->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "binds", aBuf, gs_BindPrintColor);
 		}
 		else
 		{
-			if(!pBinds->m_aapKeyBindings[Modifier][KeyID])
-				str_format(aBuf, sizeof(aBuf), "%s (%d) is not bound", pKeyName, KeyID);
+			if(!pBinds->m_aapKeyBindings[Modifier][KeyId])
+				str_format(aBuf, sizeof(aBuf), "%s (%d) is not bound", pKeyName, KeyId);
 			else
-				str_format(aBuf, sizeof(aBuf), "%s (%d) = %s", pKeyName, KeyID, pBinds->m_aapKeyBindings[Modifier][KeyID]);
+				str_format(aBuf, sizeof(aBuf), "%s (%d) = %s", pKeyName, KeyId, pBinds->m_aapKeyBindings[Modifier][KeyId]);
 
 			pBinds->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "binds", aBuf, gs_BindPrintColor);
 		}
@@ -357,9 +357,9 @@ void CBinds::ConUnbind(IConsole::IResult *pResult, void *pUserData)
 	CBinds *pBinds = (CBinds *)pUserData;
 	const char *pKeyName = pResult->GetString(0);
 	int Modifier;
-	int KeyID = pBinds->GetBindSlot(pKeyName, &Modifier);
+	int KeyId = pBinds->GetBindSlot(pKeyName, &Modifier);
 
-	if(!KeyID)
+	if(!KeyId)
 	{
 		char aBuf[256];
 		str_format(aBuf, sizeof(aBuf), "key %s not found", pKeyName);
@@ -367,7 +367,7 @@ void CBinds::ConUnbind(IConsole::IResult *pResult, void *pUserData)
 		return;
 	}
 
-	pBinds->Bind(KeyID, "", false, Modifier);
+	pBinds->Bind(KeyId, "", false, Modifier);
 }
 
 void CBinds::ConUnbindAll(IConsole::IResult *pResult, void *pUserData)
@@ -376,7 +376,7 @@ void CBinds::ConUnbindAll(IConsole::IResult *pResult, void *pUserData)
 	pBinds->UnbindAll();
 }
 
-int CBinds::GetKeyID(const char *pKeyName)
+int CBinds::GetKeyId(const char *pKeyName)
 {
 	// check for numeric
 	if(pKeyName[0] == '&')
@@ -420,7 +420,7 @@ int CBinds::GetBindSlot(const char *pBindString, int *pModifierCombination)
 		else
 			break;
 	}
-	return GetKeyID(*pModifierCombination == MODIFIER_NONE ? aMod : pKey + 1);
+	return GetKeyId(*pModifierCombination == MODIFIER_NONE ? aMod : pKey + 1);
 }
 
 const char *CBinds::GetModifierName(int Modifier)

--- a/src/game/client/components/binds.h
+++ b/src/game/client/components/binds.h
@@ -12,7 +12,7 @@ class IConfigManager;
 
 class CBinds : public CComponent
 {
-	int GetKeyID(const char *pKeyName);
+	int GetKeyId(const char *pKeyName);
 
 	static void ConBind(IConsole::IResult *pResult, void *pUserData);
 	static void ConBinds(IConsole::IResult *pResult, void *pUserData);
@@ -50,10 +50,10 @@ public:
 
 	CBindsSpecial m_SpecialBinds;
 
-	void Bind(int KeyID, const char *pStr, bool FreeOnly = false, int ModifierCombination = MODIFIER_NONE);
+	void Bind(int KeyId, const char *pStr, bool FreeOnly = false, int ModifierCombination = MODIFIER_NONE);
 	void SetDefaults();
 	void UnbindAll();
-	const char *Get(int KeyID, int ModifierCombination);
+	const char *Get(int KeyId, int ModifierCombination);
 	void GetKey(const char *pBindStr, char *pBuf, size_t BufSize);
 	int GetBindSlot(const char *pBindString, int *pModifierCombination);
 	static int GetModifierMask(IInput *pInput);

--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -303,11 +303,11 @@ bool CChat::OnInput(const IInput::CEvent &Event)
 			{
 				if(PlayerInfo)
 				{
-					PlayerName = m_pClient->m_aClients[PlayerInfo->m_ClientID].m_aName;
+					PlayerName = m_pClient->m_aClients[PlayerInfo->m_ClientId].m_aName;
 					FoundInput = str_utf8_find_nocase(PlayerName, m_aCompletionBuffer);
 					if(FoundInput != 0)
 					{
-						m_aPlayerCompletionList[m_PlayerCompletionListLength].ClientID = PlayerInfo->m_ClientID;
+						m_aPlayerCompletionList[m_PlayerCompletionListLength].ClientId = PlayerInfo->m_ClientId;
 						// The score for suggesting a player name is determined by the distance of the search input to the beginning of the player name
 						m_aPlayerCompletionList[m_PlayerCompletionListLength].Score = (int)(FoundInput - PlayerName);
 						m_PlayerCompletionListLength++;
@@ -411,7 +411,7 @@ bool CChat::OnInput(const IInput::CEvent &Event)
 					m_CompletionChosen %= m_PlayerCompletionListLength;
 					m_CompletionUsed = true;
 
-					pCompletionClientData = &m_pClient->m_aClients[m_aPlayerCompletionList[m_CompletionChosen].ClientID];
+					pCompletionClientData = &m_pClient->m_aClients[m_aPlayerCompletionList[m_CompletionChosen].ClientId];
 					if(!pCompletionClientData->m_Active)
 					{
 						continue;
@@ -551,7 +551,7 @@ void CChat::OnMessage(int MsgType, void *pRawMsg)
 	if(MsgType == NETMSGTYPE_SV_CHAT)
 	{
 		CNetMsg_Sv_Chat *pMsg = (CNetMsg_Sv_Chat *)pRawMsg;
-		AddLine(pMsg->m_ClientID, pMsg->m_Team, pMsg->m_pMessage);
+		AddLine(pMsg->m_ClientId, pMsg->m_Team, pMsg->m_pMessage);
 	}
 	else if(MsgType == NETMSGTYPE_SV_COMMANDINFO)
 	{
@@ -644,14 +644,14 @@ void CChat::StoreSave(const char *pText)
 	io_close(File);
 }
 
-void CChat::AddLine(int ClientID, int Team, const char *pLine)
+void CChat::AddLine(int ClientId, int Team, const char *pLine)
 {
 	if(*pLine == 0 ||
-		(ClientID == SERVER_MSG && !g_Config.m_ClShowChatSystem) ||
-		(ClientID >= 0 && (m_pClient->m_aClients[ClientID].m_aName[0] == '\0' || // unknown client
-					  m_pClient->m_aClients[ClientID].m_ChatIgnore ||
-					  (m_pClient->m_Snap.m_LocalClientID != ClientID && g_Config.m_ClShowChatFriends && !m_pClient->m_aClients[ClientID].m_Friend) ||
-					  (m_pClient->m_Snap.m_LocalClientID != ClientID && m_pClient->m_aClients[ClientID].m_Foe))))
+		(ClientId == SERVER_MSG && !g_Config.m_ClShowChatSystem) ||
+		(ClientId >= 0 && (m_pClient->m_aClients[ClientId].m_aName[0] == '\0' || // unknown client
+					  m_pClient->m_aClients[ClientId].m_ChatIgnore ||
+					  (m_pClient->m_Snap.m_LocalClientId != ClientId && g_Config.m_ClShowChatFriends && !m_pClient->m_aClients[ClientId].m_Friend) ||
+					  (m_pClient->m_Snap.m_LocalClientId != ClientId && m_pClient->m_aClients[ClientId].m_Foe))))
 		return;
 
 	// trim right and set maximum length to 256 utf8-characters
@@ -688,14 +688,14 @@ void CChat::AddLine(int ClientID, int Team, const char *pLine)
 		return;
 
 	auto &&FChatMsgCheckAndPrint = [this](CLine *pLine_) {
-		if(pLine_->m_ClientID < 0) // server or client message
+		if(pLine_->m_ClientId < 0) // server or client message
 		{
 			if(Client()->State() != IClient::STATE_DEMOPLAYBACK)
 				StoreSave(pLine_->m_aText);
 		}
 
 		char aBuf[1024];
-		str_format(aBuf, sizeof(aBuf), "%s%s%s", pLine_->m_aName, pLine_->m_ClientID >= 0 ? ": " : "", pLine_->m_aText);
+		str_format(aBuf, sizeof(aBuf), "%s%s%s", pLine_->m_aName, pLine_->m_ClientId >= 0 ? ": " : "", pLine_->m_aText);
 
 		ColorRGBA ChatLogColor{1, 1, 1, 1};
 		if(pLine_->m_Highlighted)
@@ -708,9 +708,9 @@ void CChat::AddLine(int ClientID, int Team, const char *pLine)
 				ChatLogColor = color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClMessageFriendColor));
 			else if(pLine_->m_Team)
 				ChatLogColor = color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClMessageTeamColor));
-			else if(pLine_->m_ClientID == SERVER_MSG)
+			else if(pLine_->m_ClientId == SERVER_MSG)
 				ChatLogColor = color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClMessageSystemColor));
-			else if(pLine_->m_ClientID == CLIENT_MSG)
+			else if(pLine_->m_ClientId == CLIENT_MSG)
 				ChatLogColor = color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClMessageClientColor));
 			else // regular message
 				ChatLogColor = color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClMessageColor));
@@ -739,7 +739,7 @@ void CChat::AddLine(int ClientID, int Team, const char *pLine)
 		// 0 = global; 1 = team; 2 = sending whisper; 3 = receiving whisper
 
 		// If it's a client message, m_aText will have ": " prepended so we have to work around it.
-		if(pCurrentLine->m_TeamNumber == Team && pCurrentLine->m_ClientID == ClientID && str_comp(pCurrentLine->m_aText, pLine) == 0)
+		if(pCurrentLine->m_TeamNumber == Team && pCurrentLine->m_ClientId == ClientId && str_comp(pCurrentLine->m_aText, pLine) == 0)
 		{
 			pCurrentLine->m_TimesRepeated++;
 			TextRender()->DeleteTextContainer(pCurrentLine->m_TextContainerIndex);
@@ -759,7 +759,7 @@ void CChat::AddLine(int ClientID, int Team, const char *pLine)
 		pCurrentLine->m_Time = time();
 		pCurrentLine->m_aYOffset[0] = -1.0f;
 		pCurrentLine->m_aYOffset[1] = -1.0f;
-		pCurrentLine->m_ClientID = ClientID;
+		pCurrentLine->m_ClientId = ClientId;
 		pCurrentLine->m_TeamNumber = Team;
 		pCurrentLine->m_Team = Team == 1;
 		pCurrentLine->m_Whisper = Team >= 2;
@@ -771,86 +771,86 @@ void CChat::AddLine(int ClientID, int Team, const char *pLine)
 		// check for highlighted name
 		if(Client()->State() != IClient::STATE_DEMOPLAYBACK)
 		{
-			if(ClientID >= 0 && ClientID != m_pClient->m_aLocalIDs[0] && (!m_pClient->Client()->DummyConnected() || ClientID != m_pClient->m_aLocalIDs[1]))
+			if(ClientId >= 0 && ClientId != m_pClient->m_aLocalIds[0] && (!m_pClient->Client()->DummyConnected() || ClientId != m_pClient->m_aLocalIds[1]))
 			{
 				// main character
-				Highlighted |= LineShouldHighlight(pLine, m_pClient->m_aClients[m_pClient->m_aLocalIDs[0]].m_aName);
+				Highlighted |= LineShouldHighlight(pLine, m_pClient->m_aClients[m_pClient->m_aLocalIds[0]].m_aName);
 				// dummy
-				Highlighted |= m_pClient->Client()->DummyConnected() && LineShouldHighlight(pLine, m_pClient->m_aClients[m_pClient->m_aLocalIDs[1]].m_aName);
+				Highlighted |= m_pClient->Client()->DummyConnected() && LineShouldHighlight(pLine, m_pClient->m_aClients[m_pClient->m_aLocalIds[1]].m_aName);
 			}
 		}
 		else
 		{
 			// on demo playback use local id from snap directly,
-			// since m_aLocalIDs isn't valid there
-			Highlighted |= m_pClient->m_Snap.m_LocalClientID >= 0 && LineShouldHighlight(pLine, m_pClient->m_aClients[m_pClient->m_Snap.m_LocalClientID].m_aName);
+			// since m_aLocalIds isn't valid there
+			Highlighted |= m_pClient->m_Snap.m_LocalClientId >= 0 && LineShouldHighlight(pLine, m_pClient->m_aClients[m_pClient->m_Snap.m_LocalClientId].m_aName);
 		}
 
 		pCurrentLine->m_Highlighted = Highlighted;
 
-		if(pCurrentLine->m_ClientID == SERVER_MSG)
+		if(pCurrentLine->m_ClientId == SERVER_MSG)
 		{
 			str_copy(pCurrentLine->m_aName, "*** ");
 			str_copy(pCurrentLine->m_aText, pLine);
 		}
-		else if(pCurrentLine->m_ClientID == CLIENT_MSG)
+		else if(pCurrentLine->m_ClientId == CLIENT_MSG)
 		{
 			str_copy(pCurrentLine->m_aName, "— ");
 			str_copy(pCurrentLine->m_aText, pLine);
 		}
 		else
 		{
-			if(m_pClient->m_aClients[ClientID].m_Team == TEAM_SPECTATORS)
+			if(m_pClient->m_aClients[ClientId].m_Team == TEAM_SPECTATORS)
 				pCurrentLine->m_NameColor = TEAM_SPECTATORS;
 
 			if(m_pClient->m_Snap.m_pGameInfoObj && m_pClient->m_Snap.m_pGameInfoObj->m_GameFlags & GAMEFLAG_TEAMS)
 			{
-				if(m_pClient->m_aClients[ClientID].m_Team == TEAM_RED)
+				if(m_pClient->m_aClients[ClientId].m_Team == TEAM_RED)
 					pCurrentLine->m_NameColor = TEAM_RED;
-				else if(m_pClient->m_aClients[ClientID].m_Team == TEAM_BLUE)
+				else if(m_pClient->m_aClients[ClientId].m_Team == TEAM_BLUE)
 					pCurrentLine->m_NameColor = TEAM_BLUE;
 			}
 
 			if(Team == 2) // whisper send
 			{
-				str_format(pCurrentLine->m_aName, sizeof(pCurrentLine->m_aName), "→ %s", m_pClient->m_aClients[ClientID].m_aName);
+				str_format(pCurrentLine->m_aName, sizeof(pCurrentLine->m_aName), "→ %s", m_pClient->m_aClients[ClientId].m_aName);
 				pCurrentLine->m_NameColor = TEAM_BLUE;
 				pCurrentLine->m_Highlighted = false;
 				Highlighted = false;
 			}
 			else if(Team == 3) // whisper recv
 			{
-				str_format(pCurrentLine->m_aName, sizeof(pCurrentLine->m_aName), "← %s", m_pClient->m_aClients[ClientID].m_aName);
+				str_format(pCurrentLine->m_aName, sizeof(pCurrentLine->m_aName), "← %s", m_pClient->m_aClients[ClientId].m_aName);
 				pCurrentLine->m_NameColor = TEAM_RED;
 				pCurrentLine->m_Highlighted = true;
 				Highlighted = true;
 			}
 			else
-				str_copy(pCurrentLine->m_aName, m_pClient->m_aClients[ClientID].m_aName);
+				str_copy(pCurrentLine->m_aName, m_pClient->m_aClients[ClientId].m_aName);
 
 			str_copy(pCurrentLine->m_aText, pLine);
-			pCurrentLine->m_Friend = m_pClient->m_aClients[ClientID].m_Friend;
+			pCurrentLine->m_Friend = m_pClient->m_aClients[ClientId].m_Friend;
 		}
 
 		pCurrentLine->m_HasRenderTee = false;
 
-		pCurrentLine->m_Friend = ClientID >= 0 ? m_pClient->m_aClients[ClientID].m_Friend : false;
+		pCurrentLine->m_Friend = ClientId >= 0 ? m_pClient->m_aClients[ClientId].m_Friend : false;
 
-		if(pCurrentLine->m_ClientID >= 0 && pCurrentLine->m_aName[0] != '\0')
+		if(pCurrentLine->m_ClientId >= 0 && pCurrentLine->m_aName[0] != '\0')
 		{
 			if(!g_Config.m_ClChatOld)
 			{
-				pCurrentLine->m_CustomColoredSkin = m_pClient->m_aClients[pCurrentLine->m_ClientID].m_RenderInfo.m_CustomColoredSkin;
+				pCurrentLine->m_CustomColoredSkin = m_pClient->m_aClients[pCurrentLine->m_ClientId].m_RenderInfo.m_CustomColoredSkin;
 				if(pCurrentLine->m_CustomColoredSkin)
-					pCurrentLine->m_RenderSkin = m_pClient->m_aClients[pCurrentLine->m_ClientID].m_RenderInfo.m_ColorableRenderSkin;
+					pCurrentLine->m_RenderSkin = m_pClient->m_aClients[pCurrentLine->m_ClientId].m_RenderInfo.m_ColorableRenderSkin;
 				else
-					pCurrentLine->m_RenderSkin = m_pClient->m_aClients[pCurrentLine->m_ClientID].m_RenderInfo.m_OriginalRenderSkin;
+					pCurrentLine->m_RenderSkin = m_pClient->m_aClients[pCurrentLine->m_ClientId].m_RenderInfo.m_OriginalRenderSkin;
 
-				str_copy(pCurrentLine->m_aSkinName, m_pClient->m_aClients[pCurrentLine->m_ClientID].m_aSkinName);
-				pCurrentLine->m_ColorBody = m_pClient->m_aClients[pCurrentLine->m_ClientID].m_RenderInfo.m_ColorBody;
-				pCurrentLine->m_ColorFeet = m_pClient->m_aClients[pCurrentLine->m_ClientID].m_RenderInfo.m_ColorFeet;
+				str_copy(pCurrentLine->m_aSkinName, m_pClient->m_aClients[pCurrentLine->m_ClientId].m_aSkinName);
+				pCurrentLine->m_ColorBody = m_pClient->m_aClients[pCurrentLine->m_ClientId].m_RenderInfo.m_ColorBody;
+				pCurrentLine->m_ColorFeet = m_pClient->m_aClients[pCurrentLine->m_ClientId].m_RenderInfo.m_ColorFeet;
 
-				pCurrentLine->m_RenderSkinMetrics = m_pClient->m_aClients[pCurrentLine->m_ClientID].m_RenderInfo.m_SkinMetrics;
+				pCurrentLine->m_RenderSkinMetrics = m_pClient->m_aClients[pCurrentLine->m_ClientId].m_RenderInfo.m_SkinMetrics;
 				pCurrentLine->m_HasRenderTee = true;
 			}
 		}
@@ -860,7 +860,7 @@ void CChat::AddLine(int ClientID, int Team, const char *pLine)
 
 	// play sound
 	int64_t Now = time();
-	if(ClientID == SERVER_MSG)
+	if(ClientId == SERVER_MSG)
 	{
 		if(Now - m_aLastSoundPlayed[CHAT_SERVER] >= time_freq() * 3 / 10)
 		{
@@ -871,7 +871,7 @@ void CChat::AddLine(int ClientID, int Team, const char *pLine)
 			}
 		}
 	}
-	else if(ClientID == CLIENT_MSG)
+	else if(ClientId == CLIENT_MSG)
 	{
 		// No sound yet
 	}
@@ -982,24 +982,24 @@ void CChat::OnPrepareLines(float y)
 
 		char aName[64 + 12] = "";
 
-		if(g_Config.m_ClShowIDs && Line.m_ClientID >= 0 && Line.m_aName[0] != '\0')
+		if(g_Config.m_ClShowIds && Line.m_ClientId >= 0 && Line.m_aName[0] != '\0')
 		{
-			if(Line.m_ClientID < 10)
-				str_format(aName, sizeof(aName), " %d: ", Line.m_ClientID);
+			if(Line.m_ClientId < 10)
+				str_format(aName, sizeof(aName), " %d: ", Line.m_ClientId);
 			else
-				str_format(aName, sizeof(aName), "%d: ", Line.m_ClientID);
+				str_format(aName, sizeof(aName), "%d: ", Line.m_ClientId);
 		}
 
 		str_append(aName, Line.m_aName);
 
 		char aCount[12];
-		if(Line.m_ClientID < 0)
+		if(Line.m_ClientId < 0)
 			str_format(aCount, sizeof(aCount), "[%d] ", Line.m_TimesRepeated + 1);
 		else
 			str_format(aCount, sizeof(aCount), " [%d]", Line.m_TimesRepeated + 1);
 
 		const char *pText = Line.m_aText;
-		if(Config()->m_ClStreamerMode && Line.m_ClientID == SERVER_MSG)
+		if(Config()->m_ClStreamerMode && Line.m_ClientId == SERVER_MSG)
 		{
 			if(str_startswith(Line.m_aText, "Team save in progress. You'll be able to load with '/load") && str_endswith(Line.m_aText, "if it fails"))
 			{
@@ -1022,7 +1022,7 @@ void CChat::OnPrepareLines(float y)
 			TextRender()->SetCursor(&Cursor, TextBegin, 0.0f, FontSize, 0);
 			Cursor.m_LineWidth = LineWidth;
 
-			if(Line.m_ClientID >= 0 && Line.m_aName[0] != '\0')
+			if(Line.m_ClientId >= 0 && Line.m_aName[0] != '\0')
 			{
 				Cursor.m_X += RealMsgPaddingTee;
 
@@ -1036,7 +1036,7 @@ void CChat::OnPrepareLines(float y)
 			if(Line.m_TimesRepeated > 0)
 				TextRender()->TextEx(&Cursor, aCount);
 
-			if(Line.m_ClientID >= 0 && Line.m_aName[0] != '\0')
+			if(Line.m_ClientId >= 0 && Line.m_aName[0] != '\0')
 			{
 				TextRender()->TextEx(&Cursor, ": ");
 			}
@@ -1071,7 +1071,7 @@ void CChat::OnPrepareLines(float y)
 		Cursor.m_LineWidth = LineWidth;
 
 		// Message is from valid player
-		if(Line.m_ClientID >= 0 && Line.m_aName[0] != '\0')
+		if(Line.m_ClientId >= 0 && Line.m_aName[0] != '\0')
 		{
 			Cursor.m_X += RealMsgPaddingTee;
 
@@ -1084,9 +1084,9 @@ void CChat::OnPrepareLines(float y)
 
 		// render name
 		ColorRGBA NameColor;
-		if(Line.m_ClientID == SERVER_MSG)
+		if(Line.m_ClientId == SERVER_MSG)
 			NameColor = color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClMessageSystemColor));
-		else if(Line.m_ClientID == CLIENT_MSG)
+		else if(Line.m_ClientId == CLIENT_MSG)
 			NameColor = color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClMessageClientColor));
 		else if(Line.m_Team)
 			NameColor = CalculateNameColor(ColorHSLA(g_Config.m_ClMessageTeamColor));
@@ -1096,8 +1096,8 @@ void CChat::OnPrepareLines(float y)
 			NameColor = ColorRGBA(0.7f, 0.7f, 1.0f, 1.f);
 		else if(Line.m_NameColor == TEAM_SPECTATORS)
 			NameColor = ColorRGBA(0.75f, 0.5f, 0.75f, 1.f);
-		else if(Line.m_ClientID >= 0 && g_Config.m_ClChatTeamColors && m_pClient->m_Teams.Team(Line.m_ClientID))
-			NameColor = m_pClient->GetDDTeamColor(m_pClient->m_Teams.Team(Line.m_ClientID), 0.75f);
+		else if(Line.m_ClientId >= 0 && g_Config.m_ClChatTeamColors && m_pClient->m_Teams.Team(Line.m_ClientId))
+			NameColor = m_pClient->GetDDTeamColor(m_pClient->m_Teams.Team(Line.m_ClientId), 0.75f);
 		else
 			NameColor = ColorRGBA(0.8f, 0.8f, 0.8f, 1.f);
 
@@ -1110,7 +1110,7 @@ void CChat::OnPrepareLines(float y)
 			TextRender()->CreateOrAppendTextContainer(Line.m_TextContainerIndex, &Cursor, aCount);
 		}
 
-		if(Line.m_ClientID >= 0 && Line.m_aName[0] != '\0')
+		if(Line.m_ClientId >= 0 && Line.m_aName[0] != '\0')
 		{
 			TextRender()->TextColor(NameColor);
 			TextRender()->CreateOrAppendTextContainer(Line.m_TextContainerIndex, &Cursor, ": ");
@@ -1118,9 +1118,9 @@ void CChat::OnPrepareLines(float y)
 
 		// render line
 		ColorRGBA Color;
-		if(Line.m_ClientID == SERVER_MSG)
+		if(Line.m_ClientId == SERVER_MSG)
 			Color = color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClMessageSystemColor));
-		else if(Line.m_ClientID == CLIENT_MSG)
+		else if(Line.m_ClientId == CLIENT_MSG)
 			Color = color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClMessageClientColor));
 		else if(Line.m_Highlighted)
 			Color = color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClMessageHighlightColor));
@@ -1229,7 +1229,7 @@ void CChat::OnRender()
 		else if(CaretPositionY + Cursor.m_FontSize > ClippingRect.y + ClippingRect.h)
 			ScrollOffsetChange += CaretPositionY + Cursor.m_FontSize - (ClippingRect.y + ClippingRect.h);
 
-		UI()->DoSmoothScrollLogic(&ScrollOffset, &ScrollOffsetChange, ClippingRect.h, BoundingBox.m_H);
+		Ui()->DoSmoothScrollLogic(&ScrollOffset, &ScrollOffsetChange, ClippingRect.h, BoundingBox.m_H);
 
 		m_Input.SetScrollOffset(ScrollOffset);
 		m_Input.SetScrollOffsetChange(ScrollOffsetChange);

--- a/src/game/client/components/chat.h
+++ b/src/game/client/components/chat.h
@@ -30,7 +30,7 @@ class CChat : public CComponent
 	{
 		int64_t m_Time;
 		float m_aYOffset[2];
-		int m_ClientID;
+		int m_ClientId;
 		int m_TeamNumber;
 		bool m_Team;
 		bool m_Whisper;
@@ -88,7 +88,7 @@ class CChat : public CComponent
 	static char ms_aDisplayText[MAX_LINE_LENGTH];
 	struct CRateablePlayer
 	{
-		int ClientID;
+		int ClientId;
 		int Score;
 	};
 	CRateablePlayer m_aPlayerCompletionList[MAX_CLIENTS];
@@ -152,7 +152,7 @@ public:
 	static constexpr float MESSAGE_TEE_PADDING_RIGHT = 0.5f;
 
 	bool IsActive() const { return m_Mode != MODE_NONE; }
-	void AddLine(int ClientID, int Team, const char *pLine);
+	void AddLine(int ClientId, int Team, const char *pLine);
 	void EnableMode(int Team);
 	void DisableMode();
 	void Say(int Team, const char *pLine);

--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -238,7 +238,7 @@ void CGameConsole::CInstance::PumpBacklogPending()
 		m_BacklogPending.Init();
 	}
 
-	m_pGameConsole->UI()->MapScreen();
+	m_pGameConsole->Ui()->MapScreen();
 	for(CInstance::CBacklogEntry *pEntry : vpEntries)
 	{
 		UpdateEntryTextAttributes(pEntry);
@@ -639,7 +639,7 @@ void CGameConsole::CInstance::UpdateEntryTextAttributes(CBacklogEntry *pEntry) c
 {
 	CTextCursor Cursor;
 	m_pGameConsole->TextRender()->SetCursor(&Cursor, 0.0f, 0.0f, FONT_SIZE, 0);
-	Cursor.m_LineWidth = m_pGameConsole->UI()->Screen()->w - 10;
+	Cursor.m_LineWidth = m_pGameConsole->Ui()->Screen()->w - 10;
 	Cursor.m_MaxLines = 10;
 	Cursor.m_LineSpacing = LINE_SPACING;
 	m_pGameConsole->TextRender()->TextEx(&Cursor, pEntry->m_aText, -1);
@@ -679,8 +679,8 @@ void CGameConsole::CInstance::UpdateSearch()
 		m_HasSelection = false;
 	}
 
-	ITextRender *pTextRender = m_pGameConsole->UI()->TextRender();
-	const int LineWidth = m_pGameConsole->UI()->Screen()->w - 10.0f;
+	ITextRender *pTextRender = m_pGameConsole->Ui()->TextRender();
+	const int LineWidth = m_pGameConsole->Ui()->Screen()->w - 10.0f;
 
 	CBacklogEntry *pEntry = m_Backlog.Last();
 	int EntryLine = 0, LineToScrollStart = 0, LineToScrollEnd = 0;
@@ -881,7 +881,7 @@ void CGameConsole::Prompt(char (&aPrompt)[32])
 
 void CGameConsole::OnRender()
 {
-	CUIRect Screen = *UI()->Screen();
+	CUIRect Screen = *Ui()->Screen();
 	CInstance *pConsole = CurrentConsole();
 
 	const float MaxConsoleHeight = Screen.h * 3 / 5.0f;
@@ -923,7 +923,7 @@ void CGameConsole::OnRender()
 
 	const float ConsoleHeight = ConsoleHeightScale * MaxConsoleHeight;
 
-	UI()->MapScreen();
+	Ui()->MapScreen();
 
 	// do console shadow
 	Graphics()->TextureClear();
@@ -1098,7 +1098,7 @@ void CGameConsole::OnRender()
 				}
 			}
 
-			UI()->DoSmoothScrollLogic(&pConsole->m_CompletionRenderOffset, &pConsole->m_CompletionRenderOffsetChange, Info.m_Width, Info.m_TotalWidth);
+			Ui()->DoSmoothScrollLogic(&pConsole->m_CompletionRenderOffset, &pConsole->m_CompletionRenderOffsetChange, Info.m_Width, Info.m_TotalWidth);
 		}
 		else if(pConsole->m_Searching && !pConsole->m_Input.IsEmpty())
 		{ // Render current match and match count
@@ -1281,7 +1281,7 @@ void CGameConsole::OnRender()
 
 		if(m_ConsoleType == CONSOLETYPE_REMOTE && Client()->ReceivingRconCommands())
 		{
-			UI()->RenderProgressSpinner(vec2(Screen.w / 4.0f + FONT_SIZE / 2.f, FONT_SIZE), FONT_SIZE / 2.f);
+			Ui()->RenderProgressSpinner(vec2(Screen.w / 4.0f + FONT_SIZE / 2.f, FONT_SIZE), FONT_SIZE / 2.f);
 			TextRender()->Text(Screen.w / 4.0f + FONT_SIZE + 2.0f, FONT_SIZE / 2.f, FONT_SIZE, Localize("Loading commands…"));
 		}
 
@@ -1336,13 +1336,13 @@ void CGameConsole::Toggle(int Type)
 
 		if(m_ConsoleState == CONSOLE_CLOSED || m_ConsoleState == CONSOLE_CLOSING)
 		{
-			UI()->SetEnabled(false);
+			Ui()->SetEnabled(false);
 			m_ConsoleState = CONSOLE_OPENING;
 		}
 		else
 		{
 			Input()->MouseModeRelative();
-			UI()->SetEnabled(true);
+			Ui()->SetEnabled(true);
 			m_pClient->OnRelease();
 			m_ConsoleState = CONSOLE_CLOSING;
 		}

--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -427,7 +427,7 @@ bool CControls::OnCursorMove(float x, float y, IInput::ECursorType CursorType)
 		}
 	}
 
-	if(m_pClient->m_Snap.m_SpecInfo.m_Active && m_pClient->m_Snap.m_SpecInfo.m_SpectatorID < 0)
+	if(m_pClient->m_Snap.m_SpecInfo.m_Active && m_pClient->m_Snap.m_SpecInfo.m_SpectatorId < 0)
 		Factor *= m_pClient->m_Camera.m_Zoom;
 
 	m_aMousePos[g_Config.m_ClDummy] += vec2(x, y) * Factor;
@@ -437,7 +437,7 @@ bool CControls::OnCursorMove(float x, float y, IInput::ECursorType CursorType)
 
 void CControls::ClampMousePos()
 {
-	if(m_pClient->m_Snap.m_SpecInfo.m_Active && m_pClient->m_Snap.m_SpecInfo.m_SpectatorID < 0)
+	if(m_pClient->m_Snap.m_SpecInfo.m_Active && m_pClient->m_Snap.m_SpecInfo.m_SpectatorId < 0)
 	{
 		m_aMousePos[g_Config.m_ClDummy].x = clamp(m_aMousePos[g_Config.m_ClDummy].x, -201.0f * 32, (Collision()->GetWidth() + 201.0f) * 32.0f);
 		m_aMousePos[g_Config.m_ClDummy].y = clamp(m_aMousePos[g_Config.m_ClDummy].y, -201.0f * 32, (Collision()->GetHeight() + 201.0f) * 32.0f);

--- a/src/game/client/components/debughud.cpp
+++ b/src/game/client/components/debughud.cpp
@@ -33,7 +33,7 @@ void CDebugHud::RenderNetCorrections()
 	const float VelspeedX = m_pClient->m_Snap.m_pLocalCharacter->m_VelX / 256.0f * Client()->GameTickSpeed();
 	const float VelspeedY = m_pClient->m_Snap.m_pLocalCharacter->m_VelY / 256.0f * Client()->GameTickSpeed();
 	const float Ramp = VelocityRamp(Velspeed, m_pClient->m_aTuning[g_Config.m_ClDummy].m_VelrampStart, m_pClient->m_aTuning[g_Config.m_ClDummy].m_VelrampRange, m_pClient->m_aTuning[g_Config.m_ClDummy].m_VelrampCurvature);
-	const CCharacter *pCharacter = m_pClient->m_GameWorld.GetCharacterByID(m_pClient->m_Snap.m_LocalClientID);
+	const CCharacter *pCharacter = m_pClient->m_GameWorld.GetCharacterById(m_pClient->m_Snap.m_LocalClientId);
 
 	const float FontSize = 5.0f;
 	const float LineHeight = FontSize + 1.0f;
@@ -92,7 +92,7 @@ void CDebugHud::RenderTuning()
 	if(g_Config.m_DbgTuning == DBG_TUNING_OFF)
 		return;
 
-	const CCharacter *pCharacter = m_pClient->m_GameWorld.GetCharacterByID(m_pClient->m_Snap.m_LocalClientID);
+	const CCharacter *pCharacter = m_pClient->m_GameWorld.GetCharacterById(m_pClient->m_Snap.m_LocalClientId);
 
 	const CTuningParams StandardTuning;
 	const CTuningParams *pGlobalTuning = m_pClient->GetTuning(0);

--- a/src/game/client/components/effects.cpp
+++ b/src/game/client/components/effects.cpp
@@ -190,11 +190,11 @@ void CEffects::PlayerSpawn(vec2 Pos, float Alpha)
 		m_pClient->m_Sounds.PlayAt(CSounds::CHN_WORLD, SOUND_PLAYER_SPAWN, 1.0f, Pos);
 }
 
-void CEffects::PlayerDeath(vec2 Pos, int ClientID, float Alpha)
+void CEffects::PlayerDeath(vec2 Pos, int ClientId, float Alpha)
 {
 	ColorRGBA BloodColor(1.0f, 1.0f, 1.0f);
 
-	if(ClientID >= 0)
+	if(ClientId >= 0)
 	{
 		// Use m_RenderInfo.m_CustomColoredSkin instead of m_UseCustomColor
 		// m_UseCustomColor says if the player's skin has a custom color (value sent from the client side)
@@ -202,11 +202,11 @@ void CEffects::PlayerDeath(vec2 Pos, int ClientID, float Alpha)
 		// m_RenderInfo.m_CustomColoredSkin Defines if in the context of the game the color is being customized,
 		// Using this value if the game is teams (red and blue), this value will be true even if the skin is with the normal color.
 		// And will use the team body color to create player death effect instead of tee color
-		if(m_pClient->m_aClients[ClientID].m_RenderInfo.m_CustomColoredSkin)
-			BloodColor = m_pClient->m_aClients[ClientID].m_RenderInfo.m_ColorBody;
+		if(m_pClient->m_aClients[ClientId].m_RenderInfo.m_CustomColoredSkin)
+			BloodColor = m_pClient->m_aClients[ClientId].m_RenderInfo.m_ColorBody;
 		else
 		{
-			BloodColor = m_pClient->m_aClients[ClientID].m_RenderInfo.m_BloodColor;
+			BloodColor = m_pClient->m_aClients[ClientId].m_RenderInfo.m_BloodColor;
 		}
 	}
 

--- a/src/game/client/components/effects.h
+++ b/src/game/client/components/effects.h
@@ -25,7 +25,7 @@ public:
 	void DamageIndicator(vec2 Pos, vec2 Dir, float Alpha = 1.0f);
 	void ResetDamageIndicator();
 	void PlayerSpawn(vec2 Pos, float Alpha = 1.0f);
-	void PlayerDeath(vec2 Pos, int ClientID, float Alpha = 1.0f);
+	void PlayerDeath(vec2 Pos, int ClientId, float Alpha = 1.0f);
 	void PowerupShine(vec2 Pos, vec2 Size, float Alpha = 1.0f);
 	void FreezingFlakes(vec2 Pos, vec2 Size, float Alpha = 1.0f);
 

--- a/src/game/client/components/emoticon.cpp
+++ b/src/game/client/components/emoticon.cpp
@@ -53,7 +53,7 @@ bool CEmoticon::OnCursorMove(float x, float y, IInput::ECursorType CursorType)
 	if(!m_Active)
 		return false;
 
-	UI()->ConvertMouseMove(&x, &y, CursorType);
+	Ui()->ConvertMouseMove(&x, &y, CursorType);
 	m_SelectorMouse += vec2(x, y);
 	return true;
 }
@@ -93,9 +93,9 @@ void CEmoticon::OnRender()
 	else if(length(m_SelectorMouse) > 40.0f)
 		m_SelectedEyeEmote = (int)(SelectedAngle / (2 * pi) * NUM_EMOTES);
 
-	CUIRect Screen = *UI()->Screen();
+	CUIRect Screen = *Ui()->Screen();
 
-	UI()->MapScreen();
+	Ui()->MapScreen();
 
 	Graphics()->BlendNormal();
 
@@ -135,7 +135,7 @@ void CEmoticon::OnRender()
 		Graphics()->DrawCircle(Screen.w / 2, Screen.h / 2, 100.0f, 64);
 		Graphics()->QuadsEnd();
 
-		CTeeRenderInfo TeeInfo = m_pClient->m_aClients[m_pClient->m_aLocalIDs[g_Config.m_ClDummy]].m_RenderInfo;
+		CTeeRenderInfo TeeInfo = m_pClient->m_aClients[m_pClient->m_aLocalIds[g_Config.m_ClDummy]].m_RenderInfo;
 
 		for(int i = 0; i < NUM_EMOTES; i++)
 		{

--- a/src/game/client/components/freezebars.cpp
+++ b/src/game/client/components/freezebars.cpp
@@ -2,16 +2,16 @@
 
 #include "freezebars.h"
 
-void CFreezeBars::RenderFreezeBar(const int ClientID)
+void CFreezeBars::RenderFreezeBar(const int ClientId)
 {
 	const float FreezeBarWidth = 64.0f;
 	const float FreezeBarHalfWidth = 32.0f;
 	const float FreezeBarHight = 16.0f;
 
 	// pCharacter contains the predicted character for local players or the last snap for players who are spectated
-	CCharacterCore *pCharacter = &m_pClient->m_aClients[ClientID].m_Predicted;
+	CCharacterCore *pCharacter = &m_pClient->m_aClients[ClientId].m_Predicted;
 
-	if(pCharacter->m_FreezeEnd <= 0 || pCharacter->m_FreezeStart == 0 || pCharacter->m_FreezeEnd <= pCharacter->m_FreezeStart || !m_pClient->m_Snap.m_aCharacters[ClientID].m_HasExtendedDisplayInfo || (pCharacter->m_IsInFreeze && g_Config.m_ClFreezeBarsAlphaInsideFreeze == 0))
+	if(pCharacter->m_FreezeEnd <= 0 || pCharacter->m_FreezeStart == 0 || pCharacter->m_FreezeEnd <= pCharacter->m_FreezeStart || !m_pClient->m_Snap.m_aCharacters[ClientId].m_HasExtendedDisplayInfo || (pCharacter->m_IsInFreeze && g_Config.m_ClFreezeBarsAlphaInsideFreeze == 0))
 	{
 		return;
 	}
@@ -23,11 +23,11 @@ void CFreezeBars::RenderFreezeBar(const int ClientID)
 		return;
 	}
 
-	vec2 Position = m_pClient->m_aClients[ClientID].m_RenderPos;
+	vec2 Position = m_pClient->m_aClients[ClientId].m_RenderPos;
 	Position.x -= FreezeBarHalfWidth;
 	Position.y += 32;
 
-	float Alpha = m_pClient->IsOtherTeam(ClientID) ? g_Config.m_ClShowOthersAlpha / 100.0f : 1.0f;
+	float Alpha = m_pClient->IsOtherTeam(ClientId) ? g_Config.m_ClShowOthersAlpha / 100.0f : 1.0f;
 	if(pCharacter->m_IsInFreeze)
 	{
 		Alpha *= g_Config.m_ClFreezeBarsAlphaInsideFreeze / 100.0f;
@@ -187,10 +187,10 @@ void CFreezeBars::RenderFreezeBarPos(float x, const float y, const float width, 
 	Graphics()->WrapNormal();
 }
 
-inline bool CFreezeBars::IsPlayerInfoAvailable(int ClientID) const
+inline bool CFreezeBars::IsPlayerInfoAvailable(int ClientId) const
 {
-	const void *pPrevInfo = Client()->SnapFindItem(IClient::SNAP_PREV, NETOBJTYPE_PLAYERINFO, ClientID);
-	const void *pInfo = Client()->SnapFindItem(IClient::SNAP_CURRENT, NETOBJTYPE_PLAYERINFO, ClientID);
+	const void *pPrevInfo = Client()->SnapFindItem(IClient::SNAP_PREV, NETOBJTYPE_PLAYERINFO, ClientId);
+	const void *pInfo = Client()->SnapFindItem(IClient::SNAP_CURRENT, NETOBJTYPE_PLAYERINFO, ClientId);
 	return pPrevInfo && pInfo;
 }
 
@@ -213,27 +213,27 @@ void CFreezeBars::OnRender()
 	ScreenY0 -= BorderBuffer;
 	ScreenY1 += BorderBuffer;
 
-	int LocalClientID = m_pClient->m_Snap.m_LocalClientID;
+	int LocalClientId = m_pClient->m_Snap.m_LocalClientId;
 
 	// render everyone else's freeze bar, then our own
-	for(int ClientID = 0; ClientID < MAX_CLIENTS; ClientID++)
+	for(int ClientId = 0; ClientId < MAX_CLIENTS; ClientId++)
 	{
-		if(ClientID == LocalClientID || !m_pClient->m_Snap.m_aCharacters[ClientID].m_Active || !IsPlayerInfoAvailable(ClientID))
+		if(ClientId == LocalClientId || !m_pClient->m_Snap.m_aCharacters[ClientId].m_Active || !IsPlayerInfoAvailable(ClientId))
 		{
 			continue;
 		}
 
 		//don't render if the tee is offscreen
-		vec2 *pRenderPos = &m_pClient->m_aClients[ClientID].m_RenderPos;
+		vec2 *pRenderPos = &m_pClient->m_aClients[ClientId].m_RenderPos;
 		if(pRenderPos->x < ScreenX0 || pRenderPos->x > ScreenX1 || pRenderPos->y < ScreenY0 || pRenderPos->y > ScreenY1)
 		{
 			continue;
 		}
 
-		RenderFreezeBar(ClientID);
+		RenderFreezeBar(ClientId);
 	}
-	if(LocalClientID != -1 && m_pClient->m_Snap.m_aCharacters[LocalClientID].m_Active && IsPlayerInfoAvailable(LocalClientID))
+	if(LocalClientId != -1 && m_pClient->m_Snap.m_aCharacters[LocalClientId].m_Active && IsPlayerInfoAvailable(LocalClientId))
 	{
-		RenderFreezeBar(LocalClientID);
+		RenderFreezeBar(LocalClientId);
 	}
 }

--- a/src/game/client/components/freezebars.h
+++ b/src/game/client/components/freezebars.h
@@ -4,9 +4,9 @@
 
 class CFreezeBars : public CComponent
 {
-	void RenderFreezeBar(const int ClientID);
+	void RenderFreezeBar(const int ClientId);
 	void RenderFreezeBarPos(float x, const float y, const float width, const float height, float Progress, float Alpha = 1.0f);
-	bool IsPlayerInfoAvailable(int ClientID) const;
+	bool IsPlayerInfoAvailable(int ClientId) const;
 
 public:
 	virtual int Sizeof() const override { return sizeof(*this); }

--- a/src/game/client/components/ghost.cpp
+++ b/src/game/client/components/ghost.cpp
@@ -287,7 +287,7 @@ void CGhost::OnNewSnapshot()
 			CheckStart();
 
 		if(m_Recording)
-			AddInfos(m_pClient->m_Snap.m_pLocalCharacter, (m_pClient->m_Snap.m_LocalClientID != -1 && m_pClient->m_Snap.m_aCharacters[m_pClient->m_Snap.m_LocalClientID].m_HasExtendedData) ? &m_pClient->m_Snap.m_aCharacters[m_pClient->m_Snap.m_LocalClientID].m_ExtendedData : nullptr);
+			AddInfos(m_pClient->m_Snap.m_pLocalCharacter, (m_pClient->m_Snap.m_LocalClientId != -1 && m_pClient->m_Snap.m_aCharacters[m_pClient->m_Snap.m_LocalClientId].m_HasExtendedData) ? &m_pClient->m_Snap.m_aCharacters[m_pClient->m_Snap.m_LocalClientId].m_ExtendedData : nullptr);
 	}
 
 	// Record m_LastRaceTick for g_Config.m_ClConfirmDisconnect/QuitTime anyway
@@ -415,7 +415,7 @@ void CGhost::StartRecord(int Tick)
 	m_CurGhost.Reset();
 	m_CurGhost.m_StartTick = Tick;
 
-	const CGameClient::CClientData *pData = &m_pClient->m_aClients[m_pClient->m_Snap.m_LocalClientID];
+	const CGameClient::CClientData *pData = &m_pClient->m_aClients[m_pClient->m_Snap.m_LocalClientId];
 	str_copy(m_CurGhost.m_aPlayer, Client()->PlayerName());
 	GetGhostSkin(&m_CurGhost.m_Skin, pData->m_aSkinName, pData->m_UseCustomColor, pData->m_ColorBody, pData->m_ColorFeet);
 	InitRenderInfos(&m_CurGhost);
@@ -620,7 +620,7 @@ void CGhost::OnMessage(int MsgType, void *pRawMsg)
 	if(MsgType == NETMSGTYPE_SV_KILLMSG)
 	{
 		CNetMsg_Sv_KillMsg *pMsg = (CNetMsg_Sv_KillMsg *)pRawMsg;
-		if(pMsg->m_Victim == m_pClient->m_Snap.m_LocalClientID)
+		if(pMsg->m_Victim == m_pClient->m_Snap.m_LocalClientId)
 		{
 			if(m_Recording)
 				StopRecord();
@@ -633,7 +633,7 @@ void CGhost::OnMessage(int MsgType, void *pRawMsg)
 		CNetMsg_Sv_KillMsgTeam *pMsg = (CNetMsg_Sv_KillMsgTeam *)pRawMsg;
 		for(int i = 0; i < MAX_CLIENTS; i++)
 		{
-			if(m_pClient->m_Teams.Team(i) == pMsg->m_Team && i == m_pClient->m_Snap.m_LocalClientID)
+			if(m_pClient->m_Teams.Team(i) == pMsg->m_Team && i == m_pClient->m_Snap.m_LocalClientId)
 			{
 				if(m_Recording)
 					StopRecord();
@@ -645,11 +645,11 @@ void CGhost::OnMessage(int MsgType, void *pRawMsg)
 	else if(MsgType == NETMSGTYPE_SV_CHAT)
 	{
 		CNetMsg_Sv_Chat *pMsg = (CNetMsg_Sv_Chat *)pRawMsg;
-		if(pMsg->m_ClientID == -1 && m_Recording)
+		if(pMsg->m_ClientId == -1 && m_Recording)
 		{
 			char aName[MAX_NAME_LENGTH];
 			int Time = CRaceHelper::TimeFromFinishMessage(pMsg->m_pMessage, aName, sizeof(aName));
-			if(Time > 0 && m_pClient->m_Snap.m_LocalClientID >= 0 && str_comp(aName, m_pClient->m_aClients[m_pClient->m_Snap.m_LocalClientID].m_aName) == 0)
+			if(Time > 0 && m_pClient->m_Snap.m_LocalClientId >= 0 && str_comp(aName, m_pClient->m_aClients[m_pClient->m_Snap.m_LocalClientId].m_aName) == 0)
 			{
 				StopRecord(Time);
 				StopRender();

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -244,8 +244,8 @@ void CHud::RenderScoreHud()
 					else if(aFlagCarrier[t] >= 0)
 					{
 						// draw name of the flag holder
-						int ID = aFlagCarrier[t] % MAX_CLIENTS;
-						const char *pName = m_pClient->m_aClients[ID].m_aName;
+						int Id = aFlagCarrier[t] % MAX_CLIENTS;
+						const char *pName = m_pClient->m_aClients[Id].m_aName;
 						if(str_comp(pName, m_aScoreInfo[t].m_aPlayerNameText) != 0 || RecreateRect)
 						{
 							mem_copy(m_aScoreInfo[t].m_aPlayerNameText, pName, sizeof(m_aScoreInfo[t].m_aPlayerNameText));
@@ -266,7 +266,7 @@ void CHud::RenderScoreHud()
 						}
 
 						// draw tee of the flag holder
-						CTeeRenderInfo TeeInfo = m_pClient->m_aClients[ID].m_RenderInfo;
+						CTeeRenderInfo TeeInfo = m_pClient->m_aClients[Id].m_RenderInfo;
 						TeeInfo.m_Size = ScoreSingleBoxHeight;
 
 						const CAnimState *pIdleState = CAnimState::GetIdle();
@@ -291,7 +291,7 @@ void CHud::RenderScoreHud()
 				if(m_pClient->m_Snap.m_apInfoByScore[i]->m_Team != TEAM_SPECTATORS)
 				{
 					apPlayerInfo[t] = m_pClient->m_Snap.m_apInfoByScore[i];
-					if(apPlayerInfo[t]->m_ClientID == m_pClient->m_Snap.m_LocalClientID)
+					if(apPlayerInfo[t]->m_ClientId == m_pClient->m_Snap.m_LocalClientId)
 						Local = t;
 					++t;
 				}
@@ -303,7 +303,7 @@ void CHud::RenderScoreHud()
 				{
 					if(m_pClient->m_Snap.m_apInfoByScore[i]->m_Team != TEAM_SPECTATORS)
 						++aPos[1];
-					if(m_pClient->m_Snap.m_apInfoByScore[i]->m_ClientID == m_pClient->m_Snap.m_LocalClientID)
+					if(m_pClient->m_Snap.m_apInfoByScore[i]->m_ClientId == m_pClient->m_Snap.m_LocalClientId)
 					{
 						apPlayerInfo[1] = m_pClient->m_Snap.m_apInfoByScore[i];
 						Local = 1;
@@ -330,9 +330,9 @@ void CHud::RenderScoreHud()
 					aScore[t][0] = 0;
 			}
 
-			static int LocalClientID = -1;
-			bool RecreateScores = str_comp(aScore[0], m_aScoreInfo[0].m_aScoreText) != 0 || str_comp(aScore[1], m_aScoreInfo[1].m_aScoreText) != 0 || LocalClientID != m_pClient->m_Snap.m_LocalClientID;
-			LocalClientID = m_pClient->m_Snap.m_LocalClientID;
+			static int LocalClientId = -1;
+			bool RecreateScores = str_comp(aScore[0], m_aScoreInfo[0].m_aScoreText) != 0 || str_comp(aScore[1], m_aScoreInfo[1].m_aScoreText) != 0 || LocalClientId != m_pClient->m_Snap.m_LocalClientId;
+			LocalClientId = m_pClient->m_Snap.m_LocalClientId;
 
 			bool RecreateRect = ForceScoreInfoInit;
 			for(int t = 0; t < 2; t++)
@@ -346,10 +346,10 @@ void CHud::RenderScoreHud()
 
 				if(apPlayerInfo[t])
 				{
-					int ID = apPlayerInfo[t]->m_ClientID;
-					if(ID >= 0 && ID < MAX_CLIENTS)
+					int Id = apPlayerInfo[t]->m_ClientId;
+					if(Id >= 0 && Id < MAX_CLIENTS)
 					{
-						const char *pName = m_pClient->m_aClients[ID].m_aName;
+						const char *pName = m_pClient->m_aClients[Id].m_aName;
 						if(str_comp(pName, m_aScoreInfo[t].m_aPlayerNameText) != 0)
 							RecreateRect = true;
 					}
@@ -406,10 +406,10 @@ void CHud::RenderScoreHud()
 				if(apPlayerInfo[t])
 				{
 					// draw name
-					int ID = apPlayerInfo[t]->m_ClientID;
-					if(ID >= 0 && ID < MAX_CLIENTS)
+					int Id = apPlayerInfo[t]->m_ClientId;
+					if(Id >= 0 && Id < MAX_CLIENTS)
 					{
-						const char *pName = m_pClient->m_aClients[ID].m_aName;
+						const char *pName = m_pClient->m_aClients[Id].m_aName;
 						if(RecreateRect)
 						{
 							mem_copy(m_aScoreInfo[t].m_aPlayerNameText, pName, sizeof(m_aScoreInfo[t].m_aPlayerNameText));
@@ -429,7 +429,7 @@ void CHud::RenderScoreHud()
 						}
 
 						// draw tee
-						CTeeRenderInfo TeeInfo = m_pClient->m_aClients[ID].m_RenderInfo;
+						CTeeRenderInfo TeeInfo = m_pClient->m_aClients[Id].m_RenderInfo;
 						TeeInfo.m_Size = ScoreSingleBoxHeight;
 
 						const CAnimState *pIdleState = CAnimState::GetIdle();
@@ -754,18 +754,18 @@ void CHud::PreparePlayerStateQuads()
 	m_LockModeOffset = RenderTools()->QuadContainerAddSprite(m_HudQuadContainerIndex, 0.f, 0.f, 12.f, 12.f);
 }
 
-void CHud::RenderPlayerState(const int ClientID)
+void CHud::RenderPlayerState(const int ClientId)
 {
 	Graphics()->SetColor(1.f, 1.f, 1.f, 1.f);
 
 	// pCharacter contains the predicted character for local players or the last snap for players who are spectated
-	CCharacterCore *pCharacter = &m_pClient->m_aClients[ClientID].m_Predicted;
-	CNetObj_Character *pPlayer = &m_pClient->m_aClients[ClientID].m_RenderCur;
+	CCharacterCore *pCharacter = &m_pClient->m_aClients[ClientId].m_Predicted;
+	CNetObj_Character *pPlayer = &m_pClient->m_aClients[ClientId].m_RenderCur;
 	int TotalJumpsToDisplay = 0;
 	if(g_Config.m_ClShowhudJumpsIndicator)
 	{
 		int AvailableJumpsToDisplay;
-		if(m_pClient->m_Snap.m_aCharacters[ClientID].m_HasExtendedDisplayInfo)
+		if(m_pClient->m_Snap.m_aCharacters[ClientId].m_HasExtendedDisplayInfo)
 		{
 			bool Grounded = false;
 			if(Collision()->CheckPoint(pPlayer->m_X + CCharacterCore::PhysicalSize() / 2,
@@ -811,7 +811,7 @@ void CHud::RenderPlayerState(const int ClientID)
 		}
 		else
 		{
-			TotalJumpsToDisplay = AvailableJumpsToDisplay = absolute(m_pClient->m_Snap.m_aCharacters[ClientID].m_ExtendedData.m_Jumps);
+			TotalJumpsToDisplay = AvailableJumpsToDisplay = absolute(m_pClient->m_Snap.m_aCharacters[ClientId].m_ExtendedData.m_Jumps);
 		}
 
 		// render available and used jumps
@@ -864,7 +864,7 @@ void CHud::RenderPlayerState(const int ClientID)
 		{
 			const int Max = g_pData->m_Weapons.m_Ninja.m_Duration * Client()->GameTickSpeed() / 1000;
 			float NinjaProgress = clamp(pCharacter->m_Ninja.m_ActivationTick + g_pData->m_Weapons.m_Ninja.m_Duration * Client()->GameTickSpeed() / 1000 - Client()->GameTick(g_Config.m_ClDummy), 0, Max) / (float)Max;
-			if(NinjaProgress > 0.0f && m_pClient->m_Snap.m_aCharacters[ClientID].m_HasExtendedDisplayInfo)
+			if(NinjaProgress > 0.0f && m_pClient->m_Snap.m_aCharacters[ClientId].m_HasExtendedDisplayInfo)
 			{
 				RenderNinjaBarPos(x, y - 12, 6.f, 24.f, NinjaProgress);
 			}
@@ -990,13 +990,13 @@ void CHud::RenderPlayerState(const int ClientID)
 	{
 		y += 12;
 	}
-	if(m_pClient->m_Snap.m_aCharacters[ClientID].m_HasExtendedDisplayInfo && m_pClient->m_Snap.m_aCharacters[ClientID].m_ExtendedData.m_Flags & CHARACTERFLAG_LOCK_MODE)
+	if(m_pClient->m_Snap.m_aCharacters[ClientId].m_HasExtendedDisplayInfo && m_pClient->m_Snap.m_aCharacters[ClientId].m_ExtendedData.m_Flags & CHARACTERFLAG_LOCK_MODE)
 	{
 		Graphics()->TextureSet(m_pClient->m_HudSkin.m_SpriteHudLockMode);
 		Graphics()->RenderQuadContainerAsSprite(m_HudQuadContainerIndex, m_LockModeOffset, x, y);
 		x += 12;
 	}
-	if(m_pClient->m_Snap.m_aCharacters[ClientID].m_HasExtendedDisplayInfo && m_pClient->m_Snap.m_aCharacters[ClientID].m_ExtendedData.m_Flags & CHARACTERFLAG_PRACTICE_MODE)
+	if(m_pClient->m_Snap.m_aCharacters[ClientId].m_HasExtendedDisplayInfo && m_pClient->m_Snap.m_aCharacters[ClientId].m_ExtendedData.m_Flags & CHARACTERFLAG_PRACTICE_MODE)
 	{
 		Graphics()->TextureSet(m_pClient->m_HudSkin.m_SpriteHudPracticeMode);
 		Graphics()->RenderQuadContainerAsSprite(m_HudQuadContainerIndex, m_PracticeModeOffset, x, y);
@@ -1238,7 +1238,7 @@ inline float CHud::GetMovementInformationBoxHeight()
 	return BoxHeight;
 }
 
-void CHud::RenderMovementInformation(const int ClientID)
+void CHud::RenderMovementInformation(const int ClientId)
 {
 	// Draw the infomations depending on settings: Position, speed and target angle
 	// This display is only to present the available information from the last snapshot, not to interpolate or predict
@@ -1261,8 +1261,8 @@ void CHud::RenderMovementInformation(const int ClientID)
 
 	Graphics()->DrawRect(StartX, StartY, BoxWidth, BoxHeight, ColorRGBA(0.0f, 0.0f, 0.0f, 0.4f), IGraphics::CORNER_L, 5.0f);
 
-	const CNetObj_Character *pPrevChar = &m_pClient->m_Snap.m_aCharacters[ClientID].m_Prev;
-	const CNetObj_Character *pCurChar = &m_pClient->m_Snap.m_aCharacters[ClientID].m_Cur;
+	const CNetObj_Character *pPrevChar = &m_pClient->m_Snap.m_aCharacters[ClientId].m_Prev;
+	const CNetObj_Character *pCurChar = &m_pClient->m_Snap.m_aCharacters[ClientId].m_Cur;
 	const float IntraTick = Client()->IntraGameTick(g_Config.m_ClDummy);
 
 	// To make the player position relative to blocks we need to divide by the block size
@@ -1289,7 +1289,7 @@ void CHud::RenderMovementInformation(const int ClientID)
 	DisplaySpeedX *= Ramp;
 	float DisplaySpeedY = VelspeedY / 32;
 
-	float Angle = m_pClient->m_Players.GetPlayerTargetAngle(pPrevChar, pCurChar, ClientID, IntraTick);
+	float Angle = m_pClient->m_Players.GetPlayerTargetAngle(pPrevChar, pCurChar, ClientId, IntraTick);
 	if(Angle < 0)
 	{
 		Angle += 2.0f * pi;
@@ -1377,7 +1377,7 @@ void CHud::RenderSpectatorHud()
 
 	// draw the text
 	char aBuf[128];
-	str_format(aBuf, sizeof(aBuf), "%s: %s", Localize("Spectate"), GameClient()->m_MultiViewActivated ? Localize("Multi-View") : m_pClient->m_Snap.m_SpecInfo.m_SpectatorID != SPEC_FREEVIEW ? m_pClient->m_aClients[m_pClient->m_Snap.m_SpecInfo.m_SpectatorID].m_aName : Localize("Free-View"));
+	str_format(aBuf, sizeof(aBuf), "%s: %s", Localize("Spectate"), GameClient()->m_MultiViewActivated ? Localize("Multi-View") : m_pClient->m_Snap.m_SpecInfo.m_SpectatorId != SPEC_FREEVIEW ? m_pClient->m_aClients[m_pClient->m_Snap.m_SpecInfo.m_SpectatorId].m_aName : Localize("Free-View"));
 	TextRender()->Text(m_Width - 174.0f, m_Height - 15.0f + (15.f - 8.f) / 2.f, 8.0f, aBuf, -1.0f);
 }
 
@@ -1416,31 +1416,31 @@ void CHud::OnRender()
 			{
 				RenderAmmoHealthAndArmor(m_pClient->m_Snap.m_pLocalCharacter);
 			}
-			if(m_pClient->m_Snap.m_aCharacters[m_pClient->m_Snap.m_LocalClientID].m_HasExtendedData && g_Config.m_ClShowhudDDRace && GameClient()->m_GameInfo.m_HudDDRace)
+			if(m_pClient->m_Snap.m_aCharacters[m_pClient->m_Snap.m_LocalClientId].m_HasExtendedData && g_Config.m_ClShowhudDDRace && GameClient()->m_GameInfo.m_HudDDRace)
 			{
-				RenderPlayerState(m_pClient->m_Snap.m_LocalClientID);
+				RenderPlayerState(m_pClient->m_Snap.m_LocalClientId);
 			}
-			RenderMovementInformation(m_pClient->m_Snap.m_LocalClientID);
+			RenderMovementInformation(m_pClient->m_Snap.m_LocalClientId);
 			RenderDDRaceEffects();
 		}
 		else if(m_pClient->m_Snap.m_SpecInfo.m_Active)
 		{
-			int SpectatorID = m_pClient->m_Snap.m_SpecInfo.m_SpectatorID;
-			if(SpectatorID != SPEC_FREEVIEW && g_Config.m_ClShowhudHealthAmmo)
+			int SpectatorId = m_pClient->m_Snap.m_SpecInfo.m_SpectatorId;
+			if(SpectatorId != SPEC_FREEVIEW && g_Config.m_ClShowhudHealthAmmo)
 			{
-				RenderAmmoHealthAndArmor(&m_pClient->m_Snap.m_aCharacters[SpectatorID].m_Cur);
+				RenderAmmoHealthAndArmor(&m_pClient->m_Snap.m_aCharacters[SpectatorId].m_Cur);
 			}
-			if(SpectatorID != SPEC_FREEVIEW &&
-				m_pClient->m_Snap.m_aCharacters[SpectatorID].m_HasExtendedData &&
+			if(SpectatorId != SPEC_FREEVIEW &&
+				m_pClient->m_Snap.m_aCharacters[SpectatorId].m_HasExtendedData &&
 				g_Config.m_ClShowhudDDRace &&
 				(!GameClient()->m_MultiViewActivated || GameClient()->m_MultiViewShowHud) &&
 				GameClient()->m_GameInfo.m_HudDDRace)
 			{
-				RenderPlayerState(SpectatorID);
+				RenderPlayerState(SpectatorId);
 			}
-			if(SpectatorID != SPEC_FREEVIEW)
+			if(SpectatorId != SPEC_FREEVIEW)
 			{
-				RenderMovementInformation(SpectatorID);
+				RenderMovementInformation(SpectatorId);
 			}
 			RenderSpectatorHud();
 		}

--- a/src/game/client/components/hud.h
+++ b/src/game/client/components/hud.h
@@ -57,9 +57,9 @@ class CHud : public CComponent
 	void RenderAmmoHealthAndArmor(const CNetObj_Character *pCharacter);
 
 	void PreparePlayerStateQuads();
-	void RenderPlayerState(const int ClientID);
+	void RenderPlayerState(const int ClientId);
 	void RenderDummyActions();
-	void RenderMovementInformation(const int ClientID);
+	void RenderMovementInformation(const int ClientId);
 
 	void RenderGameTimer();
 	void RenderPauseNotification();

--- a/src/game/client/components/infomessages.h
+++ b/src/game/client/components/infomessages.h
@@ -31,7 +31,7 @@ class CInfoMessages : public CComponent
 		char m_aVictimName[64];
 		STextContainerIndex m_VictimTextContainerIndex;
 		CTeeRenderInfo m_aVictimRenderInfo[MAX_KILLMSG_TEAM_MEMBERS];
-		int m_KillerID;
+		int m_KillerId;
 		char m_aKillerName[64];
 		STextContainerIndex m_KillerTextContainerIndex;
 		CTeeRenderInfo m_KillerRenderInfo;

--- a/src/game/client/components/items.cpp
+++ b/src/game/client/components/items.cpp
@@ -23,7 +23,7 @@
 
 #include "items.h"
 
-void CItems::RenderProjectile(const CProjectileData *pCurrent, int ItemID)
+void CItems::RenderProjectile(const CProjectileData *pCurrent, int ItemId)
 {
 	int CurWeapon = clamp(pCurrent->m_Type, 0, NUM_WEAPONS - 1);
 
@@ -50,7 +50,7 @@ void CItems::RenderProjectile(const CProjectileData *pCurrent, int ItemID)
 	bool LocalPlayerInGame = false;
 
 	if(m_pClient->m_Snap.m_pLocalInfo)
-		LocalPlayerInGame = m_pClient->m_aClients[m_pClient->m_Snap.m_pLocalInfo->m_ClientID].m_Team != TEAM_SPECTATORS;
+		LocalPlayerInGame = m_pClient->m_aClients[m_pClient->m_Snap.m_pLocalInfo->m_ClientId].m_Team != TEAM_SPECTATORS;
 
 	static float s_LastGameTickTime = Client()->GameTickTime(g_Config.m_ClDummy);
 	if(m_pClient->m_Snap.m_pGameInfoObj && !(m_pClient->m_Snap.m_pGameInfoObj->m_GameStateFlags & GAMESTATEFLAG_PAUSED))
@@ -117,7 +117,7 @@ void CItems::RenderProjectile(const CProjectileData *pCurrent, int ItemID)
 				s_Time += LocalTime() - s_LastLocalTime;
 		}
 
-		Graphics()->QuadsSetRotation(s_Time * pi * 2 * 2 + ItemID);
+		Graphics()->QuadsSetRotation(s_Time * pi * 2 * 2 + ItemId);
 		s_LastLocalTime = LocalTime();
 	}
 	else
@@ -383,7 +383,7 @@ void CItems::OnRender()
 				continue;
 
 			CProjectileData Data = pProj->GetData();
-			RenderProjectile(&Data, pProj->GetID());
+			RenderProjectile(&Data, pProj->GetId());
 		}
 		for(CEntity *pEnt = GameClient()->m_PredictedWorld.FindFirst(CGameWorld::ENTTYPE_LASER); pEnt; pEnt = pEnt->NextEntity())
 		{
@@ -400,7 +400,7 @@ void CItems::OnRender()
 
 			if(pPickup->InDDNetTile())
 			{
-				if(auto *pPrev = (CPickup *)GameClient()->m_PrevPredictedWorld.GetEntity(pPickup->GetID(), CGameWorld::ENTTYPE_PICKUP))
+				if(auto *pPrev = (CPickup *)GameClient()->m_PrevPredictedWorld.GetEntity(pPickup->GetId(), CGameWorld::ENTTYPE_PICKUP))
 				{
 					CNetObj_Pickup Data, Prev;
 					pPickup->FillInfo(&Data);
@@ -426,13 +426,13 @@ void CItems::OnRender()
 			if(UsePredicted)
 
 			{
-				if(auto *pProj = (CProjectile *)GameClient()->m_GameWorld.FindMatch(Item.m_ID, Item.m_Type, pData))
+				if(auto *pProj = (CProjectile *)GameClient()->m_GameWorld.FindMatch(Item.m_Id, Item.m_Type, pData))
 				{
 					bool IsOtherTeam = m_pClient->IsOtherTeam(pProj->GetOwner());
 					if(pProj->m_LastRenderTick <= 0 && (pProj->m_Type != WEAPON_SHOTGUN || (!pProj->m_Freeze && !pProj->m_Explosive)) // skip ddrace shotgun bullets
 						&& (pProj->m_Type == WEAPON_SHOTGUN || absolute(length(pProj->m_Direction) - 1.f) < 0.02f) // workaround to skip grenades on ball mod
 						&& (pProj->GetOwner() < 0 || !GameClient()->m_aClients[pProj->GetOwner()].m_IsPredictedLocal || IsOtherTeam) // skip locally predicted projectiles
-						&& !Client()->SnapFindItem(IClient::SNAP_PREV, Item.m_Type, Item.m_ID))
+						&& !Client()->SnapFindItem(IClient::SNAP_PREV, Item.m_Type, Item.m_Id))
 					{
 						ReconstructSmokeTrail(&Data, pProj->m_DestroyTick);
 					}
@@ -441,7 +441,7 @@ void CItems::OnRender()
 						continue;
 				}
 			}
-			RenderProjectile(&Data, Item.m_ID);
+			RenderProjectile(&Data, Item.m_Id);
 		}
 		else if(Item.m_Type == NETOBJTYPE_PICKUP || Item.m_Type == NETOBJTYPE_DDNETPICKUP)
 		{
@@ -452,11 +452,11 @@ void CItems::OnRender()
 				continue;
 			if(UsePredicted)
 			{
-				auto *pPickup = (CPickup *)GameClient()->m_GameWorld.FindMatch(Item.m_ID, Item.m_Type, pData);
+				auto *pPickup = (CPickup *)GameClient()->m_GameWorld.FindMatch(Item.m_Id, Item.m_Type, pData);
 				if(pPickup && pPickup->InDDNetTile())
 					continue;
 			}
-			const void *pPrev = Client()->SnapFindItem(IClient::SNAP_PREV, Item.m_Type, Item.m_ID);
+			const void *pPrev = Client()->SnapFindItem(IClient::SNAP_PREV, Item.m_Type, Item.m_Id);
 			if(pPrev)
 				RenderPickup((const CNetObj_Pickup *)pPrev, (const CNetObj_Pickup *)pData);
 		}
@@ -464,7 +464,7 @@ void CItems::OnRender()
 		{
 			if(UsePredicted)
 			{
-				auto *pLaser = dynamic_cast<CLaser *>(GameClient()->m_GameWorld.FindMatch(Item.m_ID, Item.m_Type, pData));
+				auto *pLaser = dynamic_cast<CLaser *>(GameClient()->m_GameWorld.FindMatch(Item.m_Id, Item.m_Type, pData));
 				if(pLaser && pLaser->GetOwner() >= 0 && GameClient()->m_aClients[pLaser->GetOwner()].m_IsPredictedLocal)
 					continue;
 			}
@@ -528,10 +528,10 @@ void CItems::OnRender()
 
 		if(Item.m_Type == NETOBJTYPE_FLAG)
 		{
-			const void *pPrev = Client()->SnapFindItem(IClient::SNAP_PREV, Item.m_Type, Item.m_ID);
+			const void *pPrev = Client()->SnapFindItem(IClient::SNAP_PREV, Item.m_Type, Item.m_Id);
 			if(pPrev)
 			{
-				const void *pPrevGameData = Client()->SnapFindItem(IClient::SNAP_PREV, NETOBJTYPE_GAMEDATA, m_pClient->m_Snap.m_GameDataSnapID);
+				const void *pPrevGameData = Client()->SnapFindItem(IClient::SNAP_PREV, NETOBJTYPE_GAMEDATA, m_pClient->m_Snap.m_GameDataSnapId);
 				RenderFlag(static_cast<const CNetObj_Flag *>(pPrev), static_cast<const CNetObj_Flag *>(pData),
 					static_cast<const CNetObj_GameData *>(pPrevGameData), m_pClient->m_Snap.m_pGameDataObj);
 			}
@@ -599,7 +599,7 @@ void CItems::ReconstructSmokeTrail(const CProjectileData *pCurrent, int DestroyT
 	bool LocalPlayerInGame = false;
 
 	if(m_pClient->m_Snap.m_pLocalInfo)
-		LocalPlayerInGame = m_pClient->m_aClients[m_pClient->m_Snap.m_pLocalInfo->m_ClientID].m_Team != TEAM_SPECTATORS;
+		LocalPlayerInGame = m_pClient->m_aClients[m_pClient->m_Snap.m_pLocalInfo->m_ClientId].m_Team != TEAM_SPECTATORS;
 	if(!m_pClient->AntiPingGunfire() || !LocalPlayerInGame)
 		return;
 	if(Client()->PredGameTick(g_Config.m_ClDummy) == pCurrent->m_StartTick)

--- a/src/game/client/components/items.h
+++ b/src/game/client/components/items.h
@@ -10,7 +10,7 @@ class CLaserData;
 
 class CItems : public CComponent
 {
-	void RenderProjectile(const CProjectileData *pCurrent, int ItemID);
+	void RenderProjectile(const CProjectileData *pCurrent, int ItemId);
 	void RenderPickup(const CNetObj_Pickup *pPrev, const CNetObj_Pickup *pCurrent, bool IsPredicted = false);
 	void RenderFlag(const CNetObj_Flag *pPrev, const CNetObj_Flag *pCurrent, const CNetObj_GameData *pPrevGameData, const CNetObj_GameData *pCurGameData);
 	void RenderLaser(const CLaserData *pCurrent, bool IsPredicted = false);

--- a/src/game/client/components/maplayers.cpp
+++ b/src/game/client/components/maplayers.cpp
@@ -813,36 +813,36 @@ void CMapLayers::OnMapLoad()
 					CQuad *pQuad = &pQuads[i];
 					for(int j = 0; j < 4; ++j)
 					{
-						int QuadIDX = j;
+						int QuadIdX = j;
 						if(j == 2)
-							QuadIDX = 3;
+							QuadIdX = 3;
 						else if(j == 3)
-							QuadIDX = 2;
+							QuadIdX = 2;
 						if(!Textured)
 						{
 							// ignore the conversion for the position coordinates
-							vtmpQuads[i].m_aVertices[j].m_X = (pQuad->m_aPoints[QuadIDX].x);
-							vtmpQuads[i].m_aVertices[j].m_Y = (pQuad->m_aPoints[QuadIDX].y);
+							vtmpQuads[i].m_aVertices[j].m_X = (pQuad->m_aPoints[QuadIdX].x);
+							vtmpQuads[i].m_aVertices[j].m_Y = (pQuad->m_aPoints[QuadIdX].y);
 							vtmpQuads[i].m_aVertices[j].m_CenterX = (pQuad->m_aPoints[4].x);
 							vtmpQuads[i].m_aVertices[j].m_CenterY = (pQuad->m_aPoints[4].y);
-							vtmpQuads[i].m_aVertices[j].m_R = (unsigned char)pQuad->m_aColors[QuadIDX].r;
-							vtmpQuads[i].m_aVertices[j].m_G = (unsigned char)pQuad->m_aColors[QuadIDX].g;
-							vtmpQuads[i].m_aVertices[j].m_B = (unsigned char)pQuad->m_aColors[QuadIDX].b;
-							vtmpQuads[i].m_aVertices[j].m_A = (unsigned char)pQuad->m_aColors[QuadIDX].a;
+							vtmpQuads[i].m_aVertices[j].m_R = (unsigned char)pQuad->m_aColors[QuadIdX].r;
+							vtmpQuads[i].m_aVertices[j].m_G = (unsigned char)pQuad->m_aColors[QuadIdX].g;
+							vtmpQuads[i].m_aVertices[j].m_B = (unsigned char)pQuad->m_aColors[QuadIdX].b;
+							vtmpQuads[i].m_aVertices[j].m_A = (unsigned char)pQuad->m_aColors[QuadIdX].a;
 						}
 						else
 						{
 							// ignore the conversion for the position coordinates
-							vtmpQuadsTextured[i].m_aVertices[j].m_X = (pQuad->m_aPoints[QuadIDX].x);
-							vtmpQuadsTextured[i].m_aVertices[j].m_Y = (pQuad->m_aPoints[QuadIDX].y);
+							vtmpQuadsTextured[i].m_aVertices[j].m_X = (pQuad->m_aPoints[QuadIdX].x);
+							vtmpQuadsTextured[i].m_aVertices[j].m_Y = (pQuad->m_aPoints[QuadIdX].y);
 							vtmpQuadsTextured[i].m_aVertices[j].m_CenterX = (pQuad->m_aPoints[4].x);
 							vtmpQuadsTextured[i].m_aVertices[j].m_CenterY = (pQuad->m_aPoints[4].y);
-							vtmpQuadsTextured[i].m_aVertices[j].m_U = fx2f(pQuad->m_aTexcoords[QuadIDX].x);
-							vtmpQuadsTextured[i].m_aVertices[j].m_V = fx2f(pQuad->m_aTexcoords[QuadIDX].y);
-							vtmpQuadsTextured[i].m_aVertices[j].m_R = (unsigned char)pQuad->m_aColors[QuadIDX].r;
-							vtmpQuadsTextured[i].m_aVertices[j].m_G = (unsigned char)pQuad->m_aColors[QuadIDX].g;
-							vtmpQuadsTextured[i].m_aVertices[j].m_B = (unsigned char)pQuad->m_aColors[QuadIDX].b;
-							vtmpQuadsTextured[i].m_aVertices[j].m_A = (unsigned char)pQuad->m_aColors[QuadIDX].a;
+							vtmpQuadsTextured[i].m_aVertices[j].m_U = fx2f(pQuad->m_aTexcoords[QuadIdX].x);
+							vtmpQuadsTextured[i].m_aVertices[j].m_V = fx2f(pQuad->m_aTexcoords[QuadIdX].y);
+							vtmpQuadsTextured[i].m_aVertices[j].m_R = (unsigned char)pQuad->m_aColors[QuadIdX].r;
+							vtmpQuadsTextured[i].m_aVertices[j].m_G = (unsigned char)pQuad->m_aColors[QuadIdX].g;
+							vtmpQuadsTextured[i].m_aVertices[j].m_B = (unsigned char)pQuad->m_aColors[QuadIdX].b;
+							vtmpQuadsTextured[i].m_aVertices[j].m_A = (unsigned char)pQuad->m_aColors[QuadIdX].a;
 						}
 					}
 				}

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -99,7 +99,7 @@ CMenus::CMenus()
 	m_PasswordInput.SetHidden(true);
 }
 
-int CMenus::DoButton_Toggle(const void *pID, int Checked, const CUIRect *pRect, bool Active)
+int CMenus::DoButton_Toggle(const void *pId, int Checked, const CUIRect *pRect, bool Active)
 {
 	Graphics()->TextureSet(g_pData->m_aImages[IMAGE_GUIBUTTONS].m_Id);
 	Graphics()->QuadsBegin();
@@ -108,7 +108,7 @@ int CMenus::DoButton_Toggle(const void *pID, int Checked, const CUIRect *pRect, 
 	RenderTools()->SelectSprite(Checked ? SPRITE_GUIBUTTON_ON : SPRITE_GUIBUTTON_OFF);
 	IGraphics::CQuadItem QuadItem(pRect->x, pRect->y, pRect->w, pRect->h);
 	Graphics()->QuadsDrawTL(&QuadItem, 1);
-	if(UI()->HotItem() == pID && Active)
+	if(Ui()->HotItem() == pId && Active)
 	{
 		RenderTools()->SelectSprite(SPRITE_GUIBUTTON_HOVER);
 		QuadItem = IGraphics::CQuadItem(pRect->x, pRect->y, pRect->w, pRect->h);
@@ -116,7 +116,7 @@ int CMenus::DoButton_Toggle(const void *pID, int Checked, const CUIRect *pRect, 
 	}
 	Graphics()->QuadsEnd();
 
-	return Active ? UI()->DoButtonLogic(pID, Checked, pRect) : 0;
+	return Active ? Ui()->DoButtonLogic(pId, Checked, pRect) : 0;
 }
 
 int CMenus::DoButton_Menu(CButtonContainer *pButtonContainer, const char *pText, int Checked, const CUIRect *pRect, const char *pImageName, int Corners, float Rounding, float FontFactor, ColorRGBA Color)
@@ -125,7 +125,7 @@ int CMenus::DoButton_Menu(CButtonContainer *pButtonContainer, const char *pText,
 
 	if(Checked)
 		Color = ColorRGBA(0.6f, 0.6f, 0.6f, 0.5f);
-	Color.a *= UI()->ButtonColorMul(pButtonContainer);
+	Color.a *= Ui()->ButtonColorMul(pButtonContainer);
 
 	pRect->Draw(Color, Corners, Rounding);
 
@@ -138,7 +138,7 @@ int CMenus::DoButton_Menu(CButtonContainer *pButtonContainer, const char *pText,
 		const CMenuImage *pImage = FindMenuImage(pImageName);
 		if(pImage)
 		{
-			Graphics()->TextureSet(UI()->HotItem() == pButtonContainer ? pImage->m_OrgTexture : pImage->m_GreyTexture);
+			Graphics()->TextureSet(Ui()->HotItem() == pButtonContainer ? pImage->m_OrgTexture : pImage->m_GreyTexture);
 			Graphics()->WrapClamp();
 			Graphics()->QuadsBegin();
 			Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
@@ -151,14 +151,14 @@ int CMenus::DoButton_Menu(CButtonContainer *pButtonContainer, const char *pText,
 
 	Text.HMargin(pRect->h >= 20.0f ? 2.0f : 1.0f, &Text);
 	Text.HMargin((Text.h * FontFactor) / 2.0f, &Text);
-	UI()->DoLabel(&Text, pText, Text.h * CUI::ms_FontmodHeight, TEXTALIGN_MC);
+	Ui()->DoLabel(&Text, pText, Text.h * CUi::ms_FontmodHeight, TEXTALIGN_MC);
 
-	return UI()->DoButtonLogic(pButtonContainer, Checked, pRect);
+	return Ui()->DoButtonLogic(pButtonContainer, Checked, pRect);
 }
 
 int CMenus::DoButton_MenuTab(CButtonContainer *pButtonContainer, const char *pText, int Checked, const CUIRect *pRect, int Corners, SUIAnimator *pAnimator, const ColorRGBA *pDefaultColor, const ColorRGBA *pActiveColor, const ColorRGBA *pHoverColor, float EdgeRounding, const SCommunityIcon *pCommunityIcon)
 {
-	const bool MouseInside = UI()->HotItem() == pButtonContainer;
+	const bool MouseInside = Ui()->HotItem() == pButtonContainer;
 	CUIRect Rect = *pRect;
 
 	if(pAnimator != NULL)
@@ -239,13 +239,13 @@ int CMenus::DoButton_MenuTab(CButtonContainer *pButtonContainer, const char *pTe
 	{
 		CUIRect Label;
 		Rect.HMargin(2.0f, &Label);
-		UI()->DoLabel(&Label, pText, Label.h * CUI::ms_FontmodHeight, TEXTALIGN_MC);
+		Ui()->DoLabel(&Label, pText, Label.h * CUi::ms_FontmodHeight, TEXTALIGN_MC);
 	}
 
-	return UI()->DoButtonLogic(pButtonContainer, Checked, pRect);
+	return Ui()->DoButtonLogic(pButtonContainer, Checked, pRect);
 }
 
-int CMenus::DoButton_GridHeader(const void *pID, const char *pText, int Checked, const CUIRect *pRect)
+int CMenus::DoButton_GridHeader(const void *pId, const char *pText, int Checked, const CUIRect *pRect)
 {
 	if(Checked == 2)
 		pRect->Draw(ColorRGBA(1, 0.98f, 0.5f, 0.55f), IGraphics::CORNER_T, 5.0f);
@@ -254,52 +254,52 @@ int CMenus::DoButton_GridHeader(const void *pID, const char *pText, int Checked,
 
 	CUIRect Temp;
 	pRect->VSplitLeft(5.0f, nullptr, &Temp);
-	UI()->DoLabel(&Temp, pText, pRect->h * CUI::ms_FontmodHeight, TEXTALIGN_ML);
-	return UI()->DoButtonLogic(pID, Checked, pRect);
+	Ui()->DoLabel(&Temp, pText, pRect->h * CUi::ms_FontmodHeight, TEXTALIGN_ML);
+	return Ui()->DoButtonLogic(pId, Checked, pRect);
 }
 
 int CMenus::DoButton_Favorite(const void *pButtonId, const void *pParentId, bool Checked, const CUIRect *pRect)
 {
-	if(Checked || (pParentId != nullptr && UI()->HotItem() == pParentId) || UI()->HotItem() == pButtonId)
+	if(Checked || (pParentId != nullptr && Ui()->HotItem() == pParentId) || Ui()->HotItem() == pButtonId)
 	{
 		TextRender()->SetFontPreset(EFontPreset::ICON_FONT);
 		TextRender()->SetRenderFlags(ETextRenderFlags::TEXT_RENDER_FLAG_ONLY_ADVANCE_WIDTH | ETextRenderFlags::TEXT_RENDER_FLAG_NO_X_BEARING | ETextRenderFlags::TEXT_RENDER_FLAG_NO_Y_BEARING | ETextRenderFlags::TEXT_RENDER_FLAG_NO_PIXEL_ALIGMENT | ETextRenderFlags::TEXT_RENDER_FLAG_NO_OVERSIZE);
-		const float Alpha = UI()->HotItem() == pButtonId ? 0.2f : 0.0f;
+		const float Alpha = Ui()->HotItem() == pButtonId ? 0.2f : 0.0f;
 		TextRender()->TextColor(Checked ? ColorRGBA(1.0f, 0.85f, 0.3f, 0.8f + Alpha) : ColorRGBA(0.5f, 0.5f, 0.5f, 0.8f + Alpha));
 		SLabelProperties Props;
 		Props.m_MaxWidth = pRect->w;
-		UI()->DoLabel(pRect, FONT_ICON_STAR, 12.0f, TEXTALIGN_MC, Props);
+		Ui()->DoLabel(pRect, FONT_ICON_STAR, 12.0f, TEXTALIGN_MC, Props);
 		TextRender()->TextColor(TextRender()->DefaultTextColor());
 		TextRender()->SetRenderFlags(0);
 		TextRender()->SetFontPreset(EFontPreset::DEFAULT_FONT);
 	}
-	return UI()->DoButtonLogic(pButtonId, 0, pRect);
+	return Ui()->DoButtonLogic(pButtonId, 0, pRect);
 }
 
-int CMenus::DoButton_CheckBox_Common(const void *pID, const char *pText, const char *pBoxText, const CUIRect *pRect)
+int CMenus::DoButton_CheckBox_Common(const void *pId, const char *pText, const char *pBoxText, const CUIRect *pRect)
 {
 	CUIRect Box, Label;
 	pRect->VSplitLeft(pRect->h, &Box, &Label);
 	Label.VSplitLeft(5.0f, nullptr, &Label);
 
 	Box.Margin(2.0f, &Box);
-	Box.Draw(ColorRGBA(1, 1, 1, 0.25f * UI()->ButtonColorMul(pID)), IGraphics::CORNER_ALL, 3.0f);
+	Box.Draw(ColorRGBA(1, 1, 1, 0.25f * Ui()->ButtonColorMul(pId)), IGraphics::CORNER_ALL, 3.0f);
 
 	const bool Checkable = *pBoxText == 'X';
 	if(Checkable)
 	{
 		TextRender()->SetRenderFlags(ETextRenderFlags::TEXT_RENDER_FLAG_ONLY_ADVANCE_WIDTH | ETextRenderFlags::TEXT_RENDER_FLAG_NO_X_BEARING | ETextRenderFlags::TEXT_RENDER_FLAG_NO_Y_BEARING | ETextRenderFlags::TEXT_RENDER_FLAG_NO_OVERSIZE | ETextRenderFlags::TEXT_RENDER_FLAG_NO_PIXEL_ALIGMENT);
 		TextRender()->SetFontPreset(EFontPreset::ICON_FONT);
-		UI()->DoLabel(&Box, FONT_ICON_XMARK, Box.h * CUI::ms_FontmodHeight, TEXTALIGN_MC);
+		Ui()->DoLabel(&Box, FONT_ICON_XMARK, Box.h * CUi::ms_FontmodHeight, TEXTALIGN_MC);
 		TextRender()->SetFontPreset(EFontPreset::DEFAULT_FONT);
 	}
 	else
-		UI()->DoLabel(&Box, pBoxText, Box.h * CUI::ms_FontmodHeight, TEXTALIGN_MC);
+		Ui()->DoLabel(&Box, pBoxText, Box.h * CUi::ms_FontmodHeight, TEXTALIGN_MC);
 
 	TextRender()->SetRenderFlags(0);
-	UI()->DoLabel(&Label, pText, Box.h * CUI::ms_FontmodHeight, TEXTALIGN_ML);
+	Ui()->DoLabel(&Label, pText, Box.h * CUi::ms_FontmodHeight, TEXTALIGN_ML);
 
-	return UI()->DoButtonLogic(pID, 0, pRect);
+	return Ui()->DoButtonLogic(pId, 0, pRect);
 }
 
 void CMenus::DoLaserPreview(const CUIRect *pRect, const ColorHSLA LaserOutlineColor, const ColorHSLA LaserInnerColor, const int LaserType)
@@ -373,7 +373,7 @@ void CMenus::DoLaserPreview(const CUIRect *pRect, const ColorHSLA LaserOutlineCo
 	}
 }
 
-ColorHSLA CMenus::DoLine_ColorPicker(CButtonContainer *pResetID, const float LineSize, const float LabelSize, const float BottomMargin, CUIRect *pMainRect, const char *pText, unsigned int *pColorValue, const ColorRGBA DefaultColor, bool CheckBoxSpacing, int *pCheckBoxValue, bool Alpha)
+ColorHSLA CMenus::DoLine_ColorPicker(CButtonContainer *pResetId, const float LineSize, const float LabelSize, const float BottomMargin, CUIRect *pMainRect, const char *pText, unsigned int *pColorValue, const ColorRGBA DefaultColor, bool CheckBoxSpacing, int *pCheckBoxValue, bool Alpha)
 {
 	CUIRect Section, ColorPickerButton, ResetButton, Label;
 
@@ -398,12 +398,12 @@ ColorHSLA CMenus::DoLine_ColorPicker(CButtonContainer *pResetID, const float Lin
 	Section.VSplitRight(8.0f, &Section, nullptr);
 	Section.VSplitRight(Section.h, &Section, &ColorPickerButton);
 
-	UI()->DoLabel(&Label, pText, LabelSize, TEXTALIGN_ML);
+	Ui()->DoLabel(&Label, pText, LabelSize, TEXTALIGN_ML);
 
 	ColorHSLA PickedColor = DoButton_ColorPicker(&ColorPickerButton, pColorValue, Alpha);
 
 	ResetButton.HMargin(2.0f, &ResetButton);
-	if(DoButton_Menu(pResetID, Localize("Reset"), 0, &ResetButton, nullptr, IGraphics::CORNER_ALL, 4.0f, 0.1f, ColorRGBA(1.0f, 1.0f, 1.0f, 0.25f)))
+	if(DoButton_Menu(pResetId, Localize("Reset"), 0, &ResetButton, nullptr, IGraphics::CORNER_ALL, 4.0f, 0.1f, ColorRGBA(1.0f, 1.0f, 1.0f, 0.25f)))
 	{
 		*pColorValue = color_cast<ColorHSLA>(DefaultColor).Pack(Alpha);
 	}
@@ -416,7 +416,7 @@ ColorHSLA CMenus::DoButton_ColorPicker(const CUIRect *pRect, unsigned int *pHsla
 	ColorHSLA HslaColor = ColorHSLA(*pHslaColor, Alpha);
 
 	ColorRGBA Outline = ColorRGBA(1.0f, 1.0f, 1.0f, 0.25f);
-	Outline.a *= UI()->ButtonColorMul(pHslaColor);
+	Outline.a *= Ui()->ButtonColorMul(pHslaColor);
 
 	CUIRect Rect;
 	pRect->Margin(3.0f, &Rect);
@@ -424,17 +424,17 @@ ColorHSLA CMenus::DoButton_ColorPicker(const CUIRect *pRect, unsigned int *pHsla
 	pRect->Draw(Outline, IGraphics::CORNER_ALL, 4.0f);
 	Rect.Draw(color_cast<ColorRGBA>(HslaColor), IGraphics::CORNER_ALL, 4.0f);
 
-	static CUI::SColorPickerPopupContext s_ColorPickerPopupContext;
-	if(UI()->DoButtonLogic(pHslaColor, 0, pRect))
+	static CUi::SColorPickerPopupContext s_ColorPickerPopupContext;
+	if(Ui()->DoButtonLogic(pHslaColor, 0, pRect))
 	{
 		s_ColorPickerPopupContext.m_pHslaColor = pHslaColor;
 		s_ColorPickerPopupContext.m_HslaColor = HslaColor;
 		s_ColorPickerPopupContext.m_HsvaColor = color_cast<ColorHSVA>(HslaColor);
 		s_ColorPickerPopupContext.m_RgbaColor = color_cast<ColorRGBA>(s_ColorPickerPopupContext.m_HsvaColor);
 		s_ColorPickerPopupContext.m_Alpha = Alpha;
-		UI()->ShowPopupColorPicker(UI()->MouseX(), UI()->MouseY(), &s_ColorPickerPopupContext);
+		Ui()->ShowPopupColorPicker(Ui()->MouseX(), Ui()->MouseY(), &s_ColorPickerPopupContext);
 	}
-	else if(UI()->IsPopupOpen(&s_ColorPickerPopupContext) && s_ColorPickerPopupContext.m_pHslaColor == pHslaColor)
+	else if(Ui()->IsPopupOpen(&s_ColorPickerPopupContext) && s_ColorPickerPopupContext.m_pHslaColor == pHslaColor)
 	{
 		HslaColor = color_cast<ColorHSLA>(s_ColorPickerPopupContext.m_HsvaColor);
 	}
@@ -442,12 +442,12 @@ ColorHSLA CMenus::DoButton_ColorPicker(const CUIRect *pRect, unsigned int *pHsla
 	return HslaColor;
 }
 
-int CMenus::DoButton_CheckBoxAutoVMarginAndSet(const void *pID, const char *pText, int *pValue, CUIRect *pRect, float VMargin)
+int CMenus::DoButton_CheckBoxAutoVMarginAndSet(const void *pId, const char *pText, int *pValue, CUIRect *pRect, float VMargin)
 {
 	CUIRect CheckBoxRect;
 	pRect->HSplitTop(VMargin, &CheckBoxRect, pRect);
 
-	int Logic = DoButton_CheckBox_Common(pID, pText, *pValue ? "X" : "", &CheckBoxRect);
+	int Logic = DoButton_CheckBox_Common(pId, pText, *pValue ? "X" : "", &CheckBoxRect);
 
 	if(Logic)
 		*pValue ^= 1;
@@ -455,32 +455,32 @@ int CMenus::DoButton_CheckBoxAutoVMarginAndSet(const void *pID, const char *pTex
 	return Logic;
 }
 
-int CMenus::DoButton_CheckBox(const void *pID, const char *pText, int Checked, const CUIRect *pRect)
+int CMenus::DoButton_CheckBox(const void *pId, const char *pText, int Checked, const CUIRect *pRect)
 {
-	return DoButton_CheckBox_Common(pID, pText, Checked ? "X" : "", pRect);
+	return DoButton_CheckBox_Common(pId, pText, Checked ? "X" : "", pRect);
 }
 
-int CMenus::DoButton_CheckBox_Number(const void *pID, const char *pText, int Checked, const CUIRect *pRect)
+int CMenus::DoButton_CheckBox_Number(const void *pId, const char *pText, int Checked, const CUIRect *pRect)
 {
 	char aBuf[16];
 	str_from_int(Checked, aBuf);
-	return DoButton_CheckBox_Common(pID, pText, aBuf, pRect);
+	return DoButton_CheckBox_Common(pId, pText, aBuf, pRect);
 }
 
-int CMenus::DoKeyReader(const void *pID, const CUIRect *pRect, int Key, int ModifierCombination, int *pNewModifierCombination)
+int CMenus::DoKeyReader(const void *pId, const CUIRect *pRect, int Key, int ModifierCombination, int *pNewModifierCombination)
 {
 	// process
-	static const void *s_pGrabbedID = nullptr;
+	static const void *s_pGrabbedId = nullptr;
 	static bool s_MouseReleased = true;
 	static int s_ButtonUsed = 0;
-	const bool Inside = UI()->MouseHovered(pRect);
+	const bool Inside = Ui()->MouseHovered(pRect);
 	int NewKey = Key;
 	*pNewModifierCombination = ModifierCombination;
 
-	if(!UI()->MouseButton(0) && !UI()->MouseButton(1) && s_pGrabbedID == pID)
+	if(!Ui()->MouseButton(0) && !Ui()->MouseButton(1) && s_pGrabbedId == pId)
 		s_MouseReleased = true;
 
-	if(UI()->CheckActiveItem(pID))
+	if(Ui()->CheckActiveItem(pId))
 	{
 		if(m_Binder.m_GotKey)
 		{
@@ -491,54 +491,54 @@ int CMenus::DoKeyReader(const void *pID, const CUIRect *pRect, int Key, int Modi
 				*pNewModifierCombination = m_Binder.m_ModifierCombination;
 			}
 			m_Binder.m_GotKey = false;
-			UI()->SetActiveItem(nullptr);
+			Ui()->SetActiveItem(nullptr);
 			s_MouseReleased = false;
-			s_pGrabbedID = pID;
+			s_pGrabbedId = pId;
 		}
 
-		if(s_ButtonUsed == 1 && !UI()->MouseButton(1))
+		if(s_ButtonUsed == 1 && !Ui()->MouseButton(1))
 		{
 			if(Inside)
 				NewKey = 0;
-			UI()->SetActiveItem(nullptr);
+			Ui()->SetActiveItem(nullptr);
 		}
 	}
-	else if(UI()->HotItem() == pID)
+	else if(Ui()->HotItem() == pId)
 	{
 		if(s_MouseReleased)
 		{
-			if(UI()->MouseButton(0))
+			if(Ui()->MouseButton(0))
 			{
 				m_Binder.m_TakeKey = true;
 				m_Binder.m_GotKey = false;
-				UI()->SetActiveItem(pID);
+				Ui()->SetActiveItem(pId);
 				s_ButtonUsed = 0;
 			}
 
-			if(UI()->MouseButton(1))
+			if(Ui()->MouseButton(1))
 			{
-				UI()->SetActiveItem(pID);
+				Ui()->SetActiveItem(pId);
 				s_ButtonUsed = 1;
 			}
 		}
 	}
 
 	if(Inside)
-		UI()->SetHotItem(pID);
+		Ui()->SetHotItem(pId);
 
 	char aBuf[64];
-	if(UI()->CheckActiveItem(pID) && s_ButtonUsed == 0)
+	if(Ui()->CheckActiveItem(pId) && s_ButtonUsed == 0)
 		str_copy(aBuf, Localize("Press a key…"));
 	else if(NewKey == 0)
 		aBuf[0] = '\0';
 	else
 		str_format(aBuf, sizeof(aBuf), "%s%s", CBinds::GetKeyBindModifiersName(*pNewModifierCombination), Input()->KeyName(NewKey));
 
-	const ColorRGBA Color = UI()->CheckActiveItem(pID) && m_Binder.m_TakeKey ? ColorRGBA(0.0f, 1.0f, 0.0f, 0.4f) : ColorRGBA(1.0f, 1.0f, 1.0f, 0.5f * UI()->ButtonColorMul(pID));
+	const ColorRGBA Color = Ui()->CheckActiveItem(pId) && m_Binder.m_TakeKey ? ColorRGBA(0.0f, 1.0f, 0.0f, 0.4f) : ColorRGBA(1.0f, 1.0f, 1.0f, 0.5f * Ui()->ButtonColorMul(pId));
 	pRect->Draw(Color, IGraphics::CORNER_ALL, 5.0f);
 	CUIRect Temp;
 	pRect->HMargin(1.0f, &Temp);
-	UI()->DoLabel(&Temp, aBuf, Temp.h * CUI::ms_FontmodHeight, TEXTALIGN_MC);
+	Ui()->DoLabel(&Temp, aBuf, Temp.h * CUi::ms_FontmodHeight, TEXTALIGN_MC);
 
 	return NewKey;
 }
@@ -785,14 +785,14 @@ void CMenus::RenderLoading(const char *pCaption, const char *pContent, int Incre
 	// need up date this here to get correct
 	ms_GuiColor = color_cast<ColorRGBA>(ColorHSLA(g_Config.m_UiColor, true));
 
-	UI()->MapScreen();
+	Ui()->MapScreen();
 
 	if(!RenderMenuBackgroundMap || !m_pBackground->Render())
 	{
 		RenderBackground();
 	}
 
-	CUIRect Box = *UI()->Screen();
+	CUIRect Box = *Ui()->Screen();
 	Box.Margin(160.0f, &Box);
 
 	Graphics()->BlendNormal();
@@ -804,12 +804,12 @@ void CMenus::RenderLoading(const char *pCaption, const char *pContent, int Incre
 	Box.HSplitTop(20.f, nullptr, &Box);
 	Box.HSplitTop(24.f, &Part, &Box);
 	Part.VMargin(20.f, &Part);
-	UI()->DoLabel(&Part, pCaption, 24.f, TEXTALIGN_MC);
+	Ui()->DoLabel(&Part, pCaption, 24.f, TEXTALIGN_MC);
 
 	Box.HSplitTop(20.f, nullptr, &Box);
 	Box.HSplitTop(24.f, &Part, &Box);
 	Part.VMargin(20.f, &Part);
-	UI()->DoLabel(&Part, pContent, 20.0f, TEXTALIGN_MC);
+	Ui()->DoLabel(&Part, pContent, 20.0f, TEXTALIGN_MC);
 
 	if(RenderLoadingBar)
 		Graphics()->DrawRect(Box.x + 40, Box.y + Box.h - 75, (Box.w - 80) * Percent, 25, ColorRGBA(1.0f, 1.0f, 1.0f, 0.75f), IGraphics::CORNER_ALL, 5.0f);
@@ -837,12 +837,12 @@ void CMenus::RenderNews(CUIRect MainView)
 		{
 			MainView.HSplitTop(30.0f, &Label, &MainView);
 			aLine[Len - 1] = '\0';
-			UI()->DoLabel(&Label, aLine + 1, 20.0f, TEXTALIGN_ML);
+			Ui()->DoLabel(&Label, aLine + 1, 20.0f, TEXTALIGN_ML);
 		}
 		else
 		{
 			MainView.HSplitTop(20.0f, &Label, &MainView);
-			UI()->DoLabel(&Label, aLine, 15.f, TEXTALIGN_ML);
+			Ui()->DoLabel(&Label, aLine, 15.f, TEXTALIGN_ML);
 		}
 	}
 }
@@ -869,8 +869,8 @@ void CMenus::OnInit()
 
 	SetMenuPage(g_Config.m_UiPage);
 
-	m_RefreshButton.Init(UI(), -1);
-	m_ConnectButton.Init(UI(), -1);
+	m_RefreshButton.Init(Ui(), -1);
+	m_ConnectButton.Init(Ui(), -1);
 
 	Console()->Chain("add_favorite", ConchainFavoritesUpdate, this);
 	Console()->Chain("remove_favorite", ConchainFavoritesUpdate, this);
@@ -943,7 +943,7 @@ void CMenus::UpdateMusicState()
 void CMenus::PopupMessage(const char *pTitle, const char *pMessage, const char *pButtonLabel, int NextPopup, FPopupButtonCallback pfnButtonCallback)
 {
 	// reset active item
-	UI()->SetActiveItem(nullptr);
+	Ui()->SetActiveItem(nullptr);
 
 	str_copy(m_aPopupTitle, pTitle);
 	str_copy(m_aPopupMessage, pMessage);
@@ -957,7 +957,7 @@ void CMenus::PopupConfirm(const char *pTitle, const char *pMessage, const char *
 	FPopupButtonCallback pfnConfirmButtonCallback, int ConfirmNextPopup, FPopupButtonCallback pfnCancelButtonCallback, int CancelNextPopup)
 {
 	// reset active item
-	UI()->SetActiveItem(nullptr);
+	Ui()->SetActiveItem(nullptr);
 
 	str_copy(m_aPopupTitle, pTitle);
 	str_copy(m_aPopupMessage, pMessage);
@@ -979,7 +979,7 @@ void CMenus::PopupWarning(const char *pTopic, const char *pBody, const char *pBu
 	dbg_msg(pTopic, "%s", BodyStr.c_str());
 
 	// reset active item
-	UI()->SetActiveItem(nullptr);
+	Ui()->SetActiveItem(nullptr);
 
 	str_copy(m_aMessageTopic, pTopic);
 	str_copy(m_aMessageBody, pBody);
@@ -1001,11 +1001,11 @@ void CMenus::Render()
 	if(Client()->State() == IClient::STATE_DEMOPLAYBACK && m_Popup == POPUP_NONE)
 		return;
 
-	CUIRect Screen = *UI()->Screen();
+	CUIRect Screen = *Ui()->Screen();
 	Screen.Margin(10.0f, &Screen);
 
-	UI()->MapScreen();
-	UI()->ResetMouseSlow();
+	Ui()->MapScreen();
+	Ui()->ResetMouseSlow();
 
 	static int s_Frame = 0;
 	if(s_Frame == 0)
@@ -1161,10 +1161,10 @@ void CMenus::Render()
 		RenderPopupFullscreen(Screen);
 	}
 
-	UI()->RenderPopupMenus();
+	Ui()->RenderPopupMenus();
 
 	// Handle this escape hotkey after popup menus
-	if(!m_ShowStart && Client()->State() == IClient::STATE_OFFLINE && UI()->ConsumeHotkey(CUI::HOTKEY_ESCAPE))
+	if(!m_ShowStart && Client()->State() == IClient::STATE_OFFLINE && Ui()->ConsumeHotkey(CUi::HOTKEY_ESCAPE))
 	{
 		m_ShowStart = true;
 	}
@@ -1340,9 +1340,9 @@ void CMenus::RenderPopupFullscreen(CUIRect Screen)
 	Props.m_MaxWidth = (int)Part.w;
 
 	if(TextRender()->TextWidth(24.f, pTitle, -1, -1.0f) > Part.w)
-		UI()->DoLabel(&Part, pTitle, 24.f, TEXTALIGN_ML, Props);
+		Ui()->DoLabel(&Part, pTitle, 24.f, TEXTALIGN_ML, Props);
 	else
-		UI()->DoLabel(&Part, pTitle, 24.f, TEXTALIGN_MC);
+		Ui()->DoLabel(&Part, pTitle, 24.f, TEXTALIGN_MC);
 
 	Box.HSplitTop(20.f, &Part, &Box);
 	Box.HSplitTop(24.f, &Part, &Box);
@@ -1355,18 +1355,18 @@ void CMenus::RenderPopupFullscreen(CUIRect Screen)
 		SLabelProperties IpLabelProps;
 		IpLabelProps.m_MaxWidth = Part.w;
 		IpLabelProps.m_EllipsisAtEnd = true;
-		UI()->DoLabel(&Part, Client()->ConnectAddressString(), FontSize, TEXTALIGN_MC, IpLabelProps);
+		Ui()->DoLabel(&Part, Client()->ConnectAddressString(), FontSize, TEXTALIGN_MC, IpLabelProps);
 		Box.HSplitTop(20.f, &Part, &Box);
 		Box.HSplitTop(24.f, &Part, &Box);
 	}
 
 	Props.m_MaxWidth = (int)Part.w;
 	if(TopAlign)
-		UI()->DoLabel(&Part, pExtraText, FontSize, TEXTALIGN_TL, Props);
+		Ui()->DoLabel(&Part, pExtraText, FontSize, TEXTALIGN_TL, Props);
 	else if(TextRender()->TextWidth(FontSize, pExtraText, -1, -1.0f) > Part.w)
-		UI()->DoLabel(&Part, pExtraText, FontSize, TEXTALIGN_ML, Props);
+		Ui()->DoLabel(&Part, pExtraText, FontSize, TEXTALIGN_ML, Props);
 	else
-		UI()->DoLabel(&Part, pExtraText, FontSize, TEXTALIGN_MC);
+		Ui()->DoLabel(&Part, pExtraText, FontSize, TEXTALIGN_MC);
 
 	if(m_Popup == POPUP_MESSAGE || m_Popup == POPUP_CONFIRM)
 	{
@@ -1378,7 +1378,7 @@ void CMenus::RenderPopupFullscreen(CUIRect Screen)
 		if(m_Popup == POPUP_MESSAGE)
 		{
 			static CButtonContainer s_ButtonConfirm;
-			if(DoButton_Menu(&s_ButtonConfirm, m_aPopupButtons[BUTTON_CONFIRM].m_aLabel, 0, &ButtonBar) || UI()->ConsumeHotkey(CUI::HOTKEY_ESCAPE) || UI()->ConsumeHotkey(CUI::HOTKEY_ENTER))
+			if(DoButton_Menu(&s_ButtonConfirm, m_aPopupButtons[BUTTON_CONFIRM].m_aLabel, 0, &ButtonBar) || Ui()->ConsumeHotkey(CUi::HOTKEY_ESCAPE) || Ui()->ConsumeHotkey(CUi::HOTKEY_ENTER))
 			{
 				m_Popup = m_aPopupButtons[BUTTON_CONFIRM].m_NextPopup;
 				(this->*m_aPopupButtons[BUTTON_CONFIRM].m_pfnCallback)();
@@ -1390,14 +1390,14 @@ void CMenus::RenderPopupFullscreen(CUIRect Screen)
 			ButtonBar.VSplitMid(&CancelButton, &ConfirmButton, 40.0f);
 
 			static CButtonContainer s_ButtonCancel;
-			if(DoButton_Menu(&s_ButtonCancel, m_aPopupButtons[BUTTON_CANCEL].m_aLabel, 0, &CancelButton) || UI()->ConsumeHotkey(CUI::HOTKEY_ESCAPE))
+			if(DoButton_Menu(&s_ButtonCancel, m_aPopupButtons[BUTTON_CANCEL].m_aLabel, 0, &CancelButton) || Ui()->ConsumeHotkey(CUi::HOTKEY_ESCAPE))
 			{
 				m_Popup = m_aPopupButtons[BUTTON_CANCEL].m_NextPopup;
 				(this->*m_aPopupButtons[BUTTON_CANCEL].m_pfnCallback)();
 			}
 
 			static CButtonContainer s_ButtonConfirm;
-			if(DoButton_Menu(&s_ButtonConfirm, m_aPopupButtons[BUTTON_CONFIRM].m_aLabel, 0, &ConfirmButton) || UI()->ConsumeHotkey(CUI::HOTKEY_ENTER))
+			if(DoButton_Menu(&s_ButtonConfirm, m_aPopupButtons[BUTTON_CONFIRM].m_aLabel, 0, &ConfirmButton) || Ui()->ConsumeHotkey(CUi::HOTKEY_ENTER))
 			{
 				m_Popup = m_aPopupButtons[BUTTON_CONFIRM].m_NextPopup;
 				(this->*m_aPopupButtons[BUTTON_CONFIRM].m_pfnCallback)();
@@ -1416,7 +1416,7 @@ void CMenus::RenderPopupFullscreen(CUIRect Screen)
 		{
 			str_format(aBuf, sizeof(aBuf), "%s\n\n%s", Localize("There's an unsaved map in the editor, you might want to save it."), Localize("Continue anyway?"));
 			Props.m_MaxWidth = Part.w - 20.0f;
-			UI()->DoLabel(&Box, aBuf, 20.f, TEXTALIGN_ML, Props);
+			Ui()->DoLabel(&Box, aBuf, 20.f, TEXTALIGN_ML, Props);
 		}
 
 		// buttons
@@ -1426,11 +1426,11 @@ void CMenus::RenderPopupFullscreen(CUIRect Screen)
 		No.VMargin(20.0f, &No);
 
 		static CButtonContainer s_ButtonAbort;
-		if(DoButton_Menu(&s_ButtonAbort, Localize("No"), 0, &No) || UI()->ConsumeHotkey(CUI::HOTKEY_ESCAPE))
+		if(DoButton_Menu(&s_ButtonAbort, Localize("No"), 0, &No) || Ui()->ConsumeHotkey(CUi::HOTKEY_ESCAPE))
 			m_Popup = POPUP_NONE;
 
 		static CButtonContainer s_ButtonTryAgain;
-		if(DoButton_Menu(&s_ButtonTryAgain, Localize("Yes"), 0, &Yes) || UI()->ConsumeHotkey(CUI::HOTKEY_ENTER))
+		if(DoButton_Menu(&s_ButtonTryAgain, Localize("Yes"), 0, &Yes) || Ui()->ConsumeHotkey(CUi::HOTKEY_ENTER))
 		{
 			if(m_Popup == POPUP_RESTART)
 			{
@@ -1458,11 +1458,11 @@ void CMenus::RenderPopupFullscreen(CUIRect Screen)
 		Abort.VMargin(20.0f, &Abort);
 
 		static CButtonContainer s_ButtonAbort;
-		if(DoButton_Menu(&s_ButtonAbort, Localize("Abort"), 0, &Abort) || UI()->ConsumeHotkey(CUI::HOTKEY_ESCAPE))
+		if(DoButton_Menu(&s_ButtonAbort, Localize("Abort"), 0, &Abort) || Ui()->ConsumeHotkey(CUi::HOTKEY_ESCAPE))
 			m_Popup = POPUP_NONE;
 
 		static CButtonContainer s_ButtonTryAgain;
-		if(DoButton_Menu(&s_ButtonTryAgain, Localize("Try again"), 0, &TryAgain) || UI()->ConsumeHotkey(CUI::HOTKEY_ENTER))
+		if(DoButton_Menu(&s_ButtonTryAgain, Localize("Try again"), 0, &TryAgain) || Ui()->ConsumeHotkey(CUi::HOTKEY_ENTER))
 		{
 			Client()->Connect(g_Config.m_UiServerAddress, g_Config.m_Password);
 		}
@@ -1474,8 +1474,8 @@ void CMenus::RenderPopupFullscreen(CUIRect Screen)
 		Label.VSplitLeft(100.0f, 0, &TextBox);
 		TextBox.VSplitLeft(20.0f, 0, &TextBox);
 		TextBox.VSplitRight(60.0f, &TextBox, 0);
-		UI()->DoLabel(&Label, Localize("Password"), 18.0f, TEXTALIGN_ML);
-		UI()->DoClearableEditBox(&m_PasswordInput, &TextBox, 12.0f);
+		Ui()->DoLabel(&Label, Localize("Password"), 18.0f, TEXTALIGN_ML);
+		Ui()->DoClearableEditBox(&m_PasswordInput, &TextBox, 12.0f);
 	}
 	else if(m_Popup == POPUP_CONNECTING)
 	{
@@ -1486,7 +1486,7 @@ void CMenus::RenderPopupFullscreen(CUIRect Screen)
 		Part.VMargin(120.0f, &Part);
 
 		static CButtonContainer s_Button;
-		if(DoButton_Menu(&s_Button, pButtonText, 0, &Part) || UI()->ConsumeHotkey(CUI::HOTKEY_ESCAPE))
+		if(DoButton_Menu(&s_Button, pButtonText, 0, &Part) || Ui()->ConsumeHotkey(CUi::HOTKEY_ESCAPE))
 		{
 			Client()->Disconnect();
 			m_Popup = POPUP_NONE;
@@ -1518,7 +1518,7 @@ void CMenus::RenderPopupFullscreen(CUIRect Screen)
 			Box.HSplitTop(64.f, 0, &Box);
 			Box.HSplitTop(24.f, &Part, &Box);
 			str_format(aBuf, sizeof(aBuf), "%d/%d KiB (%.1f KiB/s)", Client()->MapDownloadAmount() / 1024, Client()->MapDownloadTotalsize() / 1024, m_DownloadSpeed / 1024.0f);
-			UI()->DoLabel(&Part, aBuf, 20.f, TEXTALIGN_MC);
+			Ui()->DoLabel(&Part, aBuf, 20.f, TEXTALIGN_MC);
 
 			// time left
 			int TimeLeft = maximum(1, m_DownloadSpeed > 0.0f ? static_cast<int>((Client()->MapDownloadTotalsize() - Client()->MapDownloadAmount()) / m_DownloadSpeed) : 1);
@@ -1533,7 +1533,7 @@ void CMenus::RenderPopupFullscreen(CUIRect Screen)
 			}
 			Box.HSplitTop(20.f, 0, &Box);
 			Box.HSplitTop(24.f, &Part, &Box);
-			UI()->DoLabel(&Part, aBuf, 20.f, TEXTALIGN_MC);
+			Ui()->DoLabel(&Part, aBuf, 20.f, TEXTALIGN_MC);
 
 			// progress bar
 			Box.HSplitTop(20.f, 0, &Box);
@@ -1557,7 +1557,7 @@ void CMenus::RenderPopupFullscreen(CUIRect Screen)
 		Button.VMargin(120.0f, &Button);
 
 		static CButtonContainer s_Button;
-		if(DoButton_Menu(&s_Button, Localize("Ok"), 0, &Button) || UI()->ConsumeHotkey(CUI::HOTKEY_ESCAPE) || UI()->ConsumeHotkey(CUI::HOTKEY_ENTER) || Activated)
+		if(DoButton_Menu(&s_Button, Localize("Ok"), 0, &Button) || Ui()->ConsumeHotkey(CUi::HOTKEY_ESCAPE) || Ui()->ConsumeHotkey(CUi::HOTKEY_ENTER) || Activated)
 			m_Popup = POPUP_FIRST_LAUNCH;
 	}
 	else if(m_Popup == POPUP_RENAME_DEMO)
@@ -1574,11 +1574,11 @@ void CMenus::RenderPopupFullscreen(CUIRect Screen)
 		Abort.VMargin(20.0f, &Abort);
 
 		static CButtonContainer s_ButtonAbort;
-		if(DoButton_Menu(&s_ButtonAbort, Localize("Abort"), 0, &Abort) || UI()->ConsumeHotkey(CUI::HOTKEY_ESCAPE))
+		if(DoButton_Menu(&s_ButtonAbort, Localize("Abort"), 0, &Abort) || Ui()->ConsumeHotkey(CUi::HOTKEY_ESCAPE))
 			m_Popup = POPUP_NONE;
 
 		static CButtonContainer s_ButtonOk;
-		if(DoButton_Menu(&s_ButtonOk, Localize("Ok"), 0, &Ok) || UI()->ConsumeHotkey(CUI::HOTKEY_ENTER))
+		if(DoButton_Menu(&s_ButtonOk, Localize("Ok"), 0, &Ok) || Ui()->ConsumeHotkey(CUi::HOTKEY_ENTER))
 		{
 			m_Popup = POPUP_NONE;
 			// rename demo
@@ -1618,8 +1618,8 @@ void CMenus::RenderPopupFullscreen(CUIRect Screen)
 		Label.VSplitLeft(120.0f, 0, &TextBox);
 		TextBox.VSplitLeft(20.0f, 0, &TextBox);
 		TextBox.VSplitRight(60.0f, &TextBox, 0);
-		UI()->DoLabel(&Label, Localize("New name:"), 18.0f, TEXTALIGN_ML);
-		UI()->DoEditBox(&m_DemoRenameInput, &TextBox, 12.0f);
+		Ui()->DoLabel(&Label, Localize("New name:"), 18.0f, TEXTALIGN_ML);
+		Ui()->DoEditBox(&m_DemoRenameInput, &TextBox, 12.0f);
 	}
 #if defined(CONF_VIDEORECORDER)
 	else if(m_Popup == POPUP_RENDER_DEMO)
@@ -1633,14 +1633,14 @@ void CMenus::RenderPopupFullscreen(CUIRect Screen)
 		Row.VSplitMid(&Abort, &Ok, 40.0f);
 
 		static CButtonContainer s_ButtonAbort;
-		if(DoButton_Menu(&s_ButtonAbort, Localize("Abort"), 0, &Abort) || UI()->ConsumeHotkey(CUI::HOTKEY_ESCAPE))
+		if(DoButton_Menu(&s_ButtonAbort, Localize("Abort"), 0, &Abort) || Ui()->ConsumeHotkey(CUi::HOTKEY_ESCAPE))
 		{
 			m_DemoRenderInput.Clear();
 			m_Popup = POPUP_NONE;
 		}
 
 		static CButtonContainer s_ButtonOk;
-		if(DoButton_Menu(&s_ButtonOk, Localize("Ok"), 0, &Ok) || UI()->ConsumeHotkey(CUI::HOTKEY_ENTER))
+		if(DoButton_Menu(&s_ButtonOk, Localize("Ok"), 0, &Ok) || Ui()->ConsumeHotkey(CUi::HOTKEY_ENTER))
 		{
 			m_Popup = POPUP_NONE;
 			// render video
@@ -1710,7 +1710,7 @@ void CMenus::RenderPopupFullscreen(CUIRect Screen)
 		char aBuffer[128];
 		const char *pPaused = m_StartPaused ? Localize("(paused)") : "";
 		str_format(aBuffer, sizeof(aBuffer), "%s: ×%g %s", Localize("Speed"), g_aSpeeds[m_Speed], pPaused);
-		UI()->DoLabel(&Row, aBuffer, 12.8f, TEXTALIGN_ML);
+		Ui()->DoLabel(&Row, aBuffer, 12.8f, TEXTALIGN_ML);
 
 		Box.HSplitBottom(16.0f, &Box, nullptr);
 		Box.HSplitBottom(24.0f, &Box, &Row);
@@ -1718,8 +1718,8 @@ void CMenus::RenderPopupFullscreen(CUIRect Screen)
 		CUIRect Label, TextBox;
 		Row.VSplitLeft(110.0f, &Label, &TextBox);
 		TextBox.VSplitLeft(10.0f, nullptr, &TextBox);
-		UI()->DoLabel(&Label, Localize("Video name:"), 12.8f, TEXTALIGN_ML);
-		UI()->DoEditBox(&m_DemoRenderInput, &TextBox, 12.8f);
+		Ui()->DoLabel(&Label, Localize("Video name:"), 12.8f, TEXTALIGN_ML);
+		Ui()->DoEditBox(&m_DemoRenderInput, &TextBox, 12.8f);
 	}
 	else if(m_Popup == POPUP_RENDER_DONE)
 	{
@@ -1749,7 +1749,7 @@ void CMenus::RenderPopupFullscreen(CUIRect Screen)
 		}
 
 		static CButtonContainer s_ButtonOk;
-		if(DoButton_Menu(&s_ButtonOk, Localize("Ok"), 0, &Ok) || UI()->ConsumeHotkey(CUI::HOTKEY_ENTER))
+		if(DoButton_Menu(&s_ButtonOk, Localize("Ok"), 0, &Ok) || Ui()->ConsumeHotkey(CUi::HOTKEY_ENTER))
 		{
 			m_Popup = POPUP_NONE;
 			m_DemoRenderInput.Clear();
@@ -1762,7 +1762,7 @@ void CMenus::RenderPopupFullscreen(CUIRect Screen)
 
 		SLabelProperties MessageProps;
 		MessageProps.m_MaxWidth = (int)Part.w;
-		UI()->DoLabel(&Part, aBuf, 18.0f, TEXTALIGN_TL, MessageProps);
+		Ui()->DoLabel(&Part, aBuf, 18.0f, TEXTALIGN_TL, MessageProps);
 	}
 #endif
 	else if(m_Popup == POPUP_FIRST_LAUNCH)
@@ -1777,7 +1777,7 @@ void CMenus::RenderPopupFullscreen(CUIRect Screen)
 		Join.VMargin(20.0f, &Join);
 
 		static CButtonContainer s_JoinTutorialButton;
-		if(DoButton_Menu(&s_JoinTutorialButton, Localize("Join Tutorial Server"), 0, &Join) || UI()->ConsumeHotkey(CUI::HOTKEY_ENTER))
+		if(DoButton_Menu(&s_JoinTutorialButton, Localize("Join Tutorial Server"), 0, &Join) || Ui()->ConsumeHotkey(CUi::HOTKEY_ENTER))
 		{
 			m_JoinTutorial = true;
 			Client()->RequestDDNetInfo();
@@ -1785,7 +1785,7 @@ void CMenus::RenderPopupFullscreen(CUIRect Screen)
 		}
 
 		static CButtonContainer s_SkipTutorialButton;
-		if(DoButton_Menu(&s_SkipTutorialButton, Localize("Skip Tutorial"), 0, &Skip) || UI()->ConsumeHotkey(CUI::HOTKEY_ESCAPE))
+		if(DoButton_Menu(&s_SkipTutorialButton, Localize("Skip Tutorial"), 0, &Skip) || Ui()->ConsumeHotkey(CUi::HOTKEY_ESCAPE))
 		{
 			m_JoinTutorial = false;
 			Client()->RequestDDNetInfo();
@@ -1810,10 +1810,10 @@ void CMenus::RenderPopupFullscreen(CUIRect Screen)
 		Label.VSplitLeft(100.0f, 0, &TextBox);
 		TextBox.VSplitLeft(20.0f, 0, &TextBox);
 		TextBox.VSplitRight(60.0f, &TextBox, 0);
-		UI()->DoLabel(&Label, Localize("Nickname"), 16.0f, TEXTALIGN_ML);
+		Ui()->DoLabel(&Label, Localize("Nickname"), 16.0f, TEXTALIGN_ML);
 		static CLineInput s_PlayerNameInput(g_Config.m_PlayerName, sizeof(g_Config.m_PlayerName));
 		s_PlayerNameInput.SetEmptyText(Client()->PlayerName());
-		UI()->DoEditBox(&s_PlayerNameInput, &TextBox, 12.0f);
+		Ui()->DoEditBox(&s_PlayerNameInput, &TextBox, 12.0f);
 	}
 	else if(m_Popup == POPUP_POINTS)
 	{
@@ -1829,11 +1829,11 @@ void CMenus::RenderPopupFullscreen(CUIRect Screen)
 		No.VMargin(20.0f, &No);
 
 		static CButtonContainer s_ButtonNo;
-		if(DoButton_Menu(&s_ButtonNo, Localize("No"), 0, &No) || UI()->ConsumeHotkey(CUI::HOTKEY_ESCAPE))
+		if(DoButton_Menu(&s_ButtonNo, Localize("No"), 0, &No) || Ui()->ConsumeHotkey(CUi::HOTKEY_ESCAPE))
 			m_Popup = POPUP_FIRST_LAUNCH;
 
 		static CButtonContainer s_ButtonYes;
-		if(DoButton_Menu(&s_ButtonYes, Localize("Yes"), 0, &Yes) || UI()->ConsumeHotkey(CUI::HOTKEY_ENTER))
+		if(DoButton_Menu(&s_ButtonYes, Localize("Yes"), 0, &Yes) || Ui()->ConsumeHotkey(CUi::HOTKEY_ENTER))
 			m_Popup = POPUP_NONE;
 	}
 	else if(m_Popup == POPUP_WARNING)
@@ -1843,7 +1843,7 @@ void CMenus::RenderPopupFullscreen(CUIRect Screen)
 		Part.VMargin(120.0f, &Part);
 
 		static CButtonContainer s_Button;
-		if(DoButton_Menu(&s_Button, pButtonText, 0, &Part) || UI()->ConsumeHotkey(CUI::HOTKEY_ESCAPE) || UI()->ConsumeHotkey(CUI::HOTKEY_ENTER) || (m_PopupWarningDuration > 0s && time_get_nanoseconds() - m_PopupWarningLastTime >= m_PopupWarningDuration))
+		if(DoButton_Menu(&s_Button, pButtonText, 0, &Part) || Ui()->ConsumeHotkey(CUi::HOTKEY_ESCAPE) || Ui()->ConsumeHotkey(CUi::HOTKEY_ENTER) || (m_PopupWarningDuration > 0s && time_get_nanoseconds() - m_PopupWarningLastTime >= m_PopupWarningDuration))
 		{
 			m_Popup = POPUP_NONE;
 			SetActive(false);
@@ -1856,7 +1856,7 @@ void CMenus::RenderPopupFullscreen(CUIRect Screen)
 		Part.VMargin(120.0f, &Part);
 
 		static CButtonContainer s_Button;
-		if(DoButton_Menu(&s_Button, pButtonText, 0, &Part) || UI()->ConsumeHotkey(CUI::HOTKEY_ESCAPE) || UI()->ConsumeHotkey(CUI::HOTKEY_ENTER))
+		if(DoButton_Menu(&s_Button, pButtonText, 0, &Part) || Ui()->ConsumeHotkey(CUi::HOTKEY_ESCAPE) || Ui()->ConsumeHotkey(CUi::HOTKEY_ENTER))
 		{
 			if(m_Popup == POPUP_DISCONNECTED && Client()->ReconnectTime() > 0)
 				Client()->SetReconnectTime(0);
@@ -1865,7 +1865,7 @@ void CMenus::RenderPopupFullscreen(CUIRect Screen)
 	}
 
 	if(m_Popup == POPUP_NONE)
-		UI()->SetActiveItem(nullptr);
+		Ui()->SetActiveItem(nullptr);
 }
 
 #if defined(CONF_VIDEORECORDER)
@@ -1949,7 +1949,7 @@ void CMenus::RenderThemeSelection(CUIRect MainView)
 		else // generic
 			str_copy(aName, Theme.m_Name.c_str());
 
-		UI()->DoLabel(&Label, aName, 16.0f * CUI::ms_FontmodHeight, TEXTALIGN_ML);
+		Ui()->DoLabel(&Label, aName, 16.0f * CUi::ms_FontmodHeight, TEXTALIGN_ML);
 	}
 
 	SelectedTheme = s_ListBox.DoEnd();
@@ -1966,8 +1966,8 @@ void CMenus::SetActive(bool Active)
 {
 	if(Active != m_MenuActive)
 	{
-		UI()->SetHotItem(nullptr);
-		UI()->SetActiveItem(nullptr);
+		Ui()->SetHotItem(nullptr);
+		Ui()->SetActiveItem(nullptr);
 	}
 	m_MenuActive = Active;
 	if(!m_MenuActive)
@@ -2011,8 +2011,8 @@ bool CMenus::OnCursorMove(float x, float y, IInput::ECursorType CursorType)
 	if(!m_MenuActive)
 		return false;
 
-	UI()->ConvertMouseMove(&x, &y, CursorType);
-	UI()->OnCursorMove(x, y);
+	Ui()->ConvertMouseMove(&x, &y, CursorType);
+	Ui()->OnCursorMove(x, y);
 
 	return true;
 }
@@ -2022,7 +2022,7 @@ bool CMenus::OnInput(const IInput::CEvent &Event)
 	// Escape key is always handled to activate/deactivate menu
 	if((Event.m_Flags & IInput::FLAG_PRESS && Event.m_Key == KEY_ESCAPE) || IsActive())
 	{
-		UI()->OnInput(Event);
+		Ui()->OnInput(Event);
 		return true;
 	}
 	return false;
@@ -2031,7 +2031,7 @@ bool CMenus::OnInput(const IInput::CEvent &Event)
 void CMenus::OnStateChange(int NewState, int OldState)
 {
 	// reset active item
-	UI()->SetActiveItem(nullptr);
+	Ui()->SetActiveItem(nullptr);
 
 	if(OldState == IClient::STATE_ONLINE || OldState == IClient::STATE_OFFLINE)
 		TextRender()->DeleteTextContainer(m_MotdTextContainerIndex);
@@ -2047,7 +2047,7 @@ void CMenus::OnStateChange(int NewState, int OldState)
 			{
 				m_Popup = POPUP_PASSWORD;
 				m_PasswordInput.SelectAll();
-				UI()->SetActiveItem(&m_PasswordInput);
+				Ui()->SetActiveItem(&m_PasswordInput);
 			}
 			else
 				m_Popup = POPUP_DISCONNECTED;
@@ -2081,15 +2081,15 @@ void CMenus::OnWindowResize()
 
 void CMenus::OnRender()
 {
-	UI()->StartCheck();
+	Ui()->StartCheck();
 
 	if(Client()->State() != IClient::STATE_ONLINE && Client()->State() != IClient::STATE_DEMOPLAYBACK)
 		SetActive(true);
 
 	if(Client()->State() == IClient::STATE_DEMOPLAYBACK)
 	{
-		UI()->MapScreen();
-		RenderDemoPlayer(*UI()->Screen());
+		Ui()->MapScreen();
+		RenderDemoPlayer(*Ui()->Screen());
 	}
 
 	if(Client()->State() == IClient::STATE_ONLINE && m_pClient->m_ServerMode == CGameClient::SERVERMODE_PUREMOD)
@@ -2101,29 +2101,29 @@ void CMenus::OnRender()
 
 	if(!IsActive())
 	{
-		if(UI()->ConsumeHotkey(CUI::HOTKEY_ESCAPE))
+		if(Ui()->ConsumeHotkey(CUi::HOTKEY_ESCAPE))
 			SetActive(true);
-		UI()->FinishCheck();
-		UI()->ClearHotkeys();
+		Ui()->FinishCheck();
+		Ui()->ClearHotkeys();
 		return;
 	}
 
 	UpdateColors();
 
-	UI()->Update();
+	Ui()->Update();
 
 	Render();
-	RenderTools()->RenderCursor(UI()->MousePos(), 24.0f);
+	RenderTools()->RenderCursor(Ui()->MousePos(), 24.0f);
 
 	// render debug information
 	if(g_Config.m_Debug)
-		UI()->DebugRender();
+		Ui()->DebugRender();
 
-	if(UI()->ConsumeHotkey(CUI::HOTKEY_ESCAPE))
+	if(Ui()->ConsumeHotkey(CUi::HOTKEY_ESCAPE))
 		SetActive(false);
 
-	UI()->FinishCheck();
-	UI()->ClearHotkeys();
+	Ui()->FinishCheck();
+	Ui()->ClearHotkeys();
 }
 
 void CMenus::UpdateColors()
@@ -2202,7 +2202,7 @@ void CMenus::RenderBackground()
 	Graphics()->QuadsEnd();
 
 	// restore screen
-	UI()->MapScreen();
+	Ui()->MapScreen();
 }
 
 bool CMenus::CheckHotKey(int Key) const
@@ -2212,16 +2212,16 @@ bool CMenus::CheckHotKey(int Key) const
 	       Input()->KeyIsPressed(Key) && m_pClient->m_GameConsole.IsClosed();
 }
 
-int CMenus::DoButton_CheckBox_Tristate(const void *pID, const char *pText, TRISTATE Checked, const CUIRect *pRect)
+int CMenus::DoButton_CheckBox_Tristate(const void *pId, const char *pText, TRISTATE Checked, const CUIRect *pRect)
 {
 	switch(Checked)
 	{
 	case TRISTATE::NONE:
-		return DoButton_CheckBox_Common(pID, pText, "", pRect);
+		return DoButton_CheckBox_Common(pId, pText, "", pRect);
 	case TRISTATE::SOME:
-		return DoButton_CheckBox_Common(pID, pText, "O", pRect);
+		return DoButton_CheckBox_Common(pId, pText, "O", pRect);
 	case TRISTATE::ALL:
-		return DoButton_CheckBox_Common(pID, pText, "X", pRect);
+		return DoButton_CheckBox_Common(pId, pText, "X", pRect);
 	default:
 		dbg_assert(false, "invalid tristate");
 	}

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -67,22 +67,22 @@ class CMenus : public CComponent
 	static ColorRGBA ms_ColorTabbarHover;
 
 	int DoButton_FontIcon(CButtonContainer *pButtonContainer, const char *pText, int Checked, const CUIRect *pRect, int Corners = IGraphics::CORNER_ALL, bool Enabled = true);
-	int DoButton_Toggle(const void *pID, int Checked, const CUIRect *pRect, bool Active);
+	int DoButton_Toggle(const void *pId, int Checked, const CUIRect *pRect, bool Active);
 	int DoButton_Menu(CButtonContainer *pButtonContainer, const char *pText, int Checked, const CUIRect *pRect, const char *pImageName = nullptr, int Corners = IGraphics::CORNER_ALL, float Rounding = 5.0f, float FontFactor = 0.0f, ColorRGBA Color = ColorRGBA(1.0f, 1.0f, 1.0f, 0.5f));
 	int DoButton_MenuTab(CButtonContainer *pButtonContainer, const char *pText, int Checked, const CUIRect *pRect, int Corners, SUIAnimator *pAnimator = nullptr, const ColorRGBA *pDefaultColor = nullptr, const ColorRGBA *pActiveColor = nullptr, const ColorRGBA *pHoverColor = nullptr, float EdgeRounding = 10.0f, const SCommunityIcon *pCommunityIcon = nullptr);
 
-	int DoButton_CheckBox_Common(const void *pID, const char *pText, const char *pBoxText, const CUIRect *pRect);
-	int DoButton_CheckBox(const void *pID, const char *pText, int Checked, const CUIRect *pRect);
-	int DoButton_CheckBoxAutoVMarginAndSet(const void *pID, const char *pText, int *pValue, CUIRect *pRect, float VMargin);
-	int DoButton_CheckBox_Number(const void *pID, const char *pText, int Checked, const CUIRect *pRect);
+	int DoButton_CheckBox_Common(const void *pId, const char *pText, const char *pBoxText, const CUIRect *pRect);
+	int DoButton_CheckBox(const void *pId, const char *pText, int Checked, const CUIRect *pRect);
+	int DoButton_CheckBoxAutoVMarginAndSet(const void *pId, const char *pText, int *pValue, CUIRect *pRect, float VMargin);
+	int DoButton_CheckBox_Number(const void *pId, const char *pText, int Checked, const CUIRect *pRect);
 
-	ColorHSLA DoLine_ColorPicker(CButtonContainer *pResetID, float LineSize, float LabelSize, float BottomMargin, CUIRect *pMainRect, const char *pText, unsigned int *pColorValue, ColorRGBA DefaultColor, bool CheckBoxSpacing = true, int *pCheckBoxValue = nullptr, bool Alpha = false);
+	ColorHSLA DoLine_ColorPicker(CButtonContainer *pResetId, float LineSize, float LabelSize, float BottomMargin, CUIRect *pMainRect, const char *pText, unsigned int *pColorValue, ColorRGBA DefaultColor, bool CheckBoxSpacing = true, int *pCheckBoxValue = nullptr, bool Alpha = false);
 	ColorHSLA DoButton_ColorPicker(const CUIRect *pRect, unsigned int *pHslaColor, bool Alpha);
 	void DoLaserPreview(const CUIRect *pRect, ColorHSLA OutlineColor, ColorHSLA InnerColor, const int LaserType);
-	int DoButton_GridHeader(const void *pID, const char *pText, int Checked, const CUIRect *pRect);
+	int DoButton_GridHeader(const void *pId, const char *pText, int Checked, const CUIRect *pRect);
 	int DoButton_Favorite(const void *pButtonId, const void *pParentId, bool Checked, const CUIRect *pRect);
 
-	int DoKeyReader(const void *pID, const CUIRect *pRect, int Key, int ModifierCombination, int *pNewModifierCombination);
+	int DoKeyReader(const void *pId, const CUIRect *pRect, int Key, int ModifierCombination, int *pNewModifierCombination);
 
 	void DoSettingsControlsButtons(int Start, int Stop, CUIRect View);
 
@@ -489,7 +489,7 @@ protected:
 		int m_Selection;
 		bool m_New;
 	};
-	static CUI::EPopupMenuFunctionResult PopupCountrySelection(void *pContext, CUIRect View, bool Active);
+	static CUi::EPopupMenuFunctionResult PopupCountrySelection(void *pContext, CUIRect View, bool Active);
 	void RenderServerbrowserInfo(CUIRect View);
 	void RenderServerbrowserInfoScoreboard(CUIRect View, const CServerInfo *pSelectedServer);
 	void RenderServerbrowserFriends(CUIRect View);
@@ -692,7 +692,7 @@ public:
 	SUIAnimator m_aAnimatorsSettingsTab[SETTINGS_LENGTH];
 
 	// DDRace
-	int DoButton_CheckBox_Tristate(const void *pID, const char *pText, TRISTATE Checked, const CUIRect *pRect);
+	int DoButton_CheckBox_Tristate(const void *pId, const char *pText, TRISTATE Checked, const CUIRect *pRect);
 	std::vector<CDemoItem> m_vDemos;
 	std::vector<CDemoItem *> m_vpFilteredDemos;
 	void DemolistPopulate();

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -92,7 +92,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View, bool &WasListboxItemAct
 
 	struct SColumn
 	{
-		int m_ID;
+		int m_Id;
 		int m_Sort;
 		const char *m_pCaption;
 		int m_Direction;
@@ -182,7 +182,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View, bool &WasListboxItemAct
 		if(PlayersOrPing && g_Config.m_BrSortOrder == 2 && (Col.m_Sort == IServerBrowser::SORT_NUMPLAYERS || Col.m_Sort == IServerBrowser::SORT_PING))
 			Checked = 2;
 
-		if(DoButton_GridHeader(&Col.m_ID, Localize(Col.m_pCaption), Checked, &Col.m_Rect))
+		if(DoButton_GridHeader(&Col.m_Id, Localize(Col.m_pCaption), Checked, &Col.m_Rect))
 		{
 			if(Col.m_Sort != -1)
 			{
@@ -194,11 +194,11 @@ void CMenus::RenderServerbrowserServerList(CUIRect View, bool &WasListboxItemAct
 			}
 		}
 
-		if(Col.m_ID == COL_FRIENDS)
+		if(Col.m_Id == COL_FRIENDS)
 		{
 			TextRender()->SetFontPreset(EFontPreset::ICON_FONT);
 			TextRender()->SetRenderFlags(ETextRenderFlags::TEXT_RENDER_FLAG_ONLY_ADVANCE_WIDTH | ETextRenderFlags::TEXT_RENDER_FLAG_NO_X_BEARING | ETextRenderFlags::TEXT_RENDER_FLAG_NO_Y_BEARING | ETextRenderFlags::TEXT_RENDER_FLAG_NO_PIXEL_ALIGMENT | ETextRenderFlags::TEXT_RENDER_FLAG_NO_OVERSIZE);
-			UI()->DoLabel(&Col.m_Rect, FONT_ICON_HEART, 14.0f, TEXTALIGN_MC);
+			Ui()->DoLabel(&Col.m_Rect, FONT_ICON_HEART, 14.0f, TEXTALIGN_MC);
 			TextRender()->SetRenderFlags(0);
 			TextRender()->SetFontPreset(EFontPreset::DEFAULT_FONT);
 		}
@@ -211,11 +211,11 @@ void CMenus::RenderServerbrowserServerList(CUIRect View, bool &WasListboxItemAct
 	{
 		if(!ServerBrowser()->NumServers() && ServerBrowser()->IsGettingServerlist())
 		{
-			UI()->DoLabel(&View, Localize("Getting server list from master server"), 16.0f, TEXTALIGN_MC);
+			Ui()->DoLabel(&View, Localize("Getting server list from master server"), 16.0f, TEXTALIGN_MC);
 		}
 		else if(!ServerBrowser()->NumServers())
 		{
-			UI()->DoLabel(&View, Localize("No servers found"), 16.0f, TEXTALIGN_MC);
+			Ui()->DoLabel(&View, Localize("No servers found"), 16.0f, TEXTALIGN_MC);
 		}
 		else if(ServerBrowser()->NumServers() && !NumServers)
 		{
@@ -224,7 +224,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View, bool &WasListboxItemAct
 			Label.HSplitTop(16.0f, &Label, &ResetButton);
 			ResetButton.HSplitTop(8.0f, nullptr, &ResetButton);
 			ResetButton.VMargin((ResetButton.w - 200.0f) / 2.0f, &ResetButton);
-			UI()->DoLabel(&Label, Localize("No servers match your filter criteria"), 16.0f, TEXTALIGN_MC);
+			Ui()->DoLabel(&Label, Localize("No servers match your filter criteria"), 16.0f, TEXTALIGN_MC);
 			static CButtonContainer s_ResetButton;
 			if(DoButton_Menu(&s_ResetButton, Localize("Reset filter"), 0, &ResetButton))
 			{
@@ -233,7 +233,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View, bool &WasListboxItemAct
 		}
 	}
 
-	s_ListBox.SetActive(!UI()->IsPopupOpen());
+	s_ListBox.SetActive(!Ui()->IsPopupOpen());
 	s_ListBox.DoStart(ms_ListheaderHeight, NumServers, 1, 3, -1, &View, false);
 
 	if(m_ServerBrowserShouldRevealSelection)
@@ -249,7 +249,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View, bool &WasListboxItemAct
 		TextRender()->SetRenderFlags(ETextRenderFlags::TEXT_RENDER_FLAG_ONLY_ADVANCE_WIDTH | ETextRenderFlags::TEXT_RENDER_FLAG_NO_X_BEARING | ETextRenderFlags::TEXT_RENDER_FLAG_NO_Y_BEARING | ETextRenderFlags::TEXT_RENDER_FLAG_NO_PIXEL_ALIGMENT | ETextRenderFlags::TEXT_RENDER_FLAG_NO_OVERSIZE);
 		TextRender()->TextColor(TextColor);
 		TextRender()->TextOutlineColor(TextOutlineColor);
-		UI()->DoLabelStreamed(UIRect, pRect, pText, FontSize, TextAlign);
+		Ui()->DoLabelStreamed(UIRect, pRect, pText, FontSize, TextAlign);
 		TextRender()->TextOutlineColor(TextRender()->DefaultTextOutlineColor());
 		TextRender()->TextColor(TextRender()->DefaultTextColor());
 		TextRender()->SetRenderFlags(0);
@@ -267,7 +267,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View, bool &WasListboxItemAct
 
 		if(vpServerBrowserUiElements[i] == nullptr)
 		{
-			vpServerBrowserUiElements[i] = UI()->GetNewUIElement(NUM_UI_ELEMS);
+			vpServerBrowserUiElements[i] = Ui()->GetNewUIElement(NUM_UI_ELEMS);
 		}
 		CUIElement *pUiElement = vpServerBrowserUiElements[i];
 
@@ -278,8 +278,8 @@ void CMenus::RenderServerbrowserServerList(CUIRect View, bool &WasListboxItemAct
 		if(!ListItem.m_Visible)
 		{
 			// reset active item, if not visible
-			if(UI()->CheckActiveItem(pItem))
-				UI()->SetActiveItem(nullptr);
+			if(Ui()->CheckActiveItem(pItem))
+				Ui()->SetActiveItem(nullptr);
 
 			// don't render invisible items
 			continue;
@@ -295,22 +295,22 @@ void CMenus::RenderServerbrowserServerList(CUIRect View, bool &WasListboxItemAct
 			Button.h = ListItem.m_Rect.h;
 			Button.w = Col.m_Rect.w;
 
-			const int ID = Col.m_ID;
-			if(ID == COL_FLAG_LOCK)
+			const int Id = Col.m_Id;
+			if(Id == COL_FLAG_LOCK)
 			{
 				if(pItem->m_Flags & SERVER_FLAG_PASSWORD)
 				{
 					RenderBrowserIcons(*pUiElement->Rect(UI_ELEM_LOCK_ICON), &Button, ColorRGBA(0.75f, 0.75f, 0.75f, 1.0f), TextRender()->DefaultTextOutlineColor(), FONT_ICON_LOCK, TEXTALIGN_MC);
 				}
 			}
-			else if(ID == COL_FLAG_FAV)
+			else if(Id == COL_FLAG_FAV)
 			{
 				if(pItem->m_Favorite != TRISTATE::NONE)
 				{
 					RenderBrowserIcons(*pUiElement->Rect(UI_ELEM_FAVORITE_ICON), &Button, ColorRGBA(1.0f, 0.85f, 0.3f, 1.0f), TextRender()->DefaultTextOutlineColor(), FONT_ICON_STAR, TEXTALIGN_MC);
 				}
 			}
-			else if(ID == COL_COMMUNITY)
+			else if(Id == COL_COMMUNITY)
 			{
 				if(pCommunity != nullptr)
 				{
@@ -320,12 +320,12 @@ void CMenus::RenderServerbrowserServerList(CUIRect View, bool &WasListboxItemAct
 						CUIRect CommunityIcon;
 						Button.Margin(2.0f, &CommunityIcon);
 						RenderCommunityIcon(pIcon, CommunityIcon, true);
-						UI()->DoButtonLogic(&pItem->m_aCommunityId, 0, &CommunityIcon);
+						Ui()->DoButtonLogic(&pItem->m_aCommunityId, 0, &CommunityIcon);
 						GameClient()->m_Tooltips.DoToolTip(&pItem->m_aCommunityId, &CommunityIcon, pCommunity->Name());
 					}
 				}
 			}
-			else if(ID == COL_NAME)
+			else if(Id == COL_NAME)
 			{
 				SLabelProperties Props;
 				Props.m_MaxWidth = Button.w;
@@ -334,16 +334,16 @@ void CMenus::RenderServerbrowserServerList(CUIRect View, bool &WasListboxItemAct
 				bool Printed = false;
 				if(g_Config.m_BrFilterString[0] && (pItem->m_QuickSearchHit & IServerBrowser::QUICK_SERVERNAME))
 					Printed = PrintHighlighted(pItem->m_aName, [&](const char *pFilteredStr, const int FilterLen) {
-						UI()->DoLabelStreamed(*pUiElement->Rect(UI_ELEM_NAME_1), &Button, pItem->m_aName, FontSize, TEXTALIGN_ML, Props, (int)(pFilteredStr - pItem->m_aName));
+						Ui()->DoLabelStreamed(*pUiElement->Rect(UI_ELEM_NAME_1), &Button, pItem->m_aName, FontSize, TEXTALIGN_ML, Props, (int)(pFilteredStr - pItem->m_aName));
 						TextRender()->TextColor(gs_HighlightedTextColor);
-						UI()->DoLabelStreamed(*pUiElement->Rect(UI_ELEM_NAME_2), &Button, pFilteredStr, FontSize, TEXTALIGN_ML, Props, FilterLen, &pUiElement->Rect(UI_ELEM_NAME_1)->m_Cursor);
+						Ui()->DoLabelStreamed(*pUiElement->Rect(UI_ELEM_NAME_2), &Button, pFilteredStr, FontSize, TEXTALIGN_ML, Props, FilterLen, &pUiElement->Rect(UI_ELEM_NAME_1)->m_Cursor);
 						TextRender()->TextColor(TextRender()->DefaultTextColor());
-						UI()->DoLabelStreamed(*pUiElement->Rect(UI_ELEM_NAME_3), &Button, pFilteredStr + FilterLen, FontSize, TEXTALIGN_ML, Props, -1, &pUiElement->Rect(UI_ELEM_NAME_2)->m_Cursor);
+						Ui()->DoLabelStreamed(*pUiElement->Rect(UI_ELEM_NAME_3), &Button, pFilteredStr + FilterLen, FontSize, TEXTALIGN_ML, Props, -1, &pUiElement->Rect(UI_ELEM_NAME_2)->m_Cursor);
 					});
 				if(!Printed)
-					UI()->DoLabelStreamed(*pUiElement->Rect(UI_ELEM_NAME_1), &Button, pItem->m_aName, FontSize, TEXTALIGN_ML, Props);
+					Ui()->DoLabelStreamed(*pUiElement->Rect(UI_ELEM_NAME_1), &Button, pItem->m_aName, FontSize, TEXTALIGN_ML, Props);
 			}
-			else if(ID == COL_GAMETYPE)
+			else if(Id == COL_GAMETYPE)
 			{
 				SLabelProperties Props;
 				Props.m_MaxWidth = Button.w;
@@ -353,10 +353,10 @@ void CMenus::RenderServerbrowserServerList(CUIRect View, bool &WasListboxItemAct
 				{
 					TextRender()->TextColor(GetGametypeTextColor(pItem->m_aGameType));
 				}
-				UI()->DoLabelStreamed(*pUiElement->Rect(UI_ELEM_GAMETYPE), &Button, pItem->m_aGameType, FontSize, TEXTALIGN_ML, Props);
+				Ui()->DoLabelStreamed(*pUiElement->Rect(UI_ELEM_GAMETYPE), &Button, pItem->m_aGameType, FontSize, TEXTALIGN_ML, Props);
 				TextRender()->TextColor(TextRender()->DefaultTextColor());
 			}
-			else if(ID == COL_MAP)
+			else if(Id == COL_MAP)
 			{
 				{
 					CUIRect Icon;
@@ -376,16 +376,16 @@ void CMenus::RenderServerbrowserServerList(CUIRect View, bool &WasListboxItemAct
 				bool Printed = false;
 				if(g_Config.m_BrFilterString[0] && (pItem->m_QuickSearchHit & IServerBrowser::QUICK_MAPNAME))
 					Printed = PrintHighlighted(pItem->m_aMap, [&](const char *pFilteredStr, const int FilterLen) {
-						UI()->DoLabelStreamed(*pUiElement->Rect(UI_ELEM_MAP_1), &Button, pItem->m_aMap, FontSize, TEXTALIGN_ML, Props, (int)(pFilteredStr - pItem->m_aMap));
+						Ui()->DoLabelStreamed(*pUiElement->Rect(UI_ELEM_MAP_1), &Button, pItem->m_aMap, FontSize, TEXTALIGN_ML, Props, (int)(pFilteredStr - pItem->m_aMap));
 						TextRender()->TextColor(gs_HighlightedTextColor);
-						UI()->DoLabelStreamed(*pUiElement->Rect(UI_ELEM_MAP_2), &Button, pFilteredStr, FontSize, TEXTALIGN_ML, Props, FilterLen, &pUiElement->Rect(UI_ELEM_MAP_1)->m_Cursor);
+						Ui()->DoLabelStreamed(*pUiElement->Rect(UI_ELEM_MAP_2), &Button, pFilteredStr, FontSize, TEXTALIGN_ML, Props, FilterLen, &pUiElement->Rect(UI_ELEM_MAP_1)->m_Cursor);
 						TextRender()->TextColor(TextRender()->DefaultTextColor());
-						UI()->DoLabelStreamed(*pUiElement->Rect(UI_ELEM_MAP_3), &Button, pFilteredStr + FilterLen, FontSize, TEXTALIGN_ML, Props, -1, &pUiElement->Rect(UI_ELEM_MAP_2)->m_Cursor);
+						Ui()->DoLabelStreamed(*pUiElement->Rect(UI_ELEM_MAP_3), &Button, pFilteredStr + FilterLen, FontSize, TEXTALIGN_ML, Props, -1, &pUiElement->Rect(UI_ELEM_MAP_2)->m_Cursor);
 					});
 				if(!Printed)
-					UI()->DoLabelStreamed(*pUiElement->Rect(UI_ELEM_MAP_1), &Button, pItem->m_aMap, FontSize, TEXTALIGN_ML, Props);
+					Ui()->DoLabelStreamed(*pUiElement->Rect(UI_ELEM_MAP_1), &Button, pItem->m_aMap, FontSize, TEXTALIGN_ML, Props);
 			}
-			else if(ID == COL_FRIENDS)
+			else if(Id == COL_FRIENDS)
 			{
 				if(pItem->m_FriendState != IFriends::FRIEND_NO)
 				{
@@ -395,22 +395,22 @@ void CMenus::RenderServerbrowserServerList(CUIRect View, bool &WasListboxItemAct
 					{
 						str_from_int(pItem->m_FriendNum, aTemp);
 						TextRender()->TextColor(0.94f, 0.8f, 0.8f, 1.0f);
-						UI()->DoLabel(&Button, aTemp, 9.0f, TEXTALIGN_MC);
+						Ui()->DoLabel(&Button, aTemp, 9.0f, TEXTALIGN_MC);
 						TextRender()->TextColor(TextRender()->DefaultTextColor());
 					}
 				}
 			}
-			else if(ID == COL_PLAYERS)
+			else if(Id == COL_PLAYERS)
 			{
 				str_format(aTemp, sizeof(aTemp), "%i/%i", pItem->m_NumFilteredPlayers, ServerBrowser()->Max(*pItem));
 				if(g_Config.m_BrFilterString[0] && (pItem->m_QuickSearchHit & IServerBrowser::QUICK_PLAYER))
 				{
 					TextRender()->TextColor(gs_HighlightedTextColor);
 				}
-				UI()->DoLabelStreamed(*pUiElement->Rect(UI_ELEM_PLAYERS), &Button, aTemp, FontSize, TEXTALIGN_MR);
+				Ui()->DoLabelStreamed(*pUiElement->Rect(UI_ELEM_PLAYERS), &Button, aTemp, FontSize, TEXTALIGN_MR);
 				TextRender()->TextColor(TextRender()->DefaultTextColor());
 			}
-			else if(ID == COL_PING)
+			else if(Id == COL_PING)
 			{
 				Button.VMargin(4.0f, &Button);
 				FormatServerbrowserPing(aTemp, pItem);
@@ -418,7 +418,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View, bool &WasListboxItemAct
 				{
 					TextRender()->TextColor(GetPingTextColor(pItem->m_Latency));
 				}
-				UI()->DoLabelStreamed(*pUiElement->Rect(UI_ELEM_PING), &Button, aTemp, FontSize, TEXTALIGN_MR);
+				Ui()->DoLabelStreamed(*pUiElement->Rect(UI_ELEM_PING), &Button, aTemp, FontSize, TEXTALIGN_MR);
 				TextRender()->TextColor(TextRender()->DefaultTextColor());
 			}
 		}
@@ -489,7 +489,7 @@ void CMenus::RenderServerbrowserStatusBox(CUIRect StatusBox, bool WasListboxItem
 	{
 		TextRender()->SetFontPreset(EFontPreset::ICON_FONT);
 		TextRender()->SetRenderFlags(ETextRenderFlags::TEXT_RENDER_FLAG_ONLY_ADVANCE_WIDTH | ETextRenderFlags::TEXT_RENDER_FLAG_NO_X_BEARING | ETextRenderFlags::TEXT_RENDER_FLAG_NO_Y_BEARING | ETextRenderFlags::TEXT_RENDER_FLAG_NO_PIXEL_ALIGMENT | ETextRenderFlags::TEXT_RENDER_FLAG_NO_OVERSIZE);
-		UI()->DoLabel(&QuickSearch, FONT_ICON_MAGNIFYING_GLASS, 16.0f, TEXTALIGN_ML);
+		Ui()->DoLabel(&QuickSearch, FONT_ICON_MAGNIFYING_GLASS, 16.0f, TEXTALIGN_ML);
 		TextRender()->SetRenderFlags(0);
 		TextRender()->SetFontPreset(EFontPreset::DEFAULT_FONT);
 		QuickSearch.VSplitLeft(ExcludeSearchIconMax, nullptr, &QuickSearch);
@@ -497,17 +497,17 @@ void CMenus::RenderServerbrowserStatusBox(CUIRect StatusBox, bool WasListboxItem
 
 		char aBufSearch[64];
 		str_format(aBufSearch, sizeof(aBufSearch), "%s:", Localize("Search"));
-		UI()->DoLabel(&QuickSearch, aBufSearch, 14.0f, TEXTALIGN_ML);
+		Ui()->DoLabel(&QuickSearch, aBufSearch, 14.0f, TEXTALIGN_ML);
 		QuickSearch.VSplitLeft(SearchExcludeAddrStrMax, nullptr, &QuickSearch);
 		QuickSearch.VSplitLeft(5.0f, nullptr, &QuickSearch);
 
 		static CLineInput s_FilterInput(g_Config.m_BrFilterString, sizeof(g_Config.m_BrFilterString));
-		if(!UI()->IsPopupOpen() && Input()->KeyPress(KEY_F) && Input()->ModifierIsPressed())
+		if(!Ui()->IsPopupOpen() && Input()->KeyPress(KEY_F) && Input()->ModifierIsPressed())
 		{
-			UI()->SetActiveItem(&s_FilterInput);
+			Ui()->SetActiveItem(&s_FilterInput);
 			s_FilterInput.SelectAll();
 		}
-		if(UI()->DoClearableEditBox(&s_FilterInput, &QuickSearch, 12.0f))
+		if(Ui()->DoClearableEditBox(&s_FilterInput, &QuickSearch, 12.0f))
 			Client()->ServerBrowserUpdate();
 	}
 
@@ -515,7 +515,7 @@ void CMenus::RenderServerbrowserStatusBox(CUIRect StatusBox, bool WasListboxItem
 	{
 		TextRender()->SetFontPreset(EFontPreset::ICON_FONT);
 		TextRender()->SetRenderFlags(ETextRenderFlags::TEXT_RENDER_FLAG_ONLY_ADVANCE_WIDTH | ETextRenderFlags::TEXT_RENDER_FLAG_NO_X_BEARING | ETextRenderFlags::TEXT_RENDER_FLAG_NO_Y_BEARING | ETextRenderFlags::TEXT_RENDER_FLAG_NO_PIXEL_ALIGMENT | ETextRenderFlags::TEXT_RENDER_FLAG_NO_OVERSIZE);
-		UI()->DoLabel(&QuickExclude, FONT_ICON_BAN, 16.0f, TEXTALIGN_ML);
+		Ui()->DoLabel(&QuickExclude, FONT_ICON_BAN, 16.0f, TEXTALIGN_ML);
 		TextRender()->SetRenderFlags(0);
 		TextRender()->SetFontPreset(EFontPreset::DEFAULT_FONT);
 		QuickExclude.VSplitLeft(ExcludeSearchIconMax, nullptr, &QuickExclude);
@@ -523,17 +523,17 @@ void CMenus::RenderServerbrowserStatusBox(CUIRect StatusBox, bool WasListboxItem
 
 		char aBufExclude[64];
 		str_format(aBufExclude, sizeof(aBufExclude), "%s:", Localize("Exclude"));
-		UI()->DoLabel(&QuickExclude, aBufExclude, 14.0f, TEXTALIGN_ML);
+		Ui()->DoLabel(&QuickExclude, aBufExclude, 14.0f, TEXTALIGN_ML);
 		QuickExclude.VSplitLeft(SearchExcludeAddrStrMax, nullptr, &QuickExclude);
 		QuickExclude.VSplitLeft(5.0f, nullptr, &QuickExclude);
 
 		static CLineInput s_ExcludeInput(g_Config.m_BrExcludeString, sizeof(g_Config.m_BrExcludeString));
-		if(!UI()->IsPopupOpen() && Input()->KeyPress(KEY_X) && Input()->ShiftIsPressed() && Input()->ModifierIsPressed())
+		if(!Ui()->IsPopupOpen() && Input()->KeyPress(KEY_X) && Input()->ShiftIsPressed() && Input()->ModifierIsPressed())
 		{
-			UI()->SetActiveItem(&s_ExcludeInput);
+			Ui()->SetActiveItem(&s_ExcludeInput);
 			s_ExcludeInput.SelectAll();
 		}
-		if(UI()->DoClearableEditBox(&s_ExcludeInput, &QuickExclude, 12.0f))
+		if(Ui()->DoClearableEditBox(&s_ExcludeInput, &QuickExclude, 12.0f))
 			Client()->ServerBrowserUpdate();
 	}
 
@@ -547,13 +547,13 @@ void CMenus::RenderServerbrowserStatusBox(CUIRect StatusBox, bool WasListboxItem
 			str_format(aBuf, sizeof(aBuf), Localize("%d of %d servers"), ServerBrowser()->NumSortedServers(), ServerBrowser()->NumServers());
 		else
 			str_format(aBuf, sizeof(aBuf), Localize("%d of %d server"), ServerBrowser()->NumSortedServers(), ServerBrowser()->NumServers());
-		UI()->DoLabel(&ServersOnline, aBuf, 12.0f, TEXTALIGN_MR);
+		Ui()->DoLabel(&ServersOnline, aBuf, 12.0f, TEXTALIGN_MR);
 
 		if(ServerBrowser()->NumSortedPlayers() != 1)
 			str_format(aBuf, sizeof(aBuf), Localize("%d players"), ServerBrowser()->NumSortedPlayers());
 		else
 			str_format(aBuf, sizeof(aBuf), Localize("%d player"), ServerBrowser()->NumSortedPlayers());
-		UI()->DoLabel(&PlayersOnline, aBuf, 12.0f, TEXTALIGN_MR);
+		Ui()->DoLabel(&PlayersOnline, aBuf, 12.0f, TEXTALIGN_MR);
 	}
 
 	// address info
@@ -562,9 +562,9 @@ void CMenus::RenderServerbrowserStatusBox(CUIRect StatusBox, bool WasListboxItem
 		ServerAddr.Margin(2.0f, &ServerAddr);
 		ServerAddr.VSplitLeft(SearchExcludeAddrStrMax + 5.0f + ExcludeSearchIconMax + 5.0f, &ServerAddrLabel, &ServerAddrEditBox);
 
-		UI()->DoLabel(&ServerAddrLabel, Localize("Server address:"), 14.0f, TEXTALIGN_ML);
+		Ui()->DoLabel(&ServerAddrLabel, Localize("Server address:"), 14.0f, TEXTALIGN_ML);
 		static CLineInput s_ServerAddressInput(g_Config.m_UiServerAddress, sizeof(g_Config.m_UiServerAddress));
-		if(UI()->DoClearableEditBox(&s_ServerAddressInput, &ServerAddrEditBox, 12.0f))
+		if(Ui()->DoClearableEditBox(&s_ServerAddressInput, &ServerAddrEditBox, 12.0f))
 			m_ServerBrowserShouldRevealSelection = true;
 	}
 
@@ -589,7 +589,7 @@ void CMenus::RenderServerbrowserStatusBox(CUIRect StatusBox, bool WasListboxItem
 			Props.m_UseIconFont = true;
 
 			static CButtonContainer s_RefreshButton;
-			if(UI()->DoButton_Menu(m_RefreshButton, &s_RefreshButton, RefreshLabelFunc, &ButtonRefresh, Props) || (!UI()->IsPopupOpen() && (Input()->KeyPress(KEY_F5) || (Input()->KeyPress(KEY_R) && Input()->ModifierIsPressed()))))
+			if(Ui()->DoButton_Menu(m_RefreshButton, &s_RefreshButton, RefreshLabelFunc, &ButtonRefresh, Props) || (!Ui()->IsPopupOpen() && (Input()->KeyPress(KEY_F5) || (Input()->KeyPress(KEY_R) && Input()->ModifierIsPressed()))))
 			{
 				RefreshBrowserTab(g_Config.m_UiPage);
 			}
@@ -604,7 +604,7 @@ void CMenus::RenderServerbrowserStatusBox(CUIRect StatusBox, bool WasListboxItem
 			Props.m_Color = ColorRGBA(0.5f, 1.0f, 0.5f, 0.5f);
 
 			static CButtonContainer s_ConnectButton;
-			if(UI()->DoButton_Menu(m_ConnectButton, &s_ConnectButton, ConnectLabelFunc, &ButtonConnect, Props) || WasListboxItemActivated || (!UI()->IsPopupOpen() && UI()->ConsumeHotkey(CUI::HOTKEY_ENTER)))
+			if(Ui()->DoButton_Menu(m_ConnectButton, &s_ConnectButton, ConnectLabelFunc, &ButtonConnect, Props) || WasListboxItemActivated || (!Ui()->IsPopupOpen() && Ui()->ConsumeHotkey(CUi::HOTKEY_ENTER)))
 			{
 				Connect(g_Config.m_UiServerAddress);
 			}
@@ -631,7 +631,7 @@ void CMenus::PopupConfirmSwitchServer()
 void CMenus::RenderServerbrowserFilters(CUIRect View)
 {
 	const float RowHeight = 18.0f;
-	const float FontSize = (RowHeight - 4.0f) * CUI::ms_FontmodHeight; // based on DoButton_CheckBox
+	const float FontSize = (RowHeight - 4.0f) * CUi::ms_FontmodHeight; // based on DoButton_CheckBox
 
 	View.Draw(ColorRGBA(0.0f, 0.0f, 0.0f, 0.15f), IGraphics::CORNER_B, 4.0f);
 	View.Margin(5.0f, &View);
@@ -666,20 +666,20 @@ void CMenus::RenderServerbrowserFilters(CUIRect View)
 
 	View.HSplitTop(3.0f, nullptr, &View);
 	View.HSplitTop(RowHeight, &Button, &View);
-	UI()->DoLabel(&Button, Localize("Game types:"), FontSize, TEXTALIGN_ML);
+	Ui()->DoLabel(&Button, Localize("Game types:"), FontSize, TEXTALIGN_ML);
 	Button.VSplitRight(60.0f, nullptr, &Button);
 	static CLineInput s_GametypeInput(g_Config.m_BrFilterGametype, sizeof(g_Config.m_BrFilterGametype));
-	if(UI()->DoEditBox(&s_GametypeInput, &Button, FontSize))
+	if(Ui()->DoEditBox(&s_GametypeInput, &Button, FontSize))
 		Client()->ServerBrowserUpdate();
 
 	// server address
 	View.HSplitTop(6.0f, nullptr, &View);
 	View.HSplitTop(RowHeight, &Button, &View);
 	View.HSplitTop(6.0f, nullptr, &View);
-	UI()->DoLabel(&Button, Localize("Server address:"), FontSize, TEXTALIGN_ML);
+	Ui()->DoLabel(&Button, Localize("Server address:"), FontSize, TEXTALIGN_ML);
 	Button.VSplitRight(60.0f, nullptr, &Button);
 	static CLineInput s_FilterServerAddressInput(g_Config.m_BrFilterServerAddress, sizeof(g_Config.m_BrFilterServerAddress));
-	if(UI()->DoEditBox(&s_FilterServerAddressInput, &Button, FontSize))
+	if(Ui()->DoEditBox(&s_FilterServerAddressInput, &Button, FontSize))
 		Client()->ServerBrowserUpdate();
 
 	// player country
@@ -693,16 +693,16 @@ void CMenus::RenderServerbrowserFilters(CUIRect View)
 		const float OldWidth = Flag.w;
 		Flag.w = Flag.h * 2.0f;
 		Flag.x += (OldWidth - Flag.w) / 2.0f;
-		m_pClient->m_CountryFlags.Render(g_Config.m_BrFilterCountryIndex, ColorRGBA(1.0f, 1.0f, 1.0f, UI()->HotItem() == &g_Config.m_BrFilterCountryIndex ? 1.0f : g_Config.m_BrFilterCountry ? 0.9f : 0.5f), Flag.x, Flag.y, Flag.w, Flag.h);
+		m_pClient->m_CountryFlags.Render(g_Config.m_BrFilterCountryIndex, ColorRGBA(1.0f, 1.0f, 1.0f, Ui()->HotItem() == &g_Config.m_BrFilterCountryIndex ? 1.0f : g_Config.m_BrFilterCountry ? 0.9f : 0.5f), Flag.x, Flag.y, Flag.w, Flag.h);
 
-		if(UI()->DoButtonLogic(&g_Config.m_BrFilterCountryIndex, 0, &Flag))
+		if(Ui()->DoButtonLogic(&g_Config.m_BrFilterCountryIndex, 0, &Flag))
 		{
 			static SPopupMenuId s_PopupCountryId;
 			static SPopupCountrySelectionContext s_PopupCountryContext;
 			s_PopupCountryContext.m_pMenus = this;
 			s_PopupCountryContext.m_Selection = g_Config.m_BrFilterCountryIndex;
 			s_PopupCountryContext.m_New = true;
-			UI()->DoPopupMenu(&s_PopupCountryId, Flag.x, Flag.y + Flag.h, 490, 210, &s_PopupCountryContext, PopupCountrySelection);
+			Ui()->DoPopupMenu(&s_PopupCountryId, Flag.x, Flag.y + Flag.h, 490, 210, &s_PopupCountryContext, PopupCountrySelection);
 		}
 	}
 
@@ -851,7 +851,7 @@ void CMenus::RenderServerbrowserDDNetFilter(CUIRect View,
 		const char *pName = GetItemName(ItemIndex);
 		const bool Active = !Filter.Filtered(pName);
 
-		const int Click = UI()->DoButtonLogic(pItemId, 0, &Item);
+		const int Click = Ui()->DoButtonLogic(pItemId, 0, &Item);
 		if(Click == 1 || Click == 2)
 		{
 			// left/right click to toggle filter
@@ -914,7 +914,7 @@ void CMenus::RenderServerbrowserDDNetFilter(CUIRect View,
 				UpdateCommunityCache(true);
 		}
 
-		if(UI()->HotItem() == pItemId && !ScrollRegion.Animating())
+		if(Ui()->HotItem() == pItemId && !ScrollRegion.Animating())
 			Item.Draw(ColorRGBA(1.0f, 1.0f, 1.0f, 0.33f), IGraphics::CORNER_ALL, 2.0f);
 		RenderItem(ItemIndex, Item, pItemId, Active);
 	}
@@ -927,7 +927,7 @@ void CMenus::RenderServerbrowserCommunitiesFilter(CUIRect View)
 	CUIRect Tab;
 	View.HSplitTop(19.0f, &Tab, &View);
 	Tab.Draw(ColorRGBA(0.0f, 0.0f, 0.0f, 0.3f), IGraphics::CORNER_T, 4.0f);
-	UI()->DoLabel(&Tab, Localize("Communities"), 12.0f, TEXTALIGN_MC);
+	Ui()->DoLabel(&Tab, Localize("Communities"), 12.0f, TEXTALIGN_MC);
 	View.Draw(ColorRGBA(0.0f, 0.0f, 0.0f, 0.15f), IGraphics::CORNER_B, 4.0f);
 
 	const int MaxEntries = ServerBrowser()->Communities().size();
@@ -947,7 +947,7 @@ void CMenus::RenderServerbrowserCommunitiesFilter(CUIRect View)
 		return ServerBrowser()->Communities()[ItemIndex].Name();
 	};
 	const auto &&RenderItem = [&](int ItemIndex, CUIRect Item, const void *pItemId, bool Active) {
-		const float Alpha = (Active ? 0.9f : 0.2f) + (UI()->HotItem() == pItemId ? 0.1f : 0.0f);
+		const float Alpha = (Active ? 0.9f : 0.2f) + (Ui()->HotItem() == pItemId ? 0.1f : 0.0f);
 
 		CUIRect Icon, Label, FavoriteButton;
 		Item.VSplitRight(Item.h, &Item, &FavoriteButton);
@@ -963,7 +963,7 @@ void CMenus::RenderServerbrowserCommunitiesFilter(CUIRect View)
 		}
 
 		TextRender()->TextColor(1.0f, 1.0f, 1.0f, Alpha);
-		UI()->DoLabel(&Label, GetItemDisplayName(ItemIndex), Label.h * CUI::ms_FontmodHeight, TEXTALIGN_ML);
+		Ui()->DoLabel(&Label, GetItemDisplayName(ItemIndex), Label.h * CUi::ms_FontmodHeight, TEXTALIGN_ML);
 		TextRender()->TextColor(TextRender()->DefaultTextColor());
 
 		const bool Favorite = ServerBrowser()->FavoriteCommunitiesFilter().Filtered(pItemName);
@@ -1003,7 +1003,7 @@ void CMenus::RenderServerbrowserCountriesFilter(CUIRect View)
 		const float OldWidth = Item.w;
 		Item.w = Item.h * 2.0f;
 		Item.x += (OldWidth - Item.w) / 2.0f;
-		m_pClient->m_CountryFlags.Render(m_CommunityCache.m_vpSelectableCountries[ItemIndex]->FlagId(), ColorRGBA(1.0f, 1.0f, 1.0f, (Active ? 0.9f : 0.2f) + (UI()->HotItem() == pItemId ? 0.1f : 0.0f)), Item.x, Item.y, Item.w, Item.h);
+		m_pClient->m_CountryFlags.Render(m_CommunityCache.m_vpSelectableCountries[ItemIndex]->FlagId(), ColorRGBA(1.0f, 1.0f, 1.0f, (Active ? 0.9f : 0.2f) + (Ui()->HotItem() == pItemId ? 0.1f : 0.0f)), Item.x, Item.y, Item.w, Item.h);
 	};
 
 	RenderServerbrowserDDNetFilter(View, ServerBrowser()->CountriesFilter(), ItemHeight + 2.0f * Spacing, MaxEntries, EntriesPerRow, s_ScrollRegion, s_vItemIds, false, GetItemName, RenderItem);
@@ -1025,15 +1025,15 @@ void CMenus::RenderServerbrowserTypesFilter(CUIRect View)
 	};
 	const auto &&RenderItem = [&](int ItemIndex, CUIRect Item, const void *pItemId, bool Active) {
 		Item.Margin(Spacing, &Item);
-		TextRender()->TextColor(1.0f, 1.0f, 1.0f, (Active ? 0.9f : 0.2f) + (UI()->HotItem() == pItemId ? 0.1f : 0.0f));
-		UI()->DoLabel(&Item, GetItemName(ItemIndex), Item.h * CUI::ms_FontmodHeight, TEXTALIGN_MC);
+		TextRender()->TextColor(1.0f, 1.0f, 1.0f, (Active ? 0.9f : 0.2f) + (Ui()->HotItem() == pItemId ? 0.1f : 0.0f));
+		Ui()->DoLabel(&Item, GetItemName(ItemIndex), Item.h * CUi::ms_FontmodHeight, TEXTALIGN_MC);
 		TextRender()->TextColor(TextRender()->DefaultTextColor());
 	};
 
 	RenderServerbrowserDDNetFilter(View, ServerBrowser()->TypesFilter(), ItemHeight + 2.0f * Spacing, MaxEntries, EntriesPerRow, s_ScrollRegion, s_vItemIds, false, GetItemName, RenderItem);
 }
 
-CUI::EPopupMenuFunctionResult CMenus::PopupCountrySelection(void *pContext, CUIRect View, bool Active)
+CUi::EPopupMenuFunctionResult CMenus::PopupCountrySelection(void *pContext, CUIRect View, bool Active)
 {
 	SPopupCountrySelectionContext *pPopupContext = static_cast<SPopupCountrySelectionContext *>(pContext);
 	CMenus *pMenus = pPopupContext->m_pMenus;
@@ -1065,7 +1065,7 @@ CUI::EPopupMenuFunctionResult CMenus::PopupCountrySelection(void *pContext, CUIR
 		FlagRect.x += (OldWidth - FlagRect.w) / 2.0f;
 		pMenus->m_pClient->m_CountryFlags.Render(pEntry->m_CountryCode, ColorRGBA(1.0f, 1.0f, 1.0f, 1.0f), FlagRect.x, FlagRect.y, FlagRect.w, FlagRect.h);
 
-		pMenus->UI()->DoLabel(&Label, pEntry->m_aCountryCodeString, 10.0f, TEXTALIGN_MC);
+		pMenus->Ui()->DoLabel(&Label, pEntry->m_aCountryCodeString, 10.0f, TEXTALIGN_MC);
 	}
 
 	const int NewSelected = s_ListBox.DoEnd();
@@ -1075,10 +1075,10 @@ CUI::EPopupMenuFunctionResult CMenus::PopupCountrySelection(void *pContext, CUIR
 		g_Config.m_BrFilterCountry = 1;
 		g_Config.m_BrFilterCountryIndex = pPopupContext->m_Selection;
 		pMenus->Client()->ServerBrowserUpdate();
-		return CUI::POPUP_CLOSE_CURRENT;
+		return CUi::POPUP_CLOSE_CURRENT;
 	}
 
-	return CUI::POPUP_KEEP_OPEN;
+	return CUi::POPUP_KEEP_OPEN;
 }
 
 void CMenus::RenderServerbrowserInfo(CUIRect View)
@@ -1086,7 +1086,7 @@ void CMenus::RenderServerbrowserInfo(CUIRect View)
 	const CServerInfo *pSelectedServer = ServerBrowser()->SortedGet(m_SelectedIndex);
 
 	const float RowHeight = 18.0f;
-	const float FontSize = (RowHeight - 4.0f) * CUI::ms_FontmodHeight; // based on DoButton_CheckBox
+	const float FontSize = (RowHeight - 4.0f) * CUi::ms_FontmodHeight; // based on DoButton_CheckBox
 
 	CUIRect ServerDetails, Scoreboard;
 	View.HSplitTop(4.0f * 15.0f + RowHeight + 2.0f * 5.0f + 2.0f * 2.0f, &ServerDetails, &Scoreboard);
@@ -1148,30 +1148,30 @@ void CMenus::RenderServerbrowserInfo(CUIRect View)
 		ServerDetails.VSplitLeft(80.0f, &LeftColumn, &RightColumn);
 
 		LeftColumn.HSplitTop(15.0f, &Row, &LeftColumn);
-		UI()->DoLabel(&Row, Localize("Version"), FontSize, TEXTALIGN_ML);
+		Ui()->DoLabel(&Row, Localize("Version"), FontSize, TEXTALIGN_ML);
 
 		RightColumn.HSplitTop(15.0f, &Row, &RightColumn);
-		UI()->DoLabel(&Row, pSelectedServer->m_aVersion, FontSize, TEXTALIGN_ML);
+		Ui()->DoLabel(&Row, pSelectedServer->m_aVersion, FontSize, TEXTALIGN_ML);
 
 		LeftColumn.HSplitTop(15.0f, &Row, &LeftColumn);
-		UI()->DoLabel(&Row, Localize("Game type"), FontSize, TEXTALIGN_ML);
+		Ui()->DoLabel(&Row, Localize("Game type"), FontSize, TEXTALIGN_ML);
 
 		RightColumn.HSplitTop(15.0f, &Row, &RightColumn);
-		UI()->DoLabel(&Row, pSelectedServer->m_aGameType, FontSize, TEXTALIGN_ML);
+		Ui()->DoLabel(&Row, pSelectedServer->m_aGameType, FontSize, TEXTALIGN_ML);
 
 		LeftColumn.HSplitTop(15.0f, &Row, &LeftColumn);
-		UI()->DoLabel(&Row, Localize("Ping"), FontSize, TEXTALIGN_ML);
+		Ui()->DoLabel(&Row, Localize("Ping"), FontSize, TEXTALIGN_ML);
 
 		char aTemp[16];
 		FormatServerbrowserPing(aTemp, pSelectedServer);
 		RightColumn.HSplitTop(15.0f, &Row, &RightColumn);
-		UI()->DoLabel(&Row, aTemp, FontSize, TEXTALIGN_ML);
+		Ui()->DoLabel(&Row, aTemp, FontSize, TEXTALIGN_ML);
 
 		RenderServerbrowserInfoScoreboard(Scoreboard, pSelectedServer);
 	}
 	else
 	{
-		UI()->DoLabel(&ServerDetails, Localize("No server selected"), FontSize, TEXTALIGN_MC);
+		Ui()->DoLabel(&ServerDetails, Localize("No server selected"), FontSize, TEXTALIGN_MC);
 	}
 }
 
@@ -1268,7 +1268,7 @@ void CMenus::RenderServerbrowserInfoScoreboard(CUIRect View, const CServerInfo *
 			}
 		}
 
-		UI()->DoLabel(&Score, aTemp, FontSize, TEXTALIGN_ML);
+		Ui()->DoLabel(&Score, aTemp, FontSize, TEXTALIGN_ML);
 
 		// render tee if available
 		if(CurrentClient.m_aSkin[0] != '\0')
@@ -1399,12 +1399,12 @@ void CMenus::RenderServerbrowserFriends(CUIRect View)
 		CUIRect Header, GroupIcon, GroupLabel;
 		List.HSplitTop(ms_ListheaderHeight, &Header, &List);
 		s_ScrollRegion.AddRect(Header);
-		Header.Draw(ColorRGBA(1.0f, 1.0f, 1.0f, UI()->HotItem() == &s_aListExtended[FriendType] ? 0.4f : 0.25f), IGraphics::CORNER_ALL, 5.0f);
+		Header.Draw(ColorRGBA(1.0f, 1.0f, 1.0f, Ui()->HotItem() == &s_aListExtended[FriendType] ? 0.4f : 0.25f), IGraphics::CORNER_ALL, 5.0f);
 		Header.VSplitLeft(Header.h, &GroupIcon, &GroupLabel);
 		GroupIcon.Margin(2.0f, &GroupIcon);
 		TextRender()->SetFontPreset(EFontPreset::ICON_FONT);
-		TextRender()->TextColor(UI()->HotItem() == &s_aListExtended[FriendType] ? TextRender()->DefaultTextColor() : ColorRGBA(0.6f, 0.6f, 0.6f, 1.0f));
-		UI()->DoLabel(&GroupIcon, s_aListExtended[FriendType] ? FONT_ICON_SQUARE_MINUS : FONT_ICON_SQUARE_PLUS, GroupIcon.h * CUI::ms_FontmodHeight, TEXTALIGN_MC);
+		TextRender()->TextColor(Ui()->HotItem() == &s_aListExtended[FriendType] ? TextRender()->DefaultTextColor() : ColorRGBA(0.6f, 0.6f, 0.6f, 1.0f));
+		Ui()->DoLabel(&GroupIcon, s_aListExtended[FriendType] ? FONT_ICON_SQUARE_MINUS : FONT_ICON_SQUARE_PLUS, GroupIcon.h * CUi::ms_FontmodHeight, TEXTALIGN_MC);
 		TextRender()->TextColor(TextRender()->DefaultTextColor());
 		TextRender()->SetFontPreset(EFontPreset::DEFAULT_FONT);
 		switch(FriendType)
@@ -1422,8 +1422,8 @@ void CMenus::RenderServerbrowserFriends(CUIRect View)
 			dbg_assert(false, "FriendType invalid");
 			break;
 		}
-		UI()->DoLabel(&GroupLabel, aBuf, FontSize, TEXTALIGN_ML);
-		if(UI()->DoButtonLogic(&s_aListExtended[FriendType], 0, &Header))
+		Ui()->DoLabel(&GroupLabel, aBuf, FontSize, TEXTALIGN_ML);
+		if(Ui()->DoButtonLogic(&s_aListExtended[FriendType], 0, &Header))
 		{
 			s_aListExtended[FriendType] = !s_aListExtended[FriendType];
 		}
@@ -1447,8 +1447,8 @@ void CMenus::RenderServerbrowserFriends(CUIRect View)
 				if(s_ScrollRegion.RectClipped(Rect))
 					continue;
 
-				const bool Inside = UI()->HotItem() == Friend.ListItemId() || UI()->HotItem() == Friend.RemoveButtonId() || UI()->HotItem() == Friend.CommunityTooltipId();
-				bool ButtonResult = UI()->DoButtonLogic(Friend.ListItemId(), 0, &Rect);
+				const bool Inside = Ui()->HotItem() == Friend.ListItemId() || Ui()->HotItem() == Friend.RemoveButtonId() || Ui()->HotItem() == Friend.CommunityTooltipId();
+				bool ButtonResult = Ui()->DoButtonLogic(Friend.ListItemId(), 0, &Rect);
 				if(Friend.ServerInfo())
 				{
 					GameClient()->m_Tooltips.DoToolTip(Friend.ListItemId(), &Rect, Localize("Click to select server. Double click to join your friend."));
@@ -1484,10 +1484,10 @@ void CMenus::RenderServerbrowserFriends(CUIRect View)
 				Rect.HSplitTop(11.0f, &NameLabel, &ClanLabel);
 
 				// name
-				UI()->DoLabel(&NameLabel, Friend.Name(), FontSize - 1.0f, TEXTALIGN_ML);
+				Ui()->DoLabel(&NameLabel, Friend.Name(), FontSize - 1.0f, TEXTALIGN_ML);
 
 				// clan
-				UI()->DoLabel(&ClanLabel, Friend.Clan(), FontSize - 2.0f, TEXTALIGN_ML);
+				Ui()->DoLabel(&ClanLabel, Friend.Clan(), FontSize - 2.0f, TEXTALIGN_ML);
 
 				// server info
 				if(Friend.ServerInfo())
@@ -1503,7 +1503,7 @@ void CMenus::RenderServerbrowserFriends(CUIRect View)
 							InfoLabel.VSplitLeft(21.0f, &CommunityIcon, &InfoLabel);
 							InfoLabel.VSplitLeft(2.0f, nullptr, &InfoLabel);
 							RenderCommunityIcon(pIcon, CommunityIcon, true);
-							UI()->DoButtonLogic(Friend.CommunityTooltipId(), 0, &CommunityIcon);
+							Ui()->DoButtonLogic(Friend.CommunityTooltipId(), 0, &CommunityIcon);
 							GameClient()->m_Tooltips.DoToolTip(Friend.CommunityTooltipId(), &CommunityIcon, pCommunity->Name());
 						}
 					}
@@ -1515,20 +1515,20 @@ void CMenus::RenderServerbrowserFriends(CUIRect View)
 						str_format(aBuf, sizeof(aBuf), "%s | %s | %s", Friend.ServerInfo()->m_aMap, Friend.ServerInfo()->m_aGameType, aLatency);
 					else
 						str_format(aBuf, sizeof(aBuf), "%s | %s", Friend.ServerInfo()->m_aMap, Friend.ServerInfo()->m_aGameType);
-					UI()->DoLabel(&InfoLabel, aBuf, FontSize - 2.0f, TEXTALIGN_ML);
+					Ui()->DoLabel(&InfoLabel, aBuf, FontSize - 2.0f, TEXTALIGN_ML);
 				}
 
 				// remove button
 				if(Inside)
 				{
-					TextRender()->TextColor(UI()->HotItem() == Friend.RemoveButtonId() ? TextRender()->DefaultTextColor() : ColorRGBA(0.4f, 0.4f, 0.4f, 1.0f));
+					TextRender()->TextColor(Ui()->HotItem() == Friend.RemoveButtonId() ? TextRender()->DefaultTextColor() : ColorRGBA(0.4f, 0.4f, 0.4f, 1.0f));
 					TextRender()->SetFontPreset(EFontPreset::ICON_FONT);
 					TextRender()->SetRenderFlags(ETextRenderFlags::TEXT_RENDER_FLAG_ONLY_ADVANCE_WIDTH | ETextRenderFlags::TEXT_RENDER_FLAG_NO_X_BEARING | ETextRenderFlags::TEXT_RENDER_FLAG_NO_Y_BEARING | ETextRenderFlags::TEXT_RENDER_FLAG_NO_OVERSIZE);
-					UI()->DoLabel(&RemoveButton, FONT_ICON_TRASH, RemoveButton.h * CUI::ms_FontmodHeight, TEXTALIGN_MC);
+					Ui()->DoLabel(&RemoveButton, FONT_ICON_TRASH, RemoveButton.h * CUi::ms_FontmodHeight, TEXTALIGN_MC);
 					TextRender()->SetRenderFlags(0);
 					TextRender()->SetFontPreset(EFontPreset::DEFAULT_FONT);
 					TextRender()->TextColor(TextRender()->DefaultTextColor());
-					if(UI()->DoButtonLogic(Friend.RemoveButtonId(), 0, &RemoveButton))
+					if(Ui()->DoButtonLogic(Friend.RemoveButtonId(), 0, &RemoveButton))
 					{
 						m_pRemoveFriend = &Friend;
 						ButtonResult = false;
@@ -1553,7 +1553,7 @@ void CMenus::RenderServerbrowserFriends(CUIRect View)
 				CUIRect Label;
 				List.HSplitTop(12.0f, &Label, &List);
 				s_ScrollRegion.AddRect(Label);
-				UI()->DoLabel(&Label, Localize("None"), Label.h * CUI::ms_FontmodHeight, TEXTALIGN_ML);
+				Ui()->DoLabel(&Label, Localize("None"), Label.h * CUi::ms_FontmodHeight, TEXTALIGN_ML);
 			}
 		}
 
@@ -1583,18 +1583,18 @@ void CMenus::RenderServerbrowserFriends(CUIRect View)
 
 		ServerFriends.HSplitTop(18.0f, &Button, &ServerFriends);
 		str_format(aBuf, sizeof(aBuf), "%s:", Localize("Name"));
-		UI()->DoLabel(&Button, aBuf, FontSize + 2.0f, TEXTALIGN_ML);
+		Ui()->DoLabel(&Button, aBuf, FontSize + 2.0f, TEXTALIGN_ML);
 		Button.VSplitLeft(80.0f, nullptr, &Button);
 		static CLineInputBuffered<MAX_NAME_LENGTH> s_NameInput;
-		UI()->DoEditBox(&s_NameInput, &Button, FontSize + 2.0f);
+		Ui()->DoEditBox(&s_NameInput, &Button, FontSize + 2.0f);
 
 		ServerFriends.HSplitTop(3.0f, nullptr, &ServerFriends);
 		ServerFriends.HSplitTop(18.0f, &Button, &ServerFriends);
 		str_format(aBuf, sizeof(aBuf), "%s:", Localize("Clan"));
-		UI()->DoLabel(&Button, aBuf, FontSize + 2.0f, TEXTALIGN_ML);
+		Ui()->DoLabel(&Button, aBuf, FontSize + 2.0f, TEXTALIGN_ML);
 		Button.VSplitLeft(80.0f, nullptr, &Button);
 		static CLineInputBuffered<MAX_CLAN_LENGTH> s_ClanInput;
-		UI()->DoEditBox(&s_ClanInput, &Button, FontSize + 2.0f);
+		Ui()->DoEditBox(&s_ClanInput, &Button, FontSize + 2.0f);
 
 		ServerFriends.HSplitTop(3.0f, nullptr, &ServerFriends);
 		ServerFriends.HSplitTop(18.0f, &Button, &ServerFriends);
@@ -1640,7 +1640,7 @@ void CMenus::RenderServerbrowserTabBar(CUIRect TabBar)
 	const ColorRGBA ColorActive = ColorRGBA(0.0f, 0.0f, 0.0f, 0.3f);
 	const ColorRGBA ColorInactive = ColorRGBA(0.0f, 0.0f, 0.0f, 0.15f);
 
-	if(!UI()->IsPopupOpen() && UI()->ConsumeHotkey(CUI::HOTKEY_TAB))
+	if(!Ui()->IsPopupOpen() && Ui()->ConsumeHotkey(CUi::HOTKEY_TAB))
 	{
 		const int Direction = Input()->ShiftIsPressed() ? -1 : 1;
 		g_Config.m_UiToolboxPage = (g_Config.m_UiToolboxPage + NUM_UI_TOOLBOX_PAGES + Direction) % NUM_UI_TOOLBOX_PAGES;

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -30,7 +30,7 @@ using namespace std::chrono_literals;
 
 int CMenus::DoButton_FontIcon(CButtonContainer *pButtonContainer, const char *pText, int Checked, const CUIRect *pRect, int Corners, bool Enabled)
 {
-	pRect->Draw(ColorRGBA(1.0f, 1.0f, 1.0f, (Checked ? 0.10f : 0.5f) * UI()->ButtonColorMul(pButtonContainer)), Corners, 5.0f);
+	pRect->Draw(ColorRGBA(1.0f, 1.0f, 1.0f, (Checked ? 0.10f : 0.5f) * Ui()->ButtonColorMul(pButtonContainer)), Corners, 5.0f);
 
 	TextRender()->SetFontPreset(EFontPreset::ICON_FONT);
 	TextRender()->SetRenderFlags(ETextRenderFlags::TEXT_RENDER_FLAG_ONLY_ADVANCE_WIDTH | ETextRenderFlags::TEXT_RENDER_FLAG_NO_X_BEARING | ETextRenderFlags::TEXT_RENDER_FLAG_NO_Y_BEARING);
@@ -38,13 +38,13 @@ int CMenus::DoButton_FontIcon(CButtonContainer *pButtonContainer, const char *pT
 	TextRender()->TextColor(TextRender()->DefaultTextColor());
 	CUIRect Temp;
 	pRect->HMargin(2.0f, &Temp);
-	UI()->DoLabel(&Temp, pText, Temp.h * CUI::ms_FontmodHeight, TEXTALIGN_MC);
+	Ui()->DoLabel(&Temp, pText, Temp.h * CUi::ms_FontmodHeight, TEXTALIGN_MC);
 
 	if(!Enabled)
 	{
 		TextRender()->TextColor(ColorRGBA(1.0f, 0.0f, 0.0f, 1.0f));
 		TextRender()->TextOutlineColor(ColorRGBA(0.0f, 0.0f, 0.0f, 0.0f));
-		UI()->DoLabel(&Temp, FONT_ICON_SLASH, Temp.h * CUI::ms_FontmodHeight, TEXTALIGN_MC);
+		Ui()->DoLabel(&Temp, FONT_ICON_SLASH, Temp.h * CUi::ms_FontmodHeight, TEXTALIGN_MC);
 		TextRender()->TextOutlineColor(TextRender()->DefaultTextOutlineColor());
 		TextRender()->TextColor(TextRender()->DefaultTextColor());
 	}
@@ -52,7 +52,7 @@ int CMenus::DoButton_FontIcon(CButtonContainer *pButtonContainer, const char *pT
 	TextRender()->SetRenderFlags(0);
 	TextRender()->SetFontPreset(EFontPreset::DEFAULT_FONT);
 
-	return UI()->DoButtonLogic(pButtonContainer, Checked, pRect);
+	return Ui()->DoButtonLogic(pButtonContainer, Checked, pRect);
 }
 
 bool CMenus::DemoFilterChat(const void *pData, int Size, void *pUser)
@@ -169,7 +169,7 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 	// handle keyboard shortcuts independent of active menu
 	float PositionToSeek = -1.0f;
 	float TimeToSeek = 0.0f;
-	if(m_pClient->m_GameConsole.IsClosed() && m_DemoPlayerState == DEMOPLAYER_NONE && g_Config.m_ClDemoKeyboardShortcuts && !UI()->IsPopupOpen())
+	if(m_pClient->m_GameConsole.IsClosed() && m_DemoPlayerState == DEMOPLAYER_NONE && g_Config.m_ClDemoKeyboardShortcuts && !Ui()->IsPopupOpen())
 	{
 		// increase/decrease speed
 		if(!Input()->ModifierIsPressed() && !Input()->ShiftIsPressed() && !Input()->AltIsPressed())
@@ -271,7 +271,7 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 				TextRender()->TextOutlineColor(TextRender()->DefaultTextOutlineColor().WithMultipliedAlpha(Alpha));
 				TextRender()->SetFontPreset(EFontPreset::ICON_FONT);
 				TextRender()->SetRenderFlags(ETextRenderFlags::TEXT_RENDER_FLAG_ONLY_ADVANCE_WIDTH | ETextRenderFlags::TEXT_RENDER_FLAG_NO_X_BEARING | ETextRenderFlags::TEXT_RENDER_FLAG_NO_Y_BEARING);
-				UI()->DoLabel(UI()->Screen(), pInfo->m_Paused ? FONT_ICON_PAUSE : FONT_ICON_PLAY, 36.0f + Time * 12.0f, TEXTALIGN_MC);
+				Ui()->DoLabel(Ui()->Screen(), pInfo->m_Paused ? FONT_ICON_PAUSE : FONT_ICON_PLAY, 36.0f + Time * 12.0f, TEXTALIGN_MC);
 				TextRender()->TextColor(TextRender()->DefaultTextColor());
 				TextRender()->TextOutlineColor(TextRender()->DefaultTextOutlineColor());
 				TextRender()->SetFontPreset(EFontPreset::DEFAULT_FONT);
@@ -282,7 +282,7 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 		// Render speed info
 		if(g_Config.m_ClDemoShowSpeed && Client()->GlobalTime() - m_LastSpeedChange < 1.0f)
 		{
-			CUIRect Screen = *UI()->Screen();
+			CUIRect Screen = *Ui()->Screen();
 
 			char aSpeedBuf[16];
 			str_format(aSpeedBuf, sizeof(aSpeedBuf), "×%.2f", pInfo->m_Speed);
@@ -349,18 +349,18 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 
 		bool Clicked;
 		bool Abrupted;
-		if(int Result = UI()->DoDraggableButtonLogic(&s_Operation, 8, &DemoControlsDragRect, &Clicked, &Abrupted))
+		if(int Result = Ui()->DoDraggableButtonLogic(&s_Operation, 8, &DemoControlsDragRect, &Clicked, &Abrupted))
 		{
 			if(s_Operation == OP_NONE && Result == 1)
 			{
-				s_InitialMouse = UI()->MousePos();
+				s_InitialMouse = Ui()->MousePos();
 				s_Operation = OP_CLICKED;
 			}
 
 			if(Clicked || Abrupted)
 				s_Operation = OP_NONE;
 
-			if(s_Operation == OP_CLICKED && length(UI()->MousePos() - s_InitialMouse) > 5.0f)
+			if(s_Operation == OP_CLICKED && length(Ui()->MousePos() - s_InitialMouse) > 5.0f)
 			{
 				s_Operation = OP_DRAGGING;
 				s_InitialMouse -= m_DemoControlsPositionOffset;
@@ -368,7 +368,7 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 
 			if(s_Operation == OP_DRAGGING)
 			{
-				m_DemoControlsPositionOffset = UI()->MousePos() - s_InitialMouse;
+				m_DemoControlsPositionOffset = Ui()->MousePos() - s_InitialMouse;
 				m_DemoControlsPositionOffset.x = clamp(m_DemoControlsPositionOffset.x, -DemoControlsOriginal.x, MainView.w - DemoControlsDragRect.w - DemoControlsOriginal.x);
 				m_DemoControlsPositionOffset.y = clamp(m_DemoControlsPositionOffset.y, -DemoControlsOriginal.y, MainView.h - DemoControlsDragRect.h - DemoControlsOriginal.y);
 			}
@@ -379,8 +379,8 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 	{
 		const float Rounding = 5.0f;
 
-		static int s_SeekBarID = 0;
-		void *pId = &s_SeekBarID;
+		static int s_SeekBarId = 0;
+		void *pId = &s_SeekBarId;
 		char aBuffer[128];
 
 		// draw seek bar
@@ -413,7 +413,7 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 			Graphics()->TextureClear();
 			Graphics()->QuadsBegin();
 			Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
-			IGraphics::CQuadItem QuadItem(2 * Rounding + SeekBar.x + (SeekBar.w - 2 * Rounding) * Ratio, SeekBar.y, UI()->PixelSize(), SeekBar.h);
+			IGraphics::CQuadItem QuadItem(2 * Rounding + SeekBar.x + (SeekBar.w - 2 * Rounding) * Ratio, SeekBar.y, Ui()->PixelSize(), SeekBar.h);
 			Graphics()->QuadsDrawTL(&QuadItem, 1);
 			Graphics()->QuadsEnd();
 		}
@@ -426,7 +426,7 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 			Graphics()->TextureClear();
 			Graphics()->QuadsBegin();
 			Graphics()->SetColor(1.0f, 0.0f, 0.0f, 1.0f);
-			IGraphics::CQuadItem QuadItem(2 * Rounding + SeekBar.x + (SeekBar.w - 2 * Rounding) * Ratio, SeekBar.y, UI()->PixelSize(), SeekBar.h);
+			IGraphics::CQuadItem QuadItem(2 * Rounding + SeekBar.x + (SeekBar.w - 2 * Rounding) * Ratio, SeekBar.y, Ui()->PixelSize(), SeekBar.h);
 			Graphics()->QuadsDrawTL(&QuadItem, 1);
 			Graphics()->QuadsEnd();
 		}
@@ -438,7 +438,7 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 			Graphics()->TextureClear();
 			Graphics()->QuadsBegin();
 			Graphics()->SetColor(1.0f, 0.0f, 0.0f, 1.0f);
-			IGraphics::CQuadItem QuadItem(2 * Rounding + SeekBar.x + (SeekBar.w - 2 * Rounding) * Ratio, SeekBar.y, UI()->PixelSize(), SeekBar.h);
+			IGraphics::CQuadItem QuadItem(2 * Rounding + SeekBar.x + (SeekBar.w - 2 * Rounding) * Ratio, SeekBar.y, Ui()->PixelSize(), SeekBar.h);
 			Graphics()->QuadsDrawTL(&QuadItem, 1);
 			Graphics()->QuadsEnd();
 		}
@@ -449,19 +449,19 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 		char aTotalTime[32];
 		str_time((int64_t)TotalTicks / Client()->GameTickSpeed() * 100, TIME_HOURS, aTotalTime, sizeof(aTotalTime));
 		str_format(aBuffer, sizeof(aBuffer), "%s / %s", aCurrentTime, aTotalTime);
-		UI()->DoLabel(&SeekBar, aBuffer, SeekBar.h * 0.70f, TEXTALIGN_MC);
+		Ui()->DoLabel(&SeekBar, aBuffer, SeekBar.h * 0.70f, TEXTALIGN_MC);
 
 		// do the logic
-		const bool Inside = UI()->MouseInside(&SeekBar);
+		const bool Inside = Ui()->MouseInside(&SeekBar);
 
-		if(UI()->CheckActiveItem(pId))
+		if(Ui()->CheckActiveItem(pId))
 		{
-			if(!UI()->MouseButton(0))
-				UI()->SetActiveItem(nullptr);
+			if(!Ui()->MouseButton(0))
+				Ui()->SetActiveItem(nullptr);
 			else
 			{
 				static float s_PrevAmount = 0.0f;
-				float AmountSeek = clamp((UI()->MouseX() - SeekBar.x - Rounding) / (float)(SeekBar.w - 2 * Rounding), 0.0f, 1.0f);
+				float AmountSeek = clamp((Ui()->MouseX() - SeekBar.x - Rounding) / (float)(SeekBar.w - 2 * Rounding), 0.0f, 1.0f);
 
 				if(Input()->ShiftIsPressed())
 				{
@@ -481,15 +481,15 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 				}
 			}
 		}
-		else if(UI()->HotItem() == pId)
+		else if(Ui()->HotItem() == pId)
 		{
-			if(UI()->MouseButton(0))
+			if(Ui()->MouseButton(0))
 			{
-				UI()->SetActiveItem(pId);
+				Ui()->SetActiveItem(pId);
 			}
 			else
 			{
-				const int HoveredTick = (int)(clamp((UI()->MouseX() - SeekBar.x - Rounding) / (float)(SeekBar.w - 2 * Rounding), 0.0f, 1.0f) * TotalTicks);
+				const int HoveredTick = (int)(clamp((Ui()->MouseX() - SeekBar.x - Rounding) / (float)(SeekBar.w - 2 * Rounding), 0.0f, 1.0f) * TotalTicks);
 				static char s_aHoveredTime[32];
 				str_time((int64_t)HoveredTick / Client()->GameTickSpeed() * 100, TIME_HOURS, s_aHoveredTime, sizeof(s_aHoveredTime));
 				GameClient()->m_Tooltips.DoToolTip(pId, &SeekBar, s_aHoveredTime);
@@ -497,7 +497,7 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 		}
 
 		if(Inside)
-			UI()->SetHotItem(pId);
+			Ui()->SetHotItem(pId);
 	}
 
 	bool IncreaseDemoSpeed = false, DecreaseDemoSpeed = false;
@@ -565,10 +565,10 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 			s_vpDurationNames[i] = s_vDurationNames[i].c_str();
 		}
 
-		static CUI::SDropDownState s_SkipDurationDropDownState;
+		static CUi::SDropDownState s_SkipDurationDropDownState;
 		static CScrollRegion s_SkipDurationDropDownScrollRegion;
 		s_SkipDurationDropDownState.m_SelectionPopupContext.m_pScrollRegion = &s_SkipDurationDropDownScrollRegion;
-		s_SkipDurationIndex = UI()->DoDropDown(&Button, s_SkipDurationIndex, s_vpDurationNames.data(), NumDurationLabels, s_SkipDurationDropDownState);
+		s_SkipDurationIndex = Ui()->DoDropDown(&Button, s_SkipDurationIndex, s_vpDurationNames.data(), NumDurationLabels, s_SkipDurationDropDownState);
 		GameClient()->m_Tooltips.DoToolTip(&s_SkipDurationDropDownState.m_ButtonContainer, &Button, Localize("Change the skip duration"));
 	}
 
@@ -642,7 +642,7 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 	ButtonBar.VSplitLeft(Margins * 12, &SpeedBar, &ButtonBar);
 	char aBuffer[64];
 	str_format(aBuffer, sizeof(aBuffer), "×%g", pInfo->m_Speed);
-	UI()->DoLabel(&SpeedBar, aBuffer, Button.h * 0.7f, TEXTALIGN_MC);
+	Ui()->DoLabel(&SpeedBar, aBuffer, Button.h * 0.7f, TEXTALIGN_MC);
 
 	// slice begin button
 	ButtonBar.VSplitLeft(ButtonbarHeight, &Button, &ButtonBar);
@@ -691,7 +691,7 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 		char aDemoName[IO_MAX_PATH_LENGTH];
 		DemoPlayer()->GetDemoName(aDemoName, sizeof(aDemoName));
 		m_DemoSliceInput.Set(aDemoName);
-		UI()->SetActiveItem(&m_DemoSliceInput);
+		Ui()->SetActiveItem(&m_DemoSliceInput);
 		m_DemoPlayerState = DEMOPLAYER_SLICE_SAVE;
 	}
 	GameClient()->m_Tooltips.DoToolTip(&s_SliceSaveButton, &Button, Localize("Export cut as a separate demo"));
@@ -725,7 +725,7 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 	Props.m_MaxWidth = NameBar.w;
 	Props.m_EllipsisAtEnd = true;
 	Props.m_EnableWidthCheck = false;
-	UI()->DoLabel(&NameBar, aBuf, Button.h * 0.5f, TEXTALIGN_ML, Props);
+	Ui()->DoLabel(&NameBar, aBuf, Button.h * 0.5f, TEXTALIGN_ML, Props);
 
 	if(IncreaseDemoSpeed)
 	{
@@ -744,14 +744,14 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 	if(m_DemoPlayerState != DEMOPLAYER_NONE)
 	{
 		// prevent element under the active popup from being activated
-		UI()->SetHotItem(nullptr);
+		Ui()->SetHotItem(nullptr);
 	}
 	if(m_DemoPlayerState == DEMOPLAYER_SLICE_SAVE)
 	{
 		RenderDemoPlayerSliceSavePopup(MainView);
 	}
 
-	UI()->RenderPopupMenus();
+	Ui()->RenderPopupMenus();
 }
 
 void CMenus::RenderDemoPlayerSliceSavePopup(CUIRect MainView)
@@ -769,7 +769,7 @@ void CMenus::RenderDemoPlayerSliceSavePopup(CUIRect MainView)
 	CUIRect Title;
 	Box.HSplitTop(24.0f, &Title, &Box);
 	Box.HSplitTop(20.0f, nullptr, &Box);
-	UI()->DoLabel(&Title, Localize("Export demo cut"), 24.0f, TEXTALIGN_MC);
+	Ui()->DoLabel(&Title, Localize("Export demo cut"), 24.0f, TEXTALIGN_MC);
 
 	// slice times
 	CUIRect SliceTimesBar, SliceInterval, SliceLength;
@@ -786,9 +786,9 @@ void CMenus::RenderDemoPlayerSliceSavePopup(CUIRect MainView)
 	str_time((RealSliceEnd - RealSliceBegin) / Client()->GameTickSpeed() * 100, TIME_HOURS, aSliceLength, sizeof(aSliceLength));
 	char aBuf[256];
 	str_format(aBuf, sizeof(aBuf), "%s: %s – %s", Localize("Cut interval"), aSliceBegin, aSliceEnd);
-	UI()->DoLabel(&SliceInterval, aBuf, 18.0f, TEXTALIGN_ML);
+	Ui()->DoLabel(&SliceInterval, aBuf, 18.0f, TEXTALIGN_ML);
 	str_format(aBuf, sizeof(aBuf), "%s: %s", Localize("Cut length"), aSliceLength);
-	UI()->DoLabel(&SliceLength, aBuf, 18.0f, TEXTALIGN_ML);
+	Ui()->DoLabel(&SliceLength, aBuf, 18.0f, TEXTALIGN_ML);
 
 	// file name
 	CUIRect NameLabel, NameBox;
@@ -796,8 +796,8 @@ void CMenus::RenderDemoPlayerSliceSavePopup(CUIRect MainView)
 	Box.HSplitTop(20.0f, nullptr, &Box);
 	NameLabel.VSplitLeft(150.0f, &NameLabel, &NameBox);
 	NameBox.VSplitLeft(20.0f, nullptr, &NameBox);
-	UI()->DoLabel(&NameLabel, Localize("New name:"), 18.0f, TEXTALIGN_ML);
-	UI()->DoEditBox(&m_DemoSliceInput, &NameBox, 12.0f);
+	Ui()->DoLabel(&NameLabel, Localize("New name:"), 18.0f, TEXTALIGN_ML);
+	Ui()->DoEditBox(&m_DemoSliceInput, &NameBox, 12.0f);
 
 	// remove chat checkbox
 	static int s_RemoveChat = 0;
@@ -824,12 +824,12 @@ void CMenus::RenderDemoPlayerSliceSavePopup(CUIRect MainView)
 	ButtonBar.VSplitMid(&AbortButton, &OkButton, 40.0f);
 
 	static CButtonContainer s_ButtonAbort;
-	if(DoButton_Menu(&s_ButtonAbort, Localize("Abort"), 0, &AbortButton) || (!UI()->IsPopupOpen() && UI()->ConsumeHotkey(CUI::HOTKEY_ESCAPE)))
+	if(DoButton_Menu(&s_ButtonAbort, Localize("Abort"), 0, &AbortButton) || (!Ui()->IsPopupOpen() && Ui()->ConsumeHotkey(CUi::HOTKEY_ESCAPE)))
 		m_DemoPlayerState = DEMOPLAYER_NONE;
 
-	static CUI::SConfirmPopupContext s_ConfirmPopupContext;
+	static CUi::SConfirmPopupContext s_ConfirmPopupContext;
 	static CButtonContainer s_ButtonOk;
-	if(DoButton_Menu(&s_ButtonOk, Localize("Ok"), 0, &OkButton) || (!UI()->IsPopupOpen() && UI()->ConsumeHotkey(CUI::HOTKEY_ENTER)))
+	if(DoButton_Menu(&s_ButtonOk, Localize("Ok"), 0, &OkButton) || (!Ui()->IsPopupOpen() && Ui()->ConsumeHotkey(CUi::HOTKEY_ENTER)))
 	{
 		char aDemoName[IO_MAX_PATH_LENGTH];
 		char aNameWithoutExt[IO_MAX_PATH_LENGTH];
@@ -840,10 +840,10 @@ void CMenus::RenderDemoPlayerSliceSavePopup(CUIRect MainView)
 
 		if(str_comp(aDemoName, m_DemoSliceInput.GetString()) == 0)
 		{
-			static CUI::SMessagePopupContext s_MessagePopupContext;
+			static CUi::SMessagePopupContext s_MessagePopupContext;
 			s_MessagePopupContext.ErrorColor();
 			str_copy(s_MessagePopupContext.m_aMessage, Localize("Please use a different filename"));
-			UI()->ShowPopupMessage(UI()->MouseX(), OkButton.y + OkButton.h + 5.0f, &s_MessagePopupContext);
+			Ui()->ShowPopupMessage(Ui()->MouseX(), OkButton.y + OkButton.h + 5.0f, &s_MessagePopupContext);
 		}
 		else
 		{
@@ -854,14 +854,14 @@ void CMenus::RenderDemoPlayerSliceSavePopup(CUIRect MainView)
 				s_ConfirmPopupContext.Reset();
 				s_ConfirmPopupContext.YesNoButtons();
 				str_copy(s_ConfirmPopupContext.m_aMessage, Localize("File already exists, do you want to overwrite it?"));
-				UI()->ShowPopupConfirm(UI()->MouseX(), OkButton.y + OkButton.h + 5.0f, &s_ConfirmPopupContext);
+				Ui()->ShowPopupConfirm(Ui()->MouseX(), OkButton.y + OkButton.h + 5.0f, &s_ConfirmPopupContext);
 			}
 			else
-				s_ConfirmPopupContext.m_Result = CUI::SConfirmPopupContext::CONFIRMED;
+				s_ConfirmPopupContext.m_Result = CUi::SConfirmPopupContext::CONFIRMED;
 		}
 	}
 
-	if(s_ConfirmPopupContext.m_Result == CUI::SConfirmPopupContext::CONFIRMED)
+	if(s_ConfirmPopupContext.m_Result == CUi::SConfirmPopupContext::CONFIRMED)
 	{
 		char aPath[IO_MAX_PATH_LENGTH];
 		str_format(aPath, sizeof(aPath), "%s/%s.demo", m_aCurrentDemoFolder, m_DemoSliceInput.GetString());
@@ -879,13 +879,13 @@ void CMenus::RenderDemoPlayerSliceSavePopup(CUIRect MainView)
 			m_Popup = POPUP_RENDER_DEMO;
 			m_StartPaused = false;
 			m_DemoRenderInput.Set(m_aCurrentDemoSelectionName);
-			UI()->SetActiveItem(&m_DemoRenderInput);
+			Ui()->SetActiveItem(&m_DemoRenderInput);
 			if(m_DemolistStorageType != IStorage::TYPE_ALL && m_DemolistStorageType != IStorage::TYPE_SAVE)
 				m_DemolistStorageType = IStorage::TYPE_ALL; // Select a storage type containing the sliced demo
 		}
 #endif
 	}
-	if(s_ConfirmPopupContext.m_Result != CUI::SConfirmPopupContext::UNSET)
+	if(s_ConfirmPopupContext.m_Result != CUi::SConfirmPopupContext::UNSET)
 	{
 		s_ConfirmPopupContext.Reset();
 	}
@@ -1212,7 +1212,7 @@ void CMenus::RenderDemoBrowserList(CUIRect ListView, bool &WasListboxItemActivat
 				TextRender()->SetFontPreset(EFontPreset::ICON_FONT);
 				TextRender()->TextColor(IconColor);
 				TextRender()->SetRenderFlags(ETextRenderFlags::TEXT_RENDER_FLAG_ONLY_ADVANCE_WIDTH | ETextRenderFlags::TEXT_RENDER_FLAG_NO_X_BEARING | ETextRenderFlags::TEXT_RENDER_FLAG_NO_Y_BEARING);
-				UI()->DoLabel(&Button, pIconType, 12.0f, TEXTALIGN_ML);
+				Ui()->DoLabel(&Button, pIconType, 12.0f, TEXTALIGN_ML);
 				TextRender()->SetRenderFlags(0);
 				TextRender()->TextColor(TextRender()->DefaultTextColor());
 				TextRender()->SetFontPreset(EFontPreset::DEFAULT_FONT);
@@ -1223,19 +1223,19 @@ void CMenus::RenderDemoBrowserList(CUIRect ListView, bool &WasListboxItemActivat
 				Props.m_MaxWidth = Button.w;
 				Props.m_EllipsisAtEnd = true;
 				Props.m_EnableWidthCheck = false;
-				UI()->DoLabel(&Button, pItem->m_aName, 12.0f, TEXTALIGN_ML, Props);
+				Ui()->DoLabel(&Button, pItem->m_aName, 12.0f, TEXTALIGN_ML, Props);
 			}
 			else if(Col.m_Id == COL_LENGTH && !pItem->m_IsDir && pItem->m_Valid)
 			{
 				str_time((int64_t)pItem->Length() * 100, TIME_HOURS, aBuf, sizeof(aBuf));
 				Button.VMargin(4.0f, &Button);
-				UI()->DoLabel(&Button, aBuf, 12.0f, TEXTALIGN_MR);
+				Ui()->DoLabel(&Button, aBuf, 12.0f, TEXTALIGN_MR);
 			}
 			else if(Col.m_Id == COL_DATE && !pItem->m_IsDir)
 			{
 				str_timestamp_ex(pItem->m_Date, aBuf, sizeof(aBuf), FORMAT_SPACE);
 				Button.VMargin(4.0f, &Button);
-				UI()->DoLabel(&Button, aBuf, 12.0f, TEXTALIGN_MR);
+				Ui()->DoLabel(&Button, aBuf, 12.0f, TEXTALIGN_MR);
 			}
 		}
 	}
@@ -1276,7 +1276,7 @@ void CMenus::RenderDemoBrowserDetails(CUIRect DetailsView)
 		pHeaderLabel = Localize("Invalid Demo");
 	else
 		pHeaderLabel = Localize("Demo");
-	UI()->DoLabel(&Header, pHeaderLabel, FontSize + 2.0f, TEXTALIGN_MC);
+	Ui()->DoLabel(&Header, pHeaderLabel, FontSize + 2.0f, TEXTALIGN_MC);
 
 	if(pItem == nullptr || pItem->m_IsDir)
 		return;
@@ -1285,10 +1285,10 @@ void CMenus::RenderDemoBrowserDetails(CUIRect DetailsView)
 	CUIRect Left, Right;
 
 	Contents.HSplitTop(18.0f, &Left, &Contents);
-	UI()->DoLabel(&Left, Localize("Created"), FontSize, TEXTALIGN_ML);
+	Ui()->DoLabel(&Left, Localize("Created"), FontSize, TEXTALIGN_ML);
 	str_timestamp_ex(pItem->m_Date, aBuf, sizeof(aBuf), FORMAT_SPACE);
 	Contents.HSplitTop(18.0f, &Left, &Contents);
-	UI()->DoLabel(&Left, aBuf, FontSize - 1.0f, TEXTALIGN_ML);
+	Ui()->DoLabel(&Left, aBuf, FontSize - 1.0f, TEXTALIGN_ML);
 	Contents.HSplitTop(4.0f, nullptr, &Contents);
 
 	if(!pItem->m_Valid)
@@ -1296,41 +1296,41 @@ void CMenus::RenderDemoBrowserDetails(CUIRect DetailsView)
 
 	Contents.HSplitTop(18.0f, &Left, &Contents);
 	Left.VSplitMid(&Left, &Right, 4.0f);
-	UI()->DoLabel(&Left, Localize("Type"), FontSize, TEXTALIGN_ML);
-	UI()->DoLabel(&Right, Localize("Version"), FontSize, TEXTALIGN_ML);
+	Ui()->DoLabel(&Left, Localize("Type"), FontSize, TEXTALIGN_ML);
+	Ui()->DoLabel(&Right, Localize("Version"), FontSize, TEXTALIGN_ML);
 	Contents.HSplitTop(18.0f, &Left, &Contents);
 	Left.VSplitMid(&Left, &Right, 4.0f);
-	UI()->DoLabel(&Left, pItem->m_Info.m_aType, FontSize - 1.0f, TEXTALIGN_ML);
+	Ui()->DoLabel(&Left, pItem->m_Info.m_aType, FontSize - 1.0f, TEXTALIGN_ML);
 	str_from_int(pItem->m_Info.m_Version, aBuf);
-	UI()->DoLabel(&Right, aBuf, FontSize - 1.0f, TEXTALIGN_ML);
+	Ui()->DoLabel(&Right, aBuf, FontSize - 1.0f, TEXTALIGN_ML);
 	Contents.HSplitTop(4.0f, nullptr, &Contents);
 
 	Contents.HSplitTop(18.0f, &Left, &Contents);
 	Left.VSplitMid(&Left, &Right, 4.0f);
-	UI()->DoLabel(&Left, Localize("Length"), FontSize, TEXTALIGN_ML);
-	UI()->DoLabel(&Right, Localize("Markers"), FontSize, TEXTALIGN_ML);
+	Ui()->DoLabel(&Left, Localize("Length"), FontSize, TEXTALIGN_ML);
+	Ui()->DoLabel(&Right, Localize("Markers"), FontSize, TEXTALIGN_ML);
 	Contents.HSplitTop(18.0f, &Left, &Contents);
 	Left.VSplitMid(&Left, &Right, 4.0f);
 	str_time((int64_t)pItem->Length() * 100, TIME_HOURS, aBuf, sizeof(aBuf));
-	UI()->DoLabel(&Left, aBuf, FontSize - 1.0f, TEXTALIGN_ML);
+	Ui()->DoLabel(&Left, aBuf, FontSize - 1.0f, TEXTALIGN_ML);
 	str_from_int(pItem->NumMarkers(), aBuf);
-	UI()->DoLabel(&Right, aBuf, FontSize - 1.0f, TEXTALIGN_ML);
+	Ui()->DoLabel(&Right, aBuf, FontSize - 1.0f, TEXTALIGN_ML);
 	Contents.HSplitTop(4.0f, nullptr, &Contents);
 
 	Contents.HSplitTop(18.0f, &Left, &Contents);
-	UI()->DoLabel(&Left, Localize("Netversion"), FontSize, TEXTALIGN_ML);
+	Ui()->DoLabel(&Left, Localize("Netversion"), FontSize, TEXTALIGN_ML);
 	Contents.HSplitTop(18.0f, &Left, &Contents);
-	UI()->DoLabel(&Left, pItem->m_Info.m_aNetversion, FontSize - 1.0f, TEXTALIGN_ML);
+	Ui()->DoLabel(&Left, pItem->m_Info.m_aNetversion, FontSize - 1.0f, TEXTALIGN_ML);
 	Contents.HSplitTop(16.0f, nullptr, &Contents);
 
 	Contents.HSplitTop(18.0f, &Left, &Contents);
-	UI()->DoLabel(&Left, Localize("Map"), FontSize, TEXTALIGN_ML);
+	Ui()->DoLabel(&Left, Localize("Map"), FontSize, TEXTALIGN_ML);
 	Contents.HSplitTop(18.0f, &Left, &Contents);
-	UI()->DoLabel(&Left, pItem->m_Info.m_aMapName, FontSize - 1.0f, TEXTALIGN_ML);
+	Ui()->DoLabel(&Left, pItem->m_Info.m_aMapName, FontSize - 1.0f, TEXTALIGN_ML);
 	Contents.HSplitTop(4.0f, nullptr, &Contents);
 
 	Contents.HSplitTop(18.0f, &Left, &Contents);
-	UI()->DoLabel(&Left, Localize("Size"), FontSize, TEXTALIGN_ML);
+	Ui()->DoLabel(&Left, Localize("Size"), FontSize, TEXTALIGN_ML);
 	Contents.HSplitTop(18.0f, &Left, &Contents);
 	const float Size = pItem->Size() / 1024.0f;
 	if(Size == 0.0f)
@@ -1339,13 +1339,13 @@ void CMenus::RenderDemoBrowserDetails(CUIRect DetailsView)
 		str_format(aBuf, sizeof(aBuf), Localize("%.2f MiB"), Size / 1024.0f);
 	else
 		str_format(aBuf, sizeof(aBuf), Localize("%.2f KiB"), Size);
-	UI()->DoLabel(&Left, aBuf, FontSize - 1.0f, TEXTALIGN_ML);
+	Ui()->DoLabel(&Left, aBuf, FontSize - 1.0f, TEXTALIGN_ML);
 	Contents.HSplitTop(4.0f, nullptr, &Contents);
 
 	Contents.HSplitTop(18.0f, &Left, &Contents);
 	if(pItem->m_MapInfo.m_Sha256 != SHA256_ZEROED)
 	{
-		UI()->DoLabel(&Left, "SHA256", FontSize, TEXTALIGN_ML);
+		Ui()->DoLabel(&Left, "SHA256", FontSize, TEXTALIGN_ML);
 		Contents.HSplitTop(18.0f, &Left, &Contents);
 		char aSha[SHA256_MAXSTRSIZE];
 		sha256_str(pItem->m_MapInfo.m_Sha256, aSha, sizeof(aSha));
@@ -1353,14 +1353,14 @@ void CMenus::RenderDemoBrowserDetails(CUIRect DetailsView)
 		Props.m_MaxWidth = Left.w;
 		Props.m_EllipsisAtEnd = true;
 		Props.m_EnableWidthCheck = false;
-		UI()->DoLabel(&Left, aSha, FontSize - 1.0f, TEXTALIGN_ML, Props);
+		Ui()->DoLabel(&Left, aSha, FontSize - 1.0f, TEXTALIGN_ML, Props);
 	}
 	else
 	{
-		UI()->DoLabel(&Left, "CRC32", FontSize, TEXTALIGN_ML);
+		Ui()->DoLabel(&Left, "CRC32", FontSize, TEXTALIGN_ML);
 		Contents.HSplitTop(18.0f, &Left, &Contents);
 		str_format(aBuf, sizeof(aBuf), "%08x", pItem->m_MapInfo.m_Crc);
-		UI()->DoLabel(&Left, aBuf, FontSize - 1.0f, TEXTALIGN_ML);
+		Ui()->DoLabel(&Left, aBuf, FontSize - 1.0f, TEXTALIGN_ML);
 	}
 	Contents.HSplitTop(4.0f, nullptr, &Contents);
 }
@@ -1392,16 +1392,16 @@ void CMenus::RenderDemoBrowserButtons(CUIRect ButtonsView, bool WasListboxItemAc
 		ButtonBarTop.VSplitLeft(ButtonBarTop.h / 2.0f, nullptr, &ButtonBarTop);
 		DemoSearch.VSplitLeft(TextRender()->TextWidth(14.0f, FONT_ICON_MAGNIFYING_GLASS), &SearchIcon, &DemoSearch);
 		DemoSearch.VSplitLeft(5.0f, nullptr, &DemoSearch);
-		UI()->DoLabel(&SearchIcon, FONT_ICON_MAGNIFYING_GLASS, 14.0f, TEXTALIGN_ML);
+		Ui()->DoLabel(&SearchIcon, FONT_ICON_MAGNIFYING_GLASS, 14.0f, TEXTALIGN_ML);
 		SetIconMode(false);
 		m_DemoSearchInput.SetEmptyText(Localize("Search"));
 
 		if(Input()->KeyPress(KEY_F) && Input()->ModifierIsPressed())
 		{
-			UI()->SetActiveItem(&m_DemoSearchInput);
+			Ui()->SetActiveItem(&m_DemoSearchInput);
 			m_DemoSearchInput.SelectAll();
 		}
-		if(UI()->DoClearableEditBox(&m_DemoSearchInput, &DemoSearch, 12.0f))
+		if(Ui()->DoClearableEditBox(&m_DemoSearchInput, &DemoSearch, 12.0f))
 		{
 			RefreshFilteredDemos();
 			DemolistOnUpdate(false);
@@ -1464,7 +1464,7 @@ void CMenus::RenderDemoBrowserButtons(CUIRect ButtonsView, bool WasListboxItemAc
 		ButtonBarBottom.VSplitRight(ButtonBarBottom.h, &ButtonBarBottom, nullptr);
 		SetIconMode(true);
 		static CButtonContainer s_PlayButton;
-		if(DoButton_Menu(&s_PlayButton, (m_DemolistSelectedIndex >= 0 && m_vpFilteredDemos[m_DemolistSelectedIndex]->m_IsDir) ? FONT_ICON_FOLDER_OPEN : FONT_ICON_PLAY, 0, &PlayButton) || WasListboxItemActivated || UI()->ConsumeHotkey(CUI::HOTKEY_ENTER) || (Input()->KeyPress(KEY_P) && m_pClient->m_GameConsole.IsClosed() && !m_DemoSearchInput.IsActive()))
+		if(DoButton_Menu(&s_PlayButton, (m_DemolistSelectedIndex >= 0 && m_vpFilteredDemos[m_DemolistSelectedIndex]->m_IsDir) ? FONT_ICON_FOLDER_OPEN : FONT_ICON_PLAY, 0, &PlayButton) || WasListboxItemActivated || Ui()->ConsumeHotkey(CUi::HOTKEY_ENTER) || (Input()->KeyPress(KEY_P) && m_pClient->m_GameConsole.IsClosed() && !m_DemoSearchInput.IsActive()))
 		{
 			SetIconMode(false);
 			if(m_vpFilteredDemos[m_DemolistSelectedIndex]->m_IsDir) // folder
@@ -1513,7 +1513,7 @@ void CMenus::RenderDemoBrowserButtons(CUIRect ButtonsView, bool WasListboxItemAc
 				}
 				else
 				{
-					UI()->SetActiveItem(nullptr);
+					Ui()->SetActiveItem(nullptr);
 					return;
 				}
 			}
@@ -1544,7 +1544,7 @@ void CMenus::RenderDemoBrowserButtons(CUIRect ButtonsView, bool WasListboxItemAc
 						fs_split_file_extension(m_vpFilteredDemos[m_DemolistSelectedIndex]->m_aFilename, aNameWithoutExt, sizeof(aNameWithoutExt));
 						m_DemoRenameInput.Set(aNameWithoutExt);
 					}
-					UI()->SetActiveItem(&m_DemoRenameInput);
+					Ui()->SetActiveItem(&m_DemoRenameInput);
 					return;
 				}
 
@@ -1553,7 +1553,7 @@ void CMenus::RenderDemoBrowserButtons(CUIRect ButtonsView, bool WasListboxItemAc
 				CUIRect DeleteButton;
 				ButtonBarBottom.VSplitRight(ButtonBarBottom.h * 3.0f, &ButtonBarBottom, &DeleteButton);
 				ButtonBarBottom.VSplitRight(ButtonBarBottom.h / 2.0f, &ButtonBarBottom, nullptr);
-				if(DoButton_Menu(&s_DeleteButton, FONT_ICON_TRASH, 0, &DeleteButton) || UI()->ConsumeHotkey(CUI::HOTKEY_DELETE) || (Input()->KeyPress(KEY_D) && m_pClient->m_GameConsole.IsClosed() && !m_DemoSearchInput.IsActive()))
+				if(DoButton_Menu(&s_DeleteButton, FONT_ICON_TRASH, 0, &DeleteButton) || Ui()->ConsumeHotkey(CUi::HOTKEY_DELETE) || (Input()->KeyPress(KEY_D) && m_pClient->m_GameConsole.IsClosed() && !m_DemoSearchInput.IsActive()))
 				{
 					SetIconMode(false);
 					char aBuf[128 + IO_MAX_PATH_LENGTH];
@@ -1581,7 +1581,7 @@ void CMenus::RenderDemoBrowserButtons(CUIRect ButtonsView, bool WasListboxItemAc
 					char aNameWithoutExt[IO_MAX_PATH_LENGTH];
 					fs_split_file_extension(m_vpFilteredDemos[m_DemolistSelectedIndex]->m_aFilename, aNameWithoutExt, sizeof(aNameWithoutExt));
 					m_DemoRenderInput.Set(aNameWithoutExt);
-					UI()->SetActiveItem(&m_DemoRenderInput);
+					Ui()->SetActiveItem(&m_DemoRenderInput);
 					return;
 				}
 				SetIconMode(false);

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -116,10 +116,10 @@ void CMenus::RenderGame(CUIRect MainView)
 
 	bool Paused = false;
 	bool Spec = false;
-	if(m_pClient->m_Snap.m_LocalClientID >= 0)
+	if(m_pClient->m_Snap.m_LocalClientId >= 0)
 	{
-		Paused = m_pClient->m_aClients[m_pClient->m_Snap.m_LocalClientID].m_Paused;
-		Spec = m_pClient->m_aClients[m_pClient->m_Snap.m_LocalClientID].m_Spec;
+		Paused = m_pClient->m_aClients[m_pClient->m_Snap.m_LocalClientId].m_Paused;
+		Spec = m_pClient->m_aClients[m_pClient->m_Snap.m_LocalClientId].m_Spec;
 	}
 
 	if(m_pClient->m_Snap.m_pLocalInfo && m_pClient->m_Snap.m_pGameInfoObj && !Paused && !Spec)
@@ -232,12 +232,12 @@ void CMenus::RenderPlayers(CUIRect MainView)
 	Options.Draw(ColorRGBA(1.0f, 1.0f, 1.0f, 0.25f), IGraphics::CORNER_ALL, 10.0f);
 	Options.Margin(10.0f, &Options);
 	Options.HSplitTop(50.0f, &Button, &Options);
-	UI()->DoLabel(&Button, Localize("Player options"), 34.0f, TEXTALIGN_ML);
+	Ui()->DoLabel(&Button, Localize("Player options"), 34.0f, TEXTALIGN_ML);
 
 	// headline
 	Options.HSplitTop(34.0f, &ButtonBar, &Options);
 	ButtonBar.VSplitRight(231.0f, &Player, &ButtonBar);
-	UI()->DoLabel(&Player, Localize("Player"), 24.0f, TEXTALIGN_ML);
+	Ui()->DoLabel(&Player, Localize("Player"), 24.0f, TEXTALIGN_ML);
 
 	ButtonBar.HMargin(1.0f, &ButtonBar);
 	float Width = ButtonBar.h * 2.0f;
@@ -258,9 +258,9 @@ void CMenus::RenderPlayers(CUIRect MainView)
 		if(!pInfoByName)
 			continue;
 
-		int Index = pInfoByName->m_ClientID;
+		int Index = pInfoByName->m_ClientId;
 
-		if(Index == m_pClient->m_Snap.m_LocalClientID)
+		if(Index == m_pClient->m_Snap.m_LocalClientId)
 			continue;
 
 		TotalPlayers++;
@@ -270,15 +270,15 @@ void CMenus::RenderPlayers(CUIRect MainView)
 	s_ListBox.DoStart(24.0f, TotalPlayers, 1, 3, -1, &Options);
 
 	// options
-	static char s_aPlayerIDs[MAX_CLIENTS][3] = {{0}};
+	static char s_aPlayerIds[MAX_CLIENTS][3] = {{0}};
 
 	for(int i = 0, Count = 0; i < MAX_CLIENTS; ++i)
 	{
 		if(!m_pClient->m_Snap.m_apInfoByName[i])
 			continue;
 
-		int Index = m_pClient->m_Snap.m_apInfoByName[i]->m_ClientID;
-		if(Index == m_pClient->m_Snap.m_LocalClientID)
+		int Index = m_pClient->m_Snap.m_apInfoByName[i]->m_ClientId;
+		if(Index == m_pClient->m_Snap.m_LocalClientId)
 			continue;
 
 		CGameClient::CClientData &CurrentClient = m_pClient->m_aClients[Index];
@@ -312,8 +312,8 @@ void CMenus::RenderPlayers(CUIRect MainView)
 		Player.VSplitMid(&Player, &Button);
 		Row.VSplitRight(210.0f, &Button2, &Row);
 
-		UI()->DoLabel(&Player, CurrentClient.m_aName, 14.0f, TEXTALIGN_ML);
-		UI()->DoLabel(&Button, CurrentClient.m_aClan, 14.0f, TEXTALIGN_ML);
+		Ui()->DoLabel(&Player, CurrentClient.m_aName, 14.0f, TEXTALIGN_ML);
+		Ui()->DoLabel(&Button, CurrentClient.m_aClan, 14.0f, TEXTALIGN_ML);
 
 		m_pClient->m_CountryFlags.Render(CurrentClient.m_Country, ColorRGBA(1.0f, 1.0f, 1.0f, 0.5f),
 			Button2.x, Button2.y + Button2.h / 2.0f - 0.75f * Button2.h / 2.0f, 1.5f * Button2.h, 0.75f * Button2.h);
@@ -324,8 +324,8 @@ void CMenus::RenderPlayers(CUIRect MainView)
 		Button.VSplitLeft((Width - Button.h) / 4.0f, nullptr, &Button);
 		Button.VSplitLeft(Button.h, &Button, nullptr);
 		if(g_Config.m_ClShowChatFriends && !CurrentClient.m_Friend)
-			DoButton_Toggle(&s_aPlayerIDs[Index][0], 1, &Button, false);
-		else if(DoButton_Toggle(&s_aPlayerIDs[Index][0], CurrentClient.m_ChatIgnore, &Button, true))
+			DoButton_Toggle(&s_aPlayerIds[Index][0], 1, &Button, false);
+		else if(DoButton_Toggle(&s_aPlayerIds[Index][0], CurrentClient.m_ChatIgnore, &Button, true))
 			CurrentClient.m_ChatIgnore ^= 1;
 
 		// ignore emoticon button
@@ -334,8 +334,8 @@ void CMenus::RenderPlayers(CUIRect MainView)
 		Button.VSplitLeft((Width - Button.h) / 4.0f, nullptr, &Button);
 		Button.VSplitLeft(Button.h, &Button, nullptr);
 		if(g_Config.m_ClShowChatFriends && !CurrentClient.m_Friend)
-			DoButton_Toggle(&s_aPlayerIDs[Index][1], 1, &Button, false);
-		else if(DoButton_Toggle(&s_aPlayerIDs[Index][1], CurrentClient.m_EmoticonIgnore, &Button, true))
+			DoButton_Toggle(&s_aPlayerIds[Index][1], 1, &Button, false);
+		else if(DoButton_Toggle(&s_aPlayerIds[Index][1], CurrentClient.m_EmoticonIgnore, &Button, true))
 			CurrentClient.m_EmoticonIgnore ^= 1;
 
 		// friend button
@@ -343,7 +343,7 @@ void CMenus::RenderPlayers(CUIRect MainView)
 		Row.VSplitLeft(Width, &Button, &Row);
 		Button.VSplitLeft((Width - Button.h) / 4.0f, nullptr, &Button);
 		Button.VSplitLeft(Button.h, &Button, nullptr);
-		if(DoButton_Toggle(&s_aPlayerIDs[Index][2], CurrentClient.m_Friend, &Button, true))
+		if(DoButton_Toggle(&s_aPlayerIds[Index][2], CurrentClient.m_Friend, &Button, true))
 		{
 			if(CurrentClient.m_Friend)
 				m_pClient->Friends()->RemoveFriend(CurrentClient.m_aName, CurrentClient.m_aClan);
@@ -556,7 +556,7 @@ bool CMenus::RenderServerControlServer(CUIRect MainView)
 
 		CUIRect Label;
 		Item.m_Rect.VMargin(2.0f, &Label);
-		UI()->DoLabel(&Label, pOption->m_aDescription, 13.0f, TEXTALIGN_ML);
+		Ui()->DoLabel(&Label, pOption->m_aDescription, 13.0f, TEXTALIGN_ML);
 	}
 
 	s_CurVoteOption = s_ListBox.DoEnd();
@@ -569,14 +569,14 @@ bool CMenus::RenderServerControlKick(CUIRect MainView, bool FilterSpectators)
 {
 	int NumOptions = 0;
 	int Selected = -1;
-	int aPlayerIDs[MAX_CLIENTS];
+	int aPlayerIds[MAX_CLIENTS];
 	for(const auto &pInfoByName : m_pClient->m_Snap.m_apInfoByName)
 	{
 		if(!pInfoByName)
 			continue;
 
-		int Index = pInfoByName->m_ClientID;
-		if(Index == m_pClient->m_Snap.m_LocalClientID || (FilterSpectators && pInfoByName->m_Team == TEAM_SPECTATORS))
+		int Index = pInfoByName->m_ClientId;
+		if(Index == m_pClient->m_Snap.m_LocalClientId || (FilterSpectators && pInfoByName->m_Team == TEAM_SPECTATORS))
 			continue;
 
 		if(!str_utf8_find_nocase(m_pClient->m_aClients[Index].m_aName, m_FilterInput.GetString()))
@@ -584,7 +584,7 @@ bool CMenus::RenderServerControlKick(CUIRect MainView, bool FilterSpectators)
 
 		if(m_CallvoteSelectedPlayer == Index)
 			Selected = NumOptions;
-		aPlayerIDs[NumOptions] = Index;
+		aPlayerIds[NumOptions] = Index;
 		NumOptions++;
 	}
 
@@ -593,14 +593,14 @@ bool CMenus::RenderServerControlKick(CUIRect MainView, bool FilterSpectators)
 
 	for(int i = 0; i < NumOptions; i++)
 	{
-		const CListboxItem Item = s_ListBox.DoNextItem(&aPlayerIDs[i]);
+		const CListboxItem Item = s_ListBox.DoNextItem(&aPlayerIds[i]);
 		if(!Item.m_Visible)
 			continue;
 
 		CUIRect TeeRect, Label;
 		Item.m_Rect.VSplitLeft(Item.m_Rect.h, &TeeRect, &Label);
 
-		CTeeRenderInfo TeeInfo = m_pClient->m_aClients[aPlayerIDs[i]].m_RenderInfo;
+		CTeeRenderInfo TeeInfo = m_pClient->m_aClients[aPlayerIds[i]].m_RenderInfo;
 		TeeInfo.m_Size = TeeRect.h;
 
 		const CAnimState *pIdleState = CAnimState::GetIdle();
@@ -610,11 +610,11 @@ bool CMenus::RenderServerControlKick(CUIRect MainView, bool FilterSpectators)
 
 		RenderTools()->RenderTee(pIdleState, &TeeInfo, EMOTE_NORMAL, vec2(1.0f, 0.0f), TeeRenderPos);
 
-		UI()->DoLabel(&Label, m_pClient->m_aClients[aPlayerIDs[i]].m_aName, 16.0f, TEXTALIGN_ML);
+		Ui()->DoLabel(&Label, m_pClient->m_aClients[aPlayerIds[i]].m_aName, 16.0f, TEXTALIGN_ML);
 	}
 
 	Selected = s_ListBox.DoEnd();
-	m_CallvoteSelectedPlayer = Selected != -1 ? aPlayerIDs[Selected] : -1;
+	m_CallvoteSelectedPlayer = Selected != -1 ? aPlayerIds[Selected] : -1;
 	return s_ListBox.WasItemActivated();
 }
 
@@ -676,7 +676,7 @@ void CMenus::RenderServerControl(CUIRect MainView)
 	TextRender()->SetFontPreset(EFontPreset::ICON_FONT);
 	TextRender()->SetRenderFlags(ETextRenderFlags::TEXT_RENDER_FLAG_ONLY_ADVANCE_WIDTH | ETextRenderFlags::TEXT_RENDER_FLAG_NO_X_BEARING | ETextRenderFlags::TEXT_RENDER_FLAG_NO_Y_BEARING | ETextRenderFlags::TEXT_RENDER_FLAG_NO_PIXEL_ALIGMENT | ETextRenderFlags::TEXT_RENDER_FLAG_NO_OVERSIZE);
 
-	UI()->DoLabel(&QuickSearch, FONT_ICON_MAGNIFYING_GLASS, 14.0f, TEXTALIGN_ML);
+	Ui()->DoLabel(&QuickSearch, FONT_ICON_MAGNIFYING_GLASS, 14.0f, TEXTALIGN_ML);
 	float wSearch = TextRender()->TextWidth(14.0f, FONT_ICON_MAGNIFYING_GLASS, -1, -1.0f);
 	TextRender()->SetRenderFlags(0);
 	TextRender()->SetFontPreset(EFontPreset::DEFAULT_FONT);
@@ -685,12 +685,12 @@ void CMenus::RenderServerControl(CUIRect MainView)
 
 	if(m_ControlPageOpening || (Input()->KeyPress(KEY_F) && Input()->ModifierIsPressed()))
 	{
-		UI()->SetActiveItem(&m_FilterInput);
+		Ui()->SetActiveItem(&m_FilterInput);
 		m_ControlPageOpening = false;
 		m_FilterInput.SelectAll();
 	}
 	m_FilterInput.SetEmptyText(Localize("Search"));
-	UI()->DoClearableEditBox(&m_FilterInput, &QuickSearch, 14.0f);
+	Ui()->DoClearableEditBox(&m_FilterInput, &QuickSearch, 14.0f);
 
 	// call vote
 	Bottom.VSplitRight(10.0f, &Bottom, 0);
@@ -731,15 +731,15 @@ void CMenus::RenderServerControl(CUIRect MainView)
 	Bottom.VSplitRight(20.0f, &Bottom, 0);
 	Bottom.VSplitRight(200.0f, &Bottom, &Reason);
 	const char *pLabel = Localize("Reason:");
-	UI()->DoLabel(&Reason, pLabel, 14.0f, TEXTALIGN_ML);
+	Ui()->DoLabel(&Reason, pLabel, 14.0f, TEXTALIGN_ML);
 	float w = TextRender()->TextWidth(14.0f, pLabel, -1, -1.0f);
 	Reason.VSplitLeft(w + 10.0f, 0, &Reason);
 	if(Input()->KeyPress(KEY_R) && Input()->ModifierIsPressed())
 	{
-		UI()->SetActiveItem(&m_CallvoteReasonInput);
+		Ui()->SetActiveItem(&m_CallvoteReasonInput);
 		m_CallvoteReasonInput.SelectAll();
 	}
-	UI()->DoEditBox(&m_CallvoteReasonInput, &Reason, 14.0f);
+	Ui()->DoEditBox(&m_CallvoteReasonInput, &Reason, 14.0f);
 
 	// vote option loading indicator
 	if(s_ControlPage == EServerControlTab::SETTINGS && m_pClient->m_Voting.IsReceivingOptions())
@@ -749,8 +749,8 @@ void CMenus::RenderServerControl(CUIRect MainView)
 		Bottom.VSplitLeft(16.0f, &Spinner, &Bottom);
 		Bottom.VSplitLeft(5.0f, nullptr, &Bottom);
 		Bottom.VSplitRight(10.0f, &LoadingLabel, nullptr);
-		UI()->RenderProgressSpinner(Spinner.Center(), 8.0f);
-		UI()->DoLabel(&LoadingLabel, Localize("Loading…"), 14.0f, TEXTALIGN_ML);
+		Ui()->RenderProgressSpinner(Spinner.Center(), 8.0f);
+		Ui()->DoLabel(&LoadingLabel, Localize("Loading…"), 14.0f, TEXTALIGN_ML);
 	}
 
 	// extended features (only available when authed in rcon)
@@ -806,10 +806,10 @@ void CMenus::RenderServerControl(CUIRect MainView)
 			RconExtension.HSplitTop(20.0f, &Bottom, &RconExtension);
 			Bottom.VSplitLeft(5.0f, 0, &Bottom);
 			Bottom.VSplitLeft(250.0f, &Button, &Bottom);
-			UI()->DoLabel(&Button, Localize("Vote description:"), 14.0f, TEXTALIGN_ML);
+			Ui()->DoLabel(&Button, Localize("Vote description:"), 14.0f, TEXTALIGN_ML);
 
 			Bottom.VSplitLeft(20.0f, 0, &Button);
-			UI()->DoLabel(&Button, Localize("Vote command:"), 14.0f, TEXTALIGN_ML);
+			Ui()->DoLabel(&Button, Localize("Vote command:"), 14.0f, TEXTALIGN_ML);
 
 			static CLineInputBuffered<VOTE_DESC_LENGTH> s_VoteDescriptionInput;
 			static CLineInputBuffered<VOTE_CMD_LENGTH> s_VoteCommandInput;
@@ -823,10 +823,10 @@ void CMenus::RenderServerControl(CUIRect MainView)
 
 			Bottom.VSplitLeft(5.0f, 0, &Bottom);
 			Bottom.VSplitLeft(250.0f, &Button, &Bottom);
-			UI()->DoEditBox(&s_VoteDescriptionInput, &Button, 14.0f);
+			Ui()->DoEditBox(&s_VoteDescriptionInput, &Button, 14.0f);
 
 			Bottom.VMargin(20.0f, &Button);
-			UI()->DoEditBox(&s_VoteCommandInput, &Button, 14.0f);
+			Ui()->DoEditBox(&s_VoteCommandInput, &Button, 14.0f);
 		}
 	}
 }
@@ -1134,19 +1134,19 @@ void CMenus::RenderGhost(CUIRect MainView)
 			}
 			else if(Id == COL_NAME)
 			{
-				UI()->DoLabel(&Button, pGhost->m_aPlayer, 12.0f, TEXTALIGN_ML);
+				Ui()->DoLabel(&Button, pGhost->m_aPlayer, 12.0f, TEXTALIGN_ML);
 			}
 			else if(Id == COL_TIME)
 			{
 				char aBuf[64];
 				str_time(pGhost->m_Time / 10, TIME_HOURS_CENTISECS, aBuf, sizeof(aBuf));
-				UI()->DoLabel(&Button, aBuf, 12.0f, TEXTALIGN_ML);
+				Ui()->DoLabel(&Button, aBuf, 12.0f, TEXTALIGN_ML);
 			}
 			else if(Id == COL_DATE)
 			{
 				char aBuf[64];
 				str_timestamp_ex(pGhost->m_Date, aBuf, sizeof(aBuf), FORMAT_SPACE);
-				UI()->DoLabel(&Button, aBuf, 12.0f, TEXTALIGN_ML);
+				Ui()->DoLabel(&Button, aBuf, 12.0f, TEXTALIGN_ML);
 			}
 		}
 
@@ -1275,5 +1275,5 @@ void CMenus::RenderIngameHint()
 	Graphics()->MapScreen(0, 0, Width, 300);
 	TextRender()->TextColor(1, 1, 1, 1);
 	TextRender()->Text(5, 280, 5, Localize("Menu opened. Press Esc key again to close menu."), -1.0f);
-	UI()->MapScreen();
+	Ui()->MapScreen();
 }

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -82,7 +82,7 @@ void CMenus::RenderSettingsGeneral(CUIRect MainView)
 	{
 		// headline
 		Game.HSplitTop(30.0f, &Label, &Game);
-		UI()->DoLabel(&Label, Localize("Game"), 20.0f, TEXTALIGN_ML);
+		Ui()->DoLabel(&Label, Localize("Game"), 20.0f, TEXTALIGN_ML);
 		Game.HSplitTop(5.0f, nullptr, &Game);
 		Game.VSplitMid(&Left, nullptr, 20.0f);
 
@@ -138,7 +138,7 @@ void CMenus::RenderSettingsGeneral(CUIRect MainView)
 	{
 		// headline
 		Client.HSplitTop(30.0f, &Label, &Client);
-		UI()->DoLabel(&Label, Localize("Client"), 20.0f, TEXTALIGN_ML);
+		Ui()->DoLabel(&Label, Localize("Client"), 20.0f, TEXTALIGN_ML);
 		Client.HSplitTop(5.0f, nullptr, &Client);
 		Client.VSplitMid(&Left, &Right, 20.0f);
 
@@ -149,7 +149,7 @@ void CMenus::RenderSettingsGeneral(CUIRect MainView)
 
 		Left.HSplitTop(10.0f, nullptr, &Left);
 		Left.HSplitTop(20.0f, &Button, &Left);
-		UI()->DoScrollbarOption(&g_Config.m_ClRefreshRate, &g_Config.m_ClRefreshRate, &Button, Localize("Refresh Rate"), 10, 10000, &CUI::ms_LogarithmicScrollbarScale, CUI::SCROLLBAR_OPTION_INFINITE, " Hz");
+		Ui()->DoScrollbarOption(&g_Config.m_ClRefreshRate, &g_Config.m_ClRefreshRate, &Button, Localize("Refresh Rate"), 10, 10000, &CUi::ms_LogarithmicScrollbarScale, CUi::SCROLLBAR_OPTION_INFINITE, " Hz");
 		Left.HSplitTop(5.0f, nullptr, &Left);
 		Left.HSplitTop(20.0f, &Button, &Left);
 		static int s_LowerRefreshRate;
@@ -159,8 +159,8 @@ void CMenus::RenderSettingsGeneral(CUIRect MainView)
 		CUIRect SettingsButton;
 		Left.HSplitBottom(20.0f, &Left, &SettingsButton);
 		Left.HSplitBottom(5.0f, &Left, nullptr);
-		static CButtonContainer s_SettingsButtonID;
-		if(DoButton_Menu(&s_SettingsButtonID, Localize("Settings file"), 0, &SettingsButton))
+		static CButtonContainer s_SettingsButtonId;
+		if(DoButton_Menu(&s_SettingsButtonId, Localize("Settings file"), 0, &SettingsButton))
 		{
 			Storage()->GetCompletePath(IStorage::TYPE_SAVE, CONFIG_FILE, aBuf, sizeof(aBuf));
 			if(!open_file(aBuf))
@@ -168,13 +168,13 @@ void CMenus::RenderSettingsGeneral(CUIRect MainView)
 				dbg_msg("menus", "couldn't open file '%s'", aBuf);
 			}
 		}
-		GameClient()->m_Tooltips.DoToolTip(&s_SettingsButtonID, &SettingsButton, Localize("Open the settings file"));
+		GameClient()->m_Tooltips.DoToolTip(&s_SettingsButtonId, &SettingsButton, Localize("Open the settings file"));
 
 		CUIRect ConfigButton;
 		Left.HSplitBottom(20.0f, &Left, &ConfigButton);
 		Left.HSplitBottom(5.0f, &Left, nullptr);
-		static CButtonContainer s_ConfigButtonID;
-		if(DoButton_Menu(&s_ConfigButtonID, Localize("Config directory"), 0, &ConfigButton))
+		static CButtonContainer s_ConfigButtonId;
+		if(DoButton_Menu(&s_ConfigButtonId, Localize("Config directory"), 0, &ConfigButton))
 		{
 			Storage()->GetCompletePath(IStorage::TYPE_SAVE, "", aBuf, sizeof(aBuf));
 			if(!open_file(aBuf))
@@ -182,13 +182,13 @@ void CMenus::RenderSettingsGeneral(CUIRect MainView)
 				dbg_msg("menus", "couldn't open file '%s'", aBuf);
 			}
 		}
-		GameClient()->m_Tooltips.DoToolTip(&s_ConfigButtonID, &ConfigButton, Localize("Open the directory that contains the configuration and user files"));
+		GameClient()->m_Tooltips.DoToolTip(&s_ConfigButtonId, &ConfigButton, Localize("Open the directory that contains the configuration and user files"));
 
 		CUIRect DirectoryButton;
 		Left.HSplitBottom(20.0f, &Left, &DirectoryButton);
 		Left.HSplitBottom(5.0f, &Left, nullptr);
-		static CButtonContainer s_ThemesButtonID;
-		if(DoButton_Menu(&s_ThemesButtonID, Localize("Themes directory"), 0, &DirectoryButton))
+		static CButtonContainer s_ThemesButtonId;
+		if(DoButton_Menu(&s_ThemesButtonId, Localize("Themes directory"), 0, &DirectoryButton))
 		{
 			Storage()->GetCompletePath(IStorage::TYPE_SAVE, "themes", aBuf, sizeof(aBuf));
 			Storage()->CreateFolder("themes", IStorage::TYPE_SAVE);
@@ -197,7 +197,7 @@ void CMenus::RenderSettingsGeneral(CUIRect MainView)
 				dbg_msg("menus", "couldn't open file '%s'", aBuf);
 			}
 		}
-		GameClient()->m_Tooltips.DoToolTip(&s_ThemesButtonID, &DirectoryButton, Localize("Open the directory to add custom themes"));
+		GameClient()->m_Tooltips.DoToolTip(&s_ThemesButtonId, &DirectoryButton, Localize("Open the directory to add custom themes"));
 
 		Left.HSplitTop(20.0f, nullptr, &Left);
 		RenderThemeSelection(Left);
@@ -211,7 +211,7 @@ void CMenus::RenderSettingsGeneral(CUIRect MainView)
 
 			Right.HSplitTop(2 * 20.0f, &Button, &Right);
 			if(g_Config.m_ClAutoDemoRecord)
-				UI()->DoScrollbarOption(&g_Config.m_ClAutoDemoMax, &g_Config.m_ClAutoDemoMax, &Button, Localize("Max demos"), 1, 1000, &CUI::ms_LinearScrollbarScale, CUI::SCROLLBAR_OPTION_INFINITE | CUI::SCROLLBAR_OPTION_MULTILINE);
+				Ui()->DoScrollbarOption(&g_Config.m_ClAutoDemoMax, &g_Config.m_ClAutoDemoMax, &Button, Localize("Max demos"), 1, 1000, &CUi::ms_LinearScrollbarScale, CUi::SCROLLBAR_OPTION_INFINITE | CUi::SCROLLBAR_OPTION_MULTILINE);
 
 			Right.HSplitTop(10.0f, nullptr, &Right);
 			Right.HSplitTop(20.0f, &Button, &Right);
@@ -220,7 +220,7 @@ void CMenus::RenderSettingsGeneral(CUIRect MainView)
 
 			Right.HSplitTop(2 * 20.0f, &Button, &Right);
 			if(g_Config.m_ClAutoScreenshot)
-				UI()->DoScrollbarOption(&g_Config.m_ClAutoScreenshotMax, &g_Config.m_ClAutoScreenshotMax, &Button, Localize("Max Screenshots"), 1, 1000, &CUI::ms_LinearScrollbarScale, CUI::SCROLLBAR_OPTION_INFINITE | CUI::SCROLLBAR_OPTION_MULTILINE);
+				Ui()->DoScrollbarOption(&g_Config.m_ClAutoScreenshotMax, &g_Config.m_ClAutoScreenshotMax, &Button, Localize("Max Screenshots"), 1, 1000, &CUi::ms_LinearScrollbarScale, CUi::SCROLLBAR_OPTION_INFINITE | CUi::SCROLLBAR_OPTION_MULTILINE);
 		}
 
 		// auto statboard screenshot
@@ -234,7 +234,7 @@ void CMenus::RenderSettingsGeneral(CUIRect MainView)
 
 			Right.HSplitTop(2 * 20.0f, &Button, &Right);
 			if(g_Config.m_ClAutoStatboardScreenshot)
-				UI()->DoScrollbarOption(&g_Config.m_ClAutoStatboardScreenshotMax, &g_Config.m_ClAutoStatboardScreenshotMax, &Button, Localize("Max Screenshots"), 1, 1000, &CUI::ms_LinearScrollbarScale, CUI::SCROLLBAR_OPTION_INFINITE | CUI::SCROLLBAR_OPTION_MULTILINE);
+				Ui()->DoScrollbarOption(&g_Config.m_ClAutoStatboardScreenshotMax, &g_Config.m_ClAutoStatboardScreenshotMax, &Button, Localize("Max Screenshots"), 1, 1000, &CUi::ms_LinearScrollbarScale, CUi::SCROLLBAR_OPTION_INFINITE | CUi::SCROLLBAR_OPTION_MULTILINE);
 		}
 
 		// auto statboard csv
@@ -248,7 +248,7 @@ void CMenus::RenderSettingsGeneral(CUIRect MainView)
 
 			Right.HSplitTop(2 * 20.0f, &Button, &Right);
 			if(g_Config.m_ClAutoCSV)
-				UI()->DoScrollbarOption(&g_Config.m_ClAutoCSVMax, &g_Config.m_ClAutoCSVMax, &Button, Localize("Max CSVs"), 1, 1000, &CUI::ms_LinearScrollbarScale, CUI::SCROLLBAR_OPTION_INFINITE | CUI::SCROLLBAR_OPTION_MULTILINE);
+				Ui()->DoScrollbarOption(&g_Config.m_ClAutoCSVMax, &g_Config.m_ClAutoCSVMax, &Button, Localize("Max CSVs"), 1, 1000, &CUi::ms_LinearScrollbarScale, CUi::SCROLLBAR_OPTION_INFINITE | CUi::SCROLLBAR_OPTION_MULTILINE);
 		}
 	}
 }
@@ -286,7 +286,7 @@ void CMenus::RenderSettingsPlayer(CUIRect MainView)
 		char aChangeInfo[128], aTimeLeft[32];
 		str_format(aTimeLeft, sizeof(aTimeLeft), Localize("%ds left"), (m_pClient->m_NextChangeInfo - Client()->GameTick(g_Config.m_ClDummy) + Client()->GameTickSpeed() - 1) / Client()->GameTickSpeed());
 		str_format(aChangeInfo, sizeof(aChangeInfo), "%s: %s", Localize("Player info change cooldown"), aTimeLeft);
-		UI()->DoLabel(&ChangeInfo, aChangeInfo, 10.f, TEXTALIGN_ML);
+		Ui()->DoLabel(&ChangeInfo, aChangeInfo, 10.f, TEXTALIGN_ML);
 	}
 
 	static CLineInput s_NameInput;
@@ -315,8 +315,8 @@ void CMenus::RenderSettingsPlayer(CUIRect MainView)
 	Button.VSplitLeft(150.0f, &Button, nullptr);
 	char aBuf[128];
 	str_format(aBuf, sizeof(aBuf), "%s:", Localize("Name"));
-	UI()->DoLabel(&Label, aBuf, 14.0f, TEXTALIGN_ML);
-	if(UI()->DoEditBox(&s_NameInput, &Button, 14.0f))
+	Ui()->DoLabel(&Label, aBuf, 14.0f, TEXTALIGN_ML);
+	if(Ui()->DoEditBox(&s_NameInput, &Button, 14.0f))
 	{
 		SetNeedSendInfo();
 	}
@@ -327,8 +327,8 @@ void CMenus::RenderSettingsPlayer(CUIRect MainView)
 	Button.VSplitLeft(80.0f, &Label, &Button);
 	Button.VSplitLeft(150.0f, &Button, nullptr);
 	str_format(aBuf, sizeof(aBuf), "%s:", Localize("Clan"));
-	UI()->DoLabel(&Label, aBuf, 14.0f, TEXTALIGN_ML);
-	if(UI()->DoEditBox(&s_ClanInput, &Button, 14.0f))
+	Ui()->DoLabel(&Label, aBuf, 14.0f, TEXTALIGN_ML);
+	if(Ui()->DoEditBox(&s_ClanInput, &Button, 14.0f))
 	{
 		SetNeedSendInfo();
 	}
@@ -373,7 +373,7 @@ void CMenus::RenderSettingsPlayer(CUIRect MainView)
 
 		if(pEntry->m_Texture.IsValid())
 		{
-			UI()->DoLabel(&Label, pEntry->m_aCountryCodeString, 10.0f, TEXTALIGN_MC);
+			Ui()->DoLabel(&Label, pEntry->m_aCountryCodeString, 10.0f, TEXTALIGN_MC);
 		}
 	}
 
@@ -390,7 +390,7 @@ void CMenus::RenderSettingsPlayer(CUIRect MainView)
 
 	TextRender()->SetFontPreset(EFontPreset::ICON_FONT);
 	TextRender()->SetRenderFlags(ETextRenderFlags::TEXT_RENDER_FLAG_ONLY_ADVANCE_WIDTH | ETextRenderFlags::TEXT_RENDER_FLAG_NO_X_BEARING | ETextRenderFlags::TEXT_RENDER_FLAG_NO_Y_BEARING | ETextRenderFlags::TEXT_RENDER_FLAG_NO_PIXEL_ALIGMENT | ETextRenderFlags::TEXT_RENDER_FLAG_NO_OVERSIZE);
-	UI()->DoLabel(&QuickSearch, FONT_ICON_MAGNIFYING_GLASS, 14.0f, TEXTALIGN_ML);
+	Ui()->DoLabel(&QuickSearch, FONT_ICON_MAGNIFYING_GLASS, 14.0f, TEXTALIGN_ML);
 	TextRender()->SetRenderFlags(0);
 	TextRender()->SetFontPreset(EFontPreset::DEFAULT_FONT);
 
@@ -403,11 +403,11 @@ void CMenus::RenderSettingsPlayer(CUIRect MainView)
 	TextRender()->SetFontPreset(EFontPreset::DEFAULT_FONT);
 	if(Input()->KeyPress(KEY_F) && Input()->ModifierIsPressed())
 	{
-		UI()->SetActiveItem(&s_FlagFilterInput);
+		Ui()->SetActiveItem(&s_FlagFilterInput);
 		s_FlagFilterInput.SelectAll();
 	}
 	s_FlagFilterInput.SetEmptyText(Localize("Search"));
-	UI()->DoClearableEditBox(&s_FlagFilterInput, &QuickSearch, 14.0f);
+	Ui()->DoClearableEditBox(&s_FlagFilterInput, &QuickSearch, 14.0f);
 }
 
 struct CUISkin
@@ -541,7 +541,7 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 		char aChangeInfo[128], aTimeLeft[32];
 		str_format(aTimeLeft, sizeof(aTimeLeft), Localize("%ds left"), (m_pClient->m_NextChangeInfo - Client()->GameTick(g_Config.m_ClDummy) + Client()->GameTickSpeed() - 1) / Client()->GameTickSpeed());
 		str_format(aChangeInfo, sizeof(aChangeInfo), "%s: %s", Localize("Player info change cooldown"), aTimeLeft);
-		UI()->DoLabel(&ChangeInfo, aChangeInfo, 10.f, TEXTALIGN_ML);
+		Ui()->DoLabel(&ChangeInfo, aChangeInfo, 10.f, TEXTALIGN_ML);
 	}
 
 	char *pSkinName;
@@ -623,11 +623,11 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 	// Skin prefix
 	{
 		SkinPrefix.HSplitTop(20.0f, &Label, &SkinPrefix);
-		UI()->DoLabel(&Label, Localize("Skin prefix"), 14.0f, TEXTALIGN_ML);
+		Ui()->DoLabel(&Label, Localize("Skin prefix"), 14.0f, TEXTALIGN_ML);
 
 		SkinPrefix.HSplitTop(20.0f, &Button, &SkinPrefix);
 		static CLineInput s_SkinPrefixInput(g_Config.m_ClSkinPrefix, sizeof(g_Config.m_ClSkinPrefix));
-		UI()->DoClearableEditBox(&s_SkinPrefixInput, &Button, 14.0f);
+		Ui()->DoClearableEditBox(&s_SkinPrefixInput, &Button, 14.0f);
 
 		SkinPrefix.HSplitTop(2.0f, nullptr, &SkinPrefix);
 
@@ -656,7 +656,7 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 
 	char aBuf[128 + IO_MAX_PATH_LENGTH];
 	str_format(aBuf, sizeof(aBuf), "%s:", Localize("Your skin"));
-	UI()->DoLabel(&Label, aBuf, 14.0f, TEXTALIGN_ML);
+	Ui()->DoLabel(&Label, aBuf, 14.0f, TEXTALIGN_ML);
 
 	// Note: get the skin info after the settings buttons, because they can trigger a refresh
 	// which invalidates the skin.
@@ -690,7 +690,7 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 	static CLineInput s_SkinInput;
 	s_SkinInput.SetBuffer(pSkinName, SkinNameSize);
 	s_SkinInput.SetEmptyText("default");
-	if(UI()->DoClearableEditBox(&s_SkinInput, &Button, 14.0f))
+	if(Ui()->DoClearableEditBox(&s_SkinInput, &Button, 14.0f))
 	{
 		SetNeedSendInfo();
 	}
@@ -764,7 +764,7 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 		for(int i = 0; i < 2; i++)
 		{
 			aRects[i].HSplitTop(20.0f, &Label, &aRects[i]);
-			UI()->DoLabel(&Label, apParts[i], 14.0f, TEXTALIGN_ML);
+			Ui()->DoLabel(&Label, apParts[i], 14.0f, TEXTALIGN_ML);
 
 			const unsigned PrevColor = *apColors[i];
 			RenderHSLScrollbars(&aRects[i], apColors[i], false, true);
@@ -872,7 +872,7 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 
 		SLabelProperties Props;
 		Props.m_MaxWidth = Label.w - 5.0f;
-		UI()->DoLabel(&Label, pSkinToBeDraw->GetName(), 12.0f, TEXTALIGN_ML, Props);
+		Ui()->DoLabel(&Label, pSkinToBeDraw->GetName(), 12.0f, TEXTALIGN_ML, Props);
 
 		if(g_Config.m_Debug)
 		{
@@ -918,7 +918,7 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 	{
 		TextRender()->SetFontPreset(EFontPreset::ICON_FONT);
 		TextRender()->SetRenderFlags(ETextRenderFlags::TEXT_RENDER_FLAG_ONLY_ADVANCE_WIDTH | ETextRenderFlags::TEXT_RENDER_FLAG_NO_X_BEARING | ETextRenderFlags::TEXT_RENDER_FLAG_NO_Y_BEARING | ETextRenderFlags::TEXT_RENDER_FLAG_NO_PIXEL_ALIGMENT | ETextRenderFlags::TEXT_RENDER_FLAG_NO_OVERSIZE);
-		UI()->DoLabel(&QuickSearch, FONT_ICON_MAGNIFYING_GLASS, 14.0f, TEXTALIGN_ML);
+		Ui()->DoLabel(&QuickSearch, FONT_ICON_MAGNIFYING_GLASS, 14.0f, TEXTALIGN_ML);
 		float wSearch = TextRender()->TextWidth(14.0f, FONT_ICON_MAGNIFYING_GLASS, -1, -1.0f);
 		TextRender()->SetRenderFlags(0);
 		TextRender()->SetFontPreset(EFontPreset::DEFAULT_FONT);
@@ -926,11 +926,11 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 		static CLineInput s_SkinFilterInput(g_Config.m_ClSkinFilterString, sizeof(g_Config.m_ClSkinFilterString));
 		if(Input()->KeyPress(KEY_F) && Input()->ModifierIsPressed())
 		{
-			UI()->SetActiveItem(&s_SkinFilterInput);
+			Ui()->SetActiveItem(&s_SkinFilterInput);
 			s_SkinFilterInput.SelectAll();
 		}
 		s_SkinFilterInput.SetEmptyText(Localize("Search"));
-		if(UI()->DoClearableEditBox(&s_SkinFilterInput, &QuickSearch, 14.0f))
+		if(Ui()->DoClearableEditBox(&s_SkinFilterInput, &QuickSearch, 14.0f))
 			m_SkinListNeedsUpdate = true;
 	}
 
@@ -1044,7 +1044,7 @@ void CMenus::DoSettingsControlsButtons(int Start, int Stop, CUIRect View)
 		char aBuf[64];
 		str_format(aBuf, sizeof(aBuf), "%s:", Localize(Key.m_pName));
 
-		UI()->DoLabel(&Label, aBuf, 13.0f, TEXTALIGN_ML);
+		Ui()->DoLabel(&Label, aBuf, 13.0f, TEXTALIGN_ML);
 		int OldId = Key.m_KeyId, OldModifierCombination = Key.m_ModifierCombination, NewModifierCombination;
 		int NewId = DoKeyReader(&Key.m_KeyId, &Button, OldId, OldModifierCombination, &NewModifierCombination);
 		if(NewId != OldId || NewModifierCombination != OldModifierCombination)
@@ -1117,11 +1117,11 @@ float CMenus::RenderSettingsControlsJoystick(CUIRect View)
 						s_vpJoystickNames[i] = s_vJoystickNames[i].c_str();
 					}
 
-					static CUI::SDropDownState s_JoystickDropDownState;
+					static CUi::SDropDownState s_JoystickDropDownState;
 					static CScrollRegion s_JoystickDropDownScrollRegion;
 					s_JoystickDropDownState.m_SelectionPopupContext.m_pScrollRegion = &s_JoystickDropDownScrollRegion;
 					const int CurrentJoystick = Input()->GetActiveJoystick()->GetIndex();
-					const int NewJoystick = UI()->DoDropDown(&JoystickDropDown, CurrentJoystick, s_vpJoystickNames.data(), s_vpJoystickNames.size(), s_JoystickDropDownState);
+					const int NewJoystick = Ui()->DoDropDown(&JoystickDropDown, CurrentJoystick, s_vpJoystickNames.data(), s_vpJoystickNames.size(), s_JoystickDropDownState);
 					if(NewJoystick != CurrentJoystick)
 					{
 						Input()->SetActiveJoystick(NewJoystick);
@@ -1131,7 +1131,7 @@ float CMenus::RenderSettingsControlsJoystick(CUIRect View)
 				{
 					char aBuf[256];
 					str_format(aBuf, sizeof(aBuf), "%s 0: %s", Localize("Controller"), Input()->GetJoystick(0)->GetName());
-					UI()->DoLabel(&JoystickDropDown, aBuf, 13.0f, TEXTALIGN_ML);
+					Ui()->DoLabel(&JoystickDropDown, aBuf, 13.0f, TEXTALIGN_ML);
 				}
 			}
 
@@ -1142,7 +1142,7 @@ float CMenus::RenderSettingsControlsJoystick(CUIRect View)
 				Button.VSplitMid(&Label, &Button, 10.0f);
 				Button.HMargin(2.0f, &Button);
 				Button.VSplitMid(&ButtonRelative, &ButtonAbsolute);
-				UI()->DoLabel(&Label, Localize("Ingame controller mode"), 13.0f, TEXTALIGN_ML);
+				Ui()->DoLabel(&Label, Localize("Ingame controller mode"), 13.0f, TEXTALIGN_ML);
 				CButtonContainer s_RelativeButton;
 				if(DoButton_Menu(&s_RelativeButton, Localize("Relative", "Ingame controller mode"), g_Config.m_InpControllerAbsolute == 0, &ButtonRelative, nullptr, IGraphics::CORNER_L))
 				{
@@ -1159,16 +1159,16 @@ float CMenus::RenderSettingsControlsJoystick(CUIRect View)
 			{
 				View.HSplitTop(Spacing, nullptr, &View);
 				View.HSplitTop(ButtonHeight, &Button, &View);
-				UI()->DoScrollbarOption(&g_Config.m_InpControllerSens, &g_Config.m_InpControllerSens, &Button, Localize("Ingame controller sens."), 1, 500, &CUI::ms_LogarithmicScrollbarScale, CUI::SCROLLBAR_OPTION_NOCLAMPVALUE);
+				Ui()->DoScrollbarOption(&g_Config.m_InpControllerSens, &g_Config.m_InpControllerSens, &Button, Localize("Ingame controller sens."), 1, 500, &CUi::ms_LogarithmicScrollbarScale, CUi::SCROLLBAR_OPTION_NOCLAMPVALUE);
 			}
 
 			View.HSplitTop(Spacing, nullptr, &View);
 			View.HSplitTop(ButtonHeight, &Button, &View);
-			UI()->DoScrollbarOption(&g_Config.m_UiControllerSens, &g_Config.m_UiControllerSens, &Button, Localize("UI controller sens."), 1, 500, &CUI::ms_LogarithmicScrollbarScale, CUI::SCROLLBAR_OPTION_NOCLAMPVALUE);
+			Ui()->DoScrollbarOption(&g_Config.m_UiControllerSens, &g_Config.m_UiControllerSens, &Button, Localize("Ui controller sens."), 1, 500, &CUi::ms_LogarithmicScrollbarScale, CUi::SCROLLBAR_OPTION_NOCLAMPVALUE);
 
 			View.HSplitTop(Spacing, nullptr, &View);
 			View.HSplitTop(ButtonHeight, &Button, &View);
-			UI()->DoScrollbarOption(&g_Config.m_InpControllerTolerance, &g_Config.m_InpControllerTolerance, &Button, Localize("Controller jitter tolerance"), 0, 50);
+			Ui()->DoScrollbarOption(&g_Config.m_InpControllerTolerance, &g_Config.m_InpControllerTolerance, &Button, Localize("Controller jitter tolerance"), 0, 50);
 
 			View.HSplitTop(Spacing, nullptr, &View);
 			View.Draw(ColorRGBA(0.0f, 0.0f, 0.0f, 0.125f), IGraphics::CORNER_ALL, 5.0f);
@@ -1178,7 +1178,7 @@ float CMenus::RenderSettingsControlsJoystick(CUIRect View)
 		{
 			View.HSplitTop(View.h - ButtonHeight, nullptr, &View);
 			View.HSplitTop(ButtonHeight, &Button, &View);
-			UI()->DoLabel(&Button, Localize("No controller found. Plug in a controller."), 13.0f, TEXTALIGN_ML);
+			Ui()->DoLabel(&Button, Localize("No controller found. Plug in a controller."), 13.0f, TEXTALIGN_ML);
 		}
 	}
 
@@ -1204,9 +1204,9 @@ void CMenus::DoJoystickAxisPicker(CUIRect View)
 	Row.VSplitLeft(SpacingV, nullptr, &Row);
 	Row.VSplitLeft(AimBindWidth, &AimBind, &Row);
 
-	UI()->DoLabel(&Axis, Localize("Axis"), FontSize, TEXTALIGN_MC);
-	UI()->DoLabel(&Status, Localize("Status"), FontSize, TEXTALIGN_MC);
-	UI()->DoLabel(&AimBind, Localize("Aim bind"), FontSize, TEXTALIGN_MC);
+	Ui()->DoLabel(&Axis, Localize("Axis"), FontSize, TEXTALIGN_MC);
+	Ui()->DoLabel(&Status, Localize("Status"), FontSize, TEXTALIGN_MC);
+	Ui()->DoLabel(&AimBind, Localize("Aim bind"), FontSize, TEXTALIGN_MC);
 
 	IInput::IJoystick *pJoystick = Input()->GetActiveJoystick();
 	static int s_aActive[NUM_JOYSTICK_AXES][2];
@@ -1230,7 +1230,7 @@ void CMenus::DoJoystickAxisPicker(CUIRect View)
 			TextRender()->TextColor(TextRender()->DefaultTextColor());
 		else
 			TextRender()->TextColor(0.7f, 0.7f, 0.7f, 1.0f);
-		UI()->DoLabel(&Axis, aBuf, FontSize, TEXTALIGN_MC);
+		Ui()->DoLabel(&Axis, aBuf, FontSize, TEXTALIGN_MC);
 
 		// Axis status
 		Status.HMargin(7.0f, &Status);
@@ -1323,15 +1323,15 @@ void CMenus::RenderSettingsControls(CUIRect MainView)
 			MouseSettings.VMargin(10.0f, &MouseSettings);
 
 			MouseSettings.HSplitTop(HeaderHeight, &Button, &MouseSettings);
-			UI()->DoLabel(&Button, Localize("Mouse"), FontSize, TEXTALIGN_ML);
+			Ui()->DoLabel(&Button, Localize("Mouse"), FontSize, TEXTALIGN_ML);
 
 			MouseSettings.HSplitTop(20.0f, &Button, &MouseSettings);
-			UI()->DoScrollbarOption(&g_Config.m_InpMousesens, &g_Config.m_InpMousesens, &Button, Localize("Ingame mouse sens."), 1, 500, &CUI::ms_LogarithmicScrollbarScale, CUI::SCROLLBAR_OPTION_NOCLAMPVALUE);
+			Ui()->DoScrollbarOption(&g_Config.m_InpMousesens, &g_Config.m_InpMousesens, &Button, Localize("Ingame mouse sens."), 1, 500, &CUi::ms_LogarithmicScrollbarScale, CUi::SCROLLBAR_OPTION_NOCLAMPVALUE);
 
 			MouseSettings.HSplitTop(2.0f, nullptr, &MouseSettings);
 
 			MouseSettings.HSplitTop(20.0f, &Button, &MouseSettings);
-			UI()->DoScrollbarOption(&g_Config.m_UiMousesens, &g_Config.m_UiMousesens, &Button, Localize("UI mouse sens."), 1, 500, &CUI::ms_LogarithmicScrollbarScale, CUI::SCROLLBAR_OPTION_NOCLAMPVALUE);
+			Ui()->DoScrollbarOption(&g_Config.m_UiMousesens, &g_Config.m_UiMousesens, &Button, Localize("Ui mouse sens."), 1, 500, &CUi::ms_LogarithmicScrollbarScale, CUi::SCROLLBAR_OPTION_NOCLAMPVALUE);
 		}
 	}
 
@@ -1345,7 +1345,7 @@ void CMenus::RenderSettingsControls(CUIRect MainView)
 			JoystickSettings.VMargin(Margin, &JoystickSettings);
 
 			JoystickSettings.HSplitTop(HeaderHeight, &Button, &JoystickSettings);
-			UI()->DoLabel(&Button, Localize("Controller"), FontSize, TEXTALIGN_ML);
+			Ui()->DoLabel(&Button, Localize("Controller"), FontSize, TEXTALIGN_ML);
 
 			s_JoystickSettingsHeight = RenderSettingsControlsJoystick(JoystickSettings);
 		}
@@ -1361,7 +1361,7 @@ void CMenus::RenderSettingsControls(CUIRect MainView)
 			MovementSettings.VMargin(Margin, &MovementSettings);
 
 			MovementSettings.HSplitTop(HeaderHeight, &Button, &MovementSettings);
-			UI()->DoLabel(&Button, Localize("Movement"), FontSize, TEXTALIGN_ML);
+			Ui()->DoLabel(&Button, Localize("Movement"), FontSize, TEXTALIGN_ML);
 
 			DoSettingsControlsButtons(0, 15, MovementSettings);
 		}
@@ -1377,7 +1377,7 @@ void CMenus::RenderSettingsControls(CUIRect MainView)
 			WeaponSettings.VMargin(Margin, &WeaponSettings);
 
 			WeaponSettings.HSplitTop(HeaderHeight, &Button, &WeaponSettings);
-			UI()->DoLabel(&Button, Localize("Weapon"), FontSize, TEXTALIGN_ML);
+			Ui()->DoLabel(&Button, Localize("Weapon"), FontSize, TEXTALIGN_ML);
 
 			DoSettingsControlsButtons(15, 22, WeaponSettings);
 		}
@@ -1410,7 +1410,7 @@ void CMenus::RenderSettingsControls(CUIRect MainView)
 			VotingSettings.VMargin(Margin, &VotingSettings);
 
 			VotingSettings.HSplitTop(HeaderHeight, &Button, &VotingSettings);
-			UI()->DoLabel(&Button, Localize("Voting"), FontSize, TEXTALIGN_ML);
+			Ui()->DoLabel(&Button, Localize("Voting"), FontSize, TEXTALIGN_ML);
 
 			DoSettingsControlsButtons(22, 24, VotingSettings);
 		}
@@ -1426,7 +1426,7 @@ void CMenus::RenderSettingsControls(CUIRect MainView)
 			ChatSettings.VMargin(Margin, &ChatSettings);
 
 			ChatSettings.HSplitTop(HeaderHeight, &Button, &ChatSettings);
-			UI()->DoLabel(&Button, Localize("Chat"), FontSize, TEXTALIGN_ML);
+			Ui()->DoLabel(&Button, Localize("Chat"), FontSize, TEXTALIGN_ML);
 
 			DoSettingsControlsButtons(24, 29, ChatSettings);
 		}
@@ -1442,7 +1442,7 @@ void CMenus::RenderSettingsControls(CUIRect MainView)
 			DummySettings.VMargin(Margin, &DummySettings);
 
 			DummySettings.HSplitTop(HeaderHeight, &Button, &DummySettings);
-			UI()->DoLabel(&Button, Localize("Dummy"), FontSize, TEXTALIGN_ML);
+			Ui()->DoLabel(&Button, Localize("Dummy"), FontSize, TEXTALIGN_ML);
 
 			DoSettingsControlsButtons(29, 32, DummySettings);
 		}
@@ -1458,7 +1458,7 @@ void CMenus::RenderSettingsControls(CUIRect MainView)
 			MiscSettings.VMargin(Margin, &MiscSettings);
 
 			MiscSettings.HSplitTop(HeaderHeight, &Button, &MiscSettings);
-			UI()->DoLabel(&Button, Localize("Miscellaneous"), FontSize, TEXTALIGN_ML);
+			Ui()->DoLabel(&Button, Localize("Miscellaneous"), FontSize, TEXTALIGN_ML);
 
 			DoSettingsControlsButtons(32, 44, MiscSettings);
 		}
@@ -1495,7 +1495,7 @@ void CMenus::RenderSettingsGraphics(CUIRect MainView)
 	static int s_NumNodes = Graphics()->GetVideoModes(s_aModes, MAX_RESOLUTIONS, g_Config.m_GfxScreen);
 	static int s_GfxFsaaSamples = g_Config.m_GfxFsaaSamples;
 	static bool s_GfxBackendChanged = false;
-	static bool s_GfxGPUChanged = false;
+	static bool s_GfxGpuChanged = false;
 	static int s_GfxHighdpi = g_Config.m_GfxHighdpi;
 
 	static int s_InitDisplayAllVideoModes = g_Config.m_GfxDisplayAllVideoModes;
@@ -1532,11 +1532,11 @@ void CMenus::RenderSettingsGraphics(CUIRect MainView)
 	{
 		int G = std::gcd(g_Config.m_GfxScreenWidth, g_Config.m_GfxScreenHeight);
 		str_format(aBuf, sizeof(aBuf), "%s: %dx%d @%dhz %d bit (%d:%d)", Localize("Current"), (int)(g_Config.m_GfxScreenWidth * Graphics()->ScreenHiDPIScale()), (int)(g_Config.m_GfxScreenHeight * Graphics()->ScreenHiDPIScale()), g_Config.m_GfxScreenRefreshRate, g_Config.m_GfxColorDepth, g_Config.m_GfxScreenWidth / G, g_Config.m_GfxScreenHeight / G);
-		UI()->DoLabel(&ModeLabel, aBuf, sc_FontSizeResListHeader, TEXTALIGN_MC);
+		Ui()->DoLabel(&ModeLabel, aBuf, sc_FontSizeResListHeader, TEXTALIGN_MC);
 	}
 
 	int OldSelected = -1;
-	s_ListBox.SetActive(!UI()->IsPopupOpen());
+	s_ListBox.SetActive(!Ui()->IsPopupOpen());
 	s_ListBox.DoStart(sc_RowHeightResList, s_NumNodes, 1, 3, OldSelected, &ModeList);
 
 	for(int i = 0; i < s_NumNodes; ++i)
@@ -1556,7 +1556,7 @@ void CMenus::RenderSettingsGraphics(CUIRect MainView)
 
 		int G = std::gcd(s_aModes[i].m_CanvasWidth, s_aModes[i].m_CanvasHeight);
 		str_format(aBuf, sizeof(aBuf), " %dx%d @%dhz %d bit (%d:%d)", s_aModes[i].m_CanvasWidth, s_aModes[i].m_CanvasHeight, s_aModes[i].m_RefreshRate, Depth, s_aModes[i].m_CanvasWidth / G, s_aModes[i].m_CanvasHeight / G);
-		UI()->DoLabel(&Item.m_Rect, aBuf, sc_FontSizeResList, TEXTALIGN_ML);
+		Ui()->DoLabel(&Item.m_Rect, aBuf, sc_FontSizeResList, TEXTALIGN_ML);
 	}
 
 	const int NewSelected = s_ListBox.DoEnd();
@@ -1579,10 +1579,10 @@ void CMenus::RenderSettingsGraphics(CUIRect MainView)
 
 	const int OldWindowMode = (g_Config.m_GfxFullscreen ? (g_Config.m_GfxFullscreen == 1 ? 4 : (g_Config.m_GfxFullscreen == 2 ? 3 : 2)) : (g_Config.m_GfxBorderless ? 1 : 0));
 
-	static CUI::SDropDownState s_WindowModeDropDownState;
+	static CUi::SDropDownState s_WindowModeDropDownState;
 	static CScrollRegion s_WindowModeDropDownScrollRegion;
 	s_WindowModeDropDownState.m_SelectionPopupContext.m_pScrollRegion = &s_WindowModeDropDownScrollRegion;
-	const int NewWindowMode = UI()->DoDropDown(&WindowModeDropDown, OldWindowMode, apWindowModes, s_NumWindowMode, s_WindowModeDropDownState);
+	const int NewWindowMode = Ui()->DoDropDown(&WindowModeDropDown, OldWindowMode, apWindowModes, s_NumWindowMode, s_WindowModeDropDownState);
 	if(OldWindowMode != NewWindowMode)
 	{
 		if(NewWindowMode == 0)
@@ -1616,10 +1616,10 @@ void CMenus::RenderSettingsGraphics(CUIRect MainView)
 			s_vpScreenNames[i] = s_vScreenNames[i].c_str();
 		}
 
-		static CUI::SDropDownState s_ScreenDropDownState;
+		static CUi::SDropDownState s_ScreenDropDownState;
 		static CScrollRegion s_ScreenDropDownScrollRegion;
 		s_ScreenDropDownState.m_SelectionPopupContext.m_pScrollRegion = &s_ScreenDropDownScrollRegion;
-		const int NewScreen = UI()->DoDropDown(&ScreenDropDown, g_Config.m_GfxScreen, s_vpScreenNames.data(), s_vpScreenNames.size(), s_ScreenDropDownState);
+		const int NewScreen = Ui()->DoDropDown(&ScreenDropDown, g_Config.m_GfxScreen, s_vpScreenNames.data(), s_vpScreenNames.size(), s_ScreenDropDownState);
 		if(NewScreen != g_Config.m_GfxScreen)
 			Client()->SwitchWindowScreen(NewScreen);
 	}
@@ -1685,11 +1685,11 @@ void CMenus::RenderSettingsGraphics(CUIRect MainView)
 	}
 
 	MainView.HSplitTop(20.0f, &Button, &MainView);
-	UI()->DoScrollbarOption(&g_Config.m_GfxRefreshRate, &g_Config.m_GfxRefreshRate, &Button, Localize("Refresh Rate"), 10, 1000, &CUI::ms_LinearScrollbarScale, CUI::SCROLLBAR_OPTION_INFINITE | CUI::SCROLLBAR_OPTION_NOCLAMPVALUE, " Hz");
+	Ui()->DoScrollbarOption(&g_Config.m_GfxRefreshRate, &g_Config.m_GfxRefreshRate, &Button, Localize("Refresh Rate"), 10, 1000, &CUi::ms_LinearScrollbarScale, CUi::SCROLLBAR_OPTION_INFINITE | CUi::SCROLLBAR_OPTION_NOCLAMPVALUE, " Hz");
 
 	MainView.HSplitTop(2.0f, nullptr, &MainView);
 	static CButtonContainer s_UiColorResetId;
-	DoLine_ColorPicker(&s_UiColorResetId, 25.0f, 13.0f, 2.0f, &MainView, Localize("UI Color"), &g_Config.m_UiColor, color_cast<ColorRGBA>(ColorHSLA(0xE4A046AFU, true)), false, nullptr, true);
+	DoLine_ColorPicker(&s_UiColorResetId, 25.0f, 13.0f, 2.0f, &MainView, Localize("Ui Color"), &g_Config.m_UiColor, color_cast<ColorRGBA>(ColorHSLA(0xE4A046AFU, true)), false, nullptr, true);
 
 	// Backend list
 	struct SMenuBackendInfo
@@ -1728,15 +1728,15 @@ void CMenus::RenderSettingsGraphics(CUIRect MainView)
 		MainView.HSplitTop(20.0f, &Text, &MainView);
 		MainView.HSplitTop(2.0f, nullptr, &MainView);
 		MainView.HSplitTop(20.0f, &BackendDropDown, &MainView);
-		UI()->DoLabel(&Text, Localize("Renderer"), 16.0f, TEXTALIGN_MC);
+		Ui()->DoLabel(&Text, Localize("Renderer"), 16.0f, TEXTALIGN_MC);
 
-		static std::vector<std::string> s_vBackendIDNames;
-		static std::vector<const char *> s_vpBackendIDNamesCStr;
+		static std::vector<std::string> s_vBackendIdNames;
+		static std::vector<const char *> s_vpBackendIdNamesCStr;
 		static std::vector<SMenuBackendInfo> s_vBackendInfos;
 
 		size_t BackendCount = FoundBackendCount + 1;
-		s_vBackendIDNames.resize(BackendCount);
-		s_vpBackendIDNamesCStr.resize(BackendCount);
+		s_vBackendIdNames.resize(BackendCount);
+		s_vpBackendIdNamesCStr.resize(BackendCount);
 		s_vBackendInfos.resize(BackendCount);
 
 		char aTmpBackendName[256];
@@ -1756,8 +1756,8 @@ void CMenus::RenderSettingsGraphics(CUIRect MainView)
 				{
 					bool IsDefault = IsInfoDefault(Info);
 					str_format(aTmpBackendName, sizeof(aTmpBackendName), "%s (%d.%d.%d)%s%s", Info.m_pBackendName, Info.m_Major, Info.m_Minor, Info.m_Patch, IsDefault ? " - " : "", IsDefault ? Localize("default") : "");
-					s_vBackendIDNames[CurCounter] = aTmpBackendName;
-					s_vpBackendIDNamesCStr[CurCounter] = s_vBackendIDNames[CurCounter].c_str();
+					s_vBackendIdNames[CurCounter] = aTmpBackendName;
+					s_vpBackendIdNamesCStr[CurCounter] = s_vBackendIdNames[CurCounter].c_str();
 					if(str_comp_nocase(Info.m_pBackendName, g_Config.m_GfxBackend) == 0 && g_Config.m_GfxGLMajor == Info.m_Major && g_Config.m_GfxGLMinor == Info.m_Minor && g_Config.m_GfxGLPatch == Info.m_Patch)
 					{
 						OldSelectedBackend = CurCounter;
@@ -1778,8 +1778,8 @@ void CMenus::RenderSettingsGraphics(CUIRect MainView)
 		{
 			// custom selected one
 			str_format(aTmpBackendName, sizeof(aTmpBackendName), "%s (%s %d.%d.%d)", Localize("custom"), g_Config.m_GfxBackend, g_Config.m_GfxGLMajor, g_Config.m_GfxGLMinor, g_Config.m_GfxGLPatch);
-			s_vBackendIDNames[CurCounter] = aTmpBackendName;
-			s_vpBackendIDNamesCStr[CurCounter] = s_vBackendIDNames[CurCounter].c_str();
+			s_vBackendIdNames[CurCounter] = aTmpBackendName;
+			s_vpBackendIdNamesCStr[CurCounter] = s_vBackendIdNames[CurCounter].c_str();
 			OldSelectedBackend = CurCounter;
 
 			s_vBackendInfos[CurCounter].m_pBackendName = "custom";
@@ -1792,10 +1792,10 @@ void CMenus::RenderSettingsGraphics(CUIRect MainView)
 		if(s_OldSelectedBackend == -1)
 			s_OldSelectedBackend = OldSelectedBackend;
 
-		static CUI::SDropDownState s_BackendDropDownState;
+		static CUi::SDropDownState s_BackendDropDownState;
 		static CScrollRegion s_BackendDropDownScrollRegion;
 		s_BackendDropDownState.m_SelectionPopupContext.m_pScrollRegion = &s_BackendDropDownScrollRegion;
-		const int NewBackend = UI()->DoDropDown(&BackendDropDown, OldSelectedBackend, s_vpBackendIDNamesCStr.data(), BackendCount, s_BackendDropDownState);
+		const int NewBackend = Ui()->DoDropDown(&BackendDropDown, OldSelectedBackend, s_vpBackendIdNamesCStr.data(), BackendCount, s_BackendDropDownState);
 		if(OldSelectedBackend != NewBackend)
 		{
 			str_copy(g_Config.m_GfxBackend, s_vBackendInfos[NewBackend].m_pBackendName);
@@ -1809,61 +1809,61 @@ void CMenus::RenderSettingsGraphics(CUIRect MainView)
 	}
 
 	// GPU list
-	const auto &GPUList = Graphics()->GetGPUs();
-	if(GPUList.m_vGPUs.size() > 1)
+	const auto &GPUList = Graphics()->GetGpus();
+	if(GPUList.m_vGpus.size() > 1)
 	{
 		CUIRect Text, GpuDropDown;
 		MainView.HSplitTop(10.0f, nullptr, &MainView);
 		MainView.HSplitTop(20.0f, &Text, &MainView);
 		MainView.HSplitTop(2.0f, nullptr, &MainView);
 		MainView.HSplitTop(20.0f, &GpuDropDown, &MainView);
-		UI()->DoLabel(&Text, Localize("Graphics card"), 16.0f, TEXTALIGN_MC);
+		Ui()->DoLabel(&Text, Localize("Graphics card"), 16.0f, TEXTALIGN_MC);
 
-		static std::vector<const char *> s_vpGPUIDNames;
+		static std::vector<const char *> s_vpGpuIDNames;
 
-		size_t GPUCount = GPUList.m_vGPUs.size() + 1;
-		s_vpGPUIDNames.resize(GPUCount);
+		size_t GPUCount = GPUList.m_vGpus.size() + 1;
+		s_vpGpuIDNames.resize(GPUCount);
 
 		char aCurDeviceName[256 + 4];
 
-		int OldSelectedGPU = -1;
+		int OldSelectedGpu = -1;
 		for(size_t i = 0; i < GPUCount; ++i)
 		{
 			if(i == 0)
 			{
-				str_format(aCurDeviceName, sizeof(aCurDeviceName), "%s (%s)", Localize("auto"), GPUList.m_AutoGPU.m_aName);
-				s_vpGPUIDNames[i] = aCurDeviceName;
-				if(str_comp("auto", g_Config.m_GfxGPUName) == 0)
+				str_format(aCurDeviceName, sizeof(aCurDeviceName), "%s (%s)", Localize("auto"), GPUList.m_AutoGpu.m_aName);
+				s_vpGpuIDNames[i] = aCurDeviceName;
+				if(str_comp("auto", g_Config.m_GfxGpuName) == 0)
 				{
-					OldSelectedGPU = 0;
+					OldSelectedGpu = 0;
 				}
 			}
 			else
 			{
-				s_vpGPUIDNames[i] = GPUList.m_vGPUs[i - 1].m_aName;
-				if(str_comp(GPUList.m_vGPUs[i - 1].m_aName, g_Config.m_GfxGPUName) == 0)
+				s_vpGpuIDNames[i] = GPUList.m_vGpus[i - 1].m_aName;
+				if(str_comp(GPUList.m_vGpus[i - 1].m_aName, g_Config.m_GfxGpuName) == 0)
 				{
-					OldSelectedGPU = i;
+					OldSelectedGpu = i;
 				}
 			}
 		}
 
-		static int s_OldSelectedGPU = -1;
-		if(s_OldSelectedGPU == -1)
-			s_OldSelectedGPU = OldSelectedGPU;
+		static int s_OldSelectedGpu = -1;
+		if(s_OldSelectedGpu == -1)
+			s_OldSelectedGpu = OldSelectedGpu;
 
-		static CUI::SDropDownState s_GpuDropDownState;
+		static CUi::SDropDownState s_GpuDropDownState;
 		static CScrollRegion s_GpuDropDownScrollRegion;
 		s_GpuDropDownState.m_SelectionPopupContext.m_pScrollRegion = &s_GpuDropDownScrollRegion;
-		const int NewGPU = UI()->DoDropDown(&GpuDropDown, OldSelectedGPU, s_vpGPUIDNames.data(), GPUCount, s_GpuDropDownState);
-		if(OldSelectedGPU != NewGPU)
+		const int NewGpu = Ui()->DoDropDown(&GpuDropDown, OldSelectedGpu, s_vpGpuIDNames.data(), GPUCount, s_GpuDropDownState);
+		if(OldSelectedGpu != NewGpu)
 		{
-			if(NewGPU == 0)
-				str_copy(g_Config.m_GfxGPUName, "auto");
+			if(NewGpu == 0)
+				str_copy(g_Config.m_GfxGpuName, "auto");
 			else
-				str_copy(g_Config.m_GfxGPUName, GPUList.m_vGPUs[NewGPU - 1].m_aName);
+				str_copy(g_Config.m_GfxGpuName, GPUList.m_vGpus[NewGpu - 1].m_aName);
 			CheckSettings = true;
-			s_GfxGPUChanged = NewGPU != s_OldSelectedGPU;
+			s_GfxGpuChanged = NewGpu != s_OldSelectedGpu;
 		}
 	}
 
@@ -1872,7 +1872,7 @@ void CMenus::RenderSettingsGraphics(CUIRect MainView)
 	{
 		m_NeedRestartGraphics = !(s_GfxFsaaSamples == g_Config.m_GfxFsaaSamples &&
 					  !s_GfxBackendChanged &&
-					  !s_GfxGPUChanged &&
+					  !s_GfxGpuChanged &&
 					  s_GfxHighdpi == g_Config.m_GfxHighdpi);
 	}
 }
@@ -1936,35 +1936,35 @@ void CMenus::RenderSettingsSound(CUIRect MainView)
 	{
 		MainView.HSplitTop(5.0f, nullptr, &MainView);
 		MainView.HSplitTop(20.0f, &Button, &MainView);
-		UI()->DoScrollbarOption(&g_Config.m_SndVolume, &g_Config.m_SndVolume, &Button, Localize("Sound volume"), 0, 100, &CUI::ms_LogarithmicScrollbarScale, 0u, "%");
+		Ui()->DoScrollbarOption(&g_Config.m_SndVolume, &g_Config.m_SndVolume, &Button, Localize("Sound volume"), 0, 100, &CUi::ms_LogarithmicScrollbarScale, 0u, "%");
 	}
 
 	// volume slider game sounds
 	{
 		MainView.HSplitTop(5.0f, nullptr, &MainView);
 		MainView.HSplitTop(20.0f, &Button, &MainView);
-		UI()->DoScrollbarOption(&g_Config.m_SndGameSoundVolume, &g_Config.m_SndGameSoundVolume, &Button, Localize("Game sound volume"), 0, 100, &CUI::ms_LogarithmicScrollbarScale, 0u, "%");
+		Ui()->DoScrollbarOption(&g_Config.m_SndGameSoundVolume, &g_Config.m_SndGameSoundVolume, &Button, Localize("Game sound volume"), 0, 100, &CUi::ms_LogarithmicScrollbarScale, 0u, "%");
 	}
 
 	// volume slider gui sounds
 	{
 		MainView.HSplitTop(5.0f, nullptr, &MainView);
 		MainView.HSplitTop(20.0f, &Button, &MainView);
-		UI()->DoScrollbarOption(&g_Config.m_SndChatSoundVolume, &g_Config.m_SndChatSoundVolume, &Button, Localize("Chat sound volume"), 0, 100, &CUI::ms_LogarithmicScrollbarScale, 0u, "%");
+		Ui()->DoScrollbarOption(&g_Config.m_SndChatSoundVolume, &g_Config.m_SndChatSoundVolume, &Button, Localize("Chat sound volume"), 0, 100, &CUi::ms_LogarithmicScrollbarScale, 0u, "%");
 	}
 
 	// volume slider map sounds
 	{
 		MainView.HSplitTop(5.0f, nullptr, &MainView);
 		MainView.HSplitTop(20.0f, &Button, &MainView);
-		UI()->DoScrollbarOption(&g_Config.m_SndMapSoundVolume, &g_Config.m_SndMapSoundVolume, &Button, Localize("Map sound volume"), 0, 100, &CUI::ms_LogarithmicScrollbarScale, 0u, "%");
+		Ui()->DoScrollbarOption(&g_Config.m_SndMapSoundVolume, &g_Config.m_SndMapSoundVolume, &Button, Localize("Map sound volume"), 0, 100, &CUi::ms_LogarithmicScrollbarScale, 0u, "%");
 	}
 
 	// volume slider background music
 	{
 		MainView.HSplitTop(5.0f, nullptr, &MainView);
 		MainView.HSplitTop(20.0f, &Button, &MainView);
-		UI()->DoScrollbarOption(&g_Config.m_SndBackgroundMusicVolume, &g_Config.m_SndBackgroundMusicVolume, &Button, Localize("Background music volume"), 0, 100, &CUI::ms_LogarithmicScrollbarScale, 0u, "%");
+		Ui()->DoScrollbarOption(&g_Config.m_SndBackgroundMusicVolume, &g_Config.m_SndBackgroundMusicVolume, &Button, Localize("Background music volume"), 0, 100, &CUi::ms_LogarithmicScrollbarScale, 0u, "%");
 	}
 }
 
@@ -2003,7 +2003,7 @@ bool CMenus::RenderLanguageSelection(CUIRect MainView)
 		FlagRect.HMargin(3.0f, &FlagRect);
 		m_pClient->m_CountryFlags.Render(Language.m_CountryCode, ColorRGBA(1.0f, 1.0f, 1.0f, 1.0f), FlagRect.x, FlagRect.y, FlagRect.w, FlagRect.h);
 
-		UI()->DoLabel(&Label, Language.m_Name.c_str(), 16.0f, TEXTALIGN_ML);
+		Ui()->DoLabel(&Label, Language.m_Name.c_str(), 16.0f, TEXTALIGN_ML);
 	}
 
 	s_SelectedLanguage = s_ListBox.DoEnd();
@@ -2111,12 +2111,12 @@ void CMenus::RenderSettings(CUIRect MainView)
 		if(m_NeedRestartUpdate)
 		{
 			TextRender()->TextColor(1.0f, 0.4f, 0.4f, 1.0f);
-			UI()->DoLabel(&RestartWarning, Localize("DDNet Client needs to be restarted to complete update!"), 14.0f, TEXTALIGN_ML);
+			Ui()->DoLabel(&RestartWarning, Localize("DDNet Client needs to be restarted to complete update!"), 14.0f, TEXTALIGN_ML);
 			TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
 		}
 		else
 		{
-			UI()->DoLabel(&RestartWarning, Localize("You must restart the game for all settings to take effect."), 14.0f, TEXTALIGN_ML);
+			Ui()->DoLabel(&RestartWarning, Localize("You must restart the game for all settings to take effect."), 14.0f, TEXTALIGN_ML);
 		}
 
 		static CButtonContainer s_RestartButton;
@@ -2431,7 +2431,7 @@ ColorHSLA CMenus::RenderHSLScrollbars(CUIRect *pRect, unsigned int *pColor, bool
 		Button.Margin(2.0f, &Rail);
 
 		str_format(aBuf, sizeof(aBuf), "%s: %03d", apLabels[i], (int)(*apComponent[i] * 255));
-		UI()->DoLabel(&Label, aBuf, 14.0f, TEXTALIGN_ML);
+		Ui()->DoLabel(&Label, aBuf, 14.0f, TEXTALIGN_ML);
 
 		ColorHSLA CurColorPureHSLA(RenderColorHSLA.r, 1, 0.5f, 1);
 		ColorRGBA CurColorPure = color_cast<ColorRGBA>(CurColorPureHSLA);
@@ -2466,7 +2466,7 @@ ColorHSLA CMenus::RenderHSLScrollbars(CUIRect *pRect, unsigned int *pColor, bool
 			ColorInner = color_cast<ColorRGBA>(ColorHSLA(CurColorPureHSLA.r, *apComponent[1], LightVal, *apComponent[3]));
 		}
 
-		*apComponent[i] = UI()->DoScrollbarH(&((char *)pColor)[i], &Button, *apComponent[i], &ColorInner);
+		*apComponent[i] = Ui()->DoScrollbarH(&((char *)pColor)[i], &Button, *apComponent[i], &ColorInner);
 	}
 
 	*pColor = Color.Pack(Alpha);
@@ -2531,7 +2531,7 @@ void CMenus::RenderSettingsAppearance(CUIRect MainView)
 
 		// ***** HUD ***** //
 		LeftView.HSplitTop(HeadlineAndVMargin, &Label, &LeftView);
-		UI()->DoLabel(&Label, Localize("HUD"), HeadlineFontSize, TEXTALIGN_ML);
+		Ui()->DoLabel(&Label, Localize("HUD"), HeadlineFontSize, TEXTALIGN_ML);
 
 		// Switch of the entire HUD
 		LeftView.HSplitTop(SectionTotalMargin + LineSize, &Section, &LeftView);
@@ -2555,14 +2555,14 @@ void CMenus::RenderSettingsAppearance(CUIRect MainView)
 
 		// ***** DDRace HUD ***** //
 		RightView.HSplitTop(HeadlineAndVMargin, &Label, &RightView);
-		UI()->DoLabel(&Label, Localize("DDRace HUD"), HeadlineFontSize, TEXTALIGN_ML);
+		Ui()->DoLabel(&Label, Localize("DDRace HUD"), HeadlineFontSize, TEXTALIGN_ML);
 
 		// Switches of various DDRace HUD elements
 		RightView.HSplitTop(SectionTotalMargin + 4 * LineSize, &Section, &RightView);
 		Section.Margin(SectionMargin, &Section);
 
 		DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClDDRaceScoreBoard, Localize("Use DDRace Scoreboard"), &g_Config.m_ClDDRaceScoreBoard, &Section, LineSize);
-		DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClShowIDs, Localize("Show client IDs in scoreboard"), &g_Config.m_ClShowIDs, &Section, LineSize);
+		DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClShowIds, Localize("Show client IDs in scoreboard"), &g_Config.m_ClShowIds, &Section, LineSize);
 		DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClShowhudDDRace, Localize("Show DDRace HUD"), &g_Config.m_ClShowhudDDRace, &Section, LineSize);
 		if(g_Config.m_ClShowhudDDRace)
 		{
@@ -2596,7 +2596,7 @@ void CMenus::RenderSettingsAppearance(CUIRect MainView)
 			Section.HSplitTop(2 * LineSize, &Button, &Section);
 			if(g_Config.m_ClShowFreezeBars)
 			{
-				UI()->DoScrollbarOption(&g_Config.m_ClFreezeBarsAlphaInsideFreeze, &g_Config.m_ClFreezeBarsAlphaInsideFreeze, &Button, Localize("Opacity of freeze bars inside freeze"), 0, 100, &CUI::ms_LinearScrollbarScale, CUI::SCROLLBAR_OPTION_MULTILINE, "%");
+				Ui()->DoScrollbarOption(&g_Config.m_ClFreezeBarsAlphaInsideFreeze, &g_Config.m_ClFreezeBarsAlphaInsideFreeze, &Button, Localize("Opacity of freeze bars inside freeze"), 0, 100, &CUi::ms_LinearScrollbarScale, CUi::SCROLLBAR_OPTION_MULTILINE, "%");
 			}
 		}
 	}
@@ -2610,7 +2610,7 @@ void CMenus::RenderSettingsAppearance(CUIRect MainView)
 
 		// ***** Chat ***** //
 		LeftView.HSplitTop(HeadlineAndVMargin, &Label, &LeftView);
-		UI()->DoLabel(&Label, Localize("Chat"), HeadlineFontSize, TEXTALIGN_ML);
+		Ui()->DoLabel(&Label, Localize("Chat"), HeadlineFontSize, TEXTALIGN_ML);
 
 		// General chat settings
 		LeftView.HSplitTop(SectionTotalMargin + 8 * LineSize, &Section, &LeftView);
@@ -2625,7 +2625,7 @@ void CMenus::RenderSettingsAppearance(CUIRect MainView)
 
 		Section.HSplitTop(2 * LineSize, &Button, &Section);
 		int PrevFontSize = g_Config.m_ClChatFontSize;
-		UI()->DoScrollbarOption(&g_Config.m_ClChatFontSize, &g_Config.m_ClChatFontSize, &Button, Localize("Chat font size"), 10, 100, &CUI::ms_LinearScrollbarScale, CUI::SCROLLBAR_OPTION_MULTILINE);
+		Ui()->DoScrollbarOption(&g_Config.m_ClChatFontSize, &g_Config.m_ClChatFontSize, &Button, Localize("Chat font size"), 10, 100, &CUi::ms_LinearScrollbarScale, CUi::SCROLLBAR_OPTION_MULTILINE);
 		if(PrevFontSize != g_Config.m_ClChatFontSize)
 		{
 			Chat.EnsureCoherentWidth();
@@ -2634,7 +2634,7 @@ void CMenus::RenderSettingsAppearance(CUIRect MainView)
 
 		Section.HSplitTop(2 * LineSize, &Button, &Section);
 		int PrevWidth = g_Config.m_ClChatWidth;
-		UI()->DoScrollbarOption(&g_Config.m_ClChatWidth, &g_Config.m_ClChatWidth, &Button, Localize("Chat width"), 120, 400, &CUI::ms_LinearScrollbarScale, CUI::SCROLLBAR_OPTION_MULTILINE);
+		Ui()->DoScrollbarOption(&g_Config.m_ClChatWidth, &g_Config.m_ClChatWidth, &Button, Localize("Chat width"), 120, 400, &CUi::ms_LinearScrollbarScale, CUi::SCROLLBAR_OPTION_MULTILINE);
 		if(PrevWidth != g_Config.m_ClChatWidth)
 		{
 			Chat.EnsureCoherentFontSize();
@@ -2643,27 +2643,27 @@ void CMenus::RenderSettingsAppearance(CUIRect MainView)
 
 		// ***** Messages ***** //
 		RightView.HSplitTop(HeadlineAndVMargin, &Label, &RightView);
-		UI()->DoLabel(&Label, Localize("Messages"), HeadlineFontSize, TEXTALIGN_ML);
+		Ui()->DoLabel(&Label, Localize("Messages"), HeadlineFontSize, TEXTALIGN_ML);
 
 		// Message Colors and extra settings
 		RightView.HSplitTop(SectionTotalMargin + 6 * ColorPickerLineSize, &Section, &RightView);
 		Section.Margin(SectionMargin, &Section);
 
 		int i = 0;
-		static CButtonContainer s_aResetIDs[24];
+		static CButtonContainer s_aResetIds[24];
 
-		DoLine_ColorPicker(&s_aResetIDs[i++], ColorPickerLineSize, ColorPickerLabelSize, ColorPickerLineSpacing, &Section, Localize("System message"), &g_Config.m_ClMessageSystemColor, ColorRGBA(1.0f, 1.0f, 0.5f), true, &g_Config.m_ClShowChatSystem);
-		DoLine_ColorPicker(&s_aResetIDs[i++], ColorPickerLineSize, ColorPickerLabelSize, ColorPickerLineSpacing, &Section, Localize("Highlighted message"), &g_Config.m_ClMessageHighlightColor, ColorRGBA(1.0f, 0.5f, 0.5f));
-		DoLine_ColorPicker(&s_aResetIDs[i++], ColorPickerLineSize, ColorPickerLabelSize, ColorPickerLineSpacing, &Section, Localize("Team message"), &g_Config.m_ClMessageTeamColor, ColorRGBA(0.65f, 1.0f, 0.65f));
-		DoLine_ColorPicker(&s_aResetIDs[i++], ColorPickerLineSize, ColorPickerLabelSize, ColorPickerLineSpacing, &Section, Localize("Friend message"), &g_Config.m_ClMessageFriendColor, ColorRGBA(1.0f, 0.137f, 0.137f), true, &g_Config.m_ClMessageFriend);
-		DoLine_ColorPicker(&s_aResetIDs[i++], ColorPickerLineSize, ColorPickerLabelSize, ColorPickerLineSpacing, &Section, Localize("Normal message"), &g_Config.m_ClMessageColor, ColorRGBA(1.0f, 1.0f, 1.0f));
+		DoLine_ColorPicker(&s_aResetIds[i++], ColorPickerLineSize, ColorPickerLabelSize, ColorPickerLineSpacing, &Section, Localize("System message"), &g_Config.m_ClMessageSystemColor, ColorRGBA(1.0f, 1.0f, 0.5f), true, &g_Config.m_ClShowChatSystem);
+		DoLine_ColorPicker(&s_aResetIds[i++], ColorPickerLineSize, ColorPickerLabelSize, ColorPickerLineSpacing, &Section, Localize("Highlighted message"), &g_Config.m_ClMessageHighlightColor, ColorRGBA(1.0f, 0.5f, 0.5f));
+		DoLine_ColorPicker(&s_aResetIds[i++], ColorPickerLineSize, ColorPickerLabelSize, ColorPickerLineSpacing, &Section, Localize("Team message"), &g_Config.m_ClMessageTeamColor, ColorRGBA(0.65f, 1.0f, 0.65f));
+		DoLine_ColorPicker(&s_aResetIds[i++], ColorPickerLineSize, ColorPickerLabelSize, ColorPickerLineSpacing, &Section, Localize("Friend message"), &g_Config.m_ClMessageFriendColor, ColorRGBA(1.0f, 0.137f, 0.137f), true, &g_Config.m_ClMessageFriend);
+		DoLine_ColorPicker(&s_aResetIds[i++], ColorPickerLineSize, ColorPickerLabelSize, ColorPickerLineSpacing, &Section, Localize("Normal message"), &g_Config.m_ClMessageColor, ColorRGBA(1.0f, 1.0f, 1.0f));
 
 		str_format(aBuf, sizeof(aBuf), "%s (echo)", Localize("Client message"));
-		DoLine_ColorPicker(&s_aResetIDs[i++], ColorPickerLineSize, ColorPickerLabelSize, ColorPickerLineSpacing, &Section, aBuf, &g_Config.m_ClMessageClientColor, ColorRGBA(0.5f, 0.78f, 1.0f));
+		DoLine_ColorPicker(&s_aResetIds[i++], ColorPickerLineSize, ColorPickerLabelSize, ColorPickerLineSpacing, &Section, aBuf, &g_Config.m_ClMessageClientColor, ColorRGBA(0.5f, 0.78f, 1.0f));
 
 		// ***** Chat Preview ***** //
 		PreviewView.HSplitTop(HeadlineAndVMargin, &Label, &PreviewView);
-		UI()->DoLabel(&Label, Localize("Preview"), HeadlineFontSize, TEXTALIGN_ML);
+		Ui()->DoLabel(&Label, Localize("Preview"), HeadlineFontSize, TEXTALIGN_ML);
 
 		// Use the rest of the view for preview
 		Section = PreviewView;
@@ -2706,7 +2706,7 @@ void CMenus::RenderSettingsAppearance(CUIRect MainView)
 
 		struct SPreviewLine
 		{
-			int m_ClientID;
+			int m_ClientId;
 			bool m_Team;
 			char m_aName[64];
 			char m_aText[256];
@@ -2738,7 +2738,7 @@ void CMenus::RenderSettingsAppearance(CUIRect MainView)
 			PREVIEW_SPAMMER,
 			PREVIEW_CLIENT
 		};
-		auto &&SetPreviewLine = [](int Index, int ClientID, const char *pName, const char *pText, int Flag, int Repeats) {
+		auto &&SetPreviewLine = [](int Index, int ClientId, const char *pName, const char *pText, int Flag, int Repeats) {
 			SPreviewLine *pLine;
 			if((int)s_vLines.size() <= Index)
 			{
@@ -2749,10 +2749,10 @@ void CMenus::RenderSettingsAppearance(CUIRect MainView)
 			{
 				pLine = &s_vLines[Index];
 			}
-			pLine->m_ClientID = ClientID;
+			pLine->m_ClientId = ClientId;
 			pLine->m_Team = Flag & FLAG_TEAM;
 			pLine->m_Friend = Flag & FLAG_FRIEND;
-			pLine->m_Player = ClientID >= 0;
+			pLine->m_Player = ClientId >= 0;
 			pLine->m_Highlighted = Flag & FLAG_HIGHLIGHT;
 			pLine->m_Client = Flag & FLAG_CLIENT;
 			pLine->m_TimesRepeated = Repeats;
@@ -2780,18 +2780,18 @@ void CMenus::RenderSettingsAppearance(CUIRect MainView)
 
 			char aName[64 + 12] = "";
 
-			if(g_Config.m_ClShowIDs && Line.m_ClientID >= 0 && Line.m_aName[0] != '\0')
+			if(g_Config.m_ClShowIds && Line.m_ClientId >= 0 && Line.m_aName[0] != '\0')
 			{
-				if(Line.m_ClientID < 10)
-					str_format(aName, sizeof(aName), " %d: ", Line.m_ClientID);
+				if(Line.m_ClientId < 10)
+					str_format(aName, sizeof(aName), " %d: ", Line.m_ClientId);
 				else
-					str_format(aName, sizeof(aName), "%d: ", Line.m_ClientID);
+					str_format(aName, sizeof(aName), "%d: ", Line.m_ClientId);
 			}
 
 			str_append(aName, Line.m_aName);
 
 			char aCount[12];
-			if(Line.m_ClientID < 0)
+			if(Line.m_ClientId < 0)
 				str_format(aCount, sizeof(aCount), "[%d] ", Line.m_TimesRepeated + 1);
 			else
 				str_format(aCount, sizeof(aCount), " [%d]", Line.m_TimesRepeated + 1);
@@ -2830,7 +2830,7 @@ void CMenus::RenderSettingsAppearance(CUIRect MainView)
 				TextRender()->TextEx(&LocalCursor, aCount, -1);
 			}
 
-			if(Line.m_ClientID >= 0 && Line.m_aName[0] != '\0')
+			if(Line.m_ClientId >= 0 && Line.m_aName[0] != '\0')
 			{
 				if(Render)
 					TextRender()->TextColor(NameColor);
@@ -2965,7 +2965,7 @@ void CMenus::RenderSettingsAppearance(CUIRect MainView)
 
 		// ***** Name Plate ***** //
 		LeftView.HSplitTop(HeadlineAndVMargin, &Label, &LeftView);
-		UI()->DoLabel(&Label, Localize("Name Plate"), HeadlineFontSize, TEXTALIGN_ML);
+		Ui()->DoLabel(&Label, Localize("Name Plate"), HeadlineFontSize, TEXTALIGN_ML);
 
 		// General name plate settings
 		LeftView.HSplitTop(SectionTotalMargin + 10 * LineSize + 2 * ColorPickerLineSize, &Section, &LeftView);
@@ -2973,13 +2973,13 @@ void CMenus::RenderSettingsAppearance(CUIRect MainView)
 
 		DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClNameplates, Localize("Show name plates"), &g_Config.m_ClNameplates, &Section, LineSize);
 		Section.HSplitTop(2 * LineSize, &Button, &Section);
-		UI()->DoScrollbarOption(&g_Config.m_ClNameplatesSize, &g_Config.m_ClNameplatesSize, &Button, Localize("Name plates size"), 0, 100, &CUI::ms_LinearScrollbarScale, CUI::SCROLLBAR_OPTION_MULTILINE);
+		Ui()->DoScrollbarOption(&g_Config.m_ClNameplatesSize, &g_Config.m_ClNameplatesSize, &Button, Localize("Name plates size"), 0, 100, &CUi::ms_LinearScrollbarScale, CUi::SCROLLBAR_OPTION_MULTILINE);
 
 		DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClNameplatesClan, Localize("Show clan above name plates"), &g_Config.m_ClNameplatesClan, &Section, LineSize);
 		Section.HSplitTop(2 * LineSize, &Button, &Section);
 		if(g_Config.m_ClNameplatesClan)
 		{
-			UI()->DoScrollbarOption(&g_Config.m_ClNameplatesClanSize, &g_Config.m_ClNameplatesClanSize, &Button, Localize("Clan plates size"), 0, 100, &CUI::ms_LinearScrollbarScale, CUI::SCROLLBAR_OPTION_MULTILINE);
+			Ui()->DoScrollbarOption(&g_Config.m_ClNameplatesClanSize, &g_Config.m_ClNameplatesClanSize, &Button, Localize("Clan plates size"), 0, 100, &CUi::ms_LinearScrollbarScale, CUi::SCROLLBAR_OPTION_MULTILINE);
 		}
 
 		DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClNameplatesTeamcolors, Localize("Use team colors for name plates"), &g_Config.m_ClNameplatesTeamcolors, &Section, LineSize);
@@ -3009,7 +3009,7 @@ void CMenus::RenderSettingsAppearance(CUIRect MainView)
 
 		// ***** Hookline ***** //
 		LeftView.HSplitTop(HeadlineAndVMargin, &Label, &LeftView);
-		UI()->DoLabel(&Label, Localize("Hook collision line"), HeadlineFontSize, TEXTALIGN_ML);
+		Ui()->DoLabel(&Label, Localize("Hook collision line"), HeadlineFontSize, TEXTALIGN_ML);
 
 		// General hookline settings
 		LeftView.HSplitTop(SectionTotalMargin + 6 * LineSize + 3 * ColorPickerLineSize, &Section, &LeftView);
@@ -3022,21 +3022,21 @@ void CMenus::RenderSettingsAppearance(CUIRect MainView)
 		}
 
 		Section.HSplitTop(2 * LineSize, &Button, &Section);
-		UI()->DoScrollbarOption(&g_Config.m_ClHookCollSize, &g_Config.m_ClHookCollSize, &Button, Localize("Hook collision line width"), 0, 20, &CUI::ms_LinearScrollbarScale, CUI::SCROLLBAR_OPTION_MULTILINE);
+		Ui()->DoScrollbarOption(&g_Config.m_ClHookCollSize, &g_Config.m_ClHookCollSize, &Button, Localize("Hook collision line width"), 0, 20, &CUi::ms_LinearScrollbarScale, CUi::SCROLLBAR_OPTION_MULTILINE);
 
 		Section.HSplitTop(2 * LineSize, &Button, &Section);
-		UI()->DoScrollbarOption(&g_Config.m_ClHookCollAlpha, &g_Config.m_ClHookCollAlpha, &Button, Localize("Hook collision line opacity"), 0, 100, &CUI::ms_LinearScrollbarScale, CUI::SCROLLBAR_OPTION_MULTILINE, "%");
+		Ui()->DoScrollbarOption(&g_Config.m_ClHookCollAlpha, &g_Config.m_ClHookCollAlpha, &Button, Localize("Hook collision line opacity"), 0, 100, &CUi::ms_LinearScrollbarScale, CUi::SCROLLBAR_OPTION_MULTILINE, "%");
 
-		static CButtonContainer s_HookCollNoCollResetID, s_HookCollHookableCollResetID, s_HookCollTeeCollResetID;
+		static CButtonContainer s_HookCollNoCollResetId, s_HookCollHookableCollResetId, s_HookCollTeeCollResetId;
 		static int s_HookCollToolTip;
 
 		Section.HSplitTop(LineSize, &Label, &Section);
-		UI()->DoLabel(&Label, Localize("Colors of the hook collision line, in case of a possible collision with:"), 13.0f, TEXTALIGN_ML);
-		UI()->DoButtonLogic(&s_HookCollToolTip, 0, &Label); // Just for the tooltip, result ignored
+		Ui()->DoLabel(&Label, Localize("Colors of the hook collision line, in case of a possible collision with:"), 13.0f, TEXTALIGN_ML);
+		Ui()->DoButtonLogic(&s_HookCollToolTip, 0, &Label); // Just for the tooltip, result ignored
 		GameClient()->m_Tooltips.DoToolTip(&s_HookCollToolTip, &Label, Localize("Your movements are not taken into account when calculating the line colors"));
-		DoLine_ColorPicker(&s_HookCollNoCollResetID, ColorPickerLineSize, ColorPickerLabelSize, ColorPickerLineSpacing, &Section, Localize("Nothing hookable"), &g_Config.m_ClHookCollColorNoColl, ColorRGBA(1.0f, 0.0f, 0.0f, 1.0f), false);
-		DoLine_ColorPicker(&s_HookCollHookableCollResetID, ColorPickerLineSize, ColorPickerLabelSize, ColorPickerLineSpacing, &Section, Localize("Something hookable"), &g_Config.m_ClHookCollColorHookableColl, ColorRGBA(130.0f / 255.0f, 232.0f / 255.0f, 160.0f / 255.0f, 1.0f), false);
-		DoLine_ColorPicker(&s_HookCollTeeCollResetID, ColorPickerLineSize, ColorPickerLabelSize, ColorPickerLineSpacing, &Section, Localize("A Tee"), &g_Config.m_ClHookCollColorTeeColl, ColorRGBA(1.0f, 1.0f, 0.0f, 1.0f), false);
+		DoLine_ColorPicker(&s_HookCollNoCollResetId, ColorPickerLineSize, ColorPickerLabelSize, ColorPickerLineSpacing, &Section, Localize("Nothing hookable"), &g_Config.m_ClHookCollColorNoColl, ColorRGBA(1.0f, 0.0f, 0.0f, 1.0f), false);
+		DoLine_ColorPicker(&s_HookCollHookableCollResetId, ColorPickerLineSize, ColorPickerLabelSize, ColorPickerLineSpacing, &Section, Localize("Something hookable"), &g_Config.m_ClHookCollColorHookableColl, ColorRGBA(130.0f / 255.0f, 232.0f / 255.0f, 160.0f / 255.0f, 1.0f), false);
+		DoLine_ColorPicker(&s_HookCollTeeCollResetId, ColorPickerLineSize, ColorPickerLabelSize, ColorPickerLineSpacing, &Section, Localize("A Tee"), &g_Config.m_ClHookCollColorTeeColl, ColorRGBA(1.0f, 1.0f, 0.0f, 1.0f), false);
 	}
 	else if(s_CurTab == APPEARANCE_TAB_INFO_MESSAGES)
 	{
@@ -3044,7 +3044,7 @@ void CMenus::RenderSettingsAppearance(CUIRect MainView)
 
 		// ***** Info Messages ***** //
 		LeftView.HSplitTop(HeadlineAndVMargin, &Label, &LeftView);
-		UI()->DoLabel(&Label, Localize("Info Messages"), HeadlineFontSize, TEXTALIGN_ML);
+		Ui()->DoLabel(&Label, Localize("Info Messages"), HeadlineFontSize, TEXTALIGN_ML);
 
 		// General info messages settings
 		LeftView.HSplitTop(SectionTotalMargin + 2 * LineSize + 2 * ColorPickerLineSize, &Section, &LeftView);
@@ -3062,9 +3062,9 @@ void CMenus::RenderSettingsAppearance(CUIRect MainView)
 			g_Config.m_ClShowFinishMessages ^= 1;
 		}
 
-		static CButtonContainer s_KillMessageNormalColorID, s_KillMessageHighlightColorID;
-		DoLine_ColorPicker(&s_KillMessageNormalColorID, ColorPickerLineSize, ColorPickerLabelSize, ColorPickerLineSpacing, &Section, Localize("Normal Color"), &g_Config.m_ClKillMessageNormalColor, ColorRGBA(1.0f, 1.0f, 1.0f), false);
-		DoLine_ColorPicker(&s_KillMessageHighlightColorID, ColorPickerLineSize, ColorPickerLabelSize, ColorPickerLineSpacing, &Section, Localize("Highlight Color"), &g_Config.m_ClKillMessageHighlightColor, ColorRGBA(1.0f, 1.0f, 1.0f), false);
+		static CButtonContainer s_KillMessageNormalColorId, s_KillMessageHighlightColorId;
+		DoLine_ColorPicker(&s_KillMessageNormalColorId, ColorPickerLineSize, ColorPickerLabelSize, ColorPickerLineSpacing, &Section, Localize("Normal Color"), &g_Config.m_ClKillMessageNormalColor, ColorRGBA(1.0f, 1.0f, 1.0f), false);
+		DoLine_ColorPicker(&s_KillMessageHighlightColorId, ColorPickerLineSize, ColorPickerLabelSize, ColorPickerLineSpacing, &Section, Localize("Highlight Color"), &g_Config.m_ClKillMessageHighlightColor, ColorRGBA(1.0f, 1.0f, 1.0f), false);
 	}
 	else if(s_CurTab == APPEARANCE_TAB_LASER)
 	{
@@ -3072,40 +3072,40 @@ void CMenus::RenderSettingsAppearance(CUIRect MainView)
 
 		// ***** Weapons ***** //
 		LeftView.HSplitTop(HeadlineAndVMargin, &Label, &LeftView);
-		UI()->DoLabel(&Label, Localize("Weapons"), HeadlineFontSize, TEXTALIGN_ML);
+		Ui()->DoLabel(&Label, Localize("Weapons"), HeadlineFontSize, TEXTALIGN_ML);
 
 		// General weapon laser settings
 		LeftView.HSplitTop(SectionTotalMargin + 4 * ColorPickerLineSize, &Section, &LeftView);
 		Section.Margin(SectionMargin, &Section);
 
-		static CButtonContainer s_LaserRifleOutResetID, s_LaserRifleInResetID, s_LaserShotgunOutResetID, s_LaserShotgunInResetID;
+		static CButtonContainer s_LaserRifleOutResetId, s_LaserRifleInResetId, s_LaserShotgunOutResetId, s_LaserShotgunInResetId;
 
-		ColorHSLA LaserRifleOutlineColor = DoLine_ColorPicker(&s_LaserRifleOutResetID, ColorPickerLineSize, ColorPickerLabelSize, ColorPickerLineSpacing, &Section, Localize("Rifle Laser Outline Color"), &g_Config.m_ClLaserRifleOutlineColor, ColorRGBA(0.074402f, 0.074402f, 0.247166f, 1.0f), false);
-		ColorHSLA LaserRifleInnerColor = DoLine_ColorPicker(&s_LaserRifleInResetID, ColorPickerLineSize, ColorPickerLabelSize, ColorPickerLineSpacing, &Section, Localize("Rifle Laser Inner Color"), &g_Config.m_ClLaserRifleInnerColor, ColorRGBA(0.498039f, 0.498039f, 1.0f, 1.0f), false);
-		ColorHSLA LaserShotgunOutlineColor = DoLine_ColorPicker(&s_LaserShotgunOutResetID, ColorPickerLineSize, ColorPickerLabelSize, ColorPickerLineSpacing, &Section, Localize("Shotgun Laser Outline Color"), &g_Config.m_ClLaserShotgunOutlineColor, ColorRGBA(0.125490f, 0.098039f, 0.043137f, 1.0f), false);
-		ColorHSLA LaserShotgunInnerColor = DoLine_ColorPicker(&s_LaserShotgunInResetID, ColorPickerLineSize, ColorPickerLabelSize, ColorPickerLineSpacing, &Section, Localize("Shotgun Laser Inner Color"), &g_Config.m_ClLaserShotgunInnerColor, ColorRGBA(0.570588f, 0.417647f, 0.252941f, 1.0f), false);
+		ColorHSLA LaserRifleOutlineColor = DoLine_ColorPicker(&s_LaserRifleOutResetId, ColorPickerLineSize, ColorPickerLabelSize, ColorPickerLineSpacing, &Section, Localize("Rifle Laser Outline Color"), &g_Config.m_ClLaserRifleOutlineColor, ColorRGBA(0.074402f, 0.074402f, 0.247166f, 1.0f), false);
+		ColorHSLA LaserRifleInnerColor = DoLine_ColorPicker(&s_LaserRifleInResetId, ColorPickerLineSize, ColorPickerLabelSize, ColorPickerLineSpacing, &Section, Localize("Rifle Laser Inner Color"), &g_Config.m_ClLaserRifleInnerColor, ColorRGBA(0.498039f, 0.498039f, 1.0f, 1.0f), false);
+		ColorHSLA LaserShotgunOutlineColor = DoLine_ColorPicker(&s_LaserShotgunOutResetId, ColorPickerLineSize, ColorPickerLabelSize, ColorPickerLineSpacing, &Section, Localize("Shotgun Laser Outline Color"), &g_Config.m_ClLaserShotgunOutlineColor, ColorRGBA(0.125490f, 0.098039f, 0.043137f, 1.0f), false);
+		ColorHSLA LaserShotgunInnerColor = DoLine_ColorPicker(&s_LaserShotgunInResetId, ColorPickerLineSize, ColorPickerLabelSize, ColorPickerLineSpacing, &Section, Localize("Shotgun Laser Inner Color"), &g_Config.m_ClLaserShotgunInnerColor, ColorRGBA(0.570588f, 0.417647f, 0.252941f, 1.0f), false);
 
 		// ***** Entities ***** //
 		LeftView.HSplitTop(MarginToNextSection * 2.0f, 0x0, &LeftView);
 		LeftView.HSplitTop(HeadlineAndVMargin, &Label, &LeftView);
-		UI()->DoLabel(&Label, Localize("Entities"), HeadlineFontSize, TEXTALIGN_ML);
+		Ui()->DoLabel(&Label, Localize("Entities"), HeadlineFontSize, TEXTALIGN_ML);
 
 		// General entity laser settings
 		LeftView.HSplitTop(SectionTotalMargin + 4 * ColorPickerLineSize, &Section, &LeftView);
 		Section.Margin(SectionMargin, &Section);
 
-		static CButtonContainer s_LaserDoorOutResetID, s_LaserDoorInResetID, s_LaserFreezeOutResetID, s_LaserFreezeInResetID;
+		static CButtonContainer s_LaserDoorOutResetId, s_LaserDoorInResetId, s_LaserFreezeOutResetId, s_LaserFreezeInResetId;
 
-		ColorHSLA LaserDoorOutlineColor = DoLine_ColorPicker(&s_LaserDoorOutResetID, ColorPickerLineSize, ColorPickerLabelSize, ColorPickerLineSpacing, &Section, Localize("Door Laser Outline Color"), &g_Config.m_ClLaserDoorOutlineColor, ColorRGBA(0.0f, 0.131372f, 0.096078f, 1.0f), false);
-		ColorHSLA LaserDoorInnerColor = DoLine_ColorPicker(&s_LaserDoorInResetID, ColorPickerLineSize, ColorPickerLabelSize, ColorPickerLineSpacing, &Section, Localize("Door Laser Inner Color"), &g_Config.m_ClLaserDoorInnerColor, ColorRGBA(0.262745f, 0.760784f, 0.639215f, 1.0f), false);
-		ColorHSLA LaserFreezeOutlineColor = DoLine_ColorPicker(&s_LaserFreezeOutResetID, ColorPickerLineSize, ColorPickerLabelSize, ColorPickerLineSpacing, &Section, Localize("Freeze Laser Outline Color"), &g_Config.m_ClLaserFreezeOutlineColor, ColorRGBA(0.131372f, 0.123529f, 0.182352f, 1.0f), false);
-		ColorHSLA LaserFreezeInnerColor = DoLine_ColorPicker(&s_LaserFreezeInResetID, ColorPickerLineSize, ColorPickerLabelSize, ColorPickerLineSpacing, &Section, Localize("Freeze Laser Inner Color"), &g_Config.m_ClLaserFreezeInnerColor, ColorRGBA(0.482352f, 0.443137f, 0.564705f, 1.0f), false);
+		ColorHSLA LaserDoorOutlineColor = DoLine_ColorPicker(&s_LaserDoorOutResetId, ColorPickerLineSize, ColorPickerLabelSize, ColorPickerLineSpacing, &Section, Localize("Door Laser Outline Color"), &g_Config.m_ClLaserDoorOutlineColor, ColorRGBA(0.0f, 0.131372f, 0.096078f, 1.0f), false);
+		ColorHSLA LaserDoorInnerColor = DoLine_ColorPicker(&s_LaserDoorInResetId, ColorPickerLineSize, ColorPickerLabelSize, ColorPickerLineSpacing, &Section, Localize("Door Laser Inner Color"), &g_Config.m_ClLaserDoorInnerColor, ColorRGBA(0.262745f, 0.760784f, 0.639215f, 1.0f), false);
+		ColorHSLA LaserFreezeOutlineColor = DoLine_ColorPicker(&s_LaserFreezeOutResetId, ColorPickerLineSize, ColorPickerLabelSize, ColorPickerLineSpacing, &Section, Localize("Freeze Laser Outline Color"), &g_Config.m_ClLaserFreezeOutlineColor, ColorRGBA(0.131372f, 0.123529f, 0.182352f, 1.0f), false);
+		ColorHSLA LaserFreezeInnerColor = DoLine_ColorPicker(&s_LaserFreezeInResetId, ColorPickerLineSize, ColorPickerLabelSize, ColorPickerLineSpacing, &Section, Localize("Freeze Laser Inner Color"), &g_Config.m_ClLaserFreezeInnerColor, ColorRGBA(0.482352f, 0.443137f, 0.564705f, 1.0f), false);
 
-		static CButtonContainer s_AllToRifleResetID, s_AllToDefaultResetID;
+		static CButtonContainer s_AllToRifleResetId, s_AllToDefaultResetId;
 
 		LeftView.HSplitTop(20.0f, 0x0, &LeftView);
 		LeftView.HSplitTop(20.0f, &Button, &LeftView);
-		if(DoButton_Menu(&s_AllToRifleResetID, Localize("Set all to Rifle"), 0, &Button))
+		if(DoButton_Menu(&s_AllToRifleResetId, Localize("Set all to Rifle"), 0, &Button))
 		{
 			g_Config.m_ClLaserShotgunOutlineColor = g_Config.m_ClLaserRifleOutlineColor;
 			g_Config.m_ClLaserShotgunInnerColor = g_Config.m_ClLaserRifleInnerColor;
@@ -3118,7 +3118,7 @@ void CMenus::RenderSettingsAppearance(CUIRect MainView)
 		// values taken from the CL commands
 		LeftView.HSplitTop(10.0f, 0x0, &LeftView);
 		LeftView.HSplitTop(20.0f, &Button, &LeftView);
-		if(DoButton_Menu(&s_AllToDefaultResetID, Localize("Reset to defaults"), 0, &Button))
+		if(DoButton_Menu(&s_AllToDefaultResetId, Localize("Reset to defaults"), 0, &Button))
 		{
 			g_Config.m_ClLaserRifleOutlineColor = 11176233;
 			g_Config.m_ClLaserRifleInnerColor = 11206591;
@@ -3132,7 +3132,7 @@ void CMenus::RenderSettingsAppearance(CUIRect MainView)
 
 		// ***** Laser Preview ***** //
 		RightView.HSplitTop(HeadlineAndVMargin, &Label, &RightView);
-		UI()->DoLabel(&Label, Localize("Preview"), HeadlineFontSize, TEXTALIGN_ML);
+		Ui()->DoLabel(&Label, Localize("Preview"), HeadlineFontSize, TEXTALIGN_ML);
 
 		RightView.HSplitTop(SectionTotalMargin + 50.0f, &Section, &RightView);
 		Section.Margin(SectionMargin, &Section);
@@ -3166,9 +3166,9 @@ void CMenus::RenderSettingsDDNet(CUIRect MainView)
 	CUIRect Demo;
 	MainView.HSplitTop(110.0f, &Demo, &MainView);
 	Demo.HSplitTop(30.0f, &Label, &Demo);
-	UI()->DoLabel(&Label, Localize("Demo"), 20.0f, TEXTALIGN_ML);
+	Ui()->DoLabel(&Label, Localize("Demo"), 20.0f, TEXTALIGN_ML);
 	Label.VSplitMid(nullptr, &Label, 20.0f);
-	UI()->DoLabel(&Label, Localize("Ghost"), 20.0f, TEXTALIGN_ML);
+	Ui()->DoLabel(&Label, Localize("Ghost"), 20.0f, TEXTALIGN_ML);
 
 	Demo.HSplitTop(5.0f, nullptr, &Demo);
 	Demo.VSplitMid(&Left, &Right, 20.0f);
@@ -3188,7 +3188,7 @@ void CMenus::RenderSettingsDDNet(CUIRect MainView)
 
 	Left.HSplitTop(20.0f, &Button, &Left);
 	if(g_Config.m_ClReplays)
-		UI()->DoScrollbarOption(&g_Config.m_ClReplayLength, &g_Config.m_ClReplayLength, &Button, Localize("Default length"), 10, 600, &CUI::ms_LinearScrollbarScale, CUI::SCROLLBAR_OPTION_NOCLAMPVALUE);
+		Ui()->DoScrollbarOption(&g_Config.m_ClReplayLength, &g_Config.m_ClReplayLength, &Button, Localize("Default length"), 10, 600, &CUi::ms_LinearScrollbarScale, CUi::SCROLLBAR_OPTION_NOCLAMPVALUE);
 
 	Right.HSplitTop(20.0f, &Button, &Right);
 	if(DoButton_CheckBox(&g_Config.m_ClRaceGhost, Localize("Enable ghost"), g_Config.m_ClRaceGhost, &Button))
@@ -3205,7 +3205,7 @@ void CMenus::RenderSettingsDDNet(CUIRect MainView)
 		{
 			g_Config.m_ClRaceShowGhost ^= 1;
 		}
-		UI()->DoScrollbarOption(&g_Config.m_ClRaceGhostAlpha, &g_Config.m_ClRaceGhostAlpha, &Button, Localize("Opacity"), 0, 100, &CUI::ms_LinearScrollbarScale, 0u, "%");
+		Ui()->DoScrollbarOption(&g_Config.m_ClRaceGhostAlpha, &g_Config.m_ClRaceGhostAlpha, &Button, Localize("Opacity"), 0, 100, &CUi::ms_LinearScrollbarScale, 0u, "%");
 
 		Right.HSplitTop(20.0f, &Button, &Right);
 		if(DoButton_CheckBox(&g_Config.m_ClRaceSaveGhost, Localize("Save ghost"), g_Config.m_ClRaceSaveGhost, &Button))
@@ -3227,12 +3227,12 @@ void CMenus::RenderSettingsDDNet(CUIRect MainView)
 	CUIRect Gameplay;
 	MainView.HSplitTop(150.0f, &Gameplay, &MainView);
 	Gameplay.HSplitTop(30.0f, &Label, &Gameplay);
-	UI()->DoLabel(&Label, Localize("Gameplay"), 20.0f, TEXTALIGN_ML);
+	Ui()->DoLabel(&Label, Localize("Gameplay"), 20.0f, TEXTALIGN_ML);
 	Gameplay.HSplitTop(5.0f, nullptr, &Gameplay);
 	Gameplay.VSplitMid(&Left, &Right, 20.0f);
 
 	Left.HSplitTop(20.0f, &Button, &Left);
-	UI()->DoScrollbarOption(&g_Config.m_ClOverlayEntities, &g_Config.m_ClOverlayEntities, &Button, Localize("Overlay entities"), 0, 100);
+	Ui()->DoScrollbarOption(&g_Config.m_ClOverlayEntities, &g_Config.m_ClOverlayEntities, &Button, Localize("Overlay entities"), 0, 100);
 
 	Left.HSplitTop(20.0f, &Button, &Left);
 	Button.VSplitMid(&LeftLeft, &Button);
@@ -3243,7 +3243,7 @@ void CMenus::RenderSettingsDDNet(CUIRect MainView)
 	if(g_Config.m_ClTextEntities)
 	{
 		int PreviousSize = g_Config.m_ClTextEntitiesSize;
-		UI()->DoScrollbarOption(&g_Config.m_ClTextEntitiesSize, &g_Config.m_ClTextEntitiesSize, &Button, Localize("Size"), 0, 100);
+		Ui()->DoScrollbarOption(&g_Config.m_ClTextEntitiesSize, &g_Config.m_ClTextEntitiesSize, &Button, Localize("Size"), 0, 100);
 
 		if(PreviousSize != g_Config.m_ClTextEntitiesSize)
 			m_pClient->m_MapImages.SetTextureScale(g_Config.m_ClTextEntitiesSize);
@@ -3255,13 +3255,13 @@ void CMenus::RenderSettingsDDNet(CUIRect MainView)
 	if(DoButton_CheckBox(&g_Config.m_ClShowOthers, Localize("Show others"), g_Config.m_ClShowOthers == SHOW_OTHERS_ON, &LeftLeft))
 		g_Config.m_ClShowOthers = g_Config.m_ClShowOthers != SHOW_OTHERS_ON ? SHOW_OTHERS_ON : SHOW_OTHERS_OFF;
 
-	UI()->DoScrollbarOption(&g_Config.m_ClShowOthersAlpha, &g_Config.m_ClShowOthersAlpha, &Button, Localize("Opacity"), 0, 100, &CUI::ms_LinearScrollbarScale, 0u, "%");
+	Ui()->DoScrollbarOption(&g_Config.m_ClShowOthersAlpha, &g_Config.m_ClShowOthersAlpha, &Button, Localize("Opacity"), 0, 100, &CUi::ms_LinearScrollbarScale, 0u, "%");
 
 	GameClient()->m_Tooltips.DoToolTip(&g_Config.m_ClShowOthersAlpha, &Button, Localize("Adjust the opacity of entities belonging to other teams, such as tees and nameplates"));
 
 	Left.HSplitTop(20.0f, &Button, &Left);
-	static int s_ShowOwnTeamID = 0;
-	if(DoButton_CheckBox(&s_ShowOwnTeamID, Localize("Show others (own team only)"), g_Config.m_ClShowOthers == SHOW_OTHERS_ONLY_TEAM, &Button))
+	static int s_ShowOwnTeamId = 0;
+	if(DoButton_CheckBox(&s_ShowOwnTeamId, Localize("Show others (own team only)"), g_Config.m_ClShowOthers == SHOW_OTHERS_ONLY_TEAM, &Button))
 	{
 		g_Config.m_ClShowOthers = g_Config.m_ClShowOthers != SHOW_OTHERS_ONLY_TEAM ? SHOW_OTHERS_ONLY_TEAM : SHOW_OTHERS_OFF;
 	}
@@ -3275,7 +3275,7 @@ void CMenus::RenderSettingsDDNet(CUIRect MainView)
 
 	Right.HSplitTop(20.0f, &Button, &Right);
 	int PreviousZoom = g_Config.m_ClDefaultZoom;
-	UI()->DoScrollbarOption(&g_Config.m_ClDefaultZoom, &g_Config.m_ClDefaultZoom, &Button, Localize("Default zoom"), 0, 20);
+	Ui()->DoScrollbarOption(&g_Config.m_ClDefaultZoom, &g_Config.m_ClDefaultZoom, &Button, Localize("Default zoom"), 0, 20);
 	if(PreviousZoom != g_Config.m_ClDefaultZoom)
 		m_pClient->m_Camera.SetZoom(std::pow(CCamera::ZOOM_STEP, g_Config.m_ClDefaultZoom - 10), g_Config.m_ClSmoothZoomTime);
 
@@ -3313,15 +3313,15 @@ void CMenus::RenderSettingsDDNet(CUIRect MainView)
 	// background
 	Background.HSplitTop(30.0f, &Label, &Background);
 	Background.HSplitTop(5.0f, nullptr, &Background);
-	UI()->DoLabel(&Label, Localize("Background"), 20.0f, TEXTALIGN_ML);
+	Ui()->DoLabel(&Label, Localize("Background"), 20.0f, TEXTALIGN_ML);
 
 	ColorRGBA GreyDefault(0.5f, 0.5f, 0.5f, 1);
 
-	static CButtonContainer s_ResetID1;
-	DoLine_ColorPicker(&s_ResetID1, 25.0f, 13.0f, 5.0f, &Background, Localize("Regular background color"), &g_Config.m_ClBackgroundColor, GreyDefault, false);
+	static CButtonContainer s_ResetId1;
+	DoLine_ColorPicker(&s_ResetId1, 25.0f, 13.0f, 5.0f, &Background, Localize("Regular background color"), &g_Config.m_ClBackgroundColor, GreyDefault, false);
 
-	static CButtonContainer s_ResetID2;
-	DoLine_ColorPicker(&s_ResetID2, 25.0f, 13.0f, 5.0f, &Background, Localize("Entities background color"), &g_Config.m_ClBackgroundEntitiesColor, GreyDefault, false);
+	static CButtonContainer s_ResetId2;
+	DoLine_ColorPicker(&s_ResetId2, 25.0f, 13.0f, 5.0f, &Background, Localize("Entities background color"), &g_Config.m_ClBackgroundEntitiesColor, GreyDefault, false);
 
 	CUIRect EditBox;
 	Background.HSplitTop(20.0f, &Label, &Background);
@@ -3330,10 +3330,10 @@ void CMenus::RenderSettingsDDNet(CUIRect MainView)
 	EditBox.VSplitRight(100.0f, &EditBox, &Button);
 	EditBox.VSplitRight(5.0f, &EditBox, nullptr);
 
-	UI()->DoLabel(&Label, Localize("Map"), 14.0f, TEXTALIGN_ML);
+	Ui()->DoLabel(&Label, Localize("Map"), 14.0f, TEXTALIGN_ML);
 
 	static CLineInput s_BackgroundEntitiesInput(g_Config.m_ClBackgroundEntities, sizeof(g_Config.m_ClBackgroundEntities));
-	UI()->DoEditBox(&s_BackgroundEntitiesInput, &EditBox, 14.0f);
+	Ui()->DoEditBox(&s_BackgroundEntitiesInput, &EditBox, 14.0f);
 
 	static CButtonContainer s_BackgroundEntitiesReloadButton;
 	if(DoButton_Menu(&s_BackgroundEntitiesReloadButton, Localize("Reload"), 0, &Button))
@@ -3344,8 +3344,8 @@ void CMenus::RenderSettingsDDNet(CUIRect MainView)
 
 	Background.HSplitTop(20.0f, &Button, &Background);
 	const bool UseCurrentMap = str_comp(g_Config.m_ClBackgroundEntities, CURRENT_MAP) == 0;
-	static int s_UseCurrentMapID = 0;
-	if(DoButton_CheckBox(&s_UseCurrentMapID, Localize("Use current map as background"), UseCurrentMap, &Button))
+	static int s_UseCurrentMapId = 0;
+	if(DoButton_CheckBox(&s_UseCurrentMapId, Localize("Use current map as background"), UseCurrentMap, &Button))
 	{
 		if(UseCurrentMap)
 			g_Config.m_ClBackgroundEntities[0] = '\0';
@@ -3362,7 +3362,7 @@ void CMenus::RenderSettingsDDNet(CUIRect MainView)
 	Miscellaneous.HSplitTop(30.0f, &Label, &Miscellaneous);
 	Miscellaneous.HSplitTop(5.0f, nullptr, &Miscellaneous);
 
-	UI()->DoLabel(&Label, Localize("Miscellaneous"), 20.0f, TEXTALIGN_ML);
+	Ui()->DoLabel(&Label, Localize("Miscellaneous"), 20.0f, TEXTALIGN_ML);
 
 	static CButtonContainer s_ButtonTimeout;
 	Miscellaneous.HSplitTop(20.0f, &Button, &Miscellaneous);
@@ -3374,11 +3374,11 @@ void CMenus::RenderSettingsDDNet(CUIRect MainView)
 	Miscellaneous.HSplitTop(5.0f, nullptr, &Miscellaneous);
 	Miscellaneous.HSplitTop(20.0f, &Label, &Miscellaneous);
 	Miscellaneous.HSplitTop(2.0f, nullptr, &Miscellaneous);
-	UI()->DoLabel(&Label, Localize("Run on join"), 14.0f, TEXTALIGN_ML);
+	Ui()->DoLabel(&Label, Localize("Run on join"), 14.0f, TEXTALIGN_ML);
 	Miscellaneous.HSplitTop(20.0f, &Button, &Miscellaneous);
 	static CLineInput s_RunOnJoinInput(g_Config.m_ClRunOnJoin, sizeof(g_Config.m_ClRunOnJoin));
 	s_RunOnJoinInput.SetEmptyText(Localize("Chat command (e.g. showall 1)"));
-	UI()->DoEditBox(&s_RunOnJoinInput, &Button, 14.0f);
+	Ui()->DoEditBox(&s_RunOnJoinInput, &Button, 14.0f);
 
 #if defined(CONF_FAMILY_WINDOWS)
 	static CButtonContainer s_ButtonUnregisterShell;
@@ -3427,7 +3427,7 @@ void CMenus::RenderSettingsDDNet(CUIRect MainView)
 				Client()->RequestDDNetInfo();
 			}
 		}
-		UI()->DoLabel(&UpdaterRect, aBuf, 14.0f, TEXTALIGN_ML);
+		Ui()->DoLabel(&UpdaterRect, aBuf, 14.0f, TEXTALIGN_ML);
 		TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
 	}
 #endif

--- a/src/game/client/components/menus_settings_assets.cpp
+++ b/src/game/client/components/menus_settings_assets.cpp
@@ -547,7 +547,7 @@ void CMenus::RenderSettingsCustom(CUIRect MainView)
 		CUIRect TextureRect;
 		ItemRect.HSplitTop(15, &ItemRect, &TextureRect);
 		TextureRect.HSplitTop(10, NULL, &TextureRect);
-		UI()->DoLabel(&ItemRect, pItem->m_aName, ItemRect.h - 2, TEXTALIGN_MC);
+		Ui()->DoLabel(&ItemRect, pItem->m_aName, ItemRect.h - 2, TEXTALIGN_MC);
 		if(pItem->m_RenderTexture.IsValid())
 		{
 			Graphics()->WrapClamp();
@@ -607,7 +607,7 @@ void CMenus::RenderSettingsCustom(CUIRect MainView)
 		TextRender()->SetFontPreset(EFontPreset::ICON_FONT);
 		TextRender()->SetRenderFlags(ETextRenderFlags::TEXT_RENDER_FLAG_ONLY_ADVANCE_WIDTH | ETextRenderFlags::TEXT_RENDER_FLAG_NO_X_BEARING | ETextRenderFlags::TEXT_RENDER_FLAG_NO_Y_BEARING | ETextRenderFlags::TEXT_RENDER_FLAG_NO_PIXEL_ALIGMENT | ETextRenderFlags::TEXT_RENDER_FLAG_NO_OVERSIZE);
 
-		UI()->DoLabel(&QuickSearch, FONT_ICON_MAGNIFYING_GLASS, 14.0f, TEXTALIGN_ML);
+		Ui()->DoLabel(&QuickSearch, FONT_ICON_MAGNIFYING_GLASS, 14.0f, TEXTALIGN_ML);
 		float wSearch = TextRender()->TextWidth(14.0f, FONT_ICON_MAGNIFYING_GLASS, -1, -1.0f);
 		TextRender()->SetRenderFlags(0);
 		TextRender()->SetFontPreset(EFontPreset::DEFAULT_FONT);
@@ -616,11 +616,11 @@ void CMenus::RenderSettingsCustom(CUIRect MainView)
 		QuickSearch.VSplitLeft(QuickSearch.w - 10.0f, &QuickSearch, &QuickSearchClearButton);
 		if(Input()->KeyPress(KEY_F) && Input()->ModifierIsPressed())
 		{
-			UI()->SetActiveItem(&s_aFilterInputs[s_CurCustomTab]);
+			Ui()->SetActiveItem(&s_aFilterInputs[s_CurCustomTab]);
 			s_aFilterInputs[s_CurCustomTab].SelectAll();
 		}
 		s_aFilterInputs[s_CurCustomTab].SetEmptyText(Localize("Search"));
-		if(UI()->DoClearableEditBox(&s_aFilterInputs[s_CurCustomTab], &QuickSearch, 14.0f))
+		if(Ui()->DoClearableEditBox(&s_aFilterInputs[s_CurCustomTab], &QuickSearch, 14.0f))
 			gs_aInitCustomList[s_CurCustomTab] = true;
 	}
 
@@ -628,8 +628,8 @@ void CMenus::RenderSettingsCustom(CUIRect MainView)
 	DirectoryButton.VSplitRight(175.0f, 0, &DirectoryButton);
 	DirectoryButton.VSplitRight(25.0f, &DirectoryButton, &ReloadButton);
 	DirectoryButton.VSplitRight(10.0f, &DirectoryButton, 0);
-	static CButtonContainer s_AssetsDirID;
-	if(DoButton_Menu(&s_AssetsDirID, Localize("Assets directory"), 0, &DirectoryButton))
+	static CButtonContainer s_AssetsDirId;
+	if(DoButton_Menu(&s_AssetsDirId, Localize("Assets directory"), 0, &DirectoryButton))
 	{
 		char aBuf[IO_MAX_PATH_LENGTH];
 		char aBufFull[IO_MAX_PATH_LENGTH + 7];
@@ -653,12 +653,12 @@ void CMenus::RenderSettingsCustom(CUIRect MainView)
 			dbg_msg("menus", "couldn't open file '%s'", aBuf);
 		}
 	}
-	GameClient()->m_Tooltips.DoToolTip(&s_AssetsDirID, &DirectoryButton, Localize("Open the directory to add custom assets"));
+	GameClient()->m_Tooltips.DoToolTip(&s_AssetsDirId, &DirectoryButton, Localize("Open the directory to add custom assets"));
 
 	TextRender()->SetFontPreset(EFontPreset::ICON_FONT);
 	TextRender()->SetRenderFlags(ETextRenderFlags::TEXT_RENDER_FLAG_ONLY_ADVANCE_WIDTH | ETextRenderFlags::TEXT_RENDER_FLAG_NO_X_BEARING | ETextRenderFlags::TEXT_RENDER_FLAG_NO_Y_BEARING | ETextRenderFlags::TEXT_RENDER_FLAG_NO_PIXEL_ALIGMENT | ETextRenderFlags::TEXT_RENDER_FLAG_NO_OVERSIZE);
-	static CButtonContainer s_AssetsReloadBtnID;
-	if(DoButton_Menu(&s_AssetsReloadBtnID, FONT_ICON_ARROW_ROTATE_RIGHT, 0, &ReloadButton) || Input()->KeyPress(KEY_F5) || (Input()->KeyPress(KEY_R) && Input()->ModifierIsPressed()))
+	static CButtonContainer s_AssetsReloadBtnId;
+	if(DoButton_Menu(&s_AssetsReloadBtnId, FONT_ICON_ARROW_ROTATE_RIGHT, 0, &ReloadButton) || Input()->KeyPress(KEY_F5) || (Input()->KeyPress(KEY_R) && Input()->ModifierIsPressed()))
 	{
 		ClearCustomItems(s_CurCustomTab);
 	}

--- a/src/game/client/components/menus_start.cpp
+++ b/src/game/client/components/menus_start.cpp
@@ -114,7 +114,7 @@ void CMenus::RenderStartMenu(CUIRect MainView)
 	Menu.HSplitBottom(40.0f, &Menu, &Button);
 	static CButtonContainer s_QuitButton;
 	bool UsedEscape = false;
-	if(DoButton_Menu(&s_QuitButton, Localize("Quit"), 0, &Button, 0, IGraphics::CORNER_ALL, Rounding, 0.5f, ColorRGBA(0.0f, 0.0f, 0.0f, 0.25f)) || (UsedEscape = UI()->ConsumeHotkey(CUI::HOTKEY_ESCAPE)) || CheckHotKey(KEY_Q))
+	if(DoButton_Menu(&s_QuitButton, Localize("Quit"), 0, &Button, 0, IGraphics::CORNER_ALL, Rounding, 0.5f, ColorRGBA(0.0f, 0.0f, 0.0f, 0.25f)) || (UsedEscape = Ui()->ConsumeHotkey(CUi::HOTKEY_ESCAPE)) || CheckHotKey(KEY_Q))
 	{
 		if(UsedEscape || m_pClient->Editor()->HasUnsavedData() || (Client()->GetCurrentRaceTime() / 60 >= g_Config.m_ClConfirmQuitTime && g_Config.m_ClConfirmQuitTime >= 0))
 		{
@@ -189,7 +189,7 @@ void CMenus::RenderStartMenu(CUIRect MainView)
 	Menu.HSplitBottom(5.0f, &Menu, 0); // little space
 	Menu.HSplitBottom(40.0f, &Menu, &Button);
 	static CButtonContainer s_PlayButton;
-	if(DoButton_Menu(&s_PlayButton, Localize("Play", "Start menu"), 0, &Button, g_Config.m_ClShowStartMenuImages ? "play_game" : 0, IGraphics::CORNER_ALL, Rounding, 0.5f, ColorRGBA(0.0f, 0.0f, 0.0f, 0.25f)) || UI()->ConsumeHotkey(CUI::HOTKEY_ENTER) || CheckHotKey(KEY_P))
+	if(DoButton_Menu(&s_PlayButton, Localize("Play", "Start menu"), 0, &Button, g_Config.m_ClShowStartMenuImages ? "play_game" : 0, IGraphics::CORNER_ALL, Rounding, 0.5f, ColorRGBA(0.0f, 0.0f, 0.0f, 0.25f)) || Ui()->ConsumeHotkey(CUi::HOTKEY_ENTER) || CheckHotKey(KEY_P))
 	{
 		NewPage = g_Config.m_UiPage >= PAGE_INTERNET && g_Config.m_UiPage <= PAGE_FAVORITE_COMMUNITY_3 ? g_Config.m_UiPage : PAGE_INTERNET;
 	}
@@ -231,7 +231,7 @@ void CMenus::RenderStartMenu(CUIRect MainView)
 		str_format(aBuf, sizeof(aBuf), Localize("DDNet Client updated!"));
 		TextRender()->TextColor(1.0f, 0.4f, 0.4f, 1.0f);
 	}
-	UI()->DoLabel(&VersionUpdate, aBuf, 14.0f, TEXTALIGN_ML);
+	Ui()->DoLabel(&VersionUpdate, aBuf, 14.0f, TEXTALIGN_ML);
 	TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
 
 	VersionUpdate.VSplitLeft(TextRender()->TextWidth(14.0f, aBuf, -1, -1.0f) + 10.0f, 0, &Part);
@@ -274,12 +274,12 @@ void CMenus::RenderStartMenu(CUIRect MainView)
 		char aBuf[64];
 		str_format(aBuf, sizeof(aBuf), Localize("DDNet %s is out!"), Client()->LatestVersion());
 		TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
-		UI()->DoLabel(&VersionUpdate, aBuf, 14.0f, TEXTALIGN_MC);
+		Ui()->DoLabel(&VersionUpdate, aBuf, 14.0f, TEXTALIGN_MC);
 		TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
 	}
 #endif
 
-	UI()->DoLabel(&CurVersion, GAME_RELEASE_VERSION, 14.0f, TEXTALIGN_MR);
+	Ui()->DoLabel(&CurVersion, GAME_RELEASE_VERSION, 14.0f, TEXTALIGN_MR);
 
 	if(NewPage != -1)
 	{

--- a/src/game/client/components/nameplates.cpp
+++ b/src/game/client/components/nameplates.cpp
@@ -19,11 +19,11 @@ void CNamePlates::RenderNameplate(
 	const CNetObj_Character *pPlayerChar,
 	const CNetObj_PlayerInfo *pPlayerInfo)
 {
-	int ClientID = pPlayerInfo->m_ClientID;
+	int ClientId = pPlayerInfo->m_ClientId;
 
 	vec2 Position;
-	if(ClientID >= 0 && ClientID < MAX_CLIENTS)
-		Position = m_pClient->m_aClients[ClientID].m_RenderPos;
+	if(ClientId >= 0 && ClientId < MAX_CLIENTS)
+		Position = m_pClient->m_aClients[ClientId].m_RenderPos;
 	else
 		Position = mix(vec2(pPrevChar->m_X, pPrevChar->m_Y), vec2(pPlayerChar->m_X, pPlayerChar->m_Y), Client()->IntraGameTick(g_Config.m_ClDummy));
 
@@ -32,9 +32,9 @@ void CNamePlates::RenderNameplate(
 
 void CNamePlates::RenderNameplatePos(vec2 Position, const CNetObj_PlayerInfo *pPlayerInfo, float Alpha, bool ForceAlpha)
 {
-	int ClientID = pPlayerInfo->m_ClientID;
+	int ClientId = pPlayerInfo->m_ClientId;
 
-	bool OtherTeam = m_pClient->IsOtherTeam(ClientID);
+	bool OtherTeam = m_pClient->IsOtherTeam(ClientId);
 
 	float FontSize = 18.0f + 20.0f * g_Config.m_ClNameplatesSize / 100.0f;
 	float FontSizeClan = 18.0f + 20.0f * g_Config.m_ClNameplatesClanSize / 100.0f;
@@ -49,7 +49,7 @@ void CNamePlates::RenderNameplatePos(vec2 Position, const CNetObj_PlayerInfo *pP
 	if(IVideo::Current())
 		ShowDirection = g_Config.m_ClVideoShowDirection;
 #endif
-	if((ShowDirection && ShowDirection != 3 && !pPlayerInfo->m_Local) || (ShowDirection >= 2 && pPlayerInfo->m_Local) || (ShowDirection == 3 && Client()->DummyConnected() && Client()->State() != IClient::STATE_DEMOPLAYBACK && ClientID == m_pClient->m_aLocalIDs[!g_Config.m_ClDummy]))
+	if((ShowDirection && ShowDirection != 3 && !pPlayerInfo->m_Local) || (ShowDirection >= 2 && pPlayerInfo->m_Local) || (ShowDirection == 3 && Client()->DummyConnected() && Client()->State() != IClient::STATE_DEMOPLAYBACK && ClientId == m_pClient->m_aLocalIds[!g_Config.m_ClDummy]))
 	{
 		Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
 		Graphics()->QuadsSetRotation(0);
@@ -58,9 +58,9 @@ void CNamePlates::RenderNameplatePos(vec2 Position, const CNetObj_PlayerInfo *pP
 		YOffset -= ShowDirectionImgSize;
 		vec2 ShowDirectionPos = vec2(Position.x - 11.0f, YOffset);
 
-		bool DirLeft = m_pClient->m_Snap.m_aCharacters[pPlayerInfo->m_ClientID].m_Cur.m_Direction == -1;
-		bool DirRight = m_pClient->m_Snap.m_aCharacters[pPlayerInfo->m_ClientID].m_Cur.m_Direction == 1;
-		bool Jump = m_pClient->m_Snap.m_aCharacters[pPlayerInfo->m_ClientID].m_Cur.m_Jumped & 1;
+		bool DirLeft = m_pClient->m_Snap.m_aCharacters[pPlayerInfo->m_ClientId].m_Cur.m_Direction == -1;
+		bool DirRight = m_pClient->m_Snap.m_aCharacters[pPlayerInfo->m_ClientId].m_Cur.m_Direction == 1;
+		bool Jump = m_pClient->m_Snap.m_aCharacters[pPlayerInfo->m_ClientId].m_Cur.m_Jumped & 1;
 
 		if(pPlayerInfo->m_Local && Client()->State() != IClient::STATE_DEMOPLAYBACK)
 		{
@@ -68,7 +68,7 @@ void CNamePlates::RenderNameplatePos(vec2 Position, const CNetObj_PlayerInfo *pP
 			DirRight = m_pClient->m_Controls.m_aInputData[g_Config.m_ClDummy].m_Direction == 1;
 			Jump = m_pClient->m_Controls.m_aInputData[g_Config.m_ClDummy].m_Jump == 1;
 		}
-		if(Client()->DummyConnected() && Client()->State() != IClient::STATE_DEMOPLAYBACK && pPlayerInfo->m_ClientID == m_pClient->m_aLocalIDs[!g_Config.m_ClDummy])
+		if(Client()->DummyConnected() && Client()->State() != IClient::STATE_DEMOPLAYBACK && pPlayerInfo->m_ClientId == m_pClient->m_aLocalIds[!g_Config.m_ClDummy])
 		{
 			DirLeft = m_pClient->m_Controls.m_aInputData[!g_Config.m_ClDummy].m_Direction == -1;
 			DirRight = m_pClient->m_Controls.m_aInputData[!g_Config.m_ClDummy].m_Direction == 1;
@@ -102,11 +102,11 @@ void CNamePlates::RenderNameplatePos(vec2 Position, const CNetObj_PlayerInfo *pP
 		if(g_Config.m_ClNameplatesAlways == 0)
 			a = clamp(1 - std::pow(distance(m_pClient->m_Controls.m_aTargetPos[g_Config.m_ClDummy], Position) / 200.0f, 16.0f), 0.0f, 1.0f);
 
-		const char *pName = m_pClient->m_aClients[pPlayerInfo->m_ClientID].m_aName;
-		if(str_comp(pName, m_aNamePlates[ClientID].m_aName) != 0 || FontSize != m_aNamePlates[ClientID].m_NameTextFontSize)
+		const char *pName = m_pClient->m_aClients[pPlayerInfo->m_ClientId].m_aName;
+		if(str_comp(pName, m_aNamePlates[ClientId].m_aName) != 0 || FontSize != m_aNamePlates[ClientId].m_NameTextFontSize)
 		{
-			mem_copy(m_aNamePlates[ClientID].m_aName, pName, sizeof(m_aNamePlates[ClientID].m_aName));
-			m_aNamePlates[ClientID].m_NameTextFontSize = FontSize;
+			mem_copy(m_aNamePlates[ClientId].m_aName, pName, sizeof(m_aNamePlates[ClientId].m_aName));
+			m_aNamePlates[ClientId].m_NameTextFontSize = FontSize;
 
 			CTextCursor Cursor;
 			TextRender()->SetCursor(&Cursor, 0, 0, FontSize, TEXTFLAG_RENDER);
@@ -117,19 +117,19 @@ void CNamePlates::RenderNameplatePos(vec2 Position, const CNetObj_PlayerInfo *pP
 			Graphics()->GetScreen(&ScreenX0, &ScreenY0, &ScreenX1, &ScreenY1);
 			RenderTools()->MapScreenToInterface(m_pClient->m_Camera.m_Center.x, m_pClient->m_Camera.m_Center.y);
 
-			m_aNamePlates[ClientID].m_NameTextWidth = TextRender()->TextWidth(FontSize, pName, -1, -1.0f);
+			m_aNamePlates[ClientId].m_NameTextWidth = TextRender()->TextWidth(FontSize, pName, -1, -1.0f);
 
-			TextRender()->RecreateTextContainer(m_aNamePlates[ClientID].m_NameTextContainerIndex, &Cursor, pName);
+			TextRender()->RecreateTextContainer(m_aNamePlates[ClientId].m_NameTextContainerIndex, &Cursor, pName);
 			Graphics()->MapScreen(ScreenX0, ScreenY0, ScreenX1, ScreenY1);
 		}
 
 		if(g_Config.m_ClNameplatesClan)
 		{
-			const char *pClan = m_pClient->m_aClients[ClientID].m_aClan;
-			if(str_comp(pClan, m_aNamePlates[ClientID].m_aClanName) != 0 || FontSizeClan != m_aNamePlates[ClientID].m_ClanNameTextFontSize)
+			const char *pClan = m_pClient->m_aClients[ClientId].m_aClan;
+			if(str_comp(pClan, m_aNamePlates[ClientId].m_aClanName) != 0 || FontSizeClan != m_aNamePlates[ClientId].m_ClanNameTextFontSize)
 			{
-				mem_copy(m_aNamePlates[ClientID].m_aClanName, pClan, sizeof(m_aNamePlates[ClientID].m_aClanName));
-				m_aNamePlates[ClientID].m_ClanNameTextFontSize = FontSizeClan;
+				mem_copy(m_aNamePlates[ClientId].m_aClanName, pClan, sizeof(m_aNamePlates[ClientId].m_aClanName));
+				m_aNamePlates[ClientId].m_ClanNameTextFontSize = FontSizeClan;
 
 				CTextCursor Cursor;
 				TextRender()->SetCursor(&Cursor, 0, 0, FontSizeClan, TEXTFLAG_RENDER);
@@ -140,16 +140,16 @@ void CNamePlates::RenderNameplatePos(vec2 Position, const CNetObj_PlayerInfo *pP
 				Graphics()->GetScreen(&ScreenX0, &ScreenY0, &ScreenX1, &ScreenY1);
 				RenderTools()->MapScreenToInterface(m_pClient->m_Camera.m_Center.x, m_pClient->m_Camera.m_Center.y);
 
-				m_aNamePlates[ClientID].m_ClanNameTextWidth = TextRender()->TextWidth(FontSizeClan, pClan, -1, -1.0f);
+				m_aNamePlates[ClientId].m_ClanNameTextWidth = TextRender()->TextWidth(FontSizeClan, pClan, -1, -1.0f);
 
-				TextRender()->RecreateTextContainer(m_aNamePlates[ClientID].m_ClanNameTextContainerIndex, &Cursor, pClan);
+				TextRender()->RecreateTextContainer(m_aNamePlates[ClientId].m_ClanNameTextContainerIndex, &Cursor, pClan);
 				Graphics()->MapScreen(ScreenX0, ScreenY0, ScreenX1, ScreenY1);
 			}
 		}
 
-		float tw = m_aNamePlates[ClientID].m_NameTextWidth;
-		if(g_Config.m_ClNameplatesTeamcolors && m_pClient->m_Teams.Team(ClientID))
-			rgb = m_pClient->GetDDTeamColor(m_pClient->m_Teams.Team(ClientID), 0.75f);
+		float tw = m_aNamePlates[ClientId].m_NameTextWidth;
+		if(g_Config.m_ClNameplatesTeamcolors && m_pClient->m_Teams.Team(ClientId))
+			rgb = m_pClient->GetDDTeamColor(m_pClient->m_Teams.Team(ClientId), 0.75f);
 
 		ColorRGBA TColor;
 		ColorRGBA TOutlineColor;
@@ -166,29 +166,29 @@ void CNamePlates::RenderNameplatePos(vec2 Position, const CNetObj_PlayerInfo *pP
 		}
 		if(g_Config.m_ClNameplatesTeamcolors && m_pClient->m_Snap.m_pGameInfoObj && m_pClient->m_Snap.m_pGameInfoObj->m_GameFlags & GAMEFLAG_TEAMS)
 		{
-			if(m_pClient->m_aClients[ClientID].m_Team == TEAM_RED)
+			if(m_pClient->m_aClients[ClientId].m_Team == TEAM_RED)
 				TColor = ColorRGBA(1.0f, 0.5f, 0.5f, a);
-			else if(m_pClient->m_aClients[ClientID].m_Team == TEAM_BLUE)
+			else if(m_pClient->m_aClients[ClientId].m_Team == TEAM_BLUE)
 				TColor = ColorRGBA(0.7f, 0.7f, 1.0f, a);
 		}
 
 		TOutlineColor.a *= Alpha;
 		TColor.a *= Alpha;
 
-		if(m_aNamePlates[ClientID].m_NameTextContainerIndex.Valid())
+		if(m_aNamePlates[ClientId].m_NameTextContainerIndex.Valid())
 		{
 			YOffset -= FontSize;
-			TextRender()->RenderTextContainer(m_aNamePlates[ClientID].m_NameTextContainerIndex, TColor, TOutlineColor, Position.x - tw / 2.0f, YOffset);
+			TextRender()->RenderTextContainer(m_aNamePlates[ClientId].m_NameTextContainerIndex, TColor, TOutlineColor, Position.x - tw / 2.0f, YOffset);
 		}
 
 		if(g_Config.m_ClNameplatesClan)
 		{
 			YOffset -= FontSizeClan;
-			if(m_aNamePlates[ClientID].m_ClanNameTextContainerIndex.Valid())
-				TextRender()->RenderTextContainer(m_aNamePlates[ClientID].m_ClanNameTextContainerIndex, TColor, TOutlineColor, Position.x - m_aNamePlates[ClientID].m_ClanNameTextWidth / 2.0f, YOffset);
+			if(m_aNamePlates[ClientId].m_ClanNameTextContainerIndex.Valid())
+				TextRender()->RenderTextContainer(m_aNamePlates[ClientId].m_ClanNameTextContainerIndex, TColor, TOutlineColor, Position.x - m_aNamePlates[ClientId].m_ClanNameTextWidth / 2.0f, YOffset);
 		}
 
-		if(g_Config.m_ClNameplatesFriendMark && m_pClient->m_aClients[ClientID].m_Friend)
+		if(g_Config.m_ClNameplatesFriendMark && m_pClient->m_aClients[ClientId].m_Friend)
 		{
 			YOffset -= FontSize;
 			char aFriendMark[] = "♥";
@@ -207,11 +207,11 @@ void CNamePlates::RenderNameplatePos(vec2 Position, const CNetObj_PlayerInfo *pP
 			TextRender()->Text(Position.x - XOffSet, YOffset, FontSize, aFriendMark, -1.0f);
 		}
 
-		if(g_Config.m_Debug || g_Config.m_ClNameplatesIDs) // render client id when in debug as well
+		if(g_Config.m_Debug || g_Config.m_ClNameplatesIds) // render client id when in debug as well
 		{
 			YOffset -= FontSize;
 			char aBuf[128];
-			str_from_int(pPlayerInfo->m_ClientID, aBuf);
+			str_from_int(pPlayerInfo->m_ClientId, aBuf);
 			float XOffset = TextRender()->TextWidth(FontSize, aBuf, -1, -1.0f) / 2.0f;
 			TextRender()->TextColor(rgb);
 			TextRender()->Text(Position.x - XOffset, YOffset, FontSize, aBuf, -1.0f);
@@ -220,10 +220,10 @@ void CNamePlates::RenderNameplatePos(vec2 Position, const CNetObj_PlayerInfo *pP
 
 	if((g_Config.m_Debug || g_Config.m_ClNameplatesStrong) && g_Config.m_ClNameplates)
 	{
-		if(m_pClient->m_Snap.m_LocalClientID != -1 && m_pClient->m_Snap.m_aCharacters[pPlayerInfo->m_ClientID].m_HasExtendedData && m_pClient->m_Snap.m_aCharacters[m_pClient->m_Snap.m_LocalClientID].m_HasExtendedData)
+		if(m_pClient->m_Snap.m_LocalClientId != -1 && m_pClient->m_Snap.m_aCharacters[pPlayerInfo->m_ClientId].m_HasExtendedData && m_pClient->m_Snap.m_aCharacters[m_pClient->m_Snap.m_LocalClientId].m_HasExtendedData)
 		{
-			CCharacter *pLocalChar = m_pClient->m_GameWorld.GetCharacterByID(m_pClient->m_Snap.m_LocalClientID);
-			CCharacter *pCharacter = m_pClient->m_GameWorld.GetCharacterByID(pPlayerInfo->m_ClientID);
+			CCharacter *pLocalChar = m_pClient->m_GameWorld.GetCharacterById(m_pClient->m_Snap.m_LocalClientId);
+			CCharacter *pCharacter = m_pClient->m_GameWorld.GetCharacterById(pPlayerInfo->m_ClientId);
 			if(pCharacter && pLocalChar)
 			{
 				if(pPlayerInfo->m_Local)
@@ -236,16 +236,16 @@ void CNamePlates::RenderNameplatePos(vec2 Position, const CNetObj_PlayerInfo *pP
 					Graphics()->TextureSet(g_pData->m_aImages[IMAGE_STRONGWEAK].m_Id);
 					Graphics()->QuadsBegin();
 					ColorRGBA StrongWeakStatusColor;
-					int StrongWeakSpriteID;
-					if(pLocalChar->GetStrongWeakID() > pCharacter->GetStrongWeakID())
+					int StrongWeakSpriteId;
+					if(pLocalChar->GetStrongWeakId() > pCharacter->GetStrongWeakId())
 					{
 						StrongWeakStatusColor = color_cast<ColorRGBA>(ColorHSLA(6401973));
-						StrongWeakSpriteID = SPRITE_HOOK_STRONG;
+						StrongWeakSpriteId = SPRITE_HOOK_STRONG;
 					}
 					else
 					{
 						StrongWeakStatusColor = color_cast<ColorRGBA>(ColorHSLA(41131));
-						StrongWeakSpriteID = SPRITE_HOOK_WEAK;
+						StrongWeakSpriteId = SPRITE_HOOK_WEAK;
 					}
 
 					float ClampedAlpha = 1;
@@ -259,8 +259,8 @@ void CNamePlates::RenderNameplatePos(vec2 Position, const CNetObj_PlayerInfo *pP
 
 					StrongWeakStatusColor.a *= Alpha;
 					Graphics()->SetColor(StrongWeakStatusColor);
-					RenderTools()->SelectSprite(StrongWeakSpriteID);
-					RenderTools()->GetSpriteScale(StrongWeakSpriteID, ScaleX, ScaleY);
+					RenderTools()->SelectSprite(StrongWeakSpriteId);
+					RenderTools()->GetSpriteScale(StrongWeakSpriteId, ScaleX, ScaleY);
 					TextRender()->TextColor(StrongWeakStatusColor);
 
 					YOffset -= StrongWeakImgSize * ScaleY;
@@ -271,7 +271,7 @@ void CNamePlates::RenderNameplatePos(vec2 Position, const CNetObj_PlayerInfo *pP
 				{
 					YOffset -= FontSize;
 					char aBuf[12];
-					str_from_int(pCharacter->GetStrongWeakID(), aBuf);
+					str_from_int(pCharacter->GetStrongWeakId(), aBuf);
 					float XOffset = TextRender()->TextWidth(FontSize, aBuf, -1, -1.0f) / 2.0f;
 					TextRender()->Text(Position.x - XOffset, YOffset, FontSize, aBuf, -1.0f);
 				}

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -71,19 +71,19 @@ inline float AngularApproach(float Src, float Dst, float Amount)
 float CPlayers::GetPlayerTargetAngle(
 	const CNetObj_Character *pPrevChar,
 	const CNetObj_Character *pPlayerChar,
-	int ClientID,
+	int ClientId,
 	float Intra)
 {
 	float AngleIntraTick = Intra;
 	// using unpredicted angle when rendering other players in-game
-	if(ClientID >= 0)
+	if(ClientId >= 0)
 		AngleIntraTick = Client()->IntraGameTick(g_Config.m_ClDummy);
-	if(ClientID >= 0 && m_pClient->m_Snap.m_aCharacters[ClientID].m_HasExtendedDisplayInfo)
+	if(ClientId >= 0 && m_pClient->m_Snap.m_aCharacters[ClientId].m_HasExtendedDisplayInfo)
 	{
-		CNetObj_DDNetCharacter *pExtendedData = &m_pClient->m_Snap.m_aCharacters[ClientID].m_ExtendedData;
-		if(m_pClient->m_Snap.m_aCharacters[ClientID].m_PrevExtendedData)
+		CNetObj_DDNetCharacter *pExtendedData = &m_pClient->m_Snap.m_aCharacters[ClientId].m_ExtendedData;
+		if(m_pClient->m_Snap.m_aCharacters[ClientId].m_PrevExtendedData)
 		{
-			const CNetObj_DDNetCharacter *PrevExtendedData = m_pClient->m_Snap.m_aCharacters[ClientID].m_PrevExtendedData;
+			const CNetObj_DDNetCharacter *PrevExtendedData = m_pClient->m_Snap.m_aCharacters[ClientId].m_PrevExtendedData;
 
 			float MixX = mix((float)PrevExtendedData->m_TargetX, (float)pExtendedData->m_TargetX, AngleIntraTick);
 			float MixY = mix((float)PrevExtendedData->m_TargetY, (float)pExtendedData->m_TargetY, AngleIntraTick);
@@ -118,7 +118,7 @@ float CPlayers::GetPlayerTargetAngle(
 void CPlayers::RenderHookCollLine(
 	const CNetObj_Character *pPrevChar,
 	const CNetObj_Character *pPlayerChar,
-	int ClientID,
+	int ClientId,
 	float Intra)
 {
 	CNetObj_Character Prev;
@@ -126,36 +126,36 @@ void CPlayers::RenderHookCollLine(
 	Prev = *pPrevChar;
 	Player = *pPlayerChar;
 
-	bool Local = m_pClient->m_Snap.m_LocalClientID == ClientID;
-	bool OtherTeam = m_pClient->IsOtherTeam(ClientID);
-	float Alpha = (OtherTeam || ClientID < 0) ? g_Config.m_ClShowOthersAlpha / 100.0f : 1.0f;
+	bool Local = m_pClient->m_Snap.m_LocalClientId == ClientId;
+	bool OtherTeam = m_pClient->IsOtherTeam(ClientId);
+	float Alpha = (OtherTeam || ClientId < 0) ? g_Config.m_ClShowOthersAlpha / 100.0f : 1.0f;
 	Alpha *= (float)g_Config.m_ClHookCollAlpha / 100;
 
 	float IntraTick = Intra;
-	if(ClientID >= 0)
-		IntraTick = m_pClient->m_aClients[ClientID].m_IsPredicted ? Client()->PredIntraGameTick(g_Config.m_ClDummy) : Client()->IntraGameTick(g_Config.m_ClDummy);
+	if(ClientId >= 0)
+		IntraTick = m_pClient->m_aClients[ClientId].m_IsPredicted ? Client()->PredIntraGameTick(g_Config.m_ClDummy) : Client()->IntraGameTick(g_Config.m_ClDummy);
 
 	float Angle;
-	if(Local && (!m_pClient->m_Snap.m_SpecInfo.m_Active || m_pClient->m_Snap.m_SpecInfo.m_SpectatorID != SPEC_FREEVIEW) && Client()->State() != IClient::STATE_DEMOPLAYBACK)
+	if(Local && (!m_pClient->m_Snap.m_SpecInfo.m_Active || m_pClient->m_Snap.m_SpecInfo.m_SpectatorId != SPEC_FREEVIEW) && Client()->State() != IClient::STATE_DEMOPLAYBACK)
 	{
 		// just use the direct input if it's the local player we are rendering
 		Angle = angle(m_pClient->m_Controls.m_aMousePos[g_Config.m_ClDummy] * m_pClient->m_Camera.m_Zoom);
 	}
 	else
 	{
-		Angle = GetPlayerTargetAngle(&Prev, &Player, ClientID, IntraTick);
+		Angle = GetPlayerTargetAngle(&Prev, &Player, ClientId, IntraTick);
 	}
 
 	vec2 Direction = direction(Angle);
 	vec2 Position;
-	if(in_range(ClientID, MAX_CLIENTS - 1))
-		Position = m_pClient->m_aClients[ClientID].m_RenderPos;
+	if(in_range(ClientId, MAX_CLIENTS - 1))
+		Position = m_pClient->m_aClients[ClientId].m_RenderPos;
 	else
 		Position = mix(vec2(Prev.m_X, Prev.m_Y), vec2(Player.m_X, Player.m_Y), IntraTick);
 	// draw hook collision line
 	{
 		bool AlwaysRenderHookColl = GameClient()->m_GameInfo.m_AllowHookColl && (Local ? g_Config.m_ClShowHookCollOwn : g_Config.m_ClShowHookCollOther) == 2;
-		bool RenderHookCollPlayer = ClientID >= 0 && Player.m_PlayerFlags & PLAYERFLAG_AIM && (Local ? g_Config.m_ClShowHookCollOwn : g_Config.m_ClShowHookCollOther) > 0;
+		bool RenderHookCollPlayer = ClientId >= 0 && Player.m_PlayerFlags & PLAYERFLAG_AIM && (Local ? g_Config.m_ClShowHookCollOwn : g_Config.m_ClShowHookCollOther) > 0;
 		if(Local && GameClient()->m_GameInfo.m_AllowHookColl && Client()->State() != IClient::STATE_DEMOPLAYBACK)
 			RenderHookCollPlayer = GameClient()->m_Controls.m_aShowHookColl[g_Config.m_ClDummy] && g_Config.m_ClShowHookCollOwn > 0;
 
@@ -167,7 +167,7 @@ void CPlayers::RenderHookCollLine(
 		{
 			vec2 ExDirection = Direction;
 
-			if(Local && (!m_pClient->m_Snap.m_SpecInfo.m_Active || m_pClient->m_Snap.m_SpecInfo.m_SpectatorID != SPEC_FREEVIEW) && Client()->State() != IClient::STATE_DEMOPLAYBACK)
+			if(Local && (!m_pClient->m_Snap.m_SpecInfo.m_Active || m_pClient->m_Snap.m_SpecInfo.m_SpectatorId != SPEC_FREEVIEW) && Client()->State() != IClient::STATE_DEMOPLAYBACK)
 			{
 				ExDirection = normalize(
 					vec2((int)((int)m_pClient->m_Controls.m_aMousePos[g_Config.m_ClDummy].x * m_pClient->m_Camera.m_Zoom),
@@ -214,7 +214,7 @@ void CPlayers::RenderHookCollLine(
 					}
 				}
 
-				if(m_pClient->IntersectCharacter(OldPos, FinishPos, FinishPos, ClientID) != -1)
+				if(m_pClient->IntersectCharacter(OldPos, FinishPos, FinishPos, ClientId) != -1)
 				{
 					HookCollColor = color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClHookCollColorTeeColl));
 					break;
@@ -264,7 +264,7 @@ void CPlayers::RenderHook(
 	const CNetObj_Character *pPrevChar,
 	const CNetObj_Character *pPlayerChar,
 	const CTeeRenderInfo *pRenderInfo,
-	int ClientID,
+	int ClientId,
 	float Intra)
 {
 	CNetObj_Character Prev;
@@ -279,19 +279,19 @@ void CPlayers::RenderHook(
 		return;
 
 	float IntraTick = Intra;
-	if(ClientID >= 0)
-		IntraTick = (m_pClient->m_aClients[ClientID].m_IsPredicted) ? Client()->PredIntraGameTick(g_Config.m_ClDummy) : Client()->IntraGameTick(g_Config.m_ClDummy);
+	if(ClientId >= 0)
+		IntraTick = (m_pClient->m_aClients[ClientId].m_IsPredicted) ? Client()->PredIntraGameTick(g_Config.m_ClDummy) : Client()->IntraGameTick(g_Config.m_ClDummy);
 
-	bool OtherTeam = m_pClient->IsOtherTeam(ClientID);
-	float Alpha = (OtherTeam || ClientID < 0) ? g_Config.m_ClShowOthersAlpha / 100.0f : 1.0f;
-	if(ClientID == -2) // ghost
+	bool OtherTeam = m_pClient->IsOtherTeam(ClientId);
+	float Alpha = (OtherTeam || ClientId < 0) ? g_Config.m_ClShowOthersAlpha / 100.0f : 1.0f;
+	if(ClientId == -2) // ghost
 		Alpha = g_Config.m_ClRaceGhostAlpha / 100.0f;
 
 	RenderInfo.m_Size = 64.0f;
 
 	vec2 Position;
-	if(in_range(ClientID, MAX_CLIENTS - 1))
-		Position = m_pClient->m_aClients[ClientID].m_RenderPos;
+	if(in_range(ClientId, MAX_CLIENTS - 1))
+		Position = m_pClient->m_aClients[ClientId].m_RenderPos;
 	else
 		Position = mix(vec2(Prev.m_X, Prev.m_Y), vec2(Player.m_X, Player.m_Y), IntraTick);
 
@@ -299,7 +299,7 @@ void CPlayers::RenderHook(
 	if(Prev.m_HookState > 0 && Player.m_HookState > 0)
 	{
 		Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
-		if(ClientID < 0)
+		if(ClientId < 0)
 			Graphics()->SetColor(1.0f, 1.0f, 1.0f, 0.5f);
 
 		vec2 Pos = Position;
@@ -346,7 +346,7 @@ void CPlayers::RenderPlayer(
 	const CNetObj_Character *pPrevChar,
 	const CNetObj_Character *pPlayerChar,
 	const CTeeRenderInfo *pRenderInfo,
-	int ClientID,
+	int ClientId,
 	float Intra)
 {
 	CNetObj_Character Prev;
@@ -356,18 +356,18 @@ void CPlayers::RenderPlayer(
 
 	CTeeRenderInfo RenderInfo = *pRenderInfo;
 
-	bool Local = m_pClient->m_Snap.m_LocalClientID == ClientID;
-	bool OtherTeam = m_pClient->IsOtherTeam(ClientID);
-	float Alpha = (OtherTeam || ClientID < 0) ? g_Config.m_ClShowOthersAlpha / 100.0f : 1.0f;
-	if(ClientID == -2) // ghost
+	bool Local = m_pClient->m_Snap.m_LocalClientId == ClientId;
+	bool OtherTeam = m_pClient->IsOtherTeam(ClientId);
+	float Alpha = (OtherTeam || ClientId < 0) ? g_Config.m_ClShowOthersAlpha / 100.0f : 1.0f;
+	if(ClientId == -2) // ghost
 		Alpha = g_Config.m_ClRaceGhostAlpha / 100.0f;
 
 	// set size
 	RenderInfo.m_Size = 64.0f;
 
 	float IntraTick = Intra;
-	if(ClientID >= 0)
-		IntraTick = m_pClient->m_aClients[ClientID].m_IsPredicted ? Client()->PredIntraGameTick(g_Config.m_ClDummy) : Client()->IntraGameTick(g_Config.m_ClDummy);
+	if(ClientId >= 0)
+		IntraTick = m_pClient->m_aClients[ClientId].m_IsPredicted ? Client()->PredIntraGameTick(g_Config.m_ClDummy) : Client()->IntraGameTick(g_Config.m_ClDummy);
 
 	static float s_LastGameTickTime = Client()->GameTickTime(g_Config.m_ClDummy);
 	static float s_LastPredIntraTick = Client()->PredIntraGameTick(g_Config.m_ClDummy);
@@ -380,7 +380,7 @@ void CPlayers::RenderPlayer(
 	bool PredictLocalWeapons = false;
 	float AttackTime = (Client()->PrevGameTick(g_Config.m_ClDummy) - Player.m_AttackTick) / (float)Client()->GameTickSpeed() + Client()->GameTickTime(g_Config.m_ClDummy);
 	float LastAttackTime = (Client()->PrevGameTick(g_Config.m_ClDummy) - Player.m_AttackTick) / (float)Client()->GameTickSpeed() + s_LastGameTickTime;
-	if(ClientID >= 0 && m_pClient->m_aClients[ClientID].m_IsPredictedLocal && m_pClient->AntiPingGunfire())
+	if(ClientId >= 0 && m_pClient->m_aClients[ClientId].m_IsPredictedLocal && m_pClient->AntiPingGunfire())
 	{
 		PredictLocalWeapons = true;
 		AttackTime = (Client()->PredIntraGameTick(g_Config.m_ClDummy) + (Client()->PredGameTick(g_Config.m_ClDummy) - 1 - Player.m_AttackTick)) / (float)Client()->GameTickSpeed();
@@ -389,20 +389,20 @@ void CPlayers::RenderPlayer(
 	float AttackTicksPassed = AttackTime * (float)Client()->GameTickSpeed();
 
 	float Angle;
-	if(Local && (!m_pClient->m_Snap.m_SpecInfo.m_Active || m_pClient->m_Snap.m_SpecInfo.m_SpectatorID != SPEC_FREEVIEW) && Client()->State() != IClient::STATE_DEMOPLAYBACK)
+	if(Local && (!m_pClient->m_Snap.m_SpecInfo.m_Active || m_pClient->m_Snap.m_SpecInfo.m_SpectatorId != SPEC_FREEVIEW) && Client()->State() != IClient::STATE_DEMOPLAYBACK)
 	{
 		// just use the direct input if it's the local player we are rendering
 		Angle = angle(m_pClient->m_Controls.m_aMousePos[g_Config.m_ClDummy] * m_pClient->m_Camera.m_Zoom);
 	}
 	else
 	{
-		Angle = GetPlayerTargetAngle(&Prev, &Player, ClientID, IntraTick);
+		Angle = GetPlayerTargetAngle(&Prev, &Player, ClientId, IntraTick);
 	}
 
 	vec2 Direction = direction(Angle);
 	vec2 Position;
-	if(in_range(ClientID, MAX_CLIENTS - 1))
-		Position = m_pClient->m_aClients[ClientID].m_RenderPos;
+	if(in_range(ClientId, MAX_CLIENTS - 1))
+		Position = m_pClient->m_aClients[ClientId].m_RenderPos;
 	else
 		Position = mix(vec2(Prev.m_X, Prev.m_Y), vec2(Player.m_X, Player.m_Y), IntraTick);
 	vec2 Vel = mix(vec2(Prev.m_VelX / 256.0f, Prev.m_VelY / 256.0f), vec2(Player.m_VelX / 256.0f, Player.m_VelY / 256.0f), IntraTick);
@@ -417,7 +417,7 @@ void CPlayers::RenderPlayer(
 	bool InAir = !Collision()->CheckPoint(Player.m_X, Player.m_Y + 16);
 	bool Running = Player.m_VelX >= 5000 || Player.m_VelX <= -5000;
 	bool WantOtherDir = (Player.m_Direction == -1 && Vel.x > 0) || (Player.m_Direction == 1 && Vel.x < 0);
-	bool Inactive = m_pClient->m_aClients[ClientID].m_Afk || m_pClient->m_aClients[ClientID].m_Paused;
+	bool Inactive = m_pClient->m_aClients[ClientId].m_Afk || m_pClient->m_aClients[ClientId].m_Paused;
 
 	// evaluate animation
 	float WalkTime = std::fmod(Position.x, 100.0f) / 100.0f;
@@ -481,7 +481,7 @@ void CPlayers::RenderPlayer(
 			Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
 			Graphics()->QuadsSetRotation(State.GetAttach()->m_Angle * pi * 2 + Angle);
 
-			if(ClientID < 0)
+			if(ClientId < 0)
 				Graphics()->SetColor(1.0f, 1.0f, 1.0f, 0.5f);
 
 			// normal weapons
@@ -564,7 +564,7 @@ void CPlayers::RenderPlayer(
 						if(PredictLocalWeapons)
 							Dir = vec2(pPlayerChar->m_X, pPlayerChar->m_Y) - vec2(pPrevChar->m_X, pPrevChar->m_Y);
 						else
-							Dir = vec2(m_pClient->m_Snap.m_aCharacters[ClientID].m_Cur.m_X, m_pClient->m_Snap.m_aCharacters[ClientID].m_Cur.m_Y) - vec2(m_pClient->m_Snap.m_aCharacters[ClientID].m_Prev.m_X, m_pClient->m_Snap.m_aCharacters[ClientID].m_Prev.m_Y);
+							Dir = vec2(m_pClient->m_Snap.m_aCharacters[ClientId].m_Cur.m_X, m_pClient->m_Snap.m_aCharacters[ClientId].m_Cur.m_Y) - vec2(m_pClient->m_Snap.m_aCharacters[ClientId].m_Prev.m_X, m_pClient->m_Snap.m_aCharacters[ClientId].m_Prev.m_Y);
 						float HadOkenAngle = 0;
 						if(absolute(Dir.x) > 0.0001f || absolute(Dir.y) > 0.0001f)
 						{
@@ -661,10 +661,10 @@ void CPlayers::RenderPlayer(
 	if(Local && ((g_Config.m_Debug && g_Config.m_ClUnpredictedShadow >= 0) || g_Config.m_ClUnpredictedShadow == 1))
 	{
 		vec2 ShadowPosition = Position;
-		if(ClientID >= 0)
+		if(ClientId >= 0)
 			ShadowPosition = mix(
-				vec2(m_pClient->m_Snap.m_aCharacters[ClientID].m_Prev.m_X, m_pClient->m_Snap.m_aCharacters[ClientID].m_Prev.m_Y),
-				vec2(m_pClient->m_Snap.m_aCharacters[ClientID].m_Cur.m_X, m_pClient->m_Snap.m_aCharacters[ClientID].m_Cur.m_Y),
+				vec2(m_pClient->m_Snap.m_aCharacters[ClientId].m_Prev.m_X, m_pClient->m_Snap.m_aCharacters[ClientId].m_Prev.m_Y),
+				vec2(m_pClient->m_Snap.m_aCharacters[ClientId].m_Cur.m_X, m_pClient->m_Snap.m_aCharacters[ClientId].m_Cur.m_Y),
 				Client()->IntraGameTick(g_Config.m_ClDummy));
 
 		CTeeRenderInfo Shadow = RenderInfo;
@@ -682,7 +682,7 @@ void CPlayers::RenderPlayer(
 	}
 
 	int QuadOffsetToEmoticon = NUM_WEAPONS * 2 + 2 + 2;
-	if((Player.m_PlayerFlags & PLAYERFLAG_CHATTING) && !m_pClient->m_aClients[ClientID].m_Afk)
+	if((Player.m_PlayerFlags & PLAYERFLAG_CHATTING) && !m_pClient->m_aClients[ClientId].m_Afk)
 	{
 		int CurEmoticon = (SPRITE_DOTDOT - SPRITE_OOP);
 		Graphics()->TextureSet(GameClient()->m_EmoticonsSkin.m_aSpriteEmoticons[CurEmoticon]);
@@ -694,10 +694,10 @@ void CPlayers::RenderPlayer(
 		Graphics()->QuadsSetRotation(0);
 	}
 
-	if(ClientID < 0)
+	if(ClientId < 0)
 		return;
 
-	if(g_Config.m_ClAfkEmote && m_pClient->m_aClients[ClientID].m_Afk && !(Client()->DummyConnected() && ClientID == m_pClient->m_aLocalIDs[!g_Config.m_ClDummy]))
+	if(g_Config.m_ClAfkEmote && m_pClient->m_aClients[ClientId].m_Afk && !(Client()->DummyConnected() && ClientId == m_pClient->m_aLocalIds[!g_Config.m_ClDummy]))
 	{
 		int CurEmoticon = (SPRITE_ZZZ - SPRITE_OOP);
 		Graphics()->TextureSet(GameClient()->m_EmoticonsSkin.m_aSpriteEmoticons[CurEmoticon]);
@@ -709,9 +709,9 @@ void CPlayers::RenderPlayer(
 		Graphics()->QuadsSetRotation(0);
 	}
 
-	if(g_Config.m_ClShowEmotes && !m_pClient->m_aClients[ClientID].m_EmoticonIgnore && m_pClient->m_aClients[ClientID].m_EmoticonStartTick != -1)
+	if(g_Config.m_ClShowEmotes && !m_pClient->m_aClients[ClientId].m_EmoticonIgnore && m_pClient->m_aClients[ClientId].m_EmoticonStartTick != -1)
 	{
-		float SinceStart = (Client()->GameTick(g_Config.m_ClDummy) - m_pClient->m_aClients[ClientID].m_EmoticonStartTick) + (Client()->IntraGameTickSincePrev(g_Config.m_ClDummy) - m_pClient->m_aClients[ClientID].m_EmoticonStartFraction);
+		float SinceStart = (Client()->GameTick(g_Config.m_ClDummy) - m_pClient->m_aClients[ClientId].m_EmoticonStartTick) + (Client()->IntraGameTickSincePrev(g_Config.m_ClDummy) - m_pClient->m_aClients[ClientId].m_EmoticonStartFraction);
 		float FromEnd = (2 * Client()->GameTickSpeed()) - SinceStart;
 
 		if(0 <= SinceStart && FromEnd > 0)
@@ -735,8 +735,8 @@ void CPlayers::RenderPlayer(
 
 			Graphics()->SetColor(1.0f, 1.0f, 1.0f, a * Alpha);
 			// client_datas::emoticon is an offset from the first emoticon
-			int QuadOffset = QuadOffsetToEmoticon + m_pClient->m_aClients[ClientID].m_Emoticon;
-			Graphics()->TextureSet(GameClient()->m_EmoticonsSkin.m_aSpriteEmoticons[m_pClient->m_aClients[ClientID].m_Emoticon]);
+			int QuadOffset = QuadOffsetToEmoticon + m_pClient->m_aClients[ClientId].m_Emoticon;
+			Graphics()->TextureSet(GameClient()->m_EmoticonsSkin.m_aSpriteEmoticons[m_pClient->m_aClients[ClientId].m_Emoticon]);
 			Graphics()->RenderQuadContainerAsSprite(m_WeaponEmoteQuadContainerIndex, QuadOffset, Position.x, Position.y - 23.f - 32.f * h, 1.f, (64.f * h) / 64.f);
 
 			Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
@@ -745,10 +745,10 @@ void CPlayers::RenderPlayer(
 	}
 }
 
-inline bool CPlayers::IsPlayerInfoAvailable(int ClientID) const
+inline bool CPlayers::IsPlayerInfoAvailable(int ClientId) const
 {
-	const void *pPrevInfo = Client()->SnapFindItem(IClient::SNAP_PREV, NETOBJTYPE_PLAYERINFO, ClientID);
-	const void *pInfo = Client()->SnapFindItem(IClient::SNAP_CURRENT, NETOBJTYPE_PLAYERINFO, ClientID);
+	const void *pPrevInfo = Client()->SnapFindItem(IClient::SNAP_PREV, NETOBJTYPE_PLAYERINFO, ClientId);
+	const void *pInfo = Client()->SnapFindItem(IClient::SNAP_CURRENT, NETOBJTYPE_PLAYERINFO, ClientId);
 	return pPrevInfo && pInfo;
 }
 
@@ -798,7 +798,7 @@ void CPlayers::OnRender()
 	RenderInfoSpec.m_SkinMetrics = pSkin->m_Metrics;
 	RenderInfoSpec.m_CustomColoredSkin = false;
 	RenderInfoSpec.m_Size = 64.0f;
-	const int LocalClientID = m_pClient->m_Snap.m_LocalClientID;
+	const int LocalClientId = m_pClient->m_Snap.m_LocalClientId;
 
 	// get screen edges to avoid rendering offscreen
 	float ScreenX0, ScreenY0, ScreenX1, ScreenY1;
@@ -814,18 +814,18 @@ void CPlayers::OnRender()
 	ScreenY1 += BorderBuffer;
 
 	// render everyone else's hook, then our own
-	for(int ClientID = 0; ClientID < MAX_CLIENTS; ClientID++)
+	for(int ClientId = 0; ClientId < MAX_CLIENTS; ClientId++)
 	{
-		if(ClientID == LocalClientID || !m_pClient->m_Snap.m_aCharacters[ClientID].m_Active || !IsPlayerInfoAvailable(ClientID))
+		if(ClientId == LocalClientId || !m_pClient->m_Snap.m_aCharacters[ClientId].m_Active || !IsPlayerInfoAvailable(ClientId))
 		{
 			continue;
 		}
-		RenderHook(&m_pClient->m_aClients[ClientID].m_RenderPrev, &m_pClient->m_aClients[ClientID].m_RenderCur, &aRenderInfo[ClientID], ClientID);
+		RenderHook(&m_pClient->m_aClients[ClientId].m_RenderPrev, &m_pClient->m_aClients[ClientId].m_RenderCur, &aRenderInfo[ClientId], ClientId);
 	}
-	if(LocalClientID != -1 && m_pClient->m_Snap.m_aCharacters[LocalClientID].m_Active && IsPlayerInfoAvailable(LocalClientID))
+	if(LocalClientId != -1 && m_pClient->m_Snap.m_aCharacters[LocalClientId].m_Active && IsPlayerInfoAvailable(LocalClientId))
 	{
-		const CGameClient::CClientData *pLocalClientData = &m_pClient->m_aClients[LocalClientID];
-		RenderHook(&pLocalClientData->m_RenderPrev, &pLocalClientData->m_RenderCur, &aRenderInfo[LocalClientID], LocalClientID);
+		const CGameClient::CClientData *pLocalClientData = &m_pClient->m_aClients[LocalClientId];
+		RenderHook(&pLocalClientData->m_RenderPrev, &pLocalClientData->m_RenderCur, &aRenderInfo[LocalClientId], LocalClientId);
 	}
 
 	// render spectating players
@@ -839,30 +839,30 @@ void CPlayers::OnRender()
 	}
 
 	// render everyone else's tee, then either our own or the tee we are spectating.
-	const int RenderLastID = (m_pClient->m_Snap.m_SpecInfo.m_SpectatorID != SPEC_FREEVIEW && m_pClient->m_Snap.m_SpecInfo.m_Active) ? m_pClient->m_Snap.m_SpecInfo.m_SpectatorID : LocalClientID;
+	const int RenderLastId = (m_pClient->m_Snap.m_SpecInfo.m_SpectatorId != SPEC_FREEVIEW && m_pClient->m_Snap.m_SpecInfo.m_Active) ? m_pClient->m_Snap.m_SpecInfo.m_SpectatorId : LocalClientId;
 
-	for(int ClientID = 0; ClientID < MAX_CLIENTS; ClientID++)
+	for(int ClientId = 0; ClientId < MAX_CLIENTS; ClientId++)
 	{
-		if(ClientID == RenderLastID || !m_pClient->m_Snap.m_aCharacters[ClientID].m_Active || !IsPlayerInfoAvailable(ClientID))
+		if(ClientId == RenderLastId || !m_pClient->m_Snap.m_aCharacters[ClientId].m_Active || !IsPlayerInfoAvailable(ClientId))
 		{
 			continue;
 		}
 
-		RenderHookCollLine(&m_pClient->m_aClients[ClientID].m_RenderPrev, &m_pClient->m_aClients[ClientID].m_RenderCur, ClientID);
+		RenderHookCollLine(&m_pClient->m_aClients[ClientId].m_RenderPrev, &m_pClient->m_aClients[ClientId].m_RenderCur, ClientId);
 
 		// don't render offscreen
-		vec2 *pRenderPos = &m_pClient->m_aClients[ClientID].m_RenderPos;
+		vec2 *pRenderPos = &m_pClient->m_aClients[ClientId].m_RenderPos;
 		if(pRenderPos->x < ScreenX0 || pRenderPos->x > ScreenX1 || pRenderPos->y < ScreenY0 || pRenderPos->y > ScreenY1)
 		{
 			continue;
 		}
-		RenderPlayer(&m_pClient->m_aClients[ClientID].m_RenderPrev, &m_pClient->m_aClients[ClientID].m_RenderCur, &aRenderInfo[ClientID], ClientID);
+		RenderPlayer(&m_pClient->m_aClients[ClientId].m_RenderPrev, &m_pClient->m_aClients[ClientId].m_RenderCur, &aRenderInfo[ClientId], ClientId);
 	}
-	if(RenderLastID != -1 && m_pClient->m_Snap.m_aCharacters[RenderLastID].m_Active && IsPlayerInfoAvailable(RenderLastID))
+	if(RenderLastId != -1 && m_pClient->m_Snap.m_aCharacters[RenderLastId].m_Active && IsPlayerInfoAvailable(RenderLastId))
 	{
-		const CGameClient::CClientData *pClientData = &m_pClient->m_aClients[RenderLastID];
-		RenderHookCollLine(&pClientData->m_RenderPrev, &pClientData->m_RenderCur, RenderLastID);
-		RenderPlayer(&pClientData->m_RenderPrev, &pClientData->m_RenderCur, &aRenderInfo[RenderLastID], RenderLastID);
+		const CGameClient::CClientData *pClientData = &m_pClient->m_aClients[RenderLastId];
+		RenderHookCollLine(&pClientData->m_RenderPrev, &pClientData->m_RenderCur, RenderLastId);
+		RenderPlayer(&pClientData->m_RenderPrev, &pClientData->m_RenderCur, &aRenderInfo[RenderLastId], RenderLastId);
 	}
 }
 

--- a/src/game/client/components/players.h
+++ b/src/game/client/components/players.h
@@ -16,20 +16,20 @@ class CPlayers : public CComponent
 		const CNetObj_Character *pPrevChar,
 		const CNetObj_Character *pPlayerChar,
 		const CTeeRenderInfo *pRenderInfo,
-		int ClientID,
+		int ClientId,
 		float Intra = 0.f);
 	void RenderHook(
 		const CNetObj_Character *pPrevChar,
 		const CNetObj_Character *pPlayerChar,
 		const CTeeRenderInfo *pRenderInfo,
-		int ClientID,
+		int ClientId,
 		float Intra = 0.f);
 	void RenderHookCollLine(
 		const CNetObj_Character *pPrevChar,
 		const CNetObj_Character *pPlayerChar,
-		int ClientID,
+		int ClientId,
 		float Intra = 0.f);
-	bool IsPlayerInfoAvailable(int ClientID) const;
+	bool IsPlayerInfoAvailable(int ClientId) const;
 
 	int m_WeaponEmoteQuadContainerIndex;
 	int m_aWeaponSpriteMuzzleQuadContainerIndex[NUM_WEAPONS];
@@ -38,7 +38,7 @@ public:
 	float GetPlayerTargetAngle(
 		const CNetObj_Character *pPrevChar,
 		const CNetObj_Character *pPlayerChar,
-		int ClientID,
+		int ClientId,
 		float Intra = 0.f);
 
 	virtual int Sizeof() const override { return sizeof(*this); }

--- a/src/game/client/components/race_demo.cpp
+++ b/src/game/client/components/race_demo.cpp
@@ -132,7 +132,7 @@ void CRaceDemo::OnMessage(int MsgType, void *pRawMsg)
 	if(MsgType == NETMSGTYPE_SV_KILLMSG)
 	{
 		CNetMsg_Sv_KillMsg *pMsg = (CNetMsg_Sv_KillMsg *)pRawMsg;
-		if(pMsg->m_Victim == m_pClient->m_Snap.m_LocalClientID && Client()->RaceRecord_IsRecording())
+		if(pMsg->m_Victim == m_pClient->m_Snap.m_LocalClientId && Client()->RaceRecord_IsRecording())
 			StopRecord(m_Time);
 	}
 	else if(MsgType == NETMSGTYPE_SV_KILLMSGTEAM)
@@ -140,18 +140,18 @@ void CRaceDemo::OnMessage(int MsgType, void *pRawMsg)
 		CNetMsg_Sv_KillMsgTeam *pMsg = (CNetMsg_Sv_KillMsgTeam *)pRawMsg;
 		for(int i = 0; i < MAX_CLIENTS; i++)
 		{
-			if(m_pClient->m_Teams.Team(i) == pMsg->m_Team && i == m_pClient->m_Snap.m_LocalClientID && Client()->RaceRecord_IsRecording())
+			if(m_pClient->m_Teams.Team(i) == pMsg->m_Team && i == m_pClient->m_Snap.m_LocalClientId && Client()->RaceRecord_IsRecording())
 				StopRecord(m_Time);
 		}
 	}
 	else if(MsgType == NETMSGTYPE_SV_CHAT)
 	{
 		CNetMsg_Sv_Chat *pMsg = (CNetMsg_Sv_Chat *)pRawMsg;
-		if(pMsg->m_ClientID == -1 && m_RaceState == RACE_STARTED)
+		if(pMsg->m_ClientId == -1 && m_RaceState == RACE_STARTED)
 		{
 			char aName[MAX_NAME_LENGTH];
 			int Time = CRaceHelper::TimeFromFinishMessage(pMsg->m_pMessage, aName, sizeof(aName));
-			if(Time > 0 && m_pClient->m_Snap.m_LocalClientID >= 0 && str_comp(aName, m_pClient->m_aClients[m_pClient->m_Snap.m_LocalClientID].m_aName) == 0)
+			if(Time > 0 && m_pClient->m_Snap.m_LocalClientId >= 0 && str_comp(aName, m_pClient->m_aClients[m_pClient->m_Snap.m_LocalClientId].m_aName) == 0)
 			{
 				m_RaceState = RACE_FINISHED;
 				m_RecordStopTick = Client()->GameTick(g_Config.m_ClDummy) + Client()->GameTickSpeed();

--- a/src/game/client/components/scoreboard.cpp
+++ b/src/game/client/components/scoreboard.cpp
@@ -110,19 +110,19 @@ void CScoreboard::RenderSpectators(float x, float y, float w, float h)
 		if(Multiple)
 			TextRender()->TextEx(&Cursor, ", ", 2);
 
-		if(m_pClient->m_aClients[pInfo->m_ClientID].m_AuthLevel)
+		if(m_pClient->m_aClients[pInfo->m_ClientId].m_AuthLevel)
 		{
 			ColorRGBA Color = color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClAuthedPlayerColor));
 			TextRender()->TextColor(Color);
 		}
 
-		if(g_Config.m_ClShowIDs)
+		if(g_Config.m_ClShowIds)
 		{
 			char aBuffer[5];
-			int size = str_format(aBuffer, sizeof(aBuffer), "%d: ", pInfo->m_ClientID);
+			int size = str_format(aBuffer, sizeof(aBuffer), "%d: ", pInfo->m_ClientId);
 			TextRender()->TextEx(&Cursor, aBuffer, size);
 		}
-		TextRender()->TextEx(&Cursor, m_pClient->m_aClients[pInfo->m_ClientID].m_aName, -1);
+		TextRender()->TextEx(&Cursor, m_pClient->m_aClients[pInfo->m_ClientId].m_aName, -1);
 		TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
 
 		Multiple = true;
@@ -207,10 +207,10 @@ void CScoreboard::RenderScoreboard(float x, float y, float w, int Team, const ch
 	}
 	else
 	{
-		if(m_pClient->m_Snap.m_SpecInfo.m_Active && m_pClient->m_Snap.m_SpecInfo.m_SpectatorID != SPEC_FREEVIEW &&
-			m_pClient->m_Snap.m_apPlayerInfos[m_pClient->m_Snap.m_SpecInfo.m_SpectatorID])
+		if(m_pClient->m_Snap.m_SpecInfo.m_Active && m_pClient->m_Snap.m_SpecInfo.m_SpectatorId != SPEC_FREEVIEW &&
+			m_pClient->m_Snap.m_apPlayerInfos[m_pClient->m_Snap.m_SpecInfo.m_SpectatorId])
 		{
-			int Score = m_pClient->m_Snap.m_apPlayerInfos[m_pClient->m_Snap.m_SpecInfo.m_SpectatorID]->m_Score;
+			int Score = m_pClient->m_Snap.m_apPlayerInfos[m_pClient->m_Snap.m_SpecInfo.m_SpectatorId]->m_Score;
 			str_from_int(Score, aBuf);
 		}
 		else if(m_pClient->m_Snap.m_pLocalInfo)
@@ -325,7 +325,7 @@ void CScoreboard::RenderScoreboard(float x, float y, float w, int Team, const ch
 		if(rendered++ < 0)
 			continue;
 
-		int DDTeam = m_pClient->m_Teams.Team(pInfo->m_ClientID);
+		int DDTeam = m_pClient->m_Teams.Team(pInfo->m_ClientId);
 		int NextDDTeam = 0;
 
 		for(int j = i + 1; j < MAX_CLIENTS; j++)
@@ -335,7 +335,7 @@ void CScoreboard::RenderScoreboard(float x, float y, float w, int Team, const ch
 			if(!pInfo2 || pInfo2->m_Team != Team)
 				continue;
 
-			NextDDTeam = m_pClient->m_Teams.Team(pInfo2->m_ClientID);
+			NextDDTeam = m_pClient->m_Teams.Team(pInfo2->m_ClientId);
 			break;
 		}
 
@@ -348,7 +348,7 @@ void CScoreboard::RenderScoreboard(float x, float y, float w, int Team, const ch
 				if(!pInfo2 || pInfo2->m_Team != Team)
 					continue;
 
-				OldDDTeam = m_pClient->m_Teams.Team(pInfo2->m_ClientID);
+				OldDDTeam = m_pClient->m_Teams.Team(pInfo2->m_ClientId);
 				break;
 			}
 		}
@@ -391,7 +391,7 @@ void CScoreboard::RenderScoreboard(float x, float y, float w, int Team, const ch
 		OldDDTeam = DDTeam;
 
 		// background so it's easy to find the local player or the followed one in spectator mode
-		if((!m_pClient->m_Snap.m_SpecInfo.m_Active && pInfo->m_Local) || (m_pClient->m_Snap.m_SpecInfo.m_SpectatorID == SPEC_FREEVIEW && pInfo->m_Local) || (m_pClient->m_Snap.m_SpecInfo.m_Active && pInfo->m_ClientID == m_pClient->m_Snap.m_SpecInfo.m_SpectatorID))
+		if((!m_pClient->m_Snap.m_SpecInfo.m_Active && pInfo->m_Local) || (m_pClient->m_Snap.m_SpecInfo.m_SpectatorId == SPEC_FREEVIEW && pInfo->m_Local) || (m_pClient->m_Snap.m_SpecInfo.m_Active && pInfo->m_ClientId == m_pClient->m_Snap.m_SpecInfo.m_SpectatorId))
 		{
 			Graphics()->DrawRect(x, y, w - 20.0f, LineHeight, ColorRGBA(1.0f, 1.0f, 1.0f, 0.25f), IGraphics::CORNER_ALL, RoundRadius);
 		}
@@ -412,10 +412,10 @@ void CScoreboard::RenderScoreboard(float x, float y, float w, int Team, const ch
 
 		// flag
 		if(m_pClient->m_Snap.m_pGameInfoObj->m_GameFlags & GAMEFLAG_FLAGS &&
-			m_pClient->m_Snap.m_pGameDataObj && (m_pClient->m_Snap.m_pGameDataObj->m_FlagCarrierRed == pInfo->m_ClientID || m_pClient->m_Snap.m_pGameDataObj->m_FlagCarrierBlue == pInfo->m_ClientID))
+			m_pClient->m_Snap.m_pGameDataObj && (m_pClient->m_Snap.m_pGameDataObj->m_FlagCarrierRed == pInfo->m_ClientId || m_pClient->m_Snap.m_pGameDataObj->m_FlagCarrierBlue == pInfo->m_ClientId))
 		{
 			Graphics()->BlendNormal();
-			if(m_pClient->m_Snap.m_pGameDataObj->m_FlagCarrierBlue == pInfo->m_ClientID)
+			if(m_pClient->m_Snap.m_pGameDataObj->m_FlagCarrierBlue == pInfo->m_ClientId)
 				Graphics()->TextureSet(GameClient()->m_GameSkin.m_SpriteFlagBlue);
 			else
 				Graphics()->TextureSet(GameClient()->m_GameSkin.m_SpriteFlagRed);
@@ -430,7 +430,7 @@ void CScoreboard::RenderScoreboard(float x, float y, float w, int Team, const ch
 		}
 
 		// avatar
-		CTeeRenderInfo TeeInfo = m_pClient->m_aClients[pInfo->m_ClientID].m_RenderInfo;
+		CTeeRenderInfo TeeInfo = m_pClient->m_aClients[pInfo->m_ClientId].m_RenderInfo;
 		TeeInfo.m_Size *= TeeSizeMod;
 		const CAnimState *pIdleState = CAnimState::GetIdle();
 		vec2 OffsetToMid;
@@ -441,22 +441,22 @@ void CScoreboard::RenderScoreboard(float x, float y, float w, int Team, const ch
 
 		// name
 		TextRender()->SetCursor(&Cursor, NameOffset, y + (LineHeight - FontSize) / 2.f, FontSize, TEXTFLAG_RENDER | TEXTFLAG_ELLIPSIS_AT_END);
-		if(m_pClient->m_aClients[pInfo->m_ClientID].m_AuthLevel)
+		if(m_pClient->m_aClients[pInfo->m_ClientId].m_AuthLevel)
 		{
 			ColorRGBA Color = color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClAuthedPlayerColor));
 			TextRender()->TextColor(Color);
 		}
 
-		if(g_Config.m_ClShowIDs)
+		if(g_Config.m_ClShowIds)
 		{
 			char aId[64] = "";
-			if(pInfo->m_ClientID < 10)
+			if(pInfo->m_ClientId < 10)
 			{
-				str_format(aId, sizeof(aId), " %d: %s", pInfo->m_ClientID, m_pClient->m_aClients[pInfo->m_ClientID].m_aName);
+				str_format(aId, sizeof(aId), " %d: %s", pInfo->m_ClientId, m_pClient->m_aClients[pInfo->m_ClientId].m_aName);
 			}
 			else
 			{
-				str_format(aId, sizeof(aId), "%d: %s", pInfo->m_ClientID, m_pClient->m_aClients[pInfo->m_ClientID].m_aName);
+				str_format(aId, sizeof(aId), "%d: %s", pInfo->m_ClientId, m_pClient->m_aClients[pInfo->m_ClientId].m_aName);
 			}
 			Cursor.m_LineWidth = NameLength;
 			TextRender()->TextEx(&Cursor, aId, -1);
@@ -464,12 +464,12 @@ void CScoreboard::RenderScoreboard(float x, float y, float w, int Team, const ch
 		else
 		{
 			Cursor.m_LineWidth = NameLength;
-			TextRender()->TextEx(&Cursor, m_pClient->m_aClients[pInfo->m_ClientID].m_aName, -1);
+			TextRender()->TextEx(&Cursor, m_pClient->m_aClients[pInfo->m_ClientId].m_aName, -1);
 		}
 
 		// clan
-		if(str_comp(m_pClient->m_aClients[pInfo->m_ClientID].m_aClan,
-			   m_pClient->m_aClients[GameClient()->m_aLocalIDs[g_Config.m_ClDummy]].m_aClan) == 0)
+		if(str_comp(m_pClient->m_aClients[pInfo->m_ClientId].m_aClan,
+			   m_pClient->m_aClients[GameClient()->m_aLocalIds[g_Config.m_ClDummy]].m_aClan) == 0)
 		{
 			ColorRGBA Color = color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClSameClanColor));
 			TextRender()->TextColor(Color);
@@ -477,15 +477,15 @@ void CScoreboard::RenderScoreboard(float x, float y, float w, int Team, const ch
 		else
 			TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
 
-		tw = minimum(TextRender()->TextWidth(FontSize, m_pClient->m_aClients[pInfo->m_ClientID].m_aClan, -1, -1.0f), ClanLength);
+		tw = minimum(TextRender()->TextWidth(FontSize, m_pClient->m_aClients[pInfo->m_ClientId].m_aClan, -1, -1.0f), ClanLength);
 		TextRender()->SetCursor(&Cursor, ClanOffset + (ClanLength - tw) / 2, y + (LineHeight - FontSize) / 2.f, FontSize, TEXTFLAG_RENDER | TEXTFLAG_ELLIPSIS_AT_END);
 		Cursor.m_LineWidth = ClanLength;
-		TextRender()->TextEx(&Cursor, m_pClient->m_aClients[pInfo->m_ClientID].m_aClan, -1);
+		TextRender()->TextEx(&Cursor, m_pClient->m_aClients[pInfo->m_ClientId].m_aClan, -1);
 
 		TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
 
 		// country flag
-		m_pClient->m_CountryFlags.Render(m_pClient->m_aClients[pInfo->m_ClientID].m_Country, ColorRGBA(1.0f, 1.0f, 1.0f, 0.5f),
+		m_pClient->m_CountryFlags.Render(m_pClient->m_aClients[pInfo->m_ClientId].m_Country, ColorRGBA(1.0f, 1.0f, 1.0f, 0.5f),
 			CountryOffset, y + (Spacing + TeeSizeMod * 5.0f) / 2.0f, CountryLength, LineHeight - Spacing - TeeSizeMod * 5.0f);
 
 		// ping
@@ -692,12 +692,12 @@ const char *CScoreboard::GetClanName(int Team)
 
 		if(!pClanName)
 		{
-			pClanName = m_pClient->m_aClients[pInfo->m_ClientID].m_aClan;
+			pClanName = m_pClient->m_aClients[pInfo->m_ClientId].m_aClan;
 			ClanPlayers++;
 		}
 		else
 		{
-			if(str_comp(m_pClient->m_aClients[pInfo->m_ClientID].m_aClan, pClanName) == 0)
+			if(str_comp(m_pClient->m_aClients[pInfo->m_ClientId].m_aClan, pClanName) == 0)
 				ClanPlayers++;
 			else
 				return 0;

--- a/src/game/client/components/sounds.cpp
+++ b/src/game/client/components/sounds.cpp
@@ -194,7 +194,7 @@ void CSounds::Enqueue(int Channel, int SetId)
 void CSounds::PlayAndRecord(int Channel, int SetId, float Vol, vec2 Pos)
 {
 	CNetMsg_Sv_SoundGlobal Msg;
-	Msg.m_SoundID = SetId;
+	Msg.m_SoundId = SetId;
 	Client()->SendPackMsgActive(&Msg, MSGFLAG_NOSEND | MSGFLAG_RECORD);
 
 	Play(Channel, SetId, Vol);

--- a/src/game/client/components/spectator.cpp
+++ b/src/game/client/components/spectator.cpp
@@ -20,7 +20,7 @@
 
 bool CSpectator::CanChangeSpectator()
 {
-	// Don't change SpectatorID when not spectating
+	// Don't change SpectatorId when not spectating
 	return m_pClient->m_Snap.m_SpecInfo.m_Active;
 }
 
@@ -29,12 +29,12 @@ void CSpectator::SpectateNext(bool Reverse)
 	int CurIndex = -1;
 	const CNetObj_PlayerInfo **paPlayerInfos = m_pClient->m_Snap.m_apInfoByDDTeamName;
 
-	// m_SpectatorID may be uninitialized if m_Active is false
+	// m_SpectatorId may be uninitialized if m_Active is false
 	if(m_pClient->m_Snap.m_SpecInfo.m_Active)
 	{
 		for(int i = 0; i < MAX_CLIENTS; i++)
 		{
-			if(paPlayerInfos[i] && paPlayerInfos[i]->m_ClientID == m_pClient->m_Snap.m_SpecInfo.m_SpectatorID)
+			if(paPlayerInfos[i] && paPlayerInfos[i]->m_ClientId == m_pClient->m_Snap.m_SpecInfo.m_SpectatorId)
 			{
 				CurIndex = i;
 				break;
@@ -70,7 +70,7 @@ void CSpectator::SpectateNext(bool Reverse)
 		const CNetObj_PlayerInfo *pPlayerInfo = paPlayerInfos[PlayerIndex];
 		if(pPlayerInfo && pPlayerInfo->m_Team != TEAM_SPECTATORS)
 		{
-			Spectate(pPlayerInfo->m_ClientID);
+			Spectate(pPlayerInfo->m_ClientId);
 			break;
 		}
 	}
@@ -120,14 +120,14 @@ void CSpectator::ConSpectateClosest(IConsole::IResult *pResult, void *pUserData)
 		return;
 
 	const CGameClient::CSnapState &Snap = pSelf->m_pClient->m_Snap;
-	int SpectatorID = Snap.m_SpecInfo.m_SpectatorID;
+	int SpectatorId = Snap.m_SpecInfo.m_SpectatorId;
 
-	int NewSpectatorID = -1;
+	int NewSpectatorId = -1;
 
 	vec2 CurPosition(pSelf->m_pClient->m_Camera.m_Center);
-	if(SpectatorID != SPEC_FREEVIEW)
+	if(SpectatorId != SPEC_FREEVIEW)
 	{
-		const CNetObj_Character &CurCharacter = Snap.m_aCharacters[SpectatorID].m_Cur;
+		const CNetObj_Character &CurCharacter = Snap.m_aCharacters[SpectatorId].m_Cur;
 		CurPosition.x = CurCharacter.m_X;
 		CurPosition.y = CurCharacter.m_Y;
 	}
@@ -135,18 +135,18 @@ void CSpectator::ConSpectateClosest(IConsole::IResult *pResult, void *pUserData)
 	int ClosestDistance = std::numeric_limits<int>::max();
 	for(int i = 0; i < MAX_CLIENTS; i++)
 	{
-		if(i == SpectatorID || !Snap.m_apPlayerInfos[i] || Snap.m_apPlayerInfos[i]->m_Team == TEAM_SPECTATORS || (SpectatorID == SPEC_FREEVIEW && i == Snap.m_LocalClientID))
+		if(i == SpectatorId || !Snap.m_apPlayerInfos[i] || Snap.m_apPlayerInfos[i]->m_Team == TEAM_SPECTATORS || (SpectatorId == SPEC_FREEVIEW && i == Snap.m_LocalClientId))
 			continue;
 		const CNetObj_Character &MaybeClosestCharacter = Snap.m_aCharacters[i].m_Cur;
 		int Distance = distance(CurPosition, vec2(MaybeClosestCharacter.m_X, MaybeClosestCharacter.m_Y));
-		if(NewSpectatorID == -1 || Distance < ClosestDistance)
+		if(NewSpectatorId == -1 || Distance < ClosestDistance)
 		{
-			NewSpectatorID = i;
+			NewSpectatorId = i;
 			ClosestDistance = Distance;
 		}
 	}
-	if(NewSpectatorID > -1)
-		pSelf->Spectate(NewSpectatorID);
+	if(NewSpectatorId > -1)
+		pSelf->Spectate(NewSpectatorId);
 }
 
 void CSpectator::ConMultiView(IConsole::IResult *pResult, void *pUserData)
@@ -182,7 +182,7 @@ bool CSpectator::OnCursorMove(float x, float y, IInput::ECursorType CursorType)
 	if(!m_Active)
 		return false;
 
-	UI()->ConvertMouseMove(&x, &y, CursorType);
+	Ui()->ConvertMouseMove(&x, &y, CursorType);
 	m_SelectorMouse += vec2(x, y);
 	return true;
 }
@@ -208,20 +208,20 @@ void CSpectator::OnRender()
 		// closing the spectator menu
 		if(m_WasActive)
 		{
-			if(m_SelectedSpectatorID != NO_SELECTION)
+			if(m_SelectedSpectatorId != NO_SELECTION)
 			{
-				if(m_SelectedSpectatorID == MULTI_VIEW)
+				if(m_SelectedSpectatorId == MULTI_VIEW)
 					GameClient()->m_MultiViewActivated = true;
-				else if(m_SelectedSpectatorID == SPEC_FREEVIEW || m_SelectedSpectatorID == SPEC_FOLLOW)
+				else if(m_SelectedSpectatorId == SPEC_FREEVIEW || m_SelectedSpectatorId == SPEC_FOLLOW)
 					GameClient()->m_MultiViewActivated = false;
 
 				if(!GameClient()->m_MultiViewActivated)
-					Spectate(m_SelectedSpectatorID);
+					Spectate(m_SelectedSpectatorId);
 
-				if(GameClient()->m_MultiViewActivated && m_SelectedSpectatorID != MULTI_VIEW && m_pClient->m_Teams.Team(m_SelectedSpectatorID) != GameClient()->m_MultiViewTeam)
+				if(GameClient()->m_MultiViewActivated && m_SelectedSpectatorId != MULTI_VIEW && m_pClient->m_Teams.Team(m_SelectedSpectatorId) != GameClient()->m_MultiViewTeam)
 				{
 					GameClient()->ResetMultiView();
-					Spectate(m_SelectedSpectatorID);
+					Spectate(m_SelectedSpectatorId);
 					m_MultiViewActivateDelay = Client()->LocalTime() + 0.3f;
 				}
 			}
@@ -230,20 +230,20 @@ void CSpectator::OnRender()
 		return;
 	}
 
-	if(m_SelectedSpectatorID != NO_SELECTION)
+	if(m_SelectedSpectatorId != NO_SELECTION)
 	{
 		// clicking a component
 		if(m_Clicked)
 		{
 			if(!GameClient()->m_MultiViewActivated)
-				Spectate(m_SelectedSpectatorID);
+				Spectate(m_SelectedSpectatorId);
 
-			if(m_SelectedSpectatorID == MULTI_VIEW)
+			if(m_SelectedSpectatorId == MULTI_VIEW)
 				GameClient()->m_MultiViewActivated = true;
-			else if(m_SelectedSpectatorID == SPEC_FREEVIEW || m_SelectedSpectatorID == SPEC_FOLLOW)
+			else if(m_SelectedSpectatorId == SPEC_FREEVIEW || m_SelectedSpectatorId == SPEC_FOLLOW)
 				GameClient()->m_MultiViewActivated = false;
 
-			if(!GameClient()->m_MultiViewActivated && m_SelectedSpectatorID >= 0 && m_SelectedSpectatorID < MAX_CLIENTS)
+			if(!GameClient()->m_MultiViewActivated && m_SelectedSpectatorId >= 0 && m_SelectedSpectatorId < MAX_CLIENTS)
 				m_Clicked = false;
 		}
 	}
@@ -256,7 +256,7 @@ void CSpectator::OnRender()
 	}
 
 	m_WasActive = true;
-	m_SelectedSpectatorID = NO_SELECTION;
+	m_SelectedSpectatorId = NO_SELECTION;
 
 	// draw background
 	float Width = 400 * 3.0f * Graphics()->ScreenAspect();
@@ -307,8 +307,8 @@ void CSpectator::OnRender()
 	m_SelectorMouse.y = clamp(m_SelectorMouse.y, -280.0f, 280.0f);
 
 	// draw selections
-	if((Client()->State() == IClient::STATE_DEMOPLAYBACK && m_pClient->m_DemoSpecID == SPEC_FREEVIEW) ||
-		(Client()->State() != IClient::STATE_DEMOPLAYBACK && m_pClient->m_Snap.m_SpecInfo.m_SpectatorID == SPEC_FREEVIEW))
+	if((Client()->State() == IClient::STATE_DEMOPLAYBACK && m_pClient->m_DemoSpecId == SPEC_FREEVIEW) ||
+		(Client()->State() != IClient::STATE_DEMOPLAYBACK && m_pClient->m_Snap.m_SpecInfo.m_SpectatorId == SPEC_FREEVIEW))
 	{
 		Graphics()->DrawRect(Width / 2.0f - (ObjWidth - 20.0f), Height / 2.0f - 280.0f, ((ObjWidth * 2.0f) / 3.0f) - 40.0f, 60.0f, ColorRGBA(1.0f, 1.0f, 1.0f, 0.25f), IGraphics::CORNER_ALL, 20.0f);
 	}
@@ -318,7 +318,7 @@ void CSpectator::OnRender()
 		Graphics()->DrawRect(Width / 2.0f - (ObjWidth - 20.0f) + (ObjWidth * 2.0f / 3.0f), Height / 2.0f - 280.0f, ((ObjWidth * 2.0f) / 3.0f) - 40.0f, 60.0f, ColorRGBA(1.0f, 1.0f, 1.0f, 0.25f), IGraphics::CORNER_ALL, 20.0f);
 	}
 
-	if(Client()->State() == IClient::STATE_DEMOPLAYBACK && m_pClient->m_Snap.m_LocalClientID >= 0 && m_pClient->m_DemoSpecID == SPEC_FOLLOW)
+	if(Client()->State() == IClient::STATE_DEMOPLAYBACK && m_pClient->m_Snap.m_LocalClientId >= 0 && m_pClient->m_DemoSpecId == SPEC_FOLLOW)
 	{
 		Graphics()->DrawRect(Width / 2.0f - (ObjWidth - 20.0f) + (ObjWidth * 2.0f * 2.0f / 3.0f), Height / 2.0f - 280.0f, ((ObjWidth * 2.0f) / 3.0f) - 40.0f, 60.0f, ColorRGBA(1.0f, 1.0f, 1.0f, 0.25f), IGraphics::CORNER_ALL, 20.0f);
 	}
@@ -326,7 +326,7 @@ void CSpectator::OnRender()
 	if(m_SelectorMouse.x >= -(ObjWidth - 20.0f) && m_SelectorMouse.x <= -(ObjWidth - 20.0f) + ((ObjWidth * 2.0f) / 3.0f) - 40.0f &&
 		m_SelectorMouse.y >= -280.0f && m_SelectorMouse.y <= -220.0f)
 	{
-		m_SelectedSpectatorID = SPEC_FREEVIEW;
+		m_SelectedSpectatorId = SPEC_FREEVIEW;
 		Selected = true;
 	}
 	TextRender()->TextColor(1.0f, 1.0f, 1.0f, Selected ? 1.0f : 0.5f);
@@ -335,19 +335,19 @@ void CSpectator::OnRender()
 	if(m_SelectorMouse.x >= -(ObjWidth - 20.0f) + (ObjWidth * 2.0f / 3.0f) && m_SelectorMouse.x <= -(ObjWidth - 20.0f) + (ObjWidth * 2.0f / 3.0f) + ((ObjWidth * 2.0f) / 3.0f) - 40.0f &&
 		m_SelectorMouse.y >= -280.0f && m_SelectorMouse.y <= -220.0f)
 	{
-		m_SelectedSpectatorID = MULTI_VIEW;
+		m_SelectedSpectatorId = MULTI_VIEW;
 		MultiViewSelected = true;
 	}
 	TextRender()->TextColor(1.0f, 1.0f, 1.0f, MultiViewSelected ? 1.0f : 0.5f);
 	TextRender()->Text(Width / 2.0f - (ObjWidth - 40.0f) + (ObjWidth * 2.0f / 3.0f), Height / 2.0f - 280.f + (60.f - BigFontSize) / 2.f, BigFontSize, Localize("Multi-View"), -1.0f);
 
-	if(Client()->State() == IClient::STATE_DEMOPLAYBACK && m_pClient->m_Snap.m_LocalClientID >= 0)
+	if(Client()->State() == IClient::STATE_DEMOPLAYBACK && m_pClient->m_Snap.m_LocalClientId >= 0)
 	{
 		Selected = false;
 		if(m_SelectorMouse.x >= -(ObjWidth - 20.0f) + (ObjWidth * 2.0f * 2.0f / 3.0f) && m_SelectorMouse.x <= -(ObjWidth - 20.0f) + (ObjWidth * 2.0f * 2.0f / 3.0f) + ((ObjWidth * 2.0f) / 3.0f) - 40.0f &&
 			m_SelectorMouse.y >= -280.0f && m_SelectorMouse.y <= -220.0f)
 		{
-			m_SelectedSpectatorID = SPEC_FOLLOW;
+			m_SelectedSpectatorId = SPEC_FOLLOW;
 			Selected = true;
 		}
 		TextRender()->TextColor(1.0f, 1.0f, 1.0f, Selected ? 1.0f : 0.5f);
@@ -372,7 +372,7 @@ void CSpectator::OnRender()
 		}
 
 		const CNetObj_PlayerInfo *pInfo = m_pClient->m_Snap.m_apInfoByDDTeamName[i];
-		int DDTeam = m_pClient->m_Teams.Team(pInfo->m_ClientID);
+		int DDTeam = m_pClient->m_Teams.Team(pInfo->m_ClientId);
 		int NextDDTeam = 0;
 
 		for(int j = i + 1; j < MAX_CLIENTS; j++)
@@ -382,7 +382,7 @@ void CSpectator::OnRender()
 			if(!pInfo2 || pInfo2->m_Team == TEAM_SPECTATORS)
 				continue;
 
-			NextDDTeam = m_pClient->m_Teams.Team(pInfo2->m_ClientID);
+			NextDDTeam = m_pClient->m_Teams.Team(pInfo2->m_ClientId);
 			break;
 		}
 
@@ -395,7 +395,7 @@ void CSpectator::OnRender()
 				if(!pInfo2 || pInfo2->m_Team == TEAM_SPECTATORS)
 					continue;
 
-				OldDDTeam = m_pClient->m_Teams.Team(pInfo2->m_ClientID);
+				OldDDTeam = m_pClient->m_Teams.Team(pInfo2->m_ClientId);
 				break;
 			}
 		}
@@ -413,7 +413,7 @@ void CSpectator::OnRender()
 
 		OldDDTeam = DDTeam;
 
-		if((Client()->State() == IClient::STATE_DEMOPLAYBACK && m_pClient->m_DemoSpecID == m_pClient->m_Snap.m_apInfoByDDTeamName[i]->m_ClientID) || (Client()->State() != IClient::STATE_DEMOPLAYBACK && m_pClient->m_Snap.m_SpecInfo.m_SpectatorID == m_pClient->m_Snap.m_apInfoByDDTeamName[i]->m_ClientID))
+		if((Client()->State() == IClient::STATE_DEMOPLAYBACK && m_pClient->m_DemoSpecId == m_pClient->m_Snap.m_apInfoByDDTeamName[i]->m_ClientId) || (Client()->State() != IClient::STATE_DEMOPLAYBACK && m_pClient->m_Snap.m_SpecInfo.m_SpectatorId == m_pClient->m_Snap.m_apInfoByDDTeamName[i]->m_ClientId))
 		{
 			Graphics()->DrawRect(Width / 2.0f + x - 10.0f + BoxOffset, Height / 2.0f + y + BoxMove, 270.0f - BoxOffset, LineHeight, ColorRGBA(1.0f, 1.0f, 1.0f, 0.25f), IGraphics::CORNER_ALL, RoundRadius);
 		}
@@ -422,28 +422,28 @@ void CSpectator::OnRender()
 		if(m_SelectorMouse.x >= x - 10.0f && m_SelectorMouse.x < x + 260.0f &&
 			m_SelectorMouse.y >= y - (LineHeight / 6.0f) && m_SelectorMouse.y < y + (LineHeight * 5.0f / 6.0f))
 		{
-			m_SelectedSpectatorID = m_pClient->m_Snap.m_apInfoByDDTeamName[i]->m_ClientID;
+			m_SelectedSpectatorId = m_pClient->m_Snap.m_apInfoByDDTeamName[i]->m_ClientId;
 			Selected = true;
 			if(GameClient()->m_MultiViewActivated && m_Clicked)
 			{
 				if(GameClient()->m_MultiViewTeam == DDTeam)
 				{
-					GameClient()->m_aMultiViewId[m_SelectedSpectatorID] = !GameClient()->m_aMultiViewId[m_SelectedSpectatorID];
-					if(!GameClient()->m_aMultiViewId[m_pClient->m_Snap.m_SpecInfo.m_SpectatorID])
+					GameClient()->m_aMultiViewId[m_SelectedSpectatorId] = !GameClient()->m_aMultiViewId[m_SelectedSpectatorId];
+					if(!GameClient()->m_aMultiViewId[m_pClient->m_Snap.m_SpecInfo.m_SpectatorId])
 					{
-						int NewClientID = GameClient()->FindFirstMultiViewId();
-						if(NewClientID < MAX_CLIENTS && NewClientID >= 0)
+						int NewClientId = GameClient()->FindFirstMultiViewId();
+						if(NewClientId < MAX_CLIENTS && NewClientId >= 0)
 						{
-							GameClient()->CleanMultiViewId(NewClientID);
-							GameClient()->m_aMultiViewId[NewClientID] = true;
-							Spectate(NewClientID);
+							GameClient()->CleanMultiViewId(NewClientId);
+							GameClient()->m_aMultiViewId[NewClientId] = true;
+							Spectate(NewClientId);
 						}
 					}
 				}
 				else
 				{
 					GameClient()->ResetMultiView();
-					Spectate(m_SelectedSpectatorID);
+					Spectate(m_SelectedSpectatorId);
 					m_MultiViewActivateDelay = Client()->LocalTime() + 0.3f;
 				}
 				m_Clicked = false;
@@ -451,7 +451,7 @@ void CSpectator::OnRender()
 		}
 		float TeeAlpha;
 		if(Client()->State() == IClient::STATE_DEMOPLAYBACK &&
-			!m_pClient->m_Snap.m_aCharacters[m_pClient->m_Snap.m_apInfoByDDTeamName[i]->m_ClientID].m_Active)
+			!m_pClient->m_Snap.m_aCharacters[m_pClient->m_Snap.m_apInfoByDDTeamName[i]->m_ClientId].m_Active)
 		{
 			TextRender()->TextColor(1.0f, 1.0f, 1.0f, 0.25f);
 			TeeAlpha = 0.5f;
@@ -461,11 +461,11 @@ void CSpectator::OnRender()
 			TextRender()->TextColor(1.0f, 1.0f, 1.0f, Selected ? 1.0f : 0.5f);
 			TeeAlpha = 1.0f;
 		}
-		TextRender()->Text(Width / 2.0f + x + 50.0f, Height / 2.0f + y + BoxMove + (LineHeight - FontSize) / 2.f, FontSize, m_pClient->m_aClients[m_pClient->m_Snap.m_apInfoByDDTeamName[i]->m_ClientID].m_aName, 220.0f);
+		TextRender()->Text(Width / 2.0f + x + 50.0f, Height / 2.0f + y + BoxMove + (LineHeight - FontSize) / 2.f, FontSize, m_pClient->m_aClients[m_pClient->m_Snap.m_apInfoByDDTeamName[i]->m_ClientId].m_aName, 220.0f);
 
 		if(GameClient()->m_MultiViewActivated)
 		{
-			if(GameClient()->m_aMultiViewId[m_pClient->m_Snap.m_apInfoByDDTeamName[i]->m_ClientID])
+			if(GameClient()->m_aMultiViewId[m_pClient->m_Snap.m_apInfoByDDTeamName[i]->m_ClientId])
 			{
 				TextRender()->TextColor(0.1f, 1.0f, 0.1f, Selected ? 1.0f : 0.5f);
 				TextRender()->Text(Width / 2.0f + x + 50.0f + 180.0f, Height / 2.0f + y + BoxMove + (LineHeight - FontSize) / 2.f, FontSize - 3, "⬤", 220.0f);
@@ -479,10 +479,10 @@ void CSpectator::OnRender()
 
 		// flag
 		if(m_pClient->m_Snap.m_pGameInfoObj && (m_pClient->m_Snap.m_pGameInfoObj->m_GameFlags & GAMEFLAG_FLAGS) &&
-			m_pClient->m_Snap.m_pGameDataObj && (m_pClient->m_Snap.m_pGameDataObj->m_FlagCarrierRed == m_pClient->m_Snap.m_apInfoByDDTeamName[i]->m_ClientID || m_pClient->m_Snap.m_pGameDataObj->m_FlagCarrierBlue == m_pClient->m_Snap.m_apInfoByDDTeamName[i]->m_ClientID))
+			m_pClient->m_Snap.m_pGameDataObj && (m_pClient->m_Snap.m_pGameDataObj->m_FlagCarrierRed == m_pClient->m_Snap.m_apInfoByDDTeamName[i]->m_ClientId || m_pClient->m_Snap.m_pGameDataObj->m_FlagCarrierBlue == m_pClient->m_Snap.m_apInfoByDDTeamName[i]->m_ClientId))
 		{
 			Graphics()->BlendNormal();
-			if(m_pClient->m_Snap.m_pGameDataObj->m_FlagCarrierBlue == m_pClient->m_Snap.m_apInfoByDDTeamName[i]->m_ClientID)
+			if(m_pClient->m_Snap.m_pGameDataObj->m_FlagCarrierBlue == m_pClient->m_Snap.m_apInfoByDDTeamName[i]->m_ClientId)
 				Graphics()->TextureSet(GameClient()->m_GameSkin.m_SpriteFlagBlue);
 			else
 				Graphics()->TextureSet(GameClient()->m_GameSkin.m_SpriteFlagRed);
@@ -496,7 +496,7 @@ void CSpectator::OnRender()
 			Graphics()->QuadsEnd();
 		}
 
-		CTeeRenderInfo TeeInfo = m_pClient->m_aClients[m_pClient->m_Snap.m_apInfoByDDTeamName[i]->m_ClientID].m_RenderInfo;
+		CTeeRenderInfo TeeInfo = m_pClient->m_aClients[m_pClient->m_Snap.m_apInfoByDDTeamName[i]->m_ClientId].m_RenderInfo;
 		TeeInfo.m_Size *= TeeSizeMod;
 
 		const CAnimState *pIdleState = CAnimState::GetIdle();
@@ -506,7 +506,7 @@ void CSpectator::OnRender()
 
 		RenderTools()->RenderTee(pIdleState, &TeeInfo, EMOTE_NORMAL, vec2(1.0f, 0.0f), TeeRenderPos, TeeAlpha);
 
-		if(m_pClient->m_aClients[m_pClient->m_Snap.m_apInfoByDDTeamName[i]->m_ClientID].m_Friend)
+		if(m_pClient->m_aClients[m_pClient->m_Snap.m_apInfoByDDTeamName[i]->m_ClientId].m_Friend)
 		{
 			ColorRGBA rgb = color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClMessageFriendColor));
 			TextRender()->TextColor(rgb.WithAlpha(1.f));
@@ -525,25 +525,25 @@ void CSpectator::OnReset()
 {
 	m_WasActive = false;
 	m_Active = false;
-	m_SelectedSpectatorID = NO_SELECTION;
+	m_SelectedSpectatorId = NO_SELECTION;
 }
 
-void CSpectator::Spectate(int SpectatorID)
+void CSpectator::Spectate(int SpectatorId)
 {
 	if(Client()->State() == IClient::STATE_DEMOPLAYBACK)
 	{
-		m_pClient->m_DemoSpecID = clamp(SpectatorID, (int)SPEC_FOLLOW, MAX_CLIENTS - 1);
+		m_pClient->m_DemoSpecId = clamp(SpectatorId, (int)SPEC_FOLLOW, MAX_CLIENTS - 1);
 		// The tick must be rendered for the spectator mode to be updated, so we do it manually when demo playback is paused
 		if(DemoPlayer()->BaseInfo()->m_Paused)
 			GameClient()->m_Menus.DemoSeekTick(IDemoPlayer::TICK_CURRENT);
 		return;
 	}
 
-	if(m_pClient->m_Snap.m_SpecInfo.m_SpectatorID == SpectatorID)
+	if(m_pClient->m_Snap.m_SpecInfo.m_SpectatorId == SpectatorId)
 		return;
 
 	CNetMsg_Cl_SetSpectatorMode Msg;
-	Msg.m_SpectatorID = SpectatorID;
+	Msg.m_SpectatorId = SpectatorId;
 	Client()->SendPackMsgActive(&Msg, MSGFLAG_VITAL);
 }
 

--- a/src/game/client/components/spectator.h
+++ b/src/game/client/components/spectator.h
@@ -18,7 +18,7 @@ class CSpectator : public CComponent
 	bool m_WasActive;
 	bool m_Clicked;
 
-	int m_SelectedSpectatorID;
+	int m_SelectedSpectatorId;
 	vec2 m_SelectorMouse;
 
 	float m_OldMouseX;
@@ -47,7 +47,7 @@ public:
 	virtual void OnReset() override;
 	virtual bool OnInput(const IInput::CEvent &Event) override;
 
-	void Spectate(int SpectatorID);
+	void Spectate(int SpectatorId);
 	void SpectateClosest();
 };
 

--- a/src/game/client/components/statboard.cpp
+++ b/src/game/client/components/statboard.cpp
@@ -90,7 +90,7 @@ void CStatboard::OnMessage(int MsgType, void *pRawMsg)
 	else if(MsgType == NETMSGTYPE_SV_CHAT)
 	{
 		CNetMsg_Sv_Chat *pMsg = (CNetMsg_Sv_Chat *)pRawMsg;
-		if(pMsg->m_ClientID < 0)
+		if(pMsg->m_ClientId < 0)
 		{
 			const char *p, *t;
 			const char *pLookFor = "flag was captured by '";
@@ -155,7 +155,7 @@ void CStatboard::RenderGlobalStats()
 	// sort red or dm players by score
 	for(const auto *pInfo : m_pClient->m_Snap.m_apInfoByScore)
 	{
-		if(!pInfo || !m_pClient->m_aStats[pInfo->m_ClientID].IsActive() || m_pClient->m_aClients[pInfo->m_ClientID].m_Team != TEAM_RED)
+		if(!pInfo || !m_pClient->m_aStats[pInfo->m_ClientId].IsActive() || m_pClient->m_aClients[pInfo->m_ClientId].m_Team != TEAM_RED)
 			continue;
 		apPlayers[NumPlayers] = pInfo;
 		NumPlayers++;
@@ -166,7 +166,7 @@ void CStatboard::RenderGlobalStats()
 	{
 		for(const auto *pInfo : m_pClient->m_Snap.m_apInfoByScore)
 		{
-			if(!pInfo || !m_pClient->m_aStats[pInfo->m_ClientID].IsActive() || m_pClient->m_aClients[pInfo->m_ClientID].m_Team != TEAM_BLUE)
+			if(!pInfo || !m_pClient->m_aStats[pInfo->m_ClientId].IsActive() || m_pClient->m_aClients[pInfo->m_ClientId].m_Team != TEAM_BLUE)
 				continue;
 			apPlayers[NumPlayers] = pInfo;
 			NumPlayers++;
@@ -193,7 +193,7 @@ void CStatboard::RenderGlobalStats()
 	bool aDisplayWeapon[NUM_WEAPONS] = {false};
 	for(int i = 0; i < NumPlayers; i++)
 	{
-		const CGameClient::CClientStats *pStats = &m_pClient->m_aStats[apPlayers[i]->m_ClientID];
+		const CGameClient::CClientStats *pStats = &m_pClient->m_aStats[apPlayers[i]->m_ClientId];
 		for(int j = 0; j < NUM_WEAPONS; j++)
 			aDisplayWeapon[j] = aDisplayWeapon[j] || pStats->m_aFragsWith[j] || pStats->m_aDeathsFrom[j];
 	}
@@ -279,15 +279,15 @@ void CStatboard::RenderGlobalStats()
 	for(int j = 0; j < NumPlayers; j++)
 	{
 		const CNetObj_PlayerInfo *pInfo = apPlayers[j];
-		const CGameClient::CClientStats *pStats = &m_pClient->m_aStats[pInfo->m_ClientID];
+		const CGameClient::CClientStats *pStats = &m_pClient->m_aStats[pInfo->m_ClientId];
 
-		if(m_pClient->m_Snap.m_LocalClientID == pInfo->m_ClientID || (m_pClient->m_Snap.m_SpecInfo.m_Active && pInfo->m_ClientID == m_pClient->m_Snap.m_SpecInfo.m_SpectatorID))
+		if(m_pClient->m_Snap.m_LocalClientId == pInfo->m_ClientId || (m_pClient->m_Snap.m_SpecInfo.m_Active && pInfo->m_ClientId == m_pClient->m_Snap.m_SpecInfo.m_SpectatorId))
 		{
 			// background so it's easy to find the local player
 			Graphics()->DrawRect(x - 10, y + ContentLineOffset / 2, StatboardContentWidth, LineHeight - ContentLineOffset, ColorRGBA(1.0f, 1.0f, 1.0f, 0.25f), IGraphics::CORNER_NONE, 0.0f);
 		}
 
-		CTeeRenderInfo Teeinfo = m_pClient->m_aClients[pInfo->m_ClientID].m_RenderInfo;
+		CTeeRenderInfo Teeinfo = m_pClient->m_aClients[pInfo->m_ClientId].m_RenderInfo;
 		Teeinfo.m_Size *= TeeSizemod;
 
 		const CAnimState *pIdleState = CAnimState::GetIdle();
@@ -301,7 +301,7 @@ void CStatboard::RenderGlobalStats()
 		CTextCursor Cursor;
 		TextRender()->SetCursor(&Cursor, x + 64, y + (LineHeight * 0.95f - FontSize) / 2.f, FontSize, TEXTFLAG_RENDER | TEXTFLAG_STOP_AT_END);
 		Cursor.m_LineWidth = 220;
-		TextRender()->TextEx(&Cursor, m_pClient->m_aClients[pInfo->m_ClientID].m_aName, -1);
+		TextRender()->TextEx(&Cursor, m_pClient->m_aClients[pInfo->m_ClientId].m_aName, -1);
 
 		px = 325;
 
@@ -464,7 +464,7 @@ void CStatboard::FormatStats(char *pDest, size_t DestSize)
 	// sort red or dm players by score
 	for(const auto *pInfo : m_pClient->m_Snap.m_apInfoByScore)
 	{
-		if(!pInfo || !m_pClient->m_aStats[pInfo->m_ClientID].IsActive() || m_pClient->m_aClients[pInfo->m_ClientID].m_Team != TEAM_RED)
+		if(!pInfo || !m_pClient->m_aStats[pInfo->m_ClientId].IsActive() || m_pClient->m_aClients[pInfo->m_ClientId].m_Team != TEAM_RED)
 			continue;
 		apPlayers[NumPlayers] = pInfo;
 		NumPlayers++;
@@ -475,7 +475,7 @@ void CStatboard::FormatStats(char *pDest, size_t DestSize)
 	{
 		for(const auto *pInfo : m_pClient->m_Snap.m_apInfoByScore)
 		{
-			if(!pInfo || !m_pClient->m_aStats[pInfo->m_ClientID].IsActive() || m_pClient->m_aClients[pInfo->m_ClientID].m_Team != TEAM_BLUE)
+			if(!pInfo || !m_pClient->m_aStats[pInfo->m_ClientId].IsActive() || m_pClient->m_aClients[pInfo->m_ClientId].m_Team != TEAM_BLUE)
 				continue;
 			apPlayers[NumPlayers] = pInfo;
 			NumPlayers++;
@@ -487,7 +487,7 @@ void CStatboard::FormatStats(char *pDest, size_t DestSize)
 	for(int i = 0; i < NumPlayers; i++)
 	{
 		const CNetObj_PlayerInfo *pInfo = apPlayers[i];
-		const CGameClient::CClientStats *pStats = &m_pClient->m_aStats[pInfo->m_ClientID];
+		const CGameClient::CClientStats *pStats = &m_pClient->m_aStats[pInfo->m_ClientId];
 
 		// Pre-formatting
 
@@ -507,7 +507,7 @@ void CStatboard::FormatStats(char *pDest, size_t DestSize)
 			fdratio = (float)(pStats->m_Frags) / pStats->m_Deaths;
 
 		// Local player
-		bool localPlayer = (m_pClient->m_Snap.m_LocalClientID == pInfo->m_ClientID || (m_pClient->m_Snap.m_SpecInfo.m_Active && pInfo->m_ClientID == m_pClient->m_Snap.m_SpecInfo.m_SpectatorID));
+		bool localPlayer = (m_pClient->m_Snap.m_LocalClientId == pInfo->m_ClientId || (m_pClient->m_Snap.m_SpecInfo.m_Active && pInfo->m_ClientId == m_pClient->m_Snap.m_SpecInfo.m_SpectatorId));
 
 		// Game with flags
 		bool GameWithFlags = (m_pClient->m_Snap.m_pGameInfoObj && m_pClient->m_Snap.m_pGameInfoObj->m_GameFlags & GAMEFLAG_FLAGS);
@@ -515,9 +515,9 @@ void CStatboard::FormatStats(char *pDest, size_t DestSize)
 		char aBuf[1024];
 		str_format(aBuf, sizeof(aBuf), "%d,%d,%s,%s,%d,%d,%d,%d,%.2f,%i,%.1f,%d,%d,%s,%d,%d,%d\n",
 			localPlayer ? 1 : 0, // Local player
-			m_pClient->m_aClients[pInfo->m_ClientID].m_Team, // Team
-			ReplaceCommata(m_pClient->m_aClients[pInfo->m_ClientID].m_aName).c_str(), // Name
-			ReplaceCommata(m_pClient->m_aClients[pInfo->m_ClientID].m_aClan).c_str(), // Clan
+			m_pClient->m_aClients[pInfo->m_ClientId].m_Team, // Team
+			ReplaceCommata(m_pClient->m_aClients[pInfo->m_ClientId].m_aName).c_str(), // Name
+			ReplaceCommata(m_pClient->m_aClients[pInfo->m_ClientId].m_aClan).c_str(), // Clan
 			clamp(pInfo->m_Score, -999, 999), // Score
 			pStats->m_Frags, // Frags
 			pStats->m_Deaths, // Deaths

--- a/src/game/client/components/tooltips.cpp
+++ b/src/game/client/components/tooltips.cpp
@@ -26,11 +26,11 @@ inline void CTooltips::ClearActiveTooltip()
 	m_PreviousTooltip.reset();
 }
 
-void CTooltips::DoToolTip(const void *pID, const CUIRect *pNearRect, const char *pText, float WidthHint)
+void CTooltips::DoToolTip(const void *pId, const CUIRect *pNearRect, const char *pText, float WidthHint)
 {
-	uintptr_t ID = reinterpret_cast<uintptr_t>(pID);
-	const auto result = m_Tooltips.emplace(ID, CTooltip{
-							   pID,
+	uintptr_t Id = reinterpret_cast<uintptr_t>(pId);
+	const auto result = m_Tooltips.emplace(Id, CTooltip{
+							   pId,
 							   *pNearRect,
 							   pText,
 							   WidthHint,
@@ -45,7 +45,7 @@ void CTooltips::DoToolTip(const void *pID, const CUIRect *pNearRect, const char 
 
 	Tooltip.m_OnScreen = true;
 
-	if(UI()->HotItem() == Tooltip.m_pID)
+	if(Ui()->HotItem() == Tooltip.m_pId)
 	{
 		SetActiveTooltip(Tooltip);
 	}
@@ -57,7 +57,7 @@ void CTooltips::OnRender()
 	{
 		CTooltip &Tooltip = m_ActiveTooltip.value();
 
-		if(UI()->HotItem() != Tooltip.m_pID)
+		if(Ui()->HotItem() != Tooltip.m_pId)
 		{
 			Tooltip.m_OnScreen = false;
 			ClearActiveTooltip();
@@ -91,33 +91,33 @@ void CTooltips::OnRender()
 		Rect.w = BoundingBox.m_W + 2 * Padding;
 		Rect.h = BoundingBox.m_H + 2 * Padding;
 
-		const CUIRect *pScreen = UI()->Screen();
+		const CUIRect *pScreen = Ui()->Screen();
 		Rect.w = minimum(Rect.w, pScreen->w - 2 * Margin);
 		Rect.h = minimum(Rect.h, pScreen->h - 2 * Margin);
 
 		// Try the top side.
 		if(Tooltip.m_Rect.y - Rect.h - Margin > pScreen->y)
 		{
-			Rect.x = clamp(UI()->MouseX() - Rect.w / 2.0f, Margin, pScreen->w - Rect.w - Margin);
+			Rect.x = clamp(Ui()->MouseX() - Rect.w / 2.0f, Margin, pScreen->w - Rect.w - Margin);
 			Rect.y = Tooltip.m_Rect.y - Rect.h - Margin;
 		}
 		// Try the bottom side.
 		else if(Tooltip.m_Rect.y + Tooltip.m_Rect.h + Margin < pScreen->h)
 		{
-			Rect.x = clamp(UI()->MouseX() - Rect.w / 2.0f, Margin, pScreen->w - Rect.w - Margin);
+			Rect.x = clamp(Ui()->MouseX() - Rect.w / 2.0f, Margin, pScreen->w - Rect.w - Margin);
 			Rect.y = Tooltip.m_Rect.y + Tooltip.m_Rect.h + Margin;
 		}
 		// Try the right side.
 		else if(Tooltip.m_Rect.x + Tooltip.m_Rect.w + Margin + Rect.w < pScreen->w)
 		{
 			Rect.x = Tooltip.m_Rect.x + Tooltip.m_Rect.w + Margin;
-			Rect.y = clamp(UI()->MouseY() - Rect.h / 2.0f, Margin, pScreen->h - Rect.h - Margin);
+			Rect.y = clamp(Ui()->MouseY() - Rect.h / 2.0f, Margin, pScreen->h - Rect.h - Margin);
 		}
 		// Try the left side.
 		else if(Tooltip.m_Rect.x - Rect.w - Margin > pScreen->x)
 		{
 			Rect.x = Tooltip.m_Rect.x - Rect.w - Margin;
-			Rect.y = clamp(UI()->MouseY() - Rect.h / 2.0f, Margin, pScreen->h - Rect.h - Margin);
+			Rect.y = clamp(Ui()->MouseY() - Rect.h / 2.0f, Margin, pScreen->h - Rect.h - Margin);
 		}
 
 		Rect.Draw(ColorRGBA(0.2f, 0.2f, 0.2f, 0.8f * AlphaFactor), IGraphics::CORNER_ALL, Padding);

--- a/src/game/client/components/tooltips.h
+++ b/src/game/client/components/tooltips.h
@@ -11,7 +11,7 @@
 
 struct CTooltip
 {
-	const void *m_pID;
+	const void *m_pId;
 	CUIRect m_Rect;
 	const char *m_pText;
 	float m_WidthHint;
@@ -47,12 +47,12 @@ public:
 	 * On the first call to this function, the data passed is cached, afterwards the calls are used to detect if the tooltip should be activated.
 	 * If multiple tooltips cover the same rect or the rects intersect, then the tooltip that is added later has priority.
 	 *
-	 * @param pID The ID of the tooltip. Usually a reference to some g_Config value.
+	 * @param pId The ID of the tooltip. Usually a reference to some g_Config value.
 	 * @param pNearRect Place the tooltip near this rect.
 	 * @param pText The text to display in the tooltip.
 	 * @param WidthHint The maximum width of the tooltip, or -1.0f for unlimited.
 	 */
-	void DoToolTip(const void *pID, const CUIRect *pNearRect, const char *pText, float WidthHint = -1.0f);
+	void DoToolTip(const void *pId, const CUIRect *pNearRect, const char *pText, float WidthHint = -1.0f);
 
 	virtual void OnReset() override;
 	virtual void OnRender() override;

--- a/src/game/client/components/voting.cpp
+++ b/src/game/client/components/voting.cpp
@@ -36,44 +36,44 @@ void CVoting::Callvote(const char *pType, const char *pValue, const char *pReaso
 	Client()->SendPackMsgActive(&Msg, MSGFLAG_VITAL);
 }
 
-void CVoting::CallvoteSpectate(int ClientID, const char *pReason, bool ForceVote)
+void CVoting::CallvoteSpectate(int ClientId, const char *pReason, bool ForceVote)
 {
 	if(ForceVote)
 	{
 		char aBuf[128];
-		str_format(aBuf, sizeof(aBuf), "set_team %d -1", ClientID);
+		str_format(aBuf, sizeof(aBuf), "set_team %d -1", ClientId);
 		Client()->Rcon(aBuf);
 	}
 	else
 	{
 		char aBuf[32];
-		str_from_int(ClientID, aBuf);
+		str_from_int(ClientId, aBuf);
 		Callvote("spectate", aBuf, pReason);
 	}
 }
 
-void CVoting::CallvoteKick(int ClientID, const char *pReason, bool ForceVote)
+void CVoting::CallvoteKick(int ClientId, const char *pReason, bool ForceVote)
 {
 	if(ForceVote)
 	{
 		char aBuf[128];
-		str_format(aBuf, sizeof(aBuf), "force_vote kick %d %s", ClientID, pReason);
+		str_format(aBuf, sizeof(aBuf), "force_vote kick %d %s", ClientId, pReason);
 		Client()->Rcon(aBuf);
 	}
 	else
 	{
 		char aBuf[32];
-		str_from_int(ClientID, aBuf);
+		str_from_int(ClientId, aBuf);
 		Callvote("kick", aBuf, pReason);
 	}
 }
 
-void CVoting::CallvoteOption(int OptionID, const char *pReason, bool ForceVote)
+void CVoting::CallvoteOption(int OptionId, const char *pReason, bool ForceVote)
 {
 	CVoteOptionClient *pOption = m_pFirst;
-	while(pOption && OptionID >= 0)
+	while(pOption && OptionId >= 0)
 	{
-		if(OptionID == 0)
+		if(OptionId == 0)
 		{
 			if(ForceVote)
 			{
@@ -92,17 +92,17 @@ void CVoting::CallvoteOption(int OptionID, const char *pReason, bool ForceVote)
 			break;
 		}
 
-		OptionID--;
+		OptionId--;
 		pOption = pOption->m_pNext;
 	}
 }
 
-void CVoting::RemovevoteOption(int OptionID)
+void CVoting::RemovevoteOption(int OptionId)
 {
 	CVoteOptionClient *pOption = m_pFirst;
-	while(pOption && OptionID >= 0)
+	while(pOption && OptionId >= 0)
 	{
-		if(OptionID == 0)
+		if(OptionId == 0)
 		{
 			char aBuf[128];
 			str_copy(aBuf, "remove_vote \"");
@@ -113,7 +113,7 @@ void CVoting::RemovevoteOption(int OptionID)
 			break;
 		}
 
-		OptionID--;
+		OptionId--;
 		pOption = pOption->m_pNext;
 	}
 }
@@ -349,18 +349,18 @@ void CVoting::Render()
 
 	SProgressSpinnerProperties ProgressProps;
 	ProgressProps.m_Progress = clamp((time() - m_Opentime) / (float)(m_Closetime - m_Opentime), 0.0f, 1.0f);
-	UI()->RenderProgressSpinner(ProgressSpinner.Center(), ProgressSpinner.h / 2.0f, ProgressProps);
+	Ui()->RenderProgressSpinner(ProgressSpinner.Center(), ProgressSpinner.h / 2.0f, ProgressProps);
 
-	UI()->DoLabel(&RightColumn, aBuf, 6.0f, TEXTALIGN_MR);
+	Ui()->DoLabel(&RightColumn, aBuf, 6.0f, TEXTALIGN_MR);
 
 	Props.m_MaxWidth = LeftColumn.w;
-	UI()->DoLabel(&LeftColumn, VoteDescription(), 6.0f, TEXTALIGN_ML, Props);
+	Ui()->DoLabel(&LeftColumn, VoteDescription(), 6.0f, TEXTALIGN_ML, Props);
 
 	View.HSplitTop(3.0f, nullptr, &View);
 	View.HSplitTop(6.0f, &Row, &View);
 	str_format(aBuf, sizeof(aBuf), "%s %s", Localize("Reason:"), VoteReason());
 	Props.m_MaxWidth = Row.w;
-	UI()->DoLabel(&Row, aBuf, 6.0f, TEXTALIGN_ML, Props);
+	Ui()->DoLabel(&Row, aBuf, 6.0f, TEXTALIGN_ML, Props);
 
 	View.HSplitTop(3.0f, nullptr, &View);
 	View.HSplitTop(4.0f, &Row, &View);
@@ -374,12 +374,12 @@ void CVoting::Render()
 	m_pClient->m_Binds.GetKey("vote yes", aKey, sizeof(aKey));
 	str_format(aBuf, sizeof(aBuf), "%s - %s", aKey, Localize("Vote yes"));
 	TextRender()->TextColor(TakenChoice() == 1 ? ColorRGBA(0.2f, 0.9f, 0.2f, 0.85f) : TextRender()->DefaultTextColor());
-	UI()->DoLabel(&LeftColumn, aBuf, 6.0f, TEXTALIGN_ML);
+	Ui()->DoLabel(&LeftColumn, aBuf, 6.0f, TEXTALIGN_ML);
 
 	m_pClient->m_Binds.GetKey("vote no", aKey, sizeof(aKey));
 	str_format(aBuf, sizeof(aBuf), "%s - %s", Localize("Vote no"), aKey);
 	TextRender()->TextColor(TakenChoice() == -1 ? ColorRGBA(0.95f, 0.25f, 0.25f, 0.85f) : TextRender()->DefaultTextColor());
-	UI()->DoLabel(&RightColumn, aBuf, 6.0f, TEXTALIGN_MR);
+	Ui()->DoLabel(&RightColumn, aBuf, 6.0f, TEXTALIGN_MR);
 
 	TextRender()->TextColor(TextRender()->DefaultTextColor());
 }

--- a/src/game/client/components/voting.h
+++ b/src/game/client/components/voting.h
@@ -49,10 +49,10 @@ public:
 
 	void Render();
 
-	void CallvoteSpectate(int ClientID, const char *pReason, bool ForceVote = false);
-	void CallvoteKick(int ClientID, const char *pReason, bool ForceVote = false);
-	void CallvoteOption(int OptionID, const char *pReason, bool ForceVote = false);
-	void RemovevoteOption(int OptionID);
+	void CallvoteSpectate(int ClientId, const char *pReason, bool ForceVote = false);
+	void CallvoteKick(int ClientId, const char *pReason, bool ForceVote = false);
+	void CallvoteOption(int OptionId, const char *pReason, bool ForceVote = false);
+	void RemovevoteOption(int OptionId);
 	void AddvoteOption(const char *pDescription, const char *pCommand);
 
 	void Vote(int v); // -1 = no, 1 = yes

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -370,7 +370,7 @@ void CGameClient::OnUpdate()
 {
 	HandleLanguageChanged();
 
-	CUIElementBase::Init(UI()); // update static pointer because game and editor use separate UI
+	CUIElementBase::Init(Ui()); // update static pointer because game and editor use separate UI
 
 	// handle mouse movement
 	float x = 0.0f, y = 0.0f;
@@ -459,7 +459,7 @@ int CGameClient::OnSnapInput(int *pData, bool Dummy, bool Force)
 		}
 
 		vec2 MainPos = m_LocalCharacterPos;
-		vec2 DummyPos = m_aClients[m_aLocalIDs[!g_Config.m_ClDummy]].m_Predicted.m_Pos;
+		vec2 DummyPos = m_aClients[m_aLocalIds[!g_Config.m_ClDummy]].m_Predicted.m_Pos;
 		vec2 Dir = MainPos - DummyPos;
 		m_HammerInput.m_TargetX = (int)(Dir.x);
 		m_HammerInput.m_TargetY = (int)(Dir.y);
@@ -517,7 +517,7 @@ void CGameClient::OnConnected()
 	m_GameWorld.Clear();
 	m_GameWorld.m_WorldConfig.m_InfiniteAmmo = true;
 	mem_zero(&m_GameInfo, sizeof(m_GameInfo));
-	m_PredictedDummyID = -1;
+	m_PredictedDummyId = -1;
 	ConfigManager()->ResetGameSettings();
 	LoadMapSettings();
 
@@ -547,7 +547,7 @@ void CGameClient::OnReset()
 	for(auto &pComponent : m_vpAll)
 		pComponent->OnReset();
 
-	m_DemoSpecID = SPEC_FOLLOW;
+	m_DemoSpecId = SPEC_FOLLOW;
 	m_aFlagDropTick[TEAM_RED] = 0;
 	m_aFlagDropTick[TEAM_BLUE] = 0;
 	m_LastRoundStartTick = -1;
@@ -612,17 +612,17 @@ void CGameClient::UpdatePositions()
 		{
 			HandleMultiView();
 		}
-		else if(Client()->State() == IClient::STATE_DEMOPLAYBACK && m_DemoSpecID != SPEC_FOLLOW && m_Snap.m_SpecInfo.m_SpectatorID != SPEC_FREEVIEW)
+		else if(Client()->State() == IClient::STATE_DEMOPLAYBACK && m_DemoSpecId != SPEC_FOLLOW && m_Snap.m_SpecInfo.m_SpectatorId != SPEC_FREEVIEW)
 		{
 			m_Snap.m_SpecInfo.m_Position = mix(
-				vec2(m_Snap.m_aCharacters[m_Snap.m_SpecInfo.m_SpectatorID].m_Prev.m_X, m_Snap.m_aCharacters[m_Snap.m_SpecInfo.m_SpectatorID].m_Prev.m_Y),
-				vec2(m_Snap.m_aCharacters[m_Snap.m_SpecInfo.m_SpectatorID].m_Cur.m_X, m_Snap.m_aCharacters[m_Snap.m_SpecInfo.m_SpectatorID].m_Cur.m_Y),
+				vec2(m_Snap.m_aCharacters[m_Snap.m_SpecInfo.m_SpectatorId].m_Prev.m_X, m_Snap.m_aCharacters[m_Snap.m_SpecInfo.m_SpectatorId].m_Prev.m_Y),
+				vec2(m_Snap.m_aCharacters[m_Snap.m_SpecInfo.m_SpectatorId].m_Cur.m_X, m_Snap.m_aCharacters[m_Snap.m_SpecInfo.m_SpectatorId].m_Cur.m_Y),
 				Client()->IntraGameTick(g_Config.m_ClDummy));
 			m_Snap.m_SpecInfo.m_UsePosition = true;
 		}
-		else if(m_Snap.m_pSpectatorInfo && ((Client()->State() == IClient::STATE_DEMOPLAYBACK && m_DemoSpecID == SPEC_FOLLOW) || (Client()->State() != IClient::STATE_DEMOPLAYBACK && m_Snap.m_SpecInfo.m_SpectatorID != SPEC_FREEVIEW)))
+		else if(m_Snap.m_pSpectatorInfo && ((Client()->State() == IClient::STATE_DEMOPLAYBACK && m_DemoSpecId == SPEC_FOLLOW) || (Client()->State() != IClient::STATE_DEMOPLAYBACK && m_Snap.m_SpecInfo.m_SpectatorId != SPEC_FREEVIEW)))
 		{
-			if(m_Snap.m_pPrevSpectatorInfo && m_Snap.m_pPrevSpectatorInfo->m_SpectatorID == m_Snap.m_pSpectatorInfo->m_SpectatorID)
+			if(m_Snap.m_pPrevSpectatorInfo && m_Snap.m_pPrevSpectatorInfo->m_SpectatorId == m_Snap.m_pSpectatorInfo->m_SpectatorId)
 				m_Snap.m_SpecInfo.m_Position = mix(vec2(m_Snap.m_pPrevSpectatorInfo->m_X, m_Snap.m_pPrevSpectatorInfo->m_Y),
 					vec2(m_Snap.m_pSpectatorInfo->m_X, m_Snap.m_pSpectatorInfo->m_Y), Client()->IntraGameTick(g_Config.m_ClDummy));
 			else
@@ -643,8 +643,8 @@ void CGameClient::OnRender()
 	if(!m_MultiView.m_IsInit && m_MultiViewActivated)
 	{
 		int TeamId = 0;
-		if(m_Snap.m_SpecInfo.m_SpectatorID >= 0)
-			TeamId = m_Teams.Team(m_Snap.m_SpecInfo.m_SpectatorID);
+		if(m_Snap.m_SpecInfo.m_SpectatorId >= 0)
+			TeamId = m_Teams.Team(m_Snap.m_SpecInfo.m_SpectatorId);
 
 		if(TeamId > MAX_CLIENTS || TeamId < 0)
 			TeamId = 0;
@@ -691,13 +691,13 @@ void CGameClient::OnRender()
 		if(m_aCheckInfo[0] == 0)
 		{
 			if(
-				str_comp(m_aClients[m_aLocalIDs[0]].m_aName, Client()->PlayerName()) ||
-				str_comp(m_aClients[m_aLocalIDs[0]].m_aClan, g_Config.m_PlayerClan) ||
-				m_aClients[m_aLocalIDs[0]].m_Country != g_Config.m_PlayerCountry ||
-				str_comp(m_aClients[m_aLocalIDs[0]].m_aSkinName, g_Config.m_ClPlayerSkin) ||
-				m_aClients[m_aLocalIDs[0]].m_UseCustomColor != g_Config.m_ClPlayerUseCustomColor ||
-				m_aClients[m_aLocalIDs[0]].m_ColorBody != (int)g_Config.m_ClPlayerColorBody ||
-				m_aClients[m_aLocalIDs[0]].m_ColorFeet != (int)g_Config.m_ClPlayerColorFeet)
+				str_comp(m_aClients[m_aLocalIds[0]].m_aName, Client()->PlayerName()) ||
+				str_comp(m_aClients[m_aLocalIds[0]].m_aClan, g_Config.m_PlayerClan) ||
+				m_aClients[m_aLocalIds[0]].m_Country != g_Config.m_PlayerCountry ||
+				str_comp(m_aClients[m_aLocalIds[0]].m_aSkinName, g_Config.m_ClPlayerSkin) ||
+				m_aClients[m_aLocalIds[0]].m_UseCustomColor != g_Config.m_ClPlayerUseCustomColor ||
+				m_aClients[m_aLocalIds[0]].m_ColorBody != (int)g_Config.m_ClPlayerColorBody ||
+				m_aClients[m_aLocalIds[0]].m_ColorFeet != (int)g_Config.m_ClPlayerColorFeet)
 				SendInfo(false);
 			else
 				m_aCheckInfo[0] = -1;
@@ -711,13 +711,13 @@ void CGameClient::OnRender()
 			if(m_aCheckInfo[1] == 0)
 			{
 				if(
-					str_comp(m_aClients[m_aLocalIDs[1]].m_aName, Client()->DummyName()) ||
-					str_comp(m_aClients[m_aLocalIDs[1]].m_aClan, g_Config.m_ClDummyClan) ||
-					m_aClients[m_aLocalIDs[1]].m_Country != g_Config.m_ClDummyCountry ||
-					str_comp(m_aClients[m_aLocalIDs[1]].m_aSkinName, g_Config.m_ClDummySkin) ||
-					m_aClients[m_aLocalIDs[1]].m_UseCustomColor != g_Config.m_ClDummyUseCustomColor ||
-					m_aClients[m_aLocalIDs[1]].m_ColorBody != (int)g_Config.m_ClDummyColorBody ||
-					m_aClients[m_aLocalIDs[1]].m_ColorFeet != (int)g_Config.m_ClDummyColorFeet)
+					str_comp(m_aClients[m_aLocalIds[1]].m_aName, Client()->DummyName()) ||
+					str_comp(m_aClients[m_aLocalIds[1]].m_aClan, g_Config.m_ClDummyClan) ||
+					m_aClients[m_aLocalIds[1]].m_Country != g_Config.m_ClDummyCountry ||
+					str_comp(m_aClients[m_aLocalIds[1]].m_aSkinName, g_Config.m_ClDummySkin) ||
+					m_aClients[m_aLocalIds[1]].m_UseCustomColor != g_Config.m_ClDummyUseCustomColor ||
+					m_aClients[m_aLocalIds[1]].m_ColorBody != (int)g_Config.m_ClDummyColorBody ||
+					m_aClients[m_aLocalIds[1]].m_ColorFeet != (int)g_Config.m_ClDummyColorFeet)
 					SendDummyInfo(false);
 				else
 					m_aCheckInfo[1] = -1;
@@ -734,7 +734,7 @@ void CGameClient::OnDummyDisconnect()
 	m_aDDRaceMsgSent[1] = false;
 	m_aShowOthers[1] = SHOW_OTHERS_NOT_SET;
 	m_aLastNewPredictedTick[1] = -1;
-	m_PredictedDummyID = -1;
+	m_PredictedDummyId = -1;
 }
 
 int CGameClient::GetLastRaceTick() const
@@ -816,11 +816,11 @@ void CGameClient::OnMessage(int MsgId, CUnpacker *pUnpacker, int Conn, bool Dumm
 
 	if(Dummy)
 	{
-		if(MsgId == NETMSGTYPE_SV_CHAT && m_aLocalIDs[0] >= 0 && m_aLocalIDs[1] >= 0)
+		if(MsgId == NETMSGTYPE_SV_CHAT && m_aLocalIds[0] >= 0 && m_aLocalIds[1] >= 0)
 		{
 			CNetMsg_Sv_Chat *pMsg = (CNetMsg_Sv_Chat *)pRawMsg;
 
-			if((pMsg->m_Team == 1 && (m_aClients[m_aLocalIDs[0]].m_Team != m_aClients[m_aLocalIDs[1]].m_Team || m_Teams.Team(m_aLocalIDs[0]) != m_Teams.Team(m_aLocalIDs[1]))) || pMsg->m_Team > 1)
+			if((pMsg->m_Team == 1 && (m_aClients[m_aLocalIds[0]].m_Team != m_aClients[m_aLocalIds[1]].m_Team || m_Teams.Team(m_aLocalIds[0]) != m_Teams.Team(m_aLocalIds[1]))) || pMsg->m_Team > 1)
 			{
 				m_Chat.OnMessage(MsgId, pRawMsg);
 			}
@@ -841,9 +841,9 @@ void CGameClient::OnMessage(int MsgId, CUnpacker *pUnpacker, int Conn, bool Dumm
 		CNetMsg_Sv_Emoticon *pMsg = (CNetMsg_Sv_Emoticon *)pRawMsg;
 
 		// apply
-		m_aClients[pMsg->m_ClientID].m_Emoticon = pMsg->m_Emoticon;
-		m_aClients[pMsg->m_ClientID].m_EmoticonStartTick = Client()->GameTick(Conn);
-		m_aClients[pMsg->m_ClientID].m_EmoticonStartFraction = Client()->IntraGameTickSincePrev(Conn);
+		m_aClients[pMsg->m_ClientId].m_Emoticon = pMsg->m_Emoticon;
+		m_aClients[pMsg->m_ClientId].m_EmoticonStartTick = Client()->GameTick(Conn);
+		m_aClients[pMsg->m_ClientId].m_EmoticonStartFraction = Client()->IntraGameTickSincePrev(Conn);
 	}
 	else if(MsgId == NETMSGTYPE_SV_SOUNDGLOBAL)
 	{
@@ -852,17 +852,17 @@ void CGameClient::OnMessage(int MsgId, CUnpacker *pUnpacker, int Conn, bool Dumm
 
 		// don't enqueue pseudo-global sounds from demos (created by PlayAndRecord)
 		CNetMsg_Sv_SoundGlobal *pMsg = (CNetMsg_Sv_SoundGlobal *)pRawMsg;
-		if(pMsg->m_SoundID == SOUND_CTF_DROP || pMsg->m_SoundID == SOUND_CTF_RETURN ||
-			pMsg->m_SoundID == SOUND_CTF_CAPTURE || pMsg->m_SoundID == SOUND_CTF_GRAB_EN ||
-			pMsg->m_SoundID == SOUND_CTF_GRAB_PL)
+		if(pMsg->m_SoundId == SOUND_CTF_DROP || pMsg->m_SoundId == SOUND_CTF_RETURN ||
+			pMsg->m_SoundId == SOUND_CTF_CAPTURE || pMsg->m_SoundId == SOUND_CTF_GRAB_EN ||
+			pMsg->m_SoundId == SOUND_CTF_GRAB_PL)
 		{
 			if(g_Config.m_SndGame)
-				m_Sounds.Enqueue(CSounds::CHN_GLOBAL, pMsg->m_SoundID);
+				m_Sounds.Enqueue(CSounds::CHN_GLOBAL, pMsg->m_SoundId);
 		}
 		else
 		{
 			if(g_Config.m_SndGame)
-				m_Sounds.Play(CSounds::CHN_GLOBAL, pMsg->m_SoundID, 1.0f);
+				m_Sounds.Play(CSounds::CHN_GLOBAL, pMsg->m_SoundId, 1.0f);
 		}
 	}
 	else if(MsgId == NETMSGTYPE_SV_TEAMSSTATE || MsgId == NETMSGTYPE_SV_TEAMSSTATELEGACY)
@@ -894,7 +894,7 @@ void CGameClient::OnMessage(int MsgId, CUnpacker *pUnpacker, int Conn, bool Dumm
 		if(!(m_GameWorld.m_WorldConfig.m_IsFNG && pMsg->m_Weapon == WEAPON_LASER))
 		{
 			m_CharOrder.GiveWeak(pMsg->m_Victim);
-			if(CCharacter *pChar = m_GameWorld.GetCharacterByID(pMsg->m_Victim))
+			if(CCharacter *pChar = m_GameWorld.GetCharacterById(pMsg->m_Victim))
 				pChar->ResetPrediction();
 			m_GameWorld.ReleaseHooked(pMsg->m_Victim);
 		}
@@ -910,14 +910,14 @@ void CGameClient::OnMessage(int MsgId, CUnpacker *pUnpacker, int Conn, bool Dumm
 			else
 			{
 				// the "main" tee killed, search a new one
-				if(m_Snap.m_SpecInfo.m_SpectatorID == pMsg->m_Victim)
+				if(m_Snap.m_SpecInfo.m_SpectatorId == pMsg->m_Victim)
 				{
-					int NewClientID = FindFirstMultiViewId();
-					if(NewClientID < MAX_CLIENTS && NewClientID >= 0)
+					int NewClientId = FindFirstMultiViewId();
+					if(NewClientId < MAX_CLIENTS && NewClientId >= 0)
 					{
-						CleanMultiViewId(NewClientID);
-						m_aMultiViewId[NewClientID] = true;
-						m_Spectator.Spectate(NewClientID);
+						CleanMultiViewId(NewClientId);
+						m_aMultiViewId[NewClientId] = true;
+						m_Spectator.Spectate(NewClientId);
 					}
 				}
 			}
@@ -933,18 +933,18 @@ void CGameClient::OnMessage(int MsgId, CUnpacker *pUnpacker, int Conn, bool Dumm
 		{
 			if(m_Teams.Team(i) == pMsg->m_Team)
 			{
-				if(CCharacter *pChar = m_GameWorld.GetCharacterByID(i))
+				if(CCharacter *pChar = m_GameWorld.GetCharacterById(i))
 				{
 					pChar->ResetPrediction();
-					vStrongWeakSorted.emplace_back(i, pMsg->m_First == i ? MAX_CLIENTS : pChar ? pChar->GetStrongWeakID() : 0);
+					vStrongWeakSorted.emplace_back(i, pMsg->m_First == i ? MAX_CLIENTS : pChar ? pChar->GetStrongWeakId() : 0);
 				}
 				m_GameWorld.ReleaseHooked(i);
 			}
 		}
 		std::stable_sort(vStrongWeakSorted.begin(), vStrongWeakSorted.end(), [](auto &Left, auto &Right) { return Left.second > Right.second; });
-		for(auto ID : vStrongWeakSorted)
+		for(auto Id : vStrongWeakSorted)
 		{
-			m_CharOrder.GiveWeak(ID.first);
+			m_CharOrder.GiveWeak(Id.first);
 		}
 	}
 	else if(MsgId == NETMSGTYPE_SV_CHANGEINFOCOOLDOWN)
@@ -1000,9 +1000,9 @@ void CGameClient::OnStartRound()
 	m_RaceDemo.OnReset();
 }
 
-void CGameClient::OnFlagGrab(int TeamID)
+void CGameClient::OnFlagGrab(int TeamId)
 {
-	if(TeamID == TEAM_RED)
+	if(TeamId == TEAM_RED)
 		m_aStats[m_Snap.m_pGameDataObj->m_FlagCarrierRed].m_FlagGrabs++;
 	else
 		m_aStats[m_Snap.m_pGameDataObj->m_FlagCarrierBlue].m_FlagGrabs++;
@@ -1013,7 +1013,7 @@ void CGameClient::OnWindowResize()
 	for(auto &pComponent : m_vpAll)
 		pComponent->OnWindowResize();
 
-	UI()->OnWindowResize();
+	Ui()->OnWindowResize();
 }
 
 void CGameClient::OnLanguageChange()
@@ -1049,9 +1049,9 @@ void CGameClient::RenderShutdownMessage()
 
 	// This function only gets called after the render loop has already terminated, so we have to call Swap manually.
 	Graphics()->Clear(0.0f, 0.0f, 0.0f);
-	UI()->MapScreen();
+	Ui()->MapScreen();
 	TextRender()->TextColor(TextRender()->DefaultTextColor());
-	UI()->DoLabel(UI()->Screen(), pMessage, 16.0f, TEXTALIGN_MC);
+	Ui()->DoLabel(Ui()->Screen(), pMessage, 16.0f, TEXTALIGN_MC);
 	Graphics()->Swap();
 	Graphics()->Clear(0.0f, 0.0f, 0.0f);
 }
@@ -1104,7 +1104,7 @@ void CGameClient::ProcessEvents()
 		else if(Item.m_Type == NETEVENTTYPE_DEATH)
 		{
 			CNetEvent_Death *pEvent = (CNetEvent_Death *)pData;
-			m_Effects.PlayerDeath(vec2(pEvent->m_X, pEvent->m_Y), pEvent->m_ClientID, Alpha);
+			m_Effects.PlayerDeath(vec2(pEvent->m_X, pEvent->m_Y), pEvent->m_ClientId, Alpha);
 		}
 		else if(Item.m_Type == NETEVENTTYPE_SOUNDWORLD)
 		{
@@ -1112,10 +1112,10 @@ void CGameClient::ProcessEvents()
 			if(!Config()->m_SndGame)
 				continue;
 
-			if(m_GameInfo.m_RaceSounds && ((pEvent->m_SoundID == SOUND_GUN_FIRE && !g_Config.m_SndGun) || (pEvent->m_SoundID == SOUND_PLAYER_PAIN_LONG && !g_Config.m_SndLongPain)))
+			if(m_GameInfo.m_RaceSounds && ((pEvent->m_SoundId == SOUND_GUN_FIRE && !g_Config.m_SndGun) || (pEvent->m_SoundId == SOUND_PLAYER_PAIN_LONG && !g_Config.m_SndLongPain)))
 				continue;
 
-			m_Sounds.PlayAt(CSounds::CHN_WORLD, pEvent->m_SoundID, 1.0f, vec2(pEvent->m_X, pEvent->m_Y));
+			m_Sounds.PlayAt(CSounds::CHN_WORLD, pEvent->m_SoundId, 1.0f, vec2(pEvent->m_X, pEvent->m_Y));
 		}
 	}
 }
@@ -1287,7 +1287,7 @@ void CGameClient::InvalidateSnapshot()
 {
 	// clear all pointers
 	mem_zero(&m_Snap, sizeof(m_Snap));
-	m_Snap.m_LocalClientID = -1;
+	m_Snap.m_LocalClientId = -1;
 	SnapCollectEntities();
 }
 
@@ -1359,10 +1359,10 @@ void CGameClient::OnNewSnapshot()
 			if(Item.m_Type == NETOBJTYPE_CLIENTINFO)
 			{
 				const CNetObj_ClientInfo *pInfo = (const CNetObj_ClientInfo *)pData;
-				int ClientID = Item.m_ID;
-				if(ClientID < MAX_CLIENTS)
+				int ClientId = Item.m_Id;
+				if(ClientId < MAX_CLIENTS)
 				{
-					CClientData *pClient = &m_aClients[ClientID];
+					CClientData *pClient = &m_aClients[ClientId];
 
 					IntsToStr(&pInfo->m_Name0, 4, pClient->m_aName);
 					IntsToStr(&pInfo->m_Clan0, 3, pClient->m_aClan);
@@ -1402,16 +1402,16 @@ void CGameClient::OnNewSnapshot()
 			{
 				const CNetObj_PlayerInfo *pInfo = (const CNetObj_PlayerInfo *)pData;
 
-				if(pInfo->m_ClientID < MAX_CLIENTS && pInfo->m_ClientID == Item.m_ID)
+				if(pInfo->m_ClientId < MAX_CLIENTS && pInfo->m_ClientId == Item.m_Id)
 				{
-					m_aClients[pInfo->m_ClientID].m_Team = pInfo->m_Team;
-					m_aClients[pInfo->m_ClientID].m_Active = true;
-					m_Snap.m_apPlayerInfos[pInfo->m_ClientID] = pInfo;
+					m_aClients[pInfo->m_ClientId].m_Team = pInfo->m_Team;
+					m_aClients[pInfo->m_ClientId].m_Active = true;
+					m_Snap.m_apPlayerInfos[pInfo->m_ClientId] = pInfo;
 					m_Snap.m_NumPlayers++;
 
 					if(pInfo->m_Local)
 					{
-						m_Snap.m_LocalClientID = pInfo->m_ClientID;
+						m_Snap.m_LocalClientId = pInfo->m_ClientId;
 						m_Snap.m_pLocalInfo = pInfo;
 
 						if(pInfo->m_Team == TEAM_SPECTATORS)
@@ -1424,25 +1424,25 @@ void CGameClient::OnNewSnapshot()
 					if(pInfo->m_Team != TEAM_SPECTATORS)
 					{
 						m_Snap.m_aTeamSize[pInfo->m_Team]++;
-						if(!m_aStats[pInfo->m_ClientID].IsActive())
-							m_aStats[pInfo->m_ClientID].JoinGame(Client()->GameTick(g_Config.m_ClDummy));
+						if(!m_aStats[pInfo->m_ClientId].IsActive())
+							m_aStats[pInfo->m_ClientId].JoinGame(Client()->GameTick(g_Config.m_ClDummy));
 					}
-					else if(m_aStats[pInfo->m_ClientID].IsActive())
-						m_aStats[pInfo->m_ClientID].JoinSpec(Client()->GameTick(g_Config.m_ClDummy));
+					else if(m_aStats[pInfo->m_ClientId].IsActive())
+						m_aStats[pInfo->m_ClientId].JoinSpec(Client()->GameTick(g_Config.m_ClDummy));
 				}
 			}
 			else if(Item.m_Type == NETOBJTYPE_DDNETPLAYER)
 			{
 				m_ReceivedDDNetPlayer = true;
 				const CNetObj_DDNetPlayer *pInfo = (const CNetObj_DDNetPlayer *)pData;
-				if(Item.m_ID < MAX_CLIENTS)
+				if(Item.m_Id < MAX_CLIENTS)
 				{
-					m_aClients[Item.m_ID].m_AuthLevel = pInfo->m_AuthLevel;
-					m_aClients[Item.m_ID].m_Afk = pInfo->m_Flags & EXPLAYERFLAG_AFK;
-					m_aClients[Item.m_ID].m_Paused = pInfo->m_Flags & EXPLAYERFLAG_PAUSED;
-					m_aClients[Item.m_ID].m_Spec = pInfo->m_Flags & EXPLAYERFLAG_SPEC;
+					m_aClients[Item.m_Id].m_AuthLevel = pInfo->m_AuthLevel;
+					m_aClients[Item.m_Id].m_Afk = pInfo->m_Flags & EXPLAYERFLAG_AFK;
+					m_aClients[Item.m_Id].m_Paused = pInfo->m_Flags & EXPLAYERFLAG_PAUSED;
+					m_aClients[Item.m_Id].m_Spec = pInfo->m_Flags & EXPLAYERFLAG_SPEC;
 
-					if(Item.m_ID == m_Snap.m_LocalClientID && (m_aClients[Item.m_ID].m_Paused || m_aClients[Item.m_ID].m_Spec))
+					if(Item.m_Id == m_Snap.m_LocalClientId && (m_aClients[Item.m_Id].m_Paused || m_aClients[Item.m_Id].m_Spec))
 					{
 						m_Snap.m_SpecInfo.m_Active = true;
 					}
@@ -1450,39 +1450,39 @@ void CGameClient::OnNewSnapshot()
 			}
 			else if(Item.m_Type == NETOBJTYPE_CHARACTER)
 			{
-				if(Item.m_ID < MAX_CLIENTS)
+				if(Item.m_Id < MAX_CLIENTS)
 				{
-					const void *pOld = Client()->SnapFindItem(IClient::SNAP_PREV, NETOBJTYPE_CHARACTER, Item.m_ID);
-					m_Snap.m_aCharacters[Item.m_ID].m_Cur = *((const CNetObj_Character *)pData);
+					const void *pOld = Client()->SnapFindItem(IClient::SNAP_PREV, NETOBJTYPE_CHARACTER, Item.m_Id);
+					m_Snap.m_aCharacters[Item.m_Id].m_Cur = *((const CNetObj_Character *)pData);
 					if(pOld)
 					{
-						m_Snap.m_aCharacters[Item.m_ID].m_Active = true;
-						m_Snap.m_aCharacters[Item.m_ID].m_Prev = *((const CNetObj_Character *)pOld);
+						m_Snap.m_aCharacters[Item.m_Id].m_Active = true;
+						m_Snap.m_aCharacters[Item.m_Id].m_Prev = *((const CNetObj_Character *)pOld);
 
 						// limit evolving to 3 seconds
-						bool EvolvePrev = Client()->PrevGameTick(g_Config.m_ClDummy) - m_Snap.m_aCharacters[Item.m_ID].m_Prev.m_Tick <= 3 * Client()->GameTickSpeed();
-						bool EvolveCur = Client()->GameTick(g_Config.m_ClDummy) - m_Snap.m_aCharacters[Item.m_ID].m_Cur.m_Tick <= 3 * Client()->GameTickSpeed();
+						bool EvolvePrev = Client()->PrevGameTick(g_Config.m_ClDummy) - m_Snap.m_aCharacters[Item.m_Id].m_Prev.m_Tick <= 3 * Client()->GameTickSpeed();
+						bool EvolveCur = Client()->GameTick(g_Config.m_ClDummy) - m_Snap.m_aCharacters[Item.m_Id].m_Cur.m_Tick <= 3 * Client()->GameTickSpeed();
 
 						// reuse the result from the previous evolve if the snapped character didn't change since the previous snapshot
-						if(EvolveCur && m_aClients[Item.m_ID].m_Evolved.m_Tick == Client()->PrevGameTick(g_Config.m_ClDummy))
+						if(EvolveCur && m_aClients[Item.m_Id].m_Evolved.m_Tick == Client()->PrevGameTick(g_Config.m_ClDummy))
 						{
-							if(mem_comp(&m_Snap.m_aCharacters[Item.m_ID].m_Prev, &m_aClients[Item.m_ID].m_Snapped, sizeof(CNetObj_Character)) == 0)
-								m_Snap.m_aCharacters[Item.m_ID].m_Prev = m_aClients[Item.m_ID].m_Evolved;
-							if(mem_comp(&m_Snap.m_aCharacters[Item.m_ID].m_Cur, &m_aClients[Item.m_ID].m_Snapped, sizeof(CNetObj_Character)) == 0)
-								m_Snap.m_aCharacters[Item.m_ID].m_Cur = m_aClients[Item.m_ID].m_Evolved;
+							if(mem_comp(&m_Snap.m_aCharacters[Item.m_Id].m_Prev, &m_aClients[Item.m_Id].m_Snapped, sizeof(CNetObj_Character)) == 0)
+								m_Snap.m_aCharacters[Item.m_Id].m_Prev = m_aClients[Item.m_Id].m_Evolved;
+							if(mem_comp(&m_Snap.m_aCharacters[Item.m_Id].m_Cur, &m_aClients[Item.m_Id].m_Snapped, sizeof(CNetObj_Character)) == 0)
+								m_Snap.m_aCharacters[Item.m_Id].m_Cur = m_aClients[Item.m_Id].m_Evolved;
 						}
 
-						if(EvolvePrev && m_Snap.m_aCharacters[Item.m_ID].m_Prev.m_Tick)
-							Evolve(&m_Snap.m_aCharacters[Item.m_ID].m_Prev, Client()->PrevGameTick(g_Config.m_ClDummy));
-						if(EvolveCur && m_Snap.m_aCharacters[Item.m_ID].m_Cur.m_Tick)
-							Evolve(&m_Snap.m_aCharacters[Item.m_ID].m_Cur, Client()->GameTick(g_Config.m_ClDummy));
+						if(EvolvePrev && m_Snap.m_aCharacters[Item.m_Id].m_Prev.m_Tick)
+							Evolve(&m_Snap.m_aCharacters[Item.m_Id].m_Prev, Client()->PrevGameTick(g_Config.m_ClDummy));
+						if(EvolveCur && m_Snap.m_aCharacters[Item.m_Id].m_Cur.m_Tick)
+							Evolve(&m_Snap.m_aCharacters[Item.m_Id].m_Cur, Client()->GameTick(g_Config.m_ClDummy));
 
-						m_aClients[Item.m_ID].m_Snapped = *((const CNetObj_Character *)pData);
-						m_aClients[Item.m_ID].m_Evolved = m_Snap.m_aCharacters[Item.m_ID].m_Cur;
+						m_aClients[Item.m_Id].m_Snapped = *((const CNetObj_Character *)pData);
+						m_aClients[Item.m_Id].m_Evolved = m_Snap.m_aCharacters[Item.m_Id].m_Cur;
 					}
 					else
 					{
-						m_aClients[Item.m_ID].m_Evolved.m_Tick = -1;
+						m_aClients[Item.m_Id].m_Evolved.m_Tick = -1;
 					}
 				}
 			}
@@ -1490,17 +1490,17 @@ void CGameClient::OnNewSnapshot()
 			{
 				const CNetObj_DDNetCharacter *pCharacterData = (const CNetObj_DDNetCharacter *)pData;
 
-				if(Item.m_ID < MAX_CLIENTS)
+				if(Item.m_Id < MAX_CLIENTS)
 				{
-					m_Snap.m_aCharacters[Item.m_ID].m_ExtendedData = *pCharacterData;
-					m_Snap.m_aCharacters[Item.m_ID].m_PrevExtendedData = (const CNetObj_DDNetCharacter *)Client()->SnapFindItem(IClient::SNAP_PREV, NETOBJTYPE_DDNETCHARACTER, Item.m_ID);
-					m_Snap.m_aCharacters[Item.m_ID].m_HasExtendedData = true;
-					m_Snap.m_aCharacters[Item.m_ID].m_HasExtendedDisplayInfo = false;
+					m_Snap.m_aCharacters[Item.m_Id].m_ExtendedData = *pCharacterData;
+					m_Snap.m_aCharacters[Item.m_Id].m_PrevExtendedData = (const CNetObj_DDNetCharacter *)Client()->SnapFindItem(IClient::SNAP_PREV, NETOBJTYPE_DDNETCHARACTER, Item.m_Id);
+					m_Snap.m_aCharacters[Item.m_Id].m_HasExtendedData = true;
+					m_Snap.m_aCharacters[Item.m_Id].m_HasExtendedDisplayInfo = false;
 					if(pCharacterData->m_JumpedTotal != -1)
 					{
-						m_Snap.m_aCharacters[Item.m_ID].m_HasExtendedDisplayInfo = true;
+						m_Snap.m_aCharacters[Item.m_Id].m_HasExtendedDisplayInfo = true;
 					}
-					CClientData *pClient = &m_aClients[Item.m_ID];
+					CClientData *pClient = &m_aClients[Item.m_Id];
 					// Collision
 					pClient->m_Solo = pCharacterData->m_Flags & CHARACTERFLAG_SOLO;
 					pClient->m_Jetpack = pCharacterData->m_Flags & CHARACTERFLAG_JETPACK;
@@ -1528,16 +1528,16 @@ void CGameClient::OnNewSnapshot()
 
 					pClient->m_Predicted.ReadDDNet(pCharacterData);
 
-					m_Teams.SetSolo(Item.m_ID, pClient->m_Solo);
+					m_Teams.SetSolo(Item.m_Id, pClient->m_Solo);
 				}
 			}
 			else if(Item.m_Type == NETOBJTYPE_SPECCHAR)
 			{
 				const CNetObj_SpecChar *pSpecCharData = (const CNetObj_SpecChar *)pData;
 
-				if(Item.m_ID < MAX_CLIENTS)
+				if(Item.m_Id < MAX_CLIENTS)
 				{
-					CClientData *pClient = &m_aClients[Item.m_ID];
+					CClientData *pClient = &m_aClients[Item.m_Id];
 					pClient->m_SpecCharPresent = true;
 					pClient->m_SpecChar.x = pSpecCharData->m_X;
 					pClient->m_SpecChar.y = pSpecCharData->m_Y;
@@ -1546,9 +1546,9 @@ void CGameClient::OnNewSnapshot()
 			else if(Item.m_Type == NETOBJTYPE_SPECTATORINFO)
 			{
 				m_Snap.m_pSpectatorInfo = (const CNetObj_SpectatorInfo *)pData;
-				m_Snap.m_pPrevSpectatorInfo = (const CNetObj_SpectatorInfo *)Client()->SnapFindItem(IClient::SNAP_PREV, NETOBJTYPE_SPECTATORINFO, Item.m_ID);
+				m_Snap.m_pPrevSpectatorInfo = (const CNetObj_SpectatorInfo *)Client()->SnapFindItem(IClient::SNAP_PREV, NETOBJTYPE_SPECTATORINFO, Item.m_Id);
 
-				m_Snap.m_SpecInfo.m_SpectatorID = m_Snap.m_pSpectatorInfo->m_SpectatorID;
+				m_Snap.m_SpecInfo.m_SpectatorId = m_Snap.m_pSpectatorInfo->m_SpectatorId;
 			}
 			else if(Item.m_Type == NETOBJTYPE_GAMEINFO)
 			{
@@ -1580,7 +1580,7 @@ void CGameClient::OnNewSnapshot()
 			else if(Item.m_Type == NETOBJTYPE_GAMEDATA)
 			{
 				m_Snap.m_pGameDataObj = (const CNetObj_GameData *)pData;
-				m_Snap.m_GameDataSnapID = Item.m_ID;
+				m_Snap.m_GameDataSnapId = Item.m_Id;
 				if(m_Snap.m_pGameDataObj->m_FlagCarrierRed == FLAG_TAKEN)
 				{
 					if(m_aFlagDropTick[TEAM_RED] == 0)
@@ -1604,7 +1604,7 @@ void CGameClient::OnNewSnapshot()
 				m_LastFlagCarrierBlue = m_Snap.m_pGameDataObj->m_FlagCarrierBlue;
 			}
 			else if(Item.m_Type == NETOBJTYPE_FLAG)
-				m_Snap.m_apFlags[Item.m_ID % 2] = (const CNetObj_Flag *)pData;
+				m_Snap.m_apFlags[Item.m_Id % 2] = (const CNetObj_Flag *)pData;
 			else if(Item.m_Type == NETOBJTYPE_SWITCHSTATE)
 			{
 				if(Item.m_DataSize < 36)
@@ -1612,7 +1612,7 @@ void CGameClient::OnNewSnapshot()
 					continue;
 				}
 				const CNetObj_SwitchState *pSwitchStateData = (const CNetObj_SwitchState *)pData;
-				int Team = clamp(Item.m_ID, (int)TEAM_FLOCK, (int)TEAM_SUPER - 1);
+				int Team = clamp(Item.m_Id, (int)TEAM_FLOCK, (int)TEAM_SUPER - 1);
 
 				int HighestSwitchNumber = clamp(pSwitchStateData->m_HighestSwitchNumber, 0, 255);
 				if(HighestSwitchNumber != maximum(0, (int)Switchers().size() - 1))
@@ -1666,11 +1666,11 @@ void CGameClient::OnNewSnapshot()
 	}
 
 	// setup local pointers
-	if(m_Snap.m_LocalClientID >= 0)
+	if(m_Snap.m_LocalClientId >= 0)
 	{
-		m_aLocalIDs[g_Config.m_ClDummy] = m_Snap.m_LocalClientID;
+		m_aLocalIds[g_Config.m_ClDummy] = m_Snap.m_LocalClientId;
 
-		CSnapState::CCharacterInfo *pChr = &m_Snap.m_aCharacters[m_Snap.m_LocalClientID];
+		CSnapState::CCharacterInfo *pChr = &m_Snap.m_aCharacters[m_Snap.m_LocalClientId];
 		if(pChr->m_Active)
 		{
 			if(!m_Snap.m_SpecInfo.m_Active)
@@ -1680,7 +1680,7 @@ void CGameClient::OnNewSnapshot()
 				m_LocalCharacterPos = vec2(m_Snap.m_pLocalCharacter->m_X, m_Snap.m_pLocalCharacter->m_Y);
 			}
 		}
-		else if(Client()->SnapFindItem(IClient::SNAP_PREV, NETOBJTYPE_CHARACTER, m_Snap.m_LocalClientID))
+		else if(Client()->SnapFindItem(IClient::SNAP_PREV, NETOBJTYPE_CHARACTER, m_Snap.m_LocalClientId))
 		{
 			// player died
 			m_Controls.OnPlayerDeath();
@@ -1688,15 +1688,15 @@ void CGameClient::OnNewSnapshot()
 	}
 	if(Client()->State() == IClient::STATE_DEMOPLAYBACK)
 	{
-		if(m_Snap.m_LocalClientID == -1 && m_DemoSpecID == SPEC_FOLLOW)
-			m_DemoSpecID = SPEC_FREEVIEW;
-		if(m_DemoSpecID != SPEC_FOLLOW)
+		if(m_Snap.m_LocalClientId == -1 && m_DemoSpecId == SPEC_FOLLOW)
+			m_DemoSpecId = SPEC_FREEVIEW;
+		if(m_DemoSpecId != SPEC_FOLLOW)
 		{
 			m_Snap.m_SpecInfo.m_Active = true;
-			if(m_DemoSpecID > SPEC_FREEVIEW && m_Snap.m_aCharacters[m_DemoSpecID].m_Active)
-				m_Snap.m_SpecInfo.m_SpectatorID = m_DemoSpecID;
+			if(m_DemoSpecId > SPEC_FREEVIEW && m_Snap.m_aCharacters[m_DemoSpecId].m_Active)
+				m_Snap.m_SpecInfo.m_SpectatorId = m_DemoSpecId;
 			else
-				m_Snap.m_SpecInfo.m_SpectatorID = SPEC_FREEVIEW;
+				m_Snap.m_SpecInfo.m_SpectatorId = SPEC_FREEVIEW;
 		}
 	}
 
@@ -1713,10 +1713,10 @@ void CGameClient::OnNewSnapshot()
 	for(int i = 0; i < MAX_CLIENTS; ++i)
 	{
 		// update friend state
-		m_aClients[i].m_Friend = !(i == m_Snap.m_LocalClientID || !m_Snap.m_apPlayerInfos[i] || !Friends()->IsFriend(m_aClients[i].m_aName, m_aClients[i].m_aClan, true));
+		m_aClients[i].m_Friend = !(i == m_Snap.m_LocalClientId || !m_Snap.m_apPlayerInfos[i] || !Friends()->IsFriend(m_aClients[i].m_aName, m_aClients[i].m_aClan, true));
 
 		// update foe state
-		m_aClients[i].m_Foe = !(i == m_Snap.m_LocalClientID || !m_Snap.m_apPlayerInfos[i] || !Foes()->IsFriend(m_aClients[i].m_aName, m_aClients[i].m_aClan, true));
+		m_aClients[i].m_Foe = !(i == m_Snap.m_LocalClientId || !m_Snap.m_apPlayerInfos[i] || !Foes()->IsFriend(m_aClients[i].m_aName, m_aClients[i].m_aClan, true));
 	}
 
 	// sort player infos by name
@@ -1727,7 +1727,7 @@ void CGameClient::OnNewSnapshot()
 				return static_cast<bool>(p1);
 			if(!p1)
 				return false;
-			return str_comp_nocase(m_aClients[p1->m_ClientID].m_aName, m_aClients[p2->m_ClientID].m_aName) < 0;
+			return str_comp_nocase(m_aClients[p1->m_ClientId].m_aName, m_aClients[p2->m_ClientId].m_aName) < 0;
 		});
 
 	bool TimeScore = m_GameInfo.m_TimeScore;
@@ -1750,7 +1750,7 @@ void CGameClient::OnNewSnapshot()
 	{
 		for(int i = 0; i < MAX_CLIENTS && Index < MAX_CLIENTS; ++i)
 		{
-			if(m_Snap.m_apInfoByScore[i] && m_Teams.Team(m_Snap.m_apInfoByScore[i]->m_ClientID) == Team)
+			if(m_Snap.m_apInfoByScore[i] && m_Teams.Team(m_Snap.m_apInfoByScore[i]->m_ClientId) == Team)
 				m_Snap.m_apInfoByDDTeamScore[Index++] = m_Snap.m_apInfoByScore[i];
 		}
 	}
@@ -1761,7 +1761,7 @@ void CGameClient::OnNewSnapshot()
 	{
 		for(int i = 0; i < MAX_CLIENTS && Index < MAX_CLIENTS; ++i)
 		{
-			if(m_Snap.m_apInfoByName[i] && m_Teams.Team(m_Snap.m_apInfoByName[i]->m_ClientID) == Team)
+			if(m_Snap.m_apInfoByName[i] && m_Teams.Team(m_Snap.m_apInfoByName[i]->m_ClientId) == Team)
 				m_Snap.m_apInfoByDDTeamName[Index++] = m_Snap.m_apInfoByName[i];
 		}
 	}
@@ -1871,21 +1871,21 @@ void CGameClient::OnNewSnapshot()
 	// detect air jump for other players
 	for(int i = 0; i < MAX_CLIENTS; i++)
 		if(m_Snap.m_aCharacters[i].m_Active && (m_Snap.m_aCharacters[i].m_Cur.m_Jumped & 2) && !(m_Snap.m_aCharacters[i].m_Prev.m_Jumped & 2))
-			if(!Predict() || (i != m_Snap.m_LocalClientID && (!AntiPingPlayers() || i != m_PredictedDummyID)))
+			if(!Predict() || (i != m_Snap.m_LocalClientId && (!AntiPingPlayers() || i != m_PredictedDummyId)))
 			{
 				vec2 Pos = mix(vec2(m_Snap.m_aCharacters[i].m_Prev.m_X, m_Snap.m_aCharacters[i].m_Prev.m_Y),
 					vec2(m_Snap.m_aCharacters[i].m_Cur.m_X, m_Snap.m_aCharacters[i].m_Cur.m_Y),
 					Client()->IntraGameTick(g_Config.m_ClDummy));
 				float Alpha = 1.0f;
-				bool SameTeam = m_Teams.SameTeam(m_Snap.m_LocalClientID, i);
-				if(!SameTeam || m_aClients[i].m_Solo || m_aClients[m_Snap.m_LocalClientID].m_Solo)
+				bool SameTeam = m_Teams.SameTeam(m_Snap.m_LocalClientId, i);
+				if(!SameTeam || m_aClients[i].m_Solo || m_aClients[m_Snap.m_LocalClientId].m_Solo)
 					Alpha = g_Config.m_ClShowOthersAlpha / 100.0f;
 				m_Effects.AirJump(Pos, Alpha);
 			}
 
-	if(m_Snap.m_LocalClientID != m_PrevLocalID)
-		m_PredictedDummyID = m_PrevLocalID;
-	m_PrevLocalID = m_Snap.m_LocalClientID;
+	if(m_Snap.m_LocalClientId != m_PrevLocalId)
+		m_PredictedDummyId = m_PrevLocalId;
+	m_PrevLocalId = m_Snap.m_LocalClientId;
 	m_IsDummySwapping = 0;
 
 	SnapCollectEntities(); // creates a collection that associates EntityEx snap items with the entities they belong to
@@ -1919,7 +1919,7 @@ void CGameClient::OnPredict()
 	CCharacterCore BeforeChar = m_PredictedChar;
 
 	// we can't predict without our own id or own character
-	if(m_Snap.m_LocalClientID == -1 || !m_Snap.m_aCharacters[m_Snap.m_LocalClientID].m_Active)
+	if(m_Snap.m_LocalClientId == -1 || !m_Snap.m_aCharacters[m_Snap.m_LocalClientId].m_Active)
 		return;
 
 	// don't predict anything if we are paused
@@ -1948,7 +1948,7 @@ void CGameClient::OnPredict()
 
 	// don't predict inactive players, or entities from other teams
 	for(int i = 0; i < MAX_CLIENTS; i++)
-		if(CCharacter *pChar = m_PredictedWorld.GetCharacterByID(i))
+		if(CCharacter *pChar = m_PredictedWorld.GetCharacterById(i))
 			if((!m_Snap.m_aCharacters[i].m_Active && pChar->m_SnapTicks > 10) || IsOtherTeam(i))
 				pChar->Destroy();
 
@@ -1962,12 +1962,12 @@ void CGameClient::OnPredict()
 		}
 	}
 
-	CCharacter *pLocalChar = m_PredictedWorld.GetCharacterByID(m_Snap.m_LocalClientID);
+	CCharacter *pLocalChar = m_PredictedWorld.GetCharacterById(m_Snap.m_LocalClientId);
 	if(!pLocalChar)
 		return;
 	CCharacter *pDummyChar = 0;
 	if(PredictDummy())
-		pDummyChar = m_PredictedWorld.GetCharacterByID(m_PredictedDummyID);
+		pDummyChar = m_PredictedWorld.GetCharacterById(m_PredictedDummyId);
 
 	// predict
 	for(int Tick = Client()->GameTick(g_Config.m_ClDummy) + 1; Tick <= Client()->PredGameTick(g_Config.m_ClDummy); Tick++)
@@ -1978,7 +1978,7 @@ void CGameClient::OnPredict()
 			m_PrevPredictedWorld.CopyWorld(&m_PredictedWorld);
 			m_PredictedPrevChar = pLocalChar->GetCore();
 			for(int i = 0; i < MAX_CLIENTS; i++)
-				if(CCharacter *pChar = m_PredictedWorld.GetCharacterByID(i))
+				if(CCharacter *pChar = m_PredictedWorld.GetCharacterById(i))
 					m_aClients[i].m_PrevPredicted = pChar->GetCore();
 		}
 
@@ -1989,7 +1989,7 @@ void CGameClient::OnPredict()
 		// apply inputs and tick
 		CNetObj_PlayerInput *pInputData = (CNetObj_PlayerInput *)Client()->GetInput(Tick, m_IsDummySwapping);
 		CNetObj_PlayerInput *pDummyInputData = !pDummyChar ? 0 : (CNetObj_PlayerInput *)Client()->GetInput(Tick, m_IsDummySwapping ^ 1);
-		bool DummyFirst = pInputData && pDummyInputData && pDummyChar->GetCID() < pLocalChar->GetCID();
+		bool DummyFirst = pInputData && pDummyInputData && pDummyChar->GetCid() < pLocalChar->GetCid();
 
 		if(DummyFirst)
 			pDummyChar->OnDirectInput(pDummyInputData);
@@ -2009,12 +2009,12 @@ void CGameClient::OnPredict()
 		{
 			m_PredictedChar = pLocalChar->GetCore();
 			for(int i = 0; i < MAX_CLIENTS; i++)
-				if(CCharacter *pChar = m_PredictedWorld.GetCharacterByID(i))
+				if(CCharacter *pChar = m_PredictedWorld.GetCharacterById(i))
 					m_aClients[i].m_Predicted = pChar->GetCore();
 		}
 
 		for(int i = 0; i < MAX_CLIENTS; i++)
-			if(CCharacter *pChar = m_PredictedWorld.GetCharacterByID(i))
+			if(CCharacter *pChar = m_PredictedWorld.GetCharacterById(i))
 			{
 				m_aClients[i].m_aPredPos[Tick % 200] = pChar->Core()->m_Pos;
 				m_aClients[i].m_aPredTick[Tick % 200] = Tick;
@@ -2062,7 +2062,7 @@ void CGameClient::OnPredict()
 
 		for(int i = 0; i < MAX_CLIENTS; i++)
 		{
-			if(!m_Snap.m_aCharacters[i].m_Active || i == m_Snap.m_LocalClientID || !m_aLastActive[i])
+			if(!m_Snap.m_aCharacters[i].m_Active || i == m_Snap.m_LocalClientId || !m_aLastActive[i])
 				continue;
 			vec2 NewPos = (m_PredictedTick == Client()->PredGameTick(g_Config.m_ClDummy)) ? m_aClients[i].m_Predicted.m_Pos : m_aClients[i].m_PrevPredicted.m_Pos;
 			vec2 PredErr = (m_aLastPos[i] - NewPos) / (float)minimum(Client()->GetPredictionTime(), 200);
@@ -2334,7 +2334,7 @@ void CGameClient::SendDummyInfo(bool Start)
 	}
 }
 
-void CGameClient::SendKill(int ClientID) const
+void CGameClient::SendKill(int ClientId) const
 {
 	CNetMsg_Cl_Kill Msg;
 	Client()->SendPackMsgActive(&Msg, MSGFLAG_VITAL);
@@ -2401,16 +2401,16 @@ IGameClient *CreateGameClient()
 	return new CGameClient();
 }
 
-int CGameClient::IntersectCharacter(vec2 HookPos, vec2 NewPos, vec2 &NewPos2, int ownID)
+int CGameClient::IntersectCharacter(vec2 HookPos, vec2 NewPos, vec2 &NewPos2, int ownId)
 {
 	float Distance = 0.0f;
-	int ClosestID = -1;
+	int ClosestId = -1;
 
-	const CClientData &OwnClientData = m_aClients[ownID];
+	const CClientData &OwnClientData = m_aClients[ownId];
 
 	for(int i = 0; i < MAX_CLIENTS; i++)
 	{
-		if(i == ownID)
+		if(i == ownId)
 			continue;
 
 		const CClientData &cData = m_aClients[i];
@@ -2426,7 +2426,7 @@ int CGameClient::IntersectCharacter(vec2 HookPos, vec2 NewPos, vec2 &NewPos2, in
 		bool IsOneSuper = cData.m_Super || OwnClientData.m_Super;
 		bool IsOneSolo = cData.m_Solo || OwnClientData.m_Solo;
 
-		if(!IsOneSuper && (!m_Teams.SameTeam(i, ownID) || IsOneSolo || OwnClientData.m_HookHitDisabled))
+		if(!IsOneSuper && (!m_Teams.SameTeam(i, ownId) || IsOneSolo || OwnClientData.m_HookHitDisabled))
 			continue;
 
 		vec2 ClosestPoint;
@@ -2434,17 +2434,17 @@ int CGameClient::IntersectCharacter(vec2 HookPos, vec2 NewPos, vec2 &NewPos2, in
 		{
 			if(distance(Position, ClosestPoint) < CCharacterCore::PhysicalSize() + 2.0f)
 			{
-				if(ClosestID == -1 || distance(HookPos, Position) < Distance)
+				if(ClosestId == -1 || distance(HookPos, Position) < Distance)
 				{
 					NewPos2 = ClosestPoint;
-					ClosestID = i;
+					ClosestId = i;
 					Distance = distance(HookPos, Position);
 				}
 			}
 		}
 	}
 
-	return ClosestID;
+	return ClosestId;
 }
 
 ColorRGBA CalculateNameColor(ColorHSLA TextColorHSL)
@@ -2471,14 +2471,14 @@ void CGameClient::UpdatePrediction()
 
 	if(!m_Snap.m_pLocalCharacter)
 	{
-		if(CCharacter *pLocalChar = m_GameWorld.GetCharacterByID(m_Snap.m_LocalClientID))
+		if(CCharacter *pLocalChar = m_GameWorld.GetCharacterById(m_Snap.m_LocalClientId))
 			pLocalChar->Destroy();
 		return;
 	}
 
 	if(m_Snap.m_pLocalCharacter->m_AmmoCount > 0 && m_Snap.m_pLocalCharacter->m_Weapon != WEAPON_NINJA)
 		m_GameWorld.m_WorldConfig.m_InfiniteAmmo = false;
-	m_GameWorld.m_WorldConfig.m_IsSolo = !m_Snap.m_aCharacters[m_Snap.m_LocalClientID].m_HasExtendedData && !m_aTuning[g_Config.m_ClDummy].m_PlayerCollision && !m_aTuning[g_Config.m_ClDummy].m_PlayerHooking;
+	m_GameWorld.m_WorldConfig.m_IsSolo = !m_Snap.m_aCharacters[m_Snap.m_LocalClientId].m_HasExtendedData && !m_aTuning[g_Config.m_ClDummy].m_PlayerCollision && !m_aTuning[g_Config.m_ClDummy].m_PlayerHooking;
 
 	// update the tuning/tunezone at the local character position with the latest tunings received before the new snapshot
 	vec2 LocalCharPos = vec2(m_Snap.m_pLocalCharacter->m_X, m_Snap.m_pLocalCharacter->m_Y);
@@ -2533,40 +2533,40 @@ void CGameClient::UpdatePrediction()
 	}
 
 	// if ddnetcharacter is available, ignore server-wide tunings for hook and collision
-	if(m_Snap.m_aCharacters[m_Snap.m_LocalClientID].m_HasExtendedData)
+	if(m_Snap.m_aCharacters[m_Snap.m_LocalClientId].m_HasExtendedData)
 	{
 		m_GameWorld.m_Core.m_aTuning[g_Config.m_ClDummy].m_PlayerCollision = 1;
 		m_GameWorld.m_Core.m_aTuning[g_Config.m_ClDummy].m_PlayerHooking = 1;
 	}
 
-	CCharacter *pLocalChar = m_GameWorld.GetCharacterByID(m_Snap.m_LocalClientID);
+	CCharacter *pLocalChar = m_GameWorld.GetCharacterById(m_Snap.m_LocalClientId);
 	CCharacter *pDummyChar = 0;
 	if(PredictDummy())
-		pDummyChar = m_GameWorld.GetCharacterByID(m_PredictedDummyID);
+		pDummyChar = m_GameWorld.GetCharacterById(m_PredictedDummyId);
 
 	// update strong and weak hook
 	if(pLocalChar && !m_Snap.m_SpecInfo.m_Active && Client()->State() != IClient::STATE_DEMOPLAYBACK && (m_aTuning[g_Config.m_ClDummy].m_PlayerCollision || m_aTuning[g_Config.m_ClDummy].m_PlayerHooking))
 	{
-		if(m_Snap.m_aCharacters[m_Snap.m_LocalClientID].m_HasExtendedData)
+		if(m_Snap.m_aCharacters[m_Snap.m_LocalClientId].m_HasExtendedData)
 		{
-			int aIDs[MAX_CLIENTS];
-			for(int &ID : aIDs)
-				ID = -1;
+			int aIds[MAX_CLIENTS];
+			for(int &Id : aIds)
+				Id = -1;
 			for(int i = 0; i < MAX_CLIENTS; i++)
-				if(CCharacter *pChar = m_GameWorld.GetCharacterByID(i))
-					aIDs[pChar->GetStrongWeakID()] = i;
-			for(int ID : aIDs)
-				if(ID >= 0)
-					m_CharOrder.GiveStrong(ID);
+				if(CCharacter *pChar = m_GameWorld.GetCharacterById(i))
+					aIds[pChar->GetStrongWeakId()] = i;
+			for(int Id : aIds)
+				if(Id >= 0)
+					m_CharOrder.GiveStrong(Id);
 		}
 		else
 		{
 			// manual detection
 			DetectStrongHook();
 		}
-		for(int i : m_CharOrder.m_IDs)
+		for(int i : m_CharOrder.m_Ids)
 		{
-			if(CCharacter *pChar = m_GameWorld.GetCharacterByID(i))
+			if(CCharacter *pChar = m_GameWorld.GetCharacterById(i))
 			{
 				m_GameWorld.RemoveEntity(pChar);
 				m_GameWorld.InsertEntity(pChar);
@@ -2595,7 +2595,7 @@ void CGameClient::UpdatePrediction()
 			m_GameWorld.Tick();
 
 			for(int i = 0; i < MAX_CLIENTS; i++)
-				if(CCharacter *pChar = m_GameWorld.GetCharacterByID(i))
+				if(CCharacter *pChar = m_GameWorld.GetCharacterById(i))
 				{
 					m_aClients[i].m_aPredPos[Tick % 200] = pChar->Core()->m_Pos;
 					m_aClients[i].m_aPredTick[Tick % 200] = Tick;
@@ -2615,19 +2615,19 @@ void CGameClient::UpdatePrediction()
 	}
 
 	for(int i = 0; i < MAX_CLIENTS; i++)
-		if(CCharacter *pChar = m_GameWorld.GetCharacterByID(i))
+		if(CCharacter *pChar = m_GameWorld.GetCharacterById(i))
 		{
 			m_aClients[i].m_aPredPos[Client()->GameTick(g_Config.m_ClDummy) % 200] = pChar->Core()->m_Pos;
 			m_aClients[i].m_aPredTick[Client()->GameTick(g_Config.m_ClDummy) % 200] = Client()->GameTick(g_Config.m_ClDummy);
 		}
 
 	// update the local gameworld with the new snapshot
-	m_GameWorld.NetObjBegin(m_Teams, m_Snap.m_LocalClientID);
+	m_GameWorld.NetObjBegin(m_Teams, m_Snap.m_LocalClientId);
 
 	for(int i = 0; i < MAX_CLIENTS; i++)
 		if(m_Snap.m_aCharacters[i].m_Active)
 		{
-			bool IsLocal = (i == m_Snap.m_LocalClientID || (PredictDummy() && i == m_PredictedDummyID));
+			bool IsLocal = (i == m_Snap.m_LocalClientId || (PredictDummy() && i == m_PredictedDummyId));
 			int GameTeam = (m_Snap.m_pGameInfoObj && (m_Snap.m_pGameInfoObj->m_GameFlags & GAMEFLAG_TEAMS)) ? m_aClients[i].m_Team : i;
 			m_GameWorld.NetCharAdd(i, &m_Snap.m_aCharacters[i].m_Cur,
 				m_Snap.m_aCharacters[i].m_HasExtendedData ? &m_Snap.m_aCharacters[i].m_ExtendedData : 0,
@@ -2635,7 +2635,7 @@ void CGameClient::UpdatePrediction()
 		}
 
 	for(const CSnapEntities &EntData : SnapEntities())
-		m_GameWorld.NetObjAdd(EntData.m_Item.m_ID, EntData.m_Item.m_Type, EntData.m_pData, EntData.m_pDataEx);
+		m_GameWorld.NetObjAdd(EntData.m_Item.m_Id, EntData.m_Item.m_Type, EntData.m_pData, EntData.m_pDataEx);
 
 	m_GameWorld.NetObjEnd();
 }
@@ -2656,8 +2656,8 @@ void CGameClient::UpdateRenderedCharacters()
 			Client()->IntraGameTick(g_Config.m_ClDummy));
 		vec2 Pos = UnpredPos;
 
-		CCharacter *pChar = m_PredictedWorld.GetCharacterByID(i);
-		if(Predict() && (i == m_Snap.m_LocalClientID || (AntiPingPlayers() && !IsOtherTeam(i))) && pChar)
+		CCharacter *pChar = m_PredictedWorld.GetCharacterById(i);
+		if(Predict() && (i == m_Snap.m_LocalClientId || (AntiPingPlayers() && !IsOtherTeam(i))) && pChar)
 		{
 			m_aClients[i].m_Predicted.Write(&m_aClients[i].m_RenderCur);
 			m_aClients[i].m_PrevPredicted.Write(&m_aClients[i].m_RenderPrev);
@@ -2669,7 +2669,7 @@ void CGameClient::UpdateRenderedCharacters()
 				vec2(m_aClients[i].m_RenderCur.m_X, m_aClients[i].m_RenderCur.m_Y),
 				m_aClients[i].m_IsPredicted ? Client()->PredIntraGameTick(g_Config.m_ClDummy) : Client()->IntraGameTick(g_Config.m_ClDummy));
 
-			if(i == m_Snap.m_LocalClientID)
+			if(i == m_Snap.m_LocalClientId)
 			{
 				m_aClients[i].m_IsPredictedLocal = true;
 				if(AntiPingGunfire() && ((pChar->m_NinjaJetpack && pChar->m_FreezeTime == 0) || m_Snap.m_aCharacters[i].m_Cur.m_Weapon != WEAPON_NINJA || m_Snap.m_aCharacters[i].m_Cur.m_Weapon == m_aClients[i].m_Predicted.m_ActiveWeapon))
@@ -2691,7 +2691,7 @@ void CGameClient::UpdateRenderedCharacters()
 		}
 		m_Snap.m_aCharacters[i].m_Position = Pos;
 		m_aClients[i].m_RenderPos = Pos;
-		if(Predict() && i == m_Snap.m_LocalClientID)
+		if(Predict() && i == m_Snap.m_LocalClientId)
 			m_LocalCharacterPos = Pos;
 	}
 }
@@ -2711,8 +2711,8 @@ void CGameClient::DetectStrongHook()
 		if(m_Snap.m_aCharacters[FromPlayer].m_Prev.m_Direction != m_Snap.m_aCharacters[FromPlayer].m_Cur.m_Direction || m_Snap.m_aCharacters[ToPlayer].m_Prev.m_Direction != m_Snap.m_aCharacters[ToPlayer].m_Cur.m_Direction)
 			continue;
 
-		CCharacter *pFromCharWorld = m_GameWorld.GetCharacterByID(FromPlayer);
-		CCharacter *pToCharWorld = m_GameWorld.GetCharacterByID(ToPlayer);
+		CCharacter *pFromCharWorld = m_GameWorld.GetCharacterById(FromPlayer);
+		CCharacter *pToCharWorld = m_GameWorld.GetCharacterById(ToPlayer);
 		if(!pFromCharWorld || !pToCharWorld)
 			continue;
 
@@ -2762,7 +2762,7 @@ void CGameClient::DetectStrongHook()
 		{
 			if(m_CharOrder.HasStrongAgainst(ToPlayer, FromPlayer))
 			{
-				if(ToPlayer != m_Snap.m_LocalClientID)
+				if(ToPlayer != m_Snap.m_LocalClientId)
 					m_CharOrder.GiveWeak(ToPlayer);
 				else
 					m_CharOrder.GiveStrong(FromPlayer);
@@ -2772,7 +2772,7 @@ void CGameClient::DetectStrongHook()
 		{
 			if(m_CharOrder.HasStrongAgainst(FromPlayer, ToPlayer))
 			{
-				if(ToPlayer != m_Snap.m_LocalClientID)
+				if(ToPlayer != m_Snap.m_LocalClientId)
 					m_CharOrder.GiveStrong(ToPlayer);
 				else
 					m_CharOrder.GiveWeak(FromPlayer);
@@ -2781,22 +2781,22 @@ void CGameClient::DetectStrongHook()
 	}
 }
 
-vec2 CGameClient::GetSmoothPos(int ClientID)
+vec2 CGameClient::GetSmoothPos(int ClientId)
 {
-	vec2 Pos = mix(m_aClients[ClientID].m_PrevPredicted.m_Pos, m_aClients[ClientID].m_Predicted.m_Pos, Client()->PredIntraGameTick(g_Config.m_ClDummy));
+	vec2 Pos = mix(m_aClients[ClientId].m_PrevPredicted.m_Pos, m_aClients[ClientId].m_Predicted.m_Pos, Client()->PredIntraGameTick(g_Config.m_ClDummy));
 	int64_t Now = time_get();
 	for(int i = 0; i < 2; i++)
 	{
-		int64_t Len = clamp(m_aClients[ClientID].m_aSmoothLen[i], (int64_t)1, time_freq());
-		int64_t TimePassed = Now - m_aClients[ClientID].m_aSmoothStart[i];
+		int64_t Len = clamp(m_aClients[ClientId].m_aSmoothLen[i], (int64_t)1, time_freq());
+		int64_t TimePassed = Now - m_aClients[ClientId].m_aSmoothStart[i];
 		if(in_range(TimePassed, (int64_t)0, Len - 1))
 		{
 			float MixAmount = 1.f - std::pow(1.f - TimePassed / (float)Len, 1.2f);
 			int SmoothTick;
 			float SmoothIntra;
 			Client()->GetSmoothTick(&SmoothTick, &SmoothIntra, MixAmount);
-			if(SmoothTick > 0 && m_aClients[ClientID].m_aPredTick[(SmoothTick - 1) % 200] >= Client()->PrevGameTick(g_Config.m_ClDummy) && m_aClients[ClientID].m_aPredTick[SmoothTick % 200] <= Client()->PredGameTick(g_Config.m_ClDummy))
-				Pos[i] = mix(m_aClients[ClientID].m_aPredPos[(SmoothTick - 1) % 200][i], m_aClients[ClientID].m_aPredPos[SmoothTick % 200][i], SmoothIntra);
+			if(SmoothTick > 0 && m_aClients[ClientId].m_aPredTick[(SmoothTick - 1) % 200] >= Client()->PrevGameTick(g_Config.m_ClDummy) && m_aClients[ClientId].m_aPredTick[SmoothTick % 200] <= Client()->PredGameTick(g_Config.m_ClDummy))
+				Pos[i] = mix(m_aClients[ClientId].m_aPredPos[(SmoothTick - 1) % 200][i], m_aClients[ClientId].m_aPredPos[SmoothTick % 200][i], SmoothIntra);
 		}
 	}
 	return Pos;
@@ -2807,45 +2807,45 @@ void CGameClient::Echo(const char *pString)
 	m_Chat.Echo(pString);
 }
 
-bool CGameClient::IsOtherTeam(int ClientID) const
+bool CGameClient::IsOtherTeam(int ClientId) const
 {
-	bool Local = m_Snap.m_LocalClientID == ClientID;
+	bool Local = m_Snap.m_LocalClientId == ClientId;
 
-	if(m_Snap.m_LocalClientID < 0)
+	if(m_Snap.m_LocalClientId < 0)
 		return false;
-	else if((m_Snap.m_SpecInfo.m_Active && m_Snap.m_SpecInfo.m_SpectatorID == SPEC_FREEVIEW) || ClientID < 0)
+	else if((m_Snap.m_SpecInfo.m_Active && m_Snap.m_SpecInfo.m_SpectatorId == SPEC_FREEVIEW) || ClientId < 0)
 		return false;
-	else if(m_Snap.m_SpecInfo.m_Active && m_Snap.m_SpecInfo.m_SpectatorID != SPEC_FREEVIEW)
+	else if(m_Snap.m_SpecInfo.m_Active && m_Snap.m_SpecInfo.m_SpectatorId != SPEC_FREEVIEW)
 	{
-		if(m_Teams.Team(ClientID) == TEAM_SUPER || m_Teams.Team(m_Snap.m_SpecInfo.m_SpectatorID) == TEAM_SUPER)
+		if(m_Teams.Team(ClientId) == TEAM_SUPER || m_Teams.Team(m_Snap.m_SpecInfo.m_SpectatorId) == TEAM_SUPER)
 			return false;
-		return m_Teams.Team(ClientID) != m_Teams.Team(m_Snap.m_SpecInfo.m_SpectatorID);
+		return m_Teams.Team(ClientId) != m_Teams.Team(m_Snap.m_SpecInfo.m_SpectatorId);
 	}
-	else if((m_aClients[m_Snap.m_LocalClientID].m_Solo || m_aClients[ClientID].m_Solo) && !Local)
+	else if((m_aClients[m_Snap.m_LocalClientId].m_Solo || m_aClients[ClientId].m_Solo) && !Local)
 		return true;
 
-	if(m_Teams.Team(ClientID) == TEAM_SUPER || m_Teams.Team(m_Snap.m_LocalClientID) == TEAM_SUPER)
+	if(m_Teams.Team(ClientId) == TEAM_SUPER || m_Teams.Team(m_Snap.m_LocalClientId) == TEAM_SUPER)
 		return false;
 
-	return m_Teams.Team(ClientID) != m_Teams.Team(m_Snap.m_LocalClientID);
+	return m_Teams.Team(ClientId) != m_Teams.Team(m_Snap.m_LocalClientId);
 }
 
 int CGameClient::SwitchStateTeam() const
 {
 	if(m_aSwitchStateTeam[g_Config.m_ClDummy] >= 0)
 		return m_aSwitchStateTeam[g_Config.m_ClDummy];
-	else if(m_Snap.m_LocalClientID < 0)
+	else if(m_Snap.m_LocalClientId < 0)
 		return 0;
-	else if(m_Snap.m_SpecInfo.m_Active && m_Snap.m_SpecInfo.m_SpectatorID != SPEC_FREEVIEW)
-		return m_Teams.Team(m_Snap.m_SpecInfo.m_SpectatorID);
-	return m_Teams.Team(m_Snap.m_LocalClientID);
+	else if(m_Snap.m_SpecInfo.m_Active && m_Snap.m_SpecInfo.m_SpectatorId != SPEC_FREEVIEW)
+		return m_Teams.Team(m_Snap.m_SpecInfo.m_SpectatorId);
+	return m_Teams.Team(m_Snap.m_LocalClientId);
 }
 
 bool CGameClient::IsLocalCharSuper() const
 {
-	if(m_Snap.m_LocalClientID < 0)
+	if(m_Snap.m_LocalClientId < 0)
 		return false;
-	return m_aClients[m_Snap.m_LocalClientID].m_Super;
+	return m_aClients[m_Snap.m_LocalClientId].m_Super;
 }
 
 void CGameClient::LoadGameSkin(const char *pPath, bool AsDir)
@@ -3433,10 +3433,10 @@ void CGameClient::LoadMapSettings()
 	pMap->GetType(MAPITEMTYPE_INFO, &Start, &Num);
 	for(int i = Start; i < Start + Num; i++)
 	{
-		int ItemID;
-		CMapItemInfoSettings *pItem = (CMapItemInfoSettings *)pMap->GetItem(i, nullptr, &ItemID);
+		int ItemId;
+		CMapItemInfoSettings *pItem = (CMapItemInfoSettings *)pMap->GetItem(i, nullptr, &ItemId);
 		int ItemSize = pMap->GetItemSize(i);
-		if(!pItem || ItemID != 0)
+		if(!pItem || ItemId != 0)
 			continue;
 
 		if(ItemSize < (int)sizeof(CMapItemInfoSettings))
@@ -3534,7 +3534,7 @@ void CGameClient::SnapCollectEntities()
 	public:
 		bool operator()(const CSnapEntities &lhs, const CSnapEntities &rhs) const
 		{
-			return lhs.m_Item.m_ID < rhs.m_Item.m_ID;
+			return lhs.m_Item.m_Id < rhs.m_Item.m_Id;
 		}
 	};
 
@@ -3548,9 +3548,9 @@ void CGameClient::SnapCollectEntities()
 	for(const CSnapEntities &Ent : vItemData)
 	{
 		const CNetObj_EntityEx *pDataEx = 0;
-		while(IndexEx < vItemEx.size() && vItemEx[IndexEx].m_Item.m_ID < Ent.m_Item.m_ID)
+		while(IndexEx < vItemEx.size() && vItemEx[IndexEx].m_Item.m_Id < Ent.m_Item.m_Id)
 			IndexEx++;
-		if(IndexEx < vItemEx.size() && vItemEx[IndexEx].m_Item.m_ID == Ent.m_Item.m_ID)
+		if(IndexEx < vItemEx.size() && vItemEx[IndexEx].m_Item.m_Id == Ent.m_Item.m_Id)
 			pDataEx = (const CNetObj_EntityEx *)vItemEx[IndexEx].m_pData;
 
 		m_vSnapEntities.push_back({Ent.m_Item, Ent.m_pData, pDataEx});
@@ -3608,7 +3608,7 @@ void CGameClient::HandleMultiView()
 			{
 				m_MultiView.m_aVanish[i] = true;
 				// player we want to be vanished is our "main" tee, so lets switch the tee
-				if(i == m_Snap.m_SpecInfo.m_SpectatorID)
+				if(i == m_Snap.m_SpecInfo.m_SpectatorId)
 					m_Spectator.Spectate(FindFirstMultiViewId());
 			}
 		}
@@ -3739,13 +3739,13 @@ bool CGameClient::InitMultiView(int Team)
 
 	if(IsMultiViewIdSet())
 	{
-		int SpectatorID = m_Snap.m_SpecInfo.m_SpectatorID;
-		int NewSpectatorID = -1;
+		int SpectatorId = m_Snap.m_SpecInfo.m_SpectatorId;
+		int NewSpectatorId = -1;
 
 		vec2 CurPosition(m_Camera.m_Center);
-		if(SpectatorID != SPEC_FREEVIEW)
+		if(SpectatorId != SPEC_FREEVIEW)
 		{
-			const CNetObj_Character &CurCharacter = m_Snap.m_aCharacters[SpectatorID].m_Cur;
+			const CNetObj_Character &CurCharacter = m_Snap.m_aCharacters[SpectatorId].m_Cur;
 			CurPosition.x = CurCharacter.m_X;
 			CurPosition.y = CurCharacter.m_Y;
 		}
@@ -3765,15 +3765,15 @@ bool CGameClient::InitMultiView(int Team)
 				continue;
 
 			int Distance = distance(CurPosition, PlayerPos);
-			if(NewSpectatorID == -1 || Distance < ClosestDistance)
+			if(NewSpectatorId == -1 || Distance < ClosestDistance)
 			{
-				NewSpectatorID = i;
+				NewSpectatorId = i;
 				ClosestDistance = Distance;
 			}
 		}
 
-		if(NewSpectatorID > -1)
-			m_Spectator.Spectate(NewSpectatorID);
+		if(NewSpectatorId > -1)
+			m_Spectator.Spectate(NewSpectatorId);
 	}
 
 	return IsMultiViewIdSet();
@@ -3851,14 +3851,14 @@ void CGameClient::CleanMultiViewIds()
 	std::fill(std::begin(m_MultiView.m_aVanish), std::end(m_MultiView.m_aVanish), false);
 }
 
-void CGameClient::CleanMultiViewId(int ClientID)
+void CGameClient::CleanMultiViewId(int ClientId)
 {
-	if(ClientID >= MAX_CLIENTS || ClientID < 0)
+	if(ClientId >= MAX_CLIENTS || ClientId < 0)
 		return;
 
-	m_aMultiViewId[ClientID] = false;
-	m_MultiView.m_aLastFreeze[ClientID] = 0.0f;
-	m_MultiView.m_aVanish[ClientID] = false;
+	m_aMultiViewId[ClientId] = false;
+	m_MultiView.m_aLastFreeze[ClientId] = 0.0f;
+	m_MultiView.m_aVanish[ClientId] = false;
 }
 
 bool CGameClient::IsMultiViewIdSet()
@@ -3868,11 +3868,11 @@ bool CGameClient::IsMultiViewIdSet()
 
 int CGameClient::FindFirstMultiViewId()
 {
-	int ClientID = -1;
+	int ClientId = -1;
 	for(int i = 0; i < MAX_CLIENTS; i++)
 	{
 		if(m_aMultiViewId[i] && !m_MultiView.m_aVanish[i])
 			return i;
 	}
-	return ClientID;
+	return ClientId;
 }

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -181,7 +181,7 @@ private:
 
 	CLayers m_Layers;
 	CCollision m_Collision;
-	CUI m_UI;
+	CUi m_UI;
 
 	void ProcessEvents();
 	void UpdatePositions();
@@ -222,14 +222,14 @@ private:
 	// only used in OnNewSnapshot
 	bool m_GameOver = false;
 	bool m_GamePaused = false;
-	int m_PrevLocalID = -1;
+	int m_PrevLocalId = -1;
 
 public:
 	IKernel *Kernel() { return IInterface::Kernel(); }
 	IEngine *Engine() const { return m_pEngine; }
 	class IGraphics *Graphics() const { return m_pGraphics; }
 	class IClient *Client() const { return m_pClient; }
-	class CUI *UI() { return &m_UI; }
+	class CUi *Ui() { return &m_UI; }
 	class ISound *Sound() const { return m_pSound; }
 	class IInput *Input() const { return m_pInput; }
 	class IStorage *Storage() const { return m_pStorage; }
@@ -281,7 +281,7 @@ public:
 	int m_ServerMode;
 	CGameInfo m_GameInfo;
 
-	int m_DemoSpecID;
+	int m_DemoSpecId;
 
 	vec2 m_LocalCharacterPos;
 
@@ -300,7 +300,7 @@ public:
 		const CNetObj_Flag *m_apFlags[2];
 		const CNetObj_GameInfo *m_pGameInfoObj;
 		const CNetObj_GameData *m_pGameDataObj;
-		int m_GameDataSnapID;
+		int m_GameDataSnapId;
 
 		const CNetObj_PlayerInfo *m_apPlayerInfos[MAX_CLIENTS];
 		const CNetObj_PlayerInfo *m_apInfoByScore[MAX_CLIENTS];
@@ -308,7 +308,7 @@ public:
 		const CNetObj_PlayerInfo *m_apInfoByDDTeamScore[MAX_CLIENTS];
 		const CNetObj_PlayerInfo *m_apInfoByDDTeamName[MAX_CLIENTS];
 
-		int m_LocalClientID;
+		int m_LocalClientId;
 		int m_NumPlayers;
 		int m_aTeamSize[2];
 
@@ -316,7 +316,7 @@ public:
 		struct CSpectateInfo
 		{
 			bool m_Active;
-			int m_SpectatorID;
+			int m_SpectatorId;
 			bool m_UsePosition;
 			vec2 m_Position;
 		} m_SpecInfo;
@@ -493,7 +493,7 @@ public:
 	virtual void OnGameOver();
 	virtual void OnStartGame();
 	virtual void OnStartRound();
-	virtual void OnFlagGrab(int TeamID);
+	virtual void OnFlagGrab(int TeamId);
 	void OnWindowResize() override;
 
 	bool m_LanguageChanged = false;
@@ -515,13 +515,13 @@ public:
 	void SendSwitchTeam(int Team);
 	void SendInfo(bool Start);
 	void SendDummyInfo(bool Start) override;
-	void SendKill(int ClientID) const;
+	void SendKill(int ClientId) const;
 
 	int m_NextChangeInfo;
 
 	// DDRace
 
-	int m_aLocalIDs[NUM_DUMMIES];
+	int m_aLocalIds[NUM_DUMMIES];
 	CNetObj_PlayerInput m_DummyInput;
 	CNetObj_PlayerInput m_HammerInput;
 	unsigned int m_DummyFire;
@@ -529,7 +529,7 @@ public:
 
 	class CTeamsCore m_Teams;
 
-	int IntersectCharacter(vec2 HookPos, vec2 NewPos, vec2 &NewPos2, int ownID);
+	int IntersectCharacter(vec2 HookPos, vec2 NewPos, vec2 &NewPos2, int ownId);
 
 	int GetLastRaceTick() const override;
 
@@ -540,7 +540,7 @@ public:
 	bool AntiPingWeapons() { return g_Config.m_ClAntiPing && g_Config.m_ClAntiPingWeapons && !m_Snap.m_SpecInfo.m_Active && Client()->State() != IClient::STATE_DEMOPLAYBACK; }
 	bool AntiPingGunfire() { return AntiPingGrenade() && AntiPingWeapons() && g_Config.m_ClAntiPingGunfire; }
 	bool Predict() const;
-	bool PredictDummy() { return g_Config.m_ClPredictDummy && Client()->DummyConnected() && m_Snap.m_LocalClientID >= 0 && m_PredictedDummyID >= 0 && !m_aClients[m_PredictedDummyID].m_Paused; }
+	bool PredictDummy() { return g_Config.m_ClPredictDummy && Client()->DummyConnected() && m_Snap.m_LocalClientId >= 0 && m_PredictedDummyId >= 0 && !m_aClients[m_PredictedDummyId].m_Paused; }
 	const CTuningParams *GetTuning(int i) { return &m_aTuningList[i]; }
 	ColorRGBA GetDDTeamColor(int DDTeam, float Lightness = 0.5f) const;
 
@@ -553,7 +553,7 @@ public:
 
 	void DummyResetInput() override;
 	void Echo(const char *pString) override;
-	bool IsOtherTeam(int ClientID) const;
+	bool IsOtherTeam(int ClientId) const;
 	int SwitchStateTeam() const;
 	bool IsLocalCharSuper() const;
 	bool CanDisplayWarning() const override;
@@ -734,7 +734,7 @@ public:
 
 	void ResetMultiView();
 	int FindFirstMultiViewId();
-	void CleanMultiViewId(int ClientID);
+	void CleanMultiViewId(int ClientId);
 
 private:
 	std::vector<CSnapEntities> m_vSnapEntities;
@@ -749,9 +749,9 @@ private:
 	int m_aLastUpdateTick[MAX_CLIENTS] = {0};
 	void DetectStrongHook();
 
-	vec2 GetSmoothPos(int ClientID);
+	vec2 GetSmoothPos(int ClientId);
 
-	int m_PredictedDummyID;
+	int m_PredictedDummyId;
 	int m_IsDummySwapping;
 	CCharOrder m_CharOrder;
 	int m_aSwitchStateTeam[NUM_DUMMIES];

--- a/src/game/client/lineinput.cpp
+++ b/src/game/client/lineinput.cpp
@@ -424,7 +424,7 @@ STextBoundingBox CLineInput::Render(const CUIRect *pRect, float FontSize, int Al
 		}
 
 		const STextBoundingBox BoundingBox = TextRender()->TextBoundingBox(FontSize, pDisplayStr, -1, LineWidth, LineSpacing);
-		const vec2 CursorPos = CUI::CalcAlignedCursorPos(pRect, BoundingBox.Size(), Align);
+		const vec2 CursorPos = CUi::CalcAlignedCursorPos(pRect, BoundingBox.Size(), Align);
 
 		TextRender()->SetCursor(&Cursor, CursorPos.x, CursorPos.y, FontSize, TEXTFLAG_RENDER);
 		Cursor.m_LineWidth = LineWidth;
@@ -509,7 +509,7 @@ STextBoundingBox CLineInput::Render(const CUIRect *pRect, float FontSize, int Al
 	else
 	{
 		const STextBoundingBox BoundingBox = TextRender()->TextBoundingBox(FontSize, pDisplayStr, -1, LineWidth, LineSpacing);
-		const vec2 CursorPos = CUI::CalcAlignedCursorPos(pRect, BoundingBox.Size(), Align);
+		const vec2 CursorPos = CUi::CalcAlignedCursorPos(pRect, BoundingBox.Size(), Align);
 		TextRender()->SetCursor(&Cursor, CursorPos.x, CursorPos.y, FontSize, TEXTFLAG_RENDER);
 		Cursor.m_LineWidth = LineWidth;
 		Cursor.m_LineSpacing = LineSpacing;

--- a/src/game/client/lineinput.h
+++ b/src/game/client/lineinput.h
@@ -15,7 +15,7 @@
 enum class EInputPriority
 {
 	NONE = 0,
-	UI,
+	Ui,
 	CHAT,
 	CONSOLE,
 };

--- a/src/game/client/prediction/entities/character.cpp
+++ b/src/game/client/prediction/entities/character.cpp
@@ -27,14 +27,14 @@ void CCharacter::SetWeapon(int W)
 void CCharacter::SetSolo(bool Solo)
 {
 	m_Core.m_Solo = Solo;
-	TeamsCore()->SetSolo(GetCID(), Solo);
+	TeamsCore()->SetSolo(GetCid(), Solo);
 }
 
 void CCharacter::SetSuper(bool Super)
 {
 	m_Core.m_Super = Super;
 	if(m_Core.m_Super)
-		TeamsCore()->Team(GetCID(), TeamsCore()->m_IsDDRace16 ? VANILLA_TEAM_SUPER : TEAM_SUPER);
+		TeamsCore()->Team(GetCid(), TeamsCore()->m_IsDDRace16 ? VANILLA_TEAM_SUPER : TEAM_SUPER);
 }
 
 bool CCharacter::IsGrounded()
@@ -87,7 +87,7 @@ void CCharacter::HandleJetpack()
 			float Strength = GetTuning(m_TuneZone)->m_JetpackStrength;
 			if(!m_TuneZone)
 				Strength = m_LastJetpackStrength;
-			TakeDamage(Direction * -1.0f * (Strength / 100.0f / 6.11f), 0, GetCID(), m_Core.m_ActiveWeapon);
+			TakeDamage(Direction * -1.0f * (Strength / 100.0f / 6.11f), 0, GetCid(), m_Core.m_ActiveWeapon);
 		}
 	}
 	}
@@ -142,7 +142,7 @@ void CCharacter::HandleNinja()
 			int Num = GameWorld()->FindEntities(OldPos, Radius, apEnts, MAX_CLIENTS, CGameWorld::ENTTYPE_CHARACTER);
 
 			// check that we're not in solo part
-			if(TeamsCore()->GetSolo(GetCID()))
+			if(TeamsCore()->GetSolo(GetCid()))
 				return;
 
 			for(int i = 0; i < Num; ++i)
@@ -156,14 +156,14 @@ void CCharacter::HandleNinja()
 					continue;
 
 				// Don't hit players in solo parts
-				if(TeamsCore()->GetSolo(pChr->GetCID()))
+				if(TeamsCore()->GetSolo(pChr->GetCid()))
 					return;
 
 				// make sure we haven't Hit this object before
 				bool bAlreadyHit = false;
 				for(int j = 0; j < m_NumObjectsHit; j++)
 				{
-					if(m_aHitObjects[j] == pChr->GetCID())
+					if(m_aHitObjects[j] == pChr->GetCid())
 						bAlreadyHit = true;
 				}
 				if(bAlreadyHit)
@@ -176,11 +176,11 @@ void CCharacter::HandleNinja()
 				// Hit a player, give them damage and stuffs...
 				// set his velocity to fast upward (for now)
 				if(m_NumObjectsHit < 10)
-					m_aHitObjects[m_NumObjectsHit++] = pChr->GetCID();
+					m_aHitObjects[m_NumObjectsHit++] = pChr->GetCid();
 
-				CCharacter *pChar = GameWorld()->GetCharacterByID(pChr->GetCID());
+				CCharacter *pChar = GameWorld()->GetCharacterById(pChr->GetCid());
 				if(pChar)
-					pChar->TakeDamage(vec2(0, -10.0f), g_pData->m_Weapons.m_Ninja.m_pBase->m_Damage, GetCID(), WEAPON_NINJA);
+					pChar->TakeDamage(vec2(0, -10.0f), g_pData->m_Weapons.m_Ninja.m_pBase->m_Damage, GetCid(), WEAPON_NINJA);
 			}
 		}
 
@@ -312,7 +312,7 @@ void CCharacter::FireWeapon()
 		{
 			auto *pTarget = static_cast<CCharacter *>(apEnts[i]);
 
-			if((pTarget == this || !CanCollide(pTarget->GetCID())))
+			if((pTarget == this || !CanCollide(pTarget->GetCid())))
 				continue;
 
 			// set his velocity to fast upward (for now)
@@ -348,7 +348,7 @@ void CCharacter::FireWeapon()
 				Force *= Strength;
 
 			pTarget->TakeDamage(Force, g_pData->m_Weapons.m_Hammer.m_pBase->m_Damage,
-				GetCID(), m_Core.m_ActiveWeapon);
+				GetCid(), m_Core.m_ActiveWeapon);
 			pTarget->UnFreeze();
 
 			Hits++;
@@ -372,7 +372,7 @@ void CCharacter::FireWeapon()
 			new CProjectile(
 				GameWorld(),
 				WEAPON_GUN, //Type
-				GetCID(), //Owner
+				GetCid(), //Owner
 				ProjStartPos, //Pos
 				Direction, //Dir
 				Lifetime, //Span
@@ -400,7 +400,7 @@ void CCharacter::FireWeapon()
 				new CProjectile(
 					GameWorld(),
 					WEAPON_SHOTGUN, //Type
-					GetCID(), //Owner
+					GetCid(), //Owner
 					ProjStartPos, //Pos
 					direction(a) * Speed, //Dir
 					(int)(GameWorld()->GameTickSpeed() * Tuning()->m_ShotgunLifetime), //Span
@@ -414,7 +414,7 @@ void CCharacter::FireWeapon()
 		{
 			float LaserReach = GetTuning(m_TuneZone)->m_LaserReach;
 
-			new CLaser(GameWorld(), m_Pos, Direction, LaserReach, GetCID(), WEAPON_SHOTGUN);
+			new CLaser(GameWorld(), m_Pos, Direction, LaserReach, GetCid(), WEAPON_SHOTGUN);
 		}
 	}
 	break;
@@ -426,7 +426,7 @@ void CCharacter::FireWeapon()
 		new CProjectile(
 			GameWorld(),
 			WEAPON_GRENADE, //Type
-			GetCID(), //Owner
+			GetCid(), //Owner
 			ProjStartPos, //Pos
 			Direction, //Dir
 			Lifetime, //Span
@@ -441,7 +441,7 @@ void CCharacter::FireWeapon()
 	{
 		float LaserReach = GetTuning(m_TuneZone)->m_LaserReach;
 
-		new CLaser(GameWorld(), m_Pos, Direction, LaserReach, GetCID(), WEAPON_LASER);
+		new CLaser(GameWorld(), m_Pos, Direction, LaserReach, GetCid(), WEAPON_LASER);
 	}
 	break;
 
@@ -618,19 +618,19 @@ bool CCharacter::TakeDamage(vec2 Force, int Dmg, int From, int Weapon)
 
 // DDRace
 
-bool CCharacter::CanCollide(int ClientID)
+bool CCharacter::CanCollide(int ClientId)
 {
-	return TeamsCore()->CanCollide(GetCID(), ClientID);
+	return TeamsCore()->CanCollide(GetCid(), ClientId);
 }
 
-bool CCharacter::SameTeam(int ClientID)
+bool CCharacter::SameTeam(int ClientId)
 {
-	return TeamsCore()->SameTeam(GetCID(), ClientID);
+	return TeamsCore()->SameTeam(GetCid(), ClientId);
 }
 
 int CCharacter::Team()
 {
-	return TeamsCore()->Team(GetCID());
+	return TeamsCore()->Team(GetCid());
 }
 
 void CCharacter::HandleSkippableTiles(int Index)
@@ -924,11 +924,11 @@ void CCharacter::HandleTiles(int Index)
 	}
 
 	// solo part
-	if(((m_TileIndex == TILE_SOLO_ENABLE) || (m_TileFIndex == TILE_SOLO_ENABLE)) && !TeamsCore()->GetSolo(GetCID()))
+	if(((m_TileIndex == TILE_SOLO_ENABLE) || (m_TileFIndex == TILE_SOLO_ENABLE)) && !TeamsCore()->GetSolo(GetCid()))
 	{
 		SetSolo(true);
 	}
-	else if(((m_TileIndex == TILE_SOLO_DISABLE) || (m_TileFIndex == TILE_SOLO_DISABLE)) && TeamsCore()->GetSolo(GetCID()))
+	else if(((m_TileIndex == TILE_SOLO_DISABLE) || (m_TileFIndex == TILE_SOLO_DISABLE)) && TeamsCore()->GetSolo(GetCid()))
 	{
 		SetSolo(false);
 	}
@@ -1150,10 +1150,10 @@ CTeamsCore *CCharacter::TeamsCore()
 	return GameWorld()->Teams();
 }
 
-CCharacter::CCharacter(CGameWorld *pGameWorld, int ID, CNetObj_Character *pChar, CNetObj_DDNetCharacter *pExtended) :
+CCharacter::CCharacter(CGameWorld *pGameWorld, int Id, CNetObj_Character *pChar, CNetObj_DDNetCharacter *pExtended) :
 	CEntity(pGameWorld, CGameWorld::ENTTYPE_CHARACTER, vec2(0, 0), CCharacterCore::PhysicalSize())
 {
-	m_ID = ID;
+	m_Id = Id;
 	m_IsLocal = false;
 
 	m_LastWeapon = WEAPON_HAMMER;
@@ -1162,7 +1162,7 @@ CCharacter::CCharacter(CGameWorld *pGameWorld, int ID, CNetObj_Character *pChar,
 	m_PrevPrevPos = m_PrevPos = m_Pos = vec2(pChar->m_X, pChar->m_Y);
 	m_Core.Reset();
 	m_Core.Init(&GameWorld()->m_Core, GameWorld()->Collision(), GameWorld()->Teams());
-	m_Core.m_Id = ID;
+	m_Core.m_Id = Id;
 	mem_zero(&m_Core.m_Ninja, sizeof(m_Core.m_Ninja));
 	m_Core.m_LeftWall = true;
 	m_ReloadTimer = 0;
@@ -1171,7 +1171,7 @@ CCharacter::CCharacter(CGameWorld *pGameWorld, int ID, CNetObj_Character *pChar,
 	m_LastJetpackStrength = 400.0f;
 	m_CanMoveInFreeze = false;
 	m_TeleCheckpoint = 0;
-	m_StrongWeakID = 0;
+	m_StrongWeakId = 0;
 
 	mem_zero(&m_Input, sizeof(m_Input));
 	// never initialize both to zero
@@ -1231,7 +1231,7 @@ void CCharacter::Read(CNetObj_Character *pChar, CNetObj_DDNetCharacter *pExtende
 		SetSuper(pExtended->m_Flags & CHARACTERFLAG_SUPER);
 
 		m_TeleCheckpoint = pExtended->m_TeleCheckpoint;
-		m_StrongWeakID = pExtended->m_StrongWeakID;
+		m_StrongWeakId = pExtended->m_StrongWeakId;
 
 		const bool Ninja = (pExtended->m_Flags & CHARACTERFLAG_WEAPON_NINJA) != 0;
 		if(Ninja && m_Core.m_ActiveWeapon != WEAPON_NINJA)

--- a/src/game/client/prediction/entities/character.h
+++ b/src/game/client/prediction/entities/character.h
@@ -76,8 +76,8 @@ public:
 	bool UnFreeze();
 	void GiveAllWeapons();
 	int Team();
-	bool CanCollide(int ClientID);
-	bool SameTeam(int ClientID);
+	bool CanCollide(int ClientId);
+	bool SameTeam(int ClientId);
 	bool m_NinjaJetpack;
 	int m_FreezeTime;
 	bool m_FrozenLastTick;
@@ -106,7 +106,7 @@ public:
 	void SetNinjaActivationDir(vec2 ActivationDir) { m_Core.m_Ninja.m_ActivationDir = ActivationDir; }
 	void SetNinjaActivationTick(int ActivationTick) { m_Core.m_Ninja.m_ActivationTick = ActivationTick; }
 	void SetNinjaCurrentMoveTime(int CurrentMoveTime) { m_Core.m_Ninja.m_CurrentMoveTime = CurrentMoveTime; }
-	int GetCID() { return m_ID; }
+	int GetCid() { return m_Id; }
 	void SetInput(const CNetObj_PlayerInput *pNewInput)
 	{
 		m_LatestInput = m_Input = *pNewInput;
@@ -118,9 +118,9 @@ public:
 	};
 	int GetJumped() { return m_Core.m_Jumped; }
 	int GetAttackTick() { return m_AttackTick; }
-	int GetStrongWeakID() { return m_StrongWeakID; }
+	int GetStrongWeakId() { return m_StrongWeakId; }
 
-	CCharacter(CGameWorld *pGameWorld, int ID, CNetObj_Character *pChar, CNetObj_DDNetCharacter *pExtended = 0);
+	CCharacter(CGameWorld *pGameWorld, int Id, CNetObj_Character *pChar, CNetObj_DDNetCharacter *pExtended = 0);
 	void Read(CNetObj_Character *pChar, CNetObj_DDNetCharacter *pExtended, bool IsLocal);
 	void SetCoreWorld(CGameWorld *pGameWorld);
 
@@ -179,7 +179,7 @@ private:
 
 	CTuningParams *CharacterTuning();
 
-	int m_StrongWeakID;
+	int m_StrongWeakId;
 
 	int m_LastWeaponSwitchTick;
 	int m_LastTuneZoneTick;

--- a/src/game/client/prediction/entities/dragger.cpp
+++ b/src/game/client/prediction/entities/dragger.cpp
@@ -66,7 +66,7 @@ void CDragger::LookForPlayersToDrag()
 				!Collision()->IntersectNoLaser(m_Pos, pTarget->m_Pos, 0, 0);
 		if(IsReachable)
 		{
-			const int &TargetClientId = pTarget->GetCID();
+			const int &TargetClientId = pTarget->GetCid();
 			int Distance = distance(pTarget->m_Pos, m_Pos);
 			if(MinDistInTeam == 0 || MinDistInTeam > Distance)
 			{
@@ -94,7 +94,7 @@ void CDragger::DraggerBeamReset()
 
 void CDragger::DraggerBeamTick()
 {
-	CCharacter *pTarget = GameWorld()->GetCharacterByID(m_TargetId);
+	CCharacter *pTarget = GameWorld()->GetCharacterById(m_TargetId);
 	if(!pTarget)
 	{
 		DraggerBeamReset();
@@ -128,11 +128,11 @@ void CDragger::DraggerBeamTick()
 	}
 }
 
-CDragger::CDragger(CGameWorld *pGameWorld, int ID, const CLaserData *pData) :
+CDragger::CDragger(CGameWorld *pGameWorld, int Id, const CLaserData *pData) :
 	CEntity(pGameWorld, CGameWorld::ENTTYPE_DRAGGER)
 {
 	m_Core = vec2(0.f, 0.f);
-	m_ID = ID;
+	m_Id = Id;
 	m_TargetId = -1;
 
 	m_Strength = 0;

--- a/src/game/client/prediction/entities/dragger.h
+++ b/src/game/client/prediction/entities/dragger.h
@@ -18,7 +18,7 @@ class CDragger : public CEntity
 	void DraggerBeamReset();
 
 public:
-	CDragger(CGameWorld *pGameWorld, int ID, const CLaserData *pData);
+	CDragger(CGameWorld *pGameWorld, int Id, const CLaserData *pData);
 	bool Match(CDragger *pDragger);
 	void Read(const CLaserData *pData);
 	float GetStrength() { return m_Strength; }

--- a/src/game/client/prediction/entities/laser.cpp
+++ b/src/game/client/prediction/entities/laser.cpp
@@ -31,7 +31,7 @@ bool CLaser::HitCharacter(vec2 From, vec2 To)
 {
 	static const vec2 StackedLaserShotgunBugSpeed = vec2(-2147483648.0f, -2147483648.0f);
 	vec2 At;
-	CCharacter *pOwnerChar = GameWorld()->GetCharacterByID(m_Owner);
+	CCharacter *pOwnerChar = GameWorld()->GetCharacterById(m_Owner);
 	CCharacter *pHit;
 	bool DontHitSelf = (g_Config.m_SvOldLaser || !GameWorld()->m_WorldConfig.m_IsDDRace) || (m_Bounces == 0);
 
@@ -178,7 +178,7 @@ void CLaser::Tick()
 	}
 }
 
-CLaser::CLaser(CGameWorld *pGameWorld, int ID, CLaserData *pLaser) :
+CLaser::CLaser(CGameWorld *pGameWorld, int Id, CLaserData *pLaser) :
 	CEntity(pGameWorld, CGameWorld::ENTTYPE_LASER)
 {
 	m_Pos = pLaser->m_To;
@@ -197,7 +197,7 @@ CLaser::CLaser(CGameWorld *pGameWorld, int ID, CLaserData *pLaser) :
 		m_Energy = 0;
 	m_Type = pLaser->m_Type == LASERTYPE_SHOTGUN ? WEAPON_SHOTGUN : WEAPON_LASER;
 	m_PrevPos = m_From;
-	m_ID = ID;
+	m_Id = Id;
 }
 
 bool CLaser::Match(CLaser *pLaser)

--- a/src/game/client/prediction/entities/laser.h
+++ b/src/game/client/prediction/entities/laser.h
@@ -19,7 +19,7 @@ public:
 	const vec2 &GetFrom() { return m_From; }
 	const int &GetOwner() { return m_Owner; }
 	const int &GetEvalTick() { return m_EvalTick; }
-	CLaser(CGameWorld *pGameWorld, int ID, CLaserData *pLaser);
+	CLaser(CGameWorld *pGameWorld, int Id, CLaserData *pLaser);
 	bool Match(CLaser *pLaser);
 	CLaserData GetData() const;
 

--- a/src/game/client/prediction/entities/pickup.cpp
+++ b/src/game/client/prediction/entities/pickup.cpp
@@ -144,7 +144,7 @@ void CPickup::Move()
 	}
 }
 
-CPickup::CPickup(CGameWorld *pGameWorld, int ID, const CPickupData *pPickup) :
+CPickup::CPickup(CGameWorld *pGameWorld, int Id, const CPickupData *pPickup) :
 	CEntity(pGameWorld, CGameWorld::ENTTYPE_PICKUP, vec2(0, 0), gs_PickupPhysSize)
 {
 	m_Pos = pPickup->m_Pos;
@@ -152,7 +152,7 @@ CPickup::CPickup(CGameWorld *pGameWorld, int ID, const CPickupData *pPickup) :
 	m_Subtype = pPickup->m_Subtype;
 	m_Core = vec2(0.f, 0.f);
 	m_IsCoreActive = false;
-	m_ID = ID;
+	m_Id = Id;
 	m_Number = pPickup->m_SwitchNumber;
 	m_Layer = m_Number > 0 ? LAYER_SWITCH : LAYER_GAME;
 }

--- a/src/game/client/prediction/entities/pickup.h
+++ b/src/game/client/prediction/entities/pickup.h
@@ -14,7 +14,7 @@ public:
 
 	void Tick() override;
 
-	CPickup(CGameWorld *pGameWorld, int ID, const CPickupData *pPickup);
+	CPickup(CGameWorld *pGameWorld, int Id, const CPickupData *pPickup);
 	void FillInfo(CNetObj_Pickup *pPickup);
 	bool Match(CPickup *pPickup);
 	bool InDDNetTile() { return m_IsCoreActive; }

--- a/src/game/client/prediction/entities/projectile.cpp
+++ b/src/game/client/prediction/entities/projectile.cpp
@@ -78,7 +78,7 @@ void CProjectile::Tick()
 	vec2 ColPos;
 	vec2 NewPos;
 	int Collide = Collision()->IntersectLine(PrevPos, CurPos, &ColPos, &NewPos);
-	CCharacter *pOwnerChar = GameWorld()->GetCharacterByID(m_Owner);
+	CCharacter *pOwnerChar = GameWorld()->GetCharacterById(m_Owner);
 
 	CCharacter *pTargetChr = GameWorld()->IntersectCharacter(PrevPos, ColPos, m_Freeze ? 1.0f : 6.0f, ColPos, pOwnerChar, m_Owner);
 
@@ -140,7 +140,7 @@ void CProjectile::Tick()
 		if(m_Explosive)
 		{
 			if(m_Owner >= 0)
-				pOwnerChar = GameWorld()->GetCharacterByID(m_Owner);
+				pOwnerChar = GameWorld()->GetCharacterById(m_Owner);
 
 			GameWorld()->CreateExplosion(ColPos, m_Owner, m_Type, m_Owner == -1, (!pOwnerChar ? -1 : pOwnerChar->Team()), CClientMask().set());
 		}
@@ -155,7 +155,7 @@ void CProjectile::SetBouncing(int Value)
 	m_Bouncing = Value;
 }
 
-CProjectile::CProjectile(CGameWorld *pGameWorld, int ID, const CProjectileData *pProj) :
+CProjectile::CProjectile(CGameWorld *pGameWorld, int Id, const CProjectileData *pProj) :
 	CEntity(pGameWorld, CGameWorld::ENTTYPE_PROJECTILE)
 {
 	m_Pos = pProj->m_StartPos;
@@ -190,7 +190,7 @@ CProjectile::CProjectile(CGameWorld *pGameWorld, int ID, const CProjectileData *
 	else if(m_Type == WEAPON_SHOTGUN && !GameWorld()->m_WorldConfig.m_IsDDRace)
 		Lifetime = GetTuning(m_TuneZone)->m_ShotgunLifetime * GameWorld()->GameTickSpeed();
 	m_LifeSpan = Lifetime - (pGameWorld->GameTick() - m_StartTick);
-	m_ID = ID;
+	m_Id = Id;
 	m_Number = pProj->m_SwitchNumber;
 	m_Layer = m_Number > 0 ? LAYER_SWITCH : LAYER_GAME;
 }

--- a/src/game/client/prediction/entities/projectile.h
+++ b/src/game/client/prediction/entities/projectile.h
@@ -37,7 +37,7 @@ public:
 	const vec2 &GetDirection() { return m_Direction; }
 	const int &GetOwner() { return m_Owner; }
 	const int &GetStartTick() { return m_StartTick; }
-	CProjectile(CGameWorld *pGameWorld, int ID, const CProjectileData *pProj);
+	CProjectile(CGameWorld *pGameWorld, int Id, const CProjectileData *pProj);
 
 private:
 	vec2 m_Direction;

--- a/src/game/client/prediction/entity.cpp
+++ b/src/game/client/prediction/entity.cpp
@@ -17,7 +17,7 @@ CEntity::CEntity(CGameWorld *pGameWorld, int ObjType, vec2 Pos, int ProximityRad
 	m_ProximityRadius = ProximityRadius;
 
 	m_MarkedForDestroy = false;
-	m_ID = -1;
+	m_Id = -1;
 
 	m_pPrevTypeEntity = 0;
 	m_pNextTypeEntity = 0;

--- a/src/game/client/prediction/entity.h
+++ b/src/game/client/prediction/entity.h
@@ -21,11 +21,11 @@ private:
 protected:
 	CGameWorld *m_pGameWorld;
 	bool m_MarkedForDestroy;
-	int m_ID;
+	int m_Id;
 	int m_ObjType;
 
 public:
-	int GetID() const { return m_ID; }
+	int GetId() const { return m_Id; }
 
 	CEntity(CGameWorld *pGameWorld, int Objtype, vec2 Pos = vec2(0, 0), int ProximityRadius = 0);
 	virtual ~CEntity();
@@ -66,7 +66,7 @@ public:
 
 	CEntity()
 	{
-		m_ID = -1;
+		m_Id = -1;
 		m_pGameWorld = 0;
 	}
 };

--- a/src/game/client/prediction/gameworld.cpp
+++ b/src/game/client/prediction/gameworld.cpp
@@ -112,11 +112,11 @@ void CGameWorld::InsertEntity(CEntity *pEnt, bool Last)
 	if(pEnt->m_ObjType == ENTTYPE_CHARACTER)
 	{
 		auto *pChar = (CCharacter *)pEnt;
-		int ID = pChar->GetCID();
-		if(ID >= 0 && ID < MAX_CLIENTS)
+		int Id = pChar->GetCid();
+		if(Id >= 0 && Id < MAX_CLIENTS)
 		{
-			m_apCharacters[ID] = pChar;
-			m_Core.m_apCharacters[ID] = &pChar->m_Core;
+			m_apCharacters[Id] = pChar;
+			m_Core.m_apCharacters[Id] = &pChar->m_Core;
 		}
 		pChar->SetCoreWorld(this);
 	}
@@ -159,11 +159,11 @@ void CGameWorld::RemoveEntity(CEntity *pEnt)
 
 void CGameWorld::RemoveCharacter(CCharacter *pChar)
 {
-	int ID = pChar->GetCID();
-	if(ID >= 0 && ID < MAX_CLIENTS)
+	int Id = pChar->GetCid();
+	if(Id >= 0 && Id < MAX_CLIENTS)
 	{
-		m_apCharacters[ID] = 0;
-		m_Core.m_apCharacters[ID] = 0;
+		m_apCharacters[Id] = 0;
+		m_Core.m_apCharacters[Id] = 0;
 	}
 }
 
@@ -304,12 +304,12 @@ std::vector<CCharacter *> CGameWorld::IntersectedCharacters(vec2 Pos0, vec2 Pos1
 	return vpCharacters;
 }
 
-void CGameWorld::ReleaseHooked(int ClientID)
+void CGameWorld::ReleaseHooked(int ClientId)
 {
 	CCharacter *pChr = (CCharacter *)CGameWorld::FindFirst(CGameWorld::ENTTYPE_CHARACTER);
 	for(; pChr; pChr = (CCharacter *)pChr->TypeNext())
 	{
-		if(pChr->Core()->HookedPlayer() == ClientID && !pChr->IsSuper())
+		if(pChr->Core()->HookedPlayer() == ClientId && !pChr->IsSuper())
 		{
 			pChr->ReleaseHook();
 		}
@@ -321,10 +321,10 @@ CTuningParams *CGameWorld::Tuning()
 	return &m_Core.m_aTuning[g_Config.m_ClDummy];
 }
 
-CEntity *CGameWorld::GetEntity(int ID, int EntityType)
+CEntity *CGameWorld::GetEntity(int Id, int EntityType)
 {
 	for(CEntity *pEnt = m_apFirstEntityTypes[EntityType]; pEnt; pEnt = pEnt->m_pNextTypeEntity)
-		if(pEnt->m_ID == ID)
+		if(pEnt->m_Id == Id)
 			return pEnt;
 	return 0;
 }
@@ -349,35 +349,35 @@ void CGameWorld::CreateExplosion(vec2 Pos, int Owner, int Weapon, bool NoDamage,
 			ForceDir = normalize(Diff);
 		l = 1 - clamp((l - InnerRadius) / (Radius - InnerRadius), 0.0f, 1.0f);
 		float Strength;
-		if(Owner == -1 || !GetCharacterByID(Owner))
+		if(Owner == -1 || !GetCharacterById(Owner))
 			Strength = Tuning()->m_ExplosionStrength;
 		else
-			Strength = GetCharacterByID(Owner)->Tuning()->m_ExplosionStrength;
+			Strength = GetCharacterById(Owner)->Tuning()->m_ExplosionStrength;
 
 		float Dmg = Strength * l;
 		if((int)Dmg)
-			if((GetCharacterByID(Owner) ? !GetCharacterByID(Owner)->GrenadeHitDisabled() : g_Config.m_SvHit || NoDamage) || Owner == pChar->GetCID())
+			if((GetCharacterById(Owner) ? !GetCharacterById(Owner)->GrenadeHitDisabled() : g_Config.m_SvHit || NoDamage) || Owner == pChar->GetCid())
 			{
 				if(Owner != -1 && !pChar->CanCollide(Owner))
 					continue;
 				if(Owner == -1 && ActivatedTeam != -1 && pChar->Team() != ActivatedTeam)
 					continue;
 				pChar->TakeDamage(ForceDir * Dmg * 2, (int)Dmg, Owner, Weapon);
-				if(GetCharacterByID(Owner) ? GetCharacterByID(Owner)->GrenadeHitDisabled() : !g_Config.m_SvHit || NoDamage)
+				if(GetCharacterById(Owner) ? GetCharacterById(Owner)->GrenadeHitDisabled() : !g_Config.m_SvHit || NoDamage)
 					break;
 			}
 	}
 }
 
-bool CGameWorld::IsLocalTeam(int OwnerID) const
+bool CGameWorld::IsLocalTeam(int OwnerId) const
 {
-	return OwnerID < 0 || m_Teams.CanCollide(m_LocalClientID, OwnerID);
+	return OwnerId < 0 || m_Teams.CanCollide(m_LocalClientId, OwnerId);
 }
 
-void CGameWorld::NetObjBegin(CTeamsCore Teams, int LocalClientID)
+void CGameWorld::NetObjBegin(CTeamsCore Teams, int LocalClientId)
 {
 	m_Teams = Teams;
-	m_LocalClientID = LocalClientID;
+	m_LocalClientId = LocalClientId;
 
 	for(int i = 0; i < NUM_ENTTYPES; i++)
 		for(CEntity *pEnt = FindFirst(i); pEnt; pEnt = pEnt->TypeNext())
@@ -389,19 +389,19 @@ void CGameWorld::NetObjBegin(CTeamsCore Teams, int LocalClientID)
 	OnModified();
 }
 
-void CGameWorld::NetCharAdd(int ObjID, CNetObj_Character *pCharObj, CNetObj_DDNetCharacter *pExtended, int GameTeam, bool IsLocal)
+void CGameWorld::NetCharAdd(int ObjId, CNetObj_Character *pCharObj, CNetObj_DDNetCharacter *pExtended, int GameTeam, bool IsLocal)
 {
-	if(IsLocalTeam(ObjID))
+	if(IsLocalTeam(ObjId))
 	{
 		CCharacter *pChar;
-		if((pChar = (CCharacter *)GetEntity(ObjID, ENTTYPE_CHARACTER)))
+		if((pChar = (CCharacter *)GetEntity(ObjId, ENTTYPE_CHARACTER)))
 		{
 			pChar->Read(pCharObj, pExtended, IsLocal);
 			pChar->Keep();
 		}
 		else
 		{
-			pChar = new CCharacter(this, ObjID, pCharObj, pExtended);
+			pChar = new CCharacter(this, ObjId, pCharObj, pExtended);
 			InsertEntity(pChar);
 		}
 
@@ -410,7 +410,7 @@ void CGameWorld::NetCharAdd(int ObjID, CNetObj_Character *pCharObj, CNetObj_DDNe
 	}
 }
 
-void CGameWorld::NetObjAdd(int ObjID, int ObjType, const void *pObjData, const CNetObj_EntityEx *pDataEx)
+void CGameWorld::NetObjAdd(int ObjId, int ObjType, const void *pObjData, const CNetObj_EntityEx *pDataEx)
 {
 	if((ObjType == NETOBJTYPE_PROJECTILE || ObjType == NETOBJTYPE_DDRACEPROJECTILE || ObjType == NETOBJTYPE_DDNETPROJECTILE) && m_WorldConfig.m_PredictWeapons)
 	{
@@ -418,12 +418,12 @@ void CGameWorld::NetObjAdd(int ObjID, int ObjType, const void *pObjData, const C
 		if(!IsLocalTeam(Data.m_Owner))
 			return;
 
-		CProjectile NetProj = CProjectile(this, ObjID, &Data);
+		CProjectile NetProj = CProjectile(this, ObjId, &Data);
 
 		if(NetProj.m_Type != WEAPON_SHOTGUN && absolute(length(NetProj.m_Direction) - 1.f) > 0.02f) // workaround to skip grenades on ball mod
 			return;
 
-		if(CProjectile *pProj = (CProjectile *)GetEntity(ObjID, ENTTYPE_PROJECTILE))
+		if(CProjectile *pProj = (CProjectile *)GetEntity(ObjId, ENTTYPE_PROJECTILE))
 		{
 			if(NetProj.Match(pProj))
 			{
@@ -438,9 +438,9 @@ void CGameWorld::NetObjAdd(int ObjID, int ObjType, const void *pObjData, const C
 			// try to match the newly received (unrecognized) projectile with a locally fired one
 			for(CProjectile *pProj = (CProjectile *)FindFirst(CGameWorld::ENTTYPE_PROJECTILE); pProj; pProj = (CProjectile *)pProj->TypeNext())
 			{
-				if(pProj->m_ID == -1 && NetProj.Match(pProj))
+				if(pProj->m_Id == -1 && NetProj.Match(pProj))
 				{
-					pProj->m_ID = ObjID;
+					pProj->m_Id = ObjId;
 					pProj->Keep();
 					return;
 				}
@@ -464,7 +464,7 @@ void CGameWorld::NetObjAdd(int ObjID, int ObjType, const void *pObjData, const C
 						Second = Dist;
 				}
 				if(pClosest && maximum(First, 2.f) * 1.2f < Second)
-					NetProj.m_Owner = pClosest->m_ID;
+					NetProj.m_Owner = pClosest->m_Id;
 			}
 		}
 		CProjectile *pProj = new CProjectile(NetProj);
@@ -473,8 +473,8 @@ void CGameWorld::NetObjAdd(int ObjID, int ObjType, const void *pObjData, const C
 	else if((ObjType == NETOBJTYPE_PICKUP || ObjType == NETOBJTYPE_DDNETPICKUP) && m_WorldConfig.m_PredictWeapons)
 	{
 		CPickupData Data = ExtractPickupInfo(ObjType, pObjData, pDataEx);
-		CPickup NetPickup = CPickup(this, ObjID, &Data);
-		if(CPickup *pPickup = (CPickup *)GetEntity(ObjID, ENTTYPE_PICKUP))
+		CPickup NetPickup = CPickup(this, ObjId, &Data);
+		if(CPickup *pPickup = (CPickup *)GetEntity(ObjId, ENTTYPE_PICKUP))
 		{
 			if(NetPickup.Match(pPickup))
 			{
@@ -496,9 +496,9 @@ void CGameWorld::NetObjAdd(int ObjID, int ObjType, const void *pObjData, const C
 
 		if(Data.m_Type == LASERTYPE_RIFLE || Data.m_Type == LASERTYPE_SHOTGUN || Data.m_Type < 0)
 		{
-			CLaser NetLaser = CLaser(this, ObjID, &Data);
+			CLaser NetLaser = CLaser(this, ObjId, &Data);
 			CLaser *pMatching = 0;
-			if(CLaser *pLaser = dynamic_cast<CLaser *>(GetEntity(ObjID, ENTTYPE_LASER)))
+			if(CLaser *pLaser = dynamic_cast<CLaser *>(GetEntity(ObjId, ENTTYPE_LASER)))
 				if(NetLaser.Match(pLaser))
 					pMatching = pLaser;
 			if(!pMatching)
@@ -506,10 +506,10 @@ void CGameWorld::NetObjAdd(int ObjID, int ObjType, const void *pObjData, const C
 				for(CEntity *pEnt = FindFirst(CGameWorld::ENTTYPE_LASER); pEnt; pEnt = pEnt->TypeNext())
 				{
 					auto *const pLaser = dynamic_cast<CLaser *>(pEnt);
-					if(pLaser && pLaser->m_ID == -1 && NetLaser.Match(pLaser))
+					if(pLaser && pLaser->m_Id == -1 && NetLaser.Match(pLaser))
 					{
 						pMatching = pLaser;
-						pMatching->m_ID = ObjID;
+						pMatching->m_Id = ObjId;
 						break;
 					}
 				}
@@ -527,10 +527,10 @@ void CGameWorld::NetObjAdd(int ObjID, int ObjType, const void *pObjData, const C
 		}
 		else if(Data.m_Type == LASERTYPE_DRAGGER)
 		{
-			CDragger NetDragger = CDragger(this, ObjID, &Data);
+			CDragger NetDragger = CDragger(this, ObjId, &Data);
 			if(NetDragger.GetStrength() > 0)
 			{
-				auto *pDragger = dynamic_cast<CDragger *>(GetEntity(ObjID, ENTTYPE_DRAGGER));
+				auto *pDragger = dynamic_cast<CDragger *>(GetEntity(ObjId, ENTTYPE_DRAGGER));
 				if(pDragger && NetDragger.Match(pDragger))
 				{
 					pDragger->Keep();
@@ -548,9 +548,9 @@ void CGameWorld::NetObjEnd()
 {
 	// keep predicting hooked characters, based on hook position
 	for(int i = 0; i < MAX_CLIENTS; i++)
-		if(CCharacter *pChar = GetCharacterByID(i))
+		if(CCharacter *pChar = GetCharacterById(i))
 			if(!pChar->m_MarkedForDestroy)
-				if(CCharacter *pHookedChar = GetCharacterByID(pChar->m_Core.HookedPlayer()))
+				if(CCharacter *pHookedChar = GetCharacterById(pChar->m_Core.HookedPlayer()))
 					if(pHookedChar->m_MarkedForDestroy)
 					{
 						pHookedChar->m_Pos = pHookedChar->m_Core.m_Pos = pChar->m_Core.m_HookPos;
@@ -570,11 +570,11 @@ void CGameWorld::NetObjEnd()
 	}
 	for(CCharacter *pChar = (CCharacter *)FindFirst(ENTTYPE_CHARACTER); pChar; pChar = (CCharacter *)pChar->TypeNext())
 	{
-		int ID = pChar->GetCID();
-		if(ID >= 0 && ID < MAX_CLIENTS)
+		int Id = pChar->GetCid();
+		if(Id >= 0 && Id < MAX_CLIENTS)
 		{
-			m_apCharacters[ID] = pChar;
-			m_Core.m_apCharacters[ID] = &pChar->m_Core;
+			m_apCharacters[Id] = pChar;
+			m_Core.m_apCharacters[Id] = &pChar->m_Core;
 		}
 	}
 }
@@ -633,14 +633,14 @@ void CGameWorld::CopyWorld(CGameWorld *pFrom)
 	m_IsValidCopy = true;
 }
 
-CEntity *CGameWorld::FindMatch(int ObjID, int ObjType, const void *pObjData)
+CEntity *CGameWorld::FindMatch(int ObjId, int ObjType, const void *pObjData)
 {
 	switch(ObjType)
 	{
 	case NETOBJTYPE_CHARACTER:
 	{
-		CCharacter *pEnt = (CCharacter *)GetEntity(ObjID, ENTTYPE_CHARACTER);
-		if(pEnt && CCharacter(this, ObjID, (CNetObj_Character *)pObjData).Match((CCharacter *)pEnt))
+		CCharacter *pEnt = (CCharacter *)GetEntity(ObjId, ENTTYPE_CHARACTER);
+		if(pEnt && CCharacter(this, ObjId, (CNetObj_Character *)pObjData).Match((CCharacter *)pEnt))
 		{
 			return pEnt;
 		}
@@ -651,8 +651,8 @@ CEntity *CGameWorld::FindMatch(int ObjID, int ObjType, const void *pObjData)
 	case NETOBJTYPE_DDNETPROJECTILE:
 	{
 		CProjectileData Data = ExtractProjectileInfo(ObjType, pObjData, this, nullptr);
-		CProjectile *pEnt = (CProjectile *)GetEntity(ObjID, ENTTYPE_PROJECTILE);
-		if(pEnt && CProjectile(this, ObjID, &Data).Match(pEnt))
+		CProjectile *pEnt = (CProjectile *)GetEntity(ObjId, ENTTYPE_PROJECTILE);
+		if(pEnt && CProjectile(this, ObjId, &Data).Match(pEnt))
 		{
 			return pEnt;
 		}
@@ -664,16 +664,16 @@ CEntity *CGameWorld::FindMatch(int ObjID, int ObjType, const void *pObjData)
 		CLaserData Data = ExtractLaserInfo(ObjType, pObjData, this, nullptr);
 		if(Data.m_Type == LASERTYPE_RIFLE || Data.m_Type == LASERTYPE_SHOTGUN)
 		{
-			CLaser *pEnt = (CLaser *)GetEntity(ObjID, ENTTYPE_LASER);
-			if(pEnt && CLaser(this, ObjID, &Data).Match(pEnt))
+			CLaser *pEnt = (CLaser *)GetEntity(ObjId, ENTTYPE_LASER);
+			if(pEnt && CLaser(this, ObjId, &Data).Match(pEnt))
 			{
 				return pEnt;
 			}
 		}
 		else if(Data.m_Type == LASERTYPE_DRAGGER)
 		{
-			CDragger *pEnt = (CDragger *)GetEntity(ObjID, ENTTYPE_DRAGGER);
-			if(pEnt && CDragger(this, ObjID, &Data).Match(pEnt))
+			CDragger *pEnt = (CDragger *)GetEntity(ObjId, ENTTYPE_DRAGGER);
+			if(pEnt && CDragger(this, ObjId, &Data).Match(pEnt))
 			{
 				return pEnt;
 			}
@@ -684,8 +684,8 @@ CEntity *CGameWorld::FindMatch(int ObjID, int ObjType, const void *pObjData)
 	case NETOBJTYPE_DDNETPICKUP:
 	{
 		CPickupData Data = ExtractPickupInfo(ObjType, pObjData, nullptr);
-		CPickup *pEnt = (CPickup *)GetEntity(ObjID, ENTTYPE_PICKUP);
-		if(pEnt && CPickup(this, ObjID, &Data).Match(pEnt))
+		CPickup *pEnt = (CPickup *)GetEntity(ObjId, ENTTYPE_PICKUP);
+		if(pEnt && CPickup(this, ObjId, &Data).Match(pEnt))
 		{
 			return pEnt;
 		}

--- a/src/game/client/prediction/gameworld.h
+++ b/src/game/client/prediction/gameworld.h
@@ -47,7 +47,7 @@ public:
 	void Tick();
 
 	// DDRace
-	void ReleaseHooked(int ClientID);
+	void ReleaseHooked(int ClientId);
 	std::vector<CCharacter *> IntersectedCharacters(vec2 Pos0, vec2 Pos1, float Radius, const CEntity *pNotThis = nullptr);
 
 	int m_GameTick;
@@ -60,8 +60,8 @@ public:
 	CTeamsCore *Teams() { return &m_Teams; }
 	std::vector<SSwitchers> &Switchers() { return m_Core.m_vSwitchers; }
 	CTuningParams *Tuning();
-	CEntity *GetEntity(int ID, int EntityType);
-	CCharacter *GetCharacterByID(int ID) { return (ID >= 0 && ID < MAX_CLIENTS) ? m_apCharacters[ID] : nullptr; }
+	CEntity *GetEntity(int Id, int EntityType);
+	CCharacter *GetCharacterById(int Id) { return (Id >= 0 && Id < MAX_CLIENTS) ? m_apCharacters[Id] : nullptr; }
 
 	// from gamecontext
 	void CreateExplosion(vec2 Pos, int Owner, int Weapon, bool NoDamage, int ActivatedTeam, CClientMask Mask);
@@ -87,16 +87,16 @@ public:
 	CGameWorld *m_pParent;
 	CGameWorld *m_pChild;
 
-	int m_LocalClientID;
+	int m_LocalClientId;
 
-	bool IsLocalTeam(int OwnerID) const;
+	bool IsLocalTeam(int OwnerId) const;
 	void OnModified() const;
-	void NetObjBegin(CTeamsCore Teams, int LocalClientID);
-	void NetCharAdd(int ObjID, CNetObj_Character *pChar, CNetObj_DDNetCharacter *pExtended, int GameTeam, bool IsLocal);
-	void NetObjAdd(int ObjID, int ObjType, const void *pObjData, const CNetObj_EntityEx *pDataEx);
+	void NetObjBegin(CTeamsCore Teams, int LocalClientId);
+	void NetCharAdd(int ObjId, CNetObj_Character *pChar, CNetObj_DDNetCharacter *pExtended, int GameTeam, bool IsLocal);
+	void NetObjAdd(int ObjId, int ObjType, const void *pObjData, const CNetObj_EntityEx *pDataEx);
 	void NetObjEnd();
 	void CopyWorld(CGameWorld *pFrom);
-	CEntity *FindMatch(int ObjID, int ObjType, const void *pObjData);
+	CEntity *FindMatch(int ObjId, int ObjType, const void *pObjData);
 	void Clear();
 
 	CTuningParams *m_pTuningList;
@@ -115,31 +115,31 @@ private:
 class CCharOrder
 {
 public:
-	std::list<int> m_IDs; // reverse of the order in the gameworld, since entities will be inserted in reverse
+	std::list<int> m_Ids; // reverse of the order in the gameworld, since entities will be inserted in reverse
 	CCharOrder()
 	{
 		for(int i = 0; i < MAX_CLIENTS; i++)
-			m_IDs.push_back(i);
+			m_Ids.push_back(i);
 	}
 	void GiveStrong(int c)
 	{
 		if(0 <= c && c < MAX_CLIENTS)
 		{
-			m_IDs.remove(c);
-			m_IDs.push_front(c);
+			m_Ids.remove(c);
+			m_Ids.push_front(c);
 		}
 	}
 	void GiveWeak(int c)
 	{
 		if(0 <= c && c < MAX_CLIENTS)
 		{
-			m_IDs.remove(c);
-			m_IDs.push_back(c);
+			m_Ids.remove(c);
+			m_Ids.push_back(c);
 		}
 	}
 	bool HasStrongAgainst(int From, int To)
 	{
-		for(int i : m_IDs)
+		for(int i : m_Ids)
 		{
 			if(i == To)
 				return false;

--- a/src/game/client/race.cpp
+++ b/src/game/client/race.cpp
@@ -71,7 +71,7 @@ bool CRaceHelper::IsStart(CGameClient *pClient, vec2 Prev, vec2 Pos)
 	CCollision *pCollision = pClient->Collision();
 	if(pClient->m_GameInfo.m_FlagStartsRace)
 	{
-		int EnemyTeam = pClient->m_aClients[pClient->m_Snap.m_LocalClientID].m_Team ^ 1;
+		int EnemyTeam = pClient->m_aClients[pClient->m_Snap.m_LocalClientId].m_Team ^ 1;
 		return ms_aFlagIndex[EnemyTeam] != -1 && distance(Pos, pCollision->GetPos(ms_aFlagIndex[EnemyTeam])) < 32;
 	}
 	else

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -18,7 +18,7 @@
 
 using namespace FontIcons;
 
-void CUIElement::Init(CUI *pUI, int RequestedRectCount)
+void CUIElement::Init(CUi *pUI, int RequestedRectCount)
 {
 	m_pUI = pUI;
 	pUI->AddUIElement(this);
@@ -28,7 +28,7 @@ void CUIElement::Init(CUI *pUI, int RequestedRectCount)
 
 void CUIElement::InitRects(int RequestedRectCount)
 {
-	dbg_assert(m_vUIRects.empty(), "UI rects can only be initialized once, create another ui element instead.");
+	dbg_assert(m_vUIRects.empty(), "Ui rects can only be initialized once, create another ui element instead.");
 	m_vUIRects.resize(RequestedRectCount);
 	for(auto &Rect : m_vUIRects)
 		Rect.m_pParent = this;
@@ -59,7 +59,7 @@ void CUIElement::SUIElementRect::Draw(const CUIRect *pRect, ColorRGBA Color, int
 	bool NeedsRecreate = false;
 	if(m_UIRectQuadContainer == -1 || m_Width != pRect->w || m_Height != pRect->h || mem_comp(&m_QuadColor, &Color, sizeof(Color)) != 0)
 	{
-		m_pParent->UI()->Graphics()->DeleteQuadContainer(m_UIRectQuadContainer);
+		m_pParent->Ui()->Graphics()->DeleteQuadContainer(m_UIRectQuadContainer);
 		NeedsRecreate = true;
 	}
 	m_X = pRect->x;
@@ -70,13 +70,13 @@ void CUIElement::SUIElementRect::Draw(const CUIRect *pRect, ColorRGBA Color, int
 		m_Height = pRect->h;
 		m_QuadColor = Color;
 
-		m_pParent->UI()->Graphics()->SetColor(Color);
-		m_UIRectQuadContainer = m_pParent->UI()->Graphics()->CreateRectQuadContainer(0, 0, pRect->w, pRect->h, Rounding, Corners);
-		m_pParent->UI()->Graphics()->SetColor(1, 1, 1, 1);
+		m_pParent->Ui()->Graphics()->SetColor(Color);
+		m_UIRectQuadContainer = m_pParent->Ui()->Graphics()->CreateRectQuadContainer(0, 0, pRect->w, pRect->h, Rounding, Corners);
+		m_pParent->Ui()->Graphics()->SetColor(1, 1, 1, 1);
 	}
 
-	m_pParent->UI()->Graphics()->TextureClear();
-	m_pParent->UI()->Graphics()->RenderQuadContainerEx(m_UIRectQuadContainer,
+	m_pParent->Ui()->Graphics()->TextureClear();
+	m_pParent->Ui()->Graphics()->RenderQuadContainerEx(m_UIRectQuadContainer,
 		0, -1, m_X, m_Y, 1, 1);
 }
 
@@ -84,21 +84,21 @@ void CUIElement::SUIElementRect::Draw(const CUIRect *pRect, ColorRGBA Color, int
  UI
 *********************************************************/
 
-const CLinearScrollbarScale CUI::ms_LinearScrollbarScale;
-const CLogarithmicScrollbarScale CUI::ms_LogarithmicScrollbarScale(25);
-const CDarkButtonColorFunction CUI::ms_DarkButtonColorFunction;
-const CLightButtonColorFunction CUI::ms_LightButtonColorFunction;
-const CScrollBarColorFunction CUI::ms_ScrollBarColorFunction;
-const float CUI::ms_FontmodHeight = 0.8f;
+const CLinearScrollbarScale CUi::ms_LinearScrollbarScale;
+const CLogarithmicScrollbarScale CUi::ms_LogarithmicScrollbarScale(25);
+const CDarkButtonColorFunction CUi::ms_DarkButtonColorFunction;
+const CLightButtonColorFunction CUi::ms_LightButtonColorFunction;
+const CScrollBarColorFunction CUi::ms_ScrollBarColorFunction;
+const float CUi::ms_FontmodHeight = 0.8f;
 
-CUI *CUIElementBase::s_pUI = nullptr;
+CUi *CUIElementBase::s_pUI = nullptr;
 
 IClient *CUIElementBase::Client() const { return s_pUI->Client(); }
 IGraphics *CUIElementBase::Graphics() const { return s_pUI->Graphics(); }
 IInput *CUIElementBase::Input() const { return s_pUI->Input(); }
 ITextRender *CUIElementBase::TextRender() const { return s_pUI->TextRender(); }
 
-void CUI::Init(IKernel *pKernel)
+void CUi::Init(IKernel *pKernel)
 {
 	m_pClient = pKernel->RequestInterface<IClient>();
 	m_pGraphics = pKernel->RequestInterface<IGraphics>();
@@ -109,7 +109,7 @@ void CUI::Init(IKernel *pKernel)
 	CUIElementBase::Init(this);
 }
 
-CUI::CUI()
+CUi::CUi()
 {
 	m_Enabled = true;
 
@@ -129,7 +129,7 @@ CUI::CUI()
 	m_Screen.y = 0.0f;
 }
 
-CUI::~CUI()
+CUi::~CUi()
 {
 	for(CUIElement *&pEl : m_vpOwnUIElements)
 	{
@@ -138,7 +138,7 @@ CUI::~CUI()
 	m_vpOwnUIElements.clear();
 }
 
-CUIElement *CUI::GetNewUIElement(int RequestedRectCount)
+CUIElement *CUi::GetNewUIElement(int RequestedRectCount)
 {
 	CUIElement *pNewEl = new CUIElement(this, RequestedRectCount);
 
@@ -147,12 +147,12 @@ CUIElement *CUI::GetNewUIElement(int RequestedRectCount)
 	return pNewEl;
 }
 
-void CUI::AddUIElement(CUIElement *pElement)
+void CUi::AddUIElement(CUIElement *pElement)
 {
 	m_vpUIElements.push_back(pElement);
 }
 
-void CUI::ResetUIElement(CUIElement &UIElement) const
+void CUi::ResetUIElement(CUIElement &UIElement) const
 {
 	for(CUIElement::SUIElementRect &Rect : UIElement.m_vUIRects)
 	{
@@ -162,7 +162,7 @@ void CUI::ResetUIElement(CUIElement &UIElement) const
 	}
 }
 
-void CUI::OnElementsReset()
+void CUi::OnElementsReset()
 {
 	for(CUIElement *pEl : m_vpUIElements)
 	{
@@ -170,12 +170,12 @@ void CUI::OnElementsReset()
 	}
 }
 
-void CUI::OnWindowResize()
+void CUi::OnWindowResize()
 {
 	OnElementsReset();
 }
 
-void CUI::OnCursorMove(float X, float Y)
+void CUi::OnCursorMove(float X, float Y)
 {
 	if(!CheckMouseLock())
 	{
@@ -186,7 +186,7 @@ void CUI::OnCursorMove(float X, float Y)
 	m_UpdatedMouseDelta += vec2(X, Y);
 }
 
-void CUI::Update()
+void CUi::Update()
 {
 	const CUIRect *pScreen = Screen();
 	const float MouseX = (m_UpdatedMousePos.x / (float)Graphics()->WindowWidth()) * pScreen->w;
@@ -195,7 +195,7 @@ void CUI::Update()
 	m_UpdatedMouseDelta = vec2(0.0f, 0.0f);
 }
 
-void CUI::Update(float MouseX, float MouseY, float MouseDeltaX, float MouseDeltaY, float MouseWorldX, float MouseWorldY)
+void CUi::Update(float MouseX, float MouseY, float MouseDeltaX, float MouseDeltaY, float MouseWorldX, float MouseWorldY)
 {
 	unsigned MouseButtons = 0;
 	if(Enabled())
@@ -234,7 +234,7 @@ void CUI::Update(float MouseX, float MouseY, float MouseDeltaX, float MouseDelta
 	}
 }
 
-void CUI::DebugRender()
+void CUi::DebugRender()
 {
 	MapScreen();
 
@@ -243,12 +243,12 @@ void CUI::DebugRender()
 	TextRender()->Text(2.0f, Screen()->h - 12.0f, 10.0f, aBuf);
 }
 
-bool CUI::MouseInside(const CUIRect *pRect) const
+bool CUi::MouseInside(const CUIRect *pRect) const
 {
 	return pRect->Inside(m_MouseX, m_MouseY);
 }
 
-void CUI::ConvertMouseMove(float *pX, float *pY, IInput::ECursorType CursorType) const
+void CUi::ConvertMouseMove(float *pX, float *pY, IInput::ECursorType CursorType) const
 {
 	float Factor = 1.0f;
 	switch(CursorType)
@@ -260,7 +260,7 @@ void CUI::ConvertMouseMove(float *pX, float *pY, IInput::ECursorType CursorType)
 		Factor = g_Config.m_UiControllerSens / 100.0f;
 		break;
 	default:
-		dbg_msg("assert", "CUI::ConvertMouseMove CursorType %d", (int)CursorType);
+		dbg_msg("assert", "CUi::ConvertMouseMove CursorType %d", (int)CursorType);
 		dbg_break();
 		break;
 	}
@@ -272,14 +272,14 @@ void CUI::ConvertMouseMove(float *pX, float *pY, IInput::ECursorType CursorType)
 	*pY *= Factor;
 }
 
-bool CUI::ConsumeHotkey(EHotkey Hotkey)
+bool CUi::ConsumeHotkey(EHotkey Hotkey)
 {
 	const bool Pressed = m_HotkeysPressed & Hotkey;
 	m_HotkeysPressed &= ~Hotkey;
 	return Pressed;
 }
 
-bool CUI::OnInput(const IInput::CEvent &Event)
+bool CUi::OnInput(const IInput::CEvent &Event)
 {
 	if(!Enabled())
 		return false;
@@ -320,34 +320,34 @@ bool CUI::OnInput(const IInput::CEvent &Event)
 	return false;
 }
 
-float CUI::ButtonColorMul(const void *pID)
+float CUi::ButtonColorMul(const void *pId)
 {
-	if(CheckActiveItem(pID))
+	if(CheckActiveItem(pId))
 		return ButtonColorMulActive();
-	else if(HotItem() == pID)
+	else if(HotItem() == pId)
 		return ButtonColorMulHot();
 	return ButtonColorMulDefault();
 }
 
-const CUIRect *CUI::Screen()
+const CUIRect *CUi::Screen()
 {
 	m_Screen.h = 600.0f;
 	m_Screen.w = Graphics()->ScreenAspect() * m_Screen.h;
 	return &m_Screen;
 }
 
-void CUI::MapScreen()
+void CUi::MapScreen()
 {
 	const CUIRect *pScreen = Screen();
 	Graphics()->MapScreen(pScreen->x, pScreen->y, pScreen->w, pScreen->h);
 }
 
-float CUI::PixelSize()
+float CUi::PixelSize()
 {
 	return Screen()->w / Graphics()->ScreenWidth();
 }
 
-void CUI::ClipEnable(const CUIRect *pRect)
+void CUi::ClipEnable(const CUIRect *pRect)
 {
 	if(IsClipped())
 	{
@@ -366,20 +366,20 @@ void CUI::ClipEnable(const CUIRect *pRect)
 	UpdateClipping();
 }
 
-void CUI::ClipDisable()
+void CUi::ClipDisable()
 {
 	dbg_assert(IsClipped(), "no clip region");
 	m_vClips.pop_back();
 	UpdateClipping();
 }
 
-const CUIRect *CUI::ClipArea() const
+const CUIRect *CUi::ClipArea() const
 {
 	dbg_assert(IsClipped(), "no clip region");
 	return &m_vClips.back();
 }
 
-void CUI::UpdateClipping()
+void CUi::UpdateClipping()
 {
 	if(IsClipped())
 	{
@@ -394,14 +394,14 @@ void CUI::UpdateClipping()
 	}
 }
 
-int CUI::DoButtonLogic(const void *pID, int Checked, const CUIRect *pRect)
+int CUi::DoButtonLogic(const void *pId, int Checked, const CUIRect *pRect)
 {
 	// logic
 	int ReturnValue = 0;
 	const bool Inside = MouseHovered(pRect);
 	static int s_ButtonUsed = -1;
 
-	if(CheckActiveItem(pID))
+	if(CheckActiveItem(pId))
 	{
 		if(s_ButtonUsed >= 0 && !MouseButton(s_ButtonUsed))
 		{
@@ -411,25 +411,25 @@ int CUI::DoButtonLogic(const void *pID, int Checked, const CUIRect *pRect)
 			s_ButtonUsed = -1;
 		}
 	}
-	else if(HotItem() == pID)
+	else if(HotItem() == pId)
 	{
 		for(int i = 0; i < 3; ++i)
 		{
 			if(MouseButton(i))
 			{
-				SetActiveItem(pID);
+				SetActiveItem(pId);
 				s_ButtonUsed = i;
 			}
 		}
 	}
 
 	if(Inside && !MouseButton(0) && !MouseButton(1) && !MouseButton(2))
-		SetHotItem(pID);
+		SetHotItem(pId);
 
 	return ReturnValue;
 }
 
-int CUI::DoDraggableButtonLogic(const void *pID, int Checked, const CUIRect *pRect, bool *pClicked, bool *pAbrupted)
+int CUi::DoDraggableButtonLogic(const void *pId, int Checked, const CUIRect *pRect, bool *pClicked, bool *pAbrupted)
 {
 	// logic
 	int ReturnValue = 0;
@@ -441,7 +441,7 @@ int CUI::DoDraggableButtonLogic(const void *pID, int Checked, const CUIRect *pRe
 	if(pAbrupted != nullptr)
 		*pAbrupted = false;
 
-	if(CheckActiveItem(pID))
+	if(CheckActiveItem(pId))
 	{
 		if(s_ButtonUsed == 0)
 		{
@@ -472,54 +472,54 @@ int CUI::DoDraggableButtonLogic(const void *pID, int Checked, const CUIRect *pRe
 			s_ButtonUsed = -1;
 		}
 	}
-	else if(HotItem() == pID)
+	else if(HotItem() == pId)
 	{
 		for(int i = 0; i < 3; ++i)
 		{
 			if(MouseButton(i))
 			{
-				SetActiveItem(pID);
+				SetActiveItem(pId);
 				s_ButtonUsed = i;
 			}
 		}
 	}
 
 	if(Inside && !MouseButton(0) && !MouseButton(1) && !MouseButton(2))
-		SetHotItem(pID);
+		SetHotItem(pId);
 
 	return ReturnValue;
 }
 
-EEditState CUI::DoPickerLogic(const void *pID, const CUIRect *pRect, float *pX, float *pY)
+EEditState CUi::DoPickerLogic(const void *pId, const CUIRect *pRect, float *pX, float *pY)
 {
 	static const void *s_pEditing = nullptr;
 
 	if(MouseHovered(pRect))
-		SetHotItem(pID);
+		SetHotItem(pId);
 
 	EEditState Res = EEditState::EDITING;
 
-	if(HotItem() == pID && MouseButtonClicked(0))
+	if(HotItem() == pId && MouseButtonClicked(0))
 	{
-		SetActiveItem(pID);
+		SetActiveItem(pId);
 		if(!s_pEditing)
 		{
-			s_pEditing = pID;
+			s_pEditing = pId;
 			Res = EEditState::START;
 		}
 	}
 
-	if(CheckActiveItem(pID) && !MouseButton(0))
+	if(CheckActiveItem(pId) && !MouseButton(0))
 	{
 		SetActiveItem(nullptr);
-		if(s_pEditing == pID)
+		if(s_pEditing == pId)
 		{
 			s_pEditing = nullptr;
 			Res = EEditState::END;
 		}
 	}
 
-	if(!CheckActiveItem(pID) && Res == EEditState::EDITING)
+	if(!CheckActiveItem(pId) && Res == EEditState::EDITING)
 		return EEditState::NONE;
 
 	if(Input()->ShiftIsPressed())
@@ -533,7 +533,7 @@ EEditState CUI::DoPickerLogic(const void *pID, const CUIRect *pRect, float *pX, 
 	return Res;
 }
 
-void CUI::DoSmoothScrollLogic(float *pScrollOffset, float *pScrollOffsetChange, float ViewPortSize, float TotalSize, bool SmoothClamp, float ScrollSpeed) const
+void CUi::DoSmoothScrollLogic(float *pScrollOffset, float *pScrollOffsetChange, float ViewPortSize, float TotalSize, bool SmoothClamp, float ScrollSpeed) const
 {
 	// reset scrolling if it's not necessary anymore
 	if(TotalSize < ViewPortSize)
@@ -639,7 +639,7 @@ static int GetFlagsForLabelProperties(const SLabelProperties &LabelProps, const 
 	return Flags;
 }
 
-vec2 CUI::CalcAlignedCursorPos(const CUIRect *pRect, vec2 TextSize, int Align, const float *pBiggestCharHeight)
+vec2 CUi::CalcAlignedCursorPos(const CUIRect *pRect, vec2 TextSize, int Align, const float *pBiggestCharHeight)
 {
 	vec2 Cursor(pRect->x, pRect->y);
 
@@ -666,7 +666,7 @@ vec2 CUI::CalcAlignedCursorPos(const CUIRect *pRect, vec2 TextSize, int Align, c
 	return Cursor;
 }
 
-void CUI::DoLabel(const CUIRect *pRect, const char *pText, float Size, int Align, const SLabelProperties &LabelProps) const
+void CUi::DoLabel(const CUIRect *pRect, const char *pText, float Size, int Align, const SLabelProperties &LabelProps) const
 {
 	const int Flags = GetFlagsForLabelProperties(LabelProps, nullptr);
 	const SCursorAndBoundingBox TextBounds = CalcFontSizeCursorHeightAndBoundingBox(TextRender(), pText, Flags, Size, pRect->w, LabelProps);
@@ -679,7 +679,7 @@ void CUI::DoLabel(const CUIRect *pRect, const char *pText, float Size, int Align
 	TextRender()->TextEx(&Cursor, pText, -1);
 }
 
-void CUI::DoLabel(CUIElement::SUIElementRect &RectEl, const CUIRect *pRect, const char *pText, float Size, int Align, const SLabelProperties &LabelProps, int StrLen, const CTextCursor *pReadCursor) const
+void CUi::DoLabel(CUIElement::SUIElementRect &RectEl, const CUIRect *pRect, const char *pText, float Size, int Align, const SLabelProperties &LabelProps, int StrLen, const CTextCursor *pReadCursor) const
 {
 	const int Flags = GetFlagsForLabelProperties(LabelProps, pReadCursor);
 	const SCursorAndBoundingBox TextBounds = CalcFontSizeCursorHeightAndBoundingBox(TextRender(), pText, Flags, Size, pRect->w, LabelProps);
@@ -706,7 +706,7 @@ void CUI::DoLabel(CUIElement::SUIElementRect &RectEl, const CUIRect *pRect, cons
 	RectEl.m_Cursor = Cursor;
 }
 
-void CUI::DoLabelStreamed(CUIElement::SUIElementRect &RectEl, const CUIRect *pRect, const char *pText, float Size, int Align, const SLabelProperties &LabelProps, int StrLen, const CTextCursor *pReadCursor) const
+void CUi::DoLabelStreamed(CUIElement::SUIElementRect &RectEl, const CUIRect *pRect, const char *pText, float Size, int Align, const SLabelProperties &LabelProps, int StrLen, const CTextCursor *pReadCursor) const
 {
 	const int ReadCursorGlyphCount = pReadCursor == nullptr ? -1 : pReadCursor->m_GlyphCount;
 	bool NeedsRecreate = false;
@@ -762,7 +762,7 @@ void CUI::DoLabelStreamed(CUIElement::SUIElementRect &RectEl, const CUIRect *pRe
 	}
 }
 
-bool CUI::DoEditBox(CLineInput *pLineInput, const CUIRect *pRect, float FontSize, int Corners, const std::vector<STextColorSplit> &vColorSplits)
+bool CUi::DoEditBox(CLineInput *pLineInput, const CUIRect *pRect, float FontSize, int Corners, const std::vector<STextColorSplit> &vColorSplits)
 {
 	const bool Inside = MouseHovered(pRect);
 	const bool Active = m_pLastActiveItem == pLineInput;
@@ -804,7 +804,7 @@ bool CUI::DoEditBox(CLineInput *pLineInput, const CUIRect *pRect, float FontSize
 		SetHotItem(pLineInput);
 
 	if(Enabled() && Active && !JustGotActive)
-		pLineInput->Activate(EInputPriority::UI);
+		pLineInput->Activate(EInputPriority::Ui);
 	else
 		pLineInput->Deactivate();
 
@@ -865,7 +865,7 @@ bool CUI::DoEditBox(CLineInput *pLineInput, const CUIRect *pRect, float FontSize
 	return Changed;
 }
 
-bool CUI::DoClearableEditBox(CLineInput *pLineInput, const CUIRect *pRect, float FontSize, int Corners, const std::vector<STextColorSplit> &vColorSplits)
+bool CUi::DoClearableEditBox(CLineInput *pLineInput, const CUIRect *pRect, float FontSize, int Corners, const std::vector<STextColorSplit> &vColorSplits)
 {
 	CUIRect EditBox, ClearButton;
 	pRect->VSplitRight(pRect->h, &EditBox, &ClearButton);
@@ -874,7 +874,7 @@ bool CUI::DoClearableEditBox(CLineInput *pLineInput, const CUIRect *pRect, float
 
 	ClearButton.Draw(ColorRGBA(1.0f, 1.0f, 1.0f, 0.33f * ButtonColorMul(pLineInput->GetClearButtonId())), Corners & ~IGraphics::CORNER_L, 3.0f);
 	TextRender()->SetRenderFlags(ETextRenderFlags::TEXT_RENDER_FLAG_ONLY_ADVANCE_WIDTH | ETextRenderFlags::TEXT_RENDER_FLAG_NO_X_BEARING | ETextRenderFlags::TEXT_RENDER_FLAG_NO_Y_BEARING | ETextRenderFlags::TEXT_RENDER_FLAG_NO_OVERSIZE);
-	DoLabel(&ClearButton, "×", ClearButton.h * CUI::ms_FontmodHeight * 0.8f, TEXTALIGN_MC);
+	DoLabel(&ClearButton, "×", ClearButton.h * CUi::ms_FontmodHeight * 0.8f, TEXTALIGN_MC);
 	TextRender()->SetRenderFlags(0);
 	if(DoButtonLogic(pLineInput->GetClearButtonId(), 0, &ClearButton))
 	{
@@ -886,7 +886,7 @@ bool CUI::DoClearableEditBox(CLineInput *pLineInput, const CUIRect *pRect, float
 	return ReturnValue;
 }
 
-int CUI::DoButton_Menu(CUIElement &UIElement, const CButtonContainer *pID, const std::function<const char *()> &GetTextLambda, const CUIRect *pRect, const SMenuButtonProperties &Props)
+int CUi::DoButton_Menu(CUIElement &UIElement, const CButtonContainer *pId, const std::function<const char *()> &GetTextLambda, const CUIRect *pRect, const SMenuButtonProperties &Props)
 {
 	CUIRect Text = *pRect, DropDownIcon;
 	Text.HMargin(pRect->h >= 20.0f ? 2.0f : 1.0f, &Text);
@@ -957,7 +957,7 @@ int CUI::DoButton_Menu(CUIElement &UIElement, const CButtonContainer *pID, const
 					NewRect.m_Text = pText;
 					if(Props.m_UseIconFont)
 						TextRender()->SetFontPreset(EFontPreset::ICON_FONT);
-					DoLabel(NewRect, &Text, pText, Text.h * CUI::ms_FontmodHeight, TEXTALIGN_MC);
+					DoLabel(NewRect, &Text, pText, Text.h * CUi::ms_FontmodHeight, TEXTALIGN_MC);
 					if(Props.m_UseIconFont)
 						TextRender()->SetFontPreset(EFontPreset::DEFAULT_FONT);
 				}
@@ -967,9 +967,9 @@ int CUI::DoButton_Menu(CUIElement &UIElement, const CButtonContainer *pID, const
 	}
 	// render
 	size_t Index = 2;
-	if(CheckActiveItem(pID))
+	if(CheckActiveItem(pId))
 		Index = 0;
-	else if(HotItem() == pID)
+	else if(HotItem() == pId)
 		Index = 1;
 	Graphics()->TextureClear();
 	Graphics()->RenderQuadContainer(UIElement.Rect(Index)->m_UIRectQuadContainer, -1);
@@ -977,7 +977,7 @@ int CUI::DoButton_Menu(CUIElement &UIElement, const CButtonContainer *pID, const
 	{
 		TextRender()->SetFontPreset(EFontPreset::ICON_FONT);
 		TextRender()->SetRenderFlags(ETextRenderFlags::TEXT_RENDER_FLAG_ONLY_ADVANCE_WIDTH | ETextRenderFlags::TEXT_RENDER_FLAG_NO_X_BEARING | ETextRenderFlags::TEXT_RENDER_FLAG_NO_Y_BEARING | ETextRenderFlags::TEXT_RENDER_FLAG_NO_PIXEL_ALIGMENT | ETextRenderFlags::TEXT_RENDER_FLAG_NO_OVERSIZE);
-		DoLabel(&DropDownIcon, FONT_ICON_CIRCLE_CHEVRON_DOWN, DropDownIcon.h * CUI::ms_FontmodHeight, TEXTALIGN_MR);
+		DoLabel(&DropDownIcon, FONT_ICON_CIRCLE_CHEVRON_DOWN, DropDownIcon.h * CUi::ms_FontmodHeight, TEXTALIGN_MR);
 		TextRender()->SetRenderFlags(0);
 		TextRender()->SetFontPreset(EFontPreset::DEFAULT_FONT);
 	}
@@ -985,10 +985,10 @@ int CUI::DoButton_Menu(CUIElement &UIElement, const CButtonContainer *pID, const
 	ColorRGBA ColorTextOutline(TextRender()->DefaultTextOutlineColor());
 	if(UIElement.Rect(0)->m_UITextContainer.Valid())
 		TextRender()->RenderTextContainer(UIElement.Rect(0)->m_UITextContainer, ColorText, ColorTextOutline);
-	return DoButtonLogic(pID, Props.m_Checked, pRect);
+	return DoButtonLogic(pId, Props.m_Checked, pRect);
 }
 
-int CUI::DoButton_PopupMenu(CButtonContainer *pButtonContainer, const char *pText, const CUIRect *pRect, float Size, int Align, float Padding, bool TransparentInactive, bool Enabled)
+int CUi::DoButton_PopupMenu(CButtonContainer *pButtonContainer, const char *pText, const CUIRect *pRect, float Size, int Align, float Padding, bool TransparentInactive, bool Enabled)
 {
 	if(!TransparentInactive || CheckActiveItem(pButtonContainer) || HotItem() == pButtonContainer)
 		pRect->Draw(Enabled ? ColorRGBA(1.0f, 1.0f, 1.0f, 0.5f * ButtonColorMul(pButtonContainer)) : ColorRGBA(0.0f, 0.0f, 0.0f, 0.4f), IGraphics::CORNER_ALL, 3.0f);
@@ -1000,35 +1000,35 @@ int CUI::DoButton_PopupMenu(CButtonContainer *pButtonContainer, const char *pTex
 	return Enabled ? DoButtonLogic(pButtonContainer, 0, pRect) : 0;
 }
 
-int64_t CUI::DoValueSelector(const void *pID, const CUIRect *pRect, const char *pLabel, int64_t Current, int64_t Min, int64_t Max, const SValueSelectorProperties &Props)
+int64_t CUi::DoValueSelector(const void *pId, const CUIRect *pRect, const char *pLabel, int64_t Current, int64_t Min, int64_t Max, const SValueSelectorProperties &Props)
 {
-	return DoValueSelectorWithState(pID, pRect, pLabel, Current, Min, Max, Props).m_Value;
+	return DoValueSelectorWithState(pId, pRect, pLabel, Current, Min, Max, Props).m_Value;
 }
 
-SEditResult<int64_t> CUI::DoValueSelectorWithState(const void *pID, const CUIRect *pRect, const char *pLabel, int64_t Current, int64_t Min, int64_t Max, const SValueSelectorProperties &Props)
+SEditResult<int64_t> CUi::DoValueSelectorWithState(const void *pId, const CUIRect *pRect, const char *pLabel, int64_t Current, int64_t Min, int64_t Max, const SValueSelectorProperties &Props)
 {
 	// logic
 	static float s_Value;
 	static CLineInputNumber s_NumberInput;
-	static const void *s_pLastTextID = pID;
+	static const void *s_pLastTextId = pId;
 	const bool Inside = MouseInside(pRect);
 	static const void *s_pEditing = nullptr;
 	EEditState State = EEditState::NONE;
 
 	if(Inside)
-		SetHotItem(pID);
+		SetHotItem(pId);
 
 	const int Base = Props.m_IsHex ? 16 : 10;
 
-	if(MouseButtonReleased(1) && HotItem() == pID)
+	if(MouseButtonReleased(1) && HotItem() == pId)
 	{
-		s_pLastTextID = pID;
+		s_pLastTextId = pId;
 		m_ValueSelectorTextMode = true;
 		s_NumberInput.SetInteger64(Current, Base, Props.m_HexPrefix);
 		s_NumberInput.SelectAll();
 	}
 
-	if(CheckActiveItem(pID))
+	if(CheckActiveItem(pId))
 	{
 		if(!MouseButton(0))
 		{
@@ -1038,7 +1038,7 @@ SEditResult<int64_t> CUI::DoValueSelectorWithState(const void *pID, const CUIRec
 		}
 	}
 
-	if(m_ValueSelectorTextMode && s_pLastTextID == pID)
+	if(m_ValueSelectorTextMode && s_pLastTextId == pId)
 	{
 		DoEditBox(&s_NumberInput, pRect, 10.0f);
 		SetActiveItem(&s_NumberInput);
@@ -1060,7 +1060,7 @@ SEditResult<int64_t> CUI::DoValueSelectorWithState(const void *pID, const CUIRec
 	}
 	else
 	{
-		if(CheckActiveItem(pID))
+		if(CheckActiveItem(pId))
 		{
 			if(Props.m_UseScroll)
 			{
@@ -1084,14 +1084,14 @@ SEditResult<int64_t> CUI::DoValueSelectorWithState(const void *pID, const CUIRec
 				}
 			}
 		}
-		else if(HotItem() == pID)
+		else if(HotItem() == pId)
 		{
 			if(MouseButtonClicked(0))
 			{
 				s_Value = 0;
-				SetActiveItem(pID);
+				SetActiveItem(pId);
 				if(Props.m_UseScroll)
-					EnableMouseLock(pID);
+					EnableMouseLock(pId);
 			}
 		}
 
@@ -1118,17 +1118,17 @@ SEditResult<int64_t> CUI::DoValueSelectorWithState(const void *pID, const CUIRec
 	if(!m_ValueSelectorTextMode)
 		s_NumberInput.Clear();
 
-	if(s_pEditing == pID)
+	if(s_pEditing == pId)
 		State = EEditState::EDITING;
 
 	bool MouseLocked = CheckMouseLock();
 	if((MouseLocked || m_ValueSelectorTextMode) && !s_pEditing)
 	{
 		State = EEditState::START;
-		s_pEditing = pID;
+		s_pEditing = pId;
 	}
 
-	if(!CheckMouseLock() && !m_ValueSelectorTextMode && s_pEditing == pID)
+	if(!CheckMouseLock() && !m_ValueSelectorTextMode && s_pEditing == pId)
 	{
 		State = EEditState::END;
 		s_pEditing = nullptr;
@@ -1137,7 +1137,7 @@ SEditResult<int64_t> CUI::DoValueSelectorWithState(const void *pID, const CUIRec
 	return SEditResult<int64_t>{State, Current};
 }
 
-float CUI::DoScrollbarV(const void *pID, const CUIRect *pRect, float Current)
+float CUi::DoScrollbarV(const void *pId, const CUIRect *pRect, float Current)
 {
 	Current = clamp(Current, 0.0f, 1.0f);
 
@@ -1155,7 +1155,7 @@ float CUI::DoScrollbarV(const void *pID, const CUIRect *pRect, float Current)
 	const bool InsideHandle = MouseHovered(&Handle);
 	bool Grabbed = false; // whether to apply the offset
 
-	if(CheckActiveItem(pID))
+	if(CheckActiveItem(pId))
 	{
 		if(MouseButton(0))
 		{
@@ -1168,25 +1168,25 @@ float CUI::DoScrollbarV(const void *pID, const CUIRect *pRect, float Current)
 			SetActiveItem(nullptr);
 		}
 	}
-	else if(HotItem() == pID)
+	else if(HotItem() == pId)
 	{
 		if(MouseButton(0))
 		{
-			SetActiveItem(pID);
+			SetActiveItem(pId);
 			s_OffsetY = MouseY() - Handle.y;
 			Grabbed = true;
 		}
 	}
 	else if(MouseButtonClicked(0) && !InsideHandle && InsideRail)
 	{
-		SetActiveItem(pID);
+		SetActiveItem(pId);
 		s_OffsetY = Handle.h / 2.0f;
 		Grabbed = true;
 	}
 
 	if(InsideHandle)
 	{
-		SetHotItem(pID);
+		SetHotItem(pId);
 	}
 
 	float ReturnValue = Current;
@@ -1200,12 +1200,12 @@ float CUI::DoScrollbarV(const void *pID, const CUIRect *pRect, float Current)
 
 	// render
 	Rail.Draw(ColorRGBA(1.0f, 1.0f, 1.0f, 0.25f), IGraphics::CORNER_ALL, Rail.w / 2.0f);
-	Handle.Draw(ms_ScrollBarColorFunction.GetColor(CheckActiveItem(pID), HotItem() == pID), IGraphics::CORNER_ALL, Handle.w / 2.0f);
+	Handle.Draw(ms_ScrollBarColorFunction.GetColor(CheckActiveItem(pId), HotItem() == pId), IGraphics::CORNER_ALL, Handle.w / 2.0f);
 
 	return ReturnValue;
 }
 
-float CUI::DoScrollbarH(const void *pID, const CUIRect *pRect, float Current, const ColorRGBA *pColorInner)
+float CUi::DoScrollbarH(const void *pId, const CUIRect *pRect, float Current, const ColorRGBA *pColorInner)
 {
 	Current = clamp(Current, 0.0f, 1.0f);
 
@@ -1226,7 +1226,7 @@ float CUI::DoScrollbarH(const void *pID, const CUIRect *pRect, float Current, co
 	const bool InsideHandle = MouseHovered(&Handle);
 	bool Grabbed = false; // whether to apply the offset
 
-	if(CheckActiveItem(pID))
+	if(CheckActiveItem(pId))
 	{
 		if(MouseButton(0))
 		{
@@ -1239,25 +1239,25 @@ float CUI::DoScrollbarH(const void *pID, const CUIRect *pRect, float Current, co
 			SetActiveItem(nullptr);
 		}
 	}
-	else if(HotItem() == pID)
+	else if(HotItem() == pId)
 	{
 		if(MouseButton(0))
 		{
-			SetActiveItem(pID);
+			SetActiveItem(pId);
 			s_OffsetX = MouseX() - Handle.x;
 			Grabbed = true;
 		}
 	}
 	else if(MouseButtonClicked(0) && !InsideHandle && InsideRail)
 	{
-		SetActiveItem(pID);
+		SetActiveItem(pId);
 		s_OffsetX = Handle.w / 2.0f;
 		Grabbed = true;
 	}
 
 	if(InsideHandle)
 	{
-		SetHotItem(pID);
+		SetHotItem(pId);
 	}
 
 	float ReturnValue = Current;
@@ -1282,17 +1282,17 @@ float CUI::DoScrollbarH(const void *pID, const CUIRect *pRect, float Current, co
 	else
 	{
 		Rail.Draw(ColorRGBA(1.0f, 1.0f, 1.0f, 0.25f), IGraphics::CORNER_ALL, Rail.h / 2.0f);
-		Handle.Draw(ms_ScrollBarColorFunction.GetColor(CheckActiveItem(pID), HotItem() == pID), IGraphics::CORNER_ALL, Handle.h / 2.0f);
+		Handle.Draw(ms_ScrollBarColorFunction.GetColor(CheckActiveItem(pId), HotItem() == pId), IGraphics::CORNER_ALL, Handle.h / 2.0f);
 	}
 
 	return ReturnValue;
 }
 
-void CUI::DoScrollbarOption(const void *pID, int *pOption, const CUIRect *pRect, const char *pStr, int Min, int Max, const IScrollbarScale *pScale, unsigned Flags, const char *pSuffix)
+void CUi::DoScrollbarOption(const void *pId, int *pOption, const CUIRect *pRect, const char *pStr, int Min, int Max, const IScrollbarScale *pScale, unsigned Flags, const char *pSuffix)
 {
-	const bool Infinite = Flags & CUI::SCROLLBAR_OPTION_INFINITE;
-	const bool NoClampValue = Flags & CUI::SCROLLBAR_OPTION_NOCLAMPVALUE;
-	const bool MultiLine = Flags & CUI::SCROLLBAR_OPTION_MULTILINE;
+	const bool Infinite = Flags & CUi::SCROLLBAR_OPTION_INFINITE;
+	const bool NoClampValue = Flags & CUi::SCROLLBAR_OPTION_NOCLAMPVALUE;
+	const bool MultiLine = Flags & CUi::SCROLLBAR_OPTION_MULTILINE;
 
 	int Value = *pOption;
 	if(Infinite)
@@ -1320,10 +1320,10 @@ void CUI::DoScrollbarOption(const void *pID, int *pOption, const CUIRect *pRect,
 	else
 		pRect->VSplitMid(&Label, &ScrollBar, minimum(10.0f, pRect->w * 0.05f));
 
-	const float FontSize = Label.h * CUI::ms_FontmodHeight * 0.8f;
+	const float FontSize = Label.h * CUi::ms_FontmodHeight * 0.8f;
 	DoLabel(&Label, aBuf, FontSize, TEXTALIGN_ML);
 
-	Value = pScale->ToAbsolute(DoScrollbarH(pID, &ScrollBar, pScale->ToRelative(Value, Min, Max)), Min, Max);
+	Value = pScale->ToAbsolute(DoScrollbarH(pId, &ScrollBar, pScale->ToRelative(Value, Min, Max)), Min, Max);
 	if(NoClampValue && ((Value == Min && *pOption < Min) || (Value == Max && *pOption > Max)))
 	{
 		Value = *pOption; // use previous out of range value instead if the scrollbar is at the edge
@@ -1337,7 +1337,7 @@ void CUI::DoScrollbarOption(const void *pID, int *pOption, const CUIRect *pRect,
 	*pOption = Value;
 }
 
-void CUI::RenderProgressSpinner(vec2 Center, float OuterRadius, const SProgressSpinnerProperties &Props) const
+void CUi::RenderProgressSpinner(vec2 Center, float OuterRadius, const SProgressSpinnerProperties &Props) const
 {
 	static float s_SpinnerOffset = 0.0f;
 	static float s_LastRender = Client()->LocalTime();
@@ -1386,7 +1386,7 @@ void CUI::RenderProgressSpinner(vec2 Center, float OuterRadius, const SProgressS
 	s_LastRender = Client()->LocalTime();
 }
 
-void CUI::DoPopupMenu(const SPopupMenuId *pID, int X, int Y, int Width, int Height, void *pContext, FPopupMenuFunction pfnFunc, const SPopupMenuProperties &Props)
+void CUi::DoPopupMenu(const SPopupMenuId *pId, int X, int Y, int Width, int Height, void *pContext, FPopupMenuFunction pfnFunc, const SPopupMenuProperties &Props)
 {
 	constexpr float Margin = SPopupMenu::POPUP_BORDER + SPopupMenu::POPUP_MARGIN;
 	if(X + Width > Screen()->w - Margin)
@@ -1396,7 +1396,7 @@ void CUI::DoPopupMenu(const SPopupMenuId *pID, int X, int Y, int Width, int Heig
 
 	m_vPopupMenus.emplace_back();
 	SPopupMenu *pNewMenu = &m_vPopupMenus.back();
-	pNewMenu->m_pID = pID;
+	pNewMenu->m_pId = pId;
 	pNewMenu->m_Props = Props;
 	pNewMenu->m_Rect.x = X;
 	pNewMenu->m_Rect.y = Y;
@@ -1406,35 +1406,35 @@ void CUI::DoPopupMenu(const SPopupMenuId *pID, int X, int Y, int Width, int Heig
 	pNewMenu->m_pfnFunc = pfnFunc;
 }
 
-void CUI::RenderPopupMenus()
+void CUi::RenderPopupMenus()
 {
 	for(size_t i = 0; i < m_vPopupMenus.size(); ++i)
 	{
 		const SPopupMenu &PopupMenu = m_vPopupMenus[i];
-		const SPopupMenuId *pID = PopupMenu.m_pID;
+		const SPopupMenuId *pId = PopupMenu.m_pId;
 		const bool Inside = MouseInside(&PopupMenu.m_Rect);
 		const bool Active = i == m_vPopupMenus.size() - 1;
 
 		if(Active)
-			SetHotItem(pID);
+			SetHotItem(pId);
 
-		if(CheckActiveItem(pID))
+		if(CheckActiveItem(pId))
 		{
 			if(!MouseButton(0))
 			{
 				if(!Inside)
 				{
-					ClosePopupMenu(pID);
+					ClosePopupMenu(pId);
 					--i;
 					continue;
 				}
 				SetActiveItem(nullptr);
 			}
 		}
-		else if(HotItem() == pID)
+		else if(HotItem() == pId)
 		{
 			if(MouseButton(0))
-				SetActiveItem(pID);
+				SetActiveItem(pId);
 		}
 
 		CUIRect PopupRect = PopupMenu.m_Rect;
@@ -1444,16 +1444,16 @@ void CUI::RenderPopupMenus()
 		PopupRect.Margin(SPopupMenu::POPUP_MARGIN, &PopupRect);
 
 		// The popup render function can open/close popups, which may resize the vector and thus
-		// invalidate the variable PopupMenu. We therefore store pID in a separate variable.
+		// invalidate the variable PopupMenu. We therefore store pId in a separate variable.
 		EPopupMenuFunctionResult Result = PopupMenu.m_pfnFunc(PopupMenu.m_pContext, PopupRect, Active);
 		if(Result != POPUP_KEEP_OPEN || (Active && ConsumeHotkey(HOTKEY_ESCAPE)))
-			ClosePopupMenu(pID, Result == POPUP_CLOSE_CURRENT_AND_DESCENDANTS);
+			ClosePopupMenu(pId, Result == POPUP_CLOSE_CURRENT_AND_DESCENDANTS);
 	}
 }
 
-void CUI::ClosePopupMenu(const SPopupMenuId *pID, bool IncludeDescendants)
+void CUi::ClosePopupMenu(const SPopupMenuId *pId, bool IncludeDescendants)
 {
-	auto PopupMenuToClose = std::find_if(m_vPopupMenus.begin(), m_vPopupMenus.end(), [pID](const SPopupMenu PopupMenu) { return PopupMenu.m_pID == pID; });
+	auto PopupMenuToClose = std::find_if(m_vPopupMenus.begin(), m_vPopupMenus.end(), [pId](const SPopupMenu PopupMenu) { return PopupMenu.m_pId == pId; });
 	if(PopupMenuToClose != m_vPopupMenus.end())
 	{
 		if(IncludeDescendants)
@@ -1466,7 +1466,7 @@ void CUI::ClosePopupMenu(const SPopupMenuId *pID, bool IncludeDescendants)
 	}
 }
 
-void CUI::ClosePopupMenus()
+void CUi::ClosePopupMenus()
 {
 	if(m_vPopupMenus.empty())
 		return;
@@ -1477,49 +1477,49 @@ void CUI::ClosePopupMenus()
 		m_pfnPopupMenuClosedCallback();
 }
 
-bool CUI::IsPopupOpen() const
+bool CUi::IsPopupOpen() const
 {
 	return !m_vPopupMenus.empty();
 }
 
-bool CUI::IsPopupOpen(const SPopupMenuId *pID) const
+bool CUi::IsPopupOpen(const SPopupMenuId *pId) const
 {
-	return std::any_of(m_vPopupMenus.begin(), m_vPopupMenus.end(), [pID](const SPopupMenu PopupMenu) { return PopupMenu.m_pID == pID; });
+	return std::any_of(m_vPopupMenus.begin(), m_vPopupMenus.end(), [pId](const SPopupMenu PopupMenu) { return PopupMenu.m_pId == pId; });
 }
 
-bool CUI::IsPopupHovered() const
+bool CUi::IsPopupHovered() const
 {
 	return std::any_of(m_vPopupMenus.begin(), m_vPopupMenus.end(), [this](const SPopupMenu PopupMenu) { return MouseHovered(&PopupMenu.m_Rect); });
 }
 
-void CUI::SetPopupMenuClosedCallback(FPopupMenuClosedCallback pfnCallback)
+void CUi::SetPopupMenuClosedCallback(FPopupMenuClosedCallback pfnCallback)
 {
 	m_pfnPopupMenuClosedCallback = std::move(pfnCallback);
 }
 
-void CUI::SMessagePopupContext::DefaultColor(ITextRender *pTextRender)
+void CUi::SMessagePopupContext::DefaultColor(ITextRender *pTextRender)
 {
 	m_TextColor = pTextRender->DefaultTextColor();
 }
 
-void CUI::SMessagePopupContext::ErrorColor()
+void CUi::SMessagePopupContext::ErrorColor()
 {
 	m_TextColor = ColorRGBA(1.0f, 0.0f, 0.0f, 1.0f);
 }
 
-CUI::EPopupMenuFunctionResult CUI::PopupMessage(void *pContext, CUIRect View, bool Active)
+CUi::EPopupMenuFunctionResult CUi::PopupMessage(void *pContext, CUIRect View, bool Active)
 {
 	SMessagePopupContext *pMessagePopup = static_cast<SMessagePopupContext *>(pContext);
-	CUI *pUI = pMessagePopup->m_pUI;
+	CUi *pUI = pMessagePopup->m_pUI;
 
 	pUI->TextRender()->TextColor(pMessagePopup->m_TextColor);
 	pUI->TextRender()->Text(View.x, View.y, SMessagePopupContext::POPUP_FONT_SIZE, pMessagePopup->m_aMessage, View.w);
 	pUI->TextRender()->TextColor(pUI->TextRender()->DefaultTextColor());
 
-	return (Active && pUI->ConsumeHotkey(HOTKEY_ENTER)) ? CUI::POPUP_CLOSE_CURRENT : CUI::POPUP_KEEP_OPEN;
+	return (Active && pUI->ConsumeHotkey(HOTKEY_ENTER)) ? CUi::POPUP_CLOSE_CURRENT : CUi::POPUP_KEEP_OPEN;
 }
 
-void CUI::ShowPopupMessage(float X, float Y, SMessagePopupContext *pContext)
+void CUi::ShowPopupMessage(float X, float Y, SMessagePopupContext *pContext)
 {
 	const float TextWidth = minimum(std::ceil(TextRender()->TextWidth(SMessagePopupContext::POPUP_FONT_SIZE, pContext->m_aMessage, -1, -1.0f) + 0.5f), SMessagePopupContext::POPUP_MAX_WIDTH);
 	float TextHeight = 0.0f;
@@ -1530,23 +1530,23 @@ void CUI::ShowPopupMessage(float X, float Y, SMessagePopupContext *pContext)
 	DoPopupMenu(pContext, X, Y, TextWidth + 10.0f, TextHeight + 10.0f, pContext, PopupMessage);
 }
 
-CUI::SConfirmPopupContext::SConfirmPopupContext()
+CUi::SConfirmPopupContext::SConfirmPopupContext()
 {
 	Reset();
 }
 
-void CUI::SConfirmPopupContext::Reset()
+void CUi::SConfirmPopupContext::Reset()
 {
 	m_Result = SConfirmPopupContext::UNSET;
 }
 
-void CUI::SConfirmPopupContext::YesNoButtons()
+void CUi::SConfirmPopupContext::YesNoButtons()
 {
 	str_copy(m_aPositiveButtonLabel, Localize("Yes"));
 	str_copy(m_aNegativeButtonLabel, Localize("No"));
 }
 
-void CUI::ShowPopupConfirm(float X, float Y, SConfirmPopupContext *pContext)
+void CUi::ShowPopupConfirm(float X, float Y, SConfirmPopupContext *pContext)
 {
 	const float TextWidth = minimum(std::ceil(TextRender()->TextWidth(SConfirmPopupContext::POPUP_FONT_SIZE, pContext->m_aMessage, -1, -1.0f) + 0.5f), SConfirmPopupContext::POPUP_MAX_WIDTH);
 	float TextHeight = 0.0f;
@@ -1559,10 +1559,10 @@ void CUI::ShowPopupConfirm(float X, float Y, SConfirmPopupContext *pContext)
 	DoPopupMenu(pContext, X, Y, TextWidth + 10.0f, PopupHeight, pContext, PopupConfirm);
 }
 
-CUI::EPopupMenuFunctionResult CUI::PopupConfirm(void *pContext, CUIRect View, bool Active)
+CUi::EPopupMenuFunctionResult CUi::PopupConfirm(void *pContext, CUIRect View, bool Active)
 {
 	SConfirmPopupContext *pConfirmPopup = static_cast<SConfirmPopupContext *>(pContext);
-	CUI *pUI = pConfirmPopup->m_pUI;
+	CUi *pUI = pConfirmPopup->m_pUI;
 
 	CUIRect Label, ButtonBar, CancelButton, ConfirmButton;
 	View.HSplitBottom(SConfirmPopupContext::POPUP_BUTTON_HEIGHT, &Label, &ButtonBar);
@@ -1573,24 +1573,24 @@ CUI::EPopupMenuFunctionResult CUI::PopupConfirm(void *pContext, CUIRect View, bo
 	if(pUI->DoButton_PopupMenu(&pConfirmPopup->m_CancelButton, pConfirmPopup->m_aNegativeButtonLabel, &CancelButton, SConfirmPopupContext::POPUP_FONT_SIZE, TEXTALIGN_MC))
 	{
 		pConfirmPopup->m_Result = SConfirmPopupContext::CANCELED;
-		return CUI::POPUP_CLOSE_CURRENT;
+		return CUi::POPUP_CLOSE_CURRENT;
 	}
 
 	if(pUI->DoButton_PopupMenu(&pConfirmPopup->m_ConfirmButton, pConfirmPopup->m_aPositiveButtonLabel, &ConfirmButton, SConfirmPopupContext::POPUP_FONT_SIZE, TEXTALIGN_MC) || (Active && pUI->ConsumeHotkey(HOTKEY_ENTER)))
 	{
 		pConfirmPopup->m_Result = SConfirmPopupContext::CONFIRMED;
-		return CUI::POPUP_CLOSE_CURRENT;
+		return CUi::POPUP_CLOSE_CURRENT;
 	}
 
-	return CUI::POPUP_KEEP_OPEN;
+	return CUi::POPUP_KEEP_OPEN;
 }
 
-CUI::SSelectionPopupContext::SSelectionPopupContext()
+CUi::SSelectionPopupContext::SSelectionPopupContext()
 {
 	Reset();
 }
 
-void CUI::SSelectionPopupContext::Reset()
+void CUi::SSelectionPopupContext::Reset()
 {
 	m_Props = SPopupMenuProperties();
 	m_aMessage[0] = '\0';
@@ -1607,10 +1607,10 @@ void CUI::SSelectionPopupContext::Reset()
 	m_TransparentButtons = false;
 }
 
-CUI::EPopupMenuFunctionResult CUI::PopupSelection(void *pContext, CUIRect View, bool Active)
+CUi::EPopupMenuFunctionResult CUi::PopupSelection(void *pContext, CUIRect View, bool Active)
 {
 	SSelectionPopupContext *pSelectionPopup = static_cast<SSelectionPopupContext *>(pContext);
-	CUI *pUI = pSelectionPopup->m_pUI;
+	CUi *pUI = pSelectionPopup->m_pUI;
 	CScrollRegion *pScrollRegion = pSelectionPopup->m_pScrollRegion;
 
 	vec2 ScrollOffset(0.0f, 0.0f);
@@ -1654,10 +1654,10 @@ CUI::EPopupMenuFunctionResult CUI::PopupSelection(void *pContext, CUIRect View, 
 
 	pScrollRegion->End();
 
-	return pSelectionPopup->m_pSelection == nullptr ? CUI::POPUP_KEEP_OPEN : CUI::POPUP_CLOSE_CURRENT;
+	return pSelectionPopup->m_pSelection == nullptr ? CUi::POPUP_KEEP_OPEN : CUi::POPUP_CLOSE_CURRENT;
 }
 
-void CUI::ShowPopupSelection(float X, float Y, SSelectionPopupContext *pContext)
+void CUi::ShowPopupSelection(float X, float Y, SSelectionPopupContext *pContext)
 {
 	const STextBoundingBox TextBoundingBox = TextRender()->TextBoundingBox(pContext->m_FontSize, pContext->m_aMessage, -1, pContext->m_Width);
 	const float PopupHeight = minimum((pContext->m_aMessage[0] == '\0' ? -pContext->m_EntrySpacing : TextBoundingBox.m_H) + pContext->m_vEntries.size() * (pContext->m_EntryHeight + pContext->m_EntrySpacing) + (SPopupMenu::POPUP_BORDER + SPopupMenu::POPUP_MARGIN) * 2 + CScrollRegion::HEIGHT_MAGIC_FIX, Screen()->h * 0.4f);
@@ -1686,7 +1686,7 @@ void CUI::ShowPopupSelection(float X, float Y, SSelectionPopupContext *pContext)
 	DoPopupMenu(pContext, X, Y, pContext->m_Width, PopupHeight, pContext, PopupSelection, pContext->m_Props);
 }
 
-int CUI::DoDropDown(CUIRect *pRect, int CurSelection, const char **pStrs, int Num, SDropDownState &State)
+int CUi::DoDropDown(CUIRect *pRect, int CurSelection, const char **pStrs, int Num, SDropDownState &State)
 {
 	if(!State.m_Init)
 	{
@@ -1713,7 +1713,7 @@ int CUI::DoDropDown(CUIRect *pRect, int CurSelection, const char **pStrs, int Nu
 			State.m_SelectionPopupContext.m_vEntries.emplace_back(pStrs[i]);
 		State.m_SelectionPopupContext.m_EntryHeight = pRect->h;
 		State.m_SelectionPopupContext.m_EntryPadding = pRect->h >= 20.0f ? 2.0f : 1.0f;
-		State.m_SelectionPopupContext.m_FontSize = (State.m_SelectionPopupContext.m_EntryHeight - 2 * State.m_SelectionPopupContext.m_EntryPadding) * CUI::ms_FontmodHeight;
+		State.m_SelectionPopupContext.m_FontSize = (State.m_SelectionPopupContext.m_EntryHeight - 2 * State.m_SelectionPopupContext.m_EntryPadding) * CUi::ms_FontmodHeight;
 		State.m_SelectionPopupContext.m_Width = pRect->w;
 		State.m_SelectionPopupContext.m_AlignmentHeight = pRect->h;
 		State.m_SelectionPopupContext.m_TransparentButtons = true;
@@ -1730,10 +1730,10 @@ int CUI::DoDropDown(CUIRect *pRect, int CurSelection, const char **pStrs, int Nu
 	return CurSelection;
 }
 
-CUI::EPopupMenuFunctionResult CUI::PopupColorPicker(void *pContext, CUIRect View, bool Active)
+CUi::EPopupMenuFunctionResult CUi::PopupColorPicker(void *pContext, CUIRect View, bool Active)
 {
 	SColorPickerPopupContext *pColorPicker = static_cast<SColorPickerPopupContext *>(pContext);
-	CUI *pUI = pColorPicker->m_pUI;
+	CUi *pUI = pColorPicker->m_pUI;
 	pColorPicker->m_State = EEditState::NONE;
 
 	CUIRect ColorsArea, HueArea, BottomArea, ModeButtonArea, HueRect, SatRect, ValueRect, HexRect, AlphaRect;
@@ -2001,10 +2001,10 @@ CUI::EPopupMenuFunctionResult CUI::PopupColorPicker(void *pContext, CUIRect View
 		}
 	}
 
-	return CUI::POPUP_KEEP_OPEN;
+	return CUi::POPUP_KEEP_OPEN;
 }
 
-void CUI::ShowPopupColorPicker(float X, float Y, SColorPickerPopupContext *pContext)
+void CUi::ShowPopupColorPicker(float X, float Y, SColorPickerPopupContext *pContext)
 {
 	pContext->m_pUI = this;
 	if(pContext->m_ColorMode == SColorPickerPopupContext::MODE_UNSET)

--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -142,15 +142,15 @@ public:
 	}
 };
 
-class CUI;
+class CUi;
 
 class CUIElement
 {
-	friend class CUI;
+	friend class CUi;
 
-	CUI *m_pUI;
+	CUi *m_pUI;
 
-	CUIElement(CUI *pUI, int RequestedRectCount) { Init(pUI, RequestedRectCount); }
+	CUIElement(CUi *pUI, int RequestedRectCount) { Init(pUI, RequestedRectCount); }
 
 public:
 	struct SUIElementRect
@@ -185,13 +185,13 @@ public:
 	};
 
 protected:
-	CUI *UI() const { return m_pUI; }
+	CUi *Ui() const { return m_pUI; }
 	std::vector<SUIElementRect> m_vUIRects;
 
 public:
 	CUIElement() = default;
 
-	void Init(CUI *pUI, int RequestedRectCount);
+	void Init(CUi *pUI, int RequestedRectCount);
 
 	SUIElementRect *Rect(size_t Index)
 	{
@@ -231,16 +231,16 @@ struct SMenuButtonProperties
 class CUIElementBase
 {
 private:
-	static CUI *s_pUI;
+	static CUi *s_pUI;
 
 public:
-	static void Init(CUI *pUI) { s_pUI = pUI; }
+	static void Init(CUi *pUI) { s_pUI = pUI; }
 
 	IClient *Client() const;
 	IGraphics *Graphics() const;
 	IInput *Input() const;
 	ITextRender *TextRender() const;
-	CUI *UI() const { return s_pUI; }
+	CUi *Ui() const { return s_pUI; }
 };
 
 class CButtonContainer
@@ -278,7 +278,7 @@ struct SPopupMenuProperties
 	ColorRGBA m_BackgroundColor = ColorRGBA(0.0f, 0.0f, 0.0f, 0.75f);
 };
 
-class CUI
+class CUi
 {
 public:
 	/**
@@ -337,7 +337,7 @@ private:
 	unsigned m_LastMouseButtons;
 	bool m_MouseSlow = false;
 	bool m_MouseLock = false;
-	const void *m_pMouseLockID = nullptr;
+	const void *m_pMouseLockId = nullptr;
 
 	unsigned m_HotkeysPressed = 0;
 
@@ -353,7 +353,7 @@ private:
 		static constexpr float POPUP_BORDER = 1.0f;
 		static constexpr float POPUP_MARGIN = 4.0f;
 
-		const SPopupMenuId *m_pID;
+		const SPopupMenuId *m_pId;
 		SPopupMenuProperties m_Props;
 		CUIRect m_Rect;
 		void *m_pContext;
@@ -362,17 +362,17 @@ private:
 	std::vector<SPopupMenu> m_vPopupMenus;
 	FPopupMenuClosedCallback m_pfnPopupMenuClosedCallback = nullptr;
 
-	static CUI::EPopupMenuFunctionResult PopupMessage(void *pContext, CUIRect View, bool Active);
-	static CUI::EPopupMenuFunctionResult PopupConfirm(void *pContext, CUIRect View, bool Active);
-	static CUI::EPopupMenuFunctionResult PopupSelection(void *pContext, CUIRect View, bool Active);
-	static CUI::EPopupMenuFunctionResult PopupColorPicker(void *pContext, CUIRect View, bool Active);
+	static CUi::EPopupMenuFunctionResult PopupMessage(void *pContext, CUIRect View, bool Active);
+	static CUi::EPopupMenuFunctionResult PopupConfirm(void *pContext, CUIRect View, bool Active);
+	static CUi::EPopupMenuFunctionResult PopupSelection(void *pContext, CUIRect View, bool Active);
+	static CUi::EPopupMenuFunctionResult PopupColorPicker(void *pContext, CUIRect View, bool Active);
 
 	IClient *m_pClient;
 	IGraphics *m_pGraphics;
 	IInput *m_pInput;
 	ITextRender *m_pTextRender;
 
-	std::vector<CUIElement *> m_vpOwnUIElements; // ui elements maintained by CUI class
+	std::vector<CUIElement *> m_vpOwnUIElements; // ui elements maintained by CUi class
 	std::vector<CUIElement *> m_vpUIElements;
 
 public:
@@ -390,8 +390,8 @@ public:
 	IInput *Input() const { return m_pInput; }
 	ITextRender *TextRender() const { return m_pTextRender; }
 
-	CUI();
-	~CUI();
+	CUi();
+	~CUi();
 
 	enum EHotkey : unsigned
 	{
@@ -436,28 +436,28 @@ public:
 	int MouseButtonReleased(int Index) const { return ((m_LastMouseButtons >> Index) & 1) && !MouseButton(Index); }
 	bool CheckMouseLock()
 	{
-		if(m_MouseLock && ActiveItem() != m_pMouseLockID)
+		if(m_MouseLock && ActiveItem() != m_pMouseLockId)
 			DisableMouseLock();
 		return m_MouseLock;
 	}
-	void EnableMouseLock(const void *pID)
+	void EnableMouseLock(const void *pId)
 	{
 		m_MouseLock = true;
-		m_pMouseLockID = pID;
+		m_pMouseLockId = pId;
 	}
 	void DisableMouseLock() { m_MouseLock = false; }
 
-	void SetHotItem(const void *pID) { m_pBecomingHotItem = pID; }
-	void SetActiveItem(const void *pID)
+	void SetHotItem(const void *pId) { m_pBecomingHotItem = pId; }
+	void SetActiveItem(const void *pId)
 	{
 		m_ActiveItemValid = true;
-		m_pActiveItem = pID;
-		if(pID)
-			m_pLastActiveItem = pID;
+		m_pActiveItem = pId;
+		if(pId)
+			m_pLastActiveItem = pId;
 	}
-	bool CheckActiveItem(const void *pID)
+	bool CheckActiveItem(const void *pId)
 	{
-		if(m_pActiveItem == pID)
+		if(m_pActiveItem == pId)
 		{
 			m_ActiveItemValid = true;
 			return true;
@@ -492,7 +492,7 @@ public:
 	constexpr float ButtonColorMulActive() const { return 0.5f; }
 	constexpr float ButtonColorMulHot() const { return 1.5f; }
 	constexpr float ButtonColorMulDefault() const { return 1.0f; }
-	float ButtonColorMul(const void *pID);
+	float ButtonColorMul(const void *pId);
 
 	const CUIRect *Screen();
 	void MapScreen();
@@ -503,9 +503,9 @@ public:
 	const CUIRect *ClipArea() const;
 	inline bool IsClipped() const { return !m_vClips.empty(); }
 
-	int DoButtonLogic(const void *pID, int Checked, const CUIRect *pRect);
-	int DoDraggableButtonLogic(const void *pID, int Checked, const CUIRect *pRect, bool *pClicked, bool *pAbrupted);
-	EEditState DoPickerLogic(const void *pID, const CUIRect *pRect, float *pX, float *pY);
+	int DoButtonLogic(const void *pId, int Checked, const CUIRect *pRect);
+	int DoDraggableButtonLogic(const void *pId, int Checked, const CUIRect *pRect, bool *pClicked, bool *pAbrupted);
+	EEditState DoPickerLogic(const void *pId, const CUIRect *pRect, float *pX, float *pY);
 	void DoSmoothScrollLogic(float *pScrollOffset, float *pScrollOffsetChange, float ViewPortSize, float TotalSize, bool SmoothClamp = false, float ScrollSpeed = 10.0f) const;
 	static vec2 CalcAlignedCursorPos(const CUIRect *pRect, vec2 TextSize, int Align, const float *pBiggestCharHeight = nullptr);
 
@@ -550,13 +550,13 @@ public:
 	 */
 	bool DoClearableEditBox(CLineInput *pLineInput, const CUIRect *pRect, float FontSize, int Corners = IGraphics::CORNER_ALL, const std::vector<STextColorSplit> &vColorSplits = {});
 
-	int DoButton_Menu(CUIElement &UIElement, const CButtonContainer *pID, const std::function<const char *()> &GetTextLambda, const CUIRect *pRect, const SMenuButtonProperties &Props = {});
+	int DoButton_Menu(CUIElement &UIElement, const CButtonContainer *pId, const std::function<const char *()> &GetTextLambda, const CUIRect *pRect, const SMenuButtonProperties &Props = {});
 	// only used for popup menus
 	int DoButton_PopupMenu(CButtonContainer *pButtonContainer, const char *pText, const CUIRect *pRect, float Size, int Align, float Padding = 0.0f, bool TransparentInactive = false, bool Enabled = true);
 
 	// value selector
-	SEditResult<int64_t> DoValueSelectorWithState(const void *pID, const CUIRect *pRect, const char *pLabel, int64_t Current, int64_t Min, int64_t Max, const SValueSelectorProperties &Props = {});
-	int64_t DoValueSelector(const void *pID, const CUIRect *pRect, const char *pLabel, int64_t Current, int64_t Min, int64_t Max, const SValueSelectorProperties &Props = {});
+	SEditResult<int64_t> DoValueSelectorWithState(const void *pId, const CUIRect *pRect, const char *pLabel, int64_t Current, int64_t Min, int64_t Max, const SValueSelectorProperties &Props = {});
+	int64_t DoValueSelector(const void *pId, const CUIRect *pRect, const char *pLabel, int64_t Current, int64_t Min, int64_t Max, const SValueSelectorProperties &Props = {});
 	bool IsValueSelectorTextMode() const { return m_ValueSelectorTextMode; }
 	void SetValueSelectorTextMode(bool TextMode) { m_ValueSelectorTextMode = TextMode; }
 
@@ -567,20 +567,20 @@ public:
 		SCROLLBAR_OPTION_NOCLAMPVALUE = 1 << 1,
 		SCROLLBAR_OPTION_MULTILINE = 1 << 2,
 	};
-	float DoScrollbarV(const void *pID, const CUIRect *pRect, float Current);
-	float DoScrollbarH(const void *pID, const CUIRect *pRect, float Current, const ColorRGBA *pColorInner = nullptr);
-	void DoScrollbarOption(const void *pID, int *pOption, const CUIRect *pRect, const char *pStr, int Min, int Max, const IScrollbarScale *pScale = &ms_LinearScrollbarScale, unsigned Flags = 0u, const char *pSuffix = "");
+	float DoScrollbarV(const void *pId, const CUIRect *pRect, float Current);
+	float DoScrollbarH(const void *pId, const CUIRect *pRect, float Current, const ColorRGBA *pColorInner = nullptr);
+	void DoScrollbarOption(const void *pId, int *pOption, const CUIRect *pRect, const char *pStr, int Min, int Max, const IScrollbarScale *pScale = &ms_LinearScrollbarScale, unsigned Flags = 0u, const char *pSuffix = "");
 
 	// progress spinner
 	void RenderProgressSpinner(vec2 Center, float OuterRadius, const SProgressSpinnerProperties &Props = {}) const;
 
 	// popup menu
-	void DoPopupMenu(const SPopupMenuId *pID, int X, int Y, int Width, int Height, void *pContext, FPopupMenuFunction pfnFunc, const SPopupMenuProperties &Props = {});
+	void DoPopupMenu(const SPopupMenuId *pId, int X, int Y, int Width, int Height, void *pContext, FPopupMenuFunction pfnFunc, const SPopupMenuProperties &Props = {});
 	void RenderPopupMenus();
-	void ClosePopupMenu(const SPopupMenuId *pID, bool IncludeDescendants = false);
+	void ClosePopupMenu(const SPopupMenuId *pId, bool IncludeDescendants = false);
 	void ClosePopupMenus();
 	bool IsPopupOpen() const;
-	bool IsPopupOpen(const SPopupMenuId *pID) const;
+	bool IsPopupOpen(const SPopupMenuId *pId) const;
 	bool IsPopupHovered() const;
 	void SetPopupMenuClosedCallback(FPopupMenuClosedCallback pfnCallback);
 
@@ -589,7 +589,7 @@ public:
 		static constexpr float POPUP_MAX_WIDTH = 200.0f;
 		static constexpr float POPUP_FONT_SIZE = 10.0f;
 
-		CUI *m_pUI; // set by CUI when popup is shown
+		CUi *m_pUI; // set by CUi when popup is shown
 		char m_aMessage[1024];
 		ColorRGBA m_TextColor;
 
@@ -611,7 +611,7 @@ public:
 		static constexpr float POPUP_BUTTON_HEIGHT = 12.0f;
 		static constexpr float POPUP_BUTTON_SPACING = 5.0f;
 
-		CUI *m_pUI; // set by CUI when popup is shown
+		CUi *m_pUI; // set by CUi when popup is shown
 		char m_aPositiveButtonLabel[128];
 		char m_aNegativeButtonLabel[128];
 		char m_aMessage[1024];
@@ -628,7 +628,7 @@ public:
 
 	struct SSelectionPopupContext : public SPopupMenuId
 	{
-		CUI *m_pUI; // set by CUI when popup is shown
+		CUi *m_pUI; // set by CUi when popup is shown
 		class CScrollRegion *m_pScrollRegion;
 		SPopupMenuProperties m_Props;
 		char m_aMessage[256];
@@ -659,7 +659,7 @@ public:
 			MODE_HSLA,
 		};
 
-		CUI *m_pUI; // set by CUI when popup is shown
+		CUi *m_pUI; // set by CUi when popup is shown
 		EColorPickerMode m_ColorMode = MODE_UNSET;
 		bool m_Alpha = false;
 		unsigned int *m_pHslaColor = nullptr; // may be nullptr

--- a/src/game/client/ui_listbox.cpp
+++ b/src/game/client/ui_listbox.cpp
@@ -39,7 +39,7 @@ void CListBox::DoHeader(const CUIRect *pRect, const char *pTitle, float HeaderHe
 
 	// draw header
 	View.HSplitTop(HeaderHeight, &Header, &View);
-	UI()->DoLabel(&Header, pTitle, Header.h * CUI::ms_FontmodHeight * 0.8f, TEXTALIGN_MC);
+	Ui()->DoLabel(&Header, pTitle, Header.h * CUi::ms_FontmodHeight * 0.8f, TEXTALIGN_MC);
 
 	View.HSplitTop(Spacing, &Header, &View);
 
@@ -80,7 +80,7 @@ void CListBox::DoStart(float RowHeight, int NumItems, int ItemsPerRow, int RowsP
 		CUIRect Footer;
 		View.HSplitBottom(m_FooterHeight, &View, &Footer);
 		Footer.VSplitLeft(10.0f, 0, &Footer);
-		UI()->DoLabel(&Footer, m_pBottomText, Footer.h * CUI::ms_FontmodHeight * 0.8f, TEXTALIGN_MC);
+		Ui()->DoLabel(&Footer, m_pBottomText, Footer.h * CUi::ms_FontmodHeight * 0.8f, TEXTALIGN_MC);
 	}
 
 	// setup the variables
@@ -100,17 +100,17 @@ void CListBox::DoStart(float RowHeight, int NumItems, int ItemsPerRow, int RowsP
 	// handle input
 	if(m_Active && !Input()->ModifierIsPressed() && !Input()->ShiftIsPressed() && !Input()->AltIsPressed())
 	{
-		if(UI()->ConsumeHotkey(CUI::HOTKEY_DOWN))
+		if(Ui()->ConsumeHotkey(CUi::HOTKEY_DOWN))
 			m_ListBoxNewSelOffset += 1;
-		else if(UI()->ConsumeHotkey(CUI::HOTKEY_UP))
+		else if(Ui()->ConsumeHotkey(CUi::HOTKEY_UP))
 			m_ListBoxNewSelOffset -= 1;
-		else if(UI()->ConsumeHotkey(CUI::HOTKEY_PAGE_UP))
+		else if(Ui()->ConsumeHotkey(CUi::HOTKEY_PAGE_UP))
 			m_ListBoxNewSelOffset = -ItemsPerRow * RowsPerScroll * 4;
-		else if(UI()->ConsumeHotkey(CUI::HOTKEY_PAGE_DOWN))
+		else if(Ui()->ConsumeHotkey(CUi::HOTKEY_PAGE_DOWN))
 			m_ListBoxNewSelOffset = ItemsPerRow * RowsPerScroll * 4;
-		else if(UI()->ConsumeHotkey(CUI::HOTKEY_HOME))
+		else if(Ui()->ConsumeHotkey(CUi::HOTKEY_HOME))
 			m_ListBoxNewSelOffset = 1 - m_ListBoxNumItems;
-		else if(UI()->ConsumeHotkey(CUI::HOTKEY_END))
+		else if(Ui()->ConsumeHotkey(CUi::HOTKEY_END))
 			m_ListBoxNewSelOffset = m_ListBoxNumItems - 1;
 	}
 
@@ -164,7 +164,7 @@ CListboxItem CListBox::DoNextItem(const void *pId, bool Selected)
 	CListboxItem Item = DoNextRow();
 	bool ItemClicked = false;
 
-	if(Item.m_Visible && UI()->DoButtonLogic(pId, 0, &Item.m_Rect))
+	if(Item.m_Visible && Ui()->DoButtonLogic(pId, 0, &Item.m_Rect))
 	{
 		ItemClicked = true;
 		m_ListBoxNewSelected = ThisItemIndex;
@@ -181,16 +181,16 @@ CListboxItem CListBox::DoNextItem(const void *pId, bool Selected)
 		{
 			m_ListBoxDoneEvents = true;
 
-			if(UI()->ConsumeHotkey(CUI::HOTKEY_ENTER) || (ItemClicked && Input()->MouseDoubleClick()))
+			if(Ui()->ConsumeHotkey(CUi::HOTKEY_ENTER) || (ItemClicked && Input()->MouseDoubleClick()))
 			{
 				m_ListBoxItemActivated = true;
-				UI()->SetActiveItem(nullptr);
+				Ui()->SetActiveItem(nullptr);
 			}
 		}
 
 		Item.m_Rect.Draw(ColorRGBA(1.0f, 1.0f, 1.0f, m_Active ? 0.5f : 0.33f), IGraphics::CORNER_ALL, 5.0f);
 	}
-	if(UI()->HotItem() == pId && !m_ScrollRegion.Animating())
+	if(Ui()->HotItem() == pId && !m_ScrollRegion.Animating())
 	{
 		Item.m_Rect.Draw(ColorRGBA(1.0f, 1.0f, 1.0f, 0.33f), IGraphics::CORNER_ALL, 5.0f);
 	}

--- a/src/game/client/ui_listbox.h
+++ b/src/game/client/ui_listbox.h
@@ -54,7 +54,7 @@ public:
 	void DoFooter(const char *pBottomText, float FooterHeight = 20.0f); // call before DoStart to create a footer
 	void DoStart(float RowHeight, int NumItems, int ItemsPerRow, int RowsPerScroll, int SelectedIndex, const CUIRect *pRect = nullptr, bool Background = true, int BackgroundCorners = IGraphics::CORNER_ALL, bool ForceShowScrollbar = false);
 	void ScrollToSelected() { m_ListBoxUpdateScroll = true; }
-	CListboxItem DoNextItem(const void *pID, bool Selected = false);
+	CListboxItem DoNextItem(const void *pId, bool Selected = false);
 	CListboxItem DoSubheader();
 	int DoEnd();
 

--- a/src/game/client/ui_scrollregion.cpp
+++ b/src/game/client/ui_scrollregion.cpp
@@ -60,7 +60,7 @@ void CScrollRegion::Begin(CUIRect *pClipRect, vec2 *pOutOffset, const CScrollReg
 	if(m_Params.m_ClipBgColor.a > 0.0f)
 		pClipRect->Draw(m_Params.m_ClipBgColor, HasScrollBar ? IGraphics::CORNER_L : IGraphics::CORNER_ALL, 4.0f);
 
-	UI()->ClipEnable(pClipRect);
+	Ui()->ClipEnable(pClipRect);
 
 	m_ClipRect = *pClipRect;
 	m_ContentH = 0.0f;
@@ -69,7 +69,7 @@ void CScrollRegion::Begin(CUIRect *pClipRect, vec2 *pOutOffset, const CScrollReg
 
 void CScrollRegion::End()
 {
-	UI()->ClipDisable();
+	Ui()->ClipDisable();
 
 	// only show scrollbar if content overflows
 	if(m_ContentH <= m_ClipRect.h)
@@ -79,12 +79,12 @@ void CScrollRegion::End()
 	CUIRect RegionRect = m_ClipRect;
 	RegionRect.w += m_Params.m_ScrollbarWidth;
 
-	if(m_ScrollDirection != SCROLLRELATIVE_NONE || (UI()->Enabled() && m_Params.m_Active && UI()->MouseHovered(&RegionRect)))
+	if(m_ScrollDirection != SCROLLRELATIVE_NONE || (Ui()->Enabled() && m_Params.m_Active && Ui()->MouseHovered(&RegionRect)))
 	{
 		bool ProgrammaticScroll = false;
-		if(UI()->ConsumeHotkey(CUI::HOTKEY_SCROLL_UP))
+		if(Ui()->ConsumeHotkey(CUi::HOTKEY_SCROLL_UP))
 			m_ScrollDirection = SCROLLRELATIVE_UP;
-		else if(UI()->ConsumeHotkey(CUI::HOTKEY_SCROLL_DOWN))
+		else if(Ui()->ConsumeHotkey(CUi::HOTKEY_SCROLL_DOWN))
 			m_ScrollDirection = SCROLLRELATIVE_DOWN;
 		else
 			ProgrammaticScroll = true;
@@ -140,13 +140,13 @@ void CScrollRegion::End()
 	Slider.y += m_ScrollY / MaxScroll * MaxSlider;
 
 	bool Grabbed = false;
-	const void *pID = &m_ScrollY;
-	const bool InsideSlider = UI()->MouseHovered(&Slider);
-	const bool InsideRail = UI()->MouseHovered(&m_RailRect);
+	const void *pId = &m_ScrollY;
+	const bool InsideSlider = Ui()->MouseHovered(&Slider);
+	const bool InsideRail = Ui()->MouseHovered(&m_RailRect);
 
-	if(UI()->CheckActiveItem(pID) && UI()->MouseButton(0))
+	if(Ui()->CheckActiveItem(pId) && Ui()->MouseButton(0))
 	{
-		float MouseY = UI()->MouseY();
+		float MouseY = Ui()->MouseY();
 		m_ScrollY += (MouseY - (Slider.y + m_SliderGrabPos)) / MaxSlider * MaxScroll;
 		m_SliderGrabPos = clamp(m_SliderGrabPos, 0.0f, SliderHeight);
 		m_AnimTargetScrollY = m_ScrollY;
@@ -155,36 +155,36 @@ void CScrollRegion::End()
 	}
 	else if(InsideSlider)
 	{
-		UI()->SetHotItem(pID);
+		Ui()->SetHotItem(pId);
 
-		if(!UI()->CheckActiveItem(pID) && UI()->MouseButtonClicked(0))
+		if(!Ui()->CheckActiveItem(pId) && Ui()->MouseButtonClicked(0))
 		{
-			UI()->SetActiveItem(pID);
-			m_SliderGrabPos = UI()->MouseY() - Slider.y;
+			Ui()->SetActiveItem(pId);
+			m_SliderGrabPos = Ui()->MouseY() - Slider.y;
 			m_AnimTargetScrollY = m_ScrollY;
 			m_AnimTime = 0.0f;
 			m_Params.m_Active = true;
 		}
 	}
-	else if(InsideRail && UI()->MouseButtonClicked(0))
+	else if(InsideRail && Ui()->MouseButtonClicked(0))
 	{
-		m_ScrollY += (UI()->MouseY() - (Slider.y + Slider.h / 2.0f)) / MaxSlider * MaxScroll;
-		UI()->SetHotItem(pID);
-		UI()->SetActiveItem(pID);
+		m_ScrollY += (Ui()->MouseY() - (Slider.y + Slider.h / 2.0f)) / MaxSlider * MaxScroll;
+		Ui()->SetHotItem(pId);
+		Ui()->SetActiveItem(pId);
 		m_SliderGrabPos = Slider.h / 2.0f;
 		m_AnimTargetScrollY = m_ScrollY;
 		m_AnimTime = 0.0f;
 		m_Params.m_Active = true;
 	}
-	else if(UI()->CheckActiveItem(pID) && !UI()->MouseButton(0))
+	else if(Ui()->CheckActiveItem(pId) && !Ui()->MouseButton(0))
 	{
-		UI()->SetActiveItem(nullptr);
+		Ui()->SetActiveItem(nullptr);
 	}
 
 	m_ScrollY = clamp(m_ScrollY, 0.0f, MaxScroll);
 	m_ContentScrollOff.y = -m_ScrollY;
 
-	Slider.Draw(m_Params.SliderColor(Grabbed, UI()->HotItem() == pID), IGraphics::CORNER_ALL, Slider.w / 2.0f);
+	Slider.Draw(m_Params.SliderColor(Grabbed, Ui()->HotItem() == pId), IGraphics::CORNER_ALL, Slider.w / 2.0f);
 }
 
 bool CScrollRegion::AddRect(const CUIRect &Rect, bool ShouldScrollHere)
@@ -239,10 +239,10 @@ void CScrollRegion::DoEdgeScrolling()
 	const float ScrollSpeedFactor = MaxScrollMultiplier / ScrollBorderSize;
 	const float TopScrollPosition = m_ClipRect.y + ScrollBorderSize;
 	const float BottomScrollPosition = m_ClipRect.y + m_ClipRect.h - ScrollBorderSize;
-	if(UI()->MouseY() < TopScrollPosition)
-		ScrollRelative(SCROLLRELATIVE_UP, minimum(MaxScrollMultiplier, (TopScrollPosition - UI()->MouseY()) * ScrollSpeedFactor));
-	else if(UI()->MouseY() > BottomScrollPosition)
-		ScrollRelative(SCROLLRELATIVE_DOWN, minimum(MaxScrollMultiplier, (UI()->MouseY() - BottomScrollPosition) * ScrollSpeedFactor));
+	if(Ui()->MouseY() < TopScrollPosition)
+		ScrollRelative(SCROLLRELATIVE_UP, minimum(MaxScrollMultiplier, (TopScrollPosition - Ui()->MouseY()) * ScrollSpeedFactor));
+	else if(Ui()->MouseY() > BottomScrollPosition)
+		ScrollRelative(SCROLLRELATIVE_DOWN, minimum(MaxScrollMultiplier, (Ui()->MouseY() - BottomScrollPosition) * ScrollSpeedFactor));
 }
 
 bool CScrollRegion::RectClipped(const CUIRect &Rect) const

--- a/src/game/editor/auto_map.cpp
+++ b/src/game/editor/auto_map.cpp
@@ -82,16 +82,16 @@ void CAutoMapper::Load(const char *pTileName)
 				NewConf.m_EndX = 0;
 				NewConf.m_EndY = 0;
 				m_vConfigs.push_back(NewConf);
-				int ConfigurationID = m_vConfigs.size() - 1;
-				pCurrentConf = &m_vConfigs[ConfigurationID];
+				int ConfigurationId = m_vConfigs.size() - 1;
+				pCurrentConf = &m_vConfigs[ConfigurationId];
 				str_copy(pCurrentConf->m_aName, pLine, minimum<int>(sizeof(pCurrentConf->m_aName), str_length(pLine)));
 
 				// add start run
 				CRun NewRun;
 				NewRun.m_AutomapCopy = true;
 				pCurrentConf->m_vRuns.push_back(NewRun);
-				int RunID = pCurrentConf->m_vRuns.size() - 1;
-				pCurrentRun = &pCurrentConf->m_vRuns[RunID];
+				int RunId = pCurrentConf->m_vRuns.size() - 1;
+				pCurrentRun = &pCurrentConf->m_vRuns[RunId];
 			}
 			else if(str_startswith(pLine, "NewRun") && pCurrentConf)
 			{
@@ -99,21 +99,21 @@ void CAutoMapper::Load(const char *pTileName)
 				CRun NewRun;
 				NewRun.m_AutomapCopy = true;
 				pCurrentConf->m_vRuns.push_back(NewRun);
-				int RunID = pCurrentConf->m_vRuns.size() - 1;
-				pCurrentRun = &pCurrentConf->m_vRuns[RunID];
+				int RunId = pCurrentConf->m_vRuns.size() - 1;
+				pCurrentRun = &pCurrentConf->m_vRuns[RunId];
 			}
 			else if(str_startswith(pLine, "Index") && pCurrentRun)
 			{
 				// new index
-				int ID = 0;
+				int Id = 0;
 				char aOrientation1[128] = "";
 				char aOrientation2[128] = "";
 				char aOrientation3[128] = "";
 
-				sscanf(pLine, "Index %d %127s %127s %127s", &ID, aOrientation1, aOrientation2, aOrientation3);
+				sscanf(pLine, "Index %d %127s %127s %127s", &Id, aOrientation1, aOrientation2, aOrientation3);
 
 				CIndexRule NewIndexRule;
-				NewIndexRule.m_ID = ID;
+				NewIndexRule.m_Id = Id;
 				NewIndexRule.m_Flag = 0;
 				NewIndexRule.m_RandomProbability = 1.0f;
 				NewIndexRule.m_DefaultRule = true;
@@ -152,8 +152,8 @@ void CAutoMapper::Load(const char *pTileName)
 
 				// add the index rule object and make it current
 				pCurrentRun->m_vIndexRules.push_back(NewIndexRule);
-				int IndexRuleID = pCurrentRun->m_vIndexRules.size() - 1;
-				pCurrentIndex = &pCurrentRun->m_vIndexRules[IndexRuleID];
+				int IndexRuleId = pCurrentRun->m_vIndexRules.size() - 1;
+				pCurrentIndex = &pCurrentRun->m_vIndexRules[IndexRuleId];
 			}
 			else if(str_startswith(pLine, "Pos") && pCurrentIndex)
 			{
@@ -188,15 +188,15 @@ void CAutoMapper::Load(const char *pTileName)
 					int pWord = 4;
 					while(true)
 					{
-						int ID = 0;
+						int Id = 0;
 						char aOrientation1[128] = "";
 						char aOrientation2[128] = "";
 						char aOrientation3[128] = "";
 						char aOrientation4[128] = "";
-						sscanf(str_trim_words(pLine, pWord), "%d %127s %127s %127s %127s", &ID, aOrientation1, aOrientation2, aOrientation3, aOrientation4);
+						sscanf(str_trim_words(pLine, pWord), "%d %127s %127s %127s %127s", &Id, aOrientation1, aOrientation2, aOrientation3, aOrientation4);
 
 						CIndexInfo NewIndexInfo;
-						NewIndexInfo.m_ID = ID;
+						NewIndexInfo.m_Id = Id;
 						NewIndexInfo.m_Flag = 0;
 						NewIndexInfo.m_TestFlag = false;
 
@@ -296,7 +296,7 @@ void CAutoMapper::Load(const char *pTileName)
 					{
 						for(const auto &Index : vNewIndexList)
 						{
-							if(Value == CPosRule::INDEX && Index.m_ID == 0)
+							if(Value == CPosRule::INDEX && Index.m_Id == 0)
 								pCurrentIndex->m_SkipFull = true;
 							else
 								pCurrentIndex->m_SkipEmpty = true;
@@ -382,9 +382,9 @@ const char *CAutoMapper::GetConfigName(int Index)
 	return m_vConfigs[Index].m_aName;
 }
 
-void CAutoMapper::ProceedLocalized(CLayerTiles *pLayer, int ConfigID, int Seed, int X, int Y, int Width, int Height)
+void CAutoMapper::ProceedLocalized(CLayerTiles *pLayer, int ConfigId, int Seed, int X, int Y, int Width, int Height)
 {
-	if(!m_FileLoaded || pLayer->m_Readonly || ConfigID < 0 || ConfigID >= (int)m_vConfigs.size())
+	if(!m_FileLoaded || pLayer->m_Readonly || ConfigId < 0 || ConfigId >= (int)m_vConfigs.size())
 		return;
 
 	if(Width < 0)
@@ -393,7 +393,7 @@ void CAutoMapper::ProceedLocalized(CLayerTiles *pLayer, int ConfigID, int Seed, 
 	if(Height < 0)
 		Height = pLayer->m_Height;
 
-	CConfiguration *pConf = &m_vConfigs[ConfigID];
+	CConfiguration *pConf = &m_vConfigs[ConfigId];
 
 	int CommitFromX = clamp(X + pConf->m_StartX, 0, pLayer->m_Width);
 	int CommitFromY = clamp(Y + pConf->m_StartY, 0, pLayer->m_Height);
@@ -418,7 +418,7 @@ void CAutoMapper::ProceedLocalized(CLayerTiles *pLayer, int ConfigID, int Seed, 
 		}
 	}
 
-	Proceed(pUpdateLayer, ConfigID, Seed, UpdateFromX, UpdateFromY);
+	Proceed(pUpdateLayer, ConfigId, Seed, UpdateFromX, UpdateFromY);
 
 	for(int y = CommitFromY; y < CommitToY; y++)
 	{
@@ -436,15 +436,15 @@ void CAutoMapper::ProceedLocalized(CLayerTiles *pLayer, int ConfigID, int Seed, 
 	delete pUpdateLayer;
 }
 
-void CAutoMapper::Proceed(CLayerTiles *pLayer, int ConfigID, int Seed, int SeedOffsetX, int SeedOffsetY)
+void CAutoMapper::Proceed(CLayerTiles *pLayer, int ConfigId, int Seed, int SeedOffsetX, int SeedOffsetY)
 {
-	if(!m_FileLoaded || pLayer->m_Readonly || ConfigID < 0 || ConfigID >= (int)m_vConfigs.size())
+	if(!m_FileLoaded || pLayer->m_Readonly || ConfigId < 0 || ConfigId >= (int)m_vConfigs.size())
 		return;
 
 	if(Seed == 0)
 		Seed = rand();
 
-	CConfiguration *pConf = &m_vConfigs[ConfigID];
+	CConfiguration *pConf = &m_vConfigs[ConfigId];
 	pLayer->ClearHistory();
 
 	// for every run: copy tiles, automap, overwrite tiles
@@ -515,7 +515,7 @@ void CAutoMapper::Proceed(CLayerTiles *pLayer, int ConfigID, int Seed, int SeedO
 							RespectRules = false;
 							for(const auto &Index : pRule->m_vIndexList)
 							{
-								if(CheckIndex == Index.m_ID && (!Index.m_TestFlag || CheckFlags == Index.m_Flag))
+								if(CheckIndex == Index.m_Id && (!Index.m_TestFlag || CheckFlags == Index.m_Flag))
 								{
 									RespectRules = true;
 									break;
@@ -526,7 +526,7 @@ void CAutoMapper::Proceed(CLayerTiles *pLayer, int ConfigID, int Seed, int SeedO
 						{
 							for(const auto &Index : pRule->m_vIndexList)
 							{
-								if(CheckIndex == Index.m_ID && (!Index.m_TestFlag || CheckFlags == Index.m_Flag))
+								if(CheckIndex == Index.m_Id && (!Index.m_TestFlag || CheckFlags == Index.m_Flag))
 								{
 									RespectRules = false;
 									break;
@@ -539,7 +539,7 @@ void CAutoMapper::Proceed(CLayerTiles *pLayer, int ConfigID, int Seed, int SeedO
 						(pIndexRule->m_RandomProbability >= 1.0f || HashLocation(Seed, h, i, x + SeedOffsetX, y + SeedOffsetY) < HASH_MAX * pIndexRule->m_RandomProbability))
 					{
 						CTile Previous = *pTile;
-						pTile->m_Index = pIndexRule->m_ID;
+						pTile->m_Index = pIndexRule->m_Id;
 						pTile->m_Flags = pIndexRule->m_Flag;
 						pLayer->RecordStateChange(x, y, Previous, *pTile);
 					}

--- a/src/game/editor/auto_map.h
+++ b/src/game/editor/auto_map.h
@@ -9,7 +9,7 @@ class CAutoMapper : public CEditorComponent
 {
 	struct CIndexInfo
 	{
-		int m_ID;
+		int m_Id;
 		int m_Flag;
 		bool m_TestFlag;
 	};
@@ -31,7 +31,7 @@ class CAutoMapper : public CEditorComponent
 
 	struct CIndexRule
 	{
-		int m_ID;
+		int m_Id;
 		std::vector<CPosRule> m_vRules;
 		int m_Flag;
 		float m_RandomProbability;
@@ -60,8 +60,8 @@ public:
 	explicit CAutoMapper(CEditor *pEditor);
 
 	void Load(const char *pTileName);
-	void ProceedLocalized(class CLayerTiles *pLayer, int ConfigID, int Seed = 0, int X = 0, int Y = 0, int Width = -1, int Height = -1);
-	void Proceed(class CLayerTiles *pLayer, int ConfigID, int Seed = 0, int SeedOffsetX = 0, int SeedOffsetY = 0);
+	void ProceedLocalized(class CLayerTiles *pLayer, int ConfigId, int Seed = 0, int X = 0, int Y = 0, int Width = -1, int Height = -1);
+	void Proceed(class CLayerTiles *pLayer, int ConfigId, int Seed = 0, int SeedOffsetX = 0, int SeedOffsetY = 0);
 
 	int ConfigNamesNum() const { return m_vConfigs.size(); }
 	const char *GetConfigName(int Index);

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -114,16 +114,16 @@ void CEditor::EnvelopeEval(int TimeOffsetMillis, int Env, ColorRGBA &Result, siz
 bool CEditor::DoEditBox(CLineInput *pLineInput, const CUIRect *pRect, float FontSize, int Corners, const char *pToolTip, const std::vector<STextColorSplit> &vColorSplits)
 {
 	UpdateTooltip(pLineInput, pRect, pToolTip);
-	return UI()->DoEditBox(pLineInput, pRect, FontSize, Corners, vColorSplits);
+	return Ui()->DoEditBox(pLineInput, pRect, FontSize, Corners, vColorSplits);
 }
 
 bool CEditor::DoClearableEditBox(CLineInput *pLineInput, const CUIRect *pRect, float FontSize, int Corners, const char *pToolTip, const std::vector<STextColorSplit> &vColorSplits)
 {
 	UpdateTooltip(pLineInput, pRect, pToolTip);
-	return UI()->DoClearableEditBox(pLineInput, pRect, FontSize, Corners, vColorSplits);
+	return Ui()->DoClearableEditBox(pLineInput, pRect, FontSize, Corners, vColorSplits);
 }
 
-ColorRGBA CEditor::GetButtonColor(const void *pID, int Checked)
+ColorRGBA CEditor::GetButtonColor(const void *pId, int Checked)
 {
 	if(Checked < 0)
 		return ColorRGBA(0, 0, 0, 0.5f);
@@ -133,92 +133,92 @@ ColorRGBA CEditor::GetButtonColor(const void *pID, int Checked)
 	case 8: // invisible
 		return ColorRGBA(0, 0, 0, 0);
 	case 7: // selected + game layers
-		if(UI()->HotItem() == pID)
+		if(Ui()->HotItem() == pId)
 			return ColorRGBA(1, 0, 0, 0.4f);
 		return ColorRGBA(1, 0, 0, 0.2f);
 
 	case 6: // game layers
-		if(UI()->HotItem() == pID)
+		if(Ui()->HotItem() == pId)
 			return ColorRGBA(1, 1, 1, 0.4f);
 		return ColorRGBA(1, 1, 1, 0.2f);
 
 	case 5: // selected + image/sound should be embedded
-		if(UI()->HotItem() == pID)
+		if(Ui()->HotItem() == pId)
 			return ColorRGBA(1, 0, 0, 0.75f);
 		return ColorRGBA(1, 0, 0, 0.5f);
 
 	case 4: // image/sound should be embedded
-		if(UI()->HotItem() == pID)
+		if(Ui()->HotItem() == pId)
 			return ColorRGBA(1, 0, 0, 1.0f);
 		return ColorRGBA(1, 0, 0, 0.875f);
 
 	case 3: // selected + unused image/sound
-		if(UI()->HotItem() == pID)
+		if(Ui()->HotItem() == pId)
 			return ColorRGBA(1, 0, 1, 0.75f);
 		return ColorRGBA(1, 0, 1, 0.5f);
 
 	case 2: // unused image/sound
-		if(UI()->HotItem() == pID)
+		if(Ui()->HotItem() == pId)
 			return ColorRGBA(0, 0, 1, 0.75f);
 		return ColorRGBA(0, 0, 1, 0.5f);
 
 	case 1: // selected
-		if(UI()->HotItem() == pID)
+		if(Ui()->HotItem() == pId)
 			return ColorRGBA(1, 0, 0, 0.75f);
 		return ColorRGBA(1, 0, 0, 0.5f);
 
 	default: // regular
-		if(UI()->HotItem() == pID)
+		if(Ui()->HotItem() == pId)
 			return ColorRGBA(1, 1, 1, 0.75f);
 		return ColorRGBA(1, 1, 1, 0.5f);
 	}
 }
 
-void CEditor::UpdateTooltip(const void *pID, const CUIRect *pRect, const char *pToolTip)
+void CEditor::UpdateTooltip(const void *pId, const CUIRect *pRect, const char *pToolTip)
 {
-	if(UI()->MouseInside(pRect) && !pToolTip)
+	if(Ui()->MouseInside(pRect) && !pToolTip)
 		str_copy(m_aTooltip, "");
-	else if(UI()->HotItem() == pID && pToolTip)
+	else if(Ui()->HotItem() == pId && pToolTip)
 		str_copy(m_aTooltip, pToolTip);
 }
 
-int CEditor::DoButton_Editor_Common(const void *pID, const char *pText, int Checked, const CUIRect *pRect, int Flags, const char *pToolTip)
+int CEditor::DoButton_Editor_Common(const void *pId, const char *pText, int Checked, const CUIRect *pRect, int Flags, const char *pToolTip)
 {
-	if(UI()->MouseInside(pRect))
+	if(Ui()->MouseInside(pRect))
 	{
 		if(Flags & BUTTON_CONTEXT)
-			ms_pUiGotContext = pID;
+			ms_pUiGotContext = pId;
 	}
 
-	UpdateTooltip(pID, pRect, pToolTip);
-	return UI()->DoButtonLogic(pID, Checked, pRect);
+	UpdateTooltip(pId, pRect, pToolTip);
+	return Ui()->DoButtonLogic(pId, Checked, pRect);
 }
 
-int CEditor::DoButton_Editor(const void *pID, const char *pText, int Checked, const CUIRect *pRect, int Flags, const char *pToolTip)
+int CEditor::DoButton_Editor(const void *pId, const char *pText, int Checked, const CUIRect *pRect, int Flags, const char *pToolTip)
 {
-	pRect->Draw(GetButtonColor(pID, Checked), IGraphics::CORNER_ALL, 3.0f);
+	pRect->Draw(GetButtonColor(pId, Checked), IGraphics::CORNER_ALL, 3.0f);
 	CUIRect NewRect = *pRect;
-	UI()->DoLabel(&NewRect, pText, 10.0f, TEXTALIGN_MC);
+	Ui()->DoLabel(&NewRect, pText, 10.0f, TEXTALIGN_MC);
 	Checked %= 2;
-	return DoButton_Editor_Common(pID, pText, Checked, pRect, Flags, pToolTip);
+	return DoButton_Editor_Common(pId, pText, Checked, pRect, Flags, pToolTip);
 }
 
-int CEditor::DoButton_Env(const void *pID, const char *pText, int Checked, const CUIRect *pRect, const char *pToolTip, ColorRGBA BaseColor, int Corners)
+int CEditor::DoButton_Env(const void *pId, const char *pText, int Checked, const CUIRect *pRect, const char *pToolTip, ColorRGBA BaseColor, int Corners)
 {
 	float Bright = Checked ? 1.0f : 0.5f;
-	float Alpha = UI()->HotItem() == pID ? 1.0f : 0.75f;
+	float Alpha = Ui()->HotItem() == pId ? 1.0f : 0.75f;
 	ColorRGBA Color = ColorRGBA(BaseColor.r * Bright, BaseColor.g * Bright, BaseColor.b * Bright, Alpha);
 
 	pRect->Draw(Color, Corners, 3.0f);
-	UI()->DoLabel(pRect, pText, 10.0f, TEXTALIGN_MC);
+	Ui()->DoLabel(pRect, pText, 10.0f, TEXTALIGN_MC);
 	Checked %= 2;
-	return DoButton_Editor_Common(pID, pText, Checked, pRect, 0, pToolTip);
+	return DoButton_Editor_Common(pId, pText, Checked, pRect, 0, pToolTip);
 }
 
-int CEditor::DoButton_MenuItem(const void *pID, const char *pText, int Checked, const CUIRect *pRect, int Flags, const char *pToolTip)
+int CEditor::DoButton_MenuItem(const void *pId, const char *pText, int Checked, const CUIRect *pRect, int Flags, const char *pToolTip)
 {
-	if(UI()->HotItem() == pID || Checked)
-		pRect->Draw(GetButtonColor(pID, Checked), IGraphics::CORNER_ALL, 3.0f);
+	if(Ui()->HotItem() == pId || Checked)
+		pRect->Draw(GetButtonColor(pId, Checked), IGraphics::CORNER_ALL, 3.0f);
 
 	CUIRect Rect;
 	pRect->VMargin(5.0f, &Rect);
@@ -226,14 +226,14 @@ int CEditor::DoButton_MenuItem(const void *pID, const char *pText, int Checked, 
 	SLabelProperties Props;
 	Props.m_MaxWidth = Rect.w;
 	Props.m_EllipsisAtEnd = true;
-	UI()->DoLabel(&Rect, pText, 10.0f, TEXTALIGN_ML, Props);
+	Ui()->DoLabel(&Rect, pText, 10.0f, TEXTALIGN_ML, Props);
 
-	return DoButton_Editor_Common(pID, pText, Checked, pRect, Flags, pToolTip);
+	return DoButton_Editor_Common(pId, pText, Checked, pRect, Flags, pToolTip);
 }
 
-int CEditor::DoButton_Ex(const void *pID, const char *pText, int Checked, const CUIRect *pRect, int Flags, const char *pToolTip, int Corners, float FontSize, int Align)
+int CEditor::DoButton_Ex(const void *pId, const char *pText, int Checked, const CUIRect *pRect, int Flags, const char *pToolTip, int Corners, float FontSize, int Align)
 {
-	pRect->Draw(GetButtonColor(pID, Checked), Corners, 3.0f);
+	pRect->Draw(GetButtonColor(pId, Checked), Corners, 3.0f);
 
 	CUIRect Rect;
 	pRect->VMargin(((Align & TEXTALIGN_MASK_HORIZONTAL) == TEXTALIGN_CENTER) ? 1.0f : 5.0f, &Rect);
@@ -241,27 +241,27 @@ int CEditor::DoButton_Ex(const void *pID, const char *pText, int Checked, const 
 	SLabelProperties Props;
 	Props.m_MaxWidth = Rect.w;
 	Props.m_EllipsisAtEnd = true;
-	UI()->DoLabel(&Rect, pText, FontSize, Align, Props);
+	Ui()->DoLabel(&Rect, pText, FontSize, Align, Props);
 
-	return DoButton_Editor_Common(pID, pText, Checked, pRect, Flags, pToolTip);
+	return DoButton_Editor_Common(pId, pText, Checked, pRect, Flags, pToolTip);
 }
 
-int CEditor::DoButton_FontIcon(const void *pID, const char *pText, int Checked, const CUIRect *pRect, int Flags, const char *pToolTip, int Corners, float FontSize)
+int CEditor::DoButton_FontIcon(const void *pId, const char *pText, int Checked, const CUIRect *pRect, int Flags, const char *pToolTip, int Corners, float FontSize)
 {
-	pRect->Draw(GetButtonColor(pID, Checked), Corners, 3.0f);
+	pRect->Draw(GetButtonColor(pId, Checked), Corners, 3.0f);
 
 	TextRender()->SetFontPreset(EFontPreset::ICON_FONT);
 	TextRender()->SetRenderFlags(ETextRenderFlags::TEXT_RENDER_FLAG_ONLY_ADVANCE_WIDTH | ETextRenderFlags::TEXT_RENDER_FLAG_NO_X_BEARING | ETextRenderFlags::TEXT_RENDER_FLAG_NO_Y_BEARING);
-	UI()->DoLabel(pRect, pText, FontSize, TEXTALIGN_MC);
+	Ui()->DoLabel(pRect, pText, FontSize, TEXTALIGN_MC);
 	TextRender()->SetRenderFlags(0);
 	TextRender()->SetFontPreset(EFontPreset::DEFAULT_FONT);
 
-	return DoButton_Editor_Common(pID, pText, Checked, pRect, Flags, pToolTip);
+	return DoButton_Editor_Common(pId, pText, Checked, pRect, Flags, pToolTip);
 }
 
-int CEditor::DoButton_DraggableEx(const void *pID, const char *pText, int Checked, const CUIRect *pRect, bool *pClicked, bool *pAbrupted, int Flags, const char *pToolTip, int Corners, float FontSize)
+int CEditor::DoButton_DraggableEx(const void *pId, const char *pText, int Checked, const CUIRect *pRect, bool *pClicked, bool *pAbrupted, int Flags, const char *pToolTip, int Corners, float FontSize)
 {
-	pRect->Draw(GetButtonColor(pID, Checked), Corners, 3.0f);
+	pRect->Draw(GetButtonColor(pId, Checked), Corners, 3.0f);
 
 	CUIRect Rect;
 	pRect->VMargin(pRect->w > 20.0f ? 5.0f : 0.0f, &Rect);
@@ -269,16 +269,16 @@ int CEditor::DoButton_DraggableEx(const void *pID, const char *pText, int Checke
 	SLabelProperties Props;
 	Props.m_MaxWidth = Rect.w;
 	Props.m_EllipsisAtEnd = true;
-	UI()->DoLabel(&Rect, pText, FontSize, TEXTALIGN_MC, Props);
+	Ui()->DoLabel(&Rect, pText, FontSize, TEXTALIGN_MC, Props);
 
-	if(UI()->MouseInside(pRect))
+	if(Ui()->MouseInside(pRect))
 	{
 		if(Flags & BUTTON_CONTEXT)
-			ms_pUiGotContext = pID;
+			ms_pUiGotContext = pId;
 	}
 
-	UpdateTooltip(pID, pRect, pToolTip);
-	return UI()->DoDraggableButtonLogic(pID, Checked, pRect, pClicked, pAbrupted);
+	UpdateTooltip(pId, pRect, pToolTip);
+	return Ui()->DoDraggableButtonLogic(pId, Checked, pRect, pClicked, pAbrupted);
 }
 
 void CEditor::RenderBackground(CUIRect View, IGraphics::CTextureHandle Texture, float Size, float Brightness) const
@@ -293,65 +293,65 @@ void CEditor::RenderBackground(CUIRect View, IGraphics::CTextureHandle Texture, 
 	Graphics()->QuadsEnd();
 }
 
-SEditResult<int> CEditor::UiDoValueSelector(void *pID, CUIRect *pRect, const char *pLabel, int Current, int Min, int Max, int Step, float Scale, const char *pToolTip, bool IsDegree, bool IsHex, int Corners, const ColorRGBA *pColor, bool ShowValue)
+SEditResult<int> CEditor::UiDoValueSelector(void *pId, CUIRect *pRect, const char *pLabel, int Current, int Min, int Max, int Step, float Scale, const char *pToolTip, bool IsDegree, bool IsHex, int Corners, const ColorRGBA *pColor, bool ShowValue)
 {
 	// logic
 	static float s_Value;
 	static CLineInputNumber s_NumberInput;
 	static bool s_TextMode = false;
-	static void *s_pLastTextID = pID;
-	const bool Inside = UI()->MouseInside(pRect);
+	static void *s_pLastTextId = pId;
+	const bool Inside = Ui()->MouseInside(pRect);
 	const int Base = IsHex ? 16 : 10;
 	static bool s_Editing = false;
 	EEditState State = EEditState::EDITING;
 
-	if(UI()->MouseButton(1) && UI()->HotItem() == pID)
+	if(Ui()->MouseButton(1) && Ui()->HotItem() == pId)
 	{
-		s_pLastTextID = pID;
+		s_pLastTextId = pId;
 		s_TextMode = true;
-		UI()->DisableMouseLock();
+		Ui()->DisableMouseLock();
 		s_NumberInput.SetInteger(Current, Base);
 	}
 
-	if(UI()->CheckActiveItem(pID))
+	if(Ui()->CheckActiveItem(pId))
 	{
-		if(!UI()->MouseButton(0))
+		if(!Ui()->MouseButton(0))
 		{
-			UI()->DisableMouseLock();
-			UI()->SetActiveItem(nullptr);
+			Ui()->DisableMouseLock();
+			Ui()->SetActiveItem(nullptr);
 			s_TextMode = false;
 		}
 	}
 
-	if(s_TextMode && s_pLastTextID == pID)
+	if(s_TextMode && s_pLastTextId == pId)
 	{
 		str_copy(m_aTooltip, "Type your number");
 
 		DoEditBox(&s_NumberInput, pRect, 10.0f, Corners);
 
-		UI()->SetActiveItem(&s_NumberInput);
+		Ui()->SetActiveItem(&s_NumberInput);
 
 		if(Input()->KeyIsPressed(KEY_RETURN) || Input()->KeyIsPressed(KEY_KP_ENTER) ||
-			((UI()->MouseButton(1) || UI()->MouseButton(0)) && !Inside))
+			((Ui()->MouseButton(1) || Ui()->MouseButton(0)) && !Inside))
 		{
 			Current = clamp(s_NumberInput.GetInteger(Base), Min, Max);
-			UI()->DisableMouseLock();
-			UI()->SetActiveItem(nullptr);
+			Ui()->DisableMouseLock();
+			Ui()->SetActiveItem(nullptr);
 			s_TextMode = false;
 		}
 
-		if(UI()->ConsumeHotkey(CUI::HOTKEY_ESCAPE))
+		if(Ui()->ConsumeHotkey(CUi::HOTKEY_ESCAPE))
 		{
-			UI()->DisableMouseLock();
-			UI()->SetActiveItem(nullptr);
+			Ui()->DisableMouseLock();
+			Ui()->SetActiveItem(nullptr);
 			s_TextMode = false;
 		}
 	}
 	else
 	{
-		if(UI()->CheckActiveItem(pID))
+		if(Ui()->CheckActiveItem(pId))
 		{
-			if(UI()->MouseButton(0))
+			if(Ui()->MouseButton(0))
 			{
 				if(Input()->ShiftIsPressed())
 					s_Value += m_MouseDeltaX * 0.05f;
@@ -375,12 +375,12 @@ SEditResult<int> CEditor::UiDoValueSelector(void *pID, CUIRect *pRect, const cha
 			if(pToolTip && !s_TextMode)
 				str_copy(m_aTooltip, pToolTip);
 		}
-		else if(UI()->HotItem() == pID)
+		else if(Ui()->HotItem() == pId)
 		{
-			if(UI()->MouseButton(0))
+			if(Ui()->MouseButton(0))
 			{
-				UI()->SetActiveItem(pID);
-				UI()->EnableMouseLock(pID);
+				Ui()->SetActiveItem(pId);
+				Ui()->EnableMouseLock(pId);
 				s_Value = 0;
 			}
 			if(pToolTip && !s_TextMode)
@@ -388,7 +388,7 @@ SEditResult<int> CEditor::UiDoValueSelector(void *pID, CUIRect *pRect, const cha
 		}
 
 		if(Inside)
-			UI()->SetHotItem(pID);
+			Ui()->SetHotItem(pId);
 
 		// render
 		char aBuf[128];
@@ -405,14 +405,14 @@ SEditResult<int> CEditor::UiDoValueSelector(void *pID, CUIRect *pRect, const cha
 			str_format(aBuf, sizeof(aBuf), "#%06X", Current);
 		else
 			str_from_int(Current, aBuf);
-		pRect->Draw(pColor ? *pColor : GetButtonColor(pID, 0), Corners, 3.0f);
-		UI()->DoLabel(pRect, aBuf, 10, TEXTALIGN_MC);
+		pRect->Draw(pColor ? *pColor : GetButtonColor(pId, 0), Corners, 3.0f);
+		Ui()->DoLabel(pRect, aBuf, 10, TEXTALIGN_MC);
 	}
 
 	if(!s_TextMode)
 		s_NumberInput.Clear();
 
-	bool MouseLocked = UI()->CheckMouseLock();
+	bool MouseLocked = Ui()->CheckMouseLock();
 	if((MouseLocked || s_TextMode) && !s_Editing)
 	{
 		State = EEditState::START;
@@ -914,25 +914,25 @@ bool CEditor::CallbackSaveSound(const char *pFileName, int StorageType, void *pU
 	return false;
 }
 
-void CEditor::DoAudioPreview(CUIRect View, const void *pPlayPauseButtonID, const void *pStopButtonID, const void *pSeekBarID, const int SampleID)
+void CEditor::DoAudioPreview(CUIRect View, const void *pPlayPauseButtonId, const void *pStopButtonId, const void *pSeekBarId, const int SampleId)
 {
 	CUIRect Button, SeekBar;
 	// play/pause button
 	{
 		View.VSplitLeft(View.h, &Button, &View);
-		if(DoButton_FontIcon(pPlayPauseButtonID, Sound()->IsPlaying(SampleID) ? FONT_ICON_PAUSE : FONT_ICON_PLAY, 0, &Button, 0, "Play/pause audio preview", IGraphics::CORNER_ALL) ||
+		if(DoButton_FontIcon(pPlayPauseButtonId, Sound()->IsPlaying(SampleId) ? FONT_ICON_PAUSE : FONT_ICON_PLAY, 0, &Button, 0, "Play/pause audio preview", IGraphics::CORNER_ALL) ||
 			(m_Dialog == DIALOG_NONE && CLineInput::GetActiveInput() == nullptr && Input()->KeyPress(KEY_SPACE)))
 		{
-			if(Sound()->IsPlaying(SampleID))
+			if(Sound()->IsPlaying(SampleId))
 			{
-				Sound()->Pause(SampleID);
+				Sound()->Pause(SampleId);
 			}
 			else
 			{
-				if(SampleID != m_ToolbarPreviewSound && m_ToolbarPreviewSound >= 0 && Sound()->IsPlaying(m_ToolbarPreviewSound))
+				if(SampleId != m_ToolbarPreviewSound && m_ToolbarPreviewSound >= 0 && Sound()->IsPlaying(m_ToolbarPreviewSound))
 					Sound()->Pause(m_ToolbarPreviewSound);
 
-				Sound()->Play(CSounds::CHN_GUI, SampleID, ISound::FLAG_PREVIEW);
+				Sound()->Play(CSounds::CHN_GUI, SampleId, ISound::FLAG_PREVIEW);
 			}
 		}
 	}
@@ -940,9 +940,9 @@ void CEditor::DoAudioPreview(CUIRect View, const void *pPlayPauseButtonID, const
 	{
 		View.VSplitLeft(2.0f, nullptr, &View);
 		View.VSplitLeft(View.h, &Button, &View);
-		if(DoButton_FontIcon(pStopButtonID, FONT_ICON_STOP, 0, &Button, 0, "Stop audio preview", IGraphics::CORNER_ALL))
+		if(DoButton_FontIcon(pStopButtonId, FONT_ICON_STOP, 0, &Button, 0, "Stop audio preview", IGraphics::CORNER_ALL))
 		{
-			Sound()->Stop(SampleID);
+			Sound()->Stop(SampleId);
 		}
 	}
 	// do seekbar
@@ -955,8 +955,8 @@ void CEditor::DoAudioPreview(CUIRect View, const void *pPlayPauseButtonID, const
 		const float Rounding = 5.0f;
 
 		char aBuffer[64];
-		const float CurrentTime = Sound()->GetSampleCurrentTime(SampleID);
-		const float TotalTime = Sound()->GetSampleTotalTime(SampleID);
+		const float CurrentTime = Sound()->GetSampleCurrentTime(SampleId);
+		const float TotalTime = Sound()->GetSampleTotalTime(SampleId);
 
 		// draw seek bar
 		SeekBar.Draw(ColorRGBA(0, 0, 0, 0.5f), IGraphics::CORNER_ALL, Rounding);
@@ -973,31 +973,31 @@ void CEditor::DoAudioPreview(CUIRect View, const void *pPlayPauseButtonID, const
 		char aTotalTime[32];
 		str_time_float(TotalTime, TIME_HOURS, aTotalTime, sizeof(aTotalTime));
 		str_format(aBuffer, sizeof(aBuffer), "%s / %s", aCurrentTime, aTotalTime);
-		UI()->DoLabel(&SeekBar, aBuffer, SeekBar.h * 0.70f, TEXTALIGN_MC);
+		Ui()->DoLabel(&SeekBar, aBuffer, SeekBar.h * 0.70f, TEXTALIGN_MC);
 
 		// do the logic
-		const bool Inside = UI()->MouseInside(&SeekBar);
+		const bool Inside = Ui()->MouseInside(&SeekBar);
 
-		if(UI()->CheckActiveItem(pSeekBarID))
+		if(Ui()->CheckActiveItem(pSeekBarId))
 		{
-			if(!UI()->MouseButton(0))
+			if(!Ui()->MouseButton(0))
 			{
-				UI()->SetActiveItem(nullptr);
+				Ui()->SetActiveItem(nullptr);
 			}
 			else
 			{
-				const float AmountSeek = clamp((UI()->MouseX() - SeekBar.x - Rounding) / (float)(SeekBar.w - 2 * Rounding), 0.0f, 1.0f);
-				Sound()->SetSampleCurrentTime(SampleID, AmountSeek);
+				const float AmountSeek = clamp((Ui()->MouseX() - SeekBar.x - Rounding) / (float)(SeekBar.w - 2 * Rounding), 0.0f, 1.0f);
+				Sound()->SetSampleCurrentTime(SampleId, AmountSeek);
 			}
 		}
-		else if(UI()->HotItem() == pSeekBarID)
+		else if(Ui()->HotItem() == pSeekBarId)
 		{
-			if(UI()->MouseButton(0))
-				UI()->SetActiveItem(pSeekBarID);
+			if(Ui()->MouseButton(0))
+				Ui()->SetActiveItem(pSeekBarId);
 		}
 
 		if(Inside)
-			UI()->SetHotItem(pSeekBarID);
+			Ui()->SetHotItem(pSeekBarId);
 	}
 }
 
@@ -1064,7 +1064,7 @@ void CEditor::DoToolbarLayers(CUIRect ToolBar)
 		{
 			m_AnimateUpdatePopup = true;
 			static SPopupMenuId s_PopupAnimateSettingsId;
-			UI()->DoPopupMenu(&s_PopupAnimateSettingsId, Button.x, Button.y + Button.h, 150.0f, 37.0f, this, PopupAnimateSettings);
+			Ui()->DoPopupMenu(&s_PopupAnimateSettingsId, Button.x, Button.y + Button.h, 150.0f, 37.0f, this, PopupAnimateSettings);
 		}
 
 		TB_Top.VSplitLeft(5.0f, nullptr, &TB_Top);
@@ -1083,7 +1083,7 @@ void CEditor::DoToolbarLayers(CUIRect ToolBar)
 		if(DoButton_FontIcon(&s_ProofModeButton, FONT_ICON_CIRCLE_CHEVRON_DOWN, 0, &Button, 0, "Select proof mode.", IGraphics::CORNER_R, 8.0f))
 		{
 			static SPopupMenuId s_PopupProofModeId;
-			UI()->DoPopupMenu(&s_PopupProofModeId, Button.x, Button.y + Button.h, 60.0f, 36.0f, this, PopupProofMode);
+			Ui()->DoPopupMenu(&s_PopupProofModeId, Button.x, Button.y + Button.h, 60.0f, 36.0f, this, PopupProofMode);
 		}
 
 		TB_Top.VSplitLeft(5.0f, nullptr, &TB_Top);
@@ -1266,7 +1266,7 @@ void CEditor::DoToolbarLayers(CUIRect ToolBar)
 				if(pS)
 				{
 					const char *pButtonName = nullptr;
-					CUI::FPopupMenuFunction pfnPopupFunc = nullptr;
+					CUi::FPopupMenuFunction pfnPopupFunc = nullptr;
 					int Rows = 0;
 					if(pS == m_Map.m_pSwitchLayer)
 					{
@@ -1303,9 +1303,9 @@ void CEditor::DoToolbarLayers(CUIRect ToolBar)
 						if(DoButton_Ex(&s_ModifierButton, pButtonName, 0, &Button, 0, s_aButtonTooltip, IGraphics::CORNER_ALL) || (m_Dialog == DIALOG_NONE && CLineInput::GetActiveInput() == nullptr && ModPressed && Input()->KeyPress(KEY_T)))
 						{
 							static SPopupMenuId s_PopupModifierId;
-							if(!UI()->IsPopupOpen(&s_PopupModifierId))
+							if(!Ui()->IsPopupOpen(&s_PopupModifierId))
 							{
-								UI()->DoPopupMenu(&s_PopupModifierId, Button.x, Button.y + Button.h, 120, 10.0f + Rows * 13.0f, this, pfnPopupFunc);
+								Ui()->DoPopupMenu(&s_PopupModifierId, Button.x, Button.y + Button.h, 120, 10.0f + Rows * 13.0f, this, pfnPopupFunc);
 							}
 						}
 						TB_Bottom.VSplitLeft(5.0f, nullptr, &TB_Bottom);
@@ -1344,8 +1344,8 @@ void CEditor::DoToolbarLayers(CUIRect ToolBar)
 				int y = aMapping[1] + (aMapping[3] - aMapping[1]) / 2;
 				if(m_Dialog == DIALOG_NONE && CLineInput::GetActiveInput() == nullptr && Input()->KeyPress(KEY_Q) && ModPressed)
 				{
-					x += UI()->MouseWorldX() - (MapView()->GetWorldOffset().x * pGroup->m_ParallaxX / 100) - pGroup->m_OffsetX;
-					y += UI()->MouseWorldY() - (MapView()->GetWorldOffset().y * pGroup->m_ParallaxY / 100) - pGroup->m_OffsetY;
+					x += Ui()->MouseWorldX() - (MapView()->GetWorldOffset().x * pGroup->m_ParallaxX / 100) - pGroup->m_OffsetX;
+					y += Ui()->MouseWorldY() - (MapView()->GetWorldOffset().y * pGroup->m_ParallaxY / 100) - pGroup->m_OffsetY;
 				}
 
 				if(pLayer->m_Type == LAYERTYPE_QUADS)
@@ -1376,9 +1376,9 @@ void CEditor::DoToolbarSounds(CUIRect ToolBar)
 	if(m_SelectedSound >= 0 && (size_t)m_SelectedSound < m_Map.m_vpSounds.size())
 	{
 		const std::shared_ptr<CEditorSound> pSelectedSound = m_Map.m_vpSounds[m_SelectedSound];
-		if(pSelectedSound->m_SoundID != m_ToolbarPreviewSound && m_ToolbarPreviewSound >= 0 && Sound()->IsPlaying(m_ToolbarPreviewSound))
+		if(pSelectedSound->m_SoundId != m_ToolbarPreviewSound && m_ToolbarPreviewSound >= 0 && Sound()->IsPlaying(m_ToolbarPreviewSound))
 			Sound()->Stop(m_ToolbarPreviewSound);
-		m_ToolbarPreviewSound = pSelectedSound->m_SoundID;
+		m_ToolbarPreviewSound = pSelectedSound->m_SoundId;
 
 		static int s_PlayPauseButton, s_StopButton, s_SeekBar = 0;
 		DoAudioPreview(ToolBarBottom, &s_PlayPauseButton, &s_StopButton, &s_SeekBar, m_ToolbarPreviewSound);
@@ -1397,12 +1397,12 @@ static void Rotate(const CPoint *pCenter, CPoint *pPoint, float Rotation)
 
 void CEditor::DoSoundSource(int LayerIndex, CSoundSource *pSource, int Index)
 {
-	void *pID = &pSource->m_Position;
+	void *pId = &pSource->m_Position;
 
 	static ESoundSourceOp s_Operation = ESoundSourceOp::OP_NONE;
 
-	float wx = UI()->MouseWorldX();
-	float wy = UI()->MouseWorldY();
+	float wx = Ui()->MouseWorldX();
+	float wy = Ui()->MouseWorldY();
 
 	float CenterX = fx2f(pSource->m_Position.x);
 	float CenterY = fx2f(pSource->m_Position.y);
@@ -1410,18 +1410,18 @@ void CEditor::DoSoundSource(int LayerIndex, CSoundSource *pSource, int Index)
 	float dx = (CenterX - wx) / m_MouseWScale;
 	float dy = (CenterY - wy) / m_MouseWScale;
 	if(dx * dx + dy * dy < 50)
-		UI()->SetHotItem(pID);
+		Ui()->SetHotItem(pId);
 
 	const bool IgnoreGrid = Input()->AltIsPressed();
 	static CSoundSourceOperationTracker s_Tracker(this);
 
 	if(s_Operation == ESoundSourceOp::OP_NONE)
 	{
-		if(!UI()->MouseButton(0))
+		if(!Ui()->MouseButton(0))
 			s_Tracker.End();
 	}
 
-	if(UI()->CheckActiveItem(pID))
+	if(Ui()->CheckActiveItem(pId))
 	{
 		if(s_Operation != ESoundSourceOp::OP_NONE)
 		{
@@ -1443,50 +1443,50 @@ void CEditor::DoSoundSource(int LayerIndex, CSoundSource *pSource, int Index)
 
 		if(s_Operation == ESoundSourceOp::OP_CONTEXT_MENU)
 		{
-			if(!UI()->MouseButton(1))
+			if(!Ui()->MouseButton(1))
 			{
 				if(m_vSelectedLayers.size() == 1)
 				{
 					static SPopupMenuId s_PopupSourceId;
-					UI()->DoPopupMenu(&s_PopupSourceId, UI()->MouseX(), UI()->MouseY(), 120, 200, this, PopupSource);
-					UI()->DisableMouseLock();
+					Ui()->DoPopupMenu(&s_PopupSourceId, Ui()->MouseX(), Ui()->MouseY(), 120, 200, this, PopupSource);
+					Ui()->DisableMouseLock();
 				}
 				s_Operation = ESoundSourceOp::OP_NONE;
-				UI()->SetActiveItem(nullptr);
+				Ui()->SetActiveItem(nullptr);
 			}
 		}
 		else
 		{
-			if(!UI()->MouseButton(0))
+			if(!Ui()->MouseButton(0))
 			{
-				UI()->DisableMouseLock();
+				Ui()->DisableMouseLock();
 				s_Operation = ESoundSourceOp::OP_NONE;
-				UI()->SetActiveItem(nullptr);
+				Ui()->SetActiveItem(nullptr);
 			}
 		}
 
 		Graphics()->SetColor(1, 1, 1, 1);
 	}
-	else if(UI()->HotItem() == pID)
+	else if(Ui()->HotItem() == pId)
 	{
-		ms_pUiGotContext = pID;
+		ms_pUiGotContext = pId;
 
 		Graphics()->SetColor(1, 1, 1, 1);
 		str_copy(m_aTooltip, "Left mouse button to move. Hold alt to ignore grid.");
 
-		if(UI()->MouseButton(0))
+		if(Ui()->MouseButton(0))
 		{
 			s_Operation = ESoundSourceOp::OP_MOVE;
 
-			UI()->SetActiveItem(pID);
+			Ui()->SetActiveItem(pId);
 			m_SelectedSource = Index;
 		}
 
-		if(UI()->MouseButton(1))
+		if(Ui()->MouseButton(1))
 		{
 			m_SelectedSource = Index;
 			s_Operation = ESoundSourceOp::OP_CONTEXT_MENU;
-			UI()->SetActiveItem(pID);
+			Ui()->SetActiveItem(pId);
 		}
 	}
 	else
@@ -1977,14 +1977,14 @@ void CEditor::DoQuad(int LayerIndex, const std::shared_ptr<CLayerQuads> &pLayer,
 	};
 
 	// some basic values
-	void *pID = &pQuad->m_aPoints[4]; // use pivot addr as id
+	void *pId = &pQuad->m_aPoints[4]; // use pivot addr as id
 	static std::vector<std::vector<CPoint>> s_vvRotatePoints;
 	static int s_Operation = OP_NONE;
 	static float s_MouseXStart = 0.0f;
 	static float s_MouseYStart = 0.0f;
 	static float s_RotateAngle = 0;
-	float wx = UI()->MouseWorldX();
-	float wy = UI()->MouseWorldY();
+	float wx = Ui()->MouseWorldX();
+	float wy = Ui()->MouseWorldY();
 	static CPoint s_OriginalPosition;
 	static std::vector<SAlignmentInfo> s_PivotAlignments; // Alignments per pivot per quad
 	static std::vector<SAlignmentInfo> s_vAABBAlignments; // Alignments for one AABB (single quad or selection of multiple quads)
@@ -2017,14 +2017,14 @@ void CEditor::DoQuad(int LayerIndex, const std::shared_ptr<CLayerQuads> &pLayer,
 		Graphics()->QuadsDraw(&QuadItem, 1);
 	}
 
-	if(UI()->CheckActiveItem(pID))
+	if(Ui()->CheckActiveItem(pId))
 	{
 		if(m_MouseDeltaWx * m_MouseDeltaWx + m_MouseDeltaWy * m_MouseDeltaWy > 0.0f)
 		{
 			if(s_Operation == OP_SELECT)
 			{
-				float x = s_MouseXStart - UI()->MouseX();
-				float y = s_MouseYStart - UI()->MouseY();
+				float x = s_MouseXStart - Ui()->MouseX();
+				float y = s_MouseYStart - Ui()->MouseY();
 
 				if(x * x + y * y > 20.0f)
 				{
@@ -2140,48 +2140,48 @@ void CEditor::DoQuad(int LayerIndex, const std::shared_ptr<CLayerQuads> &pLayer,
 
 		if(s_Operation == OP_CONTEXT_MENU)
 		{
-			if(!UI()->MouseButton(1))
+			if(!Ui()->MouseButton(1))
 			{
 				if(m_vSelectedLayers.size() == 1)
 				{
 					m_SelectedQuadIndex = FindSelectedQuadIndex(Index);
 
 					static SPopupMenuId s_PopupQuadId;
-					UI()->DoPopupMenu(&s_PopupQuadId, UI()->MouseX(), UI()->MouseY(), 120, 198, this, PopupQuad);
-					UI()->DisableMouseLock();
+					Ui()->DoPopupMenu(&s_PopupQuadId, Ui()->MouseX(), Ui()->MouseY(), 120, 198, this, PopupQuad);
+					Ui()->DisableMouseLock();
 				}
 				s_Operation = OP_NONE;
-				UI()->SetActiveItem(nullptr);
+				Ui()->SetActiveItem(nullptr);
 			}
 		}
 		else if(s_Operation == OP_DELETE)
 		{
-			if(!UI()->MouseButton(1))
+			if(!Ui()->MouseButton(1))
 			{
 				if(m_vSelectedLayers.size() == 1)
 				{
-					UI()->DisableMouseLock();
+					Ui()->DisableMouseLock();
 					m_Map.OnModify();
 					DeleteSelectedQuads();
 				}
 				s_Operation = OP_NONE;
-				UI()->SetActiveItem(nullptr);
+				Ui()->SetActiveItem(nullptr);
 			}
 		}
 		else if(s_Operation == OP_ROTATE)
 		{
-			if(UI()->MouseButton(0))
+			if(Ui()->MouseButton(0))
 			{
-				UI()->DisableMouseLock();
+				Ui()->DisableMouseLock();
 				s_Operation = OP_NONE;
-				UI()->SetActiveItem(nullptr);
+				Ui()->SetActiveItem(nullptr);
 				m_QuadTracker.EndQuadTrack();
 			}
-			else if(UI()->MouseButton(1))
+			else if(Ui()->MouseButton(1))
 			{
-				UI()->DisableMouseLock();
+				Ui()->DisableMouseLock();
 				s_Operation = OP_NONE;
-				UI()->SetActiveItem(nullptr);
+				Ui()->SetActiveItem(nullptr);
 
 				// Reset points to old position
 				for(size_t i = 0; i < m_vSelectedQuads.size(); ++i)
@@ -2194,7 +2194,7 @@ void CEditor::DoQuad(int LayerIndex, const std::shared_ptr<CLayerQuads> &pLayer,
 		}
 		else
 		{
-			if(!UI()->MouseButton(0))
+			if(!Ui()->MouseButton(0))
 			{
 				if(s_Operation == OP_SELECT)
 				{
@@ -2208,9 +2208,9 @@ void CEditor::DoQuad(int LayerIndex, const std::shared_ptr<CLayerQuads> &pLayer,
 					m_QuadTracker.EndQuadTrack();
 				}
 
-				UI()->DisableMouseLock();
+				Ui()->DisableMouseLock();
 				s_Operation = OP_NONE;
-				UI()->SetActiveItem(nullptr);
+				Ui()->SetActiveItem(nullptr);
 
 				s_LastOffset = ivec2();
 				s_OriginalPosition = ivec2();
@@ -2223,8 +2223,8 @@ void CEditor::DoQuad(int LayerIndex, const std::shared_ptr<CLayerQuads> &pLayer,
 	}
 	else if(Input()->KeyPress(KEY_R) && !m_vSelectedQuads.empty() && m_Dialog == DIALOG_NONE)
 	{
-		UI()->EnableMouseLock(pID);
-		UI()->SetActiveItem(pID);
+		Ui()->EnableMouseLock(pId);
+		Ui()->SetActiveItem(pId);
 		s_Operation = OP_ROTATE;
 		s_RotateAngle = 0;
 
@@ -2241,23 +2241,23 @@ void CEditor::DoQuad(int LayerIndex, const std::shared_ptr<CLayerQuads> &pLayer,
 			s_vvRotatePoints[i][3] = pCurrentQuad->m_aPoints[3];
 		}
 	}
-	else if(UI()->HotItem() == pID)
+	else if(Ui()->HotItem() == pId)
 	{
-		ms_pUiGotContext = pID;
+		ms_pUiGotContext = pId;
 
 		Graphics()->SetColor(1, 1, 1, 1);
 		str_copy(m_aTooltip, "Left mouse button to move. Hold shift to move pivot. Hold alt to ignore grid. Hold shift and right click to delete.");
 
-		if(UI()->MouseButton(0))
+		if(Ui()->MouseButton(0))
 		{
-			UI()->SetActiveItem(pID);
+			Ui()->SetActiveItem(pId);
 
-			s_MouseXStart = UI()->MouseX();
-			s_MouseYStart = UI()->MouseY();
+			s_MouseXStart = Ui()->MouseX();
+			s_MouseYStart = Ui()->MouseY();
 
 			s_Operation = OP_SELECT;
 		}
-		else if(UI()->MouseButton(1))
+		else if(Ui()->MouseButton(1))
 		{
 			if(Input()->ShiftIsPressed())
 			{
@@ -2266,7 +2266,7 @@ void CEditor::DoQuad(int LayerIndex, const std::shared_ptr<CLayerQuads> &pLayer,
 				if(!IsQuadSelected(Index))
 					SelectQuad(Index);
 
-				UI()->SetActiveItem(pID);
+				Ui()->SetActiveItem(pId);
 			}
 			else
 			{
@@ -2275,7 +2275,7 @@ void CEditor::DoQuad(int LayerIndex, const std::shared_ptr<CLayerQuads> &pLayer,
 				if(!IsQuadSelected(Index))
 					SelectQuad(Index);
 
-				UI()->SetActiveItem(pID);
+				Ui()->SetActiveItem(pId);
 			}
 		}
 	}
@@ -2288,10 +2288,10 @@ void CEditor::DoQuad(int LayerIndex, const std::shared_ptr<CLayerQuads> &pLayer,
 
 void CEditor::DoQuadPoint(int LayerIndex, const std::shared_ptr<CLayerQuads> &pLayer, CQuad *pQuad, int QuadIndex, int V)
 {
-	void *pID = &pQuad->m_aPoints[V];
+	void *pId = &pQuad->m_aPoints[V];
 
-	float wx = UI()->MouseWorldX();
-	float wy = UI()->MouseWorldY();
+	float wx = Ui()->MouseWorldX();
+	float wy = Ui()->MouseWorldY();
 
 	float px = fx2f(pQuad->m_aPoints[V].x);
 	float py = fx2f(pQuad->m_aPoints[V].y);
@@ -2334,14 +2334,14 @@ void CEditor::DoQuadPoint(int LayerIndex, const std::shared_ptr<CLayerQuads> &pL
 		return {OffsetX, OffsetY};
 	};
 
-	if(UI()->CheckActiveItem(pID))
+	if(Ui()->CheckActiveItem(pId))
 	{
 		if(m_MouseDeltaWx * m_MouseDeltaWx + m_MouseDeltaWy * m_MouseDeltaWy > 0.0f)
 		{
 			if(s_Operation == OP_SELECT)
 			{
-				float x = s_MouseXStart - UI()->MouseX();
-				float y = s_MouseYStart - UI()->MouseY();
+				float x = s_MouseXStart - Ui()->MouseX();
+				float y = s_MouseYStart - Ui()->MouseY();
 
 				if(x * x + y * y > 20.0f)
 				{
@@ -2351,7 +2351,7 @@ void CEditor::DoQuadPoint(int LayerIndex, const std::shared_ptr<CLayerQuads> &pL
 					if(Input()->ShiftIsPressed())
 					{
 						s_Operation = OP_MOVEUV;
-						UI()->EnableMouseLock(pID);
+						Ui()->EnableMouseLock(pId);
 					}
 					else
 					{
@@ -2435,7 +2435,7 @@ void CEditor::DoQuadPoint(int LayerIndex, const std::shared_ptr<CLayerQuads> &pL
 
 		if(s_Operation == OP_CONTEXT_MENU)
 		{
-			if(!UI()->MouseButton(1))
+			if(!Ui()->MouseButton(1))
 			{
 				if(m_vSelectedLayers.size() == 1)
 				{
@@ -2446,14 +2446,14 @@ void CEditor::DoQuadPoint(int LayerIndex, const std::shared_ptr<CLayerQuads> &pL
 					m_SelectedQuadIndex = FindSelectedQuadIndex(QuadIndex);
 
 					static SPopupMenuId s_PopupPointId;
-					UI()->DoPopupMenu(&s_PopupPointId, UI()->MouseX(), UI()->MouseY(), 120, 75, this, PopupPoint);
+					Ui()->DoPopupMenu(&s_PopupPointId, Ui()->MouseX(), Ui()->MouseY(), 120, 75, this, PopupPoint);
 				}
-				UI()->SetActiveItem(nullptr);
+				Ui()->SetActiveItem(nullptr);
 			}
 		}
 		else
 		{
-			if(!UI()->MouseButton(0))
+			if(!Ui()->MouseButton(0))
 			{
 				if(s_Operation == OP_SELECT)
 				{
@@ -2472,34 +2472,34 @@ void CEditor::DoQuadPoint(int LayerIndex, const std::shared_ptr<CLayerQuads> &pL
 					m_QuadTracker.EndQuadPointPropTrackAll();
 				}
 
-				UI()->DisableMouseLock();
-				UI()->SetActiveItem(nullptr);
+				Ui()->DisableMouseLock();
+				Ui()->SetActiveItem(nullptr);
 			}
 		}
 
 		Graphics()->SetColor(1, 1, 1, 1);
 	}
-	else if(UI()->HotItem() == pID)
+	else if(Ui()->HotItem() == pId)
 	{
-		ms_pUiGotContext = pID;
+		ms_pUiGotContext = pId;
 
 		Graphics()->SetColor(1, 1, 1, 1);
 		str_copy(m_aTooltip, "Left mouse button to move. Hold shift to move the texture. Hold alt to ignore grid.");
 
-		if(UI()->MouseButton(0))
+		if(Ui()->MouseButton(0))
 		{
-			UI()->SetActiveItem(pID);
+			Ui()->SetActiveItem(pId);
 
-			s_MouseXStart = UI()->MouseX();
-			s_MouseYStart = UI()->MouseY();
+			s_MouseXStart = Ui()->MouseX();
+			s_MouseYStart = Ui()->MouseY();
 
 			s_Operation = OP_SELECT;
 		}
-		else if(UI()->MouseButton(1))
+		else if(Ui()->MouseButton(1))
 		{
 			s_Operation = OP_CONTEXT_MENU;
 
-			UI()->SetActiveItem(pID);
+			Ui()->SetActiveItem(pId);
 
 			if(!IsQuadPointSelected(QuadIndex, V))
 				SelectQuadPoint(QuadIndex, V);
@@ -2546,7 +2546,7 @@ void CEditor::DoQuadKnife(int QuadIndex)
 	const bool IgnoreGrid = Input()->AltIsPressed();
 	float SnapRadius = 4.f * m_MouseWScale;
 
-	vec2 Mouse = vec2(UI()->MouseWorldX(), UI()->MouseWorldY());
+	vec2 Mouse = vec2(Ui()->MouseWorldX(), Ui()->MouseWorldY());
 	vec2 Point = Mouse;
 
 	vec2 v[4] = {
@@ -2557,7 +2557,7 @@ void CEditor::DoQuadKnife(int QuadIndex)
 
 	str_copy(m_aTooltip, "Left click inside the quad to select an area to slice. Hold alt to ignore grid. Right click to leave knife mode");
 
-	if(UI()->MouseButtonClicked(1))
+	if(Ui()->MouseButtonClicked(1))
 	{
 		m_QuadKnifeActive = false;
 		return;
@@ -2651,7 +2651,7 @@ void CEditor::DoQuadKnife(int QuadIndex)
 
 	bool ValidPosition = IsInTriangle(Point, v[0], v[1], v[2]) || IsInTriangle(Point, v[0], v[3], v[2]);
 
-	if(UI()->MouseButtonClicked(0) && ValidPosition)
+	if(Ui()->MouseButtonClicked(0) && ValidPosition)
 	{
 		m_aQuadKnifePoints[m_QuadKnifeCount] = Point;
 		m_QuadKnifeCount++;
@@ -2901,10 +2901,10 @@ void CEditor::DoQuadEnvPoint(const CQuad *pQuad, int QIndex, int PIndex)
 	static float s_LastWx = 0;
 	static float s_LastWy = 0;
 	static int s_Operation = OP_NONE;
-	float wx = UI()->MouseWorldX();
-	float wy = UI()->MouseWorldY();
+	float wx = Ui()->MouseWorldX();
+	float wy = Ui()->MouseWorldY();
 	std::shared_ptr<CEnvelope> pEnvelope = m_Map.m_vpEnvelopes[pQuad->m_PosEnv];
-	void *pID = &pEnvelope->m_vPoints[PIndex];
+	void *pId = &pEnvelope->m_vPoints[PIndex];
 
 	// get pivot
 	float CenterX = fx2f(pQuad->m_aPoints[4].x) + fx2f(pEnvelope->m_vPoints[PIndex].m_aValues[0]);
@@ -2912,7 +2912,7 @@ void CEditor::DoQuadEnvPoint(const CQuad *pQuad, int QIndex, int PIndex)
 
 	const bool IgnoreGrid = Input()->AltIsPressed();
 
-	if(UI()->CheckActiveItem(pID) && m_CurrentQuadIndex == QIndex)
+	if(Ui()->CheckActiveItem(pId) && m_CurrentQuadIndex == QIndex)
 	{
 		if(s_Operation == OP_MOVE)
 		{
@@ -2936,27 +2936,27 @@ void CEditor::DoQuadEnvPoint(const CQuad *pQuad, int QIndex, int PIndex)
 		s_LastWx = wx;
 		s_LastWy = wy;
 
-		if(!UI()->MouseButton(0))
+		if(!Ui()->MouseButton(0))
 		{
-			UI()->DisableMouseLock();
+			Ui()->DisableMouseLock();
 			s_Operation = OP_NONE;
-			UI()->SetActiveItem(nullptr);
+			Ui()->SetActiveItem(nullptr);
 		}
 
 		Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
 	}
-	else if(UI()->HotItem() == pID && m_CurrentQuadIndex == QIndex)
+	else if(Ui()->HotItem() == pId && m_CurrentQuadIndex == QIndex)
 	{
-		ms_pUiGotContext = pID;
+		ms_pUiGotContext = pId;
 
 		Graphics()->SetColor(1.0f, 1.0f, 1.0f, 1.0f);
 		str_copy(m_aTooltip, "Left mouse button to move. Hold ctrl to rotate. Hold alt to ignore grid.");
 
-		if(UI()->MouseButton(0))
+		if(Ui()->MouseButton(0))
 		{
 			if(Input()->ModifierIsPressed())
 			{
-				UI()->EnableMouseLock(pID);
+				Ui()->EnableMouseLock(pId);
 				s_Operation = OP_ROTATE;
 
 				SelectQuad(QIndex);
@@ -2971,7 +2971,7 @@ void CEditor::DoQuadEnvPoint(const CQuad *pQuad, int QIndex, int PIndex)
 			SelectEnvPoint(PIndex);
 			m_SelectedQuadEnvelope = pQuad->m_PosEnv;
 
-			UI()->SetActiveItem(pID);
+			Ui()->SetActiveItem(pId);
 
 			s_LastWx = wx;
 			s_LastWy = wy;
@@ -3003,13 +3003,13 @@ void CEditor::DoMapEditor(CUIRect View)
 		View.w = View.h = Max;
 	}
 
-	const bool Inside = UI()->MouseInside(&View);
+	const bool Inside = Ui()->MouseInside(&View);
 
 	// fetch mouse position
-	float wx = UI()->MouseWorldX();
-	float wy = UI()->MouseWorldY();
-	float mx = UI()->MouseX();
-	float my = UI()->MouseY();
+	float wx = Ui()->MouseWorldX();
+	float wy = Ui()->MouseWorldY();
+	float mx = Ui()->MouseX();
+	float my = Ui()->MouseY();
 
 	static float s_StartWx = 0;
 	static float s_StartWy = 0;
@@ -3027,7 +3027,7 @@ void CEditor::DoMapEditor(CUIRect View)
 	// remap the screen so it can display the whole tileset
 	if(m_ShowPicker)
 	{
-		CUIRect Screen = *UI()->Screen();
+		CUIRect Screen = *Ui()->Screen();
 		float Size = 32.0f * 16.0f;
 		float w = Size * (Screen.w / View.w);
 		float h = Size * (Screen.h / View.h);
@@ -3126,7 +3126,7 @@ void CEditor::DoMapEditor(CUIRect View)
 		MapView()->MapGrid()->OnRender(View);
 	}
 
-	const bool ShouldPan = (Input()->ModifierIsPressed() && UI()->MouseButton(0)) || UI()->MouseButton(2);
+	const bool ShouldPan = (Input()->ModifierIsPressed() && Ui()->MouseButton(0)) || Ui()->MouseButton(2);
 	if(m_pContainerPanned == &m_MapEditorId)
 	{
 		// do panning
@@ -3151,10 +3151,10 @@ void CEditor::DoMapEditor(CUIRect View)
 
 	if(Inside)
 	{
-		UI()->SetHotItem(&m_MapEditorId);
+		Ui()->SetHotItem(&m_MapEditorId);
 
 		// do global operations like pan and zoom
-		if(UI()->CheckActiveItem(nullptr) && (UI()->MouseButton(0) || UI()->MouseButton(2)))
+		if(Ui()->CheckActiveItem(nullptr) && (Ui()->MouseButton(0) || Ui()->MouseButton(2)))
 		{
 			s_StartWx = wx;
 			s_StartWy = wy;
@@ -3164,7 +3164,7 @@ void CEditor::DoMapEditor(CUIRect View)
 		}
 
 		// brush editing
-		if(UI()->HotItem() == &m_MapEditorId)
+		if(Ui()->HotItem() == &m_MapEditorId)
 		{
 			if(m_ShowPicker)
 			{
@@ -3213,7 +3213,7 @@ void CEditor::DoMapEditor(CUIRect View)
 			else
 				str_copy(m_aTooltip, "Use left mouse button to paint with the brush. Right button clears the brush.");
 
-			if(UI()->CheckActiveItem(&m_MapEditorId))
+			if(Ui()->CheckActiveItem(&m_MapEditorId))
 			{
 				CUIRect r;
 				r.x = s_StartWx;
@@ -3260,7 +3260,7 @@ void CEditor::DoMapEditor(CUIRect View)
 				}
 				else if(s_Operation == OP_BRUSH_GRAB)
 				{
-					if(!UI()->MouseButton(0))
+					if(!Ui()->MouseButton(0))
 					{
 						std::shared_ptr<CLayerQuads> pQuadLayer = std::static_pointer_cast<CLayerQuads>(GetSelectedLayerType(0, LAYERTYPE_QUADS));
 						if(Input()->ShiftIsPressed() && pQuadLayer)
@@ -3298,12 +3298,12 @@ void CEditor::DoMapEditor(CUIRect View)
 					{
 						for(size_t k = 0; k < NumEditLayers; k++)
 							apEditLayers[k].second->BrushSelecting(r);
-						UI()->MapScreen();
+						Ui()->MapScreen();
 					}
 				}
 				else if(s_Operation == OP_BRUSH_PAINT)
 				{
-					if(!UI()->MouseButton(0))
+					if(!Ui()->MouseButton(0))
 					{
 						for(size_t k = 0; k < NumEditLayers; k++)
 						{
@@ -3320,20 +3320,20 @@ void CEditor::DoMapEditor(CUIRect View)
 					{
 						for(size_t k = 0; k < NumEditLayers; k++)
 							apEditLayers[k].second->BrushSelecting(r);
-						UI()->MapScreen();
+						Ui()->MapScreen();
 					}
 				}
 			}
 			else
 			{
-				if(UI()->MouseButton(1))
+				if(Ui()->MouseButton(1))
 				{
 					m_pBrush->Clear();
 				}
 
-				if(!Input()->ModifierIsPressed() && UI()->MouseButton(0) && s_Operation == OP_NONE && !m_QuadKnifeActive)
+				if(!Input()->ModifierIsPressed() && Ui()->MouseButton(0) && s_Operation == OP_NONE && !m_QuadKnifeActive)
 				{
-					UI()->SetActiveItem(&m_MapEditorId);
+					Ui()->SetActiveItem(&m_MapEditorId);
 
 					if(m_pBrush->IsEmpty())
 						s_Operation = OP_BRUSH_GRAB;
@@ -3448,7 +3448,7 @@ void CEditor::DoMapEditor(CUIRect View)
 					}
 				}
 
-				UI()->MapScreen();
+				Ui()->MapScreen();
 			}
 		}
 
@@ -3465,18 +3465,18 @@ void CEditor::DoMapEditor(CUIRect View)
 				vec2 MousePos(m_MouseWorldNoParaX, m_MouseWorldNoParaY);
 				if(distance(Pos, MousePos) <= 20.0f)
 				{
-					UI()->SetHotItem(&MapView()->ProofMode()->m_vMenuBackgroundPositions[i]);
+					Ui()->SetHotItem(&MapView()->ProofMode()->m_vMenuBackgroundPositions[i]);
 
-					if(i != MapView()->ProofMode()->m_CurrentMenuProofIndex && UI()->CheckActiveItem(&MapView()->ProofMode()->m_vMenuBackgroundPositions[i]))
+					if(i != MapView()->ProofMode()->m_CurrentMenuProofIndex && Ui()->CheckActiveItem(&MapView()->ProofMode()->m_vMenuBackgroundPositions[i]))
 					{
-						if(!UI()->MouseButton(0))
+						if(!Ui()->MouseButton(0))
 						{
 							MapView()->ProofMode()->m_CurrentMenuProofIndex = i;
 							MapView()->SetWorldOffset(MapView()->ProofMode()->m_vMenuBackgroundPositions[i]);
-							UI()->SetActiveItem(nullptr);
+							Ui()->SetActiveItem(nullptr);
 						}
 					}
-					else if(UI()->HotItem() == &MapView()->ProofMode()->m_vMenuBackgroundPositions[i])
+					else if(Ui()->HotItem() == &MapView()->ProofMode()->m_vMenuBackgroundPositions[i])
 					{
 						char aTooltipPrefix[32] = "Switch proof position to";
 						if(i == MapView()->ProofMode()->m_CurrentMenuProofIndex)
@@ -3516,18 +3516,18 @@ void CEditor::DoMapEditor(CUIRect View)
 						str_format(m_aMenuBackgroundTooltip, sizeof(m_aMenuBackgroundTooltip), "%s %s", aTooltipPrefix, aTooltipPositions);
 
 						str_copy(m_aTooltip, m_aMenuBackgroundTooltip);
-						if(UI()->MouseButton(0))
-							UI()->SetActiveItem(&MapView()->ProofMode()->m_vMenuBackgroundPositions[i]);
+						if(Ui()->MouseButton(0))
+							Ui()->SetActiveItem(&MapView()->ProofMode()->m_vMenuBackgroundPositions[i]);
 					}
 					break;
 				}
 			}
 		}
 
-		if(UI()->CheckActiveItem(&m_MapEditorId))
+		if(Ui()->CheckActiveItem(&m_MapEditorId))
 		{
 			// release mouse
-			if(!UI()->MouseButton(0))
+			if(!Ui()->MouseButton(0))
 			{
 				if(s_Operation == OP_BRUSH_DRAW)
 				{
@@ -3538,7 +3538,7 @@ void CEditor::DoMapEditor(CUIRect View)
 				}
 
 				s_Operation = OP_NONE;
-				UI()->SetActiveItem(nullptr);
+				Ui()->SetActiveItem(nullptr);
 			}
 		}
 		if(!Input()->ModifierIsPressed() && m_Dialog == DIALOG_NONE && CLineInput::GetActiveInput() == nullptr)
@@ -3554,13 +3554,13 @@ void CEditor::DoMapEditor(CUIRect View)
 				MapView()->OffsetWorld({0, PanSpeed * m_MouseWScale});
 		}
 	}
-	else if(UI()->CheckActiveItem(&m_MapEditorId))
+	else if(Ui()->CheckActiveItem(&m_MapEditorId))
 	{
 		// release mouse
-		if(!UI()->MouseButton(0))
+		if(!Ui()->MouseButton(0))
 		{
 			s_Operation = OP_NONE;
-			UI()->SetActiveItem(nullptr);
+			Ui()->SetActiveItem(nullptr);
 		}
 	}
 
@@ -3604,18 +3604,18 @@ void CEditor::DoMapEditor(CUIRect View)
 		m_ShowEnvelopePreview = SHOWENV_NONE;
 	}
 
-	UI()->MapScreen();
+	Ui()->MapScreen();
 }
 
 void CEditor::SetHotQuadPoint(const std::shared_ptr<CLayerQuads> &pLayer)
 {
-	float wx = UI()->MouseWorldX();
-	float wy = UI()->MouseWorldY();
+	float wx = Ui()->MouseWorldX();
+	float wy = Ui()->MouseWorldY();
 
 	float MinDist = 500.0f;
 	void *pMinPoint = nullptr;
 
-	auto UpdateMinimum = [&](float px, float py, void *pID) {
+	auto UpdateMinimum = [&](float px, float py, void *pId) {
 		float dx = (px - wx) / m_MouseWScale;
 		float dy = (py - wy) / m_MouseWScale;
 
@@ -3623,7 +3623,7 @@ void CEditor::SetHotQuadPoint(const std::shared_ptr<CLayerQuads> &pLayer)
 		if(CurrDist < MinDist)
 		{
 			MinDist = CurrDist;
-			pMinPoint = pID;
+			pMinPoint = pId;
 			return true;
 		}
 		return false;
@@ -3649,17 +3649,17 @@ void CEditor::SetHotQuadPoint(const std::shared_ptr<CLayerQuads> &pLayer)
 	}
 
 	if(pMinPoint != nullptr)
-		UI()->SetHotItem(pMinPoint);
+		Ui()->SetHotItem(pMinPoint);
 }
 
-void CEditor::DoColorPickerButton(const void *pID, const CUIRect *pRect, ColorRGBA Color, const std::function<void(ColorRGBA Color)> &SetColor)
+void CEditor::DoColorPickerButton(const void *pId, const CUIRect *pRect, ColorRGBA Color, const std::function<void(ColorRGBA Color)> &SetColor)
 {
 	CUIRect ColorRect;
-	pRect->Draw(ColorRGBA(1.0f, 1.0f, 1.0f, 0.5f * UI()->ButtonColorMul(pID)), IGraphics::CORNER_ALL, 3.0f);
+	pRect->Draw(ColorRGBA(1.0f, 1.0f, 1.0f, 0.5f * Ui()->ButtonColorMul(pId)), IGraphics::CORNER_ALL, 3.0f);
 	pRect->Margin(1.0f, &ColorRect);
 	ColorRect.Draw(Color, IGraphics::CORNER_ALL, 3.0f);
 
-	const int ButtonResult = DoButton_Editor_Common(pID, nullptr, 0, pRect, 0, "Click to show the color picker. Shift+rightclick to copy color to clipboard. Shift+leftclick to paste color from clipboard.");
+	const int ButtonResult = DoButton_Editor_Common(pId, nullptr, 0, pRect, 0, "Click to show the color picker. Shift+rightclick to copy color to clipboard. Shift+leftclick to paste color from clipboard.");
 	if(Input()->ShiftIsPressed())
 	{
 		if(ButtonResult == 1)
@@ -3686,24 +3686,24 @@ void CEditor::DoColorPickerButton(const void *pID, const CUIRect *pRect, ColorRG
 	}
 	else if(ButtonResult > 0)
 	{
-		if(m_ColorPickerPopupContext.m_ColorMode == CUI::SColorPickerPopupContext::MODE_UNSET)
-			m_ColorPickerPopupContext.m_ColorMode = CUI::SColorPickerPopupContext::MODE_RGBA;
+		if(m_ColorPickerPopupContext.m_ColorMode == CUi::SColorPickerPopupContext::MODE_UNSET)
+			m_ColorPickerPopupContext.m_ColorMode = CUi::SColorPickerPopupContext::MODE_RGBA;
 		m_ColorPickerPopupContext.m_RgbaColor = Color;
 		m_ColorPickerPopupContext.m_HslaColor = color_cast<ColorHSLA>(Color);
 		m_ColorPickerPopupContext.m_HsvaColor = color_cast<ColorHSVA>(m_ColorPickerPopupContext.m_HslaColor);
 		m_ColorPickerPopupContext.m_Alpha = true;
-		m_pColorPickerPopupActiveID = pID;
-		UI()->ShowPopupColorPicker(UI()->MouseX(), UI()->MouseY(), &m_ColorPickerPopupContext);
+		m_pColorPickerPopupActiveId = pId;
+		Ui()->ShowPopupColorPicker(Ui()->MouseX(), Ui()->MouseY(), &m_ColorPickerPopupContext);
 	}
 
-	if(UI()->IsPopupOpen(&m_ColorPickerPopupContext))
+	if(Ui()->IsPopupOpen(&m_ColorPickerPopupContext))
 	{
-		if(m_pColorPickerPopupActiveID == pID)
+		if(m_pColorPickerPopupActiveId == pId)
 			SetColor(m_ColorPickerPopupContext.m_RgbaColor);
 	}
 	else
 	{
-		m_pColorPickerPopupActiveID = nullptr;
+		m_pColorPickerPopupActiveId = nullptr;
 		if(m_ColorPickerPopupContext.m_State == EEditState::EDITING)
 		{
 			ColorRGBA c = color_cast<ColorRGBA>(m_ColorPickerPopupContext.m_HsvaColor);
@@ -3770,7 +3770,7 @@ void CEditor::RenderLayers(CUIRect LayersBox)
 		vButtonsPerGroup.push_back(pGroup->m_vpLayers.size() + 1);
 	}
 
-	if(s_pDraggedButton != nullptr && UI()->ActiveItem() != s_pDraggedButton)
+	if(s_pDraggedButton != nullptr && Ui()->ActiveItem() != s_pDraggedButton)
 	{
 		SetOperation(OP_NONE);
 	}
@@ -3796,7 +3796,7 @@ void CEditor::RenderLayers(CUIRect LayersBox)
 		}
 
 		UnscrolledLayersBox.HSplitTop(s_InitialCutHeight, nullptr, &UnscrolledLayersBox);
-		UnscrolledLayersBox.y -= s_InitialMouseY - UI()->MouseY();
+		UnscrolledLayersBox.y -= s_InitialMouseY - Ui()->MouseY();
 
 		UnscrolledLayersBox.y = clamp(UnscrolledLayersBox.y, MinDraggableValue, MaxDraggableValue);
 
@@ -3810,7 +3810,7 @@ void CEditor::RenderLayers(CUIRect LayersBox)
 	// render layers
 	for(int g = 0; g < (int)m_Map.m_vpGroups.size(); g++)
 	{
-		if(s_Operation == OP_LAYER_DRAG && g > 0 && !DraggedPositionFound && UI()->MouseY() < LayersBox.y + RowHeight / 2)
+		if(s_Operation == OP_LAYER_DRAG && g > 0 && !DraggedPositionFound && Ui()->MouseY() < LayersBox.y + RowHeight / 2)
 		{
 			DraggedPositionFound = true;
 			GroupAfterDraggedLayer = g;
@@ -3830,7 +3830,7 @@ void CEditor::RenderLayers(CUIRect LayersBox)
 				UnscrolledLayersBox.HSplitTop(RowHeight, &Slot, &UnscrolledLayersBox);
 				UnscrolledLayersBox.HSplitTop(2.0f, nullptr, &UnscrolledLayersBox);
 			}
-			else if(!DraggedPositionFound && UI()->MouseY() < LayersBox.y + RowHeight * vButtonsPerGroup[g] / 2 + 3.0f)
+			else if(!DraggedPositionFound && Ui()->MouseY() < LayersBox.y + RowHeight * vButtonsPerGroup[g] / 2 + 3.0f)
 			{
 				DraggedPositionFound = true;
 				GroupAfterDraggedLayer = g;
@@ -3867,7 +3867,7 @@ void CEditor::RenderLayers(CUIRect LayersBox)
 			{
 				if(s_Operation == OP_NONE)
 				{
-					s_InitialMouseY = UI()->MouseY();
+					s_InitialMouseY = Ui()->MouseY();
 					s_InitialCutHeight = s_InitialMouseY - UnscrolledLayersBox.y;
 					SetOperation(OP_CLICK);
 
@@ -3880,7 +3880,7 @@ void CEditor::RenderLayers(CUIRect LayersBox)
 					SetOperation(OP_NONE);
 				}
 
-				if(s_Operation == OP_CLICK && absolute(UI()->MouseY() - s_InitialMouseY) > MinDragDistance)
+				if(s_Operation == OP_CLICK && absolute(Ui()->MouseY() - s_InitialMouseY) > MinDragDistance)
 				{
 					StartDragGroup = true;
 					s_pDraggedButton = m_Map.m_vpGroups[g].get();
@@ -3903,7 +3903,7 @@ void CEditor::RenderLayers(CUIRect LayersBox)
 					if(Result == 2)
 					{
 						static SPopupMenuId s_PopupGroupId;
-						UI()->DoPopupMenu(&s_PopupGroupId, UI()->MouseX(), UI()->MouseY(), 145, 256, this, PopupGroup);
+						Ui()->DoPopupMenu(&s_PopupGroupId, Ui()->MouseX(), Ui()->MouseY(), 145, 256, this, PopupGroup);
 					}
 
 					if(!m_Map.m_vpGroups[g]->m_vpLayers.empty() && Input()->MouseDoubleClick())
@@ -3951,7 +3951,7 @@ void CEditor::RenderLayers(CUIRect LayersBox)
 				}
 				else
 				{
-					if(!DraggedPositionFound && UI()->MouseY() < LayersBox.y + RowHeight / 2)
+					if(!DraggedPositionFound && Ui()->MouseY() < LayersBox.y + RowHeight / 2)
 					{
 						DraggedPositionFound = true;
 						GroupAfterDraggedLayer = g + 1;
@@ -4017,7 +4017,7 @@ void CEditor::RenderLayers(CUIRect LayersBox)
 			{
 				if(s_Operation == OP_NONE)
 				{
-					s_InitialMouseY = UI()->MouseY();
+					s_InitialMouseY = Ui()->MouseY();
 					s_InitialCutHeight = s_InitialMouseY - UnscrolledLayersBox.y;
 
 					SetOperation(OP_CLICK);
@@ -4033,7 +4033,7 @@ void CEditor::RenderLayers(CUIRect LayersBox)
 					SetOperation(OP_NONE);
 				}
 
-				if(s_Operation == OP_CLICK && absolute(UI()->MouseY() - s_InitialMouseY) > MinDragDistance)
+				if(s_Operation == OP_CLICK && absolute(Ui()->MouseY() - s_InitialMouseY) > MinDragDistance)
 				{
 					bool EntitiesLayerSelected = false;
 					for(int k : m_vSelectedLayers)
@@ -4100,7 +4100,7 @@ void CEditor::RenderLayers(CUIRect LayersBox)
 							}
 						}
 
-						UI()->DoPopupMenu(&s_LayerPopupContext, UI()->MouseX(), UI()->MouseY(), 120, 270, &s_LayerPopupContext, PopupLayer);
+						Ui()->DoPopupMenu(&s_LayerPopupContext, Ui()->MouseX(), Ui()->MouseY(), 120, 270, &s_LayerPopupContext, PopupLayer);
 					}
 
 					SetOperation(OP_NONE);
@@ -4227,7 +4227,7 @@ void CEditor::RenderLayers(CUIRect LayersBox)
 		else
 		{
 			s_ScrollRegion.DoEdgeScrolling();
-			UI()->SetActiveItem(s_pDraggedButton);
+			Ui()->SetActiveItem(s_pDraggedButton);
 		}
 	}
 
@@ -4505,7 +4505,7 @@ bool CEditor::AddSound(const char *pFileName, int StorageType, void *pUser)
 
 	// add sound
 	std::shared_ptr<CEditorSound> pSound = std::make_shared<CEditorSound>(pEditor);
-	pSound->m_SoundID = SoundId;
+	pSound->m_SoundId = SoundId;
 	pSound->m_DataSize = DataSize;
 	pSound->m_pData = pData;
 	str_copy(pSound->m_aName, aBuf);
@@ -4564,12 +4564,12 @@ bool CEditor::ReplaceSound(const char *pFileName, int StorageType, bool CheckDup
 	std::shared_ptr<CEditorSound> pSound = m_Map.m_vpSounds[m_SelectedSound];
 
 	// unload sample
-	Sound()->UnloadSample(pSound->m_SoundID);
+	Sound()->UnloadSample(pSound->m_SoundId);
 	free(pSound->m_pData);
 
 	// replace sound
 	str_copy(pSound->m_aName, aBuf);
-	pSound->m_SoundID = SoundId;
+	pSound->m_SoundId = SoundId;
 	pSound->m_pData = pData;
 	pSound->m_DataSize = DataSize;
 
@@ -4705,7 +4705,7 @@ void CEditor::RenderImagesList(CUIRect ToolBox)
 		CUIRect Slot;
 		ToolBox.HSplitTop(RowHeight + 3.0f, &Slot, &ToolBox);
 		if(s_ScrollRegion.AddRect(Slot))
-			UI()->DoLabel(&Slot, e == 0 ? "Embedded" : "External", 12.0f, TEXTALIGN_MC);
+			Ui()->DoLabel(&Slot, e == 0 ? "Embedded" : "External", 12.0f, TEXTALIGN_MC);
 
 		for(int i = 0; i < (int)m_Map.m_vpImages.size(); i++)
 		{
@@ -4752,7 +4752,7 @@ void CEditor::RenderImagesList(CUIRect ToolBox)
 					const std::shared_ptr<CEditorImage> pImg = m_Map.m_vpImages[m_SelectedImage];
 					const int Height = !pImg->m_External && IsVanillaImage(pImg->m_aName) ? 107 : (pImg->m_External ? 73 : 90);
 					static SPopupMenuId s_PopupImageId;
-					UI()->DoPopupMenu(&s_PopupImageId, UI()->MouseX(), UI()->MouseY(), 140, Height, this, PopupImage);
+					Ui()->DoPopupMenu(&s_PopupImageId, Ui()->MouseX(), Ui()->MouseY(), 140, Height, this, PopupImage);
 				}
 			}
 		}
@@ -4837,7 +4837,7 @@ void CEditor::RenderSounds(CUIRect ToolBox)
 	CUIRect Slot;
 	ToolBox.HSplitTop(RowHeight + 3.0f, &Slot, &ToolBox);
 	if(s_ScrollRegion.AddRect(Slot))
-		UI()->DoLabel(&Slot, "Embedded", 12.0f, TEXTALIGN_MC);
+		Ui()->DoLabel(&Slot, "Embedded", 12.0f, TEXTALIGN_MC);
 
 	for(int i = 0; i < (int)m_Map.m_vpSounds.size(); i++)
 	{
@@ -4866,7 +4866,7 @@ void CEditor::RenderSounds(CUIRect ToolBox)
 			if(Result == 2)
 			{
 				static SPopupMenuId s_PopupSoundId;
-				UI()->DoPopupMenu(&s_PopupSoundId, UI()->MouseX(), UI()->MouseY(), 140, 90, this, PopupSound);
+				Ui()->DoPopupMenu(&s_PopupSoundId, Ui()->MouseX(), Ui()->MouseY(), 140, 90, this, PopupSound);
 			}
 		}
 	}
@@ -4948,8 +4948,8 @@ void CEditor::SortFilteredFileList()
 void CEditor::RenderFileDialog()
 {
 	// GUI coordsys
-	UI()->MapScreen();
-	CUIRect View = *UI()->Screen();
+	Ui()->MapScreen();
+	CUIRect View = *Ui()->Screen();
 	CUIRect Preview = {0.0f, 0.0f, 0.0f, 0.0f};
 	float Width = View.w, Height = View.h;
 
@@ -5027,7 +5027,7 @@ void CEditor::RenderFileDialog()
 
 	Title.Draw(ColorRGBA(1, 1, 1, 0.25f), IGraphics::CORNER_ALL, 4.0f);
 	Title.VMargin(10.0f, &Title);
-	UI()->DoLabel(&Title, m_pFileDialogTitle, 12.0f, TEXTALIGN_ML);
+	Ui()->DoLabel(&Title, m_pFileDialogTitle, 12.0f, TEXTALIGN_ML);
 
 	// pathbox
 	if(m_FilesSelectedIndex >= 0 && m_vpFilteredFileList[m_FilesSelectedIndex]->m_StorageType >= IStorage::TYPE_SAVE)
@@ -5035,7 +5035,7 @@ void CEditor::RenderFileDialog()
 		char aPath[IO_MAX_PATH_LENGTH], aBuf[128 + IO_MAX_PATH_LENGTH];
 		Storage()->GetCompletePath(m_vpFilteredFileList[m_FilesSelectedIndex]->m_StorageType, m_pFileDialogPath, aPath, sizeof(aPath));
 		str_format(aBuf, sizeof(aBuf), "Current path: %s", aPath);
-		UI()->DoLabel(&PathBox, aBuf, 10.0f, TEXTALIGN_ML);
+		Ui()->DoLabel(&PathBox, aBuf, 10.0f, TEXTALIGN_ML);
 	}
 
 	const auto &&UpdateFileNameInput = [this]() {
@@ -5051,11 +5051,11 @@ void CEditor::RenderFileDialog()
 
 	// filebox
 	static CListBox s_ListBox;
-	s_ListBox.SetActive(!UI()->IsPopupOpen());
+	s_ListBox.SetActive(!Ui()->IsPopupOpen());
 
 	if(m_FileDialogStorageType == IStorage::TYPE_SAVE)
 	{
-		UI()->DoLabel(&FileBoxLabel, "Filename:", 10.0f, TEXTALIGN_ML);
+		Ui()->DoLabel(&FileBoxLabel, "Filename:", 10.0f, TEXTALIGN_ML);
 		if(DoEditBox(&m_FileDialogFileNameInput, &FileBox, 10.0f))
 		{
 			// remove '/' and '\'
@@ -5084,18 +5084,18 @@ void CEditor::RenderFileDialog()
 		}
 
 		if(m_FileDialogOpening)
-			UI()->SetActiveItem(&m_FileDialogFileNameInput);
+			Ui()->SetActiveItem(&m_FileDialogFileNameInput);
 	}
 	else
 	{
 		// render search bar
-		UI()->DoLabel(&FileBoxLabel, "Search:", 10.0f, TEXTALIGN_ML);
+		Ui()->DoLabel(&FileBoxLabel, "Search:", 10.0f, TEXTALIGN_ML);
 		if(m_FileDialogOpening || (Input()->KeyPress(KEY_F) && Input()->ModifierIsPressed()))
 		{
-			UI()->SetActiveItem(&m_FileDialogFilterInput);
+			Ui()->SetActiveItem(&m_FileDialogFilterInput);
 			m_FileDialogFilterInput.SelectAll();
 		}
-		if(UI()->DoClearableEditBox(&m_FileDialogFilterInput, &FileBox, 10.0f))
+		if(Ui()->DoClearableEditBox(&m_FileDialogFilterInput, &FileBox, 10.0f))
 		{
 			RefreshFilteredFileList();
 			if(m_vpFilteredFileList.empty())
@@ -5191,7 +5191,7 @@ void CEditor::RenderFileDialog()
 			{
 				SLabelProperties Props;
 				Props.m_MaxWidth = Preview.w;
-				UI()->DoLabel(&Preview, "Failed to load the image (check the local console for details).", 12.0f, TEXTALIGN_TL, Props);
+				Ui()->DoLabel(&Preview, "Failed to load the image (check the local console for details).", 12.0f, TEXTALIGN_TL, Props);
 			}
 		}
 		else if(m_FileDialogFileType == CEditor::FILETYPE_SOUND)
@@ -5209,7 +5209,7 @@ void CEditor::RenderFileDialog()
 			{
 				SLabelProperties Props;
 				Props.m_MaxWidth = Preview.w;
-				UI()->DoLabel(&Preview, "Failed to load the sound (check the local console for details). Make sure you enabled sounds in the settings.", 12.0f, TEXTALIGN_TL, Props);
+				Ui()->DoLabel(&Preview, "Failed to load the sound (check the local console for details). Make sure you enabled sounds in the settings.", 12.0f, TEXTALIGN_TL, Props);
 			}
 		}
 	}
@@ -5256,20 +5256,20 @@ void CEditor::RenderFileDialog()
 
 		TextRender()->SetFontPreset(EFontPreset::ICON_FONT);
 		TextRender()->SetRenderFlags(ETextRenderFlags::TEXT_RENDER_FLAG_ONLY_ADVANCE_WIDTH | ETextRenderFlags::TEXT_RENDER_FLAG_NO_X_BEARING | ETextRenderFlags::TEXT_RENDER_FLAG_NO_Y_BEARING);
-		UI()->DoLabel(&FileIcon, pIconType, 12.0f, TEXTALIGN_ML);
+		Ui()->DoLabel(&FileIcon, pIconType, 12.0f, TEXTALIGN_ML);
 		TextRender()->SetRenderFlags(0);
 		TextRender()->SetFontPreset(EFontPreset::DEFAULT_FONT);
 
 		SLabelProperties Props;
 		Props.m_MaxWidth = Button.w;
 		Props.m_EllipsisAtEnd = true;
-		UI()->DoLabel(&Button, m_vpFilteredFileList[i]->m_aName, 10.0f, TEXTALIGN_ML, Props);
+		Ui()->DoLabel(&Button, m_vpFilteredFileList[i]->m_aName, 10.0f, TEXTALIGN_ML, Props);
 
 		if(!m_vpFilteredFileList[i]->m_IsLink && str_comp(m_vpFilteredFileList[i]->m_aFilename, "..") != 0)
 		{
 			char aBufTimeModified[64];
 			str_timestamp_ex(m_vpFilteredFileList[i]->m_TimeModified, aBufTimeModified, sizeof(aBufTimeModified), "%d.%m.%Y %H:%M");
-			UI()->DoLabel(&TimeModified, aBufTimeModified, 10.0f, TEXTALIGN_MR);
+			Ui()->DoLabel(&TimeModified, aBufTimeModified, 10.0f, TEXTALIGN_MR);
 		}
 	}
 
@@ -5298,12 +5298,12 @@ void CEditor::RenderFileDialog()
 	CUIRect Button;
 	ButtonBar.VSplitRight(50.0f, &ButtonBar, &Button);
 	const bool IsDir = m_FilesSelectedIndex >= 0 && m_vpFilteredFileList[m_FilesSelectedIndex]->m_IsDir;
-	if(DoButton_Editor(&s_OkButton, IsDir ? "Open" : m_pFileDialogButtonText, 0, &Button, 0, nullptr) || s_ListBox.WasItemActivated() || (s_ListBox.Active() && UI()->ConsumeHotkey(CUI::HOTKEY_ENTER)))
+	if(DoButton_Editor(&s_OkButton, IsDir ? "Open" : m_pFileDialogButtonText, 0, &Button, 0, nullptr) || s_ListBox.WasItemActivated() || (s_ListBox.Active() && Ui()->ConsumeHotkey(CUi::HOTKEY_ENTER)))
 	{
 		if(IsDir) // folder
 		{
 			m_FileDialogFilterInput.Clear();
-			UI()->SetActiveItem(&m_FileDialogFilterInput);
+			Ui()->SetActiveItem(&m_FileDialogFilterInput);
 			const bool ParentFolder = str_comp(m_vpFilteredFileList[m_FilesSelectedIndex]->m_aFilename, "..") == 0;
 			if(ParentFolder) // parent folder
 			{
@@ -5377,7 +5377,7 @@ void CEditor::RenderFileDialog()
 
 	ButtonBar.VSplitRight(ButtonSpacing, &ButtonBar, nullptr);
 	ButtonBar.VSplitRight(50.0f, &ButtonBar, &Button);
-	if(DoButton_Editor(&s_CancelButton, "Cancel", 0, &Button, 0, nullptr) || (s_ListBox.Active() && UI()->ConsumeHotkey(CUI::HOTKEY_ESCAPE)))
+	if(DoButton_Editor(&s_CancelButton, "Cancel", 0, &Button, 0, nullptr) || (s_ListBox.Active() && Ui()->ConsumeHotkey(CUi::HOTKEY_ESCAPE)))
 	{
 		OnDialogClose();
 		m_Dialog = DIALOG_NONE;
@@ -5405,17 +5405,17 @@ void CEditor::RenderFileDialog()
 
 	ButtonBar.VSplitRight(ButtonSpacing, &ButtonBar, nullptr);
 	ButtonBar.VSplitRight(50.0f, &ButtonBar, &Button);
-	static CUI::SConfirmPopupContext s_ConfirmDeletePopupContext;
+	static CUi::SConfirmPopupContext s_ConfirmDeletePopupContext;
 	if(m_FilesSelectedIndex >= 0 && m_vpFilteredFileList[m_FilesSelectedIndex]->m_StorageType == IStorage::TYPE_SAVE && !m_vpFilteredFileList[m_FilesSelectedIndex]->m_IsLink && str_comp(m_vpFilteredFileList[m_FilesSelectedIndex]->m_aFilename, "..") != 0)
 	{
-		if(DoButton_Editor(&s_DeleteButton, "Delete", 0, &Button, 0, nullptr) || (s_ListBox.Active() && UI()->ConsumeHotkey(CUI::HOTKEY_DELETE)))
+		if(DoButton_Editor(&s_DeleteButton, "Delete", 0, &Button, 0, nullptr) || (s_ListBox.Active() && Ui()->ConsumeHotkey(CUi::HOTKEY_DELETE)))
 		{
 			s_ConfirmDeletePopupContext.Reset();
 			s_ConfirmDeletePopupContext.YesNoButtons();
 			str_format(s_ConfirmDeletePopupContext.m_aMessage, sizeof(s_ConfirmDeletePopupContext.m_aMessage), "Are you sure that you want to delete the %s '%s/%s'?", IsDir ? "folder" : "file", m_pFileDialogPath, m_vpFilteredFileList[m_FilesSelectedIndex]->m_aFilename);
-			UI()->ShowPopupConfirm(UI()->MouseX(), UI()->MouseY(), &s_ConfirmDeletePopupContext);
+			Ui()->ShowPopupConfirm(Ui()->MouseX(), Ui()->MouseY(), &s_ConfirmDeletePopupContext);
 		}
-		if(s_ConfirmDeletePopupContext.m_Result == CUI::SConfirmPopupContext::CONFIRMED)
+		if(s_ConfirmDeletePopupContext.m_Result == CUi::SConfirmPopupContext::CONFIRMED)
 		{
 			char aDeleteFilePath[IO_MAX_PATH_LENGTH];
 			str_format(aDeleteFilePath, sizeof(aDeleteFilePath), "%s/%s", m_pFileDialogPath, m_vpFilteredFileList[m_FilesSelectedIndex]->m_aFilename);
@@ -5435,7 +5435,7 @@ void CEditor::RenderFileDialog()
 			}
 			UpdateFileNameInput();
 		}
-		if(s_ConfirmDeletePopupContext.m_Result != CUI::SConfirmPopupContext::UNSET)
+		if(s_ConfirmDeletePopupContext.m_Result != CUi::SConfirmPopupContext::UNSET)
 			s_ConfirmDeletePopupContext.Reset();
 	}
 	else
@@ -5450,8 +5450,8 @@ void CEditor::RenderFileDialog()
 			static SPopupMenuId s_PopupNewFolderId;
 			constexpr float PopupWidth = 400.0f;
 			constexpr float PopupHeight = 110.0f;
-			UI()->DoPopupMenu(&s_PopupNewFolderId, Width / 2.0f - PopupWidth / 2.0f, Height / 2.0f - PopupHeight / 2.0f, PopupWidth, PopupHeight, this, PopupNewFolder);
-			UI()->SetActiveItem(&m_FileDialogNewFolderNameInput);
+			Ui()->DoPopupMenu(&s_PopupNewFolderId, Width / 2.0f - PopupWidth / 2.0f, Height / 2.0f - PopupHeight / 2.0f, PopupWidth, PopupHeight, this, PopupNewFolder);
+			Ui()->SetActiveItem(&m_FileDialogNewFolderNameInput);
 		}
 	}
 }
@@ -5589,7 +5589,7 @@ void CEditor::InvokeFileDialog(int StorageType, int FileType, const char *pTitle
 		m_FileDialogMultipleStorages = false;
 	}
 
-	UI()->ClosePopupMenus();
+	Ui()->ClosePopupMenus();
 	m_pFileDialogTitle = pTitle;
 	m_pFileDialogButtonText = pButtonText;
 	m_pfnFileDialogFunc = pfnFunc;
@@ -5628,20 +5628,20 @@ void CEditor::ShowFileDialogError(const char *pFormat, ...)
 	va_end(VarArgs);
 
 	auto ContextIterator = m_PopupMessageContexts.find(aMessage);
-	CUI::SMessagePopupContext *pContext;
+	CUi::SMessagePopupContext *pContext;
 	if(ContextIterator != m_PopupMessageContexts.end())
 	{
 		pContext = ContextIterator->second;
-		UI()->ClosePopupMenu(pContext);
+		Ui()->ClosePopupMenu(pContext);
 	}
 	else
 	{
-		pContext = new CUI::SMessagePopupContext();
+		pContext = new CUi::SMessagePopupContext();
 		pContext->ErrorColor();
 		str_copy(pContext->m_aMessage, aMessage);
 		m_PopupMessageContexts[pContext->m_aMessage] = pContext;
 	}
-	UI()->ShowPopupMessage(UI()->MouseX(), UI()->MouseY(), pContext);
+	Ui()->ShowPopupMessage(Ui()->MouseX(), Ui()->MouseY(), pContext);
 }
 
 void CEditor::RenderModebar(CUIRect View)
@@ -5666,7 +5666,7 @@ void CEditor::RenderModebar(CUIRect View)
 			str_copy(aBuf, Localize("9+ new mentions"));
 
 		TextRender()->TextColor(ColorRGBA(1.0f, 0.0f, 0.0f, 1.0f));
-		UI()->DoLabel(&Mentions, aBuf, 10.0f, TEXTALIGN_MC);
+		Ui()->DoLabel(&Mentions, aBuf, 10.0f, TEXTALIGN_MC);
 		TextRender()->TextColor(TextRender()->DefaultTextColor());
 	}
 
@@ -5674,7 +5674,7 @@ void CEditor::RenderModebar(CUIRect View)
 	if(m_IngameMoved)
 	{
 		TextRender()->TextColor(ColorRGBA(1.0f, 0.0f, 0.0f, 1.0f));
-		UI()->DoLabel(&IngameMoved, Localize("Moved ingame"), 10.0f, TEXTALIGN_MC);
+		Ui()->DoLabel(&IngameMoved, Localize("Moved ingame"), 10.0f, TEXTALIGN_MC);
 		TextRender()->TextColor(TextRender()->DefaultTextColor());
 	}
 
@@ -5749,7 +5749,7 @@ void CEditor::RenderTooltip(CUIRect TooltipRect)
 		return;
 
 	char aBuf[256];
-	if(ms_pUiGotContext && ms_pUiGotContext == UI()->HotItem())
+	if(ms_pUiGotContext && ms_pUiGotContext == Ui()->HotItem())
 		str_format(aBuf, sizeof(aBuf), "%s Right click for context menu.", m_aTooltip);
 	else
 		str_copy(aBuf, m_aTooltip);
@@ -5757,7 +5757,7 @@ void CEditor::RenderTooltip(CUIRect TooltipRect)
 	SLabelProperties Props;
 	Props.m_MaxWidth = TooltipRect.w;
 	Props.m_EllipsisAtEnd = true;
-	UI()->DoLabel(&TooltipRect, aBuf, 10.0f, TEXTALIGN_ML, Props);
+	Ui()->DoLabel(&TooltipRect, aBuf, 10.0f, TEXTALIGN_ML, Props);
 }
 
 bool CEditor::IsEnvelopeUsed(int EnvelopeIndex) const
@@ -5823,7 +5823,7 @@ void CEditor::RemoveUnusedEnvelopes()
 
 void CEditor::ZoomAdaptOffsetX(float ZoomFactor, const CUIRect &View)
 {
-	float PosX = g_Config.m_EdZoomTarget ? (UI()->MouseX() - View.x) / View.w : 0.5f;
+	float PosX = g_Config.m_EdZoomTarget ? (Ui()->MouseX() - View.x) / View.w : 0.5f;
 	m_OffsetEnvelopeX = PosX - (PosX - m_OffsetEnvelopeX) * ZoomFactor;
 }
 
@@ -5836,7 +5836,7 @@ void CEditor::UpdateZoomEnvelopeX(const CUIRect &View)
 
 void CEditor::ZoomAdaptOffsetY(float ZoomFactor, const CUIRect &View)
 {
-	float PosY = g_Config.m_EdZoomTarget ? 1.0f - (UI()->MouseY() - View.y) / View.h : 0.5f;
+	float PosY = g_Config.m_EdZoomTarget ? 1.0f - (Ui()->MouseY() - View.y) / View.h : 0.5f;
 	m_OffsetEnvelopeY = PosY - (PosY - m_OffsetEnvelopeY) * ZoomFactor;
 }
 
@@ -5933,12 +5933,12 @@ float CEditor::EnvelopeToScreenY(const CUIRect &View, float y) const
 
 float CEditor::ScreenToEnvelopeDX(const CUIRect &View, float dx)
 {
-	return dx / Graphics()->ScreenWidth() * UI()->Screen()->w / View.w * m_ZoomEnvelopeX.GetValue();
+	return dx / Graphics()->ScreenWidth() * Ui()->Screen()->w / View.w * m_ZoomEnvelopeX.GetValue();
 }
 
 float CEditor::ScreenToEnvelopeDY(const CUIRect &View, float dy)
 {
-	return dy / Graphics()->ScreenHeight() * UI()->Screen()->h / View.h * m_ZoomEnvelopeY.GetValue();
+	return dy / Graphics()->ScreenHeight() * Ui()->Screen()->h / View.h * m_ZoomEnvelopeY.GetValue();
 }
 
 void CEditor::RemoveTimeOffsetEnvelope(const std::shared_ptr<CEnvelope> &pEnvelope)
@@ -6036,16 +6036,16 @@ private:
 
 void CEditor::SetHotEnvelopePoint(const CUIRect &View, const std::shared_ptr<CEnvelope> &pEnvelope, int ActiveChannels)
 {
-	if(!UI()->MouseInside(&View))
+	if(!Ui()->MouseInside(&View))
 		return;
 
-	float mx = UI()->MouseX();
-	float my = UI()->MouseY();
+	float mx = Ui()->MouseX();
+	float my = Ui()->MouseY();
 
 	float MinDist = 200.0f;
 	int *pMinPoint = nullptr;
 
-	auto UpdateMinimum = [&](float px, float py, int *pID) {
+	auto UpdateMinimum = [&](float px, float py, int *pId) {
 		float dx = px - mx;
 		float dy = py - my;
 
@@ -6053,7 +6053,7 @@ void CEditor::SetHotEnvelopePoint(const CUIRect &View, const std::shared_ptr<CEn
 		if(CurrDist < MinDist)
 		{
 			MinDist = CurrDist;
-			pMinPoint = pID;
+			pMinPoint = pId;
 		}
 	};
 
@@ -6085,7 +6085,7 @@ void CEditor::SetHotEnvelopePoint(const CUIRect &View, const std::shared_ptr<CEn
 	}
 
 	if(pMinPoint != nullptr)
-		UI()->SetHotItem(pMinPoint);
+		Ui()->SetHotItem(pMinPoint);
 }
 
 void CEditor::RenderEnvelopeEditor(CUIRect View)
@@ -6303,7 +6303,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 		{
 			ToolBar.VSplitLeft(15.0f, nullptr, &ToolBar);
 			ToolBar.VSplitLeft(40.0f, &Button, &ToolBar);
-			UI()->DoLabel(&Button, "Name:", 10.0f, TEXTALIGN_MR);
+			Ui()->DoLabel(&Button, "Name:", 10.0f, TEXTALIGN_MR);
 
 			ToolBar.VSplitLeft(3.0f, nullptr, &ToolBar);
 			ToolBar.VSplitLeft(ToolBar.w > ToolBar.h * 40 ? 80.0f : 60.0f, &Button, &ToolBar);
@@ -6334,7 +6334,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 			ResetZoomEnvelope(pEnvelope, s_ActiveChannels);
 		}
 
-		static int s_EnvelopeEditorID = 0;
+		static int s_EnvelopeEditorId = 0;
 
 		ColorRGBA aColors[] = {ColorRGBA(1, 0.2f, 0.2f), ColorRGBA(0.2f, 1, 0.2f), ColorRGBA(0.2f, 0.2f, 1), ColorRGBA(1, 1, 0.2f)};
 
@@ -6389,24 +6389,24 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 			m_Map.OnModify();
 		}
 
-		const bool ShouldPan = s_Operation == EEnvelopeEditorOp::OP_NONE && (UI()->MouseButton(2) || (UI()->MouseButton(0) && Input()->ModifierIsPressed()));
-		if(m_pContainerPanned == &s_EnvelopeEditorID)
+		const bool ShouldPan = s_Operation == EEnvelopeEditorOp::OP_NONE && (Ui()->MouseButton(2) || (Ui()->MouseButton(0) && Input()->ModifierIsPressed()));
+		if(m_pContainerPanned == &s_EnvelopeEditorId)
 		{
 			if(!ShouldPan)
 				m_pContainerPanned = nullptr;
 			else
 			{
-				m_OffsetEnvelopeX += UI()->MouseDeltaX() / Graphics()->ScreenWidth() * UI()->Screen()->w / View.w;
-				m_OffsetEnvelopeY -= UI()->MouseDeltaY() / Graphics()->ScreenHeight() * UI()->Screen()->h / View.h;
+				m_OffsetEnvelopeX += Ui()->MouseDeltaX() / Graphics()->ScreenWidth() * Ui()->Screen()->w / View.w;
+				m_OffsetEnvelopeY -= Ui()->MouseDeltaY() / Graphics()->ScreenHeight() * Ui()->Screen()->h / View.h;
 			}
 		}
 
-		if(UI()->MouseInside(&View) && m_Dialog == DIALOG_NONE)
+		if(Ui()->MouseInside(&View) && m_Dialog == DIALOG_NONE)
 		{
-			UI()->SetHotItem(&s_EnvelopeEditorID);
+			Ui()->SetHotItem(&s_EnvelopeEditorId);
 
 			if(ShouldPan && m_pContainerPanned == nullptr)
-				m_pContainerPanned = &s_EnvelopeEditorID;
+				m_pContainerPanned = &s_EnvelopeEditorId;
 
 			if(Input()->KeyPress(KEY_KP_MULTIPLY))
 				ResetZoomEnvelope(pEnvelope, s_ActiveChannels);
@@ -6434,15 +6434,15 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 			}
 		}
 
-		if(UI()->HotItem() == &s_EnvelopeEditorID)
+		if(Ui()->HotItem() == &s_EnvelopeEditorId)
 		{
 			// do stuff
-			if(UI()->MouseButton(0))
+			if(Ui()->MouseButton(0))
 			{
 				if(Input()->MouseDoubleClick())
 				{
 					// add point
-					float Time = ScreenToEnvelopeX(View, UI()->MouseX());
+					float Time = ScreenToEnvelopeX(View, Ui()->MouseX());
 					ColorRGBA Channels = ColorRGBA(0.0f, 0.0f, 0.0f, 0.0f);
 					if(in_range(Time, 0.0f, pEnvelope->EndTime()))
 						pEnvelope->Eval(Time, Channels, 4);
@@ -6464,11 +6464,11 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 				}
 				else if(s_Operation != EEnvelopeEditorOp::OP_BOX_SELECT && !Input()->ModifierIsPressed())
 				{
-					static int s_BoxSelectID = 0;
-					UI()->SetActiveItem(&s_BoxSelectID);
+					static int s_BoxSelectId = 0;
+					Ui()->SetActiveItem(&s_BoxSelectId);
 					s_Operation = EEnvelopeEditorOp::OP_BOX_SELECT;
-					s_MouseXStart = UI()->MouseX();
-					s_MouseYStart = UI()->MouseY();
+					s_MouseXStart = Ui()->MouseX();
+					s_MouseYStart = Ui()->MouseY();
 				}
 			}
 
@@ -6489,7 +6489,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 			}
 			int NumLinesY = m_ZoomEnvelopeY.GetValue() / static_cast<float>(UnitsPerLineY) + 1;
 
-			UI()->ClipEnable(&View);
+			Ui()->ClipEnable(&View);
 			Graphics()->TextureClear();
 			Graphics()->LinesBegin();
 			Graphics()->SetColor(1.0f, 1.0f, 1.0f, 0.2f);
@@ -6504,7 +6504,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 
 			Graphics()->LinesEnd();
 
-			UI()->TextRender()->TextColor(1.0f, 1.0f, 1.0f, 0.4f);
+			Ui()->TextRender()->TextColor(1.0f, 1.0f, 1.0f, 0.4f);
 			for(int i = 0; i <= NumLinesY; i++)
 			{
 				float Value = UnitsPerLineY * i - BaseValue;
@@ -6517,10 +6517,10 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 				{
 					str_format(aValueBuffer, sizeof(aValueBuffer), "%.3f", Value);
 				}
-				UI()->TextRender()->Text(View.x, EnvelopeToScreenY(View, Value) + 4.0f, 8.0f, aValueBuffer);
+				Ui()->TextRender()->Text(View.x, EnvelopeToScreenY(View, Value) + 4.0f, 8.0f, aValueBuffer);
 			}
-			UI()->TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
-			UI()->ClipDisable();
+			Ui()->TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
+			Ui()->ClipDisable();
 		}
 
 		{
@@ -6534,7 +6534,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 			}
 			int NumLinesX = m_ZoomEnvelopeX.GetValue() / static_cast<float>(UnitsPerLineX.AsSeconds()) + 1;
 
-			UI()->ClipEnable(&View);
+			Ui()->ClipEnable(&View);
 			Graphics()->TextureClear();
 			Graphics()->LinesBegin();
 			Graphics()->SetColor(1.0f, 1.0f, 1.0f, 0.2f);
@@ -6549,7 +6549,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 
 			Graphics()->LinesEnd();
 
-			UI()->TextRender()->TextColor(1.0f, 1.0f, 1.0f, 0.4f);
+			Ui()->TextRender()->TextColor(1.0f, 1.0f, 1.0f, 0.4f);
 			for(int i = 0; i <= NumLinesX; i++)
 			{
 				CTimeStep Value = UnitsPerLineX * i - BaseValue;
@@ -6558,16 +6558,16 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 					char aValueBuffer[16];
 					Value.Format(aValueBuffer, sizeof(aValueBuffer));
 
-					UI()->TextRender()->Text(EnvelopeToScreenX(View, Value.AsSeconds()) + 1.0f, View.y + View.h - 8.0f, 8.0f, aValueBuffer);
+					Ui()->TextRender()->Text(EnvelopeToScreenX(View, Value.AsSeconds()) + 1.0f, View.y + View.h - 8.0f, 8.0f, aValueBuffer);
 				}
 			}
-			UI()->TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
-			UI()->ClipDisable();
+			Ui()->TextRender()->TextColor(1.0f, 1.0f, 1.0f, 1.0f);
+			Ui()->ClipDisable();
 		}
 
 		// render tangents for bezier curves
 		{
-			UI()->ClipEnable(&View);
+			Ui()->ClipEnable(&View);
 			Graphics()->TextureClear();
 			Graphics()->LinesBegin();
 			for(int c = 0; c < pEnvelope->GetChannels(); c++)
@@ -6612,7 +6612,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 				}
 			}
 			Graphics()->LinesEnd();
-			UI()->ClipDisable();
+			Ui()->ClipDisable();
 		}
 
 		// render lines
@@ -6624,7 +6624,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 			float EndTime = ScreenToEnvelopeX(View, EndX);
 			float StartTime = ScreenToEnvelopeX(View, StartX);
 
-			UI()->ClipEnable(&View);
+			Ui()->ClipEnable(&View);
 			Graphics()->TextureClear();
 			Graphics()->LinesBegin();
 			for(int c = 0; c < pEnvelope->GetChannels(); c++)
@@ -6634,7 +6634,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 				else
 					Graphics()->SetColor(aColors[c].r * 0.5f, aColors[c].g * 0.5f, aColors[c].b * 0.5f, 1);
 
-				int Steps = static_cast<int>(((EndX - StartX) / UI()->Screen()->w) * Graphics()->ScreenWidth());
+				int Steps = static_cast<int>(((EndX - StartX) / Ui()->Screen()->w) * Graphics()->ScreenWidth());
 				float StepTime = (EndTime - StartTime) / static_cast<float>(Steps);
 				float StepSize = (EndX - StartX) / static_cast<float>(Steps);
 
@@ -6658,7 +6658,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 				}
 			}
 			Graphics()->LinesEnd();
-			UI()->ClipDisable();
+			Ui()->ClipDisable();
 		}
 
 		// render curve options
@@ -6674,7 +6674,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 				CurveButton.h = CurveBar.h;
 				CurveButton.w = CurveBar.h;
 				CurveButton.x -= CurveButton.w / 2.0f;
-				const void *pID = &pEnvelope->m_vPoints[i].m_Curvetype;
+				const void *pId = &pEnvelope->m_vPoints[i].m_Curvetype;
 				const char *apTypeName[] = {"N", "L", "S", "F", "M", "B"};
 				const char *pTypeName = "!?";
 				if(0 <= pEnvelope->m_vPoints[i].m_Curvetype && pEnvelope->m_vPoints[i].m_Curvetype < (int)std::size(apTypeName))
@@ -6682,7 +6682,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 
 				if(CurveButton.x >= View.x)
 				{
-					if(DoButton_Editor(pID, pTypeName, 0, &CurveButton, 0, "Switch curve type (N = step, L = linear, S = slow, F = fast, M = smooth, B = bezier)"))
+					if(DoButton_Editor(pId, pTypeName, 0, &CurveButton, 0, "Switch curve type (N = step, L = linear, S = slow, F = fast, M = smooth, B = bezier)"))
 					{
 						int PrevCurve = pEnvelope->m_vPoints[i].m_Curvetype;
 						pEnvelope->m_vPoints[i].m_Curvetype = (pEnvelope->m_vPoints[i].m_Curvetype + 1) % NUM_CURVETYPES;
@@ -6698,7 +6698,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 		// render colorbar
 		if(ShowColorBar)
 		{
-			UI()->ClipEnable(&ColorBar);
+			Ui()->ClipEnable(&ColorBar);
 
 			float StartX = maximum(EnvelopeToScreenX(View, 0), ColorBar.x);
 			float EndX = EnvelopeToScreenX(View, pEnvelope->EndTime());
@@ -6735,7 +6735,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 				Graphics()->QuadsDrawTL(&QuadItem, 1);
 			}
 			Graphics()->QuadsEnd();
-			UI()->ClipDisable();
+			Ui()->ClipDisable();
 		}
 
 		// render handles
@@ -6748,13 +6748,13 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 		{
 			static SPopupMenuId s_PopupEnvPointId;
 			const auto &&ShowPopupEnvPoint = [&]() {
-				UI()->DoPopupMenu(&s_PopupEnvPointId, UI()->MouseX(), UI()->MouseY(), 150, 56 + (pEnvelope->GetChannels() == 4 && !IsTangentSelected() ? 16.0f : 0.0f), this, PopupEnvPoint);
+				Ui()->DoPopupMenu(&s_PopupEnvPointId, Ui()->MouseX(), Ui()->MouseY(), 150, 56 + (pEnvelope->GetChannels() == 4 && !IsTangentSelected() ? 16.0f : 0.0f), this, PopupEnvPoint);
 			};
 
 			if(s_Operation == EEnvelopeEditorOp::OP_NONE)
 			{
 				SetHotEnvelopePoint(View, pEnvelope, s_ActiveChannels);
-				if(!UI()->MouseButton(0))
+				if(!Ui()->MouseButton(0))
 					m_EnvOpTracker.Stop(false);
 			}
 			else
@@ -6762,7 +6762,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 				m_EnvOpTracker.Begin(s_Operation);
 			}
 
-			UI()->ClipEnable(&View);
+			Ui()->ClipEnable(&View);
 			Graphics()->TextureClear();
 			Graphics()->QuadsBegin();
 			for(int c = 0; c < pEnvelope->GetChannels(); c++)
@@ -6782,7 +6782,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 						Final.w = 4.0f;
 						Final.h = 4.0f;
 
-						const void *pID = &pEnvelope->m_vPoints[i].m_aValues[c];
+						const void *pId = &pEnvelope->m_vPoints[i].m_aValues[c];
 
 						if(IsEnvPointSelected(i, c))
 						{
@@ -6796,14 +6796,14 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 							Graphics()->QuadsDrawTL(&QuadItem, 1);
 						}
 
-						if(UI()->CheckActiveItem(pID))
+						if(Ui()->CheckActiveItem(pId))
 						{
 							m_ShowEnvelopePreview = SHOWENV_SELECTED;
 
 							if(s_Operation == EEnvelopeEditorOp::OP_SELECT)
 							{
-								float dx = s_MouseXStart - UI()->MouseX();
-								float dy = s_MouseYStart - UI()->MouseY();
+								float dx = s_MouseXStart - Ui()->MouseX();
+								float dy = s_MouseYStart - Ui()->MouseY();
 
 								if(dx * dx + dy * dy > 20.0f)
 								{
@@ -6827,7 +6827,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 									}
 									else
 									{
-										float DeltaX = ScreenToEnvelopeDX(View, UI()->MouseDeltaX()) * (Input()->ModifierIsPressed() ? 50.0f : 1000.0f);
+										float DeltaX = ScreenToEnvelopeDX(View, Ui()->MouseDeltaX()) * (Input()->ModifierIsPressed() ? 50.0f : 1000.0f);
 
 										for(size_t k = 0; k < m_vSelectedEnvelopePoints.size(); k++)
 										{
@@ -6878,7 +6878,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 									}
 									else
 									{
-										float DeltaY = ScreenToEnvelopeDY(View, UI()->MouseDeltaY()) * (Input()->ModifierIsPressed() ? 51.2f : 1024.0f);
+										float DeltaY = ScreenToEnvelopeDY(View, Ui()->MouseDeltaY()) * (Input()->ModifierIsPressed() ? 51.2f : 1024.0f);
 										for(size_t k = 0; k < m_vSelectedEnvelopePoints.size(); k++)
 										{
 											auto [SelectedIndex, SelectedChannel] = m_vSelectedEnvelopePoints[k];
@@ -6897,7 +6897,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 
 							if(s_Operation == EEnvelopeEditorOp::OP_CONTEXT_MENU)
 							{
-								if(!UI()->MouseButton(1))
+								if(!Ui()->MouseButton(1))
 								{
 									if(m_vSelectedEnvelopePoints.size() == 1)
 									{
@@ -6907,15 +6907,15 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 									else if(m_vSelectedEnvelopePoints.size() > 1)
 									{
 										static SPopupMenuId s_PopupEnvPointMultiId;
-										UI()->DoPopupMenu(&s_PopupEnvPointMultiId, UI()->MouseX(), UI()->MouseY(), 80, 22, this, PopupEnvPointMulti);
+										Ui()->DoPopupMenu(&s_PopupEnvPointMultiId, Ui()->MouseX(), Ui()->MouseY(), 80, 22, this, PopupEnvPointMulti);
 									}
-									UI()->SetActiveItem(nullptr);
+									Ui()->SetActiveItem(nullptr);
 									s_Operation = EEnvelopeEditorOp::OP_NONE;
 								}
 							}
-							else if(!UI()->MouseButton(0))
+							else if(!Ui()->MouseButton(0))
 							{
-								UI()->SetActiveItem(nullptr);
+								Ui()->SetActiveItem(nullptr);
 								m_SelectedQuadEnvelope = -1;
 
 								if(s_Operation == EEnvelopeEditorOp::OP_SELECT)
@@ -6932,18 +6932,18 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 
 							Graphics()->SetColor(1, 1, 1, 1);
 						}
-						else if(UI()->HotItem() == pID)
+						else if(Ui()->HotItem() == pId)
 						{
-							if(UI()->MouseButton(0))
+							if(Ui()->MouseButton(0))
 							{
-								UI()->SetActiveItem(pID);
+								Ui()->SetActiveItem(pId);
 								s_Operation = EEnvelopeEditorOp::OP_SELECT;
 								m_SelectedQuadEnvelope = m_SelectedEnvelope;
 
-								s_MouseXStart = UI()->MouseX();
-								s_MouseYStart = UI()->MouseY();
+								s_MouseXStart = Ui()->MouseX();
+								s_MouseYStart = Ui()->MouseY();
 							}
-							else if(UI()->MouseButtonClicked(1))
+							else if(Ui()->MouseButtonClicked(1))
 							{
 								if(Input()->ShiftIsPressed())
 								{
@@ -6954,14 +6954,14 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 									s_Operation = EEnvelopeEditorOp::OP_CONTEXT_MENU;
 									if(!IsEnvPointSelected(i, c))
 										SelectEnvPoint(i, c);
-									UI()->SetActiveItem(pID);
+									Ui()->SetActiveItem(pId);
 								}
 							}
 
 							m_ShowEnvelopePreview = SHOWENV_SELECTED;
 							Graphics()->SetColor(1, 1, 1, 1);
 							str_copy(m_aTooltip, "Envelope point. Left mouse to drag. Hold ctrl to be more precise. Hold shift to alter time. Shift + right-click to delete.");
-							ms_pUiGotContext = pID;
+							ms_pUiGotContext = pId;
 						}
 						else
 							Graphics()->SetColor(aColors[c].r, aColors[c].g, aColors[c].b, 1.0f);
@@ -6985,7 +6985,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 							Final.h = 4.0f;
 
 							// handle logic
-							const void *pID = &pEnvelope->m_vPoints[i].m_Bezier.m_aOutTangentDeltaX[c];
+							const void *pId = &pEnvelope->m_vPoints[i].m_Bezier.m_aOutTangentDeltaX[c];
 
 							if(IsTangentOutPointSelected(i, c))
 							{
@@ -7002,14 +7002,14 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 								Graphics()->QuadsDrawFreeform(&FreeformItem, 1);
 							}
 
-							if(UI()->CheckActiveItem(pID))
+							if(Ui()->CheckActiveItem(pId))
 							{
 								m_ShowEnvelopePreview = SHOWENV_SELECTED;
 
 								if(s_Operation == EEnvelopeEditorOp::OP_SELECT)
 								{
-									float dx = s_MouseXStart - UI()->MouseX();
-									float dy = s_MouseYStart - UI()->MouseY();
+									float dx = s_MouseXStart - Ui()->MouseX();
+									float dy = s_MouseYStart - Ui()->MouseY();
 
 									if(dx * dx + dy * dy > 20.0f)
 									{
@@ -7025,8 +7025,8 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 
 								if(s_Operation == EEnvelopeEditorOp::OP_DRAG_POINT)
 								{
-									float DeltaX = ScreenToEnvelopeDX(View, UI()->MouseDeltaX()) * (Input()->ModifierIsPressed() ? 50.0f : 1000.0f);
-									float DeltaY = ScreenToEnvelopeDY(View, UI()->MouseDeltaY()) * (Input()->ModifierIsPressed() ? 51.2f : 1024.0f);
+									float DeltaX = ScreenToEnvelopeDX(View, Ui()->MouseDeltaX()) * (Input()->ModifierIsPressed() ? 50.0f : 1000.0f);
+									float DeltaY = ScreenToEnvelopeDY(View, Ui()->MouseDeltaY()) * (Input()->ModifierIsPressed() ? 51.2f : 1024.0f);
 									s_vAccurateDragValuesX[0] += DeltaX;
 									s_vAccurateDragValuesY[0] -= DeltaY;
 
@@ -7040,19 +7040,19 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 
 								if(s_Operation == EEnvelopeEditorOp::OP_CONTEXT_MENU)
 								{
-									if(!UI()->MouseButton(1))
+									if(!Ui()->MouseButton(1))
 									{
 										if(IsTangentOutPointSelected(i, c))
 										{
 											m_UpdateEnvPointInfo = true;
 											ShowPopupEnvPoint();
 										}
-										UI()->SetActiveItem(nullptr);
+										Ui()->SetActiveItem(nullptr);
 									}
 								}
-								else if(!UI()->MouseButton(0))
+								else if(!Ui()->MouseButton(0))
 								{
-									UI()->SetActiveItem(nullptr);
+									Ui()->SetActiveItem(nullptr);
 									m_SelectedQuadEnvelope = -1;
 
 									if(s_Operation == EEnvelopeEditorOp::OP_SELECT)
@@ -7064,18 +7064,18 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 
 								Graphics()->SetColor(1, 1, 1, 1);
 							}
-							else if(UI()->HotItem() == pID)
+							else if(Ui()->HotItem() == pId)
 							{
-								if(UI()->MouseButton(0))
+								if(Ui()->MouseButton(0))
 								{
-									UI()->SetActiveItem(pID);
+									Ui()->SetActiveItem(pId);
 									s_Operation = EEnvelopeEditorOp::OP_SELECT;
 									m_SelectedQuadEnvelope = m_SelectedEnvelope;
 
-									s_MouseXStart = UI()->MouseX();
-									s_MouseYStart = UI()->MouseY();
+									s_MouseXStart = Ui()->MouseX();
+									s_MouseYStart = Ui()->MouseY();
 								}
-								else if(UI()->MouseButtonClicked(1))
+								else if(Ui()->MouseButtonClicked(1))
 								{
 									if(Input()->ShiftIsPressed())
 									{
@@ -7088,14 +7088,14 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 									{
 										s_Operation = EEnvelopeEditorOp::OP_CONTEXT_MENU;
 										SelectTangentOutPoint(i, c);
-										UI()->SetActiveItem(pID);
+										Ui()->SetActiveItem(pId);
 									}
 								}
 
 								m_ShowEnvelopePreview = SHOWENV_SELECTED;
 								Graphics()->SetColor(1, 1, 1, 1);
 								str_copy(m_aTooltip, "Bezier out-tangent. Left mouse to drag. Hold ctrl to be more precise. Shift + right-click to reset.");
-								ms_pUiGotContext = pID;
+								ms_pUiGotContext = pId;
 							}
 							else
 								Graphics()->SetColor(aColors[c].r, aColors[c].g, aColors[c].b, 1.0f);
@@ -7117,7 +7117,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 							Final.h = 4.0f;
 
 							// handle logic
-							const void *pID = &pEnvelope->m_vPoints[i].m_Bezier.m_aInTangentDeltaX[c];
+							const void *pId = &pEnvelope->m_vPoints[i].m_Bezier.m_aInTangentDeltaX[c];
 
 							if(IsTangentInPointSelected(i, c))
 							{
@@ -7134,14 +7134,14 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 								Graphics()->QuadsDrawFreeform(&FreeformItem, 1);
 							}
 
-							if(UI()->CheckActiveItem(pID))
+							if(Ui()->CheckActiveItem(pId))
 							{
 								m_ShowEnvelopePreview = SHOWENV_SELECTED;
 
 								if(s_Operation == EEnvelopeEditorOp::OP_SELECT)
 								{
-									float dx = s_MouseXStart - UI()->MouseX();
-									float dy = s_MouseYStart - UI()->MouseY();
+									float dx = s_MouseXStart - Ui()->MouseX();
+									float dy = s_MouseYStart - Ui()->MouseY();
 
 									if(dx * dx + dy * dy > 20.0f)
 									{
@@ -7157,8 +7157,8 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 
 								if(s_Operation == EEnvelopeEditorOp::OP_DRAG_POINT)
 								{
-									float DeltaX = ScreenToEnvelopeDX(View, UI()->MouseDeltaX()) * (Input()->ModifierIsPressed() ? 50.0f : 1000.0f);
-									float DeltaY = ScreenToEnvelopeDY(View, UI()->MouseDeltaY()) * (Input()->ModifierIsPressed() ? 51.2f : 1024.0f);
+									float DeltaX = ScreenToEnvelopeDX(View, Ui()->MouseDeltaX()) * (Input()->ModifierIsPressed() ? 50.0f : 1000.0f);
+									float DeltaY = ScreenToEnvelopeDY(View, Ui()->MouseDeltaY()) * (Input()->ModifierIsPressed() ? 51.2f : 1024.0f);
 									s_vAccurateDragValuesX[0] += DeltaX;
 									s_vAccurateDragValuesY[0] -= DeltaY;
 
@@ -7172,19 +7172,19 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 
 								if(s_Operation == EEnvelopeEditorOp::OP_CONTEXT_MENU)
 								{
-									if(!UI()->MouseButton(1))
+									if(!Ui()->MouseButton(1))
 									{
 										if(IsTangentInPointSelected(i, c))
 										{
 											m_UpdateEnvPointInfo = true;
 											ShowPopupEnvPoint();
 										}
-										UI()->SetActiveItem(nullptr);
+										Ui()->SetActiveItem(nullptr);
 									}
 								}
-								else if(!UI()->MouseButton(0))
+								else if(!Ui()->MouseButton(0))
 								{
-									UI()->SetActiveItem(nullptr);
+									Ui()->SetActiveItem(nullptr);
 									m_SelectedQuadEnvelope = -1;
 
 									if(s_Operation == EEnvelopeEditorOp::OP_SELECT)
@@ -7196,18 +7196,18 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 
 								Graphics()->SetColor(1, 1, 1, 1);
 							}
-							else if(UI()->HotItem() == pID)
+							else if(Ui()->HotItem() == pId)
 							{
-								if(UI()->MouseButton(0))
+								if(Ui()->MouseButton(0))
 								{
-									UI()->SetActiveItem(pID);
+									Ui()->SetActiveItem(pId);
 									s_Operation = EEnvelopeEditorOp::OP_SELECT;
 									m_SelectedQuadEnvelope = m_SelectedEnvelope;
 
-									s_MouseXStart = UI()->MouseX();
-									s_MouseYStart = UI()->MouseY();
+									s_MouseXStart = Ui()->MouseX();
+									s_MouseYStart = Ui()->MouseY();
 								}
-								else if(UI()->MouseButtonClicked(1))
+								else if(Ui()->MouseButtonClicked(1))
 								{
 									if(Input()->ShiftIsPressed())
 									{
@@ -7220,14 +7220,14 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 									{
 										s_Operation = EEnvelopeEditorOp::OP_CONTEXT_MENU;
 										SelectTangentInPoint(i, c);
-										UI()->SetActiveItem(pID);
+										Ui()->SetActiveItem(pId);
 									}
 								}
 
 								m_ShowEnvelopePreview = SHOWENV_SELECTED;
 								Graphics()->SetColor(1, 1, 1, 1);
 								str_copy(m_aTooltip, "Bezier in-tangent. Left mouse to drag. Hold ctrl to be more precise. Shift + right-click to reset.");
-								ms_pUiGotContext = pID;
+								ms_pUiGotContext = pId;
 							}
 							else
 								Graphics()->SetColor(aColors[c].r, aColors[c].g, aColors[c].b, 1.0f);
@@ -7240,7 +7240,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 				}
 			}
 			Graphics()->QuadsEnd();
-			UI()->ClipDisable();
+			Ui()->ClipDisable();
 		}
 
 		// handle scaling
@@ -7288,7 +7288,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 
 			if(Input()->ShiftIsPressed())
 			{
-				s_ScaleFactorX += UI()->MouseDeltaX() / Graphics()->ScreenWidth() * (Input()->ModifierIsPressed() ? 0.5f : 10.0f);
+				s_ScaleFactorX += Ui()->MouseDeltaX() / Graphics()->ScreenWidth() * (Input()->ModifierIsPressed() ? 0.5f : 10.0f);
 				float Midpoint = Input()->AltIsPressed() ? s_MidpointX : 0.0f;
 				for(size_t k = 0; k < m_vSelectedEnvelopePoints.size(); k++)
 				{
@@ -7341,7 +7341,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 			}
 			else
 			{
-				s_ScaleFactorY -= UI()->MouseDeltaY() / Graphics()->ScreenHeight() * (Input()->ModifierIsPressed() ? 0.5f : 10.0f);
+				s_ScaleFactorY -= Ui()->MouseDeltaY() / Graphics()->ScreenHeight() * (Input()->ModifierIsPressed() ? 0.5f : 10.0f);
 				for(size_t k = 0; k < m_vSelectedEnvelopePoints.size(); k++)
 				{
 					auto [SelectedIndex, SelectedChannel] = m_vSelectedEnvelopePoints[k];
@@ -7355,12 +7355,12 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 				}
 			}
 
-			if(UI()->MouseButton(0))
+			if(Ui()->MouseButton(0))
 			{
 				s_Operation = EEnvelopeEditorOp::OP_NONE;
 				m_EnvOpTracker.Stop(false);
 			}
-			else if(UI()->MouseButton(1) || UI()->ConsumeHotkey(CUI::HOTKEY_ESCAPE))
+			else if(Ui()->MouseButton(1) || Ui()->ConsumeHotkey(CUi::HOTKEY_ESCAPE))
 			{
 				for(size_t k = 0; k < m_vSelectedEnvelopePoints.size(); k++)
 				{
@@ -7381,25 +7381,25 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 		if(s_Operation == EEnvelopeEditorOp::OP_BOX_SELECT)
 		{
 			IGraphics::CLineItem aLines[4] = {
-				{s_MouseXStart, s_MouseYStart, UI()->MouseX(), s_MouseYStart},
-				{s_MouseXStart, s_MouseYStart, s_MouseXStart, UI()->MouseY()},
-				{s_MouseXStart, UI()->MouseY(), UI()->MouseX(), UI()->MouseY()},
-				{UI()->MouseX(), s_MouseYStart, UI()->MouseX(), UI()->MouseY()}};
-			UI()->ClipEnable(&View);
+				{s_MouseXStart, s_MouseYStart, Ui()->MouseX(), s_MouseYStart},
+				{s_MouseXStart, s_MouseYStart, s_MouseXStart, Ui()->MouseY()},
+				{s_MouseXStart, Ui()->MouseY(), Ui()->MouseX(), Ui()->MouseY()},
+				{Ui()->MouseX(), s_MouseYStart, Ui()->MouseX(), Ui()->MouseY()}};
+			Ui()->ClipEnable(&View);
 			Graphics()->LinesBegin();
 			Graphics()->LinesDraw(aLines, std::size(aLines));
 			Graphics()->LinesEnd();
-			UI()->ClipDisable();
+			Ui()->ClipDisable();
 
-			if(!UI()->MouseButton(0))
+			if(!Ui()->MouseButton(0))
 			{
 				s_Operation = EEnvelopeEditorOp::OP_NONE;
-				UI()->SetActiveItem(nullptr);
+				Ui()->SetActiveItem(nullptr);
 
 				float TimeStart = ScreenToEnvelopeX(View, s_MouseXStart);
-				float TimeEnd = ScreenToEnvelopeX(View, UI()->MouseX());
+				float TimeEnd = ScreenToEnvelopeX(View, Ui()->MouseX());
 				float ValueStart = ScreenToEnvelopeY(View, s_MouseYStart);
-				float ValueEnd = ScreenToEnvelopeY(View, UI()->MouseY());
+				float ValueEnd = ScreenToEnvelopeY(View, Ui()->MouseY());
 
 				float TimeMin = minimum(TimeStart, TimeEnd);
 				float TimeMax = maximum(TimeStart, TimeEnd);
@@ -7440,7 +7440,7 @@ void CEditor::RenderEditorHistory(CUIRect View)
 	static EHistoryType s_HistoryType = EDITOR_HISTORY;
 	static int s_ActionSelectedIndex = 0;
 	static CListBox s_ListBox;
-	s_ListBox.SetActive(m_Dialog == DIALOG_NONE && !UI()->IsPopupOpen());
+	s_ListBox.SetActive(m_Dialog == DIALOG_NONE && !Ui()->IsPopupOpen());
 
 	const bool GotSelection = s_ListBox.Active() && s_ActionSelectedIndex >= 0 && (size_t)s_ActionSelectedIndex < m_Map.m_vSettings.size();
 
@@ -7486,7 +7486,7 @@ void CEditor::RenderEditorHistory(CUIRect View)
 	InfoProps.m_MaxWidth = ToolBar.w - 60.f;
 	InfoProps.m_EllipsisAtEnd = true;
 	Label.VSplitLeft(8.0f, nullptr, &Label);
-	UI()->DoLabel(&Label, "Editor history. Click on an action to undo all actions above.", 10.0f, TEXTALIGN_ML, InfoProps);
+	Ui()->DoLabel(&Label, "Editor history. Click on an action to undo all actions above.", 10.0f, TEXTALIGN_ML, InfoProps);
 
 	CEditorHistory *pCurrentHistory;
 	if(s_HistoryType == EDITOR_HISTORY)
@@ -7502,7 +7502,7 @@ void CEditor::RenderEditorHistory(CUIRect View)
 	ToolBar.VSplitRight(25.0f, &ToolBar, &Button);
 	ToolBar.VSplitRight(5.0f, &ToolBar, nullptr);
 	static int s_DeleteButton = 0;
-	if(DoButton_FontIcon(&s_DeleteButton, FONT_ICON_TRASH, (!pCurrentHistory->m_vpUndoActions.empty() || !pCurrentHistory->m_vpRedoActions.empty()) ? 0 : -1, &Button, 0, "Clear the history.", IGraphics::CORNER_ALL, 9.0f) == 1 || (GotSelection && CLineInput::GetActiveInput() == nullptr && m_Dialog == DIALOG_NONE && UI()->ConsumeHotkey(CUI::HOTKEY_DELETE)))
+	if(DoButton_FontIcon(&s_DeleteButton, FONT_ICON_TRASH, (!pCurrentHistory->m_vpUndoActions.empty() || !pCurrentHistory->m_vpRedoActions.empty()) ? 0 : -1, &Button, 0, "Clear the history.", IGraphics::CORNER_ALL, 9.0f) == 1 || (GotSelection && CLineInput::GetActiveInput() == nullptr && m_Dialog == DIALOG_NONE && Ui()->ConsumeHotkey(CUi::HOTKEY_DELETE)))
 	{
 		pCurrentHistory->Clear();
 		s_ActionSelectedIndex = 0;
@@ -7527,7 +7527,7 @@ void CEditor::RenderEditorHistory(CUIRect View)
 		Props.m_EllipsisAtEnd = true;
 		TextRender()->TextColor({.5f, .5f, .5f});
 		TextRender()->TextOutlineColor(TextRender()->DefaultTextOutlineColor());
-		UI()->DoLabel(&Label, pCurrentHistory->m_vpRedoActions[i]->DisplayText(), 10.0f, TEXTALIGN_ML, Props);
+		Ui()->DoLabel(&Label, pCurrentHistory->m_vpRedoActions[i]->DisplayText(), 10.0f, TEXTALIGN_ML, Props);
 		TextRender()->TextColor(TextRender()->DefaultTextColor());
 	}
 
@@ -7542,7 +7542,7 @@ void CEditor::RenderEditorHistory(CUIRect View)
 		SLabelProperties Props;
 		Props.m_MaxWidth = Label.w;
 		Props.m_EllipsisAtEnd = true;
-		UI()->DoLabel(&Label, pCurrentHistory->m_vpUndoActions[UndoSize - i - 1]->DisplayText(), 10.0f, TEXTALIGN_ML, Props);
+		Ui()->DoLabel(&Label, pCurrentHistory->m_vpUndoActions[UndoSize - i - 1]->DisplayText(), 10.0f, TEXTALIGN_ML, Props);
 	}
 
 	{ // Base action "Loaded map" that cannot be undone
@@ -7552,7 +7552,7 @@ void CEditor::RenderEditorHistory(CUIRect View)
 		{
 			Item.m_Rect.VMargin(5.0f, &Label);
 
-			UI()->DoLabel(&Label, "Loaded map", 10.0f, TEXTALIGN_ML);
+			Ui()->DoLabel(&Label, "Loaded map", 10.0f, TEXTALIGN_ML);
 		}
 	}
 
@@ -7595,7 +7595,7 @@ void CEditor::DoEditorDragBar(CUIRect View, CUIRect *pDragBar, EDragSide Side, f
 
 	bool IsVertical = Side == EDragSide::SIDE_TOP || Side == EDragSide::SIDE_BOTTOM;
 
-	if(UI()->MouseInside(pDragBar) && UI()->HotItem() == pDragBar)
+	if(Ui()->MouseInside(pDragBar) && Ui()->HotItem() == pDragBar)
 		m_CursorType = IsVertical ? CURSOR_RESIZE_V : CURSOR_RESIZE_H;
 
 	bool Clicked;
@@ -7604,29 +7604,29 @@ void CEditor::DoEditorDragBar(CUIRect View, CUIRect *pDragBar, EDragSide Side, f
 	{
 		if(s_Operation == OP_NONE && Result == 1)
 		{
-			s_InitialMouseY = UI()->MouseY();
-			s_InitialMouseOffsetY = UI()->MouseY() - pDragBar->y;
-			s_InitialMouseX = UI()->MouseX();
-			s_InitialMouseOffsetX = UI()->MouseX() - pDragBar->x;
+			s_InitialMouseY = Ui()->MouseY();
+			s_InitialMouseOffsetY = Ui()->MouseY() - pDragBar->y;
+			s_InitialMouseX = Ui()->MouseX();
+			s_InitialMouseOffsetX = Ui()->MouseX() - pDragBar->x;
 			s_Operation = OP_CLICKED;
 		}
 
 		if(Clicked || Abrupted)
 			s_Operation = OP_NONE;
 
-		if(s_Operation == OP_CLICKED && absolute(IsVertical ? UI()->MouseY() - s_InitialMouseY : UI()->MouseX() - s_InitialMouseX) > 5.0f)
+		if(s_Operation == OP_CLICKED && absolute(IsVertical ? Ui()->MouseY() - s_InitialMouseY : Ui()->MouseX() - s_InitialMouseX) > 5.0f)
 			s_Operation = OP_DRAGGING;
 
 		if(s_Operation == OP_DRAGGING)
 		{
 			if(Side == EDragSide::SIDE_TOP)
-				*pValue = clamp(s_InitialMouseOffsetY + View.y + View.h - UI()->MouseY(), MinValue, MaxValue);
+				*pValue = clamp(s_InitialMouseOffsetY + View.y + View.h - Ui()->MouseY(), MinValue, MaxValue);
 			else if(Side == EDragSide::SIDE_RIGHT)
-				*pValue = clamp(UI()->MouseX() - s_InitialMouseOffsetX - View.x + pDragBar->w, MinValue, MaxValue);
+				*pValue = clamp(Ui()->MouseX() - s_InitialMouseOffsetX - View.x + pDragBar->w, MinValue, MaxValue);
 			else if(Side == EDragSide::SIDE_BOTTOM)
-				*pValue = clamp(UI()->MouseY() - s_InitialMouseOffsetY - View.y + pDragBar->h, MinValue, MaxValue);
+				*pValue = clamp(Ui()->MouseY() - s_InitialMouseOffsetY - View.y + pDragBar->h, MinValue, MaxValue);
 			else if(Side == EDragSide::SIDE_LEFT)
-				*pValue = clamp(s_InitialMouseOffsetX + View.x + View.w - UI()->MouseX(), MinValue, MaxValue);
+				*pValue = clamp(s_InitialMouseOffsetX + View.x + View.w - Ui()->MouseX(), MinValue, MaxValue);
 
 			m_CursorType = IsVertical ? CURSOR_RESIZE_V : CURSOR_RESIZE_H;
 		}
@@ -7644,7 +7644,7 @@ void CEditor::RenderMenubar(CUIRect MenuBar)
 	if(DoButton_Ex(&s_FileButton, "File", 0, &FileButton, 0, nullptr, IGraphics::CORNER_T, EditorFontSizes::MENU, TEXTALIGN_ML))
 	{
 		static SPopupMenuId s_PopupMenuFileId;
-		UI()->DoPopupMenu(&s_PopupMenuFileId, FileButton.x, FileButton.y + FileButton.h - 1.0f, 120.0f, 174.0f, this, PopupMenuFile, PopupProperties);
+		Ui()->DoPopupMenu(&s_PopupMenuFileId, FileButton.x, FileButton.y + FileButton.h - 1.0f, 120.0f, 174.0f, this, PopupMenuFile, PopupProperties);
 	}
 
 	MenuBar.VSplitLeft(5.0f, nullptr, &MenuBar);
@@ -7655,7 +7655,7 @@ void CEditor::RenderMenubar(CUIRect MenuBar)
 	if(DoButton_Ex(&s_ToolsButton, "Tools", 0, &ToolsButton, 0, nullptr, IGraphics::CORNER_T, EditorFontSizes::MENU, TEXTALIGN_ML))
 	{
 		static SPopupMenuId s_PopupMenuToolsId;
-		UI()->DoPopupMenu(&s_PopupMenuToolsId, ToolsButton.x, ToolsButton.y + ToolsButton.h - 1.0f, 200.0f, 64.0f, this, PopupMenuTools, PopupProperties);
+		Ui()->DoPopupMenu(&s_PopupMenuToolsId, ToolsButton.x, ToolsButton.y + ToolsButton.h - 1.0f, 200.0f, 64.0f, this, PopupMenuTools, PopupProperties);
 	}
 
 	MenuBar.VSplitLeft(5.0f, nullptr, &MenuBar);
@@ -7666,7 +7666,7 @@ void CEditor::RenderMenubar(CUIRect MenuBar)
 	if(DoButton_Ex(&s_SettingsButton, "Settings", 0, &SettingsButton, 0, nullptr, IGraphics::CORNER_T, EditorFontSizes::MENU, TEXTALIGN_ML))
 	{
 		static SPopupMenuId s_PopupMenuEntitiesId;
-		UI()->DoPopupMenu(&s_PopupMenuEntitiesId, SettingsButton.x, SettingsButton.y + SettingsButton.h - 1.0f, 200.0f, 92.0f, this, PopupMenuSettings, PopupProperties);
+		Ui()->DoPopupMenu(&s_PopupMenuEntitiesId, SettingsButton.x, SettingsButton.y + SettingsButton.h - 1.0f, 200.0f, 92.0f, this, PopupMenuSettings, PopupProperties);
 	}
 
 	CUIRect ChangedIndicator, Info, Close;
@@ -7681,7 +7681,7 @@ void CEditor::RenderMenubar(CUIRect MenuBar)
 	{
 		TextRender()->SetFontPreset(EFontPreset::ICON_FONT);
 		TextRender()->SetRenderFlags(ETextRenderFlags::TEXT_RENDER_FLAG_ONLY_ADVANCE_WIDTH | ETextRenderFlags::TEXT_RENDER_FLAG_NO_X_BEARING | ETextRenderFlags::TEXT_RENDER_FLAG_NO_Y_BEARING | ETextRenderFlags::TEXT_RENDER_FLAG_NO_PIXEL_ALIGMENT | ETextRenderFlags::TEXT_RENDER_FLAG_NO_OVERSIZE);
-		UI()->DoLabel(&ChangedIndicator, FONT_ICON_CIRCLE, 8.0f, TEXTALIGN_MC);
+		Ui()->DoLabel(&ChangedIndicator, FONT_ICON_CIRCLE, 8.0f, TEXTALIGN_MC);
 		TextRender()->SetRenderFlags(0);
 		TextRender()->SetFontPreset(EFontPreset::DEFAULT_FONT);
 		static int s_ChangedIndicator;
@@ -7693,13 +7693,13 @@ void CEditor::RenderMenubar(CUIRect MenuBar)
 	SLabelProperties Props;
 	Props.m_MaxWidth = MenuBar.w;
 	Props.m_EllipsisAtEnd = true;
-	UI()->DoLabel(&MenuBar, aBuf, 10.0f, TEXTALIGN_ML, Props);
+	Ui()->DoLabel(&MenuBar, aBuf, 10.0f, TEXTALIGN_ML, Props);
 
 	char aTimeStr[6];
 	str_timestamp_format(aTimeStr, sizeof(aTimeStr), "%H:%M");
 
-	str_format(aBuf, sizeof(aBuf), "X: %.1f, Y: %.1f, Z: %.1f, A: %.1f, G: %i  %s", UI()->MouseWorldX() / 32.0f, UI()->MouseWorldY() / 32.0f, MapView()->Zoom()->GetValue(), m_AnimateSpeed, MapView()->MapGrid()->Factor(), aTimeStr);
-	UI()->DoLabel(&Info, aBuf, 10.0f, TEXTALIGN_MR);
+	str_format(aBuf, sizeof(aBuf), "X: %.1f, Y: %.1f, Z: %.1f, A: %.1f, G: %i  %s", Ui()->MouseWorldX() / 32.0f, Ui()->MouseWorldY() / 32.0f, MapView()->Zoom()->GetValue(), m_AnimateSpeed, MapView()->MapGrid()->Factor(), aTimeStr);
+	Ui()->DoLabel(&Info, aBuf, 10.0f, TEXTALIGN_MR);
 
 	static int s_CloseButton = 0;
 	if(DoButton_Editor(&s_CloseButton, "×", 0, &Close, 0, "Exits from the editor"))
@@ -7713,8 +7713,8 @@ void CEditor::Render()
 {
 	// basic start
 	Graphics()->Clear(0.0f, 0.0f, 0.0f);
-	CUIRect View = *UI()->Screen();
-	UI()->MapScreen();
+	CUIRect View = *Ui()->Screen();
+	Ui()->MapScreen();
 	m_CursorType = CURSOR_NORMAL;
 
 	float Width = View.w;
@@ -7907,7 +7907,7 @@ void CEditor::Render()
 			RenderSounds(ToolBox);
 	}
 
-	UI()->MapScreen();
+	Ui()->MapScreen();
 
 	CUIRect TooltipRect;
 	if(m_GuiActive)
@@ -7947,13 +7947,13 @@ void CEditor::Render()
 	if(m_Dialog == DIALOG_FILE)
 	{
 		static int s_NullUiTarget = 0;
-		UI()->SetHotItem(&s_NullUiTarget);
+		Ui()->SetHotItem(&s_NullUiTarget);
 		RenderFileDialog();
 	}
 	else if(m_Dialog == DIALOG_MAPSETTINGS_ERROR)
 	{
 		static int s_NullUiTarget = 0;
-		UI()->SetHotItem(&s_NullUiTarget);
+		Ui()->SetHotItem(&s_NullUiTarget);
 		RenderMapSettingsErrorDialog();
 	}
 
@@ -7962,12 +7962,12 @@ void CEditor::Render()
 		static SPopupMenuId s_PopupEventId;
 		constexpr float PopupWidth = 400.0f;
 		constexpr float PopupHeight = 150.0f;
-		UI()->DoPopupMenu(&s_PopupEventId, Width / 2.0f - PopupWidth / 2.0f, Height / 2.0f - PopupHeight / 2.0f, PopupWidth, PopupHeight, this, PopupEvent);
+		Ui()->DoPopupMenu(&s_PopupEventId, Width / 2.0f - PopupWidth / 2.0f, Height / 2.0f - PopupHeight / 2.0f, PopupWidth, PopupHeight, this, PopupEvent);
 		m_PopupEventActivated = false;
 		m_PopupEventWasActivated = true;
 	}
 
-	if(m_Dialog == DIALOG_NONE && !UI()->IsPopupHovered() && UI()->MouseInside(&View))
+	if(m_Dialog == DIALOG_NONE && !Ui()->IsPopupHovered() && Ui()->MouseInside(&View))
 	{
 		// handle zoom hotkeys
 		if(Input()->KeyPress(KEY_KP_MINUS))
@@ -8012,17 +8012,17 @@ void CEditor::Render()
 	MapView()->UpdateZoom();
 
 	// Cancel color pipette with escape before closing popup menus with escape
-	if(m_ColorPipetteActive && UI()->ConsumeHotkey(CUI::HOTKEY_ESCAPE))
+	if(m_ColorPipetteActive && Ui()->ConsumeHotkey(CUi::HOTKEY_ESCAPE))
 	{
 		m_ColorPipetteActive = false;
 	}
 
-	UI()->RenderPopupMenus();
+	Ui()->RenderPopupMenus();
 	FreeDynamicPopupMenus();
 
 	UpdateColorPipette();
 
-	if(m_Dialog == DIALOG_NONE && !m_PopupEventActivated && UI()->ConsumeHotkey(CUI::HOTKEY_ESCAPE))
+	if(m_Dialog == DIALOG_NONE && !m_PopupEventActivated && Ui()->ConsumeHotkey(CUi::HOTKEY_ESCAPE))
 	{
 		OnClose();
 		g_Config.m_ClEditor = 0;
@@ -8040,7 +8040,7 @@ void CEditor::RenderPressedKeys(CUIRect View)
 	if(!g_Config.m_EdShowkeys)
 		return;
 
-	UI()->MapScreen();
+	Ui()->MapScreen();
 	CTextCursor Cursor;
 	TextRender()->SetCursor(&Cursor, View.x + 10, View.y + View.h - 24 - 10, 24.0f, TEXTFLAG_RENDER);
 
@@ -8065,14 +8065,14 @@ void CEditor::RenderSavingIndicator(CUIRect View)
 	const char *pText = "Saving…";
 	const float FontSize = 24.0f;
 
-	UI()->MapScreen();
+	Ui()->MapScreen();
 	CUIRect Label, Spinner;
 	View.Margin(20.0f, &View);
 	View.HSplitBottom(FontSize, nullptr, &View);
 	View.VSplitRight(TextRender()->TextWidth(FontSize, pText) + 2.0f, &Spinner, &Label);
 	Spinner.VSplitRight(Spinner.h, nullptr, &Spinner);
-	UI()->DoLabel(&Label, pText, FontSize, TEXTALIGN_MR);
-	UI()->RenderProgressSpinner(Spinner.Center(), 8.0f);
+	Ui()->DoLabel(&Label, pText, FontSize, TEXTALIGN_MR);
+	Ui()->RenderProgressSpinner(Spinner.Center(), 8.0f);
 }
 
 void CEditor::FreeDynamicPopupMenus()
@@ -8080,9 +8080,9 @@ void CEditor::FreeDynamicPopupMenus()
 	auto Iterator = m_PopupMessageContexts.begin();
 	while(Iterator != m_PopupMessageContexts.end())
 	{
-		if(!UI()->IsPopupOpen(Iterator->second))
+		if(!Ui()->IsPopupOpen(Iterator->second))
 		{
-			CUI::SMessagePopupContext *pContext = Iterator->second;
+			CUi::SMessagePopupContext *pContext = Iterator->second;
 			Iterator = m_PopupMessageContexts.erase(Iterator);
 			delete pContext;
 		}
@@ -8097,17 +8097,17 @@ void CEditor::UpdateColorPipette()
 		return;
 
 	static char s_PipetteScreenButton;
-	if(UI()->HotItem() == &s_PipetteScreenButton)
+	if(Ui()->HotItem() == &s_PipetteScreenButton)
 	{
 		// Read color one pixel to the top and left as we would otherwise not read the correct
 		// color due to the cursor sprite being rendered over the current mouse position.
-		const int PixelX = clamp<int>(round_to_int((UI()->MouseX() - 1.0f) / UI()->Screen()->w * Graphics()->ScreenWidth()), 0, Graphics()->ScreenWidth() - 1);
-		const int PixelY = clamp<int>(round_to_int((UI()->MouseY() - 1.0f) / UI()->Screen()->h * Graphics()->ScreenHeight()), 0, Graphics()->ScreenHeight() - 1);
+		const int PixelX = clamp<int>(round_to_int((Ui()->MouseX() - 1.0f) / Ui()->Screen()->w * Graphics()->ScreenWidth()), 0, Graphics()->ScreenWidth() - 1);
+		const int PixelY = clamp<int>(round_to_int((Ui()->MouseY() - 1.0f) / Ui()->Screen()->h * Graphics()->ScreenHeight()), 0, Graphics()->ScreenHeight() - 1);
 		Graphics()->ReadPixel(ivec2(PixelX, PixelY), &m_PipetteColor);
 	}
 
 	// Simulate button overlaying the entire screen to intercept all clicks for color pipette.
-	const int ButtonResult = DoButton_Editor_Common(&s_PipetteScreenButton, "", 0, UI()->Screen(), 0, "Left click to pick a color from the screen. Right click to cancel pipette mode.");
+	const int ButtonResult = DoButton_Editor_Common(&s_PipetteScreenButton, "", 0, Ui()->Screen(), 0, "Left click to pick a color from the screen. Right click to cancel pipette mode.");
 	// Don't handle clicks if we are panning, so the pipette stays active while panning.
 	// Checking m_pContainerPanned alone is not enough, as this variable is reset when
 	// panning ends before this function is called.
@@ -8158,12 +8158,12 @@ void CEditor::RenderMousePointer()
 	{
 		Graphics()->QuadsSetRotation(pi / 2.0f);
 	}
-	if(ms_pUiGotContext == UI()->HotItem())
+	if(ms_pUiGotContext == Ui()->HotItem())
 	{
 		Graphics()->SetColor(1.0f, 0.0f, 0.0f, 1.0f);
 	}
 	const float CursorOffset = m_CursorType == CURSOR_RESIZE_V || m_CursorType == CURSOR_RESIZE_H ? -CursorSize / 2.0f : 0.0f;
-	IGraphics::CQuadItem QuadItem(UI()->MouseX() + CursorOffset, UI()->MouseY() + CursorOffset, CursorSize, CursorSize);
+	IGraphics::CQuadItem QuadItem(Ui()->MouseX() + CursorOffset, Ui()->MouseY() + CursorOffset, CursorSize, CursorSize);
 	Graphics()->QuadsDrawTL(&QuadItem, 1);
 	Graphics()->QuadsEnd();
 	Graphics()->WrapNormal();
@@ -8171,14 +8171,14 @@ void CEditor::RenderMousePointer()
 	// Pipette color
 	if(m_ColorPipetteActive)
 	{
-		CUIRect PipetteRect = {UI()->MouseX() + CursorSize, UI()->MouseY() + CursorSize, 80.0f, 20.0f};
-		if(PipetteRect.x + PipetteRect.w + 2.0f > UI()->Screen()->w)
+		CUIRect PipetteRect = {Ui()->MouseX() + CursorSize, Ui()->MouseY() + CursorSize, 80.0f, 20.0f};
+		if(PipetteRect.x + PipetteRect.w + 2.0f > Ui()->Screen()->w)
 		{
-			PipetteRect.x = UI()->MouseX() - PipetteRect.w - CursorSize / 2.0f;
+			PipetteRect.x = Ui()->MouseX() - PipetteRect.w - CursorSize / 2.0f;
 		}
-		if(PipetteRect.y + PipetteRect.h + 2.0f > UI()->Screen()->h)
+		if(PipetteRect.y + PipetteRect.h + 2.0f > Ui()->Screen()->h)
 		{
-			PipetteRect.y = UI()->MouseY() - PipetteRect.h - CursorSize / 2.0f;
+			PipetteRect.y = Ui()->MouseY() - PipetteRect.h - CursorSize / 2.0f;
 		}
 		PipetteRect.Draw(ColorRGBA(0.2f, 0.2f, 0.2f, 0.7f), IGraphics::CORNER_ALL, 3.0f);
 
@@ -8189,13 +8189,13 @@ void CEditor::RenderMousePointer()
 
 		char aLabel[8];
 		str_format(aLabel, sizeof(aLabel), "#%06X", m_PipetteColor.PackAlphaLast(false));
-		UI()->DoLabel(&Label, aLabel, 10.0f, TEXTALIGN_MC);
+		Ui()->DoLabel(&Label, aLabel, 10.0f, TEXTALIGN_MC);
 	}
 }
 
 void CEditor::Reset(bool CreateDefault)
 {
-	UI()->ClosePopupMenus();
+	Ui()->ClosePopupMenus();
 	m_Map.Clean();
 
 	for(CEditorComponent &Component : m_vComponents)
@@ -8372,20 +8372,20 @@ void CEditor::HandleCursorMovement()
 	float MouseRelX = 0.0f, MouseRelY = 0.0f;
 	IInput::ECursorType CursorType = Input()->CursorRelative(&MouseRelX, &MouseRelY);
 	if(CursorType != IInput::CURSOR_NONE)
-		UI()->ConvertMouseMove(&MouseRelX, &MouseRelY, CursorType);
+		Ui()->ConvertMouseMove(&MouseRelX, &MouseRelY, CursorType);
 
 	m_MouseDeltaX += MouseRelX;
 	m_MouseDeltaY += MouseRelY;
 
-	if(!UI()->CheckMouseLock())
+	if(!Ui()->CheckMouseLock())
 	{
 		s_MouseX = clamp(s_MouseX + MouseRelX, 0.0f, Graphics()->WindowWidth() - 1.0f);
 		s_MouseY = clamp(s_MouseY + MouseRelY, 0.0f, Graphics()->WindowHeight() - 1.0f);
 	}
 
 	// update positions for ui, but only update ui when rendering
-	m_MouseX = UI()->Screen()->w * ((float)s_MouseX / Graphics()->WindowWidth());
-	m_MouseY = UI()->Screen()->h * ((float)s_MouseY / Graphics()->WindowHeight());
+	m_MouseX = Ui()->Screen()->w * ((float)s_MouseX / Graphics()->WindowWidth());
+	m_MouseY = Ui()->Screen()->h * ((float)s_MouseY / Graphics()->WindowHeight());
 
 	// fix correct world x and y
 	std::shared_ptr<CLayerGroup> pGroup = GetSelectedGroup();
@@ -8473,7 +8473,7 @@ void CEditor::OnMouseMove(float MouseX, float MouseY)
 					g, l, x, y, Tile));
 		}
 	}
-	UI()->MapScreen();
+	Ui()->MapScreen();
 }
 
 void CEditor::DispatchInputEvents()
@@ -8483,7 +8483,7 @@ void CEditor::DispatchInputEvents()
 		const IInput::CEvent &Event = Input()->GetEvent(i);
 		if(!Input()->IsEventValid(Event))
 			continue;
-		UI()->OnInput(Event);
+		Ui()->OnInput(Event);
 	}
 }
 
@@ -8607,7 +8607,7 @@ void CEditor::HandleWriterFinishJobs()
 
 void CEditor::OnUpdate()
 {
-	CUIElementBase::Init(UI()); // update static pointer because game and editor use separate UI
+	CUIElementBase::Init(Ui()); // update static pointer because game and editor use separate UI
 
 	if(!m_EditorWasUsedBefore)
 	{
@@ -8642,7 +8642,7 @@ void CEditor::OnUpdate()
 
 void CEditor::OnRender()
 {
-	UI()->ResetMouseSlow();
+	Ui()->ResetMouseSlow();
 
 	// toggle gui
 	if(m_Dialog == DIALOG_NONE && CLineInput::GetActiveInput() == nullptr && Input()->KeyPress(KEY_TAB))
@@ -8657,9 +8657,9 @@ void CEditor::OnRender()
 		m_AnimateTime = 0;
 
 	ms_pUiGotContext = nullptr;
-	UI()->StartCheck();
+	Ui()->StartCheck();
 
-	UI()->Update(m_MouseX, m_MouseY, m_MouseDeltaX, m_MouseDeltaY, m_MouseWorldX, m_MouseWorldY);
+	Ui()->Update(m_MouseX, m_MouseY, m_MouseDeltaX, m_MouseDeltaY, m_MouseWorldX, m_MouseWorldY);
 
 	Render();
 
@@ -8674,8 +8674,8 @@ void CEditor::OnRender()
 		m_ShowMousePointer = true;
 	}
 
-	UI()->FinishCheck();
-	UI()->ClearHotkeys();
+	Ui()->FinishCheck();
+	Ui()->ClearHotkeys();
 	Input()->Clear();
 
 	CLineInput::RenderCandidates();
@@ -8689,7 +8689,7 @@ void CEditor::OnActivate()
 
 void CEditor::OnWindowResize()
 {
-	UI()->OnWindowResize();
+	Ui()->OnWindowResize();
 }
 
 void CEditor::OnClose()

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -274,7 +274,7 @@ class CEditor : public IEditor
 	class ISound *m_pSound = nullptr;
 	class IStorage *m_pStorage = nullptr;
 	CRenderTools m_RenderTools;
-	CUI m_UI;
+	CUi m_UI;
 
 	std::vector<std::reference_wrapper<CEditorComponent>> m_vComponents;
 	CMapView m_MapView;
@@ -313,7 +313,7 @@ public:
 	class ISound *Sound() const { return m_pSound; }
 	class ITextRender *TextRender() const { return m_pTextRender; }
 	class IStorage *Storage() const { return m_pStorage; }
-	CUI *UI() { return &m_UI; }
+	CUi *Ui() { return &m_UI; }
 	CRenderTools *RenderTools() { return &m_RenderTools; }
 
 	CMapView *MapView() { return &m_MapView; }
@@ -482,7 +482,7 @@ public:
 			return str_comp(pLhs, pRhs) < 0;
 		}
 	};
-	std::map<const char *, CUI::SMessagePopupContext *, SStringKeyComparator> m_PopupMessageContexts;
+	std::map<const char *, CUi::SMessagePopupContext *, SStringKeyComparator> m_PopupMessageContexts;
 	void ShowFileDialogError(const char *pFormat, ...)
 		GNUC_ATTRIBUTE((format(printf, 2, 3)));
 
@@ -536,12 +536,12 @@ public:
 	std::pair<int, int> EnvGetSelectedTimeAndValue() const;
 
 	template<typename E>
-	SEditResult<E> DoPropertiesWithState(CUIRect *pToolbox, CProperty *pProps, int *pIDs, int *pNewVal, const std::vector<ColorRGBA> &vColors = {});
-	int DoProperties(CUIRect *pToolbox, CProperty *pProps, int *pIDs, int *pNewVal, const std::vector<ColorRGBA> &vColors = {});
+	SEditResult<E> DoPropertiesWithState(CUIRect *pToolbox, CProperty *pProps, int *pIds, int *pNewVal, const std::vector<ColorRGBA> &vColors = {});
+	int DoProperties(CUIRect *pToolbox, CProperty *pProps, int *pIds, int *pNewVal, const std::vector<ColorRGBA> &vColors = {});
 
-	CUI::SColorPickerPopupContext m_ColorPickerPopupContext;
-	const void *m_pColorPickerPopupActiveID = nullptr;
-	void DoColorPickerButton(const void *pID, const CUIRect *pRect, ColorRGBA Color, const std::function<void(ColorRGBA Color)> &SetColor);
+	CUi::SColorPickerPopupContext m_ColorPickerPopupContext;
+	const void *m_pColorPickerPopupActiveId = nullptr;
+	void DoColorPickerButton(const void *pId, const CUIRect *pRect, ColorRGBA Color, const std::function<void(ColorRGBA Color)> &SetColor);
 
 	int m_Mode;
 	int m_Dialog;
@@ -822,16 +822,16 @@ public:
 
 	void PlaceBorderTiles();
 
-	void UpdateTooltip(const void *pID, const CUIRect *pRect, const char *pToolTip);
-	int DoButton_Editor_Common(const void *pID, const char *pText, int Checked, const CUIRect *pRect, int Flags, const char *pToolTip);
-	int DoButton_Editor(const void *pID, const char *pText, int Checked, const CUIRect *pRect, int Flags, const char *pToolTip);
-	int DoButton_Env(const void *pID, const char *pText, int Checked, const CUIRect *pRect, const char *pToolTip, ColorRGBA Color, int Corners);
+	void UpdateTooltip(const void *pId, const CUIRect *pRect, const char *pToolTip);
+	int DoButton_Editor_Common(const void *pId, const char *pText, int Checked, const CUIRect *pRect, int Flags, const char *pToolTip);
+	int DoButton_Editor(const void *pId, const char *pText, int Checked, const CUIRect *pRect, int Flags, const char *pToolTip);
+	int DoButton_Env(const void *pId, const char *pText, int Checked, const CUIRect *pRect, const char *pToolTip, ColorRGBA Color, int Corners);
 
-	int DoButton_Ex(const void *pID, const char *pText, int Checked, const CUIRect *pRect, int Flags, const char *pToolTip, int Corners, float FontSize = EditorFontSizes::MENU, int Align = TEXTALIGN_MC);
-	int DoButton_FontIcon(const void *pID, const char *pText, int Checked, const CUIRect *pRect, int Flags, const char *pToolTip, int Corners, float FontSize = 10.0f);
-	int DoButton_MenuItem(const void *pID, const char *pText, int Checked, const CUIRect *pRect, int Flags = 0, const char *pToolTip = nullptr);
+	int DoButton_Ex(const void *pId, const char *pText, int Checked, const CUIRect *pRect, int Flags, const char *pToolTip, int Corners, float FontSize = EditorFontSizes::MENU, int Align = TEXTALIGN_MC);
+	int DoButton_FontIcon(const void *pId, const char *pText, int Checked, const CUIRect *pRect, int Flags, const char *pToolTip, int Corners, float FontSize = 10.0f);
+	int DoButton_MenuItem(const void *pId, const char *pText, int Checked, const CUIRect *pRect, int Flags = 0, const char *pToolTip = nullptr);
 
-	int DoButton_DraggableEx(const void *pID, const char *pText, int Checked, const CUIRect *pRect, bool *pClicked, bool *pAbrupted, int Flags, const char *pToolTip = nullptr, int Corners = IGraphics::CORNER_ALL, float FontSize = 10.0f);
+	int DoButton_DraggableEx(const void *pId, const char *pText, int Checked, const CUIRect *pRect, bool *pClicked, bool *pAbrupted, int Flags, const char *pToolTip = nullptr, int Corners = IGraphics::CORNER_ALL, float FontSize = 10.0f);
 
 	bool DoEditBox(CLineInput *pLineInput, const CUIRect *pRect, float FontSize, int Corners = IGraphics::CORNER_ALL, const char *pToolTip = nullptr, const std::vector<STextColorSplit> &vColorSplits = {});
 	bool DoClearableEditBox(CLineInput *pLineInput, const CUIRect *pRect, float FontSize, int Corners = IGraphics::CORNER_ALL, const char *pToolTip = nullptr, const std::vector<STextColorSplit> &vColorSplits = {});
@@ -845,12 +845,12 @@ public:
 
 	void RenderBackground(CUIRect View, IGraphics::CTextureHandle Texture, float Size, float Brightness) const;
 
-	SEditResult<int> UiDoValueSelector(void *pID, CUIRect *pRect, const char *pLabel, int Current, int Min, int Max, int Step, float Scale, const char *pToolTip, bool IsDegree = false, bool IsHex = false, int corners = IGraphics::CORNER_ALL, const ColorRGBA *pColor = nullptr, bool ShowValue = true);
+	SEditResult<int> UiDoValueSelector(void *pId, CUIRect *pRect, const char *pLabel, int Current, int Min, int Max, int Step, float Scale, const char *pToolTip, bool IsDegree = false, bool IsHex = false, int corners = IGraphics::CORNER_ALL, const ColorRGBA *pColor = nullptr, bool ShowValue = true);
 
-	static CUI::EPopupMenuFunctionResult PopupMenuFile(void *pContext, CUIRect View, bool Active);
-	static CUI::EPopupMenuFunctionResult PopupMenuTools(void *pContext, CUIRect View, bool Active);
-	static CUI::EPopupMenuFunctionResult PopupMenuSettings(void *pContext, CUIRect View, bool Active);
-	static CUI::EPopupMenuFunctionResult PopupGroup(void *pContext, CUIRect View, bool Active);
+	static CUi::EPopupMenuFunctionResult PopupMenuFile(void *pContext, CUIRect View, bool Active);
+	static CUi::EPopupMenuFunctionResult PopupMenuTools(void *pContext, CUIRect View, bool Active);
+	static CUi::EPopupMenuFunctionResult PopupMenuSettings(void *pContext, CUIRect View, bool Active);
+	static CUi::EPopupMenuFunctionResult PopupGroup(void *pContext, CUIRect View, bool Active);
 	struct SLayerPopupContext : public SPopupMenuId
 	{
 		CEditor *m_pEditor;
@@ -858,30 +858,30 @@ public:
 		std::vector<int> m_vLayerIndices;
 		CLayerTiles::SCommonPropState m_CommonPropState;
 	};
-	static CUI::EPopupMenuFunctionResult PopupLayer(void *pContext, CUIRect View, bool Active);
-	static CUI::EPopupMenuFunctionResult PopupQuad(void *pContext, CUIRect View, bool Active);
-	static CUI::EPopupMenuFunctionResult PopupSource(void *pContext, CUIRect View, bool Active);
-	static CUI::EPopupMenuFunctionResult PopupPoint(void *pContext, CUIRect View, bool Active);
-	static CUI::EPopupMenuFunctionResult PopupEnvPoint(void *pContext, CUIRect View, bool Active);
-	static CUI::EPopupMenuFunctionResult PopupEnvPointMulti(void *pContext, CUIRect View, bool Active);
-	static CUI::EPopupMenuFunctionResult PopupEnvPointCurveType(void *pContext, CUIRect View, bool Active);
-	static CUI::EPopupMenuFunctionResult PopupImage(void *pContext, CUIRect View, bool Active);
-	static CUI::EPopupMenuFunctionResult PopupSound(void *pContext, CUIRect View, bool Active);
-	static CUI::EPopupMenuFunctionResult PopupNewFolder(void *pContext, CUIRect View, bool Active);
-	static CUI::EPopupMenuFunctionResult PopupMapInfo(void *pContext, CUIRect View, bool Active);
-	static CUI::EPopupMenuFunctionResult PopupEvent(void *pContext, CUIRect View, bool Active);
-	static CUI::EPopupMenuFunctionResult PopupSelectImage(void *pContext, CUIRect View, bool Active);
-	static CUI::EPopupMenuFunctionResult PopupSelectSound(void *pContext, CUIRect View, bool Active);
-	static CUI::EPopupMenuFunctionResult PopupSelectGametileOp(void *pContext, CUIRect View, bool Active);
-	static CUI::EPopupMenuFunctionResult PopupSelectConfigAutoMap(void *pContext, CUIRect View, bool Active);
-	static CUI::EPopupMenuFunctionResult PopupTele(void *pContext, CUIRect View, bool Active);
-	static CUI::EPopupMenuFunctionResult PopupSpeedup(void *pContext, CUIRect View, bool Active);
-	static CUI::EPopupMenuFunctionResult PopupSwitch(void *pContext, CUIRect View, bool Active);
-	static CUI::EPopupMenuFunctionResult PopupTune(void *pContext, CUIRect View, bool Active);
-	static CUI::EPopupMenuFunctionResult PopupGoto(void *pContext, CUIRect View, bool Active);
-	static CUI::EPopupMenuFunctionResult PopupEntities(void *pContext, CUIRect View, bool Active);
-	static CUI::EPopupMenuFunctionResult PopupProofMode(void *pContext, CUIRect View, bool Active);
-	static CUI::EPopupMenuFunctionResult PopupAnimateSettings(void *pContext, CUIRect View, bool Active);
+	static CUi::EPopupMenuFunctionResult PopupLayer(void *pContext, CUIRect View, bool Active);
+	static CUi::EPopupMenuFunctionResult PopupQuad(void *pContext, CUIRect View, bool Active);
+	static CUi::EPopupMenuFunctionResult PopupSource(void *pContext, CUIRect View, bool Active);
+	static CUi::EPopupMenuFunctionResult PopupPoint(void *pContext, CUIRect View, bool Active);
+	static CUi::EPopupMenuFunctionResult PopupEnvPoint(void *pContext, CUIRect View, bool Active);
+	static CUi::EPopupMenuFunctionResult PopupEnvPointMulti(void *pContext, CUIRect View, bool Active);
+	static CUi::EPopupMenuFunctionResult PopupEnvPointCurveType(void *pContext, CUIRect View, bool Active);
+	static CUi::EPopupMenuFunctionResult PopupImage(void *pContext, CUIRect View, bool Active);
+	static CUi::EPopupMenuFunctionResult PopupSound(void *pContext, CUIRect View, bool Active);
+	static CUi::EPopupMenuFunctionResult PopupNewFolder(void *pContext, CUIRect View, bool Active);
+	static CUi::EPopupMenuFunctionResult PopupMapInfo(void *pContext, CUIRect View, bool Active);
+	static CUi::EPopupMenuFunctionResult PopupEvent(void *pContext, CUIRect View, bool Active);
+	static CUi::EPopupMenuFunctionResult PopupSelectImage(void *pContext, CUIRect View, bool Active);
+	static CUi::EPopupMenuFunctionResult PopupSelectSound(void *pContext, CUIRect View, bool Active);
+	static CUi::EPopupMenuFunctionResult PopupSelectGametileOp(void *pContext, CUIRect View, bool Active);
+	static CUi::EPopupMenuFunctionResult PopupSelectConfigAutoMap(void *pContext, CUIRect View, bool Active);
+	static CUi::EPopupMenuFunctionResult PopupTele(void *pContext, CUIRect View, bool Active);
+	static CUi::EPopupMenuFunctionResult PopupSpeedup(void *pContext, CUIRect View, bool Active);
+	static CUi::EPopupMenuFunctionResult PopupSwitch(void *pContext, CUIRect View, bool Active);
+	static CUi::EPopupMenuFunctionResult PopupTune(void *pContext, CUIRect View, bool Active);
+	static CUi::EPopupMenuFunctionResult PopupGoto(void *pContext, CUIRect View, bool Active);
+	static CUi::EPopupMenuFunctionResult PopupEntities(void *pContext, CUIRect View, bool Active);
+	static CUi::EPopupMenuFunctionResult PopupProofMode(void *pContext, CUIRect View, bool Active);
+	static CUi::EPopupMenuFunctionResult PopupAnimateSettings(void *pContext, CUIRect View, bool Active);
 
 	static bool CallbackOpenMap(const char *pFileName, int StorageType, void *pUser);
 	static bool CallbackAppendMap(const char *pFileName, int StorageType, void *pUser);
@@ -942,7 +942,7 @@ public:
 	EAxis GetDragAxis(int OffsetX, int OffsetY) const;
 	void DrawAxis(EAxis Axis, CPoint &OriginalPoint, CPoint &Point) const;
 	void DrawAABB(const SAxisAlignedBoundingBox &AABB, int OffsetX = 0, int OffsetY = 0) const;
-	ColorRGBA GetButtonColor(const void *pID, int Checked);
+	ColorRGBA GetButtonColor(const void *pId, int Checked);
 
 	// Alignment methods
 	// These methods take `OffsetX` and `OffsetY` because the calculations are made with the original positions
@@ -1015,7 +1015,7 @@ public:
 	void SelectGameLayer();
 	std::vector<int> SortImages();
 
-	void DoAudioPreview(CUIRect View, const void *pPlayPauseButtonID, const void *pStopButtonID, const void *pSeekBarID, const int SampleID);
+	void DoAudioPreview(CUIRect View, const void *pPlayPauseButtonId, const void *pStopButtonId, const void *pSeekBarId, const int SampleId);
 
 	// Tile Numbers For Explanations - TODO: Add/Improve tiles and explanations
 	enum

--- a/src/game/editor/editor_object.cpp
+++ b/src/game/editor/editor_object.cpp
@@ -28,37 +28,37 @@ void CEditorObject::OnMapLoad() {}
 
 bool CEditorObject::IsHot()
 {
-	return UI()->HotItem() == this;
+	return Ui()->HotItem() == this;
 }
 
 void CEditorObject::SetHot()
 {
-	UI()->SetHotItem(this);
+	Ui()->SetHotItem(this);
 }
 
 void CEditorObject::UnsetHot()
 {
 	if(IsHot())
-		UI()->SetHotItem(nullptr);
+		Ui()->SetHotItem(nullptr);
 }
 
 void CEditorObject::OnHot() {}
 
 bool CEditorObject::IsActive()
 {
-	return UI()->CheckActiveItem(this);
+	return Ui()->CheckActiveItem(this);
 }
 
 void CEditorObject::SetActive()
 {
 	SetHot();
-	UI()->SetActiveItem(this);
+	Ui()->SetActiveItem(this);
 }
 
 void CEditorObject::SetInactive()
 {
 	if(IsActive())
-		UI()->SetActiveItem(nullptr);
+		Ui()->SetActiveItem(nullptr);
 }
 
 void CEditorObject::OnActive() {}
@@ -74,5 +74,5 @@ IGraphics *CEditorObject::Graphics() { return m_pEditor->Graphics(); }
 ISound *CEditorObject::Sound() { return m_pEditor->Sound(); }
 ITextRender *CEditorObject::TextRender() { return m_pEditor->TextRender(); }
 IStorage *CEditorObject::Storage() { return m_pEditor->Storage(); }
-CUI *CEditorObject::UI() { return m_pEditor->UI(); }
+CUi *CEditorObject::Ui() { return m_pEditor->Ui(); }
 CRenderTools *CEditorObject::RenderTools() { return m_pEditor->RenderTools(); }

--- a/src/game/editor/editor_object.h
+++ b/src/game/editor/editor_object.h
@@ -6,7 +6,7 @@
 #include <engine/input.h>
 #include <game/client/ui_rect.h>
 
-class CUI;
+class CUi;
 class CEditor;
 class IClient;
 class CConfig;
@@ -75,7 +75,7 @@ public:
 	ISound *Sound();
 	ITextRender *TextRender();
 	IStorage *Storage();
-	CUI *UI();
+	CUi *Ui();
 	CRenderTools *RenderTools();
 
 private:

--- a/src/game/editor/editor_props.cpp
+++ b/src/game/editor/editor_props.cpp
@@ -9,14 +9,14 @@ using namespace FontIcons;
 
 const ColorRGBA CEditor::ms_DefaultPropColor = ColorRGBA(1, 1, 1, 0.5f);
 
-int CEditor::DoProperties(CUIRect *pToolbox, CProperty *pProps, int *pIDs, int *pNewVal, const std::vector<ColorRGBA> &vColors)
+int CEditor::DoProperties(CUIRect *pToolbox, CProperty *pProps, int *pIds, int *pNewVal, const std::vector<ColorRGBA> &vColors)
 {
-	auto Res = DoPropertiesWithState<int>(pToolbox, pProps, pIDs, pNewVal, vColors);
+	auto Res = DoPropertiesWithState<int>(pToolbox, pProps, pIds, pNewVal, vColors);
 	return Res.m_Value;
 }
 
 template<typename E>
-SEditResult<E> CEditor::DoPropertiesWithState(CUIRect *pToolBox, CProperty *pProps, int *pIDs, int *pNewVal, const std::vector<ColorRGBA> &vColors)
+SEditResult<E> CEditor::DoPropertiesWithState(CUIRect *pToolBox, CProperty *pProps, int *pIds, int *pNewVal, const std::vector<ColorRGBA> &vColors)
 {
 	int Change = -1;
 	EEditState State = EEditState::EDITING;
@@ -30,7 +30,7 @@ SEditResult<E> CEditor::DoPropertiesWithState(CUIRect *pToolBox, CProperty *pPro
 		CUIRect Label, Shifter;
 		Slot.VSplitMid(&Label, &Shifter);
 		Shifter.HMargin(1.0f, &Shifter);
-		UI()->DoLabel(&Label, pProps[i].m_pName, 10.0f, TEXTALIGN_ML);
+		Ui()->DoLabel(&Label, pProps[i].m_pName, 10.0f, TEXTALIGN_ML);
 
 		if(pProps[i].m_Type == PROPTYPE_INT)
 		{
@@ -40,7 +40,7 @@ SEditResult<E> CEditor::DoPropertiesWithState(CUIRect *pToolBox, CProperty *pPro
 			Shifter.VSplitRight(10.0f, &Shifter, &Inc);
 			Shifter.VSplitLeft(10.0f, &Dec, &Shifter);
 			str_from_int(pProps[i].m_Value, aBuf);
-			auto NewValueRes = UiDoValueSelector((char *)&pIDs[i], &Shifter, "", pProps[i].m_Value, pProps[i].m_Min, pProps[i].m_Max, 1, 1.0f, "Use left mouse button to drag and change the value. Hold shift to be more precise. Rightclick to edit as text.", false, false, 0, pColor);
+			auto NewValueRes = UiDoValueSelector((char *)&pIds[i], &Shifter, "", pProps[i].m_Value, pProps[i].m_Min, pProps[i].m_Max, 1, 1.0f, "Use left mouse button to drag and change the value. Hold shift to be more precise. Rightclick to edit as text.", false, false, 0, pColor);
 			int NewValue = NewValueRes.m_Value;
 			if(NewValue != pProps[i].m_Value || NewValueRes.m_State != EEditState::EDITING)
 			{
@@ -48,13 +48,13 @@ SEditResult<E> CEditor::DoPropertiesWithState(CUIRect *pToolBox, CProperty *pPro
 				Change = i;
 				State = NewValueRes.m_State;
 			}
-			if(DoButton_FontIcon((char *)&pIDs[i] + 1, FONT_ICON_MINUS, 0, &Dec, 0, "Decrease", IGraphics::CORNER_L, 7.0f))
+			if(DoButton_FontIcon((char *)&pIds[i] + 1, FONT_ICON_MINUS, 0, &Dec, 0, "Decrease", IGraphics::CORNER_L, 7.0f))
 			{
 				*pNewVal = pProps[i].m_Value - 1;
 				Change = i;
 				State = EEditState::ONE_GO;
 			}
-			if(DoButton_FontIcon(((char *)&pIDs[i]) + 2, FONT_ICON_PLUS, 0, &Inc, 0, "Increase", IGraphics::CORNER_R, 7.0f))
+			if(DoButton_FontIcon(((char *)&pIds[i]) + 2, FONT_ICON_PLUS, 0, &Inc, 0, "Increase", IGraphics::CORNER_R, 7.0f))
 			{
 				*pNewVal = pProps[i].m_Value + 1;
 				Change = i;
@@ -65,13 +65,13 @@ SEditResult<E> CEditor::DoPropertiesWithState(CUIRect *pToolBox, CProperty *pPro
 		{
 			CUIRect No, Yes;
 			Shifter.VSplitMid(&No, &Yes);
-			if(DoButton_Ex(&pIDs[i], "No", !pProps[i].m_Value, &No, 0, "", IGraphics::CORNER_L))
+			if(DoButton_Ex(&pIds[i], "No", !pProps[i].m_Value, &No, 0, "", IGraphics::CORNER_L))
 			{
 				*pNewVal = 0;
 				Change = i;
 				State = EEditState::ONE_GO;
 			}
-			if(DoButton_Ex(((char *)&pIDs[i]) + 1, "Yes", pProps[i].m_Value, &Yes, 0, "", IGraphics::CORNER_R))
+			if(DoButton_Ex(((char *)&pIds[i]) + 1, "Yes", pProps[i].m_Value, &Yes, 0, "", IGraphics::CORNER_R))
 			{
 				*pNewVal = 1;
 				Change = i;
@@ -87,16 +87,16 @@ SEditResult<E> CEditor::DoPropertiesWithState(CUIRect *pToolBox, CProperty *pPro
 			int Step = Shift ? 1 : 45;
 			int Value = pProps[i].m_Value;
 
-			auto NewValueRes = UiDoValueSelector(&pIDs[i], &Shifter, "", Value, pProps[i].m_Min, pProps[i].m_Max, Shift ? 1 : 45, Shift ? 1.0f : 10.0f, "Use left mouse button to drag and change the value. Hold shift to be more precise. Rightclick to edit as text.", false, false, 0);
+			auto NewValueRes = UiDoValueSelector(&pIds[i], &Shifter, "", Value, pProps[i].m_Min, pProps[i].m_Max, Shift ? 1 : 45, Shift ? 1.0f : 10.0f, "Use left mouse button to drag and change the value. Hold shift to be more precise. Rightclick to edit as text.", false, false, 0);
 			int NewValue = NewValueRes.m_Value;
-			if(DoButton_FontIcon(&pIDs[i] + 1, FONT_ICON_MINUS, 0, &Dec, 0, "Decrease", IGraphics::CORNER_L, 7.0f))
+			if(DoButton_FontIcon(&pIds[i] + 1, FONT_ICON_MINUS, 0, &Dec, 0, "Decrease", IGraphics::CORNER_L, 7.0f))
 			{
 				NewValue = (std::ceil((pProps[i].m_Value / (float)Step)) - 1) * Step;
 				if(NewValue < 0)
 					NewValue += 360;
 				State = EEditState::ONE_GO;
 			}
-			if(DoButton_FontIcon(&pIDs[i] + 2, FONT_ICON_PLUS, 0, &Inc, 0, "Increase", IGraphics::CORNER_R, 7.0f))
+			if(DoButton_FontIcon(&pIds[i] + 2, FONT_ICON_PLUS, 0, &Inc, 0, "Increase", IGraphics::CORNER_R, 7.0f))
 			{
 				NewValue = (pProps[i].m_Value + Step) / Step * Step;
 				State = EEditState::ONE_GO;
@@ -120,7 +120,7 @@ SEditResult<E> CEditor::DoPropertiesWithState(CUIRect *pToolBox, CProperty *pPro
 					State = m_ColorPickerPopupContext.m_State;
 				}
 			};
-			DoColorPickerButton(&pIDs[i], &Shifter, ColorRGBA::UnpackAlphaLast<ColorRGBA>(pProps[i].m_Value), SetColor);
+			DoColorPickerButton(&pIds[i], &Shifter, ColorRGBA::UnpackAlphaLast<ColorRGBA>(pProps[i].m_Value), SetColor);
 		}
 		else if(pProps[i].m_Type == PROPTYPE_IMAGE)
 		{
@@ -130,8 +130,8 @@ SEditResult<E> CEditor::DoPropertiesWithState(CUIRect *pToolBox, CProperty *pPro
 			else
 				pName = m_Map.m_vpImages[pProps[i].m_Value]->m_aName;
 
-			if(DoButton_Ex(&pIDs[i], pName, 0, &Shifter, 0, nullptr, IGraphics::CORNER_ALL))
-				PopupSelectImageInvoke(pProps[i].m_Value, UI()->MouseX(), UI()->MouseY());
+			if(DoButton_Ex(&pIds[i], pName, 0, &Shifter, 0, nullptr, IGraphics::CORNER_ALL))
+				PopupSelectImageInvoke(pProps[i].m_Value, Ui()->MouseX(), Ui()->MouseY());
 
 			int r = PopupSelectImageResult();
 			if(r >= -1)
@@ -148,30 +148,30 @@ SEditResult<E> CEditor::DoPropertiesWithState(CUIRect *pToolBox, CProperty *pPro
 			Left.VSplitLeft(10.0f, &Left, &Shifter);
 			Shifter.VSplitRight(10.0f, &Shifter, &Right);
 			Shifter.Draw(ColorRGBA(1, 1, 1, 0.5f), IGraphics::CORNER_NONE, 0.0f);
-			UI()->DoLabel(&Shifter, "X", 10.0f, TEXTALIGN_MC);
+			Ui()->DoLabel(&Shifter, "X", 10.0f, TEXTALIGN_MC);
 			Up.VSplitLeft(10.0f, &Up, &Shifter);
 			Shifter.VSplitRight(10.0f, &Shifter, &Down);
 			Shifter.Draw(ColorRGBA(1, 1, 1, 0.5f), IGraphics::CORNER_NONE, 0.0f);
-			UI()->DoLabel(&Shifter, "Y", 10.0f, TEXTALIGN_MC);
-			if(DoButton_FontIcon(&pIDs[i], FONT_ICON_MINUS, 0, &Left, 0, "Left", IGraphics::CORNER_L, 7.0f))
+			Ui()->DoLabel(&Shifter, "Y", 10.0f, TEXTALIGN_MC);
+			if(DoButton_FontIcon(&pIds[i], FONT_ICON_MINUS, 0, &Left, 0, "Left", IGraphics::CORNER_L, 7.0f))
 			{
 				*pNewVal = DIRECTION_LEFT;
 				Change = i;
 				State = EEditState::ONE_GO;
 			}
-			if(DoButton_FontIcon(((char *)&pIDs[i]) + 3, FONT_ICON_PLUS, 0, &Right, 0, "Right", IGraphics::CORNER_R, 7.0f))
+			if(DoButton_FontIcon(((char *)&pIds[i]) + 3, FONT_ICON_PLUS, 0, &Right, 0, "Right", IGraphics::CORNER_R, 7.0f))
 			{
 				*pNewVal = DIRECTION_RIGHT;
 				Change = i;
 				State = EEditState::ONE_GO;
 			}
-			if(DoButton_FontIcon(((char *)&pIDs[i]) + 1, FONT_ICON_MINUS, 0, &Up, 0, "Up", IGraphics::CORNER_L, 7.0f))
+			if(DoButton_FontIcon(((char *)&pIds[i]) + 1, FONT_ICON_MINUS, 0, &Up, 0, "Up", IGraphics::CORNER_L, 7.0f))
 			{
 				*pNewVal = DIRECTION_UP;
 				Change = i;
 				State = EEditState::ONE_GO;
 			}
-			if(DoButton_FontIcon(((char *)&pIDs[i]) + 2, FONT_ICON_PLUS, 0, &Down, 0, "Down", IGraphics::CORNER_R, 7.0f))
+			if(DoButton_FontIcon(((char *)&pIds[i]) + 2, FONT_ICON_PLUS, 0, &Down, 0, "Down", IGraphics::CORNER_R, 7.0f))
 			{
 				*pNewVal = DIRECTION_DOWN;
 				Change = i;
@@ -186,8 +186,8 @@ SEditResult<E> CEditor::DoPropertiesWithState(CUIRect *pToolBox, CProperty *pPro
 			else
 				pName = m_Map.m_vpSounds[pProps[i].m_Value]->m_aName;
 
-			if(DoButton_Ex(&pIDs[i], pName, 0, &Shifter, 0, nullptr, IGraphics::CORNER_ALL))
-				PopupSelectSoundInvoke(pProps[i].m_Value, UI()->MouseX(), UI()->MouseY());
+			if(DoButton_Ex(&pIds[i], pName, 0, &Shifter, 0, nullptr, IGraphics::CORNER_ALL))
+				PopupSelectSoundInvoke(pProps[i].m_Value, Ui()->MouseX(), Ui()->MouseY());
 
 			int r = PopupSelectSoundResult();
 			if(r >= -1)
@@ -205,8 +205,8 @@ SEditResult<E> CEditor::DoPropertiesWithState(CUIRect *pToolBox, CProperty *pPro
 			else
 				pName = m_Map.m_vpImages[pProps[i].m_Min]->m_AutoMapper.GetConfigName(pProps[i].m_Value);
 
-			if(DoButton_Ex(&pIDs[i], pName, 0, &Shifter, 0, nullptr, IGraphics::CORNER_ALL))
-				PopupSelectConfigAutoMapInvoke(pProps[i].m_Value, UI()->MouseX(), UI()->MouseY());
+			if(DoButton_Ex(&pIds[i], pName, 0, &Shifter, 0, nullptr, IGraphics::CORNER_ALL))
+				PopupSelectConfigAutoMapInvoke(pProps[i].m_Value, Ui()->MouseX(), Ui()->MouseY());
 
 			int r = PopupSelectConfigAutoMapResult();
 			if(r >= -1)
@@ -239,7 +239,7 @@ SEditResult<E> CEditor::DoPropertiesWithState(CUIRect *pToolBox, CProperty *pPro
 			else
 				aBuf[0] = '\0';
 
-			auto NewValueRes = UiDoValueSelector((char *)&pIDs[i], &Shifter, aBuf, CurValue, 0, m_Map.m_vpEnvelopes.size(), 1, 1.0f, "Set Envelope", false, false, IGraphics::CORNER_NONE);
+			auto NewValueRes = UiDoValueSelector((char *)&pIds[i], &Shifter, aBuf, CurValue, 0, m_Map.m_vpEnvelopes.size(), 1, 1.0f, "Set Envelope", false, false, IGraphics::CORNER_NONE);
 			int NewVal = NewValueRes.m_Value;
 			if(NewVal != CurValue || NewValueRes.m_State != EEditState::EDITING)
 			{
@@ -248,13 +248,13 @@ SEditResult<E> CEditor::DoPropertiesWithState(CUIRect *pToolBox, CProperty *pPro
 				State = NewValueRes.m_State;
 			}
 
-			if(DoButton_FontIcon((char *)&pIDs[i] + 1, FONT_ICON_MINUS, 0, &Dec, 0, "Previous Envelope", IGraphics::CORNER_L, 7.0f))
+			if(DoButton_FontIcon((char *)&pIds[i] + 1, FONT_ICON_MINUS, 0, &Dec, 0, "Previous Envelope", IGraphics::CORNER_L, 7.0f))
 			{
 				*pNewVal = pProps[i].m_Value - 1;
 				Change = i;
 				State = EEditState::ONE_GO;
 			}
-			if(DoButton_FontIcon(((char *)&pIDs[i]) + 2, FONT_ICON_PLUS, 0, &Inc, 0, "Next Envelope", IGraphics::CORNER_R, 7.0f))
+			if(DoButton_FontIcon(((char *)&pIds[i]) + 2, FONT_ICON_PLUS, 0, &Inc, 0, "Next Envelope", IGraphics::CORNER_R, 7.0f))
 			{
 				*pNewVal = pProps[i].m_Value + 1;
 				Change = i;

--- a/src/game/editor/editor_server_settings.cpp
+++ b/src/game/editor/editor_server_settings.cpp
@@ -56,7 +56,7 @@ void CEditor::RenderServerSettingsEditor(CUIRect View, bool ShowServerSettingsEd
 {
 	static int s_CommandSelectedIndex = -1;
 	static CListBox s_ListBox;
-	s_ListBox.SetActive(!m_MapSettingsCommandContext.m_DropdownContext.m_ListBox.Active() && m_Dialog == DIALOG_NONE && !UI()->IsPopupOpen());
+	s_ListBox.SetActive(!m_MapSettingsCommandContext.m_DropdownContext.m_ListBox.Active() && m_Dialog == DIALOG_NONE && !Ui()->IsPopupOpen());
 
 	bool GotSelection = s_ListBox.Active() && s_CommandSelectedIndex >= 0 && (size_t)s_CommandSelectedIndex < m_Map.m_vSettings.size();
 	const bool CurrentInputValid = m_MapSettingsCommandContext.Valid(); // Use the context to validate the input
@@ -75,7 +75,7 @@ void CEditor::RenderServerSettingsEditor(CUIRect View, bool ShowServerSettingsEd
 	ToolBar.VSplitRight(25.0f, &ToolBar, &Button);
 	ToolBar.VSplitRight(5.0f, &ToolBar, nullptr);
 	static int s_DeleteButton = 0;
-	if(DoButton_FontIcon(&s_DeleteButton, FONT_ICON_TRASH, GotSelection ? 0 : -1, &Button, 0, "[Delete] Delete the selected command from the command list.", IGraphics::CORNER_ALL, 9.0f) == 1 || (GotSelection && CLineInput::GetActiveInput() == nullptr && m_Dialog == DIALOG_NONE && UI()->ConsumeHotkey(CUI::HOTKEY_DELETE)))
+	if(DoButton_FontIcon(&s_DeleteButton, FONT_ICON_TRASH, GotSelection ? 0 : -1, &Button, 0, "[Delete] Delete the selected command from the command list.", IGraphics::CORNER_ALL, 9.0f) == 1 || (GotSelection && CLineInput::GetActiveInput() == nullptr && m_Dialog == DIALOG_NONE && Ui()->ConsumeHotkey(CUi::HOTKEY_DELETE)))
 	{
 		m_ServerSettingsHistory.RecordAction(std::make_shared<CEditorCommandAction>(this, CEditorCommandAction::EType::DELETE, &s_CommandSelectedIndex, s_CommandSelectedIndex, m_Map.m_vSettings[s_CommandSelectedIndex].m_aCommand));
 
@@ -92,7 +92,7 @@ void CEditor::RenderServerSettingsEditor(CUIRect View, bool ShowServerSettingsEd
 	ToolBar.VSplitRight(25.0f, &ToolBar, &Button);
 	const bool CanMoveDown = GotSelection && s_CommandSelectedIndex < (int)m_Map.m_vSettings.size() - 1;
 	static int s_DownButton = 0;
-	if(DoButton_FontIcon(&s_DownButton, FONT_ICON_SORT_DOWN, CanMoveDown ? 0 : -1, &Button, 0, "[Alt+Down] Move the selected command down.", IGraphics::CORNER_R, 11.0f) == 1 || (CanMoveDown && Input()->AltIsPressed() && UI()->ConsumeHotkey(CUI::HOTKEY_DOWN)))
+	if(DoButton_FontIcon(&s_DownButton, FONT_ICON_SORT_DOWN, CanMoveDown ? 0 : -1, &Button, 0, "[Alt+Down] Move the selected command down.", IGraphics::CORNER_R, 11.0f) == 1 || (CanMoveDown && Input()->AltIsPressed() && Ui()->ConsumeHotkey(CUi::HOTKEY_DOWN)))
 	{
 		m_ServerSettingsHistory.RecordAction(std::make_shared<CEditorCommandAction>(this, CEditorCommandAction::EType::MOVE_DOWN, &s_CommandSelectedIndex, s_CommandSelectedIndex));
 
@@ -107,7 +107,7 @@ void CEditor::RenderServerSettingsEditor(CUIRect View, bool ShowServerSettingsEd
 	ToolBar.VSplitRight(5.0f, &ToolBar, nullptr);
 	const bool CanMoveUp = GotSelection && s_CommandSelectedIndex > 0;
 	static int s_UpButton = 0;
-	if(DoButton_FontIcon(&s_UpButton, FONT_ICON_SORT_UP, CanMoveUp ? 0 : -1, &Button, 0, "[Alt+Up] Move the selected command up.", IGraphics::CORNER_L, 11.0f) == 1 || (CanMoveUp && Input()->AltIsPressed() && UI()->ConsumeHotkey(CUI::HOTKEY_UP)))
+	if(DoButton_FontIcon(&s_UpButton, FONT_ICON_SORT_UP, CanMoveUp ? 0 : -1, &Button, 0, "[Alt+Up] Move the selected command up.", IGraphics::CORNER_L, 11.0f) == 1 || (CanMoveUp && Input()->AltIsPressed() && Ui()->ConsumeHotkey(CUi::HOTKEY_UP)))
 	{
 		m_ServerSettingsHistory.RecordAction(std::make_shared<CEditorCommandAction>(this, CEditorCommandAction::EType::MOVE_UP, &s_CommandSelectedIndex, s_CommandSelectedIndex));
 
@@ -120,7 +120,7 @@ void CEditor::RenderServerSettingsEditor(CUIRect View, bool ShowServerSettingsEd
 	// redo button
 	ToolBar.VSplitRight(25.0f, &ToolBar, &Button);
 	static int s_RedoButton = 0;
-	if(DoButton_FontIcon(&s_RedoButton, FONT_ICON_REDO, m_ServerSettingsHistory.CanRedo() ? 0 : -1, &Button, 0, "[Ctrl+Y] Redo command edit", IGraphics::CORNER_R, 11.0f) == 1 || (CanMoveDown && Input()->AltIsPressed() && UI()->ConsumeHotkey(CUI::HOTKEY_DOWN)))
+	if(DoButton_FontIcon(&s_RedoButton, FONT_ICON_REDO, m_ServerSettingsHistory.CanRedo() ? 0 : -1, &Button, 0, "[Ctrl+Y] Redo command edit", IGraphics::CORNER_R, 11.0f) == 1 || (CanMoveDown && Input()->AltIsPressed() && Ui()->ConsumeHotkey(CUi::HOTKEY_DOWN)))
 	{
 		m_ServerSettingsHistory.Redo();
 	}
@@ -129,7 +129,7 @@ void CEditor::RenderServerSettingsEditor(CUIRect View, bool ShowServerSettingsEd
 	ToolBar.VSplitRight(25.0f, &ToolBar, &Button);
 	ToolBar.VSplitRight(5.0f, &ToolBar, nullptr);
 	static int s_UndoButton = 0;
-	if(DoButton_FontIcon(&s_UndoButton, FONT_ICON_UNDO, m_ServerSettingsHistory.CanUndo() ? 0 : -1, &Button, 0, "[Ctrl+Z] Undo command edit", IGraphics::CORNER_L, 11.0f) == 1 || (CanMoveUp && Input()->AltIsPressed() && UI()->ConsumeHotkey(CUI::HOTKEY_UP)))
+	if(DoButton_FontIcon(&s_UndoButton, FONT_ICON_UNDO, m_ServerSettingsHistory.CanUndo() ? 0 : -1, &Button, 0, "[Ctrl+Z] Undo command edit", IGraphics::CORNER_L, 11.0f) == 1 || (CanMoveUp && Input()->AltIsPressed() && Ui()->ConsumeHotkey(CUi::HOTKEY_UP)))
 	{
 		m_ServerSettingsHistory.Undo();
 	}
@@ -149,7 +149,7 @@ void CEditor::RenderServerSettingsEditor(CUIRect View, bool ShowServerSettingsEd
 	const bool CanUpdate = GotSelection && CurrentInputValid && str_comp(m_Map.m_vSettings[s_CommandSelectedIndex].m_aCommand, m_SettingsCommandInput.GetString()) != 0;
 
 	static int s_UpdateButton = 0;
-	if(DoButton_FontIcon(&s_UpdateButton, FONT_ICON_PENCIL, CanUpdate ? 0 : -1, &Button, 0, "[Alt+Enter] Update the selected command based on the entered value.", IGraphics::CORNER_R, 9.0f) == 1 || (CanUpdate && Input()->AltIsPressed() && m_Dialog == DIALOG_NONE && UI()->ConsumeHotkey(CUI::HOTKEY_ENTER)))
+	if(DoButton_FontIcon(&s_UpdateButton, FONT_ICON_PENCIL, CanUpdate ? 0 : -1, &Button, 0, "[Alt+Enter] Update the selected command based on the entered value.", IGraphics::CORNER_R, 9.0f) == 1 || (CanUpdate && Input()->AltIsPressed() && m_Dialog == DIALOG_NONE && Ui()->ConsumeHotkey(CUi::HOTKEY_ENTER)))
 	{
 		if(CollidingCommandIndex == -1)
 		{
@@ -208,7 +208,7 @@ void CEditor::RenderServerSettingsEditor(CUIRect View, bool ShowServerSettingsEd
 		s_ListBox.ScrollToSelected();
 		m_SettingsCommandInput.Clear();
 		m_MapSettingsCommandContext.Reset(); // Reset context
-		UI()->SetActiveItem(&m_SettingsCommandInput);
+		Ui()->SetActiveItem(&m_SettingsCommandInput);
 	}
 
 	// add button
@@ -216,7 +216,7 @@ void CEditor::RenderServerSettingsEditor(CUIRect View, bool ShowServerSettingsEd
 	ToolBar.VSplitRight(100.0f, &ToolBar, nullptr);
 
 	static int s_AddButton = 0;
-	if(DoButton_FontIcon(&s_AddButton, CanReplace ? FONT_ICON_ARROWS_ROTATE : FONT_ICON_PLUS, CanAdd || CanReplace ? 0 : -1, &Button, 0, CanReplace ? "[Enter] Replace the corresponding command in the command list." : "[Enter] Add a command to the command list.", IGraphics::CORNER_L) == 1 || ((CanAdd || CanReplace) && !Input()->AltIsPressed() && m_Dialog == DIALOG_NONE && UI()->ConsumeHotkey(CUI::HOTKEY_ENTER)))
+	if(DoButton_FontIcon(&s_AddButton, CanReplace ? FONT_ICON_ARROWS_ROTATE : FONT_ICON_PLUS, CanAdd || CanReplace ? 0 : -1, &Button, 0, CanReplace ? "[Enter] Replace the corresponding command in the command list." : "[Enter] Add a command to the command list.", IGraphics::CORNER_L) == 1 || ((CanAdd || CanReplace) && !Input()->AltIsPressed() && m_Dialog == DIALOG_NONE && Ui()->ConsumeHotkey(CUi::HOTKEY_ENTER)))
 	{
 		if(CanReplace)
 		{
@@ -238,12 +238,12 @@ void CEditor::RenderServerSettingsEditor(CUIRect View, bool ShowServerSettingsEd
 		s_ListBox.ScrollToSelected();
 		m_SettingsCommandInput.Clear();
 		m_MapSettingsCommandContext.Reset(); // Reset context
-		UI()->SetActiveItem(&m_SettingsCommandInput);
+		Ui()->SetActiveItem(&m_SettingsCommandInput);
 	}
 
 	// command input (use remaining toolbar width)
 	if(!ShowServerSettingsEditorLast) // Just activated
-		UI()->SetActiveItem(&m_SettingsCommandInput);
+		Ui()->SetActiveItem(&m_SettingsCommandInput);
 	m_SettingsCommandInput.SetEmptyText("Command");
 
 	TextRender()->TextColor(TextRender()->DefaultTextColor());
@@ -262,7 +262,7 @@ void CEditor::RenderServerSettingsEditor(CUIRect View, bool ShowServerSettingsEd
 		SLabelProperties Props;
 		Props.m_MaxWidth = Label.w;
 		Props.m_EllipsisAtEnd = true;
-		UI()->DoLabel(&Label, m_Map.m_vSettings[i].m_aCommand, 10.0f, TEXTALIGN_ML, Props);
+		Ui()->DoLabel(&Label, m_Map.m_vSettings[i].m_aCommand, 10.0f, TEXTALIGN_ML, Props);
 	}
 
 	const int NewSelected = s_ListBox.DoEnd();
@@ -276,7 +276,7 @@ void CEditor::RenderServerSettingsEditor(CUIRect View, bool ShowServerSettingsEd
 			m_MapSettingsCommandContext.UpdateCursor(true);
 		}
 		m_MapSettingsCommandContext.m_DropdownContext.m_ShouldHide = true;
-		UI()->SetActiveItem(&m_SettingsCommandInput);
+		Ui()->SetActiveItem(&m_SettingsCommandInput);
 	}
 
 	// Map setting input
@@ -309,7 +309,7 @@ void CEditor::DoMapSettingsEditBox(CMapSettingsBackend::CContext *pContext, cons
 		CUIRect Label;
 		Background.VSplitLeft(PartMargin, nullptr, &Label);
 		TextRender()->TextColor(0.8f, 0.8f, 0.8f, 1.0f);
-		UI()->DoLabel(&Label, pStr, FontSize, TEXTALIGN_ML);
+		Ui()->DoLabel(&Label, pStr, FontSize, TEXTALIGN_ML);
 		TextRender()->TextColor(TextRender()->DefaultTextColor());
 	};
 
@@ -426,7 +426,7 @@ int CEditor::DoEditBoxDropdown(SEditBoxDropdownContext *pDropdown, CLineInput *p
 		int CurrentSelected = pDropdown->m_Selected;
 
 		// Use tab to navigate through entries
-		if(UI()->ConsumeHotkey(CUI::HOTKEY_TAB) && !vData.empty())
+		if(Ui()->ConsumeHotkey(CUi::HOTKEY_TAB) && !vData.empty())
 		{
 			int Direction = Input()->ShiftIsPressed() ? -1 : 1;
 
@@ -462,7 +462,7 @@ int CEditor::RenderEditBoxDropdown(SEditBoxDropdownContext *pDropdown, CUIRect V
 	// Render a dropdown tied to an edit box/line input
 	auto *pListBox = &pDropdown->m_ListBox;
 
-	pListBox->SetActive(m_Dialog == DIALOG_NONE && !UI()->IsPopupOpen() && pLineInput->IsActive());
+	pListBox->SetActive(m_Dialog == DIALOG_NONE && !Ui()->IsPopupOpen() && pLineInput->IsActive());
 	pListBox->SetScrollbarWidth(15.0f);
 
 	const int NumEntries = vData.size();
@@ -481,7 +481,7 @@ int CEditor::RenderEditBoxDropdown(SEditBoxDropdownContext *pDropdown, CUIRect V
 		CommandsDropdown.h = minimum(NumEntries * 15.0f + 1.0f, MaxHeight);
 		CommandsDropdown.Draw(ColorRGBA(0.1f, 0.1f, 0.1f, 0.9f), IGraphics::CORNER_ALL, 3.0f);
 
-		if(UI()->MouseButton(0) && UI()->MouseInside(&CommandsDropdown))
+		if(Ui()->MouseButton(0) && Ui()->MouseInside(&CommandsDropdown))
 			pDropdown->m_MousePressedInside = true;
 
 		// Do the list box
@@ -509,14 +509,14 @@ int CEditor::RenderEditBoxDropdown(SEditBoxDropdownContext *pDropdown, CUIRect V
 			if(!Item.m_Visible)
 				continue;
 
-			UI()->DoLabel(&Label, aBuf, 12.0f, TEXTALIGN_ML, Props);
+			Ui()->DoLabel(&Label, aBuf, 12.0f, TEXTALIGN_ML, Props);
 
-			if(UI()->ActiveItem() == &vData[i])
+			if(Ui()->ActiveItem() == &vData[i])
 			{
 				// If we selected an item (by clicking on it for example), then set the active item back to the
 				// line input so we don't loose focus
 				NewIndex = i;
-				UI()->SetActiveItem(pLineInput);
+				Ui()->SetActiveItem(pLineInput);
 			}
 		}
 
@@ -526,15 +526,15 @@ int CEditor::RenderEditBoxDropdown(SEditBoxDropdownContext *pDropdown, CUIRect V
 		if(NewIndex == Selected)
 			NewIndex = EndIndex;
 
-		if(pDropdown->m_MousePressedInside && !UI()->MouseButton(0))
+		if(pDropdown->m_MousePressedInside && !Ui()->MouseButton(0))
 		{
-			UI()->SetActiveItem(pLineInput);
+			Ui()->SetActiveItem(pLineInput);
 			pDropdown->m_MousePressedInside = false;
 		}
 
 		if(NewIndex != Selected)
 		{
-			UI()->SetActiveItem(pLineInput);
+			Ui()->SetActiveItem(pLineInput);
 			return NewIndex;
 		}
 	}
@@ -548,8 +548,8 @@ void CEditor::RenderMapSettingsErrorDialog()
 	auto &vSettingsValid = LoadedMapSettings.m_vSettingsValid;
 	auto &SettingsDuplicate = LoadedMapSettings.m_SettingsDuplicate;
 
-	UI()->MapScreen();
-	CUIRect Overlay = *UI()->Screen();
+	Ui()->MapScreen();
+	CUIRect Overlay = *Ui()->Screen();
 
 	Overlay.Draw(ColorRGBA(0, 0, 0, 0.33f), IGraphics::CORNER_NONE, 0.0f);
 	CUIRect Background;
@@ -569,7 +569,7 @@ void CEditor::RenderMapSettingsErrorDialog()
 	// title bar
 	Title.Draw(ColorRGBA(1, 1, 1, 0.25f), IGraphics::CORNER_ALL, 4.0f);
 	Title.VMargin(10.0f, &Title);
-	UI()->DoLabel(&Title, "Map settings error", 12.0f, TEXTALIGN_ML);
+	Ui()->DoLabel(&Title, "Map settings error", 12.0f, TEXTALIGN_ML);
 
 	// Render body
 	{
@@ -581,7 +581,7 @@ void CEditor::RenderMapSettingsErrorDialog()
 		CUIRect Text;
 		View.HSplitTop(30.0f, &Text, &View);
 		Props.m_MaxWidth = Text.w;
-		UI()->DoLabel(&Text, "Below is a report of the invalid map settings found when loading the map. Please fix them before proceeding further.", 10.0f, TEXTALIGN_MC, Props);
+		Ui()->DoLabel(&Text, "Below is a report of the invalid map settings found when loading the map. Please fix them before proceeding further.", 10.0f, TEXTALIGN_MC, Props);
 
 		// Mixed list
 		CUIRect List = View;
@@ -604,7 +604,7 @@ void CEditor::RenderMapSettingsErrorDialog()
 			s_Input.Set(pString);
 			s_Context.Update();
 			s_Context.UpdateCursor(true);
-			UI()->SetActiveItem(&s_Input);
+			Ui()->SetActiveItem(&s_Input);
 		};
 
 		CUIRect FixInput;
@@ -666,7 +666,7 @@ void CEditor::RenderMapSettingsErrorDialog()
 
 						// Buttons
 						static int s_Cancel = 0, s_Ok = 0;
-						if(DoButton_Editor(&s_Cancel, "Cancel", 0, &CancelBtn, 0, "Cancel fixing this command") || UI()->ConsumeHotkey(CUI::HOTKEY_ESCAPE))
+						if(DoButton_Editor(&s_Cancel, "Cancel", 0, &CancelBtn, 0, "Cancel fixing this command") || Ui()->ConsumeHotkey(CUi::HOTKEY_ESCAPE))
 						{
 							s_FixingCommandIndex = -1;
 							s_Input.Clear();
@@ -679,7 +679,7 @@ void CEditor::RenderMapSettingsErrorDialog()
 						s_Context.CheckCollision(vSettingsValid, Res);
 						bool Valid = s_Context.Valid() && Res == ECollisionCheckResult::ADD;
 
-						if(DoButton_Editor(&s_Ok, "Done", Valid ? 0 : -1, &OkBtn, 0, "Confirm editing of this command") || (s_Input.IsActive() && Valid && UI()->ConsumeHotkey(CUI::HOTKEY_ENTER)))
+						if(DoButton_Editor(&s_Ok, "Done", Valid ? 0 : -1, &OkBtn, 0, "Confirm editing of this command") || (s_Input.IsActive() && Valid && Ui()->ConsumeHotkey(CUi::HOTKEY_ENTER)))
 						{
 							// Mark the setting is being fixed
 							pInvalidSetting->m_Context.m_Fixed = true;
@@ -716,12 +716,12 @@ void CEditor::RenderMapSettingsErrorDialog()
 								TextRender()->TextColor(0.0f, 1.0f, 0.0f, 1.0f);
 							else
 								TextRender()->TextColor(1.0f, 0.0f, 0.0f, 1.0f);
-							UI()->DoLabel(&Label, pInvalidSetting->m_aSetting, 10.0f, TEXTALIGN_ML, Props);
+							Ui()->DoLabel(&Label, pInvalidSetting->m_aSetting, 10.0f, TEXTALIGN_ML, Props);
 						}
 						else
 						{
 							TextRender()->TextColor(0.3f, 0.3f, 0.3f, 1.0f);
-							UI()->DoLabel(&Label, pInvalidSetting->m_aSetting, 10.0f, TEXTALIGN_ML, Props);
+							Ui()->DoLabel(&Label, pInvalidSetting->m_aSetting, 10.0f, TEXTALIGN_ML, Props);
 
 							CUIRect Line = Label;
 							Line.y = Label.y + Label.h / 2;
@@ -775,7 +775,7 @@ void CEditor::RenderMapSettingsErrorDialog()
 
 				// Draw the label
 				Props.m_MaxWidth = Label.w;
-				UI()->DoLabel(&Label, m_Map.m_vSettings[i].m_aCommand, 10.0f, TEXTALIGN_ML, Props);
+				Ui()->DoLabel(&Label, m_Map.m_vSettings[i].m_aCommand, 10.0f, TEXTALIGN_ML, Props);
 
 				// Draw the list of duplicates, with a "Choose" button for each duplicate
 				// In case a duplicate is also invalid, then we draw a "Fix" button which behaves like the fix button above
@@ -842,7 +842,7 @@ void CEditor::RenderMapSettingsErrorDialog()
 						OkBtn.HMargin(1.0f, &OkBtn);
 
 						static int s_Cancel = 0, s_Ok = 0;
-						if(DoButton_Editor(&s_Cancel, "Cancel", 0, &CancelBtn, 0, "Cancel fixing this command") || UI()->ConsumeHotkey(CUI::HOTKEY_ESCAPE))
+						if(DoButton_Editor(&s_Cancel, "Cancel", 0, &CancelBtn, 0, "Cancel fixing this command") || Ui()->ConsumeHotkey(CUi::HOTKEY_ESCAPE))
 						{
 							s_FixingCommandIndex = -1;
 							s_Input.Clear();
@@ -859,7 +859,7 @@ void CEditor::RenderMapSettingsErrorDialog()
 						s_Context.CheckCollision({m_Map.m_vSettings[i]}, Res);
 						bool Valid = s_Context.Valid() && Res == ECollisionCheckResult::REPLACE;
 
-						if(DoButton_Editor(&s_Ok, "Done", Valid ? 0 : -1, &OkBtn, 0, "Confirm editing of this command") || (s_Input.IsActive() && Valid && UI()->ConsumeHotkey(CUI::HOTKEY_ENTER)))
+						if(DoButton_Editor(&s_Ok, "Done", Valid ? 0 : -1, &OkBtn, 0, "Confirm editing of this command") || (s_Input.IsActive() && Valid && Ui()->ConsumeHotkey(CUi::HOTKEY_ENTER)))
 						{
 							if(Valid) // Just to make sure
 							{
@@ -887,7 +887,7 @@ void CEditor::RenderMapSettingsErrorDialog()
 					{
 						// Otherwise, render the setting label
 						TextRender()->TextColor(Color);
-						UI()->DoLabel(&Label, Duplicate.m_aSetting, 10.0f, TEXTALIGN_ML, Props);
+						Ui()->DoLabel(&Label, Duplicate.m_aSetting, 10.0f, TEXTALIGN_ML, Props);
 						TextRender()->TextColor(TextRender()->DefaultTextColor());
 					}
 				}
@@ -999,14 +999,14 @@ void CEditor::RenderMapSettingsErrorDialog()
 	}
 
 	// Confirm - execute the fixes
-	if(DoButton_Editor(&s_ConfirmButton, "Confirm", CanConfirm ? 0 : -1, &ConfimButton, 0, nullptr) || (CanConfirm && UI()->ConsumeHotkey(CUI::HOTKEY_ENTER)))
+	if(DoButton_Editor(&s_ConfirmButton, "Confirm", CanConfirm ? 0 : -1, &ConfimButton, 0, nullptr) || (CanConfirm && Ui()->ConsumeHotkey(CUi::HOTKEY_ENTER)))
 	{
 		Execute();
 		m_Dialog = DIALOG_NONE;
 	}
 
 	// Cancel - we load a new empty map
-	if(DoButton_Editor(&s_CancelButton, "Cancel", 0, &CancelButton, 0, nullptr) || (UI()->ConsumeHotkey(CUI::HOTKEY_ESCAPE)))
+	if(DoButton_Editor(&s_CancelButton, "Cancel", 0, &CancelButton, 0, nullptr) || (Ui()->ConsumeHotkey(CUi::HOTKEY_ESCAPE)))
 	{
 		Reset();
 		m_aFileName[0] = 0;

--- a/src/game/editor/layer_selector.cpp
+++ b/src/game/editor/layer_selector.cpp
@@ -12,9 +12,9 @@ void CLayerSelector::Init(CEditor *pEditor)
 bool CLayerSelector::SelectByTile()
 {
 	// ctrl+rightclick a map index to select the layer that has a tile there
-	if(UI()->HotItem() != &Editor()->m_MapEditorId)
+	if(Ui()->HotItem() != &Editor()->m_MapEditorId)
 		return false;
-	if(!Input()->ModifierIsPressed() || !UI()->MouseButtonClicked(1))
+	if(!Input()->ModifierIsPressed() || !Ui()->MouseButtonClicked(1))
 		return false;
 
 	int MatchedGroup = -1;

--- a/src/game/editor/map_grid.cpp
+++ b/src/game/editor/map_grid.cpp
@@ -26,7 +26,7 @@ void CMapGrid::OnRender(CUIRect View)
 		float aGroupPoints[4];
 		pGroup->Mapping(aGroupPoints);
 
-		const CUIRect *pScreen = UI()->Screen();
+		const CUIRect *pScreen = Ui()->Screen();
 
 		int LineDistance = GridLineDistance();
 
@@ -110,10 +110,10 @@ void CMapGrid::SetFactor(int Factor)
 
 void CMapGrid::DoSettingsPopup(vec2 Position)
 {
-	UI()->DoPopupMenu(&m_PopupGridSettingsId, Position.x, Position.y, 120.0f, 37.0f, this, PopupGridSettings);
+	Ui()->DoPopupMenu(&m_PopupGridSettingsId, Position.x, Position.y, 120.0f, 37.0f, this, PopupGridSettings);
 }
 
-CUI::EPopupMenuFunctionResult CMapGrid::PopupGridSettings(void *pContext, CUIRect View, bool Active)
+CUi::EPopupMenuFunctionResult CMapGrid::PopupGridSettings(void *pContext, CUIRect View, bool Active)
 {
 	CMapGrid *pMapGrid = static_cast<CMapGrid *>(pContext);
 
@@ -145,5 +145,5 @@ CUI::EPopupMenuFunctionResult CMapGrid::PopupGridSettings(void *pContext, CUIRec
 		pMapGrid->SetFactor(1);
 	}
 
-	return CUI::POPUP_KEEP_OPEN;
+	return CUi::POPUP_KEEP_OPEN;
 }

--- a/src/game/editor/map_grid.h
+++ b/src/game/editor/map_grid.h
@@ -31,7 +31,7 @@ private:
 	int m_GridFactor;
 
 	SPopupMenuId m_PopupGridSettingsId;
-	static CUI::EPopupMenuFunctionResult PopupGridSettings(void *pContext, CUIRect View, bool Active);
+	static CUi::EPopupMenuFunctionResult PopupGridSettings(void *pContext, CUIRect View, bool Active);
 };
 
 #endif

--- a/src/game/editor/map_view.cpp
+++ b/src/game/editor/map_view.cpp
@@ -152,8 +152,8 @@ void CMapView::ZoomMouseTarget(float ZoomFactor)
 	float WorldWidth = aPoints[2] - aPoints[0];
 	float WorldHeight = aPoints[3] - aPoints[1];
 
-	float Mwx = aPoints[0] + WorldWidth * (UI()->MouseX() / UI()->Screen()->w);
-	float Mwy = aPoints[1] + WorldHeight * (UI()->MouseY() / UI()->Screen()->h);
+	float Mwx = aPoints[0] + WorldWidth * (Ui()->MouseX() / Ui()->Screen()->w);
+	float Mwy = aPoints[1] + WorldHeight * (Ui()->MouseY() / Ui()->Screen()->h);
 
 	// adjust camera
 	OffsetWorld((vec2(Mwx, Mwy) - GetWorldOffset()) * (1.0f - ZoomFactor));

--- a/src/game/editor/mapitems/image.cpp
+++ b/src/game/editor/mapitems/image.cpp
@@ -33,9 +33,9 @@ void CEditorImage::AnalyseTileFlags()
 	{
 		unsigned char *pPixelData = (unsigned char *)m_pData;
 
-		int TileID = 0;
+		int TileId = 0;
 		for(int ty = 0; ty < 16; ty++)
-			for(int tx = 0; tx < 16; tx++, TileID++)
+			for(int tx = 0; tx < 16; tx++, TileId++)
 			{
 				bool Opaque = true;
 				for(int x = 0; x < tw; x++)
@@ -50,7 +50,7 @@ void CEditorImage::AnalyseTileFlags()
 					}
 
 				if(Opaque)
-					m_aTileFlags[TileID] |= TILEFLAG_OPAQUE;
+					m_aTileFlags[TileId] |= TILEFLAG_OPAQUE;
 			}
 	}
 }

--- a/src/game/editor/mapitems/layer.h
+++ b/src/game/editor/mapitems/layer.h
@@ -55,7 +55,7 @@ public:
 	virtual bool IsEntitiesLayer() const { return false; }
 
 	virtual void Render(bool Tileset = false) {}
-	virtual CUI::EPopupMenuFunctionResult RenderProperties(CUIRect *pToolbox) { return CUI::POPUP_KEEP_OPEN; }
+	virtual CUi::EPopupMenuFunctionResult RenderProperties(CUIRect *pToolbox) { return CUi::POPUP_KEEP_OPEN; }
 
 	virtual void ModifyImageIndex(FIndexModifyFunction pfnFunc) {}
 	virtual void ModifyEnvelopeIndex(FIndexModifyFunction pfnFunc) {}

--- a/src/game/editor/mapitems/layer_game.cpp
+++ b/src/game/editor/mapitems/layer_game.cpp
@@ -61,9 +61,9 @@ void CLayerGame::SetTile(int x, int y, CTile Tile)
 	}
 }
 
-CUI::EPopupMenuFunctionResult CLayerGame::RenderProperties(CUIRect *pToolbox)
+CUi::EPopupMenuFunctionResult CLayerGame::RenderProperties(CUIRect *pToolbox)
 {
-	const CUI::EPopupMenuFunctionResult Result = CLayerTiles::RenderProperties(pToolbox);
+	const CUi::EPopupMenuFunctionResult Result = CLayerTiles::RenderProperties(pToolbox);
 	m_Image = -1;
 	return Result;
 }

--- a/src/game/editor/mapitems/layer_game.h
+++ b/src/game/editor/mapitems/layer_game.h
@@ -13,7 +13,7 @@ public:
 	void SetTile(int x, int y, CTile Tile) override;
 	const char *TypeName() const override;
 
-	CUI::EPopupMenuFunctionResult RenderProperties(CUIRect *pToolbox) override;
+	CUi::EPopupMenuFunctionResult RenderProperties(CUIRect *pToolbox) override;
 };
 
 #endif

--- a/src/game/editor/mapitems/layer_quads.cpp
+++ b/src/game/editor/mapitems/layer_quads.cpp
@@ -221,7 +221,7 @@ void CLayerQuads::GetSize(float *pWidth, float *pHeight)
 	}
 }
 
-CUI::EPopupMenuFunctionResult CLayerQuads::RenderProperties(CUIRect *pToolBox)
+CUi::EPopupMenuFunctionResult CLayerQuads::RenderProperties(CUIRect *pToolBox)
 {
 	CProperty aProps[] = {
 		{"Image", m_Image, PROPTYPE_IMAGE, -1, 0},
@@ -249,7 +249,7 @@ CUI::EPopupMenuFunctionResult CLayerQuads::RenderProperties(CUIRect *pToolBox)
 
 	s_Tracker.End(Prop, State);
 
-	return CUI::POPUP_KEEP_OPEN;
+	return CUi::POPUP_KEEP_OPEN;
 }
 
 void CLayerQuads::ModifyImageIndex(FIndexModifyFunction Func)

--- a/src/game/editor/mapitems/layer_quads.h
+++ b/src/game/editor/mapitems/layer_quads.h
@@ -21,7 +21,7 @@ public:
 	void BrushFlipY() override;
 	void BrushRotate(float Amount) override;
 
-	CUI::EPopupMenuFunctionResult RenderProperties(CUIRect *pToolbox) override;
+	CUi::EPopupMenuFunctionResult RenderProperties(CUIRect *pToolbox) override;
 
 	void ModifyImageIndex(FIndexModifyFunction pfnFunc) override;
 	void ModifyEnvelopeIndex(FIndexModifyFunction pfnFunc) override;

--- a/src/game/editor/mapitems/layer_sounds.cpp
+++ b/src/game/editor/mapitems/layer_sounds.cpp
@@ -168,7 +168,7 @@ void CLayerSounds::BrushPlace(std::shared_ptr<CLayer> pBrush, float wx, float wy
 	m_pEditor->m_Map.OnModify();
 }
 
-CUI::EPopupMenuFunctionResult CLayerSounds::RenderProperties(CUIRect *pToolBox)
+CUi::EPopupMenuFunctionResult CLayerSounds::RenderProperties(CUIRect *pToolBox)
 {
 	CProperty aProps[] = {
 		{"Sound", m_Sound, PROPTYPE_SOUND, -1, 0},
@@ -196,7 +196,7 @@ CUI::EPopupMenuFunctionResult CLayerSounds::RenderProperties(CUIRect *pToolBox)
 
 	s_Tracker.End(Prop, State);
 
-	return CUI::POPUP_KEEP_OPEN;
+	return CUi::POPUP_KEEP_OPEN;
 }
 
 void CLayerSounds::ModifySoundIndex(FIndexModifyFunction Func)

--- a/src/game/editor/mapitems/layer_sounds.h
+++ b/src/game/editor/mapitems/layer_sounds.h
@@ -17,7 +17,7 @@ public:
 	int BrushGrab(std::shared_ptr<CLayerGroup> pBrush, CUIRect Rect) override;
 	void BrushPlace(std::shared_ptr<CLayer> pBrush, float wx, float wy) override;
 
-	CUI::EPopupMenuFunctionResult RenderProperties(CUIRect *pToolbox) override;
+	CUi::EPopupMenuFunctionResult RenderProperties(CUIRect *pToolbox) override;
 
 	void ModifyEnvelopeIndex(FIndexModifyFunction pfnFunc) override;
 	void ModifySoundIndex(FIndexModifyFunction pfnFunc) override;

--- a/src/game/editor/mapitems/layer_tiles.cpp
+++ b/src/game/editor/mapitems/layer_tiles.cpp
@@ -693,7 +693,7 @@ void CLayerTiles::ShowInfo()
 	Graphics()->MapScreen(ScreenX0, ScreenY0, ScreenX1, ScreenY1);
 }
 
-CUI::EPopupMenuFunctionResult CLayerTiles::RenderProperties(CUIRect *pToolBox)
+CUi::EPopupMenuFunctionResult CLayerTiles::RenderProperties(CUIRect *pToolBox)
 {
 	CUIRect Button;
 
@@ -707,7 +707,7 @@ CUI::EPopupMenuFunctionResult CLayerTiles::RenderProperties(CUIRect *pToolBox)
 		pToolBox->HSplitBottom(12.0f, pToolBox, &Button);
 		static int s_GameTilesButton = 0;
 		if(m_pEditor->DoButton_Editor(&s_GameTilesButton, "Game tiles", 0, &Button, 0, "Constructs game tiles from this layer"))
-			m_pEditor->PopupSelectGametileOpInvoke(m_pEditor->UI()->MouseX(), m_pEditor->UI()->MouseY());
+			m_pEditor->PopupSelectGametileOpInvoke(m_pEditor->Ui()->MouseX(), m_pEditor->Ui()->MouseY());
 		int Result = m_pEditor->PopupSelectGameTileOpResult();
 		switch(Result)
 		{
@@ -938,7 +938,7 @@ CUI::EPopupMenuFunctionResult CLayerTiles::RenderProperties(CUIRect *pToolBox)
 				// record undo
 				m_pEditor->m_EditorHistory.RecordAction(std::make_shared<CEditorActionTileChanges>(m_pEditor, m_pEditor->m_SelectedGroup, m_pEditor->m_vSelectedLayers[0], "Auto map", m_TilesHistory));
 				ClearHistory();
-				return CUI::POPUP_CLOSE_CURRENT;
+				return CUi::POPUP_CLOSE_CURRENT;
 			}
 		}
 	}
@@ -1086,10 +1086,10 @@ CUI::EPopupMenuFunctionResult CLayerTiles::RenderProperties(CUIRect *pToolBox)
 	// Since we may also squeeze a tile changes action, we want both to appear as one, thus using a bulk
 	m_pEditor->m_EditorHistory.EndBulk(0);
 
-	return CUI::POPUP_KEEP_OPEN;
+	return CUi::POPUP_KEEP_OPEN;
 }
 
-CUI::EPopupMenuFunctionResult CLayerTiles::RenderCommonProperties(SCommonPropState &State, CEditor *pEditor, CUIRect *pToolbox, std::vector<std::shared_ptr<CLayerTiles>> &vpLayers, std::vector<int> &vLayerIndices)
+CUi::EPopupMenuFunctionResult CLayerTiles::RenderCommonProperties(SCommonPropState &State, CEditor *pEditor, CUIRect *pToolbox, std::vector<std::shared_ptr<CLayerTiles>> &vpLayers, std::vector<int> &vLayerIndices)
 {
 	if(State.m_Modified)
 	{
@@ -1190,7 +1190,7 @@ CUI::EPopupMenuFunctionResult CLayerTiles::RenderCommonProperties(SCommonPropSta
 		pEditor->TextRender()->TextColor(ColorRGBA(1.0f, 0.0f, 0.0f, 1.0f));
 		SLabelProperties Props;
 		Props.m_MaxWidth = Warning.w;
-		pEditor->UI()->DoLabel(&Warning, "Editing multiple layers", 9.0f, TEXTALIGN_ML, Props);
+		pEditor->Ui()->DoLabel(&Warning, "Editing multiple layers", 9.0f, TEXTALIGN_ML, Props);
 		pEditor->TextRender()->TextColor(ColorRGBA(1.0f, 1.0f, 1.0f, 1.0f));
 		pToolbox->HSplitTop(2.0f, nullptr, pToolbox);
 	}
@@ -1259,7 +1259,7 @@ CUI::EPopupMenuFunctionResult CLayerTiles::RenderCommonProperties(SCommonPropSta
 		State.m_Modified |= SCommonPropState::MODIFIED_COLOR;
 	}
 
-	return CUI::POPUP_KEEP_OPEN;
+	return CUi::POPUP_KEEP_OPEN;
 }
 
 void CLayerTiles::FlagModified(int x, int y, int w, int h)

--- a/src/game/editor/mapitems/layer_tiles.h
+++ b/src/game/editor/mapitems/layer_tiles.h
@@ -131,7 +131,7 @@ public:
 	const char *TypeName() const override;
 
 	virtual void ShowInfo();
-	CUI::EPopupMenuFunctionResult RenderProperties(CUIRect *pToolbox) override;
+	CUi::EPopupMenuFunctionResult RenderProperties(CUIRect *pToolbox) override;
 
 	struct SCommonPropState
 	{
@@ -145,7 +145,7 @@ public:
 		int m_Height = -1;
 		int m_Color = 0;
 	};
-	static CUI::EPopupMenuFunctionResult RenderCommonProperties(SCommonPropState &State, CEditor *pEditor, CUIRect *pToolbox, std::vector<std::shared_ptr<CLayerTiles>> &vpLayers, std::vector<int> &vLayerIndices);
+	static CUi::EPopupMenuFunctionResult RenderCommonProperties(SCommonPropState &State, CEditor *pEditor, CUIRect *pToolbox, std::vector<std::shared_ptr<CLayerTiles>> &vpLayers, std::vector<int> &vLayerIndices);
 
 	void ModifyImageIndex(FIndexModifyFunction pfnFunc) override;
 	void ModifyEnvelopeIndex(FIndexModifyFunction pfnFunc) override;

--- a/src/game/editor/mapitems/map_io.cpp
+++ b/src/game/editor/mapitems/map_io.cpp
@@ -428,9 +428,9 @@ bool CEditorMap::Load(const char *pFileName, int StorageType, const std::functio
 		for(int i = Start; i < Start + Num; i++)
 		{
 			int ItemSize = DataFile.GetItemSize(Start);
-			int ItemID;
-			CMapItemInfoSettings *pItem = (CMapItemInfoSettings *)DataFile.GetItem(i, nullptr, &ItemID);
-			if(!pItem || ItemID != 0)
+			int ItemId;
+			CMapItemInfoSettings *pItem = (CMapItemInfoSettings *)DataFile.GetItem(i, nullptr, &ItemId);
+			if(!pItem || ItemId != 0)
 				continue;
 
 			const auto &&ReadStringInfo = [&](int Index, char *pBuffer, size_t BufferSize, const char *pErrorContext) {
@@ -572,7 +572,7 @@ bool CEditorMap::Load(const char *pFileName, int StorageType, const std::functio
 				// load external
 				if(m_pEditor->Storage()->ReadFile(aBuf, IStorage::TYPE_ALL, &pSound->m_pData, &pSound->m_DataSize))
 				{
-					pSound->m_SoundID = m_pEditor->Sound()->LoadOpusFromMem(pSound->m_pData, pSound->m_DataSize, true);
+					pSound->m_SoundId = m_pEditor->Sound()->LoadOpusFromMem(pSound->m_pData, pSound->m_DataSize, true);
 				}
 			}
 			else
@@ -581,7 +581,7 @@ bool CEditorMap::Load(const char *pFileName, int StorageType, const std::functio
 				void *pData = DataFile.GetData(pItem->m_SoundData);
 				pSound->m_pData = malloc(pSound->m_DataSize);
 				mem_copy(pSound->m_pData, pData, pSound->m_DataSize);
-				pSound->m_SoundID = m_pEditor->Sound()->LoadOpusFromMem(pSound->m_pData, pSound->m_DataSize, true);
+				pSound->m_SoundId = m_pEditor->Sound()->LoadOpusFromMem(pSound->m_pData, pSound->m_DataSize, true);
 			}
 
 			m_vpSounds.push_back(pSound);

--- a/src/game/editor/mapitems/sound.cpp
+++ b/src/game/editor/mapitems/sound.cpp
@@ -9,7 +9,7 @@ CEditorSound::CEditorSound(CEditor *pEditor)
 
 CEditorSound::~CEditorSound()
 {
-	Sound()->UnloadSample(m_SoundID);
+	Sound()->UnloadSample(m_SoundId);
 	free(m_pData);
 	m_pData = nullptr;
 }

--- a/src/game/editor/mapitems/sound.h
+++ b/src/game/editor/mapitems/sound.h
@@ -10,7 +10,7 @@ public:
 	explicit CEditorSound(CEditor *pEditor);
 	~CEditorSound();
 
-	int m_SoundID = 0;
+	int m_SoundId = 0;
 	char m_aName[IO_MAX_PATH_LENGTH] = "";
 
 	void *m_pData = nullptr;

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -21,7 +21,7 @@
 
 using namespace FontIcons;
 
-CUI::EPopupMenuFunctionResult CEditor::PopupMenuFile(void *pContext, CUIRect View, bool Active)
+CUi::EPopupMenuFunctionResult CEditor::PopupMenuFile(void *pContext, CUIRect View, bool Active)
 {
 	CEditor *pEditor = static_cast<CEditor *>(pContext);
 
@@ -49,7 +49,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupMenuFile(void *pContext, CUIRect Vie
 			pEditor->Reset();
 			pEditor->m_aFileName[0] = 0;
 		}
-		return CUI::POPUP_CLOSE_CURRENT;
+		return CUi::POPUP_CLOSE_CURRENT;
 	}
 
 	View.HSplitTop(10.0f, nullptr, &View);
@@ -63,7 +63,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupMenuFile(void *pContext, CUIRect Vie
 		}
 		else
 			pEditor->InvokeFileDialog(IStorage::TYPE_ALL, FILETYPE_MAP, "Load map", "Load", "maps", false, CEditor::CallbackOpenMap, pEditor);
-		return CUI::POPUP_CLOSE_CURRENT;
+		return CUi::POPUP_CLOSE_CURRENT;
 	}
 
 	View.HSplitTop(2.0f, nullptr, &View);
@@ -79,7 +79,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupMenuFile(void *pContext, CUIRect Vie
 		{
 			pEditor->LoadCurrentMap();
 		}
-		return CUI::POPUP_CLOSE_CURRENT;
+		return CUi::POPUP_CLOSE_CURRENT;
 	}
 
 	View.HSplitTop(10.0f, nullptr, &View);
@@ -87,7 +87,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupMenuFile(void *pContext, CUIRect Vie
 	if(pEditor->DoButton_MenuItem(&s_AppendButton, "Append", 0, &Slot, 0, "Opens a map and adds everything from that map to the current one (ctrl+a)"))
 	{
 		pEditor->InvokeFileDialog(IStorage::TYPE_ALL, FILETYPE_MAP, "Append map", "Append", "maps", false, CEditor::CallbackAppendMap, pEditor);
-		return CUI::POPUP_CLOSE_CURRENT;
+		return CUi::POPUP_CLOSE_CURRENT;
 	}
 
 	View.HSplitTop(10.0f, nullptr, &View);
@@ -102,7 +102,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupMenuFile(void *pContext, CUIRect Vie
 		}
 		else
 			pEditor->InvokeFileDialog(IStorage::TYPE_SAVE, FILETYPE_MAP, "Save map", "Save", "maps", false, CEditor::CallbackSaveMap, pEditor);
-		return CUI::POPUP_CLOSE_CURRENT;
+		return CUi::POPUP_CLOSE_CURRENT;
 	}
 
 	View.HSplitTop(2.0f, nullptr, &View);
@@ -110,7 +110,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupMenuFile(void *pContext, CUIRect Vie
 	if(pEditor->DoButton_MenuItem(&s_SaveAsButton, "Save As", 0, &Slot, 0, "Saves the current map under a new name (ctrl+shift+s)"))
 	{
 		pEditor->InvokeFileDialog(IStorage::TYPE_SAVE, FILETYPE_MAP, "Save map", "Save", "maps", true, CEditor::CallbackSaveMap, pEditor);
-		return CUI::POPUP_CLOSE_CURRENT;
+		return CUi::POPUP_CLOSE_CURRENT;
 	}
 
 	View.HSplitTop(2.0f, nullptr, &View);
@@ -118,21 +118,21 @@ CUI::EPopupMenuFunctionResult CEditor::PopupMenuFile(void *pContext, CUIRect Vie
 	if(pEditor->DoButton_MenuItem(&s_SaveCopyButton, "Save Copy", 0, &Slot, 0, "Saves a copy of the current map under a new name (ctrl+shift+alt+s)"))
 	{
 		pEditor->InvokeFileDialog(IStorage::TYPE_SAVE, FILETYPE_MAP, "Save map", "Save", "maps", true, CEditor::CallbackSaveCopyMap, pEditor);
-		return CUI::POPUP_CLOSE_CURRENT;
+		return CUi::POPUP_CLOSE_CURRENT;
 	}
 
 	View.HSplitTop(10.0f, nullptr, &View);
 	View.HSplitTop(12.0f, &Slot, &View);
 	if(pEditor->DoButton_MenuItem(&s_MapInfoButton, "Map details", 0, &Slot, 0, "Adjust the map details of the current map"))
 	{
-		const CUIRect *pScreen = pEditor->UI()->Screen();
+		const CUIRect *pScreen = pEditor->Ui()->Screen();
 		pEditor->m_Map.m_MapInfoTmp.Copy(pEditor->m_Map.m_MapInfo);
 		static SPopupMenuId s_PopupMapInfoId;
 		constexpr float PopupWidth = 400.0f;
 		constexpr float PopupHeight = 170.0f;
-		pEditor->UI()->DoPopupMenu(&s_PopupMapInfoId, pScreen->w / 2.0f - PopupWidth / 2.0f, pScreen->h / 2.0f - PopupHeight / 2.0f, PopupWidth, PopupHeight, pEditor, PopupMapInfo);
-		pEditor->UI()->SetActiveItem(nullptr);
-		return CUI::POPUP_CLOSE_CURRENT;
+		pEditor->Ui()->DoPopupMenu(&s_PopupMapInfoId, pScreen->w / 2.0f - PopupWidth / 2.0f, pScreen->h / 2.0f - PopupHeight / 2.0f, PopupWidth, PopupHeight, pEditor, PopupMapInfo);
+		pEditor->Ui()->SetActiveItem(nullptr);
+		return CUi::POPUP_CLOSE_CURRENT;
 	}
 
 	View.HSplitTop(10.0f, nullptr, &View);
@@ -149,33 +149,33 @@ CUI::EPopupMenuFunctionResult CEditor::PopupMenuFile(void *pContext, CUIRect Vie
 			pEditor->OnClose();
 			g_Config.m_ClEditor = 0;
 		}
-		return CUI::POPUP_CLOSE_CURRENT;
+		return CUi::POPUP_CLOSE_CURRENT;
 	}
 
-	return CUI::POPUP_KEEP_OPEN;
+	return CUi::POPUP_KEEP_OPEN;
 }
 
-CUI::EPopupMenuFunctionResult CEditor::PopupMenuTools(void *pContext, CUIRect View, bool Active)
+CUi::EPopupMenuFunctionResult CEditor::PopupMenuTools(void *pContext, CUIRect View, bool Active)
 {
 	CEditor *pEditor = static_cast<CEditor *>(pContext);
 
 	CUIRect Slot;
 	View.HSplitTop(12.0f, &Slot, &View);
 	static int s_RemoveUnusedEnvelopesButton = 0;
-	static CUI::SConfirmPopupContext s_ConfirmPopupContext;
+	static CUi::SConfirmPopupContext s_ConfirmPopupContext;
 	if(pEditor->DoButton_MenuItem(&s_RemoveUnusedEnvelopesButton, "Remove unused envelopes", 0, &Slot, 0, "Removes all unused envelopes from the map"))
 	{
 		s_ConfirmPopupContext.Reset();
 		s_ConfirmPopupContext.YesNoButtons();
 		str_copy(s_ConfirmPopupContext.m_aMessage, "Are you sure that you want to remove all unused envelopes from this map?");
-		pEditor->UI()->ShowPopupConfirm(Slot.x + Slot.w, Slot.y, &s_ConfirmPopupContext);
+		pEditor->Ui()->ShowPopupConfirm(Slot.x + Slot.w, Slot.y, &s_ConfirmPopupContext);
 	}
-	if(s_ConfirmPopupContext.m_Result == CUI::SConfirmPopupContext::CONFIRMED)
+	if(s_ConfirmPopupContext.m_Result == CUi::SConfirmPopupContext::CONFIRMED)
 		pEditor->RemoveUnusedEnvelopes();
-	if(s_ConfirmPopupContext.m_Result != CUI::SConfirmPopupContext::UNSET)
+	if(s_ConfirmPopupContext.m_Result != CUi::SConfirmPopupContext::UNSET)
 	{
 		s_ConfirmPopupContext.Reset();
-		return CUI::POPUP_CLOSE_CURRENT;
+		return CUi::POPUP_CLOSE_CURRENT;
 	}
 
 	static int s_BorderButton = 0;
@@ -191,10 +191,10 @@ CUI::EPopupMenuFunctionResult CEditor::PopupMenuTools(void *pContext, CUIRect Vi
 		}
 		else
 		{
-			static CUI::SMessagePopupContext s_MessagePopupContext;
+			static CUi::SMessagePopupContext s_MessagePopupContext;
 			s_MessagePopupContext.DefaultColor(pEditor->m_pTextRender);
 			str_copy(s_MessagePopupContext.m_aMessage, "No tile layer selected");
-			pEditor->UI()->ShowPopupMessage(Slot.x, Slot.y + Slot.h, &s_MessagePopupContext);
+			pEditor->Ui()->ShowPopupMessage(Slot.x, Slot.y + Slot.h, &s_MessagePopupContext);
 		}
 	}
 
@@ -204,7 +204,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupMenuTools(void *pContext, CUIRect Vi
 	if(pEditor->DoButton_MenuItem(&s_GotoButton, "Goto XY", 0, &Slot, 0, "Go to a specified coordinate point on the map"))
 	{
 		static SPopupMenuId s_PopupGotoId;
-		pEditor->UI()->DoPopupMenu(&s_PopupGotoId, Slot.x, Slot.y + Slot.h, 120, 52, pEditor, PopupGoto);
+		pEditor->Ui()->DoPopupMenu(&s_PopupGotoId, Slot.x, Slot.y + Slot.h, 120, 52, pEditor, PopupGoto);
 	}
 
 	static int s_TileartButton = 0;
@@ -213,10 +213,10 @@ CUI::EPopupMenuFunctionResult CEditor::PopupMenuTools(void *pContext, CUIRect Vi
 	if(pEditor->DoButton_MenuItem(&s_TileartButton, "Add tileart", 0, &Slot, 0, "Generate tileart from image"))
 	{
 		pEditor->InvokeFileDialog(IStorage::TYPE_ALL, FILETYPE_IMG, "Add tileart", "Open", "mapres", false, CallbackAddTileart, pEditor);
-		return CUI::POPUP_CLOSE_CURRENT;
+		return CUi::POPUP_CLOSE_CURRENT;
 	}
 
-	return CUI::POPUP_KEEP_OPEN;
+	return CUi::POPUP_KEEP_OPEN;
 }
 
 static int EntitiesListdirCallback(const char *pName, int IsDir, int StorageType, void *pUser)
@@ -231,23 +231,23 @@ static int EntitiesListdirCallback(const char *pName, int IsDir, int StorageType
 	return 0;
 }
 
-CUI::EPopupMenuFunctionResult CEditor::PopupMenuSettings(void *pContext, CUIRect View, bool Active)
+CUi::EPopupMenuFunctionResult CEditor::PopupMenuSettings(void *pContext, CUIRect View, bool Active)
 {
 	CEditor *pEditor = static_cast<CEditor *>(pContext);
 
 	CUIRect Slot;
 	View.HSplitTop(12.0f, &Slot, &View);
-	static int s_EntitiesButtonID = 0;
+	static int s_EntitiesButtonId = 0;
 	char aButtonText[64];
 	str_format(aButtonText, sizeof(aButtonText), "Entities: %s", pEditor->m_SelectEntitiesImage.c_str());
-	if(pEditor->DoButton_MenuItem(&s_EntitiesButtonID, aButtonText, 0, &Slot, 0, "Choose game layer entities image for different gametypes"))
+	if(pEditor->DoButton_MenuItem(&s_EntitiesButtonId, aButtonText, 0, &Slot, 0, "Choose game layer entities image for different gametypes"))
 	{
 		pEditor->m_vSelectEntitiesFiles.clear();
 		pEditor->Storage()->ListDirectory(IStorage::TYPE_ALL, "editor/entities", EntitiesListdirCallback, pEditor);
 		std::sort(pEditor->m_vSelectEntitiesFiles.begin(), pEditor->m_vSelectEntitiesFiles.end());
 
 		static SPopupMenuId s_PopupEntitiesId;
-		pEditor->UI()->DoPopupMenu(&s_PopupEntitiesId, Slot.x, Slot.y + Slot.h, 250, pEditor->m_vSelectEntitiesFiles.size() * 14.0f + 10.0f, pEditor, PopupEntities);
+		pEditor->Ui()->DoPopupMenu(&s_PopupEntitiesId, Slot.x, Slot.y + Slot.h, 250, pEditor->m_vSelectEntitiesFiles.size() * 14.0f + 10.0f, pEditor, PopupEntities);
 	}
 
 	View.HSplitTop(2.0f, nullptr, &View);
@@ -260,7 +260,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupMenuSettings(void *pContext, CUIRect
 		CUIRect No, Yes;
 		Selector.VSplitMid(&No, &Yes);
 
-		pEditor->UI()->DoLabel(&Label, "Brush coloring", 10.0f, TEXTALIGN_ML);
+		pEditor->Ui()->DoLabel(&Label, "Brush coloring", 10.0f, TEXTALIGN_ML);
 		static int s_ButtonNo = 0;
 		static int s_ButtonYes = 0;
 		if(pEditor->DoButton_Ex(&s_ButtonNo, "No", !pEditor->m_BrushColorEnabled, &No, 0, "Disable brush coloring", IGraphics::CORNER_L))
@@ -283,7 +283,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupMenuSettings(void *pContext, CUIRect
 		CUIRect No, Yes;
 		Selector.VSplitMid(&No, &Yes);
 
-		pEditor->UI()->DoLabel(&Label, "Allow unused", 10.0f, TEXTALIGN_ML);
+		pEditor->Ui()->DoLabel(&Label, "Allow unused", 10.0f, TEXTALIGN_ML);
 		if(pEditor->m_AllowPlaceUnusedTiles != -1)
 		{
 			static int s_ButtonNo = 0;
@@ -310,7 +310,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupMenuSettings(void *pContext, CUIRect
 		Selector.VSplitLeft(Selector.w / 3.0f, &Off, &Selector);
 		Selector.VSplitMid(&Dec, &Hex);
 
-		pEditor->UI()->DoLabel(&Label, "Show Info", 10.0f, TEXTALIGN_ML);
+		pEditor->Ui()->DoLabel(&Label, "Show Info", 10.0f, TEXTALIGN_ML);
 		static int s_ButtonOff = 0;
 		static int s_ButtonDec = 0;
 		static int s_ButtonHex = 0;
@@ -341,7 +341,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupMenuSettings(void *pContext, CUIRect
 		CUIRect No, Yes;
 		Selector.VSplitMid(&No, &Yes);
 
-		pEditor->UI()->DoLabel(&Label, "Align quads", 10.0f, TEXTALIGN_ML);
+		pEditor->Ui()->DoLabel(&Label, "Align quads", 10.0f, TEXTALIGN_ML);
 
 		static int s_ButtonNo = 0;
 		static int s_ButtonYes = 0;
@@ -365,7 +365,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupMenuSettings(void *pContext, CUIRect
 		CUIRect No, Yes;
 		Selector.VSplitMid(&No, &Yes);
 
-		pEditor->UI()->DoLabel(&Label, "Show quads bounds", 10.0f, TEXTALIGN_ML);
+		pEditor->Ui()->DoLabel(&Label, "Show quads bounds", 10.0f, TEXTALIGN_ML);
 
 		static int s_ButtonNo = 0;
 		static int s_ButtonYes = 0;
@@ -379,10 +379,10 @@ CUI::EPopupMenuFunctionResult CEditor::PopupMenuSettings(void *pContext, CUIRect
 		}
 	}
 
-	return CUI::POPUP_KEEP_OPEN;
+	return CUi::POPUP_KEEP_OPEN;
 }
 
-CUI::EPopupMenuFunctionResult CEditor::PopupGroup(void *pContext, CUIRect View, bool Active)
+CUi::EPopupMenuFunctionResult CEditor::PopupGroup(void *pContext, CUIRect View, bool Active)
 {
 	CEditor *pEditor = static_cast<CEditor *>(pContext);
 
@@ -399,7 +399,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupGroup(void *pContext, CUIRect View, 
 			pEditor->m_EditorHistory.RecordAction(std::make_shared<CEditorActionGroup>(pEditor, pEditor->m_SelectedGroup, true));
 			pEditor->m_Map.DeleteGroup(pEditor->m_SelectedGroup);
 			pEditor->m_SelectedGroup = maximum(0, pEditor->m_SelectedGroup - 1);
-			return CUI::POPUP_CLOSE_CURRENT;
+			return CUi::POPUP_CLOSE_CURRENT;
 		}
 	}
 	else
@@ -461,7 +461,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupGroup(void *pContext, CUIRect View, 
 				pGameLayer->ClearHistory();
 			}
 
-			return CUI::POPUP_CLOSE_CURRENT;
+			return CUi::POPUP_CLOSE_CURRENT;
 		}
 	}
 
@@ -480,7 +480,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupGroup(void *pContext, CUIRect View, 
 			pEditor->SelectLayer(LayerIndex);
 			pEditor->m_pBrush->Clear();
 			pEditor->m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(pEditor, pEditor->m_SelectedGroup, LayerIndex));
-			return CUI::POPUP_CLOSE_CURRENT;
+			return CUi::POPUP_CLOSE_CURRENT;
 		}
 	}
 
@@ -499,7 +499,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupGroup(void *pContext, CUIRect View, 
 			pEditor->SelectLayer(LayerIndex);
 			pEditor->m_pBrush->Clear();
 			pEditor->m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(pEditor, pEditor->m_SelectedGroup, LayerIndex));
-			return CUI::POPUP_CLOSE_CURRENT;
+			return CUi::POPUP_CLOSE_CURRENT;
 		}
 	}
 
@@ -518,7 +518,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupGroup(void *pContext, CUIRect View, 
 			pEditor->SelectLayer(LayerIndex);
 			pEditor->m_pBrush->Clear();
 			pEditor->m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(pEditor, pEditor->m_SelectedGroup, LayerIndex));
-			return CUI::POPUP_CLOSE_CURRENT;
+			return CUi::POPUP_CLOSE_CURRENT;
 		}
 	}
 
@@ -537,7 +537,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupGroup(void *pContext, CUIRect View, 
 			pEditor->SelectLayer(LayerIndex);
 			pEditor->m_pBrush->Clear();
 			pEditor->m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(pEditor, pEditor->m_SelectedGroup, LayerIndex));
-			return CUI::POPUP_CLOSE_CURRENT;
+			return CUi::POPUP_CLOSE_CURRENT;
 		}
 	}
 
@@ -556,7 +556,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupGroup(void *pContext, CUIRect View, 
 			pEditor->SelectLayer(LayerIndex);
 			pEditor->m_pBrush->Clear();
 			pEditor->m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(pEditor, pEditor->m_SelectedGroup, LayerIndex));
-			return CUI::POPUP_CLOSE_CURRENT;
+			return CUi::POPUP_CLOSE_CURRENT;
 		}
 	}
 
@@ -572,7 +572,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupGroup(void *pContext, CUIRect View, 
 		pEditor->SelectLayer(LayerIndex);
 		pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_Collapse = false;
 		pEditor->m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(pEditor, pEditor->m_SelectedGroup, LayerIndex));
-		return CUI::POPUP_CLOSE_CURRENT;
+		return CUi::POPUP_CLOSE_CURRENT;
 	}
 
 	// new tile layer
@@ -588,7 +588,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupGroup(void *pContext, CUIRect View, 
 		pEditor->SelectLayer(LayerIndex);
 		pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_Collapse = false;
 		pEditor->m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(pEditor, pEditor->m_SelectedGroup, LayerIndex));
-		return CUI::POPUP_CLOSE_CURRENT;
+		return CUi::POPUP_CLOSE_CURRENT;
 	}
 
 	// new sound layer
@@ -603,7 +603,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupGroup(void *pContext, CUIRect View, 
 		pEditor->SelectLayer(LayerIndex);
 		pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_Collapse = false;
 		pEditor->m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(pEditor, pEditor->m_SelectedGroup, LayerIndex));
-		return CUI::POPUP_CLOSE_CURRENT;
+		return CUi::POPUP_CLOSE_CURRENT;
 	}
 
 	// group name
@@ -611,7 +611,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupGroup(void *pContext, CUIRect View, 
 	{
 		View.HSplitBottom(5.0f, &View, nullptr);
 		View.HSplitBottom(12.0f, &View, &Button);
-		pEditor->UI()->DoLabel(&Button, "Name:", 10.0f, TEXTALIGN_ML);
+		pEditor->Ui()->DoLabel(&Button, "Name:", 10.0f, TEXTALIGN_ML);
 		Button.VSplitLeft(40.0f, nullptr, &Button);
 		static CLineInput s_NameInput;
 		s_NameInput.SetBuffer(pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_aName, sizeof(pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->m_aName));
@@ -696,10 +696,10 @@ CUI::EPopupMenuFunctionResult CEditor::PopupGroup(void *pContext, CUIRect View, 
 
 	s_Tracker.End(Prop, State);
 
-	return CUI::POPUP_KEEP_OPEN;
+	return CUi::POPUP_KEEP_OPEN;
 }
 
-CUI::EPopupMenuFunctionResult CEditor::PopupLayer(void *pContext, CUIRect View, bool Active)
+CUi::EPopupMenuFunctionResult CEditor::PopupLayer(void *pContext, CUIRect View, bool Active)
 {
 	SLayerPopupContext *pPopup = (SLayerPopupContext *)pContext;
 	CEditor *pEditor = pPopup->m_pEditor;
@@ -736,7 +736,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupLayer(void *pContext, CUIRect View, 
 				pEditor->m_Map.m_pTuneLayer = nullptr;
 			pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->DeleteLayer(pEditor->m_vSelectedLayers[0]);
 
-			return CUI::POPUP_CLOSE_CURRENT;
+			return CUi::POPUP_CLOSE_CURRENT;
 		}
 	}
 
@@ -751,7 +751,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupLayer(void *pContext, CUIRect View, 
 		{
 			pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->DuplicateLayer(pEditor->m_vSelectedLayers[0]);
 			pEditor->m_EditorHistory.RecordAction(std::make_shared<CEditorActionAddLayer>(pEditor, pEditor->m_SelectedGroup, pEditor->m_vSelectedLayers[0] + 1, true));
-			return CUI::POPUP_CLOSE_CURRENT;
+			return CUi::POPUP_CLOSE_CURRENT;
 		}
 	}
 
@@ -762,7 +762,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupLayer(void *pContext, CUIRect View, 
 		View.HSplitBottom(5.0f, &View, nullptr);
 		View.HSplitBottom(12.0f, &View, &Label);
 		Label.VSplitLeft(40.0f, &Label, &EditBox);
-		pEditor->UI()->DoLabel(&Label, "Name:", 10.0f, TEXTALIGN_ML);
+		pEditor->Ui()->DoLabel(&Label, "Name:", 10.0f, TEXTALIGN_ML);
 		static CLineInput s_NameInput;
 		s_NameInput.SetBuffer(pCurrentLayer->m_aName, sizeof(pCurrentLayer->m_aName));
 		if(pEditor->DoEditBox(&s_NameInput, &EditBox, 10.0f))
@@ -827,12 +827,12 @@ CUI::EPopupMenuFunctionResult CEditor::PopupLayer(void *pContext, CUIRect View, 
 	return pCurrentLayer->RenderProperties(&View);
 }
 
-CUI::EPopupMenuFunctionResult CEditor::PopupQuad(void *pContext, CUIRect View, bool Active)
+CUi::EPopupMenuFunctionResult CEditor::PopupQuad(void *pContext, CUIRect View, bool Active)
 {
 	CEditor *pEditor = static_cast<CEditor *>(pContext);
 	std::vector<CQuad *> vpQuads = pEditor->GetSelectedQuads();
 	if(pEditor->m_SelectedQuadIndex < 0 || pEditor->m_SelectedQuadIndex >= (int)vpQuads.size())
-		return CUI::POPUP_CLOSE_CURRENT;
+		return CUi::POPUP_CLOSE_CURRENT;
 	CQuad *pCurrentQuad = vpQuads[pEditor->m_SelectedQuadIndex];
 	std::shared_ptr<CLayerQuads> pLayer = std::static_pointer_cast<CLayerQuads>(pEditor->GetSelectedLayerType(0, LAYERTYPE_QUADS));
 
@@ -848,7 +848,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupQuad(void *pContext, CUIRect View, b
 			pEditor->m_Map.OnModify();
 			pEditor->DeleteSelectedQuads();
 		}
-		return CUI::POPUP_CLOSE_CURRENT;
+		return CUi::POPUP_CLOSE_CURRENT;
 	}
 
 	// aspect ratio button
@@ -890,7 +890,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupQuad(void *pContext, CUIRect View, b
 			}
 			pEditor->m_QuadTracker.EndQuadTrack();
 
-			return CUI::POPUP_CLOSE_CURRENT;
+			return CUi::POPUP_CLOSE_CURRENT;
 		}
 	}
 
@@ -911,7 +911,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupQuad(void *pContext, CUIRect View, b
 			pEditor->m_Map.OnModify();
 		}
 		pEditor->m_QuadTracker.EndQuadTrack();
-		return CUI::POPUP_CLOSE_CURRENT;
+		return CUi::POPUP_CLOSE_CURRENT;
 	}
 
 	// square button
@@ -951,7 +951,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupQuad(void *pContext, CUIRect View, b
 			pEditor->m_Map.OnModify();
 		}
 		pEditor->m_QuadTracker.EndQuadTrack();
-		return CUI::POPUP_CLOSE_CURRENT;
+		return CUi::POPUP_CLOSE_CURRENT;
 	}
 
 	// slice button
@@ -962,7 +962,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupQuad(void *pContext, CUIRect View, b
 	{
 		pEditor->m_QuadKnifeCount = 0;
 		pEditor->m_QuadKnifeActive = true;
-		return CUI::POPUP_CLOSE_CURRENT;
+		return CUi::POPUP_CLOSE_CURRENT;
 	}
 
 	const int NumQuads = pLayer ? (int)pLayer->m_vQuads.size() : 0;
@@ -1061,15 +1061,15 @@ CUI::EPopupMenuFunctionResult CEditor::PopupQuad(void *pContext, CUIRect View, b
 		}
 	}
 
-	return CUI::POPUP_KEEP_OPEN;
+	return CUi::POPUP_KEEP_OPEN;
 }
 
-CUI::EPopupMenuFunctionResult CEditor::PopupSource(void *pContext, CUIRect View, bool Active)
+CUi::EPopupMenuFunctionResult CEditor::PopupSource(void *pContext, CUIRect View, bool Active)
 {
 	CEditor *pEditor = static_cast<CEditor *>(pContext);
 	CSoundSource *pSource = pEditor->GetSelectedSource();
 	if(!pSource)
-		return CUI::POPUP_CLOSE_CURRENT;
+		return CUi::POPUP_CLOSE_CURRENT;
 
 	CUIRect Button;
 
@@ -1083,7 +1083,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupSource(void *pContext, CUIRect View,
 		{
 			pEditor->m_EditorHistory.Execute(std::make_shared<CEditorActionDeleteSoundSource>(pEditor, pEditor->m_SelectedGroup, pEditor->m_vSelectedLayers[0], pEditor->m_SelectedSource));
 		}
-		return CUI::POPUP_CLOSE_CURRENT;
+		return CUi::POPUP_CLOSE_CURRENT;
 	}
 
 	// Sound shape button
@@ -1252,15 +1252,15 @@ CUI::EPopupMenuFunctionResult CEditor::PopupSource(void *pContext, CUIRect View,
 	}
 	}
 
-	return CUI::POPUP_KEEP_OPEN;
+	return CUi::POPUP_KEEP_OPEN;
 }
 
-CUI::EPopupMenuFunctionResult CEditor::PopupPoint(void *pContext, CUIRect View, bool Active)
+CUi::EPopupMenuFunctionResult CEditor::PopupPoint(void *pContext, CUIRect View, bool Active)
 {
 	CEditor *pEditor = static_cast<CEditor *>(pContext);
 	std::vector<CQuad *> vpQuads = pEditor->GetSelectedQuads();
 	if(!in_range<int>(pEditor->m_SelectedQuadIndex, 0, vpQuads.size() - 1))
-		return CUI::POPUP_CLOSE_CURRENT;
+		return CUi::POPUP_CLOSE_CURRENT;
 	CQuad *pCurrentQuad = vpQuads[pEditor->m_SelectedQuadIndex];
 	std::shared_ptr<CLayerQuads> pLayer = std::static_pointer_cast<CLayerQuads>(pEditor->GetSelectedLayerType(0, LAYERTYPE_QUADS));
 
@@ -1344,14 +1344,14 @@ CUI::EPopupMenuFunctionResult CEditor::PopupPoint(void *pContext, CUIRect View, 
 		}
 	}
 
-	return CUI::POPUP_KEEP_OPEN;
+	return CUi::POPUP_KEEP_OPEN;
 }
 
-CUI::EPopupMenuFunctionResult CEditor::PopupEnvPoint(void *pContext, CUIRect View, bool Active)
+CUi::EPopupMenuFunctionResult CEditor::PopupEnvPoint(void *pContext, CUIRect View, bool Active)
 {
 	CEditor *pEditor = static_cast<CEditor *>(pContext);
 	if(pEditor->m_SelectedEnvelope < 0 || pEditor->m_SelectedEnvelope >= (int)pEditor->m_Map.m_vpEnvelopes.size())
-		return CUI::POPUP_CLOSE_CURRENT;
+		return CUi::POPUP_CLOSE_CURRENT;
 
 	const float RowHeight = 12.0f;
 	CUIRect Row, Label, EditBox;
@@ -1366,7 +1366,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupEnvPoint(void *pContext, CUIRect Vie
 		View.HSplitTop(4.0f, nullptr, &View);
 		Row.VSplitLeft(60.0f, &Label, &Row);
 		Row.VSplitLeft(10.0f, nullptr, &EditBox);
-		pEditor->UI()->DoLabel(&Label, "Color:", RowHeight - 2.0f, TEXTALIGN_ML);
+		pEditor->Ui()->DoLabel(&Label, "Color:", RowHeight - 2.0f, TEXTALIGN_ML);
 
 		const auto SelectedPoint = pEditor->m_vSelectedEnvelopePoints.front();
 		const int SelectedIndex = SelectedPoint.first;
@@ -1435,14 +1435,14 @@ CUI::EPopupMenuFunctionResult CEditor::PopupEnvPoint(void *pContext, CUIRect Vie
 	View.HSplitTop(RowHeight, &Row, &View);
 	Row.VSplitLeft(60.0f, &Label, &Row);
 	Row.VSplitLeft(10.0f, nullptr, &EditBox);
-	pEditor->UI()->DoLabel(&Label, "Value:", RowHeight - 2.0f, TEXTALIGN_ML);
+	pEditor->Ui()->DoLabel(&Label, "Value:", RowHeight - 2.0f, TEXTALIGN_ML);
 	pEditor->DoEditBox(&s_CurValueInput, &EditBox, RowHeight - 2.0f, IGraphics::CORNER_ALL, "The value of the selected envelope point");
 
 	View.HSplitTop(4.0f, nullptr, &View);
 	View.HSplitTop(RowHeight, &Row, &View);
 	Row.VSplitLeft(60.0f, &Label, &Row);
 	Row.VSplitLeft(10.0f, nullptr, &EditBox);
-	pEditor->UI()->DoLabel(&Label, "Time (in s):", RowHeight - 2.0f, TEXTALIGN_ML);
+	pEditor->Ui()->DoLabel(&Label, "Time (in s):", RowHeight - 2.0f, TEXTALIGN_ML);
 	pEditor->DoEditBox(&s_CurTimeInput, &EditBox, RowHeight - 2.0f, IGraphics::CORNER_ALL, "The time of the selected envelope point");
 
 	if(pEditor->Input()->KeyIsPressed(KEY_RETURN) || pEditor->Input()->KeyIsPressed(KEY_KP_ENTER))
@@ -1493,10 +1493,10 @@ CUI::EPopupMenuFunctionResult CEditor::PopupEnvPoint(void *pContext, CUIRect Vie
 
 	View.HSplitTop(6.0f, nullptr, &View);
 	View.HSplitTop(RowHeight, &Row, &View);
-	static int s_DeleteButtonID = 0;
+	static int s_DeleteButtonId = 0;
 	const char *pButtonText = pEditor->IsTangentSelected() ? "Reset" : "Delete";
 	const char *pTooltip = pEditor->IsTangentSelected() ? "Reset tangent point to default value." : "Delete current envelope point in all channels.";
-	if(pEditor->DoButton_Editor(&s_DeleteButtonID, pButtonText, 0, &Row, 0, pTooltip))
+	if(pEditor->DoButton_Editor(&s_DeleteButtonId, pButtonText, 0, &Row, 0, pTooltip))
 	{
 		if(pEditor->IsTangentInSelected())
 		{
@@ -1514,64 +1514,64 @@ CUI::EPopupMenuFunctionResult CEditor::PopupEnvPoint(void *pContext, CUIRect Vie
 			pEditor->m_EnvelopeEditorHistory.Execute(std::make_shared<CEditorActionDeleteEnvelopePoint>(pEditor, pEditor->m_SelectedEnvelope, SelectedIndex));
 		}
 
-		return CUI::POPUP_CLOSE_CURRENT;
+		return CUi::POPUP_CLOSE_CURRENT;
 	}
 
-	return CUI::POPUP_KEEP_OPEN;
+	return CUi::POPUP_KEEP_OPEN;
 }
 
-CUI::EPopupMenuFunctionResult CEditor::PopupEnvPointMulti(void *pContext, CUIRect View, bool Active)
+CUi::EPopupMenuFunctionResult CEditor::PopupEnvPointMulti(void *pContext, CUIRect View, bool Active)
 {
 	CEditor *pEditor = static_cast<CEditor *>(pContext);
 	const float RowHeight = 12.0f;
 
-	static int s_CurveButtonID = 0;
+	static int s_CurveButtonId = 0;
 	CUIRect CurveButton;
 	View.HSplitTop(RowHeight, &CurveButton, &View);
-	if(pEditor->DoButton_Editor(&s_CurveButtonID, "Project onto", 0, &CurveButton, 0, "Project all selected envelopes onto the curve between the first and last selected envelope."))
+	if(pEditor->DoButton_Editor(&s_CurveButtonId, "Project onto", 0, &CurveButton, 0, "Project all selected envelopes onto the curve between the first and last selected envelope."))
 	{
 		static SPopupMenuId s_PopupCurveTypeId;
-		pEditor->UI()->DoPopupMenu(&s_PopupCurveTypeId, pEditor->UI()->MouseX(), pEditor->UI()->MouseY(), 80, 80, pEditor, PopupEnvPointCurveType);
+		pEditor->Ui()->DoPopupMenu(&s_PopupCurveTypeId, pEditor->Ui()->MouseX(), pEditor->Ui()->MouseY(), 80, 80, pEditor, PopupEnvPointCurveType);
 	}
 
-	return CUI::POPUP_KEEP_OPEN;
+	return CUi::POPUP_KEEP_OPEN;
 }
 
-CUI::EPopupMenuFunctionResult CEditor::PopupEnvPointCurveType(void *pContext, CUIRect View, bool Active)
+CUi::EPopupMenuFunctionResult CEditor::PopupEnvPointCurveType(void *pContext, CUIRect View, bool Active)
 {
 	CEditor *pEditor = static_cast<CEditor *>(pContext);
 	const float RowHeight = 14.0f;
 
 	int CurveType = -1;
 
-	static int s_ButtonLinearID;
+	static int s_ButtonLinearId;
 	CUIRect ButtonLinear;
 	View.HSplitTop(RowHeight, &ButtonLinear, &View);
-	if(pEditor->DoButton_MenuItem(&s_ButtonLinearID, "Linear", 0, &ButtonLinear))
+	if(pEditor->DoButton_MenuItem(&s_ButtonLinearId, "Linear", 0, &ButtonLinear))
 		CurveType = CURVETYPE_LINEAR;
 
-	static int s_ButtonSlowID;
+	static int s_ButtonSlowId;
 	CUIRect ButtonSlow;
 	View.HSplitTop(RowHeight, &ButtonSlow, &View);
-	if(pEditor->DoButton_MenuItem(&s_ButtonSlowID, "Slow", 0, &ButtonSlow))
+	if(pEditor->DoButton_MenuItem(&s_ButtonSlowId, "Slow", 0, &ButtonSlow))
 		CurveType = CURVETYPE_SLOW;
 
-	static int s_ButtonFastID;
+	static int s_ButtonFastId;
 	CUIRect ButtonFast;
 	View.HSplitTop(RowHeight, &ButtonFast, &View);
-	if(pEditor->DoButton_MenuItem(&s_ButtonFastID, "Fast", 0, &ButtonFast))
+	if(pEditor->DoButton_MenuItem(&s_ButtonFastId, "Fast", 0, &ButtonFast))
 		CurveType = CURVETYPE_FAST;
 
-	static int s_ButtonStepID;
+	static int s_ButtonStepId;
 	CUIRect ButtonStep;
 	View.HSplitTop(RowHeight, &ButtonStep, &View);
-	if(pEditor->DoButton_MenuItem(&s_ButtonStepID, "Step", 0, &ButtonStep))
+	if(pEditor->DoButton_MenuItem(&s_ButtonStepId, "Step", 0, &ButtonStep))
 		CurveType = CURVETYPE_STEP;
 
-	static int s_ButtonSmoothID;
+	static int s_ButtonSmoothId;
 	CUIRect ButtonSmooth;
 	View.HSplitTop(RowHeight, &ButtonSmooth, &View);
-	if(pEditor->DoButton_MenuItem(&s_ButtonSmoothID, "Smooth", 0, &ButtonSmooth))
+	if(pEditor->DoButton_MenuItem(&s_ButtonSmoothId, "Smooth", 0, &ButtonSmooth))
 		CurveType = CURVETYPE_SMOOTH;
 
 	std::vector<std::shared_ptr<IEditorAction>> vpActions;
@@ -1627,10 +1627,10 @@ CUI::EPopupMenuFunctionResult CEditor::PopupEnvPointCurveType(void *pContext, CU
 		}
 
 		pEditor->m_Map.OnModify();
-		return CUI::POPUP_CLOSE_CURRENT;
+		return CUi::POPUP_CLOSE_CURRENT;
 	}
 
-	return CUI::POPUP_KEEP_OPEN;
+	return CUi::POPUP_KEEP_OPEN;
 }
 
 static const auto &&gs_ModifyIndexDeleted = [](int DeletedIndex) {
@@ -1642,7 +1642,7 @@ static const auto &&gs_ModifyIndexDeleted = [](int DeletedIndex) {
 	};
 };
 
-CUI::EPopupMenuFunctionResult CEditor::PopupImage(void *pContext, CUIRect View, bool Active)
+CUi::EPopupMenuFunctionResult CEditor::PopupImage(void *pContext, CUIRect View, bool Active)
 {
 	CEditor *pEditor = static_cast<CEditor *>(pContext);
 
@@ -1667,7 +1667,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupImage(void *pContext, CUIRect View, 
 		Slot.VMargin(5.0f, &Slot);
 		Slot.VSplitLeft(35.0f, &Label, &Slot);
 		Slot.VSplitLeft(RowHeight - 2.0f, nullptr, &EditBox);
-		pEditor->UI()->DoLabel(&Label, "Name:", RowHeight - 2.0f, TEXTALIGN_ML);
+		pEditor->Ui()->DoLabel(&Label, "Name:", RowHeight - 2.0f, TEXTALIGN_ML);
 
 		s_RenameInput.SetBuffer(pImg->m_aName, sizeof(pImg->m_aName));
 		if(pEditor->DoEditBox(&s_RenameInput, &EditBox, RowHeight - 2.0f))
@@ -1682,7 +1682,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupImage(void *pContext, CUIRect View, 
 		if(pEditor->DoButton_MenuItem(&s_ExternalButton, "Embed", 0, &Slot, 0, "Embeds the image into the map file."))
 		{
 			pImg->m_External = 0;
-			return CUI::POPUP_CLOSE_CURRENT;
+			return CUi::POPUP_CLOSE_CURRENT;
 		}
 		View.HSplitTop(5.0f, nullptr, &View);
 		View.HSplitTop(RowHeight, &Slot, &View);
@@ -1692,13 +1692,13 @@ CUI::EPopupMenuFunctionResult CEditor::PopupImage(void *pContext, CUIRect View, 
 		if(pEditor->DoButton_MenuItem(&s_ExternalButton, "Make external", 0, &Slot, 0, "Removes the image from the map file."))
 		{
 			pImg->m_External = 1;
-			return CUI::POPUP_CLOSE_CURRENT;
+			return CUi::POPUP_CLOSE_CURRENT;
 		}
 		View.HSplitTop(5.0f, nullptr, &View);
 		View.HSplitTop(RowHeight, &Slot, &View);
 	}
 
-	static CUI::SSelectionPopupContext s_SelectionPopupContext;
+	static CUi::SSelectionPopupContext s_SelectionPopupContext;
 	static CScrollRegion s_SelectionPopupScrollRegion;
 	s_SelectionPopupContext.m_pScrollRegion = &s_SelectionPopupScrollRegion;
 	if(pEditor->DoButton_MenuItem(&s_ReaddButton, "Readd", 0, &Slot, 0, "Reloads the image from the mapres folder"))
@@ -1721,7 +1721,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupImage(void *pContext, CUIRect View, 
 		else
 		{
 			str_copy(s_SelectionPopupContext.m_aMessage, "Select the wanted image:");
-			pEditor->UI()->ShowPopupSelection(pEditor->UI()->MouseX(), pEditor->UI()->MouseY(), &s_SelectionPopupContext);
+			pEditor->Ui()->ShowPopupSelection(pEditor->Ui()->MouseX(), pEditor->Ui()->MouseY(), &s_SelectionPopupContext);
 		}
 	}
 	if(s_SelectionPopupContext.m_pSelection != nullptr)
@@ -1730,7 +1730,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupImage(void *pContext, CUIRect View, 
 		const bool Result = pEditor->ReplaceImage(s_SelectionPopupContext.m_pSelection->c_str(), IStorage::TYPE_ALL, false);
 		pImg->m_External = WasExternal;
 		s_SelectionPopupContext.Reset();
-		return Result ? CUI::POPUP_CLOSE_CURRENT : CUI::POPUP_KEEP_OPEN;
+		return Result ? CUi::POPUP_CLOSE_CURRENT : CUi::POPUP_KEEP_OPEN;
 	}
 
 	View.HSplitTop(5.0f, nullptr, &View);
@@ -1738,7 +1738,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupImage(void *pContext, CUIRect View, 
 	if(pEditor->DoButton_MenuItem(&s_ReplaceButton, "Replace", 0, &Slot, 0, "Replaces the image with a new one"))
 	{
 		pEditor->InvokeFileDialog(IStorage::TYPE_ALL, FILETYPE_IMG, "Replace Image", "Replace", "mapres", false, ReplaceImageCallback, pEditor);
-		return CUI::POPUP_CLOSE_CURRENT;
+		return CUi::POPUP_CLOSE_CURRENT;
 	}
 
 	View.HSplitTop(5.0f, nullptr, &View);
@@ -1747,7 +1747,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupImage(void *pContext, CUIRect View, 
 	{
 		pEditor->m_Map.m_vpImages.erase(pEditor->m_Map.m_vpImages.begin() + pEditor->m_SelectedImage);
 		pEditor->m_Map.ModifyImageIndex(gs_ModifyIndexDeleted(pEditor->m_SelectedImage));
-		return CUI::POPUP_CLOSE_CURRENT;
+		return CUi::POPUP_CLOSE_CURRENT;
 	}
 
 	if(!pImg->m_External)
@@ -1758,14 +1758,14 @@ CUI::EPopupMenuFunctionResult CEditor::PopupImage(void *pContext, CUIRect View, 
 		{
 			pEditor->InvokeFileDialog(IStorage::TYPE_SAVE, FILETYPE_IMG, "Save image", "Save", "mapres", false, CallbackSaveImage, pEditor);
 			pEditor->m_FileDialogFileNameInput.Set(pImg->m_aName);
-			return CUI::POPUP_CLOSE_CURRENT;
+			return CUi::POPUP_CLOSE_CURRENT;
 		}
 	}
 
-	return CUI::POPUP_KEEP_OPEN;
+	return CUi::POPUP_KEEP_OPEN;
 }
 
-CUI::EPopupMenuFunctionResult CEditor::PopupSound(void *pContext, CUIRect View, bool Active)
+CUi::EPopupMenuFunctionResult CEditor::PopupSound(void *pContext, CUIRect View, bool Active)
 {
 	CEditor *pEditor = static_cast<CEditor *>(pContext);
 
@@ -1780,7 +1780,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupSound(void *pContext, CUIRect View, 
 	View.HSplitTop(RowHeight, &Slot, &View);
 	std::shared_ptr<CEditorSound> pSound = pEditor->m_Map.m_vpSounds[pEditor->m_SelectedSound];
 
-	static CUI::SSelectionPopupContext s_SelectionPopupContext;
+	static CUi::SSelectionPopupContext s_SelectionPopupContext;
 	static CScrollRegion s_SelectionPopupScrollRegion;
 	s_SelectionPopupContext.m_pScrollRegion = &s_SelectionPopupScrollRegion;
 
@@ -1791,7 +1791,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupSound(void *pContext, CUIRect View, 
 	Slot.VMargin(5.0f, &Slot);
 	Slot.VSplitLeft(35.0f, &Label, &Slot);
 	Slot.VSplitLeft(RowHeight - 2.0f, nullptr, &EditBox);
-	pEditor->UI()->DoLabel(&Label, "Name:", RowHeight - 2.0f, TEXTALIGN_ML);
+	pEditor->Ui()->DoLabel(&Label, "Name:", RowHeight - 2.0f, TEXTALIGN_ML);
 
 	s_RenameInput.SetBuffer(pSound->m_aName, sizeof(pSound->m_aName));
 	if(pEditor->DoEditBox(&s_RenameInput, &EditBox, RowHeight - 2.0f))
@@ -1820,14 +1820,14 @@ CUI::EPopupMenuFunctionResult CEditor::PopupSound(void *pContext, CUIRect View, 
 		else
 		{
 			str_copy(s_SelectionPopupContext.m_aMessage, "Select the wanted sound:");
-			pEditor->UI()->ShowPopupSelection(pEditor->UI()->MouseX(), pEditor->UI()->MouseY(), &s_SelectionPopupContext);
+			pEditor->Ui()->ShowPopupSelection(pEditor->Ui()->MouseX(), pEditor->Ui()->MouseY(), &s_SelectionPopupContext);
 		}
 	}
 	if(s_SelectionPopupContext.m_pSelection != nullptr)
 	{
 		const bool Result = pEditor->ReplaceSound(s_SelectionPopupContext.m_pSelection->c_str(), IStorage::TYPE_ALL, false);
 		s_SelectionPopupContext.Reset();
-		return Result ? CUI::POPUP_CLOSE_CURRENT : CUI::POPUP_KEEP_OPEN;
+		return Result ? CUi::POPUP_CLOSE_CURRENT : CUi::POPUP_KEEP_OPEN;
 	}
 
 	View.HSplitTop(5.0f, nullptr, &View);
@@ -1835,7 +1835,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupSound(void *pContext, CUIRect View, 
 	if(pEditor->DoButton_MenuItem(&s_ReplaceButton, "Replace", 0, &Slot, 0, "Replaces the sound with a new one"))
 	{
 		pEditor->InvokeFileDialog(IStorage::TYPE_ALL, FILETYPE_SOUND, "Replace sound", "Replace", "mapres", false, ReplaceSoundCallback, pEditor);
-		return CUI::POPUP_CLOSE_CURRENT;
+		return CUi::POPUP_CLOSE_CURRENT;
 	}
 
 	View.HSplitTop(5.0f, nullptr, &View);
@@ -1844,7 +1844,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupSound(void *pContext, CUIRect View, 
 	{
 		pEditor->m_Map.m_vpSounds.erase(pEditor->m_Map.m_vpSounds.begin() + pEditor->m_SelectedSound);
 		pEditor->m_Map.ModifySoundIndex(gs_ModifyIndexDeleted(pEditor->m_SelectedSound));
-		return CUI::POPUP_CLOSE_CURRENT;
+		return CUi::POPUP_CLOSE_CURRENT;
 	}
 
 	View.HSplitTop(5.0f, nullptr, &View);
@@ -1853,13 +1853,13 @@ CUI::EPopupMenuFunctionResult CEditor::PopupSound(void *pContext, CUIRect View, 
 	{
 		pEditor->InvokeFileDialog(IStorage::TYPE_SAVE, FILETYPE_SOUND, "Save sound", "Save", "mapres", false, CallbackSaveSound, pEditor);
 		pEditor->m_FileDialogFileNameInput.Set(pSound->m_aName);
-		return CUI::POPUP_CLOSE_CURRENT;
+		return CUi::POPUP_CLOSE_CURRENT;
 	}
 
-	return CUI::POPUP_KEEP_OPEN;
+	return CUi::POPUP_KEEP_OPEN;
 }
 
-CUI::EPopupMenuFunctionResult CEditor::PopupNewFolder(void *pContext, CUIRect View, bool Active)
+CUi::EPopupMenuFunctionResult CEditor::PopupNewFolder(void *pContext, CUIRect View, bool Active)
 {
 	CEditor *pEditor = static_cast<CEditor *>(pContext);
 
@@ -1870,12 +1870,12 @@ CUI::EPopupMenuFunctionResult CEditor::PopupNewFolder(void *pContext, CUIRect Vi
 
 	// title
 	View.HSplitTop(20.0f, &Label, &View);
-	pEditor->UI()->DoLabel(&Label, "Create new folder", 20.0f, TEXTALIGN_MC);
+	pEditor->Ui()->DoLabel(&Label, "Create new folder", 20.0f, TEXTALIGN_MC);
 	View.HSplitTop(10.0f, nullptr, &View);
 
 	// folder name
 	View.HSplitTop(20.0f, &Label, &View);
-	pEditor->UI()->DoLabel(&Label, "Name:", 10.0f, TEXTALIGN_ML);
+	pEditor->Ui()->DoLabel(&Label, "Name:", 10.0f, TEXTALIGN_ML);
 	Label.VSplitLeft(50.0f, nullptr, &Button);
 	Button.HMargin(2.0f, &Button);
 	pEditor->DoEditBox(&pEditor->m_FileDialogNewFolderNameInput, &Button, 12.0f);
@@ -1884,11 +1884,11 @@ CUI::EPopupMenuFunctionResult CEditor::PopupNewFolder(void *pContext, CUIRect Vi
 	ButtonBar.VSplitLeft(110.0f, &Button, &ButtonBar);
 	static int s_CancelButton = 0;
 	if(pEditor->DoButton_Editor(&s_CancelButton, "Cancel", 0, &Button, 0, nullptr))
-		return CUI::POPUP_CLOSE_CURRENT;
+		return CUi::POPUP_CLOSE_CURRENT;
 
 	ButtonBar.VSplitRight(110.0f, &ButtonBar, &Button);
 	static int s_CreateButton = 0;
-	if(pEditor->DoButton_Editor(&s_CreateButton, "Create", 0, &Button, 0, nullptr) || (Active && pEditor->UI()->ConsumeHotkey(CUI::HOTKEY_ENTER)))
+	if(pEditor->DoButton_Editor(&s_CreateButton, "Create", 0, &Button, 0, nullptr) || (Active && pEditor->Ui()->ConsumeHotkey(CUi::HOTKEY_ENTER)))
 	{
 		// create the folder
 		if(!pEditor->m_FileDialogNewFolderNameInput.IsEmpty())
@@ -1898,7 +1898,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupNewFolder(void *pContext, CUIRect Vi
 			if(pEditor->Storage()->CreateFolder(aBuf, IStorage::TYPE_SAVE))
 			{
 				pEditor->FilelistPopulate(IStorage::TYPE_SAVE);
-				return CUI::POPUP_CLOSE_CURRENT;
+				return CUi::POPUP_CLOSE_CURRENT;
 			}
 			else
 			{
@@ -1907,10 +1907,10 @@ CUI::EPopupMenuFunctionResult CEditor::PopupNewFolder(void *pContext, CUIRect Vi
 		}
 	}
 
-	return CUI::POPUP_KEEP_OPEN;
+	return CUi::POPUP_KEEP_OPEN;
 }
 
-CUI::EPopupMenuFunctionResult CEditor::PopupMapInfo(void *pContext, CUIRect View, bool Active)
+CUi::EPopupMenuFunctionResult CEditor::PopupMapInfo(void *pContext, CUIRect View, bool Active)
 {
 	CEditor *pEditor = static_cast<CEditor *>(pContext);
 
@@ -1921,12 +1921,12 @@ CUI::EPopupMenuFunctionResult CEditor::PopupMapInfo(void *pContext, CUIRect View
 
 	// title
 	View.HSplitTop(20.0f, &Label, &View);
-	pEditor->UI()->DoLabel(&Label, "Map details", 20.0f, TEXTALIGN_MC);
+	pEditor->Ui()->DoLabel(&Label, "Map details", 20.0f, TEXTALIGN_MC);
 	View.HSplitTop(10.0f, nullptr, &View);
 
 	// author box
 	View.HSplitTop(20.0f, &Label, &View);
-	pEditor->UI()->DoLabel(&Label, "Author:", 10.0f, TEXTALIGN_ML);
+	pEditor->Ui()->DoLabel(&Label, "Author:", 10.0f, TEXTALIGN_ML);
 	Label.VSplitLeft(60.0f, nullptr, &Button);
 	Button.HMargin(3.0f, &Button);
 	static CLineInput s_AuthorInput;
@@ -1935,7 +1935,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupMapInfo(void *pContext, CUIRect View
 
 	// version box
 	View.HSplitTop(20.0f, &Label, &View);
-	pEditor->UI()->DoLabel(&Label, "Version:", 10.0f, TEXTALIGN_ML);
+	pEditor->Ui()->DoLabel(&Label, "Version:", 10.0f, TEXTALIGN_ML);
 	Label.VSplitLeft(60.0f, nullptr, &Button);
 	Button.HMargin(3.0f, &Button);
 	static CLineInput s_VersionInput;
@@ -1944,7 +1944,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupMapInfo(void *pContext, CUIRect View
 
 	// credits box
 	View.HSplitTop(20.0f, &Label, &View);
-	pEditor->UI()->DoLabel(&Label, "Credits:", 10.0f, TEXTALIGN_ML);
+	pEditor->Ui()->DoLabel(&Label, "Credits:", 10.0f, TEXTALIGN_ML);
 	Label.VSplitLeft(60.0f, nullptr, &Button);
 	Button.HMargin(3.0f, &Button);
 	static CLineInput s_CreditsInput;
@@ -1953,7 +1953,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupMapInfo(void *pContext, CUIRect View
 
 	// license box
 	View.HSplitTop(20.0f, &Label, &View);
-	pEditor->UI()->DoLabel(&Label, "License:", 10.0f, TEXTALIGN_ML);
+	pEditor->Ui()->DoLabel(&Label, "License:", 10.0f, TEXTALIGN_ML);
 	Label.VSplitLeft(60.0f, nullptr, &Button);
 	Button.HMargin(3.0f, &Button);
 	static CLineInput s_LicenseInput;
@@ -1964,11 +1964,11 @@ CUI::EPopupMenuFunctionResult CEditor::PopupMapInfo(void *pContext, CUIRect View
 	ButtonBar.VSplitLeft(110.0f, &Label, &ButtonBar);
 	static int s_CancelButton = 0;
 	if(pEditor->DoButton_Editor(&s_CancelButton, "Cancel", 0, &Label, 0, nullptr))
-		return CUI::POPUP_CLOSE_CURRENT;
+		return CUi::POPUP_CLOSE_CURRENT;
 
 	ButtonBar.VSplitRight(110.0f, &ButtonBar, &Label);
 	static int s_ConfirmButton = 0;
-	if(pEditor->DoButton_Editor(&s_ConfirmButton, "Confirm", 0, &Label, 0, nullptr) || (Active && pEditor->UI()->ConsumeHotkey(CUI::HOTKEY_ENTER)))
+	if(pEditor->DoButton_Editor(&s_ConfirmButton, "Confirm", 0, &Label, 0, nullptr) || (Active && pEditor->Ui()->ConsumeHotkey(CUi::HOTKEY_ENTER)))
 	{
 		bool AuthorDifferent = str_comp(pEditor->m_Map.m_MapInfoTmp.m_aAuthor, pEditor->m_Map.m_MapInfo.m_aAuthor) != 0;
 		bool VersionDifferent = str_comp(pEditor->m_Map.m_MapInfoTmp.m_aVersion, pEditor->m_Map.m_MapInfo.m_aVersion) != 0;
@@ -1979,13 +1979,13 @@ CUI::EPopupMenuFunctionResult CEditor::PopupMapInfo(void *pContext, CUIRect View
 			pEditor->m_Map.OnModify();
 
 		pEditor->m_Map.m_MapInfo.Copy(pEditor->m_Map.m_MapInfoTmp);
-		return CUI::POPUP_CLOSE_CURRENT;
+		return CUi::POPUP_CLOSE_CURRENT;
 	}
 
-	return CUI::POPUP_KEEP_OPEN;
+	return CUi::POPUP_KEEP_OPEN;
 }
 
-CUI::EPopupMenuFunctionResult CEditor::PopupEvent(void *pContext, CUIRect View, bool Active)
+CUi::EPopupMenuFunctionResult CEditor::PopupEvent(void *pContext, CUIRect View, bool Active)
 {
 	CEditor *pEditor = static_cast<CEditor *>(pContext);
 
@@ -2072,7 +2072,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupEvent(void *pContext, CUIRect View, 
 	else
 	{
 		dbg_assert(false, "m_PopupEventType invalid");
-		return CUI::POPUP_CLOSE_CURRENT;
+		return CUi::POPUP_CLOSE_CURRENT;
 	}
 
 	CUIRect Label, ButtonBar, Button;
@@ -2082,12 +2082,12 @@ CUI::EPopupMenuFunctionResult CEditor::PopupEvent(void *pContext, CUIRect View, 
 
 	// title
 	View.HSplitTop(20.0f, &Label, &View);
-	pEditor->UI()->DoLabel(&Label, pTitle, 20.0f, TEXTALIGN_MC);
+	pEditor->Ui()->DoLabel(&Label, pTitle, 20.0f, TEXTALIGN_MC);
 
 	// message
 	SLabelProperties Props;
 	Props.m_MaxWidth = View.w;
-	pEditor->UI()->DoLabel(&View, pMessage, 10.0f, TEXTALIGN_ML, Props);
+	pEditor->Ui()->DoLabel(&View, pMessage, 10.0f, TEXTALIGN_ML, Props);
 
 	// button bar
 	ButtonBar.VSplitLeft(110.0f, &Button, &ButtonBar);
@@ -2111,13 +2111,13 @@ CUI::EPopupMenuFunctionResult CEditor::PopupEvent(void *pContext, CUIRect View, 
 				pEditor->m_TileartImageInfo.m_pData = nullptr;
 			}
 
-			return CUI::POPUP_CLOSE_CURRENT;
+			return CUi::POPUP_CLOSE_CURRENT;
 		}
 	}
 
 	ButtonBar.VSplitRight(110.0f, &ButtonBar, &Button);
 	static int s_ConfirmButton = 0;
-	if(pEditor->DoButton_Editor(&s_ConfirmButton, "Confirm", 0, &Button, 0, nullptr) || (Active && pEditor->UI()->ConsumeHotkey(CUI::HOTKEY_ENTER)))
+	if(pEditor->DoButton_Editor(&s_ConfirmButton, "Confirm", 0, &Button, 0, nullptr) || (Active && pEditor->Ui()->ConsumeHotkey(CUi::HOTKEY_ENTER)))
 	{
 		if(pEditor->m_PopupEventType == POPEVENT_EXIT)
 		{
@@ -2147,22 +2147,22 @@ CUI::EPopupMenuFunctionResult CEditor::PopupEvent(void *pContext, CUIRect View, 
 		else if(pEditor->m_PopupEventType == POPEVENT_SAVE)
 		{
 			CallbackSaveMap(pEditor->m_aFileSaveName, IStorage::TYPE_SAVE, pEditor);
-			return CUI::POPUP_CLOSE_CURRENT;
+			return CUi::POPUP_CLOSE_CURRENT;
 		}
 		else if(pEditor->m_PopupEventType == POPEVENT_SAVE_COPY)
 		{
 			CallbackSaveCopyMap(pEditor->m_aFileSaveName, IStorage::TYPE_SAVE, pEditor);
-			return CUI::POPUP_CLOSE_CURRENT;
+			return CUi::POPUP_CLOSE_CURRENT;
 		}
 		else if(pEditor->m_PopupEventType == POPEVENT_SAVE_IMG)
 		{
 			CallbackSaveImage(pEditor->m_aFileSaveName, IStorage::TYPE_SAVE, pEditor);
-			return CUI::POPUP_CLOSE_CURRENT;
+			return CUi::POPUP_CLOSE_CURRENT;
 		}
 		else if(pEditor->m_PopupEventType == POPEVENT_SAVE_SOUND)
 		{
 			CallbackSaveSound(pEditor->m_aFileSaveName, IStorage::TYPE_SAVE, pEditor);
-			return CUI::POPUP_CLOSE_CURRENT;
+			return CUi::POPUP_CLOSE_CURRENT;
 		}
 		else if(pEditor->m_PopupEventType == POPEVENT_PLACE_BORDER_TILES)
 		{
@@ -2177,16 +2177,16 @@ CUI::EPopupMenuFunctionResult CEditor::PopupEvent(void *pContext, CUIRect View, 
 			pEditor->AddTileart();
 		}
 		pEditor->m_PopupEventWasActivated = false;
-		return CUI::POPUP_CLOSE_CURRENT;
+		return CUi::POPUP_CLOSE_CURRENT;
 	}
 
-	return CUI::POPUP_KEEP_OPEN;
+	return CUi::POPUP_KEEP_OPEN;
 }
 
 static int g_SelectImageSelected = -100;
 static int g_SelectImageCurrent = -100;
 
-CUI::EPopupMenuFunctionResult CEditor::PopupSelectImage(void *pContext, CUIRect View, bool Active)
+CUi::EPopupMenuFunctionResult CEditor::PopupSelectImage(void *pContext, CUIRect View, bool Active)
 {
 	CEditor *pEditor = static_cast<CEditor *>(pContext);
 
@@ -2215,7 +2215,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupSelectImage(void *pContext, CUIRect 
 		ButtonBar.HSplitTop(ButtonHeight, &Button, &ButtonBar);
 		if(s_ScrollRegion.AddRect(Button))
 		{
-			if(pEditor->UI()->MouseInside(&Button))
+			if(pEditor->Ui()->MouseInside(&Button))
 				ShowImage = i;
 
 			static int s_NoneButton = 0;
@@ -2245,7 +2245,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupSelectImage(void *pContext, CUIRect 
 		pEditor->Graphics()->WrapNormal();
 	}
 
-	return CUI::POPUP_KEEP_OPEN;
+	return CUi::POPUP_KEEP_OPEN;
 }
 
 void CEditor::PopupSelectImageInvoke(int Current, float x, float y)
@@ -2253,7 +2253,7 @@ void CEditor::PopupSelectImageInvoke(int Current, float x, float y)
 	static SPopupMenuId s_PopupSelectImageId;
 	g_SelectImageSelected = -100;
 	g_SelectImageCurrent = Current;
-	UI()->DoPopupMenu(&s_PopupSelectImageId, x, y, 450, 300, this, PopupSelectImage);
+	Ui()->DoPopupMenu(&s_PopupSelectImageId, x, y, 450, 300, this, PopupSelectImage);
 }
 
 int CEditor::PopupSelectImageResult()
@@ -2269,7 +2269,7 @@ int CEditor::PopupSelectImageResult()
 static int g_SelectSoundSelected = -100;
 static int g_SelectSoundCurrent = -100;
 
-CUI::EPopupMenuFunctionResult CEditor::PopupSelectSound(void *pContext, CUIRect View, bool Active)
+CUi::EPopupMenuFunctionResult CEditor::PopupSelectSound(void *pContext, CUIRect View, bool Active)
 {
 	CEditor *pEditor = static_cast<CEditor *>(pContext);
 
@@ -2300,7 +2300,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupSelectSound(void *pContext, CUIRect 
 
 	s_ScrollRegion.End();
 
-	return CUI::POPUP_KEEP_OPEN;
+	return CUi::POPUP_KEEP_OPEN;
 }
 
 void CEditor::PopupSelectSoundInvoke(int Current, float x, float y)
@@ -2308,7 +2308,7 @@ void CEditor::PopupSelectSoundInvoke(int Current, float x, float y)
 	static SPopupMenuId s_PopupSelectSoundId;
 	g_SelectSoundSelected = -100;
 	g_SelectSoundCurrent = Current;
-	UI()->DoPopupMenu(&s_PopupSelectSoundId, x, y, 150, 300, this, PopupSelectSound);
+	Ui()->DoPopupMenu(&s_PopupSelectSoundId, x, y, 150, 300, this, PopupSelectSound);
 }
 
 int CEditor::PopupSelectSoundResult()
@@ -2339,7 +2339,7 @@ static const char *s_apGametileOpButtonNames[] = {
 	"Live Unfreeze",
 };
 
-CUI::EPopupMenuFunctionResult CEditor::PopupSelectGametileOp(void *pContext, CUIRect View, bool Active)
+CUi::EPopupMenuFunctionResult CEditor::PopupSelectGametileOp(void *pContext, CUIRect View, bool Active)
 {
 	CEditor *pEditor = static_cast<CEditor *>(pContext);
 
@@ -2354,14 +2354,14 @@ CUI::EPopupMenuFunctionResult CEditor::PopupSelectGametileOp(void *pContext, CUI
 			s_GametileOpSelected = i;
 	}
 
-	return s_GametileOpSelected == PreviousSelected ? CUI::POPUP_KEEP_OPEN : CUI::POPUP_CLOSE_CURRENT;
+	return s_GametileOpSelected == PreviousSelected ? CUi::POPUP_KEEP_OPEN : CUi::POPUP_CLOSE_CURRENT;
 }
 
 void CEditor::PopupSelectGametileOpInvoke(float x, float y)
 {
 	static SPopupMenuId s_PopupSelectGametileOpId;
 	s_GametileOpSelected = -1;
-	UI()->DoPopupMenu(&s_PopupSelectGametileOpId, x, y, 120.0f, std::size(s_apGametileOpButtonNames) * 14.0f + 10.0f, this, PopupSelectGametileOp);
+	Ui()->DoPopupMenu(&s_PopupSelectGametileOpId, x, y, 120.0f, std::size(s_apGametileOpButtonNames) * 14.0f + 10.0f, this, PopupSelectGametileOp);
 }
 
 int CEditor::PopupSelectGameTileOpResult()
@@ -2377,7 +2377,7 @@ int CEditor::PopupSelectGameTileOpResult()
 static int s_AutoMapConfigSelected = -100;
 static int s_AutoMapConfigCurrent = -100;
 
-CUI::EPopupMenuFunctionResult CEditor::PopupSelectConfigAutoMap(void *pContext, CUIRect View, bool Active)
+CUi::EPopupMenuFunctionResult CEditor::PopupSelectConfigAutoMap(void *pContext, CUIRect View, bool Active)
 {
 	CEditor *pEditor = static_cast<CEditor *>(pContext);
 	std::shared_ptr<CLayerTiles> pLayer = std::static_pointer_cast<CLayerTiles>(pEditor->GetSelectedLayer(0));
@@ -2410,7 +2410,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupSelectConfigAutoMap(void *pContext, 
 
 	s_ScrollRegion.End();
 
-	return CUI::POPUP_KEEP_OPEN;
+	return CUi::POPUP_KEEP_OPEN;
 }
 
 void CEditor::PopupSelectConfigAutoMapInvoke(int Current, float x, float y)
@@ -2421,7 +2421,7 @@ void CEditor::PopupSelectConfigAutoMapInvoke(int Current, float x, float y)
 	std::shared_ptr<CLayerTiles> pLayer = std::static_pointer_cast<CLayerTiles>(GetSelectedLayer(0));
 	const int ItemCount = minimum(m_Map.m_vpImages[pLayer->m_Image]->m_AutoMapper.ConfigNamesNum(), 10);
 	// Width for buttons is 120, 15 is the scrollbar width, 2 is the margin between both.
-	UI()->DoPopupMenu(&s_PopupSelectConfigAutoMapId, x, y, 120.0f + 15.0f + 2.0f, 26.0f + 14.0f * ItemCount, this, PopupSelectConfigAutoMap);
+	Ui()->DoPopupMenu(&s_PopupSelectConfigAutoMapId, x, y, 120.0f + 15.0f + 2.0f, 26.0f + 14.0f * ItemCount, this, PopupSelectConfigAutoMap);
 }
 
 int CEditor::PopupSelectConfigAutoMapResult()
@@ -2436,7 +2436,7 @@ int CEditor::PopupSelectConfigAutoMapResult()
 
 // DDRace
 
-CUI::EPopupMenuFunctionResult CEditor::PopupTele(void *pContext, CUIRect View, bool Active)
+CUi::EPopupMenuFunctionResult CEditor::PopupTele(void *pContext, CUIRect View, bool Active)
 {
 	CEditor *pEditor = static_cast<CEditor *>(pContext);
 
@@ -2547,10 +2547,10 @@ CUI::EPopupMenuFunctionResult CEditor::PopupTele(void *pContext, CUIRect View, b
 	s_PreviousCheckpointNumber = pEditor->m_TeleCheckpointNumber;
 	s_PreviousViewTeleNumber = pEditor->m_ViewTeleNumber;
 
-	return CUI::POPUP_KEEP_OPEN;
+	return CUi::POPUP_KEEP_OPEN;
 }
 
-CUI::EPopupMenuFunctionResult CEditor::PopupSpeedup(void *pContext, CUIRect View, bool Active)
+CUi::EPopupMenuFunctionResult CEditor::PopupSpeedup(void *pContext, CUIRect View, bool Active)
 {
 	CEditor *pEditor = static_cast<CEditor *>(pContext);
 
@@ -2586,10 +2586,10 @@ CUI::EPopupMenuFunctionResult CEditor::PopupSpeedup(void *pContext, CUIRect View
 		pEditor->m_SpeedupAngle = clamp(NewVal, 0, 359);
 	}
 
-	return CUI::POPUP_KEEP_OPEN;
+	return CUi::POPUP_KEEP_OPEN;
 }
 
-CUI::EPopupMenuFunctionResult CEditor::PopupSwitch(void *pContext, CUIRect View, bool Active)
+CUi::EPopupMenuFunctionResult CEditor::PopupSwitch(void *pContext, CUIRect View, bool Active)
 {
 	CEditor *pEditor = static_cast<CEditor *>(pContext);
 
@@ -2684,10 +2684,10 @@ CUI::EPopupMenuFunctionResult CEditor::PopupSwitch(void *pContext, CUIRect View,
 
 	s_PreviousNumber = pEditor->m_SwitchNum;
 	s_PreviousView = pEditor->m_ViewSwitch;
-	return CUI::POPUP_KEEP_OPEN;
+	return CUi::POPUP_KEEP_OPEN;
 }
 
-CUI::EPopupMenuFunctionResult CEditor::PopupTune(void *pContext, CUIRect View, bool Active)
+CUi::EPopupMenuFunctionResult CEditor::PopupTune(void *pContext, CUIRect View, bool Active)
 {
 	CEditor *pEditor = static_cast<CEditor *>(pContext);
 
@@ -2711,10 +2711,10 @@ CUI::EPopupMenuFunctionResult CEditor::PopupTune(void *pContext, CUIRect View, b
 		pEditor->m_TuningNum = (NewVal - 1 + 255) % 255 + 1;
 	}
 
-	return CUI::POPUP_KEEP_OPEN;
+	return CUi::POPUP_KEEP_OPEN;
 }
 
-CUI::EPopupMenuFunctionResult CEditor::PopupGoto(void *pContext, CUIRect View, bool Active)
+CUi::EPopupMenuFunctionResult CEditor::PopupGoto(void *pContext, CUIRect View, bool Active)
 {
 	CEditor *pEditor = static_cast<CEditor *>(pContext);
 
@@ -2755,10 +2755,10 @@ CUI::EPopupMenuFunctionResult CEditor::PopupGoto(void *pContext, CUIRect View, b
 		pEditor->MapView()->SetWorldOffset({32.0f * s_GotoPos.x + 0.5f, 32.0f * s_GotoPos.y + 0.5f});
 	}
 
-	return CUI::POPUP_KEEP_OPEN;
+	return CUi::POPUP_KEEP_OPEN;
 }
 
-CUI::EPopupMenuFunctionResult CEditor::PopupEntities(void *pContext, CUIRect View, bool Active)
+CUi::EPopupMenuFunctionResult CEditor::PopupEntities(void *pContext, CUIRect View, bool Active)
 {
 	CEditor *pEditor = static_cast<CEditor *>(pContext);
 
@@ -2782,15 +2782,15 @@ CUI::EPopupMenuFunctionResult CEditor::PopupEntities(void *pContext, CUIRect Vie
 				char aBuf[IO_MAX_PATH_LENGTH];
 				str_format(aBuf, sizeof(aBuf), "editor/entities/%s.png", pName);
 				pEditor->m_EntitiesTexture = pEditor->Graphics()->LoadTexture(aBuf, IStorage::TYPE_ALL, pEditor->GetTextureUsageFlag());
-				return CUI::POPUP_CLOSE_CURRENT;
+				return CUi::POPUP_CLOSE_CURRENT;
 			}
 		}
 	}
 
-	return CUI::POPUP_KEEP_OPEN;
+	return CUi::POPUP_KEEP_OPEN;
 }
 
-CUI::EPopupMenuFunctionResult CEditor::PopupProofMode(void *pContext, CUIRect View, bool Active)
+CUi::EPopupMenuFunctionResult CEditor::PopupProofMode(void *pContext, CUIRect View, bool Active)
 {
 	CEditor *pEditor = static_cast<CEditor *>(pContext);
 
@@ -2800,7 +2800,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupProofMode(void *pContext, CUIRect Vi
 	if(pEditor->DoButton_MenuItem(&s_ButtonIngame, "Ingame", pEditor->MapView()->ProofMode()->IsModeIngame(), &Button, 0, "These borders represent what a player maximum can see."))
 	{
 		pEditor->MapView()->ProofMode()->SetModeIngame();
-		return CUI::POPUP_CLOSE_CURRENT;
+		return CUi::POPUP_CLOSE_CURRENT;
 	}
 
 	View.HSplitTop(2.0f, nullptr, &View);
@@ -2809,13 +2809,13 @@ CUI::EPopupMenuFunctionResult CEditor::PopupProofMode(void *pContext, CUIRect Vi
 	if(pEditor->DoButton_MenuItem(&s_ButtonMenu, "Menu", pEditor->MapView()->ProofMode()->IsModeMenu(), &Button, 0, "These borders represent what will be shown in the menu."))
 	{
 		pEditor->MapView()->ProofMode()->SetModeMenu();
-		return CUI::POPUP_CLOSE_CURRENT;
+		return CUi::POPUP_CLOSE_CURRENT;
 	}
 
-	return CUI::POPUP_KEEP_OPEN;
+	return CUi::POPUP_KEEP_OPEN;
 }
 
-CUI::EPopupMenuFunctionResult CEditor::PopupAnimateSettings(void *pContext, CUIRect View, bool Active)
+CUi::EPopupMenuFunctionResult CEditor::PopupAnimateSettings(void *pContext, CUIRect View, bool Active)
 {
 	CEditor *pEditor = static_cast<CEditor *>(pContext);
 
@@ -2829,7 +2829,7 @@ CUI::EPopupMenuFunctionResult CEditor::PopupAnimateSettings(void *pContext, CUIR
 	Row.VSplitLeft(10.0f, &ButtonDecrease, &Row);
 	Row.VSplitRight(10.0f, &EditBox, &ButtonIncrease);
 	View.HSplitBottom(12.0f, &View, &ButtonReset);
-	pEditor->UI()->DoLabel(&Label, "Speed", 10.0f, TEXTALIGN_ML);
+	pEditor->Ui()->DoLabel(&Label, "Speed", 10.0f, TEXTALIGN_ML);
 
 	static char s_DecreaseButton;
 	if(pEditor->DoButton_FontIcon(&s_DecreaseButton, FONT_ICON_MINUS, 0, &ButtonDecrease, 0, "Decrease animation speed", IGraphics::CORNER_L, 7.0f))
@@ -2869,5 +2869,5 @@ CUI::EPopupMenuFunctionResult CEditor::PopupAnimateSettings(void *pContext, CUIR
 		pEditor->m_AnimateSpeed = clamp(s_SpeedInput.GetFloat(), MIN_ANIM_SPEED, MAX_ANIM_SPEED);
 	}
 
-	return CUI::POPUP_KEEP_OPEN;
+	return CUi::POPUP_KEEP_OPEN;
 }

--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -11,7 +11,7 @@
 #include "player.h"
 #include "score.h"
 
-bool CheckClientID(int ClientID);
+bool CheckClientId(int ClientId);
 
 void CGameContext::ConCredits(IConsole::IResult *pResult, void *pUserData)
 {
@@ -81,15 +81,15 @@ void CGameContext::ConInfo(IConsole::IResult *pResult, void *pUserData)
 void CGameContext::ConList(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	int ClientID = pResult->m_ClientID;
-	if(!CheckClientID(ClientID))
+	int ClientId = pResult->m_ClientId;
+	if(!CheckClientId(ClientId))
 		return;
 
 	char zerochar = 0;
 	if(pResult->NumArguments() > 0)
-		pSelf->List(ClientID, pResult->GetString(0));
+		pSelf->List(ClientId, pResult->GetString(0));
 	else
-		pSelf->List(ClientID, &zerochar);
+		pSelf->List(ClientId, &zerochar);
 }
 
 void CGameContext::ConHelp(IConsole::IResult *pResult, void *pUserData)
@@ -295,12 +295,12 @@ void CGameContext::ConRules(IConsole::IResult *pResult, void *pUserData)
 
 void ToggleSpecPause(IConsole::IResult *pResult, void *pUserData, int PauseType)
 {
-	if(!CheckClientID(pResult->m_ClientID))
+	if(!CheckClientId(pResult->m_ClientId))
 		return;
 
 	CGameContext *pSelf = (CGameContext *)pUserData;
 	IServer *pServ = pSelf->Server();
-	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientID];
+	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientId];
 	if(!pPlayer)
 		return;
 
@@ -313,7 +313,7 @@ void ToggleSpecPause(IConsole::IResult *pResult, void *pUserData, int PauseType)
 	}
 	else if(pResult->NumArguments() > 0)
 	{
-		if(-PauseState == PauseType && pPlayer->m_SpectatorID != pResult->m_ClientID && pServ->ClientIngame(pPlayer->m_SpectatorID) && !str_comp(pServ->ClientName(pPlayer->m_SpectatorID), pResult->GetString(0)))
+		if(-PauseState == PauseType && pPlayer->m_SpectatorId != pResult->m_ClientId && pServ->ClientIngame(pPlayer->m_SpectatorId) && !str_comp(pServ->ClientName(pPlayer->m_SpectatorId), pResult->GetString(0)))
 		{
 			pPlayer->Pause(CPlayer::PAUSE_NONE, false);
 		}
@@ -335,11 +335,11 @@ void ToggleSpecPause(IConsole::IResult *pResult, void *pUserData, int PauseType)
 
 void ToggleSpecPauseVoted(IConsole::IResult *pResult, void *pUserData, int PauseType)
 {
-	if(!CheckClientID(pResult->m_ClientID))
+	if(!CheckClientId(pResult->m_ClientId))
 		return;
 
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientID];
+	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientId];
 	if(!pPlayer)
 		return;
 
@@ -355,9 +355,9 @@ void ToggleSpecPauseVoted(IConsole::IResult *pResult, void *pUserData, int Pause
 
 	bool IsPlayerBeingVoted = pSelf->m_VoteCloseTime &&
 				  (pSelf->IsKickVote() || pSelf->IsSpecVote()) &&
-				  pResult->m_ClientID != pSelf->m_VoteVictim;
+				  pResult->m_ClientId != pSelf->m_VoteVictim;
 	if((!IsPlayerBeingVoted && -PauseState == PauseType) ||
-		(IsPlayerBeingVoted && PauseState && pPlayer->m_SpectatorID == pSelf->m_VoteVictim))
+		(IsPlayerBeingVoted && PauseState && pPlayer->m_SpectatorId == pSelf->m_VoteVictim))
 	{
 		pPlayer->Pause(CPlayer::PAUSE_NONE, false);
 	}
@@ -365,7 +365,7 @@ void ToggleSpecPauseVoted(IConsole::IResult *pResult, void *pUserData, int Pause
 	{
 		pPlayer->Pause(PauseType, false);
 		if(IsPlayerBeingVoted)
-			pPlayer->m_SpectatorID = pSelf->m_VoteVictim;
+			pPlayer->m_SpectatorId = pSelf->m_VoteVictim;
 	}
 }
 
@@ -392,7 +392,7 @@ void CGameContext::ConTogglePauseVoted(IConsole::IResult *pResult, void *pUserDa
 void CGameContext::ConTeamTop5(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	if(!CheckClientID(pResult->m_ClientID))
+	if(!CheckClientId(pResult->m_ClientId))
 		return;
 
 	if(g_Config.m_SvHideScore)
@@ -404,28 +404,28 @@ void CGameContext::ConTeamTop5(IConsole::IResult *pResult, void *pUserData)
 
 	if(pResult->NumArguments() == 0)
 	{
-		pSelf->Score()->ShowTeamTop5(pResult->m_ClientID, 1);
+		pSelf->Score()->ShowTeamTop5(pResult->m_ClientId, 1);
 	}
 	else if(pResult->NumArguments() == 1)
 	{
 		if(pResult->GetInteger(0) != 0)
 		{
-			pSelf->Score()->ShowTeamTop5(pResult->m_ClientID, pResult->GetInteger(0));
+			pSelf->Score()->ShowTeamTop5(pResult->m_ClientId, pResult->GetInteger(0));
 		}
 		else
 		{
 			const char *pRequestedName = (str_comp_nocase(pResult->GetString(0), "me") == 0) ?
-							     pSelf->Server()->ClientName(pResult->m_ClientID) :
+							     pSelf->Server()->ClientName(pResult->m_ClientId) :
 							     pResult->GetString(0);
-			pSelf->Score()->ShowPlayerTeamTop5(pResult->m_ClientID, pRequestedName, 0);
+			pSelf->Score()->ShowPlayerTeamTop5(pResult->m_ClientId, pRequestedName, 0);
 		}
 	}
 	else if(pResult->NumArguments() == 2 && pResult->GetInteger(1) != 0)
 	{
 		const char *pRequestedName = (str_comp_nocase(pResult->GetString(0), "me") == 0) ?
-						     pSelf->Server()->ClientName(pResult->m_ClientID) :
+						     pSelf->Server()->ClientName(pResult->m_ClientId) :
 						     pResult->GetString(0);
-		pSelf->Score()->ShowPlayerTeamTop5(pResult->m_ClientID, pRequestedName, pResult->GetInteger(1));
+		pSelf->Score()->ShowPlayerTeamTop5(pResult->m_ClientId, pRequestedName, pResult->GetInteger(1));
 	}
 	else
 	{
@@ -438,7 +438,7 @@ void CGameContext::ConTeamTop5(IConsole::IResult *pResult, void *pUserData)
 void CGameContext::ConTop(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	if(!CheckClientID(pResult->m_ClientID))
+	if(!CheckClientId(pResult->m_ClientId))
 		return;
 
 	if(g_Config.m_SvHideScore)
@@ -449,41 +449,41 @@ void CGameContext::ConTop(IConsole::IResult *pResult, void *pUserData)
 	}
 
 	if(pResult->NumArguments() > 0)
-		pSelf->Score()->ShowTop(pResult->m_ClientID, pResult->GetInteger(0));
+		pSelf->Score()->ShowTop(pResult->m_ClientId, pResult->GetInteger(0));
 	else
-		pSelf->Score()->ShowTop(pResult->m_ClientID);
+		pSelf->Score()->ShowTop(pResult->m_ClientId);
 }
 
 void CGameContext::ConTimes(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	if(!CheckClientID(pResult->m_ClientID))
+	if(!CheckClientId(pResult->m_ClientId))
 		return;
 
 	if(pResult->NumArguments() == 0)
 	{
-		pSelf->Score()->ShowTimes(pResult->m_ClientID, 1);
+		pSelf->Score()->ShowTimes(pResult->m_ClientId, 1);
 	}
 	else if(pResult->NumArguments() == 1)
 	{
 		if(pResult->GetInteger(0) != 0)
 		{
-			pSelf->Score()->ShowTimes(pResult->m_ClientID, pResult->GetInteger(0));
+			pSelf->Score()->ShowTimes(pResult->m_ClientId, pResult->GetInteger(0));
 		}
 		else
 		{
 			const char *pRequestedName = (str_comp_nocase(pResult->GetString(0), "me") == 0) ?
-							     pSelf->Server()->ClientName(pResult->m_ClientID) :
+							     pSelf->Server()->ClientName(pResult->m_ClientId) :
 							     pResult->GetString(0);
-			pSelf->Score()->ShowTimes(pResult->m_ClientID, pRequestedName, pResult->GetInteger(1));
+			pSelf->Score()->ShowTimes(pResult->m_ClientId, pRequestedName, pResult->GetInteger(1));
 		}
 	}
 	else if(pResult->NumArguments() == 2 && pResult->GetInteger(1) != 0)
 	{
 		const char *pRequestedName = (str_comp_nocase(pResult->GetString(0), "me") == 0) ?
-						     pSelf->Server()->ClientName(pResult->m_ClientID) :
+						     pSelf->Server()->ClientName(pResult->m_ClientId) :
 						     pResult->GetString(0);
-		pSelf->Score()->ShowTimes(pResult->m_ClientID, pRequestedName, pResult->GetInteger(1));
+		pSelf->Score()->ShowTimes(pResult->m_ClientId, pRequestedName, pResult->GetInteger(1));
 	}
 	else
 	{
@@ -496,10 +496,10 @@ void CGameContext::ConTimes(IConsole::IResult *pResult, void *pUserData)
 void CGameContext::ConDND(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	if(!CheckClientID(pResult->m_ClientID))
+	if(!CheckClientId(pResult->m_ClientId))
 		return;
 
-	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientID];
+	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientId];
 	if(!pPlayer)
 		return;
 
@@ -518,7 +518,7 @@ void CGameContext::ConDND(IConsole::IResult *pResult, void *pUserData)
 void CGameContext::ConMap(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	if(!CheckClientID(pResult->m_ClientID))
+	if(!CheckClientId(pResult->m_ClientId))
 		return;
 
 	if(g_Config.m_SvMapVote == 0)
@@ -534,55 +534,55 @@ void CGameContext::ConMap(IConsole::IResult *pResult, void *pUserData)
 		return;
 	}
 
-	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientID];
+	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientId];
 	if(!pPlayer)
 		return;
 
-	if(pSelf->RateLimitPlayerVote(pResult->m_ClientID) || pSelf->RateLimitPlayerMapVote(pResult->m_ClientID))
+	if(pSelf->RateLimitPlayerVote(pResult->m_ClientId) || pSelf->RateLimitPlayerMapVote(pResult->m_ClientId))
 		return;
 
-	pSelf->Score()->MapVote(pResult->m_ClientID, pResult->GetString(0));
+	pSelf->Score()->MapVote(pResult->m_ClientId, pResult->GetString(0));
 }
 
 void CGameContext::ConMapInfo(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	if(!CheckClientID(pResult->m_ClientID))
+	if(!CheckClientId(pResult->m_ClientId))
 		return;
 
-	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientID];
+	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientId];
 	if(!pPlayer)
 		return;
 
 	if(pResult->NumArguments() > 0)
-		pSelf->Score()->MapInfo(pResult->m_ClientID, pResult->GetString(0));
+		pSelf->Score()->MapInfo(pResult->m_ClientId, pResult->GetString(0));
 	else
-		pSelf->Score()->MapInfo(pResult->m_ClientID, g_Config.m_SvMap);
+		pSelf->Score()->MapInfo(pResult->m_ClientId, g_Config.m_SvMap);
 }
 
 void CGameContext::ConTimeout(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	if(!CheckClientID(pResult->m_ClientID))
+	if(!CheckClientId(pResult->m_ClientId))
 		return;
 
-	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientID];
+	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientId];
 	if(!pPlayer)
 		return;
 
 	const char *pTimeout = pResult->NumArguments() > 0 ? pResult->GetString(0) : pPlayer->m_aTimeoutCode;
 
-	if(!pSelf->Server()->IsSixup(pResult->m_ClientID))
+	if(!pSelf->Server()->IsSixup(pResult->m_ClientId))
 	{
 		for(int i = 0; i < pSelf->Server()->MaxClients(); i++)
 		{
-			if(i == pResult->m_ClientID)
+			if(i == pResult->m_ClientId)
 				continue;
 			if(!pSelf->m_apPlayers[i])
 				continue;
 			if(str_comp(pSelf->m_apPlayers[i]->m_aTimeoutCode, pTimeout))
 				continue;
-			if(pSelf->Server()->SetTimedOut(i, pResult->m_ClientID))
+			if(pSelf->Server()->SetTimedOut(i, pResult->m_ClientId))
 			{
 				if(pSelf->m_apPlayers[i]->GetCharacter())
 					pSelf->SendTuningParams(i, pSelf->m_apPlayers[i]->GetCharacter()->m_TuneZone);
@@ -596,21 +596,21 @@ void CGameContext::ConTimeout(IConsole::IResult *pResult, void *pUserData)
 			"Your timeout code has been set. 0.7 clients can not reclaim their tees on timeout; however, a 0.6 client can claim your tee ");
 	}
 
-	pSelf->Server()->SetTimeoutProtected(pResult->m_ClientID);
+	pSelf->Server()->SetTimeoutProtected(pResult->m_ClientId);
 	str_copy(pPlayer->m_aTimeoutCode, pResult->GetString(0), sizeof(pPlayer->m_aTimeoutCode));
 }
 
 void CGameContext::ConPractice(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	if(!CheckClientID(pResult->m_ClientID))
+	if(!CheckClientId(pResult->m_ClientId))
 		return;
 
-	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientID];
+	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientId];
 	if(!pPlayer)
 		return;
 
-	if(pSelf->ProcessSpamProtection(pResult->m_ClientID, false))
+	if(pSelf->ProcessSpamProtection(pResult->m_ClientId, false))
 		return;
 
 	if(!g_Config.m_SvPractice)
@@ -624,7 +624,7 @@ void CGameContext::ConPractice(IConsole::IResult *pResult, void *pUserData)
 
 	CGameTeams &Teams = pSelf->m_pController->Teams();
 
-	int Team = Teams.m_Core.Team(pResult->m_ClientID);
+	int Team = Teams.m_Core.Team(pResult->m_ClientId);
 
 	if(Team < TEAM_FLOCK || (Team == TEAM_FLOCK && g_Config.m_SvTeam != SV_TEAM_FORCED_SOLO) || Team >= TEAM_SUPER)
 	{
@@ -668,7 +668,7 @@ void CGameContext::ConPractice(IConsole::IResult *pResult, void *pUserData)
 	int NumRequiredVotes = TeamSize / 2 + 1;
 
 	char aBuf[512];
-	str_format(aBuf, sizeof(aBuf), "'%s' voted to %s /practice mode for your team, which means you can use /r, but you can't earn a rank. Type /practice to vote (%d/%d required votes)", pSelf->Server()->ClientName(pResult->m_ClientID), VotedForPractice ? "enable" : "disable", NumCurrentVotes, NumRequiredVotes);
+	str_format(aBuf, sizeof(aBuf), "'%s' voted to %s /practice mode for your team, which means you can use /r, but you can't earn a rank. Type /practice to vote (%d/%d required votes)", pSelf->Server()->ClientName(pResult->m_ClientId), VotedForPractice ? "enable" : "disable", NumCurrentVotes, NumRequiredVotes);
 	pSelf->SendChatTeam(Team, aBuf);
 
 	if(NumCurrentVotes >= NumRequiredVotes)
@@ -683,10 +683,10 @@ void CGameContext::ConSwap(IConsole::IResult *pResult, void *pUserData)
 	CGameContext *pSelf = (CGameContext *)pUserData;
 	const char *pName = pResult->GetString(0);
 
-	if(!CheckClientID(pResult->m_ClientID))
+	if(!CheckClientId(pResult->m_ClientId))
 		return;
 
-	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientID];
+	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientId];
 	if(!pPlayer)
 		return;
 
@@ -701,7 +701,7 @@ void CGameContext::ConSwap(IConsole::IResult *pResult, void *pUserData)
 
 	CGameTeams &Teams = pSelf->m_pController->Teams();
 
-	int Team = Teams.m_Core.Team(pResult->m_ClientID);
+	int Team = Teams.m_Core.Team(pResult->m_ClientId);
 
 	if(Team < TEAM_FLOCK || Team >= TEAM_SUPER)
 	{
@@ -729,7 +729,7 @@ void CGameContext::ConSwap(IConsole::IResult *pResult, void *pUserData)
 		int TeamSize = 1;
 		for(int i = 0; i < MAX_CLIENTS; i++)
 		{
-			if(pSelf->m_apPlayers[i] && Teams.m_Core.Team(i) == Team && i != pResult->m_ClientID)
+			if(pSelf->m_apPlayers[i] && Teams.m_Core.Team(i) == Team && i != pResult->m_ClientId)
 			{
 				TargetClientId = i;
 				TeamSize++;
@@ -745,7 +745,7 @@ void CGameContext::ConSwap(IConsole::IResult *pResult, void *pUserData)
 		return;
 	}
 
-	if(TargetClientId == pResult->m_ClientID)
+	if(TargetClientId == pResult->m_ClientId)
 	{
 		pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "chatresp", "Can't swap with yourself");
 		return;
@@ -774,16 +774,16 @@ void CGameContext::ConSwap(IConsole::IResult *pResult, void *pUserData)
 		pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "chatresp", "Need to have started the map to swap with a player.");
 		return;
 	}
-	if(pSelf->m_World.m_Core.m_apCharacters[pResult->m_ClientID] == nullptr || pSelf->m_World.m_Core.m_apCharacters[TargetClientId] == nullptr)
+	if(pSelf->m_World.m_Core.m_apCharacters[pResult->m_ClientId] == nullptr || pSelf->m_World.m_Core.m_apCharacters[TargetClientId] == nullptr)
 	{
 		pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "chatresp", "You and the other player must not be paused.");
 		return;
 	}
 
-	bool SwapPending = pSwapPlayer->m_SwapTargetsClientID != pResult->m_ClientID;
+	bool SwapPending = pSwapPlayer->m_SwapTargetsClientId != pResult->m_ClientId;
 	if(SwapPending)
 	{
-		if(pSelf->ProcessSpamProtection(pResult->m_ClientID))
+		if(pSelf->ProcessSpamProtection(pResult->m_ClientId))
 			return;
 
 		Teams.RequestTeamSwap(pPlayer, pSwapPlayer, Team);
@@ -796,12 +796,12 @@ void CGameContext::ConSwap(IConsole::IResult *pResult, void *pUserData)
 void CGameContext::ConSave(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	if(!CheckClientID(pResult->m_ClientID))
+	if(!CheckClientId(pResult->m_ClientId))
 		return;
 
 	if(!g_Config.m_SvSaveGames)
 	{
-		pSelf->SendChatTarget(pResult->m_ClientID, "Save-function is disabled on this server");
+		pSelf->SendChatTarget(pResult->m_ClientId, "Save-function is disabled on this server");
 		return;
 	}
 
@@ -809,37 +809,37 @@ void CGameContext::ConSave(IConsole::IResult *pResult, void *pUserData)
 	if(pResult->NumArguments() > 0)
 		pCode = pResult->GetString(0);
 
-	pSelf->Score()->SaveTeam(pResult->m_ClientID, pCode, g_Config.m_SvSqlServerName);
+	pSelf->Score()->SaveTeam(pResult->m_ClientId, pCode, g_Config.m_SvSqlServerName);
 }
 
 void CGameContext::ConLoad(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	if(!CheckClientID(pResult->m_ClientID))
+	if(!CheckClientId(pResult->m_ClientId))
 		return;
 
 	if(!g_Config.m_SvSaveGames)
 	{
-		pSelf->SendChatTarget(pResult->m_ClientID, "Save-function is disabled on this server");
+		pSelf->SendChatTarget(pResult->m_ClientId, "Save-function is disabled on this server");
 		return;
 	}
 
 	if(pResult->NumArguments() > 0)
-		pSelf->Score()->LoadTeam(pResult->GetString(0), pResult->m_ClientID);
+		pSelf->Score()->LoadTeam(pResult->GetString(0), pResult->m_ClientId);
 	else
-		pSelf->Score()->GetSaves(pResult->m_ClientID);
+		pSelf->Score()->GetSaves(pResult->m_ClientId);
 }
 
 void CGameContext::ConTeamRank(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	if(!CheckClientID(pResult->m_ClientID))
+	if(!CheckClientId(pResult->m_ClientId))
 		return;
 
 	if(pResult->NumArguments() > 0)
 	{
 		if(!g_Config.m_SvHideScore)
-			pSelf->Score()->ShowTeamRank(pResult->m_ClientID, pResult->GetString(0));
+			pSelf->Score()->ShowTeamRank(pResult->m_ClientId, pResult->GetString(0));
 		else
 			pSelf->Console()->Print(
 				IConsole::OUTPUT_LEVEL_STANDARD,
@@ -847,20 +847,20 @@ void CGameContext::ConTeamRank(IConsole::IResult *pResult, void *pUserData)
 				"Showing the team rank of other players is not allowed on this server.");
 	}
 	else
-		pSelf->Score()->ShowTeamRank(pResult->m_ClientID,
-			pSelf->Server()->ClientName(pResult->m_ClientID));
+		pSelf->Score()->ShowTeamRank(pResult->m_ClientId,
+			pSelf->Server()->ClientName(pResult->m_ClientId));
 }
 
 void CGameContext::ConRank(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	if(!CheckClientID(pResult->m_ClientID))
+	if(!CheckClientId(pResult->m_ClientId))
 		return;
 
 	if(pResult->NumArguments() > 0)
 	{
 		if(!g_Config.m_SvHideScore)
-			pSelf->Score()->ShowRank(pResult->m_ClientID, pResult->GetString(0));
+			pSelf->Score()->ShowRank(pResult->m_ClientId, pResult->GetString(0));
 		else
 			pSelf->Console()->Print(
 				IConsole::OUTPUT_LEVEL_STANDARD,
@@ -868,14 +868,14 @@ void CGameContext::ConRank(IConsole::IResult *pResult, void *pUserData)
 				"Showing the rank of other players is not allowed on this server.");
 	}
 	else
-		pSelf->Score()->ShowRank(pResult->m_ClientID,
-			pSelf->Server()->ClientName(pResult->m_ClientID));
+		pSelf->Score()->ShowRank(pResult->m_ClientId,
+			pSelf->Server()->ClientName(pResult->m_ClientId));
 }
 
 void CGameContext::ConLock(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	if(!CheckClientID(pResult->m_ClientID))
+	if(!CheckClientId(pResult->m_ClientId))
 		return;
 
 	if(g_Config.m_SvTeam == SV_TEAM_FORBIDDEN || g_Config.m_SvTeam == SV_TEAM_FORCED_SOLO)
@@ -885,7 +885,7 @@ void CGameContext::ConLock(IConsole::IResult *pResult, void *pUserData)
 		return;
 	}
 
-	int Team = pSelf->GetDDRaceTeam(pResult->m_ClientID);
+	int Team = pSelf->GetDDRaceTeam(pResult->m_ClientId);
 
 	bool Lock = pSelf->m_pController->Teams().TeamLocked(Team);
 
@@ -901,19 +901,19 @@ void CGameContext::ConLock(IConsole::IResult *pResult, void *pUserData)
 		return;
 	}
 
-	if(pSelf->ProcessSpamProtection(pResult->m_ClientID, false))
+	if(pSelf->ProcessSpamProtection(pResult->m_ClientId, false))
 		return;
 
 	char aBuf[512];
 	if(Lock)
 	{
-		pSelf->UnlockTeam(pResult->m_ClientID, Team);
+		pSelf->UnlockTeam(pResult->m_ClientId, Team);
 	}
 	else
 	{
 		pSelf->m_pController->Teams().SetTeamLock(Team, true);
 
-		str_format(aBuf, sizeof(aBuf), "'%s' locked your team. After the race starts, killing will kill everyone in your team.", pSelf->Server()->ClientName(pResult->m_ClientID));
+		str_format(aBuf, sizeof(aBuf), "'%s' locked your team. After the race starts, killing will kill everyone in your team.", pSelf->Server()->ClientName(pResult->m_ClientId));
 		pSelf->SendChatTeam(Team, aBuf);
 	}
 }
@@ -921,7 +921,7 @@ void CGameContext::ConLock(IConsole::IResult *pResult, void *pUserData)
 void CGameContext::ConUnlock(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	if(!CheckClientID(pResult->m_ClientID))
+	if(!CheckClientId(pResult->m_ClientId))
 		return;
 
 	if(g_Config.m_SvTeam == SV_TEAM_FORBIDDEN || g_Config.m_SvTeam == SV_TEAM_FORCED_SOLO)
@@ -931,33 +931,33 @@ void CGameContext::ConUnlock(IConsole::IResult *pResult, void *pUserData)
 		return;
 	}
 
-	int Team = pSelf->GetDDRaceTeam(pResult->m_ClientID);
+	int Team = pSelf->GetDDRaceTeam(pResult->m_ClientId);
 
 	if(Team <= TEAM_FLOCK || Team >= TEAM_SUPER)
 		return;
 
-	if(pSelf->ProcessSpamProtection(pResult->m_ClientID, false))
+	if(pSelf->ProcessSpamProtection(pResult->m_ClientId, false))
 		return;
 
-	pSelf->UnlockTeam(pResult->m_ClientID, Team);
+	pSelf->UnlockTeam(pResult->m_ClientId, Team);
 }
 
-void CGameContext::UnlockTeam(int ClientID, int Team) const
+void CGameContext::UnlockTeam(int ClientId, int Team) const
 {
 	m_pController->Teams().SetTeamLock(Team, false);
 
 	char aBuf[512];
-	str_format(aBuf, sizeof(aBuf), "'%s' unlocked your team.", Server()->ClientName(ClientID));
+	str_format(aBuf, sizeof(aBuf), "'%s' unlocked your team.", Server()->ClientName(ClientId));
 	SendChatTeam(Team, aBuf);
 }
 
-void CGameContext::AttemptJoinTeam(int ClientID, int Team)
+void CGameContext::AttemptJoinTeam(int ClientId, int Team)
 {
-	CPlayer *pPlayer = m_apPlayers[ClientID];
+	CPlayer *pPlayer = m_apPlayers[ClientId];
 	if(!pPlayer)
 		return;
 
-	if(m_VoteCloseTime && m_VoteCreator == ClientID && (IsKickVote() || IsSpecVote()))
+	if(m_VoteCloseTime && m_VoteCreator == ClientId && (IsKickVote() || IsSpecVote()))
 	{
 		Console()->Print(
 			IConsole::OUTPUT_LEVEL_STANDARD,
@@ -995,7 +995,7 @@ void CGameContext::AttemptJoinTeam(int ClientID, int Team)
 			Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "chatresp",
 				"You can\'t change teams that fast!");
 		}
-		else if(Team > 0 && Team < MAX_CLIENTS && m_pController->Teams().TeamLocked(Team) && !m_pController->Teams().IsInvited(Team, ClientID))
+		else if(Team > 0 && Team < MAX_CLIENTS && m_pController->Teams().TeamLocked(Team) && !m_pController->Teams().IsInvited(Team, ClientId))
 		{
 			Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "chatresp",
 				g_Config.m_SvInvite ?
@@ -1008,7 +1008,7 @@ void CGameContext::AttemptJoinTeam(int ClientID, int Team)
 			str_format(aBuf, sizeof(aBuf), "This team already has the maximum allowed size of %d players", g_Config.m_SvMaxTeamSize);
 			Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "chatresp", aBuf);
 		}
-		else if(const char *pError = m_pController->Teams().SetCharacterTeam(pPlayer->GetCID(), Team))
+		else if(const char *pError = m_pController->Teams().SetCharacterTeam(pPlayer->GetCid(), Team))
 		{
 			Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "chatresp", pError);
 		}
@@ -1016,13 +1016,13 @@ void CGameContext::AttemptJoinTeam(int ClientID, int Team)
 		{
 			char aBuf[512];
 			str_format(aBuf, sizeof(aBuf), "'%s' joined team %d",
-				Server()->ClientName(pPlayer->GetCID()),
+				Server()->ClientName(pPlayer->GetCid()),
 				Team);
 			SendChat(-1, CGameContext::CHAT_ALL, aBuf);
 			pPlayer->m_Last_Team = Server()->Tick();
 
 			if(m_pController->Teams().IsPractice(Team))
-				SendChatTarget(pPlayer->GetCID(), "Practice mode enabled for your team, happy practicing!");
+				SendChatTarget(pPlayer->GetCid(), "Practice mode enabled for your team, happy practicing!");
 		}
 	}
 }
@@ -1046,7 +1046,7 @@ void CGameContext::ConInvite(IConsole::IResult *pResult, void *pUserData)
 		return;
 	}
 
-	int Team = pController->Teams().m_Core.Team(pResult->m_ClientID);
+	int Team = pController->Teams().m_Core.Team(pResult->m_ClientId);
 	if(Team > TEAM_FLOCK && Team < TEAM_SUPER)
 	{
 		int Target = -1;
@@ -1071,20 +1071,20 @@ void CGameContext::ConInvite(IConsole::IResult *pResult, void *pUserData)
 			return;
 		}
 
-		if(pSelf->m_apPlayers[pResult->m_ClientID] && pSelf->m_apPlayers[pResult->m_ClientID]->m_LastInvited + g_Config.m_SvInviteFrequency * pSelf->Server()->TickSpeed() > pSelf->Server()->Tick())
+		if(pSelf->m_apPlayers[pResult->m_ClientId] && pSelf->m_apPlayers[pResult->m_ClientId]->m_LastInvited + g_Config.m_SvInviteFrequency * pSelf->Server()->TickSpeed() > pSelf->Server()->Tick())
 		{
 			pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "chatresp", "Can't invite this quickly");
 			return;
 		}
 
 		pController->Teams().SetClientInvited(Team, Target, true);
-		pSelf->m_apPlayers[pResult->m_ClientID]->m_LastInvited = pSelf->Server()->Tick();
+		pSelf->m_apPlayers[pResult->m_ClientId]->m_LastInvited = pSelf->Server()->Tick();
 
 		char aBuf[512];
-		str_format(aBuf, sizeof(aBuf), "'%s' invited you to team %d. Use /team %d to join.", pSelf->Server()->ClientName(pResult->m_ClientID), Team, Team);
+		str_format(aBuf, sizeof(aBuf), "'%s' invited you to team %d. Use /team %d to join.", pSelf->Server()->ClientName(pResult->m_ClientId), Team, Team);
 		pSelf->SendChatTarget(Target, aBuf);
 
-		str_format(aBuf, sizeof(aBuf), "'%s' invited '%s' to your team.", pSelf->Server()->ClientName(pResult->m_ClientID), pSelf->Server()->ClientName(Target));
+		str_format(aBuf, sizeof(aBuf), "'%s' invited '%s' to your team.", pSelf->Server()->ClientName(pResult->m_ClientId), pSelf->Server()->ClientName(Target));
 		pSelf->SendChatTeam(Team, aBuf);
 	}
 	else
@@ -1094,16 +1094,16 @@ void CGameContext::ConInvite(IConsole::IResult *pResult, void *pUserData)
 void CGameContext::ConTeam(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	if(!CheckClientID(pResult->m_ClientID))
+	if(!CheckClientId(pResult->m_ClientId))
 		return;
 
-	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientID];
+	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientId];
 	if(!pPlayer)
 		return;
 
 	if(pResult->NumArguments() > 0)
 	{
-		pSelf->AttemptJoinTeam(pResult->m_ClientID, pResult->GetInteger(0));
+		pSelf->AttemptJoinTeam(pResult->m_ClientId, pResult->GetInteger(0));
 	}
 	else
 	{
@@ -1121,7 +1121,7 @@ void CGameContext::ConTeam(IConsole::IResult *pResult, void *pUserData)
 				aBuf,
 				sizeof(aBuf),
 				"You are in team %d",
-				pSelf->GetDDRaceTeam(pResult->m_ClientID));
+				pSelf->GetDDRaceTeam(pResult->m_ClientId));
 			pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "chatresp", aBuf);
 		}
 	}
@@ -1130,7 +1130,7 @@ void CGameContext::ConTeam(IConsole::IResult *pResult, void *pUserData)
 void CGameContext::ConJoin(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	if(!CheckClientID(pResult->m_ClientID))
+	if(!CheckClientId(pResult->m_ClientId))
 		return;
 
 	int Target = -1;
@@ -1151,25 +1151,25 @@ void CGameContext::ConJoin(IConsole::IResult *pResult, void *pUserData)
 	}
 
 	int Team = pSelf->GetDDRaceTeam(Target);
-	if(pSelf->ProcessSpamProtection(pResult->m_ClientID, false))
+	if(pSelf->ProcessSpamProtection(pResult->m_ClientId, false))
 		return;
 
-	pSelf->AttemptJoinTeam(pResult->m_ClientID, Team);
+	pSelf->AttemptJoinTeam(pResult->m_ClientId, Team);
 }
 
 void CGameContext::ConMe(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	if(!CheckClientID(pResult->m_ClientID))
+	if(!CheckClientId(pResult->m_ClientId))
 		return;
 
 	char aBuf[256 + 24];
 
 	str_format(aBuf, 256 + 24, "'%s' %s",
-		pSelf->Server()->ClientName(pResult->m_ClientID),
+		pSelf->Server()->ClientName(pResult->m_ClientId),
 		pResult->GetString(0));
 	if(g_Config.m_SvSlashMe)
-		pSelf->SendChat(-2, CGameContext::CHAT_ALL, aBuf, pResult->m_ClientID);
+		pSelf->SendChat(-2, CGameContext::CHAT_ALL, aBuf, pResult->m_ClientId);
 	else
 		pSelf->Console()->Print(
 			IConsole::OUTPUT_LEVEL_STANDARD,
@@ -1191,10 +1191,10 @@ void CGameContext::ConSetEyeEmote(IConsole::IResult *pResult,
 	void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	if(!CheckClientID(pResult->m_ClientID))
+	if(!CheckClientId(pResult->m_ClientId))
 		return;
 
-	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientID];
+	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientId];
 	if(!pPlayer)
 		return;
 	if(pResult->NumArguments() == 0)
@@ -1231,10 +1231,10 @@ void CGameContext::ConEyeEmote(IConsole::IResult *pResult, void *pUserData)
 		return;
 	}
 
-	if(!CheckClientID(pResult->m_ClientID))
+	if(!CheckClientId(pResult->m_ClientId))
 		return;
 
-	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientID];
+	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientId];
 	if(!pPlayer)
 		return;
 
@@ -1287,10 +1287,10 @@ void CGameContext::ConEyeEmote(IConsole::IResult *pResult, void *pUserData)
 void CGameContext::ConNinjaJetpack(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	if(!CheckClientID(pResult->m_ClientID))
+	if(!CheckClientId(pResult->m_ClientId))
 		return;
 
-	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientID];
+	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientId];
 	if(!pPlayer)
 		return;
 	if(pResult->NumArguments())
@@ -1302,10 +1302,10 @@ void CGameContext::ConNinjaJetpack(IConsole::IResult *pResult, void *pUserData)
 void CGameContext::ConShowOthers(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	if(!CheckClientID(pResult->m_ClientID))
+	if(!CheckClientId(pResult->m_ClientId))
 		return;
 
-	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientID];
+	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientId];
 	if(!pPlayer)
 		return;
 	if(g_Config.m_SvShowOthers)
@@ -1325,10 +1325,10 @@ void CGameContext::ConShowOthers(IConsole::IResult *pResult, void *pUserData)
 void CGameContext::ConShowAll(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	if(!CheckClientID(pResult->m_ClientID))
+	if(!CheckClientId(pResult->m_ClientId))
 		return;
 
-	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientID];
+	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientId];
 	if(!pPlayer)
 		return;
 
@@ -1345,18 +1345,18 @@ void CGameContext::ConShowAll(IConsole::IResult *pResult, void *pUserData)
 	}
 
 	if(pPlayer->m_ShowAll)
-		pSelf->SendChatTarget(pResult->m_ClientID, "You will now see all tees on this server, no matter the distance");
+		pSelf->SendChatTarget(pResult->m_ClientId, "You will now see all tees on this server, no matter the distance");
 	else
-		pSelf->SendChatTarget(pResult->m_ClientID, "You will no longer see all tees on this server");
+		pSelf->SendChatTarget(pResult->m_ClientId, "You will no longer see all tees on this server");
 }
 
 void CGameContext::ConSpecTeam(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	if(!CheckClientID(pResult->m_ClientID))
+	if(!CheckClientId(pResult->m_ClientId))
 		return;
 
-	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientID];
+	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientId];
 	if(!pPlayer)
 		return;
 
@@ -1366,38 +1366,38 @@ void CGameContext::ConSpecTeam(IConsole::IResult *pResult, void *pUserData)
 		pPlayer->m_SpecTeam = !pPlayer->m_SpecTeam;
 }
 
-bool CheckClientID(int ClientID)
+bool CheckClientId(int ClientId)
 {
-	return ClientID >= 0 && ClientID < MAX_CLIENTS;
+	return ClientId >= 0 && ClientId < MAX_CLIENTS;
 }
 
 void CGameContext::ConSayTime(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	if(!CheckClientID(pResult->m_ClientID))
+	if(!CheckClientId(pResult->m_ClientId))
 		return;
 
-	int ClientID;
+	int ClientId;
 	char aBufName[MAX_NAME_LENGTH];
 
 	if(pResult->NumArguments() > 0)
 	{
-		for(ClientID = 0; ClientID < MAX_CLIENTS; ClientID++)
-			if(str_comp(pResult->GetString(0), pSelf->Server()->ClientName(ClientID)) == 0)
+		for(ClientId = 0; ClientId < MAX_CLIENTS; ClientId++)
+			if(str_comp(pResult->GetString(0), pSelf->Server()->ClientName(ClientId)) == 0)
 				break;
 
-		if(ClientID == MAX_CLIENTS)
+		if(ClientId == MAX_CLIENTS)
 			return;
 
-		str_format(aBufName, sizeof(aBufName), "%s's", pSelf->Server()->ClientName(ClientID));
+		str_format(aBufName, sizeof(aBufName), "%s's", pSelf->Server()->ClientName(ClientId));
 	}
 	else
 	{
 		str_copy(aBufName, "Your", sizeof(aBufName));
-		ClientID = pResult->m_ClientID;
+		ClientId = pResult->m_ClientId;
 	}
 
-	CPlayer *pPlayer = pSelf->m_apPlayers[ClientID];
+	CPlayer *pPlayer = pSelf->m_apPlayers[ClientId];
 	if(!pPlayer)
 		return;
 	CCharacter *pChr = pPlayer->GetCharacter();
@@ -1417,10 +1417,10 @@ void CGameContext::ConSayTime(IConsole::IResult *pResult, void *pUserData)
 void CGameContext::ConSayTimeAll(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	if(!CheckClientID(pResult->m_ClientID))
+	if(!CheckClientId(pResult->m_ClientId))
 		return;
 
-	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientID];
+	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientId];
 	if(!pPlayer)
 		return;
 	CCharacter *pChr = pPlayer->GetCharacter();
@@ -1432,19 +1432,19 @@ void CGameContext::ConSayTimeAll(IConsole::IResult *pResult, void *pUserData)
 	char aBufTime[32];
 	char aBuf[64];
 	int64_t Time = (int64_t)100 * (float)(pSelf->Server()->Tick() - pChr->m_StartTime) / ((float)pSelf->Server()->TickSpeed());
-	const char *pName = pSelf->Server()->ClientName(pResult->m_ClientID);
+	const char *pName = pSelf->Server()->ClientName(pResult->m_ClientId);
 	str_time(Time, TIME_HOURS, aBufTime, sizeof(aBufTime));
 	str_format(aBuf, sizeof(aBuf), "%s\'s current race time is %s", pName, aBufTime);
-	pSelf->SendChat(-1, CGameContext::CHAT_ALL, aBuf, pResult->m_ClientID);
+	pSelf->SendChat(-1, CGameContext::CHAT_ALL, aBuf, pResult->m_ClientId);
 }
 
 void CGameContext::ConTime(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	if(!CheckClientID(pResult->m_ClientID))
+	if(!CheckClientId(pResult->m_ClientId))
 		return;
 
-	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientID];
+	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientId];
 	if(!pPlayer)
 		return;
 	CCharacter *pChr = pPlayer->GetCharacter();
@@ -1456,7 +1456,7 @@ void CGameContext::ConTime(IConsole::IResult *pResult, void *pUserData)
 	int64_t Time = (int64_t)100 * (float)(pSelf->Server()->Tick() - pChr->m_StartTime) / ((float)pSelf->Server()->TickSpeed());
 	str_time(Time, TIME_HOURS, aBufTime, sizeof(aBufTime));
 	str_format(aBuf, sizeof(aBuf), "Your time is %s", aBufTime);
-	pSelf->SendBroadcast(aBuf, pResult->m_ClientID);
+	pSelf->SendBroadcast(aBuf, pResult->m_ClientId);
 }
 
 static const char s_aaMsg[4][128] = {"game/round timer.", "broadcast.", "both game/round timer and broadcast.", "racetime."};
@@ -1465,10 +1465,10 @@ void CGameContext::ConSetTimerType(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
 
-	if(!CheckClientID(pResult->m_ClientID))
+	if(!CheckClientId(pResult->m_ClientId))
 		return;
 
-	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientID];
+	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientId];
 	if(!pPlayer)
 		return;
 
@@ -1502,7 +1502,7 @@ void CGameContext::ConSetTimerType(IConsole::IResult *pResult, void *pUserData)
 		}
 
 		if((OldType == CPlayer::TIMERTYPE_BROADCAST || OldType == CPlayer::TIMERTYPE_GAMETIMER_AND_BROADCAST) && (pPlayer->m_TimerType == CPlayer::TIMERTYPE_GAMETIMER || pPlayer->m_TimerType == CPlayer::TIMERTYPE_NONE))
-			pSelf->SendBroadcast("", pResult->m_ClientID);
+			pSelf->SendBroadcast("", pResult->m_ClientId);
 	}
 
 	if(pPlayer->m_TimerType <= CPlayer::TIMERTYPE_SIXUP && pPlayer->m_TimerType >= CPlayer::TIMERTYPE_GAMETIMER)
@@ -1516,9 +1516,9 @@ void CGameContext::ConSetTimerType(IConsole::IResult *pResult, void *pUserData)
 void CGameContext::ConRescue(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	if(!CheckClientID(pResult->m_ClientID))
+	if(!CheckClientId(pResult->m_ClientId))
 		return;
-	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientID];
+	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientId];
 	if(!pPlayer)
 		return;
 	CCharacter *pChr = pPlayer->GetCharacter();
@@ -1526,10 +1526,10 @@ void CGameContext::ConRescue(IConsole::IResult *pResult, void *pUserData)
 		return;
 
 	CGameTeams &Teams = pSelf->m_pController->Teams();
-	int Team = pSelf->GetDDRaceTeam(pResult->m_ClientID);
+	int Team = pSelf->GetDDRaceTeam(pResult->m_ClientId);
 	if(!g_Config.m_SvRescue && !Teams.IsPractice(Team))
 	{
-		pSelf->SendChatTarget(pPlayer->GetCID(), "Rescue is not enabled on this server and you're not in a team with /practice turned on. Note that you can't earn a rank with practice enabled.");
+		pSelf->SendChatTarget(pPlayer->GetCid(), "Rescue is not enabled on this server and you're not in a team with /practice turned on. Note that you can't earn a rank with practice enabled.");
 		return;
 	}
 
@@ -1540,9 +1540,9 @@ void CGameContext::ConRescue(IConsole::IResult *pResult, void *pUserData)
 void CGameContext::ConTeleTo(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	if(!CheckClientID(pResult->m_ClientID))
+	if(!CheckClientId(pResult->m_ClientId))
 		return;
-	CPlayer *pCallingPlayer = pSelf->m_apPlayers[pResult->m_ClientID];
+	CPlayer *pCallingPlayer = pSelf->m_apPlayers[pResult->m_ClientId];
 	if(!pCallingPlayer)
 		return;
 	CCharacter *pCallingCharacter = pCallingPlayer->GetCharacter();
@@ -1550,10 +1550,10 @@ void CGameContext::ConTeleTo(IConsole::IResult *pResult, void *pUserData)
 		return;
 
 	CGameTeams &Teams = pSelf->m_pController->Teams();
-	int Team = pSelf->GetDDRaceTeam(pResult->m_ClientID);
+	int Team = pSelf->GetDDRaceTeam(pResult->m_ClientId);
 	if(!Teams.IsPractice(Team))
 	{
-		pSelf->SendChatTarget(pCallingPlayer->GetCID(), "You're not in a team with /practice turned on. Note that you can't earn a rank with practice enabled.");
+		pSelf->SendChatTarget(pCallingPlayer->GetCid(), "You're not in a team with /practice turned on. Note that you can't earn a rank with practice enabled.");
 		return;
 	}
 
@@ -1567,19 +1567,19 @@ void CGameContext::ConTeleTo(IConsole::IResult *pResult, void *pUserData)
 	else
 	{
 		// Search for player with this name
-		int ClientID;
-		for(ClientID = 0; ClientID < MAX_CLIENTS; ClientID++)
+		int ClientId;
+		for(ClientId = 0; ClientId < MAX_CLIENTS; ClientId++)
 		{
-			if(str_comp(pResult->GetString(0), pSelf->Server()->ClientName(ClientID)) == 0)
+			if(str_comp(pResult->GetString(0), pSelf->Server()->ClientName(ClientId)) == 0)
 				break;
 		}
-		if(ClientID == MAX_CLIENTS)
+		if(ClientId == MAX_CLIENTS)
 		{
-			pSelf->SendChatTarget(pCallingPlayer->GetCID(), "No player with this name found.");
+			pSelf->SendChatTarget(pCallingPlayer->GetCid(), "No player with this name found.");
 			return;
 		}
 
-		CPlayer *pDestPlayer = pSelf->m_apPlayers[ClientID];
+		CPlayer *pDestPlayer = pSelf->m_apPlayers[ClientId];
 		if(!pDestPlayer)
 			return;
 		CCharacter *pDestCharacter = pDestPlayer->GetCharacter();
@@ -1600,9 +1600,9 @@ void CGameContext::ConTeleTo(IConsole::IResult *pResult, void *pUserData)
 void CGameContext::ConTeleXY(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	if(!CheckClientID(pResult->m_ClientID))
+	if(!CheckClientId(pResult->m_ClientId))
 		return;
-	CPlayer *pCallingPlayer = pSelf->m_apPlayers[pResult->m_ClientID];
+	CPlayer *pCallingPlayer = pSelf->m_apPlayers[pResult->m_ClientId];
 	if(!pCallingPlayer)
 		return;
 	CCharacter *pCallingCharacter = pCallingPlayer->GetCharacter();
@@ -1610,10 +1610,10 @@ void CGameContext::ConTeleXY(IConsole::IResult *pResult, void *pUserData)
 		return;
 
 	CGameTeams &Teams = pSelf->m_pController->Teams();
-	int Team = pSelf->GetDDRaceTeam(pResult->m_ClientID);
+	int Team = pSelf->GetDDRaceTeam(pResult->m_ClientId);
 	if(!Teams.IsPractice(Team))
 	{
-		pSelf->SendChatTarget(pCallingPlayer->GetCID(), "You're not in a team with /practice turned on. Note that you can't earn a rank with practice enabled.");
+		pSelf->SendChatTarget(pCallingPlayer->GetCid(), "You're not in a team with /practice turned on. Note that you can't earn a rank with practice enabled.");
 		return;
 	}
 
@@ -1621,7 +1621,7 @@ void CGameContext::ConTeleXY(IConsole::IResult *pResult, void *pUserData)
 
 	if(pResult->NumArguments() != 2)
 	{
-		pSelf->SendChatTarget(pCallingPlayer->GetCID(), "Can't recognize specified arguments. Usage: /tpxy x y, e.g. /tpxy 9 3.");
+		pSelf->SendChatTarget(pCallingPlayer->GetCid(), "Can't recognize specified arguments. Usage: /tpxy x y, e.g. /tpxy 9 3.");
 		return;
 	}
 	else
@@ -1655,12 +1655,12 @@ void CGameContext::ConTeleXY(IConsole::IResult *pResult, void *pUserData)
 
 		if(!DetermineCoordinateRelativity(pResult->GetString(0), pCallingPlayer->m_ViewPos.x, BaseX))
 		{
-			pSelf->SendChatTarget(pCallingPlayer->GetCID(), "Invalid X coordinate.");
+			pSelf->SendChatTarget(pCallingPlayer->GetCid(), "Invalid X coordinate.");
 			return;
 		}
 		if(!DetermineCoordinateRelativity(pResult->GetString(1), pCallingPlayer->m_ViewPos.y, BaseY))
 		{
-			pSelf->SendChatTarget(pCallingPlayer->GetCID(), "Invalid Y coordinate.");
+			pSelf->SendChatTarget(pCallingPlayer->GetCid(), "Invalid Y coordinate.");
 			return;
 		}
 
@@ -1677,9 +1677,9 @@ void CGameContext::ConTeleXY(IConsole::IResult *pResult, void *pUserData)
 void CGameContext::ConTeleCursor(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	if(!CheckClientID(pResult->m_ClientID))
+	if(!CheckClientId(pResult->m_ClientId))
 		return;
-	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientID];
+	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientId];
 	if(!pPlayer)
 		return;
 	CCharacter *pChr = pPlayer->GetCharacter();
@@ -1687,10 +1687,10 @@ void CGameContext::ConTeleCursor(IConsole::IResult *pResult, void *pUserData)
 		return;
 
 	CGameTeams &Teams = pSelf->m_pController->Teams();
-	int Team = pSelf->GetDDRaceTeam(pResult->m_ClientID);
+	int Team = pSelf->GetDDRaceTeam(pResult->m_ClientId);
 	if(!Teams.IsPractice(Team))
 	{
-		pSelf->SendChatTarget(pPlayer->GetCID(), "You're not in a team with /practice turned on. Note that you can't earn a rank with practice enabled.");
+		pSelf->SendChatTarget(pPlayer->GetCid(), "You're not in a team with /practice turned on. Note that you can't earn a rank with practice enabled.");
 		return;
 	}
 
@@ -1701,18 +1701,18 @@ void CGameContext::ConTeleCursor(IConsole::IResult *pResult, void *pUserData)
 	}
 	else if(pResult->NumArguments() > 0)
 	{
-		int ClientID;
-		for(ClientID = 0; ClientID < MAX_CLIENTS; ClientID++)
+		int ClientId;
+		for(ClientId = 0; ClientId < MAX_CLIENTS; ClientId++)
 		{
-			if(str_comp(pResult->GetString(0), pSelf->Server()->ClientName(ClientID)) == 0)
+			if(str_comp(pResult->GetString(0), pSelf->Server()->ClientName(ClientId)) == 0)
 				break;
 		}
-		if(ClientID == MAX_CLIENTS)
+		if(ClientId == MAX_CLIENTS)
 		{
-			pSelf->SendChatTarget(pPlayer->GetCID(), "No player with this name found.");
+			pSelf->SendChatTarget(pPlayer->GetCid(), "No player with this name found.");
 			return;
 		}
-		CPlayer *pPlayerTo = pSelf->m_apPlayers[ClientID];
+		CPlayer *pPlayerTo = pSelf->m_apPlayers[ClientId];
 		if(!pPlayerTo)
 			return;
 		CCharacter *pChrTo = pPlayerTo->GetCharacter();
@@ -1729,9 +1729,9 @@ void CGameContext::ConTeleCursor(IConsole::IResult *pResult, void *pUserData)
 void CGameContext::ConLastTele(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	if(!CheckClientID(pResult->m_ClientID))
+	if(!CheckClientId(pResult->m_ClientId))
 		return;
-	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientID];
+	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientId];
 	if(!pPlayer)
 		return;
 	CCharacter *pChr = pPlayer->GetCharacter();
@@ -1739,15 +1739,15 @@ void CGameContext::ConLastTele(IConsole::IResult *pResult, void *pUserData)
 		return;
 
 	CGameTeams &Teams = pSelf->m_pController->Teams();
-	int Team = pSelf->GetDDRaceTeam(pResult->m_ClientID);
+	int Team = pSelf->GetDDRaceTeam(pResult->m_ClientId);
 	if(!Teams.IsPractice(Team))
 	{
-		pSelf->SendChatTarget(pPlayer->GetCID(), "You're not in a team with /practice turned on. Note that you can't earn a rank with practice enabled.");
+		pSelf->SendChatTarget(pPlayer->GetCid(), "You're not in a team with /practice turned on. Note that you can't earn a rank with practice enabled.");
 		return;
 	}
 	if(!pPlayer->m_LastTeleTee.GetPos().x)
 	{
-		pSelf->SendChatTarget(pPlayer->GetCID(), "You haven't previously teleported. Use /tp before using this command.");
+		pSelf->SendChatTarget(pPlayer->GetCid(), "You haven't previously teleported. Use /tp before using this command.");
 		return;
 	}
 	pPlayer->m_LastTeleTee.Load(pChr, pChr->Team(), true);
@@ -1757,9 +1757,9 @@ void CGameContext::ConLastTele(IConsole::IResult *pResult, void *pUserData)
 void CGameContext::ConPracticeUnSolo(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	if(!CheckClientID(pResult->m_ClientID))
+	if(!CheckClientId(pResult->m_ClientId))
 		return;
-	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientID];
+	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientId];
 	if(!pPlayer)
 		return;
 	CCharacter *pChr = pPlayer->GetCharacter();
@@ -1768,15 +1768,15 @@ void CGameContext::ConPracticeUnSolo(IConsole::IResult *pResult, void *pUserData
 
 	if(g_Config.m_SvTeam == SV_TEAM_FORBIDDEN || g_Config.m_SvTeam == SV_TEAM_FORCED_SOLO)
 	{
-		pSelf->SendChatTarget(pPlayer->GetCID(), "Command is not available on solo servers");
+		pSelf->SendChatTarget(pPlayer->GetCid(), "Command is not available on solo servers");
 		return;
 	}
 
 	CGameTeams &Teams = pSelf->m_pController->Teams();
-	int Team = pSelf->GetDDRaceTeam(pResult->m_ClientID);
+	int Team = pSelf->GetDDRaceTeam(pResult->m_ClientId);
 	if(!Teams.IsPractice(Team))
 	{
-		pSelf->SendChatTarget(pPlayer->GetCID(), "You're not in a team with /practice turned on. Note that you can't earn a rank with practice enabled.");
+		pSelf->SendChatTarget(pPlayer->GetCid(), "You're not in a team with /practice turned on. Note that you can't earn a rank with practice enabled.");
 		return;
 	}
 
@@ -1786,9 +1786,9 @@ void CGameContext::ConPracticeUnSolo(IConsole::IResult *pResult, void *pUserData
 void CGameContext::ConPracticeSolo(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	if(!CheckClientID(pResult->m_ClientID))
+	if(!CheckClientId(pResult->m_ClientId))
 		return;
-	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientID];
+	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientId];
 	if(!pPlayer)
 		return;
 	CCharacter *pChr = pPlayer->GetCharacter();
@@ -1797,15 +1797,15 @@ void CGameContext::ConPracticeSolo(IConsole::IResult *pResult, void *pUserData)
 
 	if(g_Config.m_SvTeam == SV_TEAM_FORBIDDEN || g_Config.m_SvTeam == SV_TEAM_FORCED_SOLO)
 	{
-		pSelf->SendChatTarget(pPlayer->GetCID(), "Command is not available on solo servers");
+		pSelf->SendChatTarget(pPlayer->GetCid(), "Command is not available on solo servers");
 		return;
 	}
 
 	CGameTeams &Teams = pSelf->m_pController->Teams();
-	int Team = pSelf->GetDDRaceTeam(pResult->m_ClientID);
+	int Team = pSelf->GetDDRaceTeam(pResult->m_ClientId);
 	if(!Teams.IsPractice(Team))
 	{
-		pSelf->SendChatTarget(pPlayer->GetCID(), "You're not in a team with /practice turned on. Note that you can't earn a rank with practice enabled.");
+		pSelf->SendChatTarget(pPlayer->GetCid(), "You're not in a team with /practice turned on. Note that you can't earn a rank with practice enabled.");
 		return;
 	}
 
@@ -1815,9 +1815,9 @@ void CGameContext::ConPracticeSolo(IConsole::IResult *pResult, void *pUserData)
 void CGameContext::ConPracticeUnDeep(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	if(!CheckClientID(pResult->m_ClientID))
+	if(!CheckClientId(pResult->m_ClientId))
 		return;
-	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientID];
+	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientId];
 	if(!pPlayer)
 		return;
 	CCharacter *pChr = pPlayer->GetCharacter();
@@ -1825,10 +1825,10 @@ void CGameContext::ConPracticeUnDeep(IConsole::IResult *pResult, void *pUserData
 		return;
 
 	CGameTeams &Teams = pSelf->m_pController->Teams();
-	int Team = pSelf->GetDDRaceTeam(pResult->m_ClientID);
+	int Team = pSelf->GetDDRaceTeam(pResult->m_ClientId);
 	if(!Teams.IsPractice(Team))
 	{
-		pSelf->SendChatTarget(pPlayer->GetCID(), "You're not in a team with /practice turned on. Note that you can't earn a rank with practice enabled.");
+		pSelf->SendChatTarget(pPlayer->GetCid(), "You're not in a team with /practice turned on. Note that you can't earn a rank with practice enabled.");
 		return;
 	}
 
@@ -1839,9 +1839,9 @@ void CGameContext::ConPracticeUnDeep(IConsole::IResult *pResult, void *pUserData
 void CGameContext::ConPracticeDeep(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	if(!CheckClientID(pResult->m_ClientID))
+	if(!CheckClientId(pResult->m_ClientId))
 		return;
-	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientID];
+	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientId];
 	if(!pPlayer)
 		return;
 	CCharacter *pChr = pPlayer->GetCharacter();
@@ -1849,10 +1849,10 @@ void CGameContext::ConPracticeDeep(IConsole::IResult *pResult, void *pUserData)
 		return;
 
 	CGameTeams &Teams = pSelf->m_pController->Teams();
-	int Team = pSelf->GetDDRaceTeam(pResult->m_ClientID);
+	int Team = pSelf->GetDDRaceTeam(pResult->m_ClientId);
 	if(!Teams.IsPractice(Team))
 	{
-		pSelf->SendChatTarget(pPlayer->GetCID(), "You're not in a team with /practice turned on. Note that you can't earn a rank with practice enabled.");
+		pSelf->SendChatTarget(pPlayer->GetCid(), "You're not in a team with /practice turned on. Note that you can't earn a rank with practice enabled.");
 		return;
 	}
 
@@ -1862,9 +1862,9 @@ void CGameContext::ConPracticeDeep(IConsole::IResult *pResult, void *pUserData)
 void CGameContext::ConProtectedKill(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	if(!CheckClientID(pResult->m_ClientID))
+	if(!CheckClientId(pResult->m_ClientId))
 		return;
-	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientID];
+	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientId];
 	if(!pPlayer)
 		return;
 	CCharacter *pChr = pPlayer->GetCharacter();
@@ -1881,13 +1881,13 @@ void CGameContext::ConProtectedKill(IConsole::IResult *pResult, void *pUserData)
 void CGameContext::ConPoints(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	if(!CheckClientID(pResult->m_ClientID))
+	if(!CheckClientId(pResult->m_ClientId))
 		return;
 
 	if(pResult->NumArguments() > 0)
 	{
 		if(!g_Config.m_SvHideScore)
-			pSelf->Score()->ShowPoints(pResult->m_ClientID, pResult->GetString(0));
+			pSelf->Score()->ShowPoints(pResult->m_ClientId, pResult->GetString(0));
 		else
 			pSelf->Console()->Print(
 				IConsole::OUTPUT_LEVEL_STANDARD,
@@ -1895,14 +1895,14 @@ void CGameContext::ConPoints(IConsole::IResult *pResult, void *pUserData)
 				"Showing the global points of other players is not allowed on this server.");
 	}
 	else
-		pSelf->Score()->ShowPoints(pResult->m_ClientID,
-			pSelf->Server()->ClientName(pResult->m_ClientID));
+		pSelf->Score()->ShowPoints(pResult->m_ClientId,
+			pSelf->Server()->ClientName(pResult->m_ClientId));
 }
 
 void CGameContext::ConTopPoints(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	if(!CheckClientID(pResult->m_ClientID))
+	if(!CheckClientId(pResult->m_ClientId))
 		return;
 
 	if(g_Config.m_SvHideScore)
@@ -1913,15 +1913,15 @@ void CGameContext::ConTopPoints(IConsole::IResult *pResult, void *pUserData)
 	}
 
 	if(pResult->NumArguments() > 0)
-		pSelf->Score()->ShowTopPoints(pResult->m_ClientID, pResult->GetInteger(0));
+		pSelf->Score()->ShowTopPoints(pResult->m_ClientId, pResult->GetInteger(0));
 	else
-		pSelf->Score()->ShowTopPoints(pResult->m_ClientID);
+		pSelf->Score()->ShowTopPoints(pResult->m_ClientId);
 }
 
 void CGameContext::ConTimeCP(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	if(!CheckClientID(pResult->m_ClientID))
+	if(!CheckClientId(pResult->m_ClientId))
 		return;
 
 	if(g_Config.m_SvHideScore)
@@ -1931,10 +1931,10 @@ void CGameContext::ConTimeCP(IConsole::IResult *pResult, void *pUserData)
 		return;
 	}
 
-	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientID];
+	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientId];
 	if(!pPlayer)
 		return;
 
 	const char *pName = pResult->GetString(0);
-	pSelf->Score()->LoadPlayerData(pResult->m_ClientID, pName);
+	pSelf->Score()->LoadPlayerData(pResult->m_ClientId, pName);
 }

--- a/src/game/server/ddracecommands.cpp
+++ b/src/game/server/ddracecommands.cpp
@@ -10,16 +10,16 @@
 #include <game/server/save.h>
 #include <game/server/teams.h>
 
-bool CheckClientID(int ClientID);
+bool CheckClientId(int ClientId);
 
 void CGameContext::ConGoLeft(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
 	int Tiles = pResult->NumArguments() == 1 ? pResult->GetInteger(0) : 1;
 
-	if(!CheckClientID(pResult->m_ClientID))
+	if(!CheckClientId(pResult->m_ClientId))
 		return;
-	pSelf->MoveCharacter(pResult->m_ClientID, -1 * Tiles, 0);
+	pSelf->MoveCharacter(pResult->m_ClientId, -1 * Tiles, 0);
 }
 
 void CGameContext::ConGoRight(IConsole::IResult *pResult, void *pUserData)
@@ -27,9 +27,9 @@ void CGameContext::ConGoRight(IConsole::IResult *pResult, void *pUserData)
 	CGameContext *pSelf = (CGameContext *)pUserData;
 	int Tiles = pResult->NumArguments() == 1 ? pResult->GetInteger(0) : 1;
 
-	if(!CheckClientID(pResult->m_ClientID))
+	if(!CheckClientId(pResult->m_ClientId))
 		return;
-	pSelf->MoveCharacter(pResult->m_ClientID, Tiles, 0);
+	pSelf->MoveCharacter(pResult->m_ClientId, Tiles, 0);
 }
 
 void CGameContext::ConGoDown(IConsole::IResult *pResult, void *pUserData)
@@ -37,9 +37,9 @@ void CGameContext::ConGoDown(IConsole::IResult *pResult, void *pUserData)
 	CGameContext *pSelf = (CGameContext *)pUserData;
 	int Tiles = pResult->NumArguments() == 1 ? pResult->GetInteger(0) : 1;
 
-	if(!CheckClientID(pResult->m_ClientID))
+	if(!CheckClientId(pResult->m_ClientId))
 		return;
-	pSelf->MoveCharacter(pResult->m_ClientID, 0, Tiles);
+	pSelf->MoveCharacter(pResult->m_ClientId, 0, Tiles);
 }
 
 void CGameContext::ConGoUp(IConsole::IResult *pResult, void *pUserData)
@@ -47,32 +47,32 @@ void CGameContext::ConGoUp(IConsole::IResult *pResult, void *pUserData)
 	CGameContext *pSelf = (CGameContext *)pUserData;
 	int Tiles = pResult->NumArguments() == 1 ? pResult->GetInteger(0) : 1;
 
-	if(!CheckClientID(pResult->m_ClientID))
+	if(!CheckClientId(pResult->m_ClientId))
 		return;
-	pSelf->MoveCharacter(pResult->m_ClientID, 0, -1 * Tiles);
+	pSelf->MoveCharacter(pResult->m_ClientId, 0, -1 * Tiles);
 }
 
 void CGameContext::ConMove(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	if(!CheckClientID(pResult->m_ClientID))
+	if(!CheckClientId(pResult->m_ClientId))
 		return;
-	pSelf->MoveCharacter(pResult->m_ClientID, pResult->GetInteger(0),
+	pSelf->MoveCharacter(pResult->m_ClientId, pResult->GetInteger(0),
 		pResult->GetInteger(1));
 }
 
 void CGameContext::ConMoveRaw(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	if(!CheckClientID(pResult->m_ClientID))
+	if(!CheckClientId(pResult->m_ClientId))
 		return;
-	pSelf->MoveCharacter(pResult->m_ClientID, pResult->GetInteger(0),
+	pSelf->MoveCharacter(pResult->m_ClientId, pResult->GetInteger(0),
 		pResult->GetInteger(1), true);
 }
 
-void CGameContext::MoveCharacter(int ClientID, int X, int Y, bool Raw)
+void CGameContext::MoveCharacter(int ClientId, int X, int Y, bool Raw)
 {
-	CCharacter *pChr = GetPlayerChar(ClientID);
+	CCharacter *pChr = GetPlayerChar(ClientId);
 
 	if(!pChr)
 		return;
@@ -84,7 +84,7 @@ void CGameContext::MoveCharacter(int ClientID, int X, int Y, bool Raw)
 void CGameContext::ConKillPlayer(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	if(!CheckClientID(pResult->m_ClientID))
+	if(!CheckClientId(pResult->m_ClientId))
 		return;
 	int Victim = pResult->GetVictim();
 
@@ -94,7 +94,7 @@ void CGameContext::ConKillPlayer(IConsole::IResult *pResult, void *pUserData)
 		char aBuf[512];
 		str_format(aBuf, sizeof(aBuf), "%s was killed by %s",
 			pSelf->Server()->ClientName(Victim),
-			pSelf->Server()->ClientName(pResult->m_ClientID));
+			pSelf->Server()->ClientName(pResult->m_ClientId));
 		pSelf->SendChat(-1, CGameContext::CHAT_ALL, aBuf);
 	}
 }
@@ -114,9 +114,9 @@ void CGameContext::ConUnNinja(IConsole::IResult *pResult, void *pUserData)
 void CGameContext::ConEndlessHook(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	if(!CheckClientID(pResult->m_ClientID))
+	if(!CheckClientId(pResult->m_ClientId))
 		return;
-	CCharacter *pChr = pSelf->GetPlayerChar(pResult->m_ClientID);
+	CCharacter *pChr = pSelf->GetPlayerChar(pResult->m_ClientId);
 	if(pChr)
 	{
 		pChr->SetEndlessHook(true);
@@ -126,9 +126,9 @@ void CGameContext::ConEndlessHook(IConsole::IResult *pResult, void *pUserData)
 void CGameContext::ConUnEndlessHook(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	if(!CheckClientID(pResult->m_ClientID))
+	if(!CheckClientId(pResult->m_ClientId))
 		return;
-	CCharacter *pChr = pSelf->GetPlayerChar(pResult->m_ClientID);
+	CCharacter *pChr = pSelf->GetPlayerChar(pResult->m_ClientId);
 	if(pChr)
 	{
 		pChr->SetEndlessHook(false);
@@ -138,9 +138,9 @@ void CGameContext::ConUnEndlessHook(IConsole::IResult *pResult, void *pUserData)
 void CGameContext::ConSuper(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	if(!CheckClientID(pResult->m_ClientID))
+	if(!CheckClientId(pResult->m_ClientId))
 		return;
-	CCharacter *pChr = pSelf->GetPlayerChar(pResult->m_ClientID);
+	CCharacter *pChr = pSelf->GetPlayerChar(pResult->m_ClientId);
 	if(pChr && !pChr->IsSuper())
 	{
 		pChr->SetSuper(true);
@@ -151,9 +151,9 @@ void CGameContext::ConSuper(IConsole::IResult *pResult, void *pUserData)
 void CGameContext::ConUnSuper(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	if(!CheckClientID(pResult->m_ClientID))
+	if(!CheckClientId(pResult->m_ClientId))
 		return;
-	CCharacter *pChr = pSelf->GetPlayerChar(pResult->m_ClientID);
+	CCharacter *pChr = pSelf->GetPlayerChar(pResult->m_ClientId);
 	if(pChr && pChr->IsSuper())
 	{
 		pChr->SetSuper(false);
@@ -163,9 +163,9 @@ void CGameContext::ConUnSuper(IConsole::IResult *pResult, void *pUserData)
 void CGameContext::ConSolo(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	if(!CheckClientID(pResult->m_ClientID))
+	if(!CheckClientId(pResult->m_ClientId))
 		return;
-	CCharacter *pChr = pSelf->GetPlayerChar(pResult->m_ClientID);
+	CCharacter *pChr = pSelf->GetPlayerChar(pResult->m_ClientId);
 	if(pChr)
 		pChr->SetSolo(true);
 }
@@ -173,9 +173,9 @@ void CGameContext::ConSolo(IConsole::IResult *pResult, void *pUserData)
 void CGameContext::ConUnSolo(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	if(!CheckClientID(pResult->m_ClientID))
+	if(!CheckClientId(pResult->m_ClientId))
 		return;
-	CCharacter *pChr = pSelf->GetPlayerChar(pResult->m_ClientID);
+	CCharacter *pChr = pSelf->GetPlayerChar(pResult->m_ClientId);
 	if(pChr)
 		pChr->SetSolo(false);
 }
@@ -183,9 +183,9 @@ void CGameContext::ConUnSolo(IConsole::IResult *pResult, void *pUserData)
 void CGameContext::ConFreeze(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	if(!CheckClientID(pResult->m_ClientID))
+	if(!CheckClientId(pResult->m_ClientId))
 		return;
-	CCharacter *pChr = pSelf->GetPlayerChar(pResult->m_ClientID);
+	CCharacter *pChr = pSelf->GetPlayerChar(pResult->m_ClientId);
 	if(pChr)
 		pChr->Freeze();
 }
@@ -193,9 +193,9 @@ void CGameContext::ConFreeze(IConsole::IResult *pResult, void *pUserData)
 void CGameContext::ConUnFreeze(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	if(!CheckClientID(pResult->m_ClientID))
+	if(!CheckClientId(pResult->m_ClientId))
 		return;
-	CCharacter *pChr = pSelf->GetPlayerChar(pResult->m_ClientID);
+	CCharacter *pChr = pSelf->GetPlayerChar(pResult->m_ClientId);
 	if(pChr)
 		pChr->UnFreeze();
 }
@@ -203,9 +203,9 @@ void CGameContext::ConUnFreeze(IConsole::IResult *pResult, void *pUserData)
 void CGameContext::ConDeep(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	if(!CheckClientID(pResult->m_ClientID))
+	if(!CheckClientId(pResult->m_ClientId))
 		return;
-	CCharacter *pChr = pSelf->GetPlayerChar(pResult->m_ClientID);
+	CCharacter *pChr = pSelf->GetPlayerChar(pResult->m_ClientId);
 	if(pChr)
 		pChr->SetDeepFrozen(true);
 }
@@ -213,9 +213,9 @@ void CGameContext::ConDeep(IConsole::IResult *pResult, void *pUserData)
 void CGameContext::ConUnDeep(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	if(!CheckClientID(pResult->m_ClientID))
+	if(!CheckClientId(pResult->m_ClientId))
 		return;
-	CCharacter *pChr = pSelf->GetPlayerChar(pResult->m_ClientID);
+	CCharacter *pChr = pSelf->GetPlayerChar(pResult->m_ClientId);
 	if(pChr)
 	{
 		pChr->SetDeepFrozen(false);
@@ -226,9 +226,9 @@ void CGameContext::ConUnDeep(IConsole::IResult *pResult, void *pUserData)
 void CGameContext::ConLiveFreeze(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	if(!CheckClientID(pResult->m_ClientID))
+	if(!CheckClientId(pResult->m_ClientId))
 		return;
-	CCharacter *pChr = pSelf->GetPlayerChar(pResult->m_ClientID);
+	CCharacter *pChr = pSelf->GetPlayerChar(pResult->m_ClientId);
 	if(pChr)
 		pChr->SetLiveFrozen(true);
 }
@@ -236,9 +236,9 @@ void CGameContext::ConLiveFreeze(IConsole::IResult *pResult, void *pUserData)
 void CGameContext::ConUnLiveFreeze(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	if(!CheckClientID(pResult->m_ClientID))
+	if(!CheckClientId(pResult->m_ClientId))
 		return;
-	CCharacter *pChr = pSelf->GetPlayerChar(pResult->m_ClientID);
+	CCharacter *pChr = pSelf->GetPlayerChar(pResult->m_ClientId);
 	if(pChr)
 		pChr->SetLiveFrozen(false);
 }
@@ -264,7 +264,7 @@ void CGameContext::ConLaser(IConsole::IResult *pResult, void *pUserData)
 void CGameContext::ConJetpack(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	CCharacter *pChr = pSelf->GetPlayerChar(pResult->m_ClientID);
+	CCharacter *pChr = pSelf->GetPlayerChar(pResult->m_ClientId);
 	if(pChr)
 		pChr->SetJetpack(true);
 }
@@ -296,7 +296,7 @@ void CGameContext::ConUnLaser(IConsole::IResult *pResult, void *pUserData)
 void CGameContext::ConUnJetpack(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	CCharacter *pChr = pSelf->GetPlayerChar(pResult->m_ClientID);
+	CCharacter *pChr = pSelf->GetPlayerChar(pResult->m_ClientId);
 	if(pChr)
 		pChr->SetJetpack(false);
 }
@@ -323,7 +323,7 @@ void CGameContext::ModifyWeapons(IConsole::IResult *pResult, void *pUserData,
 	int Weapon, bool Remove)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	CCharacter *pChr = GetPlayerChar(pResult->m_ClientID);
+	CCharacter *pChr = GetPlayerChar(pResult->m_ClientId);
 	if(!pChr)
 		return;
 
@@ -363,7 +363,7 @@ void CGameContext::ConToTeleporter(IConsole::IResult *pResult, void *pUserData)
 
 	if(!pSelf->m_pController->m_TeleOuts[TeleTo - 1].empty())
 	{
-		CCharacter *pChr = pSelf->GetPlayerChar(pResult->m_ClientID);
+		CCharacter *pChr = pSelf->GetPlayerChar(pResult->m_ClientId);
 		if(pChr)
 		{
 			int TeleOut = pSelf->m_World.m_Core.RandomOr0(pSelf->m_pController->m_TeleOuts[TeleTo - 1].size());
@@ -379,7 +379,7 @@ void CGameContext::ConToCheckTeleporter(IConsole::IResult *pResult, void *pUserD
 
 	if(!pSelf->m_pController->m_TeleCheckOuts[TeleTo - 1].empty())
 	{
-		CCharacter *pChr = pSelf->GetPlayerChar(pResult->m_ClientID);
+		CCharacter *pChr = pSelf->GetPlayerChar(pResult->m_ClientId);
 		if(pChr)
 		{
 			int TeleOut = pSelf->m_World.m_Core.RandomOr0(pSelf->m_pController->m_TeleCheckOuts[TeleTo - 1].size());
@@ -392,18 +392,18 @@ void CGameContext::ConToCheckTeleporter(IConsole::IResult *pResult, void *pUserD
 void CGameContext::ConTeleport(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	int Tele = pResult->NumArguments() == 2 ? pResult->GetInteger(0) : pResult->m_ClientID;
-	int TeleTo = pResult->NumArguments() ? pResult->GetInteger(pResult->NumArguments() - 1) : pResult->m_ClientID;
-	int AuthLevel = pSelf->Server()->GetAuthedState(pResult->m_ClientID);
+	int Tele = pResult->NumArguments() == 2 ? pResult->GetInteger(0) : pResult->m_ClientId;
+	int TeleTo = pResult->NumArguments() ? pResult->GetInteger(pResult->NumArguments() - 1) : pResult->m_ClientId;
+	int AuthLevel = pSelf->Server()->GetAuthedState(pResult->m_ClientId);
 
-	if(Tele != pResult->m_ClientID && AuthLevel < g_Config.m_SvTeleOthersAuthLevel)
+	if(Tele != pResult->m_ClientId && AuthLevel < g_Config.m_SvTeleOthersAuthLevel)
 	{
 		pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "tele", "you aren't allowed to tele others");
 		return;
 	}
 
 	CCharacter *pChr = pSelf->GetPlayerChar(Tele);
-	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientID];
+	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientId];
 
 	if(pChr && pPlayer && pSelf->GetPlayerChar(TeleTo))
 	{
@@ -421,9 +421,9 @@ void CGameContext::ConTeleport(IConsole::IResult *pResult, void *pUserData)
 void CGameContext::ConKill(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	if(!CheckClientID(pResult->m_ClientID))
+	if(!CheckClientId(pResult->m_ClientId))
 		return;
-	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientID];
+	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientId];
 
 	if(!pPlayer || (pPlayer->m_LastKill && pPlayer->m_LastKill + pSelf->Server()->TickSpeed() * g_Config.m_SvKillDelay > pSelf->Server()->Tick()))
 		return;
@@ -474,7 +474,7 @@ bool CGameContext::TryVoteMute(const NETADDR *pAddr, int Secs, const char *pReas
 	return false;
 }
 
-void CGameContext::VoteMute(const NETADDR *pAddr, int Secs, const char *pReason, const char *pDisplayName, int AuthedID)
+void CGameContext::VoteMute(const NETADDR *pAddr, int Secs, const char *pReason, const char *pDisplayName, int AuthedId)
 {
 	if(!TryVoteMute(pAddr, Secs, pReason))
 		return;
@@ -484,14 +484,14 @@ void CGameContext::VoteMute(const NETADDR *pAddr, int Secs, const char *pReason,
 	char aBuf[128];
 	if(pReason[0])
 		str_format(aBuf, sizeof(aBuf), "'%s' banned '%s' for %d seconds from voting (%s)",
-			Server()->ClientName(AuthedID), pDisplayName, Secs, pReason);
+			Server()->ClientName(AuthedId), pDisplayName, Secs, pReason);
 	else
 		str_format(aBuf, sizeof(aBuf), "'%s' banned '%s' for %d seconds from voting",
-			Server()->ClientName(AuthedID), pDisplayName, Secs);
+			Server()->ClientName(AuthedId), pDisplayName, Secs);
 	SendChat(-1, CHAT_ALL, aBuf);
 }
 
-bool CGameContext::VoteUnmute(const NETADDR *pAddr, const char *pDisplayName, int AuthedID)
+bool CGameContext::VoteUnmute(const NETADDR *pAddr, const char *pDisplayName, int AuthedId)
 {
 	for(int i = 0; i < m_NumVoteMutes; i++)
 	{
@@ -503,7 +503,7 @@ bool CGameContext::VoteUnmute(const NETADDR *pAddr, const char *pDisplayName, in
 			{
 				char aBuf[128];
 				str_format(aBuf, sizeof(aBuf), "'%s' unbanned '%s' from voting.",
-					Server()->ClientName(AuthedID), pDisplayName);
+					Server()->ClientName(AuthedId), pDisplayName);
 				Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "voteunmute", aBuf);
 			}
 			return true;
@@ -580,7 +580,7 @@ void CGameContext::ConVoteMute(IConsole::IResult *pResult, void *pUserData)
 
 	int Seconds = clamp(pResult->GetInteger(1), 1, 86400);
 	const char *pReason = pResult->NumArguments() > 2 ? pResult->GetString(2) : "";
-	pSelf->VoteMute(&Addr, Seconds, pReason, pSelf->Server()->ClientName(Victim), pResult->m_ClientID);
+	pSelf->VoteMute(&Addr, Seconds, pReason, pSelf->Server()->ClientName(Victim), pResult->m_ClientId);
 }
 
 void CGameContext::ConVoteUnmute(IConsole::IResult *pResult, void *pUserData)
@@ -597,12 +597,12 @@ void CGameContext::ConVoteUnmute(IConsole::IResult *pResult, void *pUserData)
 	NETADDR Addr;
 	pSelf->Server()->GetClientAddr(Victim, &Addr);
 
-	bool Found = pSelf->VoteUnmute(&Addr, pSelf->Server()->ClientName(Victim), pResult->m_ClientID);
+	bool Found = pSelf->VoteUnmute(&Addr, pSelf->Server()->ClientName(Victim), pResult->m_ClientId);
 	if(Found)
 	{
 		char aBuf[128];
 		str_format(aBuf, sizeof(aBuf), "'%s' unbanned '%s' from voting.",
-			pSelf->Server()->ClientName(pResult->m_ClientID), pSelf->Server()->ClientName(Victim));
+			pSelf->Server()->ClientName(pResult->m_ClientId), pSelf->Server()->ClientName(Victim));
 		pSelf->SendChat(-1, 0, aBuf);
 	}
 }
@@ -643,7 +643,7 @@ void CGameContext::ConMute(IConsole::IResult *pResult, void *pUserData)
 }
 
 // mute through client id
-void CGameContext::ConMuteID(IConsole::IResult *pResult, void *pUserData)
+void CGameContext::ConMuteId(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
 	int Victim = pResult->GetVictim();
@@ -664,7 +664,7 @@ void CGameContext::ConMuteID(IConsole::IResult *pResult, void *pUserData)
 }
 
 // mute through ip, arguments reversed to workaround parsing
-void CGameContext::ConMuteIP(IConsole::IResult *pResult, void *pUserData)
+void CGameContext::ConMuteIp(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
 	NETADDR Addr;
@@ -697,7 +697,7 @@ void CGameContext::ConUnmute(IConsole::IResult *pResult, void *pUserData)
 }
 
 // unmute by player id
-void CGameContext::ConUnmuteID(IConsole::IResult *pResult, void *pUserData)
+void CGameContext::ConUnmuteId(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
 	int Victim = pResult->GetVictim();
@@ -754,12 +754,12 @@ void CGameContext::ConMutes(IConsole::IResult *pResult, void *pUserData)
 void CGameContext::ConModerate(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	if(!CheckClientID(pResult->m_ClientID))
+	if(!CheckClientId(pResult->m_ClientId))
 		return;
 
 	bool HadModerator = pSelf->PlayerModerating();
 
-	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientID];
+	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientId];
 	pPlayer->m_Moderating = !pPlayer->m_Moderating;
 
 	if(!HadModerator && pPlayer->m_Moderating)
@@ -769,9 +769,9 @@ void CGameContext::ConModerate(IConsole::IResult *pResult, void *pUserData)
 		pSelf->SendChat(-1, CHAT_ALL, "Server kick/spec votes are no longer actively moderated.", 0);
 
 	if(pPlayer->m_Moderating)
-		pSelf->SendChatTarget(pResult->m_ClientID, "Active moderator mode enabled for you.");
+		pSelf->SendChatTarget(pResult->m_ClientId, "Active moderator mode enabled for you.");
 	else
-		pSelf->SendChatTarget(pResult->m_ClientID, "Active moderator mode disabled for you.");
+		pSelf->SendChatTarget(pResult->m_ClientId, "Active moderator mode disabled for you.");
 }
 
 void CGameContext::ConSetDDRTeam(IConsole::IResult *pResult, void *pUserData)
@@ -847,28 +847,28 @@ void CGameContext::ConVoteNo(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
 
-	pSelf->ForceVote(pResult->m_ClientID, false);
+	pSelf->ForceVote(pResult->m_ClientId, false);
 }
 
 void CGameContext::ConDrySave(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
 
-	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientID];
+	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientId];
 
-	if(!pPlayer || pSelf->Server()->GetAuthedState(pResult->m_ClientID) != AUTHED_ADMIN)
+	if(!pPlayer || pSelf->Server()->GetAuthedState(pResult->m_ClientId) != AUTHED_ADMIN)
 		return;
 
 	CSaveTeam SavedTeam;
-	int Team = pSelf->GetDDRaceTeam(pResult->m_ClientID);
+	int Team = pSelf->GetDDRaceTeam(pResult->m_ClientId);
 	int Result = SavedTeam.Save(pSelf, Team, true);
-	if(CSaveTeam::HandleSaveError(Result, pResult->m_ClientID, pSelf))
+	if(CSaveTeam::HandleSaveError(Result, pResult->m_ClientId, pSelf))
 		return;
 
 	char aTimestamp[32];
 	str_timestamp(aTimestamp, sizeof(aTimestamp));
 	char aBuf[64];
-	str_format(aBuf, sizeof(aBuf), "%s_%s_%s.save", pSelf->Server()->GetMapName(), aTimestamp, pSelf->Server()->GetAuthName(pResult->m_ClientID));
+	str_format(aBuf, sizeof(aBuf), "%s_%s_%s.save", pSelf->Server()->GetMapName(), aTimestamp, pSelf->Server()->GetAuthName(pResult->m_ClientId));
 	IOHANDLE File = pSelf->Storage()->OpenFile(aBuf, IOFLAG_WRITE, IStorage::TYPE_ALL);
 	if(!File)
 		return;
@@ -923,18 +923,18 @@ void CGameContext::ConDumpLog(IConsole::IResult *pResult, void *pUserData)
 	}
 }
 
-void CGameContext::LogEvent(const char *Description, int ClientID)
+void CGameContext::LogEvent(const char *Description, int ClientId)
 {
 	CLog *pNewEntry = &m_aLogs[m_LatestLog];
 	m_LatestLog = (m_LatestLog + 1) % MAX_LOGS;
 
 	pNewEntry->m_Timestamp = time_get();
 	str_copy(pNewEntry->m_aDescription, Description);
-	pNewEntry->m_FromServer = ClientID < 0;
+	pNewEntry->m_FromServer = ClientId < 0;
 	if(!pNewEntry->m_FromServer)
 	{
-		pNewEntry->m_ClientVersion = Server()->GetClientVersion(ClientID);
-		Server()->GetClientAddr(ClientID, pNewEntry->m_aClientAddrStr, sizeof(pNewEntry->m_aClientAddrStr));
-		str_copy(pNewEntry->m_aClientName, Server()->ClientName(ClientID));
+		pNewEntry->m_ClientVersion = Server()->GetClientVersion(ClientId);
+		Server()->GetClientAddr(ClientId, pNewEntry->m_aClientAddrStr, sizeof(pNewEntry->m_aClientAddrStr));
+		str_copy(pNewEntry->m_aClientName, Server()->ClientName(ClientId));
 	}
 }

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -28,7 +28,7 @@ CCharacter::CCharacter(CGameWorld *pWorld, CNetObj_PlayerInput LastInput) :
 {
 	m_Health = 0;
 	m_Armor = 0;
-	m_StrongWeakID = 0;
+	m_StrongWeakId = 0;
 
 	m_Input = LastInput;
 	// never initialize both to zero
@@ -72,14 +72,14 @@ bool CCharacter::Spawn(CPlayer *pPlayer, vec2 Pos)
 	m_NumInputs = 0;
 	m_SpawnTick = Server()->Tick();
 	m_WeaponChangeTick = Server()->Tick();
-	Antibot()->OnSpawn(m_pPlayer->GetCID());
+	Antibot()->OnSpawn(m_pPlayer->GetCid());
 
 	m_Core.Reset();
 	m_Core.Init(&GameServer()->m_World.m_Core, Collision());
 	m_Core.m_ActiveWeapon = WEAPON_GUN;
 	m_Core.m_Pos = m_Pos;
-	m_Core.m_Id = m_pPlayer->GetCID();
-	GameServer()->m_World.m_Core.m_apCharacters[m_pPlayer->GetCID()] = &m_Core;
+	m_Core.m_Id = m_pPlayer->GetCid();
+	GameServer()->m_World.m_Core.m_apCharacters[m_pPlayer->GetCid()] = &m_Core;
 
 	m_ReckoningTick = 0;
 	m_SendCore = CCharacterCore();
@@ -96,16 +96,16 @@ bool CCharacter::Spawn(CPlayer *pPlayer, vec2 Pos)
 	m_TuneZoneOld = -1; // no zone leave msg on spawn
 	m_NeededFaketuning = 0; // reset fake tunings on respawn and send the client
 	SendZoneMsgs(); // we want a entermessage also on spawn
-	GameServer()->SendTuningParams(m_pPlayer->GetCID(), m_TuneZone);
+	GameServer()->SendTuningParams(m_pPlayer->GetCid(), m_TuneZone);
 
-	Server()->StartRecord(m_pPlayer->GetCID());
+	Server()->StartRecord(m_pPlayer->GetCid());
 
 	return true;
 }
 
 void CCharacter::Destroy()
 {
-	GameServer()->m_World.m_Core.m_apCharacters[m_pPlayer->GetCID()] = 0;
+	GameServer()->m_World.m_Core.m_apCharacters[m_pPlayer->GetCid()] = 0;
 	m_Alive = false;
 	SetSolo(false);
 }
@@ -132,7 +132,7 @@ void CCharacter::SetJetpack(bool Active)
 void CCharacter::SetSolo(bool Solo)
 {
 	m_Core.m_Solo = Solo;
-	Teams()->m_Core.SetSolo(m_pPlayer->GetCID(), Solo);
+	Teams()->m_Core.SetSolo(m_pPlayer->GetCid(), Solo);
 }
 
 void CCharacter::SetSuper(bool Super)
@@ -141,12 +141,12 @@ void CCharacter::SetSuper(bool Super)
 	if(Super)
 	{
 		m_TeamBeforeSuper = Team();
-		Teams()->SetCharacterTeam(GetPlayer()->GetCID(), TEAM_SUPER);
+		Teams()->SetCharacterTeam(GetPlayer()->GetCid(), TEAM_SUPER);
 		m_DDRaceState = DDRACE_CHEAT;
 	}
 	else
 	{
-		Teams()->SetForceCharacterTeam(GetPlayer()->GetCID(), m_TeamBeforeSuper);
+		Teams()->SetForceCharacterTeam(GetPlayer()->GetCid(), m_TeamBeforeSuper);
 	}
 }
 
@@ -209,7 +209,7 @@ void CCharacter::HandleJetpack()
 				Strength = Tuning()->m_JetpackStrength;
 			else
 				Strength = TuningList()[m_TuneZone].m_JetpackStrength;
-			TakeDamage(Direction * -1.0f * (Strength / 100.0f / 6.11f), 0, m_pPlayer->GetCID(), m_Core.m_ActiveWeapon);
+			TakeDamage(Direction * -1.0f * (Strength / 100.0f / 6.11f), 0, m_pPlayer->GetCid(), m_Core.m_ActiveWeapon);
 		}
 	}
 	}
@@ -271,7 +271,7 @@ void CCharacter::HandleNinja()
 			int Num = GameServer()->m_World.FindEntities(OldPos, Radius, apEnts, MAX_CLIENTS, CGameWorld::ENTTYPE_CHARACTER);
 
 			// check that we're not in solo part
-			if(Teams()->m_Core.GetSolo(m_pPlayer->GetCID()))
+			if(Teams()->m_Core.GetSolo(m_pPlayer->GetCid()))
 				return;
 
 			for(int i = 0; i < Num; ++i)
@@ -285,7 +285,7 @@ void CCharacter::HandleNinja()
 					continue;
 
 				// Don't hit players in solo parts
-				if(Teams()->m_Core.GetSolo(pChr->m_pPlayer->GetCID()))
+				if(Teams()->m_Core.GetSolo(pChr->m_pPlayer->GetCid()))
 					return;
 
 				// make sure we haven't Hit this object before
@@ -308,7 +308,7 @@ void CCharacter::HandleNinja()
 				if(m_NumObjectsHit < 10)
 					m_apHitObjects[m_NumObjectsHit++] = pChr;
 
-				pChr->TakeDamage(vec2(0, -10.0f), g_pData->m_Weapons.m_Ninja.m_pBase->m_Damage, m_pPlayer->GetCID(), WEAPON_NINJA);
+				pChr->TakeDamage(vec2(0, -10.0f), g_pData->m_Weapons.m_Ninja.m_pBase->m_Damage, m_pPlayer->GetCid(), WEAPON_NINJA);
 			}
 		}
 
@@ -379,7 +379,7 @@ void CCharacter::FireWeapon()
 	{
 		if(m_LatestInput.m_Fire & 1)
 		{
-			Antibot()->OnHammerFireReloading(m_pPlayer->GetCID());
+			Antibot()->OnHammerFireReloading(m_pPlayer->GetCid());
 		}
 		return;
 	}
@@ -438,7 +438,7 @@ void CCharacter::FireWeapon()
 		m_NumObjectsHit = 0;
 		GameServer()->CreateSound(m_Pos, SOUND_HAMMER_FIRE, TeamMask());
 
-		Antibot()->OnHammerFire(m_pPlayer->GetCID());
+		Antibot()->OnHammerFire(m_pPlayer->GetCid());
 
 		if(m_Core.m_HammerHitDisabled)
 			break;
@@ -453,7 +453,7 @@ void CCharacter::FireWeapon()
 			auto *pTarget = static_cast<CCharacter *>(apEnts[i]);
 
 			//if ((pTarget == this) || Collision()->IntersectLine(ProjStartPos, pTarget->m_Pos, NULL, NULL))
-			if((pTarget == this || (pTarget->IsAlive() && !CanCollide(pTarget->GetPlayer()->GetCID()))))
+			if((pTarget == this || (pTarget->IsAlive() && !CanCollide(pTarget->GetPlayer()->GetCid()))))
 				continue;
 
 			// set his velocity to fast upward (for now)
@@ -478,13 +478,13 @@ void CCharacter::FireWeapon()
 			Temp = ClampVel(pTarget->m_MoveRestrictions, Temp);
 			Temp -= pTarget->m_Core.m_Vel;
 			pTarget->TakeDamage((vec2(0.f, -1.0f) + Temp) * Strength, g_pData->m_Weapons.m_Hammer.m_pBase->m_Damage,
-				m_pPlayer->GetCID(), m_Core.m_ActiveWeapon);
+				m_pPlayer->GetCid(), m_Core.m_ActiveWeapon);
 			pTarget->UnFreeze();
 
 			if(m_FreezeHammer)
 				pTarget->Freeze();
 
-			Antibot()->OnHammerHit(m_pPlayer->GetCID(), pTarget->GetPlayer()->GetCID());
+			Antibot()->OnHammerHit(m_pPlayer->GetCid(), pTarget->GetPlayer()->GetCid());
 
 			Hits++;
 		}
@@ -515,7 +515,7 @@ void CCharacter::FireWeapon()
 			new CProjectile(
 				GameWorld(),
 				WEAPON_GUN, //Type
-				m_pPlayer->GetCID(), //Owner
+				m_pPlayer->GetCid(), //Owner
 				ProjStartPos, //Pos
 				Direction, //Dir
 				Lifetime, //Span
@@ -538,7 +538,7 @@ void CCharacter::FireWeapon()
 		else
 			LaserReach = TuningList()[m_TuneZone].m_LaserReach;
 
-		new CLaser(&GameServer()->m_World, m_Pos, Direction, LaserReach, m_pPlayer->GetCID(), WEAPON_SHOTGUN);
+		new CLaser(&GameServer()->m_World, m_Pos, Direction, LaserReach, m_pPlayer->GetCid(), WEAPON_SHOTGUN);
 		GameServer()->CreateSound(m_Pos, SOUND_SHOTGUN_FIRE, TeamMask()); // NOLINT(clang-analyzer-unix.Malloc)
 	}
 	break;
@@ -554,7 +554,7 @@ void CCharacter::FireWeapon()
 		new CProjectile(
 			GameWorld(),
 			WEAPON_GRENADE, //Type
-			m_pPlayer->GetCID(), //Owner
+			m_pPlayer->GetCid(), //Owner
 			ProjStartPos, //Pos
 			Direction, //Dir
 			Lifetime, //Span
@@ -576,7 +576,7 @@ void CCharacter::FireWeapon()
 		else
 			LaserReach = TuningList()[m_TuneZone].m_LaserReach;
 
-		new CLaser(GameWorld(), m_Pos, Direction, LaserReach, m_pPlayer->GetCID(), WEAPON_LASER);
+		new CLaser(GameWorld(), m_Pos, Direction, LaserReach, m_pPlayer->GetCid(), WEAPON_LASER);
 		GameServer()->CreateSound(m_Pos, SOUND_LASER_FIRE, TeamMask()); // NOLINT(clang-analyzer-unix.Malloc)
 	}
 	break;
@@ -686,7 +686,7 @@ void CCharacter::OnDirectInput(CNetObj_PlayerInput *pNewInput)
 	if(m_LatestInput.m_TargetX == 0 && m_LatestInput.m_TargetY == 0)
 		m_LatestInput.m_TargetY = -1;
 
-	Antibot()->OnDirectInput(m_pPlayer->GetCID());
+	Antibot()->OnDirectInput(m_pPlayer->GetCid());
 
 	if(m_NumInputs > 1 && m_pPlayer->GetTeam() != TEAM_SPECTATORS)
 	{
@@ -729,8 +729,8 @@ void CCharacter::PreTick()
 		// Prevent the player from getting a negative time
 		// The main reason why this can happen is because of time penalty tiles
 		// However, other reasons are hereby also excluded
-		GameServer()->SendChatTarget(m_pPlayer->GetCID(), "You died of old age");
-		Die(m_pPlayer->GetCID(), WEAPON_WORLD);
+		GameServer()->SendChatTarget(m_pPlayer->GetCid(), "You died of old age");
+		Die(m_pPlayer->GetCid(), WEAPON_WORLD);
 	}
 
 	if(m_Paused)
@@ -744,7 +744,7 @@ void CCharacter::PreTick()
 
 	DDRaceTick();
 
-	Antibot()->OnCharacterTick(m_pPlayer->GetCID());
+	Antibot()->OnCharacterTick(m_pPlayer->GetCid());
 
 	m_Core.m_Input = m_Input;
 	m_Core.Tick(true, !g_Config.m_SvNoWeakHook);
@@ -766,7 +766,7 @@ void CCharacter::Tick()
 
 	if(!m_PrevInput.m_Hook && m_Input.m_Hook && !(m_Core.m_TriggeredEvents & COREEVENT_HOOK_ATTACH_PLAYER))
 	{
-		Antibot()->OnHookAttach(m_pPlayer->GetCID(), false);
+		Antibot()->OnHookAttach(m_pPlayer->GetCid(), false);
 	}
 
 	// handle Weapons
@@ -779,7 +779,7 @@ void CCharacter::Tick()
 		const int HookedPlayer = m_Core.HookedPlayer();
 		if(HookedPlayer != -1 && GameServer()->m_apPlayers[HookedPlayer]->GetTeam() != TEAM_SPECTATORS)
 		{
-			Antibot()->OnHookAttach(m_pPlayer->GetCID(), true);
+			Antibot()->OnHookAttach(m_pPlayer->GetCid(), true);
 		}
 	}
 
@@ -795,7 +795,7 @@ void CCharacter::TickDeferred()
 	{
 		CWorldCore TempWorld;
 		m_ReckoningCore.Init(&TempWorld, Collision(), &Teams()->m_Core, m_pTeleOuts);
-		m_ReckoningCore.m_Id = m_pPlayer->GetCID();
+		m_ReckoningCore.m_Id = m_pPlayer->GetCid();
 		m_ReckoningCore.Tick(false);
 		m_ReckoningCore.Move();
 		m_ReckoningCore.Quantize();
@@ -806,7 +806,7 @@ void CCharacter::TickDeferred()
 	vec2 StartVel = m_Core.m_Vel;
 	bool StuckBefore = Collision()->TestBox(m_Core.m_Pos, CCharacterCore::PhysicalSizeVec2());
 
-	m_Core.m_Id = m_pPlayer->GetCID();
+	m_Core.m_Id = m_pPlayer->GetCid();
 	m_Core.Move();
 	bool StuckAfterMove = Collision()->TestBox(m_Core.m_Pos, CCharacterCore::PhysicalSizeVec2());
 	m_Core.Quantize();
@@ -841,7 +841,7 @@ void CCharacter::TickDeferred()
 
 	{
 		int Events = m_Core.m_TriggeredEvents;
-		int CID = m_pPlayer->GetCID();
+		int CID = m_pPlayer->GetCid();
 
 		CClientMask TeamMask = Teams()->TeamMask(Team(), -1, CID);
 		// Some sounds are triggered client-side for the acting player
@@ -921,14 +921,14 @@ bool CCharacter::IncreaseArmor(int Amount)
 
 void CCharacter::Die(int Killer, int Weapon, bool SendKillMsg)
 {
-	if(Server()->IsRecording(m_pPlayer->GetCID()))
+	if(Server()->IsRecording(m_pPlayer->GetCid()))
 	{
-		CPlayerData *pData = GameServer()->Score()->PlayerData(m_pPlayer->GetCID());
+		CPlayerData *pData = GameServer()->Score()->PlayerData(m_pPlayer->GetCid());
 
 		if(pData->m_RecordStopTick - Server()->Tick() <= Server()->TickSpeed() && pData->m_RecordStopTick != -1)
-			Server()->SaveDemo(m_pPlayer->GetCID(), pData->m_RecordFinishTime);
+			Server()->SaveDemo(m_pPlayer->GetCid(), pData->m_RecordFinishTime);
 		else
-			Server()->StopRecord(m_pPlayer->GetCID());
+			Server()->StopRecord(m_pPlayer->GetCid());
 
 		pData->m_RecordStopTick = -1;
 	}
@@ -938,7 +938,7 @@ void CCharacter::Die(int Killer, int Weapon, bool SendKillMsg)
 	char aBuf[256];
 	str_format(aBuf, sizeof(aBuf), "kill killer='%d:%s' victim='%d:%s' weapon=%d special=%d",
 		Killer, Server()->ClientName(Killer),
-		m_pPlayer->GetCID(), Server()->ClientName(m_pPlayer->GetCID()), Weapon, ModeSpecial);
+		m_pPlayer->GetCid(), Server()->ClientName(m_pPlayer->GetCid()), Weapon, ModeSpecial);
 	GameServer()->Console()->Print(IConsole::OUTPUT_LEVEL_DEBUG, "game", aBuf);
 
 	// send the kill message
@@ -946,7 +946,7 @@ void CCharacter::Die(int Killer, int Weapon, bool SendKillMsg)
 	{
 		CNetMsg_Sv_KillMsg Msg;
 		Msg.m_Killer = Killer;
-		Msg.m_Victim = m_pPlayer->GetCID();
+		Msg.m_Victim = m_pPlayer->GetCid();
 		Msg.m_Weapon = Weapon;
 		Msg.m_ModeSpecial = ModeSpecial;
 		Server()->SendPackMsg(&Msg, MSGFLAG_VITAL, -1);
@@ -963,9 +963,9 @@ void CCharacter::Die(int Killer, int Weapon, bool SendKillMsg)
 	SetSolo(false);
 
 	GameServer()->m_World.RemoveEntity(this);
-	GameServer()->m_World.m_Core.m_apCharacters[m_pPlayer->GetCID()] = 0;
-	GameServer()->CreateDeath(m_Pos, m_pPlayer->GetCID(), TeamMask());
-	Teams()->OnCharacterDeath(GetPlayer()->GetCID(), Weapon);
+	GameServer()->m_World.m_Core.m_apCharacters[m_pPlayer->GetCid()] = 0;
+	GameServer()->CreateDeath(m_Pos, m_pPlayer->GetCid(), TeamMask());
+	Teams()->OnCharacterDeath(GetPlayer()->GetCid(), Weapon);
 }
 
 bool CCharacter::TakeDamage(vec2 Force, int Dmg, int From, int Weapon)
@@ -982,7 +982,7 @@ bool CCharacter::TakeDamage(vec2 Force, int Dmg, int From, int Weapon)
 }
 
 //TODO: Move the emote stuff to a function
-void CCharacter::SnapCharacter(int SnappingClient, int ID)
+void CCharacter::SnapCharacter(int SnappingClient, int Id)
 {
 	int SnappingClientVersion = GameServer()->GetClientVersion(SnappingClient);
 	CCharacterCore *pCore;
@@ -1010,7 +1010,7 @@ void CCharacter::SnapCharacter(int SnappingClient, int ID)
 	}
 
 	// solo, collision, jetpack and ninjajetpack prediction
-	if(m_pPlayer->GetCID() == SnappingClient)
+	if(m_pPlayer->GetCid() == SnappingClient)
 	{
 		int Faketuning = 0;
 		if(m_pPlayer->GetClientVersion() < VERSION_DDNET_NEW_HUD)
@@ -1031,7 +1031,7 @@ void CCharacter::SnapCharacter(int SnappingClient, int ID)
 		if(Faketuning != m_NeededFaketuning)
 		{
 			m_NeededFaketuning = Faketuning;
-			GameServer()->SendTuningParams(m_pPlayer->GetCID(), m_TuneZone); // update tunings
+			GameServer()->SendTuningParams(m_pPlayer->GetCid(), m_TuneZone); // update tunings
 		}
 	}
 
@@ -1044,8 +1044,8 @@ void CCharacter::SnapCharacter(int SnappingClient, int ID)
 		AmmoCount = 10;
 	}
 
-	if(m_pPlayer->GetCID() == SnappingClient || SnappingClient == SERVER_DEMO_CLIENT ||
-		(!g_Config.m_SvStrictSpectateMode && m_pPlayer->GetCID() == GameServer()->m_apPlayers[SnappingClient]->m_SpectatorID))
+	if(m_pPlayer->GetCid() == SnappingClient || SnappingClient == SERVER_DEMO_CLIENT ||
+		(!g_Config.m_SvStrictSpectateMode && m_pPlayer->GetCid() == GameServer()->m_apPlayers[SnappingClient]->m_SpectatorId))
 	{
 		Health = m_Health;
 		Armor = m_Armor;
@@ -1069,7 +1069,7 @@ void CCharacter::SnapCharacter(int SnappingClient, int ID)
 
 	if(!Server()->IsSixup(SnappingClient))
 	{
-		CNetObj_Character *pCharacter = Server()->SnapNewItem<CNetObj_Character>(ID);
+		CNetObj_Character *pCharacter = Server()->SnapNewItem<CNetObj_Character>(Id);
 		if(!pCharacter)
 			return;
 
@@ -1094,7 +1094,7 @@ void CCharacter::SnapCharacter(int SnappingClient, int ID)
 	}
 	else
 	{
-		protocol7::CNetObj_Character *pCharacter = Server()->SnapNewItem<protocol7::CNetObj_Character>(ID);
+		protocol7::CNetObj_Character *pCharacter = Server()->SnapNewItem<protocol7::CNetObj_Character>(Id);
 		if(!pCharacter)
 			return;
 
@@ -1147,9 +1147,9 @@ bool CCharacter::CanSnapCharacter(int SnappingClient)
 
 	if(pSnapPlayer->GetTeam() == TEAM_SPECTATORS || pSnapPlayer->IsPaused())
 	{
-		if(pSnapPlayer->m_SpectatorID != SPEC_FREEVIEW && !CanCollide(pSnapPlayer->m_SpectatorID) && (pSnapPlayer->m_ShowOthers == SHOW_OTHERS_OFF || (pSnapPlayer->m_ShowOthers == SHOW_OTHERS_ONLY_TEAM && !SameTeam(pSnapPlayer->m_SpectatorID))))
+		if(pSnapPlayer->m_SpectatorId != SPEC_FREEVIEW && !CanCollide(pSnapPlayer->m_SpectatorId) && (pSnapPlayer->m_ShowOthers == SHOW_OTHERS_OFF || (pSnapPlayer->m_ShowOthers == SHOW_OTHERS_ONLY_TEAM && !SameTeam(pSnapPlayer->m_SpectatorId))))
 			return false;
-		else if(pSnapPlayer->m_SpectatorID == SPEC_FREEVIEW && !CanCollide(SnappingClient) && pSnapPlayer->m_SpecTeam && !SameTeam(SnappingClient))
+		else if(pSnapPlayer->m_SpectatorId == SPEC_FREEVIEW && !CanCollide(SnappingClient) && pSnapPlayer->m_SpecTeam && !SameTeam(SnappingClient))
 			return false;
 	}
 	else if(pSnapChar && !pSnapChar->m_Core.m_Super && !CanCollide(SnappingClient) && (pSnapPlayer->m_ShowOthers == SHOW_OTHERS_OFF || (pSnapPlayer->m_ShowOthers == SHOW_OTHERS_ONLY_TEAM && !SameTeam(SnappingClient))))
@@ -1158,21 +1158,21 @@ bool CCharacter::CanSnapCharacter(int SnappingClient)
 	return true;
 }
 
-bool CCharacter::IsSnappingCharacterInView(int SnappingClientID)
+bool CCharacter::IsSnappingCharacterInView(int SnappingClientId)
 {
-	int ID = m_pPlayer->GetCID();
+	int Id = m_pPlayer->GetCid();
 
 	// A player may not be clipped away if his hook or a hook attached to him is in the field of view
-	bool PlayerAndHookNotInView = NetworkClippedLine(SnappingClientID, m_Pos, m_Core.m_HookPos);
+	bool PlayerAndHookNotInView = NetworkClippedLine(SnappingClientId, m_Pos, m_Core.m_HookPos);
 	bool AttachedHookInView = false;
 	if(PlayerAndHookNotInView)
 	{
-		for(const auto &AttachedPlayerID : m_Core.m_AttachedPlayers)
+		for(const auto &AttachedPlayerId : m_Core.m_AttachedPlayers)
 		{
-			const CCharacter *pOtherPlayer = GameServer()->GetPlayerChar(AttachedPlayerID);
-			if(pOtherPlayer && pOtherPlayer->m_Core.HookedPlayer() == ID)
+			const CCharacter *pOtherPlayer = GameServer()->GetPlayerChar(AttachedPlayerId);
+			if(pOtherPlayer && pOtherPlayer->m_Core.HookedPlayer() == Id)
 			{
-				if(!NetworkClippedLine(SnappingClientID, m_Pos, pOtherPlayer->m_Pos))
+				if(!NetworkClippedLine(SnappingClientId, m_Pos, pOtherPlayer->m_Pos))
 				{
 					AttachedHookInView = true;
 					break;
@@ -1189,9 +1189,9 @@ bool CCharacter::IsSnappingCharacterInView(int SnappingClientID)
 
 void CCharacter::Snap(int SnappingClient)
 {
-	int ID = m_pPlayer->GetCID();
+	int Id = m_pPlayer->GetCid();
 
-	if(!Server()->Translate(ID, SnappingClient))
+	if(!Server()->Translate(Id, SnappingClient))
 		return;
 
 	if(!CanSnapCharacter(SnappingClient))
@@ -1202,9 +1202,9 @@ void CCharacter::Snap(int SnappingClient)
 	if(!IsSnappingCharacterInView(SnappingClient))
 		return;
 
-	SnapCharacter(SnappingClient, ID);
+	SnapCharacter(SnappingClient, Id);
 
-	CNetObj_DDNetCharacter *pDDNetCharacter = Server()->SnapNewItem<CNetObj_DDNetCharacter>(ID);
+	CNetObj_DDNetCharacter *pDDNetCharacter = Server()->SnapNewItem<CNetObj_DDNetCharacter>(Id);
 	if(!pDDNetCharacter)
 		return;
 
@@ -1255,7 +1255,7 @@ void CCharacter::Snap(int SnappingClient)
 	pDDNetCharacter->m_FreezeEnd = m_Core.m_DeepFrozen ? -1 : m_FreezeTime == 0 ? 0 : Server()->Tick() + m_FreezeTime;
 	pDDNetCharacter->m_Jumps = m_Core.m_Jumps;
 	pDDNetCharacter->m_TeleCheckpoint = m_TeleCheckpoint;
-	pDDNetCharacter->m_StrongWeakID = m_StrongWeakID;
+	pDDNetCharacter->m_StrongWeakId = m_StrongWeakId;
 
 	// Display Information
 	pDDNetCharacter->m_JumpedTotal = m_Core.m_JumpedTotal;
@@ -1279,18 +1279,18 @@ void CCharacter::Snap(int SnappingClient)
 
 // DDRace
 
-bool CCharacter::CanCollide(int ClientID)
+bool CCharacter::CanCollide(int ClientId)
 {
-	return Teams()->m_Core.CanCollide(GetPlayer()->GetCID(), ClientID);
+	return Teams()->m_Core.CanCollide(GetPlayer()->GetCid(), ClientId);
 }
-bool CCharacter::SameTeam(int ClientID)
+bool CCharacter::SameTeam(int ClientId)
 {
-	return Teams()->m_Core.SameTeam(GetPlayer()->GetCID(), ClientID);
+	return Teams()->m_Core.SameTeam(GetPlayer()->GetCid(), ClientId);
 }
 
 int CCharacter::Team()
 {
-	return Teams()->m_Core.Team(m_pPlayer->GetCID());
+	return Teams()->m_Core.Team(m_pPlayer->GetCid());
 }
 
 void CCharacter::SetTeleports(std::map<int, std::vector<vec2>> *pTeleOuts, std::map<int, std::vector<vec2>> *pTeleCheckOuts)
@@ -1318,7 +1318,7 @@ void CCharacter::FillAntibot(CAntibotCharacterData *pData)
 
 void CCharacter::HandleBroadcast()
 {
-	CPlayerData *pData = GameServer()->Score()->PlayerData(m_pPlayer->GetCID());
+	CPlayerData *pData = GameServer()->Score()->PlayerData(m_pPlayer->GetCid());
 
 	if(m_DDRaceState == DDRACE_STARTED && m_pPlayer->GetClientVersion() == VERSION_VANILLA &&
 		m_LastTimeCpBroadcasted != m_LastTimeCp && m_LastTimeCp > -1 &&
@@ -1327,7 +1327,7 @@ void CCharacter::HandleBroadcast()
 		char aBroadcast[128];
 		float Diff = m_aCurrentTimeCp[m_LastTimeCp] - pData->m_aBestTimeCp[m_LastTimeCp];
 		str_format(aBroadcast, sizeof(aBroadcast), "Checkpoint | Diff : %+5.2f", Diff);
-		GameServer()->SendBroadcast(aBroadcast, m_pPlayer->GetCID());
+		GameServer()->SendBroadcast(aBroadcast, m_pPlayer->GetCid());
 		m_LastTimeCpBroadcasted = m_LastTimeCp;
 		m_LastBroadcast = Server()->Tick();
 	}
@@ -1336,7 +1336,7 @@ void CCharacter::HandleBroadcast()
 		char aBuf[32];
 		int Time = (int64_t)100 * ((float)(Server()->Tick() - m_StartTime) / ((float)Server()->TickSpeed()));
 		str_time(Time, TIME_HOURS, aBuf, sizeof(aBuf));
-		GameServer()->SendBroadcast(aBuf, m_pPlayer->GetCID(), false);
+		GameServer()->SendBroadcast(aBuf, m_pPlayer->GetCid(), false);
 		m_LastTimeCpBroadcasted = m_LastTimeCp;
 		m_LastBroadcast = Server()->Tick();
 	}
@@ -1353,15 +1353,15 @@ void CCharacter::HandleSkippableTiles(int Index)
 		   Collision()->GetFCollisionAt(m_Pos.x + GetProximityRadius() / 3.f, m_Pos.y + GetProximityRadius() / 3.f) == TILE_DEATH ||
 		   Collision()->GetFCollisionAt(m_Pos.x - GetProximityRadius() / 3.f, m_Pos.y - GetProximityRadius() / 3.f) == TILE_DEATH ||
 		   Collision()->GetFCollisionAt(m_Pos.x - GetProximityRadius() / 3.f, m_Pos.y + GetProximityRadius() / 3.f) == TILE_DEATH) &&
-		!m_Core.m_Super && !(Team() && Teams()->TeeFinished(m_pPlayer->GetCID())))
+		!m_Core.m_Super && !(Team() && Teams()->TeeFinished(m_pPlayer->GetCid())))
 	{
-		Die(m_pPlayer->GetCID(), WEAPON_WORLD);
+		Die(m_pPlayer->GetCid(), WEAPON_WORLD);
 		return;
 	}
 
 	if(GameLayerClipped(m_Pos))
 	{
-		Die(m_pPlayer->GetCID(), WEAPON_WORLD);
+		Die(m_pPlayer->GetCid(), WEAPON_WORLD);
 		return;
 	}
 
@@ -1444,7 +1444,7 @@ void CCharacter::SetTimeCheckpoint(int TimeCheckpoint)
 		m_TimeCpBroadcastEndTick = Server()->Tick() + Server()->TickSpeed() * 2;
 		if(m_pPlayer->GetClientVersion() >= VERSION_DDRACE)
 		{
-			CPlayerData *pData = GameServer()->Score()->PlayerData(m_pPlayer->GetCID());
+			CPlayerData *pData = GameServer()->Score()->PlayerData(m_pPlayer->GetCid());
 			if(pData->m_BestTime && pData->m_aBestTimeCp[m_LastTimeCp] != 0.0f)
 			{
 				CNetMsg_Sv_DDRaceTime Msg;
@@ -1452,7 +1452,7 @@ void CCharacter::SetTimeCheckpoint(int TimeCheckpoint)
 				Msg.m_Finish = 0;
 				float Diff = (m_aCurrentTimeCp[m_LastTimeCp] - pData->m_aBestTimeCp[m_LastTimeCp]) * 100;
 				Msg.m_Check = (int)Diff;
-				Server()->SendPackMsg(&Msg, MSGFLAG_VITAL, m_pPlayer->GetCID());
+				Server()->SendPackMsg(&Msg, MSGFLAG_VITAL, m_pPlayer->GetCid());
 			}
 		}
 	}
@@ -1517,7 +1517,7 @@ void CCharacter::HandleTiles(int Index)
 	// hit others
 	if(((m_TileIndex == TILE_HIT_DISABLE) || (m_TileFIndex == TILE_HIT_DISABLE)) && (!m_Core.m_HammerHitDisabled || !m_Core.m_ShotgunHitDisabled || !m_Core.m_GrenadeHitDisabled || !m_Core.m_LaserHitDisabled))
 	{
-		GameServer()->SendChatTarget(GetPlayer()->GetCID(), "You can't hit others");
+		GameServer()->SendChatTarget(GetPlayer()->GetCid(), "You can't hit others");
 		m_Core.m_HammerHitDisabled = true;
 		m_Core.m_ShotgunHitDisabled = true;
 		m_Core.m_GrenadeHitDisabled = true;
@@ -1525,7 +1525,7 @@ void CCharacter::HandleTiles(int Index)
 	}
 	else if(((m_TileIndex == TILE_HIT_ENABLE) || (m_TileFIndex == TILE_HIT_ENABLE)) && (m_Core.m_HammerHitDisabled || m_Core.m_ShotgunHitDisabled || m_Core.m_GrenadeHitDisabled || m_Core.m_LaserHitDisabled))
 	{
-		GameServer()->SendChatTarget(GetPlayer()->GetCID(), "You can hit others");
+		GameServer()->SendChatTarget(GetPlayer()->GetCid(), "You can hit others");
 		m_Core.m_ShotgunHitDisabled = false;
 		m_Core.m_GrenadeHitDisabled = false;
 		m_Core.m_HammerHitDisabled = false;
@@ -1535,36 +1535,36 @@ void CCharacter::HandleTiles(int Index)
 	// collide with others
 	if(((m_TileIndex == TILE_NPC_DISABLE) || (m_TileFIndex == TILE_NPC_DISABLE)) && !m_Core.m_CollisionDisabled)
 	{
-		GameServer()->SendChatTarget(GetPlayer()->GetCID(), "You can't collide with others");
+		GameServer()->SendChatTarget(GetPlayer()->GetCid(), "You can't collide with others");
 		m_Core.m_CollisionDisabled = true;
 	}
 	else if(((m_TileIndex == TILE_NPC_ENABLE) || (m_TileFIndex == TILE_NPC_ENABLE)) && m_Core.m_CollisionDisabled)
 	{
-		GameServer()->SendChatTarget(GetPlayer()->GetCID(), "You can collide with others");
+		GameServer()->SendChatTarget(GetPlayer()->GetCid(), "You can collide with others");
 		m_Core.m_CollisionDisabled = false;
 	}
 
 	// hook others
 	if(((m_TileIndex == TILE_NPH_DISABLE) || (m_TileFIndex == TILE_NPH_DISABLE)) && !m_Core.m_HookHitDisabled)
 	{
-		GameServer()->SendChatTarget(GetPlayer()->GetCID(), "You can't hook others");
+		GameServer()->SendChatTarget(GetPlayer()->GetCid(), "You can't hook others");
 		m_Core.m_HookHitDisabled = true;
 	}
 	else if(((m_TileIndex == TILE_NPH_ENABLE) || (m_TileFIndex == TILE_NPH_ENABLE)) && m_Core.m_HookHitDisabled)
 	{
-		GameServer()->SendChatTarget(GetPlayer()->GetCID(), "You can hook others");
+		GameServer()->SendChatTarget(GetPlayer()->GetCid(), "You can hook others");
 		m_Core.m_HookHitDisabled = false;
 	}
 
 	// unlimited air jumps
 	if(((m_TileIndex == TILE_UNLIMITED_JUMPS_ENABLE) || (m_TileFIndex == TILE_UNLIMITED_JUMPS_ENABLE)) && !m_Core.m_EndlessJump)
 	{
-		GameServer()->SendChatTarget(GetPlayer()->GetCID(), "You have unlimited air jumps");
+		GameServer()->SendChatTarget(GetPlayer()->GetCid(), "You have unlimited air jumps");
 		m_Core.m_EndlessJump = true;
 	}
 	else if(((m_TileIndex == TILE_UNLIMITED_JUMPS_DISABLE) || (m_TileFIndex == TILE_UNLIMITED_JUMPS_DISABLE)) && m_Core.m_EndlessJump)
 	{
-		GameServer()->SendChatTarget(GetPlayer()->GetCID(), "You don't have unlimited air jumps");
+		GameServer()->SendChatTarget(GetPlayer()->GetCid(), "You don't have unlimited air jumps");
 		m_Core.m_EndlessJump = false;
 	}
 
@@ -1582,12 +1582,12 @@ void CCharacter::HandleTiles(int Index)
 	// jetpack gun
 	if(((m_TileIndex == TILE_JETPACK_ENABLE) || (m_TileFIndex == TILE_JETPACK_ENABLE)) && !m_Core.m_Jetpack)
 	{
-		GameServer()->SendChatTarget(GetPlayer()->GetCID(), "You have a jetpack gun");
+		GameServer()->SendChatTarget(GetPlayer()->GetCid(), "You have a jetpack gun");
 		m_Core.m_Jetpack = true;
 	}
 	else if(((m_TileIndex == TILE_JETPACK_DISABLE) || (m_TileFIndex == TILE_JETPACK_DISABLE)) && m_Core.m_Jetpack)
 	{
-		GameServer()->SendChatTarget(GetPlayer()->GetCID(), "You lost your jetpack gun");
+		GameServer()->SendChatTarget(GetPlayer()->GetCid(), "You lost your jetpack gun");
 		m_Core.m_Jetpack = false;
 	}
 
@@ -1608,39 +1608,39 @@ void CCharacter::HandleTiles(int Index)
 	{
 		m_Core.m_HasTelegunGun = true;
 
-		GameServer()->SendChatTarget(GetPlayer()->GetCID(), "Teleport gun enabled");
+		GameServer()->SendChatTarget(GetPlayer()->GetCid(), "Teleport gun enabled");
 	}
 	else if(((m_TileIndex == TILE_TELE_GUN_DISABLE) || (m_TileFIndex == TILE_TELE_GUN_DISABLE)) && m_Core.m_HasTelegunGun)
 	{
 		m_Core.m_HasTelegunGun = false;
 
-		GameServer()->SendChatTarget(GetPlayer()->GetCID(), "Teleport gun disabled");
+		GameServer()->SendChatTarget(GetPlayer()->GetCid(), "Teleport gun disabled");
 	}
 
 	if(((m_TileIndex == TILE_TELE_GRENADE_ENABLE) || (m_TileFIndex == TILE_TELE_GRENADE_ENABLE)) && !m_Core.m_HasTelegunGrenade)
 	{
 		m_Core.m_HasTelegunGrenade = true;
 
-		GameServer()->SendChatTarget(GetPlayer()->GetCID(), "Teleport grenade enabled");
+		GameServer()->SendChatTarget(GetPlayer()->GetCid(), "Teleport grenade enabled");
 	}
 	else if(((m_TileIndex == TILE_TELE_GRENADE_DISABLE) || (m_TileFIndex == TILE_TELE_GRENADE_DISABLE)) && m_Core.m_HasTelegunGrenade)
 	{
 		m_Core.m_HasTelegunGrenade = false;
 
-		GameServer()->SendChatTarget(GetPlayer()->GetCID(), "Teleport grenade disabled");
+		GameServer()->SendChatTarget(GetPlayer()->GetCid(), "Teleport grenade disabled");
 	}
 
 	if(((m_TileIndex == TILE_TELE_LASER_ENABLE) || (m_TileFIndex == TILE_TELE_LASER_ENABLE)) && !m_Core.m_HasTelegunLaser)
 	{
 		m_Core.m_HasTelegunLaser = true;
 
-		GameServer()->SendChatTarget(GetPlayer()->GetCID(), "Teleport laser enabled");
+		GameServer()->SendChatTarget(GetPlayer()->GetCid(), "Teleport laser enabled");
 	}
 	else if(((m_TileIndex == TILE_TELE_LASER_DISABLE) || (m_TileFIndex == TILE_TELE_LASER_DISABLE)) && m_Core.m_HasTelegunLaser)
 	{
 		m_Core.m_HasTelegunLaser = false;
 
-		GameServer()->SendChatTarget(GetPlayer()->GetCID(), "Teleport laser disabled");
+		GameServer()->SendChatTarget(GetPlayer()->GetCid(), "Teleport laser disabled");
 	}
 
 	// stopper
@@ -1713,42 +1713,42 @@ void CCharacter::HandleTiles(int Index)
 	}
 	else if(Collision()->GetSwitchType(MapIndex) == TILE_HIT_ENABLE && m_Core.m_HammerHitDisabled && Collision()->GetSwitchDelay(MapIndex) == WEAPON_HAMMER)
 	{
-		GameServer()->SendChatTarget(GetPlayer()->GetCID(), "You can hammer hit others");
+		GameServer()->SendChatTarget(GetPlayer()->GetCid(), "You can hammer hit others");
 		m_Core.m_HammerHitDisabled = false;
 	}
 	else if(Collision()->GetSwitchType(MapIndex) == TILE_HIT_DISABLE && !(m_Core.m_HammerHitDisabled) && Collision()->GetSwitchDelay(MapIndex) == WEAPON_HAMMER)
 	{
-		GameServer()->SendChatTarget(GetPlayer()->GetCID(), "You can't hammer hit others");
+		GameServer()->SendChatTarget(GetPlayer()->GetCid(), "You can't hammer hit others");
 		m_Core.m_HammerHitDisabled = true;
 	}
 	else if(Collision()->GetSwitchType(MapIndex) == TILE_HIT_ENABLE && m_Core.m_ShotgunHitDisabled && Collision()->GetSwitchDelay(MapIndex) == WEAPON_SHOTGUN)
 	{
-		GameServer()->SendChatTarget(GetPlayer()->GetCID(), "You can shoot others with shotgun");
+		GameServer()->SendChatTarget(GetPlayer()->GetCid(), "You can shoot others with shotgun");
 		m_Core.m_ShotgunHitDisabled = false;
 	}
 	else if(Collision()->GetSwitchType(MapIndex) == TILE_HIT_DISABLE && !(m_Core.m_ShotgunHitDisabled) && Collision()->GetSwitchDelay(MapIndex) == WEAPON_SHOTGUN)
 	{
-		GameServer()->SendChatTarget(GetPlayer()->GetCID(), "You can't shoot others with shotgun");
+		GameServer()->SendChatTarget(GetPlayer()->GetCid(), "You can't shoot others with shotgun");
 		m_Core.m_ShotgunHitDisabled = true;
 	}
 	else if(Collision()->GetSwitchType(MapIndex) == TILE_HIT_ENABLE && m_Core.m_GrenadeHitDisabled && Collision()->GetSwitchDelay(MapIndex) == WEAPON_GRENADE)
 	{
-		GameServer()->SendChatTarget(GetPlayer()->GetCID(), "You can shoot others with grenade");
+		GameServer()->SendChatTarget(GetPlayer()->GetCid(), "You can shoot others with grenade");
 		m_Core.m_GrenadeHitDisabled = false;
 	}
 	else if(Collision()->GetSwitchType(MapIndex) == TILE_HIT_DISABLE && !(m_Core.m_GrenadeHitDisabled) && Collision()->GetSwitchDelay(MapIndex) == WEAPON_GRENADE)
 	{
-		GameServer()->SendChatTarget(GetPlayer()->GetCID(), "You can't shoot others with grenade");
+		GameServer()->SendChatTarget(GetPlayer()->GetCid(), "You can't shoot others with grenade");
 		m_Core.m_GrenadeHitDisabled = true;
 	}
 	else if(Collision()->GetSwitchType(MapIndex) == TILE_HIT_ENABLE && m_Core.m_LaserHitDisabled && Collision()->GetSwitchDelay(MapIndex) == WEAPON_LASER)
 	{
-		GameServer()->SendChatTarget(GetPlayer()->GetCID(), "You can shoot others with laser");
+		GameServer()->SendChatTarget(GetPlayer()->GetCid(), "You can shoot others with laser");
 		m_Core.m_LaserHitDisabled = false;
 	}
 	else if(Collision()->GetSwitchType(MapIndex) == TILE_HIT_DISABLE && !(m_Core.m_LaserHitDisabled) && Collision()->GetSwitchDelay(MapIndex) == WEAPON_LASER)
 	{
-		GameServer()->SendChatTarget(GetPlayer()->GetCID(), "You can't shoot others with laser");
+		GameServer()->SendChatTarget(GetPlayer()->GetCid(), "You can't shoot others with laser");
 		m_Core.m_LaserHitDisabled = true;
 	}
 	else if(Collision()->GetSwitchType(MapIndex) == TILE_JUMP)
@@ -1768,7 +1768,7 @@ void CCharacter::HandleTiles(int Index)
 				str_format(aBuf, sizeof(aBuf), "You can jump %d time", NewJumps);
 			else
 				str_format(aBuf, sizeof(aBuf), "You can jump %d times", NewJumps);
-			GameServer()->SendChatTarget(GetPlayer()->GetCID(), aBuf);
+			GameServer()->SendChatTarget(GetPlayer()->GetCid(), aBuf);
 			m_Core.m_Jumps = NewJumps;
 		}
 	}
@@ -1862,7 +1862,7 @@ void CCharacter::HandleTiles(int Index)
 			if(!g_Config.m_SvTeleportHoldHook)
 			{
 				ResetHook();
-				GameWorld()->ReleaseHooked(GetPlayer()->GetCID());
+				GameWorld()->ReleaseHooked(GetPlayer()->GetCid());
 			}
 			if(g_Config.m_SvTeleportLoseWeapons)
 			{
@@ -1887,7 +1887,7 @@ void CCharacter::HandleTiles(int Index)
 				if(!g_Config.m_SvTeleportHoldHook)
 				{
 					ResetHook();
-					GameWorld()->ReleaseHooked(GetPlayer()->GetCID());
+					GameWorld()->ReleaseHooked(GetPlayer()->GetCid());
 				}
 
 				return;
@@ -1895,7 +1895,7 @@ void CCharacter::HandleTiles(int Index)
 		}
 		// if no checkpointout have been found (or if there no recorded checkpoint), teleport to start
 		vec2 SpawnPos;
-		if(GameServer()->m_pController->CanSpawn(m_pPlayer->GetTeam(), &SpawnPos, GameServer()->GetDDRaceTeam(GetPlayer()->GetCID())))
+		if(GameServer()->m_pController->CanSpawn(m_pPlayer->GetTeam(), &SpawnPos, GameServer()->GetDDRaceTeam(GetPlayer()->GetCid())))
 		{
 			m_Core.m_Pos = SpawnPos;
 			m_Core.m_Vel = vec2(0, 0);
@@ -1903,7 +1903,7 @@ void CCharacter::HandleTiles(int Index)
 			if(!g_Config.m_SvTeleportHoldHook)
 			{
 				ResetHook();
-				GameWorld()->ReleaseHooked(GetPlayer()->GetCID());
+				GameWorld()->ReleaseHooked(GetPlayer()->GetCid());
 			}
 		}
 		return;
@@ -1930,7 +1930,7 @@ void CCharacter::HandleTiles(int Index)
 		}
 		// if no checkpointout have been found (or if there no recorded checkpoint), teleport to start
 		vec2 SpawnPos;
-		if(GameServer()->m_pController->CanSpawn(m_pPlayer->GetTeam(), &SpawnPos, GameServer()->GetDDRaceTeam(GetPlayer()->GetCID())))
+		if(GameServer()->m_pController->CanSpawn(m_pPlayer->GetTeam(), &SpawnPos, GameServer()->GetDDRaceTeam(GetPlayer()->GetCid())))
 		{
 			m_Core.m_Pos = SpawnPos;
 
@@ -1975,9 +1975,9 @@ void CCharacter::SendZoneMsgs()
 			str_copy(aBuf, pCur, pPos - pCur + 1);
 			aBuf[pPos - pCur + 1] = '\0';
 			pCur = pPos + 2;
-			GameServer()->SendChatTarget(m_pPlayer->GetCID(), aBuf);
+			GameServer()->SendChatTarget(m_pPlayer->GetCid(), aBuf);
 		}
-		GameServer()->SendChatTarget(m_pPlayer->GetCID(), pCur);
+		GameServer()->SendChatTarget(m_pPlayer->GetCid(), pCur);
 	}
 	// send zone enter msg
 	if(GameServer()->m_aaZoneEnterMsg[m_TuneZone][0])
@@ -1990,9 +1990,9 @@ void CCharacter::SendZoneMsgs()
 			str_copy(aBuf, pCur, pPos - pCur + 1);
 			aBuf[pPos - pCur + 1] = '\0';
 			pCur = pPos + 2;
-			GameServer()->SendChatTarget(m_pPlayer->GetCID(), aBuf);
+			GameServer()->SendChatTarget(m_pPlayer->GetCid(), aBuf);
 		}
-		GameServer()->SendChatTarget(m_pPlayer->GetCID(), pCur);
+		GameServer()->SendChatTarget(m_pPlayer->GetCid(), pCur);
 	}
 }
 
@@ -2088,7 +2088,7 @@ void CCharacter::DDRaceTick()
 		}
 	}
 
-	m_Core.m_Id = GetPlayer()->GetCID();
+	m_Core.m_Id = GetPlayer()->GetCid();
 }
 
 void CCharacter::DDRacePostCoreTick()
@@ -2157,11 +2157,11 @@ void CCharacter::DDRacePostCoreTick()
 	// teleport gun
 	if(m_TeleGunTeleport)
 	{
-		GameServer()->CreateDeath(m_Pos, m_pPlayer->GetCID(), TeamMask());
+		GameServer()->CreateDeath(m_Pos, m_pPlayer->GetCid(), TeamMask());
 		m_Core.m_Pos = m_TeleGunPos;
 		if(!m_IsBlueTeleGunTeleport)
 			m_Core.m_Vel = vec2(0, 0);
-		GameServer()->CreateDeath(m_TeleGunPos, m_pPlayer->GetCID(), TeamMask());
+		GameServer()->CreateDeath(m_TeleGunPos, m_pPlayer->GetCid(), TeamMask());
 		GameServer()->CreateSound(m_TeleGunPos, SOUND_WEAPON_SPAWN, TeamMask());
 		m_TeleGunTeleport = false;
 		m_IsBlueTeleGunTeleport = false;
@@ -2252,7 +2252,7 @@ void CCharacter::SetEndlessHook(bool Enable)
 	{
 		return;
 	}
-	GameServer()->SendChatTarget(GetPlayer()->GetCID(), Enable ? "Endless hook has been activated" : "Endless hook has been deactivated");
+	GameServer()->SendChatTarget(GetPlayer()->GetCid(), Enable ? "Endless hook has been activated" : "Endless hook has been deactivated");
 
 	m_Core.m_EndlessHook = Enable;
 }
@@ -2262,19 +2262,19 @@ void CCharacter::Pause(bool Pause)
 	m_Paused = Pause;
 	if(Pause)
 	{
-		GameServer()->m_World.m_Core.m_apCharacters[m_pPlayer->GetCID()] = 0;
+		GameServer()->m_World.m_Core.m_apCharacters[m_pPlayer->GetCid()] = 0;
 		GameServer()->m_World.RemoveEntity(this);
 
 		if(m_Core.HookedPlayer() != -1) // Keeping hook would allow cheats
 		{
 			ResetHook();
-			GameWorld()->ReleaseHooked(GetPlayer()->GetCID());
+			GameWorld()->ReleaseHooked(GetPlayer()->GetCid());
 		}
 	}
 	else
 	{
 		m_Core.m_Vel = vec2(0, 0);
-		GameServer()->m_World.m_Core.m_apCharacters[m_pPlayer->GetCID()] = &m_Core;
+		GameServer()->m_World.m_Core.m_apCharacters[m_pPlayer->GetCid()] = &m_Core;
 		GameServer()->m_World.InsertEntity(this);
 	}
 }
@@ -2287,7 +2287,7 @@ void CCharacter::DDRaceInit()
 	m_SetSavePos = false;
 	m_LastBroadcast = 0;
 	m_TeamBeforeSuper = 0;
-	m_Core.m_Id = GetPlayer()->GetCID();
+	m_Core.m_Id = GetPlayer()->GetCid();
 	m_TeleCheckpoint = 0;
 	m_Core.m_EndlessHook = g_Config.m_SvEndlessDrag;
 	if(g_Config.m_SvHit)
@@ -2328,7 +2328,7 @@ void CCharacter::DDRaceInit()
 
 	if(g_Config.m_SvTeam == SV_TEAM_MANDATORY && Team == TEAM_FLOCK)
 	{
-		GameServer()->SendStartWarning(GetPlayer()->GetCID(), "Please join a team before you start");
+		GameServer()->SendStartWarning(GetPlayer()->GetCid(), "Please join a team before you start");
 	}
 }
 
@@ -2340,7 +2340,7 @@ void CCharacter::Rescue()
 		{
 			char aBuf[256];
 			str_format(aBuf, sizeof(aBuf), "You have to wait %d seconds until you can rescue yourself", (int)((m_LastRescue + (int64_t)g_Config.m_SvRescueDelay * Server()->TickSpeed() - Server()->Tick()) / Server()->TickSpeed()));
-			GameServer()->SendChatTarget(GetPlayer()->GetCID(), aBuf);
+			GameServer()->SendChatTarget(GetPlayer()->GetCid(), aBuf);
 			return;
 		}
 
@@ -2363,7 +2363,7 @@ void CCharacter::Rescue()
 
 CClientMask CCharacter::TeamMask()
 {
-	return Teams()->TeamMask(Team(), -1, GetPlayer()->GetCID());
+	return Teams()->TeamMask(Team(), -1, GetPlayer()->GetCid());
 }
 
 void CCharacter::SetPosition(const vec2 &Position)

--- a/src/game/server/entities/character.h
+++ b/src/game/server/entities/character.h
@@ -41,7 +41,7 @@ public:
 	void SwapClients(int Client1, int Client2) override;
 
 	bool CanSnapCharacter(int SnappingClient);
-	bool IsSnappingCharacterInView(int SnappingClientID);
+	bool IsSnappingCharacterInView(int SnappingClientId);
 
 	bool IsGrounded();
 
@@ -157,7 +157,7 @@ private:
 
 	// DDRace
 
-	void SnapCharacter(int SnappingClient, int ID);
+	void SnapCharacter(int SnappingClient, int Id);
 	static bool IsSwitchActiveCb(int Number, void *pUser);
 	void SetTimeCheckpoint(int TimeCheckpoint);
 	void HandleTiles(int Index);
@@ -190,8 +190,8 @@ public:
 	void ResetPickups();
 	int m_DDRaceState;
 	int Team();
-	bool CanCollide(int ClientID);
-	bool SameTeam(int ClientID);
+	bool CanCollide(int ClientId);
+	bool SameTeam(int ClientId);
 	bool m_NinjaJetpack;
 	int m_TeamBeforeSuper;
 	int m_FreezeTime;
@@ -221,7 +221,7 @@ public:
 	vec2 m_TeleGunPos;
 	bool m_TeleGunTeleport;
 	bool m_IsBlueTeleGunTeleport;
-	int m_StrongWeakID;
+	int m_StrongWeakId;
 
 	int m_SpawnTick;
 	int m_WeaponChangeTick;

--- a/src/game/server/entities/door.cpp
+++ b/src/game/server/entities/door.cpp
@@ -64,8 +64,8 @@ void CDoor::Snap(int SnappingClient)
 	{
 		CCharacter *pChr = GameServer()->GetPlayerChar(SnappingClient);
 
-		if(SnappingClient != SERVER_DEMO_CLIENT && (GameServer()->m_apPlayers[SnappingClient]->GetTeam() == TEAM_SPECTATORS || GameServer()->m_apPlayers[SnappingClient]->IsPaused()) && GameServer()->m_apPlayers[SnappingClient]->m_SpectatorID != SPEC_FREEVIEW)
-			pChr = GameServer()->GetPlayerChar(GameServer()->m_apPlayers[SnappingClient]->m_SpectatorID);
+		if(SnappingClient != SERVER_DEMO_CLIENT && (GameServer()->m_apPlayers[SnappingClient]->GetTeam() == TEAM_SPECTATORS || GameServer()->m_apPlayers[SnappingClient]->IsPaused()) && GameServer()->m_apPlayers[SnappingClient]->m_SpectatorId != SPEC_FREEVIEW)
+			pChr = GameServer()->GetPlayerChar(GameServer()->m_apPlayers[SnappingClient]->m_SpectatorId);
 
 		if(pChr && pChr->Team() != TEAM_SUPER && pChr->IsAlive() && !Switchers().empty() && Switchers()[m_Number].m_aStatus[pChr->Team()])
 		{
@@ -78,6 +78,6 @@ void CDoor::Snap(int SnappingClient)
 		StartTick = Server()->Tick();
 	}
 
-	GameServer()->SnapLaserObject(CSnapContext(SnappingClientVersion), GetID(),
+	GameServer()->SnapLaserObject(CSnapContext(SnappingClientVersion), GetId(),
 		m_Pos, From, StartTick, -1, LASERTYPE_DOOR, 0, m_Number);
 }

--- a/src/game/server/entities/dragger.cpp
+++ b/src/game/server/entities/dragger.cpp
@@ -105,7 +105,7 @@ void CDragger::LookForPlayersToDrag()
 				!GameServer()->Collision()->IntersectNoLaser(m_Pos, pTarget->m_Pos, 0, 0);
 		if(IsReachable && pTarget->IsAlive())
 		{
-			const int &TargetClientId = pTarget->GetPlayer()->GetCID();
+			const int &TargetClientId = pTarget->GetPlayer()->GetCid();
 			// Solo players are dragged independently from the rest of the team
 			if(pTarget->Teams()->m_Core.GetSolo(TargetClientId))
 			{
@@ -156,30 +156,30 @@ void CDragger::LookForPlayersToDrag()
 	}
 }
 
-void CDragger::RemoveDraggerBeam(int ClientID)
+void CDragger::RemoveDraggerBeam(int ClientId)
 {
-	m_apDraggerBeam[ClientID] = nullptr;
+	m_apDraggerBeam[ClientId] = nullptr;
 }
 
-bool CDragger::WillDraggerBeamUseDraggerID(int TargetClientID, int SnappingClientID)
+bool CDragger::WillDraggerBeamUseDraggerId(int TargetClientId, int SnappingClientId)
 {
 	// For each snapping client, this must return true for at most one target (i.e. only one of the dragger beams),
 	// in which case the dragger itself must not be snapped
-	CCharacter *pTargetChar = GameServer()->GetPlayerChar(TargetClientID);
-	CCharacter *pSnapChar = GameServer()->GetPlayerChar(SnappingClientID);
-	if(pTargetChar && pSnapChar && m_apDraggerBeam[TargetClientID] != nullptr)
+	CCharacter *pTargetChar = GameServer()->GetPlayerChar(TargetClientId);
+	CCharacter *pSnapChar = GameServer()->GetPlayerChar(SnappingClientId);
+	if(pTargetChar && pSnapChar && m_apDraggerBeam[TargetClientId] != nullptr)
 	{
 		const int SnapTeam = pSnapChar->Team();
 		const int TargetTeam = pTargetChar->Team();
 		if(SnapTeam == TargetTeam && SnapTeam < MAX_CLIENTS)
 		{
-			if(pSnapChar->Teams()->m_Core.GetSolo(SnappingClientID) || m_aTargetIdInTeam[SnapTeam] < 0)
+			if(pSnapChar->Teams()->m_Core.GetSolo(SnappingClientId) || m_aTargetIdInTeam[SnapTeam] < 0)
 			{
-				return SnappingClientID == TargetClientID;
+				return SnappingClientId == TargetClientId;
 			}
 			else
 			{
-				return m_aTargetIdInTeam[SnapTeam] == TargetClientID;
+				return m_aTargetIdInTeam[SnapTeam] == TargetClientId;
 			}
 		}
 	}
@@ -200,7 +200,7 @@ void CDragger::Snap(int SnappingClient)
 	// Send the dragger in its resting position if the player would not otherwise see a dragger beam within its own team
 	for(int i = 0; i < MAX_CLIENTS; i++)
 	{
-		if(WillDraggerBeamUseDraggerID(i, SnappingClient))
+		if(WillDraggerBeamUseDraggerId(i, SnappingClient))
 		{
 			return;
 		}
@@ -222,8 +222,8 @@ void CDragger::Snap(int SnappingClient)
 		if(SnappingClient != SERVER_DEMO_CLIENT &&
 			(GameServer()->m_apPlayers[SnappingClient]->GetTeam() == TEAM_SPECTATORS ||
 				GameServer()->m_apPlayers[SnappingClient]->IsPaused()) &&
-			GameServer()->m_apPlayers[SnappingClient]->m_SpectatorID != SPEC_FREEVIEW)
-			pChar = GameServer()->GetPlayerChar(GameServer()->m_apPlayers[SnappingClient]->m_SpectatorID);
+			GameServer()->m_apPlayers[SnappingClient]->m_SpectatorId != SPEC_FREEVIEW)
+			pChar = GameServer()->GetPlayerChar(GameServer()->m_apPlayers[SnappingClient]->m_SpectatorId);
 
 		int Tick = (Server()->Tick() % Server()->TickSpeed()) % 11;
 		if(pChar && m_Layer == LAYER_SWITCH && m_Number > 0 &&
@@ -237,7 +237,7 @@ void CDragger::Snap(int SnappingClient)
 			StartTick = Server()->Tick();
 	}
 
-	GameServer()->SnapLaserObject(CSnapContext(SnappingClientVersion), GetID(),
+	GameServer()->SnapLaserObject(CSnapContext(SnappingClientVersion), GetId(),
 		m_Pos, m_Pos, StartTick, -1, LASERTYPE_DRAGGER, Subtype, m_Number);
 }
 

--- a/src/game/server/entities/dragger.h
+++ b/src/game/server/entities/dragger.h
@@ -35,8 +35,8 @@ class CDragger : public CEntity
 public:
 	CDragger(CGameWorld *pGameWorld, vec2 Pos, float Strength, bool IgnoreWalls, int Layer = 0, int Number = 0);
 
-	void RemoveDraggerBeam(int ClientID);
-	bool WillDraggerBeamUseDraggerID(int TargetClientID, int SnappingClientID);
+	void RemoveDraggerBeam(int ClientId);
+	bool WillDraggerBeamUseDraggerId(int TargetClientId, int SnappingClientId);
 
 	void Reset() override;
 	void Tick() override;

--- a/src/game/server/entities/dragger_beam.cpp
+++ b/src/game/server/entities/dragger_beam.cpp
@@ -12,14 +12,14 @@
 #include <game/server/gamecontext.h>
 
 CDraggerBeam::CDraggerBeam(CGameWorld *pGameWorld, CDragger *pDragger, vec2 Pos, float Strength, bool IgnoreWalls,
-	int ForClientID, int Layer, int Number) :
+	int ForClientId, int Layer, int Number) :
 	CEntity(pGameWorld, CGameWorld::ENTTYPE_LASER)
 {
 	m_pDragger = pDragger;
 	m_Pos = Pos;
 	m_Strength = Strength;
 	m_IgnoreWalls = IgnoreWalls;
-	m_ForClientID = ForClientID;
+	m_ForClientId = ForClientId;
 	m_Active = true;
 	m_Layer = Layer;
 	m_Number = Number;
@@ -36,7 +36,7 @@ void CDraggerBeam::Tick()
 	}
 
 	// Drag only if the player is reachable and alive
-	CCharacter *pTarget = GameServer()->GetPlayerChar(m_ForClientID);
+	CCharacter *pTarget = GameServer()->GetPlayerChar(m_ForClientId);
 	if(!pTarget)
 	{
 		Reset();
@@ -85,7 +85,7 @@ void CDraggerBeam::Reset()
 	m_MarkedForDestroy = true;
 	m_Active = false;
 
-	m_pDragger->RemoveDraggerBeam(m_ForClientID);
+	m_pDragger->RemoveDraggerBeam(m_ForClientId);
 }
 
 void CDraggerBeam::Snap(int SnappingClient)
@@ -96,7 +96,7 @@ void CDraggerBeam::Snap(int SnappingClient)
 	}
 
 	// Only players who can see the player attached to the dragger can see the dragger beam
-	CCharacter *pTarget = GameServer()->GetPlayerChar(m_ForClientID);
+	CCharacter *pTarget = GameServer()->GetPlayerChar(m_ForClientId);
 	if(!pTarget || !pTarget->CanSnapCharacter(SnappingClient))
 	{
 		return;
@@ -126,17 +126,17 @@ void CDraggerBeam::Snap(int SnappingClient)
 		StartTick = -1;
 	}
 
-	int SnapObjID = GetID();
-	if(m_pDragger->WillDraggerBeamUseDraggerID(m_ForClientID, SnappingClient))
+	int SnapObjId = GetId();
+	if(m_pDragger->WillDraggerBeamUseDraggerId(m_ForClientId, SnappingClient))
 	{
-		SnapObjID = m_pDragger->GetID();
+		SnapObjId = m_pDragger->GetId();
 	}
 
-	GameServer()->SnapLaserObject(CSnapContext(SnappingClientVersion), SnapObjID,
-		TargetPos, m_Pos, StartTick, m_ForClientID, LASERTYPE_DRAGGER, Subtype, m_Number);
+	GameServer()->SnapLaserObject(CSnapContext(SnappingClientVersion), SnapObjId,
+		TargetPos, m_Pos, StartTick, m_ForClientId, LASERTYPE_DRAGGER, Subtype, m_Number);
 }
 
 void CDraggerBeam::SwapClients(int Client1, int Client2)
 {
-	m_ForClientID = m_ForClientID == Client1 ? Client2 : m_ForClientID == Client2 ? Client1 : m_ForClientID;
+	m_ForClientId = m_ForClientId == Client1 ? Client2 : m_ForClientId == Client2 ? Client1 : m_ForClientId;
 }

--- a/src/game/server/entities/dragger_beam.h
+++ b/src/game/server/entities/dragger_beam.h
@@ -26,12 +26,12 @@ class CDraggerBeam : public CEntity
 	CDragger *m_pDragger;
 	float m_Strength;
 	bool m_IgnoreWalls;
-	int m_ForClientID;
+	int m_ForClientId;
 	int m_EvalTick;
 	bool m_Active;
 
 public:
-	CDraggerBeam(CGameWorld *pGameWorld, CDragger *pDragger, vec2 Pos, float Strength, bool IgnoreWalls, int ForClientID, int Layer, int Number);
+	CDraggerBeam(CGameWorld *pGameWorld, CDragger *pDragger, vec2 Pos, float Strength, bool IgnoreWalls, int ForClientId, int Layer, int Number);
 
 	void SetPos(vec2 Pos);
 

--- a/src/game/server/entities/gun.cpp
+++ b/src/game/server/entities/gun.cpp
@@ -85,7 +85,7 @@ void CGun::Fire()
 		}
 
 		// Turrets can only shoot at a speed of sv_plasma_per_sec
-		const int &TargetClientId = pTarget->GetPlayer()->GetCID();
+		const int &TargetClientId = pTarget->GetPlayer()->GetCid();
 		const bool &TargetIsSolo = pTarget->Teams()->m_Core.GetSolo(TargetClientId);
 		if((TargetIsSolo &&
 			   m_aLastFireSolo[TargetClientId] + Server()->TickSpeed() / g_Config.m_SvPlasmaPerSec > Server()->Tick()) ||
@@ -165,8 +165,8 @@ void CGun::Snap(int SnappingClient)
 		if(SnappingClient != SERVER_DEMO_CLIENT &&
 			(GameServer()->m_apPlayers[SnappingClient]->GetTeam() == TEAM_SPECTATORS ||
 				GameServer()->m_apPlayers[SnappingClient]->IsPaused()) &&
-			GameServer()->m_apPlayers[SnappingClient]->m_SpectatorID != SPEC_FREEVIEW)
-			pChar = GameServer()->GetPlayerChar(GameServer()->m_apPlayers[SnappingClient]->m_SpectatorID);
+			GameServer()->m_apPlayers[SnappingClient]->m_SpectatorId != SPEC_FREEVIEW)
+			pChar = GameServer()->GetPlayerChar(GameServer()->m_apPlayers[SnappingClient]->m_SpectatorId);
 
 		int Tick = (Server()->Tick() % Server()->TickSpeed()) % 11;
 		if(pChar && m_Layer == LAYER_SWITCH && m_Number > 0 &&
@@ -176,6 +176,6 @@ void CGun::Snap(int SnappingClient)
 		StartTick = m_EvalTick;
 	}
 
-	GameServer()->SnapLaserObject(CSnapContext(SnappingClientVersion), GetID(),
+	GameServer()->SnapLaserObject(CSnapContext(SnappingClientVersion), GetId(),
 		m_Pos, m_Pos, StartTick, -1, LASERTYPE_GUN, Subtype, m_Number);
 }

--- a/src/game/server/entities/laser.cpp
+++ b/src/game/server/entities/laser.cpp
@@ -314,7 +314,7 @@ void CLaser::Snap(int SnappingClient)
 	int SnappingClientVersion = GameServer()->GetClientVersion(SnappingClient);
 	int LaserType = m_Type == WEAPON_LASER ? LASERTYPE_RIFLE : m_Type == WEAPON_SHOTGUN ? LASERTYPE_SHOTGUN : -1;
 
-	GameServer()->SnapLaserObject(CSnapContext(SnappingClientVersion), GetID(),
+	GameServer()->SnapLaserObject(CSnapContext(SnappingClientVersion), GetId(),
 		m_Pos, m_From, m_EvalTick, m_Owner, LaserType, 0, m_Number);
 }
 

--- a/src/game/server/entities/laser.h
+++ b/src/game/server/entities/laser.h
@@ -16,7 +16,7 @@ public:
 	virtual void Snap(int SnappingClient) override;
 	virtual void SwapClients(int Client1, int Client2) override;
 
-	virtual int GetOwnerID() const override { return m_Owner; }
+	virtual int GetOwnerId() const override { return m_Owner; }
 
 protected:
 	bool HitCharacter(vec2 From, vec2 To);

--- a/src/game/server/entities/light.cpp
+++ b/src/game/server/entities/light.cpp
@@ -110,8 +110,8 @@ void CLight::Snap(int SnappingClient)
 
 	CCharacter *pChr = GameServer()->GetPlayerChar(SnappingClient);
 
-	if(SnappingClient != SERVER_DEMO_CLIENT && (GameServer()->m_apPlayers[SnappingClient]->GetTeam() == TEAM_SPECTATORS || GameServer()->m_apPlayers[SnappingClient]->IsPaused()) && GameServer()->m_apPlayers[SnappingClient]->m_SpectatorID != SPEC_FREEVIEW)
-		pChr = GameServer()->GetPlayerChar(GameServer()->m_apPlayers[SnappingClient]->m_SpectatorID);
+	if(SnappingClient != SERVER_DEMO_CLIENT && (GameServer()->m_apPlayers[SnappingClient]->GetTeam() == TEAM_SPECTATORS || GameServer()->m_apPlayers[SnappingClient]->IsPaused()) && GameServer()->m_apPlayers[SnappingClient]->m_SpectatorId != SPEC_FREEVIEW)
+		pChr = GameServer()->GetPlayerChar(GameServer()->m_apPlayers[SnappingClient]->m_SpectatorId);
 
 	vec2 From = m_Pos;
 	int StartTick = -1;
@@ -142,6 +142,6 @@ void CLight::Snap(int SnappingClient)
 			StartTick = Server()->Tick();
 	}
 
-	GameServer()->SnapLaserObject(CSnapContext(SnappingClientVersion), GetID(),
+	GameServer()->SnapLaserObject(CSnapContext(SnappingClientVersion), GetId(),
 		m_Pos, From, StartTick, -1, LASERTYPE_FREEZE, 0, m_Number);
 }

--- a/src/game/server/entities/pickup.cpp
+++ b/src/game/server/entities/pickup.cpp
@@ -142,7 +142,7 @@ void CPickup::Tick()
 						GameServer()->CreateSound(m_Pos, SOUND_PICKUP_SHOTGUN, pChr->TeamMask());
 
 					if(pChr->GetPlayer())
-						GameServer()->SendWeaponPickup(pChr->GetPlayer()->GetCID(), m_Subtype);
+						GameServer()->SendWeaponPickup(pChr->GetPlayer()->GetCid(), m_Subtype);
 				}
 				break;
 
@@ -175,15 +175,15 @@ void CPickup::Snap(int SnappingClient)
 	{
 		CCharacter *pChar = GameServer()->GetPlayerChar(SnappingClient);
 
-		if(SnappingClient != SERVER_DEMO_CLIENT && (GameServer()->m_apPlayers[SnappingClient]->GetTeam() == TEAM_SPECTATORS || GameServer()->m_apPlayers[SnappingClient]->IsPaused()) && GameServer()->m_apPlayers[SnappingClient]->m_SpectatorID != SPEC_FREEVIEW)
-			pChar = GameServer()->GetPlayerChar(GameServer()->m_apPlayers[SnappingClient]->m_SpectatorID);
+		if(SnappingClient != SERVER_DEMO_CLIENT && (GameServer()->m_apPlayers[SnappingClient]->GetTeam() == TEAM_SPECTATORS || GameServer()->m_apPlayers[SnappingClient]->IsPaused()) && GameServer()->m_apPlayers[SnappingClient]->m_SpectatorId != SPEC_FREEVIEW)
+			pChar = GameServer()->GetPlayerChar(GameServer()->m_apPlayers[SnappingClient]->m_SpectatorId);
 
 		int Tick = (Server()->Tick() % Server()->TickSpeed()) % 11;
 		if(pChar && pChar->IsAlive() && m_Layer == LAYER_SWITCH && m_Number > 0 && !Switchers()[m_Number].m_aStatus[pChar->Team()] && !Tick)
 			return;
 	}
 
-	GameServer()->SnapPickup(CSnapContext(SnappingClientVersion, Sixup), GetID(), m_Pos, m_Type, m_Subtype, m_Number);
+	GameServer()->SnapPickup(CSnapContext(SnappingClientVersion, Sixup), GetId(), m_Pos, m_Type, m_Subtype, m_Number);
 }
 
 void CPickup::Move()

--- a/src/game/server/entities/plasma.cpp
+++ b/src/game/server/entities/plasma.cpp
@@ -12,14 +12,14 @@
 const float PLASMA_ACCEL = 1.1f;
 
 CPlasma::CPlasma(CGameWorld *pGameWorld, vec2 Pos, vec2 Dir, bool Freeze,
-	bool Explosive, int ForClientID) :
+	bool Explosive, int ForClientId) :
 	CEntity(pGameWorld, CGameWorld::ENTTYPE_LASER)
 {
 	m_Pos = Pos;
 	m_Core = Dir;
 	m_Freeze = Freeze;
 	m_Explosive = Explosive;
-	m_ForClientID = ForClientID;
+	m_ForClientId = ForClientId;
 	m_EvalTick = Server()->Tick();
 	m_LifeTime = Server()->TickSpeed() * 1.5f;
 
@@ -34,7 +34,7 @@ void CPlasma::Tick()
 		Reset();
 		return;
 	}
-	CCharacter *pTarget = GameServer()->GetPlayerChar(m_ForClientID);
+	CCharacter *pTarget = GameServer()->GetPlayerChar(m_ForClientId);
 	// Without a target, a plasma bullet has no reason to live
 	if(!pTarget)
 	{
@@ -58,7 +58,7 @@ bool CPlasma::HitCharacter(CCharacter *pTarget)
 {
 	vec2 IntersectPos;
 	CCharacter *pHitPlayer = GameServer()->m_World.IntersectCharacter(
-		m_Pos, m_Pos + m_Core, 0.0f, IntersectPos, 0, m_ForClientID);
+		m_Pos, m_Pos + m_Core, 0.0f, IntersectPos, 0, m_ForClientId);
 	if(!pHitPlayer)
 	{
 		return false;
@@ -76,7 +76,7 @@ bool CPlasma::HitCharacter(CCharacter *pTarget)
 		// Plasma Turrets are very precise weapons only one tee gets speed from it,
 		// other tees near the explosion remain unaffected
 		GameServer()->CreateExplosion(
-			m_Pos, m_ForClientID, WEAPON_GRENADE, true, pTarget->Team(), pTarget->TeamMask());
+			m_Pos, m_ForClientId, WEAPON_GRENADE, true, pTarget->Team(), pTarget->TeamMask());
 	}
 	Reset();
 	return true;
@@ -92,7 +92,7 @@ bool CPlasma::HitObstacle(CCharacter *pTarget)
 		{
 			// Even in the case of an explosion due to a collision with obstacles, only one player is affected
 			GameServer()->CreateExplosion(
-				m_Pos, m_ForClientID, WEAPON_GRENADE, true, pTarget->Team(), pTarget->TeamMask());
+				m_Pos, m_ForClientId, WEAPON_GRENADE, true, pTarget->Team(), pTarget->TeamMask());
 		}
 		Reset();
 		return true;
@@ -108,7 +108,7 @@ void CPlasma::Reset()
 void CPlasma::Snap(int SnappingClient)
 {
 	// Only players who can see the targeted player can see the plasma bullet
-	CCharacter *pTarget = GameServer()->GetPlayerChar(m_ForClientID);
+	CCharacter *pTarget = GameServer()->GetPlayerChar(m_ForClientId);
 	if(!pTarget || !pTarget->CanSnapCharacter(SnappingClient))
 	{
 		return;
@@ -121,11 +121,11 @@ void CPlasma::Snap(int SnappingClient)
 	int SnappingClientVersion = GameServer()->GetClientVersion(SnappingClient);
 
 	int Subtype = (m_Explosive ? 1 : 0) | (m_Freeze ? 2 : 0);
-	GameServer()->SnapLaserObject(CSnapContext(SnappingClientVersion), GetID(),
+	GameServer()->SnapLaserObject(CSnapContext(SnappingClientVersion), GetId(),
 		m_Pos, m_Pos, m_EvalTick, -1, LASERTYPE_PLASMA, Subtype, m_Number);
 }
 
 void CPlasma::SwapClients(int Client1, int Client2)
 {
-	m_ForClientID = m_ForClientID == Client1 ? Client2 : m_ForClientID == Client2 ? Client1 : m_ForClientID;
+	m_ForClientId = m_ForClientId == Client1 ? Client2 : m_ForClientId == Client2 ? Client1 : m_ForClientId;
 }

--- a/src/game/server/entities/plasma.h
+++ b/src/game/server/entities/plasma.h
@@ -25,7 +25,7 @@ class CPlasma : public CEntity
 	vec2 m_Core;
 	int m_Freeze;
 	bool m_Explosive;
-	int m_ForClientID;
+	int m_ForClientId;
 	int m_EvalTick;
 	int m_LifeTime;
 

--- a/src/game/server/entities/projectile.cpp
+++ b/src/game/server/entities/projectile.cpp
@@ -331,7 +331,7 @@ void CProjectile::Snap(int SnappingClient)
 
 	if(SnappingClientVersion >= VERSION_DDNET_ENTITY_NETOBJS)
 	{
-		CNetObj_DDNetProjectile *pDDNetProjectile = static_cast<CNetObj_DDNetProjectile *>(Server()->SnapNewItem(NETOBJTYPE_DDNETPROJECTILE, GetID(), sizeof(CNetObj_DDNetProjectile)));
+		CNetObj_DDNetProjectile *pDDNetProjectile = static_cast<CNetObj_DDNetProjectile *>(Server()->SnapNewItem(NETOBJTYPE_DDNETPROJECTILE, GetId(), sizeof(CNetObj_DDNetProjectile)));
 		if(!pDDNetProjectile)
 		{
 			return;
@@ -341,7 +341,7 @@ void CProjectile::Snap(int SnappingClient)
 	else if(SnappingClientVersion >= VERSION_DDNET_ANTIPING_PROJECTILE && FillExtraInfoLegacy(&DDRaceProjectile))
 	{
 		int Type = SnappingClientVersion < VERSION_DDNET_MSG_LEGACY ? (int)NETOBJTYPE_PROJECTILE : NETOBJTYPE_DDRACEPROJECTILE;
-		void *pProj = Server()->SnapNewItem(Type, GetID(), sizeof(DDRaceProjectile));
+		void *pProj = Server()->SnapNewItem(Type, GetId(), sizeof(DDRaceProjectile));
 		if(!pProj)
 		{
 			return;
@@ -350,7 +350,7 @@ void CProjectile::Snap(int SnappingClient)
 	}
 	else
 	{
-		CNetObj_Projectile *pProj = Server()->SnapNewItem<CNetObj_Projectile>(GetID());
+		CNetObj_Projectile *pProj = Server()->SnapNewItem<CNetObj_Projectile>(GetId());
 		if(!pProj)
 		{
 			return;

--- a/src/game/server/entities/projectile.h
+++ b/src/game/server/entities/projectile.h
@@ -54,7 +54,7 @@ public:
 	bool FillExtraInfoLegacy(CNetObj_DDRaceProjectile *pProj);
 	void FillExtraInfo(CNetObj_DDNetProjectile *pProj);
 
-	virtual int GetOwnerID() const override { return m_Owner; }
+	virtual int GetOwnerId() const override { return m_Owner; }
 };
 
 #endif

--- a/src/game/server/entity.cpp
+++ b/src/game/server/entity.cpp
@@ -18,7 +18,7 @@ CEntity::CEntity(CGameWorld *pGameWorld, int ObjType, vec2 Pos, int ProximityRad
 	m_ProximityRadius = ProximityRadius;
 
 	m_MarkedForDestroy = false;
-	m_ID = Server()->SnapNewID();
+	m_Id = Server()->SnapNewId();
 
 	m_pPrevTypeEntity = 0;
 	m_pNextTypeEntity = 0;
@@ -27,7 +27,7 @@ CEntity::CEntity(CGameWorld *pGameWorld, int ObjType, vec2 Pos, int ProximityRad
 CEntity::~CEntity()
 {
 	GameWorld()->RemoveEntity(this);
-	Server()->SnapFreeID(m_ID);
+	Server()->SnapFreeId(m_Id);
 }
 
 bool CEntity::NetworkClipped(int SnappingClient) const

--- a/src/game/server/entity.h
+++ b/src/game/server/entity.h
@@ -29,7 +29,7 @@ private:
 	CGameWorld *m_pGameWorld;
 	CCollision *m_pCCollision;
 
-	int m_ID;
+	int m_Id;
 	int m_ObjType;
 
 	/*
@@ -50,7 +50,7 @@ public: // TODO: Maybe make protected
 	vec2 m_Pos;
 
 	/* Getters */
-	int GetID() const { return m_ID; }
+	int GetId() const { return m_Id; }
 
 	/* Constructor */
 	CEntity(CGameWorld *pGameWorld, int Objtype, vec2 Pos = vec2(0, 0), int ProximityRadius = 0);
@@ -133,14 +133,14 @@ public: // TODO: Maybe make protected
 	virtual void SwapClients(int Client1, int Client2) {}
 
 	/*
-		Function GetOwnerID
+		Function GetOwnerId
 		Returns:
-			ClientID of the initiator from this entity. -1 created by map.
+			ClientId of the initiator from this entity. -1 created by map.
 			This is used by save/load to remove related entities to the tee.
 			CCharacter should not return the PlayerId, because they get
 			handled separately in save/load code.
 	*/
-	virtual int GetOwnerID() const { return -1; }
+	virtual int GetOwnerId() const { return -1; }
 
 	/*
 		Function: NetworkClipped

--- a/src/game/server/eventhandler.cpp
+++ b/src/game/server/eventhandler.cpp
@@ -81,7 +81,7 @@ void CEventHandler::EventToSixup(int *pType, int *pSize, const char **ppData)
 		pEvent7->m_X = pEvent->m_X;
 		pEvent7->m_Y = pEvent->m_Y;
 
-		pEvent7->m_ClientID = 0;
+		pEvent7->m_ClientId = 0;
 		pEvent7->m_Angle = 0;
 
 		// This will need some work, perhaps an event wrapper for damageind,
@@ -102,7 +102,7 @@ void CEventHandler::EventToSixup(int *pType, int *pSize, const char **ppData)
 		*pType = -protocol7::NETEVENTTYPE_SOUNDWORLD;
 		*pSize = sizeof(*pEvent7);
 
-		pEvent7->m_SoundID = pEvent->m_SoundID;
+		pEvent7->m_SoundId = pEvent->m_SoundId;
 		pEvent7->m_X = pEvent->m_X;
 		pEvent7->m_Y = pEvent->m_Y;
 

--- a/src/game/server/eventhandler.h
+++ b/src/game/server/eventhandler.h
@@ -36,7 +36,7 @@ public:
 	template<typename T>
 	T *Create(CClientMask Mask = CClientMask().set())
 	{
-		return static_cast<T *>(Create(T::ms_MsgID, sizeof(T), Mask));
+		return static_cast<T *>(Create(T::ms_MsgId, sizeof(T), Mask));
 	}
 
 	void Clear();

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -38,13 +38,13 @@
 class CClientChatLogger : public ILogger
 {
 	CGameContext *m_pGameServer;
-	int m_ClientID;
+	int m_ClientId;
 	ILogger *m_pOuterLogger;
 
 public:
-	CClientChatLogger(CGameContext *pGameServer, int ClientID, ILogger *pOuterLogger) :
+	CClientChatLogger(CGameContext *pGameServer, int ClientId, ILogger *pOuterLogger) :
 		m_pGameServer(pGameServer),
-		m_ClientID(ClientID),
+		m_ClientId(ClientId),
 		m_pOuterLogger(pOuterLogger)
 	{
 	}
@@ -59,7 +59,7 @@ void CClientChatLogger::Log(const CLogMessage *pMessage)
 		{
 			return;
 		}
-		m_pGameServer->SendChatTarget(m_ClientID, pMessage->Message());
+		m_pGameServer->SendChatTarget(m_ClientId, pMessage->Message());
 	}
 	else
 	{
@@ -167,26 +167,26 @@ void CGameContext::TeeHistorianWrite(const void *pData, int DataSize, void *pUse
 	aio_write(pSelf->m_pTeeHistorianFile, pData, DataSize);
 }
 
-void CGameContext::CommandCallback(int ClientID, int FlagMask, const char *pCmd, IConsole::IResult *pResult, void *pUser)
+void CGameContext::CommandCallback(int ClientId, int FlagMask, const char *pCmd, IConsole::IResult *pResult, void *pUser)
 {
 	CGameContext *pSelf = (CGameContext *)pUser;
 	if(pSelf->m_TeeHistorianActive)
 	{
-		pSelf->m_TeeHistorian.RecordConsoleCommand(ClientID, FlagMask, pCmd, pResult);
+		pSelf->m_TeeHistorian.RecordConsoleCommand(ClientId, FlagMask, pCmd, pResult);
 	}
 }
 
-CNetObj_PlayerInput CGameContext::GetLastPlayerInput(int ClientID) const
+CNetObj_PlayerInput CGameContext::GetLastPlayerInput(int ClientId) const
 {
-	dbg_assert(0 <= ClientID && ClientID < MAX_CLIENTS, "invalid ClientID");
-	return m_aLastPlayerInput[ClientID];
+	dbg_assert(0 <= ClientId && ClientId < MAX_CLIENTS, "invalid ClientId");
+	return m_aLastPlayerInput[ClientId];
 }
 
-class CCharacter *CGameContext::GetPlayerChar(int ClientID)
+class CCharacter *CGameContext::GetPlayerChar(int ClientId)
 {
-	if(ClientID < 0 || ClientID >= MAX_CLIENTS || !m_apPlayers[ClientID])
+	if(ClientId < 0 || ClientId >= MAX_CLIENTS || !m_apPlayers[ClientId])
 		return 0;
-	return m_apPlayers[ClientID]->GetCharacter();
+	return m_apPlayers[ClientId]->GetCharacter();
 }
 
 bool CGameContext::EmulateBug(int Bug)
@@ -301,7 +301,7 @@ void CGameContext::CreateExplosion(vec2 Pos, int Owner, int Weapon, bool NoDamag
 		if(!(int)Dmg)
 			continue;
 
-		if((GetPlayerChar(Owner) ? !GetPlayerChar(Owner)->GrenadeHitDisabled() : g_Config.m_SvHit) || NoDamage || Owner == pChr->GetPlayer()->GetCID())
+		if((GetPlayerChar(Owner) ? !GetPlayerChar(Owner)->GrenadeHitDisabled() : g_Config.m_SvHit) || NoDamage || Owner == pChr->GetPlayer()->GetCid())
 		{
 			if(Owner != -1 && pChr->IsAlive() && !pChr->CanCollide(Owner))
 				continue;
@@ -335,7 +335,7 @@ void CGameContext::CreatePlayerSpawn(vec2 Pos, CClientMask Mask)
 	}
 }
 
-void CGameContext::CreateDeath(vec2 Pos, int ClientID, CClientMask Mask)
+void CGameContext::CreateDeath(vec2 Pos, int ClientId, CClientMask Mask)
 {
 	// create the event
 	CNetEvent_Death *pEvent = m_Events.Create<CNetEvent_Death>(Mask);
@@ -343,7 +343,7 @@ void CGameContext::CreateDeath(vec2 Pos, int ClientID, CClientMask Mask)
 	{
 		pEvent->m_X = (int)Pos.x;
 		pEvent->m_Y = (int)Pos.y;
-		pEvent->m_ClientID = ClientID;
+		pEvent->m_ClientId = ClientId;
 	}
 }
 
@@ -358,7 +358,7 @@ void CGameContext::CreateSound(vec2 Pos, int Sound, CClientMask Mask)
 	{
 		pEvent->m_X = (int)Pos.x;
 		pEvent->m_Y = (int)Pos.y;
-		pEvent->m_SoundID = Sound;
+		pEvent->m_SoundId = Sound;
 	}
 }
 
@@ -368,7 +368,7 @@ void CGameContext::CreateSoundGlobal(int Sound, int Target) const
 		return;
 
 	CNetMsg_Sv_SoundGlobal Msg;
-	Msg.m_SoundID = Sound;
+	Msg.m_SoundId = Sound;
 	if(Target == -2)
 		Server()->SendPackMsg(&Msg, MSGFLAG_NOSEND, -1);
 	else
@@ -388,8 +388,8 @@ void CGameContext::SnapSwitchers(int SnappingClient)
 	CPlayer *pPlayer = SnappingClient != SERVER_DEMO_CLIENT ? m_apPlayers[SnappingClient] : 0;
 	int Team = pPlayer && pPlayer->GetCharacter() ? pPlayer->GetCharacter()->Team() : 0;
 
-	if(pPlayer && (pPlayer->GetTeam() == TEAM_SPECTATORS || pPlayer->IsPaused()) && pPlayer->m_SpectatorID != SPEC_FREEVIEW && m_apPlayers[pPlayer->m_SpectatorID] && m_apPlayers[pPlayer->m_SpectatorID]->GetCharacter())
-		Team = m_apPlayers[pPlayer->m_SpectatorID]->GetCharacter()->Team();
+	if(pPlayer && (pPlayer->GetTeam() == TEAM_SPECTATORS || pPlayer->IsPaused()) && pPlayer->m_SpectatorId != SPEC_FREEVIEW && m_apPlayers[pPlayer->m_SpectatorId] && m_apPlayers[pPlayer->m_SpectatorId]->GetCharacter())
+		Team = m_apPlayers[pPlayer->m_SpectatorId]->GetCharacter()->Team();
 
 	if(Team == TEAM_SUPER)
 		return;
@@ -434,11 +434,11 @@ void CGameContext::SnapSwitchers(int SnappingClient)
 	}
 }
 
-bool CGameContext::SnapLaserObject(const CSnapContext &Context, int SnapID, const vec2 &To, const vec2 &From, int StartTick, int Owner, int LaserType, int Subtype, int SwitchNumber) const
+bool CGameContext::SnapLaserObject(const CSnapContext &Context, int SnapId, const vec2 &To, const vec2 &From, int StartTick, int Owner, int LaserType, int Subtype, int SwitchNumber) const
 {
 	if(Context.GetClientVersion() >= VERSION_DDNET_MULTI_LASER)
 	{
-		CNetObj_DDNetLaser *pObj = Server()->SnapNewItem<CNetObj_DDNetLaser>(SnapID);
+		CNetObj_DDNetLaser *pObj = Server()->SnapNewItem<CNetObj_DDNetLaser>(SnapId);
 		if(!pObj)
 			return false;
 
@@ -455,7 +455,7 @@ bool CGameContext::SnapLaserObject(const CSnapContext &Context, int SnapID, cons
 	}
 	else
 	{
-		CNetObj_Laser *pObj = Server()->SnapNewItem<CNetObj_Laser>(SnapID);
+		CNetObj_Laser *pObj = Server()->SnapNewItem<CNetObj_Laser>(SnapId);
 		if(!pObj)
 			return false;
 
@@ -469,11 +469,11 @@ bool CGameContext::SnapLaserObject(const CSnapContext &Context, int SnapID, cons
 	return true;
 }
 
-bool CGameContext::SnapPickup(const CSnapContext &Context, int SnapID, const vec2 &Pos, int Type, int SubType, int SwitchNumber) const
+bool CGameContext::SnapPickup(const CSnapContext &Context, int SnapId, const vec2 &Pos, int Type, int SubType, int SwitchNumber) const
 {
 	if(Context.IsSixup())
 	{
-		protocol7::CNetObj_Pickup *pPickup = Server()->SnapNewItem<protocol7::CNetObj_Pickup>(SnapID);
+		protocol7::CNetObj_Pickup *pPickup = Server()->SnapNewItem<protocol7::CNetObj_Pickup>(SnapId);
 		if(!pPickup)
 			return false;
 
@@ -489,7 +489,7 @@ bool CGameContext::SnapPickup(const CSnapContext &Context, int SnapID, const vec
 	}
 	else if(Context.GetClientVersion() >= VERSION_DDNET_ENTITY_NETOBJS)
 	{
-		CNetObj_DDNetPickup *pPickup = Server()->SnapNewItem<CNetObj_DDNetPickup>(SnapID);
+		CNetObj_DDNetPickup *pPickup = Server()->SnapNewItem<CNetObj_DDNetPickup>(SnapId);
 		if(!pPickup)
 			return false;
 
@@ -501,7 +501,7 @@ bool CGameContext::SnapPickup(const CSnapContext &Context, int SnapID, const vec
 	}
 	else
 	{
-		CNetObj_Pickup *pPickup = Server()->SnapNewItem<CNetObj_Pickup>(SnapID);
+		CNetObj_Pickup *pPickup = Server()->SnapNewItem<CNetObj_Pickup>(SnapId);
 		if(!pPickup)
 			return false;
 
@@ -522,14 +522,14 @@ bool CGameContext::SnapPickup(const CSnapContext &Context, int SnapID, const vec
 	return true;
 }
 
-void CGameContext::CallVote(int ClientID, const char *pDesc, const char *pCmd, const char *pReason, const char *pChatmsg, const char *pSixupDesc)
+void CGameContext::CallVote(int ClientId, const char *pDesc, const char *pCmd, const char *pReason, const char *pChatmsg, const char *pSixupDesc)
 {
 	// check if a vote is already running
 	if(m_VoteCloseTime)
 		return;
 
 	int64_t Now = Server()->Tick();
-	CPlayer *pPlayer = m_apPlayers[ClientID];
+	CPlayer *pPlayer = m_apPlayers[ClientId];
 
 	if(!pPlayer)
 		return;
@@ -538,7 +538,7 @@ void CGameContext::CallVote(int ClientID, const char *pDesc, const char *pCmd, c
 	if(!pSixupDesc)
 		pSixupDesc = pDesc;
 
-	m_VoteCreator = ClientID;
+	m_VoteCreator = ClientId;
 	StartVote(pDesc, pCmd, pReason, pSixupDesc);
 	pPlayer->m_Vote = 1;
 	pPlayer->m_VotePos = m_VotePos = 1;
@@ -549,7 +549,7 @@ void CGameContext::SendChatTarget(int To, const char *pText, int Flags) const
 {
 	CNetMsg_Sv_Chat Msg;
 	Msg.m_Team = 0;
-	Msg.m_ClientID = -1;
+	Msg.m_ClientId = -1;
 	Msg.m_pMessage = pText;
 
 	if(g_Config.m_SvDemoChat)
@@ -583,21 +583,21 @@ void CGameContext::SendChatTeam(int Team, const char *pText) const
 			SendChatTarget(i, pText);
 }
 
-void CGameContext::SendChat(int ChatterClientID, int Team, const char *pText, int SpamProtectionClientID, int Flags)
+void CGameContext::SendChat(int ChatterClientId, int Team, const char *pText, int SpamProtectionClientId, int Flags)
 {
-	if(SpamProtectionClientID >= 0 && SpamProtectionClientID < MAX_CLIENTS)
-		if(ProcessSpamProtection(SpamProtectionClientID))
+	if(SpamProtectionClientId >= 0 && SpamProtectionClientId < MAX_CLIENTS)
+		if(ProcessSpamProtection(SpamProtectionClientId))
 			return;
 
 	char aBuf[256], aText[256];
 	str_copy(aText, pText, sizeof(aText));
-	if(ChatterClientID >= 0 && ChatterClientID < MAX_CLIENTS)
-		str_format(aBuf, sizeof(aBuf), "%d:%d:%s: %s", ChatterClientID, Team, Server()->ClientName(ChatterClientID), aText);
-	else if(ChatterClientID == -2)
+	if(ChatterClientId >= 0 && ChatterClientId < MAX_CLIENTS)
+		str_format(aBuf, sizeof(aBuf), "%d:%d:%s: %s", ChatterClientId, Team, Server()->ClientName(ChatterClientId), aText);
+	else if(ChatterClientId == -2)
 	{
 		str_format(aBuf, sizeof(aBuf), "### %s", aText);
 		str_copy(aText, aBuf, sizeof(aText));
-		ChatterClientID = -1;
+		ChatterClientId = -1;
 	}
 	else
 		str_format(aBuf, sizeof(aBuf), "*** %s", aText);
@@ -607,7 +607,7 @@ void CGameContext::SendChat(int ChatterClientID, int Team, const char *pText, in
 	{
 		CNetMsg_Sv_Chat Msg;
 		Msg.m_Team = 0;
-		Msg.m_ClientID = ChatterClientID;
+		Msg.m_ClientId = ChatterClientId;
 		Msg.m_pMessage = aText;
 
 		// pack one for the recording only
@@ -627,14 +627,14 @@ void CGameContext::SendChat(int ChatterClientID, int Team, const char *pText, in
 		}
 
 		str_format(aBuf, sizeof(aBuf), "Chat: %s", aText);
-		LogEvent(aBuf, ChatterClientID);
+		LogEvent(aBuf, ChatterClientId);
 	}
 	else
 	{
 		CTeamsCore *pTeams = &m_pController->Teams().m_Core;
 		CNetMsg_Sv_Chat Msg;
 		Msg.m_Team = 1;
-		Msg.m_ClientID = ChatterClientID;
+		Msg.m_ClientId = ChatterClientId;
 		Msg.m_pMessage = aText;
 
 		// pack one for the recording only
@@ -665,39 +665,39 @@ void CGameContext::SendChat(int ChatterClientID, int Team, const char *pText, in
 	}
 }
 
-void CGameContext::SendStartWarning(int ClientID, const char *pMessage)
+void CGameContext::SendStartWarning(int ClientId, const char *pMessage)
 {
-	CCharacter *pChr = GetPlayerChar(ClientID);
+	CCharacter *pChr = GetPlayerChar(ClientId);
 	if(pChr && pChr->m_LastStartWarning < Server()->Tick() - 3 * Server()->TickSpeed())
 	{
-		SendChatTarget(ClientID, pMessage);
+		SendChatTarget(ClientId, pMessage);
 		pChr->m_LastStartWarning = Server()->Tick();
 	}
 }
 
-void CGameContext::SendEmoticon(int ClientID, int Emoticon, int TargetClientID) const
+void CGameContext::SendEmoticon(int ClientId, int Emoticon, int TargetClientId) const
 {
 	CNetMsg_Sv_Emoticon Msg;
-	Msg.m_ClientID = ClientID;
+	Msg.m_ClientId = ClientId;
 	Msg.m_Emoticon = Emoticon;
-	Server()->SendPackMsg(&Msg, MSGFLAG_VITAL, TargetClientID);
+	Server()->SendPackMsg(&Msg, MSGFLAG_VITAL, TargetClientId);
 }
 
-void CGameContext::SendWeaponPickup(int ClientID, int Weapon) const
+void CGameContext::SendWeaponPickup(int ClientId, int Weapon) const
 {
 	CNetMsg_Sv_WeaponPickup Msg;
 	Msg.m_Weapon = Weapon;
-	Server()->SendPackMsg(&Msg, MSGFLAG_VITAL, ClientID);
+	Server()->SendPackMsg(&Msg, MSGFLAG_VITAL, ClientId);
 }
 
-void CGameContext::SendMotd(int ClientID) const
+void CGameContext::SendMotd(int ClientId) const
 {
 	CNetMsg_Sv_Motd Msg;
 	Msg.m_pMessage = g_Config.m_SvMotd;
-	Server()->SendPackMsg(&Msg, MSGFLAG_VITAL, ClientID);
+	Server()->SendPackMsg(&Msg, MSGFLAG_VITAL, ClientId);
 }
 
-void CGameContext::SendSettings(int ClientID) const
+void CGameContext::SendSettings(int ClientId) const
 {
 	protocol7::CNetMsg_Sv_ServerSettings Msg;
 	Msg.m_KickVote = g_Config.m_SvVoteKick;
@@ -706,18 +706,18 @@ void CGameContext::SendSettings(int ClientID) const
 	Msg.m_TeamLock = 0;
 	Msg.m_TeamBalance = 0;
 	Msg.m_PlayerSlots = g_Config.m_SvMaxClients - g_Config.m_SvSpectatorSlots;
-	Server()->SendPackMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_NORECORD, ClientID);
+	Server()->SendPackMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_NORECORD, ClientId);
 }
 
-void CGameContext::SendBroadcast(const char *pText, int ClientID, bool IsImportant)
+void CGameContext::SendBroadcast(const char *pText, int ClientId, bool IsImportant)
 {
 	CNetMsg_Sv_Broadcast Msg;
 	Msg.m_pMessage = pText;
 
-	if(ClientID == -1)
+	if(ClientId == -1)
 	{
 		dbg_assert(IsImportant, "broadcast messages to all players must be important");
-		Server()->SendPackMsg(&Msg, MSGFLAG_VITAL, ClientID);
+		Server()->SendPackMsg(&Msg, MSGFLAG_VITAL, ClientId);
 
 		for(auto &pPlayer : m_apPlayers)
 		{
@@ -730,15 +730,15 @@ void CGameContext::SendBroadcast(const char *pText, int ClientID, bool IsImporta
 		return;
 	}
 
-	if(!m_apPlayers[ClientID])
+	if(!m_apPlayers[ClientId])
 		return;
 
-	if(!IsImportant && m_apPlayers[ClientID]->m_LastBroadcastImportance && m_apPlayers[ClientID]->m_LastBroadcast > Server()->Tick() - Server()->TickSpeed() * 10)
+	if(!IsImportant && m_apPlayers[ClientId]->m_LastBroadcastImportance && m_apPlayers[ClientId]->m_LastBroadcast > Server()->Tick() - Server()->TickSpeed() * 10)
 		return;
 
-	Server()->SendPackMsg(&Msg, MSGFLAG_VITAL, ClientID);
-	m_apPlayers[ClientID]->m_LastBroadcast = Server()->Tick();
-	m_apPlayers[ClientID]->m_LastBroadcastImportance = IsImportant;
+	Server()->SendPackMsg(&Msg, MSGFLAG_VITAL, ClientId);
+	m_apPlayers[ClientId]->m_LastBroadcast = Server()->Tick();
+	m_apPlayers[ClientId]->m_LastBroadcastImportance = IsImportant;
 }
 
 void CGameContext::StartVote(const char *pDesc, const char *pCommand, const char *pReason, const char *pSixupDesc)
@@ -771,12 +771,12 @@ void CGameContext::EndVote()
 	SendVoteSet(-1);
 }
 
-void CGameContext::SendVoteSet(int ClientID)
+void CGameContext::SendVoteSet(int ClientId)
 {
 	::CNetMsg_Sv_VoteSet Msg6;
 	protocol7::CNetMsg_Sv_VoteSet Msg7;
 
-	Msg7.m_ClientID = m_VoteCreator;
+	Msg7.m_ClientId = m_VoteCreator;
 	if(m_VoteCloseTime)
 	{
 		Msg6.m_Timeout = Msg7.m_Timeout = (m_VoteCloseTime - time_get()) / time_freq();
@@ -807,10 +807,10 @@ void CGameContext::SendVoteSet(int ClientID)
 			Type = protocol7::VOTE_END_ABORT;
 
 		if(m_VoteEnforce == VOTE_ENFORCE_NO_ADMIN || m_VoteEnforce == VOTE_ENFORCE_YES_ADMIN)
-			Msg7.m_ClientID = -1;
+			Msg7.m_ClientId = -1;
 	}
 
-	if(ClientID == -1)
+	if(ClientId == -1)
 	{
 		for(int i = 0; i < Server()->MaxClients(); i++)
 		{
@@ -824,16 +824,16 @@ void CGameContext::SendVoteSet(int ClientID)
 	}
 	else
 	{
-		if(!Server()->IsSixup(ClientID))
-			Server()->SendPackMsg(&Msg6, MSGFLAG_VITAL, ClientID);
+		if(!Server()->IsSixup(ClientId))
+			Server()->SendPackMsg(&Msg6, MSGFLAG_VITAL, ClientId);
 		else
-			Server()->SendPackMsg(&Msg7, MSGFLAG_VITAL, ClientID);
+			Server()->SendPackMsg(&Msg7, MSGFLAG_VITAL, ClientId);
 	}
 }
 
-void CGameContext::SendVoteStatus(int ClientID, int Total, int Yes, int No)
+void CGameContext::SendVoteStatus(int ClientId, int Total, int Yes, int No)
 {
-	if(ClientID == -1)
+	if(ClientId == -1)
 	{
 		for(int i = 0; i < MAX_CLIENTS; ++i)
 			if(Server()->ClientIngame(i))
@@ -841,7 +841,7 @@ void CGameContext::SendVoteStatus(int ClientID, int Total, int Yes, int No)
 		return;
 	}
 
-	if(Total > VANILLA_MAX_CLIENTS && m_apPlayers[ClientID] && m_apPlayers[ClientID]->GetClientVersion() <= VERSION_DDRACE)
+	if(Total > VANILLA_MAX_CLIENTS && m_apPlayers[ClientId] && m_apPlayers[ClientId]->GetClientVersion() <= VERSION_DDRACE)
 	{
 		Yes = (Yes * VANILLA_MAX_CLIENTS) / (float)Total;
 		No = (No * VANILLA_MAX_CLIENTS) / (float)Total;
@@ -854,13 +854,13 @@ void CGameContext::SendVoteStatus(int ClientID, int Total, int Yes, int No)
 	Msg.m_No = No;
 	Msg.m_Pass = Total - (Yes + No);
 
-	Server()->SendPackMsg(&Msg, MSGFLAG_VITAL, ClientID);
+	Server()->SendPackMsg(&Msg, MSGFLAG_VITAL, ClientId);
 }
 
-void CGameContext::AbortVoteKickOnDisconnect(int ClientID)
+void CGameContext::AbortVoteKickOnDisconnect(int ClientId)
 {
-	if(m_VoteCloseTime && ((str_startswith(m_aVoteCommand, "kick ") && str_toint(&m_aVoteCommand[5]) == ClientID) ||
-				      (str_startswith(m_aVoteCommand, "set_team ") && str_toint(&m_aVoteCommand[9]) == ClientID)))
+	if(m_VoteCloseTime && ((str_startswith(m_aVoteCommand, "kick ") && str_toint(&m_aVoteCommand[5]) == ClientId) ||
+				      (str_startswith(m_aVoteCommand, "set_team ") && str_toint(&m_aVoteCommand[9]) == ClientId)))
 		m_VoteEnforce = VOTE_ENFORCE_ABORT;
 }
 
@@ -883,9 +883,9 @@ void CGameContext::CheckPureTuning()
 	}
 }
 
-void CGameContext::SendTuningParams(int ClientID, int Zone)
+void CGameContext::SendTuningParams(int ClientId, int Zone)
 {
-	if(ClientID == -1)
+	if(ClientId == -1)
 	{
 		for(int i = 0; i < MAX_CLIENTS; ++i)
 		{
@@ -916,35 +916,35 @@ void CGameContext::SendTuningParams(int ClientID, int Zone)
 
 	for(unsigned i = 0; i < sizeof(m_Tuning) / sizeof(int); i++)
 	{
-		if(m_apPlayers[ClientID] && m_apPlayers[ClientID]->GetCharacter())
+		if(m_apPlayers[ClientId] && m_apPlayers[ClientId]->GetCharacter())
 		{
 			if((i == 30) // laser_damage is removed from 0.7
-				&& (Server()->IsSixup(ClientID)))
+				&& (Server()->IsSixup(ClientId)))
 			{
 				continue;
 			}
 			else if((i == 31) // collision
-				&& (m_apPlayers[ClientID]->GetCharacter()->NeededFaketuning() & FAKETUNE_SOLO || m_apPlayers[ClientID]->GetCharacter()->NeededFaketuning() & FAKETUNE_NOCOLL))
+				&& (m_apPlayers[ClientId]->GetCharacter()->NeededFaketuning() & FAKETUNE_SOLO || m_apPlayers[ClientId]->GetCharacter()->NeededFaketuning() & FAKETUNE_NOCOLL))
 			{
 				Msg.AddInt(0);
 			}
 			else if((i == 32) // hooking
-				&& (m_apPlayers[ClientID]->GetCharacter()->NeededFaketuning() & FAKETUNE_SOLO || m_apPlayers[ClientID]->GetCharacter()->NeededFaketuning() & FAKETUNE_NOHOOK))
+				&& (m_apPlayers[ClientId]->GetCharacter()->NeededFaketuning() & FAKETUNE_SOLO || m_apPlayers[ClientId]->GetCharacter()->NeededFaketuning() & FAKETUNE_NOHOOK))
 			{
 				Msg.AddInt(0);
 			}
 			else if((i == 3) // ground jump impulse
-				&& m_apPlayers[ClientID]->GetCharacter()->NeededFaketuning() & FAKETUNE_NOJUMP)
+				&& m_apPlayers[ClientId]->GetCharacter()->NeededFaketuning() & FAKETUNE_NOJUMP)
 			{
 				Msg.AddInt(0);
 			}
 			else if((i == 33) // jetpack
-				&& !(m_apPlayers[ClientID]->GetCharacter()->NeededFaketuning() & FAKETUNE_JETPACK))
+				&& !(m_apPlayers[ClientId]->GetCharacter()->NeededFaketuning() & FAKETUNE_JETPACK))
 			{
 				Msg.AddInt(0);
 			}
 			else if((i == 36) // hammer hit
-				&& m_apPlayers[ClientID]->GetCharacter()->NeededFaketuning() & FAKETUNE_NOHAMMER)
+				&& m_apPlayers[ClientId]->GetCharacter()->NeededFaketuning() & FAKETUNE_NOHAMMER)
 			{
 				Msg.AddInt(0);
 			}
@@ -956,7 +956,7 @@ void CGameContext::SendTuningParams(int ClientID, int Zone)
 		else
 			Msg.AddInt(pParams[i]); // if everything is normal just send true tunings
 	}
-	Server()->SendMsg(&Msg, MSGFLAG_VITAL, ClientID);
+	Server()->SendMsg(&Msg, MSGFLAG_VITAL, ClientId);
 }
 
 void CGameContext::OnPreTickTeehistorian()
@@ -1043,16 +1043,16 @@ void CGameContext::OnTick()
 			if(m_VoteUpdate)
 			{
 				// count votes
-				char aaBuf[MAX_CLIENTS][NETADDR_MAXSTRSIZE] = {{0}}, *pIP = NULL;
+				char aaBuf[MAX_CLIENTS][NETADDR_MAXSTRSIZE] = {{0}}, *pIp = NULL;
 				bool SinglePlayer = true;
 				for(int i = 0; i < MAX_CLIENTS; i++)
 				{
 					if(m_apPlayers[i])
 					{
 						Server()->GetClientAddr(i, aaBuf[i], NETADDR_MAXSTRSIZE);
-						if(!pIP)
-							pIP = aaBuf[i];
-						else if(SinglePlayer && str_comp(pIP, aaBuf[i]))
+						if(!pIp)
+							pIp = aaBuf[i];
+						else if(SinglePlayer && str_comp(pIp, aaBuf[i]))
 							SinglePlayer = false;
 					}
 				}
@@ -1158,9 +1158,9 @@ void CGameContext::OnTick()
 			if(m_VoteEnforce == VOTE_ENFORCE_YES && !(PlayerModerating() &&
 									(IsKickVote() || IsSpecVote()) && time_get() < m_VoteCloseTime))
 			{
-				Server()->SetRconCID(IServer::RCON_CID_VOTE);
+				Server()->SetRconCid(IServer::RCON_CID_VOTE);
 				Console()->ExecuteLine(m_aVoteCommand);
-				Server()->SetRconCID(IServer::RCON_CID_SERV);
+				Server()->SetRconCid(IServer::RCON_CID_SERV);
 				EndVote();
 				SendChat(-1, CGameContext::CHAT_ALL, "Vote passed", -1, CHAT_SIX);
 
@@ -1241,8 +1241,8 @@ void CGameContext::OnTick()
 	{
 		if(m_SqlRandomMapResult->m_Success)
 		{
-			if(PlayerExists(m_SqlRandomMapResult->m_ClientID) && m_SqlRandomMapResult->m_aMessage[0] != '\0')
-				SendChatTarget(m_SqlRandomMapResult->m_ClientID, m_SqlRandomMapResult->m_aMessage);
+			if(PlayerExists(m_SqlRandomMapResult->m_ClientId) && m_SqlRandomMapResult->m_aMessage[0] != '\0')
+				SendChatTarget(m_SqlRandomMapResult->m_ClientId, m_SqlRandomMapResult->m_aMessage);
 			if(m_SqlRandomMapResult->m_aMap[0] != '\0')
 				Server()->ChangeMap(m_SqlRandomMapResult->m_aMap);
 			else
@@ -1286,53 +1286,53 @@ static int PlayerFlags_SevenToSix(int Flags)
 }
 
 // Server hooks
-void CGameContext::OnClientPrepareInput(int ClientID, void *pInput)
+void CGameContext::OnClientPrepareInput(int ClientId, void *pInput)
 {
 	auto *pPlayerInput = (CNetObj_PlayerInput *)pInput;
-	if(Server()->IsSixup(ClientID))
+	if(Server()->IsSixup(ClientId))
 		pPlayerInput->m_PlayerFlags = PlayerFlags_SevenToSix(pPlayerInput->m_PlayerFlags);
 }
 
-void CGameContext::OnClientDirectInput(int ClientID, void *pInput)
+void CGameContext::OnClientDirectInput(int ClientId, void *pInput)
 {
 	if(!m_World.m_Paused)
-		m_apPlayers[ClientID]->OnDirectInput((CNetObj_PlayerInput *)pInput);
+		m_apPlayers[ClientId]->OnDirectInput((CNetObj_PlayerInput *)pInput);
 
 	int Flags = ((CNetObj_PlayerInput *)pInput)->m_PlayerFlags;
 	if((Flags & 256) || (Flags & 512))
 	{
-		Server()->Kick(ClientID, "please update your client or use DDNet client");
+		Server()->Kick(ClientId, "please update your client or use DDNet client");
 	}
 }
 
-void CGameContext::OnClientPredictedInput(int ClientID, void *pInput)
+void CGameContext::OnClientPredictedInput(int ClientId, void *pInput)
 {
 	// early return if no input at all has been sent by a player
-	if(pInput == nullptr && !m_aPlayerHasInput[ClientID])
+	if(pInput == nullptr && !m_aPlayerHasInput[ClientId])
 		return;
 
 	// set to last sent input when no new input has been sent
 	CNetObj_PlayerInput *pApplyInput = (CNetObj_PlayerInput *)pInput;
 	if(pApplyInput == nullptr)
 	{
-		pApplyInput = &m_aLastPlayerInput[ClientID];
+		pApplyInput = &m_aLastPlayerInput[ClientId];
 	}
 
 	if(!m_World.m_Paused)
-		m_apPlayers[ClientID]->OnPredictedInput(pApplyInput);
+		m_apPlayers[ClientId]->OnPredictedInput(pApplyInput);
 }
 
-void CGameContext::OnClientPredictedEarlyInput(int ClientID, void *pInput)
+void CGameContext::OnClientPredictedEarlyInput(int ClientId, void *pInput)
 {
 	// early return if no input at all has been sent by a player
-	if(pInput == nullptr && !m_aPlayerHasInput[ClientID])
+	if(pInput == nullptr && !m_aPlayerHasInput[ClientId])
 		return;
 
 	// set to last sent input when no new input has been sent
 	CNetObj_PlayerInput *pApplyInput = (CNetObj_PlayerInput *)pInput;
 	if(pApplyInput == nullptr)
 	{
-		pApplyInput = &m_aLastPlayerInput[ClientID];
+		pApplyInput = &m_aLastPlayerInput[ClientId];
 	}
 	else
 	{
@@ -1340,16 +1340,16 @@ void CGameContext::OnClientPredictedEarlyInput(int ClientID, void *pInput)
 		// because this function is called on all inputs, while
 		// `OnClientPredictedInput` is only called on the first input of each
 		// tick.
-		mem_copy(&m_aLastPlayerInput[ClientID], pApplyInput, sizeof(m_aLastPlayerInput[ClientID]));
-		m_aPlayerHasInput[ClientID] = true;
+		mem_copy(&m_aLastPlayerInput[ClientId], pApplyInput, sizeof(m_aLastPlayerInput[ClientId]));
+		m_aPlayerHasInput[ClientId] = true;
 	}
 
 	if(!m_World.m_Paused)
-		m_apPlayers[ClientID]->OnPredictedEarlyInput(pApplyInput);
+		m_apPlayers[ClientId]->OnPredictedEarlyInput(pApplyInput);
 
 	if(m_TeeHistorianActive)
 	{
-		m_TeeHistorian.RecordPlayerInput(ClientID, m_apPlayers[ClientID]->GetUniqueCID(), pApplyInput);
+		m_TeeHistorian.RecordPlayerInput(ClientId, m_apPlayers[ClientId]->GetUniqueCid(), pApplyInput);
 	}
 }
 
@@ -1366,9 +1366,9 @@ const CVoteOptionServer *CGameContext::GetVoteOption(int Index) const
 	return pCurrent;
 }
 
-void CGameContext::ProgressVoteOptions(int ClientID)
+void CGameContext::ProgressVoteOptions(int ClientId)
 {
-	CPlayer *pPl = m_apPlayers[ClientID];
+	CPlayer *pPl = m_apPlayers[ClientId];
 
 	if(pPl->m_SendVoteIndex == -1)
 		return; // we didn't start sending options yet
@@ -1437,30 +1437,30 @@ void CGameContext::ProgressVoteOptions(int ClientID)
 	if(pPl->m_SendVoteIndex == 0)
 	{
 		CNetMsg_Sv_VoteOptionGroupStart StartMsg;
-		Server()->SendPackMsg(&StartMsg, MSGFLAG_VITAL, ClientID);
+		Server()->SendPackMsg(&StartMsg, MSGFLAG_VITAL, ClientId);
 	}
 
 	OptionMsg.m_NumOptions = NumVotesToSend;
-	Server()->SendPackMsg(&OptionMsg, MSGFLAG_VITAL, ClientID);
+	Server()->SendPackMsg(&OptionMsg, MSGFLAG_VITAL, ClientId);
 
 	pPl->m_SendVoteIndex += NumVotesToSend;
 
 	if(pPl->m_SendVoteIndex == m_NumVoteOptions)
 	{
 		CNetMsg_Sv_VoteOptionGroupEnd EndMsg;
-		Server()->SendPackMsg(&EndMsg, MSGFLAG_VITAL, ClientID);
+		Server()->SendPackMsg(&EndMsg, MSGFLAG_VITAL, ClientId);
 	}
 }
 
-void CGameContext::OnClientEnter(int ClientID)
+void CGameContext::OnClientEnter(int ClientId)
 {
 	if(m_TeeHistorianActive)
 	{
-		m_TeeHistorian.RecordPlayerReady(ClientID);
+		m_TeeHistorian.RecordPlayerReady(ClientId);
 	}
-	m_pController->OnPlayerConnect(m_apPlayers[ClientID]);
+	m_pController->OnPlayerConnect(m_apPlayers[ClientId]);
 
-	if(Server()->IsSixup(ClientID))
+	if(Server()->IsSixup(ClientId))
 	{
 		{
 			protocol7::CNetMsg_Sv_GameInfo Msg;
@@ -1469,27 +1469,27 @@ void CGameContext::OnClientEnter(int ClientID)
 			Msg.m_MatchNum = 0;
 			Msg.m_ScoreLimit = 0;
 			Msg.m_TimeLimit = 0;
-			Server()->SendPackMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_NORECORD, ClientID);
+			Server()->SendPackMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_NORECORD, ClientId);
 		}
 
 		// /team is essential
 		{
 			protocol7::CNetMsg_Sv_CommandInfoRemove Msg;
 			Msg.m_pName = "team";
-			Server()->SendPackMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_NORECORD, ClientID);
+			Server()->SendPackMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_NORECORD, ClientId);
 		}
 	}
 
 	{
 		CNetMsg_Sv_CommandInfoGroupStart Msg;
-		Server()->SendPackMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_NORECORD, ClientID);
+		Server()->SendPackMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_NORECORD, ClientId);
 	}
 	for(const IConsole::CCommandInfo *pCmd = Console()->FirstCommandInfo(IConsole::ACCESS_LEVEL_USER, CFGFLAG_CHAT);
 		pCmd; pCmd = pCmd->NextCommandInfo(IConsole::ACCESS_LEVEL_USER, CFGFLAG_CHAT))
 	{
 		const char *pName = pCmd->m_pName;
 
-		if(Server()->IsSixup(ClientID))
+		if(Server()->IsSixup(ClientId))
 		{
 			if(!str_comp_nocase(pName, "w") || !str_comp_nocase(pName, "whisper"))
 				continue;
@@ -1501,7 +1501,7 @@ void CGameContext::OnClientEnter(int ClientID)
 			Msg.m_pName = pName;
 			Msg.m_pArgsFormat = pCmd->m_pParams;
 			Msg.m_pHelpText = pCmd->m_pHelp;
-			Server()->SendPackMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_NORECORD, ClientID);
+			Server()->SendPackMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_NORECORD, ClientId);
 		}
 		else
 		{
@@ -1509,12 +1509,12 @@ void CGameContext::OnClientEnter(int ClientID)
 			Msg.m_pName = pName;
 			Msg.m_pArgsFormat = pCmd->m_pParams;
 			Msg.m_pHelpText = pCmd->m_pHelp;
-			Server()->SendPackMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_NORECORD, ClientID);
+			Server()->SendPackMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_NORECORD, ClientId);
 		}
 	}
 	{
 		CNetMsg_Sv_CommandInfoGroupEnd Msg;
-		Server()->SendPackMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_NORECORD, ClientID);
+		Server()->SendPackMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_NORECORD, ClientId);
 	}
 
 	{
@@ -1529,52 +1529,52 @@ void CGameContext::OnClientEnter(int ClientID)
 		}
 		CNetMsg_Sv_Chat Msg;
 		Msg.m_Team = 0;
-		Msg.m_ClientID = Empty;
+		Msg.m_ClientId = Empty;
 		Msg.m_pMessage = "Do you know someone who uses a bot? Please report them to the moderators.";
-		m_apPlayers[ClientID]->m_EligibleForFinishCheck = time_get();
-		Server()->SendPackMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_NORECORD, ClientID);
+		m_apPlayers[ClientId]->m_EligibleForFinishCheck = time_get();
+		Server()->SendPackMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_NORECORD, ClientId);
 	}
 
 	IServer::CClientInfo Info;
-	if(Server()->GetClientInfo(ClientID, &Info) && Info.m_GotDDNetVersion)
+	if(Server()->GetClientInfo(ClientId, &Info) && Info.m_GotDDNetVersion)
 	{
-		if(OnClientDDNetVersionKnown(ClientID))
+		if(OnClientDDNetVersionKnown(ClientId))
 			return; // kicked
 	}
 
-	if(!Server()->ClientPrevIngame(ClientID))
+	if(!Server()->ClientPrevIngame(ClientId))
 	{
 		if(g_Config.m_SvWelcome[0] != 0)
-			SendChatTarget(ClientID, g_Config.m_SvWelcome);
+			SendChatTarget(ClientId, g_Config.m_SvWelcome);
 
 		if(g_Config.m_SvShowOthersDefault > SHOW_OTHERS_OFF)
 		{
 			if(g_Config.m_SvShowOthers)
-				SendChatTarget(ClientID, "You can see other players. To disable this use DDNet client and type /showothers");
+				SendChatTarget(ClientId, "You can see other players. To disable this use DDNet client and type /showothers");
 
-			m_apPlayers[ClientID]->m_ShowOthers = g_Config.m_SvShowOthersDefault;
+			m_apPlayers[ClientId]->m_ShowOthers = g_Config.m_SvShowOthersDefault;
 		}
 	}
 	m_VoteUpdate = true;
 
 	// send active vote
 	if(m_VoteCloseTime)
-		SendVoteSet(ClientID);
+		SendVoteSet(ClientId);
 
 	Server()->ExpireServerInfo();
 
-	CPlayer *pNewPlayer = m_apPlayers[ClientID];
-	mem_zero(&m_aLastPlayerInput[ClientID], sizeof(m_aLastPlayerInput[ClientID]));
-	m_aPlayerHasInput[ClientID] = false;
+	CPlayer *pNewPlayer = m_apPlayers[ClientId];
+	mem_zero(&m_aLastPlayerInput[ClientId], sizeof(m_aLastPlayerInput[ClientId]));
+	m_aPlayerHasInput[ClientId] = false;
 
 	// new info for others
 	protocol7::CNetMsg_Sv_ClientInfo NewClientInfoMsg;
-	NewClientInfoMsg.m_ClientID = ClientID;
+	NewClientInfoMsg.m_ClientId = ClientId;
 	NewClientInfoMsg.m_Local = 0;
 	NewClientInfoMsg.m_Team = pNewPlayer->GetTeam();
-	NewClientInfoMsg.m_pName = Server()->ClientName(ClientID);
-	NewClientInfoMsg.m_pClan = Server()->ClientClan(ClientID);
-	NewClientInfoMsg.m_Country = Server()->ClientCountry(ClientID);
+	NewClientInfoMsg.m_pName = Server()->ClientName(ClientId);
+	NewClientInfoMsg.m_pClan = Server()->ClientClan(ClientId);
+	NewClientInfoMsg.m_Country = Server()->ClientCountry(ClientId);
 	NewClientInfoMsg.m_Silent = false;
 
 	for(int p = 0; p < 6; p++)
@@ -1587,7 +1587,7 @@ void CGameContext::OnClientEnter(int ClientID)
 	// update client infos (others before local)
 	for(int i = 0; i < Server()->MaxClients(); ++i)
 	{
-		if(i == ClientID || !m_apPlayers[i] || !Server()->ClientIngame(i))
+		if(i == ClientId || !m_apPlayers[i] || !Server()->ClientIngame(i))
 			continue;
 
 		CPlayer *pPlayer = m_apPlayers[i];
@@ -1595,11 +1595,11 @@ void CGameContext::OnClientEnter(int ClientID)
 		if(Server()->IsSixup(i))
 			Server()->SendPackMsg(&NewClientInfoMsg, MSGFLAG_VITAL | MSGFLAG_NORECORD, i);
 
-		if(Server()->IsSixup(ClientID))
+		if(Server()->IsSixup(ClientId))
 		{
 			// existing infos for new player
 			protocol7::CNetMsg_Sv_ClientInfo ClientInfoMsg;
-			ClientInfoMsg.m_ClientID = i;
+			ClientInfoMsg.m_ClientId = i;
 			ClientInfoMsg.m_Local = 0;
 			ClientInfoMsg.m_Team = pPlayer->GetTeam();
 			ClientInfoMsg.m_pName = Server()->ClientName(i);
@@ -1614,44 +1614,44 @@ void CGameContext::OnClientEnter(int ClientID)
 				ClientInfoMsg.m_aSkinPartColors[p] = pPlayer->m_TeeInfos.m_aSkinPartColors[p];
 			}
 
-			Server()->SendPackMsg(&ClientInfoMsg, MSGFLAG_VITAL | MSGFLAG_NORECORD, ClientID);
+			Server()->SendPackMsg(&ClientInfoMsg, MSGFLAG_VITAL | MSGFLAG_NORECORD, ClientId);
 		}
 	}
 
 	// local info
-	if(Server()->IsSixup(ClientID))
+	if(Server()->IsSixup(ClientId))
 	{
 		NewClientInfoMsg.m_Local = 1;
-		Server()->SendPackMsg(&NewClientInfoMsg, MSGFLAG_VITAL | MSGFLAG_NORECORD, ClientID);
+		Server()->SendPackMsg(&NewClientInfoMsg, MSGFLAG_VITAL | MSGFLAG_NORECORD, ClientId);
 	}
 
 	// initial chat delay
-	if(g_Config.m_SvChatInitialDelay != 0 && m_apPlayers[ClientID]->m_JoinTick > m_NonEmptySince + 10 * Server()->TickSpeed())
+	if(g_Config.m_SvChatInitialDelay != 0 && m_apPlayers[ClientId]->m_JoinTick > m_NonEmptySince + 10 * Server()->TickSpeed())
 	{
 		char aBuf[128];
 		NETADDR Addr;
-		Server()->GetClientAddr(ClientID, &Addr);
+		Server()->GetClientAddr(ClientId, &Addr);
 		str_format(aBuf, sizeof(aBuf), "This server has an initial chat delay, you will need to wait %d seconds before talking.", g_Config.m_SvChatInitialDelay);
-		SendChatTarget(ClientID, aBuf);
-		Mute(&Addr, g_Config.m_SvChatInitialDelay, Server()->ClientName(ClientID), "Initial chat delay", true);
+		SendChatTarget(ClientId, aBuf);
+		Mute(&Addr, g_Config.m_SvChatInitialDelay, Server()->ClientName(ClientId), "Initial chat delay", true);
 	}
 
-	LogEvent("Connect", ClientID);
+	LogEvent("Connect", ClientId);
 }
 
-bool CGameContext::OnClientDataPersist(int ClientID, void *pData)
+bool CGameContext::OnClientDataPersist(int ClientId, void *pData)
 {
 	CPersistentClientData *pPersistent = (CPersistentClientData *)pData;
-	if(!m_apPlayers[ClientID])
+	if(!m_apPlayers[ClientId])
 	{
 		return false;
 	}
-	pPersistent->m_IsSpectator = m_apPlayers[ClientID]->GetTeam() == TEAM_SPECTATORS;
-	pPersistent->m_IsAfk = m_apPlayers[ClientID]->IsAfk();
+	pPersistent->m_IsSpectator = m_apPlayers[ClientId]->GetTeam() == TEAM_SPECTATORS;
+	pPersistent->m_IsAfk = m_apPlayers[ClientId]->IsAfk();
 	return true;
 }
 
-void CGameContext::OnClientConnected(int ClientID, void *pData)
+void CGameContext::OnClientConnected(int ClientId, void *pData)
 {
 	CPersistentClientData *pPersistentData = (CPersistentClientData *)pData;
 	bool Spec = false;
@@ -1667,7 +1667,7 @@ void CGameContext::OnClientConnected(int ClientID, void *pData)
 		for(auto &pPlayer : m_apPlayers)
 		{
 			// connecting clients with spoofed ips can clog slots without being ingame
-			if(pPlayer && Server()->ClientIngame(pPlayer->GetCID()))
+			if(pPlayer && Server()->ClientIngame(pPlayer->GetCid()))
 			{
 				Empty = false;
 				break;
@@ -1680,47 +1680,47 @@ void CGameContext::OnClientConnected(int ClientID, void *pData)
 	}
 
 	// Check which team the player should be on
-	const int StartTeam = (Spec || g_Config.m_SvTournamentMode) ? TEAM_SPECTATORS : m_pController->GetAutoTeam(ClientID);
+	const int StartTeam = (Spec || g_Config.m_SvTournamentMode) ? TEAM_SPECTATORS : m_pController->GetAutoTeam(ClientId);
 
-	if(m_apPlayers[ClientID])
-		delete m_apPlayers[ClientID];
-	m_apPlayers[ClientID] = new(ClientID) CPlayer(this, NextUniqueClientID, ClientID, StartTeam);
-	m_apPlayers[ClientID]->SetInitialAfk(Afk);
-	NextUniqueClientID += 1;
+	if(m_apPlayers[ClientId])
+		delete m_apPlayers[ClientId];
+	m_apPlayers[ClientId] = new(ClientId) CPlayer(this, NextUniqueClientId, ClientId, StartTeam);
+	m_apPlayers[ClientId]->SetInitialAfk(Afk);
+	NextUniqueClientId += 1;
 
-	SendMotd(ClientID);
-	SendSettings(ClientID);
+	SendMotd(ClientId);
+	SendSettings(ClientId);
 
 	Server()->ExpireServerInfo();
 }
 
-void CGameContext::OnClientDrop(int ClientID, const char *pReason)
+void CGameContext::OnClientDrop(int ClientId, const char *pReason)
 {
-	LogEvent("Disconnect", ClientID);
+	LogEvent("Disconnect", ClientId);
 
-	AbortVoteKickOnDisconnect(ClientID);
-	m_pController->OnPlayerDisconnect(m_apPlayers[ClientID], pReason);
-	delete m_apPlayers[ClientID];
-	m_apPlayers[ClientID] = 0;
+	AbortVoteKickOnDisconnect(ClientId);
+	m_pController->OnPlayerDisconnect(m_apPlayers[ClientId], pReason);
+	delete m_apPlayers[ClientId];
+	m_apPlayers[ClientId] = 0;
 
 	m_VoteUpdate = true;
 
 	// update spectator modes
 	for(auto &pPlayer : m_apPlayers)
 	{
-		if(pPlayer && pPlayer->m_SpectatorID == ClientID)
-			pPlayer->m_SpectatorID = SPEC_FREEVIEW;
+		if(pPlayer && pPlayer->m_SpectatorId == ClientId)
+			pPlayer->m_SpectatorId = SPEC_FREEVIEW;
 	}
 
 	// update conversation targets
 	for(auto &pPlayer : m_apPlayers)
 	{
-		if(pPlayer && pPlayer->m_LastWhisperTo == ClientID)
+		if(pPlayer && pPlayer->m_LastWhisperTo == ClientId)
 			pPlayer->m_LastWhisperTo = -1;
 	}
 
 	protocol7::CNetMsg_Sv_ClientDrop Msg;
-	Msg.m_ClientID = ClientID;
+	Msg.m_ClientId = ClientId;
 	Msg.m_pReason = pReason;
 	Msg.m_Silent = false;
 	Server()->SendPackMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_NORECORD, -1);
@@ -1736,92 +1736,92 @@ void CGameContext::TeehistorianRecordAntibot(const void *pData, int DataSize)
 	}
 }
 
-void CGameContext::TeehistorianRecordPlayerJoin(int ClientID, bool Sixup)
+void CGameContext::TeehistorianRecordPlayerJoin(int ClientId, bool Sixup)
 {
 	if(m_TeeHistorianActive)
 	{
-		m_TeeHistorian.RecordPlayerJoin(ClientID, !Sixup ? CTeeHistorian::PROTOCOL_6 : CTeeHistorian::PROTOCOL_7);
+		m_TeeHistorian.RecordPlayerJoin(ClientId, !Sixup ? CTeeHistorian::PROTOCOL_6 : CTeeHistorian::PROTOCOL_7);
 	}
 }
 
-void CGameContext::TeehistorianRecordPlayerDrop(int ClientID, const char *pReason)
+void CGameContext::TeehistorianRecordPlayerDrop(int ClientId, const char *pReason)
 {
 	if(m_TeeHistorianActive)
 	{
-		m_TeeHistorian.RecordPlayerDrop(ClientID, pReason);
+		m_TeeHistorian.RecordPlayerDrop(ClientId, pReason);
 	}
 }
 
-void CGameContext::TeehistorianRecordPlayerRejoin(int ClientID)
+void CGameContext::TeehistorianRecordPlayerRejoin(int ClientId)
 {
 	if(m_TeeHistorianActive)
 	{
-		m_TeeHistorian.RecordPlayerRejoin(ClientID);
+		m_TeeHistorian.RecordPlayerRejoin(ClientId);
 	}
 }
 
-bool CGameContext::OnClientDDNetVersionKnown(int ClientID)
+bool CGameContext::OnClientDDNetVersionKnown(int ClientId)
 {
 	IServer::CClientInfo Info;
-	dbg_assert(Server()->GetClientInfo(ClientID, &Info), "failed to get client info");
+	dbg_assert(Server()->GetClientInfo(ClientId, &Info), "failed to get client info");
 	int ClientVersion = Info.m_DDNetVersion;
-	dbg_msg("ddnet", "cid=%d version=%d", ClientID, ClientVersion);
+	dbg_msg("ddnet", "cid=%d version=%d", ClientId, ClientVersion);
 
 	if(m_TeeHistorianActive)
 	{
-		if(Info.m_pConnectionID && Info.m_pDDNetVersionStr)
+		if(Info.m_pConnectionId && Info.m_pDDNetVersionStr)
 		{
-			m_TeeHistorian.RecordDDNetVersion(ClientID, *Info.m_pConnectionID, ClientVersion, Info.m_pDDNetVersionStr);
+			m_TeeHistorian.RecordDDNetVersion(ClientId, *Info.m_pConnectionId, ClientVersion, Info.m_pDDNetVersionStr);
 		}
 		else
 		{
-			m_TeeHistorian.RecordDDNetVersionOld(ClientID, ClientVersion);
+			m_TeeHistorian.RecordDDNetVersionOld(ClientId, ClientVersion);
 		}
 	}
 
 	// Autoban known bot versions.
 	if(g_Config.m_SvBannedVersions[0] != '\0' && IsVersionBanned(ClientVersion))
 	{
-		Server()->Kick(ClientID, "unsupported client");
+		Server()->Kick(ClientId, "unsupported client");
 		return true;
 	}
 
-	CPlayer *pPlayer = m_apPlayers[ClientID];
+	CPlayer *pPlayer = m_apPlayers[ClientId];
 	if(ClientVersion >= VERSION_DDNET_GAMETICK)
 		pPlayer->m_TimerType = g_Config.m_SvDefaultTimerType;
 
 	// First update the teams state.
-	m_pController->Teams().SendTeamsState(ClientID);
+	m_pController->Teams().SendTeamsState(ClientId);
 
 	// Then send records.
-	SendRecord(ClientID);
+	SendRecord(ClientId);
 
 	// And report correct tunings.
 	if(ClientVersion < VERSION_DDNET_EARLY_VERSION)
-		SendTuningParams(ClientID, pPlayer->m_TuneZone);
+		SendTuningParams(ClientId, pPlayer->m_TuneZone);
 
 	// Tell old clients to update.
 	if(ClientVersion < VERSION_DDNET_UPDATER_FIXED && g_Config.m_SvClientSuggestionOld[0] != '\0')
-		SendBroadcast(g_Config.m_SvClientSuggestionOld, ClientID);
+		SendBroadcast(g_Config.m_SvClientSuggestionOld, ClientId);
 	// Tell known bot clients that they're botting and we know it.
 	if(((ClientVersion >= 15 && ClientVersion < 100) || ClientVersion == 502) && g_Config.m_SvClientSuggestionBot[0] != '\0')
-		SendBroadcast(g_Config.m_SvClientSuggestionBot, ClientID);
+		SendBroadcast(g_Config.m_SvClientSuggestionBot, ClientId);
 
 	return false;
 }
 
-void *CGameContext::PreProcessMsg(int *pMsgID, CUnpacker *pUnpacker, int ClientID)
+void *CGameContext::PreProcessMsg(int *pMsgId, CUnpacker *pUnpacker, int ClientId)
 {
-	if(Server()->IsSixup(ClientID) && *pMsgID < OFFSET_UUID)
+	if(Server()->IsSixup(ClientId) && *pMsgId < OFFSET_UUID)
 	{
-		void *pRawMsg = m_NetObjHandler7.SecureUnpackMsg(*pMsgID, pUnpacker);
+		void *pRawMsg = m_NetObjHandler7.SecureUnpackMsg(*pMsgId, pUnpacker);
 		if(!pRawMsg)
 			return 0;
 
-		CPlayer *pPlayer = m_apPlayers[ClientID];
+		CPlayer *pPlayer = m_apPlayers[ClientId];
 		static char s_aRawMsg[1024];
 
-		if(*pMsgID == protocol7::NETMSGTYPE_CL_SAY)
+		if(*pMsgId == protocol7::NETMSGTYPE_CL_SAY)
 		{
 			protocol7::CNetMsg_Cl_Say *pMsg7 = (protocol7::CNetMsg_Cl_Say *)pRawMsg;
 			// Should probably use a placement new to start the lifetime of the object to avoid future weirdness
@@ -1829,18 +1829,18 @@ void *CGameContext::PreProcessMsg(int *pMsgID, CUnpacker *pUnpacker, int ClientI
 
 			if(pMsg7->m_Target >= 0)
 			{
-				if(ProcessSpamProtection(ClientID))
+				if(ProcessSpamProtection(ClientId))
 					return 0;
 
 				// Should we maybe recraft the message so that it can go through the usual path?
-				WhisperID(ClientID, pMsg7->m_Target, pMsg7->m_pMessage);
+				WhisperId(ClientId, pMsg7->m_Target, pMsg7->m_pMessage);
 				return 0;
 			}
 
 			pMsg->m_Team = pMsg7->m_Mode == protocol7::CHAT_TEAM;
 			pMsg->m_pMessage = pMsg7->m_pMessage;
 		}
-		else if(*pMsgID == protocol7::NETMSGTYPE_CL_STARTINFO)
+		else if(*pMsgId == protocol7::NETMSGTYPE_CL_STARTINFO)
 		{
 			protocol7::CNetMsg_Cl_StartInfo *pMsg7 = (protocol7::CNetMsg_Cl_StartInfo *)pRawMsg;
 			::CNetMsg_Cl_StartInfo *pMsg = (::CNetMsg_Cl_StartInfo *)s_aRawMsg;
@@ -1860,7 +1860,7 @@ void *CGameContext::PreProcessMsg(int *pMsgID, CUnpacker *pUnpacker, int ClientI
 			pMsg->m_ColorBody = pPlayer->m_TeeInfos.m_ColorBody;
 			pMsg->m_ColorFeet = pPlayer->m_TeeInfos.m_ColorFeet;
 		}
-		else if(*pMsgID == protocol7::NETMSGTYPE_CL_SKINCHANGE)
+		else if(*pMsgId == protocol7::NETMSGTYPE_CL_SKINCHANGE)
 		{
 			protocol7::CNetMsg_Cl_SkinChange *pMsg = (protocol7::CNetMsg_Cl_SkinChange *)pRawMsg;
 			if(g_Config.m_SvSpamprotection && pPlayer->m_LastChangeInfo &&
@@ -1874,7 +1874,7 @@ void *CGameContext::PreProcessMsg(int *pMsgID, CUnpacker *pUnpacker, int ClientI
 			pPlayer->m_TeeInfos = Info;
 
 			protocol7::CNetMsg_Sv_SkinChange Msg;
-			Msg.m_ClientID = ClientID;
+			Msg.m_ClientId = ClientId;
 			for(int p = 0; p < 6; p++)
 			{
 				Msg.m_apSkinPartNames[p] = pMsg->m_apSkinPartNames[p];
@@ -1886,26 +1886,26 @@ void *CGameContext::PreProcessMsg(int *pMsgID, CUnpacker *pUnpacker, int ClientI
 
 			return 0;
 		}
-		else if(*pMsgID == protocol7::NETMSGTYPE_CL_SETSPECTATORMODE)
+		else if(*pMsgId == protocol7::NETMSGTYPE_CL_SETSPECTATORMODE)
 		{
 			protocol7::CNetMsg_Cl_SetSpectatorMode *pMsg7 = (protocol7::CNetMsg_Cl_SetSpectatorMode *)pRawMsg;
 			::CNetMsg_Cl_SetSpectatorMode *pMsg = (::CNetMsg_Cl_SetSpectatorMode *)s_aRawMsg;
 
 			if(pMsg7->m_SpecMode == protocol7::SPEC_FREEVIEW)
-				pMsg->m_SpectatorID = SPEC_FREEVIEW;
+				pMsg->m_SpectatorId = SPEC_FREEVIEW;
 			else if(pMsg7->m_SpecMode == protocol7::SPEC_PLAYER)
-				pMsg->m_SpectatorID = pMsg7->m_SpectatorID;
+				pMsg->m_SpectatorId = pMsg7->m_SpectatorId;
 			else
-				pMsg->m_SpectatorID = SPEC_FREEVIEW; // Probably not needed
+				pMsg->m_SpectatorId = SPEC_FREEVIEW; // Probably not needed
 		}
-		else if(*pMsgID == protocol7::NETMSGTYPE_CL_SETTEAM)
+		else if(*pMsgId == protocol7::NETMSGTYPE_CL_SETTEAM)
 		{
 			protocol7::CNetMsg_Cl_SetTeam *pMsg7 = (protocol7::CNetMsg_Cl_SetTeam *)pRawMsg;
 			::CNetMsg_Cl_SetTeam *pMsg = (::CNetMsg_Cl_SetTeam *)s_aRawMsg;
 
 			pMsg->m_Team = pMsg7->m_Team;
 		}
-		else if(*pMsgID == protocol7::NETMSGTYPE_CL_COMMAND)
+		else if(*pMsgId == protocol7::NETMSGTYPE_CL_COMMAND)
 		{
 			protocol7::CNetMsg_Cl_Command *pMsg7 = (protocol7::CNetMsg_Cl_Command *)pRawMsg;
 			::CNetMsg_Cl_Say *pMsg = (::CNetMsg_Cl_Say *)s_aRawMsg;
@@ -1915,20 +1915,20 @@ void *CGameContext::PreProcessMsg(int *pMsgID, CUnpacker *pUnpacker, int ClientI
 			dbg_msg("debug", "line='%s'", s_aRawMsg + sizeof(*pMsg));
 			pMsg->m_Team = 0;
 
-			*pMsgID = NETMSGTYPE_CL_SAY;
+			*pMsgId = NETMSGTYPE_CL_SAY;
 			return s_aRawMsg;
 		}
-		else if(*pMsgID == protocol7::NETMSGTYPE_CL_CALLVOTE)
+		else if(*pMsgId == protocol7::NETMSGTYPE_CL_CALLVOTE)
 		{
 			protocol7::CNetMsg_Cl_CallVote *pMsg7 = (protocol7::CNetMsg_Cl_CallVote *)pRawMsg;
 			::CNetMsg_Cl_CallVote *pMsg = (::CNetMsg_Cl_CallVote *)s_aRawMsg;
 
-			int Authed = Server()->GetAuthedState(ClientID);
+			int Authed = Server()->GetAuthedState(ClientId);
 			if(pMsg7->m_Force)
 			{
 				str_format(s_aRawMsg, sizeof(s_aRawMsg), "force_vote \"%s\" \"%s\" \"%s\"", pMsg7->m_pType, pMsg7->m_pValue, pMsg7->m_pReason);
 				Console()->SetAccessLevel(Authed == AUTHED_ADMIN ? IConsole::ACCESS_LEVEL_ADMIN : Authed == AUTHED_MOD ? IConsole::ACCESS_LEVEL_MOD : IConsole::ACCESS_LEVEL_HELPER);
-				Console()->ExecuteLine(s_aRawMsg, ClientID, false);
+				Console()->ExecuteLine(s_aRawMsg, ClientId, false);
 				Console()->SetAccessLevel(IConsole::ACCESS_LEVEL_ADMIN);
 				return 0;
 			}
@@ -1937,14 +1937,14 @@ void *CGameContext::PreProcessMsg(int *pMsgID, CUnpacker *pUnpacker, int ClientI
 			pMsg->m_pReason = pMsg7->m_pReason;
 			pMsg->m_pType = pMsg7->m_pType;
 		}
-		else if(*pMsgID == protocol7::NETMSGTYPE_CL_EMOTICON)
+		else if(*pMsgId == protocol7::NETMSGTYPE_CL_EMOTICON)
 		{
 			protocol7::CNetMsg_Cl_Emoticon *pMsg7 = (protocol7::CNetMsg_Cl_Emoticon *)pRawMsg;
 			::CNetMsg_Cl_Emoticon *pMsg = (::CNetMsg_Cl_Emoticon *)s_aRawMsg;
 
 			pMsg->m_Emoticon = pMsg7->m_Emoticon;
 		}
-		else if(*pMsgID == protocol7::NETMSGTYPE_CL_VOTE)
+		else if(*pMsgId == protocol7::NETMSGTYPE_CL_VOTE)
 		{
 			protocol7::CNetMsg_Cl_Vote *pMsg7 = (protocol7::CNetMsg_Cl_Vote *)pRawMsg;
 			::CNetMsg_Cl_Vote *pMsg = (::CNetMsg_Cl_Vote *)s_aRawMsg;
@@ -1952,12 +1952,12 @@ void *CGameContext::PreProcessMsg(int *pMsgID, CUnpacker *pUnpacker, int ClientI
 			pMsg->m_Vote = pMsg7->m_Vote;
 		}
 
-		*pMsgID = Msg_SevenToSix(*pMsgID);
+		*pMsgId = Msg_SevenToSix(*pMsgId);
 
 		return s_aRawMsg;
 	}
 	else
-		return m_NetObjHandler.SecureUnpackMsg(*pMsgID, pUnpacker);
+		return m_NetObjHandler.SecureUnpackMsg(*pMsgId, pUnpacker);
 }
 
 void CGameContext::CensorMessage(char *pCensoredMessage, const char *pMessage, int Size)
@@ -1982,84 +1982,84 @@ void CGameContext::CensorMessage(char *pCensoredMessage, const char *pMessage, i
 	}
 }
 
-void CGameContext::OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID)
+void CGameContext::OnMessage(int MsgId, CUnpacker *pUnpacker, int ClientId)
 {
 	if(m_TeeHistorianActive)
 	{
-		if(m_NetObjHandler.TeeHistorianRecordMsg(MsgID))
+		if(m_NetObjHandler.TeeHistorianRecordMsg(MsgId))
 		{
-			m_TeeHistorian.RecordPlayerMessage(ClientID, pUnpacker->CompleteData(), pUnpacker->CompleteSize());
+			m_TeeHistorian.RecordPlayerMessage(ClientId, pUnpacker->CompleteData(), pUnpacker->CompleteSize());
 		}
 	}
 
-	void *pRawMsg = PreProcessMsg(&MsgID, pUnpacker, ClientID);
+	void *pRawMsg = PreProcessMsg(&MsgId, pUnpacker, ClientId);
 
 	if(!pRawMsg)
 		return;
 
-	if(Server()->ClientIngame(ClientID))
+	if(Server()->ClientIngame(ClientId))
 	{
-		switch(MsgID)
+		switch(MsgId)
 		{
 		case NETMSGTYPE_CL_SAY:
-			OnSayNetMessage(static_cast<CNetMsg_Cl_Say *>(pRawMsg), ClientID, pUnpacker);
+			OnSayNetMessage(static_cast<CNetMsg_Cl_Say *>(pRawMsg), ClientId, pUnpacker);
 			break;
 		case NETMSGTYPE_CL_CALLVOTE:
-			OnCallVoteNetMessage(static_cast<CNetMsg_Cl_CallVote *>(pRawMsg), ClientID);
+			OnCallVoteNetMessage(static_cast<CNetMsg_Cl_CallVote *>(pRawMsg), ClientId);
 			break;
 		case NETMSGTYPE_CL_VOTE:
-			OnVoteNetMessage(static_cast<CNetMsg_Cl_Vote *>(pRawMsg), ClientID);
+			OnVoteNetMessage(static_cast<CNetMsg_Cl_Vote *>(pRawMsg), ClientId);
 			break;
 		case NETMSGTYPE_CL_SETTEAM:
-			OnSetTeamNetMessage(static_cast<CNetMsg_Cl_SetTeam *>(pRawMsg), ClientID);
+			OnSetTeamNetMessage(static_cast<CNetMsg_Cl_SetTeam *>(pRawMsg), ClientId);
 			break;
 		case NETMSGTYPE_CL_ISDDNETLEGACY:
-			OnIsDDNetLegacyNetMessage(static_cast<CNetMsg_Cl_IsDDNetLegacy *>(pRawMsg), ClientID, pUnpacker);
+			OnIsDDNetLegacyNetMessage(static_cast<CNetMsg_Cl_IsDDNetLegacy *>(pRawMsg), ClientId, pUnpacker);
 			break;
 		case NETMSGTYPE_CL_SHOWOTHERSLEGACY:
-			OnShowOthersLegacyNetMessage(static_cast<CNetMsg_Cl_ShowOthersLegacy *>(pRawMsg), ClientID);
+			OnShowOthersLegacyNetMessage(static_cast<CNetMsg_Cl_ShowOthersLegacy *>(pRawMsg), ClientId);
 			break;
 		case NETMSGTYPE_CL_SHOWOTHERS:
-			OnShowOthersNetMessage(static_cast<CNetMsg_Cl_ShowOthers *>(pRawMsg), ClientID);
+			OnShowOthersNetMessage(static_cast<CNetMsg_Cl_ShowOthers *>(pRawMsg), ClientId);
 			break;
 		case NETMSGTYPE_CL_SHOWDISTANCE:
-			OnShowDistanceNetMessage(static_cast<CNetMsg_Cl_ShowDistance *>(pRawMsg), ClientID);
+			OnShowDistanceNetMessage(static_cast<CNetMsg_Cl_ShowDistance *>(pRawMsg), ClientId);
 			break;
 		case NETMSGTYPE_CL_SETSPECTATORMODE:
-			OnSetSpectatorModeNetMessage(static_cast<CNetMsg_Cl_SetSpectatorMode *>(pRawMsg), ClientID);
+			OnSetSpectatorModeNetMessage(static_cast<CNetMsg_Cl_SetSpectatorMode *>(pRawMsg), ClientId);
 			break;
 		case NETMSGTYPE_CL_CHANGEINFO:
-			OnChangeInfoNetMessage(static_cast<CNetMsg_Cl_ChangeInfo *>(pRawMsg), ClientID);
+			OnChangeInfoNetMessage(static_cast<CNetMsg_Cl_ChangeInfo *>(pRawMsg), ClientId);
 			break;
 		case NETMSGTYPE_CL_EMOTICON:
-			OnEmoticonNetMessage(static_cast<CNetMsg_Cl_Emoticon *>(pRawMsg), ClientID);
+			OnEmoticonNetMessage(static_cast<CNetMsg_Cl_Emoticon *>(pRawMsg), ClientId);
 			break;
 		case NETMSGTYPE_CL_KILL:
-			OnKillNetMessage(static_cast<CNetMsg_Cl_Kill *>(pRawMsg), ClientID);
+			OnKillNetMessage(static_cast<CNetMsg_Cl_Kill *>(pRawMsg), ClientId);
 			break;
 		default:
 			break;
 		}
 	}
-	if(MsgID == NETMSGTYPE_CL_STARTINFO)
+	if(MsgId == NETMSGTYPE_CL_STARTINFO)
 	{
-		OnStartInfoNetMessage(static_cast<CNetMsg_Cl_StartInfo *>(pRawMsg), ClientID);
+		OnStartInfoNetMessage(static_cast<CNetMsg_Cl_StartInfo *>(pRawMsg), ClientId);
 	}
 }
 
-void CGameContext::OnSayNetMessage(const CNetMsg_Cl_Say *pMsg, int ClientID, const CUnpacker *pUnpacker)
+void CGameContext::OnSayNetMessage(const CNetMsg_Cl_Say *pMsg, int ClientId, const CUnpacker *pUnpacker)
 {
-	CPlayer *pPlayer = m_apPlayers[ClientID];
+	CPlayer *pPlayer = m_apPlayers[ClientId];
 	bool Check = !pPlayer->m_NotEligibleForFinish && pPlayer->m_EligibleForFinishCheck + 10 * time_freq() >= time_get();
 	if(Check && str_comp(pMsg->m_pMessage, "xd sure chillerbot.png is lyfe") == 0 && pMsg->m_Team == 0)
 	{
 		if(m_TeeHistorianActive)
 		{
-			m_TeeHistorian.RecordPlayerMessage(ClientID, pUnpacker->CompleteData(), pUnpacker->CompleteSize());
+			m_TeeHistorian.RecordPlayerMessage(ClientId, pUnpacker->CompleteData(), pUnpacker->CompleteSize());
 		}
 
 		pPlayer->m_NotEligibleForFinish = true;
-		dbg_msg("hack", "bot detected, cid=%d", ClientID);
+		dbg_msg("hack", "bot detected, cid=%d", ClientId);
 		return;
 	}
 	int Team = pMsg->m_Team;
@@ -2094,7 +2094,7 @@ void CGameContext::OnSayNetMessage(const CNetMsg_Cl_Say *pMsg, int ClientID, con
 	if(Length == 0 || (pMsg->m_pMessage[0] != '/' && (g_Config.m_SvSpamprotection && pPlayer->m_LastChat && pPlayer->m_LastChat + Server()->TickSpeed() * ((31 + Length) / 32) > Server()->Tick())))
 		return;
 
-	int GameTeam = GetDDRaceTeam(pPlayer->GetCID());
+	int GameTeam = GetDDRaceTeam(pPlayer->GetCid());
 	if(Team)
 		Team = ((pPlayer->GetTeam() == TEAM_SPECTATORS) ? CHAT_SPEC : GameTeam);
 	else
@@ -2106,25 +2106,25 @@ void CGameContext::OnSayNetMessage(const CNetMsg_Cl_Say *pMsg, int ClientID, con
 		{
 			char aWhisperMsg[256];
 			str_copy(aWhisperMsg, pMsg->m_pMessage + 3, 256);
-			Whisper(pPlayer->GetCID(), aWhisperMsg);
+			Whisper(pPlayer->GetCid(), aWhisperMsg);
 		}
 		else if(str_startswith_nocase(pMsg->m_pMessage + 1, "whisper "))
 		{
 			char aWhisperMsg[256];
 			str_copy(aWhisperMsg, pMsg->m_pMessage + 9, 256);
-			Whisper(pPlayer->GetCID(), aWhisperMsg);
+			Whisper(pPlayer->GetCid(), aWhisperMsg);
 		}
 		else if(str_startswith_nocase(pMsg->m_pMessage + 1, "c "))
 		{
 			char aWhisperMsg[256];
 			str_copy(aWhisperMsg, pMsg->m_pMessage + 3, 256);
-			Converse(pPlayer->GetCID(), aWhisperMsg);
+			Converse(pPlayer->GetCid(), aWhisperMsg);
 		}
 		else if(str_startswith_nocase(pMsg->m_pMessage + 1, "converse "))
 		{
 			char aWhisperMsg[256];
 			str_copy(aWhisperMsg, pMsg->m_pMessage + 10, 256);
-			Converse(pPlayer->GetCID(), aWhisperMsg);
+			Converse(pPlayer->GetCid(), aWhisperMsg);
 		}
 		else
 		{
@@ -2136,21 +2136,21 @@ void CGameContext::OnSayNetMessage(const CNetMsg_Cl_Say *pMsg, int ClientID, con
 			pPlayer->m_LastCommandPos = (pPlayer->m_LastCommandPos + 1) % 4;
 
 			Console()->SetFlagMask(CFGFLAG_CHAT);
-			int Authed = Server()->GetAuthedState(ClientID);
+			int Authed = Server()->GetAuthedState(ClientId);
 			if(Authed)
 				Console()->SetAccessLevel(Authed == AUTHED_ADMIN ? IConsole::ACCESS_LEVEL_ADMIN : Authed == AUTHED_MOD ? IConsole::ACCESS_LEVEL_MOD : IConsole::ACCESS_LEVEL_HELPER);
 			else
 				Console()->SetAccessLevel(IConsole::ACCESS_LEVEL_USER);
 
 			{
-				CClientChatLogger Logger(this, ClientID, log_get_scope_logger());
+				CClientChatLogger Logger(this, ClientId, log_get_scope_logger());
 				CLogScope Scope(&Logger);
-				Console()->ExecuteLine(pMsg->m_pMessage + 1, ClientID, false);
+				Console()->ExecuteLine(pMsg->m_pMessage + 1, ClientId, false);
 			}
-			// m_apPlayers[ClientID] can be NULL, if the player used a
+			// m_apPlayers[ClientId] can be NULL, if the player used a
 			// timeout code and replaced another client.
 			char aBuf[256];
-			str_format(aBuf, sizeof(aBuf), "%d used %s", ClientID, pMsg->m_pMessage);
+			str_format(aBuf, sizeof(aBuf), "%d used %s", ClientId, pMsg->m_pMessage);
 			Console()->Print(IConsole::OUTPUT_LEVEL_DEBUG, "chat-command", aBuf);
 
 			Console()->SetAccessLevel(IConsole::ACCESS_LEVEL_ADMIN);
@@ -2162,16 +2162,16 @@ void CGameContext::OnSayNetMessage(const CNetMsg_Cl_Say *pMsg, int ClientID, con
 		pPlayer->UpdatePlaytime();
 		char aCensoredMessage[256];
 		CensorMessage(aCensoredMessage, pMsg->m_pMessage, sizeof(aCensoredMessage));
-		SendChat(ClientID, Team, aCensoredMessage, ClientID);
+		SendChat(ClientId, Team, aCensoredMessage, ClientId);
 	}
 }
 
-void CGameContext::OnCallVoteNetMessage(const CNetMsg_Cl_CallVote *pMsg, int ClientID)
+void CGameContext::OnCallVoteNetMessage(const CNetMsg_Cl_CallVote *pMsg, int ClientId)
 {
-	if(RateLimitPlayerVote(ClientID) || m_VoteCloseTime)
+	if(RateLimitPlayerVote(ClientId) || m_VoteCloseTime)
 		return;
 
-	m_apPlayers[ClientID]->UpdatePlaytime();
+	m_apPlayers[ClientId]->UpdatePlaytime();
 
 	m_VoteType = VOTE_TYPE_UNKNOWN;
 	char aChatmsg[512] = {0};
@@ -2186,7 +2186,7 @@ void CGameContext::OnCallVoteNetMessage(const CNetMsg_Cl_CallVote *pMsg, int Cli
 
 	if(str_comp_nocase(pMsg->m_pType, "option") == 0)
 	{
-		int Authed = Server()->GetAuthedState(ClientID);
+		int Authed = Server()->GetAuthedState(ClientId);
 		CVoteOptionServer *pOption = m_pVoteOptionFirst;
 		while(pOption)
 		{
@@ -2194,15 +2194,15 @@ void CGameContext::OnCallVoteNetMessage(const CNetMsg_Cl_CallVote *pMsg, int Cli
 			{
 				if(!Console()->LineIsValid(pOption->m_aCommand))
 				{
-					SendChatTarget(ClientID, "Invalid option");
+					SendChatTarget(ClientId, "Invalid option");
 					return;
 				}
-				if((str_find(pOption->m_aCommand, "sv_map ") != 0 || str_find(pOption->m_aCommand, "change_map ") != 0 || str_find(pOption->m_aCommand, "random_map") != 0 || str_find(pOption->m_aCommand, "random_unfinished_map") != 0) && RateLimitPlayerMapVote(ClientID))
+				if((str_find(pOption->m_aCommand, "sv_map ") != 0 || str_find(pOption->m_aCommand, "change_map ") != 0 || str_find(pOption->m_aCommand, "random_map") != 0 || str_find(pOption->m_aCommand, "random_unfinished_map") != 0) && RateLimitPlayerMapVote(ClientId))
 				{
 					return;
 				}
 
-				str_format(aChatmsg, sizeof(aChatmsg), "'%s' called vote to change server option '%s' (%s)", Server()->ClientName(ClientID),
+				str_format(aChatmsg, sizeof(aChatmsg), "'%s' called vote to change server option '%s' (%s)", Server()->ClientName(ClientId),
 					pOption->m_aDescription, aReason);
 				str_copy(aDesc, pOption->m_aDescription);
 
@@ -2228,12 +2228,12 @@ void CGameContext::OnCallVoteNetMessage(const CNetMsg_Cl_CallVote *pMsg, int Cli
 			if(Authed != AUTHED_ADMIN) // allow admins to call any vote they want
 			{
 				str_format(aChatmsg, sizeof(aChatmsg), "'%s' isn't an option on this server", pMsg->m_pValue);
-				SendChatTarget(ClientID, aChatmsg);
+				SendChatTarget(ClientId, aChatmsg);
 				return;
 			}
 			else
 			{
-				str_format(aChatmsg, sizeof(aChatmsg), "'%s' called vote to change server option '%s'", Server()->ClientName(ClientID), pMsg->m_pValue);
+				str_format(aChatmsg, sizeof(aChatmsg), "'%s' called vote to change server option '%s'", Server()->ClientName(ClientId), pMsg->m_pValue);
 				str_copy(aDesc, pMsg->m_pValue);
 				str_copy(aCmd, pMsg->m_pValue);
 			}
@@ -2243,23 +2243,23 @@ void CGameContext::OnCallVoteNetMessage(const CNetMsg_Cl_CallVote *pMsg, int Cli
 	}
 	else if(str_comp_nocase(pMsg->m_pType, "kick") == 0)
 	{
-		int Authed = Server()->GetAuthedState(ClientID);
+		int Authed = Server()->GetAuthedState(ClientId);
 
 		if(!g_Config.m_SvVoteKick && !Authed) // allow admins to call kick votes even if they are forbidden
 		{
-			SendChatTarget(ClientID, "Server does not allow voting to kick players");
+			SendChatTarget(ClientId, "Server does not allow voting to kick players");
 			return;
 		}
-		if(!Authed && time_get() < m_apPlayers[ClientID]->m_Last_KickVote + (time_freq() * g_Config.m_SvVoteKickDelay))
+		if(!Authed && time_get() < m_apPlayers[ClientId]->m_Last_KickVote + (time_freq() * g_Config.m_SvVoteKickDelay))
 		{
 			str_format(aChatmsg, sizeof(aChatmsg), "There's a %d second wait time between kick votes for each player please wait %d second(s)",
 				g_Config.m_SvVoteKickDelay,
-				(int)((m_apPlayers[ClientID]->m_Last_KickVote + g_Config.m_SvVoteKickDelay * time_freq() - time_get()) / time_freq()));
-			SendChatTarget(ClientID, aChatmsg);
+				(int)((m_apPlayers[ClientId]->m_Last_KickVote + g_Config.m_SvVoteKickDelay * time_freq() - time_get()) / time_freq()));
+			SendChatTarget(ClientId, aChatmsg);
 			return;
 		}
 
-		if(g_Config.m_SvVoteKickMin && !GetDDRaceTeam(ClientID))
+		if(g_Config.m_SvVoteKickMin && !GetDDRaceTeam(ClientId))
 		{
 			char aaAddresses[MAX_CLIENTS][NETADDR_MAXSTRSIZE] = {{0}};
 			for(int i = 0; i < MAX_CLIENTS; i++)
@@ -2292,128 +2292,128 @@ void CGameContext::OnCallVoteNetMessage(const CNetMsg_Cl_CallVote *pMsg, int Cli
 			if(NumPlayers < g_Config.m_SvVoteKickMin)
 			{
 				str_format(aChatmsg, sizeof(aChatmsg), "Kick voting requires %d players", g_Config.m_SvVoteKickMin);
-				SendChatTarget(ClientID, aChatmsg);
+				SendChatTarget(ClientId, aChatmsg);
 				return;
 			}
 		}
 
-		int KickID = str_toint(pMsg->m_pValue);
+		int KickId = str_toint(pMsg->m_pValue);
 
-		if(KickID < 0 || KickID >= MAX_CLIENTS || !m_apPlayers[KickID])
+		if(KickId < 0 || KickId >= MAX_CLIENTS || !m_apPlayers[KickId])
 		{
-			SendChatTarget(ClientID, "Invalid client id to kick");
+			SendChatTarget(ClientId, "Invalid client id to kick");
 			return;
 		}
-		if(KickID == ClientID)
+		if(KickId == ClientId)
 		{
-			SendChatTarget(ClientID, "You can't kick yourself");
+			SendChatTarget(ClientId, "You can't kick yourself");
 			return;
 		}
-		if(!Server()->ReverseTranslate(KickID, ClientID))
+		if(!Server()->ReverseTranslate(KickId, ClientId))
 		{
 			return;
 		}
-		int KickedAuthed = Server()->GetAuthedState(KickID);
+		int KickedAuthed = Server()->GetAuthedState(KickId);
 		if(KickedAuthed > Authed)
 		{
-			SendChatTarget(ClientID, "You can't kick authorized players");
+			SendChatTarget(ClientId, "You can't kick authorized players");
 			char aBufKick[128];
-			str_format(aBufKick, sizeof(aBufKick), "'%s' called for vote to kick you", Server()->ClientName(ClientID));
-			SendChatTarget(KickID, aBufKick);
+			str_format(aBufKick, sizeof(aBufKick), "'%s' called for vote to kick you", Server()->ClientName(ClientId));
+			SendChatTarget(KickId, aBufKick);
 			return;
 		}
 
 		// Don't allow kicking if a player has no character
-		if(!GetPlayerChar(ClientID) || !GetPlayerChar(KickID) || GetDDRaceTeam(ClientID) != GetDDRaceTeam(KickID))
+		if(!GetPlayerChar(ClientId) || !GetPlayerChar(KickId) || GetDDRaceTeam(ClientId) != GetDDRaceTeam(KickId))
 		{
-			SendChatTarget(ClientID, "You can kick only your team member");
+			SendChatTarget(ClientId, "You can kick only your team member");
 			return;
 		}
 
-		str_format(aChatmsg, sizeof(aChatmsg), "'%s' called for vote to kick '%s' (%s)", Server()->ClientName(ClientID), Server()->ClientName(KickID), aReason);
-		str_format(aSixupDesc, sizeof(aSixupDesc), "%2d: %s", KickID, Server()->ClientName(KickID));
-		if(!GetDDRaceTeam(ClientID))
+		str_format(aChatmsg, sizeof(aChatmsg), "'%s' called for vote to kick '%s' (%s)", Server()->ClientName(ClientId), Server()->ClientName(KickId), aReason);
+		str_format(aSixupDesc, sizeof(aSixupDesc), "%2d: %s", KickId, Server()->ClientName(KickId));
+		if(!GetDDRaceTeam(ClientId))
 		{
 			if(!g_Config.m_SvVoteKickBantime)
 			{
-				str_format(aCmd, sizeof(aCmd), "kick %d Kicked by vote", KickID);
-				str_format(aDesc, sizeof(aDesc), "Kick '%s'", Server()->ClientName(KickID));
+				str_format(aCmd, sizeof(aCmd), "kick %d Kicked by vote", KickId);
+				str_format(aDesc, sizeof(aDesc), "Kick '%s'", Server()->ClientName(KickId));
 			}
 			else
 			{
 				char aAddrStr[NETADDR_MAXSTRSIZE] = {0};
-				Server()->GetClientAddr(KickID, aAddrStr, sizeof(aAddrStr));
+				Server()->GetClientAddr(KickId, aAddrStr, sizeof(aAddrStr));
 				str_format(aCmd, sizeof(aCmd), "ban %s %d Banned by vote", aAddrStr, g_Config.m_SvVoteKickBantime);
-				str_format(aDesc, sizeof(aDesc), "Ban '%s'", Server()->ClientName(KickID));
+				str_format(aDesc, sizeof(aDesc), "Ban '%s'", Server()->ClientName(KickId));
 			}
 		}
 		else
 		{
-			str_format(aCmd, sizeof(aCmd), "uninvite %d %d; set_team_ddr %d 0", KickID, GetDDRaceTeam(KickID), KickID);
-			str_format(aDesc, sizeof(aDesc), "Move '%s' to team 0", Server()->ClientName(KickID));
+			str_format(aCmd, sizeof(aCmd), "uninvite %d %d; set_team_ddr %d 0", KickId, GetDDRaceTeam(KickId), KickId);
+			str_format(aDesc, sizeof(aDesc), "Move '%s' to team 0", Server()->ClientName(KickId));
 		}
-		m_apPlayers[ClientID]->m_Last_KickVote = time_get();
+		m_apPlayers[ClientId]->m_Last_KickVote = time_get();
 		m_VoteType = VOTE_TYPE_KICK;
-		m_VoteVictim = KickID;
+		m_VoteVictim = KickId;
 	}
 	else if(str_comp_nocase(pMsg->m_pType, "spectate") == 0)
 	{
 		if(!g_Config.m_SvVoteSpectate)
 		{
-			SendChatTarget(ClientID, "Server does not allow voting to move players to spectators");
+			SendChatTarget(ClientId, "Server does not allow voting to move players to spectators");
 			return;
 		}
 
-		int SpectateID = str_toint(pMsg->m_pValue);
+		int SpectateId = str_toint(pMsg->m_pValue);
 
-		if(SpectateID < 0 || SpectateID >= MAX_CLIENTS || !m_apPlayers[SpectateID] || m_apPlayers[SpectateID]->GetTeam() == TEAM_SPECTATORS)
+		if(SpectateId < 0 || SpectateId >= MAX_CLIENTS || !m_apPlayers[SpectateId] || m_apPlayers[SpectateId]->GetTeam() == TEAM_SPECTATORS)
 		{
-			SendChatTarget(ClientID, "Invalid client id to move");
+			SendChatTarget(ClientId, "Invalid client id to move");
 			return;
 		}
-		if(SpectateID == ClientID)
+		if(SpectateId == ClientId)
 		{
-			SendChatTarget(ClientID, "You can't move yourself");
+			SendChatTarget(ClientId, "You can't move yourself");
 			return;
 		}
-		if(!Server()->ReverseTranslate(SpectateID, ClientID))
+		if(!Server()->ReverseTranslate(SpectateId, ClientId))
 		{
-			return;
-		}
-
-		if(!GetPlayerChar(ClientID) || !GetPlayerChar(SpectateID) || GetDDRaceTeam(ClientID) != GetDDRaceTeam(SpectateID))
-		{
-			SendChatTarget(ClientID, "You can only move your team member to spectators");
 			return;
 		}
 
-		str_format(aSixupDesc, sizeof(aSixupDesc), "%2d: %s", SpectateID, Server()->ClientName(SpectateID));
+		if(!GetPlayerChar(ClientId) || !GetPlayerChar(SpectateId) || GetDDRaceTeam(ClientId) != GetDDRaceTeam(SpectateId))
+		{
+			SendChatTarget(ClientId, "You can only move your team member to spectators");
+			return;
+		}
+
+		str_format(aSixupDesc, sizeof(aSixupDesc), "%2d: %s", SpectateId, Server()->ClientName(SpectateId));
 		if(g_Config.m_SvPauseable && g_Config.m_SvVotePause)
 		{
-			str_format(aChatmsg, sizeof(aChatmsg), "'%s' called for vote to pause '%s' for %d seconds (%s)", Server()->ClientName(ClientID), Server()->ClientName(SpectateID), g_Config.m_SvVotePauseTime, aReason);
-			str_format(aDesc, sizeof(aDesc), "Pause '%s' (%ds)", Server()->ClientName(SpectateID), g_Config.m_SvVotePauseTime);
-			str_format(aCmd, sizeof(aCmd), "uninvite %d %d; force_pause %d %d", SpectateID, GetDDRaceTeam(SpectateID), SpectateID, g_Config.m_SvVotePauseTime);
+			str_format(aChatmsg, sizeof(aChatmsg), "'%s' called for vote to pause '%s' for %d seconds (%s)", Server()->ClientName(ClientId), Server()->ClientName(SpectateId), g_Config.m_SvVotePauseTime, aReason);
+			str_format(aDesc, sizeof(aDesc), "Pause '%s' (%ds)", Server()->ClientName(SpectateId), g_Config.m_SvVotePauseTime);
+			str_format(aCmd, sizeof(aCmd), "uninvite %d %d; force_pause %d %d", SpectateId, GetDDRaceTeam(SpectateId), SpectateId, g_Config.m_SvVotePauseTime);
 		}
 		else
 		{
-			str_format(aChatmsg, sizeof(aChatmsg), "'%s' called for vote to move '%s' to spectators (%s)", Server()->ClientName(ClientID), Server()->ClientName(SpectateID), aReason);
-			str_format(aDesc, sizeof(aDesc), "Move '%s' to spectators", Server()->ClientName(SpectateID));
-			str_format(aCmd, sizeof(aCmd), "uninvite %d %d; set_team %d -1 %d", SpectateID, GetDDRaceTeam(SpectateID), SpectateID, g_Config.m_SvVoteSpectateRejoindelay);
+			str_format(aChatmsg, sizeof(aChatmsg), "'%s' called for vote to move '%s' to spectators (%s)", Server()->ClientName(ClientId), Server()->ClientName(SpectateId), aReason);
+			str_format(aDesc, sizeof(aDesc), "Move '%s' to spectators", Server()->ClientName(SpectateId));
+			str_format(aCmd, sizeof(aCmd), "uninvite %d %d; set_team %d -1 %d", SpectateId, GetDDRaceTeam(SpectateId), SpectateId, g_Config.m_SvVoteSpectateRejoindelay);
 		}
 		m_VoteType = VOTE_TYPE_SPECTATE;
-		m_VoteVictim = SpectateID;
+		m_VoteVictim = SpectateId;
 	}
 
 	if(aCmd[0] && str_comp_nocase(aCmd, "info") != 0)
-		CallVote(ClientID, aDesc, aCmd, aReason, aChatmsg, aSixupDesc[0] ? aSixupDesc : 0);
+		CallVote(ClientId, aDesc, aCmd, aReason, aChatmsg, aSixupDesc[0] ? aSixupDesc : 0);
 }
 
-void CGameContext::OnVoteNetMessage(const CNetMsg_Cl_Vote *pMsg, int ClientID)
+void CGameContext::OnVoteNetMessage(const CNetMsg_Cl_Vote *pMsg, int ClientId)
 {
 	if(!m_VoteCloseTime)
 		return;
 
-	CPlayer *pPlayer = m_apPlayers[ClientID];
+	CPlayer *pPlayer = m_apPlayers[ClientId];
 
 	if(g_Config.m_SvSpamprotection && pPlayer->m_LastVoteTry && pPlayer->m_LastVoteTry + Server()->TickSpeed() * 3 > Server()->Tick())
 		return;
@@ -2431,15 +2431,15 @@ void CGameContext::OnVoteNetMessage(const CNetMsg_Cl_Vote *pMsg, int ClientID)
 	m_VoteUpdate = true;
 
 	CNetMsg_Sv_YourVote Msg = {pMsg->m_Vote};
-	Server()->SendPackMsg(&Msg, MSGFLAG_VITAL, ClientID);
+	Server()->SendPackMsg(&Msg, MSGFLAG_VITAL, ClientId);
 }
 
-void CGameContext::OnSetTeamNetMessage(const CNetMsg_Cl_SetTeam *pMsg, int ClientID)
+void CGameContext::OnSetTeamNetMessage(const CNetMsg_Cl_SetTeam *pMsg, int ClientId)
 {
 	if(m_World.m_Paused)
 		return;
 
-	CPlayer *pPlayer = m_apPlayers[ClientID];
+	CPlayer *pPlayer = m_apPlayers[ClientId];
 
 	if(pPlayer->GetTeam() == pMsg->m_Team || (g_Config.m_SvSpamprotection && pPlayer->m_LastSetTeam && pPlayer->m_LastSetTeam + Server()->TickSpeed() * g_Config.m_SvTeamChangeDelay > Server()->Tick()))
 		return;
@@ -2451,7 +2451,7 @@ void CGameContext::OnSetTeamNetMessage(const CNetMsg_Cl_SetTeam *pMsg, int Clien
 		int CurrTime = (Server()->Tick() - pChr->m_StartTime) / Server()->TickSpeed();
 		if(g_Config.m_SvKillProtection != 0 && CurrTime >= (60 * g_Config.m_SvKillProtection) && pChr->m_DDRaceState == DDRACE_STARTED)
 		{
-			SendChatTarget(ClientID, "Kill Protection enabled. If you really want to join the spectators, first type /kill");
+			SendChatTarget(ClientId, "Kill Protection enabled. If you really want to join the spectators, first type /kill");
 			return;
 		}
 	}
@@ -2464,13 +2464,13 @@ void CGameContext::OnSetTeamNetMessage(const CNetMsg_Cl_SetTeam *pMsg, int Clien
 		str_time((int64_t)TimeLeft * 100, TIME_HOURS, aTime, sizeof(aTime));
 		char aBuf[128];
 		str_format(aBuf, sizeof(aBuf), "Time to wait before changing team: %s", aTime);
-		SendBroadcast(aBuf, ClientID);
+		SendBroadcast(aBuf, ClientId);
 		return;
 	}
 
 	// Switch team on given client and kill/respawn them
 	char aTeamJoinError[512];
-	if(m_pController->CanJoinTeam(pMsg->m_Team, ClientID, aTeamJoinError, sizeof(aTeamJoinError)))
+	if(m_pController->CanJoinTeam(pMsg->m_Team, ClientId, aTeamJoinError, sizeof(aTeamJoinError)))
 	{
 		if(pPlayer->GetTeam() == TEAM_SPECTATORS || pMsg->m_Team == TEAM_SPECTATORS)
 			m_VoteUpdate = true;
@@ -2478,13 +2478,13 @@ void CGameContext::OnSetTeamNetMessage(const CNetMsg_Cl_SetTeam *pMsg, int Clien
 		pPlayer->m_TeamChangeTick = Server()->Tick();
 	}
 	else
-		SendBroadcast(aTeamJoinError, ClientID);
+		SendBroadcast(aTeamJoinError, ClientId);
 }
 
-void CGameContext::OnIsDDNetLegacyNetMessage(const CNetMsg_Cl_IsDDNetLegacy *pMsg, int ClientID, CUnpacker *pUnpacker)
+void CGameContext::OnIsDDNetLegacyNetMessage(const CNetMsg_Cl_IsDDNetLegacy *pMsg, int ClientId, CUnpacker *pUnpacker)
 {
 	IServer::CClientInfo Info;
-	if(Server()->GetClientInfo(ClientID, &Info) && Info.m_GotDDNetVersion)
+	if(Server()->GetClientInfo(ClientId, &Info) && Info.m_GotDDNetVersion)
 	{
 		return;
 	}
@@ -2493,59 +2493,59 @@ void CGameContext::OnIsDDNetLegacyNetMessage(const CNetMsg_Cl_IsDDNetLegacy *pMs
 	{
 		DDNetVersion = VERSION_DDRACE;
 	}
-	Server()->SetClientDDNetVersion(ClientID, DDNetVersion);
-	OnClientDDNetVersionKnown(ClientID);
+	Server()->SetClientDDNetVersion(ClientId, DDNetVersion);
+	OnClientDDNetVersionKnown(ClientId);
 }
 
-void CGameContext::OnShowOthersLegacyNetMessage(const CNetMsg_Cl_ShowOthersLegacy *pMsg, int ClientID)
+void CGameContext::OnShowOthersLegacyNetMessage(const CNetMsg_Cl_ShowOthersLegacy *pMsg, int ClientId)
 {
 	if(g_Config.m_SvShowOthers && !g_Config.m_SvShowOthersDefault)
 	{
-		CPlayer *pPlayer = m_apPlayers[ClientID];
+		CPlayer *pPlayer = m_apPlayers[ClientId];
 		pPlayer->m_ShowOthers = pMsg->m_Show;
 	}
 }
 
-void CGameContext::OnShowOthersNetMessage(const CNetMsg_Cl_ShowOthers *pMsg, int ClientID)
+void CGameContext::OnShowOthersNetMessage(const CNetMsg_Cl_ShowOthers *pMsg, int ClientId)
 {
 	if(g_Config.m_SvShowOthers && !g_Config.m_SvShowOthersDefault)
 	{
-		CPlayer *pPlayer = m_apPlayers[ClientID];
+		CPlayer *pPlayer = m_apPlayers[ClientId];
 		pPlayer->m_ShowOthers = pMsg->m_Show;
 	}
 }
 
-void CGameContext::OnShowDistanceNetMessage(const CNetMsg_Cl_ShowDistance *pMsg, int ClientID)
+void CGameContext::OnShowDistanceNetMessage(const CNetMsg_Cl_ShowDistance *pMsg, int ClientId)
 {
-	CPlayer *pPlayer = m_apPlayers[ClientID];
+	CPlayer *pPlayer = m_apPlayers[ClientId];
 	pPlayer->m_ShowDistance = vec2(pMsg->m_X, pMsg->m_Y);
 }
 
-void CGameContext::OnSetSpectatorModeNetMessage(const CNetMsg_Cl_SetSpectatorMode *pMsg, int ClientID)
+void CGameContext::OnSetSpectatorModeNetMessage(const CNetMsg_Cl_SetSpectatorMode *pMsg, int ClientId)
 {
 	if(m_World.m_Paused)
 		return;
 
-	int SpectatorID = clamp(pMsg->m_SpectatorID, (int)SPEC_FOLLOW, MAX_CLIENTS - 1);
-	if(SpectatorID >= 0)
-		if(!Server()->ReverseTranslate(SpectatorID, ClientID))
+	int SpectatorId = clamp(pMsg->m_SpectatorId, (int)SPEC_FOLLOW, MAX_CLIENTS - 1);
+	if(SpectatorId >= 0)
+		if(!Server()->ReverseTranslate(SpectatorId, ClientId))
 			return;
 
-	CPlayer *pPlayer = m_apPlayers[ClientID];
+	CPlayer *pPlayer = m_apPlayers[ClientId];
 	if((g_Config.m_SvSpamprotection && pPlayer->m_LastSetSpectatorMode && pPlayer->m_LastSetSpectatorMode + Server()->TickSpeed() / 4 > Server()->Tick()))
 		return;
 
 	pPlayer->m_LastSetSpectatorMode = Server()->Tick();
 	pPlayer->UpdatePlaytime();
-	if(SpectatorID >= 0 && (!m_apPlayers[SpectatorID] || m_apPlayers[SpectatorID]->GetTeam() == TEAM_SPECTATORS))
-		SendChatTarget(ClientID, "Invalid spectator id used");
+	if(SpectatorId >= 0 && (!m_apPlayers[SpectatorId] || m_apPlayers[SpectatorId]->GetTeam() == TEAM_SPECTATORS))
+		SendChatTarget(ClientId, "Invalid spectator id used");
 	else
-		pPlayer->m_SpectatorID = SpectatorID;
+		pPlayer->m_SpectatorId = SpectatorId;
 }
 
-void CGameContext::OnChangeInfoNetMessage(const CNetMsg_Cl_ChangeInfo *pMsg, int ClientID)
+void CGameContext::OnChangeInfoNetMessage(const CNetMsg_Cl_ChangeInfo *pMsg, int ClientId)
 {
-	CPlayer *pPlayer = m_apPlayers[ClientID];
+	CPlayer *pPlayer = m_apPlayers[ClientId];
 	if(g_Config.m_SvSpamprotection && pPlayer->m_LastChangeInfo && pPlayer->m_LastChangeInfo + Server()->TickSpeed() * g_Config.m_SvInfoChangeDelay > Server()->Tick())
 		return;
 
@@ -2558,58 +2558,58 @@ void CGameContext::OnChangeInfoNetMessage(const CNetMsg_Cl_ChangeInfo *pMsg, int
 	{
 		CNetMsg_Sv_ChangeInfoCooldown ChangeInfoCooldownMsg;
 		ChangeInfoCooldownMsg.m_WaitUntil = Server()->Tick() + Server()->TickSpeed() * g_Config.m_SvInfoChangeDelay;
-		Server()->SendPackMsg(&ChangeInfoCooldownMsg, MSGFLAG_VITAL | MSGFLAG_NORECORD, ClientID);
+		Server()->SendPackMsg(&ChangeInfoCooldownMsg, MSGFLAG_VITAL | MSGFLAG_NORECORD, ClientId);
 	}
 
 	// set infos
-	if(Server()->WouldClientNameChange(ClientID, pMsg->m_pName) && !ProcessSpamProtection(ClientID))
+	if(Server()->WouldClientNameChange(ClientId, pMsg->m_pName) && !ProcessSpamProtection(ClientId))
 	{
 		char aOldName[MAX_NAME_LENGTH];
-		str_copy(aOldName, Server()->ClientName(ClientID), sizeof(aOldName));
+		str_copy(aOldName, Server()->ClientName(ClientId), sizeof(aOldName));
 
-		Server()->SetClientName(ClientID, pMsg->m_pName);
+		Server()->SetClientName(ClientId, pMsg->m_pName);
 
 		char aChatText[256];
-		str_format(aChatText, sizeof(aChatText), "'%s' changed name to '%s'", aOldName, Server()->ClientName(ClientID));
+		str_format(aChatText, sizeof(aChatText), "'%s' changed name to '%s'", aOldName, Server()->ClientName(ClientId));
 		SendChat(-1, CGameContext::CHAT_ALL, aChatText);
 
 		// reload scores
-		Score()->PlayerData(ClientID)->Reset();
-		m_apPlayers[ClientID]->m_Score.reset();
-		Score()->LoadPlayerData(ClientID);
+		Score()->PlayerData(ClientId)->Reset();
+		m_apPlayers[ClientId]->m_Score.reset();
+		Score()->LoadPlayerData(ClientId);
 
 		SixupNeedsUpdate = true;
 
-		LogEvent("Name change", ClientID);
+		LogEvent("Name change", ClientId);
 	}
 
-	if(Server()->WouldClientClanChange(ClientID, pMsg->m_pClan))
+	if(Server()->WouldClientClanChange(ClientId, pMsg->m_pClan))
 	{
 		SixupNeedsUpdate = true;
-		Server()->SetClientClan(ClientID, pMsg->m_pClan);
+		Server()->SetClientClan(ClientId, pMsg->m_pClan);
 	}
 
-	if(Server()->ClientCountry(ClientID) != pMsg->m_Country)
+	if(Server()->ClientCountry(ClientId) != pMsg->m_Country)
 		SixupNeedsUpdate = true;
-	Server()->SetClientCountry(ClientID, pMsg->m_Country);
+	Server()->SetClientCountry(ClientId, pMsg->m_Country);
 
 	str_copy(pPlayer->m_TeeInfos.m_aSkinName, pMsg->m_pSkin, sizeof(pPlayer->m_TeeInfos.m_aSkinName));
 	pPlayer->m_TeeInfos.m_UseCustomColor = pMsg->m_UseCustomColor;
 	pPlayer->m_TeeInfos.m_ColorBody = pMsg->m_ColorBody;
 	pPlayer->m_TeeInfos.m_ColorFeet = pMsg->m_ColorFeet;
-	if(!Server()->IsSixup(ClientID))
+	if(!Server()->IsSixup(ClientId))
 		pPlayer->m_TeeInfos.ToSixup();
 
 	if(SixupNeedsUpdate)
 	{
 		protocol7::CNetMsg_Sv_ClientDrop Drop;
-		Drop.m_ClientID = ClientID;
+		Drop.m_ClientId = ClientId;
 		Drop.m_pReason = "";
 		Drop.m_Silent = true;
 
 		protocol7::CNetMsg_Sv_ClientInfo Info;
-		Info.m_ClientID = ClientID;
-		Info.m_pName = Server()->ClientName(ClientID);
+		Info.m_ClientId = ClientId;
+		Info.m_pName = Server()->ClientName(ClientId);
 		Info.m_Country = pMsg->m_Country;
 		Info.m_pClan = pMsg->m_pClan;
 		Info.m_Local = 0;
@@ -2625,7 +2625,7 @@ void CGameContext::OnChangeInfoNetMessage(const CNetMsg_Cl_ChangeInfo *pMsg, int
 
 		for(int i = 0; i < Server()->MaxClients(); i++)
 		{
-			if(i != ClientID)
+			if(i != ClientId)
 			{
 				Server()->SendPackMsg(&Drop, MSGFLAG_VITAL | MSGFLAG_NORECORD, i);
 				Server()->SendPackMsg(&Info, MSGFLAG_VITAL | MSGFLAG_NORECORD, i);
@@ -2635,7 +2635,7 @@ void CGameContext::OnChangeInfoNetMessage(const CNetMsg_Cl_ChangeInfo *pMsg, int
 	else
 	{
 		protocol7::CNetMsg_Sv_SkinChange Msg;
-		Msg.m_ClientID = ClientID;
+		Msg.m_ClientId = ClientId;
 		for(int p = 0; p < 6; p++)
 		{
 			Msg.m_apSkinPartNames[p] = pPlayer->m_TeeInfos.m_apSkinPartNames[p];
@@ -2649,12 +2649,12 @@ void CGameContext::OnChangeInfoNetMessage(const CNetMsg_Cl_ChangeInfo *pMsg, int
 	Server()->ExpireServerInfo();
 }
 
-void CGameContext::OnEmoticonNetMessage(const CNetMsg_Cl_Emoticon *pMsg, int ClientID)
+void CGameContext::OnEmoticonNetMessage(const CNetMsg_Cl_Emoticon *pMsg, int ClientId)
 {
 	if(m_World.m_Paused)
 		return;
 
-	CPlayer *pPlayer = m_apPlayers[ClientID];
+	CPlayer *pPlayer = m_apPlayers[ClientId];
 
 	auto &&CheckPreventEmote = [&](int64_t LastEmote, int64_t DelayInMs) {
 		return (LastEmote * (int64_t)1000) + (int64_t)Server()->TickSpeed() * DelayInMs > ((int64_t)Server()->Tick() * (int64_t)1000);
@@ -2679,7 +2679,7 @@ void CGameContext::OnEmoticonNetMessage(const CNetMsg_Cl_Emoticon *pMsg, int Cli
 		{
 			if(m_apPlayers[i] && pChr->CanSnapCharacter(i) && pChr->IsSnappingCharacterInView(i))
 			{
-				SendEmoticon(ClientID, pMsg->m_Emoticon, i);
+				SendEmoticon(ClientId, pMsg->m_Emoticon, i);
 			}
 		}
 	}
@@ -2687,7 +2687,7 @@ void CGameContext::OnEmoticonNetMessage(const CNetMsg_Cl_Emoticon *pMsg, int Cli
 	{
 		// else send emoticons to all players
 		pPlayer->m_LastEmoteGlobal = Server()->Tick();
-		SendEmoticon(ClientID, pMsg->m_Emoticon, -1);
+		SendEmoticon(ClientId, pMsg->m_Emoticon, -1);
 	}
 
 	if(g_Config.m_SvEmotionalTees == 1 && pPlayer->m_EyeEmoteEnabled)
@@ -2728,17 +2728,17 @@ void CGameContext::OnEmoticonNetMessage(const CNetMsg_Cl_Emoticon *pMsg, int Cli
 	}
 }
 
-void CGameContext::OnKillNetMessage(const CNetMsg_Cl_Kill *pMsg, int ClientID)
+void CGameContext::OnKillNetMessage(const CNetMsg_Cl_Kill *pMsg, int ClientId)
 {
 	if(m_World.m_Paused)
 		return;
 
-	if(m_VoteCloseTime && m_VoteCreator == ClientID && GetDDRaceTeam(ClientID) && (IsKickVote() || IsSpecVote()))
+	if(m_VoteCloseTime && m_VoteCreator == ClientId && GetDDRaceTeam(ClientId) && (IsKickVote() || IsSpecVote()))
 	{
-		SendChatTarget(ClientID, "You are running a vote please try again after the vote is done!");
+		SendChatTarget(ClientId, "You are running a vote please try again after the vote is done!");
 		return;
 	}
-	CPlayer *pPlayer = m_apPlayers[ClientID];
+	CPlayer *pPlayer = m_apPlayers[ClientId];
 	if(pPlayer->m_LastKill && pPlayer->m_LastKill + Server()->TickSpeed() * g_Config.m_SvKillDelay > Server()->Tick())
 		return;
 	if(pPlayer->IsPaused())
@@ -2752,7 +2752,7 @@ void CGameContext::OnKillNetMessage(const CNetMsg_Cl_Kill *pMsg, int ClientID)
 	int CurrTime = (Server()->Tick() - pChr->m_StartTime) / Server()->TickSpeed();
 	if(g_Config.m_SvKillProtection != 0 && CurrTime >= (60 * g_Config.m_SvKillProtection) && pChr->m_DDRaceState == DDRACE_STARTED)
 	{
-		SendChatTarget(ClientID, "Kill Protection enabled. If you really want to kill, type /kill");
+		SendChatTarget(ClientId, "Kill Protection enabled. If you really want to kill, type /kill");
 		return;
 	}
 
@@ -2761,9 +2761,9 @@ void CGameContext::OnKillNetMessage(const CNetMsg_Cl_Kill *pMsg, int ClientID)
 	pPlayer->Respawn();
 }
 
-void CGameContext::OnStartInfoNetMessage(const CNetMsg_Cl_StartInfo *pMsg, int ClientID)
+void CGameContext::OnStartInfoNetMessage(const CNetMsg_Cl_StartInfo *pMsg, int ClientId)
 {
-	CPlayer *pPlayer = m_apPlayers[ClientID];
+	CPlayer *pPlayer = m_apPlayers[ClientId];
 
 	if(pPlayer->m_IsReady)
 		return;
@@ -2771,40 +2771,40 @@ void CGameContext::OnStartInfoNetMessage(const CNetMsg_Cl_StartInfo *pMsg, int C
 	pPlayer->m_LastChangeInfo = Server()->Tick();
 
 	// set start infos
-	Server()->SetClientName(ClientID, pMsg->m_pName);
+	Server()->SetClientName(ClientId, pMsg->m_pName);
 	// trying to set client name can delete the player object, check if it still exists
-	if(!m_apPlayers[ClientID])
+	if(!m_apPlayers[ClientId])
 	{
 		return;
 	}
-	Server()->SetClientClan(ClientID, pMsg->m_pClan);
+	Server()->SetClientClan(ClientId, pMsg->m_pClan);
 	// trying to set client clan can delete the player object, check if it still exists
-	if(!m_apPlayers[ClientID])
+	if(!m_apPlayers[ClientId])
 	{
 		return;
 	}
-	Server()->SetClientCountry(ClientID, pMsg->m_Country);
+	Server()->SetClientCountry(ClientId, pMsg->m_Country);
 	str_copy(pPlayer->m_TeeInfos.m_aSkinName, pMsg->m_pSkin, sizeof(pPlayer->m_TeeInfos.m_aSkinName));
 	pPlayer->m_TeeInfos.m_UseCustomColor = pMsg->m_UseCustomColor;
 	pPlayer->m_TeeInfos.m_ColorBody = pMsg->m_ColorBody;
 	pPlayer->m_TeeInfos.m_ColorFeet = pMsg->m_ColorFeet;
-	if(!Server()->IsSixup(ClientID))
+	if(!Server()->IsSixup(ClientId))
 		pPlayer->m_TeeInfos.ToSixup();
 
 	// send clear vote options
 	CNetMsg_Sv_VoteClearOptions ClearMsg;
-	Server()->SendPackMsg(&ClearMsg, MSGFLAG_VITAL, ClientID);
+	Server()->SendPackMsg(&ClearMsg, MSGFLAG_VITAL, ClientId);
 
 	// begin sending vote options
 	pPlayer->m_SendVoteIndex = 0;
 
 	// send tuning parameters to client
-	SendTuningParams(ClientID, pPlayer->m_TuneZone);
+	SendTuningParams(ClientId, pPlayer->m_TuneZone);
 
 	// client is ready to enter
 	pPlayer->m_IsReady = true;
 	CNetMsg_Sv_ReadyToEnter m;
-	Server()->SendPackMsg(&m, MSGFLAG_VITAL | MSGFLAG_FLUSH, ClientID);
+	Server()->SendPackMsg(&m, MSGFLAG_VITAL | MSGFLAG_FLUSH, ClientId);
 
 	Server()->ExpireServerInfo();
 }
@@ -3118,21 +3118,21 @@ void CGameContext::ConSay(IConsole::IResult *pResult, void *pUserData)
 void CGameContext::ConSetTeam(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	int ClientID = clamp(pResult->GetInteger(0), 0, (int)MAX_CLIENTS - 1);
+	int ClientId = clamp(pResult->GetInteger(0), 0, (int)MAX_CLIENTS - 1);
 	int Team = clamp(pResult->GetInteger(1), -1, 1);
 	int Delay = pResult->NumArguments() > 2 ? pResult->GetInteger(2) : 0;
-	if(!pSelf->m_apPlayers[ClientID])
+	if(!pSelf->m_apPlayers[ClientId])
 		return;
 
 	char aBuf[256];
-	str_format(aBuf, sizeof(aBuf), "moved client %d to team %d", ClientID, Team);
+	str_format(aBuf, sizeof(aBuf), "moved client %d to team %d", ClientId, Team);
 	pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "server", aBuf);
 
-	pSelf->m_apPlayers[ClientID]->Pause(CPlayer::PAUSE_NONE, false); // reset /spec and /pause to allow rejoin
-	pSelf->m_apPlayers[ClientID]->m_TeamChangeTick = pSelf->Server()->Tick() + pSelf->Server()->TickSpeed() * Delay * 60;
-	pSelf->m_pController->DoTeamChange(pSelf->m_apPlayers[ClientID], Team);
+	pSelf->m_apPlayers[ClientId]->Pause(CPlayer::PAUSE_NONE, false); // reset /spec and /pause to allow rejoin
+	pSelf->m_apPlayers[ClientId]->m_TeamChangeTick = pSelf->Server()->Tick() + pSelf->Server()->TickSpeed() * Delay * 60;
+	pSelf->m_pController->DoTeamChange(pSelf->m_apPlayers[ClientId], Team);
 	if(Team == TEAM_SPECTATORS)
-		pSelf->m_apPlayers[ClientID]->Pause(CPlayer::PAUSE_NONE, true);
+		pSelf->m_apPlayers[ClientId]->Pause(CPlayer::PAUSE_NONE, true);
 }
 
 void CGameContext::ConSetTeamAll(IConsole::IResult *pResult, void *pUserData)
@@ -3317,8 +3317,8 @@ void CGameContext::ConForceVote(IConsole::IResult *pResult, void *pUserData)
 	}
 	else if(str_comp_nocase(pType, "kick") == 0)
 	{
-		int KickID = str_toint(pValue);
-		if(KickID < 0 || KickID >= MAX_CLIENTS || !pSelf->m_apPlayers[KickID])
+		int KickId = str_toint(pValue);
+		if(KickId < 0 || KickId >= MAX_CLIENTS || !pSelf->m_apPlayers[KickId])
 		{
 			pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "server", "Invalid client id to kick");
 			return;
@@ -3326,29 +3326,29 @@ void CGameContext::ConForceVote(IConsole::IResult *pResult, void *pUserData)
 
 		if(!g_Config.m_SvVoteKickBantime)
 		{
-			str_format(aBuf, sizeof(aBuf), "kick %d %s", KickID, pReason);
+			str_format(aBuf, sizeof(aBuf), "kick %d %s", KickId, pReason);
 			pSelf->Console()->ExecuteLine(aBuf);
 		}
 		else
 		{
 			char aAddrStr[NETADDR_MAXSTRSIZE] = {0};
-			pSelf->Server()->GetClientAddr(KickID, aAddrStr, sizeof(aAddrStr));
+			pSelf->Server()->GetClientAddr(KickId, aAddrStr, sizeof(aAddrStr));
 			str_format(aBuf, sizeof(aBuf), "ban %s %d %s", aAddrStr, g_Config.m_SvVoteKickBantime, pReason);
 			pSelf->Console()->ExecuteLine(aBuf);
 		}
 	}
 	else if(str_comp_nocase(pType, "spectate") == 0)
 	{
-		int SpectateID = str_toint(pValue);
-		if(SpectateID < 0 || SpectateID >= MAX_CLIENTS || !pSelf->m_apPlayers[SpectateID] || pSelf->m_apPlayers[SpectateID]->GetTeam() == TEAM_SPECTATORS)
+		int SpectateId = str_toint(pValue);
+		if(SpectateId < 0 || SpectateId >= MAX_CLIENTS || !pSelf->m_apPlayers[SpectateId] || pSelf->m_apPlayers[SpectateId]->GetTeam() == TEAM_SPECTATORS)
 		{
 			pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "server", "Invalid client id to move");
 			return;
 		}
 
-		str_format(aBuf, sizeof(aBuf), "'%s' was moved to spectator (%s)", pSelf->Server()->ClientName(SpectateID), pReason);
+		str_format(aBuf, sizeof(aBuf), "'%s' was moved to spectator (%s)", pSelf->Server()->ClientName(SpectateId), pReason);
 		pSelf->SendChatTarget(-1, aBuf);
-		str_format(aBuf, sizeof(aBuf), "set_team %d -1 %d", SpectateID, g_Config.m_SvVoteSpectateRejoindelay);
+		str_format(aBuf, sizeof(aBuf), "set_team %d -1 %d", SpectateId, g_Config.m_SvVoteSpectateRejoindelay);
 		pSelf->Console()->ExecuteLine(aBuf);
 	}
 }
@@ -3421,9 +3421,9 @@ void CGameContext::ConVote(IConsole::IResult *pResult, void *pUserData)
 	CGameContext *pSelf = (CGameContext *)pUserData;
 
 	if(str_comp_nocase(pResult->GetString(0), "yes") == 0)
-		pSelf->ForceVote(pResult->m_ClientID, true);
+		pSelf->ForceVote(pResult->m_ClientId, true);
 	else if(str_comp_nocase(pResult->GetString(0), "no") == 0)
-		pSelf->ForceVote(pResult->m_ClientID, false);
+		pSelf->ForceVote(pResult->m_ClientId, false);
 }
 
 void CGameContext::ConVotes(IConsole::IResult *pResult, void *pUserData)
@@ -3581,10 +3581,10 @@ void CGameContext::RegisterDDRaceCommands()
 	Console()->Register("vote_unmute", "v[id]", CFGFLAG_SERVER, ConVoteUnmute, this, "Give back v's right to vote.");
 	Console()->Register("vote_mutes", "", CFGFLAG_SERVER, ConVoteMutes, this, "List the current active vote mutes.");
 	Console()->Register("mute", "", CFGFLAG_SERVER, ConMute, this, "Use either 'muteid <client_id> <seconds> <reason>' or 'muteip <ip> <seconds> <reason>'");
-	Console()->Register("muteid", "v[id] i[seconds] ?r[reason]", CFGFLAG_SERVER, ConMuteID, this, "Mute player with id");
-	Console()->Register("muteip", "s[ip] i[seconds] ?r[reason]", CFGFLAG_SERVER, ConMuteIP, this, "Mute player with IP address");
+	Console()->Register("muteid", "v[id] i[seconds] ?r[reason]", CFGFLAG_SERVER, ConMuteId, this, "Mute player with id");
+	Console()->Register("muteip", "s[ip] i[seconds] ?r[reason]", CFGFLAG_SERVER, ConMuteIp, this, "Mute player with IP address");
 	Console()->Register("unmute", "i[muteid]", CFGFLAG_SERVER, ConUnmute, this, "Unmute mute with number from \"mutes\"");
-	Console()->Register("unmuteid", "v[id]", CFGFLAG_SERVER, ConUnmuteID, this, "Unmute player with id");
+	Console()->Register("unmuteid", "v[id]", CFGFLAG_SERVER, ConUnmuteId, this, "Unmute player with id");
 	Console()->Register("mutes", "", CFGFLAG_SERVER, ConMutes, this, "Show all active mutes");
 	Console()->Register("moderate", "", CFGFLAG_SERVER, ConModerate, this, "Enables/disables active moderator mode for the player");
 	Console()->Register("vote_no", "", CFGFLAG_SERVER, ConVoteNo, this, "Same as \"vote no\"");
@@ -4038,12 +4038,12 @@ void CGameContext::OnMapChange(char *pNewMapName, int MapNameSize)
 	bool FoundInfo = false;
 	for(int i = 0; i < Reader.NumItems(); i++)
 	{
-		int TypeID;
-		int ItemID;
-		void *pData = Reader.GetItem(i, &TypeID, &ItemID);
+		int TypeId;
+		int ItemId;
+		void *pData = Reader.GetItem(i, &TypeId, &ItemId);
 		int Size = Reader.GetItemSize(i);
 		CMapItemInfoSettings MapInfo;
-		if(TypeID == MAPITEMTYPE_INFO && ItemID == 0)
+		if(TypeId == MAPITEMTYPE_INFO && ItemId == 0)
 		{
 			FoundInfo = true;
 			if(Size >= (int)sizeof(CMapItemInfoSettings))
@@ -4078,7 +4078,7 @@ void CGameContext::OnMapChange(char *pNewMapName, int MapNameSize)
 				Size = sizeof(MapInfo);
 			}
 		}
-		Writer.AddItem(TypeID, ItemID, Size, pData);
+		Writer.AddItem(TypeId, ItemId, Size, pData);
 	}
 
 	if(!FoundInfo)
@@ -4160,10 +4160,10 @@ void CGameContext::LoadMapSettings()
 	pMap->GetType(MAPITEMTYPE_INFO, &Start, &Num);
 	for(int i = Start; i < Start + Num; i++)
 	{
-		int ItemID;
-		CMapItemInfoSettings *pItem = (CMapItemInfoSettings *)pMap->GetItem(i, nullptr, &ItemID);
+		int ItemId;
+		CMapItemInfoSettings *pItem = (CMapItemInfoSettings *)pMap->GetItem(i, nullptr, &ItemId);
 		int ItemSize = pMap->GetItemSize(i);
-		if(!pItem || ItemID != 0)
+		if(!pItem || ItemId != 0)
 			continue;
 
 		if(ItemSize < (int)sizeof(CMapItemInfoSettings))
@@ -4189,32 +4189,32 @@ void CGameContext::LoadMapSettings()
 	Console()->ExecuteFile(aBuf, IConsole::CLIENT_ID_NO_GAME);
 }
 
-void CGameContext::OnSnap(int ClientID)
+void CGameContext::OnSnap(int ClientId)
 {
 	// add tuning to demo
 	CTuningParams StandardTuning;
-	if(Server()->IsRecording(ClientID > -1 ? ClientID : MAX_CLIENTS) && mem_comp(&StandardTuning, &m_Tuning, sizeof(CTuningParams)) != 0)
+	if(Server()->IsRecording(ClientId > -1 ? ClientId : MAX_CLIENTS) && mem_comp(&StandardTuning, &m_Tuning, sizeof(CTuningParams)) != 0)
 	{
 		CMsgPacker Msg(NETMSGTYPE_SV_TUNEPARAMS);
 		int *pParams = (int *)&m_Tuning;
 		for(unsigned i = 0; i < sizeof(m_Tuning) / sizeof(int); i++)
 			Msg.AddInt(pParams[i]);
-		Server()->SendMsg(&Msg, MSGFLAG_RECORD | MSGFLAG_NOSEND, ClientID);
+		Server()->SendMsg(&Msg, MSGFLAG_RECORD | MSGFLAG_NOSEND, ClientId);
 	}
 
-	m_pController->Snap(ClientID);
+	m_pController->Snap(ClientId);
 
 	for(auto &pPlayer : m_apPlayers)
 	{
 		if(pPlayer)
-			pPlayer->Snap(ClientID);
+			pPlayer->Snap(ClientId);
 	}
 
-	if(ClientID > -1)
-		m_apPlayers[ClientID]->FakeSnap();
+	if(ClientId > -1)
+		m_apPlayers[ClientId]->FakeSnap();
 
-	m_World.Snap(ClientID);
-	m_Events.Snap(ClientID);
+	m_World.Snap(ClientId);
+	m_Events.Snap(ClientId);
 }
 void CGameContext::OnPreSnap() {}
 void CGameContext::OnPostSnap()
@@ -4283,14 +4283,14 @@ void CGameContext::UpdatePlayerMaps()
 	}
 }
 
-bool CGameContext::IsClientReady(int ClientID) const
+bool CGameContext::IsClientReady(int ClientId) const
 {
-	return m_apPlayers[ClientID] && m_apPlayers[ClientID]->m_IsReady;
+	return m_apPlayers[ClientId] && m_apPlayers[ClientId]->m_IsReady;
 }
 
-bool CGameContext::IsClientPlayer(int ClientID) const
+bool CGameContext::IsClientPlayer(int ClientId) const
 {
-	return m_apPlayers[ClientID] && m_apPlayers[ClientID]->GetTeam() != TEAM_SPECTATORS;
+	return m_apPlayers[ClientId] && m_apPlayers[ClientId]->GetTeam() != TEAM_SPECTATORS;
 }
 
 CUuid CGameContext::GameUuid() const { return m_GameUuid; }
@@ -4300,13 +4300,13 @@ const char *CGameContext::NetVersion() const { return GAME_NETVERSION; }
 
 IGameServer *CreateGameServer() { return new CGameContext; }
 
-void CGameContext::OnSetAuthed(int ClientID, int Level)
+void CGameContext::OnSetAuthed(int ClientId, int Level)
 {
-	if(m_apPlayers[ClientID])
+	if(m_apPlayers[ClientId])
 	{
-		char aBuf[512], aIP[NETADDR_MAXSTRSIZE];
-		Server()->GetClientAddr(ClientID, aIP, sizeof(aIP));
-		str_format(aBuf, sizeof(aBuf), "ban %s %d Banned by vote", aIP, g_Config.m_SvVoteKickBantime);
+		char aBuf[512], aIp[NETADDR_MAXSTRSIZE];
+		Server()->GetClientAddr(ClientId, aIp, sizeof(aIp));
+		str_format(aBuf, sizeof(aBuf), "ban %s %d Banned by vote", aIp, g_Config.m_SvVoteKickBantime);
 		if(!str_comp_nocase(m_aVoteCommand, aBuf) && Level > Server()->GetAuthedState(m_VoteCreator))
 		{
 			m_VoteEnforce = CGameContext::VOTE_ENFORCE_NO_ADMIN;
@@ -4317,44 +4317,44 @@ void CGameContext::OnSetAuthed(int ClientID, int Level)
 	{
 		if(Level)
 		{
-			m_TeeHistorian.RecordAuthLogin(ClientID, Level, Server()->GetAuthName(ClientID));
+			m_TeeHistorian.RecordAuthLogin(ClientId, Level, Server()->GetAuthName(ClientId));
 		}
 		else
 		{
-			m_TeeHistorian.RecordAuthLogout(ClientID);
+			m_TeeHistorian.RecordAuthLogout(ClientId);
 		}
 	}
 }
 
-void CGameContext::SendRecord(int ClientID)
+void CGameContext::SendRecord(int ClientId)
 {
 	CNetMsg_Sv_Record Msg;
 	CNetMsg_Sv_RecordLegacy MsgLegacy;
-	MsgLegacy.m_PlayerTimeBest = Msg.m_PlayerTimeBest = Score()->PlayerData(ClientID)->m_BestTime * 100.0f;
+	MsgLegacy.m_PlayerTimeBest = Msg.m_PlayerTimeBest = Score()->PlayerData(ClientId)->m_BestTime * 100.0f;
 	MsgLegacy.m_ServerTimeBest = Msg.m_ServerTimeBest = m_pController->m_CurrentRecord * 100.0f; //TODO: finish this
-	Server()->SendPackMsg(&Msg, MSGFLAG_VITAL, ClientID);
-	if(!Server()->IsSixup(ClientID) && GetClientVersion(ClientID) < VERSION_DDNET_MSG_LEGACY)
+	Server()->SendPackMsg(&Msg, MSGFLAG_VITAL, ClientId);
+	if(!Server()->IsSixup(ClientId) && GetClientVersion(ClientId) < VERSION_DDNET_MSG_LEGACY)
 	{
-		Server()->SendPackMsg(&MsgLegacy, MSGFLAG_VITAL, ClientID);
+		Server()->SendPackMsg(&MsgLegacy, MSGFLAG_VITAL, ClientId);
 	}
 }
 
-bool CGameContext::ProcessSpamProtection(int ClientID, bool RespectChatInitialDelay)
+bool CGameContext::ProcessSpamProtection(int ClientId, bool RespectChatInitialDelay)
 {
-	if(!m_apPlayers[ClientID])
+	if(!m_apPlayers[ClientId])
 		return false;
-	if(g_Config.m_SvSpamprotection && m_apPlayers[ClientID]->m_LastChat && m_apPlayers[ClientID]->m_LastChat + Server()->TickSpeed() * g_Config.m_SvChatDelay > Server()->Tick())
+	if(g_Config.m_SvSpamprotection && m_apPlayers[ClientId]->m_LastChat && m_apPlayers[ClientId]->m_LastChat + Server()->TickSpeed() * g_Config.m_SvChatDelay > Server()->Tick())
 		return true;
-	else if(g_Config.m_SvDnsblChat && Server()->DnsblBlack(ClientID))
+	else if(g_Config.m_SvDnsblChat && Server()->DnsblBlack(ClientId))
 	{
-		SendChatTarget(ClientID, "Players are not allowed to chat from VPNs at this time");
+		SendChatTarget(ClientId, "Players are not allowed to chat from VPNs at this time");
 		return true;
 	}
 	else
-		m_apPlayers[ClientID]->m_LastChat = Server()->Tick();
+		m_apPlayers[ClientId]->m_LastChat = Server()->Tick();
 
 	NETADDR Addr;
-	Server()->GetClientAddr(ClientID, &Addr);
+	Server()->GetClientAddr(ClientId, &Addr);
 
 	CMute Muted;
 	int Expires = 0;
@@ -4377,23 +4377,23 @@ bool CGameContext::ProcessSpamProtection(int ClientID, bool RespectChatInitialDe
 			str_format(aBuf, sizeof(aBuf), "This server has an initial chat delay, you will be able to talk in %d seconds.", Expires);
 		else
 			str_format(aBuf, sizeof(aBuf), "You are not permitted to talk for the next %d seconds.", Expires);
-		SendChatTarget(ClientID, aBuf);
+		SendChatTarget(ClientId, aBuf);
 		return true;
 	}
 
-	if(g_Config.m_SvSpamMuteDuration && (m_apPlayers[ClientID]->m_ChatScore += g_Config.m_SvChatPenalty) > g_Config.m_SvChatThreshold)
+	if(g_Config.m_SvSpamMuteDuration && (m_apPlayers[ClientId]->m_ChatScore += g_Config.m_SvChatPenalty) > g_Config.m_SvChatThreshold)
 	{
-		Mute(&Addr, g_Config.m_SvSpamMuteDuration, Server()->ClientName(ClientID));
-		m_apPlayers[ClientID]->m_ChatScore = 0;
+		Mute(&Addr, g_Config.m_SvSpamMuteDuration, Server()->ClientName(ClientId));
+		m_apPlayers[ClientId]->m_ChatScore = 0;
 		return true;
 	}
 
 	return false;
 }
 
-int CGameContext::GetDDRaceTeam(int ClientID) const
+int CGameContext::GetDDRaceTeam(int ClientId) const
 {
-	return m_pController->Teams().m_Core.Team(ClientID);
+	return m_pController->Teams().m_Core.Team(ClientId);
 }
 
 void CGameContext::ResetTuning()
@@ -4408,14 +4408,14 @@ void CGameContext::ResetTuning()
 	SendTuningParams(-1);
 }
 
-bool CheckClientID2(int ClientID)
+bool CheckClientId2(int ClientId)
 {
-	return ClientID >= 0 && ClientID < MAX_CLIENTS;
+	return ClientId >= 0 && ClientId < MAX_CLIENTS;
 }
 
-void CGameContext::Whisper(int ClientID, char *pStr)
+void CGameContext::Whisper(int ClientId, char *pStr)
 {
-	if(ProcessSpamProtection(ClientID))
+	if(ProcessSpamProtection(ClientId))
 		return;
 
 	pStr = str_skip_whitespaces(pStr);
@@ -4503,106 +4503,106 @@ void CGameContext::Whisper(int ClientID, char *pStr)
 
 	if(Error)
 	{
-		SendChatTarget(ClientID, "Invalid whisper");
+		SendChatTarget(ClientId, "Invalid whisper");
 		return;
 	}
 
-	if(Victim >= MAX_CLIENTS || !CheckClientID2(Victim))
+	if(Victim >= MAX_CLIENTS || !CheckClientId2(Victim))
 	{
 		char aBuf[256];
 		str_format(aBuf, sizeof(aBuf), "No player with name \"%s\" found", pName);
-		SendChatTarget(ClientID, aBuf);
+		SendChatTarget(ClientId, aBuf);
 		return;
 	}
 
-	WhisperID(ClientID, Victim, pStr);
+	WhisperId(ClientId, Victim, pStr);
 }
 
-void CGameContext::WhisperID(int ClientID, int VictimID, const char *pMessage)
+void CGameContext::WhisperId(int ClientId, int VictimId, const char *pMessage)
 {
-	if(!CheckClientID2(ClientID))
+	if(!CheckClientId2(ClientId))
 		return;
 
-	if(!CheckClientID2(VictimID))
+	if(!CheckClientId2(VictimId))
 		return;
 
-	if(m_apPlayers[ClientID])
-		m_apPlayers[ClientID]->m_LastWhisperTo = VictimID;
+	if(m_apPlayers[ClientId])
+		m_apPlayers[ClientId]->m_LastWhisperTo = VictimId;
 
 	char aCensoredMessage[256];
 	CensorMessage(aCensoredMessage, pMessage, sizeof(aCensoredMessage));
 
 	char aBuf[256];
 
-	if(Server()->IsSixup(ClientID))
+	if(Server()->IsSixup(ClientId))
 	{
 		protocol7::CNetMsg_Sv_Chat Msg;
-		Msg.m_ClientID = ClientID;
+		Msg.m_ClientId = ClientId;
 		Msg.m_Mode = protocol7::CHAT_WHISPER;
 		Msg.m_pMessage = aCensoredMessage;
-		Msg.m_TargetID = VictimID;
+		Msg.m_TargetId = VictimId;
 
-		Server()->SendPackMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_NORECORD, ClientID);
+		Server()->SendPackMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_NORECORD, ClientId);
 	}
-	else if(GetClientVersion(ClientID) >= VERSION_DDNET_WHISPER)
+	else if(GetClientVersion(ClientId) >= VERSION_DDNET_WHISPER)
 	{
 		CNetMsg_Sv_Chat Msg;
 		Msg.m_Team = CHAT_WHISPER_SEND;
-		Msg.m_ClientID = VictimID;
+		Msg.m_ClientId = VictimId;
 		Msg.m_pMessage = aCensoredMessage;
 		if(g_Config.m_SvDemoChat)
-			Server()->SendPackMsg(&Msg, MSGFLAG_VITAL, ClientID);
+			Server()->SendPackMsg(&Msg, MSGFLAG_VITAL, ClientId);
 		else
-			Server()->SendPackMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_NORECORD, ClientID);
+			Server()->SendPackMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_NORECORD, ClientId);
 	}
 	else
 	{
-		str_format(aBuf, sizeof(aBuf), "[→ %s] %s", Server()->ClientName(VictimID), aCensoredMessage);
-		SendChatTarget(ClientID, aBuf);
+		str_format(aBuf, sizeof(aBuf), "[→ %s] %s", Server()->ClientName(VictimId), aCensoredMessage);
+		SendChatTarget(ClientId, aBuf);
 	}
 
-	if(Server()->IsSixup(VictimID))
+	if(Server()->IsSixup(VictimId))
 	{
 		protocol7::CNetMsg_Sv_Chat Msg;
-		Msg.m_ClientID = ClientID;
+		Msg.m_ClientId = ClientId;
 		Msg.m_Mode = protocol7::CHAT_WHISPER;
 		Msg.m_pMessage = aCensoredMessage;
-		Msg.m_TargetID = VictimID;
+		Msg.m_TargetId = VictimId;
 
-		Server()->SendPackMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_NORECORD, VictimID);
+		Server()->SendPackMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_NORECORD, VictimId);
 	}
-	else if(GetClientVersion(VictimID) >= VERSION_DDNET_WHISPER)
+	else if(GetClientVersion(VictimId) >= VERSION_DDNET_WHISPER)
 	{
 		CNetMsg_Sv_Chat Msg2;
 		Msg2.m_Team = CHAT_WHISPER_RECV;
-		Msg2.m_ClientID = ClientID;
+		Msg2.m_ClientId = ClientId;
 		Msg2.m_pMessage = aCensoredMessage;
 		if(g_Config.m_SvDemoChat)
-			Server()->SendPackMsg(&Msg2, MSGFLAG_VITAL, VictimID);
+			Server()->SendPackMsg(&Msg2, MSGFLAG_VITAL, VictimId);
 		else
-			Server()->SendPackMsg(&Msg2, MSGFLAG_VITAL | MSGFLAG_NORECORD, VictimID);
+			Server()->SendPackMsg(&Msg2, MSGFLAG_VITAL | MSGFLAG_NORECORD, VictimId);
 	}
 	else
 	{
-		str_format(aBuf, sizeof(aBuf), "[← %s] %s", Server()->ClientName(ClientID), aCensoredMessage);
-		SendChatTarget(VictimID, aBuf);
+		str_format(aBuf, sizeof(aBuf), "[← %s] %s", Server()->ClientName(ClientId), aCensoredMessage);
+		SendChatTarget(VictimId, aBuf);
 	}
 }
 
-void CGameContext::Converse(int ClientID, char *pStr)
+void CGameContext::Converse(int ClientId, char *pStr)
 {
-	CPlayer *pPlayer = m_apPlayers[ClientID];
+	CPlayer *pPlayer = m_apPlayers[ClientId];
 	if(!pPlayer)
 		return;
 
-	if(ProcessSpamProtection(ClientID))
+	if(ProcessSpamProtection(ClientId))
 		return;
 
 	if(pPlayer->m_LastWhisperTo < 0)
-		SendChatTarget(ClientID, "You do not have an ongoing conversation. Whisper to someone to start one");
+		SendChatTarget(ClientId, "You do not have an ongoing conversation. Whisper to someone to start one");
 	else
 	{
-		WhisperID(ClientID, pPlayer->m_LastWhisperTo, pStr);
+		WhisperId(ClientId, pPlayer->m_LastWhisperTo, pStr);
 	}
 }
 
@@ -4614,7 +4614,7 @@ bool CGameContext::IsVersionBanned(int Version)
 	return str_in_list(g_Config.m_SvBannedVersions, ",", aVersion);
 }
 
-void CGameContext::List(int ClientID, const char *pFilter)
+void CGameContext::List(int ClientId, const char *pFilter)
 {
 	int Total = 0;
 	char aBuf[256];
@@ -4623,7 +4623,7 @@ void CGameContext::List(int ClientID, const char *pFilter)
 		str_format(aBuf, sizeof(aBuf), "Listing players with \"%s\" in name:", pFilter);
 	else
 		str_copy(aBuf, "Listing all players:");
-	SendChatTarget(ClientID, aBuf);
+	SendChatTarget(ClientId, aBuf);
 	for(int i = 0; i < MAX_CLIENTS; i++)
 	{
 		if(m_apPlayers[i])
@@ -4634,7 +4634,7 @@ void CGameContext::List(int ClientID, const char *pFilter)
 				continue;
 			if(Bufcnt + str_length(pName) + 4 > 256)
 			{
-				SendChatTarget(ClientID, aBuf);
+				SendChatTarget(ClientId, aBuf);
 				Bufcnt = 0;
 			}
 			if(Bufcnt != 0)
@@ -4650,14 +4650,14 @@ void CGameContext::List(int ClientID, const char *pFilter)
 		}
 	}
 	if(Bufcnt != 0)
-		SendChatTarget(ClientID, aBuf);
+		SendChatTarget(ClientId, aBuf);
 	str_format(aBuf, sizeof(aBuf), "%d players online", Total);
-	SendChatTarget(ClientID, aBuf);
+	SendChatTarget(ClientId, aBuf);
 }
 
-int CGameContext::GetClientVersion(int ClientID) const
+int CGameContext::GetClientVersion(int ClientId) const
 {
-	return Server()->GetClientVersion(ClientID);
+	return Server()->GetClientVersion(ClientId);
 }
 
 CClientMask CGameContext::ClientsMaskExcludeClientVersionAndHigher(int Version) const
@@ -4677,14 +4677,14 @@ bool CGameContext::PlayerModerating() const
 	return std::any_of(std::begin(m_apPlayers), std::end(m_apPlayers), [](const CPlayer *pPlayer) { return pPlayer && pPlayer->m_Moderating; });
 }
 
-void CGameContext::ForceVote(int EnforcerID, bool Success)
+void CGameContext::ForceVote(int EnforcerId, bool Success)
 {
 	// check if there is a vote running
 	if(!m_VoteCloseTime)
 		return;
 
 	m_VoteEnforce = Success ? CGameContext::VOTE_ENFORCE_YES_ADMIN : CGameContext::VOTE_ENFORCE_NO_ADMIN;
-	m_VoteEnforcer = EnforcerID;
+	m_VoteEnforcer = EnforcerId;
 
 	char aBuf[256];
 	const char *pOption = Success ? "yes" : "no";
@@ -4694,28 +4694,28 @@ void CGameContext::ForceVote(int EnforcerID, bool Success)
 	Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "server", aBuf);
 }
 
-bool CGameContext::RateLimitPlayerVote(int ClientID)
+bool CGameContext::RateLimitPlayerVote(int ClientId)
 {
 	int64_t Now = Server()->Tick();
 	int64_t TickSpeed = Server()->TickSpeed();
-	CPlayer *pPlayer = m_apPlayers[ClientID];
+	CPlayer *pPlayer = m_apPlayers[ClientId];
 
-	if(g_Config.m_SvRconVote && !Server()->GetAuthedState(ClientID))
+	if(g_Config.m_SvRconVote && !Server()->GetAuthedState(ClientId))
 	{
-		SendChatTarget(ClientID, "You can only vote after logging in.");
+		SendChatTarget(ClientId, "You can only vote after logging in.");
 		return true;
 	}
 
 	if(g_Config.m_SvDnsblVote && Server()->DistinctClientCount() > 1)
 	{
-		if(m_pServer->DnsblPending(ClientID))
+		if(m_pServer->DnsblPending(ClientId))
 		{
-			SendChatTarget(ClientID, "You are not allowed to vote because we're currently checking for VPNs. Try again in ~30 seconds.");
+			SendChatTarget(ClientId, "You are not allowed to vote because we're currently checking for VPNs. Try again in ~30 seconds.");
 			return true;
 		}
-		else if(m_pServer->DnsblBlack(ClientID))
+		else if(m_pServer->DnsblBlack(ClientId))
 		{
-			SendChatTarget(ClientID, "You are not allowed to vote because you appear to be using a VPN. Try connecting without a VPN or contacting an admin if you think this is a mistake.");
+			SendChatTarget(ClientId, "You are not allowed to vote because you appear to be using a VPN. Try connecting without a VPN or contacting an admin if you think this is a mistake.");
 			return true;
 		}
 	}
@@ -4726,7 +4726,7 @@ bool CGameContext::RateLimitPlayerVote(int ClientID)
 	pPlayer->m_LastVoteTry = Now;
 	if(m_VoteCloseTime)
 	{
-		SendChatTarget(ClientID, "Wait for current vote to end before calling a new one.");
+		SendChatTarget(ClientId, "Wait for current vote to end before calling a new one.");
 		return true;
 	}
 
@@ -4734,7 +4734,7 @@ bool CGameContext::RateLimitPlayerVote(int ClientID)
 	{
 		char aBuf[64];
 		str_format(aBuf, sizeof(aBuf), "You must wait %d seconds before making your first vote.", (int)((pPlayer->m_FirstVoteTick - Now) / TickSpeed) + 1);
-		SendChatTarget(ClientID, aBuf);
+		SendChatTarget(ClientId, aBuf);
 		return true;
 	}
 
@@ -4743,12 +4743,12 @@ bool CGameContext::RateLimitPlayerVote(int ClientID)
 	{
 		char aChatmsg[64];
 		str_format(aChatmsg, sizeof(aChatmsg), "You must wait %d seconds before making another vote.", (int)(TimeLeft / TickSpeed) + 1);
-		SendChatTarget(ClientID, aChatmsg);
+		SendChatTarget(ClientId, aChatmsg);
 		return true;
 	}
 
 	NETADDR Addr;
-	Server()->GetClientAddr(ClientID, &Addr);
+	Server()->GetClientAddr(ClientId, &Addr);
 	int VoteMuted = 0;
 	for(int i = 0; i < m_NumVoteMutes && !VoteMuted; i++)
 		if(!net_addr_comp_noport(&Addr, &m_aVoteMutes[i].m_Addr))
@@ -4762,43 +4762,43 @@ bool CGameContext::RateLimitPlayerVote(int ClientID)
 	{
 		char aChatmsg[64];
 		str_format(aChatmsg, sizeof(aChatmsg), "You are not permitted to vote for the next %d seconds.", VoteMuted);
-		SendChatTarget(ClientID, aChatmsg);
+		SendChatTarget(ClientId, aChatmsg);
 		return true;
 	}
 	return false;
 }
 
-bool CGameContext::RateLimitPlayerMapVote(int ClientID) const
+bool CGameContext::RateLimitPlayerMapVote(int ClientId) const
 {
-	if(!Server()->GetAuthedState(ClientID) && time_get() < m_LastMapVote + (time_freq() * g_Config.m_SvVoteMapTimeDelay))
+	if(!Server()->GetAuthedState(ClientId) && time_get() < m_LastMapVote + (time_freq() * g_Config.m_SvVoteMapTimeDelay))
 	{
 		char aChatmsg[512] = {0};
 		str_format(aChatmsg, sizeof(aChatmsg), "There's a %d second delay between map-votes, please wait %d seconds.",
 			g_Config.m_SvVoteMapTimeDelay, (int)((m_LastMapVote + g_Config.m_SvVoteMapTimeDelay * time_freq() - time_get()) / time_freq()));
-		SendChatTarget(ClientID, aChatmsg);
+		SendChatTarget(ClientId, aChatmsg);
 		return true;
 	}
 	return false;
 }
 
-void CGameContext::OnUpdatePlayerServerInfo(char *aBuf, int BufSize, int ID)
+void CGameContext::OnUpdatePlayerServerInfo(char *aBuf, int BufSize, int Id)
 {
 	if(BufSize <= 0)
 		return;
 
 	aBuf[0] = '\0';
 
-	if(!m_apPlayers[ID])
+	if(!m_apPlayers[Id])
 		return;
 
 	char aCSkinName[64];
 
-	CTeeInfo &TeeInfo = m_apPlayers[ID]->m_TeeInfos;
+	CTeeInfo &TeeInfo = m_apPlayers[Id]->m_TeeInfos;
 
 	char aJsonSkin[400];
 	aJsonSkin[0] = '\0';
 
-	if(!Server()->IsSixup(ID))
+	if(!Server()->IsSixup(Id))
 	{
 		// 0.6
 		if(TeeInfo.m_UseCustomColor)
@@ -4845,7 +4845,7 @@ void CGameContext::OnUpdatePlayerServerInfo(char *aBuf, int BufSize, int ID)
 		}
 	}
 
-	const int Team = m_pController->IsTeamPlay() ? m_apPlayers[ID]->GetTeam() : m_apPlayers[ID]->GetTeam() == TEAM_SPECTATORS ? -1 : GetDDRaceTeam(ID);
+	const int Team = m_pController->IsTeamPlay() ? m_apPlayers[Id]->GetTeam() : m_apPlayers[Id]->GetTeam() == TEAM_SPECTATORS ? -1 : GetDDRaceTeam(Id);
 	str_format(aBuf, BufSize,
 		",\"skin\":{"
 		"%s"
@@ -4853,6 +4853,6 @@ void CGameContext::OnUpdatePlayerServerInfo(char *aBuf, int BufSize, int ID)
 		"\"afk\":%s,"
 		"\"team\":%d",
 		aJsonSkin,
-		JsonBool(m_apPlayers[ID]->IsAfk()),
+		JsonBool(m_apPlayers[Id]->IsAfk()),
 		Team);
 }

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -101,7 +101,7 @@ class CGameContext : public IGameServer
 
 	bool m_Resetting;
 
-	static void CommandCallback(int ClientID, int FlagMask, const char *pCmd, IConsole::IResult *pResult, void *pUser);
+	static void CommandCallback(int ClientId, int FlagMask, const char *pCmd, IConsole::IResult *pResult, void *pUser);
 	static void TeeHistorianWrite(const void *pData, int DataSize, void *pUser);
 
 	static void ConTuneParam(IConsole::IResult *pResult, void *pUserData);
@@ -182,23 +182,23 @@ public:
 	bool m_aPlayerHasInput[MAX_CLIENTS];
 
 	// returns last input if available otherwise nulled PlayerInput object
-	// ClientID has to be valid
-	CNetObj_PlayerInput GetLastPlayerInput(int ClientID) const;
+	// ClientId has to be valid
+	CNetObj_PlayerInput GetLastPlayerInput(int ClientId) const;
 
 	IGameController *m_pController;
 	CGameWorld m_World;
 
 	// helper functions
-	class CCharacter *GetPlayerChar(int ClientID);
+	class CCharacter *GetPlayerChar(int ClientId);
 	bool EmulateBug(int Bug);
 	std::vector<SSwitchers> &Switchers() { return m_World.m_Core.m_vSwitchers; }
 
 	// voting
 	void StartVote(const char *pDesc, const char *pCommand, const char *pReason, const char *pSixupDesc);
 	void EndVote();
-	void SendVoteSet(int ClientID);
-	void SendVoteStatus(int ClientID, int Total, int Yes, int No);
-	void AbortVoteKickOnDisconnect(int ClientID);
+	void SendVoteSet(int ClientId);
+	void SendVoteStatus(int ClientId, int Total, int Yes, int No);
+	void AbortVoteKickOnDisconnect(int ClientId);
 
 	int m_VoteCreator;
 	int m_VoteType;
@@ -235,13 +235,13 @@ public:
 	void CreateExplosion(vec2 Pos, int Owner, int Weapon, bool NoDamage, int ActivatedTeam, CClientMask Mask = CClientMask().set());
 	void CreateHammerHit(vec2 Pos, CClientMask Mask = CClientMask().set());
 	void CreatePlayerSpawn(vec2 Pos, CClientMask Mask = CClientMask().set());
-	void CreateDeath(vec2 Pos, int ClientID, CClientMask Mask = CClientMask().set());
+	void CreateDeath(vec2 Pos, int ClientId, CClientMask Mask = CClientMask().set());
 	void CreateSound(vec2 Pos, int Sound, CClientMask Mask = CClientMask().set());
 	void CreateSoundGlobal(int Sound, int Target = -1) const;
 
 	void SnapSwitchers(int SnappingClient);
-	bool SnapLaserObject(const CSnapContext &Context, int SnapID, const vec2 &To, const vec2 &From, int StartTick, int Owner = -1, int LaserType = -1, int Subtype = -1, int SwitchNumber = -1) const;
-	bool SnapPickup(const CSnapContext &Context, int SnapID, const vec2 &Pos, int Type, int SubType, int SwitchNumber) const;
+	bool SnapLaserObject(const CSnapContext &Context, int SnapId, const vec2 &To, const vec2 &From, int StartTick, int Owner = -1, int LaserType = -1, int Subtype = -1, int SwitchNumber = -1) const;
+	bool SnapPickup(const CSnapContext &Context, int SnapId, const vec2 &Pos, int Type, int SubType, int SwitchNumber) const;
 
 	enum
 	{
@@ -257,25 +257,25 @@ public:
 	};
 
 	// network
-	void CallVote(int ClientID, const char *pDesc, const char *pCmd, const char *pReason, const char *pChatmsg, const char *pSixupDesc = 0);
+	void CallVote(int ClientId, const char *pDesc, const char *pCmd, const char *pReason, const char *pChatmsg, const char *pSixupDesc = 0);
 	void SendChatTarget(int To, const char *pText, int Flags = CHAT_SIX | CHAT_SIXUP) const;
 	void SendChatTeam(int Team, const char *pText) const;
-	void SendChat(int ClientID, int Team, const char *pText, int SpamProtectionClientID = -1, int Flags = CHAT_SIX | CHAT_SIXUP);
-	void SendStartWarning(int ClientID, const char *pMessage);
-	void SendEmoticon(int ClientID, int Emoticon, int TargetClientID) const;
-	void SendWeaponPickup(int ClientID, int Weapon) const;
-	void SendMotd(int ClientID) const;
-	void SendSettings(int ClientID) const;
-	void SendBroadcast(const char *pText, int ClientID, bool IsImportant = true);
+	void SendChat(int ClientId, int Team, const char *pText, int SpamProtectionClientId = -1, int Flags = CHAT_SIX | CHAT_SIXUP);
+	void SendStartWarning(int ClientId, const char *pMessage);
+	void SendEmoticon(int ClientId, int Emoticon, int TargetClientId) const;
+	void SendWeaponPickup(int ClientId, int Weapon) const;
+	void SendMotd(int ClientId) const;
+	void SendSettings(int ClientId) const;
+	void SendBroadcast(const char *pText, int ClientId, bool IsImportant = true);
 
-	void List(int ClientID, const char *pFilter);
+	void List(int ClientId, const char *pFilter);
 
 	//
 	void CheckPureTuning();
-	void SendTuningParams(int ClientID, int Zone = 0);
+	void SendTuningParams(int ClientId, int Zone = 0);
 
 	const CVoteOptionServer *GetVoteOption(int Index) const;
-	void ProgressVoteOptions(int ClientID);
+	void ProgressVoteOptions(int ClientId);
 
 	//
 	void LoadMapSettings();
@@ -290,44 +290,44 @@ public:
 
 	void OnTick() override;
 	void OnPreSnap() override;
-	void OnSnap(int ClientID) override;
+	void OnSnap(int ClientId) override;
 	void OnPostSnap() override;
 
 	void UpdatePlayerMaps();
 
-	void *PreProcessMsg(int *pMsgID, CUnpacker *pUnpacker, int ClientID);
+	void *PreProcessMsg(int *pMsgId, CUnpacker *pUnpacker, int ClientId);
 	void CensorMessage(char *pCensoredMessage, const char *pMessage, int Size);
-	void OnMessage(int MsgID, CUnpacker *pUnpacker, int ClientID) override;
-	void OnSayNetMessage(const CNetMsg_Cl_Say *pMsg, int ClientID, const CUnpacker *pUnpacker);
-	void OnCallVoteNetMessage(const CNetMsg_Cl_CallVote *pMsg, int ClientID);
-	void OnVoteNetMessage(const CNetMsg_Cl_Vote *pMsg, int ClientID);
-	void OnSetTeamNetMessage(const CNetMsg_Cl_SetTeam *pMsg, int ClientID);
-	void OnIsDDNetLegacyNetMessage(const CNetMsg_Cl_IsDDNetLegacy *pMsg, int ClientID, CUnpacker *pUnpacker);
-	void OnShowOthersLegacyNetMessage(const CNetMsg_Cl_ShowOthersLegacy *pMsg, int ClientID);
-	void OnShowOthersNetMessage(const CNetMsg_Cl_ShowOthers *pMsg, int ClientID);
-	void OnShowDistanceNetMessage(const CNetMsg_Cl_ShowDistance *pMsg, int ClientID);
-	void OnSetSpectatorModeNetMessage(const CNetMsg_Cl_SetSpectatorMode *pMsg, int ClientID);
-	void OnChangeInfoNetMessage(const CNetMsg_Cl_ChangeInfo *pMsg, int ClientID);
-	void OnEmoticonNetMessage(const CNetMsg_Cl_Emoticon *pMsg, int ClientID);
-	void OnKillNetMessage(const CNetMsg_Cl_Kill *pMsg, int ClientID);
-	void OnStartInfoNetMessage(const CNetMsg_Cl_StartInfo *pMsg, int ClientID);
+	void OnMessage(int MsgId, CUnpacker *pUnpacker, int ClientId) override;
+	void OnSayNetMessage(const CNetMsg_Cl_Say *pMsg, int ClientId, const CUnpacker *pUnpacker);
+	void OnCallVoteNetMessage(const CNetMsg_Cl_CallVote *pMsg, int ClientId);
+	void OnVoteNetMessage(const CNetMsg_Cl_Vote *pMsg, int ClientId);
+	void OnSetTeamNetMessage(const CNetMsg_Cl_SetTeam *pMsg, int ClientId);
+	void OnIsDDNetLegacyNetMessage(const CNetMsg_Cl_IsDDNetLegacy *pMsg, int ClientId, CUnpacker *pUnpacker);
+	void OnShowOthersLegacyNetMessage(const CNetMsg_Cl_ShowOthersLegacy *pMsg, int ClientId);
+	void OnShowOthersNetMessage(const CNetMsg_Cl_ShowOthers *pMsg, int ClientId);
+	void OnShowDistanceNetMessage(const CNetMsg_Cl_ShowDistance *pMsg, int ClientId);
+	void OnSetSpectatorModeNetMessage(const CNetMsg_Cl_SetSpectatorMode *pMsg, int ClientId);
+	void OnChangeInfoNetMessage(const CNetMsg_Cl_ChangeInfo *pMsg, int ClientId);
+	void OnEmoticonNetMessage(const CNetMsg_Cl_Emoticon *pMsg, int ClientId);
+	void OnKillNetMessage(const CNetMsg_Cl_Kill *pMsg, int ClientId);
+	void OnStartInfoNetMessage(const CNetMsg_Cl_StartInfo *pMsg, int ClientId);
 
-	bool OnClientDataPersist(int ClientID, void *pData) override;
-	void OnClientConnected(int ClientID, void *pData) override;
-	void OnClientEnter(int ClientID) override;
-	void OnClientDrop(int ClientID, const char *pReason) override;
-	void OnClientPrepareInput(int ClientID, void *pInput) override;
-	void OnClientDirectInput(int ClientID, void *pInput) override;
-	void OnClientPredictedInput(int ClientID, void *pInput) override;
-	void OnClientPredictedEarlyInput(int ClientID, void *pInput) override;
+	bool OnClientDataPersist(int ClientId, void *pData) override;
+	void OnClientConnected(int ClientId, void *pData) override;
+	void OnClientEnter(int ClientId) override;
+	void OnClientDrop(int ClientId, const char *pReason) override;
+	void OnClientPrepareInput(int ClientId, void *pInput) override;
+	void OnClientDirectInput(int ClientId, void *pInput) override;
+	void OnClientPredictedInput(int ClientId, void *pInput) override;
+	void OnClientPredictedEarlyInput(int ClientId, void *pInput) override;
 
 	void TeehistorianRecordAntibot(const void *pData, int DataSize) override;
-	void TeehistorianRecordPlayerJoin(int ClientID, bool Sixup) override;
-	void TeehistorianRecordPlayerDrop(int ClientID, const char *pReason) override;
-	void TeehistorianRecordPlayerRejoin(int ClientID) override;
+	void TeehistorianRecordPlayerJoin(int ClientId, bool Sixup) override;
+	void TeehistorianRecordPlayerDrop(int ClientId, const char *pReason) override;
+	void TeehistorianRecordPlayerRejoin(int ClientId) override;
 
-	bool IsClientReady(int ClientID) const override;
-	bool IsClientPlayer(int ClientID) const override;
+	bool IsClientReady(int ClientId) const override;
+	bool IsClientPlayer(int ClientId) const override;
 	int PersistentDataSize() const override { return sizeof(CPersistentData); }
 	int PersistentClientDataSize() const override { return sizeof(CPersistentClientData); }
 
@@ -338,31 +338,31 @@ public:
 
 	// DDRace
 	void OnPreTickTeehistorian() override;
-	bool OnClientDDNetVersionKnown(int ClientID);
+	bool OnClientDDNetVersionKnown(int ClientId);
 	void FillAntibot(CAntibotRoundData *pData) override;
-	bool ProcessSpamProtection(int ClientID, bool RespectChatInitialDelay = true);
-	int GetDDRaceTeam(int ClientID) const;
+	bool ProcessSpamProtection(int ClientId, bool RespectChatInitialDelay = true);
+	int GetDDRaceTeam(int ClientId) const;
 	// Describes the time when the first player joined the server.
 	int64_t m_NonEmptySince;
 	int64_t m_LastMapVote;
-	int GetClientVersion(int ClientID) const;
+	int GetClientVersion(int ClientId) const;
 	CClientMask ClientsMaskExcludeClientVersionAndHigher(int Version) const;
-	bool PlayerExists(int ClientID) const override { return m_apPlayers[ClientID]; }
+	bool PlayerExists(int ClientId) const override { return m_apPlayers[ClientId]; }
 	// Returns true if someone is actively moderating.
 	bool PlayerModerating() const;
-	void ForceVote(int EnforcerID, bool Success);
+	void ForceVote(int EnforcerId, bool Success);
 
 	// Checks if player can vote and notify them about the reason
-	bool RateLimitPlayerVote(int ClientID);
-	bool RateLimitPlayerMapVote(int ClientID) const;
+	bool RateLimitPlayerVote(int ClientId);
+	bool RateLimitPlayerMapVote(int ClientId) const;
 
-	void OnUpdatePlayerServerInfo(char *aBuf, int BufSize, int ID) override;
+	void OnUpdatePlayerServerInfo(char *aBuf, int BufSize, int Id) override;
 
 	std::shared_ptr<CScoreRandomMapResult> m_SqlRandomMapResult;
 
 private:
 	// starting 1 to make 0 the special value "no client id"
-	uint32_t NextUniqueClientID = 1;
+	uint32_t NextUniqueClientId = 1;
 	bool m_VoteWillPass;
 	CScore *m_pScore;
 
@@ -398,7 +398,7 @@ private:
 	static void ConRemoveWeapon(IConsole::IResult *pResult, void *pUserData);
 
 	void ModifyWeapons(IConsole::IResult *pResult, void *pUserData, int Weapon, bool Remove);
-	void MoveCharacter(int ClientID, int X, int Y, bool Raw = false);
+	void MoveCharacter(int ClientId, int X, int Y, bool Raw = false);
 	static void ConGoLeft(IConsole::IResult *pResult, void *pUserData);
 	static void ConGoRight(IConsole::IResult *pResult, void *pUserData);
 	static void ConGoUp(IConsole::IResult *pResult, void *pUserData);
@@ -472,10 +472,10 @@ private:
 	static void ConVoteUnmute(IConsole::IResult *pResult, void *pUserData);
 	static void ConVoteMutes(IConsole::IResult *pResult, void *pUserData);
 	static void ConMute(IConsole::IResult *pResult, void *pUserData);
-	static void ConMuteID(IConsole::IResult *pResult, void *pUserData);
-	static void ConMuteIP(IConsole::IResult *pResult, void *pUserData);
+	static void ConMuteId(IConsole::IResult *pResult, void *pUserData);
+	static void ConMuteIp(IConsole::IResult *pResult, void *pUserData);
 	static void ConUnmute(IConsole::IResult *pResult, void *pUserData);
-	static void ConUnmuteID(IConsole::IResult *pResult, void *pUserData);
+	static void ConUnmuteId(IConsole::IResult *pResult, void *pUserData);
 	static void ConMutes(IConsole::IResult *pResult, void *pUserData);
 	static void ConModerate(IConsole::IResult *pResult, void *pUserData);
 
@@ -505,14 +505,14 @@ private:
 	bool TryMute(const NETADDR *pAddr, int Secs, const char *pReason, bool InitialChatDelay);
 	void Mute(const NETADDR *pAddr, int Secs, const char *pDisplayName, const char *pReason = "", bool InitialChatDelay = false);
 	bool TryVoteMute(const NETADDR *pAddr, int Secs, const char *pReason);
-	void VoteMute(const NETADDR *pAddr, int Secs, const char *pReason, const char *pDisplayName, int AuthedID);
-	bool VoteUnmute(const NETADDR *pAddr, const char *pDisplayName, int AuthedID);
-	void Whisper(int ClientID, char *pStr);
-	void WhisperID(int ClientID, int VictimID, const char *pMessage);
-	void Converse(int ClientID, char *pStr);
+	void VoteMute(const NETADDR *pAddr, int Secs, const char *pReason, const char *pDisplayName, int AuthedId);
+	bool VoteUnmute(const NETADDR *pAddr, const char *pDisplayName, int AuthedId);
+	void Whisper(int ClientId, char *pStr);
+	void WhisperId(int ClientId, int VictimId, const char *pMessage);
+	void Converse(int ClientId, char *pStr);
 	bool IsVersionBanned(int Version);
-	void UnlockTeam(int ClientID, int Team) const;
-	void AttemptJoinTeam(int ClientID, int Team);
+	void UnlockTeam(int ClientId, int Team) const;
+	void AttemptJoinTeam(int ClientId, int Team);
 
 	enum
 	{
@@ -531,7 +531,7 @@ private:
 	CLog m_aLogs[MAX_LOGS];
 	int m_LatestLog;
 
-	void LogEvent(const char *Description, int ClientID);
+	void LogEvent(const char *Description, int ClientId);
 
 public:
 	CLayers *Layers() { return &m_Layers; }
@@ -554,8 +554,8 @@ public:
 	inline bool IsKickVote() const { return m_VoteType == VOTE_TYPE_KICK; }
 	inline bool IsSpecVote() const { return m_VoteType == VOTE_TYPE_SPECTATE; }
 
-	void SendRecord(int ClientID);
-	void OnSetAuthed(int ClientID, int Level) override;
+	void SendRecord(int ClientId);
+	void OnSetAuthed(int ClientId, int Level) override;
 
 	void ResetTuning();
 };

--- a/src/game/server/gamecontroller.cpp
+++ b/src/game/server/gamecontroller.cpp
@@ -96,7 +96,7 @@ float IGameController::EvaluateSpawnPos(CSpawnEval *pEval, vec2 Pos, int DDTeam)
 	for(; pC; pC = (CCharacter *)pC->TypeNext())
 	{
 		// ignore players in other teams
-		if(GameServer()->GetDDRaceTeam(pC->GetPlayer()->GetCID()) != DDTeam)
+		if(GameServer()->GetDDRaceTeam(pC->GetPlayer()->GetCid()) != DDTeam)
 			continue;
 
 		float d = distance(Pos, pC->m_Pos);
@@ -390,13 +390,13 @@ bool IGameController::OnEntity(int Index, int x, int y, int Layer, int Flags, bo
 
 void IGameController::OnPlayerConnect(CPlayer *pPlayer)
 {
-	int ClientID = pPlayer->GetCID();
+	int ClientId = pPlayer->GetCid();
 	pPlayer->Respawn();
 
-	if(!Server()->ClientPrevIngame(ClientID))
+	if(!Server()->ClientPrevIngame(ClientId))
 	{
 		char aBuf[128];
-		str_format(aBuf, sizeof(aBuf), "team_join player='%d:%s' team=%d", ClientID, Server()->ClientName(ClientID), pPlayer->GetTeam());
+		str_format(aBuf, sizeof(aBuf), "team_join player='%d:%s' team=%d", ClientId, Server()->ClientName(ClientId), pPlayer->GetTeam());
 		GameServer()->Console()->Print(IConsole::OUTPUT_LEVEL_DEBUG, "game", aBuf);
 	}
 }
@@ -404,17 +404,17 @@ void IGameController::OnPlayerConnect(CPlayer *pPlayer)
 void IGameController::OnPlayerDisconnect(class CPlayer *pPlayer, const char *pReason)
 {
 	pPlayer->OnDisconnect();
-	int ClientID = pPlayer->GetCID();
-	if(Server()->ClientIngame(ClientID))
+	int ClientId = pPlayer->GetCid();
+	if(Server()->ClientIngame(ClientId))
 	{
 		char aBuf[512];
 		if(pReason && *pReason)
-			str_format(aBuf, sizeof(aBuf), "'%s' has left the game (%s)", Server()->ClientName(ClientID), pReason);
+			str_format(aBuf, sizeof(aBuf), "'%s' has left the game (%s)", Server()->ClientName(ClientId), pReason);
 		else
-			str_format(aBuf, sizeof(aBuf), "'%s' has left the game", Server()->ClientName(ClientID));
+			str_format(aBuf, sizeof(aBuf), "'%s' has left the game", Server()->ClientName(ClientId));
 		GameServer()->SendChat(-1, CGameContext::CHAT_ALL, aBuf, -1, CGameContext::CHAT_SIX);
 
-		str_format(aBuf, sizeof(aBuf), "leave player='%d:%s'", ClientID, Server()->ClientName(ClientID));
+		str_format(aBuf, sizeof(aBuf), "leave player='%d:%s'", ClientId, Server()->ClientName(ClientId));
 		GameServer()->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "game", aBuf);
 	}
 }
@@ -476,7 +476,7 @@ int IGameController::OnCharacterDeath(class CCharacter *pVictim, class CPlayer *
 void IGameController::OnCharacterSpawn(class CCharacter *pChr)
 {
 	pChr->SetTeams(&Teams());
-	Teams().OnCharacterSpawn(pChr->GetPlayer()->GetCID());
+	Teams().OnCharacterSpawn(pChr->GetPlayer()->GetCid());
 
 	// default health
 	pChr->IncreaseHealth(10);
@@ -506,7 +506,7 @@ bool IGameController::IsForceBalanced()
 	return false;
 }
 
-bool IGameController::CanBeMovedOnBalance(int ClientID)
+bool IGameController::CanBeMovedOnBalance(int ClientId)
 {
 	return true;
 }
@@ -577,7 +577,7 @@ void IGameController::Snap(int SnappingClient)
 
 	if(pPlayer && (pPlayer->m_TimerType == CPlayer::TIMERTYPE_GAMETIMER || pPlayer->m_TimerType == CPlayer::TIMERTYPE_GAMETIMER_AND_BROADCAST) && pPlayer->GetClientVersion() >= VERSION_DDNET_GAMETICK)
 	{
-		if((pPlayer->GetTeam() == TEAM_SPECTATORS || pPlayer->IsPaused()) && pPlayer->m_SpectatorID != SPEC_FREEVIEW && (pPlayer2 = GameServer()->m_apPlayers[pPlayer->m_SpectatorID]))
+		if((pPlayer->GetTeam() == TEAM_SPECTATORS || pPlayer->IsPaused()) && pPlayer->m_SpectatorId != SPEC_FREEVIEW && (pPlayer2 = GameServer()->m_apPlayers[pPlayer->m_SpectatorId]))
 		{
 			if((pChr = pPlayer2->GetCharacter()) && pChr->m_DDRaceState == DDRACE_STARTED)
 			{
@@ -648,12 +648,12 @@ void IGameController::Snap(int SnappingClient)
 	GameServer()->SnapSwitchers(SnappingClient);
 }
 
-int IGameController::GetAutoTeam(int NotThisID)
+int IGameController::GetAutoTeam(int NotThisId)
 {
 	int aNumplayers[2] = {0, 0};
 	for(int i = 0; i < MAX_CLIENTS; i++)
 	{
-		if(GameServer()->m_apPlayers[i] && i != NotThisID)
+		if(GameServer()->m_apPlayers[i] && i != NotThisId)
 		{
 			if(GameServer()->m_apPlayers[i]->GetTeam() >= TEAM_RED && GameServer()->m_apPlayers[i]->GetTeam() <= TEAM_BLUE)
 				aNumplayers[GameServer()->m_apPlayers[i]->GetTeam()]++;
@@ -662,14 +662,14 @@ int IGameController::GetAutoTeam(int NotThisID)
 
 	int Team = 0;
 
-	if(CanJoinTeam(Team, NotThisID, nullptr, 0))
+	if(CanJoinTeam(Team, NotThisId, nullptr, 0))
 		return Team;
 	return -1;
 }
 
-bool IGameController::CanJoinTeam(int Team, int NotThisID, char *pErrorReason, int ErrorReasonSize)
+bool IGameController::CanJoinTeam(int Team, int NotThisId, char *pErrorReason, int ErrorReasonSize)
 {
-	const CPlayer *pPlayer = GameServer()->m_apPlayers[NotThisID];
+	const CPlayer *pPlayer = GameServer()->m_apPlayers[NotThisId];
 	if(pPlayer && pPlayer->IsPaused())
 	{
 		if(pErrorReason)
@@ -682,7 +682,7 @@ bool IGameController::CanJoinTeam(int Team, int NotThisID, char *pErrorReason, i
 	int aNumplayers[2] = {0, 0};
 	for(int i = 0; i < MAX_CLIENTS; i++)
 	{
-		if(GameServer()->m_apPlayers[i] && i != NotThisID)
+		if(GameServer()->m_apPlayers[i] && i != NotThisId)
 		{
 			if(GameServer()->m_apPlayers[i]->GetTeam() >= TEAM_RED && GameServer()->m_apPlayers[i]->GetTeam() <= TEAM_BLUE)
 				aNumplayers[GameServer()->m_apPlayers[i]->GetTeam()]++;
@@ -704,12 +704,12 @@ int IGameController::ClampTeam(int Team)
 	return 0;
 }
 
-CClientMask IGameController::GetMaskForPlayerWorldEvent(int Asker, int ExceptID)
+CClientMask IGameController::GetMaskForPlayerWorldEvent(int Asker, int ExceptId)
 {
 	if(Asker == -1)
-		return CClientMask().set().reset(ExceptID);
+		return CClientMask().set().reset(ExceptId);
 
-	return Teams().TeamMask(GameServer()->GetDDRaceTeam(Asker), ExceptID, Asker);
+	return Teams().TeamMask(GameServer()->GetDDRaceTeam(Asker), ExceptId, Asker);
 }
 
 void IGameController::InitTeleporter()
@@ -744,17 +744,17 @@ void IGameController::DoTeamChange(CPlayer *pPlayer, int Team, bool DoChatMsg)
 		return;
 
 	pPlayer->SetTeam(Team);
-	int ClientID = pPlayer->GetCID();
+	int ClientId = pPlayer->GetCid();
 
 	char aBuf[128];
 	DoChatMsg = false;
 	if(DoChatMsg)
 	{
-		str_format(aBuf, sizeof(aBuf), "'%s' joined the %s", Server()->ClientName(ClientID), GameServer()->m_pController->GetTeamName(Team));
+		str_format(aBuf, sizeof(aBuf), "'%s' joined the %s", Server()->ClientName(ClientId), GameServer()->m_pController->GetTeamName(Team));
 		GameServer()->SendChat(-1, CGameContext::CHAT_ALL, aBuf);
 	}
 
-	str_format(aBuf, sizeof(aBuf), "team_join player='%d:%s' m_Team=%d", ClientID, Server()->ClientName(ClientID), Team);
+	str_format(aBuf, sizeof(aBuf), "team_join player='%d:%s' m_Team=%d", ClientId, Server()->ClientName(ClientId), Team);
 	GameServer()->Console()->Print(IConsole::OUTPUT_LEVEL_DEBUG, "game", aBuf);
 
 	// OnPlayerInfoChange(pPlayer);

--- a/src/game/server/gamecontroller.h
+++ b/src/game/server/gamecontroller.h
@@ -130,7 +130,7 @@ public:
 	/*
 
 	*/
-	virtual bool CanBeMovedOnBalance(int ClientID);
+	virtual bool CanBeMovedOnBalance(int ClientId);
 
 	virtual void Tick();
 
@@ -144,11 +144,11 @@ public:
 
 	*/
 	virtual const char *GetTeamName(int Team);
-	virtual int GetAutoTeam(int NotThisID);
-	virtual bool CanJoinTeam(int Team, int NotThisID, char *pErrorReason, int ErrorReasonSize);
+	virtual int GetAutoTeam(int NotThisId);
+	virtual bool CanJoinTeam(int Team, int NotThisId, char *pErrorReason, int ErrorReasonSize);
 	int ClampTeam(int Team);
 
-	CClientMask GetMaskForPlayerWorldEvent(int Asker, int ExceptID = -1);
+	CClientMask GetMaskForPlayerWorldEvent(int Asker, int ExceptId = -1);
 	virtual void InitTeleporter();
 
 	bool IsTeamPlay() { return m_GameFlags & GAMEFLAG_TEAMS; }

--- a/src/game/server/gamemodes/DDRace.cpp
+++ b/src/game/server/gamemodes/DDRace.cpp
@@ -30,7 +30,7 @@ CScore *CGameControllerDDRace::Score()
 void CGameControllerDDRace::HandleCharacterTiles(CCharacter *pChr, int MapIndex)
 {
 	CPlayer *pPlayer = pChr->GetPlayer();
-	const int ClientID = pPlayer->GetCID();
+	const int ClientId = pPlayer->GetCid();
 
 	int m_TileIndex = GameServer()->Collision()->GetTileIndex(MapIndex);
 	int m_TileFIndex = GameServer()->Collision()->GetFTileIndex(MapIndex);
@@ -54,31 +54,31 @@ void CGameControllerDDRace::HandleCharacterTiles(CCharacter *pChr, int MapIndex)
 	// start
 	if(IsOnStartTile && PlayerDDRaceState != DDRACE_CHEAT)
 	{
-		const int Team = GameServer()->GetDDRaceTeam(ClientID);
+		const int Team = GameServer()->GetDDRaceTeam(ClientId);
 		if(Teams().GetSaving(Team))
 		{
-			GameServer()->SendStartWarning(ClientID, "You can't start while loading/saving of team is in progress");
-			pChr->Die(ClientID, WEAPON_WORLD);
+			GameServer()->SendStartWarning(ClientId, "You can't start while loading/saving of team is in progress");
+			pChr->Die(ClientId, WEAPON_WORLD);
 			return;
 		}
 		if(g_Config.m_SvTeam == SV_TEAM_MANDATORY && (Team == TEAM_FLOCK || Teams().Count(Team) <= 1))
 		{
-			GameServer()->SendStartWarning(ClientID, "You have to be in a team with other tees to start");
-			pChr->Die(ClientID, WEAPON_WORLD);
+			GameServer()->SendStartWarning(ClientId, "You have to be in a team with other tees to start");
+			pChr->Die(ClientId, WEAPON_WORLD);
 			return;
 		}
 		if(g_Config.m_SvTeam != SV_TEAM_FORCED_SOLO && Team > TEAM_FLOCK && Team < TEAM_SUPER && Teams().Count(Team) < g_Config.m_SvMinTeamSize)
 		{
 			char aBuf[128];
 			str_format(aBuf, sizeof(aBuf), "Your team has fewer than %d players, so your team rank won't count", g_Config.m_SvMinTeamSize);
-			GameServer()->SendStartWarning(ClientID, aBuf);
+			GameServer()->SendStartWarning(ClientId, aBuf);
 		}
 		if(g_Config.m_SvResetPickups)
 		{
 			pChr->ResetPickups();
 		}
 
-		Teams().OnCharacterStart(ClientID);
+		Teams().OnCharacterStart(ClientId);
 		pChr->m_LastTimeCp = -1;
 		pChr->m_LastTimeCpBroadcasted = -1;
 		for(float &CurrentTimeCp : pChr->m_aCurrentTimeCp)
@@ -89,24 +89,24 @@ void CGameControllerDDRace::HandleCharacterTiles(CCharacter *pChr, int MapIndex)
 
 	// finish
 	if(((m_TileIndex == TILE_FINISH) || (m_TileFIndex == TILE_FINISH) || FTile1 == TILE_FINISH || FTile2 == TILE_FINISH || FTile3 == TILE_FINISH || FTile4 == TILE_FINISH || Tile1 == TILE_FINISH || Tile2 == TILE_FINISH || Tile3 == TILE_FINISH || Tile4 == TILE_FINISH) && PlayerDDRaceState == DDRACE_STARTED)
-		Teams().OnCharacterFinish(ClientID);
+		Teams().OnCharacterFinish(ClientId);
 
 	// unlock team
-	else if(((m_TileIndex == TILE_UNLOCK_TEAM) || (m_TileFIndex == TILE_UNLOCK_TEAM)) && Teams().TeamLocked(GameServer()->GetDDRaceTeam(ClientID)))
+	else if(((m_TileIndex == TILE_UNLOCK_TEAM) || (m_TileFIndex == TILE_UNLOCK_TEAM)) && Teams().TeamLocked(GameServer()->GetDDRaceTeam(ClientId)))
 	{
-		Teams().SetTeamLock(GameServer()->GetDDRaceTeam(ClientID), false);
-		GameServer()->SendChatTeam(GameServer()->GetDDRaceTeam(ClientID), "Your team was unlocked by an unlock team tile");
+		Teams().SetTeamLock(GameServer()->GetDDRaceTeam(ClientId), false);
+		GameServer()->SendChatTeam(GameServer()->GetDDRaceTeam(ClientId), "Your team was unlocked by an unlock team tile");
 	}
 
 	// solo part
-	if(((m_TileIndex == TILE_SOLO_ENABLE) || (m_TileFIndex == TILE_SOLO_ENABLE)) && !Teams().m_Core.GetSolo(ClientID))
+	if(((m_TileIndex == TILE_SOLO_ENABLE) || (m_TileFIndex == TILE_SOLO_ENABLE)) && !Teams().m_Core.GetSolo(ClientId))
 	{
-		GameServer()->SendChatTarget(ClientID, "You are now in a solo part");
+		GameServer()->SendChatTarget(ClientId, "You are now in a solo part");
 		pChr->SetSolo(true);
 	}
-	else if(((m_TileIndex == TILE_SOLO_DISABLE) || (m_TileFIndex == TILE_SOLO_DISABLE)) && Teams().m_Core.GetSolo(ClientID))
+	else if(((m_TileIndex == TILE_SOLO_DISABLE) || (m_TileFIndex == TILE_SOLO_DISABLE)) && Teams().m_Core.GetSolo(ClientId))
 	{
-		GameServer()->SendChatTarget(ClientID, "You are now out of the solo part");
+		GameServer()->SendChatTarget(ClientId, "You are now out of the solo part");
 		pChr->SetSolo(false);
 	}
 }
@@ -114,30 +114,30 @@ void CGameControllerDDRace::HandleCharacterTiles(CCharacter *pChr, int MapIndex)
 void CGameControllerDDRace::OnPlayerConnect(CPlayer *pPlayer)
 {
 	IGameController::OnPlayerConnect(pPlayer);
-	int ClientID = pPlayer->GetCID();
+	int ClientId = pPlayer->GetCid();
 
 	// init the player
-	Score()->PlayerData(ClientID)->Reset();
+	Score()->PlayerData(ClientId)->Reset();
 
 	// Can't set score here as LoadScore() is threaded, run it in
 	// LoadScoreThreaded() instead
-	Score()->LoadPlayerData(ClientID);
+	Score()->LoadPlayerData(ClientId);
 
-	if(!Server()->ClientPrevIngame(ClientID))
+	if(!Server()->ClientPrevIngame(ClientId))
 	{
 		char aBuf[512];
-		str_format(aBuf, sizeof(aBuf), "'%s' entered and joined the %s", Server()->ClientName(ClientID), GetTeamName(pPlayer->GetTeam()));
+		str_format(aBuf, sizeof(aBuf), "'%s' entered and joined the %s", Server()->ClientName(ClientId), GetTeamName(pPlayer->GetTeam()));
 		GameServer()->SendChat(-1, CGameContext::CHAT_ALL, aBuf, -1, CGameContext::CHAT_SIX);
 
-		GameServer()->SendChatTarget(ClientID, "DDraceNetwork Mod. Version: " GAME_VERSION);
-		GameServer()->SendChatTarget(ClientID, "please visit DDNet.org or say /info and make sure to read our /rules");
+		GameServer()->SendChatTarget(ClientId, "DDraceNetwork Mod. Version: " GAME_VERSION);
+		GameServer()->SendChatTarget(ClientId, "please visit DDNet.org or say /info and make sure to read our /rules");
 	}
 }
 
 void CGameControllerDDRace::OnPlayerDisconnect(CPlayer *pPlayer, const char *pReason)
 {
-	int ClientID = pPlayer->GetCID();
-	bool WasModerator = pPlayer->m_Moderating && Server()->ClientIngame(ClientID);
+	int ClientId = pPlayer->GetCid();
+	bool WasModerator = pPlayer->m_Moderating && Server()->ClientIngame(ClientId);
 
 	IGameController::OnPlayerDisconnect(pPlayer, pReason);
 
@@ -145,11 +145,11 @@ void CGameControllerDDRace::OnPlayerDisconnect(CPlayer *pPlayer, const char *pRe
 		GameServer()->SendChat(-1, CGameContext::CHAT_ALL, "Server kick/spec votes are no longer actively moderated.");
 
 	if(g_Config.m_SvTeam != SV_TEAM_FORCED_SOLO)
-		Teams().SetForceCharacterTeam(ClientID, TEAM_FLOCK);
+		Teams().SetForceCharacterTeam(ClientId, TEAM_FLOCK);
 
 	for(int Team = TEAM_FLOCK + 1; Team < TEAM_SUPER; Team++)
-		if(Teams().IsInvited(Team, ClientID))
-			Teams().SetClientInvited(Team, ClientID, false);
+		if(Teams().IsInvited(Team, ClientId))
+			Teams().SetClientInvited(Team, ClientId, false);
 }
 
 void CGameControllerDDRace::OnReset()
@@ -180,7 +180,7 @@ void CGameControllerDDRace::DoTeamChange(class CPlayer *pPlayer, int Team, bool 
 			// Joining spectators should not kill a locked team, but should still
 			// check if the team finished by you leaving it.
 			int DDRTeam = pCharacter->Team();
-			Teams().SetForceCharacterTeam(pPlayer->GetCID(), TEAM_FLOCK);
+			Teams().SetForceCharacterTeam(pPlayer->GetCid(), TEAM_FLOCK);
 			Teams().CheckTeamFinished(DDRTeam);
 		}
 	}

--- a/src/game/server/gameworld.cpp
+++ b/src/game/server/gameworld.cpp
@@ -163,7 +163,7 @@ void CGameWorld::RemoveEntitiesFromPlayers(int PlayerIds[], int NumPlayers)
 			m_pNextTraverseEntity = pEnt->m_pNextTypeEntity;
 			for(int i = 0; i < NumPlayers; i++)
 			{
-				if(pEnt->GetOwnerID() == PlayerIds[i])
+				if(pEnt->GetOwnerId() == PlayerIds[i])
 				{
 					RemoveEntity(pEnt);
 					pEnt->Destroy();
@@ -249,11 +249,11 @@ void CGameWorld::Tick()
 	RemoveEntities();
 
 	// find the characters' strong/weak id
-	int StrongWeakID = 0;
+	int StrongWeakId = 0;
 	for(CCharacter *pChar = (CCharacter *)FindFirst(ENTTYPE_CHARACTER); pChar; pChar = (CCharacter *)pChar->TypeNext())
 	{
-		pChar->m_StrongWeakID = StrongWeakID;
-		StrongWeakID++;
+		pChar->m_StrongWeakId = StrongWeakId;
+		StrongWeakId++;
 	}
 }
 
@@ -356,12 +356,12 @@ std::vector<CCharacter *> CGameWorld::IntersectedCharacters(vec2 Pos0, vec2 Pos1
 	return vpCharacters;
 }
 
-void CGameWorld::ReleaseHooked(int ClientID)
+void CGameWorld::ReleaseHooked(int ClientId)
 {
 	CCharacter *pChr = (CCharacter *)CGameWorld::FindFirst(CGameWorld::ENTTYPE_CHARACTER);
 	for(; pChr; pChr = (CCharacter *)pChr->TypeNext())
 	{
-		if(pChr->Core()->HookedPlayer() == ClientID && !pChr->IsSuper())
+		if(pChr->Core()->HookedPlayer() == ClientId && !pChr->IsSuper())
 		{
 			pChr->ReleaseHook();
 		}

--- a/src/game/server/gameworld.h
+++ b/src/game/server/gameworld.h
@@ -148,7 +148,7 @@ public:
 	void SwapClients(int Client1, int Client2);
 
 	// DDRace
-	void ReleaseHooked(int ClientID);
+	void ReleaseHooked(int ClientId);
 
 	/*
 		Function: IntersectedCharacters

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -19,20 +19,20 @@ MACRO_ALLOC_POOL_ID_IMPL(CPlayer, MAX_CLIENTS)
 
 IServer *CPlayer::Server() const { return m_pGameServer->Server(); }
 
-CPlayer::CPlayer(CGameContext *pGameServer, uint32_t UniqueClientID, int ClientID, int Team) :
-	m_UniqueClientID(UniqueClientID)
+CPlayer::CPlayer(CGameContext *pGameServer, uint32_t UniqueClientId, int ClientId, int Team) :
+	m_UniqueClientId(UniqueClientId)
 {
 	m_pGameServer = pGameServer;
-	m_ClientID = ClientID;
+	m_ClientId = ClientId;
 	m_Team = GameServer()->m_pController->ClampTeam(Team);
 	m_NumInputs = 0;
 	Reset();
-	GameServer()->Antibot()->OnPlayerInit(m_ClientID);
+	GameServer()->Antibot()->OnPlayerInit(m_ClientId);
 }
 
 CPlayer::~CPlayer()
 {
-	GameServer()->Antibot()->OnPlayerDestroy(m_ClientID);
+	GameServer()->Antibot()->OnPlayerDestroy(m_ClientId);
 	delete m_pLastTarget;
 	delete m_pCharacter;
 	m_pCharacter = 0;
@@ -45,18 +45,18 @@ void CPlayer::Reset()
 	m_JoinTick = Server()->Tick();
 	delete m_pCharacter;
 	m_pCharacter = 0;
-	m_SpectatorID = SPEC_FREEVIEW;
+	m_SpectatorId = SPEC_FREEVIEW;
 	m_LastActionTick = Server()->Tick();
 	m_TeamChangeTick = Server()->Tick();
 	m_LastInvited = 0;
 	m_WeakHookSpawn = false;
 
-	int *pIdMap = Server()->GetIdMap(m_ClientID);
+	int *pIdMap = Server()->GetIdMap(m_ClientId);
 	for(int i = 1; i < VANILLA_MAX_CLIENTS; i++)
 	{
 		pIdMap[i] = -1;
 	}
-	pIdMap[0] = m_ClientID;
+	pIdMap[0] = m_ClientId;
 
 	// DDRace
 
@@ -65,7 +65,7 @@ void CPlayer::Reset()
 	m_ChatScore = 0;
 	m_Moderating = false;
 	m_EyeEmoteEnabled = true;
-	if(Server()->IsSixup(m_ClientID))
+	if(Server()->IsSixup(m_ClientId))
 		m_TimerType = TIMERTYPE_SIXUP;
 	else
 		m_TimerType = (g_Config.m_SvDefaultTimerType == TIMERTYPE_GAMETIMER || g_Config.m_SvDefaultTimerType == TIMERTYPE_GAMETIMER_AND_BROADCAST) ? TIMERTYPE_BROADCAST : g_Config.m_SvDefaultTimerType;
@@ -104,7 +104,7 @@ void CPlayer::Reset()
 	}
 	m_OverrideEmoteReset = -1;
 
-	GameServer()->Score()->PlayerData(m_ClientID)->Reset();
+	GameServer()->Score()->PlayerData(m_ClientId)->Reset();
 
 	m_Last_KickVote = 0;
 	m_Last_Team = 0;
@@ -122,7 +122,7 @@ void CPlayer::Reset()
 
 	// Variable initialized:
 	m_Last_Team = 0;
-	m_LastSQLQuery = 0;
+	m_LastSqlQuery = 0;
 	m_ScoreQueryResult = nullptr;
 	m_ScoreFinishResult = nullptr;
 
@@ -141,7 +141,7 @@ void CPlayer::Reset()
 	m_NotEligibleForFinish = false;
 	m_EligibleForFinishCheck = 0;
 	m_VotedForPractice = false;
-	m_SwapTargetsClientID = -1;
+	m_SwapTargetsClientId = -1;
 	m_BirthdayAnnounced = false;
 }
 
@@ -169,18 +169,18 @@ void CPlayer::Tick()
 		m_ScoreFinishResult = nullptr;
 	}
 
-	if(!Server()->ClientIngame(m_ClientID))
+	if(!Server()->ClientIngame(m_ClientId))
 		return;
 
 	if(m_ChatScore > 0)
 		m_ChatScore--;
 
-	Server()->SetClientScore(m_ClientID, m_Score);
+	Server()->SetClientScore(m_ClientId, m_Score);
 
 	if(m_Moderating && m_Afk)
 	{
 		m_Moderating = false;
-		GameServer()->SendChatTarget(m_ClientID, "Active moderator mode disabled because you are afk.");
+		GameServer()->SendChatTarget(m_ClientId, "Active moderator mode disabled because you are afk.");
 
 		if(!GameServer()->PlayerModerating())
 			GameServer()->SendChat(-1, CGameContext::CHAT_ALL, "Server kick/spec votes are no longer actively moderated.");
@@ -189,7 +189,7 @@ void CPlayer::Tick()
 	// do latency stuff
 	{
 		IServer::CClientInfo Info;
-		if(Server()->GetClientInfo(m_ClientID, &Info))
+		if(Server()->GetClientInfo(m_ClientId, &Info))
 		{
 			m_Latency.m_Accum += Info.m_Latency;
 			m_Latency.m_AccumMax = maximum(m_Latency.m_AccumMax, Info.m_Latency);
@@ -207,14 +207,14 @@ void CPlayer::Tick()
 		}
 	}
 
-	if(Server()->GetNetErrorString(m_ClientID)[0])
+	if(Server()->GetNetErrorString(m_ClientId)[0])
 	{
 		SetInitialAfk(true);
 
 		char aBuf[512];
-		str_format(aBuf, sizeof(aBuf), "'%s' would have timed out, but can use timeout protection now", Server()->ClientName(m_ClientID));
+		str_format(aBuf, sizeof(aBuf), "'%s' would have timed out, but can use timeout protection now", Server()->ClientName(m_ClientId));
 		GameServer()->SendChat(-1, CGameContext::CHAT_ALL, aBuf);
-		Server()->ResetNetErrorString(m_ClientID);
+		Server()->ResetNetErrorString(m_ClientId);
 	}
 
 	if(!GameServer()->m_World.m_Paused)
@@ -256,7 +256,7 @@ void CPlayer::Tick()
 
 	if(m_TuneZone != m_TuneZoneOld) // don't send tunings all the time
 	{
-		GameServer()->SendTuningParams(m_ClientID, m_TuneZone);
+		GameServer()->SendTuningParams(m_ClientId, m_TuneZone);
 	}
 
 	if(m_OverrideEmoteReset >= 0 && m_OverrideEmoteReset <= Server()->Tick())
@@ -268,7 +268,7 @@ void CPlayer::Tick()
 	{
 		if(1200 - ((Server()->Tick() - m_pCharacter->GetLastAction()) % (1200)) < 5)
 		{
-			GameServer()->SendEmoticon(GetCID(), EMOTICON_GHOST, -1);
+			GameServer()->SendEmoticon(GetCid(), EMOTICON_GHOST, -1);
 		}
 	}
 }
@@ -277,7 +277,7 @@ void CPlayer::PostTick()
 {
 	// update latency value
 	if(m_PlayerFlags & PLAYERFLAG_IN_MENU)
-		m_aCurLatency[m_ClientID] = GameServer()->m_apPlayers[m_ClientID]->m_Latency.m_Min;
+		m_aCurLatency[m_ClientId] = GameServer()->m_apPlayers[m_ClientId]->m_Latency.m_Min;
 
 	if(m_PlayerFlags & PLAYERFLAG_SCOREBOARD)
 	{
@@ -289,13 +289,13 @@ void CPlayer::PostTick()
 	}
 
 	// update view pos for spectators
-	if((m_Team == TEAM_SPECTATORS || m_Paused) && m_SpectatorID != SPEC_FREEVIEW && GameServer()->m_apPlayers[m_SpectatorID] && GameServer()->m_apPlayers[m_SpectatorID]->GetCharacter())
-		m_ViewPos = GameServer()->m_apPlayers[m_SpectatorID]->GetCharacter()->m_Pos;
+	if((m_Team == TEAM_SPECTATORS || m_Paused) && m_SpectatorId != SPEC_FREEVIEW && GameServer()->m_apPlayers[m_SpectatorId] && GameServer()->m_apPlayers[m_SpectatorId]->GetCharacter())
+		m_ViewPos = GameServer()->m_apPlayers[m_SpectatorId]->GetCharacter()->m_Pos;
 }
 
 void CPlayer::PostPostTick()
 {
-	if(!Server()->ClientIngame(m_ClientID))
+	if(!Server()->ClientIngame(m_ClientId))
 		return;
 
 	if(!GameServer()->m_World.m_Paused && !m_pCharacter && m_Spawning && m_WeakHookSpawn)
@@ -304,10 +304,10 @@ void CPlayer::PostPostTick()
 
 void CPlayer::Snap(int SnappingClient)
 {
-	if(!Server()->ClientIngame(m_ClientID))
+	if(!Server()->ClientIngame(m_ClientId))
 		return;
 
-	int id = m_ClientID;
+	int id = m_ClientId;
 	if(!Server()->Translate(id, SnappingClient))
 		return;
 
@@ -315,16 +315,16 @@ void CPlayer::Snap(int SnappingClient)
 	if(!pClientInfo)
 		return;
 
-	StrToInts(&pClientInfo->m_Name0, 4, Server()->ClientName(m_ClientID));
-	StrToInts(&pClientInfo->m_Clan0, 3, Server()->ClientClan(m_ClientID));
-	pClientInfo->m_Country = Server()->ClientCountry(m_ClientID);
+	StrToInts(&pClientInfo->m_Name0, 4, Server()->ClientName(m_ClientId));
+	StrToInts(&pClientInfo->m_Clan0, 3, Server()->ClientClan(m_ClientId));
+	pClientInfo->m_Country = Server()->ClientCountry(m_ClientId);
 	StrToInts(&pClientInfo->m_Skin0, 6, m_TeeInfos.m_aSkinName);
 	pClientInfo->m_UseCustomColor = m_TeeInfos.m_UseCustomColor;
 	pClientInfo->m_ColorBody = m_TeeInfos.m_ColorBody;
 	pClientInfo->m_ColorFeet = m_TeeInfos.m_ColorFeet;
 
 	int SnappingClientVersion = GameServer()->GetClientVersion(SnappingClient);
-	int Latency = SnappingClient == SERVER_DEMO_CLIENT ? m_Latency.m_Min : GameServer()->m_apPlayers[SnappingClient]->m_aCurLatency[m_ClientID];
+	int Latency = SnappingClient == SERVER_DEMO_CLIENT ? m_Latency.m_Min : GameServer()->m_apPlayers[SnappingClient]->m_aCurLatency[m_ClientId];
 
 	int Score;
 	// This is the time sent to the player while ingame (do not confuse to the one reported to the master server).
@@ -346,7 +346,7 @@ void CPlayer::Snap(int SnappingClient)
 	}
 
 	// send 0 if times of others are not shown
-	if(SnappingClient != m_ClientID && g_Config.m_SvHideScore)
+	if(SnappingClient != m_ClientId && g_Config.m_SvHideScore)
 		Score = -9999;
 
 	if(!Server()->IsSixup(SnappingClient))
@@ -357,13 +357,13 @@ void CPlayer::Snap(int SnappingClient)
 
 		pPlayerInfo->m_Latency = Latency;
 		pPlayerInfo->m_Score = Score;
-		pPlayerInfo->m_Local = (int)(m_ClientID == SnappingClient && (m_Paused != PAUSE_PAUSED || SnappingClientVersion >= VERSION_DDNET_OLD));
-		pPlayerInfo->m_ClientID = id;
+		pPlayerInfo->m_Local = (int)(m_ClientId == SnappingClient && (m_Paused != PAUSE_PAUSED || SnappingClientVersion >= VERSION_DDNET_OLD));
+		pPlayerInfo->m_ClientId = id;
 		pPlayerInfo->m_Team = m_Team;
 		if(SnappingClientVersion < VERSION_DDNET_INDEPENDENT_SPECTATORS_TEAM)
 		{
 			// In older versions the SPECTATORS TEAM was also used if the own player is in PAUSE_PAUSED or if any player is in PAUSE_SPEC.
-			pPlayerInfo->m_Team = (m_Paused != PAUSE_PAUSED || m_ClientID != SnappingClient) && m_Paused < PAUSE_SPEC ? m_Team : TEAM_SPECTATORS;
+			pPlayerInfo->m_Team = (m_Paused != PAUSE_PAUSED || m_ClientId != SnappingClient) && m_Paused < PAUSE_SPEC ? m_Team : TEAM_SPECTATORS;
 		}
 	}
 	else
@@ -375,34 +375,34 @@ void CPlayer::Snap(int SnappingClient)
 		pPlayerInfo->m_PlayerFlags = PlayerFlags_SixToSeven(m_PlayerFlags);
 		if(SnappingClientVersion >= VERSION_DDRACE && (m_PlayerFlags & PLAYERFLAG_AIM))
 			pPlayerInfo->m_PlayerFlags |= protocol7::PLAYERFLAG_AIM;
-		if(Server()->ClientAuthed(m_ClientID))
+		if(Server()->ClientAuthed(m_ClientId))
 			pPlayerInfo->m_PlayerFlags |= protocol7::PLAYERFLAG_ADMIN;
 
 		// Times are in milliseconds for 0.7
-		pPlayerInfo->m_Score = m_Score.has_value() ? GameServer()->Score()->PlayerData(m_ClientID)->m_BestTime * 1000 : -1;
+		pPlayerInfo->m_Score = m_Score.has_value() ? GameServer()->Score()->PlayerData(m_ClientId)->m_BestTime * 1000 : -1;
 		pPlayerInfo->m_Latency = Latency;
 	}
 
-	if(m_ClientID == SnappingClient && (m_Team == TEAM_SPECTATORS || m_Paused))
+	if(m_ClientId == SnappingClient && (m_Team == TEAM_SPECTATORS || m_Paused))
 	{
 		if(!Server()->IsSixup(SnappingClient))
 		{
-			CNetObj_SpectatorInfo *pSpectatorInfo = Server()->SnapNewItem<CNetObj_SpectatorInfo>(m_ClientID);
+			CNetObj_SpectatorInfo *pSpectatorInfo = Server()->SnapNewItem<CNetObj_SpectatorInfo>(m_ClientId);
 			if(!pSpectatorInfo)
 				return;
 
-			pSpectatorInfo->m_SpectatorID = m_SpectatorID;
+			pSpectatorInfo->m_SpectatorId = m_SpectatorId;
 			pSpectatorInfo->m_X = m_ViewPos.x;
 			pSpectatorInfo->m_Y = m_ViewPos.y;
 		}
 		else
 		{
-			protocol7::CNetObj_SpectatorInfo *pSpectatorInfo = Server()->SnapNewItem<protocol7::CNetObj_SpectatorInfo>(m_ClientID);
+			protocol7::CNetObj_SpectatorInfo *pSpectatorInfo = Server()->SnapNewItem<protocol7::CNetObj_SpectatorInfo>(m_ClientId);
 			if(!pSpectatorInfo)
 				return;
 
-			pSpectatorInfo->m_SpecMode = m_SpectatorID == SPEC_FREEVIEW ? protocol7::SPEC_FREEVIEW : protocol7::SPEC_PLAYER;
-			pSpectatorInfo->m_SpectatorID = m_SpectatorID;
+			pSpectatorInfo->m_SpecMode = m_SpectatorId == SPEC_FREEVIEW ? protocol7::SPEC_FREEVIEW : protocol7::SPEC_PLAYER;
+			pSpectatorInfo->m_SpectatorId = m_SpectatorId;
 			pSpectatorInfo->m_X = m_ViewPos.x;
 			pSpectatorInfo->m_Y = m_ViewPos.y;
 		}
@@ -412,7 +412,7 @@ void CPlayer::Snap(int SnappingClient)
 	if(!pDDNetPlayer)
 		return;
 
-	pDDNetPlayer->m_AuthLevel = Server()->GetAuthedState(m_ClientID);
+	pDDNetPlayer->m_AuthLevel = Server()->GetAuthedState(m_ClientId);
 	pDDNetPlayer->m_Flags = 0;
 	if(m_Afk)
 		pDDNetPlayer->m_Flags |= EXPLAYERFLAG_AFK;
@@ -435,7 +435,7 @@ void CPlayer::Snap(int SnappingClient)
 	if(SnappingClient != SERVER_DEMO_CLIENT)
 	{
 		CPlayer *pSnapPlayer = GameServer()->m_apPlayers[SnappingClient];
-		ShowSpec = ShowSpec && (GameServer()->GetDDRaceTeam(m_ClientID) == GameServer()->GetDDRaceTeam(SnappingClient) || pSnapPlayer->m_ShowOthers == SHOW_OTHERS_ON || (pSnapPlayer->GetTeam() == TEAM_SPECTATORS || pSnapPlayer->IsPaused()));
+		ShowSpec = ShowSpec && (GameServer()->GetDDRaceTeam(m_ClientId) == GameServer()->GetDDRaceTeam(SnappingClient) || pSnapPlayer->m_ShowOthers == SHOW_OTHERS_ON || (pSnapPlayer->GetTeam() == TEAM_SPECTATORS || pSnapPlayer->IsPaused()));
 	}
 
 	if(ShowSpec)
@@ -455,12 +455,12 @@ void CPlayer::FakeSnap()
 	if(GetClientVersion() >= VERSION_DDNET_OLD)
 		return;
 
-	if(Server()->IsSixup(m_ClientID))
+	if(Server()->IsSixup(m_ClientId))
 		return;
 
-	int FakeID = VANILLA_MAX_CLIENTS - 1;
+	int FakeId = VANILLA_MAX_CLIENTS - 1;
 
-	CNetObj_ClientInfo *pClientInfo = Server()->SnapNewItem<CNetObj_ClientInfo>(FakeID);
+	CNetObj_ClientInfo *pClientInfo = Server()->SnapNewItem<CNetObj_ClientInfo>(FakeId);
 
 	if(!pClientInfo)
 		return;
@@ -472,21 +472,21 @@ void CPlayer::FakeSnap()
 	if(m_Paused != PAUSE_PAUSED)
 		return;
 
-	CNetObj_PlayerInfo *pPlayerInfo = Server()->SnapNewItem<CNetObj_PlayerInfo>(FakeID);
+	CNetObj_PlayerInfo *pPlayerInfo = Server()->SnapNewItem<CNetObj_PlayerInfo>(FakeId);
 	if(!pPlayerInfo)
 		return;
 
 	pPlayerInfo->m_Latency = m_Latency.m_Min;
 	pPlayerInfo->m_Local = 1;
-	pPlayerInfo->m_ClientID = FakeID;
+	pPlayerInfo->m_ClientId = FakeId;
 	pPlayerInfo->m_Score = -9999;
 	pPlayerInfo->m_Team = TEAM_SPECTATORS;
 
-	CNetObj_SpectatorInfo *pSpectatorInfo = Server()->SnapNewItem<CNetObj_SpectatorInfo>(FakeID);
+	CNetObj_SpectatorInfo *pSpectatorInfo = Server()->SnapNewItem<CNetObj_SpectatorInfo>(FakeId);
 	if(!pSpectatorInfo)
 		return;
 
-	pSpectatorInfo->m_SpectatorID = m_SpectatorID;
+	pSpectatorInfo->m_SpectatorId = m_SpectatorId;
 	pSpectatorInfo->m_X = m_ViewPos.x;
 	pSpectatorInfo->m_Y = m_ViewPos.y;
 }
@@ -513,18 +513,18 @@ void CPlayer::OnPredictedInput(CNetObj_PlayerInput *pNewInput)
 
 	// Magic number when we can hope that client has successfully identified itself
 	if(m_NumInputs == 20 && g_Config.m_SvClientSuggestion[0] != '\0' && GetClientVersion() <= VERSION_DDNET_OLD)
-		GameServer()->SendBroadcast(g_Config.m_SvClientSuggestion, m_ClientID);
-	else if(m_NumInputs == 200 && Server()->IsSixup(m_ClientID))
-		GameServer()->SendBroadcast("This server uses an experimental translation from Teeworlds 0.7 to 0.6. Please report bugs on ddnet.org/discord", m_ClientID);
+		GameServer()->SendBroadcast(g_Config.m_SvClientSuggestion, m_ClientId);
+	else if(m_NumInputs == 200 && Server()->IsSixup(m_ClientId))
+		GameServer()->SendBroadcast("This server uses an experimental translation from Teeworlds 0.7 to 0.6. Please report bugs on ddnet.org/discord", m_ClientId);
 }
 
 void CPlayer::OnDirectInput(CNetObj_PlayerInput *pNewInput)
 {
-	Server()->SetClientFlags(m_ClientID, pNewInput->m_PlayerFlags);
+	Server()->SetClientFlags(m_ClientId, pNewInput->m_PlayerFlags);
 
 	AfkTimer();
 
-	if(((!m_pCharacter && m_Team == TEAM_SPECTATORS) || m_Paused) && m_SpectatorID == SPEC_FREEVIEW)
+	if(((!m_pCharacter && m_Team == TEAM_SPECTATORS) || m_Paused) && m_SpectatorId == SPEC_FREEVIEW)
 		m_ViewPos = vec2(pNewInput->m_TargetX, pNewInput->m_TargetY);
 
 	// check for activity
@@ -556,7 +556,7 @@ void CPlayer::OnPredictedEarlyInput(CNetObj_PlayerInput *pNewInput)
 
 int CPlayer::GetClientVersion() const
 {
-	return m_pGameServer->GetClientVersion(m_ClientID);
+	return m_pGameServer->GetClientVersion(m_ClientId);
 }
 
 CCharacter *CPlayer::GetCharacter()
@@ -577,7 +577,7 @@ void CPlayer::KillCharacter(int Weapon, bool SendKillMsg)
 {
 	if(m_pCharacter)
 	{
-		m_pCharacter->Die(m_ClientID, Weapon, SendKillMsg);
+		m_pCharacter->Die(m_ClientId, Weapon, SendKillMsg);
 
 		delete m_pCharacter;
 		m_pCharacter = 0;
@@ -596,7 +596,7 @@ void CPlayer::Respawn(bool WeakHook)
 CCharacter *CPlayer::ForceSpawn(vec2 Pos)
 {
 	m_Spawning = false;
-	m_pCharacter = new(m_ClientID) CCharacter(&GameServer()->m_World, GameServer()->GetLastPlayerInput(m_ClientID));
+	m_pCharacter = new(m_ClientId) CCharacter(&GameServer()->m_World, GameServer()->GetLastPlayerInput(m_ClientId));
 	m_pCharacter->Spawn(this, Pos);
 	m_Team = 0;
 	return m_pCharacter;
@@ -609,10 +609,10 @@ void CPlayer::SetTeam(int Team, bool DoChatMsg)
 	m_Team = Team;
 	m_LastSetTeam = Server()->Tick();
 	m_LastActionTick = Server()->Tick();
-	m_SpectatorID = SPEC_FREEVIEW;
+	m_SpectatorId = SPEC_FREEVIEW;
 
 	protocol7::CNetMsg_Sv_Team Msg;
-	Msg.m_ClientID = m_ClientID;
+	Msg.m_ClientId = m_ClientId;
 	Msg.m_Team = m_Team;
 	Msg.m_Silent = !DoChatMsg;
 	Msg.m_CooldownTick = m_LastSetTeam + Server()->TickSpeed() * g_Config.m_SvTeamChangeDelay;
@@ -623,8 +623,8 @@ void CPlayer::SetTeam(int Team, bool DoChatMsg)
 		// update spectator modes
 		for(auto &pPlayer : GameServer()->m_apPlayers)
 		{
-			if(pPlayer && pPlayer->m_SpectatorID == m_ClientID)
-				pPlayer->m_SpectatorID = SPEC_FREEVIEW;
+			if(pPlayer && pPlayer->m_SpectatorId == m_ClientId)
+				pPlayer->m_SpectatorId = SPEC_FREEVIEW;
 		}
 	}
 
@@ -635,7 +635,7 @@ bool CPlayer::SetTimerType(int TimerType)
 {
 	if(TimerType == TIMERTYPE_DEFAULT)
 	{
-		if(Server()->IsSixup(m_ClientID))
+		if(Server()->IsSixup(m_ClientId))
 			m_TimerType = TIMERTYPE_SIXUP;
 		else
 			SetTimerType(g_Config.m_SvDefaultTimerType);
@@ -643,7 +643,7 @@ bool CPlayer::SetTimerType(int TimerType)
 		return true;
 	}
 
-	if(Server()->IsSixup(m_ClientID))
+	if(Server()->IsSixup(m_ClientId))
 	{
 		if(TimerType == TIMERTYPE_SIXUP || TimerType == TIMERTYPE_NONE)
 		{
@@ -681,15 +681,15 @@ void CPlayer::TryRespawn()
 {
 	vec2 SpawnPos;
 
-	if(!GameServer()->m_pController->CanSpawn(m_Team, &SpawnPos, GameServer()->GetDDRaceTeam(m_ClientID)))
+	if(!GameServer()->m_pController->CanSpawn(m_Team, &SpawnPos, GameServer()->GetDDRaceTeam(m_ClientId)))
 		return;
 
 	m_WeakHookSpawn = false;
 	m_Spawning = false;
-	m_pCharacter = new(m_ClientID) CCharacter(&GameServer()->m_World, GameServer()->GetLastPlayerInput(m_ClientID));
+	m_pCharacter = new(m_ClientId) CCharacter(&GameServer()->m_World, GameServer()->GetLastPlayerInput(m_ClientId));
 	m_ViewPos = SpawnPos;
 	m_pCharacter->Spawn(this, SpawnPos);
-	GameServer()->CreatePlayerSpawn(SpawnPos, GameServer()->m_pController->GetMaskForPlayerWorldEvent(m_ClientID));
+	GameServer()->CreatePlayerSpawn(SpawnPos, GameServer()->m_pController->GetMaskForPlayerWorldEvent(m_ClientId));
 
 	if(g_Config.m_SvTeam == SV_TEAM_FORCED_SOLO)
 		m_pCharacter->SetSolo(true);
@@ -762,8 +762,8 @@ void CPlayer::ProcessPause()
 	if(m_Paused == PAUSE_SPEC && !m_pCharacter->IsPaused() && m_pCharacter->IsGrounded() && m_pCharacter->m_Pos == m_pCharacter->m_PrevPos)
 	{
 		m_pCharacter->Pause(true);
-		GameServer()->CreateDeath(m_pCharacter->m_Pos, m_ClientID, GameServer()->m_pController->GetMaskForPlayerWorldEvent(m_ClientID));
-		GameServer()->CreateSound(m_pCharacter->m_Pos, SOUND_PLAYER_DIE, GameServer()->m_pController->GetMaskForPlayerWorldEvent(m_ClientID));
+		GameServer()->CreateDeath(m_pCharacter->m_Pos, m_ClientId, GameServer()->m_pController->GetMaskForPlayerWorldEvent(m_ClientId));
+		GameServer()->CreateSound(m_pCharacter->m_Pos, SOUND_PLAYER_DIE, GameServer()->m_pController->GetMaskForPlayerWorldEvent(m_ClientId));
 	}
 }
 
@@ -787,18 +787,18 @@ int CPlayer::Pause(int State, bool Force)
 			{
 				if(!Force && m_LastPause && m_LastPause + (int64_t)g_Config.m_SvSpecFrequency * Server()->TickSpeed() > Server()->Tick())
 				{
-					GameServer()->SendChatTarget(m_ClientID, "Can't /spec that quickly.");
+					GameServer()->SendChatTarget(m_ClientId, "Can't /spec that quickly.");
 					return m_Paused; // Do not update state. Do not collect $200
 				}
 				m_pCharacter->Pause(false);
 				m_ViewPos = m_pCharacter->m_Pos;
-				GameServer()->CreatePlayerSpawn(m_pCharacter->m_Pos, GameServer()->m_pController->GetMaskForPlayerWorldEvent(m_ClientID));
+				GameServer()->CreatePlayerSpawn(m_pCharacter->m_Pos, GameServer()->m_pController->GetMaskForPlayerWorldEvent(m_ClientId));
 			}
 			[[fallthrough]];
 		case PAUSE_SPEC:
 			if(g_Config.m_SvPauseMessages)
 			{
-				str_format(aBuf, sizeof(aBuf), (State > PAUSE_NONE) ? "'%s' speced" : "'%s' resumed", Server()->ClientName(m_ClientID));
+				str_format(aBuf, sizeof(aBuf), (State > PAUSE_NONE) ? "'%s' speced" : "'%s' resumed", Server()->ClientName(m_ClientId));
 				GameServer()->SendChat(-1, CGameContext::CHAT_ALL, aBuf);
 			}
 			break;
@@ -810,12 +810,12 @@ int CPlayer::Pause(int State, bool Force)
 
 		// Sixup needs a teamchange
 		protocol7::CNetMsg_Sv_Team Msg;
-		Msg.m_ClientID = m_ClientID;
+		Msg.m_ClientId = m_ClientId;
 		Msg.m_CooldownTick = Server()->Tick();
 		Msg.m_Silent = true;
 		Msg.m_Team = m_Paused ? protocol7::TEAM_SPECTATORS : m_Team;
 
-		GameServer()->Server()->SendPackMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_NORECORD, m_ClientID);
+		GameServer()->Server()->SendPackMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_NORECORD, m_ClientId);
 	}
 
 	return m_Paused;
@@ -828,7 +828,7 @@ int CPlayer::ForcePause(int Time)
 	if(g_Config.m_SvPauseMessages)
 	{
 		char aBuf[128];
-		str_format(aBuf, sizeof(aBuf), "'%s' was force-paused for %ds", Server()->ClientName(m_ClientID), Time);
+		str_format(aBuf, sizeof(aBuf), "'%s' was force-paused for %ds", Server()->ClientName(m_ClientId), Time);
 		GameServer()->SendChat(-1, CGameContext::CHAT_ALL, aBuf);
 	}
 
@@ -852,9 +852,9 @@ void CPlayer::SpectatePlayerName(const char *pName)
 
 	for(int i = 0; i < MAX_CLIENTS; ++i)
 	{
-		if(i != m_ClientID && Server()->ClientIngame(i) && !str_comp(pName, Server()->ClientName(i)))
+		if(i != m_ClientId && Server()->ClientIngame(i) && !str_comp(pName, Server()->ClientName(i)))
 		{
-			m_SpectatorID = i;
+			m_SpectatorId = i;
 			return;
 		}
 	}
@@ -871,7 +871,7 @@ void CPlayer::ProcessScoreResult(CScorePlayerResult &Result)
 			{
 				if(aMessage[0] == 0)
 					break;
-				GameServer()->SendChatTarget(m_ClientID, aMessage);
+				GameServer()->SendChatTarget(m_ClientId, aMessage);
 			}
 			break;
 		case CScorePlayerResult::ALL:
@@ -882,7 +882,7 @@ void CPlayer::ProcessScoreResult(CScorePlayerResult &Result)
 				if(aMessage[0] == 0)
 					break;
 
-				if(GameServer()->ProcessSpamProtection(m_ClientID) && PrimaryMessage)
+				if(GameServer()->ProcessSpamProtection(m_ClientId) && PrimaryMessage)
 					break;
 
 				GameServer()->SendChat(-1, CGameContext::CHAT_ALL, aMessage, -1);
@@ -905,14 +905,14 @@ void CPlayer::ProcessScoreResult(CScorePlayerResult &Result)
 
 			char aChatmsg[512];
 			str_format(aChatmsg, sizeof(aChatmsg), "'%s' called vote to change server option '%s' (%s)",
-				Server()->ClientName(m_ClientID), Result.m_Data.m_MapVote.m_aMap, "/map");
+				Server()->ClientName(m_ClientId), Result.m_Data.m_MapVote.m_aMap, "/map");
 
-			GameServer()->CallVote(m_ClientID, Result.m_Data.m_MapVote.m_aMap, aCmd, "/map", aChatmsg);
+			GameServer()->CallVote(m_ClientId, Result.m_Data.m_MapVote.m_aMap, aCmd, "/map", aChatmsg);
 			break;
 		case CScorePlayerResult::PLAYER_INFO:
 			if(Result.m_Data.m_Info.m_Time.has_value())
 			{
-				GameServer()->Score()->PlayerData(m_ClientID)->Set(Result.m_Data.m_Info.m_Time.value(), Result.m_Data.m_Info.m_aTimeCp);
+				GameServer()->Score()->PlayerData(m_ClientId)->Set(Result.m_Data.m_Info.m_Time.value(), Result.m_Data.m_Info.m_aTimeCp);
 				m_Score = Result.m_Data.m_Info.m_Time;
 			}
 			Server()->ExpireServerInfo();
@@ -922,15 +922,15 @@ void CPlayer::ProcessScoreResult(CScorePlayerResult &Result)
 				char aBuf[512];
 				str_format(aBuf, sizeof(aBuf),
 					"Happy DDNet birthday to %s for finishing their first map %d year%s ago!",
-					Server()->ClientName(m_ClientID), Birthday, Birthday > 1 ? "s" : "");
-				GameServer()->SendChat(-1, CGameContext::CHAT_ALL, aBuf, m_ClientID);
+					Server()->ClientName(m_ClientId), Birthday, Birthday > 1 ? "s" : "");
+				GameServer()->SendChat(-1, CGameContext::CHAT_ALL, aBuf, m_ClientId);
 				str_format(aBuf, sizeof(aBuf),
 					"Happy DDNet birthday, %s!\nYou have finished your first map exactly %d year%s ago!",
-					Server()->ClientName(m_ClientID), Birthday, Birthday > 1 ? "s" : "");
-				GameServer()->SendBroadcast(aBuf, m_ClientID);
+					Server()->ClientName(m_ClientId), Birthday, Birthday > 1 ? "s" : "");
+				GameServer()->SendBroadcast(aBuf, m_ClientId);
 				m_BirthdayAnnounced = true;
 			}
-			GameServer()->SendRecord(m_ClientID);
+			GameServer()->SendRecord(m_ClientId);
 			break;
 		}
 	}

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -34,7 +34,7 @@ class CPlayer
 	MACRO_ALLOC_POOL_ID()
 
 public:
-	CPlayer(CGameContext *pGameServer, uint32_t UniqueClientID, int ClientID, int Team);
+	CPlayer(CGameContext *pGameServer, uint32_t UniqueClientId, int ClientId, int Team);
 	~CPlayer();
 
 	void Reset();
@@ -44,8 +44,8 @@ public:
 	CCharacter *ForceSpawn(vec2 Pos); // required for loading savegames
 	void SetTeam(int Team, bool DoChatMsg = true);
 	int GetTeam() const { return m_Team; }
-	int GetCID() const { return m_ClientID; }
-	uint32_t GetUniqueCID() const { return m_UniqueClientID; }
+	int GetCid() const { return m_ClientId; }
+	uint32_t GetUniqueCid() const { return m_UniqueClientId; }
 	int GetClientVersion() const;
 	bool SetTimerType(int TimerType);
 
@@ -83,7 +83,7 @@ public:
 	int m_SentSnaps = 0;
 
 	// used for spectator mode
-	int m_SpectatorID;
+	int m_SpectatorId;
 
 	bool m_IsReady;
 
@@ -129,7 +129,7 @@ public:
 	} m_Latency;
 
 private:
-	const uint32_t m_UniqueClientID;
+	const uint32_t m_UniqueClientId;
 	CCharacter *m_pCharacter;
 	int m_NumInputs;
 	CGameContext *m_pGameServer;
@@ -140,7 +140,7 @@ private:
 	//
 	bool m_Spawning;
 	bool m_WeakHookSpawn;
-	int m_ClientID;
+	int m_ClientId;
 	int m_Team;
 
 	int m_Paused;
@@ -215,14 +215,14 @@ public:
 	bool CanOverrideDefaultEmote() const;
 
 	bool m_FirstPacket;
-	int64_t m_LastSQLQuery;
+	int64_t m_LastSqlQuery;
 	void ProcessScoreResult(CScorePlayerResult &Result);
 	std::shared_ptr<CScorePlayerResult> m_ScoreQueryResult;
 	std::shared_ptr<CScorePlayerResult> m_ScoreFinishResult;
 	bool m_NotEligibleForFinish;
 	int64_t m_EligibleForFinishCheck;
 	bool m_VotedForPractice;
-	int m_SwapTargetsClientID; //Client ID of the swap target for the given player
+	int m_SwapTargetsClientId; //Client ID of the swap target for the given player
 	bool m_BirthdayAnnounced;
 
 	CSaveTee m_LastTeleTee;

--- a/src/game/server/save.h
+++ b/src/game/server/save.h
@@ -25,8 +25,8 @@ public:
 	bool IsHooking() const;
 	vec2 GetPos() const { return m_Pos; }
 	const char *GetName() const { return m_aName; }
-	int GetClientID() const { return m_ClientID; }
-	void SetClientID(int ClientID) { m_ClientID = ClientID; }
+	int GetClientId() const { return m_ClientId; }
+	void SetClientId(int ClientId) { m_ClientId = ClientId; }
 
 	enum
 	{
@@ -38,7 +38,7 @@ public:
 	};
 
 private:
-	int m_ClientID;
+	int m_ClientId;
 
 	char m_aString[2048];
 	char m_aName[16];
@@ -140,17 +140,17 @@ public:
 	// MatchPlayers has to be called afterwards
 	int FromString(const char *pString);
 	// returns true if a team can load, otherwise writes a nice error Message in pMessage
-	bool MatchPlayers(const char (*paNames)[MAX_NAME_LENGTH], const int *pClientID, int NumPlayer, char *pMessage, int MessageLen) const;
+	bool MatchPlayers(const char (*paNames)[MAX_NAME_LENGTH], const int *pClientId, int NumPlayer, char *pMessage, int MessageLen) const;
 	int Save(CGameContext *pGameServer, int Team, bool Dry = false);
 	void Load(CGameContext *pGameServer, int Team, bool KeepCurrentWeakStrong);
 
 	CSaveTee *m_pSavedTees = nullptr;
 
 	// returns true if an error occurred
-	static bool HandleSaveError(int Result, int ClientID, CGameContext *pGameContext);
+	static bool HandleSaveError(int Result, int ClientId, CGameContext *pGameContext);
 
 private:
-	CCharacter *MatchCharacter(CGameContext *pGameServer, int ClientID, int SaveID, bool KeepCurrentCharacter) const;
+	CCharacter *MatchCharacter(CGameContext *pGameServer, int ClientId, int SaveId, bool KeepCurrentCharacter) const;
 
 	char m_aString[65536];
 

--- a/src/game/server/score.h
+++ b/src/game/server/score.h
@@ -26,51 +26,51 @@ class CScore
 	void GeneratePassphrase(char *pBuf, int BufSize);
 
 	// returns new SqlResult bound to the player, if no current Thread is active for this player
-	std::shared_ptr<CScorePlayerResult> NewSqlPlayerResult(int ClientID);
+	std::shared_ptr<CScorePlayerResult> NewSqlPlayerResult(int ClientId);
 	// Creates for player database requests
 	void ExecPlayerThread(
 		bool (*pFuncPtr)(IDbConnection *, const ISqlData *, char *pError, int ErrorSize),
 		const char *pThreadName,
-		int ClientID,
+		int ClientId,
 		const char *pName,
 		int Offset);
 
 	// returns true if the player should be rate limited
-	bool RateLimitPlayer(int ClientID);
+	bool RateLimitPlayer(int ClientId);
 
 public:
 	CScore(CGameContext *pGameServer, CDbConnectionPool *pPool);
 	~CScore() {}
 
-	CPlayerData *PlayerData(int ID) { return &m_aPlayerData[ID]; }
+	CPlayerData *PlayerData(int Id) { return &m_aPlayerData[Id]; }
 
 	void LoadBestTime();
-	void MapInfo(int ClientID, const char *pMapName);
-	void MapVote(int ClientID, const char *pMapName);
-	void LoadPlayerData(int ClientID, const char *pName = "");
-	void SaveScore(int ClientID, float Time, const char *pTimestamp, const float aTimeCp[NUM_CHECKPOINTS], bool NotEligible);
+	void MapInfo(int ClientId, const char *pMapName);
+	void MapVote(int ClientId, const char *pMapName);
+	void LoadPlayerData(int ClientId, const char *pName = "");
+	void SaveScore(int ClientId, float Time, const char *pTimestamp, const float aTimeCp[NUM_CHECKPOINTS], bool NotEligible);
 
-	void SaveTeamScore(int *pClientIDs, unsigned int Size, float Time, const char *pTimestamp);
+	void SaveTeamScore(int *pClientIds, unsigned int Size, float Time, const char *pTimestamp);
 
-	void ShowTop(int ClientID, int Offset = 1);
-	void ShowRank(int ClientID, const char *pName);
+	void ShowTop(int ClientId, int Offset = 1);
+	void ShowRank(int ClientId, const char *pName);
 
-	void ShowTeamTop5(int ClientID, int Offset = 1);
-	void ShowPlayerTeamTop5(int ClientID, const char *pName, int Offset = 1);
-	void ShowTeamRank(int ClientID, const char *pName);
+	void ShowTeamTop5(int ClientId, int Offset = 1);
+	void ShowPlayerTeamTop5(int ClientId, const char *pName, int Offset = 1);
+	void ShowTeamRank(int ClientId, const char *pName);
 
-	void ShowTopPoints(int ClientID, int Offset = 1);
-	void ShowPoints(int ClientID, const char *pName);
+	void ShowTopPoints(int ClientId, int Offset = 1);
+	void ShowPoints(int ClientId, const char *pName);
 
-	void ShowTimes(int ClientID, const char *pName, int Offset = 1);
-	void ShowTimes(int ClientID, int Offset = 1);
+	void ShowTimes(int ClientId, const char *pName, int Offset = 1);
+	void ShowTimes(int ClientId, int Offset = 1);
 
-	void RandomMap(int ClientID, int Stars);
-	void RandomUnfinishedMap(int ClientID, int Stars);
+	void RandomMap(int ClientId, int Stars);
+	void RandomUnfinishedMap(int ClientId, int Stars);
 
-	void SaveTeam(int ClientID, const char *pCode, const char *pServer);
-	void LoadTeam(const char *pCode, int ClientID);
-	void GetSaves(int ClientID);
+	void SaveTeam(int ClientId, const char *pCode, const char *pServer);
+	void LoadTeam(const char *pCode, int ClientId);
+	void GetSaves(int ClientId);
 };
 
 #endif // GAME_SERVER_SCORE_H

--- a/src/game/server/scoreworker.cpp
+++ b/src/game/server/scoreworker.cpp
@@ -51,20 +51,20 @@ CTeamrank::CTeamrank() :
 {
 	for(auto &aName : m_aaNames)
 		aName[0] = '\0';
-	mem_zero(&m_TeamID.m_aData, sizeof(m_TeamID));
+	mem_zero(&m_TeamId.m_aData, sizeof(m_TeamId));
 }
 
 bool CTeamrank::NextSqlResult(IDbConnection *pSqlServer, bool *pEnd, char *pError, int ErrorSize)
 {
-	pSqlServer->GetBlob(1, m_TeamID.m_aData, sizeof(m_TeamID.m_aData));
+	pSqlServer->GetBlob(1, m_TeamId.m_aData, sizeof(m_TeamId.m_aData));
 	pSqlServer->GetString(2, m_aaNames[0], sizeof(m_aaNames[0]));
 	m_NumNames = 1;
 	bool End = false;
 	while(!pSqlServer->Step(&End, pError, ErrorSize) && !End)
 	{
-		CUuid TeamID;
-		pSqlServer->GetBlob(1, TeamID.m_aData, sizeof(TeamID.m_aData));
-		if(m_TeamID != TeamID)
+		CUuid TeamId;
+		pSqlServer->GetBlob(1, TeamId.m_aData, sizeof(TeamId.m_aData));
+		if(m_TeamId != TeamId)
 		{
 			*pEnd = false;
 			return false;
@@ -517,7 +517,7 @@ bool CScoreWorker::SaveScore(IDbConnection *pSqlServer, const ISqlData *pGameDat
 		"	Map, Name, Timestamp, Time, Server, "
 		"	cp1, cp2, cp3, cp4, cp5, cp6, cp7, cp8, cp9, cp10, cp11, cp12, cp13, "
 		"	cp14, cp15, cp16, cp17, cp18, cp19, cp20, cp21, cp22, cp23, cp24, cp25, "
-		"	GameID, DDNet7) "
+		"	GameId, DDNet7) "
 		"VALUES (?, ?, %s, %.2f, ?, "
 		"	%.2f, %.2f, %.2f, %.2f, %.2f, %.2f, %.2f, %.2f, %.2f, "
 		"	%.2f, %.2f, %.2f, %.2f, %.2f, %.2f, %.2f, %.2f, %.2f, "
@@ -558,7 +558,7 @@ bool CScoreWorker::SaveTeamScore(IDbConnection *pSqlServer, const ISqlData *pGam
 	if(w == Write::NORMAL_SUCCEEDED)
 	{
 		str_format(aBuf, sizeof(aBuf),
-			"DELETE FROM %s_teamrace_backup WHERE ID=?",
+			"DELETE FROM %s_teamrace_backup WHERE Id=?",
 			pSqlServer->GetPrefix());
 		if(pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
 		{
@@ -586,7 +586,7 @@ bool CScoreWorker::SaveTeamScore(IDbConnection *pSqlServer, const ISqlData *pGam
 		CUuid TeamrankId = pData->m_TeamrankUuid;
 
 		str_format(aBuf, sizeof(aBuf),
-			"INSERT INTO %s_teamrace SELECT * FROM %s_teamrace_backup WHERE ID=?",
+			"INSERT INTO %s_teamrace SELECT * FROM %s_teamrace_backup WHERE Id=?",
 			pSqlServer->GetPrefix(), pSqlServer->GetPrefix());
 		if(pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
 		{
@@ -600,7 +600,7 @@ bool CScoreWorker::SaveTeamScore(IDbConnection *pSqlServer, const ISqlData *pGam
 		}
 
 		str_format(aBuf, sizeof(aBuf),
-			"DELETE FROM %s_teamrace_backup WHERE ID=?",
+			"DELETE FROM %s_teamrace_backup WHERE Id=?",
 			pSqlServer->GetPrefix());
 		if(pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
 		{
@@ -620,13 +620,13 @@ bool CScoreWorker::SaveTeamScore(IDbConnection *pSqlServer, const ISqlData *pGam
 
 		std::sort(vNames.begin(), vNames.end());
 		str_format(aBuf, sizeof(aBuf),
-			"SELECT l.ID, Name, Time "
+			"SELECT l.Id, Name, Time "
 			"FROM (" // preselect teams with first name in team
 			"  SELECT ID "
 			"  FROM %s_teamrace "
 			"  WHERE Map = ? AND Name = ? AND DDNet7 = %s"
-			") as l INNER JOIN %s_teamrace AS r ON l.ID = r.ID "
-			"ORDER BY l.ID, Name COLLATE %s",
+			") as l INNER JOIN %s_teamrace AS r ON l.Id = r.Id "
+			"ORDER BY l.Id, Name COLLATE %s",
 			pSqlServer->GetPrefix(), pSqlServer->False(), pSqlServer->GetPrefix(), pSqlServer->BinaryCollate());
 		if(pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
 		{
@@ -666,7 +666,7 @@ bool CScoreWorker::SaveTeamScore(IDbConnection *pSqlServer, const ISqlData *pGam
 			if(pData->m_Time < Time)
 			{
 				str_format(aBuf, sizeof(aBuf),
-					"UPDATE %s_teamrace SET Time=%.2f, Timestamp=%s, DDNet7=%s, GameID=? WHERE ID = ?",
+					"UPDATE %s_teamrace SET Time=%.2f, Timestamp=%s, DDNet7=%s, GameId=? WHERE Id = ?",
 					pSqlServer->GetPrefix(), pData->m_Time, pSqlServer->InsertTimestampAsUtc(), pSqlServer->False());
 				if(pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
 				{
@@ -674,7 +674,7 @@ bool CScoreWorker::SaveTeamScore(IDbConnection *pSqlServer, const ISqlData *pGam
 				}
 				pSqlServer->BindString(1, pData->m_aTimestamp);
 				pSqlServer->BindString(2, pData->m_aGameUuid);
-				pSqlServer->BindBlob(3, Teamrank.m_TeamID.m_aData, sizeof(Teamrank.m_TeamID.m_aData));
+				pSqlServer->BindBlob(3, Teamrank.m_TeamId.m_aData, sizeof(Teamrank.m_TeamId.m_aData));
 				pSqlServer->Print();
 				int NumUpdated;
 				if(pSqlServer->ExecuteUpdate(&NumUpdated, pError, ErrorSize))
@@ -692,7 +692,7 @@ bool CScoreWorker::SaveTeamScore(IDbConnection *pSqlServer, const ISqlData *pGam
 	{
 		// if no entry found... create a new one
 		str_format(aBuf, sizeof(aBuf),
-			"%s INTO %s_teamrace%s(Map, Name, Timestamp, Time, ID, GameID, DDNet7) "
+			"%s INTO %s_teamrace%s(Map, Name, Timestamp, Time, Id, GameId, DDNet7) "
 			"VALUES (?, ?, %s, %.2f, ?, ?, %s)",
 			pSqlServer->InsertIgnore(), pSqlServer->GetPrefix(),
 			w == Write::NORMAL ? "" : "_backup",
@@ -839,9 +839,9 @@ bool CScoreWorker::ShowTeamRank(IDbConnection *pSqlServer, const ISqlData *pGame
 	char aBuf[2400];
 
 	str_format(aBuf, sizeof(aBuf),
-		"SELECT l.ID, Name, Time, Ranking, PercentRank "
+		"SELECT l.Id, Name, Time, Ranking, PercentRank "
 		"FROM (" // teamrank score board
-		"  SELECT RANK() OVER w AS Ranking, PERCENT_RANK() OVER w AS PercentRank, ID "
+		"  SELECT RANK() OVER w AS Ranking, PERCENT_RANK() OVER w AS PercentRank, Id "
 		"  FROM %s_teamrace "
 		"  WHERE Map = ? "
 		"  GROUP BY ID "
@@ -852,8 +852,8 @@ bool CScoreWorker::ShowTeamRank(IDbConnection *pSqlServer, const ISqlData *pGame
 		"  WHERE Map = ? AND Name = ? "
 		"  ORDER BY Time "
 		"  LIMIT 1"
-		") AS l ON TeamRank.ID = l.ID "
-		"INNER JOIN %s_teamrace AS r ON l.ID = r.ID ",
+		") AS l ON TeamRank.Id = l.Id "
+		"INNER JOIN %s_teamrace AS r ON l.Id = r.Id ",
 		pSqlServer->GetPrefix(), pSqlServer->GetPrefix(), pSqlServer->GetPrefix());
 	if(pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
 	{
@@ -1021,9 +1021,9 @@ bool CScoreWorker::ShowTeamTop5(IDbConnection *pSqlServer, const ISqlData *pGame
 	str_format(aBuf, sizeof(aBuf),
 		"SELECT Name, Time, Ranking, TeamSize "
 		"FROM (" // limit to 5
-		"  SELECT TeamSize, Ranking, ID "
+		"  SELECT TeamSize, Ranking, Id "
 		"  FROM (" // teamrank score board
-		"    SELECT RANK() OVER w AS Ranking, COUNT(*) AS Teamsize, ID "
+		"    SELECT RANK() OVER w AS Ranking, COUNT(*) AS Teamsize, Id "
 		"    FROM %s_teamrace "
 		"    WHERE Map = ? "
 		"    GROUP BY ID "
@@ -1032,8 +1032,8 @@ bool CScoreWorker::ShowTeamTop5(IDbConnection *pSqlServer, const ISqlData *pGame
 		"  ORDER BY Ranking %s "
 		"  LIMIT %d, 5"
 		") as l2 "
-		"INNER JOIN %s_teamrace as r ON l2.ID = r.ID "
-		"ORDER BY Ranking %s, r.ID, Name ASC",
+		"INNER JOIN %s_teamrace as r ON l2.Id = r.Id "
+		"ORDER BY Ranking %s, r.Id, Name ASC",
 		pSqlServer->GetPrefix(), pOrder, LimitStart, pSqlServer->GetPrefix(), pOrder);
 	if(pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
 	{
@@ -1106,9 +1106,9 @@ bool CScoreWorker::ShowPlayerTeamTop5(IDbConnection *pSqlServer, const ISqlData 
 	char aBuf[2400];
 
 	str_format(aBuf, sizeof(aBuf),
-		"SELECT l.ID, Name, Time, Ranking "
+		"SELECT l.Id, Name, Time, Ranking "
 		"FROM (" // teamrank score board
-		"  SELECT RANK() OVER w AS Ranking, ID "
+		"  SELECT RANK() OVER w AS Ranking, Id "
 		"  FROM %s_teamrace "
 		"  WHERE Map = ? "
 		"  GROUP BY ID "
@@ -1119,9 +1119,9 @@ bool CScoreWorker::ShowPlayerTeamTop5(IDbConnection *pSqlServer, const ISqlData 
 		"  WHERE Map = ? AND Name = ? "
 		"  ORDER BY Time %s "
 		"  LIMIT %d, 5 "
-		") AS l ON TeamRank.ID = l.ID "
-		"INNER JOIN %s_teamrace AS r ON l.ID = r.ID "
-		"ORDER BY Time %s, l.ID, Name ASC",
+		") AS l ON TeamRank.Id = l.Id "
+		"INNER JOIN %s_teamrace AS r ON l.Id = r.Id "
+		"ORDER BY Time %s, l.Id, Name ASC",
 		pSqlServer->GetPrefix(), pSqlServer->GetPrefix(), pOrder, LimitStart, pSqlServer->GetPrefix(), pOrder);
 	if(pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
 	{
@@ -1558,8 +1558,8 @@ bool CScoreWorker::SaveTeam(IDbConnection *pSqlServer, const ISqlData *pGameData
 		return pSqlServer->Step(&End, pError, ErrorSize);
 	}
 
-	char aSaveID[UUID_MAXSTRSIZE];
-	FormatUuid(pResult->m_SaveID, aSaveID, UUID_MAXSTRSIZE);
+	char aSaveId[UUID_MAXSTRSIZE];
+	FormatUuid(pResult->m_SaveId, aSaveId, UUID_MAXSTRSIZE);
 
 	char *pSaveState = pResult->m_SavedTeam.GetString();
 	char aBuf[65536];
@@ -1579,7 +1579,7 @@ bool CScoreWorker::SaveTeam(IDbConnection *pSqlServer, const ISqlData *pGameData
 			str_copy(aCode, pData->m_aCode, sizeof(aCode));
 
 		str_format(aBuf, sizeof(aBuf),
-			"%s INTO %s_saves%s(Savegame, Map, Code, Timestamp, Server, SaveID, DDNet7) "
+			"%s INTO %s_saves%s(Savegame, Map, Code, Timestamp, Server, SaveId, DDNet7) "
 			"VALUES (?, ?, ?, CURRENT_TIMESTAMP, ?, ?, %s)",
 			pSqlServer->InsertIgnore(), pSqlServer->GetPrefix(),
 			w == Write::NORMAL ? "" : "_backup", pSqlServer->False());
@@ -1591,7 +1591,7 @@ bool CScoreWorker::SaveTeam(IDbConnection *pSqlServer, const ISqlData *pGameData
 		pSqlServer->BindString(2, pData->m_aMap);
 		pSqlServer->BindString(3, aCode);
 		pSqlServer->BindString(4, pData->m_aServer);
-		pSqlServer->BindString(5, aSaveID);
+		pSqlServer->BindString(5, aSaveId);
 		pSqlServer->Print();
 		int NumInserted;
 		if(pSqlServer->ExecuteUpdate(&NumInserted, pError, ErrorSize))
@@ -1668,7 +1668,7 @@ bool CScoreWorker::LoadTeam(IDbConnection *pSqlServer, const ISqlData *pGameData
 
 	char aBuf[512];
 	str_format(aBuf, sizeof(aBuf),
-		"SELECT Savegame, %s-%s AS Ago, SaveID "
+		"SELECT Savegame, %s-%s AS Ago, SaveId "
 		"FROM %s_saves "
 		"where Code = ? AND Map = ? AND DDNet7 = %s",
 		aCurrentTimestamp, aTimestamp,
@@ -1691,14 +1691,14 @@ bool CScoreWorker::LoadTeam(IDbConnection *pSqlServer, const ISqlData *pGameData
 		return false;
 	}
 
-	pResult->m_SaveID = UUID_NO_SAVE_ID;
+	pResult->m_SaveId = UUID_NO_SAVE_ID;
 	if(!pSqlServer->IsNull(3))
 	{
-		char aSaveID[UUID_MAXSTRSIZE];
-		pSqlServer->GetString(3, aSaveID, sizeof(aSaveID));
-		if(ParseUuid(&pResult->m_SaveID, aSaveID) || pResult->m_SaveID == UUID_NO_SAVE_ID)
+		char aSaveId[UUID_MAXSTRSIZE];
+		pSqlServer->GetString(3, aSaveId, sizeof(aSaveId));
+		if(ParseUuid(&pResult->m_SaveId, aSaveId) || pResult->m_SaveId == UUID_NO_SAVE_ID)
 		{
-			str_copy(pResult->m_aMessage, "Unable to load savegame: SaveID corrupted", sizeof(pResult->m_aMessage));
+			str_copy(pResult->m_aMessage, "Unable to load savegame: SaveId corrupted", sizeof(pResult->m_aMessage));
 			return false;
 		}
 	}
@@ -1742,7 +1742,7 @@ bool CScoreWorker::LoadTeam(IDbConnection *pSqlServer, const ISqlData *pGameData
 	}
 
 	bool CanLoad = pResult->m_SavedTeam.MatchPlayers(
-		pData->m_aClientNames, pData->m_aClientID, pData->m_NumPlayer,
+		pData->m_aClientNames, pData->m_aClientId, pData->m_NumPlayer,
 		pResult->m_aMessage, sizeof(pResult->m_aMessage));
 
 	if(!CanLoad)
@@ -1750,9 +1750,9 @@ bool CScoreWorker::LoadTeam(IDbConnection *pSqlServer, const ISqlData *pGameData
 
 	str_format(aBuf, sizeof(aBuf),
 		"DELETE FROM %s_saves "
-		"WHERE Code = ? AND Map = ? AND SaveID %s",
+		"WHERE Code = ? AND Map = ? AND SaveId %s",
 		pSqlServer->GetPrefix(),
-		pResult->m_SaveID != UUID_NO_SAVE_ID ? "= ?" : "IS NULL");
+		pResult->m_SaveId != UUID_NO_SAVE_ID ? "= ?" : "IS NULL");
 	if(pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
 	{
 		return true;
@@ -1760,9 +1760,9 @@ bool CScoreWorker::LoadTeam(IDbConnection *pSqlServer, const ISqlData *pGameData
 	pSqlServer->BindString(1, pData->m_aCode);
 	pSqlServer->BindString(2, pData->m_aMap);
 	char aUuid[UUID_MAXSTRSIZE];
-	if(pResult->m_SaveID != UUID_NO_SAVE_ID)
+	if(pResult->m_SaveId != UUID_NO_SAVE_ID)
 	{
-		FormatUuid(pResult->m_SaveID, aUuid, sizeof(aUuid));
+		FormatUuid(pResult->m_SaveId, aUuid, sizeof(aUuid));
 		pSqlServer->BindString(3, aUuid);
 	}
 	pSqlServer->Print();

--- a/src/game/server/scoreworker.h
+++ b/src/game/server/scoreworker.h
@@ -100,13 +100,13 @@ struct CSqlPlayerRequest : ISqlData
 
 struct CScoreRandomMapResult : ISqlResult
 {
-	CScoreRandomMapResult(int ClientID) :
-		m_ClientID(ClientID)
+	CScoreRandomMapResult(int ClientId) :
+		m_ClientId(ClientId)
 	{
 		m_aMap[0] = '\0';
 		m_aMessage[0] = '\0';
 	}
-	int m_ClientID;
+	int m_ClientId;
 	char m_aMap[MAX_MAP_LENGTH];
 	char m_aMessage[512];
 };
@@ -137,7 +137,7 @@ struct CSqlScoreData : ISqlData
 	char m_aGameUuid[UUID_MAXSTRSIZE];
 	char m_aName[MAX_MAP_LENGTH];
 
-	int m_ClientID;
+	int m_ClientId;
 	float m_Time;
 	char m_aTimestamp[TIMESTAMP_STR_LENGTH];
 	float m_aCurrentTimeCp[NUM_CHECKPOINTS];
@@ -148,9 +148,9 @@ struct CSqlScoreData : ISqlData
 
 struct CScoreSaveResult : ISqlResult
 {
-	CScoreSaveResult(int PlayerID) :
+	CScoreSaveResult(int PlayerId) :
 		m_Status(SAVE_FAILED),
-		m_RequestingPlayer(PlayerID)
+		m_RequestingPlayer(PlayerId)
 	{
 		m_aMessage[0] = '\0';
 		m_aBroadcast[0] = '\0';
@@ -167,7 +167,7 @@ struct CScoreSaveResult : ISqlResult
 	char m_aBroadcast[512];
 	CSaveTeam m_SavedTeam;
 	int m_RequestingPlayer;
-	CUuid m_SaveID;
+	CUuid m_SaveId;
 };
 
 struct CSqlTeamScoreData : ISqlData
@@ -212,10 +212,10 @@ struct CSqlTeamLoad : ISqlData
 	char m_aCode[128];
 	char m_aMap[MAX_MAP_LENGTH];
 	char m_aRequestingPlayer[MAX_NAME_LENGTH];
-	int m_ClientID;
+	int m_ClientId;
 	// struct holding all player names in the team or an empty string
 	char m_aClientNames[MAX_CLIENTS][MAX_NAME_LENGTH];
-	int m_aClientID[MAX_CLIENTS];
+	int m_aClientId[MAX_CLIENTS];
 	int m_NumPlayer;
 };
 
@@ -253,16 +253,16 @@ public:
 
 struct CTeamrank
 {
-	CUuid m_TeamID;
+	CUuid m_TeamId;
 	char m_aaNames[MAX_CLIENTS][MAX_NAME_LENGTH];
 	unsigned int m_NumNames;
 	CTeamrank();
 
 	// Assumes that a database query equivalent to
 	//
-	//     SELECT TeamID, Name [, ...] -- the order is important
+	//     SELECT TeamId, Name [, ...] -- the order is important
 	//     FROM record_teamrace
-	//     ORDER BY TeamID, Name
+	//     ORDER BY TeamId, Name
 	//
 	// was executed and that the result line of the first team member is already selected.
 	// Afterwards the team member of the next team is selected.

--- a/src/game/server/teams.h
+++ b/src/game/server/teams.h
@@ -41,10 +41,10 @@ class CGameTeams
 	/**
 	* Kill the whole team.
 	* @param Team The team id to kill
-	* @param NewStrongID The player with that id will get strong hook on everyone else, -1 will set the normal spawning order
-	* @param ExceptID The player that should not get killed
+	* @param NewStrongId The player with that id will get strong hook on everyone else, -1 will set the normal spawning order
+	* @param ExceptId The player that should not get killed
 	*/
-	void KillTeam(int Team, int NewStrongID, int ExceptID = -1);
+	void KillTeam(int Team, int NewStrongId, int ExceptId = -1);
 	bool TeamFinished(int Team);
 	void OnTeamFinish(CPlayer **Players, unsigned int Size, float Time, const char *pTimestamp);
 	void OnFinish(CPlayer *Player, float Time, const char *pTimestamp);
@@ -66,13 +66,13 @@ public:
 	CGameTeams(CGameContext *pGameContext);
 
 	// helper methods
-	CCharacter *Character(int ClientID)
+	CCharacter *Character(int ClientId)
 	{
-		return GameServer()->GetPlayerChar(ClientID);
+		return GameServer()->GetPlayerChar(ClientId);
 	}
-	CPlayer *GetPlayer(int ClientID)
+	CPlayer *GetPlayer(int ClientId)
 	{
-		return GameServer()->m_apPlayers[ClientID];
+		return GameServer()->m_apPlayers[ClientId];
 	}
 
 	class CGameContext *GameServer()
@@ -84,33 +84,33 @@ public:
 		return m_pGameContext->Server();
 	}
 
-	void OnCharacterStart(int ClientID);
-	void OnCharacterFinish(int ClientID);
-	void OnCharacterSpawn(int ClientID);
-	void OnCharacterDeath(int ClientID, int Weapon);
+	void OnCharacterStart(int ClientId);
+	void OnCharacterFinish(int ClientId);
+	void OnCharacterSpawn(int ClientId);
+	void OnCharacterDeath(int ClientId, int Weapon);
 	void Tick();
 
 	// returns nullptr if successful, error string if failed
-	const char *SetCharacterTeam(int ClientID, int Team);
+	const char *SetCharacterTeam(int ClientId, int Team);
 	void CheckTeamFinished(int Team);
 
 	void ChangeTeamState(int Team, int State);
 
-	CClientMask TeamMask(int Team, int ExceptID = -1, int Asker = -1);
+	CClientMask TeamMask(int Team, int ExceptId = -1, int Asker = -1);
 
 	int Count(int Team) const;
 
 	// need to be very careful using this method. SERIOUSLY...
-	void SetForceCharacterTeam(int ClientID, int Team);
+	void SetForceCharacterTeam(int ClientId, int Team);
 
 	void Reset();
 	void ResetRoundState(int Team);
 	void ResetSwitchers(int Team);
 
-	void SendTeamsState(int ClientID);
+	void SendTeamsState(int ClientId);
 	void SetTeamLock(int Team, bool Lock);
 	void ResetInvited(int Team);
-	void SetClientInvited(int Team, int ClientID, bool Invited);
+	void SetClientInvited(int Team, int ClientId, bool Invited);
 
 	int GetDDRaceState(CPlayer *Player);
 	int GetStartTime(CPlayer *Player);
@@ -118,22 +118,22 @@ public:
 	void SetDDRaceState(CPlayer *Player, int DDRaceState);
 	void SetStartTime(CPlayer *Player, int StartTime);
 	void SetLastTimeCp(CPlayer *Player, int LastTimeCp);
-	void KillSavedTeam(int ClientID, int Team);
-	void ResetSavedTeam(int ClientID, int Team);
+	void KillSavedTeam(int ClientId, int Team);
+	void ResetSavedTeam(int ClientId, int Team);
 	void RequestTeamSwap(CPlayer *pPlayer, CPlayer *pTargetPlayer, int Team);
 	void SwapTeamCharacters(CPlayer *pPrimaryPlayer, CPlayer *pTargetPlayer, int Team);
 	void ProcessSaveTeam();
 
 	int GetFirstEmptyTeam() const;
 
-	bool TeeStarted(int ClientID)
+	bool TeeStarted(int ClientId)
 	{
-		return m_aTeeStarted[ClientID];
+		return m_aTeeStarted[ClientId];
 	}
 
-	bool TeeFinished(int ClientID)
+	bool TeeFinished(int ClientId)
 	{
-		return m_aTeeFinished[ClientID];
+		return m_aTeeFinished[ClientId];
 	}
 
 	int GetTeamState(int Team)
@@ -149,9 +149,9 @@ public:
 		return m_aTeamLocked[Team];
 	}
 
-	bool IsInvited(int Team, int ClientID)
+	bool IsInvited(int Team, int ClientId)
 	{
-		return m_aInvited[Team].test(ClientID);
+		return m_aInvited[Team].test(ClientId);
 	}
 
 	bool IsStarted(int Team)
@@ -159,29 +159,29 @@ public:
 		return m_aTeamState[Team] == CGameTeams::TEAMSTATE_STARTED;
 	}
 
-	void SetStarted(int ClientID, bool Started)
+	void SetStarted(int ClientId, bool Started)
 	{
-		m_aTeeStarted[ClientID] = Started;
+		m_aTeeStarted[ClientId] = Started;
 	}
 
-	void SetFinished(int ClientID, bool Finished)
+	void SetFinished(int ClientId, bool Finished)
 	{
-		m_aTeeFinished[ClientID] = Finished;
+		m_aTeeFinished[ClientId] = Finished;
 	}
 
-	void SetSaving(int TeamID, std::shared_ptr<CScoreSaveResult> &SaveResult)
+	void SetSaving(int TeamId, std::shared_ptr<CScoreSaveResult> &SaveResult)
 	{
-		m_apSaveTeamResult[TeamID] = SaveResult;
+		m_apSaveTeamResult[TeamId] = SaveResult;
 	}
 
-	bool GetSaving(int TeamID)
+	bool GetSaving(int TeamId)
 	{
-		if(TeamID < TEAM_FLOCK || TeamID >= TEAM_SUPER)
+		if(TeamId < TEAM_FLOCK || TeamId >= TEAM_SUPER)
 			return false;
-		if(g_Config.m_SvTeam != SV_TEAM_FORCED_SOLO && TeamID == TEAM_FLOCK)
+		if(g_Config.m_SvTeam != SV_TEAM_FORCED_SOLO && TeamId == TEAM_FLOCK)
 			return false;
 
-		return m_apSaveTeamResult[TeamID] != nullptr;
+		return m_apSaveTeamResult[TeamId] != nullptr;
 	}
 
 	void SetPractice(int Team, bool Enabled)

--- a/src/game/server/teehistorian.h
+++ b/src/game/server/teehistorian.h
@@ -57,36 +57,36 @@ public:
 	void BeginTick(int Tick);
 
 	void BeginPlayers();
-	void RecordPlayer(int ClientID, const CNetObj_CharacterCore *pChar);
-	void RecordDeadPlayer(int ClientID);
-	void RecordPlayerTeam(int ClientID, int Team);
+	void RecordPlayer(int ClientId, const CNetObj_CharacterCore *pChar);
+	void RecordDeadPlayer(int ClientId);
+	void RecordPlayerTeam(int ClientId, int Team);
 	void RecordTeamPractice(int Team, bool Practice);
 	void EndPlayers();
 
 	void BeginInputs();
-	void RecordPlayerInput(int ClientID, uint32_t UniqueClientID, const CNetObj_PlayerInput *pInput);
-	void RecordPlayerMessage(int ClientID, const void *pMsg, int MsgSize);
-	void RecordPlayerJoin(int ClientID, int Protocol);
-	void RecordPlayerRejoin(int ClientID);
-	void RecordPlayerReady(int ClientID);
-	void RecordPlayerDrop(int ClientID, const char *pReason);
-	void RecordConsoleCommand(int ClientID, int FlagMask, const char *pCmd, IConsole::IResult *pResult);
+	void RecordPlayerInput(int ClientId, uint32_t UniqueClientId, const CNetObj_PlayerInput *pInput);
+	void RecordPlayerMessage(int ClientId, const void *pMsg, int MsgSize);
+	void RecordPlayerJoin(int ClientId, int Protocol);
+	void RecordPlayerRejoin(int ClientId);
+	void RecordPlayerReady(int ClientId);
+	void RecordPlayerDrop(int ClientId, const char *pReason);
+	void RecordConsoleCommand(int ClientId, int FlagMask, const char *pCmd, IConsole::IResult *pResult);
 	void RecordTestExtra();
-	void RecordPlayerSwap(int ClientID1, int ClientID2);
-	void RecordTeamSaveSuccess(int Team, CUuid SaveID, const char *pTeamSave);
+	void RecordPlayerSwap(int ClientId1, int ClientId2);
+	void RecordTeamSaveSuccess(int Team, CUuid SaveId, const char *pTeamSave);
 	void RecordTeamSaveFailure(int Team);
-	void RecordTeamLoadSuccess(int Team, CUuid SaveID, const char *pTeamSave);
+	void RecordTeamLoadSuccess(int Team, CUuid SaveId, const char *pTeamSave);
 	void RecordTeamLoadFailure(int Team);
 	void EndInputs();
 
 	void EndTick();
 
-	void RecordDDNetVersionOld(int ClientID, int DDNetVersion);
-	void RecordDDNetVersion(int ClientID, CUuid ConnectionID, int DDNetVersion, const char *pDDNetVersionStr);
+	void RecordDDNetVersionOld(int ClientId, int DDNetVersion);
+	void RecordDDNetVersion(int ClientId, CUuid ConnectionId, int DDNetVersion, const char *pDDNetVersionStr);
 
-	void RecordAuthInitial(int ClientID, int Level, const char *pAuthName);
-	void RecordAuthLogin(int ClientID, int Level, const char *pAuthName);
-	void RecordAuthLogout(int ClientID);
+	void RecordAuthInitial(int ClientId, int Level, const char *pAuthName);
+	void RecordAuthLogin(int ClientId, int Level, const char *pAuthName);
+	void RecordAuthLogout(int ClientId);
 
 	void RecordAntibot(const void *pData, int DataSize);
 
@@ -95,7 +95,7 @@ public:
 private:
 	void WriteHeader(const CGameInfo *pGameInfo);
 	void WriteExtra(CUuid Uuid, const void *pData, int DataSize);
-	void EnsureTickWrittenPlayerData(int ClientID);
+	void EnsureTickWrittenPlayerData(int ClientId);
 	void EnsureTickWritten();
 	void WriteTick();
 	void Write(const void *pData, int DataSize);
@@ -119,7 +119,7 @@ private:
 		int m_Y;
 
 		CNetObj_PlayerInput m_Input;
-		uint32_t m_UniqueClientID;
+		uint32_t m_UniqueClientId;
 
 		// DDNet team
 		int m_Team;
@@ -138,8 +138,8 @@ private:
 	int m_LastWrittenTick;
 	bool m_TickWritten;
 	int m_Tick;
-	int m_PrevMaxClientID;
-	int m_MaxClientID;
+	int m_PrevMaxClientId;
+	int m_MaxClientId;
 	CTeehistorianPlayer m_aPrevPlayers[MAX_CLIENTS];
 	CTeam m_aPrevTeams[MAX_CLIENTS];
 };

--- a/src/game/teamscore.cpp
+++ b/src/game/teamscore.cpp
@@ -8,36 +8,36 @@ CTeamsCore::CTeamsCore()
 	Reset();
 }
 
-bool CTeamsCore::SameTeam(int ClientID1, int ClientID2) const
+bool CTeamsCore::SameTeam(int ClientId1, int ClientId2) const
 {
-	return m_aTeam[ClientID1] == TEAM_SUPER || m_aTeam[ClientID2] == TEAM_SUPER || m_aTeam[ClientID1] == m_aTeam[ClientID2];
+	return m_aTeam[ClientId1] == TEAM_SUPER || m_aTeam[ClientId2] == TEAM_SUPER || m_aTeam[ClientId1] == m_aTeam[ClientId2];
 }
 
-int CTeamsCore::Team(int ClientID) const
+int CTeamsCore::Team(int ClientId) const
 {
-	return m_aTeam[ClientID];
+	return m_aTeam[ClientId];
 }
 
-void CTeamsCore::Team(int ClientID, int Team)
+void CTeamsCore::Team(int ClientId, int Team)
 {
 	dbg_assert(Team >= TEAM_FLOCK && Team <= TEAM_SUPER, "invalid team");
-	m_aTeam[ClientID] = Team;
+	m_aTeam[ClientId] = Team;
 }
 
-bool CTeamsCore::CanKeepHook(int ClientID1, int ClientID2) const
+bool CTeamsCore::CanKeepHook(int ClientId1, int ClientId2) const
 {
-	if(m_aTeam[ClientID1] == (m_IsDDRace16 ? VANILLA_TEAM_SUPER : TEAM_SUPER) || m_aTeam[ClientID2] == (m_IsDDRace16 ? VANILLA_TEAM_SUPER : TEAM_SUPER) || ClientID1 == ClientID2)
+	if(m_aTeam[ClientId1] == (m_IsDDRace16 ? VANILLA_TEAM_SUPER : TEAM_SUPER) || m_aTeam[ClientId2] == (m_IsDDRace16 ? VANILLA_TEAM_SUPER : TEAM_SUPER) || ClientId1 == ClientId2)
 		return true;
-	return m_aTeam[ClientID1] == m_aTeam[ClientID2];
+	return m_aTeam[ClientId1] == m_aTeam[ClientId2];
 }
 
-bool CTeamsCore::CanCollide(int ClientID1, int ClientID2) const
+bool CTeamsCore::CanCollide(int ClientId1, int ClientId2) const
 {
-	if(m_aTeam[ClientID1] == (m_IsDDRace16 ? VANILLA_TEAM_SUPER : TEAM_SUPER) || m_aTeam[ClientID2] == (m_IsDDRace16 ? VANILLA_TEAM_SUPER : TEAM_SUPER) || ClientID1 == ClientID2)
+	if(m_aTeam[ClientId1] == (m_IsDDRace16 ? VANILLA_TEAM_SUPER : TEAM_SUPER) || m_aTeam[ClientId2] == (m_IsDDRace16 ? VANILLA_TEAM_SUPER : TEAM_SUPER) || ClientId1 == ClientId2)
 		return true;
-	if(m_aIsSolo[ClientID1] || m_aIsSolo[ClientID2])
+	if(m_aIsSolo[ClientId1] || m_aIsSolo[ClientId2])
 		return false;
-	return m_aTeam[ClientID1] == m_aTeam[ClientID2];
+	return m_aTeam[ClientId1] == m_aTeam[ClientId2];
 }
 
 void CTeamsCore::Reset()
@@ -54,15 +54,15 @@ void CTeamsCore::Reset()
 	}
 }
 
-void CTeamsCore::SetSolo(int ClientID, bool Value)
+void CTeamsCore::SetSolo(int ClientId, bool Value)
 {
-	dbg_assert(ClientID >= 0 && ClientID < MAX_CLIENTS, "Invalid client id");
-	m_aIsSolo[ClientID] = Value;
+	dbg_assert(ClientId >= 0 && ClientId < MAX_CLIENTS, "Invalid client id");
+	m_aIsSolo[ClientId] = Value;
 }
 
-bool CTeamsCore::GetSolo(int ClientID) const
+bool CTeamsCore::GetSolo(int ClientId) const
 {
-	if(ClientID < 0 || ClientID >= MAX_CLIENTS)
+	if(ClientId < 0 || ClientId >= MAX_CLIENTS)
 		return false;
-	return m_aIsSolo[ClientID];
+	return m_aIsSolo[ClientId];
 }

--- a/src/game/teamscore.h
+++ b/src/game/teamscore.h
@@ -31,17 +31,17 @@ public:
 
 	CTeamsCore();
 
-	bool SameTeam(int ClientID1, int ClientID2) const;
+	bool SameTeam(int ClientId1, int ClientId2) const;
 
-	bool CanKeepHook(int ClientID1, int ClientID2) const;
-	bool CanCollide(int ClientID1, int ClientID2) const;
+	bool CanKeepHook(int ClientId1, int ClientId2) const;
+	bool CanCollide(int ClientId1, int ClientId2) const;
 
-	int Team(int ClientID) const;
-	void Team(int ClientID, int Team);
+	int Team(int ClientId) const;
+	void Team(int ClientId, int Team);
 
 	void Reset();
-	void SetSolo(int ClientID, bool Value);
-	bool GetSolo(int ClientID) const;
+	void SetSolo(int ClientId, bool Value);
+	bool GetSolo(int ClientId) const;
 };
 
 #endif

--- a/src/rust-bridge/cpp/console.cpp
+++ b/src/rust-bridge/cpp/console.cpp
@@ -123,9 +123,9 @@ void cxxbridge1$IConsole_IResult$GetColor(const ::IConsole_IResult &self, ::std:
   return (self.*GetVictim$)();
 }
 
-void cxxbridge1$IConsole$ExecuteLine(::IConsole &self, ::StrRef *pStr, ::std::int32_t ClientID, bool InterpretSemicolons) noexcept {
+void cxxbridge1$IConsole$ExecuteLine(::IConsole &self, ::StrRef *pStr, ::std::int32_t ClientId, bool InterpretSemicolons) noexcept {
   void (::IConsole::*ExecuteLine$)(::StrRef, ::std::int32_t, bool) = &::IConsole::ExecuteLine;
-  (self.*ExecuteLine$)(::std::move(*pStr), ClientID, InterpretSemicolons);
+  (self.*ExecuteLine$)(::std::move(*pStr), ClientId, InterpretSemicolons);
 }
 
 void cxxbridge1$IConsole$Print(const ::IConsole &self, ::std::int32_t Level, ::StrRef *pFrom, ::StrRef *pStr, ::ColorRGBA *PrintColor) noexcept {

--- a/src/steam/steam_api_flat.h
+++ b/src/steam/steam_api_flat.h
@@ -11,7 +11,7 @@
 
 extern "C" {
 
-typedef uint64_t CSteamID;
+typedef uint64_t CSteamId;
 typedef int32_t HSteamPipe;
 typedef int32_t HSteamUser;
 
@@ -29,7 +29,7 @@ struct GameRichPresenceJoinRequested_t
 	{
 		k_iCallback = 337
 	};
-	CSteamID m_steamIDFriend;
+	CSteamId m_steamIdFriend;
 	char m_aRGCHConnect[256];
 };
 

--- a/src/test/datafile.cpp
+++ b/src/test/datafile.cpp
@@ -40,11 +40,11 @@ TEST(Datafile, ExtendedType)
 		ASSERT_GE(Index, 0);
 		ASSERT_EQ(Reader.GetItemSize(Index), (int)sizeof(ItemTest));
 
-		int Type, ID;
-		const CMapItemTest *pTest = (const CMapItemTest *)Reader.GetItem(Index, &Type, &ID);
+		int Type, Id;
+		const CMapItemTest *pTest = (const CMapItemTest *)Reader.GetItem(Index, &Type, &Id);
 		EXPECT_EQ(pTest, Reader.FindItem(MAPITEMTYPE_TEST, 0x8000));
 		EXPECT_EQ(Type, MAPITEMTYPE_TEST);
-		EXPECT_EQ(ID, 0x8000);
+		EXPECT_EQ(Id, 0x8000);
 
 		EXPECT_EQ(pTest->m_Version, ItemTest.m_Version);
 		EXPECT_EQ(pTest->m_aFields[0], ItemTest.m_aFields[0]);

--- a/src/test/score.cpp
+++ b/src/test/score.cpp
@@ -25,7 +25,7 @@ int CSaveTeam::FromString(const char *)
 	return 1;
 }
 
-bool CSaveTeam::MatchPlayers(const char (*paNames)[MAX_NAME_LENGTH], const int *pClientID, int NumPlayer, char *pMessage, int MessageLen) const
+bool CSaveTeam::MatchPlayers(const char (*paNames)[MAX_NAME_LENGTH], const int *pClientId, int NumPlayer, char *pMessage, int MessageLen) const
 {
 	// Dummy implementation for testing
 	return false;
@@ -98,7 +98,7 @@ struct Score : public testing::TestWithParam<IDbConnection *>
 		str_copy(ScoreData.m_aMap, "Kobra 3", sizeof(ScoreData.m_aMap));
 		str_copy(ScoreData.m_aGameUuid, "8d300ecf-5873-4297-bee5-95668fdff320", sizeof(ScoreData.m_aGameUuid));
 		str_copy(ScoreData.m_aName, "nameless tee", sizeof(ScoreData.m_aName));
-		ScoreData.m_ClientID = 0;
+		ScoreData.m_ClientId = 0;
 		ScoreData.m_Time = Time;
 		str_copy(ScoreData.m_aTimestamp, "2021-11-24 19:24:08", sizeof(ScoreData.m_aTimestamp));
 		for(int i = 0; i < NUM_CHECKPOINTS; i++)
@@ -542,7 +542,7 @@ TEST_P(RandomMap, NoStars)
 {
 	m_RandomMapRequest.m_Stars = -1;
 	ASSERT_FALSE(CScoreWorker::RandomMap(m_pConn, &m_RandomMapRequest, m_aError, sizeof(m_aError))) << m_aError;
-	EXPECT_EQ(m_pRandomMapResult->m_ClientID, 0);
+	EXPECT_EQ(m_pRandomMapResult->m_ClientId, 0);
 	EXPECT_STREQ(m_pRandomMapResult->m_aMap, "Kobra 3");
 	EXPECT_STREQ(m_pRandomMapResult->m_aMessage, "");
 }
@@ -551,7 +551,7 @@ TEST_P(RandomMap, StarsExists)
 {
 	m_RandomMapRequest.m_Stars = 5;
 	ASSERT_FALSE(CScoreWorker::RandomMap(m_pConn, &m_RandomMapRequest, m_aError, sizeof(m_aError))) << m_aError;
-	EXPECT_EQ(m_pRandomMapResult->m_ClientID, 0);
+	EXPECT_EQ(m_pRandomMapResult->m_ClientId, 0);
 	EXPECT_STREQ(m_pRandomMapResult->m_aMap, "Kobra 3");
 	EXPECT_STREQ(m_pRandomMapResult->m_aMessage, "");
 }
@@ -560,7 +560,7 @@ TEST_P(RandomMap, StarsDoesntExist)
 {
 	m_RandomMapRequest.m_Stars = 3;
 	ASSERT_FALSE(CScoreWorker::RandomMap(m_pConn, &m_RandomMapRequest, m_aError, sizeof(m_aError))) << m_aError;
-	EXPECT_EQ(m_pRandomMapResult->m_ClientID, 0);
+	EXPECT_EQ(m_pRandomMapResult->m_ClientId, 0);
 	EXPECT_STREQ(m_pRandomMapResult->m_aMap, "");
 	EXPECT_STREQ(m_pRandomMapResult->m_aMessage, "No maps found on this server!");
 }
@@ -569,7 +569,7 @@ TEST_P(RandomMap, UnfinishedExists)
 {
 	m_RandomMapRequest.m_Stars = -1;
 	ASSERT_FALSE(CScoreWorker::RandomUnfinishedMap(m_pConn, &m_RandomMapRequest, m_aError, sizeof(m_aError))) << m_aError;
-	EXPECT_EQ(m_pRandomMapResult->m_ClientID, 0);
+	EXPECT_EQ(m_pRandomMapResult->m_ClientId, 0);
 	EXPECT_STREQ(m_pRandomMapResult->m_aMap, "Kobra 3");
 	EXPECT_STREQ(m_pRandomMapResult->m_aMessage, "");
 }
@@ -578,7 +578,7 @@ TEST_P(RandomMap, UnfinishedDoesntExist)
 {
 	InsertRank();
 	ASSERT_FALSE(CScoreWorker::RandomUnfinishedMap(m_pConn, &m_RandomMapRequest, m_aError, sizeof(m_aError))) << m_aError;
-	EXPECT_EQ(m_pRandomMapResult->m_ClientID, 0);
+	EXPECT_EQ(m_pRandomMapResult->m_ClientId, 0);
 	EXPECT_STREQ(m_pRandomMapResult->m_aMap, "");
 	EXPECT_STREQ(m_pRandomMapResult->m_aMessage, "You have no more unfinished maps on this server!");
 }

--- a/src/test/teehistorian.cpp
+++ b/src/test/teehistorian.cpp
@@ -211,17 +211,17 @@ protected:
 		}
 		m_TH.Finish();
 	}
-	void DeadPlayer(int ClientID)
+	void DeadPlayer(int ClientId)
 	{
-		m_TH.RecordDeadPlayer(ClientID);
+		m_TH.RecordDeadPlayer(ClientId);
 	}
-	void Player(int ClientID, int x, int y)
+	void Player(int ClientId, int x, int y)
 	{
 		CNetObj_CharacterCore Char;
 		mem_zero(&Char, sizeof(Char));
 		Char.m_X = x;
 		Char.m_Y = y;
-		m_TH.RecordPlayer(ClientID, &Char);
+		m_TH.RecordPlayer(ClientId, &Char);
 	}
 };
 
@@ -264,7 +264,7 @@ TEST_F(TeeHistorian, TickImplicitTwoTicks)
 	Expect(EXPECTED, sizeof(EXPECTED));
 }
 
-TEST_F(TeeHistorian, TickImplicitDescendingClientID)
+TEST_F(TeeHistorian, TickImplicitDescendingClientId)
 {
 	const unsigned char EXPECTED[] = {
 		0x42, 0x01, 0x02, 0x03, // PLAYER_NEW cid=1 x=2 y=3
@@ -281,7 +281,7 @@ TEST_F(TeeHistorian, TickImplicitDescendingClientID)
 	Expect(EXPECTED, sizeof(EXPECTED));
 }
 
-TEST_F(TeeHistorian, TickExplicitAscendingClientID)
+TEST_F(TeeHistorian, TickExplicitAscendingClientId)
 {
 	const unsigned char EXPECTED[] = {
 		0x42, 0x00, 0x04, 0x05, // PLAYER_NEW cid=0 x=4 y=5
@@ -388,10 +388,10 @@ TEST_F(TeeHistorian, DDNetVersion)
 		0x01, 0x92, 0xcb, 0x01,
 		0x40, // FINISH
 	};
-	CUuid ConnectionID = {
+	CUuid ConnectionId = {
 		0xfb, 0x13, 0xa5, 0x76, 0xd3, 0x5f, 0x48, 0x93,
 		0xb8, 0x15, 0xee, 0xdc, 0x6d, 0x98, 0x01, 0x5b};
-	m_TH.RecordDDNetVersion(0, ConnectionID, 13010, "DDNet 13.1 (3623f5e4cd184556)");
+	m_TH.RecordDDNetVersion(0, ConnectionId, 13010, "DDNet 13.1 (3623f5e4cd184556)");
 	m_TH.RecordDDNetVersionOld(1, 13010);
 	Finish();
 	Expect(EXPECTED, sizeof(EXPECTED));
@@ -482,16 +482,16 @@ TEST_F(TeeHistorian, Input)
 		0x41, 0x00,
 		// new player -> InputNew
 		0x45,
-		0x00, // ClientID 0
+		0x00, // ClientId 0
 		0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a,
 		// same unique id, same input -> nothing
 		// same unique id, different input -> InputDiff
 		0x44,
-		0x00, // ClientID 0
+		0x00, // ClientId 0
 		0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 		// different unique id, same input -> InputNew
 		0x45,
-		0x00, // ClientID 0
+		0x00, // ClientId 0
 		0x00, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a,
 		// FINISH
 		0x40};
@@ -533,11 +533,11 @@ TEST_F(TeeHistorian, SaveSuccess)
 		// FINISH
 		0x40};
 
-	CUuid SaveID = {
+	CUuid SaveId = {
 		0xfb, 0x13, 0xa5, 0x76, 0xd3, 0x5f, 0x48, 0x93,
 		0xb8, 0x15, 0xee, 0xdc, 0x6d, 0x98, 0x01, 0x5b};
 	const char *pTeamSave = "2\tH.\nll0";
-	m_TH.RecordTeamSaveSuccess(21, SaveID, pTeamSave);
+	m_TH.RecordTeamSaveSuccess(21, SaveId, pTeamSave);
 	Finish();
 	Expect(EXPECTED, sizeof(EXPECTED));
 }
@@ -577,11 +577,11 @@ TEST_F(TeeHistorian, LoadSuccess)
 		// FINISH
 		0x40};
 
-	CUuid SaveID = {
+	CUuid SaveId = {
 		0xfb, 0x13, 0xa5, 0x76, 0xd3, 0x5f, 0x48, 0x93,
 		0xb8, 0x15, 0xee, 0xdc, 0x6d, 0x98, 0x01, 0x5b};
 	const char *pTeamSave = "2\tH.\nll0";
-	m_TH.RecordTeamLoadSuccess(21, SaveID, pTeamSave);
+	m_TH.RecordTeamLoadSuccess(21, SaveId, pTeamSave);
 	Finish();
 	Expect(EXPECTED, sizeof(EXPECTED));
 }

--- a/src/tools/config_retrieve.cpp
+++ b/src/tools/config_retrieve.cpp
@@ -16,10 +16,10 @@ void Process(IStorage *pStorage, const char *pMapName, const char *pConfigName)
 	Reader.GetType(MAPITEMTYPE_INFO, &Start, &Num);
 	for(int i = Start; i < Start + Num; i++)
 	{
-		int ID;
-		CMapItemInfoSettings *pItem = (CMapItemInfoSettings *)Reader.GetItem(i, nullptr, &ID);
+		int Id;
+		CMapItemInfoSettings *pItem = (CMapItemInfoSettings *)Reader.GetItem(i, nullptr, &Id);
 		int ItemSize = Reader.GetItemSize(i);
-		if(!pItem || ID != 0)
+		if(!pItem || Id != 0)
 			continue;
 
 		if(ItemSize < (int)sizeof(CMapItemInfoSettings))

--- a/src/tools/config_store.cpp
+++ b/src/tools/config_store.cpp
@@ -50,11 +50,11 @@ void Process(IStorage *pStorage, const char *pMapName, const char *pConfigName)
 	bool FoundInfo = false;
 	for(int i = 0; i < Reader.NumItems(); i++)
 	{
-		int Type, ID;
-		int *pItem = (int *)Reader.GetItem(i, &Type, &ID);
+		int Type, Id;
+		int *pItem = (int *)Reader.GetItem(i, &Type, &Id);
 		int Size = Reader.GetItemSize(i);
 		CMapItemInfoSettings MapInfo;
-		if(Type == MAPITEMTYPE_INFO && ID == 0)
+		if(Type == MAPITEMTYPE_INFO && Id == 0)
 		{
 			FoundInfo = true;
 			CMapItemInfoSettings *pInfo = (CMapItemInfoSettings *)pItem;
@@ -92,7 +92,7 @@ void Process(IStorage *pStorage, const char *pMapName, const char *pConfigName)
 				Size = sizeof(MapInfo);
 			}
 		}
-		Writer.AddItem(Type, ID, Size, pItem);
+		Writer.AddItem(Type, Id, Size, pItem);
 	}
 
 	if(!FoundInfo)

--- a/src/tools/crapnet.cpp
+++ b/src/tools/crapnet.cpp
@@ -15,7 +15,7 @@ struct SPacket
 
 	NETADDR m_SendTo;
 	int64_t m_Timestamp;
-	int m_ID;
+	int m_Id;
 	int m_DataSize;
 	char m_aData[1];
 };
@@ -51,7 +51,7 @@ void Run(unsigned short Port, NETADDR Dest)
 	NETADDR Src = {NETTYPE_IPV4, {0, 0, 0, 0}, Port};
 	NETSOCKET Socket = net_udp_create(Src);
 
-	int ID = 0;
+	int Id = 0;
 	int Delaycounter = 0;
 
 	while(true)
@@ -108,10 +108,10 @@ void Run(unsigned short Port, NETADDR Dest)
 			// set data in packet
 			p->m_Timestamp = time_get();
 			p->m_DataSize = Bytes;
-			p->m_ID = ID++;
+			p->m_Id = Id++;
 			mem_copy(p->m_aData, pData, Bytes);
 
-			if(ID > 20 && Bytes > 6 && DataTrash)
+			if(Id > 20 && Bytes > 6 && DataTrash)
 			{
 				p->m_aData[6 + (rand() % (Bytes - 6))] = rand() & 255; // modify a byte
 				if((rand() % 10) == 0)
@@ -134,7 +134,7 @@ void Run(unsigned short Port, NETADDR Dest)
 			{
 				char aAddrStr[NETADDR_MAXSTRSIZE];
 				net_addr_str(&From, aAddrStr, sizeof(aAddrStr), true);
-				dbg_msg("crapnet", "<< %08d %s (%d)", p->m_ID, aAddrStr, p->m_DataSize);
+				dbg_msg("crapnet", "<< %08d %s (%d)", p->m_Id, aAddrStr, p->m_DataSize);
 			}
 		}
 
@@ -176,7 +176,7 @@ void Run(unsigned short Port, NETADDR Dest)
 				int MsPing = Ping.m_Base;
 				g_CurrentLatency = ((time_freq() * MsPing) / 1000) + (int64_t)(((time_freq() * MsFlux) / 1000) * Flux); // 50ms
 
-				if(MsSpike && (p->m_ID % 100) == 0)
+				if(MsSpike && (p->m_Id % 100) == 0)
 				{
 					g_CurrentLatency += (time_freq() * MsSpike) / 1000;
 					aFlags[1] = 'S';
@@ -186,7 +186,7 @@ void Run(unsigned short Port, NETADDR Dest)
 				{
 					char aAddrStr[NETADDR_MAXSTRSIZE];
 					net_addr_str(&p->m_SendTo, aAddrStr, sizeof(aAddrStr), true);
-					dbg_msg("crapnet", ">> %08d %s (%d) %s", p->m_ID, aAddrStr, p->m_DataSize, aFlags);
+					dbg_msg("crapnet", ">> %08d %s (%d) %s", p->m_Id, aAddrStr, p->m_DataSize, aFlags);
 				}
 
 				free(p);

--- a/src/tools/demo_extract_chat.cpp
+++ b/src/tools/demo_extract_chat.cpp
@@ -61,7 +61,7 @@ public:
 				continue;
 
 			const int ItemSize = NetObjHandler.GetUnpackedObjSize(ItemType);
-			void *pObj = Builder.NewItem(pFromItem->Type(), pFromItem->ID(), ItemSize);
+			void *pObj = Builder.NewItem(pFromItem->Type(), pFromItem->Id(), ItemSize);
 			if(!pObj)
 				return -4;
 
@@ -71,21 +71,21 @@ public:
 		return Builder.Finish(pTo);
 	}
 
-	int SnapNumItems(int SnapID)
+	int SnapNumItems(int SnapId)
 	{
-		dbg_assert(SnapID >= 0 && SnapID < IClient::NUM_SNAPSHOT_TYPES, "invalid SnapID");
-		if(!m_apSnapshots[SnapID])
+		dbg_assert(SnapId >= 0 && SnapId < IClient::NUM_SNAPSHOT_TYPES, "invalid SnapId");
+		if(!m_apSnapshots[SnapId])
 			return 0;
-		return m_apSnapshots[SnapID]->m_pAltSnap->NumItems();
+		return m_apSnapshots[SnapId]->m_pAltSnap->NumItems();
 	}
 
-	void *SnapGetItem(int SnapID, int Index, IClient::CSnapItem *pItem)
+	void *SnapGetItem(int SnapId, int Index, IClient::CSnapItem *pItem)
 	{
-		dbg_assert(SnapID >= 0 && SnapID < IClient::NUM_SNAPSHOT_TYPES, "invalid SnapID");
-		const CSnapshotItem *pSnapshotItem = m_apSnapshots[SnapID]->m_pAltSnap->GetItem(Index);
-		pItem->m_DataSize = m_apSnapshots[SnapID]->m_pAltSnap->GetItemSize(Index);
-		pItem->m_Type = m_apSnapshots[SnapID]->m_pAltSnap->GetItemType(Index);
-		pItem->m_ID = pSnapshotItem->ID();
+		dbg_assert(SnapId >= 0 && SnapId < IClient::NUM_SNAPSHOT_TYPES, "invalid SnapId");
+		const CSnapshotItem *pSnapshotItem = m_apSnapshots[SnapId]->m_pAltSnap->GetItem(Index);
+		pItem->m_DataSize = m_apSnapshots[SnapId]->m_pAltSnap->GetItemSize(Index);
+		pItem->m_Type = m_apSnapshots[SnapId]->m_pAltSnap->GetItemType(Index);
+		pItem->m_Id = pSnapshotItem->Id();
 		return (void *)pSnapshotItem->Data();
 	}
 
@@ -100,10 +100,10 @@ public:
 			if(Item.m_Type == NETOBJTYPE_CLIENTINFO)
 			{
 				const CNetObj_ClientInfo *pInfo = (const CNetObj_ClientInfo *)pData;
-				int ClientID = Item.m_ID;
-				if(ClientID < MAX_CLIENTS)
+				int ClientId = Item.m_Id;
+				if(ClientId < MAX_CLIENTS)
 				{
-					CClientData *pClient = &m_aClients[ClientID];
+					CClientData *pClient = &m_aClients[ClientId];
 					IntsToStr(&pInfo->m_Name0, 4, pClient->m_aName);
 				}
 			}
@@ -147,7 +147,7 @@ public:
 		bool Sys;
 		CUuid Uuid;
 
-		int Result = UnpackMessageID(&Msg, &Sys, &Uuid, &Unpacker, &Packer);
+		int Result = UnpackMessageId(&Msg, &Sys, &Uuid, &Unpacker, &Packer);
 		if(Result == UNPACKMESSAGE_ERROR)
 			return;
 
@@ -162,23 +162,23 @@ public:
 			{
 				CNetMsg_Sv_Chat *pMsg = (CNetMsg_Sv_Chat *)pRawMsg;
 
-				if(pMsg->m_ClientID > -1 && m_pClientSnapshotHandler->m_aClients[pMsg->m_ClientID].m_aName[0] == '\0')
+				if(pMsg->m_ClientId > -1 && m_pClientSnapshotHandler->m_aClients[pMsg->m_ClientId].m_aName[0] == '\0')
 					return;
 
 				const char *Prefix = pMsg->m_Team > 1 ? "whisper" : (pMsg->m_Team ? "teamchat" : "chat");
 
-				if(pMsg->m_ClientID < 0)
+				if(pMsg->m_ClientId < 0)
 				{
 					printf("%s: *** %s\n", Prefix, pMsg->m_pMessage);
 					return;
 				}
 
 				if(pMsg->m_Team == 2) // WHISPER SEND
-					printf("%s: -> %s: %s\n", Prefix, m_pClientSnapshotHandler->m_aClients[pMsg->m_ClientID].m_aName, pMsg->m_pMessage);
+					printf("%s: -> %s: %s\n", Prefix, m_pClientSnapshotHandler->m_aClients[pMsg->m_ClientId].m_aName, pMsg->m_pMessage);
 				else if(pMsg->m_Team == 3) // WHISPER RECEIVE
-					printf("%s: <- %s: %s\n", Prefix, m_pClientSnapshotHandler->m_aClients[pMsg->m_ClientID].m_aName, pMsg->m_pMessage);
+					printf("%s: <- %s: %s\n", Prefix, m_pClientSnapshotHandler->m_aClients[pMsg->m_ClientId].m_aName, pMsg->m_pMessage);
 				else
-					printf("%s: %s: %s\n", Prefix, m_pClientSnapshotHandler->m_aClients[pMsg->m_ClientID].m_aName, pMsg->m_pMessage);
+					printf("%s: %s: %s\n", Prefix, m_pClientSnapshotHandler->m_aClients[pMsg->m_ClientId].m_aName, pMsg->m_pMessage);
 			}
 			else if(Msg == NETMSGTYPE_SV_BROADCAST)
 			{

--- a/src/tools/map_convert_07.cpp
+++ b/src/tools/map_convert_07.cpp
@@ -21,9 +21,9 @@ int g_aNewDataSize[MAX_MAPIMAGES];
 void *g_apNewData[MAX_MAPIMAGES];
 
 int g_Index = 0;
-int g_NextDataItemID = -1;
+int g_NextDataItemId = -1;
 
-int g_aImageIDs[MAX_MAPIMAGES];
+int g_aImageIds[MAX_MAPIMAGES];
 
 int LoadPNG(CImageInfo *pImg, const char *pFilename)
 {
@@ -86,7 +86,7 @@ bool CheckImageDimensions(void *pLayerItem, int LayerType, const char *pFilename
 		return true;
 
 	int Type;
-	void *pItem = g_DataReader.GetItem(g_aImageIDs[pTMap->m_Image], &Type);
+	void *pItem = g_DataReader.GetItem(g_aImageIds[pTMap->m_Image], &Type);
 	if(Type != MAPITEMTYPE_IMAGE)
 		return true;
 
@@ -134,7 +134,7 @@ void *ReplaceImageItem(int Index, CMapItemImage *pImgItem, CMapItemImage *pNewIm
 	pNewImgItem->m_Width = ImgInfo.m_Width;
 	pNewImgItem->m_Height = ImgInfo.m_Height;
 	pNewImgItem->m_External = false;
-	pNewImgItem->m_ImageData = g_NextDataItemID++;
+	pNewImgItem->m_ImageData = g_NextDataItemId++;
 
 	g_apNewData[g_Index] = ImgInfo.m_pData;
 	g_aNewDataSize[g_Index] = (size_t)ImgInfo.m_Width * ImgInfo.m_Height * ImgInfo.PixelSize();
@@ -199,7 +199,7 @@ int main(int argc, const char **argv)
 		return -1;
 	}
 
-	g_NextDataItemID = g_DataReader.NumData();
+	g_NextDataItemId = g_DataReader.NumData();
 
 	size_t i = 0;
 	for(int Index = 0; Index < g_DataReader.NumItems(); Index++)
@@ -213,7 +213,7 @@ int main(int argc, const char **argv)
 				dbg_msg("map_convert_07", "map uses more images than the client maximum of %" PRIzu ". filename='%s'", MAX_MAPIMAGES, pSourceFileName);
 				break;
 			}
-			g_aImageIDs[i] = Index;
+			g_aImageIds[i] = Index;
 			i++;
 		}
 	}
@@ -223,9 +223,9 @@ int main(int argc, const char **argv)
 	// add all items
 	for(int Index = 0; Index < g_DataReader.NumItems(); Index++)
 	{
-		int Type, ID;
+		int Type, Id;
 		CUuid Uuid;
-		void *pItem = g_DataReader.GetItem(Index, &Type, &ID, &Uuid);
+		void *pItem = g_DataReader.GetItem(Index, &Type, &Id, &Uuid);
 
 		// Filter ITEMTYPE_EX items, they will be automatically added again.
 		if(Type == ITEMTYPE_EX)
@@ -245,7 +245,7 @@ int main(int argc, const char **argv)
 			Size = sizeof(CMapItemImage);
 			NewImageItem.m_Version = CMapItemImage::CURRENT_VERSION;
 		}
-		g_DataWriter.AddItem(Type, ID, Size, pItem, &Uuid);
+		g_DataWriter.AddItem(Type, Id, Size, pItem, &Uuid);
 	}
 
 	// add all data

--- a/src/tools/map_find_env.cpp
+++ b/src/tools/map_find_env.cpp
@@ -7,8 +7,8 @@
 
 struct EnvelopedQuad
 {
-	int m_GroupID;
-	int m_LayerID;
+	int m_GroupId;
+	int m_LayerId;
 	int m_TilePosX;
 	int m_TilePosY;
 };
@@ -25,7 +25,7 @@ bool OpenMap(const char pMapName[64], CDataFileReader &InputMap)
 	return true;
 }
 
-bool GetLayerGroupIDs(CDataFileReader &InputMap, const int LayerNumber, int &GroupID, int &LayerRelativeID)
+bool GetLayerGroupIds(CDataFileReader &InputMap, const int LayerNumber, int &GroupId, int &LayerRelativeId)
 {
 	int Start, Num;
 	InputMap.GetType(MAPITEMTYPE_GROUP, &Start, &Num);
@@ -35,8 +35,8 @@ bool GetLayerGroupIDs(CDataFileReader &InputMap, const int LayerNumber, int &Gro
 		CMapItemGroup *pItem = (CMapItemGroup *)InputMap.GetItem(Start + i);
 		if(LayerNumber >= pItem->m_StartLayer && LayerNumber <= pItem->m_StartLayer + pItem->m_NumLayers)
 		{
-			GroupID = i;
-			LayerRelativeID = LayerNumber - pItem->m_StartLayer - 1;
+			GroupId = i;
+			LayerRelativeId = LayerNumber - pItem->m_StartLayer - 1;
 			return true;
 		}
 	}
@@ -49,16 +49,16 @@ int FxToTilePos(const int FxPos)
 	return std::floor(fx2f(FxPos) / 32);
 }
 
-bool GetEnvelopedQuads(const CQuad *pQuads, const int NumQuads, const int EnvID, const int GroupID, const int LayerID, int &QuadsCounter, EnvelopedQuad pEnvQuads[1024])
+bool GetEnvelopedQuads(const CQuad *pQuads, const int NumQuads, const int EnvId, const int GroupId, const int LayerId, int &QuadsCounter, EnvelopedQuad pEnvQuads[1024])
 {
 	bool bFound = false;
 	for(int i = 0; i < NumQuads; i++)
 	{
-		if(pQuads[i].m_PosEnv != EnvID && pQuads[i].m_ColorEnv != EnvID)
+		if(pQuads[i].m_PosEnv != EnvId && pQuads[i].m_ColorEnv != EnvId)
 			continue;
 
-		pEnvQuads[QuadsCounter].m_GroupID = GroupID;
-		pEnvQuads[QuadsCounter].m_LayerID = LayerID;
+		pEnvQuads[QuadsCounter].m_GroupId = GroupId;
+		pEnvQuads[QuadsCounter].m_LayerId = LayerId;
 		pEnvQuads[QuadsCounter].m_TilePosX = FxToTilePos(pQuads[i].m_aPoints[4].x);
 		pEnvQuads[QuadsCounter].m_TilePosY = FxToTilePos(pQuads[i].m_aPoints[4].y);
 
@@ -69,20 +69,20 @@ bool GetEnvelopedQuads(const CQuad *pQuads, const int NumQuads, const int EnvID,
 	return bFound;
 }
 
-void PrintEnvelopedQuads(const EnvelopedQuad pEnvQuads[1024], const int EnvID, const int QuadsCounter)
+void PrintEnvelopedQuads(const EnvelopedQuad pEnvQuads[1024], const int EnvId, const int QuadsCounter)
 {
 	if(!QuadsCounter)
 	{
-		dbg_msg("map_find_env", "No quads found with env number #%d", EnvID + 1);
+		dbg_msg("map_find_env", "No quads found with env number #%d", EnvId + 1);
 		return;
 	}
 
-	dbg_msg("map_find_env", "Found %d quads with env number #%d:", QuadsCounter, EnvID + 1);
+	dbg_msg("map_find_env", "Found %d quads with env number #%d:", QuadsCounter, EnvId + 1);
 	for(int i = 0; i < QuadsCounter; i++)
-		dbg_msg("map_find_env", "%*d. Group: #%d - Layer: #%d - Pos: %d,%d", (int)(std::log10(absolute(QuadsCounter))) + 1, i + 1, pEnvQuads[i].m_GroupID, pEnvQuads[i].m_LayerID, pEnvQuads[i].m_TilePosX, pEnvQuads[i].m_TilePosY);
+		dbg_msg("map_find_env", "%*d. Group: #%d - Layer: #%d - Pos: %d,%d", (int)(std::log10(absolute(QuadsCounter))) + 1, i + 1, pEnvQuads[i].m_GroupId, pEnvQuads[i].m_LayerId, pEnvQuads[i].m_TilePosX, pEnvQuads[i].m_TilePosY);
 }
 
-bool FindEnv(const char aFilename[64], const int EnvID)
+bool FindEnv(const char aFilename[64], const int EnvId)
 {
 	CDataFileReader InputMap;
 	if(!OpenMap(aFilename, InputMap))
@@ -103,14 +103,14 @@ bool FindEnv(const char aFilename[64], const int EnvID)
 		CMapItemLayerQuads *pQuadLayer = (CMapItemLayerQuads *)pItem;
 		CQuad *pQuads = (CQuad *)InputMap.GetDataSwapped(pQuadLayer->m_Data);
 
-		int GroupID = 0, LayerRelativeID = 0;
-		if(!GetLayerGroupIDs(InputMap, i + 1, GroupID, LayerRelativeID))
+		int GroupId = 0, LayerRelativeId = 0;
+		if(!GetLayerGroupIds(InputMap, i + 1, GroupId, LayerRelativeId))
 			return false;
 
-		GetEnvelopedQuads(pQuads, pQuadLayer->m_NumQuads, EnvID, GroupID, LayerRelativeID, QuadsCounter, pEnvQuads);
+		GetEnvelopedQuads(pQuads, pQuadLayer->m_NumQuads, EnvId, GroupId, LayerRelativeId, QuadsCounter, pEnvQuads);
 	}
 
-	PrintEnvelopedQuads(pEnvQuads, EnvID, QuadsCounter);
+	PrintEnvelopedQuads(pEnvQuads, EnvId, QuadsCounter);
 
 	return true;
 }
@@ -131,8 +131,8 @@ int main(int argc, const char **argv)
 
 	char aFilename[64];
 	str_copy(aFilename, argv[1]);
-	int EnvID = str_toint(argv[2]) - 1;
-	dbg_msg("map_find_env", "input_map='%s'; env_number='#%d';", aFilename, EnvID + 1);
+	int EnvId = str_toint(argv[2]) - 1;
+	dbg_msg("map_find_env", "input_map='%s'; env_number='#%d';", aFilename, EnvId + 1);
 
-	return FindEnv(aFilename, EnvID);
+	return FindEnv(aFilename, EnvId);
 }

--- a/src/tools/map_optimize.cpp
+++ b/src/tools/map_optimize.cpp
@@ -138,9 +138,9 @@ int main(int argc, const char **argv)
 	// add all items
 	for(int Index = 0, i = 0; Index < Reader.NumItems(); Index++)
 	{
-		int Type, ID;
+		int Type, Id;
 		CUuid Uuid;
-		void *pPtr = Reader.GetItem(Index, &Type, &ID, &Uuid);
+		void *pPtr = Reader.GetItem(Index, &Type, &Id, &Uuid);
 
 		// Filter ITEMTYPE_EX items, they will be automatically added again.
 		if(Type == ITEMTYPE_EX)
@@ -205,7 +205,7 @@ int main(int argc, const char **argv)
 		}
 
 		int Size = Reader.GetItemSize(Index);
-		Writer.AddItem(Type, ID, Size, pPtr, &Uuid);
+		Writer.AddItem(Type, Id, Size, pPtr, &Uuid);
 	}
 
 	// add all data

--- a/src/tools/map_replace_area.cpp
+++ b/src/tools/map_replace_area.cpp
@@ -165,9 +165,9 @@ void SaveOutputMap(CDataFileReader &InputMap, CDataFileWriter &OutputMap)
 {
 	for(int i = 0; i < InputMap.NumItems(); i++)
 	{
-		int ID, Type;
+		int Id, Type;
 		CUuid Uuid;
-		void *pItem = InputMap.GetItem(i, &Type, &ID, &Uuid);
+		void *pItem = InputMap.GetItem(i, &Type, &Id, &Uuid);
 
 		// Filter ITEMTYPE_EX items, they will be automatically added again.
 		if(Type == ITEMTYPE_EX)
@@ -179,7 +179,7 @@ void SaveOutputMap(CDataFileReader &InputMap, CDataFileWriter &OutputMap)
 			pItem = g_apNewItem[i];
 
 		int Size = InputMap.GetItemSize(i);
-		OutputMap.AddItem(Type, ID, Size, pItem, &Uuid);
+		OutputMap.AddItem(Type, Id, Size, pItem, &Uuid);
 	}
 
 	for(int i = 0; i < InputMap.NumData(); i++)

--- a/src/tools/map_replace_image.cpp
+++ b/src/tools/map_replace_image.cpp
@@ -17,9 +17,9 @@
 CDataFileReader g_DataReader;
 
 // global new image data (set by ReplaceImageItem)
-int g_NewNameID = -1;
+int g_NewNameId = -1;
 char g_aNewName[128];
-int g_NewDataID = -1;
+int g_NewDataId = -1;
 int g_NewDataSize = 0;
 void *g_pNewData = nullptr;
 
@@ -101,9 +101,9 @@ void *ReplaceImageItem(int Index, CMapItemImage *pImgItem, const char *pImgName,
 	pNewImgItem->m_Width = ImgInfo.m_Width;
 	pNewImgItem->m_Height = ImgInfo.m_Height;
 
-	g_NewNameID = pImgItem->m_ImageName;
+	g_NewNameId = pImgItem->m_ImageName;
 	IStorage::StripPathAndExtension(pImgFile, g_aNewName, sizeof(g_aNewName));
-	g_NewDataID = pImgItem->m_ImageData;
+	g_NewDataId = pImgItem->m_ImageData;
 	g_pNewData = ImgInfo.m_pData;
 	g_NewDataSize = (size_t)ImgInfo.m_Width * ImgInfo.m_Height * ImgInfo.PixelSize();
 
@@ -152,9 +152,9 @@ int main(int argc, const char **argv)
 	// add all items
 	for(int Index = 0; Index < g_DataReader.NumItems(); Index++)
 	{
-		int Type, ID;
+		int Type, Id;
 		CUuid Uuid;
-		void *pItem = g_DataReader.GetItem(Index, &Type, &ID, &Uuid);
+		void *pItem = g_DataReader.GetItem(Index, &Type, &Id, &Uuid);
 
 		// Filter ITEMTYPE_EX items, they will be automatically added again.
 		if(Type == ITEMTYPE_EX)
@@ -174,10 +174,10 @@ int main(int argc, const char **argv)
 			NewImageItem.m_Version = CMapItemImage::CURRENT_VERSION;
 		}
 
-		Writer.AddItem(Type, ID, Size, pItem, &Uuid);
+		Writer.AddItem(Type, Id, Size, pItem, &Uuid);
 	}
 
-	if(g_NewDataID == -1)
+	if(g_NewDataId == -1)
 	{
 		dbg_msg("map_replace_image", "image '%s' not found on source map '%s'.", pImageName, pSourceFileName);
 		return -1;
@@ -188,12 +188,12 @@ int main(int argc, const char **argv)
 	{
 		void *pData;
 		int Size;
-		if(Index == g_NewDataID)
+		if(Index == g_NewDataId)
 		{
 			pData = g_pNewData;
 			Size = g_NewDataSize;
 		}
-		else if(Index == g_NewNameID)
+		else if(Index == g_NewNameId)
 		{
 			pData = (void *)g_aNewName;
 			Size = str_length(g_aNewName) + 1;

--- a/src/tools/map_resave.cpp
+++ b/src/tools/map_resave.cpp
@@ -29,9 +29,9 @@ static int ResaveMap(const char *pSourceMap, const char *pDestinationMap, IStora
 	// add all items
 	for(int Index = 0; Index < Reader.NumItems(); Index++)
 	{
-		int Type, ID;
+		int Type, Id;
 		CUuid Uuid;
-		const void *pPtr = Reader.GetItem(Index, &Type, &ID, &Uuid);
+		const void *pPtr = Reader.GetItem(Index, &Type, &Id, &Uuid);
 
 		// Filter ITEMTYPE_EX items, they will be automatically added again.
 		if(Type == ITEMTYPE_EX)
@@ -40,7 +40,7 @@ static int ResaveMap(const char *pSourceMap, const char *pDestinationMap, IStora
 		}
 
 		int Size = Reader.GetItemSize(Index);
-		Writer.AddItem(Type, ID, Size, pPtr, &Uuid);
+		Writer.AddItem(Type, Id, Size, pPtr, &Uuid);
 	}
 
 	// add all data

--- a/src/tools/twping.cpp
+++ b/src/tools/twping.cpp
@@ -44,7 +44,7 @@ int main(int argc, const char **argv)
 	aBuffer[sizeof(SERVERBROWSE_GETINFO)] = CurToken;
 
 	CNetChunk Packet;
-	Packet.m_ClientID = -1;
+	Packet.m_ClientId = -1;
 	Packet.m_Address = Addr;
 	Packet.m_Flags = NETSENDFLAG_CONNLESS;
 	Packet.m_DataSize = sizeof(aBuffer);


### PR DESCRIPTION
This is the strict version, ID → Id, UI → Ui, except DDNet which stays DDNet.

This would fix #7750.

Done using a naive rename script (for bash, use `shopt -s globstar`):

```fish
sed -i \
        -e 's/\([a-z]_\?\)ID/\1Id/g' \
        -e 's/\([^ ]\)\<UI\>/\1Ui/g' \
        -e 's/UI()/Ui()/g' \
        -e 's/\<CUI\>/CUi/g' \
        -e 's/\([\ta-z.(&]\|[,=|] \)ID\>/\1Id/g' \
        -e 's/\<ID\>\([^ ").]\)/Id\1/g' \
        -e 's/\<ID\([0-9]\)/Id\1/g' \
        -e 's/\<ID\>\( [<=>:+*/-]\)/Id\1/g' \
        -e 's/int ID/int Id/g' \
        -e 's/\([a-z]_\?\)GPU/\1Gpu/g' \
        -e 's/\([a-z]_\?\)IP/\1Ip/g' \
        -e 's/\([a-z]_\?\)CID/\1Cid/g' \
        -e 's/\([a-z]_\?\)MySQL/\1Mysql/g' \
        -e 's/MySql/Mysql/g' \
        -e 's/\([a-xz]_\?\)SQL/\1Sql/g' \
        -e 's/DPMode/DpMode/g' \
        -e 's/TTWGraphics/TTwGraphics/g' \
        \
        -e 's/Ipointer/IPointer/g' \
        -e 's/\.vendorId/.vendorID/g' \
        -e 's/\.windowId/.windowID/g' \
        -e 's/SDL_GetWindowFromId/SDL_GetWindowFromID/g' \
        -e 's/SDL_AudioDeviceId/SDL_AudioDeviceID/g' \
        -e 's/SDL_JoystickId/SDL_JoystickID/g' \
        -e 's/SDL_JoystickInstanceId/SDL_JoystickInstanceID/g' \
        -e 's/AVCodecId/AVCodecID/g' \
        src/**/*.cpp src/**/*.h {datasrc,scripts}/**/*.py
git checkout -- src/engine/external
```

I like this option because it presents clear rules.


## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
