### PR TITLE
Add support for colored broadcast (0.7 compatible)

### DIFF
--- a/src/game/client/components/broadcast.cpp
+++ b/src/game/client/components/broadcast.cpp
@@ -116,6 +116,14 @@ void CBroadcast::OnBroadcastMessage(const CNetMsg_Sv_Broadcast *pMsg)
 	for(int i = 0; i < MsgLength && ServerMsgLen < MAX_BROADCAST_MSG_SIZE - 1; i++)
 	{
 		const char *c = pMsg->m_pMessage + i;
+
+		if(*c == '\\' && c[1] == '^')
+		{
+			m_aBroadcastText[ServerMsgLen++] = c[1];
+			i++; // skip '^'
+			continue;
+		}
+
 		if(*c == '^' && i + 3 < MsgLength && str_isnum(c[1]) && str_isnum(c[2]) && str_isnum(c[3]))
 		{
 			m_aSegments[NumSegments].m_Color = ColorRGBA((c[1] - '0') / 9.0f, (c[2] - '0') / 9.0f, (c[3] - '0') / 9.0f, 1.0f);

--- a/src/game/client/components/broadcast.h
+++ b/src/game/client/components/broadcast.h
@@ -3,6 +3,7 @@
 #ifndef GAME_CLIENT_COMPONENTS_BROADCAST_H
 #define GAME_CLIENT_COMPONENTS_BROADCAST_H
 
+#include <base/color.h>
 #include <engine/textrender.h>
 #include <game/generated/protocol.h>
 
@@ -10,11 +11,26 @@
 
 class CBroadcast : public CComponent
 {
+	enum
+	{
+		MAX_BROADCAST_MSG_SIZE = 1024,
+		MAX_BROADCAST_COLOR_SEGMENTS = MAX_BROADCAST_MSG_SIZE / 4
+	};
+
+	class CBroadcastSegment
+	{
+	public:
+		// start index in m_aBroadcastText
+		int m_TextIndex = -1;
+		ColorRGBA m_Color;
+	};
+
 	// broadcasts
-	char m_aBroadcastText[1024];
+	char m_aBroadcastText[MAX_BROADCAST_MSG_SIZE];
 	int m_BroadcastTick;
 	float m_BroadcastRenderOffset;
-	STextContainerIndex m_TextContainerIndex;
+	STextContainerIndex m_aTextContainerIndices[MAX_BROADCAST_COLOR_SEGMENTS];
+	CBroadcastSegment m_aSegments[MAX_BROADCAST_COLOR_SEGMENTS];
 
 	void RenderServerBroadcast();
 	void OnBroadcastMessage(const CNetMsg_Sv_Broadcast *pMsg);


### PR DESCRIPTION
Example rcon command:
```
broadcast "aaaaaaa^123bbbbbbbbbbbb^321cccccccccccccccccc"
```

^123 and ^321 are the color codes that will not be included in the displayed text

![ddnet_teeworlds_broadcast_color_codes](https://github.com/ddnet/ddnet/assets/20344300/37ae9d99-a6f6-49b7-b555-93105d69bfb9)

See https://github.com/ddnet/ddnet/issues/4897

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
