### PR TITLE
Revert "Initialize all ghost item member (Closed #8297)"

### DIFF
--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -700,11 +700,11 @@ public:
 		char m_aFilename[IO_MAX_PATH_LENGTH];
 		char m_aPlayer[MAX_NAME_LENGTH];
 
-		bool m_Failed = true;
-		int m_Time = 0;
-		int m_Slot = -1;
-		bool m_Own = false;
-		time_t m_Date = 0;
+		bool m_Failed;
+		int m_Time;
+		int m_Slot;
+		bool m_Own;
+		time_t m_Date;
 
 		CGhostItem() :
 			m_Slot(-1), m_Own(false) { m_aFilename[0] = 0; }


### PR DESCRIPTION
This reverts commit f319ed239ad27ceda928b9bcd399ca6c6379c88b.

Initializing these variables with junk data doesn't seem to be an improvement over not initializing them. It hides potential Valgrind warnings about data accesses to uninitialized memory though.

https://github.com/ddnet/ddnet/pull/8309/commits/f319ed239ad27ceda928b9bcd399ca6c6379c88b#r1590801501

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
