### PR TITLE
Fix cursor drifting when using smooth dyncam and zoom at the same time

### DIFF
--- a/src/game/client/components/camera.cpp
+++ b/src/game/client/components/camera.cpp
@@ -35,6 +35,11 @@ CCamera::CCamera()
 	m_WasSpectating = false;
 
 	m_CameraSmoothing = false;
+
+	m_LastMousePos = vec2(0, 0);
+	m_DyncamTargetCameraOffset = vec2(0, 0);
+	mem_zero(m_aDyncamCurrentCameraOffset, sizeof(m_aDyncamCurrentCameraOffset));
+	m_DyncamSmoothingSpeedBias = 0.5f;
 }
 
 float CCamera::CameraSmoothingProgress(float CurrentTime) const
@@ -89,7 +94,7 @@ void CCamera::ChangeZoom(float Target, int Smoothness)
 	m_Zooming = true;
 }
 
-void CCamera::OnRender()
+void CCamera::UpdateCamera()
 {
 	if(m_Zooming)
 	{
@@ -112,6 +117,58 @@ void CCamera::OnRender()
 		m_Zoom = clamp(m_Zoom, MinZoomLevel(), MaxZoomLevel());
 	}
 
+	if(!ZoomAllowed())
+	{
+		m_ZoomSet = false;
+		m_Zoom = 1.0f;
+		m_Zooming = false;
+	}
+	else if(!m_ZoomSet && g_Config.m_ClDefaultZoom != 10)
+	{
+		m_ZoomSet = true;
+		OnReset();
+	}
+
+	if(m_pClient->m_Snap.m_SpecInfo.m_Active && !m_pClient->m_Snap.m_SpecInfo.m_UsePosition)
+		return;
+
+	float DeltaTime = Client()->RenderFrameTime();
+
+	if(g_Config.m_ClDyncamSmoothness > 0)
+	{
+		float CameraSpeed = (1.0f - (g_Config.m_ClDyncamSmoothness / 100.0f)) * 9.5f + 0.5f;
+		float CameraStabilizingFactor = 1 + g_Config.m_ClDyncamStabilizing / 100.0f;
+
+		m_DyncamSmoothingSpeedBias += CameraSpeed * DeltaTime;
+		if(g_Config.m_ClDyncam)
+		{
+			m_DyncamSmoothingSpeedBias -= length(m_pClient->m_Controls.m_aMousePos[g_Config.m_ClDummy] - m_LastMousePos) * std::log10(CameraStabilizingFactor) * 0.02f;
+			m_DyncamSmoothingSpeedBias = clamp(m_DyncamSmoothingSpeedBias, 0.5f, CameraSpeed);
+		}
+		else
+		{
+			m_DyncamSmoothingSpeedBias = maximum(5.0f, CameraSpeed); // make sure toggle back is fast
+		}
+	}
+
+	m_DyncamTargetCameraOffset = vec2(0, 0);
+	vec2 MousePos = m_pClient->m_Controls.m_aMousePos[g_Config.m_ClDummy];
+	float l = length(MousePos);
+	if(l > 0.0001f) // make sure that this isn't 0
+	{
+		float OffsetAmount = maximum(l - Deadzone(), 0.0f) * (FollowFactor() / 100.0f);
+		m_DyncamTargetCameraOffset = normalize(MousePos) * OffsetAmount;
+	}
+
+	m_LastMousePos = MousePos;
+	if(g_Config.m_ClDyncamSmoothness > 0)
+		m_aDyncamCurrentCameraOffset[g_Config.m_ClDummy] += (m_DyncamTargetCameraOffset - m_aDyncamCurrentCameraOffset[g_Config.m_ClDummy]) * minimum(DeltaTime * m_DyncamSmoothingSpeedBias, 1.0f);
+	else
+		m_aDyncamCurrentCameraOffset[g_Config.m_ClDummy] = m_DyncamTargetCameraOffset;
+}
+
+void CCamera::OnRender()
+{
 	if(m_CameraSmoothing)
 	{
 		if(!m_pClient->m_Snap.m_SpecInfo.m_Active)
@@ -139,18 +196,6 @@ void CCamera::OnRender()
 		}
 	}
 
