### PR TITLE
Scoreboard spectator clans

### DIFF
--- a/src/game/client/components/scoreboard.cpp
+++ b/src/game/client/components/scoreboard.cpp
@@ -199,17 +199,39 @@ void CScoreboard::RenderSpectators(CUIRect Spectators)
 			break;
 		}
 
-		if(GameClient()->m_aClients[pInfo->m_ClientId].m_AuthLevel)
-		{
-			TextRender()->TextColor(color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClAuthedPlayerColor)));
-		}
-
 		if(g_Config.m_ClShowIds)
 		{
 			char aClientId[5];
 			str_format(aClientId, sizeof(aClientId), "%d: ", pInfo->m_ClientId);
 			TextRender()->TextEx(&Cursor, aClientId);
 		}
+
+		{
+			const char *pClanName = GameClient()->m_aClients[pInfo->m_ClientId].m_aClan;
+
+			if(pClanName[0] != '\0')
+			{
+				if(str_comp(pClanName, GameClient()->m_aClients[GameClient()->m_aLocalIds[g_Config.m_ClDummy]].m_aClan) == 0)
+				{
+					TextRender()->TextColor(color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClSameClanColor)));
+				}
+				else
+				{
+					TextRender()->TextColor(ColorRGBA(0.7f, 0.7f, 0.7f));
+				}
+
+				TextRender()->TextEx(&Cursor, pClanName);
+				TextRender()->TextEx(&Cursor, " ");
+
+				TextRender()->TextColor(TextRender()->DefaultTextColor());
+			}
+		}
+
+		if(GameClient()->m_aClients[pInfo->m_ClientId].m_AuthLevel)
+		{
+			TextRender()->TextColor(color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClAuthedPlayerColor)));
+		}
+
 		TextRender()->TextEx(&Cursor, GameClient()->m_aClients[pInfo->m_ClientId].m_aName);
 		TextRender()->TextColor(TextRender()->DefaultTextColor());
 


### PR DESCRIPTION
It's quite strange that you have no access for spectators' clan information being actually in-game (scoreboard) and forced to use `Player Info` tab in in-game overlay menu. This PR aims to make access for spectators' clan field easier

![screenshot](https://media.discordapp.net/attachments/1177692308355940413/1260676184543334481/screenshot_2024-07-10_21-55-01.png?ex=66902fb0&is=668ede30&hm=b862c9e26dba81b79e612cdd5b852402615194aef8dd33bfb2bf5b823ef3ee1e&=&format=webp&quality=lossless)

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
