### PR TITLE
Fix `goto_tele` not finding all teleporters

### DIFF
--- a/src/game/client/components/camera.cpp
+++ b/src/game/client/components/camera.cpp
@@ -323,7 +323,8 @@ void CCamera::GotoTele(int Number, int Offset)
 	{
 		if((size_t)Offset >= NumTeles || Offset < 0)
 			Offset = 0;
-		MatchPos = ivec2(Collision()->TeleAllGet(Number, Offset).x / 32, Collision()->TeleAllGet(Number, Offset).y / 32);
+		vec2 Tele = Collision()->TeleAllGet(Number, Offset);
+		MatchPos = ivec2(Tele.x / 32, Tele.y / 32);
 		m_GotoTeleOffset = Offset;
 	}
 	else
@@ -331,7 +332,8 @@ void CCamera::GotoTele(int Number, int Offset)
 		bool FullRound = false;
 		do
 		{
-			MatchPos = ivec2(Collision()->TeleAllGet(Number, m_GotoTeleOffset).x / 32, Collision()->TeleAllGet(Number, m_GotoTeleOffset).y / 32);
+			vec2 Tele = Collision()->TeleAllGet(Number, m_GotoTeleOffset);
+			MatchPos = ivec2(Tele.x / 32, Tele.y / 32);
 			m_GotoTeleOffset++;
 			if((size_t)m_GotoTeleOffset >= NumTeles)
 			{

--- a/src/game/client/components/camera.h
+++ b/src/game/client/components/camera.h
@@ -72,6 +72,7 @@ private:
 	int m_GotoTeleOffset;
 	ivec2 m_GotoSwitchLastPos;
 	ivec2 m_GotoTeleLastPos;
+	int m_GotoTeleLastNumber = -1;
 };
 
 #endif

--- a/src/game/collision.cpp
+++ b/src/game/collision.cpp
@@ -139,6 +139,10 @@ void CCollision::Init(class CLayers *pLayers)
 				{
 					m_TeleCheckOuts[Number - 1].emplace_back(i % m_Width * 32.0f + 16.0f, i / m_Width * 32.0f + 16.0f);
 				}
+				else if(Type)
+				{
+					m_TeleOthers[Number - 1].emplace_back(i % m_Width * 32.0f + 16.0f, i / m_Width * 32.0f + 16.0f);
+				}
 			}
 		}
 	}
@@ -156,6 +160,7 @@ void CCollision::Unload()
 	m_TeleIns.clear();
 	m_TeleOuts.clear();
 	m_TeleCheckOuts.clear();
+	m_TeleOthers.clear();
 
 	m_pTele = nullptr;
 	m_pSpeedup = nullptr;
@@ -1259,4 +1264,49 @@ int CCollision::IsFTimeCheckpoint(int Index) const
 	if(z >= TILE_TIME_CHECKPOINT_FIRST && z <= TILE_TIME_CHECKPOINT_LAST)
 		return z - TILE_TIME_CHECKPOINT_FIRST;
 	return -1;
+}
+
+vec2 CCollision::TeleAllGet(int Number, size_t Offset)
+{
+	if(m_TeleIns.count(Number) > 0)
+	{
+		if(m_TeleIns[Number].size() > Offset)
+			return m_TeleIns[Number][Offset];
+		else
+			Offset -= m_TeleIns[Number].size();
+	}
+	if(m_TeleOuts.count(Number) > 0)
+	{
+		if(m_TeleOuts[Number].size() > Offset)
+			return m_TeleOuts[Number][Offset];
+		else
+			Offset -= m_TeleOuts[Number].size();
+	}
+	if(m_TeleCheckOuts.count(Number) > 0)
+	{
+		if(m_TeleCheckOuts[Number].size() > Offset)
+			return m_TeleCheckOuts[Number][Offset];
+		else
+			Offset -= m_TeleCheckOuts[Number].size();
+	}
+	if(m_TeleOthers.count(Number) > 0)
+	{
+		if(m_TeleOthers[Number].size() > Offset)
+			return m_TeleOthers[Number][Offset];
+	}
+	return vec2(-1, -1);
+}
+
+size_t CCollision::TeleAllSize(int Number)
+{
+	size_t Total = 0;
+	if(m_TeleIns.count(Number) > 0)
+		Total += m_TeleIns[Number].size();
+	if(m_TeleOuts.count(Number) > 0)
+		Total += m_TeleOuts[Number].size();
+	if(m_TeleCheckOuts.count(Number) > 0)
+		Total += m_TeleCheckOuts[Number].size();
+	if(m_TeleOthers.count(Number) > 0)
+		Total += m_TeleOthers[Number].size();
+	return Total;
 }

