### PR TITLE
Use same Red/Blue team colors for score HUD as for scoreboard

### DIFF
--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -216,9 +216,9 @@ void CHud::RenderScoreHud()
 					Graphics()->DeleteQuadContainer(m_aScoreInfo[t].m_RoundRectQuadContainerIndex);
 
 					if(t == 0)
-						Graphics()->SetColor(1.0f, 0.0f, 0.0f, 0.25f);
+						Graphics()->SetColor(0.975f, 0.17f, 0.17f, 0.3f);
 					else
-						Graphics()->SetColor(0.0f, 0.0f, 1.0f, 0.25f);
+						Graphics()->SetColor(0.17f, 0.46f, 0.975f, 0.3f);
 					m_aScoreInfo[t].m_RoundRectQuadContainerIndex = Graphics()->CreateRectQuadContainer(m_Width - ScoreWidthMax - ImageSize - 2 * Split, StartY + t * 20, ScoreWidthMax + ImageSize + 2 * Split, ScoreSingleBoxHeight, 5.0f, IGraphics::CORNER_L);
 				}
 				Graphics()->TextureClear();


### PR DESCRIPTION
Before: 
![teamcolors old](https://github.com/user-attachments/assets/1a56ef20-dbb7-4018-8593-6559ed5c3a04)

After: 
![teamcolors new03](https://github.com/user-attachments/assets/e441376b-9fe3-4ab5-86d5-10ca02becc42)

## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
