### PR TITLE
Fix dummy 0.7 tee skin name not being used, fix some unused config variables not being detected

### DIFF
--- a/scripts/check_config_variables.py
+++ b/scripts/check_config_variables.py
@@ -17,7 +17,7 @@ def parse_config_variables(lines):
 	return matches
 
 def generate_regex(variable_code):
-	return fr'(g_Config\.m_{variable_code}|Config\(\)->m_{variable_code}|m_pConfig->m_{variable_code})'
+	return fr'(g_Config\.m_{variable_code}\b|Config\(\)->m_{variable_code}\b|m_pConfig->m_{variable_code}\b)'
 
 def find_config_variables(config_variables):
 	"""Returns the config variables which were not found."""

--- a/src/game/client/components/menus_settings7.cpp
+++ b/src/game/client/components/menus_settings7.cpp
@@ -313,7 +313,6 @@ void CMenus::RenderSettingsTeeCustom7(CUIRect MainView)
 	if(DoButton_Menu(&s_RandomSkinButton, s_apDice[s_CurrentDie], 0, &RandomSkinButton, nullptr, IGraphics::CORNER_ALL, 5.0f, -0.2f))
 	{
 		m_pClient->m_Skins7.RandomizeSkin(m_Dummy);
-		Config()->m_ClPlayer7Skin[0] = '\0';
 		SetNeedSendInfo();
 		s_CurrentDie = rand() % std::size(s_apDice);
 	}
@@ -356,7 +355,7 @@ void CMenus::RenderSkinSelection7(CUIRect MainView)
 		const CSkins7::CSkin *pSkin = s_vpSkinList[i];
 		if(pSkin == nullptr)
 			continue;
