### PR TITLE
Add Simplify Tele popup setting

### DIFF
--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -111,6 +111,7 @@ MACRO_CONFIG_INT(EdAlignQuads, ed_align_quads, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG
 MACRO_CONFIG_INT(EdShowQuadsRect, ed_show_quads_rect, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show the bounds of the selected quad. In case of multiple quads, it shows the bounds of the englobing rect. Can be helpful when aligning a group of quads")
 MACRO_CONFIG_INT(EdAutoMapReload, ed_auto_map_reload, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Run 'hot_reload' on the local server while rcon authed on map save")
 MACRO_CONFIG_INT(EdLayerSelector, ed_layer_selector, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Ctrl+right click tiles to select their layers in the editor")
+MACRO_CONFIG_INT(EdSimplifyTeles, ed_simplify_teles, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Simplifies the Tele popup")
 
 MACRO_CONFIG_INT(ClShowWelcome, cl_show_welcome, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show welcome message indicating the first launch of the client")
 MACRO_CONFIG_INT(ClMotdTime, cl_motd_time, 10, 0, 100, CFGFLAG_CLIENT | CFGFLAG_SAVE, "How long to show the server message of the day")

--- a/src/game/editor/editor.h
+++ b/src/game/editor/editor.h
@@ -1175,6 +1175,8 @@ public:
 	void AdjustBrushSpecialTiles(bool UseNextFree, int Adjust = 0);
 	int FindNextFreeSwitchNumber();
 	int FindNextFreeTeleNumber(int Index);
+	int FindNextFreeTeleNumberAny(bool Checkpoint = false);
+	void SetTeleNumbers(int Number, bool Checkpoint = false);
 
 	// Undo/Redo
 	CEditorHistory m_EditorHistory;

--- a/src/game/editor/mapitems/layer_tele.cpp
+++ b/src/game/editor/mapitems/layer_tele.cpp
@@ -310,6 +310,21 @@ bool CLayerTele::ContainsElementWithId(int Id, int Index)
 	return false;
 }
 
+bool CLayerTele::ContainsTeleWithId(int Id, bool Checkpoint)
+{
+	for(int y = 0; y < m_Height; ++y)
+	{
+		for(int x = 0; x < m_Width; ++x)
+		{
+			if(IsTeleTileNumberUsed(m_pTeleTile[y * m_Width + x].m_Type, Checkpoint) && m_pTeleTile[y * m_Width + x].m_Number == Id)
+			{
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
 void CLayerTele::GetPos(int Number, int Offset, int &TeleX, int &TeleY)
 {
 	int Match = -1;

--- a/src/game/editor/mapitems/layer_tele.h
+++ b/src/game/editor/mapitems/layer_tele.h
@@ -33,6 +33,7 @@ public:
 	void BrushRotate(float Amount) override;
 	void FillSelection(bool Empty, std::shared_ptr<CLayer> pBrush, CUIRect Rect) override;
 	virtual bool ContainsElementWithId(int Id, int Index);
+	virtual bool ContainsTeleWithId(int Id, bool Checkpoint);
 	virtual void GetPos(int Number, int Offset, int &TeleX, int &TeleY);
 
 	int m_GotoTeleOffset;

--- a/src/game/editor/mapitems/layer_tiles.cpp
+++ b/src/game/editor/mapitems/layer_tiles.cpp
@@ -3,6 +3,7 @@
 #include "layer_tiles.h"
 
 #include <engine/keys.h>
+#include <engine/shared/config.h>
 #include <engine/shared/map.h>
 #include <game/editor/editor.h>
 #include <game/editor/editor_actions.h>
@@ -313,7 +314,17 @@ int CLayerTiles::BrushGrab(std::shared_ptr<CLayerGroup> pBrush, CUIRect Rect)
 					unsigned char TgtIndex = pGrabbed->m_pTeleTile[y * pGrabbed->m_Width + x].m_Type;
 					if(IsValidTeleTile(TgtIndex) && IsTeleTileNumberUsedAny(TgtIndex))
 					{
-						m_pEditor->m_TeleNumbers[TgtIndex] = pGrabbed->m_pTeleTile[y * pGrabbed->m_Width + x].m_Number;
+						if(g_Config.m_EdSimplifyTeles)
+						{
+							if(IsTeleTileNumberUsed(TgtIndex, false))
+								m_pEditor->SetTeleNumbers(pGrabbed->m_pTeleTile[y * pGrabbed->m_Width + x].m_Number);
+							else if(IsTeleTileNumberUsed(TgtIndex, true))
+								m_pEditor->SetTeleNumbers(pGrabbed->m_pTeleTile[y * pGrabbed->m_Width + x].m_Number, true);
+						}
+						else
+						{
+							m_pEditor->m_TeleNumbers[TgtIndex] = pGrabbed->m_pTeleTile[y * pGrabbed->m_Width + x].m_Number;
+						}
 					}
 				}
 				else


### PR DESCRIPTION
Adds a setting to revert #8961, as some mappers don't use all teleports on their maps. This change was requested on Discord.
Also fixes an issue where the view instantly teleports to teleport number 1 when the teleport popup got first opened

![image](https://github.com/user-attachments/assets/884b7713-3dd0-4f9e-a830-28cf383101f2)
![image](https://github.com/user-attachments/assets/3311dab2-0bae-4f64-8d3f-80ef758a67b9)


## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
