### PR TITLE
Refactor client input event handling

### DIFF
--- a/src/engine/client/input.h
+++ b/src/engine/client/input.h
@@ -92,14 +92,17 @@ private:
 	std::vector<std::string> m_vCandidates;
 	int m_CandidateSelectedIndex;
 
-	void AddEvent(char *pText, int Key, int Flags);
-	void Clear() override;
-	bool IsEventValid(const CEvent &Event) const override { return Event.m_InputCount == m_InputCounter; }
+	// events
+	std::vector<CEvent> m_vInputEvents;
+	int64_t m_LastUpdate;
+	float m_UpdateTime;
+	void AddKeyEvent(int Key, int Flags);
+	void AddTextEvent(const char *pText);
 
 	// quick access to input
-	unsigned short m_aInputCount[g_MaxKeys]; // tw-KEY
-	unsigned char m_aInputState[g_MaxKeys]; // SDL_SCANCODE
-	int m_InputCounter;
+	uint32_t m_aInputCount[g_MaxKeys];
+	unsigned char m_aInputState[g_MaxKeys];
+	uint32_t m_InputCounter;
 
 	void UpdateMouseState();
 	void UpdateJoystickState();
@@ -121,6 +124,10 @@ public:
 	void Init() override;
 	int Update() override;
 	void Shutdown() override;
+
+	void ConsumeEvents(std::function<void(const CEvent &Event)> Consumer) const override;
+	void Clear() override;
+	float GetUpdateTime() const override;
 
 	bool ModifierIsPressed() const override { return KeyState(KEY_LCTRL) || KeyState(KEY_RCTRL) || KeyState(KEY_LGUI) || KeyState(KEY_RGUI); }
 	bool ShiftIsPressed() const override { return KeyState(KEY_LSHIFT) || KeyState(KEY_RSHIFT); }

--- a/src/engine/input.h
+++ b/src/engine/input.h
@@ -6,6 +6,9 @@
 #include "kernel.h"
 #include <base/system.h>
 
+#include <cstdint>
+#include <functional>
+
 const int g_MaxKeys = 512;
 extern const char g_aaKeyStrings[g_MaxKeys][20];
 
@@ -23,23 +26,10 @@ public:
 	public:
 		int m_Flags;
 		int m_Key;
+		uint32_t m_InputCount;
 		char m_aText[INPUT_TEXT_SIZE];
-		int m_InputCount;
 	};
 
-protected:
-	enum
-	{
-		INPUT_BUFFER_SIZE = 32
-	};
-
-	// quick access to events
-	size_t m_NumEvents;
-	CEvent m_aInputEvents[INPUT_BUFFER_SIZE];
-	int64_t m_LastUpdate;
-	float m_UpdateTime;
-
-public:
 	enum
 	{
 		FLAG_PRESS = 1 << 0,
@@ -60,19 +50,14 @@ public:
 	};
 
 	// events
-	size_t NumEvents() const { return m_NumEvents; }
-	virtual bool IsEventValid(const CEvent &Event) const = 0;
-	const CEvent &GetEvent(size_t Index) const
-	{
-		dbg_assert(Index < m_NumEvents, "Index invalid");
-		return m_aInputEvents[Index];
-	}
+	virtual void ConsumeEvents(std::function<void(const CEvent &Event)> Consumer) const = 0;
+	virtual void Clear() = 0;
 
 	/**
 	 * @return Rolling average of the time in seconds between
 	 * calls of the Update function.
 	 */
-	float GetUpdateTime() const { return m_UpdateTime; }
+	virtual float GetUpdateTime() const = 0;
 
 	// keys
 	virtual bool ModifierIsPressed() const = 0;
@@ -81,7 +66,6 @@ public:
 	virtual bool KeyIsPressed(int Key) const = 0;
 	virtual bool KeyPress(int Key, bool CheckCounter = false) const = 0;
 	const char *KeyName(int Key) const { return (Key >= 0 && Key < g_MaxKeys) ? g_aaKeyStrings[Key] : g_aaKeyStrings[0]; }
-	virtual void Clear() = 0;
 
 	// joystick
 	class IJoystick

--- a/src/engine/input.h
+++ b/src/engine/input.h
@@ -4,7 +4,8 @@
 #define ENGINE_INPUT_H
 
 #include "kernel.h"
-#include <base/system.h>
+
+#include <base/types.h>
 
 #include <cstdint>
 #include <functional>

--- a/src/game/client/component.cpp
+++ b/src/game/client/component.cpp
@@ -2,6 +2,8 @@
 
 #include "gameclient.h"
 
+#include <base/system.h>
+
 class IKernel *CComponent::Kernel() const { return m_pClient->Kernel(); }
 class IEngine *CComponent::Engine() const { return m_pClient->Engine(); }
 class IGraphics *CComponent::Graphics() const { return m_pClient->Graphics(); }
@@ -26,6 +28,15 @@ class IUpdater *CComponent::Updater() const
 	return m_pClient->Updater();
 }
 #endif
