### PR TITLE
Fix heap-use-after-free in `CVideo::Stop`

### DIFF
--- a/src/engine/client/video.cpp
+++ b/src/engine/client/video.cpp
@@ -283,6 +283,7 @@ void CVideo::Pause(bool Pause)
 void CVideo::Stop()
 {
 	dbg_assert(!m_Stopped, "Already stopped");
+	m_Stopped = true;
 
 	m_pGraphics->WaitForIdle();
 
@@ -341,8 +342,6 @@ void CVideo::Stop()
 	pSound->PauseAudioDevice();
 	delete ms_pCurrentVideo;
 	pSound->UnpauseAudioDevice();
-
-	m_Stopped = true;
 }
 
 void CVideo::NextVideoFrameThread()


### PR DESCRIPTION
The `delete ms_pCurrentVideo` deletes the current video instance (`this`) so the subsequent write to `m_Stopped` was invalid.

Closes #8899.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [X] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
