### PR TITLE
Update translations for 18.5, remove 0.7-only translations

### DIFF
--- a/data/languages/arabic.txt
+++ b/data/languages/arabic.txt
@@ -275,9 +275,6 @@ Player
 Player country:
 == ﺐﻋﻼﻟﺍ ﺪﻠﺑ:
 
-Player options
-== ﺐﻋﻼﻟﺍ ﺕﺍﺩﺍﺪﻋﺍ
-
 Players
 == ﻦﻴﺒﻋﻻ
 
@@ -773,9 +770,6 @@ Skin prefix
 Show HUD
 == ﻞﻜﺸﻟﺍ ﺭﺎﻬﻇﺍ
 
-Reload
-== ﻞﻴﻤﺤﺘﻟﺍ ﺓﺩﺎﻋﺍ
-
 9+ new mentions
 == 9+ ﺓﺪﻳﺪﺟ ﺕﺍﺭﺎﻌﺷﺍ
 
@@ -1026,9 +1020,6 @@ Debug mode enabled. Press Ctrl+Shift+D to disable debug mode.
 Existing Player
 == ﺩﻮﺟﻮﻣ ﺐﻋﻼﻟﺍ
 
-Your nickname '%s' is already used (%d points). Do you still want to use it?
-== 
-
 Checking for existing player with your name
 == ﻚﻤﺳﺎﺑ ﺐﻋﻻ ﺩﻮﺟﻭ ﻦﻣ ﻖﻘﺤﺘﻟﺍ
 
@@ -1092,7 +1083,16 @@ Could not initialize the given graphics backend, reverting to the default backen
 Could not initialize the given graphics backend, this is probably because you didn't install the driver of the integrated graphics card.
 == 
 
+Could not resolve connect address '%s'. See local console for details.
+== 
+
+Connect address error
+== 
+
 Could not save downloaded map. Try manually deleting this file: %s
+== 
+
+Could not connect dummy
 == 
 
 Error playing demo
@@ -1223,6 +1223,9 @@ Render complete
 == 
 
 Are you sure that you want to restart?
+== 
+
+Your nickname '%s' is already used (%d points). Do you still want to use it?
 == 
 
 There's an unsaved map in the editor, you might want to save it.
@@ -1478,6 +1481,12 @@ Unable to delete the demo '%s'
 Unable to delete the folder '%s'. Make sure it's empty first.
 == 
 
+Dummy is not allowed on this server
+== 
+
+Please wait…
+== 
+
 Loading…
 == 
 
@@ -1645,7 +1654,7 @@ Show local time always
 DDRace HUD
 == 
 
-Show client IDs in scoreboard
+Show client IDs (scoreboard, chat, spectator)
 == 
 
 Show DDRace HUD
@@ -1817,6 +1826,39 @@ Unregister protocol and file extensions
 == 
 
 DDNet %s is available:
+== 
+
+Normal:
+== 
+
+Team:
+== 
+
+Dummy settings
+== 
+
+Toggle to edit your dummy settings
+== 
+
+Randomize
+== 
+
+Are you sure that you want to delete '%s'?
+== 
+
+Delete skin
+== 
+
+Basic
+== 
+
+Custom
+== 
+
+Unable to delete skin
+== 
+
+Customize
 == 
 
 Extras

--- a/data/languages/azerbaijanese.txt
+++ b/data/languages/azerbaijanese.txt
@@ -274,9 +274,6 @@ Play background music
 Player
 == Oyunçu
 
-Player options
-== Oyunçu parametrlər	
-
 Players
 == Oyunçular
 
@@ -651,9 +648,6 @@ Connecting dummy
 
 Connect Dummy
 == Dummy daxil ol
-
-Reload
-== Yenilə
 
 Deactivate
 == Qeyri-aktiv etmək 
@@ -1450,9 +1444,6 @@ Show health, shields and ammo
 DDRace HUD
 == DDRace interfeysi
 
-Show client IDs in scoreboard
-== Xal lövhəsində klient ID-lərini göstərin
-
 Show DDRace HUD
 == DDRace interfeysi göstər 
 
@@ -1870,3 +1861,54 @@ Team %d (%d/%d)
 
 https://wiki.ddnet.org/wiki/Mapping
 == https://wiki.ddnet.org/wiki/Mapping
+
+Could not resolve connect address '%s'. See local console for details.
+== 
+
+Connect address error
+== 
+
+Could not connect dummy
+== 
+
+Dummy is not allowed on this server
+== 
+
+Please wait…
+== 
+
+Show client IDs (scoreboard, chat, spectator)
+== 
+
+Normal:
+== 
+
+Team:
+== 
+
+Dummy settings
+== 
+
+Toggle to edit your dummy settings
+== 
+
+Randomize
+== 
+
+Are you sure that you want to delete '%s'?
+== 
+
+Delete skin
+== 
+
+Basic
+== 
+
+Custom
+== 
+
+Unable to delete skin
+== 
+
+Customize
+== 

--- a/data/languages/belarusian.txt
+++ b/data/languages/belarusian.txt
@@ -282,9 +282,6 @@ Player
 Player country:
 == Краіна гульца:
 
-Player options
-== Опцыі гульца
-
 Players
 == Гульцы
 
@@ -868,9 +865,6 @@ Loading ghost files
 Time
 == Час
 
-Reload
-== Перазагрузіць
-
 Deactivate
 == Выключыць
 
@@ -1166,9 +1160,6 @@ Show votes window after voting
 
 DDRace HUD
 == DDRace HUD
-
-Show client IDs in scoreboard
-== Паказваць ID кліента ў табло ачкоў
 
 Show DDRace HUD
 == Паказваць DDRace HUD
@@ -1706,6 +1697,7 @@ Regular background color
 Entities background color
 == Колер фону энтыты
 
+[Graphics error]
 An error during command recording occurred. Try to update your GPU drivers.
 == Адбылася памылка падчас выканання каманды запісу. Паспрабуйце абнавіць драйверы відэакарты.
 
@@ -1874,3 +1866,54 @@ Team %d (%d/%d)
 
 https://wiki.ddnet.org/wiki/Mapping
 == https://wiki.ddnet.org/wiki/Mapping
+
+Could not resolve connect address '%s'. See local console for details.
+== 
+
+Connect address error
+== 
+
+Could not connect dummy
+== 
+
+Dummy is not allowed on this server
+== 
+
+Please wait…
+== 
+
+Show client IDs (scoreboard, chat, spectator)
+== 
+
+Normal:
+== 
+
+Team:
+== 
+
+Dummy settings
+== 
+
+Toggle to edit your dummy settings
+== 
+
+Randomize
+== 
+
+Are you sure that you want to delete '%s'?
+== 
+
+Delete skin
+== 
+
+Basic
+== 
+
+Custom
+== 
+
+Unable to delete skin
+== 
+
+Customize
+== 

--- a/data/languages/bosnian.txt
+++ b/data/languages/bosnian.txt
@@ -280,9 +280,6 @@ Player
 Player country:
 == Država
 
-Player options
-== Postavke igrača
-
 Players
 == Igrači
 
@@ -651,9 +648,6 @@ Connecting dummy
 Connect Dummy
 == Konektuj dummy-a
 
-Reload
-== Reload
-
 Deactivate
 == Deaktiviraj
 
@@ -951,7 +945,16 @@ Could not initialize the given graphics backend, reverting to the default backen
 Could not initialize the given graphics backend, this is probably because you didn't install the driver of the integrated graphics card.
 == 
 
+Could not resolve connect address '%s'. See local console for details.
+== 
+
+Connect address error
+== 
+
 Could not save downloaded map. Try manually deleting this file: %s
+== 
+
+Could not connect dummy
 == 
 
 Error playing demo
@@ -1385,6 +1388,12 @@ Unable to delete the demo '%s'
 Unable to delete the folder '%s'. Make sure it's empty first.
 == 
 
+Dummy is not allowed on this server
+== 
+
+Please wait…
+== 
+
 Loading…
 == 
 
@@ -1591,7 +1600,7 @@ Show local time always
 DDRace HUD
 == 
 
-Show client IDs in scoreboard
+Show client IDs (scoreboard, chat, spectator)
 == 
 
 Show DDRace HUD
@@ -1775,6 +1784,39 @@ Chat command (e.g. showall 1)
 == 
 
 Unregister protocol and file extensions
+== 
+
+Normal:
+== 
+
+Team:
+== 
+
+Dummy settings
+== 
+
+Toggle to edit your dummy settings
+== 
+
+Randomize
+== 
+
+Are you sure that you want to delete '%s'?
+== 
+
+Delete skin
+== 
+
+Basic
+== 
+
+Custom
+== 
+
+Unable to delete skin
+== 
+
+Customize
 == 
 
 Emoticons

--- a/data/languages/brazilian_portuguese.txt
+++ b/data/languages/brazilian_portuguese.txt
@@ -311,9 +311,6 @@ Player
 Player country:
 == País do jogador:
 
-Player options
-== Opções do jogador
-
 Players
 == Jogadores
 
@@ -817,9 +814,6 @@ Show DDNet map finishes in server browser
 
 transmits your player name to info.ddnet.org
 == transmite seu nome de jogador para info.ddnet.org
-
-Reload
-== Recarregar
 
 Time
 == Tempo
@@ -1376,9 +1370,6 @@ Show health, shields and ammo
 DDRace HUD
 == HUD do DDRace
 
-Show client IDs in scoreboard
-== Mostrar IDs de cliente no placar
-
 Show DDRace HUD
 == Mostrar HUD do DDRace
 
@@ -1901,3 +1892,54 @@ Team %d (%d/%d)
 
 https://wiki.ddnet.org/wiki/Mapping
 == https://wiki.ddnet.org/wiki/Mapping
+
+Could not resolve connect address '%s'. See local console for details.
+== 
+
+Connect address error
+== 
+
+Could not connect dummy
+== 
+
+Dummy is not allowed on this server
+== 
+
+Please wait…
+== 
+
+Show client IDs (scoreboard, chat, spectator)
+== 
+
+Normal:
+== 
+
+Team:
+== 
+
+Dummy settings
+== 
+
+Toggle to edit your dummy settings
+== 
+
+Randomize
+== 
+
+Are you sure that you want to delete '%s'?
+== 
+
+Delete skin
+== 
+
+Basic
+== 
+
+Custom
+== 
+
+Unable to delete skin
+== 
+
+Customize
+== 

--- a/data/languages/bulgarian.txt
+++ b/data/languages/bulgarian.txt
@@ -277,9 +277,6 @@ Player
 Player country:
 == Страна на играча:
 
-Player options
-== Настройки на Играча
-
 Players
 == Играчи
 
@@ -546,7 +543,16 @@ Could not initialize the given graphics backend, reverting to the default backen
 Could not initialize the given graphics backend, this is probably because you didn't install the driver of the integrated graphics card.
 == 
 
+Could not resolve connect address '%s'. See local console for details.
+== 
+
+Connect address error
+== 
+
 Could not save downloaded map. Try manually deleting this file: %s
+== 
+
+Could not connect dummy
 == 
 
 Error playing demo
