### PR TITLE
Revert self spec from the list and allow left clicking yourself

### DIFF
--- a/src/game/client/components/spectator.cpp
+++ b/src/game/client/components/spectator.cpp
@@ -123,7 +123,7 @@ void CSpectator::ConSpectatePrevious(IConsole::IResult *pResult, void *pUserData
 void CSpectator::ConSpectateClosest(IConsole::IResult *pResult, void *pUserData)
 {
 	CSpectator *pSelf = (CSpectator *)pUserData;
-	pSelf->SpectateClosest(true);
+	pSelf->SpectateClosest();
 }
 
 void CSpectator::ConMultiView(IConsole::IResult *pResult, void *pUserData)
@@ -181,7 +181,7 @@ bool CSpectator::OnInput(const IInput::CEvent &Event)
 				if(m_pClient->m_Snap.m_SpecInfo.m_SpectatorId != SPEC_FREEVIEW)
 					Spectate(SPEC_FREEVIEW);
 				else
-					SpectateClosest(Client()->State() == IClient::STATE_DEMOPLAYBACK);
+					SpectateClosest();
 				return true;
 			}
 		}
@@ -618,7 +618,7 @@ void CSpectator::Spectate(int SpectatorId)
 	Client()->SendPackMsgActive(&Msg, MSGFLAG_VITAL);
 }
 
-void CSpectator::SpectateClosest(bool AllowSelf)
+void CSpectator::SpectateClosest()
 {
 	if(!CanChangeSpectatorId())
 		return;
@@ -640,9 +640,6 @@ void CSpectator::SpectateClosest(bool AllowSelf)
 	for(int i = 0; i < MAX_CLIENTS; i++)
 	{
 		if(i == SpectatorId || !Snap.m_aCharacters[i].m_Active || !Snap.m_apPlayerInfos[i] || Snap.m_apPlayerInfos[i]->m_Team == TEAM_SPECTATORS)
-			continue;
-
-		if(!AllowSelf && i == Snap.m_LocalClientId)
 			continue;
 
 		const CNetObj_Character &MaybeClosestCharacter = Snap.m_aCharacters[i].m_Cur;

--- a/src/game/client/components/spectator.cpp
+++ b/src/game/client/components/spectator.cpp
@@ -403,9 +403,6 @@ void CSpectator::OnRender()
 		if(!m_pClient->m_Snap.m_apInfoByDDTeamName[i] || m_pClient->m_Snap.m_apInfoByDDTeamName[i]->m_Team == TEAM_SPECTATORS)
 			continue;
 
-		if(Client()->State() != IClient::STATE_DEMOPLAYBACK && m_pClient->m_Snap.m_apInfoByDDTeamName[i]->m_ClientId == m_pClient->m_Snap.m_LocalClientId)
-			continue;
-
 		++Count;
 
 		if(Count == PerLine + 1 || (Count > PerLine + 1 && (Count - 1) % PerLine == 0))

--- a/src/game/client/components/spectator.h
+++ b/src/game/client/components/spectator.h
@@ -48,7 +48,7 @@ public:
 	virtual void OnReset() override;
 
 	void Spectate(int SpectatorId);
-	void SpectateClosest(bool AllowSelf);
+	void SpectateClosest();
 
 	bool IsActive() const { return m_Active; }
 };

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -4103,9 +4103,6 @@ bool CGameClient::InitMultiView(int Team)
 		int Count = 0;
 		for(int i = 0; i < MAX_CLIENTS; i++)
 		{
-			if(Client()->State() != IClient::STATE_DEMOPLAYBACK && m_Snap.m_apPlayerInfos[i] && m_Snap.m_apPlayerInfos[i]->m_ClientId == m_Snap.m_LocalClientId)
-				continue;
-
 			vec2 PlayerPos;
 
 			// get the position of the player


### PR DESCRIPTION
> @sjrc6 :
> you don't get prediction when spectating yourself everyone is smooth
> I use it all the time when I'm the one being dragged through a freeze part and I don't need to do anything

> @Pioooooo :
> for showing im afk while watching myself

This reverts the menu changes, also 180'd on the left click to make sure it is possible to click on yourself to spectate for consistency.

As for solving the confusion problem where player accidentally triggering self-spec and wondering why they cant move camera when pausing, let's come up with other ways to do it.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
