### PR TITLE
DDNet 18.5

### DIFF
--- a/data/languages/azerbaijanese.txt
+++ b/data/languages/azerbaijanese.txt
@@ -4,6 +4,7 @@
 #modified by:
 #     Gokturk          2024-06-09 12:00:50
 #     Gokturk          2024-07-17 02:24:00
+#     Gokturk          2024-08-29 23:39:00
 ##### /authors #####
 
 ##### translated strings #####
@@ -1863,52 +1864,52 @@ https://wiki.ddnet.org/wiki/Mapping
 == https://wiki.ddnet.org/wiki/Mapping
 
 Could not resolve connect address '%s'. See local console for details.
-== 
+== '%s' Link ünvanını həll etmək mümkün olmadı. Ətraflı məlumat üçün yerli konsola baxın
 
 Connect address error
-== 
+== Link ünvanı xətası
 
 Could not connect dummy
-== 
+== Dummy qoşula bilmədi
 
 Dummy is not allowed on this server
-== 
+== Bu serverdə dummy icazə verilmir
 
 Please wait…
-== 
+== Zəhmət olmasa gözləyin…
 
 Show client IDs (scoreboard, chat, spectator)
-== 
+== Klient ID'sini göstərin (aparıcı lövhə, söhbət, izləyici)
 
 Normal:
-== 
+== Normal:
 
 Team:
-== 
+== Komanda:
 
 Dummy settings
-== 
+== Dummy parametrlər
 
 Toggle to edit your dummy settings
-== 
+== Dummy parametrlərini redaktə etmək üçün açın
 
 Randomize
-== 
+== Təsadüfi
 
 Are you sure that you want to delete '%s'?
-== 
+== '%s' Bunu silmək istədiyinizə əminsiniz?
 
 Delete skin
-== 
+== Skini silin
 
 Basic
-== 
+== Sadə
 
 Custom
-== 
+== Xüsusi
 
 Unable to delete skin
-== 
+== Skin silinə bilməz
 
 Customize
-== 
+== Fərdiləşdirmək

--- a/data/languages/czech.txt
+++ b/data/languages/czech.txt
@@ -6,7 +6,7 @@
 #	Petr			2011-04-02 23:02:33
 #	Medik & Petr	2011-07-02 19:37:05
 #	TeeWorlds-org	2011-07-15 00:34:19
-#	dobrykafe		2024-06-09 00:00:00
+#	dobrykafe		2024-08-30 00:00:00
 ##### /authors #####
 
 ##### translated strings #####
@@ -1845,76 +1845,76 @@ Show only chat messages from team members
 == Zobrazit pouze zprávy od členů týmu
 
 Could not resolve connect address '%s'. See local console for details.
-== 
+== Nelze získat adresu k připojení '%s'. Podrobnosti najdete v místní konzoli.
 
 Connect address error
-== 
+== Chyba v adrese k připojení
 
 Could not connect dummy
-== 
+== Nepodařilo se připojit dummyho
 
 [Spectating]
 Following %s
-== 
+== Sledujete %s
 
 Example of usage
-== 
+== Příklad použití
 
 Dummy is not allowed on this server
-== 
+== Dummy není na tomto serveru povolen
 
 Please wait…
-== 
+== Čekejte prosím…
 
 Show client IDs (scoreboard, chat, spectator)
-== 
+== Zobrazit ID klientů (výsledková tabulka, chat, divák)
 
 Normal:
-== 
+== Normální:
 
 Team:
-== 
+== Tým:
 
 Dummy settings
-== 
+== Nastavení dummyho
 
 Toggle to edit your dummy settings
-== 
+== Přepnutím upravíte nastavení dummyho
 
 Randomize
-== 
+== Randomizovat
 
 Are you sure that you want to delete '%s'?
-== 
+== Jste si jisti, že chcete smazat '%s'?
 
 Delete skin
-== 
+== Odstranit skin
 
 Basic
-== 
+== Základní
 
 Custom
-== 
+== Vlastní
 
 Unable to delete skin
-== 
+== Nelze odstranit skin
 
 Customize
-== 
+== Přizpůsobit
 
 Round %d/%d
-== 
+== Kolo %d/%d
 
 [Spectators]
 %d others…
-== 
+== %d dalších…
 
 [Team and size]
 %d\n(%d/%d)
-== 
+== %d\n(%d/%d)
 
 Team %d (%d/%d)
-== 
+== Tým %d (%d/%d)
 
 https://wiki.ddnet.org/wiki/Mapping
-== 
+== https://wiki.ddnet.org/wiki/Mapping

--- a/data/languages/russian.txt
+++ b/data/languages/russian.txt
@@ -1880,52 +1880,52 @@ https://wiki.ddnet.org/wiki/Mapping
 == https://wiki.ddnet.org/wiki/Mapping/ru
 
 Could not resolve connect address '%s'. See local console for details.
-== 
+== Не удалось определить адрес подключения '%s'. Подробности в локальной консоли.
 
 Connect address error
-== 
+== Ошибка подключения сервера 
 
 Could not connect dummy
-== 
+== Невозможно подключить дамми
 
 Dummy is not allowed on this server
-== 
+== Дамми не разрешен на этом сервере
 
 Please wait…
-== 
+== Пожалуйста подождите…
 
 Show client IDs (scoreboard, chat, spectator)
-== 
+== Показывать ID клиента (Табло, чат, наблюдатель)
 
 Normal:
-== 
+== Обычный:
 
 Team:
-== 
+== Команда:
 
 Dummy settings
-== 
+== Настройки дамми
 
 Toggle to edit your dummy settings
-== 
+== Нажмите чтоб изменить настройки дамми
 
 Randomize
-== 
+== Перемешать 
 
 Are you sure that you want to delete '%s'?
-== 
+== Вы уверены что хотите удалить '%s'?
 
 Delete skin
-== 
+== Удалить скин
 
 Basic
-== 
+== Базовый
 
 Custom
-== 
+== Кастомизация
 
 Unable to delete skin
-== 
+== Невозможно удалить скин
 
 Customize
-== 
+== Кастомизировать

--- a/data/languages/russian.txt
+++ b/data/languages/russian.txt
@@ -631,7 +631,7 @@ Loading DDNet Client
 == Загрузка DDNet Client
 
 Normal message
-== Обычное с.
+== Обычное
 
 Connecting dummy
 == Подключение дамми
@@ -643,10 +643,10 @@ Save ghost
 == Сохранять тень
 
 DDNet Client updated!
-== DDNet Client обновлён!
+== DDNet клиент обновлён!
 
 Highlighted message
-== Выделенное с.
+== Выделенное
 
 Demo
 == Демо
@@ -724,7 +724,7 @@ Downloading %s:
 == Скачивание %s:
 
 Update failed! Check log…
-== Ошибка. Проверьте логи…
+== Не удалось обновиться! Подробности в логах…
 
 Restart
 == Рестарт
@@ -844,7 +844,7 @@ DDNet
 == DDNet
 
 Friend message
-== Дружеское с.
+== Дружеское
 
 Save the best demo of each race
 == Сохранять лучшее демо каждой карты
@@ -916,10 +916,10 @@ Ratio
 == Соотношение
 
 Net
-== Сеть
+== Сальдо
 
 FPM
-== FPM
+== У/мин
 
 Spree
 == Серия
@@ -940,7 +940,7 @@ Grabs
 == 9+ упоминаний
 
 Client message
-== Клиентское с.
+== Клиентское
 
 Warning
 == Предупреждение
@@ -973,7 +973,7 @@ Run server
 == Запустить сервер
 
 Server executable not found, can't run server
-== Файл сервера не найден, невозможно запустить
+== Файл сервера не найден, не удалось запустить сервер
 
 Editor
 == Редактор
@@ -1883,7 +1883,7 @@ Could not resolve connect address '%s'. See local console for details.
 == Не удалось определить адрес подключения '%s'. Подробности в локальной консоли.
 
 Connect address error
-== Ошибка подключения сервера 
+== Ошибка адреса подключения
 
 Could not connect dummy
 == Невозможно подключить дамми
@@ -1892,34 +1892,34 @@ Dummy is not allowed on this server
 == Дамми не разрешен на этом сервере
 
 Please wait…
-== Пожалуйста подождите…
+== Пожалуйста, подождите…
 
 Show client IDs (scoreboard, chat, spectator)
-== Показывать ID клиента (Табло, чат, наблюдатель)
+== Показывать ID клиента (табло, чат, наблюдатель)
 
 Normal:
 == Обычный:
 
 Team:
-== Команда:
+== В команде:
 
 Dummy settings
 == Настройки дамми
 
 Toggle to edit your dummy settings
-== Нажмите чтоб изменить настройки дамми
+== Нажмите, чтобы изменить настройки дамми
 
 Randomize
-== Перемешать 
+== Случайный
 
 Are you sure that you want to delete '%s'?
-== Вы уверены что хотите удалить '%s'?
+== Вы уверены, что хотите удалить '%s'?
 
 Delete skin
 == Удалить скин
 
 Basic
-== Базовый
+== Пресеты
 
 Custom
 == Кастомизация

--- a/data/languages/simplified_chinese.txt
+++ b/data/languages/simplified_chinese.txt
@@ -41,6 +41,7 @@
 # 2024-04-21 By
 # 2024-06-10 By
 # 2024-07-21 By
+# 2024-08-29 Pioooooo
 ##### /authors #####
 
 ##### translated strings #####
@@ -1514,7 +1515,7 @@ Are you sure that you want to reset the controls to their defaults?
 
 [Graphics error]
 Failed during initialization. Try to change gfx_backend to OpenGL or Vulkan in settings_ddnet.cfg in the config directory and try again.
-== 初始化失败。请尝试打开配置目录中的设置文件（settings_ddnet.cfg）并将“gfx_backend OpenGL”修改为“gfx_backend Vulkan”（若没有前者则可直接输入后者）再重试。
+== 初始化失败。请尝试打开配置目录中的设置文件（settings_ddnet.cfg）并将 “gfx_backend” 设置为 “gfx_backend OpenGL” 或 “gfx_backend Vulkan” 再重试。
 
 [Graphics error]
 Out of VRAM. Try removing custom assets (skins, entities, etc.), especially those with high resolution.
