### PR TITLE
Make sixup TriggeredEvents reliable

### DIFF
--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -28,6 +28,7 @@ CCharacter::CCharacter(CGameWorld *pWorld, CNetObj_PlayerInput LastInput) :
 {
 	m_Health = 0;
 	m_Armor = 0;
+	m_TriggeredEvents7 = 0;
 	m_StrongWeakId = 0;
 
 	m_Input = LastInput;
@@ -861,6 +862,17 @@ void CCharacter::TickDeferred()
 
 		if(Events & COREEVENT_HOOK_HIT_NOHOOK)
 			GameServer()->CreateSound(m_Pos, SOUND_HOOK_NOATTACH, TeamMaskExceptSelf);
+
+		if(Events & COREEVENT_GROUND_JUMP)
+			m_TriggeredEvents7 |= protocol7::COREEVENTFLAG_GROUND_JUMP;
+		if(Events & COREEVENT_AIR_JUMP)
+			m_TriggeredEvents7 |= protocol7::COREEVENTFLAG_AIR_JUMP;
+		if(Events & COREEVENT_HOOK_ATTACH_PLAYER)
+			m_TriggeredEvents7 |= protocol7::COREEVENTFLAG_HOOK_ATTACH_PLAYER;
+		if(Events & COREEVENT_HOOK_ATTACH_GROUND)
+			m_TriggeredEvents7 |= protocol7::COREEVENTFLAG_HOOK_ATTACH_GROUND;
+		if(Events & COREEVENT_HOOK_HIT_NOHOOK)
+			m_TriggeredEvents7 |= protocol7::COREEVENTFLAG_HOOK_HIT_NOHOOK;
 	}
 
 	if(m_pPlayer->GetTeam() == TEAM_SPECTATORS)
@@ -1122,18 +1134,7 @@ void CCharacter::SnapCharacter(int SnappingClient, int Id)
 
 		pCharacter->m_Health = Health;
 		pCharacter->m_Armor = Armor;
-		int TriggeredEvents7 = 0;
-		if(m_Core.m_TriggeredEvents & COREEVENT_GROUND_JUMP)
-			TriggeredEvents7 |= protocol7::COREEVENTFLAG_GROUND_JUMP;
-		if(m_Core.m_TriggeredEvents & COREEVENT_AIR_JUMP)
-			TriggeredEvents7 |= protocol7::COREEVENTFLAG_AIR_JUMP;
-		if(m_Core.m_TriggeredEvents & COREEVENT_HOOK_ATTACH_PLAYER)
-			TriggeredEvents7 |= protocol7::COREEVENTFLAG_HOOK_ATTACH_PLAYER;
-		if(m_Core.m_TriggeredEvents & COREEVENT_HOOK_ATTACH_GROUND)
-			TriggeredEvents7 |= protocol7::COREEVENTFLAG_HOOK_ATTACH_GROUND;
-		if(m_Core.m_TriggeredEvents & COREEVENT_HOOK_HIT_NOHOOK)
-			TriggeredEvents7 |= protocol7::COREEVENTFLAG_HOOK_HIT_NOHOOK;
-		pCharacter->m_TriggeredEvents = TriggeredEvents7;
+		pCharacter->m_TriggeredEvents = m_TriggeredEvents7;
 	}
 }
 
@@ -1275,6 +1276,11 @@ void CCharacter::Snap(int SnappingClient)
 	}
 	pDDNetCharacter->m_TargetX = m_Core.m_Input.m_TargetX;
 	pDDNetCharacter->m_TargetY = m_Core.m_Input.m_TargetY;
+}
+
+void CCharacter::PostSnap()
+{
+	m_TriggeredEvents7 = 0;
 }
 
 // DDRace

--- a/src/game/server/entities/character.h
+++ b/src/game/server/entities/character.h
@@ -38,6 +38,7 @@ public:
 	void TickDeferred() override;
 	void TickPaused() override;
 	void Snap(int SnappingClient) override;
