### PR TITLE
Change editor teleport number behavior

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -1268,6 +1268,7 @@ void CEditor::DoToolbarLayers(CUIRect ToolBar)
 					const char *pButtonName = nullptr;
 					CUi::FPopupMenuFunction pfnPopupFunc = nullptr;
 					int Rows = 0;
+					int ExtraWidth = 0;
 					if(pS == m_Map.m_pSwitchLayer)
 					{
 						pButtonName = "Switch";
@@ -1290,7 +1291,8 @@ void CEditor::DoToolbarLayers(CUIRect ToolBar)
 					{
 						pButtonName = "Tele";
 						pfnPopupFunc = PopupTele;
-						Rows = 3;
+						Rows = m_TeleNumbers.size() + 1;
+						ExtraWidth = 50;
 					}
 
 					if(pButtonName != nullptr)
@@ -1305,7 +1307,7 @@ void CEditor::DoToolbarLayers(CUIRect ToolBar)
 							static SPopupMenuId s_PopupModifierId;
 							if(!Ui()->IsPopupOpen(&s_PopupModifierId))
 							{
-								Ui()->DoPopupMenu(&s_PopupModifierId, Button.x, Button.y + Button.h, 120, 10.0f + Rows * 13.0f, this, pfnPopupFunc);
+								Ui()->DoPopupMenu(&s_PopupModifierId, Button.x, Button.y + Button.h, 120 + ExtraWidth, 10.0f + Rows * 13.0f, this, pfnPopupFunc);
 							}
 						}
 						TB_Bottom.VSplitLeft(5.0f, nullptr, &TB_Bottom);
@@ -8050,7 +8052,7 @@ void CEditor::Render()
 				return pLayer->m_Type == LAYERTYPE_TILES && std::static_pointer_cast<CLayerTiles>(pLayer)->m_Tele;
 			});
 			if(HasTeleTiles)
-				str_copy(m_aTooltip, "Use shift+mousewheel up/down to adjust the tele numbers. Use ctrl+f to change all tele numbers to the first unused number.");
+				str_copy(m_aTooltip, "Use shift+mousewheel up/down to adjust the tele number. Use ctrl+f to change current tele number to the first unused number.");
 
 			if(Input()->ShiftIsPressed())
 			{
@@ -8995,9 +8997,6 @@ void CEditor::AdjustBrushSpecialTiles(bool UseNextFree, int Adjust)
 		// Only handle tele, switch and tune layers
 		if(pLayerTiles->m_Tele)
 		{
-			int NextFreeTeleNumber = FindNextFreeTeleNumber();
-			int NextFreeCPNumber = FindNextFreeTeleNumber(true);
-
 			std::shared_ptr<CLayerTele> pTeleLayer = std::static_pointer_cast<CLayerTele>(pLayer);
 			for(int y = 0; y < pTeleLayer->m_Height; y++)
 			{
@@ -9009,13 +9008,19 @@ void CEditor::AdjustBrushSpecialTiles(bool UseNextFree, int Adjust)
 
 					if(UseNextFree)
 					{
-						if(IsTeleTileCheckpoint(pTeleLayer->m_pTiles[i].m_Index))
-							pTeleLayer->m_pTeleTile[i].m_Number = NextFreeCPNumber;
-						else
-							pTeleLayer->m_pTeleTile[i].m_Number = NextFreeTeleNumber;
+						pTeleLayer->m_pTeleTile[i].m_Number = FindNextFreeTeleNumber(pTeleLayer->m_pTiles[i].m_Index);
 					}
 					else
 						AdjustNumber(pTeleLayer->m_pTeleTile[i].m_Number);
+
+					if(IsTeleTileNumberUsedAny(pTeleLayer->m_pTiles[i].m_Index) &&
+						m_TeleNumbers[pTeleLayer->m_pTiles[i].m_Index] != pTeleLayer->m_pTeleTile[i].m_Number)
+					{
+						if(UseNextFree || Adjust != 0)
+							m_TeleNumbers[pTeleLayer->m_pTiles[i].m_Index] = pTeleLayer->m_pTeleTile[i].m_Number;
+						else if(!UseNextFree && Adjust == 0)
+							pTeleLayer->m_pTeleTile[i].m_Number = m_TeleNumbers[pTeleLayer->m_pTiles[i].m_Index];
+					}
 				}
 			}
 		}
