### PR TITLE
Various fixes for envelope and bezier evaluation

### DIFF
--- a/src/game/client/render_map.cpp
+++ b/src/game/client/render_map.cpp
@@ -300,11 +300,11 @@ void CRenderTools::RenderEvalEnvelope(const IEnvelopePointAccess *pPoints, std::
 				for(size_t c = 0; c < Channels; c++)
 				{
 					// monotonic 2d cubic bezier curve
-					const vec2 p0 = vec2(pCurrentPoint->m_Time / 1000.0f, fx2f(pCurrentPoint->m_aValues[c]));
-					const vec2 p3 = vec2(pNextPoint->m_Time / 1000.0f, fx2f(pNextPoint->m_aValues[c]));
+					const vec2 p0 = vec2(pCurrentPoint->m_Time, fx2f(pCurrentPoint->m_aValues[c]));
+					const vec2 p3 = vec2(pNextPoint->m_Time, fx2f(pNextPoint->m_aValues[c]));
 
-					const vec2 OutTang = vec2(pCurrentPointBezier->m_aOutTangentDeltaX[c] / 1000.0f, fx2f(pCurrentPointBezier->m_aOutTangentDeltaY[c]));
-					const vec2 InTang = -vec2(pNextPointBezier->m_aInTangentDeltaX[c] / 1000.0f, fx2f(pNextPointBezier->m_aInTangentDeltaY[c]));
+					const vec2 OutTang = vec2(pCurrentPointBezier->m_aOutTangentDeltaX[c], fx2f(pCurrentPointBezier->m_aOutTangentDeltaY[c]));
+					const vec2 InTang = -vec2(pNextPointBezier->m_aInTangentDeltaX[c], fx2f(pNextPointBezier->m_aInTangentDeltaY[c]));
 					vec2 p1 = p0 + OutTang;
 					vec2 p2 = p3 - InTang;
 
@@ -312,7 +312,7 @@ void CRenderTools::RenderEvalEnvelope(const IEnvelopePointAccess *pPoints, std::
 					ValidateFCurve(p0, p1, p2, p3);
 
 					// solve x(a) = time for a
-					a = clamp(SolveBezier(TimeMillis / 1000.0f, p0.x, p1.x, p2.x, p3.x), 0.0f, 1.0f);
+					a = clamp(SolveBezier(TimeMillis, p0.x, p1.x, p2.x, p3.x), 0.0f, 1.0f);
 
 					// value = y(t)
 					Result[c] = bezier(p0.y, p1.y, p2.y, p3.y, a);

--- a/src/game/client/render_map.cpp
+++ b/src/game/client/render_map.cpp
@@ -124,13 +124,6 @@ const CEnvPointBezier *CMapBasedEnvelopePointAccess::GetBezier(int Index) const
 	return nullptr;
 }
 
-static void ValidateFCurve(const vec2 &p0, vec2 &p1, vec2 &p2, const vec2 &p3)
-{
-	// validate the bezier curve
-	p1.x = clamp(p1.x, p0.x, p3.x);
-	p2.x = clamp(p2.x, p0.x, p3.x);
-}
-
 static double CubicRoot(double x)
 {
 	if(x == 0.0)
@@ -143,11 +136,6 @@ static double CubicRoot(double x)
 
 static float SolveBezier(float x, float p0, float p1, float p2, float p3)
 {
-	// check for valid f-curve
-	// we only take care of monotonic bezier curves, so there has to be exactly 1 real solution
-	if(!(p0 <= x && x <= p3) || !(p0 <= p1 && p1 <= p3) || !(p0 <= p2 && p2 <= p3))
-		return 0.0f;
-
 	const double x3 = -p0 + 3.0 * p1 - 3.0 * p2 + p3;
 	const double x2 = 3.0 * p0 - 6.0 * p1 + 3.0 * p2;
 	const double x1 = -3.0 * p0 + 3.0 * p1;
@@ -167,7 +155,7 @@ static float SolveBezier(float x, float p0, float p1, float p2, float p3)
 	else if(x3 == 0.0)
 	{
 		// quadratic
-		// t * t + b * t +c = 0
+		// t * t + b * t + c = 0
 		const double b = x1 / x2;
 		const double c = x0 / x2;
 
@@ -179,7 +167,7 @@ static float SolveBezier(float x, float p0, float p1, float p2, float p3)
 
 		const double t = (-b + SqrtD) / 2.0;
 
-		if(0.0 <= t && t <= 1.0001f)
+		if(0.0 <= t && t <= 1.0001)
 			return t;
 		return (-b - SqrtD) / 2.0;
 	}
@@ -213,24 +201,24 @@ static float SolveBezier(float x, float p0, float p1, float p2, float p3)
 			const double s = CubicRoot(-q);
 			const double t = 2.0 * s - sub;
 
-			if(0.0 <= t && t <= 1.0001f)
+			if(0.0 <= t && t <= 1.0001)
 				return t;
 			return (-s - sub);
 		}
 		else
 		{
-			// Casus irreductibilis ... ,_,
+			// Casus irreducibilis ... ,_,
 			const double phi = std::acos(-q / std::sqrt(-(p * p * p))) / 3.0;
 			const double s = 2.0 * std::sqrt(-p);
 
 			const double t1 = s * std::cos(phi) - sub;
 
-			if(0.0 <= t1 && t1 <= 1.0001f)
+			if(0.0 <= t1 && t1 <= 1.0001)
 				return t1;
 
 			const double t2 = -s * std::cos(phi + pi / 3.0) - sub;
 
-			if(0.0 <= t2 && t2 <= 1.0001f)
+			if(0.0 <= t2 && t2 <= 1.0001)
 				return t2;
 			return -s * std::cos(phi - pi / 3.0) - sub;
 		}
@@ -304,12 +292,14 @@ void CRenderTools::RenderEvalEnvelope(const IEnvelopePointAccess *pPoints, std::
 					const vec2 p3 = vec2(pNextPoint->m_Time, fx2f(pNextPoint->m_aValues[c]));
 
 					const vec2 OutTang = vec2(pCurrentPointBezier->m_aOutTangentDeltaX[c], fx2f(pCurrentPointBezier->m_aOutTangentDeltaY[c]));
-					const vec2 InTang = -vec2(pNextPointBezier->m_aInTangentDeltaX[c], fx2f(pNextPointBezier->m_aInTangentDeltaY[c]));
+					const vec2 InTang = vec2(pNextPointBezier->m_aInTangentDeltaX[c], fx2f(pNextPointBezier->m_aInTangentDeltaY[c]));
+
 					vec2 p1 = p0 + OutTang;
-					vec2 p2 = p3 - InTang;
+					vec2 p2 = p3 + InTang;
 
 					// validate bezier curve
-					ValidateFCurve(p0, p1, p2, p3);
+					p1.x = clamp(p1.x, p0.x, p3.x);
+					p2.x = clamp(p2.x, p0.x, p3.x);
 
 					// solve x(a) = time for a
 					a = clamp(SolveBezier(TimeMillis, p0.x, p1.x, p2.x, p3.x), 0.0f, 1.0f);

--- a/src/game/client/render_map.cpp
+++ b/src/game/client/render_map.cpp
@@ -267,7 +267,7 @@ void CRenderTools::RenderEvalEnvelope(const IEnvelopePointAccess *pPoints, std::
 	{
 		const CEnvPoint *pCurrentPoint = pPoints->GetPoint(i);
 		const CEnvPoint *pNextPoint = pPoints->GetPoint(i + 1);
-		if(TimeMillis >= pCurrentPoint->m_Time && TimeMillis <= pNextPoint->m_Time)
+		if(TimeMillis >= pCurrentPoint->m_Time && TimeMillis < pNextPoint->m_Time)
 		{
 			const float Delta = pNextPoint->m_Time - pCurrentPoint->m_Time;
 			float a = (float)(TimeMillis - pCurrentPoint->m_Time) / Delta;

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -6639,9 +6639,9 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 				float StepSize = (EndX - StartX) / static_cast<float>(Steps);
 
 				ColorRGBA Channels = ColorRGBA(0.0f, 0.0f, 0.0f, 0.0f);
-				pEnvelope->Eval(StartTime + StepTime, Channels, c + 1);
+				pEnvelope->Eval(StartTime, Channels, c + 1);
 				float PrevY = EnvelopeToScreenY(View, Channels[c]);
-				for(int i = 2; i < Steps; i++)
+				for(int i = 1; i < Steps; i++)
 				{
 					Channels = ColorRGBA(0.0f, 0.0f, 0.0f, 0.0f);
 					pEnvelope->Eval(StartTime + i * StepTime, Channels, c + 1);


### PR DESCRIPTION
See commit messages.

Closes #8005.

Screenshots:

- Example 1:
   - Before:
![screenshot_2024-02-26_20-44-03](https://github.com/ddnet/ddnet/assets/23437060/c128deb0-7659-476b-be77-ca406d0eb226)
   - After: 
![screenshot_2024-02-26_20-46-26](https://github.com/ddnet/ddnet/assets/23437060/980304a0-b76c-453e-bade-95a0c1df4d79)
- Example 2 (you can see the missing first line segment here):
   - Before:
![screenshot_2024-02-26_20-44-18](https://github.com/ddnet/ddnet/assets/23437060/2ce7efc3-345e-45ea-903e-f8ba95d74ca6)
   - After: 
![screenshot_2024-02-26_20-46-34](https://github.com/ddnet/ddnet/assets/23437060/08f0c817-2260-4798-978d-f8035cfd3bab)
- Example 3 (you can see what "to the point where evaluation of bezier curves goes completely wrong in some cases" means):
   - Before:
![screenshot_2024-02-26_20-44-36](https://github.com/ddnet/ddnet/assets/23437060/a757e389-114b-4c05-a9c6-0cb1c5c520ee)
   - After: 
![screenshot_2024-02-26_20-46-47](https://github.com/ddnet/ddnet/assets/23437060/497c39e8-dbac-4f53-be85-780f7423c52a)

## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
