### PR TITLE
Fix Teehistorian server crash with MSVC due to uninitialized memory

### DIFF
--- a/src/engine/server.h
+++ b/src/engine/server.h
@@ -58,7 +58,6 @@ public:
 	virtual int ClientCountry(int ClientId) const = 0;
 	virtual bool ClientSlotEmpty(int ClientId) const = 0;
 	virtual bool ClientIngame(int ClientId) const = 0;
-	virtual bool ClientAuthed(int ClientId) const = 0;
 	virtual bool GetClientInfo(int ClientId, CClientInfo *pInfo) const = 0;
 	virtual void SetClientDDNetVersion(int ClientId, int DDNetVersion) = 0;
 	virtual void GetClientAddr(int ClientId, char *pAddrStr, int Size) const = 0;

--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -563,16 +563,17 @@ void CServer::SetRconCid(int ClientId)
 
 int CServer::GetAuthedState(int ClientId) const
 {
+	dbg_assert(ClientId >= 0 && ClientId < MAX_CLIENTS, "ClientId is not valid");
+	dbg_assert(m_aClients[ClientId].m_State != CServer::CClient::STATE_EMPTY, "Client slot is empty");
 	return m_aClients[ClientId].m_Authed;
 }
 
 const char *CServer::GetAuthName(int ClientId) const
 {
+	dbg_assert(ClientId >= 0 && ClientId < MAX_CLIENTS, "ClientId is not valid");
+	dbg_assert(m_aClients[ClientId].m_State != CServer::CClient::STATE_EMPTY, "Client slot is empty");
 	int Key = m_aClients[ClientId].m_AuthKey;
-	if(Key == -1)
-	{
-		return 0;
-	}
+	dbg_assert(Key != -1, "Client not authed");
 	return m_AuthManager.KeyIdent(Key);
 }
 
@@ -657,11 +658,6 @@ bool CServer::ClientSlotEmpty(int ClientId) const
 bool CServer::ClientIngame(int ClientId) const
 {
 	return ClientId >= 0 && ClientId < MAX_CLIENTS && m_aClients[ClientId].m_State == CServer::CClient::STATE_INGAME;
-}
-
-bool CServer::ClientAuthed(int ClientId) const
-{
-	return ClientId >= 0 && ClientId < MAX_CLIENTS && m_aClients[ClientId].m_Authed;
 }
 
 int CServer::Port() const

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -304,7 +304,6 @@ public:
 	int ClientCountry(int ClientId) const override;
 	bool ClientSlotEmpty(int ClientId) const override;
 	bool ClientIngame(int ClientId) const override;
-	bool ClientAuthed(int ClientId) const override;
 	int Port() const override;
 	int MaxClients() const override;
 	int ClientCount() const override;

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -4014,11 +4014,16 @@ void CGameContext::OnInit(const void *pPersistentData)
 
 		for(int i = 0; i < MAX_CLIENTS; i++)
 		{
-			int Level = Server()->GetAuthedState(i);
-			if(Level)
+			if(Server()->ClientSlotEmpty(i))
 			{
-				m_TeeHistorian.RecordAuthInitial(i, Level, Server()->GetAuthName(i));
+				continue;
 			}
+			const int Level = Server()->GetAuthedState(i);
+			if(Level == AUTHED_NO)
+			{
+				continue;
+			}
+			m_TeeHistorian.RecordAuthInitial(i, Level, Server()->GetAuthName(i));
 		}
 	}
 
@@ -4462,7 +4467,7 @@ void CGameContext::OnSetAuthed(int ClientId, int Level)
 	}
 	if(m_TeeHistorianActive)
 	{
-		if(Level)
+		if(Level != AUTHED_NO)
 		{
 			m_TeeHistorian.RecordAuthLogin(ClientId, Level, Server()->GetAuthName(ClientId));
 		}

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -378,7 +378,7 @@ void CPlayer::Snap(int SnappingClient)
 		pPlayerInfo->m_PlayerFlags = PlayerFlags_SixToSeven(m_PlayerFlags);
 		if(SnappingClientVersion >= VERSION_DDRACE && (m_PlayerFlags & PLAYERFLAG_AIM))
 			pPlayerInfo->m_PlayerFlags |= protocol7::PLAYERFLAG_AIM;
-		if(Server()->ClientAuthed(m_ClientId))
+		if(Server()->GetAuthedState(m_ClientId) != AUTHED_NO)
 			pPlayerInfo->m_PlayerFlags |= protocol7::PLAYERFLAG_ADMIN;
 
 		// Times are in milliseconds for 0.7


### PR DESCRIPTION
The variable `CServer::CClient::m_Authed` and the function `IServer::GetAuthedState` may only be used when the client slot is not empty, as the authed state is uninitialized before a client slot has been used for the first time. When compiling the server with MSVC the variable is not zero-initialized like with other compilers currently. This was causing the server compiled with MSVC to crash on start when Teehistorian is enabled, as empty clients were incorrectly considered as authenticated for recording the initial auth state to the Teehistorian file. For these uninitialized clients, the `IServer::GetAuthName` function was returning `nullptr` which was then causing the `CPacker::AddString` function to crash when trying to pack the `nullptr` string.

Add check to only record the initial auth state for non-empty players.

Add assertions to prevent incorrect usage of the `IServer::GetAuthedState` and `IServer::GetAuthName` functions.

Replace the separate `IServer::ClientAuthed` function with the `IServer::GetAuthedState` function.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
