### PR TITLE
Fix incorrect rendering of menu and entities background maps

### DIFF
--- a/src/game/client/components/background.cpp
+++ b/src/game/client/components/background.cpp
@@ -80,9 +80,11 @@ void CBackground::LoadBackground()
 
 		if(m_Loaded)
 		{
-			CMapLayers::OnMapLoad();
 			if(NeedImageLoading)
+			{
 				m_pImages->LoadBackground(m_pLayers, m_pMap);
+			}
+			CMapLayers::OnMapLoad();
 		}
 	}
 }

--- a/src/game/client/components/menu_background.cpp
+++ b/src/game/client/components/menu_background.cpp
@@ -256,8 +256,8 @@ void CMenuBackground::LoadMenuBackground(bool HasDayHint, bool HasNightHint)
 		{
 			m_pLayers->Init(m_pMap, true);
 
-			CMapLayers::OnMapLoad();
 			m_pImages->LoadBackground(m_pLayers, m_pMap);
+			CMapLayers::OnMapLoad();
 
 			// look for custom positions
 			CMapItemLayerTilemap *pTLayer = m_pLayers->GameLayer();


### PR DESCRIPTION
Load the map images for the menu and entities background maps before the respective map layers. Otherwise, the total number of images is `0` when loading the layers, which causes the images of tiles and quads layers to be considered invalid during the initialization, which results in the wrong tile/quad memory layout being used.

Regression from #9213.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
