### PR TITLE
Consistently use `str_copy` instead of `mem_copy` for strings

### DIFF
--- a/src/engine/server/databases/connection_pool.cpp
+++ b/src/engine/server/databases/connection_pool.cpp
@@ -96,7 +96,7 @@ CSqlExecData::CSqlExecData(
 	m_pName("add sqlite server")
 {
 	m_Ptr.m_Sqlite.m_Mode = m;
-	mem_copy(m_Ptr.m_Sqlite.m_FileName, aFileName, sizeof(m_Ptr.m_Sqlite.m_FileName));
+	str_copy(m_Ptr.m_Sqlite.m_FileName, aFileName);
 }
 CSqlExecData::CSqlExecData(CDbConnectionPool::Mode m,
 	const CMysqlConfig *pMysqlConfig) :

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -186,7 +186,7 @@ void CHud::RenderScoreHud()
 				if(aRecreateTeamScore[t])
 				{
 					m_aScoreInfo[t].m_ScoreTextWidth = TextRender()->TextWidth(14.0f, aScoreTeam[t == 0 ? TEAM_RED : TEAM_BLUE], -1, -1.0f);
-					mem_copy(m_aScoreInfo[t].m_aScoreText, aScoreTeam[t == 0 ? TEAM_RED : TEAM_BLUE], sizeof(m_aScoreInfo[t].m_aScoreText));
+					str_copy(m_aScoreInfo[t].m_aScoreText, aScoreTeam[t == 0 ? TEAM_RED : TEAM_BLUE]);
 					RecreateRect = true;
 				}
 			}
