### PR TITLE
Enforce UpperCamelCase for local variables

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -77,7 +77,6 @@ Checks: >
   -readability-function-cognitive-complexity,
   -readability-function-size,
   -readability-identifier-length,
-  -readability-identifier-naming,
   -readability-implicit-bool-conversion,
   -readability-isolate-declaration,
   -readability-magic-numbers,
@@ -89,3 +88,19 @@ Checks: >
   performance-*,
   -performance-no-int-to-ptr,
   portability-*,
+
+WarningsAsErrors:
+  readability-identifier-naming,
+
+CheckOptions:
+  - key:             readability-identifier-naming.LocalVariableCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.StaticConstantCase
+    value:           aNy_CasE
+  - key:             readability-identifier-naming.StaticVariableCase
+    value:           aNy_CasE
+  - key:             readability-identifier-naming.LocalConstantCase
+    value:           aNy_CasE
+  - key:             readability-identifier-naming.LocalVariableIgnoredRegexp
+    value:           '^(p|a|s_|FT_|TB_|s_|ul_|v|[xy]i$|[zijklxyhmrgbacwestnduvqf]$|[dmpwsitcf][xy]$|(ch|skel)[0-2]?$|it$|tw$|dt$|th$|ls$|func$|res$|shader$|len$|maxLength$|length$|offset$|offpos$|result$|bg$|sp$|url$|Tickdelta_legacy$|index$|ctxt$|key$|null$|logger$|LAST_MODIFIED$|GfxFsaaSamples_MouseButton$|teleNr$|target$|id$|hit$|hsl[0-2]?$|rgb[0-2]?$|dir$|tmp$|cData$|sub$|ret$|rendered$|(lower|upper)(16|26|24|32)|size$|wSearch$|bAlreadyHit$|isWeaponCollide$|zerochar$|dist$|sound$|match$|best_skin$|best_matches$|m_aClient$|matches$|nohook$|through_cut$|btn$|savedLayers$|l[hw]$|evilz$|sec$|min$|to2$|delay$|m_TileF?Index$|mode$|maxModes$|numModes$|iLogLength$|[xy]Fract$|[xy]Int$|imgg[xy]$|skip$|localPlayer$|fdratio$|[rgbat][0-2]$|[xy][0-3]$|x[rl]$).*'
+

--- a/src/base/.clang-tidy
+++ b/src/base/.clang-tidy
@@ -1,0 +1,1 @@
+Checks: '-readability-identifier-naming'

--- a/src/tools/.clang-tidy
+++ b/src/tools/.clang-tidy
@@ -1,0 +1,1 @@
+Checks: '-readability-identifier-naming'


### PR DESCRIPTION
For now it is only checking local variables. There are also member/private/protected/parameter/global and so on variables. There are a lot of exceptions to show 0 warnings on the current code base which has a bunch of style violations when it comes to short variables. And also the hungarian like teeworlds variable prefixes ``p*`` ``a*`` etc are violating strict camel case. Clang tidy has support for hungarian notation. And it is also quite configurable. You can choose your own prefix for all types. But I did not manage to reorder the prefixes or remove prefixes. So it would try to prefix all integeres with ``i`` and all bools with ``b`` and use ``pa_`` instead of ``ap_``. So I went with strict camel case instead and allowed our hungarian prefixes and the short variables.

This would close https://github.com/ddnet/ddnet/pull/8141 if also more variable types are added. I wanted to get feedback first if this approach will be accepted. Because it is quite time consuming to iterate with this. The regex could also be simplified a lot if we remove usages of ``url``, ``len``, ``dx`` in the code and fix them up to ``Url``, ``Len`` and ``Dx`` or we could also ignore the camel case check for short variables all together.

Clang format does not support such sophisticated styling conventions. Only clang tidy does. But clang tidy also has a --fix flag so that should be fine. It is just way slower because it does all the checks.

Here is how the CI would fail if for example a local variable ``foo`` would be introduced.
```
-- Build files have been written to: /home/chiller/Desktop/git/ddnet/build-tidy
[3/4] Building CXX object CMakeFiles/game-client.dir/src/engine/client/client.cpp.o
FAILED: CMakeFiles/game-client.dir/src/engine/client/client.cpp.o 
/usr/bin/cmake -E __run_co_compile --launcher=ccache --tidy="clang-tidy;-warnings-as-errors=*;--extra-arg-before=--driver-mode=g++" --source=/home/chiller/Desktop/git/ddnet/src/engine/client/client.cpp -- /usr/bin/c++ -DCONF_BACKEND_VULKAN -DCONF_DEBUG -DCONF_INFORM_UPDATE -DCONF_OPENSSL -DCONF_VIDEORECORDER -DCONF_WAVPACK_CLOSE_FILE -DCONF_WAVPACK_OPEN_FILE_INPUT_EX -DGAME_RELEASE_VERSION=\"18.1\" -DGLEW_STATIC -I/home/chiller/Desktop/git/ddnet/build-tidy/src -I/home/chiller/Desktop/git/ddnet/src -I/home/chiller/Desktop/git/ddnet/src/rust-bridge -isystem /usr/include/freetype2 -isystem /usr/include/opus -isystem /usr/include/SDL2 -isystem /usr/include/wavpack -isystem /usr/include/gdk-pixbuf-2.0 -isystem /usr/include/glib-2.0 -isystem /usr/lib/x86_64-linux-gnu/glib-2.0/include -isystem /usr/include/libpng16 -isystem /usr/include/libmount -isystem /usr/include/blkid -g -fdiagnostics-color=always -fstack-protector-strong -fno-exceptions -Wall -Wextra -Wno-psabi -Wno-unused-parameter -Wno-missing-field-initializers -Wformat=2 -Wno-nullability-completeness -Wduplicated-cond -Wduplicated-branches -Wlogical-op -Wrestrict -Wshadow=global -Wsuggest-override -Wclass-memaccess -std=c++17 -MD -MT CMakeFiles/game-client.dir/src/engine/client/client.cpp.o -MF CMakeFiles/game-client.dir/src/engine/client/client.cpp.o.d -o CMakeFiles/game-client.dir/src/engine/client/client.cpp.o -c /home/chiller/Desktop/git/ddnet/src/engine/client/client.cpp
/home/chiller/Desktop/git/ddnet/src/engine/client/client.cpp:3766:6: error: invalid case style for local variable 'foo' [readability-identifier-naming,-warnings-as-errors]
 3766 |         int foo = 2;
      |             ^~~
      |             Foo
 3767 |         dbg_msg("foo", "foo=%d", foo);
      |                                  ~~~
      |                                  Foo
357 warnings generated.
Suppressed 356 warnings (344 in non-user code, 12 with check filters).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
1 warning treated as error
ninja: build stopped: cannot make progress due to previous errors.
```
