### PR TITLE
Refresh air jumps after teleporting

### DIFF
--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -1605,6 +1605,7 @@ void CGameContext::ConTeleTo(IConsole::IResult *pResult, void *pUserData)
 
 	// Teleport tee
 	pSelf->Teleport(pCallingCharacter, Pos);
+	pCallingCharacter->ResetJumps();
 	pCallingCharacter->UnFreeze();
 	pCallingCharacter->ResetVelocity();
 	pCallingPlayer->m_LastTeleTee.Save(pCallingCharacter);
@@ -1682,6 +1683,7 @@ void CGameContext::ConTeleXY(IConsole::IResult *pResult, void *pUserData)
 
 	// Teleport tee
 	pSelf->Teleport(pCallingCharacter, Pos);
+	pCallingCharacter->ResetJumps();
 	pCallingCharacter->UnFreeze();
 	pCallingCharacter->ResetVelocity();
 	pCallingPlayer->m_LastTeleTee.Save(pCallingCharacter);
@@ -1734,6 +1736,7 @@ void CGameContext::ConTeleCursor(IConsole::IResult *pResult, void *pUserData)
 		Pos = pChrTo->m_Pos;
 	}
 	pSelf->Teleport(pChr, Pos);
+	pChr->ResetJumps();
 	pChr->UnFreeze();
 	pChr->ResetVelocity();
 	pPlayer->m_LastTeleTee.Save(pChr);

--- a/src/game/server/ddracecommands.cpp
+++ b/src/game/server/ddracecommands.cpp
@@ -413,6 +413,7 @@ void CGameContext::ConTeleport(IConsole::IResult *pResult, void *pUserData)
 			Pos += vec2(pChr->Core()->m_Input.m_TargetX, pChr->Core()->m_Input.m_TargetY);
 		}
 		pSelf->Teleport(pChr, Pos);
+		pChr->ResetJumps();
 		pChr->UnFreeze();
 		pChr->SetVelocity(vec2(0, 0));
 	}

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -2197,6 +2197,12 @@ bool CCharacter::UnFreeze()
 	return false;
 }
 
+void CCharacter::ResetJumps()
+{
+	m_Core.m_JumpedTotal = 0;
+	m_Core.m_Jumped = 0;
+}
+
 void CCharacter::GiveWeapon(int Weapon, bool Remove)
 {
 	if(Weapon == WEAPON_NINJA)

--- a/src/game/server/entities/character.h
+++ b/src/game/server/entities/character.h
@@ -185,6 +185,7 @@ public:
 	bool UnFreeze();
 	void GiveAllWeapons();
 	void ResetPickups();
+	void ResetJumps();
 	int m_DDRaceState;
 	int Team();
 	bool CanCollide(int ClientId);


### PR DESCRIPTION
I have honestly no idea if thats the right approach and I'm uncertain about what other adjustments might be necessary.

I'm currently in a hotel on a rainy day, and I decided to test a map for fun. I noticed a minor inconvenience: the only way to regain the double jump (after it's been used up) is by landing or using the /r command. However, using /r isn't always ideal, especially if a platform is far away. Take a look at the videos for more details.


https://github.com/ddnet/ddnet/assets/60477660/fc129c9e-5c54-4ae5-9ae7-01210dcb7a5b



https://github.com/ddnet/ddnet/assets/60477660/23349624-94ab-47b9-9e60-158b5645c5a7


## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
