### PR TITLE
Fix browser not refreshing if `ui_page` is changed in start menu, refresh LAN tab after starting/stopping local server

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -2354,9 +2354,15 @@ void CMenus::SetMenuPage(int NewPage)
 	if(NewPage >= PAGE_INTERNET && NewPage <= PAGE_FAVORITE_COMMUNITY_5)
 	{
 		g_Config.m_UiPage = NewPage;
-		if(OldPage != NewPage)
+		bool ForceRefresh = false;
+		if(m_ForceRefreshLanPage)
 		{
-			RefreshBrowserTab(false);
+			ForceRefresh = NewPage == PAGE_LAN;
+			m_ForceRefreshLanPage = false;
+		}
+		if(OldPage != NewPage || ForceRefresh)
+		{
+			RefreshBrowserTab(ForceRefresh);
 		}
 	}
 }

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -2354,7 +2354,7 @@ void CMenus::SetMenuPage(int NewPage)
 	if(NewPage >= PAGE_INTERNET && NewPage <= PAGE_FAVORITE_COMMUNITY_5)
 	{
 		g_Config.m_UiPage = NewPage;
-		if(!m_ShowStart && OldPage != NewPage)
+		if(OldPage != NewPage)
 		{
 			RefreshBrowserTab(false);
 		}

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -170,6 +170,7 @@ protected:
 
 	bool m_JoinTutorial = false;
 	bool m_CreateDefaultFavoriteCommunities = false;
+	bool m_ForceRefreshLanPage = false;
 
 	char m_aNextServer[256];
 

--- a/src/game/client/components/menus_start.cpp
+++ b/src/game/client/components/menus_start.cpp
@@ -285,8 +285,8 @@ void CMenus::RenderStartMenu(CUIRect MainView)
 
 	if(NewPage != -1)
 	{
-		m_MenuPage = NewPage;
 		m_ShowStart = false;
+		SetMenuPage(NewPage);
 	}
 }
 

--- a/src/game/client/components/menus_start.cpp
+++ b/src/game/client/components/menus_start.cpp
@@ -155,6 +155,7 @@ void CMenus::RenderStartMenu(CUIRect MainView)
 			if(str_find(aBuf, "/") == 0 || fs_is_file(aBuf))
 			{
 				m_ServerProcess.m_Process = shell_execute(aBuf, EShellExecuteWindowState::BACKGROUND);
+				m_ForceRefreshLanPage = true;
 			}
 			else
 			{
@@ -297,6 +298,7 @@ void CMenus::KillServer()
 		if(kill_process(m_ServerProcess.m_Process))
 		{
 			m_ServerProcess.m_Process = INVALID_PROCESS;
+			m_ForceRefreshLanPage = true;
 		}
 	}
 }


### PR DESCRIPTION
When changing `ui_page` via the console while the start menu is active, the browser tab was not refreshed when clicking the Play-button, leading to the old server list being shown for the new browser tab.

After starting/stopping the local server from the main menu, refresh the LAN tab on its next activation, so it immediately shows/hides the started/stopped server without needing a manual refresh.

This is not a perfect solution, as the server would not show up when activating the LAN tab immediately after starting the server, because the server needs some time before it will respond to server info requests, but this works well enough unless the hotkeys are used.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
