### PR TITLE
Force landscape orientation and hide title bar on Android

### DIFF
--- a/scripts/android/files/AndroidManifest.xml
+++ b/scripts/android/files/AndroidManifest.xml
@@ -3,6 +3,8 @@
 	package="tw.DDNet">
 	<uses-feature
 		android:glEsVersion="0x00030000" />
+	<uses-feature
+		android:name="android.hardware.screen.landscape" />
 
 	<!-- Teeworlds does broadcasts over local networks -->
 	<uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
@@ -24,10 +26,11 @@
 		android:isGame="true"
 		android:icon="@mipmap/ic_launcher"
 		android:roundIcon="@mipmap/ic_launcher_round"
-		>
+		android:theme="@android:style/Theme.NoTitleBar.Fullscreen">
 		<activity
 			android:name=".NativeMain"
-			android:configChanges="orientation|screenSize|screenLayout|keyboardHidden">
+			android:configChanges="orientation|screenSize|screenLayout|keyboardHidden"
+			android:screenOrientation="landscape">
 			<intent-filter>
 				<action android:name="android.intent.action.MAIN" />
 

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -4529,6 +4529,8 @@ int main(int argc, const char **argv)
 	// Trap the Android back button so it can be handled in our code reliably
 	// instead of letting the system handle it.
 	SDL_SetHint("SDL_ANDROID_TRAP_BACK_BUTTON", "1");
+	// Force landscape screen orientation.
+	SDL_SetHint("SDL_IOS_ORIENTATIONS", "LandscapeLeft LandscapeRight");
 #endif
 
 	// init SDL


### PR DESCRIPTION
Always force landscape orientation to be used for the game on Android.

Hide the title bar so it is not shown when starting the game. There is also a bug with SDL currently that leads to the title bar and status bar being shown permanently after minimizing and reopening the app, which is alleviated by hiding the title bar.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
