### PR TITLE
Fix editor crash when saving maps with RGB mapres

### DIFF
--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -300,7 +300,7 @@ void CGraphics_Threaded::UnloadTexture(CTextureHandle *pIndex)
 	FreeTextureIndex(pIndex);
 }
 
-static bool ConvertToRGBA(uint8_t *pDest, const CImageInfo &SrcImage)
+bool ConvertToRGBA(uint8_t *pDest, const CImageInfo &SrcImage)
 {
 	if(SrcImage.m_Format == CImageInfo::FORMAT_RGBA)
 	{

--- a/src/engine/graphics.h
+++ b/src/engine/graphics.h
@@ -124,6 +124,8 @@ public:
 	}
 };
 
+bool ConvertToRGBA(uint8_t *pDest, const CImageInfo &SrcImage);
+
 /*
 	Structure: CVideoMode
 */

--- a/src/game/editor/mapitems/map_io.cpp
+++ b/src/game/editor/mapitems/map_io.cpp
@@ -509,6 +509,15 @@ bool CEditorMap::Load(const char *pFileName, int StorageType, const std::functio
 					pImg->m_Height = ImgInfo.m_Height;
 					pImg->m_Format = ImgInfo.m_Format;
 					pImg->m_pData = ImgInfo.m_pData;
+					if(pImg->m_Format != CImageInfo::FORMAT_RGBA)
+					{
+						uint8_t *pRgbaData = static_cast<uint8_t *>(malloc((size_t)pImg->m_Width * pImg->m_Height * CImageInfo::PixelSize(CImageInfo::FORMAT_RGBA)));
+						ConvertToRGBA(pRgbaData, *pImg);
+						free(pImg->m_pData);
+						pImg->m_pData = pRgbaData;
+						pImg->m_Format = CImageInfo::FORMAT_RGBA;
+					}
+
 					int TextureLoadFlag = m_pEditor->Graphics()->Uses2DTextureArrays() ? IGraphics::TEXLOAD_TO_2D_ARRAY_TEXTURE : IGraphics::TEXLOAD_TO_3D_TEXTURE;
 					if(ImgInfo.m_Width % 16 != 0 || ImgInfo.m_Height % 16 != 0)
 						TextureLoadFlag = 0;


### PR DESCRIPTION
Convert mapres to RGBA immediately when loading them, so the image data is always in RGBA format internally, instead of only converting when the map is saved (which was erroneously removed in #8670).

This means the `cl_editor_dilate` setting will now also be applied to converted RGB images.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
