### PR TITLE
Add bounce positions in order to calculate hit map indices properly

### DIFF
--- a/src/game/client/prediction/entities/character.cpp
+++ b/src/game/client/prediction/entities/character.cpp
@@ -1042,7 +1042,24 @@ void CCharacter::DDRacePostCoreTick()
 	HandleSkippableTiles(CurrentIndex);
 
 	// handle Anti-Skip tiles
-	std::vector<int> vIndices = Collision()->GetMapIndices(m_PrevPos, m_Pos);
+	std::vector<int> vIndices;
+	if(m_Core.m_BouncePostions.empty())
+	{
+	 	vIndices = Collision()->GetMapIndices(m_PrevPos, m_Pos);
+	}
+	else
+	{
+		// handle bouncing being multiple straight lines
+		vIndices = Collision()->GetMapIndices(m_PrevPos, m_Core.m_BouncePostions.front());
+		for(size_t i = 0; i < m_Core.m_BouncePostions.size() - 1; ++i)
+		{
+			std::vector<int> vStepIndices = Collision()->GetMapIndices(m_Core.m_BouncePostions[i], m_Core.m_BouncePostions[i + 1]);
+			vIndices.insert(vIndices.end(), vStepIndices.begin(), vStepIndices.end());
+		}
+		std::vector<int> vLastStepIndices = Collision()->GetMapIndices(m_Core.m_BouncePostions.back(), m_Pos);
+		vIndices.insert(vIndices.end(), vLastStepIndices.begin(), vLastStepIndices.end());
+	}
+
 	if(!vIndices.empty())
 		for(int Index : vIndices)
 			HandleTiles(Index);

--- a/src/game/collision.cpp
+++ b/src/game/collision.cpp
@@ -519,7 +519,7 @@ bool CCollision::TestBox(vec2 Pos, vec2 Size) const
 	return false;
 }
 
-void CCollision::MoveBox(vec2 *pInoutPos, vec2 *pInoutVel, vec2 Size, vec2 Elasticity, bool *pGrounded) const
+void CCollision::MoveBox(vec2 *pInoutPos, vec2 *pInoutVel, vec2 Size, vec2 Elasticity, bool *pGrounded, std::vector<vec2> *pBouncePositions) const
 {
 	// do the move
 	vec2 Pos = *pInoutPos;
@@ -564,6 +564,8 @@ void CCollision::MoveBox(vec2 *pInoutPos, vec2 *pInoutVel, vec2 Size, vec2 Elast
 					NewPos.y = Pos.y;
 					Vel.y *= -ElasticityY;
 					Hits++;
+					if(pBouncePositions)
+						pBouncePositions->push_back(NewPos);
 				}
 
 				if(TestBox(vec2(NewPos.x, Pos.y), Size))
@@ -571,6 +573,8 @@ void CCollision::MoveBox(vec2 *pInoutPos, vec2 *pInoutVel, vec2 Size, vec2 Elast
 					NewPos.x = Pos.x;
 					Vel.x *= -ElasticityX;
 					Hits++;
+					if(pBouncePositions)
+						pBouncePositions->push_back(NewPos);
 				}
 
 				// neither of the tests got a collision.
@@ -583,6 +587,8 @@ void CCollision::MoveBox(vec2 *pInoutPos, vec2 *pInoutVel, vec2 Size, vec2 Elast
 					Vel.y *= -ElasticityY;
 					NewPos.x = Pos.x;
 					Vel.x *= -ElasticityX;
+					if(pBouncePositions)
+						pBouncePositions->push_back(NewPos);
 				}
 			}
 

--- a/src/game/collision.h
+++ b/src/game/collision.h
@@ -49,7 +49,7 @@ public:
 	int IntersectLineTeleWeapon(vec2 Pos0, vec2 Pos1, vec2 *pOutCollision, vec2 *pOutBeforeCollision, int *pTeleNr = nullptr) const;
 	int IntersectLineTeleHook(vec2 Pos0, vec2 Pos1, vec2 *pOutCollision, vec2 *pOutBeforeCollision, int *pTeleNr = nullptr) const;
 	void MovePoint(vec2 *pInoutPos, vec2 *pInoutVel, float Elasticity, int *pBounces) const;
