### PR TITLE
Add validation for chat and console command arguments

### DIFF
--- a/src/engine/console.h
+++ b/src/engine/console.h
@@ -53,7 +53,7 @@ public:
 		virtual int GetInteger(unsigned Index) const = 0;
 		virtual float GetFloat(unsigned Index) const = 0;
 		virtual const char *GetString(unsigned Index) const = 0;
-		virtual ColorHSLA GetColor(unsigned Index, bool Light) const = 0;
+		virtual std::optional<ColorHSLA> GetColor(unsigned Index, bool Light) const = 0;
 
 		virtual void RemoveArgument(unsigned Index) = 0;
 

--- a/src/engine/shared/console.cpp
+++ b/src/engine/shared/console.cpp
@@ -40,22 +40,29 @@ float CConsole::CResult::GetFloat(unsigned Index) const
 	return str_tofloat(m_apArgs[Index]);
 }
 
-ColorHSLA CConsole::CResult::GetColor(unsigned Index, bool Light) const
+std::optional<ColorHSLA> CConsole::CResult::GetColor(unsigned Index, bool Light) const
 {
 	if(Index >= m_NumArgs)
-		return ColorHSLA(0, 0, 0);
+		return std::nullopt;
 
 	const char *pStr = m_apArgs[Index];
 	if(str_isallnum(pStr) || ((pStr[0] == '-' || pStr[0] == '+') && str_isallnum(pStr + 1))) // Teeworlds Color (Packed HSL)
 	{
-		const ColorHSLA Hsla = ColorHSLA(str_toulong_base(pStr, 10), true);
+		unsigned long Value = str_toulong_base(pStr, 10);
+		if(Value == std::numeric_limits<unsigned long>::max())
+			return std::nullopt;
+		const ColorHSLA Hsla = ColorHSLA(Value, true);
 		if(Light)
 			return Hsla.UnclampLighting();
 		return Hsla;
 	}
 	else if(*pStr == '$') // Hex RGB/RGBA
 	{
-		return color_cast<ColorHSLA>(color_parse<ColorRGBA>(pStr + 1).value_or(ColorRGBA(0.0f, 0.0f, 0.0f, 1.0f)));
+		auto ParsedColor = color_parse<ColorRGBA>(pStr + 1);
+		if(ParsedColor)
+			return color_cast<ColorHSLA>(ParsedColor.value());
+		else
+			return std::nullopt;
 	}
 	else if(!str_comp_nocase(pStr, "red"))
 		return ColorHSLA(0.0f / 6.0f, 1, .5f);
@@ -76,7 +83,7 @@ ColorHSLA CConsole::CResult::GetColor(unsigned Index, bool Light) const
 	else if(!str_comp_nocase(pStr, "black"))
 		return ColorHSLA(0, 0, 0);
 
-	return ColorHSLA(0, 0, 0);
+	return std::nullopt;
 }
 
 const IConsole::CCommandInfo *CConsole::CCommand::NextCommandInfo(int AccessLevel, int FlagMask) const
@@ -129,12 +136,12 @@ int CConsole::ParseStart(CResult *pResult, const char *pString, int Length)
 	return 0;
 }
 
