### PR TITLE
Move double-click handling from engine input to UI, improve envelope editor double-click handling 

### DIFF
--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -66,7 +66,6 @@ CInput::CInput()
 	m_InputCounter = 1;
 	m_InputGrabbed = false;
 
-	m_MouseDoubleClick = false;
 	m_MouseFocus = true;
 
 	m_pClipboardText = nullptr;
@@ -307,16 +306,6 @@ bool CInput::NativeMousePressed(int Index)
 	return (i & SDL_BUTTON(Index)) != 0;
 }
 
-bool CInput::MouseDoubleClick()
-{
-	if(m_MouseDoubleClick)
-	{
-		m_MouseDoubleClick = false;
-		return true;
-	}
-	return false;
-}
-
 const char *CInput::GetClipboardText()
 {
 	SDL_free(m_pClipboardText);
@@ -364,7 +353,6 @@ void CInput::Clear()
 	mem_zero(m_aInputState, sizeof(m_aInputState));
 	mem_zero(m_aInputCount, sizeof(m_aInputCount));
 	m_vInputEvents.clear();
-	m_MouseDoubleClick = false;
 }
 
 float CInput::GetUpdateTime() const
@@ -743,13 +731,6 @@ int CInput::Update()
 				Scancode = KEY_MOUSE_8;
 			if(Event.button.button == 9)
 				Scancode = KEY_MOUSE_9;
-			if(Event.button.button == SDL_BUTTON_LEFT)
-			{
-				if(Event.button.clicks % 2 == 0)
-					m_MouseDoubleClick = true;
-				if(Event.button.clicks == 1)
-					m_MouseDoubleClick = false;
-			}
 			break;
 
 		case SDL_MOUSEWHEEL:

--- a/src/engine/client/input.h
+++ b/src/engine/client/input.h
@@ -77,7 +77,6 @@ private:
 	char *m_pClipboardText;
 
 	bool m_MouseFocus;
-	bool m_MouseDoubleClick;
 #if defined(CONF_PLATFORM_ANDROID)
 	ivec2 m_LastMousePos = ivec2(0, 0); // No relative mouse on Android
 	int m_NumBackPresses = 0;
@@ -145,7 +144,6 @@ public:
 	void MouseModeRelative() override;
 	void NativeMousePos(int *pX, int *pY) const override;
 	bool NativeMousePressed(int Index) override;
-	bool MouseDoubleClick() override;
 
 	const char *GetClipboardText() override;
 	void SetClipboardText(const char *pText) override;

--- a/src/engine/input.h
+++ b/src/engine/input.h
@@ -93,7 +93,6 @@ public:
 	virtual bool NativeMousePressed(int Index) = 0;
 	virtual void MouseModeRelative() = 0;
 	virtual void MouseModeAbsolute() = 0;
