### PR TITLE
Fix clipboard not being sanitized when pasting multiple lines

### DIFF
--- a/src/game/client/lineinput.cpp
+++ b/src/game/client/lineinput.cpp
@@ -358,6 +358,7 @@ bool CLineInput::ProcessInput(const IInput::CEvent &Event)
 								Line = GetString();
 							}
 							Begin = i + 1;
+							str_sanitize_cc(Line.data());
 							m_pfnClipboardLineCallback(Line.c_str());
 						}
 					}


### PR DESCRIPTION
For example when pasting multiple lines of text containing Windows line endings, the `\r` characters were not being removed from lines except the first one.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
