### PR TITLE
Update Turkish & Azerbaijani translation for 18.8

### DIFF
--- a/data/languages/azerbaijani.txt
+++ b/data/languages/azerbaijani.txt
@@ -7,6 +7,7 @@
 #     Gokturk          2024-08-29 23:39:00
 #     Gokturk          2024-09-29 19:24:00
 #     Gokturk          2024-11-04 11:35:00
+#     Gokturk & seishiroon          2024-12-03 16:35:00
 ##### /authors #####
 
 ##### translated strings #####
@@ -1933,108 +1934,108 @@ Eyes
 == Göz
 
 Some fonts could not be loaded. Check the local console for details.
-== Bəzi yazı fontları yüklənə bilmir. Ətraflı məlumat üçün əsas konsolu yoxlayın
+== Bəzi yazı fontları yüklənə bilmir. Ətraflı məlumat üçün əsas konsolu yoxlayın.
 
 Online friends (%d)
-== 
+== Onlayn dostlar (%d)
 
 Add friends by entering their name below or by clicking their name in the player list.
-== 
+== Aşağıya ad yazaraq və ya oyunçu siyahısından adlarına tıklayaraq dost əlavə edin.
 
 Add clanmates by entering their clan below and leaving the name blank.
-== 
+== Klan yoldaşlarınızı klan adını aşağıya yazaraq və ad hissəsini boş buraxaraq əlavə edin.
 
 Offline friends and clanmates will appear here.
-== 
+== Oflayn dostlar və klan yoldaşları burada görünəcək.
 
 Edit touch controls
-== 
+== Toxunuş idarəetmələrini düzəlt
 
 Close
-== 
+== Bağla
 
 Save changes
-== 
+== Dəyişiklikləri yadda saxla
 
 Error saving touch controls
-== 
+== Toxunuş idarəetmələri saxlanılarkən xəta baş verdi
 
 Could not save touch controls to file. See local console for details.
-== 
+== Toxunuş idarəetmələrini fayllara yadda saxlamaq mümkün olmadı. Ətraflı məlumat üçün konsola baxın.
 
 Unsaved changes
-== 
+== Yadda saxlanılmamış dəyişikliklər
 
 Discard changes
-== 
+== Dəyişiklikləri ləğv et
 
 Are you sure that you want to discard the current changes to the touch controls?
-== 
+== Toxunuş idarəetmələrindəki dəyişiklikləri ləğv etmək istədiyinizə əminsinizmi?
 
 Are you sure that you want to reset the touch controls to default?
-== 
+== oxunuş idarəetmələrini varsayılan parametrlərə qaytarmaq istədiyinizə əminsinizmi?
 
 Import from clipboard
-== 
+== Panodan içəri idxal et
 
 Are you sure that you want to import the touch controls from the clipboard? This will overwrite your current touch controls.
-== 
+== Toxunuş idarəetmələrini panodan idxal etmək istədiyinizə əminsinizmi? Bu, mövcud idarəetmələrin üzərinə yazılacaq.
 
 Export to clipboard
-== 
+== Panoya ixrac et
 
 Direct touch input while ingame
-== 
+== Oyun içində olarkən birbaşa toxunuş girişi
 
 [Direct touch input]
 Disabled
-== 
+== Deaktiv edilib
 
 [Direct touch input]
 Active action
-== 
+== Aktiv hərəkət
 
 [Direct touch input]
 Aim
-== 
+== Aim
 
 [Direct touch input]
 Fire
-== 
+== Atəş
 
 [Direct touch input]
 Hook
-== 
+== Qarmaq
 
 Direct touch input while spectating
-== 
+== İzləmə rejimində olarkən birbaşa toxunuş girişi
 
 Error loading touch controls
-== 
+== Toxunuş idarəetmələri yüklənərkən xəta baş verdi
 
 Could not load touch controls from file. See local console for details.
-== 
+== Toxunuş idarəetmələrini fayllardan yükləmək mümkün olmadı. Ətraflı məlumat üçün konsola baxın.
 
 Could not load default touch controls from file. See local console for details.
-== 
+== Varsayılan toxunuş idarəetmələrini fayllardan yükləmək mümkün olmadı. Ətraflı məlumat üçün konsola baxın.
 
 Could not load touch controls from clipboard. See local console for details.
-== 
+== Toxunuş idarəetmələrini panodan yükləmək mümkün olmadı. Ətraflı məlumat üçün konsola baxın.
 
 Width of your own hook collision line
-== 
+== Öz qarmağınızın toqquşma xəttinin qalınlığı
 
 Width of others' hook collision line
-== 
+== Başqalarının qarmaqlarının toqquşma xəttinin qalınlığı
 
 Preview 'Hook collisions' being pressed
-== 
+== ‘Qarmaq toqquşmaları’ basılarkən önizləmə
 
 Aim
-== 
+== Aim
 
 Active: Fire
-== 
+== Aktiv: Atəş
 
 Active: Hook
-== 
+== Aktiv: Qarmaq

--- a/data/languages/turkish.txt
+++ b/data/languages/turkish.txt
@@ -20,6 +20,7 @@
 # Gokturk          2024-09-29 19:23:00
 # Gokturk          2024-09-29 19:23:00
 # Gokturk          2024-11-04 11:32:00
