### PR TITLE
Add assertions to `CDataFileReader` checking if file open/closed

### DIFF
--- a/src/tools/dummy_map.cpp
+++ b/src/tools/dummy_map.cpp
@@ -81,7 +81,6 @@ void CreateEmptyMap(IStorage *pStorage)
 
 	dbg_msg("dummy_map", "dummy map written to '%s'", pMapName);
 
-	CDataFileReader Reader;
 	void *pData;
 	unsigned DataSize;
 	if(!pStorage->ReadFile(pMapName, IStorage::TYPE_ALL, &pData, &DataSize))


### PR DESCRIPTION
When the datafile is closed, only the `CDataFileReader::Open` and `CDataFileReader::Close` functions may be called. All other functions will now assert instead of returning some default-values if no file is open. The `CDataFileReader::Open` function will now assert if the file is already open instead of implicitly closing the previous one.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