@@ -1094,6 +1100,12 @@ Are you sure that you want to disconnect?
 Connect Dummy
 == 
 
+Dummy is not allowed on this server
+== 
+
+Please wait…
+== 
+
 Connecting dummy
 == 
 
@@ -1441,7 +1453,7 @@ Show votes window after voting
 DDRace HUD
 == 
 
-Show client IDs in scoreboard
+Show client IDs (scoreboard, chat, spectator)
 == 
 
 Show DDRace HUD
@@ -1693,9 +1705,6 @@ Regular background color
 Entities background color
 == 
 
-Reload
-== 
-
 Use current map as background
 == 
 
@@ -1730,6 +1739,39 @@ No updates available
 == 
 
 Check now
+== 
+
+Normal:
+== 
+
+Team:
+== 
+
+Dummy settings
+== 
+
+Toggle to edit your dummy settings
+== 
+
+Randomize
+== 
+
+Are you sure that you want to delete '%s'?
+== 
+
+Delete skin
+== 
+
+Basic
+== 
+
+Custom
+== 
+
+Unable to delete skin
+== 
+
+Customize
 == 
 
 Emoticons

--- a/data/languages/catalan.txt
+++ b/data/languages/catalan.txt
@@ -275,9 +275,6 @@ Player
 Player country:
 == País del jugador
 
-Player options
-== Opcions del jugador
-
 Players
 == Jugadors
 
@@ -782,9 +779,6 @@ Show DDNet map finishes in server browser
 transmits your player name to info.ddnet.org
 == retransmet el teu nom de jugar a info.ddnet.org
 
-Reload
-== Recarga
-
 Successfully saved the replay!
 == S'ha guardat la repetició correctament!
 
@@ -1197,7 +1191,16 @@ Could not initialize the given graphics backend, reverting to the default backen
 Could not initialize the given graphics backend, this is probably because you didn't install the driver of the integrated graphics card.
 == 
 
+Could not resolve connect address '%s'. See local console for details.
+== 
+
+Connect address error
+== 
+
 Could not save downloaded map. Try manually deleting this file: %s
+== 
+
+Could not connect dummy
 == 
 
 Error playing demo
@@ -1541,6 +1544,12 @@ Unable to delete the demo '%s'
 Unable to delete the folder '%s'. Make sure it's empty first.
 == 
 
+Dummy is not allowed on this server
+== 
+
+Please wait…
+== 
+
 Loading…
 == 
 
@@ -1672,7 +1681,7 @@ Show local time always
 DDRace HUD
 == 
 
-Show client IDs in scoreboard
+Show client IDs (scoreboard, chat, spectator)
 == 
 
 Show DDRace HUD
@@ -1826,6 +1835,39 @@ Entities background color
 == 
 
 Unregister protocol and file extensions
+== 
+
+Normal:
+== 
+
+Team:
+== 
+
+Dummy settings
+== 
+
+Toggle to edit your dummy settings
+== 
+
+Randomize
+== 
+
+Are you sure that you want to delete '%s'?
+== 
+
+Delete skin
+== 
+
+Basic
+== 
+
+Custom
+== 
+
+Unable to delete skin
+== 
+
+Customize
 == 
 
 Extras

--- a/data/languages/chuvash.txt
+++ b/data/languages/chuvash.txt
@@ -277,9 +277,6 @@ Player
 Player country:
 == Çĕршыв:
 
-Player options
-== Опцисем
-
 Players
 == Çынсем
 
@@ -549,7 +546,16 @@ Could not initialize the given graphics backend, reverting to the default backen
 Could not initialize the given graphics backend, this is probably because you didn't install the driver of the integrated graphics card.
 == 
 
+Could not resolve connect address '%s'. See local console for details.
+== 
+
+Connect address error
+== 
+
 Could not save downloaded map. Try manually deleting this file: %s
+== 
+
+Could not connect dummy
 == 
 
 Error playing demo
@@ -1097,6 +1103,12 @@ Are you sure that you want to disconnect?
 Connect Dummy
 == 
 
+Dummy is not allowed on this server
+== 
+
+Please wait…
+== 
+
 Connecting dummy
 == 
 
@@ -1441,7 +1453,7 @@ Show votes window after voting
 DDRace HUD
 == 
 
-Show client IDs in scoreboard
+Show client IDs (scoreboard, chat, spectator)
 == 
 
 Show DDRace HUD
@@ -1693,9 +1705,6 @@ Regular background color
 Entities background color
 == 
 
-Reload
-== 
-
 Use current map as background
 == 
 
@@ -1730,6 +1739,39 @@ No updates available
 == 
 
 Check now
+== 
+
+Normal:
+== 
+
+Team:
+== 
+
+Dummy settings
+== 
+
+Toggle to edit your dummy settings
+== 
+
+Randomize
+== 
+
+Are you sure that you want to delete '%s'?
+== 
+
+Delete skin
+== 
+
+Basic
+== 
+
+Custom
+== 
+
+Unable to delete skin
+== 
+
+Customize
 == 
 
 Emoticons

--- a/data/languages/czech.txt
+++ b/data/languages/czech.txt
@@ -281,9 +281,6 @@ Player
 Player country:
 == Země hráčů:
 
-Player options
-== Možnosti hráčů
-
 Players
 == Hráči
 
@@ -645,9 +642,6 @@ Connecting dummy
 
 Connect Dummy
 == Připojit dummyho
-
-Reload
-== Znovu načíst
 
 Deactivate
 == Deaktivovat
@@ -1634,9 +1628,6 @@ Show local time always
 DDRace HUD
 == DDRace HUD
 
-Show client IDs in scoreboard
-== Zobrazit ID klientů ve výsledkové tabulce
-
 Show DDRace HUD
 == Zobrazit DDRace HUD
 
@@ -1853,11 +1844,62 @@ Tee
 Show only chat messages from team members
 == Zobrazit pouze zprávy od členů týmu
 
+Could not resolve connect address '%s'. See local console for details.
+== 
+
+Connect address error
+== 
+
+Could not connect dummy
+== 
+
 [Spectating]
 Following %s
 == 
 
 Example of usage
+== 
+
+Dummy is not allowed on this server
+== 
+
+Please wait…
+== 
+
+Show client IDs (scoreboard, chat, spectator)
+== 
+
+Normal:
+== 
+
+Team:
+== 
+
+Dummy settings
+== 
+
+Toggle to edit your dummy settings
+== 
+
+Randomize
+== 
+
+Are you sure that you want to delete '%s'?
+== 
+
+Delete skin
+== 
+
+Basic
+== 
+
+Custom
+== 
+
+Unable to delete skin
+== 
+
+Customize
 == 
 
 Round %d/%d

--- a/data/languages/danish.txt
+++ b/data/languages/danish.txt
@@ -278,9 +278,6 @@ Player
 Player country:
 == Spillernes land:
 
-Player options
-== Spillermuligheder
-
 Players
 == Spillere
 
@@ -675,9 +672,6 @@ Kill
 
 Pause
 == Pause
-
-Reload
-== Genindlæs
 
 Deactivate
 == Deaktiver
@@ -1100,7 +1094,16 @@ Could not initialize the given graphics backend, reverting to the default backen
 Could not initialize the given graphics backend, this is probably because you didn't install the driver of the integrated graphics card.
 == 
 
+Could not resolve connect address '%s'. See local console for details.
+== 
+
+Connect address error
+== 
+
 Could not save downloaded map. Try manually deleting this file: %s
+== 
+
+Could not connect dummy
 == 
 
 Error playing demo
@@ -1486,6 +1489,12 @@ Unable to delete the demo '%s'
 Unable to delete the folder '%s'. Make sure it's empty first.
 == 
 
+Dummy is not allowed on this server
+== 
+
+Please wait…
+== 
+
 Loading…
 == 
 
@@ -1653,7 +1662,7 @@ Show local time always
 DDRace HUD
 == 
 
-Show client IDs in scoreboard
+Show client IDs (scoreboard, chat, spectator)
 == 
 
 Show DDRace HUD
@@ -1822,6 +1831,39 @@ Chat command (e.g. showall 1)
 == 
 
 Unregister protocol and file extensions
+== 
+
+Normal:
+== 
+
+Team:
+== 
+
+Dummy settings
+== 
+
+Toggle to edit your dummy settings
+== 
+
+Randomize
+== 
+
+Are you sure that you want to delete '%s'?
+== 
+
+Delete skin
+== 
+
+Basic
+== 
+
+Custom
+== 
+
+Unable to delete skin
+== 
+
+Customize
 == 
 
 Extras

--- a/data/languages/dutch.txt
+++ b/data/languages/dutch.txt
@@ -290,9 +290,6 @@ Player
 Player country:
 == Speler land:
 
-Player options
-== Speler opties
-
 Players
 == Spelers
 
@@ -662,9 +659,6 @@ Connecting dummy
 
 Connect Dummy
 == Verbind Dummy
-
-Reload
-== Herladen
 
 Deactivate
 == Deactiveren
@@ -1243,7 +1237,16 @@ Could not initialize the given graphics backend, reverting to the default backen
 Could not initialize the given graphics backend, this is probably because you didn't install the driver of the integrated graphics card.
 == 
 
+Could not resolve connect address '%s'. See local console for details.
+== 
+
+Connect address error
+== 
+
 Could not save downloaded map. Try manually deleting this file: %s
+== 
+
+Could not connect dummy
 == 
 
 Error playing demo
@@ -1584,6 +1587,12 @@ Unable to delete the demo '%s'
 Unable to delete the folder '%s'. Make sure it's empty first.
 == 
 
+Dummy is not allowed on this server
+== 
+
+Please wait…
+== 
+
 Loading…
 == 
 
@@ -1709,7 +1718,7 @@ Show local time always
 DDRace HUD
 == 
 
-Show client IDs in scoreboard
+Show client IDs (scoreboard, chat, spectator)
 == 
 
 Show DDRace HUD
@@ -1848,6 +1857,39 @@ Entities background color
 == 
 
 Unregister protocol and file extensions
+== 
+
+Normal:
+== 
+
+Team:
+== 
+
+Dummy settings
+== 
+
+Toggle to edit your dummy settings
+== 
+
+Randomize
+== 
+
+Are you sure that you want to delete '%s'?
+== 
+
+Delete skin
+== 
+
+Basic
+== 
+
+Custom
+== 
+
+Unable to delete skin
+== 
+
+Customize
 == 
 
 Extras

--- a/data/languages/esperanto.txt
+++ b/data/languages/esperanto.txt
@@ -300,9 +300,6 @@ Kill
 Pause
 == Paŭzi
 
-Player options
-== Ludantaj agordoj
-
 Player
 == Ludanto
 
@@ -565,7 +562,16 @@ Could not initialize the given graphics backend, reverting to the default backen
 Could not initialize the given graphics backend, this is probably because you didn't install the driver of the integrated graphics card.
 == 
 
+Could not resolve connect address '%s'. See local console for details.
+== 
+
+Connect address error
+== 
+
 Could not save downloaded map. Try manually deleting this file: %s
+== 
+
+Could not connect dummy
 == 
 
 Error playing demo
