### PR TITLE
Unify editor UI mouse handling with `CUi`

### DIFF
--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -113,13 +113,6 @@ CUi::CUi()
 {
 	m_Enabled = true;
 
-	m_MouseX = 0;
-	m_MouseY = 0;
-	m_MouseWorldX = 0;
-	m_MouseWorldY = 0;
-	m_MouseButtons = 0;
-	m_LastMouseButtons = 0;
-
 	m_Screen.x = 0.0f;
 	m_Screen.y = 0.0f;
 }
@@ -181,16 +174,7 @@ void CUi::OnCursorMove(float X, float Y)
 	m_UpdatedMouseDelta += vec2(X, Y);
 }
 
-void CUi::Update()
-{
-	const CUIRect *pScreen = Screen();
-	const float MouseX = (m_UpdatedMousePos.x / (float)Graphics()->WindowWidth()) * pScreen->w;
-	const float MouseY = (m_UpdatedMousePos.y / (float)Graphics()->WindowHeight()) * pScreen->h;
-	Update(MouseX, MouseY, m_UpdatedMouseDelta.x, m_UpdatedMouseDelta.y, MouseX * 3.0f, MouseY * 3.0f);
-	m_UpdatedMouseDelta = vec2(0.0f, 0.0f);
-}
-
-void CUi::Update(float MouseX, float MouseY, float MouseDeltaX, float MouseDeltaY, float MouseWorldX, float MouseWorldY)
+void CUi::Update(vec2 MouseWorldPos)
 {
 	unsigned MouseButtons = 0;
 	if(Enabled())
@@ -203,14 +187,14 @@ void CUi::Update(float MouseX, float MouseY, float MouseDeltaX, float MouseDelta
 			MouseButtons |= 4;
 	}
 
-	m_MouseDeltaX = MouseDeltaX;
-	m_MouseDeltaY = MouseDeltaY;
-	m_MouseX = MouseX;
-	m_MouseY = MouseY;
-	m_MouseWorldX = MouseWorldX;
-	m_MouseWorldY = MouseWorldY;
+	const CUIRect *pScreen = Screen();
+	m_MousePos = m_UpdatedMousePos * vec2(pScreen->w / Graphics()->WindowWidth(), pScreen->h / Graphics()->WindowHeight());
+	m_MouseDelta = m_UpdatedMouseDelta;
+	m_UpdatedMouseDelta = vec2(0.0f, 0.0f);
+	m_MouseWorldPos = MouseWorldPos;
 	m_LastMouseButtons = m_MouseButtons;
 	m_MouseButtons = MouseButtons;
+
 	m_pHotItem = m_pBecomingHotItem;
 	if(m_pActiveItem)
 		m_pHotItem = m_pActiveItem;
@@ -243,7 +227,7 @@ void CUi::DebugRender()
 
 bool CUi::MouseInside(const CUIRect *pRect) const
 {
-	return pRect->Inside(m_MouseX, m_MouseY);
+	return pRect->Inside(MousePos());
 }
 
 void CUi::ConvertMouseMove(float *pX, float *pY, IInput::ECursorType CursorType) const
@@ -524,9 +508,9 @@ EEditState CUi::DoPickerLogic(const void *pId, const CUIRect *pRect, float *pX, 
 		m_MouseSlow = true;
 
 	if(pX)
-		*pX = clamp(m_MouseX - pRect->x, 0.0f, pRect->w);
+		*pX = clamp(MouseX() - pRect->x, 0.0f, pRect->w);
 	if(pY)
-		*pY = clamp(m_MouseY - pRect->y, 0.0f, pRect->h);
+		*pY = clamp(MouseY() - pRect->y, 0.0f, pRect->h);
 
 	return Res;
 }

--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -331,13 +331,13 @@ private:
 	const CScrollRegion *m_pBecomingHotScrollRegion = nullptr;
 	bool m_ActiveItemValid = false;
 
-	vec2 m_UpdatedMousePos = vec2(0.0f, 0.0f);
-	vec2 m_UpdatedMouseDelta = vec2(0.0f, 0.0f);
-	float m_MouseX, m_MouseY; // in gui space
-	float m_MouseDeltaX, m_MouseDeltaY; // in gui space
-	float m_MouseWorldX, m_MouseWorldY; // in world space
-	unsigned m_MouseButtons;
-	unsigned m_LastMouseButtons;
+	vec2 m_UpdatedMousePos = vec2(0.0f, 0.0f); // in window screen space
+	vec2 m_UpdatedMouseDelta = vec2(0.0f, 0.0f); // in window screen space
+	vec2 m_MousePos = vec2(0.0f, 0.0f); // in gui space
+	vec2 m_MouseDelta = vec2(0.0f, 0.0f); // in gui space
+	vec2 m_MouseWorldPos = vec2(-1.0f, -1.0f); // in world space
+	unsigned m_MouseButtons = 0;
+	unsigned m_LastMouseButtons = 0;
 	bool m_MouseSlow = false;
 	bool m_MouseLock = false;
 	const void *m_pMouseLockId = nullptr;
@@ -423,17 +423,20 @@ public:
 
 	void SetEnabled(bool Enabled) { m_Enabled = Enabled; }
 	bool Enabled() const { return m_Enabled; }
-	void Update();
-	void Update(float MouseX, float MouseY, float MouseDeltaX, float MouseDeltaY, float MouseWorldX, float MouseWorldY);
+	void Update(vec2 MouseWorldPos = vec2(-1.0f, -1.0f));
 	void DebugRender();
 
-	float MouseDeltaX() const { return m_MouseDeltaX; }
-	float MouseDeltaY() const { return m_MouseDeltaY; }
-	float MouseX() const { return m_MouseX; }
-	float MouseY() const { return m_MouseY; }
-	vec2 MousePos() const { return vec2(m_MouseX, m_MouseY); }
-	float MouseWorldX() const { return m_MouseWorldX; }
-	float MouseWorldY() const { return m_MouseWorldY; }
+	vec2 MousePos() const { return m_MousePos; }
+	float MouseX() const { return m_MousePos.x; }
+	float MouseY() const { return m_MousePos.y; }
+	vec2 MouseDelta() const { return m_MouseDelta; }
+	float MouseDeltaX() const { return m_MouseDelta.x; }
+	float MouseDeltaY() const { return m_MouseDelta.y; }
+	vec2 MouseWorldPos() const { return m_MouseWorldPos; }
+	float MouseWorldX() const { return m_MouseWorldPos.x; }
+	float MouseWorldY() const { return m_MouseWorldPos.y; }
+	vec2 UpdatedMousePos() const { return m_UpdatedMousePos; }
+	vec2 UpdatedMouseDelta() const { return m_UpdatedMouseDelta; }
 	int MouseButton(int Index) const { return (m_MouseButtons >> Index) & 1; }
 	int MouseButtonClicked(int Index) const { return MouseButton(Index) && !((m_LastMouseButtons >> Index) & 1); }
 	int MouseButtonReleased(int Index) const { return ((m_LastMouseButtons >> Index) & 1) && !MouseButton(Index); }

--- a/src/game/client/ui_rect.cpp
+++ b/src/game/client/ui_rect.cpp
@@ -161,9 +161,9 @@ void CUIRect::HMargin(float Cut, CUIRect *pOtherRect) const
 	Margin(vec2(0.0f, Cut), pOtherRect);
 }
 
