### PR TITLE
android build: Allow specifying parallelism via BUILD_FLAGS

### DIFF
--- a/scripts/android/cmake_android.sh
+++ b/scripts/android/cmake_android.sh
@@ -3,8 +3,8 @@ set -e
 
 # $HOME must be used instead of ~ else cargo-ndk cannot find the folder
 export ANDROID_HOME=$HOME/Android/Sdk
-MAKEFLAGS=-j$(nproc)
-export MAKEFLAGS
+BUILD_FLAGS="${BUILD_FLAGS:--j$(nproc)}"
+export BUILD_FLAGS
 
 ANDROID_NDK_VERSION="$(cd "$ANDROID_HOME/ndk" && find . -maxdepth 1 | sort -n | tail -1)"
 ANDROID_NDK_VERSION="${ANDROID_NDK_VERSION:2}"
@@ -151,7 +151,9 @@ function build_for_type() {
 		-DVIDEORECORDER=OFF
 	(
 		cd "${BUILD_FOLDER}/$ANDROID_SUB_BUILD_DIR/$1" || exit 1
-		cmake --build . --target game-client
+		# We want word splitting
+		# shellcheck disable=SC2086
+		cmake --build . --target game-client $BUILD_FLAGS
 	)
 }
 


### PR DESCRIPTION
MAKEFLAGS are not used by ninja anyway.
## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
