### PR TITLE
Fix crash when the serverlist request fails

### DIFF
--- a/src/engine/client/serverbrowser_http.cpp
+++ b/src/engine/client/serverbrowser_http.cpp
@@ -400,19 +400,22 @@ void CServerBrowserHttp::Update()
 		Success = Success && pJson;
 		Success = Success && !Parse(pJson, &m_vServers, &m_vLegacyServers);
 		json_value_free(pJson);
-		int Age = SanitizeAge(pGetServers->ResultAgeSeconds());
 		if(!Success)
 		{
 			log_error("serverbrowse_http", "failed getting serverlist, trying to find best URL");
 			m_pChooseMaster->Reset();
 			m_pChooseMaster->Refresh();
 		}
-		// Try to find new master if the current one returns results
-		// that are 5 minutes old.
-		else if(Age > 300)
+		else
 		{
-			log_info("serverbrowse_http", "got stale serverlist, age=%ds, trying to find best URL", Age);
-			m_pChooseMaster->Refresh();
+			// Try to find new master if the current one returns
+			// results that are 5 minutes old.
+			int Age = SanitizeAge(pGetServers->ResultAgeSeconds());
+			if(Age > 300)
+			{
+				log_info("serverbrowse_http", "got stale serverlist, age=%ds, trying to find best URL", Age);
+				m_pChooseMaster->Refresh();
+			}
 		}
 	}
 }


### PR DESCRIPTION
We're not allowed to look at `ResultAgeSeconds` when the state is `EHttpState::ERROR`.

Fixes #8107.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
