### PR TITLE
Improve ghost file validation

### DIFF
--- a/src/engine/client/ghost.cpp
+++ b/src/engine/client/ghost.cpp
@@ -1,8 +1,8 @@
 #include "ghost.h"
 
+#include <base/log.h>
 #include <base/system.h>
 
-#include <engine/console.h>
 #include <engine/shared/compression.h>
 #include <engine/shared/config.h>
 #include <engine/shared/network.h>
@@ -10,33 +10,52 @@
 
 static const unsigned char gs_aHeaderMarker[8] = {'T', 'W', 'G', 'H', 'O', 'S', 'T', 0};
 static const unsigned char gs_CurVersion = 6;
-static const int gs_NumTicksOffset = 93;
 
-static const ColorRGBA gs_GhostPrintColor{0.65f, 0.6f, 0.6f, 1.0f};
+static const LOG_COLOR LOG_COLOR_GHOST{165, 153, 153};
+
+int CGhostHeader::GetTicks() const
+{
+	return bytes_be_to_uint(m_aNumTicks);
+}
+
+int CGhostHeader::GetTime() const
+{
+	return bytes_be_to_uint(m_aTime);
+}
+
+CGhostInfo CGhostHeader::ToGhostInfo() const
+{
+	CGhostInfo Result;
+	str_copy(Result.m_aOwner, m_aOwner);
+	str_copy(Result.m_aMap, m_aMap);
+	Result.m_NumTicks = GetTicks();
+	Result.m_Time = GetTime();
+	return Result;
+}
 
 CGhostRecorder::CGhostRecorder()
 {
 	m_File = 0;
+	m_aFilename[0] = '\0';
 	ResetBuffer();
 }
 
 void CGhostRecorder::Init()
 {
-	m_pConsole = Kernel()->RequestInterface<IConsole>();
 	m_pStorage = Kernel()->RequestInterface<IStorage>();
 }
 
-// Record
-int CGhostRecorder::Start(const char *pFilename, const char *pMap, SHA256_DIGEST MapSha256, const char *pName)
+int CGhostRecorder::Start(const char *pFilename, const char *pMap, const SHA256_DIGEST &MapSha256, const char *pName)
 {
+	dbg_assert(!m_File, "File already open");
+
 	m_File = m_pStorage->OpenFile(pFilename, IOFLAG_WRITE, IStorage::TYPE_SAVE);
 	if(!m_File)
 	{
-		char aBuf[256];
-		str_format(aBuf, sizeof(aBuf), "Unable to open '%s' for ghost recording", pFilename);
-		m_pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "ghost_recorder", aBuf, gs_GhostPrintColor);
+		log_info_color(LOG_COLOR_GHOST, "ghost_recorder", "Unable to open '%s' for recording", pFilename);
 		return -1;
 	}
+	str_copy(m_aFilename, pFilename);
 
 	// write header
 	CGhostHeader Header;
@@ -51,19 +70,18 @@ int CGhostRecorder::Start(const char *pFilename, const char *pMap, SHA256_DIGEST
 	m_LastItem.Reset();
 	ResetBuffer();
 
-	char aBuf[256];
-	str_format(aBuf, sizeof(aBuf), "ghost recording to '%s'", pFilename);
-	m_pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "ghost_recorder", aBuf, gs_GhostPrintColor);
+	log_info_color(LOG_COLOR_GHOST, "ghost_recorder", "Recording to '%s'", pFilename);
 	return 0;
 }
 
 void CGhostRecorder::ResetBuffer()
 {
 	m_pBufferPos = m_aBuffer;
+	m_pBufferEnd = m_aBuffer;
 	m_BufferNumItems = 0;
 }
 
-static void DiffItem(int *pPast, int *pCurrent, int *pOut, int Size)
+static void DiffItem(const int32_t *pPast, const int32_t *pCurrent, int32_t *pOut, size_t Size)
 {
 	while(Size)
 	{
@@ -75,16 +93,23 @@ static void DiffItem(int *pPast, int *pCurrent, int *pOut, int Size)
 	}
 }
 
