### PR TITLE
Support float config on server side

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -4133,6 +4133,11 @@ int CClient::HandleChecksum(int Conn, CUuid Uuid, CUnpacker *pUnpacker)
 	{ \
 		m_Checksum.m_Data.m_Config.m_##Name = g_Config.m_##Name; \
 	}
+#define MACRO_CONFIG_FLOAT(Name, ScriptName, Def, Min, Max, Flags, Desc) \
+	if(CHECKSUM_RECORD(Flags)) \
+	{ \
+		m_Checksum.m_Data.m_Config.m_##Name = g_Config.m_##Name; \
+	}
 #define MACRO_CONFIG_COL(Name, ScriptName, Def, Flags, Desc) \
 	if(CHECKSUM_RECORD(Flags)) \
 	{ \
@@ -4146,6 +4151,7 @@ int CClient::HandleChecksum(int Conn, CUuid Uuid, CUnpacker *pUnpacker)
 #include <engine/shared/config_variables.h>
 #undef CHECKSUM_RECORD
 #undef MACRO_CONFIG_INT
+#undef MACRO_CONFIG_FLOAT
 #undef MACRO_CONFIG_COL
 #undef MACRO_CONFIG_STR
 	}

--- a/src/engine/shared/config.h
+++ b/src/engine/shared/config.h
@@ -25,6 +25,9 @@ public:
 #define MACRO_CONFIG_INT(Name, ScriptName, Def, Min, Max, Flags, Desc) \
 	static constexpr int ms_##Name = Def; \
 	int m_##Name;
+#define MACRO_CONFIG_FLOAT(Name, ScriptName, Def, Min, Max, Flags, Desc) \
+	static constexpr float ms_##Name = Def; \
+	float m_##Name;
 #define MACRO_CONFIG_COL(Name, ScriptName, Def, Flags, Desc) \
 	static constexpr unsigned ms_##Name = Def; \
 	unsigned m_##Name;
@@ -33,6 +36,7 @@ public:
 	char m_##Name[Len]; // Flawfinder: ignore
 #include "config_variables.h"
 #undef MACRO_CONFIG_INT
+#undef MACRO_CONFIG_FLOAT
 #undef MACRO_CONFIG_COL
 #undef MACRO_CONFIG_STR
 };
@@ -65,6 +69,7 @@ struct SConfigVariable
 	enum EVariableType
 	{
 		VAR_INT,
+		VAR_FLOAT,
 		VAR_COLOR,
 		VAR_STRING,
 	};
@@ -126,6 +131,37 @@ struct SIntConfigVariable : public SConfigVariable
 	void Serialize(char *pOut, size_t Size, int Value) const;
 	void Serialize(char *pOut, size_t Size) const override;
 	void SetValue(int Value);
+	void ResetToDefault() override;
+	void ResetToOld() override;
+};
+
+struct SFloatConfigVariable : public SConfigVariable
+{
+	float *m_pVariable;
+	float m_Default;
+	float m_Min;
+	float m_Max;
+	float m_OldValue;
+
+	SFloatConfigVariable(IConsole *pConsole, const char *pScriptName, EVariableType Type, int Flags, const char *pHelp, float *pVariable, float Default, float Min, float Max) :
+		SConfigVariable(pConsole, pScriptName, Type, Flags, pHelp),
+		m_pVariable(pVariable),
+		m_Default(Default),
+		m_Min(Min),
+		m_Max(Max),
+		m_OldValue(Default)
+	{
+		*m_pVariable = m_Default;
+	}
+
+	~SFloatConfigVariable() override = default;
+
+	static void CommandCallback(IConsole::IResult *pResult, void *pUserData);
+	void Register() override;
+	bool IsDefault() const override;
+	void Serialize(char *pOut, size_t Size, float Value) const;
+	void Serialize(char *pOut, size_t Size) const override;
+	void SetValue(float Value);
 	void ResetToDefault() override;
 	void ResetToOld() override;
 };

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -6,6 +6,7 @@
 #ifndef MACRO_CONFIG_INT
 #error "The config macros must be defined"
 #define MACRO_CONFIG_INT(Name, ScriptName, Def, Min, Max, Save, Desc) ;
+#define MACRO_CONFIG_FLOAT(Name, ScriptName, Def, Min, Max, Save, Desc) ;
 #define MACRO_CONFIG_COL(Name, ScriptName, Def, Save, Desc) ;
 #define MACRO_CONFIG_STR(Name, ScriptName, Len, Def, Save, Desc) ;
 #endif

