### PR TITLE
Support IME composition strings of arbitrary length

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -4562,6 +4562,11 @@ int main(int argc, const char **argv)
 	SDL_SetHint("SDL_TOUCH_MOUSE_EVENTS", "0");
 	SDL_SetHint("SDL_MOUSE_TOUCH_EVENTS", "0");
 
+	// Support longer IME composition strings (enables SDL_TEXTEDITING_EXT).
+#if SDL_VERSION_ATLEAST(2, 0, 22)
+	SDL_SetHint(SDL_HINT_IME_SUPPORT_EXTENDED_TEXT, "1");
+#endif
+
 #if defined(CONF_PLATFORM_MACOS)
 	// Hints will not be set if there is an existing override hint or environment variable that takes precedence.
 	// So this respects cli environment overrides.

--- a/src/engine/client/input.h
+++ b/src/engine/client/input.h
@@ -84,9 +84,8 @@ private:
 #endif
 
 	// IME support
-	char m_aComposition[MAX_COMPOSITION_ARRAY_SIZE];
+	std::string m_CompositionString;
 	int m_CompositionCursor;
-	int m_CompositionLength;
 	std::vector<std::string> m_vCandidates;
 	int m_CandidateSelectedIndex;
 
@@ -113,6 +112,7 @@ private:
 	void HandleTouchDownEvent(const SDL_TouchFingerEvent &Event);
 	void HandleTouchUpEvent(const SDL_TouchFingerEvent &Event);
 	void HandleTouchMotionEvent(const SDL_TouchFingerEvent &Event);
+	void HandleTextEditingEvent(const char *pText, int Start, int Length);
 
 	char m_aDropFile[IO_MAX_PATH_LENGTH];
 
@@ -155,10 +155,10 @@ public:
 
 	void StartTextInput() override;
 	void StopTextInput() override;
-	const char *GetComposition() const override { return m_aComposition; }
-	bool HasComposition() const override { return m_CompositionLength != COMP_LENGTH_INACTIVE; }
+	const char *GetComposition() const override { return m_CompositionString.c_str(); }
+	bool HasComposition() const override { return !m_CompositionString.empty(); }
 	int GetCompositionCursor() const override { return m_CompositionCursor; }
-	int GetCompositionLength() const override { return m_CompositionLength; }
+	int GetCompositionLength() const override { return m_CompositionString.length(); }
 	const char *GetCandidate(int Index) const override { return m_vCandidates[Index].c_str(); }
 	int GetCandidateCount() const override { return m_vCandidates.size(); }
 	int GetCandidateSelectedIndex() const override { return m_CandidateSelectedIndex; }

--- a/src/engine/input.h
+++ b/src/engine/input.h
@@ -19,18 +19,13 @@ class IInput : public IInterface
 {
 	MACRO_INTERFACE("input")
 public:
-	enum
-	{
-		INPUT_TEXT_SIZE = 32 * UTF8_BYTE_LENGTH + 1,
-	};
-
 	class CEvent
 	{
 	public:
 		int m_Flags;
 		int m_Key;
 		uint32_t m_InputCount;
-		char m_aText[INPUT_TEXT_SIZE];
+		char m_aText[32]; // SDL_TEXTINPUTEVENT_TEXT_SIZE
 	};
 
 	enum
@@ -44,12 +39,6 @@ public:
 		CURSOR_NONE,
 		CURSOR_MOUSE,
 		CURSOR_JOYSTICK,
-	};
-	enum
-	{
-		MAX_COMPOSITION_ARRAY_SIZE = 32, // SDL2 limitation
-
-		COMP_LENGTH_INACTIVE = -1,
 	};
 
 	// events


### PR DESCRIPTION
Previously, IME composition strings were limited to at most 32 bytes, e.g. 10 Hiragana characters. Now, `SDL_TextEditingExtEvent` (`SDL_TEXTEDITING_EXT`) is supported, which uses heap-allocated composition strings of arbitrary length.

On the other hand, the buffer for input event text was larger than necessary, as SDL text events only contain at most 32 bytes (`SDL_TEXTINPUTEVENT_TEXT_SIZE` is not used directly to avoid the include). With the hint for extended IME handling enabled, long composition text will be sent as multiple text events (without breaking UTF-8).

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
