### PR TITLE
Use `uint8_t *` consistently for raw image data

### DIFF
--- a/src/engine/client/backend/backend_base.cpp
+++ b/src/engine/client/backend/backend_base.cpp
@@ -2,12 +2,12 @@
 #include <base/system.h>
 #include <engine/gfx/image_manipulation.h>
 
-void *CCommandProcessorFragment_GLBase::Resize(const unsigned char *pData, int Width, int Height, int NewWidth, int NewHeight, int BPP)
+uint8_t *CCommandProcessorFragment_GLBase::Resize(const uint8_t *pData, int Width, int Height, int NewWidth, int NewHeight, int BPP)
 {
-	return ResizeImage((const uint8_t *)pData, Width, Height, NewWidth, NewHeight, BPP);
+	return ResizeImage(pData, Width, Height, NewWidth, NewHeight, BPP);
 }
 
-bool CCommandProcessorFragment_GLBase::Texture2DTo3D(void *pImageBuffer, int ImageWidth, int ImageHeight, size_t PixelSize, int SplitCountWidth, int SplitCountHeight, void *pTarget3DImageData, int &Target3DImageWidth, int &Target3DImageHeight)
+bool CCommandProcessorFragment_GLBase::Texture2DTo3D(uint8_t *pImageBuffer, int ImageWidth, int ImageHeight, size_t PixelSize, int SplitCountWidth, int SplitCountHeight, uint8_t *pTarget3DImageData, int &Target3DImageWidth, int &Target3DImageHeight)
 {
 	Target3DImageWidth = ImageWidth / SplitCountWidth;
 	Target3DImageHeight = ImageHeight / SplitCountHeight;
@@ -26,7 +26,7 @@ bool CCommandProcessorFragment_GLBase::Texture2DTo3D(void *pImageBuffer, int Ima
 				size_t TargetImageFullSize = (size_t)TargetImageFullWidth * Target3DImageHeight;
 				ptrdiff_t ImageOffset = (ptrdiff_t)(((size_t)Y * FullImageWidth * (size_t)Target3DImageHeight) + ((size_t)Y3D * FullImageWidth) + ((size_t)X * TargetImageFullWidth));
 				ptrdiff_t TargetImageOffset = (ptrdiff_t)(TargetImageFullSize * (size_t)DepthIndex + ((size_t)Y3D * TargetImageFullWidth));
-				mem_copy(((uint8_t *)pTarget3DImageData) + TargetImageOffset, ((uint8_t *)pImageBuffer) + (ptrdiff_t)(ImageOffset), TargetImageFullWidth);
+				mem_copy(pTarget3DImageData + TargetImageOffset, pImageBuffer + (ptrdiff_t)(ImageOffset), TargetImageFullWidth);
 			}
 		}
 	}

--- a/src/engine/client/backend/backend_base.h
+++ b/src/engine/client/backend/backend_base.h
@@ -84,9 +84,9 @@ protected:
 	SGfxErrorContainer m_Error;
 	SGfxWarningContainer m_Warning;
 
-	static void *Resize(const unsigned char *pData, int Width, int Height, int NewWidth, int NewHeight, int BPP);
+	static uint8_t *Resize(const uint8_t *pData, int Width, int Height, int NewWidth, int NewHeight, int BPP);
 
-	static bool Texture2DTo3D(void *pImageBuffer, int ImageWidth, int ImageHeight, size_t PixelSize, int SplitCountWidth, int SplitCountHeight, void *pTarget3DImageData, int &Target3DImageWidth, int &Target3DImageHeight);
+	static bool Texture2DTo3D(uint8_t *pImageBuffer, int ImageWidth, int ImageHeight, size_t PixelSize, int SplitCountWidth, int SplitCountHeight, uint8_t *pTarget3DImageData, int &Target3DImageWidth, int &Target3DImageHeight);
 
 	virtual bool GetPresentedImageData(uint32_t &Width, uint32_t &Height, CImageInfo::EImageFormat &Format, std::vector<uint8_t> &vDstData) = 0;
 

--- a/src/engine/client/backend/opengl/backend_opengl.h
+++ b/src/engine/client/backend/opengl/backend_opengl.h
@@ -85,8 +85,8 @@ protected:
 	static int TexFormatToOpenGLFormat(int TexFormat);
 	static size_t GLFormatToPixelSize(int GLFormat);
 
