### PR TITLE
Smoother menu checker background scrolling on loading screens, fix menu checker background on wide resolutions and optimize it

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -3820,6 +3820,7 @@ void CClient::UpdateAndSwap()
 	Input()->Update();
 	Graphics()->Swap();
 	Graphics()->Clear(0, 0, 0);
+	m_GlobalTime = (time_get() - m_GlobalStartTime) / (float)time_freq();
 }
 
 void CClient::ServerBrowserUpdate()

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -2234,11 +2234,13 @@ void CMenus::RenderBackground()
 	const float OffsetTime = std::fmod(Client()->GlobalTime() * 0.15f, 2.0f);
 	IGraphics::CQuadItem aCheckerItems[64];
 	size_t NumCheckerItems = 0;
-	for(int y = -2; y < (int)(ScreenWidth / Size); y++)
+	const int NumItemsWidth = std::ceil(ScreenWidth / Size);
+	const int NumItemsHeight = std::ceil(ScreenHeight / Size);
+	for(int y = -2; y < NumItemsHeight; y++)
 	{
-		for(int x = -2; x < (int)(ScreenHeight / Size); x++)
+		for(int x = 0; x < NumItemsWidth + 4; x += 2)
 		{
-			aCheckerItems[NumCheckerItems] = IGraphics::CQuadItem((x - OffsetTime) * Size * 2 + (y & 1) * Size, (y + OffsetTime) * Size, Size, Size);
+			aCheckerItems[NumCheckerItems] = IGraphics::CQuadItem((x - 2 * OffsetTime + (y & 1)) * Size, (y + OffsetTime) * Size, Size, Size);
 			NumCheckerItems++;
 			if(NumCheckerItems == std::size(aCheckerItems))
 			{

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -2231,7 +2231,7 @@ void CMenus::RenderBackground()
 	Graphics()->QuadsBegin();
 	Graphics()->SetColor(0.0f, 0.0f, 0.0f, 0.045f);
 	const float Size = 15.0f;
-	const float OffsetTime = std::fmod(LocalTime() * 0.15f, 2.0f);
+	const float OffsetTime = std::fmod(Client()->GlobalTime() * 0.15f, 2.0f);
 	IGraphics::CQuadItem aCheckerItems[64];
 	size_t NumCheckerItems = 0;
 	for(int y = -2; y < (int)(ScreenWidth / Size); y++)


### PR DESCRIPTION
Update global time also while rendering loading screens and shift the menu checker background based on the global time so it's smoother while loading.

The maximum width and height were swapped as the loop bounds, so the menu checker background did not have the correct width on very wide resolutions.

This was not noticed on common resolutions because twice as many quads as necessary were also being rendered for each row of the background. The bounds of the inner loop are adjusted and only every second x-value is iterated, which reduced the total number of quads for the checker background rendering by more than half.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
