### PR TITLE
Also print external module/symbol names in `parse_drmingw.sh`

### DIFF
--- a/scripts/parse_drmingw.sh
+++ b/scripts/parse_drmingw.sh
@@ -14,37 +14,57 @@ if [ -z ${2+x} ]; then
 	exit 1
 fi
 
-TMP_OFFSET=$(grep -E -o "\(with offset [0-9A-Fa-f]+\)" "$2" | grep -E -o "[0-9A-Fa-f]*")
-if [ -z "$TMP_OFFSET" ]; then
-	TMP_OFFSET=$(grep -E -o "^[0-9A-Fa-f]+-[0-9A-Fa-f]+ \S+\.exe" "$2" | grep -E -o "^[0-9A-Fa-f]+")
-	if [ -z "$TMP_OFFSET" ]; then
-		TMP_OFFSET="0"
-		if ! grep -q -E -o "\s\S+\.exe!" "$2"; then
+EXE_FILE=$1
+EXE_FILE_FILENAME=$(basename "$EXE_FILE")
+EXE_FILE_FILENAME_REGEX=$(printf '%s\n' "$EXE_FILE_FILENAME" | sed 's/\./\\./g')
+CRASH_LOG_FILE=$2
+
+# Determine module offset
+MODULE_OFFSET=$(grep -E -o "\(with offset [0-9A-Fa-f]+\)" "$CRASH_LOG_FILE" | grep -E -o "[0-9A-Fa-f]*")
+if [ -z "$MODULE_OFFSET" ]; then
+	MODULE_OFFSET=$(grep -E -o "^[0-9A-Fa-f]+-[0-9A-Fa-f]+ ${EXE_FILE_FILENAME_REGEX}" "$CRASH_LOG_FILE" | grep -E -o "^[0-9A-Fa-f]+")
+	if [ -z "$MODULE_OFFSET" ]; then
+		MODULE_OFFSET="0"
+		if ! grep -q -E -o "\s${EXE_FILE_FILENAME_REGEX}!" "$CRASH_LOG_FILE"; then
 			printf "\e[31m%s\e[30m\n" "Module offset not found; addresses will be absolute"
 			echo -en "\e[0m"
 		fi
 	fi
 fi
 
-if [ "$TMP_OFFSET" != "0" ]; then
-	echo "Module offset: 0x$TMP_OFFSET"
+if [ "$MODULE_OFFSET" != "0" ]; then
+	echo "Module offset: 0x$MODULE_OFFSET"
 fi
 
-ADDR_BASE=0x$(objdump -x "$1" | grep -E -o "^ImageBase\s+[0-9A-Fa-f]+$" | grep -E -o "[0-9A-Fa-f]+$")
+# Determine base address
+ADDR_BASE=0x$(objdump -x "$EXE_FILE" | grep -E -o -m 1 "^ImageBase\s+[0-9A-Fa-f]+$" | grep -E -o "[0-9A-Fa-f]+$")
 echo "Image base: $ADDR_BASE"
+echo
+
+function prine_line_for_address() {
+	addr2line -e "$EXE_FILE" -a -p -f -C -i "$1" | sed 's/ [^ ]*\/src\// src\//g'
+}
 
 ADDR_PC_REGEX='[0-9A-Fa-f]+ [0-9A-Fa-f]+ [0-9A-Fa-f]+ [0-9A-Fa-f]+'
 while read -r line
 do
-	if [[ $line =~ $ADDR_PC_REGEX ]]
-	then
-		RELATIVE_ADDR=$(echo "$line" | grep -E -o -m 1 "\s\S+\.exe!.*0x([0-9A-Fa-f]+)" | grep -E -o "0x[0-9A-Fa-f]+" | head -1)
-		if [ -z "$RELATIVE_ADDR" ]; then
-			TMP_ADDR=$(echo "$line" | grep -E -o -m 1 "[0-9A-Fa-f]+ " | head -1)
-			REAL_ADDR=$(printf '0x%X\n' "$(((0x$TMP_ADDR-0x$TMP_OFFSET)+ADDR_BASE))")
-		else
-			REAL_ADDR=$(printf '0x%X\n' "$((RELATIVE_ADDR+ADDR_BASE))")
+	if [[ $line =~ $ADDR_PC_REGEX ]]; then
+		# Check for main executable file with address information
+		EXE_FILE_RELATIVE_ADDR=$(echo "$line" | grep -E -o -m 1 "\s${EXE_FILE_FILENAME_REGEX}!.*0x[0-9A-Fa-f]+" | grep -E -o "0x[0-9A-Fa-f]+" | head -1)
+		if [ -n "$EXE_FILE_RELATIVE_ADDR" ]; then
+			prine_line_for_address "$(printf '0x%X\n' "$((EXE_FILE_RELATIVE_ADDR+ADDR_BASE))")"
+			continue
 		fi
