### PR TITLE
Fix hook collisions preview string not being localizable

### DIFF
--- a/data/languages/arabic.txt
+++ b/data/languages/arabic.txt
@@ -1852,6 +1852,9 @@ Something hookable
 A Tee
 == 
 
+Preview 'Hook collisions' being pressed
+== 
+
 Show finish messages
 == 
 

--- a/data/languages/azerbaijani.txt
+++ b/data/languages/azerbaijani.txt
@@ -2027,6 +2027,9 @@ Width of your own hook collision line
 Width of others' hook collision line
 == 
 
+Preview 'Hook collisions' being pressed
+== 
+
 Aim
 == 
 

--- a/data/languages/belarusian.txt
+++ b/data/languages/belarusian.txt
@@ -1990,6 +1990,9 @@ Width of your own hook collision line
 Width of others' hook collision line
 == 
 
+Preview 'Hook collisions' being pressed
+== 
+
 Basic
 == 
 

--- a/data/languages/bosnian.txt
+++ b/data/languages/bosnian.txt
@@ -1801,6 +1801,9 @@ Something hookable
 A Tee
 == 
 
+Preview 'Hook collisions' being pressed
+== 
+
 Show finish messages
 == 
 

--- a/data/languages/brazilian_portuguese.txt
+++ b/data/languages/brazilian_portuguese.txt
@@ -2058,6 +2058,9 @@ Width of your own hook collision line
 Width of others' hook collision line
 == 
 
+Preview 'Hook collisions' being pressed
+== 
+
 Aim
 == 
 

--- a/data/languages/bulgarian.txt
+++ b/data/languages/bulgarian.txt
@@ -1693,6 +1693,9 @@ Something hookable
 A Tee
 == 
 
+Preview 'Hook collisions' being pressed
+== 
+
 Show kill messages
 == 
 

--- a/data/languages/catalan.txt
+++ b/data/languages/catalan.txt
@@ -1873,6 +1873,9 @@ Something hookable
 A Tee
 == 
 
+Preview 'Hook collisions' being pressed
+== 
+
 Show finish messages
 == 
 

--- a/data/languages/chuvash.txt
+++ b/data/languages/chuvash.txt
@@ -1693,6 +1693,9 @@ Something hookable
 A Tee
 == 
 
+Preview 'Hook collisions' being pressed
+== 
+
 Show kill messages
 == 
 

--- a/data/languages/czech.txt
+++ b/data/languages/czech.txt
@@ -2030,6 +2030,9 @@ Width of your own hook collision line
 Width of others' hook collision line
 == 
 
+Preview 'Hook collisions' being pressed
+== 
+
 Aim
 == 
 

--- a/data/languages/danish.txt
+++ b/data/languages/danish.txt
@@ -1860,6 +1860,9 @@ Something hookable
 A Tee
 == 
 
+Preview 'Hook collisions' being pressed
+== 
+
 Show finish messages
 == 
 

--- a/data/languages/dutch.txt
+++ b/data/languages/dutch.txt
@@ -1910,6 +1910,9 @@ Something hookable
 A Tee
 == 
 
+Preview 'Hook collisions' being pressed
+== 
+
 Show finish messages
 == 
 

--- a/data/languages/esperanto.txt
+++ b/data/languages/esperanto.txt
@@ -1724,6 +1724,9 @@ Nothing hookable
 Something hookable
 == 
 
+Preview 'Hook collisions' being pressed
+== 
+
 Show kill messages
 == 
 

--- a/data/languages/estonian.txt
+++ b/data/languages/estonian.txt
@@ -1986,6 +1986,9 @@ Width of your own hook collision line
 Width of others' hook collision line
 == 
 
+Preview 'Hook collisions' being pressed
+== 
+
 Basic
 == 
 

--- a/data/languages/finnish.txt
+++ b/data/languages/finnish.txt
@@ -1965,6 +1965,9 @@ Width of your own hook collision line
 Width of others' hook collision line
 == 
 
