### PR TITLE
Fix integer overflow when computing tilemap size

### DIFF
--- a/src/engine/shared/map.cpp
+++ b/src/engine/shared/map.cpp
@@ -106,8 +106,17 @@ bool CMap::Load(const char *pMapName)
 				CMapItemLayerTilemap *pTilemap = reinterpret_cast<CMapItemLayerTilemap *>(pLayer);
 				if(pTilemap->m_Version >= CMapItemLayerTilemap::TILE_SKIP_MIN_VERSION)
 				{
-					const size_t TilemapSize = (size_t)pTilemap->m_Width * pTilemap->m_Height * sizeof(CTile);
+					const size_t TilemapCount = (size_t)pTilemap->m_Width * pTilemap->m_Height;
+					const size_t TilemapSize = TilemapCount * sizeof(CTile);
+
+					if(((int)TilemapCount / pTilemap->m_Width != pTilemap->m_Height) || (TilemapSize / sizeof(CTile) != TilemapCount))
+					{
+						log_error("map/load", "map layer too big (%d * %d * %d causes an integer overflow)", pTilemap->m_Width, pTilemap->m_Height, sizeof(CTile));
+						return false;
+					}
 					CTile *pTiles = static_cast<CTile *>(malloc(TilemapSize));
+					if(!pTiles)
+						return false;
 					ExtractTiles(pTiles, (size_t)pTilemap->m_Width * pTilemap->m_Height, static_cast<CTile *>(NewDataFile.GetData(pTilemap->m_Data)), NewDataFile.GetDataSize(pTilemap->m_Data) / sizeof(CTile));
 					NewDataFile.ReplaceData(pTilemap->m_Data, reinterpret_cast<char *>(pTiles), TilemapSize);
 				}


### PR DESCRIPTION
Cherry-picked from https://github.com/teeworlds/teeworlds/pull/2076/commits/d25869626a8cfbdd320929ba93ce73abed1402ce

Thanks to Charly Reux for notifying us.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
