### PR TITLE
Remove clang-tidy `static` variable name exceptions

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -121,8 +121,6 @@ CheckOptions:
     value:           ms_
   - key:             readability-identifier-naming.StaticVariablePrefix
     value:           s_
-  - key:             readability-identifier-naming.StaticVariableIgnoredRegexp
-    value:           '^(NullAddr$|aDummyNameBuf$|aModifier$|EXPLANATION$|LocalClientId$|Dir$|LOCATION_NAMES$|EditorHotkeyWasPressed$|EditorHotKeyChecktime$|FrictionFraction$|LastTime$|SkidSoundTime$|NewVal$|aRotated$).*'
   - key:             readability-identifier-naming.ClassMethodCase
     value:           CamelCase
   - key:             readability-identifier-naming.ClassCase

--- a/src/engine/client.h
+++ b/src/engine/client.h
@@ -247,7 +247,7 @@ public:
 
 	//
 	virtual const char *PlayerName() const = 0;
-	virtual const char *DummyName() const = 0;
+	virtual const char *DummyName() = 0;
 	virtual const char *ErrorString() const = 0;
 	virtual const char *LatestVersion() const = 0;
 	virtual bool ConnectionProblems() const = 0;

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -876,7 +876,7 @@ const char *CClient::PlayerName() const
 	return "nameless tee";
 }
 
-const char *CClient::DummyName() const
+const char *CClient::DummyName()
 {
 	if(g_Config.m_ClDummyName[0])
 	{
@@ -893,9 +893,8 @@ const char *CClient::DummyName() const
 	}
 	if(pBase)
 	{
-		static char aDummyNameBuf[16];
-		str_format(aDummyNameBuf, sizeof(aDummyNameBuf), "[D] %s", pBase);
-		return aDummyNameBuf;
+		str_format(m_aAutomaticDummyName, sizeof(m_aAutomaticDummyName), "[D] %s", pBase);
+		return m_aAutomaticDummyName;
 	}
 	return "brainless tee";
 }

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -255,6 +255,9 @@ class CClient : public IClient, public CDemoPlayer::IListener
 	std::shared_ptr<ILogger> m_pFileLogger = nullptr;
 	std::shared_ptr<ILogger> m_pStdoutLogger = nullptr;
 
+	// For DummyName function
+	char m_aAutomaticDummyName[MAX_NAME_LENGTH];
+
 public:
 	IConfigManager *ConfigManager() { return m_pConfigManager; }
 	CConfig *Config() { return m_pConfig; }
@@ -339,7 +342,7 @@ public:
 	void Quit() override;
 
 	const char *PlayerName() const override;
-	const char *DummyName() const override;
+	const char *DummyName() override;
 	const char *ErrorString() const override;
 
 	const char *LoadMap(const char *pName, const char *pFilename, SHA256_DIGEST *pWantedSha256, unsigned WantedCrc);