-void CGhostRecorder::WriteData(int Type, const void *pData, int Size)
+void CGhostRecorder::WriteData(int Type, const void *pData, size_t Size)
 {
-	if(!m_File || (unsigned)Size > MAX_ITEM_SIZE || Size <= 0 || Type == -1)
-		return;
+	dbg_assert((bool)m_File, "File not open");
+	dbg_assert(Type >= 0 && Type <= (int)std::numeric_limits<unsigned char>::max(), "Type invalid");
+	dbg_assert(Size > 0 && Size <= MAX_ITEM_SIZE && Size % sizeof(int32_t) == 0, "Size invalid");
+
+	if((size_t)(m_pBufferEnd - m_pBufferPos) < Size)
+	{
+		FlushChunk();
+	}
 
 	CGhostItem Data(Type);
 	mem_copy(Data.m_aData, pData, Size);
-
 	if(m_LastItem.m_Type == Data.m_Type)
-		DiffItem((int *)m_LastItem.m_aData, (int *)Data.m_aData, (int *)m_pBufferPos, Size / sizeof(int32_t));
+	{
+		DiffItem((const int32_t *)m_LastItem.m_aData, (const int32_t *)Data.m_aData, (int32_t *)m_pBufferPos, Size / sizeof(int32_t));
+	}
 	else
 	{
 		FlushChunk();
@@ -95,235 +120,313 @@ void CGhostRecorder::WriteData(int Type, const void *pData, int Size)
 	m_pBufferPos += Size;
 	m_BufferNumItems++;
 	if(m_BufferNumItems >= NUM_ITEMS_PER_CHUNK)
+	{
 		FlushChunk();
+	}
 }
 
 void CGhostRecorder::FlushChunk()
 {
-	static char s_aBuffer[MAX_ITEM_SIZE * NUM_ITEMS_PER_CHUNK];
-	static char s_aBuffer2[MAX_ITEM_SIZE * NUM_ITEMS_PER_CHUNK];
-	unsigned char aChunk[4];
+	dbg_assert((bool)m_File, "File not open");
 
 	int Size = m_pBufferPos - m_aBuffer;
-	int Type = m_LastItem.m_Type;
-
-	if(!m_File || Size == 0)
+	if(Size == 0 || m_BufferNumItems == 0)
+	{
 		return;
+	}
+	dbg_assert(Size % sizeof(int32_t) == 0, "Chunk size invalid");
 
-	while(Size & 3)
-		m_aBuffer[Size++] = 0;
-
-	Size = CVariableInt::Compress(m_aBuffer, Size, s_aBuffer, sizeof(s_aBuffer));
+	Size = CVariableInt::Compress(m_aBuffer, Size, m_aBufferTemp, sizeof(m_aBufferTemp));
 	if(Size < 0)
+	{
+		log_info_color(LOG_COLOR_GHOST, "ghost_recorder", "Failed to write chunk to '%s': error during intpack compression", m_aFilename);
+		m_LastItem.Reset();
+		ResetBuffer();
 		return;
+	}
 
-	Size = CNetBase::Compress(s_aBuffer, Size, s_aBuffer2, sizeof(s_aBuffer2));
+	Size = CNetBase::Compress(m_aBufferTemp, Size, m_aBuffer, sizeof(m_aBuffer));
 	if(Size < 0)
+	{
+		log_info_color(LOG_COLOR_GHOST, "ghost_recorder", "Failed to write chunk to '%s': error during network compression", m_aFilename);
+		m_LastItem.Reset();
+		ResetBuffer();
 		return;
+	}
 
-	aChunk[0] = Type & 0xff;
-	aChunk[1] = m_BufferNumItems & 0xff;
-	aChunk[2] = (Size >> 8) & 0xff;
-	aChunk[3] = (Size)&0xff;
+	unsigned char aChunkHeader[4];
+	aChunkHeader[0] = m_LastItem.m_Type & 0xff;
+	aChunkHeader[1] = m_BufferNumItems & 0xff;
+	aChunkHeader[2] = (Size >> 8) & 0xff;
+	aChunkHeader[3] = Size & 0xff;
 
-	io_write(m_File, aChunk, sizeof(aChunk));
-	io_write(m_File, s_aBuffer2, Size);
+	io_write(m_File, aChunkHeader, sizeof(aChunkHeader));
+	io_write(m_File, m_aBuffer, Size);
 
 	m_LastItem.Reset();
 	ResetBuffer();
 }
 
-int CGhostRecorder::Stop(int Ticks, int Time)
+void CGhostRecorder::Stop(int Ticks, int Time)
 {
 	if(!m_File)
-		return -1;
+	{
+		return;
+	}
 
-	m_pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "ghost_recorder", "Stopped ghost recording", gs_GhostPrintColor);
+	const bool DiscardFile = Ticks <= 0 || Time <= 0;
 
-	FlushChunk();
+	if(!DiscardFile)
+	{
+		FlushChunk();
 
-	// write down num shots and time
-	io_seek(m_File, gs_NumTicksOffset, IOSEEK_START);
+		// write number of ticks and time
+		io_seek(m_File, offsetof(CGhostHeader, m_aNumTicks), IOSEEK_START);
 
-	unsigned char aNumTicks[sizeof(int32_t)];
-	uint_to_bytes_be(aNumTicks, Ticks);
-	io_write(m_File, aNumTicks, sizeof(aNumTicks));
+		unsigned char aNumTicks[sizeof(int32_t)];
+		uint_to_bytes_be(aNumTicks, Ticks);
+		io_write(m_File, aNumTicks, sizeof(aNumTicks));
 
-	unsigned char aTime[sizeof(int32_t)];
-	uint_to_bytes_be(aTime, Time);
-	io_write(m_File, aTime, sizeof(aTime));
+		unsigned char aTime[sizeof(int32_t)];
+		uint_to_bytes_be(aTime, Time);
+		io_write(m_File, aTime, sizeof(aTime));
+	}
 
 	io_close(m_File);
 	m_File = 0;
-	return 0;
+
+	if(DiscardFile)
+	{
+		m_pStorage->RemoveFile(m_aFilename, IStorage::TYPE_SAVE);
+	}
+
+	log_info_color(LOG_COLOR_GHOST, "ghost_recorder", "Stopped recording to '%s'", m_aFilename);
+	m_aFilename[0] = '\0';
 }
 
 CGhostLoader::CGhostLoader()
 {
 	m_File = 0;
+	m_aFilename[0] = '\0';
 	ResetBuffer();
 }
 
 void CGhostLoader::Init()
 {
-	m_pConsole = Kernel()->RequestInterface<IConsole>();
 	m_pStorage = Kernel()->RequestInterface<IStorage>();
 }
 
 void CGhostLoader::ResetBuffer()
 {
 	m_pBufferPos = m_aBuffer;
+	m_pBufferEnd = m_aBuffer;
 	m_BufferNumItems = 0;
 	m_BufferCurItem = 0;
 	m_BufferPrevItem = -1;
 }
 
