### PR TITLE
Fix redefinition of `CONF_ARCH_STRING` for ARM architectures

### DIFF
--- a/src/base/detect.h
+++ b/src/base/detect.h
@@ -163,18 +163,18 @@
 #define CONF_ARCH_ARM 1
 #define CONF_ARCH_STRING "arm"
 #define CONF_ARCH_ENDIAN_BIG 1
-#endif
-
-#if defined(__ARMEL__)
+#elif defined(__ARMEL__)
 #define CONF_ARCH_ARM 1
 #define CONF_ARCH_STRING "arm"
 #define CONF_ARCH_ENDIAN_LITTLE 1
-#endif
-
-#if defined(__aarch64__) || defined(__arm64__) || defined(__ARM_ARCH)
+#elif defined(__aarch64__) || defined(__arm64__) || defined(__ARM_ARCH_ISA_A64)
 #define CONF_ARCH_ARM64 1
 #define CONF_ARCH_STRING "arm64"
+#if defined(__ARM_BIG_ENDIAN)
+#define CONF_ARCH_ENDIAN_BIG 1
+#else
 #define CONF_ARCH_ENDIAN_LITTLE 1
+#endif
 #endif
 
 #ifndef CONF_FAMILY_STRING


### PR DESCRIPTION
The macro `__ARM_ARCH` is defined both for 32-bit and 64-bit ARM so it cannot be used to identify ARM64. Now `__ARM_ARCH_ISA_A64` is used instead, which should only be defined for ARM64. This caused a warning due to the macro `CONF_ARCH_STRING` being redefined when compiling for Android. Furthermore, support for detecting big-endian ARM64 with the `__ARM_BIG_ENDIAN` macro is added.

See https://developer.arm.com/documentation/dui0774/g/chr1383660321827

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
