### PR TITLE
Rename editor component `Init` to `OnInit`

### DIFF
--- a/src/game/editor/auto_map.cpp
+++ b/src/game/editor/auto_map.cpp
@@ -42,7 +42,7 @@ static int HashLocation(uint32_t Seed, uint32_t Run, uint32_t Rule, uint32_t X, 
 
 CAutoMapper::CAutoMapper(CEditor *pEditor)
 {
-	Init(pEditor);
+	OnInit(pEditor);
 }
 
 void CAutoMapper::Load(const char *pTileName)

--- a/src/game/editor/component.cpp
+++ b/src/game/editor/component.cpp
@@ -14,7 +14,7 @@ void CEditorComponent::InitSubComponents()
 {
 	for(CEditorComponent &Component : m_vSubComponents)
 	{
-		Component.Init(Editor());
+		Component.OnInit(Editor());
 	}
 }
 

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -8324,15 +8324,15 @@ void CEditor::Init()
 		m_PopupEventWasActivated = false;
 	});
 	m_RenderTools.Init(m_pGraphics, m_pTextRender);
-	m_ZoomEnvelopeX.Init(this);
-	m_ZoomEnvelopeY.Init(this);
+	m_ZoomEnvelopeX.OnInit(this);
+	m_ZoomEnvelopeY.OnInit(this);
 	m_Map.m_pEditor = this;
 
 	m_vComponents.emplace_back(m_MapView);
 	m_vComponents.emplace_back(m_MapSettingsBackend);
 	m_vComponents.emplace_back(m_LayerSelector);
 	for(CEditorComponent &Component : m_vComponents)
-		Component.Init(this);
+		Component.OnInit(this);
 
 	m_CheckerTexture = Graphics()->LoadTexture("editor/checker.png", IStorage::TYPE_ALL);
 	m_BackgroundTexture = Graphics()->LoadTexture("editor/background.png", IStorage::TYPE_ALL);

--- a/src/game/editor/editor_object.cpp
+++ b/src/game/editor/editor_object.cpp
@@ -2,7 +2,7 @@
 
 #include "editor.h"
 
