### PR TITLE
Fix freeze bar not being correct after returning from pause

### DIFF
--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -2263,12 +2263,17 @@ void CCharacter::Pause(bool Pause)
 			ResetHook();
 			GameWorld()->ReleaseHooked(GetPlayer()->GetCid());
 		}
+		m_PausedTick = Server()->Tick();
 	}
 	else
 	{
 		m_Core.m_Vel = vec2(0, 0);
 		GameServer()->m_World.m_Core.m_apCharacters[m_pPlayer->GetCid()] = &m_Core;
 		GameServer()->m_World.InsertEntity(this);
+		if(m_Core.m_FreezeStart > 0 && m_PausedTick >= 0)
+		{
+			m_Core.m_FreezeStart += Server()->Tick() - m_PausedTick;
+		}
 	}
 }
 

--- a/src/game/server/entities/character.h
+++ b/src/game/server/entities/character.h
@@ -104,6 +104,7 @@ private:
 
 	bool m_Alive;
 	bool m_Paused;
+	int m_PausedTick;
 	int m_NeededFaketuning;
 
 	// weapon info


### PR DESCRIPTION
The freezebar would previously be incorrect after returning from pause. The bar would countdown, but at a slower speed. Cherrypicked fix from #6724

Before

https://github.com/ddnet/ddnet/assets/141338449/1416a5bc-f138-4b75-9d5c-76f12670f118


After

https://github.com/ddnet/ddnet/assets/141338449/0480a4bc-f8af-4a6b-9ace-bcee7c676994

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
