### PR TITLE
Cleanup sql worker request/result naming convention

### DIFF
--- a/src/game/server/score.cpp
+++ b/src/game/server/score.cpp
@@ -112,7 +112,7 @@ void CScore::LoadBestTime()
 	auto LoadBestTimeResult = std::make_shared<CScoreLoadBestTimeResult>();
 	m_pGameServer->m_pController->m_pLoadBestTimeResult = LoadBestTimeResult;
 
-	auto Tmp = std::make_unique<CSqlLoadBestTimeData>(LoadBestTimeResult);
+	auto Tmp = std::make_unique<CSqlLoadBestTimeRequest>(LoadBestTimeResult);
 	str_copy(Tmp->m_aMap, Server()->GetMapName(), sizeof(Tmp->m_aMap));
 	m_pPool->Execute(CScoreWorker::LoadBestTime, std::move(Tmp), "load best time");
 }
@@ -308,7 +308,7 @@ void CScore::SaveTeam(int ClientId, const char *pCode, const char *pServer)
 		return;
 	pController->Teams().SetSaving(Team, SaveResult);
 
-	auto Tmp = std::make_unique<CSqlTeamSave>(SaveResult);
+	auto Tmp = std::make_unique<CSqlTeamSaveData>(SaveResult);
 	str_copy(Tmp->m_aCode, pCode, sizeof(Tmp->m_aCode));
 	str_copy(Tmp->m_aMap, Server()->GetMapName(), sizeof(Tmp->m_aMap));
 	str_copy(Tmp->m_aServer, pServer, sizeof(Tmp->m_aServer));
@@ -370,7 +370,7 @@ void CScore::LoadTeam(const char *pCode, int ClientId)
 	auto SaveResult = std::make_shared<CScoreSaveResult>(ClientId);
 	SaveResult->m_Status = CScoreSaveResult::LOAD_FAILED;
 	pController->Teams().SetSaving(Team, SaveResult);
-	auto Tmp = std::make_unique<CSqlTeamLoad>(SaveResult);
+	auto Tmp = std::make_unique<CSqlTeamLoadRequest>(SaveResult);
 	str_copy(Tmp->m_aCode, pCode, sizeof(Tmp->m_aCode));
 	str_copy(Tmp->m_aMap, Server()->GetMapName(), sizeof(Tmp->m_aMap));
 	Tmp->m_ClientId = ClientId;

