### PR TITLE
Make client/graphics warnings thread-safe, improve log format

### DIFF
--- a/src/engine/client.h
+++ b/src/engine/client.h
@@ -8,15 +8,15 @@
 #include "message.h"
 #include <base/hash.h>
 
+#include <engine/client/enums.h>
+#include <engine/friends.h>
 #include <engine/shared/translation_context.h>
 
 #include <game/generated/protocol.h>
 #include <game/generated/protocol7.h>
 
-#include <engine/friends.h>
 #include <functional>
-
-#include <engine/client/enums.h>
+#include <optional>
 
 struct SWarning;
 
@@ -300,7 +300,7 @@ public:
 	virtual void GetSmoothTick(int *pSmoothTick, float *pSmoothIntraTick, float MixAmount) = 0;
 
 	virtual void AddWarning(const SWarning &Warning) = 0;
-	virtual SWarning *GetCurWarning() = 0;
+	virtual std::optional<SWarning> CurrentWarning() = 0;
 
 	virtual CChecksumData *ChecksumData() = 0;
 	virtual int UdpConnectivity(int NetType) = 0;

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -2651,7 +2651,7 @@ void CClient::Update()
 			{
 				SWarning Warning(Localize("Error playing demo"), m_DemoPlayer.ErrorMessage());
 				Warning.m_AutoHide = false;
-				m_vWarnings.emplace_back(Warning);
+				AddWarning(Warning);
 			}
 		}
 	}
@@ -3085,7 +3085,7 @@ void CClient::Run()
 	{
 		SWarning Warning(Localize("Sound error"), Localize("The audio device couldn't be initialised."));
 		Warning.m_AutoHide = false;
-		m_vWarnings.emplace_back(Warning);
+		AddWarning(Warning);
 	}
 
 	bool LastD = false;
@@ -5014,23 +5014,22 @@ void CClient::GetSmoothTick(int *pSmoothTick, float *pSmoothIntraTick, float Mix
 
 void CClient::AddWarning(const SWarning &Warning)
 {
+	const std::unique_lock<std::mutex> Lock(m_WarningsMutex);
 	m_vWarnings.emplace_back(Warning);
 }
 
-SWarning *CClient::GetCurWarning()
+std::optional<SWarning> CClient::CurrentWarning()
 {
+	const std::unique_lock<std::mutex> Lock(m_WarningsMutex);
 	if(m_vWarnings.empty())
 	{
-		return NULL;
-	}
-	else if(m_vWarnings[0].m_WasShown)
-	{
-		m_vWarnings.erase(m_vWarnings.begin());
-		return NULL;
+		return std::nullopt;
 	}
 	else
 	{
-		return m_vWarnings.data();
+		std::optional<SWarning> Result = std::make_optional(m_vWarnings[0]);
+		m_vWarnings.erase(m_vWarnings.begin());
+		return Result;
 	}
 }
 

--- a/src/engine/client/client.h
+++ b/src/engine/client/client.h
@@ -5,6 +5,7 @@
 
 #include <deque>
 #include <memory>
+#include <mutex>
 
 #include <base/hash.h>
 
@@ -235,6 +236,7 @@ class CClient : public IClient, public CDemoPlayer::IListener
 		int m_State = STATE_INIT;
 	} m_VersionInfo;
 
+	std::mutex m_WarningsMutex;
 	std::vector<SWarning> m_vWarnings;
 	std::vector<SWarning> m_vQuittingWarnings;
 
@@ -508,7 +510,7 @@ public:
 	void GetSmoothTick(int *pSmoothTick, float *pSmoothIntraTick, float MixAmount) override;
 
 	void AddWarning(const SWarning &Warning) override;
-	SWarning *GetCurWarning() override;
+	std::optional<SWarning> CurrentWarning() override;
 	std::vector<SWarning> &&QuittingWarnings() { return std::move(m_vQuittingWarnings); }
 
 	CChecksumData *ChecksumData() override { return &m_Checksum.m_Data; }

--- a/src/engine/client/graphics_threaded.h
+++ b/src/engine/client/graphics_threaded.h
@@ -2,10 +2,13 @@
 #define ENGINE_CLIENT_GRAPHICS_THREADED_H
 
 #include <base/system.h>
+
 #include <engine/graphics.h>
 #include <engine/shared/config.h>
 
+#include <atomic>
 #include <cstddef>
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -798,8 +801,9 @@ class CGraphics_Threaded : public IEngineGraphics
 	size_t m_FirstFreeTexture;
 	int m_TextureMemoryUsage;
 
-	bool m_WarnPngliteIncompatibleImages = false;
+	std::atomic<bool> m_WarnPngliteIncompatibleImages = false;
 
+	std::mutex m_WarningsMutex;
 	std::vector<SWarning> m_vWarnings;
 
 	// is a non full windowed (in a sense that the viewport won't include the whole window),
@@ -945,6 +949,7 @@ public:
 	IGraphics::CTextureHandle FindFreeTextureIndex();
 	void FreeTextureIndex(CTextureHandle *pIndex);
 	void UnloadTexture(IGraphics::CTextureHandle *pIndex) override;
+	void LoadTextureAddWarning(size_t Width, size_t Height, int Flags, const char *pTexName);
 	IGraphics::CTextureHandle LoadTextureRaw(const CImageInfo &Image, int Flags, const char *pTexName = nullptr) override;
 	IGraphics::CTextureHandle LoadTextureRawMove(CImageInfo &Image, int Flags, const char *pTexName = nullptr) override;
 
