### PR TITLE
Fix vanilla demo tuning

### DIFF
--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -950,6 +950,7 @@ void CGameClient::OnMessage(int MsgId, CUnpacker *pUnpacker, int Conn, bool Dumm
 		m_aReceivedTuning[Conn] = true;
 		// apply new tuning
 		m_aTuning[Conn] = NewTuning;
+		TuningList()[0] = NewTuning;
 		return;
 	}
 
@@ -3799,6 +3800,13 @@ void CGameClient::LoadMapSettings()
 	for(int i = 0; i < NUM_TUNEZONES; i++)
 	{
 		TuningList()[i] = TuningParams;
+
+		// only hardcode ddrace tuning for the tune zones
+		// and not the base tuning
+		// that one will be sent by the server if needed
+		if(!i)
+			continue;
+
 		TuningList()[i].Set("gun_curvature", 0);
 		TuningList()[i].Set("gun_speed", 1400);
 		TuningList()[i].Set("shotgun_curvature", 0);


### PR DESCRIPTION
On the current master everything looks good in game. But demos with vanilla tuned weapons are broken.

# before

ddrace demos displayed the tunings correctly.

https://github.com/user-attachments/assets/fc8572b1-d02e-4514-84b6-e5a1dc6b4238

vanilla demos had a broken shotgun.

https://github.com/user-attachments/assets/d4cda237-b0bf-407f-8f8a-b98c338d4331

# after

ddrace demos still work fine. And in game as well. Tested with ``cl_antiping 0`` and ``cl_antiping 1`` with tune zones and crazy shotgun.

https://github.com/user-attachments/assets/2eb966ff-ed99-451a-83c1-745afb98f81a

and vanilla shotgun is fixed in demos now.

https://github.com/user-attachments/assets/e8c6fdcd-1698-4110-9d7d-da86a0135af5




## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
