### PR TITLE
Consistent value selector behavior, support double-clicking

### DIFF
--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -807,7 +807,7 @@ bool CUi::DoEditBox(CLineInput *pLineInput, const CUIRect *pRect, float FontSize
 	if(pMouseSelection->m_Selecting)
 	{
 		pMouseSelection->m_ReleaseMouse = MousePos();
-		if(MouseButtonReleased(0))
+		if(!MouseButton(0))
 		{
 			pMouseSelection->m_Selecting = false;
 		}

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -990,87 +990,90 @@ int64_t CUi::DoValueSelector(const void *pId, const CUIRect *pRect, const char *
 SEditResult<int64_t> CUi::DoValueSelectorWithState(const void *pId, const CUIRect *pRect, const char *pLabel, int64_t Current, int64_t Min, int64_t Max, const SValueSelectorProperties &Props)
 {
 	// logic
-	static float s_Value;
+	static bool s_DidScroll = false;
+	static float s_ScrollValue = 0.0f;
 	static CLineInputNumber s_NumberInput;
-	static const void *s_pLastTextId = pId;
-	const bool Inside = MouseInside(pRect);
-	static const void *s_pEditing = nullptr;
-	EEditState State = EEditState::NONE;
+	static int s_ButtonUsed = -1;
+	static const void *s_pLastTextId = nullptr;
 
+	const bool Inside = MouseInside(pRect);
 	const int Base = Props.m_IsHex ? 16 : 10;
 
-	if(MouseButtonReleased(1) && HotItem() == pId)
+	if(HotItem() == pId && s_ButtonUsed >= 0 && !MouseButton(s_ButtonUsed))
 	{
-		s_pLastTextId = pId;
-		m_ValueSelectorTextMode = true;
-		s_NumberInput.SetInteger64(Current, Base, Props.m_HexPrefix);
-		s_NumberInput.SelectAll();
-	}
-
-	if(CheckActiveItem(pId))
-	{
-		if(!MouseButton(0))
+		DisableMouseLock();
+		if(CheckActiveItem(pId))
 		{
-			DisableMouseLock();
 			SetActiveItem(nullptr);
-			m_ValueSelectorTextMode = false;
 		}
+		if(Inside && ((s_ButtonUsed == 0 && !s_DidScroll && Input()->MouseDoubleClick()) || s_ButtonUsed == 1))
+		{
+			s_pLastTextId = pId;
+			s_NumberInput.SetInteger64(Current, Base, Props.m_HexPrefix);
+			s_NumberInput.SelectAll();
+		}
+		s_ButtonUsed = -1;
 	}
 
-	if(m_ValueSelectorTextMode && s_pLastTextId == pId)
+	if(s_pLastTextId == pId)
 	{
-		DoEditBox(&s_NumberInput, pRect, 10.0f);
 		SetActiveItem(&s_NumberInput);
+		DoEditBox(&s_NumberInput, pRect, 10.0f);
 
 		if(ConsumeHotkey(HOTKEY_ENTER) || ((MouseButtonClicked(1) || MouseButtonClicked(0)) && !Inside))
 		{
 			Current = clamp(s_NumberInput.GetInteger64(Base), Min, Max);
 			DisableMouseLock();
 			SetActiveItem(nullptr);
-			m_ValueSelectorTextMode = false;
+			s_pLastTextId = nullptr;
 		}
 
 		if(ConsumeHotkey(HOTKEY_ESCAPE))
 		{
 			DisableMouseLock();
 			SetActiveItem(nullptr);
-			m_ValueSelectorTextMode = false;
+			s_pLastTextId = nullptr;
 		}
 	}
 	else
 	{
 		if(CheckActiveItem(pId))
 		{
-			if(Props.m_UseScroll)
+			if(Props.m_UseScroll && s_ButtonUsed == 0 && MouseButton(0))
 			{
-				if(MouseButton(0))
+				s_ScrollValue += MouseDeltaX() * (Input()->ShiftIsPressed() ? 0.05f : 1.0f);
+
+				if(absolute(s_ScrollValue) > Props.m_Scale)
 				{
-					s_Value += MouseDeltaX() * (Input()->ShiftIsPressed() ? 0.05f : 1.0f);
+					const int64_t Count = (int64_t)(s_ScrollValue / Props.m_Scale);
+					s_ScrollValue = std::fmod(s_ScrollValue, Props.m_Scale);
+					Current += Props.m_Step * Count;
+					Current = clamp(Current, Min, Max);
+					s_DidScroll = true;
 
-					if(absolute(s_Value) > Props.m_Scale)
-					{
-						const int64_t Count = (int64_t)(s_Value / Props.m_Scale);
-						s_Value = std::fmod(s_Value, Props.m_Scale);
-						Current += Props.m_Step * Count;
-						Current = clamp(Current, Min, Max);
-
-						// Constrain to discrete steps
-						if(Count > 0)
-							Current = Current / Props.m_Step * Props.m_Step;
-						else
-							Current = std::ceil(Current / (float)Props.m_Step) * Props.m_Step;
-					}
+					// Constrain to discrete steps
+					if(Count > 0)
+						Current = Current / Props.m_Step * Props.m_Step;
+					else
+						Current = std::ceil(Current / (float)Props.m_Step) * Props.m_Step;
 				}
 			}
 		}
 		else if(HotItem() == pId)
 		{
-			if(MouseButtonClicked(0))
+			if(MouseButton(0))
 			{
-				s_Value = 0;
+				s_ButtonUsed = 0;
+				s_DidScroll = false;
+				s_ScrollValue = 0.0f;
 				SetActiveItem(pId);
 				if(Props.m_UseScroll)
 					EnableMouseLock(pId);
+			}
+			else if(MouseButton(1))
+			{
+				s_ButtonUsed = 1;
+				SetActiveItem(pId);
 			}
 		}
 
@@ -1094,23 +1097,21 @@ SEditResult<int64_t> CUi::DoValueSelectorWithState(const void *pId, const CUIRec
 		DoLabel(pRect, aBuf, 10.0f, TEXTALIGN_MC);
 	}
 
-	if(Inside && !MouseButton(0))
+	if(Inside && !MouseButton(0) && !MouseButton(1))
 		SetHotItem(pId);
 
-	if(!m_ValueSelectorTextMode)
-		s_NumberInput.Clear();
-
+	static const void *s_pEditing = nullptr;
+	EEditState State = EEditState::NONE;
 	if(s_pEditing == pId)
+	{
 		State = EEditState::EDITING;
-
-	bool MouseLocked = CheckMouseLock();
-	if((MouseLocked || m_ValueSelectorTextMode) && !s_pEditing)
+	}
+	if(((CheckActiveItem(pId) && CheckMouseLock()) || s_pLastTextId == pId) && s_pEditing != pId)
 	{
 		State = EEditState::START;
 		s_pEditing = pId;
 	}
-
-	if(!CheckMouseLock() && !m_ValueSelectorTextMode && s_pEditing == pId)
+	if(!CheckMouseLock() && s_pLastTextId != pId && s_pEditing == pId)
 	{
 		State = EEditState::END;
 		s_pEditing = nullptr;

--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -349,8 +349,6 @@ private:
 	std::vector<CUIRect> m_vClips;
 	void UpdateClipping();
 
-	bool m_ValueSelectorTextMode = false;
-
 	struct SPopupMenu
 	{
 		static constexpr float POPUP_BORDER = 1.0f;
@@ -565,8 +563,6 @@ public:
 	// value selector
 	SEditResult<int64_t> DoValueSelectorWithState(const void *pId, const CUIRect *pRect, const char *pLabel, int64_t Current, int64_t Min, int64_t Max, const SValueSelectorProperties &Props = {});
 	int64_t DoValueSelector(const void *pId, const CUIRect *pRect, const char *pLabel, int64_t Current, int64_t Min, int64_t Max, const SValueSelectorProperties &Props = {});
-	bool IsValueSelectorTextMode() const { return m_ValueSelectorTextMode; }
-	void SetValueSelectorTextMode(bool TextMode) { m_ValueSelectorTextMode = TextMode; }
 
 	// scrollbars
 	enum

--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -437,7 +437,6 @@ public:
 	vec2 UpdatedMouseDelta() const { return m_UpdatedMouseDelta; }
 	int MouseButton(int Index) const { return (m_MouseButtons >> Index) & 1; }
 	int MouseButtonClicked(int Index) const { return MouseButton(Index) && !((m_LastMouseButtons >> Index) & 1); }
-	int MouseButtonReleased(int Index) const { return ((m_LastMouseButtons >> Index) & 1) && !MouseButton(Index); }
 	bool CheckMouseLock()
 	{
 		if(m_MouseLock && ActiveItem() != m_pMouseLockId)

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -296,71 +296,67 @@ void CEditor::RenderBackground(CUIRect View, IGraphics::CTextureHandle Texture, 
 SEditResult<int> CEditor::UiDoValueSelector(void *pId, CUIRect *pRect, const char *pLabel, int Current, int Min, int Max, int Step, float Scale, const char *pToolTip, bool IsDegree, bool IsHex, int Corners, const ColorRGBA *pColor, bool ShowValue)
 {
 	// logic
-	static float s_Value;
+	static bool s_DidScroll = false;
+	static float s_ScrollValue = 0.0f;
 	static CLineInputNumber s_NumberInput;
-	static bool s_TextMode = false;
-	static void *s_pLastTextId = pId;
+	static int s_ButtonUsed = -1;
+	static void *s_pLastTextId = nullptr;
+
 	const bool Inside = Ui()->MouseInside(pRect);
 	const int Base = IsHex ? 16 : 10;
-	static bool s_Editing = false;
-	EEditState State = EEditState::EDITING;
 
-	if(Ui()->MouseButton(1) && Ui()->HotItem() == pId)
+	if(Ui()->HotItem() == pId && s_ButtonUsed >= 0 && !Ui()->MouseButton(s_ButtonUsed))
 	{
-		s_pLastTextId = pId;
-		s_TextMode = true;
 		Ui()->DisableMouseLock();
-		s_NumberInput.SetInteger(Current, Base);
-	}
-
-	if(Ui()->CheckActiveItem(pId))
-	{
-		if(!Ui()->MouseButton(0))
+		if(Ui()->CheckActiveItem(pId))
 		{
-			Ui()->DisableMouseLock();
 			Ui()->SetActiveItem(nullptr);
-			s_TextMode = false;
 		}
+		if(Inside && ((s_ButtonUsed == 0 && !s_DidScroll && Input()->MouseDoubleClick()) || s_ButtonUsed == 1))
+		{
+			s_pLastTextId = pId;
+			s_NumberInput.SetInteger(Current, Base);
+			s_NumberInput.SelectAll();
+		}
+		s_ButtonUsed = -1;
 	}
 
-	if(s_TextMode && s_pLastTextId == pId)
+	if(s_pLastTextId == pId)
 	{
 		str_copy(m_aTooltip, "Type your number");
-
+		Ui()->SetActiveItem(&s_NumberInput);
 		DoEditBox(&s_NumberInput, pRect, 10.0f, Corners);
 
-		Ui()->SetActiveItem(&s_NumberInput);
-
-		if(Input()->KeyIsPressed(KEY_RETURN) || Input()->KeyIsPressed(KEY_KP_ENTER) ||
-			((Ui()->MouseButton(1) || Ui()->MouseButton(0)) && !Inside))
+		if(Ui()->ConsumeHotkey(CUi::HOTKEY_ENTER) || ((Ui()->MouseButtonClicked(1) || Ui()->MouseButtonClicked(0)) && !Inside))
 		{
 			Current = clamp(s_NumberInput.GetInteger(Base), Min, Max);
 			Ui()->DisableMouseLock();
 			Ui()->SetActiveItem(nullptr);
-			s_TextMode = false;
+			s_pLastTextId = nullptr;
 		}
 
 		if(Ui()->ConsumeHotkey(CUi::HOTKEY_ESCAPE))
 		{
 			Ui()->DisableMouseLock();
 			Ui()->SetActiveItem(nullptr);
-			s_TextMode = false;
+			s_pLastTextId = nullptr;
 		}
 	}
 	else
 	{
 		if(Ui()->CheckActiveItem(pId))
 		{
-			if(Ui()->MouseButton(0))
+			if(s_ButtonUsed == 0 && Ui()->MouseButton(0))
 			{
-				s_Value += Ui()->MouseDeltaX() * (Input()->ShiftIsPressed() ? 0.05f : 1.0f);
+				s_ScrollValue += Ui()->MouseDeltaX() * (Input()->ShiftIsPressed() ? 0.05f : 1.0f);
 
-				if(absolute(s_Value) >= Scale)
+				if(absolute(s_ScrollValue) >= Scale)
 				{
-					int Count = (int)(s_Value / Scale);
-					s_Value = std::fmod(s_Value, Scale);
+					int Count = (int)(s_ScrollValue / Scale);
+					s_ScrollValue = std::fmod(s_ScrollValue, Scale);
 					Current += Step * Count;
 					Current = clamp(Current, Min, Max);
+					s_DidScroll = true;
 
 					// Constrain to discrete steps
 					if(Count > 0)
@@ -369,23 +365,29 @@ SEditResult<int> CEditor::UiDoValueSelector(void *pId, CUIRect *pRect, const cha
 						Current = std::ceil(Current / (float)Step) * Step;
 				}
 			}
-			if(pToolTip && !s_TextMode)
+
+			if(pToolTip && s_pLastTextId != pId)
 				str_copy(m_aTooltip, pToolTip);
 		}
 		else if(Ui()->HotItem() == pId)
 		{
 			if(Ui()->MouseButton(0))
 			{
+				s_ButtonUsed = 0;
+				s_DidScroll = false;
+				s_ScrollValue = 0.0f;
 				Ui()->SetActiveItem(pId);
 				Ui()->EnableMouseLock(pId);
-				s_Value = 0;
 			}
-			if(pToolTip && !s_TextMode)
+			else if(Ui()->MouseButton(1))
+			{
+				s_ButtonUsed = 1;
+				Ui()->SetActiveItem(pId);
+			}
+
+			if(pToolTip && s_pLastTextId != pId)
 				str_copy(m_aTooltip, pToolTip);
 		}
-
-		if(Inside && !Ui()->MouseButton(0))
-			Ui()->SetHotItem(pId);
 
 		// render
 		char aBuf[128];
@@ -406,20 +408,24 @@ SEditResult<int> CEditor::UiDoValueSelector(void *pId, CUIRect *pRect, const cha
 		Ui()->DoLabel(pRect, aBuf, 10, TEXTALIGN_MC);
 	}
 
-	if(!s_TextMode)
-		s_NumberInput.Clear();
+	if(Inside && !Ui()->MouseButton(0) && !Ui()->MouseButton(1))
+		Ui()->SetHotItem(pId);
 
-	bool MouseLocked = Ui()->CheckMouseLock();
-	if((MouseLocked || s_TextMode) && !s_Editing)
+	static const void *s_pEditing = nullptr;
+	EEditState State = EEditState::NONE;
+	if(s_pEditing == pId)
+	{
+		State = EEditState::EDITING;
+	}
+	if(((Ui()->CheckActiveItem(pId) && Ui()->CheckMouseLock()) || s_pLastTextId == pId) && s_pEditing != pId)
 	{
 		State = EEditState::START;
-		s_Editing = true;
+		s_pEditing = pId;
 	}
-
-	if(!MouseLocked && !s_TextMode && s_Editing)
+	if(!Ui()->CheckMouseLock() && s_pLastTextId != pId && s_pEditing == pId)
 	{
 		State = EEditState::END;
-		s_Editing = false;
+		s_pEditing = nullptr;
 	}
 
 	return SEditResult<int>{State, Current};

--- a/src/game/editor/editor_props.cpp
+++ b/src/game/editor/editor_props.cpp
@@ -19,7 +19,7 @@ template<typename E>
 SEditResult<E> CEditor::DoPropertiesWithState(CUIRect *pToolBox, CProperty *pProps, int *pIds, int *pNewVal, const std::vector<ColorRGBA> &vColors)
 {
 	int Change = -1;
-	EEditState State = EEditState::EDITING;
+	EEditState State = EEditState::NONE;
 
 	for(int i = 0; pProps[i].m_pName; i++)
 	{
@@ -42,7 +42,7 @@ SEditResult<E> CEditor::DoPropertiesWithState(CUIRect *pToolBox, CProperty *pPro
 			str_format(aBuf, sizeof(aBuf), "%d", pProps[i].m_Value);
 			auto NewValueRes = UiDoValueSelector((char *)&pIds[i], &Shifter, "", pProps[i].m_Value, pProps[i].m_Min, pProps[i].m_Max, 1, 1.0f, "Use left mouse button to drag and change the value. Hold shift to be more precise. Rightclick to edit as text.", false, false, 0, pColor);
 			int NewValue = NewValueRes.m_Value;
-			if(NewValue != pProps[i].m_Value || NewValueRes.m_State != EEditState::EDITING)
+			if(NewValue != pProps[i].m_Value || (NewValueRes.m_State != EEditState::NONE && NewValueRes.m_State != EEditState::EDITING))
 			{
 				*pNewVal = NewValue;
 				Change = i;
@@ -102,7 +102,7 @@ SEditResult<E> CEditor::DoPropertiesWithState(CUIRect *pToolBox, CProperty *pPro
 				State = EEditState::ONE_GO;
 			}
 
-			if(NewValue != pProps[i].m_Value || NewValueRes.m_State != EEditState::EDITING)
+			if(NewValue != pProps[i].m_Value || (NewValueRes.m_State != EEditState::NONE && NewValueRes.m_State != EEditState::EDITING))
 			{
 				*pNewVal = NewValue % 360;
 				Change = i;
@@ -241,7 +241,7 @@ SEditResult<E> CEditor::DoPropertiesWithState(CUIRect *pToolBox, CProperty *pPro
 
 			auto NewValueRes = UiDoValueSelector((char *)&pIds[i], &Shifter, aBuf, CurValue, 0, m_Map.m_vpEnvelopes.size(), 1, 1.0f, "Set Envelope", false, false, IGraphics::CORNER_NONE);
 			int NewVal = NewValueRes.m_Value;
-			if(NewVal != CurValue || NewValueRes.m_State != EEditState::EDITING)
+			if(NewVal != CurValue || (NewValueRes.m_State != EEditState::NONE && NewValueRes.m_State != EEditState::EDITING))
 			{
 				*pNewVal = NewVal;
 				Change = i;

--- a/src/game/editor/mapitems/layer_quads.cpp
+++ b/src/game/editor/mapitems/layer_quads.cpp
@@ -231,7 +231,7 @@ CUi::EPopupMenuFunctionResult CLayerQuads::RenderProperties(CUIRect *pToolBox)
 	static int s_aIds[(int)ELayerQuadsProp::NUM_PROPS] = {0};
 	int NewVal = 0;
 	auto [State, Prop] = m_pEditor->DoPropertiesWithState<ELayerQuadsProp>(pToolBox, aProps, s_aIds, &NewVal);
-	if(Prop != ELayerQuadsProp::PROP_NONE)
+	if(Prop != ELayerQuadsProp::PROP_NONE && (State == EEditState::END || State == EEditState::ONE_GO))
 	{
 		m_pEditor->m_Map.OnModify();
 	}

--- a/src/game/editor/mapitems/layer_sounds.cpp
+++ b/src/game/editor/mapitems/layer_sounds.cpp
@@ -178,7 +178,7 @@ CUi::EPopupMenuFunctionResult CLayerSounds::RenderProperties(CUIRect *pToolBox)
 	static int s_aIds[(int)ELayerSoundsProp::NUM_PROPS] = {0};
 	int NewVal = 0;
 	auto [State, Prop] = m_pEditor->DoPropertiesWithState<ELayerSoundsProp>(pToolBox, aProps, s_aIds, &NewVal);
-	if(Prop != ELayerSoundsProp::PROP_NONE)
+	if(Prop != ELayerSoundsProp::PROP_NONE && (State == EEditState::END || State == EEditState::ONE_GO))
 	{
 		m_pEditor->m_Map.OnModify();
 	}

--- a/src/game/editor/mapitems/layer_tiles.cpp
+++ b/src/game/editor/mapitems/layer_tiles.cpp
@@ -1070,7 +1070,7 @@ CUi::EPopupMenuFunctionResult CLayerTiles::RenderProperties(CUIRect *pToolBox)
 	s_Tracker.End(Prop, State);
 
 	// Check if modified property could have an effect on automapper
-	if(HasAutomapEffect(Prop))
+	if((State == EEditState::END || State == EEditState::ONE_GO) && HasAutomapEffect(Prop))
 	{
 		FlagModified(0, 0, m_Width, m_Height);
 
@@ -1251,13 +1251,16 @@ CUi::EPopupMenuFunctionResult CLayerTiles::RenderCommonProperties(SCommonPropSta
 
 	s_Tracker.End(Prop, PropState);
 
-	if(Prop == ETilesCommonProp::PROP_WIDTH || Prop == ETilesCommonProp::PROP_HEIGHT)
+	if(PropState == EEditState::END || PropState == EEditState::ONE_GO)
 	{
-		State.m_Modified |= SCommonPropState::MODIFIED_SIZE;
-	}
-	else if(Prop == ETilesCommonProp::PROP_COLOR)
-	{
-		State.m_Modified |= SCommonPropState::MODIFIED_COLOR;
+		if(Prop == ETilesCommonProp::PROP_WIDTH || Prop == ETilesCommonProp::PROP_HEIGHT)
+		{
+			State.m_Modified |= SCommonPropState::MODIFIED_SIZE;
+		}
+		else if(Prop == ETilesCommonProp::PROP_COLOR)
+		{
+			State.m_Modified |= SCommonPropState::MODIFIED_COLOR;
+		}
 	}
 
 	return CUi::POPUP_KEEP_OPEN;

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -640,7 +640,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupGroup(void *pContext, CUIRect View, 
 	static int s_aIds[(int)EGroupProp::NUM_PROPS] = {0};
 	int NewVal = 0;
 	auto [State, Prop] = pEditor->DoPropertiesWithState<EGroupProp>(&View, aProps, s_aIds, &NewVal);
-	if(Prop != EGroupProp::PROP_NONE)
+	if(Prop != EGroupProp::PROP_NONE && (State == EEditState::END || State == EEditState::ONE_GO))
 	{
 		pEditor->m_Map.OnModify();
 	}
@@ -790,7 +790,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupLayer(void *pContext, CUIRect View, 
 	static int s_aIds[(int)ELayerProp::NUM_PROPS] = {0};
 	int NewVal = 0;
 	auto [State, Prop] = pEditor->DoPropertiesWithState<ELayerProp>(&View, aProps, s_aIds, &NewVal);
-	if(Prop != ELayerProp::PROP_NONE)
+	if(Prop != ELayerProp::PROP_NONE && (State == EEditState::END || State == EEditState::ONE_GO))
 	{
 		pEditor->m_Map.OnModify();
 	}
@@ -979,15 +979,10 @@ CUi::EPopupMenuFunctionResult CEditor::PopupQuad(void *pContext, CUIRect View, b
 
 	static int s_aIds[(int)EQuadProp::NUM_PROPS] = {0};
 	int NewVal = 0;
-	auto PropRes = pEditor->DoPropertiesWithState<EQuadProp>(&View, aProps, s_aIds, &NewVal);
-	EQuadProp Prop = PropRes.m_Value;
-	if(Prop != EQuadProp::PROP_NONE)
+	auto [State, Prop] = pEditor->DoPropertiesWithState<EQuadProp>(&View, aProps, s_aIds, &NewVal);
+	if(Prop != EQuadProp::PROP_NONE && (State == EEditState::START || State == EEditState::ONE_GO))
 	{
-		pEditor->m_Map.OnModify();
-		if(PropRes.m_State == EEditState::START || PropRes.m_State == EEditState::ONE_GO)
-		{
-			pEditor->m_QuadTracker.BeginQuadPropTrack(pLayer, pEditor->m_vSelectedQuads, Prop);
-		}
+		pEditor->m_QuadTracker.BeginQuadPropTrack(pLayer, pEditor->m_vSelectedQuads, Prop);
 	}
 
 	const float OffsetX = i2fx(NewVal) - pCurrentQuad->m_aPoints[4].x;
@@ -1053,12 +1048,10 @@ CUi::EPopupMenuFunctionResult CEditor::PopupQuad(void *pContext, CUIRect View, b
 		}
 	}
 
-	if(Prop != EQuadProp::PROP_NONE)
+	if(Prop != EQuadProp::PROP_NONE && (State == EEditState::END || State == EEditState::ONE_GO))
 	{
-		if(PropRes.m_State == EEditState::END || PropRes.m_State == EEditState::ONE_GO)
-		{
-			pEditor->m_QuadTracker.EndQuadPropTrack(Prop);
-		}
+		pEditor->m_QuadTracker.EndQuadPropTrack(Prop);
+		pEditor->m_Map.OnModify();
 	}
 
 	return CUi::POPUP_KEEP_OPEN;
@@ -1120,7 +1113,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupSource(void *pContext, CUIRect View,
 	static int s_aIds[(int)ESoundProp::NUM_PROPS] = {0};
 	int NewVal = 0;
 	auto [State, Prop] = pEditor->DoPropertiesWithState<ESoundProp>(&View, aProps, s_aIds, &NewVal);
-	if(Prop != ESoundProp::PROP_NONE)
+	if(Prop != ESoundProp::PROP_NONE && (State == EEditState::END || State == EEditState::ONE_GO))
 	{
 		pEditor->m_Map.OnModify();
 	}
@@ -1202,7 +1195,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupSource(void *pContext, CUIRect View,
 		static int s_aCircleIds[(int)ECircleShapeProp::NUM_CIRCLE_PROPS] = {0};
 		NewVal = 0;
 		auto [LocalState, LocalProp] = pEditor->DoPropertiesWithState<ECircleShapeProp>(&View, aCircleProps, s_aCircleIds, &NewVal);
-		if(LocalProp != ECircleShapeProp::PROP_NONE)
+		if(LocalProp != ECircleShapeProp::PROP_NONE && (LocalState == EEditState::END || LocalState == EEditState::ONE_GO))
 		{
 			pEditor->m_Map.OnModify();
 		}
@@ -1230,7 +1223,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupSource(void *pContext, CUIRect View,
 		static int s_aRectangleIds[(int)ERectangleShapeProp::NUM_RECTANGLE_PROPS] = {0};
 		NewVal = 0;
 		auto [LocalState, LocalProp] = pEditor->DoPropertiesWithState<ERectangleShapeProp>(&View, aRectangleProps, s_aRectangleIds, &NewVal);
-		if(LocalProp != ERectangleShapeProp::PROP_NONE)
+		if(LocalProp != ERectangleShapeProp::PROP_NONE && (LocalState == EEditState::END || LocalState == EEditState::ONE_GO))
 		{
 			pEditor->m_Map.OnModify();
 		}
@@ -1282,16 +1275,11 @@ CUi::EPopupMenuFunctionResult CEditor::PopupPoint(void *pContext, CUIRect View, 
 
 	static int s_aIds[(int)EQuadPointProp::NUM_PROPS] = {0};
 	int NewVal = 0;
-	auto PropRes = pEditor->DoPropertiesWithState<EQuadPointProp>(&View, aProps, s_aIds, &NewVal);
-	EQuadPointProp Prop = PropRes.m_Value;
-	if(Prop != EQuadPointProp::PROP_NONE)
+	auto [State, Prop] = pEditor->DoPropertiesWithState<EQuadPointProp>(&View, aProps, s_aIds, &NewVal);
+	if(Prop != EQuadPointProp::PROP_NONE && (State == EEditState::START || State == EEditState::ONE_GO))
 	{
-		pEditor->m_Map.OnModify();
-		if(PropRes.m_State == EEditState::START || PropRes.m_State == EEditState::ONE_GO)
-		{
-			pEditor->m_QuadTracker.BeginQuadPointPropTrack(pLayer, pEditor->m_vSelectedQuads, pEditor->m_SelectedQuadPoints);
-			pEditor->m_QuadTracker.AddQuadPointPropTrack(Prop);
-		}
+		pEditor->m_QuadTracker.BeginQuadPointPropTrack(pLayer, pEditor->m_vSelectedQuads, pEditor->m_SelectedQuadPoints);
+		pEditor->m_QuadTracker.AddQuadPointPropTrack(Prop);
 	}
 
 	for(CQuad *pQuad : vpQuads)
@@ -1335,13 +1323,10 @@ CUi::EPopupMenuFunctionResult CEditor::PopupPoint(void *pContext, CUIRect View, 
 		}
 	}
 
-	if(Prop != EQuadPointProp::PROP_NONE)
+	if(Prop != EQuadPointProp::PROP_NONE && (State == EEditState::END || State == EEditState::ONE_GO))
 	{
+		pEditor->m_QuadTracker.EndQuadPointPropTrack(Prop);
 		pEditor->m_Map.OnModify();
-		if(PropRes.m_State == EEditState::END || PropRes.m_State == EEditState::ONE_GO)
-		{
-			pEditor->m_QuadTracker.EndQuadPointPropTrack(Prop);
-		}
 	}
 
 	return CUi::POPUP_KEEP_OPEN;


### PR DESCRIPTION
Make value selector behavior consistent with the generic button logic. Consistently check for completed mouse clicks on the value selector UI element instead of handling some mouse down and mouse up events separately. Fix text mode being activated when moving the mouse over value selectors with held down mouse button. Fix text mode being deactivated immediately when the mouse leaves text area while holding down the mouse button, which is inconvenient when selecting text. Remove unnecessary usage of `CUi::MouseButtonReleased` function.

Support double-clicking value selectors to enter text edit mode in addition to right-clicking. This feels more intuitive to use and also makes it usable without a second mouse button.

Select all text when entering text mode also in the editor, which was previously only a feature in the menus.

Fix value selector edit state being `EDITING` by default instead of `NONE` in the editor and fix maps being marked as modified immediately when a value selector text input is activated. The map will now be marked as modified only when the editing operation is completed, which should be synchonized with the undo history action being added.

Use the `CUi::ConsumeHotkey` function instead of checking the enter keys manually.

Remove unnecessary and unused `CUi::m_ValueSelectorTextMode` variable and its accessors as well as the equivalent `s_TextMode` variable in the editor. This separate flag is unnecessary as we can use the existing `s_pLastTextId` variable instead.

Replace the last remaining usage of the `CUi::MouseButtonReleased` function with `!MouseButton(...)`. The `pMouseSelection->m_Selecting` flag is only set to `true` when the mouse button is already pressed down, so the additional check of `MouseButtonReleased` is unnecessary in this case. In general, this function is an anti-pattern in our UI, as only checking for the mouse button to be released does not guarantee that the mouse was also pressed down over the respective UI element. The `DoButtonLogic` function or similar code should be used instead of only handling the press or release of a mouse button.

This has no effect on #8413.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
