### PR TITLE
Fix empty vector element access in mysql prepare

### DIFF
--- a/src/engine/server/databases/mysql.cpp
+++ b/src/engine/server/databases/mysql.cpp
@@ -331,8 +331,11 @@ bool CMysqlConnection::PrepareStatement(const char *pStmt, char *pError, int Err
 	unsigned NumParameters = mysql_stmt_param_count(m_pStmt.get());
 	m_vStmtParameters.resize(NumParameters);
 	m_vStmtParameterExtras.resize(NumParameters);
-	mem_zero(&m_vStmtParameters[0], sizeof(m_vStmtParameters[0]) * m_vStmtParameters.size());
-	mem_zero(&m_vStmtParameterExtras[0], sizeof(m_vStmtParameterExtras[0]) * m_vStmtParameterExtras.size());
+	if(NumParameters)
+	{
+		mem_zero(&m_vStmtParameters[0], sizeof(m_vStmtParameters[0]) * m_vStmtParameters.size());
+		mem_zero(&m_vStmtParameterExtras[0], sizeof(m_vStmtParameterExtras[0]) * m_vStmtParameterExtras.size());
+	}
 	return false;
 }
 


### PR DESCRIPTION
If the sql statement does not contain placeholders ``NumParameters`` can be empty.

In that case accessing the first element will cause an asan error:

```
runtime error: reference binding to null pointer of type 'st_mysql_bind'
```