### PR TITLE
Fix save message text

### DIFF
--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -949,9 +949,9 @@ void CChat::OnPrepareLines(float y)
 			{
 				pText = "Team save in progress. You'll be able to load with '/load ***'";
 			}
-			else if(str_startswith(Line.m_aText, "Team save in progress. You'll be able to load with '/load") && str_endswith(Line.m_aText, "if it fails"))
+			else if(str_startswith(Line.m_aText, "Team save in progress. If the code is valid, you'll be able to load with '/load") && str_endswith(Line.m_aText, "'"))
 			{
-				pText = "Team save in progress. You'll be able to load with '/load ***' if save is successful or with '/load *** *** ***' if it fails";
+				pText = "Team save in progress. If the code is valid, you'll be able to load with '/load ***'; if not, load with '/load *** *** ***'";
 			}
 			else if(str_startswith(Line.m_aText, "Team successfully saved by ") && str_endswith(Line.m_aText, " to continue"))
 			{

--- a/src/game/server/score.cpp
+++ b/src/game/server/score.cpp
@@ -327,7 +327,7 @@ void CScore::SaveTeam(int ClientId, const char *pCode, const char *pServer)
 	{
 		str_format(aBuf,
 			sizeof(aBuf),
-			"Team save in progress. You'll be able to load with '/load %s' if save is successful or with '/load %s' if it fails",
+			"Team save in progress. If the code is valid, you'll be able to load with '/load %s'; if not, load with '/load %s'",
 			Tmp->m_aCode,
 			Tmp->m_aGeneratedCode);
 	}


### PR DESCRIPTION
Closes #8238

The generated code is only used if the new code is not valid or has already been used, so the previous message didn't make sense

![image](https://github.com/user-attachments/assets/46363f32-b15c-445c-8dd3-4b5d8d3fe6d7)


## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
