### PR TITLE
Translate back-button to escape-key on Android, quit if Android back-button is pressed 3 times within 1 second 

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -4535,6 +4535,12 @@ int main(int argc, const char **argv)
 	SDL_SetHint("SDL_IME_SHOW_UI", "1");
 #endif
 
+#if defined(CONF_PLATFORM_ANDROID)
+	// Trap the Android back button so it can be handled in our code reliably
+	// instead of letting the system handle it.
+	SDL_SetHint("SDL_ANDROID_TRAP_BACK_BUTTON", "1");
+#endif
+
 	// init SDL
 	if(SDL_Init(0) < 0)
 	{

--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -538,6 +538,40 @@ void CInput::SetCompositionWindowPosition(float X, float Y, float H)
 	SDL_SetTextInputRect(&Rect);
 }
 
+static int TranslateScancode(const SDL_KeyboardEvent &KeyEvent)
+{
+	// See SDL_Keymod for possible modifiers:
+	// NONE   =     0
+	// LSHIFT =     1
+	// RSHIFT =     2
+	// LCTRL  =    64
+	// RCTRL  =   128
+	// LALT   =   256
+	// RALT   =   512
+	// LGUI   =  1024
+	// RGUI   =  2048
+	// NUM    =  4096
+	// CAPS   =  8192
+	// MODE   = 16384
+	// Sum if you want to ignore multiple modifiers.
+	if(KeyEvent.keysym.mod & g_Config.m_InpIgnoredModifiers)
+	{
+		return 0;
+	}
+
+	int Scancode = g_Config.m_InpTranslatedKeys ? SDL_GetScancodeFromKey(KeyEvent.keysym.sym) : KeyEvent.keysym.scancode;
+
+#if defined(CONF_PLATFORM_ANDROID)
+	// Translate the Android back-button to the escape-key so it can be used to open/close the menu, close popups etc.
+	if(Scancode == KEY_AC_BACK)
+	{
+		Scancode = KEY_ESCAPE;
+	}
+#endif
+
+	return Scancode;
+}
+
 int CInput::Update()
 {
 	const int64_t Now = time_get();
@@ -607,28 +641,11 @@ int CInput::Update()
 
 		// handle keys
 		case SDL_KEYDOWN:
-			// See SDL_Keymod for possible modifiers:
-			// NONE   =     0
-			// LSHIFT =     1
-			// RSHIFT =     2
-			// LCTRL  =    64
-			// RCTRL  =   128
-			// LALT   =   256
-			// RALT   =   512
-			// LGUI   =  1024
-			// RGUI   =  2048
-			// NUM    =  4096
-			// CAPS   =  8192
-			// MODE   = 16384
-			// Sum if you want to ignore multiple modifiers.
-			if(!(Event.key.keysym.mod & g_Config.m_InpIgnoredModifiers))
-			{
-				Scancode = g_Config.m_InpTranslatedKeys ? SDL_GetScancodeFromKey(Event.key.keysym.sym) : Event.key.keysym.scancode;
-			}
+			Scancode = TranslateScancode(Event.key);
 			break;
 		case SDL_KEYUP:
 			Action = IInput::FLAG_RELEASE;
-			Scancode = g_Config.m_InpTranslatedKeys ? SDL_GetScancodeFromKey(Event.key.keysym.sym) : Event.key.keysym.scancode;
+			Scancode = TranslateScancode(Event.key);
 			break;
 
 		// handle the joystick events

--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -641,9 +641,35 @@ int CInput::Update()
 
 		// handle keys
 		case SDL_KEYDOWN:
+#if defined(CONF_PLATFORM_ANDROID)
+			if(Event.key.keysym.scancode == KEY_AC_BACK && m_BackButtonReleased)
+			{
+				if(m_LastBackPress == -1 || (Now - m_LastBackPress) / (float)time_freq() > 1.0f)
+				{
+					m_NumBackPresses = 1;
+					m_LastBackPress = Now;
+				}
+				else
+				{
+					m_NumBackPresses++;
+					if(m_NumBackPresses >= 3)
+					{
+						// Quit if the Android back-button was pressed 3 times within 1 second
+						return 1;
+					}
+				}
+				m_BackButtonReleased = false;
+			}
+#endif
 			Scancode = TranslateScancode(Event.key);
 			break;
 		case SDL_KEYUP:
+#if defined(CONF_PLATFORM_ANDROID)
+			if(Event.key.keysym.scancode == KEY_AC_BACK && !m_BackButtonReleased)
+			{
+				m_BackButtonReleased = true;
+			}
+#endif
 			Action = IInput::FLAG_RELEASE;
 			Scancode = TranslateScancode(Event.key);
 			break;

--- a/src/engine/client/input.h
+++ b/src/engine/client/input.h
@@ -78,8 +78,11 @@ private:
 
 	bool m_MouseFocus;
 	bool m_MouseDoubleClick;
-#if defined(CONF_PLATFORM_ANDROID) // No relative mouse on Android
-	ivec2 m_LastMousePos = ivec2(0, 0);
+#if defined(CONF_PLATFORM_ANDROID)
+	ivec2 m_LastMousePos = ivec2(0, 0); // No relative mouse on Android
+	int m_NumBackPresses = 0;
+	bool m_BackButtonReleased = true;
+	int64_t m_LastBackPress = -1;
 #endif
 
 	// IME support


### PR DESCRIPTION
Translate the Android back-button to the escape-key, so it can be used to navigate back in menus, open/close the ingame menu, close the editor etc.

Trap the Android back button by setting the `SDL_ANDROID_TRAP_BACK_BUTTON` hint, so it can be handled in our code reliably instead of letting the system handle it.

Interpret fast repeated presses of the back-button (3 times within 1 second) as a quit-event, so the app can be quit cleanly and quickly without using the UI. The client settings are otherwise not saved if the app is closed by minimizing it using the home button and waiting for the OS to kill it or by discarding it in the recent apps view.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
