### PR TITLE
Use `str_copy` instead of `str_format` where possible

### DIFF
--- a/src/base/system.h
+++ b/src/base/system.h
@@ -1236,6 +1236,7 @@ int str_format_int(char *buffer, size_t buffer_size, int value);
 template<typename... Args>
 int str_format_opt(char *buffer, int buffer_size, const char *format, Args... args)
 {
+	static_assert(sizeof...(args) > 0, "Use str_copy instead of str_format without format arguments");
 	return str_format(buffer, buffer_size, format, args...);
 }
 

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -3317,7 +3317,7 @@ bool CClient::InitNetworkClient(char *pError, size_t ErrorSize)
 					if(g_Config.m_Bindaddr[0])
 						str_format(pError, ErrorSize, "Could not open the network client, try changing or unsetting the bindaddr '%s'.", g_Config.m_Bindaddr);
 					else
-						str_format(pError, ErrorSize, "Could not open the network client.");
+						str_copy(pError, "Could not open the network client.", ErrorSize);
 					return false;
 				}
 			}

--- a/src/engine/shared/netban.cpp
+++ b/src/engine/shared/netban.cpp
@@ -490,8 +490,7 @@ void CNetBan::ConBans(IConsole::IResult *pResult, void *pUser)
 
 	if(NumBans == 0)
 	{
-		str_format(aMsg, sizeof(aMsg), "The ban list is empty.");
-		pThis->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "net_ban", aMsg);
+		pThis->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "net_ban", "The ban list is empty.");
 
 		return;
 	}

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -1693,8 +1693,7 @@ void CHud::RenderRecord()
 	if(m_ServerRecord > 0.0f)
 	{
 		char aBuf[64];
-		str_format(aBuf, sizeof(aBuf), Localize("Server best:"));
-		TextRender()->Text(5, 75, 6, aBuf, -1.0f);
+		TextRender()->Text(5, 75, 6, Localize("Server best:"), -1.0f);
 		char aTime[32];
 		str_time_float(m_ServerRecord, TIME_HOURS_CENTISECS, aTime, sizeof(aTime));
 		str_format(aBuf, sizeof(aBuf), "%s%s", m_ServerRecord > 3600 ? "" : "   ", aTime);
@@ -1705,8 +1704,7 @@ void CHud::RenderRecord()
 	if(PlayerRecord > 0.0f)
 	{
 		char aBuf[64];
-		str_format(aBuf, sizeof(aBuf), Localize("Personal best:"));
-		TextRender()->Text(5, 82, 6, aBuf, -1.0f);
+		TextRender()->Text(5, 82, 6, Localize("Personal best:"), -1.0f);
 		char aTime[32];
 		str_time_float(PlayerRecord, TIME_HOURS_CENTISECS, aTime, sizeof(aTime));
 		str_format(aBuf, sizeof(aBuf), "%s%s", PlayerRecord > 3600 ? "" : "   ", aTime);

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -3310,21 +3310,21 @@ void CMenus::RenderSettingsDDNet(CUIRect MainView)
 			}
 		}
 		else if(State >= IUpdater::GETTING_MANIFEST && State < IUpdater::NEED_RESTART)
