### PR TITLE
Fix game launch on Wayland-only systems with SDL2.30+

### DIFF
--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -1019,6 +1019,13 @@ int CGraphicsBackend_SDL_GL::Init(const char *pName, int *pScreen, int *pWidth, 
 		SDL_GetVersion(&Linked);
 		dbg_msg("sdl", "SDL version %d.%d.%d (compiled = %d.%d.%d)", Linked.major, Linked.minor, Linked.patch,
 			Compiled.major, Compiled.minor, Compiled.patch);
+
+#if CONF_PLATFORM_LINUX && SDL_VERSION_ATLEAST(2, 0, 22)
+		// needed to workaround SDL from forcing exclusively X11 if linking against the GLX flavour of GLEW instead of the EGL one
+		// w/o this on Wayland systems (no XWayland support) SDL's Video subsystem will fail to load (starting from SDL2.30+)
+		if(Linked.major == 2 && Linked.minor >= 30)
+			SDL_SetHint(SDL_HINT_VIDEODRIVER, "x11,wayland");
+#endif
 	}
 
 	if(!SDL_WasInit(SDL_INIT_VIDEO))


### PR DESCRIPTION
**How to reproduce**
Ensure that you're using a Wayland compositor and DDNet is linked against SDL2.30+, regardless of having XWayland enabled or not, do:
```(unset DISPLAY && ./DDNet)```
the game will complain that `x11 not available`.
This doesn't happen with SDL2 versions before the 2.30 series.

**What is the motivation for the changes of this pull request?**
If you try to run DDNet on SDL2.30+ on a Wayland-only machine (that is, one without XWayland support) then SDL will arbitrarily force X11 causing the game to fail to load.

The cause of the trouble lies in this SDL commit https://github.com/libsdl-org/SDL/commit/bd2f1e9ea635b232d5aa39fb9f0326b1f134b99e which was introduced in response to https://github.com/libsdl-org/SDL/issues/8812.
_TLDR;_ We link against GLEW for OpenGL, GLEW has tricky support for Wayland/EGL, SDL tries to be smart and tries to prevent the `wayland` "video driver" from being used if we link against GLEW (regardless of effective use, just linking it) --> DDNet fails to load although we could have used the Vulkan backend.

I have opened an issue https://github.com/libsdl-org/SDL/issues/10385 to probe whether this patch is the intended solution to the issue. I'll mark this as ready to review once I get feedback about it.

CC: @Jupeyy


## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
