### PR TITLE
Fix server handling when vote creator leaves

### DIFF
--- a/src/game/server/score.cpp
+++ b/src/game/server/score.cpp
@@ -264,7 +264,7 @@ void CScore::RandomMap(int ClientId, int Stars)
 	Tmp->m_Stars = Stars;
 	str_copy(Tmp->m_aCurrentMap, Server()->GetMapName(), sizeof(Tmp->m_aCurrentMap));
 	str_copy(Tmp->m_aServerType, g_Config.m_SvServerType, sizeof(Tmp->m_aServerType));
-	str_copy(Tmp->m_aRequestingPlayer, GameServer()->Server()->ClientName(ClientId), sizeof(Tmp->m_aRequestingPlayer));
+	str_copy(Tmp->m_aRequestingPlayer, ClientId == -1 ? "nameless tee" : GameServer()->Server()->ClientName(ClientId), sizeof(Tmp->m_aRequestingPlayer));
 
 	m_pPool->Execute(CScoreWorker::RandomMap, std::move(Tmp), "random map");
 }
@@ -278,7 +278,7 @@ void CScore::RandomUnfinishedMap(int ClientId, int Stars)
 	Tmp->m_Stars = Stars;
 	str_copy(Tmp->m_aCurrentMap, Server()->GetMapName(), sizeof(Tmp->m_aCurrentMap));
 	str_copy(Tmp->m_aServerType, g_Config.m_SvServerType, sizeof(Tmp->m_aServerType));
-	str_copy(Tmp->m_aRequestingPlayer, GameServer()->Server()->ClientName(ClientId), sizeof(Tmp->m_aRequestingPlayer));
+	str_copy(Tmp->m_aRequestingPlayer, ClientId == -1 ? "nameless tee" : GameServer()->Server()->ClientName(ClientId), sizeof(Tmp->m_aRequestingPlayer));
 
 	m_pPool->Execute(CScoreWorker::RandomUnfinishedMap, std::move(Tmp), "random unfinished map");
 }


### PR DESCRIPTION
Reset the vote creator client ID `CGameContext::m_VoteCreator` to `-1` when the player that started the vote leaves instead of keeping the invalid client ID around. Previously, this was causing the server to crash due an assertion in the `IServer::GetAuthedState` function when a ban vote was aborted due to rcon authentication change being handled in the `CGameContext::OnSetAuthed` function after the vote creator has already left the server. It was possible to cause this situation as the target of a vote by executing `rcon_auth "<password>"; rcon "kick <vote creator>"; rcon "logout"` (`ban` works for the same effect). This also caused existing votes to use the wrong vote creator if the same client ID was reused by a new client while a vote from a client that left is still running.

Ban votes are now only aborted in the `CGameContext::OnSetAuthed` function when 1) a vote is actually active (this was previously not checked), 2) a client logged in (previously logout was also affected), and 3) the vote creator is unset or has a lower authentication level than the player logging in (previously used invalid vote creator).

In particular also improve the handling for the `random_map` and `random_unfinished_map` commands when the vote creator leaves. Use the name `nameless tee` instead of `(invalid)` (returned by `IServer::ClientName`) as the requesting player name in queries. Handle the requesting player not being set when sending the result message. Avoid overriding the `m_VoteCreator` value in the callback of the `random_unfinished_map` command, which is not necessary and would cause incorrect vote behavior when the command is used while a vote is active.

Also ensure that the voting state is initialized properly on server start.

Closes #9374.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
