### PR TITLE
Fix envelope points not clickable after opening bezier popup

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -7047,6 +7047,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 											ShowPopupEnvPoint();
 										}
 										Ui()->SetActiveItem(nullptr);
+										s_Operation = EEnvelopeEditorOp::OP_NONE;
 									}
 								}
 								else if(!Ui()->MouseButton(0))
@@ -7179,6 +7180,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 											ShowPopupEnvPoint();
 										}
 										Ui()->SetActiveItem(nullptr);
+										s_Operation = EEnvelopeEditorOp::OP_NONE;
 									}
 								}
 								else if(!Ui()->MouseButton(0))


### PR DESCRIPTION
Closes #8017.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