-bool CUIRect::Inside(float PointX, float PointY) const
+bool CUIRect::Inside(vec2 Point) const
 {
-	return PointX >= x && PointX < x + w && PointY >= y && PointY < y + h;
+	return Point.x >= x && Point.x < x + w && Point.y >= y && Point.y < y + h;
 }
 
 void CUIRect::Draw(ColorRGBA Color, int Corners, float Rounding) const

--- a/src/game/client/ui_rect.h
+++ b/src/game/client/ui_rect.h
@@ -111,14 +111,14 @@ public:
 	 * @param pOtherRect The CUIRect to place inside *this* CUIRect
 	 */
 	void HMargin(float Cut, CUIRect *pOtherRect) const;
+
 	/**
 	 * Checks whether a point is inside *this* CUIRect.
 	 *
-	 * @param PointX The point's X position.
-	 * @param PointY The point's Y position.
+	 * @param Point The point's position.
 	 * @return true iff the given point is inside *this* CUIRect.
 	 */
-	bool Inside(float PointX, float PointY) const;
+	bool Inside(vec2 Point) const;
 
 	/**
 	 * Fill background of *this* CUIRect.

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -370,10 +370,6 @@ public:
 		m_OffsetEnvelopeY = 0.5f;
 
 		m_ShowMousePointer = true;
-		m_MouseDeltaX = 0;
-		m_MouseDeltaY = 0;
-		m_MouseDeltaWx = 0;
-		m_MouseDeltaWy = 0;
 
 		m_GuiActive = true;
 		m_PreviewZoom = false;
@@ -464,7 +460,7 @@ public:
 	void ResetIngameMoved() override { m_IngameMoved = false; }
 
 	void HandleCursorMovement();
-	void OnMouseMove(float MouseX, float MouseY);
+	void OnMouseMove(vec2 MousePos);
 	void HandleAutosave();
 	bool PerformAutosave();
 	void HandleWriterFinishJobs();
@@ -705,17 +701,10 @@ public:
 
 	char m_aMenuBackgroundTooltip[256];
 	bool m_PreviewZoom;
-	float m_MouseWScale = 1.0f; // Mouse (i.e. UI) scale relative to the World (selected Group)
-	float m_MouseX = 0.0f;
-	float m_MouseY = 0.0f;
-	float m_MouseWorldX = 0.0f;
-	float m_MouseWorldY = 0.0f;
-	float m_MouseWorldNoParaX = 0.0f;
-	float m_MouseWorldNoParaY = 0.0f;
-	float m_MouseDeltaX;
-	float m_MouseDeltaY;
-	float m_MouseDeltaWx;
-	float m_MouseDeltaWy;
+	float m_MouseWorldScale = 1.0f; // Mouse (i.e. UI) scale relative to the World (selected Group)
+	vec2 m_MouseWorldPos = vec2(0.0f, 0.0f);
+	vec2 m_MouseWorldNoParaPos = vec2(0.0f, 0.0f);
+	vec2 m_MouseDeltaWorld = vec2(0.0f, 0.0f);
 	const void *m_pContainerPanned;
 	const void *m_pContainerPannedLast;
 	char m_MapEditorId; // UI element ID for the main map editor


### PR DESCRIPTION
Remove separate handling of UI mouse position and delta in the editor and use the UI directly for this like in the gameclient. Raw cursor movements are redirected to the UI with the `CUi::OnCursorMove` function. The editor separately updates its world positions and delta after the mouse position was changed. The mouse world position for the editor is passed to the UI with the `CUi::Update` funtion as before, whereas the world position is unused in the gameclient.

Use `vec2`s for mouse positions and deltas instead of two separate floats.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
