### PR TITLE
Fix stack-overflow in `demo_extract_chat` tool

### DIFF
--- a/src/tools/demo_extract_chat.cpp
+++ b/src/tools/demo_extract_chat.cpp
@@ -9,6 +9,8 @@
 
 #include <game/gamecore.h>
 
+#include <memory>
+
 static const char *TOOL_NAME = "demo_extract_chat";
 
 class CClientSnapshotHandler
@@ -195,8 +197,8 @@ public:
 
 static int ExtractDemoChat(const char *pDemoFilePath, IStorage *pStorage)
 {
-	CSnapshotDelta DemoSnapshotDelta;
-	CDemoPlayer DemoPlayer(&DemoSnapshotDelta, false);
+	std::unique_ptr<CSnapshotDelta> pDemoSnapshotDelta = std::make_unique<CSnapshotDelta>();
+	CDemoPlayer DemoPlayer(pDemoSnapshotDelta.get(), false);
 
 	if(DemoPlayer.Load(pStorage, nullptr, pDemoFilePath, IStorage::TYPE_ALL_OR_ABSOLUTE) == -1)
 	{


### PR DESCRIPTION
Don't store `CSnapshotDelta` object on the stack, as it's currently 524560 bytes large.

See #9234, which almost doubled the size of `CSnapshotDelta` due to the type being changed from `int` to `uint64_t`.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
