### PR TITLE
Remove unnecessary client component variables and setters

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -779,7 +779,7 @@ void CMenus::RenderLoading(const char *pCaption, const char *pContent, int Incre
 
 	Ui()->MapScreen();
 
-	if(!RenderMenuBackgroundMap || !m_pBackground->Render())
+	if(!RenderMenuBackgroundMap || !GameClient()->m_MenuBackground.Render())
 	{
 		RenderBackground();
 	}
@@ -811,7 +811,7 @@ void CMenus::RenderLoading(const char *pCaption, const char *pContent, int Incre
 
 void CMenus::RenderNews(CUIRect MainView)
 {
-	m_pBackground->ChangePosition(CMenuBackground::POS_NEWS);
+	GameClient()->m_MenuBackground.ChangePosition(CMenuBackground::POS_NEWS);
 
 	g_Config.m_UiUnreadNews = false;
 
@@ -1069,7 +1069,7 @@ void CMenus::Render()
 	}
 	else
 	{
-		if(!m_pBackground->Render())
+		if(!GameClient()->m_MenuBackground.Render())
 		{
 			RenderBackground();
 		}
@@ -1977,7 +1977,7 @@ void CMenus::PopupConfirmDemoReplaceVideo()
 
 void CMenus::RenderThemeSelection(CUIRect MainView)
 {
-	const std::vector<CTheme> &vThemes = m_pBackground->GetThemes();
+	const std::vector<CTheme> &vThemes = GameClient()->m_MenuBackground.GetThemes();
 
 	int SelectedTheme = -1;
 	for(int i = 0; i < (int)vThemes.size(); i++)
@@ -2043,7 +2043,7 @@ void CMenus::RenderThemeSelection(CUIRect MainView)
 	{
 		const CTheme &Theme = vThemes[SelectedTheme];
 		str_copy(g_Config.m_ClMenuMap, Theme.m_Name.c_str());
-		m_pBackground->LoadMenuBackground(Theme.m_HasDay, Theme.m_HasNight);
+		GameClient()->m_MenuBackground.LoadMenuBackground(Theme.m_HasDay, Theme.m_HasNight);
 	}
 }
 

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -591,12 +591,8 @@ protected:
 
 	bool CheckHotKey(int Key) const;
 
-	class CMenuBackground *m_pBackground;
-
 public:
 	void RenderBackground();
-
-	void SetMenuBackground(class CMenuBackground *pBackground) { m_pBackground = pBackground; }
 
 	static CMenusKeyBinder m_Binder;
 

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1712,20 +1712,20 @@ void CMenus::RenderServerbrowser(CUIRect MainView)
 	switch(g_Config.m_UiPage)
 	{
 	case PAGE_INTERNET:
-		m_pBackground->ChangePosition(CMenuBackground::POS_BROWSER_INTERNET);
+		GameClient()->m_MenuBackground.ChangePosition(CMenuBackground::POS_BROWSER_INTERNET);
 		break;
 	case PAGE_LAN:
-		m_pBackground->ChangePosition(CMenuBackground::POS_BROWSER_LAN);
+		GameClient()->m_MenuBackground.ChangePosition(CMenuBackground::POS_BROWSER_LAN);
 		break;
 	case PAGE_FAVORITES:
-		m_pBackground->ChangePosition(CMenuBackground::POS_BROWSER_FAVORITES);
+		GameClient()->m_MenuBackground.ChangePosition(CMenuBackground::POS_BROWSER_FAVORITES);
 		break;
 	case PAGE_FAVORITE_COMMUNITY_1:
 	case PAGE_FAVORITE_COMMUNITY_2:
 	case PAGE_FAVORITE_COMMUNITY_3:
 	case PAGE_FAVORITE_COMMUNITY_4:
 	case PAGE_FAVORITE_COMMUNITY_5:
-		m_pBackground->ChangePosition(g_Config.m_UiPage - PAGE_FAVORITE_COMMUNITY_1 + CMenuBackground::POS_BROWSER_CUSTOM0);
+		GameClient()->m_MenuBackground.ChangePosition(g_Config.m_UiPage - PAGE_FAVORITE_COMMUNITY_1 + CMenuBackground::POS_BROWSER_CUSTOM0);
 		break;
 	default:
 		dbg_assert(false, "ui_page invalid for RenderServerbrowser");

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -1058,7 +1058,7 @@ void CMenus::FetchAllHeaders()
 
 void CMenus::RenderDemoBrowser(CUIRect MainView)
 {
-	m_pBackground->ChangePosition(CMenuBackground::POS_DEMOS);
+	GameClient()->m_MenuBackground.ChangePosition(CMenuBackground::POS_DEMOS);
 
 	CUIRect ListView, DetailsView, ButtonsView;
 	MainView.Draw(ms_ColorTabbarActive, IGraphics::CORNER_B, 10.0f);

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -2058,52 +2058,52 @@ void CMenus::RenderSettings(CUIRect MainView)
 
 	if(g_Config.m_UiSettingsPage == SETTINGS_LANGUAGE)
 	{
-		m_pBackground->ChangePosition(CMenuBackground::POS_SETTINGS_LANGUAGE);
+		GameClient()->m_MenuBackground.ChangePosition(CMenuBackground::POS_SETTINGS_LANGUAGE);
 		RenderLanguageSelection(MainView);
 	}
 	else if(g_Config.m_UiSettingsPage == SETTINGS_GENERAL)
 	{
-		m_pBackground->ChangePosition(CMenuBackground::POS_SETTINGS_GENERAL);
+		GameClient()->m_MenuBackground.ChangePosition(CMenuBackground::POS_SETTINGS_GENERAL);
 		RenderSettingsGeneral(MainView);
 	}
 	else if(g_Config.m_UiSettingsPage == SETTINGS_PLAYER)
 	{
-		m_pBackground->ChangePosition(CMenuBackground::POS_SETTINGS_PLAYER);
+		GameClient()->m_MenuBackground.ChangePosition(CMenuBackground::POS_SETTINGS_PLAYER);
 		RenderSettingsPlayer(MainView);
 	}
 	else if(g_Config.m_UiSettingsPage == SETTINGS_TEE)
 	{
-		m_pBackground->ChangePosition(CMenuBackground::POS_SETTINGS_TEE);
+		GameClient()->m_MenuBackground.ChangePosition(CMenuBackground::POS_SETTINGS_TEE);
 		RenderSettingsTee(MainView);
 	}
 	else if(g_Config.m_UiSettingsPage == SETTINGS_APPEARANCE)
 	{
-		m_pBackground->ChangePosition(CMenuBackground::POS_SETTINGS_APPEARANCE);
+		GameClient()->m_MenuBackground.ChangePosition(CMenuBackground::POS_SETTINGS_APPEARANCE);
 		RenderSettingsAppearance(MainView);
 	}
 	else if(g_Config.m_UiSettingsPage == SETTINGS_CONTROLS)
 	{
-		m_pBackground->ChangePosition(CMenuBackground::POS_SETTINGS_CONTROLS);
+		GameClient()->m_MenuBackground.ChangePosition(CMenuBackground::POS_SETTINGS_CONTROLS);
 		RenderSettingsControls(MainView);
 	}
 	else if(g_Config.m_UiSettingsPage == SETTINGS_GRAPHICS)
 	{
-		m_pBackground->ChangePosition(CMenuBackground::POS_SETTINGS_GRAPHICS);
+		GameClient()->m_MenuBackground.ChangePosition(CMenuBackground::POS_SETTINGS_GRAPHICS);
 		RenderSettingsGraphics(MainView);
 	}
 	else if(g_Config.m_UiSettingsPage == SETTINGS_SOUND)
 	{
-		m_pBackground->ChangePosition(CMenuBackground::POS_SETTINGS_SOUND);
+		GameClient()->m_MenuBackground.ChangePosition(CMenuBackground::POS_SETTINGS_SOUND);
 		RenderSettingsSound(MainView);
 	}
 	else if(g_Config.m_UiSettingsPage == SETTINGS_DDNET)
 	{
-		m_pBackground->ChangePosition(CMenuBackground::POS_SETTINGS_DDNET);
+		GameClient()->m_MenuBackground.ChangePosition(CMenuBackground::POS_SETTINGS_DDNET);
 		RenderSettingsDDNet(MainView);
 	}
 	else if(g_Config.m_UiSettingsPage == SETTINGS_ASSETS)
 	{
-		m_pBackground->ChangePosition(CMenuBackground::POS_SETTINGS_ASSETS);
+		GameClient()->m_MenuBackground.ChangePosition(CMenuBackground::POS_SETTINGS_ASSETS);
 		RenderSettingsCustom(MainView);
 	}
 	else

--- a/src/game/client/components/menus_start.cpp
+++ b/src/game/client/components/menus_start.cpp
@@ -19,7 +19,7 @@
 
 void CMenus::RenderStartMenu(CUIRect MainView)
 {
-	m_pBackground->ChangePosition(CMenuBackground::POS_START);
+	GameClient()->m_MenuBackground.ChangePosition(CMenuBackground::POS_START);
 
 	// render logo
 	Graphics()->TextureSet(g_pData->m_aImages[IMAGE_BANNER].m_Id);

--- a/src/game/client/components/nameplates.cpp
+++ b/src/game/client/components/nameplates.cpp
@@ -347,11 +347,6 @@ void CNamePlates::OnRender()
 	}
 }
 
-void CNamePlates::SetPlayers(CPlayers *pPlayers)
-{
-	m_pPlayers = pPlayers;
-}
-
 void CNamePlates::ResetNamePlates()
 {
 	for(auto &NamePlate : m_aNamePlates)

--- a/src/game/client/components/nameplates.h
+++ b/src/game/client/components/nameplates.h
@@ -49,7 +49,6 @@ class CNamePlates : public CComponent
 	void RenderNameplatePos(vec2 Position, const CNetObj_PlayerInfo *pPlayerInfo, float Alpha, bool ForceAlpha = false);
 
 	SPlayerNamePlate m_aNamePlates[MAX_CLIENTS];
-	class CPlayers *m_pPlayers;
 
 	void ResetNamePlates();
 
@@ -60,8 +59,6 @@ public:
 	virtual void OnWindowResize() override;
 	virtual void OnInit() override;
 	virtual void OnRender() override;
-
-	void SetPlayers(class CPlayers *pPlayers);
 };
 
 #endif

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -102,10 +102,6 @@ void CGameClient::OnConsoleInit()
 #endif
 	m_pHttp = Kernel()->RequestInterface<IHttp>();
 
-	m_Menus.SetMenuBackground(&m_MenuBackground);
-
-	m_NamePlates.SetPlayers(&m_Players);
-
 	// make a list of all the systems, make sure to add them in the correct render order
 	m_vpAll.insert(m_vpAll.end(), {&m_Skins,
 					      &m_CountryFlags,


### PR DESCRIPTION
Use the gameclient to access other components instead.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
