### PR TITLE
Fix Android crash in release build due to ProGuard

### DIFF
--- a/scripts/android/files/proguard-rules.pro
+++ b/scripts/android/files/proguard-rules.pro
@@ -16,7 +16,7 @@
 # debugging stack traces.
 -keepattributes SourceFile,LineNumberTable
 
--keepclassmembers, allowoptimization public class org.ddnet.client.NativeMain {
+-keepclassmembers, allowoptimization public class org.ddnet.client.* {
 	*;
 }
 


### PR DESCRIPTION
ProGuard optimizes out methods it considers unused in release build, but methods only called from native code appear unused.

The ProGuard rule was broken from renaming the main activity and also did not consider the server service yet.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
