### PR TITLE
Fix invalid team count in scoreboard for split teams

### DIFF
--- a/src/game/client/components/scoreboard.h
+++ b/src/game/client/components/scoreboard.h
@@ -10,10 +10,20 @@
 
 class CScoreboard : public CComponent
 {
+	struct CScoreboardRenderState
+	{
+		float m_TeamStartX;
+		float m_TeamStartY;
+		int m_CurrentDDTeamSize;
+
+		CScoreboardRenderState() :
+			m_TeamStartX(0), m_TeamStartY(0), m_CurrentDDTeamSize(0) {}
+	};
+
 	void RenderTitle(CUIRect TitleBar, int Team, const char *pTitle);
 	void RenderGoals(CUIRect Goals);
 	void RenderSpectators(CUIRect Spectators);
-	void RenderScoreboard(CUIRect Scoreboard, int Team, int CountStart, int CountEnd);
+	void RenderScoreboard(CUIRect Scoreboard, int Team, int CountStart, int CountEnd, CScoreboardRenderState &State);
 	void RenderRecordingNotification(float x);
 
 	static void ConKeyScoreboard(IConsole::IResult *pResult, void *pUserData);


### PR DESCRIPTION
Fixes #8681.

![DDNet_rcQue7LR2c](https://github.com/user-attachments/assets/8a708ee4-26ed-418c-aee3-978f89db4442)

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
