### PR TITLE
stops coloring of Y and X speed vals if val=0

### DIFF
--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -1369,7 +1369,8 @@ void CHud::RenderMovementInformation(const int ClientId)
 		const char aaCoordinates[][4] = {"X:", "Y:"};
 		for(int i = 0; i < 2; i++)
 		{
-			TextRender()->TextColor(ColorRGBA(1, 1, 1, 1));
+			if(m_aPlayerSpeed[0] == 0 || m_aPlayerSpeed[1] == 0)
+				TextRender()->TextColor(ColorRGBA(1, 1, 1, 1));
 			if(m_aLastPlayerSpeedChange[i] == ESpeedChange::INCREASE)
 				TextRender()->TextColor(ColorRGBA(0, 1, 0, 1));
 			if(m_aLastPlayerSpeedChange[i] == ESpeedChange::DECREASE)


### PR DESCRIPTION
attempt to fix #8814 
Absolutely no idea if this has any effect - but if i understand m_aPlayerSpeed correctly this should prevent the color from rendering if any of both values is 0. one other possible fix seems to use `m_aLastPlayerSpeedChange[i] = ESpeedChange::NONE;` instead - hard to fix something you can't reproduce.

two other things i found out were that when you spam a and d the Y value spasm's a little bit and the X speed value isnt actually properly aligned with the position value?
no idea what causes this, maybe related to #8743

spasms:
https://github.com/user-attachments/assets/5f5d2691-5fec-4a8f-ae60-78577da88388

speed != position
https://github.com/user-attachments/assets/aa6230f2-8d92-4313-bd35-101b3f068d55

cc: @ChillerDragon 

## Checklist
- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
