### PR TITLE
Avoid redundant overwriting of texture handles after unloading

### DIFF
--- a/src/game/client/components/mapimages.cpp
+++ b/src/game/client/components/mapimages.cpp
@@ -357,13 +357,8 @@ void CMapImages::ChangeEntitiesPath(const char *pPath)
 		{
 			for(int LayerType = 0; LayerType < MAP_IMAGE_ENTITY_LAYER_TYPE_COUNT; ++LayerType)
 			{
-				if(m_aaEntitiesTextures[ModType][LayerType].IsValid())
-				{
-					Graphics()->UnloadTexture(&(m_aaEntitiesTextures[ModType][LayerType]));
-				}
-				m_aaEntitiesTextures[ModType][LayerType] = IGraphics::CTextureHandle();
+				Graphics()->UnloadTexture(&m_aaEntitiesTextures[ModType][LayerType]);
 			}
-
 			m_aEntitiesIsLoaded[ModType] = false;
 		}
 	}
@@ -382,10 +377,6 @@ void CMapImages::SetTextureScale(int Scale)
 		Graphics()->UnloadTexture(&m_OverlayBottomTexture);
 		Graphics()->UnloadTexture(&m_OverlayTopTexture);
 		Graphics()->UnloadTexture(&m_OverlayCenterTexture);
-
-		m_OverlayBottomTexture = IGraphics::CTextureHandle();
-		m_OverlayTopTexture = IGraphics::CTextureHandle();
-		m_OverlayCenterTexture = IGraphics::CTextureHandle();
 
 		InitOverlayTextures();
 	}

--- a/src/game/client/components/menus_settings_assets.cpp
+++ b/src/game/client/components/menus_settings_assets.cpp
@@ -249,11 +249,9 @@ static const CMenus::SCustomItem *GetCustomItem(int CurTab, size_t Index)
 template<typename TName>
 void ClearAssetList(std::vector<TName> &vList, IGraphics *pGraphics)
 {
-	for(size_t i = 0; i < vList.size(); ++i)
+	for(TName &Asset : vList)
 	{
-		if(vList[i].m_RenderTexture.IsValid())
-			pGraphics->UnloadTexture(&(vList[i].m_RenderTexture));
-		vList[i].m_RenderTexture = IGraphics::CTextureHandle();
+		pGraphics->UnloadTexture(&Asset.m_RenderTexture);
 	}
 	vList.clear();
 }
@@ -266,9 +264,7 @@ void CMenus::ClearCustomItems(int CurTab)
 		{
 			for(auto &Image : Entity.m_aImages)
 			{
-				if(Image.m_Texture.IsValid())
-					Graphics()->UnloadTexture(&Image.m_Texture);
-				Image.m_Texture = IGraphics::CTextureHandle();
+				Graphics()->UnloadTexture(&Image.m_Texture);
 			}
 		}
 		m_vEntitiesList.clear();


### PR DESCRIPTION
It's not necessary to create a new `CTextureHandle` object after unloading the handle and it's also not necessary to check if the texture handle is valid when unloading it.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
