### PR TITLE
Add `verify_url` field to master for automatic verification

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -621,6 +621,18 @@ void CClient::Connect(const char *pAddress, const char *pPassword)
 	else
 		m_aNetClient[CONN_MAIN].Connect(aConnectAddrs, NumConnectAddrs);
 
+	const CServerBrowser::CServerEntry *pEntry = m_ServerBrowser.Find(aConnectAddrs[0]);
+	if(pEntry != nullptr && pEntry->m_GotInfo)
+	{
+		if(str_length(pEntry->m_Info.m_aVerifyUrl))
+		{
+			std::shared_ptr<CHttpRequest> pVerifyGet = HttpGet(pEntry->m_Info.m_aVerifyUrl);
+			pVerifyGet->Timeout(CTimeout{10000, 0, 500, 10});
+			pVerifyGet->IpResolve(aConnectAddrs[0].type == NETTYPE_IPV4 ? IPRESOLVE::V4 : IPRESOLVE::V6);
+			Http()->Run(pVerifyGet);
+		}
+	}
+
 	m_aNetClient[CONN_MAIN].RefreshStun();
 	SetState(IClient::STATE_CONNECTING);
 

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -2357,6 +2357,10 @@ void CServer::UpdateRegisterServerInfo()
 	JsonWriter.WriteAttribute("requires_login");
 	JsonWriter.WriteBoolValue(false);
 
+	// Client will send a HTTP GET request to the url of sv_verify_url upon connecting
+	JsonWriter.WriteAttribute("verify_url");
+	JsonWriter.WriteStrValue(g_Config.m_SvVerifyUrl);
+
 	JsonWriter.WriteAttribute("clients");
 	JsonWriter.BeginArray();
 

--- a/src/engine/serverbrowser.h
+++ b/src/engine/serverbrowser.h
@@ -118,6 +118,7 @@ public:
 	CClient m_aClients[SERVERINFO_MAX_CLIENTS];
 	int m_NumFilteredPlayers;
 	bool m_RequiresLogin;
+	char m_aVerifyUrl[128];
 
 	static int EstimateLatency(int Loc1, int Loc2);
 	static bool ParseLocation(int *pResult, const char *pString);

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -444,6 +444,7 @@ MACRO_CONFIG_INT(SvDnsblBan, sv_dnsbl_ban, 0, 0, 1, CFGFLAG_SERVER, "Automatical
 MACRO_CONFIG_STR(SvDnsblBanReason, sv_dnsbl_ban_reason, 128, "VPN detected, try connecting without. Contact admin if mistaken", CFGFLAG_SERVER, "Ban reason for 'sv_dnsbl_ban'")
 MACRO_CONFIG_INT(SvDnsblChat, sv_dnsbl_chat, 0, 0, 1, CFGFLAG_SERVER, "Don't allow chat from blacklisted addresses")
 MACRO_CONFIG_INT(SvRconVote, sv_rcon_vote, 0, 0, 1, CFGFLAG_SERVER, "Only allow authed clients to call votes")
+MACRO_CONFIG_STR(SvVerifyUrl, sv_verify_url, 128, "", CFGFLAG_SERVER, "A URL which the client will send a HTTP GET request to upon connecting")
 
 MACRO_CONFIG_INT(SvPlayerDemoRecord, sv_player_demo_record, 0, 0, 1, CFGFLAG_SERVER, "Automatically record demos for each player")
 MACRO_CONFIG_INT(SvDemoChat, sv_demo_chat, 0, 0, 1, CFGFLAG_SERVER, "Record chat for demos")

--- a/src/engine/shared/serverinfo.cpp
+++ b/src/engine/shared/serverinfo.cpp
@@ -72,6 +72,7 @@ bool CServerInfo2::FromJsonRaw(CServerInfo2 *pOut, const json_value *pJson)
 	const json_value &Version = ServerInfo["version"];
 	const json_value &Clients = ServerInfo["clients"];
 	const json_value &RequiresLogin = ServerInfo["requires_login"];
+	const json_value &VerifyUrl = ServerInfo["verify_url"];
 
 	Error = false;
 	Error = Error || MaxClients.type != json_integer;
@@ -102,6 +103,11 @@ bool CServerInfo2::FromJsonRaw(CServerInfo2 *pOut, const json_value *pJson)
 	if(RequiresLogin.type == json_boolean)
 	{
 		pOut->m_RequiresLogin = RequiresLogin;
+	}
+	str_copy(pOut->m_aVerifyUrl, "");
+	if(VerifyUrl.type == json_string)
+	{
+		str_copy(pOut->m_aVerifyUrl, VerifyUrl);
 	}
 	pOut->m_Passworded = Passworded;
 	str_copy(pOut->m_aGameType, GameType);
@@ -239,6 +245,7 @@ CServerInfo2::operator CServerInfo() const
 	str_copy(Result.m_aName, m_aName);
 	str_copy(Result.m_aMap, m_aMapName);
 	str_copy(Result.m_aVersion, m_aVersion);
+	str_copy(Result.m_aVerifyUrl, m_aVerifyUrl);
 
 	for(int i = 0; i < minimum(m_NumClients, (int)SERVERINFO_MAX_CLIENTS); i++)
 	{

--- a/src/engine/shared/serverinfo.h
+++ b/src/engine/shared/serverinfo.h
@@ -39,6 +39,7 @@ public:
 	char m_aMapName[MAX_MAP_LENGTH];
 	char m_aVersion[32];
 	bool m_RequiresLogin;
+	char m_aVerifyUrl[128];
 
 	bool operator==(const CServerInfo2 &Other) const;
 	bool operator!=(const CServerInfo2 &Other) const { return !(*this == Other); }


### PR DESCRIPTION
Not sure if it should be a config option, so that GER10 for example doesn't have to maintain it's own fork.

Closes #6808 Supersedes #8698

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
