### PR TITLE
Replace `IGraphics::FreePNG` with `CImageInfo::Free`

### DIFF
--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -657,12 +657,6 @@ bool CGraphics_Threaded::LoadPNG(CImageInfo *pImg, const char *pFilename, int St
 	return true;
 }
 
-void CGraphics_Threaded::FreePNG(CImageInfo *pImg)
-{
-	free(pImg->m_pData);
-	pImg->m_pData = NULL;
-}
-
 bool CGraphics_Threaded::CheckImageDivisibility(const char *pFileName, CImageInfo &Img, int DivX, int DivY, bool AllowResize)
 {
 	dbg_assert(DivX != 0 && DivY != 0, "Passing 0 to this function is not allowed.");

--- a/src/engine/client/graphics_threaded.h
+++ b/src/engine/client/graphics_threaded.h
@@ -983,7 +983,6 @@ public:
 	// simple uncompressed RGBA loaders
 	IGraphics::CTextureHandle LoadTexture(const char *pFilename, int StorageType, int Flags = 0) override;
 	bool LoadPNG(CImageInfo *pImg, const char *pFilename, int StorageType) override;
-	void FreePNG(CImageInfo *pImg) override;
 
 	bool CheckImageDivisibility(const char *pFileName, CImageInfo &Img, int DivX, int DivY, bool AllowResize) override;
 	bool IsImageFormatRGBA(const char *pFileName, CImageInfo &Img) override;

--- a/src/engine/graphics.h
+++ b/src/engine/graphics.h
@@ -97,6 +97,15 @@ public:
 	 */
 	uint8_t *m_pData = nullptr;
 
+	void Free()
+	{
+		m_Width = 0;
+		m_Height = 0;
+		m_Format = FORMAT_ERROR;
+		free(m_pData);
+		m_pData = nullptr;
+	}
+
 	static size_t PixelSize(EImageFormat Format)
 	{
 		dbg_assert(Format != FORMAT_ERROR, "Format invalid");
@@ -322,7 +331,6 @@ public:
 	virtual const TTwGraphicsGpuList &GetGpus() const = 0;
 
 	virtual bool LoadPNG(CImageInfo *pImg, const char *pFilename, int StorageType) = 0;
-	virtual void FreePNG(CImageInfo *pImg) = 0;
 
 	virtual bool CheckImageDivisibility(const char *pFileName, CImageInfo &Img, int DivX, int DivY, bool AllowResize) = 0;
 	virtual bool IsImageFormatRGBA(const char *pFileName, CImageInfo &Img) = 0;

--- a/src/game/client/components/mapimages.cpp
+++ b/src/game/client/components/mapimages.cpp
@@ -286,8 +286,7 @@ IGraphics::CTextureHandle CMapImages::GetEntities(EMapImageEntityLayerType Entit
 			}
 
 			free(pBuildImgData);
-
-			Graphics()->FreePNG(&ImgInfo);
+			ImgInfo.Free();
 		}
 	}
 

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -2249,7 +2249,7 @@ int CMenus::MenuImageScan(const char *pName, int IsDir, int DirType, void *pUser
 	}
 	if(Info.m_Format != CImageInfo::FORMAT_RGBA)
 	{
-		pSelf->Graphics()->FreePNG(&Info);
+		Info.Free();
 		char aError[IO_MAX_PATH_LENGTH + 64];
 		str_format(aError, sizeof(aError), "Failed to load menu image from '%s': must be an RGBA image", aPath);
 		pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "menus", aError);

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1944,8 +1944,7 @@ CMenus::CCommunityIconLoadJob::CCommunityIconLoadJob(CMenus *pMenus, const char 
 
 CMenus::CCommunityIconLoadJob::~CCommunityIconLoadJob()
 {
-	free(m_ImageInfo.m_pData);
-	m_ImageInfo.m_pData = nullptr;
+	m_ImageInfo.Free();
 }
 
 int CMenus::CommunityIconScan(const char *pName, int IsDir, int DirType, void *pUser)
@@ -1983,14 +1982,14 @@ bool CMenus::LoadCommunityIconFile(const char *pPath, int DirType, CImageInfo &I
 	}
 	if(Info.m_Format != CImageInfo::FORMAT_RGBA)
 	{
-		Graphics()->FreePNG(&Info);
+		Info.Free();
 		str_format(aError, sizeof(aError), "Failed to load community icon from '%s': must be an RGBA image", pPath);
 		Console()->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "menus/browser", aError);
 		return false;
 	}
 	if(!Storage()->CalculateHashes(pPath, DirType, &Sha256))
 	{
-		Graphics()->FreePNG(&Info);
+		Info.Free();
 		str_format(aError, sizeof(aError), "Failed to load community icon from '%s': could not calculate hash", pPath);
 		Console()->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "menus/browser", aError);
 		return false;

--- a/src/game/client/components/skins.cpp
+++ b/src/game/client/components/skins.cpp
@@ -293,7 +293,7 @@ const CSkin *CSkins::LoadSkin(const char *pName, CImageInfo &Info)
 	for(int i = 0; i < 6; ++i)
 		Skin.m_ColorableSkin.m_aEyes[i] = Graphics()->LoadSpriteTexture(Info, &g_pData->m_aSprites[SPRITE_TEE_EYE_NORMAL + i]);
 
