### PR TITLE
Refactor key event handling, fix controller input, fix swapped mouse wheel left/right keys

### DIFF
--- a/src/engine/client/input.h
+++ b/src/engine/client/input.h
@@ -93,13 +93,11 @@ private:
 	void AddTextEvent(const char *pText);
 
 	// quick access to input
-	uint32_t m_aInputCount[g_MaxKeys];
-	unsigned char m_aInputState[g_MaxKeys];
+	bool m_aCurrentKeyStates[KEY_LAST];
+	bool m_aFrameKeyStates[KEY_LAST];
 	uint32_t m_InputCounter;
 	std::vector<CTouchFingerState> m_vTouchFingerStates;
 
-	void UpdateMouseState();
-	void UpdateJoystickState();
 	void HandleJoystickAxisMotionEvent(const SDL_JoyAxisEvent &Event);
 	void HandleJoystickButtonEvent(const SDL_JoyButtonEvent &Event);
 	void HandleJoystickHatMotionEvent(const SDL_JoyHatEvent &Event);
@@ -111,8 +109,6 @@ private:
 	void HandleTextEditingEvent(const char *pText, int Start, int Length);
 
 	char m_aDropFile[IO_MAX_PATH_LENGTH];
-
-	bool KeyState(int Key) const;
 
 	void ProcessSystemMessage(SDL_SysWMmsg *pMsg);
 
@@ -127,11 +123,12 @@ public:
 	void Clear() override;
 	float GetUpdateTime() const override;
 
-	bool ModifierIsPressed() const override { return KeyState(KEY_LCTRL) || KeyState(KEY_RCTRL) || KeyState(KEY_LGUI) || KeyState(KEY_RGUI); }
-	bool ShiftIsPressed() const override { return KeyState(KEY_LSHIFT) || KeyState(KEY_RSHIFT); }
-	bool AltIsPressed() const override { return KeyState(KEY_LALT) || KeyState(KEY_RALT); }
-	bool KeyIsPressed(int Key) const override { return KeyState(Key); }
-	bool KeyPress(int Key, bool CheckCounter) const override { return CheckCounter ? (m_aInputCount[Key] == m_InputCounter) : m_aInputCount[Key]; }
+	bool ModifierIsPressed() const override { return KeyIsPressed(KEY_LCTRL) || KeyIsPressed(KEY_RCTRL) || KeyIsPressed(KEY_LGUI) || KeyIsPressed(KEY_RGUI); }
+	bool ShiftIsPressed() const override { return KeyIsPressed(KEY_LSHIFT) || KeyIsPressed(KEY_RSHIFT); }
+	bool AltIsPressed() const override { return KeyIsPressed(KEY_LALT) || KeyIsPressed(KEY_RALT); }
+	bool KeyIsPressed(int Key) const override;
+	bool KeyPress(int Key) const override;
+	const char *KeyName(int Key) const override;
 	int FindKeyByName(const char *pKeyName) const override;
 
 	size_t NumJoysticks() const override { return m_vJoysticks.size(); }

--- a/src/engine/input.h
+++ b/src/engine/input.h
@@ -14,9 +14,6 @@
 #include <string>
 #include <vector>
 
-const int g_MaxKeys = 512;
-extern const char g_aaKeyStrings[g_MaxKeys][20];
-
 class IInput : public IInterface
 {
 	MACRO_INTERFACE("input")
@@ -45,6 +42,9 @@ public:
 
 	// events
 	virtual void ConsumeEvents(std::function<void(const CEvent &Event)> Consumer) const = 0;
+	/**
+	 * Clears the events and @link KeyPress @endlink state for this frame. Must be called at the end of each frame.
+	 */
 	virtual void Clear() = 0;
 
 	/**
@@ -57,9 +57,31 @@ public:
 	virtual bool ModifierIsPressed() const = 0;
 	virtual bool ShiftIsPressed() const = 0;
 	virtual bool AltIsPressed() const = 0;
+	/**
+	 * Returns whether the given key is currently pressed down. This directly represents the state of pressed keys
+	 * based on all handled input events.
+	 *
+	 * This function should be used to trigger behavior continuously while a specific key is held down, e.g. for
+	 * showing a list of all keys that are currently being pressed.
+	 *
+	 * @param Key The key code (see `keys.h`).
+	 *
+	 * @return `true` if key is currently pressed down, `false` otherwise.
+	 */
 	virtual bool KeyIsPressed(int Key) const = 0;
-	virtual bool KeyPress(int Key, bool CheckCounter = false) const = 0;
-	const char *KeyName(int Key) const { return (Key >= 0 && Key < g_MaxKeys) ? g_aaKeyStrings[Key] : g_aaKeyStrings[0]; }
+	/**
+	 * Returns whether the given key was pressed down during input updates for current frame. This state is
+	 * cleared at the end of each frame by calling the @link Clear @endlink function.
+	 *
+	 * This function should be used to trigger behavior only once per key press event per frame, e.g. for menu
+	 * hotkeys that should activate behavior once per key press.
+	 *
+	 * @param Key The key code (see `keys.h`).
+	 *
+	 * @return `true` if key was pressed down during input updates for the current frame, `false` otherwise.
+	 */
+	virtual bool KeyPress(int Key) const = 0;
+	virtual const char *KeyName(int Key) const = 0;
 	virtual int FindKeyByName(const char *pKeyName) const = 0;
 
 	// joystick


### PR DESCRIPTION
Remove the `CInput::UpdateMouseState` and `CInput::UpdateJoystickState` functions and the usages of the `SDL_PumpEvents` and `SDL_GetKeyboardState` functions. Instead of unnecessarily clearing and then restoring the key state at the beginning of every input update we now update the key states consistently when handling each key press/release event (keyboard, mouse click, mouse wheel, joystick button, joystick axis, joystick hat).

Fixes binds for joystick axes and hats not working consistently as calling `SDL_PumpEvents` seems to cause most joystick events to be consumed already. Closes #9381.

Replace the `CInput::KeyState` function with the `IInput::KeyIsPressed` function which was previously wrapping it.

Remove the unused parameter `bool CheckCount = false` of the `IInput::KeyPress` function which was always set to its default value. Use `bool` instead of storing the therefore unused input count value.

Rename `CInput::m_aInputState` and `CInput::m_aInputCount` variables to `m_aCurrentKeyStates` and `m_aFrameKeyStates`, respectively, to make their usage more understandable.

Add documentation for the `IInput::KeyIsPressed` and `IInput::KeyPress` functions to explain the difference in behavior and usage.

Add assertions to ensure keys are valid.

Fix the mouse wheel left and right scroll keys being swapped. Negative `x` is left and positive is right according to the documentation for `SDL_MouseButtonEvent`.

Extract functions for translation of keys for mouse button and wheel events for readability.

Improve readability by avoiding assignment to variables in switch-cases. Use lambda-function to avoid duplicate code instead.

Consistently use name `Key` instead of `Scancode`.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [X] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [X] Considered possible null pointers and out of bounds array indexing
- [X] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
