### PR TITLE
Fix crash with `hot_reload` while in `super`

### DIFF
--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -3208,12 +3208,16 @@ void CGameContext::ConHotReload(IConsole::IResult *pResult, void *pUserData)
 		if(!pSelf->GetPlayerChar(i))
 			continue;
 
+		CCharacter *pChar = pSelf->GetPlayerChar(i);
+
 		// Save the tee individually
 		pSelf->m_apSavedTees[i] = new CSaveTee();
-		pSelf->m_apSavedTees[i]->Save(pSelf->GetPlayerChar(i), false);
+		pSelf->m_apSavedTees[i]->Save(pChar, false);
 
 		// Save the team state
 		pSelf->m_aTeamMapping[i] = pSelf->GetDDRaceTeam(i);
+		if(pSelf->m_aTeamMapping[i] == TEAM_SUPER)
+			pSelf->m_aTeamMapping[i] = pChar->m_TeamBeforeSuper;
 
 		if(pSelf->m_apSavedTeams[pSelf->m_aTeamMapping[i]])
 			continue;


### PR DESCRIPTION
It would previously crash if you were in `super` and doing `hot_reload`. It will now instead put you back into your actual team if you were in `super`.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
