### PR TITLE
Prevent UI elements from being hovered while key reader is active

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -1172,6 +1172,12 @@ void CMenus::Render()
 
 	Ui()->RenderPopupMenus();
 
+	// Prevent UI elements from being hovered while a key reader is active
+	if(m_Binder.m_TakeKey)
+	{
+		Ui()->SetHotItem(nullptr);
+	}
+
 	// Handle this escape hotkey after popup menus
 	if(!m_ShowStart && ClientState == IClient::STATE_OFFLINE && Ui()->ConsumeHotkey(CUi::HOTKEY_ESCAPE))
 	{


### PR DESCRIPTION
Since the key reader will intercept the next input, the other UI elements should not react to the hovered mouse.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
