### PR TITLE
`ClNameplatesStrong` improvements

### DIFF
--- a/src/game/client/components/nameplates.cpp
+++ b/src/game/client/components/nameplates.cpp
@@ -220,13 +220,15 @@ void CNamePlates::RenderNameplatePos(vec2 Position, const CNetObj_PlayerInfo *pP
 
 	if((g_Config.m_Debug || g_Config.m_ClNameplatesStrong) && g_Config.m_ClNameplates)
 	{
-		if(m_pClient->m_Snap.m_LocalClientId != -1)
+		bool Following = (m_pClient->m_Snap.m_SpecInfo.m_Active && !GameClient()->m_MultiViewActivated && m_pClient->m_Snap.m_SpecInfo.m_SpectatorId != SPEC_FREEVIEW);
+		if(m_pClient->m_Snap.m_LocalClientId != -1 || Following)
 		{
-			const CGameClient::CSnapState::CCharacterInfo &Local = m_pClient->m_Snap.m_aCharacters[m_pClient->m_Snap.m_LocalClientId];
-			const CGameClient::CSnapState::CCharacterInfo &Other = m_pClient->m_Snap.m_aCharacters[pPlayerInfo->m_ClientId];
-			if(Local.m_HasExtendedData && Other.m_HasExtendedData)
+			int SelectedId = Following ? m_pClient->m_Snap.m_SpecInfo.m_SpectatorId : m_pClient->m_Snap.m_LocalClientId;
+			const CGameClient::CSnapState::CCharacterInfo &Selected = m_pClient->m_Snap.m_aCharacters[SelectedId];
+			const CGameClient::CSnapState::CCharacterInfo &Other = m_pClient->m_Snap.m_aCharacters[ClientId];
+			if(Selected.m_HasExtendedData && Other.m_HasExtendedData)
 			{
-				if(pPlayerInfo->m_Local)
+				if(SelectedId == ClientId)
 					TextRender()->TextColor(rgb);
 				else
 				{
@@ -237,7 +239,7 @@ void CNamePlates::RenderNameplatePos(vec2 Position, const CNetObj_PlayerInfo *pP
 					Graphics()->QuadsBegin();
 					ColorRGBA StrongWeakStatusColor;
 					int StrongWeakSpriteId;
-					if(Local.m_ExtendedData.m_StrongWeakId > Other.m_ExtendedData.m_StrongWeakId)
+					if(Selected.m_ExtendedData.m_StrongWeakId > Other.m_ExtendedData.m_StrongWeakId)
 					{
 						StrongWeakStatusColor = color_cast<ColorRGBA>(ColorHSLA(6401973));
 						StrongWeakSpriteId = SPRITE_HOOK_STRONG;

--- a/src/game/client/components/nameplates.cpp
+++ b/src/game/client/components/nameplates.cpp
@@ -220,11 +220,11 @@ void CNamePlates::RenderNameplatePos(vec2 Position, const CNetObj_PlayerInfo *pP
 
 	if((g_Config.m_Debug || g_Config.m_ClNameplatesStrong) && g_Config.m_ClNameplates)
 	{
-		if(m_pClient->m_Snap.m_LocalClientId != -1 && m_pClient->m_Snap.m_aCharacters[pPlayerInfo->m_ClientId].m_HasExtendedData && m_pClient->m_Snap.m_aCharacters[m_pClient->m_Snap.m_LocalClientId].m_HasExtendedData)
+		if(m_pClient->m_Snap.m_LocalClientId != -1)
 		{
-			CCharacter *pLocalChar = m_pClient->m_GameWorld.GetCharacterById(m_pClient->m_Snap.m_LocalClientId);
-			CCharacter *pCharacter = m_pClient->m_GameWorld.GetCharacterById(pPlayerInfo->m_ClientId);
-			if(pCharacter && pLocalChar)
+			const CGameClient::CSnapState::CCharacterInfo &Local = m_pClient->m_Snap.m_aCharacters[m_pClient->m_Snap.m_LocalClientId];
+			const CGameClient::CSnapState::CCharacterInfo &Other = m_pClient->m_Snap.m_aCharacters[pPlayerInfo->m_ClientId];
+			if(Local.m_HasExtendedData && Other.m_HasExtendedData)
 			{
 				if(pPlayerInfo->m_Local)
 					TextRender()->TextColor(rgb);
@@ -237,7 +237,7 @@ void CNamePlates::RenderNameplatePos(vec2 Position, const CNetObj_PlayerInfo *pP
 					Graphics()->QuadsBegin();
 					ColorRGBA StrongWeakStatusColor;
 					int StrongWeakSpriteId;
-					if(pLocalChar->GetStrongWeakId() > pCharacter->GetStrongWeakId())
+					if(Local.m_ExtendedData.m_StrongWeakId > Other.m_ExtendedData.m_StrongWeakId)
 					{
 						StrongWeakStatusColor = color_cast<ColorRGBA>(ColorHSLA(6401973));
 						StrongWeakSpriteId = SPRITE_HOOK_STRONG;
@@ -271,7 +271,7 @@ void CNamePlates::RenderNameplatePos(vec2 Position, const CNetObj_PlayerInfo *pP
 				{
 					YOffset -= FontSize;
 					char aBuf[12];
-					str_from_int(pCharacter->GetStrongWeakId(), aBuf);
+					str_from_int(Other.m_ExtendedData.m_StrongWeakId, aBuf);
 					float XOffset = TextRender()->TextWidth(FontSize, aBuf, -1, -1.0f) / 2.0f;
 					TextRender()->Text(Position.x - XOffset, YOffset, FontSize, aBuf, -1.0f);
 				}


### PR DESCRIPTION
Fixes strong indicator not showing above:
- players in different team or solo
- all players when paused

Additionally strong indicator is now shown from perspective of locked on player as described in #7704

closes #7704

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
