### PR TITLE
[Editor] Fix crash when trying to select autorule with arrow keys

### DIFF
--- a/src/game/client/ui_listbox.cpp
+++ b/src/game/client/ui_listbox.cpp
@@ -147,7 +147,7 @@ CListboxItem CListBox::DoNextRow()
 	return Item;
 }
 
-CListboxItem CListBox::DoNextItem(const void *pId, bool Selected)
+CListboxItem CListBox::DoNextItem(const void *pId, bool Selected, float CornerRadius)
 {
 	if(m_AutoSpacing > 0.0f && m_ListBoxItemIndex > 0)
 		DoSpacing(m_AutoSpacing);
@@ -187,11 +187,11 @@ CListboxItem CListBox::DoNextItem(const void *pId, bool Selected)
 			}
 		}
 
-		Item.m_Rect.Draw(ColorRGBA(1.0f, 1.0f, 1.0f, m_Active ? 0.5f : 0.33f), IGraphics::CORNER_ALL, 5.0f);
+		Item.m_Rect.Draw(ColorRGBA(1.0f, 1.0f, 1.0f, m_Active ? 0.5f : 0.33f), IGraphics::CORNER_ALL, CornerRadius);
 	}
 	if(Ui()->HotItem() == pId && !m_ScrollRegion.Animating())
 	{
-		Item.m_Rect.Draw(ColorRGBA(1.0f, 1.0f, 1.0f, 0.33f), IGraphics::CORNER_ALL, 5.0f);
+		Item.m_Rect.Draw(ColorRGBA(1.0f, 1.0f, 1.0f, 0.33f), IGraphics::CORNER_ALL, CornerRadius);
 	}
 
 	return Item;

--- a/src/game/client/ui_listbox.h
+++ b/src/game/client/ui_listbox.h
@@ -54,7 +54,7 @@ public:
 	void DoFooter(const char *pBottomText, float FooterHeight = 20.0f); // call before DoStart to create a footer
 	void DoStart(float RowHeight, int NumItems, int ItemsPerRow, int RowsPerScroll, int SelectedIndex, const CUIRect *pRect = nullptr, bool Background = true, int BackgroundCorners = IGraphics::CORNER_ALL, bool ForceShowScrollbar = false);
 	void ScrollToSelected() { m_ListBoxUpdateScroll = true; }
-	CListboxItem DoNextItem(const void *pId, bool Selected = false);
+	CListboxItem DoNextItem(const void *pId, bool Selected = false, float CornerRadius = 5.0f);
 	CListboxItem DoSubheader();
 	int DoEnd();
 

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -4231,7 +4231,7 @@ void CEditor::RenderLayers(CUIRect LayersBox)
 		}
 	}
 
-	if(Input()->KeyPress(KEY_DOWN) && m_Dialog == DIALOG_NONE && CLineInput::GetActiveInput() == nullptr && s_Operation == OP_NONE)
+	if(Input()->KeyPress(KEY_DOWN) && m_Dialog == DIALOG_NONE && !Ui()->IsPopupOpen() && CLineInput::GetActiveInput() == nullptr && s_Operation == OP_NONE)
 	{
 		if(Input()->ShiftIsPressed())
 		{
@@ -4263,7 +4263,7 @@ void CEditor::RenderLayers(CUIRect LayersBox)
 		}
 		s_ScrollToSelectionNext = true;
 	}
