### PR TITLE
Don't access static ConCommandStatus with a member

### DIFF
--- a/src/engine/shared/console.cpp
+++ b/src/engine/shared/console.cpp
@@ -736,7 +736,7 @@ void CConsole::ConUserCommandStatus(IResult *pResult, void *pUser)
 	str_from_int((int)IConsole::ACCESS_LEVEL_USER, aBuf);
 	Result.AddArgument(aBuf);
 
-	pConsole->ConCommandStatus(&Result, pConsole);
+	CConsole::ConCommandStatus(&Result, pConsole);
 }
 
 void CConsole::TraverseChain(FCommandCallback *ppfnCallback, void **ppUserData)


### PR DESCRIPTION
Fixes this clang-tidy 19 warning

```
/home/chiller/Desktop/git/ddnet/src/engine/shared/console.cpp:739:2: error: static member accessed through instance [readability-static-accessed-through-instance,-warnings-as-errors]
  739 |         pConsole->ConCommandStatus(&Result, pConsole);
      |         ^~~~~~~~~~
      |         CConsole::
```