--- a/src/game/editor/editor_server_settings.cpp
+++ b/src/game/editor/editor_server_settings.cpp
@@ -26,6 +26,7 @@ struct IMapSetting
 	enum EType
 	{
 		SETTING_INT,
+		SETTING_FLOAT,
 		SETTING_COMMAND,
 	};
 	const char *m_pName;
@@ -43,6 +44,15 @@ struct SMapSettingInt : public IMapSetting
 
 	SMapSettingInt(const char *pName, const char *pHelp, int Default, int Min, int Max) :
 		IMapSetting(pName, pHelp, IMapSetting::SETTING_INT), m_Default(Default), m_Min(Min), m_Max(Max) {}
+};
+struct SMapSettingFloat : public IMapSetting
+{
+	float m_Default;
+	float m_Min;
+	float m_Max;
+
+	SMapSettingFloat(const char *pName, const char *pHelp, float Default, float Min, float Max) :
+		IMapSetting(pName, pHelp, IMapSetting::SETTING_FLOAT), m_Default(Default), m_Min(Min), m_Max(Max) {}
 };
 struct SMapSettingCommand : public IMapSetting
 {
@@ -1033,6 +1043,10 @@ void CEditor::MapSettingsDropdownRenderCallback(const SPossibleValueMatch &Match
 		{
 			str_format(aOutput, sizeof(aOutput), "%s i[value]", pInfo->m_pName);
 		}
+		else if(pInfo->m_Type == IMapSetting::SETTING_FLOAT)
+		{
+			str_format(aOutput, sizeof(aOutput), "%s f[value]", pInfo->m_pName);
+		}
 		else if(pInfo->m_Type == IMapSetting::SETTING_COMMAND)
 		{
 			SMapSettingCommand *pCommand = (SMapSettingCommand *)pInfo;
@@ -1067,9 +1081,12 @@ void CMapSettingsBackend::OnInit(CEditor *pEditor)
 		// We want to parse the arguments of each map setting so we can autocomplete them later
 		// But that depends on the type of the setting.
 		// If we have a INT setting, then we know we can only ever have 1 argument which is a integer value
+		// If we have a FLOAT setting, then we know we can only ever have 1 argument which is a float value
 		// If we have a COMMAND setting, then we need to parse its arguments
 		if(pSetting->m_Type == IMapSetting::SETTING_INT)
 			LoadSettingInt(std::static_pointer_cast<SMapSettingInt>(pSetting));
+		else if(pSetting->m_Type == IMapSetting::SETTING_FLOAT)
+			LoadSettingFloat(std::static_pointer_cast<SMapSettingFloat>(pSetting));
 		else if(pSetting->m_Type == IMapSetting::SETTING_COMMAND)
 			LoadSettingCommand(std::static_pointer_cast<SMapSettingCommand>(pSetting));
 
@@ -1106,6 +1123,15 @@ void CMapSettingsBackend::LoadSettingInt(const std::shared_ptr<SMapSettingInt> &
 	auto &Arg = m_ParsedCommandArgs[pSetting].back();
 	str_copy(Arg.m_aName, "value");
 	Arg.m_Type = 'i';
+}
+
+void CMapSettingsBackend::LoadSettingFloat(const std::shared_ptr<SMapSettingFloat> &pSetting)
+{
+	// We load an int argument here
+	m_ParsedCommandArgs[pSetting].emplace_back();
+	auto &Arg = m_ParsedCommandArgs[pSetting].back();
+	str_copy(Arg.m_aName, "value");
+	Arg.m_Type = 'f';
 }
 
 void CMapSettingsBackend::LoadSettingCommand(const std::shared_ptr<SMapSettingCommand> &pSetting)
@@ -1194,6 +1220,16 @@ void CMapSettingsBackend::PossibleConfigVariableCallback(const SConfigVariable *
 			pIntVariable->m_Default,
 			pIntVariable->m_Min,
 			pIntVariable->m_Max));
+	}
+	else if(pVariable->m_Type == SConfigVariable::VAR_FLOAT)
+	{
+		SFloatConfigVariable *pFloatVariable = (SFloatConfigVariable *)pVariable;
+		pBackend->m_vpMapSettings.emplace_back(std::make_shared<SMapSettingFloat>(
+			pFloatVariable->m_pScriptName,
+			pFloatVariable->m_pHelp,
+			pFloatVariable->m_Default,
+			pFloatVariable->m_Min,
+			pFloatVariable->m_Max));
 	}
 }
 