@@ -1566,7 +1567,7 @@ No controller found. Plug in a controller.
 == 未检测到任何控制器。请尝试重新连接控制器。
 
 Unregister protocol and file extensions
-== 未注册的协议与扩充文件
+== 清除协议与文件类型关联
 
 Open the directory to add custom assets
 == 打开用以添加自定义资源的文件夹路径

--- a/data/languages/simplified_chinese.txt
+++ b/data/languages/simplified_chinese.txt
@@ -1539,7 +1539,7 @@ Failed to swap framebuffers. Try to update your GPU drivers.
 
 [Graphics error]
 Unknown error. Try to change gfx_backend to OpenGL or Vulkan in settings_ddnet.cfg in the config directory and try again.
-== 未知错误。请尝试打开配置目录中的设置文件（settings_ddnet.cfg）并将“gfx_backend OpenGL”修改为“gfx_backend Vulkan”（若没有前者则可直接输入后者）再重试。
+== 未知错误。请尝试打开配置目录中的设置文件（settings_ddnet.cfg）并将 “gfx_backend” 设置为 “gfx_backend OpenGL” 或 “gfx_backend Vulkan” 再重试。
 
 [Graphics error]
 Could not initialize the given graphics backend, reverting to the default backend now.
@@ -1908,52 +1908,52 @@ https://wiki.ddnet.org/wiki/Mapping
 == https://wiki.ddnet.org/index.php?title=Mapping/zh&variant=zh-hans
 
 Could not resolve connect address '%s'. See local console for details.
-== 
+== 无法解析连接地址 '%s'。检查本地控制台以获取详情。
 
 Connect address error
-== 
+== 连接地址错误
 
 Could not connect dummy
-== 
+== 无法连接分身
 
 Dummy is not allowed on this server
-== 
+== 此服务器禁止使用分身
 
 Please wait…
-== 
+== 请稍等…
 
 Show client IDs (scoreboard, chat, spectator)
-== 
+== 显示客户端 ID（计分板、聊天、观战者）
 
 Normal:
-== 
+== 正常：
 
 Team:
-== 
+== 队伍：
 
 Dummy settings
-== 
+== 分身设置
 
 Toggle to edit your dummy settings
-== 
+== 切换以编辑分身设置
 
 Randomize
-== 
+== 随机
 
 Are you sure that you want to delete '%s'?
-== 
+== 你确定要删除'%s'吗？
 
 Delete skin
-== 
+== 删除皮肤
 
 Basic
-== 
+== 基本
 
 Custom
-== 
+== 自定义
 
 Unable to delete skin
-== 
+== 无法删除皮肤
 
 Customize
-== 
+== 自定义

--- a/data/languages/slovak.txt
+++ b/data/languages/slovak.txt
@@ -3,7 +3,7 @@
 #	Limit and Petr
 #modified by:
 #	LimiT		2011-07-02 20:24:44
-#	dobrykafe	2024-06-09 00:00:00
+#	dobrykafe	2024-08-30 00:00:00
 ##### /authors #####
 
 ##### translated strings #####
@@ -1842,76 +1842,76 @@ Show only chat messages from team members
 == Zobraziť iba správy od členov tímu
 
 Could not resolve connect address '%s'. See local console for details.
-== 
+== Nie je možné získať adresu na pripojenie '%s'. Podrobnosti nájdete v miestnej konzole.
 
 Connect address error
-== 
+== Chyba v adrese na pripojenie
 
 Could not connect dummy
-== 
+== Nepodarilo sa pripojiť dummyho
 
 [Spectating]
 Following %s
-== 
+== Sledujete %s
 
 Example of usage
-== 
+== Príklad použitia
 
 Dummy is not allowed on this server
-== 
+== Dummy nie je na tomto serveri povolený
 
 Please wait…
-== 
+== Čakajte prosím…
 
 Show client IDs (scoreboard, chat, spectator)
-== 
+== Zobraziť ID klientov (výsledková tabuľka, chat, divák)
 
 Normal:
-== 
+== Normálny:
 
 Team:
-== 
+== Tím:
 
 Dummy settings
-== 
+== Nastavenie dummyho
 
 Toggle to edit your dummy settings
-== 
+== Prepnutím upravíte nastavenie dummyho
 
 Randomize
-== 
+== Randomizovať
 
 Are you sure that you want to delete '%s'?
-== 
+== Ste si istí, že chcete zmazať '%s'?
 
 Delete skin
-== 
+== Odstrániť skin
 
 Basic
-== 
+== Základné
 
 Custom
-== 
+== Vlastné
 
 Unable to delete skin
-== 
+== Nedá sa odstrániť skin
 
 Customize
-== 
+== Prispôsobiť
 
 Round %d/%d
-== 
+== Kolo %d/%d
 
 [Spectators]
 %d others…
-== 
+== %d ďalších…
 
 [Team and size]
 %d\n(%d/%d)
-== 
+== %d\n(%d/%d)
 
 Team %d (%d/%d)
-== 
+== Tím %d (%d/%d)
 
 https://wiki.ddnet.org/wiki/Mapping
-== 
+== https://wiki.ddnet.org/wiki/Mapping

--- a/data/languages/spanish.txt
+++ b/data/languages/spanish.txt
@@ -623,7 +623,7 @@ Types
 == Tipos
 
 DDNet %s is out!
-== ¡DDNet %s ya esta disponible!
+== ¡DDNet %s ya está disponible!
 
 Downloading %s:
 == Descargando %s:
@@ -1884,52 +1884,52 @@ https://wiki.ddnet.org/wiki/Mapping
 == https://wiki.ddnet.org/wiki/Mapping/es
 
 Could not resolve connect address '%s'. See local console for details.
-== 
+== No se pudo resolver la dirección de conexión '%s'. Ver la consola local para más detalles.
 
 Connect address error
-== 
+== Error de dirección de conexión
 
 Could not connect dummy
-== 
+== No se pudo conectar tu dummy
 
 Dummy is not allowed on this server
-== 
+== No se permiten dummys en este servidor
 
 Please wait…
-== 
+== Espera por favor…
 
 Show client IDs (scoreboard, chat, spectator)
-== 
+== Mostrar IDs de cliente (scoreboard, chat, espectador)
 
 Normal:
-== 
+== Normal:
 
 Team:
-== 
+== Equipo:
 
 Dummy settings
-== 
+== Configuración del dummy
 
 Toggle to edit your dummy settings
-== 
+== Actívalo para configurar tu dummy
 
 Randomize
-== 
+== Aleatorizar
 
 Are you sure that you want to delete '%s'?
-== 
+== ¿Estás seguro de que quieres eliminar '%s'?
 
 Delete skin
-== 
+== Eliminar skin
 
 Basic
-== 
+== Básico
 
 Custom
-== 
+== Personalizado
 
 Unable to delete skin
-== 
+== No se pudo borrar la skin
 
 Customize
-== 
+== Personalizar

--- a/data/languages/swedish.txt
+++ b/data/languages/swedish.txt
@@ -7,7 +7,7 @@
 #	3edcxzaq1		2020-06-25 00:00:00
 #	cur.ie			2020-09-28 00:00:00
 #	simpygirl		2022-02-20 00:00:00
-#	furo			2024-07-17 00:00:00
+#	furo			2024-08-29 00:00:00
 ##### /authors #####
 
 ##### translated strings #####
@@ -1868,52 +1868,52 @@ https://wiki.ddnet.org/wiki/Mapping
 == https://wiki.ddnet.org/wiki/Mapping
 
 Could not resolve connect address '%s'. See local console for details.
-== 
+== Kunde inte förstå anslutnings adress '%s'. Se den lokala konsolen för detaljer.
 
 Connect address error
-== 
+== Anslutnings problem
 
 Could not connect dummy
-== 
+== Kunde inte ansluta dummy
 
 Dummy is not allowed on this server
-== 
+== Dummy är inte tillåten på denna server
 
 Please wait…
-== 
+== Vänligen vänta…
 
 Show client IDs (scoreboard, chat, spectator)
-== 
+== Visa klient IDen (poänglistan, chatt, åskadarmeny)
 
 Normal:
-== 
+== Normal:
 
 Team:
-== 
+== Lag:
 
 Dummy settings
-== 
+== Dummy inställningar
 
 Toggle to edit your dummy settings
-== 
+== Växla för att ändra dina dummy inställningar
 
 Randomize
-== 
+== Slumpa
 
 Are you sure that you want to delete '%s'?
-== 
+== Är du säker att du vill ta bort '%s'?
 
 Delete skin
-== 
+== Ta bort skin
 
 Basic
-== 
+== Enkel
 
 Custom
-== 
+== Anpassa
 
 Unable to delete skin
-== 
+== Kunde inte ta bort skin
 
 Customize
-== 
+== Ändra

--- a/data/languages/traditional_chinese.txt
+++ b/data/languages/traditional_chinese.txt
@@ -1504,7 +1504,7 @@ Are you sure that you want to reset the controls to their defaults?
 
 [Graphics error]
 Failed during initialization. Try to change gfx_backend to OpenGL or Vulkan in settings_ddnet.cfg in the config directory and try again.
-== 初始化失敗。請嘗試打開配置目錄中的設定檔案 (settings_ddnet.cfg) 并將“gfx_backend OpenGL”修改為“gfx_backend Vulkan” (若沒有前者則可直接輸入後者) 再重試。
+== 初始化失敗。請嘗試打開配置目錄中的設定檔案 (settings_ddnet.cfg) 并將 “gfx_backend” 設定為 “gfx_backend OpenGL” 或 “gfx_backend Vulkan” 再重試。
 
 [Graphics error]
 Out of VRAM. Try removing custom assets (skins, entities, etc.), especially those with high resolution.
@@ -1897,52 +1897,52 @@ https://wiki.ddnet.org/wiki/Mapping
 == https://wiki.ddnet.org/index.php?title=Mapping/zh&variant=zh-hant
 
 Could not resolve connect address '%s'. See local console for details.
