### PR TITLE
Improve performance when rendering menus

### DIFF
--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -1166,6 +1166,9 @@ void CChat::OnPrepareLines(float y)
 
 void CChat::OnRender()
 {
+	if(Client()->State() != IClient::STATE_ONLINE && Client()->State() != IClient::STATE_DEMOPLAYBACK)
+		return;
+
 	// send pending chat messages
 	if(m_PendingChatCounter > 0 && m_LastChatSend + time_freq() < time())
 	{

--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -360,6 +360,9 @@ int CControls::SnapInput(int *pData)
 
 void CControls::OnRender()
 {
+	if(Client()->State() != IClient::STATE_ONLINE && Client()->State() != IClient::STATE_DEMOPLAYBACK)
+		return;
+
 	if(g_Config.m_ClAutoswitchWeaponsOutOfAmmo && !GameClient()->m_GameInfo.m_UnlimitedAmmo && m_pClient->m_Snap.m_pLocalCharacter)
 	{
 		// Keep track of ammo count, we know weapon ammo only when we switch to that weapon, this is tracked on server and protocol does not track that

--- a/src/game/client/components/damageind.cpp
+++ b/src/game/client/components/damageind.cpp
@@ -49,6 +49,9 @@ void CDamageInd::Create(vec2 Pos, vec2 Dir, float Alpha)
 
 void CDamageInd::OnRender()
 {
+	if(Client()->State() != IClient::STATE_ONLINE && Client()->State() != IClient::STATE_DEMOPLAYBACK)
+		return;
+
 	Graphics()->TextureSet(GameClient()->m_GameSkin.m_aSpriteStars[0]);
 	static float s_LastLocalTime = LocalTime();
 	for(int i = 0; i < m_NumItems;)

--- a/src/game/client/components/debughud.cpp
+++ b/src/game/client/components/debughud.cpp
@@ -261,6 +261,9 @@ void CDebugHud::RenderHint()
 
 void CDebugHud::OnRender()
 {
+	if(Client()->State() != IClient::STATE_ONLINE && Client()->State() != IClient::STATE_DEMOPLAYBACK)
+		return;
+
 	RenderTuning();
 	RenderNetCorrections();
 	RenderHint();

--- a/src/game/client/components/emoticon.cpp
+++ b/src/game/client/components/emoticon.cpp
@@ -60,6 +60,9 @@ bool CEmoticon::OnCursorMove(float x, float y, IInput::ECursorType CursorType)
 
 void CEmoticon::OnRender()
 {
+	if(Client()->State() != IClient::STATE_ONLINE && Client()->State() != IClient::STATE_DEMOPLAYBACK)
+		return;
+
 	if(!m_Active)
 	{
 		if(m_WasActive && m_SelectedEmote != -1)

--- a/src/game/client/components/freezebars.cpp
+++ b/src/game/client/components/freezebars.cpp
@@ -196,6 +196,9 @@ inline bool CFreezeBars::IsPlayerInfoAvailable(int ClientId) const
 
 void CFreezeBars::OnRender()
 {
+	if(Client()->State() != IClient::STATE_ONLINE && Client()->State() != IClient::STATE_DEMOPLAYBACK)
+		return;
+
 	if(!g_Config.m_ClShowFreezeBars)
 	{
 		return;

--- a/src/game/client/components/ghost.cpp
+++ b/src/game/client/components/ghost.cpp
@@ -311,6 +311,9 @@ void CGhost::OnNewPredictedSnapshot()
 
 void CGhost::OnRender()
 {
+	if(Client()->State() != IClient::STATE_ONLINE && Client()->State() != IClient::STATE_DEMOPLAYBACK)
+		return;
+
 	// Play the ghost
 	if(!m_Rendering || !g_Config.m_ClRaceShowGhost)
 		return;

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -1397,6 +1397,9 @@ void CHud::RenderLocalTime(float x)
 
 void CHud::OnRender()
 {
+	if(Client()->State() != IClient::STATE_ONLINE && Client()->State() != IClient::STATE_DEMOPLAYBACK)
+		return;
+
 	if(!m_pClient->m_Snap.m_pGameInfoObj)
 		return;
 

--- a/src/game/client/components/infomessages.cpp
+++ b/src/game/client/components/infomessages.cpp
@@ -420,6 +420,9 @@ void CInfoMessages::RenderFinishMsg(const CInfoMsg &InfoMsg, float x, float y)
 
 void CInfoMessages::OnRender()
 {
+	if(Client()->State() != IClient::STATE_ONLINE && Client()->State() != IClient::STATE_DEMOPLAYBACK)
+		return;
+
 	const float Height = 1.5f * 400.0f * 3.0f;
 	const float Width = Height * Graphics()->ScreenAspect();
 

--- a/src/game/client/components/motd.cpp
+++ b/src/game/client/components/motd.cpp
@@ -43,6 +43,9 @@ void CMotd::OnWindowResize()
 
 void CMotd::OnRender()
 {
+	if(Client()->State() != IClient::STATE_ONLINE && Client()->State() != IClient::STATE_DEMOPLAYBACK)
+		return;
+
 	if(!IsActive())
 		return;
 

--- a/src/game/client/components/nameplates.cpp
+++ b/src/game/client/components/nameplates.cpp
@@ -289,6 +289,9 @@ void CNamePlates::RenderNameplatePos(vec2 Position, const CNetObj_PlayerInfo *pP
 
 void CNamePlates::OnRender()
 {
+	if(Client()->State() != IClient::STATE_ONLINE && Client()->State() != IClient::STATE_DEMOPLAYBACK)
+		return;
+
 	int ShowDirection = g_Config.m_ClShowDirection;
 #if defined(CONF_VIDEORECORDER)
 	if(IVideo::Current())

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -754,6 +754,9 @@ inline bool CPlayers::IsPlayerInfoAvailable(int ClientId) const
 
 void CPlayers::OnRender()
 {
+	if(Client()->State() != IClient::STATE_ONLINE && Client()->State() != IClient::STATE_DEMOPLAYBACK)
+		return;
+
 	CTeeRenderInfo aRenderInfo[MAX_CLIENTS];
 
 	// update RenderInfo for ninja

--- a/src/game/client/components/scoreboard.cpp
+++ b/src/game/client/components/scoreboard.cpp
@@ -568,6 +568,9 @@ void CScoreboard::RenderRecordingNotification(float x)
 
 void CScoreboard::OnRender()
 {
+	if(Client()->State() != IClient::STATE_ONLINE && Client()->State() != IClient::STATE_DEMOPLAYBACK)
+		return;
+
 	if(!Active())
 		return;
 

--- a/src/game/client/components/spectator.cpp
+++ b/src/game/client/components/spectator.cpp
@@ -194,6 +194,9 @@ void CSpectator::OnRelease()
 
 void CSpectator::OnRender()
 {
+	if(Client()->State() != IClient::STATE_ONLINE && Client()->State() != IClient::STATE_DEMOPLAYBACK)
+		return;
+
 	if(!GameClient()->m_MultiViewActivated && m_MultiViewActivateDelay != 0.0f)
 	{
 		if(m_MultiViewActivateDelay <= Client()->LocalTime())

--- a/src/game/client/components/statboard.cpp
+++ b/src/game/client/components/statboard.cpp
@@ -122,6 +122,9 @@ void CStatboard::OnMessage(int MsgType, void *pRawMsg)
 
 void CStatboard::OnRender()
 {
+	if(Client()->State() != IClient::STATE_ONLINE && Client()->State() != IClient::STATE_DEMOPLAYBACK)
+		return;
+
 	if((g_Config.m_ClAutoStatboardScreenshot || g_Config.m_ClAutoCSV) && Client()->State() != IClient::STATE_DEMOPLAYBACK)
 	{
 		if(m_ScreenshotTime < 0 && m_pClient->m_Snap.m_pGameInfoObj && m_pClient->m_Snap.m_pGameInfoObj->m_GameStateFlags & GAMESTATEFLAG_GAMEOVER)


### PR DESCRIPTION
Skip rendering various client components (players, ghosts, nameplates, HUD etc.) while not ingame to improve performance. This increases FPS when rendering the start menu by around 300-400 both in debug and release builds.

This also fixes potential crashes when components using the map data where rendered while the client is loading a new map.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
