### PR TITLE
Add test map locally

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2971,6 +2971,7 @@ if(GTEST_FOUND OR DOWNLOAD_GTEST)
     secure_random.cpp
     serverbrowser.cpp
     serverinfo.cpp
+    shell_execute.cpp
     snapshot.cpp
     str.cpp
     strip_path_and_extension.cpp

--- a/src/base/system.h
+++ b/src/base/system.h
@@ -2636,6 +2636,20 @@ enum class EShellExecuteWindowState
 	BACKGROUND,
 };
 
+#if defined(CONF_FAMILY_WINDOWS)
+/**
+ * Converts an array of arguments into a wide string with proper escaping for Windows command-line usage.
+ *
+ * @ingroup Shell
+ *
+ * @param arguments Array of arguments.
+ * @param num_arguments The number of arguments.
+ *
+ * @return Wide string of arguments with escaped quotes.
+ */
+std::wstring windows_args_to_wide(const char **arguments, const size_t num_arguments);
+#endif
+
 /**
  * Executes a given file.
  *
@@ -2643,10 +2657,12 @@ enum class EShellExecuteWindowState
  *
  * @param file The file to execute.
  * @param window_state The window state how the process window should be shown.
+ * @param arguments Optional array of arguments to pass to the process.
+ * @param num_arguments The number of arguments.
  *
  * @return Handle of the new process, or @link INVALID_PROCESS @endlink on error.
  */
