### PR TITLE
Improve `/timecp` chat command

### DIFF
--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -1936,5 +1936,5 @@ void CGameContext::ConTimeCP(IConsole::IResult *pResult, void *pUserData)
 		return;
 
 	const char *pName = pResult->GetString(0);
-	pSelf->Score()->LoadPlayerData(pResult->m_ClientId, pName);
+	pSelf->Score()->LoadPlayerTimeCp(pResult->m_ClientId, pName);
 }

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -1445,7 +1445,7 @@ void CCharacter::SetTimeCheckpoint(int TimeCheckpoint)
 		if(m_pPlayer->GetClientVersion() >= VERSION_DDRACE)
 		{
 			CPlayerData *pData = GameServer()->Score()->PlayerData(m_pPlayer->GetCid());
-			if(pData->m_BestTime && pData->m_aBestTimeCp[m_LastTimeCp] != 0.0f)
+			if(pData->m_aBestTimeCp[m_LastTimeCp] != 0.0f)
 			{
 				CNetMsg_Sv_DDRaceTime Msg;
 				Msg.m_Time = (int)(m_Time * 100.0f);

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -910,6 +910,7 @@ void CPlayer::ProcessScoreResult(CScorePlayerResult &Result)
 			GameServer()->CallVote(m_ClientId, Result.m_Data.m_MapVote.m_aMap, aCmd, "/map", aChatmsg);
 			break;
 		case CScorePlayerResult::PLAYER_INFO:
+		{
 			if(Result.m_Data.m_Info.m_Time.has_value())
 			{
 				GameServer()->Score()->PlayerData(m_ClientId)->Set(Result.m_Data.m_Info.m_Time.value(), Result.m_Data.m_Info.m_aTimeCp);
@@ -931,6 +932,14 @@ void CPlayer::ProcessScoreResult(CScorePlayerResult &Result)
 				m_BirthdayAnnounced = true;
 			}
 			GameServer()->SendRecord(m_ClientId);
+			break;
+		}
+		case CScorePlayerResult::PLAYER_TIMECP:
+			GameServer()->Score()->PlayerData(m_ClientId)->SetBestTimeCp(Result.m_Data.m_Info.m_aTimeCp);
+			char aBuf[128], aTime[32];
+			str_time_float(Result.m_Data.m_Info.m_Time.value(), TIME_HOURS_CENTISECS, aTime, sizeof(aTime));
+			str_format(aBuf, sizeof(aBuf), "Showing the checkpoint times for '%s' with a race time of %s", Result.m_Data.m_Info.m_aRequestedPlayer, aTime);
+			GameServer()->SendChatTarget(m_ClientId, aBuf);
 			break;
 		}
 	}

--- a/src/game/server/score.cpp
+++ b/src/game/server/score.cpp
@@ -126,6 +126,11 @@ void CScore::LoadPlayerData(int ClientId, const char *pName)
 	ExecPlayerThread(CScoreWorker::LoadPlayerData, "load player data", ClientId, pName, 0);
 }
 
+void CScore::LoadPlayerTimeCp(int ClientId, const char *pName)
+{
+	ExecPlayerThread(CScoreWorker::LoadPlayerTimeCp, "load player timecp", ClientId, pName, 0);
+}
+
 void CScore::MapVote(int ClientId, const char *pMapName)
 {
 	if(RateLimitPlayer(ClientId))

--- a/src/game/server/score.h
+++ b/src/game/server/score.h
@@ -48,6 +48,7 @@ public:
 	void MapInfo(int ClientId, const char *pMapName);
 	void MapVote(int ClientId, const char *pMapName);
 	void LoadPlayerData(int ClientId, const char *pName = "");
+	void LoadPlayerTimeCp(int ClientId, const char *pName = "");
 	void SaveScore(int ClientId, float Time, const char *pTimestamp, const float aTimeCp[NUM_CHECKPOINTS], bool NotEligible);
 
 	void SaveTeamScore(int *pClientIds, unsigned int Size, float Time, const char *pTimestamp);

--- a/src/game/server/scoreworker.h
+++ b/src/game/server/scoreworker.h
@@ -39,6 +39,7 @@ struct CScorePlayerResult : ISqlResult
 		BROADCAST,
 		MAP_VOTE,
 		PLAYER_INFO,
+		PLAYER_TIMECP,
 	} m_MessageKind;
 	union
 	{
@@ -49,6 +50,7 @@ struct CScorePlayerResult : ISqlResult
 			std::optional<float> m_Time;
 			float m_aTimeCp[NUM_CHECKPOINTS];
 			int m_Birthday; // 0 indicates no birthday
+			char m_aRequestedPlayer[MAX_NAME_LENGTH];
 		} m_Info = {};
 		struct
 		{
@@ -244,6 +246,12 @@ public:
 			m_aBestTimeCp[i] = aTimeCp[i];
 	}
 
+	void SetBestTimeCp(const float aTimeCp[NUM_CHECKPOINTS])
+	{
+		for(int i = 0; i < NUM_CHECKPOINTS; i++)
+			m_aBestTimeCp[i] = aTimeCp[i];
+	}
+
 	float m_BestTime;
 	float m_aBestTimeCp[NUM_CHECKPOINTS];
 
@@ -284,6 +292,7 @@ struct CScoreWorker
 	static bool MapVote(IDbConnection *pSqlServer, const ISqlData *pGameData, char *pError, int ErrorSize);
 
 	static bool LoadPlayerData(IDbConnection *pSqlServer, const ISqlData *pGameData, char *pError, int ErrorSize);
+	static bool LoadPlayerTimeCp(IDbConnection *pSqlServer, const ISqlData *pGameData, char *pError, int ErrorSize);
 	static bool MapInfo(IDbConnection *pSqlServer, const ISqlData *pGameData, char *pError, int ErrorSize);
 	static bool ShowRank(IDbConnection *pSqlServer, const ISqlData *pGameData, char *pError, int ErrorSize);
 	static bool ShowTeamRank(IDbConnection *pSqlServer, const ISqlData *pGameData, char *pError, int ErrorSize);


### PR DESCRIPTION
Fixed the command not working without having a finish on the map.

Added appropriate chat responses since it was rather confusing to use.
![1](https://github.com/ddnet/ddnet/assets/121701317/58ab1cb2-8743-44a0-a841-2eb007304570)
![2](https://github.com/ddnet/ddnet/assets/121701317/2ae8b29f-031c-4ef1-b63c-52b51d10ab56)

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
