### PR TITLE
Share gameflags for 0.6/0.7 instead of hardcoding it

### DIFF
--- a/src/engine/shared/protocolglue.cpp
+++ b/src/engine/shared/protocolglue.cpp
@@ -4,6 +4,16 @@
 
 #include "protocolglue.h"
 
+int GameFlags_ClampToSix(int Flags)
+{
+	int Six = 0;
+	if(Flags & GAMEFLAG_TEAMS)
+		Six |= GAMEFLAG_TEAMS;
+	if(Flags & GAMEFLAG_FLAGS)
+		Six |= GAMEFLAG_FLAGS;
+	return Six;
+}
+
 int PlayerFlags_SevenToSix(int Flags)
 {
 	int Six = 0;

--- a/src/engine/shared/protocolglue.h
+++ b/src/engine/shared/protocolglue.h
@@ -1,6 +1,7 @@
 #ifndef ENGINE_SHARED_PROTOCOLGLUE_H
 #define ENGINE_SHARED_PROTOCOLGLUE_H
 
+int GameFlags_ClampToSix(int Flags);
 int PlayerFlags_SevenToSix(int Flags);
 int PlayerFlags_SixToSeven(int Flags);
 void PickupType_SevenToSix(int Type7, int &Type6, int &SubType6);

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -1483,26 +1483,6 @@ void CGameContext::OnClientEnter(int ClientId)
 	}
 	m_pController->OnPlayerConnect(m_apPlayers[ClientId]);
 
-	if(Server()->IsSixup(ClientId))
-	{
-		{
-			protocol7::CNetMsg_Sv_GameInfo Msg;
-			Msg.m_GameFlags = protocol7::GAMEFLAG_RACE;
-			Msg.m_MatchCurrent = 1;
-			Msg.m_MatchNum = 0;
-			Msg.m_ScoreLimit = 0;
-			Msg.m_TimeLimit = 0;
-			Server()->SendPackMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_NORECORD, ClientId);
-		}
-
-		// /team is essential
-		{
-			protocol7::CNetMsg_Sv_CommandInfoRemove Msg;
-			Msg.m_pName = "team";
-			Server()->SendPackMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_NORECORD, ClientId);
-		}
-	}
-
 	{
 		CNetMsg_Sv_CommandInfoGroupStart Msg;
 		Server()->SendPackMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_NORECORD, ClientId);

--- a/src/game/server/gamecontroller.cpp
+++ b/src/game/server/gamecontroller.cpp
@@ -2,6 +2,7 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include <engine/shared/config.h>
 
+#include <engine/shared/protocolglue.h>
 #include <game/generated/protocol.h>
 #include <game/mapitems.h>
 #include <game/server/score.h>
@@ -397,6 +398,26 @@ void IGameController::OnPlayerConnect(CPlayer *pPlayer)
 		str_format(aBuf, sizeof(aBuf), "team_join player='%d:%s' team=%d", ClientId, Server()->ClientName(ClientId), pPlayer->GetTeam());
 		GameServer()->Console()->Print(IConsole::OUTPUT_LEVEL_DEBUG, "game", aBuf);
 	}
+
+	if(Server()->IsSixup(ClientId))
+	{
+		{
+			protocol7::CNetMsg_Sv_GameInfo Msg;
+			Msg.m_GameFlags = m_GameFlags;
+			Msg.m_MatchCurrent = 1;
+			Msg.m_MatchNum = 0;
+			Msg.m_ScoreLimit = 0;
+			Msg.m_TimeLimit = 0;
+			Server()->SendPackMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_NORECORD, ClientId);
+		}
+
+		// /team is essential
+		{
+			protocol7::CNetMsg_Sv_CommandInfoRemove Msg;
+			Msg.m_pName = "team";
+			Server()->SendPackMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_NORECORD, ClientId);
+		}
+	}
 }
 
 void IGameController::OnPlayerDisconnect(class CPlayer *pPlayer, const char *pReason)
@@ -553,7 +574,7 @@ void IGameController::Snap(int SnappingClient)
 	if(!pGameInfoObj)
 		return;
 
-	pGameInfoObj->m_GameFlags = m_GameFlags;
+	pGameInfoObj->m_GameFlags = GameFlags_ClampToSix(m_GameFlags);
 	pGameInfoObj->m_GameStateFlags = 0;
 	if(m_GameOverTick != -1)
 		pGameInfoObj->m_GameStateFlags |= GAMESTATEFLAG_GAMEOVER;

--- a/src/game/server/gamemodes/DDRace.cpp
+++ b/src/game/server/gamemodes/DDRace.cpp
@@ -18,6 +18,7 @@ CGameControllerDDRace::CGameControllerDDRace(class CGameContext *pGameServer) :
 	IGameController(pGameServer)
 {
 	m_pGameType = g_Config.m_SvTestingCommands ? TEST_TYPE_NAME : GAME_TYPE_NAME;
+	m_GameFlags = protocol7::GAMEFLAG_RACE;
 }
 
 CGameControllerDDRace::~CGameControllerDDRace() = default;


### PR DESCRIPTION
https://github.com/ddnet/ddnet/blob/5cf0e5e99788c0d883e4c7d18bed2ff6c5e6a424/datasrc/network.py#L8 https://github.com/ddnet/ddnet/blob/5cf0e5e99788c0d883e4c7d18bed2ff6c5e6a424/datasrc/seven/network.py#L10

0.6 game flags:

```python
GameFlags = ["TEAMS", "FLAGS"]
```

0.7 game flags:

```python
GameFlags = Flags("GAMEFLAG", ["TEAMS", "FLAGS", "SURVIVAL", "RACE"])
```

The 0.7 protocol extended the game flags without changing the old 0.6 flags. So flag teams and flag flags are the same in both versions and 0.7 just has additional flags.

The server is now sending the same m_GameFlags from the gamemode controller to 0.6 and 0.7 connections. It clamps away the unsupported flags for 0.6.

Before this commit the ddnet server would always send the hardcodet race flag to 0.7 connections while ignoring what the gamemode set as a game flag.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
