### PR TITLE
Show help text when chaining multiple commands

### DIFF
--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -3155,6 +3155,38 @@ const char *str_find(const char *haystack, const char *needle)
 	return 0;
 }
 
+bool str_delimiters_around_offset(const char *haystack, const char *delim, int offset, int *start, int *end)
+{
+	bool found = true;
+	const char *search = haystack;
+	const int delim_len = str_length(delim);
+	*start = 0;
+	while(str_find(search, delim))
+	{
+		const char *test = str_find(search, delim) + delim_len;
+		int distance = test - haystack;
+		if(distance > offset)
+			break;
+
+		*start = distance;
+		search = test;
+	}
+	if(search == haystack)
+		found = false;
+
+	if(str_find(search, delim))
+	{
+		*end = str_find(search, delim) - haystack;
+	}
+	else
+	{
+		*end = str_length(haystack);
+		found = false;
+	}
+
+	return found;
+}
+
 const char *str_rchr(const char *haystack, char needle)
 {
 	return strrchr(haystack, needle);

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -1605,6 +1605,21 @@ const char *str_find_nocase(const char *haystack, const char *needle);
 */
 const char *str_find(const char *haystack, const char *needle);
 
+/*
+	Function: str_delimiters_around_offset
+	Parameters:
+		haystack - String to search in
+		needle - String to search for
+
+	Returns:
+		true if both delimiters were found
+		false if a delimiter is missing (it uses haystart start and end as fallback)
+
+	Remarks:
+		- The strings are treated as zero-terminated strings.
+*/
+bool str_delimiters_around_offset(const char *haystay, const char *delim, int offset, int *start, int *end);
+
 /**
  * Finds the last occurrence of a character
  *

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -1605,19 +1605,20 @@ const char *str_find_nocase(const char *haystack, const char *needle);
 */
 const char *str_find(const char *haystack, const char *needle);
 
-/*
-	Function: str_delimiters_around_offset
-	Parameters:
-		haystack - String to search in
-		needle - String to search for
-
-	Returns:
-		true if both delimiters were found
-		false if a delimiter is missing (it uses haystart start and end as fallback)
-
-	Remarks:
-		- The strings are treated as zero-terminated strings.
-*/
+/**
+ * @ingroup Strings
+ *
+ * @param haystack String to search in
+ * @param delim String to search for
+ * @param offset Number of characters into the haystack
+ * @param start Will be set to the first delimiter on the left side of the offset (or haystack start)
+ * @param end Will be set to the furst delimiter on the right side  of the offset (or haystack end)
+ *
+ * @return `true` if both delimiters were found
+ * @return 'false' if a delimiter is missing (it uses haystack start and end as fallback)
+ *
+ * @remark The strings are treated as zero-terminated strings.
+ */
 bool str_delimiters_around_offset(const char *haystay, const char *delim, int offset, int *start, int *end);
 
 /**

--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -324,6 +324,14 @@ void CGameConsole::CInstance::PossibleCommandsCompleteCallback(int Index, const 
 		pInstance->m_Input.Set(pStr);
 }
 
+void CGameConsole::CInstance::GetCommand(char *pBuf, size_t Size) const
+{
+	const char *pInput = GetString();
+	while(str_find(pInput, ";"))
+		pInput = str_find(pInput, ";") + 1;
+	StrCopyUntilSpace(pBuf, Size, pInput);
+}
+
 static void StrCopyUntilSpace(char *pDest, size_t DestSize, const char *pSrc)
 {
 	const char *pSpace = str_find(pSrc, " ");
@@ -582,7 +590,8 @@ bool CGameConsole::CInstance::OnInput(const IInput::CEvent &Event)
 		// find the current command
 		{
 			char aBuf[IConsole::CMDLINE_LENGTH];
-			StrCopyUntilSpace(aBuf, sizeof(aBuf), GetString());
+			GetCommand(aBuf, sizeof(aBuf));
+
 			const IConsole::CCommandInfo *pCommand = m_pGameConsole->m_pConsole->GetCommandInfo(aBuf, m_CompletionFlagmask,
 				m_Type != CGameConsole::CONSOLETYPE_LOCAL && m_pGameConsole->Client()->RconAuthed() && m_pGameConsole->Client()->UseTempRconCommands());
 			if(pCommand)

--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -324,12 +324,11 @@ void CGameConsole::CInstance::PossibleCommandsCompleteCallback(int Index, const 
 		pInstance->m_Input.Set(pStr);
 }
 
-void CGameConsole::CInstance::GetCommand(char *pBuf, size_t Size) const
+const char *CGameConsole::CInstance::GetCommand(const char *pInput) const
 {
-	const char *pInput = GetString();
 	while(str_find(pInput, ";"))
 		pInput = str_find(pInput, ";") + 1;
-	StrCopyUntilSpace(pBuf, Size, pInput);
+	return pInput;
 }
 
 static void StrCopyUntilSpace(char *pDest, size_t DestSize, const char *pSrc)
@@ -590,7 +589,7 @@ bool CGameConsole::CInstance::OnInput(const IInput::CEvent &Event)
 		// find the current command
 		{
 			char aBuf[IConsole::CMDLINE_LENGTH];
-			GetCommand(aBuf, sizeof(aBuf));
+			StrCopyUntilSpace(aBuf, sizeof(aBuf), GetCommand(GetString()));
 
 			const IConsole::CCommandInfo *pCommand = m_pGameConsole->m_pConsole->GetCommandInfo(aBuf, m_CompletionFlagmask,
 				m_Type != CGameConsole::CONSOLETYPE_LOCAL && m_pGameConsole->Client()->RconAuthed() && m_pGameConsole->Client()->UseTempRconCommands());
@@ -1120,7 +1119,8 @@ void CGameConsole::OnRender()
 			Info.m_pOffsetChange = &pConsole->m_CompletionRenderOffsetChange;
 			Info.m_Width = Screen.w;
 			Info.m_TotalWidth = 0.0f;
-			Info.m_pCurrentCmd = pConsole->m_aCompletionBuffer;
+			Info.m_pCurrentCmd = pConsole->GetCommand(pConsole->m_aCompletionBuffer);
+
 			TextRender()->SetCursor(&Info.m_Cursor, InitialX - Info.m_Offset, InitialY + RowHeight + 2.0f, FONT_SIZE, TEXTFLAG_RENDER | TEXTFLAG_STOP_AT_END);
 			Info.m_Cursor.m_LineWidth = std::numeric_limits<float>::max();
 			const int NumCommands = m_pConsole->PossibleCommands(Info.m_pCurrentCmd, pConsole->m_CompletionFlagmask, m_ConsoleType != CGameConsole::CONSOLETYPE_LOCAL && Client()->RconAuthed() && Client()->UseTempRconCommands(), PossibleCommandsRenderCallback, &Info);

--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -331,24 +331,24 @@ void CGameConsole::CInstance::PossibleCommandsCompleteCallback(int Index, const 
 	}
 }
 
-void CGameConsole::CInstance::GetCommand(const char *pInput, char *pCmd, size_t CmdSize)
+void CGameConsole::CInstance::GetCommand(const char *pInput, char (&aCmd)[IConsole::CMDLINE_LENGTH])
 {
 	char aInput[IConsole::CMDLINE_LENGTH];
 	str_copy(aInput, pInput);
-	int Start, End;
 	m_CompletionCommandStart = 0;
 	m_CompletionCommandEnd = 0;
 
-	char aaSeperators[][2] = {";", "\"", " "};
-	for(auto *pSeperator : aaSeperators)
+	char aaSeparators[][2] = {";", "\""};
+	for(auto *pSeparator : aaSeparators)
 	{
-		str_delimiters_around_offset(aInput + m_CompletionCommandStart, pSeperator, m_Input.GetCursorOffset() - m_CompletionCommandStart, &Start, &End);
+		int Start, End;
+		str_delimiters_around_offset(aInput + m_CompletionCommandStart, pSeparator, m_Input.GetCursorOffset() - m_CompletionCommandStart, &Start, &End);
 		m_CompletionCommandStart += Start;
 		m_CompletionCommandEnd = m_CompletionCommandStart + (End - Start);
 		aInput[m_CompletionCommandEnd] = '\0';
 	}
 
-	str_copy(pCmd, aInput + m_CompletionCommandStart, CmdSize);
+	str_copy(aCmd, aInput + m_CompletionCommandStart, sizeof(aCmd));
 }
 
 static void StrCopyUntilSpace(char *pDest, size_t DestSize, const char *pSrc)
@@ -472,8 +472,8 @@ bool CGameConsole::CInstance::OnInput(const IInput::CEvent &Event)
 
 			if(!m_Searching)
 			{
-				char aSearch[128];
-				GetCommand(m_aCompletionBuffer, aSearch, sizeof(aSearch));
+				char aSearch[IConsole::CMDLINE_LENGTH];
+				GetCommand(m_aCompletionBuffer, aSearch);
 
 				// command completion
 				const bool UseTempCommands = m_Type == CGameConsole::CONSOLETYPE_REMOTE && m_pGameConsole->Client()->RconAuthed() && m_pGameConsole->Client()->UseTempRconCommands();
@@ -612,7 +612,7 @@ bool CGameConsole::CInstance::OnInput(const IInput::CEvent &Event)
 		// find the current command
 		{
 			char aCmd[IConsole::CMDLINE_LENGTH];
-			GetCommand(GetString(), aCmd, sizeof(aCmd));
+			GetCommand(GetString(), aCmd);
 			char aBuf[IConsole::CMDLINE_LENGTH];
 			StrCopyUntilSpace(aBuf, sizeof(aBuf), aCmd);
 
@@ -1144,8 +1144,8 @@ void CGameConsole::OnRender()
 			Info.m_pOffsetChange = &pConsole->m_CompletionRenderOffsetChange;
 			Info.m_Width = Screen.w;
 			Info.m_TotalWidth = 0.0f;
-			char aCmd[128];
-			pConsole->GetCommand(pConsole->m_aCompletionBuffer, aCmd, sizeof(aCmd));
+			char aCmd[IConsole::CMDLINE_LENGTH];
+			pConsole->GetCommand(pConsole->m_aCompletionBuffer, aCmd);
 			Info.m_pCurrentCmd = aCmd;
 
 			TextRender()->SetCursor(&Info.m_Cursor, InitialX - Info.m_Offset, InitialY + RowHeight + 2.0f, FONT_SIZE, TEXTFLAG_RENDER | TEXTFLAG_STOP_AT_END);

--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -333,14 +333,22 @@ void CGameConsole::CInstance::PossibleCommandsCompleteCallback(int Index, const 
 
 void CGameConsole::CInstance::GetCommand(const char *pInput, char *pCmd, size_t CmdSize)
 {
-	str_delimiters_around_offset(pInput, ";", m_Input.GetCursorOffset(), &m_CompletionCommandStart, &m_CompletionCommandEnd);
-	char aCmd[IConsole::CMDLINE_LENGTH];
-	str_truncate(aCmd, sizeof(aCmd), pInput + m_CompletionCommandStart, m_CompletionCommandEnd - m_CompletionCommandStart);
+	char aInput[IConsole::CMDLINE_LENGTH];
+	str_copy(aInput, pInput);
 	int Start, End;
-	str_delimiters_around_offset(aCmd, "\"", m_Input.GetCursorOffset() - m_CompletionCommandStart, &Start, &End);
-	m_CompletionCommandStart += Start;
-	m_CompletionCommandEnd = m_CompletionCommandStart + (End - Start);
-	str_truncate(pCmd, CmdSize, pInput + m_CompletionCommandStart, m_CompletionCommandEnd - m_CompletionCommandStart);
+	m_CompletionCommandStart = 0;
+	m_CompletionCommandEnd = 0;
+
+	char aaSeperators[][2] = {";", "\"", " "};
+	for(auto *pSeperator : aaSeperators)
+	{
+		str_delimiters_around_offset(aInput + m_CompletionCommandStart, pSeperator, m_Input.GetCursorOffset() - m_CompletionCommandStart, &Start, &End);
+		m_CompletionCommandStart += Start;
+		m_CompletionCommandEnd = m_CompletionCommandStart + (End - Start);
+		aInput[m_CompletionCommandEnd] = '\0';
+	}
+
+	str_copy(pCmd, aInput + m_CompletionCommandStart, CmdSize);
 }
 
 static void StrCopyUntilSpace(char *pDest, size_t DestSize, const char *pSrc)

--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -322,9 +322,9 @@ void CGameConsole::CInstance::PossibleCommandsCompleteCallback(int Index, const 
 	CGameConsole::CInstance *pInstance = (CGameConsole::CInstance *)pUser;
 	if(pInstance->m_CompletionChosen == Index)
 	{
-		char aBefore[512];
+		char aBefore[IConsole::CMDLINE_LENGTH];
 		str_truncate(aBefore, sizeof(aBefore), pInstance->m_aCompletionBuffer, pInstance->m_CompletionCommandStart);
-		char aBuf[512];
+		char aBuf[IConsole::CMDLINE_LENGTH];
 		str_format(aBuf, sizeof(aBuf), "%s%s%s", aBefore, pStr, pInstance->m_aCompletionBuffer + pInstance->m_CompletionCommandEnd);
 		pInstance->m_Input.Set(aBuf);
 		pInstance->m_Input.SetCursorOffset(str_length(pStr) + pInstance->m_CompletionCommandStart);
@@ -334,6 +334,12 @@ void CGameConsole::CInstance::PossibleCommandsCompleteCallback(int Index, const 
 void CGameConsole::CInstance::GetCommand(const char *pInput, char *pCmd, size_t CmdSize)
 {
 	str_delimiters_around_offset(pInput, ";", m_Input.GetCursorOffset(), &m_CompletionCommandStart, &m_CompletionCommandEnd);
+	char aCmd[IConsole::CMDLINE_LENGTH];
+	str_truncate(aCmd, sizeof(aCmd), pInput + m_CompletionCommandStart, m_CompletionCommandEnd - m_CompletionCommandStart);
+	int Start, End;
+	str_delimiters_around_offset(aCmd, "\"", m_Input.GetCursorOffset() - m_CompletionCommandStart, &Start, &End);
+	m_CompletionCommandStart += Start;
+	m_CompletionCommandEnd = m_CompletionCommandStart + (End - Start);
 	str_truncate(pCmd, CmdSize, pInput + m_CompletionCommandStart, m_CompletionCommandEnd - m_CompletionCommandStart);
 }
 
@@ -597,7 +603,7 @@ bool CGameConsole::CInstance::OnInput(const IInput::CEvent &Event)
 
 		// find the current command
 		{
-			char aCmd[128];
+			char aCmd[IConsole::CMDLINE_LENGTH];
 			GetCommand(GetString(), aCmd, sizeof(aCmd));
 			char aBuf[IConsole::CMDLINE_LENGTH];
 			StrCopyUntilSpace(aBuf, sizeof(aBuf), aCmd);

--- a/src/game/client/components/console.h
+++ b/src/game/client/components/console.h
@@ -69,6 +69,7 @@ class CGameConsole : public CComponent
 		float m_CompletionRenderOffset;
 		float m_CompletionRenderOffsetChange;
 		int m_CompletionArgumentPosition;
+		int m_CompletionCommandStart = 0;
 
 		char m_aUser[32];
 		bool m_UserGot;

--- a/src/game/client/components/console.h
+++ b/src/game/client/components/console.h
@@ -113,6 +113,7 @@ class CGameConsole : public CComponent
 		void Dump() REQUIRES(!m_BacklogPendingLock);
 
 		const char *GetString() const { return m_Input.GetString(); }
+		void GetCommand(char *pBuf, size_t Size) const;
 		static void PossibleCommandsCompleteCallback(int Index, const char *pStr, void *pUser);
 		static void PossibleArgumentsCompleteCallback(int Index, const char *pStr, void *pUser);
 

--- a/src/game/client/components/console.h
+++ b/src/game/client/components/console.h
@@ -125,10 +125,9 @@ class CGameConsole : public CComponent
 		 * The result would be " world "
 		 *
 		 * @param pInput the console input line
-		 * @param pCmd the command the cursor is at
-		 * @param CmdSize size of the pCmd buffer
+		 * @param aCmd the command the cursor is at
 		 */
-		void GetCommand(const char *pInput, char *pCmd, size_t CmdSize);
+		void GetCommand(const char *pInput, char (&aCmd)[IConsole::CMDLINE_LENGTH]);
 		static void PossibleCommandsCompleteCallback(int Index, const char *pStr, void *pUser);
 		static void PossibleArgumentsCompleteCallback(int Index, const char *pStr, void *pUser);
 

--- a/src/game/client/components/console.h
+++ b/src/game/client/components/console.h
@@ -70,6 +70,7 @@ class CGameConsole : public CComponent
 		float m_CompletionRenderOffsetChange;
 		int m_CompletionArgumentPosition;
 		int m_CompletionCommandStart = 0;
+		int m_CompletionCommandEnd = 0;
 
 		char m_aUser[32];
 		bool m_UserGot;
@@ -114,7 +115,20 @@ class CGameConsole : public CComponent
 		void Dump() REQUIRES(!m_BacklogPendingLock);
 
 		const char *GetString() const { return m_Input.GetString(); }
-		void GetCommand(char *pBuf, size_t Size) const;
+		/**
+		 * Gets the command at the current cursor including surrounding spaces.
+		 * Commands are split by semicolons.
+		 *
+		 * So if the current console input is for example "hello; world ;foo"
+		 *                                                        ^
+		 *                   and the cursor is here  -------------/
+		 * The result would be " world "
+		 *
+		 * @param pInput the console input line
+		 * @param pCmd the command the cursor is at
+		 * @param CmdSize size of the pCmd buffer
+		 */
+		void GetCommand(const char *pInput, char *pCmd, size_t CmdSize);
 		static void PossibleCommandsCompleteCallback(int Index, const char *pStr, void *pUser);
 		static void PossibleArgumentsCompleteCallback(int Index, const char *pStr, void *pUser);
 

--- a/src/test/str.cpp
+++ b/src/test/str.cpp
@@ -9,53 +9,51 @@ TEST(Str, StrDelim)
 	int Start, End;
 	//                                      0123456
 	//                            01234567891111111
-	str_delimiters_around_offset("123;123456789;aaa", ";", 5, &Start, &End);
+	EXPECT_EQ(str_delimiters_around_offset("123;123456789;aaa", ";", 5, &Start, &End), true);
 	EXPECT_EQ(Start, 4);
 	EXPECT_EQ(End, 13);
 
-	str_delimiters_around_offset("123;123", ";", 1, &Start, &End);
+	EXPECT_EQ(str_delimiters_around_offset("123;123", ";", 1, &Start, &End), false);
 	EXPECT_EQ(Start, 0);
 	EXPECT_EQ(End, 3);
 
-	str_delimiters_around_offset("---foo---bar---baz---hello", "---", 1, &Start, &End);
+	EXPECT_EQ(str_delimiters_around_offset("---foo---bar---baz---hello", "---", 1, &Start, &End), false);
 	EXPECT_EQ(Start, 0);
 	EXPECT_EQ(End, 0);
 
-	str_delimiters_around_offset("---foo---bar---baz---hello", "---", 2, &Start, &End);
+	EXPECT_EQ(str_delimiters_around_offset("---foo---bar---baz---hello", "---", 2, &Start, &End), false);
 	EXPECT_EQ(Start, 0);
 	EXPECT_EQ(End, 0);
 
-	str_delimiters_around_offset("---foo---bar---baz---hello", "---", 3, &Start, &End);
+	EXPECT_EQ(str_delimiters_around_offset("---foo---bar---baz---hello", "---", 3, &Start, &End), true);
 	EXPECT_EQ(Start, 3);
 	EXPECT_EQ(End, 6);
 
-	str_delimiters_around_offset("---foo---bar---baz---hello", "---", 4, &Start, &End);
+	EXPECT_EQ(str_delimiters_around_offset("---foo---bar---baz---hello", "---", 4, &Start, &End), true);
 	EXPECT_EQ(Start, 3);
 	EXPECT_EQ(End, 6);
 
-	str_delimiters_around_offset("---foo---bar---baz---hello", "---", 9, &Start, &End);
+	EXPECT_EQ(str_delimiters_around_offset("---foo---bar---baz---hello", "---", 9, &Start, &End), true);
 	EXPECT_EQ(Start, 9);
 	EXPECT_EQ(End, 12);
 
-	str_delimiters_around_offset("---foo---bar---baz---hello", "---", 22, &Start, &End);
+	EXPECT_EQ(str_delimiters_around_offset("---foo---bar---baz---hello", "---", 22, &Start, &End), false);
 	EXPECT_EQ(Start, 21);
 	EXPECT_EQ(End, 26);
 
-	str_delimiters_around_offset("foo;;;;bar;;;;;;", ";", 2, &Start, &End);
+	EXPECT_EQ(str_delimiters_around_offset("foo;;;;bar;;;;;;", ";", 2, &Start, &End), false);
 	EXPECT_EQ(Start, 0);
 	EXPECT_EQ(End, 3);
 
-	str_delimiters_around_offset("foo;;;;bar;;;;;;", ";", 3, &Start, &End);
+	EXPECT_EQ(str_delimiters_around_offset("foo;;;;bar;;;;;;", ";", 3, &Start, &End), false);
 	EXPECT_EQ(Start, 0);
 	EXPECT_EQ(End, 3);
 
-	bool Found = str_delimiters_around_offset("foo;;;;bar;;;;;;", ";", 4, &Start, &End);
-	EXPECT_EQ(Found, true);
+	EXPECT_EQ(str_delimiters_around_offset("foo;;;;bar;;;;;;", ";", 4, &Start, &End), true);
 	EXPECT_EQ(Start, 4);
 	EXPECT_EQ(End, 4);
 
-	Found = str_delimiters_around_offset("", ";", 4, &Start, &End);
-	EXPECT_EQ(Found, false);
+	EXPECT_EQ(str_delimiters_around_offset("", ";", 4, &Start, &End), false);
 	EXPECT_EQ(Start, 0);
 	EXPECT_EQ(End, 0);
 }

