### PR TITLE
Enable mac arm64 Discord RPC

### DIFF
--- a/src/engine/client/discord.cpp
+++ b/src/engine/client/discord.cpp
@@ -1,10 +1,7 @@
 #include <base/system.h>
 #include <engine/discord.h>
 
-// Hack for universal binary builds on macOS: Ignore arm64 until Discord
-// releases a native arm64 SDK for macOS.
-
-#if defined(CONF_DISCORD) && !(defined(CONF_ARCH_ARM64) && defined(CONF_PLATFORM_MACOS))
+#if defined(CONF_DISCORD)
 #include <discord_game_sdk.h>
 
 typedef enum EDiscordResult DISCORD_API (*FDiscordCreate)(DiscordVersion, struct DiscordCreateParams *, struct IDiscordCore **);


### PR DESCRIPTION
Closed #8440

ddnet-libs already has a mac arm64 discord library and it is even included in main releases but it was not being used

<img width="277" alt="screenss" src="https://github.com/user-attachments/assets/fc3f0e04-2de0-45ca-bdd6-a665aabadb77">

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
