### PR TITLE
Fix old 0.7 skins overwriting 0.6 skins in chat

### DIFF
--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -1303,12 +1303,15 @@ void CChat::OnRender()
 				RenderInfo.m_ColorFeet = Line.m_ColorFeet;
 				RenderInfo.m_Size = TeeSize;
 
-				for(int Part = 0; Part < protocol7::NUM_SKINPARTS; Part++)
+				if(Client()->IsSixup())
 				{
-					RenderInfo.m_Sixup.m_aColors[Part] = Line.m_Sixup.m_aColors[Part];
-					RenderInfo.m_Sixup.m_aTextures[Part] = Line.m_Sixup.m_aTextures[Part];
-					RenderInfo.m_Sixup.m_HatSpriteIndex = Line.m_Sixup.m_HatSpriteIndex;
-					RenderInfo.m_Sixup.m_HatTexture = Line.m_Sixup.m_HatTexture;
+					for(int Part = 0; Part < protocol7::NUM_SKINPARTS; Part++)
+					{
+						RenderInfo.m_Sixup.m_aColors[Part] = Line.m_Sixup.m_aColors[Part];
+						RenderInfo.m_Sixup.m_aTextures[Part] = Line.m_Sixup.m_aTextures[Part];
+						RenderInfo.m_Sixup.m_HatSpriteIndex = Line.m_Sixup.m_HatSpriteIndex;
+						RenderInfo.m_Sixup.m_HatTexture = Line.m_Sixup.m_HatTexture;
+					}
 				}
 
 				float RowHeight = FontSize() + RealMsgPaddingY;


### PR DESCRIPTION
Closed #8731

Thanks @Bamcane for the clear bug report. I was able to cleanly reproduce and verify its fixed now.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
