### PR TITLE
Make `parse_drmingw.sh` script also useable on Windows with MSYS2

### DIFF
--- a/scripts/parse_drmingw.sh
+++ b/scripts/parse_drmingw.sh
@@ -30,7 +30,7 @@ if [ "$TMP_OFFSET" != "0" ]; then
 	echo "Module offset: 0x$TMP_OFFSET"
 fi
 
-ADDR_BASE=$(winedump -f "$1" | grep -E -o "image base[ ]*0x[0-9A-Fa-f]*" | grep -E -o "0x[0-9A-Fa-f]+" | tail -1)
+ADDR_BASE=0x$(objdump -x "$1" | grep -E -o "^ImageBase\s+[0-9A-Fa-f]+$" | grep -E -o "[0-9A-Fa-f]+$")
 echo "Image base: $ADDR_BASE"
 
 ADDR_PC_REGEX='[0-9A-Fa-f]+ [0-9A-Fa-f]+ [0-9A-Fa-f]+ [0-9A-Fa-f]+'


### PR DESCRIPTION
Use `objdump` instead of `winedump` to determine the image base address of the executable file, as `winedump` is not easily available on Windows.

It should be enough to install the `binutils` package (containing `addr2line` and `objdump`) from a package manager to use the script now.

## Checklist

- [X] Tested the change (Ubuntu, Windows with MSYS2)
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
