### PR TITLE
Mitigate self spectating confusion problem

### DIFF
--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -359,6 +359,8 @@ void CControls::OnRender()
 	{
 		m_aTargetPos[g_Config.m_ClDummy] = m_aMousePos[g_Config.m_ClDummy];
 	}
+
+	m_MouseOvershoot += (-m_MouseOvershoot) * (1 - exp(-10.0f * Client()->RenderFrameTime()));
 }
 
 bool CControls::OnCursorMove(float x, float y, IInput::ECursorType CursorType)
@@ -406,6 +408,7 @@ bool CControls::OnCursorMove(float x, float y, IInput::ECursorType CursorType)
 
 void CControls::ClampMousePos()
 {
+	const vec2 MousePos = m_aMousePos[g_Config.m_ClDummy];
 	if(m_pClient->m_Snap.m_SpecInfo.m_Active && m_pClient->m_Snap.m_SpecInfo.m_SpectatorId < 0)
 	{
 		m_aMousePos[g_Config.m_ClDummy].x = clamp(m_aMousePos[g_Config.m_ClDummy].x, -201.0f * 32, (Collision()->GetWidth() + 201.0f) * 32.0f);
@@ -429,6 +432,8 @@ void CControls::ClampMousePos()
 		if(MouseDistance > MouseMax)
 			m_aMousePos[g_Config.m_ClDummy] = normalize_pre_length(m_aMousePos[g_Config.m_ClDummy], MouseDistance) * MouseMax;
 	}
+
+	m_MouseOvershoot += m_aMousePos[g_Config.m_ClDummy] - MousePos;
 }
 
 float CControls::GetMinMouseDistance() const

--- a/src/game/client/components/controls.h
+++ b/src/game/client/components/controls.h
@@ -20,6 +20,8 @@ public:
 	vec2 m_aMousePosOnAction[NUM_DUMMIES];
 	vec2 m_aTargetPos[NUM_DUMMIES];
 
+	vec2 m_MouseOvershoot;
+
 	int m_aAmmoCount[NUM_WEAPONS];
 
 	int64_t m_LastSendTime;

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -1427,6 +1427,32 @@ void CHud::RenderSpectatorHud()
 		str_copy(aBuf, Localize("Free-View"));
 	}
 	TextRender()->Text(m_Width - 174.0f, m_Height - 15.0f + (15.f - 8.f) / 2.f, 8.0f, aBuf, -1.0f);
+
+	// draw overshoot indicator
+	vec2 Overshoot = GameClient()->m_Controls.m_MouseOvershoot;
+	float Length = length(GameClient()->m_Controls.m_MouseOvershoot);
+	if(Length > 1.0f)
+	{
+		m_OvershootIndicatorActivatedTime = Client()->LocalTime();
+	}
+
+	const float IndicatorDuration = 2.0f;
+	const float IndicatorTime = Client()->LocalTime() - m_OvershootIndicatorActivatedTime;
+	if(IndicatorTime < IndicatorDuration)
+	{
+		float Shake = mix(sin(Client()->LocalTime() * pi * 20.0f) * 2.5f, 0.0f, clamp(IndicatorTime, 0.0f, 0.5f) / 0.5f);
+		Overshoot = normalize_pre_length(Overshoot, Length) * clamp(Length / 10.0f, -5.0f, 5.0f);
+
+		Graphics()->TextureClear();
+		Graphics()->QuadsBegin();
+		Graphics()->SetColor(0.0f, 0.0f, 0.0f, 0.4f);
+		Graphics()->DrawCircle(m_Width - 200.0f + Shake, m_Height - 7.5f, 7.5f, 32);
+
+		// todo: add icon and tune the design
+		Graphics()->SetColor(1.0f, 0.0f, 0.0f, 1.0f);
+		Graphics()->DrawCircle(m_Width - 200.0f - Overshoot.x + Shake, m_Height - 7.5f - Overshoot.y, 5.0f, 32);
+		Graphics()->QuadsEnd();
+	}
 }
 
 void CHud::RenderSpectatorModeEffect()
@@ -1605,6 +1631,7 @@ void CHud::OnRender()
 			}
 			RenderMovementInformation(m_pClient->m_Snap.m_LocalClientId);
 			RenderDDRaceEffects();
+			m_OvershootIndicatorActivatedTime = -INFINITY;
 		}
 		else if(m_pClient->m_Snap.m_SpecInfo.m_Active)
 		{
@@ -1626,6 +1653,10 @@ void CHud::OnRender()
 				RenderMovementInformation(SpectatorId);
 			}
 			RenderSpectatorHud();
+		}
+		else
+		{
+			m_OvershootIndicatorActivatedTime = -INFINITY;
 		}
 		RenderSpectatorModeEffect();
 

--- a/src/game/client/components/hud.h
+++ b/src/game/client/components/hud.h
@@ -90,6 +90,7 @@ class CHud : public CComponent
 	int m_LastLocalClientId = -1;
 
 	void RenderSpectatorHud();
+	void RenderSpectatorModeEffect();
 	void RenderWarmupTimer();
 	void RenderLocalTime(float x);
 
@@ -158,6 +159,12 @@ private:
 	int m_PracticeModeOffset;
 	int m_Team0ModeOffset;
 	int m_LockModeOffset;
+
+	bool m_LastSpectatingPlayer;
+	bool m_LastFreeView;
+	float m_SpectatingPlayerTime;
+	float m_FreeViewTime;
+	ColorRGBA m_SpectatorModeEffectColor;
 };
 
 #endif

--- a/src/game/client/components/hud.h
+++ b/src/game/client/components/hud.h
@@ -165,6 +165,8 @@ private:
 	float m_SpectatingPlayerTime;
 	float m_FreeViewTime;
 	ColorRGBA m_SpectatorModeEffectColor;
+
+	float m_OvershootIndicatorActivatedTime;
 };
 
 #endif

--- a/src/game/client/components/spectator.h
+++ b/src/game/client/components/spectator.h
@@ -19,6 +19,7 @@ class CSpectator : public CComponent
 	bool m_Active;
 	bool m_WasActive;
 
+	int m_LastViewedClientId;
 	int m_SelectedSpectatorId;
 	vec2 m_SelectorMouse;
 


### PR DESCRIPTION
This is a showcase of different ways we can avoid self spectating confusions while still allowing self spectating options to be readily available. More approaches will be experimented here as they come up.

Check commits for different approaches.

Note that with all approaches combined this can very obnoxious, ideally only the most effective solution will be accepted, but since it is all visual and control changes, it will be very hard to get a feel for it unless you try it yourself so I'm doing **rough** implementations (meaning none of the commit are fully tuned and finished) here just to showcase.

Current demo:

https://github.com/user-attachments/assets/a2c93ce2-b630-4ec3-a713-131c6245a36a

## Checklist

- [ ] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
