### PR TITLE
Fix potential client crash and console not keeping scrolling position when console backlog is full

### DIFF
--- a/src/engine/shared/ringbuffer.cpp
+++ b/src/engine/shared/ringbuffer.cpp
@@ -123,10 +123,20 @@ void *CRingBufferBase::Allocate(int Size)
 	return (void *)(pBlock + 1);
 }
 
+void CRingBufferBase::SetPopCallback(std::function<void(void *pCurrent)> PopCallback)
+{
+	m_PopCallback = std::move(PopCallback);
+}
+
 int CRingBufferBase::PopFirst()
 {
 	if(m_pConsume->m_Free)
 		return 0;
+
+	if(m_PopCallback)
+	{
+		m_PopCallback(m_pConsume + 1);
+	}
 
 	// set the free flag
 	m_pConsume->m_Free = 1;

--- a/src/engine/shared/ringbuffer.h
+++ b/src/engine/shared/ringbuffer.h
@@ -5,6 +5,8 @@
 
 #include <base/system.h>
 
+#include <functional>
+
 class CRingBufferBase
 {
 	class CItem
@@ -25,6 +27,8 @@ class CRingBufferBase
 	int m_Size;
 	int m_Flags;
 
+	std::function<void(void *pCurrent)> m_PopCallback = nullptr;
+
 	CItem *NextBlock(CItem *pItem);
 	CItem *PrevBlock(CItem *pItem);
 	CItem *MergeBack(CItem *pItem);
@@ -39,6 +43,7 @@ protected:
 
 	void Init(void *pMemory, int Size, int Flags);
 	int PopFirst();
+	void SetPopCallback(const std::function<void(void *pCurrent)> PopCallback);
 
 public:
 	enum
@@ -55,6 +60,12 @@ class CTypedRingBuffer : public CRingBufferBase
 public:
 	T *Allocate(int Size) { return (T *)CRingBufferBase::Allocate(Size); }
 	int PopFirst() { return CRingBufferBase::PopFirst(); }
+	void SetPopCallback(std::function<void(T *pCurrent)> PopCallback)
+	{
+		CRingBufferBase::SetPopCallback([PopCallback](void *pCurrent) {
+			PopCallback((T *)pCurrent);
+		});
+	}
 
 	T *Prev(T *pCurrent) { return (T *)CRingBufferBase::Prev(pCurrent); }
 	T *Next(T *pCurrent) { return (T *)CRingBufferBase::Next(pCurrent); }

--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -208,6 +208,13 @@ CGameConsole::CInstance::CInstance(int Type)
 
 	m_IsCommand = false;
 
+	m_Backlog.SetPopCallback([this](CBacklogEntry *pEntry) {
+		if(pEntry->m_LineCount != -1)
+		{
+			m_NewLineCounter -= pEntry->m_LineCount;
+		}
+	});
+
 	m_Input.SetClipboardLineCallback([this](const char *pStr) { ExecuteLine(pStr); });
 
 	m_CurrentMatchIndex = -1;
@@ -1135,7 +1142,7 @@ void CGameConsole::OnRender()
 		}
 
 		pConsole->PumpBacklogPending();
-		if(pConsole->m_NewLineCounter > 0)
+		if(pConsole->m_NewLineCounter != 0)
 		{
 			pConsole->UpdateSearch();
 
@@ -1145,6 +1152,8 @@ void CGameConsole::OnRender()
 				pConsole->m_BacklogCurLine += pConsole->m_NewLineCounter;
 				pConsole->m_BacklogLastActiveLine += pConsole->m_NewLineCounter;
 			}
+			if(pConsole->m_NewLineCounter < 0)
+				pConsole->m_NewLineCounter = 0;
 		}
 
 		// render console log (current entry, status, wrap lines)


### PR DESCRIPTION
Fix backlog corruption in `CConsole::PumpBacklogPending` when many backlog entries are allocated at the same time. When allocating many entries from the `m_Backlog` ringbuffer at the same time, the first entries being allocated may already have been recycled again, so the pointers to them being stored in the temporary vector of new backlog entries were pointing arbitrarily into the ringbuffer data, which could cause corruption of the structural and user data of the ringbuffer. Now, we iterate over the entire backlog and only update uninitialized entries instead of storing the new entries separately.

This was sometimes caught as a misaligned access with UBSan:

```
src/engine/shared/ringbuffer.cpp:160:14: runtime error: member access within misaligned address 0x00014126f4df for type 'struct CItem', which requires 8 byte alignment
0x00014126f4df: note: pointer points here
<memory cannot be printed>
    0 0x5825349a6a1c in CRingBufferBase::Prev(void*) src/engine/shared/ringbuffer.cpp:160
    1 0x5825334e8934 in CTypedRingBuffer<CGameConsole::CInstance::CBacklogEntry>::Prev(CGameConsole::CInstance::CBacklogEntry*) src/engine/shared/ringbuffer.h:59
    2 0x5825334d13e6 in CGameConsole::OnRender() src/game/client/components/console.cpp:1259
    3 0x582533bce058 in CGameClient::OnRender() src/game/client/gameclient.cpp:715
    4 0x582532f3cc44 in CClient::Render() src/engine/client/client.cpp:894
    5 0x582532f9d236 in CClient::Run() src/engine/client/client.cpp:2971
    6 0x582533002e5e in main src/engine/client/client.cpp:4523
```

The console was not keeping its current scoll position if entries from the backlog are removed due to being recycled when new entries are added. For this purpose, a callback function is added to the ringbuffer to handle popped items, so the scrolling position of the console can be updated based on the number of lines of the removed backlog entries.

Closes #8097.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [X] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
