### PR TITLE
Fix Dynam Offset Causing Target Drift when Zooming

### DIFF
--- a/src/game/client/components/camera.cpp
+++ b/src/game/client/components/camera.cpp
@@ -194,17 +194,8 @@ void CCamera::OnRender()
 			}
 		}
 
-		vec2 TargetCameraOffset(0, 0);
+		vec2 TargetCameraOffset = CalculateCameraOffset();
 		s_LastMousePos = m_pClient->m_Controls.m_aMousePos[g_Config.m_ClDummy];
-		float l = length(s_LastMousePos);
-		if(l > 0.0001f) // make sure that this isn't 0
-		{
-			float DeadZone = g_Config.m_ClDyncam ? g_Config.m_ClDyncamDeadzone : g_Config.m_ClMouseDeadzone;
-			float FollowFactor = (g_Config.m_ClDyncam ? g_Config.m_ClDyncamFollowFactor : g_Config.m_ClMouseFollowfactor) / 100.0f;
-			float OffsetAmount = maximum(l - DeadZone, 0.0f) * FollowFactor;
-
-			TargetCameraOffset = normalize(m_pClient->m_Controls.m_aMousePos[g_Config.m_ClDummy]) * OffsetAmount;
-		}
 
 		if(g_Config.m_ClDyncamSmoothness > 0)
 			s_aCurrentCameraOffset[g_Config.m_ClDummy] += (TargetCameraOffset - s_aCurrentCameraOffset[g_Config.m_ClDummy]) * minimum(DeltaTime * s_SpeedBias, 1.0f);
@@ -477,4 +468,20 @@ bool CCamera::ZoomAllowed() const
 	return GameClient()->m_Snap.m_SpecInfo.m_Active ||
 	       GameClient()->m_GameInfo.m_AllowZoom ||
 	       Client()->State() == IClient::STATE_DEMOPLAYBACK;
+}
+
+vec2 CCamera::CalculateCameraOffset() const
+{
+	vec2 Result(0, 0);
+	vec2 MousePos = m_pClient->m_Controls.m_aMousePos[g_Config.m_ClDummy];
+	float l = length(MousePos);
+	if(l > 0.0001f) // make sure that this isn't 0
+	{
+		float DeadZone = g_Config.m_ClDyncam ? g_Config.m_ClDyncamDeadzone : g_Config.m_ClMouseDeadzone;
+		float FollowFactor = (g_Config.m_ClDyncam ? g_Config.m_ClDyncamFollowFactor : g_Config.m_ClMouseFollowfactor) / 100.0f;
+		float OffsetAmount = maximum(l - DeadZone, 0.0f) * FollowFactor;
+
+		Result = normalize(MousePos) * OffsetAmount;
+	}
+	return Result;
 }

--- a/src/game/client/components/camera.h
+++ b/src/game/client/components/camera.h
@@ -75,6 +75,8 @@ public:
 	void SetZoom(float Target, int Smoothness);
 	bool ZoomAllowed() const;
 
+	vec2 CalculateCameraOffset() const;
+
 private:
 	static void ConZoomPlus(IConsole::IResult *pResult, void *pUserData);
 	static void ConZoomMinus(IConsole::IResult *pResult, void *pUserData);

--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -246,12 +246,21 @@ int CControls::SnapInput(int *pData)
 		if(!m_aInputDirectionLeft[g_Config.m_ClDummy] && m_aInputDirectionRight[g_Config.m_ClDummy])
 			m_aInputData[g_Config.m_ClDummy].m_Direction = 1;
 
+		// cancel camera offset before scaling
+		vec2 CameraOffset = m_pClient->m_Camera.CalculateCameraOffset();
+		m_aInputData[g_Config.m_ClDummy].m_TargetX -= CameraOffset.x;
+		m_aInputData[g_Config.m_ClDummy].m_TargetY -= CameraOffset.y;
+
 		// scale TargetX, TargetY by zoom.
 		if(!m_pClient->m_Snap.m_SpecInfo.m_Active)
 		{
 			m_aInputData[g_Config.m_ClDummy].m_TargetX *= m_pClient->m_Camera.m_Zoom;
 			m_aInputData[g_Config.m_ClDummy].m_TargetY *= m_pClient->m_Camera.m_Zoom;
 		}
+
+		// reapply camera offset
+		m_aInputData[g_Config.m_ClDummy].m_TargetX += CameraOffset.x;
+		m_aInputData[g_Config.m_ClDummy].m_TargetY += CameraOffset.y;
 
 		// dummy copy moves
 		if(g_Config.m_ClDummyCopyMoves)


### PR DESCRIPTION
Fixes #9294
by taking the `keep the current behavior and fix dyncam drift (fix this issue only)` route.

But i kinda want to demonstrate that:
* this introduces a new coupling between control and camera
* camera settings need to be send to server in order to do this server-side @sjrc6 

***I personally do not think this is the best way to go about it***, review and merge only after agreed upon please.

Screenshot: (spec char showing server target position)
![image](https://github.com/user-attachments/assets/a9245a34-3145-4974-951a-f38bebdc4bc4)

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
