### PR TITLE
Fix demo player hotkeys not working when menu is inactive, fix duplicated rendering of popup menus in demo player

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -2176,10 +2176,15 @@ void CMenus::OnRender()
 	if(!IsActive())
 	{
 		if(Ui()->ConsumeHotkey(CUi::HOTKEY_ESCAPE))
+		{
 			SetActive(true);
-		Ui()->FinishCheck();
-		Ui()->ClearHotkeys();
-		return;
+		}
+		else if(Client()->State() != IClient::STATE_DEMOPLAYBACK)
+		{
+			Ui()->FinishCheck();
+			Ui()->ClearHotkeys();
+			return;
+		}
 	}
 
 	UpdateColors();
@@ -2187,7 +2192,11 @@ void CMenus::OnRender()
 	Ui()->Update();
 
 	Render();
-	RenderTools()->RenderCursor(Ui()->MousePos(), 24.0f);
+
+	if(IsActive())
+	{
+		RenderTools()->RenderCursor(Ui()->MousePos(), 24.0f);
+	}
 
 	// render debug information
 	if(g_Config.m_Debug)

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -750,8 +750,6 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 	{
 		RenderDemoPlayerSliceSavePopup(MainView);
 	}
-
-	Ui()->RenderPopupMenus();
 }
 
 void CMenus::RenderDemoPlayerSliceSavePopup(CUIRect MainView)


### PR DESCRIPTION
The demo player needs to be rendered also when the menu is inactive, to handle the hotkeys for controlling the demo player and to render the play/pause and speed indicators.

Closes #8208.

The popup menus are already rendered in the `CMenus::Render` function, also for the demo player since #8156.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
