### PR TITLE
Change type from int to int64_t

### DIFF
--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -2613,7 +2613,7 @@ int net_socket_read_wait(NETSOCKET sock, int time)
 	return 0;
 }
 
-int time_timestamp()
+int64_t time_timestamp()
 {
 	return time(0);
 }

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -698,7 +698,7 @@ int64_t time_freq();
  *
  * @return The time as a UNIX timestamp
  */
-int time_timestamp();
+int64_t time_timestamp();
 
 /**
  * Retrieves the hours since midnight (0..23)

--- a/src/engine/shared/netban.cpp
+++ b/src/engine/shared/netban.cpp
@@ -217,7 +217,7 @@ int CNetBan::Ban(T *pBanPool, const typename T::CDataType *pData, int Seconds, c
 		return -1;
 	}
 
-	int Stamp = Seconds > 0 ? time_timestamp() + Seconds : CBanInfo::EXPIRES_NEVER;
+	int64_t Stamp = Seconds > 0 ? time_timestamp() + Seconds : static_cast<int64_t>(CBanInfo::EXPIRES_NEVER);
 
 	// set up info
 	CBanInfo Info = {0};
@@ -290,7 +290,7 @@ void CNetBan::Init(IConsole *pConsole, IStorage *pStorage)
 
 void CNetBan::Update()
 {
-	int Now = time_timestamp();
+	int64_t Now = time_timestamp();
 
 	// remove expired bans
 	char aBuf[256], aNetStr[256];
@@ -522,7 +522,7 @@ void CNetBan::ConBansSave(IConsole::IResult *pResult, void *pUser)
 		return;
 	}
 
-	int Now = time_timestamp();
+	int64_t Now = time_timestamp();
 	char aAddrStr1[NETADDR_MAXSTRSIZE], aAddrStr2[NETADDR_MAXSTRSIZE];
 	for(CBanAddr *pBan = pThis->m_BanAddrPool.First(); pBan; pBan = pBan->m_pNext)
 	{

--- a/src/engine/shared/netban.h
+++ b/src/engine/shared/netban.h
@@ -79,7 +79,7 @@ protected:
 			EXPIRES_NEVER = -1,
 			REASON_LENGTH = 64,
 		};
-		int m_Expires;
+		int64_t m_Expires;
 		char m_aReason[REASON_LENGTH];
 	};
 


### PR DESCRIPTION
closes: #8303 
this expects all systems to correctly handle int64_t

from heinrich:

>  Simply changing the return type and places where it's used to int64_t should work. Most systems today will have 64-bit time_t. 

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
