### PR TITLE
Reset color in RenderLoading

### DIFF
--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -86,6 +86,8 @@ void CHud::OnInit()
 {
 	OnReset();
 
+	Graphics()->SetColor(1.0, 1.0, 1.0, 1.0);
+
 	m_HudQuadContainerIndex = Graphics()->CreateQuadContainer(false);
 	Graphics()->QuadsSetSubset(0, 0, 1, 1);
 	PrepareAmmoHealthAndArmorQuads();

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -806,6 +806,8 @@ void CMenus::RenderLoading(const char *pCaption, const char *pContent, int Incre
 		Ui()->RenderProgressBar(ProgressBar, CurLoadRenderCount / (float)m_LoadingState.m_Total);
 	}
 
+	Graphics()->SetColor(1.0, 1.0, 1.0, 1.0);
+
 	Client()->UpdateAndSwap();
 }
 


### PR DESCRIPTION
Trying to fix a color bug during initialization for MilkeeyCat

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
