### PR TITLE
Use OpenGL ES graphics backend per default on Android

### DIFF
--- a/scripts/android/files/java/org/ddnet/client/NativeMain.java
+++ b/scripts/android/files/java/org/ddnet/client/NativeMain.java
@@ -29,8 +29,8 @@ public class NativeMain extends SDLActivity {
 			if(gfxBackend != null) {
 				if(gfxBackend.equals("Vulkan")) {
 					launchArguments = new String[] {"gfx_backend Vulkan"};
-				} else if(gfxBackend.equals("OpenGL")) {
-					launchArguments = new String[] {"gfx_backend OpenGL"};
+				} else if(gfxBackend.equals("GLES")) {
+					launchArguments = new String[] {"gfx_backend GLES"};
 				}
 			}
 		}

--- a/scripts/android/files/res/values/strings.xml
+++ b/scripts/android/files/res/values/strings.xml
@@ -2,5 +2,5 @@
 <resources>
 	<string name="app_name">DDNet</string>
 	<string name="shortcut_play_vulkan_short">Play (Vulkan)</string>
-	<string name="shortcut_play_opengl_short">Play (OpenGL)</string>
+	<string name="shortcut_play_gles_short">Play (OpenGL ES)</string>
 </resources>

--- a/scripts/android/files/res/xml/shortcuts.xml
+++ b/scripts/android/files/res/xml/shortcuts.xml
@@ -14,17 +14,17 @@
 		</intent>
 	</shortcut>
 	<shortcut
-		android:shortcutId="play-opengl"
+		android:shortcutId="play-gles"
 		android:enabled="true"
 		android:icon="@mipmap/ic_launcher"
-		android:shortcutShortLabel="@string/shortcut_play_opengl_short">
+		android:shortcutShortLabel="@string/shortcut_play_gles_short">
 		<intent
 			android:action="android.intent.action.VIEW"
 			android:targetPackage="org.ddnet.client"
 			android:targetClass="org.ddnet.client.NativeMain">
 			<extra
 				android:name="gfx-backend"
-				android:value="OpenGL" />
+				android:value="GLES" />
 		</intent>
 	</shortcut>
 </shortcuts>

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -717,7 +717,9 @@ MACRO_CONFIG_STR(Gfx3DTextureAnalysisRenderer, gfx_3d_texture_analysis_renderer,
 MACRO_CONFIG_STR(Gfx3DTextureAnalysisVersion, gfx_3d_texture_analysis_version, 128, "", CFGFLAG_SAVE | CFGFLAG_CLIENT, "The version on which the analysis was performed")
 
 MACRO_CONFIG_STR(GfxGpuName, gfx_gpu_name, 256, "auto", CFGFLAG_SAVE | CFGFLAG_CLIENT, "The GPU's name, which will be selected by the backend. (if supported by the backend)")
-#if !defined(CONF_ARCH_IA32) && !defined(CONF_PLATFORM_MACOS)
+#if defined(CONF_PLATFORM_ANDROID)
+MACRO_CONFIG_STR(GfxBackend, gfx_backend, 256, "GLES", CFGFLAG_SAVE | CFGFLAG_CLIENT, "The backend to use (e.g. GLES or Vulkan)")
+#elif !defined(CONF_ARCH_IA32) && !defined(CONF_PLATFORM_MACOS)
 MACRO_CONFIG_STR(GfxBackend, gfx_backend, 256, "Vulkan", CFGFLAG_SAVE | CFGFLAG_CLIENT, "The backend to use (e.g. OpenGL or Vulkan)")
 #else
 MACRO_CONFIG_STR(GfxBackend, gfx_backend, 256, "OpenGL", CFGFLAG_SAVE | CFGFLAG_CLIENT, "The backend to use (e.g. OpenGL or Vulkan)")


### PR DESCRIPTION
As Vulkan crashes immediately on launch on a lot of Android devices (for around 15% of users that commented on the Android beta on Discord).

The previous usage of the OpenGL backend in the shortcuts was incorrect, as this backend is not strictly available on Android and the GLES backend should be used instead, as this is also what is displayed in the graphics settings.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
