### PR TITLE
Remove `(until you die)` part from `/eyeemote off`

### DIFF
--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -1217,7 +1217,7 @@ void CGameContext::ConSetEyeEmote(IConsole::IResult *pResult,
 			"chatresp",
 			(pPlayer->m_EyeEmoteEnabled) ?
 				"You can now use the preset eye emotes." :
-				"You don't have any eye emotes, remember to bind some. (until you die)");
+				"You don't have any eye emotes, remember to bind some.");
 		return;
 	}
 	else if(str_comp_nocase(pResult->GetString(0), "on") == 0)
@@ -1231,7 +1231,7 @@ void CGameContext::ConSetEyeEmote(IConsole::IResult *pResult,
 		"chatresp",
 		(pPlayer->m_EyeEmoteEnabled) ?
 			"You can now use the preset eye emotes." :
-			"You don't have any eye emotes, remember to bind some. (until you die)");
+			"You don't have any eye emotes, remember to bind some.");
 }
 
 void CGameContext::ConEyeEmote(IConsole::IResult *pResult, void *pUserData)


### PR DESCRIPTION
`eyeemote` will keep its setting after death, so I'm not sure what that part is supposed to mean.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