-	virtual bool MouseDoubleClick() = 0;
 	virtual bool MouseRelative(float *pX, float *pY) = 0;
 
 	// clipboard

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1551,7 +1551,7 @@ void CMenus::RenderServerbrowserFriends(CUIRect View)
 				{
 					str_copy(g_Config.m_UiServerAddress, Friend.ServerInfo()->m_aAddress);
 					m_ServerBrowserShouldRevealSelection = true;
-					if(Input()->MouseDoubleClick())
+					if(Ui()->DoDoubleClickLogic(Friend.ListItemId()))
 					{
 						Connect(g_Config.m_UiServerAddress);
 					}

--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -475,6 +475,21 @@ int CUi::DoDraggableButtonLogic(const void *pId, int Checked, const CUIRect *pRe
 	return ReturnValue;
 }
 
+bool CUi::DoDoubleClickLogic(const void *pId)
+{
+	if(m_DoubleClickState.m_pLastClickedId == pId &&
+		Client()->GlobalTime() - m_DoubleClickState.m_LastClickTime < 0.5f &&
+		distance(m_DoubleClickState.m_LastClickPos, MousePos()) <= 32.0f * Screen()->h / Graphics()->ScreenHeight())
+	{
+		m_DoubleClickState.m_pLastClickedId = nullptr;
+		return true;
+	}
+	m_DoubleClickState.m_pLastClickedId = pId;
+	m_DoubleClickState.m_LastClickTime = Client()->GlobalTime();
+	m_DoubleClickState.m_LastClickPos = MousePos();
+	return false;
+}
+
 EEditState CUi::DoPickerLogic(const void *pId, const CUIRect *pRect, float *pX, float *pY)
 {
 	if(MouseHovered(pRect))
@@ -1001,7 +1016,7 @@ SEditResult<int64_t> CUi::DoValueSelectorWithState(const void *pId, const CUIRec
 		{
 			SetActiveItem(nullptr);
 		}
-		if(Inside && ((m_ActiveValueSelectorState.m_Button == 0 && !m_ActiveValueSelectorState.m_DidScroll && Input()->MouseDoubleClick()) || m_ActiveValueSelectorState.m_Button == 1))
+		if(Inside && ((m_ActiveValueSelectorState.m_Button == 0 && !m_ActiveValueSelectorState.m_DidScroll && DoDoubleClickLogic(pId)) || m_ActiveValueSelectorState.m_Button == 1))
 		{
 			m_ActiveValueSelectorState.m_pLastTextId = pId;
 			m_ActiveValueSelectorState.m_NumberInput.SetInteger64(Current, Base, Props.m_HexPrefix);

--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -333,6 +333,14 @@ private:
 
 	int m_ActiveButtonLogicButton = -1;
 	int m_ActiveDraggableButtonLogicButton = -1;
+	class CDoubleClickState
+	{
+	public:
+		const void *m_pLastClickedId = nullptr;
+		float m_LastClickTime = -1.0f;
+		vec2 m_LastClickPos = vec2(-1.0f, -1.0f);
+	};
+	CDoubleClickState m_DoubleClickState;
 	const void *m_pLastEditingItem = nullptr;
 	float m_ActiveScrollbarOffset = 0.0f;
 	float m_ProgressSpinnerOffset = 0.0f;
@@ -526,6 +534,7 @@ public:
 
 	int DoButtonLogic(const void *pId, int Checked, const CUIRect *pRect);
 	int DoDraggableButtonLogic(const void *pId, int Checked, const CUIRect *pRect, bool *pClicked, bool *pAbrupted);
+	bool DoDoubleClickLogic(const void *pId);
 	EEditState DoPickerLogic(const void *pId, const CUIRect *pRect, float *pX, float *pY);
 	void DoSmoothScrollLogic(float *pScrollOffset, float *pScrollOffsetChange, float ViewPortSize, float TotalSize, bool SmoothClamp = false, float ScrollSpeed = 10.0f) const;
 	static vec2 CalcAlignedCursorPos(const CUIRect *pRect, vec2 TextSize, int Align, const float *pBiggestCharHeight = nullptr);

--- a/src/game/client/ui_listbox.cpp
+++ b/src/game/client/ui_listbox.cpp
@@ -93,7 +93,6 @@ void CListBox::DoStart(float RowHeight, int NumItems, int ItemsPerRow, int RowsP
 	m_ListBoxRowHeight = RowHeight;
 	m_ListBoxNumItems = NumItems;
 	m_ListBoxItemsPerRow = ItemsPerRow;
-	m_ListBoxDoneEvents = false;
 	m_ListBoxItemActivated = false;
 	m_ListBoxItemSelected = false;
 
@@ -174,13 +173,11 @@ CListboxItem CListBox::DoNextItem(const void *pId, bool Selected, float CornerRa
 		ItemClicked = false;
 
 	// process input, regard selected index
-	if(m_ListBoxSelectedIndex == ThisItemIndex)
+	if(m_ListBoxNewSelected == ThisItemIndex)
 	{
-		if(m_Active && !m_ListBoxDoneEvents)
+		if(m_Active)
 		{
-			m_ListBoxDoneEvents = true;
-
-			if(Ui()->ConsumeHotkey(CUi::HOTKEY_ENTER) || (ItemClicked && Input()->MouseDoubleClick()))
+			if(Ui()->ConsumeHotkey(CUi::HOTKEY_ENTER) || (ItemClicked && Ui()->DoDoubleClickLogic(pId)))
 			{
 				m_ListBoxItemActivated = true;
 				Ui()->SetActiveItem(nullptr);

--- a/src/game/client/ui_listbox.h
+++ b/src/game/client/ui_listbox.h
@@ -24,7 +24,6 @@ private:
 	int m_ListBoxNewSelected;
 	int m_ListBoxNewSelOffset;
 	bool m_ListBoxUpdateScroll;
-	bool m_ListBoxDoneEvents;
 	int m_ListBoxNumItems;
 	int m_ListBoxItemsPerRow;
 	bool m_ListBoxItemSelected;

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -6334,8 +6334,6 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 			ResetZoomEnvelope(pEnvelope, s_ActiveChannels);
 		}
 
-		static int s_EnvelopeEditorId = 0;
-
 		ColorRGBA aColors[] = {ColorRGBA(1, 0.2f, 0.2f), ColorRGBA(0.2f, 1, 0.2f), ColorRGBA(0.2f, 0.2f, 1), ColorRGBA(1, 1, 0.2f)};
 
 		CUIRect Button;
@@ -6389,6 +6387,8 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 			m_Map.OnModify();
 		}
 
+		static int s_EnvelopeEditorId = 0;
+		static int s_EnvelopeEditorButtonUsed = -1;
 		const bool ShouldPan = s_Operation == EEnvelopeEditorOp::OP_NONE && (Ui()->MouseButton(2) || (Ui()->MouseButton(0) && Input()->ModifierIsPressed()));
 		if(m_pContainerPanned == &s_EnvelopeEditorId)
 		{
@@ -6439,6 +6439,16 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 			// do stuff
 			if(Ui()->MouseButton(0))
 			{
+				s_EnvelopeEditorButtonUsed = 0;
+				if(s_Operation != EEnvelopeEditorOp::OP_BOX_SELECT && !Input()->ModifierIsPressed())
+				{
+					s_Operation = EEnvelopeEditorOp::OP_BOX_SELECT;
+					s_MouseXStart = Ui()->MouseX();
+					s_MouseYStart = Ui()->MouseY();
+				}
+			}
+			else if(s_EnvelopeEditorButtonUsed == 0)
+			{
 				if(Input()->MouseDoubleClick())
 				{
 					// add point
@@ -6462,14 +6472,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 						RemoveTimeOffsetEnvelope(pEnvelope);
 					m_Map.OnModify();
 				}
-				else if(s_Operation != EEnvelopeEditorOp::OP_BOX_SELECT && !Input()->ModifierIsPressed())
-				{
-					static int s_BoxSelectId = 0;
-					Ui()->SetActiveItem(&s_BoxSelectId);
-					s_Operation = EEnvelopeEditorOp::OP_BOX_SELECT;
-					s_MouseXStart = Ui()->MouseX();
-					s_MouseYStart = Ui()->MouseY();
-				}
+				s_EnvelopeEditorButtonUsed = -1;
 			}
 
 			m_ShowEnvelopePreview = SHOWENV_SELECTED;

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -312,7 +312,7 @@ SEditResult<int> CEditor::UiDoValueSelector(void *pId, CUIRect *pRect, const cha
 		{
 			Ui()->SetActiveItem(nullptr);
 		}
-		if(Inside && ((s_ButtonUsed == 0 && !s_DidScroll && Input()->MouseDoubleClick()) || s_ButtonUsed == 1))
+		if(Inside && ((s_ButtonUsed == 0 && !s_DidScroll && Ui()->DoDoubleClickLogic(pId)) || s_ButtonUsed == 1))
 		{
 			s_pLastTextId = pId;
 			s_NumberInput.SetInteger(Current, Base);
@@ -3907,7 +3907,7 @@ void CEditor::RenderLayers(CUIRect LayersBox)
 						Ui()->DoPopupMenu(&s_PopupGroupId, Ui()->MouseX(), Ui()->MouseY(), 145, 256, this, PopupGroup);
 					}
 
-					if(!m_Map.m_vpGroups[g]->m_vpLayers.empty() && Input()->MouseDoubleClick())
+					if(!m_Map.m_vpGroups[g]->m_vpLayers.empty() && Ui()->DoDoubleClickLogic(m_Map.m_vpGroups[g].get()))
 						m_Map.m_vpGroups[g]->m_Collapse ^= 1;
 
 					SetOperation(OP_NONE);
@@ -6449,7 +6449,7 @@ void CEditor::RenderEnvelopeEditor(CUIRect View)
 			}
 			else if(s_EnvelopeEditorButtonUsed == 0)
 			{
-				if(Input()->MouseDoubleClick())
+				if(Ui()->DoDoubleClickLogic(&s_EnvelopeEditorId))
 				{
 					// add point
 					float Time = ScreenToEnvelopeX(View, Ui()->MouseX());


### PR DESCRIPTION
Instead of relying on SDL to determine when a click is a double-click, implement double-click handling specifically for the UI, as double-clicks are only supposed to be used there. This allows us to ensure that double-clicks only activate UI elements if both clicks were performed on the same UI element. Previously, only the position of the second click was considered, so UI element would incorrectly activate when double-clicking close to them as long as the second click starts and ends on them.

Implementing double-clicking handling separately is also necessary to support double-clicking in the UI with touch events, as SDL does not provide the double-click information for touch events.

The newly added `CUi::DoDoubleClickLogic` function should be called after a UI element has been clicked. It will return `true` if the current click should be interpreted as a double-click, i.e. if the same UI element was clicked, the click was within 0.5 seconds of the previous click (the default duration for SDL and Windows) and the distance from the previous click is within 32 screen pixels (the default distance for SDL).

Only handle the double-click on the envelope editor when the second click is released instead of when it is pressed down already.

Remove unnecessary UI element `s_BoxSelectId`, the temporary activation of which was causing the tooltip to be missing for one frame when clicking the envelope editor.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)