### PR TITLE
Add spectator cursor: third time's the charm

### DIFF
--- a/datasrc/network.py
+++ b/datasrc/network.py
@@ -316,6 +316,13 @@ Objects = [
 		NetIntAny("m_SwitchNumber"),
 	]),
 
+	NetObjectEx("DDNetSpectatorInfo", "spectator-info@netobj.ddnet.org", [
+		NetBool("m_HasCameraInfo"),
+		NetIntRange("m_Zoom", 0, 'max_int'),
+		NetIntRange("m_Deadzone", 0, 'max_int'),
+		NetIntRange("m_FollowFactor", 0, 'max_int'),
+	]),
+
 	## Events
 
 	NetEvent("Common", [

--- a/src/base/math.h
+++ b/src/base/math.h
@@ -41,6 +41,21 @@ inline T bezier(const T p0, const T p1, const T p2, const T p3, TB amount)
 	return mix(c20, c21, amount); // c30
 }
 
+template<typename T, typename TB>
+inline T mix_polynomial(const TB time[], const T data[], int samples, TB amount, T init)
+{
+	T result = init;
+	for(int i = 0; i < samples; i++)
+	{
+		T term = data[i];
+		for(int j = 0; j < samples; j++)
+			if(j != i)
+				term = term * (amount - time[j]) / TB(time[i] - time[j]);
+		result += term;
+	}
+	return result;
+}
+
 inline float random_float()
 {
 	return rand() / (float)(RAND_MAX);

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -80,6 +80,8 @@ MACRO_CONFIG_INT(ClEyeWheel, cl_eye_wheel, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAV
 MACRO_CONFIG_INT(ClEyeDuration, cl_eye_duration, 999999, 1, 999999, CFGFLAG_CLIENT | CFGFLAG_SAVE, "How long the eyes emotes last")
 MACRO_CONFIG_INT(ClFreezeStars, cl_freeze_stars, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show old star particles for frozen tees")
 
+MACRO_CONFIG_INT(ClSpecCursor, cl_spec_cursor, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Enable the cursor of spectating player if available")
+
 MACRO_CONFIG_INT(ClAirjumpindicator, cl_airjumpindicator, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show the air jump indicator")
 MACRO_CONFIG_INT(ClThreadsoundloading, cl_threadsoundloading, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Load sound files threaded")
 

--- a/src/engine/textrender.h
+++ b/src/engine/textrender.h
@@ -149,6 +149,8 @@ MAYBE_UNUSED static const char *FONT_ICON_REDO = "\xEF\x8B\xB9";
 
 MAYBE_UNUSED static const char *FONT_ICON_ARROWS_ROTATE = "\xEF\x80\xA1";
 MAYBE_UNUSED static const char *FONT_ICON_QUESTION = "?";
+
+MAYBE_UNUSED static const char *FONT_ICON_CAMERA = "\xEF\x80\xB0";
 } // end namespace FontIcons
 
 enum ETextCursorSelectionMode

--- a/src/game/client/components/camera.cpp
+++ b/src/game/client/components/camera.cpp
@@ -36,10 +36,14 @@ CCamera::CCamera()
 
 	m_CameraSmoothing = false;
 
-	m_LastMousePos = vec2(0, 0);
+	m_LastTargetPos = vec2(0, 0);
 	m_DyncamTargetCameraOffset = vec2(0, 0);
 	mem_zero(m_aDyncamCurrentCameraOffset, sizeof(m_aDyncamCurrentCameraOffset));
 	m_DyncamSmoothingSpeedBias = 0.5f;
+
+	m_AutoSpecCamera = true;
+	m_AutoSpecCameraZooming = false;
+	m_UsingAutoSpecCamera = false;
 }
 
 float CCamera::CameraSmoothingProgress(float CurrentTime) const
@@ -56,7 +60,15 @@ float CCamera::ZoomProgress(float CurrentTime) const
 void CCamera::ScaleZoom(float Factor)
 {
 	float CurrentTarget = m_Zooming ? m_ZoomSmoothingTarget : m_Zoom;
-	ChangeZoom(CurrentTarget * Factor, m_pClient->m_Snap.m_SpecInfo.m_Active && GameClient()->m_MultiViewActivated ? g_Config.m_ClMultiViewZoomSmoothness : g_Config.m_ClSmoothZoomTime);
+	bool IsUserZoom = !m_IsSpectatingPlayer;
+
+	ChangeZoom(CurrentTarget * Factor, m_pClient->m_Snap.m_SpecInfo.m_Active && GameClient()->m_MultiViewActivated ? g_Config.m_ClMultiViewZoomSmoothness : g_Config.m_ClSmoothZoomTime, IsUserZoom);
+
+	if(m_IsSpectatingPlayer)
+	{
+		m_AutoSpecCamera = false;
+		m_SpecZoomTarget = m_ZoomSmoothingTarget;
+	}
 }
 
 float CCamera::MaxZoomLevel()
@@ -69,7 +81,7 @@ float CCamera::MinZoomLevel()
 	return 0.01f;
 }
 
-void CCamera::ChangeZoom(float Target, int Smoothness)
+void CCamera::ChangeZoom(float Target, int Smoothness, bool IsUser)
 {
 	if(Target > MaxZoomLevel() || Target < MinZoomLevel())
 	{
@@ -91,11 +103,47 @@ void CCamera::ChangeZoom(float Target, int Smoothness)
 	m_ZoomSmoothingStart = Now;
 	m_ZoomSmoothingEnd = Now + (float)Smoothness / 1000;
 
+	if(IsUser)
+		m_UserZoomTarget = Target;
+
 	m_Zooming = true;
+}
+
+void CCamera::ResetAutoSpecCamera()
+{
+	m_AutoSpecCamera = true;
+	m_SpecZoomTarget = CCamera::ZoomStepsToValue(g_Config.m_ClDefaultZoom - 10);
 }
 
 void CCamera::UpdateCamera()
 {
+	// use hardcoded smooth camera for spectating unless player explictly turn it off
+	bool IsSpectatingPlayer = !GameClient()->m_MultiViewActivated;
+	if(Client()->State() == IClient::STATE_DEMOPLAYBACK)
+		IsSpectatingPlayer = IsSpectatingPlayer && m_pClient->m_Snap.m_SpecInfo.m_SpectatorId >= 0;
+	else
+		IsSpectatingPlayer = IsSpectatingPlayer && m_pClient->m_Snap.m_SpecInfo.m_Active && m_pClient->m_Snap.m_SpecInfo.m_SpectatorId >= 0;
+
+	bool UsingAutoSpecCamera = m_AutoSpecCamera && CanUseAutoSpecCamera();
+	float CurrentZoom = m_Zooming ? m_ZoomSmoothingTarget : m_Zoom;
+
+	if(IsSpectatingPlayer && UsingAutoSpecCamera && CurrentZoom != m_pClient->m_Snap.m_SpecInfo.m_Zoom)
+	{
+		ChangeZoom(m_pClient->m_Snap.m_SpecInfo.m_Zoom, 250, false);
+		// it is auto spec camera zooming if only the zoom is changed during activation, not at the start of the activation
+		m_AutoSpecCameraZooming = IsSpectatingPlayer && m_UsingAutoSpecCamera;
+	}
+	else if((IsSpectatingPlayer && !UsingAutoSpecCamera) && CurrentZoom != m_SpecZoomTarget)
+	{
+		ChangeZoom(m_SpecZoomTarget, g_Config.m_ClSmoothZoomTime, false);
+		m_AutoSpecCameraZooming = false;
+	}
+	else if(!IsSpectatingPlayer && CurrentZoom != m_UserZoomTarget)
+	{
+		ChangeZoom(m_UserZoomTarget, GameClient()->m_MultiViewActivated ? g_Config.m_ClMultiViewZoomSmoothness : g_Config.m_ClSmoothZoomTime, false);
+		m_AutoSpecCameraZooming = false;
+	}
+
 	if(m_Zooming)
 	{
 		float Time = Client()->LocalTime();
@@ -130,19 +178,29 @@ void CCamera::UpdateCamera()
 	}
 
 	if(m_pClient->m_Snap.m_SpecInfo.m_Active && !m_pClient->m_Snap.m_SpecInfo.m_UsePosition)
+	{
+		m_aDyncamCurrentCameraOffset[g_Config.m_ClDummy] = vec2(0, 0);
+		m_IsSpectatingPlayer = IsSpectatingPlayer;
+		m_UsingAutoSpecCamera = UsingAutoSpecCamera;
 		return;
+	}
+
+	vec2 TargetPos = IsSpectatingPlayer ? m_pClient->m_CursorInfo.Target() : m_pClient->m_Controls.m_aMousePos[g_Config.m_ClDummy];
+	int Smoothness = IsSpectatingPlayer ? 50 : g_Config.m_ClDyncamSmoothness;
+	int Stabilizing = IsSpectatingPlayer ? 50 : g_Config.m_ClDyncamStabilizing;
+	bool IsDyncam = IsSpectatingPlayer ? true : g_Config.m_ClDyncam;
 
 	float DeltaTime = Client()->RenderFrameTime();
 
-	if(g_Config.m_ClDyncamSmoothness > 0)
+	if(Smoothness > 0)
 	{
-		float CameraSpeed = (1.0f - (g_Config.m_ClDyncamSmoothness / 100.0f)) * 9.5f + 0.5f;
-		float CameraStabilizingFactor = 1 + g_Config.m_ClDyncamStabilizing / 100.0f;
+		float CameraSpeed = (1.0f - (Smoothness / 100.0f)) * 9.5f + 0.5f;
+		float CameraStabilizingFactor = 1 + Stabilizing / 100.0f;
 
 		m_DyncamSmoothingSpeedBias += CameraSpeed * DeltaTime;
-		if(g_Config.m_ClDyncam)
+		if(IsDyncam)
 		{
-			m_DyncamSmoothingSpeedBias -= length(m_pClient->m_Controls.m_aMousePos[g_Config.m_ClDummy] - m_LastMousePos) * std::log10(CameraStabilizingFactor) * 0.02f;
+			m_DyncamSmoothingSpeedBias -= length(TargetPos - m_LastTargetPos) * std::log10(CameraStabilizingFactor) * 0.02f;
 			m_DyncamSmoothingSpeedBias = clamp(m_DyncamSmoothingSpeedBias, 0.5f, CameraSpeed);
 		}
 		else
@@ -152,19 +210,47 @@ void CCamera::UpdateCamera()
 	}
 
 	m_DyncamTargetCameraOffset = vec2(0, 0);
-	vec2 MousePos = m_pClient->m_Controls.m_aMousePos[g_Config.m_ClDummy];
-	float l = length(MousePos);
+	float l = length(TargetPos);
 	if(l > 0.0001f) // make sure that this isn't 0
 	{
-		float OffsetAmount = maximum(l - Deadzone(), 0.0f) * (FollowFactor() / 100.0f);
-		m_DyncamTargetCameraOffset = normalize_pre_length(MousePos, l) * OffsetAmount;
+		float CurrentDeadzone = Deadzone();
+		float CurrentFollowFactor = FollowFactor();
+
+		// use provided camera setting from server
+		if(IsSpectatingPlayer)
+		{
+			CurrentDeadzone = m_pClient->m_Snap.m_SpecInfo.m_Deadzone;
+			CurrentFollowFactor = m_pClient->m_Snap.m_SpecInfo.m_FollowFactor;
+
+			if(!UsingAutoSpecCamera)
+			{
+				// turn off dyncam if user zooms when spectating
+				CurrentDeadzone = 0;
+				CurrentFollowFactor = 0;
+			}
+		}
+
+		float OffsetAmount = maximum(l - CurrentDeadzone, 0.0f) * (CurrentFollowFactor / 100.0f);
+		m_DyncamTargetCameraOffset = normalize(TargetPos) * OffsetAmount;
 	}
 
-	m_LastMousePos = MousePos;
-	if(g_Config.m_ClDyncamSmoothness > 0)
-		m_aDyncamCurrentCameraOffset[g_Config.m_ClDummy] += (m_DyncamTargetCameraOffset - m_aDyncamCurrentCameraOffset[g_Config.m_ClDummy]) * minimum(DeltaTime * m_DyncamSmoothingSpeedBias, 1.0f);
+	m_LastTargetPos = TargetPos;
+	vec2 CurrentCameraOffset = m_aDyncamCurrentCameraOffset[g_Config.m_ClDummy];
+	float SpeedBias = m_CameraSmoothing ? 50.0f : m_DyncamSmoothingSpeedBias;
+	if(Smoothness > 0)
+		CurrentCameraOffset += (m_DyncamTargetCameraOffset - CurrentCameraOffset) * minimum(DeltaTime * SpeedBias, 1.0f);
 	else
-		m_aDyncamCurrentCameraOffset[g_Config.m_ClDummy] = m_DyncamTargetCameraOffset;
+		CurrentCameraOffset = m_DyncamTargetCameraOffset;
+
+	// directly put the camera in place when switching in and out of freeview or spectate mode
+	if(m_IsSpectatingPlayer != IsSpectatingPlayer)
+	{
+		CurrentCameraOffset = m_DyncamTargetCameraOffset;
+	}
+
+	m_aDyncamCurrentCameraOffset[g_Config.m_ClDummy] = CurrentCameraOffset;
+	m_IsSpectatingPlayer = IsSpectatingPlayer;
+	m_UsingAutoSpecCamera = UsingAutoSpecCamera;
 }
 
 void CCamera::OnRender()
@@ -295,8 +381,10 @@ void CCamera::OnReset()
 {
 	m_CameraSmoothing = false;
 
-	m_Zoom = std::pow(CCamera::ZOOM_STEP, g_Config.m_ClDefaultZoom - 10);
+	m_Zoom = CCamera::ZoomStepsToValue(g_Config.m_ClDefaultZoom - 10);
 	m_Zooming = false;
+	m_UserZoomTarget = CCamera::ZoomStepsToValue(g_Config.m_ClDefaultZoom - 10);
+	m_SpecZoomTarget = CCamera::ZoomStepsToValue(g_Config.m_ClDefaultZoom - 10);
 }
 
 void CCamera::ConZoomPlus(IConsole::IResult *pResult, void *pUserData)
@@ -307,7 +395,7 @@ void CCamera::ConZoomPlus(IConsole::IResult *pResult, void *pUserData)
 
 	float ZoomAmount = pResult->NumArguments() ? pResult->GetFloat(0) : 1.0f;
 
-	pSelf->ScaleZoom(std::pow(CCamera::ZOOM_STEP, ZoomAmount));
+	pSelf->ScaleZoom(CCamera::ZoomStepsToValue(ZoomAmount));
 
 	if(pSelf->GameClient()->m_MultiViewActivated)
 		pSelf->GameClient()->m_MultiViewPersonalZoom += ZoomAmount;
@@ -321,7 +409,7 @@ void CCamera::ConZoomMinus(IConsole::IResult *pResult, void *pUserData)
 	float ZoomAmount = pResult->NumArguments() ? pResult->GetFloat(0) : 1.0f;
 	ZoomAmount *= -1.0f;
 
-	pSelf->ScaleZoom(std::pow(CCamera::ZOOM_STEP, ZoomAmount));
+	pSelf->ScaleZoom(CCamera::ZoomStepsToValue(ZoomAmount));
 
 	if(pSelf->GameClient()->m_MultiViewActivated)
 		pSelf->GameClient()->m_MultiViewPersonalZoom += ZoomAmount;
@@ -332,8 +420,20 @@ void CCamera::ConZoom(IConsole::IResult *pResult, void *pUserData)
 	if(!pSelf->ZoomAllowed())
 		return;
 
-	float TargetLevel = pResult->NumArguments() ? pResult->GetFloat(0) : g_Config.m_ClDefaultZoom;
-	pSelf->ChangeZoom(std::pow(CCamera::ZOOM_STEP, TargetLevel - 10.0f), pSelf->m_pClient->m_Snap.m_SpecInfo.m_Active && pSelf->GameClient()->m_MultiViewActivated ? g_Config.m_ClMultiViewZoomSmoothness : g_Config.m_ClSmoothZoomTime);
+	bool IsReset = !pResult->NumArguments();
+	bool IsSpectating = pSelf->m_IsSpectatingPlayer;
+
+	float TargetLevel = !IsReset ? pResult->GetFloat(0) : g_Config.m_ClDefaultZoom;
+	if(IsSpectating && IsReset)
+		pSelf->ResetAutoSpecCamera();
+	else
+		pSelf->ChangeZoom(CCamera::ZoomStepsToValue(TargetLevel - 10.0f), pSelf->m_pClient->m_Snap.m_SpecInfo.m_Active && pSelf->GameClient()->m_MultiViewActivated ? g_Config.m_ClMultiViewZoomSmoothness : g_Config.m_ClSmoothZoomTime, true);
+
+	if(IsSpectating && !IsReset)
+	{
+		pSelf->m_AutoSpecCamera = false;
+		pSelf->m_SpecZoomTarget = pSelf->m_ZoomSmoothingTarget;
+	}
 
 	if(pSelf->GameClient()->m_MultiViewActivated && pSelf->m_pClient->m_Snap.m_SpecInfo.m_Active)
 		pSelf->GameClient()->m_MultiViewPersonalZoom = TargetLevel - 10.0f;
@@ -473,9 +573,9 @@ void CCamera::GotoTele(int Number, int Offset)
 	SetView(MatchPos);
 }
 
-void CCamera::SetZoom(float Target, int Smoothness)
+void CCamera::SetZoom(float Target, int Smoothness, bool IsUser)
 {
-	ChangeZoom(Target, Smoothness);
+	ChangeZoom(Target, Smoothness, IsUser);
 }
 
 bool CCamera::ZoomAllowed() const
@@ -493,4 +593,15 @@ int CCamera::Deadzone() const
 int CCamera::FollowFactor() const
 {
 	return g_Config.m_ClDyncam ? g_Config.m_ClDyncamFollowFactor : g_Config.m_ClMouseFollowfactor;
+}
+
+bool CCamera::CanUseAutoSpecCamera() const
+{
+	if(Client()->State() == IClient::STATE_DEMOPLAYBACK)
+	{
+		// only follow mode has the correct camera info
+		return m_pClient->m_Snap.m_SpecInfo.m_HasCameraInfo && m_pClient->m_DemoSpecId == SPEC_FOLLOW;
+	}
+
+	return m_pClient->m_Snap.m_SpecInfo.m_HasCameraInfo && m_pClient->m_Snap.m_SpecInfo.m_SpectatorId != m_pClient->m_Snap.m_LocalClientId;
 }

--- a/src/game/client/components/camera.h
+++ b/src/game/client/components/camera.h
@@ -46,23 +46,38 @@ private:
 	float m_ZoomSmoothingEnd;
 
 	void ScaleZoom(float Factor);
-	void ChangeZoom(float Target, int Smoothness);
+	void ChangeZoom(float Target, int Smoothness, bool IsUser);
 	float ZoomProgress(float CurrentTime) const;
 
 	float MinZoomLevel();
 	float MaxZoomLevel();
 
-	vec2 m_LastMousePos;
+	vec2 m_LastTargetPos;
 	float m_DyncamSmoothingSpeedBias;
+	bool m_IsSpectatingPlayer;
+	bool m_UsingAutoSpecCamera;
 
 public:
 	static constexpr float ZOOM_STEP = 0.866025f;
+
+	/** 
+	 * Convert zoom steps to zoom value
+	 * 
+	 * @param Steps - Zoom steps, 0.0f converts to default zoom (returns 1.0f)
+	 * @return converted zoom value
+	 **/
+	static inline float ZoomStepsToValue(float Steps) { return std::pow(CCamera::ZOOM_STEP, Steps); }
 
 	vec2 m_Center;
 	bool m_ZoomSet;
 	bool m_Zooming;
 	float m_Zoom;
 	float m_ZoomSmoothingTarget;
+
+	bool m_AutoSpecCameraZooming;
+	bool m_AutoSpecCamera;
+	float m_UserZoomTarget;
+	float m_SpecZoomTarget;
 
 	vec2 m_DyncamTargetCameraOffset;
 	vec2 m_aDyncamCurrentCameraOffset[NUM_DUMMIES];
@@ -80,7 +95,7 @@ public:
 	void GotoSwitch(int Number, int Offset = -1);
 	void GotoTele(int Number, int Offset = -1);
 
-	void SetZoom(float Target, int Smoothness);
+	void SetZoom(float Target, int Smoothness, bool IsUser);
 	bool ZoomAllowed() const;
 
 	int Deadzone() const;
@@ -88,6 +103,9 @@ public:
 	int CamType() const { return m_CamType; }
 
 	void UpdateCamera();
+	void ResetAutoSpecCamera();
+	bool SpectatingPlayer() const { return m_IsSpectatingPlayer; }
+	bool CanUseAutoSpecCamera() const;
 
 private:
 	static void ConZoomPlus(IConsole::IResult *pResult, void *pUserData);

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -587,16 +587,68 @@ void CHud::RenderTeambalanceWarning()
 
 void CHud::RenderCursor()
 {
-	if(!m_pClient->m_Snap.m_pLocalCharacter || Client()->State() == IClient::STATE_DEMOPLAYBACK)
+	if(Client()->State() != IClient::STATE_DEMOPLAYBACK && m_pClient->m_Snap.m_pLocalCharacter)
+	{
+		// render local cursor
+		int CurWeapon = maximum(0, m_pClient->m_Snap.m_pLocalCharacter->m_Weapon % NUM_WEAPONS);
+		vec2 TargetPos = m_pClient->m_Controls.m_aTargetPos[g_Config.m_ClDummy];
+
+		RenderTools()->MapScreenToInterface(m_pClient->m_Camera.m_Center.x, m_pClient->m_Camera.m_Center.y);
+		Graphics()->SetColor(1.f, 1.f, 1.f, 1.f);
+		Graphics()->TextureSet(m_pClient->m_GameSkin.m_aSpriteWeaponCursors[CurWeapon]);
+		Graphics()->RenderQuadContainerAsSprite(m_HudQuadContainerIndex, m_aCursorOffset[CurWeapon], TargetPos.x, TargetPos.y);
+		return;
+	}
+
+	if(!g_Config.m_ClSpecCursor || !m_pClient->m_CursorInfo.IsAvailable())
 		return;
 
-	RenderTools()->MapScreenToInterface(m_pClient->m_Camera.m_Center.x, m_pClient->m_Camera.m_Center.y);
+	bool RenderSpecCursor = (m_pClient->m_Snap.m_SpecInfo.m_Active && m_pClient->m_Snap.m_SpecInfo.m_SpectatorId != SPEC_FREEVIEW) || Client()->State() == IClient::STATE_DEMOPLAYBACK;
 
-	// render cursor
-	int CurWeapon = maximum(0, m_pClient->m_Snap.m_pLocalCharacter->m_Weapon % NUM_WEAPONS);
-	Graphics()->SetColor(1.f, 1.f, 1.f, 1.f);
+	if(!RenderSpecCursor)
+		return;
+
+	int CurWeapon = maximum(0, m_pClient->m_CursorInfo.Weapon() % NUM_WEAPONS);
+	vec2 TargetPos = m_pClient->m_CursorInfo.WorldTarget();
+
+	float CenterX = m_pClient->m_Camera.m_Center.x;
+	float CenterY = m_pClient->m_Camera.m_Center.y;
+	float Zoom = m_pClient->m_Camera.m_Zoom;
+
+	float aPoints[4];
+	RenderTools()->MapScreenToWorld(CenterX, CenterY, 100.0f, 100.0f, 100.0f, 0, 0, Graphics()->ScreenAspect(), Zoom, aPoints);
+	Graphics()->MapScreen(aPoints[0], aPoints[1], aPoints[2], aPoints[3]);
+
+	vec2 ScreenPos = TargetPos - m_pClient->m_Camera.m_Center;
+
+	bool Clamped = false;
+	float HalfWidth = CenterX - aPoints[0];
+	float HalfHeight = CenterY - aPoints[1];
+
+	// specialized lineseg-rect intersection
+	// https://gist.github.com/ChickenProp/3194723
+	if(ScreenPos.x < -HalfWidth || ScreenPos.x > HalfWidth || ScreenPos.y < -HalfHeight || ScreenPos.y > HalfHeight)
+	{
+		float aDeltas[] = {ScreenPos.x, ScreenPos.y};
+		float aBounds[] = {HalfWidth, HalfHeight};
+		float ClampFactor = INFINITY;
+
+		static_assert(std::size(aDeltas) == std::size(aBounds), "delta and bounds arrays must have the same size");
+		for(std::size_t i = 0; i < std::size(aDeltas); i++)
+		{
+			float t = absolute(aBounds[i] / aDeltas[i]);
+			if(ClampFactor > t)
+				ClampFactor = t;
+		}
+
+		Clamped = true;
+		TargetPos = ScreenPos * ClampFactor + m_pClient->m_Camera.m_Center;
+	}
+
+	// render spec cursor
+	Graphics()->SetColor(1.f, 1.f, 1.f, Clamped ? .5f : 1.f);
 	Graphics()->TextureSet(m_pClient->m_GameSkin.m_aSpriteWeaponCursors[CurWeapon]);
-	Graphics()->RenderQuadContainerAsSprite(m_HudQuadContainerIndex, m_aCursorOffset[CurWeapon], m_pClient->m_Controls.m_aTargetPos[g_Config.m_ClDummy].x, m_pClient->m_Controls.m_aTargetPos[g_Config.m_ClDummy].y);
+	Graphics()->RenderQuadContainerAsSprite(m_HudQuadContainerIndex, m_aCursorOffset[CurWeapon], TargetPos.x, TargetPos.y, Zoom, Zoom);
 }
 
 void CHud::PrepareAmmoHealthAndArmorQuads()
@@ -1415,6 +1467,27 @@ void CHud::RenderSpectatorHud()
 		str_copy(aBuf, Localize("Free-View"));
 	}
 	TextRender()->Text(m_Width - 174.0f, m_Height - 15.0f + (15.f - 8.f) / 2.f, 8.0f, aBuf, -1.0f);
+
+	// draw the camera info
+	if(m_pClient->m_Camera.SpectatingPlayer() && m_pClient->m_Camera.CanUseAutoSpecCamera())
+	{
+		bool AutoSpecCameraEnabled = m_pClient->m_Camera.m_AutoSpecCamera;
+		const char *pLabelText = Localize("AUTO", "Spectating Camera Mode Icon");
+		const float TextWidth = TextRender()->TextWidth(6.0f, pLabelText);
+
+		constexpr float RightMargin = 4.0f;
+		constexpr float IconWidth = 6.0f;
+		constexpr float Padding = 3.0f;
+		const float TagWidth = IconWidth + TextWidth + Padding * 3.0f;
+		const float TagX = m_Width - RightMargin - TagWidth;
+		Graphics()->DrawRect(TagX, m_Height - 12.0f, TagWidth, 10.0f, ColorRGBA(0.84f, 0.53f, 0.17f, AutoSpecCameraEnabled ? 0.85f : 0.25f), IGraphics::CORNER_ALL, 2.5f);
+		TextRender()->TextColor(1, 1, 1, AutoSpecCameraEnabled ? 1.0f : 0.65f);
+		TextRender()->SetFontPreset(EFontPreset::ICON_FONT);
+		TextRender()->Text(TagX + Padding, m_Height - 10.0f, 6.0f, FontIcons::FONT_ICON_CAMERA, -1.0f);
+		TextRender()->SetFontPreset(EFontPreset::DEFAULT_FONT);
+		TextRender()->Text(TagX + Padding + IconWidth + Padding, m_Height - 10.0f, 6.0f, pLabelText, -1.0f);
+		TextRender()->TextColor(1, 1, 1, 1);
+	}
 }
 
 void CHud::RenderLocalTime(float x)

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -714,6 +714,19 @@ void CMenus::RenderDemoPlayer(CUIRect MainView)
 	}
 	GameClient()->m_Tooltips.DoToolTip(&s_KeyboardShortcutsButton, &Button, Localize("Toggle keyboard shortcuts"));
 
+	// auto camera button (only available when it is possible to use)
+	if(m_pClient->m_Camera.CanUseAutoSpecCamera())
+	{
+		ButtonBar.VSplitRight(Margins, &ButtonBar, nullptr);
+		ButtonBar.VSplitRight(ButtonbarHeight, &ButtonBar, &Button);
+		static CButtonContainer s_AutoCameraButton;
+		if(DoButton_FontIcon(&s_AutoCameraButton, FONT_ICON_CAMERA, 0, &Button, IGraphics::CORNER_ALL, m_pClient->m_Camera.m_AutoSpecCamera))
+		{
+			m_pClient->m_Camera.m_AutoSpecCamera = !m_pClient->m_Camera.m_AutoSpecCamera;
+		}
+		GameClient()->m_Tooltips.DoToolTip(&s_AutoCameraButton, &Button, Localize("Toggle auto camera"));
+	}
+
 	// demo name
 	char aDemoName[IO_MAX_PATH_LENGTH];
 	DemoPlayer()->GetDemoName(aDemoName, sizeof(aDemoName));

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -3287,7 +3287,7 @@ void CMenus::RenderSettingsDDNet(CUIRect MainView)
 
 	Right.HSplitTop(20.0f, &Button, &Right);
 	if(Ui()->DoScrollbarOption(&g_Config.m_ClDefaultZoom, &g_Config.m_ClDefaultZoom, &Button, Localize("Default zoom"), 0, 20))
-		m_pClient->m_Camera.SetZoom(std::pow(CCamera::ZOOM_STEP, g_Config.m_ClDefaultZoom - 10), g_Config.m_ClSmoothZoomTime);
+		m_pClient->m_Camera.SetZoom(CCamera::ZoomStepsToValue(g_Config.m_ClDefaultZoom - 10), g_Config.m_ClSmoothZoomTime, true);
 
 	Right.HSplitTop(20.0f, &Button, &Right);
 	if(DoButton_CheckBox(&g_Config.m_ClAntiPing, Localize("AntiPing"), g_Config.m_ClAntiPing, &Button))

--- a/src/game/client/components/spectator.cpp
+++ b/src/game/client/components/spectator.cpp
@@ -187,6 +187,15 @@ bool CSpectator::OnInput(const IInput::CEvent &Event)
 		}
 	}
 