-	void TextureUpdate(int Slot, int X, int Y, int Width, int Height, int GLFormat, void *pTexData);
-	void TextureCreate(int Slot, int Width, int Height, int GLFormat, int GLStoreFormat, int Flags, void *pTexData);
+	void TextureUpdate(int Slot, int X, int Y, int Width, int Height, int GLFormat, uint8_t *pTexData);
+	void TextureCreate(int Slot, int Width, int Height, int GLFormat, int GLStoreFormat, int Flags, uint8_t *pTexData);
 
 	virtual bool Cmd_Init(const SCommand_Init *pCommand);
 	virtual void Cmd_Shutdown(const SCommand_Shutdown *pCommand) {}
@@ -151,7 +151,7 @@ class CCommandProcessorFragment_OpenGL2 : public CCommandProcessorFragment_OpenG
 			m_DataSize = 0;
 		}
 		TWGLuint m_BufferObjectId;
-		void *m_pData;
+		uint8_t *m_pData;
 		size_t m_DataSize;
 	};
 

--- a/src/engine/client/backend/opengl/backend_opengl3.h
+++ b/src/engine/client/backend/opengl/backend_opengl3.h
@@ -78,8 +78,8 @@ protected:
 	void UploadStreamBufferData(unsigned int PrimitiveType, const void *pVertices, size_t VertSize, unsigned int PrimitiveCount, bool AsTex3D = false);
 	void RenderText(const CCommandBuffer::SState &State, int DrawNum, int TextTextureIndex, int TextOutlineTextureIndex, int TextureSize, const ColorRGBA &TextColor, const ColorRGBA &TextOutlineColor);
 
-	void TextureUpdate(int Slot, int X, int Y, int Width, int Height, int GLFormat, void *pTexData);
-	void TextureCreate(int Slot, int Width, int Height, int GLFormat, int GLStoreFormat, int Flags, void *pTexData);
+	void TextureUpdate(int Slot, int X, int Y, int Width, int Height, int GLFormat, uint8_t *pTexData);
+	void TextureCreate(int Slot, int Width, int Height, int GLFormat, int GLStoreFormat, int Flags, uint8_t *pTexData);
 
 	bool Cmd_Init(const SCommand_Init *pCommand) override;
 	void Cmd_Shutdown(const SCommand_Shutdown *pCommand) override;

--- a/src/engine/client/graphics_threaded.h
+++ b/src/engine/client/graphics_threaded.h
@@ -530,7 +530,7 @@ public:
 		int m_Format;
 		int m_StoreFormat;
 		int m_Flags;
-		void *m_pData; // will be freed by the command processor
+		uint8_t *m_pData; // will be freed by the command processor
 	};
 
 	struct SCommand_Texture_Update : public SCommand
@@ -546,7 +546,7 @@ public:
 		size_t m_Width;
 		size_t m_Height;
 		int m_Format;
-		void *m_pData; // will be freed by the command processor
+		uint8_t *m_pData; // will be freed by the command processor
 	};
 
 	struct SCommand_Texture_Destroy : public SCommand
@@ -570,8 +570,8 @@ public:
 		size_t m_Width;
 		size_t m_Height;
 
-		void *m_pTextData;
-		void *m_pTextOutlineData;
+		uint8_t *m_pTextData; // will be freed by the command processor
+		uint8_t *m_pTextOutlineData; // will be freed by the command processor
 	};
 
 	struct SCommand_TextTextures_Destroy : public SCommand
@@ -596,7 +596,7 @@ public:
 		int m_Y;
 		size_t m_Width;
 		size_t m_Height;
-		void *m_pData; // will be freed by the command processor
+		uint8_t *m_pData; // will be freed by the command processor
 	};
 
 	struct SCommand_WindowCreateNtf : public CCommandBuffer::SCommand
@@ -965,14 +965,14 @@ public:
 	IGraphics::CTextureHandle FindFreeTextureIndex();
 	void FreeTextureIndex(CTextureHandle *pIndex);
 	int UnloadTexture(IGraphics::CTextureHandle *pIndex) override;
-	IGraphics::CTextureHandle LoadTextureRaw(size_t Width, size_t Height, CImageInfo::EImageFormat Format, const void *pData, int Flags, const char *pTexName = nullptr) override;
-	IGraphics::CTextureHandle LoadTextureRawMove(size_t Width, size_t Height, CImageInfo::EImageFormat Format, void *pData, int Flags, const char *pTexName = nullptr) override;
-	int LoadTextureRawSub(IGraphics::CTextureHandle TextureId, int x, int y, size_t Width, size_t Height, CImageInfo::EImageFormat Format, const void *pData) override;
+	IGraphics::CTextureHandle LoadTextureRaw(size_t Width, size_t Height, CImageInfo::EImageFormat Format, const uint8_t *pData, int Flags, const char *pTexName = nullptr) override;
+	IGraphics::CTextureHandle LoadTextureRawMove(size_t Width, size_t Height, CImageInfo::EImageFormat Format, uint8_t *pData, int Flags, const char *pTexName = nullptr) override;
+	int LoadTextureRawSub(IGraphics::CTextureHandle TextureId, int x, int y, size_t Width, size_t Height, CImageInfo::EImageFormat Format, const uint8_t *pData) override;
 	IGraphics::CTextureHandle NullTexture() const override;
 
