### PR TITLE
Fix `possibly-used-before-assignment` in `copy_fix.py`

### DIFF
--- a/scripts/languages/copy_fix.py
+++ b/scripts/languages/copy_fix.py
@@ -8,10 +8,8 @@ def copy_fix(infile, delete_unused, append_missing, delete_empty):
 	with open(infile, encoding="utf-8") as f:
 		content = f.readlines()
 	trans = twlang.translations(infile)
-	if delete_unused or append_missing:
-		local = twlang.localizes()
-	if append_missing:
-		supported = []
+	local = twlang.localizes()
+	supported = []
 	for tran, (start, expr, end) in trans.items():
 		if delete_unused and tran not in local:
 			content[start:end] = [None]*(end-start)


### PR DESCRIPTION
Always initialize the variables `local` and `supported` instead of initializing them conditionally, to fix the false-positive `possibly-used-before-assignment` pylint detection.

Closes #8369.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
