### PR TITLE
Fix clan nameplate alignment

### DIFF
--- a/src/game/client/components/nameplates.cpp
+++ b/src/game/client/components/nameplates.cpp
@@ -172,9 +172,11 @@ void CNamePlates::RenderNameplate(vec2 Position, const CNetObj_PlayerInfo *pPlay
 
 		if(g_Config.m_ClNameplatesClan)
 		{
-			YOffset -= FontSizeClan;
 			if(NamePlate.m_ClanTextContainerIndex.Valid())
+			{
+				YOffset -= FontSizeClan;
 				TextRender()->RenderTextContainer(NamePlate.m_ClanTextContainerIndex, TColor, TOutlineColor, Position.x - TextRender()->GetBoundingBoxTextContainer(NamePlate.m_ClanTextContainerIndex).m_W / 2.0f, YOffset);
+			}
 		}
 
 		if(g_Config.m_ClNameplatesFriendMark && ClientData.m_Friend)


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/d05148d1-db0b-43d1-91a9-3eb2950956d7)

After:
![image](https://github.com/user-attachments/assets/36dee478-89f5-49d6-a361-8ba79aef7f16)


## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
