### PR TITLE
Do not apply gravity when grounded

### DIFF
--- a/src/game/gamecore.cpp
+++ b/src/game/gamecore.cpp
@@ -196,7 +196,10 @@ void CCharacterCore::Tick(bool UseInput, bool DoDeferredTick)
 	const bool Grounded = m_pCollision->CheckPoint(m_Pos.x + PhysicalSize() / 2, m_Pos.y + PhysicalSize() / 2 + 5) || m_pCollision->CheckPoint(m_Pos.x - PhysicalSize() / 2, m_Pos.y + PhysicalSize() / 2 + 5);
 	vec2 TargetDirection = normalize(vec2(m_Input.m_TargetX, m_Input.m_TargetY));
 
-	m_Vel.y += m_Tuning.m_Gravity;
+	if(!Grounded)
+	{
+		m_Vel.y += m_Tuning.m_Gravity;
+	}
 
 	float MaxSpeed = Grounded ? m_Tuning.m_GroundControlSpeed : m_Tuning.m_AirControlSpeed;
 	float Accel = Grounded ? m_Tuning.m_GroundControlAccel : m_Tuning.m_AirControlAccel;


### PR DESCRIPTION
The server applies gravity to tees that are on the ground. And also includes that velocity in the snapshot sent to the client (sometimes). This pr makes sure that the y velocity sent over the network is always 0 when grounded.


https://github.com/user-attachments/assets/10ee4c59-bdba-43c7-8a8b-2c686fae8d86



## Checklist

- [ ] :warning:  Changed no physics that affect existing maps :warning:
