### PR TITLE
Ensure commands executed via Econ are valid UTF-8

### DIFF
--- a/src/engine/shared/network_console_conn.cpp
+++ b/src/engine/shared/network_console_conn.cpp
@@ -143,7 +143,7 @@ int CConsoleNetConnection::Recv(char *pLine, int MaxLength)
 			str_sanitize_cc(pLine);
 			mem_move(m_aBuffer, m_aBuffer + EndOffset, m_BufferOffset - EndOffset);
 			m_BufferOffset -= EndOffset;
-			return 1;
+			return str_utf8_check(pLine);
 		}
 	}
 	return 0;


### PR DESCRIPTION
`CNetConsole` will now ignore received lines containing invalid UTF-8 codepoints. Previously, it was possible to crash the server on Windows with Econ commands like `exec <invalid UTF-8>`.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