-int CGhostLoader::Load(const char *pFilename, const char *pMap, SHA256_DIGEST MapSha256, unsigned MapCrc)
+IOHANDLE CGhostLoader::ReadHeader(CGhostHeader &Header, const char *pFilename, const char *pMap, const SHA256_DIGEST &MapSha256, unsigned MapCrc, bool LogMapMismatch) const
 {
-	m_File = m_pStorage->OpenFile(pFilename, IOFLAG_READ, IStorage::TYPE_SAVE);
-	if(!m_File)
+	IOHANDLE File = m_pStorage->OpenFile(pFilename, IOFLAG_READ, IStorage::TYPE_SAVE);
+	if(!File)
 	{
-		char aBuf[256];
-		str_format(aBuf, sizeof(aBuf), "could not open '%s'", pFilename);
-		m_pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "ghost_loader", aBuf);
-		return -1;
+		log_error_color(LOG_COLOR_GHOST, "ghost_loader", "Failed to open ghost file '%s' for reading", pFilename);
+		return nullptr;
 	}
 
-	// read the header
-	mem_zero(&m_Header, sizeof(m_Header));
-	io_read(m_File, &m_Header, sizeof(CGhostHeader));
-	if(mem_comp(m_Header.m_aMarker, gs_aHeaderMarker, sizeof(gs_aHeaderMarker)) != 0)
+	if(io_read(File, &Header, sizeof(Header)) != sizeof(Header))
 	{
-		char aBuf[256];
-		str_format(aBuf, sizeof(aBuf), "'%s' is not a ghost file", pFilename);
-		m_pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "ghost_loader", aBuf);
-		io_close(m_File);
-		m_File = 0;
-		return -1;
+		log_error_color(LOG_COLOR_GHOST, "ghost_loader", "Failed to read ghost file '%s': failed to read header", pFilename);
+		io_close(File);
+		return nullptr;
 	}
 
-	if(!(4 <= m_Header.m_Version && m_Header.m_Version <= gs_CurVersion))
+	if(!ValidateHeader(Header, pFilename) ||
+		!CheckHeaderMap(Header, pFilename, pMap, MapSha256, MapCrc, LogMapMismatch))
 	{
-		char aBuf[256];
-		str_format(aBuf, sizeof(aBuf), "ghost version %d is not supported", m_Header.m_Version);
-		m_pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "ghost_loader", aBuf);
-		io_close(m_File);
-		m_File = 0;
-		return -1;
+		io_close(File);
+		return nullptr;
 	}
 
