### PR TITLE
Let users pick background entities map without file extensions

### DIFF
--- a/src/game/client/components/background.cpp
+++ b/src/game/client/components/background.cpp
@@ -60,7 +60,7 @@ void CBackground::LoadBackground()
 		bool NeedImageLoading = false;
 
 		char aBuf[IO_MAX_PATH_LENGTH];
-		str_format(aBuf, sizeof(aBuf), "maps/%s", g_Config.m_ClBackgroundEntities);
+		str_format(aBuf, sizeof(aBuf), str_endswith_nocase(g_Config.m_ClBackgroundEntities, ".map") ? "maps/%s" : "maps/%s.map", g_Config.m_ClBackgroundEntities);
 		if(str_comp(g_Config.m_ClBackgroundEntities, CURRENT_MAP) == 0)
 		{
 			m_pMap = Kernel()->RequestInterface<IEngineMap>();

--- a/src/game/client/components/background.cpp
+++ b/src/game/client/components/background.cpp
@@ -60,7 +60,7 @@ void CBackground::LoadBackground()
 		bool NeedImageLoading = false;
 
 		char aBuf[IO_MAX_PATH_LENGTH];
-		str_format(aBuf, sizeof(aBuf), str_endswith_nocase(g_Config.m_ClBackgroundEntities, ".map") ? "maps/%s" : "maps/%s.map", g_Config.m_ClBackgroundEntities);
+		str_format(aBuf, sizeof(aBuf), "maps/%s%s", g_Config.m_ClBackgroundEntities, str_endswith(g_Config.m_ClBackgroundEntities, ".map") ? "" : ".map");
 		if(str_comp(g_Config.m_ClBackgroundEntities, CURRENT_MAP) == 0)
 		{
 			m_pMap = Kernel()->RequestInterface<IEngineMap>();


### PR DESCRIPTION
Lets users input their entities background map without the .map file extension. Works with both cl_background_entities, and the input box in settings, DDNet tab.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
