### PR TITLE
Enforce more styling with clang tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -100,7 +100,33 @@ CheckOptions:
   - key:             readability-identifier-naming.StaticVariableCase
     value:           aNy_CasE
   - key:             readability-identifier-naming.LocalConstantCase
-    value:           aNy_CasE
+    value:           CamelCase
+  - key:             readability-identifier-naming.ClassMemberCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.ClassMemberPrefix
+    value:           m_
+  - key:             readability-identifier-naming.ClassMethodCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.ClassCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.ClassPrefix
+    value:           C
+  - key:             readability-identifier-naming.StructPrefix
+    value:           S
+  - key:             readability-identifier-naming.StructIgnoredRegexp
+    value:           '^([CS]|MapObject$|EnvelopedQuad$).*'
+  - key:             readability-identifier-naming.ClassIgnoredRegexp
+    value:           '^(CCommandProcessorFragment_Vulkan$).*'
+  - key:             readability-identifier-naming.ParameterCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.ParameterIgnoredRegexp
+    value:           '^(p|a|v|[a-z]$|s[hw]$|warning_msg$|error_msg$|string$|integer$|boolean$|object$|index$|rhs$|lhs$|[xy]off$|id$|mode$|rgb$|[xy][0123]$|width$|height$|[sdw][xy]$|ownId$|fnMatchCallback$).*'
+  - key:             readability-identifier-naming.ClassMethodIgnoredRegexp
+    value:           '^(Con_).*'
+  - key:             readability-identifier-naming.ClassMemberIgnoredRegexp
+    value:           '^(ms_aStandardScreen$|s_1024x1024ImgSize$|s_ImageBufferCacheId$|s_VertexBufferCacheId$|s_StagingBufferImageCacheId$|REPLACEMENT_CHARACTER$|(MAX|MIN)_FONT_SIZE$|MAXIMUM_ATLAS_DIMENSION$|INITIAL_ATLAS_DIMENSION$|MAX_SECTION_DIMENSION_MAPPED$|MIN_SECTION_DIMENSION$|s_StagingBufferCacheId$|ms_MainThreadIndex$).*'
+  - key:             readability-identifier-naming.LocalConstantIgnoredRegexp
+    value:           '^(p|a|v|s_|MAX_ANIM_SPEED$|DATA_OFFSET$|HEADER_LEN$|MIN_ANIM_SPEED$|[hwdcbqstf]$|[xt][0123]$|result$|sub$|it$|len$|d[xy]$).*'
   - key:             readability-identifier-naming.LocalVariableIgnoredRegexp
     value:           '^(p|a|s_|FT_|TB_|s_|ul_|v|[xy]i$|[zijklxyhmrgbacwestnduvqf]$|[dmpwsitcf][xy]$|(ch|skel)[0-2]?$|it$|tw$|dt$|th$|ls$|func$|res$|shader$|len$|maxLength$|length$|offset$|offpos$|result$|bg$|sp$|url$|Tickdelta_legacy$|index$|ctxt$|key$|null$|logger$|LAST_MODIFIED$|GfxFsaaSamples_MouseButton$|teleNr$|target$|id$|hit$|hsl[0-2]?$|rgb[0-2]?$|dir$|tmp$|cData$|sub$|ret$|rendered$|(lower|upper)(16|26|24|32)|size$|wSearch$|bAlreadyHit$|isWeaponCollide$|zerochar$|dist$|sound$|match$|best_skin$|best_matches$|m_aClient$|matches$|nohook$|through_cut$|btn$|savedLayers$|l[hw]$|evilz$|sec$|min$|to2$|delay$|m_TileF?Index$|mode$|maxModes$|numModes$|iLogLength$|[xy]Fract$|[xy]Int$|imgg[xy]$|skip$|localPlayer$|fdratio$|[rgbat][0-2]$|[xy][0-3]$|x[rl]$).*'
 


### PR DESCRIPTION
It already used to enforce camel case for variables defined in methods.

It now also enforces camel case for local constants, class members, class methods, class names, struct names, method parameters.

It also enforces a m_ prefix for class member and a C/S prefix for class and struct names.

There are a bunch of exceptions with ignore regexes to make it pass on the current code base without any changes.
The most crazy one is that structs starting with `C` or `S` are okay. There are just too many structs in the code that start with `C` instead of `S`. And it seems like clang tries to apply class and struct prefixes to structs. So it would try to enforce `CSClassName`. That could be smoothed out when we decide that we want to use classes instead of structs in the future https://github.com/ddnet/ddnet/pull/8288.