+
+int64_t CComponent::time() const
+{
+#if defined(CONF_VIDEORECORDER)
+	return IVideo::Current() ? IVideo::Time() : time_get();
+#else
+	return time_get();
+#endif
+}
 
 float CComponent::LocalTime() const
 {

--- a/src/game/client/component.h
+++ b/src/game/client/component.h
@@ -104,25 +104,12 @@ protected:
 	class IUpdater *Updater() const;
 #endif
 
-#if defined(CONF_VIDEORECORDER)
 	/**
 	 * Gets the current time.
 	 * @see time_get()
 	 */
-	int64_t time() const
-	{
-		return IVideo::Current() ? IVideo::Time() : time_get();
-	}
-#else
-	/**
-	 * Gets the current time.
-	 * @see time_get()
-	 */
-	int64_t time() const
-	{
-		return time_get();
-	}
-#endif
+	int64_t time() const;
+
 	/**
 	 * Gets the local time.
 	 */

--- a/src/game/client/components/voting.cpp
+++ b/src/game/client/components/voting.cpp
@@ -2,6 +2,8 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include "voting.h"
 
+#include <base/system.h>
+
 #include <engine/shared/config.h>
 #include <engine/textrender.h>
 
@@ -137,6 +139,11 @@ void CVoting::Vote(int v)
 		m_Voted = v;
 	CNetMsg_Cl_Vote Msg = {v};
 	Client()->SendPackMsgActive(&Msg, MSGFLAG_VITAL);
+}
+
+int CVoting::SecondsLeft() const
+{
+	return (m_Closetime - time()) / time_freq();
 }
 
 CVoting::CVoting()

--- a/src/game/client/components/voting.h
+++ b/src/game/client/components/voting.h
@@ -57,8 +57,8 @@ public:
 
 	void Vote(int v); // -1 = no, 1 = yes
 
-	int SecondsLeft() { return (m_Closetime - time()) / time_freq(); }
-	bool IsVoting() { return m_Closetime != 0; }
+	int SecondsLeft() const;
+	bool IsVoting() const { return m_Closetime != 0; }
 	int TakenChoice() const { return m_Voted; }
 	const char *VoteDescription() const { return m_aDescription; }
 	const char *VoteReason() const { return m_aReason; }

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -385,18 +385,13 @@ void CGameClient::OnUpdate()
 	}
 
 	// handle key presses
-	for(size_t i = 0; i < Input()->NumEvents(); i++)
-	{
-		const IInput::CEvent &Event = Input()->GetEvent(i);
-		if(!Input()->IsEventValid(Event))
-			continue;
-
+	Input()->ConsumeEvents([&](const IInput::CEvent &Event) {
 		for(auto &pComponent : m_vpInput)
 		{
 			if(pComponent->OnInput(Event))
 				break;
 		}
-	}
+	});
 
 	if(g_Config.m_ClSubTickAiming && m_Binds.m_MouseOnAction)
 	{

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -8482,17 +8482,6 @@ void CEditor::OnMouseMove(float MouseX, float MouseY)
 	Ui()->MapScreen();
 }
 
-void CEditor::DispatchInputEvents()
-{
-	for(size_t i = 0; i < Input()->NumEvents(); i++)
-	{
-		const IInput::CEvent &Event = Input()->GetEvent(i);
-		if(!Input()->IsEventValid(Event))
-			continue;
-		Ui()->OnInput(Event);
-	}
-}
-
 void CEditor::HandleAutosave()
 {
 	const float Time = Client()->GlobalTime();
@@ -8624,21 +8613,16 @@ void CEditor::OnUpdate()
 	m_pContainerPannedLast = m_pContainerPanned;
 
 	// handle key presses
-	for(size_t i = 0; i < Input()->NumEvents(); i++)
-	{
-		const IInput::CEvent &Event = Input()->GetEvent(i);
-		if(!Input()->IsEventValid(Event))
-			continue;
-
+	Input()->ConsumeEvents([&](const IInput::CEvent &Event) {
 		for(CEditorComponent &Component : m_vComponents)
 		{
 			if(Component.OnInput(Event))
-				break;
+				return;
 		}
-	}
+		Ui()->OnInput(Event);
+	});
 
 	HandleCursorMovement();
-	DispatchInputEvents();
 	HandleAutosave();
 	HandleWriterFinishJobs();
 

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -465,7 +465,6 @@ public:
 
 	void HandleCursorMovement();
 	void OnMouseMove(float MouseX, float MouseY);
-	void DispatchInputEvents();
 	void HandleAutosave();
 	bool PerformAutosave();
 	void HandleWriterFinishJobs();


### PR DESCRIPTION
Add `IInput::ConsumeEvents` function accepting a consumer `std::function` to replace the duplicate usage of the `IInput::NumEvents`, `IInput::GetEvent` and `IInput::IsEventValid` functions.

Use an `std::vector` to store the current input events to support any number of input events per client update instead of at most 32.

Use full `uint32_t` range for input counter instead of only using the range 0..0xFFFF. If the range is artificially reduced, then this can result in inputs being handled multiple times with high refresh rates, so the increased range should add future proofing for extremely fast devices.

Split `CInput::AddEvent` function into `CInput::AddKeyEvent` and `CInput::AddTextEvent` functions for readability and to make it easier to add additional input events (i.e. touch events).

Ensure double-click state is cleared at the end of each frame to prevent the double-click from being stored when no UI element consumes it.

Move member variables from `IInput` interface to `CInput` implementation.

Remove separate `CEditor::DispatchInputEvents` function.

Include `types.h` instead of `system.h` in `input.h`.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
