### PR TITLE
Set editor map groups collapsed by default

### DIFF
--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -103,6 +103,7 @@ MACRO_CONFIG_INT(EdZoomTarget, ed_zoom_target, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG
 MACRO_CONFIG_INT(EdShowkeys, ed_showkeys, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show pressed keys")
 MACRO_CONFIG_INT(EdAlignQuads, ed_align_quads, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Enable/disable quad alignment. When enabled, red lines appear to show how quad/points are aligned and snapped to other quads/points when moving them")
 MACRO_CONFIG_INT(EdShowQuadsRect, ed_show_quads_rect, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show the bounds of the selected quad. In case of multiple quads, it shows the bounds of the englobing rect. Can be helpful when aligning a group of quads")
+MACRO_CONFIG_INT(EdGroupsCollapsed, ed_groups_collapsed, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Collapse all groups on map opening")
 
 MACRO_CONFIG_INT(ClShowWelcome, cl_show_welcome, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show welcome message indicating the first launch of the client")
 MACRO_CONFIG_INT(ClMotdTime, cl_motd_time, 10, 0, 100, CFGFLAG_CLIENT | CFGFLAG_SAVE, "How long to show the server message of the day")

--- a/src/game/editor/mapitems/layer_group.cpp
+++ b/src/game/editor/mapitems/layer_group.cpp
@@ -1,6 +1,7 @@
 #include "layer_group.h"
 
 #include <base/math.h>
+#include <engine/shared/config.h>
 #include <game/editor/editor.h>
 
 CLayerGroup::CLayerGroup()
@@ -8,7 +9,7 @@ CLayerGroup::CLayerGroup()
 	m_vpLayers.clear();
 	m_aName[0] = 0;
 	m_Visible = true;
-	m_Collapse = true;
+	m_Collapse = g_Config.m_EdGroupsCollapsed;
 	m_GameGroup = false;
 	m_OffsetX = 0;
 	m_OffsetY = 0;

--- a/src/game/editor/mapitems/layer_group.cpp
+++ b/src/game/editor/mapitems/layer_group.cpp
@@ -8,7 +8,7 @@ CLayerGroup::CLayerGroup()
 	m_vpLayers.clear();
 	m_aName[0] = 0;
 	m_Visible = true;
-	m_Collapse = false;
+	m_Collapse = true;
 	m_GameGroup = false;
 	m_OffsetX = 0;
 	m_OffsetY = 0;


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->
#7902
<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
