### PR TITLE
Support different skin states for dummy and main in 0.7 connections

### DIFF
--- a/src/engine/client.h
+++ b/src/engine/client.h
@@ -390,7 +390,7 @@ public:
 
 	virtual int ClientVersion7() const = 0;
 
-	virtual void ApplySkin7InfoFromSnapObj(const protocol7::CNetObj_De_ClientInfo *pObj, int ClientId, int Conn) = 0;
+	virtual void ApplySkin7InfoFromSnapObj(const protocol7::CNetObj_De_ClientInfo *pObj, int ClientId) = 0;
 	virtual int OnDemoRecSnap7(class CSnapshot *pFrom, class CSnapshot *pTo, int Conn) = 0;
 	virtual int TranslateSnap(class CSnapshot *pSnapDstSix, class CSnapshot *pSnapSrcSeven, int Conn, bool Dummy) = 0;
 };

--- a/src/engine/client.h
+++ b/src/engine/client.h
@@ -390,7 +390,7 @@ public:
 
 	virtual int ClientVersion7() const = 0;
 
-	virtual void ApplySkin7InfoFromSnapObj(const protocol7::CNetObj_De_ClientInfo *pObj, int ClientId) = 0;
+	virtual void ApplySkin7InfoFromSnapObj(const protocol7::CNetObj_De_ClientInfo *pObj, int ClientId, int Conn) = 0;
 	virtual int OnDemoRecSnap7(class CSnapshot *pFrom, class CSnapshot *pTo, int Conn) = 0;
 	virtual int TranslateSnap(class CSnapshot *pSnapDstSix, class CSnapshot *pSnapSrcSeven, int Conn, bool Dummy) = 0;
 };

--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -839,13 +839,13 @@ void CChat::AddLine(int ClientId, int Team, const char *pLine)
 							pCurrentLine->m_Sixup.m_aColors[Part] = vec4(1.0f, 1.0f, 1.0f, 1.0f);
 						}
 
-						if(LineAuthor.m_SkinInfo.m_Sixup.m_HatTexture.IsValid())
+						if(LineAuthor.m_SkinInfo.m_Sixup[g_Config.m_ClDummy].m_HatTexture.IsValid())
 						{
 							if(Part == protocol7::SKINPART_BODY && str_comp(pPartName, "standard"))
 								pCurrentLine->m_Sixup.m_HatSpriteIndex = CSkins7::HAT_OFFSET_SIDE + (ClientId % CSkins7::HAT_NUM);
 							if(Part == protocol7::SKINPART_DECORATION && str_comp(pPartName, "twinbopp"))
 								pCurrentLine->m_Sixup.m_HatSpriteIndex = CSkins7::HAT_OFFSET_SIDE + (ClientId % CSkins7::HAT_NUM);
-							pCurrentLine->m_Sixup.m_HatTexture = LineAuthor.m_SkinInfo.m_Sixup.m_HatTexture;
+							pCurrentLine->m_Sixup.m_HatTexture = LineAuthor.m_SkinInfo.m_Sixup[g_Config.m_ClDummy].m_HatTexture;
 						}
 					}
 				}
@@ -1303,10 +1303,10 @@ void CChat::OnRender()
 				{
 					for(int Part = 0; Part < protocol7::NUM_SKINPARTS; Part++)
 					{
-						RenderInfo.m_Sixup.m_aColors[Part] = Line.m_Sixup.m_aColors[Part];
-						RenderInfo.m_Sixup.m_aTextures[Part] = Line.m_Sixup.m_aTextures[Part];
-						RenderInfo.m_Sixup.m_HatSpriteIndex = Line.m_Sixup.m_HatSpriteIndex;
-						RenderInfo.m_Sixup.m_HatTexture = Line.m_Sixup.m_HatTexture;
+						RenderInfo.m_Sixup[g_Config.m_ClDummy].m_aColors[Part] = Line.m_Sixup.m_aColors[Part];
+						RenderInfo.m_Sixup[g_Config.m_ClDummy].m_aTextures[Part] = Line.m_Sixup.m_aTextures[Part];
+						RenderInfo.m_Sixup[g_Config.m_ClDummy].m_HatSpriteIndex = Line.m_Sixup.m_HatSpriteIndex;
+						RenderInfo.m_Sixup[g_Config.m_ClDummy].m_HatTexture = Line.m_Sixup.m_HatTexture;
 					}
 				}
 

--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -823,14 +823,14 @@ void CChat::AddLine(int ClientId, int Team, const char *pLine)
 				{
 					for(int Part = 0; Part < protocol7::NUM_SKINPARTS; Part++)
 					{
-						const char *pPartName = LineAuthor.m_Sixup.m_aaSkinPartNames[Part];
+						const char *pPartName = LineAuthor.m_Sixup[g_Config.m_ClDummy].m_aaSkinPartNames[Part];
 						int Id = m_pClient->m_Skins7.FindSkinPart(Part, pPartName, false);
 						const CSkins7::CSkinPart *pSkinPart = m_pClient->m_Skins7.GetSkinPart(Part, Id);
-						if(LineAuthor.m_Sixup.m_aUseCustomColors[Part])
+						if(LineAuthor.m_Sixup[g_Config.m_ClDummy].m_aUseCustomColors[Part])
 						{
 							pCurrentLine->m_Sixup.m_aTextures[Part] = pSkinPart->m_ColorTexture;
 							pCurrentLine->m_Sixup.m_aColors[Part] = m_pClient->m_Skins7.GetColor(
-								LineAuthor.m_Sixup.m_aSkinPartColors[Part],
+								LineAuthor.m_Sixup[g_Config.m_ClDummy].m_aSkinPartColors[Part],
 								Part == protocol7::SKINPART_MARKING);
 						}
 						else

--- a/src/game/client/components/menus_settings7.cpp
+++ b/src/game/client/components/menus_settings7.cpp
@@ -117,13 +117,13 @@ void CMenus::RenderSettingsTee7(CUIRect MainView)
 			const CSkins7::CSkinPart *pSkinPart = m_pClient->m_Skins7.GetSkinPart(Part, SkinPart);
 			if(aUCCVars[Part])
 			{
-				OwnSkinInfo.m_Sixup.m_aTextures[Part] = pSkinPart->m_ColorTexture;
-				OwnSkinInfo.m_Sixup.m_aColors[Part] = m_pClient->m_Skins7.GetColor(aColorVars[Part], Part == protocol7::SKINPART_MARKING);
+				OwnSkinInfo.m_Sixup[g_Config.m_ClDummy].m_aTextures[Part] = pSkinPart->m_ColorTexture;
+				OwnSkinInfo.m_Sixup[g_Config.m_ClDummy].m_aColors[Part] = m_pClient->m_Skins7.GetColor(aColorVars[Part], Part == protocol7::SKINPART_MARKING);
 			}
 			else
 			{
-				OwnSkinInfo.m_Sixup.m_aTextures[Part] = pSkinPart->m_OrgTexture;
-				OwnSkinInfo.m_Sixup.m_aColors[Part] = ColorRGBA(1.0f, 1.0f, 1.0f, 1.0f);
+				OwnSkinInfo.m_Sixup[g_Config.m_ClDummy].m_aTextures[Part] = pSkinPart->m_OrgTexture;
+				OwnSkinInfo.m_Sixup[g_Config.m_ClDummy].m_aColors[Part] = ColorRGBA(1.0f, 1.0f, 1.0f, 1.0f);
 			}
 		}
 
@@ -169,13 +169,13 @@ void CMenus::RenderSettingsTee7(CUIRect MainView)
 			const CSkins7::CSkinPart *pSkinPart = m_pClient->m_Skins7.GetSkinPart(Part, SkinPart);
 			if(aUCCVars[Part])
 			{
-				TeamSkinInfo.m_Sixup.m_aTextures[Part] = pSkinPart->m_ColorTexture;
-				TeamSkinInfo.m_Sixup.m_aColors[Part] = m_pClient->m_Skins7.GetColor(aColorVars[Part], Part == protocol7::SKINPART_MARKING);
+				TeamSkinInfo.m_Sixup[g_Config.m_ClDummy].m_aTextures[Part] = pSkinPart->m_ColorTexture;
+				TeamSkinInfo.m_Sixup[g_Config.m_ClDummy].m_aColors[Part] = m_pClient->m_Skins7.GetColor(aColorVars[Part], Part == protocol7::SKINPART_MARKING);
 			}
 			else
 			{
-				TeamSkinInfo.m_Sixup.m_aTextures[Part] = pSkinPart->m_OrgTexture;
-				TeamSkinInfo.m_Sixup.m_aColors[Part] = ColorRGBA(1.0f, 1.0f, 1.0f, 1.0f);
+				TeamSkinInfo.m_Sixup[g_Config.m_ClDummy].m_aTextures[Part] = pSkinPart->m_OrgTexture;
+				TeamSkinInfo.m_Sixup[g_Config.m_ClDummy].m_aColors[Part] = ColorRGBA(1.0f, 1.0f, 1.0f, 1.0f);
 			}
 		}
 
