### PR TITLE
Only apply DNSBL bans once when player joins

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -2890,12 +2890,12 @@ int CServer::Run()
 							str_format(aBuf, sizeof(aBuf), "ClientId=%d addr=<{%s}> secure=%s blacklisted", ClientId, aAddrStr, m_NetServer.HasSecurityToken(ClientId) ? "yes" : "no");
 
 							Console()->Print(IConsole::OUTPUT_LEVEL_ADDINFO, "dnsbl", aBuf);
-						}
-					}
 
-					if(m_aClients[ClientId].m_DnsblState == CClient::DNSBL_STATE_BLACKLISTED && Config()->m_SvDnsblBan)
-					{
-						m_NetServer.NetBan()->BanAddr(m_NetServer.ClientAddr(ClientId), 60 * 10, Config()->m_SvDnsblBanReason);
+							if(Config()->m_SvDnsblBan)
+							{
+								m_NetServer.NetBan()->BanAddr(m_NetServer.ClientAddr(ClientId), 60 * 10, Config()->m_SvDnsblBanReason);
+							}
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Only ban DNSBL blacklisted players once when joining immediately after the DNSBL result is available, to prevent current players from having their runs ended when the `sv_dnsbl_ban` setting is enabled.

Note that enabling `sv_dnsbl` and `sv_dnsbl_ban` at the same time will still cause the players to be banned immediately. To prevent this, first enable `sv_dnsbl` for at least one tick, then enable `sv_dnsbl_ban`.

Closes #2640.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
