### PR TITLE
Add `log_*_color` macros, deprecate `IConsole::Print`

### DIFF
--- a/src/base/log.h
+++ b/src/base/log.h
@@ -32,6 +32,12 @@ struct LOG_COLOR
 #define log_debug(sys, ...) log_log(LEVEL_DEBUG, sys, __VA_ARGS__)
 #define log_trace(sys, ...) log_log(LEVEL_TRACE, sys, __VA_ARGS__)
 
+#define log_error_color(color, sys, ...) log_log_color(LEVEL_ERROR, color, sys, __VA_ARGS__)
+#define log_warn_color(color, sys, ...) log_log_color(LEVEL_WARN, color, sys, __VA_ARGS__)
+#define log_info_color(color, sys, ...) log_log_color(LEVEL_INFO, color, sys, __VA_ARGS__)
+#define log_debug_color(color, sys, ...) log_log_color(LEVEL_DEBUG, color, sys, __VA_ARGS__)
+#define log_trace_color(color, sys, ...) log_log_color(LEVEL_TRACE, color, sys, __VA_ARGS__)
+
 /**
  * @defgroup Log
  *

--- a/src/engine/console.h
+++ b/src/engine/console.h
@@ -110,6 +110,12 @@ public:
 	virtual void ExecuteLineStroked(int Stroke, const char *pStr, int ClientId = -1, bool InterpretSemicolons = true) = 0;
 	virtual bool ExecuteFile(const char *pFilename, int ClientId = -1, bool LogFailure = false, int StorageType = IStorage::TYPE_ALL) = 0;
 
+	/**
+	 * @deprecated Prefer using the `log_*` functions from base/log.h instead of this function for the following reasons:
+	 * - They support `printf`-formatting without a separate buffer.
+	 * - They support all five log levels.
+	 * - They do not require a pointer to `IConsole` to be used.
+	 */
 	virtual void Print(int Level, const char *pFrom, const char *pStr, ColorRGBA PrintColor = gs_ConsoleDefaultColor) const = 0;
 	virtual void SetTeeHistorianCommandCallback(FTeeHistorianCommandCallback pfnCallback, void *pUser) = 0;
 	virtual void SetUnknownCommandCallback(FUnknownCommandCallback pfnCallback, void *pUser) = 0;


### PR DESCRIPTION
Add `log_error_color`, `log_warn_color`, `log_info_color`, `log_debug_color` and `log_trace_color` macros to wrap `log_log_color` function with specific log levels.

Add comment to mark the `IConsole::Print` function as deprecated in favor of the `log_*` functions, which should be preferred for the following reasons:

- They support `printf`-formatting without a separate buffer.
- They support all five log levels.
- They do not require a pointer to `IConsole` to be used.
- Consistency of logging code.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
