### PR TITLE
Add `sv_dnsbl_ban_reason`, increase maximum ban reason length

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -2888,9 +2888,10 @@ int CServer::Run()
 						}
 					}
 
-					if(m_aClients[ClientId].m_DnsblState == CClient::DNSBL_STATE_BLACKLISTED &&
-						Config()->m_SvDnsblBan)
-						m_NetServer.NetBan()->BanAddr(m_NetServer.ClientAddr(ClientId), 60 * 10, "VPN detected, try connecting without. Contact admin if mistaken");
+					if(m_aClients[ClientId].m_DnsblState == CClient::DNSBL_STATE_BLACKLISTED && Config()->m_SvDnsblBan)
+					{
+						m_NetServer.NetBan()->BanAddr(m_NetServer.ClientAddr(ClientId), 60 * 10, Config()->m_SvDnsblBanReason);
+					}
 				}
 			}
 

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -395,6 +395,7 @@ MACRO_CONFIG_STR(SvDnsblHost, sv_dnsbl_host, 128, "", CFGFLAG_SERVER, "Hostname 
 MACRO_CONFIG_STR(SvDnsblKey, sv_dnsbl_key, 128, "", CFGFLAG_SERVER | CFGFLAG_NONTEEHISTORIC, "Optional Authentication Key for the specified DNSBL provider")
 MACRO_CONFIG_INT(SvDnsblVote, sv_dnsbl_vote, 0, 0, 1, CFGFLAG_SERVER, "Block votes by blacklisted addresses")
 MACRO_CONFIG_INT(SvDnsblBan, sv_dnsbl_ban, 0, 0, 1, CFGFLAG_SERVER, "Automatically ban blacklisted addresses")
+MACRO_CONFIG_STR(SvDnsblBanReason, sv_dnsbl_ban_reason, 128, "VPN detected, try connecting without. Contact admin if mistaken", CFGFLAG_SERVER, "Ban reason for 'sv_dnsbl_ban'")
 MACRO_CONFIG_INT(SvDnsblChat, sv_dnsbl_chat, 0, 0, 1, CFGFLAG_SERVER, "Don't allow chat from blacklisted addresses")
 MACRO_CONFIG_INT(SvRconVote, sv_rcon_vote, 0, 0, 1, CFGFLAG_SERVER, "Only allow authed clients to call votes")
 

--- a/src/engine/shared/netban.cpp
+++ b/src/engine/shared/netban.cpp
@@ -231,7 +231,7 @@ int CNetBan::Ban(T *pBanPool, const typename T::CDataType *pData, int Seconds, c
 	{
 		// adjust the ban
 		pBanPool->Update(pBan, &Info);
-		char aBuf[128];
+		char aBuf[256];
 		MakeBanInfo(pBan, aBuf, sizeof(aBuf), MSGTYPE_LIST);
 		Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "net_ban", aBuf);
 		return 1;
@@ -241,7 +241,7 @@ int CNetBan::Ban(T *pBanPool, const typename T::CDataType *pData, int Seconds, c
 	pBan = pBanPool->Add(pData, &Info, &NetHash);
 	if(pBan)
 	{
-		char aBuf[128];
+		char aBuf[256];
 		MakeBanInfo(pBan, aBuf, sizeof(aBuf), MSGTYPE_BANADD);
 		Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "net_ban", aBuf);
 		return 0;

--- a/src/engine/shared/netban.h
+++ b/src/engine/shared/netban.h
@@ -77,7 +77,7 @@ protected:
 		enum
 		{
 			EXPIRES_NEVER = -1,
-			REASON_LENGTH = 64,
+			REASON_LENGTH = 128,
 		};
 		int64_t m_Expires;
 		char m_aReason[REASON_LENGTH];

--- a/src/engine/shared/network_conn.cpp
+++ b/src/engine/shared/network_conn.cpp
@@ -321,10 +321,10 @@ int CNetConnection::Feed(CNetPacketConstruct *pPacket, NETADDR *pAddr, SECURITY_
 				m_State = NET_CONNSTATE_ERROR;
 				m_RemoteClosed = 1;
 
-				char aStr[128] = {0};
+				char aStr[256] = {0};
 				if(pPacket->m_DataSize > 1)
 				{
-					// make sure to sanitize the error string form the other party
+					// make sure to sanitize the error string from the other party
 					str_copy(aStr, (char *)&pPacket->m_aChunkData[1], minimum(pPacket->m_DataSize, (int)sizeof(aStr)));
 					str_sanitize_cc(aStr);
 				}
@@ -455,7 +455,7 @@ int CNetConnection::Update()
 		if(Now - pResend->m_FirstSendTime > time_freq() * g_Config.m_ConnTimeout)
 		{
 			m_State = NET_CONNSTATE_ERROR;
-			char aBuf[512];
+			char aBuf[128];
 			str_format(aBuf, sizeof(aBuf), "Too weak connection (not acked for %d seconds)", g_Config.m_ConnTimeout);
 			SetError(aBuf);
 			m_TimeoutSituation = true;


### PR DESCRIPTION
Add `sv_dnsbl_ban_reason` config variable with size 128 to specify the ban reason for `sv_dnsbl_ban`.

Increase the maximum size for ban reasons on the server from 64 to 128 to support this new config variable. Adjust buffer sizes for formatting ban messages accordingly.

Additionally, increase the size of the buffer for unpacking the connection closed message from 128 to 256. Due to this limitation, old clients will see truncated disconnect messages if the entire message is longer than 127, which can now happen with long ban reasons as the ban message additionally contains the duration (e.g. `You have been banned for 10 minutes (Reason)`).

Closes #8518.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
