### PR TITLE
Improve dummy connecting button and error handling

### DIFF
--- a/src/engine/client.h
+++ b/src/engine/client.h
@@ -163,6 +163,7 @@ public:
 	virtual void DummyConnect() = 0;
 	virtual bool DummyConnected() const = 0;
 	virtual bool DummyConnecting() const = 0;
+	virtual bool DummyConnectingDelayed() const = 0;
 	virtual bool DummyAllowed() const = 0;
 
 	virtual void Restart() = 0;

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -178,8 +178,9 @@ class CClient : public IClient, public CDemoPlayer::IListener
 	int m_aCurrentInput[NUM_DUMMIES] = {0, 0};
 	bool m_LastDummy = false;
 	bool m_DummySendConnInfo = false;
+	bool m_DummyConnecting = false;
 	bool m_DummyConnected = false;
-	int m_LastDummyConnectTime = 0;
+	float m_LastDummyConnectTime = 0.0f;
 
 	// graphs
 	CGraph m_InputtimeMarginGraph;
@@ -316,6 +317,7 @@ public:
 	void DummyConnect() override;
 	bool DummyConnected() const override;
 	bool DummyConnecting() const override;
+	bool DummyConnectingDelayed() const override;
 	bool DummyAllowed() const override;
 
 	void GetServerInfo(CServerInfo *pServerInfo) const override;

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -72,13 +72,18 @@ void CMenus::RenderGame(CUIRect MainView)
 	ButtonBar.VSplitRight(5.0f, &ButtonBar, 0);
 	ButtonBar.VSplitRight(170.0f, &ButtonBar, &Button);
 
-	bool DummyConnecting = Client()->DummyConnecting();
 	static CButtonContainer s_DummyButton;
 	if(!Client()->DummyAllowed())
 	{
 		DoButton_Menu(&s_DummyButton, Localize("Connect Dummy"), 1, &Button);
+		GameClient()->m_Tooltips.DoToolTip(&s_DummyButton, &Button, Localize("Dummy is not allowed on this server."));
 	}
-	else if(DummyConnecting)
+	else if(Client()->DummyConnectingDelayed())
+	{
+		DoButton_Menu(&s_DummyButton, Localize("Connect Dummy"), 1, &Button);
+		GameClient()->m_Tooltips.DoToolTip(&s_DummyButton, &Button, Localize("Please wait…"));
+	}
+	else if(Client()->DummyConnecting())
 	{
 		DoButton_Menu(&s_DummyButton, Localize("Connecting dummy"), 1, &Button);
 	}
@@ -131,7 +136,7 @@ void CMenus::RenderGame(CUIRect MainView)
 		{
 			ButtonBar.VSplitLeft(5.0f, 0, &ButtonBar);
 			ButtonBar.VSplitLeft(120.0f, &Button, &ButtonBar);
-			if(!DummyConnecting && DoButton_Menu(&s_SpectateButton, Localize("Spectate"), 0, &Button))
+			if(!Client()->DummyConnecting() && DoButton_Menu(&s_SpectateButton, Localize("Spectate"), 0, &Button))
 			{
 				if(g_Config.m_ClDummy == 0 || Client()->DummyConnected())
 				{
@@ -148,7 +153,7 @@ void CMenus::RenderGame(CUIRect MainView)
 				ButtonBar.VSplitLeft(5.0f, 0, &ButtonBar);
 				ButtonBar.VSplitLeft(120.0f, &Button, &ButtonBar);
 				static CButtonContainer s_JoinRedButton;
-				if(!DummyConnecting && DoButton_Menu(&s_JoinRedButton, Localize("Join red"), 0, &Button))
+				if(!Client()->DummyConnecting() && DoButton_Menu(&s_JoinRedButton, Localize("Join red"), 0, &Button))
 				{
 					m_pClient->SendSwitchTeam(TEAM_RED);
 					SetActive(false);
@@ -160,7 +165,7 @@ void CMenus::RenderGame(CUIRect MainView)
 				ButtonBar.VSplitLeft(5.0f, 0, &ButtonBar);
 				ButtonBar.VSplitLeft(120.0f, &Button, &ButtonBar);
 				static CButtonContainer s_JoinBlueButton;
-				if(!DummyConnecting && DoButton_Menu(&s_JoinBlueButton, Localize("Join blue"), 0, &Button))
+				if(!Client()->DummyConnecting() && DoButton_Menu(&s_JoinBlueButton, Localize("Join blue"), 0, &Button))
 				{
 					m_pClient->SendSwitchTeam(TEAM_BLUE);
 					SetActive(false);
@@ -173,7 +178,7 @@ void CMenus::RenderGame(CUIRect MainView)
 			{
 				ButtonBar.VSplitLeft(5.0f, 0, &ButtonBar);
 				ButtonBar.VSplitLeft(120.0f, &Button, &ButtonBar);
-				if(!DummyConnecting && DoButton_Menu(&s_SpectateButton, Localize("Join game"), 0, &Button))
+				if(!Client()->DummyConnecting() && DoButton_Menu(&s_SpectateButton, Localize("Join game"), 0, &Button))
 				{
 					m_pClient->SendSwitchTeam(0);
 					SetActive(false);


### PR DESCRIPTION
Track whether the dummy is currently connecting separately so the dummy being disconnected due to errors can be detected. Show an error message as echo in the chat when the dummy could not be connected, e.g. when the server is full.

Use the global time for limiting the dummy connecting delay instead of using game ticks, so the delay also works correctly when having connection problems (i.e., when ticks do not advance). Handle the dummy connecting being delayed separately from the dummy currently connecting.

Add tooltips for the "Connect dummy"-button when it's disable due to dummy not being allow on the server or when connecting is delayed.

Add console error messages for `dummy_connect` command.

![image](https://github.com/user-attachments/assets/09d15406-8243-46c9-bca5-f8fef799ad5c)

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
