### PR TITLE
Update gtest to current main branch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -764,7 +764,7 @@ endif()
 ########################################################################
 
 if(NOT(GTEST_FOUND) AND DOWNLOAD_GTEST)
-  set(DDNET_GTEST_VERSION v1.13.0)
+  set(DDNET_GTEST_VERSION 3d73dee972d0db344bda9b659836612aba6a3564)
   configure_file(cmake/Download_GTest_CMakeLists.txt.in googletest-download/CMakeLists.txt)
   execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
     RESULT_VARIABLE result


### PR DESCRIPTION
I just ran into https://github.com/google/googletest/issues/4206 and realized that it is fixed on the main branch and google also recommends to use the main branch.

From their readme

> GoogleTest now follows the Abseil Live at Head philosophy. We
> recommend updating to the latest commit in the main branch as often as
> possible. We do publish occasional semantic versions, tagged with
> v${major}.${minor}.${patch} (e.g. v1.14.0).

https://github.com/google/googletest/blob/3d73dee972d0db344bda9b659836612aba6a3564/README.md#live-at-head

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
