### PR TITLE
Avoid busy waiting in `CHttpRequest::Wait` function

### DIFF
--- a/src/engine/shared/http.h
+++ b/src/engine/shared/http.h
@@ -116,6 +116,8 @@ class CHttpRequest : public IHttpRequest
 	char m_aErr[256]; // 256 == CURL_ERROR_SIZE
 	std::atomic<EHttpState> m_State{EHttpState::QUEUED};
 	std::atomic<bool> m_Abort{false};
+	std::mutex m_WaitMutex;
+	std::condition_variable m_WaitCondition;
 
 	int m_StatusCode = 0;
 	bool m_HeadersEnded = false;


### PR DESCRIPTION
Use a condition variable instead of busy waiting until HTTP requests are done.

Also set the state `EHttpState::RUNNING` which was previously unused.

Closes #7811.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
