### PR TITLE
Add confirm when Lock Team

### DIFF
--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -969,10 +969,17 @@ void CGameContext::ConLock(IConsole::IResult *pResult, void *pUserData)
 	
 	if (Teams -> m_aLastLocker[Team] != pResult->m_ClientId) 
 	{
-		if (abs (Teams -> m_aLastLockTime[Team] - pSelf -> Server() -> Tick ()) <= 120) 
+		if (absolute (Teams -> m_aLastLockTime[Team] - pSelf -> Server() -> Tick ()) <= 2 * pSelf -> Server() -> TickSpeed()) 
 		{
+			const char *aLoUL = "lock"; // Lock or Unlock
+			
+			if (Lock) {
+				aLoUL = "unlock";
+			}
+			
 			str_format(aBuf, sizeof(aBuf), 
-				"Your team is (un)locked by %s, If you wan't to (un)lock team, Please wait for a second and repeat the command.", pSelf->Server()->ClientName(Teams -> m_aLastLocker[Team]));
+				"Your team is %s by %s, Please wait for a second and repeat /%s if you wan't to %s your team.", 
+				aLoUL, pSelf->Server()->ClientName(Teams -> m_aLastLocker[Team]), aLoUL, aLoUL);
 			pSelf->SendChatTarget(pResult->m_ClientId, aBuf);
 			
 			return ;

--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -967,7 +967,7 @@ void CGameContext::ConLock(IConsole::IResult *pResult, void *pUserData)
 
 	char aBuf[512];
 	
-	if (Teams->m_aLastLocker[Team] != pResult->m_ClientId) 
+	if (Teams->m_aLastLocker[Team] != pResult->m_ClientId && pResult->NumArguments() == 0) 
 	{
 		if (absolute (Teams->m_aLastLockTime[Team] - pSelf->Server()->Tick ()) <= 2 * pSelf->Server()->TickSpeed()) 
 		{

--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -967,9 +967,9 @@ void CGameContext::ConLock(IConsole::IResult *pResult, void *pUserData)
 
 	char aBuf[512];
 	
-	if (Teams->m_aLastLocker[Team] != pResult->m_ClientId && pResult->NumArguments() == 0) 
+	if(Teams->m_aLastLocker[Team] != pResult->m_ClientId && pResult->NumArguments() == 0) 
 	{
-		if (absolute (Teams->m_aLastLockTime[Team] - pSelf->Server()->Tick ()) <= 2 * pSelf->Server()->TickSpeed()) 
+		if(absolute (Teams->m_aLastLockTime[Team] - pSelf->Server()->Tick ()) <= 2 * pSelf->Server()->TickSpeed()) 
 		{
 			const char *pLoUL = Lock ? "unlock" : "lock"; // Lock or Unlock
 			

--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -967,13 +967,14 @@ void CGameContext::ConLock(IConsole::IResult *pResult, void *pUserData)
 
 	char aBuf[512];
 	
-	if (Teams -> m_aLastLocker[Team] != pResult->m_ClientId) 
+	if (Teams->m_aLastLocker[Team] != pResult->m_ClientId) 
 	{
-		if (absolute (Teams -> m_aLastLockTime[Team] - pSelf -> Server() -> Tick ()) <= 2 * pSelf -> Server() -> TickSpeed()) 
+		if (absolute (Teams->m_aLastLockTime[Team] - pSelf->Server()->Tick ()) <= 2 * pSelf->Server()->TickSpeed()) 
 		{
 			const char *aLoUL = "lock"; // Lock or Unlock
 			
-			if (Lock) {
+			if (Lock) 
+			{
 				aLoUL = "unlock";
 			}
 			

--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -971,16 +971,11 @@ void CGameContext::ConLock(IConsole::IResult *pResult, void *pUserData)
 	{
 		if (absolute (Teams->m_aLastLockTime[Team] - pSelf->Server()->Tick ()) <= 2 * pSelf->Server()->TickSpeed()) 
 		{
-			const char *aLoUL = "lock"; // Lock or Unlock
-			
-			if (Lock) 
-			{
-				aLoUL = "unlock";
-			}
+			const char *pLoUL = Lock ? "unlock" : "lock"; // Lock or Unlock
 			
 			str_format(aBuf, sizeof(aBuf), 
 				"Your team is %s by %s, Please wait for a second and repeat /%s if you wan't to %s your team.", 
-				aLoUL, pSelf->Server()->ClientName(Teams -> m_aLastLocker[Team]), aLoUL, aLoUL);
+				pLoUL, pSelf->Server()->ClientName(Teams -> m_aLastLocker[Team]), pLoUL, pLoUL);
 			pSelf->SendChatTarget(pResult->m_ClientId, aBuf);
 			
 			return ;

--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -975,7 +975,7 @@ void CGameContext::ConLock(IConsole::IResult *pResult, void *pUserData)
 			
 			str_format(aBuf, sizeof(aBuf), 
 				"Your team is %s by %s, Please wait for a second and repeat /%s if you wan't to %s your team.", 
-				pLoUL, pSelf->Server()->ClientName(Teams -> m_aLastLocker[Team]), pLoUL, pLoUL);
+				pLoUL, pSelf->Server()->ClientName(Teams->m_aLastLocker[Team]), pLoUL, pLoUL);
 			pSelf->SendChatTarget(pResult->m_ClientId, aBuf);
 			
 			return ;

--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -974,7 +974,7 @@ void CGameContext::ConLock(IConsole::IResult *pResult, void *pUserData)
 			const char *pLoUL = Lock ? "unlock" : "lock"; // Lock or Unlock
 			
 			str_format(aBuf, sizeof(aBuf), 
-				"Your team is %s by %s, Please wait for a second and repeat /%s if you wan't to %s your team.", 
+				"Your team is %s by %s, Please wait for a second and repeat /%s if you want to %s your team.", 
 				pLoUL, pSelf->Server()->ClientName(Teams->m_aLastLocker[Team]), pLoUL, pLoUL);
 			pSelf->SendChatTarget(pResult->m_ClientId, aBuf);
 			

--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -30,6 +30,8 @@ void CGameTeams::Reset()
 
 	for(int i = 0; i < NUM_DDRACE_TEAMS; ++i)
 	{
+		m_aLastLocker[i] = -1;
+		m_aLastLockTime[i] = 0;
 		m_aTeamState[i] = TEAMSTATE_EMPTY;
 		m_aTeamLocked[i] = false;
 		m_aTeamFlock[i] = false;

--- a/src/game/server/teams.h
+++ b/src/game/server/teams.h
@@ -127,6 +127,9 @@ public:
 	void ProcessSaveTeam();
 
 	int GetFirstEmptyTeam() const;
+	
+	int m_aLastLocker[NUM_DDRACE_TEAMS];
+	int m_aLastLockTime[NUM_DDRACE_TEAMS];
 
 	bool TeeStarted(int ClientId)
 	{


### PR DESCRIPTION
It's will tips `Your team is (un)locked by [Locker Player], If you wan't to (un)lock team, Please wait for a second and repeat the command.` when 2 player in a team and they execute `/lock`  together It can prevent situations where several people want to lock the team, but in the end, they execute 'lock' together.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
