### PR TITLE
Remove most clang-tidy parameter and class/struct name exceptions

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -136,7 +136,7 @@ CheckOptions:
   - key:             readability-identifier-naming.ParameterCase
     value:           CamelCase
   - key:             readability-identifier-naming.ParameterIgnoredRegexp
-    value:           '^(p|a|v|[a-z]$|s[hw]$|warning_msg$|error_msg$|string$|integer$|boolean$|object$|index$|rhs$|lhs$|[xy]off$|id$|mode$|rgb$|[xy][0123]$|width$|height$|[sdw][xy]$|ownId$|fnMatchCallback$).*'
+    value:           '^(p|a|v|[a-z]$|[xy][0123]$).*'
   - key:             readability-identifier-naming.ClassMethodIgnoredRegexp
     value:           '^(Con_).*'
   - key:             readability-identifier-naming.ClassMemberIgnoredRegexp
@@ -144,5 +144,5 @@ CheckOptions:
   - key:             readability-identifier-naming.LocalConstantIgnoredRegexp
     value:           '^(p|a|v|s_|MAX_ANIM_SPEED$|DATA_OFFSET$|HEADER_LEN$|MIN_ANIM_SPEED$|[hwdcbqstf]$|[xt][0123]$|result$|sub$|it$|len$|d[xy]$).*'
   - key:             readability-identifier-naming.LocalVariableIgnoredRegexp
-    value:           '^(p|a|s_|FT_|TB_|s_|ul_|v|[xy]i$|[zijklxyhmrgbacwestnduvqf]$|[dmpwsitcf][xy]$|(ch|skel)[0-2]?$|it$|tw$|dt$|th$|ls$|func$|res$|shader$|len$|maxLength$|length$|offset$|offpos$|result$|bg$|sp$|url$|index$|ctxt$|key$|null$|logger$|LAST_MODIFIED$|teleNr$|target$|id$|hit$|hsl[0-2]?$|rgb[0-2]?$|dir$|tmp$|sub$|ret$|rendered$|(lower|upper)(16|26|24|32)|size$|isWeaponCollide$|zerochar$|dist$|sound$|match$|best_matches$|matches$|nohook$|btn$|savedLayers$|l[hw]$|evilz$|sec$|min$|to2$|delay$|mode$|maxModes$|numModes$|[xy]Fract$|[xy]Int$|imgg[xy]$|skip$|localPlayer$|fdratio$|[rgbat][0-2]$|[xy][0-3]$|x[rl]$).*'
+    value:           '^(p|a|s_|FT_|TB_|s_|ul_|v|[xy]i$|[zijklxyhmrgbacwestnduvqf]$|[dmpwsitcf][xy]$|(ch|skel)[0-2]?$|it$|tw$|dt$|th$|ls$|func$|res$|shader$|len$|maxLength$|length$|offset$|offpos$|result$|bg$|sp$|url$|index$|ctxt$|key$|null$|logger$|LAST_MODIFIED$|teleNr$|target$|id$|hit$|hsl[0-2]?$|rgb[0-2]?$|dir$|tmp$|sub$|ret$|rendered$|size$|isWeaponCollide$|zerochar$|dist$|sound$|match$|best_matches$|matches$|nohook$|btn$|savedLayers$|l[hw]$|evilz$|sec$|min$|to2$|delay$|[xy]Fract$|[xy]Int$|imgg[xy]$|skip$|localPlayer$|fdratio$|[rgbat][0-2]$|[xy][0-3]$|x[rl]$).*'
 

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -130,7 +130,7 @@ CheckOptions:
   - key:             readability-identifier-naming.StructPrefix
     value:           S
   - key:             readability-identifier-naming.StructIgnoredRegexp
-    value:           '^([CS]|MapObject$|EnvelopedQuad$).*'
+    value:           '^C.*'
   - key:             readability-identifier-naming.ClassIgnoredRegexp
     value:           '^(I|CCommandProcessorFragment_Vulkan$).*'
   - key:             readability-identifier-naming.ParameterCase

--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -905,8 +905,7 @@ static void DisplayToVideoMode(CVideoMode *pVMode, SDL_DisplayMode *pMode, int H
 void CGraphicsBackend_SDL_GL::GetVideoModes(CVideoMode *pModes, int MaxModes, int *pNumModes, int HiDPIScale, int MaxWindowWidth, int MaxWindowHeight, int ScreenId)
 {
 	SDL_DisplayMode DesktopMode;
-	int maxModes = SDL_GetNumDisplayModes(ScreenId);
-	int numModes = 0;
+	int MaxModesAvailable = SDL_GetNumDisplayModes(ScreenId);
 
 	// Only collect fullscreen modes when requested, that makes sure in windowed mode no refresh rates are shown that aren't supported without
 	// fullscreen anyway(except fullscreen desktop)
@@ -921,49 +920,50 @@ void CGraphicsBackend_SDL_GL::GetVideoModes(CVideoMode *pModes, int MaxModes, in
 	constexpr int ModeCount = 256;
 	SDL_DisplayMode aModes[ModeCount];
 	int NumModes = 0;
-	for(int i = 0; i < maxModes && NumModes < ModeCount; i++)
+	for(int i = 0; i < MaxModesAvailable && NumModes < ModeCount; i++)
 	{
-		SDL_DisplayMode mode;
-		if(SDL_GetDisplayMode(ScreenId, i, &mode) < 0)
+		SDL_DisplayMode Mode;
+		if(SDL_GetDisplayMode(ScreenId, i, &Mode) < 0)
 		{
 			dbg_msg("gfx", "unable to get display mode: %s", SDL_GetError());
 			continue;
 		}
 
-		aModes[NumModes] = mode;
+		aModes[NumModes] = Mode;
 		++NumModes;
 	}
 
-	auto &&ModeInsert = [&](SDL_DisplayMode &mode) {
-		if(numModes < MaxModes)
+	int NumModesInserted = 0;
+	auto &&ModeInsert = [&](SDL_DisplayMode &Mode) {
+		if(NumModesInserted < MaxModes)
 		{
 			// if last mode was equal, ignore this one --- in fullscreen this can really only happen if the screen
 			// supports different color modes
 			// in non fullscren these are the modes that show different refresh rate, but are basically the same
-			if(numModes > 0 && pModes[numModes - 1].m_WindowWidth == mode.w && pModes[numModes - 1].m_WindowHeight == mode.h && (pModes[numModes - 1].m_RefreshRate == mode.refresh_rate || (mode.refresh_rate != DesktopMode.refresh_rate && !CollectFullscreenModes)))
+			if(NumModesInserted > 0 && pModes[NumModesInserted - 1].m_WindowWidth == Mode.w && pModes[NumModesInserted - 1].m_WindowHeight == Mode.h && (pModes[NumModesInserted - 1].m_RefreshRate == Mode.refresh_rate || (Mode.refresh_rate != DesktopMode.refresh_rate && !CollectFullscreenModes)))
 				return;
 
-			DisplayToVideoMode(&pModes[numModes], &mode, HiDPIScale, !CollectFullscreenModes ? DesktopMode.refresh_rate : mode.refresh_rate);
-			numModes++;
+			DisplayToVideoMode(&pModes[NumModesInserted], &Mode, HiDPIScale, !CollectFullscreenModes ? DesktopMode.refresh_rate : Mode.refresh_rate);
+			NumModesInserted++;
 		}
 	};
 
 	for(int i = 0; i < NumModes; i++)
 	{
-		SDL_DisplayMode &mode = aModes[i];
+		SDL_DisplayMode &Mode = aModes[i];
 
-		if(mode.w > MaxWindowWidth || mode.h > MaxWindowHeight)
+		if(Mode.w > MaxWindowWidth || Mode.h > MaxWindowHeight)
 			continue;
 
-		ModeInsert(mode);
+		ModeInsert(Mode);
 
 		if(IsFullscreenDestkop)
 			break;
 
-		if(numModes >= MaxModes)
+		if(NumModesInserted >= MaxModes)
 			break;
 	}
-	*pNumModes = numModes;
+	*pNumModes = NumModesInserted;
 }
 
 void CGraphicsBackend_SDL_GL::GetCurrentVideoMode(CVideoMode &CurMode, int HiDPIScale, int MaxWindowWidth, int MaxWindowHeight, int ScreenId)

--- a/src/engine/client/text.cpp
+++ b/src/engine/client/text.cpp
@@ -1353,9 +1353,9 @@ public:
 		m_Color.a = a;
 	}
 
-	void TextColor(ColorRGBA rgb) override
+	void TextColor(ColorRGBA Color) override
 	{
-		m_Color = rgb;
+		m_Color = Color;
 	}
 
 	void TextOutlineColor(float r, float g, float b, float a) override
@@ -1366,9 +1366,9 @@ public:
 		m_OutlineColor.a = a;
 	}
 
-	void TextOutlineColor(ColorRGBA rgb) override
+	void TextOutlineColor(ColorRGBA Color) override
 	{
-		m_OutlineColor = rgb;
+		m_OutlineColor = Color;
 	}
 
 	void TextSelectionColor(float r, float g, float b, float a) override
@@ -1379,9 +1379,9 @@ public:
 		m_SelectionColor.a = a;
 	}
 
-	void TextSelectionColor(ColorRGBA rgb) override
+	void TextSelectionColor(ColorRGBA Color) override
 	{
-		m_SelectionColor = rgb;
+		m_SelectionColor = Color;
 	}
 
 	ColorRGBA GetTextColor() const override

