### PR TITLE
Fix Tele Commands during Dyncam Zoom and Make Aiming Consistent across Zoom Levels

### DIFF
--- a/datasrc/network.py
+++ b/datasrc/network.py
@@ -540,6 +540,12 @@ Messages = [
 		NetIntRange("m_Show", 0, 2),
 	]),
 
+	NetMessageEx("Cl_CameraInfo", "camera-info@netmsg.ddnet.org", [
+		NetIntAny("m_Zoom"),
+		NetIntAny("m_Deadzone"),
+		NetIntAny("m_FollowFactor"),
+	]),
+
 	NetMessageEx("Sv_TeamsState", "teamsstate@netmsg.ddnet.tw", []),
 
 	NetMessageEx("Sv_DDRaceTime", "ddrace-time@netmsg.ddnet.tw", [

--- a/src/game/client/components/camera.cpp
+++ b/src/game/client/components/camera.cpp
@@ -157,7 +157,7 @@ void CCamera::UpdateCamera()
 	if(l > 0.0001f) // make sure that this isn't 0
 	{
 		float OffsetAmount = maximum(l - Deadzone(), 0.0f) * (FollowFactor() / 100.0f);
-		m_DyncamTargetCameraOffset = normalize(MousePos) * OffsetAmount;
+		m_DyncamTargetCameraOffset = normalize_pre_length(MousePos, l) * OffsetAmount;
 	}
 
 	m_LastMousePos = MousePos;

--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -215,13 +215,6 @@ int CControls::SnapInput(int *pData)
 		m_aInputData[g_Config.m_ClDummy].m_TargetX = (int)m_aMousePos[g_Config.m_ClDummy].x;
 		m_aInputData[g_Config.m_ClDummy].m_TargetY = (int)m_aMousePos[g_Config.m_ClDummy].y;
 
-		// scale TargetX, TargetY by zoom.
-		if(!m_pClient->m_Snap.m_SpecInfo.m_Active)
-		{
-			m_aInputData[g_Config.m_ClDummy].m_TargetX *= m_pClient->m_Camera.m_Zoom;
-			m_aInputData[g_Config.m_ClDummy].m_TargetY *= m_pClient->m_Camera.m_Zoom;
-		}
-
 		// send once a second just to be sure
 		Send = Send || time_get() > m_LastSendTime + time_freq();
 	}
@@ -249,13 +242,6 @@ int CControls::SnapInput(int *pData)
 			m_aInputData[g_Config.m_ClDummy].m_Direction = -1;
 		if(!m_aInputDirectionLeft[g_Config.m_ClDummy] && m_aInputDirectionRight[g_Config.m_ClDummy])
 			m_aInputData[g_Config.m_ClDummy].m_Direction = 1;
-
-		// scale TargetX, TargetY by zoom.
-		if(!m_pClient->m_Snap.m_SpecInfo.m_Active)
-		{
-			m_aInputData[g_Config.m_ClDummy].m_TargetX *= m_pClient->m_Camera.m_Zoom;
-			m_aInputData[g_Config.m_ClDummy].m_TargetY *= m_pClient->m_Camera.m_Zoom;
-		}
 
 		// dummy copy moves
 		if(g_Config.m_ClDummyCopyMoves)

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -819,8 +819,11 @@ private:
 	CTuningParams m_aTuningList[NUM_TUNEZONES];
 	CTuningParams *TuningList() { return m_aTuningList; }
 
+	float m_LastShowDistanceZoom;
 	float m_LastZoom;
 	float m_LastScreenAspect;
+	float m_LastDeadzone;
+	float m_LastFollowFactor;
 	bool m_LastDummyConnected;
 
 	void HandleMultiView();

--- a/src/game/server/ddracechat.cpp
+++ b/src/game/server/ddracechat.cpp
@@ -1920,10 +1920,12 @@ void CGameContext::ConTeleCursor(IConsole::IResult *pResult, void *pUserData)
 		return;
 	}
 
+	// default to view pos when character is not available
 	vec2 Pos = pPlayer->m_ViewPos;
