### PR TITLE
Reset tuning of dummy and main when disconnecting

### DIFF
--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -538,6 +538,8 @@ void CGameClient::OnReset()
 
 	m_aReceivedTuning[0] = false;
 	m_aReceivedTuning[1] = false;
+	m_aTuning[0] = CTuningParams();
+	m_aTuning[1] = CTuningParams();
 
 	InvalidateSnapshot();
 
@@ -553,7 +555,6 @@ void CGameClient::OnReset()
 	m_LastRoundStartTick = -1;
 	m_LastFlagCarrierRed = -4;
 	m_LastFlagCarrierBlue = -4;
-	m_aTuning[g_Config.m_ClDummy] = CTuningParams();
 
 	m_NextChangeInfo = 0;
 


### PR DESCRIPTION
Instead of only resetting the tuning for either one which is currently active.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
