### PR TITLE
Add chat commands for toggling weapons in practice mode

### DIFF
--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -1876,22 +1876,43 @@ void CGameContext::ConLastTele(IConsole::IResult *pResult, void *pUserData)
 	pPlayer->Pause(CPlayer::PAUSE_NONE, true);
 }
 
-std::optional<CCharacter *> CGameContext::GetPracticeCharacter(IConsole::IResult *pResult, void *pUserData)
+CCharacter *CGameContext::GetPracticeCharacter(IConsole::IResult *pResult)
+{
+	if(!CheckClientId(pResult->m_ClientId))
+		return nullptr;
+	CPlayer *pPlayer = m_apPlayers[pResult->m_ClientId];
+	if(!pPlayer)
+		return nullptr;
+	CCharacter *pChr = pPlayer->GetCharacter();
+	if(!pChr)
+		return nullptr;
+
+	CGameTeams &Teams = m_pController->Teams();
+	int Team = GetDDRaceTeam(pResult->m_ClientId);
+	if(!Teams.IsPractice(Team))
+	{
+		SendChatTarget(pPlayer->GetCid(), "You're not in a team with /practice turned on. Note that you can't earn a rank with practice enabled.");
+		return nullptr;
+	}
+	return pChr;
+}
+
+void CGameContext::ConPracticeUnSolo(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
 	if(!CheckClientId(pResult->m_ClientId))
-		return std::nullopt;
+		return;
 	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientId];
 	if(!pPlayer)
-		return std::nullopt;
+		return;
 	CCharacter *pChr = pPlayer->GetCharacter();
 	if(!pChr)
-		return std::nullopt;
+		return;
 
 	if(g_Config.m_SvTeam == SV_TEAM_FORBIDDEN || g_Config.m_SvTeam == SV_TEAM_FORCED_SOLO)
 	{
 		pSelf->SendChatTarget(pPlayer->GetCid(), "Command is not available on solo servers");
-		return std::nullopt;
+		return;
 	}
 
 	CGameTeams &Teams = pSelf->m_pController->Teams();
