### PR TITLE
Fix wrong file extension being removed in demo cut popup

### DIFF
--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -830,13 +830,15 @@ void CMenus::RenderDemoPlayerSliceSavePopup(CUIRect MainView)
 	static CButtonContainer s_ButtonOk;
 	if(DoButton_Menu(&s_ButtonOk, Localize("Ok"), 0, &OkButton) || (!Ui()->IsPopupOpen() && Ui()->ConsumeHotkey(CUi::HOTKEY_ENTER)))
 	{
+		if(str_endswith(m_DemoSliceInput.GetString(), ".demo"))
+		{
+			char aNameWithoutExt[IO_MAX_PATH_LENGTH];
+			fs_split_file_extension(m_DemoSliceInput.GetString(), aNameWithoutExt, sizeof(aNameWithoutExt));
+			m_DemoSliceInput.Set(aNameWithoutExt);
+		}
+
 		char aDemoName[IO_MAX_PATH_LENGTH];
-		char aNameWithoutExt[IO_MAX_PATH_LENGTH];
 		DemoPlayer()->GetDemoName(aDemoName, sizeof(aDemoName));
-
-		fs_split_file_extension(m_DemoSliceInput.GetString(), aNameWithoutExt, sizeof(aNameWithoutExt));
-		m_DemoSliceInput.Set(aNameWithoutExt);
-
 		if(str_comp(aDemoName, m_DemoSliceInput.GetString()) == 0)
 		{
 			static CUi::SMessagePopupContext s_MessagePopupContext;


### PR DESCRIPTION
The `.demo` extension is supposed to be removed from the target filename when slicing demos, but anything after the last dot was being removed instead, e.g. `test.abc.def` was incorrectly replaced with `test.abc`.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
