### PR TITLE
Overload ui SplitMid functions with tripple split

### DIFF
--- a/src/game/client/ui_rect.cpp
+++ b/src/game/client/ui_rect.cpp
@@ -29,6 +29,38 @@ void CUIRect::HSplitMid(CUIRect *pTop, CUIRect *pBottom, float Spacing) const
 	}
 }
 
+void CUIRect::HSpaceAround(CUIRect *pTop, CUIRect *pMiddle, CUIRect *pBottom, float Spacing) const
+{
+	CUIRect r = *this;
+	const float Cut = r.h / 3;
+	const float HalfSpacing = Spacing / 2;
+	const float Height = Cut - Spacing;
+
+	if(pTop)
+	{
+		pTop->x = r.x;
+		pTop->y = r.y + HalfSpacing;
+		pTop->w = r.w;
+		pTop->h = Height;
+	}
+
+	if(pMiddle)
+	{
+		pMiddle->x = r.x;
+		pMiddle->y = r.y + Cut + HalfSpacing;
+		pMiddle->w = r.w;
+		pMiddle->h = Height;
+	}
+
+	if(pBottom)
+	{
+		pBottom->x = r.x;
+		pBottom->y = r.y + Cut * 2 + HalfSpacing;
+		pBottom->w = r.w;
+		pBottom->h = Height;
+	}
+}
+
 void CUIRect::HSplitTop(float Cut, CUIRect *pTop, CUIRect *pBottom) const
 {
 	CUIRect r = *this;
@@ -90,6 +122,38 @@ void CUIRect::VSplitMid(CUIRect *pLeft, CUIRect *pRight, float Spacing) const
 		pRight->x = r.x + Cut + HalfSpacing;
 		pRight->y = r.y;
 		pRight->w = r.w - Cut - HalfSpacing;
+		pRight->h = r.h;
+	}
+}
+
+void CUIRect::VSpaceAround(CUIRect *pLeft, CUIRect *pMiddle, CUIRect *pRight, float Spacing) const
+{
+	CUIRect r = *this;
+	const float Cut = r.w / 3;
+	const float HalfSpacing = Spacing / 2;
+	const float Width = Cut - Spacing;
+
+	if(pLeft)
+	{
+		pLeft->x = r.x + HalfSpacing;
+		pLeft->y = r.y;
+		pLeft->w = Width;
+		pLeft->h = r.h;
+	}
+
+	if(pMiddle)
+	{
+		pMiddle->x = r.x + Cut + HalfSpacing;
+		pMiddle->y = r.y;
+		pMiddle->w = Width;
+		pMiddle->h = r.h;
+	}
+
+	if(pRight)
+	{
+		pRight->x = r.x + Cut * 2 + HalfSpacing;
+		pRight->y = r.y;
+		pRight->w = Width;
 		pRight->h = r.h;
 	}
 }

--- a/src/game/client/ui_rect.h
+++ b/src/game/client/ui_rect.h
@@ -18,12 +18,53 @@ public:
 
 	/**
 	 * Splits 2 CUIRect inside *this* CUIRect horizontally. You can pass null pointers.
+	 * The spacing will be applied between the pTop and pBottom while both stay attached to *this*
+	 *
+	 * @verbatim
+	 * +---------------+
+	 * |+-------------+|
+	 * ||    pTop     ||
+	 * |+-------------+|
+	 * |    *this*     |
+	 * |+-------------+|
+	 * ||   pBottom   ||
+	 * |+-------------+|
+	 * +---------------+
+	 * @endverbatim
 	 *
 	 * @param pTop This rect will end up taking the top half of this CUIRect.
 	 * @param pBottom This rect will end up taking the bottom half of this CUIRect.
 	 * @param Spacing Total size of margin between split rects.
 	 */
 	void HSplitMid(CUIRect *pTop, CUIRect *pBottom, float Spacing = 0.0f) const;