@@ -193,7 +193,7 @@ void CMenus::RenderSettingsTee7(CUIRect MainView)
 		for(int Part = 0; Part < protocol7::NUM_SKINPARTS; Part++)
 		{
 			ColorRGBA TeamColor = m_pClient->m_Skins7.GetTeamColor(aUCCVars[Part], aColorVars[Part], TEAM_RED, Part);
-			TeamSkinInfo.m_Sixup.m_aColors[Part] = TeamColor;
+			TeamSkinInfo.m_Sixup[g_Config.m_ClDummy].m_aColors[Part] = TeamColor;
 		}
 		RenderTools()->RenderTee(CAnimState::GetIdle(), &TeamSkinInfo, 0, vec2(1, 0), vec2(TeeLeft.x + TeeLeft.w / 2.0f, TeeLeft.y + TeeLeft.h / 2.0f + 6.0f));
 
@@ -202,7 +202,7 @@ void CMenus::RenderSettingsTee7(CUIRect MainView)
 		for(int Part = 0; Part < protocol7::NUM_SKINPARTS; Part++)
 		{
 			ColorRGBA TeamColor = m_pClient->m_Skins7.GetTeamColor(aUCCVars[Part], aColorVars[Part], TEAM_BLUE, Part);
-			TeamSkinInfo.m_Sixup.m_aColors[Part] = TeamColor;
+			TeamSkinInfo.m_Sixup[g_Config.m_ClDummy].m_aColors[Part] = TeamColor;
 		}
 		RenderTools()->RenderTee(CAnimState::GetIdle(), &TeamSkinInfo, 0, vec2(-1, 0), vec2(TeeRight.x + TeeRight.w / 2.0f, TeeRight.y + TeeRight.h / 2.0f + 6.0f));
 	}
@@ -409,13 +409,13 @@ void CMenus::RenderSkinSelection7(CUIRect MainView)
 			{
 				if(s->m_aUseCustomColors[Part])
 				{
-					Info.m_Sixup.m_aTextures[Part] = s->m_apParts[Part]->m_ColorTexture;
-					Info.m_Sixup.m_aColors[Part] = m_pClient->m_Skins7.GetColor(s->m_aPartColors[Part], Part == protocol7::SKINPART_MARKING);
+					Info.m_Sixup[g_Config.m_ClDummy].m_aTextures[Part] = s->m_apParts[Part]->m_ColorTexture;
+					Info.m_Sixup[g_Config.m_ClDummy].m_aColors[Part] = m_pClient->m_Skins7.GetColor(s->m_aPartColors[Part], Part == protocol7::SKINPART_MARKING);
 				}
 				else
 				{
-					Info.m_Sixup.m_aTextures[Part] = s->m_apParts[Part]->m_OrgTexture;
-					Info.m_Sixup.m_aColors[Part] = ColorRGBA(1.0f, 1.0f, 1.0f, 1.0f);
+					Info.m_Sixup[g_Config.m_ClDummy].m_aTextures[Part] = s->m_apParts[Part]->m_OrgTexture;
+					Info.m_Sixup[g_Config.m_ClDummy].m_aColors[Part] = ColorRGBA(1.0f, 1.0f, 1.0f, 1.0f);
 				}
 			}
 
