### PR TITLE
Refactor and optimize damage indicators, reset damage indicators when skipping in demo

### DIFF
--- a/src/game/client/components/damageind.cpp
+++ b/src/game/client/components/damageind.cpp
@@ -42,7 +42,6 @@ void CDamageInd::Create(vec2 Pos, vec2 Dir, float Alpha)
 		pItem->m_Dir = -Dir;
 		pItem->m_StartAngle = -random_angle();
 		pItem->m_Color = ColorRGBA(1.0f, 1.0f, 1.0f, Alpha);
-		pItem->m_StartAlpha = Alpha;
 	}
 }
 
@@ -75,11 +74,8 @@ void CDamageInd::OnRender()
 		else
 		{
 			vec2 Pos = mix(m_aItems[i].m_Pos + m_aItems[i].m_Dir * 75.0f, m_aItems[i].m_Pos, clamp((Life - 0.60f) / 0.15f, 0.0f, 1.0f));
-			ColorRGBA Color = m_aItems[i].m_Color;
-
-			float LifeAlpha = Life / 0.1f;
-			Color.a = m_aItems[i].m_StartAlpha * LifeAlpha;
-			Graphics()->SetColor(Color);
+			const float LifeAlpha = Life / 0.1f;
+			Graphics()->SetColor(m_aItems[i].m_Color.WithMultipliedAlpha(LifeAlpha));
 			Graphics()->QuadsSetRotation(m_aItems[i].m_StartAngle + Life * 2.0f);
 			Graphics()->RenderQuadContainerAsSprite(m_DmgIndQuadContainerIndex, 0, Pos.x, Pos.y);
 			i++;

--- a/src/game/client/components/damageind.cpp
+++ b/src/game/client/components/damageind.cpp
@@ -12,7 +12,6 @@
 
 CDamageInd::CDamageInd()
 {
-	m_Lastupdate = 0;
 	m_NumItems = 0;
 }
 

--- a/src/game/client/components/damageind.cpp
+++ b/src/game/client/components/damageind.cpp
@@ -102,8 +102,5 @@ void CDamageInd::OnInit()
 
 void CDamageInd::OnReset()
 {
-	for(int i = 0; i < m_NumItems;)
-	{
-		DestroyI(&m_aItems[i]);
-	}
+	m_NumItems = 0;
 }

--- a/src/game/client/components/damageind.cpp
+++ b/src/game/client/components/damageind.cpp
@@ -15,34 +15,18 @@ CDamageInd::CDamageInd()
 	m_NumItems = 0;
 }
 
-CDamageInd::CItem *CDamageInd::CreateI()
-{
-	if(m_NumItems < MAX_ITEMS)
-	{
-		CItem *p = &m_aItems[m_NumItems];
-		m_NumItems++;
-		return p;
-	}
-	return 0;
-}
-
-void CDamageInd::DestroyI(CDamageInd::CItem *pItem)
-{
-	m_NumItems--;
-	*pItem = m_aItems[m_NumItems];
-}
-
 void CDamageInd::Create(vec2 Pos, vec2 Dir, float Alpha)
 {
-	CItem *pItem = CreateI();
-	if(pItem)
-	{
-		pItem->m_Pos = Pos;
-		pItem->m_StartTime = LocalTime();
-		pItem->m_Dir = -Dir;
-		pItem->m_StartAngle = -random_angle();
-		pItem->m_Color = ColorRGBA(1.0f, 1.0f, 1.0f, Alpha);
-	}
+	if(m_NumItems >= MAX_ITEMS)
+		return;
+
+	CItem *pItem = &m_aItems[m_NumItems];
+	pItem->m_Pos = Pos;
+	pItem->m_StartTime = LocalTime();
+	pItem->m_Dir = -Dir;
+	pItem->m_StartAngle = -random_angle();
+	pItem->m_Color = ColorRGBA(1.0f, 1.0f, 1.0f, Alpha);
+	++m_NumItems;
 }
 
 void CDamageInd::OnRender()
@@ -70,7 +54,10 @@ void CDamageInd::OnRender()
 
 		float Life = 0.75f - (LocalTime() - m_aItems[i].m_StartTime);
 		if(Life < 0.0f)
