### PR TITLE
Vulkan: Reset viewport and scissor

### DIFF
--- a/src/engine/client/backend/vulkan/backend_vulkan.cpp
+++ b/src/engine/client/backend/vulkan/backend_vulkan.cpp
@@ -3309,6 +3309,19 @@ protected:
 		else
 		{
 			ExecBuffer.m_HasDynamicState = false;
+			VkViewport Viewport;
+			Viewport.x = 0.0f;
+			Viewport.y = 0.0f;
+			Viewport.width = (float)m_VKSwapImgAndViewportExtent.m_SwapImageViewport.width;
+			Viewport.height = (float)m_VKSwapImgAndViewportExtent.m_SwapImageViewport.height;
+			Viewport.minDepth = 0.0f;
+			Viewport.maxDepth = 1.0f;
+			VkRect2D Scissor;
+			auto ScissorViewport = m_VKSwapImgAndViewportExtent.GetPresentedImageViewport();
+			Scissor.offset = {0, 0};
+			Scissor.extent = {ScissorViewport.width, ScissorViewport.height};
+			ExecBuffer.m_Viewport = Viewport;
+			ExecBuffer.m_Scissor = Scissor;
 		}
 	}
 
@@ -3320,12 +3333,8 @@ protected:
 			m_vLastPipeline[RenderThreadIndex] = BindingPipe;
 		}
 
-		size_t DynamicStateIndex = GetDynamicModeIndexFromExecBuffer(ExecBuffer);
-		if(DynamicStateIndex == VULKAN_BACKEND_CLIP_MODE_DYNAMIC_SCISSOR_AND_VIEWPORT)
-		{
-			vkCmdSetViewport(CommandBuffer, 0, 1, &ExecBuffer.m_Viewport);
-			vkCmdSetScissor(CommandBuffer, 0, 1, &ExecBuffer.m_Scissor);
-		}
+		vkCmdSetViewport(CommandBuffer, 0, 1, &ExecBuffer.m_Viewport);
+		vkCmdSetScissor(CommandBuffer, 0, 1, &ExecBuffer.m_Scissor);
 	}
 
 	/**************************


### PR DESCRIPTION
This fixes the graphics bugs for me using MoltenVK:
Before:
![Screenshot 2024-08-07 at 12 50 17](https://github.com/user-attachments/assets/ff9d7285-c865-4c4b-b069-2eb3605a6b35)
After:
![Screenshot 2024-08-07 at 10 12 04](https://github.com/user-attachments/assets/82665090-5917-4a1d-adfd-8cdc53846a2d)

Fixes: https://github.com/ddnet/ddnet/issues/8680
## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
