### PR TITLE
Fix save code not being censored in streamer mode

### DIFF
--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -992,7 +992,11 @@ void CChat::OnPrepareLines(float y)
 		const char *pText = Line.m_aText;
 		if(Config()->m_ClStreamerMode && Line.m_ClientId == SERVER_MSG)
 		{
-			if(str_startswith(Line.m_aText, "Team save in progress. You'll be able to load with '/load") && str_endswith(Line.m_aText, "if it fails"))
+			if(str_startswith(Line.m_aText, "Team save in progress. You'll be able to load with '/load ") && str_endswith(Line.m_aText, "'"))
+			{
+				pText = "Team save in progress. You'll be able to load with '/load ***'";
+			}
+			else if(str_startswith(Line.m_aText, "Team save in progress. You'll be able to load with '/load") && str_endswith(Line.m_aText, "if it fails"))
 			{
 				pText = "Team save in progress. You'll be able to load with '/load ***' if save is successful or with '/load *** *** ***' if it fails";
 			}


### PR DESCRIPTION
Closed #8790

There are two possible save code messages sent by the server. Only one of them was covered. Now both are covered.

https://github.com/ddnet/ddnet/blob/0013615da1c51c6665d2b75bced12a7129ff97ce/src/game/server/score.cpp#L323-L330
