### PR TITLE
Add actually setting `m_LastRescue` variable

### DIFF
--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -2376,6 +2376,7 @@ void CCharacter::Rescue()
 			return;
 		}
 
+		m_LastRescue = Server()->Tick();
 		float StartTime = m_StartTime;
 		m_RescueTee[GetPlayer()->m_RescueMode].Load(this, Team());
 		// Don't load these from saved tee:


### PR DESCRIPTION
Currently `sv_rescue_delay` doesnt seem to have the intended effect. The description states that it should set the "Number of seconds between two rescues". However, it only restricts rescue x seconds after spawning.

This seems to be the case because #2242 removed the line for updating `m_LastRescue`, which i believe was not intended.

This PR reintroduces this line. I tested the change ingame. Now the server option does what you'd expect: Restricting rescue usage for x seconds after each rescue.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