@@ -1240,7 +1245,9 @@ public:
 	bool IsIdle() const override;
 	void WaitForIdle() override;
 
-	SWarning *GetCurWarning() override;
+	void AddWarning(const SWarning &Warning);
+	std::optional<SWarning> CurrentWarning() override;
+
 	bool ShowMessageBox(unsigned Type, const char *pTitle, const char *pMsg) override;
 	bool IsBackendInitialized() override;
 

--- a/src/engine/client/warning.cpp
+++ b/src/engine/client/warning.cpp
@@ -2,12 +2,28 @@
 
 #include <base/system.h>
 
+SWarning::SWarning(const SWarning &Other)
+{
+	str_copy(m_aWarningTitle, Other.m_aWarningTitle);
+	str_copy(m_aWarningMsg, Other.m_aWarningMsg);
+	m_AutoHide = Other.m_AutoHide;
+}
+
 SWarning::SWarning(const char *pMsg)
 {
 	str_copy(m_aWarningMsg, pMsg);
 }
+
 SWarning::SWarning(const char *pTitle, const char *pMsg)
 {
 	str_copy(m_aWarningTitle, pTitle);
 	str_copy(m_aWarningMsg, pMsg);
+}
+
+SWarning &SWarning::operator=(const SWarning &Other)
+{
+	str_copy(m_aWarningTitle, Other.m_aWarningTitle);
+	str_copy(m_aWarningMsg, Other.m_aWarningMsg);
+	m_AutoHide = Other.m_AutoHide;
+	return *this;
 }

--- a/src/engine/graphics.h
+++ b/src/engine/graphics.h
@@ -13,6 +13,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <functional>
+#include <optional>
 #include <vector>
 
 #define GRAPHICS_TYPE_UNSIGNED_BYTE 0x1401
@@ -467,7 +468,7 @@ public:
 	// this function always returns the pixels in RGB
 	virtual TGLBackendReadPresentedImageData &GetReadPresentedImageDataFuncUnsafe() = 0;
 
-	virtual SWarning *GetCurWarning() = 0;
+	virtual std::optional<SWarning> CurrentWarning() = 0;
 
 	// returns true if the error msg was shown
 	virtual bool ShowMessageBox(unsigned Type, const char *pTitle, const char *pMsg) = 0;

--- a/src/engine/warning.h
+++ b/src/engine/warning.h
@@ -4,12 +4,14 @@
 struct SWarning
 {
 	SWarning() = default;
+	SWarning(const SWarning &Other);
 	SWarning(const char *pMsg);
 	SWarning(const char *pTitle, const char *pMsg);
 
+	SWarning &operator=(const SWarning &Other);
+
 	char m_aWarningTitle[128] = "";
 	char m_aWarningMsg[256] = "";
-	bool m_WasShown = false;
 	bool m_AutoHide = true;
 };
 

--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -6,6 +6,7 @@
 #include <cmath>
 #include <vector>
 
+#include <base/log.h>
 #include <base/math.h>
 #include <base/system.h>
 #include <base/vmath.h>
@@ -988,10 +989,11 @@ void CMenus::PopupWarning(const char *pTopic, const char *pBody, const char *pBu
 	// no multiline support for console
 	std::string BodyStr = pBody;
 	while(BodyStr.find('\n') != std::string::npos)
+	{
 		BodyStr.replace(BodyStr.find('\n'), 1, " ");
-	dbg_msg(pTopic, "%s", BodyStr.c_str());
+	}
+	log_warn("client", "%s: %s", pTopic, BodyStr.c_str());
 
-	// reset active item
 	Ui()->SetActiveItem(nullptr);
 
 	str_copy(m_aMessageTopic, pTopic);

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -772,13 +772,18 @@ void CGameClient::OnRender()
 	// update the local character and spectate position
 	UpdatePositions();
 
-	// display gfx & client warnings
-	for(SWarning *pWarning : {Graphics()->GetCurWarning(), Client()->GetCurWarning()})
+	// display warnings
+	if(m_Menus.CanDisplayWarning())
 	{
-		if(pWarning != nullptr && m_Menus.CanDisplayWarning())
+		std::optional<SWarning> Warning = Graphics()->CurrentWarning();
+		if(!Warning.has_value())
 		{
-			m_Menus.PopupWarning(pWarning->m_aWarningTitle[0] == '\0' ? Localize("Warning") : pWarning->m_aWarningTitle, pWarning->m_aWarningMsg, Localize("Ok"), pWarning->m_AutoHide ? 10s : 0s);
-			pWarning->m_WasShown = true;
+			Warning = Client()->CurrentWarning();
+		}
+		if(Warning.has_value())
+		{
+			const SWarning TheWarning = Warning.value();
+			m_Menus.PopupWarning(TheWarning.m_aWarningTitle[0] == '\0' ? Localize("Warning") : TheWarning.m_aWarningTitle, TheWarning.m_aWarningMsg, Localize("Ok"), TheWarning.m_AutoHide ? 10s : 0s);
 		}
 	}
 


### PR DESCRIPTION
Add mutex for client/graphics warnings. Return an optional copy of the current warning and remove it from the vector immediately instead of returning a pointer to it and removing it later.

Use atomic for `m_WarnPngliteIncompatibleImages` as this variable is also used in multiple threads.

Do not use `CLock` as the thread-safety annotations would otherwise have to be added to a lot of client/graphics functions.

Use `client` instead of the warning title as the log system, as the warning title is usually too long.

Closes #9354.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
