### PR TITLE
Ensure file is moved when `fs_rename` function returns on Windows

### DIFF
--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -2484,7 +2484,7 @@ int fs_rename(const char *oldname, const char *newname)
 #if defined(CONF_FAMILY_WINDOWS)
 	const std::wstring wide_oldname = windows_utf8_to_wide(oldname);
 	const std::wstring wide_newname = windows_utf8_to_wide(newname);
-	if(MoveFileExW(wide_oldname.c_str(), wide_newname.c_str(), MOVEFILE_REPLACE_EXISTING | MOVEFILE_COPY_ALLOWED) == 0)
+	if(MoveFileExW(wide_oldname.c_str(), wide_newname.c_str(), MOVEFILE_REPLACE_EXISTING | MOVEFILE_COPY_ALLOWED | MOVEFILE_WRITE_THROUGH) == 0)
 		return 1;
 #else
 	if(rename(oldname, newname) != 0)


### PR DESCRIPTION
Use the flag `MOVEFILE_WRITE_THROUGH` with the `MoveFileExW` function on Windows to ensure that the file is renamed/moved on the disk before the function returns. Otherwise, if the function returns before the file is moved, subsequent loading of the file with this name may fail sporadically.

See https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-movefileexw

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
