### PR TITLE
Fix warning non-canonical implementation of  on an Ord  type in rust.rs

### DIFF
--- a/src/base/rust.rs
+++ b/src/base/rust.rs
@@ -230,7 +230,7 @@ impl<'a> cmp::PartialEq<&'a str> for StrRef<'a> {
 
 impl<'a> cmp::PartialOrd for StrRef<'a> {
     fn partial_cmp(&self, other: &StrRef<'a>) -> Option<cmp::Ordering> {
-        self.to_str().partial_cmp(other.to_str())
+        Some(self.to_str().cmp(other.to_str()))
     }
 }
 


### PR DESCRIPTION
https://rust-lang.github.io/rust-clippy/master/index.html#/incorrect_partial_ord_impl_on_ord_type

Why is this bad?

If both PartialOrd and Ord are implemented, they must agree. This is commonly done by wrapping the result of cmp in Some for partial_cmp. Not doing this may silently introduce an error upon refactoring.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