-	if(Input()->KeyPress(KEY_UP) && m_Dialog == DIALOG_NONE && CLineInput::GetActiveInput() == nullptr && s_Operation == OP_NONE)
+	if(Input()->KeyPress(KEY_UP) && m_Dialog == DIALOG_NONE && !Ui()->IsPopupOpen() && CLineInput::GetActiveInput() == nullptr && s_Operation == OP_NONE)
 	{
 		if(Input()->ShiftIsPressed())
 		{

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -2198,32 +2198,32 @@ CUi::EPopupMenuFunctionResult CEditor::PopupSelectImage(void *pContext, CUIRect 
 	const float ButtonHeight = 12.0f;
 	const float ButtonMargin = 2.0f;
 
-	static CScrollRegion s_ScrollRegion;
-	vec2 ScrollOffset(0.0f, 0.0f);
-	CScrollRegionParams ScrollParams;
-	ScrollParams.m_ScrollbarWidth = 10.0f;
-	ScrollParams.m_ScrollbarMargin = 3.0f;
-	ScrollParams.m_ScrollUnit = (ButtonHeight + ButtonMargin) * 5;
-	s_ScrollRegion.Begin(&ButtonBar, &ScrollOffset, &ScrollParams);
-	ButtonBar.y += ScrollOffset.y;
+	static CListBox s_ListBox;
+	s_ListBox.DoStart(ButtonHeight, pEditor->m_Map.m_vpImages.size() + 1, 1, 4, g_SelectImageCurrent + 1, &ButtonBar, false);
+	s_ListBox.DoAutoSpacing(ButtonMargin);
 
-	for(int i = -1; i < (int)pEditor->m_Map.m_vpImages.size(); i++)
+	for(int i = 0; i <= (int)pEditor->m_Map.m_vpImages.size(); i++)
 	{
-		CUIRect Button;
-		ButtonBar.HSplitTop(ButtonMargin, nullptr, &ButtonBar);
-		ButtonBar.HSplitTop(ButtonHeight, &Button, &ButtonBar);
-		if(s_ScrollRegion.AddRect(Button))
-		{
-			if(pEditor->Ui()->MouseInside(&Button))
-				ShowImage = i;
+		static int s_NoneButton = 0;
+		CListboxItem Item = s_ListBox.DoNextItem(i == 0 ? (void *)&s_NoneButton : &pEditor->m_Map.m_vpImages[i - 1], (i - 1) == g_SelectImageCurrent, 3.0f);
+		if(!Item.m_Visible)
+			continue;
 
-			static int s_NoneButton = 0;
-			if(pEditor->DoButton_MenuItem(i == -1 ? (void *)&s_NoneButton : &pEditor->m_Map.m_vpImages[i], i == -1 ? "None" : pEditor->m_Map.m_vpImages[i]->m_aName, i == g_SelectImageCurrent, &Button))
-				g_SelectImageSelected = i;
-		}
+		if(pEditor->Ui()->MouseInside(&Item.m_Rect))
+			ShowImage = i - 1;
+
+		CUIRect Label;
+		Item.m_Rect.VMargin(5.0f, &Label);
+
+		SLabelProperties Props;
+		Props.m_MaxWidth = Label.w;
+		Props.m_EllipsisAtEnd = true;
+		pEditor->Ui()->DoLabel(&Label, i == 0 ? "None" : pEditor->m_Map.m_vpImages[i - 1]->m_aName, EditorFontSizes::MENU, TEXTALIGN_ML, Props);
 	}
 
-	s_ScrollRegion.End();
+	int NewSelected = s_ListBox.DoEnd() - 1;
+	if(NewSelected != g_SelectImageCurrent)
+		g_SelectImageSelected = NewSelected;
 
 	if(ShowImage >= 0 && (size_t)ShowImage < pEditor->m_Map.m_vpImages.size())
 	{
@@ -2275,29 +2275,29 @@ CUi::EPopupMenuFunctionResult CEditor::PopupSelectSound(void *pContext, CUIRect 
 	const float ButtonHeight = 12.0f;
 	const float ButtonMargin = 2.0f;
 
-	static CScrollRegion s_ScrollRegion;
-	vec2 ScrollOffset(0.0f, 0.0f);
-	CScrollRegionParams ScrollParams;
-	ScrollParams.m_ScrollbarWidth = 10.0f;
-	ScrollParams.m_ScrollbarMargin = 3.0f;
-	ScrollParams.m_ScrollUnit = (ButtonHeight + ButtonMargin) * 5;
-	s_ScrollRegion.Begin(&View, &ScrollOffset, &ScrollParams);
-	View.y += ScrollOffset.y;
+	static CListBox s_ListBox;
+	s_ListBox.DoStart(ButtonHeight, pEditor->m_Map.m_vpSounds.size() + 1, 1, 4, g_SelectSoundCurrent + 1, &View, false);
+	s_ListBox.DoAutoSpacing(ButtonMargin);
 
-	for(int i = -1; i < (int)pEditor->m_Map.m_vpSounds.size(); i++)
+	for(int i = 0; i <= (int)pEditor->m_Map.m_vpSounds.size(); i++)
 	{
-		CUIRect Button;
-		View.HSplitTop(ButtonMargin, nullptr, &View);
-		View.HSplitTop(ButtonHeight, &Button, &View);
-		if(s_ScrollRegion.AddRect(Button))
-		{
-			static int s_NoneButton = 0;
-			if(pEditor->DoButton_MenuItem(i == -1 ? (void *)&s_NoneButton : &pEditor->m_Map.m_vpSounds[i], i == -1 ? "None" : pEditor->m_Map.m_vpSounds[i]->m_aName, i == g_SelectSoundCurrent, &Button))
-				g_SelectSoundSelected = i;
-		}
+		static int s_NoneButton = 0;
+		CListboxItem Item = s_ListBox.DoNextItem(i == 0 ? (void *)&s_NoneButton : &pEditor->m_Map.m_vpSounds[i - 1], (i - 1) == g_SelectSoundCurrent, 3.0f);
+		if(!Item.m_Visible)
+			continue;
+
+		CUIRect Label;
+		Item.m_Rect.VMargin(5.0f, &Label);
+
+		SLabelProperties Props;
+		Props.m_MaxWidth = Label.w;
+		Props.m_EllipsisAtEnd = true;
+		pEditor->Ui()->DoLabel(&Label, i == 0 ? "None" : pEditor->m_Map.m_vpSounds[i - 1]->m_aName, EditorFontSizes::MENU, TEXTALIGN_ML, Props);
 	}
 
-	s_ScrollRegion.End();
+	int NewSelected = s_ListBox.DoEnd() - 1;
+	if(NewSelected != g_SelectSoundCurrent)
+		g_SelectSoundSelected = NewSelected;
 
 	return CUi::POPUP_KEEP_OPEN;
 }
@@ -2385,29 +2385,29 @@ CUi::EPopupMenuFunctionResult CEditor::PopupSelectConfigAutoMap(void *pContext, 
 	const float ButtonHeight = 12.0f;
 	const float ButtonMargin = 2.0f;
 
-	static CScrollRegion s_ScrollRegion;
-	vec2 ScrollOffset(0.0f, 0.0f);
-	CScrollRegionParams ScrollParams;
-	ScrollParams.m_ScrollbarWidth = 10.0f;
-	ScrollParams.m_ScrollbarMargin = 3.0f;
-	ScrollParams.m_ScrollUnit = (ButtonHeight + ButtonMargin) * 5;
-	s_ScrollRegion.Begin(&View, &ScrollOffset, &ScrollParams);
-	View.y += ScrollOffset.y;
+	static CListBox s_ListBox;
+	s_ListBox.DoStart(ButtonHeight, pAutoMapper->ConfigNamesNum() + 1, 1, 4, s_AutoMapConfigCurrent + 1, &View, false);
+	s_ListBox.DoAutoSpacing(ButtonMargin);
 
-	for(int i = -1; i < pAutoMapper->ConfigNamesNum(); i++)
+	for(int i = 0; i < pAutoMapper->ConfigNamesNum() + 1; i++)
 	{
-		CUIRect Button;
-		View.HSplitTop(ButtonMargin, nullptr, &View);
-		View.HSplitTop(ButtonHeight, &Button, &View);
-		if(s_ScrollRegion.AddRect(Button))
-		{
-			static int s_NoneButton = 0;
-			if(pEditor->DoButton_MenuItem(i == -1 ? (void *)&s_NoneButton : pAutoMapper->GetConfigName(i), i == -1 ? "None" : pAutoMapper->GetConfigName(i), i == s_AutoMapConfigCurrent, &Button))
-				s_AutoMapConfigSelected = i;
-		}
+		static int s_NoneButton = 0;
+		CListboxItem Item = s_ListBox.DoNextItem(i == 0 ? (void *)&s_NoneButton : pAutoMapper->GetConfigName(i - 1), (i - 1) == s_AutoMapConfigCurrent, 3.0f);
+		if(!Item.m_Visible)
+			continue;
+
+		CUIRect Label;
+		Item.m_Rect.VMargin(5.0f, &Label);
+
+		SLabelProperties Props;
+		Props.m_MaxWidth = Label.w;
+		Props.m_EllipsisAtEnd = true;
+		pEditor->Ui()->DoLabel(&Label, i == 0 ? "None" : pAutoMapper->GetConfigName(i - 1), EditorFontSizes::MENU, TEXTALIGN_ML, Props);
 	}
 
-	s_ScrollRegion.End();
+	int NewSelected = s_ListBox.DoEnd() - 1;
+	if(NewSelected != s_AutoMapConfigCurrent)
+		s_AutoMapConfigSelected = NewSelected;
 
 	return CUi::POPUP_KEEP_OPEN;
 }


### PR DESCRIPTION
Fixes #8116.
Also supports navigating in selection popups (image, automapper and sound) with `UP` and `DOWN` arrow keys.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
