### PR TITLE
Allow econ to succeed, even if ipv6 econ fails to bind to socket

### DIFF
--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -1846,7 +1846,7 @@ NETSOCKET net_tcp_create(NETADDR bindaddr)
 	NETSOCKET sock = (NETSOCKET_INTERNAL *)malloc(sizeof(*sock));
 	*sock = invalid_socket;
 	NETADDR tmpbindaddr = bindaddr;
-	int socket = -1;
+	int socket4 = -1;
 
 	if(bindaddr.type & NETTYPE_IPV4)
 	{
@@ -1855,14 +1855,15 @@ NETSOCKET net_tcp_create(NETADDR bindaddr)
 		/* bind, we should check for error */
 		tmpbindaddr.type = NETTYPE_IPV4;
 		netaddr_to_sockaddr_in(&tmpbindaddr, &addr);
-		socket = priv_net_create_socket(AF_INET, SOCK_STREAM, (struct sockaddr *)&addr, sizeof(addr));
-		if(socket >= 0)
+		socket4 = priv_net_create_socket(AF_INET, SOCK_STREAM, (struct sockaddr *)&addr, sizeof(addr));
+		if(socket4 >= 0)
 		{
 			sock->type |= NETTYPE_IPV4;
-			sock->ipv4sock = socket;
+			sock->ipv4sock = socket4;
 		}
 	}
 
+	int socket6 = -1;
 	if(bindaddr.type & NETTYPE_IPV6)
 	{
 		struct sockaddr_in6 addr;
@@ -1870,15 +1871,15 @@ NETSOCKET net_tcp_create(NETADDR bindaddr)
 		/* bind, we should check for error */
 		tmpbindaddr.type = NETTYPE_IPV6;
 		netaddr_to_sockaddr_in6(&tmpbindaddr, &addr);
-		socket = priv_net_create_socket(AF_INET6, SOCK_STREAM, (struct sockaddr *)&addr, sizeof(addr));
-		if(socket >= 0)
+		socket6 = priv_net_create_socket(AF_INET6, SOCK_STREAM, (struct sockaddr *)&addr, sizeof(addr));
+		if(socket6 >= 0)
 		{
 			sock->type |= NETTYPE_IPV6;
-			sock->ipv6sock = socket;
+			sock->ipv6sock = socket6;
 		}
 	}
 
-	if(socket < 0)
+	if(socket4 < 0 && socket6 < 0)
 	{
 		free(sock);
 		sock = nullptr;


### PR DESCRIPTION
It seems there is a problem with ECon, where the server somehow tries to bind to wrong IPv6 address, making the bind fail. This PR allows ECon to succeed if at least one of the two sockets (IPv4 or IPv6) could be opened.

I did some preliminary debugging and found that default bind address (localhost) at some point got properly resolved to `::1`, but when trying to bind to it, the address seems wrong. I guess it somehow got mangled up before the actual bind call. This needs some further debugging to be resolved, but it should not prevent ECon from working at all, so I changed the code accordingly.

## Checklist

- [x] Tested the change ingame
- [x] Tested in combination with possibly related configuration options
- [x] Changed no physics that affect existing maps