### PR TITLE
Remove ENV-vars from FindMySQL.cmake

### DIFF
--- a/cmake/FindMySQL.cmake
+++ b/cmake/FindMySQL.cmake
@@ -36,21 +36,12 @@ if(NOT CMAKE_CROSSCOMPILING)
   endif()
 endif()
 
-if(DEFINED ENV{MYSQL_LIBRARY_PATH})
-  list(APPEND MYSQL_CONFIG_LIBRARY_PATH $ENV{MYSQL_LIBRARY_PATH})
-endif()
-
-if(DEFINED ENV{MYSQL_INCLUDE_PATH})
-  set(MYSQL_CONFIG_INCLUDE_DIR $ENV{MYSQL_INCLUDE_PATH})
-endif()
+set_extra_dirs_lib(MYSQL mysql)
 
 find_library(MYSQL_LIBRARY
   NAMES "mysqlclient" "mysqlclient_r" "mariadbclient"
+  #explicitly tell CMake to search through the nix/store when using nix/NixOS
   HINTS 
-    ${MYSQL_CONFIG_LIBRARY_PATH}
-    $ENV{MYSQL_LIBRARY_PATH}
-    ${CMAKE_CURRENT_LIST_DIR}/../mysql
-    /run/current-system/sw/lib
     ${NIX_STORE_DIR}
   PATHS
     /nix/store
@@ -59,14 +50,9 @@ find_library(MYSQL_LIBRARY
     mariadb
   ${CROSSCOMPILING_NO_CMAKE_SYSTEM_PATH}
 )
-
 find_path(MYSQL_INCLUDEDIR
   NAMES "mysql.h"
   HINTS 
-    ${MYSQL_CONFIG_INCLUDE_DIR}
-    $ENV{MYSQL_INCLUDE_PATH}
-    ${CMAKE_CURRENT_LIST_DIR}/../mysql
-    /run/current-system/sw/include
     ${NIX_STORE_DIR}
   PATHS
     /nix/store


### PR DESCRIPTION
i forgot to remove the test ENV variables i didnt intend to push - i also added a small comment to explain the usecase for explicitly looking through the /nix/store. Thanks for noticing @heinrich5991

i didnt find a proper upstream issue about pkg-config not finding mysql on nixOS, so i'll keep digging

(also sorry for the messup there)
## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
