### PR TITLE
Fix demo seekbar tooltip not shown while seekbar is active, fix demo seekbar being activated by held button press

### DIFF
--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -487,17 +487,18 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 			{
 				Ui()->SetActiveItem(pId);
 			}
-			else
-			{
-				const int HoveredTick = (int)(clamp((Ui()->MouseX() - SeekBar.x - Rounding) / (float)(SeekBar.w - 2 * Rounding), 0.0f, 1.0f) * TotalTicks);
-				static char s_aHoveredTime[32];
-				str_time((int64_t)HoveredTick / Client()->GameTickSpeed() * 100, TIME_HOURS, s_aHoveredTime, sizeof(s_aHoveredTime));
-				GameClient()->m_Tooltips.DoToolTip(pId, &SeekBar, s_aHoveredTime);
-			}
 		}
 
 		if(Inside)
 			Ui()->SetHotItem(pId);
+
+		if(Ui()->HotItem() == pId)
+		{
+			const int HoveredTick = (int)(clamp((Ui()->MouseX() - SeekBar.x - Rounding) / (float)(SeekBar.w - 2 * Rounding), 0.0f, 1.0f) * TotalTicks);
+			static char s_aHoveredTime[32];
+			str_time((int64_t)HoveredTick / Client()->GameTickSpeed() * 100, TIME_HOURS, s_aHoveredTime, sizeof(s_aHoveredTime));
+			GameClient()->m_Tooltips.DoToolTip(pId, &SeekBar, s_aHoveredTime);
+		}
 	}
 
 	bool IncreaseDemoSpeed = false, DecreaseDemoSpeed = false;

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -489,7 +489,7 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 			}
 		}
 
-		if(Inside)
+		if(Inside && !Ui()->MouseButton(0))
 			Ui()->SetHotItem(pId);
 
 		if(Ui()->HotItem() == pId)


### PR DESCRIPTION
The tooltip was not shown if the seekbar is the active item, i.e. when the first mouse button is held down and the seekbar is currently updating the demo player.

The seekbar is immediately activated if the mouse button is held while moving the mouse over the seekbar, which is inconsistent with the general `DoButtonLogic` behavior. This is problematic on Android, where the first mouse button is always pressed while the mouse is being moved, causing the seekbar to steal focus immediately when hovered.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