@@ -1053,6 +1059,12 @@ Unable to delete the demo '%s'
 Unable to delete the folder '%s'. Make sure it's empty first.
 == 
 
+Dummy is not allowed on this server
+== 
+
+Please wait…
+== 
+
 Stop record
 == 
 
@@ -1481,7 +1493,7 @@ Show votes window after voting
 DDRace HUD
 == 
 
-Show client IDs in scoreboard
+Show client IDs (scoreboard, chat, spectator)
 == 
 
 Show DDRace HUD
@@ -1724,9 +1736,6 @@ Regular background color
 Entities background color
 == 
 
-Reload
-== 
-
 Use current map as background
 == 
 
@@ -1749,6 +1758,39 @@ DDNet Client updated!
 == 
 
 No updates available
+== 
+
+Normal:
+== 
+
+Team:
+== 
+
+Dummy settings
+== 
+
+Toggle to edit your dummy settings
+== 
+
+Randomize
+== 
+
+Are you sure that you want to delete '%s'?
+== 
+
+Delete skin
+== 
+
+Basic
+== 
+
+Custom
+== 
+
+Unable to delete skin
+== 
+
+Customize
 == 
 
 Emoticons

--- a/data/languages/estonian.txt
+++ b/data/languages/estonian.txt
@@ -281,9 +281,6 @@ Player
 Player country:
 == Mängija maa:
 
-Player options
-== Mängija sätted
-
 Players
 == Mängijad
 
@@ -709,9 +706,6 @@ Kill
 
 Pause
 == Paus
-
-Reload
-== Lae uuesti
 
 Deactivate
 == Deaktiveeri
@@ -1605,9 +1599,6 @@ Show local time always
 DDRace HUD
 == DDRace HUD
 
-Show client IDs in scoreboard
-== Näita kliendi ID-eid tulemustabelis
-
 Show DDRace HUD
 == Näita DDRace HUD-i
 
@@ -1871,6 +1862,57 @@ Round %d/%d
 
 Team %d (%d/%d)
 == Tiim %d (%d/%d)
+
+Could not resolve connect address '%s'. See local console for details.
+== 
+
+Connect address error
+== 
+
+Could not connect dummy
+== 
+
+Dummy is not allowed on this server
+== 
+
+Please wait…
+== 
+
+Show client IDs (scoreboard, chat, spectator)
+== 
+
+Normal:
+== 
+
+Team:
+== 
+
+Dummy settings
+== 
+
+Toggle to edit your dummy settings
+== 
+
+Randomize
+== 
+
+Are you sure that you want to delete '%s'?
+== 
+
+Delete skin
+== 
+
+Basic
+== 
+
+Custom
+== 
+
+Unable to delete skin
+== 
+
+Customize
+== 
 
 https://wiki.ddnet.org/wiki/Mapping
 == 

--- a/data/languages/finnish.txt
+++ b/data/languages/finnish.txt
@@ -280,9 +280,6 @@ Player
 Player country:
 == Pelaajan maa:
 
-Player options
-== Pelaajavalinnat
-
 Players
 == Pelaajat
 
@@ -708,9 +705,6 @@ Kill
 
 Pause
 == Pysäytä
-
-Reload
-== Päivitä
 
 Deactivate
 == Deaktivoi
@@ -1634,9 +1628,6 @@ Show local time always
 DDRace HUD
 == DDrace-HUD
 
-Show client IDs in scoreboard
-== Näytä asiakas-ID:t pistetaulukossa
-
 Show DDRace HUD
 == Näytä DDRace-HUD
 
@@ -1832,6 +1823,15 @@ Loading sound files
 Moved ingame
 == Liikui pelissä
 
+Could not resolve connect address '%s'. See local console for details.
+== 
+
+Connect address error
+== 
+
+Could not connect dummy
+== 
+
 [Spectating]
 Following %s
 == 
@@ -1842,13 +1842,55 @@ Following %s
 Example of usage
 == 
 
+Dummy is not allowed on this server
+== 
+
+Please wait…
+== 
+
 Converse
 == 
 
 Tee
 == 
 
+Show client IDs (scoreboard, chat, spectator)
+== 
+
 Show only chat messages from team members
+== 
+
+Normal:
+== 
+
+Team:
+== 
+
+Dummy settings
+== 
+
+Toggle to edit your dummy settings
+== 
+
+Randomize
+== 
+
+Are you sure that you want to delete '%s'?
+== 
+
+Delete skin
+== 
+
+Basic
+== 
+
+Custom
+== 
+
+Unable to delete skin
+== 
+
+Customize
 == 
 
 Round %d/%d

--- a/data/languages/french.txt
+++ b/data/languages/french.txt
@@ -302,9 +302,6 @@ Player
 Player country:
 == Origine des Tees:
 
-Player options
-== Options des joueurs
-
 Players
 == Joueurs
 
@@ -609,9 +606,6 @@ AntiPing: predict other players
 
 Are you sure that you want to disconnect your dummy?
 == Êtes vous sûrs de vouloir déconnecter votre dummy ?
-
-Reload
-== Recharger
 
 Server best:
 == Meilleur score du serveur
@@ -1390,9 +1384,6 @@ Name Plate
 Hook Collisions
 == Collisions du grappin
 
-Show client IDs in scoreboard
-== Afficher les IDs des clients dans le tableau des scores
-
 Hook collision line width
 == Largeur de la ligne de collision du grappin
 
@@ -1874,11 +1865,62 @@ Entities background color
 Moved ingame
 == Déplacé en jeu
 
+Could not resolve connect address '%s'. See local console for details.
+== 
+
+Connect address error
+== 
+
+Could not connect dummy
+== 
+
 [Spectating]
 Following %s
 == 
 
 Example of usage
+== 
+
+Dummy is not allowed on this server
+== 
+
+Please wait…
+== 
+
+Show client IDs (scoreboard, chat, spectator)
+== 
+
+Normal:
+== 
+
+Team:
+== 
+
+Dummy settings
+== 
+
+Toggle to edit your dummy settings
+== 
+
+Randomize
+== 
+
+Are you sure that you want to delete '%s'?
+== 
+
+Delete skin
+== 
+
+Basic
+== 
+
+Custom
+== 
+
+Unable to delete skin
+== 
+
+Customize
 == 
 
 Round %d/%d

--- a/data/languages/galician.txt
+++ b/data/languages/galician.txt
@@ -280,9 +280,6 @@ Player
 Player country:
 == País do xogador
 
-Player options
-== Opcións de xogador
-
 Players
 == Xogadores
 
@@ -651,9 +648,6 @@ Connecting dummy
 
 Connect Dummy
 == Conectar Dummy
-
-Reload
-== Recargar
 
 Deactivate
 == Desactivar
@@ -1358,9 +1352,6 @@ Show health, shields and ammo
 DDRace HUD
 == HUD DDRace
 
-Show client IDs in scoreboard
-== Mostrar IDs de cliente na táboa de puntuación
-
 Show DDRace HUD
 == Mostrar o HUD DDRace
 
@@ -1571,6 +1562,15 @@ Relative
 Absolute
 == Absoluto
 
+Could not resolve connect address '%s'. See local console for details.
+== 
+
+Connect address error
+== 
+
+Could not connect dummy
+== 
+
 Error playing demo
 == 
 
@@ -1767,6 +1767,12 @@ Delete folder
 Unable to delete the folder '%s'. Make sure it's empty first.
 == 
 
+Dummy is not allowed on this server
+== 
+
+Please wait…
+== 
+
 Loading…
 == 
 
@@ -1795,6 +1801,9 @@ Info Messages
 == 
 
 Show local time always
+== 
+
+Show client IDs (scoreboard, chat, spectator)
 == 
 
 Always show chat
@@ -1849,6 +1858,39 @@ Regular background color
 == 
 
 Entities background color
+== 
+
+Normal:
+== 
+
+Team:
+== 
+
+Dummy settings
+== 
+
+Toggle to edit your dummy settings
+== 
+
+Randomize
+== 
+
+Are you sure that you want to delete '%s'?
+== 
+
+Delete skin
+== 
+
+Basic
+== 
+
+Custom
+== 
+
+Unable to delete skin
+== 
+
+Customize
 == 
 
 Round %d/%d

--- a/data/languages/german.txt
+++ b/data/languages/german.txt
@@ -299,9 +299,6 @@ Player
 Player country:
 == Spielerland:
 
-Player options
-== Spieleroptionen
-
 Players
 == Spieler
 
@@ -364,9 +361,6 @@ Shotgun
 
 Show chat
 == Chat anzeigen
-
-Show client IDs in scoreboard
-== Client-IDs in der Punktetafel anzeigen
 
 Show DDRace HUD
 == DDRace-HUD anzeigen
@@ -814,9 +808,6 @@ Skin prefix
 
 Show HUD
 == HUD zeigen
-
-Reload
-== Neu laden
 
 9+ new mentions
 == 9+ Erwähnungen
@@ -1886,6 +1877,57 @@ Round %d/%d
 
 Team %d (%d/%d)
 == Team %d (%d/%d)
+
+Could not resolve connect address '%s'. See local console for details.
+== Konnte Verbindungsadresse '%s' nicht auflösen, siehe lokale Konsole für Details.
+
+Connect address error
+== Fehler in Verbindungsadresse
+
+Could not connect dummy
+== Konnte Dummy nicht verbinden
+
+Dummy is not allowed on this server
+== Dummy ist auf diesem Server nicht erlaubt
+
+Please wait…
+== Bitte warten…
+
+Show client IDs (scoreboard, chat, spectator)
+== Client-IDs anzeigen (Punktetafel, Chat, Beobachter)
+
+Normal:
+== Normal:
+
+Team:
+== Team:
+
+Dummy settings
+== Dummy-Einstellungen
+
+Toggle to edit your dummy settings
+== Zu Dummy-Einstellungen wechseln
+
+Randomize
+== Randomisieren
+
+Are you sure that you want to delete '%s'?
+== Bist du sicher dass du '%s' löschen willst?
+
+Delete skin
+== Skin löschen
+
+Basic
+== Einfach
+
+Custom
+== Individuell
+
+Unable to delete skin
+== Kann Skin nicht löschen
+
+Customize
+== Anpassen
 
 https://wiki.ddnet.org/wiki/Mapping
 == 

--- a/data/languages/greek.txt
+++ b/data/languages/greek.txt
@@ -280,9 +280,6 @@ Player
 Player country:
 == Χώρα παίκτη:
 
-Player options
-== Επιλογές παίκτη
-
 Players
 == Παίκτες
 
@@ -555,7 +552,16 @@ Could not initialize the given graphics backend, reverting to the default backen
 Could not initialize the given graphics backend, this is probably because you didn't install the driver of the integrated graphics card.
 == 
 
+Could not resolve connect address '%s'. See local console for details.
+== 
+
+Connect address error
+== 
+
 Could not save downloaded map. Try manually deleting this file: %s
+== 
+
+Could not connect dummy
 == 
 
 Error playing demo
@@ -1100,6 +1106,12 @@ Are you sure that you want to disconnect?
 Connect Dummy
 == 
 
+Dummy is not allowed on this server
+== 
+
+Please wait…
+== 
+
 Connecting dummy
 == 
 
