### PR TITLE
Disconnect when we get map change with invalid parameters

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -1447,7 +1447,7 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket, int Conn, bool Dummy)
 
 					m_pMapdownloadTask = HttpGetFile(pMapUrl ? pMapUrl : aUrl, Storage(), m_aMapdownloadFilenameTemp, IStorage::TYPE_SAVE);
 					m_pMapdownloadTask->Timeout(CTimeout{g_Config.m_ClMapDownloadConnectTimeoutMs, 0, g_Config.m_ClMapDownloadLowSpeedLimit, g_Config.m_ClMapDownloadLowSpeedTime});
-					m_pMapdownloadTask->MaxResponseSize(1024 * 1024 * 1024); // 1 GiB
+					m_pMapdownloadTask->MaxResponseSize(MapSize);
 					m_pMapdownloadTask->ExpectSha256(*pMapSha256);
 					Http()->Run(m_pMapdownloadTask);
 				}

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -1372,8 +1372,13 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket, int Conn, bool Dummy)
 			const char *pMap = Unpacker.GetString(CUnpacker::SANITIZE_CC | CUnpacker::SKIP_START_WHITESPACES);
 			int MapCrc = Unpacker.GetInt();
 			int MapSize = Unpacker.GetInt();
-			if(Unpacker.Error() || MapSize < 0)
+			if(Unpacker.Error())
 			{
+				return;
+			}
+			if(MapSize < 0 || MapSize > 1024 * 1024 * 1024) // 1 GiB
+			{
+				DisconnectWithReason("invalid map size");
 				return;
 			}
 
@@ -1381,6 +1386,7 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket, int Conn, bool Dummy)
 			{
 				if(pMap[i] == '/' || pMap[i] == '\\')
 				{
+					DisconnectWithReason("strange character in map name");
 					return;
 				}
 			}


### PR DESCRIPTION
This is the only sane thing we can do, the server will have changed its map and we can't pretend to still be on the old one.

Also inform HTTP map download of the map size.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
