### PR TITLE
Send camera type flag to prevent unexpected viewpos and target update

### DIFF
--- a/datasrc/network.py
+++ b/datasrc/network.py
@@ -4,7 +4,7 @@
 from datatypes import Enum, Flags, NetArray, NetBool, NetEvent, NetEventEx, NetIntAny, NetIntRange, NetMessage, NetMessageEx, NetObject, NetObjectEx, NetString, NetStringHalfStrict, NetStringStrict, NetTick
 
 Emotes = ["NORMAL", "PAIN", "HAPPY", "SURPRISE", "ANGRY", "BLINK"]
-PlayerFlags = ["PLAYING", "IN_MENU", "CHATTING", "SCOREBOARD", "AIM"]
+PlayerFlags = ["PLAYING", "IN_MENU", "CHATTING", "SCOREBOARD", "AIM", "SPEC_CAM"]
 GameFlags = ["TEAMS", "FLAGS"]
 GameStateFlags = ["GAMEOVER", "SUDDENDEATH", "PAUSED", "RACETIME"]
 CharacterFlags = ["SOLO", "JETPACK", "COLLISION_DISABLED", "ENDLESS_HOOK", "ENDLESS_JUMP", "SUPER",

--- a/src/game/client/components/camera.h
+++ b/src/game/client/components/camera.h
@@ -14,6 +14,7 @@ class CCamera : public CComponent
 {
 	friend class CMenuBackground;
 
+public:
 	enum
 	{
 		CAMTYPE_UNDEFINED = -1,
@@ -21,6 +22,7 @@ class CCamera : public CComponent
 		CAMTYPE_PLAYER,
 	};
 
+private:
 	int m_CamType;
 	vec2 m_aLastPos[NUM_DUMMIES];
 	vec2 m_PrevCenter;
@@ -83,6 +85,7 @@ public:
 
 	int Deadzone() const;
 	int FollowFactor() const;
+	int CamType() const { return m_CamType; }
 
 	void UpdateCamera();
 

--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -191,8 +191,12 @@ int CControls::SnapInput(int *pData)
 	if(m_pClient->m_Scoreboard.Active())
 		m_aInputData[g_Config.m_ClDummy].m_PlayerFlags |= PLAYERFLAG_SCOREBOARD;
 
-	if(m_pClient->m_Controls.m_aShowHookColl[g_Config.m_ClDummy] && Client()->ServerCapAnyPlayerFlag())
+	if(Client()->ServerCapAnyPlayerFlag() && m_pClient->m_Controls.m_aShowHookColl[g_Config.m_ClDummy])
 		m_aInputData[g_Config.m_ClDummy].m_PlayerFlags |= PLAYERFLAG_AIM;
+
+	// force send spec cam flag on first tick to let server know that it is supported
+	if(Client()->ServerCapAnyPlayerFlag() && (m_pClient->m_Camera.CamType() == CCamera::CAMTYPE_SPEC || m_LastSendTime == 0))
+		m_aInputData[g_Config.m_ClDummy].m_PlayerFlags |= PLAYERFLAG_SPEC_CAM;
 
 	bool Send = m_aLastData[g_Config.m_ClDummy].m_PlayerFlags != m_aInputData[g_Config.m_ClDummy].m_PlayerFlags;
 

--- a/src/game/server/player.cpp
+++ b/src/game/server/player.cpp
@@ -146,6 +146,8 @@ void CPlayer::Reset()
 	m_SwapTargetsClientId = -1;
 	m_BirthdayAnnounced = false;
 	m_RescueMode = RESCUEMODE_AUTO;
+
+	m_CanUseSpectatingPlayerFlag = false;
 }
 
 static int PlayerFlags_SixToSeven(int Flags)
@@ -511,7 +513,7 @@ void CPlayer::OnPredictedInput(CNetObj_PlayerInput *pNewInput)
 
 	m_NumInputs++;
 
-	if(m_pCharacter && !m_Paused)
+	if(m_pCharacter && !m_Paused && !(pNewInput->m_PlayerFlags & PLAYERFLAG_SPEC_CAM))
 		m_pCharacter->OnPredictedInput(pNewInput);
 
 	// Magic number when we can hope that client has successfully identified itself
@@ -527,7 +529,7 @@ void CPlayer::OnDirectInput(CNetObj_PlayerInput *pNewInput)
 
 	AfkTimer();
 
-	if(((!m_pCharacter && m_Team == TEAM_SPECTATORS) || m_Paused) && m_SpectatorId == SPEC_FREEVIEW)
+	if(((pNewInput->m_PlayerFlags & PLAYERFLAG_SPEC_CAM) || !m_CanUseSpectatingPlayerFlag) && ((!m_pCharacter && m_Team == TEAM_SPECTATORS) || m_Paused) && m_SpectatorId == SPEC_FREEVIEW)
 		m_ViewPos = vec2(pNewInput->m_TargetX, pNewInput->m_TargetY);
 
 	// check for activity
@@ -546,6 +548,9 @@ void CPlayer::OnPredictedEarlyInput(CNetObj_PlayerInput *pNewInput)
 {
 	m_PlayerFlags = pNewInput->m_PlayerFlags;
 
+	// enable spectating flag feature if the player has ever used it
+	m_CanUseSpectatingPlayerFlag = m_CanUseSpectatingPlayerFlag || (m_PlayerFlags & PLAYERFLAG_SPEC_CAM);
+
 	if(!m_pCharacter && m_Team != TEAM_SPECTATORS && (pNewInput->m_Fire & 1))
 		m_Spawning = true;
 
@@ -553,7 +558,7 @@ void CPlayer::OnPredictedEarlyInput(CNetObj_PlayerInput *pNewInput)
 	if(m_PlayerFlags & PLAYERFLAG_CHATTING)
 		return;
 
-	if(m_pCharacter && !m_Paused)
+	if(m_pCharacter && !m_Paused && !(m_PlayerFlags & PLAYERFLAG_SPEC_CAM))
 		m_pCharacter->OnDirectInput(pNewInput);
 }
 

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -128,6 +128,8 @@ public:
 		int m_Max;
 	} m_Latency;
 
+	bool m_CanUseSpectatingPlayerFlag;
+
 private:
 	const uint32_t m_UniqueClientId;
 	CCharacter *m_pCharacter;


### PR DESCRIPTION
Fixes #8810. Also prevents character flashing when switching to free view, especially in high ping servers.

Added a new `PLAYERFLAG_SPEC_CAM` to hint server which camera type the client is currently using to make sure:
* only apply input to character when input is not in spec cam.
* only change `m_ViewPos` to input when input is in spec cam. 

This is the first time that a new player flag has been added since hookcollision (there is no previous example for adding this), so please review more carefully and decides whether this is worth it to take up a precious bit of player flag (we only got 8, and this is the 6th one)

Compatibility detection (see `m_CanUseSpectatingPlayerFlag`) is done by sending the flag as active on first tick after join, this does mean the player character can not move on the first tick when joining server, I can't see any potential map breakage but be sure to report if you can think of one.

I can change the compatibility detection to a version based one if desired, but I feel this way is more concrete.

## Demo
* Before

https://github.com/user-attachments/assets/73968d54-30f1-44ae-95c8-2ffc09176bfa

* After

https://github.com/user-attachments/assets/2c72c90d-74cc-415c-ac06-5f6aade82c18

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
