### PR TITLE
Change country and types filter behavior

### DIFF
--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -27,9 +27,6 @@
 #include <engine/http.h>
 #include <engine/storage.h>
 
-static constexpr const char *COMMUNITY_COUNTRY_NONE = "none";
-static constexpr const char *COMMUNITY_TYPE_NONE = "None";
-
 class CSortWrap
 {
 	typedef bool (CServerBrowser::*SortFunc)(int, int) const;

--- a/src/engine/serverbrowser.h
+++ b/src/engine/serverbrowser.h
@@ -309,6 +309,9 @@ public:
 
 	static constexpr const char *COMMUNITY_DDNET = "ddnet";
 	static constexpr const char *COMMUNITY_NONE = "none";
+
+	static constexpr const char *COMMUNITY_COUNTRY_NONE = "none";
+	static constexpr const char *COMMUNITY_TYPE_NONE = "None";
 	/**
 	 * Special community value for country/type filters that
 	 * affect all communities.

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -869,11 +869,14 @@ void CMenus::RenderServerbrowserDDNetFilter(CUIRect View,
 			{
 				if(Click == 1)
 				{
-					// Left click: when all are active, only activate one
+					// Left click: when all are active, only activate one and none
 					for(int j = 0; j < MaxItems; ++j)
 					{
-						if(j != ItemIndex)
-							Filter.Add(GetItemName(j));
+						if(const char *pItemName = GetItemName(j);
+							j != ItemIndex &&
+							!((&Filter == &ServerBrowser()->CountriesFilter() && str_comp(pItemName, IServerBrowser::COMMUNITY_COUNTRY_NONE) == 0) ||
+								(&Filter == &ServerBrowser()->TypesFilter() && str_comp(pItemName, IServerBrowser::COMMUNITY_TYPE_NONE) == 0)))
+							Filter.Add(pItemName);
 					}
 				}
 				else if(Click == 2)
@@ -890,7 +893,10 @@ void CMenus::RenderServerbrowserDDNetFilter(CUIRect View,
 				bool AllFilteredExceptUs = true;
 				for(int j = 0; j < MaxItems; ++j)
 				{
-					if(j != ItemIndex && !Filter.Filtered(GetItemName(j)))
+					if(const char *pItemName = GetItemName(j);
+						j != ItemIndex && !Filter.Filtered(pItemName) &&
+						!((&Filter == &ServerBrowser()->CountriesFilter() && str_comp(pItemName, IServerBrowser::COMMUNITY_COUNTRY_NONE) == 0) ||
+							(&Filter == &ServerBrowser()->TypesFilter() && str_comp(pItemName, IServerBrowser::COMMUNITY_TYPE_NONE) == 0)))
 					{
 						AllFilteredExceptUs = false;
 						break;
@@ -898,7 +904,7 @@ void CMenus::RenderServerbrowserDDNetFilter(CUIRect View,
 				}
 				// When last one is removed, re-enable all currently selectable items.
 				// Don't use Clear, to avoid enabling also currently unselectable items.
-				if(AllFilteredExceptUs)
+				if(AllFilteredExceptUs && Active)
 				{
 					for(int j = 0; j < MaxItems; ++j)
 					{


### PR DESCRIPTION
Closes #8880 

Instead of doing nothing to the non-community servers, it'll keep them when selecting a single flag to avoid confusion. With no filter flags, clicking will enable both the flag and the 'none' flag. When one flag and the 'none' flag are enabled, clicking on the flag will disable all flags


https://github.com/user-attachments/assets/262d2385-0b8c-4da3-ad8c-d64f0c416fb5



## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