@@ -1899,122 +1920,154 @@ std::optional<CCharacter *> CGameContext::GetPracticeCharacter(IConsole::IResult
 	if(!Teams.IsPractice(Team))
 	{
 		pSelf->SendChatTarget(pPlayer->GetCid(), "You're not in a team with /practice turned on. Note that you can't earn a rank with practice enabled.");
-		return std::nullopt;
+		return;
 	}
-	return pChr;
-}
-
-void CGameContext::ConPracticeUnSolo(IConsole::IResult *pResult, void *pUserData)
-{
-	auto pChr = GetPracticeCharacter(pResult, pUserData);
-	if(pChr.has_value())
-		pChr.value()->SetSolo(false);
+	pChr->SetSolo(false);
 }
 
 void CGameContext::ConPracticeSolo(IConsole::IResult *pResult, void *pUserData)
 {
-	auto pChr = GetPracticeCharacter(pResult, pUserData);
-	if(pChr.has_value())
-		pChr.value()->SetSolo(true);
+	CGameContext *pSelf = (CGameContext *)pUserData;
+	if(!CheckClientId(pResult->m_ClientId))
+		return;
+	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientId];
+	if(!pPlayer)
+		return;
+	CCharacter *pChr = pPlayer->GetCharacter();
+	if(!pChr)
+		return;
+
+	if(g_Config.m_SvTeam == SV_TEAM_FORBIDDEN || g_Config.m_SvTeam == SV_TEAM_FORCED_SOLO)
+	{
+		pSelf->SendChatTarget(pPlayer->GetCid(), "Command is not available on solo servers");
+		return;
+	}
+
+	CGameTeams &Teams = pSelf->m_pController->Teams();
+	int Team = pSelf->GetDDRaceTeam(pResult->m_ClientId);
+	if(!Teams.IsPractice(Team))
+	{
+		pSelf->SendChatTarget(pPlayer->GetCid(), "You're not in a team with /practice turned on. Note that you can't earn a rank with practice enabled.");
+		return;
+	}
+	pChr->SetSolo(true);
 }
 
 void CGameContext::ConPracticeUnDeep(IConsole::IResult *pResult, void *pUserData)
 {
-	auto pChr = GetPracticeCharacter(pResult, pUserData);
-	if(pChr.has_value())
-	{
-		pChr.value()->SetDeepFrozen(false);
-		pChr.value()->UnFreeze();
-	}
+	CGameContext *pSelf = (CGameContext *)pUserData;
+	auto *pChr = pSelf->GetPracticeCharacter(pResult);
+	if(!pChr)
+		return;
+
+	pChr->SetDeepFrozen(false);
+	pChr->UnFreeze();
 }
 
 void CGameContext::ConPracticeDeep(IConsole::IResult *pResult, void *pUserData)
 {
-	auto pChr = GetPracticeCharacter(pResult, pUserData);
-	if(pChr.has_value())
-		pChr.value()->SetDeepFrozen(true);
+	CGameContext *pSelf = (CGameContext *)pUserData;
+	auto *pChr = pSelf->GetPracticeCharacter(pResult);
+	if(!pChr)
+		return;
+
+	pChr->SetDeepFrozen(true);
 }
 
 void CGameContext::ConPracticeShotgun(IConsole::IResult *pResult, void *pUserData)
 {
-	if(GetPracticeCharacter(pResult, pUserData))
+	CGameContext *pSelf = (CGameContext *)pUserData;
+	if(pSelf->GetPracticeCharacter(pResult))
 		ConShotgun(pResult, pUserData);
 }
 
 void CGameContext::ConPracticeGrenade(IConsole::IResult *pResult, void *pUserData)
 {
-	if(GetPracticeCharacter(pResult, pUserData))
+	CGameContext *pSelf = (CGameContext *)pUserData;
+	if(pSelf->GetPracticeCharacter(pResult))
 		ConGrenade(pResult, pUserData);
 }
 
 void CGameContext::ConPracticeLaser(IConsole::IResult *pResult, void *pUserData)
 {
-	if(GetPracticeCharacter(pResult, pUserData))
+	CGameContext *pSelf = (CGameContext *)pUserData;
+	if(pSelf->GetPracticeCharacter(pResult))
 		ConLaser(pResult, pUserData);
 }
 
 void CGameContext::ConPracticeJetpack(IConsole::IResult *pResult, void *pUserData)
 {
-	if(GetPracticeCharacter(pResult, pUserData))
+	CGameContext *pSelf = (CGameContext *)pUserData;
+	if(pSelf->GetPracticeCharacter(pResult))
 		ConJetpack(pResult, pUserData);
 }
 
 void CGameContext::ConPracticeWeapons(IConsole::IResult *pResult, void *pUserData)
 {
-	if(GetPracticeCharacter(pResult, pUserData))
+	CGameContext *pSelf = (CGameContext *)pUserData;
+	if(pSelf->GetPracticeCharacter(pResult))
 		ConWeapons(pResult, pUserData);
 }
 
 void CGameContext::ConPracticeUnShotgun(IConsole::IResult *pResult, void *pUserData)
 {
-	if(GetPracticeCharacter(pResult, pUserData))
+	CGameContext *pSelf = (CGameContext *)pUserData;
+	if(pSelf->GetPracticeCharacter(pResult))
 		ConUnShotgun(pResult, pUserData);
 }
 
 void CGameContext::ConPracticeUnGrenade(IConsole::IResult *pResult, void *pUserData)
 {
-	if(GetPracticeCharacter(pResult, pUserData))
+	CGameContext *pSelf = (CGameContext *)pUserData;
+	if(pSelf->GetPracticeCharacter(pResult))
 		ConUnGrenade(pResult, pUserData);
 }
 
 void CGameContext::ConPracticeUnLaser(IConsole::IResult *pResult, void *pUserData)
 {
-	if(GetPracticeCharacter(pResult, pUserData))
+	CGameContext *pSelf = (CGameContext *)pUserData;
+	if(pSelf->GetPracticeCharacter(pResult))
 		ConUnLaser(pResult, pUserData);
 }
 
 void CGameContext::ConPracticeUnJetpack(IConsole::IResult *pResult, void *pUserData)
 {
-	if(GetPracticeCharacter(pResult, pUserData))
+	CGameContext *pSelf = (CGameContext *)pUserData;
+	if(pSelf->GetPracticeCharacter(pResult))
 		ConUnJetpack(pResult, pUserData);
 }
 
 void CGameContext::ConPracticeUnWeapons(IConsole::IResult *pResult, void *pUserData)
 {
-	if(GetPracticeCharacter(pResult, pUserData))
+	CGameContext *pSelf = (CGameContext *)pUserData;
+	if(pSelf->GetPracticeCharacter(pResult))
 		ConUnWeapons(pResult, pUserData);
 }
 
 void CGameContext::ConPracticeNinja(IConsole::IResult *pResult, void *pUserData)
 {
-	if(GetPracticeCharacter(pResult, pUserData))
+	CGameContext *pSelf = (CGameContext *)pUserData;
+	if(pSelf->GetPracticeCharacter(pResult))
 		ConNinja(pResult, pUserData);
 }
 void CGameContext::ConPracticeUnNinja(IConsole::IResult *pResult, void *pUserData)
 {
-	if(GetPracticeCharacter(pResult, pUserData))
+	CGameContext *pSelf = (CGameContext *)pUserData;
+	if(pSelf->GetPracticeCharacter(pResult))
 		ConUnNinja(pResult, pUserData);
 }
 
 void CGameContext::ConPracticeAddWeapon(IConsole::IResult *pResult, void *pUserData)
 {
-	if(GetPracticeCharacter(pResult, pUserData))
+	CGameContext *pSelf = (CGameContext *)pUserData;
+	if(pSelf->GetPracticeCharacter(pResult))
 		ConAddWeapon(pResult, pUserData);
 }
 
 void CGameContext::ConPracticeRemoveWeapon(IConsole::IResult *pResult, void *pUserData)
 {
-	if(GetPracticeCharacter(pResult, pUserData))
+	CGameContext *pSelf = (CGameContext *)pUserData;
+	if(pSelf->GetPracticeCharacter(pResult))
 		ConRemoveWeapon(pResult, pUserData);
 }
 

