### PR TITLE
Disallow `/save` on teams with practice enabled

### DIFF
--- a/src/game/server/score.cpp
+++ b/src/game/server/score.cpp
@@ -290,6 +290,8 @@ void CScore::SaveTeam(int ClientId, const char *pCode, const char *pServer)
 	int Team = pController->Teams().m_Core.Team(ClientId);
 	if(pController->Teams().GetSaving(Team))
 		return;
+	if(pController->Teams().IsPractice(Team))
+		return;
 
 	auto SaveResult = std::make_shared<CScoreSaveResult>(ClientId);
 	SaveResult->m_SaveId = RandomUuid();


### PR DESCRIPTION
It's not necessary, because you can get back to the position anyway.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
