### PR TITLE
Update Turkish translations for 18.2 (by Gokturk)

### DIFF
--- a/data/languages/turkish.txt
+++ b/data/languages/turkish.txt
@@ -240,7 +240,7 @@ Mute when not active
 == Aktif değilken sessizleştir
 
 Name
-== Takma ad
+== Sunucu ismi
 
 Next weapon
 == Sonraki silah
@@ -576,7 +576,7 @@ DDraceNetwork is a cooperative online game where the goal is for you and your gr
 == DDRaceNetwork bitiş çizgisine en kısa sürede ulaşmayı amaçlayan oyunculardan oluşan, çevrimiçi bir takım oyunudur. Çaylak olarak ilk önce kolay haritalardan yani Novice sunuculardan oynamaya başlamanı öneririz. Herhangi bir sunucu seçmeden önce sana yakın olan sunucuyu seçmek için ping'i dikkate al.
 
 Use k key to kill (restart), q to pause and watch other players. See settings for other key binds.
-== İntihar etmek (yeniden başlamak) için k tuşu, oyunu durdurup diğer oyuncuları izlemek için q tuşunu kullanabilirsin. Diğer kontrollere ayarlardan bakabilirsin.
+== Ölmek (yeniden başlamak) için "k" tuşu, oyunu durdurup diğer oyuncuları izlemek için "q" tuşunu kullanabilirsin. Diğer kontrollere ayarlardan bakabilirsin.
 
 It's recommended that you check the settings to adjust them to your liking before joining a server.
 == Sunuculara bağlanmadan önce ayarları kontrol edip kendine göre düzenlemeni öneriyoruz.
@@ -717,7 +717,7 @@ Pause
 == Durdur
 
 Kill
-== İntihar et
+== Öl
 
 Zoom in
 == Yakınlaştır
@@ -1626,7 +1626,7 @@ Can't find a Tutorial server
 == Öğretici sunucu bulunamıyor
 
 Website
-== İnternet sitesi
+== Web sitesi
 
 Settings
 == Ayarlar


### PR DESCRIPTION
"Kill" is translated as "intihar et" by the other translators. "İntihar et" means "suicide".

1. Not using the word "intihar et" because of its meaning is more accurate.
2. In game, "intihar et" causes the font getting smaller and it does not fit in the box. (https://prnt.sc/4hxQlZdoN1MS)

Using "öl" would be better instead of "intihar et" because it fits in the box better and it keeps the original meaning more.

---

The word "Name" is translated as "Takma ad", which means nickname. It causes a mistranslation by showing up above the server's name. (https://prnt.sc/1NUC5_5qR_H8)

In this scenario, using "sunucu ismi" which means "server name" would fit better.

---

Even the word "Website" means "internet sitesi" in Turkish, it does not fit in the box and can cause the font getting smaller so it is better leaving it as "web sitesi" which also used as "website" in Turkish. (https://prnt.sc/Ngkh6nkkWQF3)

<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [x] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [x] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
