### PR TITLE
Fixes a bug where econ was exposed publicly when ec_bindaddr was set to localhost

### DIFF
--- a/src/engine/shared/econ.cpp
+++ b/src/engine/shared/econ.cpp
@@ -70,18 +70,18 @@ void CEcon::Init(CConfig *pConfig, IConsole *pConsole, CNetBan *pNetBan)
 	}
 
 	NETADDR BindAddr;
-	if(g_Config.m_EcBindaddr[0] == '\0')
+	if(g_Config.m_EcBindaddr[0] && net_host_lookup(g_Config.m_EcBindaddr, &BindAddr, NETTYPE_ALL) == 0)
 	{
-		mem_zero(&BindAddr, sizeof(BindAddr));
+		// got bindaddr
+		BindAddr.port = g_Config.m_EcPort;
 	}
-	else if(net_host_lookup(g_Config.m_EcBindaddr, &BindAddr, NETTYPE_ALL) != 0)
+	else
 	{
 		char aBuf[256];
-		str_format(aBuf, sizeof(aBuf), "The configured bindaddr '%s' cannot be resolved.", g_Config.m_Bindaddr);
+		str_format(aBuf, sizeof(aBuf), "The configured bindaddr '%s' cannot be resolved.", g_Config.m_EcBindaddr);
 		Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "econ", aBuf);
+		return;
 	}
-	BindAddr.type = NETTYPE_ALL;
-	BindAddr.port = g_Config.m_EcPort;
 
 	if(m_NetConsole.Open(BindAddr, pNetBan))
 	{


### PR DESCRIPTION
Fixes a bug where econ was exposed publicly when `ec_bindaddr` was set to `localhost`. Also implements the original intention of 85f5e9c that is to disable econ if `ec_binaddr` is invalid.

I've tested the following values and they behave as expected now:

```
ec_bindaddr "localhost" # listens on ::1 on my system
ec_bindaddr "127.0.0.1"
ec_bindaddr "0.0.0.0"
ec_bindaddr "[::1]"
ec_bindaddr "[::]"
ec_bindaddr "nonsense" # prints error and disables econ
```
Explanation: The old code first parses `ec_bindaddr` using `net_host_lookup` which returns a `NETADDR` struct. Then it overwrites the `type` field of the `NETADDR` which was either `NETTYPE_IPV4` or `NETTYPE_IPV6` and sets it to `NETTYPE_ALL` (this is the problem). Later `net_tcp_create` interprets the same 16 bytes as ipv6 and ipv4 (only first 4 bytes here) and two sockets are created one for each. If `ec_bindaddr` is `localhost` (the default) then `net_host_lookup` returns `::1` and this is interpreted as `0.0.0.0`, thus the bug.

In general having a  `NETADDR` instance with the `type` field set to `NETTYPE_ALL` never makes sense. These 16 bytes are either an ipv4 address or an ipv6 address but not both.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
