### PR TITLE
Set correct end line in `twlang.py` for strings with context

### DIFF
--- a/scripts/languages/twlang.py
+++ b/scripts/languages/twlang.py
@@ -37,7 +37,7 @@ def decode(fileobj, elements_per_key):
 			if current_key:
 				if len(data[current_key]) != 1+elements_per_key:
 					raise LanguageDecodeError("Wrong number of elements per key", fileobj.name, index)
-				data[current_key].append(index)
+				data[current_key].append(index - 1 if current_context else index)
 			if line in data:
 				raise LanguageDecodeError("Key defined multiple times: " + line, fileobj.name, index)
 			data[(line, current_context)] = [index - 1 if current_context else index]


### PR DESCRIPTION
The script didn't set the correct end line for strings with context. This caused the ending line to be on the next strings context line, which it would delete and then the next line would have no context and therefore be considered unused.

Closes #6971 

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
