### PR TITLE
Fix console behavior when pasting multiple lines of text

### DIFF
--- a/src/game/client/components/console.h
+++ b/src/game/client/components/console.h
@@ -112,7 +112,6 @@ class CGameConsole : public CComponent
 		void PrintLine(const char *pLine, int Len, ColorRGBA PrintColor) REQUIRES(!m_BacklogPendingLock);
 		int GetLinesToScroll(int Direction, int LinesToScroll);
 		void ScrollToCenter(int StartLine, int EndLine);
-		void ClearSearch();
 		void Dump() REQUIRES(!m_BacklogPendingLock);
 
 		const char *GetString() const { return m_Input.GetString(); }
@@ -135,6 +134,8 @@ class CGameConsole : public CComponent
 		void UpdateEntryTextAttributes(CBacklogEntry *pEntry) const;
 
 	private:
+		void SetSearching(bool Searching);
+		void ClearSearch();
 		void UpdateSearch();
 
 		friend class CGameConsole;


### PR DESCRIPTION
Ensure all pasted lines are added to the console history instead of only the last one.

Ensure the prompt `> [command]` is printed for all pasted lines instead of only for the last one.

Fix commands being executed when pasting multiple lines while the console is in searching-mode. Now, newline characters will be replaced with spaces while the input is used for searching.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