@@ -498,18 +498,18 @@ void CMenus::RenderSkinPartSelection7(CUIRect MainView)
 				if(*CSkins7::ms_apUCCVariables[(int)m_Dummy][j])
 				{
 					if(m_TeePartSelected == j)
-						Info.m_Sixup.m_aTextures[j] = s->m_ColorTexture;
+						Info.m_Sixup[g_Config.m_ClDummy].m_aTextures[j] = s->m_ColorTexture;
 					else
-						Info.m_Sixup.m_aTextures[j] = pSkinPart->m_ColorTexture;
-					Info.m_Sixup.m_aColors[j] = m_pClient->m_Skins7.GetColor(*CSkins7::ms_apColorVariables[(int)m_Dummy][j], j == protocol7::SKINPART_MARKING);
+						Info.m_Sixup[g_Config.m_ClDummy].m_aTextures[j] = pSkinPart->m_ColorTexture;
+					Info.m_Sixup[g_Config.m_ClDummy].m_aColors[j] = m_pClient->m_Skins7.GetColor(*CSkins7::ms_apColorVariables[(int)m_Dummy][j], j == protocol7::SKINPART_MARKING);
 				}
 				else
 				{
 					if(m_TeePartSelected == j)
-						Info.m_Sixup.m_aTextures[j] = s->m_OrgTexture;
+						Info.m_Sixup[g_Config.m_ClDummy].m_aTextures[j] = s->m_OrgTexture;
 					else
-						Info.m_Sixup.m_aTextures[j] = pSkinPart->m_OrgTexture;
-					Info.m_Sixup.m_aColors[j] = vec4(1.0f, 1.0f, 1.0f, 1.0f);
+						Info.m_Sixup[g_Config.m_ClDummy].m_aTextures[j] = pSkinPart->m_OrgTexture;
+					Info.m_Sixup[0].m_aColors[j] = vec4(1.0f, 1.0f, 1.0f, 1.0f);
 				}
 			}
 			Info.m_Size = 50.0f;

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -29,7 +29,7 @@
 
 void CPlayers::RenderHand(const CTeeRenderInfo *pInfo, vec2 CenterPos, vec2 Dir, float AngleOffset, vec2 PostRotOffset, float Alpha)
 {
-	if(pInfo->m_Sixup.m_aTextures[protocol7::SKINPART_BODY].IsValid())
+	if(pInfo->m_Sixup[g_Config.m_ClDummy].m_aTextures[protocol7::SKINPART_BODY].IsValid())
 		RenderHand7(pInfo, CenterPos, Dir, AngleOffset, PostRotOffset, Alpha);
 	else
 		RenderHand6(pInfo, CenterPos, Dir, AngleOffset, PostRotOffset, Alpha);
@@ -56,12 +56,12 @@ void CPlayers::RenderHand7(const CTeeRenderInfo *pInfo, vec2 CenterPos, vec2 Dir
 	HandPos += DirX * PostRotOffset.x;
 	HandPos += DirY * PostRotOffset.y;
 
-	ColorRGBA Color = pInfo->m_Sixup.m_aColors[protocol7::SKINPART_HANDS];
+	ColorRGBA Color = pInfo->m_Sixup[g_Config.m_ClDummy].m_aColors[protocol7::SKINPART_HANDS];
 	Color.a = Alpha;
 	IGraphics::CQuadItem QuadOutline(HandPos.x, HandPos.y, 2 * BaseSize, 2 * BaseSize);
 	IGraphics::CQuadItem QuadHand = QuadOutline;
 
-	Graphics()->TextureSet(pInfo->m_Sixup.m_aTextures[protocol7::SKINPART_HANDS]);
+	Graphics()->TextureSet(pInfo->m_Sixup[g_Config.m_ClDummy].m_aTextures[protocol7::SKINPART_HANDS]);
 	Graphics()->QuadsBegin();
 	Graphics()->SetColor(Color);
 	Graphics()->QuadsSetRotation(Angle);
@@ -842,7 +842,7 @@ void CPlayers::OnRender()
 			const auto *pSkin = m_pClient->m_Skins.FindOrNullptr("x_ninja");
 			if(pSkin != nullptr)
 			{
-				aRenderInfo[i].m_Sixup.Reset();
+				aRenderInfo[i].m_Sixup[g_Config.m_ClDummy].Reset();
 
 				aRenderInfo[i].m_OriginalRenderSkin = pSkin->m_OriginalSkin;
 				aRenderInfo[i].m_ColorableRenderSkin = pSkin->m_ColorableSkin;

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -5,6 +5,7 @@
 #include <limits>
 
 #include <engine/client/checksum.h>
+#include <engine/client/enums.h>
 #include <engine/demo.h>
 #include <engine/editor.h>
 #include <engine/engine.h>
@@ -2373,11 +2374,14 @@ void CGameClient::CClientData::Reset()
 	m_Country = -1;
 	m_aSkinName[0] = '\0';
 	m_SkinColor = 0;
-	for(int i = 0; i < protocol7::NUM_SKINPARTS; ++i)
+	for(auto &Info : m_Sixup)
 	{
-		m_Sixup.m_aaSkinPartNames[i][0] = '\0';
-		m_Sixup.m_aUseCustomColors[i] = 0;
-		m_Sixup.m_aSkinPartColors[i] = 0;
+		for(int i = 0; i < protocol7::NUM_SKINPARTS; ++i)
+		{
+			Info.m_aaSkinPartNames[i][0] = '\0';
+			Info.m_aUseCustomColors[i] = 0;
+			Info.m_aSkinPartColors[i] = 0;
+		}
 	}
 	m_Team = 0;
 	m_Emoticon = 0;
@@ -2503,11 +2507,11 @@ bool CGameClient::GotWantedSkin7(bool Dummy)
 
 	for(int SkinPart = 0; SkinPart < protocol7::NUM_SKINPARTS; SkinPart++)
 	{
-		if(str_comp(m_aClients[m_aLocalIds[(int)Dummy]].m_Sixup.m_aaSkinPartNames[SkinPart], apSkinPartsPtr[SkinPart]))
+		if(str_comp(m_aClients[m_aLocalIds[(int)Dummy]].m_Sixup[g_Config.m_ClDummy].m_aaSkinPartNames[SkinPart], apSkinPartsPtr[SkinPart]))
 			return false;
-		if(m_aClients[m_aLocalIds[(int)Dummy]].m_Sixup.m_aUseCustomColors[SkinPart] != aUCCVars[SkinPart])
+		if(m_aClients[m_aLocalIds[(int)Dummy]].m_Sixup[g_Config.m_ClDummy].m_aUseCustomColors[SkinPart] != aUCCVars[SkinPart])
 			return false;
-		if(m_aClients[m_aLocalIds[(int)Dummy]].m_Sixup.m_aSkinPartColors[SkinPart] != aColorVars[SkinPart])
+		if(m_aClients[m_aLocalIds[(int)Dummy]].m_Sixup[g_Config.m_ClDummy].m_aSkinPartColors[SkinPart] != aColorVars[SkinPart])
 			return false;
 	}
 

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1527,7 +1527,7 @@ void CGameClient::OnNewSnapshot()
 						pClient->m_SkinInfo.m_ColorFeet = ColorRGBA(1, 1, 1);
 					}
 
-					pClient->UpdateRenderInfo(IsTeamPlay());
+					pClient->UpdateRenderInfo(IsTeamPlay(), g_Config.m_ClDummy);
 				}
 			}
 			else if(Item.m_Type == NETOBJTYPE_PLAYERINFO)
@@ -2324,7 +2324,7 @@ void CGameClient::CClientStats::Reset()
 	m_FlagCaptures = 0;
 }
 