--- a/src/game/collision.h
+++ b/src/game/collision.h
@@ -113,57 +113,28 @@ public:
 	class CLayers *Layers() { return m_pLayers; }
 	int m_HighestSwitchNumber;
 
-	// Index all teleporter types (in, out and checkpoints)
-	// as one consecutive list
-	//
-	// @param Number is the teleporter number (one less than what is shown in game)
-	// @param Offset picks the n'th occurence of that teleporter in the map
-	//
-	// @return The coordinates of the teleporter in the map
-	//         or (-1, -1) if not found
-	vec2 TeleAllGet(int Number, size_t Offset)
-	{
-		if(m_TeleIns.count(Number) > 0)
-		{
-			if(m_TeleIns[Number].size() > Offset)
-				return m_TeleIns[Number][Offset];
-			else
-				Offset -= m_TeleIns[Number].size();
-		}
-		if(m_TeleOuts.count(Number) > 0)
-		{
-			if(m_TeleOuts[Number].size() > Offset)
-				return m_TeleOuts[Number][Offset];
-			else
-				Offset -= m_TeleOuts[Number].size();
-		}
-		if(m_TeleCheckOuts.count(Number) > 0)
-		{
-			if(m_TeleCheckOuts[Number].size() > Offset)
-				return m_TeleCheckOuts[Number][Offset];
-			else
-				Offset -= m_TeleCheckOuts[Number].size();
-		}
-		return vec2(-1, -1);
-	}
+	/**
+	 * Index all teleporter types (in, out and checkpoints)
+	 * as one consecutive list.
+	 *
+	 * @param Number is the teleporter number (one less than what is shown in game)
+	 * @param Offset picks the n'th occurence of that teleporter in the map
+	 *
+	 * @return The coordinates of the teleporter in the map
+	 *         or (-1, -1) if not found
+	 */
+	vec2 TeleAllGet(int Number, size_t Offset);
 
-	// @param Number is the teleporter number (one less than what is shown in game)
-	// @return The amount of occurences of that teleporter across all types (in, out, checkpoint)
-	size_t TeleAllSize(int Number)
-	{
-		size_t Total = 0;
-		if(m_TeleIns.count(Number) > 0)
-			Total += m_TeleIns[Number].size();
-		if(m_TeleOuts.count(Number) > 0)
-			Total += m_TeleOuts[Number].size();
-		if(m_TeleCheckOuts.count(Number) > 0)
-			Total += m_TeleCheckOuts[Number].size();
-		return Total;
-	}
+	/**
+	 * @param Number is the teleporter number (one less than what is shown in game)
+	 * @return The amount of occurences of that teleporter across all types (in, out, checkpoint)
+	 */
+	size_t TeleAllSize(int Number);
 
 	const std::vector<vec2> &TeleIns(int Number) { return m_TeleIns[Number]; }
 	const std::vector<vec2> &TeleOuts(int Number) { return m_TeleOuts[Number]; }
 	const std::vector<vec2> &TeleCheckOuts(int Number) { return m_TeleCheckOuts[Number]; }