--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -11,6 +11,8 @@
 #include "player.h"
 #include "score.h"
 
+#include <optional>
+
 bool CheckClientId(int ClientId);
 
 void CGameContext::ConCredits(IConsole::IResult *pResult, void *pUserData)
@@ -1874,22 +1876,22 @@ void CGameContext::ConLastTele(IConsole::IResult *pResult, void *pUserData)
 	pPlayer->Pause(CPlayer::PAUSE_NONE, true);
 }
 
-void CGameContext::ConPracticeUnSolo(IConsole::IResult *pResult, void *pUserData)
+inline std::optional<CCharacter *> CGameContext::GetPracticeCharacter(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
 	if(!CheckClientId(pResult->m_ClientId))
-		return;
+		return std::nullopt;
 	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientId];
 	if(!pPlayer)
-		return;
+		return std::nullopt;
 	CCharacter *pChr = pPlayer->GetCharacter();
 	if(!pChr)
-		return;
+		return std::nullopt;
 
 	if(g_Config.m_SvTeam == SV_TEAM_FORBIDDEN || g_Config.m_SvTeam == SV_TEAM_FORCED_SOLO)
 	{
 		pSelf->SendChatTarget(pPlayer->GetCid(), "Command is not available on solo servers");
-		return;
+		return std::nullopt;
 	}
 
 	CGameTeams &Teams = pSelf->m_pController->Teams();
@@ -1897,10 +1899,99 @@ void CGameContext::ConPracticeUnSolo(IConsole::IResult *pResult, void *pUserData
 	if(!Teams.IsPractice(Team))
 	{
 		pSelf->SendChatTarget(pPlayer->GetCid(), "You're not in a team with /practice turned on. Note that you can't earn a rank with practice enabled.");
-		return;
+		return std::nullopt;
 	}
+	return pChr;
+}
 
