### PR TITLE
Store `CTeeRenderInfo` instead of members for chat lines, extract `CTeeRenderInfo::Apply(const CSkin *)` function

### DIFF
--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -805,50 +805,9 @@ void CChat::AddLine(int ClientId, int Team, const char *pLine)
 		{
 			if(!g_Config.m_ClChatOld)
 			{
-				pCurrentLine->m_CustomColoredSkin = LineAuthor.m_RenderInfo.m_CustomColoredSkin;
-				if(pCurrentLine->m_CustomColoredSkin)
-					pCurrentLine->m_RenderSkin = LineAuthor.m_RenderInfo.m_ColorableRenderSkin;
-				else
-					pCurrentLine->m_RenderSkin = LineAuthor.m_RenderInfo.m_OriginalRenderSkin;
-
 				str_copy(pCurrentLine->m_aSkinName, LineAuthor.m_aSkinName);
-				pCurrentLine->m_ColorBody = LineAuthor.m_RenderInfo.m_ColorBody;
-				pCurrentLine->m_ColorFeet = LineAuthor.m_RenderInfo.m_ColorFeet;
-
-				pCurrentLine->m_RenderSkinMetrics = LineAuthor.m_RenderInfo.m_SkinMetrics;
+				pCurrentLine->m_TeeRenderInfo = LineAuthor.m_RenderInfo;
 				pCurrentLine->m_HasRenderTee = true;
-
-				// 0.7
-				if(Client()->IsSixup())
-				{
-					for(int Part = 0; Part < protocol7::NUM_SKINPARTS; Part++)
-					{
-						const char *pPartName = LineAuthor.m_aSixup[g_Config.m_ClDummy].m_aaSkinPartNames[Part];
-						int Id = m_pClient->m_Skins7.FindSkinPart(Part, pPartName, false);
-						const CSkins7::CSkinPart *pSkinPart = m_pClient->m_Skins7.GetSkinPart(Part, Id);
-						if(LineAuthor.m_aSixup[g_Config.m_ClDummy].m_aUseCustomColors[Part])
-						{
-							pCurrentLine->m_Sixup.m_aTextures[Part] = pSkinPart->m_ColorTexture;
-							pCurrentLine->m_Sixup.m_aColors[Part] = m_pClient->m_Skins7.GetColor(
-								LineAuthor.m_aSixup[g_Config.m_ClDummy].m_aSkinPartColors[Part],
-								Part == protocol7::SKINPART_MARKING);
-						}
-						else
-						{
-							pCurrentLine->m_Sixup.m_aTextures[Part] = pSkinPart->m_OrgTexture;
-							pCurrentLine->m_Sixup.m_aColors[Part] = vec4(1.0f, 1.0f, 1.0f, 1.0f);
-						}
-
-						if(LineAuthor.m_SkinInfo.m_aSixup[g_Config.m_ClDummy].m_HatTexture.IsValid())
-						{
-							if(Part == protocol7::SKINPART_BODY && str_comp(pPartName, "standard"))
-								pCurrentLine->m_Sixup.m_HatSpriteIndex = CSkins7::HAT_OFFSET_SIDE + (ClientId % CSkins7::HAT_NUM);
-							if(Part == protocol7::SKINPART_DECORATION && str_comp(pPartName, "twinbopp"))
-								pCurrentLine->m_Sixup.m_HatSpriteIndex = CSkins7::HAT_OFFSET_SIDE + (ClientId % CSkins7::HAT_NUM);
-							pCurrentLine->m_Sixup.m_HatTexture = LineAuthor.m_SkinInfo.m_aSixup[g_Config.m_ClDummy].m_HatTexture;
-						}
-					}
-				}
 			}
 		}
 	}
@@ -918,16 +877,13 @@ void CChat::OnRefreshSkins()
 		if(Line.m_HasRenderTee)
 		{
 			const CSkin *pSkin = m_pClient->m_Skins.Find(Line.m_aSkinName);
-			if(Line.m_CustomColoredSkin)
-				Line.m_RenderSkin = pSkin->m_ColorableSkin;
-			else
-				Line.m_RenderSkin = pSkin->m_OriginalSkin;
-
-			Line.m_RenderSkinMetrics = pSkin->m_Metrics;
+			Line.m_TeeRenderInfo.m_OriginalRenderSkin = pSkin->m_OriginalSkin;
+			Line.m_TeeRenderInfo.m_ColorableRenderSkin = pSkin->m_ColorableSkin;
+			Line.m_TeeRenderInfo.m_SkinMetrics = pSkin->m_Metrics;
 		}
 		else
 		{
-			Line.m_RenderSkin.Reset();
+			Line.m_TeeRenderInfo.Reset();
 		}
 	}
 }