+	const std::vector<vec2> &TeleOthers(int Number) { return m_TeleOthers[Number]; }
 
 private:
 	class CTile *m_pTiles;
@@ -171,9 +142,14 @@ private:
 	int m_Height;
 	class CLayers *m_pLayers;
 
+	// TILE_TELEIN
 	std::map<int, std::vector<vec2>> m_TeleIns;
+	// TILE_TELEOUT
 	std::map<int, std::vector<vec2>> m_TeleOuts;
+	// TILE_TELECHECKOUT
 	std::map<int, std::vector<vec2>> m_TeleCheckOuts;
+	// TILE_TELEINEVIL, TILE_TELECHECK, TILE_TELECHECKIN, TILE_TELECHECKINEVIL
+	std::map<int, std::vector<vec2>> m_TeleOthers;
 
 	class CTeleTile *m_pTele;
 	class CSpeedupTile *m_pSpeedup;

--- a/src/game/collision.h
+++ b/src/game/collision.h
@@ -113,6 +113,54 @@ public:
 	class CLayers *Layers() { return m_pLayers; }
 	int m_HighestSwitchNumber;
 
+	// Index all teleporter types (in, out and checkpoints)
+	// as one consecutive list
+	//
+	// @param Number is the teleporter number (one less than what is shown in game)
+	// @param Offset picks the n'th occurence of that teleporter in the map
+	//
+	// @return The coordinates of the teleporter in the map
+	//         or (-1, -1) if not found
+	vec2 TeleAllGet(int Number, size_t Offset)
+	{
+		if(m_TeleIns.count(Number) > 0)
+		{
+			if(m_TeleIns[Number].size() > Offset)
+				return m_TeleIns[Number][Offset];
+			else
+				Offset -= m_TeleIns[Number].size();
+		}
+		if(m_TeleOuts.count(Number) > 0)
+		{
+			if(m_TeleOuts[Number].size() > Offset)
+				return m_TeleOuts[Number][Offset];
+			else
+				Offset -= m_TeleOuts[Number].size();
+		}
+		if(m_TeleCheckOuts.count(Number) > 0)
+		{
+			if(m_TeleCheckOuts[Number].size() > Offset)
+				return m_TeleCheckOuts[Number][Offset];
+			else
+				Offset -= m_TeleCheckOuts[Number].size();
+		}
+		return vec2(-1, -1);
+	}
+
+	// @param Number is the teleporter number (one less than what is shown in game)
+	// @return The amount of occurences of that teleporter across all types (in, out, checkpoint)
+	size_t TeleAllSize(int Number)
+	{
+		size_t Total = 0;
+		if(m_TeleIns.count(Number) > 0)
+			Total += m_TeleIns[Number].size();
+		if(m_TeleOuts.count(Number) > 0)
+			Total += m_TeleOuts[Number].size();
+		if(m_TeleCheckOuts.count(Number) > 0)
+			Total += m_TeleCheckOuts[Number].size();
+		return Total;
+	}
+
 	const std::vector<vec2> &TeleIns(int Number) { return m_TeleIns[Number]; }
 	const std::vector<vec2> &TeleOuts(int Number) { return m_TeleOuts[Number]; }
 	const std::vector<vec2> &TeleCheckOuts(int Number) { return m_TeleCheckOuts[Number]; }


### PR DESCRIPTION
I noticed that on the current master the `goto_tele` feature was skipping one tele.


https://github.com/ddnet/ddnet/assets/20344300/afface81-7199-4419-be2a-9e80d8ada79b

I did not want to debug the code because it looked so complex. So I refactored it and it also fixed the bug. As you can see it now finds one more tele in the same map:


https://github.com/ddnet/ddnet/assets/20344300/49dc9ed3-d1f6-43db-a80a-9ca71d86b6b2

Also the performance should be much better. Since now the worst case is only iterating as many times as there are teleporters of that type in the map. Before in the worst case it would iterate over every single tile in the tele layer (including empty tiles).

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
