### PR TITLE
Improve map sound validation and performance

### DIFF
--- a/src/game/client/components/mapsounds.h
+++ b/src/game/client/components/mapsounds.h
@@ -1,32 +1,28 @@
 #ifndef GAME_CLIENT_COMPONENTS_MAPSOUNDS_H
 #define GAME_CLIENT_COMPONENTS_MAPSOUNDS_H
 
-#include <vector>
-
 #include <engine/sound.h>
 
 #include <game/client/component.h>
 #include <game/mapitems.h>
 
-struct CSoundSource;
+#include <vector>
 
 class CMapSounds : public CComponent
 {
 	int m_aSounds[MAX_MAPSOUNDS];
 	int m_Count;
 
-	struct CSourceQueueEntry
+	class CSourceQueueEntry
 	{
+	public:
 		int m_Sound;
 		bool m_HighDetail;
 		ISound::CVoiceHandle m_Voice;
-		CSoundSource *m_pSource;
-
-		bool operator==(const CSourceQueueEntry &Other) const { return (m_Sound == Other.m_Sound) && (m_Voice == Other.m_Voice) && (m_pSource == Other.m_pSource); }
+		const CMapItemGroup *m_pGroup;
+		const CSoundSource *m_pSource;
 	};
-
 	std::vector<CSourceQueueEntry> m_vSourceQueue;
-
 	void Clear();
 
 public:


### PR DESCRIPTION
- Add check for map sound data being loaded from map to avoid null pointer access.
- Add check for size of sound source data to avoid out-of-bounds reads.
- Avoid iterating over all groups and layers and then performing a linear search on the sound queue entries every frame to update the sounds. Instead, store a pointer to the respective `CMapItemGroup` for every queue entry, so iterating over the queue once is enough to update all sound queue entries.
- Move check for sound layer index outside of loop as the value does not change.
- Avoid creating source queue entries for sounds that could not be loaded.
- Mark pointers as `const` when possible.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
