### PR TITLE
Add a `No login required` filter

### DIFF
--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -445,6 +445,8 @@ void CServerBrowser::Filter()
 			Filtered = true;
 		else if(g_Config.m_BrFilterUnfinishedMap && Info.m_HasRank == CServerInfo::RANK_RANKED)
 			Filtered = true;
+		else if(g_Config.m_BrFilterLogin && Info.m_RequiresLogin)
+			Filtered = true;
 		else
 		{
 			if(!Communities().empty())
@@ -597,6 +599,7 @@ int CServerBrowser::SortHash() const
 	i |= g_Config.m_BrFilterUnfinishedMap << 13;
 	i |= g_Config.m_BrFilterCountry << 14;
 	i |= g_Config.m_BrFilterConnectingPlayers << 15;
+	i |= g_Config.m_BrFilterLogin << 16;
 	return i;
 }
 

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -2315,6 +2315,7 @@ void CServer::UpdateRegisterServerInfo()
 		"},"
 		"\"version\":\"%s\","
 		"\"client_score_kind\":\"time\","
+		"\"requires_login\":false,"
 		"\"clients\":[",
 		MaxClients,
 		MaxPlayers,

--- a/src/engine/serverbrowser.h
+++ b/src/engine/serverbrowser.h
@@ -117,6 +117,7 @@ public:
 	char m_aAddress[MAX_SERVER_ADDRESSES * NETADDR_MAXSTRSIZE];
 	CClient m_aClients[SERVERINFO_MAX_CLIENTS];
 	int m_NumFilteredPlayers;
+	bool m_RequiresLogin;
 
 	static int EstimateLatency(int Loc1, int Loc2);
 	static bool ParseLocation(int *pResult, const char *pString);

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -285,6 +285,7 @@ MACRO_CONFIG_INT(BrFilterGametypeStrict, br_filter_gametype_strict, 0, 0, 1, CFG
 MACRO_CONFIG_INT(BrFilterConnectingPlayers, br_filter_connecting_players, 1, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Filter connecting players")
 MACRO_CONFIG_STR(BrFilterServerAddress, br_filter_serveraddress, 128, "", CFGFLAG_SAVE | CFGFLAG_CLIENT, "Server address to filter")
 MACRO_CONFIG_INT(BrFilterUnfinishedMap, br_filter_unfinished_map, 0, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Show only servers with unfinished maps")
+MACRO_CONFIG_INT(BrFilterLogin, br_filter_login, 1, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Filter out servers that require login")
 
 MACRO_CONFIG_INT(BrIndicateFinished, br_indicate_finished, 1, 0, 1, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Show whether you have finished a DDNet map (transmits your player name to info.ddnet.org/info)")
 MACRO_CONFIG_STR(BrLocation, br_location, 16, "auto", CFGFLAG_SAVE | CFGFLAG_CLIENT, "Override location for ping estimation, available: auto, af, as, as:cn, eu, na, oc, sa (Automatic, Africa, Asia, China, Europe, North America, Oceania/Australia, South America")

--- a/src/engine/shared/serverinfo.cpp
+++ b/src/engine/shared/serverinfo.cpp
@@ -71,6 +71,8 @@ bool CServerInfo2::FromJsonRaw(CServerInfo2 *pOut, const json_value *pJson)
 	const json_value &MapName = ServerInfo["map"]["name"];
 	const json_value &Version = ServerInfo["version"];
 	const json_value &Clients = ServerInfo["clients"];
+	const json_value &RequiresLogin = ServerInfo["requires_login"];
+
 	Error = false;
 	Error = Error || MaxClients.type != json_integer;
 	Error = Error || MaxPlayers.type != json_integer;
@@ -95,6 +97,11 @@ bool CServerInfo2::FromJsonRaw(CServerInfo2 *pOut, const json_value *pJson)
 	else if(ClientScoreKind.type == json_string && str_startswith(ClientScoreKind, "time"))
 	{
 		pOut->m_ClientScoreKind = CServerInfo::CLIENT_SCORE_KIND_TIME;
+	}
+	pOut->m_RequiresLogin = false;
+	if(RequiresLogin.type == json_boolean)
+	{
+		pOut->m_RequiresLogin = RequiresLogin;
 	}
 	pOut->m_Passworded = Passworded;
 	str_copy(pOut->m_aGameType, GameType);
@@ -196,6 +203,7 @@ bool CServerInfo2::operator==(const CServerInfo2 &Other) const
 	Unequal = Unequal || str_comp(m_aName, Other.m_aName) != 0;
 	Unequal = Unequal || str_comp(m_aMapName, Other.m_aMapName) != 0;
 	Unequal = Unequal || str_comp(m_aVersion, Other.m_aVersion) != 0;
+	Unequal = Unequal || m_RequiresLogin != Other.m_RequiresLogin;
 	if(Unequal)
 	{
 		return false;
@@ -225,6 +233,7 @@ CServerInfo2::operator CServerInfo() const
 	Result.m_MaxPlayers = m_MaxPlayers;
 	Result.m_NumPlayers = m_NumPlayers;
 	Result.m_ClientScoreKind = m_ClientScoreKind;
+	Result.m_RequiresLogin = m_RequiresLogin;
 	Result.m_Flags = m_Passworded ? SERVER_FLAG_PASSWORD : 0;
 	str_copy(Result.m_aGameType, m_aGameType);
 	str_copy(Result.m_aName, m_aName);

--- a/src/engine/shared/serverinfo.h
+++ b/src/engine/shared/serverinfo.h
@@ -38,6 +38,7 @@ public:
 	char m_aName[64];
 	char m_aMapName[MAX_MAP_LENGTH];
 	char m_aVersion[32];
+	bool m_RequiresLogin;
 
 	bool operator==(const CServerInfo2 &Other) const;
 	bool operator!=(const CServerInfo2 &Other) const { return !(*this == Other); }

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -661,6 +661,10 @@ void CMenus::RenderServerbrowserFilters(CUIRect View)
 		g_Config.m_BrFilterPw ^= 1;
 
 	View.HSplitTop(RowHeight, &Button, &View);
+	if(DoButton_CheckBox(&g_Config.m_BrFilterLogin, Localize("No login required"), g_Config.m_BrFilterLogin, &Button))
+		g_Config.m_BrFilterLogin ^= 1;
+
+	View.HSplitTop(RowHeight, &Button, &View);
 	if(DoButton_CheckBox(&g_Config.m_BrFilterGametypeStrict, Localize("Strict gametype filter"), g_Config.m_BrFilterGametypeStrict, &Button))
 		g_Config.m_BrFilterGametypeStrict ^= 1;
 
@@ -798,6 +802,7 @@ void CMenus::ResetServerbrowserFilters()
 	g_Config.m_BrFilterGametypeStrict = 0;
 	g_Config.m_BrFilterConnectingPlayers = 1;
 	g_Config.m_BrFilterServerAddress[0] = '\0';
+	g_Config.m_BrFilterLogin = true;
 
 	if(g_Config.m_UiPage != PAGE_LAN)
 	{


### PR DESCRIPTION
Adds `br_filter_login`, which filters out servers that requires an account to play (e.g. Kog's [A] servers). The filter is enabled by default. The filter works by reading the `requires_login` boolean property from the server's info object.

![image](https://github.com/ddnet/ddnet/assets/141338449/f356438c-73fa-45a8-bc39-819519e542cb)

Closes #8024

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