-	pChr->SetSolo(false);
+void CGameContext::ConPracticeUnSolo(IConsole::IResult *pResult, void *pUserData)
+{
+	auto pChr = GetPracticeCharacter(pResult, pUserData);
+	if(pChr.has_value())
+		pChr.value()->SetSolo(false);
+}
+
+void CGameContext::ConPracticeShotgun(IConsole::IResult *pResult, void *pUserData)
+{
+	if(GetPracticeCharacter(pResult, pUserData))
+		ConShotgun(pResult, pUserData);
+}
+
+void CGameContext::ConPracticeGrenade(IConsole::IResult *pResult, void *pUserData)
+{
+	if(GetPracticeCharacter(pResult, pUserData))
+		ConGrenade(pResult, pUserData);
+}
+
+void CGameContext::ConPracticeLaser(IConsole::IResult *pResult, void *pUserData)
+{
+	if(GetPracticeCharacter(pResult, pUserData))
+		ConLaser(pResult, pUserData);
+}
+
+void CGameContext::ConPracticeJetpack(IConsole::IResult *pResult, void *pUserData)
+{
+	if(GetPracticeCharacter(pResult, pUserData))
+		ConJetpack(pResult, pUserData);
+}
+
+void CGameContext::ConPracticeWeapons(IConsole::IResult *pResult, void *pUserData)
+{
+	if(GetPracticeCharacter(pResult, pUserData))
+		ConWeapons(pResult, pUserData);
+}
+
+void CGameContext::ConPracticeUnShotgun(IConsole::IResult *pResult, void *pUserData)
+{
+	if(GetPracticeCharacter(pResult, pUserData))
+		ConUnShotgun(pResult, pUserData);
+}
+
+void CGameContext::ConPracticeUnGrenade(IConsole::IResult *pResult, void *pUserData)
+{
+	if(GetPracticeCharacter(pResult, pUserData))
+		ConUnGrenade(pResult, pUserData);
+}
+
+void CGameContext::ConPracticeUnLaser(IConsole::IResult *pResult, void *pUserData)
+{
+	if(GetPracticeCharacter(pResult, pUserData))
+		ConUnLaser(pResult, pUserData);
+}
+
+void CGameContext::ConPracticeUnJetpack(IConsole::IResult *pResult, void *pUserData)
+{
+	if(GetPracticeCharacter(pResult, pUserData))
+		ConUnJetpack(pResult, pUserData);
+}
+
+void CGameContext::ConPracticeUnWeapons(IConsole::IResult *pResult, void *pUserData)
+{
+	if(GetPracticeCharacter(pResult, pUserData))
+		ConUnWeapons(pResult, pUserData);
+}
+
+void CGameContext::ConPracticeNinja(IConsole::IResult *pResult, void *pUserData)
+{
+	if(GetPracticeCharacter(pResult, pUserData))
+		ConNinja(pResult, pUserData);
+}
+void CGameContext::ConPracticeUnNinja(IConsole::IResult *pResult, void *pUserData)
+{
+	if(GetPracticeCharacter(pResult, pUserData))
+		ConUnNinja(pResult, pUserData);
+}
+
+void CGameContext::ConPracticeAddWeapon(IConsole::IResult *pResult, void *pUserData)
+{
+	if(GetPracticeCharacter(pResult, pUserData))
+		ConAddWeapon(pResult, pUserData);
+}
+
+void CGameContext::ConPracticeRemoveWeapon(IConsole::IResult *pResult, void *pUserData)
+{
+	if(GetPracticeCharacter(pResult, pUserData))
+		ConRemoveWeapon(pResult, pUserData);
 }
 
 void CGameContext::ConPracticeSolo(IConsole::IResult *pResult, void *pUserData)

--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -1911,6 +1911,30 @@ void CGameContext::ConPracticeUnSolo(IConsole::IResult *pResult, void *pUserData
 		pChr.value()->SetSolo(false);
 }
 
