### PR TITLE
Fix crashes and memory leaks related to editor map sounds and opus file decoding, refactoring

### DIFF
--- a/src/engine/client/sound.cpp
+++ b/src/engine/client/sound.cpp
@@ -355,15 +355,15 @@ bool CSound::DecodeOpus(CSample &Sample, const void *pData, unsigned DataSize) c
 			return false;
 		}
 
-		Sample.m_pData = (short *)calloc((size_t)NumSamples * NumChannels, sizeof(short));
+		short *pSampleData = (short *)calloc((size_t)NumSamples * NumChannels, sizeof(short));
 
 		int Pos = 0;
 		while(Pos < NumSamples)
 		{
-			const int Read = op_read(pOpusFile, Sample.m_pData + Pos * NumChannels, NumSamples * NumChannels, nullptr);
+			const int Read = op_read(pOpusFile, pSampleData + Pos * NumChannels, NumSamples * NumChannels, nullptr);
 			if(Read < 0)
 			{
-				free(Sample.m_pData);
+				free(pSampleData);
 				dbg_msg("sound/opus", "op_read error %d at %d", Read, Pos);
 				return false;
 			}
@@ -372,6 +372,7 @@ bool CSound::DecodeOpus(CSample &Sample, const void *pData, unsigned DataSize) c
 			Pos += Read;
 		}
 
+		Sample.m_pData = pSampleData;
 		Sample.m_NumFrames = Pos;
 		Sample.m_Rate = 48000;
 		Sample.m_LoopStart = -1;

--- a/src/engine/client/sound.cpp
+++ b/src/engine/client/sound.cpp
@@ -292,14 +292,15 @@ CSample *CSound::AllocSample()
 		return nullptr;
 
 	CSample *pSample = &m_aSamples[m_FirstFreeSampleIndex];
-	m_FirstFreeSampleIndex = pSample->m_NextFreeSampleIndex;
-	pSample->m_NextFreeSampleIndex = SAMPLE_INDEX_USED;
-	if(pSample->m_pData != nullptr)
+	if(pSample->m_pData != nullptr || pSample->m_NextFreeSampleIndex == SAMPLE_INDEX_USED)
 	{
-		char aError[64];
-		str_format(aError, sizeof(aError), "Sample was not unloaded (index=%d, duration=%f)", pSample->m_Index, pSample->TotalTime());
+		char aError[128];
+		str_format(aError, sizeof(aError), "Sample was not unloaded (index=%d, next=%d, duration=%f, data=%p)",
+			pSample->m_Index, pSample->m_NextFreeSampleIndex, pSample->TotalTime(), pSample->m_pData);
 		dbg_assert(false, aError);
 	}
+	m_FirstFreeSampleIndex = pSample->m_NextFreeSampleIndex;
+	pSample->m_NextFreeSampleIndex = SAMPLE_INDEX_USED;
 	return pSample;
 }
 

--- a/src/engine/client/sound.cpp
+++ b/src/engine/client/sound.cpp
@@ -341,7 +341,8 @@ void CSound::RateConvert(CSample &Sample) const
 
 bool CSound::DecodeOpus(CSample &Sample, const void *pData, unsigned DataSize) const
 {
-	OggOpusFile *pOpusFile = op_open_memory((const unsigned char *)pData, DataSize, nullptr);
+	int OpusError = 0;
+	OggOpusFile *pOpusFile = op_open_memory((const unsigned char *)pData, DataSize, &OpusError);
 	if(pOpusFile)
 	{
 		const int NumChannels = op_channel_count(pOpusFile, -1);
@@ -380,7 +381,7 @@ bool CSound::DecodeOpus(CSample &Sample, const void *pData, unsigned DataSize) c
 	}
 	else
 	{
-		dbg_msg("sound/opus", "failed to decode sample");
+		dbg_msg("sound/opus", "failed to decode sample, error %d", OpusError);
 		return false;
 	}
 

--- a/src/engine/client/sound.cpp
+++ b/src/engine/client/sound.cpp
@@ -350,6 +350,7 @@ bool CSound::DecodeOpus(CSample &Sample, const void *pData, unsigned DataSize) c
 
 		if(NumChannels > 2)
 		{
+			op_free(pOpusFile);
 			dbg_msg("sound/opus", "file is not mono or stereo.");
 			return false;
 		}
@@ -363,6 +364,7 @@ bool CSound::DecodeOpus(CSample &Sample, const void *pData, unsigned DataSize) c
 			if(Read < 0)
 			{
 				free(pSampleData);
+				op_free(pOpusFile);
 				dbg_msg("sound/opus", "op_read error %d at %d", Read, Pos);
 				return false;
 			}
@@ -370,6 +372,8 @@ bool CSound::DecodeOpus(CSample &Sample, const void *pData, unsigned DataSize) c
 				break;
 			Pos += Read;
 		}
+
+		op_free(pOpusFile);
 
 		Sample.m_pData = pSampleData;
 		Sample.m_NumFrames = Pos;

