### PR TITLE
Define Windows header macros only once in `CMakeLists.txt`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3346,7 +3346,13 @@ foreach(target ${TARGETS_OWN})
     target_compile_options(${target} PRIVATE /wd4800) # Implicit conversion of int to bool.
   endif()
   if(TARGET_OS STREQUAL "windows")
+    # See https://learn.microsoft.com/en-us/windows/win32/winprog/using-the-windows-headers
     target_compile_definitions(${target} PRIVATE NOMINMAX) # windows.h shouldn't define min/max macros
+    target_compile_definitions(${target} PRIVATE WIN32_LEAN_AND_MEAN) # windows.h shouldn't define the name IStorage
+    # 0x0501 (Windows XP) is required for mingw to get getaddrinfo to work
+    # 0x0600 (Windows Vista) is required to use RegGetValueW and RegDeleteTreeW
+    target_compile_definitions(${target} PRIVATE NTDDI_VERSION=0x06000000) # Minimum OS version (new macro, since Vista)
+    target_compile_definitions(${target} PRIVATE _WIN32_WINNT=0x0600) # Minimum OS version (old macro, both must be defined)
     target_compile_definitions(${target} PRIVATE UNICODE) # Windows headers
     target_compile_definitions(${target} PRIVATE _UNICODE) # C-runtime
   endif()

--- a/src/base/log.cpp
+++ b/src/base/log.cpp
@@ -8,9 +8,6 @@
 #include <memory>
 
 #if defined(CONF_FAMILY_WINDOWS)
-#define WIN32_LEAN_AND_MEAN
-#undef _WIN32_WINNT
-#define _WIN32_WINNT 0x0501 /* required for mingw to get getaddrinfo to work */
 #include <fcntl.h>
 #include <io.h>
 #include <windows.h>

--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -62,11 +62,6 @@
 #endif
 
 #elif defined(CONF_FAMILY_WINDOWS)
-#define WIN32_LEAN_AND_MEAN
-#undef _WIN32_WINNT
-// 0x0501 (Windows XP) is required for mingw to get getaddrinfo to work
-// 0x0600 (Windows Vista) is required to use RegGetValueW and RegDeleteTreeW
-#define _WIN32_WINNT 0x0600
 #include <windows.h>
 #include <winsock2.h>
 #include <ws2tcpip.h>

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -1,8 +1,6 @@
 /* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 
-#define _WIN32_WINNT 0x0501
-
 #include <base/hash.h>
 #include <base/hash_ctxt.h>
 #include <base/logger.h>

--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -25,7 +25,6 @@
 #endif
 
 #if defined(CONF_FAMILY_WINDOWS)
-#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 // windows.h must be included before imm.h, but clang-format requires includes to be sorted alphabetically, hence this comment.
 #include <imm.h>

--- a/src/engine/server/main.cpp
+++ b/src/engine/server/main.cpp
@@ -1,6 +1,3 @@
-
-#define _WIN32_WINNT 0x0501
-
 #include <base/logger.h>
 #include <base/system.h>
 
@@ -23,7 +20,6 @@
 #include <vector>
 
 #if defined(CONF_FAMILY_WINDOWS)
-#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #endif
 

--- a/src/engine/shared/fifo.cpp
+++ b/src/engine/shared/fifo.cpp
@@ -79,7 +79,6 @@ void CFifo::Update()
 
 #elif defined(CONF_FAMILY_WINDOWS)
 
-#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
 void CFifo::Init(IConsole *pConsole, char *pFifoFile, int Flag)

--- a/src/engine/shared/http.cpp
+++ b/src/engine/shared/http.cpp
@@ -15,7 +15,6 @@
 #include <csignal>
 #endif
 
-#define WIN32_LEAN_AND_MEAN
 #include <curl/curl.h>
 
 // There is a stray constant on Windows/MSVC...


### PR DESCRIPTION
Instead of defining the macro `WIN32_LEAN_AND_MEAN` and sometimes also the macro `_WIN32_WINNT` in each file that directly or indirectly includes `<windows.h>`, only define these macros once consistently in `CMakeLists.txt`.

Also define `NTDDI_VERSION`, which is the new macro to specify the minimum Windows version starting with Windows Vista. This macro needs to be defined in addition to old `_WIN32_WINNT` macro, according to the documentation.

See https://learn.microsoft.com/en-us/windows/win32/winprog/using-the-windows-headers

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
