### PR TITLE
Fix freeze not working during first 50 server ticks

### DIFF
--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -2167,7 +2167,7 @@ bool CCharacter::Freeze(int Seconds)
 {
 	if(Seconds <= 0 || m_Core.m_Super || m_FreezeTime > Seconds * Server()->TickSpeed())
 		return false;
-	if(m_Core.m_FreezeStart < Server()->Tick() - Server()->TickSpeed())
+	if(m_FreezeTime == 0 || m_Core.m_FreezeStart < Server()->Tick() - Server()->TickSpeed())
 	{
 		m_Armor = 0;
 		m_FreezeTime = Seconds * Server()->TickSpeed();


### PR DESCRIPTION
The purpose of this condition is to only update the freeze time every 50 ticks so the freeze bar keeps being refilled after one second when standing in freeze, but it incorrectly prevented freeze from being applied during the first 50 ticks after the map has been loaded. Now, freeze is also applied if not currently frozen, so the behavior directly after changing the map is identical to subsequent respawns.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
