### PR TITLE
Add double quote support in twlang.py

### DIFF
--- a/scripts/languages/twlang.py
+++ b/scripts/languages/twlang.py
@@ -54,7 +54,7 @@ def decode(fileobj, elements_per_key):
 
 def check_file(path):
 	with open(path, encoding="utf-8") as fileobj:
-		matches = re.findall(r"(Localize|Localizable)\s*\(\s*\"([^\"]+)\"(?:\s*,\s*\"([^\"]+)\")?\s*\)", fileobj.read())
+		matches = re.findall(r"(Localize|Localizable)\s*\(\s*\"((?:(?:\\\")|[^\"])+)\"(?:\s*,\s*\"((?:(?:\\\")|[^\"])+)\")?\s*\)", fileobj.read())
 	return matches
 
 
@@ -66,7 +66,8 @@ def check_folder(path):
 			if not any(f.endswith(x) for x in [".cpp", ".c", ".h"]):
 				continue
 			for sentence in check_file(os.path.join(path2, f)):
-				englishlist[sentence[1:]] = None
+				key = (sentence[1:][0].replace("\\\"", "\""), sentence[1:][1].replace("\\\"", "\""))
+				englishlist[key] = None
 	return englishlist
 
 


### PR DESCRIPTION
submitted as draft because i'm under the impression that we either prefers to use single quote to make it work or this script shouldn't be touched. if that's not the case then tell me to undraft.

also found a missing line in `graphics_threaded.cpp` that is using double quotes.

test cases:
https://regex101.com/r/c3IWM0/1

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
