### PR TITLE
Add BindNull to SQL api

### DIFF
--- a/src/engine/server/databases/connection.h
+++ b/src/engine/server/databases/connection.h
@@ -61,6 +61,7 @@ public:
 	virtual void BindInt(int Idx, int Value) = 0;
 	virtual void BindInt64(int Idx, int64_t Value) = 0;
 	virtual void BindFloat(int Idx, float Value) = 0;
+	virtual void BindNull(int Idx) = 0;
 
 	// Print expanded sql statement
 	virtual void Print() = 0;

--- a/src/engine/server/databases/mysql.cpp
+++ b/src/engine/server/databases/mysql.cpp
@@ -89,6 +89,7 @@ public:
 	void BindInt(int Idx, int Value) override;
 	void BindInt64(int Idx, int64_t Value) override;
 	void BindFloat(int Idx, float Value) override;
+	void BindNull(int Idx) override;
 
 	void Print() override {}
 	bool Step(bool *pEnd, char *pError, int ErrorSize) override;
@@ -415,6 +416,22 @@ void CMysqlConnection::BindFloat(int Idx, float Value)
 	pParam->buffer_type = MYSQL_TYPE_FLOAT;
 	pParam->buffer = &m_vStmtParameterExtras[Idx].f;
 	pParam->buffer_length = sizeof(m_vStmtParameterExtras[Idx].i);
+	pParam->length = nullptr;
+	pParam->is_null = nullptr;
+	pParam->is_unsigned = false;
+	pParam->error = nullptr;
+}
+
+void CMysqlConnection::BindNull(int Idx)
+{
+	m_NewQuery = true;
+	Idx -= 1;
+	dbg_assert(0 <= Idx && Idx < (int)m_vStmtParameters.size(), "index out of bounds");
+
+	MYSQL_BIND *pParam = &m_vStmtParameters[Idx];
+	pParam->buffer_type = MYSQL_TYPE_NULL;
+	pParam->buffer = nullptr;
+	pParam->buffer_length = 0;
 	pParam->length = nullptr;
 	pParam->is_null = nullptr;
 	pParam->is_unsigned = false;

--- a/src/engine/server/databases/sqlite.cpp
+++ b/src/engine/server/databases/sqlite.cpp
@@ -37,6 +37,7 @@ public:
 	void BindInt(int Idx, int Value) override;
 	void BindInt64(int Idx, int64_t Value) override;
 	void BindFloat(int Idx, float Value) override;
+	void BindNull(int Idx) override;
 
 	void Print() override;
 	bool Step(bool *pEnd, char *pError, int ErrorSize) override;
@@ -237,6 +238,13 @@ void CSqliteConnection::BindInt64(int Idx, int64_t Value)
 void CSqliteConnection::BindFloat(int Idx, float Value)
 {
 	int Result = sqlite3_bind_double(m_pStmt, Idx, (double)Value);
+	AssertNoError(Result);
+	m_Done = false;
+}
+
+void CSqliteConnection::BindNull(int Idx)
+{
+	int Result = sqlite3_bind_null(m_pStmt, Idx);
 	AssertNoError(Result);
 	m_Done = false;
 }


### PR DESCRIPTION
Comes in handy in my downstream project

The mysql docs state that setting the type to MYSQL_TYPE_NULL is enough there is no need to set is_null or anything else.
https://dev.mysql.com/doc/c-api/8.0/en/c-api-prepared-statement-data-structures.html

I tested the change in game with sqlite3 and mariadb. The NULL value was correctly written in both cases.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
