### PR TITLE
Preserve super on hot reload, fix hot reload crashes

### DIFF
--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -123,13 +123,6 @@ bool CCharacter::Spawn(CPlayer *pPlayer, vec2 Pos)
 			delete GameServer()->m_apSavedTees[m_pPlayer->GetCid()];
 			GameServer()->m_apSavedTees[m_pPlayer->GetCid()] = nullptr;
 		}
-
-		if(GameServer()->m_apSavedTeleTees[m_pPlayer->GetCid()])
-		{
-			m_pPlayer->m_LastTeleTee = *GameServer()->m_apSavedTeleTees[m_pPlayer->GetCid()];
-			delete GameServer()->m_apSavedTeleTees[m_pPlayer->GetCid()];
-			GameServer()->m_apSavedTeleTees[m_pPlayer->GetCid()] = nullptr;
-		}
 	}
 
 	return true;

--- a/src/game/server/entities/character.h
+++ b/src/game/server/entities/character.h
@@ -26,7 +26,9 @@ class CCharacter : public CEntity
 {
 	MACRO_ALLOC_POOL_ID()
 
-	friend class CSaveTee; // need to use core
+	// need to use core
+	friend class CSaveTee;
+	friend class CSaveHotReloadTee;
 
 public:
 	CCharacter(CGameWorld *pWorld, CNetObj_PlayerInput LastInput);

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -108,9 +108,6 @@ void CGameContext::Construct(int Resetting)
 		for(auto &pSavedTee : m_apSavedTees)
 			pSavedTee = nullptr;
 
-		for(auto &pSavedTeleTee : m_apSavedTeleTees)
-			pSavedTeleTee = nullptr;
-
 		for(auto &pSavedTeam : m_apSavedTeams)
 			pSavedTeam = nullptr;
 
@@ -133,9 +130,6 @@ void CGameContext::Destruct(int Resetting)
 	{
 		for(auto &pSavedTee : m_apSavedTees)
 			delete pSavedTee;
-
-		for(auto &pSavedTeleTee : m_apSavedTeleTees)
-			delete pSavedTeleTee;
 
 		for(auto &pSavedTeam : m_apSavedTeams)
 			delete pSavedTeam;
@@ -1717,9 +1711,6 @@ void CGameContext::OnClientDrop(int ClientId, const char *pReason)
 	delete m_apSavedTees[ClientId];
 	m_apSavedTees[ClientId] = nullptr;
 
-	delete m_apSavedTeleTees[ClientId];
-	m_apSavedTeleTees[ClientId] = nullptr;
-
 	m_aTeamMapping[ClientId] = -1;
 
 	m_VoteUpdate = true;
@@ -3219,11 +3210,8 @@ void CGameContext::ConHotReload(IConsole::IResult *pResult, void *pUserData)
 		CCharacter *pChar = pSelf->GetPlayerChar(i);
 
 		// Save the tee individually
-		pSelf->m_apSavedTees[i] = new CSaveTee();
+		pSelf->m_apSavedTees[i] = new CSaveHotReloadTee();
 		pSelf->m_apSavedTees[i]->Save(pChar, false);
-
-		if(pSelf->m_apPlayers[i])
-			pSelf->m_apSavedTeleTees[i] = new CSaveTee(pSelf->m_apPlayers[i]->m_LastTeleTee);
 
 		// Save the team state
 		pSelf->m_aTeamMapping[i] = pSelf->GetDDRaceTeam(i);

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -182,8 +182,7 @@ public:
 	CNetObj_PlayerInput m_aLastPlayerInput[MAX_CLIENTS];
 	bool m_aPlayerHasInput[MAX_CLIENTS];
 	CSaveTeam *m_apSavedTeams[MAX_CLIENTS];
-	CSaveTee *m_apSavedTees[MAX_CLIENTS];
-	CSaveTee *m_apSavedTeleTees[MAX_CLIENTS];
+	CSaveHotReloadTee *m_apSavedTees[MAX_CLIENTS];
 	int m_aTeamMapping[MAX_CLIENTS];
 
 	// returns last input if available otherwise nulled PlayerInput object

--- a/src/game/server/save.cpp
+++ b/src/game/server/save.cpp
@@ -482,6 +482,24 @@ bool CSaveTee::IsHooking() const
 	return m_HookState == HOOK_GRABBED || m_HookState == HOOK_FLYING;
 }
 
+void CSaveHotReloadTee::Save(CCharacter *pChr, bool AddPenalty)
+{
+	m_SaveTee.Save(pChr, AddPenalty);
+	m_Super = pChr->m_Core.m_Super;
+	m_Invincible = pChr->m_Core.m_Invincible;
+	m_SavedTeleTee = pChr->m_pPlayer->m_LastTeleTee;
+}
+
+bool CSaveHotReloadTee::Load(CCharacter *pChr, int Team, bool IsSwap)
+{
+	bool Result = m_SaveTee.Load(pChr, Team, IsSwap);
+	pChr->SetSuper(m_Super);
+	pChr->SetInvincible(m_Invincible);
+	pChr->GetPlayer()->m_LastTeleTee = m_SavedTeleTee;
+
+	return Result;
+}
+
 CSaveTeam::CSaveTeam()
 {
 	m_aString[0] = '\0';
@@ -507,7 +525,7 @@ ESaveResult CSaveTeam::Save(CGameContext *pGameServer, int Team, bool Dry, bool 
 	}
 
 	m_MembersCount = pTeams->Count(Team);
-	if(m_MembersCount <= 0 && !Force)
+	if(m_MembersCount <= 0)
 	{
 		return ESaveResult::TEAM_NOT_FOUND;
 	}
@@ -529,7 +547,7 @@ ESaveResult CSaveTeam::Save(CGameContext *pGameServer, int Team, bool Dry, bool 
 	CCharacter *p = (CCharacter *)pGameServer->m_World.FindFirst(CGameWorld::ENTTYPE_CHARACTER);
 	for(; p; p = (CCharacter *)p->TypeNext())
 	{
-		if(pTeams->m_Core.Team(p->GetPlayer()->GetCid()) != Team && !Force)
+		if(pTeams->m_Core.Team(p->GetPlayer()->GetCid()) != Team)
 			continue;
 		if(m_MembersCount == j && !Force)
 			return ESaveResult::CHAR_NOT_FOUND;

--- a/src/game/server/save.h
+++ b/src/game/server/save.h
@@ -148,6 +148,21 @@ private:
 	char m_aGameUuid[UUID_MAXSTRSIZE];
 };
 
+class CSaveHotReloadTee
+{
+public:
+	CSaveHotReloadTee() = default;
+	~CSaveHotReloadTee() = default;
+	void Save(CCharacter *pChr, bool AddPenalty = true);
+	bool Load(CCharacter *pChr, int Team, bool IsSwap = false);
+
+private:
+	CSaveTee m_SaveTee;
+	bool m_Super;
+	bool m_Invincible;
+	CSaveTee m_SavedTeleTee;
+};
+
 class CSaveTeam
 {
 public:


### PR DESCRIPTION
Fixes #9156 for both super and /invincible

Fixed a crash when in super with an empty previous team and when players were on a different teams during hot reload

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
