### PR TITLE
Fix segfault when swapchain images change (e.g. toggling Vsync)

### DIFF
--- a/src/engine/client/backend/vulkan/backend_vulkan.cpp
+++ b/src/engine/client/backend/vulkan/backend_vulkan.cpp
@@ -6112,20 +6112,20 @@ public:
 	template<bool IsFirstInitialization>
 	int InitVulkan()
 	{
-		if(!CreateDescriptorSetLayouts())
-			return -1;
-
-		if(!CreateTextDescriptorSetLayout())
-			return -1;
-
-		if(!CreateSpriteMultiUniformDescriptorSetLayout())
-			return -1;
-
-		if(!CreateQuadUniformDescriptorSetLayout())
-			return -1;
-
 		if(IsFirstInitialization)
 		{
+			if(!CreateDescriptorSetLayouts())
+				return -1;
+
+			if(!CreateTextDescriptorSetLayout())
+				return -1;
+
+			if(!CreateSpriteMultiUniformDescriptorSetLayout())
+				return -1;
+
+			if(!CreateQuadUniformDescriptorSetLayout())
+				return -1;
+
 			VkSwapchainKHR OldSwapChain = VK_NULL_HANDLE;
 			if(InitVulkanSwapChain(OldSwapChain) != 0)
 				return -1;

--- a/src/engine/client/backend/vulkan/backend_vulkan.cpp
+++ b/src/engine/client/backend/vulkan/backend_vulkan.cpp
@@ -5374,6 +5374,8 @@ public:
 
 		m_vFrameFences.clear();
 		m_vImagesFences.clear();
+
+		m_CurFrameSyncObject = 0;
 	}
 
 	void DestroyBufferOfFrame(size_t ImageIndex, SFrameBuffers &Buffer)
@@ -5427,7 +5429,7 @@ public:
 	}
 
 	template<bool IsLastCleanup>
-	void CleanupVulkan()
+	void CleanupVulkan(size_t SwapchainCount)
 	{
 		if(IsLastCleanup)
 		{
@@ -5465,7 +5467,7 @@ public:
 		m_vStreamedVertexBuffers.clear();
 		m_vStreamedUniformBuffers.clear();
 
-		for(size_t i = 0; i < m_SwapChainImageCount; ++i)
+		for(size_t i = 0; i < SwapchainCount; ++i)
 		{
 			ClearFrameData(i);
 		}
@@ -5474,11 +5476,11 @@ public:
 		m_vvFrameDelayedTextureCleanup.clear();
 		m_vvFrameDelayedTextTexturesCleanup.clear();
 
-		m_StagingBufferCache.DestroyFrameData(m_SwapChainImageCount);
-		m_StagingBufferCacheImage.DestroyFrameData(m_SwapChainImageCount);
-		m_VertexBufferCache.DestroyFrameData(m_SwapChainImageCount);
+		m_StagingBufferCache.DestroyFrameData(SwapchainCount);
+		m_StagingBufferCacheImage.DestroyFrameData(SwapchainCount);
+		m_VertexBufferCache.DestroyFrameData(SwapchainCount);
 		for(auto &ImageBufferCache : m_ImageBufferCaches)
-			ImageBufferCache.second.DestroyFrameData(m_SwapChainImageCount);
+			ImageBufferCache.second.DestroyFrameData(SwapchainCount);
 
 		if(IsLastCleanup)
 		{
@@ -5556,7 +5558,7 @@ public:
 
 		if(OldSwapChainImageCount != m_SwapChainImageCount)
 		{
-			CleanupVulkan<false>();
+			CleanupVulkan<false>(OldSwapChainImageCount);
 			InitVulkan<false>();
 		}
 
@@ -6620,7 +6622,7 @@ public:
 		DestroyIndexBuffer(m_IndexBuffer, m_IndexBufferMemory);
 		DestroyIndexBuffer(m_RenderIndexBuffer, m_RenderIndexBufferMemory);
 
-		CleanupVulkan<true>();
+		CleanupVulkan<true>(m_SwapChainImageCount);
 
 		return true;
 	}


### PR DESCRIPTION
fixes #8328

I was able to reproduce #8328 by simply faking the swapchain image count

```cpp
uint32_t ImgNumber = VKCapabilities.minImageCount + 1 + rand() % 5;
```

in `GetNumberOfSwapImages`.

For sync objects I decided that they should not be dependent on the frame count directly anyway.
For vulkan cleanup simply take the swapchain count as parameter instead of relying on the cached one (since that is overwritten when recreating the swapchain).

Also minor refactoring.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
