### PR TITLE
Add Spectator Cursor

### DIFF
--- a/datasrc/network.py
+++ b/datasrc/network.py
@@ -378,6 +378,15 @@ Objects = [
 	NetEventEx("MapSoundWorld:Common", "map-sound-world@netevent.ddnet.org", [
 		NetIntAny("m_SoundId"),
 	]),
+
+	# Spectating cursor
+	NetObjectEx("SpecCursor", "spec-cursor@netobj.ddnet.org", [
+		NetIntAny("m_Weapon"),
+		NetIntAny("m_TargetX"),
+		NetIntAny("m_TargetY"),
+		NetIntAny("m_DeltaPrevTargetX"),
+		NetIntAny("m_DeltaPrevTargetY"),
+	]),
 ]
 
 Messages = [

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -73,6 +73,9 @@ MACRO_CONFIG_INT(ClShowfps, cl_showfps, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, 
 MACRO_CONFIG_INT(ClShowpred, cl_showpred, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show ingame prediction time in milliseconds")
 MACRO_CONFIG_INT(ClEyeWheel, cl_eye_wheel, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show eye wheel along together with emotes")
 MACRO_CONFIG_INT(ClEyeDuration, cl_eye_duration, 999999, 1, 999999, CFGFLAG_CLIENT | CFGFLAG_SAVE, "How long the eyes emotes last")
+MACRO_CONFIG_INT(ClSpecCursor, cl_spec_cursor, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Enable the cursor of spectating player if available")
+MACRO_CONFIG_INT(ClSpecCursorInterp, cl_spec_cursor_interp, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Interpolate the cursor of spectating player")
+MACRO_CONFIG_INT(ClSpecCursorDemo, cl_spec_cursor_demo, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show cursor during demo playback if available")
 
 MACRO_CONFIG_INT(ClAirjumpindicator, cl_airjumpindicator, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show the air jump indicator")
 MACRO_CONFIG_INT(ClThreadsoundloading, cl_threadsoundloading, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Load sound files threaded")

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -585,16 +585,35 @@ void CHud::RenderTeambalanceWarning()
 
 void CHud::RenderCursor()
 {
-	if(!m_pClient->m_Snap.m_pLocalCharacter || Client()->State() == IClient::STATE_DEMOPLAYBACK)
+	int CurWeapon;
+	vec2 TargetPos;
+
+	if(Client()->State() != IClient::STATE_DEMOPLAYBACK && m_pClient->m_Snap.m_pLocalCharacter)
+	{
+		// render local cursor
+		CurWeapon = m_pClient->m_Snap.m_pLocalCharacter->m_Weapon % NUM_WEAPONS;
+		TargetPos = m_pClient->m_Controls.m_aTargetPos[g_Config.m_ClDummy];
+	}
+	else if(g_Config.m_ClSpecCursor && m_pClient->m_Snap.m_pSpecCursor && m_pClient->m_Snap.m_SpecInfo.m_Active && m_pClient->m_Snap.m_SpecInfo.m_SpectatorId != SPEC_FREEVIEW)
+	{
+		// render spec cursor
+		CurWeapon = m_pClient->m_Snap.m_pSpecCursor->m_Weapon % NUM_WEAPONS;
+		TargetPos = m_pClient->m_Snap.m_SpecInfo.m_Position + m_pClient->m_Snap.m_DisplayCursorPos;
+	}
+	else if(g_Config.m_ClSpecCursorDemo && m_pClient->m_Snap.m_pSpecCursor && Client()->State() == IClient::STATE_DEMOPLAYBACK && m_pClient->m_Snap.m_pLocalCharacter)
+	{
+		CurWeapon = m_pClient->m_Snap.m_pLocalCharacter->m_Weapon % NUM_WEAPONS;
+		TargetPos = m_pClient->m_LocalCharacterPos + m_pClient->m_Snap.m_DisplayCursorPos;
+	}
+	else
+	{
 		return;
+	}
 
 	RenderTools()->MapScreenToInterface(m_pClient->m_Camera.m_Center.x, m_pClient->m_Camera.m_Center.y);
-
-	// render cursor
-	int CurWeapon = m_pClient->m_Snap.m_pLocalCharacter->m_Weapon % NUM_WEAPONS;
 	Graphics()->SetColor(1.f, 1.f, 1.f, 1.f);
 	Graphics()->TextureSet(m_pClient->m_GameSkin.m_aSpriteWeaponCursors[CurWeapon]);
-	Graphics()->RenderQuadContainerAsSprite(m_HudQuadContainerIndex, m_aCursorOffset[CurWeapon], m_pClient->m_Controls.m_aTargetPos[g_Config.m_ClDummy].x, m_pClient->m_Controls.m_aTargetPos[g_Config.m_ClDummy].y);
+	Graphics()->RenderQuadContainerAsSprite(m_HudQuadContainerIndex, m_aCursorOffset[CurWeapon], TargetPos.x, TargetPos.y);
 }
 
 void CHud::PrepareAmmoHealthAndArmorQuads()

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -313,6 +313,8 @@ public:
 		const CNetObj_PlayerInfo *m_pLocalInfo;
 		const CNetObj_SpectatorInfo *m_pSpectatorInfo;
 		const CNetObj_SpectatorInfo *m_pPrevSpectatorInfo;
+		const CNetObj_SpecCursor *m_pSpecCursor;
+		const CNetObj_SpecCursor *m_pPrevSpecCursor;
 		const CNetObj_Flag *m_apFlags[2];
 		const CNetObj_GameInfo *m_pGameInfoObj;
 		const CNetObj_GameData *m_pGameDataObj;
@@ -337,6 +339,9 @@ public:
 			bool m_UsePosition;
 			vec2 m_Position;
 		} m_SpecInfo;
+
+		// cursor data
+		vec2 m_DisplayCursorPos;
 
 		//
 		struct CCharacterInfo
@@ -794,6 +799,7 @@ private:
 	int m_aShowOthers[NUM_DUMMIES];
 
 	void UpdatePrediction();
+	void UpdateSpectatorCursor();
 	void UpdateRenderedCharacters();
 
 	int m_aLastUpdateTick[MAX_CLIENTS] = {0};

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -1170,6 +1170,24 @@ void CCharacter::SnapCharacter(int SnappingClient, int Id)
 	}
 }
 
+void CCharacter::SnapSpecCursor(int SnappingClient)
+{
+	CNetObj_SpecCursor *pCursorInfo = static_cast<CNetObj_SpecCursor *>(Server()->SnapNewItem(NETOBJTYPE_SPECCURSOR, SnappingClient, sizeof(CNetObj_SpecCursor)));
+	if(pCursorInfo)
+	{
+		pCursorInfo->m_Weapon = GetActiveWeapon();
+
+		pCursorInfo->m_TargetX = m_Input.m_TargetX;
+		pCursorInfo->m_TargetY = m_Input.m_TargetY;
+
+		/*
+		 	ensure info density at SERVER_TICK_SPEED even if sv_high_bandwidth is 0
+		*/
+		pCursorInfo->m_DeltaPrevTargetX = m_PrevInput.m_TargetX - m_Input.m_TargetX;
+		pCursorInfo->m_DeltaPrevTargetY = m_PrevInput.m_TargetY - m_Input.m_TargetY;
+	}
+}
+
 bool CCharacter::CanSnapCharacter(int SnappingClient)
 {
 	if(SnappingClient == SERVER_DEMO_CLIENT)

--- a/src/game/server/entities/character.h
+++ b/src/game/server/entities/character.h
@@ -100,6 +100,8 @@ public:
 	void AddVelocity(vec2 Addition);
 	void ApplyMoveRestrictions();
 
+	void SnapSpecCursor(int SnappingClient);
+
 private:
 	// player controlling this character
 	class CPlayer *m_pPlayer;

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -410,6 +410,29 @@ void CPlayer::Snap(int SnappingClient)
 		}
 	}
 
+	if(m_ClientId == SnappingClient && !Server()->IsSixup(SnappingClient))
+	{
+		/*
+			Snap spectator cursors for local players by default.
+		 	The information is not visible to local player unless they recorded demo, which the spectator cursor will act as local player's cursor.
+		 */
+		CPlayer *pCursorOwner = this;
+
+		if(m_Team == TEAM_SPECTATORS || IsPaused())
+		{
+			pCursorOwner = m_SpectatorId != SPEC_FREEVIEW ? GameServer()->m_apPlayers[m_SpectatorId] : NULL;
+		}
+
+		if(pCursorOwner)
+		{
+			CCharacter *pCursorOwnerChar = pCursorOwner->GetCharacter();
+			if(pCursorOwnerChar && pCursorOwnerChar->IsAlive())
+			{
+				pCursorOwnerChar->SnapSpecCursor(m_ClientId);
+			}
+		}
+	}
+
 	CNetObj_DDNetPlayer *pDDNetPlayer = Server()->SnapNewItem<CNetObj_DDNetPlayer>(id);
 	if(!pDDNetPlayer)
 		return;


### PR DESCRIPTION
Re-implements #3262

Implications:
* Server protocol
* Increased bandwidth per player (at least it is not player^player)
* No server demo support

Added settings: `cl_spec_cursor`, `cl_spec_cursor_interp`, `cl_spec_cursor_demo`

SpecCursor snapshot contains cursor info of two ticks, with prev-info delta encoded, (which is then delta encoded again by snapshot deltas), expect about 5~7 bytes per player per snap pre-huffman.

The decision of including two ticks of input is to make sure client have the info density to display fluid enough cursor when sv_high_bandwidth is 0 (which snaps at 25tps instead of 50)

Interpolation is really hard in Teeworlds, but I think it looks barely acceptable online and definitely acceptable in demo.

For people wanting to see the "real" input processed by server for various reasons, turning off interpolation is recommended.

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)

Video demo:
https://github.com/user-attachments/assets/3d590ed2-f3f8-41ca-a311-7ec5aa782e71



