### PR TITLE
Readd is not a word, Reload makes more sense and is easier readablility.

### DIFF
--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -1686,7 +1686,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupImage(void *pContext, CUIRect View, 
 	static CUi::SSelectionPopupContext s_SelectionPopupContext;
 	static CScrollRegion s_SelectionPopupScrollRegion;
 	s_SelectionPopupContext.m_pScrollRegion = &s_SelectionPopupScrollRegion;
-	if(pEditor->DoButton_MenuItem(&s_ReaddButton, "Readd", 0, &Slot, 0, "Reloads the image from the mapres folder"))
+	if(pEditor->DoButton_MenuItem(&s_ReaddButton, "Reload", 0, &Slot, 0, "Reloads the image from the mapres folder"))
 	{
 		char aFilename[IO_MAX_PATH_LENGTH];
 		str_format(aFilename, sizeof(aFilename), "%s.png", pImg->m_aName);
@@ -1785,7 +1785,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupSound(void *pContext, CUIRect View, 
 	View.HSplitTop(5.0f, nullptr, &View);
 	View.HSplitTop(RowHeight, &Slot, &View);
 
-	if(pEditor->DoButton_MenuItem(&s_ReaddButton, "Readd", 0, &Slot, 0, "Reloads the sound from the mapres folder"))
+	if(pEditor->DoButton_MenuItem(&s_ReaddButton, "Reload", 0, &Slot, 0, "Reloads the sound from the mapres folder"))
 	{
 		char aFilename[IO_MAX_PATH_LENGTH];
 		str_format(aFilename, sizeof(aFilename), "%s.opus", pSound->m_aName);

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -1632,7 +1632,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupImage(void *pContext, CUIRect View, 
 	CEditor *pEditor = static_cast<CEditor *>(pContext);
 
 	static int s_ExternalButton = 0;
-	static int s_ReaddButton = 0;
+	static int s_ReloadButton = 0;
 	static int s_ReplaceButton = 0;
 	static int s_RemoveButton = 0;
 	static int s_ExportButton = 0;
@@ -1686,7 +1686,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupImage(void *pContext, CUIRect View, 
 	static CUi::SSelectionPopupContext s_SelectionPopupContext;
 	static CScrollRegion s_SelectionPopupScrollRegion;
 	s_SelectionPopupContext.m_pScrollRegion = &s_SelectionPopupScrollRegion;
-	if(pEditor->DoButton_MenuItem(&s_ReaddButton, "Reload", 0, &Slot, 0, "Reloads the image from the mapres folder"))
+	if(pEditor->DoButton_MenuItem(&s_ReloadButton, "Reload", 0, &Slot, 0, "Reloads the image from the mapres folder"))
 	{
 		char aFilename[IO_MAX_PATH_LENGTH];
 		str_format(aFilename, sizeof(aFilename), "%s.png", pImg->m_aName);
@@ -1754,7 +1754,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupSound(void *pContext, CUIRect View, 
 {
 	CEditor *pEditor = static_cast<CEditor *>(pContext);
 
-	static int s_ReaddButton = 0;
+	static int s_ReloadButton = 0;
 	static int s_ReplaceButton = 0;
 	static int s_RemoveButton = 0;
 	static int s_ExportButton = 0;
@@ -1785,7 +1785,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupSound(void *pContext, CUIRect View, 
 	View.HSplitTop(5.0f, nullptr, &View);
 	View.HSplitTop(RowHeight, &Slot, &View);
 
-	if(pEditor->DoButton_MenuItem(&s_ReaddButton, "Reload", 0, &Slot, 0, "Reloads the sound from the mapres folder"))
+	if(pEditor->DoButton_MenuItem(&s_ReloadButton, "Reload", 0, &Slot, 0, "Reloads the sound from the mapres folder"))
 	{
 		char aFilename[IO_MAX_PATH_LENGTH];
 		str_format(aFilename, sizeof(aFilename), "%s.opus", pSound->m_aName);

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -1632,7 +1632,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupImage(void *pContext, CUIRect View, 
 	CEditor *pEditor = static_cast<CEditor *>(pContext);
 
 	static int s_ExternalButton = 0;
-	static int s_ReloadButton = 0;
+	static int s_ReimportButton = 0;
 	static int s_ReplaceButton = 0;
 	static int s_RemoveButton = 0;
 	static int s_ExportButton = 0;
@@ -1686,7 +1686,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupImage(void *pContext, CUIRect View, 
 	static CUi::SSelectionPopupContext s_SelectionPopupContext;
 	static CScrollRegion s_SelectionPopupScrollRegion;
 	s_SelectionPopupContext.m_pScrollRegion = &s_SelectionPopupScrollRegion;
-	if(pEditor->DoButton_MenuItem(&s_ReloadButton, "Reload", 0, &Slot, 0, "Reloads the image from the mapres folder"))
+	if(pEditor->DoButton_MenuItem(&s_ReimportButton, "Re-import", 0, &Slot, 0, "Re-imports the image from the mapres folder"))
 	{
 		char aFilename[IO_MAX_PATH_LENGTH];
 		str_format(aFilename, sizeof(aFilename), "%s.png", pImg->m_aName);
@@ -1754,7 +1754,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupSound(void *pContext, CUIRect View, 
 {
 	CEditor *pEditor = static_cast<CEditor *>(pContext);
 
-	static int s_ReloadButton = 0;
+	static int s_ReimportButton = 0;
 	static int s_ReplaceButton = 0;
 	static int s_RemoveButton = 0;
 	static int s_ExportButton = 0;
@@ -1785,7 +1785,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupSound(void *pContext, CUIRect View, 
 	View.HSplitTop(5.0f, nullptr, &View);
 	View.HSplitTop(RowHeight, &Slot, &View);
 
-	if(pEditor->DoButton_MenuItem(&s_ReloadButton, "Reload", 0, &Slot, 0, "Reloads the sound from the mapres folder"))
+	if(pEditor->DoButton_MenuItem(&s_ReimportButton, "Re-import", 0, &Slot, 0, "Re-imports the sound from the mapres folder"))
 	{
 		char aFilename[IO_MAX_PATH_LENGTH];
 		str_format(aFilename, sizeof(aFilename), "%s.opus", pSound->m_aName);


### PR DESCRIPTION
Hello & Greetings, 
Upon opening the editor I have found an issue with the wording and ran this buy multiple of my friend. although the functionality of this button works as intended. 
I found that  the previous button labeled: "readd" was heavily confusing, with me first thinking it read, "Read", then a friend suggesting perhaps it meant "Re-add" so a word like Reload is clear and easy to understand and defines what the function of the button does. 

<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them your
![reload](https://github.com/ddnet/ddnet/assets/162745945/8c7aa5c9-b44a-44d1-964f-684f667d2384)
self, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
