### PR TITLE
Replace magic numbers with compile time string length

### DIFF
--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -2179,25 +2179,25 @@ void CGameContext::OnSayNetMessage(const CNetMsg_Cl_Say *pMsg, int ClientId, con
 		if(str_startswith_nocase(pMsg->m_pMessage + 1, "w "))
 		{
 			char aWhisperMsg[256];
-			str_copy(aWhisperMsg, pMsg->m_pMessage + 3);
+			str_copy(aWhisperMsg, pMsg->m_pMessage + sizeof("w "));
 			Whisper(pPlayer->GetCid(), aWhisperMsg);
 		}
 		else if(str_startswith_nocase(pMsg->m_pMessage + 1, "whisper "))
 		{
 			char aWhisperMsg[256];
-			str_copy(aWhisperMsg, pMsg->m_pMessage + 9);
+			str_copy(aWhisperMsg, pMsg->m_pMessage + sizeof("whisper "));
 			Whisper(pPlayer->GetCid(), aWhisperMsg);
 		}
 		else if(str_startswith_nocase(pMsg->m_pMessage + 1, "c "))
 		{
 			char aWhisperMsg[256];
-			str_copy(aWhisperMsg, pMsg->m_pMessage + 3);
+			str_copy(aWhisperMsg, pMsg->m_pMessage + sizeof("c "));
 			Converse(pPlayer->GetCid(), aWhisperMsg);
 		}
 		else if(str_startswith_nocase(pMsg->m_pMessage + 1, "converse "))
 		{
 			char aWhisperMsg[256];
-			str_copy(aWhisperMsg, pMsg->m_pMessage + 10);
+			str_copy(aWhisperMsg, pMsg->m_pMessage + sizeof("converse "));
 			Converse(pPlayer->GetCid(), aWhisperMsg);
 		}
 		else


### PR DESCRIPTION
The ``sizeof()`` macro is evaluated at compile time. The string passed to it does not end up in the final binary and there is also no counting happening at runtime.

The ``sizeof()`` operator counts the null terminator too. So ``sizeof("foo")`` is 4 and not 3.
But this comes in handy because we want to skip over the length of the command and the slash character in front of it.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
