### PR TITLE
Improve entities/menu background map loading

### DIFF
--- a/src/game/client/components/background.cpp
+++ b/src/game/client/components/background.cpp
@@ -8,6 +8,7 @@
 
 #include <game/client/gameclient.h>
 #include <game/layers.h>
+#include <game/localization.h>
 
 #include "background.h"
 
@@ -31,6 +32,11 @@ CBackground::~CBackground()
 CBackgroundEngineMap *CBackground::CreateBGMap()
 {
 	return new CBackgroundEngineMap;
+}
+
+const char *CBackground::LoadingTitle() const
+{
+	return Localize("Loading background map");
 }
 
 void CBackground::OnInit()

--- a/src/game/client/components/background.h
+++ b/src/game/client/components/background.h
@@ -32,6 +32,8 @@ protected:
 
 	virtual CBackgroundEngineMap *CreateBGMap();
 
+	const char *LoadingTitle() const override;
+
 public:
 	CBackground(int MapType = CMapLayers::TYPE_BACKGROUND_FORCE, bool OnlineOnly = true);
 	virtual ~CBackground();

--- a/src/game/client/components/maplayers.cpp
+++ b/src/game/client/components/maplayers.cpp
@@ -41,6 +41,11 @@ CCamera *CMapLayers::GetCurCamera()
 	return &m_pClient->m_Camera;
 }
 
+const char *CMapLayers::LoadingTitle() const
+{
+	return GameClient()->DemoPlayer()->IsPlaying() ? Localize("Preparing demo playback") : Localize("Connected");
+}
+
 void CMapLayers::EnvelopeEval(int TimeOffsetMillis, int Env, ColorRGBA &Result, size_t Channels, void *pUser)
 {
 	CMapLayers *pThis = (CMapLayers *)pUser;
@@ -276,15 +281,10 @@ void CMapLayers::OnMapLoad()
 	if(!Graphics()->IsTileBufferingEnabled() && !Graphics()->IsQuadBufferingEnabled())
 		return;
 
-	const char *pConnectCaption = GameClient()->DemoPlayer()->IsPlaying() ? Localize("Preparing demo playback") : Localize("Connected");
-	const char *pLoadMapContent = Localize("Uploading map data to GPU");
-
-	auto CurTime = time_get_nanoseconds();
+	const char *pLoadingTitle = LoadingTitle();
+	const char *pLoadingMessage = Localize("Uploading map data to GPU");
 	auto &&RenderLoading = [&]() {
-		if(CanRenderMenuBackground())
-			GameClient()->m_Menus.RenderLoading(pConnectCaption, pLoadMapContent, 0, false);
-		else if(time_get_nanoseconds() - CurTime > 500ms)
-			GameClient()->m_Menus.RenderLoading(pConnectCaption, pLoadMapContent, 0, false, false);
+		GameClient()->m_Menus.RenderLoading(pLoadingTitle, pLoadingMessage, 0);
 	};
 
 	//clear everything and destroy all buffers

--- a/src/game/client/components/maplayers.h
+++ b/src/game/client/components/maplayers.h
@@ -126,11 +126,9 @@ class CMapLayers : public CComponent
 	std::vector<SQuadLayerVisuals *> m_vpQuadLayerVisuals;
 
 	virtual CCamera *GetCurCamera();
+	virtual const char *LoadingTitle() const;
 
 	void LayersOfGroupCount(CMapItemGroup *pGroup, int &TileLayerCount, int &QuadLayerCount, bool &PassedGameLayer);
-
-protected:
-	virtual bool CanRenderMenuBackground() { return true; }
 
 public:
 	enum

--- a/src/game/client/components/menu_background.cpp
+++ b/src/game/client/components/menu_background.cpp
@@ -66,6 +66,7 @@ CMenuBackground::CMenuBackground() :
 	m_MoveTime = 0.0f;
 
 	m_IsInit = false;
+	m_Loading = false;
 }
 
 CBackgroundEngineMap *CMenuBackground::CreateBGMap()
@@ -159,7 +160,7 @@ int CMenuBackground::ThemeScan(const char *pName, int IsDir, int DirType, void *
 
 	if(time_get_nanoseconds() - pSelf->m_ThemeScanStartTime > 500ms)
 	{
-		pSelf->GameClient()->m_Menus.RenderLoading(Localize("Loading menu themes"), "", 0, false);
+		pSelf->GameClient()->m_Menus.RenderLoading(Localize("Loading menu themes"), "", 0);
 	}
 	return 0;
 }
