### PR TITLE
Remove unused `CImageInfo::ImageFormatFromInt`

### DIFF
--- a/src/engine/graphics.h
+++ b/src/engine/graphics.h
@@ -122,13 +122,6 @@ public:
 	{
 		return m_Width * m_Height * PixelSize(m_Format);
 	}
-
-	static EImageFormat ImageFormatFromInt(int Format)
-	{
-		if(Format < (int)FORMAT_RGB || Format > (int)FORMAT_SINGLE_COMPONENT)
-			return FORMAT_ERROR;
-		return (EImageFormat)Format;
-	}
 };
 
 /*


### PR DESCRIPTION
Follow-up for #8326.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
