### PR TITLE
Refactor `CTeeRenderInfo` usage

### DIFF
--- a/src/game/client/components/ghost.cpp
+++ b/src/game/client/components/ghost.cpp
@@ -388,20 +388,8 @@ void CGhost::InitRenderInfos(CGhostItem *pGhost)
 	char aSkinName[MAX_SKIN_LENGTH];
 	IntsToStr(&pGhost->m_Skin.m_Skin0, 6, aSkinName, std::size(aSkinName));
 	CTeeRenderInfo *pRenderInfo = &pGhost->m_RenderInfo;
-
 	pRenderInfo->Apply(m_pClient->m_Skins.Find(aSkinName));
-	pRenderInfo->m_CustomColoredSkin = pGhost->m_Skin.m_UseCustomColor;
-	if(pGhost->m_Skin.m_UseCustomColor)
-	{
-		pRenderInfo->m_ColorBody = color_cast<ColorRGBA>(ColorHSLA(pGhost->m_Skin.m_ColorBody).UnclampLighting(ColorHSLA::DARKEST_LGT));
-		pRenderInfo->m_ColorFeet = color_cast<ColorRGBA>(ColorHSLA(pGhost->m_Skin.m_ColorFeet).UnclampLighting(ColorHSLA::DARKEST_LGT));
-	}
-	else
-	{
-		pRenderInfo->m_ColorBody = ColorRGBA(1, 1, 1);
-		pRenderInfo->m_ColorFeet = ColorRGBA(1, 1, 1);
-	}
-
+	pRenderInfo->ApplyColors(pGhost->m_Skin.m_UseCustomColor, pGhost->m_Skin.m_ColorBody, pGhost->m_Skin.m_ColorFeet);
 	pRenderInfo->m_Size = 64;
 }
 
@@ -687,16 +675,7 @@ void CGhost::OnRefreshSkins()
 			return;
 		char aSkinName[MAX_SKIN_LENGTH];
 		IntsToStr(&Ghost.m_Skin.m_Skin0, 6, aSkinName, std::size(aSkinName));
-		CTeeRenderInfo *pRenderInfo = &Ghost.m_RenderInfo;
-		if(aSkinName[0] != '\0')
-		{
-			pRenderInfo->Apply(m_pClient->m_Skins.Find(aSkinName));
-		}
-		else
-		{
-			pRenderInfo->m_OriginalRenderSkin.Reset();
-			pRenderInfo->m_ColorableRenderSkin.Reset();
-		}
+		Ghost.m_RenderInfo.Apply(m_pClient->m_Skins.Find(aSkinName));
 	};
 
 	for(auto &Ghost : m_aActiveGhosts)

--- a/src/game/client/components/menus_browser.cpp
+++ b/src/game/client/components/menus_browser.cpp
@@ -1846,17 +1846,7 @@ CTeeRenderInfo CMenus::GetTeeRenderInfo(vec2 Size, const char *pSkinName, bool C
 {
 	CTeeRenderInfo TeeInfo;
 	TeeInfo.Apply(m_pClient->m_Skins.Find(pSkinName));
-	TeeInfo.m_CustomColoredSkin = CustomSkinColors;
-	if(CustomSkinColors)
-	{
-		TeeInfo.m_ColorBody = color_cast<ColorRGBA>(ColorHSLA(CustomSkinColorBody).UnclampLighting(ColorHSLA::DARKEST_LGT));
-		TeeInfo.m_ColorFeet = color_cast<ColorRGBA>(ColorHSLA(CustomSkinColorFeet).UnclampLighting(ColorHSLA::DARKEST_LGT));
-	}
-	else
-	{
-		TeeInfo.m_ColorBody = ColorRGBA(1.0f, 1.0f, 1.0f);
-		TeeInfo.m_ColorFeet = ColorRGBA(1.0f, 1.0f, 1.0f);
-	}
+	TeeInfo.ApplyColors(CustomSkinColors, CustomSkinColorBody, CustomSkinColorFeet);
 	TeeInfo.m_Size = minimum(Size.x, Size.y);
 	return TeeInfo;
 }

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -862,7 +862,6 @@ void CPlayers::OnRender()
 	}
 	CTeeRenderInfo RenderInfoSpec;
 	RenderInfoSpec.Apply(m_pClient->m_Skins.Find("x_spec"));
-	RenderInfoSpec.m_CustomColoredSkin = false;
 	RenderInfoSpec.m_Size = 64.0f;
 	const int LocalClientId = m_pClient->m_Snap.m_LocalClientId;
 

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -1542,30 +1542,21 @@ void CGameClient::OnNewSnapshot()
 					}
 					IntsToStr(&pInfo->m_Clan0, 3, pClient->m_aClan, std::size(pClient->m_aClan));
 					pClient->m_Country = pInfo->m_Country;
