### PR TITLE
Refactor `CSkins7` accessor functions and 0.7 skin json parsing

### DIFF
--- a/src/game/client/components/skins7.h
+++ b/src/game/client/components/skins7.h
@@ -2,15 +2,18 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #ifndef GAME_CLIENT_COMPONENTS_SKINS7_H
 #define GAME_CLIENT_COMPONENTS_SKINS7_H
+
 #include <base/color.h>
 #include <base/vmath.h>
+
 #include <engine/client/enums.h>
 #include <engine/graphics.h>
-#include <game/client/component.h>
-#include <vector>
 
+#include <game/client/component.h>
 #include <game/generated/protocol.h>
 #include <game/generated/protocol7.h>
+
+#include <vector>
 
 class CSkins7 : public CComponent
 {
@@ -26,8 +29,9 @@ public:
 		HAT_OFFSET_SIDE = 2,
 	};
 
-	struct CSkinPart
+	class CSkinPart
 	{
+	public:
 		int m_Flags;
 		char m_aName[24];
 		IGraphics::CTextureHandle m_OrgTexture;
@@ -37,13 +41,14 @@ public:
 		bool operator<(const CSkinPart &Other) { return str_comp_nocase(m_aName, Other.m_aName) < 0; }
 	};
 
-	struct CSkin
+	class CSkin
 	{
+	public:
 		int m_Flags;
 		char m_aName[24];
 		const CSkinPart *m_apParts[protocol7::NUM_SKINPARTS];
-		int m_aPartColors[protocol7::NUM_SKINPARTS];
 		int m_aUseCustomColors[protocol7::NUM_SKINPARTS];
+		unsigned m_aPartColors[protocol7::NUM_SKINPARTS];
 
 		bool operator<(const CSkin &Other) const { return str_comp_nocase(m_aName, Other.m_aName) < 0; }
 		bool operator==(const CSkin &Other) const { return !str_comp(m_aName, Other.m_aName); }
@@ -56,23 +61,17 @@ public:
 	static char *ms_apSkinNameVariables[NUM_DUMMIES];
 	static char *ms_apSkinVariables[NUM_DUMMIES][protocol7::NUM_SKINPARTS];
 	static int *ms_apUCCVariables[NUM_DUMMIES][protocol7::NUM_SKINPARTS]; // use custom color
-	static unsigned int *ms_apColorVariables[NUM_DUMMIES][protocol7::NUM_SKINPARTS];
-	IGraphics::CTextureHandle m_XmasHatTexture;
-	IGraphics::CTextureHandle m_BotTexture;
+	static unsigned *ms_apColorVariables[NUM_DUMMIES][protocol7::NUM_SKINPARTS];
 
-	int GetInitAmount() const;
+	int Sizeof() const override { return sizeof(*this); }
 	void OnInit() override;
 
-	void AddSkin(const char *pSkinName, int Dummy);
-	bool RemoveSkin(const CSkin *pSkin);
-
-	int Num();
-	int NumSkinPart(int Part);
-	const CSkin *Get(int Index);
-	int Find(const char *pName, bool AllowSpecialSkin);
-	const CSkinPart *GetSkinPart(int Part, int Index);
-	int FindSkinPart(int Part, const char *pName, bool AllowSpecialPart);
-	void RandomizeSkin(int Dummy);
+	const std::vector<CSkin> &GetSkins() const;
+	const std::vector<CSkinPart> &GetSkinParts(int Part) const;
+	const CSkinPart *FindSkinPartOrNullptr(int Part, const char *pName, bool AllowSpecialPart) const;
+	const CSkinPart *FindDefaultSkinPart(int Part) const;
+	const CSkinPart *FindSkinPart(int Part, const char *pName, bool AllowSpecialPart) const;
+	void RandomizeSkin(int Dummy) const;
 
 	ColorRGBA GetColor(int Value, bool UseAlpha) const;
 	ColorRGBA GetTeamColor(int UseCustomColors, int PartColor, int Team, int Part) const;
@@ -80,21 +79,30 @@ public:
 	// returns true if everything was valid and nothing changed
 	bool ValidateSkinParts(char *apPartNames[protocol7::NUM_SKINPARTS], int *pUseCustomColors, int *pPartColors, int GameFlags) const;
 
-	bool SaveSkinfile(const char *pSaveSkinName, int Dummy);
+	bool SaveSkinfile(const char *pName, int Dummy);
+	bool RemoveSkin(const CSkin *pSkin);
 
-	virtual int Sizeof() const override { return sizeof(*this); }
+	IGraphics::CTextureHandle XmasHatTexture() const { return m_XmasHatTexture; }
+	IGraphics::CTextureHandle BotDecorationTexture() const { return m_BotTexture; }
 
 private:
 	int m_ScanningPart;
+
 	std::vector<CSkinPart> m_avSkinParts[protocol7::NUM_SKINPARTS];
+	CSkinPart m_aPlaceholderSkinParts[protocol7::NUM_SKINPARTS];
 	std::vector<CSkin> m_vSkins;
-	CSkin m_DummySkin;
+
+	IGraphics::CTextureHandle m_XmasHatTexture;
+	IGraphics::CTextureHandle m_BotTexture;
 
 	static int SkinPartScan(const char *pName, int IsDir, int DirType, void *pUser);
 	static int SkinScan(const char *pName, int IsDir, int DirType, void *pUser);
 
+	void InitPlaceholderSkinParts();
 	void LoadXmasHat();
 	void LoadBotDecoration();
+
+	void AddSkinFromConfigVariables(const char *pName, int Dummy);
 };
 
 #endif