-			DestroyI(&m_aItems[i]);
+		{
+			--m_NumItems;
+			m_aItems[i] = m_aItems[m_NumItems];
+		}
 		else
 		{
 			vec2 Pos = mix(m_aItems[i].m_Pos + m_aItems[i].m_Dir * 75.0f, m_aItems[i].m_Pos, clamp((Life - 0.60f) / 0.15f, 0.0f, 1.0f));

--- a/src/game/client/components/damageind.cpp
+++ b/src/game/client/components/damageind.cpp
@@ -105,7 +105,7 @@ void CDamageInd::OnInit()
 	Graphics()->QuadContainerUpload(m_DmgIndQuadContainerIndex);
 }
 
-void CDamageInd::Reset()
+void CDamageInd::OnReset()
 {
 	for(int i = 0; i < m_NumItems;)
 	{

--- a/src/game/client/components/damageind.h
+++ b/src/game/client/components/damageind.h
@@ -25,9 +25,6 @@ class CDamageInd : public CComponent
 	CItem m_aItems[MAX_ITEMS];
 	int m_NumItems;
 
-	CItem *CreateI();
-	void DestroyI(CItem *pItem);
-
 	int m_DmgIndQuadContainerIndex;
 
 public:

--- a/src/game/client/components/damageind.h
+++ b/src/game/client/components/damageind.h
@@ -37,7 +37,7 @@ public:
 	virtual int Sizeof() const override { return sizeof(*this); }
 
 	void Create(vec2 Pos, vec2 Dir, float Alpha);
-	void Reset();
+	virtual void OnReset() override;
 	virtual void OnRender() override;
 	virtual void OnInit() override;
 };

--- a/src/game/client/components/damageind.h
+++ b/src/game/client/components/damageind.h
@@ -8,7 +8,6 @@
 
 class CDamageInd : public CComponent
 {
-	int64_t m_Lastupdate;
 	struct CItem
 	{
 		vec2 m_Pos;

--- a/src/game/client/components/damageind.h
+++ b/src/game/client/components/damageind.h
@@ -15,7 +15,6 @@ class CDamageInd : public CComponent
 		float m_StartTime;
 		float m_StartAngle;
 		ColorRGBA m_Color;
-		float m_StartAlpha;
 	};
 
 	enum

--- a/src/game/client/components/damageind.h
+++ b/src/game/client/components/damageind.h
@@ -12,7 +12,7 @@ class CDamageInd : public CComponent
 	{
 		vec2 m_Pos;
 		vec2 m_Dir;
-		float m_StartTime;
+		float m_RemainingLife;
 		float m_StartAngle;
 		ColorRGBA m_Color;
 	};

--- a/src/game/client/components/effects.cpp
+++ b/src/game/client/components/effects.cpp
@@ -53,11 +53,6 @@ void CEffects::DamageIndicator(vec2 Pos, vec2 Dir, float Alpha)
 	m_pClient->m_DamageInd.Create(Pos, Dir, Alpha);
 }
 
-void CEffects::ResetDamageIndicator()
-{
-	m_pClient->m_DamageInd.Reset();
-}
-
 void CEffects::PowerupShine(vec2 Pos, vec2 Size, float Alpha)
 {
 	if(!m_Add50hz)

--- a/src/game/client/components/effects.h
+++ b/src/game/client/components/effects.h
@@ -26,7 +26,6 @@ public:
 	void HammerHit(vec2 Pos, float Alpha = 1.0f);
 	void AirJump(vec2 Pos, float Alpha = 1.0f);
 	void DamageIndicator(vec2 Pos, vec2 Dir, float Alpha = 1.0f);
-	void ResetDamageIndicator();
 	void PlayerSpawn(vec2 Pos, float Alpha = 1.0f);
 	void PlayerDeath(vec2 Pos, int ClientId, float Alpha = 1.0f);
 	void PowerupShine(vec2 Pos, vec2 Size, float Alpha = 1.0f);

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -78,6 +78,7 @@ void CMenus::HandleDemoSeeking(float PositionToSeek, float TimeToSeek)
 	if((PositionToSeek >= 0.0f && PositionToSeek <= 1.0f) || TimeToSeek != 0.0f)
 	{
 		m_pClient->m_Chat.Reset();
+		m_pClient->m_DamageInd.OnReset();
 		m_pClient->m_InfoMessages.OnReset();
 		m_pClient->m_Particles.OnReset();
 		m_pClient->m_Sounds.OnReset();

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1010,7 +1010,6 @@ void CGameClient::OnShutdown()
 
 void CGameClient::OnEnterGame()
 {
-	m_Effects.ResetDamageIndicator();
 }
 
 void CGameClient::OnGameOver()


### PR DESCRIPTION
See commit messages.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
