### PR TITLE
Don't allow SpectateClosest / left-clicking to select self

### DIFF
--- a/src/game/client/components/spectator.cpp
+++ b/src/game/client/components/spectator.cpp
@@ -642,6 +642,9 @@ void CSpectator::SpectateClosest()
 		if(i == SpectatorId || !Snap.m_aCharacters[i].m_Active || !Snap.m_apPlayerInfos[i] || Snap.m_apPlayerInfos[i]->m_Team == TEAM_SPECTATORS)
 			continue;
 
+		if(Client()->State() != IClient::STATE_DEMOPLAYBACK && i == Snap.m_LocalClientId)
+			continue;
+
 		const CNetObj_Character &MaybeClosestCharacter = Snap.m_aCharacters[i].m_Cur;
 		int Distance = distance(CurPosition, vec2(MaybeClosestCharacter.m_X, MaybeClosestCharacter.m_Y));
 		if(NewSpectatorId == -1 || Distance < ClosestDistance)


### PR DESCRIPTION
This reverts spec behavior to how it was pre 18.8 in game. We should keep this in 18.8 while exploring other ways to avoid player confusion before we fully commit to a consistent spec behavior.

So the player confusion issue is still unsolved after a round of changes.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
