### PR TITLE
Add quick actions for zooming the view

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -1121,23 +1121,23 @@ void CEditor::DoToolbarLayers(CUIRect ToolBar)
 		// zoom group
 		TB_Top.VSplitLeft(20.0f, &Button, &TB_Top);
 		static int s_ZoomOutButton = 0;
-		if(DoButton_FontIcon(&s_ZoomOutButton, FONT_ICON_MINUS, 0, &Button, 0, "[NumPad-] Zoom out", IGraphics::CORNER_L))
+		if(DoButton_FontIcon(&s_ZoomOutButton, FONT_ICON_MINUS, 0, &Button, 0, m_QuickActionZoomOut.Description(), IGraphics::CORNER_L))
 		{
-			MapView()->Zoom()->ChangeValue(50.0f);
+			m_QuickActionZoomOut.Call();
 		}
 
 		TB_Top.VSplitLeft(25.0f, &Button, &TB_Top);
 		static int s_ZoomNormalButton = 0;
-		if(DoButton_FontIcon(&s_ZoomNormalButton, FONT_ICON_MAGNIFYING_GLASS, 0, &Button, 0, "[NumPad*] Zoom to normal and remove editor offset", IGraphics::CORNER_NONE))
+		if(DoButton_FontIcon(&s_ZoomNormalButton, FONT_ICON_MAGNIFYING_GLASS, 0, &Button, 0, m_QuickActionResetZoom.Description(), IGraphics::CORNER_NONE))
 		{
-			MapView()->ResetZoom();
+			m_QuickActionResetZoom.Call();
 		}
 
 		TB_Top.VSplitLeft(20.0f, &Button, &TB_Top);
 		static int s_ZoomInButton = 0;
-		if(DoButton_FontIcon(&s_ZoomInButton, FONT_ICON_PLUS, 0, &Button, 0, "[NumPad+] Zoom in", IGraphics::CORNER_R))
+		if(DoButton_FontIcon(&s_ZoomInButton, FONT_ICON_PLUS, 0, &Button, 0, m_QuickActionZoomIn.Description(), IGraphics::CORNER_R))
 		{
-			MapView()->Zoom()->ChangeValue(-50.0f);
+			m_QuickActionZoomIn.Call();
 		}
 
 		TB_Top.VSplitLeft(5.0f, nullptr, &TB_Top);

--- a/src/game/editor/quick_actions.h
+++ b/src/game/editor/quick_actions.h
@@ -128,6 +128,30 @@ REGISTER_QUICK_ACTION(
 	DEFAULT_BTN,
 	"Adds a new group.")
 REGISTER_QUICK_ACTION(
+	ResetZoom,
+	"Reset Zoom",
+	[&]() { MapView()->ResetZoom(); },
+	ALWAYS_FALSE,
+	ALWAYS_FALSE,
+	DEFAULT_BTN,
+	"[Numpad*] Zoom to normal and remove editor offset.")
+REGISTER_QUICK_ACTION(
+	ZoomOut,
+	"Zoom Out",
+	[&]() { MapView()->Zoom()->ChangeValue(50.0f); },
+	ALWAYS_FALSE,
+	ALWAYS_FALSE,
+	DEFAULT_BTN,
+	"[Numpad-] Zoom out.")
+REGISTER_QUICK_ACTION(
+	ZoomIn,
+	"Zoom In",
+	[&]() { MapView()->Zoom()->ChangeValue(-50.0f); },
+	ALWAYS_FALSE,
+	ALWAYS_FALSE,
+	DEFAULT_BTN,
+	"[Numpad+] Zoom in.")
+REGISTER_QUICK_ACTION(
 	Refocus,
 	"Refocus",
 	[&]() { MapView()->Focus(); },


### PR DESCRIPTION
https://github.com/user-attachments/assets/ca5c871c-1660-4ba6-9ff4-51e9f4fd5364

Intentionally ordered the actions so "Reset Zoom" shows up before "Refocus" and "Server settings"
Renamed NumPad to Numpad to pass the style test.

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
