### PR TITLE
Fix height of controller settings with exactly 1 controller

### DIFF
--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -1066,12 +1066,9 @@ float CMenus::RenderSettingsControlsJoystick(CUIRect View)
 	int NumOptions = 1; // expandable header
 	if(JoystickEnabled)
 	{
-		if(NumJoysticks == 0)
-			NumOptions++; // message
-		else
+		NumOptions++; // message or joystick name/selection
+		if(NumJoysticks > 0)
 		{
-			if(NumJoysticks > 1)
-				NumOptions++; // joystick selection
 			NumOptions += 3; // mode, ui sens, tolerance
 			if(!g_Config.m_InpControllerAbsolute)
 				NumOptions++; // ingame sens


### PR DESCRIPTION
The controller name is also shown if there is only exactly one controller connected, but the height was not increased for the additional row.

Screenshots:
- Before: 
![screenshot_2024-05-11_17-04-57](https://github.com/ddnet/ddnet/assets/23437060/8bc2d66c-db63-42f9-aaba-4272ec3e7801)
- After:
![screenshot_2024-05-11_17-04-52](https://github.com/ddnet/ddnet/assets/23437060/cf07802b-15e9-487e-b57a-c9c30f43f9a6)

## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