-void CEditorObject::Init(CEditor *pEditor)
+void CEditorObject::OnInit(CEditor *pEditor)
 {
 	m_pEditor = pEditor;
 	OnReset();

--- a/src/game/editor/editor_object.h
+++ b/src/game/editor/editor_object.h
@@ -28,7 +28,7 @@ public:
 	 * Needs to be the first function that is called.
 	 * The default implentation also resets the component.
 	 */
-	virtual void Init(CEditor *pEditor);
+	virtual void OnInit(CEditor *pEditor);
 
 	/**
 	 * Maybe calls `OnHot` or `OnActive`.

--- a/src/game/editor/editor_server_settings.cpp
+++ b/src/game/editor/editor_server_settings.cpp
@@ -1049,9 +1049,9 @@ void CEditor::MapSettingsDropdownRenderCallback(const SPossibleValueMatch &Match
 
 CMapSettingsBackend::CContext *CMapSettingsBackend::ms_pActiveContext = nullptr;
 
-void CMapSettingsBackend::Init(CEditor *pEditor)
+void CMapSettingsBackend::OnInit(CEditor *pEditor)
 {
-	CEditorComponent::Init(pEditor);
+	CEditorComponent::OnInit(pEditor);
 
 	// Register values loader
 	InitValueLoaders();

--- a/src/game/editor/editor_server_settings.h
+++ b/src/game/editor/editor_server_settings.h
@@ -198,7 +198,7 @@ class CMapSettingsBackend : public CEditorComponent
 public: // General methods
 	CMapSettingsBackend() = default;
 
-	void Init(CEditor *pEditor) override;
+	void OnInit(CEditor *pEditor) override;
 	bool OnInput(const IInput::CEvent &Event) override;
 	void OnUpdate() override;
 	void OnMapLoad() override;

--- a/src/game/editor/layer_selector.cpp
+++ b/src/game/editor/layer_selector.cpp
@@ -2,9 +2,9 @@
 
 #include "layer_selector.h"
 
-void CLayerSelector::Init(CEditor *pEditor)
+void CLayerSelector::OnInit(CEditor *pEditor)
 {
-	CEditorComponent::Init(pEditor);
+	CEditorComponent::OnInit(pEditor);
 
 	m_SelectionOffset = 0;
 }

--- a/src/game/editor/layer_selector.h
+++ b/src/game/editor/layer_selector.h
@@ -8,7 +8,7 @@ class CLayerSelector : public CEditorComponent
 	int m_SelectionOffset;
 
 public:
-	void Init(CEditor *pEditor) override;
+	void OnInit(CEditor *pEditor) override;
 	bool SelectByTile();
 };
 

--- a/src/game/editor/map_view.cpp
+++ b/src/game/editor/map_view.cpp
@@ -8,9 +8,9 @@
 
 #include "editor.h"
 
-void CMapView::Init(CEditor *pEditor)
+void CMapView::OnInit(CEditor *pEditor)
 {
-	CEditorComponent::Init(pEditor);
+	CEditorComponent::OnInit(pEditor);
 	RegisterSubComponent(m_MapGrid);
 	RegisterSubComponent(m_ProofMode);
 	InitSubComponents();
@@ -19,7 +19,7 @@ void CMapView::Init(CEditor *pEditor)
 void CMapView::OnReset()
 {
 	m_Zoom = CSmoothValue(200.0f, 10.0f, 2000.0f);
-	m_Zoom.Init(Editor());
+	m_Zoom.OnInit(Editor());
 	m_WorldZoom = 1.0f;
 
 	SetWorldOffset({0, 0});

--- a/src/game/editor/map_view.h
+++ b/src/game/editor/map_view.h
@@ -13,7 +13,7 @@ class CLayerGroup;
 class CMapView : public CEditorComponent
 {
 public:
-	void Init(CEditor *pEditor) override;
+	void OnInit(CEditor *pEditor) override;
 	void OnReset() override;
 	void OnMapLoad() override;
 

--- a/src/game/editor/mapitems/image.cpp
+++ b/src/game/editor/mapitems/image.cpp
@@ -5,7 +5,7 @@
 CEditorImage::CEditorImage(CEditor *pEditor) :
 	m_AutoMapper(pEditor)
 {
-	Init(pEditor);
+	OnInit(pEditor);
 	m_Texture.Invalidate();
 }
 
@@ -16,9 +16,9 @@ CEditorImage::~CEditorImage()
 	m_pData = nullptr;
 }
 
-void CEditorImage::Init(CEditor *pEditor)
+void CEditorImage::OnInit(CEditor *pEditor)
 {
-	CEditorComponent::Init(pEditor);
+	CEditorComponent::OnInit(pEditor);
 	RegisterSubComponent(m_AutoMapper);
 	InitSubComponents();
 }

--- a/src/game/editor/mapitems/image.h
+++ b/src/game/editor/mapitems/image.h
@@ -12,7 +12,7 @@ public:
 	explicit CEditorImage(CEditor *pEditor);
 	~CEditorImage();
 
-	void Init(CEditor *pEditor) override;
+	void OnInit(CEditor *pEditor) override;
 	void AnalyseTileFlags();
 	bool DataEquals(const CEditorImage &Other) const;
 

--- a/src/game/editor/mapitems/sound.cpp
+++ b/src/game/editor/mapitems/sound.cpp
@@ -4,7 +4,7 @@
 
 CEditorSound::CEditorSound(CEditor *pEditor)
 {
-	Init(pEditor);
+	OnInit(pEditor);
 }
 
 CEditorSound::~CEditorSound()

--- a/src/game/editor/proof_mode.cpp
+++ b/src/game/editor/proof_mode.cpp
@@ -4,9 +4,9 @@
 
 #include "editor.h"
 
-void CProofMode::Init(CEditor *pEditor)
+void CProofMode::OnInit(CEditor *pEditor)
 {
-	CEditorComponent::Init(pEditor);
+	CEditorComponent::OnInit(pEditor);
 	SetMenuBackgroundPositionNames();
 	OnReset();
 	OnMapLoad();

--- a/src/game/editor/proof_mode.h
+++ b/src/game/editor/proof_mode.h
@@ -6,7 +6,7 @@
 class CProofMode : public CEditorComponent
 {
 public:
-	void Init(CEditor *pEditor) override;
+	void OnInit(CEditor *pEditor) override;
 	void OnReset() override;
 	void OnMapLoad() override;
 	void RenderScreenSizes();


### PR DESCRIPTION
This matches the naming convention used for client components and the `GameServer()->OnInit()`

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
