### PR TITLE
Support composite binds with `+` commands, fix handling of composite binds with F1-F24 keys, fix incorrect key names with multiple modifiers, refactoring

### DIFF
--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -367,6 +367,26 @@ bool CInput::KeyState(int Key) const
 	return m_aInputState[Key];
 }
 
+int CInput::FindKeyByName(const char *pKeyName) const
+{
+	// check for numeric
+	if(pKeyName[0] == '&')
+	{
+		int Key = str_toint(pKeyName + 1);
+		if(Key > KEY_FIRST && Key < KEY_LAST)
+			return Key; // numeric
+	}
+
+	// search for key
+	for(int Key = KEY_FIRST; Key < KEY_LAST; Key++)
+	{
+		if(str_comp_nocase(pKeyName, KeyName(Key)) == 0)
+			return Key;
+	}
+
+	return KEY_UNKNOWN;
+}
+
 void CInput::UpdateMouseState()
 {
 	const int MouseState = SDL_GetMouseState(nullptr, nullptr);

--- a/src/engine/client/input.h
+++ b/src/engine/client/input.h
@@ -136,6 +136,7 @@ public:
 	bool AltIsPressed() const override { return KeyState(KEY_LALT) || KeyState(KEY_RALT); }
 	bool KeyIsPressed(int Key) const override { return KeyState(Key); }
 	bool KeyPress(int Key, bool CheckCounter) const override { return CheckCounter ? (m_aInputCount[Key] == m_InputCounter) : m_aInputCount[Key]; }
+	int FindKeyByName(const char *pKeyName) const override;
 
 	size_t NumJoysticks() const override { return m_vJoysticks.size(); }
 	CJoystick *GetJoystick(size_t Index) override { return &m_vJoysticks[Index]; }

--- a/src/engine/input.h
+++ b/src/engine/input.h
@@ -58,6 +58,7 @@ public:
 	virtual bool KeyIsPressed(int Key) const = 0;
 	virtual bool KeyPress(int Key, bool CheckCounter = false) const = 0;
 	const char *KeyName(int Key) const { return (Key >= 0 && Key < g_MaxKeys) ? g_aaKeyStrings[Key] : g_aaKeyStrings[0]; }
+	virtual int FindKeyByName(const char *pKeyName) const = 0;
 
 	// joystick
 	class IJoystick

--- a/src/game/client/components/binds.cpp
+++ b/src/game/client/components/binds.cpp
@@ -11,26 +11,15 @@ static const ColorRGBA gs_BindPrintColor{1.0f, 1.0f, 0.8f, 1.0f};
 
 bool CBinds::CBindsSpecial::OnInput(const IInput::CEvent &Event)
 {
+	if((Event.m_Flags & (IInput::FLAG_PRESS | IInput::FLAG_RELEASE)) == 0)
+		return false;
+
 	// only handle F and composed F binds
-	if(((Event.m_Key >= KEY_F1 && Event.m_Key <= KEY_F12) || (Event.m_Key >= KEY_F13 && Event.m_Key <= KEY_F24)) && (Event.m_Key != KEY_F5 || !m_pClient->m_Menus.IsActive()))
+	// do not handle F5 bind while menu is active
+	if(((Event.m_Key >= KEY_F1 && Event.m_Key <= KEY_F12) || (Event.m_Key >= KEY_F13 && Event.m_Key <= KEY_F24)) &&
+		(Event.m_Key != KEY_F5 || !m_pClient->m_Menus.IsActive()))
 	{
-		int Mask = CBinds::GetModifierMask(Input());
-
-		// Look for a composed bind
-		bool ret = false;
-		if(m_pBinds->m_aapKeyBindings[Mask][Event.m_Key])
-		{
-			m_pBinds->GetConsole()->ExecuteLineStroked(Event.m_Flags & IInput::FLAG_PRESS, m_pBinds->m_aapKeyBindings[Mask][Event.m_Key]);
-			ret = true;
-		}
-		// Look for a non composed bind
-		if(!ret && m_pBinds->m_aapKeyBindings[0][Event.m_Key])
-		{
-			m_pBinds->GetConsole()->ExecuteLineStroked(Event.m_Flags & IInput::FLAG_PRESS, m_pBinds->m_aapKeyBindings[0][Event.m_Key]);
-			ret = true;
-		}
-
-		return ret;
+		return m_pBinds->OnInput(Event);
 	}
 
 	return false;

--- a/src/game/client/components/binds.cpp
+++ b/src/game/client/components/binds.cpp
@@ -51,8 +51,8 @@ CBinds::~CBinds()
 
 void CBinds::Bind(int KeyId, const char *pStr, bool FreeOnly, int ModifierCombination)
 {
-	if(KeyId < 0 || KeyId >= KEY_LAST)
-		return;
+	dbg_assert(KeyId >= KEY_FIRST && KeyId < KEY_LAST, "KeyId invalid");
+	dbg_assert(ModifierCombination >= MODIFIER_NONE && ModifierCombination < MODIFIER_COMBINATION_COUNT, "ModifierCombination invalid");
 
 	if(FreeOnly && Get(KeyId, ModifierCombination)[0])
 		return;
@@ -189,9 +189,9 @@ void CBinds::UnbindAll()
 
 const char *CBinds::Get(int KeyId, int ModifierCombination)
 {
-	if(KeyId > 0 && KeyId < KEY_LAST && m_aapKeyBindings[ModifierCombination][KeyId])
-		return m_aapKeyBindings[ModifierCombination][KeyId];
-	return "";
+	dbg_assert(KeyId >= KEY_FIRST && KeyId < KEY_LAST, "KeyId invalid");
+	dbg_assert(ModifierCombination >= MODIFIER_NONE && ModifierCombination < MODIFIER_COMBINATION_COUNT, "ModifierCombination invalid");
+	return m_aapKeyBindings[ModifierCombination][KeyId] ? m_aapKeyBindings[ModifierCombination][KeyId] : "";
 }
 
 void CBinds::GetKey(const char *pBindStr, char *pBuf, size_t BufSize)

--- a/src/game/client/components/binds.cpp
+++ b/src/game/client/components/binds.cpp
@@ -196,21 +196,18 @@ const char *CBinds::Get(int KeyId, int ModifierCombination)
 
 void CBinds::GetKey(const char *pBindStr, char *pBuf, size_t BufSize)
 {
-	pBuf[0] = 0;
-	for(int Mod = 0; Mod < MODIFIER_COMBINATION_COUNT; Mod++)
+	pBuf[0] = '\0';
+	for(int Modifier = MODIFIER_NONE; Modifier < MODIFIER_COMBINATION_COUNT; Modifier++)
 	{
-		for(int KeyId = 0; KeyId < KEY_LAST; KeyId++)
+		for(int KeyId = KEY_FIRST; KeyId < KEY_LAST; KeyId++)
 		{
-			const char *pBind = Get(KeyId, Mod);
+			const char *pBind = Get(KeyId, Modifier);
 			if(!pBind[0])
 				continue;
 
 			if(str_comp(pBind, pBindStr) == 0)
 			{
-				if(Mod)
-					str_format(pBuf, BufSize, "%s+%s", GetModifierName(Mod), Input()->KeyName(KeyId));
-				else
-					str_copy(pBuf, Input()->KeyName(KeyId), BufSize);
+				str_format(pBuf, BufSize, "%s%s", GetKeyBindModifiersName(Modifier), Input()->KeyName(KeyId));
 				return;
 			}
 		}

--- a/src/game/client/components/binds.cpp
+++ b/src/game/client/components/binds.cpp
@@ -376,26 +376,6 @@ void CBinds::ConUnbindAll(IConsole::IResult *pResult, void *pUserData)
 	pBinds->UnbindAll();
 }
 
-int CBinds::GetKeyId(const char *pKeyName)
-{
-	// check for numeric
-	if(pKeyName[0] == '&')
-	{
-		int i = str_toint(pKeyName + 1);
-		if(i > 0 && i < KEY_LAST)
-			return i; // numeric
-	}
-
-	// search for key
-	for(int i = 0; i < KEY_LAST; i++)
-	{
-		if(str_comp_nocase(pKeyName, Input()->KeyName(i)) == 0)
-			return i;
-	}
-
-	return 0;
-}
-
 int CBinds::GetBindSlot(const char *pBindString, int *pModifierCombination)
 {
 	*pModifierCombination = MODIFIER_NONE;
@@ -420,7 +400,7 @@ int CBinds::GetBindSlot(const char *pBindString, int *pModifierCombination)
 		else
 			break;
 	}
-	return GetKeyId(*pModifierCombination == MODIFIER_NONE ? aMod : pKey + 1);
+	return Input()->FindKeyByName(*pModifierCombination == MODIFIER_NONE ? aMod : pKey + 1);
 }
 
 const char *CBinds::GetModifierName(int Modifier)

--- a/src/game/client/components/binds.h
+++ b/src/game/client/components/binds.h
@@ -20,6 +20,20 @@ class CBinds : public CComponent
 
 	static void ConfigSaveCallback(IConfigManager *pConfigManager, void *pUserData);
 
+	class CBindSlot
+	{
+	public:
+		int m_Key;
+		int m_ModifierMask;
+
+		CBindSlot(int Key, int ModifierMask) :
+			m_Key(Key),
+			m_ModifierMask(ModifierMask)
+		{
+		}
+	};
+	CBindSlot GetBindSlot(const char *pBindString) const;
+
 public:
 	CBinds();
 	~CBinds();
@@ -53,7 +67,6 @@ public:
 	void UnbindAll();
 	const char *Get(int KeyId, int ModifierCombination);
 	void GetKey(const char *pBindStr, char *pBuf, size_t BufSize);
-	int GetBindSlot(const char *pBindString, int *pModifierCombination);
 	static int GetModifierMask(IInput *pInput);
 	static int GetModifierMaskOfKey(int Key);
 	static const char *GetModifierName(int Modifier);

--- a/src/game/client/components/binds.h
+++ b/src/game/client/components/binds.h
@@ -8,6 +8,8 @@
 
 #include <game/client/component.h>
 
+#include <vector>
+
 class IConfigManager;
 
 class CBinds : public CComponent
@@ -81,5 +83,6 @@ public:
 
 private:
 	char *m_aapKeyBindings[MODIFIER_COMBINATION_COUNT][KEY_LAST];
+	std::vector<CBindSlot> m_vActiveBinds;
 };
 #endif

--- a/src/game/client/components/binds.h
+++ b/src/game/client/components/binds.h
@@ -12,8 +12,6 @@ class IConfigManager;
 
 class CBinds : public CComponent
 {
-	int GetKeyId(const char *pKeyName);
-
 	static void ConBind(IConsole::IResult *pResult, void *pUserData);
 	static void ConBinds(IConsole::IResult *pResult, void *pUserData);
 	static void ConUnbind(IConsole::IResult *pResult, void *pUserData);


### PR DESCRIPTION
See commit messages.

Closes #8314.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [X] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
