### PR TITLE
fix incorrect usage of `SvEmotionalTees`

### DIFF
--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -2683,7 +2683,7 @@ void CGameContext::OnEmoticonNetMessage(const CNetMsg_Cl_Emoticon *pMsg, int Cli
 		SendEmoticon(ClientID, pMsg->m_Emoticon, -1);
 	}
 
-	if(g_Config.m_SvEmotionalTees && pPlayer->m_EyeEmoteEnabled)
+	if(g_Config.m_SvEmotionalTees == 1 && pPlayer->m_EyeEmoteEnabled)
 	{
 		int EmoteType = EMOTE_NORMAL;
 		switch(pMsg->m_Emoticon)


### PR DESCRIPTION
According to the config description `sv_emotional_tees -1` should disable eye change completely but since `-1` evaluates to `true` that was not the case.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
