### PR TITLE
Fix wrong context value being used for translation lookup

### DIFF
--- a/src/game/localization.cpp
+++ b/src/game/localization.cpp
@@ -210,7 +210,7 @@ bool CLocalizationDatabase::Load(const char *pFilename, IStorage *pStorage, ICon
 				log_error("localization", "malformed context '%s' on line %d", pLine, Line);
 				continue;
 			}
-			str_truncate(aContext, sizeof(aContext), pLine + 1, Len - 1);
+			str_truncate(aContext, sizeof(aContext), pLine + 1, Len - 2);
 			pLine = LineReader.Get();
 			if(!pLine)
 			{


### PR DESCRIPTION
The trailing `]` was not being removed from the context anymore due to an off-by-one error introduced in #8430. Closes #8464.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
