### PR TITLE
Fix ``hot_reload`` losing spectator state

### DIFF
--- a/src/engine/server.h
+++ b/src/engine/server.h
@@ -321,7 +321,7 @@ public:
 	//
 	// Returns whether the game should be supplied with the data when the
 	// client connects for the next map.
-	virtual bool OnClientDataPersist(int ClientId, void *pData) = 0;
+	virtual bool OnClientDataPersist(int ClientId, void *pData, bool HotReload) = 0;
 
 	// Called when a client connects.
 	//

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -2827,7 +2827,7 @@ int CServer::Run()
 					{
 						if(m_aClients[i].m_State == CClient::STATE_INGAME)
 						{
-							m_aClients[i].m_HasPersistentData = GameServer()->OnClientDataPersist(i, m_aClients[i].m_pPersistentData);
+							m_aClients[i].m_HasPersistentData = GameServer()->OnClientDataPersist(i, m_aClients[i].m_pPersistentData, SameMapReload);
 						}
 					}
 

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -150,10 +150,18 @@ class CGameContext : public IGameServer
 		CUuid m_PrevGameUuid;
 	};
 
+	struct CHotReloadPlayer
+	{
+		int m_Team;
+	};
+
 	struct CPersistentClientData
 	{
 		bool m_IsSpectator;
 		bool m_IsAfk;
+
+		bool m_HotReload;
+		CHotReloadPlayer m_HotReloadPlayer;
 	};
 
 public:
@@ -315,7 +323,7 @@ public:
 	void OnKillNetMessage(const CNetMsg_Cl_Kill *pMsg, int ClientId);
 	void OnStartInfoNetMessage(const CNetMsg_Cl_StartInfo *pMsg, int ClientId);
 
-	bool OnClientDataPersist(int ClientId, void *pData) override;
+	bool OnClientDataPersist(int ClientId, void *pData, bool HotReload) override;
 	void OnClientConnected(int ClientId, void *pData) override;
 	void OnClientEnter(int ClientId) override;
 	void OnClientDrop(int ClientId, const char *pReason) override;


### PR DESCRIPTION
This fixes the bug that moved spectators in game on ``hot_reload``

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
