### PR TITLE
Don't show the git revision twice in server log

### DIFF
--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -3879,9 +3879,6 @@ void CGameContext::OnInit(const void *pPersistentData)
 	// create all entities from the game layer
 	CreateAllEntities(true);
 
-	if(GIT_SHORTREV_HASH)
-		Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "git-revision", GIT_SHORTREV_HASH);
-
 	m_pAntibot->RoundStart(this);
 }
 


### PR DESCRIPTION
Previously:
```
2024-03-03 12:17:40 I git-revision: 885ae7ecaee4f1f7
2024-03-03 12:17:40 I server: version 18.0.3 on linux amd64
2024-03-03 12:17:40 I server: git revision hash: 885ae7ecaee4f1f7
```

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
