### PR TITLE
Change color of non standard vanilla gametypes

### DIFF
--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -65,7 +65,7 @@ static ColorRGBA GetGametypeTextColor(const char *pGametype)
 		if(pGametype[0] == 'i' || pGametype[0] == 'g')
 			HslaColor = ColorHSLA(0.0f, 1.0f, 0.75f);
 		else
-			HslaColor = ColorHSLA(0.375f, 1.0f, 0.35f);
+			HslaColor = ColorHSLA(0.40f, 1.0f, 0.75f);
 	}
 	else if(str_find_nocase(pGametype, "f-ddrace") || str_find_nocase(pGametype, "freeze"))
 		HslaColor = ColorHSLA(0.0f, 1.0f, 0.75f);


### PR DESCRIPTION
Brings DM+ closer to DM instead of using a dark green.

# before

![before](https://github.com/user-attachments/assets/adc285d6-bc45-41e4-8257-340b562ab92c)

# after

![after](https://github.com/user-attachments/assets/ae97a8a5-fb9b-4b38-a87a-7e5421f94c1a)

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