-== 
+== 無法解析連線地址 '%s'。檢查本機控制台以取得詳情。
 
 Connect address error
-== 
+== 連線地址錯誤
 
 Could not connect dummy
-== 
+== 無法連線分身
 
 Dummy is not allowed on this server
-== 
+== 此服務器禁止使用分身
 
 Please wait…
-== 
+== 請稍等…
 
 Show client IDs (scoreboard, chat, spectator)
-== 
+== 顯示客戶端 ID（計分板、聊天、旁觀者）
 
 Normal:
-== 
+== 正常：
 
 Team:
-== 
+== 隊伍：
 
 Dummy settings
-== 
+== 分身設定
 
 Toggle to edit your dummy settings
-== 
+== 切換以編輯分身設定
 
 Randomize
-== 
+== 隨機
 
 Are you sure that you want to delete '%s'?
-== 
+== 你確定要刪除'%s'嗎？
 
 Delete skin
-== 
+== 刪除外觀
 
 Basic
-== 
+== 基本
 
 Custom
-== 
+== 自定義
 
 Unable to delete skin
-== 
+== 無法刪除外觀
 
 Customize
-== 
+== 自定義

--- a/data/languages/traditional_chinese.txt
+++ b/data/languages/traditional_chinese.txt
@@ -30,6 +30,7 @@
 # 2024-04-21 By
 # 2024-06-10 By
 # 2024-07-21 By
+# 2024-08-29 Pioooooo
 ##### /authors #####
 
 ##### translated strings #####
@@ -1221,7 +1222,7 @@ Team %d
 == 隊伍 %d
 
 Position:
-== 坐標	
+== 坐標
 
 Speed:
 == 速度
@@ -1527,7 +1528,7 @@ Failed to swap framebuffers. Try to update your GPU drivers.
 
 [Graphics error]
 Unknown error. Try to change gfx_backend to OpenGL or Vulkan in settings_ddnet.cfg in the config directory and try again.
-== 未知錯誤。請嘗試打開配置目錄中的設定檔案 (settings_ddnet.cfg) 并將“gfx_backend OpenGL”修改為“gfx_backend Vulkan” (若沒有前者則可直接輸入後者) 再重試。
+== 未知錯誤。請嘗試打開配置目錄中的設定檔案 (settings_ddnet.cfg) 并將 “gfx_backend” 設定為 “gfx_backend OpenGL” 或 “gfx_backend Vulkan” 再重試。
 
 [Graphics error]
 Could not initialize the given graphics backend, reverting to the default backend now.
@@ -1555,7 +1556,7 @@ No controller found. Plug in a controller.
 == 未檢測到任何控制器。請嘗試重新連接控制器。
 
 Unregister protocol and file extensions
-== 未注冊的協議與擴充檔案
+== 清除連結與檔案類型關聯
 
 Open the directory to add custom assets
 == 打開用以新增自定義材質的資料夾路徑

--- a/data/languages/turkish.txt
+++ b/data/languages/turkish.txt
@@ -1876,52 +1876,52 @@ https://wiki.ddnet.org/wiki/Mapping
 == https://wiki.ddnet.org/wiki/Mapping/tr
 
 Could not resolve connect address '%s'. See local console for details.
-== 
+== '%s' Bağlantı adresi çözümlenemedi. Detaylar için yerel konsola bakın
 
 Connect address error
-== 
+== Bağlantı adresi hatası
 
 Could not connect dummy
-== 
+== Dummy bağlanamadı
 
 Dummy is not allowed on this server
-== 
+== Bu sunucuda dummy izin verilmiyor
 
 Please wait…
-== 
+== Lütfen bekleyin…
 
 Show client IDs (scoreboard, chat, spectator)
-== 
+== İstemci ID'sini göster (skor tablosu, sohbet, izleyici)
 
 Normal:
-== 
+== Normal:
 
 Team:
-== 
+== Takım:
 
 Dummy settings
-== 
+== Dummy ayarları
 
 Toggle to edit your dummy settings
-== 
+== Dummy ayarlarını düzenlemek için açın 
 
 Randomize
-== 
+== Rastgele
 
 Are you sure that you want to delete '%s'?
-== 
+== '%s' bunu silmek istediğine emin misin?
 
 Delete skin
-== 
+== Skini sil
 
 Basic
-== 
+== Basit
 
 Custom
-== 
+== Özel
 
 Unable to delete skin
-== 
+== Skin silinemiyor
 
 Customize
-== 
+== Özelleştir

--- a/data/languages/turkish.txt
+++ b/data/languages/turkish.txt
@@ -16,6 +16,7 @@
 #   Gokturk          2024-04-24 03:01:50
 #   Gokturk          2024-06-09 12:00:50
 #   Gokturk          2024-07-17 02:24:00
+#   Gokturk          2024-08-29 23:31:00
 ##### /authors #####
 
 ##### translated strings #####

--- a/data/languages/ukrainian.txt
+++ b/data/languages/ukrainian.txt
@@ -165,6 +165,9 @@ AntiPing: predict weapons
 Appearance
 == Вигляд
 
+Are you sure that you want to delete '%s'?
+== Ви дійсно хочете видалити '%s'?
+
 Are you sure that you want to delete the demo '%s'?
 == Ви дійсно хочете видалити демо '%s'?
 
@@ -236,6 +239,9 @@ Background
 
 Background music volume
 == Гучність фонової музики
+
+Basic
+== Базовий
 
 Best
 == НКом
@@ -330,6 +336,9 @@ Communities
 Config directory
 == Тека налаштувань
 
+Connect address error
+== Помилка адреси з'єднання
+
 Connect Dummy
 == Приєднати даммі
 
@@ -366,6 +375,9 @@ Converse
 Copy info
 == Скопіювати
 
+Could not connect dummy
+== Не вдалося під'єднати даммі
+
 [Graphics error]
 Could not initialize the given graphics backend, reverting to the default backend now.
 == Не вдалося ініціалізувати заданий графічний рушій, повертаємося до рушія за замовчуванням.
@@ -373,6 +385,9 @@ Could not initialize the given graphics backend, reverting to the default backen
 [Graphics error]
 Could not initialize the given graphics backend, this is probably because you didn't install the driver of the integrated graphics card.
 == Не вдалося ініціалізувати заданий графічний рушій, можливо тому що ви не встановили драйвери на вбудовану відеокарту.
+
+Could not resolve connect address '%s'. See local console for details.
+== Не вдалося визначити адресу з'єднання '%s' (див. локальну консоль).
 
 Could not save downloaded map. Try manually deleting this file: %s
 == Не вдалося зберегти завантажену мапу. Спробуйте самостійно видалити цей файл: %s
@@ -395,8 +410,14 @@ Current
 custom
 == власний
 
+Custom
+== Власний
+
 Custom colors
 == Власні кольори
+
+Customize
+== Налаштування
 
 Cut interval
 == Інтервал
@@ -458,6 +479,9 @@ Delete demo
 Delete folder
 == Видалити теку
 
+Delete skin
+== Видалити скін
+
 Demo
 == Демо
 
@@ -511,6 +535,12 @@ Dummy
 
 Dummy copy
 == Повторювати рухи
+
+Dummy is not allowed on this server
+== Використання даммі заборонене на цьому сервері
+
+Dummy settings
+== Налаштування даммі
 
 Dynamic Camera
 == Рухома камера
@@ -1071,6 +1101,9 @@ No updates available
 None
 == Немає
 
+Normal:
+== Звичайний:
+
 Normal Color
 == Колір звичайних повідомлень
 
@@ -1188,6 +1221,9 @@ Please enter your nickname below.
 Please use a different filename
 == Будь ласка, назвіть файл по-іншому
 
+Please wait…
+== Будь ласка, зачекайте…
+
 Position:
 == Позиція:
 
@@ -1214,6 +1250,9 @@ Quitting. Please wait…
 
 Race
 == Забіг
+
+Randomize
+== Випадково
 
 Ratio
 == У/С
@@ -1410,6 +1449,9 @@ Show chat
 
 Show clan above name plates
 == Показувати клан над ніками
+
+Show client IDs (scoreboard, chat, spectator)
+== Показувати ID клієнта (табло, чат, спостерігачі)
 
 Show DDNet map finishes in server browser
 == Показувати пройдені мапи DDNet у браузері серверів
@@ -1631,6 +1673,9 @@ System message
 Team
 == Команда
 
+Team:
+== Командний:
+
 Team %d
 == Команда %d
 
@@ -1688,6 +1733,9 @@ Toggle ghost
 Toggle keyboard shortcuts
 == Перемкнути скорочення
 
+Toggle to edit your dummy settings
+== Перемкніть, щоб змінити налаштування даммі
+
 transmits your player name to info.ddnet.org
 == передає ваш нікнейм до info.ddnet.org
 
@@ -1723,6 +1771,9 @@ UI controller sens.
 
 UI mouse sens.
 == Чутл. у інтерфейсі
+
+Unable to delete skin
+== Не вдалося видалити скін
 
 Unable to delete the demo '%s'
 == Не вдалося видалити демо '%s'
@@ -1862,54 +1913,3 @@ Zoom in
 
 Zoom out
 == Віддалити
-
-Could not resolve connect address '%s'. See local console for details.
-== 
-
-Connect address error
-== 
-
-Could not connect dummy
-== 
-
-Dummy is not allowed on this server
-== 
-
-Please wait…
-== 
-
-Show client IDs (scoreboard, chat, spectator)
-== 
-
-Normal:
-== 
-
-Team:
-== 
-
-Dummy settings
-== 
-
-Toggle to edit your dummy settings
-== 
-
-Randomize
-== 
-
-Are you sure that you want to delete '%s'?
-== 
-
-Delete skin
-== 
-
-Basic
-== 
-
-Custom
-== 
-
-Unable to delete skin
-== 
-
-Customize
-== 

--- a/data/languages/ukrainian.txt
+++ b/data/languages/ukrainian.txt
@@ -4,7 +4,7 @@
 #modified by:
 #	404_not_found		2011-07-30 19:50:58
 #	EGYT5453			(15.05.2024-04.06.2024)
