### PR TITLE
Consistently return `true` from `OnInput` function for used events

### DIFF
--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -528,26 +528,35 @@ bool CGameConsole::CInstance::OnInput(const IInput::CEvent &Event)
 				// Use Tab / Shift-Tab to cycle through search matches
 				SelectNextSearchMatch(Direction);
 			}
+			Handled = true;
 		}
 		else if(Event.m_Key == KEY_PAGEUP)
 		{
 			m_BacklogCurLine += GetLinesToScroll(-1, m_LinesRendered);
+			Handled = true;
 		}
 		else if(Event.m_Key == KEY_PAGEDOWN)
 		{
 			m_BacklogCurLine -= GetLinesToScroll(1, m_LinesRendered);
 			if(m_BacklogCurLine < 0)
+			{
 				m_BacklogCurLine = 0;
+			}
+			Handled = true;
 		}
 		else if(Event.m_Key == KEY_MOUSE_WHEEL_UP)
 		{
 			m_BacklogCurLine += GetLinesToScroll(-1, 1);
+			Handled = true;
 		}
 		else if(Event.m_Key == KEY_MOUSE_WHEEL_DOWN)
 		{
 			--m_BacklogCurLine;
 			if(m_BacklogCurLine < 0)
+			{
 				m_BacklogCurLine = 0;
+			}
+			Handled = true;
 		}
 		// in order not to conflict with CLineInput's handling of Home/End only
 		// react to it when the input is empty
@@ -555,16 +564,17 @@ bool CGameConsole::CInstance::OnInput(const IInput::CEvent &Event)
 		{
 			m_BacklogCurLine += GetLinesToScroll(-1, -1);
 			m_BacklogLastActiveLine = m_BacklogCurLine;
+			Handled = true;
 		}
 		else if(Event.m_Key == KEY_END && m_Input.IsEmpty())
 		{
 			m_BacklogCurLine = 0;
+			Handled = true;
 		}
-		else if(Event.m_Key == KEY_F && m_pGameConsole->Input()->ModifierIsPressed() && Event.m_Flags & IInput::FLAG_PRESS)
+		else if(Event.m_Key == KEY_F && m_pGameConsole->Input()->ModifierIsPressed())
 		{
 			m_Searching = !m_Searching;
 			ClearSearch();
-
 			Handled = true;
 		}
 	}

--- a/src/game/client/lineinput.cpp
+++ b/src/game/client/lineinput.cpp
@@ -199,6 +199,7 @@ bool CLineInput::ProcessInput(const IInput::CEvent &Event)
 	if((Event.m_Flags & IInput::FLAG_TEXT) && !(KEY_LCTRL <= Event.m_Key && Event.m_Key <= KEY_RGUI))
 	{
 		SetRange(Event.m_aText, m_SelectionStart, m_SelectionEnd);
+		KeyHandled = true;
 	}
 
 	if(Event.m_Flags & IInput::FLAG_PRESS)
@@ -231,6 +232,7 @@ bool CLineInput::ProcessInput(const IInput::CEvent &Event)
 				}
 				m_SelectionStart = m_SelectionEnd = m_CursorPos;
 			}
+			KeyHandled = true;
 		}
 		else if(Event.m_Key == KEY_DELETE)
 		{
@@ -251,6 +253,7 @@ bool CLineInput::ProcessInput(const IInput::CEvent &Event)
 				}
 				m_SelectionStart = m_SelectionEnd = m_CursorPos;
 			}
+			KeyHandled = true;
 		}
 		else if(Event.m_Key == KEY_LEFT)
 		{
@@ -271,7 +274,10 @@ bool CLineInput::ProcessInput(const IInput::CEvent &Event)
 			}
 
 			if(!Selecting)
+			{
 				m_SelectionStart = m_SelectionEnd = m_CursorPos;
+			}
+			KeyHandled = true;
 		}
 		else if(Event.m_Key == KEY_RIGHT)
 		{
@@ -292,7 +298,10 @@ bool CLineInput::ProcessInput(const IInput::CEvent &Event)
 			}
 
 			if(!Selecting)
+			{
 				m_SelectionStart = m_SelectionEnd = m_CursorPos;
+			}
+			KeyHandled = true;
 		}
 		else if(Event.m_Key == KEY_HOME)
 		{
@@ -305,6 +314,7 @@ bool CLineInput::ProcessInput(const IInput::CEvent &Event)
 				m_SelectionEnd = 0;
 			m_CursorPos = 0;
 			m_SelectionStart = 0;
+			KeyHandled = true;
 		}
 		else if(Event.m_Key == KEY_END)
 		{
@@ -317,6 +327,7 @@ bool CLineInput::ProcessInput(const IInput::CEvent &Event)
 				m_SelectionStart = m_Len;
 			m_CursorPos = m_Len;
 			m_SelectionEnd = m_Len;
+			KeyHandled = true;
 		}
 		else if(ModPressed && !AltPressed && Event.m_Key == KEY_V)
 		{
@@ -381,12 +392,13 @@ bool CLineInput::ProcessInput(const IInput::CEvent &Event)
 		{
 			m_SelectionStart = 0;
 			m_SelectionEnd = m_CursorPos = m_Len;
+			KeyHandled = true;
 		}
 	}
 
 	m_WasCursorChanged |= OldCursorPos != m_CursorPos;
 	m_WasCursorChanged |= SelectionLength != GetSelectionLength();
-	return m_WasChanged || m_WasCursorChanged || KeyHandled;
+	return KeyHandled;
 }
 
 STextBoundingBox CLineInput::Render(const CUIRect *pRect, float FontSize, int Align, bool Changed, float LineWidth, float LineSpacing, const std::vector<STextColorSplit> &vColorSplits)


### PR DESCRIPTION
The `OnInput` function should return `true` exactly for events that were handled. In case of line inputs, the function returned `true` when then line input was changed instead. For the consoles, the function did not return `true` for some events that were handled.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
