### PR TITLE
Support touch input in engine, UI and console

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -4558,6 +4558,10 @@ int main(int argc, const char **argv)
 	pClient->ShellRegister();
 #endif
 
+	// Do not automatically translate touch events to mouse events and vice versa.
+	SDL_SetHint("SDL_TOUCH_MOUSE_EVENTS", "0");
+	SDL_SetHint("SDL_MOUSE_TOUCH_EVENTS", "0");
+
 #if defined(CONF_PLATFORM_MACOS)
 	// Hints will not be set if there is an existing override hint or environment variable that takes precedence.
 	// So this respects cli environment overrides.

--- a/src/engine/client/input.h
+++ b/src/engine/client/input.h
@@ -60,8 +60,8 @@ private:
 	IEngineGraphics *m_pGraphics;
 	IConsole *m_pConsole;
 
-	IEngineGraphics *Graphics() { return m_pGraphics; }
-	IConsole *Console() { return m_pConsole; }
+	IEngineGraphics *Graphics() const { return m_pGraphics; }
+	IConsole *Console() const { return m_pConsole; }
 
 	// joystick
 	std::vector<CJoystick> m_vJoysticks;
@@ -78,7 +78,6 @@ private:
 
 	bool m_MouseFocus;
 #if defined(CONF_PLATFORM_ANDROID)
-	ivec2 m_LastMousePos = ivec2(0, 0); // No relative mouse on Android
 	int m_NumBackPresses = 0;
 	bool m_BackButtonReleased = true;
 	int64_t m_LastBackPress = -1;
@@ -102,6 +101,7 @@ private:
 	uint32_t m_aInputCount[g_MaxKeys];
 	unsigned char m_aInputState[g_MaxKeys];
 	uint32_t m_InputCounter;
+	std::vector<CTouchFingerState> m_vTouchFingerStates;
 
 	void UpdateMouseState();
 	void UpdateJoystickState();
@@ -110,6 +110,9 @@ private:
 	void HandleJoystickHatMotionEvent(const SDL_JoyHatEvent &Event);
 	void HandleJoystickAddedEvent(const SDL_JoyDeviceEvent &Event);
 	void HandleJoystickRemovedEvent(const SDL_JoyDeviceEvent &Event);
+	void HandleTouchDownEvent(const SDL_TouchFingerEvent &Event);
+	void HandleTouchUpEvent(const SDL_TouchFingerEvent &Event);
+	void HandleTouchMotionEvent(const SDL_TouchFingerEvent &Event);
 
 	char m_aDropFile[IO_MAX_PATH_LENGTH];
 
@@ -142,8 +145,10 @@ public:
 	bool MouseRelative(float *pX, float *pY) override;
 	void MouseModeAbsolute() override;
 	void MouseModeRelative() override;
-	void NativeMousePos(int *pX, int *pY) const override;
-	bool NativeMousePressed(int Index) override;
+	vec2 NativeMousePos() const override;
+	bool NativeMousePressed(int Index) const override;
+
+	const std::vector<CTouchFingerState> &TouchFingerStates() const override;
 
 	const char *GetClipboardText() override;
 	void SetClipboardText(const char *pText) override;

--- a/src/game/client/components/console.h
+++ b/src/game/client/components/console.h
@@ -10,6 +10,7 @@
 
 #include <game/client/component.h>
 #include <game/client/lineinput.h>
+#include <game/client/ui.h>
 
 enum
 {
@@ -153,6 +154,7 @@ class CGameConsole : public CComponent
 	float m_StateChangeDuration;
 
 	bool m_WantsSelectionCopy = false;
+	CUi::CTouchState m_TouchState;
 
 	static const ColorRGBA ms_SearchHighlightColor;
 	static const ColorRGBA ms_SearchSelectedColor;

--- a/src/game/client/ui.h
+++ b/src/game/client/ui.h
@@ -320,6 +320,26 @@ public:
 	 */
 	typedef std::function<void()> FPopupMenuClosedCallback;
 
+	/**
+	 * Represents the aggregated state of current touch events to control a user interface.
+	 */
+	class CTouchState
+	{
+		friend class CUi;
+
+		bool m_SecondaryPressedNext = false;
+		float m_SecondaryActivationTime = 0.0f;
+		vec2 m_SecondaryActivationDelta = vec2(0.0f, 0.0f);
+
+	public:
+		bool m_AnyPressed = false;
+		bool m_PrimaryPressed = false;
+		bool m_SecondaryPressed = false;
+		vec2 m_PrimaryPosition = vec2(-1.0f, -1.0f);
+		vec2 m_PrimaryDelta = vec2(0.0f, 0.0f);
+		vec2 m_ScrollAmount = vec2(0.0f, 0.0f);
+	};
+
 private:
 	bool m_Enabled;
 
@@ -327,8 +347,8 @@ private:
 	const void *m_pActiveItem = nullptr;
 	const void *m_pLastActiveItem = nullptr; // only used internally to track active CLineInput
 	const void *m_pBecomingHotItem = nullptr;
-	const CScrollRegion *m_pHotScrollRegion = nullptr;
-	const CScrollRegion *m_pBecomingHotScrollRegion = nullptr;
+	CScrollRegion *m_pHotScrollRegion = nullptr;
+	CScrollRegion *m_pBecomingHotScrollRegion = nullptr;
 	bool m_ActiveItemValid = false;
 
 	int m_ActiveButtonLogicButton = -1;
@@ -360,8 +380,10 @@ private:
 	vec2 m_MousePos = vec2(0.0f, 0.0f); // in gui space
 	vec2 m_MouseDelta = vec2(0.0f, 0.0f); // in gui space
 	vec2 m_MouseWorldPos = vec2(-1.0f, -1.0f); // in world space
+	unsigned m_UpdatedMouseButtons = 0;
 	unsigned m_MouseButtons = 0;
 	unsigned m_LastMouseButtons = 0;
+	CTouchState m_TouchState;
 	bool m_MouseSlow = false;
 	bool m_MouseLock = false;
 	const void *m_pMouseLockId = nullptr;
@@ -491,7 +513,7 @@ public:
 		}
 		return false;
 	}
