### PR TITLE
Add Android shortcuts for launching with Vulkan/OpenGL

### DIFF
--- a/scripts/android/cmake_android.sh
+++ b/scripts/android/cmake_android.sh
@@ -197,6 +197,7 @@ cd "${BUILD_FOLDER}" || exit 1
 
 mkdir -p src/main
 mkdir -p src/main/res/values
+mkdir -p src/main/res/xml
 mkdir -p src/main/res/mipmap
 
 function copy_dummy_files() {
@@ -213,6 +214,7 @@ copy_dummy_files scripts/android/files/proguard-rules.pro proguard-rules.pro
 copy_dummy_files scripts/android/files/settings.gradle settings.gradle
 copy_dummy_files scripts/android/files/AndroidManifest.xml src/main/AndroidManifest.xml
 copy_dummy_files scripts/android/files/res/values/strings.xml src/main/res/values/strings.xml
+copy_dummy_files scripts/android/files/res/xml/shortcuts.xml src/main/res/xml/shortcuts.xml
 copy_dummy_files other/icons/DDNet_256x256x32.png src/main/res/mipmap/ic_launcher.png
 copy_dummy_files other/icons/DDNet_256x256x32.png src/main/res/mipmap/ic_launcher_round.png
 

--- a/scripts/android/files/AndroidManifest.xml
+++ b/scripts/android/files/AndroidManifest.xml
@@ -30,7 +30,8 @@
 			android:name="org.ddnet.client.NativeMain"
 			android:exported="true"
 			android:configChanges="orientation|screenSize|screenLayout|keyboardHidden"
-			android:screenOrientation="landscape">
+			android:screenOrientation="landscape"
+			android:launchMode="singleInstance">
 			<intent-filter>
 				<action android:name="android.intent.action.MAIN" />
 				<category android:name="android.intent.category.LAUNCHER" />
@@ -38,6 +39,9 @@
 			<meta-data
 				android:name="android.app.lib_name"
 				android:value="DDNet" />
+			<meta-data
+				android:name="android.app.shortcuts"
+				android:resource="@xml/shortcuts" />
 		</activity>
 	</application>
 </manifest>

--- a/scripts/android/files/build.sh
+++ b/scripts/android/files/build.sh
@@ -51,6 +51,8 @@ sed -i "s/TW_VERSION_NAME/${TW_VERSION_NAME}/g" build.gradle
 
 sed -i "s/DDNet/${APK_BASENAME}/g" src/main/res/values/strings.xml
 
+sed -i "s/org.ddnet.client/${APK_PACKAGE_NAME}/g" src/main/res/xml/shortcuts.xml
+
 sed -i "s/\"DDNet\"/\"${APK_BASENAME}\"/g" src/main/AndroidManifest.xml
 sed -i "s/org.ddnet.client/${APK_PACKAGE_NAME}/g" src/main/AndroidManifest.xml
 

--- a/scripts/android/files/java/org/ddnet/client/NativeMain.java
+++ b/scripts/android/files/java/org/ddnet/client/NativeMain.java
@@ -10,6 +10,8 @@ public class NativeMain extends SDLActivity {
 
 	private static final int COMMAND_RESTART_APP = SDLActivity.COMMAND_USER + 1;
 
+	private String[] launchArguments = new String[0];
+
 	@Override
 	protected String[] getLibraries() {
 		return new String[] {
@@ -20,7 +22,25 @@ public class NativeMain extends SDLActivity {
 	@Override
 	public void onCreate(Bundle SavedInstanceState) {
 		setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
+
+		Intent intent = getIntent();
+		if(intent != null) {
+			String gfxBackend = intent.getStringExtra("gfx-backend");
+			if(gfxBackend != null) {
+				if(gfxBackend.equals("Vulkan")) {
+					launchArguments = new String[] {"gfx_backend Vulkan"};
+				} else if(gfxBackend.equals("OpenGL")) {
+					launchArguments = new String[] {"gfx_backend OpenGL"};
+				}
+			}
+		}
+
 		super.onCreate(SavedInstanceState);
+	}
+
+	@Override
+	protected String[] getArguments() {
+		return launchArguments;
 	}
 
 	@Override
@@ -29,8 +49,8 @@ public class NativeMain extends SDLActivity {
 			restartApp();
 			return true;
 		}
-        return false;
-    }
+		return false;
+	}
 
 	private void restartApp() {
 		Intent restartIntent =

--- a/scripts/android/files/res/values/strings.xml
+++ b/scripts/android/files/res/values/strings.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">DDNet</string>
+	<string name="app_name">DDNet</string>
+	<string name="shortcut_play_vulkan_short">Play (Vulkan)</string>
+	<string name="shortcut_play_opengl_short">Play (OpenGL)</string>
 </resources>

--- a/scripts/android/files/res/xml/shortcuts.xml
+++ b/scripts/android/files/res/xml/shortcuts.xml
@@ -1,0 +1,30 @@
+<shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
+	<shortcut
+		android:shortcutId="play-vulkan"
+		android:enabled="true"
+		android:icon="@mipmap/ic_launcher"
+		android:shortcutShortLabel="@string/shortcut_play_vulkan_short">
+		<intent
+			android:action="android.intent.action.VIEW"
+			android:targetPackage="org.ddnet.client"
+			android:targetClass="org.ddnet.client.NativeMain">
+			<extra
+				android:name="gfx-backend"
+				android:value="Vulkan" />
+		</intent>
+	</shortcut>
+	<shortcut
+		android:shortcutId="play-opengl"
+		android:enabled="true"
+		android:icon="@mipmap/ic_launcher"
+		android:shortcutShortLabel="@string/shortcut_play_opengl_short">
+		<intent
+			android:action="android.intent.action.VIEW"
+			android:targetPackage="org.ddnet.client"
+			android:targetClass="org.ddnet.client.NativeMain">
+			<extra
+				android:name="gfx-backend"
+				android:value="OpenGL" />
+		</intent>
+	</shortcut>
+</shortcuts>


### PR DESCRIPTION
Define shortcuts to launch the client with either Vulkan or OpenGL graphics backend, which can be accessed by long-pressing the app icon on the home screen. This feature is available for Android 7.1 and newer.

![Screenshot](https://github.com/user-attachments/assets/3ab45244-45fe-41a9-bb77-ec89330baf9c)

## Checklist

- [X] Tested the change ingame
- [X] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
