### PR TITLE
Improve skin downloading: load from `downloadedskins` if possible

### DIFF
--- a/src/engine/shared/http.cpp
+++ b/src/engine/shared/http.cpp
@@ -126,6 +126,11 @@ bool CHttpRequest::ConfigureHandle(void *pHandle)
 	{
 		curl_easy_setopt(pH, CURLOPT_MAXFILESIZE_LARGE, (curl_off_t)m_MaxResponseSize);
 	}
+	if(m_IfModifiedSince >= 0)
+	{
+		curl_easy_setopt(pH, CURLOPT_TIMEVALUE_LARGE, (curl_off_t)m_IfModifiedSince);
+		curl_easy_setopt(pH, CURLOPT_TIMECONDITION, CURL_TIMECOND_IFMODSINCE);
+	}
 
 	// ‘CURLOPT_PROTOCOLS’ is deprecated: since 7.85.0. Use CURLOPT_PROTOCOLS_STR
 	// Wait until all platforms have 7.85.0

--- a/src/engine/shared/http.h
+++ b/src/engine/shared/http.h
@@ -86,6 +86,7 @@ class CHttpRequest : public IHttpRequest
 
 	CTimeout m_Timeout = CTimeout{0, 0, 0, 0};
 	int64_t m_MaxResponseSize = -1;
+	int64_t m_IfModifiedSince = -1;
 	REQUEST m_Type = REQUEST::GET;
 
 	SHA256_DIGEST m_ActualSha256 = SHA256_ZEROED;
@@ -150,6 +151,7 @@ public:
 
 	void Timeout(CTimeout Timeout) { m_Timeout = Timeout; }
 	void MaxResponseSize(int64_t MaxResponseSize) { m_MaxResponseSize = MaxResponseSize; }
+	void IfModifiedSince(int64_t IfModifiedSince) { m_IfModifiedSince = IfModifiedSince; }
 	void LogProgress(HTTPLOG LogProgress) { m_LogProgress = LogProgress; }
 	void IpResolve(IPRESOLVE IpResolve) { m_IpResolve = IpResolve; }
 	void FailOnErrorStatus(bool FailOnErrorStatus) { m_FailOnErrorStatus = FailOnErrorStatus; }

--- a/src/engine/shared/storage.cpp
+++ b/src/engine/shared/storage.cpp
@@ -574,6 +574,14 @@ public:
 		return pResult;
 	}
 
+	bool RetrieveTimes(const char *pFilename, int Type, time_t *pCreated, time_t *pModified) override
+	{
+		dbg_assert(Type == TYPE_ABSOLUTE || (Type >= TYPE_SAVE && Type < m_NumPaths), "Type invalid");
+
+		char aBuffer[IO_MAX_PATH_LENGTH];
+		return fs_file_time(GetPath(Type, pFilename, aBuffer, sizeof(aBuffer)), pCreated, pModified) == 0;
+	}
+
 	bool CalculateHashes(const char *pFilename, int Type, SHA256_DIGEST *pSha256, unsigned *pCrc) override
 	{
 		dbg_assert(pSha256 != nullptr || pCrc != nullptr, "At least one output argument required");

--- a/src/engine/storage.h
+++ b/src/engine/storage.h
@@ -54,6 +54,7 @@ public:
 	virtual bool FolderExists(const char *pFilename, int Type) = 0;
 	virtual bool ReadFile(const char *pFilename, int Type, void **ppResult, unsigned *pResultLen) = 0;
 	virtual char *ReadFileStr(const char *pFilename, int Type) = 0;
+	virtual bool RetrieveTimes(const char *pFilename, int Type, time_t *pCreated, time_t *pModified) = 0;
 	virtual bool CalculateHashes(const char *pFilename, int Type, SHA256_DIGEST *pSha256, unsigned *pCrc = nullptr) = 0;
 	virtual bool FindFile(const char *pFilename, const char *pPath, int Type, char *pBuffer, int BufferSize) = 0;
 	virtual size_t FindFiles(const char *pFilename, const char *pPath, int Type, std::set<std::string> *pEntries) = 0;

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -717,21 +717,16 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 	static std::vector<CUISkin> s_vSkinList;
 	static std::vector<CUISkin> s_vSkinListHelper;
 	static std::vector<CUISkin> s_vFavoriteSkinListHelper;
-	static int s_SkinCount = 0;
 	static CListBox s_ListBox;
 
 	// be nice to the CPU
-	static auto s_SkinLastRebuildTime = time_get_nanoseconds();
-	const auto CurTime = time_get_nanoseconds();
-	if(m_SkinListNeedsUpdate || m_pClient->m_Skins.Num() != s_SkinCount || m_SkinFavoritesChanged || (m_pClient->m_Skins.IsDownloadingSkins() && (CurTime - s_SkinLastRebuildTime > 500ms)))
+	static std::chrono::nanoseconds s_SkinLastRefreshTime = m_pClient->m_Skins.LastRefreshTime();
+	if(m_SkinListNeedsUpdate || m_SkinFavoritesChanged || s_SkinLastRefreshTime != m_pClient->m_Skins.LastRefreshTime())
 	{
-		s_SkinLastRebuildTime = CurTime;
+		s_SkinLastRefreshTime = m_pClient->m_Skins.LastRefreshTime();
 		s_vSkinList.clear();
 		s_vSkinListHelper.clear();
 		s_vFavoriteSkinListHelper.clear();
-		// set skin count early, since Find of the skin class might load
-		// a downloading skin
-		s_SkinCount = m_pClient->m_Skins.Num();
 		m_SkinFavoritesChanged = false;
 
 		auto &&SkinNotFiltered = [&](const CSkin *pSkinToBeSelected) {

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -3745,7 +3745,7 @@ void CGameClient::LoadExtrasSkin(const char *pPath, bool AsDir)
 void CGameClient::RefreshSkins()
 {
 	const auto SkinStartLoadTime = time_get_nanoseconds();
-	m_Skins.Refresh([&](int) {
+	m_Skins.Refresh([&]() {
 		// if skin refreshing takes to long, swap to a loading screen
 		if(time_get_nanoseconds() - SkinStartLoadTime > 500ms)
 		{


### PR DESCRIPTION
Previously, skins not found in the `skins` folder were downloaded from the configured URL and saved to the `downloadedskins` folder, but the saved files were never used, leading to wasted downloads and write operations.

Now, if a skin to be downloaded already exists in the `downloadedskins` folder, the modified time of the skin file is determined and included in the HTTP GET request as `If-Modified-Since` header. If the file was not modified on the server since that time, the server will answer with status 304 Not Modified and an empty response body, in which case the existing skin file is loaded. If the skin file was modified, then it will be downloaded like usual. The download will also be retried without including the `If-Modified-Since` header, if the local file is more recent but it failed to be loaded. If a skin could not be downloaded when it should but a file already exists in the `downloadedskins` folder then that file will be loaded instead.

Instead of checking whether the number of skins is different to determine whether to reload the list of skins in the settings menus, the last time that the list of skins was refreshed is now saved and compared, which is more robust. The additional check to refresh the skin list while skins are being downloaded is unnecessary, as any updates to the skin list are now covered by checking the last refresh time.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [X] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