+# Gokturk          2024-12-03 16:00:00
 ##### /authors #####
 
 ##### translated strings #####
@@ -1871,7 +1872,7 @@ https://wiki.ddnet.org/wiki/Mapping
 == https://wiki.ddnet.org/wiki/Mapping/tr
 
 Could not resolve connect address '%s'. See local console for details.
-== '%s' Bağlantı adresi çözümlenemedi. Detaylar için yerel konsola bakın
+== '%s' bağlantı adresi çözümlenemedi. Detaylar için yerel konsola bakın.
 
 Connect address error
 == Bağlantı adresi hatası
@@ -1913,7 +1914,7 @@ Unable to save the skin
 == Skin kaydedilemiyor
 
 Unable to save the skin with a reserved name
-== Skin kaydedilemiyor, bu isimde zaten bir skin var.
+== Skin kaydedilemiyor bu isimde zaten bir skin var
 
 No local servers found (ports %d-%d)
 == Yerel sunucu bulunamadı (bağlantı noktası %d-%d)
@@ -1947,108 +1948,108 @@ Eyes
 == Göz
 
 Some fonts could not be loaded. Check the local console for details.
-== Bazı fontlar yüklenemiyor. Detaylar için ana konsolu kontrol edin
+== Bazı fontlar yüklenemiyor. Detaylar için konsolu kontrol edin.
 
 Online friends (%d)
-== 
+== Çevrim içi arkadaşlar (%d)
 
 Add friends by entering their name below or by clicking their name in the player list.
-== 
+== Aşağıya isim girerek veya oyuncu listesinden isme tıklayarak arkadaş ekle.
 
 Add clanmates by entering their clan below and leaving the name blank.
-== 
+== Klan arkadaşlarınızı klanlarını aşağıya girerek ve isimlerini boş bırakarak ekleyin.
 
 Offline friends and clanmates will appear here.
-== 
+== Çevrim dışı arkadaşlar ve klan arkadaşları burada görünecek.
 
 Edit touch controls
-== 
+== Dokunmatik ayarlarını düzelt
 
 Close
-== 
+== Kapat
 
 Save changes
-== 
+== Değişiklikleri kaydet
 
 Error saving touch controls
-== 
+== Dokunmatik ayarları kaydedilirken bir hata oldu
 
 Could not save touch controls to file. See local console for details.
-== 
+== Dokunmatik ayarları dosyalara kaydedilemedi. Detaylar için yerel konsola bakın.
 
 Unsaved changes
-== 
+== Kaydedilmemiş değişiklikler
 
 Discard changes
-== 
+== Değişiklikleri iptal et
 
 Are you sure that you want to discard the current changes to the touch controls?
-== 
+== Dokunmatik ayarlarındaki değişiklikleri iptal etmek istediğinden emin misin?
 
 Are you sure that you want to reset the touch controls to default?
-== 
+== Dokunmatik ayarlarını varsayılan ayarlarına döndürmek istediğinden emin misin?
 
 Import from clipboard
-== 
+== Panodan içeri aktar
 
 Are you sure that you want to import the touch controls from the clipboard? This will overwrite your current touch controls.
-== 
+== Dokunmatik ayarlarını panodan içeri aktarmak istediğine emin misin? Bu şu anki kontrollerin üzerine yazılacak. 
 
 Export to clipboard
-== 
+== Panodan dışarı aktar
 
 Direct touch input while ingame
-== 
+== Oyun içindeyken doğrudan dokunmatik giriş
 
 [Direct touch input]
 Disabled
-== 
+== Devre dışı
 
 [Direct touch input]
 Active action
-== 
+== Aktif aksiyon
 
 [Direct touch input]
 Aim
-== 
+== Aim
 
 [Direct touch input]
 Fire
-== 
+== Ateş
 
 [Direct touch input]
 Hook
-== 
+== Kanca
 
 Direct touch input while spectating
-== 
+== Gezinme modundayken dokunarak doğrudan giriş
 
 Error loading touch controls
-== 
+== Dokunmatik ayarları yüklenirken bir hata oluştu
 
 Could not load touch controls from file. See local console for details.
-== 
+== Dokunmatik ayarları dosyalardan yüklenemedi. Detaylar için konsola bakın.
 
 Could not load default touch controls from file. See local console for details.
-== 
+== Varsayılan dokunmatik ayarları dosyalardan yüklenemedi. Detaylar için konsola bakın.
 
 Could not load touch controls from clipboard. See local console for details.
-== 
+== Dokunmatik ayarları panodan yüklenemedi. Detaylar için konsola bakın.
 
 Width of your own hook collision line
-== 
+== Kendi kancanın çarpışma çizgisi kalınlığı 
 
 Width of others' hook collision line
-== 
+== Başkalarının kancalarının çarpışma çizgisi kalınlığı
 
 Preview 'Hook collisions' being pressed
-== 
+== Önizleme 'Kanca çarpışmaları' gösteriliyor
 
 Aim
-== 
+== Aim
 
 Active: Fire
-== 
+== Aktif: Ateş etme
 
 Active: Hook
-== 
+== Aktif: Kanca


### PR DESCRIPTION
As a Turkish localization "aim" can be "hedef" but it might get out of its meaning and be confusing for players so it is left as "aim". I'm waiting for a friend's check for Azerbaijani translation, I'll edit it and send it after he returns.