### PR TITLE
Optimize `str_format(…, …, "%d", …)` using templates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -319,7 +319,11 @@ if(NOT MSVC AND NOT HAIKU)
   add_cxx_compiler_flag_if_supported(OUR_FLAGS_OWN -Wno-psabi) # parameter passing for argument of type ‘__gnu_cxx::__normal_iterator<CCommandProcessorFragment_Vulkan::SMemoryBlock<1>*, std::vector<CCommandProcessorFragment_Vulkan::SMemoryBlock<1>, std::allocator<CCommandProcessorFragment_Vulkan::SMemoryBlock<1> > > >’ changed in GCC 7.1
   add_cxx_compiler_flag_if_supported(OUR_FLAGS_OWN -Wno-unused-parameter)
   add_cxx_compiler_flag_if_supported(OUR_FLAGS_OWN -Wno-missing-field-initializers)
-  add_cxx_compiler_flag_if_supported(OUR_FLAGS_OWN -Wformat=2) # Warn about format strings.
+  if(CMAKE_BUILD_TYPE STREQUAL DEBUG)
+    add_cxx_compiler_flag_if_supported(OUR_FLAGS_OWN -Wformat=2) # Warn about format strings.
+  else()
+    add_cxx_compiler_flag_if_supported(OUR_FLAGS_OWN -Wno-format) # Don't warn about format strings in release mode since our `str_format` optimization is incompatible with it.
+  endif()
   add_c_compiler_flag_if_supported(OUR_FLAGS_DEP -Wno-implicit-function-declaration)
   add_cxx_compiler_flag_if_supported(OUR_FLAGS_OWN -Wno-nullability-completeness) # Mac OS build on github
   add_cxx_compiler_flag_if_supported(OUR_FLAGS_OWN -Wduplicated-cond)

--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -2784,6 +2784,15 @@ int str_format_v(char *buffer, int buffer_size, const char *format, va_list args
 	return str_utf8_fix_truncation(buffer);
 }
 
+int str_format_int(char *buffer, size_t buffer_size, int value)
+{
+	buffer[0] = '\0'; // Fix false positive clang-analyzer-core.UndefinedBinaryOperatorResult when using result
+	auto result = std::to_chars(buffer, buffer + buffer_size - 1, value);
+	result.ptr[0] = '\0';
+	return result.ptr - buffer;
+}
+
+#undef str_format
 int str_format(char *buffer, int buffer_size, const char *format, ...)
 {
 	va_list args;
@@ -2792,6 +2801,9 @@ int str_format(char *buffer, int buffer_size, const char *format, ...)
 	va_end(args);
 	return length;
 }