@@ -1444,7 +1456,7 @@ Show votes window after voting
 DDRace HUD
 == 
 
-Show client IDs in scoreboard
+Show client IDs (scoreboard, chat, spectator)
 == 
 
 Show DDRace HUD
@@ -1693,9 +1705,6 @@ Regular background color
 Entities background color
 == 
 
-Reload
-== 
-
 Use current map as background
 == 
 
@@ -1730,6 +1739,39 @@ No updates available
 == 
 
 Check now
+== 
+
+Normal:
+== 
+
+Team:
+== 
+
+Dummy settings
+== 
+
+Toggle to edit your dummy settings
+== 
+
+Randomize
+== 
+
+Are you sure that you want to delete '%s'?
+== 
+
+Delete skin
+== 
+
+Basic
+== 
+
+Custom
+== 
+
+Unable to delete skin
+== 
+
+Customize
 == 
 
 Emoticons

--- a/data/languages/hungarian.txt
+++ b/data/languages/hungarian.txt
@@ -270,9 +270,6 @@ Pistol
 Player
 == Játékos
 
-Player options
-== Játékosok kezelése
-
 Players
 == Játékosok
 
@@ -789,9 +786,6 @@ Show DDNet map finishes in server browser
 transmits your player name to info.ddnet.org
 == továbbítja a játékosnevedet az info.ddnet.org oldalra
 
-Reload
-== Újratöltés
-
 Hammerfly dummy
 == Másolat kalapácsolás
 
@@ -1059,9 +1053,6 @@ Auto
 
 Replay
 == Visszajátszás
-
-The width of texture %s is not divisible by %d, or the height is not divisible by %d, which might cause visual bugs.
-== 
 
 Getting server list from master server
 == Szerverlista lekérése a fő szerverekről
@@ -1338,9 +1329,6 @@ Show health, shields and ammo
 DDRace HUD
 == DDRace HUD
 
-Show client IDs in scoreboard
-== Mutassa a kliensek ID-ét a pontszámtáblán
-
 Show DDRace HUD
 == Mutassa a DDRace HUD-ot (Speciális HUD)
 
@@ -1551,6 +1539,15 @@ Unregister protocol and file extensions
 Open the directory to add custom assets
 == Megnyitni az egyedi Képek helyét
 
+Could not resolve connect address '%s'. See local console for details.
+== 
+
+Connect address error
+== 
+
+Could not connect dummy
+== 
+
 Error playing demo
 == 
 
@@ -1561,6 +1558,9 @@ Saving settings to '%s' failed
 == 
 
 Error saving settings
+== 
+
+The width of texture %s is not divisible by %d, or the height is not divisible by %d, which might cause visual bugs.
 == 
 
 Loading demo file from storage
@@ -1772,6 +1772,12 @@ Delete folder
 Unable to delete the folder '%s'. Make sure it's empty first.
 == 
 
+Dummy is not allowed on this server
+== 
+
+Please wait…
+== 
+
 Loading…
 == 
 
@@ -1800,6 +1806,9 @@ Info Messages
 == 
 
 Show local time always
+== 
+
+Show client IDs (scoreboard, chat, spectator)
 == 
 
 Always show chat
@@ -1851,6 +1860,39 @@ Regular background color
 == 
 
 Entities background color
+== 
+
+Normal:
+== 
+
+Team:
+== 
+
+Dummy settings
+== 
+
+Toggle to edit your dummy settings
+== 
+
+Randomize
+== 
+
+Are you sure that you want to delete '%s'?
+== 
+
+Delete skin
+== 
+
+Basic
+== 
+
+Custom
+== 
+
+Unable to delete skin
+== 
+
+Customize
 == 
 
 Round %d/%d

--- a/data/languages/italian.txt
+++ b/data/languages/italian.txt
@@ -284,9 +284,6 @@ Player
 Player country:
 == Filtra per paese:
 
-Player options
-== Opzioni giocatore
-
 Players
 == Giocatori
 
@@ -708,9 +705,6 @@ Kill
 
 Pause
 == Pausa
-
-Reload
-== Ricarica
 
 Deactivate
 == Disattiva
@@ -1273,9 +1267,6 @@ Hook Collisions
 Show health, shields and ammo
 == Mostra vita, scudi e munizioni
 
-Show client IDs in scoreboard
-== Mostra gli ID clienti nella scoreboard
-
 Show DDRace HUD
 == Mostra l'HUD DDRace
 
@@ -1411,7 +1402,16 @@ Could not initialize the given graphics backend, reverting to the default backen
 Could not initialize the given graphics backend, this is probably because you didn't install the driver of the integrated graphics card.
 == 
 
+Could not resolve connect address '%s'. See local console for details.
+== 
+
+Connect address error
+== 
+
 Could not save downloaded map. Try manually deleting this file: %s
+== 
+
+Could not connect dummy
 == 
 
 Error playing demo
@@ -1680,6 +1680,12 @@ Unable to delete the demo '%s'
 Unable to delete the folder '%s'. Make sure it's empty first.
 == 
 
+Dummy is not allowed on this server
+== 
+
+Please wait…
+== 
+
 Loading…
 == 
 
@@ -1783,6 +1789,9 @@ Show local time always
 DDRace HUD
 == 
 
+Show client IDs (scoreboard, chat, spectator)
+== 
+
 Always show chat
 == 
 
@@ -1871,6 +1880,39 @@ Regular background color
 == 
 
 Entities background color
+== 
+
+Normal:
+== 
+
+Team:
+== 
+
+Dummy settings
+== 
+
+Toggle to edit your dummy settings
+== 
+
+Randomize
+== 
+
+Are you sure that you want to delete '%s'?
+== 
+
+Delete skin
+== 
+
+Basic
+== 
+
+Custom
+== 
+
+Unable to delete skin
+== 
+
+Customize
 == 
 
 Extras

--- a/data/languages/japanese.txt
+++ b/data/languages/japanese.txt
@@ -274,9 +274,6 @@ Player
 Player country:
 == 所在地:
 
-Player options
-== プレイヤー設定
-
 Players
 == プレーヤー
 
@@ -683,9 +680,6 @@ Kill
 
 Pause
 == 観察
-
-Reload
-== 更新
 
 Deactivate
 == 無効にする
@@ -1135,7 +1129,16 @@ Could not initialize the given graphics backend, reverting to the default backen
 Could not initialize the given graphics backend, this is probably because you didn't install the driver of the integrated graphics card.
 == 
 
+Could not resolve connect address '%s'. See local console for details.
+== 
+
+Connect address error
+== 
+
 Could not save downloaded map. Try manually deleting this file: %s
+== 
+
+Could not connect dummy
 == 
 
 Error playing demo
@@ -1512,6 +1515,12 @@ Unable to delete the demo '%s'
 Unable to delete the folder '%s'. Make sure it's empty first.
 == 
 
+Dummy is not allowed on this server
+== 
+
+Please wait…
+== 
+
 Loading…
 == 
 
@@ -1664,7 +1673,7 @@ Show local time always
 DDRace HUD
 == 
 
-Show client IDs in scoreboard
+Show client IDs (scoreboard, chat, spectator)
 == 
 
 Show DDRace HUD
@@ -1827,6 +1836,39 @@ Chat command (e.g. showall 1)
 == 
 
 Unregister protocol and file extensions
+== 
+
+Normal:
+== 
+
+Team:
+== 
+
+Dummy settings
+== 
+
+Toggle to edit your dummy settings
+== 
+
+Randomize
+== 
+
+Are you sure that you want to delete '%s'?
+== 
+
+Delete skin
+== 
+
+Basic
+== 
+
+Custom
+== 
+
+Unable to delete skin
+== 
+
+Customize
 == 
 
 Extras

--- a/data/languages/korean.txt
+++ b/data/languages/korean.txt
@@ -280,9 +280,6 @@ Pistol
 Player
 == 플레이어
 
-Player options
-== 플레이어 옵션
-
 Players
 == 플레이어
 
@@ -534,9 +531,6 @@ Successfully saved the replay!
 Replay feature is disabled!
 == 리플레이 기능을 비활성화했습니다!
 
-The width of texture %s is not divisible by %d, or the height is not divisible by %d, which might cause visual bugs.
-== 
-
 Warning
 == 주의
 
@@ -701,9 +695,6 @@ Pause
 
 Time
 == 시간
-
-Reload
-== 새로고침
 
 Deactivate
 == 비활성화
@@ -1359,9 +1350,6 @@ Show health, shields and ammo
 DDRace HUD
 == DDRace HUD
 
-Show client IDs in scoreboard
-== 점수판에 클라이언트 ID 표시
-
 Show DDRace HUD
 == DDRace HUD 표시
 
@@ -1563,6 +1551,15 @@ Copy info
 Create a random skin
 == 무작위 스킨 생성
 
+Could not resolve connect address '%s'. See local console for details.
+== 
+
+Connect address error
+== 
+
+Could not connect dummy
+== 
+
 Error playing demo
 == 
 
@@ -1573,6 +1570,9 @@ Saving settings to '%s' failed
 == 
 
 Error saving settings
+== 
+
+The width of texture %s is not divisible by %d, or the height is not divisible by %d, which might cause visual bugs.
 == 
 
 Loading demo file from storage
@@ -1784,6 +1784,12 @@ Delete folder
 Unable to delete the folder '%s'. Make sure it's empty first.
 == 
 
+Dummy is not allowed on this server
+== 
+
+Please wait…
+== 
+
 Loading…
 == 
 
@@ -1812,6 +1818,9 @@ Info Messages
 == 
 
 Show local time always
+== 
+
+Show client IDs (scoreboard, chat, spectator)
 == 
 
 Always show chat
@@ -1863,6 +1872,39 @@ Regular background color
 == 
 
 Entities background color
+== 
+
+Normal:
+== 
+
+Team:
+== 
+
+Dummy settings
+== 
+
+Toggle to edit your dummy settings
+== 
+
+Randomize
+== 
+
+Are you sure that you want to delete '%s'?
+== 
+
+Delete skin
+== 
+
+Basic
+== 
+
+Custom
+== 
+
+Unable to delete skin
+== 
+
+Customize
 == 
 
 Round %d/%d

--- a/data/languages/kyrgyz.txt
+++ b/data/languages/kyrgyz.txt
@@ -309,9 +309,6 @@ Player
 Player country:
 == Өлкөсү:
 
-Player options
-== Оюнчу опциялары
-
 Players
 == Оюнчулар
 
@@ -546,7 +543,16 @@ Could not initialize the given graphics backend, reverting to the default backen
 Could not initialize the given graphics backend, this is probably because you didn't install the driver of the integrated graphics card.
 == 
 
+Could not resolve connect address '%s'. See local console for details.
+== 
+
+Connect address error
+== 
+
 Could not save downloaded map. Try manually deleting this file: %s
+== 
+
+Could not connect dummy
 == 
 
 Error playing demo
@@ -1091,6 +1097,12 @@ Are you sure that you want to disconnect?
 Connect Dummy
 == 
 
+Dummy is not allowed on this server
+== 
+
+Please wait…
+== 
+
 Connecting dummy
 == 
 
