### PR TITLE
Add basic support for 128 players in scoreboard and spectator UI

### DIFF
--- a/src/game/client/components/spectator.cpp
+++ b/src/game/client/components/spectator.cpp
@@ -286,7 +286,17 @@ void CSpectator::OnRender()
 		++TotalPlayers;
 	}
 
-	if(TotalPlayers > 32)
+	if(TotalPlayers > 64)
+	{
+		FontSize = 12.0f;
+		LineHeight = 15.0f;
+		TeeSizeMod = 0.3f;
+		PerLine = 32;
+		RoundRadius = 5.0f;
+		BoxMove = 3.0f;
+		BoxOffset = 6.0f;
+	}
+	else if(TotalPlayers > 32)
 	{
 		FontSize = 18.0f;
 		LineHeight = 30.0f;


### PR DESCRIPTION
Support showing up to 128 players in the scoreboard and the spectator UI. The 128 players are rendered in 3 columns of 43 players in the scoreboard and in 4 columns of 32 players in the spectator UI. Other lists like the server info (ingame and in the server browser) and the voting list already support showing any number of players.

Screenshots:

- ![screenshot_2024-07-15_23-28-30](https://github.com/user-attachments/assets/30b3321f-8b9f-4e32-9c1b-28a275678ef6)
- ![screenshot_2024-07-14_20-52-40](https://github.com/user-attachments/assets/7ce9e14c-d84e-48b0-9d31-93cb16d11b10)

## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
