### PR TITLE
Improve `map_extract` tool: fix crash when opus file cannot be opened, improve logging, refactoring

### DIFF
--- a/src/tools/map_extract.cpp
+++ b/src/tools/map_extract.cpp
@@ -59,6 +59,7 @@ bool Process(IStorage *pStorage, const char *pMapName, const char *pPathSave)
 
 		char aBuf[IO_MAX_PATH_LENGTH];
 		str_format(aBuf, sizeof(aBuf), "%s/%s.png", pPathSave, pName);
+		Reader.UnloadData(pItem->m_ImageName);
 
 		if(pItem->m_Version >= 2 && pItem->m_MustBe1 != 1)
 		{
@@ -77,6 +78,7 @@ bool Process(IStorage *pStorage, const char *pMapName, const char *pPathSave)
 			if(SavePng(IMAGE_FORMAT_RGBA, (const uint8_t *)Reader.GetData(pItem->m_ImageData), ImageByteBuffer, pItem->m_Width, pItem->m_Height))
 				io_write(File, &ByteBuffer.front(), ByteBuffer.size());
 			io_close(File);
+			Reader.UnloadData(pItem->m_ImageData);
 		}
 		else
 		{
@@ -103,6 +105,7 @@ bool Process(IStorage *pStorage, const char *pMapName, const char *pPathSave)
 		const int SoundDataSize = Reader.GetDataSize(pItem->m_SoundData);
 		char aBuf[IO_MAX_PATH_LENGTH];
 		str_format(aBuf, sizeof(aBuf), "%s/%s.opus", pPathSave, pName);
+		Reader.UnloadData(pItem->m_SoundName);
 
 		IOHANDLE Opus = io_open(aBuf, IOFLAG_WRITE);
 		if(Opus)
@@ -110,6 +113,7 @@ bool Process(IStorage *pStorage, const char *pMapName, const char *pPathSave)
 			log_info("map_extract", "writing sound: %s (%d B)", aBuf, SoundDataSize);
 			io_write(Opus, Reader.GetData(pItem->m_SoundData), SoundDataSize);
 			io_close(Opus);
+			Reader.UnloadData(pItem->m_SoundData);
 		}
 		else
 		{

--- a/src/tools/map_extract.cpp
+++ b/src/tools/map_extract.cpp
@@ -12,31 +12,31 @@ bool Process(IStorage *pStorage, const char *pMapName, const char *pPathSave)
 	CDataFileReader Reader;
 	if(!Reader.Open(pStorage, pMapName, IStorage::TYPE_ABSOLUTE))
 	{
-		dbg_msg("map_extract", "error opening map '%s'", pMapName);
+		log_error("map_extract", "error opening map '%s'", pMapName);
 		return false;
 	}
 
 	const CMapItemVersion *pVersion = static_cast<CMapItemVersion *>(Reader.FindItem(MAPITEMTYPE_VERSION, 0));
 	if(pVersion == nullptr || pVersion->m_Version != CMapItemVersion::CURRENT_VERSION)
 	{
-		dbg_msg("map_extract", "unsupported map version '%s'", pMapName);
+		log_error("map_extract", "unsupported map version '%s'", pMapName);
 		return false;
 	}
 
-	dbg_msg("map_extract", "Make sure you have the permission to use these images and sounds in your own maps");
+	log_info("map_extract", "Make sure you have the permission to use these images and sounds in your own maps");
 
 	CMapItemInfo *pInfo = (CMapItemInfo *)Reader.FindItem(MAPITEMTYPE_INFO, 0);
 
 	if(pInfo)
 	{
 		const char *pAuthor = Reader.GetDataString(pInfo->m_Author);
-		dbg_msg("map_extract", "author:  %s", pAuthor == nullptr ? "(error)" : pAuthor);
+		log_info("map_extract", "author:  %s", pAuthor == nullptr ? "(error)" : pAuthor);
 		const char *pMapVersion = Reader.GetDataString(pInfo->m_MapVersion);
-		dbg_msg("map_extract", "version: %s", pMapVersion == nullptr ? "(error)" : pMapVersion);
+		log_info("map_extract", "version: %s", pMapVersion == nullptr ? "(error)" : pMapVersion);
 		const char *pCredits = Reader.GetDataString(pInfo->m_Credits);
-		dbg_msg("map_extract", "credits: %s", pCredits == nullptr ? "(error)" : pCredits);
+		log_info("map_extract", "credits: %s", pCredits == nullptr ? "(error)" : pCredits);
 		const char *pLicense = Reader.GetDataString(pInfo->m_License);
-		dbg_msg("map_extract", "license: %s", pLicense == nullptr ? "(error)" : pLicense);
+		log_info("map_extract", "license: %s", pLicense == nullptr ? "(error)" : pLicense);
 	}
 
 	int Start, Num;
@@ -53,13 +53,12 @@ bool Process(IStorage *pStorage, const char *pMapName, const char *pPathSave)
 		const char *pName = Reader.GetDataString(pItem->m_ImageName);
 		if(pName == nullptr || pName[0] == '\0')
 		{
-			dbg_msg("map_extract", "failed to load name of image %d", i);
+			log_error("map_extract", "failed to load name of image %d", i);
 			continue;
 		}
 
 		char aBuf[IO_MAX_PATH_LENGTH];
 		str_format(aBuf, sizeof(aBuf), "%s/%s.png", pPathSave, pName);
-		dbg_msg("map_extract", "writing image: %s (%dx%d)", aBuf, pItem->m_Width, pItem->m_Height);
 
 		if(pItem->m_Version >= 2 && pItem->m_MustBe1 != 1)
 		{
@@ -71,12 +70,17 @@ bool Process(IStorage *pStorage, const char *pMapName, const char *pPathSave)
 		IOHANDLE File = io_open(aBuf, IOFLAG_WRITE);
 		if(File)
 		{
+			log_info("map_extract", "writing image: %s (%dx%d)", aBuf, pItem->m_Width, pItem->m_Height);
 			TImageByteBuffer ByteBuffer;
 			SImageByteBuffer ImageByteBuffer(&ByteBuffer);
 
 			if(SavePng(IMAGE_FORMAT_RGBA, (const uint8_t *)Reader.GetData(pItem->m_ImageData), ImageByteBuffer, pItem->m_Width, pItem->m_Height))
 				io_write(File, &ByteBuffer.front(), ByteBuffer.size());
 			io_close(File);
+		}
+		else
+		{
+			log_error("map_extract", "failed to open image file for writing. filename='%s'", aBuf);
 		}
 	}
 
@@ -92,20 +96,24 @@ bool Process(IStorage *pStorage, const char *pMapName, const char *pPathSave)
 		const char *pName = Reader.GetDataString(pItem->m_SoundName);
 		if(pName == nullptr || pName[0] == '\0')
 		{
-			dbg_msg("map_extract", "failed to load name of sound %d", i);
+			log_error("map_extract", "failed to load name of sound %d", i);
 			continue;
 		}
 
 		const int SoundDataSize = Reader.GetDataSize(pItem->m_SoundData);
 		char aBuf[IO_MAX_PATH_LENGTH];
 		str_format(aBuf, sizeof(aBuf), "%s/%s.opus", pPathSave, pName);
-		dbg_msg("map_extract", "writing sound: %s (%d B)", aBuf, SoundDataSize);
 
 		IOHANDLE Opus = io_open(aBuf, IOFLAG_WRITE);
 		if(Opus)
 		{
+			log_info("map_extract", "writing sound: %s (%d B)", aBuf, SoundDataSize);
 			io_write(Opus, Reader.GetData(pItem->m_SoundData), SoundDataSize);
 			io_close(Opus);
+		}
+		else
+		{
+			log_error("map_extract", "failed to open sound file for writing. filename='%s'", aBuf);
 		}
 	}
 