+Preview 'Hook collisions' being pressed
+== 
+
 Basic
 == 
 

--- a/data/languages/french.txt
+++ b/data/languages/french.txt
@@ -1995,6 +1995,9 @@ Width of your own hook collision line
 Width of others' hook collision line
 == 
 
+Preview 'Hook collisions' being pressed
+== 
+
 Basic
 == 
 

--- a/data/languages/galician.txt
+++ b/data/languages/galician.txt
@@ -1947,6 +1947,9 @@ Width of your own hook collision line
 Width of others' hook collision line
 == 
 
+Preview 'Hook collisions' being pressed
+== 
+
 Show finish messages
 == 
 

--- a/data/languages/german.txt
+++ b/data/languages/german.txt
@@ -2051,3 +2051,6 @@ Active: Fire
 
 Active: Hook
 == Aktiv: Haken
+
+Preview 'Hook collisions' being pressed
+== Vorschau für 'Hakenkollisionen' gedrückt

--- a/data/languages/greek.txt
+++ b/data/languages/greek.txt
@@ -1693,6 +1693,9 @@ Something hookable
 A Tee
 == 
 
+Preview 'Hook collisions' being pressed
+== 
+
 Show kill messages
 == 
 

--- a/data/languages/hungarian.txt
+++ b/data/languages/hungarian.txt
@@ -1952,6 +1952,9 @@ Width of your own hook collision line
 Width of others' hook collision line
 == 
 
+Preview 'Hook collisions' being pressed
+== 
+
 Show finish messages
 == 
 

--- a/data/languages/italian.txt
+++ b/data/languages/italian.txt
@@ -1936,6 +1936,9 @@ Width of others' hook collision line
 A Tee
 == 
 
+Preview 'Hook collisions' being pressed
+== 
+
 Show finish messages
 == 
 

--- a/data/languages/japanese.txt
+++ b/data/languages/japanese.txt
@@ -1868,6 +1868,9 @@ Something hookable
 A Tee
 == 
 
+Preview 'Hook collisions' being pressed
+== 
+
 Show finish messages
 == 
 

--- a/data/languages/korean.txt
+++ b/data/languages/korean.txt
@@ -1964,6 +1964,9 @@ Width of your own hook collision line
 Width of others' hook collision line
 == 
 
+Preview 'Hook collisions' being pressed
+== 
+
 Show finish messages
 == 
 

--- a/data/languages/kyrgyz.txt
+++ b/data/languages/kyrgyz.txt
@@ -1684,6 +1684,9 @@ Something hookable
 A Tee
 == 
 
+Preview 'Hook collisions' being pressed
+== 
+
 Show kill messages
 == 
 

--- a/data/languages/norwegian.txt
+++ b/data/languages/norwegian.txt
@@ -1861,6 +1861,9 @@ Something hookable
 A Tee
 == 
 
+Preview 'Hook collisions' being pressed
+== 
+
 Show finish messages
 == 
 

--- a/data/languages/persian.txt
+++ b/data/languages/persian.txt
@@ -2025,6 +2025,9 @@ Width of your own hook collision line
 Width of others' hook collision line
 == 
 
+Preview 'Hook collisions' being pressed
+== 
+
 Aim
 == 
 

--- a/data/languages/polish.txt
+++ b/data/languages/polish.txt
@@ -2032,6 +2032,9 @@ Width of your own hook collision line
 Width of others' hook collision line
 == 
 
+Preview 'Hook collisions' being pressed
+== 
+
 Aim
 == 
 

--- a/data/languages/portuguese.txt
+++ b/data/languages/portuguese.txt
@@ -1779,6 +1779,9 @@ Something hookable
 A Tee
 == 
 
+Preview 'Hook collisions' being pressed
+== 
+
 Show finish messages
 == 
 

--- a/data/languages/romanian.txt
+++ b/data/languages/romanian.txt
@@ -1699,6 +1699,9 @@ Something hookable
 A Tee
 == 
 
