### PR TITLE
Don't emit a warning if no capable vulkan GPU was found

### DIFF
--- a/src/engine/client/backend/vulkan/backend_vulkan.cpp
+++ b/src/engine/client/backend/vulkan/backend_vulkan.cpp
@@ -3798,7 +3798,7 @@ public:
 
 		if(m_pGpuList->m_vGpus.empty())
 		{
-			SetWarning(EGfxWarningType::GFX_WARNING_TYPE_INIT_FAILED_MISSING_INTEGRATED_GPU_DRIVER, "No devices with required vulkan version found.");
+			dbg_msg("vulkan", "no devices with required vulkan version found.");
 			return false;
 		}
 


### PR DESCRIPTION
I doubt it's useful to notify the user that vulkan creation failed, because no capable GPU was found. This also isn't an edge case (e.g. if a GPU only supports vulkan 1.0), like the other warnings we emit.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
