### PR TITLE
Fix scrollbar rail clicking being active while popups open

### DIFF
--- a/src/game/client/ui.cpp
+++ b/src/game/client/ui.cpp
@@ -1301,21 +1301,24 @@ float CUi::DoScrollbarV(const void *pId, const CUIRect *pRect, float Current)
 	}
 	else if(HotItem() == pId)
 	{
-		if(MouseButton(0))
+		if(InsideHandle)
+		{
+			if(MouseButton(0))
+			{
+				SetActiveItem(pId);
+				m_ActiveScrollbarOffset = MouseY() - Handle.y;
+				Grabbed = true;
+			}
+		}
+		else if(MouseButtonClicked(0))
 		{
 			SetActiveItem(pId);
-			m_ActiveScrollbarOffset = MouseY() - Handle.y;
+			m_ActiveScrollbarOffset = Handle.h / 2.0f;
 			Grabbed = true;
 		}
 	}
-	else if(MouseButtonClicked(0) && !InsideHandle && InsideRail)
-	{
-		SetActiveItem(pId);
-		m_ActiveScrollbarOffset = Handle.h / 2.0f;
-		Grabbed = true;
-	}
 
-	if(InsideHandle && !MouseButton(0))
+	if(InsideRail && !MouseButton(0))
 	{
 		SetHotItem(pId);
 	}
@@ -1380,18 +1383,21 @@ float CUi::DoScrollbarH(const void *pId, const CUIRect *pRect, float Current, co
 	}
 	else if(HotItem() == pId)
 	{
-		if(MouseButton(0))
+		if(InsideHandle)
+		{
+			if(MouseButton(0))
+			{
+				SetActiveItem(pId);
+				m_ActiveScrollbarOffset = MouseX() - Handle.x;
+				Grabbed = true;
+			}
+		}
+		else if(MouseButtonClicked(0))
 		{
 			SetActiveItem(pId);
-			m_ActiveScrollbarOffset = MouseX() - Handle.x;
+			m_ActiveScrollbarOffset = Handle.w / 2.0f;
 			Grabbed = true;
 		}
-	}
-	else if(MouseButtonClicked(0) && !InsideHandle && InsideRail)
-	{
-		SetActiveItem(pId);
-		m_ActiveScrollbarOffset = Handle.w / 2.0f;
-		Grabbed = true;
 	}
 
 	if(!pColorInner && (InsideHandle || Grabbed) && (CheckActiveItem(pId) || HotItem() == pId))
@@ -1400,7 +1406,7 @@ float CUi::DoScrollbarH(const void *pId, const CUIRect *pRect, float Current, co
 		Handle.y -= 1.5f;
 	}
 
-	if(InsideHandle && !MouseButton(0))
+	if(InsideRail && !MouseButton(0))
 	{
 		SetHotItem(pId);
 	}


### PR DESCRIPTION
Scrollbars are now also set as the hot item when the rail is hovered and the rail clicking function is now only enabled for the scrollbar that is the hot item.

Closes #8954.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