-	bool LoadTextTextures(size_t Width, size_t Height, CTextureHandle &TextTexture, CTextureHandle &TextOutlineTexture, void *pTextData, void *pTextOutlineData) override;
+	bool LoadTextTextures(size_t Width, size_t Height, CTextureHandle &TextTexture, CTextureHandle &TextOutlineTexture, uint8_t *pTextData, uint8_t *pTextOutlineData) override;
 	bool UnloadTextTextures(CTextureHandle &TextTexture, CTextureHandle &TextOutlineTexture) override;
-	bool UpdateTextTexture(CTextureHandle TextureId, int x, int y, size_t Width, size_t Height, const void *pData) override;
+	bool UpdateTextTexture(CTextureHandle TextureId, int x, int y, size_t Width, size_t Height, const uint8_t *pData) override;
 
 	CTextureHandle LoadSpriteTextureImpl(CImageInfo &FromImageInfo, int x, int y, size_t w, size_t h);
 	CTextureHandle LoadSpriteTexture(CImageInfo &FromImageInfo, struct CDataSprite *pSprite) override;

--- a/src/engine/client/text.cpp
+++ b/src/engine/client/text.cpp
@@ -391,8 +391,8 @@ private:
 	void UploadTextures()
 	{
 		const size_t NewTextureSize = m_TextureDimension * m_TextureDimension;
-		void *pTmpTextFillData = malloc(NewTextureSize);
-		void *pTmpTextOutlineData = malloc(NewTextureSize);
+		uint8_t *pTmpTextFillData = static_cast<uint8_t *>(malloc(NewTextureSize));
+		uint8_t *pTmpTextOutlineData = static_cast<uint8_t *>(malloc(NewTextureSize));
 		mem_copy(pTmpTextFillData, m_apTextureData[FONT_TEXTURE_FILL], NewTextureSize);
 		mem_copy(pTmpTextOutlineData, m_apTextureData[FONT_TEXTURE_OUTLINE], NewTextureSize);
 		Graphics()->LoadTextTextures(m_TextureDimension, m_TextureDimension, m_aTextures[FONT_TEXTURE_FILL], m_aTextures[FONT_TEXTURE_OUTLINE], pTmpTextFillData, pTmpTextOutlineData);
@@ -729,7 +729,7 @@ public:
 		return vec2(0.0f, 0.0f);
 	}
 
-	void UploadEntityLayerText(void *pTexBuff, size_t PixelSize, size_t TexWidth, size_t TexHeight, int TexSubWidth, int TexSubHeight, const char *pText, int Length, float x, float y, int FontSize)
+	void UploadEntityLayerText(uint8_t *pTexBuff, size_t PixelSize, size_t TexWidth, size_t TexHeight, int TexSubWidth, int TexSubHeight, const char *pText, int Length, float x, float y, int FontSize)
 	{
 		if(FontSize < 1)
 			return;
@@ -770,7 +770,6 @@ public:
 				else
 					mem_zero(m_aaGlyphData[FONT_TEXTURE_FILL], GlyphDataSize);
 
-				uint8_t *pImageBuff = (uint8_t *)pTexBuff;
 				for(unsigned OffY = 0; OffY < pBitmap->rows; ++OffY)
 				{
 					for(unsigned OffX = 0; OffX < pBitmap->width; ++OffX)
@@ -783,11 +782,11 @@ public:
 						{
 							if(i != PixelSize - 1)
 							{
-								*(pImageBuff + ImageOffset + i) = 255;
+								*(pTexBuff + ImageOffset + i) = 255;
 							}
 							else
 							{
-								*(pImageBuff + ImageOffset + i) = *(m_aaGlyphData[FONT_TEXTURE_FILL] + GlyphOffset);
+								*(pTexBuff + ImageOffset + i) = *(m_aaGlyphData[FONT_TEXTURE_FILL] + GlyphOffset);
 							}
 						}
 					}
@@ -2181,7 +2180,7 @@ public:
 		return TextContainer.m_BoundingBox;
 	}
 