-# veydzh3r			(31/08/2024-01/09/2024)
+#	veydzh3r			(31.08.2024-01.09.2024)
 ##### /authors #####
 
 ##### translated strings #####
@@ -33,10 +33,10 @@
 == ще %d…
 
 %d player
-== Гравців: %d
+== Гравці: %d
 
 %d players
-== Гравців: %d
+== Гравці: %d
 
 [Demo player duration]
 %d sec.
@@ -194,7 +194,7 @@ Are you sure that you want to remove the player '%s' from your friends list?
 == Ви дійсно хочете прибрати гравця '%s' зі списку друзів?
 
 Are you sure that you want to reset the controls to their defaults?
-== Ви дійсно хочете скинути налаштування керувань до стандартних значень?
+== Ви дійсно хочете скинути налаштування керувань до початкових значень?
 
 Are you sure that you want to restart?
 == Ви дійсно хочете перезапустити?
@@ -302,7 +302,7 @@ CHN
 == КИТ
 
 Choose default eyes when joining a server
-== Стандартні очі під час приєднання до сервера
+== Типові очі під час приєднання до сервера
 
 Clan
 == Клан
@@ -381,7 +381,7 @@ Could not connect dummy
 
 [Graphics error]
 Could not initialize the given graphics backend, reverting to the default backend now.
-== Не вдалося ініціалізувати заданий графічний рушій, повертаємося до стандартного рушія.
+== Не вдалося ініціалізувати заданий графічний рушій, повернення до тпового рушія.
 
 [Graphics error]
 Could not initialize the given graphics backend, this is probably because you didn't install the driver of the integrated graphics card.
@@ -1016,7 +1016,7 @@ Move left
 == Вліво
 
 Move player to spectators
-== Зробити гравця спостерігачем
+== Зробити гравця глядачем
 
 Move right
 == Вправо
@@ -1452,7 +1452,7 @@ Show clan above name plates
 == Показувати клан над ніками
 
 Show client IDs (scoreboard, chat, spectator)
-== Показувати ID клієнта (таблиця, чат, спостерігачі)
+== Показувати ID клієнта (таблиці, чату, глядачів)
 
 Show DDNet map finishes in server browser
 == Показувати пройдені мапи DDNet у браузері серверів

--- a/data/languages/ukrainian.txt
+++ b/data/languages/ukrainian.txt
@@ -4,7 +4,7 @@
 #modified by:
 #	404_not_found		2011-07-30 19:50:58
 #	EGYT5453			(15.05.2024-04.06.2024)
-# veydzh3r      (31/08/2024 - present)
+# veydzh3r			(31/08/2024-01/09/2024)
 ##### /authors #####
 
 ##### translated strings #####
@@ -17,7 +17,7 @@
 
 [Demo player duration]
 %d min.
-== %d хв.
+== %dхв
 
 %d new mentions
 == Нових згадок: %d
@@ -40,7 +40,7 @@
 
 [Demo player duration]
 %d sec.
-== %d сек.
+== %dс
 
 %d/%d KiB (%.1f KiB/s)
 == %d/%d КіБ (%.1f КіБ/с)
@@ -53,16 +53,16 @@
 == залишилося %dс
 
 %i minute left
-== Залишилося: %i хв.
+== Залишилося: %iхв
 
 %i minutes left
-== Залишилося: %i хв.
+== Залишилося: %iхв
 
 %i second left
-== Залишилося: %i сек.
+== Залишилося: %iс
 
 %i seconds left
-== Залишилося: %i сек.
+== Залишилося: %iс
 
 %s wins!
 == %s перемагає!
@@ -77,17 +77,17 @@
 == Нових згадок: 9+
 
 A demo with this name already exists
-== Демо з цією назвою вже існує
+== Демо з цією назвою уже існує
 
 A folder with this name already exists
-== Тека з цією назвою вже існує
+== Тека з цією назвою уже існує
 
 [Graphics error]
 A render command failed. Try to update your GPU drivers.
 == Помилка в команді відмальовування. Спробуйте оновити драйвери відеокарти.
 
 A Tee
-== Тії
+== тії
 
 Abort
 == Скасувати
@@ -121,7 +121,7 @@ AFR
 == АФР
 
 Aim bind
-== Прив'язка
+== Прив’язка
 
 All
 == Усі
@@ -206,7 +206,7 @@ Assets
 == Текстури
 
 Assets directory
-== Тека ресурсів
+== Тека текстур
 
 AUS
 == АВС
@@ -263,7 +263,7 @@ Call vote
 == Голосувати
 
 Can't find a Tutorial server
-== Не вдалося знайти сервер-посібник
+== Не вдається знайти навчальний сервер
 
 Cancel
 == Скасувати
@@ -347,7 +347,7 @@ Connected
 == Під’єднано
 
 Connecting dummy
-== Під’єднати даммі
+== Під’єднання даммі
 
 Connecting to
 == Під’єднання до
@@ -454,7 +454,7 @@ Deactivate
 == Деактивувати
 
 Deactivate all
-== Деактивувати усіх
+== Деактивувати всіх
 
 Deaths
 == Смерті
@@ -463,7 +463,7 @@ Debug mode enabled. Press Ctrl+Shift+D to disable debug mode.
 == Увімкнено режим налагодження. Натисніть Ctrl+Shift+D, щоб його вимкнути.
 
 default
-== за стандартом
+== типово
 
 Default length
 == Звичайна тривалість
@@ -610,7 +610,7 @@ Error saving settings
 == Помилка збереження налаштувань
 
 EUR
-== EUR
+== ЄВР
 
 Example of usage
 == Приклад використання
@@ -838,7 +838,7 @@ Indicate map finish
 == Позначати пройдені мапи
 
 Info Messages
-== Інформаційні повідомлення
+== Інфо. повідомлення
 
 Ingame controller mode
 == Режим контролера у грі
@@ -877,7 +877,7 @@ Join red
 == До червоних
 
 Join Tutorial Server
-== Приєднатися до сервера-посібника
+== Приєднатися до навчального сервера
 
 Jump
 == Стрибок
@@ -910,7 +910,7 @@ Lht.
 == Світл.
 
 Lines %d - %d (%s)
-== Рядки %d — %d (%s)
+== Рядки %d—%d (%s)
 
 Loading…
 == Завантаження…
@@ -925,7 +925,7 @@ Loading DDNet Client
 == Завантаження клієнта DDNet
 
 Loading demo file from storage
-== Завантаження демо-файла зі сховища
+== Завантаження демо-файлу зі сховища
 
 Loading demo files
 == Завантаження демо-файлів
@@ -971,7 +971,7 @@ map not included
 == мапу не включено
 
 Map sound volume
-== Гучність мапи
+== Гучність звуків мапи
 
 Mark the beginning of a cut (right click to reset)
 == Позначити початок фрагмента (права кнопка миші, щоб скинути)
@@ -986,13 +986,13 @@ Match %d of %d
 == Збіг %d з %d
 
 Max CSVs
-== Найбільше CSV-файлів
+== Макс. кількість файлів CSV
 
 Max demos
-== Найбільше демо-файлів
+== Макс. кількість демо-файлів
 
 Max Screenshots
-== Найбільше знімків екрана
+== Макс. кількість знімків екрана
 
 may cause delay
 == може спричинити затримку
@@ -1031,7 +1031,7 @@ Multi-View
 == Мульти-камера
 
 Mute when not active
-== Приглушувати, якщо вікно неактивне
+== Приглушувати звук поза грою
 
 NA
 == ПНА
@@ -1052,7 +1052,7 @@ Netversion
 == Версія
 
 New name:
-== Нова назва
+== Нова назва:
 
 New random timeout code
 == Новий випадковий код тайм-ауту
@@ -1134,7 +1134,7 @@ Only save improvements
 == Зберігати лише покращення
 
 Opacity
-== Непрозорість
+== Непрозор.
 
 Opacity of freeze bars inside freeze
 == Непрозорість смуги заморозки в заморозці
@@ -1159,7 +1159,7 @@ Open the settings file
 
 [Graphics error]
 Out of VRAM. Try removing custom assets (skins, entities, etc.), especially those with high resolution.
-== Недостатньо відеопам’яті. Спробуйте видалити власні текстури (скіни, сутності і т.п.), особливо ті, що мають високу роздільність.
+== Недостатньо відеопам’яті. Спробуйте видалити власні текстури (скіни, сутності і т.д.), особливо ті, що мають високу роздільність.
 
 Overlay entities
 == Накладати сутності
@@ -1171,7 +1171,7 @@ Particles
 == Частинки
 
 Pause
-== Павза
+== Пауза
 
 Pause the current demo
 == Призупинити
@@ -1262,7 +1262,7 @@ Reason:
 == Причина:
 
 Reconnect in %d sec
-== Повторне під’єднання за %d сек.
+== Повторне під’єднання за %dс
 
 Record demo
 == Запис демо
@@ -1274,7 +1274,7 @@ Red team wins!
 == Червоні перемогли!
 
 Refresh Rate
-== Частота оновлення
+== Частота кадрів
 
 Regular background color
 == Колір звичайного тла
@@ -1365,7 +1365,7 @@ Same clan color in scoreboard
 == Колір співклановців у таблиці
 
 Sat.
-== Насиченість
+== Насич.
 
 Save
 == Зберегти
@@ -1374,7 +1374,7 @@ Save ghost
 == Зберігати привида
 
 Save power by lowering refresh rate (higher input latency)
-== Економія енергії шляхом зниження частоти оновлення (вища затримка введення)
+== Економити енергію шляхом зниження частоти кадрів (вища затримка введення)
 
 Save the best demo of each race
 == Зберігати найкраще демо кожного забігу
@@ -1452,7 +1452,7 @@ Show clan above name plates
 == Показувати клан над ніками
 
 Show client IDs (scoreboard, chat, spectator)
-== Показувати ID клієнта (табло, чат, спостерігачі)
+== Показувати ID клієнта (таблиця, чат, спостерігачі)
 
 Show DDNet map finishes in server browser
 == Показувати пройдені мапи DDNet у браузері серверів
