### PR TITLE
Fix crashes with `dbg_dummies` and `sv_max_clients`, ensure that `sv_max_clients` can only be set when starting server

### DIFF
--- a/src/engine/server/main.cpp
+++ b/src/engine/server/main.cpp
@@ -167,6 +167,7 @@ int main(int argc, const char **argv)
 	if(argc > 1)
 		pConsole->ParseArguments(argc - 1, &argv[1]);
 
+	pConfigManager->SetReadOnly("sv_max_clients", true);
 	pConfigManager->SetReadOnly("sv_test_cmds", true);
 	pConfigManager->SetReadOnly("sv_rescue", true);
 

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -1527,7 +1527,7 @@ void CServer::ProcessClientPacket(CNetChunk *pPacket)
 				}
 
 				// reserved slot
-				if(ClientId >= Config()->m_SvMaxClients - Config()->m_SvReservedSlots && !CheckReservedSlotAuth(ClientId, pPassword))
+				if(ClientId >= MaxClients() - Config()->m_SvReservedSlots && !CheckReservedSlotAuth(ClientId, pPassword))
 				{
 					m_NetServer.Drop(ClientId, "This server is full");
 					return;

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -2624,10 +2624,11 @@ void CServer::UpdateDebugDummies(bool ForceDisconnect)
 	if(m_PreviousDebugDummies == g_Config.m_DbgDummies && !ForceDisconnect)
 		return;
 
+	g_Config.m_DbgDummies = clamp(g_Config.m_DbgDummies, 0, MaxClients());
 	for(int DummyIndex = 0; DummyIndex < maximum(m_PreviousDebugDummies, g_Config.m_DbgDummies); ++DummyIndex)
 	{
 		const bool AddDummy = !ForceDisconnect && DummyIndex < g_Config.m_DbgDummies;
-		const int ClientId = MAX_CLIENTS - DummyIndex - 1;
+		const int ClientId = MaxClients() - DummyIndex - 1;
 		if(AddDummy && m_aClients[ClientId].m_State == CClient::STATE_EMPTY)
 		{
 			NewClientCallback(ClientId, this, false);

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -716,7 +716,7 @@ void CGameContext::SendSettings(int ClientId) const
 	Msg.m_SpecVote = g_Config.m_SvVoteSpectate;
 	Msg.m_TeamLock = 0;
 	Msg.m_TeamBalance = 0;
-	Msg.m_PlayerSlots = g_Config.m_SvMaxClients - g_Config.m_SvSpectatorSlots;
+	Msg.m_PlayerSlots = Server()->MaxClients() - g_Config.m_SvSpectatorSlots;
 	Server()->SendPackMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_NORECORD, ClientId);
 }
 
@@ -3573,7 +3573,6 @@ void CGameContext::OnConsoleInit()
 	Console()->Chain("sv_vote_kick_min", ConchainSettingUpdate, this);
 	Console()->Chain("sv_vote_spectate", ConchainSettingUpdate, this);
 	Console()->Chain("sv_spectator_slots", ConchainSettingUpdate, this);
-	Console()->Chain("sv_max_clients", ConchainSettingUpdate, this);
 
 	RegisterDDRaceCommands();
 	RegisterChatCommands();


### PR DESCRIPTION
Use the real number of maximum clients returned by the `MaxClients()` function instead of the `MAX_CLIENTS` constant to calculate the debug dummy client IDs to fix a crash when `sv_max_clients` is below `MAX_CLIENTS`.

Ensure the `dbg_dummies` value does not exceed the maximum number of clients.

Changing the `sv_max_clients` config variable while the server is running does not change the maximum number of clients that can connect, as this is determined only once when the `CNetServer` is initialized. The reserved slot check and the calculation of the number of player slots for the `protocol7::CNetMsg_Sv_ServerSettings` message were using the `sv_max_clients` config variable directly, which was causing them to be out-of-sync with the real number of maximum clients.

Existing uses of the `sv_max_clients` config variable, except for the `CNetServer` initialization, are replaced with `MaxClients()`. The config variable `sv_max_clients` is now marked as read-only after reading the initial config and command line argument, so changing it via the remote console is not possible and shows an error message. The unnecessary conchain for `sv_max_clients` is removed.

CC #8547.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [X] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
