### PR TITLE
Implementation note for dilate: Unused sum&counter

### DIFF
--- a/src/engine/gfx/image_manipulation.cpp
+++ b/src/engine/gfx/image_manipulation.cpp
@@ -101,6 +101,10 @@ static void Dilate(int w, int h, const uint8_t *pSrc, uint8_t *pDest)
 			if(pSrc[m + DILATE_BPP - 1] > DILATE_ALPHA_THRESHOLD)
 				continue;
 
+			// --- Implementation Note ---
+			// The sum and counter variable can be used to compute a smoother dilated image.
+			// In this reference implementation, the loop breaks as soon as Counter == 1.
+			// We break the loop here to match the selection of the previously used algorithm.
 			int aSumOfOpaque[] = {0, 0, 0};
 			int Counter = 0;
 			for(int c = 0; c < 4; c++)


### PR DESCRIPTION
The code is confusing, as the sum and counter are not used. Establishing a different dilate algorithm would be a hassle. The difference is minor and probably not noticeable.

<!-- What is the motivation for the changes of this pull request? -->

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist
- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
