### PR TITLE
Add support for server-provided assets

### DIFF
--- a/datasrc/network.py
+++ b/datasrc/network.py
@@ -370,7 +370,7 @@ Objects = [
 		NetIntAny("m_EntityClass"),
 	]),
 
-	NetEventEx("MapSoundWorld:Common", "map-sound-world@netobj.ddnet.org", [
+	NetEventEx("MapSoundWorld:Common", "map-sound-world@netevent.ddnet.org", [
 		NetIntAny("m_SoundId", 0),
 	]),
 ]

--- a/datasrc/network.py
+++ b/datasrc/network.py
@@ -1,7 +1,7 @@
 # pylint: skip-file
 # See https://github.com/ddnet/ddnet/issues/3507
 
-from datatypes import Enum, Flags, NetArray, NetBool, NetEvent, NetIntAny, NetIntRange, NetMessage, NetMessageEx, NetObject, NetObjectEx, NetString, NetStringHalfStrict, NetStringStrict, NetTick
+from datatypes import Enum, Flags, NetArray, NetBool, NetEvent, NetEventEx, NetIntAny, NetIntRange, NetMessage, NetMessageEx, NetObject, NetObjectEx, NetString, NetStringHalfStrict, NetStringStrict, NetTick
 
 Emotes = ["NORMAL", "PAIN", "HAPPY", "SURPRISE", "ANGRY", "BLINK"]
 PlayerFlags = ["PLAYING", "IN_MENU", "CHATTING", "SCOREBOARD", "AIM"]
@@ -369,6 +369,10 @@ Objects = [
 		NetIntAny("m_Layer"),
 		NetIntAny("m_EntityClass"),
 	]),
+
+	NetEventEx("MapSoundWorld:Common", "map-sound-world@netobj.ddnet.org", [
+		NetIntAny("m_SoundId", 0),
+	]),
 ]
 
 Messages = [
@@ -579,5 +583,9 @@ Messages = [
 
 	NetMessageEx("Sv_ChangeInfoCooldown", "change-info-cooldown@netmsg.ddnet.org", [
 		NetTick("m_WaitUntil")
+	]),
+
+	NetMessageEx("Sv_MapSoundGlobal", "map-sound-global@netmsg.ddnet.org", [
+		NetIntAny("m_SoundId", 0),
 	]),
 ]

--- a/src/game/client/components/mapsounds.cpp
+++ b/src/game/client/components/mapsounds.cpp
@@ -17,6 +17,22 @@ CMapSounds::CMapSounds()
 	m_Count = 0;
 }
 
+void CMapSounds::Play(int SoundId)
+{
+	if(SoundId < 0 || SoundId >= m_Count)
+		return;
+
+	m_pClient->m_Sounds.PlaySample(CSounds::CHN_MAPSOUND, m_aSounds[SoundId], 1.0f, 0);
+}
+
+void CMapSounds::PlayAt(int SoundId, vec2 Pos)
+{
+	if(SoundId < 0 || SoundId >= m_Count)
+		return;
+
+	m_pClient->m_Sounds.PlaySampleAt(CSounds::CHN_MAPSOUND, m_aSounds[SoundId], 1.0f, Pos, 0);
+}
+
 void CMapSounds::OnMapLoad()
 {
 	IMap *pMap = Kernel()->RequestInterface<IMap>();

--- a/src/game/client/components/mapsounds.h
+++ b/src/game/client/components/mapsounds.h
@@ -35,7 +35,7 @@ public:
 
 	void Play(int SoundId);
 	void PlayAt(int SoundId, vec2 Pos);
-	
+
 	virtual void OnMapLoad() override;
 	virtual void OnRender() override;
 	virtual void OnStateChange(int NewState, int OldState) override;

--- a/src/game/client/components/mapsounds.h
+++ b/src/game/client/components/mapsounds.h
@@ -33,6 +33,9 @@ public:
 	CMapSounds();
 	virtual int Sizeof() const override { return sizeof(*this); }
 
+	void Play(int SoundId);
+	void PlayAt(int SoundId, vec2 Pos);
+	
 	virtual void OnMapLoad() override;
 	virtual void OnRender() override;
 	virtual void OnStateChange(int NewState, int OldState) override;

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -996,6 +996,17 @@ void CGameClient::OnMessage(int MsgId, CUnpacker *pUnpacker, int Conn, bool Dumm
 		CNetMsg_Sv_ChangeInfoCooldown *pMsg = (CNetMsg_Sv_ChangeInfoCooldown *)pRawMsg;
 		m_NextChangeInfo = pMsg->m_WaitUntil;
 	}
+	else if(MsgId == NETMSGTYPE_SV_MAPSOUNDGLOBAL)
+	{
+		if(m_SuppressEvents)
+			return;
+
+		if(!g_Config.m_SndGame)
+			return;
+
+		CNetMsg_Sv_MapSoundGlobal *pMsg = (CNetMsg_Sv_MapSoundGlobal *)pRawMsg;
+		m_MapSounds.Play(pMsg->m_SoundId);
+	}
 }
 
 void CGameClient::OnStateChange(int NewState, int OldState)
@@ -1160,6 +1171,14 @@ void CGameClient::ProcessEvents()
 				continue;
 
 			m_Sounds.PlayAt(CSounds::CHN_WORLD, pEvent->m_SoundId, 1.0f, vec2(pEvent->m_X, pEvent->m_Y));
+		}
+		else if(Item.m_Type == NETEVENTTYPE_MAPSOUNDWORLD)
+		{
+			CNetEvent_MapSoundWorld *pEvent = (CNetEvent_MapSoundWorld *)pData;
+			if(!Config()->m_SndGame)
+				continue;
+
+			m_MapSounds.PlayAt(pEvent->m_SoundId, vec2(pEvent->m_X, pEvent->m_Y));
 		}
 	}
 }


### PR DESCRIPTION
This is a working draft.

This draft uses the design of the map-embedded assets in #7296 

### Why not to use a extra file?
As we can see, the DDNet maps is bigger and bigger since we can use HTTPS download maps.
Also, I said, this is a working draft, so if this problem is too serious, we can change to other ways.

But now, map-embedded assets is the best way.

Now this draft support to play the server-provided sounds that embedded in the map anytime, as long as server needs

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
