### PR TITLE
Fix percentage not being used for console command progress spinner

### DIFF
--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -1310,7 +1310,7 @@ void CGameConsole::OnRender()
 			float Percentage = Client()->GotRconCommandsPercentage();
 			SProgressSpinnerProperties ProgressProps;
 			ProgressProps.m_Progress = Percentage;
-			Ui()->RenderProgressSpinner(vec2(Screen.w / 4.0f + FONT_SIZE / 2.f, FONT_SIZE), FONT_SIZE / 2.f);
+			Ui()->RenderProgressSpinner(vec2(Screen.w / 4.0f + FONT_SIZE / 2.f, FONT_SIZE), FONT_SIZE / 2.f, ProgressProps);
 
 			char aLoading[128];
 			str_copy(aLoading, Localize("Loading commands…"));


### PR DESCRIPTION
The percentage of received console commands was not being shown with the progress spinner because the variable `ProgressProps` was not passed to the `RenderProgressSpinner` function.

![image](https://github.com/ddnet/ddnet/assets/23437060/868d8fc5-e037-4ffa-8d0c-1ecb56eae942)

## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
