### PR TITLE
Fix menus skin list initially being empty, refactor skin refreshing

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -1815,7 +1815,7 @@ void CMenus::RenderPopupFullscreen(CUIRect Screen)
 					if(m_pClient->m_Skins7.SaveSkinfile(m_SkinNameInput.GetString(), m_Dummy))
 					{
 						m_Popup = POPUP_NONE;
-						m_SkinListNeedsUpdate = true;
+						m_SkinList7LastRefreshTime = std::nullopt;
 					}
 					else
 						PopupMessage(Localize("Error"), Localize("Unable to save the skin"), Localize("Ok"), POPUP_SAVE_SKIN);

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -8,6 +8,7 @@
 
 #include <chrono>
 #include <deque>
+#include <optional>
 #include <unordered_set>
 #include <vector>
 
@@ -94,8 +95,10 @@ class CMenus : public CComponent
 	void DoJoystickAxisPicker(CUIRect View);
 	void DoJoystickBar(const CUIRect *pRect, float Current, float Tolerance, bool Active);
 
-	bool m_SkinListNeedsUpdate = false;
+	std::optional<std::chrono::nanoseconds> m_SkinListLastRefreshTime;
 	bool m_SkinListScrollToSelected = false;
+	std::optional<std::chrono::nanoseconds> m_SkinList7LastRefreshTime;
+	std::optional<std::chrono::nanoseconds> m_SkinPartsList7LastRefreshTime;
 
 	int m_DirectionQuadContainerIndex;
 
@@ -585,7 +588,6 @@ protected:
 	void UpdateCommunityIcons();
 
 	// skin favorite list
-	bool m_SkinFavoritesChanged = false;
 	std::unordered_set<std::string> m_SkinFavorites;
 	static void Con_AddFavoriteSkin(IConsole::IResult *pResult, void *pUserData);
 	static void Con_RemFavoriteSkin(IConsole::IResult *pResult, void *pUserData);
@@ -668,7 +670,6 @@ public:
 
 	virtual void OnStateChange(int NewState, int OldState) override;
 	virtual void OnWindowResize() override;
-	virtual void OnRefreshSkins() override;
 	virtual void OnReset() override;
 	virtual void OnRender() override;
 	virtual bool OnInput(const IInput::CEvent &Event) override;

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -401,11 +401,6 @@ struct CUISkin
 	bool operator==(const char *pOther) const { return !str_comp_nocase(m_pSkin->GetName(), pOther); }
 };
 
-void CMenus::OnRefreshSkins()
-{
-	m_SkinListNeedsUpdate = true;
-}
-
 void CMenus::Con_AddFavoriteSkin(IConsole::IResult *pResult, void *pUserData)
 {
 	auto *pSelf = (CMenus *)pUserData;
@@ -417,7 +412,7 @@ void CMenus::Con_AddFavoriteSkin(IConsole::IResult *pResult, void *pUserData)
 		return;
 	}
 	pSelf->m_SkinFavorites.emplace(pStr);
-	pSelf->m_SkinFavoritesChanged = true;
+	pSelf->m_SkinListLastRefreshTime = std::nullopt;
 }
 
 void CMenus::Con_RemFavoriteSkin(IConsole::IResult *pResult, void *pUserData)
@@ -427,7 +422,7 @@ void CMenus::Con_RemFavoriteSkin(IConsole::IResult *pResult, void *pUserData)
 	if(it != pSelf->m_SkinFavorites.end())
 	{
 		pSelf->m_SkinFavorites.erase(it);
-		pSelf->m_SkinFavoritesChanged = true;
+		pSelf->m_SkinListLastRefreshTime = std::nullopt;
 	}
 }
 
@@ -713,14 +708,12 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 	static CListBox s_ListBox;
 
 	// be nice to the CPU