-	void MoveBox(vec2 *pInoutPos, vec2 *pInoutVel, vec2 Size, vec2 Elasticity, bool *pGrounded = nullptr) const;
+	void MoveBox(vec2 *pInoutPos, vec2 *pInoutVel, vec2 Size, vec2 Elasticity, bool *pGrounded = nullptr, std::vector<vec2> *pBouncePositions = nullptr) const;
 	bool TestBox(vec2 Pos, vec2 Size) const;
 
 	// DDRace

--- a/src/game/gamecore.cpp
+++ b/src/game/gamecore.cpp
@@ -538,10 +538,13 @@ void CCharacterCore::Move()
 
 	vec2 OldVel = m_Vel;
 	bool Grounded = false;
+	m_BouncePostions.clear();
+
 	m_pCollision->MoveBox(&NewPos, &m_Vel, PhysicalSizeVec2(),
 		vec2(m_Tuning.m_GroundElasticityX,
 			m_Tuning.m_GroundElasticityY),
-		&Grounded);
+		&Grounded,
+		&m_BouncePostions);
 
 	if(Grounded)
 	{

--- a/src/game/gamecore.h
+++ b/src/game/gamecore.h
@@ -241,6 +241,7 @@ public:
 
 	int m_Colliding;
 	bool m_LeftWall;
+	std::vector<vec2> m_BouncePostions;
 
 	// DDNet Character
 	void SetTeamsCore(CTeamsCore *pTeams);

--- a/src/game/server/entities/character.cpp
+++ b/src/game/server/entities/character.cpp
@@ -2180,7 +2180,24 @@ void CCharacter::DDRacePostCoreTick()
 		return;
 
 	// handle Anti-Skip tiles
-	std::vector<int> vIndices = Collision()->GetMapIndices(m_PrevPos, m_Pos);
+	std::vector<int> vIndices;
+	if(m_Core.m_BouncePostions.empty())
+	{
+	 	vIndices = Collision()->GetMapIndices(m_PrevPos, m_Pos);
+	}
+	else
+	{
+		// handle bouncing being multiple straight lines
+		vIndices = Collision()->GetMapIndices(m_PrevPos, m_Core.m_BouncePostions.front());
+		for(size_t i = 0; i < m_Core.m_BouncePostions.size() - 1; ++i)
+		{
+			std::vector<int> vStepIndices = Collision()->GetMapIndices(m_Core.m_BouncePostions[i], m_Core.m_BouncePostions[i + 1]);
+			vIndices.insert(vIndices.end(), vStepIndices.begin(), vStepIndices.end());
+		}
+		std::vector<int> vLastStepIndices = Collision()->GetMapIndices(m_Core.m_BouncePostions.back(), m_Pos);
+		vIndices.insert(vIndices.end(), vLastStepIndices.begin(), vLastStepIndices.end());
+	}
+
 	if(!vIndices.empty())
 	{
 		for(int &Index : vIndices)


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->
closes #4523 

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->
This MAY affect existing maps, but to a very small degree. This also changes normal behaviour right now, since "normal behaviour" is a bounce with 0 back velocity.

@heinrich5991 should I add a MapBugfix (similar to the double grenade bug) option to this?

Somebody besides me should also test this in-game. A profiling (before->after) would be nice, since this may cause some overhead.

## TestMap

A testmap where you can skip a freezetile with bouncing
[bounce_test.zip](https://github.com/user-attachments/files/17688558/bounce_test.zip)

## Before

![screenshot_2024-11-09_16-55-18](https://github.com/user-attachments/assets/30e35e2b-ee5e-4bde-b94a-7ad7f1225088)

## After

![screenshot_2024-11-09_16-54-59](https://github.com/user-attachments/assets/2876158a-f81c-47c3-8900-90c4c49316c2)

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options (only ground_elasticity_y 1.0)
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] **Changed no physics that affect existing maps**
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)

