### PR TITLE
fix inconsistent quickaction tooltips

### DIFF
--- a/src/game/editor/quick_actions.h
+++ b/src/game/editor/quick_actions.h
@@ -14,7 +14,7 @@ REGISTER_QUICK_ACTION(
 	ALWAYS_FALSE,
 	[&]() -> bool { return MapView()->MapGrid()->IsEnabled(); },
 	DEFAULT_BTN,
-	"[ctrl+g] Toggle Grid")
+	"[Ctrl+G] Toggle Grid.")
 REGISTER_QUICK_ACTION(
 	GameTilesAir,
 	"Game tiles: Air",
@@ -22,7 +22,7 @@ REGISTER_QUICK_ACTION(
 	[&]() -> bool { return !CanFillGameTiles(); },
 	ALWAYS_FALSE,
 	DEFAULT_BTN,
-	"Constructs game tiles from this layer")
+	"Constructs game tiles from this layer.")
 REGISTER_QUICK_ACTION(
 	GameTilesHookable,
 	"Game tiles: Hookable",
@@ -30,7 +30,7 @@ REGISTER_QUICK_ACTION(
 	[&]() -> bool { return !CanFillGameTiles(); },
 	ALWAYS_FALSE,
 	DEFAULT_BTN,
-	"Constructs game tiles from this layer")
+	"Constructs game tiles from this layer.")
 REGISTER_QUICK_ACTION(
 	GameTilesDeath,
 	"Game tiles: Death",
@@ -38,7 +38,7 @@ REGISTER_QUICK_ACTION(
 	[&]() -> bool { return !CanFillGameTiles(); },
 	ALWAYS_FALSE,
 	DEFAULT_BTN,
-	"Constructs game tiles from this layer")
+	"Constructs game tiles from this layer.")
 REGISTER_QUICK_ACTION(
 	GameTilesUnhookable,
 	"Game tiles: Unhookable",
@@ -46,7 +46,7 @@ REGISTER_QUICK_ACTION(
 	[&]() -> bool { return !CanFillGameTiles(); },
 	ALWAYS_FALSE,
 	DEFAULT_BTN,
-	"Constructs game tiles from this layer")
+	"Constructs game tiles from this layer.")
 REGISTER_QUICK_ACTION(
 	GameTilesHookthrough,
 	"Game tiles: Hookthrough",
@@ -54,7 +54,7 @@ REGISTER_QUICK_ACTION(
 	[&]() -> bool { return !CanFillGameTiles(); },
 	ALWAYS_FALSE,
 	DEFAULT_BTN,
-	"Constructs game tiles from this layer")
+	"Constructs game tiles from this layer.")
 REGISTER_QUICK_ACTION(
 	GameTilesFreeze,
 	"Game tiles: Freeze",
@@ -62,7 +62,7 @@ REGISTER_QUICK_ACTION(
 	[&]() -> bool { return !CanFillGameTiles(); },
 	ALWAYS_FALSE,
 	DEFAULT_BTN,
-	"Constructs game tiles from this layer")
+	"Constructs game tiles from this layer.")
 REGISTER_QUICK_ACTION(
 	GameTilesUnfreeze,
 	"Game tiles: Unfreeze",
@@ -70,7 +70,7 @@ REGISTER_QUICK_ACTION(
 	[&]() -> bool { return !CanFillGameTiles(); },
 	ALWAYS_FALSE,
 	DEFAULT_BTN,
-	"Constructs game tiles from this layer")
+	"Constructs game tiles from this layer.")
 REGISTER_QUICK_ACTION(
 	GameTilesDeepFreeze,
 	"Game tiles: Deep Freeze",
@@ -78,7 +78,7 @@ REGISTER_QUICK_ACTION(
 	[&]() -> bool { return !CanFillGameTiles(); },
 	ALWAYS_FALSE,
 	DEFAULT_BTN,
-	"Constructs game tiles from this layer")
+	"Constructs game tiles from this layer.")
 REGISTER_QUICK_ACTION(
 	GameTilesDeepUnfreeze,
 	"Game tiles: Deep Unfreeze",
@@ -86,7 +86,7 @@ REGISTER_QUICK_ACTION(
 	[&]() -> bool { return !CanFillGameTiles(); },
 	ALWAYS_FALSE,
 	DEFAULT_BTN,
-	"Constructs game tiles from this layer")
+	"Constructs game tiles from this layer.")
 REGISTER_QUICK_ACTION(
 	GameTilesBlueCheckTele,
 	"Game tiles: Blue Check Tele",
@@ -94,7 +94,7 @@ REGISTER_QUICK_ACTION(
 	[&]() -> bool { return !CanFillGameTiles(); },
 	ALWAYS_FALSE,
 	DEFAULT_BTN,
-	"Constructs game tiles from this layer")
+	"Constructs game tiles from this layer.")
 REGISTER_QUICK_ACTION(
 	GameTilesRedCheckTele,
 	"Game tiles: Red Check Tele",
@@ -102,7 +102,7 @@ REGISTER_QUICK_ACTION(
 	[&]() -> bool { return !CanFillGameTiles(); },
 	ALWAYS_FALSE,
 	DEFAULT_BTN,
-	"Constructs game tiles from this layer")
+	"Constructs game tiles from this layer.")
 REGISTER_QUICK_ACTION(
 	GameTilesLiveFreeze,
 	"Game tiles: Live Freeze",
@@ -110,7 +110,7 @@ REGISTER_QUICK_ACTION(
 	[&]() -> bool { return !CanFillGameTiles(); },
 	ALWAYS_FALSE,
 	DEFAULT_BTN,
-	"Constructs game tiles from this layer")
+	"Constructs game tiles from this layer.")
 REGISTER_QUICK_ACTION(
 	GameTilesLiveUnfreeze,
 	"Game tiles: Live Unfreeze",
@@ -118,11 +118,23 @@ REGISTER_QUICK_ACTION(
 	[&]() -> bool { return !CanFillGameTiles(); },
 	ALWAYS_FALSE,
 	DEFAULT_BTN,
-	"Constructs game tiles from this layer")
+	"Constructs game tiles from this layer.")
 REGISTER_QUICK_ACTION(
-	AddGroup, "Add group", [&]() { AddGroup(); }, ALWAYS_FALSE, ALWAYS_FALSE, DEFAULT_BTN, "Adds a new group")
+	AddGroup,
+	"Add group",
+	[&]() { AddGroup(); },
+	ALWAYS_FALSE,
+	ALWAYS_FALSE,
+	DEFAULT_BTN,
+	"Adds a new group.")
 REGISTER_QUICK_ACTION(
-	Refocus, "Refocus", [&]() { MapView()->Focus(); }, ALWAYS_FALSE, ALWAYS_FALSE, DEFAULT_BTN, "[HOME] Restore map focus")
+	Refocus,
+	"Refocus",
+	[&]() { MapView()->Focus(); },
+	ALWAYS_FALSE,
+	ALWAYS_FALSE,
+	DEFAULT_BTN,
+	"[HOME] Restore map focus.")
 REGISTER_QUICK_ACTION(
 	Proof,
 	"Proof",
@@ -140,7 +152,7 @@ REGISTER_QUICK_ACTION(
 	ALWAYS_FALSE,
 	ALWAYS_FALSE,
 	DEFAULT_BTN,
-	"Saves the current map under a new name (ctrl+shift+s)")
+	"[Ctrl+Shift+S] Saves the current map under a new name.")
 REGISTER_QUICK_ACTION(
 	LoadCurrentMap,
 	"Load Current Map",
@@ -158,7 +170,7 @@ REGISTER_QUICK_ACTION(
 	ALWAYS_FALSE,
 	ALWAYS_FALSE,
 	DEFAULT_BTN,
-	"Opens the current in game map for editing (ctrl+alt+l)")
+	"[Ctrl+Alt+L] Opens the current in game map for editing.")
 REGISTER_QUICK_ACTION(
 	Envelopes,
 	"Envelopes",
@@ -174,7 +186,7 @@ REGISTER_QUICK_ACTION(
 	ALWAYS_FALSE,
 	ALWAYS_FALSE,
 	DEFAULT_BTN,
-	"Load a new image to use in the map")
+	"Load a new image to use in the map.")
 REGISTER_QUICK_ACTION(
 	LayerPropAddImage,
 	"Layer: Add Image",
@@ -182,7 +194,7 @@ REGISTER_QUICK_ACTION(
 	[&]() -> bool { return !IsNonGameTileLayerSelected(); },
 	ALWAYS_FALSE,
 	DEFAULT_BTN,
-	"Pick mapres image for currently selected layer")
+	"Pick mapres image for currently selected layer.")
 REGISTER_QUICK_ACTION(
 	ShowInfoOff,
 	"Show Info: Off",
@@ -193,7 +205,7 @@ REGISTER_QUICK_ACTION(
 	ALWAYS_FALSE,
 	[&]() -> bool { return m_ShowTileInfo == SHOW_TILE_OFF; },
 	DEFAULT_BTN,
-	"Do not show tile information")
+	"Do not show tile information.")
 REGISTER_QUICK_ACTION(
 	ShowInfoDec,
 	"Show Info: Dec",
@@ -204,7 +216,7 @@ REGISTER_QUICK_ACTION(
 	ALWAYS_FALSE,
 	[&]() -> bool { return m_ShowTileInfo == SHOW_TILE_DECIMAL; },
 	DEFAULT_BTN,
-	"[ctrl+i] Show tile information")
+	"[Ctrl+I] Show tile information.")
 REGISTER_QUICK_ACTION(
 	ShowInfoHex,
 	"Show Info: Hex",
@@ -215,7 +227,7 @@ REGISTER_QUICK_ACTION(
 	ALWAYS_FALSE,
 	[&]() -> bool { return m_ShowTileInfo == SHOW_TILE_HEXADECIMAL; },
 	DEFAULT_BTN,
-	"[ctrl+shift+i] Show tile information in hexadecimal")
+	"[Ctrl+Shift+I] Show tile information in hexadecimal.")
 
 #undef ALWAYS_FALSE
 #undef DEFAULT_BTN


### PR DESCRIPTION
closes #8870
keep the style across all tooltip's - every key combination is Uppercase (e.g [Ctrl+Alt+L] in square brackets and ends with a period.
![grafik](https://github.com/user-attachments/assets/3cef8cf2-49f9-40d6-b7b5-44aef0e697fa)

addition: i found 2 lines to not be formatted like the others so i changed this in here as well.

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
