### PR TITLE
Increase register content limit to 32 KiB

### DIFF
--- a/src/mastersrv/src/main.rs
+++ b/src/mastersrv/src/main.rs
@@ -1039,7 +1039,7 @@ async fn main() {
         .and(warp::post())
         .and(warp::header::headers_cloned())
         .and(warp::addr::remote())
-        .and(warp::body::content_length_limit(16 * 1024)) // limit body size to 16 KiB
+        .and(warp::body::content_length_limit(32 * 1024)) // limit body size to 32 KiB
         .and(warp::body::bytes())
         .map(
             move |headers: warp::http::HeaderMap, addr: Option<SocketAddr>, info: bytes::Bytes| {


### PR DESCRIPTION
If possible, I would like the increase in the size of the accepted content to be added as soon as possible, as I don't know when #9274 will be merged. Closes issue #9266.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
