### PR TITLE
Add touch support to emoticon selector and spectator menu, minor refactoring

### DIFF
--- a/src/game/client/components/emoticon.cpp
+++ b/src/game/client/components/emoticon.cpp
@@ -137,6 +137,8 @@ void CEmoticon::OnRender()
 	else if(length(m_SelectorMouse) > 40.0f)
 		m_SelectedEyeEmote = (int)(SelectedAngle / (2 * pi) * NUM_EMOTES);
 
+	const vec2 ScreenCenter = Screen.Center();
+
 	Ui()->MapScreen();
 
 	Graphics()->BlendNormal();
@@ -144,26 +146,22 @@ void CEmoticon::OnRender()
 	Graphics()->TextureClear();
 	Graphics()->QuadsBegin();
 	Graphics()->SetColor(0, 0, 0, 0.3f);
-	Graphics()->DrawCircle(Screen.w / 2, Screen.h / 2, 190.0f, 64);
+	Graphics()->DrawCircle(ScreenCenter.x, ScreenCenter.y, 190.0f, 64);
 	Graphics()->QuadsEnd();
 
 	Graphics()->WrapClamp();
-	for(int i = 0; i < NUM_EMOTICONS; i++)
+	for(int Emote = 0; Emote < NUM_EMOTICONS; Emote++)
 	{
-		float Angle = 2 * pi * i / NUM_EMOTICONS;
+		float Angle = 2 * pi * Emote / NUM_EMOTICONS;
 		if(Angle > pi)
 			Angle -= 2 * pi;
 
-		bool Selected = m_SelectedEmote == i;
-
-		float Size = Selected ? 80.0f : 50.0f;
-
-		Graphics()->TextureSet(GameClient()->m_EmoticonsSkin.m_aSpriteEmoticons[i]);
+		Graphics()->TextureSet(GameClient()->m_EmoticonsSkin.m_aSpriteEmoticons[Emote]);
 		Graphics()->QuadsSetSubset(0, 0, 1, 1);
-
 		Graphics()->QuadsBegin();
 		const vec2 Nudge = direction(Angle) * 150.0f;
-		IGraphics::CQuadItem QuadItem(Screen.w / 2 + Nudge.x, Screen.h / 2 + Nudge.y, Size, Size);
+		const float Size = m_SelectedEmote == Emote ? 80.0f : 50.0f;
+		IGraphics::CQuadItem QuadItem(ScreenCenter.x + Nudge.x, ScreenCenter.y + Nudge.y, Size, Size);
 		Graphics()->QuadsDraw(&QuadItem, 1);
 		Graphics()->QuadsEnd();
 	}
@@ -174,34 +172,32 @@ void CEmoticon::OnRender()
 		Graphics()->TextureClear();
 		Graphics()->QuadsBegin();
 		Graphics()->SetColor(1.0, 1.0, 1.0, 0.3f);
-		Graphics()->DrawCircle(Screen.w / 2, Screen.h / 2, 100.0f, 64);
+		Graphics()->DrawCircle(ScreenCenter.x, ScreenCenter.y, 100.0f, 64);
 		Graphics()->QuadsEnd();
 
 		CTeeRenderInfo TeeInfo = m_pClient->m_aClients[m_pClient->m_aLocalIds[g_Config.m_ClDummy]].m_RenderInfo;
 
-		for(int i = 0; i < NUM_EMOTES; i++)
+		for(int Emote = 0; Emote < NUM_EMOTES; Emote++)
 		{
-			float Angle = 2 * pi * i / NUM_EMOTES;
+			float Angle = 2 * pi * Emote / NUM_EMOTES;
 			if(Angle > pi)
 				Angle -= 2 * pi;
 
-			const bool Selected = m_SelectedEyeEmote == i;
-
 			const vec2 Nudge = direction(Angle) * 70.0f;
-			TeeInfo.m_Size = Selected ? 64.0f : 48.0f;
-			RenderTools()->RenderTee(CAnimState::GetIdle(), &TeeInfo, i, vec2(-1, 0), vec2(Screen.w / 2 + Nudge.x, Screen.h / 2 + Nudge.y));
+			TeeInfo.m_Size = m_SelectedEyeEmote == Emote ? 64.0f : 48.0f;
+			RenderTools()->RenderTee(CAnimState::GetIdle(), &TeeInfo, Emote, vec2(-1, 0), ScreenCenter + Nudge);
 		}
 
 		Graphics()->TextureClear();
 		Graphics()->QuadsBegin();
 		Graphics()->SetColor(0, 0, 0, 0.3f);
