### PR TITLE
Adjust console search behaviour

### DIFF
--- a/src/game/client/components/console.cpp
+++ b/src/game/client/components/console.cpp
@@ -237,7 +237,7 @@ void CGameConsole::CInstance::ClearBacklog()
 
 	m_Backlog.Init();
 	m_BacklogCurLine = 0;
-	UpdateSearch();
+	ClearSearch();
 }
 
 void CGameConsole::CInstance::UpdateBacklogTextAttributes()
@@ -575,10 +575,18 @@ bool CGameConsole::CInstance::OnInput(const IInput::CEvent &Event)
 			m_BacklogCurLine = 0;
 			Handled = true;
 		}
+		else if(Event.m_Key == KEY_ESCAPE && m_Searching)
+		{
+			m_Searching = false;
+			m_Input.Clear();
+			Handled = true;
+		}
 		else if(Event.m_Key == KEY_F && m_pGameConsole->Input()->ModifierIsPressed())
 		{
-			m_Searching = !m_Searching;
-			ClearSearch();
+			m_Searching = true;
+			m_Input.Set(m_aCurrentSearchString);
+			m_Input.SelectAll();
+			UpdateSearch();
 			Handled = true;
 		}
 	}
@@ -1446,7 +1454,7 @@ bool CGameConsole::OnInput(const IInput::CEvent &Event)
 	if((Event.m_Key >= KEY_F1 && Event.m_Key <= KEY_F12) || (Event.m_Key >= KEY_F13 && Event.m_Key <= KEY_F24))
 		return false;
 
-	if(Event.m_Key == KEY_ESCAPE && (Event.m_Flags & IInput::FLAG_PRESS))
+	if(Event.m_Key == KEY_ESCAPE && (Event.m_Flags & IInput::FLAG_PRESS) && !CurrentConsole()->m_Searching)
 		Toggle(m_ConsoleType);
 	else if(!CurrentConsole()->OnInput(Event))
 	{


### PR DESCRIPTION
This makes it behave as you would expect from other programs.

- `ctrl+f` to start search
- `esc` to cancel search
- dont clear last searched string

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