-			str_format(aBuf, sizeof(aBuf), Localize("Updating…"));
+			str_copy(aBuf, Localize("Updating…");
 		else if(State == IUpdater::NEED_RESTART)
 		{
-			str_format(aBuf, sizeof(aBuf), Localize("DDNet Client updated!"));
-			m_NeedRestartUpdate = true;
+				str_copy(aBuf, Localize("DDNet Client updated!"));
+				m_NeedRestartUpdate = true;
 		}
 		else
 		{
-			str_format(aBuf, sizeof(aBuf), Localize("No updates available"));
+			str_copy(aBuf, Localize("No updates available");
 			UpdaterRect.VSplitLeft(TextRender()->TextWidth(14.0f, aBuf, -1, -1.0f) + 10.0f, &UpdaterRect, &Button);
 			Button.VSplitLeft(100.0f, &Button, nullptr);
 			static CButtonContainer s_ButtonUpdate;
 			if(DoButton_Menu(&s_ButtonUpdate, Localize("Check now"), 0, &Button))
 			{
-				Client()->RequestDDNetInfo();
+					Client()->RequestDDNetInfo();
 			}
 		}
 		Ui()->DoLabel(&UpdaterRect, aBuf, 14.0f, TEXTALIGN_ML);

--- a/src/game/client/components/menus_start.cpp
+++ b/src/game/client/components/menus_start.cpp
@@ -240,12 +240,12 @@ void CMenus::RenderStartMenu(CUIRect MainView)
 	}
 	else if(State == IUpdater::FAIL)
 	{
-		str_format(aBuf, sizeof(aBuf), Localize("Update failed! Check log…"));
+		str_copy(aBuf, Localize("Update failed! Check log…"));
 		TextRender()->TextColor(1.0f, 0.4f, 0.4f, 1.0f);
 	}
 	else if(State == IUpdater::NEED_RESTART)
 	{
-		str_format(aBuf, sizeof(aBuf), Localize("DDNet Client updated!"));
+		str_copy(aBuf, Localize("DDNet Client updated!"));
 		TextRender()->TextColor(1.0f, 0.4f, 0.4f, 1.0f);
 	}
 	Ui()->DoLabel(&VersionUpdate, aBuf, 14.0f, TEXTALIGN_ML);

--- a/src/game/editor/editor_actions.cpp
+++ b/src/game/editor/editor_actions.cpp
@@ -320,7 +320,7 @@ void CEditorActionDeleteQuad::Redo()
 CEditorActionEditQuadPoint::CEditorActionEditQuadPoint(CEditor *pEditor, int GroupIndex, int LayerIndex, int QuadIndex, std::vector<CPoint> const &vPreviousPoints, std::vector<CPoint> const &vCurrentPoints) :
 	CEditorActionLayerBase(pEditor, GroupIndex, LayerIndex), m_QuadIndex(QuadIndex), m_vPreviousPoints(vPreviousPoints), m_vCurrentPoints(vCurrentPoints)
 {
-	str_format(m_aDisplayText, sizeof(m_aDisplayText), "Edit quad points");
+	str_copy(m_aDisplayText, "Edit quad points");
 }
 
 void CEditorActionEditQuadPoint::Undo()
@@ -628,7 +628,7 @@ CEditorActionGroup::CEditorActionGroup(CEditor *pEditor, int GroupIndex, bool De
 	if(m_Delete)
 		str_format(m_aDisplayText, sizeof(m_aDisplayText), "Delete group %d", m_GroupIndex);
 	else
-		str_format(m_aDisplayText, sizeof(m_aDisplayText), "New group");
+		str_copy(m_aDisplayText, "New group", sizeof(m_aDisplayText));
 }
 
 void CEditorActionGroup::Undo()
@@ -1198,7 +1198,7 @@ CEditorActionTileArt::CEditorActionTileArt(CEditor *pEditor, int PreviousImageCo
 	IEditorAction(pEditor), m_PreviousImageCount(PreviousImageCount), m_vImageIndexMap(vImageIndexMap)
 {
 	str_copy(m_aTileArtFile, pTileArtFile);
-	str_format(m_aDisplayText, sizeof(m_aDisplayText), "Tile art");
+	str_copy(m_aDisplayText, "Tile art");
 }
 
 void CEditorActionTileArt::Undo()
@@ -1266,7 +1266,7 @@ CEditorCommandAction::CEditorCommandAction(CEditor *pEditor, EType Type, int *pS
 	switch(m_Type)
 	{
 	case EType::ADD:
-		str_format(m_aDisplayText, sizeof(m_aDisplayText), "Add command");
+		str_copy(m_aDisplayText, "Add command");
 		break;
 	case EType::EDIT:
 		str_format(m_aDisplayText, sizeof(m_aDisplayText), "Edit command %d", m_CommandIndex);


### PR DESCRIPTION
It will now also assert if you use `str_format` with no arguments. Advising you to use `str_copy` instead.

```
[build] /home/user/Development/ddnet-pr/src/base/system.h:1239:16: error: static assertion failed due to requirement 'sizeof...(args) > 0': Use str_copy instead of str_format without format arguments
[build]  1239 |         static_assert(sizeof...(args) > 0, "Use str_copy instead of str_format without format arguments");
[build]       |                       ^~~~~~~~~~~~~~~~~~~
[build] /home/user/Development/ddnet-pr/src/engine/shared/netban.cpp:493:3: note: in instantiation of function template specialization 'str_format_opt<>' requested here
[build]   493 |                 str_format(aMsg, sizeof(aMsg), "The ban list is empty.");
[build]       |                 ^
```

Closes #8884

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