+void CGameContext::ConPracticeSolo(IConsole::IResult *pResult, void *pUserData)
+{
+	auto pChr = GetPracticeCharacter(pResult, pUserData);
+	if(pChr.has_value())
+		pChr.value()->SetSolo(true);
+}
+
+void CGameContext::ConPracticeUnDeep(IConsole::IResult *pResult, void *pUserData)
+{
+	auto pChr = GetPracticeCharacter(pResult, pUserData);
+	if(pChr.has_value())
+	{
+		pChr.value()->SetDeepFrozen(false);
+		pChr.value()->UnFreeze();
+	}
+}
+
+void CGameContext::ConPracticeDeep(IConsole::IResult *pResult, void *pUserData)
+{
+	auto pChr = GetPracticeCharacter(pResult, pUserData);
+	if(pChr.has_value())
+		pChr.value()->SetDeepFrozen(true);
+}
+
 void CGameContext::ConPracticeShotgun(IConsole::IResult *pResult, void *pUserData)
 {
 	if(GetPracticeCharacter(pResult, pUserData))
@@ -1992,82 +2016,6 @@ void CGameContext::ConPracticeRemoveWeapon(IConsole::IResult *pResult, void *pUs
 {
 	if(GetPracticeCharacter(pResult, pUserData))
 		ConRemoveWeapon(pResult, pUserData);
-}
-
-void CGameContext::ConPracticeSolo(IConsole::IResult *pResult, void *pUserData)
-{
-	CGameContext *pSelf = (CGameContext *)pUserData;
-	if(!CheckClientId(pResult->m_ClientId))
-		return;
-	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientId];
-	if(!pPlayer)
-		return;
-	CCharacter *pChr = pPlayer->GetCharacter();
-	if(!pChr)
-		return;
-
-	if(g_Config.m_SvTeam == SV_TEAM_FORBIDDEN || g_Config.m_SvTeam == SV_TEAM_FORCED_SOLO)
-	{
-		pSelf->SendChatTarget(pPlayer->GetCid(), "Command is not available on solo servers");
-		return;
-	}
-
-	CGameTeams &Teams = pSelf->m_pController->Teams();
-	int Team = pSelf->GetDDRaceTeam(pResult->m_ClientId);
-	if(!Teams.IsPractice(Team))
-	{
-		pSelf->SendChatTarget(pPlayer->GetCid(), "You're not in a team with /practice turned on. Note that you can't earn a rank with practice enabled.");
-		return;
-	}
-
-	pChr->SetSolo(true);
-}
-
-void CGameContext::ConPracticeUnDeep(IConsole::IResult *pResult, void *pUserData)
-{
-	CGameContext *pSelf = (CGameContext *)pUserData;
-	if(!CheckClientId(pResult->m_ClientId))
-		return;
-	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientId];
-	if(!pPlayer)
-		return;
-	CCharacter *pChr = pPlayer->GetCharacter();
-	if(!pChr)
-		return;
-
-	CGameTeams &Teams = pSelf->m_pController->Teams();
-	int Team = pSelf->GetDDRaceTeam(pResult->m_ClientId);
-	if(!Teams.IsPractice(Team))
-	{
-		pSelf->SendChatTarget(pPlayer->GetCid(), "You're not in a team with /practice turned on. Note that you can't earn a rank with practice enabled.");
-		return;
-	}
-
-	pChr->SetDeepFrozen(false);
-	pChr->UnFreeze();
-}
-
-void CGameContext::ConPracticeDeep(IConsole::IResult *pResult, void *pUserData)
-{
-	CGameContext *pSelf = (CGameContext *)pUserData;
-	if(!CheckClientId(pResult->m_ClientId))
-		return;
-	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientId];
-	if(!pPlayer)
-		return;
-	CCharacter *pChr = pPlayer->GetCharacter();
-	if(!pChr)
-		return;
-
-	CGameTeams &Teams = pSelf->m_pController->Teams();
-	int Team = pSelf->GetDDRaceTeam(pResult->m_ClientId);
-	if(!Teams.IsPractice(Team))
-	{
-		pSelf->SendChatTarget(pPlayer->GetCid(), "You're not in a team with /practice turned on. Note that you can't earn a rank with practice enabled.");
-		return;
-	}
-
-	pChr->SetDeepFrozen(true);
 }
 
 void CGameContext::ConProtectedKill(IConsole::IResult *pResult, void *pUserData)

--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -1876,7 +1876,7 @@ void CGameContext::ConLastTele(IConsole::IResult *pResult, void *pUserData)
 	pPlayer->Pause(CPlayer::PAUSE_NONE, true);
 }
 
