### PR TITLE
Remove obsolete and broken `MakeVersion` function for map items

### DIFF
--- a/src/game/editor/mapitems/map_io.cpp
+++ b/src/game/editor/mapitems/map_io.cpp
@@ -15,12 +15,6 @@
 #include "image.h"
 #include "sound.h"
 
-template<typename T>
-static int MakeVersion(int i, const T &v)
-{
-	return (i << 16) + sizeof(T);
-}
-
 // compatibility with old sound layers
 struct CSoundSource_DEPRECATED
 {
@@ -853,15 +847,6 @@ bool CEditorMap::Load(const char *pFileName, int StorageType, const std::functio
 						void *pData = DataFile.GetData(pTilemapItem->m_Data);
 						unsigned int Size = DataFile.GetDataSize(pTilemapItem->m_Data);
 						pTiles->ExtractTiles(pTilemapItem->m_Version, (CTile *)pData, Size);
-
-						if(pTiles->m_Game && pTilemapItem->m_Version == MakeVersion(1, *pTilemapItem))
-						{
-							for(int i = 0; i < pTiles->m_Width * pTiles->m_Height; i++)
-							{
-								if(pTiles->m_pTiles[i].m_Index)
-									pTiles->m_pTiles[i].m_Index += ENTITY_OFFSET;
-							}
-						}
 						DataFile.UnloadData(pTilemapItem->m_Data);
 					}
 				}


### PR DESCRIPTION
The `MakeVersion` function dates back to at least 72c06a258940696093f255fb1061beb58e1cdd0b but it seems obsolete and broken in its current state. The function call `MakeVersion(1, *pTilemapItem)` currently returns the version number `65628` which does not conform to the version scheme for other map items and is not in the range of expected versions for `CMapItemLayerTilemap` items (versions 1-4). Because this functions derives the version based on the size of the `CMapItemLayerTilemap` item, it likely does not work correctly anymore, as the size of the map item has been changed after the `MakeVersion` function was created. Furthermore, additional handling for `CMapItemLayerTilemap` items of this version would also be missing on the server-side and for ingame client rendering.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
