### PR TITLE
Further clean up and improve the Android building scripts, lower minimum target API to 19

### DIFF
--- a/scripts/android/cmake_android.sh
+++ b/scripts/android/cmake_android.sh
@@ -12,129 +12,135 @@ export ANDROID_NDK_VERSION
 # ANDROID_NDK_HOME must be exported for cargo-ndk
 export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/$ANDROID_NDK_VERSION"
 
-_DEFAULT_ANDROID_BUILD=x86
-_DEFAULT_GAME_NAME=DDNet
-_DEFAULT_PACKAGE_NAME=org.ddnet.client
-_DEFAULT_BUILD_TYPE=Debug
-_DEFAULT_BUILD_FOLDER=build-android
-_ANDROID_API_LEVEL=34
+ANDROID_API_LEVEL=34
+ANDROID_SUB_BUILD_DIR=build_arch
 
-_ANDROID_SUB_BUILD_DIR=build_arch
+COLOR_RED="\e[1;31m"
+COLOR_YELLOW="\e[1;33m"
+COLOR_CYAN="\e[1;36m"
+COLOR_RESET="\e[0m"
 
-_SHOW_USAGE_INFO=0
+SHOW_USAGE_INFO=0
 
 if [ -z ${1+x} ]; then
-	printf "\e[31m%s\e[30m\n" "Did not pass android build type, using default: ${_DEFAULT_ANDROID_BUILD}"
-	_SHOW_USAGE_INFO=1
+	SHOW_USAGE_INFO=1
+	printf "${COLOR_RED}%s${COLOR_RESET}\n" "Did not pass Android build type"
 else
-	_DEFAULT_ANDROID_BUILD=$1
+	ANDROID_BUILD=$1
+	printf "${COLOR_YELLOW}%s${COLOR_RESET}\n" "Android build type: ${ANDROID_BUILD}"
 fi
 
 if [ -z ${2+x} ]; then
-	printf "\e[31m%s\e[30m\n" "Did not pass game name, using default: ${_DEFAULT_GAME_NAME}"
-	_SHOW_USAGE_INFO=1
+	SHOW_USAGE_INFO=1
+	printf "${COLOR_RED}%s${COLOR_RESET}\n" "Did not pass game name"
 else
-	_DEFAULT_GAME_NAME=$2
+	GAME_NAME=$2
+	printf "${COLOR_YELLOW}%s${COLOR_RESET}\n" "Game name: ${GAME_NAME}"
 fi
 
 if [ -z ${3+x} ]; then
-	printf "\e[31m%s\e[30m\n" "Did not pass package name, using default: ${_DEFAULT_PACKAGE_NAME}"
-	_SHOW_USAGE_INFO=1
+	SHOW_USAGE_INFO=1
+	printf "${COLOR_RED}%s${COLOR_RESET}\n" "Did not pass package name"
 else
-	_DEFAULT_PACKAGE_NAME=$3
+	PACKAGE_NAME=$3
+	printf "${COLOR_YELLOW}%s${COLOR_RESET}\n" "Package name: ${PACKAGE_NAME}"
 fi
 
 if [ -z ${4+x} ]; then
-	printf "\e[31m%s\e[30m\n" "Did not pass build type, using default: ${_DEFAULT_BUILD_TYPE}"
-	_SHOW_USAGE_INFO=1
+	SHOW_USAGE_INFO=1
+	printf "${COLOR_RED}%s${COLOR_RESET}\n" "Did not pass build type"
 else
-	_DEFAULT_BUILD_TYPE=$4
+	BUILD_TYPE=$4
+	printf "${COLOR_YELLOW}%s${COLOR_RESET}\n" "Build type: ${BUILD_TYPE}"
 fi
 
 if [ -z ${5+x} ]; then
-	printf "\e[31m%s\e[30m\n" "Did not pass build folder, using default: ${_DEFAULT_BUILD_FOLDER}"
-	_SHOW_USAGE_INFO=1
+	SHOW_USAGE_INFO=1
+	printf "${COLOR_RED}%s${COLOR_RESET}\n" "Did not pass build folder"
 else
-	_DEFAULT_BUILD_FOLDER=$5
+	BUILD_FOLDER=$5
+	printf "${COLOR_YELLOW}%s${COLOR_RESET}\n" "Build folder: ${BUILD_FOLDER}"
 fi
 
-_ANDROID_JAR_KEY_NAME=~/.android/debug.keystore
-_ANDROID_JAR_KEY_PW=android
-_ANDROID_JAR_KEY_ALIAS=androiddebugkey
+if [ $SHOW_USAGE_INFO == 1 ]; then
+	printf "${COLOR_RED}%s${COLOR_RESET}\n" "Usage: ./cmake_android.sh <x86/x86_64/arm/arm64/all> <Game name> <Package name> <Debug/Release> <Build folder>"
+	exit 1
+fi
+
+# These are the properties of the default Android debug key. The debug key will
+# automatically be created during the Gradle build if it does not exist already,
+# so you don't need to create it yourself.
+DEFAULT_KEY_NAME=~/.android/debug.keystore
+DEFAULT_KEY_PW=android
+DEFAULT_KEY_ALIAS=androiddebugkey
 
 if [ -z ${TW_KEY_NAME+x} ]; then
-	printf "\e[31m%s\e[30m\n" "Did not pass a key for the jar signer, using default: ${_ANDROID_JAR_KEY_NAME}"
+	printf "${COLOR_YELLOW}%s${COLOR_RESET}\n" "Did not pass a key path for the APK signer, using default: ${DEFAULT_KEY_NAME}"
 else
-	_ANDROID_JAR_KEY_NAME=$TW_KEY_NAME
+	DEFAULT_KEY_NAME=$TW_KEY_NAME
 fi
 if [ -z ${TW_KEY_PW+x} ]; then
-	printf "\e[31m%s\e[30m\n" "Did not pass a key pw for the jar signer, using default: ${_ANDROID_JAR_KEY_PW}"
+	printf "${COLOR_YELLOW}%s${COLOR_RESET}\n" "Did not pass a key password for the APK signer, using default: ${DEFAULT_KEY_PW}"
 else
-	_ANDROID_JAR_KEY_PW=$TW_KEY_PW
+	DEFAULT_KEY_PW=$TW_KEY_PW
 fi
 if [ -z ${TW_KEY_ALIAS+x} ]; then
-	printf "\e[31m%s\e[30m\n" "Did not pass a key alias for the jar signer, using default: ${_ANDROID_JAR_KEY_ALIAS}"
+	printf "${COLOR_YELLOW}%s${COLOR_RESET}\n" "Did not pass a key alias for the APK signer, using default: ${DEFAULT_KEY_ALIAS}"
 else
-	_ANDROID_JAR_KEY_ALIAS=$TW_KEY_ALIAS
+	DEFAULT_KEY_ALIAS=$TW_KEY_ALIAS
 fi
 
-export TW_KEY_NAME="${_ANDROID_JAR_KEY_NAME}"
-export TW_KEY_PW=$_ANDROID_JAR_KEY_PW
-export TW_KEY_ALIAS=$_ANDROID_JAR_KEY_ALIAS
+export TW_KEY_NAME="${DEFAULT_KEY_NAME}"
+export TW_KEY_PW=$DEFAULT_KEY_PW
+export TW_KEY_ALIAS=$DEFAULT_KEY_ALIAS
 
-_ANDROID_VERSION_CODE=1
+ANDROID_VERSION_CODE=1
 if [ -z ${TW_VERSION_CODE+x} ]; then
-	_ANDROID_VERSION_CODE=$(grep '#define DDNET_VERSION_NUMBER' src/game/version.h | awk '{print $3}')
-	if [ -z ${_ANDROID_VERSION_CODE+x} ]; then
-		_ANDROID_VERSION_CODE=1
+	ANDROID_VERSION_CODE=$(grep '#define DDNET_VERSION_NUMBER' src/game/version.h | awk '{print $3}')
+	if [ -z ${ANDROID_VERSION_CODE+x} ]; then
+		ANDROID_VERSION_CODE=1
 	fi
-	printf "\e[31m%s\e[30m\n" "Did not pass a version code, using default: ${_ANDROID_VERSION_CODE}"
+	printf "${COLOR_YELLOW}%s${COLOR_RESET}\n" "Did not pass a version code, using default: ${ANDROID_VERSION_CODE}"
 else
-	_ANDROID_VERSION_CODE=$TW_VERSION_CODE
+	ANDROID_VERSION_CODE=$TW_VERSION_CODE
 fi
 
-export TW_VERSION_CODE=$_ANDROID_VERSION_CODE
+export TW_VERSION_CODE=$ANDROID_VERSION_CODE
 
-_ANDROID_VERSION_NAME="1.0"
+ANDROID_VERSION_NAME="1.0"
 if [ -z ${TW_VERSION_NAME+x} ]; then
-	_ANDROID_VERSION_NAME="$(grep '#define GAME_RELEASE_VERSION' src/game/version.h | awk '{print $3}' | tr -d '"')"
-	if [ -z ${_ANDROID_VERSION_NAME+x} ]; then
-		_ANDROID_VERSION_NAME="1.0"
+	ANDROID_VERSION_NAME="$(grep '#define GAME_RELEASE_VERSION' src/game/version.h | awk '{print $3}' | tr -d '"')"
+	if [ -z ${ANDROID_VERSION_NAME+x} ]; then
+		ANDROID_VERSION_NAME="1.0"
 	fi