-inline std::optional<CCharacter *> CGameContext::GetPracticeCharacter(IConsole::IResult *pResult, void *pUserData)
+std::optional<CCharacter *> CGameContext::GetPracticeCharacter(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
 	if(!CheckClientId(pResult->m_ClientId))

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -3635,25 +3635,6 @@ void CGameContext::RegisterDDRaceCommands()
 
 void CGameContext::RegisterChatCommands()
 {
-	//
-	Console()->Register("addweapon", "i[weapon-id]", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeAddWeapon, this, "Gives weapon with id i to you (all = -1, hammer = 0, gun = 1, shotgun = 2, grenade = 3, laser = 4, ninja = 5)");
-	Console()->Register("removeweapon", "i[weapon-id]", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeRemoveWeapon, this, "removes weapon with id i from you (all = -1, hammer = 0, gun = 1, shotgun = 2, grenade = 3, laser = 4, ninja = 5)");
-	Console()->Register("shotgun", "", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeShotgun, this, "Gives a shotgun to you");
-	Console()->Register("grenade", "", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeGrenade, this, "Gives a grenade launcher to you");
-	Console()->Register("laser", "", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeLaser, this, "Gives a laser to you");
-	Console()->Register("rifle", "", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeLaser, this, "Gives a laser to you");
-	Console()->Register("jetpack", "", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeJetpack, this, "Gives jetpack to you");
-	Console()->Register("weapons", "", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeWeapons, this, "Gives all weapons to you");
-	Console()->Register("unshotgun", "", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeUnShotgun, this, "Removes the shotgun from you");
-	Console()->Register("ungrenade", "", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeUnGrenade, this, "Removes the grenade launcher from you");
-	Console()->Register("unlaser", "", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeUnLaser, this, "Removes the laser from you");
-	Console()->Register("unrifle", "", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeUnLaser, this, "Removes the laser from you");
-	Console()->Register("unjetpack", "", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeUnJetpack, this, "Removes the jetpack from you");
-	Console()->Register("unweapons", "", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeUnWeapons, this, "Removes all weapons from you");
-	Console()->Register("ninja", "", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeNinja, this, "Makes you a ninja");
-	Console()->Register("unninja", "", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeUnNinja, this, "Removes ninja from you");
-	//
-
 	Console()->Register("credits", "", CFGFLAG_CHAT | CFGFLAG_SERVER, ConCredits, this, "Shows the credits of the DDNet mod");
 	Console()->Register("rules", "", CFGFLAG_CHAT | CFGFLAG_SERVER, ConRules, this, "Shows the server rules");
 	Console()->Register("emote", "?s[emote name] i[duration in seconds]", CFGFLAG_CHAT | CFGFLAG_SERVER, ConEyeEmote, this, "Sets your tee's eye emote");
@@ -3721,6 +3702,22 @@ void CGameContext::RegisterChatCommands()
 	Console()->Register("solo", "", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeSolo, this, "Puts you into solo part");
 	Console()->Register("undeep", "", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeUnDeep, this, "Puts you out of deep freeze");
 	Console()->Register("deep", "", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeDeep, this, "Puts you into deep freeze");
+	Console()->Register("addweapon", "i[weapon-id]", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeAddWeapon, this, "Gives weapon with id i to you (all = -1, hammer = 0, gun = 1, shotgun = 2, grenade = 3, laser = 4, ninja = 5)");
+	Console()->Register("removeweapon", "i[weapon-id]", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeRemoveWeapon, this, "removes weapon with id i from you (all = -1, hammer = 0, gun = 1, shotgun = 2, grenade = 3, laser = 4, ninja = 5)");
+	Console()->Register("shotgun", "", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeShotgun, this, "Gives a shotgun to you");
+	Console()->Register("grenade", "", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeGrenade, this, "Gives a grenade launcher to you");
+	Console()->Register("laser", "", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeLaser, this, "Gives a laser to you");
+	Console()->Register("rifle", "", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeLaser, this, "Gives a laser to you");
+	Console()->Register("jetpack", "", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeJetpack, this, "Gives jetpack to you");
+	Console()->Register("weapons", "", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeWeapons, this, "Gives all weapons to you");
+	Console()->Register("unshotgun", "", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeUnShotgun, this, "Removes the shotgun from you");
+	Console()->Register("ungrenade", "", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeUnGrenade, this, "Removes the grenade launcher from you");
+	Console()->Register("unlaser", "", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeUnLaser, this, "Removes the laser from you");
+	Console()->Register("unrifle", "", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeUnLaser, this, "Removes the laser from you");
+	Console()->Register("unjetpack", "", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeUnJetpack, this, "Removes the jetpack from you");
+	Console()->Register("unweapons", "", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeUnWeapons, this, "Removes all weapons from you");
+	Console()->Register("ninja", "", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeNinja, this, "Makes you a ninja");
+	Console()->Register("unninja", "", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeUnNinja, this, "Removes ninja from you");
 
 	Console()->Register("kill", "", CFGFLAG_CHAT | CFGFLAG_SERVER, ConProtectedKill, this, "Kill yourself when kill-protected during a long game (use f1, kill for regular kill)");
 }

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -3635,6 +3635,25 @@ void CGameContext::RegisterDDRaceCommands()
 
 void CGameContext::RegisterChatCommands()
 {
+	//
+	Console()->Register("addweapon", "i[weapon-id]", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeAddWeapon, this, "Gives weapon with id i to you (all = -1, hammer = 0, gun = 1, shotgun = 2, grenade = 3, laser = 4, ninja = 5)");
+	Console()->Register("removeweapon", "i[weapon-id]", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeRemoveWeapon, this, "removes weapon with id i from you (all = -1, hammer = 0, gun = 1, shotgun = 2, grenade = 3, laser = 4, ninja = 5)");
+	Console()->Register("shotgun", "", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeShotgun, this, "Gives a shotgun to you");
+	Console()->Register("grenade", "", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeGrenade, this, "Gives a grenade launcher to you");
+	Console()->Register("laser", "", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeLaser, this, "Gives a laser to you");
+	Console()->Register("rifle", "", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeLaser, this, "Gives a laser to you");
+	Console()->Register("jetpack", "", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeJetpack, this, "Gives jetpack to you");
+	Console()->Register("weapons", "", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeWeapons, this, "Gives all weapons to you");
+	Console()->Register("unshotgun", "", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeUnShotgun, this, "Removes the shotgun from you");
+	Console()->Register("ungrenade", "", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeUnGrenade, this, "Removes the grenade launcher from you");
+	Console()->Register("unlaser", "", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeUnLaser, this, "Removes the laser from you");
+	Console()->Register("unrifle", "", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeUnLaser, this, "Removes the laser from you");
+	Console()->Register("unjetpack", "", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeUnJetpack, this, "Removes the jetpack from you");
+	Console()->Register("unweapons", "", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeUnWeapons, this, "Removes all weapons from you");
+	Console()->Register("ninja", "", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeNinja, this, "Makes you a ninja");
+	Console()->Register("unninja", "", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeUnNinja, this, "Removes ninja from you");
+	//
+
 	Console()->Register("credits", "", CFGFLAG_CHAT | CFGFLAG_SERVER, ConCredits, this, "Shows the credits of the DDNet mod");
 	Console()->Register("rules", "", CFGFLAG_CHAT | CFGFLAG_SERVER, ConRules, this, "Shows the server rules");
 	Console()->Register("emote", "?s[emote name] i[duration in seconds]", CFGFLAG_CHAT | CFGFLAG_SERVER, ConEyeEmote, this, "Sets your tee's eye emote");

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -502,7 +502,7 @@ private:
 	static void ConFreezeHammer(IConsole::IResult *pResult, void *pUserData);
 	static void ConUnFreezeHammer(IConsole::IResult *pResult, void *pUserData);
 
-	static std::optional<CCharacter *> GetPracticeCharacter(IConsole::IResult *pResult, void *pUserData);
+	CCharacter *GetPracticeCharacter(IConsole::IResult *pResult);
 
 	enum
 	{

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -395,7 +395,6 @@ private:
 	static void ConUnWeapons(IConsole::IResult *pResult, void *pUserData);
 	static void ConAddWeapon(IConsole::IResult *pResult, void *pUserData);
 	static void ConRemoveWeapon(IConsole::IResult *pResult, void *pUserData);
-
 	void ModifyWeapons(IConsole::IResult *pResult, void *pUserData, int Weapon, bool Remove);
 	void MoveCharacter(int ClientId, int X, int Y, bool Raw = false);
 	static void ConGoLeft(IConsole::IResult *pResult, void *pUserData);
@@ -462,10 +461,28 @@ private:
 	static void ConTeleXY(IConsole::IResult *pResult, void *pUserData);
 	static void ConTeleCursor(IConsole::IResult *pResult, void *pUserData);
 	static void ConLastTele(IConsole::IResult *pResult, void *pUserData);
+
+	// Practice commands
 	static void ConPracticeUnSolo(IConsole::IResult *pResult, void *pUserData);
 	static void ConPracticeSolo(IConsole::IResult *pResult, void *pUserData);
 	static void ConPracticeUnDeep(IConsole::IResult *pResult, void *pUserData);
 	static void ConPracticeDeep(IConsole::IResult *pResult, void *pUserData);
+	static void ConPracticeShotgun(IConsole::IResult *pResult, void *pUserData);
+	static void ConPracticeGrenade(IConsole::IResult *pResult, void *pUserData);
+	static void ConPracticeLaser(IConsole::IResult *pResult, void *pUserData);
+	static void ConPracticeJetpack(IConsole::IResult *pResult, void *pUserData);
+	static void ConPracticeWeapons(IConsole::IResult *pResult, void *pUserData);
+	static void ConPracticeUnShotgun(IConsole::IResult *pResult, void *pUserData);
+	static void ConPracticeUnGrenade(IConsole::IResult *pResult, void *pUserData);
+	static void ConPracticeUnLaser(IConsole::IResult *pResult, void *pUserData);
+	static void ConPracticeUnJetpack(IConsole::IResult *pResult, void *pUserData);
+	static void ConPracticeUnWeapons(IConsole::IResult *pResult, void *pUserData);
+	static void ConPracticeNinja(IConsole::IResult *pResult, void *pUserData);
+	static void ConPracticeUnNinja(IConsole::IResult *pResult, void *pUserData);
+
+	static void ConPracticeAddWeapon(IConsole::IResult *pResult, void *pUserData);
+	static void ConPracticeRemoveWeapon(IConsole::IResult *pResult, void *pUserData);
+
 	static void ConProtectedKill(IConsole::IResult *pResult, void *pUserData);
 
 	static void ConVoteMute(IConsole::IResult *pResult, void *pUserData);
@@ -484,6 +501,8 @@ private:
 	static void ConUninvite(IConsole::IResult *pResult, void *pUserData);
 	static void ConFreezeHammer(IConsole::IResult *pResult, void *pUserData);
 	static void ConUnFreezeHammer(IConsole::IResult *pResult, void *pUserData);
+
+	static std::optional<CCharacter *> GetPracticeCharacter(IConsole::IResult *pResult, void *pUserData);
 
 	enum
 	{

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -462,7 +462,7 @@ private:
 	static void ConTeleCursor(IConsole::IResult *pResult, void *pUserData);
 	static void ConLastTele(IConsole::IResult *pResult, void *pUserData);
 
-	// Practice commands
+	// Chat commands for practice mode
 	static void ConPracticeUnSolo(IConsole::IResult *pResult, void *pUserData);
 	static void ConPracticeSolo(IConsole::IResult *pResult, void *pUserData);
 	static void ConPracticeUnDeep(IConsole::IResult *pResult, void *pUserData);


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->
Some people wanted the ability to give themselves weapons within practice mode without having to teleport to the location of the weapon on the map. This allows them to do so by typing something like `/grenade` in the game chat (as long as they're in a team with practice mode enabled).

Note that with the way things are currently being done, there's no clean way for me to "wrap" the callbacks used in the rcon commands cleanly. Currently there has to be a duplicate function for every command that we want to wrap. If you have any ideas on how to reduce the amount of boilerplate please let me know.

Closes #8092

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