-	if(!ZoomAllowed())
-	{
-		m_ZoomSet = false;
-		m_Zoom = 1.0f;
-		m_Zooming = false;
-	}
-	else if(!m_ZoomSet && g_Config.m_ClDefaultZoom != 10)
-	{
-		m_ZoomSet = true;
-		OnReset();
-	}
-
 	// update camera center
 	if(m_pClient->m_Snap.m_SpecInfo.m_Active && !m_pClient->m_Snap.m_SpecInfo.m_UsePosition)
 	{
@@ -172,49 +217,10 @@ void CCamera::OnRender()
 			m_CamType = CAMTYPE_PLAYER;
 		}
 
-		float DeltaTime = Client()->RenderFrameTime();
-		static vec2 s_LastMousePos(0, 0);
-		static vec2 s_aCurrentCameraOffset[NUM_DUMMIES] = {vec2(0, 0), vec2(0, 0)};
-		static float s_SpeedBias = 0.5f;
-
-		if(g_Config.m_ClDyncamSmoothness > 0)
-		{
-			float CameraSpeed = (1.0f - (g_Config.m_ClDyncamSmoothness / 100.0f)) * 9.5f + 0.5f;
-			float CameraStabilizingFactor = 1 + g_Config.m_ClDyncamStabilizing / 100.0f;
-
-			s_SpeedBias += CameraSpeed * DeltaTime;
-			if(g_Config.m_ClDyncam)
-			{
-				s_SpeedBias -= length(m_pClient->m_Controls.m_aMousePos[g_Config.m_ClDummy] - s_LastMousePos) * std::log10(CameraStabilizingFactor) * 0.02f;
-				s_SpeedBias = clamp(s_SpeedBias, 0.5f, CameraSpeed);
-			}
-			else
-			{
-				s_SpeedBias = maximum(5.0f, CameraSpeed); // make sure toggle back is fast
-			}
-		}
-
-		vec2 TargetCameraOffset(0, 0);
-		s_LastMousePos = m_pClient->m_Controls.m_aMousePos[g_Config.m_ClDummy];
-		float l = length(s_LastMousePos);
-		if(l > 0.0001f) // make sure that this isn't 0
-		{
-			float DeadZone = g_Config.m_ClDyncam ? g_Config.m_ClDyncamDeadzone : g_Config.m_ClMouseDeadzone;
-			float FollowFactor = (g_Config.m_ClDyncam ? g_Config.m_ClDyncamFollowFactor : g_Config.m_ClMouseFollowfactor) / 100.0f;
-			float OffsetAmount = maximum(l - DeadZone, 0.0f) * FollowFactor;
-
-			TargetCameraOffset = normalize(m_pClient->m_Controls.m_aMousePos[g_Config.m_ClDummy]) * OffsetAmount;
-		}
-
-		if(g_Config.m_ClDyncamSmoothness > 0)
-			s_aCurrentCameraOffset[g_Config.m_ClDummy] += (TargetCameraOffset - s_aCurrentCameraOffset[g_Config.m_ClDummy]) * minimum(DeltaTime * s_SpeedBias, 1.0f);
-		else
-			s_aCurrentCameraOffset[g_Config.m_ClDummy] = TargetCameraOffset;
-
 		if(m_pClient->m_Snap.m_SpecInfo.m_Active)
-			m_Center = m_pClient->m_Snap.m_SpecInfo.m_Position + s_aCurrentCameraOffset[g_Config.m_ClDummy];
+			m_Center = m_pClient->m_Snap.m_SpecInfo.m_Position + m_aDyncamCurrentCameraOffset[g_Config.m_ClDummy];
 		else
-			m_Center = m_pClient->m_LocalCharacterPos + s_aCurrentCameraOffset[g_Config.m_ClDummy];
+			m_Center = m_pClient->m_LocalCharacterPos + m_aDyncamCurrentCameraOffset[g_Config.m_ClDummy];
 	}
 
 	if(m_ForceFreeview && m_CamType == CAMTYPE_SPEC)
@@ -477,4 +483,14 @@ bool CCamera::ZoomAllowed() const
 	return GameClient()->m_Snap.m_SpecInfo.m_Active ||
 	       GameClient()->m_GameInfo.m_AllowZoom ||
 	       Client()->State() == IClient::STATE_DEMOPLAYBACK;
+}
+
+int CCamera::Deadzone() const
+{
+	return g_Config.m_ClDyncam ? g_Config.m_ClDyncamDeadzone : g_Config.m_ClMouseDeadzone;
+}
+
+int CCamera::FollowFactor() const
+{
+	return g_Config.m_ClDyncam ? g_Config.m_ClDyncamFollowFactor : g_Config.m_ClMouseFollowfactor;
 }

