### PR TITLE
Disallow activating /practice while save is in progress and improve messaging for when `/save`/`/load` command does nothing

### DIFF
--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -644,6 +644,15 @@ void CGameContext::ConPractice(IConsole::IResult *pResult, void *pUserData)
 		return;
 	}
 
+	if(Teams.GetSaving(Team))
+	{
+		pSelf->Console()->Print(
+			IConsole::OUTPUT_LEVEL_STANDARD,
+			"chatresp",
+			"Practice mode can't be enabled while team save or load is in progress");
+		return;
+	}
+
 	if(Teams.IsPractice(Team))
 	{
 		pSelf->Console()->Print(

--- a/src/game/server/score.cpp
+++ b/src/game/server/score.cpp
@@ -288,10 +288,17 @@ void CScore::SaveTeam(int ClientId, const char *pCode, const char *pServer)
 		return;
 	auto *pController = GameServer()->m_pController;
 	int Team = pController->Teams().m_Core.Team(ClientId);
+	char aBuf[512];
 	if(pController->Teams().GetSaving(Team))
+	{
+		GameServer()->SendChatTarget(ClientId, "Team save already in progress");
 		return;
+	}
 	if(pController->Teams().IsPractice(Team))
+	{
+		GameServer()->SendChatTarget(ClientId, "Team save disabled for teams in practice mode");
 		return;
+	}
 
 	auto SaveResult = std::make_shared<CScoreSaveResult>(ClientId);
 	SaveResult->m_SaveId = RandomUuid();
@@ -308,7 +315,6 @@ void CScore::SaveTeam(int ClientId, const char *pCode, const char *pServer)
 	Tmp->m_aGeneratedCode[0] = '\0';
 	GeneratePassphrase(Tmp->m_aGeneratedCode, sizeof(Tmp->m_aGeneratedCode));
 
-	char aBuf[512];
 	if(Tmp->m_aCode[0] == '\0')
 	{
 		str_format(aBuf,

--- a/src/game/server/score.cpp
+++ b/src/game/server/score.cpp
@@ -358,6 +358,11 @@ void CScore::LoadTeam(const char *pCode, int ClientId)
 		GameServer()->SendChatTarget(ClientId, "Team can't be loaded while in team 0 mode");
 		return;
 	}
+	if(pController->Teams().IsPractice(Team))
+	{
+		GameServer()->SendChatTarget(ClientId, "Team can't be loaded while practice is enabled");
+		return;
+	}
 	auto SaveResult = std::make_shared<CScoreSaveResult>(ClientId);
 	SaveResult->m_Status = CScoreSaveResult::LOAD_FAILED;
 	pController->Teams().SetSaving(Team, SaveResult);

--- a/src/game/server/score.cpp
+++ b/src/game/server/score.cpp
@@ -342,7 +342,10 @@ void CScore::LoadTeam(const char *pCode, int ClientId)
 	auto *pController = GameServer()->m_pController;
 	int Team = pController->Teams().m_Core.Team(ClientId);
 	if(pController->Teams().GetSaving(Team))
+	{
+		GameServer()->SendChatTarget(ClientId, "Team load already in progress");
 		return;
+	}
 	if(Team < TEAM_FLOCK || Team >= MAX_CLIENTS || (g_Config.m_SvTeam != SV_TEAM_FORCED_SOLO && Team == TEAM_FLOCK))
 	{
 		GameServer()->SendChatTarget(ClientId, "You have to be in a team (from 1-63)");


### PR DESCRIPTION
Also require that practice mode is disabled for `/load` to reduce possible side effects.

Follow up on #8220

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