-	printf "\e[31m%s\e[30m\n" "Did not pass a version name, using default: ${_ANDROID_VERSION_NAME}"
+	printf "${COLOR_YELLOW}%s${COLOR_RESET}\n" "Did not pass a version name, using default: ${ANDROID_VERSION_NAME}"
 else
-	_ANDROID_VERSION_NAME=$TW_VERSION_NAME
+	ANDROID_VERSION_NAME=$TW_VERSION_NAME
 fi
 
-export TW_VERSION_NAME=$_ANDROID_VERSION_NAME
+export TW_VERSION_NAME=$ANDROID_VERSION_NAME
 
-printf "\e[31m%s\e[1m\n" "Building with setting, for arch: ${_DEFAULT_ANDROID_BUILD}, with build type: ${_DEFAULT_BUILD_TYPE}, with name: ${_DEFAULT_GAME_NAME} (${_DEFAULT_PACKAGE_NAME})"
-
-if [ $_SHOW_USAGE_INFO == 1 ]; then
-	printf "\e[31m%s\e[1m\n" "Usage: ./cmake_android.sh <x86/x86_64/arm/arm64/all> <Game name> <Package name> <Debug/Release> <Build folder>"
-fi
-
-printf "\e[33mBuilding cmake\e[0m\n"
+printf "${COLOR_CYAN}%s${COLOR_RESET}\n" "Building cmake..."
 
 function build_for_type() {
 	cmake \
 		-H. \
 		-G "Ninja" \
 		-DPREFER_BUNDLED_LIBS=ON \
-		-DCMAKE_BUILD_TYPE="${_DEFAULT_BUILD_TYPE}" \
-		-DANDROID_PLATFORM="android-${_ANDROID_API_LEVEL}" \
+		-DCMAKE_BUILD_TYPE="${BUILD_TYPE}" \
+		-DANDROID_PLATFORM="android-${ANDROID_API_LEVEL}" \
 		-DCMAKE_TOOLCHAIN_FILE="$ANDROID_NDK_HOME/build/cmake/android.toolchain.cmake" \
 		-DANDROID_NDK="$ANDROID_NDK_HOME" \
 		-DANDROID_ABI="${2}" \
 		-DANDROID_ARM_NEON=TRUE \
 		-DCMAKE_ANDROID_NDK="$ANDROID_NDK_HOME" \
 		-DCMAKE_SYSTEM_NAME=Android \
-		-DCMAKE_SYSTEM_VERSION="$_ANDROID_API_LEVEL" \
+		-DCMAKE_SYSTEM_VERSION="$ANDROID_API_LEVEL" \
 		-DCMAKE_ANDROID_ARCH_ABI="${2}" \
 		-DCARGO_NDK_TARGET="${3}" \
-		-DCARGO_NDK_API="$_ANDROID_API_LEVEL" \
+		-DCARGO_NDK_API="$ANDROID_API_LEVEL" \
 		-DDDNET_TEST_NO_LINK=ON \
-		-B"${_DEFAULT_BUILD_FOLDER}/$_ANDROID_SUB_BUILD_DIR/$1" \
+		-B"${BUILD_FOLDER}/$ANDROID_SUB_BUILD_DIR/$1" \
 		-DSERVER=OFF \
 		-DTOOLS=OFF \
 		-DDEV=TRUE \
@@ -142,60 +148,60 @@ function build_for_type() {
 		-DVULKAN=ON \
 		-DVIDEORECORDER=OFF
 	(
-		cd "${_DEFAULT_BUILD_FOLDER}/$_ANDROID_SUB_BUILD_DIR/$1" || exit 1
+		cd "${BUILD_FOLDER}/$ANDROID_SUB_BUILD_DIR/$1" || exit 1
 		cmake --build . --target game-client
 	)
 }
 
-mkdir "${_DEFAULT_BUILD_FOLDER}"
+mkdir -p "${BUILD_FOLDER}"
 
-if [[ "${_DEFAULT_ANDROID_BUILD}" == "arm" || "${_DEFAULT_ANDROID_BUILD}" == "all" ]]; then
+if [[ "${ANDROID_BUILD}" == "arm" || "${ANDROID_BUILD}" == "all" ]]; then
 	build_for_type arm armeabi-v7a armv7-linux-androideabi &
 	PID_BUILD_ARM=$!
 fi
 
-if [[ "${_DEFAULT_ANDROID_BUILD}" == "arm64" || "${_DEFAULT_ANDROID_BUILD}" == "all" ]]; then
+if [[ "${ANDROID_BUILD}" == "arm64" || "${ANDROID_BUILD}" == "all" ]]; then
 	build_for_type arm64 arm64-v8a aarch64-linux-android &
 	PID_BUILD_ARM64=$!
 fi
 
-if [[ "${_DEFAULT_ANDROID_BUILD}" == "x86" || "${_DEFAULT_ANDROID_BUILD}" == "all" ]]; then
+if [[ "${ANDROID_BUILD}" == "x86" || "${ANDROID_BUILD}" == "all" ]]; then
 	build_for_type x86 x86 i686-linux-android &
 	PID_BUILD_X86=$!
 fi
 
-if [[ "${_DEFAULT_ANDROID_BUILD}" == "x86_64" || "${_DEFAULT_ANDROID_BUILD}" == "x64" || "${_DEFAULT_ANDROID_BUILD}" == "all" ]]; then
+if [[ "${ANDROID_BUILD}" == "x86_64" || "${ANDROID_BUILD}" == "x64" || "${ANDROID_BUILD}" == "all" ]]; then
 	build_for_type x86_64 x86_64 x86_64-linux-android &
 	PID_BUILD_X86_64=$!
 fi
 
 if [ -n "$PID_BUILD_ARM" ] && ! wait "$PID_BUILD_ARM"; then
-	printf "\e[31m%s\e[30m\n" "Building for arm failed"
+	printf "${COLOR_RED}%s${COLOR_RESET}\n" "Building for arm failed"
 	exit 1
 fi
 if [ -n "$PID_BUILD_ARM64" ] && ! wait "$PID_BUILD_ARM64"; then
-	printf "\e[31m%s\e[30m\n" "Building for arm64 failed"
+	printf "${COLOR_RED}%s${COLOR_RESET}\n" "Building for arm64 failed"
 	exit 1
 fi
 if [ -n "$PID_BUILD_X86" ] && ! wait "$PID_BUILD_X86"; then
-	printf "\e[31m%s\e[30m\n" "Building for x86 failed"
+	printf "${COLOR_RED}%s${COLOR_RESET}\n" "Building for x86 failed"
 	exit 1
 fi
 if [ -n "$PID_BUILD_X86_64" ] && ! wait "$PID_BUILD_X86_64"; then
-	printf "\e[31m%s\e[30m\n" "Building for x86_64 failed"
+	printf "${COLOR_RED}%s${COLOR_RESET}\n" "Building for x86_64 failed"
 	exit 1
 fi
 
-printf "\e[36mPreparing gradle build\n"
+printf "${COLOR_CYAN}%s${COLOR_RESET}\n" "Copying project files..."
 
-cd "${_DEFAULT_BUILD_FOLDER}" || exit 1
+cd "${BUILD_FOLDER}" || exit 1
 
 mkdir -p src/main
 mkdir -p src/main/res/values
 mkdir -p src/main/res/mipmap
 
 function copy_dummy_files() {
-	rm ./"$2"
+	rm -f ./"$2"
 	cp ../"$1" "$2"
 }
 
@@ -211,39 +217,43 @@ copy_dummy_files scripts/android/files/res/values/strings.xml src/main/res/value
 copy_dummy_files other/icons/DDNet_256x256x32.png src/main/res/mipmap/ic_launcher.png
 copy_dummy_files other/icons/DDNet_256x256x32.png src/main/res/mipmap/ic_launcher_round.png
 
+printf "${COLOR_CYAN}%s${COLOR_RESET}\n" "Copying libraries..."
+
 function copy_libs() {
 	mkdir -p "lib/$2"
-	cp "$_ANDROID_SUB_BUILD_DIR/$1/libDDNet.so" "lib/$2" || exit 1
+	cp "$ANDROID_SUB_BUILD_DIR/$1/libDDNet.so" "lib/$2" || exit 1
 }
 
-if [[ "${_DEFAULT_ANDROID_BUILD}" == "arm" || "${_DEFAULT_ANDROID_BUILD}" == "all" ]]; then
+if [[ "${ANDROID_BUILD}" == "arm" || "${ANDROID_BUILD}" == "all" ]]; then
 	copy_libs arm armeabi-v7a
 fi
 
-if [[ "${_DEFAULT_ANDROID_BUILD}" == "arm64" || "${_DEFAULT_ANDROID_BUILD}" == "all" ]]; then
+if [[ "${ANDROID_BUILD}" == "arm64" || "${ANDROID_BUILD}" == "all" ]]; then
 	copy_libs arm64 arm64-v8a
 fi
 
-if [[ "${_DEFAULT_ANDROID_BUILD}" == "x86" || "${_DEFAULT_ANDROID_BUILD}" == "all" ]]; then
+if [[ "${ANDROID_BUILD}" == "x86" || "${ANDROID_BUILD}" == "all" ]]; then
 	copy_libs x86 x86
 fi
 
-if [[ "${_DEFAULT_ANDROID_BUILD}" == "x86_64" || "${_DEFAULT_ANDROID_BUILD}" == "x64" || "${_DEFAULT_ANDROID_BUILD}" == "all" ]]; then
+if [[ "${ANDROID_BUILD}" == "x86_64" || "${ANDROID_BUILD}" == "x64" || "${ANDROID_BUILD}" == "all" ]]; then
 	copy_libs x86_64 x86_64
 fi
 
-_DEFAULT_ANDROID_BUILD_DUMMY=$_DEFAULT_ANDROID_BUILD
-if [[ "${_DEFAULT_ANDROID_BUILD}" == "all" ]]; then
-	_DEFAULT_ANDROID_BUILD_DUMMY=arm
+ANDROID_BUILD_DUMMY=$ANDROID_BUILD
+if [[ "${ANDROID_BUILD}" == "all" ]]; then
+	ANDROID_BUILD_DUMMY=arm
 fi
 
+printf "${COLOR_CYAN}%s${COLOR_RESET}\n" "Copying data folder..."
 mkdir -p assets/asset_integrity_files
-cp -R "$_ANDROID_SUB_BUILD_DIR/$_DEFAULT_ANDROID_BUILD_DUMMY/data" ./assets/asset_integrity_files
+cp -R "$ANDROID_SUB_BUILD_DIR/$ANDROID_BUILD_DUMMY/data" ./assets/asset_integrity_files
 
-curl --remote-name --time-cond cacert.pem https://curl.se/ca/cacert.pem
-cp ./cacert.pem ./assets/asset_integrity_files/data/cacert.pem
+printf "${COLOR_CYAN}%s${COLOR_RESET}\n" "Downloading certificate..."
+curl -s -S --remote-name --time-cond cacert.pem https://curl.se/ca/cacert.pem
+cp ./cacert.pem ./assets/asset_integrity_files/data/cacert.pem || exit 1
 
-# create integrity file for extracting assets
+printf "${COLOR_CYAN}%s${COLOR_RESET}\n" "Creating integrity index file..."
 (
 	cd assets/asset_integrity_files || exit 1
 
@@ -256,23 +266,21 @@ cp ./cacert.pem ./assets/asset_integrity_files/data/cacert.pem
 
 	full_hash="$(sha256sum "$tmpfile" | cut -d' ' -f 1)"
 
-	rm "integrity.txt"
+	rm -f "integrity.txt"
 	{
 		echo "$full_hash"
 		cat "$tmpfile"
 	} > "integrity.txt"
 )
 
-printf "\e[0m"
+printf "${COLOR_CYAN}%s${COLOR_RESET}\n" "Preparing gradle build..."
 
-echo "Building..."
-
-rm -R src/main/java/org
+rm -R -f src/main/java/org
 mkdir -p src/main/java
 cp -R ../scripts/android/files/java/org src/main/java/
 cp -R ../ddnet-libs/sdl/java/org src/main/java/
 
 # shellcheck disable=SC1091
-source ./build.sh "$_DEFAULT_GAME_NAME" "$_DEFAULT_PACKAGE_NAME" "$_DEFAULT_BUILD_TYPE"
+source ./build.sh "$GAME_NAME" "$PACKAGE_NAME" "$BUILD_TYPE"
 
 cd ..

--- a/scripts/android/cmake_android.sh
+++ b/scripts/android/cmake_android.sh
@@ -151,21 +151,40 @@ mkdir "${_DEFAULT_BUILD_FOLDER}"
 
 if [[ "${_DEFAULT_ANDROID_BUILD}" == "arm" || "${_DEFAULT_ANDROID_BUILD}" == "all" ]]; then
 	build_for_type arm armeabi-v7a armv7-linux-androideabi &
+	PID_BUILD_ARM=$!
 fi
 
 if [[ "${_DEFAULT_ANDROID_BUILD}" == "arm64" || "${_DEFAULT_ANDROID_BUILD}" == "all" ]]; then
 	build_for_type arm64 arm64-v8a aarch64-linux-android &
+	PID_BUILD_ARM64=$!
 fi
 
 if [[ "${_DEFAULT_ANDROID_BUILD}" == "x86" || "${_DEFAULT_ANDROID_BUILD}" == "all" ]]; then
 	build_for_type x86 x86 i686-linux-android &
+	PID_BUILD_X86=$!
 fi
 
 if [[ "${_DEFAULT_ANDROID_BUILD}" == "x86_64" || "${_DEFAULT_ANDROID_BUILD}" == "x64" || "${_DEFAULT_ANDROID_BUILD}" == "all" ]]; then
 	build_for_type x86_64 x86_64 x86_64-linux-android &
+	PID_BUILD_X86_64=$!
 fi
 
-wait
+if [ -n "$PID_BUILD_ARM" ] && ! wait "$PID_BUILD_ARM"; then
+	printf "\e[31m%s\e[30m\n" "Building for arm failed"
+	exit 1
+fi
+if [ -n "$PID_BUILD_ARM64" ] && ! wait "$PID_BUILD_ARM64"; then
+	printf "\e[31m%s\e[30m\n" "Building for arm64 failed"
+	exit 1
+fi
+if [ -n "$PID_BUILD_X86" ] && ! wait "$PID_BUILD_X86"; then
+	printf "\e[31m%s\e[30m\n" "Building for x86 failed"
+	exit 1
+fi
+if [ -n "$PID_BUILD_X86_64" ] && ! wait "$PID_BUILD_X86_64"; then
+	printf "\e[31m%s\e[30m\n" "Building for x86_64 failed"
+	exit 1
+fi
 
 printf "\e[36mPreparing gradle build\n"
 

--- a/scripts/android/cmake_android.sh
+++ b/scripts/android/cmake_android.sh
@@ -198,9 +198,7 @@ copy_dummy_files other/icons/DDNet_256x256x32.png src/main/res/mipmap/ic_launche
 
 function copy_libs() {
 	mkdir -p "lib/$2"
-	cp "$_ANDROID_SUB_BUILD_DIR/$1/libDDNet.so" "lib/$2"
-	cp "$_ANDROID_SUB_BUILD_DIR/$1/libs/libSDL2.so" "lib/$2"
-	cp "$_ANDROID_SUB_BUILD_DIR/$1/libs/libhidapi.so" "lib/$2"
+	cp "$_ANDROID_SUB_BUILD_DIR/$1/libDDNet.so" "lib/$2" || exit 1
 }
 
 if [[ "${_DEFAULT_ANDROID_BUILD}" == "arm" || "${_DEFAULT_ANDROID_BUILD}" == "all" ]]; then

--- a/scripts/android/cmake_android.sh
+++ b/scripts/android/cmake_android.sh
@@ -172,16 +172,12 @@ printf "\e[36mPreparing gradle build\n"
 cd "${_DEFAULT_BUILD_FOLDER}" || exit 1
 
 mkdir -p src/main
+mkdir -p src/main/res/values
 mkdir -p src/main/res/mipmap
 
 function copy_dummy_files() {
 	rm ./"$2"
 	cp ../"$1" "$2"
-}
-
-function copy_dummy_files_rec() {
-	rm -R ./"$2"/"$1"
-	cp -R ../"$1" "$2"
 }
 
 copy_dummy_files scripts/android/files/build.sh build.sh
@@ -192,7 +188,7 @@ copy_dummy_files scripts/android/files/gradle.properties gradle.properties
 copy_dummy_files scripts/android/files/proguard-rules.pro proguard-rules.pro
 copy_dummy_files scripts/android/files/settings.gradle settings.gradle
 copy_dummy_files scripts/android/files/AndroidManifest.xml src/main/AndroidManifest.xml
-copy_dummy_files_rec scripts/android/files/res src/main
+copy_dummy_files scripts/android/files/res/values/strings.xml src/main/res/values/strings.xml
 copy_dummy_files other/icons/DDNet_256x256x32.png src/main/res/mipmap/ic_launcher.png
 copy_dummy_files other/icons/DDNet_256x256x32.png src/main/res/mipmap/ic_launcher_round.png
 

--- a/scripts/android/files/build.gradle
+++ b/scripts/android/files/build.gradle
@@ -1,17 +1,12 @@
 apply plugin: 'com.android.application'
 
-apply plugin: 'kotlin-android'
-
 buildscript {
-	ext.kotlin_version = '+'
 	repositories {
 		google()
 		mavenCentral()
 	}
-	
 	dependencies {
 		classpath 'com.android.tools.build:gradle:8.3.0'
-		classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 	}
 }
 
@@ -27,7 +22,7 @@ android {
 	defaultConfig {
 		applicationId "org.ddnet.client"
 		namespace("org.ddnet.client")
-		minSdkVersion 24
+		minSdkVersion 19
 		targetSdkVersion 34
 		versionCode TW_VERSION_CODE
 		versionName "TW_VERSION_NAME"
@@ -61,10 +56,8 @@ android {
 		main {
 			assets.srcDirs = ['assets']
 			jniLibs.srcDirs = ['lib']
-			//TW_ENABLE_RESOURCESresources.srcDirs = ['resources']
 		}
 	}
-
 	lintOptions {
 		abortOnError false
 	}
@@ -80,11 +73,4 @@ allprojects {
 			options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation"
 		}
 	}
-}
-
-dependencies {
-	implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-	implementation 'androidx.appcompat:appcompat:1.1.0'
-	implementation 'androidx.core:core-ktx:1.3.0'
-	implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
 }

--- a/scripts/android/files/build.sh
+++ b/scripts/android/files/build.sh
@@ -1,38 +1,41 @@
 #!/bin/bash
 
-[ "$1" == "" ] && {
-	printf '\e[31mDid not pass APK name to build script\e[30m\n'
-	exit 1
-}
+COLOR_RED="\e[1;31m"
+COLOR_RESET="\e[0m"
 
-[ "$2" == "" ] && {
-	printf '\e[31mDid not pass package name to build script\e[30m\n'
-	exit 1
-}
-
-[ "$3" == "" ] && {
-	printf '\e[31mDid not pass build type to build script\e[30m\n'
-	exit 1
-}
-
-_APK_BASENAME="$1"
-_APK_PACKAGE_NAME="$2"
-_APK_BUILD_TYPE="$3"
-
-if [[ "${_APK_BUILD_TYPE}" == "Debug" ]]; then
-	_RELEASE_TYPE_NAME=debug
-elif [[ "${_APK_BUILD_TYPE}" == "Release" ]]; then
-	_RELEASE_TYPE_NAME=release
-else
-	printf '\e[31mDid not pass build type to build script: Debug, Release\e[30m\n'
+if [ -z ${1+x} ]; then
+	printf "${COLOR_RED}%s${COLOR_RESET}\n" "Did not pass APK name to build script"
 	exit 1
 fi
 
-_APK_PACKAGE_FOLDER=$(echo "$_APK_PACKAGE_NAME" | sed 's/\./\//g')
+if [ -z ${2+x} ]; then
+	printf "${COLOR_RED}%s${COLOR_RESET}\n" "Did not pass package name to build script"
+	exit 1
+fi
 
-sed -i "s/DDNet/${_APK_BASENAME}/g" settings.gradle
+if [ -z ${3+x} ]; then
+	printf "${COLOR_RED}%s${COLOR_RESET}\n" "Did not pass build type to build script: Debug, Release"
+	exit 1
+fi
 
-sed -i "s/org.ddnet.client/${_APK_PACKAGE_NAME}/g" build.gradle
+APK_BASENAME="$1"
+APK_PACKAGE_NAME="$2"
+APK_BUILD_TYPE="$3"
+
+if [[ "${APK_BUILD_TYPE}" == "Debug" ]]; then
+	RELEASE_TYPE_NAME=debug
+elif [[ "${APK_BUILD_TYPE}" == "Release" ]]; then
+	RELEASE_TYPE_NAME=release
+else
+	printf "${COLOR_RED}%s${COLOR_RESET}\n" "Did not pass build type to build script: Debug, Release"
+	exit 1
+fi
+
+APK_PACKAGE_FOLDER=$(echo "$APK_PACKAGE_NAME" | sed 's/\./\//g')
+
+sed -i "s/DDNet/${APK_BASENAME}/g" settings.gradle
+
+sed -i "s/org.ddnet.client/${APK_PACKAGE_NAME}/g" build.gradle
 
 TW_KEY_NAME_ESCAPED=$(echo "$TW_KEY_NAME" | sed 's/\//\\\//g')
 TW_KEY_PW_ESCAPED=$(echo "$TW_KEY_PW" | sed 's/\//\\\//g')
@@ -46,20 +49,22 @@ sed -i "s/TW_NDK_VERSION/${ANDROID_NDK_VERSION}/g" build.gradle
 sed -i "s/TW_VERSION_CODE/${TW_VERSION_CODE}/g" build.gradle
 sed -i "s/TW_VERSION_NAME/${TW_VERSION_NAME}/g" build.gradle
 
-sed -i "s/DDNet/${_APK_BASENAME}/g" src/main/res/values/strings.xml
+sed -i "s/DDNet/${APK_BASENAME}/g" src/main/res/values/strings.xml
 
-sed -i "s/\"DDNet\"/\"${_APK_BASENAME}\"/g" src/main/AndroidManifest.xml
-sed -i "s/org.ddnet.client/${_APK_PACKAGE_NAME}/g" src/main/AndroidManifest.xml
+sed -i "s/\"DDNet\"/\"${APK_BASENAME}\"/g" src/main/AndroidManifest.xml
+sed -i "s/org.ddnet.client/${APK_PACKAGE_NAME}/g" src/main/AndroidManifest.xml
 
-mv src/main/java/org/ddnet/client src/main/java/"${_APK_PACKAGE_FOLDER}"
+if [ "${APK_PACKAGE_FOLDER}" != "org/ddnet/client" ]; then
+	mv src/main/java/org/ddnet/client src/main/java/"${APK_PACKAGE_FOLDER}"
+fi
 
-sed -i "s/org.ddnet.client/${_APK_PACKAGE_NAME}/g" src/main/java/"${_APK_PACKAGE_FOLDER}"/NativeMain.java
-sed -i "s/org.ddnet.client/${_APK_PACKAGE_NAME}/g" proguard-rules.pro
+sed -i "s/org.ddnet.client/${APK_PACKAGE_NAME}/g" src/main/java/"${APK_PACKAGE_FOLDER}"/NativeMain.java
+sed -i "s/org.ddnet.client/${APK_PACKAGE_NAME}/g" proguard-rules.pro
 
 # disable hid manager for now
 sed -i "s/mHIDDeviceManager = HIDDeviceManager.acquire(this);/mHIDDeviceManager=null;/g" src/main/java/org/libsdl/app/SDLActivity.java
 
-if [[ "${_APK_BUILD_TYPE}" == "Debug" ]]; then
+if [[ "${APK_BUILD_TYPE}" == "Debug" ]]; then
 	sed -i "s/android.enableR8.fullMode=true/android.enableR8.fullMode=false/g" gradle.properties
 fi
 
@@ -67,16 +72,16 @@ function build_gradle() {
 	java "-Dorg.gradle.appname=Gradle" -classpath gradle-wrapper.jar org.gradle.wrapper.GradleWrapperMain --warning-mode all "$1"
 }
 
-if [[ "${_APK_BUILD_TYPE}" == "Debug" ]]; then
+if [[ "${APK_BUILD_TYPE}" == "Debug" ]]; then
 	build_gradle builddebug
 	build_gradle assembleDebug
 else
 	build_gradle buildrelease
 	build_gradle assembleRelease
 fi
-cp build/outputs/apk/"$_RELEASE_TYPE_NAME"/"$_APK_BASENAME"-"$_RELEASE_TYPE_NAME".apk "$_APK_BASENAME".apk
+cp build/outputs/apk/"$RELEASE_TYPE_NAME"/"$APK_BASENAME"-"$RELEASE_TYPE_NAME".apk "$APK_BASENAME".apk
 
-if [[ "${_APK_BUILD_TYPE}" == "Release" ]]; then
+if [[ "${APK_BUILD_TYPE}" == "Release" ]]; then
 	build_gradle bundleRelease
-	cp build/outputs/bundle/"$_RELEASE_TYPE_NAME"/"$_APK_BASENAME"-"$_RELEASE_TYPE_NAME".aab "$_APK_BASENAME".aab
+	cp build/outputs/bundle/"$RELEASE_TYPE_NAME"/"$APK_BASENAME"-"$RELEASE_TYPE_NAME".aab "$APK_BASENAME".aab
 fi

--- a/scripts/android/files/build.sh
+++ b/scripts/android/files/build.sh
@@ -63,19 +63,20 @@ if [[ "${_APK_BUILD_TYPE}" == "Release" ]]; then
 	_RELEASE_TYPE_NAME=release
 fi
 
-APP_BASE_NAME=Gradle
-CLASSPATH=gradle-wrapper.jar
-java "-Dorg.gradle.appname=${APP_BASE_NAME}" -classpath "${CLASSPATH}" org.gradle.wrapper.GradleWrapperMain --warning-mode all
+function build_gradle() {
+	java "-Dorg.gradle.appname=Gradle" -classpath gradle-wrapper.jar org.gradle.wrapper.GradleWrapperMain --warning-mode all "$1"
+}
+
 if [[ "${_APK_BUILD_TYPE}" == "Debug" ]]; then
-	java "-Dorg.gradle.appname=${APP_BASE_NAME}" -classpath "${CLASSPATH}" org.gradle.wrapper.GradleWrapperMain --warning-mode all builddebug
-	java "-Dorg.gradle.appname=${APP_BASE_NAME}" -classpath "${CLASSPATH}" org.gradle.wrapper.GradleWrapperMain --warning-mode all assembleDebug
+	build_gradle builddebug
+	build_gradle assembleDebug
 else
-	java "-Dorg.gradle.appname=${APP_BASE_NAME}" -classpath "${CLASSPATH}" org.gradle.wrapper.GradleWrapperMain --warning-mode all buildrelease
-	java "-Dorg.gradle.appname=${APP_BASE_NAME}" -classpath "${CLASSPATH}" org.gradle.wrapper.GradleWrapperMain --warning-mode all assembleRelease
+	build_gradle buildrelease
+	build_gradle assembleRelease
 fi
 cp build/outputs/apk/"$_RELEASE_TYPE_NAME"/"$_APK_BASENAME"-"$_RELEASE_TYPE_NAME".apk "$_APK_BASENAME".apk
 
 if [[ "${_APK_BUILD_TYPE}" == "Release" ]]; then
-	java "-Dorg.gradle.appname=${APP_BASE_NAME}" -classpath "${CLASSPATH}" org.gradle.wrapper.GradleWrapperMain --warning-mode all bundleRelease
+	build_gradle bundleRelease
 	cp build/outputs/bundle/"$_RELEASE_TYPE_NAME"/"$_APK_BASENAME"-"$_RELEASE_TYPE_NAME".aab "$_APK_BASENAME".aab
 fi

--- a/scripts/android/files/build.sh
+++ b/scripts/android/files/build.sh
@@ -54,33 +54,30 @@ if [[ "${_APK_BUILD_TYPE}" == "Debug" ]]; then
 	sed -i "s/android.enableR8.fullMode=true/android.enableR8.fullMode=false/g" gradle.properties
 fi
 
-if [[ -z ${GE_NO_APK_BUILD} || "${GE_NO_APK_BUILD}" != "1" ]]; then
+_RELEASE_TYPE_NAME=debug
+_RELEASE_TYPE_APK_NAME=
+if [[ "${_APK_BUILD_TYPE}" == "Debug" ]]; then
 	_RELEASE_TYPE_NAME=debug
+fi
+
+if [[ "${_APK_BUILD_TYPE}" == "Release" ]]; then
+	_RELEASE_TYPE_NAME=release
 	_RELEASE_TYPE_APK_NAME=
-	if [[ "${_APK_BUILD_TYPE}" == "Debug" ]]; then
-		_RELEASE_TYPE_NAME=debug
-	fi
+fi
 
-	if [[ "${_APK_BUILD_TYPE}" == "Release" ]]; then
-		_RELEASE_TYPE_NAME=release
-		_RELEASE_TYPE_APK_NAME=
-	fi
+APP_BASE_NAME=Gradle
+CLASSPATH=gradle-wrapper.jar
+java "-Dorg.gradle.appname=${APP_BASE_NAME}" -classpath "${CLASSPATH}" org.gradle.wrapper.GradleWrapperMain --warning-mode all
+if [[ "${_APK_BUILD_TYPE}" == "Debug" ]]; then
+	java "-Dorg.gradle.appname=${APP_BASE_NAME}" -classpath "${CLASSPATH}" org.gradle.wrapper.GradleWrapperMain --warning-mode all builddebug
+	java "-Dorg.gradle.appname=${APP_BASE_NAME}" -classpath "${CLASSPATH}" org.gradle.wrapper.GradleWrapperMain --warning-mode all assembleDebug
+else
+	java "-Dorg.gradle.appname=${APP_BASE_NAME}" -classpath "${CLASSPATH}" org.gradle.wrapper.GradleWrapperMain --warning-mode all buildrelease
+	java "-Dorg.gradle.appname=${APP_BASE_NAME}" -classpath "${CLASSPATH}" org.gradle.wrapper.GradleWrapperMain --warning-mode all assembleRelease
+fi
+cp build/outputs/apk/"$_RELEASE_TYPE_NAME"/"$_APK_BASENAME"-"$_RELEASE_TYPE_NAME""$_RELEASE_TYPE_APK_NAME".apk "$_APK_BASENAME".apk
 
-	APP_BASE_NAME=Gradle
-	CLASSPATH=gradle-wrapper.jar
-	java "-Dorg.gradle.appname=${APP_BASE_NAME}" -classpath "${CLASSPATH}" org.gradle.wrapper.GradleWrapperMain --warning-mode all
-	if [[ "${_APK_BUILD_TYPE}" == "Debug" ]]; then
-		java "-Dorg.gradle.appname=${APP_BASE_NAME}" -classpath "${CLASSPATH}" org.gradle.wrapper.GradleWrapperMain --warning-mode all builddebug
-		java "-Dorg.gradle.appname=${APP_BASE_NAME}" -classpath "${CLASSPATH}" org.gradle.wrapper.GradleWrapperMain --warning-mode all assembleDebug
-	else
-		java "-Dorg.gradle.appname=${APP_BASE_NAME}" -classpath "${CLASSPATH}" org.gradle.wrapper.GradleWrapperMain --warning-mode all buildrelease
-		java "-Dorg.gradle.appname=${APP_BASE_NAME}" -classpath "${CLASSPATH}" org.gradle.wrapper.GradleWrapperMain --warning-mode all assembleRelease
-	fi
-	cp build/outputs/apk/"$_RELEASE_TYPE_NAME"/"$_APK_BASENAME"-"$_RELEASE_TYPE_NAME""$_RELEASE_TYPE_APK_NAME".apk "$_APK_BASENAME".apk
-
-	if [[ "${_APK_BUILD_TYPE}" == "Release" ]]; then
-		java "-Dorg.gradle.appname=${APP_BASE_NAME}" -classpath "${CLASSPATH}" org.gradle.wrapper.GradleWrapperMain --warning-mode all bundleRelease
-
-		cp build/outputs/bundle/"$_RELEASE_TYPE_NAME"/"$_APK_BASENAME"-"$_RELEASE_TYPE_NAME""$_RELEASE_TYPE_APK_NAME".aab "$_APK_BASENAME".aab
-	fi
+if [[ "${_APK_BUILD_TYPE}" == "Release" ]]; then
+	java "-Dorg.gradle.appname=${APP_BASE_NAME}" -classpath "${CLASSPATH}" org.gradle.wrapper.GradleWrapperMain --warning-mode all bundleRelease
+	cp build/outputs/bundle/"$_RELEASE_TYPE_NAME"/"$_APK_BASENAME"-"$_RELEASE_TYPE_NAME""$_RELEASE_TYPE_APK_NAME".aab "$_APK_BASENAME".aab
 fi

--- a/scripts/android/files/build.sh
+++ b/scripts/android/files/build.sh
@@ -19,6 +19,15 @@ _APK_BASENAME="$1"
 _APK_PACKAGE_NAME="$2"
 _APK_BUILD_TYPE="$3"
 
+if [[ "${_APK_BUILD_TYPE}" == "Debug" ]]; then
+	_RELEASE_TYPE_NAME=debug
+elif [[ "${_APK_BUILD_TYPE}" == "Release" ]]; then
+	_RELEASE_TYPE_NAME=release
+else
+	printf '\e[31mDid not pass build type to build script: Debug, Release\e[30m\n'
+	exit 1
+fi
+
 _APK_PACKAGE_FOLDER=$(echo "$_APK_PACKAGE_NAME" | sed 's/\./\//g')
 
 sed -i "s/DDNet/${_APK_BASENAME}/g" settings.gradle
@@ -52,15 +61,6 @@ sed -i "s/mHIDDeviceManager = HIDDeviceManager.acquire(this);/mHIDDeviceManager=
 
 if [[ "${_APK_BUILD_TYPE}" == "Debug" ]]; then
 	sed -i "s/android.enableR8.fullMode=true/android.enableR8.fullMode=false/g" gradle.properties
-fi
-
-_RELEASE_TYPE_NAME=debug
-if [[ "${_APK_BUILD_TYPE}" == "Debug" ]]; then
-	_RELEASE_TYPE_NAME=debug
-fi
-
-if [[ "${_APK_BUILD_TYPE}" == "Release" ]]; then
-	_RELEASE_TYPE_NAME=release
 fi
 
 function build_gradle() {

--- a/scripts/android/files/build.sh
+++ b/scripts/android/files/build.sh
@@ -55,14 +55,12 @@ if [[ "${_APK_BUILD_TYPE}" == "Debug" ]]; then
 fi
 
 _RELEASE_TYPE_NAME=debug
-_RELEASE_TYPE_APK_NAME=
 if [[ "${_APK_BUILD_TYPE}" == "Debug" ]]; then
 	_RELEASE_TYPE_NAME=debug
 fi
 
 if [[ "${_APK_BUILD_TYPE}" == "Release" ]]; then
 	_RELEASE_TYPE_NAME=release
-	_RELEASE_TYPE_APK_NAME=
 fi
 
 APP_BASE_NAME=Gradle
@@ -75,9 +73,9 @@ else
 	java "-Dorg.gradle.appname=${APP_BASE_NAME}" -classpath "${CLASSPATH}" org.gradle.wrapper.GradleWrapperMain --warning-mode all buildrelease
 	java "-Dorg.gradle.appname=${APP_BASE_NAME}" -classpath "${CLASSPATH}" org.gradle.wrapper.GradleWrapperMain --warning-mode all assembleRelease
 fi
-cp build/outputs/apk/"$_RELEASE_TYPE_NAME"/"$_APK_BASENAME"-"$_RELEASE_TYPE_NAME""$_RELEASE_TYPE_APK_NAME".apk "$_APK_BASENAME".apk
+cp build/outputs/apk/"$_RELEASE_TYPE_NAME"/"$_APK_BASENAME"-"$_RELEASE_TYPE_NAME".apk "$_APK_BASENAME".apk
 
 if [[ "${_APK_BUILD_TYPE}" == "Release" ]]; then
 	java "-Dorg.gradle.appname=${APP_BASE_NAME}" -classpath "${CLASSPATH}" org.gradle.wrapper.GradleWrapperMain --warning-mode all bundleRelease
-	cp build/outputs/bundle/"$_RELEASE_TYPE_NAME"/"$_APK_BASENAME"-"$_RELEASE_TYPE_NAME""$_RELEASE_TYPE_APK_NAME".aab "$_APK_BASENAME".aab
+	cp build/outputs/bundle/"$_RELEASE_TYPE_NAME"/"$_APK_BASENAME"-"$_RELEASE_TYPE_NAME".aab "$_APK_BASENAME".aab
 fi

--- a/scripts/android/files/java/org/ddnet/client/NativeMain.java
+++ b/scripts/android/files/java/org/ddnet/client/NativeMain.java
@@ -6,16 +6,10 @@ import android.os.Bundle;
 import android.content.pm.ActivityInfo;
 
 public class NativeMain extends SDLActivity {
-	static {
-		System.loadLibrary("DDNet");
-	}
 
 	@Override
 	protected String[] getLibraries() {
 		return new String[] {
-			// disable hid API for now
-			// "hidapi",
-			// "SDL2",
 			"DDNet",
 		};
 	}

--- a/scripts/android/files/proguard-rules.pro
+++ b/scripts/android/files/proguard-rules.pro
@@ -14,7 +14,7 @@
 
 # Uncomment this to preserve the line number information for
 # debugging stack traces.
-#-keepattributes SourceFile,LineNumberTable
+-keepattributes SourceFile,LineNumberTable
 
 -keepclassmembers, allowoptimization public class org.ddnet.client.NativeMain {
 	*;

--- a/scripts/compile_libs/cmake_lib_compile.sh
+++ b/scripts/compile_libs/cmake_lib_compile.sh
@@ -15,73 +15,73 @@ fi
 COMPILEFLAGS=$3
 LINKFLAGS=$4
 
-function compile_source() {
-	if [[ "${4}" == "android" ]]; then
-		cmake \
-			-H. \
-			-G "Unix Makefiles" \
-			-DCMAKE_BUILD_TYPE=Release \
-			-DANDROID_PLATFORM="android-$1" \
-			-DCMAKE_TOOLCHAIN_FILE="$ANDROID_NDK_HOME/build/cmake/android.toolchain.cmake" \
-			-DANDROID_NDK="$ANDROID_NDK_HOME" \
-			-DANDROID_ABI="${3}" \
-			-DANDROID_ARM_NEON=TRUE \
-			-DCMAKE_ANDROID_NDK="$ANDROID_NDK_HOME" \
-			-DCMAKE_SYSTEM_NAME=Android \
-			-DCMAKE_SYSTEM_VERSION="$1" \
-			-DCMAKE_ANDROID_ARCH_ABI="${3}" \
-			-B"$2" \
-			-DBUILD_SHARED_LIBS=OFF \
-			-DHIDAPI_SKIP_LIBUSB=TRUE \
-			-DCURL_USE_OPENSSL=ON \
-			-DSDL_HIDAPI=OFF \
-			-DOP_DISABLE_HTTP=ON \
-			-DOP_DISABLE_EXAMPLES=ON \
-			-DOP_DISABLE_DOCS=ON \
-			-DOPENSSL_ROOT_DIR="$PWD"/../openssl/"$2" \
-			-DOPENSSL_CRYPTO_LIBRARY="$PWD"/../openssl/"$2"/libcrypto.a \
-			-DOPENSSL_SSL_LIBRARY="$PWD"/../openssl/"$2"/libssl.a \
-			-DOPENSSL_INCLUDE_DIR="${PWD}/../openssl/include;${PWD}/../openssl/${2}/include"
-		(
-			cd "$2" || exit 1
-			cmake --build .
-		)
-	else
-		${5} cmake \
-			-H. \
-			-DCMAKE_BUILD_TYPE=Release \
-			-B"$2" \
-			-DSDL_STATIC=TRUE \
-			-DFT_DISABLE_HARFBUZZ=ON \
-			-DFT_DISABLE_BZIP2=ON \
-			-DFT_DISABLE_BROTLI=ON \
-			-DFT_REQUIRE_ZLIB=TRUE \
-			-DCMAKE_C_FLAGS="$COMPILEFLAGS -DGLEW_STATIC" -DCMAKE_CXX_FLAGS="$COMPILEFLAGS" -DCMAKE_CXX_FLAGS_RELEASE="$COMPILEFLAGS" -DCMAKE_C_FLAGS_RELEASE="$COMPILEFLAGS" \
-			-DCMAKE_SHARED_LINKER_FLAGS="$LINKFLAGS" -DCMAKE_SHARED_LINKER_FLAGS_RELEASE="$LINKFLAGS" \
-			-DSDL_PTHREADS=ON -DSDL_THREADS=ON \
-			-DCURL_USE_OPENSSL=ON \
-			-DOPUS_HARDENING=OFF \
-			-DOPUS_STACK_PROTECTOR=OFF \
-			-DOPENSSL_ROOT_DIR="$PWD"/../openssl/"$2" \
-			-DOPENSSL_CRYPTO_LIBRARY="$PWD"/../openssl/"$2"/libcrypto.a \
-			-DOPENSSL_SSL_LIBRARY="$PWD"/../openssl/"$2"/libssl.a \
-			-DOPENSSL_INCLUDE_DIR="${PWD}/../openssl/include;${PWD}/../openssl/${2}/include" \
-			-DZLIB_LIBRARY="${PWD}/../zlib/${2}/libz.a" -DZLIB_INCLUDE_DIR="${PWD}/../zlib;${PWD}/../zlib/${2}"
-		(
-			cd "$2" || exit 1
-			cmake --build .
-		)
-	fi
+function compile_source_android() {
+	cmake \
+		-H. \
+		-G "Unix Makefiles" \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DANDROID_PLATFORM="android-$1" \
+		-DCMAKE_TOOLCHAIN_FILE="$ANDROID_NDK_HOME/build/cmake/android.toolchain.cmake" \
+		-DANDROID_NDK="$ANDROID_NDK_HOME" \
+		-DANDROID_ABI="${3}" \
+		-DANDROID_ARM_NEON=TRUE \
+		-DCMAKE_ANDROID_NDK="$ANDROID_NDK_HOME" \
+		-DCMAKE_SYSTEM_NAME=Android \
+		-DCMAKE_SYSTEM_VERSION="$1" \
+		-DCMAKE_ANDROID_ARCH_ABI="${3}" \
+		-B"$2" \
+		-DBUILD_SHARED_LIBS=OFF \
+		-DHIDAPI_SKIP_LIBUSB=TRUE \
+		-DCURL_USE_OPENSSL=ON \
+		-DSDL_HIDAPI=OFF \
+		-DOP_DISABLE_HTTP=ON \
+		-DOP_DISABLE_EXAMPLES=ON \
+		-DOP_DISABLE_DOCS=ON \
+		-DOPENSSL_ROOT_DIR="$PWD"/../openssl/"$2" \
+		-DOPENSSL_CRYPTO_LIBRARY="$PWD"/../openssl/"$2"/libcrypto.a \
+		-DOPENSSL_SSL_LIBRARY="$PWD"/../openssl/"$2"/libssl.a \
+		-DOPENSSL_INCLUDE_DIR="${PWD}/../openssl/include;${PWD}/../openssl/${2}/include"
+	(
+		cd "$2" || exit 1
+		cmake --build .
+	)
+}
+
+function compile_source_webasm() {
+	emcmake cmake \
+		-H. \
+		-DCMAKE_BUILD_TYPE=Release \
+		-B"$2" \
+		-DSDL_STATIC=TRUE \
+		-DFT_DISABLE_HARFBUZZ=ON \
+		-DFT_DISABLE_BZIP2=ON \
+		-DFT_DISABLE_BROTLI=ON \
+		-DFT_REQUIRE_ZLIB=TRUE \
+		-DCMAKE_C_FLAGS="$COMPILEFLAGS -DGLEW_STATIC" -DCMAKE_CXX_FLAGS="$COMPILEFLAGS" -DCMAKE_CXX_FLAGS_RELEASE="$COMPILEFLAGS" -DCMAKE_C_FLAGS_RELEASE="$COMPILEFLAGS" \
+		-DCMAKE_SHARED_LINKER_FLAGS="$LINKFLAGS" -DCMAKE_SHARED_LINKER_FLAGS_RELEASE="$LINKFLAGS" \
+		-DSDL_PTHREADS=ON -DSDL_THREADS=ON \
+		-DCURL_USE_OPENSSL=ON \
+		-DOPUS_HARDENING=OFF \
+		-DOPUS_STACK_PROTECTOR=OFF \
+		-DOPENSSL_ROOT_DIR="$PWD"/../openssl/"$2" \
+		-DOPENSSL_CRYPTO_LIBRARY="$PWD"/../openssl/"$2"/libcrypto.a \
+		-DOPENSSL_SSL_LIBRARY="$PWD"/../openssl/"$2"/libssl.a \
+		-DOPENSSL_INCLUDE_DIR="${PWD}/../openssl/include;${PWD}/../openssl/${2}/include" \
+		-DZLIB_LIBRARY="${PWD}/../zlib/${2}/libz.a" -DZLIB_INCLUDE_DIR="${PWD}/../zlib;${PWD}/../zlib/${2}"
+	(
+		cd "$2" || exit 1
+		cmake --build .
+	)
 }
 
 if [[ "${2}" == "android" ]]; then
-	compile_source "$1" build_"$2"_arm armeabi-v7a "$2" "" &
-	compile_source "$1" build_"$2"_arm64 arm64-v8a "$2" "" &
-	compile_source "$1" build_"$2"_x86 x86 "$2" "" &
-	compile_source "$1" build_"$2"_x86_64 x86_64 "$2" "" &
+	compile_source_android "$1" build_android_arm armeabi-v7a &
+	compile_source_android "$1" build_android_arm64 arm64-v8a &
+	compile_source_android "$1" build_android_x86 x86 &
+	compile_source_android "$1" build_android_x86_64 x86_64 &
 elif [[ "${2}" == "webasm" ]]; then
 	sed -i "s/include(CheckSizes)//g" CMakeLists.txt
-	compile_source "$1" build_"$2"_wasm wasm "$2" emcmake &
+	compile_source_webasm "$1" build_webasm_wasm wasm &
 fi
 
 wait

--- a/scripts/compile_libs/gen_libs.sh
+++ b/scripts/compile_libs/gen_libs.sh
@@ -75,16 +75,11 @@ cd compile_libs || exit 1
 
 # start with openssl
 (
-	_WAS_THERE_SSLFILE=1
 	if [ ! -d "openssl" ]; then
 		git clone https://github.com/openssl/openssl openssl
-		_WAS_THERE_SSLFILE=0
 	fi
 	(
 		cd openssl || exit 1
-		if [[ "$_WAS_THERE_SSLFILE" == 0 ]]; then
-			./autogen.sh
-		fi
 		cp "${CURDIR}"/scripts/compile_libs/make_lib_openssl.sh make_lib_openssl.sh
 		./make_lib_openssl.sh "$_ANDROID_ABI_LEVEL" "$OS_NAME" "$COMPILEFLAGS" "$LINKFLAGS"
 	)

--- a/scripts/compile_libs/gen_libs.sh
+++ b/scripts/compile_libs/gen_libs.sh
@@ -113,6 +113,7 @@ fi
 )
 
 cd ..
+mkdir -p ddnet-libs
 
 function copy_arches_for_lib() {
 	if [[ "$COMP_HAS_ARM32" == "1" ]]; then
@@ -132,23 +133,18 @@ function copy_arches_for_lib() {
 	fi
 }
 
-mkdir ddnet-libs
 function _copy_curl() {
 	mkdir -p ddnet-libs/curl/"$OS_NAME"/lib"$2"
 	cp compile_libs/curl/build_"$OS_NAME"_"$1"/lib/libcurl.a ddnet-libs/curl/"$OS_NAME"/lib"$2"/libcurl.a
 }
-
 copy_arches_for_lib _copy_curl
 
-mkdir ddnet-libs
 function _copy_freetype2() {
 	mkdir -p ddnet-libs/freetype/"$OS_NAME"/lib"$2"
 	cp compile_libs/freetype2/build_"$OS_NAME"_"$1"/libfreetype.a ddnet-libs/freetype/"$OS_NAME"/lib"$2"/libfreetype.a
 }
-
 copy_arches_for_lib _copy_freetype2
 
-mkdir ddnet-libs
 function _copy_sdl() {
 	mkdir -p ddnet-libs/sdl/"$OS_NAME"/lib"$2"
 	cp compile_libs/sdl/build_"$OS_NAME"_"$1"/libSDL2.a ddnet-libs/sdl/"$OS_NAME"/lib"$2"/libSDL2.a
@@ -156,7 +152,6 @@ function _copy_sdl() {
 	mkdir -p ddnet-libs/sdl/include/"$OS_NAME"
 	cp -R compile_libs/sdl/include/* ddnet-libs/sdl/include/"$OS_NAME"
 }
-
 copy_arches_for_lib _copy_sdl
 
 # copy java code from SDL2
@@ -166,39 +161,30 @@ if [[ "$OS_NAME" == "android" ]]; then
 	cp -R compile_libs/sdl/android-project/app/src/main/java/org ddnet-libs/sdl/java/
 fi
 
-mkdir ddnet-libs
 function _copy_ogg() {
 	mkdir -p ddnet-libs/opus/"$OS_NAME"/lib"$2"
 	cp compile_libs/ogg/build_"$OS_NAME"_"$1"/libogg.a ddnet-libs/opus/"$OS_NAME"/lib"$2"/libogg.a
 }
-
 copy_arches_for_lib _copy_ogg
 
-mkdir ddnet-libs
 function _copy_opus() {
 	mkdir -p ddnet-libs/opus/"$OS_NAME"/lib"$2"
 	cp compile_libs/opus/build_"$OS_NAME"_"$1"/libopus.a ddnet-libs/opus/"$OS_NAME"/lib"$2"/libopus.a
 }
-
 copy_arches_for_lib _copy_opus
 
-mkdir ddnet-libs
 function _copy_opusfile() {
 	mkdir -p ddnet-libs/opus/"$OS_NAME"/lib"$2"
 	cp compile_libs/opusfile/build_"$OS_NAME"_"$1"/libopusfile.a ddnet-libs/opus/"$OS_NAME"/lib"$2"/libopusfile.a
 }
-
 copy_arches_for_lib _copy_opusfile
 
-mkdir ddnet-libs
 function _copy_sqlite3() {
 	mkdir -p ddnet-libs/sqlite3/"$OS_NAME"/lib"$2"
 	cp compile_libs/sqlite3/build_"$OS_NAME"_"$1"/sqlite3.a ddnet-libs/sqlite3/"$OS_NAME"/lib"$2"/libsqlite3.a
 }
-
 copy_arches_for_lib _copy_sqlite3
 
-mkdir ddnet-libs
 function _copy_openssl() {
 	mkdir -p ddnet-libs/openssl/"$OS_NAME"/lib"$2"
 	mkdir -p ddnet-libs/openssl/include
@@ -208,10 +194,8 @@ function _copy_openssl() {
 	cp -R compile_libs/openssl/build_"$OS_NAME"_"$1"/include/* ddnet-libs/openssl/include/"$OS_NAME"
 	cp -R compile_libs/openssl/include/* ddnet-libs/openssl/include
 }
-
 copy_arches_for_lib _copy_openssl
 
-mkdir ddnet-libs
 function _copy_zlib() {
 	# copy headers
 	(
@@ -231,13 +215,10 @@ function _copy_zlib() {
 	mkdir -p ddnet-libs/zlib/"$OS_NAME"/lib"$2"
 	cp compile_libs/zlib/build_"$OS_NAME"_"$1"/libz.a ddnet-libs/zlib/"$OS_NAME"/lib"$2"/libz.a
 }
-
 copy_arches_for_lib _copy_zlib
 
-mkdir ddnet-libs
 function _copy_png() {
 	mkdir -p ddnet-libs/png/"$OS_NAME"/lib"$2"
 	cp compile_libs/png/build_"$OS_NAME"_"$1"/libpng16.a ddnet-libs/png/"$OS_NAME"/lib"$2"/libpng16.a
 }
-
 copy_arches_for_lib _copy_png

--- a/scripts/compile_libs/gen_libs.sh
+++ b/scripts/compile_libs/gen_libs.sh
@@ -20,16 +20,6 @@ if [[ "${OS_NAME}" == "webasm" ]]; then
 	LINKFLAGS="-pthread -O3 -g -s USE_PTHREADS=1 -s ASYNCIFY=1 -s WASM=1"
 fi
 
-if [[ "${OS_NAME}" == "android" ]]; then
-	OS_NAME_PATH="android"
-elif [[ "${OS_NAME}" == "windows" ]]; then
-	OS_NAME_PATH="windows"
-elif [[ "${OS_NAME}" == "linux" ]]; then
-	OS_NAME_PATH="linux"
-elif [[ "${OS_NAME}" == "webasm" ]]; then
-	OS_NAME_PATH="webasm"
-fi
-
 COMP_HAS_ARM32=0
 COMP_HAS_ARM64=0
 COMP_HAS_x86=0
@@ -141,29 +131,29 @@ function copy_arches_for_lib() {
 
 mkdir ddnet-libs
 function _copy_curl() {
-	mkdir -p ddnet-libs/curl/"$OS_NAME_PATH"/lib"$2"
-	cp compile_libs/curl/build_"$OS_NAME"_"$1"/lib/libcurl.a ddnet-libs/curl/"$OS_NAME_PATH"/lib"$2"/libcurl.a
+	mkdir -p ddnet-libs/curl/"$OS_NAME"/lib"$2"
+	cp compile_libs/curl/build_"$OS_NAME"_"$1"/lib/libcurl.a ddnet-libs/curl/"$OS_NAME"/lib"$2"/libcurl.a
 }
 
 copy_arches_for_lib _copy_curl
 
 mkdir ddnet-libs
 function _copy_freetype2() {
-	mkdir -p ddnet-libs/freetype/"$OS_NAME_PATH"/lib"$2"
-	cp compile_libs/freetype2/build_"$OS_NAME"_"$1"/libfreetype.a ddnet-libs/freetype/"$OS_NAME_PATH"/lib"$2"/libfreetype.a
+	mkdir -p ddnet-libs/freetype/"$OS_NAME"/lib"$2"
+	cp compile_libs/freetype2/build_"$OS_NAME"_"$1"/libfreetype.a ddnet-libs/freetype/"$OS_NAME"/lib"$2"/libfreetype.a
 }
 
 copy_arches_for_lib _copy_freetype2
 
 mkdir ddnet-libs
 function _copy_sdl() {
-	mkdir -p ddnet-libs/sdl/"$OS_NAME_PATH"/lib"$2"
-	cp compile_libs/sdl/build_"$OS_NAME"_"$1"/libSDL2.a ddnet-libs/sdl/"$OS_NAME_PATH"/lib"$2"/libSDL2.a
-	cp compile_libs/sdl/build_"$OS_NAME"_"$1"/libSDL2main.a ddnet-libs/sdl/"$OS_NAME_PATH"/lib"$2"/libSDL2main.a
-	if [ ! -d "ddnet-libs/sdl/include/$OS_NAME_PATH" ]; then
-		mkdir -p ddnet-libs/sdl/include/"$OS_NAME_PATH"
+	mkdir -p ddnet-libs/sdl/"$OS_NAME"/lib"$2"
+	cp compile_libs/sdl/build_"$OS_NAME"_"$1"/libSDL2.a ddnet-libs/sdl/"$OS_NAME"/lib"$2"/libSDL2.a
+	cp compile_libs/sdl/build_"$OS_NAME"_"$1"/libSDL2main.a ddnet-libs/sdl/"$OS_NAME"/lib"$2"/libSDL2main.a
+	if [ ! -d "ddnet-libs/sdl/include/$OS_NAME" ]; then
+		mkdir -p ddnet-libs/sdl/include/"$OS_NAME"
 	fi
-	cp -R compile_libs/sdl/include/* ddnet-libs/sdl/include/"$OS_NAME_PATH"
+	cp -R compile_libs/sdl/include/* ddnet-libs/sdl/include/"$OS_NAME"
 }
 
 copy_arches_for_lib _copy_sdl
@@ -177,44 +167,44 @@ fi
 
 mkdir ddnet-libs
 function _copy_ogg() {
-	mkdir -p ddnet-libs/opus/"$OS_NAME_PATH"/lib"$2"
-	cp compile_libs/ogg/build_"$OS_NAME"_"$1"/libogg.a ddnet-libs/opus/"$OS_NAME_PATH"/lib"$2"/libogg.a
+	mkdir -p ddnet-libs/opus/"$OS_NAME"/lib"$2"
+	cp compile_libs/ogg/build_"$OS_NAME"_"$1"/libogg.a ddnet-libs/opus/"$OS_NAME"/lib"$2"/libogg.a
 }
 
 copy_arches_for_lib _copy_ogg
 
 mkdir ddnet-libs
 function _copy_opus() {
-	mkdir -p ddnet-libs/opus/"$OS_NAME_PATH"/lib"$2"
-	cp compile_libs/opus/build_"$OS_NAME"_"$1"/libopus.a ddnet-libs/opus/"$OS_NAME_PATH"/lib"$2"/libopus.a
+	mkdir -p ddnet-libs/opus/"$OS_NAME"/lib"$2"
+	cp compile_libs/opus/build_"$OS_NAME"_"$1"/libopus.a ddnet-libs/opus/"$OS_NAME"/lib"$2"/libopus.a
 }
 
 copy_arches_for_lib _copy_opus
 
 mkdir ddnet-libs
 function _copy_opusfile() {
-	mkdir -p ddnet-libs/opus/"$OS_NAME_PATH"/lib"$2"
-	cp compile_libs/opusfile/build_"$OS_NAME"_"$1"/libopusfile.a ddnet-libs/opus/"$OS_NAME_PATH"/lib"$2"/libopusfile.a
+	mkdir -p ddnet-libs/opus/"$OS_NAME"/lib"$2"
+	cp compile_libs/opusfile/build_"$OS_NAME"_"$1"/libopusfile.a ddnet-libs/opus/"$OS_NAME"/lib"$2"/libopusfile.a
 }
 
 copy_arches_for_lib _copy_opusfile
 
 mkdir ddnet-libs
 function _copy_sqlite3() {
-	mkdir -p ddnet-libs/sqlite3/"$OS_NAME_PATH"/lib"$2"
-	cp compile_libs/sqlite3/build_"$OS_NAME"_"$1"/sqlite3.a ddnet-libs/sqlite3/"$OS_NAME_PATH"/lib"$2"/libsqlite3.a
+	mkdir -p ddnet-libs/sqlite3/"$OS_NAME"/lib"$2"
+	cp compile_libs/sqlite3/build_"$OS_NAME"_"$1"/sqlite3.a ddnet-libs/sqlite3/"$OS_NAME"/lib"$2"/libsqlite3.a
 }
 
 copy_arches_for_lib _copy_sqlite3
 
 mkdir ddnet-libs
 function _copy_openssl() {
-	mkdir -p ddnet-libs/openssl/"$OS_NAME_PATH"/lib"$2"
+	mkdir -p ddnet-libs/openssl/"$OS_NAME"/lib"$2"
 	mkdir -p ddnet-libs/openssl/include
-	mkdir -p ddnet-libs/openssl/include/"$OS_NAME_PATH"
-	cp compile_libs/openssl/build_"$OS_NAME"_"$1"/libcrypto.a ddnet-libs/openssl/"$OS_NAME_PATH"/lib"$2"/libcrypto.a
-	cp compile_libs/openssl/build_"$OS_NAME"_"$1"/libssl.a ddnet-libs/openssl/"$OS_NAME_PATH"/lib"$2"/libssl.a
-	cp -R compile_libs/openssl/build_"$OS_NAME"_"$1"/include/* ddnet-libs/openssl/include/"$OS_NAME_PATH"
+	mkdir -p ddnet-libs/openssl/include/"$OS_NAME"
+	cp compile_libs/openssl/build_"$OS_NAME"_"$1"/libcrypto.a ddnet-libs/openssl/"$OS_NAME"/lib"$2"/libcrypto.a
+	cp compile_libs/openssl/build_"$OS_NAME"_"$1"/libssl.a ddnet-libs/openssl/"$OS_NAME"/lib"$2"/libssl.a
+	cp -R compile_libs/openssl/build_"$OS_NAME"_"$1"/include/* ddnet-libs/openssl/include/"$OS_NAME"
 	cp -R compile_libs/openssl/include/* ddnet-libs/openssl/include
 }
 
@@ -232,21 +222,21 @@ function _copy_zlib() {
 
 		cd build_"$OS_NAME"_"$1" || exit 1
 		find . -maxdepth 1 -iname '*.h' -print0 | while IFS= read -r -d $'\0' file; do
-			mkdir -p ../../../ddnet-libs/zlib/include/"$OS_NAME_PATH"/"$(dirname "$file")"
-			cp "$file" ../../../ddnet-libs/zlib/include/"$OS_NAME_PATH"/"$(dirname "$file")"
+			mkdir -p ../../../ddnet-libs/zlib/include/"$OS_NAME"/"$(dirname "$file")"
+			cp "$file" ../../../ddnet-libs/zlib/include/"$OS_NAME"/"$(dirname "$file")"
 		done
 	)
 
-	mkdir -p ddnet-libs/zlib/"$OS_NAME_PATH"/lib"$2"
-	cp compile_libs/zlib/build_"$OS_NAME"_"$1"/libz.a ddnet-libs/zlib/"$OS_NAME_PATH"/lib"$2"/libz.a
+	mkdir -p ddnet-libs/zlib/"$OS_NAME"/lib"$2"
+	cp compile_libs/zlib/build_"$OS_NAME"_"$1"/libz.a ddnet-libs/zlib/"$OS_NAME"/lib"$2"/libz.a
 }
 
 copy_arches_for_lib _copy_zlib
 
 mkdir ddnet-libs
 function _copy_png() {
-	mkdir -p ddnet-libs/png/"$OS_NAME_PATH"/lib"$2"
-	cp compile_libs/png/build_"$OS_NAME"_"$1"/libpng16.a ddnet-libs/png/"$OS_NAME_PATH"/lib"$2"/libpng16.a
+	mkdir -p ddnet-libs/png/"$OS_NAME"/lib"$2"
+	cp compile_libs/png/build_"$OS_NAME"_"$1"/libpng16.a ddnet-libs/png/"$OS_NAME"/lib"$2"/libpng16.a
 }
 
 copy_arches_for_lib _copy_png

--- a/scripts/compile_libs/gen_libs.sh
+++ b/scripts/compile_libs/gen_libs.sh
@@ -7,7 +7,7 @@ if [ -z ${1+x} ]; then
 fi
 
 if [ -z ${2+x} ]; then
-	echo "Specify the target system"
+	echo "Specify the target system: android, linux, window, webasm"
 	exit 1
 fi
 
@@ -38,6 +38,9 @@ elif [[ "${OS_NAME}" == "windows" ]]; then
 	COMP_HAS_x64=1
 elif [[ "${OS_NAME}" == "webasm" ]]; then
 	COMP_HAS_WEBASM=1
+else
+	echo "Specify the target system: android, linux, window, webasm"
+	exit 1
 fi
 
 mkdir -p "$1"

--- a/scripts/compile_libs/gen_libs.sh
+++ b/scripts/compile_libs/gen_libs.sh
@@ -153,9 +153,7 @@ function _copy_sdl() {
 	mkdir -p ddnet-libs/sdl/"$OS_NAME"/lib"$2"
 	cp compile_libs/sdl/build_"$OS_NAME"_"$1"/libSDL2.a ddnet-libs/sdl/"$OS_NAME"/lib"$2"/libSDL2.a
 	cp compile_libs/sdl/build_"$OS_NAME"_"$1"/libSDL2main.a ddnet-libs/sdl/"$OS_NAME"/lib"$2"/libSDL2main.a
-	if [ ! -d "ddnet-libs/sdl/include/$OS_NAME" ]; then
-		mkdir -p ddnet-libs/sdl/include/"$OS_NAME"
-	fi
+	mkdir -p ddnet-libs/sdl/include/"$OS_NAME"
 	cp -R compile_libs/sdl/include/* ddnet-libs/sdl/include/"$OS_NAME"
 }
 


### PR DESCRIPTION
See commit messages. Follow-up for #8334.

SDK 19 is the lowest API level support by SDL2 because it is the lowest API level supported by the latest NDK toolchain. According to https://www.composables.com/tools/distribution-chart this should cover virtually all Android devices.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