--- a/src/game/client/components/camera.h
+++ b/src/game/client/components/camera.h
@@ -50,6 +50,9 @@ class CCamera : public CComponent
 	float MinZoomLevel();
 	float MaxZoomLevel();
 
+	vec2 m_LastMousePos;
+	float m_DyncamSmoothingSpeedBias;
+
 public:
 	static constexpr float ZOOM_STEP = 0.866025f;
 
@@ -58,6 +61,9 @@ public:
 	bool m_Zooming;
 	float m_Zoom;
 	float m_ZoomSmoothingTarget;
+
+	vec2 m_DyncamTargetCameraOffset;
+	vec2 m_aDyncamCurrentCameraOffset[NUM_DUMMIES];
 
 	CCamera();
 	virtual int Sizeof() const override { return sizeof(*this); }
@@ -74,6 +80,11 @@ public:
 
 	void SetZoom(float Target, int Smoothness);
 	bool ZoomAllowed() const;
+
+	int Deadzone() const;
+	int FollowFactor() const;
+
+	void UpdateCamera();
 
 private:
 	static void ConZoomPlus(IConsole::IResult *pResult, void *pUserData);

--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -356,11 +356,20 @@ void CControls::OnRender()
 
 	// update target pos
 	if(m_pClient->m_Snap.m_pGameInfoObj && !m_pClient->m_Snap.m_SpecInfo.m_Active)
-		m_aTargetPos[g_Config.m_ClDummy] = m_pClient->m_LocalCharacterPos + m_aMousePos[g_Config.m_ClDummy];
+	{
+		// make sure to compensate for smooth dyncam to ensure the cursor stays still in world space if zoomed
+		vec2 DyncamOffsetDelta = m_pClient->m_Camera.m_DyncamTargetCameraOffset - m_pClient->m_Camera.m_aDyncamCurrentCameraOffset[g_Config.m_ClDummy];
+		float Zoom = m_pClient->m_Camera.m_Zoom;
+		m_aTargetPos[g_Config.m_ClDummy] = m_pClient->m_LocalCharacterPos + m_aMousePos[g_Config.m_ClDummy] - DyncamOffsetDelta + DyncamOffsetDelta / Zoom;
+	}
 	else if(m_pClient->m_Snap.m_SpecInfo.m_Active && m_pClient->m_Snap.m_SpecInfo.m_UsePosition)
+	{
 		m_aTargetPos[g_Config.m_ClDummy] = m_pClient->m_Snap.m_SpecInfo.m_Position + m_aMousePos[g_Config.m_ClDummy];
+	}
 	else
+	{
 		m_aTargetPos[g_Config.m_ClDummy] = m_aMousePos[g_Config.m_ClDummy];
+	}
 }
 
 bool CControls::OnCursorMove(float x, float y, IInput::ECursorType CursorType)

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -757,6 +757,9 @@ void CGameClient::OnRender()
 		}
 	}
 
+	// update camera data prior to CControls::OnRender to allow CControls::m_aTargetPos to compensate using camera data
+	m_Camera.UpdateCamera();
+
 	// render all systems
 	for(auto &pComponent : m_vpAll)
 		pComponent->OnRender();


### PR DESCRIPTION
DDNet's zoom made smooth dyncam (which was only made for default zoom value) very hard to use due to the cursor drifting unpredictably.

This PR addresses that by fixing the cursor in world place by doing some calculation when setting `CControls::m_aTargetPos`.
This requires a bit refactoring and now `CControls` has a coupling with `CCamera`.

I'm pretty sure this *only* affect control when using Smooth Dyncam AND Zoom at the same time, which is provable:

> The only terms added to `CControls::m_aTargetPos`  is `- DyncamOffsetDelta + DyncamOffsetDelta / Zoom` 
> 1. If Smooth Dyncam is off (with either normal Dyncam or no Dyncam) `DyncamOffsetDelta` will be 0.
> 2. If Zoom is default, the value `Zoom` is 1.
> 3. If either 1 OR 2 is true, the terms results in 0.

Video comparisons:
* Before:

https://github.com/user-attachments/assets/37bbad2f-9c76-4a2a-a868-3fbcabd0058d

* After:

https://github.com/user-attachments/assets/8ee9eab4-0c08-4dd3-af36-410e7d624b8a

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
