### PR TITLE
Better alignment of upper and lower separators

### DIFF
--- a/src/game/server/scoreworker.cpp
+++ b/src/game/server/scoreworker.cpp
@@ -1028,7 +1028,7 @@ bool CScoreWorker::ShowTop(IDbConnection *pSqlServer, const ISqlData *pGameData,
 
 	if(!g_Config.m_SvRegionalRankings)
 	{
-		str_copy(pResult->m_Data.m_aaMessages[Line], "----------------------------------------", sizeof(pResult->m_Data.m_aaMessages[Line]));
+		str_copy(pResult->m_Data.m_aaMessages[Line], "-----------------------------------------", sizeof(pResult->m_Data.m_aaMessages[Line]));
 		return !End;
 	}
 
@@ -1146,7 +1146,7 @@ bool CScoreWorker::ShowTeamTop5(IDbConnection *pSqlServer, const ISqlData *pGame
 		}
 	}
 
-	str_copy(paMessages[Line], "-------------------------------", sizeof(paMessages[Line]));
+	str_copy(paMessages[Line], "---------------------------------", sizeof(paMessages[Line]));
 	return false;
 }
 
@@ -1230,7 +1230,7 @@ bool CScoreWorker::ShowPlayerTeamTop5(IDbConnection *pSqlServer, const ISqlData 
 				break;
 			}
 		}
-		str_copy(paMessages[Line], "-------------------------------", sizeof(paMessages[Line]));
+		str_copy(paMessages[Line], "---------------------------------", sizeof(paMessages[Line]));
 	}
 	else
 	{
@@ -1352,7 +1352,7 @@ bool CScoreWorker::ShowTimes(IDbConnection *pSqlServer, const ISqlData *pGameDat
 	{
 		return true;
 	}
-	str_copy(paMessages[Line], "----------------------------------------------------", sizeof(paMessages[Line]));
+	str_copy(paMessages[Line], "-------------------------------------------", sizeof(paMessages[Line]));
 
 	return false;
 }

--- a/src/test/score.cpp
+++ b/src/test/score.cpp
@@ -160,7 +160,7 @@ TEST_P(SingleScore, Top)
 	ExpectLines(m_pPlayerResult,
 		{"------------ Global Top ------------",
 			"1. nameless tee Time: 01:40.00",
-			"----------------------------------------"});
+			"-----------------------------------------"});
 }
 
 TEST_P(SingleScore, RankRegional)
@@ -197,7 +197,7 @@ TEST_P(SingleScore, TopServer)
 	ExpectLines(m_pPlayerResult,
 		{"------------ Global Top ------------",
 			"1. nameless tee Time: 01:40.00",
-			"----------------------------------------"});
+			"-----------------------------------------"});
 }
 
 TEST_P(SingleScore, RankServerRegional)
@@ -264,7 +264,7 @@ TEST_P(SingleScore, TimesExists)
 
 	str_copy(aBuf, m_pPlayerResult->m_Data.m_aaMessages[1] + str_length(m_pPlayerResult->m_Data.m_aaMessages[1]) - 10, 11);
 	EXPECT_STREQ(aBuf, ", 01:40.00");
-	EXPECT_STREQ(m_pPlayerResult->m_Data.m_aaMessages[2], "----------------------------------------------------");
+	EXPECT_STREQ(m_pPlayerResult->m_Data.m_aaMessages[2], "-------------------------------------------");
 	for(int i = 3; i < CScorePlayerResult::MAX_MESSAGES; i++)
 	{
 		EXPECT_STREQ(m_pPlayerResult->m_Data.m_aaMessages[i], "");
@@ -321,7 +321,7 @@ TEST_P(TeamScore, All)
 	ExpectLines(m_pPlayerResult,
 		{"------- Team Top 5 -------",
 			"1. brainless tee & nameless tee Team Time: 01:40.00",
-			"-------------------------------"});
+			"---------------------------------"});
 }
 
 TEST_P(TeamScore, PlayerExists)
@@ -331,7 +331,7 @@ TEST_P(TeamScore, PlayerExists)
 	ExpectLines(m_pPlayerResult,
 		{"------- Team Top 5 -------",
 			"1. brainless tee & nameless tee Team Time: 01:40.00",
-			"-------------------------------"});
+			"---------------------------------"});
 }
 
 TEST_P(TeamScore, PlayerDoesntExist)
@@ -349,7 +349,7 @@ TEST_P(TeamScore, RankUpdates)
 	ExpectLines(m_pPlayerResult,
 		{"------- Team Top 5 -------",
 			"1. brainless tee & nameless tee Team Time: 01:38.00",
-			"-------------------------------"});
+			"---------------------------------"});
 }
 
 struct MapInfo : public Score


### PR DESCRIPTION
It was mainly the `/times` one that looked out of place but I slightly changed the other ones as well.

Before:
![before](https://github.com/user-attachments/assets/3481ce71-511c-4fd5-a44d-cd833b9a3e00)
After:
![after](https://github.com/user-attachments/assets/8a129d51-b4f6-48e3-b4e9-3d00d84f8b28)

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
