### PR TITLE
info: "finishes" shouldn't be under "icon" either

### DIFF
--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -1468,15 +1468,21 @@ void CServerBrowser::LoadDDNetServers()
 		const json_value &IconUrl = Icon["url"];
 		const json_value &Name = Community["name"];
 		const json_value HasFinishes = Community["has_finishes"];
-		const json_value *pFinishes = &Icon["finishes"];
+		const json_value *pFinishes = &Community["finishes"];
 		const json_value *pServers = &Community["servers"];
-		// We accidentally set servers to be part of icon, so support that as a
-		// fallback for now. Can be removed in a few versions when the
-		// communities.json has been updated.
+		// We accidentally set finishes/servers to be part of icon in
+		// the past, so support that, too. Can be removed once we make
+		// a breaking change to the whole thing, necessitating a new
+		// endpoint.
+		if(pFinishes->type == json_none)
+		{
+			pServers = &Icon["finishes"];
+		}
 		if(pServers->type == json_none)
 		{
 			pServers = &Icon["servers"];
 		}
+		// Backward compatibility.
 		if(pFinishes->type == json_none)
 		{
 			if(str_comp(Id, COMMUNITY_DDNET) == 0)
@@ -1484,7 +1490,6 @@ void CServerBrowser::LoadDDNetServers()
 				pFinishes = &(*m_pDDNetInfo)["maps"];
 			}
 		}
-		// Backward compatibility.
 		if(pServers->type == json_none)
 		{
 			if(str_comp(Id, COMMUNITY_DDNET) == 0)


### PR DESCRIPTION
Actually moving to those new paths shouldn't be done until we get a breaking change of this JSON, as it would otherwise unnecessarily break old clients.

Once a new endpoint is created, the backward compatibility can be removed.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