@@ -1291,28 +1247,7 @@ void CChat::OnRender()
 			if(!g_Config.m_ClChatOld && Line.m_HasRenderTee)
 			{
 				const int TeeSize = MessageTeeSize();
-				CTeeRenderInfo RenderInfo;
-				RenderInfo.m_CustomColoredSkin = Line.m_CustomColoredSkin;
-				if(Line.m_CustomColoredSkin)
-					RenderInfo.m_ColorableRenderSkin = Line.m_RenderSkin;
-				else
-					RenderInfo.m_OriginalRenderSkin = Line.m_RenderSkin;
-				RenderInfo.m_SkinMetrics = Line.m_RenderSkinMetrics;
-
-				RenderInfo.m_ColorBody = Line.m_ColorBody;
-				RenderInfo.m_ColorFeet = Line.m_ColorFeet;
-				RenderInfo.m_Size = TeeSize;
-
-				if(Client()->IsSixup())
-				{
-					for(int Part = 0; Part < protocol7::NUM_SKINPARTS; Part++)
-					{
-						RenderInfo.m_aSixup[g_Config.m_ClDummy].m_aColors[Part] = Line.m_Sixup.m_aColors[Part];
-						RenderInfo.m_aSixup[g_Config.m_ClDummy].m_aTextures[Part] = Line.m_Sixup.m_aTextures[Part];
-						RenderInfo.m_aSixup[g_Config.m_ClDummy].m_HatSpriteIndex = Line.m_Sixup.m_HatSpriteIndex;
-						RenderInfo.m_aSixup[g_Config.m_ClDummy].m_HatTexture = Line.m_Sixup.m_HatTexture;
-					}
-				}
+				Line.m_TeeRenderInfo.m_Size = TeeSize;
 
 				float RowHeight = FontSize() + RealMsgPaddingY;
 				float OffsetTeeY = TeeSize / 2.0f;
@@ -1320,9 +1255,9 @@ void CChat::OnRender()
 
 				const CAnimState *pIdleState = CAnimState::GetIdle();
 				vec2 OffsetToMid;
-				CRenderTools::GetRenderTeeOffsetToRenderedTee(pIdleState, &RenderInfo, OffsetToMid);
+				CRenderTools::GetRenderTeeOffsetToRenderedTee(pIdleState, &Line.m_TeeRenderInfo, OffsetToMid);
 				vec2 TeeRenderPos(x + (RealMsgPaddingX + TeeSize) / 2.0f, y + OffsetTeeY + FullHeightMinusTee / 2.0f + OffsetToMid.y);
-				RenderTools()->RenderTee(pIdleState, &RenderInfo, EMOTE_NORMAL, vec2(1, 0.1f), TeeRenderPos, Blend);
+				RenderTools()->RenderTee(pIdleState, &Line.m_TeeRenderInfo, EMOTE_NORMAL, vec2(1, 0.1f), TeeRenderPos, Blend);
 			}
 
 			const ColorRGBA TextColor = TextRender()->DefaultTextColor().WithMultipliedAlpha(Blend);