+	if(m_pClient->m_Camera.SpectatingPlayer() && m_pClient->m_Camera.CanUseAutoSpecCamera())
+	{
+		if(Event.m_Flags & IInput::FLAG_PRESS && Event.m_Key == KEY_MOUSE_2)
+		{
+			m_pClient->m_Camera.ResetAutoSpecCamera();
+			return true;
+		}
+	}
+
 	return false;
 }
 

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -673,6 +673,9 @@ void CGameClient::OnReset()
 	m_MultiViewActivated = false;
 	m_MultiView.m_IsInit = false;
 
+	m_CursorInfo.m_CursorOwnerId = -1;
+	m_CursorInfo.m_NumSamples = 0;
+
 	for(auto &pComponent : m_vpAll)
 		pComponent->OnReset();
 
@@ -781,6 +784,8 @@ void CGameClient::OnRender()
 
 	// update camera data prior to CControls::OnRender to allow CControls::m_aTargetPos to compensate using camera data
 	m_Camera.UpdateCamera();
+
+	UpdateSpectatorCursor();
 
 	// render all systems
 	for(auto &pComponent : m_vpAll)
@@ -1498,6 +1503,7 @@ void CGameClient::InvalidateSnapshot()
 {
 	// clear all pointers
 	mem_zero(&m_Snap, sizeof(m_Snap));
+	m_Snap.m_SpecInfo.m_Zoom = 1.0f;
 	m_Snap.m_LocalClientId = -1;
 	SnapCollectEntities();
 }
