### PR TITLE
Disable "Run server" button and process functions on Android

### DIFF
--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -4125,6 +4125,7 @@ void cmdline_free(int argc, const char **argv)
 #endif
 }
 
+#if !defined(CONF_PLATFORM_ANDROID)
 PROCESS shell_execute(const char *file, EShellExecuteWindowState window_state)
 {
 #if defined(CONF_FAMILY_WINDOWS)
@@ -4207,7 +4208,6 @@ bool is_process_alive(PROCESS process)
 #endif
 }
 
-#if !defined(CONF_PLATFORM_ANDROID)
 int open_link(const char *link)
 {
 #if defined(CONF_FAMILY_WINDOWS)

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -2542,7 +2542,7 @@ typedef pid_t PROCESS;
  */
 constexpr PROCESS INVALID_PROCESS = 0;
 #endif
-
+#if !defined(CONF_PLATFORM_ANDROID)
 /**
  * Determines the initial window state when using @link shell_execute @endlink
  * to execute a process.
@@ -2599,7 +2599,6 @@ int kill_process(PROCESS process);
  */
 bool is_process_alive(PROCESS process);
 
-#if !defined(CONF_PLATFORM_ANDROID)
 /**
  * Opens a link in the browser.
  *

--- a/src/game/client/components/menus_start.cpp
+++ b/src/game/client/components/menus_start.cpp
@@ -122,6 +122,7 @@ void CMenus::RenderStartMenu(CUIRect MainView)
 	if(DoButton_Menu(&s_SettingsButton, Localize("Settings"), 0, &Button, g_Config.m_ClShowStartMenuImages ? "settings" : 0, IGraphics::CORNER_ALL, Rounding, 0.5f, ColorRGBA(0.0f, 0.0f, 0.0f, 0.25f)) || CheckHotKey(KEY_S))
 		NewPage = PAGE_SETTINGS;
 
+#if !defined(CONF_PLATFORM_ANDROID)
 	Menu.HSplitBottom(5.0f, &Menu, 0); // little space
 	Menu.HSplitBottom(40.0f, &Menu, &Button);
 	static CButtonContainer s_LocalServerButton;
@@ -151,6 +152,7 @@ void CMenus::RenderStartMenu(CUIRect MainView)
 			}
 		}
 	}
+#endif
 
 	static bool EditorHotkeyWasPressed = true;
 	static float EditorHotKeyChecktime = 0.0f;
@@ -269,6 +271,7 @@ void CMenus::RenderStartMenu(CUIRect MainView)
 
 void CMenus::KillServer()
 {
+#if !defined(CONF_PLATFORM_ANDROID)
 	if(m_ServerProcess.m_Process)
 	{
 		if(kill_process(m_ServerProcess.m_Process))
@@ -277,4 +280,5 @@ void CMenus::KillServer()
 			m_ForceRefreshLanPage = true;
 		}
 	}
+#endif
 }


### PR DESCRIPTION
Starting the server on Android is currently not possible because a) the server executable is currently not compiled for Android b) launching the server executable with `fork` and `exec` is not supported on Android and may result in strange bugs like broken networking.

Running the server in a background service or in a separate process by using `Runtime.getRuntime().exec` from Java code might be feasible, but this is currently too much effort and may be done in the future.

For now, the "Run server" button as well as the process related system functions are disabled via conditional compilation on Android, to prevent the networking bug that would otherwise be triggered by pressing the "Run server" button.

Screenshot of start menu on Android:

![screenshot_2024-07-17_15-28-44](https://github.com/user-attachments/assets/af80c19e-a7fc-43c1-96ab-2d2cabe6649e)

## Checklist

- [X] Tested the change ingame (Windows, Android)
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
