### PR TITLE
Translate greensward skin in sixup server bridge

### DIFF
--- a/src/game/server/teeinfo.cpp
+++ b/src/game/server/teeinfo.cpp
@@ -29,7 +29,10 @@ static StdSkin g_aStdSkins[] = {
 	{"toptri", {"standard", "toptri", "", "standard", "standard", "standard"}, {true, false, false, true, true, false}, {6119331, 0, 0, 3640746, 5792119, 0}},
 	{"twinbop", {"standard", "duodonny", "twinbopp", "standard", "standard", "standard"}, {true, true, true, true, true, false}, {15310519, -1600806, 15310519, 15310519, 37600, 0}},
 	{"twintri", {"standard", "twintri", "", "standard", "standard", "standard"}, {true, true, false, true, true, false}, {3447932, -14098717, 0, 185, 9634888, 0}},
-	{"warpaint", {"standard", "warpaint", "", "standard", "standard", "standard"}, {true, false, false, true, true, false}, {1944919, 0, 0, 750337, 1944919, 0}}};
+	{"warpaint", {"standard", "warpaint", "", "standard", "standard", "standard"}, {true, false, false, true, true, false}, {1944919, 0, 0, 750337, 1944919, 0}},
+	/* custom */
+	{"greensward", {"greensward", "duodonny", "", "standard", "standard", "standard"}, {true, true, false, false, false, false}, {5635840, -11141356, 65408, 65408, 65408, 65408}},
+};
 
 CTeeInfo::CTeeInfo(const char *pSkinName, int UseCustomColor, int ColorBody, int ColorFeet)
 {


### PR DESCRIPTION
greensward is not a official teeworlds skin. But it comes pre installed in 4 custom 0.7 clients so the translation will display the correct skin for users of one of those clients:
- gamer
- ddnet
- F-Client
- ZillyWoods

Or for everyone that has the skin installed manually.

## before

This is a official teeworlds 0.7 client with the custom skin greensward manually installed on the left.
And a ddnet client (0.6 connection) on the right side on a ddnet server (master branch).

![Screenshot from 2024-09-01 16-44-28](https://github.com/user-attachments/assets/6bf08c17-d445-4d41-9a46-b503a5731315)

## after

These are the same clients connected to the ddnet server built from this pr.

![Screenshot from 2024-09-01 16-45-25](https://github.com/user-attachments/assets/b56ec4cb-5eed-4b88-b21a-14bb5a088ba0)


## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
