### PR TITLE
Use `Ipv6::to_ipv4_mapped` in mastersrv

### DIFF
--- a/src/mastersrv/src/main.rs
+++ b/src/mastersrv/src/main.rs
@@ -1009,11 +1009,8 @@ async fn main() {
             addr.unwrap().ip()
         };
         if let IpAddr::V6(v6) = addr {
-            if let Some(v4) = v6.to_ipv4() {
-                // TODO: switch to `to_ipv4_mapped` in the future.
-                if !v6.is_loopback() {
-                    addr = IpAddr::from(v4);
-                }
+            if let Some(v4) = v6.to_ipv4_mapped() {
+                addr = IpAddr::from(v4);
             }
         }
         Ok(addr)


### PR DESCRIPTION
Needs Rust 1.63.0, should be old enough at this point.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