+	void PostSnap() override;
 	void SwapClients(int Client1, int Client2) override;
 
 	bool CanSnapCharacter(int SnappingClient);
@@ -143,6 +144,8 @@ private:
 
 	int m_Health;
 	int m_Armor;
+
+	int m_TriggeredEvents7;
 
 	// the player core for the physics
 	CCharacterCore m_Core;

--- a/src/game/server/entity.h
+++ b/src/game/server/entity.h
@@ -123,6 +123,12 @@ public: // TODO: Maybe make protected
 	virtual void Snap(int SnappingClient) {}
 
 	/*
+		Function: PostSnap
+			Called after all clients received their snapshot.
+	*/
+	virtual void PostSnap() {}
+
+	/*
 		Function: SwapClients
 			Called when two players have swapped their client ids.
 

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -4235,6 +4235,7 @@ void CGameContext::OnSnap(int ClientId)
 void CGameContext::OnPreSnap() {}
 void CGameContext::OnPostSnap()
 {
+	m_World.PostSnap();
 	m_Events.Clear();
 }
 

--- a/src/game/server/gameworld.cpp
+++ b/src/game/server/gameworld.cpp
@@ -129,6 +129,19 @@ void CGameWorld::Snap(int SnappingClient)
 	}
 }
 
+void CGameWorld::PostSnap()
+{
+	for(auto *pEnt : m_apFirstEntityTypes)
+	{
+		for(; pEnt;)
+		{
+			m_pNextTraverseEntity = pEnt->m_pNextTypeEntity;
+			pEnt->PostSnap();
+			pEnt = m_pNextTraverseEntity;
+		}
+	}
+}
+
 void CGameWorld::Reset()
 {
 	// reset all entities

--- a/src/game/server/gameworld.h
+++ b/src/game/server/gameworld.h
@@ -134,6 +134,12 @@ public:
 	void Snap(int SnappingClient);
 
 	/*
+		Function: PostSnap
+			Called after all clients received their snapshot.
+	*/
+	void PostSnap();
+
+	/*
 		Function: Tick
 			Calls Tick on all the entities in the world to progress
 			the world to the next tick.


### PR DESCRIPTION
Relevant upstream commit:
https://github.com/teeworlds/teeworlds/commit/d2924b5ad6982945da5f2db299d964133a3e5e63

Closes https://github.com/ChillerDragon/ddnet/issues/7

The snap item [obj_character](https://chillerdragon.github.io/teeworlds-protocol/07/snap_items.html#obj_character) contains a field called m_TriggeredEvents

It is responsible for effects and sounds. Those flags are set in the gamecore. So if the servers gamecore ticks twice and resets the flags before a snap is sent the client misses the information. Which is not too big of a problem since the client has his own gamecore running (prediction) which also sets those flags. But it is still wrong and teeworlds does always include the triggered events in the snap.

So this commit fixes it using the same approach as teeworlds. By not resetting the triggered events until a snap was sent.

I tested it against https://github.com/ddnet/ddnet/pull/5949 which has no 0.7 specific prediction running. It plays hook sounds just fine on vanilla servers but not on ddnet.

## Before: [ddnet7](https://github.com/ddnet/ddnet/pull/5949) clients would only get a hook sound by chance

https://github.com/ddnet/ddnet/assets/20344300/a2b52fb5-93c3-4280-b8c6-5802511e83f4

## After: [ddnet7](https://github.com/ddnet/ddnet/pull/5949) as long as the internet is stable and no snaps are dropped no effect is lost

https://github.com/ddnet/ddnet/assets/20344300/3dab63bd-11dd-4ca9-9711-153a491329e8

Make sure to unmute the github videos to hear the difference.

## Checklist

- [x] Tested the change ingame
- [x] Provided mp4 file if it is a audible change :stuck_out_tongue_winking_eye: 
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