--- a/src/engine/gfx/image_loader.cpp
+++ b/src/engine/gfx/image_loader.cpp
@@ -44,17 +44,17 @@ public:
 	std::jmp_buf m_JmpBuf;
 };
 
-[[noreturn]] static void PngErrorCallback(png_structp png_ptr, png_const_charp error_msg)
+[[noreturn]] static void PngErrorCallback(png_structp pPngStruct, png_const_charp pErrorMessage)
 {
-	CUserErrorStruct *pUserStruct = static_cast<CUserErrorStruct *>(png_get_error_ptr(png_ptr));
-	log_error("png", "error for file \"%s\": %s", pUserStruct->m_pContextName, error_msg);
+	CUserErrorStruct *pUserStruct = static_cast<CUserErrorStruct *>(png_get_error_ptr(pPngStruct));
+	log_error("png", "error for file \"%s\": %s", pUserStruct->m_pContextName, pErrorMessage);
 	std::longjmp(pUserStruct->m_JmpBuf, 1);
 }
 
-static void PngWarningCallback(png_structp png_ptr, png_const_charp warning_msg)
+static void PngWarningCallback(png_structp pPngStruct, png_const_charp pWarningMessage)
 {
-	CUserErrorStruct *pUserStruct = static_cast<CUserErrorStruct *>(png_get_error_ptr(png_ptr));
-	log_warn("png", "warning for file \"%s\": %s", pUserStruct->m_pContextName, warning_msg);
+	CUserErrorStruct *pUserStruct = static_cast<CUserErrorStruct *>(png_get_error_ptr(pPngStruct));
+	log_warn("png", "warning for file \"%s\": %s", pUserStruct->m_pContextName, pWarningMessage);
 }
 
 static void PngReadDataCallback(png_structp pPngStruct, png_bytep pOutBytes, png_size_t ByteCountToRead)
@@ -307,7 +307,7 @@ static void PngWriteDataCallback(png_structp pPngStruct, png_bytep pOutBytes, pn
 	pWriter->Write(pOutBytes, ByteCountToWrite);
 }
 
-static void PngOutputFlushCallback(png_structp png_ptr)
+static void PngOutputFlushCallback(png_structp pPngStruct)
 {
 	// no need to flush memory buffer
 }

--- a/src/engine/gfx/image_manipulation.cpp
+++ b/src/engine/gfx/image_manipulation.cpp
@@ -157,41 +157,41 @@ void DilateImage(const CImageInfo &Image)
 	DilateImage(Image.m_pData, Image.m_Width, Image.m_Height);
 }
 