-	void SetHotScrollRegion(const CScrollRegion *pId) { m_pBecomingHotScrollRegion = pId; }
+	void SetHotScrollRegion(CScrollRegion *pId) { m_pBecomingHotScrollRegion = pId; }
 	const void *HotItem() const { return m_pHotItem; }
 	const void *NextHotItem() const { return m_pBecomingHotItem; }
 	const void *ActiveItem() const { return m_pActiveItem; }
@@ -512,6 +534,7 @@ public:
 	bool MouseInsideClip() const { return !IsClipped() || MouseInside(ClipArea()); }
 	bool MouseHovered(const CUIRect *pRect) const { return MouseInside(pRect) && MouseInsideClip(); }
 	void ConvertMouseMove(float *pX, float *pY, IInput::ECursorType CursorType) const;
+	void UpdateTouchState(CTouchState &State) const;
 	void ResetMouseSlow() { m_MouseSlow = false; }
 
 	bool ConsumeHotkey(EHotkey Hotkey);

--- a/src/game/client/ui_scrollregion.cpp
+++ b/src/game/client/ui_scrollregion.cpp
@@ -234,6 +234,11 @@ void CScrollRegion::ScrollRelative(EScrollRelative Direction, float SpeedMultipl
 	m_ScrollSpeedMultiplier = SpeedMultiplier;
 }
 
+void CScrollRegion::ScrollRelativeDirect(float ScrollAmount)
+{
+	m_RequestScrollY = clamp(m_ScrollY + ScrollAmount, 0.0f, m_ContentH - m_ClipRect.h);
+}
+
 void CScrollRegion::DoEdgeScrolling()
 {
 	if(!ScrollbarShown())

--- a/src/game/client/ui_scrollregion.h
+++ b/src/game/client/ui_scrollregion.h
@@ -133,6 +133,7 @@ public:
 	bool AddRect(const CUIRect &Rect, bool ShouldScrollHere = false); // returns true if the added rect is visible (not clipped)
 	void ScrollHere(EScrollOption Option = SCROLLHERE_KEEP_IN_VIEW);
 	void ScrollRelative(EScrollRelative Direction, float SpeedMultiplier = 1.0f);
+	void ScrollRelativeDirect(float ScrollAmount);
 	const CUIRect *ClipRect() const { return &m_ClipRect; }
 	void DoEdgeScrolling();
 	bool RectClipped(const CUIRect &Rect) const;


### PR DESCRIPTION
Add support for touch input to the engine, UI and console. Ingame touch controls require more discussion and will be delivered separately based on this engine implementation.

Engine
------

The state of all currently pressed touch fingers is aggregated based on the SDL touch events and can be retrieved with the `IInput::TouchFingerStates` function. This design is less complex than an event-based system where the touch events are delivered to the individual client components, as each system would then have to keep track of the finger states individually. However, this means that only one component can handle touch fingers at any given time, which seems like a reasonable assumption for our use cases.

Obsolete code for relative mouse handling on Android is removed. Connecting a mouse to an Android device should now also work as expected, as more recent SDL/Android versions support relative mouse input natively.

User Interface
--------------

Support absolute mouse positioning and clicking in the user interfaces (menus, editor, demo player) with touch presses.

Support right clicking by pressing and holding one finger at roughly the same position for 0.5 seconds.

Support scrolling scroll regions up and down with a two finger swiping gesture. Fast scrolling via a two finger flinging gesture is not yet supported and would be a useful future extension.

The menus and demo player are fully usable with touch inputs. The editor is only fully usable with an external keyboard and/or mouse, as panning the map is not currently possible with only touch inputs, which is also left as a possible future extension.

Console
-------

The touch input logic for the user interface is reused for the console. Thereby, text selection in the console with touch input works, although the text can only be copied by pressing Ctrl+C with an external keyboard at the moment. In the future, we could add buttons to the console to activate the search and copy functionalities with touch inputs.

Support scrolling the console history up and down with a two finger swiping gesture.

The local/remote consoles can currently only be opened with an external keyboard. The ingame touch controls will also include buttons to open the consoles.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
