### PR TITLE
Add quick action "Toggle Grid"

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -1102,10 +1102,10 @@ void CEditor::DoToolbarLayers(CUIRect ToolBar)
 		// grid button
 		TB_Top.VSplitLeft(25.0f, &Button, &TB_Top);
 		static int s_GridButton = 0;
-		if(DoButton_FontIcon(&s_GridButton, FONT_ICON_BORDER_ALL, MapView()->MapGrid()->IsEnabled(), &Button, 0, "[ctrl+g] Toggle Grid", IGraphics::CORNER_L) ||
+		if(DoButton_FontIcon(&s_GridButton, FONT_ICON_BORDER_ALL, m_QuickActionToggleGrid.Active(), &Button, 0, m_QuickActionToggleGrid.Description(), IGraphics::CORNER_L) ||
 			(m_Dialog == DIALOG_NONE && CLineInput::GetActiveInput() == nullptr && Input()->KeyPress(KEY_G) && ModPressed && !ShiftPressed))
 		{
-			MapView()->MapGrid()->Toggle();
+			m_QuickActionToggleGrid.Call();
 		}
 
 		// grid settings button

--- a/src/game/editor/quick_actions.h
+++ b/src/game/editor/quick_actions.h
@@ -8,6 +8,14 @@
 #define DEFAULT_BTN []() -> int { return -1; }
 
 REGISTER_QUICK_ACTION(
+	ToggleGrid,
+	"Toggle Grid",
+	[&]() { MapView()->MapGrid()->Toggle(); },
+	ALWAYS_FALSE,
+	[&]() -> bool { return MapView()->MapGrid()->IsEnabled(); },
+	DEFAULT_BTN,
+	"[ctrl+g] Toggle Grid")
+REGISTER_QUICK_ACTION(
 	GameTilesAir,
 	"Game tiles: Air",
 	[&]() { FillGameTiles(EGameTileOp::AIR); },


### PR DESCRIPTION
https://github.com/user-attachments/assets/ebcd18a0-cb05-4af4-823d-6ef6a4cb75ae

The "searching" in the clip does not make much sense since "Toggle Grid" will be the first entry.
Which made me realize that there should probably be some smart default ordering of those actions.

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