-	if(str_comp(m_Header.m_aMap, pMap) != 0)
+	return File;
+}
+
+bool CGhostLoader::ValidateHeader(const CGhostHeader &Header, const char *pFilename) const
+{
+	if(mem_comp(Header.m_aMarker, gs_aHeaderMarker, sizeof(gs_aHeaderMarker)) != 0)
 	{
-		char aBuf[256];
-		str_format(aBuf, sizeof(aBuf), "ghost map name '%s' does not match current map '%s'", m_Header.m_aMap, pMap);
-		m_pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "ghost_loader", aBuf);
-		io_close(m_File);
-		m_File = 0;
-		return -1;
+		log_error_color(LOG_COLOR_GHOST, "ghost_loader", "Failed to read ghost file '%s': invalid header marker", pFilename);
+		return false;
 	}
 
-	if(m_Header.m_Version >= 6)
+	if(Header.m_Version < 4 || Header.m_Version > gs_CurVersion)
 	{
-		if(m_Header.m_MapSha256 != MapSha256 && g_Config.m_ClRaceGhostStrictMap)
+		log_error_color(LOG_COLOR_GHOST, "ghost_loader", "Failed to read ghost file '%s': ghost version '%d' is not supported", pFilename, Header.m_Version);
+		return false;
+	}
+
+	if(!mem_has_null(Header.m_aOwner, sizeof(Header.m_aOwner)) || !str_utf8_check(Header.m_aOwner))
+	{
+		log_error_color(LOG_COLOR_GHOST, "ghost_loader", "Failed to read ghost file '%s': owner name is invalid", pFilename);
+		return false;
+	}
+
+	if(!mem_has_null(Header.m_aMap, sizeof(Header.m_aMap)) || !str_utf8_check(Header.m_aMap))
+	{
+		log_error_color(LOG_COLOR_GHOST, "ghost_loader", "Failed to read ghost file '%s': map name is invalid", pFilename);
+		return false;
+	}
+
+	const int NumTicks = Header.GetTicks();
+	if(NumTicks <= 0)
+	{
+		log_error_color(LOG_COLOR_GHOST, "ghost_loader", "Failed to read ghost file '%s': number of ticks '%d' is invalid", pFilename, NumTicks);
+		return false;
+	}
+
+	const int Time = Header.GetTime();
+	if(Time <= 0)
+	{
+		log_error_color(LOG_COLOR_GHOST, "ghost_loader", "Failed to read ghost file '%s': time '%d' is invalid", pFilename, Time);
+		return false;
+	}
+
+	return true;
+}
+
+bool CGhostLoader::CheckHeaderMap(const CGhostHeader &Header, const char *pFilename, const char *pMap, const SHA256_DIGEST &MapSha256, unsigned MapCrc, bool LogMapMismatch) const
+{
+	if(str_comp(Header.m_aMap, pMap) != 0)
+	{
+		if(LogMapMismatch)
 		{
-			char aGhostSha256[SHA256_MAXSTRSIZE];
-			sha256_str(m_Header.m_MapSha256, aGhostSha256, sizeof(aGhostSha256));
-			char aMapSha256[SHA256_MAXSTRSIZE];
-			sha256_str(MapSha256, aMapSha256, sizeof(aMapSha256));
-			char aBuf[256];
-			str_format(aBuf, sizeof(aBuf), "ghost map '%s' sha256 mismatch, wanted=%s ghost=%s", pMap, aMapSha256, aGhostSha256);
-			m_pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "ghost_loader", aBuf);
-			io_close(m_File);
-			m_File = 0;
-			return -1;
+			log_error_color(LOG_COLOR_GHOST, "ghost_loader", "Failed to read ghost file '%s': ghost map name '%s' does not match current map '%s'", pFilename, Header.m_aMap, pMap);
+		}
+		return false;
+	}
+
+	if(Header.m_Version >= 6)
+	{
+		if(Header.m_MapSha256 != MapSha256 && g_Config.m_ClRaceGhostStrictMap)
+		{
+			if(LogMapMismatch)
+			{
+				char aGhostSha256[SHA256_MAXSTRSIZE];
+				sha256_str(Header.m_MapSha256, aGhostSha256, sizeof(aGhostSha256));
+				char aMapSha256[SHA256_MAXSTRSIZE];
+				sha256_str(MapSha256, aMapSha256, sizeof(aMapSha256));
+				log_error_color(LOG_COLOR_GHOST, "ghost_loader", "Failed to read ghost file '%s': ghost map SHA256 mismatch (wanted='%s', ghost='%s')", pFilename, aMapSha256, aGhostSha256);
+			}
+			return false;
 		}
 	}
 	else
 	{
-		io_skip(m_File, -(int)sizeof(SHA256_DIGEST));
-		unsigned GhostMapCrc = bytes_be_to_uint(m_Header.m_aZeroes);
+		const unsigned GhostMapCrc = bytes_be_to_uint(Header.m_aZeroes);
 		if(GhostMapCrc != MapCrc && g_Config.m_ClRaceGhostStrictMap)
 		{
-			char aBuf[256];
-			str_format(aBuf, sizeof(aBuf), "ghost map '%s' crc mismatch, wanted=%08x ghost=%08x", pMap, MapCrc, GhostMapCrc);
-			m_pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "ghost_loader", aBuf);
-			io_close(m_File);
-			m_File = 0;
-			return -1;
+			if(LogMapMismatch)
+			{
+				log_error_color(LOG_COLOR_GHOST, "ghost_loader", "Failed to read ghost file '%s': ghost map CRC mismatch (wanted='%08x', ghost='%08x')", pFilename, MapCrc, GhostMapCrc);
+			}
+			return false;
 		}
 	}
 
