### PR TITLE
Increase MSVC stack size

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2602,7 +2602,7 @@ if(CLIENT)
   target_link_libraries(game-client ${LIBS_CLIENT})
 
   if(MSVC)
-    target_link_options(game-client PRIVATE /ENTRY:mainCRTStartup)
+    target_link_options(game-client PRIVATE /ENTRY:mainCRTStartup /STACK:2097152)
   endif()
 
   target_include_directories(game-client SYSTEM PRIVATE
@@ -2792,6 +2792,11 @@ if(SERVER)
   set_property(TARGET game-server
       PROPERTY OUTPUT_NAME ${SERVER_EXECUTABLE}
   )
+
+  if(MSVC)
+    target_link_options(game-server PRIVATE /STACK:2097152)
+  endif()
+
   target_link_libraries(game-server ${LIBS_SERVER})
   target_include_directories(game-server PRIVATE ${PNG_INCLUDE_DIRS})
   list(APPEND TARGETS_OWN game-server)


### PR DESCRIPTION
Because of #9226 the stack size was too small, causing the game to instantly crash when joining any server if compiled with Visual Studio on Windows. This PR increases the stack size from 1 MB to 2 MB, which prevents the crash, but not sure if this amount of memory will be enough in all cases, as this doesn't make the C6262 warnings go away. 
I think that commit should be reverted, but for now, at least this PR makes the game playable.

Before: 
![image](https://github.com/user-attachments/assets/943a5f99-ee42-4ef1-8612-23000afd58f0)
![image](https://github.com/user-attachments/assets/5eecc7bb-1957-464b-9eeb-e5f2ccef739f)


## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