@@ -1506,8 +1542,16 @@ void CMapSettingsBackend::CContext::ParseArgs(const char *pLineInputStr, const c
 				}
 				else
 				{
-					std::shared_ptr<SMapSettingInt> pSettingInt = std::static_pointer_cast<SMapSettingInt>(m_pCurrentSetting);
-					str_format(m_Error.m_aMessage, sizeof(m_Error.m_aMessage), "Invalid argument value: %s at position %d for argument '%s': out of range [%d, %d]", aFormattedValue, (int)ErrorArg.m_Start, SettingArg.m_aName, pSettingInt->m_Min, pSettingInt->m_Max);
+					if(m_pCurrentSetting->m_Type == IMapSetting::SETTING_INT)
+					{
+						std::shared_ptr<SMapSettingInt> pSettingInt = std::static_pointer_cast<SMapSettingInt>(m_pCurrentSetting);
+						str_format(m_Error.m_aMessage, sizeof(m_Error.m_aMessage), "Invalid argument value: %s at position %d for argument '%s': out of range [%d, %d]", aFormattedValue, (int)ErrorArg.m_Start, SettingArg.m_aName, pSettingInt->m_Min, pSettingInt->m_Max);
+					}
+					else if(m_pCurrentSetting->m_Type == IMapSetting::SETTING_FLOAT)
+					{
+						std::shared_ptr<SMapSettingFloat> pSettingFloat = std::static_pointer_cast<SMapSettingFloat>(m_pCurrentSetting);
+						str_format(m_Error.m_aMessage, sizeof(m_Error.m_aMessage), "Invalid argument value: %s at position %d for argument '%s': out of range [%.2f, %.2f]", aFormattedValue, (int)ErrorArg.m_Start, SettingArg.m_aName, pSettingFloat->m_Min, pSettingFloat->m_Max);
+					}
 				}
 				m_Error.m_ArgIndex = ErrorArgIndex;
 				m_Error.m_Type = Error;
@@ -1624,7 +1668,19 @@ EValidationResult CMapSettingsBackend::CContext::ValidateArg(int Index, const ch
 
 		return Value >= pSetting->m_Min && Value <= pSetting->m_Max ? EValidationResult::VALID : EValidationResult::OUT_OF_RANGE;
 	}
