### PR TITLE
Add quick action "Delete layer"

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -738,6 +738,54 @@ std::pair<int, int> CEditor::EnvGetSelectedTimeAndValue() const
 	return std::pair<int, int>{CurrentTime, CurrentValue};
 }
 
+void CEditor::SelectNextLayer()
+{
+	int CurrentLayer = 0;
+	for(const auto &Selected : m_vSelectedLayers)
+		CurrentLayer = maximum(Selected, CurrentLayer);
+	SelectLayer(CurrentLayer);
+
+	if(m_vSelectedLayers[0] < (int)m_Map.m_vpGroups[m_SelectedGroup]->m_vpLayers.size() - 1)
+	{
+		SelectLayer(m_vSelectedLayers[0] + 1);
+	}
+	else
+	{
+		for(size_t Group = m_SelectedGroup + 1; Group < m_Map.m_vpGroups.size(); Group++)
+		{
+			if(!m_Map.m_vpGroups[Group]->m_vpLayers.empty())
+			{
+				SelectLayer(0, Group);
+				break;
+			}
+		}
+	}
+}
+
+void CEditor::SelectPreviousLayer()
+{
+	int CurrentLayer = std::numeric_limits<int>::max();
+	for(const auto &Selected : m_vSelectedLayers)
+		CurrentLayer = minimum(Selected, CurrentLayer);
+	SelectLayer(CurrentLayer);
+
+	if(m_vSelectedLayers[0] > 0)
+	{
+		SelectLayer(m_vSelectedLayers[0] - 1);
+	}
+	else
+	{
+		for(int Group = m_SelectedGroup - 1; Group >= 0; Group--)
+		{
+			if(!m_Map.m_vpGroups[Group]->m_vpLayers.empty())
+			{
+				SelectLayer(m_Map.m_vpGroups[Group]->m_vpLayers.size() - 1, Group);
+				break;
+			}
+		}
+	}
+}
+
 bool CEditor::CallbackOpenMap(const char *pFileName, int StorageType, void *pUser)
 {
 	CEditor *pEditor = (CEditor *)pUser;
@@ -4195,26 +4243,7 @@ void CEditor::RenderLayers(CUIRect LayersBox)
 		}
 		else
 		{
-			int CurrentLayer = 0;
-			for(const auto &Selected : m_vSelectedLayers)
-				CurrentLayer = maximum(Selected, CurrentLayer);
-			SelectLayer(CurrentLayer);
-
-			if(m_vSelectedLayers[0] < (int)m_Map.m_vpGroups[m_SelectedGroup]->m_vpLayers.size() - 1)
-			{
-				SelectLayer(m_vSelectedLayers[0] + 1);
-			}
-			else
-			{
-				for(size_t Group = m_SelectedGroup + 1; Group < m_Map.m_vpGroups.size(); Group++)
-				{
-					if(!m_Map.m_vpGroups[Group]->m_vpLayers.empty())
-					{
-						SelectLayer(0, Group);
-						break;
-					}
-				}
-			}
+			SelectNextLayer();
 		}
 		s_ScrollToSelectionNext = true;
 	}
@@ -4227,27 +4256,9 @@ void CEditor::RenderLayers(CUIRect LayersBox)
 		}
 		else
 		{
-			int CurrentLayer = std::numeric_limits<int>::max();
-			for(const auto &Selected : m_vSelectedLayers)
-				CurrentLayer = minimum(Selected, CurrentLayer);
-			SelectLayer(CurrentLayer);
-
-			if(m_vSelectedLayers[0] > 0)
-			{
-				SelectLayer(m_vSelectedLayers[0] - 1);
-			}
-			else
-			{
-				for(int Group = m_SelectedGroup - 1; Group >= 0; Group--)
-				{
-					if(!m_Map.m_vpGroups[Group]->m_vpLayers.empty())
-					{
-						SelectLayer(m_Map.m_vpGroups[Group]->m_vpLayers.size() - 1, Group);
-						break;
-					}
-				}
-			}
+			SelectPreviousLayer();
 		}
+
 		s_ScrollToSelectionNext = true;
 	}
 

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -324,6 +324,9 @@ public:
 	const CMapView *MapView() const { return &m_MapView; }
 	CLayerSelector *LayerSelector() { return &m_LayerSelector; }
 
+	void SelectNextLayer();
+	void SelectPreviousLayer();
+
 	void FillGameTiles(EGameTileOp FillTile) const;
 	bool CanFillGameTiles() const;
 	void AddQuadOrSound();

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -331,6 +331,7 @@ public:
 	void AddTileLayer();
 	void AddFrontLayer();
 	void AddQuadsLayer();
