### PR TITLE
Grow prompt label if there is space and fix margins

### DIFF
--- a/src/game/editor/prompt.cpp
+++ b/src/game/editor/prompt.cpp
@@ -126,6 +126,8 @@ void CPrompt::OnRender(CUIRect _)
 	s_ListBox.SetActive(!Ui()->IsPopupOpen());
 	s_ListBox.DoStart(15.0f, m_vpFilteredPromptList.size(), 1, 5, m_PromptSelectedIndex, &Suggestions, false);
 
+	float LabelWidth = Overlay.w > 855.0f ? 200.0f : 100.0f;
+
 	for(size_t i = 0; i < m_vpFilteredPromptList.size(); i++)
 	{
 		const CListboxItem Item = s_ListBox.DoNextItem(m_vpFilteredPromptList[i], m_PromptSelectedIndex >= 0 && (size_t)m_PromptSelectedIndex == i);
@@ -133,9 +135,10 @@ void CPrompt::OnRender(CUIRect _)
 			continue;
 
 		CUIRect LabelColumn, DescColumn;
-		Item.m_Rect.VSplitLeft(5.0f, nullptr, &LabelColumn);
-		LabelColumn.VSplitLeft(100.0f, &LabelColumn, &DescColumn);
-		LabelColumn.VSplitRight(5.0f, &LabelColumn, nullptr);
+		float Margin = 5.0f;
+		Item.m_Rect.VSplitLeft(Margin, nullptr, &LabelColumn);
+		LabelColumn.VSplitLeft(LabelWidth, &LabelColumn, &DescColumn);
+		DescColumn.VSplitRight(Margin, &DescColumn, nullptr);
 
 		SLabelProperties Props;
 		Props.m_MaxWidth = LabelColumn.w;


### PR DESCRIPTION
Closed #8867

Take enough space for the label on wide screens.

![image](https://github.com/user-attachments/assets/9c816ac7-f1e4-4edc-b269-234a4acb8447)

Shrink label on small screens to make sure descriptions are still readable.

![image](https://github.com/user-attachments/assets/540ed407-5f90-4de4-8829-32bcf78529f1)


## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
