### PR TITLE
Use quad container for race flag in finish infomessages

### DIFF
--- a/src/game/client/components/infomessages.cpp
+++ b/src/game/client/components/infomessages.cpp
@@ -16,6 +16,7 @@
 
 static constexpr float ROW_HEIGHT = 46.0f;
 static constexpr float FONT_SIZE = 36.0f;
+static constexpr float RACE_FLAG_SIZE = 52.0f;
 
 void CInfoMessages::OnWindowResize()
 {
@@ -65,6 +66,10 @@ void CInfoMessages::OnInit()
 		RenderTools()->GetSpriteScale(g_pData->m_Weapons.m_aId[i].m_pSpriteBody, ScaleX, ScaleY);
 		RenderTools()->QuadContainerAddSprite(m_SpriteQuadContainerIndex, 96.f * ScaleX, 96.f * ScaleY);
 	}
+
+	Graphics()->QuadsSetSubset(0, 0, 1, 1);
+	m_QuadOffsetRaceFlag = RenderTools()->QuadContainerAddSprite(m_SpriteQuadContainerIndex, 0.0f, 0.0f, RACE_FLAG_SIZE, RACE_FLAG_SIZE);
+
 	Graphics()->QuadContainerUpload(m_SpriteQuadContainerIndex);
 }
 
@@ -389,13 +394,9 @@ void CInfoMessages::RenderFinishMsg(const CInfoMsg &InfoMsg, float x, float y)
 	}
 
 	// render flag
-	const float FlagSize = 52.0f;
-	x -= FlagSize;
+	x -= RACE_FLAG_SIZE;
 	Graphics()->TextureSet(g_pData->m_aImages[IMAGE_RACEFLAG].m_Id);
-	Graphics()->QuadsBegin();
-	IGraphics::CQuadItem QuadItem(x, y, FlagSize, FlagSize);
-	Graphics()->QuadsDrawTL(&QuadItem, 1);
-	Graphics()->QuadsEnd();
+	Graphics()->RenderQuadContainerAsSprite(m_SpriteQuadContainerIndex, m_QuadOffsetRaceFlag, x, y);
 
 	// render victim name
 	if(InfoMsg.m_VictimTextContainerIndex.Valid())

--- a/src/game/client/components/infomessages.h
+++ b/src/game/client/components/infomessages.h
@@ -8,7 +8,8 @@
 #include <game/client/render.h>
 class CInfoMessages : public CComponent
 {
-	int m_SpriteQuadContainerIndex;
+	int m_SpriteQuadContainerIndex = -1;
+	int m_QuadOffsetRaceFlag = -1;
 
 	enum
 	{


### PR DESCRIPTION
Avoid uploading quad for race flag in finish infomessages every frame by adding it to the existing quad container.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
