### PR TITLE
Ignore 0.7 connections if sixup map is unavailable

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -2563,17 +2563,26 @@ int CServer::LoadMap(const char *pMapName)
 		void *pData;
 		if(!Storage()->ReadFile(aBuf, IStorage::TYPE_ALL, &pData, &m_aCurrentMapSize[MAP_TYPE_SIXUP]))
 		{
-			Config()->m_SvSixup = 0;
-			if(m_pRegister)
+			if(Config()->m_SvSixup == 2)
 			{
-				m_pRegister->OnConfigChange();
+				Config()->m_SvSixup = 1; // enabled, ignoring sixup connections
+				if(m_pRegister)
+					m_pRegister->OnConfigChange();
 			}
+
 			str_format(aBufMsg, sizeof(aBufMsg), "couldn't load map %s", aBuf);
 			Console()->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "sixup", aBufMsg);
-			Console()->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "sixup", "disabling 0.7 compatibility");
+			Console()->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "sixup", "ignoring 0.7 connections");
 		}
 		else
 		{
+			if(Config()->m_SvSixup == 1)
+			{
+				Config()->m_SvSixup = 2; // enabled
+				if(m_pRegister)
+					m_pRegister->OnConfigChange();
+			}
+
 			free(m_apCurrentMapData[MAP_TYPE_SIXUP]);
 			m_apCurrentMapData[MAP_TYPE_SIXUP] = (unsigned char *)pData;
 
@@ -2584,7 +2593,7 @@ int CServer::LoadMap(const char *pMapName)
 			Console()->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "sixup", aBufMsg);
 		}
 	}
-	if(!Config()->m_SvSixup)
+	if(Config()->m_SvSixup != 2)
 	{
 		free(m_apCurrentMapData[MAP_TYPE_SIXUP]);
 		m_apCurrentMapData[MAP_TYPE_SIXUP] = 0;

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -400,7 +400,7 @@ MACRO_CONFIG_INT(SvPlayerDemoRecord, sv_player_demo_record, 0, 0, 1, CFGFLAG_SER
 MACRO_CONFIG_INT(SvDemoChat, sv_demo_chat, 0, 0, 1, CFGFLAG_SERVER, "Record chat for demos")
 MACRO_CONFIG_INT(SvServerInfoPerSecond, sv_server_info_per_second, 50, 0, 10000, CFGFLAG_SERVER, "Maximum number of complete server info responses that are sent out per second (0 for no limit)")
 MACRO_CONFIG_INT(SvVanConnPerSecond, sv_van_conn_per_second, 10, 0, 10000, CFGFLAG_SERVER, "Antispoof specific ratelimit (0 for no limit)")
-MACRO_CONFIG_INT(SvSixup, sv_sixup, 1, 0, 1, CFGFLAG_SERVER, "Enable sixup connections")
+MACRO_CONFIG_INT(SvSixup, sv_sixup, 2, 0, 2, CFGFLAG_SERVER, "Enable sixup connections (0 = disabled, 1 = enabled, but sixup map not found, 2 = enabled)")
 MACRO_CONFIG_INT(SvSkillLevel, sv_skill_level, 1, SERVERINFO_LEVEL_MIN, SERVERINFO_LEVEL_MAX, CFGFLAG_SERVER, "Difficulty level for Teeworlds 0.7 (0: Casual, 1: Normal, 2: Competitive)")
 
 MACRO_CONFIG_STR(EcBindaddr, ec_bindaddr, 128, "localhost", CFGFLAG_ECON, "Address to bind the external console to. Anything but 'localhost' is dangerous")

--- a/src/engine/shared/network_server.cpp
+++ b/src/engine/shared/network_server.cpp
@@ -199,7 +199,7 @@ bool CNetServer::Connlimit(NETADDR Addr)
 
 int CNetServer::TryAcceptClient(NETADDR &Addr, SECURITY_TOKEN SecurityToken, bool VanillaAuth, bool Sixup, SECURITY_TOKEN Token)
 {
-	if(Sixup && !g_Config.m_SvSixup)
+	if(Sixup && g_Config.m_SvSixup != 2)
 	{
 		const char aMsg[] = "0.7 connections are not accepted at this time";
 		CNetBase::SendControlMsg(m_Socket, &Addr, 0, NET_CTRLMSG_CLOSE, aMsg, sizeof(aMsg), SecurityToken, Sixup);


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->
Check #7669
<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