+	return true;
+}
+
+bool CGhostLoader::Load(const char *pFilename, const char *pMap, const SHA256_DIGEST &MapSha256, unsigned MapCrc)
+{
+	dbg_assert(!m_File, "File already open");
+
+	CGhostHeader Header;
+	IOHANDLE File = ReadHeader(Header, pFilename, pMap, MapSha256, MapCrc, true);
+	if(!File)
+	{
+		return false;
+	}
+
+	if(Header.m_Version < 6)
+	{
+		io_skip(File, -(int)sizeof(SHA256_DIGEST));
+	}
+
+	m_File = File;
+	str_copy(m_aFilename, pFilename);
+	m_Header = Header;
 	m_Info = m_Header.ToGhostInfo();
 	m_LastItem.Reset();
 	ResetBuffer();
-
-	return 0;
+	return true;
 }
 
-int CGhostLoader::ReadChunk(int *pType)
+bool CGhostLoader::ReadChunk(int *pType)
 {
-	static char s_aCompresseddata[MAX_ITEM_SIZE * NUM_ITEMS_PER_CHUNK];
-	static char s_aDecompressed[MAX_ITEM_SIZE * NUM_ITEMS_PER_CHUNK];
-	unsigned char aChunk[4];
-
 	if(m_Header.m_Version != 4)
+	{
 		m_LastItem.Reset();
+	}
 	ResetBuffer();
 
-	if(io_read(m_File, aChunk, sizeof(aChunk)) != sizeof(aChunk))
-		return -1;
-
-	*pType = aChunk[0];
-	int Size = (aChunk[2] << 8) | aChunk[3];
-	m_BufferNumItems = aChunk[1];
-
-	if(Size > MAX_ITEM_SIZE * NUM_ITEMS_PER_CHUNK || Size <= 0)
-		return -1;
-
-	if(io_read(m_File, s_aCompresseddata, Size) != (unsigned)Size)
+	unsigned char aChunkHeader[4];
+	if(io_read(m_File, aChunkHeader, sizeof(aChunkHeader)) != sizeof(aChunkHeader))
 	{
-		m_pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "ghost", "error reading chunk");
-		return -1;
+		return false; // EOF
 	}
 
-	Size = CNetBase::Decompress(s_aCompresseddata, Size, s_aDecompressed, sizeof(s_aDecompressed));
+	*pType = aChunkHeader[0];
+	int Size = (aChunkHeader[2] << 8) | aChunkHeader[3];
+	m_BufferNumItems = aChunkHeader[1];
+
+	if(Size <= 0 || Size > MAX_CHUNK_SIZE)
+	{
+		log_error_color(LOG_COLOR_GHOST, "ghost_loader", "Failed to read ghost file '%s': invalid chunk header size", m_aFilename);
+		return false;
+	}
+
+	if(io_read(m_File, m_aBuffer, Size) != (unsigned)Size)
+	{
+		log_error_color(LOG_COLOR_GHOST, "ghost_loader", "Failed to read ghost file '%s': error reading chunk data", m_aFilename);
+		return false;
+	}
+
+	Size = CNetBase::Decompress(m_aBuffer, Size, m_aBufferTemp, sizeof(m_aBufferTemp));
 	if(Size < 0)
 	{
-		m_pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "ghost", "error during network decompression");
-		return -1;
+		log_error_color(LOG_COLOR_GHOST, "ghost_loader", "Failed to read ghost file '%s': error during network decompression", m_aFilename);
+		return false;
 	}
 
