### PR TITLE
Store 0.7 favorites in url format

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -3630,7 +3630,8 @@ void CClient::Con_AddFavorite(IConsole::IResult *pResult, void *pUserData)
 {
 	CClient *pSelf = (CClient *)pUserData;
 	NETADDR Addr;
-	if(net_addr_from_str(&Addr, pResult->GetString(0)) != 0)
+
+	if(net_addr_from_url(&Addr, pResult->GetString(0), nullptr, 0) != 0 && net_addr_from_str(&Addr, pResult->GetString(0)) != 0)
 	{
 		char aBuf[128];
 		str_format(aBuf, sizeof(aBuf), "invalid address '%s'", pResult->GetString(0));

--- a/src/engine/client/favorites.cpp
+++ b/src/engine/client/favorites.cpp
@@ -42,7 +42,21 @@ void CFavorites::OnConfigSave(IConfigManager *pConfigManager)
 		{
 			char aAddr[NETADDR_MAXSTRSIZE];
 			char aBuffer[128];
-			net_addr_str(&Entry.m_aAddrs[i], aAddr, sizeof(aAddr), true);
+			net_addr_str(&Entry.m_aAddrs[i], aBuffer, sizeof(aBuffer), true);
+
+			if(Entry.m_aAddrs[i].type & NETTYPE_TW7)
+			{
+				str_format(
+					aAddr,
+					sizeof(aAddr),
+					"tw-0.7+udp://%s",
+					aBuffer);
+			}
+			else
+			{
+				str_copy(aAddr, aBuffer);
+			}
+
 			if(!Entry.m_AllowPing)
 			{
 				str_format(aBuffer, sizeof(aBuffer), "add_favorite %s", aAddr);

--- a/src/engine/client/favorites.cpp
+++ b/src/engine/client/favorites.cpp
@@ -135,16 +135,14 @@ void CFavorites::Add(const NETADDR *pAddrs, int NumAddrs)
 	// other favorite.
 	for(int i = 0; i < NumAddrs; i++)
 	{
-		NETADDR Addr = pAddrs[i];
-		Addr.type &= ~(NETTYPE_TW7);
-		CEntry *pEntry = Entry(Addr);
+		CEntry *pEntry = Entry(pAddrs[i]);
 		if(pEntry == nullptr)
 		{
 			continue;
 		}
 		for(int j = 0; j < pEntry->m_NumAddrs; j++)
 		{
-			if(pEntry->m_aAddrs[j] == Addr)
+			if(pEntry->m_aAddrs[j] == pAddrs[i])
 			{
 				pEntry->m_aAddrs[j] = pEntry->m_aAddrs[pEntry->m_NumAddrs - 1];
 				pEntry->m_NumAddrs -= 1;
@@ -164,10 +162,8 @@ void CFavorites::Add(const NETADDR *pAddrs, int NumAddrs)
 	NewEntry.m_NumAddrs = std::min(NumAddrs, (int)std::size(NewEntry.m_aAddrs));
 	for(int i = 0; i < NewEntry.m_NumAddrs; i++)
 	{
-		NETADDR Addr = pAddrs[i];
-		Addr.type &= ~(NETTYPE_TW7);
-		NewEntry.m_aAddrs[i] = Addr;
-		m_ByAddr[Addr] = m_vEntries.size();
+		NewEntry.m_aAddrs[i] = pAddrs[i];
+		m_ByAddr[pAddrs[i]] = m_vEntries.size();
 	}
 	NewEntry.m_AllowPing = false;
 	m_vEntries.push_back(NewEntry);
@@ -211,10 +207,7 @@ void CFavorites::AllEntries(const CEntry **ppEntries, int *pNumEntries)
 
 CFavorites::CEntry *CFavorites::Entry(const NETADDR &Addr)
 {
-	NETADDR AddrAnyProtocol = Addr;
-	AddrAnyProtocol.type &= ~(NETTYPE_TW7);
-
-	auto Entry = m_ByAddr.find(AddrAnyProtocol);
+	auto Entry = m_ByAddr.find(Addr);
 	if(Entry == m_ByAddr.end())
 	{
 		return nullptr;
@@ -224,10 +217,7 @@ CFavorites::CEntry *CFavorites::Entry(const NETADDR &Addr)
 
 const CFavorites::CEntry *CFavorites::Entry(const NETADDR &Addr) const
 {
-	NETADDR AddrAnyProtocol = Addr;
-	AddrAnyProtocol.type &= ~(NETTYPE_TW7);
-
-	auto Entry = m_ByAddr.find(AddrAnyProtocol);
+	auto Entry = m_ByAddr.find(Addr);
 	if(Entry == m_ByAddr.end())
 	{
 		return nullptr;


### PR DESCRIPTION
Addresses https://github.com/ddnet/ddnet/pull/9052#discussion_r1796898871

Favorites written to settings_ddnet.cfg can now look like this

```
add_favorite 185.223.31.160:8308
add_favorite "tw-0.7+udp://45.142.178.158:8307" allow_ping
```

It uses ips for 0.6 and the url format for 0.7 only servers.