### PR TITLE
Fix incorrect scoreboard size if blue team used without teams flag

### DIFF
--- a/src/game/client/components/scoreboard.cpp
+++ b/src/game/client/components/scoreboard.cpp
@@ -561,7 +561,8 @@ void CScoreboard::OnRender()
 
 	const CNetObj_GameInfo *pGameInfoObj = GameClient()->m_Snap.m_pGameInfoObj;
 	const bool Teams = pGameInfoObj && (pGameInfoObj->m_GameFlags & GAMEFLAG_TEAMS);
-	const int NumPlayers = maximum(GameClient()->m_Snap.m_aTeamSize[TEAM_RED], GameClient()->m_Snap.m_aTeamSize[TEAM_BLUE]);
+	const auto &aTeamSize = GameClient()->m_Snap.m_aTeamSize;
+	const int NumPlayers = Teams ? maximum(aTeamSize[TEAM_RED], aTeamSize[TEAM_BLUE]) : aTeamSize[TEAM_RED];
 
 	const float ScoreboardSmallWidth = 750.0f + 20.0f;
 	const float ScoreboardWidth = !Teams && NumPlayers <= 16 ? ScoreboardSmallWidth : 1500.0f;


### PR DESCRIPTION
When `GAMEFLAG_TEAMS` is not set, only the players of the red team are rendered in the scoreboard, but the size of the scoreboard was incorrectly calculated based on the size of the larger team (red or blue), which should only be done when `GAMEFLAG_TEAMS` is set.

Regression from #8545.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
