### PR TITLE
Workaround GLEW error code on init with Wayland

### DIFF
--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -443,7 +443,9 @@ static bool BackendInitGlew(EBackendType BackendType, int &GlewMajor, int &GlewM
 #ifdef CONF_GLEW_HAS_CONTEXT_INIT
 		if(GLEW_OK != glewContextInit())
 #else
-		if(GLEW_OK != glewInit())
+		GLenum InitResult = glewInit();
+		const char *pVideoDriver = SDL_GetCurrentVideoDriver();
+		if(GLEW_OK != InitResult && pVideoDriver && !str_comp(pVideoDriver, "wayland") && GLEW_ERROR_NO_GLX_DISPLAY != InitResult)
 #endif
 			return false;
 


### PR DESCRIPTION
**What is the motivation for the changes of this pull request?**
The way I understand it, vanilla GLEW comes into two flavors defined at build time, one has support for GLX extensions and the other ones supports EGL extensions.

If GLEW GLX is linked into DDNet, and SDL2 is using the `wayland` video driver, `glewInit()` will return the `GLEW_ERROR_NO_GLX_DISPLAY` error code and we bail out.

Among the first things `glewInit()` does is to call `glewContextInit()` and only after that call has succeeded it errors out when looking up GLX extensions.
This means that GLEW is actually setup enough to work with DDNet needs.

This can be seen here: `https://github.com/nigels-com/glew/blob/master/auto/src/glew_init_tail.c#L42

This patch allows the aforementioned error code to be accepted only when SDL2 is using the `wayland` "video driver".

Hopefully, as @Jupeyy said here https://github.com/libsdl-org/SDL/issues/10385#issuecomment-2253211376, when a future release of GLEW is made and `glewContextInit()` becomes part of the public API this issue will fade away.

**How to reproduce**
Be sure to be linking against a vanilla GLX GLEW on Linux, this is because some distributions have been separately shipping patches.

Do:
`SDL_VIDEODRIVER=wayland ./DDNet`
-> This will lead to a failure during initialization without this PR when using the OpenGL backend.
With this PR:
-> The game loads just fine.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
