### PR TITLE
Fix ddnet ex snap item registration (closed #8271)

### DIFF
--- a/src/engine/shared/snapshot.cpp
+++ b/src/engine/shared/snapshot.cpp
@@ -765,8 +765,9 @@ int CSnapshotBuilder::GetExtendedItemTypeIndex(int TypeId)
 	}
 	dbg_assert(m_NumExtendedItemTypes < MAX_EXTENDED_ITEM_TYPES, "too many extended item types");
 	int Index = m_NumExtendedItemTypes;
-	m_aExtendedItemTypes[Index] = TypeId;
 	m_NumExtendedItemTypes++;
+	m_aExtendedItemTypes[Index] = TypeId;
+	AddExtendedItemType(Index);
 	return Index;
 }
 


### PR DESCRIPTION
The problem was that the ddnet ex items would be registered when the snapshot builder was initialized. So it checked which ddnet ex items have been used already and then register those uuids. But then all new ddnet ex items that will be added to this snap are not registered. This way the registration is always lacking one snap behind. This could cause some nasty to debug off by one snap errors that are also rare because this only happens for ddnet ex items that were not used by the server before.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
