### PR TITLE
Various refactoring of 0.7 skin loading

### DIFF
--- a/src/game/client/components/skins.cpp
+++ b/src/game/client/components/skins.cpp
@@ -298,7 +298,7 @@ const CSkin *CSkins::LoadSkin(const char *pName, CImageInfo &Info)
 
 	if(g_Config.m_Debug)
 	{
-		log_trace("skins", "Loaded skin %s", Skin.GetName());
+		log_trace("skins", "Loaded skin '%s'", Skin.GetName());
 	}
 
 	auto &&pSkin = std::make_unique<CSkin>(std::move(Skin));

--- a/src/game/client/components/skins7.h
+++ b/src/game/client/components/skins7.h
@@ -92,6 +92,9 @@ private:
 
 	static int SkinPartScan(const char *pName, int IsDir, int DirType, void *pUser);
 	static int SkinScan(const char *pName, int IsDir, int DirType, void *pUser);
+
+	void LoadXmasHat();
+	void LoadBotDecoration();
 };
 
 #endif


### PR DESCRIPTION
- Only log successful log messages when `debug` is enabled, consistent with logging for regular skins.
- Use `IsImageFormatRgba` to check for RGBA image format, so this also shows a warning popup.
- Remove redundant logic for non-RGBA image data.
- Use `CheckImageDivisibility` instead of enforcing exact size of xmas hat and bot decoration images to allow higher resolution images.
- Fix image data not being freed if it has the wrong format or ratio.
- Fix potential integer overflow when calculating skin part blood color (same as for regular skins).
- Extract `LoadXmasHat` and `LoadBotDecoration` functions for readability.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
