### PR TITLE
Add practice save/load commands

### DIFF
--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -893,6 +893,67 @@ void CGameContext::ConLoad(IConsole::IResult *pResult, void *pUserData)
 		pSelf->Score()->GetSaves(pResult->m_ClientId);
 }
 
+void CGameContext::ConPracticeSave(IConsole::IResult *pResult, void *pUserData)
+{
+	auto *pSelf = (CGameContext *)pUserData;
+	auto *pCaller = pSelf->GetPracticeCharacter(pResult);
+	if(!pCaller)
+		return;
+
+	int Team = pCaller->Team();
+
+	auto &Teams = pSelf->m_pController->Teams().m_Core;
+	for(int i = 0; i < MAX_CLIENTS; ++i)
+	{
+		auto *pPlayer = pSelf->m_apPlayers[i];
+		if(!pPlayer || Teams.Team(i) != Team)
+			continue;
+		auto *pChr = pPlayer->GetCharacter();
+		if(!pChr)
+			continue;
+
+		pPlayer->m_SavedPracticeTee.Save(pChr);
+	}
+}
+
+void CGameContext::ConPracticeLoad(IConsole::IResult *pResult, void *pUserData)
+{
+	auto *pSelf = (CGameContext *)pUserData;
+	auto *pCaller = pSelf->GetPracticeCharacter(pResult);
+	if(!pCaller)
+		return;
+
+	int Team = pCaller->Team();
+
+	auto &Teams = pSelf->m_pController->Teams().m_Core;
+	for(int i = 0; i < MAX_CLIENTS; ++i)
+	{
+		auto *pPlayer = pSelf->m_apPlayers[i];
+		if(!pPlayer || Teams.Team(i) != Team)
+			continue;
+		auto *pChr = pPlayer->GetCharacter();
+		if(!pChr)
+			continue;
+
+		if(!pPlayer->m_SavedPracticeTee.GetPos().x)
+		{
+			pSelf->SendChatTarget(pResult->m_ClientId, "You haven't previously saved. Use /savepractice before using this command.");
+			return;
+		}
+	}
+	for(int i = 0; i < MAX_CLIENTS; ++i)
+	{
+		auto *pPlayer = pSelf->m_apPlayers[i];
+		if(!pPlayer || Teams.Team(i) != Team)
+			continue;
+		auto *pChr = pPlayer->GetCharacter();
+		if(!pChr)
+			continue;
+		pPlayer->m_SavedPracticeTee.Load(pChr, Team, true);
+		pPlayer->Pause(CPlayer::PAUSE_NONE, true);
+	}
+}
+
 void CGameContext::ConTeamRank(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -130,6 +130,13 @@ bool CCharacter::Spawn(CPlayer *pPlayer, vec2 Pos)
 			delete GameServer()->m_apSavedTeleTees[m_pPlayer->GetCid()];
 			GameServer()->m_apSavedTeleTees[m_pPlayer->GetCid()] = nullptr;
 		}
+
+		if(GameServer()->m_apSavedSaveTees[m_pPlayer->GetCid()])
+		{
+			m_pPlayer->m_SavedPracticeTee = *GameServer()->m_apSavedSaveTees[m_pPlayer->GetCid()];
+			delete GameServer()->m_apSavedSaveTees[m_pPlayer->GetCid()];
+			GameServer()->m_apSavedSaveTees[m_pPlayer->GetCid()] = nullptr;
+		}
 	}
 
 	return true;

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -111,6 +111,9 @@ void CGameContext::Construct(int Resetting)
 		for(auto &pSavedTeleTee : m_apSavedTeleTees)
 			pSavedTeleTee = nullptr;
 
+		for(auto &pSavedSaveTee : m_apSavedSaveTees)
+			pSavedSaveTee = nullptr;
+
 		for(auto &pSavedTeam : m_apSavedTeams)
 			pSavedTeam = nullptr;
 
@@ -136,6 +139,9 @@ void CGameContext::Destruct(int Resetting)
 
 		for(auto &pSavedTeleTee : m_apSavedTeleTees)
 			delete pSavedTeleTee;
