### PR TITLE
Implement bans_find command.

### DIFF
--- a/src/engine/shared/netban.h
+++ b/src/engine/shared/netban.h
@@ -191,6 +191,7 @@ public:
 	static void ConUnbanRange(class IConsole::IResult *pResult, void *pUser);
 	static void ConUnbanAll(class IConsole::IResult *pResult, void *pUser);
 	static void ConBans(class IConsole::IResult *pResult, void *pUser);
+	static void ConBansFind(class IConsole::IResult *pResult, void *pUser);
 	static void ConBansSave(class IConsole::IResult *pResult, void *pUser);
 };
 


### PR DESCRIPTION
This rcon command simplifies searching for all ban records for a specific IP if the ban list has too many records.

The motivation behind comes from Blockworlds as we have around 900 ban records and searching for a ban record without having access to the bans.cfg can be quite annoying.

I guess the way to search for records and print the index can be optimized but didn't find how for now. I'm open to suggestions.

The corresponding issue for this pull request is #9202.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
