### PR TITLE
Cleanup snapshot member variables in `demo_extract_chat` tool

### DIFF
--- a/src/tools/demo_extract_chat.cpp
+++ b/src/tools/demo_extract_chat.cpp
@@ -20,23 +20,17 @@ public:
 	};
 	CClientData m_aClients[MAX_CLIENTS];
 
-	CSnapshotStorage::CHolder m_aDemoSnapshotHolders[IClient::NUM_SNAPSHOT_TYPES];
-	char m_aaaDemoSnapshotData[IClient::NUM_SNAPSHOT_TYPES][2][CSnapshot::MAX_SIZE];
-	CSnapshotStorage::CHolder *m_apSnapshots[IClient::NUM_SNAPSHOT_TYPES];
+	char m_aaDemoSnapshotData[IClient::NUM_SNAPSHOT_TYPES][CSnapshot::MAX_SIZE];
+	CSnapshot *m_apAltSnapshots[IClient::NUM_SNAPSHOT_TYPES];
 
 	CClientSnapshotHandler() :
-		m_aClients(), m_aDemoSnapshotHolders()
+		m_aClients()
 	{
-		mem_zero(m_aaaDemoSnapshotData, sizeof(m_aaaDemoSnapshotData));
+		mem_zero(m_aaDemoSnapshotData, sizeof(m_aaDemoSnapshotData));
 
 		for(int SnapshotType = 0; SnapshotType < IClient::NUM_SNAPSHOT_TYPES; SnapshotType++)
 		{
-			m_apSnapshots[SnapshotType] = &m_aDemoSnapshotHolders[SnapshotType];
-			m_apSnapshots[SnapshotType]->m_pSnap = (CSnapshot *)&m_aaaDemoSnapshotData[SnapshotType][0];
-			m_apSnapshots[SnapshotType]->m_pAltSnap = (CSnapshot *)&m_aaaDemoSnapshotData[SnapshotType][1];
-			m_apSnapshots[SnapshotType]->m_SnapSize = 0;
-			m_apSnapshots[SnapshotType]->m_AltSnapSize = 0;
-			m_apSnapshots[SnapshotType]->m_Tick = -1;
+			m_apAltSnapshots[SnapshotType] = (CSnapshot *)&m_aaDemoSnapshotData[SnapshotType];
 		}
 	}
 
@@ -74,17 +68,15 @@ public:
 	int SnapNumItems(int SnapId)
 	{
 		dbg_assert(SnapId >= 0 && SnapId < IClient::NUM_SNAPSHOT_TYPES, "invalid SnapId");
-		if(!m_apSnapshots[SnapId])
-			return 0;
-		return m_apSnapshots[SnapId]->m_pAltSnap->NumItems();
+		return m_apAltSnapshots[SnapId]->NumItems();
 	}
 
 	void *SnapGetItem(int SnapId, int Index, IClient::CSnapItem *pItem)
 	{
 		dbg_assert(SnapId >= 0 && SnapId < IClient::NUM_SNAPSHOT_TYPES, "invalid SnapId");
-		const CSnapshotItem *pSnapshotItem = m_apSnapshots[SnapId]->m_pAltSnap->GetItem(Index);
-		pItem->m_DataSize = m_apSnapshots[SnapId]->m_pAltSnap->GetItemSize(Index);
-		pItem->m_Type = m_apSnapshots[SnapId]->m_pAltSnap->GetItemType(Index);
+		const CSnapshotItem *pSnapshotItem = m_apAltSnapshots[SnapId]->GetItem(Index);
+		pItem->m_DataSize = m_apAltSnapshots[SnapId]->GetItemSize(Index);
+		pItem->m_Type = m_apAltSnapshots[SnapId]->GetItemType(Index);
 		pItem->m_Id = pSnapshotItem->Id();
 		return (void *)pSnapshotItem->Data();
 	}
@@ -118,9 +110,8 @@ public:
 		if(AltSnapSize < 0)
 			return;
 
-		std::swap(m_apSnapshots[IClient::SNAP_PREV], m_apSnapshots[IClient::SNAP_CURRENT]);
-		mem_copy(m_apSnapshots[IClient::SNAP_CURRENT]->m_pSnap, pData, Size);
-		mem_copy(m_apSnapshots[IClient::SNAP_CURRENT]->m_pAltSnap, pAltSnapBuffer, AltSnapSize);
+		std::swap(m_apAltSnapshots[IClient::SNAP_PREV], m_apAltSnapshots[IClient::SNAP_CURRENT]);
+		mem_copy(m_apAltSnapshots[IClient::SNAP_CURRENT], pAltSnapBuffer, AltSnapSize);
 
 		OnNewSnapshot();
 	}


### PR DESCRIPTION
Using `CSnapshotStorage::CHolder`s in the `demo_extract_chat` tool is not necessary, as only the member variable `m_pAltSnap` is being used in this tool. The regular snapshot data was copied into `m_pSnap` but never read. The other member variables were initialized but never read.

## Checklist

- [X] Tested the change
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
