### PR TITLE
Add tests for snapshot crc overflow

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2804,6 +2804,7 @@ if(GTEST_FOUND OR DOWNLOAD_GTEST)
     secure_random.cpp
     serverbrowser.cpp
     serverinfo.cpp
+    snapshot.cpp
     str.cpp
     strip_path_and_extension.cpp
     swap_endian.cpp

--- a/src/test/snapshot.cpp
+++ b/src/test/snapshot.cpp
@@ -1,0 +1,85 @@
+#include <gtest/gtest.h>
+
+#include <base/system.h>
+#include <engine/shared/snapshot.h>
+#include <game/generated/protocol.h>
+
+TEST(Snapshot, CrcOneInt)
+{
+	CSnapshotBuilder Builder;
+	Builder.Init();
+
+	CNetObj_Flag Flag;
+	void *pItem = Builder.NewItem(CNetObj_Flag::ms_MsgId, 0, sizeof(Flag));
+	ASSERT_FALSE(pItem == nullptr);
+	Flag.m_X = 4;
+	Flag.m_Y = 0;
+	Flag.m_Team = 0;
+	mem_copy(pItem, &Flag, sizeof(Flag));
+
+	char aData[CSnapshot::MAX_SIZE];
+	CSnapshot *pSnapshot = (CSnapshot *)aData;
+	Builder.Finish(pSnapshot);
+
+	ASSERT_EQ(pSnapshot->Crc(), 4);
+}
+
+TEST(Snapshot, CrcTwoInts)
+{
+	CSnapshotBuilder Builder;
+	Builder.Init();
+
+	CNetObj_Flag Flag;
+	void *pItem = Builder.NewItem(CNetObj_Flag::ms_MsgId, 0, sizeof(Flag));
+	ASSERT_FALSE(pItem == nullptr);
+	Flag.m_X = 1;
+	Flag.m_Y = 1;
+	Flag.m_Team = 0;
+	mem_copy(pItem, &Flag, sizeof(Flag));
+
+	char aData[CSnapshot::MAX_SIZE];
+	CSnapshot *pSnapshot = (CSnapshot *)aData;
+	Builder.Finish(pSnapshot);
+
+	ASSERT_EQ(pSnapshot->Crc(), 2);
+}
+
+TEST(Snapshot, CrcBiggerInts)
+{
+	CSnapshotBuilder Builder;
+	Builder.Init();
+
+	CNetObj_Flag Flag;
+	void *pItem = Builder.NewItem(CNetObj_Flag::ms_MsgId, 0, sizeof(Flag));
+	ASSERT_FALSE(pItem == nullptr);
+	Flag.m_X = 99999999;
+	Flag.m_Y = 1;
+	Flag.m_Team = 1;
+	mem_copy(pItem, &Flag, sizeof(Flag));
+
+	char aData[CSnapshot::MAX_SIZE];
+	CSnapshot *pSnapshot = (CSnapshot *)aData;
+	Builder.Finish(pSnapshot);
+
+	ASSERT_EQ(pSnapshot->Crc(), 100000001);
+}
+
+TEST(Snapshot, CrcOverflow)
+{
+	CSnapshotBuilder Builder;
+	Builder.Init();
+
+	CNetObj_Flag Flag;
+	void *pItem = Builder.NewItem(CNetObj_Flag::ms_MsgId, 0, sizeof(Flag));
+	ASSERT_FALSE(pItem == nullptr);
+	Flag.m_X = 0xFFFFFFFF;
+	Flag.m_Y = 1;
+	Flag.m_Team = 1;
+	mem_copy(pItem, &Flag, sizeof(Flag));
+
+	char aData[CSnapshot::MAX_SIZE];
+	CSnapshot *pSnapshot = (CSnapshot *)aData;
+	Builder.Finish(pSnapshot);
+
+	ASSERT_EQ(pSnapshot->Crc(), 1);
+}


### PR DESCRIPTION
If there are too many snap items with too high values the crc will overflow. If that overflow differs from client to server the client will drop the snapshot and it will cause lags. This test case should help staying compatible with other implementations such as the one from teeworlds which does not use an unsigned int but a regular int. And it also helps spot this rare issue faster on machines where `unsigned int` has a different size than 4 byte.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