-	void UploadEntityLayerText(void *pTexBuff, size_t PixelSize, size_t TexWidth, size_t TexHeight, int TexSubWidth, int TexSubHeight, const char *pText, int Length, float x, float y, int FontSize) override
+	void UploadEntityLayerText(uint8_t *pTexBuff, size_t PixelSize, size_t TexWidth, size_t TexHeight, int TexSubWidth, int TexSubHeight, const char *pText, int Length, float x, float y, int FontSize) override
 	{
 		m_pGlyphMap->UploadEntityLayerText(pTexBuff, PixelSize, TexWidth, TexHeight, TexSubWidth, TexSubHeight, pText, Length, x, y, FontSize);
 	}

--- a/src/engine/gfx/image_manipulation.cpp
+++ b/src/engine/gfx/image_manipulation.cpp
@@ -4,7 +4,7 @@
 
 #define TW_DILATE_ALPHA_THRESHOLD 10
 
-static void Dilate(int w, int h, const unsigned char *pSrc, unsigned char *pDest, unsigned char AlphaThreshold = TW_DILATE_ALPHA_THRESHOLD)
+static void Dilate(int w, int h, const uint8_t *pSrc, uint8_t *pDest, uint8_t AlphaThreshold = TW_DILATE_ALPHA_THRESHOLD)
 {
 	const int BPP = 4; // RGBA assumed
 	int ix, iy;
@@ -44,7 +44,7 @@ static void Dilate(int w, int h, const unsigned char *pSrc, unsigned char *pDest
 				for(int i = 0; i < BPP - 1; ++i)
 				{
 					aSumOfOpaque[i] /= Counter;
-					pDest[m + i] = (unsigned char)aSumOfOpaque[i];
+					pDest[m + i] = (uint8_t)aSumOfOpaque[i];
 				}
 
 				pDest[m + AlphaCompIndex] = 255;
@@ -53,7 +53,7 @@ static void Dilate(int w, int h, const unsigned char *pSrc, unsigned char *pDest
 	}
 }
 
-static void CopyColorValues(int w, int h, int BPP, const unsigned char *pSrc, unsigned char *pDest)
+static void CopyColorValues(int w, int h, int BPP, const uint8_t *pSrc, uint8_t *pDest)
 {
 	int m = 0;
 	for(int y = 0; y < h; y++)
@@ -69,28 +69,26 @@ static void CopyColorValues(int w, int h, int BPP, const unsigned char *pSrc, un
 	}
 }
 
-void DilateImage(unsigned char *pImageBuff, int w, int h)
+void DilateImage(uint8_t *pImageBuff, int w, int h)
 {
 	DilateImageSub(pImageBuff, w, h, 0, 0, w, h);
 }
 
-void DilateImageSub(unsigned char *pImageBuff, int w, int h, int x, int y, int sw, int sh)
+void DilateImageSub(uint8_t *pImageBuff, int w, int h, int x, int y, int sw, int sh)
 {
 	const int BPP = 4; // RGBA assumed
-	unsigned char *apBuffer[2] = {NULL, NULL};
+	uint8_t *apBuffer[2] = {NULL, NULL};
 
-	apBuffer[0] = (unsigned char *)malloc((size_t)sw * sh * sizeof(unsigned char) * BPP);
-	apBuffer[1] = (unsigned char *)malloc((size_t)sw * sh * sizeof(unsigned char) * BPP);
-	unsigned char *pBufferOriginal = (unsigned char *)malloc((size_t)sw * sh * sizeof(unsigned char) * BPP);
-
-	unsigned char *pPixelBuff = (unsigned char *)pImageBuff;
+	apBuffer[0] = (uint8_t *)malloc((size_t)sw * sh * sizeof(uint8_t) * BPP);
+	apBuffer[1] = (uint8_t *)malloc((size_t)sw * sh * sizeof(uint8_t) * BPP);
+	uint8_t *pBufferOriginal = (uint8_t *)malloc((size_t)sw * sh * sizeof(uint8_t) * BPP);
 
 	for(int Y = 0; Y < sh; ++Y)
 	{
 		int SrcImgOffset = ((y + Y) * w * BPP) + (x * BPP);
 		int DstImgOffset = (Y * sw * BPP);
 		int CopySize = sw * BPP;
-		mem_copy(&pBufferOriginal[DstImgOffset], &pPixelBuff[SrcImgOffset], CopySize);
+		mem_copy(&pBufferOriginal[DstImgOffset], &pImageBuff[SrcImgOffset], CopySize);
 	}
 
 	Dilate(sw, sh, pBufferOriginal, apBuffer[0]);
@@ -111,7 +109,7 @@ void DilateImageSub(unsigned char *pImageBuff, int w, int h, int x, int y, int s
 		int SrcImgOffset = ((y + Y) * w * BPP) + (x * BPP);
 		int DstImgOffset = (Y * sw * BPP);
 		int CopySize = sw * BPP;
-		mem_copy(&pPixelBuff[SrcImgOffset], &pBufferOriginal[DstImgOffset], CopySize);
+		mem_copy(&pImageBuff[SrcImgOffset], &pBufferOriginal[DstImgOffset], CopySize);
 	}
 
 	free(pBufferOriginal);

--- a/src/engine/gfx/image_manipulation.h
+++ b/src/engine/gfx/image_manipulation.h
@@ -4,8 +4,8 @@
 #include <cstdint>
 
 // These functions assume that the image data is 4 bytes per pixel RGBA
-void DilateImage(unsigned char *pImageBuff, int w, int h);
-void DilateImageSub(unsigned char *pImageBuff, int w, int h, int x, int y, int sw, int sh);
+void DilateImage(uint8_t *pImageBuff, int w, int h);
+void DilateImageSub(uint8_t *pImageBuff, int w, int h, int x, int y, int sw, int sh);
 
 // returned pointer is allocated with malloc
 uint8_t *ResizeImage(const uint8_t *pImageData, int Width, int Height, int NewWidth, int NewHeight, int BPP);

--- a/src/engine/graphics.h
+++ b/src/engine/graphics.h
@@ -95,7 +95,7 @@ public:
 	/**
 	 * Pointer to the image data.
 	 */
-	void *m_pData = nullptr;
+	uint8_t *m_pData = nullptr;
 
 	static size_t PixelSize(EImageFormat Format)
 	{
@@ -334,18 +334,18 @@ public:
 	virtual void CopyTextureFromTextureBufferSub(uint8_t *pDestBuffer, size_t DestWidth, size_t DestHeight, uint8_t *pSourceBuffer, size_t SrcWidth, size_t SrcHeight, size_t PixelSize, size_t SrcSubOffsetX, size_t SrcSubOffsetY, size_t SrcSubCopyWidth, size_t SrcSubCopyHeight) = 0;
 
 	virtual int UnloadTexture(CTextureHandle *pIndex) = 0;
-	virtual CTextureHandle LoadTextureRaw(size_t Width, size_t Height, CImageInfo::EImageFormat Format, const void *pData, int Flags, const char *pTexName = nullptr) = 0;
-	virtual CTextureHandle LoadTextureRawMove(size_t Width, size_t Height, CImageInfo::EImageFormat Format, void *pData, int Flags, const char *pTexName = nullptr) = 0;
-	virtual int LoadTextureRawSub(CTextureHandle TextureId, int x, int y, size_t Width, size_t Height, CImageInfo::EImageFormat Format, const void *pData) = 0;
+	virtual CTextureHandle LoadTextureRaw(size_t Width, size_t Height, CImageInfo::EImageFormat Format, const uint8_t *pData, int Flags, const char *pTexName = nullptr) = 0;
+	virtual CTextureHandle LoadTextureRawMove(size_t Width, size_t Height, CImageInfo::EImageFormat Format, uint8_t *pData, int Flags, const char *pTexName = nullptr) = 0;
+	virtual int LoadTextureRawSub(CTextureHandle TextureId, int x, int y, size_t Width, size_t Height, CImageInfo::EImageFormat Format, const uint8_t *pData) = 0;
 	virtual CTextureHandle LoadTexture(const char *pFilename, int StorageType, int Flags = 0) = 0;
 	virtual CTextureHandle NullTexture() const = 0;
 	virtual void TextureSet(CTextureHandle Texture) = 0;
 	void TextureClear() { TextureSet(CTextureHandle()); }
 
 	// pTextData & pTextOutlineData are automatically free'd
-	virtual bool LoadTextTextures(size_t Width, size_t Height, CTextureHandle &TextTexture, CTextureHandle &TextOutlineTexture, void *pTextData, void *pTextOutlineData) = 0;
+	virtual bool LoadTextTextures(size_t Width, size_t Height, CTextureHandle &TextTexture, CTextureHandle &TextOutlineTexture, uint8_t *pTextData, uint8_t *pTextOutlineData) = 0;
 	virtual bool UnloadTextTextures(CTextureHandle &TextTexture, CTextureHandle &TextOutlineTexture) = 0;
-	virtual bool UpdateTextTexture(CTextureHandle TextureId, int x, int y, size_t Width, size_t Height, const void *pData) = 0;
+	virtual bool UpdateTextTexture(CTextureHandle TextureId, int x, int y, size_t Width, size_t Height, const uint8_t *pData) = 0;
 
 	virtual CTextureHandle LoadSpriteTexture(CImageInfo &FromImageInfo, struct CDataSprite *pSprite) = 0;
 

--- a/src/engine/textrender.h
+++ b/src/engine/textrender.h
@@ -344,7 +344,7 @@ public:
 
 	virtual STextBoundingBox GetBoundingBoxTextContainer(STextContainerIndex TextContainerIndex) = 0;
 
-	virtual void UploadEntityLayerText(void *pTexBuff, size_t PixelSize, size_t TexWidth, size_t TexHeight, int TexSubWidth, int TexSubHeight, const char *pText, int Length, float x, float y, int FontSize) = 0;
+	virtual void UploadEntityLayerText(uint8_t *pTexBuff, size_t PixelSize, size_t TexWidth, size_t TexHeight, int TexSubWidth, int TexSubHeight, const char *pText, int Length, float x, float y, int FontSize) = 0;
 	virtual int AdjustFontSize(const char *pText, int TextLength, int MaxSize, int MaxWidth) const = 0;
 	virtual float GetGlyphOffsetX(int FontSize, char TextCharacter) const = 0;
 	virtual int CalculateTextWidth(const char *pText, int TextLength, int FontWidth, int FontSize) const = 0;

--- a/src/game/client/components/mapimages.cpp
+++ b/src/game/client/components/mapimages.cpp
@@ -131,7 +131,7 @@ void CMapImages::OnMapLoadImpl(class CLayers *pLayers, IMap *pMap)
 		}
 		else if(Format == CImageInfo::FORMAT_RGBA)
 		{
-			void *pData = pMap->GetData(pImg->m_ImageData);
+			const uint8_t *pData = static_cast<uint8_t *>(pMap->GetData(pImg->m_ImageData));
 			char aTexName[IO_MAX_PATH_LENGTH];
 			str_format(aTexName, sizeof(aTexName), "embedded: %s", pName);
 			m_aTextures[i] = Graphics()->LoadTextureRaw(pImg->m_Width, pImg->m_Height, Format, pData, LoadFlag, aTexName);
@@ -223,7 +223,7 @@ IGraphics::CTextureHandle CMapImages::GetEntities(EMapImageEntityLayerType Entit
 			const size_t PixelSize = ImgInfo.PixelSize();
 			const size_t BuildImageSize = (size_t)ImgInfo.m_Width * ImgInfo.m_Height * PixelSize;
 
-			uint8_t *pTmpImgData = (uint8_t *)ImgInfo.m_pData;
+			uint8_t *pTmpImgData = ImgInfo.m_pData;
 			uint8_t *pBuildImgData = (uint8_t *)malloc(BuildImageSize);
 
 			// build game layer
@@ -382,7 +382,7 @@ IGraphics::CTextureHandle CMapImages::UploadEntityLayerText(int TextureSize, int
 	const size_t Height = 1024;
 	const size_t PixelSize = CImageInfo::PixelSize(CImageInfo::FORMAT_RGBA);
 
-	void *pMem = calloc(Width * Height * PixelSize, 1);
+	uint8_t *pMem = static_cast<uint8_t *>(calloc(Width * Height * PixelSize, 1));
 
 	UpdateEntityLayerText(pMem, PixelSize, Width, Height, TextureSize, MaxWidth, YOffset, 0);
 	UpdateEntityLayerText(pMem, PixelSize, Width, Height, TextureSize, MaxWidth, YOffset, 1);
@@ -392,7 +392,7 @@ IGraphics::CTextureHandle CMapImages::UploadEntityLayerText(int TextureSize, int
 	return Graphics()->LoadTextureRawMove(Width, Height, CImageInfo::FORMAT_RGBA, pMem, TextureLoadFlag);
 }
 
-void CMapImages::UpdateEntityLayerText(void *pTexBuffer, size_t PixelSize, size_t TexWidth, size_t TexHeight, int TextureSize, int MaxWidth, int YOffset, int NumbersPower, int MaxNumber)
+void CMapImages::UpdateEntityLayerText(uint8_t *pTexBuffer, size_t PixelSize, size_t TexWidth, size_t TexHeight, int TextureSize, int MaxWidth, int YOffset, int NumbersPower, int MaxNumber)
 {
 	char aBuf[4];
 	int DigitsCount = NumbersPower + 1;

--- a/src/game/client/components/mapimages.h
+++ b/src/game/client/components/mapimages.h
@@ -80,7 +80,7 @@ private:
 
 	void InitOverlayTextures();
 	IGraphics::CTextureHandle UploadEntityLayerText(int TextureSize, int MaxWidth, int YOffset);
-	void UpdateEntityLayerText(void *pTexBuffer, size_t PixelSize, size_t TexWidth, size_t TexHeight, int TextureSize, int MaxWidth, int YOffset, int NumbersPower, int MaxNumber = -1);
+	void UpdateEntityLayerText(uint8_t *pTexBuffer, size_t PixelSize, size_t TexWidth, size_t TexHeight, int TextureSize, int MaxWidth, int YOffset, int NumbersPower, int MaxNumber = -1);
 };
 
 #endif

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -866,7 +866,7 @@ bool CEditor::CallbackSaveImage(const char *pFileName, int StorageType, void *pU
 
 	TImageByteBuffer ByteBuffer;
 	SImageByteBuffer ImageByteBuffer(&ByteBuffer);
-	if(SavePNG(OutputFormat, static_cast<const uint8_t *>(pImg->m_pData), ImageByteBuffer, pImg->m_Width, pImg->m_Height))
+	if(SavePNG(OutputFormat, pImg->m_pData, ImageByteBuffer, pImg->m_Width, pImg->m_Height))
 	{
 		IOHANDLE File = pEditor->Storage()->OpenFile(pFileName, IOFLAG_WRITE, StorageType);
 		if(File)
@@ -4377,7 +4377,7 @@ bool CEditor::ReplaceImage(const char *pFileName, int StorageType, bool CheckDup
 
 	if(!pImg->m_External && g_Config.m_ClEditorDilate == 1 && pImg->m_Format == CImageInfo::FORMAT_RGBA)
 	{
-		DilateImage((unsigned char *)ImgInfo.m_pData, ImgInfo.m_Width, ImgInfo.m_Height);
+		DilateImage(ImgInfo.m_pData, ImgInfo.m_Width, ImgInfo.m_Height);
 	}
 
 	pImg->m_AutoMapper.Load(pImg->m_aName);
@@ -4437,7 +4437,7 @@ bool CEditor::AddImage(const char *pFileName, int StorageType, void *pUser)
 
 	if(!pImg->m_External && g_Config.m_ClEditorDilate == 1 && pImg->m_Format == CImageInfo::FORMAT_RGBA)
 	{
-		DilateImage((unsigned char *)ImgInfo.m_pData, ImgInfo.m_Width, ImgInfo.m_Height);
+		DilateImage(ImgInfo.m_pData, ImgInfo.m_Width, ImgInfo.m_Height);
 	}
 
 	int TextureLoadFlag = pEditor->Graphics()->Uses2DTextureArrays() ? IGraphics::TEXLOAD_TO_2D_ARRAY_TEXTURE : IGraphics::TEXLOAD_TO_3D_TEXTURE;

--- a/src/game/editor/mapitems/image.cpp
+++ b/src/game/editor/mapitems/image.cpp
@@ -63,8 +63,8 @@ bool CEditorImage::DataEquals(const CEditorImage &Other) const
 	if(Other.m_Height != m_Height || Other.m_Width != m_Width || Other.PixelSize() != ImgPixelSize)
 		return false;
 
-	const auto &&GetPixel = [&](void *pData, int x, int y, size_t p) -> uint8_t {
-		return ((uint8_t *)pData)[x * ImgPixelSize + (m_Width * ImgPixelSize * y) + p];
+	const auto &&GetPixel = [&](uint8_t *pData, int x, int y, size_t p) -> uint8_t {
+		return pData[x * ImgPixelSize + (m_Width * ImgPixelSize * y) + p];
 	};
 
 	// Look through every pixel and check if there are any difference

--- a/src/game/editor/mapitems/map_io.cpp
+++ b/src/game/editor/mapitems/map_io.cpp
@@ -524,7 +524,7 @@ bool CEditorMap::Load(const char *pFileName, int StorageType, const std::functio
 				// copy image data
 				void *pData = DataFile.GetData(pItem->m_ImageData);
 				const size_t DataSize = (size_t)pImg->m_Width * pImg->m_Height * CImageInfo::PixelSize(Format);
-				pImg->m_pData = malloc(DataSize);
+				pImg->m_pData = static_cast<uint8_t *>(malloc(DataSize));
 				mem_copy(pImg->m_pData, pData, DataSize);
 				int TextureLoadFlag = m_pEditor->Graphics()->Uses2DTextureArrays() ? IGraphics::TEXLOAD_TO_2D_ARRAY_TEXTURE : IGraphics::TEXLOAD_TO_3D_TEXTURE;
 				if(pImg->m_Width % 16 != 0 || pImg->m_Height % 16 != 0)

--- a/src/game/editor/tileart.cpp
+++ b/src/game/editor/tileart.cpp
@@ -19,7 +19,7 @@ bool operator<(const ColorRGBA &Left, const ColorRGBA &Right)
 
 static ColorRGBA GetPixelColor(const CImageInfo &Image, size_t x, size_t y)
 {
-	uint8_t *pData = static_cast<uint8_t *>(Image.m_pData);
+	uint8_t *pData = Image.m_pData;
 	const size_t PixelSize = Image.PixelSize();
 	const size_t PixelStartIndex = x * PixelSize + (Image.m_Width * PixelSize * y);
 
@@ -43,7 +43,7 @@ static ColorRGBA GetPixelColor(const CImageInfo &Image, size_t x, size_t y)
 
 static void SetPixelColor(CImageInfo *pImage, size_t x, size_t y, ColorRGBA Color)
 {
-	uint8_t *pData = static_cast<uint8_t *>(pImage->m_pData);
+	uint8_t *pData = pImage->m_pData;
 	const size_t PixelSize = pImage->PixelSize();
 	const size_t PixelStartIndex = x * PixelSize + (pImage->m_Width * PixelSize * y);
 

--- a/src/tools/dilate.cpp
+++ b/src/tools/dilate.cpp
@@ -29,27 +29,18 @@ int DilateFile(const char *pFilename)
 		io_close(File);
 
 		CImageInfo Img;
-
-		uint8_t *pImgBuffer = NULL;
 		EImageFormat ImageFormat;
 		int PngliteIncompatible;
-		if(LoadPNG(ImageByteBuffer, pFilename, PngliteIncompatible, Img.m_Width, Img.m_Height, pImgBuffer, ImageFormat))
+		if(LoadPNG(ImageByteBuffer, pFilename, PngliteIncompatible, Img.m_Width, Img.m_Height, Img.m_pData, ImageFormat))
 		{
 			if(ImageFormat != IMAGE_FORMAT_RGBA)
 			{
-				free(pImgBuffer);
+				free(Img.m_pData);
 				dbg_msg("dilate", "%s: not an RGBA image", pFilename);
 				return -1;
 			}
 
-			Img.m_pData = pImgBuffer;
-
-			unsigned char *pBuffer = (unsigned char *)Img.m_pData;
-
-			int w = Img.m_Width;
-			int h = Img.m_Height;
-
-			DilateImage(pBuffer, w, h);
+			DilateImage(Img.m_pData, Img.m_Width, Img.m_Height);
 
 			// save here
 			IOHANDLE SaveFile = io_open(pFilename, IOFLAG_WRITE);
@@ -58,11 +49,11 @@ int DilateFile(const char *pFilename)
 				TImageByteBuffer ByteBuffer2;
 				SImageByteBuffer ImageByteBuffer2(&ByteBuffer2);
 
-				if(SavePNG(IMAGE_FORMAT_RGBA, (const uint8_t *)pBuffer, ImageByteBuffer2, w, h))
+				if(SavePNG(IMAGE_FORMAT_RGBA, Img.m_pData, ImageByteBuffer2, Img.m_Width, Img.m_Height))
 					io_write(SaveFile, &ByteBuffer2.front(), ByteBuffer2.size());
 				io_close(SaveFile);
 
-				free(pBuffer);
+				free(Img.m_pData);
 			}
 		}
 		else

--- a/src/tools/map_create_pixelart.cpp
+++ b/src/tools/map_create_pixelart.cpp
@@ -222,7 +222,7 @@ bool GetPixelClamped(const CImageInfo &Img, int x, int y, uint8_t aPixel[4])
 
 	const size_t PixelSize = Img.PixelSize();
 	for(size_t i = 0; i < PixelSize; i++)
-		aPixel[i] = ((uint8_t *)Img.m_pData)[x * PixelSize + (Img.m_Width * PixelSize * y) + i];
+		aPixel[i] = Img.m_pData[x * PixelSize + (Img.m_Width * PixelSize * y) + i];
 
 	return aPixel[3] > 0;
 }


### PR DESCRIPTION
Previously, usage of `void *`, `unsigned char *` and `uint8_t *` was mixed in various places for pointers to raw image data and the pointers ended up being cast to `uint8_t *` at some point anyway. Now only `uint8_t *` is used consistently, which improves type safety and readability. Casts to `uint8_t *` are now only necessary when using `malloc` or when reading data from a map.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [X] Tested in combination with possibly related configuration options: Vulkan and OpenGL
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