-void CGameClient::CClientData::UpdateRenderInfo(bool IsTeamPlay)
+void CGameClient::CClientData::UpdateRenderInfo(bool IsTeamPlay, int Conn)
 {
 	m_RenderInfo = m_SkinInfo;
 
@@ -2346,18 +2346,18 @@ void CGameClient::CClientData::UpdateRenderInfo(bool IsTeamPlay)
 				const ColorRGBA aMarkingColorsSixup[2] = {
 					ColorRGBA(0.824f, 0.345f, 0.345f, 1.0f),
 					ColorRGBA(0.345f, 0.514f, 0.824f, 1.0f)};
-				float MarkingAlpha = m_RenderInfo.m_Sixup.m_aColors[protocol7::SKINPART_MARKING].a;
-				for(auto &Color : m_RenderInfo.m_Sixup.m_aColors)
+				float MarkingAlpha = m_RenderInfo.m_Sixup[Conn].m_aColors[protocol7::SKINPART_MARKING].a;
+				for(auto &Color : m_RenderInfo.m_Sixup[Conn].m_aColors)
 					Color = aTeamColorsSixup[m_Team];
 				if(MarkingAlpha > 0.1f)
-					m_RenderInfo.m_Sixup.m_aColors[protocol7::SKINPART_MARKING] = aMarkingColorsSixup[m_Team];
+					m_RenderInfo.m_Sixup[Conn].m_aColors[protocol7::SKINPART_MARKING] = aMarkingColorsSixup[m_Team];
 			}
 		}
 		else
 		{
 			m_RenderInfo.m_ColorBody = color_cast<ColorRGBA>(ColorHSLA(12829350));
 			m_RenderInfo.m_ColorFeet = color_cast<ColorRGBA>(ColorHSLA(12829350));
-			for(auto &Color : m_RenderInfo.m_Sixup.m_aColors)
+			for(auto &Color : m_RenderInfo.m_Sixup[Conn].m_aColors)
 				Color = color_cast<ColorRGBA>(ColorHSLA(12829350));
 		}
 	}
@@ -3692,7 +3692,8 @@ void CGameClient::RefreshSkins()
 			Client.m_SkinInfo.m_OriginalRenderSkin.Reset();
 			Client.m_SkinInfo.m_ColorableRenderSkin.Reset();
 		}
-		Client.UpdateRenderInfo(IsTeamPlay());
+		for(int Dummy = 0; Dummy < NUM_DUMMIES; Dummy++)
+			Client.UpdateRenderInfo(IsTeamPlay(), Dummy);
 	}
 
 	for(auto &pComponent : m_vpAll)

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -438,7 +438,7 @@ public:
 		bool m_SpecCharPresent;
 		vec2 m_SpecChar;
 
-		void UpdateRenderInfo(bool IsTeamPlay);
+		void UpdateRenderInfo(bool IsTeamPlay, int Conn);
 		void Reset();
 
 		class CSixup
@@ -511,7 +511,7 @@ public:
 	void OnStateChange(int NewState, int OldState) override;
 	template<typename T>
 	void ApplySkin7InfoFromGameMsg(const T *pMsg, int ClientId, int Conn);
-	void ApplySkin7InfoFromSnapObj(const protocol7::CNetObj_De_ClientInfo *pObj, int ClientId, int Conn) override;
+	void ApplySkin7InfoFromSnapObj(const protocol7::CNetObj_De_ClientInfo *pObj, int ClientId) override;
 	int OnDemoRecSnap7(class CSnapshot *pFrom, class CSnapshot *pTo, int Conn) override;
 	void *TranslateGameMsg(int *pMsgId, CUnpacker *pUnpacker, int Conn);
 	int TranslateSnap(CSnapshot *pSnapDstSix, CSnapshot *pSnapSrcSeven, int Conn, bool Dummy) override;

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -7,6 +7,7 @@
 #include <base/color.h>
 #include <base/vmath.h>
 #include <engine/client.h>
+#include <engine/client/enums.h>
 #include <engine/console.h>
 #include <engine/shared/config.h>
 
@@ -449,7 +450,7 @@ public:
 		};
 
 		// 0.7 Skin
-		CSixup m_Sixup;
+		CSixup m_Sixup[NUM_DUMMIES];
 	};
 
 	CClientData m_aClients[MAX_CLIENTS];
@@ -509,8 +510,8 @@ public:
 	void OnConsoleInit() override;
 	void OnStateChange(int NewState, int OldState) override;
 	template<typename T>
-	void ApplySkin7InfoFromGameMsg(const T *pMsg, int ClientId);
-	void ApplySkin7InfoFromSnapObj(const protocol7::CNetObj_De_ClientInfo *pObj, int ClientId) override;
+	void ApplySkin7InfoFromGameMsg(const T *pMsg, int ClientId, int Conn);
+	void ApplySkin7InfoFromSnapObj(const protocol7::CNetObj_De_ClientInfo *pObj, int ClientId, int Conn) override;
 	int OnDemoRecSnap7(class CSnapshot *pFrom, class CSnapshot *pTo, int Conn) override;
 	void *TranslateGameMsg(int *pMsgId, CUnpacker *pUnpacker, int Conn);
 	int TranslateSnap(CSnapshot *pSnapDstSix, CSnapshot *pSnapSrcSeven, int Conn, bool Dummy) override;