-	Size = CVariableInt::Decompress(s_aDecompressed, Size, m_aBuffer, sizeof(m_aBuffer));
+	Size = CVariableInt::Decompress(m_aBufferTemp, Size, m_aBuffer, sizeof(m_aBuffer));
 	if(Size < 0)
 	{
-		m_pConsole->Print(IConsole::OUTPUT_LEVEL_STANDARD, "ghost", "error during intpack decompression");
-		return -1;
+		log_error_color(LOG_COLOR_GHOST, "ghost_loader", "Failed to read ghost file '%s': error during intpack decompression", m_aFilename);
+		return false;
 	}
 
-	return 0;
+	m_pBufferEnd = m_aBuffer + Size;
+	return true;
 }
 
 bool CGhostLoader::ReadNextType(int *pType)
 {
-	if(!m_File)
-		return false;
+	dbg_assert((bool)m_File, "File not open");
 
 	if(m_BufferCurItem != m_BufferPrevItem && m_BufferCurItem < m_BufferNumItems)
 	{
 		*pType = m_LastItem.m_Type;
 	}
-	else
+	else if(!ReadChunk(pType))
 	{
-		if(ReadChunk(pType))
-			return false; // error or eof
+		return false; // error or EOF
 	}
 
 	m_BufferPrevItem = m_BufferCurItem;
-
 	return true;
 }
 
-static void UndiffItem(int *pPast, int *pDiff, int *pOut, int Size)
+static void UndiffItem(const int32_t *pPast, const int32_t *pDiff, int32_t *pOut, size_t Size)
 {
 	while(Size)
 	{
@@ -335,17 +438,27 @@ static void UndiffItem(int *pPast, int *pDiff, int *pOut, int Size)
 	}
 }
 
-bool CGhostLoader::ReadData(int Type, void *pData, int Size)
+bool CGhostLoader::ReadData(int Type, void *pData, size_t Size)
 {
-	if(!m_File || Size > MAX_ITEM_SIZE || Size <= 0 || Type == -1)
+	dbg_assert((bool)m_File, "File not open");
+	dbg_assert(Type >= 0 && Type <= (int)std::numeric_limits<unsigned char>::max(), "Type invalid");
+	dbg_assert(Size > 0 && Size <= MAX_ITEM_SIZE && Size % sizeof(int32_t) == 0, "Size invalid");
+
+	if((size_t)(m_pBufferEnd - m_pBufferPos) < Size)
+	{
+		log_error_color(LOG_COLOR_GHOST, "ghost_loader", "Failed to read ghost file '%s': not enough data (type='%d', got='%" PRIzu "', wanted='%" PRIzu "')", m_aFilename, Type, (size_t)(m_pBufferEnd - m_pBufferPos), Size);
 		return false;
+	}
 
 	CGhostItem Data(Type);
-
 	if(m_LastItem.m_Type == Data.m_Type)
-		UndiffItem((int *)m_LastItem.m_aData, (int *)m_pBufferPos, (int *)Data.m_aData, Size / sizeof(int32_t));
+	{
+		UndiffItem((const int32_t *)m_LastItem.m_aData, (const int32_t *)m_pBufferPos, (int32_t *)Data.m_aData, Size / sizeof(int32_t));
+	}
 	else
+	{
 		mem_copy(Data.m_aData, m_pBufferPos, Size);
+	}
 
 	mem_copy(pData, Data.m_aData, Size);
 
@@ -358,47 +471,24 @@ bool CGhostLoader::ReadData(int Type, void *pData, int Size)
 void CGhostLoader::Close()
 {
 	if(!m_File)
+	{
 		return;
+	}
+
 	io_close(m_File);
 	m_File = 0;
+	m_aFilename[0] = '\0';
 }
 
-bool CGhostLoader::GetGhostInfo(const char *pFilename, CGhostInfo *pGhostInfo, const char *pMap, SHA256_DIGEST MapSha256, unsigned MapCrc)
+bool CGhostLoader::GetGhostInfo(const char *pFilename, CGhostInfo *pGhostInfo, const char *pMap, const SHA256_DIGEST &MapSha256, unsigned MapCrc)
 {
 	CGhostHeader Header;
-	mem_zero(&Header, sizeof(Header));
-
-	IOHANDLE File = m_pStorage->OpenFile(pFilename, IOFLAG_READ, IStorage::TYPE_SAVE);
+	IOHANDLE File = ReadHeader(Header, pFilename, pMap, MapSha256, MapCrc, false);
 	if(!File)
+	{
 		return false;
-
-	io_read(File, &Header, sizeof(Header));
+	}
 	io_close(File);
-
-	if(mem_comp(Header.m_aMarker, gs_aHeaderMarker, sizeof(gs_aHeaderMarker)) || !(4 <= Header.m_Version && Header.m_Version <= gs_CurVersion))
-		return false;
-
-	if(str_comp(Header.m_aMap, pMap) != 0)
-	{
-		return false;
-	}
-
-	if(Header.m_Version >= 6 && g_Config.m_ClRaceGhostStrictMap)
-	{
-		if(Header.m_MapSha256 != MapSha256)
-		{
-			return false;
-		}
-	}
-	else if(g_Config.m_ClRaceGhostStrictMap)
-	{
-		unsigned GhostMapCrc = bytes_be_to_uint(Header.m_aZeroes);
-		if(GhostMapCrc != MapCrc)
-		{
-			return false;
-		}
-	}
 	*pGhostInfo = Header.ToGhostInfo();
-
 	return true;
 }

--- a/src/engine/ghost.h
+++ b/src/engine/ghost.h
@@ -21,10 +21,10 @@ class IGhostRecorder : public IInterface
 public:
 	virtual ~IGhostRecorder() {}
 
-	virtual int Start(const char *pFilename, const char *pMap, SHA256_DIGEST MapSha256, const char *pName) = 0;
-	virtual int Stop(int Ticks, int Time) = 0;
+	virtual int Start(const char *pFilename, const char *pMap, const SHA256_DIGEST &MapSha256, const char *pName) = 0;
+	virtual void Stop(int Ticks, int Time) = 0;
 
-	virtual void WriteData(int Type, const void *pData, int Size) = 0;
+	virtual void WriteData(int Type, const void *pData, size_t Size) = 0;
 	virtual bool IsRecording() const = 0;
 };
 