-PROCESS shell_execute(const char *file, EShellExecuteWindowState window_state);
+PROCESS shell_execute(const char *file, EShellExecuteWindowState window_state, const char **arguments = nullptr, const size_t num_arguments = 0);
 
 /**
  * Sends kill signal to a process.

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -669,7 +669,7 @@ public:
 	bool IsActive() const { return m_MenuActive; }
 	void SetActive(bool Active);
 
-	void RunServer();
+	void RunServer(const char **ppArguments = nullptr, const size_t NumArguments = 0);
 	void KillServer();
 	bool IsServerRunning() const;
 

--- a/src/game/client/components/menus_start.cpp
+++ b/src/game/client/components/menus_start.cpp
@@ -270,10 +270,10 @@ void CMenus::RenderStartMenu(CUIRect MainView)
 	}
 }
 
-void CMenus::RunServer()
+void CMenus::RunServer(const char **ppArguments, const size_t NumArguments)
 {
 #if defined(CONF_PLATFORM_ANDROID)
-	if(StartAndroidServer({}, 0))
+	if(StartAndroidServer(ppArguments, NumArguments))
 	{
 		m_ForceRefreshLanPage = true;
 	}
@@ -287,7 +287,7 @@ void CMenus::RunServer()
 	// No / in binary path means to search in $PATH, so it is expected that the file can't be opened. Just try executing anyway.
 	if(str_find(aBuf, "/") == 0 || fs_is_file(aBuf))
 	{
-		m_ServerProcess.m_Process = shell_execute(aBuf, EShellExecuteWindowState::BACKGROUND);
+		m_ServerProcess.m_Process = shell_execute(aBuf, EShellExecuteWindowState::BACKGROUND, ppArguments, NumArguments);
 		m_ForceRefreshLanPage = true;
 	}
 	else

--- a/src/game/editor/editor.cpp
+++ b/src/game/editor/editor.cpp
@@ -7837,7 +7837,7 @@ void CEditor::RenderMenubar(CUIRect MenuBar)
 	if(DoButton_Ex(&s_FileButton, "File", 0, &FileButton, 0, nullptr, IGraphics::CORNER_T, EditorFontSizes::MENU, TEXTALIGN_ML))
 	{
 		static SPopupMenuId s_PopupMenuFileId;
-		Ui()->DoPopupMenu(&s_PopupMenuFileId, FileButton.x, FileButton.y + FileButton.h - 1.0f, 120.0f, 174.0f, this, PopupMenuFile, PopupProperties);
+		Ui()->DoPopupMenu(&s_PopupMenuFileId, FileButton.x, FileButton.y + FileButton.h - 1.0f, 120.0f, 188.0f, this, PopupMenuFile, PopupProperties);
 	}
 
 	MenuBar.VSplitLeft(5.0f, nullptr, &MenuBar);

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -351,6 +351,7 @@ public:
 	void LayerSelectImage();
 	bool IsNonGameTileLayerSelected() const;
 	void MapDetails();
+	void TestMapLocally();
 #define REGISTER_QUICK_ACTION(name, text, callback, disabled, active, button_color, description) CQuickAction m_QuickAction##name;
 #include <game/editor/quick_actions.h>
 #undef REGISTER_QUICK_ACTION
@@ -612,6 +613,8 @@ public:
 		POPEVENT_PIXELART_TOO_MANY_COLORS,
 		POPEVENT_REMOVE_USED_IMAGE,
 		POPEVENT_REMOVE_USED_SOUND,
+		POPEVENT_RESTART_SERVER,
+		POPEVENT_RESTARTING_SERVER,
 	};
 
 	int m_PopupEventType;

--- a/src/game/editor/popups.cpp
+++ b/src/game/editor/popups.cpp
@@ -12,6 +12,7 @@
 #include <engine/textrender.h>
 #include <limits>
 
+#include <game/client/gameclient.h>
 #include <game/client/ui_scrollregion.h>
 #include <game/editor/mapitems/image.h>
 #include <game/editor/mapitems/sound.h>
@@ -32,6 +33,7 @@ CUi::EPopupMenuFunctionResult CEditor::PopupMenuFile(void *pContext, CUIRect Vie
 	static int s_OpenButton = 0;
 	static int s_OpenCurrentMapButton = 0;
 	static int s_AppendButton = 0;
+	static int s_TestMapLocallyButton = 0;
 	static int s_ExitButton = 0;
 
 	CUIRect Slot;
@@ -117,6 +119,14 @@ CUi::EPopupMenuFunctionResult CEditor::PopupMenuFile(void *pContext, CUIRect Vie
 	if(pEditor->DoButton_MenuItem(&pEditor->m_QuickActionMapDetails, pEditor->m_QuickActionMapDetails.Label(), 0, &Slot, 0, pEditor->m_QuickActionMapDetails.Description()))
 	{
 		pEditor->m_QuickActionMapDetails.Call();
+		return CUi::POPUP_CLOSE_CURRENT;
+	}
+
+	View.HSplitTop(2.0f, nullptr, &View);
+	View.HSplitTop(12.0f, &Slot, &View);
+	if(pEditor->DoButton_MenuItem(&s_TestMapLocallyButton, pEditor->m_QuickActionTestMapLocally.Label(), 0, &Slot, 0, pEditor->m_QuickActionTestMapLocally.Description()))
+	{
+		pEditor->m_QuickActionTestMapLocally.Call();
 		return CUi::POPUP_CLOSE_CURRENT;
 	}
 
@@ -2113,6 +2123,23 @@ CUi::EPopupMenuFunctionResult CEditor::PopupEvent(void *pContext, CUIRect View, 
 		pTitle = "Remove sound";
 		pMessage = "This sound is used in the map. Removing it will reset all layers that use this sound to their default.\n\nRemove anyway?";
 	}
+	else if(pEditor->m_PopupEventType == POPEVENT_RESTART_SERVER)
+	{
+		pTitle = "Restart server";
+		pMessage = "You have a local server running, but you are not authorized or connected.\n\nDo you want to restart the server and reconnect?";
+	}
+	else if(pEditor->m_PopupEventType == POPEVENT_RESTARTING_SERVER)
+	{
+		pTitle = "Restarting server";
+		pMessage = "Local server is restarting. Please wait…";
+
+		const CGameClient *pGameClient = (CGameClient *)pEditor->Kernel()->RequestInterface<IGameClient>();
+		if(!pGameClient->m_Menus.IsServerRunning())
+		{
+			pEditor->TestMapLocally();
+			return CUi::POPUP_CLOSE_CURRENT;
+		}
+	}
 	else
 	{
 		dbg_assert(false, "m_PopupEventType invalid");
@@ -2157,6 +2184,9 @@ CUi::EPopupMenuFunctionResult CEditor::PopupEvent(void *pContext, CUIRect View, 
 			return CUi::POPUP_CLOSE_CURRENT;
 		}
 	}
+
+	if(pEditor->m_PopupEventType == POPEVENT_RESTARTING_SERVER)
+		return CUi::POPUP_KEEP_OPEN;
 
 	ButtonBar.VSplitRight(110.0f, &ButtonBar, &Button);
 	static int s_ConfirmButton = 0;
@@ -2228,6 +2258,13 @@ CUi::EPopupMenuFunctionResult CEditor::PopupEvent(void *pContext, CUIRect View, 
 		{
 			pEditor->m_Map.m_vpSounds.erase(pEditor->m_Map.m_vpSounds.begin() + pEditor->m_SelectedSound);
 			pEditor->m_Map.ModifySoundIndex(gs_ModifyIndexDeleted(pEditor->m_SelectedSound));
+		}
+		else if(pEditor->m_PopupEventType == POPEVENT_RESTART_SERVER)
+		{
+			CGameClient *pGameClient = (CGameClient *)pEditor->Kernel()->RequestInterface<IGameClient>();
+			pGameClient->m_Menus.KillServer();
+			pEditor->m_PopupEventType = CEditor::POPEVENT_RESTARTING_SERVER;
+			pEditor->m_PopupEventActivated = true;
 		}
 		pEditor->m_PopupEventWasActivated = false;
 		return CUi::POPUP_CLOSE_CURRENT;

--- a/src/game/editor/quick_actions.h
+++ b/src/game/editor/quick_actions.h
@@ -367,6 +367,14 @@ REGISTER_QUICK_ACTION(
 	ALWAYS_FALSE,
 	DEFAULT_BTN,
 	"[Ctrl+Q] Add a new sound source.")
+REGISTER_QUICK_ACTION(
+	TestMapLocally,
+	"Test map locally",
+	[&]() { TestMapLocally(); },
+	ALWAYS_FALSE,
+	ALWAYS_FALSE,
+	DEFAULT_BTN,
+	"Run a local server with the current map and connect you to it.")
 
 #undef ALWAYS_FALSE
 #undef DEFAULT_BTN

--- a/src/test/shell_execute.cpp
+++ b/src/test/shell_execute.cpp
@@ -1,0 +1,50 @@
+#include "test.h"
+#include <gtest/gtest.h>
+
+#include <base/system.h>
+
+#if defined(CONF_FAMILY_WINDOWS)
+
+TEST(ArgumentsToWide, SingleArgumentNoQuotes)
+{
+	const char *apArguments[] = {"change_map ctf5"};
+	std::wstring result = windows_args_to_wide(apArguments, std::size(apArguments));
+	EXPECT_EQ(result, LR"("change_map ctf5")");
+}
+
+TEST(ArgumentsToWide, SingleArgumentWithQuotes)
+{
+	const char *apArguments[] = {"change_map \"ctf5\""};
+	std::wstring result = windows_args_to_wide(apArguments, std::size(apArguments));
+	EXPECT_EQ(result, L"\"change_map \\\"ctf5\\\"\"");
+}
+
+TEST(ArgumentsToWide, MultipleArguments)
+{
+	const char *apArguments[] = {"change_map ctf5", "sv_register 0"};
+	std::wstring result = windows_args_to_wide(apArguments, std::size(apArguments));
+	EXPECT_EQ(result, LR"("change_map ctf5" "sv_register 0")");
+}
+
+TEST(ArgumentsToWide, SingleArgumentWithSlashes)
+{
+	const char *apArguments[] = {R"(sv_name te\st)"};
+	std::wstring result = windows_args_to_wide(apArguments, std::size(apArguments));
+	EXPECT_EQ(result, L"\"sv_name te\\st\"");
+}
+
+TEST(ArgumentsToWide, MultipleArgumentsWithSlashesAndQuotes)
+{
+	const char *apArguments[] = {R"(sv_name "te\\st")", R"(sv_motd "fo\\o")"};
+	std::wstring result = windows_args_to_wide(apArguments, std::size(apArguments));
+	EXPECT_EQ(result, L"\"sv_name \\\"te\\\\st\\\"\" \"sv_motd \\\"fo\\\\o\\\"\"");
+}
+
+TEST(ArgumentsToWide, MultipleArgumentsWithEndSlash)
+{
+	const char *apArguments[] = {R"(sv_name "te\\st\\")", R"(sv_motd foo\)"};
+	std::wstring result = windows_args_to_wide(apArguments, std::size(apArguments));
+	EXPECT_EQ(result, L"\"sv_name \\\"te\\\\st\\\\\\\\\\\"\" \"sv_motd foo\\\\\"");
+}
+
+#endif


### PR DESCRIPTION
Closes #6733
Closes #9009
Alternative to #9060

Runs a local server with the currently opened map (if it's saved to `maps/`) and automatically authenticates with a new custom rcon password

https://github.com/user-attachments/assets/6fda8098-9a85-48a9-a2d9-fd84e770f361



## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
