### PR TITLE
Improve clang variable naming checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -111,8 +111,18 @@ CheckOptions:
     value:           CamelCase
   - key:             readability-identifier-naming.ClassMemberCase
     value:           CamelCase
-  - key:             readability-identifier-naming.ClassMemberPrefix
+  - key:             readability-identifier-naming.MemberCase
+    value:           CamelCase
+  - key:             readability-identifier-naming.MemberPrefix
     value:           m_
+  - key:             readability-identifier-naming.MemberIgnoredRegexp
+    value:           '^(m_ap|m_v|m_p|m_a|ms_p|[a-z]$).*'
+  - key:             readability-identifier-naming.ClassMemberPrefix
+    value:           ms_
+  - key:             readability-identifier-naming.StaticVariablePrefix
+    value:           s_
+  - key:             readability-identifier-naming.StaticVariableIgnoredRegexp
+    value:           '^(NullAddr$|aDummyNameBuf$|aModifier$|EXPLANATION$|LocalClientId$|Dir$|LOCATION_NAMES$|EditorHotkeyWasPressed$|EditorHotKeyChecktime$|FrictionFraction$|LastTime$|SkidSoundTime$|NewVal$|aRotated$).*'
   - key:             readability-identifier-naming.ClassMethodCase
     value:           CamelCase
   - key:             readability-identifier-naming.ClassCase
@@ -132,7 +142,7 @@ CheckOptions:
   - key:             readability-identifier-naming.ClassMethodIgnoredRegexp
     value:           '^(Con_).*'
   - key:             readability-identifier-naming.ClassMemberIgnoredRegexp
-    value:           '^(ms_aStandardScreen$|s_1024x1024ImgSize$|s_ImageBufferCacheId$|s_VertexBufferCacheId$|s_StagingBufferImageCacheId$|REPLACEMENT_CHARACTER$|(MAX|MIN)_FONT_SIZE$|MAXIMUM_ATLAS_DIMENSION$|INITIAL_ATLAS_DIMENSION$|MAX_SECTION_DIMENSION_MAPPED$|MIN_SECTION_DIMENSION$|s_StagingBufferCacheId$|ms_MainThreadIndex$).*'
+    value:           '^(m_a|m_v|m_p|ms_p|ms_a|ms_v|s_1024x1024ImgSize$|s_ImageBufferCacheId$|s_VertexBufferCacheId$|s_StagingBufferImageCacheId$|REPLACEMENT_CHARACTER$|(MAX|MIN)_FONT_SIZE$|MAXIMUM_ATLAS_DIMENSION$|INITIAL_ATLAS_DIMENSION$|MAX_SECTION_DIMENSION_MAPPED$|MIN_SECTION_DIMENSION$|s_StagingBufferCacheId$).*'
   - key:             readability-identifier-naming.LocalConstantIgnoredRegexp
     value:           '^(p|a|v|s_|MAX_ANIM_SPEED$|DATA_OFFSET$|HEADER_LEN$|MIN_ANIM_SPEED$|[hwdcbqstf]$|[xt][0123]$|result$|sub$|it$|len$|d[xy]$).*'
   - key:             readability-identifier-naming.LocalVariableIgnoredRegexp

--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -739,11 +739,11 @@ void CServerBrowser::SetInfo(CServerEntry *pEntry, const CServerInfo &Info) cons
 
 	class CPlayerScoreNameLess
 	{
-		const int ScoreKind;
+		const int m_ScoreKind;
 
 	public:
 		CPlayerScoreNameLess(int ClientScoreKind) :
-			ScoreKind(ClientScoreKind)
+			m_ScoreKind(ClientScoreKind)
 		{
 		}
 
@@ -758,7 +758,7 @@ void CServerBrowser::SetInfo(CServerEntry *pEntry, const CServerInfo &Info) cons
 			int Score0 = p0.m_Score;
 			int Score1 = p1.m_Score;
 
-			if(ScoreKind == CServerInfo::CLIENT_SCORE_KIND_TIME || ScoreKind == CServerInfo::CLIENT_SCORE_KIND_TIME_BACKCOMPAT)
+			if(m_ScoreKind == CServerInfo::CLIENT_SCORE_KIND_TIME || m_ScoreKind == CServerInfo::CLIENT_SCORE_KIND_TIME_BACKCOMPAT)
 			{
 				// Sort unfinished (-9999) and still connecting players (-1) after others
 				if(Score0 < 0 && Score1 >= 0)
@@ -770,7 +770,7 @@ void CServerBrowser::SetInfo(CServerEntry *pEntry, const CServerInfo &Info) cons
 			if(Score0 != Score1)
 			{
 				// Handle the sign change introduced with CLIENT_SCORE_KIND_TIME
-				if(ScoreKind == CServerInfo::CLIENT_SCORE_KIND_TIME)
+				if(m_ScoreKind == CServerInfo::CLIENT_SCORE_KIND_TIME)
 					return Score0 < Score1;
 				else
 					return Score0 > Score1;

--- a/src/game/client/components/race_demo.cpp
+++ b/src/game/client/components/race_demo.cpp
@@ -29,7 +29,7 @@ struct CDemoListParam
 {
 	const CRaceDemo *m_pThis;
 	std::vector<CDemoItem> *m_pvDemos;
-	const char *pMap;
+	const char *m_pMap;
 };
 
 CRaceDemo::CRaceDemo() :
@@ -203,8 +203,8 @@ int CRaceDemo::RaceDemolistFetchCallback(const CFsFileInfo *pInfo, int IsDir, in
 {
 	auto *pRealUser = (SRaceDemoFetchUser *)pUser;
 	auto *pParam = pRealUser->m_pParam;
-	int MapLen = str_length(pParam->pMap);
-	if(IsDir || !str_endswith(pInfo->m_pName, ".demo") || !str_startswith(pInfo->m_pName, pParam->pMap) || pInfo->m_pName[MapLen] != '_')
+	int MapLen = str_length(pParam->m_pMap);
+	if(IsDir || !str_endswith(pInfo->m_pName, ".demo") || !str_startswith(pInfo->m_pName, pParam->m_pMap) || pInfo->m_pName[MapLen] != '_')
 		return 0;
 
 	CDemoItem Item;


### PR DESCRIPTION
Introduces checks for more variable types.
And fixes false positives in newer clang versions.