@@ -1756,6 +1762,14 @@ void CGameClient::OnNewSnapshot()
 				if(Client()->IsSixup())
 					m_Snap.m_SpecInfo.m_Active = true;
 				m_Snap.m_SpecInfo.m_SpectatorId = m_Snap.m_pSpectatorInfo->m_SpectatorId;
+			}
+			else if(Item.m_Type == NETOBJTYPE_DDNETSPECTATORINFO)
+			{
+				const CNetObj_DDNetSpectatorInfo *pDDNetSpecInfo = (const CNetObj_DDNetSpectatorInfo *)Item.m_pData;
+				m_Snap.m_SpecInfo.m_HasCameraInfo = true;
+				m_Snap.m_SpecInfo.m_Zoom = pDDNetSpecInfo->m_Zoom / 1000.0f;
+				m_Snap.m_SpecInfo.m_Deadzone = pDDNetSpecInfo->m_Deadzone;
+				m_Snap.m_SpecInfo.m_FollowFactor = pDDNetSpecInfo->m_FollowFactor;
 			}
 			else if(Item.m_Type == NETOBJTYPE_GAMEINFO)
 			{
@@ -2065,6 +2079,14 @@ void CGameClient::OnNewSnapshot()
 
 	float Deadzone = m_Camera.Deadzone();
 	float FollowFactor = m_Camera.FollowFactor();
+
+	if(m_Snap.m_SpecInfo.m_Active)
+	{
+		// don't send camera infomation when spectating
+		Zoom = m_LastZoom;
+		Deadzone = m_LastDeadzone;
+		FollowFactor = m_LastFollowFactor;
+	}
 
 	// initialize dummy vital when first connected
 	if(Client()->DummyConnected() && !m_LastDummyConnected)
@@ -3094,6 +3116,131 @@ void CGameClient::UpdatePrediction()
 	m_GameWorld.NetObjEnd();
 }
 