+Preview 'Hook collisions' being pressed
+== 
+
 Show kill messages
 == 
 

--- a/data/languages/russian.txt
+++ b/data/languages/russian.txt
@@ -2042,6 +2042,9 @@ Width of your own hook collision line
 Width of others' hook collision line
 == 
 
+Preview 'Hook collisions' being pressed
+== 
+
 Aim
 == 
 

--- a/data/languages/serbian.txt
+++ b/data/languages/serbian.txt
@@ -1959,6 +1959,9 @@ Width of your own hook collision line
 Width of others' hook collision line
 == 
 
+Preview 'Hook collisions' being pressed
+== 
+
 Show finish messages
 == 
 

--- a/data/languages/serbian_cyrillic.txt
+++ b/data/languages/serbian_cyrillic.txt
@@ -1916,6 +1916,9 @@ Width of your own hook collision line
 Width of others' hook collision line
 == 
 
+Preview 'Hook collisions' being pressed
+== 
+
 Show finish messages
 == 
 

--- a/data/languages/simplified_chinese.txt
+++ b/data/languages/simplified_chinese.txt
@@ -2071,6 +2071,9 @@ Width of your own hook collision line
 Width of others' hook collision line
 == 
 
+Preview 'Hook collisions' being pressed
+== 
+
 Aim
 == 
 

--- a/data/languages/slovak.txt
+++ b/data/languages/slovak.txt
@@ -2027,6 +2027,9 @@ Width of your own hook collision line
 Width of others' hook collision line
 == 
 
+Preview 'Hook collisions' being pressed
+== 
+
 Aim
 == 
 

--- a/data/languages/spanish.txt
+++ b/data/languages/spanish.txt
@@ -2045,6 +2045,9 @@ Width of your own hook collision line
 Width of others' hook collision line
 == 
 
+Preview 'Hook collisions' being pressed
+== 
+
 Aim
 == 
 

--- a/data/languages/swedish.txt
+++ b/data/languages/swedish.txt
@@ -2029,6 +2029,9 @@ Width of your own hook collision line
 Width of others' hook collision line
 == 
 
+Preview 'Hook collisions' being pressed
+== 
+
 Aim
 == 
 

--- a/data/languages/traditional_chinese.txt
+++ b/data/languages/traditional_chinese.txt
@@ -2060,6 +2060,9 @@ Width of your own hook collision line
 Width of others' hook collision line
 == 
 
+Preview 'Hook collisions' being pressed
+== 
+
 Aim
 == 
 

--- a/data/languages/turkish.txt
+++ b/data/languages/turkish.txt
@@ -2041,6 +2041,9 @@ Width of your own hook collision line
 Width of others' hook collision line
 == 
 
+Preview 'Hook collisions' being pressed
+== 
+
 Aim
 == 
 

--- a/data/languages/ukrainian.txt
+++ b/data/languages/ukrainian.txt
@@ -2026,6 +2026,9 @@ Width of your own hook collision line
 Width of others' hook collision line
 == 
 
+Preview 'Hook collisions' being pressed
+== 
+
 Aim
 == 
 

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -3053,7 +3053,7 @@ void CMenus::RenderSettingsAppearance(CUIRect MainView)
 
 		// ***** Preview +hookcoll pressed toggle *****
 		RightView.HSplitTop(LineSize, &Button, &RightView);
-		if(DoButton_CheckBox(&s_HookCollPressed, Localize("Preview \"Hook collisions\" being pressed"), s_HookCollPressed, &Button))
+		if(DoButton_CheckBox(&s_HookCollPressed, Localize("Preview 'Hook collisions' being pressed"), s_HookCollPressed, &Button))
 			s_HookCollPressed = !s_HookCollPressed;
 	}
 	else if(s_CurTab == APPEARANCE_TAB_INFO_MESSAGES)


### PR DESCRIPTION
Use single quotes as the localization script does not support strings containing escaped double quotes.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
