### PR TITLE
Fix alignment of labels in friends list

### DIFF
--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1479,12 +1479,11 @@ void CMenus::RenderServerbrowserFriends(CUIRect View)
 				Rect.HSplitTop(11.0f + 10.0f, &Rect, nullptr);
 
 				// tee
+				CUIRect Skin;
+				Rect.VSplitLeft(Rect.h, &Skin, &Rect);
+				Rect.VSplitLeft(2.0f, nullptr, &Rect);
 				if(Friend.Skin()[0] != '\0')
 				{
-					CUIRect Skin;
-					Rect.VSplitLeft(Rect.h, &Skin, &Rect);
-					Rect.VSplitLeft(2.0f, nullptr, &Rect);
-
 					const CTeeRenderInfo TeeInfo = GetTeeRenderInfo(vec2(Skin.w, Skin.h), Friend.Skin(), Friend.CustomSkinColors(), Friend.CustomSkinColorBody(), Friend.CustomSkinColorFeet());
 					const CAnimState *pIdleState = CAnimState::GetIdle();
 					vec2 OffsetToMid;


### PR DESCRIPTION
I'm not sure if this was intended but no variation makes it easier to read.

Before:
![before](https://github.com/ddnet/ddnet/assets/121701317/8e9f8f7e-7929-4f5c-a431-dad870634503)

After:
![after](https://github.com/ddnet/ddnet/assets/121701317/a6fa7352-3561-4371-95b2-5f7275461110)

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