@@ -248,7 +248,7 @@ void CHud::RenderScoreHud()
 						const char *pName = m_pClient->m_aClients[Id].m_aName;
 						if(str_comp(pName, m_aScoreInfo[t].m_aPlayerNameText) != 0 || RecreateRect)
 						{
-							mem_copy(m_aScoreInfo[t].m_aPlayerNameText, pName, sizeof(m_aScoreInfo[t].m_aPlayerNameText));
+							str_copy(m_aScoreInfo[t].m_aPlayerNameText, pName);
 
 							float w = TextRender()->TextWidth(8.0f, pName, -1, -1.0f);
 
@@ -340,7 +340,7 @@ void CHud::RenderScoreHud()
 				if(RecreateScores)
 				{
 					m_aScoreInfo[t].m_ScoreTextWidth = TextRender()->TextWidth(14.0f, aScore[t], -1, -1.0f);
-					mem_copy(m_aScoreInfo[t].m_aScoreText, aScore[t], sizeof(m_aScoreInfo[t].m_aScoreText));
+					str_copy(m_aScoreInfo[t].m_aScoreText, aScore[t]);
 					RecreateRect = true;
 				}
 
@@ -412,7 +412,7 @@ void CHud::RenderScoreHud()
 						const char *pName = m_pClient->m_aClients[Id].m_aName;
 						if(RecreateRect)
 						{
-							mem_copy(m_aScoreInfo[t].m_aPlayerNameText, pName, sizeof(m_aScoreInfo[t].m_aPlayerNameText));
+							str_copy(m_aScoreInfo[t].m_aPlayerNameText, pName);
 
 							CTextCursor Cursor;
 							float w = TextRender()->TextWidth(8.0f, pName, -1, -1.0f);
@@ -450,7 +450,7 @@ void CHud::RenderScoreHud()
 				str_format(aBuf, sizeof(aBuf), "%d.", aPos[t]);
 				if(RecreateRect)
 				{
-					mem_copy(m_aScoreInfo[t].m_aRankText, aBuf, sizeof(m_aScoreInfo[t].m_aRankText));
+					str_copy(m_aScoreInfo[t].m_aRankText, aBuf);
 
 					CTextCursor Cursor;
 					TextRender()->SetCursor(&Cursor, m_Width - ScoreWidthMax - ImageSize - Split - PosSize, StartY + t * 20 + (18.f - 10.f) / 2.f, 10.0f, TEXTFLAG_RENDER);

--- a/src/game/client/components/nameplates.cpp
+++ b/src/game/client/components/nameplates.cpp
@@ -105,7 +105,7 @@ void CNamePlates::RenderNameplatePos(vec2 Position, const CNetObj_PlayerInfo *pP
 		const char *pName = m_pClient->m_aClients[pPlayerInfo->m_ClientId].m_aName;
 		if(str_comp(pName, m_aNamePlates[ClientId].m_aName) != 0 || FontSize != m_aNamePlates[ClientId].m_NameTextFontSize)
 		{
-			mem_copy(m_aNamePlates[ClientId].m_aName, pName, sizeof(m_aNamePlates[ClientId].m_aName));
+			str_copy(m_aNamePlates[ClientId].m_aName, pName);
 			m_aNamePlates[ClientId].m_NameTextFontSize = FontSize;
 
 			CTextCursor Cursor;
@@ -128,7 +128,7 @@ void CNamePlates::RenderNameplatePos(vec2 Position, const CNetObj_PlayerInfo *pP
 			const char *pClan = m_pClient->m_aClients[ClientId].m_aClan;
 			if(str_comp(pClan, m_aNamePlates[ClientId].m_aClanName) != 0 || FontSizeClan != m_aNamePlates[ClientId].m_ClanNameTextFontSize)
 			{
-				mem_copy(m_aNamePlates[ClientId].m_aClanName, pClan, sizeof(m_aNamePlates[ClientId].m_aClanName));
+				str_copy(m_aNamePlates[ClientId].m_aClanName, pClan);
 				m_aNamePlates[ClientId].m_ClanNameTextFontSize = FontSizeClan;
 
 				CTextCursor Cursor;

--- a/src/game/editor/mapitems/layer_tiles.cpp
+++ b/src/game/editor/mapitems/layer_tiles.cpp
@@ -64,7 +64,7 @@ CLayerTiles::CLayerTiles(const CLayerTiles &Other) :
 	m_Switch = Other.m_Switch;
 	m_Tune = Other.m_Tune;
 
-	mem_copy(m_aFileName, Other.m_aFileName, IO_MAX_PATH_LENGTH);
+	str_copy(m_aFileName, Other.m_aFileName);
 }
 
 CLayerTiles::~CLayerTiles()

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -3250,7 +3250,7 @@ void CGameContext::AddVote(const char *pDescription, const char *pCommand)
 		m_pVoteOptionFirst = pOption;
 
 	str_copy(pOption->m_aDescription, pDescription, sizeof(pOption->m_aDescription));
-	mem_copy(pOption->m_aCommand, pCommand, Len + 1);
+	str_copy(pOption->m_aCommand, pCommand, Len + 1);
 }
 
 void CGameContext::ConRemoveVote(IConsole::IResult *pResult, void *pUserData)
@@ -3311,7 +3311,7 @@ void CGameContext::ConRemoveVote(IConsole::IResult *pResult, void *pUserData)
 			pVoteOptionFirst = pDst;
 
 		str_copy(pDst->m_aDescription, pSrc->m_aDescription, sizeof(pDst->m_aDescription));
-		mem_copy(pDst->m_aCommand, pSrc->m_aCommand, Len + 1);
+		str_copy(pDst->m_aCommand, pSrc->m_aCommand, Len + 1);
 	}
 
 	// clean up
@@ -4068,7 +4068,7 @@ void CGameContext::OnMapChange(char *pNewMapName, int MapNameSize)
 	{
 		int Length = str_length(pLine) + 1;
 		char *pCopy = (char *)malloc(Length);
-		mem_copy(pCopy, pLine, Length);
+		str_copy(pCopy, pLine, Length);
 		vLines.push_back(pCopy);
 		TotalLength += Length;
 	}


### PR DESCRIPTION

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
