### PR TITLE
Update Vulkan and OpenGL ES versions specified in Android manifest

### DIFF
--- a/scripts/android/files/AndroidManifest.xml
+++ b/scripts/android/files/AndroidManifest.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+	<!-- Vulkan 1.1.0 is used if supported -->
 	<uses-feature
-		android:glEsVersion="0x00030000" />
+		android:name="android.hardware.vulkan.version"
+		android:version="0x00401000" />
+	<!-- android:glEsVersion is not specified as OpenGL ES 1.0 is supported as fallback -->
 	<uses-feature
 		android:name="android.hardware.screen.landscape" />
 


### PR DESCRIPTION
Specify that Vulkan 1.1.0 is used if supported.

Remove explicit requirement of OpenGL ES 3.0 as OpenGL ES 1.0 is also supported as fallback and the client should pick the highest supported version.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