--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -590,7 +590,7 @@ bool CGraphics_Threaded::LoadPng(CImageInfo &Image, const char *pFilename, int S
 				SWarning Warning;
 				str_format(Warning.m_aWarningMsg, sizeof(Warning.m_aWarningMsg), Localize("\"%s\" is not compatible with pnglite and cannot be loaded by old DDNet versions: "), pFilename);
 				static const int FLAGS[] = {PNGLITE_COLOR_TYPE, PNGLITE_BIT_DEPTH, PNGLITE_INTERLACE_TYPE, PNGLITE_COMPRESSION_TYPE, PNGLITE_FILTER_TYPE};
-				static const char *EXPLANATION[] = {"color type", "bit depth", "interlace type", "compression type", "filter type"};
+				static const char *const EXPLANATION[] = {"color type", "bit depth", "interlace type", "compression type", "filter type"};
 
 				bool First = true;
 				for(size_t i = 0; i < std::size(FLAGS); ++i)

--- a/src/engine/shared/network_server.cpp
+++ b/src/engine/shared/network_server.cpp
@@ -122,8 +122,8 @@ int CNetServer::Update()
 
 SECURITY_TOKEN CNetServer::GetGlobalToken()
 {
-	static NETADDR NullAddr = {0};
-	return GetToken(NullAddr);
+	static const NETADDR NULL_ADDR = {0};
+	return GetToken(NULL_ADDR);
 }
 SECURITY_TOKEN CNetServer::GetToken(const NETADDR &Addr)
 {

--- a/src/game/client/components/binds.h
+++ b/src/game/client/components/binds.h
@@ -72,7 +72,7 @@ public:
 	static int GetModifierMask(IInput *pInput);
 	static int GetModifierMaskOfKey(int Key);
 	static const char *GetModifierName(int Modifier);
-	static const char *GetKeyBindModifiersName(int ModifierCombination);
+	static void GetKeyBindModifiersName(int ModifierCombination, char *pBuf, size_t BufSize);
 
 	virtual void OnConsoleInit() override;
 	virtual bool OnInput(const IInput::CEvent &Event) override;

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -343,9 +343,8 @@ void CHud::RenderScoreHud()
 					aScore[t][0] = 0;
 			}
 
-			static int LocalClientId = -1;
-			bool RecreateScores = str_comp(aScore[0], m_aScoreInfo[0].m_aScoreText) != 0 || str_comp(aScore[1], m_aScoreInfo[1].m_aScoreText) != 0 || LocalClientId != m_pClient->m_Snap.m_LocalClientId;
-			LocalClientId = m_pClient->m_Snap.m_LocalClientId;
+			bool RecreateScores = str_comp(aScore[0], m_aScoreInfo[0].m_aScoreText) != 0 || str_comp(aScore[1], m_aScoreInfo[1].m_aScoreText) != 0 || m_LastLocalClientId != m_pClient->m_Snap.m_LocalClientId;
+			m_LastLocalClientId = m_pClient->m_Snap.m_LocalClientId;
 
 			bool RecreateRect = ForceScoreInfoInit;
 			for(int t = 0; t < 2; t++)

--- a/src/game/client/components/hud.h
+++ b/src/game/client/components/hud.h
@@ -77,7 +77,10 @@ class CHud : public CComponent
 	void RenderGameTimer();
 	void RenderPauseNotification();
 	void RenderSuddenDeath();
+
 	void RenderScoreHud();
+	int m_LastLocalClientId = -1;
+
 	void RenderSpectatorHud();
 	void RenderWarmupTimer();
 	void RenderLocalTime(float x);

--- a/src/game/client/components/menu_background.cpp
+++ b/src/game/client/components/menu_background.cpp
@@ -307,15 +307,14 @@ bool CMenuBackground::Render()
 		return false;
 
 	m_Camera.m_Zoom = 0.7f;
-	static vec2 Dir = vec2(1.0f, 0.0f);
 
 	float DistToCenter = distance(m_Camera.m_Center, m_RotationCenter);
 	if(!m_ChangedPosition && absolute(DistToCenter - (float)g_Config.m_ClRotationRadius) <= 0.5f)
 	{
 		// do little rotation
 		float RotPerTick = 360.0f / (float)g_Config.m_ClRotationSpeed * clamp(Client()->RenderFrameTime(), 0.0f, 0.1f);
-		Dir = rotate(Dir, RotPerTick);
-		m_Camera.m_Center = m_RotationCenter + Dir * (float)g_Config.m_ClRotationRadius;
+		m_CurrentDirection = rotate(m_CurrentDirection, RotPerTick);
+		m_Camera.m_Center = m_RotationCenter + m_CurrentDirection * (float)g_Config.m_ClRotationRadius;
 	}
 	else
 	{
@@ -328,16 +327,16 @@ bool CMenuBackground::Render()
 		vec2 TargetPos = m_RotationCenter + DirToCenter * (float)g_Config.m_ClRotationRadius;
 		float Distance = distance(m_AnimationStartPos, TargetPos);
 		if(Distance > 0.001f)
-			Dir = normalize(m_AnimationStartPos - TargetPos);
+			m_CurrentDirection = normalize(m_AnimationStartPos - TargetPos);
 		else
-			Dir = vec2(1, 0);
+			m_CurrentDirection = vec2(1.0f, 0.0f);
 
 		// move time
 		m_MoveTime += clamp(Client()->RenderFrameTime(), 0.0f, 0.1f) * g_Config.m_ClCameraSpeed / 10.0f;
 		float XVal = 1 - m_MoveTime;
 		XVal = std::pow(XVal, 7.0f);
 
-		m_Camera.m_Center = TargetPos + Dir * (XVal * Distance);
+		m_Camera.m_Center = TargetPos + m_CurrentDirection * (XVal * Distance);
 		if(m_CurrentPosition < 0)
 		{
 			m_AnimationStartPos = m_Camera.m_Center;

--- a/src/game/client/components/menu_background.h
+++ b/src/game/client/components/menu_background.h
@@ -85,6 +85,7 @@ public:
 	vec2 m_RotationCenter;
 	std::array<vec2, NUM_POS> m_aPositions;
 	int m_CurrentPosition;
+	vec2 m_CurrentDirection = vec2(1.0f, 0.0f);
 	vec2 m_AnimationStartPos;
 	bool m_ChangedPosition;
 	float m_MoveTime;

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -503,7 +503,11 @@ int CMenus::DoKeyReader(const void *pId, const CUIRect *pRect, int Key, int Modi
 	else if(NewKey == 0)
 		aBuf[0] = '\0';
 	else
-		str_format(aBuf, sizeof(aBuf), "%s%s", CBinds::GetKeyBindModifiersName(*pNewModifierCombination), Input()->KeyName(NewKey));
+	{
+		char aModifiers[128];
+		CBinds::GetKeyBindModifiersName(*pNewModifierCombination, aModifiers, sizeof(aModifiers));
+		str_format(aBuf, sizeof(aBuf), "%s%s", aModifiers, Input()->KeyName(NewKey));
+	}
 
 	const ColorRGBA Color = m_Binder.m_pKeyReaderId == pId && m_Binder.m_TakeKey ? ColorRGBA(0.0f, 1.0f, 0.0f, 0.4f) : ColorRGBA(1.0f, 1.0f, 1.0f, 0.5f * Ui()->ButtonColorMul(pId));
 	pRect->Draw(Color, IGraphics::CORNER_ALL, 5.0f);

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -460,6 +460,8 @@ protected:
 
 	// found in menus_start.cpp
 	void RenderStartMenu(CUIRect MainView);
+	bool m_EditorHotkeyWasPressed = true;
+	float m_EditorHotKeyChecktime = 0.0f;
 
 	// found in menus_ingame.cpp
 	STextContainerIndex m_MotdTextContainerIndex;

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -33,7 +33,7 @@ static void FormatServerbrowserPing(char (&aBuffer)[N], const CServerInfo *pInfo
 		str_format(aBuffer, sizeof(aBuffer), "%d", pInfo->m_Latency);
 		return;
 	}
-	static const char *LOCATION_NAMES[CServerInfo::NUM_LOCS] = {
+	static const char *const LOCATION_NAMES[CServerInfo::NUM_LOCS] = {
 		"", // LOC_UNKNOWN
 		Localizable("AFR"), // LOC_AFRICA
 		Localizable("ASI"), // LOC_ASIA

--- a/src/game/client/components/menus_start.cpp
+++ b/src/game/client/components/menus_start.cpp
@@ -154,21 +154,19 @@ void CMenus::RenderStartMenu(CUIRect MainView)
 	}
 #endif
 
-	static bool EditorHotkeyWasPressed = true;
-	static float EditorHotKeyChecktime = 0.0f;
 	Menu.HSplitBottom(5.0f, &Menu, 0); // little space
 	Menu.HSplitBottom(40.0f, &Menu, &Button);
 	static CButtonContainer s_MapEditorButton;
-	if(DoButton_Menu(&s_MapEditorButton, Localize("Editor"), 0, &Button, g_Config.m_ClShowStartMenuImages ? "editor" : 0, IGraphics::CORNER_ALL, Rounding, 0.5f, m_pClient->Editor()->HasUnsavedData() ? ColorRGBA(0.0f, 1.0f, 0.0f, 0.25f) : ColorRGBA(0.0f, 0.0f, 0.0f, 0.25f)) || (!EditorHotkeyWasPressed && Client()->LocalTime() - EditorHotKeyChecktime < 0.1f && CheckHotKey(KEY_E)))
+	if(DoButton_Menu(&s_MapEditorButton, Localize("Editor"), 0, &Button, g_Config.m_ClShowStartMenuImages ? "editor" : 0, IGraphics::CORNER_ALL, Rounding, 0.5f, m_pClient->Editor()->HasUnsavedData() ? ColorRGBA(0.0f, 1.0f, 0.0f, 0.25f) : ColorRGBA(0.0f, 0.0f, 0.0f, 0.25f)) || (!m_EditorHotkeyWasPressed && Client()->LocalTime() - m_EditorHotKeyChecktime < 0.1f && CheckHotKey(KEY_E)))
 	{
 		g_Config.m_ClEditor = 1;
 		Input()->MouseModeRelative();
-		EditorHotkeyWasPressed = true;
+		m_EditorHotkeyWasPressed = true;
 	}
 	if(!Input()->KeyIsPressed(KEY_E))
 	{
-		EditorHotkeyWasPressed = false;
-		EditorHotKeyChecktime = Client()->LocalTime();
+		m_EditorHotkeyWasPressed = false;
+		m_EditorHotKeyChecktime = Client()->LocalTime();
 	}
 
 	Menu.HSplitBottom(5.0f, &Menu, 0); // little space

--- a/src/game/client/components/particles.cpp
+++ b/src/game/client/components/particles.cpp
@@ -78,17 +78,16 @@ void CParticles::Update(float TimePassed)
 	if(TimePassed <= 0.0f)
 		return;
 
-	static float FrictionFraction = 0;
-	FrictionFraction += TimePassed;
+	m_FrictionFraction += TimePassed;
 
-	if(FrictionFraction > 2.0f) // safety measure
-		FrictionFraction = 0;
+	if(m_FrictionFraction > 2.0f) // safety measure
+		m_FrictionFraction = 0;
 
 	int FrictionCount = 0;
-	while(FrictionFraction > 0.05f)
+	while(m_FrictionFraction > 0.05f)
 	{
 		FrictionCount++;
-		FrictionFraction -= 0.05f;
+		m_FrictionFraction -= 0.05f;
 	}
 
 	for(int &FirstPart : m_aFirstPart)
@@ -149,22 +148,21 @@ void CParticles::OnRender()
 		return;
 
 	set_new_tick();
-	static int64_t LastTime = 0;
 	int64_t t = time();
 
 	if(Client()->State() == IClient::STATE_DEMOPLAYBACK)
 	{
 		const IDemoPlayer::CInfo *pInfo = DemoPlayer()->BaseInfo();
 		if(!pInfo->m_Paused)
-			Update((float)((t - LastTime) / (double)time_freq()) * pInfo->m_Speed);
+			Update((float)((t - m_LastRenderTime) / (double)time_freq()) * pInfo->m_Speed);
 	}
 	else
 	{
 		if(m_pClient->m_Snap.m_pGameInfoObj && !(m_pClient->m_Snap.m_pGameInfoObj->m_GameStateFlags & GAMESTATEFLAG_PAUSED))
-			Update((float)((t - LastTime) / (double)time_freq()));
+			Update((float)((t - m_LastRenderTime) / (double)time_freq()));
 	}
 
-	LastTime = t;
+	m_LastRenderTime = t;
 }
 
 void CParticles::OnInit()

--- a/src/game/client/components/particles.h
+++ b/src/game/client/components/particles.h
@@ -96,6 +96,9 @@ private:
 	int m_FirstFree;
 	int m_aFirstPart[NUM_GROUPS];
 
+	float m_FrictionFraction = 0.0f;
+	int64_t m_LastRenderTime = 0;
+
 	void RenderGroup(int Group);
 	void Update(float TimePassed);
 

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -460,12 +460,11 @@ void CPlayers::RenderPlayer(
 	// do skidding
 	if(!InAir && WantOtherDir && length(Vel * 50) > 500.0f)
 	{
-		static int64_t SkidSoundTime = 0;
-		if(time() - SkidSoundTime > time_freq() / 10)
+		if(time() - m_SkidSoundTime > time_freq() / 10)
 		{
 			if(g_Config.m_SndGame)
 				m_pClient->m_Sounds.PlayAt(CSounds::CHN_WORLD, SOUND_PLAYER_SKID, 0.25f, Position);
-			SkidSoundTime = time();
+			m_SkidSoundTime = time();
 		}
 
 		m_pClient->m_Effects.SkidTrail(

--- a/src/game/client/components/players.h
+++ b/src/game/client/components/players.h
@@ -34,6 +34,8 @@ class CPlayers : public CComponent
 	int m_WeaponEmoteQuadContainerIndex;
 	int m_aWeaponSpriteMuzzleQuadContainerIndex[NUM_WEAPONS];
 
+	int64_t m_SkidSoundTime = 0;
+
 public:
 	float GetPlayerTargetAngle(
 		const CNetObj_Character *pPrevChar,

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -2845,9 +2845,9 @@ void CEditor::DoQuadEnvelopes(const std::vector<CQuad> &vQuads, IGraphics::CText
 			Graphics()->SetColorVertex(aArray, 4);
 
 			// Rotation
+			CPoint aRotated[4];
 			if(Rot != 0)
 			{
-				static CPoint aRotated[4];
 				aRotated[0] = vQuads[j].m_aPoints[0];
 				aRotated[1] = vQuads[j].m_aPoints[1];
 				aRotated[2] = vQuads[j].m_aPoints[2];

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -2508,7 +2508,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupTele(void *pContext, CUIRect View, b
 
 		static int s_aIds[NUM_PROPS] = {0};
 
-		static int NewVal = 0;
+		int NewVal = 0;
 		int Prop = pEditor->DoProperties(&NumberPicker, aProps, s_aIds, &NewVal, s_vColors);
 		if(Prop == PROP_TELE)
 			pEditor->m_TeleNumber = (NewVal - 1 + 255) % 255 + 1;


### PR DESCRIPTION
- Remove `readability-identifier-naming.StaticVariableIgnoredRegexp`.
- Mark `static` variables as `const` and use `UPPER_CASE` for names when possible.
- Use local variables instead of `static` variables when possible.
- Use member variables with correct name instead of `static` variables.
- Pass output buffer for `static` function `GetKeyBindModifiersName` by argument instead of returning pointer to `static` buffer.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