@@ -183,6 +184,8 @@ void CMenuBackground::LoadMenuBackground(bool HasDayHint, bool HasNightHint)
 
 	if(g_Config.m_ClMenuMap[0] != '\0')
 	{
+		m_Loading = true;
+
 		const char *pMenuMap = g_Config.m_ClMenuMap;
 		if(str_comp(pMenuMap, "auto") == 0)
 		{
@@ -287,6 +290,7 @@ void CMenuBackground::LoadMenuBackground(bool HasDayHint, bool HasNightHint)
 				}
 			}
 		}
+		m_Loading = false;
 	}
 }
 
@@ -356,6 +360,11 @@ bool CMenuBackground::Render()
 CCamera *CMenuBackground::GetCurCamera()
 {
 	return &m_Camera;
+}
+
+const char *CMenuBackground::LoadingTitle() const
+{
+	return Localize("Loading background map");
 }
 
 void CMenuBackground::ChangePosition(int PositionNumber)

--- a/src/game/client/components/menu_background.h
+++ b/src/game/client/components/menu_background.h
@@ -33,9 +33,6 @@ class CMenuBackground : public CBackground
 {
 	std::chrono::nanoseconds m_ThemeScanStartTime{0};
 
-protected:
-	bool CanRenderMenuBackground() override { return false; }
-
 public:
 	enum
 	{
@@ -78,6 +75,7 @@ public:
 		PREDEFINED_THEMES_COUNT = 3,
 	};
 
+private:
 	CCamera m_Camera;
 
 	CBackgroundEngineMap *CreateBGMap() override;
@@ -91,6 +89,7 @@ public:
 	float m_MoveTime;
 
 	bool m_IsInit;
+	bool m_Loading;
 
 	void ResetPositions();
 
@@ -99,6 +98,7 @@ public:
 
 	std::vector<CTheme> m_vThemes;
 
+public:
 	CMenuBackground();
 	~CMenuBackground() override {}
 	virtual int Sizeof() const override { return sizeof(*this); }
@@ -110,8 +110,10 @@ public:
 	void LoadMenuBackground(bool HasDayHint = true, bool HasNightHint = true);
 
 	bool Render();
+	bool IsLoading() const { return m_Loading; }
 
 	class CCamera *GetCurCamera() override;
+	const char *LoadingTitle() const override;
 
 	void ChangePosition(int PositionNumber);
 

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -661,7 +661,8 @@ public:
 	CMenus();
 	virtual int Sizeof() const override { return sizeof(*this); }
 
-	void RenderLoading(const char *pCaption, const char *pContent, int IncreaseCounter, bool RenderLoadingBar = true, bool RenderMenuBackgroundMap = true);
+	void RenderLoading(const char *pCaption, const char *pContent, int IncreaseCounter);
+	void FinishLoading();
 
 	bool IsInit() { return m_IsInit; }
 

--- a/src/game/client/components/menus_demo.cpp
+++ b/src/game/client/components/menus_demo.cpp
@@ -920,7 +920,7 @@ int CMenus::DemolistFetchCallback(const CFsFileInfo *pInfo, int IsDir, int Stora
 
 	if(time_get_nanoseconds() - pSelf->m_DemoPopulateStartTime > 500ms)
 	{
-		pSelf->RenderLoading(Localize("Loading demo files"), "", 0, false);
+		pSelf->RenderLoading(Localize("Loading demo files"), "", 0);
 	}
 
 	return 0;

--- a/src/game/client/components/menus_ingame.cpp
+++ b/src/game/client/components/menus_ingame.cpp
@@ -1139,7 +1139,7 @@ int CMenus::GhostlistFetchCallback(const CFsFileInfo *pInfo, int IsDir, int Stor
 
 	if(time_get_nanoseconds() - pSelf->m_GhostPopulateStartTime > 500ms)
 	{
-		pSelf->RenderLoading(Localize("Loading ghost files"), "", 0, false);
+		pSelf->RenderLoading(Localize("Loading ghost files"), "", 0);
 	}
 
 	return 0;

--- a/src/game/client/components/menus_settings_assets.cpp
+++ b/src/game/client/components/menus_settings_assets.cpp
@@ -377,7 +377,7 @@ void CMenus::RenderSettingsCustom(CUIRect MainView)
 	User.m_pUser = this;
 	User.m_LoadedFunc = [&]() {
 		if(time_get_nanoseconds() - LoadStartTime > 500ms)
-			RenderLoading(Localize("Loading assets"), "", 0, false);
+			RenderLoading(Localize("Loading assets"), "", 0);
 	};
 	if(s_CurCustomTab == ASSETS_TAB_ENTITIES)
 	{

--- a/src/game/client/components/race_demo.cpp
+++ b/src/game/client/components/race_demo.cpp
@@ -233,7 +233,7 @@ int CRaceDemo::RaceDemolistFetchCallback(const CFsFileInfo *pInfo, int IsDir, in
 
 	if(time_get_nanoseconds() - pRealUser->m_pThis->m_RaceDemosLoadStartTime > 500ms)
 	{
-		pRealUser->m_pThis->GameClient()->m_Menus.RenderLoading(Localize("Loading race demo files"), "", 0, false);
+		pRealUser->m_pThis->GameClient()->m_Menus.RenderLoading(Localize("Loading race demo files"), "", 0);
 	}
 
 	return 0;

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -304,7 +304,7 @@ void CGameClient::OnInit()
 			dbg_assert(false, "Invalid callback loading detail");
 			dbg_break();
 		}
-		m_Menus.RenderLoading(pTitle, pMessage, 0, false);
+		m_Menus.RenderLoading(pTitle, pMessage, 0);
 	});
 
 	m_pGraphics = Kernel()->RequestInterface<IGraphics>();
@@ -428,6 +428,7 @@ void CGameClient::OnInit()
 		pChecksum->m_aComponentsChecksum[i] = Size;
 	}
 
+	m_Menus.FinishLoading();
 	log_trace("gameclient", "initialization finished after %.2fms", (time_get() - OnInitStart) * 1000.0f / (float)time_freq());
 }
 
