### PR TITLE
Remove demo snap buffer and mem copy

### DIFF
--- a/src/engine/client.h
+++ b/src/engine/client.h
@@ -11,6 +11,7 @@
 #include <game/generated/protocol.h>
 
 #include <engine/friends.h>
+#include <engine/shared/snapshot.h>
 #include <functional>
 
 struct SWarning;
@@ -346,7 +347,7 @@ public:
 	virtual CNetObjHandler *GetNetObjHandler() = 0;
 };
 
-void SnapshotRemoveExtraProjectileInfo(unsigned char *pData);
+void SnapshotRemoveExtraProjectileInfo(CSnapshot *pSnap);
 
 extern IGameClient *CreateGameClient();
 #endif

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -1821,9 +1821,7 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket, int Conn, bool Dummy)
 					if(!Dummy)
 					{
 						// for antiping: if the projectile netobjects from the server contains extra data, this is removed and the original content restored before recording demo
-						unsigned char aExtraInfoRemoved[CSnapshot::MAX_SIZE];
-						mem_copy(aExtraInfoRemoved, pTmpBuffer3, SnapSize);
-						SnapshotRemoveExtraProjectileInfo(aExtraInfoRemoved);
+						SnapshotRemoveExtraProjectileInfo(pTmpBuffer3);
 
 						// add snapshot to demo
 						for(auto &DemoRecorder : m_aDemoRecorder)
@@ -1831,7 +1829,7 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket, int Conn, bool Dummy)
 							if(DemoRecorder.IsRecording())
 							{
 								// write snapshot
-								DemoRecorder.RecordSnapshot(GameTick, aExtraInfoRemoved, SnapSize);
+								DemoRecorder.RecordSnapshot(GameTick, pTmpBuffer3, SnapSize);
 							}
 						}
 					}

--- a/src/game/client/projectile_data.cpp
+++ b/src/game/client/projectile_data.cpp
@@ -104,9 +104,8 @@ CProjectileData ExtractProjectileInfoDDNet(const CNetObj_DDNetProjectile *pProj)
 	return Result;
 }
 
-void SnapshotRemoveExtraProjectileInfo(unsigned char *pData)
+void SnapshotRemoveExtraProjectileInfo(CSnapshot *pSnap)
 {
-	CSnapshot *pSnap = (CSnapshot *)pData;
 	for(int Index = 0; Index < pSnap->NumItems(); Index++)
 	{
 		const CSnapshotItem *pItem = pSnap->GetItem(Index);


### PR DESCRIPTION
Adding the snap to the demo is the last usage of `pTmpBuffer3` all prior usages of it copy the data if needed.
So we can edit it in place. No need to copy it into a new buffer.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