@@ -1435,7 +1447,7 @@ Show votes window after voting
 DDRace HUD
 == 
 
-Show client IDs in scoreboard
+Show client IDs (scoreboard, chat, spectator)
 == 
 
 Show DDRace HUD
@@ -1684,9 +1696,6 @@ Regular background color
 Entities background color
 == 
 
-Reload
-== 
-
 Use current map as background
 == 
 
@@ -1721,6 +1730,39 @@ No updates available
 == 
 
 Check now
+== 
+
+Normal:
+== 
+
+Team:
+== 
+
+Dummy settings
+== 
+
+Toggle to edit your dummy settings
+== 
+
+Randomize
+== 
+
+Are you sure that you want to delete '%s'?
+== 
+
+Delete skin
+== 
+
+Basic
+== 
+
+Custom
+== 
+
+Unable to delete skin
+== 
+
+Customize
 == 
 
 Emoticons

--- a/data/languages/norwegian.txt
+++ b/data/languages/norwegian.txt
@@ -279,9 +279,6 @@ Player
 Player country:
 == Spillerland:
 
-Player options
-== Spillerinstillinger
-
 Players
 == Spillere
 
@@ -652,9 +649,6 @@ Connecting dummy
 
 Connect Dummy
 == Koble til dummy
-
-Reload
-== Last på nytt
 
 Deactivate
 == Deaktiver
@@ -1101,7 +1095,16 @@ Could not initialize the given graphics backend, reverting to the default backen
 Could not initialize the given graphics backend, this is probably because you didn't install the driver of the integrated graphics card.
 == 
 
+Could not resolve connect address '%s'. See local console for details.
+== 
+
+Connect address error
+== 
+
 Could not save downloaded map. Try manually deleting this file: %s
+== 
+
+Could not connect dummy
 == 
 
 Error playing demo
@@ -1487,6 +1490,12 @@ Unable to delete the demo '%s'
 Unable to delete the folder '%s'. Make sure it's empty first.
 == 
 
+Dummy is not allowed on this server
+== 
+
+Please wait…
+== 
+
 Loading…
 == 
 
@@ -1654,7 +1663,7 @@ Show local time always
 DDRace HUD
 == 
 
-Show client IDs in scoreboard
+Show client IDs (scoreboard, chat, spectator)
 == 
 
 Show DDRace HUD
@@ -1823,6 +1832,39 @@ Chat command (e.g. showall 1)
 == 
 
 Unregister protocol and file extensions
+== 
+
+Normal:
+== 
+
+Team:
+== 
+
+Dummy settings
+== 
+
+Toggle to edit your dummy settings
+== 
+
+Randomize
+== 
+
+Are you sure that you want to delete '%s'?
+== 
+
+Delete skin
+== 
+
+Basic
+== 
+
+Custom
+== 
+
+Unable to delete skin
+== 
+
+Customize
 == 
 
 Extras

--- a/data/languages/persian.txt
+++ b/data/languages/persian.txt
@@ -519,9 +519,6 @@ Kill
 Pause
 == ﺚﮑﻣ ﺖﻟﺎﺣ
 
-Player options
-== ﻦﮑﯾﺯﺎﺑ ﺕﺎﻤﯿﻈﻨﺗ
-
 Player
 == ﻦﮑﯾﺯﺎﺑ
 
@@ -542,9 +539,6 @@ Vote command:
 
 Time
 == ﻥﺎﻣﺯ
-
-Reload
-== ﻩﺭﺎﺑﻭﺩ ﯼﺮﯿﮔﺭﺎﺑ
 
 Deactivate
 == ﻥﺩﺮﮐ ﻝﺎﻌﻓﺮﯿﻏ
@@ -1225,9 +1219,6 @@ Show votes window after voting
 DDRace HUD
 == DDRace HUD
 
-Show client IDs in scoreboard
-== ﺯﺎﯿﺘﻣﺍ ﯼﻮﻠﺑﺎﺗ ﺭﺩ ﺖﻨﯾﻼﮐ ID ﺶﯾﺎﻤﻧ
-
 Show DDRace HUD
 == DDRace HUD ﺶﯾﺎﻤﻧ
 
@@ -1518,7 +1509,16 @@ Could not initialize the given graphics backend, reverting to the default backen
 Could not initialize the given graphics backend, this is probably because you didn't install the driver of the integrated graphics card.
 == 
 
+Could not resolve connect address '%s'. See local console for details.
+== 
+
+Connect address error
+== 
+
 Could not save downloaded map. Try manually deleting this file: %s
+== 
+
+Could not connect dummy
 == 
 
 Error playing demo
@@ -1754,6 +1754,12 @@ Delete folder
 Unable to delete the folder '%s'. Make sure it's empty first.
 == 
 
+Dummy is not allowed on this server
+== 
+
+Please wait…
+== 
+
 Loading…
 == 
 
@@ -1785,6 +1791,9 @@ Info Messages
 == 
 
 Show local time always
+== 
+
+Show client IDs (scoreboard, chat, spectator)
 == 
 
 Always show chat
@@ -1839,6 +1848,39 @@ Entities background color
 == 
 
 Unregister protocol and file extensions
+== 
+
+Normal:
+== 
+
+Team:
+== 
+
+Dummy settings
+== 
+
+Toggle to edit your dummy settings
+== 
+
+Randomize
+== 
+
+Are you sure that you want to delete '%s'?
+== 
+
+Delete skin
+== 
+
+Basic
+== 
+
+Custom
+== 
+
+Unable to delete skin
+== 
+
+Customize
 == 
 
 Round %d/%d

--- a/data/languages/polish.txt
+++ b/data/languages/polish.txt
@@ -282,9 +282,6 @@ Player
 Player country:
 == Narodowość:
 
-Player options
-== Opcje gracza
-
 Players
 == Gracze
 
@@ -682,9 +679,6 @@ Enable replays
 
 Automatically create statboard csv
 == Automatycznie stwórz plik csv z tabelą wyników
-
-Reload
-== Przeładuj
 
 Replay feature is disabled!
 == Funkcja odtwarzania jest wyłączona!
@@ -1639,9 +1633,6 @@ Show health, shields and ammo
 Show local time always
 == Pokazuj czas lokalny
 
-Show client IDs in scoreboard
-== Pokazuj ID klienta w tabeli wyników
-
 Show DDRace HUD
 == Pokazuj HUD DDRace
 
@@ -1808,6 +1799,15 @@ Submitting the render commands failed. Try to update your GPU drivers.
 Failed to swap framebuffers. Try to update your GPU drivers.
 == 
 
+Could not resolve connect address '%s'. See local console for details.
+== 
+
+Connect address error
+== 
+
+Could not connect dummy
+== 
+
 Match %d of %d
 == 
 
@@ -1840,6 +1840,12 @@ Folder Link
 map not included
 == 
 
+Dummy is not allowed on this server
+== 
+
+Please wait…
+== 
+
 Aim bind
 == 
 
@@ -1855,7 +1861,43 @@ Tee
 DDRace HUD
 == 
 
+Show client IDs (scoreboard, chat, spectator)
+== 
+
 Show only chat messages from team members
+== 
+
+Normal:
+== 
+
+Team:
+== 
+
+Dummy settings
+== 
+
+Toggle to edit your dummy settings
+== 
+
+Randomize
+== 
+
+Are you sure that you want to delete '%s'?
+== 
+
+Delete skin
+== 
+
+Basic
+== 
+
+Custom
+== 
+
+Unable to delete skin
+== 
+
+Customize
 == 
 
 Round %d/%d

--- a/data/languages/portuguese.txt
+++ b/data/languages/portuguese.txt
@@ -290,9 +290,6 @@ Player
 Player country:
 == País do jogador
 
-Player options
-== Opções do jogador
-
 Players
 == Jogadores
 
@@ -773,9 +770,6 @@ Connect Dummy
 Time
 == Tempo
 
-Reload
-== Recarregar
-
 Deactivate
 == Desativar
 
@@ -890,7 +884,16 @@ Could not initialize the given graphics backend, reverting to the default backen
 Could not initialize the given graphics backend, this is probably because you didn't install the driver of the integrated graphics card.
 == 
 
+Could not resolve connect address '%s'. See local console for details.
+== 
+
+Connect address error
+== 
+
 Could not save downloaded map. Try manually deleting this file: %s
+== 
+
+Could not connect dummy
 == 
 
 Error playing demo
@@ -1330,6 +1333,12 @@ Unable to delete the demo '%s'
 Unable to delete the folder '%s'. Make sure it's empty first.
 == 
 
+Dummy is not allowed on this server
+== 
+
+Please wait…
+== 
+
 Kill
 == 
 
@@ -1563,7 +1572,7 @@ Show local time always
 DDRace HUD
 == 
 
-Show client IDs in scoreboard
+Show client IDs (scoreboard, chat, spectator)
 == 
 
 Show DDRace HUD
@@ -1765,6 +1774,39 @@ Chat command (e.g. showall 1)
 == 
 
 Unregister protocol and file extensions
+== 
+
+Normal:
+== 
+
+Team:
+== 
+
+Dummy settings
+== 
+
+Toggle to edit your dummy settings
+== 
+
+Randomize
+== 
+
+Are you sure that you want to delete '%s'?
+== 
+
+Delete skin
+== 
+
+Basic
+== 
+
+Custom
+== 
+
+Unable to delete skin
+== 
+
+Customize
 == 
 
 Emoticons

--- a/data/languages/romanian.txt
+++ b/data/languages/romanian.txt
@@ -286,9 +286,6 @@ Player
 Player country:
 == Țara jucătorului:
 
-Player options
-== Opțiuni jucător
-
 Players
 == Jucători
 
@@ -561,7 +558,16 @@ Could not initialize the given graphics backend, reverting to the default backen
 Could not initialize the given graphics backend, this is probably because you didn't install the driver of the integrated graphics card.
 == 
 
+Could not resolve connect address '%s'. See local console for details.
+== 
+
+Connect address error
+== 
+
 Could not save downloaded map. Try manually deleting this file: %s
+== 
+
+Could not connect dummy
 == 
 
 Error playing demo
@@ -1106,6 +1112,12 @@ Are you sure that you want to disconnect?
 Connect Dummy
 == 
 
+Dummy is not allowed on this server
+== 
+
+Please wait…
+== 
+
 Connecting dummy
 == 
 
@@ -1450,7 +1462,7 @@ Show votes window after voting
 DDRace HUD
 == 
 
-Show client IDs in scoreboard
+Show client IDs (scoreboard, chat, spectator)
 == 
 
 Show DDRace HUD
@@ -1699,9 +1711,6 @@ Regular background color
 Entities background color
 == 
 
-Reload
-== 
-
 Use current map as background
 == 
 
@@ -1736,6 +1745,39 @@ No updates available
 == 
 
 Check now
+== 
+
+Normal:
+== 
+
+Team:
+== 
+
+Dummy settings
+== 
+
+Toggle to edit your dummy settings
+== 
+
+Randomize
+== 
+
+Are you sure that you want to delete '%s'?
+== 
+
+Delete skin
+== 
+
+Basic
+== 
+
+Custom
+== 
+
+Unable to delete skin
+== 
+
+Customize
 == 
 
 Emoticons

