### PR TITLE
Color speed in hud based on increase or decrease

### DIFF
--- a/src/game/client/components/hud.h
+++ b/src/game/client/components/hud.h
@@ -53,6 +53,14 @@ class CHud : public CComponent
 	char m_aPlayerAngleText[128];
 	STextContainerIndex m_aPlayerSpeedTextContainers[2];
 	char m_aaPlayerSpeedText[2][128];
+	int m_aPlayerSpeed[2];
+	enum class ESpeedChange
+	{
+		NONE,
+		INCREASE,
+		DECREASE
+	};
+	ESpeedChange m_aLastPlayerSpeedChange[2];
 	STextContainerIndex m_aPlayerPositionContainers[2];
 	char m_aaPlayerPositionText[2][128];
 
@@ -96,6 +104,7 @@ public:
 	virtual void OnReset() override;
 	virtual void OnRender() override;
 	virtual void OnInit() override;
+	virtual void OnNewSnapshot() override;
 
 	// DDRace
 


### PR DESCRIPTION

https://github.com/user-attachments/assets/acb54e53-6bd7-47b7-88d1-e98b7b64f125

<details>
<summary>Outdated colors preview</summary>

https://github.com/user-attachments/assets/5faf0ebf-4799-4b79-81ae-7e81e45b13e6

</details>

Sometimes the Y velocity is marked green when walking on the floor this is caused by the server bug described in https://github.com/ddnet/ddnet/pull/8743

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