+void CGameClient::UpdateSpectatorCursor()
+{
+	int CursorOwnerId = m_Snap.m_LocalClientId;
+	if(m_Snap.m_SpecInfo.m_Active || Client()->State() == IClient::STATE_DEMOPLAYBACK)
+	{
+		CursorOwnerId = m_Snap.m_SpecInfo.m_SpectatorId;
+	}
+
+	if(CursorOwnerId != m_CursorInfo.m_CursorOwnerId)
+	{
+		// reset cursor sample count upon changing spectating character
+		m_CursorInfo.m_NumSamples = 0;
+		m_CursorInfo.m_CursorOwnerId = CursorOwnerId;
+	}
+
+	if(m_MultiViewActivated || CursorOwnerId < 0 || CursorOwnerId >= MAX_CLIENTS)
+	{
+		// do not show spec cursor in multi-view
+		m_CursorInfo.m_Available = false;
+		m_CursorInfo.m_NumSamples = 0;
+		return;
+	}
+
+	const CSnapState::CCharacterInfo CharInfo = m_Snap.m_aCharacters[CursorOwnerId];
+	if(!CharInfo.m_HasExtendedData || !m_aClients[CursorOwnerId].m_Active || (!g_Config.m_Debug && m_aClients[CursorOwnerId].m_Paused))
+	{
+		// hide cursor when the spectating player is paused
+		m_CursorInfo.m_Available = false;
+		m_CursorInfo.m_NumSamples = 0;
+		return;
+	}
+
+	m_CursorInfo.m_Available = true;
+	m_CursorInfo.m_Position = CharInfo.m_Position;
+	m_CursorInfo.m_Weapon = CharInfo.m_Cur.m_Weapon;
+
+	const vec2 Target = vec2(CharInfo.m_ExtendedData.m_TargetX, CharInfo.m_ExtendedData.m_TargetY);
+
+	// interpolate cursor positions when not in debug mode
+	const double Tick = Client()->GameTick(g_Config.m_ClDummy);
+
+	const bool HasSample = m_CursorInfo.m_NumSamples > 0;
+	const vec2 LastInput = HasSample ? m_CursorInfo.m_aTargetSamplesData[m_CursorInfo.m_NumSamples - 1] : vec2(0.0f, 0.0f);
+	const double LastTime = HasSample ? m_CursorInfo.m_aTargetSamplesTime[m_CursorInfo.m_NumSamples - 1] : 0.0;
+	bool NewSample = LastInput != Target || LastTime + CCursorInfo::REST_THRESHOLD < Tick;
+
+	if(LastTime > Tick)
+	{
+		// clear samples when time flows backwards
+		m_CursorInfo.m_NumSamples = 0;
+		NewSample = true;
+	}
+
+	if(m_CursorInfo.m_NumSamples == 0)
+	{
+		m_CursorInfo.m_aTargetSamplesTime[0] = Tick - CCursorInfo::INTERP_DELAY;
+		m_CursorInfo.m_aTargetSamplesData[0] = Target;
+	}
+
+	if(NewSample)
+	{
+		if(m_CursorInfo.m_NumSamples == CCursorInfo::CURSOR_SAMPLES)
+		{
+			m_CursorInfo.m_NumSamples--;
+			mem_move(m_CursorInfo.m_aTargetSamplesTime, m_CursorInfo.m_aTargetSamplesTime + 1, m_CursorInfo.m_NumSamples * sizeof(double));
+			mem_move(m_CursorInfo.m_aTargetSamplesData, m_CursorInfo.m_aTargetSamplesData + 1, m_CursorInfo.m_NumSamples * sizeof(vec2));
+		}
+		m_CursorInfo.m_aTargetSamplesTime[m_CursorInfo.m_NumSamples] = Tick;
+		m_CursorInfo.m_aTargetSamplesData[m_CursorInfo.m_NumSamples] = Target;
+		m_CursorInfo.m_NumSamples++;
+	}
+
+	// using double to avoid precision loss when converting int tick to decimal type
+	const double DisplayTime = Tick - CCursorInfo::INTERP_DELAY + double(Client()->IntraGameTickSincePrev(g_Config.m_ClDummy));
+	double aTime[CCursorInfo::SAMPLE_FRAME_WINDOW];
+	vec2 aData[CCursorInfo::SAMPLE_FRAME_WINDOW];
+
+	// find the available sample timing
+	int Index = m_CursorInfo.m_NumSamples;
+	for(int i = 0; i < m_CursorInfo.m_NumSamples; i++)
+	{
+		if(m_CursorInfo.m_aTargetSamplesTime[i] > DisplayTime)
+		{
+			Index = i;
+			break;
+		}
+	}
+
+	for(int i = 0; i < CCursorInfo::SAMPLE_FRAME_WINDOW; i++)
+	{
+		const int Offset = i - CCursorInfo::SAMPLE_FRAME_OFFSET;
+		const int SampleIndex = Index + Offset;
+		if(SampleIndex < 0)
+		{
+			aTime[i] = m_CursorInfo.m_aTargetSamplesTime[0] + CCursorInfo::REST_THRESHOLD * Offset;
+			aData[i] = m_CursorInfo.m_aTargetSamplesData[0];
+		}
+		else if(SampleIndex >= m_CursorInfo.m_NumSamples)
+		{
+			aTime[i] = m_CursorInfo.m_aTargetSamplesTime[m_CursorInfo.m_NumSamples - 1] + CCursorInfo::REST_THRESHOLD * (Offset + 1);
+			aData[i] = m_CursorInfo.m_aTargetSamplesData[m_CursorInfo.m_NumSamples - 1];
+		}
+		else
+		{
+			aTime[i] = m_CursorInfo.m_aTargetSamplesTime[SampleIndex];
+			aData[i] = m_CursorInfo.m_aTargetSamplesData[SampleIndex];
+		}
+	}
+
+	m_CursorInfo.m_Target = mix_polynomial(aTime, aData, CCursorInfo::SAMPLE_FRAME_WINDOW, DisplayTime, vec2(0.0f, 0.0f));
+
+	vec2 TargetCameraOffset(0, 0);
+	float l = length(m_CursorInfo.m_Target);
+
+	if(l > 0.0001f) // make sure that this isn't 0
+	{
+		float OffsetAmount = maximum(l - m_Snap.m_SpecInfo.m_Deadzone, 0.0f) * (m_Snap.m_SpecInfo.m_FollowFactor / 100.0f);
+		TargetCameraOffset = normalize(m_CursorInfo.m_Target) * OffsetAmount;
+	}
+
+	// if we are in auto spec mode, use camera zoom to smooth out cursor transitions
+	const float Zoom = (m_Camera.m_Zooming && m_Camera.m_AutoSpecCameraZooming) ? m_Camera.m_Zoom : m_Snap.m_SpecInfo.m_Zoom;
+	m_CursorInfo.m_WorldTarget = m_CursorInfo.m_Position + (m_CursorInfo.m_Target - TargetCameraOffset) * Zoom + TargetCameraOffset;
+}
+
 void CGameClient::UpdateRenderedCharacters()
 {
 	for(int i = 0; i < MAX_CLIENTS; i++)
@@ -4121,9 +4268,9 @@ void CGameClient::HandleMultiView()
 	float AvgVel = clamp(TmpVel / AmountPlayers ? TmpVel / (float)AmountPlayers : 0.0f, 0.0f, 1000.0f);
 
 	if(m_MultiView.m_OldPersonalZoom == m_MultiViewPersonalZoom)
-		m_Camera.SetZoom(CalculateMultiViewZoom(Minpos, Maxpos, AvgVel), g_Config.m_ClMultiViewZoomSmoothness);
+		m_Camera.SetZoom(CalculateMultiViewZoom(Minpos, Maxpos, AvgVel), g_Config.m_ClMultiViewZoomSmoothness, false);
 	else
-		m_Camera.SetZoom(CalculateMultiViewZoom(Minpos, Maxpos, AvgVel), 50);
+		m_Camera.SetZoom(CalculateMultiViewZoom(Minpos, Maxpos, AvgVel), 50, false);
 
 	m_Snap.m_SpecInfo.m_Position = m_MultiView.m_OldPos + ((TargetPos - m_MultiView.m_OldPos) * CalculateMultiViewMultiplier(TargetPos));
 	m_MultiView.m_OldPos = m_Snap.m_SpecInfo.m_Position;
@@ -4280,7 +4427,7 @@ float CGameClient::CalculateMultiViewZoom(vec2 MinPos, vec2 MaxPos, float Vel)
 	// zoom should stay between 1.1 and 20.0
 	Zoom = clamp(Zoom + Diff, 1.1f, 20.0f);
 	// dont go below default zoom
-	Zoom = std::max(float(std::pow(CCamera::ZOOM_STEP, g_Config.m_ClDefaultZoom - 10)), Zoom);
+	Zoom = std::max(CCamera::ZoomStepsToValue(g_Config.m_ClDefaultZoom - 10), Zoom);
 	// add the user preference
 	Zoom -= (Zoom * 0.1f) * m_MultiViewPersonalZoom;
 	m_MultiView.m_OldPersonalZoom = m_MultiViewPersonalZoom;
@@ -4295,7 +4442,7 @@ float CGameClient::MapValue(float MaxValue, float MinValue, float MaxRange, floa
 
 void CGameClient::ResetMultiView()
 {
-	m_Camera.SetZoom(std::pow(CCamera::ZOOM_STEP, g_Config.m_ClDefaultZoom - 10), g_Config.m_ClSmoothZoomTime);
+	m_Camera.SetZoom(CCamera::ZoomStepsToValue(g_Config.m_ClDefaultZoom - 10), g_Config.m_ClSmoothZoomTime, true);
 	m_MultiViewPersonalZoom = 0.0f;
 	m_MultiViewActivated = false;
 	m_MultiView.m_Solo = false;

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -332,12 +332,18 @@ public:
 		int m_HighestClientId;
 
 		// spectate data
-		struct CSpectateInfo
+		class CSpectateInfo
 		{
+		public:
 			bool m_Active;
 			int m_SpectatorId;
 			bool m_UsePosition;
 			vec2 m_Position;
+
+			bool m_HasCameraInfo;
+			float m_Zoom;
+			int m_Deadzone;
+			int m_FollowFactor;
 		} m_SpecInfo;
 
 		//
@@ -367,6 +373,35 @@ public:
 	int m_aExpectingTuningForZone[NUM_DUMMIES];
 	int m_aExpectingTuningSince[NUM_DUMMIES];
 	CTuningParams m_aTuning[NUM_DUMMIES];
+
+	// spectate cursor data
+	class CCursorInfo
+	{
+		friend class CGameClient;
+		static constexpr int CURSOR_SAMPLES = 8; // how many samples to keep
+		static constexpr int SAMPLE_FRAME_WINDOW = 3; // how many samples should be used for polynomial interpolation
+		static constexpr int SAMPLE_FRAME_OFFSET = 2; // how many samples in the past should be included
+		static constexpr double INTERP_DELAY = 4.25; // how many ticks in the past to show, enables extrapolation with smaller value (<= SAMPLE_FRAME_WINDOW - SAMPLE_FRAME_OFFSET + 3)
+		static constexpr double REST_THRESHOLD = 3.0; // how many ticks of the same samples are considered to be resting
+
+		int m_CursorOwnerId;
+		double m_aTargetSamplesTime[CURSOR_SAMPLES];
+		vec2 m_aTargetSamplesData[CURSOR_SAMPLES];
+		int m_NumSamples;
+
+		bool m_Available;
+		int m_Weapon;
+		vec2 m_Target;
+		vec2 m_WorldTarget;
+		vec2 m_Position;
+
+	public:
+		bool IsAvailable() const { return m_Available; }
+		int Weapon() const { return m_Weapon; }
+		vec2 Target() const { return m_Target; }
+		vec2 WorldTarget() const { return m_WorldTarget; }
+		vec2 Position() const { return m_Position; }
+	} m_CursorInfo;
 
 	// client data
 	struct CClientData
@@ -799,6 +834,7 @@ private:
 	int m_aShowOthers[NUM_DUMMIES];
 
 	void UpdatePrediction();
+	void UpdateSpectatorCursor();
 	void UpdateRenderedCharacters();
 
 	int m_aLastUpdateTick[MAX_CLIENTS] = {0};

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -194,6 +194,8 @@ public:
 	// camera info is used sparingly for converting aim target to absolute world coordinates
 	class CCameraInfo
 	{
+		friend class CPlayer;
+		bool m_HasCameraInfo;
 		float m_Zoom;
 		int m_Deadzone;
 		int m_FollowFactor;


### PR DESCRIPTION
Another branch for #8836

Depends on #9301. I'll rebase accordingly.

## Spectator Cursor
This is a interpolation only method using existing info from `DDNetCharacter NetObj`.

Added settings: `cl_spec_cursor`, ~~`cl_spec_cursor_interpolate`, `cl_spec_cursor_demo`~~.

* The interpolation is using a cubic interpolation using 3 crafted samples. 
* The cursor guarantees to pass through the sample point but everything in between is fake.
* Note that a polynomial_mix function accepting variable sample sizes is used to test different sampling windows, I settled on the 3 sample one.
* Interpolation settings are hardcoded instead configurable to avoid player thinking interp can affect network latency.
* Downside, if you look close enough or use a 0.1x playback speed in demo, hook collision line will mismatch the cursor due to different interpolation method even if you set `cl_spec_cursor_interp 0` due to hook collision line using a linear angle interpolation.

The interpolated visual is targeted to general player base who wants to see mouse movements in demo / specview and not necessarily want to check the exact position, if you want to see the exact data point, set `cl_spec_cursor_interp 0`.

The interpolation assumes the non-changing data points as non-existent instead of a new sample point, this finally gives us the smoothness similar to local mouse cursor.

Demos:
* interp on

https://github.com/user-attachments/assets/3f81e552-27e4-419d-82c1-720f52de3a4e

* interp off (debug mode)

https://github.com/user-attachments/assets/3bc76927-02a9-4874-9864-c84a3d22e02e

* ground truth comparison

https://github.com/user-attachments/assets/3274e89f-78f8-4d2f-b520-cb5e40ad0a5f

In case of dyncam or zooming. A transparent cursor will show at the lineseg-rect intersection point, this does not apply to local player's cursor.
![image](https://github.com/user-attachments/assets/76bfd444-2274-4953-a3cc-b158955bf9fd)

Thanks to everyone involved in the discussion for this feature:
@sjrc6 @gerdoe-jr @heinrich5991 

## Auto Spec Camera
After #9301, now it is possible to grab player's camera settings with a new `DDNetSpectatorInfo` NetObjectEx.

~~Added settings: `cl_spec_use_player_camera`. `cl_spec_use_player_camera 1` essentially turn off the feature and revert back to the behavior with this.~~

The new feature, dubbed Auto Spec Camera, will sync player's camera settings to make spectating (and demo recording) resembles more closely to what the observed player is seeing.

> If you can think of a better name for this feature, please reply your suggestion.

With Auto Spec Camera on, the camera will automatically match observed player's zoom and dyncam settings, this essentially guarantees the cursor is displayed correctly and not off-screen most of the time if observed player is zoomed.

If player zooms manually, the feature will automatically turn off, until player press `zoom` key-bind or right click.

When in spectator view, an indicator will show whether the feature is on or off (only if it is available).
![image](https://github.com/user-attachments/assets/6a03219b-ceec-4cb3-92af-8737969e1457)

When in demo player, an extra button is added to toggle the feature as well.
![image](https://github.com/user-attachments/assets/04dd6cea-12ef-4ecf-a562-a612cdbedff4)

When the feature is on, zoom smoothing and smooth dyncam is ***hardcoded*** to be ON. This is to avoid dyncam spinning player making the screen unwatchable for a player using non-smooth dyncam, since one player's camera setting does not necessarily look good on another player.

No config about auto spec camera will be provided, this feature is essentially a crafted watching experience. Personally i think it is pretty good for recording video too.

Auto Spec Camera will only available if observed player is using a client that supports `Cl_CameraInfo`, and will only available in newly recorded demo with **Follow mode only**.

Here is a demo of me playing Tutorial (badly), while constantly changing zoom and dyncam toggles.
[BadlyPlayingTutorial.zip](https://github.com/user-attachments/files/17966196/BadlyPlayingTutorial.zip)

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
