### PR TITLE
Revert "Quit if Android back-button is pressed 3 times within 1 second"

### DIFF
--- a/src/engine/client/input.cpp
+++ b/src/engine/client/input.cpp
@@ -712,35 +712,9 @@ int CInput::Update()
 
 		// handle keys
 		case SDL_KEYDOWN:
-#if defined(CONF_PLATFORM_ANDROID)
-			if(Event.key.keysym.scancode == KEY_AC_BACK && m_BackButtonReleased)
-			{
-				if(m_LastBackPress == -1 || (Now - m_LastBackPress) / (float)time_freq() > 1.0f)
-				{
-					m_NumBackPresses = 1;
-					m_LastBackPress = Now;
-				}
-				else
-				{
-					m_NumBackPresses++;
-					if(m_NumBackPresses >= 3)
-					{
-						// Quit if the Android back-button was pressed 3 times within 1 second
-						return 1;
-					}
-				}
-				m_BackButtonReleased = false;
-			}
-#endif
 			Scancode = TranslateScancode(Event.key);
 			break;
 		case SDL_KEYUP:
-#if defined(CONF_PLATFORM_ANDROID)
-			if(Event.key.keysym.scancode == KEY_AC_BACK && !m_BackButtonReleased)
-			{
-				m_BackButtonReleased = true;
-			}
-#endif
 			Action = IInput::FLAG_RELEASE;
 			Scancode = TranslateScancode(Event.key);
 			break;

--- a/src/engine/client/input.h
+++ b/src/engine/client/input.h
@@ -76,11 +76,6 @@ private:
 	bool m_InputGrabbed;
 
 	bool m_MouseFocus;
-#if defined(CONF_PLATFORM_ANDROID)
-	int m_NumBackPresses = 0;
-	bool m_BackButtonReleased = true;
-	int64_t m_LastBackPress = -1;
-#endif
 
 	// IME support
 	std::string m_CompositionString;


### PR DESCRIPTION
This reverts commit 91848f0be635ef495b18600abd3a95afe3b7beeb.

This was prone to accidental usage. The user interface is now usable with touch input, so this additional method to quickly and cleanly quit the game is not necessary anymore.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
