### PR TITLE
Don't reset zoom on team switch

### DIFF
--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -2513,14 +2513,11 @@ void CGameClient::CClientData::CSixup::Reset()
 	}
 }
 
-void CGameClient::SendSwitchTeam(int Team)
+void CGameClient::SendSwitchTeam(int Team) const
 {
 	CNetMsg_Cl_SetTeam Msg;
 	Msg.m_Team = Team;
 	Client()->SendPackMsgActive(&Msg, MSGFLAG_VITAL);
-
-	if(Team != TEAM_SPECTATORS)
-		m_Camera.OnReset();
 }
 
 void CGameClient::SendStartInfo7(bool Dummy) const

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -554,7 +554,7 @@ public:
 
 	// actions
 	// TODO: move these
-	void SendSwitchTeam(int Team);
+	void SendSwitchTeam(int Team) const;
 	void SendStartInfo7(bool Dummy) const;
 	void SendSkinChange7(bool Dummy);
 	// Returns true if the requested skin change got applied by the server


### PR DESCRIPTION
The code isn't needed any more as the zoom is always reset on render on mods that don't allow zoom.

https://github.com/user-attachments/assets/9004790b-ddb3-45eb-87c8-78cfa48c3f1b

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
