### PR TITLE
Use same descriptions for game tile actions as the button

### DIFF
--- a/src/game/editor/quick_actions.h
+++ b/src/game/editor/quick_actions.h
@@ -14,7 +14,7 @@ REGISTER_QUICK_ACTION(
 	[&]() -> bool { return !CanFillGameTiles(); },
 	ALWAYS_FALSE,
 	DEFAULT_BTN,
-	"")
+	"Constructs game tiles from this layer")
 REGISTER_QUICK_ACTION(
 	GameTilesHookable,
 	"Game tiles: Hookable",
@@ -22,7 +22,7 @@ REGISTER_QUICK_ACTION(
 	[&]() -> bool { return !CanFillGameTiles(); },
 	ALWAYS_FALSE,
 	DEFAULT_BTN,
-	"")
+	"Constructs game tiles from this layer")
 REGISTER_QUICK_ACTION(
 	GameTilesDeath,
 	"Game tiles: Death",
@@ -30,7 +30,7 @@ REGISTER_QUICK_ACTION(
 	[&]() -> bool { return !CanFillGameTiles(); },
 	ALWAYS_FALSE,
 	DEFAULT_BTN,
-	"")
+	"Constructs game tiles from this layer")
 REGISTER_QUICK_ACTION(
 	GameTilesUnhookable,
 	"Game tiles: Unhookable",
@@ -38,7 +38,7 @@ REGISTER_QUICK_ACTION(
 	[&]() -> bool { return !CanFillGameTiles(); },
 	ALWAYS_FALSE,
 	DEFAULT_BTN,
-	"")
+	"Constructs game tiles from this layer")
 REGISTER_QUICK_ACTION(
 	GameTilesHookthrough,
 	"Game tiles: Hookthrough",
@@ -46,7 +46,7 @@ REGISTER_QUICK_ACTION(
 	[&]() -> bool { return !CanFillGameTiles(); },
 	ALWAYS_FALSE,
 	DEFAULT_BTN,
-	"")
+	"Constructs game tiles from this layer")
 REGISTER_QUICK_ACTION(
 	GameTilesFreeze,
 	"Game tiles: Freeze",
@@ -54,7 +54,7 @@ REGISTER_QUICK_ACTION(
 	[&]() -> bool { return !CanFillGameTiles(); },
 	ALWAYS_FALSE,
 	DEFAULT_BTN,
-	"")
+	"Constructs game tiles from this layer")
 REGISTER_QUICK_ACTION(
 	GameTilesUnfreeze,
 	"Game tiles: Unfreeze",
@@ -62,7 +62,7 @@ REGISTER_QUICK_ACTION(
 	[&]() -> bool { return !CanFillGameTiles(); },
 	ALWAYS_FALSE,
 	DEFAULT_BTN,
-	"")
+	"Constructs game tiles from this layer")
 REGISTER_QUICK_ACTION(
 	GameTilesDeepFreeze,
 	"Game tiles: Deep Freeze",
@@ -70,7 +70,7 @@ REGISTER_QUICK_ACTION(
 	[&]() -> bool { return !CanFillGameTiles(); },
 	ALWAYS_FALSE,
 	DEFAULT_BTN,
-	"")
+	"Constructs game tiles from this layer")
 REGISTER_QUICK_ACTION(
 	GameTilesDeepUnfreeze,
 	"Game tiles: Deep Unfreeze",
@@ -78,7 +78,7 @@ REGISTER_QUICK_ACTION(
 	[&]() -> bool { return !CanFillGameTiles(); },
 	ALWAYS_FALSE,
 	DEFAULT_BTN,
-	"")
+	"Constructs game tiles from this layer")
 REGISTER_QUICK_ACTION(
 	GameTilesBlueCheckTele,
 	"Game tiles: Blue Check Tele",
@@ -86,7 +86,7 @@ REGISTER_QUICK_ACTION(
 	[&]() -> bool { return !CanFillGameTiles(); },
 	ALWAYS_FALSE,
 	DEFAULT_BTN,
-	"")
+	"Constructs game tiles from this layer")
 REGISTER_QUICK_ACTION(
 	GameTilesRedCheckTele,
 	"Game tiles: Red Check Tele",
@@ -94,7 +94,7 @@ REGISTER_QUICK_ACTION(
 	[&]() -> bool { return !CanFillGameTiles(); },
 	ALWAYS_FALSE,
 	DEFAULT_BTN,
-	"")
+	"Constructs game tiles from this layer")
 REGISTER_QUICK_ACTION(
 	GameTilesLiveFreeze,
 	"Game tiles: Live Freeze",
@@ -102,7 +102,7 @@ REGISTER_QUICK_ACTION(
 	[&]() -> bool { return !CanFillGameTiles(); },
 	ALWAYS_FALSE,
 	DEFAULT_BTN,
-	"")
+	"Constructs game tiles from this layer")
 REGISTER_QUICK_ACTION(
 	GameTilesLiveUnfreeze,
 	"Game tiles: Live Unfreeze",
@@ -110,7 +110,7 @@ REGISTER_QUICK_ACTION(
 	[&]() -> bool { return !CanFillGameTiles(); },
 	ALWAYS_FALSE,
 	DEFAULT_BTN,
-	"")
+	"Constructs game tiles from this layer")
 REGISTER_QUICK_ACTION(
 	AddGroup, "Add group", [&]() { AddGroup(); }, ALWAYS_FALSE, ALWAYS_FALSE, DEFAULT_BTN, "Adds a new group")
 REGISTER_QUICK_ACTION(


### PR DESCRIPTION
I used empty as a placeholder in an earlier pr and forgot to fill it.
The text from the button is not the best but I can not come up with anything better.

![image](https://github.com/user-attachments/assets/baba5349-1221-45a8-b894-2f7107e6ecbe)


## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
