### PR TITLE
Fix tabs being used in ascii art browser comment

### DIFF
--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1773,13 +1773,13 @@ void CMenus::RenderServerbrowser(CUIRect MainView)
 
 	/*
 		+---------------------------+ +---communities---+
-		|							| |					|
-		|							| +------tabs-------+
-		|	server list				| |					|
-		|							| |		tool		|
-		|							| |		box			|
-		+---------------------------+ |					|
-			status box				  +-----------------+
+		|                           | |                 |
+		|                           | +------tabs-------+
+		|       server list         | |                 |
+		|                           | |      tool       |
+		|                           | |      box        |
+		+---------------------------+ |                 |
+		        status box            +-----------------+
 	*/
 
 	CUIRect ServerList, StatusBox, ToolBox, TabBar;


### PR DESCRIPTION
Spaces are more portable if alignment matters