--- a/src/game/server/scoreworker.cpp
+++ b/src/game/server/scoreworker.cpp
@@ -101,7 +101,7 @@ bool CTeamrank::SamePlayers(const std::vector<std::string> *pvSortedNames)
 
 bool CScoreWorker::LoadBestTime(IDbConnection *pSqlServer, const ISqlData *pGameData, char *pError, int ErrorSize)
 {
-	const auto *pData = dynamic_cast<const CSqlLoadBestTimeData *>(pGameData);
+	const auto *pData = dynamic_cast<const CSqlLoadBestTimeRequest *>(pGameData);
 	auto *pResult = dynamic_cast<CScoreLoadBestTimeResult *>(pGameData->m_pResult.get());
 
 	char aBuf[512];
@@ -1568,7 +1568,7 @@ bool CScoreWorker::RandomUnfinishedMap(IDbConnection *pSqlServer, const ISqlData
 
 bool CScoreWorker::SaveTeam(IDbConnection *pSqlServer, const ISqlData *pGameData, Write w, char *pError, int ErrorSize)
 {
-	const auto *pData = dynamic_cast<const CSqlTeamSave *>(pGameData);
+	const auto *pData = dynamic_cast<const CSqlTeamSaveData *>(pGameData);
 	auto *pResult = dynamic_cast<CScoreSaveResult *>(pGameData->m_pResult.get());
 
 	if(w == Write::NORMAL_SUCCEEDED)
@@ -1715,7 +1715,7 @@ bool CScoreWorker::LoadTeam(IDbConnection *pSqlServer, const ISqlData *pGameData
 {
 	if(w == Write::NORMAL_SUCCEEDED || w == Write::BACKUP_FIRST)
 		return false;
-	const auto *pData = dynamic_cast<const CSqlTeamLoad *>(pGameData);
+	const auto *pData = dynamic_cast<const CSqlTeamLoadRequest *>(pGameData);
 	auto *pResult = dynamic_cast<CScoreSaveResult *>(pGameData->m_pResult.get());
 	pResult->m_Status = CScoreSaveResult::LOAD_FAILED;
 

--- a/src/game/server/scoreworker.h
+++ b/src/game/server/scoreworker.h
@@ -72,9 +72,9 @@ struct CScoreLoadBestTimeResult : ISqlResult
 	float m_CurrentRecord;
 };
 
-struct CSqlLoadBestTimeData : ISqlData
+struct CSqlLoadBestTimeRequest : ISqlData
 {
-	CSqlLoadBestTimeData(std::shared_ptr<CScoreLoadBestTimeResult> pResult) :
+	CSqlLoadBestTimeRequest(std::shared_ptr<CScoreLoadBestTimeResult> pResult) :
 		ISqlData(std::move(pResult))
 	{
 	}
@@ -188,13 +188,13 @@ struct CSqlTeamScoreData : ISqlData
 	CUuid m_TeamrankUuid;
 };
 
-struct CSqlTeamSave : ISqlData
+struct CSqlTeamSaveData : ISqlData
 {
-	CSqlTeamSave(std::shared_ptr<CScoreSaveResult> pResult) :
+	CSqlTeamSaveData(std::shared_ptr<CScoreSaveResult> pResult) :
 		ISqlData(std::move(pResult))
 	{
 	}
-	virtual ~CSqlTeamSave(){};
+	virtual ~CSqlTeamSaveData(){};
 
 	char m_aClientName[MAX_NAME_LENGTH];
 	char m_aMap[MAX_MAP_LENGTH];
@@ -203,13 +203,13 @@ struct CSqlTeamSave : ISqlData
 	char m_aServer[5];
 };
 
-struct CSqlTeamLoad : ISqlData
+struct CSqlTeamLoadRequest : ISqlData
 {
-	CSqlTeamLoad(std::shared_ptr<CScoreSaveResult> pResult) :
+	CSqlTeamLoadRequest(std::shared_ptr<CScoreSaveResult> pResult) :
 		ISqlData(std::move(pResult))
 	{
 	}
-	virtual ~CSqlTeamLoad(){};
+	virtual ~CSqlTeamLoadRequest(){};
 
 	char m_aCode[128];
 	char m_aMap[MAX_MAP_LENGTH];

--- a/src/test/score.cpp
+++ b/src/test/score.cpp
@@ -70,9 +70,9 @@ struct Score : public testing::TestWithParam<IDbConnection *>
 
 	void LoadBestTime()
 	{
-		CSqlLoadBestTimeData loadBestTimeData(std::make_shared<CScoreLoadBestTimeResult>());
-		str_copy(loadBestTimeData.m_aMap, "Kobra 3", sizeof(loadBestTimeData.m_aMap));
-		ASSERT_FALSE(CScoreWorker::LoadBestTime(m_pConn, &loadBestTimeData, m_aError, sizeof(m_aError))) << m_aError;
+		CSqlLoadBestTimeRequest loadBestTimeReq(std::make_shared<CScoreLoadBestTimeResult>());
+		str_copy(loadBestTimeReq.m_aMap, "Kobra 3", sizeof(loadBestTimeReq.m_aMap));
+		ASSERT_FALSE(CScoreWorker::LoadBestTime(m_pConn, &loadBestTimeReq, m_aError, sizeof(m_aError))) << m_aError;
 	}
 
 	void InsertMap()


### PR DESCRIPTION
There are two interfaces for score worker data:

There is ``ISqlResult`` and every class inheriting from it should have the suffix ``Result``

Then there is ``ISqlData`` and every class inheriting from it should have the suffix ``Data`` if it is data that should be written in an INSERT statement. Or ``Request`` if it is used to perform a read operation and will be used in a SELECT statament.

The convention was mostly established alreay. In this commit the last three classes that broke this convention got fixed.
