### PR TITLE
Ensure sample indices are initialized also with sound disabled, faster map loading with sound disabled, fix map sound warning

### DIFF
--- a/src/engine/client/sound.cpp
+++ b/src/engine/client/sound.cpp
@@ -207,6 +207,18 @@ int CSound::Init()
 	m_pGraphics = Kernel()->RequestInterface<IEngineGraphics>();
 	m_pStorage = Kernel()->RequestInterface<IStorage>();
 
+	// Initialize sample indices. We always need them to load sounds in
+	// the editor even if sound is disabled or failed to be enabled.
+	m_FirstFreeSampleIndex = 0;
+	for(size_t i = 0; i < std::size(m_aSamples) - 1; ++i)
+	{
+		m_aSamples[i].m_Index = i;
+		m_aSamples[i].m_NextFreeSampleIndex = i + 1;
+		m_aSamples[i].m_pData = nullptr;
+	}
+	m_aSamples[std::size(m_aSamples) - 1].m_Index = std::size(m_aSamples) - 1;
+	m_aSamples[std::size(m_aSamples) - 1].m_NextFreeSampleIndex = SAMPLE_INDEX_FULL;
+
 	if(!g_Config.m_SndEnable)
 		return 0;
 
@@ -228,7 +240,6 @@ int CSound::Init()
 
 	// Open the audio device and start playing sound!
 	m_Device = SDL_OpenAudioDevice(nullptr, 0, &Format, &FormatOut, 0);
-
 	if(m_Device == 0)
 	{
 		dbg_msg("sound", "unable to open audio: %s", SDL_GetError());
@@ -242,15 +253,6 @@ int CSound::Init()
 	m_MaxFrames = maximum<uint32_t>(m_MaxFrames, 1024 * 2); // make the buffer bigger just in case
 #endif
 	m_pMixBuffer = (int *)calloc(m_MaxFrames * 2, sizeof(int));
-
-	m_FirstFreeSampleIndex = 0;
-	for(size_t i = 0; i < std::size(m_aSamples) - 1; ++i)
-	{
-		m_aSamples[i].m_Index = i;
-		m_aSamples[i].m_NextFreeSampleIndex = i + 1;
-	}
-	m_aSamples[std::size(m_aSamples) - 1].m_Index = std::size(m_aSamples) - 1;
-	m_aSamples[std::size(m_aSamples) - 1].m_NextFreeSampleIndex = SAMPLE_INDEX_FULL;
 
 	SDL_PauseAudioDevice(m_Device, 0);
 

--- a/src/game/client/components/mapsounds.cpp
+++ b/src/game/client/components/mapsounds.cpp
@@ -23,6 +23,9 @@ void CMapSounds::OnMapLoad()
 
 	Clear();
 
+	if(!Sound()->IsSoundEnabled())
+		return;
+
 	// load samples
 	int Start;
 	pMap->GetType(MAPITEMTYPE_SOUND, &Start, &m_Count);
@@ -64,7 +67,6 @@ void CMapSounds::OnMapLoad()
 	}
 
 	// enqueue sound sources
-	m_vSourceQueue.clear();
 	for(int g = 0; g < Layers()->NumGroups(); g++)
 	{
 		CMapItemGroup *pGroup = Layers()->GetGroup(g);
@@ -239,6 +241,7 @@ void CMapSounds::OnRender()
 void CMapSounds::Clear()
 {
 	// unload all samples
+	m_vSourceQueue.clear();
 	for(int i = 0; i < m_Count; i++)
 	{
 		Sound()->UnloadSample(m_aSounds[i]);


### PR DESCRIPTION
The assertion of #8262 can be reproduced when sound is disabled or failed to be initialized, as the sample indices where not being initialized properly in these cases. It is still necessary to initialized them so sounds can be loaded in the editor also when sound is disabled.

The potential thread-safety issues of the `CSound::AllocSample` function are not yet resolved so the issue remains open.

Fix map sound loading warning being incorrectly shown when sound is disabled. Make map loading faster in this case by not unpacking the sound data and sound sources from the map at all if sound is disabled.

Closes #8450.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
