### PR TITLE
FIx team0mode team state

### DIFF
--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -1176,7 +1176,6 @@ void CGameTeams::OnCharacterDeath(int ClientId, int Weapon)
 
 			if(!AnyStarted)
 			{
-				ResetSwitchers(Team);
 				ChangeTeamState(Team, CGameTeams::TEAMSTATE_OPEN);
 			}
 		}
@@ -1192,7 +1191,11 @@ void CGameTeams::SetTeamLock(int Team, bool Lock)
 void CGameTeams::SetTeamFlock(int Team, bool Mode)
 {
 	if(Team > TEAM_FLOCK && Team < TEAM_SUPER)
+	{
 		m_aTeamFlock[Team] = Mode;
+		if(!Mode)
+			ResetSwitchers(Team);
+	}
 }
 
 void CGameTeams::ResetInvited(int Team)

--- a/src/game/server/teams.cpp
+++ b/src/game/server/teams.cpp
@@ -1176,6 +1176,7 @@ void CGameTeams::OnCharacterDeath(int ClientId, int Weapon)
 
 			if(!AnyStarted)
 			{
+				ResetSwitchers(Team);
 				ChangeTeamState(Team, CGameTeams::TEAMSTATE_OPEN);
 			}
 		}


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->
Fixed a bug where players in a team could not disable team0mode if someone touched the start and died (no one in the team had a race started)

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