--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -876,10 +876,7 @@ void CChat::OnRefreshSkins()
 	{
 		if(Line.m_HasRenderTee)
 		{
-			const CSkin *pSkin = m_pClient->m_Skins.Find(Line.m_aSkinName);
-			Line.m_TeeRenderInfo.m_OriginalRenderSkin = pSkin->m_OriginalSkin;
-			Line.m_TeeRenderInfo.m_ColorableRenderSkin = pSkin->m_ColorableSkin;
-			Line.m_TeeRenderInfo.m_SkinMetrics = pSkin->m_Metrics;
+			Line.m_TeeRenderInfo.Apply(m_pClient->m_Skins.Find(Line.m_aSkinName));
 		}
 		else
 		{

--- a/src/game/client/components/chat.h
+++ b/src/game/client/components/chat.h
@@ -11,6 +11,7 @@
 
 #include <game/client/component.h>
 #include <game/client/lineinput.h>
+#include <game/client/render.h>
 #include <game/client/skin.h>
 #include <game/generated/protocol7.h>
 
@@ -45,30 +46,12 @@ class CChat : public CComponent
 		int m_QuadContainerIndex;
 
 		char m_aSkinName[std::size(g_Config.m_ClPlayerSkin)];
-		CSkin::SSkinTextures m_RenderSkin;
-		CSkin::SSkinMetrics m_RenderSkinMetrics;
-		bool m_CustomColoredSkin;
-		ColorRGBA m_ColorBody;
-		ColorRGBA m_ColorFeet;
-
 		bool m_HasRenderTee;
+		CTeeRenderInfo m_TeeRenderInfo;
+
 		float m_TextYOffset;
 
 		int m_TimesRepeated;
-
-		class CSixup
-		{
-		public:
-			IGraphics::CTextureHandle m_aTextures[protocol7::NUM_SKINPARTS];
-			IGraphics::CTextureHandle m_HatTexture;
-			IGraphics::CTextureHandle m_BotTexture;
-			int m_HatSpriteIndex;
-			ColorRGBA m_BotColor;
-			ColorRGBA m_aColors[protocol7::NUM_SKINPARTS];
-		};
-
-		// 0.7 Skin
-		CSixup m_Sixup;
 	};
 
 	bool m_PrevScoreBoardShowed;

--- a/src/game/client/components/ghost.cpp
+++ b/src/game/client/components/ghost.cpp
@@ -366,10 +366,7 @@ void CGhost::OnRender()
 					IsTeamplay = (m_pClient->m_Snap.m_pGameInfoObj->m_GameFlags & GAMEFLAG_TEAMS) != 0;
 
 				GhostNinjaRenderInfo = Ghost.m_RenderInfo;
-				GhostNinjaRenderInfo.m_OriginalRenderSkin = pSkin->m_OriginalSkin;
-				GhostNinjaRenderInfo.m_ColorableRenderSkin = pSkin->m_ColorableSkin;
-				GhostNinjaRenderInfo.m_BloodColor = pSkin->m_BloodColor;
-				GhostNinjaRenderInfo.m_SkinMetrics = pSkin->m_Metrics;
+				GhostNinjaRenderInfo.Apply(pSkin);
 				GhostNinjaRenderInfo.m_CustomColoredSkin = IsTeamplay;
 				if(!IsTeamplay)
 				{
@@ -392,11 +389,7 @@ void CGhost::InitRenderInfos(CGhostItem *pGhost)
 	IntsToStr(&pGhost->m_Skin.m_Skin0, 6, aSkinName, std::size(aSkinName));
 	CTeeRenderInfo *pRenderInfo = &pGhost->m_RenderInfo;
 
-	const CSkin *pSkin = m_pClient->m_Skins.Find(aSkinName);
-	pRenderInfo->m_OriginalRenderSkin = pSkin->m_OriginalSkin;
-	pRenderInfo->m_ColorableRenderSkin = pSkin->m_ColorableSkin;
-	pRenderInfo->m_BloodColor = pSkin->m_BloodColor;
-	pRenderInfo->m_SkinMetrics = pSkin->m_Metrics;
+	pRenderInfo->Apply(m_pClient->m_Skins.Find(aSkinName));
 	pRenderInfo->m_CustomColoredSkin = pGhost->m_Skin.m_UseCustomColor;
 	if(pGhost->m_Skin.m_UseCustomColor)
 	{
@@ -697,11 +690,7 @@ void CGhost::OnRefreshSkins()
 		CTeeRenderInfo *pRenderInfo = &Ghost.m_RenderInfo;
 		if(aSkinName[0] != '\0')
 		{
-			const CSkin *pSkin = m_pClient->m_Skins.Find(aSkinName);
-			pRenderInfo->m_OriginalRenderSkin = pSkin->m_OriginalSkin;
-			pRenderInfo->m_ColorableRenderSkin = pSkin->m_ColorableSkin;
-			pRenderInfo->m_BloodColor = pSkin->m_BloodColor;
-			pRenderInfo->m_SkinMetrics = pSkin->m_Metrics;
+			pRenderInfo->Apply(m_pClient->m_Skins.Find(aSkinName));
 		}
 		else
 		{

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1822,12 +1822,8 @@ bool CMenus::PrintHighlighted(const char *pName, F &&PrintFn)
 
 CTeeRenderInfo CMenus::GetTeeRenderInfo(vec2 Size, const char *pSkinName, bool CustomSkinColors, int CustomSkinColorBody, int CustomSkinColorFeet) const
 {
-	const CSkin *pSkin = m_pClient->m_Skins.Find(pSkinName);
-
 	CTeeRenderInfo TeeInfo;
-	TeeInfo.m_OriginalRenderSkin = pSkin->m_OriginalSkin;
-	TeeInfo.m_ColorableRenderSkin = pSkin->m_ColorableSkin;
-	TeeInfo.m_SkinMetrics = pSkin->m_Metrics;
+	TeeInfo.Apply(m_pClient->m_Skins.Find(pSkinName));
 	TeeInfo.m_CustomColoredSkin = CustomSkinColors;
 	if(CustomSkinColors)
 	{

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -633,11 +633,8 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 
 	// Note: get the skin info after the settings buttons, because they can trigger a refresh
 	// which invalidates the skin.
-	const CSkin *pSkin = m_pClient->m_Skins.Find(pSkinName);
 	CTeeRenderInfo OwnSkinInfo;
-	OwnSkinInfo.m_OriginalRenderSkin = pSkin->m_OriginalSkin;
-	OwnSkinInfo.m_ColorableRenderSkin = pSkin->m_ColorableSkin;
-	OwnSkinInfo.m_SkinMetrics = pSkin->m_Metrics;
+	OwnSkinInfo.Apply(m_pClient->m_Skins.Find(pSkinName));
 	OwnSkinInfo.m_CustomColoredSkin = *pUseCustomColor;
 	if(*pUseCustomColor)
 	{

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -844,10 +844,7 @@ void CPlayers::OnRender()
 			{
 				aRenderInfo[i].m_aSixup[g_Config.m_ClDummy].Reset();
 
-				aRenderInfo[i].m_OriginalRenderSkin = pSkin->m_OriginalSkin;
-				aRenderInfo[i].m_ColorableRenderSkin = pSkin->m_ColorableSkin;
-				aRenderInfo[i].m_BloodColor = pSkin->m_BloodColor;
-				aRenderInfo[i].m_SkinMetrics = pSkin->m_Metrics;
+				aRenderInfo[i].Apply(pSkin);
 				aRenderInfo[i].m_CustomColoredSkin = IsTeamplay;
 				if(!IsTeamplay)
 				{
@@ -857,12 +854,8 @@ void CPlayers::OnRender()
 			}
 		}
 	}
-	const CSkin *pSkin = m_pClient->m_Skins.Find("x_spec");
 	CTeeRenderInfo RenderInfoSpec;
-	RenderInfoSpec.m_OriginalRenderSkin = pSkin->m_OriginalSkin;
-	RenderInfoSpec.m_ColorableRenderSkin = pSkin->m_ColorableSkin;
-	RenderInfoSpec.m_BloodColor = pSkin->m_BloodColor;
-	RenderInfoSpec.m_SkinMetrics = pSkin->m_Metrics;
+	RenderInfoSpec.Apply(m_pClient->m_Skins.Find("x_spec"));
 	RenderInfoSpec.m_CustomColoredSkin = false;
 	RenderInfoSpec.m_Size = 64.0f;
 	const int LocalClientId = m_pClient->m_Snap.m_LocalClientId;

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1554,11 +1554,7 @@ void CGameClient::OnNewSnapshot()
 					pClient->m_SkinInfo.m_Size = 64;
 
 					// find new skin
-					const CSkin *pSkin = m_Skins.Find(pClient->m_aSkinName);
-					pClient->m_SkinInfo.m_OriginalRenderSkin = pSkin->m_OriginalSkin;
-					pClient->m_SkinInfo.m_ColorableRenderSkin = pSkin->m_ColorableSkin;
-					pClient->m_SkinInfo.m_SkinMetrics = pSkin->m_Metrics;
-					pClient->m_SkinInfo.m_BloodColor = pSkin->m_BloodColor;
+					pClient->m_SkinInfo.Apply(m_Skins.Find(pClient->m_aSkinName));
 					pClient->m_SkinInfo.m_CustomColoredSkin = pClient->m_UseCustomColor;
 
 					if(!pClient->m_UseCustomColor)
@@ -3750,13 +3746,9 @@ void CGameClient::RefreshSkins()
 
 	for(auto &Client : m_aClients)
 	{
-		Client.m_SkinInfo.m_OriginalRenderSkin.Reset();
-		Client.m_SkinInfo.m_ColorableRenderSkin.Reset();
 		if(Client.m_aSkinName[0] != '\0')
 		{
-			const CSkin *pSkin = m_Skins.Find(Client.m_aSkinName);
-			Client.m_SkinInfo.m_OriginalRenderSkin = pSkin->m_OriginalSkin;
-			Client.m_SkinInfo.m_ColorableRenderSkin = pSkin->m_ColorableSkin;
+			Client.m_SkinInfo.Apply(m_Skins.Find(Client.m_aSkinName));
 		}
 		else
 		{

--- a/src/game/client/render.h
+++ b/src/game/client/render.h
@@ -56,6 +56,14 @@ public:
 			Sixup.Reset();
 	}
 
+	void Apply(const CSkin *pSkin)
+	{
+		m_OriginalRenderSkin = pSkin->m_OriginalSkin;
+		m_ColorableRenderSkin = pSkin->m_ColorableSkin;
+		m_BloodColor = pSkin->m_BloodColor;
+		m_SkinMetrics = pSkin->m_Metrics;
+	}
+
 	CSkin::SSkinTextures m_OriginalRenderSkin;
 	CSkin::SSkinTextures m_ColorableRenderSkin;
 


### PR DESCRIPTION
Avoid code to convert from `CTeeRenderInfo` to chat-internal representation and back to `CTeeRenderInfo`.

Add function to apply information of `CSkin` to a `CTeeRenderInfo` to reduce duplicate code.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
