### PR TITLE
Remove useless operation in CUIRect SplitMid

### DIFF
--- a/src/game/client/ui_rect.cpp
+++ b/src/game/client/ui_rect.cpp
@@ -25,7 +25,7 @@ void CUIRect::HSplitMid(CUIRect *pTop, CUIRect *pBottom, float Spacing) const
 		pBottom->x = r.x;
 		pBottom->y = r.y + Cut + HalfSpacing;
 		pBottom->w = r.w;
-		pBottom->h = r.h - Cut - HalfSpacing;
+		pBottom->h = Cut - HalfSpacing;
 	}
 }
 
@@ -89,7 +89,7 @@ void CUIRect::VSplitMid(CUIRect *pLeft, CUIRect *pRight, float Spacing) const
 	{
 		pRight->x = r.x + Cut + HalfSpacing;
 		pRight->y = r.y;
-		pRight->w = r.w - Cut - HalfSpacing;
+		pRight->w = Cut - HalfSpacing;
 		pRight->h = r.h;
 	}
 }


### PR DESCRIPTION

![image](https://github.com/ddnet/ddnet/assets/20344300/18faa208-305e-444e-89fc-f040f910bf2e)

![image](https://github.com/ddnet/ddnet/assets/20344300/2fa8e64b-7514-4499-a320-ca0353dc31f4)

![image](https://github.com/ddnet/ddnet/assets/20344300/d3526583-23a2-4df7-aa95-15e02a5da5df)

![image](https://github.com/ddnet/ddnet/assets/20344300/8c2f8879-b675-473a-bd1e-4e10ba900191)

The math

w / 2 = w - (w / 2)

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