--- a/src/game/client/sixup_translate_game.cpp
+++ b/src/game/client/sixup_translate_game.cpp
@@ -94,7 +94,7 @@ void CGameClient::ApplySkin7InfoFromGameMsg(const T *pMsg, int ClientId, int Con
 
 	if(time_season() == SEASON_XMAS)
 	{
-		pClient->m_SkinInfo.m_aSixup[Conn].m_HatTexture = m_Skins7.m_XmasHatTexture;
+		pClient->m_SkinInfo.m_aSixup[Conn].m_HatTexture = m_Skins7.XmasHatTexture();
 		pClient->m_SkinInfo.m_aSixup[Conn].m_HatSpriteIndex = ClientId % CSkins7::HAT_NUM;
 	}
 	else
@@ -102,8 +102,7 @@ void CGameClient::ApplySkin7InfoFromGameMsg(const T *pMsg, int ClientId, int Con
 
 	for(int Part = 0; Part < protocol7::NUM_SKINPARTS; Part++)
 	{
-		int Id = m_Skins7.FindSkinPart(Part, pClient->m_aSixup[Conn].m_aaSkinPartNames[Part], false);
-		const CSkins7::CSkinPart *pSkinPart = m_Skins7.GetSkinPart(Part, Id);
+		const CSkins7::CSkinPart *pSkinPart = m_Skins7.FindSkinPart(Part, pClient->m_aSixup[Conn].m_aaSkinPartNames[Part], false);
 		if(pClient->m_aSixup[Conn].m_aUseCustomColors[Part])
 		{
 			pClient->m_SkinInfo.m_aSixup[Conn].m_aTextures[Part] = pSkinPart->m_ColorTexture;


### PR DESCRIPTION
- Combine `CSkins7::FindSkinPart` and `CSkins7::GetSkinPart` functions into `CSkins7::FindSkinPart` function to simplify the usage.
- Replace `CSkins7::Num` and `CSkins7::Get` functions with `CSkins7::GetSkins` function to return all skins to improve readability using for-each loops.
- Replace `CSkins7::NumSkinPart` and `CSkins7::GetSkinPart` functions with `CSkins7::GetSkinParts` function to return all skin parts to improve readability using for-each loops.
- Add `CSkins7::FindSkinPartOrNullptr` function to find a skin by name or return `nullptr` if it's not found. Let the `CSkins7::FindSkinPart` function return the desired part, then the default part, and lastly the placeholder part.
- Add `CSkins7::FindDefaultSkinPart` function to find the default skin part or placeholder skin part (never `nullptr`).
- Remove redundant check for duplicate skin parts. This is already prevented by the `IStorage::ListDirectory` function.
- Remove separate placeholder skin that was being used to initialized every loaded and created skin.
- Remove unused `CSkins7::GetInitAmount` function.
- Add `CSkins7::InitPlaceholderSkinParts` function to initialize the placeholder skin parts. Keep placeholder skin parts separate from normal skin parts, i.e. not in the vectors of parts.
- Rename `CSkins7::AddSkin` function to `AddSkinFromConfigVariables` for clarity about its behavior.
- Fix `CSkins7::RandomizeSkin` function not terminating if there exist only special skin parts for any part type.
- Add `CSkins7::XmasHatTexture` and `CSkins7::BotDecorationTexture` getter functions instead of exposing the respective member variables.
- Improve validation when parsing 0.7 skin json format. Fail loading and log error messages on invalid skin json files instead of silently loading incorrect/incomplete skins.

<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
