### PR TITLE
Use separate packer with larger buffer only for Teehistorian

### DIFF
--- a/src/engine/shared/packer.cpp
+++ b/src/engine/shared/packer.cpp
@@ -5,14 +5,20 @@
 #include "compression.h"
 #include "packer.h"
 
-void CPacker::Reset()
+CAbstractPacker::CAbstractPacker(unsigned char *pBuffer, size_t Size) :
+	m_pBuffer(pBuffer),
+	m_BufferSize(Size)
 {
-	m_Error = false;
-	m_pCurrent = m_aBuffer;
-	m_pEnd = m_pCurrent + PACKER_BUFFER_SIZE;
 }
 
-void CPacker::AddInt(int i)
+void CAbstractPacker::Reset()
+{
+	m_Error = false;
+	m_pCurrent = m_pBuffer;
+	m_pEnd = m_pCurrent + m_BufferSize;
+}
+
+void CAbstractPacker::AddInt(int i)
 {
 	if(m_Error)
 		return;
@@ -26,7 +32,7 @@ void CPacker::AddInt(int i)
 	m_pCurrent = pNext;
 }
 
-void CPacker::AddString(const char *pStr, int Limit, bool AllowTruncation)
+void CAbstractPacker::AddString(const char *pStr, int Limit, bool AllowTruncation)
 {
 	if(m_Error)
 		return;
@@ -34,7 +40,7 @@ void CPacker::AddString(const char *pStr, int Limit, bool AllowTruncation)
 	unsigned char *const pPrevCurrent = m_pCurrent;
 	if(Limit <= 0)
 	{
-		Limit = PACKER_BUFFER_SIZE;
+		Limit = m_BufferSize;
 	}
 	while(*pStr)
 	{
@@ -70,7 +76,7 @@ void CPacker::AddString(const char *pStr, int Limit, bool AllowTruncation)
 	*m_pCurrent++ = '\0';
 }
 
-void CPacker::AddRaw(const void *pData, int Size)
+void CAbstractPacker::AddRaw(const void *pData, int Size)
 {
 	if(m_Error)
 		return;

--- a/src/engine/shared/packer.cpp
+++ b/src/engine/shared/packer.cpp
@@ -26,39 +26,48 @@ void CPacker::AddInt(int i)
 	m_pCurrent = pNext;
 }
 
-void CPacker::AddString(const char *pStr, int Limit)
+void CPacker::AddString(const char *pStr, int Limit, bool AllowTruncation)
 {
 	if(m_Error)
 		return;
 
+	unsigned char *const pPrevCurrent = m_pCurrent;
 	if(Limit <= 0)
 	{
 		Limit = PACKER_BUFFER_SIZE;
 	}
-	while(*pStr && Limit != 0)
+	while(*pStr)
 	{
 		int Codepoint = str_utf8_decode(&pStr);
 		if(Codepoint == -1)
 		{
 			Codepoint = 0xfffd; // Unicode replacement character.
 		}
-		char aGarbage[4];
-		int Length = str_utf8_encode(aGarbage, Codepoint);
+		char aEncoded[4];
+		const int Length = str_utf8_encode(aEncoded, Codepoint);
+		// Limit must ensure space for null termination if desired.
 		if(Limit < Length)
 		{
-			break;
+			if(AllowTruncation)
+			{
+				break;
+			}
+			m_Error = true;
+			m_pCurrent = pPrevCurrent;
+			return;
 		}
 		// Ensure space for the null termination.
-		if(m_pEnd - m_pCurrent < Length + 1)
+		if(m_pCurrent + Length + 1 > m_pEnd)
 		{
 			m_Error = true;
-			break;
+			m_pCurrent = pPrevCurrent;
+			return;
 		}
-		Length = str_utf8_encode((char *)m_pCurrent, Codepoint);
+		mem_copy(m_pCurrent, aEncoded, Length);
 		m_pCurrent += Length;
 		Limit -= Length;
 	}
-	*m_pCurrent++ = 0;
+	*m_pCurrent++ = '\0';
 }
 
 void CPacker::AddRaw(const void *pData, int Size)

--- a/src/engine/shared/packer.h
+++ b/src/engine/shared/packer.h
@@ -3,29 +3,51 @@
 #ifndef ENGINE_SHARED_PACKER_H
 #define ENGINE_SHARED_PACKER_H
 
-class CPacker
-{
-public:
-	enum
-	{
-		PACKER_BUFFER_SIZE = 1024 * 64
-	};
+#include <cstddef>
 
+/**
+ * Abstract packer implementation. Subclasses must supply the buffer.
+ */
+class CAbstractPacker
+{
 private:
-	unsigned char m_aBuffer[PACKER_BUFFER_SIZE];
+	unsigned char *const m_pBuffer;
+	const size_t m_BufferSize;
 	unsigned char *m_pCurrent;
 	unsigned char *m_pEnd;
 	bool m_Error;
 
+protected:
+	CAbstractPacker(unsigned char *pBuffer, size_t Size);
+
 public:
 	void Reset();
 	void AddInt(int i);
-	void AddString(const char *pStr, int Limit = PACKER_BUFFER_SIZE, bool AllowTruncation = true);
+	void AddString(const char *pStr, int Limit = 0, bool AllowTruncation = true);
 	void AddRaw(const void *pData, int Size);
 
-	int Size() const { return (int)(m_pCurrent - m_aBuffer); }
-	const unsigned char *Data() const { return m_aBuffer; }
+	int Size() const { return (int)(m_pCurrent - m_pBuffer); }
+	const unsigned char *Data() const { return m_pBuffer; }
 	bool Error() const { return m_Error; }
+};
+
+/**
+ * Default packer with buffer for networking.
+ */
+class CPacker : public CAbstractPacker
+{
+public:
+	enum
+	{
+		PACKER_BUFFER_SIZE = 1024 * 2
+	};
+	CPacker() :
+		CAbstractPacker(m_aBuffer, sizeof(m_aBuffer))
+	{
+	}
+
+private:
+	unsigned char m_aBuffer[PACKER_BUFFER_SIZE];
 };
 
 class CUnpacker

--- a/src/engine/shared/packer.h
+++ b/src/engine/shared/packer.h
@@ -20,7 +20,7 @@ private:
 public:
 	void Reset();
 	void AddInt(int i);
-	void AddString(const char *pStr, int Limit = PACKER_BUFFER_SIZE);
+	void AddString(const char *pStr, int Limit = PACKER_BUFFER_SIZE, bool AllowTruncation = true);
 	void AddRaw(const void *pData, int Size);
 
 	int Size() const { return (int)(m_pCurrent - m_aBuffer); }

--- a/src/test/packer.cpp
+++ b/src/test/packer.cpp
@@ -5,24 +5,24 @@
 #include <engine/shared/packer.h>
 
 // pExpected is NULL if an error is expected
-static void ExpectAddString5(const char *pString, int Limit, const char *pExpected)
+static void ExpectAddString5(const char *pString, int Limit, bool AllowTruncation, const char *pExpected)
 {
 	static char ZEROS[CPacker::PACKER_BUFFER_SIZE] = {0};
 	static const int OFFSET = CPacker::PACKER_BUFFER_SIZE - 5;
 	CPacker Packer;
 	Packer.Reset();
 	Packer.AddRaw(ZEROS, OFFSET);
-	Packer.AddString(pString, Limit);
+	Packer.AddString(pString, Limit, AllowTruncation);
 
-	EXPECT_EQ(pExpected == 0, Packer.Error());
+	EXPECT_EQ(pExpected == 0, Packer.Error()) << "for String='" << pString << "', Limit='" << Limit << "', AllowTruncation='" << AllowTruncation << "'";
 	if(pExpected)
 	{
 		// Include null termination.
 		int ExpectedLength = str_length(pExpected) + 1;
-		EXPECT_EQ(ExpectedLength, Packer.Size() - OFFSET);
+		EXPECT_EQ(ExpectedLength, Packer.Size() - OFFSET) << "for String='" << pString << "', Limit='" << Limit << "', AllowTruncation='" << AllowTruncation << "'";
 		if(ExpectedLength == Packer.Size() - OFFSET)
 		{
-			EXPECT_STREQ(pExpected, (const char *)Packer.Data() + OFFSET);
+			EXPECT_STREQ(pExpected, (const char *)Packer.Data() + OFFSET) << "for String='" << pString << "', Limit='" << Limit << "', AllowTruncation='" << AllowTruncation << "'";
 		}
 	}
 }
@@ -207,40 +207,63 @@ TEST(Packer, AddExtendedInt)
 
 TEST(Packer, AddString)
 {
-	ExpectAddString5("", 0, "");
-	ExpectAddString5("a", 0, "a");
-	ExpectAddString5("abcd", 0, "abcd");
-	ExpectAddString5("abcde", 0, 0);
+	ExpectAddString5("", 0, true, "");
+	ExpectAddString5("a", 0, true, "a");
+	ExpectAddString5("abcd", 0, true, "abcd");
+	ExpectAddString5("abcde", 0, true, nullptr);
 }
 
 TEST(Packer, AddStringLimit)
 {
-	ExpectAddString5("", 1, "");
-	ExpectAddString5("a", 1, "a");
-	ExpectAddString5("aa", 1, "a");
-	ExpectAddString5("ä", 1, "");
+	ExpectAddString5("", 1, true, "");
+	ExpectAddString5("a", 1, true, "a");
+	ExpectAddString5("aa", 1, true, "a");
+	ExpectAddString5("ä", 1, true, "");
 
-	ExpectAddString5("", 10, "");
-	ExpectAddString5("a", 10, "a");
-	ExpectAddString5("abcd", 10, "abcd");
-	ExpectAddString5("abcde", 10, 0);
+	ExpectAddString5("", 10, true, "");
+	ExpectAddString5("a", 10, true, "a");
+	ExpectAddString5("abcd", 10, true, "abcd");
+	ExpectAddString5("abcde", 10, true, nullptr);
 
-	ExpectAddString5("äöü", 5, "äö");
-	ExpectAddString5("äöü", 6, 0);
+	ExpectAddString5("äöü", 4, true, "äö");
+	ExpectAddString5("äöü", 5, true, "äö");
+	ExpectAddString5("äöü", 6, true, nullptr);
+
+	ExpectAddString5("", 1, false, "");
+	ExpectAddString5("a", 1, false, "a");
+	ExpectAddString5("aa", 1, false, nullptr);
+	ExpectAddString5("ä", 1, false, nullptr);
+
+	ExpectAddString5("", 10, false, "");
+	ExpectAddString5("a", 10, false, "a");
+	ExpectAddString5("abcd", 10, false, "abcd");
+	ExpectAddString5("abcde", 10, false, nullptr);
+
+	ExpectAddString5("äöü", 4, false, nullptr);
+	ExpectAddString5("äöü", 5, false, nullptr);
+	ExpectAddString5("äöü", 6, false, nullptr);
 }
 
 TEST(Packer, AddStringBroken)
 {
-	ExpectAddString5("\x80", 0, "�");
-	ExpectAddString5("\x80\x80", 0, 0);
-	ExpectAddString5("a\x80", 0, "a�");
+	ExpectAddString5("\x80", 0, true, "�");
+	ExpectAddString5("\x80\x80", 0, true, nullptr);
+	ExpectAddString5("a\x80", 0, true, "a�");
 	ExpectAddString5("\x80"
 			 "a",
-		0, "�a");
-	ExpectAddString5("\x80", 1, "");
-	ExpectAddString5("\x80\x80", 3, "�");
-	ExpectAddString5("\x80\x80", 5, "�");
-	ExpectAddString5("\x80\x80", 6, 0);
+		0, true, "�a");
+
+	ExpectAddString5("\x80", 1, true, "");
+	ExpectAddString5("\x80", 3, true, "�");
+	ExpectAddString5("\x80\x80", 3, true, "�");
+	ExpectAddString5("\x80\x80", 5, true, "�");
+	ExpectAddString5("\x80\x80", 6, true, nullptr);
+
+	ExpectAddString5("\x80", 1, false, nullptr);
+	ExpectAddString5("\x80", 3, false, "�");
+	ExpectAddString5("\x80\x80", 3, false, nullptr);
+	ExpectAddString5("\x80\x80", 5, false, nullptr);
+	ExpectAddString5("\x80\x80", 6, false, nullptr);
 }
 
 TEST(Packer, Error)

--- a/src/test/packer.cpp
+++ b/src/test/packer.cpp
@@ -266,56 +266,62 @@ TEST(Packer, AddStringBroken)
 	ExpectAddString5("\x80\x80", 6, false, nullptr);
 }
 