@@ -1464,7 +1464,7 @@ Show dummy actions
 == Показувати дії з даммі
 
 Show entities
-== Показувати сутності
+== Показ сутностей
 
 Show finish messages
 == Показувати повідомлення про фініші
@@ -1666,7 +1666,7 @@ Switch weapon on pickup
 == Змінювати зброю при підхопленні
 
 Switch weapon when out of ammo
-== Змінювати зброю коли закінчуються набої
+== Змінювати зброю при закінченні набоїв
 
 System message
 == Повідомлення системи
@@ -1732,7 +1732,7 @@ Toggle ghost
 == Привид
 
 Toggle keyboard shortcuts
-== Перемкнути скорочення
+== Перемкнути сполучення
 
 Toggle to edit your dummy settings
 == Перемкніть, щоб змінити налаштування даммі
@@ -1747,7 +1747,7 @@ Try again
 == Спробувати ще раз
 
 Trying to determine UDP connectivity…
-== Намагаємося визначити UDP-з'єднання…
+== Спроба визначити UDP-з’єднання…
 
 Tutorial
 == Посібник
@@ -1768,10 +1768,10 @@ UI Color
 == Колір інтерфейсу
 
 UI controller sens.
-== Чутливість в інтерфейсі
+== Чутл. в інтерфейсі
 
 UI mouse sens.
-== Чутливість в інтерфейсі
+== Чутл. в інтерфейсі
 
 Unable to delete skin
 == Не вдалося видалити скін
@@ -1841,7 +1841,7 @@ Video name:
 == Назва відео:
 
 Video was saved to '%s'
-== Відео було збережено до '%s'
+== Відео збережено до '%s'
 
 Videos directory
 == Тека відео
@@ -1901,7 +1901,7 @@ Your movements are not taken into account when calculating the line colors
 == Ваші рухи не враховуються при розранку кольору лінії
 
 You must restart the game for all settings to take effect.
-== Щоб налаштування набрали чинності, перезапустіть гру.
+== Щоб налаштування набули чинності, перезапустіть гру.
 
 Your nickname '%s' is already used (%d points). Do you still want to use it?
 == Ваш псевдонім «%s» вже зайнято (%d балів). Усе ще хочете використовувати його?

--- a/data/languages/ukrainian.txt
+++ b/data/languages/ukrainian.txt
@@ -1452,7 +1452,7 @@ Show clan above name plates
 == Показувати клан над ніками
 
 Show client IDs (scoreboard, chat, spectator)
-== Показувати ID клієнта (таблиці, чату, глядачів)
+== Показувати ID клієнта (таблиця, чат, глядачі)
 
 Show DDNet map finishes in server browser
 == Показувати пройдені мапи DDNet у браузері серверів

--- a/data/languages/ukrainian.txt
+++ b/data/languages/ukrainian.txt
@@ -4,6 +4,7 @@
 #modified by:
 #	404_not_found		2011-07-30 19:50:58
 #	EGYT5453			(15.05.2024-04.06.2024)
+# veydzh3r      (31/08/2024 - present)
 ##### /authors #####
 
 ##### translated strings #####
@@ -16,7 +17,7 @@
 
 [Demo player duration]
 %d min.
-== %dхв
+== %d хв.
 
 %d new mentions
 == Нових згадок: %d
@@ -39,7 +40,7 @@
 
 [Demo player duration]
 %d sec.
-== %dс
+== %d сек.
 
 %d/%d KiB (%.1f KiB/s)
 == %d/%d КіБ (%.1f КіБ/с)
@@ -52,16 +53,16 @@
 == залишилося %dс
 
 %i minute left
-== Залишилося: %iхв
+== Залишилося: %i хв.
 
 %i minutes left
-== Залишилося: %iхв
+== Залишилося: %i хв.
 
 %i second left
-== Залишилося: %iс
+== Залишилося: %i сек.
 
 %i seconds left
-== Залишилося: %iс
+== Залишилося: %i сек.
 
 %s wins!
 == %s перемагає!
@@ -86,7 +87,7 @@ A render command failed. Try to update your GPU drivers.
 == Помилка в команді відмальовування. Спробуйте оновити драйвери відеокарти.
 
 A Tee
-== тії
+== Тії
 
 Abort
 == Скасувати
@@ -175,13 +176,13 @@ Are you sure that you want to delete the folder '%s'?
 == Ви дійсно хочете видалити теку '%s'?
 
 Are you sure that you want to disconnect?
-== Ви дійсно хочете від'єднатися?
+== Ви дійсно хочете від’єднатися?
 
 Are you sure that you want to disconnect and switch to a different server?
-== Ви дійсно хочете від'єднатися й приєднатися до іншого сервера?
+== Ви дійсно хочете від’єднатися й приєднатися до іншого сервера?
 
 Are you sure that you want to disconnect your dummy?
-== Ви дійсно хочете від'єднати свого даммі?
+== Ви дійсно хочете від’єднати свого даммі?
 
 Are you sure that you want to quit?
 == Ви дійсно хочете вийти?
@@ -193,7 +194,7 @@ Are you sure that you want to remove the player '%s' from your friends list?
 == Ви дійсно хочете прибрати гравця '%s' зі списку друзів?
 
 Are you sure that you want to reset the controls to their defaults?
-== Ви дійсно хочете скинути налаштування керування до значень за замовчуванням?
+== Ви дійсно хочете скинути налаштування керувань до стандартних значень?
 
 Are you sure that you want to restart?
 == Ви дійсно хочете перезапустити?
@@ -205,13 +206,13 @@ Assets
 == Текстури
 
 Assets directory
-== Тека текстур
+== Тека ресурсів
 
 AUS
 == АВС
 
 Authed name color in scoreboard
-== Колір авторизованих у таблі
+== Колір авторизованих у таблиці
 
 Auto
 == Авто
@@ -220,7 +221,7 @@ auto
 == автоматично
 
 Automatically create statboard csv
-== Автоматично зберігати статистику у CSV-файл
+== Автоматично зберігати статистику у файл CSV
 
 Automatically record demos
 == Автоматично записувати демо
@@ -235,7 +236,7 @@ Axis
 == Осі
 
 Background
-== Фон
+== Тло
 
 Background music volume
 == Гучність фонової музики
@@ -295,13 +296,13 @@ Check now
 == Перевірити
 
 Checking for existing player with your name
-== Перевіряємо Ваш нікнейм на доступність
+== Перевірка на наявність гравця з вашим ім’ям
 
 CHN
 == КИТ
 
 Choose default eyes when joining a server
-== Очі, які відображатимуться за замовчуванням
+== Стандартні очі під час приєднання до сервера
 
 Clan
 == Клан
@@ -328,7 +329,7 @@ Close the demo player
 == Закрити програвач демо
 
 Colors of the hook collision line, in case of a possible collision with:
-== Кольори лінії зіткнення гака, якщо він може зіштовхнутися з:
+== Кольори лінії зіткнення гака, в разі можливого зіткнення з:
 
 Communities
 == Спільноти
@@ -337,28 +338,28 @@ Config directory
 == Тека налаштувань
 
 Connect address error
-== Помилка адреси з'єднання
+== Помилка адреси з’єднання
 
 Connect Dummy
-== Приєднати даммі
+== Під’єднати даммі
 
 Connected
-== Приєднано
+== Під’єднано
 
 Connecting dummy
-== Приєднуємо даммі
+== Під’єднати даммі
 
 Connecting to
-== Приєднуємося до
+== Під’єднання до
 
 Connection Problems…
-== Проблеми зі з'єднанням…
+== Проблеми зі з’єднанням…
 
 Console
 == Консоль
 
 Continue anyway?
-== Все одно продовжити?
+== Усе одно продовжити?
 
 Controller
 == Контролер
@@ -376,24 +377,24 @@ Copy info
 == Скопіювати
 
 Could not connect dummy
-== Не вдалося під'єднати даммі
+== Не вдалося під’єднати даммі
 
 [Graphics error]
 Could not initialize the given graphics backend, reverting to the default backend now.
-== Не вдалося ініціалізувати заданий графічний рушій, повертаємося до рушія за замовчуванням.
+== Не вдалося ініціалізувати заданий графічний рушій, повертаємося до стандартного рушія.
 
 [Graphics error]
 Could not initialize the given graphics backend, this is probably because you didn't install the driver of the integrated graphics card.
-== Не вдалося ініціалізувати заданий графічний рушій, можливо тому що ви не встановили драйвери на вбудовану відеокарту.
+== Не вдалося ініціалізувати заданий графічний рушій, імовірно, ви не встановили драйвери на вбудовану відеокарту.
 
 Could not resolve connect address '%s'. See local console for details.
-== Не вдалося визначити адресу з'єднання '%s' (див. локальну консоль).
+== Не вдалося визначити адресу з’єднання '%s'. Див. локальну консоль для подробиць.
 
 Could not save downloaded map. Try manually deleting this file: %s
 == Не вдалося зберегти завантажену мапу. Спробуйте самостійно видалити цей файл: %s
 
 Count players only
-== Рахувати тільки гравців
+== Рахувати лише гравців
 
 Countries
 == Країни
@@ -417,7 +418,7 @@ Custom colors
 == Власні кольори
 
 Customize
-== Налаштування
+== Налаштувати
 
 Cut interval
 == Інтервал
@@ -438,7 +439,7 @@ DDNet %s is out!
 == Вийшов DDNet %s!
 
 DDNet Client needs to be restarted to complete update!
-== Потрібно перезапустити клієнт DDNet, щоб завершити оновлення!
+== Потрібно перезапустити клієнт DDNet для завершення оновлення!
 
 DDNet Client updated!
 == Клієнт DDNet оновлено!
@@ -447,7 +448,7 @@ DDRace HUD
 == HUD DDRace
 
 DDraceNetwork is a cooperative online game where the goal is for you and your group of tees to reach the finish line of the map. As a newcomer you should start on Novice servers, which host the easiest maps. Consider the ping to choose a server close to you.
