### PR TITLE
Fix practice mode not resetting after disconnect on solo servers

### DIFF
--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -1065,7 +1065,7 @@ void CGameTeams::OnCharacterDeath(int ClientID, int Weapon)
 		ChangeTeamState(Team, CGameTeams::TEAMSTATE_OPEN);
 		if(m_aPractice[Team])
 		{
-			if(Weapon == WEAPON_SELF)
+			if(Weapon != WEAPON_WORLD)
 			{
 				ResetRoundState(Team);
 			}


### PR DESCRIPTION
## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