--- a/data/languages/russian.txt
+++ b/data/languages/russian.txt
@@ -294,9 +294,6 @@ Player
 Player country:
 == Страна игрока:
 
-Player options
-== Опции игрока
-
 Players
 == Игроки
 
@@ -749,9 +746,6 @@ Fetch Info
 
 Connect Dummy
 == Подключить дамми
-
-Reload
-== Перезагрузить
 
 Deactivate
 == Выключить
@@ -1362,9 +1356,6 @@ Show health, shields and ammo
 DDRace HUD
 == DDRace HUD
 
-Show client IDs in scoreboard
-== Показывать ид. игроков
-
 Show DDRace HUD
 == Показывать DDRace HUD
 
@@ -1887,3 +1878,54 @@ Team %d (%d/%d)
 
 https://wiki.ddnet.org/wiki/Mapping
 == https://wiki.ddnet.org/wiki/Mapping/ru
+
+Could not resolve connect address '%s'. See local console for details.
+== 
+
+Connect address error
+== 
+
+Could not connect dummy
+== 
+
+Dummy is not allowed on this server
+== 
+
+Please wait…
+== 
+
+Show client IDs (scoreboard, chat, spectator)
+== 
+
+Normal:
+== 
+
+Team:
+== 
+
+Dummy settings
+== 
+
+Toggle to edit your dummy settings
+== 
+
+Randomize
+== 
+
+Are you sure that you want to delete '%s'?
+== 
+
+Delete skin
+== 
+
+Basic
+== 
+
+Custom
+== 
+
+Unable to delete skin
+== 
+
+Customize
+== 

--- a/data/languages/serbian.txt
+++ b/data/languages/serbian.txt
@@ -281,9 +281,6 @@ Player
 Player country:
 == Država igrača
 
-Player options
-== Podešavanja igrača
-
 Players
 == Igrači
 
@@ -684,9 +681,6 @@ Kill
 
 Pause
 == Pauza
-
-Reload
-== Osveži
 
 Deactivate
 == Deaktiviraj
@@ -1264,9 +1258,6 @@ Show health, shields and ammo
 DDRace HUD
 == DDRace Prikaz
 
-Show client IDs in scoreboard
-== Prikaži identitete na tabli rezultata
-
 Show DDRace HUD
 == Prikaži DDRace Prikaz
 
@@ -1649,6 +1640,15 @@ Could not initialize the given graphics backend, reverting to the default backen
 Could not initialize the given graphics backend, this is probably because you didn't install the driver of the integrated graphics card.
 == 
 
+Could not resolve connect address '%s'. See local console for details.
+== 
+
+Connect address error
+== 
+
+Could not connect dummy
+== 
+
 Error playing demo
 == 
 
@@ -1785,6 +1785,12 @@ Netversion
 map not included
 == 
 
+Dummy is not allowed on this server
+== 
+
+Please wait…
+== 
+
 Loading…
 == 
 
@@ -1807,6 +1813,9 @@ Info Messages
 == 
 
 Show local time always
+== 
+
+Show client IDs (scoreboard, chat, spectator)
 == 
 
 Always show chat
@@ -1858,6 +1867,39 @@ Regular background color
 == 
 
 Entities background color
+== 
+
+Normal:
+== 
+
+Team:
+== 
+
+Dummy settings
+== 
+
+Toggle to edit your dummy settings
+== 
+
+Randomize
+== 
+
+Are you sure that you want to delete '%s'?
+== 
+
+Delete skin
+== 
+
+Basic
+== 
+
+Custom
+== 
+
+Unable to delete skin
+== 
+
+Customize
 == 
 
 Round %d/%d

--- a/data/languages/serbian_cyrillic.txt
+++ b/data/languages/serbian_cyrillic.txt
@@ -277,9 +277,6 @@ Player
 Player country:
 == Држава играча
 
-Player options
-== Подешавања играча
-
 Players
 == Играчи
 
@@ -683,9 +680,6 @@ Kill
 
 Pause
 == Пауза
-
-Reload
-== Освежи
 
 Deactivate
 == Деактивирај
@@ -1263,9 +1257,6 @@ Show health, shields and ammo
 DDRace HUD
 == DDRace Приказ
 
-Show client IDs in scoreboard
-== Прикажи идентитете на табли резултата
-
 Show DDRace HUD
 == Прикажи DDRace Приказ
 
@@ -1422,7 +1413,16 @@ Could not initialize the given graphics backend, reverting to the default backen
 Could not initialize the given graphics backend, this is probably because you didn't install the driver of the integrated graphics card.
 == 
 
+Could not resolve connect address '%s'. See local console for details.
+== 
+
+Connect address error
+== 
+
 Could not save downloaded map. Try manually deleting this file: %s
+== 
+
+Could not connect dummy
 == 
 
 Error playing demo
@@ -1703,6 +1703,12 @@ Unable to delete the demo '%s'
 Unable to delete the folder '%s'. Make sure it's empty first.
 == 
 
+Dummy is not allowed on this server
+== 
+
+Please wait…
+== 
+
 Loading…
 == 
 
@@ -1764,6 +1770,9 @@ Info Messages
 == 
 
 Show local time always
+== 
+
+Show client IDs (scoreboard, chat, spectator)
 == 
 
 Always show chat
@@ -1848,6 +1857,39 @@ Entities background color
 == 
 
 Unregister protocol and file extensions
+== 
+
+Normal:
+== 
+
+Team:
+== 
+
+Dummy settings
+== 
+
+Toggle to edit your dummy settings
+== 
+
+Randomize
+== 
+
+Are you sure that you want to delete '%s'?
+== 
+
+Delete skin
+== 
+
+Basic
+== 
+
+Custom
+== 
+
+Unable to delete skin
+== 
+
+Customize
 == 
 
 Open the directory to add custom assets

--- a/data/languages/simplified_chinese.txt
+++ b/data/languages/simplified_chinese.txt
@@ -342,9 +342,6 @@ HUD
 Player country:
 == 玩家国家 / 地区：
 
-Player options
-== 玩家选项
-
 Players
 == 玩家
 
@@ -830,9 +827,6 @@ Show DDNet map finishes in server browser
 
 transmits your player name to info.ddnet.org
 == 将会发送你的玩家昵称到 info.ddnet.org
-
-Reload
-== 刷新
 
 Enable replays
 == 启用短时回放
@@ -1389,9 +1383,6 @@ Show health, shields and ammo
 DDRace HUD
 == DDRace HUD
 
-Show client IDs in scoreboard
-== 显示客户端 IDs （计分板中）
-
 Show DDRace HUD
 == 显示 DDRace HUD
 
@@ -1914,3 +1905,54 @@ Team %d (%d/%d)
 
 https://wiki.ddnet.org/wiki/Mapping
 == https://wiki.ddnet.org/index.php?title=Mapping/zh&variant=zh-hans
+
+Could not resolve connect address '%s'. See local console for details.
+== 
+
+Connect address error
+== 
+
+Could not connect dummy
+== 
+
+Dummy is not allowed on this server
+== 
+
+Please wait…
+== 
+
+Show client IDs (scoreboard, chat, spectator)
+== 
+
+Normal:
+== 
+
+Team:
+== 
+
+Dummy settings
+== 
+
+Toggle to edit your dummy settings
+== 
+
+Randomize
+== 
+
+Are you sure that you want to delete '%s'?
+== 
+
+Delete skin
+== 
+
+Basic
+== 
+
+Custom
+== 
+
+Unable to delete skin
+== 
+
+Customize
+== 

--- a/data/languages/slovak.txt
+++ b/data/languages/slovak.txt
@@ -278,9 +278,6 @@ Player
 Player country:
 == Filter krajín:
 
-Player options
-== Nastavenia hráča
-
 Players
 == Hráči
 
@@ -1420,9 +1417,6 @@ Show votes window after voting
 DDRace HUD
 == DDRace HUD
 
-Show client IDs in scoreboard
-== Zobraziť ID klientov vo výsledkovej tabuľke
-
 Show DDRace HUD
 == Zobraziť DDRace HUD
 
@@ -1648,9 +1642,6 @@ Regular background color
 Entities background color
 == Farba pozadia entít
 
-Reload
-== Znovu načítať
-
 Use current map as background
 == Použiť aktuálnu mapu ako pozadie
 
@@ -1850,11 +1841,62 @@ Tee
 Show only chat messages from team members
 == Zobraziť iba správy od členov tímu
 
+Could not resolve connect address '%s'. See local console for details.
+== 
+
+Connect address error
+== 
+
+Could not connect dummy
+== 
+
 [Spectating]
 Following %s
 == 
 
 Example of usage
+== 
+
+Dummy is not allowed on this server
+== 
+
+Please wait…
+== 
+
+Show client IDs (scoreboard, chat, spectator)
+== 
+
+Normal:
+== 
+
+Team:
+== 
+
+Dummy settings
+== 
+
+Toggle to edit your dummy settings
+== 
+
+Randomize
+== 
+
+Are you sure that you want to delete '%s'?
+== 
+
+Delete skin
+== 
+
+Basic
+== 
+
+Custom
+== 
+
+Unable to delete skin
+== 
+
+Customize
 == 
 
 Round %d/%d

--- a/data/languages/spanish.txt
+++ b/data/languages/spanish.txt
@@ -299,9 +299,6 @@ Player
 Player country:
 == País del jugador
 
-Player options
-== Opciones de jugador
-
 Players
 == Jugadores
 
@@ -672,9 +669,6 @@ Connecting dummy
 
 Connect Dummy
 == Conectar Dummy
-
-Reload
-== Recargar
 
 Deactivate
 == Desactivar
@@ -1390,9 +1384,6 @@ Show health, shields and ammo
 DDRace HUD
 == HUD DDRace
 
-Show client IDs in scoreboard
-== Mostrar IDs de cliente en la tabla de puntuación
-
 Show DDRace HUD
 == Mostrar el HUD DDRace
 
@@ -1891,3 +1882,54 @@ Team %d (%d/%d)
 
 https://wiki.ddnet.org/wiki/Mapping
 == https://wiki.ddnet.org/wiki/Mapping/es
+
+Could not resolve connect address '%s'. See local console for details.
+== 
+
+Connect address error
+== 
+
+Could not connect dummy
+== 
+
+Dummy is not allowed on this server
+== 
+
+Please wait…
+== 
+
+Show client IDs (scoreboard, chat, spectator)
+== 
+
+Normal:
+== 
+
+Team:
+== 
+
+Dummy settings
+== 
+
+Toggle to edit your dummy settings
+== 
+
+Randomize
+== 
+
+Are you sure that you want to delete '%s'?
+== 
+
+Delete skin
+== 
+
+Basic
+== 
+
+Custom
+== 
+
+Unable to delete skin
+== 
+
+Customize
+== 

--- a/data/languages/swedish.txt
+++ b/data/languages/swedish.txt
@@ -282,9 +282,6 @@ Player
 Player country:
 == Land
 
-Player options
-== Spelaralternativ
-
 Players
 == Spelare
 
