### PR TITLE
Fix client hanging when rendering text with small maximum width

### DIFF
--- a/src/engine/client/text.cpp
+++ b/src/engine/client/text.cpp
@@ -1560,6 +1560,7 @@ public:
 
 		const char *pCurrent = pText;
 		const char *pEnd = pCurrent + Length;
+		const char *pPrevBatchEnd = nullptr;
 		const char *pEllipsis = "…";
 		const SGlyph *pEllipsisGlyph = nullptr;
 		if(pCursor->m_Flags & TEXTFLAG_ELLIPSIS_AT_END)
@@ -1966,6 +1967,9 @@ public:
 
 			if(NewLine)
 			{
+				if(pPrevBatchEnd == pBatchEnd)
+					break;
+				pPrevBatchEnd = pBatchEnd;
 				if(!StartNewLine())
 					break;
 				GotNewLineLast = true;


### PR DESCRIPTION
Previously, when rendering text with a maximum width that is too small for a single glyph then the text rendering would loop indefinitely trying to advance the cursor to the next line where the glyph will also not fit.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