-TEST(Packer, Error)
+TEST(Packer, Error1)
 {
 	char aData[CPacker::PACKER_BUFFER_SIZE];
 	mem_zero(aData, sizeof(aData));
 
-	{
-		CPacker Packer;
-		Packer.Reset();
-		EXPECT_EQ(Packer.Error(), false);
-		Packer.AddRaw(aData, sizeof(aData) - 1);
-		EXPECT_EQ(Packer.Error(), false);
-		EXPECT_EQ(Packer.Size(), sizeof(aData) - 1);
-		Packer.AddInt(1);
-		EXPECT_EQ(Packer.Error(), false);
-		EXPECT_EQ(Packer.Size(), sizeof(aData));
-		Packer.AddInt(2);
-		EXPECT_EQ(Packer.Error(), true);
-		Packer.AddInt(3);
-		EXPECT_EQ(Packer.Error(), true);
-	}
+	CPacker Packer;
+	Packer.Reset();
+	EXPECT_EQ(Packer.Error(), false);
+	Packer.AddRaw(aData, sizeof(aData) - 1);
+	EXPECT_EQ(Packer.Error(), false);
+	EXPECT_EQ(Packer.Size(), sizeof(aData) - 1);
+	Packer.AddInt(1);
+	EXPECT_EQ(Packer.Error(), false);
+	EXPECT_EQ(Packer.Size(), sizeof(aData));
+	Packer.AddInt(2);
+	EXPECT_EQ(Packer.Error(), true);
+	Packer.AddInt(3);
+	EXPECT_EQ(Packer.Error(), true);
+}
 
