### PR TITLE
Fix gcc format-security warnings on build

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -3124,7 +3124,7 @@ bool CClient::InitNetworkClient(char *pError, size_t ErrorSize)
 					if(g_Config.m_Bindaddr[0])
 						str_format(pError, ErrorSize, "Could not open the network client, try changing or unsetting the bindaddr '%s'.", g_Config.m_Bindaddr);
 					else
-						str_format(pError, ErrorSize, "Could not open the network client.");
+						str_format(pError, ErrorSize, "Could not open the network client.", "");
 					return false;
 				}
 			}

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -1631,7 +1631,7 @@ void CHud::RenderRecord()
 	if(m_ServerRecord > 0.0f)
 	{
 		char aBuf[64];
-		str_format(aBuf, sizeof(aBuf), Localize("Server best:"));
+		str_format(aBuf, sizeof(aBuf), Localize("Server best:"), "");
 		TextRender()->Text(5, 75, 6, aBuf, -1.0f);
 		char aTime[32];
 		str_time_float(m_ServerRecord, TIME_HOURS_CENTISECS, aTime, sizeof(aTime));
@@ -1643,7 +1643,7 @@ void CHud::RenderRecord()
 	if(PlayerRecord > 0.0f)
 	{
 		char aBuf[64];
-		str_format(aBuf, sizeof(aBuf), Localize("Personal best:"));
+		str_format(aBuf, sizeof(aBuf), Localize("Personal best:"), "");
 		TextRender()->Text(5, 82, 6, aBuf, -1.0f);
 		char aTime[32];
 		str_time_float(PlayerRecord, TIME_HOURS_CENTISECS, aTime, sizeof(aTime));

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -3418,15 +3418,15 @@ void CMenus::RenderSettingsDDNet(CUIRect MainView)
 			}
 		}
 		else if(State >= IUpdater::GETTING_MANIFEST && State < IUpdater::NEED_RESTART)
-			str_format(aBuf, sizeof(aBuf), Localize("Updating…"));
+			str_format(aBuf, sizeof(aBuf), Localize("Updating…"), "");
 		else if(State == IUpdater::NEED_RESTART)
 		{
-			str_format(aBuf, sizeof(aBuf), Localize("DDNet Client updated!"));
+			str_format(aBuf, sizeof(aBuf), Localize("DDNet Client updated!"), "");
 			m_NeedRestartUpdate = true;
 		}
 		else
 		{
-			str_format(aBuf, sizeof(aBuf), Localize("No updates available"));
+			str_format(aBuf, sizeof(aBuf), Localize("No updates available"), "");
 			UpdaterRect.VSplitLeft(TextRender()->TextWidth(14.0f, aBuf, -1, -1.0f) + 10.0f, &UpdaterRect, &Button);
 			Button.VSplitLeft(100.0f, &Button, nullptr);
 			static CButtonContainer s_ButtonUpdate;

--- a/src/game/client/components/menus_start.cpp
+++ b/src/game/client/components/menus_start.cpp
@@ -225,12 +225,12 @@ void CMenus::RenderStartMenu(CUIRect MainView)
 	}
 	else if(State == IUpdater::FAIL)
 	{
-		str_format(aBuf, sizeof(aBuf), Localize("Update failed! Check log…"));
+		str_format(aBuf, sizeof(aBuf), Localize("Update failed! Check log…"), "");
 		TextRender()->TextColor(1.0f, 0.4f, 0.4f, 1.0f);
 	}
 	else if(State == IUpdater::NEED_RESTART)
 	{
-		str_format(aBuf, sizeof(aBuf), Localize("DDNet Client updated!"));
+		str_format(aBuf, sizeof(aBuf), Localize("DDNet Client updated!"), "");
 		TextRender()->TextColor(1.0f, 0.4f, 0.4f, 1.0f);
 	}
 	Ui()->DoLabel(&VersionUpdate, aBuf, 14.0f, TEXTALIGN_ML);

--- a/src/game/editor/editor_actions.cpp
+++ b/src/game/editor/editor_actions.cpp
@@ -320,7 +320,7 @@ void CEditorActionDeleteQuad::Redo()
 CEditorActionEditQuadPoint::CEditorActionEditQuadPoint(CEditor *pEditor, int GroupIndex, int LayerIndex, int QuadIndex, std::vector<CPoint> const &vPreviousPoints, std::vector<CPoint> const &vCurrentPoints) :
 	CEditorActionLayerBase(pEditor, GroupIndex, LayerIndex), m_QuadIndex(QuadIndex), m_vPreviousPoints(vPreviousPoints), m_vCurrentPoints(vCurrentPoints)
 {
-	str_format(m_aDisplayText, sizeof(m_aDisplayText), "Edit quad points");
+	str_format(m_aDisplayText, sizeof(m_aDisplayText), "Edit quad points", "");
 }
 
 void CEditorActionEditQuadPoint::Undo()
