### PR TITLE
Revert screen mode config variables when change not accepted, update screen index config variable after moving window 

### DIFF
--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -1539,6 +1539,7 @@ bool CGraphicsBackend_SDL_GL::UpdateDisplayMode(int Index)
 		return false;
 	}
 
+	g_Config.m_GfxScreen = Index;
 	g_Config.m_GfxDesktopWidth = DisplayMode.w;
 	g_Config.m_GfxDesktopHeight = DisplayMode.h;
 

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -3943,7 +3943,7 @@ void CClient::SwitchWindowScreen(int Index)
 	g_Config.m_GfxScreenHeight = CurMode.m_WindowHeight;
 	g_Config.m_GfxScreenRefreshRate = CurMode.m_RefreshRate;
 
-	Graphics()->Resize(g_Config.m_GfxScreenWidth, g_Config.m_GfxScreenHeight, g_Config.m_GfxScreenRefreshRate);
+	Graphics()->ResizeToScreen();
 
 	SetWindowParams(IsFullscreen, IsBorderless);
 }
@@ -4032,7 +4032,7 @@ void CClient::ConchainWindowResize(IConsole::IResult *pResult, void *pUserData, 
 	pfnCallback(pResult, pCallbackUserData);
 	if(pSelf->Graphics() && pResult->NumArguments())
 	{
-		pSelf->Graphics()->Resize(g_Config.m_GfxScreenWidth, g_Config.m_GfxScreenHeight, g_Config.m_GfxScreenRefreshRate);
+		pSelf->Graphics()->ResizeToScreen();
 	}
 }
 

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -3929,8 +3929,10 @@ void CClient::SwitchWindowScreen(int Index)
 	int IsFullscreen = g_Config.m_GfxFullscreen;
 	int IsBorderless = g_Config.m_GfxBorderless;
 
-	if(Graphics()->SetWindowScreen(Index))
-		g_Config.m_GfxScreen = Index;
+	if(!Graphics()->SetWindowScreen(Index))
+	{
+		return;
+	}
 
 	SetWindowParams(3, false); // prevent DDNet to get stretch on monitors
 

--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -2664,15 +2664,15 @@ void CGraphics_Threaded::Move(int x, int y)
 		PropChangedListener();
 }
 
-void CGraphics_Threaded::Resize(int w, int h, int RefreshRate)
+bool CGraphics_Threaded::Resize(int w, int h, int RefreshRate)
 {
 #if defined(CONF_VIDEORECORDER)
 	if(IVideo::Current() && IVideo::Current()->IsRecording())
-		return;
+		return false;
 #endif
 
 	if(WindowWidth() == w && WindowHeight() == h && RefreshRate == m_ScreenRefreshRate)
-		return;
+		return false;
 
 	// if the size is changed manually, only set the window resize, a window size changed event is triggered anyway
 	if(m_pBackend->ResizeWindow(w, h, RefreshRate))
@@ -2680,7 +2680,20 @@ void CGraphics_Threaded::Resize(int w, int h, int RefreshRate)
 		CVideoMode CurMode;
 		m_pBackend->GetCurrentVideoMode(CurMode, m_ScreenHiDPIScale, g_Config.m_GfxDesktopWidth, g_Config.m_GfxDesktopHeight, g_Config.m_GfxScreen);
 		GotResized(w, h, RefreshRate);
+		return true;
 	}
+	return false;
+}
+
+void CGraphics_Threaded::ResizeToScreen()
+{
+	if(Resize(g_Config.m_GfxScreenWidth, g_Config.m_GfxScreenHeight, g_Config.m_GfxScreenRefreshRate))
+		return;
+
+	// Revert config variables if the change was not accepted
+	g_Config.m_GfxScreenWidth = ScreenWidth();
+	g_Config.m_GfxScreenHeight = ScreenHeight();
+	g_Config.m_GfxScreenRefreshRate = m_ScreenRefreshRate;
 }
 
 void CGraphics_Threaded::GotResized(int w, int h, int RefreshRate)

--- a/src/engine/client/graphics_threaded.h
+++ b/src/engine/client/graphics_threaded.h
@@ -1237,7 +1237,8 @@ public:
 	void SetWindowParams(int FullscreenMode, bool IsBorderless) override;
 	bool SetWindowScreen(int Index) override;
 	void Move(int x, int y) override;
-	void Resize(int w, int h, int RefreshRate) override;
+	bool Resize(int w, int h, int RefreshRate) override;
+	void ResizeToScreen() override;
 	void GotResized(int w, int h, int RefreshRate) override;
 	void UpdateViewport(int X, int Y, int W, int H, bool ByResize) override;
 	void AddWindowResizeListener(WINDOW_RESIZE_FUNC pFunc) override;

--- a/src/engine/graphics.h
+++ b/src/engine/graphics.h
@@ -295,7 +295,8 @@ public:
 	virtual bool SetMultiSampling(uint32_t ReqMultiSamplingCount, uint32_t &MultiSamplingCountBackend) = 0;
 	virtual int GetWindowScreen() = 0;
 	virtual void Move(int x, int y) = 0;
-	virtual void Resize(int w, int h, int RefreshRate) = 0;
+	virtual bool Resize(int w, int h, int RefreshRate) = 0;
+	virtual void ResizeToScreen() = 0;
 	virtual void GotResized(int w, int h, int RefreshRate) = 0;
 	virtual void UpdateViewport(int X, int Y, int W, int H, bool ByResize) = 0;
 

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -1567,7 +1567,7 @@ void CMenus::RenderSettingsGraphics(CUIRect MainView)
 		g_Config.m_GfxScreenWidth = s_aModes[NewSelected].m_WindowWidth;
 		g_Config.m_GfxScreenHeight = s_aModes[NewSelected].m_WindowHeight;
 		g_Config.m_GfxScreenRefreshRate = s_aModes[NewSelected].m_RefreshRate;
-		Graphics()->Resize(g_Config.m_GfxScreenWidth, g_Config.m_GfxScreenHeight, g_Config.m_GfxScreenRefreshRate);
+		Graphics()->ResizeToScreen();
 	}
 
 	// switches


### PR DESCRIPTION
See commit messages.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
