### PR TITLE
Add `required` attributes to Android manifest

### DIFF
--- a/scripts/android/files/AndroidManifest.xml
+++ b/scripts/android/files/AndroidManifest.xml
@@ -3,10 +3,12 @@
 	<!-- Vulkan 1.1.0 is used if supported -->
 	<uses-feature
 		android:name="android.hardware.vulkan.version"
+		android:required="false"
 		android:version="0x00401000" />
 	<!-- android:glEsVersion is not specified as OpenGL ES 1.0 is supported as fallback -->
 	<uses-feature
-		android:name="android.hardware.screen.landscape" />
+		android:name="android.hardware.screen.landscape"
+		android:required="true" />
 
 	<!-- Teeworlds does broadcasts over local networks -->
 	<uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>


### PR DESCRIPTION
Fix incorrect default value for Vulkan, which is not required.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
