### PR TITLE
Fix HTTP client shutdown and deadlock on request error

### DIFF
--- a/src/engine/shared/http.h
+++ b/src/engine/shared/http.h
@@ -255,7 +255,6 @@ class CHttp : public IHttp
 	{
 		UNINITIALIZED,
 		RUNNING,
-		STOPPING,
 		ERROR,
 	};
 


### PR DESCRIPTION
Fix HTTP client effectively shutting down by entering the `ERROR` state when a request cannot be added. Now only the invalid request is aborted immediately. The `ERROR` state is now only entered when a curl function fails in a way where recovery is not possible.

Fix occasional deadlock when HTTP client is shutting down after entering the `ERROR` state, by also immediately aborting new requests when the HTTP client is already in the `ERROR` state.

Remove unused `CHttp::EState::STOPPING`.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
