### PR TITLE
Remove self from spectator menu unless in demo

### DIFF
--- a/src/game/client/components/spectator.cpp
+++ b/src/game/client/components/spectator.cpp
@@ -426,6 +426,9 @@ void CSpectator::OnRender()
 		if(!m_pClient->m_Snap.m_apInfoByDDTeamName[i] || m_pClient->m_Snap.m_apInfoByDDTeamName[i]->m_Team == TEAM_SPECTATORS)
 			continue;
 
+		if(Client()->State() != IClient::STATE_DEMOPLAYBACK && m_pClient->m_Snap.m_apInfoByDDTeamName[i]->m_ClientId == m_pClient->m_Snap.m_LocalClientId)
+			continue;
+
 		++Count;
 
 		if(Count == PerLine + 1 || (Count > PerLine + 1 && (Count - 1) % PerLine == 0))

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -4084,6 +4084,9 @@ bool CGameClient::InitMultiView(int Team)
 		int Count = 0;
 		for(int i = 0; i < MAX_CLIENTS; i++)
 		{
+			if(Client()->State() != IClient::STATE_DEMOPLAYBACK && m_Snap.m_apPlayerInfos[i] && m_Snap.m_apPlayerInfos[i]->m_ClientId == m_Snap.m_LocalClientId)
+				continue;
+
 			vec2 PlayerPos;
 
 			// get the position of the player


### PR DESCRIPTION
Simple change, prevents multi-view auto selecting yourself in game too.

This eliminates all possibilities of a player accidentally spectating themselves (without using console) during a pause and become confused wondering why they can't move the camera after pausing.

If someone **really** *really* want to spectate themselves for some reason, `spectate` and `spectate_multiview` still works on yourself, and of course modded server can just send a SpectatorId to force it.

Note that left-clicking on yourself in freeview is already disabled previously.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
