### PR TITLE
Fix editor prompt suggesting disabled last action

### DIFF
--- a/src/game/editor/prompt.cpp
+++ b/src/game/editor/prompt.cpp
@@ -101,7 +101,7 @@ void CPrompt::OnRender(CUIRect _)
 	{
 		m_PromptSelectedIndex = 0;
 		m_vpFilteredPromptList.clear();
-		if(m_ResetFilterResults && m_pLastAction)
+		if(m_ResetFilterResults && m_pLastAction && !m_pLastAction->Disabled())
 		{
 			m_vpFilteredPromptList.push_back(m_pLastAction);
 		}
@@ -160,7 +160,7 @@ void CPrompt::OnRender(CUIRect _)
 	{
 		if(m_PromptSelectedIndex >= 0)
 		{
-			const CQuickAction *pBtn = m_vpFilteredPromptList[m_PromptSelectedIndex];
+			CQuickAction *pBtn = m_vpFilteredPromptList[m_PromptSelectedIndex];
 			SetInactive();
 			pBtn->Call();
 			m_pLastAction = pBtn;

--- a/src/game/editor/prompt.h
+++ b/src/game/editor/prompt.h
@@ -10,10 +10,10 @@
 class CPrompt : public CEditorComponent
 {
 	bool m_ResetFilterResults = true;
-	const CQuickAction *m_pLastAction = nullptr;
+	CQuickAction *m_pLastAction = nullptr;
 	int m_PromptSelectedIndex = -1;
 
-	std::vector<const CQuickAction *> m_vpFilteredPromptList;
+	std::vector<CQuickAction *> m_vpFilteredPromptList;
 	std::vector<CQuickAction *> m_vQuickActions;
 	CLineInputBuffered<512> m_PromptInput;
 


### PR DESCRIPTION
The editor prompt always has as a first entry the last action that ran. But this entry should not show up if that action is currently disabled.


https://github.com/user-attachments/assets/f0a4a576-9a18-4e61-9b8e-d9ae69ade8ed


## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