-void DilateImageSub(uint8_t *pImageBuff, int w, int h, int x, int y, int sw, int sh)
+void DilateImageSub(uint8_t *pImageBuff, int w, int h, int x, int y, int SubWidth, int SubHeight)
 {
 	uint8_t *apBuffer[2] = {nullptr, nullptr};
 
-	const size_t ImageSize = (size_t)sw * sh * sizeof(uint8_t) * DILATE_BPP;
+	const size_t ImageSize = (size_t)SubWidth * SubHeight * sizeof(uint8_t) * DILATE_BPP;
 	apBuffer[0] = (uint8_t *)malloc(ImageSize);
 	apBuffer[1] = (uint8_t *)malloc(ImageSize);
 	uint8_t *pBufferOriginal = (uint8_t *)malloc(ImageSize);
 
-	for(int Y = 0; Y < sh; ++Y)
+	for(int Y = 0; Y < SubHeight; ++Y)
 	{
 		int SrcImgOffset = ((y + Y) * w * DILATE_BPP) + (x * DILATE_BPP);
-		int DstImgOffset = (Y * sw * DILATE_BPP);
-		int CopySize = sw * DILATE_BPP;
+		int DstImgOffset = (Y * SubWidth * DILATE_BPP);
+		int CopySize = SubWidth * DILATE_BPP;
 		mem_copy(&pBufferOriginal[DstImgOffset], &pImageBuff[SrcImgOffset], CopySize);
 	}
 
-	Dilate(sw, sh, pBufferOriginal, apBuffer[0]);
+	Dilate(SubWidth, SubHeight, pBufferOriginal, apBuffer[0]);
 
 	for(int i = 0; i < 5; i++)
 	{
-		Dilate(sw, sh, apBuffer[0], apBuffer[1]);
-		Dilate(sw, sh, apBuffer[1], apBuffer[0]);
+		Dilate(SubWidth, SubHeight, apBuffer[0], apBuffer[1]);
+		Dilate(SubWidth, SubHeight, apBuffer[1], apBuffer[0]);
 	}
 
-	CopyColorValues(sw, sh, apBuffer[0], pBufferOriginal);
+	CopyColorValues(SubWidth, SubHeight, apBuffer[0], pBufferOriginal);
 
 	free(apBuffer[0]);
 	free(apBuffer[1]);
 
-	for(int Y = 0; Y < sh; ++Y)
+	for(int Y = 0; Y < SubHeight; ++Y)
 	{
 		int SrcImgOffset = ((y + Y) * w * DILATE_BPP) + (x * DILATE_BPP);
-		int DstImgOffset = (Y * sw * DILATE_BPP);
-		int CopySize = sw * DILATE_BPP;
+		int DstImgOffset = (Y * SubWidth * DILATE_BPP);
+		int CopySize = SubWidth * DILATE_BPP;
 		mem_copy(&pImageBuff[SrcImgOffset], &pBufferOriginal[DstImgOffset], CopySize);
 	}
 

--- a/src/engine/gfx/image_manipulation.h
+++ b/src/engine/gfx/image_manipulation.h
@@ -18,7 +18,7 @@ void ConvertToGrayscale(const CImageInfo &Image);
 // These functions assume that the image data is 4 bytes per pixel RGBA
 void DilateImage(uint8_t *pImageBuff, int w, int h);
 void DilateImage(const CImageInfo &Image);
-void DilateImageSub(uint8_t *pImageBuff, int w, int h, int x, int y, int sw, int sh);
+void DilateImageSub(uint8_t *pImageBuff, int w, int h, int x, int y, int SubWidth, int SubHeight);
 
 // Returned buffer is allocated with malloc, must be freed by caller
 uint8_t *ResizeImage(const uint8_t *pImageData, int Width, int Height, int NewWidth, int NewHeight, int BPP);

--- a/src/engine/shared/filecollection.cpp
+++ b/src/engine/shared/filecollection.cpp
@@ -19,7 +19,7 @@ void CFileCollection::Init(IStorage *pStorage, const char *pPath, const char *pF
 	m_pStorage = pStorage;
 
 	m_pStorage->ListDirectory(IStorage::TYPE_SAVE, m_aPath, FilelistCallback, this);
-	std::sort(m_vFileEntries.begin(), m_vFileEntries.end(), [](const CFileEntry &lhs, const CFileEntry &rhs) { return lhs.m_Timestamp < rhs.m_Timestamp; });
+	std::sort(m_vFileEntries.begin(), m_vFileEntries.end(), [](const CFileEntry &Lhs, const CFileEntry &Rhs) { return Lhs.m_Timestamp < Rhs.m_Timestamp; });
 
 	int FilesDeleted = 0;
 	for(auto FileEntry : m_vFileEntries)

--- a/src/engine/shared/json.cpp
+++ b/src/engine/shared/json.cpp
@@ -1,46 +1,46 @@
 #include <base/system.h>
 #include <engine/shared/json.h>
 
-const struct _json_value *json_object_get(const json_value *object, const char *index)
+const struct _json_value *json_object_get(const json_value *pObject, const char *pIndex)
 {
 	unsigned int i;
 
-	if(object->type != json_object)
+	if(pObject->type != json_object)
 		return &json_value_none;
 
-	for(i = 0; i < object->u.object.length; ++i)
-		if(!str_comp(object->u.object.values[i].name, index))
-			return object->u.object.values[i].value;
+	for(i = 0; i < pObject->u.object.length; ++i)
+		if(!str_comp(pObject->u.object.values[i].name, pIndex))
+			return pObject->u.object.values[i].value;
 
 	return &json_value_none;
 }
 
-const struct _json_value *json_array_get(const json_value *array, int index)
+const struct _json_value *json_array_get(const json_value *pArray, int Index)
 {
-	if(array->type != json_array || index >= (int)array->u.array.length)
+	if(pArray->type != json_array || Index >= (int)pArray->u.array.length)
 		return &json_value_none;
 
-	return array->u.array.values[index];
+	return pArray->u.array.values[Index];
 }
 
-int json_array_length(const json_value *array)
+int json_array_length(const json_value *pArray)
 {
-	return array->u.array.length;
+	return pArray->u.array.length;
 }
 
-const char *json_string_get(const json_value *string)
+const char *json_string_get(const json_value *pString)
 {
-	return string->u.string.ptr;
+	return pString->u.string.ptr;
 }
 
-int json_int_get(const json_value *integer)
+int json_int_get(const json_value *pInteger)
 {
-	return integer->u.integer;
+	return pInteger->u.integer;
 }
 
-int json_boolean_get(const json_value *boolean)
+int json_boolean_get(const json_value *pBoolean)
 {
-	return boolean->u.boolean != 0;
+	return pBoolean->u.boolean != 0;
 }
 
 static char EscapeJsonChar(char c)

--- a/src/engine/textrender.h
+++ b/src/engine/textrender.h
@@ -352,11 +352,11 @@ public:
 
 	// old foolish interface
 	virtual void TextColor(float r, float g, float b, float a) = 0;
-	virtual void TextColor(ColorRGBA rgb) = 0;
+	virtual void TextColor(ColorRGBA Color) = 0;
 	virtual void TextOutlineColor(float r, float g, float b, float a) = 0;
-	virtual void TextOutlineColor(ColorRGBA rgb) = 0;
+	virtual void TextOutlineColor(ColorRGBA Color) = 0;
 	virtual void TextSelectionColor(float r, float g, float b, float a) = 0;
-	virtual void TextSelectionColor(ColorRGBA rgb) = 0;
+	virtual void TextSelectionColor(ColorRGBA Color) = 0;
 	virtual void Text(float x, float y, float Size, const char *pText, float LineWidth = -1.0f) = 0;
 	virtual float TextWidth(float Size, const char *pText, int StrLength = -1, float LineWidth = -1.0f, int Flags = 0, const STextSizeProperties &TextSizeProps = {}) = 0;
 	virtual STextBoundingBox TextBoundingBox(float Size, const char *pText, int StrLength = -1, float LineWidth = -1.0f, float LineSpacing = 0.0f, int Flags = 0) = 0;

--- a/src/game/alloc.h
+++ b/src/game/alloc.h
@@ -22,9 +22,9 @@
 public: \
 	void *operator new(size_t Size) \
 	{ \
-		void *p = malloc(Size); \
-		mem_zero(p, Size); \
-		return p; \
+		void *pObj = malloc(Size); \
+		mem_zero(pObj, Size); \
+		return pObj; \
 	} \
 	void operator delete(void *pPtr) \
 	{ \
@@ -35,9 +35,9 @@ private:
 
 #define MACRO_ALLOC_POOL_ID() \
 public: \
-	void *operator new(size_t Size, int id); \
-	void operator delete(void *p, int id); \
-	void operator delete(void *p); /* NOLINT(misc-new-delete-overloads) */ \
+	void *operator new(size_t Size, int Id); \
+	void operator delete(void *pObj, int Id); \
+	void operator delete(void *pObj); /* NOLINT(misc-new-delete-overloads) */ \
 \
 private:
 
@@ -51,30 +51,30 @@ private:
 	static char gs_PoolData##POOLTYPE[PoolSize][MACRO_ALLOC_GET_SIZE(POOLTYPE)] = {{0}}; \
 	static int gs_PoolUsed##POOLTYPE[PoolSize] = {0}; \
 	MAYBE_UNUSED static int gs_PoolDummy##POOLTYPE = (ASAN_POISON_MEMORY_REGION(gs_PoolData##POOLTYPE, sizeof(gs_PoolData##POOLTYPE)), 0); \
-	void *POOLTYPE::operator new(size_t Size, int id) \
+	void *POOLTYPE::operator new(size_t Size, int Id) \
 	{ \
 		dbg_assert(sizeof(POOLTYPE) >= Size, "size error"); \
-		dbg_assert(!gs_PoolUsed##POOLTYPE[id], "already used"); \
-		ASAN_UNPOISON_MEMORY_REGION(gs_PoolData##POOLTYPE[id], sizeof(gs_PoolData##POOLTYPE[id])); \
-		gs_PoolUsed##POOLTYPE[id] = 1; \
-		mem_zero(gs_PoolData##POOLTYPE[id], sizeof(gs_PoolData##POOLTYPE[id])); \
-		return gs_PoolData##POOLTYPE[id]; \
+		dbg_assert(!gs_PoolUsed##POOLTYPE[Id], "already used"); \
+		ASAN_UNPOISON_MEMORY_REGION(gs_PoolData##POOLTYPE[Id], sizeof(gs_PoolData##POOLTYPE[Id])); \
+		gs_PoolUsed##POOLTYPE[Id] = 1; \
+		mem_zero(gs_PoolData##POOLTYPE[Id], sizeof(gs_PoolData##POOLTYPE[Id])); \
+		return gs_PoolData##POOLTYPE[Id]; \
 	} \
-	void POOLTYPE::operator delete(void *p, int id) \
+	void POOLTYPE::operator delete(void *pObj, int Id) \
 	{ \
-		dbg_assert(gs_PoolUsed##POOLTYPE[id], "not used"); \
-		dbg_assert(id == (POOLTYPE *)p - (POOLTYPE *)gs_PoolData##POOLTYPE, "invalid id"); \
-		gs_PoolUsed##POOLTYPE[id] = 0; \
-		mem_zero(gs_PoolData##POOLTYPE[id], sizeof(gs_PoolData##POOLTYPE[id])); \
-		ASAN_POISON_MEMORY_REGION(gs_PoolData##POOLTYPE[id], sizeof(gs_PoolData##POOLTYPE[id])); \
+		dbg_assert(gs_PoolUsed##POOLTYPE[Id], "not used"); \
+		dbg_assert(Id == (POOLTYPE *)pObj - (POOLTYPE *)gs_PoolData##POOLTYPE, "invalid id"); \
+		gs_PoolUsed##POOLTYPE[Id] = 0; \
+		mem_zero(gs_PoolData##POOLTYPE[Id], sizeof(gs_PoolData##POOLTYPE[Id])); \
+		ASAN_POISON_MEMORY_REGION(gs_PoolData##POOLTYPE[Id], sizeof(gs_PoolData##POOLTYPE[Id])); \
 	} \
-	void POOLTYPE::operator delete(void *p) /* NOLINT(misc-new-delete-overloads) */ \
+	void POOLTYPE::operator delete(void *pObj) /* NOLINT(misc-new-delete-overloads) */ \
 	{ \
-		int id = (POOLTYPE *)p - (POOLTYPE *)gs_PoolData##POOLTYPE; \
-		dbg_assert(gs_PoolUsed##POOLTYPE[id], "not used"); \
-		gs_PoolUsed##POOLTYPE[id] = 0; \
-		mem_zero(gs_PoolData##POOLTYPE[id], sizeof(gs_PoolData##POOLTYPE[id])); \
-		ASAN_POISON_MEMORY_REGION(gs_PoolData##POOLTYPE[id], sizeof(gs_PoolData##POOLTYPE[id])); \
+		int Id = (POOLTYPE *)pObj - (POOLTYPE *)gs_PoolData##POOLTYPE; \
+		dbg_assert(gs_PoolUsed##POOLTYPE[Id], "not used"); \
+		gs_PoolUsed##POOLTYPE[Id] = 0; \
+		mem_zero(gs_PoolData##POOLTYPE[Id], sizeof(gs_PoolData##POOLTYPE[Id])); \
+		ASAN_POISON_MEMORY_REGION(gs_PoolData##POOLTYPE[Id], sizeof(gs_PoolData##POOLTYPE[Id])); \
 	}
 
 #endif

--- a/src/game/client/components/freezebars.cpp
+++ b/src/game/client/components/freezebars.cpp
@@ -36,7 +36,7 @@ void CFreezeBars::RenderFreezeBar(const int ClientId)
 	RenderFreezeBarPos(Position.x, Position.y, FreezeBarWidth, FreezeBarHight, FreezeProgress, Alpha);
 }
 
-void CFreezeBars::RenderFreezeBarPos(float x, const float y, const float width, const float height, float Progress, const float Alpha)
+void CFreezeBars::RenderFreezeBarPos(float x, const float y, const float Width, const float Height, float Progress, const float Alpha)
 {
 	Progress = clamp(Progress, 0.0f, 1.0f);
 
@@ -45,9 +45,9 @@ void CFreezeBars::RenderFreezeBarPos(float x, const float y, const float width, 
 	const float RestPct = 0.5f;
 	const float ProgPct = 0.5f;
 
-	const float EndWidth = height; // to keep the correct scale - the height of the sprite is as long as the width
-	const float BarHeight = height;
-	const float WholeBarWidth = width;
+	const float EndWidth = Height; // to keep the correct scale - the height of the sprite is as long as the width
+	const float BarHeight = Height;
+	const float WholeBarWidth = Width;
 	const float MiddleBarWidth = WholeBarWidth - (EndWidth * 2.0f);
 	const float EndProgressWidth = EndWidth * ProgPct;
 	const float EndRestWidth = EndWidth * RestPct;

--- a/src/game/client/components/freezebars.h
+++ b/src/game/client/components/freezebars.h
@@ -5,7 +5,7 @@
 class CFreezeBars : public CComponent
 {
 	void RenderFreezeBar(const int ClientId);
-	void RenderFreezeBarPos(float x, const float y, const float width, const float height, float Progress, float Alpha = 1.0f);
+	void RenderFreezeBarPos(float x, const float y, const float Width, const float Height, float Progress, float Alpha = 1.0f);
 	bool IsPlayerInfoAvailable(int ClientId) const;
 
 public:

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -1040,7 +1040,7 @@ void CHud::RenderPlayerState(const int ClientId)
 	}
 }
 
-void CHud::RenderNinjaBarPos(const float x, float y, const float width, const float height, float Progress, const float Alpha)
+void CHud::RenderNinjaBarPos(const float x, float y, const float Width, const float Height, float Progress, const float Alpha)
 {
 	Progress = clamp(Progress, 0.0f, 1.0f);
 
@@ -1049,9 +1049,9 @@ void CHud::RenderNinjaBarPos(const float x, float y, const float width, const fl
 	const float RestPct = 0.5f;
 	const float ProgPct = 0.5f;
 
-	const float EndHeight = width; // to keep the correct scale - the width of the sprite is as long as the height
-	const float BarWidth = width;
-	const float WholeBarHeight = height;
+	const float EndHeight = Width; // to keep the correct scale - the width of the sprite is as long as the height
+	const float BarWidth = Width;
+	const float WholeBarHeight = Height;
 	const float MiddleBarHeight = WholeBarHeight - (EndHeight * 2.0f);
 	const float EndProgressHeight = EndHeight * ProgPct;
 	const float EndRestHeight = EndHeight * RestPct;

--- a/src/game/client/components/hud.h
+++ b/src/game/client/components/hud.h
@@ -109,7 +109,7 @@ public:
 	// DDRace
 
 	virtual void OnMessage(int MsgType, void *pRawMsg) override;
-	void RenderNinjaBarPos(float x, const float y, const float width, const float height, float Progress, float Alpha = 1.0f);
+	void RenderNinjaBarPos(float x, const float y, const float Width, const float Height, float Progress, float Alpha = 1.0f);
 
 private:
 	void RenderRecord();

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -2772,16 +2772,16 @@ IGameClient *CreateGameClient()
 	return new CGameClient();
 }
 
-int CGameClient::IntersectCharacter(vec2 HookPos, vec2 NewPos, vec2 &NewPos2, int ownId)
+int CGameClient::IntersectCharacter(vec2 HookPos, vec2 NewPos, vec2 &NewPos2, int OwnId)
 {
 	float Distance = 0.0f;
 	int ClosestId = -1;
 
-	const CClientData &OwnClientData = m_aClients[ownId];
+	const CClientData &OwnClientData = m_aClients[OwnId];
 
 	for(int i = 0; i < MAX_CLIENTS; i++)
 	{
-		if(i == ownId)
+		if(i == OwnId)
 			continue;
 
 		const CClientData &Data = m_aClients[i];
@@ -2797,7 +2797,7 @@ int CGameClient::IntersectCharacter(vec2 HookPos, vec2 NewPos, vec2 &NewPos2, in
 		bool IsOneSuper = Data.m_Super || OwnClientData.m_Super;
 		bool IsOneSolo = Data.m_Solo || OwnClientData.m_Solo;
 
-		if(!IsOneSuper && (!m_Teams.SameTeam(i, ownId) || IsOneSolo || OwnClientData.m_HookHitDisabled))
+		if(!IsOneSuper && (!m_Teams.SameTeam(i, OwnId) || IsOneSolo || OwnClientData.m_HookHitDisabled))
 			continue;
 
 		vec2 ClosestPoint;
@@ -3904,9 +3904,9 @@ void CGameClient::SnapCollectEntities()
 	class CEntComparer
 	{
 	public:
-		bool operator()(const CSnapEntities &lhs, const CSnapEntities &rhs) const
+		bool operator()(const CSnapEntities &Lhs, const CSnapEntities &Rhs) const
 		{
-			return lhs.m_Item.m_Id < rhs.m_Item.m_Id;
+			return Lhs.m_Item.m_Id < Rhs.m_Item.m_Id;
 		}
 	};
 

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -576,7 +576,7 @@ public:
 
 	class CTeamsCore m_Teams;
 
-	int IntersectCharacter(vec2 HookPos, vec2 NewPos, vec2 &NewPos2, int ownId);
+	int IntersectCharacter(vec2 HookPos, vec2 NewPos, vec2 &NewPos2, int OwnId);
 
 	int GetLastRaceTick() const override;
 

--- a/src/game/collision.cpp
+++ b/src/game/collision.cpp
@@ -602,28 +602,28 @@ int CCollision::IsSolid(int x, int y) const
 	return index == TILE_SOLID || index == TILE_NOHOOK;
 }
 
-bool CCollision::IsThrough(int x, int y, int xoff, int yoff, vec2 pos0, vec2 pos1) const
+bool CCollision::IsThrough(int x, int y, int OffsetX, int OffsetY, vec2 Pos0, vec2 Pos1) const
 {
 	int pos = GetPureMapIndex(x, y);
 	if(m_pFront && (m_pFront[pos].m_Index == TILE_THROUGH_ALL || m_pFront[pos].m_Index == TILE_THROUGH_CUT))
 		return true;
-	if(m_pFront && m_pFront[pos].m_Index == TILE_THROUGH_DIR && ((m_pFront[pos].m_Flags == ROTATION_0 && pos0.y > pos1.y) || (m_pFront[pos].m_Flags == ROTATION_90 && pos0.x < pos1.x) || (m_pFront[pos].m_Flags == ROTATION_180 && pos0.y < pos1.y) || (m_pFront[pos].m_Flags == ROTATION_270 && pos0.x > pos1.x)))
+	if(m_pFront && m_pFront[pos].m_Index == TILE_THROUGH_DIR && ((m_pFront[pos].m_Flags == ROTATION_0 && Pos0.y > Pos1.y) || (m_pFront[pos].m_Flags == ROTATION_90 && Pos0.x < Pos1.x) || (m_pFront[pos].m_Flags == ROTATION_180 && Pos0.y < Pos1.y) || (m_pFront[pos].m_Flags == ROTATION_270 && Pos0.x > Pos1.x)))
 		return true;
-	int offpos = GetPureMapIndex(x + xoff, y + yoff);
+	int offpos = GetPureMapIndex(x + OffsetX, y + OffsetY);
 	return m_pTiles[offpos].m_Index == TILE_THROUGH || (m_pFront && m_pFront[offpos].m_Index == TILE_THROUGH);
 }
 
-bool CCollision::IsHookBlocker(int x, int y, vec2 pos0, vec2 pos1) const
+bool CCollision::IsHookBlocker(int x, int y, vec2 Pos0, vec2 Pos1) const
 {
 	int pos = GetPureMapIndex(x, y);
 	if(m_pTiles[pos].m_Index == TILE_THROUGH_ALL || (m_pFront && m_pFront[pos].m_Index == TILE_THROUGH_ALL))
 		return true;
-	if(m_pTiles[pos].m_Index == TILE_THROUGH_DIR && ((m_pTiles[pos].m_Flags == ROTATION_0 && pos0.y < pos1.y) ||
-								(m_pTiles[pos].m_Flags == ROTATION_90 && pos0.x > pos1.x) ||
-								(m_pTiles[pos].m_Flags == ROTATION_180 && pos0.y > pos1.y) ||
-								(m_pTiles[pos].m_Flags == ROTATION_270 && pos0.x < pos1.x)))
+	if(m_pTiles[pos].m_Index == TILE_THROUGH_DIR && ((m_pTiles[pos].m_Flags == ROTATION_0 && Pos0.y < Pos1.y) ||
+								(m_pTiles[pos].m_Flags == ROTATION_90 && Pos0.x > Pos1.x) ||
+								(m_pTiles[pos].m_Flags == ROTATION_180 && Pos0.y > Pos1.y) ||
+								(m_pTiles[pos].m_Flags == ROTATION_270 && Pos0.x < Pos1.x)))
 		return true;
-	if(m_pFront && m_pFront[pos].m_Index == TILE_THROUGH_DIR && ((m_pFront[pos].m_Flags == ROTATION_0 && pos0.y < pos1.y) || (m_pFront[pos].m_Flags == ROTATION_90 && pos0.x > pos1.x) || (m_pFront[pos].m_Flags == ROTATION_180 && pos0.y > pos1.y) || (m_pFront[pos].m_Flags == ROTATION_270 && pos0.x < pos1.x)))
+	if(m_pFront && m_pFront[pos].m_Index == TILE_THROUGH_DIR && ((m_pFront[pos].m_Flags == ROTATION_0 && Pos0.y < Pos1.y) || (m_pFront[pos].m_Flags == ROTATION_90 && Pos0.x > Pos1.x) || (m_pFront[pos].m_Flags == ROTATION_180 && Pos0.y > Pos1.y) || (m_pFront[pos].m_Flags == ROTATION_270 && Pos0.x < Pos1.x)))
 		return true;
 	return false;
 }
@@ -1078,12 +1078,12 @@ int CCollision::Entity(int x, int y, int Layer) const
 	}
 }
 
-void CCollision::SetCollisionAt(float x, float y, int id)
+void CCollision::SetCollisionAt(float x, float y, int Index)
 {
 	int Nx = clamp(round_to_int(x) / 32, 0, m_Width - 1);
 	int Ny = clamp(round_to_int(y) / 32, 0, m_Height - 1);
 
-	m_pTiles[Ny * m_Width + Nx].m_Index = id;
+	m_pTiles[Ny * m_Width + Nx].m_Index = Index;
 }
 
 void CCollision::SetDCollisionAt(float x, float y, int Type, int Flags, int Number)

--- a/src/game/collision.h
+++ b/src/game/collision.h
@@ -53,7 +53,7 @@ public:
 	bool TestBox(vec2 Pos, vec2 Size) const;
 
 	// DDRace
-	void SetCollisionAt(float x, float y, int id);
+	void SetCollisionAt(float x, float y, int Index);
 	void SetDCollisionAt(float x, float y, int Type, int Flags, int Number);
 	int GetDTileIndex(int Index) const;
 	int GetDTileFlags(int Index) const;
@@ -101,8 +101,8 @@ public:
 	int GetSwitchDelay(int Index) const;
 
 	int IsSolid(int x, int y) const;
-	bool IsThrough(int x, int y, int xoff, int yoff, vec2 pos0, vec2 pos1) const;
-	bool IsHookBlocker(int x, int y, vec2 pos0, vec2 pos1) const;
+	bool IsThrough(int x, int y, int OffsetX, int OffsetY, vec2 Pos0, vec2 Pos1) const;
+	bool IsHookBlocker(int x, int y, vec2 Pos0, vec2 Pos1) const;
 	int IsWallJump(int Index) const;
 	int IsNoLaser(int x, int y) const;
 	int IsFNoLaser(int x, int y) const;

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -3207,11 +3207,11 @@ void CEditor::DoMapEditor(CUIRect View)
 									std::shared_ptr<CLayerTiles> pBrushLayer = std::static_pointer_cast<CLayerTiles>(m_pBrush->m_vpLayers[BrushIndex]);
 
 									if(pLayer->m_Tele <= pBrushLayer->m_Tele && pLayer->m_Speedup <= pBrushLayer->m_Speedup && pLayer->m_Front <= pBrushLayer->m_Front && pLayer->m_Game <= pBrushLayer->m_Game && pLayer->m_Switch <= pBrushLayer->m_Switch && pLayer->m_Tune <= pBrushLayer->m_Tune)
-										pLayer->BrushDraw(pBrushLayer, wx, wy);
+										pLayer->BrushDraw(pBrushLayer, vec2(wx, wy));
 								}
 								else
 								{
-									apEditLayers[k].second->BrushDraw(m_pBrush->m_vpLayers[BrushIndex], wx, wy);
+									apEditLayers[k].second->BrushDraw(m_pBrush->m_vpLayers[BrushIndex], vec2(wx, wy));
 								}
 							}
 						}
@@ -3304,7 +3304,7 @@ void CEditor::DoMapEditor(CUIRect View)
 								BrushIndex = 0;
 
 							if(apEditLayers[k].second->m_Type == m_pBrush->m_vpLayers[BrushIndex]->m_Type)
-								apEditLayers[k].second->BrushPlace(m_pBrush->m_vpLayers[BrushIndex], wx, wy);
+								apEditLayers[k].second->BrushPlace(m_pBrush->m_vpLayers[BrushIndex], vec2(wx, wy));
 						}
 					}
 
@@ -5915,14 +5915,14 @@ float CEditor::EnvelopeToScreenY(const CUIRect &View, float y) const
 	return View.y + View.h - y / m_ZoomEnvelopeY.GetValue() * View.h - m_OffsetEnvelopeY * View.h;
 }
 
-float CEditor::ScreenToEnvelopeDX(const CUIRect &View, float dx)
+float CEditor::ScreenToEnvelopeDX(const CUIRect &View, float DeltaX)
 {
-	return dx / Graphics()->ScreenWidth() * Ui()->Screen()->w / View.w * m_ZoomEnvelopeX.GetValue();
+	return DeltaX / Graphics()->ScreenWidth() * Ui()->Screen()->w / View.w * m_ZoomEnvelopeX.GetValue();
 }
 
-float CEditor::ScreenToEnvelopeDY(const CUIRect &View, float dy)
+float CEditor::ScreenToEnvelopeDY(const CUIRect &View, float DeltaY)
 {
-	return dy / Graphics()->ScreenHeight() * Ui()->Screen()->h / View.h * m_ZoomEnvelopeY.GetValue();
+	return DeltaY / Graphics()->ScreenHeight() * Ui()->Screen()->h / View.h * m_ZoomEnvelopeY.GetValue();
 }
 
 void CEditor::RemoveTimeOffsetEnvelope(const std::shared_ptr<CEnvelope> &pEnvelope)

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -850,9 +850,9 @@ public:
 	void DoMapSettingsEditBox(CMapSettingsBackend::CContext *pContext, const CUIRect *pRect, float FontSize, float DropdownMaxHeight, int Corners = IGraphics::CORNER_ALL, const char *pToolTip = nullptr);
 
 	template<typename T>
-	int DoEditBoxDropdown(SEditBoxDropdownContext *pDropdown, CLineInput *pLineInput, const CUIRect *pEditBoxRect, int x, float MaxHeight, bool AutoWidth, const std::vector<T> &vData, const FDropdownRenderCallback<T> &fnMatchCallback);
+	int DoEditBoxDropdown(SEditBoxDropdownContext *pDropdown, CLineInput *pLineInput, const CUIRect *pEditBoxRect, int x, float MaxHeight, bool AutoWidth, const std::vector<T> &vData, const FDropdownRenderCallback<T> &pfnMatchCallback);
 	template<typename T>
-	int RenderEditBoxDropdown(SEditBoxDropdownContext *pDropdown, CUIRect View, CLineInput *pLineInput, int x, float MaxHeight, bool AutoWidth, const std::vector<T> &vData, const FDropdownRenderCallback<T> &fnMatchCallback);
+	int RenderEditBoxDropdown(SEditBoxDropdownContext *pDropdown, CUIRect View, CLineInput *pLineInput, int x, float MaxHeight, bool AutoWidth, const std::vector<T> &vData, const FDropdownRenderCallback<T> &pfnMatchCallback);
 
 	void RenderBackground(CUIRect View, IGraphics::CTextureHandle Texture, float Size, float Brightness) const;
 
@@ -1121,8 +1121,8 @@ public:
 	float EnvelopeToScreenX(const CUIRect &View, float x) const;
 	float ScreenToEnvelopeY(const CUIRect &View, float y) const;
 	float EnvelopeToScreenY(const CUIRect &View, float y) const;
-	float ScreenToEnvelopeDX(const CUIRect &View, float dx);
-	float ScreenToEnvelopeDY(const CUIRect &View, float dy);
+	float ScreenToEnvelopeDX(const CUIRect &View, float DeltaX);
+	float ScreenToEnvelopeDY(const CUIRect &View, float DeltaY);
 
 	// DDRace
 

--- a/src/game/editor/editor_server_settings.cpp
+++ b/src/game/editor/editor_server_settings.cpp
@@ -399,7 +399,7 @@ void CEditor::DoMapSettingsEditBox(CMapSettingsBackend::CContext *pContext, cons
 }
 
 template<typename T>
-int CEditor::DoEditBoxDropdown(SEditBoxDropdownContext *pDropdown, CLineInput *pLineInput, const CUIRect *pEditBoxRect, int x, float MaxHeight, bool AutoWidth, const std::vector<T> &vData, const FDropdownRenderCallback<T> &fnMatchCallback)
+int CEditor::DoEditBoxDropdown(SEditBoxDropdownContext *pDropdown, CLineInput *pLineInput, const CUIRect *pEditBoxRect, int x, float MaxHeight, bool AutoWidth, const std::vector<T> &vData, const FDropdownRenderCallback<T> &pfnMatchCallback)
 {
 	// Do an edit box with a possible dropdown
 	// This is a generic method which can display any data we want
@@ -439,7 +439,7 @@ int CEditor::DoEditBoxDropdown(SEditBoxDropdownContext *pDropdown, CLineInput *p
 			pDropdown->m_Selected %= vData.size();
 		}
 
-		int Selected = RenderEditBoxDropdown<T>(pDropdown, *pEditBoxRect, pLineInput, x, MaxHeight, AutoWidth, vData, fnMatchCallback);
+		int Selected = RenderEditBoxDropdown<T>(pDropdown, *pEditBoxRect, pLineInput, x, MaxHeight, AutoWidth, vData, pfnMatchCallback);
 		if(Selected != -1)
 			pDropdown->m_Selected = Selected;
 
@@ -460,7 +460,7 @@ int CEditor::DoEditBoxDropdown(SEditBoxDropdownContext *pDropdown, CLineInput *p
 }
 
 template<typename T>
-int CEditor::RenderEditBoxDropdown(SEditBoxDropdownContext *pDropdown, CUIRect View, CLineInput *pLineInput, int x, float MaxHeight, bool AutoWidth, const std::vector<T> &vData, const FDropdownRenderCallback<T> &fnMatchCallback)
+int CEditor::RenderEditBoxDropdown(SEditBoxDropdownContext *pDropdown, CUIRect View, CLineInput *pLineInput, int x, float MaxHeight, bool AutoWidth, const std::vector<T> &vData, const FDropdownRenderCallback<T> &pfnMatchCallback)
 {
 	// Render a dropdown tied to an edit box/line input
 	auto *pListBox = &pDropdown->m_ListBox;
@@ -506,7 +506,7 @@ int CEditor::RenderEditBoxDropdown(SEditBoxDropdownContext *pDropdown, CUIRect V
 
 			// Call the callback to fill the current line string
 			char aBuf[128];
-			fnMatchCallback(vData.at(i), aBuf, Props.m_vColorSplits);
+			pfnMatchCallback(vData.at(i), aBuf, Props.m_vColorSplits);
 
 			LargestWidth = maximum(LargestWidth, TextRender()->TextWidth(12.0f, aBuf) + 10.0f);
 			if(!Item.m_Visible)

--- a/src/game/editor/mapitems/layer.h
+++ b/src/game/editor/mapitems/layer.h
@@ -46,8 +46,8 @@ public:
 	virtual void BrushSelecting(CUIRect Rect) {}
 	virtual int BrushGrab(std::shared_ptr<CLayerGroup> pBrush, CUIRect Rect) { return 0; }
 	virtual void FillSelection(bool Empty, std::shared_ptr<CLayer> pBrush, CUIRect Rect) {}
-	virtual void BrushDraw(std::shared_ptr<CLayer> pBrush, float x, float y) {}
-	virtual void BrushPlace(std::shared_ptr<CLayer> pBrush, float x, float y) {}
+	virtual void BrushDraw(std::shared_ptr<CLayer> pBrush, vec2 WorldPos) {}
+	virtual void BrushPlace(std::shared_ptr<CLayer> pBrush, vec2 WorldPos) {}
 	virtual void BrushFlipX() {}
 	virtual void BrushFlipY() {}
 	virtual void BrushRotate(float Amount) {}

--- a/src/game/editor/mapitems/layer_quads.cpp
+++ b/src/game/editor/mapitems/layer_quads.cpp
@@ -138,7 +138,7 @@ int CLayerQuads::BrushGrab(std::shared_ptr<CLayerGroup> pBrush, CUIRect Rect)
 	return pGrabbed->m_vQuads.empty() ? 0 : 1;
 }
 
-void CLayerQuads::BrushPlace(std::shared_ptr<CLayer> pBrush, float wx, float wy)
+void CLayerQuads::BrushPlace(std::shared_ptr<CLayer> pBrush, vec2 WorldPos)
 {
 	std::shared_ptr<CLayerQuads> pQuadLayer = std::static_pointer_cast<CLayerQuads>(pBrush);
 	std::vector<CQuad> vAddedQuads;
@@ -148,8 +148,8 @@ void CLayerQuads::BrushPlace(std::shared_ptr<CLayer> pBrush, float wx, float wy)
 
 		for(auto &Point : n.m_aPoints)
 		{
-			Point.x += f2fx(wx);
-			Point.y += f2fx(wy);
+			Point.x += f2fx(WorldPos.x);
+			Point.y += f2fx(WorldPos.y);
 		}
 
 		m_vQuads.push_back(n);

--- a/src/game/editor/mapitems/layer_quads.h
+++ b/src/game/editor/mapitems/layer_quads.h
@@ -16,7 +16,7 @@ public:
 
 	void BrushSelecting(CUIRect Rect) override;
 	int BrushGrab(std::shared_ptr<CLayerGroup> pBrush, CUIRect Rect) override;
-	void BrushPlace(std::shared_ptr<CLayer> pBrush, float wx, float wy) override;
+	void BrushPlace(std::shared_ptr<CLayer> pBrush, vec2 WorldPos) override;
 	void BrushFlipX() override;
 	void BrushFlipY() override;
 	void BrushRotate(float Amount) override;

--- a/src/game/editor/mapitems/layer_sounds.cpp
+++ b/src/game/editor/mapitems/layer_sounds.cpp
@@ -150,7 +150,7 @@ int CLayerSounds::BrushGrab(std::shared_ptr<CLayerGroup> pBrush, CUIRect Rect)
 	return pGrabbed->m_vSources.empty() ? 0 : 1;
 }
 
-void CLayerSounds::BrushPlace(std::shared_ptr<CLayer> pBrush, float wx, float wy)
+void CLayerSounds::BrushPlace(std::shared_ptr<CLayer> pBrush, vec2 WorldPos)
 {
 	std::shared_ptr<CLayerSounds> pSoundLayer = std::static_pointer_cast<CLayerSounds>(pBrush);
 	std::vector<CSoundSource> vAddedSources;
@@ -158,8 +158,8 @@ void CLayerSounds::BrushPlace(std::shared_ptr<CLayer> pBrush, float wx, float wy
 	{
 		CSoundSource n = Source;
 
-		n.m_Position.x += f2fx(wx);
-		n.m_Position.y += f2fx(wy);
+		n.m_Position.x += f2fx(WorldPos.x);
+		n.m_Position.y += f2fx(WorldPos.y);
 
 		m_vSources.push_back(n);
 		vAddedSources.push_back(n);

--- a/src/game/editor/mapitems/layer_sounds.h
+++ b/src/game/editor/mapitems/layer_sounds.h
@@ -15,7 +15,7 @@ public:
 
 	void BrushSelecting(CUIRect Rect) override;
 	int BrushGrab(std::shared_ptr<CLayerGroup> pBrush, CUIRect Rect) override;
-	void BrushPlace(std::shared_ptr<CLayer> pBrush, float wx, float wy) override;
+	void BrushPlace(std::shared_ptr<CLayer> pBrush, vec2 WorldPos) override;
 
 	CUi::EPopupMenuFunctionResult RenderProperties(CUIRect *pToolbox) override;
 

--- a/src/game/editor/mapitems/layer_speedup.cpp
+++ b/src/game/editor/mapitems/layer_speedup.cpp
@@ -65,14 +65,14 @@ bool CLayerSpeedup::IsEmpty(const std::shared_ptr<CLayerTiles> &pLayer)
 	return true;
 }
 
-void CLayerSpeedup::BrushDraw(std::shared_ptr<CLayer> pBrush, float wx, float wy)
+void CLayerSpeedup::BrushDraw(std::shared_ptr<CLayer> pBrush, vec2 WorldPos)
 {
 	if(m_Readonly)
 		return;
 
 	std::shared_ptr<CLayerSpeedup> pSpeedupLayer = std::static_pointer_cast<CLayerSpeedup>(pBrush);
-	int sx = ConvertX(wx);
-	int sy = ConvertY(wy);
+	int sx = ConvertX(WorldPos.x);
+	int sy = ConvertY(WorldPos.y);
 	if(str_comp(pSpeedupLayer->m_aFileName, m_pEditor->m_aFileName))
 	{
 		m_pEditor->m_SpeedupAngle = pSpeedupLayer->m_SpeedupAngle;

--- a/src/game/editor/mapitems/layer_speedup.h
+++ b/src/game/editor/mapitems/layer_speedup.h
@@ -31,7 +31,7 @@ public:
 	void Resize(int NewW, int NewH) override;
 	void Shift(int Direction) override;
 	bool IsEmpty(const std::shared_ptr<CLayerTiles> &pLayer) override;
-	void BrushDraw(std::shared_ptr<CLayer> pBrush, float wx, float wy) override;
+	void BrushDraw(std::shared_ptr<CLayer> pBrush, vec2 WorldPos) override;
 	void BrushFlipX() override;
 	void BrushFlipY() override;
 	void BrushRotate(float Amount) override;

--- a/src/game/editor/mapitems/layer_switch.cpp
+++ b/src/game/editor/mapitems/layer_switch.cpp
@@ -67,14 +67,14 @@ bool CLayerSwitch::IsEmpty(const std::shared_ptr<CLayerTiles> &pLayer)
 	return true;
 }
 
-void CLayerSwitch::BrushDraw(std::shared_ptr<CLayer> pBrush, float wx, float wy)
+void CLayerSwitch::BrushDraw(std::shared_ptr<CLayer> pBrush, vec2 WorldPos)
 {
 	if(m_Readonly)
 		return;
 
 	std::shared_ptr<CLayerSwitch> pSwitchLayer = std::static_pointer_cast<CLayerSwitch>(pBrush);
-	int sx = ConvertX(wx);
-	int sy = ConvertY(wy);
+	int sx = ConvertX(WorldPos.x);
+	int sy = ConvertY(WorldPos.y);
 	if(str_comp(pSwitchLayer->m_aFileName, m_pEditor->m_aFileName))
 	{
 		m_pEditor->m_SwitchNum = pSwitchLayer->m_SwitchNumber;

--- a/src/game/editor/mapitems/layer_switch.h
+++ b/src/game/editor/mapitems/layer_switch.h
@@ -30,7 +30,7 @@ public:
 	void Resize(int NewW, int NewH) override;
 	void Shift(int Direction) override;
 	bool IsEmpty(const std::shared_ptr<CLayerTiles> &pLayer) override;
-	void BrushDraw(std::shared_ptr<CLayer> pBrush, float wx, float wy) override;
+	void BrushDraw(std::shared_ptr<CLayer> pBrush, vec2 WorldPos) override;
 	void BrushFlipX() override;
 	void BrushFlipY() override;
 	void BrushRotate(float Amount) override;

--- a/src/game/editor/mapitems/layer_tele.cpp
+++ b/src/game/editor/mapitems/layer_tele.cpp
@@ -68,14 +68,14 @@ bool CLayerTele::IsEmpty(const std::shared_ptr<CLayerTiles> &pLayer)
 	return true;
 }
 
-void CLayerTele::BrushDraw(std::shared_ptr<CLayer> pBrush, float wx, float wy)
+void CLayerTele::BrushDraw(std::shared_ptr<CLayer> pBrush, vec2 WorldPos)
 {
 	if(m_Readonly)
 		return;
 
 	std::shared_ptr<CLayerTele> pTeleLayer = std::static_pointer_cast<CLayerTele>(pBrush);
-	int sx = ConvertX(wx);
-	int sy = ConvertY(wy);
+	int sx = ConvertX(WorldPos.x);
+	int sy = ConvertY(WorldPos.y);
 	if(str_comp(pTeleLayer->m_aFileName, m_pEditor->m_aFileName))
 		m_pEditor->m_TeleNumber = pTeleLayer->m_TeleNum;
 

--- a/src/game/editor/mapitems/layer_tele.h
+++ b/src/game/editor/mapitems/layer_tele.h
@@ -28,7 +28,7 @@ public:
 	void Resize(int NewW, int NewH) override;
 	void Shift(int Direction) override;
 	bool IsEmpty(const std::shared_ptr<CLayerTiles> &pLayer) override;
-	void BrushDraw(std::shared_ptr<CLayer> pBrush, float wx, float wy) override;
+	void BrushDraw(std::shared_ptr<CLayer> pBrush, vec2 WorldPos) override;
 	void BrushFlipX() override;
 	void BrushFlipY() override;
 	void BrushRotate(float Amount) override;

--- a/src/game/editor/mapitems/layer_tiles.cpp
+++ b/src/game/editor/mapitems/layer_tiles.cpp
@@ -487,15 +487,15 @@ void CLayerTiles::FillSelection(bool Empty, std::shared_ptr<CLayer> pBrush, CUIR
 	FlagModified(sx, sy, w, h);
 }
 
-void CLayerTiles::BrushDraw(std::shared_ptr<CLayer> pBrush, float wx, float wy)
+void CLayerTiles::BrushDraw(std::shared_ptr<CLayer> pBrush, vec2 WorldPos)
 {
 	if(m_Readonly)
 		return;
 
 	//
 	std::shared_ptr<CLayerTiles> pTileLayer = std::static_pointer_cast<CLayerTiles>(pBrush);
-	int sx = ConvertX(wx);
-	int sy = ConvertY(wy);
+	int sx = ConvertX(WorldPos.x);
+	int sy = ConvertY(WorldPos.y);
 
 	bool Destructive = m_pEditor->m_BrushDrawDestructive || IsEmpty(pTileLayer);
 

--- a/src/game/editor/mapitems/layer_tiles.h
+++ b/src/game/editor/mapitems/layer_tiles.h
@@ -125,7 +125,7 @@ public:
 	void FillSelection(bool Empty, std::shared_ptr<CLayer> pBrush, CUIRect Rect) override;
 	void FillGameTiles(EGameTileOp Fill);
 	bool CanFillGameTiles() const;
-	void BrushDraw(std::shared_ptr<CLayer> pBrush, float wx, float wy) override;
+	void BrushDraw(std::shared_ptr<CLayer> pBrush, vec2 WorldPos) override;
 	void BrushFlipX() override;
 	void BrushFlipY() override;
 	void BrushRotate(float Amount) override;

--- a/src/game/editor/mapitems/layer_tune.cpp
+++ b/src/game/editor/mapitems/layer_tune.cpp
@@ -65,14 +65,14 @@ bool CLayerTune::IsEmpty(const std::shared_ptr<CLayerTiles> &pLayer)
 	return true;
 }
 
-void CLayerTune::BrushDraw(std::shared_ptr<CLayer> pBrush, float wx, float wy)
+void CLayerTune::BrushDraw(std::shared_ptr<CLayer> pBrush, vec2 WorldPos)
 {
 	if(m_Readonly)
 		return;
 
 	std::shared_ptr<CLayerTune> pTuneLayer = std::static_pointer_cast<CLayerTune>(pBrush);
-	int sx = ConvertX(wx);
-	int sy = ConvertY(wy);
+	int sx = ConvertX(WorldPos.x);
+	int sy = ConvertY(WorldPos.y);
 	if(str_comp(pTuneLayer->m_aFileName, m_pEditor->m_aFileName))
 	{
 		m_pEditor->m_TuningNum = pTuneLayer->m_TuningNumber;

--- a/src/game/editor/mapitems/layer_tune.h
+++ b/src/game/editor/mapitems/layer_tune.h
@@ -27,7 +27,7 @@ public:
 	void Resize(int NewW, int NewH) override;
 	void Shift(int Direction) override;
 	bool IsEmpty(const std::shared_ptr<CLayerTiles> &pLayer) override;
-	void BrushDraw(std::shared_ptr<CLayer> pBrush, float wx, float wy) override;
+	void BrushDraw(std::shared_ptr<CLayer> pBrush, vec2 WorldPos) override;
 	void BrushFlipX() override;
 	void BrushFlipY() override;
 	void BrushRotate(float Amount) override;

--- a/src/tools/map_find_env.cpp
+++ b/src/tools/map_find_env.cpp
@@ -4,8 +4,9 @@
 #include <engine/storage.h>
 #include <game/mapitems.h>
 
-struct EnvelopedQuad
+class CEnvelopedQuad
 {
+public:
 	int m_GroupId;
 	int m_LayerId;
 	int m_TilePosX;
@@ -48,7 +49,7 @@ int FxToTilePos(const int FxPos)
 	return std::floor(fx2f(FxPos) / 32);
 }
 
-bool GetEnvelopedQuads(const CQuad *pQuads, const int NumQuads, const int EnvId, const int GroupId, const int LayerId, int &QuadsCounter, EnvelopedQuad pEnvQuads[1024])
+bool GetEnvelopedQuads(const CQuad *pQuads, const int NumQuads, const int EnvId, const int GroupId, const int LayerId, int &QuadsCounter, CEnvelopedQuad pEnvQuads[1024])
 {
 	bool Found = false;
 	for(int i = 0; i < NumQuads; i++)
@@ -68,7 +69,7 @@ bool GetEnvelopedQuads(const CQuad *pQuads, const int NumQuads, const int EnvId,
 	return Found;
 }
 
-void PrintEnvelopedQuads(const EnvelopedQuad pEnvQuads[1024], const int EnvId, const int QuadsCounter)
+void PrintEnvelopedQuads(const CEnvelopedQuad pEnvQuads[1024], const int EnvId, const int QuadsCounter)
 {
 	if(!QuadsCounter)
 	{
@@ -89,7 +90,7 @@ bool FindEnv(const char aFilename[64], const int EnvId)
 
 	int LayersStart, LayersCount, QuadsCounter = 0;
 	InputMap.GetType(MAPITEMTYPE_LAYER, &LayersStart, &LayersCount);
-	EnvelopedQuad pEnvQuads[1024];
+	CEnvelopedQuad pEnvQuads[1024];
 
 	for(int i = 0; i < LayersCount; i++)
 	{

--- a/src/tools/map_replace_area.cpp
+++ b/src/tools/map_replace_area.cpp
@@ -9,8 +9,9 @@ void *g_apNewData[1024];
 void *g_apNewItem[1024];
 int g_aNewDataSize[1024];
 
-struct MapObject // quad pivot or tile layer
+class CMapObject // quad pivot or tile layer
 {
+public:
 	static constexpr float ms_aStandardScreen[2] = {1430 / 2.f, 1050 / 2.f};
 
 	float m_aLayerOffset[2];
@@ -32,22 +33,22 @@ const CMapItemGroup *GetLayerGroup(CDataFileReader &, int);
 void ReplaceAreaTiles(CDataFileReader[2], const float[][2][2], const CMapItemGroup *[2], CMapItemLayer *[2]);
 void RemoveDestinationTiles(CMapItemLayerTilemap *, CTile *, float[2][2]);
 void ReplaceDestinationTiles(CMapItemLayerTilemap *[2], CTile *[2], float[2][2][2]);
-bool AdaptVisibleAreas(const float[2][2][2], const MapObject[2], float[2][2][2]);
-bool AdaptReplaceableAreas(const float[2][2][2], const float[2][2][2], const MapObject[2], float[2][2][2]);
+bool AdaptVisibleAreas(const float[2][2][2], const CMapObject[2], float[2][2][2]);
+bool AdaptReplaceableAreas(const float[2][2][2], const float[2][2][2], const CMapObject[2], float[2][2][2]);
 
 void ReplaceAreaQuads(CDataFileReader[2], const float[][2][2], const CMapItemGroup *[2], CMapItemLayer *[2], int);
 bool RemoveDestinationQuads(const float[2][2], const CQuad *, int, const CMapItemGroup *, CQuad *, int &);
 bool InsertDestinationQuads(const float[2][2][2], const CQuad *, int, const CMapItemGroup *[2], CQuad *, int &);
-bool AdaptVisiblePoint(const float[2][2][2], const float[2][2], const MapObject[2], float[2]);
+bool AdaptVisiblePoint(const float[2][2][2], const float[2][2], const CMapObject[2], float[2]);
 
-MapObject CreateMapObject(const CMapItemGroup *, int, int, int, int);
-void SetExtendedArea(MapObject &);
-bool GetVisibleArea(const float[2][2], const MapObject &, float[2][2] = 0x0);
-bool GetReplaceableArea(const float[2][2], const MapObject &, float[2][2]);
+CMapObject CreateMapObject(const CMapItemGroup *, int, int, int, int);
+void SetExtendedArea(CMapObject &);
+bool GetVisibleArea(const float[2][2], const CMapObject &, float[2][2] = 0x0);
+bool GetReplaceableArea(const float[2][2], const CMapObject &, float[2][2]);
 
-void GetGameAreaDistance(const float[2][2][2], const MapObject[2], const float[2][2][2], float[2]);
-void GetGameAreaDistance(const float[2][2][2], const MapObject[2], const float[2][2], float[2]);
-void GetSignificantScreenPos(const MapObject &, const float[2][2], const float[2][2], float[2]);
+void GetGameAreaDistance(const float[2][2][2], const CMapObject[2], const float[2][2][2], float[2]);
+void GetGameAreaDistance(const float[2][2][2], const CMapObject[2], const float[2][2], float[2]);
+void GetSignificantScreenPos(const CMapObject &, const float[2][2], const float[2][2], float[2]);
 void ConvertToTiles(const float[2][2], int[2][2]);
 
 bool GetLineIntersection(const float[2], const float[2], float[2] = 0x0);
@@ -262,7 +263,7 @@ void ReplaceAreaTiles(CDataFileReader aInputMaps[2], const float aaaGameAreas[][
 	CMapItemLayerTilemap *apTilemap[2];
 	CTile *apTile[2];
 	float aaaVisibleAreas[2][2][2], aaaReplaceableAreas[2][2][2];
-	MapObject aObs[2];
+	CMapObject aObs[2];
 
 	for(int i = 0; i < 2; i++)
 	{
@@ -313,7 +314,7 @@ void ReplaceDestinationTiles(CMapItemLayerTilemap *apTilemap[2], CTile *apTile[2
 			apTile[1][x1 + (y1 * apTilemap[1]->m_Width)] = apTile[0][x0 + (y0 * apTilemap[0]->m_Width)];
 }
 
-bool AdaptVisibleAreas(const float aaaGameAreas[2][2][2], const MapObject aObs[2], float aaaVisibleAreas[2][2][2])
+bool AdaptVisibleAreas(const float aaaGameAreas[2][2][2], const CMapObject aObs[2], float aaaVisibleAreas[2][2][2])
 {
 	float aDistance[2];
 	GetGameAreaDistance(aaaGameAreas, aObs, aaaVisibleAreas, aDistance);
@@ -336,7 +337,7 @@ bool AdaptVisibleAreas(const float aaaGameAreas[2][2][2], const MapObject aObs[2
 	return true;
 }
 
-bool AdaptReplaceableAreas(const float aaaGameAreas[2][2][2], const float aaaVisibleAreas[2][2][2], const MapObject aObs[2], float aaaReplaceableAreas[2][2][2])
+bool AdaptReplaceableAreas(const float aaaGameAreas[2][2][2], const float aaaVisibleAreas[2][2][2], const CMapObject aObs[2], float aaaReplaceableAreas[2][2][2])
 {
 	float aDistance[2], aScreenPos[2];
 	GetGameAreaDistance(aaaGameAreas, aObs, aaaVisibleAreas, aDistance);
@@ -398,7 +399,7 @@ bool RemoveDestinationQuads(const float aaGameArea[2][2], const CQuad *pQuads, c
 
 	for(int i = 0; i < NumQuads; i++)
 	{
-		MapObject Ob = CreateMapObject(pLayerGroup, fx2f(pQuads[i].m_aPoints[4].x), fx2f(pQuads[i].m_aPoints[4].y), 0, 0);
+		CMapObject Ob = CreateMapObject(pLayerGroup, fx2f(pQuads[i].m_aPoints[4].x), fx2f(pQuads[i].m_aPoints[4].y), 0, 0);
 
 		if(GetVisibleArea(aaGameArea, Ob))
 		{
@@ -419,7 +420,7 @@ bool InsertDestinationQuads(const float aaaGameAreas[2][2][2], const CQuad *pQua
 
 	for(int i = 0; i < NumQuads; i++)
 	{
-		MapObject aObs[2];
+		CMapObject aObs[2];
 		aObs[0] = CreateMapObject(apLayerGroups[0], fx2f(pQuads[i].m_aPoints[4].x), fx2f(pQuads[i].m_aPoints[4].y), 0, 0);
 		float aaVisibleArea[2][2];
 
@@ -446,7 +447,7 @@ bool InsertDestinationQuads(const float aaaGameAreas[2][2][2], const CQuad *pQua
 	return DataChanged;
 }
 
-bool AdaptVisiblePoint(const float aaaGameAreas[2][2][2], const float aaVisibleArea[2][2], const MapObject aObs[2], float aPos[2])
+bool AdaptVisiblePoint(const float aaaGameAreas[2][2][2], const float aaVisibleArea[2][2], const CMapObject aObs[2], float aPos[2])
 {
 	float aDistance[2], aScreenPos[2];
 	GetGameAreaDistance(aaaGameAreas, aObs, aaVisibleArea, aDistance);
@@ -455,7 +456,7 @@ bool AdaptVisiblePoint(const float aaaGameAreas[2][2][2], const float aaVisibleA
 	for(int i = 0; i < 2; i++)
 		aPos[i] = aaVisibleArea[i][0] + aDistance[i] + aObs[1].m_aLayerOffset[i] - (aScreenPos[i] + aDistance[i]) * aObs[1].m_aSpeed[i];
 
-	MapObject FinalOb = aObs[1];
+	CMapObject FinalOb = aObs[1];
 	for(int i = 0; i < 2; i++)
 		FinalOb.m_aaBaseArea[i][0] = FinalOb.m_aaBaseArea[i][1] += aPos[i];
 	SetExtendedArea(FinalOb);
@@ -463,9 +464,9 @@ bool AdaptVisiblePoint(const float aaaGameAreas[2][2][2], const float aaVisibleA
 	return GetVisibleArea(aaaGameAreas[1], FinalOb);
 }
 
-MapObject CreateMapObject(const CMapItemGroup *pLayerGroup, const int PosX, const int PosY, const int Width, const int Height)
+CMapObject CreateMapObject(const CMapItemGroup *pLayerGroup, const int PosX, const int PosY, const int Width, const int Height)
 {
-	MapObject Ob;
+	CMapObject Ob;
 
 	Ob.m_aaBaseArea[0][0] = PosX - pLayerGroup->m_OffsetX;
 	Ob.m_aaBaseArea[1][0] = PosY - pLayerGroup->m_OffsetY;
@@ -483,8 +484,8 @@ MapObject CreateMapObject(const CMapItemGroup *pLayerGroup, const int PosX, cons
 
 	for(int i = 0; i < 2; i++)
 	{
-		Ob.m_aaScreenOffset[i][0] = -MapObject::ms_aStandardScreen[i];
-		Ob.m_aaScreenOffset[i][1] = MapObject::ms_aStandardScreen[i];
+		Ob.m_aaScreenOffset[i][0] = -CMapObject::ms_aStandardScreen[i];
+		Ob.m_aaScreenOffset[i][1] = CMapObject::ms_aStandardScreen[i];
 		if(Ob.m_aSpeed[i] < 0)
 			std::swap(Ob.m_aaScreenOffset[i][0], Ob.m_aaScreenOffset[i][1]);
 	}
@@ -493,7 +494,7 @@ MapObject CreateMapObject(const CMapItemGroup *pLayerGroup, const int PosX, cons
 	return Ob;
 }
 
-void SetExtendedArea(MapObject &Ob)
+void SetExtendedArea(CMapObject &Ob)
 {
 	SetInexistent((float *)Ob.m_aaExtendedArea, 4);
 
@@ -515,7 +516,7 @@ void SetExtendedArea(MapObject &Ob)
 	}
 }
 
-bool GetVisibleArea(const float aaGameArea[2][2], const MapObject &Ob, float aaVisibleArea[2][2])
+bool GetVisibleArea(const float aaGameArea[2][2], const CMapObject &Ob, float aaVisibleArea[2][2])
 {
 	if(IsInexistent((float *)Ob.m_aaExtendedArea, 4))
 		return false;
@@ -547,7 +548,7 @@ bool GetVisibleArea(const float aaGameArea[2][2], const MapObject &Ob, float aaV
 	return true;
 }
 
-bool GetReplaceableArea(const float aaVisibleArea[2][2], const MapObject &Ob, float aaReplaceableArea[2][2])
+bool GetReplaceableArea(const float aaVisibleArea[2][2], const CMapObject &Ob, float aaReplaceableArea[2][2])
 {
 	SetInexistent((float *)aaReplaceableArea, 4);
 	if(IsInexistent((float *)aaVisibleArea, 4))
@@ -580,7 +581,7 @@ bool GetReplaceableArea(const float aaVisibleArea[2][2], const MapObject &Ob, fl
 	return true;
 }
 
-void GetGameAreaDistance(const float aaaGameAreas[2][2][2], const MapObject aObs[2], const float aaaVisibleAreas[2][2][2], float aDistance[2])
+void GetGameAreaDistance(const float aaaGameAreas[2][2][2], const CMapObject aObs[2], const float aaaVisibleAreas[2][2][2], float aDistance[2])
 {
 	for(int i = 0; i < 2; i++)
 	{
@@ -595,7 +596,7 @@ void GetGameAreaDistance(const float aaaGameAreas[2][2][2], const MapObject aObs
 	}
 }
 
-void GetGameAreaDistance(const float aaaGameAreas[2][2][2], const MapObject aObs[2], const float aaVisibleArea[2][2], float aDistance[2])
+void GetGameAreaDistance(const float aaaGameAreas[2][2][2], const CMapObject aObs[2], const float aaVisibleArea[2][2], float aDistance[2])
 {
 	float aaaVisibleAreas[2][2][2];
 	mem_copy(aaaVisibleAreas[0], aaVisibleArea[0], sizeof(float[2][2]));
@@ -603,7 +604,7 @@ void GetGameAreaDistance(const float aaaGameAreas[2][2][2], const MapObject aObs
 	GetGameAreaDistance(aaaGameAreas, aObs, aaaVisibleAreas, aDistance);
 }
 
-void GetSignificantScreenPos(const MapObject &Ob, const float aaVisibleArea[2][2], const float aaReplaceableArea[2][2], float aScreen[2])
+void GetSignificantScreenPos(const CMapObject &Ob, const float aaVisibleArea[2][2], const float aaReplaceableArea[2][2], float aScreen[2])
 {
 	for(int i = 0; i < 2; i++)
 	{


### PR DESCRIPTION


## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