-	Graphics()->FreePNG(&Info);
+	Info.Free();
 
 	if(g_Config.m_Debug)
 	{

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -3104,8 +3104,7 @@ void CGameClient::LoadGameSkin(const char *pPath, bool AsDir)
 		}
 
 		m_GameSkinLoaded = true;
-
-		Graphics()->FreePNG(&ImgInfo);
+		ImgInfo.Free();
 	}
 }
 
@@ -3149,7 +3148,7 @@ void CGameClient::LoadEmoticonsSkin(const char *pPath, bool AsDir)
 			m_EmoticonsSkin.m_aSpriteEmoticons[i] = Graphics()->LoadSpriteTexture(ImgInfo, &g_pData->m_aSprites[SPRITE_OOP + i]);
 
 		m_EmoticonsSkinLoaded = true;
-		Graphics()->FreePNG(&ImgInfo);
+		ImgInfo.Free();
 	}
 }
 
@@ -3220,7 +3219,7 @@ void CGameClient::LoadParticlesSkin(const char *pPath, bool AsDir)
 		m_ParticlesSkin.m_aSpriteParticles[9] = m_ParticlesSkin.m_SpriteParticleHit;
 
 		m_ParticlesSkinLoaded = true;
-		free(ImgInfo.m_pData);
+		ImgInfo.Free();
 	}
 }
 
@@ -3319,7 +3318,7 @@ void CGameClient::LoadHudSkin(const char *pPath, bool AsDir)
 		m_HudSkin.m_SpriteHudDummyCopy = Graphics()->LoadSpriteTexture(ImgInfo, &g_pData->m_aSprites[SPRITE_HUD_DUMMY_COPY]);
 
 		m_HudSkinLoaded = true;
-		free(ImgInfo.m_pData);
+		ImgInfo.Free();
 	}
 }
 
@@ -3364,7 +3363,7 @@ void CGameClient::LoadExtrasSkin(const char *pPath, bool AsDir)
 		m_ExtrasSkin.m_SpriteParticleSnowflake = Graphics()->LoadSpriteTexture(ImgInfo, &g_pData->m_aSprites[SPRITE_PART_SNOWFLAKE]);
 		m_ExtrasSkin.m_aSpriteParticles[0] = m_ExtrasSkin.m_SpriteParticleSnowflake;
 		m_ExtrasSkinLoaded = true;
-		free(ImgInfo.m_pData);
+		ImgInfo.Free();
 	}
 }
 

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -4369,8 +4369,7 @@ bool CEditor::ReplaceImage(const char *pFileName, int StorageType, bool CheckDup
 
 	std::shared_ptr<CEditorImage> pImg = m_Map.m_vpImages[m_SelectedImage];
 	Graphics()->UnloadTexture(&(pImg->m_Texture));
-	free(pImg->m_pData);
-	pImg->m_pData = nullptr;
+	pImg->Free();
 	*pImg = ImgInfo;
 	str_copy(pImg->m_aName, aBuf);
 	pImg->m_External = IsVanillaImage(pImg->m_aName);

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -2107,8 +2107,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupEvent(void *pContext, CUIRect View, 
 
 			if(pEditor->m_PopupEventType == POPEVENT_PIXELART_BIG_IMAGE || pEditor->m_PopupEventType == POPEVENT_PIXELART_MANY_COLORS)
 			{
-				free(pEditor->m_TileartImageInfo.m_pData);
-				pEditor->m_TileartImageInfo.m_pData = nullptr;
+				pEditor->m_TileartImageInfo.Free();
 			}
 
 			return CUi::POPUP_CLOSE_CURRENT;

--- a/src/game/editor/tileart.cpp
+++ b/src/game/editor/tileart.cpp
@@ -212,8 +212,7 @@ void CEditor::AddTileart(bool IgnoreHistory)
 		m_EditorHistory.RecordAction(std::make_shared<CEditorActionTileArt>(this, ImageCount, m_aTileartFilename, IndexMap));
 	}
 
-	free(m_TileartImageInfo.m_pData);
-	m_TileartImageInfo.m_pData = nullptr;
+	m_TileartImageInfo.Free();
 	m_Map.OnModify();
 	m_Dialog = DIALOG_NONE;
 }
@@ -226,8 +225,7 @@ void CEditor::TileartCheckColors()
 	{
 		m_PopupEventType = CEditor::POPEVENT_PIXELART_TOO_MANY_COLORS;
 		m_PopupEventActivated = true;
-		free(m_TileartImageInfo.m_pData);
-		m_TileartImageInfo.m_pData = nullptr;
+		m_TileartImageInfo.Free();
 	}
 	else if(NumColorGroups > 1)
 	{


### PR DESCRIPTION
The engine graphics do not need to be involved with freeing image data.

The `Free` function now also ensures that all other member variables are cleared when freeing the image data.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
