### PR TITLE
Fix top5team sql

### DIFF
--- a/src/game/server/scoreworker.cpp
+++ b/src/game/server/scoreworker.cpp
@@ -1126,7 +1126,7 @@ bool CScoreWorker::ShowTeamTop5(IDbConnection *pSqlServer, const ISqlData *pGame
 		"    SELECT RANK() OVER w AS Ranking, COUNT(*) AS Teamsize, Id, Server "
 		"    FROM ("
 		"      SELECT tr.Map, tr.Time, tr.Id, rr.Server FROM %s_teamrace as tr "
-		"      INNER JOIN %s_race as rr ON tr.Map = rr.Map AND tr.Name = rr.Name AND tr.Time = rr.Time AND tr.Timestamp = rr.Timestamp"
+		"      INNER JOIN %s_race as rr ON tr.Map = rr.Map AND tr.Name = rr.Name AND tr.Time = rr.Time"
 		"    ) AS ll "
 		"    WHERE Map = ? "
 		"    GROUP BY ID "


### PR DESCRIPTION
It was possible for the race record to be saved at the very last millisecond, causing the timerace to have a different timestamp. Now, the query matches the one from the website: https://github.com/ddnet/ddnet-scripts/blob/182df7c68408f3af443852429720133692c623d6/servers/scripts/maps.py#L37

Tested with many maps on https://db.ddstats.org/ It was rarely off by 1-3 records, likely because the database isn't up to date. It would be best if someone could check with the updated database.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
