### PR TITLE
Show Discord activity when offline

### DIFF
--- a/src/engine/client/discord.cpp
+++ b/src/engine/client/discord.cpp
@@ -55,6 +55,7 @@ public:
 		}
 
 		m_pActivityManager = m_pCore->get_activity_manager(m_pCore);
+		ClearGameInfo();
 		return false;
 	}
 	void Update() override
@@ -63,7 +64,13 @@ public:
 	}
 	void ClearGameInfo() override
 	{
-		m_pActivityManager->clear_activity(m_pActivityManager, 0, 0);
+		DiscordActivity Activity;
+		mem_zero(&Activity, sizeof(DiscordActivity));
+		str_copy(Activity.assets.large_image, "ddnet_logo", sizeof(Activity.assets.large_image));
+		str_copy(Activity.assets.large_text, "DDNet logo", sizeof(Activity.assets.large_text));
+		Activity.timestamps.start = time_timestamp();
+		str_copy(Activity.details, "Offline", sizeof(Activity.details));
+		m_pActivityManager->update_activity(m_pActivityManager, &Activity, 0, 0);
 	}
 	void SetGameInfo(const NETADDR &ServerAddr, const char *pMapName, bool AnnounceAddr) override
 	{
@@ -72,7 +79,8 @@ public:
 		str_copy(Activity.assets.large_image, "ddnet_logo", sizeof(Activity.assets.large_image));
 		str_copy(Activity.assets.large_text, "DDNet logo", sizeof(Activity.assets.large_text));
 		Activity.timestamps.start = time_timestamp();
-		str_copy(Activity.details, pMapName, sizeof(Activity.details));
+		str_copy(Activity.details, "Online", sizeof(Activity.details));
+		str_copy(Activity.state, pMapName, sizeof(Activity.state));
 		m_pActivityManager->update_activity(m_pActivityManager, &Activity, 0, 0);
 	}
 };


### PR DESCRIPTION
There seems to be an issue with `clear_activity` in the version of discord game sdk that we are using: `ResponseError { code: InvalidPayload, message: "child \"activity\" fails because [child \"supported_platforms\" fails because [\"supported_platforms\" must contain at least 1 items]]" }`

closes #8180 

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
