### PR TITLE
Fix 0.7 tokens after #8322

### DIFF
--- a/src/engine/shared/network_server.cpp
+++ b/src/engine/shared/network_server.cpp
@@ -540,7 +540,7 @@ int CNetServer::OnSixupCtrlMsg(NETADDR &Addr, CNetChunk *pChunk, int ControlMsg,
 	if(m_RecvUnpacker.m_Data.m_DataSize < 5 || ClientExists(Addr))
 		return 0; // silently ignore
 
-	mem_copy(&ResponseToken, Packet.m_aChunkData + 1, 4);
+	ResponseToken = ToSecurityToken(Packet.m_aChunkData + 1);
 
 	if(ControlMsg == 5)
 	{
@@ -758,7 +758,7 @@ void CNetServer::SendTokenSixup(NETADDR &Addr, SECURITY_TOKEN Token)
 {
 	SECURITY_TOKEN MyToken = GetToken(Addr);
 	unsigned char aBuf[512] = {};
-	mem_copy(aBuf, &MyToken, 4);
+	WriteSecurityToken(aBuf, MyToken);
 	int Size = (Token == NET_SECURITY_TOKEN_UNKNOWN) ? 512 : 4;
 	CNetBase::SendControlMsg(m_Socket, &Addr, 0, 5, aBuf, Size, Token, true);
 }
@@ -771,8 +771,8 @@ int CNetServer::SendConnlessSixup(CNetChunk *pChunk, SECURITY_TOKEN ResponseToke
 	unsigned char aBuffer[NET_MAX_PACKETSIZE];
 	aBuffer[0] = NET_PACKETFLAG_CONNLESS << 2 | 1;
 	SECURITY_TOKEN Token = GetToken(pChunk->m_Address);
-	mem_copy(aBuffer + 1, &ResponseToken, 4);
-	mem_copy(aBuffer + 5, &Token, 4);
+	WriteSecurityToken(aBuffer + 1, ResponseToken);
+	WriteSecurityToken(aBuffer + 5, Token);
 	mem_copy(aBuffer + 9, pChunk->m_pData, pChunk->m_DataSize);
 	net_udp_send(m_Socket, &pChunk->m_Address, aBuffer, pChunk->m_DataSize + 9);
 


### PR DESCRIPTION
They're also read as big-endian integers now.

Thanks to @ChillerDragon for noticing.

Fixes #8330.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
