### PR TITLE
Correct arguments highlighting after removing entry

### DIFF
--- a/src/game/editor/editor_server_settings.cpp
+++ b/src/game/editor/editor_server_settings.cpp
@@ -84,7 +84,10 @@ void CEditor::RenderServerSettingsEditor(CUIRect View, bool ShowServerSettingsEd
 			s_CommandSelectedIndex = m_Map.m_vSettings.size() - 1;
 		if(s_CommandSelectedIndex >= 0)
 			m_SettingsCommandInput.Set(m_Map.m_vSettings[s_CommandSelectedIndex].m_aCommand);
+		else
+			m_SettingsCommandInput.Clear();
 		m_Map.OnModify();
+		m_MapSettingsCommandContext.Update();
 		s_ListBox.ScrollToSelected();
 	}
 


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->
Fixes #8485. I don't know if it's the way it has to be done but it works xd. Also I added an else statement which clears the text input it the last command was deleted.
<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
