### PR TITLE
Adjust slider handle size

### DIFF
--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -1332,9 +1332,18 @@ float CUi::DoScrollbarH(const void *pId, const CUIRect *pRect, float Current, co
 	Rail.VSplitLeft(pColorInner ? 8.0f : clamp(33.0f, Rail.h, Rail.w / 3.0f), &Handle, 0);
 	Handle.x += (Rail.w - Handle.w) * Current;
 
+	CUIRect HandleArea = Handle;
+	if(!pColorInner)
+	{
+		HandleArea.h = pRect->h * 0.9f;
+		HandleArea.y = pRect->y + pRect->h * 0.05f;
+		HandleArea.w += 6.0f;
+		HandleArea.x -= 3.0f;
+	}
+
 	// logic
 	const bool InsideRail = MouseHovered(&Rail);
-	const bool InsideHandle = MouseHovered(&Handle);
+	const bool InsideHandle = MouseHovered(&HandleArea);
 	bool Grabbed = false; // whether to apply the offset
 
 	if(CheckActiveItem(pId))
@@ -1366,6 +1375,12 @@ float CUi::DoScrollbarH(const void *pId, const CUIRect *pRect, float Current, co
 		Grabbed = true;
 	}
 
+	if(!pColorInner && (InsideHandle || Grabbed) && (CheckActiveItem(pId) || HotItem() == pId))
+	{
+		Handle.h += 3.0f;
+		Handle.y -= 1.5f;
+	}
+
 	if(InsideHandle && !MouseButton(0))
 	{
 		SetHotItem(pId);
@@ -1394,7 +1409,7 @@ float CUi::DoScrollbarH(const void *pId, const CUIRect *pRect, float Current, co
 	else
 	{
 		Rail.Draw(ColorRGBA(1.0f, 1.0f, 1.0f, 0.25f), IGraphics::CORNER_ALL, Rail.h / 2.0f);
-		Handle.Draw(HandleColor, IGraphics::CORNER_ALL, Handle.h / 2.0f);
+		Handle.Draw(HandleColor, IGraphics::CORNER_ALL, Rail.h / 2.0f);
 	}
 
 	return ReturnValue;


### PR DESCRIPTION
Motivation: It's annoying how hard it is to grab the sliders when we have so much extra space between them. 

### Before:
![image](https://github.com/user-attachments/assets/88092d28-c0b9-4c19-afb0-05386485b286)
![image](https://github.com/user-attachments/assets/19ee4fcb-b580-457e-9fc0-23f545af3f7d)
![image](https://github.com/user-attachments/assets/ee87966b-0171-401a-ba4b-c2a6c833d7a4)


### After:
![image](https://github.com/user-attachments/assets/3801d91c-8a6f-4bbe-845a-da0382fd7a2f)
![image](https://github.com/user-attachments/assets/2276adcd-adef-44ae-8701-d65a04f104ca)
![image](https://github.com/user-attachments/assets/48096b65-93d9-444a-8cb0-d2575ac122f7)



## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
