### PR TITLE
Remove unnecessary `ndkVersion` from Gradle build

### DIFF
--- a/scripts/android/cmake_android.sh
+++ b/scripts/android/cmake_android.sh
@@ -7,8 +7,6 @@ export MAKEFLAGS
 
 ANDROID_NDK_VERSION="$(cd "$ANDROID_HOME/ndk" && find . -maxdepth 1 | sort -n | tail -1)"
 ANDROID_NDK_VERSION="${ANDROID_NDK_VERSION:2}"
-# ANDROID_NDK_VERSION must be exported for build.sh step
-export ANDROID_NDK_VERSION
 # ANDROID_NDK_HOME must be exported for cargo-ndk
 export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/$ANDROID_NDK_VERSION"
 

--- a/scripts/android/files/build.gradle
+++ b/scripts/android/files/build.gradle
@@ -18,7 +18,6 @@ java {
 
 android {
 	compileSdkVersion 34
-	ndkVersion "TW_NDK_VERSION"
 	defaultConfig {
 		applicationId "org.ddnet.client"
 		namespace("org.ddnet.client")

--- a/scripts/android/files/build.sh
+++ b/scripts/android/files/build.sh
@@ -45,7 +45,6 @@ sed -i "s/TW_KEY_NAME/${TW_KEY_NAME_ESCAPED}/g" build.gradle
 sed -i "s/TW_KEY_PW/${TW_KEY_PW_ESCAPED}/g" build.gradle
 sed -i "s/TW_KEY_ALIAS/${TW_KEY_ALIAS_ESCAPED}/g" build.gradle
 
-sed -i "s/TW_NDK_VERSION/${ANDROID_NDK_VERSION}/g" build.gradle
 sed -i "s/TW_VERSION_CODE/${TW_VERSION_CODE}/g" build.gradle
 sed -i "s/TW_VERSION_NAME/${TW_VERSION_NAME}/g" build.gradle
 


### PR DESCRIPTION
Gradle can determine the NDK version automatically and this property is only required if multiple NDK versions are installed. The NDK version previously determined from the filename could not be parsed by Gradle anyway.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