-	if(pResult->NumArguments() == 0 && !pPlayer->IsPaused())
+	if(pResult->NumArguments() == 0 && !pPlayer->IsPaused() && pPlayer->GetCharacter() && pPlayer->GetCharacter()->IsAlive())
 	{
-		Pos += vec2(pChr->Core()->m_Input.m_TargetX, pChr->Core()->m_Input.m_TargetY);
+		vec2 Target = vec2(pChr->Core()->m_Input.m_TargetX, pChr->Core()->m_Input.m_TargetY);
+		Pos = pPlayer->m_CameraInfo.ConvertTargetToWorld(pPlayer->GetCharacter()->GetPos(), Target);
 	}
 	else if(pResult->NumArguments() > 0)
 	{

--- a/src/game/server/ddracecommands.cpp
+++ b/src/game/server/ddracecommands.cpp
@@ -439,10 +439,12 @@ void CGameContext::ConTeleport(IConsole::IResult *pResult, void *pUserData)
 
 	if(pChr && pPlayer && pSelf->GetPlayerChar(TeleTo))
 	{
-		vec2 Pos = pSelf->m_apPlayers[TeleTo]->m_ViewPos;
-		if(!pPlayer->IsPaused() && !pResult->NumArguments())
+		// default to view pos when character is not available
+		vec2 Pos = pPlayer->m_ViewPos;
+		if(pResult->NumArguments() == 0 && !pPlayer->IsPaused() && pChr->IsAlive())
 		{
-			Pos += vec2(pChr->Core()->m_Input.m_TargetX, pChr->Core()->m_Input.m_TargetY);
+			vec2 Target = vec2(pChr->Core()->m_Input.m_TargetX, pChr->Core()->m_Input.m_TargetY);
+			Pos = pPlayer->m_CameraInfo.ConvertTargetToWorld(pChr->GetPos(), Target);
 		}
 		pSelf->Teleport(pChr, Pos);
 		pChr->ResetJumps();

--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -2075,6 +2075,9 @@ void CGameContext::OnMessage(int MsgId, CUnpacker *pUnpacker, int ClientId)
 		case NETMSGTYPE_CL_SHOWDISTANCE:
 			OnShowDistanceNetMessage(static_cast<CNetMsg_Cl_ShowDistance *>(pRawMsg), ClientId);
 			break;
+		case NETMSGTYPE_CL_CAMERAINFO:
+			OnCameraInfoNetMessage(static_cast<CNetMsg_Cl_CameraInfo *>(pRawMsg), ClientId);
+			break;
 		case NETMSGTYPE_CL_SETSPECTATORMODE:
 			OnSetSpectatorModeNetMessage(static_cast<CNetMsg_Cl_SetSpectatorMode *>(pRawMsg), ClientId);
 			break;
@@ -2583,6 +2586,12 @@ void CGameContext::OnShowDistanceNetMessage(const CNetMsg_Cl_ShowDistance *pMsg,
 {
 	CPlayer *pPlayer = m_apPlayers[ClientId];
 	pPlayer->m_ShowDistance = vec2(pMsg->m_X, pMsg->m_Y);
+}
+
+void CGameContext::OnCameraInfoNetMessage(const CNetMsg_Cl_CameraInfo *pMsg, int ClientId)
+{
+	CPlayer *pPlayer = m_apPlayers[ClientId];
+	pPlayer->m_CameraInfo.Write(pMsg);
 }
 
 void CGameContext::OnSetSpectatorModeNetMessage(const CNetMsg_Cl_SetSpectatorMode *pMsg, int ClientId)

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -309,6 +309,7 @@ public:
 	void OnShowOthersLegacyNetMessage(const CNetMsg_Cl_ShowOthersLegacy *pMsg, int ClientId);
 	void OnShowOthersNetMessage(const CNetMsg_Cl_ShowOthers *pMsg, int ClientId);
 	void OnShowDistanceNetMessage(const CNetMsg_Cl_ShowDistance *pMsg, int ClientId);
+	void OnCameraInfoNetMessage(const CNetMsg_Cl_CameraInfo *pMsg, int ClientId);
 	void OnSetSpectatorModeNetMessage(const CNetMsg_Cl_SetSpectatorMode *pMsg, int ClientId);
 	void OnChangeInfoNetMessage(const CNetMsg_Cl_ChangeInfo *pMsg, int ClientId);
 	void OnEmoticonNetMessage(const CNetMsg_Cl_Emoticon *pMsg, int ClientId);

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -146,8 +146,9 @@ void CPlayer::Reset()
 	m_SwapTargetsClientId = -1;
 	m_BirthdayAnnounced = false;
 	m_RescueMode = RESCUEMODE_AUTO;
-
 	m_CanUseSpectatingPlayerFlag = false;
+
+	m_CameraInfo.Reset();
 }
 
 static int PlayerFlags_SixToSeven(int Flags)
@@ -958,4 +959,32 @@ void CPlayer::ProcessScoreResult(CScorePlayerResult &Result)
 			break;
 		}
 	}
