### PR TITLE
Minor refactoring of `CClient::SetState`

### DIFF
--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -299,7 +299,7 @@ public:
 	const char *LatestVersion() const override;
 
 	// ------ state handling -----
-	void SetState(EClientState s);
+	void SetState(EClientState State);
 
 	// called when the map is loaded and we should init for a new round
 	void OnEnterGame(bool Dummy);


### PR DESCRIPTION
- Rename parameter `s` to `State`.
- Only print debug message if new state is different from old state.
- Reduce indentation.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