+
+		for(auto &pSavedSaveTee : m_apSavedSaveTees)
+			delete pSavedSaveTee;
 
 		for(auto &pSavedTeam : m_apSavedTeams)
 			delete pSavedTeam;
@@ -1720,6 +1726,9 @@ void CGameContext::OnClientDrop(int ClientId, const char *pReason)
 	delete m_apSavedTeleTees[ClientId];
 	m_apSavedTeleTees[ClientId] = nullptr;
 
+	delete m_apSavedSaveTees[ClientId];
+	m_apSavedSaveTees[ClientId] = nullptr;
+
 	m_aTeamMapping[ClientId] = -1;
 
 	m_VoteUpdate = true;
@@ -3223,7 +3232,10 @@ void CGameContext::ConHotReload(IConsole::IResult *pResult, void *pUserData)
 		pSelf->m_apSavedTees[i]->Save(pChar, false);
 
 		if(pSelf->m_apPlayers[i])
+		{
 			pSelf->m_apSavedTeleTees[i] = new CSaveTee(pSelf->m_apPlayers[i]->m_LastTeleTee);
+			pSelf->m_apSavedSaveTees[i] = new CSaveTee(pSelf->m_apPlayers[i]->m_SavedPracticeTee);
+		}
 
 		// Save the team state
 		pSelf->m_aTeamMapping[i] = pSelf->GetDDRaceTeam(i);
@@ -3832,6 +3844,8 @@ void CGameContext::RegisterChatCommands()
 	Console()->Register("endless", "", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeEndlessHook, this, "Gives you endless hook");
 	Console()->Register("unendless", "", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeUnEndlessHook, this, "Removes endless hook from you");
 	Console()->Register("invincible", "?i['0'|'1']", CFGFLAG_CHAT | CMDFLAG_PRACTICE, ConPracticeToggleInvincible, this, "Toggles invincible mode");
+	Console()->Register("savepractice", "", CFGFLAG_CHAT | CFGFLAG_SERVER | CMDFLAG_PRACTICE, ConPracticeSave, this, "Set lasttp for all players in team");
+	Console()->Register("loadpractice", "", CFGFLAG_CHAT | CFGFLAG_SERVER | CMDFLAG_PRACTICE, ConPracticeLoad, this, "Load lasttp for all players in team");
 	Console()->Register("kill", "", CFGFLAG_CHAT | CFGFLAG_SERVER, ConProtectedKill, this, "Kill yourself when kill-protected during a long game (use f1, kill for regular kill)");
 }
 

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -184,6 +184,7 @@ public:
 	CSaveTeam *m_apSavedTeams[MAX_CLIENTS];
 	CSaveTee *m_apSavedTees[MAX_CLIENTS];
 	CSaveTee *m_apSavedTeleTees[MAX_CLIENTS];
+	CSaveTee *m_apSavedSaveTees[MAX_CLIENTS];
 	int m_aTeamMapping[MAX_CLIENTS];
 
 	// returns last input if available otherwise nulled PlayerInput object
@@ -504,6 +505,8 @@ private:
 	static void ConPracticeEndlessHook(IConsole::IResult *pResult, void *pUserData);
 	static void ConPracticeUnEndlessHook(IConsole::IResult *pResult, void *pUserData);
 	static void ConPracticeToggleInvincible(IConsole::IResult *pResult, void *pUserData);
+	static void ConPracticeSave(IConsole::IResult *pResult, void *pUserData);
+	static void ConPracticeLoad(IConsole::IResult *pResult, void *pUserData);
 
 	static void ConPracticeAddWeapon(IConsole::IResult *pResult, void *pUserData);
 	static void ConPracticeRemoveWeapon(IConsole::IResult *pResult, void *pUserData);

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -230,6 +230,7 @@ public:
 	int m_RescueMode;
 
 	CSaveTee m_LastTeleTee;
+	CSaveTee m_SavedPracticeTee{};
 };
 
 #endif


### PR DESCRIPTION
Currently, `lasttp` is good for practice, but is insufficient when synchronization of multiple tees is required in a certain part of a map. This PR adds this functionality and provides players with a more convenient practice experience.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options (sv_solo_server)
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
