### PR TITLE
Fix smoke particles sometimes being stuck inside solid tiles

### DIFF
--- a/src/game/client/components/effects.cpp
+++ b/src/game/client/components/effects.cpp
@@ -257,6 +257,28 @@ void CEffects::Explosion(vec2 Pos, float Alpha)
 	p.m_StartAlpha = Alpha;
 	m_pClient->m_Particles.Add(CParticles::GROUP_EXPLOSIONS, &p);
 
+	// Nudge position slightly to edge of closest tile so the
+	// smoke doesn't get stuck inside the tile.
+	if(Collision()->CheckPoint(Pos))
+	{
+		const vec2 DistanceToTopLeft = Pos - vec2(round_truncate(Pos.x / 32), round_truncate(Pos.y / 32)) * 32;
+
+		vec2 CheckOffset;
+		CheckOffset.x = (DistanceToTopLeft.x > 16 ? 32 : -1);
+		CheckOffset.y = (DistanceToTopLeft.y > 16 ? 32 : -1);
+		CheckOffset -= DistanceToTopLeft;
+
+		for(vec2 Mask : {vec2(1.0f, 0.0f), vec2(0.0f, 1.0f), vec2(1.0f, 1.0f)})
+		{
+			const vec2 NewPos = Pos + CheckOffset * Mask;
+			if(!Collision()->CheckPoint(NewPos))
+			{
+				Pos = NewPos;
+				break;
+			}
+		}
+	}
+
 	// add the smoke
 	for(int i = 0; i < 24; i++)
 	{


### PR DESCRIPTION
Nudge the initial position for explosions' smoke particles slightly towards the edge of the closest non-solid tile, if it would otherwise be inside a solid tile, so the smoke particles do not get stuck inside solid tiles on explosion events happening at the edges of tiles but slightly inside them. The physical position of the explosion event is unchanged, so this does not affect physics. The explosion sprite is still rendered at the physical position of the explosion, to preserve the apprearance.

Comparison screenshots:
- Before (several smoke particles could bunch of at the center of the explosion depending on the exact position):
![smoke-old](https://github.com/ddnet/ddnet/assets/23437060/557608d3-2f92-4e6f-9a87-ed47fecf5b81)
- After:
![smoke-new](https://github.com/ddnet/ddnet/assets/23437060/6f61d634-d26b-4414-9997-6461faed049a)

Comparison videos:

- Before:

https://github.com/ddnet/ddnet/assets/23437060/a8cc59df-12ca-4105-837e-4ee43e66237a

- After:

https://github.com/ddnet/ddnet/assets/23437060/e08976d6-b933-41f7-96b7-4802adf475d2


## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
