### PR TITLE
Fix multiple redirected clients not dropped in the same tick

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -2971,14 +2971,21 @@ int CServer::Run()
 			if(!NonActive)
 				PumpNetwork(PacketWaiting);
 
-			NonActive = true;
-
 			for(int i = 0; i < MAX_CLIENTS; ++i)
 			{
 				if(m_aClients[i].m_State == CClient::STATE_REDIRECTED)
+				{
 					if(time_get() > m_aClients[i].m_RedirectDropTime)
+					{
 						m_NetServer.Drop(i, "redirected");
-				if(m_aClients[i].m_State != CClient::STATE_EMPTY)
+					}
+				}
+			}
+
+			NonActive = true;
+			for(const auto &Client : m_aClients)
+			{
+				if(Client.m_State != CClient::STATE_EMPTY)
 				{
 					NonActive = false;
 					break;


### PR DESCRIPTION
Closes #8551.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