@@ -34,15 +34,15 @@ class IGhostLoader : public IInterface
 public:
 	virtual ~IGhostLoader() {}
 
-	virtual int Load(const char *pFilename, const char *pMap, SHA256_DIGEST MapSha256, unsigned MapCrc) = 0;
+	virtual bool Load(const char *pFilename, const char *pMap, const SHA256_DIGEST &MapSha256, unsigned MapCrc) = 0;
 	virtual void Close() = 0;
 
 	virtual const CGhostInfo *GetInfo() const = 0;
 
 	virtual bool ReadNextType(int *pType) = 0;
-	virtual bool ReadData(int Type, void *pData, int Size) = 0;
+	virtual bool ReadData(int Type, void *pData, size_t Size) = 0;
 
-	virtual bool GetGhostInfo(const char *pFilename, CGhostInfo *pInfo, const char *pMap, SHA256_DIGEST MapSha256, unsigned MapCrc) = 0;
+	virtual bool GetGhostInfo(const char *pFilename, CGhostInfo *pInfo, const char *pMap, const SHA256_DIGEST &MapSha256, unsigned MapCrc) = 0;
 };
 
 #endif

--- a/src/game/client/components/ghost.cpp
+++ b/src/game/client/components/ghost.cpp
@@ -1,19 +1,22 @@
 /* (c) Rajh, Redix and Sushi. */
 
+#include "ghost.h"
+
+#include <base/log.h>
+
 #include <engine/ghost.h>
 #include <engine/shared/config.h>
 #include <engine/storage.h>
 
+#include <game/client/components/menus.h>
+#include <game/client/components/players.h>
+#include <game/client/components/skins.h>
+#include <game/client/gameclient.h>
 #include <game/client/race.h>
 
-#include "ghost.h"
-#include "menus.h"
-#include "players.h"
-#include "skins.h"
-
-#include <game/client/gameclient.h>
-
 const char *CGhost::ms_pGhostDir = "ghosts";
