### PR TITLE
Whitelist class names starting with I

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -116,7 +116,7 @@ CheckOptions:
   - key:             readability-identifier-naming.StructIgnoredRegexp
     value:           '^([CS]|MapObject$|EnvelopedQuad$).*'
   - key:             readability-identifier-naming.ClassIgnoredRegexp
-    value:           '^(CCommandProcessorFragment_Vulkan$).*'
+    value:           '^(I|CCommandProcessorFragment_Vulkan$).*'
   - key:             readability-identifier-naming.ParameterCase
     value:           CamelCase
   - key:             readability-identifier-naming.ParameterIgnoredRegexp


### PR DESCRIPTION
Fixes clang issues being detected in interface classes such as `class IJob`

Fixes the following clangd error:

``Invalid case style for class 'IJob' (fix available)``

![image](https://github.com/ddnet/ddnet/assets/20344300/b5d6c969-232b-435d-857b-3a874c80143e)