-	else if(m_pCurrentSetting->m_Type == IMapSetting::SETTING_COMMAND)
+	if(m_pCurrentSetting->m_Type == IMapSetting::SETTING_FLOAT)
+	{
+		std::shared_ptr<SMapSettingFloat> pSetting = std::static_pointer_cast<SMapSettingFloat>(m_pCurrentSetting);
+		if(Index > 0)
+			return EValidationResult::ERROR;
+
+		float Value;
+		if(!str_tofloat(pArg, &Value)) // Try parse the float
+			return EValidationResult::ERROR;
+
+		return Value >= pSetting->m_Min && Value <= pSetting->m_Max ? EValidationResult::VALID : EValidationResult::OUT_OF_RANGE;
+	}
+	if(m_pCurrentSetting->m_Type == IMapSetting::SETTING_COMMAND)
 	{
 		auto &vArgs = m_pBackend->m_ParsedCommandArgs.at(m_pCurrentSetting);
 		if(Index < (int)vArgs.size())
@@ -1714,9 +1770,9 @@ void CMapSettingsBackend::CContext::UpdatePossibleMatches()
 		if(!m_pCurrentSetting) // If we are on an argument of an unknown setting, we can't handle it => no possible values, ever.
 			return;
 
-		if(m_pCurrentSetting->m_Type == IMapSetting::SETTING_INT)
+		if(m_pCurrentSetting->m_Type == IMapSetting::SETTING_INT || m_pCurrentSetting->m_Type == IMapSetting::SETTING_FLOAT)
 		{
-			// No possible values for int settings.
+			// No possible values for int or float settings.
 			// Maybe we can add "0" and "1" as possible values for settings that are binary.
 		}
 		else
@@ -1942,12 +1998,12 @@ int CMapSettingsBackend::CContext::CheckCollision(const char *pInputString, cons
 	// related to valid map settings, such as parsed command arguments, etc.
 
 	const std::shared_ptr<IMapSetting> &pSetting = Setting();
-	if(pSetting->m_Type == IMapSetting::SETTING_INT)
+	if(pSetting->m_Type == IMapSetting::SETTING_INT || m_pCurrentSetting->m_Type == IMapSetting::SETTING_FLOAT)
 	{
-		// For integer settings, the check is quite simple as we know
+		// For integer or float settings, the check is quite simple as we know
 		// we can only ever have 1 argument.
 
-		// The integer setting cannot be added multiple times, which means if a collision was found, then the only result we
+		// The integer or float setting cannot be added multiple times, which means if a collision was found, then the only result we
 		// can have is REPLACE.
 		// In this case, the collision is found only by checking the command name for every setting in the current map settings.
 		char aBuffer[256];

--- a/src/game/editor/editor_server_settings.h
+++ b/src/game/editor/editor_server_settings.h
@@ -10,6 +10,7 @@
 
 class CEditor;
 struct SMapSettingInt;
+struct SMapSettingFloat;
 struct SMapSettingCommand;
 struct IMapSetting;
 class CLineInput;
@@ -311,6 +312,7 @@ private: // Loader methods
 	void LoadAllMapSettings();
 	void LoadCommand(const char *pName, const char *pArgs, const char *pHelp);
 	void LoadSettingInt(const std::shared_ptr<SMapSettingInt> &pSetting);
+	void LoadSettingFloat(const std::shared_ptr<SMapSettingFloat> &pSetting);
 	void LoadSettingCommand(const std::shared_ptr<SMapSettingCommand> &pSetting);
 	void InitValueLoaders();
 	void LoadPossibleValues(const CSettingValuesBuilder &Builder, const std::shared_ptr<IMapSetting> &pSetting);

--- a/src/game/server/teehistorian.cpp
+++ b/src/game/server/teehistorian.cpp
@@ -158,6 +158,17 @@ void CTeeHistorian::WriteHeader(const CGameInfo *pGameInfo)
 		First = false; \
 	}
 
+#define MACRO_CONFIG_FLOAT(Name, ScriptName, Def, Min, Max, Flags, Desc) \
+	if((Flags)&CFGFLAG_SERVER && !((Flags)&CFGFLAG_NONTEEHISTORIC) && pGameInfo->m_pConfig->m_##Name != (Def)) \
+	{ \
+		str_format(aJson, sizeof(aJson), "%s\"%s\":\"%.2f\"", \
+			First ? "" : ",", \
+			E(aBuffer1, #ScriptName), \
+			pGameInfo->m_pConfig->m_##Name); \
+		Write(aJson, str_length(aJson)); \
+		First = false; \
+	}
+
 #define MACRO_CONFIG_COL(Name, ScriptName, Def, Flags, Desc) MACRO_CONFIG_INT(Name, ScriptName, Def, 0, 0, Flags, Desc)
 
 #define MACRO_CONFIG_STR(Name, ScriptName, Len, Def, Flags, Desc) \

--- a/src/test/teehistorian.cpp
+++ b/src/test/teehistorian.cpp
@@ -36,12 +36,15 @@ protected:
 		mem_zero(&m_Config, sizeof(m_Config));
 #define MACRO_CONFIG_INT(Name, ScriptName, Def, Min, Max, Save, Desc) \
 	m_Config.m_##Name = (Def);
+#define MACRO_CONFIG_FLOAT(Name, ScriptName, Def, Min, Max, Save, Desc) \
+	m_Config.m_##Name = (Def);
 #define MACRO_CONFIG_COL(Name, ScriptName, Def, Save, Desc) MACRO_CONFIG_INT(Name, ScriptName, Def, 0, 0, Save, Desc)
 #define MACRO_CONFIG_STR(Name, ScriptName, Len, Def, Save, Desc) \
 	str_copy(m_Config.m_##Name, (Def), sizeof(m_Config.m_##Name));
 #include <engine/shared/config_variables.h>
 #undef MACRO_CONFIG_STR
 #undef MACRO_CONFIG_COL
+#undef MACRO_CONFIG_FLOAT
 #undef MACRO_CONFIG_INT
 
 		RegisterUuids(&m_UuidManager);


### PR DESCRIPTION
Redo of #5894 PR with nan/inf check and map settings support. 

Perhaps this type of configuration won't be used in DDNet, but for modifications, it's an extremely useful feature. Before adding support for float configurations, I had to specify values as percentages or divide them by some constant. Yes, in some cases the precision might not be perfect, but for most of my tasks, this is more than sufficient.

To prevent breaking values by re-saving, I suggest using these configurations **only for the server side** where we only read without write.

**What's the difficulty in saving as an int and divide/multiplying by 1000?**
The problem lies in the fact that the configuration file is loaded via CConsole::ExecuteFile, meaning all lines are treated as console inputs. As a result, 
1. either a custom implementation for reading configurations needs to be written, 
2. or the console must be made aware that it's reading from a file, 
3. or int values will also need to be entered in the console. 

In any case, this leads to either bad code or a massive refactor, which could potentially be done later [^1] if someone needs to add a configuration variable specifically on the client side.  For the server side, I find the current implementation fully sufficient.

[^1]: The current version won't need to be changed in any case, as it specifically parses console input, and the input into the console will be float values

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
