### PR TITLE
Remove unused `CClient::DirectInput` function

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -236,19 +236,6 @@ bool CClient::ConnectionProblems() const
 	return m_aNetClient[g_Config.m_ClDummy].GotProblems(MaxLatencyTicks() * time_freq() / GameTickSpeed()) != 0;
 }
 
-void CClient::DirectInput(int *pInput, int Size)
-{
-	CMsgPacker Msg(NETMSG_INPUT, true);
-	Msg.AddInt(m_aAckGameTick[g_Config.m_ClDummy]);
-	Msg.AddInt(m_aPredTick[g_Config.m_ClDummy]);
-	Msg.AddInt(Size);
-
-	for(int i = 0; i < Size / 4; i++)
-		Msg.AddInt(pInput[i]);
-
-	SendMsgActive(&Msg, 0);
-}
-
 void CClient::SendInput()
 {
 	int64_t Now = time_get();

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -294,7 +294,6 @@ public:
 
 	IGraphics::CTextureHandle GetDebugFont() const override { return m_DebugFont; }
 
-	void DirectInput(int *pInput, int Size);
 	void SendInput();
 
 	// TODO: OPT: do this a lot smarter!


### PR DESCRIPTION
The function is unused and because the message is not flushed it would also not have worked correctly. The `NETMSG_INPUT` message is already packed and flushed in the `CClient::SendInput` function.

Closes #8408.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
