### PR TITLE
Ignore case when map voting with full match

### DIFF
--- a/src/game/server/scoreworker.cpp
+++ b/src/game/server/scoreworker.cpp
@@ -322,7 +322,7 @@ bool CScoreWorker::MapVote(IDbConnection *pSqlServer, const ISqlData *pGameData,
 		"FROM %s_maps "
 		"WHERE Map LIKE %s "
 		"ORDER BY "
-		"  CASE WHEN Map = ? THEN 0 ELSE 1 END, "
+		"  CASE WHEN LOWER(Map) = LOWER(?) THEN 0 ELSE 1 END, "
 		"  CASE WHEN Map LIKE ? THEN 0 ELSE 1 END, "
 		"  LENGTH(Map), Map "
 		"LIMIT 1",
@@ -395,7 +395,7 @@ bool CScoreWorker::MapInfo(IDbConnection *pSqlServer, const ISqlData *pGameData,
 		"  SELECT * FROM %s_maps "
 		"  WHERE Map LIKE %s "
 		"  ORDER BY "
-		"    CASE WHEN Map = ? THEN 0 ELSE 1 END, "
+		"    CASE WHEN LOWER(Map) = LOWER(?) THEN 0 ELSE 1 END, "
 		"    CASE WHEN Map LIKE ? THEN 0 ELSE 1 END, "
 		"    LENGTH(Map), "
 		"    Map "


### PR DESCRIPTION
This pr updates map vote behavior so that the case is ignored if the map name is matched. `/map reflect` currently changes map to `reflects` while map `Reflect` exists. After this change, it should select `Reflect`. However, I don't know how to setup a test environment, so this pr is not tested.

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