-int CConsole::ParseArgs(CResult *pResult, const char *pFormat)
+int CConsole::ParseArgs(CResult *pResult, const char *pFormat, FCommandCallback pfnCallback)
 {
 	char Command = *pFormat;
 	char *pStr;
 	int Optional = 0;
-	int Error = 0;
+	int Error = PARSEARGS_OK;
 
 	pResult->ResetVictim();
 
@@ -155,7 +162,7 @@ int CConsole::ParseArgs(CResult *pResult, const char *pFormat)
 			{
 				if(!Optional)
 				{
-					Error = 1;
+					Error = PARSEARGS_MISSING_VALUE;
 					break;
 				}
 
@@ -191,7 +198,7 @@ int CConsole::ParseArgs(CResult *pResult, const char *pFormat)
 							pStr++; // skip due to escape
 					}
 					else if(pStr[0] == 0)
-						return 1; // return error
+						return PARSEARGS_MISSING_VALUE; // return error
 
 					*pDst = *pStr;
 					pDst++;
@@ -215,19 +222,39 @@ int CConsole::ParseArgs(CResult *pResult, const char *pFormat)
 
 				if(Command == 'r') // rest of the string
 					break;
-				else if(Command == 'v') // validate victim
-					pStr = str_skip_to_whitespace(pStr);
-				else if(Command == 'i') // validate int
-					pStr = str_skip_to_whitespace(pStr);
-				else if(Command == 'f') // validate float
-					pStr = str_skip_to_whitespace(pStr);
-				else if(Command == 's') // validate string
+				else if(Command == 'v' || Command == 'i' || Command == 'f' || Command == 's')
 					pStr = str_skip_to_whitespace(pStr);
 
 				if(pStr[0] != 0) // check for end of string
 				{
 					pStr[0] = 0;
 					pStr++;
+				}
+
+				// validate args
+				if(Command == 'i')
+				{
+					// don't validate colors here
+					if(pfnCallback != &SColorConfigVariable::CommandCallback)
+					{
+						int Value;
+						if(!str_toint(pResult->GetString(pResult->NumArguments() - 1), &Value) ||
+							Value == std::numeric_limits<int>::max() || Value == std::numeric_limits<int>::min())
+						{
+							Error = PARSEARGS_INVALID_INTEGER;
+							break;
+						}
+					}
+				}
+				else if(Command == 'f')
+				{
+					float Value;
+					if(!str_tofloat(pResult->GetString(pResult->NumArguments() - 1), &Value) ||
+						Value == std::numeric_limits<float>::max() || Value == std::numeric_limits<float>::min())
+					{
+						Error = PARSEARGS_INVALID_FLOAT;
+						break;
+					}
 				}
 
 				if(pVictim)
@@ -487,10 +514,15 @@ void CConsole::ExecuteLineStroked(int Stroke, const char *pStr, int ClientId, bo
 
 				if(Stroke || IsStrokeCommand)
 				{
-					if(ParseArgs(&Result, pCommand->m_pParams))
+					if(int Error = ParseArgs(&Result, pCommand->m_pParams, pCommand->m_pfnCallback))
 					{
-						char aBuf[TEMPCMD_NAME_LENGTH + TEMPCMD_PARAMS_LENGTH + 32];
-						str_format(aBuf, sizeof(aBuf), "Invalid arguments. Usage: %s %s", pCommand->m_pName, pCommand->m_pParams);
+						char aBuf[CMDLINE_LENGTH + 64];
+						if(Error == PARSEARGS_INVALID_INTEGER)
+							str_format(aBuf, sizeof(aBuf), "%s is not a valid integer.", Result.GetString(Result.NumArguments() - 1));
+						else if(Error == PARSEARGS_INVALID_FLOAT)
+							str_format(aBuf, sizeof(aBuf), "%s is not a valid decimal number.", Result.GetString(Result.NumArguments() - 1));
+						else
+							str_format(aBuf, sizeof(aBuf), "Invalid arguments. Usage: %s %s", pCommand->m_pName, pCommand->m_pParams);
 						Print(OUTPUT_LEVEL_STANDARD, "chatresp", aBuf);
 					}
 					else if(m_StoreCommands && pCommand->m_Flags & CFGFLAG_STORE)

--- a/src/engine/shared/console.h
+++ b/src/engine/shared/console.h
@@ -115,7 +115,7 @@ class CConsole : public IConsole
 		const char *GetString(unsigned Index) const override;
 		int GetInteger(unsigned Index) const override;
 		float GetFloat(unsigned Index) const override;
-		ColorHSLA GetColor(unsigned Index, bool Light) const override;
+		std::optional<ColorHSLA> GetColor(unsigned Index, bool Light) const override;
 
 		void RemoveArgument(unsigned Index) override
 		{
@@ -144,7 +144,16 @@ class CConsole : public IConsole
 	};
 
 	int ParseStart(CResult *pResult, const char *pString, int Length);
-	int ParseArgs(CResult *pResult, const char *pFormat);
+
+	enum
+	{
+		PARSEARGS_OK = 0,
+		PARSEARGS_MISSING_VALUE,
+		PARSEARGS_INVALID_INTEGER,
+		PARSEARGS_INVALID_FLOAT,
+	};
+
+	int ParseArgs(CResult *pResult, const char *pFormat, FCommandCallback pfnCallback = 0);
 
 	/*
 	this function will set pFormat to the next parameter (i,s,r,v,?) it contains and

--- a/src/rust-bridge/cpp/console.cpp
+++ b/src/rust-bridge/cpp/console.cpp
@@ -109,8 +109,8 @@ void cxxbridge1$IConsole_IResult$GetString(const ::IConsole_IResult &self, ::std
 }
 
 void cxxbridge1$IConsole_IResult$GetColor(const ::IConsole_IResult &self, ::std::uint32_t Index, bool Light, ::ColorHSLA *return$) noexcept {
-  ::ColorHSLA (::IConsole_IResult::*GetColor$)(::std::uint32_t, bool) const = &::IConsole_IResult::GetColor;
-  new (return$) ::ColorHSLA((self.*GetColor$)(Index, Light));
+  std::optional<::ColorHSLA> (::IConsole_IResult::*GetColor$)(::std::uint32_t, bool) const = &::IConsole_IResult::GetColor;
+  new(return$)::ColorHSLA((self.*GetColor$)(Index, Light).value_or(::ColorHSLA(0, 0, 0)));
 }
 
 ::std::int32_t cxxbridge1$IConsole_IResult$NumArguments(const ::IConsole_IResult &self) noexcept {


### PR DESCRIPTION
Closes #8594

Integer in console :
![image](https://github.com/user-attachments/assets/b9b28eed-b1da-4449-a90b-217153cdac20)

Float with multiple arguments:
![image](https://github.com/user-attachments/assets/64575a69-8b25-4a01-812d-7fee879b4e58)
/tpxy 3.2 4 - works with ints
/tpxy 3.2 -32 - works with negative numbers

Color validation:
![image](https://github.com/user-attachments/assets/593fb9a8-8884-412c-a4de-673ae996e3cc)


Old validation checks preserved:
![image](https://github.com/user-attachments/assets/80d11b10-ffc1-47e7-82a8-d5ab2fdfc569)


<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
