### PR TITLE
Don't show "you've been banned" for VPN bans

### DIFF
--- a/src/engine/server.h
+++ b/src/engine/server.h
@@ -250,7 +250,7 @@ public:
 	virtual int GetAuthedState(int ClientId) const = 0;
 	virtual const char *GetAuthName(int ClientId) const = 0;
 	virtual void Kick(int ClientId, const char *pReason) = 0;
-	virtual void Ban(int ClientId, int Seconds, const char *pReason, bool DisplayTime) = 0;
+	virtual void Ban(int ClientId, int Seconds, const char *pReason, bool VerbatimReason) = 0;
 	virtual void RedirectClient(int ClientId, int Port, bool Verbose = false) = 0;
 	virtual void ChangeMap(const char *pMap) = 0;
 

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -46,14 +46,14 @@ class CServerBan : public CNetBan
 	class CServer *m_pServer;
 
 	template<class T>
-	int BanExt(T *pBanPool, const typename T::CDataType *pData, int Seconds, const char *pReason, bool DisplayTime);
+	int BanExt(T *pBanPool, const typename T::CDataType *pData, int Seconds, const char *pReason, bool VerbatimReason);
 
 public:
 	class CServer *Server() const { return m_pServer; }
 
 	void InitServerBan(class IConsole *pConsole, class IStorage *pStorage, class CServer *pServer);
 
-	int BanAddr(const NETADDR *pAddr, int Seconds, const char *pReason, bool DisplayTime) override;
+	int BanAddr(const NETADDR *pAddr, int Seconds, const char *pReason, bool VerbatimReason) override;
 	int BanRange(const CNetRange *pRange, int Seconds, const char *pReason) override;
 
 	static void ConBanExt(class IConsole::IResult *pResult, void *pUser);
@@ -279,7 +279,7 @@ public:
 	void SetClientFlags(int ClientId, int Flags) override;
 
 	void Kick(int ClientId, const char *pReason) override;
-	void Ban(int ClientId, int Seconds, const char *pReason, bool DisplayTime) override;
+	void Ban(int ClientId, int Seconds, const char *pReason, bool VerbatimReason) override;
 	void RedirectClient(int ClientId, int Port, bool Verbose = false) override;
 
 	void DemoRecorder_HandleAutoStart() override;

--- a/src/engine/shared/econ.cpp
+++ b/src/engine/shared/econ.cpp
@@ -130,7 +130,7 @@ void CEcon::Update()
 					if(!g_Config.m_EcBantime)
 						m_NetConsole.Drop(ClientId, "Too many authentication tries");
 					else
-						m_NetConsole.NetBan()->BanAddr(m_NetConsole.ClientAddr(ClientId), g_Config.m_EcBantime * 60, "Too many authentication tries", true);
+						m_NetConsole.NetBan()->BanAddr(m_NetConsole.ClientAddr(ClientId), g_Config.m_EcBantime * 60, "Too many authentication tries", false);
 				}
 			}
 		}

--- a/src/engine/shared/netban.cpp
+++ b/src/engine/shared/netban.cpp
@@ -208,7 +208,7 @@ typename CNetBan::CBan<T> *CNetBan::CBanPool<T, HashCount>::Get(int Index) const
 }
 
 template<class T>
-int CNetBan::Ban(T *pBanPool, const typename T::CDataType *pData, int Seconds, const char *pReason, bool DisplayTime)
+int CNetBan::Ban(T *pBanPool, const typename T::CDataType *pData, int Seconds, const char *pReason, bool VerbatimReason)
 {
 	// do not ban localhost
 	if(NetMatch(pData, &m_LocalhostIpV4) || NetMatch(pData, &m_LocalhostIpV6))
@@ -222,7 +222,7 @@ int CNetBan::Ban(T *pBanPool, const typename T::CDataType *pData, int Seconds, c
 	// set up info
 	CBanInfo Info = {0};
 	Info.m_Expires = Stamp;
-	Info.m_DisplayTime = DisplayTime;
+	Info.m_VerbatimReason = VerbatimReason;
 	str_copy(Info.m_aReason, pReason);
 
 	// check if it already exists
@@ -309,15 +309,15 @@ void CNetBan::Update()
 	}
 }
 
