### PR TITLE
Fix CSV header being written multiple times to `ddnet-saves.txt`

### DIFF
--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -604,6 +604,7 @@ void CChat::StoreSave(const char *pText)
 	}
 	*/
 
+	const bool SavesFileExists = Storage()->FileExists(SAVES_FILE, IStorage::TYPE_SAVE);
 	IOHANDLE File = Storage()->OpenFile(SAVES_FILE, IOFLAG_APPEND, IStorage::TYPE_SAVE);
 	if(!File)
 		return;
@@ -615,7 +616,7 @@ void CChat::StoreSave(const char *pText)
 		aSaveCode,
 	};
 
-	if(io_tell(File) == 0)
+	if(!SavesFileExists)
 	{
 		CsvWrite(File, 4, SAVES_HEADER);
 	}


### PR DESCRIPTION
It is implementation-defined whether the file position returned by `ftell` denotes the beginning or the end of the file when opening in append-mode. This was causing the condition `io_tell(File) == 0` to always be true, so the CSV header was also written to `ddnet-saves.txt` every time that a new save code is written. Now, we check if the file already exists before appending and only write the CSV header once when the file does not exist yet.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
