### PR TITLE
Add cl_enable_self_spectate

### DIFF
--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -105,6 +105,7 @@ MACRO_CONFIG_INT(ClMultiViewZoomSmoothness, cl_multiview_zoom_smoothness, 1300, 
 
 MACRO_CONFIG_INT(ClSpectatorMouseclicks, cl_spectator_mouseclicks, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Enables left-click to toggle between spectating the closest player and free-view")
 MACRO_CONFIG_INT(ClSmoothSpectatingTime, cl_smooth_spectating_time, 300, 0, 5000, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Time of smooth camera switch animation when spectating in ms (0 for off)")
+MACRO_CONFIG_INT(ClEnableSelfSpectate, cl_enable_self_spectate, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Enables self spectating in game")
 
 MACRO_CONFIG_INT(EdAutosaveInterval, ed_autosave_interval, 10, 0, 240, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Interval in minutes at which a copy of the current editor map is automatically saved to the 'auto' folder (0 for off)")
 MACRO_CONFIG_INT(EdAutosaveMax, ed_autosave_max, 10, 0, 1000, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Maximum number of autosaves that are kept per map name (0 = no limit)")

--- a/src/game/client/components/spectator.cpp
+++ b/src/game/client/components/spectator.cpp
@@ -403,6 +403,11 @@ void CSpectator::OnRender()
 		if(!m_pClient->m_Snap.m_apInfoByDDTeamName[i] || m_pClient->m_Snap.m_apInfoByDDTeamName[i]->m_Team == TEAM_SPECTATORS)
 			continue;
 
+		// always show self when multiview is enabled
+		bool ExcludeSelf = !m_pClient->m_MultiViewActivated && !g_Config.m_ClEnableSelfSpectate;
+		if(ExcludeSelf && m_pClient->m_Snap.m_apInfoByDDTeamName[i]->m_ClientId == m_pClient->m_Snap.m_LocalClientId)
+			continue;
+
 		++Count;
 
 		if(Count == PerLine + 1 || (Count > PerLine + 1 && (Count - 1) % PerLine == 0))
@@ -422,6 +427,9 @@ void CSpectator::OnRender()
 			if(!pInfo2 || pInfo2->m_Team == TEAM_SPECTATORS)
 				continue;
 
+			if(ExcludeSelf && pInfo2->m_ClientId == m_pClient->m_Snap.m_LocalClientId)
+				continue;
+
 			NextDDTeam = m_pClient->m_Teams.Team(pInfo2->m_ClientId);
 			break;
 		}
@@ -433,6 +441,9 @@ void CSpectator::OnRender()
 				const CNetObj_PlayerInfo *pInfo2 = m_pClient->m_Snap.m_apInfoByDDTeamName[j];
 
 				if(!pInfo2 || pInfo2->m_Team == TEAM_SPECTATORS)
+					continue;
+
+				if(ExcludeSelf && pInfo2->m_ClientId == m_pClient->m_Snap.m_LocalClientId)
 					continue;
 
 				OldDDTeam = m_pClient->m_Teams.Team(pInfo2->m_ClientId);
@@ -640,6 +651,9 @@ void CSpectator::SpectateClosest()
 	for(int i = 0; i < MAX_CLIENTS; i++)
 	{
 		if(i == SpectatorId || !Snap.m_aCharacters[i].m_Active || !Snap.m_apPlayerInfos[i] || Snap.m_apPlayerInfos[i]->m_Team == TEAM_SPECTATORS)
+			continue;
+
+		if(!g_Config.m_ClEnableSelfSpectate && i == Snap.m_LocalClientId)
 			continue;
 
 		const CNetObj_Character &MaybeClosestCharacter = Snap.m_aCharacters[i].m_Cur;


### PR DESCRIPTION
Added `cl_enable_self_spectate` config defaulting to off.

Again, I strongly believe in behavioral consistency, so I argue against different behaviors between left clicking and menu selector.

From what have been discussed on discord:
* People arguing FOR self spec prefer staying with the old behavior of using menu, they can turn it on.
* People arguing AGAINST self left clicking to avoid confusion, I believe, does not care for menu spec being removed for new players to avoid confusion too.

Pick your poison.

Multi-View now shows yourself always in menu as long as it is turned on.

## Checklist

- [x] Tested the change ingame
- [] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
