### PR TITLE
Ensure return value of `secure_random_init` is always checked

### DIFF
--- a/src/base/system.h
+++ b/src/base/system.h
@@ -2637,7 +2637,7 @@ void generate_password(char *buffer, unsigned length, const unsigned short *rand
  *
  * @return `0` on success.
  */
-int secure_random_init();
+[[nodiscard]] int secure_random_init();
 
 /**
  * Uninitializes the secure random module.

--- a/src/tools/stun.cpp
+++ b/src/tools/stun.cpp
@@ -6,8 +6,12 @@ int main(int argc, const char **argv)
 {
 	CCmdlineFix CmdlineFix(&argc, &argv);
 
-	secure_random_init();
 	log_set_global_logger_default();
+	if(secure_random_init() != 0)
+	{
+		log_error("stun", "could not initialize secure RNG");
+		return -1;
+	}
 
 	if(argc < 2)
 	{

--- a/src/tools/twping.cpp
+++ b/src/tools/twping.cpp
@@ -11,8 +11,12 @@ int main(int argc, const char **argv)
 {
 	CCmdlineFix CmdlineFix(&argc, &argv);
 
-	secure_random_init();
 	log_set_global_logger_default();
+	if(secure_random_init() != 0)
+	{
+		log_error("twping", "could not initialize secure RNG");
+		return -1;
+	}
 
 	net_init();
 	NETADDR BindAddr;


### PR DESCRIPTION


## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
