### PR TITLE
Fix switch overlay text order

### DIFF
--- a/src/game/client/components/maplayers.cpp
+++ b/src/game/client/components/maplayers.cpp
@@ -1750,9 +1750,9 @@ void CMapLayers::OnRender()
 						RenderTileLayer(TileLayerCounter - 3, Color, pTMap, pGroup);
 						if(g_Config.m_ClTextEntities)
 						{
-							Graphics()->TextureSet(m_pImages->GetOverlayBottom());
-							RenderTileLayer(TileLayerCounter - 2, Color, pTMap, pGroup);
 							Graphics()->TextureSet(m_pImages->GetOverlayTop());
+							RenderTileLayer(TileLayerCounter - 2, Color, pTMap, pGroup);
+							Graphics()->TextureSet(m_pImages->GetOverlayBottom());
 							RenderTileLayer(TileLayerCounter - 1, Color, pTMap, pGroup);
 						}
 					}


### PR DESCRIPTION
Closes #8124
Now both in-game and in the editor, the number is at the top and the delay is at the bottom

![image](https://github.com/user-attachments/assets/f89f37db-f0d1-41dd-960b-fbd4c9186ad8)
![image](https://github.com/user-attachments/assets/df078570-1d24-483f-9297-3f1bd5086a93)


## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