+	void DeleteSelectedLayer();
 	void LayerSelectImage();
 	bool IsNonGameTileLayerSelected() const;
 	void MapDetails();

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -708,23 +708,9 @@ CUi::EPopupMenuFunctionResult CEditor::PopupLayer(void *pContext, CUIRect View, 
 	{
 		CUIRect DeleteButton;
 		View.HSplitBottom(12.0f, &View, &DeleteButton);
-		static int s_DeleteButton = 0;
-		if(pEditor->DoButton_Editor(&s_DeleteButton, "Delete layer", 0, &DeleteButton, 0, "Deletes the layer"))
+		if(pEditor->DoButton_Editor(&pEditor->m_QuickActionDeleteLayer, pEditor->m_QuickActionDeleteLayer.Label(), 0, &DeleteButton, 0, pEditor->m_QuickActionDeleteLayer.Description()))
 		{
-			pEditor->m_EditorHistory.RecordAction(std::make_shared<CEditorActionDeleteLayer>(pEditor, pEditor->m_SelectedGroup, pEditor->m_vSelectedLayers[0]));
-
-			if(pCurrentLayer == pEditor->m_Map.m_pFrontLayer)
-				pEditor->m_Map.m_pFrontLayer = nullptr;
-			if(pCurrentLayer == pEditor->m_Map.m_pTeleLayer)
-				pEditor->m_Map.m_pTeleLayer = nullptr;
-			if(pCurrentLayer == pEditor->m_Map.m_pSpeedupLayer)
-				pEditor->m_Map.m_pSpeedupLayer = nullptr;
-			if(pCurrentLayer == pEditor->m_Map.m_pSwitchLayer)
-				pEditor->m_Map.m_pSwitchLayer = nullptr;
-			if(pCurrentLayer == pEditor->m_Map.m_pTuneLayer)
-				pEditor->m_Map.m_pTuneLayer = nullptr;
-			pEditor->m_Map.m_vpGroups[pEditor->m_SelectedGroup]->DeleteLayer(pEditor->m_vSelectedLayers[0]);
-
+			pEditor->m_QuickActionDeleteLayer.Call();
 			return CUi::POPUP_CLOSE_CURRENT;
 		}
 	}

--- a/src/game/editor/quick_actions.cpp
+++ b/src/game/editor/quick_actions.cpp
@@ -135,3 +135,26 @@ void CEditor::MapDetails()
 		PopupMapInfo);
 	Ui()->SetActiveItem(nullptr);
 }
+
+void CEditor::DeleteSelectedLayer()
+{
+	std::shared_ptr<CLayer> pCurrentLayer = GetSelectedLayer(0);
+	if(!pCurrentLayer)
+		return;
+	if(m_Map.m_pGameLayer == pCurrentLayer)
+		return;
+
+	m_EditorHistory.RecordAction(std::make_shared<CEditorActionDeleteLayer>(this, m_SelectedGroup, m_vSelectedLayers[0]));
+
+	if(pCurrentLayer == m_Map.m_pFrontLayer)
+		m_Map.m_pFrontLayer = nullptr;
+	if(pCurrentLayer == m_Map.m_pTeleLayer)
+		m_Map.m_pTeleLayer = nullptr;
+	if(pCurrentLayer == m_Map.m_pSpeedupLayer)
+		m_Map.m_pSpeedupLayer = nullptr;
+	if(pCurrentLayer == m_Map.m_pSwitchLayer)
+		m_Map.m_pSwitchLayer = nullptr;
+	if(pCurrentLayer == m_Map.m_pTuneLayer)
+		m_Map.m_pTuneLayer = nullptr;
+	m_Map.m_vpGroups[m_SelectedGroup]->DeleteLayer(m_vSelectedLayers[0]);
+}

--- a/src/game/editor/quick_actions.cpp
+++ b/src/game/editor/quick_actions.cpp
@@ -157,4 +157,6 @@ void CEditor::DeleteSelectedLayer()
 	if(pCurrentLayer == m_Map.m_pTuneLayer)
 		m_Map.m_pTuneLayer = nullptr;
 	m_Map.m_vpGroups[m_SelectedGroup]->DeleteLayer(m_vSelectedLayers[0]);
+
+	SelectPreviousLayer();
 }

--- a/src/game/editor/quick_actions.h
+++ b/src/game/editor/quick_actions.h
@@ -279,6 +279,19 @@ REGISTER_QUICK_ACTION(
 	DEFAULT_BTN,
 	"[Ctrl+Shift+I] Show tile information in hexadecimal.")
 REGISTER_QUICK_ACTION(
+	DeleteLayer,
+	"Delete layer",
+	[&]() { DeleteSelectedLayer(); },
+	[&]() -> bool {
+		std::shared_ptr<CLayer> pCurrentLayer = GetSelectedLayer(0);
+		if(!pCurrentLayer)
+			return true;
+		return m_Map.m_pGameLayer == pCurrentLayer;
+	},
+	ALWAYS_FALSE,
+	DEFAULT_BTN,
+	"Deletes the layer.")
+REGISTER_QUICK_ACTION(
 	Pipette,
 	"Pipette",
 	[&]() { m_ColorPipetteActive = !m_ColorPipetteActive; },


### PR DESCRIPTION
I am not too sure about this one. This would be the first destructive quick action. Meaning one little typo or miss scroll could delete an entire layer by accident. The way the prompt is designed to be used this can happen way more likely than clicking the delete button. I am not sure how mature the undo feature is. Is it stable? Is it on by default? If we can rely on the undo feature to avoid data loss then this should be fine.

The other option would be introducing a "are you sure?" popup but that would then be in the way of "batch deletion"

https://github.com/user-attachments/assets/054766d5-7166-4d6c-87a1-0ff7e836dc74


## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
