### PR TITLE
Fix player info being resent too fast/slow depending on FPS

### DIFF
--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -557,7 +557,7 @@ public:
 	// actions
 	// TODO: move these
 	void SendSwitchTeam(int Team) const;
-	void SendStartInfo7(bool Dummy) const;
+	void SendStartInfo7(bool Dummy);
 	void SendSkinChange7(bool Dummy);
 	// Returns true if the requested skin change got applied by the server
 	bool GotWantedSkin7(bool Dummy);


### PR DESCRIPTION
The change info message was being resent too fast/slow because `m_aCheckInfo` was decremented every frame whereas it was intended to be decremented every tick. As `m_aCheckInfo` is set to `Client()->GameTickSpeed()` after sending the info, it's likely that this was intended as one second delay. With debug messages is can be confirmed that the change info message was previously resent more than 10 times per second with high FPS on a local server.

Also fix the info resending delay not being reset when reconnecting a dummy on 0.7 servers.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