-		addr2line -e "$1" -a -p -f -C -i "$REAL_ADDR" | sed 's/ [^ ]*\/src\// src\//g'
+
+		# Check for other module with defined symbol name and print the line literally
+		MODULE_WITH_SYMBOL_NAME=$(echo "$line" | grep -E -o -m 1 "\S+\.\S+![A-Za-z0-9_]+\+0x[0-9A-Fa-f]+")
+		if [ -n "$MODULE_WITH_SYMBOL_NAME" ]; then
+			echo "$MODULE_WITH_SYMBOL_NAME"
+			continue
+		fi
+
+		# Compatibilty with old crash logs: use the raw address and assume it belongs to the main executable
+		RAW_ADDR=$(echo "$line" | grep -E -o -m 1 "[0-9A-Fa-f]+ " | head -1)
+		prine_line_for_address "$(printf '0x%X\n' "$(((0x$RAW_ADDR-0x$MODULE_OFFSET)+ADDR_BASE))")"
 	fi
-done < "$2"
+done < "$CRASH_LOG_FILE"


### PR DESCRIPTION
Example output before this change:

```
Module offset: 0x00007FF7C8DE0000
Image base: 0x0000000140000000
0x0000000772cb5efc: ?? ??:0
0x000000077cd5c3e8: ?? ??:0
0x000000075d063cc3: ?? ??:0
0x000000075d2a3d61: ?? ??:0
0x000000075d0b7fde: ?? ??:0
0x000000075d2a5f18: ?? ??:0
0x000000075d2a6809: ?? ??:0
0x000000075d0b8140: ?? ??:0
0x000000075cf9d41b: ?? ??:0
0x000000014034b4c7: CCommandProcessorFragment_Vulkan::WaitFrame() at src/engine/client/backend/vulkan/backend_vulkan.cpp:2341
0x000000014034a1a5: CCommandProcessorFragment_Vulkan::NextFrame() at src/engine/client/backend/vulkan/backend_vulkan.cpp:2501
0x000000014032d5b6: CCommandProcessorFragment_Vulkan::RunCommand(CCommandBuffer::SCommand const*) at src/engine/client/backend/vulkan/backend_vulkan.cpp:6473
0x000000014001a7e6: CCommandProcessor_SDL_GL::RunBuffer(CCommandBuffer*) at src/engine/client/backend_sdl.cpp:335
0x00000001400168eb: CGraphicsBackend_Threaded::ThreadFunc(void*) at src/engine/client/backend_sdl.cpp:65
0x0000000140237f9a: CWindowsComLifecycle::~CWindowsComLifecycle() at src/base/system.cpp:4660
 (inlined by) thread_run at src/base/system.cpp:796
0x00000007ea7e257d: ?? ??:0
0x00000007eb62aa48: ?? ??:0
```

Output for the same crash dump with this change:

```
Module offset: 0x00007FF7C8DE0000
Image base: 0x0000000140000000

amdvlk64.dll!vk_icdGetInstanceProcAddrSG+0x1f40c
atig6pxx.dll!AmdGetCallbackProcs+0x124
amdvlk64.dll!vk_icdGetInstanceProcAddrSG+0x57773
amdvlk64.dll!vk_icdGetInstanceProcAddrSG+0x297811
amdvlk64.dll!vk_icdGetInstanceProcAddrSG+0xaba8e
amdvlk64.dll!vk_icdGetInstanceProcAddrSG+0x2999c8
amdvlk64.dll!vk_icdGetInstanceProcAddrSG+0x29a2b9
amdvlk64.dll!vk_icdGetInstanceProcAddrSG+0xabbf0
amdvlk64.dll!IcdPresentBuffers+0xb8eb
0x000000014034b4c7: CCommandProcessorFragment_Vulkan::WaitFrame() at src/engine/client/backend/vulkan/backend_vulkan.cpp:2341
0x000000014034a1a5: CCommandProcessorFragment_Vulkan::NextFrame() at src/engine/client/backend/vulkan/backend_vulkan.cpp:2501
0x000000014032d5b6: CCommandProcessorFragment_Vulkan::RunCommand(CCommandBuffer::SCommand const*) at src/engine/client/backend/vulkan/backend_vulkan.cpp:6473
0x000000014001a7e6: CCommandProcessor_SDL_GL::RunBuffer(CCommandBuffer*) at src/engine/client/backend_sdl.cpp:335
0x00000001400168eb: CGraphicsBackend_Threaded::ThreadFunc(void*) at src/engine/client/backend_sdl.cpp:65
0x0000000140237f9a: CWindowsComLifecycle::~CWindowsComLifecycle() at src/base/system.cpp:4660
 (inlined by) thread_run at src/base/system.cpp:796
KERNEL32.DLL!BaseThreadInitThunk+0x1d
ntdll.dll!RtlUserThreadStart+0x28
```

Also improve variable names in the script and add some comments.

<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
