### PR TITLE
Cleanup envelope updating during demo playback

### DIFF
--- a/src/game/client/components/maplayers.cpp
+++ b/src/game/client/components/maplayers.cpp
@@ -24,13 +24,9 @@
 
 using namespace std::chrono_literals;
 
-CMapLayers::CMapLayers(int t, bool OnlineOnly)
+CMapLayers::CMapLayers(int Type, bool OnlineOnly)
 {
-	m_Type = t;
-	m_pLayers = 0;
-	m_CurrentLocalTick = 0;
-	m_LastLocalTick = 0;
-	m_EnvelopeUpdate = false;
+	m_Type = Type;
 	m_OnlineOnly = OnlineOnly;
 }
 
@@ -43,17 +39,6 @@ void CMapLayers::OnInit()
 CCamera *CMapLayers::GetCurCamera()
 {
 	return &m_pClient->m_Camera;
-}
-
-void CMapLayers::EnvelopeUpdate()
-{
-	if(Client()->State() == IClient::STATE_DEMOPLAYBACK)
-	{
-		const IDemoPlayer::CInfo *pInfo = DemoPlayer()->BaseInfo();
-		m_CurrentLocalTick = pInfo->m_CurrentTick;
-		m_LastLocalTick = pInfo->m_CurrentTick;
-		m_EnvelopeUpdate = true;
-	}
 }
 
 void CMapLayers::EnvelopeEval(int TimeOffsetMillis, int Env, ColorRGBA &Result, size_t Channels, void *pUser)
@@ -75,73 +60,31 @@ void CMapLayers::EnvelopeEval(int TimeOffsetMillis, int Env, ColorRGBA &Result, 
 	if(EnvelopePoints.NumPoints() == 0)
 		return;
 
-	const auto TickToNanoSeconds = std::chrono::nanoseconds(1s) / (int64_t)pThis->Client()->GameTickSpeed();
-
 	static std::chrono::nanoseconds s_Time{0};
 	static auto s_LastLocalTime = time_get_nanoseconds();
-	if(pThis->Client()->State() == IClient::STATE_DEMOPLAYBACK)
+	if(pThis->m_OnlineOnly && (pItem->m_Version < 2 || pItem->m_Synchronized))
 	{
-		const IDemoPlayer::CInfo *pInfo = pThis->DemoPlayer()->BaseInfo();
-
-		if(!pInfo->m_Paused || pThis->m_EnvelopeUpdate)
+		if(pThis->m_pClient->m_Snap.m_pGameInfoObj)
 		{
-			if(pThis->m_CurrentLocalTick != pInfo->m_CurrentTick)
-			{
-				pThis->m_LastLocalTick = pThis->m_CurrentLocalTick;
-				pThis->m_CurrentLocalTick = pInfo->m_CurrentTick;
-			}
-			if(pItem->m_Version < 2 || pItem->m_Synchronized)
-			{
-				if(pThis->m_pClient->m_Snap.m_pGameInfoObj)
-				{
-					// get the lerp of the current tick and prev
-					int MinTick = pThis->Client()->PrevGameTick(g_Config.m_ClDummy) - pThis->m_pClient->m_Snap.m_pGameInfoObj->m_RoundStartTick;
-					int CurTick = pThis->Client()->GameTick(g_Config.m_ClDummy) - pThis->m_pClient->m_Snap.m_pGameInfoObj->m_RoundStartTick;
-					s_Time = std::chrono::nanoseconds((int64_t)(mix<double>(
-											    0,
-											    (CurTick - MinTick),
-											    (double)pThis->Client()->IntraGameTick(g_Config.m_ClDummy)) *
-										    TickToNanoSeconds.count())) +
-						 MinTick * TickToNanoSeconds;
-				}
-			}
-			else
-			{
-				int MinTick = pThis->m_LastLocalTick;
-				s_Time = std::chrono::nanoseconds((int64_t)(mix<double>(0,
-										    pThis->m_CurrentLocalTick - MinTick,
-										    (double)pThis->Client()->IntraGameTick(g_Config.m_ClDummy)) *
-									    TickToNanoSeconds.count())) +
-					 MinTick * TickToNanoSeconds;
-			}
+			// get the lerp of the current tick and prev
+			const auto TickToNanoSeconds = std::chrono::nanoseconds(1s) / (int64_t)pThis->Client()->GameTickSpeed();
+			const int MinTick = pThis->Client()->PrevGameTick(g_Config.m_ClDummy) - pThis->m_pClient->m_Snap.m_pGameInfoObj->m_RoundStartTick;
+			const int CurTick = pThis->Client()->GameTick(g_Config.m_ClDummy) - pThis->m_pClient->m_Snap.m_pGameInfoObj->m_RoundStartTick;
+			s_Time = std::chrono::nanoseconds((int64_t)(mix<double>(
+									    0,
+									    (CurTick - MinTick),
+									    (double)pThis->Client()->IntraGameTick(g_Config.m_ClDummy)) *
+								    TickToNanoSeconds.count())) +
+				 MinTick * TickToNanoSeconds;
 		}
-		CRenderTools::RenderEvalEnvelope(&EnvelopePoints, s_Time + (int64_t)TimeOffsetMillis * std::chrono::nanoseconds(1ms), Result, Channels);
 	}
 	else
 	{
-		if(pThis->m_OnlineOnly && (pItem->m_Version < 2 || pItem->m_Synchronized))
-		{
-			if(pThis->m_pClient->m_Snap.m_pGameInfoObj) // && !(pThis->m_pClient->m_Snap.m_pGameInfoObj->m_GameStateFlags&GAMESTATEFLAG_PAUSED))
-			{
-				// get the lerp of the current tick and prev
-				int MinTick = pThis->Client()->PrevGameTick(g_Config.m_ClDummy) - pThis->m_pClient->m_Snap.m_pGameInfoObj->m_RoundStartTick;
-				int CurTick = pThis->Client()->GameTick(g_Config.m_ClDummy) - pThis->m_pClient->m_Snap.m_pGameInfoObj->m_RoundStartTick;
-				s_Time = std::chrono::nanoseconds((int64_t)(mix<double>(
-										    0,
-										    (CurTick - MinTick),
-										    (double)pThis->Client()->IntraGameTick(g_Config.m_ClDummy)) *
-									    TickToNanoSeconds.count())) +
-					 MinTick * TickToNanoSeconds;
-			}
-		}
-		else
-		{
-			auto CurTime = time_get_nanoseconds();
-			s_Time += CurTime - s_LastLocalTime;
-			s_LastLocalTime = CurTime;
-		}
-		CRenderTools::RenderEvalEnvelope(&EnvelopePoints, s_Time + std::chrono::nanoseconds(std::chrono::milliseconds(TimeOffsetMillis)), Result, Channels);
+		const auto CurTime = time_get_nanoseconds();
+		s_Time += CurTime - s_LastLocalTime;
+		s_LastLocalTime = CurTime;
 	}
+	CRenderTools::RenderEvalEnvelope(&EnvelopePoints, s_Time + std::chrono::nanoseconds(std::chrono::milliseconds(TimeOffsetMillis)), Result, Channels);
 }
 
 void FillTmpTile(SGraphicTile *pTmpTile, SGraphicTileTexureCoords *pTmpTex, unsigned char Flags, unsigned char Index, int x, int y, const ivec2 &Offset, int Scale, CMapItemGroup *pGroup)

