### PR TITLE
Fix colored speed values after connecting to a server

### DIFF
--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -1277,11 +1277,11 @@ void CHud::UpdateMovementInformationTextContainer(STextContainerIndex &TextConta
 	}
 }
 
-void CHud::RenderMovementInformationTextContainer(STextContainerIndex &TextContainer, float X, float Y)
+void CHud::RenderMovementInformationTextContainer(STextContainerIndex &TextContainer, const ColorRGBA &Color, float X, float Y)
 {
 	if(TextContainer.Valid())
 	{
-		TextRender()->RenderTextContainer(TextContainer, TextRender()->DefaultTextColor(), TextRender()->DefaultTextOutlineColor(), X - TextRender()->GetBoundingBoxTextContainer(TextContainer).m_W, Y);
+		TextRender()->RenderTextContainer(TextContainer, Color, TextRender()->DefaultTextOutlineColor(), X - TextRender()->GetBoundingBoxTextContainer(TextContainer).m_W, Y);
 	}
 }
 
@@ -1354,12 +1354,12 @@ void CHud::RenderMovementInformation(const int ClientId)
 
 		TextRender()->Text(xl, y, Fontsize, "X:", -1.0f);
 		UpdateMovementInformationTextContainer(m_aPlayerPositionContainers[0], Fontsize, Pos.x, m_aaPlayerPositionText[0], sizeof(m_aaPlayerPositionText[0]));
-		RenderMovementInformationTextContainer(m_aPlayerPositionContainers[0], xr, y);
+		RenderMovementInformationTextContainer(m_aPlayerPositionContainers[0], TextRender()->DefaultTextColor(), xr, y);
 		y += MOVEMENT_INFORMATION_LINE_HEIGHT;
 
 		TextRender()->Text(xl, y, Fontsize, "Y:", -1.0f);
 		UpdateMovementInformationTextContainer(m_aPlayerPositionContainers[1], Fontsize, Pos.y, m_aaPlayerPositionText[1], sizeof(m_aaPlayerPositionText[1]));
-		RenderMovementInformationTextContainer(m_aPlayerPositionContainers[1], xr, y);
+		RenderMovementInformationTextContainer(m_aPlayerPositionContainers[1], TextRender()->DefaultTextColor(), xr, y);
 		y += MOVEMENT_INFORMATION_LINE_HEIGHT;
 	}
 
@@ -1371,14 +1371,14 @@ void CHud::RenderMovementInformation(const int ClientId)
 		const char aaCoordinates[][4] = {"X:", "Y:"};
 		for(int i = 0; i < 2; i++)
 		{
-			TextRender()->TextColor(ColorRGBA(1, 1, 1, 1));
+			ColorRGBA Color(1, 1, 1, 1);
 			if(m_aLastPlayerSpeedChange[i] == ESpeedChange::INCREASE)
-				TextRender()->TextColor(ColorRGBA(0, 1, 0, 1));
+				Color = ColorRGBA(0, 1, 0, 1);
 			if(m_aLastPlayerSpeedChange[i] == ESpeedChange::DECREASE)
-				TextRender()->TextColor(ColorRGBA(1, 0.5f, 0.5f, 1));
+				Color = ColorRGBA(1, 0.5f, 0.5f, 1);
 			TextRender()->Text(xl, y, Fontsize, aaCoordinates[i], -1.0f);
 			UpdateMovementInformationTextContainer(m_aPlayerSpeedTextContainers[i], Fontsize, i == 0 ? DisplaySpeedX : DisplaySpeedY, m_aaPlayerSpeedText[i], sizeof(m_aaPlayerSpeedText[i]));
-			RenderMovementInformationTextContainer(m_aPlayerSpeedTextContainers[i], xr, y);
+			RenderMovementInformationTextContainer(m_aPlayerSpeedTextContainers[i], Color, xr, y);
 			y += MOVEMENT_INFORMATION_LINE_HEIGHT;
 		}
 
@@ -1391,7 +1391,7 @@ void CHud::RenderMovementInformation(const int ClientId)
 		y += MOVEMENT_INFORMATION_LINE_HEIGHT;
 
 		UpdateMovementInformationTextContainer(m_PlayerAngleTextContainerIndex, Fontsize, DisplayAngle, m_aPlayerAngleText, sizeof(m_aPlayerAngleText));
-		RenderMovementInformationTextContainer(m_PlayerAngleTextContainerIndex, xr, y);
+		RenderMovementInformationTextContainer(m_PlayerAngleTextContainerIndex, TextRender()->DefaultTextColor(), xr, y);
 	}
 }
 

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -76,6 +76,8 @@ void CHud::OnReset()
 	m_ServerRecord = -1.0f;
 	m_aPlayerRecord[0] = -1.0f;
 	m_aPlayerRecord[1] = -1.0f;
+	m_aLastPlayerSpeedChange[0] = ESpeedChange::NONE;
+	m_aLastPlayerSpeedChange[1] = ESpeedChange::NONE;
 
 	ResetHudContainers();
 }

--- a/src/game/client/components/hud.h
+++ b/src/game/client/components/hud.h
@@ -80,7 +80,7 @@ class CHud : public CComponent
 	void RenderMovementInformation(const int ClientId);
 
 	void UpdateMovementInformationTextContainer(STextContainerIndex &TextContainer, float FontSize, float Value, char *pPrevValue, size_t Size);
-	void RenderMovementInformationTextContainer(STextContainerIndex &TextContainer, float X, float Y);
+	void RenderMovementInformationTextContainer(STextContainerIndex &TextContainer, const ColorRGBA &Color, float X, float Y);
 
 	void RenderGameTimer();
 	void RenderPauseNotification();


### PR DESCRIPTION
The way to reproduce this is have some speed and disconnect. After joining the tee will have old speed values.

Fixes #8814

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