--- a/src/engine/client/sound.cpp
+++ b/src/engine/client/sound.cpp
@@ -346,12 +346,18 @@ bool CSound::DecodeOpus(CSample &Sample, const void *pData, unsigned DataSize) c
 	if(pOpusFile)
 	{
 		const int NumChannels = op_channel_count(pOpusFile, -1);
-		const int NumSamples = op_pcm_total(pOpusFile, -1); // per channel!
-
 		if(NumChannels > 2)
 		{
 			op_free(pOpusFile);
 			dbg_msg("sound/opus", "file is not mono or stereo.");
+			return false;
+		}
+
+		const int NumSamples = op_pcm_total(pOpusFile, -1); // per channel!
+		if(NumSamples < 0)
+		{
+			op_free(pOpusFile);
+			dbg_msg("sound/opus", "failed to get number of samples, error %d", NumSamples);
 			return false;
 		}
 

--- a/src/engine/client/sound.cpp
+++ b/src/engine/client/sound.cpp
@@ -347,9 +347,7 @@ bool CSound::DecodeOpus(CSample &Sample, const void *pData, unsigned DataSize) c
 		const int NumChannels = op_channel_count(pOpusFile, -1);
 		const int NumSamples = op_pcm_total(pOpusFile, -1); // per channel!
 
-		Sample.m_Channels = NumChannels;
-
-		if(Sample.m_Channels > 2)
+		if(NumChannels > 2)
 		{
 			dbg_msg("sound/opus", "file is not mono or stereo.");
 			return false;
@@ -375,6 +373,7 @@ bool CSound::DecodeOpus(CSample &Sample, const void *pData, unsigned DataSize) c
 		Sample.m_pData = pSampleData;
 		Sample.m_NumFrames = Pos;
 		Sample.m_Rate = 48000;
+		Sample.m_Channels = NumChannels;
 		Sample.m_LoopStart = -1;
 		Sample.m_LoopEnd = -1;
 		Sample.m_PausedAt = 0;
@@ -460,10 +459,7 @@ bool CSound::DecodeWV(CSample &Sample, const void *pData, unsigned DataSize) con
 		const unsigned int SampleRate = WavpackGetSampleRate(pContext);
 		const int NumChannels = WavpackGetNumChannels(pContext);
 
-		Sample.m_Channels = NumChannels;
-		Sample.m_Rate = SampleRate;
-
-		if(Sample.m_Channels > 2)
+		if(NumChannels > 2)
 		{
 			dbg_msg("sound/wv", "file is not mono or stereo.");
 			s_pWVBuffer = nullptr;
@@ -499,6 +495,8 @@ bool CSound::DecodeWV(CSample &Sample, const void *pData, unsigned DataSize) con
 #endif
 
 		Sample.m_NumFrames = NumSamples;
+		Sample.m_Rate = SampleRate;
+		Sample.m_Channels = NumChannels;
 		Sample.m_LoopStart = -1;
 		Sample.m_LoopEnd = -1;
 		Sample.m_PausedAt = 0;

--- a/src/engine/client/sound.cpp
+++ b/src/engine/client/sound.cpp
@@ -358,7 +358,7 @@ bool CSound::DecodeOpus(CSample &Sample, const void *pData, unsigned DataSize) c
 		int Pos = 0;
 		while(Pos < NumSamples)
 		{
-			const int Read = op_read(pOpusFile, pSampleData + Pos * NumChannels, NumSamples * NumChannels, nullptr);
+			const int Read = op_read(pOpusFile, pSampleData + Pos * NumChannels, (NumSamples - Pos) * NumChannels, nullptr);
 			if(Read < 0)
 			{
 				free(pSampleData);

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -1379,12 +1379,17 @@ void CEditor::DoToolbarSounds(CUIRect ToolBar)
 		if(pSelectedSound->m_SoundId != m_ToolbarPreviewSound && m_ToolbarPreviewSound >= 0 && Sound()->IsPlaying(m_ToolbarPreviewSound))
 			Sound()->Stop(m_ToolbarPreviewSound);
 		m_ToolbarPreviewSound = pSelectedSound->m_SoundId;
+	}
+	else
+	{
+		m_ToolbarPreviewSound = -1;
+	}
 
+	if(m_ToolbarPreviewSound >= 0)
+	{
 		static int s_PlayPauseButton, s_StopButton, s_SeekBar = 0;
 		DoAudioPreview(ToolBarBottom, &s_PlayPauseButton, &s_StopButton, &s_SeekBar, m_ToolbarPreviewSound);
 	}
-	else
-		m_ToolbarPreviewSound = -1;
 }
 
 static void Rotate(const CPoint *pCenter, CPoint *pPoint, float Rotation)

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -8710,11 +8710,10 @@ void CEditor::OnClose()
 
 void CEditor::OnDialogClose()
 {
-	if(m_FilePreviewSound >= 0)
-	{
-		Sound()->UnloadSample(m_FilePreviewSound);
-		m_FilePreviewSound = -1;
-	}
+	Graphics()->UnloadTexture(&m_FilePreviewImage);
+	Sound()->UnloadSample(m_FilePreviewSound);
+	m_FilePreviewSound = -1;
+	m_FilePreviewState = PREVIEW_UNLOADED;
 }
 
 void CEditor::LoadCurrentMap()

--- a/src/game/editor/mapitems/sound.h
+++ b/src/game/editor/mapitems/sound.h
@@ -10,7 +10,7 @@ public:
 	explicit CEditorSound(CEditor *pEditor);
 	~CEditorSound();
 
-	int m_SoundId = 0;
+	int m_SoundId = -1;
 	char m_aName[IO_MAX_PATH_LENGTH] = "";
 
 	void *m_pData = nullptr;


### PR DESCRIPTION
See commit messages.

#8262 is not fixed entirely by this, as I could not reproduce the assertion and the potential race condition is not prevented yet.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
