### PR TITLE
mastersrv: Add DDPer support

### DIFF
--- a/src/mastersrv/src/addr.rs
+++ b/src/mastersrv/src/addr.rs
@@ -11,6 +11,7 @@ pub enum Protocol {
     V5,
     V6,
     V7,
+    Ddper6,
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
@@ -41,7 +42,7 @@ pub struct UnknownProtocol;
 
 impl fmt::Display for UnknownProtocol {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        "protocol must be one of tw-0.5+udp, tw-0.6+udp or tw-0.7+udp".fmt(f)
+        "protocol must be one of tw-0.5+udp, tw-0.6+udp, tw-0.7+udp or ddper-0.6+udp".fmt(f)
     }
 }
 
@@ -53,6 +54,7 @@ impl FromStr for Protocol {
             "tw-0.5+udp" => V5,
             "tw-0.6+udp" => V6,
             "tw-0.7+udp" => V7,
+            "ddper-0.6+udp" => Ddper6,
             _ => return Err(UnknownProtocol),
         })
     }
@@ -73,7 +75,7 @@ impl<'de> serde::de::Visitor<'de> for ProtocolVisitor {
     type Value = Protocol;
 
     fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str("one of \"tw-0.5+udp\", \"tw-0.6+udp\" and \"tw-0.7+udp\"")
+        f.write_str("one of \"tw-0.5+udp\", \"tw-0.6+udp\", \"tw-0.7+udp\" and \"ddper-0.6+udp\"")
     }
     fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Protocol, E> {
         let invalid_value = || E::invalid_value(serde::de::Unexpected::Str(v), &self);
@@ -97,6 +99,7 @@ impl Protocol {
             V5 => "tw-0.5+udp",
             V6 => "tw-0.6+udp",
             V7 => "tw-0.7+udp",
+            Ddper6 => "ddper-0.6+udp",
         }
     }
 }

--- a/src/mastersrv/src/main.rs
+++ b/src/mastersrv/src/main.rs
@@ -695,6 +695,7 @@ fn handle_register(
             })?;
             Some(token)
         }
+        Protocol::Ddper6 => None,
     };
 
     let addr = register.address.with_ip(remote_addr);


### PR DESCRIPTION
This allows DDPer to continue using our mastersrv while not showing up in the DDNet client.

## Checklist

- [x] Tested the change ~~ingame~~
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
