### PR TITLE
Add 'sv_maps_base_url' to support map download https urls

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -1582,7 +1582,7 @@ void CClient::ProcessServerPacket(CNetChunk *pPacket, int Conn, bool Dummy)
 				{
 					char aUrl[256];
 					char aEscaped[256];
-					EscapeUrl(aEscaped, sizeof(aEscaped), m_aMapdownloadFilename + 15); // cut off downloadedmaps/
+					EscapeUrl(aEscaped, m_aMapdownloadFilename + 15); // cut off downloadedmaps/
 					bool UseConfigUrl = str_comp(g_Config.m_ClMapDownloadUrl, "https://maps.ddnet.org") != 0 || m_aMapDownloadUrl[0] == '\0';
 					str_format(aUrl, sizeof(aUrl), "%s/%s", UseConfigUrl ? g_Config.m_ClMapDownloadUrl : m_aMapDownloadUrl, aEscaped);
 

--- a/src/engine/server/server.h
+++ b/src/engine/server/server.h
@@ -247,6 +247,7 @@ public:
 	unsigned m_aCurrentMapCrc[NUM_MAP_TYPES];
 	unsigned char *m_apCurrentMapData[NUM_MAP_TYPES];
 	unsigned int m_aCurrentMapSize[NUM_MAP_TYPES];
+	char m_aMapDownloadUrl[256];
 
 	CDemoRecorder m_aDemoRecorder[NUM_RECORDERS];
 	CAuthManager m_AuthManager;

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -439,6 +439,7 @@ MACRO_CONFIG_INT(SvHighBandwidth, sv_high_bandwidth, 0, 0, 1, CFGFLAG_SERVER, "U
 MACRO_CONFIG_STR(SvRegister, sv_register, 16, "1", CFGFLAG_SERVER, "Register server with master server for public listing, can also accept a comma-separated list of protocols to register on, like 'ipv4,ipv6'")
 MACRO_CONFIG_STR(SvRegisterExtra, sv_register_extra, 256, "", CFGFLAG_SERVER, "Extra headers to send to the register endpoint, comma separated 'Header: Value' pairs")
 MACRO_CONFIG_STR(SvRegisterUrl, sv_register_url, 128, "https://master1.ddnet.org/ddnet/15/register", CFGFLAG_SERVER, "Masterserver URL to register to")
+MACRO_CONFIG_STR(SvMapsBaseUrl, sv_maps_base_url, 128, "", CFGFLAG_SERVER, "Base path used to provide HTTPS map download URL to the clients")
 MACRO_CONFIG_STR(SvRconPassword, sv_rcon_password, 128, "", CFGFLAG_SERVER | CFGFLAG_NONTEEHISTORIC, "Remote console password (full access)")
 MACRO_CONFIG_STR(SvRconModPassword, sv_rcon_mod_password, 128, "", CFGFLAG_SERVER | CFGFLAG_NONTEEHISTORIC, "Remote console password for moderators (limited access)")
 MACRO_CONFIG_STR(SvRconHelperPassword, sv_rcon_helper_password, 128, "", CFGFLAG_SERVER | CFGFLAG_NONTEEHISTORIC, "Remote console password for helpers (limited access)")

--- a/src/engine/shared/http.h
+++ b/src/engine/shared/http.h
@@ -259,6 +259,13 @@ inline std::unique_ptr<CHttpRequest> HttpPostJson(const char *pUrl, const char *
 }
 
 void EscapeUrl(char *pBuf, int Size, const char *pStr);
+
+template<int N>
+void EscapeUrl(char (&aBuf)[N], const char *pStr)
+{
+	EscapeUrl(aBuf, N, pStr);
+}
+
 bool HttpHasIpresolveBug();
 
 // In an ideal world this would be a kernel interface

--- a/src/game/client/components/skins.cpp
+++ b/src/game/client/components/skins.cpp
@@ -471,7 +471,7 @@ void CSkins::CSkinDownloadJob::Run()
 	const char *pBaseUrl = g_Config.m_ClDownloadCommunitySkins != 0 ? g_Config.m_ClSkinCommunityDownloadUrl : g_Config.m_ClSkinDownloadUrl;
 
 	char aEscapedName[256];
-	EscapeUrl(aEscapedName, sizeof(aEscapedName), m_aName);
+	EscapeUrl(aEscapedName, m_aName);
 
 	char aUrl[IO_MAX_PATH_LENGTH];
 	str_format(aUrl, sizeof(aUrl), "%s%s.png", pBaseUrl, aEscapedName);


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->
Allow custom servers to provide their own map download URLs without patching the code.

// I use a [similar](https://github.com/infclass/teeworlds-infclassR/commit/d93ff6cd650e00a555bdb0d6c7d67f218290d005) (5x more complicated) patch for Infclass, works ok. Thanks @heinrich5991 for suggesting `caddy`.

I don't need this in DDNet but as @ChillerDragon [asks](https://github.com/ddnet/ddnet/issues/9359) and considering @heinrich5991 help — here you are.

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