@@ -132,13 +140,13 @@ int main(int argc, const char *argv[])
 	}
 	else
 	{
-		dbg_msg("usage", "%s map [directory]", argv[0]);
+		log_error("map_extract", "usage: %s <map> [directory]", argv[0]);
 		return -1;
 	}
 
 	if(!fs_is_dir(pDir))
 	{
-		dbg_msg("usage", "directory '%s' does not exist", pDir);
+		log_error("map_extract", "directory '%s' does not exist", pDir);
 		return -1;
 	}
 

--- a/src/tools/map_extract.cpp
+++ b/src/tools/map_extract.cpp
@@ -102,8 +102,11 @@ bool Process(IStorage *pStorage, const char *pMapName, const char *pPathSave)
 		dbg_msg("map_extract", "writing sound: %s (%d B)", aBuf, SoundDataSize);
 
 		IOHANDLE Opus = io_open(aBuf, IOFLAG_WRITE);
-		io_write(Opus, Reader.GetData(pItem->m_SoundData), SoundDataSize);
-		io_close(Opus);
+		if(Opus)
+		{
+			io_write(Opus, Reader.GetData(pItem->m_SoundData), SoundDataSize);
+			io_close(Opus);
+		}
 	}
 
 	return Reader.Close();

--- a/src/tools/map_extract.cpp
+++ b/src/tools/map_extract.cpp
@@ -9,7 +9,7 @@
 
 static void PrintMapInfo(CDataFileReader &Reader)
 {
-	CMapItemInfo *pInfo = (CMapItemInfo *)Reader.FindItem(MAPITEMTYPE_INFO, 0);
+	const CMapItemInfo *pInfo = static_cast<CMapItemInfo *>(Reader.FindItem(MAPITEMTYPE_INFO, 0));
 	if(pInfo)
 	{
 		const char *pAuthor = Reader.GetDataString(pInfo->m_Author);
@@ -29,7 +29,7 @@ static void ExtractMapImages(CDataFileReader &Reader, const char *pPathSave)
 	Reader.GetType(MAPITEMTYPE_IMAGE, &Start, &Num);
 	for(int i = 0; i < Num; i++)
 	{
-		CMapItemImage_v2 *pItem = (CMapItemImage_v2 *)Reader.GetItem(Start + i);
+		const CMapItemImage_v2 *pItem = static_cast<CMapItemImage_v2 *>(Reader.GetItem(Start + i));
 		if(pItem->m_External)
 			continue;
 
@@ -75,7 +75,7 @@ static void ExtractMapSounds(CDataFileReader &Reader, const char *pPathSave)
 	Reader.GetType(MAPITEMTYPE_SOUND, &Start, &Num);
 	for(int i = 0; i < Num; i++)
 	{
-		CMapItemSound *pItem = (CMapItemSound *)Reader.GetItem(Start + i);
+		const CMapItemSound *pItem = static_cast<CMapItemSound *>(Reader.GetItem(Start + i));
 		if(pItem->m_External)
 			continue;
 


### PR DESCRIPTION
See commit messages.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
