### PR TITLE
Add custom scoreboard name colors for different ranks

### DIFF
--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -38,7 +38,9 @@ MACRO_CONFIG_INT(ClTextEntities, cl_text_entities, 1, 0, 1, CFGFLAG_CLIENT | CFG
 MACRO_CONFIG_INT(ClTextEntitiesSize, cl_text_entities_size, 100, 1, 100, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Size of textual entity data from 1 to 100%")
 MACRO_CONFIG_INT(ClStreamerMode, cl_streamer_mode, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Censor sensitive information such as /save password")
 
-MACRO_CONFIG_COL(ClAuthedPlayerColor, cl_authed_player_color, 5898211, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Color of name of authenticated player in scoreboard")
+MACRO_CONFIG_COL(ClAdminColor, cl_admin_color, 16448153, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Color of name of admin in scoreboard")
+MACRO_CONFIG_COL(ClModeratorColor, cl_moderator_color, 6647173, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Color of name of moderator in scoreboard")
+MACRO_CONFIG_COL(ClHelperColor, cl_helper_color, 1505427, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Color of name of helper in scoreboard")
 MACRO_CONFIG_COL(ClSameClanColor, cl_same_clan_color, 5898211, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Clan color of players with the same clan as you in scoreboard.")
 
 MACRO_CONFIG_INT(ClEnablePingColor, cl_enable_ping_color, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Whether ping is colored in scoreboard.")

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -2994,10 +2994,16 @@ void CMenus::RenderSettingsAppearance(CUIRect MainView)
 			g_Config.m_ClShowDirection = g_Config.m_ClShowDirection ^ 3;
 		}
 
+		LeftView.HSplitTop(LineSize, &Button, &LeftView);
 		ColorRGBA GreenDefault(0.78f, 1.0f, 0.8f, 1.0f);
-		static CButtonContainer s_AuthedColor, s_SameClanColor;
-		DoLine_ColorPicker(&s_AuthedColor, ColorPickerLineSize, ColorPickerLabelSize, ColorPickerLineSpacing, &LeftView, Localize("Authed name color in scoreboard"), &g_Config.m_ClAuthedPlayerColor, GreenDefault, false);
-		DoLine_ColorPicker(&s_SameClanColor, ColorPickerLineSize, ColorPickerLabelSize, ColorPickerLineSpacing, &LeftView, Localize("Same clan color in scoreboard"), &g_Config.m_ClSameClanColor, GreenDefault, false);
+		ColorRGBA AdminDefault(0.98f, 0.2f, 0.3f, 1.0f);
+		ColorRGBA ModeratorDefault(0.31f, 0.72f, 0.46f, 1.0f);
+		ColorRGBA HelperDefault(0.98f, 0.58f, 0.16f, 1.0f);
+		static CButtonContainer s_AdminColor, s_ModeratorColor, s_HelperColor, s_SameClanColor;
+		DoLine_ColorPicker(&s_AdminColor, 25.0f, 13.0f, 5.0f, &Button, Localize("Admin name color in scoreboard"), &g_Config.m_ClAdminColor, AdminDefault, false);
+		DoLine_ColorPicker(&s_ModeratorColor, 25.0f, 13.0f, 5.0f, &Button, Localize("Mod name color in scoreboard"), &g_Config.m_ClModeratorColor, ModeratorDefault, false);
+		DoLine_ColorPicker(&s_HelperColor, 25.0f, 13.0f, 5.0f, &Button, Localize("Helper name color in scoreboard"), &g_Config.m_ClHelperColor, HelperDefault, false);
+		DoLine_ColorPicker(&s_SameClanColor, 25.0f, 13.0f, 5.0f, &Button, Localize("Same clan color in scoreboard"), &g_Config.m_ClSameClanColor, GreenDefault, false);
 	}
 	else if(s_CurTab == APPEARANCE_TAB_HOOK_COLLISION)
 	{

--- a/src/game/client/components/scoreboard.cpp
+++ b/src/game/client/components/scoreboard.cpp
@@ -112,7 +112,8 @@ void CScoreboard::RenderSpectators(float x, float y, float w, float h)
 
 		if(m_pClient->m_aClients[pInfo->m_ClientId].m_AuthLevel)
 		{
-			ColorRGBA Color = color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClAuthedPlayerColor));
+			//TODO: Add 0.7 Correct Conditions after ChillerDragon's pr is merged
+			ColorRGBA Color = color_cast<ColorRGBA>(ColorHSLA(m_pClient->m_aClients[pInfo->m_ClientId].m_AuthLevel == AUTHED_ADMIN ? g_Config.m_ClAdminColor : m_pClient->m_aClients[pInfo->m_ClientId].m_AuthLevel == AUTHED_MOD ? g_Config.m_ClModeratorColor : g_Config.m_ClHelperColor));
 			TextRender()->TextColor(Color);
 		}
 
@@ -443,7 +444,8 @@ void CScoreboard::RenderScoreboard(float x, float y, float w, int Team, const ch
 		TextRender()->SetCursor(&Cursor, NameOffset, y + (LineHeight - FontSize) / 2.f, FontSize, TEXTFLAG_RENDER | TEXTFLAG_ELLIPSIS_AT_END);
 		if(m_pClient->m_aClients[pInfo->m_ClientId].m_AuthLevel)
 		{
-			ColorRGBA Color = color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClAuthedPlayerColor));
+			//TODO: Add 0.7 Correct Conditions after ChillerDragon's pr is merged
+			ColorRGBA Color = color_cast<ColorRGBA>(ColorHSLA(m_pClient->m_aClients[pInfo->m_ClientId].m_AuthLevel == AUTHED_ADMIN ? g_Config.m_ClAdminColor : m_pClient->m_aClients[pInfo->m_ClientId].m_AuthLevel == AUTHED_MOD ? g_Config.m_ClModeratorColor : g_Config.m_ClHelperColor));
 			TextRender()->TextColor(Color);
 		}
 


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->
This adds separate colors for admin, mod, and helper in the scoreboard

![screenshot_2024-04-19_22-18-30](https://github.com/ddnet/ddnet/assets/57710259/bea7902d-e511-4a0d-b7a1-52e1d8fd8097)


## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