@@ -628,7 +628,7 @@ CEditorActionGroup::CEditorActionGroup(CEditor *pEditor, int GroupIndex, bool De
 	if(m_Delete)
 		str_format(m_aDisplayText, sizeof(m_aDisplayText), "Delete group %d", m_GroupIndex);
 	else
-		str_format(m_aDisplayText, sizeof(m_aDisplayText), "New group");
+		str_format(m_aDisplayText, sizeof(m_aDisplayText), "New group", "");
 }
 
 void CEditorActionGroup::Undo()
@@ -1198,7 +1198,7 @@ CEditorActionTileArt::CEditorActionTileArt(CEditor *pEditor, int PreviousImageCo
 	IEditorAction(pEditor), m_PreviousImageCount(PreviousImageCount), m_vImageIndexMap(vImageIndexMap)
 {
 	str_copy(m_aTileArtFile, pTileArtFile);
-	str_format(m_aDisplayText, sizeof(m_aDisplayText), "Tile art");
+	str_format(m_aDisplayText, sizeof(m_aDisplayText), "Tile art", "");
 }
 
 void CEditorActionTileArt::Undo()
@@ -1266,7 +1266,7 @@ CEditorCommandAction::CEditorCommandAction(CEditor *pEditor, EType Type, int *pS
 	switch(m_Type)
 	{
 	case EType::ADD:
-		str_format(m_aDisplayText, sizeof(m_aDisplayText), "Add command");
+		str_format(m_aDisplayText, sizeof(m_aDisplayText), "Add command", "");
 		break;
 	case EType::EDIT:
 		str_format(m_aDisplayText, sizeof(m_aDisplayText), "Edit command %d", m_CommandIndex);


### PR DESCRIPTION
BTW no-nullability-completeness flag seems is not recognized anymore and can be dropped after this patch applied

```
FAILED: CMakeFiles/game-client.dir/src/game/client/components/hud.cpp.o /usr/bin/g++ -DCONF_BACKEND_VULKAN -DCONF_INFORM_UPDATE -DCONF_OPENSSL -DCONF_WAVPACK_CLOSE_FILE -DCONF_WAVPACK_OPEN_FILE_INPUT_EX -DGAME_RELEASE_VERSION=\"18.3\" -DGLEW_STATIC -D_FORTIFY_SOURCE=2 -I/builddir/build/BUILD/ddnet-18.3/redhat-linux-build/src -I/builddir/build/BUILD/ddnet-18.3/src -I/builddir/build/BUILD/ddnet-18.3/src/rust-bridge -isystem /usr/include/freetype2 -isystem /usr/include/opus -isystem /usr/include/SDL2 -isystem /usr/include/wavpack -isystem /usr/include/gdk-pixbuf-2.0 -isystem /usr/include/glib-2.0 -isystem /usr/lib64/glib-2.0/include -isystem /usr/include/libpng16 -isystem /usr/include/webp -isystem /usr/include/libmount -isystem /usr/include/blkid -isystem /usr/include/sysprof-6 -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64 -march=x86-64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -O2 -g -DNDEBUG -std=c++17 -fdiagnostics-color=always -fstack-protector-strong -fno-exceptions -Wall -Wextra -Wno-psabi -Wno-unused-parameter -Wno-missing-field-initializers -Wno-nullability-completeness -Wduplicated-cond -Wduplicated-branches -Wlogical-op -Wrestrict -Wshadow=global -Wsuggest-override -Wclass-memaccess -MD -MT CMakeFiles/game-client.dir/src/game/client/components/hud.cpp.o -MF CMakeFiles/game-client.dir/src/game/client/components/hud.cpp.o.d -o CMakeFiles/game-client.dir/src/game/client/components/hud.cpp.o -c /builddir/build/BUILD/ddnet-18.3/src/game/client/components/hud.cpp In file included from /builddir/build/BUILD/ddnet-18.3/src/engine/graphics.h:10,
                 from /builddir/build/BUILD/ddnet-18.3/src/game/client/components/hud.cpp:3:
/builddir/build/BUILD/ddnet-18.3/src/base/system.h: In instantiation of ‘int str_format_opt(char*, int, const char*, Args ...) [with Args = {}]’:
/builddir/build/BUILD/ddnet-18.3/src/game/client/components/hud.cpp:1623:13:   required from here
 1623 |                 str_format(aBuf, sizeof(aBuf), Localize("Server best:"));
/builddir/build/BUILD/ddnet-18.3/src/base/system.h:1238:26: error: format not a string literal and no format arguments [-Werror=format-security]
 1238 |         return str_format(buffer, buffer_size, format, args...);
      |                ~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1plus: note: unrecognized command-line option ‘-Wno-nullability-completeness’ may have been intended to silence earlier diagnostics
cc1plus: some warnings being treated as errors
```

What is the motivation for the changes of this pull request? 

Fix builds on Fedora package

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->


## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