+	/**
+	 * Splits 3 CUIRect inside *this* CUIRect horizontally. You can pass null pointers.
+	 * The spacing will be applied between the pTop, pMiddle, pBottom and also the *this*
+	 *
+	 * @verbatim
+	 * +---------------+
+	 * |    *this*     |
+	 * |+-------------+|
+	 * ||    pTop     ||
+	 * |+-------------+|
+	 * |               |
+	 * |+-------------+|
+	 * ||   pMiddle   ||
+	 * |+-------------+|
+	 * |               |
+	 * |+-------------+|
+	 * ||   pBottom   ||
+	 * |+-------------+|
+	 * |               |
+	 * +---------------+
+	 * @endverbatim
+	 *
+	 * @param pTop This rect will end up taking the top third of this CUIRect.
+	 * @param pMiddle This rect will end up taking the middle third of this CUIRect.
+	 * @param pBottom This rect will end up taking the bottom third of this CUIRect.
+	 * @param Spacing Total size of margin between split rects.
+	 */
+	void HSpaceAround(CUIRect *pTop, CUIRect *pMiddle, CUIRect *pBottom, float Spacing = 0.0f) const;
 	/**
 	 * Splits 2 CUIRect inside *this* CUIRect.
 	 *
@@ -50,12 +91,39 @@ public:
 	void HSplitBottom(float Cut, CUIRect *pTop, CUIRect *pBottom) const;
 	/**
 	 * Splits 2 CUIRect inside *this* CUIRect vertically. You can pass null pointers.
+	 * The spacing will be applied between the pLeft and pRight while both stay attached to *this*
+	 *
+	 * @verbatim
+	 * +--------------------------+
+	 * |+-------+        +-------+|
+	 * || pLeft | *this* | pRight||
+	 * |+-------+        +-------+|
+	 * +--------------------------+
+	 * @endverbatim
 	 *
 	 * @param pLeft This rect will take up the left half of *this* CUIRect.
 	 * @param pRight This rect will take up the right half of *this* CUIRect.
 	 * @param Spacing Total size of margin between split rects.
 	 */
 	void VSplitMid(CUIRect *pLeft, CUIRect *pRight, float Spacing = 0.0f) const;
+	/**
+	 * Splits 3 CUIRect inside *this* CUIRect vertically. You can pass null pointers.
+	 * The spacing will be applied between the pLeft, pMiddle, pRight and also the *this*
+	 *
+	 * @verbatim
+	 * +--------------------------------------------------------------+
+	 * |        +--------+        +--------+        +--------+        |
+	 * | *this* | pLeft  |        | pMiddle|        | pRight |        |
+	 * |        +--------+        +--------+        +--------+        |
+	 * +--------------------------------------------------------------+
+	 * @endverbatim
+	 *
+	 * @param pLeft This rect will take up the left third of *this* CUIRect.
+	 * @param pMiddle This rect will take up the middle third of *this* CUIRect.
+	 * @param pRight This rect will take up the right third of *this* CUIRect.
+	 * @param Spacing Total size of margin between split rects.
+	 */
+	void VSpaceAround(CUIRect *pLeft, CUIRect *pMiddle, CUIRect *pRight, float Spacing = 0.0f) const;
 	/**
 	 * Splits 2 CUIRect inside *this* CUIRect.
 	 *


### PR DESCRIPTION

![tripple_hsplitmid_spacing70](https://github.com/ddnet/ddnet/assets/20344300/b64e56b3-8f1a-46fb-a6d5-24d66d1c0e72)
![tripple_vsplitmid_spacing10](https://github.com/ddnet/ddnet/assets/20344300/f493916c-8f97-40db-a311-e27316c404bc)
![tripple_vsplitmid](https://github.com/ddnet/ddnet/assets/20344300/93f13afb-5f8d-4dff-9c1e-0443c5c1c87a)
![tripple_hsplitmid](https://github.com/ddnet/ddnet/assets/20344300/3bef60c5-6b7e-404d-a14e-37a66e2b4281)


## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
