### PR TITLE
Change default Q bind to /spec

### DIFF
--- a/src/game/client/components/binds.cpp
+++ b/src/game/client/components/binds.cpp
@@ -297,7 +297,7 @@ void CBinds::SetDefaults()
 	Bind(KEY_F4, "vote no");
 
 	Bind(KEY_K, "kill");
-	Bind(KEY_Q, "say /pause");
+	Bind(KEY_Q, "say /spec");
 	Bind(KEY_P, "say /pause");
 
 	g_Config.m_ClDDRaceBindsSet = 0;


### PR DESCRIPTION
People seem to be always confused whenever the map supports going invisible on /spec and I've seen multiple times people asking about it on the discord server, as it's not explained anywhere. /spec and /pause work the same, and the P key is already bound to /pause. This changes the default bind, so it will mostly affect fresh installs - new players

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
