### PR TITLE
Move `CGameConsole::Dump` function to `CGameConsole::CInstance`

### DIFF
--- a/src/game/client/components/console.h
+++ b/src/game/client/components/console.h
@@ -110,6 +110,7 @@ class CGameConsole : public CComponent
 		int GetLinesToScroll(int Direction, int LinesToScroll);
 		void ScrollToCenter(int StartLine, int EndLine);
 		void ClearSearch();
+		void Dump() REQUIRES(!m_BacklogPendingLock);
 
 		const char *GetString() const { return m_Input.GetString(); }
 		static void PossibleCommandsCompleteCallback(int Index, const char *pStr, void *pUser);
@@ -142,7 +143,6 @@ class CGameConsole : public CComponent
 	static const ColorRGBA ms_SearchSelectedColor;
 
 	void Toggle(int Type);
-	void Dump(int Type);
 
 	static void PossibleCommandsRenderCallback(int Index, const char *pStr, void *pUser);
 	static void ConToggleLocalConsole(IConsole::IResult *pResult, void *pUserData);


### PR DESCRIPTION
Avoid the `int Type` parameter by making `CGameConsole::Dump` a member function of `CGameConsole::CInstance`.

Use `log_*` functions instead of `IConsole` for logging.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
