### PR TITLE
Add "center pivot" for quads

### DIFF
--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -2154,7 +2154,7 @@ void CEditor::DoQuad(int LayerIndex, const std::shared_ptr<CLayerQuads> &pLayer,
 					m_SelectedQuadIndex = FindSelectedQuadIndex(Index);
 
 					static SPopupMenuId s_PopupQuadId;
-					Ui()->DoPopupMenu(&s_PopupQuadId, Ui()->MouseX(), Ui()->MouseY(), 120, 198, this, PopupQuad);
+					Ui()->DoPopupMenu(&s_PopupQuadId, Ui()->MouseX(), Ui()->MouseY(), 120, 222, this, PopupQuad);
 					Ui()->DisableMouseLock();
 				}
 				s_Operation = OP_NONE;

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -869,6 +869,37 @@ CUi::EPopupMenuFunctionResult CEditor::PopupQuad(void *pContext, CUIRect View, b
 		}
 	}
 
+	// center pivot button
+	View.HSplitBottom(6.0f, &View, nullptr);
+	View.HSplitBottom(12.0f, &View, &Button);
+	static int s_CenterButton = 0;
+	if(pEditor->DoButton_Editor(&s_CenterButton, "Center pivot", 0, &Button, 0, "Centers the pivot of the current quad"))
+	{
+		pEditor->m_QuadTracker.BeginQuadTrack(pLayer, pEditor->m_vSelectedQuads);
+		int Top = pCurrentQuad->m_aPoints[0].y;
+		int Left = pCurrentQuad->m_aPoints[0].x;
+		int Bottom = pCurrentQuad->m_aPoints[0].y;
+		int Right = pCurrentQuad->m_aPoints[0].x;
+
+		for(int k = 1; k < 4; k++)
+		{
+			if(pCurrentQuad->m_aPoints[k].y < Top)
+				Top = pCurrentQuad->m_aPoints[k].y;
+			if(pCurrentQuad->m_aPoints[k].x < Left)
+				Left = pCurrentQuad->m_aPoints[k].x;
+			if(pCurrentQuad->m_aPoints[k].y > Bottom)
+				Bottom = pCurrentQuad->m_aPoints[k].y;
+			if(pCurrentQuad->m_aPoints[k].x > Right)
+				Right = pCurrentQuad->m_aPoints[k].x;
+		}
+
+		pCurrentQuad->m_aPoints[4].x = Left + (Right - Left) / 2;
+		pCurrentQuad->m_aPoints[4].y = Top + (Bottom - Top) / 2;
+		pEditor->m_QuadTracker.EndQuadTrack();
+		pEditor->m_Map.OnModify();
+		return CUi::POPUP_CLOSE_CURRENT;
+	}
+
 	// align button
 	View.HSplitBottom(6.0f, &View, nullptr);
 	View.HSplitBottom(12.0f, &View, &Button);


### PR DESCRIPTION
Add quad popup button for centering the pivot of a quad. Ported from vanilla, https://github.com/teeworlds/teeworlds/pull/970/commits/082f8767862e0811bd953c3c6ad8dc07cab05eff.

https://github.com/user-attachments/assets/dc46b2ff-91e7-4f99-897f-f8e3ae74b664



## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