-		Graphics()->DrawCircle(Screen.w / 2, Screen.h / 2, 30.0f, 64);
+		Graphics()->DrawCircle(ScreenCenter.x, ScreenCenter.y, 30.0f, 64);
 		Graphics()->QuadsEnd();
 	}
 	else
 		m_SelectedEyeEmote = -1;
 
-	RenderTools()->RenderCursor(m_SelectorMouse + vec2(Screen.w, Screen.h) / 2, 24.0f);
+	RenderTools()->RenderCursor(ScreenCenter + m_SelectorMouse, 24.0f);
 }
 
 void CEmoticon::Emote(int Emoticon)

--- a/src/game/client/components/emoticon.h
+++ b/src/game/client/components/emoticon.h
@@ -4,7 +4,9 @@
 #define GAME_CLIENT_COMPONENTS_EMOTICON_H
 #include <base/vmath.h>
 #include <engine/console.h>
+
 #include <game/client/component.h>
+#include <game/client/ui.h>
 
 class CEmoticon : public CComponent
 {
@@ -14,6 +16,9 @@ class CEmoticon : public CComponent
 	vec2 m_SelectorMouse;
 	int m_SelectedEmote;
 	int m_SelectedEyeEmote;
+
+	CUi::CTouchState m_TouchState;
+	bool m_TouchPressedOutside;
 
 	static void ConKeyEmoticon(IConsole::IResult *pResult, void *pUserData);
 	static void ConEmote(IConsole::IResult *pResult, void *pUserData);
@@ -27,9 +32,12 @@ public:
 	virtual void OnRender() override;
 	virtual void OnRelease() override;
 	virtual bool OnCursorMove(float x, float y, IInput::ECursorType CursorType) override;
+	virtual bool OnInput(const IInput::CEvent &Event) override;
 
 	void Emote(int Emoticon);
 	void EyeEmote(int EyeEmote);
+
+	bool IsActive() const { return m_Active; }
 };
 
 #endif

--- a/src/game/client/components/spectator.h
+++ b/src/game/client/components/spectator.h
@@ -6,6 +6,7 @@
 #include <engine/console.h>
 
 #include <game/client/component.h>
+#include <game/client/ui.h>
 
 class CSpectator : public CComponent
 {
@@ -20,6 +21,8 @@ class CSpectator : public CComponent
 
 	int m_SelectedSpectatorId;
 	vec2 m_SelectorMouse;
+
+	CUi::CTouchState m_TouchState;
 
 	float m_MultiViewActivateDelay;
 
@@ -39,12 +42,15 @@ public:
 
 	virtual void OnConsoleInit() override;
 	virtual bool OnCursorMove(float x, float y, IInput::ECursorType CursorType) override;
+	virtual bool OnInput(const IInput::CEvent &Event) override;
 	virtual void OnRender() override;
 	virtual void OnRelease() override;
 	virtual void OnReset() override;
 
 	void Spectate(int SpectatorId);
 	void SpectateClosest();
+
+	bool IsActive() const { return m_Active; }
 };
 
 #endif

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -160,9 +160,9 @@ void CGameClient::OnConsoleInit()
 						  &m_GameConsole,
 						  &m_Chat, // chat has higher prio, due to that you can quit it by pressing esc
 						  &m_Motd, // for pressing esc to remove it
-						  &m_Menus,
 						  &m_Spectator,
 						  &m_Emoticon,
+						  &m_Menus,
 						  &m_Controls,
 						  &m_Binds});
 


### PR DESCRIPTION
Support using emoticon selector and spectator menu with touch inputs. Touching in the emoticon selector activates the selected (eye) emote and closes the emoticon selector. The spectator menu is kept open when using it for more convenience. The emoticon selector and spectator menu can be closed by touching anywhere outside of them.

Additionally, the emoticon selector and specator menu can now be closed by pressing the Escape key (i.e. the back button on Android). This made it necessary to change the order of the components for input handling, so the ingame menu will handle the Escape key after the emoticon selector and spectator menu. This also means that the Escape key can now be used to close the selector/menu when they are stuck open, which was previously delayed until ingame menu or console were opened and closed.

Separated from #8632 to keep that PR slightly smaller.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