--- a/src/game/client/components/maplayers.h
+++ b/src/game/client/components/maplayers.h
@@ -30,11 +30,8 @@ class CMapLayers : public CComponent
 
 	CLayers *m_pLayers;
 	CMapImages *m_pImages;
-	int m_Type;
-	int m_CurrentLocalTick;
-	int m_LastLocalTick;
-	bool m_EnvelopeUpdate;
 
+	int m_Type;
 	bool m_OnlineOnly;
 
 	struct STileLayerVisuals
@@ -156,8 +153,6 @@ public:
 	void RenderTileBorder(int LayerIndex, const ColorRGBA &Color, CMapItemLayerTilemap *pTileLayer, CMapItemGroup *pGroup, int BorderX0, int BorderY0, int BorderX1, int BorderY1);
 	void RenderKillTileBorder(int LayerIndex, const ColorRGBA &Color, CMapItemLayerTilemap *pTileLayer, CMapItemGroup *pGroup);
 	void RenderQuadLayer(int LayerIndex, CMapItemLayerQuads *pQuadLayer, CMapItemGroup *pGroup, bool ForceRender = false);
-
-	void EnvelopeUpdate();
 
 	static void EnvelopeEval(int TimeOffsetMillis, int Env, ColorRGBA &Result, size_t Channels, void *pUser);
 };

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -90,8 +90,6 @@ void CMenus::HandleDemoSeeking(float PositionToSeek, float TimeToSeek)
 		else
 			DemoPlayer()->SeekPercent(PositionToSeek);
 		m_pClient->m_SuppressEvents = false;
-		m_pClient->m_MapLayersBackground.EnvelopeUpdate();
-		m_pClient->m_MapLayersForeground.EnvelopeUpdate();
 		if(!DemoPlayer()->BaseInfo()->m_Paused && PositionToSeek == 1.0f)
 			DemoPlayer()->Pause();
 	}
@@ -103,8 +101,6 @@ void CMenus::DemoSeekTick(IDemoPlayer::ETickOffset TickOffset)
 	DemoPlayer()->SeekTick(TickOffset);
 	m_pClient->m_SuppressEvents = false;
 	DemoPlayer()->Pause();
-	m_pClient->m_MapLayersBackground.EnvelopeUpdate();
-	m_pClient->m_MapLayersForeground.EnvelopeUpdate();
 }
 
 void CMenus::RenderDemoPlayer(CUIRect MainView)


### PR DESCRIPTION
The additional code to evaluate envelopes during demo playback is obsolete, as client ticks are already properly synchronized with the demo playback.

From teeworlds/teeworlds#2750 and teeworlds/teeworlds#2768.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
