### PR TITLE
Fix gametime debug graph when dummy is connected

### DIFF
--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -187,7 +187,7 @@ class CClient : public IClient, public CDemoPlayer::IListener
 
 	// graphs
 	CGraph m_InputtimeMarginGraph;
-	CGraph m_GametimeMarginGraph;
+	CGraph m_aGametimeMarginGraphs[NUM_DUMMIES];
 	CGraph m_FpsGraph;
 
 	// the game snapshots are modifiable by the game


### PR DESCRIPTION
Use separate graphs for the main and dummy gametimes to prevent the graph from using an incorrect time scale due to values for both main and dummy connection being added to it.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
