### PR TITLE
Add team size indicator

### DIFF
--- a/src/game/client/components/scoreboard.cpp
+++ b/src/game/client/components/scoreboard.cpp
@@ -273,9 +273,9 @@ void CScoreboard::RenderScoreboard(CUIRect Scoreboard, int Team, int CountStart,
 		FontSize = 16.0f;
 	}
 
-	const float ScoreOffset = Scoreboard.x + 10.0f + 10.0f;
+	const float ScoreOffset = Scoreboard.x + 40.0f;
 	const float ScoreLength = TextRender()->TextWidth(FontSize, TimeScore ? "00:00:00" : "99999");
-	const float TeeOffset = ScoreOffset + ScoreLength + 15.0f;
+	const float TeeOffset = ScoreOffset + ScoreLength + 20.0f;
 	const float TeeLength = 60.0f * TeeSizeMod;
 	const float NameOffset = TeeOffset + TeeLength;
 	const float NameLength = 300.0f - TeeLength;
@@ -302,8 +302,12 @@ void CScoreboard::RenderScoreboard(CUIRect Scoreboard, int Team, int CountStart,
 	// render player entries
 	int CountRendered = 0;
 	int PrevDDTeam = -1;
+	int CurrentDDTeamSize = 0;
 
 	char aBuf[64];
+	int MaxTeamSize = m_pClient->Config()->m_SvMaxTeamSize;
+	float TeamStartY = 0;
+
 	for(int i = 0; i < MAX_CLIENTS; i++)
 	{
 		// make sure that we render the correct team
@@ -350,30 +354,42 @@ void CScoreboard::RenderScoreboard(CUIRect Scoreboard, int Team, int CountStart,
 			const ColorRGBA Color = GameClient()->GetDDTeamColor(DDTeam).WithAlpha(0.5f);
 			int TeamRectCorners = 0;
 			if(PrevDDTeam != DDTeam)
+			{
 				TeamRectCorners |= IGraphics::CORNER_T;
+				TeamStartY = Row.y;
+			}
 			if(NextDDTeam != DDTeam)
 				TeamRectCorners |= IGraphics::CORNER_B;
 			RowAndSpacing.Draw(Color, TeamRectCorners, RoundRadius);
 
+			CurrentDDTeamSize++;
+
 			if(NextDDTeam != DDTeam)
 			{
 				const float TeamFontSize = FontSize / 1.5f;
+
 				if(NumPlayers > 8)
 				{
 					if(DDTeam == TEAM_SUPER)
 						str_copy(aBuf, Localize("Super"));
-					else
+					else if(CurrentDDTeamSize <= 1)
 						str_format(aBuf, sizeof(aBuf), "%d", DDTeam);
-					TextRender()->Text(Row.x, Row.y + Row.h / 2.0f - TeamFontSize / 2.0f, TeamFontSize, aBuf);
+					else
+						str_format(aBuf, sizeof(aBuf), Localize("%d\n(%d/%d)", "Team and size"), DDTeam, CurrentDDTeamSize, MaxTeamSize);
+					TextRender()->Text(Row.x, TeamStartY + Row.h / 2.0f - TeamFontSize / 2.0f, TeamFontSize, aBuf);
 				}
 				else
 				{
 					if(DDTeam == TEAM_SUPER)
 						str_copy(aBuf, Localize("Super"));
+					else if(CurrentDDTeamSize > 1)
+						str_format(aBuf, sizeof(aBuf), Localize("Team %d (%d/%d)"), DDTeam, CurrentDDTeamSize, MaxTeamSize);
 					else
 						str_format(aBuf, sizeof(aBuf), Localize("Team %d"), DDTeam);
 					TextRender()->Text(Row.x + Row.w / 2.0f - TextRender()->TextWidth(TeamFontSize, aBuf) / 2.0f + 10.0f, Row.y + Row.h, TeamFontSize, aBuf);
 				}
+
+				CurrentDDTeamSize = 0;
 			}
 		}
 		PrevDDTeam = DDTeam;
@@ -383,9 +399,7 @@ void CScoreboard::RenderScoreboard(CUIRect Scoreboard, int Team, int CountStart,
 			(GameClient()->m_Snap.m_SpecInfo.m_SpectatorId == SPEC_FREEVIEW && pInfo->m_Local) ||
 			(GameClient()->m_Snap.m_SpecInfo.m_Active && pInfo->m_ClientId == GameClient()->m_Snap.m_SpecInfo.m_SpectatorId))
 		{
-			CUIRect Highlight;
-			Row.VMargin(10.0f, &Highlight);
-			Highlight.Draw(ColorRGBA(1.0f, 1.0f, 1.0f, 0.25f), IGraphics::CORNER_ALL, RoundRadius);
+			Row.Draw(ColorRGBA(1.0f, 1.0f, 1.0f, 0.25f), IGraphics::CORNER_ALL, RoundRadius);
 		}
 
 		// score

--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -1241,18 +1241,25 @@ void CGameContext::ConTeam(IConsole::IResult *pResult, void *pUserData)
 		char aBuf[512];
 		if(!pPlayer->IsPlaying())
 		{
-			pSelf->Console()->Print(
-				IConsole::OUTPUT_LEVEL_STANDARD,
-				"chatresp",
-				"You can't check your team while you are dead/a spectator.");
+			pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "chatresp", "You can't check your team while you are dead/a spectator.");
 		}
 		else
 		{
-			str_format(
-				aBuf,
-				sizeof(aBuf),
-				"You are in team %d",
-				pSelf->GetDDRaceTeam(pResult->m_ClientId));
+			int TeamSize = 0;
+			const int PlayerTeam = pSelf->GetDDRaceTeam(pResult->m_ClientId);
+
+			// Count players in team
+			for(int ClientId = 0; ClientId < MAX_CLIENTS; ClientId++)
+			{
+				const CPlayer *pOtherPlayer = pSelf->m_apPlayers[ClientId];
+				if(!pOtherPlayer || !pOtherPlayer->IsPlaying())
+					continue;
+
+				if(pSelf->GetDDRaceTeam(ClientId) == PlayerTeam)
+					TeamSize++;
+			}
+
+			str_format(aBuf, sizeof(aBuf), "You are in team %d having %d %s", PlayerTeam, TeamSize, TeamSize > 1 ? "players" : "player");
 			pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "chatresp", aBuf);
 		}
 	}


### PR DESCRIPTION
Add team size indicator:
- In scoreboard
- In chat when using `/team` with no arguments

Closes #8496.

Scoreboard having a lot of players:
![DDNet_Ore0TqS1Sn](https://github.com/ddnet/ddnet/assets/13364635/251780b2-7f59-4a1f-8394-eb0117df7897)

Scoreboard having a few players:
![DDNet_DL52PkCsxc](https://github.com/ddnet/ddnet/assets/13364635/2dda7c59-e1c5-41f4-bf64-01e1249d2f25)

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
