### PR TITLE
Remove obsolete `IConsole::Format` function, fix `show_ips` output

### DIFF
--- a/src/engine/console.h
+++ b/src/engine/console.h
@@ -83,7 +83,6 @@ public:
 	};
 
 	typedef void (*FTeeHistorianCommandCallback)(int ClientId, int FlagMask, const char *pCmd, IResult *pResult, void *pUser);
-	typedef void (*FPrintCallback)(const char *pStr, void *pUser, ColorRGBA PrintColor);
 	typedef void (*FPossibleCallback)(int Index, const char *pCmd, void *pUser);
 	typedef void (*FCommandCallback)(IResult *pResult, void *pUserData);
 	typedef void (*FChainCommandCallback)(IResult *pResult, void *pUserData, FCommandCallback pfnCallback, void *pCallbackUserData);
@@ -111,7 +110,6 @@ public:
 	virtual void ExecuteLineStroked(int Stroke, const char *pStr, int ClientId = -1, bool InterpretSemicolons = true) = 0;
 	virtual bool ExecuteFile(const char *pFilename, int ClientId = -1, bool LogFailure = false, int StorageType = IStorage::TYPE_ALL) = 0;
 
-	virtual char *Format(char *pBuf, int Size, const char *pFrom, const char *pStr) = 0;
 	virtual void Print(int Level, const char *pFrom, const char *pStr, ColorRGBA PrintColor = gs_ConsoleDefaultColor) const = 0;
 	virtual void SetTeeHistorianCommandCallback(FTeeHistorianCommandCallback pfnCallback, void *pUser) = 0;
 	virtual void SetUnknownCommandCallback(FUnknownCommandCallback pfnCallback, void *pUser) = 0;

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -3548,8 +3548,7 @@ void CServer::ConShowIps(IConsole::IResult *pResult, void *pUser)
 		{
 			char aStr[9];
 			str_format(aStr, sizeof(aStr), "Value: %d", pServer->m_aClients[pServer->m_RconClientId].m_ShowIps);
-			char aBuf[32];
-			pServer->SendRconLine(pServer->m_RconClientId, pServer->Console()->Format(aBuf, sizeof(aBuf), "server", aStr));
+			pServer->Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "server", aStr);
 		}
 	}
 }

--- a/src/engine/shared/console.cpp
+++ b/src/engine/shared/console.cpp
@@ -293,15 +293,6 @@ char CConsole::NextParam(const char *&pFormat)
 	return *pFormat;
 }
 
-char *CConsole::Format(char *pBuf, int Size, const char *pFrom, const char *pStr)
-{
-	char aTimeBuf[80];
-	str_timestamp_format(aTimeBuf, sizeof(aTimeBuf), FORMAT_TIME);
-
-	str_format(pBuf, Size, "[%s][%s]: %s", aTimeBuf, pFrom, pStr);
-	return pBuf;
-}
-
 LEVEL IConsole::ToLogLevel(int Level)
 {
 	switch(Level)

--- a/src/engine/shared/console.h
+++ b/src/engine/shared/console.h
@@ -220,7 +220,6 @@ public:
 	void ExecuteLineFlag(const char *pStr, int FlagMask, int ClientId = -1, bool InterpretSemicolons = true) override;
 	bool ExecuteFile(const char *pFilename, int ClientId = -1, bool LogFailure = false, int StorageType = IStorage::TYPE_ALL) override;
 
-	char *Format(char *pBuf, int Size, const char *pFrom, const char *pStr) override;
 	void Print(int Level, const char *pFrom, const char *pStr, ColorRGBA PrintColor = gs_ConsoleDefaultColor) const override;
 	void SetTeeHistorianCommandCallback(FTeeHistorianCommandCallback pfnCallback, void *pUser) override;
 	void SetUnknownCommandCallback(FUnknownCommandCallback pfnCallback, void *pUser) override;


### PR DESCRIPTION
The `IConsole::Format` function was previously used to format the log and rcon output, but it has become obsolete when the logging was refactored.

The function was still being used to format the output of the `show_ips` command in the rcon, which was causing this particular rcon line to have the old log format (e.g. `[12:34:56][server]: Value: 0`). Now, `IConsole::Print` is used directly, as this causes the output to be sent with the correct format and only to the rcon command user.

The `IConsole::FPrintCallback` function pointer typedef is also obsolete and unused.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
