### PR TITLE
Fix bug where certain tiles would not work in `Game tiles` menu

### DIFF
--- a/src/game/editor/mapitems/layer_tiles.cpp
+++ b/src/game/editor/mapitems/layer_tiles.cpp
@@ -708,8 +708,8 @@ CUi::EPopupMenuFunctionResult CLayerTiles::RenderProperties(CUIRect *pToolBox)
 		static int s_GameTilesButton = 0;
 		if(m_pEditor->DoButton_Editor(&s_GameTilesButton, "Game tiles", 0, &Button, 0, "Constructs game tiles from this layer"))
 			m_pEditor->PopupSelectGametileOpInvoke(m_pEditor->Ui()->MouseX(), m_pEditor->Ui()->MouseY());
-		int Selected = m_pEditor->PopupSelectGameTileOpResult();
-		int Result = -1;
+		const int Selected = m_pEditor->PopupSelectGameTileOpResult();
+		int Result = Selected;
 		switch(Selected)
 		{
 		case 4:


### PR DESCRIPTION
Fixed bug where these first buttons wouldn't place any tiles. Most likely caused by #8136

![image](https://github.com/ddnet/ddnet/assets/141338449/b020a97a-eddb-454c-bc47-7fbaab79fab2)
## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
