### PR TITLE
Fix rustup toolchain overrides not working with MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -911,6 +911,7 @@ else()
   endif()
 endif()
 list(APPEND CARGO_BUILD $<$<NOT:$<CONFIG:Debug>>:--release>)
+list(APPEND CARGO_BUILD --manifest-path "${PROJECT_SOURCE_DIR}/Cargo.toml")
 
 if(CMAKE_OSX_ARCHITECTURES)
   set(RUST_OSX_ARCHITECTURES)
@@ -949,7 +950,7 @@ if(NOT CMAKE_OSX_ARCHITECTURES)
   add_custom_command(
     OUTPUT ${RUST_OUTPUTS}
     COMMAND ${CARGO_BUILD}
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+    WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
     USES_TERMINAL
     DEPENDS ${RUST_SRC}
   )
@@ -982,7 +983,7 @@ else()
     add_custom_command(
       OUTPUT ${RUST_OUTPUTS}
       COMMAND ${CARGO_BUILD} --target=${arch}
-      WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+      WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
       USES_TERMINAL
       DEPENDS ${RUST_SRC}
     )


### PR DESCRIPTION
Use the build folder as the working directory for the cargo build so rustup overrides of individual build folders are respected.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