--- a/src/test/str.cpp
+++ b/src/test/str.cpp
@@ -4,6 +4,62 @@
 
 #include <game/gamecore.h>
 
+TEST(Str, StrDelim)
+{
+	int Start, End;
+	//                                      0123456
+	//                            01234567891111111
+	str_delimiters_around_offset("123;123456789;aaa", ";", 5, &Start, &End);
+	EXPECT_EQ(Start, 4);
+	EXPECT_EQ(End, 13);
+
+	str_delimiters_around_offset("123;123", ";", 1, &Start, &End);
+	EXPECT_EQ(Start, 0);
+	EXPECT_EQ(End, 3);
+
+	str_delimiters_around_offset("---foo---bar---baz---hello", "---", 1, &Start, &End);
+	EXPECT_EQ(Start, 0);
+	EXPECT_EQ(End, 0);
+
+	str_delimiters_around_offset("---foo---bar---baz---hello", "---", 2, &Start, &End);
+	EXPECT_EQ(Start, 0);
+	EXPECT_EQ(End, 0);
+
+	str_delimiters_around_offset("---foo---bar---baz---hello", "---", 3, &Start, &End);
+	EXPECT_EQ(Start, 3);
+	EXPECT_EQ(End, 6);
+
+	str_delimiters_around_offset("---foo---bar---baz---hello", "---", 4, &Start, &End);
+	EXPECT_EQ(Start, 3);
+	EXPECT_EQ(End, 6);
+
+	str_delimiters_around_offset("---foo---bar---baz---hello", "---", 9, &Start, &End);
+	EXPECT_EQ(Start, 9);
+	EXPECT_EQ(End, 12);
+
+	str_delimiters_around_offset("---foo---bar---baz---hello", "---", 22, &Start, &End);
+	EXPECT_EQ(Start, 21);
+	EXPECT_EQ(End, 26);
+
+	str_delimiters_around_offset("foo;;;;bar;;;;;;", ";", 2, &Start, &End);
+	EXPECT_EQ(Start, 0);
+	EXPECT_EQ(End, 3);
+
+	str_delimiters_around_offset("foo;;;;bar;;;;;;", ";", 3, &Start, &End);
+	EXPECT_EQ(Start, 0);
+	EXPECT_EQ(End, 3);
+
+	bool Found = str_delimiters_around_offset("foo;;;;bar;;;;;;", ";", 4, &Start, &End);
+	EXPECT_EQ(Found, true);
+	EXPECT_EQ(Start, 4);
+	EXPECT_EQ(End, 4);
+
+	Found = str_delimiters_around_offset("", ";", 4, &Start, &End);
+	EXPECT_EQ(Found, false);
+	EXPECT_EQ(Start, 0);
+	EXPECT_EQ(End, 0);
+}
+
 TEST(Str, StrIsNum)
 {
 	EXPECT_EQ(str_isnum('/'), false);


### PR DESCRIPTION
Shows help text of last command not of the entire input.
Fix console search with multiple commands.
Auto complete when chaining multiple commands.

# before

![image](https://github.com/ddnet/ddnet/assets/20344300/b5d87a27-28d2-4e68-8e6e-91f3cea3c77f)


# after

![image](https://github.com/ddnet/ddnet/assets/20344300/45521b5a-8ff2-4013-8155-7ddcac8fecef)


https://github.com/ddnet/ddnet/assets/20344300/6df56d83-ce1e-42cb-9716-f91a54ec9764



## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