+#if !defined(CONF_DEBUG)
+#define str_format str_format_opt
+#endif
 
 const char *str_trim_words(const char *str, int words)
 {
@@ -3637,13 +3649,6 @@ bool str_tofloat(const char *str, float *out)
 	if(out != nullptr)
 		*out = value;
 	return true;
-}
-
-void str_from_int(int value, char *buffer, size_t buffer_size)
-{
-	buffer[0] = '\0'; // Fix false positive clang-analyzer-core.UndefinedBinaryOperatorResult when using result
-	auto result = std::to_chars(buffer, buffer + buffer_size - 1, value);
-	result.ptr[0] = '\0';
 }
 
 int str_utf8_comp_nocase(const char *a, const char *b)

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -1229,6 +1229,31 @@ int str_format_v(char *buffer, int buffer_size, const char *format, va_list args
 int str_format(char *buffer, int buffer_size, const char *format, ...)
 	GNUC_ATTRIBUTE((format(printf, 3, 4)));
 
+#if !defined(CONF_DEBUG)
+int str_format_int(char *buffer, size_t buffer_size, int value);
+
+template<typename... Args>
+int str_format_opt(char *buffer, int buffer_size, const char *format, Args... args)
+{
+	return str_format(buffer, buffer_size, format, args...);
+}
+
+template<>
+inline int str_format_opt(char *buffer, int buffer_size, const char *format, int val)
+{
+	if(strcmp(format, "%d") == 0)
+	{
+		return str_format_int(buffer, buffer_size, val);
+	}
+	else
+	{
+		return str_format(buffer, buffer_size, format, val);
+	}
+}
+
+#define str_format str_format_opt
+#endif
+
 /**
  * Trims specific number of words at the start of a string.
  *
@@ -2097,14 +2122,6 @@ unsigned long str_toulong_base(const char *str, int base);
 int64_t str_toint64_base(const char *str, int base = 10);
 float str_tofloat(const char *str);
 bool str_tofloat(const char *str, float *out);
-
-void str_from_int(int value, char *buffer, size_t buffer_size);
-
-template<size_t N>
-void str_from_int(int value, char (&dst)[N])
-{
-	str_from_int(value, dst, N);
-}
 
 /**
  * Determines whether a character is whitespace.

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -1944,7 +1944,7 @@ void CServer::CacheServerInfo(CCache *pCache, int Type, bool SendClients)
 #define ADD_INT(p, x) \
 	do \
 	{ \
-		str_from_int(x, aBuf); \
+		str_format(aBuf, sizeof(aBuf), "%d", x); \
 		(p).AddString(aBuf, 0); \
 	} while(0)
 
@@ -2205,7 +2205,7 @@ void CServer::SendServerInfo(const NETADDR *pAddr, int Token, int Type, bool Sen
 #define ADD_INT(p, x) \
 	do \
 	{ \
-		str_from_int(x, aBuf); \
+		str_format(aBuf, sizeof(aBuf), "%d", x); \
 		(p).AddString(aBuf, 0); \
 	} while(0)
 

--- a/src/engine/server/upnp.cpp
+++ b/src/engine/server/upnp.cpp
@@ -32,7 +32,7 @@ void CUPnP::Open(NETADDR Address)
 		{
 			m_Enabled = true;
 			dbg_msg("upnp", "found valid IGD: %s", m_pUPnPUrls->controlURL);
-			str_from_int(m_Addr.port, aPort);
+			str_format(aPort, sizeof(aPort), "%d", m_Addr.port);
 			Error = UPNP_AddPortMapping(m_pUPnPUrls->controlURL, m_pUPnPData->first.servicetype,
 				aPort, aPort, aLanAddr,
 				"DDNet Server " GAME_RELEASE_VERSION,
@@ -55,7 +55,7 @@ void CUPnP::Shutdown()
 		if(m_Enabled)
 		{
 			char aPort[6];
-			str_from_int(m_Addr.port, aPort);
+			str_format(aPort, sizeof(aPort), "%d", m_Addr.port);
 			int Error = UPNP_DeletePortMapping(m_pUPnPUrls->controlURL, m_pUPnPData->first.servicetype, aPort, "UDP", NULL);
 
 			if(Error != 0)

--- a/src/engine/shared/console.cpp
+++ b/src/engine/shared/console.cpp
@@ -733,7 +733,7 @@ void CConsole::ConUserCommandStatus(IResult *pResult, void *pUser)
 	CResult Result;
 	Result.m_pCommand = "access_status";
 	char aBuf[4];
-	str_from_int((int)IConsole::ACCESS_LEVEL_USER, aBuf);
+	str_format(aBuf, sizeof(aBuf), "%d", (int)IConsole::ACCESS_LEVEL_USER);
 	Result.AddArgument(aBuf);
 
 	CConsole::ConCommandStatus(&Result, pConsole);

--- a/src/engine/shared/jsonwriter.cpp
+++ b/src/engine/shared/jsonwriter.cpp
@@ -81,7 +81,7 @@ void CJsonWriter::WriteIntValue(int Value)
 	dbg_assert(CanWriteDatatype(), "Cannot write value here");
 	WriteIndent(false);
 	char aBuf[32];
-	str_from_int(Value, aBuf);
+	str_format(aBuf, sizeof(aBuf), "%d", Value);
 	WriteInternal(aBuf);
 	CompleteDataType();
 }

--- a/src/game/client/components/debughud.cpp
+++ b/src/game/client/components/debughud.cpp
@@ -60,10 +60,10 @@ void CDebugHud::RenderNetCorrections()
 	str_format(aBuf, sizeof(aBuf), "%.2f", Ramp);
 	RenderRow("Ramp:", aBuf);
 
-	str_from_int(pCharacter == nullptr ? -1 : pCharacter->m_TeleCheckpoint, aBuf);
+	str_format(aBuf, sizeof(aBuf), "%d", pCharacter == nullptr ? -1 : pCharacter->m_TeleCheckpoint);
 	RenderRow("Checkpoint:", aBuf);
 
-	str_from_int(pCharacter == nullptr ? -1 : pCharacter->m_TuneZone, aBuf);
+	str_format(aBuf, sizeof(aBuf), "%d", pCharacter == nullptr ? -1 : pCharacter->m_TuneZone);
 	RenderRow("Tune zone:", aBuf);
 
 	str_format(aBuf, sizeof(aBuf), "%.2f", m_pClient->m_Snap.m_pLocalCharacter->m_X / 32.0f);
@@ -72,10 +72,10 @@ void CDebugHud::RenderNetCorrections()
 	str_format(aBuf, sizeof(aBuf), "%.2f", m_pClient->m_Snap.m_pLocalCharacter->m_Y / 32.0f);
 	RenderRow("Pos.y:", aBuf);
 
-	str_from_int(m_pClient->m_Snap.m_pLocalCharacter->m_Angle, aBuf);
+	str_format(aBuf, sizeof(aBuf), "%d", m_pClient->m_Snap.m_pLocalCharacter->m_Angle);
 	RenderRow("Angle:", aBuf);
 
-	str_from_int(m_pClient->NetobjNumCorrections(), aBuf);
+	str_format(aBuf, sizeof(aBuf), "%d", m_pClient->NetobjNumCorrections());
 	RenderRow("Netobj corrections", aBuf);
 	RenderRow(" on:", m_pClient->NetobjCorrectedOn());
 }

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -171,8 +171,8 @@ void CHud::RenderScoreHud()
 		if(GameFlags & GAMEFLAG_TEAMS && m_pClient->m_Snap.m_pGameDataObj)
 		{
 			char aScoreTeam[2][16];
-			str_from_int(m_pClient->m_Snap.m_pGameDataObj->m_TeamscoreRed, aScoreTeam[TEAM_RED]);
-			str_from_int(m_pClient->m_Snap.m_pGameDataObj->m_TeamscoreBlue, aScoreTeam[TEAM_BLUE]);
+			str_format(aScoreTeam[TEAM_RED], sizeof(aScoreTeam[TEAM_RED]), "%d", m_pClient->m_Snap.m_pGameDataObj->m_TeamscoreRed);
+			str_format(aScoreTeam[TEAM_BLUE], sizeof(aScoreTeam[TEAM_BLUE]), "%d", m_pClient->m_Snap.m_pGameDataObj->m_TeamscoreBlue);
 
 			bool aRecreateTeamScore[2] = {str_comp(aScoreTeam[0], m_aScoreInfo[0].m_aScoreText) != 0, str_comp(aScoreTeam[1], m_aScoreInfo[1].m_aScoreText) != 0};
 
@@ -324,7 +324,7 @@ void CHud::RenderScoreHud()
 							aScore[t][0] = 0;
 					}
 					else
-						str_from_int(apPlayerInfo[t]->m_Score, aScore[t]);
+						str_format(aScore[t], sizeof(aScore[t]), "%d", apPlayerInfo[t]->m_Score);
 				}
 				else
 					aScore[t][0] = 0;
@@ -484,7 +484,7 @@ void CHud::RenderWarmupTimer()
 		if(Seconds < 5)
 			str_format(aBuf, sizeof(aBuf), "%d.%d", Seconds, (m_pClient->m_Snap.m_pGameInfoObj->m_WarmupTimer * 10 / Client()->GameTickSpeed()) % 10);
 		else
-			str_from_int(Seconds, aBuf);
+			str_format(aBuf, sizeof(aBuf), "%d", Seconds);
 		w = TextRender()->TextWidth(FontSize, aBuf, -1, -1.0f);
 		TextRender()->Text(150 * Graphics()->ScreenAspect() + -w / 2, 75, FontSize, aBuf, -1.0f);
 	}
@@ -503,7 +503,7 @@ void CHud::RenderTextInfo()
 		m_FrameTimeAvg = m_FrameTimeAvg * 0.9f + Client()->RenderFrameTime() * 0.1f;
 		char aBuf[64];
 		int FrameTime = (int)(1.0f / m_FrameTimeAvg + 0.5f);
-		str_from_int(FrameTime, aBuf);
+		str_format(aBuf, sizeof(aBuf), "%d", FrameTime);
 
 		static float s_TextWidth0 = TextRender()->TextWidth(12.f, "0", -1, -1.0f);
 		static float s_TextWidth00 = TextRender()->TextWidth(12.f, "00", -1, -1.0f);
@@ -532,7 +532,7 @@ void CHud::RenderTextInfo()
 	if(g_Config.m_ClShowpred && Client()->State() != IClient::STATE_DEMOPLAYBACK)
 	{
 		char aBuf[64];
-		str_from_int(Client()->GetPredictionTime(), aBuf);
+		str_format(aBuf, sizeof(aBuf), "%d", Client()->GetPredictionTime());
 		TextRender()->Text(m_Width - 10 - TextRender()->TextWidth(12, aBuf, -1, -1.0f), Showfps ? 20 : 5, 12, aBuf, -1.0f);
 	}
 }

--- a/src/game/client/components/mapimages.cpp
+++ b/src/game/client/components/mapimages.cpp
@@ -413,7 +413,7 @@ void CMapImages::UpdateEntityLayerText(CImageInfo &TextImage, int TextureSize, i
 	if(MaxNumber == -1)
 		MaxNumber = CurrentNumber * 10 - 1;
 
-	str_from_int(CurrentNumber, aBuf);
+	str_format(aBuf, sizeof(aBuf), "%d", CurrentNumber);
 
 	int CurrentNumberSuitableFontSize = TextRender()->AdjustFontSize(aBuf, DigitsCount, TextureSize, MaxWidth);
 	int UniversalSuitableFontSize = CurrentNumberSuitableFontSize * 0.92f; // should be smoothed enough to fit any digits combination
@@ -422,7 +422,7 @@ void CMapImages::UpdateEntityLayerText(CImageInfo &TextImage, int TextureSize, i
 
 	for(; CurrentNumber <= MaxNumber; ++CurrentNumber)
 	{
-		str_from_int(CurrentNumber, aBuf);
+		str_format(aBuf, sizeof(aBuf), "%d", CurrentNumber);
 
 		float x = (CurrentNumber % 16) * 64;
 		float y = (CurrentNumber / 16) * 64;

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -462,7 +462,7 @@ int CMenus::DoButton_CheckBox(const void *pId, const char *pText, int Checked, c
 int CMenus::DoButton_CheckBox_Number(const void *pId, const char *pText, int Checked, const CUIRect *pRect)
 {
 	char aBuf[16];
-	str_from_int(Checked, aBuf);
+	str_format(aBuf, sizeof(aBuf), "%d", Checked);
 	return DoButton_CheckBox_Common(pId, pText, aBuf, pRect);
 }
 

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -30,7 +30,7 @@ static void FormatServerbrowserPing(char (&aBuffer)[N], const CServerInfo *pInfo
 {
 	if(!pInfo->m_LatencyIsEstimated)
 	{
-		str_from_int(pInfo->m_Latency, aBuffer);
+		str_format(aBuffer, sizeof(aBuffer), "%d", pInfo->m_Latency);
 		return;
 	}
 	static const char *LOCATION_NAMES[CServerInfo::NUM_LOCS] = {
@@ -393,7 +393,7 @@ void CMenus::RenderServerbrowserServerList(CUIRect View, bool &WasListboxItemAct
 
 					if(pItem->m_FriendNum > 1)
 					{
-						str_from_int(pItem->m_FriendNum, aTemp);
+						str_format(aTemp, sizeof(aTemp), "%d", pItem->m_FriendNum);
 						TextRender()->TextColor(0.94f, 0.8f, 0.8f, 1.0f);
 						Ui()->DoLabel(&Button, aTemp, 9.0f, TEXTALIGN_MC);
 						TextRender()->TextColor(TextRender()->DefaultTextColor());
@@ -1250,7 +1250,7 @@ void CMenus::RenderServerbrowserInfoScoreboard(CUIRect View, const CServerInfo *
 		}
 		else if(pSelectedServer->m_ClientScoreKind == CServerInfo::CLIENT_SCORE_KIND_POINTS)
 		{
-			str_from_int(CurrentClient.m_Score, aTemp);
+			str_format(aTemp, sizeof(aTemp), "%d", CurrentClient.m_Score);
 		}
 		else
 		{

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -1309,7 +1309,7 @@ void CMenus::RenderDemoBrowserDetails(CUIRect DetailsView)
 	Contents.HSplitTop(18.0f, &Left, &Contents);
 	Left.VSplitMid(&Left, &Right, 4.0f);
 	Ui()->DoLabel(&Left, pItem->m_Info.m_aType, FontSize - 1.0f, TEXTALIGN_ML);
-	str_from_int(pItem->m_Info.m_Version, aBuf);
+	str_format(aBuf, sizeof(aBuf), "%d", pItem->m_Info.m_Version);
 	Ui()->DoLabel(&Right, aBuf, FontSize - 1.0f, TEXTALIGN_ML);
 	Contents.HSplitTop(4.0f, nullptr, &Contents);
 
@@ -1321,7 +1321,7 @@ void CMenus::RenderDemoBrowserDetails(CUIRect DetailsView)
 	Left.VSplitMid(&Left, &Right, 4.0f);
 	str_time((int64_t)pItem->Length() * 100, TIME_HOURS, aBuf, sizeof(aBuf));
 	Ui()->DoLabel(&Left, aBuf, FontSize - 1.0f, TEXTALIGN_ML);
-	str_from_int(pItem->NumMarkers(), aBuf);
+	str_format(aBuf, sizeof(aBuf), "%d", pItem->NumMarkers());
 	Ui()->DoLabel(&Right, aBuf, FontSize - 1.0f, TEXTALIGN_ML);
 	Contents.HSplitTop(4.0f, nullptr, &Contents);
 

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -1222,7 +1222,7 @@ void CMenus::DoJoystickAxisPicker(CUIRect View)
 
 		// Axis label
 		char aBuf[16];
-		str_from_int(i + 1, aBuf);
+		str_format(aBuf, sizeof(aBuf), "%d", i + 1);
 		if(Active)
 			TextRender()->TextColor(TextRender()->DefaultTextColor());
 		else

--- a/src/game/client/components/nameplates.cpp
+++ b/src/game/client/components/nameplates.cpp
@@ -211,7 +211,7 @@ void CNamePlates::RenderNameplatePos(vec2 Position, const CNetObj_PlayerInfo *pP
 		{
 			YOffset -= FontSize;
 			char aBuf[128];
-			str_from_int(pPlayerInfo->m_ClientId, aBuf);
+			str_format(aBuf, sizeof(aBuf), "%d", pPlayerInfo->m_ClientId);
 			float XOffset = TextRender()->TextWidth(FontSize, aBuf, -1, -1.0f) / 2.0f;
 			TextRender()->TextColor(rgb);
 			TextRender()->Text(Position.x - XOffset, YOffset, FontSize, aBuf, -1.0f);
@@ -273,7 +273,7 @@ void CNamePlates::RenderNameplatePos(vec2 Position, const CNetObj_PlayerInfo *pP
 				{
 					YOffset -= FontSize;
 					char aBuf[12];
-					str_from_int(Other.m_ExtendedData.m_StrongWeakId, aBuf);
+					str_format(aBuf, sizeof(aBuf), "%d", Other.m_ExtendedData.m_StrongWeakId);
 					float XOffset = TextRender()->TextWidth(FontSize, aBuf, -1, -1.0f) / 2.0f;
 					TextRender()->Text(Position.x - XOffset, YOffset, FontSize, aBuf, -1.0f);
 				}

--- a/src/game/client/components/scoreboard.cpp
+++ b/src/game/client/components/scoreboard.cpp
@@ -202,7 +202,7 @@ void CScoreboard::RenderScoreboard(float x, float y, float w, int Team, const ch
 		if(m_pClient->m_Snap.m_pGameDataObj)
 		{
 			int Score = Team == TEAM_RED ? m_pClient->m_Snap.m_pGameDataObj->m_TeamscoreRed : m_pClient->m_Snap.m_pGameDataObj->m_TeamscoreBlue;
-			str_from_int(Score, aBuf);
+			str_format(aBuf, sizeof(aBuf), "%d", Score);
 		}
 	}
 	else
@@ -211,12 +211,12 @@ void CScoreboard::RenderScoreboard(float x, float y, float w, int Team, const ch
 			m_pClient->m_Snap.m_apPlayerInfos[m_pClient->m_Snap.m_SpecInfo.m_SpectatorId])
 		{
 			int Score = m_pClient->m_Snap.m_apPlayerInfos[m_pClient->m_Snap.m_SpecInfo.m_SpectatorId]->m_Score;
-			str_from_int(Score, aBuf);
+			str_format(aBuf, sizeof(aBuf), "%d", Score);
 		}
 		else if(m_pClient->m_Snap.m_pLocalInfo)
 		{
 			int Score = m_pClient->m_Snap.m_pLocalInfo->m_Score;
-			str_from_int(Score, aBuf);
+			str_format(aBuf, sizeof(aBuf), "%d", Score);
 		}
 	}
 
@@ -370,7 +370,7 @@ void CScoreboard::RenderScoreboard(float x, float y, float w, int Team, const ch
 					if(DDTeam == TEAM_SUPER)
 						str_copy(aBuf, Localize("Super"));
 					else
-						str_from_int(DDTeam, aBuf);
+						str_format(aBuf, sizeof(aBuf), "%d", DDTeam);
 					TextRender()->SetCursor(&Cursor, x - 10.0f, y + Spacing + FontSize - (FontSize / 1.5f), FontSize / 1.5f, TEXTFLAG_RENDER | TEXTFLAG_STOP_AT_END);
 					Cursor.m_LineWidth = NameLength + 3;
 				}
@@ -405,7 +405,7 @@ void CScoreboard::RenderScoreboard(float x, float y, float w, int Team, const ch
 				str_time((int64_t)absolute(pInfo->m_Score) * 100, TIME_HOURS, aBuf, sizeof(aBuf));
 		}
 		else
-			str_from_int(clamp(pInfo->m_Score, -999, 99999), aBuf);
+			str_format(aBuf, sizeof(aBuf), "%d", clamp(pInfo->m_Score, -999, 99999));
 		tw = TextRender()->TextWidth(FontSize, aBuf, -1, -1.0f);
 		TextRender()->SetCursor(&Cursor, ScoreOffset + ScoreLength - tw, y + (LineHeight - FontSize) / 2.f, FontSize, TEXTFLAG_RENDER);
 		TextRender()->TextEx(&Cursor, aBuf, -1);
@@ -494,7 +494,7 @@ void CScoreboard::RenderScoreboard(float x, float y, float w, int Team, const ch
 			ColorRGBA rgb = color_cast<ColorRGBA>(ColorHSLA((300.0f - clamp(pInfo->m_Latency, 0, 300)) / 1000.0f, 1.0f, 0.5f));
 			TextRender()->TextColor(rgb);
 		}
-		str_from_int(clamp(pInfo->m_Latency, 0, 999), aBuf);
+		str_format(aBuf, sizeof(aBuf), "%d", clamp(pInfo->m_Latency, 0, 999));
 		tw = TextRender()->TextWidth(FontSize, aBuf, -1, -1.0f);
 		TextRender()->SetCursor(&Cursor, PingOffset + PingLength - tw, y + (LineHeight - FontSize) / 2.f, FontSize, TEXTFLAG_RENDER | TEXTFLAG_STOP_AT_END);
 		Cursor.m_LineWidth = PingLength;

--- a/src/game/client/components/statboard.cpp
+++ b/src/game/client/components/statboard.cpp
@@ -310,14 +310,14 @@ void CStatboard::RenderGlobalStats()
 
 		// FRAGS
 		{
-			str_from_int(pStats->m_Frags, aBuf);
+			str_format(aBuf, sizeof(aBuf), "%d", pStats->m_Frags);
 			tw = TextRender()->TextWidth(FontSize, aBuf, -1, -1.0f);
 			TextRender()->Text(x - tw + px, y + (LineHeight * 0.95f - FontSize) / 2.f, FontSize, aBuf, -1.0f);
 			px += 85;
 		}
 		// DEATHS
 		{
-			str_from_int(pStats->m_Deaths, aBuf);
+			str_format(aBuf, sizeof(aBuf), "%d", pStats->m_Deaths);
 			tw = TextRender()->TextWidth(FontSize, aBuf, -1, -1.0f);
 			TextRender()->Text(x - tw + px, y + (LineHeight * 0.95f - FontSize) / 2.f, FontSize, aBuf, -1.0f);
 			px += 85;
@@ -325,7 +325,7 @@ void CStatboard::RenderGlobalStats()
 		// SUICIDES
 		{
 			px += 10;
-			str_from_int(pStats->m_Suicides, aBuf);
+			str_format(aBuf, sizeof(aBuf), "%d", pStats->m_Suicides);
 			tw = TextRender()->TextWidth(FontSize, aBuf, -1, -1.0f);
 			TextRender()->Text(x - tw + px, y + (LineHeight * 0.95f - FontSize) / 2.f, FontSize, aBuf, -1.0f);
 			px += 85;
@@ -357,14 +357,14 @@ void CStatboard::RenderGlobalStats()
 		}
 		// SPREE
 		{
-			str_from_int(pStats->m_CurrentSpree, aBuf);
+			str_format(aBuf, sizeof(aBuf), "%d", pStats->m_CurrentSpree);
 			tw = TextRender()->TextWidth(FontSize, aBuf, -1, -1.0f);
 			TextRender()->Text(x - tw + px, y + (LineHeight * 0.95f - FontSize) / 2.f, FontSize, aBuf, -1.0f);
 			px += 85;
 		}
 		// BEST SPREE
 		{
-			str_from_int(pStats->m_BestSpree, aBuf);
+			str_format(aBuf, sizeof(aBuf), "%d", pStats->m_BestSpree);
 			tw = TextRender()->TextWidth(FontSize, aBuf, -1, -1.0f);
 			TextRender()->Text(x - tw + px, y + (LineHeight * 0.95f - FontSize) / 2.f, FontSize, aBuf, -1.0f);
 			px += 85;
@@ -372,7 +372,7 @@ void CStatboard::RenderGlobalStats()
 		// GRABS
 		if(GameWithFlags)
 		{
-			str_from_int(pStats->m_FlagGrabs, aBuf);
+			str_format(aBuf, sizeof(aBuf), "%d", pStats->m_FlagGrabs);
 			tw = TextRender()->TextWidth(FontSize, aBuf, -1, -1.0f);
 			TextRender()->Text(x - tw + px, y + (LineHeight * 0.95f - FontSize) / 2.f, FontSize, aBuf, -1.0f);
 			px += 85;
@@ -392,7 +392,7 @@ void CStatboard::RenderGlobalStats()
 		// FLAGS
 		if(GameWithFlags)
 		{
-			str_from_int(pStats->m_FlagCaptures, aBuf);
+			str_format(aBuf, sizeof(aBuf), "%d", pStats->m_FlagCaptures);
 			tw = TextRender()->TextWidth(FontSize, aBuf, -1, -1.0f);
 			TextRender()->Text(x - tw + px, y + (LineHeight * 0.95f - FontSize) / 2.f, FontSize, aBuf, -1.0f);
 		}

--- a/src/game/client/components/voting.cpp
+++ b/src/game/client/components/voting.cpp
@@ -47,7 +47,7 @@ void CVoting::CallvoteSpectate(int ClientId, const char *pReason, bool ForceVote
 	else
 	{
 		char aBuf[32];
-		str_from_int(ClientId, aBuf);
+		str_format(aBuf, sizeof(aBuf), "%d", ClientId);
 		Callvote("spectate", aBuf, pReason);
 	}
 }
@@ -63,7 +63,7 @@ void CVoting::CallvoteKick(int ClientId, const char *pReason, bool ForceVote)
 	else
 	{
 		char aBuf[32];
-		str_from_int(ClientId, aBuf);
+		str_format(aBuf, sizeof(aBuf), "%d", ClientId);
 		Callvote("kick", aBuf, pReason);
 	}
 }

--- a/src/game/client/lineinput.cpp
+++ b/src/game/client/lineinput.cpp
@@ -661,7 +661,7 @@ void CLineInputNumber::SetInteger(int Number, int Base, int HexPrefix)
 	switch(Base)
 	{
 	case 10:
-		str_from_int(Number, aBuf);
+		str_format(aBuf, sizeof(aBuf), "%d", Number);
 		break;
 	case 16:
 		str_format(aBuf, sizeof(aBuf), "%0*X", HexPrefix, Number);

--- a/src/game/client/render_map.cpp
+++ b/src/game/client/render_map.cpp
@@ -708,7 +708,7 @@ void CRenderTools::RenderTeleOverlay(CTeleTile *pTele, int w, int h, float Scale
 			unsigned char Index = pTele[c].m_Number;
 			if(Index && IsTeleTileNumberUsedAny(pTele[c].m_Type))
 			{
-				str_from_int(Index, aBuf);
+				str_format(aBuf, sizeof(aBuf), "%d", Index);
 				// Auto-resize text to fit inside the tile
 				float ScaledWidth = TextRender()->TextWidth(Size * Scale, aBuf, -1);
 				float Factor = clamp(Scale / ScaledWidth, 0.0f, 1.0f);
@@ -774,11 +774,11 @@ void CRenderTools::RenderSpeedupOverlay(CSpeedupTile *pSpeedup, int w, int h, fl
 				// draw force and max speed
 				if(g_Config.m_ClTextEntities)
 				{
-					str_from_int(Force, aBuf);
+					str_format(aBuf, sizeof(aBuf), "%d", Force);
 					TextRender()->Text(mx * Scale, (my + 0.5f + ToCenterOffset / 2) * Scale, Size * Scale / 2.f, aBuf);
 					if(MaxSpeed)
 					{
-						str_from_int(MaxSpeed, aBuf);
+						str_format(aBuf, sizeof(aBuf), "%d", MaxSpeed);
 						TextRender()->Text(mx * Scale, (my + ToCenterOffset / 2) * Scale, Size * Scale / 2.f, aBuf);
 					}
 				}
@@ -831,14 +831,14 @@ void CRenderTools::RenderSwitchOverlay(CSwitchTile *pSwitch, int w, int h, float
 			unsigned char Index = pSwitch[c].m_Number;
 			if(Index && IsSwitchTileNumberUsed(pSwitch[c].m_Type))
 			{
-				str_from_int(Index, aBuf);
+				str_format(aBuf, sizeof(aBuf), "%d", Index);
 				TextRender()->Text(mx * Scale, (my + ToCenterOffset / 2) * Scale, Size * Scale / 2.f, aBuf);
 			}
 
 			unsigned char Delay = pSwitch[c].m_Delay;
 			if(Delay && IsSwitchTileDelayUsed(pSwitch[c].m_Type))
 			{
-				str_from_int(Delay, aBuf);
+				str_format(aBuf, sizeof(aBuf), "%d", Delay);
 				TextRender()->Text(mx * Scale, (my + 0.5f + ToCenterOffset / 2) * Scale, Size * Scale / 2.f, aBuf);
 			}
 		}
@@ -888,7 +888,7 @@ void CRenderTools::RenderTuneOverlay(CTuneTile *pTune, int w, int h, float Scale
 			unsigned char Index = pTune[c].m_Number;
 			if(Index)
 			{
-				str_from_int(Index, aBuf);
+				str_format(aBuf, sizeof(aBuf), "%d", Index);
 				TextRender()->Text(mx * Scale + 11.f, my * Scale + 6.f, Size * Scale / 1.5f - 5.f, aBuf); // numbers shouldn't be too big and in the center of the tile
 			}
 		}

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -404,7 +404,7 @@ SEditResult<int> CEditor::UiDoValueSelector(void *pId, CUIRect *pRect, const cha
 		else if(IsHex)
 			str_format(aBuf, sizeof(aBuf), "#%06X", Current);
 		else
-			str_from_int(Current, aBuf);
+			str_format(aBuf, sizeof(aBuf), "%d", Current);
 		pRect->Draw(pColor ? *pColor : GetButtonColor(pId, 0), Corners, 3.0f);
 		Ui()->DoLabel(pRect, aBuf, 10, TEXTALIGN_MC);
 	}
@@ -6515,7 +6515,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 				char aValueBuffer[16];
 				if(UnitsPerLineY >= 1.0f)
 				{
-					str_from_int(static_cast<int>(Value), aValueBuffer);
+					str_format(aValueBuffer, sizeof(aValueBuffer), "%d", static_cast<int>(Value));
 				}
 				else
 				{

--- a/src/game/editor/editor_props.cpp
+++ b/src/game/editor/editor_props.cpp
@@ -39,7 +39,7 @@ SEditResult<E> CEditor::DoPropertiesWithState(CUIRect *pToolBox, CProperty *pPro
 
 			Shifter.VSplitRight(10.0f, &Shifter, &Inc);
 			Shifter.VSplitLeft(10.0f, &Dec, &Shifter);
-			str_from_int(pProps[i].m_Value, aBuf);
+			str_format(aBuf, sizeof(aBuf), "%d", pProps[i].m_Value);
 			auto NewValueRes = UiDoValueSelector((char *)&pIds[i], &Shifter, "", pProps[i].m_Value, pProps[i].m_Min, pProps[i].m_Max, 1, 1.0f, "Use left mouse button to drag and change the value. Hold shift to be more precise. Rightclick to edit as text.", false, false, 0, pColor);
 			int NewValue = NewValueRes.m_Value;
 			if(NewValue != pProps[i].m_Value || NewValueRes.m_State != EEditState::EDITING)

--- a/src/game/editor/mapitems/layer_tiles.cpp
+++ b/src/game/editor/mapitems/layer_tiles.cpp
@@ -676,7 +676,7 @@ void CLayerTiles::ShowInfo()
 				}
 				else
 				{
-					str_from_int(m_pTiles[c].m_Index, aBuf);
+					str_format(aBuf, sizeof(aBuf), "%d", m_pTiles[c].m_Index);
 				}
 				m_pEditor->Graphics()->QuadsText(x * 32, y * 32, 16.0f, aBuf);
 

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -4667,7 +4667,7 @@ void CGameContext::Converse(int ClientId, char *pStr)
 bool CGameContext::IsVersionBanned(int Version)
 {
 	char aVersion[16];
-	str_from_int(Version, aVersion);
+	str_format(aVersion, sizeof(aVersion), "%d", Version);
 
 	return str_in_list(g_Config.m_SvBannedVersions, ",", aVersion);
 }


### PR DESCRIPTION
This would make the function `str_from_int` unnecessary, at least user-facing.

Advantage: User doesn't have to care about `str_from_int`/`str_format` distinction.

Disadvantage: We're adding some template programming to `system.h`, potentially slowing all compilation.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