-== DDraceNetwork — кооперативна мережева гра, ціль якої — дістатися разом зі своєю групою тії до фінішної прямої. Новачкам варто почати із серверів "Для новачків" (Novice), на яких є найпростіші мапи. Зважайте на затримку, коли вибираєте сервер.
+== DDraceNetwork — кооперативна мережева гра, ціль якої — дістатися разом зі своєю групою тії до фінішної прямої. Новачкам варто почати із серверів «Для новачків» (Novice), на яких є найпростіші мапи. Зважайте на затримку, коли вибираєте сервер.
 
 Deactivate
 == Деактивувати
@@ -456,13 +457,13 @@ Deactivate all
 == Деактивувати усіх
 
 Deaths
-== С
+== Смерті
 
 Debug mode enabled. Press Ctrl+Shift+D to disable debug mode.
 == Увімкнено режим налагодження. Натисніть Ctrl+Shift+D, щоб його вимкнути.
 
 default
-== за замовчуванням
+== за стандартом
 
 Default length
 == Звичайна тривалість
@@ -495,16 +496,16 @@ Demos directory
 == Тека демо
 
 Desktop fullscreen
-== Стільничний повноекранний
+== Робочий стіл на весь екран
 
 Disconnect
-== Від'єднатися
+== Від’єднатися
 
 Disconnect Dummy
-== Від'єднати даммі
+== Від’єднати даммі
 
 Disconnected
-== Від'єднано
+== Від’єднано
 
 Discord
 == Discord
@@ -522,10 +523,10 @@ Download skins
 == Завантажувати скіни
 
 Downloading %s:
-== Завантажуємо %s:
+== Завантаження %s:
 
 Downloading map
-== Завантажуємо мапу
+== Завантаження мапи
 
 Draw!
 == Нічия!
@@ -543,7 +544,7 @@ Dummy settings
 == Налаштування даммі
 
 Dynamic Camera
-== Рухома камера
+== Динамічна камера
 
 Editor
 == Редактор
@@ -576,7 +577,7 @@ Enable regular chat sound
 == Звук звичайного повідомлення
 
 Enable replays
-== Повтори
+== Увімкнути повтори
 
 Enable server message sound
 == Звук повідомлення сервера
@@ -588,13 +589,13 @@ Enter Password
 == Введіть пароль
 
 Enter Username
-== Введіть логін
+== Введіть ім’я користувача
 
 Entities
 == Сутності
 
 Entities background color
-== Колір фону сутностей
+== Колір тла сутностей
 
 Error
 == Помилка
@@ -609,16 +610,16 @@ Error saving settings
 == Помилка збереження налаштувань
 
 EUR
-== ЄВР
+== EUR
 
 Example of usage
-== Наприклад
+== Приклад використання
 
 Exclude
 == Виключити
 
 Existing Player
-== Гравець вже існує
+== Гравець уже існує
 
 Export cut as a separate demo
 == Експортувати фрагмент як окреме демо
@@ -681,7 +682,7 @@ Following
 
 [Spectating]
 Following %s
-== Слідуємо за %s
+== Cпостерігання за %s
 
 Force vote
 == Форсувати
@@ -711,7 +712,7 @@ FSAA samples
 == Вибірка FSAA
 
 Fullscreen
-== Повноекранний
+== На весь екран
 
 Game
 == Гра
@@ -738,13 +739,13 @@ Gameplay
 == Ігролад
 
 General
-== Загальне
+== Загальні
 
 Getting game info
-== Отримуємо інформацію про гру
+== Отримання інформації про гру
 
 Getting server list from master server
-== Отримуємо список серверів з головного сервера
+== Отримання списку серверів з головного сервера
 
 Ghost
 == Привид
@@ -756,7 +757,7 @@ Go back one marker
 == Перемотати до попередньої мітки
 
 Go back one tick
-== Перемотати вперед на один тік
+== Перемотати вперед на один такт
 
 Go back the specified duration
 == Перемотати назад
@@ -765,7 +766,7 @@ Go forward one marker
 == Перемотати до наступної мітки
 
 Go forward one tick
-== Перемотати назад на один тік
+== Перемотати вперед на один такт
 
 Go forward the specified duration
 == Перемотати вперед
@@ -831,31 +832,31 @@ HUD
 == HUD
 
 Hue
-== Тон
+== Відтінок
 
 Indicate map finish
 == Позначати пройдені мапи
 
 Info Messages
-== Інфо-повідомлення
+== Інформаційні повідомлення
 
 Ingame controller mode
 == Режим контролера у грі
 
 Ingame controller sens.
-== Чутл. у грі
+== Чутливість у грі
 
 Ingame mouse sens.
-== Чутл. у грі
+== Чутливість у грі
 
 Initializing assets
-== Ініціалізуємо текстури
+== Ініціалізація текстур
 
 Initializing components
-== Ініціалізуємо компоненти
+== Ініціалізація компонентів
 
 Initializing map logic
-== Ініціалізуємо логіку мапи
+== Ініціалізація логіки мапи
 
 Internet
 == Інтернет
@@ -864,7 +865,7 @@ Invalid Demo
 == Недійсне демо
 
 It's recommended that you check the settings to adjust them to your liking before joining a server.
-== Перед тим як приєднатися до сервера, рекомендуємо змінити налаштування до ваших уподобань.
+== Перед тим, як приєднатися до сервера, рекомендуємо змінити налаштування до ваших уподобань.
 
 Join blue
 == До синіх
@@ -909,58 +910,58 @@ Lht.
 == Світл.
 
 Lines %d - %d (%s)
-== Рядки %d—%d (%s)
+== Рядки %d — %d (%s)
 
 Loading…
 == Завантаження…
 
 Loading assets
-== Завантажуємо текстури
+== Завантаження текстур
 
 Loading commands…
-== Завантажуємо команди…
+== Завантаження команд…
 
 Loading DDNet Client
-== Завантажуємо клієнт DDNet
+== Завантаження клієнта DDNet
 
 Loading demo file from storage
-== Завантажуємо демо-файл зі сховища
+== Завантаження демо-файла зі сховища
 
 Loading demo files
-== Завантажуємо демо-файли
+== Завантаження демо-файлів
 
 Loading ghost files
-== Завантажуємо файли привида
+== Завантаження файлів привида
 
 Loading map file from storage
-== Завантажуємо файл мапи зі сховища
+== Завантаження файлу мапи зі сховища
 
 Loading menu images
-== Завантажуємо зображення меню
+== Завантаження зображень меню
 
 Loading menu themes
-== Завантажуємо теми меню
+== Завантаження тем меню
 
 Loading race demo files
-== Завантажуємо демо-файли забігів
+== Завантаження демо-файлів забігів
 
 Loading skin files
-== Завантажуємо файли скінів
+== Завантаження файлів скінів
 
 Loading sound files
-== Завантажуємо звукові файли
+== Завантаження звукових файлів
 
 Lock team
 == Замкнути команду
 
 Locked
-== Заблоковано
+== Замкнено
 
 Main menu
 == Головне меню
 
 Manual
-== Вручну
+== Уручну
 
 Map
 == Мапа
@@ -1063,16 +1064,16 @@ Next weapon
 == Наст. зброя
 
 Nickname
-== Нікнейм
+== Псевдонім
 
 No
 == Ні
 
 No answer from server yet.
-== Сервер ще не відповів.
+== Поки що немає відповіді від сервера.
 
 No controller found. Plug in a controller.
-== Жодного контролера не знайдено. Підключіть контролер.
+== Жодного контролера не знайдено. Під’єднайте контролер.
 
 No demo selected
 == Жодного демо не вибрано
@@ -1111,29 +1112,29 @@ Normal message
 == Звичайні повідомлення
 
 NOT CONNECTED
-== НЕ ПРИЄДНАНО
+== НЕ ПІД’ЄДНАНО
 
 Nothing hookable
 == нічим, за що можна зачепитися
 
 [friends (server browser)]
 Offline (%d)
-== Офлайн (%d)
+== Не в мережі (%d)
 
 Ok
 == Гаразд
 
 Online clanmates (%d)
-== Онлайн клановці (%d)
+== Співклановці в мережі (%d)
 
 Online players (%d)
-== Онлайн гравці (%d)
+== Гравці в мережі (%d)
 
 Only save improvements
 == Зберігати лише покращення
 
 Opacity
-== Непрозор.
+== Непрозорість
 
 Opacity of freeze bars inside freeze
 == Непрозорість смуги заморозки в заморозці
@@ -1158,7 +1159,7 @@ Open the settings file
 
 [Graphics error]
 Out of VRAM. Try removing custom assets (skins, entities, etc.), especially those with high resolution.
-== Недостатньо відеопам'яті. Спробуйте видалити власні текстури (скіни, сутності і т.п.), особливо ті, що мають високу роздільну здатність.
+== Недостатньо відеопам’яті. Спробуйте видалити власні текстури (скіни, сутності і т.п.), особливо ті, що мають високу роздільність.
 
 Overlay entities
 == Накладати сутності
@@ -1167,10 +1168,10 @@ Parent Folder
 == Батьківська тека
 
 Particles
-== Часточки
+== Частинки
 
 Pause
-== Пауза
+== Павза
 
 Pause the current demo
 == Призупинити
@@ -1228,7 +1229,7 @@ Position:
 == Позиція:
 
 Preparing demo playback
-== Підготовлюємо відтворення демо
+== Підготовлення відтворення демо
 
 Press a key…
 == Натисніть клавішу…
@@ -1243,7 +1244,7 @@ Quads are used for background decoration
 == Квади використовуються для декорацій
 
 Quit
-== Вихід
+== Вийти
 
 Quitting. Please wait…
 == Вихід. Будь ласка, зачекайте…
@@ -1252,7 +1253,7 @@ Race
 == Забіг
 
 Randomize
-== Випадково
+== Навмання
 
 Ratio
 == У/С
@@ -1261,7 +1262,7 @@ Reason:
 == Причина:
 
 Reconnect in %d sec
-== Переприєднання через %dс
+== Повторне під’єднання за %d сек.
 
 Record demo
 == Запис демо
@@ -1273,10 +1274,10 @@ Red team wins!
 == Червоні перемогли!
 
 Refresh Rate
-== Частота кадрів
+== Частота оновлення
 
 Regular background color
