### PR TITLE
Faster /rank

### DIFF
--- a/src/test/score.cpp
+++ b/src/test/score.cpp
@@ -167,7 +167,7 @@ TEST_P(SingleScore, RankRegional)
 {
 	g_Config.m_SvRegionalRankings = true;
 	ASSERT_FALSE(CScoreWorker::ShowRank(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
-	ExpectLines(m_pPlayerResult, {"nameless tee - 01:40.00 - better than 100% - requested by brainless tee", "Global rank 1 - GER unranked"}, true);
+	ExpectLines(m_pPlayerResult, {"nameless tee - 01:40.00 - better than 100% - requested by brainless tee", "Global rank 1 - GER rank 1"}, true);
 }
 
 TEST_P(SingleScore, Rank)


### PR DESCRIPTION
with an uglier query that works in both MySQL and SQLite.

Test query in MariaDB, old:
```
MariaDB [teeworlds]> SELECT Ranking, Time, PercentRank FROM (  SELECT RANK() OVER w AS Ranking, PERCENT_RANK() OVER w as PercentRank, MIN(Time) AS Time, Name   FROM record_race   WHERE Map = 'Multeasymap'   AND Server LIKE '%'   GROUP BY Name   WINDOW w AS (ORDER BY MIN(Time))) as a WHERE Name = 'deen';
+---------+--------+--------------+
| Ranking | Time   | PercentRank  |
+---------+--------+--------------+
|   29792 | 676.88 | 0.1032216263 |
+---------+--------+--------------+
1 row in set (11.346 sec)

MariaDB [teeworlds]> SELECT Ranking, Time, PercentRank FROM (  SELECT RANK() OVER w AS Ranking, PERCENT_RANK() OVER w as PercentRank, MIN(Time) AS Time, Name   FROM record_race   WHERE Map = 'Multeasymap'   AND Server LIKE '%'   GROUP BY Name   WINDOW w AS (ORDER BY MIN(Time))) as a WHERE Name = 'deen';
+---------+--------+--------------+
| Ranking | Time   | PercentRank  |
+---------+--------+--------------+
|   29792 | 676.88 | 0.1032216263 |
+---------+--------+--------------+
1 row in set (12.344 sec)
```
New:
```
MariaDB [teeworlds]> SELECT count(distinct Name) + 1 AS Ranking,        (SELECT min(Time) FROM record_race WHERE Map = 'Multeasymap' and Server like '%' and Name = 'deen') as MinTime,        count(distinct Name)
/ (SELECT count(distinct Name) AS countAll FROM record_race WHERE Map = 'Multeasymap' and Server like '%') AS PercentRank FROM record_race WHERE Map = 'Multeasymap' and Time < (SELECT min(Time) FROM record_race WHERE Map = 'Multeasymap' and Server like '%' and Name = 'deen') and Server like '%';
+---------+---------+-------------+
| Ranking | MinTime | PercentRank |
+---------+---------+-------------+
|   29792 |  676.88 |      0.1032 |
+---------+---------+-------------+
1 row in set (1.399 sec)

MariaDB [teeworlds]> SELECT count(distinct Name) + 1 AS Ranking,        (SELECT min(Time) FROM record_race WHERE Map = 'Multeasymap' and Server like '%' and Name = 'deen') as MinTime,        count(distinct Name)
/ (SELECT count(distinct Name) AS countAll FROM record_race WHERE Map = 'Multeasymap' and Server like '%') AS PercentRank FROM record_race WHERE Map = 'Multeasymap' and Time < (SELECT min(Time) FROM record_race WHERE Map = 'Multeasymap' and Server like '%' and Name = 'deen') and Server like '%';
+---------+---------+-------------+
| Ranking | MinTime | PercentRank |
+---------+---------+-------------+
|   29792 |  676.88 |      0.1032 |
+---------+---------+-------------+
1 row in set (1.556 sec)
```

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