-		if(!str_comp(pSkin->m_aName, Config()->m_ClPlayer7Skin))
+		if(!str_comp(pSkin->m_aName, CSkins7::ms_apSkinNameVariables[m_Dummy]))
 		{
 			m_pSelectedSkin = pSkin;
 			s_OldSelected = i;
@@ -401,7 +400,7 @@ void CMenus::RenderSkinSelection7(CUIRect MainView)
 	{
 		s_LastSelectionTime = Client()->GlobalTime();
 		m_pSelectedSkin = s_vpSkinList[NewSelected];
-		str_copy(Config()->m_ClPlayer7Skin, m_pSelectedSkin->m_aName);
+		str_copy(CSkins7::ms_apSkinNameVariables[m_Dummy], m_pSelectedSkin->m_aName, protocol7::MAX_SKIN_ARRAY_SIZE);
 		for(int Part = 0; Part < protocol7::NUM_SKINPARTS; Part++)
 		{
 			str_copy(CSkins7::ms_apSkinVariables[(int)m_Dummy][Part], m_pSelectedSkin->m_apParts[Part]->m_aName, protocol7::MAX_SKIN_ARRAY_SIZE);
@@ -492,7 +491,7 @@ void CMenus::RenderSkinPartSelection7(CUIRect MainView)
 	if(NewSelected != -1 && NewSelected != s_OldSelected)
 	{
 		str_copy(CSkins7::ms_apSkinVariables[(int)m_Dummy][m_TeePartSelected], s_paList[m_TeePartSelected][NewSelected]->m_aName, protocol7::MAX_SKIN_ARRAY_SIZE);
-		Config()->m_ClPlayer7Skin[0] = '\0';
+		CSkins7::ms_apSkinNameVariables[m_Dummy][0] = '\0';
 		SetNeedSendInfo();
 	}
 	s_OldSelected = NewSelected;

--- a/src/game/client/components/skins7.cpp
+++ b/src/game/client/components/skins7.cpp
@@ -23,6 +23,7 @@ const char *const CSkins7::ms_apSkinPartNames[protocol7::NUM_SKINPARTS] = {"body
 const char *const CSkins7::ms_apSkinPartNamesLocalized[protocol7::NUM_SKINPARTS] = {Localizable("Body", "skins"), Localizable("Marking", "skins"), Localizable("Decoration", "skins"), Localizable("Hands", "skins"), Localizable("Feet", "skins"), Localizable("Eyes", "skins")};
 const char *const CSkins7::ms_apColorComponents[NUM_COLOR_COMPONENTS] = {"hue", "sat", "lgt", "alp"};
 
+char *CSkins7::ms_apSkinNameVariables[NUM_DUMMIES] = {0};
 char *CSkins7::ms_apSkinVariables[NUM_DUMMIES][protocol7::NUM_SKINPARTS] = {{0}};
 int *CSkins7::ms_apUCCVariables[NUM_DUMMIES][protocol7::NUM_SKINPARTS] = {{0}};
 int unsigned *CSkins7::ms_apColorVariables[NUM_DUMMIES][protocol7::NUM_SKINPARTS] = {{0}};
@@ -231,6 +232,7 @@ int CSkins7::GetInitAmount() const
 void CSkins7::OnInit()
 {
 	int Dummy = 0;
+	ms_apSkinNameVariables[Dummy] = Config()->m_ClPlayer7Skin;
 	ms_apSkinVariables[Dummy][protocol7::SKINPART_BODY] = Config()->m_ClPlayer7SkinBody;
 	ms_apSkinVariables[Dummy][protocol7::SKINPART_MARKING] = Config()->m_ClPlayer7SkinMarking;
 	ms_apSkinVariables[Dummy][protocol7::SKINPART_DECORATION] = Config()->m_ClPlayer7SkinDecoration;
@@ -251,6 +253,7 @@ void CSkins7::OnInit()
 	ms_apColorVariables[Dummy][protocol7::SKINPART_EYES] = &Config()->m_ClPlayer7ColorEyes;
 
 	Dummy = 1;
+	ms_apSkinNameVariables[Dummy] = Config()->m_ClDummy7Skin;
 	ms_apSkinVariables[Dummy][protocol7::SKINPART_BODY] = Config()->m_ClDummy7SkinBody;
 	ms_apSkinVariables[Dummy][protocol7::SKINPART_MARKING] = Config()->m_ClDummy7SkinMarking;
 	ms_apSkinVariables[Dummy][protocol7::SKINPART_DECORATION] = Config()->m_ClDummy7SkinDecoration;
@@ -463,17 +466,19 @@ void CSkins7::RandomizeSkin(int Dummy)
 		if(Part == protocol7::SKINPART_MARKING)
 			Alp = rand() % 255;
 		int ColorVariable = (Alp << 24) | (Hue << 16) | (Sat << 8) | Lgt;
-		*CSkins7::ms_apUCCVariables[Dummy][Part] = true;
-		*CSkins7::ms_apColorVariables[Dummy][Part] = ColorVariable;
+		*ms_apUCCVariables[Dummy][Part] = true;
+		*ms_apColorVariables[Dummy][Part] = ColorVariable;
 	}
 
 	for(int Part = 0; Part < protocol7::NUM_SKINPARTS; Part++)
 	{
-		const CSkins7::CSkinPart *pSkinPart = GetSkinPart(Part, rand() % NumSkinPart(Part));
-		while(pSkinPart->m_Flags & CSkins7::SKINFLAG_SPECIAL)
+		const CSkinPart *pSkinPart = GetSkinPart(Part, rand() % NumSkinPart(Part));
+		while(pSkinPart->m_Flags & SKINFLAG_SPECIAL)
 			pSkinPart = GetSkinPart(Part, rand() % NumSkinPart(Part));
-		mem_copy(CSkins7::ms_apSkinVariables[Dummy][Part], pSkinPart->m_aName, protocol7::MAX_SKIN_ARRAY_SIZE);
+		str_copy(ms_apSkinVariables[Dummy][Part], pSkinPart->m_aName, protocol7::MAX_SKIN_ARRAY_SIZE);
 	}
+
+	ms_apSkinNameVariables[Dummy][0] = '\0';
 }
 
 ColorRGBA CSkins7::GetColor(int Value, bool UseAlpha) const

--- a/src/game/client/components/skins7.h
+++ b/src/game/client/components/skins7.h
@@ -55,6 +55,7 @@ public:
 	static const char *const ms_apSkinPartNamesLocalized[protocol7::NUM_SKINPARTS];
 	static const char *const ms_apColorComponents[NUM_COLOR_COMPONENTS];
 
+	static char *ms_apSkinNameVariables[NUM_DUMMIES];
 	static char *ms_apSkinVariables[NUM_DUMMIES][protocol7::NUM_SKINPARTS];
 	static int *ms_apUCCVariables[NUM_DUMMIES][protocol7::NUM_SKINPARTS]; // use custom color
 	static unsigned int *ms_apColorVariables[NUM_DUMMIES][protocol7::NUM_SKINPARTS];


### PR DESCRIPTION
The dummy 0.7 skin name was not being updated and used, causing the wrong skin to be selected when switching between player and dummy settings.

Unused config variables were not detected if they were the prefix of a longer config variable which is used.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