-== Колір звичайного фону
+== Колір звичайного тла
 
 [Ingame controller mode]
 Relative
@@ -1319,10 +1320,10 @@ Replay
 == Повтор
 
 Replay feature is disabled!
-== Повтори відключено!
+== Повтори вимкнено!
 
 Requesting to join the game
-== Запитуємо приєднання до гри
+== Запит на приєднання до гри
 
 Reset
 == Скинути
@@ -1334,7 +1335,7 @@ Reset filter
 == Скинути фільтр
 
 Reset to defaults
-== Скинути
+== Скинути до типових
 
 Restart
 == Перезапустити
@@ -1361,10 +1362,10 @@ SA
 == ПДА
 
 Same clan color in scoreboard
-== Колір співклановців у таблі
+== Колір співклановців у таблиці
 
 Sat.
-== Насич.
+== Насиченість
 
 Save
 == Зберегти
@@ -1373,7 +1374,7 @@ Save ghost
 == Зберігати привида
 
 Save power by lowering refresh rate (higher input latency)
-== Зберігати енергію зниженням частоти кадрів (вища затримка вводу)
+== Економія енергії шляхом зниження частоти оновлення (вища затримка введення)
 
 Save the best demo of each race
 == Зберігати найкраще демо кожного забігу
@@ -1388,7 +1389,7 @@ Score limit
 == Гра до
 
 Scoreboard
-== Табло
+== Таблиця
 
 Screen
 == Екран
@@ -1400,10 +1401,10 @@ Search
 == Пошук
 
 Searching
-== Шукаємо
+== Пошук
 
 Sending initial client info
-== Надсилаємо початкові дані клієнта
+== Надсилання початкових даних клієнта
 
 Server address:
 == Адреса сервера:
@@ -1424,7 +1425,7 @@ Server not full
 == Неповний сервер
 
 Set all to Rifle
-== Встановити так, як у гвинтівки
+== Установити так, як у гвинтівки
 
 Settings
 == Налаштування
@@ -1463,7 +1464,7 @@ Show dummy actions
 == Показувати дії з даммі
 
 Show entities
-== Сутності
+== Показувати сутності
 
 Show finish messages
 == Показувати повідомлення про фініші
@@ -1472,7 +1473,7 @@ Show freeze bars
 == Показувати смугу заморозки
 
 Show friend mark (♥) in name plates
-== Показувати позначку друга (♥) біля ніків
+== Показувати позначку друга (♥) біля псевдонімів
 
 Show friends only
 == Показувати лише з друзями
@@ -1481,10 +1482,10 @@ Show ghost
 == Показувати привида
 
 Show health, shields and ammo
-== Показувати здоров'я, щити й набої
+== Показувати здоров’я, захист і набої
 
 Show hook strength icon indicator
-== Показувати графічний індикатор сили гака
+== Показувати іконку індикатора сили гака
 
 Show hook strength number indicator
 == Показувати числовий індикатор сили гака
@@ -1508,10 +1509,10 @@ Show local time always
 == Завжди показувати місцевий час
 
 Show name plates
-== Показувати ніки
+== Показувати псевдоніми
 
 Show names in chat in team colors
-== Фарбувати ніки в чаті в кольори команд
+== Показувати імена в чаті в кольорах команди
 
 Show only chat messages from friends
 == Показувати лише повідомлення від друзів
@@ -1550,7 +1551,7 @@ Show text entities
 == Текстові сутності
 
 Show tiles layers from BG map
-== Показувати тайли з мапи фону
+== Показувати плитки з мапи фону
 
 Show quads
 == Показувати квади
@@ -1580,13 +1581,13 @@ Slow down the demo
 == Сповільнити
 
 Smooth Dynamic Camera
-== Гладка рухома камера
+== Гладка динамічна камера
 
 Some map images could not be loaded. Check the local console for details.
-== Деякі зображення мапи не завантажилися. Деталі у локальній консолі.
+== Деякі зображення мапи не завантажилися. Див. локальну консоль для подробиць.
 
 Some map sounds could not be loaded. Check the local console for details.
-== Деякі звуки мапи не завантажилися. Деталі у локальній консолі.
+== Деякі звуки мапи не завантажилися. Див. локальну консоль для подробиць.
 
 Something hookable
 == чимось, за що можна зачепитися
@@ -1610,10 +1611,10 @@ Spectate previous
 == Попер. гравець
 
 Spectator mode
-== Режим спостерігача
+== Режим глядача
 
 Spectators
-== Спостерігачі
+== Глядачі
 
 Speed
 == Швидкість
@@ -1767,10 +1768,10 @@ UI Color
 == Колір інтерфейсу
 
 UI controller sens.
-== Чутл. у інтерфейсі
+== Чутливість в інтерфейсі
 
 UI mouse sens.
-== Чутл. у інтерфейсі
+== Чутливість в інтерфейсі
 
 Unable to delete skin
 == Не вдалося видалити скін
@@ -1798,25 +1799,25 @@ Unregister protocol and file extensions
 == Розреєструвати протокол і розширення файлів
 
 Update failed! Check log…
-== Оновлення не вдалося! Перевірте журнал…
+== Помилка оновлення! Перевірте журнал…
 
 Update now
 == Оновити
 
 Updating…
-== Оновлюємо…
+== Оновлення…
 
 Uploading map data to GPU
-== Вивантажуємо дані мапи до відеокарти
+== Вивантаження даних мапи до відеокарти
 
 Use current map as background
-== Використовувати поточну мапу як фон
+== Використовувати поточну мапу як тло
 
 Use high DPI
 == Високий DPI
 
 Use k key to kill (restart), q to pause and watch other players. See settings for other key binds.
-== Натисніть "k", щоб умерти (почати спочатку), "q", щоб спостерігати за іншими гравцями. Інші скорочення дивіться у налаштуваннях.
+== Натисніть «k», щоб умерти (почати спочатку), «q», щоб спостерігати за іншими гравцями. Інші призначення клавіш дивіться у налаштуваннях.
 
 Use old chat style
 == Старий стиль чату
@@ -1885,13 +1886,13 @@ Why are you slowmo replaying to read this?
 == Чому ви переглядаєте це у повторі?
 
 Windowed
-== Віконний
+== У вікні
 
 Windowed borderless
-== Віконний без рамок
+== Вікно без рамок
 
 Windowed fullscreen
-== Віконний повноекранний
+== Вікно на весь екран
 
 Yes
 == Так
@@ -1903,7 +1904,7 @@ You must restart the game for all settings to take effect.
 == Щоб налаштування набрали чинності, перезапустіть гру.
 
 Your nickname '%s' is already used (%d points). Do you still want to use it?
-== Нікнейм '%s' вже зайнято (%d балів). Все ще хочете використовувати його?
+== Ваш псевдонім «%s» вже зайнято (%d балів). Усе ще хочете використовувати його?
 
 Your skin
 == Ваш скін

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -191,6 +191,26 @@ void CGameClient::OnConsoleInit()
 	Console()->Chain("player_color_feet", ConchainSpecialInfoupdate, this);
 	Console()->Chain("player_skin", ConchainSpecialInfoupdate, this);
 
+	Console()->Chain("player7_skin", ConchainSpecialInfoupdate, this);
+	Console()->Chain("player7_skin_body", ConchainSpecialInfoupdate, this);
+	Console()->Chain("player7_skin_marking", ConchainSpecialInfoupdate, this);
+	Console()->Chain("player7_skin_decoration", ConchainSpecialInfoupdate, this);
+	Console()->Chain("player7_skin_hands", ConchainSpecialInfoupdate, this);
+	Console()->Chain("player7_skin_feet", ConchainSpecialInfoupdate, this);
+	Console()->Chain("player7_skin_eyes", ConchainSpecialInfoupdate, this);
+	Console()->Chain("player7_color_body", ConchainSpecialInfoupdate, this);
+	Console()->Chain("player7_color_marking", ConchainSpecialInfoupdate, this);
+	Console()->Chain("player7_color_decoration", ConchainSpecialInfoupdate, this);
+	Console()->Chain("player7_color_hands", ConchainSpecialInfoupdate, this);
+	Console()->Chain("player7_color_feet", ConchainSpecialInfoupdate, this);
+	Console()->Chain("player7_color_eyes", ConchainSpecialInfoupdate, this);
+	Console()->Chain("player7_use_custom_color_body", ConchainSpecialInfoupdate, this);
+	Console()->Chain("player7_use_custom_color_marking", ConchainSpecialInfoupdate, this);
+	Console()->Chain("player7_use_custom_color_decoration", ConchainSpecialInfoupdate, this);
+	Console()->Chain("player7_use_custom_color_hands", ConchainSpecialInfoupdate, this);
+	Console()->Chain("player7_use_custom_color_feet", ConchainSpecialInfoupdate, this);
+	Console()->Chain("player7_use_custom_color_eyes", ConchainSpecialInfoupdate, this);
+
 	Console()->Chain("dummy_name", ConchainSpecialDummyInfoupdate, this);
 	Console()->Chain("dummy_clan", ConchainSpecialDummyInfoupdate, this);
 	Console()->Chain("dummy_country", ConchainSpecialDummyInfoupdate, this);
@@ -198,6 +218,26 @@ void CGameClient::OnConsoleInit()
 	Console()->Chain("dummy_color_body", ConchainSpecialDummyInfoupdate, this);
 	Console()->Chain("dummy_color_feet", ConchainSpecialDummyInfoupdate, this);
 	Console()->Chain("dummy_skin", ConchainSpecialDummyInfoupdate, this);