-int CNetBan::BanAddr(const NETADDR *pAddr, int Seconds, const char *pReason, bool DisplayTime)
+int CNetBan::BanAddr(const NETADDR *pAddr, int Seconds, const char *pReason, bool VerbatimReason)
 {
-	return Ban(&m_BanAddrPool, pAddr, Seconds, pReason, DisplayTime);
+	return Ban(&m_BanAddrPool, pAddr, Seconds, pReason, VerbatimReason);
 }
 
 int CNetBan::BanRange(const CNetRange *pRange, int Seconds, const char *pReason)
 {
 	if(pRange->IsValid())
-		return Ban(&m_BanRangePool, pRange, Seconds, pReason, true);
+		return Ban(&m_BanRangePool, pRange, Seconds, pReason, false);
 
 	Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "net_ban", "ban failed (invalid range)");
 	return -1;
@@ -415,7 +415,7 @@ void CNetBan::ConBan(IConsole::IResult *pResult, void *pUser)
 
 	NETADDR Addr;
 	if(net_addr_from_str(&Addr, pStr) == 0)
-		pThis->BanAddr(&Addr, Minutes * 60, pReason, true);
+		pThis->BanAddr(&Addr, Minutes * 60, pReason, false);
 	else
 		pThis->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "net_ban", "ban error (invalid network address)");
 }

--- a/src/engine/shared/netban.h
+++ b/src/engine/shared/netban.h
@@ -81,7 +81,7 @@ protected:
 		};
 		int64_t m_Expires;
 		char m_aReason[REASON_LENGTH];
-		bool m_DisplayTime;
+		bool m_VerbatimReason;
 	};
 
 	template<class T>
@@ -151,7 +151,7 @@ protected:
 	template<class T>
 	void MakeBanInfo(const CBan<T> *pBan, char *pBuf, unsigned BuffSize, int Type) const;
 	template<class T>
-	int Ban(T *pBanPool, const typename T::CDataType *pData, int Seconds, const char *pReason, bool DisplayTime);
+	int Ban(T *pBanPool, const typename T::CDataType *pData, int Seconds, const char *pReason, bool VerbatimReason);
 	template<class T>
 	int Unban(T *pBanPool, const typename T::CDataType *pData);
 
@@ -177,7 +177,7 @@ public:
 	void Init(class IConsole *pConsole, class IStorage *pStorage);
 	void Update();
 
-	virtual int BanAddr(const NETADDR *pAddr, int Seconds, const char *pReason, bool DisplayTime);
+	virtual int BanAddr(const NETADDR *pAddr, int Seconds, const char *pReason, bool VerbatimReason);
 	virtual int BanRange(const CNetRange *pRange, int Seconds, const char *pReason);
 	int UnbanByAddr(const NETADDR *pAddr);
 	int UnbanByRange(const CNetRange *pRange);
@@ -228,7 +228,7 @@ void CNetBan::MakeBanInfo(const CBan<T> *pBan, char *pBuf, unsigned BuffSize, in
 	}
 
 	// add info part
-	if(pBan->m_Info.m_DisplayTime && pBan->m_Info.m_Expires != CBanInfo::EXPIRES_NEVER)
+	if(!pBan->m_Info.m_VerbatimReason && pBan->m_Info.m_Expires != CBanInfo::EXPIRES_NEVER)
 	{
 		int Mins = ((pBan->m_Info.m_Expires - time_timestamp()) + 59) / 60;
 		if(Mins <= 1)


### PR DESCRIPTION
Players are supposed to turn of their VPN or complain to the admins if they get banned for using a VPN. Calling this "banned" seems to be confusing, as players ask for an unban even after they turned off the VPN.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
