### PR TITLE
Fix size of chat history entry allocation

### DIFF
--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -1360,8 +1360,9 @@ void CChat::SendChatQueued(const char *pLine)
 
 	if(AddEntry)
 	{
-		CHistoryEntry *pEntry = m_History.Allocate(sizeof(CHistoryEntry) + str_length(pLine) - 1);
+		const int Length = str_length(pLine);
+		CHistoryEntry *pEntry = m_History.Allocate(sizeof(CHistoryEntry) + Length);
 		pEntry->m_Team = m_Mode == MODE_ALL ? 0 : 1;
-		mem_copy(pEntry->m_aText, pLine, str_length(pLine));
+		str_copy(pEntry->m_aText, pLine, Length + 1);
 	}
 }


### PR DESCRIPTION
The `-1` in the size calculation for the ringbuffer allocation of chat history entries was incorrect, so the entries potentially didn't fit the zero terminator. Because `mem_copy` was used, the string was also not zero terminated explicitly.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
