### PR TITLE
Always build switch entities layers

### DIFF
--- a/src/game/client/components/mapimages.cpp
+++ b/src/game/client/components/mapimages.cpp
@@ -229,78 +229,60 @@ IGraphics::CTextureHandle CMapImages::GetEntities(EMapImageEntityLayerType Entit
 			// build game layer
 			for(int n = 0; n < MAP_IMAGE_ENTITY_LAYER_TYPE_COUNT; ++n)
 			{
-				bool BuildThisLayer = true;
-				if(n == MAP_IMAGE_ENTITY_LAYER_TYPE_SWITCH && Layers()->SwitchLayer() == nullptr)
-					BuildThisLayer = false;
-
 				dbg_assert(!m_aaEntitiesTextures[(EntitiesModType * 2) + (int)EntitiesAreMasked][n].IsValid(), "entities texture already loaded when it should not be");
 
-				if(BuildThisLayer)
-				{
-					// set everything transparent
-					mem_zero(pBuildImgData, BuildImageSize);
+				// set everything transparent
+				mem_zero(pBuildImgData, BuildImageSize);
 
-					for(int i = 0; i < 256; ++i)
+				for(int i = 0; i < 256; ++i)
+				{
+					bool ValidTile = i != 0;
+					int TileIndex = i;
+					if(EntitiesAreMasked)
 					{
-						bool ValidTile = i != 0;
-						int TileIndex = i;
-						if(EntitiesAreMasked)
+						if(EntitiesModType == MAP_IMAGE_MOD_TYPE_DDNET || EntitiesModType == MAP_IMAGE_MOD_TYPE_DDRACE)
 						{
-							if(EntitiesModType == MAP_IMAGE_MOD_TYPE_DDNET || EntitiesModType == MAP_IMAGE_MOD_TYPE_DDRACE)
+							if(EntitiesModType == MAP_IMAGE_MOD_TYPE_DDNET || TileIndex != TILE_BOOST)
 							{
-								if(EntitiesModType == MAP_IMAGE_MOD_TYPE_DDNET || TileIndex != TILE_BOOST)
+								if(n == MAP_IMAGE_ENTITY_LAYER_TYPE_ALL_EXCEPT_SWITCH && !IsValidGameTile((int)TileIndex) && !IsValidFrontTile((int)TileIndex) && !IsValidSpeedupTile((int)TileIndex) &&
+									!IsValidTeleTile((int)TileIndex) && !IsValidTuneTile((int)TileIndex))
+									ValidTile = false;
+								else if(n == MAP_IMAGE_ENTITY_LAYER_TYPE_SWITCH)
 								{
-									if(n == MAP_IMAGE_ENTITY_LAYER_TYPE_ALL_EXCEPT_SWITCH && !IsValidGameTile((int)TileIndex) && !IsValidFrontTile((int)TileIndex) && !IsValidSpeedupTile((int)TileIndex) &&
-										!IsValidTeleTile((int)TileIndex) && !IsValidTuneTile((int)TileIndex))
+									if(!IsValidSwitchTile((int)TileIndex))
 										ValidTile = false;
-									else if(n == MAP_IMAGE_ENTITY_LAYER_TYPE_SWITCH)
-									{
-										if(!IsValidSwitchTile((int)TileIndex))
-											ValidTile = false;
-									}
 								}
 							}
-							else if((EntitiesModType == MAP_IMAGE_MOD_TYPE_RACE) && IsCreditsTile((int)TileIndex))
-							{
-								ValidTile = false;
-							}
-							else if((EntitiesModType == MAP_IMAGE_MOD_TYPE_FNG) && IsCreditsTile((int)TileIndex))
-							{
-								ValidTile = false;
-							}
-							else if((EntitiesModType == MAP_IMAGE_MOD_TYPE_VANILLA) && IsCreditsTile((int)TileIndex))
-							{
-								ValidTile = false;
-							}
 						}
-
-						if(n == MAP_IMAGE_ENTITY_LAYER_TYPE_SWITCH && TileIndex == TILE_SWITCHTIMEDOPEN)
-							TileIndex = 8;
-
-						int X = TileIndex % 16;
-						int Y = TileIndex / 16;
-
-						int CopyWidth = ImgInfo.m_Width / 16;
-						int CopyHeight = ImgInfo.m_Height / 16;
-						if(ValidTile)
+						else if((EntitiesModType == MAP_IMAGE_MOD_TYPE_RACE) && IsCreditsTile((int)TileIndex))
 						{
-							Graphics()->CopyTextureBufferSub(pBuildImgData, pTmpImgData, ImgInfo.m_Width, ImgInfo.m_Height, PixelSize, (size_t)X * CopyWidth, (size_t)Y * CopyHeight, CopyWidth, CopyHeight);
+							ValidTile = false;
+						}
+						else if((EntitiesModType == MAP_IMAGE_MOD_TYPE_FNG) && IsCreditsTile((int)TileIndex))
+						{
+							ValidTile = false;
+						}
+						else if((EntitiesModType == MAP_IMAGE_MOD_TYPE_VANILLA) && IsCreditsTile((int)TileIndex))
+						{
+							ValidTile = false;
 						}
 					}
 
-					m_aaEntitiesTextures[(EntitiesModType * 2) + (int)EntitiesAreMasked][n] = Graphics()->LoadTextureRaw(ImgInfo.m_Width, ImgInfo.m_Height, ImgInfo.m_Format, pBuildImgData, TextureLoadFlag, aPath);
-				}
-				else
-				{
-					if(!m_TransparentTexture.IsValid())
-					{
-						// set everything transparent
-						mem_zero(pBuildImgData, BuildImageSize);
+					if(n == MAP_IMAGE_ENTITY_LAYER_TYPE_SWITCH && TileIndex == TILE_SWITCHTIMEDOPEN)
+						TileIndex = 8;
 
-						m_TransparentTexture = Graphics()->LoadTextureRaw(ImgInfo.m_Width, ImgInfo.m_Height, ImgInfo.m_Format, pBuildImgData, TextureLoadFlag, aPath);
+					int X = TileIndex % 16;
+					int Y = TileIndex / 16;
+
+					int CopyWidth = ImgInfo.m_Width / 16;
+					int CopyHeight = ImgInfo.m_Height / 16;
+					if(ValidTile)
+					{
+						Graphics()->CopyTextureBufferSub(pBuildImgData, pTmpImgData, ImgInfo.m_Width, ImgInfo.m_Height, PixelSize, (size_t)X * CopyWidth, (size_t)Y * CopyHeight, CopyWidth, CopyHeight);
 					}
-					m_aaEntitiesTextures[(EntitiesModType * 2) + (int)EntitiesAreMasked][n] = m_TransparentTexture;
 				}
+
+				m_aaEntitiesTextures[(EntitiesModType * 2) + (int)EntitiesAreMasked][n] = Graphics()->LoadTextureRaw(ImgInfo.m_Width, ImgInfo.m_Height, ImgInfo.m_Format, pBuildImgData, TextureLoadFlag, aPath);
 			}
 
 			free(pBuildImgData);
@@ -355,7 +337,7 @@ void CMapImages::ChangeEntitiesPath(const char *pPath)
 		{
 			for(int n = 0; n < MAP_IMAGE_ENTITY_LAYER_TYPE_COUNT; ++n)
 			{
-				if(m_aaEntitiesTextures[i][n].IsValid() && m_aaEntitiesTextures[i][n].Id() != m_TransparentTexture.Id())
+				if(m_aaEntitiesTextures[i][n].IsValid())
 				{
 					Graphics()->UnloadTexture(&(m_aaEntitiesTextures[i][n]));
 				}

--- a/src/game/client/components/mapimages.h
+++ b/src/game/client/components/mapimages.h
@@ -76,7 +76,6 @@ private:
 	IGraphics::CTextureHandle m_OverlayBottomTexture;
 	IGraphics::CTextureHandle m_OverlayTopTexture;
 	IGraphics::CTextureHandle m_OverlayCenterTexture;
-	IGraphics::CTextureHandle m_TransparentTexture;
 	int m_TextureScale;
 
 	void InitOverlayTextures();


### PR DESCRIPTION
Only building the switch entities layer when the current map has a switch layer (#8011) also does not work, because the entities textures are cached for each type and not reloaded unless the entities are changed manually. First joining a server with a map that does not have a switch layer will cause the textures for the type of that server to be built without the switch entities layer, so the switch entities texture will be missing when joining a server of that type with a map that does have a switch layer.

Instead, the switch entities layer textures are always built now, so the cached entities textures are can be used on all maps of the respective server type. This is expected to slightly increase the total memory usage after joining multiple servers of different types. As before, tiles which are unused are masked unless `m_DontMaskEntities` is set.

[See shorter diff by ignoring whitespace.](https://github.com/ddnet/ddnet/pull/8035/files?w=1)

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