@@ -900,9 +897,6 @@ Show HUD
 Pause
 == Pausa
 
-Reload
-== Ladda om
-
 Spree
 == Spree
 
@@ -1516,9 +1510,6 @@ Show health, shields and ammo
 DDRace HUD
 == DDRace HUD
 
-Show client IDs in scoreboard
-== Visa klient ID i poänglista
-
 Show DDRace HUD
 == Visa DDRace HUD
 
@@ -1875,3 +1866,54 @@ Team %d (%d/%d)
 
 https://wiki.ddnet.org/wiki/Mapping
 == https://wiki.ddnet.org/wiki/Mapping
+
+Could not resolve connect address '%s'. See local console for details.
+== 
+
+Connect address error
+== 
+
+Could not connect dummy
+== 
+
+Dummy is not allowed on this server
+== 
+
+Please wait…
+== 
+
+Show client IDs (scoreboard, chat, spectator)
+== 
+
+Normal:
+== 
+
+Team:
+== 
+
+Dummy settings
+== 
+
+Toggle to edit your dummy settings
+== 
+
+Randomize
+== 
+
+Are you sure that you want to delete '%s'?
+== 
+
+Delete skin
+== 
+
+Basic
+== 
+
+Custom
+== 
+
+Unable to delete skin
+== 
+
+Customize
+== 

--- a/data/languages/traditional_chinese.txt
+++ b/data/languages/traditional_chinese.txt
@@ -331,9 +331,6 @@ HUD
 Player country:
 == 玩家國家/地區：
 
-Player options
-== 玩家選項
-
 Players
 == 玩家
 
@@ -819,9 +816,6 @@ Show DDNet map finishes in server browser
 
 transmits your player name to info.ddnet.org
 == 將會發送你的玩家名稱到 info.ddnet.org
-
-Reload
-== 重新整理
 
 Enable replays
 == 啟用短時回放
@@ -1378,9 +1372,6 @@ Show health, shields and ammo
 DDRace HUD
 == DDRace HUD
 
-Show client IDs in scoreboard
-== 顯示客戶端 IDs (計分板中)
-
 Show DDRace HUD
 == 顯示 DDRace HUD
 
@@ -1903,3 +1894,54 @@ Team %d (%d/%d)
 
 https://wiki.ddnet.org/wiki/Mapping
 == https://wiki.ddnet.org/index.php?title=Mapping/zh&variant=zh-hant
+
+Could not resolve connect address '%s'. See local console for details.
+== 
+
+Connect address error
+== 
+
+Could not connect dummy
+== 
+
+Dummy is not allowed on this server
+== 
+
+Please wait…
+== 
+
+Show client IDs (scoreboard, chat, spectator)
+== 
+
+Normal:
+== 
+
+Team:
+== 
+
+Dummy settings
+== 
+
+Toggle to edit your dummy settings
+== 
+
+Randomize
+== 
+
+Are you sure that you want to delete '%s'?
+== 
+
+Delete skin
+== 
+
+Basic
+== 
+
+Custom
+== 
+
+Unable to delete skin
+== 
+
+Customize
+== 

--- a/data/languages/turkish.txt
+++ b/data/languages/turkish.txt
@@ -287,9 +287,6 @@ Play background music
 Player
 == Oyuncu
 
-Player options
-== Oyuncu ayarları
-
 Players
 == Oyuncular
 
@@ -664,9 +661,6 @@ Connecting dummy
 
 Connect Dummy
 == Dummy Katıl
-
-Reload
-== Yenile
 
 Deactivate
 == Devre dışı bırak
@@ -1463,9 +1457,6 @@ Show health, shields and ammo
 DDRace HUD
 == DDRace arayüzü
 
-Show client IDs in scoreboard
-== Skor tablosunda ki istemci ID'lerini göster
-
 Show DDRace HUD
 == DDRace arayüzünü göster
 
@@ -1883,3 +1874,54 @@ Team %d (%d/%d)
 
 https://wiki.ddnet.org/wiki/Mapping
 == https://wiki.ddnet.org/wiki/Mapping/tr
+
+Could not resolve connect address '%s'. See local console for details.
+== 
+
+Connect address error
+== 
+
+Could not connect dummy
+== 
+
+Dummy is not allowed on this server
+== 
+
+Please wait…
+== 
+
+Show client IDs (scoreboard, chat, spectator)
+== 
+
+Normal:
+== 
+
+Team:
+== 
+
+Dummy settings
+== 
+
+Toggle to edit your dummy settings
+== 
+
+Randomize
+== 
+
+Are you sure that you want to delete '%s'?
+== 
+
+Delete skin
+== 
+
+Basic
+== 
+
+Custom
+== 
+
+Unable to delete skin
+== 
+
+Customize
+== 

--- a/data/languages/ukrainian.txt
+++ b/data/languages/ukrainian.txt
@@ -1176,9 +1176,6 @@ Player country:
 Player info change cooldown
 == Затримка зміни інформації про гравця
 
-Player options
-== Налаштування гравців
-
 Players
 == Гравці
 
@@ -1245,9 +1242,6 @@ Regular background color
 [Ingame controller mode]
 Relative
 == Відносний
-
-Reload
-== Оновити
 
 Remote console
 == Віддалена консоль
@@ -1416,9 +1410,6 @@ Show chat
 
 Show clan above name plates
 == Показувати клан над ніками
-
-Show client IDs in scoreboard
-== Показувати ID клієнта в таблі
 
 Show DDNet map finishes in server browser
 == Показувати пройдені мапи DDNet у браузері серверів
@@ -1871,3 +1862,54 @@ Zoom in
 
 Zoom out
 == Віддалити
+
+Could not resolve connect address '%s'. See local console for details.
+== 
+
+Connect address error
+== 
+
+Could not connect dummy
+== 
+
+Dummy is not allowed on this server
+== 
+
+Please wait…
+== 
+
+Show client IDs (scoreboard, chat, spectator)
+== 
+
+Normal:
+== 
+
+Team:
+== 
+
+Dummy settings
+== 
+
+Toggle to edit your dummy settings
+== 
+
+Randomize
+== 
+
+Are you sure that you want to delete '%s'?
+== 
+
+Delete skin
+== 
+
+Basic
+== 
+
+Custom
+== 
+
+Unable to delete skin
+== 
+
+Customize
+== 

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -76,7 +76,7 @@ void CMenus::RenderGame(CUIRect MainView)
 	if(!Client()->DummyAllowed())
 	{
 		DoButton_Menu(&s_DummyButton, Localize("Connect Dummy"), 1, &Button);
-		GameClient()->m_Tooltips.DoToolTip(&s_DummyButton, &Button, Localize("Dummy is not allowed on this server."));
+		GameClient()->m_Tooltips.DoToolTip(&s_DummyButton, &Button, Localize("Dummy is not allowed on this server"));
 	}
 	else if(Client()->DummyConnectingDelayed())
 	{

--- a/src/game/client/components/menus_settings7.cpp
+++ b/src/game/client/components/menus_settings7.cpp
@@ -251,7 +251,7 @@ void CMenus::RenderSettingsTee7(CUIRect MainView)
 		if(DoButton_Menu(&s_CustomSkinDeleteButton, Localize("Delete"), 0, &ButtonMiddle) || Ui()->ConsumeHotkey(CUi::HOTKEY_DELETE))
 		{
 			char aBuf[128];
-			str_format(aBuf, sizeof(aBuf), Localize("Are you sure that you want to delete the skin '%s'?"), m_pSelectedSkin->m_aName);
+			str_format(aBuf, sizeof(aBuf), Localize("Are you sure that you want to delete '%s'?"), m_pSelectedSkin->m_aName);
 			PopupConfirm(Localize("Delete skin"), aBuf, Localize("Yes"), Localize("No"), &CMenus::PopupConfirmDeleteSkin7);
 		}
 	}
@@ -299,7 +299,7 @@ void CMenus::PopupConfirmDeleteSkin7()
 
 	if(!m_pClient->m_Skins7.RemoveSkin(m_pSelectedSkin))
 	{
-		PopupMessage(Localize("Error"), Localize("Unable to delete the skin"), Localize("Ok"));
+		PopupMessage(Localize("Error"), Localize("Unable to delete skin"), Localize("Ok"));
 		return;
 	}
 	m_pSelectedSkin = nullptr;

--- a/src/game/client/components/skins7.cpp
+++ b/src/game/client/components/skins7.cpp
@@ -18,7 +18,7 @@
 #include "menus.h"
 #include "skins7.h"
 
-const char *const CSkins7::ms_apSkinPartNames[protocol7::NUM_SKINPARTS] = {"body", "marking", "decoration", "hands", "feet", "eyes"}; /* Localize("body","skins");Localize("marking","skins");Localize("decoration","skins");Localize("hands","skins");Localize("feet","skins");Localize("eyes","skins"); */
+const char *const CSkins7::ms_apSkinPartNames[protocol7::NUM_SKINPARTS] = {"body", "marking", "decoration", "hands", "feet", "eyes"};
 const char *const CSkins7::ms_apColorComponents[NUM_COLOR_COMPONENTS] = {"hue", "sat", "lgt", "alp"};
 
 char *CSkins7::ms_apSkinVariables[NUM_DUMMIES][protocol7::NUM_SKINPARTS] = {{0}};

