### PR TITLE
Add `clear_chat` command

### DIFF
--- a/src/game/client/components/chat.cpp
+++ b/src/game/client/components/chat.cpp
@@ -95,12 +95,7 @@ void CChat::RebuildChat()
 	}
 }
 
-void CChat::OnWindowResize()
-{
-	RebuildChat();
-}
-
-void CChat::Reset()
+void CChat::ClearLines()
 {
 	for(auto &Line : m_aLines)
 	{
@@ -115,6 +110,16 @@ void CChat::Reset()
 	}
 	m_PrevScoreBoardShowed = false;
 	m_PrevShowChat = false;
+}
+
+void CChat::OnWindowResize()
+{
+	RebuildChat();
+}
+
+void CChat::Reset()
+{
+	ClearLines();
 
 	m_Show = false;
 	m_CompletionUsed = false;
@@ -183,6 +188,11 @@ void CChat::ConEcho(IConsole::IResult *pResult, void *pUserData)
 	((CChat *)pUserData)->Echo(pResult->GetString(0));
 }
 
+void CChat::ConClearChat(IConsole::IResult *pResult, void *pUserData)
+{
+	((CChat *)pUserData)->ClearLines();
+}
+
 void CChat::ConchainChatOld(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData)
 {
 	pfnCallback(pResult, pCallbackUserData);
@@ -217,6 +227,7 @@ void CChat::OnConsoleInit()
 	Console()->Register("chat", "s['team'|'all'] ?r[message]", CFGFLAG_CLIENT, ConChat, this, "Enable chat with all/team mode");
 	Console()->Register("+show_chat", "", CFGFLAG_CLIENT, ConShowChat, this, "Show chat");
 	Console()->Register("echo", "r[message]", CFGFLAG_CLIENT | CFGFLAG_STORE, ConEcho, this, "Echo the text in chat window");
+	Console()->Register("clear_chat", "", CFGFLAG_CLIENT | CFGFLAG_STORE, ConClearChat, this, "Clear chat messages");
 }
 
 void CChat::OnInit()

--- a/src/game/client/components/chat.h
+++ b/src/game/client/components/chat.h
@@ -135,6 +135,7 @@ class CChat : public CComponent
 	static void ConChat(IConsole::IResult *pResult, void *pUserData);
 	static void ConShowChat(IConsole::IResult *pResult, void *pUserData);
 	static void ConEcho(IConsole::IResult *pResult, void *pUserData);
+	static void ConClearChat(IConsole::IResult *pResult, void *pUserData);
 
 	static void ConchainChatOld(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 	static void ConchainChatFontSize(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
@@ -170,6 +171,7 @@ public:
 	void OnInit() override;
 
 	void RebuildChat();
+	void ClearLines();
 
 	void EnsureCoherentFontSize() const;
 	void EnsureCoherentWidth() const;


### PR DESCRIPTION
Add a command to clear all lines of chat messages, same as the `clear_local_console`/`clear_remote_console` commands for the consoles. This is useful for example when taking screenshots or recording videos with initially empty chat.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
