### PR TITLE
Make demo spectator id changes consistent

### DIFF
--- a/src/game/client/components/spectator.cpp
+++ b/src/game/client/components/spectator.cpp
@@ -18,10 +18,17 @@
 
 #include <game/client/gameclient.h>
 
-bool CSpectator::CanChangeSpectator()
+bool CSpectator::CanChangeSpectatorId()
 {
-	// Don't change SpectatorId when not spectating
-	return m_pClient->m_Snap.m_SpecInfo.m_Active;
+	// don't change SpectatorId when not spectating
+	if(!m_pClient->m_Snap.m_SpecInfo.m_Active)
+		return false;
+
+	// stop follow mode from changing SpectatorId
+	if(Client()->State() == IClient::STATE_DEMOPLAYBACK && m_pClient->m_DemoSpecId == SPEC_FOLLOW)
+		return false;
+
+	return true;
 }
 
 void CSpectator::SpectateNext(bool Reverse)
@@ -89,7 +96,7 @@ void CSpectator::ConKeySpectator(IConsole::IResult *pResult, void *pUserData)
 void CSpectator::ConSpectate(IConsole::IResult *pResult, void *pUserData)
 {
 	CSpectator *pSelf = (CSpectator *)pUserData;
-	if(!pSelf->CanChangeSpectator())
+	if(!pSelf->CanChangeSpectatorId())
 		return;
 
 	pSelf->Spectate(pResult->GetInteger(0));
@@ -98,7 +105,7 @@ void CSpectator::ConSpectate(IConsole::IResult *pResult, void *pUserData)
 void CSpectator::ConSpectateNext(IConsole::IResult *pResult, void *pUserData)
 {
 	CSpectator *pSelf = (CSpectator *)pUserData;
-	if(!pSelf->CanChangeSpectator())
+	if(!pSelf->CanChangeSpectatorId())
 		return;
 
 	pSelf->SpectateNext(false);
@@ -107,7 +114,7 @@ void CSpectator::ConSpectateNext(IConsole::IResult *pResult, void *pUserData)
 void CSpectator::ConSpectatePrevious(IConsole::IResult *pResult, void *pUserData)
 {
 	CSpectator *pSelf = (CSpectator *)pUserData;
-	if(!pSelf->CanChangeSpectator())
+	if(!pSelf->CanChangeSpectatorId())
 		return;
 
 	pSelf->SpectateNext(true);
@@ -116,37 +123,7 @@ void CSpectator::ConSpectatePrevious(IConsole::IResult *pResult, void *pUserData
 void CSpectator::ConSpectateClosest(IConsole::IResult *pResult, void *pUserData)
 {
 	CSpectator *pSelf = (CSpectator *)pUserData;
-	if(!pSelf->CanChangeSpectator())
-		return;
-
-	const CGameClient::CSnapState &Snap = pSelf->m_pClient->m_Snap;
-	int SpectatorId = Snap.m_SpecInfo.m_SpectatorId;
-
-	int NewSpectatorId = -1;
-
-	vec2 CurPosition(pSelf->m_pClient->m_Camera.m_Center);
-	if(SpectatorId != SPEC_FREEVIEW)
-	{
-		const CNetObj_Character &CurCharacter = Snap.m_aCharacters[SpectatorId].m_Cur;
-		CurPosition.x = CurCharacter.m_X;
-		CurPosition.y = CurCharacter.m_Y;
-	}
-
-	int ClosestDistance = std::numeric_limits<int>::max();
-	for(int i = 0; i < MAX_CLIENTS; i++)
-	{
-		if(i == SpectatorId || !Snap.m_aCharacters[i].m_Active || !Snap.m_apPlayerInfos[i] || Snap.m_apPlayerInfos[i]->m_Team == TEAM_SPECTATORS || (SpectatorId == SPEC_FREEVIEW && i == Snap.m_LocalClientId))
-			continue;
-		const CNetObj_Character &MaybeClosestCharacter = Snap.m_aCharacters[i].m_Cur;
-		int Distance = distance(CurPosition, vec2(MaybeClosestCharacter.m_X, MaybeClosestCharacter.m_Y));
-		if(NewSpectatorId == -1 || Distance < ClosestDistance)
-		{
-			NewSpectatorId = i;
-			ClosestDistance = Distance;
-		}
-	}
-	if(NewSpectatorId > -1)
-		pSelf->Spectate(NewSpectatorId);
+	pSelf->SpectateClosest(true);
 }
 
 void CSpectator::ConMultiView(IConsole::IResult *pResult, void *pUserData)
@@ -204,7 +181,7 @@ bool CSpectator::OnInput(const IInput::CEvent &Event)
 				if(m_pClient->m_Snap.m_SpecInfo.m_SpectatorId != SPEC_FREEVIEW)
 					Spectate(SPEC_FREEVIEW);
 				else
-					SpectateClosest();
+					SpectateClosest(Client()->State() == IClient::STATE_DEMOPLAYBACK);
 				return true;
 			}
 		}
@@ -641,7 +618,41 @@ void CSpectator::Spectate(int SpectatorId)
 	Client()->SendPackMsgActive(&Msg, MSGFLAG_VITAL);
 }
 
-void CSpectator::SpectateClosest()
+void CSpectator::SpectateClosest(bool AllowSelf)
 {
-	ConSpectateClosest(NULL, this);
+	if(CanChangeSpectatorId())
+		return;
+
+	const CGameClient::CSnapState &Snap = m_pClient->m_Snap;
+	int SpectatorId = Snap.m_SpecInfo.m_SpectatorId;
+
+	int NewSpectatorId = -1;
+
+	vec2 CurPosition(m_pClient->m_Camera.m_Center);
+	if(SpectatorId != SPEC_FREEVIEW)
+	{
+		const CNetObj_Character &CurCharacter = Snap.m_aCharacters[SpectatorId].m_Cur;
+		CurPosition.x = CurCharacter.m_X;
+		CurPosition.y = CurCharacter.m_Y;
+	}
+
+	int ClosestDistance = std::numeric_limits<int>::max();
+	for(int i = 0; i < MAX_CLIENTS; i++)
+	{
+		if(i == SpectatorId || !Snap.m_aCharacters[i].m_Active || !Snap.m_apPlayerInfos[i] || Snap.m_apPlayerInfos[i]->m_Team == TEAM_SPECTATORS)
+			continue;
+
+		if(!AllowSelf && i == Snap.m_LocalClientId)
+			continue;
+
+		const CNetObj_Character &MaybeClosestCharacter = Snap.m_aCharacters[i].m_Cur;
+		int Distance = distance(CurPosition, vec2(MaybeClosestCharacter.m_X, MaybeClosestCharacter.m_Y));
+		if(NewSpectatorId == -1 || Distance < ClosestDistance)
+		{
+			NewSpectatorId = i;
+			ClosestDistance = Distance;
+		}
+	}
+	if(NewSpectatorId > -1)
+		Spectate(NewSpectatorId);
 }

--- a/src/game/client/components/spectator.h
+++ b/src/game/client/components/spectator.h
@@ -26,7 +26,7 @@ class CSpectator : public CComponent
 
 	float m_MultiViewActivateDelay;
 
-	bool CanChangeSpectator();
+	bool CanChangeSpectatorId();
 	void SpectateNext(bool Reverse);
 
 	static void ConKeySpectator(IConsole::IResult *pResult, void *pUserData);
@@ -48,7 +48,7 @@ public:
 	virtual void OnReset() override;
 
 	void Spectate(int SpectatorId);
-	void SpectateClosest();
+	void SpectateClosest(bool AllowSelf);
 
 	bool IsActive() const { return m_Active; }
 };


### PR DESCRIPTION
Demo spectator menu have several problems:
* You can not left-click yourself to spectate.
* Follow mode spectator change relies on whether the recording is spectating or not.

This PR enforces the following rule in demo player.
1. You can not change SpectatorId when in follow mode, the recording itself always decides where to look at.
2. As long as you are not in follow mode, you can change SpectatorId freely, including to yourself.

Also includes a tiny refactoring that changes `CanChangeSpectator` to `CanChangeSpectatorId` because you are the "spectator", you can't change yourself (~~but you can always improve and be a better person to allow you to be more confident~~)

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
