### PR TITLE
Fix some editor quick actions not being clickable, small refactoring

### DIFF
--- a/src/game/editor/prompt.cpp
+++ b/src/game/editor/prompt.cpp
@@ -136,9 +136,9 @@ void CPrompt::OnRender(CUIRect _)
 
 		CUIRect LabelColumn, DescColumn;
 		float Margin = 5.0f;
-		Item.m_Rect.VSplitLeft(Margin, nullptr, &LabelColumn);
+		Item.m_Rect.VMargin(Margin, &LabelColumn);
 		LabelColumn.VSplitLeft(LabelWidth, &LabelColumn, &DescColumn);
-		DescColumn.VSplitRight(Margin, &DescColumn, nullptr);
+		DescColumn.VSplitLeft(Margin, nullptr, &DescColumn);
 
 		SLabelProperties Props;
 		Props.m_MaxWidth = LabelColumn.w;

--- a/src/game/editor/prompt.cpp
+++ b/src/game/editor/prompt.cpp
@@ -130,7 +130,7 @@ void CPrompt::OnRender(CUIRect _)
 
 	for(size_t i = 0; i < m_vpFilteredPromptList.size(); i++)
 	{
-		const CListboxItem Item = s_ListBox.DoNextItem(m_vpFilteredPromptList[i], m_PromptSelectedIndex >= 0 && (size_t)m_PromptSelectedIndex == i);
+		const CListboxItem Item = s_ListBox.DoNextItem(m_vpFilteredPromptList[i]->ActionButtonId(), m_PromptSelectedIndex >= 0 && (size_t)m_PromptSelectedIndex == i);
 		if(!Item.m_Visible)
 			continue;
 

--- a/src/game/editor/prompt.cpp
+++ b/src/game/editor/prompt.cpp
@@ -112,11 +112,7 @@ void CPrompt::OnRender(CUIRect _)
 
 			if(m_PromptInput.IsEmpty() || FuzzyMatch(pQuickAction->Label(), m_PromptInput.GetString()))
 			{
-				bool Skip = false;
-				if(m_ResetFilterResults)
-					if(pQuickAction == m_pLastAction)
-						Skip = true;
-				if(!Skip)
+				if(!m_ResetFilterResults || pQuickAction != m_pLastAction)
 					m_vpFilteredPromptList.push_back(pQuickAction);
 			}
 		}
@@ -146,9 +142,7 @@ void CPrompt::OnRender(CUIRect _)
 		Ui()->DoLabel(&LabelColumn, m_vpFilteredPromptList[i]->Label(), 10.0f, TEXTALIGN_ML, Props);
 
 		Props.m_MaxWidth = DescColumn.w;
-		ColorRGBA DescColor = TextRender()->DefaultTextColor();
-		DescColor.a = Item.m_Selected ? 1.0f : 0.8f;
-		TextRender()->TextColor(DescColor);
+		TextRender()->TextColor(TextRender()->DefaultTextColor().WithAlpha(Item.m_Selected ? 1.0f : 0.8f));
 		Ui()->DoLabel(&DescColumn, m_vpFilteredPromptList[i]->Description(), 10.0f, TEXTALIGN_MR, Props);
 		TextRender()->TextColor(TextRender()->DefaultTextColor());
 	}

--- a/src/game/editor/quick_action.h
+++ b/src/game/editor/quick_action.h
@@ -20,6 +20,8 @@ private:
 	FButtonActiveCallback m_pfnActiveCallback;
 	FButtonColorCallback m_pfnColorCallback;
 
+	const char m_ActionButtonId = 0;
+
 public:
 	CQuickAction(
 		const char *pLabel,
@@ -64,6 +66,8 @@ public:
 	}
 
 	const char *Description() const { return m_pDescription; }
+
+	const void *ActionButtonId() const { return &m_ActionButtonId; }
 };
 
 #endif


### PR DESCRIPTION
Add separate UI element IDs for the quick action buttons in the prompt dialog, to ensure that the UI element IDs are different from the IDs used for the regular menu buttons. Otherwise, some buttons could not be activated with clicks because the menu button with the same ID was rendered first.

Closes #8998.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
