### PR TITLE
Fix rcon username not reset when disconnecting while connecting

### DIFF
--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -1498,7 +1498,7 @@ void CGameConsole::OnInit()
 
 void CGameConsole::OnStateChange(int NewState, int OldState)
 {
-	if(OldState == IClient::STATE_ONLINE && NewState < IClient::STATE_LOADING)
+	if(OldState <= IClient::STATE_ONLINE && NewState == IClient::STATE_OFFLINE)
 	{
 		m_RemoteConsole.m_UserGot = false;
 		m_RemoteConsole.m_aUser[0] = '\0';


### PR DESCRIPTION
The rcon username requirement was not reset correctly when disconnecting from a server while connecting/loading, at which point the `NETMSG_RCONTYPE` message has already been received.

Closes #4170.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