+
 					IntsToStr(&pInfo->m_Skin0, 6, pClient->m_aSkinName, std::size(pClient->m_aSkinName));
+					if(pClient->m_aSkinName[0] == '\0' ||
+						(!m_GameInfo.m_AllowXSkins && (pClient->m_aSkinName[0] == 'x' && pClient->m_aSkinName[1] == '_')))
+					{
+						str_copy(pClient->m_aSkinName, "default");
+					}
 
 					pClient->m_UseCustomColor = pInfo->m_UseCustomColor;
 					pClient->m_ColorBody = pInfo->m_ColorBody;
 					pClient->m_ColorFeet = pInfo->m_ColorFeet;
 
-					// prepare the info
-					if(!m_GameInfo.m_AllowXSkins && (pClient->m_aSkinName[0] == 'x' && pClient->m_aSkinName[1] == '_'))
-						str_copy(pClient->m_aSkinName, "default");
-
-					pClient->m_SkinInfo.m_ColorBody = color_cast<ColorRGBA>(ColorHSLA(pClient->m_ColorBody).UnclampLighting(ColorHSLA::DARKEST_LGT));
-					pClient->m_SkinInfo.m_ColorFeet = color_cast<ColorRGBA>(ColorHSLA(pClient->m_ColorFeet).UnclampLighting(ColorHSLA::DARKEST_LGT));
 					pClient->m_SkinInfo.m_Size = 64;
-
-					// find new skin
 					pClient->m_SkinInfo.Apply(m_Skins.Find(pClient->m_aSkinName));
-					pClient->m_SkinInfo.m_CustomColoredSkin = pClient->m_UseCustomColor;
-
-					if(!pClient->m_UseCustomColor)
-					{
-						pClient->m_SkinInfo.m_ColorBody = ColorRGBA(1, 1, 1);
-						pClient->m_SkinInfo.m_ColorFeet = ColorRGBA(1, 1, 1);
-					}
-
+					pClient->m_SkinInfo.ApplyColors(pClient->m_UseCustomColor, pClient->m_ColorBody, pClient->m_ColorFeet);
 					pClient->UpdateRenderInfo(IsTeamPlay());
 				}
 			}
@@ -3755,15 +3746,7 @@ void CGameClient::RefreshSkins()
 
 	for(auto &Client : m_aClients)
 	{
-		if(Client.m_aSkinName[0] != '\0')
-		{
-			Client.m_SkinInfo.Apply(m_Skins.Find(Client.m_aSkinName));
-		}
-		else
-		{
-			Client.m_SkinInfo.m_OriginalRenderSkin.Reset();
-			Client.m_SkinInfo.m_ColorableRenderSkin.Reset();
-		}
+		Client.m_SkinInfo.Apply(m_Skins.Find(Client.m_aSkinName));
 		Client.UpdateRenderInfo(IsTeamPlay());
 	}
 

--- a/src/game/client/render.h
+++ b/src/game/client/render.h
@@ -64,6 +64,21 @@ public:
 		m_SkinMetrics = pSkin->m_Metrics;
 	}
 
+	void ApplyColors(bool CustomColoredSkin, int ColorBody, int ColorFeet)
+	{
+		m_CustomColoredSkin = CustomColoredSkin;
+		if(CustomColoredSkin)
+		{
+			m_ColorBody = color_cast<ColorRGBA>(ColorHSLA(ColorBody).UnclampLighting(ColorHSLA::DARKEST_LGT));
+			m_ColorFeet = color_cast<ColorRGBA>(ColorHSLA(ColorFeet).UnclampLighting(ColorHSLA::DARKEST_LGT));
+		}
+		else
+		{
+			m_ColorBody = ColorRGBA(1.0f, 1.0f, 1.0f, 1.0f);
+			m_ColorFeet = ColorRGBA(1.0f, 1.0f, 1.0f, 1.0f);
+		}
+	}
+
 	CSkin::SSkinTextures m_OriginalRenderSkin;
 	CSkin::SSkinTextures m_ColorableRenderSkin;
 


### PR DESCRIPTION
- Add `CTeeRenderInfo::ApplyColors` function to reduce duplicate code.
- Use `CTeeRenderInfo::Apply` function in more cases.
- Use `CSkins::Find` function instead of implementing default skin handling manually with the `FindOrNullptr` function for chat settings preview.
- Remove redundant initialization of `CTeeRenderInfo::m_CustomColoredSkin` member.
- Replace empty client skin with `default` instead of checking for empty skin names later.
- Remove unnecessary check for empty skin name for ghost rendering. The `CSkins::Find` function will return the default skin for an empty skin name, which is more correct than invalidating the ghost skin render info.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
