### PR TITLE
Fix team number and team size rendering

### DIFF
--- a/src/game/client/components/scoreboard.cpp
+++ b/src/game/client/components/scoreboard.cpp
@@ -323,7 +323,8 @@ void CScoreboard::RenderScoreboard(CUIRect Scoreboard, int Team, int CountStart,
 
 	char aBuf[64];
 	int MaxTeamSize = m_pClient->Config()->m_SvMaxTeamSize;
-	float TeamStartY = 0;
+	static float s_TeamStartY = 0;
+	static float s_TeamStartX = 0;
 
 	for(int i = 0; i < MAX_CLIENTS; i++)
 	{
@@ -373,7 +374,8 @@ void CScoreboard::RenderScoreboard(CUIRect Scoreboard, int Team, int CountStart,
 			if(PrevDDTeam != DDTeam)
 			{
 				TeamRectCorners |= IGraphics::CORNER_T;
-				TeamStartY = Row.y;
+				s_TeamStartY = Row.y;
+				s_TeamStartX = Row.x;
 			}
 			if(NextDDTeam != DDTeam)
 				TeamRectCorners |= IGraphics::CORNER_B;
@@ -393,7 +395,7 @@ void CScoreboard::RenderScoreboard(CUIRect Scoreboard, int Team, int CountStart,
 						str_format(aBuf, sizeof(aBuf), "%d", DDTeam);
 					else
 						str_format(aBuf, sizeof(aBuf), Localize("%d\n(%d/%d)", "Team and size"), DDTeam, CurrentDDTeamSize, MaxTeamSize);
-					TextRender()->Text(Row.x, TeamStartY + Row.h / 2.0f - TeamFontSize / 2.0f, TeamFontSize, aBuf);
+					TextRender()->Text(s_TeamStartX, maximum(s_TeamStartY + Row.h / 2.0f - TeamFontSize, s_TeamStartY + 3.0f /* padding top */), TeamFontSize, aBuf);
 				}
 				else
 				{


### PR DESCRIPTION
Fix team number and team size rendering outside of the scoreboard when the team is rendered on both sides.
Fix team number and team size alignment.

Fixes #8633.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
