### PR TITLE
Add assertions to all thread and semaphore functions

### DIFF
--- a/src/base/system.h
+++ b/src/base/system.h
@@ -558,6 +558,7 @@ void aio_free(ASYNCIO *aio);
  * Threading related functions.
  *
  * @see Locks
+ * @see Semaphore
  */
 
 /**
@@ -567,7 +568,9 @@ void aio_free(ASYNCIO *aio);
  *
  * @param threadfunc Entry point for the new thread.
  * @param user Pointer to pass to the thread.
- * @param name name describing the use of the thread
+ * @param name Name describing the use of the thread.
+ *
+ * @return Handle for the new thread.
  */
 void *thread_init(void (*threadfunc)(void *), void *user, const char *name);
 
@@ -581,35 +584,33 @@ void *thread_init(void (*threadfunc)(void *), void *user, const char *name);
 void thread_wait(void *thread);
 
 /**
- * Yield the current threads execution slice.
+ * Yield the current thread's execution slice.
  *
  * @ingroup Threads
  */
 void thread_yield();
 
 /**
- * Puts the thread in the detached thread, guaranteeing that
+ * Puts the thread in the detached state, guaranteeing that
  * resources of the thread will be freed immediately when the
  * thread terminates.
  *
  * @ingroup Threads
  *
- * @param thread Thread to detach
+ * @param thread Thread to detach.
  */
 void thread_detach(void *thread);
 
 /**
- * Creates a new thread and if it succeeded detaches it.
+ * Creates a new thread and detaches it.
  *
  * @ingroup Threads
  *
  * @param threadfunc Entry point for the new thread.
  * @param user Pointer to pass to the thread.
- * @param name Name describing the use of the thread
- *
- * @return true on success, false on failure.
+ * @param name Name describing the use of the thread.
  */
-bool thread_init_and_detach(void (*threadfunc)(void *), void *user, const char *name);
+void thread_init_and_detach(void (*threadfunc)(void *), void *user, const char *name);
 
 /**
  * @defgroup Semaphore


### PR DESCRIPTION
Assert on failures in all `thread_*` and `sphore_*` functions on all operating systems instead of only printing log messages on Unix, as these functions are only expected to fail when used with incorrect arguments or in some cases when a dead-lock is detected.

On macOS, `sphore_wait` was not correctly calling `sem_wait` in a loop to repeat the wait operation if it is interrupted by a signal.

On Windows, the AIO tests were failing with the additional assertions. The maximum count that semaphores on Windows could be incremented to was previously, arbitrarily limited to 10000, which was causing the `ReleaseSemaphore` call to fail as the AIO semaphore is signaled 65536 times (for each write operation) in multiple of the AIO tests.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [X] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
