### PR TITLE
Use CHN_WORLD for MAPSOUNDWORLD and CHN_GLOBAL for MAPSOUNDGLOBAL

### DIFF
--- a/src/game/client/components/mapsounds.cpp
+++ b/src/game/client/components/mapsounds.cpp
@@ -17,20 +17,20 @@ CMapSounds::CMapSounds()
 	m_Count = 0;
 }
 
-void CMapSounds::Play(int SoundId)
+void CMapSounds::Play(int Channel, int SoundId)
 {
 	if(SoundId < 0 || SoundId >= m_Count)
 		return;
 
-	m_pClient->m_Sounds.PlaySample(CSounds::CHN_MAPSOUND, m_aSounds[SoundId], 0, 1.0f);
+	m_pClient->m_Sounds.PlaySample(Channel, m_aSounds[SoundId], 0, 1.0f);
 }
 
-void CMapSounds::PlayAt(int SoundId, vec2 Position)
+void CMapSounds::PlayAt(int Channel, int SoundId, vec2 Position)
 {
 	if(SoundId < 0 || SoundId >= m_Count)
 		return;
 
-	m_pClient->m_Sounds.PlaySampleAt(CSounds::CHN_MAPSOUND, m_aSounds[SoundId], 0, 1.0f, Position);
+	m_pClient->m_Sounds.PlaySampleAt(Channel, m_aSounds[SoundId], 0, 1.0f, Position);
 }
 
 void CMapSounds::OnMapLoad()

--- a/src/game/client/components/mapsounds.h
+++ b/src/game/client/components/mapsounds.h
@@ -33,8 +33,8 @@ public:
 	CMapSounds();
 	virtual int Sizeof() const override { return sizeof(*this); }
 
-	void Play(int SoundId);
-	void PlayAt(int SoundId, vec2 Position);
+	void Play(int Channel, int SoundId);
+	void PlayAt(int Channel, int SoundId, vec2 Position);
 
 	virtual void OnMapLoad() override;
 	virtual void OnRender() override;

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1105,7 +1105,7 @@ void CGameClient::OnMessage(int MsgId, CUnpacker *pUnpacker, int Conn, bool Dumm
 			return;
 
 		CNetMsg_Sv_MapSoundGlobal *pMsg = (CNetMsg_Sv_MapSoundGlobal *)pRawMsg;
-		m_MapSounds.Play(pMsg->m_SoundId);
+		m_MapSounds.Play(CSounds::CHN_GLOBAL, pMsg->m_SoundId);
 	}
 }
 
@@ -1286,7 +1286,7 @@ void CGameClient::ProcessEvents()
 			if(!Config()->m_SndGame)
 				continue;
 
-			m_MapSounds.PlayAt(pEvent->m_SoundId, vec2(pEvent->m_X, pEvent->m_Y));
+			m_MapSounds.PlayAt(CSounds::CHN_WORLD, pEvent->m_SoundId, vec2(pEvent->m_X, pEvent->m_Y));
 		}
 	}
 }


### PR DESCRIPTION
The whole idea behind custom sounds was to use them as replacement for built-in sounds (depending on the gameplay). We have to use the same channels instead of the MAP (aka 'ambient') channel to have the same volume for both sets of messages.
I see it is weird to use something different from `CSounds::CHN_MAPSOUND` in `CMapSounds`. Another solution would be a big refactor of the sounds (probably merging of `CSounds` and `CMapSounds`).
Otherwise we have situation of **players reporting 'no sound' because they have `snd_ambient_volume 0` in the configs**.

- `NETMSGTYPE_SV_MAPSOUNDGLOBAL` is `NETMSGTYPE_SV_SOUNDGLOBAL` which uses map assets as the sounds container. Use the same `CSounds::CHN_GLOBAL` to make the sound messages equivalent.
- `NETEVENTTYPE_MAPSOUNDWORLD` is `NETEVENTTYPE_SOUNDWORLD` which uses map assets as the sounds container. Use the same `CSounds::CHN_WORLD` to make the sound events equivalent.

My use-case (how I planned to use feature #7299) is on the video.

https://github.com/user-attachments/assets/a5a7426d-445d-437f-8aea-5c92a61528c4


<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
