### PR TITLE
Fix Android build when first building `x64` architecture

### DIFF
--- a/scripts/android/cmake_android.sh
+++ b/scripts/android/cmake_android.sh
@@ -26,6 +26,9 @@ if [ -z ${1+x} ]; then
 	printf "${COLOR_RED}%s${COLOR_RESET}\n" "Did not pass Android build type"
 else
 	ANDROID_BUILD=$1
+	if [[ "${ANDROID_BUILD}" == "x64" ]]; then
+		ANDROID_BUILD="x86_64"
+	fi
 	printf "${COLOR_YELLOW}%s${COLOR_RESET}\n" "Android build type: ${ANDROID_BUILD}"
 fi
 
@@ -168,7 +171,7 @@ if [[ "${ANDROID_BUILD}" == "x86" || "${ANDROID_BUILD}" == "all" ]]; then
 	PID_BUILD_X86=$!
 fi
 
-if [[ "${ANDROID_BUILD}" == "x86_64" || "${ANDROID_BUILD}" == "x64" || "${ANDROID_BUILD}" == "all" ]]; then
+if [[ "${ANDROID_BUILD}" == "x86_64" || "${ANDROID_BUILD}" == "all" ]]; then
 	build_for_type x86_64 x86_64 x86_64-linux-android &
 	PID_BUILD_X86_64=$!
 fi
@@ -236,7 +239,7 @@ if [[ "${ANDROID_BUILD}" == "x86" || "${ANDROID_BUILD}" == "all" ]]; then
 	copy_libs x86 x86
 fi
 
-if [[ "${ANDROID_BUILD}" == "x86_64" || "${ANDROID_BUILD}" == "x64" || "${ANDROID_BUILD}" == "all" ]]; then
+if [[ "${ANDROID_BUILD}" == "x86_64" || "${ANDROID_BUILD}" == "all" ]]; then
 	copy_libs x86_64 x86_64
 fi
 


### PR DESCRIPTION
The argument `x64` is an alias for `x86_64` but the name of the build folder always contains `x86_64`, so the `data` folder and certificate were not being found when using the `x64` argument, unless another architecture was previously built.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
