### PR TITLE
Remove unused code for saving embedded RGB map images

### DIFF
--- a/src/game/editor/mapitems/map_io.cpp
+++ b/src/game/editor/mapitems/map_io.cpp
@@ -111,27 +111,8 @@ bool CEditorMap::Save(const char *pFileName)
 		}
 		else
 		{
-			const size_t PixelSize = CImageInfo::PixelSize(CImageInfo::FORMAT_RGBA);
-			const size_t DataSize = (size_t)Item.m_Width * Item.m_Height * PixelSize;
-			if(pImg->m_Format == CImageInfo::FORMAT_RGB)
-			{
-				// Convert to RGBA
-				unsigned char *pDataRGBA = (unsigned char *)malloc(DataSize);
-				unsigned char *pDataRGB = (unsigned char *)pImg->m_pData;
-				for(int j = 0; j < Item.m_Width * Item.m_Height; j++)
-				{
-					pDataRGBA[j * PixelSize] = pDataRGB[j * 3];
-					pDataRGBA[j * PixelSize + 1] = pDataRGB[j * 3 + 1];
-					pDataRGBA[j * PixelSize + 2] = pDataRGB[j * 3 + 2];
-					pDataRGBA[j * PixelSize + 3] = 255;
-				}
-				Item.m_ImageData = Writer.AddData(DataSize, pDataRGBA);
-				free(pDataRGBA);
-			}
-			else
-			{
-				Item.m_ImageData = Writer.AddData(DataSize, pImg->m_pData);
-			}
+			dbg_assert(pImg->m_Format == CImageInfo::FORMAT_RGBA, "Embedded images must be in RGBA format");
+			Item.m_ImageData = Writer.AddData(pImg->DataSize(), pImg->m_pData);
 		}
 		Writer.AddItem(MAPITEMTYPE_IMAGE, i, sizeof(Item), &Item);
 	}


### PR DESCRIPTION
Only embedded images in RGBA format are loaded anymore, so the additional code for converting RGB to RGBA image data is not necessary.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
