### PR TITLE
Do not force scoreboard open when the game is paused

### DIFF
--- a/src/game/client/components/scoreboard.cpp
+++ b/src/game/client/components/scoreboard.cpp
@@ -797,15 +797,16 @@ bool CScoreboard::Active() const
 	if(m_Active)
 		return true;
 
+	const CNetObj_GameInfo *pGameInfoObj = GameClient()->m_Snap.m_pGameInfoObj;
 	if(GameClient()->m_Snap.m_pLocalInfo && !GameClient()->m_Snap.m_SpecInfo.m_Active)
 	{
-		// we are not a spectator, check if we are dead
-		if(!GameClient()->m_Snap.m_pLocalCharacter && g_Config.m_ClScoreboardOnDeath)
+		// we are not a spectator, check if we are dead and the game isn't paused
+		if(!GameClient()->m_Snap.m_pLocalCharacter && g_Config.m_ClScoreboardOnDeath &&
+			!(pGameInfoObj && pGameInfoObj->m_GameStateFlags & GAMESTATEFLAG_PAUSED))
 			return true;
 	}
 
 	// if the game is over
-	const CNetObj_GameInfo *pGameInfoObj = GameClient()->m_Snap.m_pGameInfoObj;
 	if(pGameInfoObj && pGameInfoObj->m_GameStateFlags & GAMESTATEFLAG_GAMEOVER)
 		return true;
 


### PR DESCRIPTION
If the game is paused and a player joins a server (sv_tournament_mode 0) The scoreboard will be forced open. Unless the client configured cl_scoreboard_on_death 0.

This can be quite annoying. Especially in the brand new 0.7 feature where users can pause the game. Oy realized that this is a problem 12 year ago:

https://github.com/teeworlds/teeworlds/commit/aec468a3c455872c208d999c65a38fc996567bbf#diff-e0ff7a1d6079610adb64fc89fbfff23a381ed92f268d8fe188731a9e0c323b0aR389-R390

For ddnet servers this would mostly affect tournaments where paused games are used to give everyone enough time to download the map.

A open scoreboard also blocks broadcasts. So new users might miss the admin announcements explaining why the game is paused.

## before

Here a screenshot of a ddnet-insta server in paused game state. The user can not close the scoreboard and does not know what is going on.

![old](https://github.com/user-attachments/assets/8f642d69-287e-4392-bc20-1b479002d46f)

## after

With the patch applied the user has control over the scoreboard again and can see the broadcast that explains the pause.

![new](https://github.com/user-attachments/assets/74d6a528-99f9-40a4-ad00-3b1702075ea7)


## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
