### PR TITLE
Add /unspec command

### DIFF
--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -376,6 +376,37 @@ void CGameContext::ConToggleSpec(IConsole::IResult *pResult, void *pUserData)
 	ToggleSpecPause(pResult, pUserData, g_Config.m_SvPauseable ? CPlayer::PAUSE_SPEC : CPlayer::PAUSE_PAUSED);
 }
 
+void CGameContext::ConUnspec(IConsole::IResult *pResult, void *pUserData)
+{
+	if(!CheckClientId(pResult->m_ClientId))
+		return;
+
+	CGameContext *pSelf = (CGameContext *)pUserData;
+	CPlayer *pPlayer = pSelf->m_apPlayers[pResult->m_ClientId];
+	if(!pPlayer)
+		return;
+
+	int PauseState = pPlayer->IsPaused();
+	int PauseType = g_Config.m_SvPauseable ? CPlayer::PAUSE_SPEC : CPlayer::PAUSE_PAUSED;
+	if(PauseState > 0)
+	{
+		IServer *pServ = pSelf->Server();
+		char aBuf[128];
+		str_format(aBuf, sizeof(aBuf), "You are force-paused for %d seconds.", (PauseState - pServ->Tick()) / pServ->TickSpeed());
+		pSelf->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "chatresp", aBuf);
+	}
+	else
+	{
+		if(-PauseState != CPlayer::PAUSE_NONE && PauseType != CPlayer::PAUSE_NONE)
+		{
+			pPlayer->Pause(CPlayer::PAUSE_NONE, false);
+
+			if(pPlayer->m_SpectatorId != pResult->m_ClientId)
+				pPlayer->SpectateFreeView();
+		}
+	}
+}
+
 void CGameContext::ConToggleSpecVoted(IConsole::IResult *pResult, void *pUserData)
 {
 	ToggleSpecPauseVoted(pResult, pUserData, g_Config.m_SvPauseable ? CPlayer::PAUSE_SPEC : CPlayer::PAUSE_PAUSED);

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -3747,6 +3747,7 @@ void CGameContext::RegisterChatCommands()
 	Console()->Register("converse", "r[message]", CFGFLAG_CHAT | CFGFLAG_SERVER | CFGFLAG_NONTEEHISTORIC, ConConverse, this, "Converse with the last person you whispered to (private message)");
 	Console()->Register("pause", "?r[player name]", CFGFLAG_CHAT | CFGFLAG_SERVER, ConTogglePause, this, "Toggles pause");
 	Console()->Register("spec", "?r[player name]", CFGFLAG_CHAT | CFGFLAG_SERVER, ConToggleSpec, this, "Toggles spec (if not available behaves as /pause)");
+	Console()->Register("unspec", "", CFGFLAG_CHAT | CFGFLAG_SERVER, ConUnspec, this, "Stops spectating the current player and returns to free view mode");
 	Console()->Register("pausevoted", "", CFGFLAG_CHAT | CFGFLAG_SERVER, ConTogglePauseVoted, this, "Toggles pause on the currently voted player");
 	Console()->Register("specvoted", "", CFGFLAG_CHAT | CFGFLAG_SERVER, ConToggleSpecVoted, this, "Toggles spec on the currently voted player");
 	Console()->Register("dnd", "?i['0'|'1']", CFGFLAG_CHAT | CFGFLAG_SERVER | CFGFLAG_NONTEEHISTORIC, ConDND, this, "Toggle Do Not Disturb (no chat and server messages)");

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -426,6 +426,7 @@ private:
 	static void ConTogglePause(IConsole::IResult *pResult, void *pUserData);
 	static void ConTogglePauseVoted(IConsole::IResult *pResult, void *pUserData);
 	static void ConToggleSpec(IConsole::IResult *pResult, void *pUserData);
+	static void ConUnspec(IConsole::IResult *pResult, void *pUserData);
 	static void ConToggleSpecVoted(IConsole::IResult *pResult, void *pUserData);
 	static void ConForcePause(IConsole::IResult *pResult, void *pUserData);
 	static void ConTeamTop5(IConsole::IResult *pResult, void *pUserData);

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -867,6 +867,12 @@ void CPlayer::SpectatePlayerName(const char *pName)
 	}
 }
 
+void CPlayer::SpectateFreeView()
+{
+	if(m_SpectatorId >= 0)
+		m_SpectatorId = SPEC_FREEVIEW;
+}
+
 void CPlayer::ProcessScoreResult(CScorePlayerResult &Result)
 {
 	if(Result.m_Success) // SQL request was successful

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -67,6 +67,7 @@ public:
 	const CCharacter *GetCharacter() const;
 
 	void SpectatePlayerName(const char *pName);
+	void SpectateFreeView();
 
 	//---------------------------------------------------------
 	// this is used for snapping so we know how we can clip the view for the player


### PR DESCRIPTION
The current way `/spec` command works is misleading for new players. After using `/spec "playername"`, we are stuck spectating that player until they disconnect, unless we know about the spectator mode selector menu, which isn't mentioned anywhere. Many players, including myself, had the same issue, as seen by searching for "stop spectating" and similar terms on the DDNet discord. The `/unspec` command feels intuitive, as it follows the same naming conventions as other commands, like `/solo` and `/unsolo`

https://github.com/user-attachments/assets/e845aff5-c95e-4588-a7a6-7e1f998e21e1



## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