--- a/src/game/client/sixup_translate_game.cpp
+++ b/src/game/client/sixup_translate_game.cpp
@@ -49,10 +49,10 @@ struct CGameMsg7
 };
 
 static CGameMsg7 gs_GameMsgList7[protocol7::NUM_GAMEMSGS] = {
-	{/*GAMEMSG_TEAM_SWAP*/ DO_CHAT, PARA_NONE, "Teams were swapped"}, // Localize("Teams were swapped")
+	{/*GAMEMSG_TEAM_SWAP*/ DO_CHAT, PARA_NONE, "Teams were swapped"},
 	{/*GAMEMSG_SPEC_INVALIDID*/ DO_CHAT, PARA_NONE, "Invalid spectator id used"}, //!
-	{/*GAMEMSG_TEAM_SHUFFLE*/ DO_CHAT, PARA_NONE, "Teams were shuffled"}, // Localize("Teams were shuffled")
-	{/*GAMEMSG_TEAM_BALANCE*/ DO_CHAT, PARA_NONE, "Teams have been balanced"}, // Localize("Teams have been balanced")
+	{/*GAMEMSG_TEAM_SHUFFLE*/ DO_CHAT, PARA_NONE, "Teams were shuffled"},
+	{/*GAMEMSG_TEAM_BALANCE*/ DO_CHAT, PARA_NONE, "Teams have been balanced"},
 	{/*GAMEMSG_CTF_DROP*/ DO_SPECIAL, PARA_NONE, ""}, // special - play ctf drop sound
 	{/*GAMEMSG_CTF_RETURN*/ DO_SPECIAL, PARA_NONE, ""}, // special - play ctf return sound
 
@@ -70,10 +70,10 @@ void CGameClient::DoTeamChangeMessage7(const char *pName, int ClientId, int Team
 	char aBuf[128];
 	switch(GetStrTeam7(Team, m_pClient->m_TranslationContext.m_GameFlags & protocol7::GAMEFLAG_TEAMS))
 	{
-	case STR_TEAM_GAME: str_format(aBuf, sizeof(aBuf), Localize("'%s' %sjoined the game"), pName, pPrefix); break;
-	case STR_TEAM_RED: str_format(aBuf, sizeof(aBuf), Localize("'%s' %sjoined the red team"), pName, pPrefix); break;
-	case STR_TEAM_BLUE: str_format(aBuf, sizeof(aBuf), Localize("'%s' %sjoined the blue team"), pName, pPrefix); break;
-	case STR_TEAM_SPECTATORS: str_format(aBuf, sizeof(aBuf), Localize("'%s' %sjoined the spectators"), pName, pPrefix); break;
+	case STR_TEAM_GAME: str_format(aBuf, sizeof(aBuf), "'%s' %sjoined the game", pName, pPrefix); break;
+	case STR_TEAM_RED: str_format(aBuf, sizeof(aBuf), "'%s' %sjoined the red team", pName, pPrefix); break;
+	case STR_TEAM_BLUE: str_format(aBuf, sizeof(aBuf), "'%s' %sjoined the blue team", pName, pPrefix); break;
+	case STR_TEAM_SPECTATORS: str_format(aBuf, sizeof(aBuf), "'%s' %sjoined the spectators", pName, pPrefix); break;
 	}
 	m_Chat.AddLine(-1, 0, aBuf);
 }
@@ -233,9 +233,9 @@ void *CGameClient::TranslateGameMsg(int *pMsgId, CUnpacker *pUnpacker, int Conn)
 		protocol7::CNetMsg_Sv_ServerSettings *pMsg = (protocol7::CNetMsg_Sv_ServerSettings *)pRawMsg;
 
 		if(!m_pClient->m_TranslationContext.m_ServerSettings.m_TeamLock && pMsg->m_TeamLock)
-			m_Chat.AddLine(-1, 0, Localize("Teams were locked"));
+			m_Chat.AddLine(-1, 0, "Teams were locked");
 		else if(m_pClient->m_TranslationContext.m_ServerSettings.m_TeamLock && !pMsg->m_TeamLock)
-			m_Chat.AddLine(-1, 0, Localize("Teams were unlocked"));
+			m_Chat.AddLine(-1, 0, "Teams were unlocked");
 
 		m_pClient->m_TranslationContext.m_ServerSettings.m_KickVote = pMsg->m_KickVote;
 		m_pClient->m_TranslationContext.m_ServerSettings.m_KickMin = pMsg->m_KickMin;
@@ -387,18 +387,18 @@ void *CGameClient::TranslateGameMsg(int *pMsgId, CUnpacker *pUnpacker, int Conn)
 				switch(pMsg7->m_Type)
 				{
 				case protocol7::VOTE_START_OP:
-					str_format(aBuf, sizeof(aBuf), Localize("'%s' called vote to change server option '%s' (%s)"), pName, pMsg7->m_pDescription, pMsg7->m_pReason);
+					str_format(aBuf, sizeof(aBuf), "'%s' called vote to change server option '%s' (%s)", pName, pMsg7->m_pDescription, pMsg7->m_pReason);
 					m_Chat.AddLine(-1, 0, aBuf);
 					break;
 				case protocol7::VOTE_START_KICK:
 				{
-					str_format(aBuf, sizeof(aBuf), Localize("'%s' called for vote to kick '%s' (%s)"), pName, pMsg7->m_pDescription, pMsg7->m_pReason);
+					str_format(aBuf, sizeof(aBuf), "'%s' called for vote to kick '%s' (%s)", pName, pMsg7->m_pDescription, pMsg7->m_pReason);
 					m_Chat.AddLine(-1, 0, aBuf);
 					break;
 				}
 				case protocol7::VOTE_START_SPEC:
 				{
-					str_format(aBuf, sizeof(aBuf), Localize("'%s' called for vote to move '%s' to spectators (%s)"), pName, pMsg7->m_pDescription, pMsg7->m_pReason);
+					str_format(aBuf, sizeof(aBuf), "'%s' called for vote to move '%s' to spectators (%s)", pName, pMsg7->m_pDescription, pMsg7->m_pReason);
 					m_Chat.AddLine(-1, 0, aBuf);
 				}
 				}
@@ -409,24 +409,24 @@ void *CGameClient::TranslateGameMsg(int *pMsgId, CUnpacker *pUnpacker, int Conn)
 			switch(pMsg7->m_Type)
 			{
 			case protocol7::VOTE_START_OP:
-				str_format(aBuf, sizeof(aBuf), Localize("Admin forced server option '%s' (%s)"), pMsg7->m_pDescription, pMsg7->m_pReason);
+				str_format(aBuf, sizeof(aBuf), "Admin forced server option '%s' (%s)", pMsg7->m_pDescription, pMsg7->m_pReason);
 				m_Chat.AddLine(-1, 0, aBuf);
 				break;
 			case protocol7::VOTE_START_SPEC:
-				str_format(aBuf, sizeof(aBuf), Localize("Admin moved '%s' to spectator (%s)"), pMsg7->m_pDescription, pMsg7->m_pReason);
+				str_format(aBuf, sizeof(aBuf), "Admin moved '%s' to spectator (%s)", pMsg7->m_pDescription, pMsg7->m_pReason);
 				m_Chat.AddLine(-1, 0, aBuf);
 				break;
 			case protocol7::VOTE_END_ABORT:
 				m_Voting.OnReset();
-				m_Chat.AddLine(-1, 0, Localize("Vote aborted"));
+				m_Chat.AddLine(-1, 0, "Vote aborted");
 				break;
 			case protocol7::VOTE_END_PASS:
 				m_Voting.OnReset();
-				m_Chat.AddLine(-1, 0, pMsg7->m_ClientId == -1 ? Localize("Admin forced vote yes") : Localize("Vote passed"));
+				m_Chat.AddLine(-1, 0, pMsg7->m_ClientId == -1 ? "Admin forced vote yes" : "Vote passed");
 				break;
 			case protocol7::VOTE_END_FAIL:
 				m_Voting.OnReset();
-				m_Chat.AddLine(-1, 0, pMsg7->m_ClientId == -1 ? Localize("Admin forced vote no") : Localize("Vote failed"));
+				m_Chat.AddLine(-1, 0, pMsg7->m_ClientId == -1 ? "Admin forced vote no" : "Vote failed");
 			}
 		}
 
@@ -630,10 +630,10 @@ void *CGameClient::TranslateGameMsg(int *pMsgId, CUnpacker *pUnpacker, int Conn)
 				const char *pMsg = "";
 				switch(GetStrTeam7(aParaI[0], TeamPlay))
 				{
-				case STR_TEAM_GAME: pMsg = Localize("All players were moved to the game"); break;
-				case STR_TEAM_RED: pMsg = Localize("All players were moved to the red team"); break;
-				case STR_TEAM_BLUE: pMsg = Localize("All players were moved to the blue team"); break;
-				case STR_TEAM_SPECTATORS: pMsg = Localize("All players were moved to the spectators"); break;
+				case STR_TEAM_GAME: pMsg = "All players were moved to the game"; break;
+				case STR_TEAM_RED: pMsg = "All players were moved to the red team"; break;
+				case STR_TEAM_BLUE: pMsg = "All players were moved to the blue team"; break;
+				case STR_TEAM_SPECTATORS: pMsg = "All players were moved to the spectators"; break;
 				}
 				m_Broadcast.DoBroadcast(pMsg); // client side broadcast
 			}
@@ -643,8 +643,8 @@ void *CGameClient::TranslateGameMsg(int *pMsgId, CUnpacker *pUnpacker, int Conn)
 				const char *pMsg = "";
 				switch(GetStrTeam7(aParaI[0], TeamPlay))
 				{
-				case STR_TEAM_RED: pMsg = Localize("You were moved to the red team due to team balancing"); break;
-				case STR_TEAM_BLUE: pMsg = Localize("You were moved to the blue team due to team balancing"); break;
+				case STR_TEAM_RED: pMsg = "You were moved to the red team due to team balancing"; break;
+				case STR_TEAM_BLUE: pMsg = "You were moved to the blue team due to team balancing"; break;
 				}
 				m_Broadcast.DoBroadcast(pMsg); // client side broadcast
 			}
@@ -655,7 +655,7 @@ void *CGameClient::TranslateGameMsg(int *pMsgId, CUnpacker *pUnpacker, int Conn)
 			case protocol7::GAMEMSG_GAME_PAUSED:
 			{
 				int ClientId = clamp(aParaI[0], 0, MAX_CLIENTS - 1);
-				str_format(aBuf, sizeof(aBuf), Localize("'%s' initiated a pause"), m_aClients[ClientId].m_aName);
+				str_format(aBuf, sizeof(aBuf), "'%s' initiated a pause", m_aClients[ClientId].m_aName);
 				SendChat(aBuf);
 			}
 			break;
@@ -669,22 +669,22 @@ void *CGameClient::TranslateGameMsg(int *pMsgId, CUnpacker *pUnpacker, int Conn)
 				{
 					if(aParaI[0])
 					{
-						str_format(aBuf, sizeof(aBuf), Localize("The blue flag was captured by '%s' (%.2f seconds)"), m_aClients[ClientId].m_aName, Time);
+						str_format(aBuf, sizeof(aBuf), "The blue flag was captured by '%s' (%.2f seconds)", m_aClients[ClientId].m_aName, Time);
 					}
 					else
 					{
-						str_format(aBuf, sizeof(aBuf), Localize("The red flag was captured by '%s' (%.2f seconds)"), m_aClients[ClientId].m_aName, Time);
+						str_format(aBuf, sizeof(aBuf), "The red flag was captured by '%s' (%.2f seconds)", m_aClients[ClientId].m_aName, Time);
 					}
 				}
 				else
 				{
 					if(aParaI[0])
 					{
-						str_format(aBuf, sizeof(aBuf), Localize("The blue flag was captured by '%s'"), m_aClients[ClientId].m_aName);
+						str_format(aBuf, sizeof(aBuf), "The blue flag was captured by '%s'", m_aClients[ClientId].m_aName);
 					}
 					else
 					{
-						str_format(aBuf, sizeof(aBuf), Localize("The red flag was captured by '%s'"), m_aClients[ClientId].m_aName);
+						str_format(aBuf, sizeof(aBuf), "The red flag was captured by '%s'", m_aClients[ClientId].m_aName);
 					}
 				}
 				SendChat(aBuf);
@@ -696,7 +696,7 @@ void *CGameClient::TranslateGameMsg(int *pMsgId, CUnpacker *pUnpacker, int Conn)
 		const char *pText = "";
 		if(NumParaI == 0)
 		{
-			pText = Localize(gs_GameMsgList7[GameMsgId].m_pText);
+			pText = gs_GameMsgList7[GameMsgId].m_pText;
 		}
 
 		// handle message


### PR DESCRIPTION
Fix some minor stuff

0.7 translations are a lot of effort for something most players will never see. They also have weird constracts like `"'%s' %sjoined the game"`

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