@@ -9075,12 +9080,12 @@ int CEditor::FindNextFreeSwitchNumber()
 	return Number;
 }
 
-int CEditor::FindNextFreeTeleNumber(bool IsCheckpoint)
+int CEditor::FindNextFreeTeleNumber(int Index)
 {
 	int Number = -1;
 	for(int i = 1; i <= 255; i++)
 	{
-		if(!m_Map.m_pTeleLayer->ContainsElementWithId(i, IsCheckpoint))
+		if(!m_Map.m_pTeleLayer->ContainsElementWithId(i, Index))
 		{
 			Number = i;
 			break;

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -218,8 +218,15 @@ public:
 	void MakeTuneLayer(const std::shared_ptr<CLayer> &pLayer);
 };
 
-struct CProperty
+class CProperty
 {
+public:
+	CProperty(const char *pName, int Value, int Type, int Min, int Max) :
+		m_pName(pName), m_Value(Value), m_Type(Type), m_Min(Min), m_Max(Max) {}
+
+	CProperty(std::nullptr_t) :
+		m_pName(nullptr), m_Value(0), m_Type(0), m_Min(0), m_Max(0) {}
+
 	const char *m_pName;
 	int m_Value;
 	int m_Type;
@@ -428,8 +435,16 @@ public:
 
 		// DDRace
 
-		m_TeleNumber = 1;
-		m_TeleCheckpointNumber = 1;
+		m_ViewTeleNumber = 1;
+		m_TeleNumbers = {
+			{TILE_TELEINEVIL, 1},
+			{TILE_TELEINWEAPON, 1},
+			{TILE_TELEINHOOK, 1},
+			{TILE_TELEIN, 1},
+			{TILE_TELEOUT, 1},
+			{TILE_TELECHECK, 1},
+			{TILE_TELECHECKOUT, 1}};
+
 		m_SwitchNum = 1;
 		m_TuningNum = 1;
 		m_SwitchDelay = 0;
@@ -1127,9 +1142,8 @@ public:
 	IGraphics::CTextureHandle GetSwitchTexture();
 	IGraphics::CTextureHandle GetTuneTexture();
 
-	unsigned char m_TeleNumber;
-	unsigned char m_TeleCheckpointNumber;
 	unsigned char m_ViewTeleNumber;
+	std::map<int, unsigned char> m_TeleNumbers;
 
 	unsigned char m_TuningNum;
 
@@ -1143,7 +1157,7 @@ public:
 
 	void AdjustBrushSpecialTiles(bool UseNextFree, int Adjust = 0);
 	int FindNextFreeSwitchNumber();
-	int FindNextFreeTeleNumber(bool IsCheckpoint = false);
+	int FindNextFreeTeleNumber(int Index);
 
 	// Undo/Redo
 	CEditorHistory m_EditorHistory;

--- a/src/game/editor/mapitems/layer_tele.cpp
+++ b/src/game/editor/mapitems/layer_tele.cpp
@@ -77,7 +77,7 @@ void CLayerTele::BrushDraw(std::shared_ptr<CLayer> pBrush, float wx, float wy)
 	int sx = ConvertX(wx);
 	int sy = ConvertY(wy);
 	if(str_comp(pTeleLayer->m_aFileName, m_pEditor->m_aFileName))
-		m_pEditor->m_TeleNumber = pTeleLayer->m_TeleNum;
+		m_pEditor->m_TeleNumbers = pTeleLayer->m_TeleNumbers;
 
 	bool Destructive = m_pEditor->m_BrushDrawDestructive || IsEmpty(pTeleLayer);
 
@@ -99,22 +99,19 @@ void CLayerTele::BrushDraw(std::shared_ptr<CLayer> pBrush, float wx, float wy)
 				m_pTeleTile[Index].m_Type,
 				m_pTiles[Index].m_Index};
 
-			if((m_pEditor->m_AllowPlaceUnusedTiles || IsValidTeleTile(pTeleLayer->m_pTiles[y * pTeleLayer->m_Width + x].m_Index)) && pTeleLayer->m_pTiles[y * pTeleLayer->m_Width + x].m_Index != TILE_AIR)
+			unsigned char TgtIndex = pTeleLayer->m_pTiles[y * pTeleLayer->m_Width + x].m_Index;
+			if((m_pEditor->m_AllowPlaceUnusedTiles || IsValidTeleTile(TgtIndex)) && TgtIndex != TILE_AIR)
 			{
-				bool IsCheckpoint = IsTeleTileCheckpoint(pTeleLayer->m_pTiles[y * pTeleLayer->m_Width + x].m_Index);
-				if(!IsCheckpoint && !IsTeleTileNumberUsed(pTeleLayer->m_pTiles[y * pTeleLayer->m_Width + x].m_Index, false))
+				bool IsCheckpoint = IsTeleTileCheckpoint(TgtIndex);
+				if(!IsCheckpoint && !IsTeleTileNumberUsed(TgtIndex, false))
 				{
 					// Tele tile number is unused. Set a known value which is not 0,
 					// as tiles with number 0 would be ignored by previous versions.
 					m_pTeleTile[Index].m_Number = 255;
 				}
-				else if(!IsCheckpoint && m_pEditor->m_TeleNumber != pTeleLayer->m_TeleNum)
+				else if(m_pEditor->m_TeleNumbers[TgtIndex] != pTeleLayer->m_TeleNumbers[TgtIndex])
 				{
-					m_pTeleTile[Index].m_Number = m_pEditor->m_TeleNumber;
-				}
-				else if(IsCheckpoint && m_pEditor->m_TeleCheckpointNumber != pTeleLayer->m_TeleCheckpointNum)
-				{
-					m_pTeleTile[Index].m_Number = m_pEditor->m_TeleCheckpointNumber;
+					m_pTeleTile[Index].m_Number = m_pEditor->m_TeleNumbers[TgtIndex];
 				}
 				else if(pTeleLayer->m_pTeleTile[y * pTeleLayer->m_Width + x].m_Number)
 				{
@@ -122,7 +119,7 @@ void CLayerTele::BrushDraw(std::shared_ptr<CLayer> pBrush, float wx, float wy)
 				}
 				else
 				{
-					if((!IsCheckpoint && !m_pEditor->m_TeleNumber) || (IsCheckpoint && !m_pEditor->m_TeleCheckpointNumber))
+					if(!m_pEditor->m_TeleNumbers[TgtIndex])
 					{
 						m_pTeleTile[Index].m_Number = 0;
 						m_pTeleTile[Index].m_Type = 0;
@@ -138,7 +135,7 @@ void CLayerTele::BrushDraw(std::shared_ptr<CLayer> pBrush, float wx, float wy)
 					}
 					else
 					{
-						m_pTeleTile[Index].m_Number = IsCheckpoint ? m_pEditor->m_TeleCheckpointNumber : m_pEditor->m_TeleNumber;
+						m_pTeleTile[Index].m_Number = m_pEditor->m_TeleNumbers[TgtIndex];
 					}
 				}
 
@@ -283,10 +280,8 @@ void CLayerTele::FillSelection(bool Empty, std::shared_ptr<CLayer> pBrush, CUIRe
 						// as tiles with number 0 would be ignored by previous versions.
 						m_pTeleTile[TgtIndex].m_Number = 255;
 					}
-					else if(!IsCheckpoint && ((pLt->m_pTeleTile[SrcIndex].m_Number == 0 && m_pEditor->m_TeleNumber) || m_pEditor->m_TeleNumber != pLt->m_TeleNum))
-						m_pTeleTile[TgtIndex].m_Number = m_pEditor->m_TeleNumber;
-					else if(IsCheckpoint && ((pLt->m_pTeleTile[SrcIndex].m_Number == 0 && m_pEditor->m_TeleCheckpointNumber) || m_pEditor->m_TeleCheckpointNumber != pLt->m_TeleCheckpointNum))
-						m_pTeleTile[TgtIndex].m_Number = m_pEditor->m_TeleCheckpointNumber;
+					else if((pLt->m_pTeleTile[SrcIndex].m_Number == 0 && m_pEditor->m_TeleNumbers[m_pTiles[TgtIndex].m_Index]) || m_pEditor->m_TeleNumbers[m_pTiles[TgtIndex].m_Index] != pLt->m_TeleNumbers[m_pTiles[TgtIndex].m_Index])
+						m_pTeleTile[TgtIndex].m_Number = m_pEditor->m_TeleNumbers[m_pTiles[TgtIndex].m_Index];
 					else
 						m_pTeleTile[TgtIndex].m_Number = pLt->m_pTeleTile[SrcIndex].m_Number;
 				}
@@ -303,13 +298,13 @@ void CLayerTele::FillSelection(bool Empty, std::shared_ptr<CLayer> pBrush, CUIRe
 	FlagModified(sx, sy, w, h);
 }
 
-bool CLayerTele::ContainsElementWithId(int Id, bool Checkpoint)
+bool CLayerTele::ContainsElementWithId(int Id, int Index)
 {
 	for(int y = 0; y < m_Height; ++y)
 	{
 		for(int x = 0; x < m_Width; ++x)
 		{
-			if(IsTeleTileNumberUsed(m_pTeleTile[y * m_Width + x].m_Type, Checkpoint) && m_pTeleTile[y * m_Width + x].m_Number == Id)
+			if(m_pTeleTile[y * m_Width + x].m_Type == Index && m_pTeleTile[y * m_Width + x].m_Number == Id)
 			{
 				return true;
 			}

--- a/src/game/editor/mapitems/layer_tele.h
+++ b/src/game/editor/mapitems/layer_tele.h
@@ -22,8 +22,7 @@ public:
 	~CLayerTele();
 
 	CTeleTile *m_pTeleTile;
-	unsigned char m_TeleNum;
-	unsigned char m_TeleCheckpointNum;
+	std::map<int, unsigned char> m_TeleNumbers;
 
 	void Resize(int NewW, int NewH) override;
 	void Shift(int Direction) override;
@@ -33,7 +32,7 @@ public:
 	void BrushFlipY() override;
 	void BrushRotate(float Amount) override;
 	void FillSelection(bool Empty, std::shared_ptr<CLayer> pBrush, CUIRect Rect) override;
-	virtual bool ContainsElementWithId(int Id, bool Checkpoint);
+	virtual bool ContainsElementWithId(int Id, int Index);
 	virtual void GetPos(int Number, int Offset, int &TeleX, int &TeleY);
 
 	int m_GotoTeleOffset;

--- a/src/game/editor/mapitems/layer_tiles.cpp
+++ b/src/game/editor/mapitems/layer_tiles.cpp
@@ -310,17 +310,15 @@ int CLayerTiles::BrushGrab(std::shared_ptr<CLayerGroup> pBrush, CUIRect Rect)
 				for(int x = 0; x < r.w; x++)
 				{
 					pGrabbed->m_pTeleTile[y * pGrabbed->m_Width + x] = static_cast<CLayerTele *>(this)->m_pTeleTile[(r.y + y) * m_Width + (r.x + x)];
-					if(IsValidTeleTile(pGrabbed->m_pTeleTile[y * pGrabbed->m_Width + x].m_Type))
+					unsigned char TgtIndex = pGrabbed->m_pTeleTile[y * pGrabbed->m_Width + x].m_Type;
+					if(IsValidTeleTile(TgtIndex))
 					{
-						if(IsTeleTileNumberUsed(pGrabbed->m_pTeleTile[y * pGrabbed->m_Width + x].m_Type, false))
-							m_pEditor->m_TeleNumber = pGrabbed->m_pTeleTile[y * pGrabbed->m_Width + x].m_Number;
-						else if(IsTeleTileNumberUsed(pGrabbed->m_pTeleTile[y * pGrabbed->m_Width + x].m_Type, true))
-							m_pEditor->m_TeleCheckpointNumber = pGrabbed->m_pTeleTile[y * pGrabbed->m_Width + x].m_Number;
+						if(IsTeleTileNumberUsedAny(TgtIndex))
+							m_pEditor->m_TeleNumbers[TgtIndex] = pGrabbed->m_pTeleTile[y * pGrabbed->m_Width + x].m_Number;
 					}
 				}
 
-		pGrabbed->m_TeleNum = m_pEditor->m_TeleNumber;
-		pGrabbed->m_TeleCheckpointNum = m_pEditor->m_TeleCheckpointNumber;
+		pGrabbed->m_TeleNumbers = m_pEditor->m_TeleNumbers;
 
 		str_copy(pGrabbed->m_aFileName, m_pEditor->m_aFileName);
 	}

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -2432,24 +2432,29 @@ int CEditor::PopupSelectConfigAutoMapResult()
 CUi::EPopupMenuFunctionResult CEditor::PopupTele(void *pContext, CUIRect View, bool Active)
 {
 	CEditor *pEditor = static_cast<CEditor *>(pContext);
+	static const int s_NumTeleTiles = 7;
 
-	static int s_PreviousTeleNumber;
-	static int s_PreviousCheckpointNumber;
+	static int s_aPreviousTeleNumbers[s_NumTeleTiles];
 	static int s_PreviousViewTeleNumber;
 
 	CUIRect NumberPicker;
 	CUIRect FindEmptySlot;
-	CUIRect FindFreeTeleSlot, FindFreeCheckpointSlot, FindFreeViewSlot;
+	CUIRect FindFreeViewSlot;
+	CUIRect aFindFreeTeleSlots[s_NumTeleTiles];
 
 	View.VSplitRight(15.f, &NumberPicker, &FindEmptySlot);
 	NumberPicker.VSplitRight(2.f, &NumberPicker, nullptr);
 
-	FindEmptySlot.HSplitTop(13.0f, &FindFreeTeleSlot, &FindEmptySlot);
-	FindEmptySlot.HSplitTop(13.0f, &FindFreeCheckpointSlot, &FindEmptySlot);
+	for(auto &Slot : aFindFreeTeleSlots)
+	{
+		FindEmptySlot.HSplitTop(13.0f, &Slot, &FindEmptySlot);
+	}
 	FindEmptySlot.HSplitTop(13.0f, &FindFreeViewSlot, &FindEmptySlot);
 
-	FindFreeTeleSlot.HMargin(1.0f, &FindFreeTeleSlot);
-	FindFreeCheckpointSlot.HMargin(1.0f, &FindFreeCheckpointSlot);
+	for(auto &Slot : aFindFreeTeleSlots)
+	{
+		Slot.HMargin(1.0f, &Slot);
+	}
 	FindFreeViewSlot.HMargin(1.0f, &FindFreeViewSlot);
 
 	auto ViewTele = [](CEditor *pEd) -> bool {
@@ -2465,79 +2470,83 @@ CUi::EPopupMenuFunctionResult CEditor::PopupTele(void *pContext, CUIRect View, b
 		return false;
 	};
 
-	static std::vector<ColorRGBA> s_vColors = {
-		ColorRGBA(0.5f, 1, 0.5f, 0.5f),
-		ColorRGBA(0.5f, 1, 0.5f, 0.5f),
-		ColorRGBA(0.5f, 1, 0.5f, 0.5f),
-	};
-	enum
-	{
-		PROP_TELE = 0,
-		PROP_TELE_CP,
-		PROP_TELE_VIEW,
-		NUM_PROPS,
-	};
+	static std::vector<ColorRGBA> s_vColors(s_NumTeleTiles + 1, ColorRGBA(0.5f, 1, 0.5f, 0.5f));
 
 	// find next free numbers buttons
 	{
-		// Pressing ctrl+f will find next free numbers for both tele and checkpoints
-
-		static int s_NextFreeTelePid = 0;
-		if(pEditor->DoButton_Editor(&s_NextFreeTelePid, "F", 0, &FindFreeTeleSlot, 0, "[ctrl+f] Find next free tele number") || (Active && pEditor->Input()->ModifierIsPressed() && pEditor->Input()->KeyPress(KEY_F)))
+		static int s_aNextFreeTeleButtonIds[s_NumTeleTiles] = {0};
+		for(int i = 0; i < s_NumTeleTiles; i++)
 		{
-			int TeleNumber = pEditor->FindNextFreeTeleNumber();
+			if(pEditor->DoButton_Editor(&s_aNextFreeTeleButtonIds[i], "F", 0, &aFindFreeTeleSlots[i], 0, "[ctrl+f] Find next free tele number") ||
+				(Active && pEditor->Input()->ModifierIsPressed() && pEditor->Input()->KeyPress(KEY_F)))
+			{
+				int Tile = (*std::next(pEditor->m_TeleNumbers.begin(), i)).first;
+				int TeleNumber = pEditor->FindNextFreeTeleNumber(Tile);
 
-			if(TeleNumber != -1)
-				pEditor->m_TeleNumber = TeleNumber;
-		}
-
-		static int s_NextFreeCheckpointPid = 0;
-		if(pEditor->DoButton_Editor(&s_NextFreeCheckpointPid, "F", 0, &FindFreeCheckpointSlot, 0, "[ctrl+f] Find next free checkpoint number") || (Active && pEditor->Input()->ModifierIsPressed() && pEditor->Input()->KeyPress(KEY_F)))
-		{
-			int CPNumber = pEditor->FindNextFreeTeleNumber(true);
-
-			if(CPNumber != -1)
-				pEditor->m_TeleCheckpointNumber = CPNumber;
+				if(TeleNumber != -1)
+				{
+					pEditor->m_TeleNumbers[Tile] = TeleNumber;
+					pEditor->AdjustBrushSpecialTiles(false);
+				}
+			}
 		}
 
 		static int s_NextFreeViewPid = 0;
 		int btn = pEditor->DoButton_Editor(&s_NextFreeViewPid, "N", 0, &FindFreeViewSlot, 0, "[n] Show next tele with this number");
 		if(btn || (Active && pEditor->Input()->KeyPress(KEY_N)))
-			s_vColors[PROP_TELE_VIEW] = ViewTele(pEditor) ? ColorRGBA(0.5f, 1, 0.5f, 0.5f) : ColorRGBA(1, 0.5f, 0.5f, 0.5f);
+			s_vColors[s_NumTeleTiles] = ViewTele(pEditor) ? ColorRGBA(0.5f, 1, 0.5f, 0.5f) : ColorRGBA(1, 0.5f, 0.5f, 0.5f);
 	}
 
 	// number picker
 	{
-		CProperty aProps[] = {
-			{"Number", pEditor->m_TeleNumber, PROPTYPE_INT, 1, 255},
-			{"Checkpoint", pEditor->m_TeleCheckpointNumber, PROPTYPE_INT, 1, 255},
-			{"View", pEditor->m_ViewTeleNumber, PROPTYPE_INT, 1, 255},
-			{nullptr},
+		static const char *s_apTeleLabelText[] = {
+			"Red Tele", // TILE_TELEINEVIL
+			"Weapon Tele", // TILE_TELEINWEAPON
+			"Hook Tele", // TILE_TELEINHOOK
+			"Blue Tele", // TILE_TELEIN
+			"Tele To", // TILE_TELEOUT
+			"CP Tele", // TILE_TELECHECK
+			"CP Tele To", // TILE_TELECHECKOUT
 		};
 
-		static int s_aIds[NUM_PROPS] = {0};
+		std::vector<CProperty> vProps;
+		for(int i = 0; i < s_NumTeleTiles; i++)
+		{
+			unsigned char TeleNumber = (*std::next(pEditor->m_TeleNumbers.begin(), i)).second;
+			vProps.emplace_back(s_apTeleLabelText[i], TeleNumber, PROPTYPE_INT, 1, 255);
+		}
+		vProps.emplace_back("View", pEditor->m_ViewTeleNumber, PROPTYPE_INT, 1, 255);
+		vProps.emplace_back(nullptr);
+
+		static int s_aIds[s_NumTeleTiles + 2] = {0};
 
 		int NewVal = 0;
-		int Prop = pEditor->DoProperties(&NumberPicker, aProps, s_aIds, &NewVal, s_vColors);
-		if(Prop == PROP_TELE)
-			pEditor->m_TeleNumber = (NewVal - 1 + 255) % 255 + 1;
-		else if(Prop == PROP_TELE_CP)
-			pEditor->m_TeleCheckpointNumber = (NewVal - 1 + 255) % 255 + 1;
-		else if(Prop == PROP_TELE_VIEW)
+		int Prop = pEditor->DoProperties(&NumberPicker, vProps.data(), s_aIds, &NewVal, s_vColors);
+
+		if(Prop >= 0 && Prop < s_NumTeleTiles)
+		{
+			auto Tele = (*std::next(pEditor->m_TeleNumbers.begin(), Prop));
+			pEditor->m_TeleNumbers[Tele.first] = (NewVal - 1 + 255) % 255 + 1;
+			pEditor->AdjustBrushSpecialTiles(false);
+		}
+		else if(Prop == s_NumTeleTiles)
 			pEditor->m_ViewTeleNumber = (NewVal - 1 + 255) % 255 + 1;
 
-		if(s_PreviousTeleNumber == 1 || s_PreviousTeleNumber != pEditor->m_TeleNumber)
-			s_vColors[PROP_TELE] = pEditor->m_Map.m_pTeleLayer->ContainsElementWithId(pEditor->m_TeleNumber, false) ? ColorRGBA(1, 0.5f, 0.5f, 0.5f) : ColorRGBA(0.5f, 1, 0.5f, 0.5f);
-
-		if(s_PreviousCheckpointNumber == 1 || s_PreviousCheckpointNumber != pEditor->m_TeleCheckpointNumber)
-			s_vColors[PROP_TELE_CP] = pEditor->m_Map.m_pTeleLayer->ContainsElementWithId(pEditor->m_TeleCheckpointNumber, true) ? ColorRGBA(1, 0.5f, 0.5f, 0.5f) : ColorRGBA(0.5f, 1, 0.5f, 0.5f);
+		for(int i = 0; i < s_NumTeleTiles; i++)
+		{
+			auto Tele = (*std::next(pEditor->m_TeleNumbers.begin(), i));
+			if(s_aPreviousTeleNumbers[i] == 1 || s_aPreviousTeleNumbers[i] != Tele.second)
+				s_vColors[i] = pEditor->m_Map.m_pTeleLayer->ContainsElementWithId(Tele.second, Tele.first) ? ColorRGBA(1, 0.5f, 0.5f, 0.5f) : ColorRGBA(0.5f, 1, 0.5f, 0.5f);
+		}
 
 		if(s_PreviousViewTeleNumber != pEditor->m_ViewTeleNumber)
-			s_vColors[PROP_TELE_VIEW] = ViewTele(pEditor) ? ColorRGBA(0.5f, 1, 0.5f, 0.5f) : ColorRGBA(1, 0.5f, 0.5f, 0.5f);
+			s_vColors[s_NumTeleTiles] = ViewTele(pEditor) ? ColorRGBA(0.5f, 1, 0.5f, 0.5f) : ColorRGBA(1, 0.5f, 0.5f, 0.5f);
 	}
 
-	s_PreviousTeleNumber = pEditor->m_TeleNumber;
-	s_PreviousCheckpointNumber = pEditor->m_TeleCheckpointNumber;
+	for(int i = 0; i < s_NumTeleTiles; i++)
+	{
+		s_aPreviousTeleNumbers[i] = (*std::next(pEditor->m_TeleNumbers.begin(), i)).second;
+	}
 	s_PreviousViewTeleNumber = pEditor->m_ViewTeleNumber;
 
 	return CUi::POPUP_KEEP_OPEN;


### PR DESCRIPTION
Closes #7896
Now, each teleport number is separate. I also fixed inconsistencies with the number when switching it in the Tele popup. The number next to the brush now always matches the one being placed

![image](https://github.com/user-attachments/assets/169e9f03-96f7-4ca2-a8ba-9a77053a21ea)


## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