+
+static const LOG_COLOR LOG_COLOR_GHOST{165, 153, 153};
 
 void CGhost::GetGhostSkin(CGhostSkin *pSkin, const char *pSkinName, int UseCustomColor, int ColorBody, int ColorFeet)
 {
@@ -400,11 +403,13 @@ void CGhost::StopRecord(int Time)
 	m_Recording = false;
 	bool RecordingToFile = GhostRecorder()->IsRecording();
 
-	if(RecordingToFile)
-		GhostRecorder()->Stop(m_CurGhost.m_Path.Size(), Time);
-
 	CMenus::CGhostItem *pOwnGhost = m_pClient->m_Menus.GetOwnGhost();
-	if(Time > 0 && (!pOwnGhost || Time < pOwnGhost->m_Time || !g_Config.m_ClRaceGhostSaveBest))
+	const bool StoreGhost = Time > 0 && (!pOwnGhost || Time < pOwnGhost->m_Time || !g_Config.m_ClRaceGhostSaveBest);
+
+	if(RecordingToFile)
+		GhostRecorder()->Stop(m_CurGhost.m_Path.Size(), StoreGhost ? Time : -1);
+
+	if(StoreGhost)
 	{
 		// add to active ghosts
 		int Slot = GetSlot();
@@ -429,11 +434,8 @@ void CGhost::StopRecord(int Time)
 		// add item to menu list
 		m_pClient->m_Menus.UpdateOwnGhost(Item);
 	}
-	else if(RecordingToFile) // no new record
-		Storage()->RemoveFile(m_aTmpFilename, IStorage::TYPE_SAVE);
 
-	m_aTmpFilename[0] = 0;
-
+	m_aTmpFilename[0] = '\0';
 	m_CurGhost.Reset();
 }
 
@@ -457,17 +459,10 @@ int CGhost::Load(const char *pFilename)
 	if(Slot == -1)
 		return -1;
 
-	if(GhostLoader()->Load(pFilename, Client()->GetCurrentMap(), Client()->GetCurrentMapSha256(), Client()->GetCurrentMapCrc()) != 0)
+	if(!GhostLoader()->Load(pFilename, Client()->GetCurrentMap(), Client()->GetCurrentMapSha256(), Client()->GetCurrentMapCrc()))
 		return -1;
 
 	const CGhostInfo *pInfo = GhostLoader()->GetInfo();
-
-	if(pInfo->m_NumTicks <= 0 || pInfo->m_Time <= 0)
-	{
-		Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "ghost", "invalid header info");
-		GhostLoader()->Close();
-		return -1;
-	}
 
 	// select ghost
 	CGhostItem *pGhost = &m_aActiveGhosts[Slot];
@@ -518,7 +513,7 @@ int CGhost::Load(const char *pFilename)
 
 	if(Error || Index != pInfo->m_NumTicks)
 	{
-		Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "ghost", "invalid ghost data");
+		log_error_color(LOG_COLOR_GHOST, "ghost", "Failed to read all ghost data (error='%d', got '%d' ticks, wanted '%d' ticks)", Error, Index, pInfo->m_NumTicks);
 		pGhost->Reset();
 		return -1;
 	}


### PR DESCRIPTION
Fix out-of-bounds reads in ghost loader when current chunk does not contain enough data for expected number of items.

Improve validation of ghost header information. Ensure strings (owner and map name) are null-terminated and valid UTF-8 to avoid crashes. Avoid duplicate code for validating header.

Remove `static` buffers for compression and decompression of ghost data, which would prevent parallelizing ghost recording and loading. Switch between the main buffer and only one temporary buffer instead of using two temporary buffers.

Automatically delete the ghost file when the recording is stopped with the number of ticks or time being invalid, i.e. when ghost recording will be restarted. This should ensure that invalid ghost files are not left behind if recording is not immediately restarted after being stopped, e.g. due to edge cases like standing inside a start-tile.

Use `int32_t` for `DiffItem` and `UndiffItem` data pointers as these functions are expected to operate on 32-bit integers. Ensure chunk and item data is aligned with `int32_t` to avoid potential unaligned accesses. Use `size_t` for size arguments.

Add assertions to ghost loader and recorder functions to ensure their correct usage. Ensure a file is not already open when opening another one and ensure that a file is open when reading/writing. Ensure that the ghost data type is valid, i.e. between `0` and `0xFF` because it is packed into an `unsigned char`. Ensure data size is valid and aligned with `int32_t`, otherwise data would be packed incorrectly by the `DiffItem` function. Improve error messages, consistent with the error messages of the demo player and recorder. Use the `log_*` functions for logging. Use the same color for all ghost-related log messages.

Avoid `system.h` include in `ghost.h` by moving `CGhostHeader` function definitions to `ghost.cpp`.

Closes #7413.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [X] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
