### PR TITLE
Remove RGB images from the map file format

### DIFF
--- a/src/game/client/components/mapimages.cpp
+++ b/src/game/client/components/mapimages.cpp
@@ -109,7 +109,6 @@ void CMapImages::OnMapLoadImpl(class CLayers *pLayers, IMap *pMap)
 	{
 		const int LoadFlag = (((m_aTextureUsedByTileOrQuadLayerFlag[i] & 1) != 0) ? TextureLoadFlag : 0) | (((m_aTextureUsedByTileOrQuadLayerFlag[i] & 2) != 0) ? 0 : (Graphics()->HasTextureArraysSupport() ? IGraphics::TEXLOAD_NO_2D_TEXTURE : 0));
 		const CMapItemImage_v2 *pImg = (CMapItemImage_v2 *)pMap->GetItem(Start + i);
-		const CImageInfo::EImageFormat Format = pImg->m_Version < CMapItemImage_v2::CURRENT_VERSION ? CImageInfo::FORMAT_RGBA : CImageInfo::ImageFormatFromInt(pImg->m_Format);
 
 		const char *pName = pMap->GetDataString(pImg->m_ImageName);
 		if(pName == nullptr || pName[0] == '\0')
@@ -123,18 +122,25 @@ void CMapImages::OnMapLoadImpl(class CLayers *pLayers, IMap *pMap)
 			pName = "(error)";
 		}
 
+		if(pImg->m_Version > 1 && pImg->m_MustBe1 != 1)
+		{
+			log_error("mapimages", "Failed to load map image %d '%s': invalid map image type.", i, pName);
+			ShowWarning = true;
+			continue;
+		}
+
 		if(pImg->m_External)
 		{
 			char aPath[IO_MAX_PATH_LENGTH];
 			str_format(aPath, sizeof(aPath), "mapres/%s.png", pName);
 			m_aTextures[i] = Graphics()->LoadTexture(aPath, IStorage::TYPE_ALL, LoadFlag);
 		}
-		else if(Format == CImageInfo::FORMAT_RGBA)
+		else
 		{
 			CImageInfo ImageInfo;
 			ImageInfo.m_Width = pImg->m_Width;
 			ImageInfo.m_Height = pImg->m_Height;
-			ImageInfo.m_Format = Format;
+			ImageInfo.m_Format = CImageInfo::FORMAT_RGBA;
 			ImageInfo.m_pData = static_cast<uint8_t *>(pMap->GetData(pImg->m_ImageData));
 			char aTexName[IO_MAX_PATH_LENGTH];
 			str_format(aTexName, sizeof(aTexName), "embedded: %s", pName);

--- a/src/game/editor/mapitems/map_io.cpp
+++ b/src/game/editor/mapitems/map_io.cpp
@@ -508,8 +508,14 @@ bool CEditorMap::Load(const char *pFileName, int StorageType, const std::functio
 			else
 				str_copy(pImg->m_aName, pName);
 
-			const CImageInfo::EImageFormat Format = pItem->m_Version < CMapItemImage_v2::CURRENT_VERSION ? CImageInfo::FORMAT_RGBA : CImageInfo::ImageFormatFromInt(pItem->m_Format);
-			if(pImg->m_External || (Format != CImageInfo::FORMAT_RGB && Format != CImageInfo::FORMAT_RGBA))
+			if(pItem->m_Version > 1 && pItem->m_MustBe1 != 1)
+			{
+				char aBuf[128];
+				str_format(aBuf, sizeof(aBuf), "Error: Unsupported image type of image %d '%s'.", i, pImg->m_aName);
+				ErrorHandler(aBuf);
+			}
+
+			if(pImg->m_External || (pItem->m_Version > 1 && pItem->m_MustBe1 != 1))
 			{
 				char aBuf[IO_MAX_PATH_LENGTH];
 				str_format(aBuf, sizeof(aBuf), "mapres/%s.png", pImg->m_aName);
@@ -534,7 +540,7 @@ bool CEditorMap::Load(const char *pFileName, int StorageType, const std::functio
 			{
 				pImg->m_Width = pItem->m_Width;
 				pImg->m_Height = pItem->m_Height;
-				pImg->m_Format = Format;
+				pImg->m_Format = CImageInfo::FORMAT_RGBA;
 
 				// copy image data
 				void *pData = DataFile.GetData(pItem->m_ImageData);

--- a/src/game/mapitems.h
+++ b/src/game/mapitems.h
@@ -277,7 +277,7 @@ struct CMapItemImage_v2 : public CMapItemImage_v1
 		CURRENT_VERSION = 2,
 	};
 
-	int m_Format; // Default before this version is CImageInfo::FORMAT_RGBA
+	int m_MustBe1;
 };
 
 typedef CMapItemImage_v1 CMapItemImage;

--- a/src/tools/map_extract.cpp
+++ b/src/tools/map_extract.cpp
@@ -61,15 +61,9 @@ bool Process(IStorage *pStorage, const char *pMapName, const char *pPathSave)
 		str_format(aBuf, sizeof(aBuf), "%s/%s.png", pPathSave, pName);
 		dbg_msg("map_extract", "writing image: %s (%dx%d)", aBuf, pItem->m_Width, pItem->m_Height);
 
-		const int Format = pItem->m_Version < CMapItemImage_v2::CURRENT_VERSION ? CImageInfo::FORMAT_RGBA : pItem->m_Format;
-		EImageFormat OutputFormat;
-		if(Format == CImageInfo::FORMAT_RGBA)
-			OutputFormat = IMAGE_FORMAT_RGBA;
-		else if(Format == CImageInfo::FORMAT_RGB)
-			OutputFormat = IMAGE_FORMAT_RGB;
-		else
+		if(pItem->m_Version >= 2 && pItem->m_MustBe1 != 1)
 		{
-			dbg_msg("map_extract", "ignoring image '%s' with unknown format %d", aBuf, Format);
+			log_error("map_extract", "ignoring image '%s' with unknown format %d", aBuf, pItem->m_MustBe1);
 			continue;
 		}
 
@@ -80,7 +74,7 @@ bool Process(IStorage *pStorage, const char *pMapName, const char *pPathSave)
 			TImageByteBuffer ByteBuffer;
 			SImageByteBuffer ImageByteBuffer(&ByteBuffer);
 
-			if(SavePng(OutputFormat, (const uint8_t *)Reader.GetData(pItem->m_ImageData), ImageByteBuffer, pItem->m_Width, pItem->m_Height))
+			if(SavePng(IMAGE_FORMAT_RGBA, (const uint8_t *)Reader.GetData(pItem->m_ImageData), ImageByteBuffer, pItem->m_Width, pItem->m_Height))
 				io_write(File, &ByteBuffer.front(), ByteBuffer.size());
 			io_close(File);
 		}


### PR DESCRIPTION
Cherry-picked from https://github.com/teeworlds/teeworlds/pull/2822.

CC https://github.com/teeworlds/teeworlds/issues/2812
CC https://github.com/teeworlds/teeworlds/issues/962

Since DDNet never saved these kinds of images, this should cause no issues.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
