### PR TITLE
Faster /rank, fixes test result

### DIFF
--- a/src/game/server/scoreworker.cpp
+++ b/src/game/server/scoreworker.cpp
@@ -786,17 +786,25 @@ bool CScoreWorker::ShowRank(IDbConnection *pSqlServer, const ISqlData *pGameData
 	// check sort method
 	char aBuf[600];
 	str_format(aBuf, sizeof(aBuf),
-		"SELECT Ranking, Time, PercentRank "
-		"FROM ("
-		"  SELECT RANK() OVER w AS Ranking, PERCENT_RANK() OVER w as PercentRank, MIN(Time) AS Time, Name "
+		"SELECT COUNT(DISTINCT Name) + 1 AS Ranking, (SELECT MIN(Time) "
 		"  FROM %s_race "
 		"  WHERE Map = ? "
 		"  AND Server LIKE ? "
+		"  AND Name = ? "
 		"  GROUP BY Name "
-		"  WINDOW w AS (ORDER BY MIN(Time))"
-		") as a "
-		"WHERE Name = ?",
-		pSqlServer->GetPrefix());
+		"  LIMIT 1) as minTime "
+		"FROM %s_race "
+		"WHERE Map = ? "
+		"AND Server LIKE ? "
+		"AND Time < (SELECT MIN(Time) "
+		"  FROM %s_race "
+		"  WHERE Map = ? "
+		"  AND Server LIKE ? "
+		"  AND Name = ? "
+		"  GROUP BY Name "
+		"  LIMIT 1 "
+		") ",
+		pSqlServer->GetPrefix(), pSqlServer->GetPrefix(), pSqlServer->GetPrefix());
 
 	if(pSqlServer->PrepareStatement(aBuf, pError, ErrorSize))
 	{
@@ -805,6 +813,11 @@ bool CScoreWorker::ShowRank(IDbConnection *pSqlServer, const ISqlData *pGameData
 	pSqlServer->BindString(1, pData->m_aMap);
 	pSqlServer->BindString(2, aServerLike);
 	pSqlServer->BindString(3, pData->m_aName);
+	pSqlServer->BindString(4, pData->m_aMap);
+	pSqlServer->BindString(5, aServerLike);
+	pSqlServer->BindString(6, pData->m_aMap);
+	pSqlServer->BindString(7, aServerLike);
+	pSqlServer->BindString(8, pData->m_aName);
 
 	bool End;
 	if(pSqlServer->Step(&End, pError, ErrorSize))
@@ -841,13 +854,11 @@ bool CScoreWorker::ShowRank(IDbConnection *pSqlServer, const ISqlData *pGameData
 	{
 		int Rank = pSqlServer->GetInt(1);
 		float Time = pSqlServer->GetFloat(2);
-		// CEIL and FLOOR are not supported in SQLite
-		int BetterThanPercent = std::floor(100.0f - 100.0f * pSqlServer->GetFloat(3));
 		str_time_float(Time, TIME_HOURS_CENTISECS, aBuf, sizeof(aBuf));
 		if(g_Config.m_SvHideScore)
 		{
 			str_format(pResult->m_Data.m_aaMessages[0], sizeof(pResult->m_Data.m_aaMessages[0]),
-				"Your time: %s, better than %d%%", aBuf, BetterThanPercent);
+				"Your time: %s", aBuf);
 		}
 		else
 		{
@@ -856,14 +867,14 @@ bool CScoreWorker::ShowRank(IDbConnection *pSqlServer, const ISqlData *pGameData
 			if(str_comp_nocase(pData->m_aRequestingPlayer, pData->m_aName) == 0)
 			{
 				str_format(pResult->m_Data.m_aaMessages[0], sizeof(pResult->m_Data.m_aaMessages[0]),
-					"%s - %s - better than %d%%",
-					pData->m_aName, aBuf, BetterThanPercent);
+					"%s - %s",
+					pData->m_aName, aBuf);
 			}
 			else
 			{
 				str_format(pResult->m_Data.m_aaMessages[0], sizeof(pResult->m_Data.m_aaMessages[0]),
-					"%s - %s - better than %d%% - requested by %s",
-					pData->m_aName, aBuf, BetterThanPercent, pData->m_aRequestingPlayer);
+					"%s - %s - requested by %s",
+					pData->m_aName, aBuf, pData->m_aRequestingPlayer);
 			}
 
 			if(g_Config.m_SvRegionalRankings)

--- a/src/test/score.cpp
+++ b/src/test/score.cpp
@@ -167,14 +167,14 @@ TEST_P(SingleScore, RankRegional)
 {
 	g_Config.m_SvRegionalRankings = true;
 	ASSERT_FALSE(CScoreWorker::ShowRank(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
-	ExpectLines(m_pPlayerResult, {"nameless tee - 01:40.00 - better than 100% - requested by brainless tee", "Global rank 1 - GER unranked"}, true);
+	ExpectLines(m_pPlayerResult, {"nameless tee - 01:40.00 - requested by brainless tee", "Global rank 1 - GER rank 1"}, true);
 }
 
 TEST_P(SingleScore, Rank)
 {
 	g_Config.m_SvRegionalRankings = false;
 	ASSERT_FALSE(CScoreWorker::ShowRank(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
-	ExpectLines(m_pPlayerResult, {"nameless tee - 01:40.00 - better than 100% - requested by brainless tee", "Global rank 1"}, true);
+	ExpectLines(m_pPlayerResult, {"nameless tee - 01:40.00 - requested by brainless tee", "Global rank 1"}, true);
 }
 
 TEST_P(SingleScore, TopServerRegional)
@@ -205,7 +205,7 @@ TEST_P(SingleScore, RankServerRegional)
 	g_Config.m_SvRegionalRankings = true;
 	str_copy(m_PlayerRequest.m_aServer, "USA", sizeof(m_PlayerRequest.m_aServer));
 	ASSERT_FALSE(CScoreWorker::ShowRank(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
-	ExpectLines(m_pPlayerResult, {"nameless tee - 01:40.00 - better than 100% - requested by brainless tee", "Global rank 1 - USA rank 1"}, true);
+	ExpectLines(m_pPlayerResult, {"nameless tee - 01:40.00 - requested by brainless tee", "Global rank 1 - USA rank 1"}, true);
 }
 
 TEST_P(SingleScore, RankServer)
@@ -213,7 +213,7 @@ TEST_P(SingleScore, RankServer)
 	g_Config.m_SvRegionalRankings = false;
 	str_copy(m_PlayerRequest.m_aServer, "USA", sizeof(m_PlayerRequest.m_aServer));
 	ASSERT_FALSE(CScoreWorker::ShowRank(m_pConn, &m_PlayerRequest, m_aError, sizeof(m_aError))) << m_aError;
-	ExpectLines(m_pPlayerResult, {"nameless tee - 01:40.00 - better than 100% - requested by brainless tee", "Global rank 1"}, true);
+	ExpectLines(m_pPlayerResult, {"nameless tee - 01:40.00 - requested by brainless tee", "Global rank 1"}, true);
 }
 
 TEST_P(SingleScore, LoadPlayerData)


### PR DESCRIPTION
Before:
```
MariaDB [teeworlds]> SELECT Ranking, Time, PercentRank
    -> FROM (
    ->   SELECT RANK() OVER w AS Ranking, PERCENT_RANK() OVER w as PercentRank, MIN(Time) AS Time, Name
    ->   FROM record_race
    ->   WHERE Map = 'Tutorial'
    ->   AND Server LIKE '%'
    ->   GROUP BY Name
    ->   WINDOW w AS (ORDER BY MIN(Time))
    -> ) as a
    -> WHERE Name = 'deen';
+---------+--------+--------------+
| Ranking | Time   | PercentRank  |
+---------+--------+--------------+
|   13674 | 191.54 | 0.0230672938 |
+---------+--------+--------------+
1 row in set (2.388 sec)
```
After:
```
MariaDB [teeworlds]> SELECT COUNT(DISTINCT Name) + 1, (SELECT MIN(Time)
    ->   FROM record_race
    ->   WHERE Map = 'Tutorial'
    ->   AND Name = 'deen'
    ->   AND Server LIKE '%'
    ->   GROUP BY Name
    ->   LIMIT 1) as minTime
    -> FROM record_race
    -> WHERE Map = 'Tutorial'
    -> AND Server LIKE '%'
    -> AND Time < (SELECT MIN(Time)
    ->   FROM record_race
    ->   WHERE Map = 'Tutorial'
    ->   AND Name = 'deen'
    ->   AND Server LIKE '%'
    ->   GROUP BY Name
    ->   LIMIT 1
    -> );
+--------------------------+---------+
| COUNT(DISTINCT Name) + 1 | minTime |
+--------------------------+---------+
|                    13674 |  191.54 |
+--------------------------+---------+
1 row in set (0.028 sec)
```
We no longer have "better than X%", but I think it's not that important, I can't calculate it cheaply. /rankteam still has it and is cheap enough because no one plays in team.
## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
