### PR TITLE
Don't set predefined DDNet tunings by default

### DIFF
--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -3788,11 +3788,14 @@ void CGameClient::LoadMapSettings()
 	for(int i = 0; i < NUM_TUNEZONES; i++)
 	{
 		TuningList()[i] = TuningParams;
-		TuningList()[i].Set("gun_curvature", 0);
-		TuningList()[i].Set("gun_speed", 1400);
-		TuningList()[i].Set("shotgun_curvature", 0);
-		TuningList()[i].Set("shotgun_speed", 500);
-		TuningList()[i].Set("shotgun_speeddiff", 0);
+		if(m_GameInfo.m_PredictDDRace || m_GameInfo.m_PredictDDRaceTiles)
+		{
+			TuningList()[i].Set("gun_curvature", 0);
+			TuningList()[i].Set("gun_speed", 1400);
+			TuningList()[i].Set("shotgun_curvature", 0);
+			TuningList()[i].Set("shotgun_speed", 500);
+			TuningList()[i].Set("shotgun_speeddiff", 0);
+		}
 	}
 
 	// Load map tunings


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->
Finally found reason of weird vanilla demos behaviour. If it has downfalls in terms of prediction DDNet/DDRace/any other mod, please mention it here
## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