+
+	Console()->Chain("dummy7_skin", ConchainSpecialDummyInfoupdate, this);
+	Console()->Chain("dummy7_skin_body", ConchainSpecialDummyInfoupdate, this);
+	Console()->Chain("dummy7_skin_marking", ConchainSpecialDummyInfoupdate, this);
+	Console()->Chain("dummy7_skin_decoration", ConchainSpecialDummyInfoupdate, this);
+	Console()->Chain("dummy7_skin_hands", ConchainSpecialDummyInfoupdate, this);
+	Console()->Chain("dummy7_skin_feet", ConchainSpecialDummyInfoupdate, this);
+	Console()->Chain("dummy7_skin_eyes", ConchainSpecialDummyInfoupdate, this);
+	Console()->Chain("dummy7_color_body", ConchainSpecialDummyInfoupdate, this);
+	Console()->Chain("dummy7_color_marking", ConchainSpecialDummyInfoupdate, this);
+	Console()->Chain("dummy7_color_decoration", ConchainSpecialDummyInfoupdate, this);
+	Console()->Chain("dummy7_color_hands", ConchainSpecialDummyInfoupdate, this);
+	Console()->Chain("dummy7_color_feet", ConchainSpecialDummyInfoupdate, this);
+	Console()->Chain("dummy7_color_eyes", ConchainSpecialDummyInfoupdate, this);
+	Console()->Chain("dummy7_use_custom_color_body", ConchainSpecialDummyInfoupdate, this);
+	Console()->Chain("dummy7_use_custom_color_marking", ConchainSpecialDummyInfoupdate, this);
+	Console()->Chain("dummy7_use_custom_color_decoration", ConchainSpecialDummyInfoupdate, this);
+	Console()->Chain("dummy7_use_custom_color_hands", ConchainSpecialDummyInfoupdate, this);
+	Console()->Chain("dummy7_use_custom_color_feet", ConchainSpecialDummyInfoupdate, this);
+	Console()->Chain("dummy7_use_custom_color_eyes", ConchainSpecialDummyInfoupdate, this);
 
 	Console()->Chain("cl_skin_download_url", ConchainRefreshSkins, this);
 	Console()->Chain("cl_skin_community_download_url", ConchainRefreshSkins, this);

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -8606,12 +8606,20 @@ void CEditor::HandleWriterFinishJobs()
 	{
 		CServerInfo CurrentServerInfo;
 		Client()->GetServerInfo(&CurrentServerInfo);
-		NETADDR ServerAddr = Client()->ServerAddress();
-		const unsigned char aIpv4Localhost[16] = {127, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-		const unsigned char aIpv6Localhost[16] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1};
 
-		// and if we're on localhost
-		if(!mem_comp(ServerAddr.ip, aIpv4Localhost, sizeof(aIpv4Localhost)) || !mem_comp(ServerAddr.ip, aIpv6Localhost, sizeof(aIpv6Localhost)))
+		NETADDR pAddr = Client()->ServerAddress();
+		char aAddrStr[NETADDR_MAXSTRSIZE];
+		net_addr_str(&Client()->ServerAddress(), aAddrStr, sizeof(aAddrStr), true);
+
+		// and if we're on a local address
+		bool IsLocalAddress = false;
+		if(pAddr.ip[0] == 127 || pAddr.ip[0] == 10 || (pAddr.ip[0] == 192 && pAddr.ip[1] == 168) || (pAddr.ip[0] == 172 && (pAddr.ip[1] >= 16 && pAddr.ip[1] <= 31)))
+			IsLocalAddress = true;
+
+		if(str_startswith(aAddrStr, "[fe80:") || str_startswith(aAddrStr, "[::1"))
+			IsLocalAddress = true;
+
+		if(IsLocalAddress)
 		{
 			char aMapName[128];
 			IStorage::StripPathAndExtension(pJob->GetRealFileName(), aMapName, sizeof(aMapName));

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -120,7 +120,7 @@ bool CCharacter::Spawn(CPlayer *pPlayer, vec2 Pos)
 		if(GameServer()->m_apSavedTees[m_pPlayer->GetCid()])
 		{
 			GameServer()->m_apSavedTees[m_pPlayer->GetCid()]->Load(m_pPlayer->GetCharacter(), Team);
-			delete GameServer()->m_apSavedTees[Team];
+			delete GameServer()->m_apSavedTees[m_pPlayer->GetCid()];
 			GameServer()->m_apSavedTees[m_pPlayer->GetCid()] = nullptr;
 		}
 	}

--- a/src/game/version.h
+++ b/src/game/version.h
@@ -3,7 +3,7 @@
 #ifndef GAME_VERSION_H
 #define GAME_VERSION_H
 #ifndef GAME_RELEASE_VERSION
-#define GAME_RELEASE_VERSION "18.4"
+#define GAME_RELEASE_VERSION "18.5"
 #endif
 
 // teeworlds
@@ -13,7 +13,7 @@
 #define GAME_NETVERSION7 "0.7 802f1be60a05665f"
 
 // ddnet
-#define DDNET_VERSION_NUMBER 18040
+#define DDNET_VERSION_NUMBER 18050
 extern const char *GIT_SHORTREV_HASH;
 #define GAME_NAME "DDNet"
 #endif


### PR DESCRIPTION
DDNet 18.5 is scheduled to release in 7 days, assuming no bad bugs are found. Please test the Release Candidate to prevent problems being only discovered after release. Report bugs in the #bugs channel on DDNet Discord or directly on Github:

- Windows 64bit: https://ddnet.tw/downloads/DDNet-18.5-rc3-win64.zip
- Windows ARM: https://ddnet.tw/downloads/DDNet-18.5-rc3-win-arm64.zip
- Windows 32bit: https://ddnet.tw/downloads/DDNet-18.5-rc3-win32.zip
- Linux x86: https://ddnet.tw/downloads/DDNet-18.5-rc3-linux_x86.tar.xz
- Linux x86-64: https://ddnet.tw/downloads/DDNet-18.5-rc3-linux_x86_64.tar.xz
- macOS: https://ddnet.tw/downloads/DDNet-18.5-rc3-macos.dmg

You can also test the release candidate in Steam by clicking on Settings -> Properties -> Betas and opting into the Release Candidates. This will automatically update you to a new release candidate when it is available, and to the next release when no new candidate is available. So you can always leave this setting enabled to help us test new releases earlier.
![0 7](https://github.com/user-attachments/assets/03e724c4-69db-4608-a5c0-d96397fad3dc)

https://github.com/user-attachments/assets/58d2a7f4-f7d5-450d-811b-a10ea99ea592


https://github.com/user-attachments/assets/d19163c5-44aa-4fcc-8fc7-ee926ccb32e4


https://github.com/user-attachments/assets/a0939595-a897-4f58-9b51-676b2fb7dc44


https://github.com/user-attachments/assets/9e656a78-2b28-4747-9289-7d1a7c259d98


The following changes are included, ideally test their behavior specifically. But just playing as you do normally also helps:

- [Client] **Support connecting to Teeworlds 0.7 servers [ChillerDragon]**
- [Client] **Color speed in hud based on increase or decrease [ChillerDragon]**
- [Client] **Spawn confetti when connecting on your DDNet birthday [furo321]**
- [Client] **ARM64 Windows support [SchrodingerZhu]**
- [Client] **Add a popup for picking a map for background entities setting [furo321]**
- [Client] **Support composite binds with + commands, fix handling of composite binds with F1-F24 keys [Robyt3]**
- [Server] **Add support for directories with add_map_votes [furo321]**
- [Server] **Add support for triggering map sounds [Bamcane]**
- [Editor&Server] **Add hot_reload cmmand to reload map while preserving state [furo321]**
- [Client] Show server info in password popup [dobrykafe]
- [Client] Spectator clans in scoreboard [gerdoe-jr]
- [Client] New lock indicator [catseyenebulous]
- [Client] Improve cl_show_ids [Robyt3]
- [Client] Improve dummy connecting button and error handling [Robyt3]
- [Client] Fix 'auto' GPU identification on hybrid GPU systems [DynamoFox]
- [Client] Check API version before adding GPU to GPU list [Jupeyy]
- [Client] Use text containers to render movement information [MilkeeyCat]
- [Client] Work on improving Android support [Robyt3]
- [Client] Remove multi-line chat [MilkeeyCat]
- [Client] 128 player support in scoreboard and spectator UI [Robyt3]
- [Client] Also trim scoreboard search strings in highlights
- [Client] Use same Red/Blue team colors for score HUD as for scoreboard [Robyt3]
- [Client] Fix CSV header being written multiple times to ddnet-saves.txt [Robyt3]
- [Client] Fix memory leak of non-RGBA image data, clear all image info [Robyt3]
- [Client] Smoother menu checker background scrolling on loading screens [Robyt3]
- [Client] Fix invalid team count in scoreboard for split teams [archimede67]
- [Client] Only activate double-clicks with left mouse button again [Robyt3]
- [Client] Show warning when connect address cannot be resolved [Robyt3]
- [Client] Show game menu buttons again, even in 5:4, when not on a red/blue-team server
- [Client] Fix debug HUD units [Jupeyy]
- [Client] Improve bans rcon command pagination [Rei-Tw]
- [Client] Increase max command length in console [ChillerDragon]
- [Client] Scale target position when spectating [Matodor]
- [Client] Make macOS semaphore names more unique, improve assertion [Robyt3]
- [Client] Fix save code not being censored in streamer mode [ChillerDragon]
- [Client] Don't allow input in console while it is opening/closing [furo321]
- [Client] Allow reloading current background entities map [bencie]
- [Client] Speed demo up with mouse scroll only if menu is active [Anime-pdf]
- [Editor] Add button to collapse/expand all groups [furo321]
- [Editor] Transfer server settings while using append [furo321]
- [Editor] Fix editor properties not being clamped on + and - button click [ChillerDragon]
- [Client&Server] Fix UDP socket creation/cleanup if opening IPv6 socket fails [Robyt3]
- [Server] Add /whispers to disable whipers (similar to /dnd)
- [Server] Disallow moving authed players to spec
- [Server] Fix practice finish time [StormA]
- [Server] Add error message when trying to /swap on forced solo server [Robyt3]
- [Server] Savegame fixes [Learath2]
- [Server] Disallow saving with draggers active
- [Server] Only apply DNSBL bans once when player joins [Robyt3]
- [Server] Don't show "you've been banned" for VPN bans [heinrich5991]
- [Server] Handle dnsbl and other non-critical stuff only on new ticks
- [Server] Don't keep state of teammate in team0mode after death [furo321]
- [Tooling] Validate language files for … and non-matching formatters in CI [furo321]