+}
+
+vec2 CPlayer::CCameraInfo::ConvertTargetToWorld(vec2 Position, vec2 Target) const
+{
+	vec2 TargetCameraOffset(0, 0);
+	float l = length(Target);
+
+	if(l > 0.0001f) // make sure that this isn't 0
+	{
+		float OffsetAmount = maximum(l - m_Deadzone, 0.0f) * (m_FollowFactor / 100.0f);
+		TargetCameraOffset = normalize_pre_length(Target, l) * OffsetAmount;
+	}
+
+	return Position + (Target - TargetCameraOffset) * m_Zoom + TargetCameraOffset;
+}
+
+void CPlayer::CCameraInfo::Write(const CNetMsg_Cl_CameraInfo *Msg)
+{
+	m_Zoom = Msg->m_Zoom / 1000.0f;
+	m_Deadzone = Msg->m_Deadzone;
+	m_FollowFactor = Msg->m_FollowFactor;
+}
+
+void CPlayer::CCameraInfo::Reset()
+{
+	m_Zoom = 1.0f;
+	m_Deadzone = 0.0f;
+	m_FollowFactor = 0.0f;
 }

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -193,6 +193,19 @@ public:
 	bool m_SpecTeam;
 	bool m_NinjaJetpack;
 
+	// camera info is used sparingly for converting aim target to absolute world coordinates
+	class CCameraInfo
+	{
+		float m_Zoom;
+		int m_Deadzone;
+		int m_FollowFactor;
+
+	public:
+		vec2 ConvertTargetToWorld(vec2 Position, vec2 Target) const;
+		void Write(const CNetMsg_Cl_CameraInfo *pMsg);
+		void Reset();
+	} m_CameraInfo;
+
 	int m_ChatScore;
 
 	bool m_Moderating;


### PR DESCRIPTION
Closes #9294, closes #8452, closes #8666, closes #9296

## Problem:
As previously stated in #9298 and #9296. Dyncam (off-character camera) and Zoom combination introduces some extra math that needs to be done to correctly calculate player's actual cursor position.

We also do not want to touch any dyncam implementation (e.g. adjust the camera position after zoom) since that could kill some player habit.

There is also player concerns about the shifted target precision when we scaled the target position by zoom, that does have some destructive impact that breaks both dyncam zoom and player input.

## Implementation:
Since the actual cursor position is rarely used (currently only `tele` and `telecursor`), after some discussion on discord we think it would be better to unscale input target to restore aiming consistency that matches teeworlds. Then we can calculate cursor position for affected commands specifically via other measures. 

This adds a `Cl_CameraInfo` NetMessageEx to send camera info to server. which allows us to calculate the cursor position in server. 
Assuming a player does not adjust dyncam settings continuously, this should roughly send as frequent as `Cl_ShowDistance`, should have pretty minor impact.

For future reference, world cursor position can be calculated with:
```
vec2 CameraOffset = normalize(Target) * maximum(l - CameraDeadzone, 0.0f) * (CameraFollowFactor / 100.0f);
CursorPos = CharacterPos + (Target - CameraOffset) * Zoom + CameraOffset;
```
This adjust the camera offset which is scaled wrong after zoom when using dyncam. (However, if dyncam scaled the value correctly, dyncam can look very weird during zoom and would shift camera's view point around)

## Drawback:
* Will calculate the wrong value during a smooth zoom animation (insignificant)
* Will calculate the wrong value when player is using a very small mouse distance with a zoom (who does that)
* Have some compatibility issue between versions (see below)

## Version compatibility:
* NEW client in OLD server: `telecursor` will send them to the wrong position if zoomed
* OLD client in NEW server: `telecursor` will behave the same as previous versions (only wrong with dyncam + zoom)

## Next step:
This also changes how #9292 should be implemented. But with the new camera info available to server, spectating experience can closely match what spectated player is currently using / seeing. Spectator cursor will be developed in that PR instead.

Due to only `tele` and `telecursor` being the one that currently uses world cursor position and new server can simulate old behavior intrinsically, I believe we don't need to introduce compatibility code.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
