### PR TITLE
Add `MAX_SKIN_LENGTH` constant

### DIFF
--- a/src/engine/serverbrowser.h
+++ b/src/engine/serverbrowser.h
@@ -72,7 +72,7 @@ public:
 		bool m_Afk;
 
 		// skin info
-		char m_aSkin[24 + 1];
+		char m_aSkin[MAX_SKIN_LENGTH];
 		bool m_CustomSkinColors;
 		int m_CustomSkinColorBody;
 		int m_CustomSkinColorFeet;

--- a/src/engine/shared/protocol.h
+++ b/src/engine/shared/protocol.h
@@ -96,6 +96,7 @@ enum
 
 	MAX_NAME_LENGTH = 16,
 	MAX_CLAN_LENGTH = 12,
+	MAX_SKIN_LENGTH = 24,
 
 	// message packing
 	MSGFLAG_VITAL = 1,

--- a/src/engine/shared/serverinfo.h
+++ b/src/engine/shared/serverinfo.h
@@ -21,7 +21,7 @@ public:
 		int m_Score;
 		bool m_IsPlayer;
 		bool m_IsAfk;
-		char m_aSkin[24 + 1];
+		char m_aSkin[MAX_SKIN_LENGTH];
 		bool m_CustomSkinColors;
 		int m_CustomSkinColorBody;
 		int m_CustomSkinColorFeet;

--- a/src/game/client/components/ghost.cpp
+++ b/src/game/client/components/ghost.cpp
@@ -385,7 +385,7 @@ void CGhost::OnRender()
 
 void CGhost::InitRenderInfos(CGhostItem *pGhost)
 {
-	char aSkinName[24];
+	char aSkinName[MAX_SKIN_LENGTH];
 	IntsToStr(&pGhost->m_Skin.m_Skin0, 6, aSkinName, std::size(aSkinName));
 	CTeeRenderInfo *pRenderInfo = &pGhost->m_RenderInfo;
 
@@ -685,7 +685,7 @@ void CGhost::OnRefreshSkins()
 	const auto &&RefindSkin = [&](auto &Ghost) {
 		if(Ghost.Empty())
 			return;
-		char aSkinName[24];
+		char aSkinName[MAX_SKIN_LENGTH];
 		IntsToStr(&Ghost.m_Skin.m_Skin0, 6, aSkinName, std::size(aSkinName));
 		CTeeRenderInfo *pRenderInfo = &Ghost.m_RenderInfo;
 		if(aSkinName[0] != '\0')

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -369,7 +369,7 @@ protected:
 		bool m_IsPlayer;
 		bool m_IsAfk;
 		// skin
-		char m_aSkin[24 + 1];
+		char m_aSkin[MAX_SKIN_LENGTH];
 		bool m_CustomSkinColors;
 		int m_CustomSkinColorBody;
 		int m_CustomSkinColorFeet;

--- a/src/game/client/components/skins.cpp
+++ b/src/game/client/components/skins.cpp
@@ -461,7 +461,7 @@ void CSkins::RandomizeSkin(int Dummy)
 	}
 
 	const size_t SkinNameSize = Dummy ? sizeof(g_Config.m_ClDummySkin) : sizeof(g_Config.m_ClPlayerSkin);
-	char aRandomSkinName[24];
+	char aRandomSkinName[MAX_SKIN_LENGTH];
 	str_copy(aRandomSkinName, "default", SkinNameSize);
 	if(!m_pClient->m_Skins.GetSkinsUnsafe().empty())
 	{

--- a/src/game/client/components/skins.h
+++ b/src/game/client/components/skins.h
@@ -30,7 +30,7 @@ public:
 	struct CDownloadSkin
 	{
 	private:
-		char m_aName[24];
+		char m_aName[MAX_SKIN_LENGTH];
 
 	public:
 		std::shared_ptr<CSkins::CGetPngFile> m_pTask;
@@ -82,7 +82,7 @@ private:
 	std::unordered_map<std::string_view, std::unique_ptr<CDownloadSkin>> m_DownloadSkins;
 	CSkin m_PlaceholderSkin;
 	size_t m_DownloadingSkins = 0;
-	char m_aEventSkinPrefix[24];
+	char m_aEventSkinPrefix[MAX_SKIN_LENGTH];
 
 	bool LoadSkinPng(CImageInfo &Info, const char *pName, const char *pPath, int DirType);
 	const CSkin *LoadSkin(const char *pName, const char *pPath, int DirType);

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -376,7 +376,7 @@ public:
 		char m_aName[MAX_NAME_LENGTH];
 		char m_aClan[MAX_CLAN_LENGTH];
 		int m_Country;
-		char m_aSkinName[24];
+		char m_aSkinName[MAX_SKIN_LENGTH];
 		int m_SkinColor;
 		int m_Team;
 		int m_Emoticon;

--- a/src/game/client/skin.h
+++ b/src/game/client/skin.h
@@ -1,16 +1,20 @@
 #ifndef GAME_CLIENT_SKIN_H
 #define GAME_CLIENT_SKIN_H
+
 #include <base/color.h>
 #include <base/system.h>
 #include <base/vmath.h>
+
 #include <engine/graphics.h>
+#include <engine/shared/protocol.h>
+
 #include <limits>
 
 // do this better and nicer
 struct CSkin
 {
 private:
-	char m_aName[24];
+	char m_aName[MAX_SKIN_LENGTH];
 
 public:
 	struct SSkinTextures

--- a/src/game/server/teeinfo.h
+++ b/src/game/server/teeinfo.h
@@ -1,10 +1,12 @@
 #ifndef GAME_SERVER_TEEINFO_H
 #define GAME_SERVER_TEEINFO_H
 
+#include <engine/shared/protocol.h>
+
 class CTeeInfo
 {
 public:
-	char m_aSkinName[24] = {'\0'};
+	char m_aSkinName[MAX_SKIN_LENGTH] = "";
 	int m_UseCustomColor = 0;
 	int m_ColorBody = 0;
 	int m_ColorFeet = 0;


### PR DESCRIPTION
Add constant to replace the magic number `24` used for the size of skin names. Skin names in the server info/browser were sized `24 + 1` but the additional byte was unnecessary.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
