### PR TITLE
Use `std::vector` for console execution queue, fix console result client ID sometimes being uninitialized

### DIFF
--- a/src/engine/console.h
+++ b/src/engine/console.h
@@ -50,6 +50,9 @@ public:
 		IResult(int ClientId) :
 			m_NumArgs(0),
 			m_ClientId(ClientId) {}
+		IResult(const IResult &Other) :
+			m_NumArgs(Other.m_NumArgs),
+			m_ClientId(Other.m_ClientId) {}
 		virtual ~IResult() {}
 
 		virtual int GetInteger(unsigned Index) const = 0;

--- a/src/engine/console.h
+++ b/src/engine/console.h
@@ -47,7 +47,9 @@ public:
 		unsigned m_NumArgs;
 
 	public:
-		IResult() { m_NumArgs = 0; }
+		IResult(int ClientId) :
+			m_NumArgs(0),
+			m_ClientId(ClientId) {}
 		virtual ~IResult() {}
 
 		virtual int GetInteger(unsigned Index) const = 0;

--- a/src/engine/shared/console.cpp
+++ b/src/engine/shared/console.cpp
@@ -376,7 +376,7 @@ bool CConsole::LineIsValid(const char *pStr)
 
 	do
 	{
-		CResult Result;
+		CResult Result(-1);
 		const char *pEnd = pStr;
 		const char *pNextPart = 0;
 		int InString = 0;
@@ -427,8 +427,7 @@ void CConsole::ExecuteLineStroked(int Stroke, const char *pStr, int ClientId, bo
 	}
 	while(pStr && *pStr)
 	{
-		CResult Result;
-		Result.m_ClientId = ClientId;
+		CResult Result(ClientId);
 		const char *pEnd = pStr;
 		const char *pNextPart = 0;
 		int InString = 0;
@@ -754,7 +753,7 @@ void CConsole::ConCommandStatus(IResult *pResult, void *pUser)
 void CConsole::ConUserCommandStatus(IResult *pResult, void *pUser)
 {
 	CConsole *pConsole = static_cast<CConsole *>(pUser);
-	CResult Result;
+	CResult Result(pResult->m_ClientId);
 	Result.m_pCommand = "access_status";
 	char aBuf[4];
 	str_format(aBuf, sizeof(aBuf), "%d", (int)IConsole::ACCESS_LEVEL_USER);

--- a/src/engine/shared/console.cpp
+++ b/src/engine/shared/console.cpp
@@ -522,9 +522,7 @@ void CConsole::ExecuteLineStroked(int Stroke, const char *pStr, int ClientId, bo
 					}
 					else if(m_StoreCommands && pCommand->m_Flags & CFGFLAG_STORE)
 					{
-						m_ExecutionQueue.AddEntry();
-						m_ExecutionQueue.m_pLast->m_pCommand = pCommand;
-						m_ExecutionQueue.m_pLast->m_Result = Result;
+						m_vExecutionQueue.emplace_back(pCommand, Result);
 					}
 					else
 					{
@@ -781,7 +779,6 @@ CConsole::CConsole(int FlagMask)
 	m_StoreCommands = true;
 	m_apStrokeStr[0] = "0";
 	m_apStrokeStr[1] = "1";
-	m_ExecutionQueue.Reset();
 	m_pFirstCommand = 0;
 	m_pFirstExec = 0;
 	m_pfnTeeHistorianCommandCallback = 0;
@@ -1030,9 +1027,11 @@ void CConsole::StoreCommands(bool Store)
 {
 	if(!Store)
 	{
-		for(CExecutionQueue::CQueueEntry *pEntry = m_ExecutionQueue.m_pFirst; pEntry; pEntry = pEntry->m_pNext)
-			pEntry->m_pCommand->m_pfnCallback(&pEntry->m_Result, pEntry->m_pCommand->m_pUserData);
-		m_ExecutionQueue.Reset();
+		for(CExecutionQueueEntry &Entry : m_vExecutionQueue)
+		{
+			Entry.m_pCommand->m_pfnCallback(&Entry.m_Result, Entry.m_pCommand->m_pUserData);
+		}
+		m_vExecutionQueue.clear();
 	}
 	m_StoreCommands = Store;
 }

--- a/src/engine/shared/console.h
+++ b/src/engine/shared/console.h
@@ -84,8 +84,8 @@ class CConsole : public IConsole
 		const char *m_pCommand;
 		const char *m_apArgs[MAX_PARTS];
 
-		CResult()
-
+		CResult(int ClientId) :
+			IResult(ClientId)
 		{
 			mem_zero(m_aStringStorage, sizeof(m_aStringStorage));
 			m_pArgsStart = 0;

--- a/src/engine/shared/console.h
+++ b/src/engine/shared/console.h
@@ -93,18 +93,14 @@ class CConsole : public IConsole
 			mem_zero(m_apArgs, sizeof(m_apArgs));
 		}
 
-		CResult &operator=(const CResult &Other)
+		CResult(const CResult &Other) :
+			IResult(Other)
 		{
-			if(this != &Other)
-			{
-				IResult::operator=(Other);
-				mem_copy(m_aStringStorage, Other.m_aStringStorage, sizeof(m_aStringStorage));
-				m_pArgsStart = m_aStringStorage + (Other.m_pArgsStart - Other.m_aStringStorage);
-				m_pCommand = m_aStringStorage + (Other.m_pCommand - Other.m_aStringStorage);
-				for(unsigned i = 0; i < Other.m_NumArgs; ++i)
-					m_apArgs[i] = m_aStringStorage + (Other.m_apArgs[i] - Other.m_aStringStorage);
-			}
-			return *this;
+			mem_copy(m_aStringStorage, Other.m_aStringStorage, sizeof(m_aStringStorage));
+			m_pArgsStart = m_aStringStorage + (Other.m_pArgsStart - Other.m_aStringStorage);
+			m_pCommand = m_aStringStorage + (Other.m_pCommand - Other.m_aStringStorage);
+			for(unsigned i = 0; i < Other.m_NumArgs; ++i)
+				m_apArgs[i] = m_aStringStorage + (Other.m_apArgs[i] - Other.m_aStringStorage);
 		}
 
 		void AddArgument(const char *pArg)
@@ -163,35 +159,16 @@ class CConsole : public IConsole
 	*/
 	char NextParam(const char *&pFormat);
 
-	class CExecutionQueue
+	class CExecutionQueueEntry
 	{
-		CHeap m_Queue;
-
 	public:
-		struct CQueueEntry
-		{
-			CQueueEntry *m_pNext;
-			CCommand *m_pCommand;
-			CResult m_Result;
-		} * m_pFirst, *m_pLast;
-
-		void AddEntry()
-		{
-			CQueueEntry *pEntry = m_Queue.Allocate<CQueueEntry>();
-			pEntry->m_pNext = 0;
-			if(!m_pFirst)
-				m_pFirst = pEntry;
-			if(m_pLast)
-				m_pLast->m_pNext = pEntry;
-			m_pLast = pEntry;
-			(void)new(&(pEntry->m_Result)) CResult;
-		}
-		void Reset()
-		{
-			m_Queue.Reset();
-			m_pFirst = m_pLast = 0;
-		}
-	} m_ExecutionQueue;
+		CCommand *m_pCommand;
+		CResult m_Result;
+		CExecutionQueueEntry(CCommand *pCommand, CResult Result) :
+			m_pCommand(pCommand),
+			m_Result(Result) {}
+	};
+	std::vector<CExecutionQueueEntry> m_vExecutionQueue;
 
 	void AddCommandSorted(CCommand *pCommand);
 	CCommand *FindCommand(const char *pName, int FlagMask);


### PR DESCRIPTION
Simplify the code by replacing the usage of a linked list and heap with an `std::vector`.

The assignment operators are replaced with copy constructors to use `std::vector`.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
