### PR TITLE
Improve interactive tee in 0.7 tee settings

### DIFF
--- a/src/game/client/components/menus_settings7.cpp
+++ b/src/game/client/components/menus_settings7.cpp
@@ -68,7 +68,6 @@ void CMenus::RenderSettingsTee7(CUIRect MainView)
 	const float ButtonHeight = 20.0f;
 	const float SkinHeight = 50.0f;
 	const float BackgroundHeight = (ButtonHeight + SpacingH) + SkinHeight * 2;
-	const vec2 MousePosition = vec2(Ui()->MouseX(), Ui()->MouseY());
 
 	MainView.HSplitTop(20.0f, 0, &MainView);
 	MainView.HSplitTop(BackgroundHeight, &TopView, &MainView);
@@ -136,14 +135,18 @@ void CMenus::RenderSettingsTee7(CUIRect MainView)
 
 		{
 			// interactive tee: tee looking towards cursor, and it is happy when you touch it
-			vec2 TeePosition = vec2(Top.x + Top.w / 2.0f, Top.y + Top.h / 2.0f + 6.0f);
-			vec2 DeltaPosition = MousePosition - TeePosition;
-			float Distance = length(DeltaPosition);
-			vec2 TeeDirection = Distance < 20.0f ? normalize(vec2(DeltaPosition.x, maximum(DeltaPosition.y, 0.5f))) : normalize(DeltaPosition);
-			int TeeEmote = Distance < 20.0f ? EMOTE_HAPPY : EMOTE_NORMAL;
+			const vec2 TeePosition = vec2(Top.x + Top.w / 2.0f, Top.y + Top.h / 2.0f + 6.0f);
+			const vec2 DeltaPosition = Ui()->MousePos() - TeePosition;
+			const float Distance = length(DeltaPosition);
+			const float InteractionDistance = 20.0f;
+			const vec2 TeeDirection = Distance < InteractionDistance ? normalize(vec2(DeltaPosition.x, maximum(DeltaPosition.y, 0.5f))) : normalize(DeltaPosition);
+			const int TeeEmote = Distance < InteractionDistance ? EMOTE_HAPPY : EMOTE_NORMAL;
 			RenderTools()->RenderTee(CAnimState::GetIdle(), &OwnSkinInfo, TeeEmote, TeeDirection, TeePosition);
-			if(Distance < 20.0f && Ui()->MouseButtonClicked(0))
-				m_pClient->m_Sounds.Play(CSounds::CHN_GUI, SOUND_PLAYER_SPAWN, 0);
+			static char s_InteractiveTeeButtonId;
+			if(Distance < InteractionDistance && Ui()->DoButtonLogic(&s_InteractiveTeeButtonId, 0, &Top))
+			{
+				m_pClient->m_Sounds.Play(CSounds::CHN_GUI, SOUND_PLAYER_SPAWN, 1.0f);
+			}
 		}
 
 		// handle right (team skins)


### PR DESCRIPTION
- Fix value `0` being used for sound volume, so the tee sound was not audible.
- Use `DoButtonLogic` to trigger sound to ensure it does not play while other UI elements are active.
- Remove unnecessay `MousePosition` variable by using `MousePos` function instead.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