-	{
-		CPacker Packer;
-		Packer.Reset();
-		EXPECT_EQ(Packer.Error(), false);
-		Packer.AddRaw(aData, sizeof(aData) - 1);
-		EXPECT_EQ(Packer.Error(), false);
-		EXPECT_EQ(Packer.Size(), sizeof(aData) - 1);
-		Packer.AddRaw(aData, 1);
-		EXPECT_EQ(Packer.Error(), false);
-		EXPECT_EQ(Packer.Size(), sizeof(aData));
-		Packer.AddRaw(aData, 1);
-		EXPECT_EQ(Packer.Error(), true);
-		Packer.AddRaw(aData, 1);
-		EXPECT_EQ(Packer.Error(), true);
-	}
+TEST(Packer, Error2)
+{
+	char aData[CPacker::PACKER_BUFFER_SIZE];
+	mem_zero(aData, sizeof(aData));
 
-	{
-		CPacker Packer;
-		Packer.Reset();
-		EXPECT_EQ(Packer.Error(), false);
-		Packer.AddRaw(aData, sizeof(aData) - 5);
-		EXPECT_EQ(Packer.Error(), false);
-		EXPECT_EQ(Packer.Size(), sizeof(aData) - 5);
-		Packer.AddString("test");
-		EXPECT_EQ(Packer.Error(), false);
-		EXPECT_EQ(Packer.Size(), sizeof(aData));
-		Packer.AddString("test");
-		EXPECT_EQ(Packer.Error(), true);
-		Packer.AddString("test");
-		EXPECT_EQ(Packer.Error(), true);
-	}
+	CPacker Packer;
+	Packer.Reset();
+	EXPECT_EQ(Packer.Error(), false);
+	Packer.AddRaw(aData, sizeof(aData) - 1);
+	EXPECT_EQ(Packer.Error(), false);
+	EXPECT_EQ(Packer.Size(), sizeof(aData) - 1);
+	Packer.AddRaw(aData, 1);
+	EXPECT_EQ(Packer.Error(), false);
+	EXPECT_EQ(Packer.Size(), sizeof(aData));
+	Packer.AddRaw(aData, 1);
+	EXPECT_EQ(Packer.Error(), true);
+	Packer.AddRaw(aData, 1);
+	EXPECT_EQ(Packer.Error(), true);
+}
+
+TEST(Packer, Error3)
+{
+	char aData[CPacker::PACKER_BUFFER_SIZE];
+	mem_zero(aData, sizeof(aData));
+
+	CPacker Packer;
+	Packer.Reset();
+	EXPECT_EQ(Packer.Error(), false);
+	Packer.AddRaw(aData, sizeof(aData) - 5);
+	EXPECT_EQ(Packer.Error(), false);
+	EXPECT_EQ(Packer.Size(), sizeof(aData) - 5);
+	Packer.AddString("test");
+	EXPECT_EQ(Packer.Error(), false);
+	EXPECT_EQ(Packer.Size(), sizeof(aData));
+	Packer.AddString("test");
+	EXPECT_EQ(Packer.Error(), true);
+	Packer.AddString("test");
+	EXPECT_EQ(Packer.Error(), true);
 }


### PR DESCRIPTION
Revert buffer size for regular `CPacker` to 2 KiB to avoid stack overflows on systems with only 1 MiB of stack memory (e.g. Windows with MSVC and Android).

Add separate `CTeehistorianPacker` with a larger buffer to be used only for Teehistorian chunks.

To avoid duplicate code the existing `CPacker` is renamed to `CAbstractPacker` and the buffer and its size are supplied by the concrete subclasses `CPacker` and `CTeehistorianPacker`.

CC #9226.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
