### PR TITLE
Fix 0.7 client flag sounds being duplicated when dummy is connected

### DIFF
--- a/src/game/client/sixup_translate_game.cpp
+++ b/src/game/client/sixup_translate_game.cpp
@@ -620,10 +620,12 @@ void *CGameClient::TranslateGameMsg(int *pMsgId, CUnpacker *pUnpacker, int Conn)
 			switch(GameMsgId)
 			{
 			case protocol7::GAMEMSG_CTF_DROP:
-				m_Sounds.Enqueue(CSounds::CHN_GLOBAL, SOUND_CTF_DROP);
+				if(Conn == g_Config.m_ClDummy)
+					m_Sounds.Enqueue(CSounds::CHN_GLOBAL, SOUND_CTF_DROP);
 				break;
 			case protocol7::GAMEMSG_CTF_RETURN:
-				m_Sounds.Enqueue(CSounds::CHN_GLOBAL, SOUND_CTF_RETURN);
+				if(Conn == g_Config.m_ClDummy)
+					m_Sounds.Enqueue(CSounds::CHN_GLOBAL, SOUND_CTF_RETURN);
 				break;
 			case protocol7::GAMEMSG_TEAM_ALL:
 			{
@@ -650,7 +652,8 @@ void *CGameClient::TranslateGameMsg(int *pMsgId, CUnpacker *pUnpacker, int Conn)
 			}
 			break;
 			case protocol7::GAMEMSG_CTF_GRAB:
-				m_Sounds.Enqueue(CSounds::CHN_GLOBAL, SOUND_CTF_GRAB_EN);
+				if(Conn == g_Config.m_ClDummy)
+					m_Sounds.Enqueue(CSounds::CHN_GLOBAL, SOUND_CTF_GRAB_EN);
 				break;
 			case protocol7::GAMEMSG_GAME_PAUSED:
 			{
@@ -660,7 +663,8 @@ void *CGameClient::TranslateGameMsg(int *pMsgId, CUnpacker *pUnpacker, int Conn)
 			}
 			break;
 			case protocol7::GAMEMSG_CTF_CAPTURE:
-				m_Sounds.Enqueue(CSounds::CHN_GLOBAL, SOUND_CTF_CAPTURE);
+				if(Conn == g_Config.m_ClDummy)
+					m_Sounds.Enqueue(CSounds::CHN_GLOBAL, SOUND_CTF_CAPTURE);
 				int ClientId = clamp(aParaI[1], 0, MAX_CLIENTS - 1);
 				m_aStats[ClientId].m_FlagCaptures++;
 


### PR DESCRIPTION
Closed https://github.com/ddnet-insta/ddnet-insta/issues/127

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
