### PR TITLE
Refactor main menu hotkey handling

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -2387,9 +2387,9 @@ void CMenus::RenderBackground()
 
 bool CMenus::CheckHotKey(int Key) const
 {
-	return m_Popup == POPUP_NONE &&
-	       !Input()->ShiftIsPressed() && !Input()->ModifierIsPressed() && // no modifier
-	       Input()->KeyIsPressed(Key) && m_pClient->m_GameConsole.IsClosed();
+	return !Input()->ShiftIsPressed() && !Input()->ModifierIsPressed() && !Input()->AltIsPressed() && // no modifier
+	       Input()->KeyPress(Key) &&
+	       m_pClient->m_GameConsole.IsClosed();
 }
 
 int CMenus::DoButton_CheckBox_Tristate(const void *pId, const char *pText, TRISTATE Checked, const CUIRect *pRect)

--- a/src/game/client/components/menus.h
+++ b/src/game/client/components/menus.h
@@ -478,8 +478,6 @@ protected:
 
 	// found in menus_start.cpp
 	void RenderStartMenu(CUIRect MainView);
-	bool m_EditorHotkeyWasPressed = true;
-	float m_EditorHotKeyChecktime = 0.0f;
 
 	// found in menus_ingame.cpp
 	STextContainerIndex m_MotdTextContainerIndex;

--- a/src/game/client/components/menus_start.cpp
+++ b/src/game/client/components/menus_start.cpp
@@ -152,16 +152,10 @@ void CMenus::RenderStartMenu(CUIRect MainView)
 	Menu.HSplitBottom(5.0f, &Menu, 0); // little space
 	Menu.HSplitBottom(40.0f, &Menu, &Button);
 	static CButtonContainer s_MapEditorButton;
-	if(DoButton_Menu(&s_MapEditorButton, Localize("Editor"), 0, &Button, g_Config.m_ClShowStartMenuImages ? "editor" : 0, IGraphics::CORNER_ALL, Rounding, 0.5f, m_pClient->Editor()->HasUnsavedData() ? ColorRGBA(0.0f, 1.0f, 0.0f, 0.25f) : ColorRGBA(0.0f, 0.0f, 0.0f, 0.25f)) || (!m_EditorHotkeyWasPressed && Client()->LocalTime() - m_EditorHotKeyChecktime < 0.1f && CheckHotKey(KEY_E)))
+	if(DoButton_Menu(&s_MapEditorButton, Localize("Editor"), 0, &Button, g_Config.m_ClShowStartMenuImages ? "editor" : 0, IGraphics::CORNER_ALL, Rounding, 0.5f, m_pClient->Editor()->HasUnsavedData() ? ColorRGBA(0.0f, 1.0f, 0.0f, 0.25f) : ColorRGBA(0.0f, 0.0f, 0.0f, 0.25f)) || CheckHotKey(KEY_E))
 	{
 		g_Config.m_ClEditor = 1;
 		Input()->MouseModeRelative();
-		m_EditorHotkeyWasPressed = true;
-	}
-	if(!Input()->KeyIsPressed(KEY_E))
-	{
-		m_EditorHotkeyWasPressed = false;
-		m_EditorHotKeyChecktime = Client()->LocalTime();
 	}
 
 	Menu.HSplitBottom(5.0f, &Menu, 0); // little space


### PR DESCRIPTION
- Also prevent main menu hotkey activating when Alt-modifier is pressed.
- Prevent repeated hotkey activating by using `IInput::KeyPress` instead of `IInput::KeyIsPressed` in `CMenus::CheckHotKey`.
- Remove unnecessary code for preventing editor hotkey from being activated quickly, which is made obsolete by using `IInput::KeyPress`.
- Remove unnecessary check for fullscreen popup which is currently always true and also an unnecessary restriction for hotkeys.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
