### PR TITLE
Set sqlite3 `.timeout` in `integration_test.sh`

### DIFF
--- a/scripts/integration_test.sh
+++ b/scripts/integration_test.sh
@@ -314,7 +314,7 @@ then
 	echo "[-] Error: demo playback of client demo in client 2 was not started/finished"
 fi
 
-ranks="$(sqlite3 ddnet-server.sqlite < <(echo "select * from record_race;"))"
+ranks="$(sqlite3 -cmd '.timeout 10000' ddnet-server.sqlite < <(echo "select * from record_race;"))"
 rank_time="$(echo "$ranks" | awk -F '|' '{ print "player:", $2, "time:", $4, "cps:", $6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28 }')"
 expected_times="\
 player: client2 time: 1020.98 cps: 0.02 0.1 0.2 0.26 0.32 600.36 600.42 600.46 600.5 1020.54 1020.58 1020.6 1020.64 1020.66 1020.7 1020.72 1020.76 1020.78 1020.8 1020.84 1020.86 1020.88 1020.9


### PR DESCRIPTION
Try to fix `database is locked` CI error with `.timeout`. Not sure if it fixes the error, as I have no way of reproducing it. Closes #8325

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
