### PR TITLE
Add no-op logger to fix leak of `CFutureLogger` pending messages

### DIFF
--- a/src/base/log.cpp
+++ b/src/base/log.cpp
@@ -483,6 +483,19 @@ std::unique_ptr<ILogger> log_logger_windows_debugger()
 }
 #endif
 
+class CLoggerNoOp : public ILogger
+{
+public:
+	void Log(const CLogMessage *pMessage) override
+	{
+		// no-op
+	}
+};
+std::unique_ptr<ILogger> log_logger_noop()
+{
+	return std::make_unique<CLoggerNoOp>();
+}
+
 void CFutureLogger::Set(std::shared_ptr<ILogger> pLogger)
 {
 	const CLockScope LockScope(m_PendingLock);

--- a/src/base/logger.h
+++ b/src/base/logger.h
@@ -213,6 +213,13 @@ std::unique_ptr<ILogger> log_logger_windows_debugger();
 /**
  * @ingroup Log
  *
+ * Logger which discards all logs.
+ */
+std::unique_ptr<ILogger> log_logger_noop();
+
+/**
+ * @ingroup Log
+ *
  * Logger that collects log messages in memory until it is replaced by another
  * logger.
  *

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -4499,9 +4499,9 @@ int main(int argc, const char **argv)
 		pSteam->ClearConnectAddress();
 	}
 
-	const int Mode = g_Config.m_Logappend ? IOFLAG_APPEND : IOFLAG_WRITE;
 	if(g_Config.m_Logfile[0])
 	{
+		const int Mode = g_Config.m_Logappend ? IOFLAG_APPEND : IOFLAG_WRITE;
 		IOHANDLE Logfile = pStorage->OpenFile(g_Config.m_Logfile, Mode, IStorage::TYPE_SAVE_OR_ABSOLUTE);
 		if(Logfile)
 		{
@@ -4510,7 +4510,12 @@ int main(int argc, const char **argv)
 		else
 		{
 			log_error("client", "failed to open '%s' for logging", g_Config.m_Logfile);
+			pFutureFileLogger->Set(log_logger_noop());
 		}
+	}
+	else
+	{
+		pFutureFileLogger->Set(log_logger_noop());
 	}
 
 	// Register protocol and file extensions

--- a/src/engine/server/main.cpp
+++ b/src/engine/server/main.cpp
@@ -170,9 +170,9 @@ int main(int argc, const char **argv)
 	pConfigManager->SetReadOnly("sv_test_cmds", true);
 	pConfigManager->SetReadOnly("sv_rescue", true);
 
-	const int Mode = g_Config.m_Logappend ? IOFLAG_APPEND : IOFLAG_WRITE;
 	if(g_Config.m_Logfile[0])
 	{
+		const int Mode = g_Config.m_Logappend ? IOFLAG_APPEND : IOFLAG_WRITE;
 		IOHANDLE Logfile = pStorage->OpenFile(g_Config.m_Logfile, Mode, IStorage::TYPE_SAVE_OR_ABSOLUTE);
 		if(Logfile)
 		{
@@ -181,8 +181,14 @@ int main(int argc, const char **argv)
 		else
 		{
 			log_error("server", "failed to open '%s' for logging", g_Config.m_Logfile);
+			pFutureFileLogger->Set(log_logger_noop());
 		}
 	}
+	else
+	{
+		pFutureFileLogger->Set(log_logger_noop());
+	}
+
 	auto pServerLogger = std::make_shared<CServerLogger>(pServer);
 	pEngine->SetAdditionalLogger(pServerLogger);
 


### PR DESCRIPTION
Fix leak of pending future logger log messages if the future logger is not set, in particular when the `logfile` config variable is not set or the file could not be opened, by setting a logger that discards all log messages in this case.

Closes #8265.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
