### PR TITLE
Fix warning because of incorrect format argument for `size_t`

### DIFF
--- a/src/engine/shared/snapshot.cpp
+++ b/src/engine/shared/snapshot.cpp
@@ -447,7 +447,7 @@ int CSnapshotDelta::DebugDumpDelta(const void *pSrcData, int DataSize)
 			}
 			if(*pData < 0 || (size_t)*pData > std::numeric_limits<int32_t>::max() / sizeof(int32_t))
 			{
-				dbg_msg("delta_dump", "|  Invalid delta. Item size %d out of range (0 - %lu)", *pData, std::numeric_limits<int32_t>::max() / sizeof(int32_t));
+				dbg_msg("delta_dump", "|  Invalid delta. Item size %d out of range (0 - %" PRIzu ")", *pData, std::numeric_limits<int32_t>::max() / sizeof(int32_t));
 				return -204;
 			}
 			dbg_msg("delta_dump", "|  %3d %12d  %08x updated size=%d", DumpIndex++, *pData, *pData, *pData);
@@ -478,7 +478,7 @@ int CSnapshotDelta::DebugDumpDelta(const void *pSrcData, int DataSize)
 		dbg_assert(pItemEnd == pData, "Incorrect amount of data dumped for this item.");
 	}
 
-	dbg_msg("delta_dump", "|  Finished with expected_data_size=%d parsed_data_size=%lu", DataSize, (pData - (int *)pSrcData) * sizeof(int32_t));
+	dbg_msg("delta_dump", "|  Finished with expected_data_size=%d parsed_data_size=%" PRIzu, DataSize, (pData - (int *)pSrcData) * sizeof(int32_t));
 	dbg_msg("delta_dump", "+--------------------");
 
 	return 0;


### PR DESCRIPTION


## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
