### PR TITLE
Distinguish birthday from finish events

### DIFF
--- a/datasrc/network.py
+++ b/datasrc/network.py
@@ -345,6 +345,8 @@ Objects = [
 		NetIntAny("m_Angle"),
 	]),
 
+	NetEventEx("Birthday:Common", "birthday@netevent.ddnet.org", []),
+
 	NetEventEx("Finish:Common", "finish@netevent.ddnet.org", []),
 
 	NetObjectEx("MyOwnEvent", "my-own-event@heinrich5991.de", [

--- a/src/game/client/components/effects.cpp
+++ b/src/game/client/components/effects.cpp
@@ -226,7 +226,7 @@ void CEffects::PlayerDeath(vec2 Pos, int ClientId, float Alpha)
 	}
 }
 
-void CEffects::FinishConfetti(vec2 Pos, float Alpha)
+void CEffects::Confetti(vec2 Pos, float Alpha)
 {
 	ColorRGBA Red(1.0f, 0.4f, 0.4f);
 	ColorRGBA Green(0.4f, 1.0f, 0.4f);

--- a/src/game/client/components/effects.h
+++ b/src/game/client/components/effects.h
@@ -30,7 +30,7 @@ public:
 	void PlayerDeath(vec2 Pos, int ClientId, float Alpha = 1.0f);
 	void PowerupShine(vec2 Pos, vec2 Size, float Alpha = 1.0f);
 	void FreezingFlakes(vec2 Pos, vec2 Size, float Alpha = 1.0f);
-	void FinishConfetti(vec2 Pos, float Alpha = 1.0f);
+	void Confetti(vec2 Pos, float Alpha = 1.0f);
 
 	void Update();
 };

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1183,10 +1183,15 @@ void CGameClient::ProcessEvents()
 			const CNetEvent_HammerHit *pEvent = (const CNetEvent_HammerHit *)Item.m_pData;
 			m_Effects.HammerHit(vec2(pEvent->m_X, pEvent->m_Y), Alpha);
 		}
+		else if(Item.m_Type == NETEVENTTYPE_BIRTHDAY)
+		{
+			const CNetEvent_Birthday *pEvent = (const CNetEvent_Birthday *)Item.m_pData;
+			m_Effects.Confetti(vec2(pEvent->m_X, pEvent->m_Y), Alpha);
+		}
 		else if(Item.m_Type == NETEVENTTYPE_FINISH)
 		{
 			const CNetEvent_Finish *pEvent = (const CNetEvent_Finish *)Item.m_pData;
-			m_Effects.FinishConfetti(vec2(pEvent->m_X, pEvent->m_Y), Alpha);
+			m_Effects.Confetti(vec2(pEvent->m_X, pEvent->m_Y), Alpha);
 		}
 		else if(Item.m_Type == NETEVENTTYPE_SPAWN)
 		{

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -258,7 +258,6 @@ void CGameContext::CreateDamageInd(vec2 Pos, float Angle, int Amount, CClientMas
 
 void CGameContext::CreateHammerHit(vec2 Pos, CClientMask Mask)
 {
-	// create the event
 	CNetEvent_HammerHit *pEvent = m_Events.Create<CNetEvent_HammerHit>(Mask);
 	if(pEvent)
 	{
@@ -327,7 +326,6 @@ void CGameContext::CreateExplosion(vec2 Pos, int Owner, int Weapon, bool NoDamag
 
 void CGameContext::CreatePlayerSpawn(vec2 Pos, CClientMask Mask)
 {
-	// create the event
 	CNetEvent_Spawn *pEvent = m_Events.Create<CNetEvent_Spawn>(Mask);
 	if(pEvent)
 	{
@@ -338,7 +336,6 @@ void CGameContext::CreatePlayerSpawn(vec2 Pos, CClientMask Mask)
 
 void CGameContext::CreateDeath(vec2 Pos, int ClientId, CClientMask Mask)
 {
-	// create the event
 	CNetEvent_Death *pEvent = m_Events.Create<CNetEvent_Death>(Mask);
 	if(pEvent)
 	{
@@ -350,7 +347,6 @@ void CGameContext::CreateDeath(vec2 Pos, int ClientId, CClientMask Mask)
 
 void CGameContext::CreateFinishConfetti(vec2 Pos, CClientMask Mask)
 {
-	// create the event
 	CNetEvent_Finish *pEvent = m_Events.Create<CNetEvent_Finish>(Mask);
 	if(pEvent)
 	{

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -345,7 +345,17 @@ void CGameContext::CreateDeath(vec2 Pos, int ClientId, CClientMask Mask)
 	}
 }
 
-void CGameContext::CreateFinishConfetti(vec2 Pos, CClientMask Mask)
+void CGameContext::CreateBirthdayEffect(vec2 Pos, CClientMask Mask)
+{
+	CNetEvent_Birthday *pEvent = m_Events.Create<CNetEvent_Birthday>(Mask);
+	if(pEvent)
+	{
+		pEvent->m_X = (int)Pos.x;
+		pEvent->m_Y = (int)Pos.y;
+	}
+}
+
+void CGameContext::CreateFinishEffect(vec2 Pos, CClientMask Mask)
 {
 	CNetEvent_Finish *pEvent = m_Events.Create<CNetEvent_Finish>(Mask);
 	if(pEvent)

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -239,7 +239,8 @@ public:
 	void CreateHammerHit(vec2 Pos, CClientMask Mask = CClientMask().set());
 	void CreatePlayerSpawn(vec2 Pos, CClientMask Mask = CClientMask().set());
 	void CreateDeath(vec2 Pos, int ClientId, CClientMask Mask = CClientMask().set());
-	void CreateFinishConfetti(vec2 Pos, CClientMask Mask = CClientMask().set());
+	void CreateBirthdayEffect(vec2 Pos, CClientMask Mask = CClientMask().set());
+	void CreateFinishEffect(vec2 Pos, CClientMask Mask = CClientMask().set());
 	void CreateSound(vec2 Pos, int Sound, CClientMask Mask = CClientMask().set());
 	void CreateSoundGlobal(int Sound, int Target = -1) const;
 

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -937,7 +937,7 @@ void CPlayer::ProcessScoreResult(CScorePlayerResult &Result)
 				GameServer()->SendBroadcast(aBuf, m_ClientId);
 				m_BirthdayAnnounced = true;
 
-				GameServer()->CreateFinishConfetti(GetCharacter()->m_Pos, GetCharacter()->TeamMask());
+				GameServer()->CreateBirthdayEffect(GetCharacter()->m_Pos, GetCharacter()->TeamMask());
 			}
 			GameServer()->SendRecord(m_ClientId);
 			break;

--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -854,7 +854,7 @@ void CGameTeams::OnFinish(CPlayer *Player, int TimeTicks, const char *pTimestamp
 
 	// Confetti
 	CCharacter *pChar = Player->GetCharacter();
-	m_pGameContext->CreateFinishConfetti(pChar->m_Pos, pChar->TeamMask());
+	m_pGameContext->CreateFinishEffect(pChar->m_Pos, pChar->TeamMask());
 }
 
 void CGameTeams::RequestTeamSwap(CPlayer *pPlayer, CPlayer *pTargetPlayer, int Team)


### PR DESCRIPTION
This allows us to give birthdays a different effect in the future if we want to.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
