### PR TITLE
Move texture scale initialization and conchain to `CMapImages`

### DIFF
--- a/src/game/client/components/mapimages.cpp
+++ b/src/game/client/components/mapimages.cpp
@@ -25,15 +25,9 @@ const char *const gs_apModEntitiesNames[] = {
 	"f-ddrace",
 };
 
-CMapImages::CMapImages() :
-	CMapImages(100)
-{
-}
-
-CMapImages::CMapImages(int TextureSize)
+CMapImages::CMapImages()
 {
 	m_Count = 0;
-	m_TextureScale = TextureSize;
 	mem_zero(m_aEntitiesIsLoaded, sizeof(m_aEntitiesIsLoaded));
 	m_SpeedupArrowIsLoaded = false;
 
@@ -44,6 +38,7 @@ CMapImages::CMapImages(int TextureSize)
 
 void CMapImages::OnInit()
 {
+	m_TextureScale = g_Config.m_ClTextEntitiesSize;
 	InitOverlayTextures();
 
 	if(str_comp(g_Config.m_ClAssetsEntities, "default") == 0)
@@ -52,6 +47,8 @@ void CMapImages::OnInit()
 	{
 		str_format(m_aEntitiesPath, sizeof(m_aEntitiesPath), "assets/entities/%s", g_Config.m_ClAssetsEntities);
 	}
+
+	Console()->Chain("cl_text_entities_size", ConchainClTextEntitiesSize, this);
 }
 
 void CMapImages::OnMapLoadImpl(class CLayers *pLayers, IMap *pMap)
@@ -378,6 +375,16 @@ void CMapImages::ChangeEntitiesPath(const char *pPath)
 			}
 			m_aEntitiesIsLoaded[ModType] = false;
 		}
+	}
+}
+
+void CMapImages::ConchainClTextEntitiesSize(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData)
+{
+	pfnCallback(pResult, pCallbackUserData);
+	if(pResult->NumArguments())
+	{
+		CMapImages *pThis = static_cast<CMapImages *>(pUserData);
+		pThis->SetTextureScale(g_Config.m_ClTextEntitiesSize);
 	}
 }
 

--- a/src/game/client/components/mapimages.h
+++ b/src/game/client/components/mapimages.h
@@ -3,6 +3,7 @@
 #ifndef GAME_CLIENT_COMPONENTS_MAPIMAGES_H
 #define GAME_CLIENT_COMPONENTS_MAPIMAGES_H
 
+#include <engine/console.h>
 #include <engine/graphics.h>
 
 #include <game/client/component.h>
@@ -43,7 +44,6 @@ class CMapImages : public CComponent
 
 public:
 	CMapImages();
-	CMapImages(int TextureSize);
 	virtual int Sizeof() const override { return sizeof(*this); }
 
 	IGraphics::CTextureHandle Get(int Index) const { return m_aTextures[Index]; }
@@ -77,6 +77,7 @@ private:
 	IGraphics::CTextureHandle m_OverlayCenterTexture;
 	int m_TextureScale;
 
+	static void ConchainClTextEntitiesSize(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 	void InitOverlayTextures();
 	IGraphics::CTextureHandle UploadEntityLayerText(int TextureSize, int MaxWidth, int YOffset);
 	void UpdateEntityLayerText(CImageInfo &TextImage, int TextureSize, int MaxWidth, int YOffset, int NumbersPower, int MaxNumber = -1);

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -247,7 +247,6 @@ void CGameClient::OnConsoleInit()
 	Console()->Chain("cl_vanilla_skins_only", ConchainRefreshSkins, this);
 
 	Console()->Chain("cl_dummy", ConchainSpecialDummy, this);
-	Console()->Chain("cl_text_entities_size", ConchainClTextEntitiesSize, this);
 
 	Console()->Chain("cl_menu_map", ConchainMenuMap, this);
 }
@@ -406,8 +405,6 @@ void CGameClient::OnInit()
 
 	GenerateTimeoutCode(g_Config.m_ClTimeoutCode);
 	GenerateTimeoutCode(g_Config.m_ClDummyTimeoutCode);
-
-	m_MapImages.SetTextureScale(g_Config.m_ClTextEntitiesSize);
 
 	// Aggressively try to grab window again since some Windows users report
 	// window not being focused after starting client.
@@ -2777,17 +2774,6 @@ void CGameClient::ConchainSpecialDummy(IConsole::IResult *pResult, void *pUserDa
 	{
 		if(g_Config.m_ClDummy && !((CGameClient *)pUserData)->Client()->DummyConnected())
 			g_Config.m_ClDummy = 0;
-	}
-}
-
-void CGameClient::ConchainClTextEntitiesSize(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData)
-{
-	pfnCallback(pResult, pCallbackUserData);
-
-	if(pResult->NumArguments())
-	{
-		CGameClient *pGameClient = (CGameClient *)pUserData;
-		pGameClient->m_MapImages.SetTextureScale(g_Config.m_ClTextEntitiesSize);
 	}
 }
 

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -227,7 +227,6 @@ private:
 	static void ConchainSpecialDummyInfoupdate(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 	static void ConchainRefreshSkins(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 	static void ConchainSpecialDummy(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
-	static void ConchainClTextEntitiesSize(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 
 	static void ConTuneZone(IConsole::IResult *pResult, void *pUserData);
 


### PR DESCRIPTION
Avoid unnecessary indirection in the gameclient by moving the initialization of the texture scale and the conchain for the `cl_text_entities_size` variable directly to `CMapImages`.

Remove the unused `CMapImages` constructor accepting a texture scale value that is never used.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