-	static std::chrono::nanoseconds s_SkinLastRefreshTime = m_pClient->m_Skins.LastRefreshTime();
-	if(m_SkinListNeedsUpdate || m_SkinFavoritesChanged || s_SkinLastRefreshTime != m_pClient->m_Skins.LastRefreshTime())
+	if(!m_SkinListLastRefreshTime.has_value() || m_SkinListLastRefreshTime.value() != m_pClient->m_Skins.LastRefreshTime())
 	{
-		s_SkinLastRefreshTime = m_pClient->m_Skins.LastRefreshTime();
+		m_SkinListLastRefreshTime = m_pClient->m_Skins.LastRefreshTime();
 		s_vSkinList.clear();
 		s_vSkinListHelper.clear();
 		s_vFavoriteSkinListHelper.clear();
-		m_SkinFavoritesChanged = false;
 
 		auto &&SkinNotFiltered = [&](const CSkin *pSkinToBeSelected) {
 			// filter quick search
@@ -756,7 +749,6 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 		std::sort(s_vFavoriteSkinListHelper.begin(), s_vFavoriteSkinListHelper.end());
 		s_vSkinList = s_vFavoriteSkinListHelper;
 		s_vSkinList.insert(s_vSkinList.end(), s_vSkinListHelper.begin(), s_vSkinListHelper.end());
-		m_SkinListNeedsUpdate = false;
 	}
 
 	int OldSelected = -1;
@@ -820,7 +812,7 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 				{
 					m_SkinFavorites.emplace(pSkinToBeDraw->GetName());
 				}
-				m_SkinListNeedsUpdate = true;
+				m_SkinListLastRefreshTime = std::nullopt;
 			}
 		}
 	}
@@ -835,7 +827,7 @@ void CMenus::RenderSettingsTee(CUIRect MainView)
 	static CLineInput s_SkinFilterInput(g_Config.m_ClSkinFilterString, sizeof(g_Config.m_ClSkinFilterString));
 	if(Ui()->DoEditBox_Search(&s_SkinFilterInput, &QuickSearch, 14.0f, !Ui()->IsPopupOpen() && m_pClient->m_GameConsole.IsClosed()))
 	{
-		m_SkinListNeedsUpdate = true;
+		m_SkinListLastRefreshTime = std::nullopt;
 	}
 
 	static CButtonContainer s_SkinDatabaseButton;

--- a/src/game/client/components/skins7.cpp
+++ b/src/game/client/components/skins7.cpp
@@ -307,6 +307,8 @@ void CSkins7::OnInit()
 	LoadXmasHat();
 	LoadBotDecoration();
 	GameClient()->m_Menus.RenderLoading(Localize("Loading DDNet Client"), Localize("Loading skin files"), 0);
+
+	m_LastRefreshTime = time_get_nanoseconds();
 }
 
 void CSkins7::InitPlaceholderSkinParts()

--- a/src/game/client/components/skins7.h
+++ b/src/game/client/components/skins7.h
@@ -13,6 +13,7 @@
 #include <game/generated/protocol.h>
 #include <game/generated/protocol7.h>
 
+#include <chrono>
 #include <vector>
 
 class CSkins7 : public CComponent
@@ -66,6 +67,8 @@ public:
 	int Sizeof() const override { return sizeof(*this); }
 	void OnInit() override;
 
+	std::chrono::nanoseconds LastRefreshTime() const { return m_LastRefreshTime; }
+
 	const std::vector<CSkin> &GetSkins() const;
 	const std::vector<CSkinPart> &GetSkinParts(int Part) const;
 	const CSkinPart *FindSkinPartOrNullptr(int Part, const char *pName, bool AllowSpecialPart) const;
@@ -87,6 +90,7 @@ public:
 
 private:
 	int m_ScanningPart;
+	std::chrono::nanoseconds m_LastRefreshTime;
 
 	std::vector<CSkinPart> m_avSkinParts[protocol7::NUM_SKINPARTS];
 	CSkinPart m_aPlaceholderSkinParts[protocol7::NUM_SKINPARTS];


### PR DESCRIPTION
The skin list in the menus was initially empty because `s_SkinLastRefreshTime` is initialized to the current refresh time, which prevents the list from being updated unless the user already has favorite skins, as adding these also cause the list to be updated.

The static `s_SkinLastRefreshTime` variable is replaced with a member variable `m_SkinListNeedsUpdate` and an empty optional is used as initial value to always refresh the list.

The separate `m_SkinListNeedsUpdate` and `m_SkinFavoritesChanged` variables are removed and instead the `m_SkinListLastRefreshTime` variable is used to handle all updates of the skin list.

Separate refresh time variables `m_SkinList7LastRefreshTime` and `m_SkinPartsList7LastRefreshTime` are added for the 0.7 skin menu to avoid interference with 0.6 skins.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
