### PR TITLE
Add context to translations & add removed translations

### DIFF
--- a/data/languages/belarusian.txt
+++ b/data/languages/belarusian.txt
@@ -518,6 +518,7 @@ LAN
 Name plates size
 == Памер таблічак з імёнамі
 
+[Graphics error]
 Failed to swap framebuffers. Try to update your GPU drivers.
 == Не атрымалася выканаць падпампоўку кадравых буфераў. Паспрабуйце абнавіць драйверы відэакарты.
 
@@ -1717,11 +1718,11 @@ Out of VRAM. Try removing custom assets (skins, entities, etc.), especially thos
 
 [Graphics error]
 An error during command recording occurred. Try to update your GPU drivers.
-== 
+== Адбылася памылка падчас выканання каманды запісу. Паспрабуйце абнавіць драйверы відэакарты.
 
 [Graphics error]
 A render command failed. Try to update your GPU drivers.
-== 
+== Каманда рэндэрынгу не выканана. Паспрабуйце абнавіць драйверы відэакарты.
 
 [Graphics error]
 Submitting the render commands failed. Try to update your GPU drivers.

--- a/data/languages/polish.txt
+++ b/data/languages/polish.txt
@@ -1211,6 +1211,7 @@ Failed during initialization. Try to change gfx_backend to OpenGL or Vulkan in s
 Out of VRAM. Try removing custom assets (skins, entities, etc.), especially those with high resolution.
 == Brak pamięci VRAM. Spróbuj usunąć niestandardowe zasoby (skiny, entities, itd.), szczególnie te z dużą rozdzielczością.
 
+[Graphics error]
 Unknown error. Try to change gfx_backend to OpenGL or Vulkan in settings_ddnet.cfg in the config directory and try again.
 == Wystąpił nieznany błąd. Spróbuj zmienić gfx_backend na OpenGL lub Vulkan w settings_ddnet.cfg w folderze konfiguracyjnym i spróbuj ponownie.
 


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

This pr fixes translation files. These 2 files had missing `[Graphics error]` context and because of this python script was destroying the translations. For example https://github.com/ddnet/ddnet/commit/2498d392dbf1ef496e647f8bdbbb406e22f7fe62#diff-3edb39080aa69131efe333703ea6a07b9a8556c8e82674d24c276ee7e0599ffe Also I added a few translation which were removed by script.


<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