--- a/src/game/client/render.cpp
+++ b/src/game/client/render.cpp
@@ -272,7 +272,7 @@ void CRenderTools::GetRenderTeeOffsetToRenderedTee(const CAnimState *pAnim, cons
 
 void CRenderTools::RenderTee(const CAnimState *pAnim, const CTeeRenderInfo *pInfo, int Emote, vec2 Dir, vec2 Pos, float Alpha) const
 {
-	if(pInfo->m_Sixup.m_aTextures[protocol7::SKINPART_BODY].IsValid())
+	if(pInfo->m_Sixup[g_Config.m_ClDummy].m_aTextures[protocol7::SKINPART_BODY].IsValid())
 		RenderTee7(pAnim, pInfo, Emote, Dir, Pos, Alpha);
 	else
 		RenderTee6(pAnim, pInfo, Emote, Dir, Pos, Alpha);
@@ -307,7 +307,7 @@ void CRenderTools::RenderTee7(const CAnimState *pAnim, const CTeeRenderInfo *pIn
 				// draw bot visuals (background)
 				if(IsBot && !OutLine)
 				{
-					Graphics()->TextureSet(pInfo->m_Sixup.m_BotTexture);
+					Graphics()->TextureSet(pInfo->m_Sixup[g_Config.m_ClDummy].m_BotTexture);
 					Graphics()->QuadsBegin();
 					Graphics()->SetColor(1.0f, 1.0f, 1.0f, Alpha);
 					SelectSprite7(client_data7::SPRITE_TEE_BOT_BACKGROUND, 0, 0, 0);
@@ -319,13 +319,13 @@ void CRenderTools::RenderTee7(const CAnimState *pAnim, const CTeeRenderInfo *pIn
 				// draw bot visuals (foreground)
 				if(IsBot && !OutLine)
 				{
-					Graphics()->TextureSet(pInfo->m_Sixup.m_BotTexture);
+					Graphics()->TextureSet(pInfo->m_Sixup[g_Config.m_ClDummy].m_BotTexture);
 					Graphics()->QuadsBegin();
 					Graphics()->SetColor(1.0f, 1.0f, 1.0f, Alpha);
 					SelectSprite7(client_data7::SPRITE_TEE_BOT_FOREGROUND, 0, 0, 0);
 					Item = BotItem;
 					Graphics()->QuadsDraw(&Item, 1);
-					ColorRGBA Color = pInfo->m_Sixup.m_BotColor;
+					ColorRGBA Color = pInfo->m_Sixup[g_Config.m_ClDummy].m_BotColor;
 					Color.a = Alpha;
 					Graphics()->SetColor(Color);
 					SelectSprite7(client_data7::SPRITE_TEE_BOT_GLOW, 0, 0, 0);
@@ -335,12 +335,12 @@ void CRenderTools::RenderTee7(const CAnimState *pAnim, const CTeeRenderInfo *pIn
 				}
 
 				// draw decoration
-				if(pInfo->m_Sixup.m_aTextures[protocol7::SKINPART_DECORATION].IsValid())
+				if(pInfo->m_Sixup[g_Config.m_ClDummy].m_aTextures[protocol7::SKINPART_DECORATION].IsValid())
 				{
-					Graphics()->TextureSet(pInfo->m_Sixup.m_aTextures[protocol7::SKINPART_DECORATION]);
+					Graphics()->TextureSet(pInfo->m_Sixup[g_Config.m_ClDummy].m_aTextures[protocol7::SKINPART_DECORATION]);
 					Graphics()->QuadsBegin();
 					Graphics()->QuadsSetRotation(pAnim->GetBody()->m_Angle * pi * 2);
-					ColorRGBA Color = pInfo->m_Sixup.m_aColors[protocol7::SKINPART_DECORATION];
+					ColorRGBA Color = pInfo->m_Sixup[g_Config.m_ClDummy].m_aColors[protocol7::SKINPART_DECORATION];
 					Color.a = Alpha;
 					Graphics()->SetColor(Color);
 					SelectSprite7(OutLine ? client_data7::SPRITE_TEE_DECORATION_OUTLINE : client_data7::SPRITE_TEE_DECORATION, 0, 0, 0);
@@ -350,7 +350,7 @@ void CRenderTools::RenderTee7(const CAnimState *pAnim, const CTeeRenderInfo *pIn
 				}
 
 				// draw body (behind marking)
-				Graphics()->TextureSet(pInfo->m_Sixup.m_aTextures[protocol7::SKINPART_BODY]);
+				Graphics()->TextureSet(pInfo->m_Sixup[g_Config.m_ClDummy].m_aTextures[protocol7::SKINPART_BODY]);
 				Graphics()->QuadsBegin();
 				Graphics()->QuadsSetRotation(pAnim->GetBody()->m_Angle * pi * 2);
 				if(OutLine)
@@ -360,7 +360,7 @@ void CRenderTools::RenderTee7(const CAnimState *pAnim, const CTeeRenderInfo *pIn
 				}
 				else
 				{
-					ColorRGBA Color = pInfo->m_Sixup.m_aColors[protocol7::SKINPART_BODY];
+					ColorRGBA Color = pInfo->m_Sixup[g_Config.m_ClDummy].m_aColors[protocol7::SKINPART_BODY];
 					Color.a = Alpha;
 					Graphics()->SetColor(Color);
 					SelectSprite7(client_data7::SPRITE_TEE_BODY, 0, 0, 0);
@@ -370,12 +370,12 @@ void CRenderTools::RenderTee7(const CAnimState *pAnim, const CTeeRenderInfo *pIn
 				Graphics()->QuadsEnd();
 
 				// draw marking
-				if(pInfo->m_Sixup.m_aTextures[protocol7::SKINPART_MARKING].IsValid() && !OutLine)
+				if(pInfo->m_Sixup[g_Config.m_ClDummy].m_aTextures[protocol7::SKINPART_MARKING].IsValid() && !OutLine)
 				{
-					Graphics()->TextureSet(pInfo->m_Sixup.m_aTextures[protocol7::SKINPART_MARKING]);
+					Graphics()->TextureSet(pInfo->m_Sixup[g_Config.m_ClDummy].m_aTextures[protocol7::SKINPART_MARKING]);
 					Graphics()->QuadsBegin();
 					Graphics()->QuadsSetRotation(pAnim->GetBody()->m_Angle * pi * 2);
-					ColorRGBA MarkingColor = pInfo->m_Sixup.m_aColors[protocol7::SKINPART_MARKING];
+					ColorRGBA MarkingColor = pInfo->m_Sixup[g_Config.m_ClDummy].m_aColors[protocol7::SKINPART_MARKING];
 					Graphics()->SetColor(MarkingColor.r * MarkingColor.a, MarkingColor.g * MarkingColor.a, MarkingColor.b * MarkingColor.a, MarkingColor.a * Alpha);
 					SelectSprite7(client_data7::SPRITE_TEE_MARKING, 0, 0, 0);
 					Item = BodyItem;
@@ -386,7 +386,7 @@ void CRenderTools::RenderTee7(const CAnimState *pAnim, const CTeeRenderInfo *pIn
 				// draw body (in front of marking)
 				if(!OutLine)
 				{
-					Graphics()->TextureSet(pInfo->m_Sixup.m_aTextures[protocol7::SKINPART_BODY]);
+					Graphics()->TextureSet(pInfo->m_Sixup[g_Config.m_ClDummy].m_aTextures[protocol7::SKINPART_BODY]);
 					Graphics()->QuadsBegin();
 					Graphics()->QuadsSetRotation(pAnim->GetBody()->m_Angle * pi * 2);
 					Graphics()->SetColor(1.0f, 1.0f, 1.0f, Alpha);
@@ -400,19 +400,19 @@ void CRenderTools::RenderTee7(const CAnimState *pAnim, const CTeeRenderInfo *pIn
 				}
 
 				// draw eyes
-				Graphics()->TextureSet(pInfo->m_Sixup.m_aTextures[protocol7::SKINPART_EYES]);
+				Graphics()->TextureSet(pInfo->m_Sixup[g_Config.m_ClDummy].m_aTextures[protocol7::SKINPART_EYES]);
 				Graphics()->QuadsBegin();
 				Graphics()->QuadsSetRotation(pAnim->GetBody()->m_Angle * pi * 2);
 				if(IsBot)
 				{
-					ColorRGBA Color = pInfo->m_Sixup.m_BotColor;
+					ColorRGBA Color = pInfo->m_Sixup[g_Config.m_ClDummy].m_BotColor;
 					Color.a = Alpha;
 					Graphics()->SetColor(Color);
 					Emote = EMOTE_SURPRISE;
 				}
 				else
 				{
-					ColorRGBA Color = pInfo->m_Sixup.m_aColors[protocol7::SKINPART_EYES];
+					ColorRGBA Color = pInfo->m_Sixup[g_Config.m_ClDummy].m_aColors[protocol7::SKINPART_EYES];
 					Color.a = Alpha;
 					Graphics()->SetColor(Color);
 				}
@@ -446,14 +446,14 @@ void CRenderTools::RenderTee7(const CAnimState *pAnim, const CTeeRenderInfo *pIn
 				Graphics()->QuadsEnd();
 
 				// draw xmas hat
-				if(!OutLine && pInfo->m_Sixup.m_HatTexture.IsValid())
+				if(!OutLine && pInfo->m_Sixup[g_Config.m_ClDummy].m_HatTexture.IsValid())
 				{
-					Graphics()->TextureSet(pInfo->m_Sixup.m_HatTexture);
+					Graphics()->TextureSet(pInfo->m_Sixup[g_Config.m_ClDummy].m_HatTexture);
 					Graphics()->QuadsBegin();
 					Graphics()->QuadsSetRotation(pAnim->GetBody()->m_Angle * pi * 2);
 					Graphics()->SetColor(1.0f, 1.0f, 1.0f, Alpha);
 					int Flag = Direction.x < 0.0f ? SPRITE_FLAG_FLIP_X : 0;
-					switch(pInfo->m_Sixup.m_HatSpriteIndex)
+					switch(pInfo->m_Sixup[g_Config.m_ClDummy].m_HatSpriteIndex)
 					{
 					case 0:
 						SelectSprite7(client_data7::SPRITE_TEE_HATS_TOP1, Flag, 0, 0);
@@ -474,7 +474,7 @@ void CRenderTools::RenderTee7(const CAnimState *pAnim, const CTeeRenderInfo *pIn
 			}
 
 			// draw feet
-			Graphics()->TextureSet(pInfo->m_Sixup.m_aTextures[protocol7::SKINPART_FEET]);
+			Graphics()->TextureSet(pInfo->m_Sixup[g_Config.m_ClDummy].m_aTextures[protocol7::SKINPART_FEET]);
 			Graphics()->QuadsBegin();
 			const CAnimKeyframe *pFoot = Filling ? pAnim->GetFrontFoot() : pAnim->GetBackFoot();
 
@@ -495,10 +495,10 @@ void CRenderTools::RenderTee7(const CAnimState *pAnim, const CTeeRenderInfo *pIn
 				if(Indicate)
 					ColorScale = 0.5f;
 				Graphics()->SetColor(
-					pInfo->m_Sixup.m_aColors[protocol7::SKINPART_FEET].r * ColorScale,
-					pInfo->m_Sixup.m_aColors[protocol7::SKINPART_FEET].g * ColorScale,
-					pInfo->m_Sixup.m_aColors[protocol7::SKINPART_FEET].b * ColorScale,
-					pInfo->m_Sixup.m_aColors[protocol7::SKINPART_FEET].a * Alpha);
+					pInfo->m_Sixup[g_Config.m_ClDummy].m_aColors[protocol7::SKINPART_FEET].r * ColorScale,
+					pInfo->m_Sixup[g_Config.m_ClDummy].m_aColors[protocol7::SKINPART_FEET].g * ColorScale,
+					pInfo->m_Sixup[g_Config.m_ClDummy].m_aColors[protocol7::SKINPART_FEET].b * ColorScale,
+					pInfo->m_Sixup[g_Config.m_ClDummy].m_aColors[protocol7::SKINPART_FEET].a * Alpha);
 				SelectSprite7(client_data7::SPRITE_TEE_FOOT, 0, 0, 0);
 			}
 

--- a/src/game/client/render.h
+++ b/src/game/client/render.h
@@ -3,6 +3,8 @@
 #ifndef GAME_CLIENT_RENDER_H
 #define GAME_CLIENT_RENDER_H
 
+#include <engine/client/enums.h>
+
 #include <base/color.h>
 #include <base/vmath.h>
 
@@ -50,7 +52,8 @@ public:
 		m_TeeRenderFlags = 0;
 		m_FeetFlipped = false;
 
-		m_Sixup.Reset();
+		for(auto &Sixup : m_Sixup)
+			Sixup.Reset();
 	}
 
 	CSkin::SSkinTextures m_OriginalRenderSkin;
@@ -104,7 +107,7 @@ public:
 		ColorRGBA m_BotColor;
 	};
 
-	CSixup m_Sixup;
+	CSixup m_Sixup[NUM_DUMMIES];
 };
 
 // Tee Render Flags

--- a/src/game/client/sixup_translate_game.cpp
+++ b/src/game/client/sixup_translate_game.cpp
@@ -94,11 +94,11 @@ void CGameClient::ApplySkin7InfoFromGameMsg(const T *pMsg, int ClientId, int Con
 
 	if(time_season() == SEASON_XMAS)
 	{
-		pClient->m_SkinInfo.m_Sixup.m_HatTexture = m_Skins7.m_XmasHatTexture;
-		pClient->m_SkinInfo.m_Sixup.m_HatSpriteIndex = ClientId % CSkins7::HAT_NUM;
+		pClient->m_SkinInfo.m_Sixup[Conn].m_HatTexture = m_Skins7.m_XmasHatTexture;
+		pClient->m_SkinInfo.m_Sixup[Conn].m_HatSpriteIndex = ClientId % CSkins7::HAT_NUM;
 	}
 	else
-		pClient->m_SkinInfo.m_Sixup.m_HatTexture.Invalidate();
+		pClient->m_SkinInfo.m_Sixup[Conn].m_HatTexture.Invalidate();
 
 	for(int Part = 0; Part < protocol7::NUM_SKINPARTS; Part++)
 	{
@@ -106,25 +106,25 @@ void CGameClient::ApplySkin7InfoFromGameMsg(const T *pMsg, int ClientId, int Con
 		const CSkins7::CSkinPart *pSkinPart = m_Skins7.GetSkinPart(Part, Id);
 		if(pClient->m_Sixup[Conn].m_aUseCustomColors[Part])
 		{
-			pClient->m_SkinInfo.m_Sixup.m_aTextures[Part] = pSkinPart->m_ColorTexture;
-			pClient->m_SkinInfo.m_Sixup.m_aColors[Part] = m_Skins7.GetColor(pMsg->m_aSkinPartColors[Part], Part == protocol7::SKINPART_MARKING);
+			pClient->m_SkinInfo.m_Sixup[Conn].m_aTextures[Part] = pSkinPart->m_ColorTexture;
+			pClient->m_SkinInfo.m_Sixup[Conn].m_aColors[Part] = m_Skins7.GetColor(pMsg->m_aSkinPartColors[Part], Part == protocol7::SKINPART_MARKING);
 		}
 		else
 		{
-			pClient->m_SkinInfo.m_Sixup.m_aTextures[Part] = pSkinPart->m_OrgTexture;
-			pClient->m_SkinInfo.m_Sixup.m_aColors[Part] = ColorRGBA(1.0f, 1.0f, 1.0f, 1.0f);
+			pClient->m_SkinInfo.m_Sixup[Conn].m_aTextures[Part] = pSkinPart->m_OrgTexture;
+			pClient->m_SkinInfo.m_Sixup[Conn].m_aColors[Part] = ColorRGBA(1.0f, 1.0f, 1.0f, 1.0f);
 		}
-		if(pClient->m_SkinInfo.m_Sixup.m_HatTexture.IsValid())
+		if(pClient->m_SkinInfo.m_Sixup[Conn].m_HatTexture.IsValid())
 		{
 			if(Part == protocol7::SKINPART_BODY && str_comp(pClient->m_Sixup[Conn].m_aaSkinPartNames[Part], "standard"))
-				pClient->m_SkinInfo.m_Sixup.m_HatSpriteIndex = CSkins7::HAT_OFFSET_SIDE + (ClientId % CSkins7::HAT_NUM);
+				pClient->m_SkinInfo.m_Sixup[Conn].m_HatSpriteIndex = CSkins7::HAT_OFFSET_SIDE + (ClientId % CSkins7::HAT_NUM);
 			if(Part == protocol7::SKINPART_DECORATION && !str_comp(pClient->m_Sixup[Conn].m_aaSkinPartNames[Part], "twinbopp"))
-				pClient->m_SkinInfo.m_Sixup.m_HatSpriteIndex = CSkins7::HAT_OFFSET_SIDE + (ClientId % CSkins7::HAT_NUM);
+				pClient->m_SkinInfo.m_Sixup[Conn].m_HatSpriteIndex = CSkins7::HAT_OFFSET_SIDE + (ClientId % CSkins7::HAT_NUM);
 		}
 	}
 }
 
-void CGameClient::ApplySkin7InfoFromSnapObj(const protocol7::CNetObj_De_ClientInfo *pObj, int ClientId, int Conn)
+void CGameClient::ApplySkin7InfoFromSnapObj(const protocol7::CNetObj_De_ClientInfo *pObj, int ClientId)
 {
 	char aSkinPartNames[protocol7::NUM_SKINPARTS][protocol7::MAX_SKIN_ARRAY_SIZE];
 	protocol7::CNetMsg_Sv_SkinChange Msg;
@@ -136,7 +136,7 @@ void CGameClient::ApplySkin7InfoFromSnapObj(const protocol7::CNetObj_De_ClientIn
 		Msg.m_aUseCustomColors[Part] = pObj->m_aUseCustomColors[Part];
 		Msg.m_aSkinPartColors[Part] = pObj->m_aSkinPartColors[Part];
 	}
-	ApplySkin7InfoFromGameMsg(&Msg, ClientId, Conn);
+	ApplySkin7InfoFromGameMsg(&Msg, ClientId, 0);
 }
 
 void *CGameClient::TranslateGameMsg(int *pMsgId, CUnpacker *pUnpacker, int Conn)
@@ -196,7 +196,7 @@ void *CGameClient::TranslateGameMsg(int *pMsgId, CUnpacker *pUnpacker, int Conn)
 		{
 			m_aClients[pMsg7->m_ClientId].m_Team = pMsg7->m_Team;
 			m_pClient->m_TranslationContext.m_aClients[pMsg7->m_ClientId].m_Team = pMsg7->m_Team;
-			m_aClients[pMsg7->m_ClientId].UpdateRenderInfo(IsTeamPlay());
+			m_aClients[pMsg7->m_ClientId].UpdateRenderInfo(IsTeamPlay(), Conn);
 
 			// if(pMsg7->m_ClientId == m_LocalClientId)
 			// {

--- a/src/game/client/sixup_translate_game.cpp
+++ b/src/game/client/sixup_translate_game.cpp
@@ -79,18 +79,18 @@ void CGameClient::DoTeamChangeMessage7(const char *pName, int ClientId, int Team
 }
 
 template<typename T>
-void CGameClient::ApplySkin7InfoFromGameMsg(const T *pMsg, int ClientId)
+void CGameClient::ApplySkin7InfoFromGameMsg(const T *pMsg, int ClientId, int Conn)
 {
 	CClientData *pClient = &m_aClients[ClientId];
 	char *apSkinPartsPtr[protocol7::NUM_SKINPARTS];
 	for(int Part = 0; Part < protocol7::NUM_SKINPARTS; Part++)
 	{
-		str_utf8_copy_num(pClient->m_Sixup.m_aaSkinPartNames[Part], pMsg->m_apSkinPartNames[Part], sizeof(pClient->m_Sixup.m_aaSkinPartNames[Part]), protocol7::MAX_SKIN_LENGTH);
-		apSkinPartsPtr[Part] = pClient->m_Sixup.m_aaSkinPartNames[Part];
-		pClient->m_Sixup.m_aUseCustomColors[Part] = pMsg->m_aUseCustomColors[Part];
-		pClient->m_Sixup.m_aSkinPartColors[Part] = pMsg->m_aSkinPartColors[Part];
+		str_utf8_copy_num(pClient->m_Sixup[Conn].m_aaSkinPartNames[Part], pMsg->m_apSkinPartNames[Part], sizeof(pClient->m_Sixup[Conn].m_aaSkinPartNames[Part]), protocol7::MAX_SKIN_LENGTH);
+		apSkinPartsPtr[Part] = pClient->m_Sixup[Conn].m_aaSkinPartNames[Part];
+		pClient->m_Sixup[Conn].m_aUseCustomColors[Part] = pMsg->m_aUseCustomColors[Part];
+		pClient->m_Sixup[Conn].m_aSkinPartColors[Part] = pMsg->m_aSkinPartColors[Part];
 	}
-	m_Skins7.ValidateSkinParts(apSkinPartsPtr, pClient->m_Sixup.m_aUseCustomColors, pClient->m_Sixup.m_aSkinPartColors, m_pClient->m_TranslationContext.m_GameFlags);
+	m_Skins7.ValidateSkinParts(apSkinPartsPtr, pClient->m_Sixup[Conn].m_aUseCustomColors, pClient->m_Sixup[Conn].m_aSkinPartColors, m_pClient->m_TranslationContext.m_GameFlags);
 
 	if(time_season() == SEASON_XMAS)
 	{
@@ -102,9 +102,9 @@ void CGameClient::ApplySkin7InfoFromGameMsg(const T *pMsg, int ClientId)
 
 	for(int Part = 0; Part < protocol7::NUM_SKINPARTS; Part++)
 	{
-		int Id = m_Skins7.FindSkinPart(Part, pClient->m_Sixup.m_aaSkinPartNames[Part], false);
+		int Id = m_Skins7.FindSkinPart(Part, pClient->m_Sixup[Conn].m_aaSkinPartNames[Part], false);
 		const CSkins7::CSkinPart *pSkinPart = m_Skins7.GetSkinPart(Part, Id);
-		if(pClient->m_Sixup.m_aUseCustomColors[Part])
+		if(pClient->m_Sixup[Conn].m_aUseCustomColors[Part])
 		{
 			pClient->m_SkinInfo.m_Sixup.m_aTextures[Part] = pSkinPart->m_ColorTexture;
 			pClient->m_SkinInfo.m_Sixup.m_aColors[Part] = m_Skins7.GetColor(pMsg->m_aSkinPartColors[Part], Part == protocol7::SKINPART_MARKING);
@@ -116,15 +116,15 @@ void CGameClient::ApplySkin7InfoFromGameMsg(const T *pMsg, int ClientId)
 		}
 		if(pClient->m_SkinInfo.m_Sixup.m_HatTexture.IsValid())
 		{
-			if(Part == protocol7::SKINPART_BODY && str_comp(pClient->m_Sixup.m_aaSkinPartNames[Part], "standard"))
+			if(Part == protocol7::SKINPART_BODY && str_comp(pClient->m_Sixup[Conn].m_aaSkinPartNames[Part], "standard"))
 				pClient->m_SkinInfo.m_Sixup.m_HatSpriteIndex = CSkins7::HAT_OFFSET_SIDE + (ClientId % CSkins7::HAT_NUM);
-			if(Part == protocol7::SKINPART_DECORATION && !str_comp(pClient->m_Sixup.m_aaSkinPartNames[Part], "twinbopp"))
+			if(Part == protocol7::SKINPART_DECORATION && !str_comp(pClient->m_Sixup[Conn].m_aaSkinPartNames[Part], "twinbopp"))
 				pClient->m_SkinInfo.m_Sixup.m_HatSpriteIndex = CSkins7::HAT_OFFSET_SIDE + (ClientId % CSkins7::HAT_NUM);
 		}
 	}
 }
 
-void CGameClient::ApplySkin7InfoFromSnapObj(const protocol7::CNetObj_De_ClientInfo *pObj, int ClientId)
+void CGameClient::ApplySkin7InfoFromSnapObj(const protocol7::CNetObj_De_ClientInfo *pObj, int ClientId, int Conn)
 {
 	char aSkinPartNames[protocol7::NUM_SKINPARTS][protocol7::MAX_SKIN_ARRAY_SIZE];
 	protocol7::CNetMsg_Sv_SkinChange Msg;
@@ -136,7 +136,7 @@ void CGameClient::ApplySkin7InfoFromSnapObj(const protocol7::CNetObj_De_ClientIn
 		Msg.m_aUseCustomColors[Part] = pObj->m_aUseCustomColors[Part];
 		Msg.m_aSkinPartColors[Part] = pObj->m_aSkinPartColors[Part];
 	}
-	ApplySkin7InfoFromGameMsg(&Msg, ClientId);
+	ApplySkin7InfoFromGameMsg(&Msg, ClientId, Conn);
 }
 
 void *CGameClient::TranslateGameMsg(int *pMsgId, CUnpacker *pUnpacker, int Conn)
@@ -293,7 +293,7 @@ void *CGameClient::TranslateGameMsg(int *pMsgId, CUnpacker *pUnpacker, int Conn)
 
 		CTranslationContext::CClientData &Client = m_pClient->m_TranslationContext.m_aClients[pMsg7->m_ClientId];
 		Client.m_Active = true;
-		ApplySkin7InfoFromGameMsg(pMsg7, pMsg7->m_ClientId);
+		ApplySkin7InfoFromGameMsg(pMsg7, pMsg7->m_ClientId, Conn);
 		// skin will be moved to the 0.6 snap by the translation context
 		// and we drop the game message
 		return nullptr;
@@ -495,7 +495,7 @@ void *CGameClient::TranslateGameMsg(int *pMsgId, CUnpacker *pUnpacker, int Conn)
 		str_copy(Client.m_aName, pMsg7->m_pName);
 		str_copy(Client.m_aClan, pMsg7->m_pClan);
 		Client.m_Country = pMsg7->m_Country;
-		ApplySkin7InfoFromGameMsg(pMsg7, pMsg7->m_ClientId);
+		ApplySkin7InfoFromGameMsg(pMsg7, pMsg7->m_ClientId, Conn);
 		if(m_pClient->m_TranslationContext.m_aLocalClientId[Conn] == -1)
 			return nullptr;
 		if(pMsg7->m_Silent || pMsg7->m_Local)

--- a/src/game/client/sixup_translate_snapshot.cpp
+++ b/src/game/client/sixup_translate_snapshot.cpp
@@ -466,7 +466,7 @@ int CGameClient::TranslateSnap(CSnapshot *pSnapDstSix, CSnapshot *pSnapSrcSeven,
 			IntsToStr(pInfo->m_aClan, 3, Client.m_aClan, std::size(Client.m_aClan));
 			Client.m_Country = pInfo->m_Country;
 
-			ApplySkin7InfoFromSnapObj(pInfo, ClientId);
+			ApplySkin7InfoFromSnapObj(pInfo, ClientId, Conn);
 		}
 		else if(pItem7->Type() == protocol7::NETOBJTYPE_DE_GAMEINFO)
 		{
@@ -524,9 +524,9 @@ int CGameClient::OnDemoRecSnap7(CSnapshot *pFrom, CSnapshot *pTo, int Conn)
 
 		for(int Part = 0; Part < protocol7::NUM_SKINPARTS; Part++)
 		{
-			StrToInts(ClientInfoObj.m_aaSkinPartNames[Part], 6, m_aClients[i].m_Sixup.m_aaSkinPartNames[Part]);
-			ClientInfoObj.m_aUseCustomColors[Part] = m_aClients[i].m_Sixup.m_aUseCustomColors[Part];
-			ClientInfoObj.m_aSkinPartColors[Part] = m_aClients[i].m_Sixup.m_aSkinPartColors[Part];
+			StrToInts(ClientInfoObj.m_aaSkinPartNames[Part], 6, m_aClients[i].m_Sixup[Conn].m_aaSkinPartNames[Part]);
+			ClientInfoObj.m_aUseCustomColors[Part] = m_aClients[i].m_Sixup[Conn].m_aUseCustomColors[Part];
+			ClientInfoObj.m_aSkinPartColors[Part] = m_aClients[i].m_Sixup[Conn].m_aSkinPartColors[Part];
 		}
 
 		mem_copy(pItem, &ClientInfoObj, sizeof(protocol7::CNetObj_De_ClientInfo));

--- a/src/game/client/sixup_translate_snapshot.cpp
+++ b/src/game/client/sixup_translate_snapshot.cpp
@@ -466,7 +466,7 @@ int CGameClient::TranslateSnap(CSnapshot *pSnapDstSix, CSnapshot *pSnapSrcSeven,
 			IntsToStr(pInfo->m_aClan, 3, Client.m_aClan, std::size(Client.m_aClan));
 			Client.m_Country = pInfo->m_Country;
 
-			ApplySkin7InfoFromSnapObj(pInfo, ClientId, Conn);
+			ApplySkin7InfoFromSnapObj(pInfo, ClientId);
 		}
 		else if(pItem7->Type() == protocol7::NETOBJTYPE_DE_GAMEINFO)
 		{


### PR DESCRIPTION
As of right now when connected to a 0.7 server there is no separation between dummy and main tee for skins states of all the clients. So if the server tells your main tee all players have the skin pinky while at the same time telling your dummy all players have the skin saddo there is information loss. This pr fixes it by storing all skins information sent by the server and rendering the correct one depending which tee is currently active (dummy or main).

Helps with https://github.com/ddnet/ddnet/pull/8707

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