@@ -553,14 +554,14 @@ void CGameClient::OnConnected()
 	const char *pConnectCaption = DemoPlayer()->IsPlaying() ? Localize("Preparing demo playback") : Localize("Connected");
 	const char *pLoadMapContent = Localize("Initializing map logic");
 	// render loading before skip is calculated
-	m_Menus.RenderLoading(pConnectCaption, pLoadMapContent, 0, false);
+	m_Menus.RenderLoading(pConnectCaption, pLoadMapContent, 0);
 	m_Layers.Init(Kernel()->RequestInterface<IMap>(), false);
 	m_Collision.Init(Layers());
 	m_GameWorld.m_Core.InitSwitchers(m_Collision.m_HighestSwitchNumber);
 	m_RaceHelper.Init(this);
 
 	// render loading before going through all components
-	m_Menus.RenderLoading(pConnectCaption, pLoadMapContent, 0, false);
+	m_Menus.RenderLoading(pConnectCaption, pLoadMapContent, 0);
 	for(auto &pComponent : m_vpAll)
 	{
 		pComponent->OnMapLoad();
@@ -568,7 +569,7 @@ void CGameClient::OnConnected()
 	}
 
 	Client()->SetLoadingStateDetail(IClient::LOADING_STATE_DETAIL_GETTING_READY);
-	m_Menus.RenderLoading(pConnectCaption, Localize("Sending initial client info"), 0, false);
+	m_Menus.RenderLoading(pConnectCaption, Localize("Sending initial client info"), 0);
 
 	// send the initial info
 	SendInfo(true);
@@ -3840,7 +3841,7 @@ void CGameClient::RefreshSkins()
 		// if skin refreshing takes to long, swap to a loading screen
 		if(time_get_nanoseconds() - SkinStartLoadTime > 500ms)
 		{
-			m_Menus.RenderLoading(Localize("Loading skin files"), "", 0, false);
+			m_Menus.RenderLoading(Localize("Loading skin files"), "", 0);
 		}
 	});
 


### PR DESCRIPTION
Fix loading screen rendering without progress bar for the entities background map during the initial loading.

Remove the `bool RenderLoadingBar` parameter of the `CMenus::RenderLoading` function. The progress bar is now rendered as long as the loading total is set. Add the `CMenus::FinishLoading` function to reset the loading total at the end of the loading process.

Remove the `bool RenderMenuBackgroundMap` parameter of the `CMenus::RenderLoading` function. The `RenderLoading` function will now check internally if the menu background map can be rendered.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
